### PR TITLE
CDK: emit `AirbyteTraceMessage` with exception trace information

### DIFF
--- a/airbyte-cdk/python/CHANGELOG.md
+++ b/airbyte-cdk/python/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Changelog
 
+## 0.1.56
+- Update protocol models to include `AirbyteTraceMessage`
+- Emit an `AirbyteTraceMessage` on uncaught exceptions
+- Add `AirbyteTracedException`
+
 ## 0.1.55
 Add support for reading the spec from a YAML file (`spec.yaml`) 
 

--- a/airbyte-cdk/python/airbyte_cdk/entrypoint.py
+++ b/airbyte-cdk/python/airbyte_cdk/entrypoint.py
@@ -11,7 +11,8 @@ import sys
 import tempfile
 from typing import Any, Dict, Iterable, List
 
-from airbyte_cdk.logger import AirbyteLogFormatter, init_logger
+from airbyte_cdk.exception_handler import init_uncaught_exception_handler
+from airbyte_cdk.logger import init_logger
 from airbyte_cdk.models import AirbyteMessage, Status, Type
 from airbyte_cdk.models.airbyte_protocol import ConnectorSpecification
 from airbyte_cdk.sources import Source
@@ -20,6 +21,7 @@ from airbyte_cdk.sources.utils.sentry import AirbyteSentry
 from airbyte_cdk.utils.airbyte_secrets_utils import AirbyteSecretHelper, get_secrets
 
 logger = init_logger("airbyte")
+init_uncaught_exception_handler(logger)
 
 
 class AirbyteEntrypoint(object):

--- a/airbyte-cdk/python/airbyte_cdk/entrypoint.py
+++ b/airbyte-cdk/python/airbyte_cdk/entrypoint.py
@@ -18,7 +18,7 @@ from airbyte_cdk.models.airbyte_protocol import ConnectorSpecification
 from airbyte_cdk.sources import Source
 from airbyte_cdk.sources.utils.schema_helpers import check_config_against_spec_or_exit, get_secret_values, split_config
 from airbyte_cdk.sources.utils.sentry import AirbyteSentry
-from airbyte_cdk.utils.airbyte_secrets_utils import AirbyteSecretHelper, get_secrets
+from airbyte_cdk.utils.airbyte_secrets_utils import get_secrets, update_secrets
 
 logger = init_logger("airbyte")
 init_uncaught_exception_handler(logger)
@@ -91,7 +91,7 @@ class AirbyteEntrypoint(object):
                 # Now that we have the config, we can use it to get a list of ai airbyte_secrets
                 # that we should filter in logging to avoid leaking secrets
                 config_secrets = get_secrets(self.source, config, self.logger)
-                AirbyteSecretHelper.update_secrets(config_secrets)
+                update_secrets(config_secrets)
 
                 # Remove internal flags from config before validating so
                 # jsonschema's additionalProperties flag wont fail the validation

--- a/airbyte-cdk/python/airbyte_cdk/entrypoint.py
+++ b/airbyte-cdk/python/airbyte_cdk/entrypoint.py
@@ -17,7 +17,7 @@ from airbyte_cdk.models.airbyte_protocol import ConnectorSpecification
 from airbyte_cdk.sources import Source
 from airbyte_cdk.sources.utils.schema_helpers import check_config_against_spec_or_exit, get_secret_values, split_config
 from airbyte_cdk.sources.utils.sentry import AirbyteSentry
-from airbyte_cdk.utils.airbyte_secrets_utils import get_secrets
+from airbyte_cdk.utils.airbyte_secrets_utils import AirbyteSecretHelper, get_secrets
 
 logger = init_logger("airbyte")
 
@@ -89,7 +89,7 @@ class AirbyteEntrypoint(object):
                 # Now that we have the config, we can use it to get a list of ai airbyte_secrets
                 # that we should filter in logging to avoid leaking secrets
                 config_secrets = get_secrets(self.source, config, self.logger)
-                AirbyteLogFormatter.update_secrets(config_secrets)
+                AirbyteSecretHelper.update_secrets(config_secrets)
 
                 # Remove internal flags from config before validating so
                 # jsonschema's additionalProperties flag wont fail the validation

--- a/airbyte-cdk/python/airbyte_cdk/exception_handler.py
+++ b/airbyte-cdk/python/airbyte_cdk/exception_handler.py
@@ -5,7 +5,7 @@
 import logging
 import sys
 
-from airbyte_cdk.utils.airbyte_secrets_utils import AirbyteSecretHelper
+from airbyte_cdk.utils.airbyte_secrets_utils import filter_secrets
 from airbyte_cdk.utils.traced_exception import AirbyteTracedException
 
 
@@ -24,9 +24,13 @@ def init_uncaught_exception_handler(logger: logging.Logger) -> None:
         logger.fatal(exception_value, exc_info=exception_value)
 
         # emit an AirbyteTraceMessage for any exception that gets to this spot
-        traced_exc = exception_value if issubclass(exception_type, AirbyteTracedException) else AirbyteTracedException.from_exception(exception_value)
+        traced_exc = (
+            exception_value
+            if issubclass(exception_type, AirbyteTracedException)
+            else AirbyteTracedException.from_exception(exception_value)
+        )
         message = traced_exc.as_airbyte_message()
         message_json = message.json(exclude_unset=True)
-        print(AirbyteSecretHelper.filter_secrets(message_json))
+        print(filter_secrets(message_json))
 
     sys.excepthook = hook_fn

--- a/airbyte-cdk/python/airbyte_cdk/exception_handler.py
+++ b/airbyte-cdk/python/airbyte_cdk/exception_handler.py
@@ -24,7 +24,7 @@ def init_uncaught_exception_handler(logger: logging.Logger) -> None:
         logger.fatal(exception_value, exc_info=exception_value)
 
         # emit an AirbyteTraceMessage for any exception that gets to this spot
-        traced_exc = exception_value if exception_type == AirbyteTracedException else AirbyteTracedException.from_exception(exception_value)
+        traced_exc = exception_value if issubclass(exception_type, AirbyteTracedException) else AirbyteTracedException.from_exception(exception_value)
         message = traced_exc.as_airbyte_message()
         message_json = message.json(exclude_unset=True)
         print(AirbyteSecretHelper.filter_secrets(message_json))

--- a/airbyte-cdk/python/airbyte_cdk/exception_handler.py
+++ b/airbyte-cdk/python/airbyte_cdk/exception_handler.py
@@ -1,0 +1,32 @@
+#
+# Copyright (c) 2021 Airbyte, Inc., all rights reserved.
+#
+
+import logging
+import sys
+
+from airbyte_cdk.utils.airbyte_secrets_utils import AirbyteSecretHelper
+from airbyte_cdk.utils.traced_exception import AirbyteTracedException
+
+
+def init_uncaught_exception_handler(logger: logging.Logger) -> None:
+    """
+    Handles uncaught exceptions by emitting an AirbyteTraceMessage and making sure they are not
+    printed to the console without having secrets removed.
+    """
+
+    def hook_fn(exception_type, exception_value, traceback_):
+        # For developer ergonomics, we want to see the stack trace in the logs when we do a ctrl-c
+        if issubclass(exception_type, KeyboardInterrupt):
+            sys.__excepthook__(exception_type, exception_value, traceback_)
+            return
+
+        logger.fatal(exception_value, exc_info=exception_value)
+
+        # emit an AirbyteTraceMessage for any exception that gets to this spot
+        traced_exc = exception_value if exception_type == AirbyteTracedException else AirbyteTracedException.from_exception(exception_value)
+        message = traced_exc.as_airbyte_message()
+        message_json = message.json(exclude_unset=True)
+        print(AirbyteSecretHelper.filter_secrets(message_json))
+
+    sys.excepthook = hook_fn

--- a/airbyte-cdk/python/airbyte_cdk/exception_handler.py
+++ b/airbyte-cdk/python/airbyte_cdk/exception_handler.py
@@ -5,7 +5,6 @@
 import logging
 import sys
 
-from airbyte_cdk.utils.airbyte_secrets_utils import filter_secrets
 from airbyte_cdk.utils.traced_exception import AirbyteTracedException
 
 
@@ -29,8 +28,7 @@ def init_uncaught_exception_handler(logger: logging.Logger) -> None:
             if issubclass(exception_type, AirbyteTracedException)
             else AirbyteTracedException.from_exception(exception_value)
         )
-        message = traced_exc.as_airbyte_message()
-        message_json = message.json(exclude_unset=True)
-        print(filter_secrets(message_json))
+
+        traced_exc.emit_message()
 
     sys.excepthook = hook_fn

--- a/airbyte-cdk/python/airbyte_cdk/logger.py
+++ b/airbyte-cdk/python/airbyte_cdk/logger.py
@@ -4,7 +4,6 @@
 
 import logging
 import logging.config
-import sys
 import traceback
 from typing import Tuple
 
@@ -33,29 +32,12 @@ LOGGING_CONFIG = {
 }
 
 
-def init_unhandled_exception_output_filtering(logger: logging.Logger) -> None:
-    """
-    Make sure unhandled exceptions are not printed to the console without passing through the Airbyte logger and having
-    secrets removed.
-    """
-
-    def hook_fn(exception_type, exception_value, traceback_):
-        # For developer ergonomics, we want to see the stack trace in the logs when we do a ctrl-c
-        if issubclass(exception_type, KeyboardInterrupt):
-            sys.__excepthook__(exception_type, exception_value, traceback_)
-        else:
-            logger.critical(exception_value, exc_info=exception_value)
-
-    sys.excepthook = hook_fn
-
-
 def init_logger(name: str = None):
     """Initial set up of logger"""
     logging.addLevelName(TRACE_LEVEL_NUM, "TRACE")
     logger = logging.getLogger(name)
     logger.setLevel(TRACE_LEVEL_NUM)
     logging.config.dictConfig(LOGGING_CONFIG)
-    init_unhandled_exception_output_filtering(logger)
     return logger
 
 

--- a/airbyte-cdk/python/airbyte_cdk/logger.py
+++ b/airbyte-cdk/python/airbyte_cdk/logger.py
@@ -8,7 +8,7 @@ import traceback
 from typing import Tuple
 
 from airbyte_cdk.models import AirbyteLogMessage, AirbyteMessage
-from airbyte_cdk.utils.airbyte_secrets_utils import AirbyteSecretHelper
+from airbyte_cdk.utils.airbyte_secrets_utils import filter_secrets
 from deprecated import deprecated
 
 TRACE_LEVEL_NUM = 5
@@ -58,7 +58,7 @@ class AirbyteLogFormatter(logging.Formatter):
         """Return a JSON representation of the log message"""
         message = super().format(record)
         airbyte_level = self.level_mapping.get(record.levelno, "INFO")
-        message = AirbyteSecretHelper.filter_secrets(message)
+        message = filter_secrets(message)
         log_message = AirbyteMessage(type="LOG", log=AirbyteLogMessage(level=airbyte_level, message=message))
         return log_message.json(exclude_unset=True)
 

--- a/airbyte-cdk/python/airbyte_cdk/sources/streams/http/rate_limiting.py
+++ b/airbyte-cdk/python/airbyte_cdk/sources/streams/http/rate_limiting.py
@@ -2,21 +2,19 @@
 # Copyright (c) 2021 Airbyte, Inc., all rights reserved.
 #
 
-
+import logging
 import sys
 import time
 from typing import Optional
 
 import backoff
-from airbyte_cdk.logger import AirbyteLogger
 from requests import codes, exceptions
 
 from .exceptions import DefaultBackoffException, UserDefinedBackoffException
 
 TRANSIENT_EXCEPTIONS = (DefaultBackoffException, exceptions.ConnectTimeout, exceptions.ReadTimeout, exceptions.ConnectionError)
 
-# TODO inject singleton logger?
-logger = AirbyteLogger()
+logger = logging.getLogger("airbyte")
 
 
 def default_backoff_handler(max_tries: Optional[int], factor: float, **kwargs):

--- a/airbyte-cdk/python/airbyte_cdk/sources/utils/transform.py
+++ b/airbyte-cdk/python/airbyte_cdk/sources/utils/transform.py
@@ -1,15 +1,14 @@
 #
 # Copyright (c) 2021 Airbyte, Inc., all rights reserved.
 #
-
+import logging
 from distutils.util import strtobool
 from enum import Flag, auto
 from typing import Any, Callable, Dict, Mapping, Optional
 
-from airbyte_cdk.logger import AirbyteLogger
 from jsonschema import Draft7Validator, validators
 
-logger = AirbyteLogger()
+logger = logging.getLogger("airbyte")
 
 
 class TransformConfig(Flag):
@@ -174,4 +173,4 @@ class TypeTransformer:
             just calling normalizer.validate() would throw an exception on
             first validation occurences and stop processing rest of schema.
             """
-            logger.warn(e.message)
+            logger.warning(e.message)

--- a/airbyte-cdk/python/airbyte_cdk/sources/utils/transform.py
+++ b/airbyte-cdk/python/airbyte_cdk/sources/utils/transform.py
@@ -1,6 +1,7 @@
 #
 # Copyright (c) 2021 Airbyte, Inc., all rights reserved.
 #
+
 import logging
 from distutils.util import strtobool
 from enum import Flag, auto

--- a/airbyte-cdk/python/airbyte_cdk/utils/airbyte_secrets_utils.py
+++ b/airbyte-cdk/python/airbyte_cdk/utils/airbyte_secrets_utils.py
@@ -20,17 +20,17 @@ def get_secrets(source: Source, config: Mapping[str, Any], logger: logging.Logge
     return [str(get_value_by_dot_notation(config, key)) for key in secret_key_names if config.get(key)]
 
 
-class AirbyteSecretHelper:
-    _secrets: List[str] = []
+__SECRETS_FROM_CONFIG: List[str] = []
 
-    @classmethod
-    def update_secrets(cls, secrets: List[str]):
-        """Update the list of secrets to be replaced"""
-        cls._secrets = secrets
 
-    @classmethod
-    def filter_secrets(cls, string: str) -> str:
-        """Filter secrets from a string by replacing them with ****"""
-        for secret in cls._secrets:
-            string = string.replace(secret, "****")
-        return string
+def update_secrets(secrets: List[str]):
+    """Update the list of secrets to be replaced"""
+    global __SECRETS_FROM_CONFIG
+    __SECRETS_FROM_CONFIG = secrets
+
+
+def filter_secrets(string: str) -> str:
+    """Filter secrets from a string by replacing them with ****"""
+    for secret in __SECRETS_FROM_CONFIG:
+        string = string.replace(secret, "****")
+    return string

--- a/airbyte-cdk/python/airbyte_cdk/utils/airbyte_secrets_utils.py
+++ b/airbyte-cdk/python/airbyte_cdk/utils/airbyte_secrets_utils.py
@@ -18,3 +18,19 @@ def get_secrets(source: Source, config: Mapping[str, Any], logger: logging.Logge
         ".".join(key.split(".")[:1]) for key, value in flattened_key_values.items() if value and key.endswith("airbyte_secret")
     ]
     return [str(get_value_by_dot_notation(config, key)) for key in secret_key_names if config.get(key)]
+
+
+class AirbyteSecretHelper:
+    _secrets: List[str] = []
+
+    @classmethod
+    def update_secrets(cls, secrets: List[str]):
+        """Update the list of secrets to be replaced"""
+        cls._secrets = secrets
+
+    @classmethod
+    def filter_secrets(cls, string: str) -> str:
+        """Filter secrets from a string by replacing them with ****"""
+        for secret in cls._secrets:
+            string = string.replace(secret, "****")
+        return string

--- a/airbyte-cdk/python/airbyte_cdk/utils/event_timing.py
+++ b/airbyte-cdk/python/airbyte_cdk/utils/event_timing.py
@@ -3,14 +3,14 @@
 #
 
 import datetime
+import logging
+
 import time
 from contextlib import contextmanager
 from dataclasses import dataclass, field
 from typing import Optional
 
-from airbyte_cdk.logger import AirbyteLogger
-
-logger = AirbyteLogger()
+logger = logging.getLogger("airbyte")
 
 
 class EventTimer:
@@ -42,7 +42,7 @@ class EventTimer:
             event = self.stack.pop(0)
             event.finish()
         else:
-            logger.warn(f"{self.name} finish_event called without start_event")
+            logger.warning(f"{self.name} finish_event called without start_event")
 
     def report(self, order_by="name"):
         """

--- a/airbyte-cdk/python/airbyte_cdk/utils/event_timing.py
+++ b/airbyte-cdk/python/airbyte_cdk/utils/event_timing.py
@@ -4,7 +4,6 @@
 
 import datetime
 import logging
-
 import time
 from contextlib import contextmanager
 from dataclasses import dataclass, field

--- a/airbyte-cdk/python/airbyte_cdk/utils/traced_exception.py
+++ b/airbyte-cdk/python/airbyte_cdk/utils/traced_exception.py
@@ -1,0 +1,51 @@
+#
+# Copyright (c) 2021 Airbyte, Inc., all rights reserved.
+#
+
+import traceback
+from datetime import datetime
+
+from airbyte_cdk.models import AirbyteErrorTraceMessage, AirbyteMessage, AirbyteTraceMessage, FailureType, TraceType
+from airbyte_cdk.models import Type as MessageType
+
+
+class AirbyteTracedException(Exception):
+    """
+    TODO: give this a meaningful description
+    """
+
+    def __init__(
+        self,
+        internal_message: str = None,
+        message: str = None,
+        failure_type: FailureType = FailureType.system_error,
+        exception: BaseException = None,
+    ):
+        self.internal_message = internal_message
+        self.message = message
+        self.failure_type = failure_type
+        self._exception = exception
+        super().__init__(internal_message)
+
+    def as_airbyte_message(self) -> AirbyteMessage:
+        now_millis = int(datetime.now().timestamp() * 1000)
+
+        trace_exc = self._exception or self
+        stack_trace_str = "".join(traceback.TracebackException.from_exception(trace_exc).format())
+
+        trace_message = AirbyteTraceMessage(
+            type=TraceType.ERROR,
+            emitted_at=now_millis,
+            error=AirbyteErrorTraceMessage(
+                message=self.message or "an error occurred with the source",
+                internal_message=self.internal_message,
+                failure_type=self.failure_type,
+                stack_trace=stack_trace_str,
+            ),
+        )
+
+        return AirbyteMessage(type=MessageType.TRACE, trace=trace_message)
+
+    @classmethod
+    def from_exception(cls, exc: Exception, *args, **kwargs) -> "AirbyteTracedException":
+        return cls(internal_message=str(exc), exception=exc, *args, **kwargs)

--- a/airbyte-cdk/python/airbyte_cdk/utils/traced_exception.py
+++ b/airbyte-cdk/python/airbyte_cdk/utils/traced_exception.py
@@ -11,7 +11,7 @@ from airbyte_cdk.models import Type as MessageType
 
 class AirbyteTracedException(Exception):
     """
-    TODO: give this a meaningful description
+    An exception that should be emitted as an AirbyteTraceMessage
     """
 
     def __init__(
@@ -21,6 +21,12 @@ class AirbyteTracedException(Exception):
         failure_type: FailureType = FailureType.system_error,
         exception: BaseException = None,
     ):
+        """
+        :param internal_message: the internal error that caused the failure
+        :param message: a user-friendly message that indicates the cause of the error
+        :param failure_type: the type of error
+        :param exception: the exception that caused the error, from which the stack trace should be retrieved
+        """
         self.internal_message = internal_message
         self.message = message
         self.failure_type = failure_type
@@ -28,6 +34,9 @@ class AirbyteTracedException(Exception):
         super().__init__(internal_message)
 
     def as_airbyte_message(self) -> AirbyteMessage:
+        """
+        Builds an AirbyteTraceMessage from the exception
+        """
         now_millis = datetime.now().timestamp() * 1000.0
 
         trace_exc = self._exception or self
@@ -48,4 +57,8 @@ class AirbyteTracedException(Exception):
 
     @classmethod
     def from_exception(cls, exc: Exception, *args, **kwargs) -> "AirbyteTracedException":
+        """
+        Helper to create an AirbyteTracedException from an existing exception
+        :param exc: the exception that caused the error
+        """
         return cls(internal_message=str(exc), exception=exc, *args, **kwargs)

--- a/airbyte-cdk/python/airbyte_cdk/utils/traced_exception.py
+++ b/airbyte-cdk/python/airbyte_cdk/utils/traced_exception.py
@@ -28,7 +28,7 @@ class AirbyteTracedException(Exception):
         super().__init__(internal_message)
 
     def as_airbyte_message(self) -> AirbyteMessage:
-        now_millis = int(datetime.now().timestamp() * 1000)
+        now_millis = datetime.now().timestamp() * 1000.0
 
         trace_exc = self._exception or self
         stack_trace_str = "".join(traceback.TracebackException.from_exception(trace_exc).format())

--- a/airbyte-cdk/python/airbyte_cdk/utils/traced_exception.py
+++ b/airbyte-cdk/python/airbyte_cdk/utils/traced_exception.py
@@ -46,7 +46,7 @@ class AirbyteTracedException(Exception):
             type=TraceType.ERROR,
             emitted_at=now_millis,
             error=AirbyteErrorTraceMessage(
-                message=self.message or "an error occurred with the source",
+                message=self.message or "Something went wrong in the connector. See the logs for more details.",
                 internal_message=self.internal_message,
                 failure_type=self.failure_type,
                 stack_trace=stack_trace_str,

--- a/airbyte-cdk/python/airbyte_cdk/utils/traced_exception.py
+++ b/airbyte-cdk/python/airbyte_cdk/utils/traced_exception.py
@@ -7,6 +7,7 @@ from datetime import datetime
 
 from airbyte_cdk.models import AirbyteErrorTraceMessage, AirbyteMessage, AirbyteTraceMessage, FailureType, TraceType
 from airbyte_cdk.models import Type as MessageType
+from airbyte_cdk.utils.airbyte_secrets_utils import filter_secrets
 
 
 class AirbyteTracedException(Exception):
@@ -54,6 +55,15 @@ class AirbyteTracedException(Exception):
         )
 
         return AirbyteMessage(type=MessageType.TRACE, trace=trace_message)
+
+    def emit_message(self):
+        """
+        Prints the exception as an AirbyteTraceMessage.
+        Note that this will be called automatically on uncaught exceptions when using the airbyte_cdk entrypoint.
+        """
+        message = self.as_airbyte_message().json(exclude_unset=True)
+        filtered_message = filter_secrets(message)
+        print(filtered_message)
 
     @classmethod
     def from_exception(cls, exc: Exception, *args, **kwargs) -> "AirbyteTracedException":

--- a/airbyte-cdk/python/setup.py
+++ b/airbyte-cdk/python/setup.py
@@ -15,7 +15,7 @@ README = (HERE / "README.md").read_text()
 
 setup(
     name="airbyte-cdk",
-    version="0.1.55",
+    version="0.1.56",
     description="A framework for writing Airbyte Connectors.",
     long_description=README,
     long_description_content_type="text/markdown",

--- a/airbyte-cdk/python/unit_tests/sources/utils/test_transform.py
+++ b/airbyte-cdk/python/unit_tests/sources/utils/test_transform.py
@@ -151,15 +151,17 @@ VERY_NESTED_SCHEMA = {
         ),
     ],
 )
-def test_transform(schema, actual, expected, expected_warns, capsys):
+def test_transform(schema, actual, expected, expected_warns, caplog):
     t = TypeTransformer(TransformConfig.DefaultSchemaNormalization)
     t.transform(actual, schema)
     assert json.dumps(actual) == json.dumps(expected)
-    stdout = capsys.readouterr().out
     if expected_warns:
-        assert expected_warns in stdout
+        record = caplog.records[0]
+        assert record.name == "airbyte"
+        assert record.levelname == "WARNING"
+        assert record.message == expected_warns
     else:
-        assert not stdout
+        assert len(caplog.records) == 0
 
 
 def test_transform_wrong_config():

--- a/airbyte-cdk/python/unit_tests/test_exception_handler.py
+++ b/airbyte-cdk/python/unit_tests/test_exception_handler.py
@@ -31,7 +31,7 @@ def test_uncaught_exception_handler():
             emitted_at=0.0,
             error=AirbyteErrorTraceMessage(
                 failure_type="system_error",
-                message="an error occurred with the source",
+                message="Something went wrong in the connector. See the logs for more details.",
                 internal_message=exception_message,
                 stack_trace=f"{exception_trace}\n",
             ),

--- a/airbyte-cdk/python/unit_tests/test_exception_handler.py
+++ b/airbyte-cdk/python/unit_tests/test_exception_handler.py
@@ -1,0 +1,57 @@
+#
+# Copyright (c) 2021 Airbyte, Inc., all rights reserved.
+#
+
+
+import json
+import subprocess
+import sys
+
+import pytest
+from airbyte_cdk.models import AirbyteErrorTraceMessage, AirbyteLogMessage, AirbyteMessage, AirbyteTraceMessage
+
+
+def test_uncaught_exception_handler():
+    cmd = "from airbyte_cdk.logger import init_logger; from airbyte_cdk.exception_handler import init_uncaught_exception_handler; logger = init_logger('airbyte'); init_uncaught_exception_handler(logger); raise 1"
+    exception_message = "exceptions must derive from BaseException"
+    exception_trace = (
+        "Traceback (most recent call last):\n"
+        '  File "<string>", line 1, in <module>\n'
+        "TypeError: exceptions must derive from BaseException"
+    )
+
+    expected_log_message = AirbyteMessage(
+        type="LOG", log=AirbyteLogMessage(level="FATAL", message=f"{exception_message}\n{exception_trace}")
+    )
+
+    expected_trace_message = AirbyteMessage(
+        type="TRACE",
+        trace=AirbyteTraceMessage(
+            type="ERROR",
+            emitted_at=0.0,
+            error=AirbyteErrorTraceMessage(
+                failure_type="system_error",
+                message="an error occurred with the source",
+                internal_message=exception_message,
+                stack_trace=f"{exception_trace}\n",
+            ),
+        ),
+    )
+
+    with pytest.raises(subprocess.CalledProcessError) as err:
+        subprocess.check_output([sys.executable, "-c", cmd], stderr=subprocess.STDOUT)
+
+    assert not err.value.stderr, "nothing on the stderr"
+
+    stdout_lines = err.value.output.decode("utf-8").strip().split("\n")
+    assert len(stdout_lines) == 2
+
+    log_output, trace_output = stdout_lines
+
+    out_log_message = AirbyteMessage.parse_obj(json.loads(log_output))
+    assert out_log_message == expected_log_message, "Log message should be emitted in expected form"
+
+    out_trace_message = AirbyteMessage.parse_obj(json.loads(trace_output))
+    assert out_trace_message.trace.emitted_at > 0
+    out_trace_message.trace.emitted_at = 0.0  # set a specific emitted_at value for testing
+    assert out_trace_message == expected_trace_message, "Trace message should be emitted in expected form"

--- a/airbyte-cdk/python/unit_tests/test_logger.py
+++ b/airbyte-cdk/python/unit_tests/test_logger.py
@@ -5,13 +5,10 @@
 
 import json
 import logging
-import subprocess
-import sys
 from typing import Dict
 
 import pytest
 from airbyte_cdk.logger import AirbyteLogFormatter
-from airbyte_cdk.models import AirbyteLogMessage, AirbyteMessage
 
 
 @pytest.fixture(scope="session")

--- a/airbyte-cdk/python/unit_tests/test_logger.py
+++ b/airbyte-cdk/python/unit_tests/test_logger.py
@@ -95,21 +95,3 @@ def test_fatal(logger, caplog):
     record = caplog.records[0]
     assert record.levelname == "CRITICAL"
     assert record.message == "Test fatal 1"
-
-
-def test_unhandled_logger():
-    cmd = "from airbyte_cdk.logger import init_logger; init_logger('airbyte'); raise 1"
-    expected_message = (
-        "exceptions must derive from BaseException\n"
-        "Traceback (most recent call last):\n"
-        '  File "<string>", line 1, in <module>\n'
-        "TypeError: exceptions must derive from BaseException"
-    )
-    log_message = AirbyteMessage(type="LOG", log=AirbyteLogMessage(level="FATAL", message=expected_message))
-    expected_output = log_message.json(exclude_unset=True)
-
-    with pytest.raises(subprocess.CalledProcessError) as err:
-        subprocess.check_output([sys.executable, "-c", cmd], stderr=subprocess.STDOUT)
-
-    assert not err.value.stderr, "nothing on the stderr"
-    assert err.value.output.decode("utf-8").strip() == expected_output, "Error should be printed in expected form"

--- a/airbyte-cdk/python/unit_tests/test_secure_logger.py
+++ b/airbyte-cdk/python/unit_tests/test_secure_logger.py
@@ -145,7 +145,7 @@ def test_airbyte_secret_is_masked_on_logger_output(source_spec, mocker, config, 
     assert all([str(v) in log_result for v in expected_plain_text_values])
 
 
-def test_airbyte_secrets_are_masked_on_uncaught_exceptions(mocker, caplog):
+def test_airbyte_secrets_are_masked_on_uncaught_exceptions(mocker, caplog, capsys):
     caplog.set_level(logging.DEBUG, logger="airbyte.test")
     caplog.handler.setFormatter(AirbyteLogFormatter())
 
@@ -188,10 +188,11 @@ def test_airbyte_secrets_are_masked_on_uncaught_exceptions(mocker, caplog):
         list(entrypoint.run(parsed_args))
     except Exception:
         sys.excepthook(*sys.exc_info())
-        assert I_AM_A_SECRET_VALUE not in caplog.text, "Should have filtered secret value from exception"
+        assert I_AM_A_SECRET_VALUE not in capsys.readouterr().out, "Should have filtered non-secret value from exception trace message"
+        assert I_AM_A_SECRET_VALUE not in caplog.text, "Should have filtered secret value from exception log message"
 
 
-def test_non_airbyte_secrets_are_not_masked_on_uncaught_exceptions(mocker, caplog):
+def test_non_airbyte_secrets_are_not_masked_on_uncaught_exceptions(mocker, caplog, capsys):
     caplog.set_level(logging.DEBUG, logger="airbyte.test")
     caplog.handler.setFormatter(AirbyteLogFormatter())
 
@@ -235,4 +236,5 @@ def test_non_airbyte_secrets_are_not_masked_on_uncaught_exceptions(mocker, caplo
         list(entrypoint.run(parsed_args))
     except Exception:
         sys.excepthook(*sys.exc_info())
-        assert NOT_A_SECRET_VALUE in caplog.text, "Should not have filtered non-secret value from exception"
+        assert NOT_A_SECRET_VALUE in capsys.readouterr().out, "Should not have filtered non-secret value from exception trace message"
+        assert NOT_A_SECRET_VALUE in caplog.text, "Should not have filtered non-secret value from exception log message"

--- a/airbyte-cdk/python/unit_tests/utils/test_secret_helper.py
+++ b/airbyte-cdk/python/unit_tests/utils/test_secret_helper.py
@@ -1,0 +1,22 @@
+#
+# Copyright (c) 2021 Airbyte, Inc., all rights reserved.
+#
+
+
+from airbyte_cdk.utils.airbyte_secrets_utils import AirbyteSecretHelper
+
+SECRET_VALUE = "i am a very sensitive secret"
+ANOTHER_SECRET_VALUE = "also super secret"
+NOT_SECRET_VALUE = "unimportant value"
+
+
+def test_airbyte_secret_helper():
+    sensitive_str = f"{SECRET_VALUE} {NOT_SECRET_VALUE} {SECRET_VALUE} {ANOTHER_SECRET_VALUE}"
+
+    AirbyteSecretHelper.update_secrets([])
+    filtered = AirbyteSecretHelper.filter_secrets(sensitive_str)
+    assert filtered == sensitive_str
+
+    AirbyteSecretHelper.update_secrets([SECRET_VALUE, ANOTHER_SECRET_VALUE])
+    filtered = AirbyteSecretHelper.filter_secrets(sensitive_str)
+    assert filtered == f"**** {NOT_SECRET_VALUE} **** ****"

--- a/airbyte-cdk/python/unit_tests/utils/test_secret_utils.py
+++ b/airbyte-cdk/python/unit_tests/utils/test_secret_utils.py
@@ -3,20 +3,20 @@
 #
 
 
-from airbyte_cdk.utils.airbyte_secrets_utils import AirbyteSecretHelper
+from airbyte_cdk.utils.airbyte_secrets_utils import filter_secrets, update_secrets
 
 SECRET_VALUE = "i am a very sensitive secret"
 ANOTHER_SECRET_VALUE = "also super secret"
 NOT_SECRET_VALUE = "unimportant value"
 
 
-def test_airbyte_secret_helper():
+def test_secret_filtering():
     sensitive_str = f"{SECRET_VALUE} {NOT_SECRET_VALUE} {SECRET_VALUE} {ANOTHER_SECRET_VALUE}"
 
-    AirbyteSecretHelper.update_secrets([])
-    filtered = AirbyteSecretHelper.filter_secrets(sensitive_str)
+    update_secrets([])
+    filtered = filter_secrets(sensitive_str)
     assert filtered == sensitive_str
 
-    AirbyteSecretHelper.update_secrets([SECRET_VALUE, ANOTHER_SECRET_VALUE])
-    filtered = AirbyteSecretHelper.filter_secrets(sensitive_str)
+    update_secrets([SECRET_VALUE, ANOTHER_SECRET_VALUE])
+    filtered = filter_secrets(sensitive_str)
     assert filtered == f"**** {NOT_SECRET_VALUE} **** ****"

--- a/airbyte-cdk/python/unit_tests/utils/test_traced_exception.py
+++ b/airbyte-cdk/python/unit_tests/utils/test_traced_exception.py
@@ -1,0 +1,53 @@
+#
+# Copyright (c) 2021 Airbyte, Inc., all rights reserved.
+#
+
+import pytest
+from airbyte_cdk.models.airbyte_protocol import AirbyteMessage, FailureType, TraceType
+from airbyte_cdk.models.airbyte_protocol import Type as MessageType
+from airbyte_cdk.utils.traced_exception import AirbyteTracedException
+
+
+@pytest.fixture
+def raised_exception():
+    try:
+        raise RuntimeError("an error has occurred")
+    except RuntimeError as e:
+        return e
+
+
+def test_build_from_existing_exception(raised_exception):
+    traced_exc = AirbyteTracedException.from_exception(raised_exception, message="my user-friendly message")
+    assert traced_exc.message == "my user-friendly message"
+    assert traced_exc.internal_message == "an error has occurred"
+    assert traced_exc.failure_type == FailureType.system_error
+    assert traced_exc._exception == raised_exception
+
+
+def test_exception_as_airbyte_message():
+    traced_exc = AirbyteTracedException("an internal message")
+    airbyte_message = traced_exc.as_airbyte_message()
+
+    assert type(airbyte_message) == AirbyteMessage
+    assert airbyte_message.type == MessageType.TRACE
+    assert airbyte_message.trace.type == TraceType.ERROR
+    assert airbyte_message.trace.emitted_at > 0
+    assert airbyte_message.trace.error.failure_type == FailureType.system_error
+    assert airbyte_message.trace.error.message == "an error occurred with the source"
+    assert airbyte_message.trace.error.internal_message == "an internal message"
+    assert airbyte_message.trace.error.stack_trace == "airbyte_cdk.utils.traced_exception.AirbyteTracedException: an internal message\n"
+
+
+def test_existing_exception_as_airbyte_message(raised_exception):
+    traced_exc = AirbyteTracedException.from_exception(raised_exception)
+    airbyte_message = traced_exc.as_airbyte_message()
+
+    assert type(airbyte_message) == AirbyteMessage
+    assert airbyte_message.type == MessageType.TRACE
+    assert airbyte_message.trace.type == TraceType.ERROR
+    assert airbyte_message.trace.error.message == "an error occurred with the source"
+    assert airbyte_message.trace.error.internal_message == "an error has occurred"
+    assert airbyte_message.trace.error.stack_trace.startswith("Traceback (most recent call last):")
+    assert airbyte_message.trace.error.stack_trace.endswith(
+        'raise RuntimeError("an error has occurred")\n' "RuntimeError: an error has occurred\n"
+    )

--- a/airbyte-cdk/python/unit_tests/utils/test_traced_exception.py
+++ b/airbyte-cdk/python/unit_tests/utils/test_traced_exception.py
@@ -33,7 +33,7 @@ def test_exception_as_airbyte_message():
     assert airbyte_message.trace.type == TraceType.ERROR
     assert airbyte_message.trace.emitted_at > 0
     assert airbyte_message.trace.error.failure_type == FailureType.system_error
-    assert airbyte_message.trace.error.message == "an error occurred with the source"
+    assert airbyte_message.trace.error.message == "Something went wrong in the connector. See the logs for more details."
     assert airbyte_message.trace.error.internal_message == "an internal message"
     assert airbyte_message.trace.error.stack_trace == "airbyte_cdk.utils.traced_exception.AirbyteTracedException: an internal message\n"
 
@@ -45,7 +45,7 @@ def test_existing_exception_as_airbyte_message(raised_exception):
     assert type(airbyte_message) == AirbyteMessage
     assert airbyte_message.type == MessageType.TRACE
     assert airbyte_message.trace.type == TraceType.ERROR
-    assert airbyte_message.trace.error.message == "an error occurred with the source"
+    assert airbyte_message.trace.error.message == "Something went wrong in the connector. See the logs for more details."
     assert airbyte_message.trace.error.internal_message == "an error has occurred"
     assert airbyte_message.trace.error.stack_trace.startswith("Traceback (most recent call last):")
     assert airbyte_message.trace.error.stack_trace.endswith(


### PR DESCRIPTION
## What
`AirbyteTraceMessage` has been introduced in the protocol to allow better debugging and attribution of failures when something in the connector goes wrong. 

This change starts emitting `AirbyteTraceMessage`s generically whenever an exception is raised. A future PR will make it easier to return better user-friendly messages.

closes #12472 

## How
- Use `sys.excepthook` to register a global handler for uncaught exceptions. This handler is in charge of emitting the generic `AirbyteTraceMessage`s.
- Introduce an `AirbyteTracedException` class, which can be used to customize the trace message and provide better error messages.
- Refactor the logger's secret filtering logic out into an `AirbyteSecretHelper` so it can be re-used to filter out secrets from trace messages.

## Recommended reading order
1. `utils/traced_exception.py`
2. `exception_handler.py`
3. tests

