### PR TITLE
Dynamically set y-axis label width for credits chart

### DIFF
--- a/airbyte-webapp/src/components/BarChart/BarChart.tsx
+++ b/airbyte-webapp/src/components/BarChart/BarChart.tsx
@@ -1,4 +1,4 @@
-import React from "react";
+import React, { useMemo } from "react";
 import { Bar, BarChart as BasicBarChart, CartesianGrid, Label, ResponsiveContainer, XAxis, YAxis } from "recharts";
 import { barChartColors, theme } from "theme";
 
@@ -16,9 +16,9 @@ const BarChart: React.FC<BarChartProps> = ({ data, legendLabels, xLabel, yLabel 
   const chartLinesColor = theme.greyColor20;
   const chartTicksColor = theme.lightTextColor;
 
-  const width = Math.min(
-    Math.max([...data].sort((a, b) => b.value - a.value)[0].value.toFixed(0).length * 10, 80),
-    130
+  const width = useMemo(
+    () => Math.min(Math.max([...data].sort((a, b) => b.value - a.value)[0].value.toFixed(0).length * 10, 80), 130),
+    [data]
   );
 
   return (

--- a/airbyte-webapp/src/components/BarChart/BarChart.tsx
+++ b/airbyte-webapp/src/components/BarChart/BarChart.tsx
@@ -1,11 +1,11 @@
 import React from "react";
-import { CartesianGrid, BarChart as BasicBarChart, ResponsiveContainer, XAxis, YAxis, Bar, Label } from "recharts";
+import { Bar, BarChart as BasicBarChart, CartesianGrid, Label, ResponsiveContainer, XAxis, YAxis } from "recharts";
 import { barChartColors, theme } from "theme";
 
 type BarChartProps = {
-  data?: {
+  data: {
     name: string;
-    value: number | number[];
+    value: number;
   }[];
   legendLabels: string[];
   xLabel?: string;
@@ -15,6 +15,11 @@ type BarChartProps = {
 const BarChart: React.FC<BarChartProps> = ({ data, legendLabels, xLabel, yLabel }) => {
   const chartLinesColor = theme.greyColor20;
   const chartTicksColor = theme.lightTextColor;
+
+  const width = Math.min(
+    Math.max([...data].sort((a, b) => b.value - a.value)[0].value.toFixed(0).length * 10, 80),
+    130
+  );
 
   return (
     <ResponsiveContainer>
@@ -38,11 +43,18 @@ const BarChart: React.FC<BarChartProps> = ({ data, legendLabels, xLabel, yLabel 
           tick={{ fontSize: "11px" }}
           tickSize={7}
         />
-        <YAxis axisLine={false} tickLine={false} stroke={chartTicksColor} tick={{ fontSize: "11px" }} tickSize={10}>
+        <YAxis
+          axisLine={false}
+          tickLine={false}
+          stroke={chartTicksColor}
+          tick={{ fontSize: "11px" }}
+          tickSize={10}
+          width={width}
+        >
           <Label value={yLabel} fontSize={11} fill={chartTicksColor} fontWeight={600} position="top" offset={10} />
         </YAxis>
         {legendLabels.map((barName, key) => (
-          <Bar dataKey={barName} fill={barChartColors[key]} />
+          <Bar dataKey={barName} key={barName} fill={barChartColors[key]} />
         ))}
       </BasicBarChart>
     </ResponsiveContainer>


### PR DESCRIPTION
Fixes #11586

This is honestly a little hackier than I wanted, but we don't have a way to dynamically set the [width](https://recharts.org/en-US/api/YAxis#width)