### PR TITLE
Fix broken password reset functionality

### DIFF
--- a/airbyte-webapp/src/packages/cloud/views/FirebaseActionRoute.tsx
+++ b/airbyte-webapp/src/packages/cloud/views/FirebaseActionRoute.tsx
@@ -17,26 +17,30 @@ export enum FirebaseActionMode {
 }
 
 export const VerifyEmailAction: React.FC = () => {
-  const { query } = useRouter<{ oobCode: string }>();
+  const { query } = useRouter<{ oobCode: string; mode: string }>();
   const { verifyEmail } = useAuthService();
   const navigate = useNavigate();
   const { formatMessage } = useIntl();
   const { registerNotification } = useNotificationService();
 
   useAsync(async () => {
-    // Send verification code to authentication service
-    await verifyEmail(query.oobCode);
-    // Show a notification that the mail got verified successfully
-    registerNotification({
-      id: "auth/email-verified",
-      title: formatMessage({ id: "verifyEmail.notification" }),
-      isError: false,
-    });
-    // Navigate the user to the homepage
-    navigate("/");
+    if (query.mode === FirebaseActionMode.VERIFY_EMAIL) {
+      // Send verification code to authentication service
+      await verifyEmail(query.oobCode);
+      // Show a notification that the mail got verified successfully
+      registerNotification({
+        id: "auth/email-verified",
+        title: formatMessage({ id: "verifyEmail.notification" }),
+        isError: false,
+      });
+      // Navigate the user to the homepage
+      navigate("/");
+    }
   }, []);
 
-  return <LoadingPage />;
+  // Only render the loading screen if we're verifying an email otherwise don't render anything,
+  // since password reset is handled in a different place.
+  return query.mode === FirebaseActionMode.VERIFY_EMAIL ? <LoadingPage /> : null;
 };
 
 export const ResetPasswordAction: React.FC = () => {


### PR DESCRIPTION
## What

Fixes the broken password reset in cloud. The reason is that the email verification (due to no longer being required before using the app) sinec https://github.com/airbytehq/airbyte/pull/12235 works whether the user is logged in or not. That route for email verification is though listening on `/verify-email` the same as all routes coming from Firebase emails. Trying to reset your password would now be caught by the actual verify email logic which tried to verify your email address using the reset password oobCode which would simply fail.

This fix makes sure that the verify email logic (which is now triggering on the `/verify-email` route no matter whether the user is logged in or not), checks that the `mode` query parameter actually is `verifyEmail` and only does it logic in this case.

Best to be reviewed with "Hide whitespace" activated.