### PR TITLE
print notice logs for socat

### DIFF
--- a/airbyte-workers/src/main/java/io/airbyte/workers/process/KubePodProcess.java
+++ b/airbyte-workers/src/main/java/io/airbyte/workers/process/KubePodProcess.java
@@ -438,11 +438,14 @@ public class KubePodProcess extends Process implements KubePod {
         envMap,
         args);
 
+    // Printing socat notice logs with socat -d -d
+    // To print info logs as well use socat -d -d -d
+    // more info: https://linux.die.net/man/1/socat
     final io.fabric8.kubernetes.api.model.ResourceRequirements sidecarResources = getResourceRequirementsBuilder(DEFAULT_SIDECAR_RESOURCES).build();
     final Container remoteStdin = new ContainerBuilder()
         .withName("remote-stdin")
         .withImage(socatImage)
-        .withCommand("sh", "-c", "socat -d TCP-L:9001 STDOUT > " + STDIN_PIPE_FILE)
+        .withCommand("sh", "-c", "socat -d -d TCP-L:9001 STDOUT > " + STDIN_PIPE_FILE)
         .withVolumeMounts(pipeVolumeMount, terminationVolumeMount)
         .withResources(sidecarResources)
         .withImagePullPolicy(sidecarImagePullPolicy)
@@ -451,7 +454,7 @@ public class KubePodProcess extends Process implements KubePod {
     final Container relayStdout = new ContainerBuilder()
         .withName("relay-stdout")
         .withImage(socatImage)
-        .withCommand("sh", "-c", String.format("cat %s | socat -d - TCP:%s:%s", STDOUT_PIPE_FILE, processRunnerHost, stdoutLocalPort))
+        .withCommand("sh", "-c", String.format("cat %s | socat -d -d - TCP:%s:%s", STDOUT_PIPE_FILE, processRunnerHost, stdoutLocalPort))
         .withVolumeMounts(pipeVolumeMount, terminationVolumeMount)
         .withResources(sidecarResources)
         .withImagePullPolicy(sidecarImagePullPolicy)
@@ -460,7 +463,7 @@ public class KubePodProcess extends Process implements KubePod {
     final Container relayStderr = new ContainerBuilder()
         .withName("relay-stderr")
         .withImage(socatImage)
-        .withCommand("sh", "-c", String.format("cat %s | socat -d - TCP:%s:%s", STDERR_PIPE_FILE, processRunnerHost, stderrLocalPort))
+        .withCommand("sh", "-c", String.format("cat %s | socat -d -d - TCP:%s:%s", STDERR_PIPE_FILE, processRunnerHost, stderrLocalPort))
         .withVolumeMounts(pipeVolumeMount, terminationVolumeMount)
         .withResources(sidecarResources)
         .withImagePullPolicy(sidecarImagePullPolicy)


### PR DESCRIPTION
## What
Currently we don't have any useful logs for socat containers.
We can enable notice logs with `-d -d`, and additionally info logs with `-d -d -d`.

Here's a sample of the full log output of a socat container with notice level logs.
```
2022/05/05 16:09:02 socat[8] N reading from and writing to stdio
2022/05/05 16:09:02 socat[8] N opening connection to AF=2 172.25.37.3:9877
2022/05/05 16:09:02 socat[8] N successfully connected from local address AF=2 172.25.32.134:38950
2022/05/05 16:09:02 socat[8] N starting data transfer loop with FDs [0,1] and [5,5]
2022/05/05 16:14:17 socat[8] N socket 1 (fd 0) is at EOF
2022/05/05 16:14:19 socat[8] N exiting with status 0
```

Info logs are more chatty
```
2022/05/05 02:03:29 socat[9] I transferred 8192 bytes from 0 to 5
2022/05/05 02:03:29 socat[9] I transferred 5306 bytes from 0 to 5
2022/05/05 02:03:29 socat[9] N socket 1 (fd 0) is at EOF
2022/05/05 02:03:29 socat[9] I shutdown(5, 1)
2022/05/05 02:03:30 socat[9] I poll timed out (no data within 0.500000 seconds)
2022/05/05 02:03:30 socat[9] I shutdown(5, 2)
2022/05/05 02:03:30 socat[9] N exiting with status 0
```
In particular, there is one log line per packet sent, which seems excessive.

Notice logs seem like useful info to have, while info logs seem too chatty, so I've chosen to only print up to notice logs, but left a comment for how to enable info logging if needed for debugging.
