### PR TITLE
Remove redirect to previous page after manual log out, expose redirect param, fix auth page titles

### DIFF
--- a/airbyte-webapp/src/packages/cloud/cloudRoutes.tsx
+++ b/airbyte-webapp/src/packages/cloud/cloudRoutes.tsx
@@ -21,7 +21,6 @@ import DestinationPage from "pages/DestinationPage";
 import OnboardingPage from "pages/OnboardingPage";
 import SourcesPage from "pages/SourcesPage";
 import { useCurrentWorkspace, WorkspaceServiceProvider } from "services/workspaces/WorkspacesService";
-import { hasFromState } from "utils/stateUtils";
 import { storeUtmFromQuery } from "utils/utmStorage";
 import { CompleteOauthRequest } from "views/CompleteOauthRequest";
 
@@ -106,16 +105,12 @@ const MainRoutes: React.FC = () => {
 const MainViewRoutes = () => {
   useApiHealthPoll();
   useIntercom();
-  const { location } = useRouter();
+  const { query } = useRouter();
 
   return (
     <Routes>
       {[CloudRoutes.Login, CloudRoutes.Signup, CloudRoutes.FirebaseAction].map((r) => (
-        <Route
-          key={r}
-          path={`${r}/*`}
-          element={hasFromState(location.state) ? <Navigate to={location.state.from} replace /> : <DefaultView />}
-        />
+        <Route key={r} path={`${r}/*`} element={query.from ? <Navigate to={query.from} replace /> : <DefaultView />} />
       ))}
       <Route path={CloudRoutes.SelectWorkspace} element={<WorkspacesPage />} />
       <Route path={CloudRoutes.AuthFlow} element={<CompleteOauthRequest />} />

--- a/airbyte-webapp/src/packages/cloud/services/auth/AuthService.tsx
+++ b/airbyte-webapp/src/packages/cloud/services/auth/AuthService.tsx
@@ -36,11 +36,12 @@ export type AuthSendEmailVerification = () => Promise<void>;
 export type AuthVerifyEmail = (code: string) => Promise<void>;
 export type AuthLogout = () => void;
 
-type AuthContextApi = {
+interface AuthContextApi {
   user: User | null;
   inited: boolean;
   emailVerified: boolean;
   isLoading: boolean;
+  loggedOut: boolean;
   login: AuthLogin;
   signUp: AuthSignUp;
   updatePassword: AuthUpdatePassword;
@@ -50,7 +51,7 @@ type AuthContextApi = {
   sendEmailVerification: AuthSendEmailVerification;
   verifyEmail: AuthVerifyEmail;
   logout: AuthLogout;
-};
+}
 
 export const AuthContext = React.createContext<AuthContextApi | null>(null);
 
@@ -96,6 +97,7 @@ export const AuthenticationProvider: React.FC = ({ children }) => {
       inited: state.inited,
       isLoading: state.loading,
       emailVerified: state.emailVerified,
+      loggedOut: state.loggedOut,
       async login(values: { email: string; password: string }): Promise<void> {
         await authService.login(values.email, values.password);
 

--- a/airbyte-webapp/src/packages/cloud/services/auth/AuthService.tsx
+++ b/airbyte-webapp/src/packages/cloud/services/auth/AuthService.tsx
@@ -107,8 +107,8 @@ export const AuthenticationProvider: React.FC = ({ children }) => {
       },
       async logout(): Promise<void> {
         await authService.signOut();
+        queryClient.removeQueries();
         loggedOut();
-        await queryClient.invalidateQueries();
       },
       async updateEmail(email, password): Promise<void> {
         await userService.changeEmail(email);

--- a/airbyte-webapp/src/packages/cloud/services/auth/reducer.ts
+++ b/airbyte-webapp/src/packages/cloud/services/auth/reducer.ts
@@ -16,6 +16,7 @@ export type AuthServiceState = {
   currentUser: User | null;
   emailVerified: boolean;
   loading: boolean;
+  loggedOut: boolean;
 };
 
 export const initialState: AuthServiceState = {
@@ -23,6 +24,7 @@ export const initialState: AuthServiceState = {
   currentUser: null,
   emailVerified: false,
   loading: false,
+  loggedOut: false,
 };
 
 export const authStateReducer = createReducer<AuthServiceState, Actions>(initialState)
@@ -39,6 +41,7 @@ export const authStateReducer = createReducer<AuthServiceState, Actions>(initial
       emailVerified: action.payload.emailVerified,
       inited: true,
       loading: false,
+      loggedOut: false,
     };
   })
   .handleAction(actions.emailVerified, (state, action): AuthServiceState => {
@@ -52,5 +55,6 @@ export const authStateReducer = createReducer<AuthServiceState, Actions>(initial
       ...state,
       currentUser: null,
       emailVerified: false,
+      loggedOut: true,
     };
   });

--- a/airbyte-webapp/src/packages/cloud/views/auth/Auth.tsx
+++ b/airbyte-webapp/src/packages/cloud/views/auth/Auth.tsx
@@ -6,6 +6,7 @@ import { LoadingPage } from "components";
 
 import useRouter from "hooks/useRouter";
 import { CloudRoutes } from "packages/cloud/cloudRoutes";
+import { useAuthService } from "packages/cloud/services/auth/AuthService";
 import { ResetPasswordAction } from "packages/cloud/views/FirebaseActionRoute";
 
 import FormContent from "./components/FormContent";
@@ -39,6 +40,7 @@ const NewsPart = styled(Part)`
 
 const Auth: React.FC = () => {
   const { pathname, location } = useRouter();
+  const { loggedOut } = useAuthService();
 
   return (
     <Content>
@@ -50,7 +52,10 @@ const Auth: React.FC = () => {
               <Route path={CloudRoutes.Signup} element={<SignupPage />} />
               <Route path={CloudRoutes.ResetPassword} element={<ResetPasswordPage />} />
               <Route path={CloudRoutes.FirebaseAction} element={<ResetPasswordAction />} />
-              <Route path="*" element={<Navigate to={CloudRoutes.Login} state={{ from: location }} />} />
+              <Route
+                path="*"
+                element={<Navigate to={`${CloudRoutes.Login}${loggedOut ? "" : `?from=${location.pathname}`}`} />}
+              />
             </Routes>
           </Suspense>
         </FormContent>

--- a/airbyte-webapp/src/packages/cloud/views/auth/LoginPage/LoginPage.tsx
+++ b/airbyte-webapp/src/packages/cloud/views/auth/LoginPage/LoginPage.tsx
@@ -4,6 +4,7 @@ import { FormattedMessage, useIntl } from "react-intl";
 import * as yup from "yup";
 
 import { LabeledInput, Link, LoadingButton } from "components";
+import HeadTitle from "components/HeadTitle";
 
 import useRouter from "hooks/useRouter";
 import { CloudRoutes } from "packages/cloud/cloudRoutes";
@@ -24,6 +25,7 @@ const LoginPage: React.FC = () => {
 
   return (
     <div>
+      <HeadTitle titles={[{ id: "login.login" }]} />
       <FormTitle bold>
         <FormattedMessage id="login.loginTitle" />
       </FormTitle>

--- a/airbyte-webapp/src/packages/cloud/views/auth/LoginPage/LoginPage.tsx
+++ b/airbyte-webapp/src/packages/cloud/views/auth/LoginPage/LoginPage.tsx
@@ -20,7 +20,7 @@ const LoginPageValidationSchema = yup.object().shape({
 const LoginPage: React.FC = () => {
   const formatMessage = useIntl().formatMessage;
   const { login } = useAuthService();
-  const { location, replace } = useRouter();
+  const { query, replace } = useRouter();
 
   return (
     <div>
@@ -35,18 +35,15 @@ const LoginPage: React.FC = () => {
         }}
         validationSchema={LoginPageValidationSchema}
         onSubmit={async (values, { setFieldError }) => {
-          return (
-            login(values)
-              // @ts-expect-error state is now unkown, needs proper typing
-              .then((_) => replace(location.state?.from ?? "/"))
-              .catch((err) => {
-                if (err instanceof FieldError) {
-                  setFieldError(err.field, err.message);
-                } else {
-                  setFieldError("password", err.message);
-                }
-              })
-          );
+          return login(values)
+            .then((_) => replace(query.from ?? "/"))
+            .catch((err) => {
+              if (err instanceof FieldError) {
+                setFieldError(err.field, err.message);
+              } else {
+                setFieldError("password", err.message);
+              }
+            });
         }}
         validateOnBlur
         validateOnChange={false}

--- a/airbyte-webapp/src/packages/cloud/views/auth/LoginPage/LoginPage.tsx
+++ b/airbyte-webapp/src/packages/cloud/views/auth/LoginPage/LoginPage.tsx
@@ -38,7 +38,7 @@ const LoginPage: React.FC = () => {
         validationSchema={LoginPageValidationSchema}
         onSubmit={async (values, { setFieldError }) => {
           return login(values)
-            .then((_) => replace(query.from ?? "/"))
+            .then(() => replace(query.from ?? "/"))
             .catch((err) => {
               if (err instanceof FieldError) {
                 setFieldError(err.field, err.message);

--- a/airbyte-webapp/src/packages/cloud/views/auth/ResetPasswordPage/ResetPasswordPage.tsx
+++ b/airbyte-webapp/src/packages/cloud/views/auth/ResetPasswordPage/ResetPasswordPage.tsx
@@ -4,6 +4,7 @@ import { FormattedMessage, useIntl } from "react-intl";
 import * as yup from "yup";
 
 import { LoadingButton, LabeledInput, Link } from "components";
+import HeadTitle from "components/HeadTitle";
 
 import { useNotificationService } from "hooks/services/Notification/NotificationService";
 import { useAuthService } from "packages/cloud/services/auth/AuthService";
@@ -23,6 +24,7 @@ const ResetPasswordPage: React.FC = () => {
 
   return (
     <div>
+      <HeadTitle titles={[{ id: "login.resetPassword" }]} />
       <FormTitle bold>
         <FormattedMessage id="login.resetPassword" />
       </FormTitle>

--- a/airbyte-webapp/src/packages/cloud/views/auth/SignupPage/SignupPage.tsx
+++ b/airbyte-webapp/src/packages/cloud/views/auth/SignupPage/SignupPage.tsx
@@ -5,6 +5,7 @@ import styled from "styled-components";
 import * as yup from "yup";
 
 import { H1, LabeledInput, Link, LoadingButton } from "components";
+import HeadTitle from "components/HeadTitle";
 
 import { useConfig } from "config";
 import { FieldError } from "packages/cloud/lib/errors/FieldError";
@@ -43,6 +44,7 @@ const SignupPage: React.FC = () => {
 
   return (
     <div>
+      <HeadTitle titles={[{ id: "login.signup" }]} />
       <H1 bold>
         <FormattedMessage id="login.activateAccess" />
       </H1>

--- a/airbyte-webapp/src/utils/stateUtils.ts
+++ b/airbyte-webapp/src/utils/stateUtils.ts
@@ -1,5 +1,0 @@
-import type { Location } from "react-router-dom";
-
-export function hasFromState(state: unknown): state is { from: Location } {
-  return typeof state === "object" && state !== null && "from" in state;
-}


### PR DESCRIPTION
## What
Fixes #12311 

This change fixes a number of issues related to logging in and out:

1. When logging out manually, the app will no longer provide a redirect location so that when the user logs in it go back to the app's home
2. The login, sign in, and reset password pages now have titles so that when navigating the title on the window updates
3. The "from" parameter on the log in page is now part of the page instead of an internal state

## How
For manually logging out, the auth service now holds a flag called `loggedOut` to indicate that the user-initiated the logout. It is reset when the user logs in.

The "from" parameter used to be part of react-router's state prop. Now it's just built into the navigation query and extracted from the query.

## Testing
- Sign out from settings and sign in
- Clear cookies, reload page, and sign in
- Navigate to reset password, sign up, and sign in
