### PR TITLE
Add timeout to publish-image task

### DIFF
--- a/.github/workflows/publish-command.yml
+++ b/.github/workflows/publish-command.yml
@@ -68,6 +68,7 @@ jobs:
           # 80 gb disk
           ec2-image-id: ami-0d648081937c75a73
   publish-image:
+    timeout-minutes: 240
     needs: start-publish-image-runner
     runs-on: ${{ needs.start-publish-image-runner.outputs.label }}
     environment: more-secrets


### PR DESCRIPTION
## What
publish-image task can take a while, because it is also running
integration tests by default. test-command workflow has a timeout
of 240 minutes. I added the same timeout value to publish-image task.

