### PR TITLE
Bump Airbyte version from 0.36.11-alpha to 0.37.0-alpha

### DIFF
--- a/.bumpversion.cfg
+++ b/.bumpversion.cfg
@@ -1,5 +1,5 @@
 [bumpversion]
-current_version = 0.36.11-alpha
+current_version = 0.37.0-alpha
 commit = False
 tag = False
 parse = (?P<major>\d+)\.(?P<minor>\d+)\.(?P<patch>\d+)(\-[a-z]+)?

--- a/.env
+++ b/.env
@@ -10,7 +10,7 @@
 
 
 ### SHARED ###
-VERSION=0.36.11-alpha
+VERSION=0.37.0-alpha
 
 # When using the airbyte-db via default docker image
 CONFIG_ROOT=/data

--- a/airbyte-bootloader/Dockerfile
+++ b/airbyte-bootloader/Dockerfile
@@ -1,7 +1,7 @@
 ARG JDK_VERSION=17.0.1
 FROM openjdk:${JDK_VERSION}-slim
 
-ARG VERSION=0.36.11-alpha
+ARG VERSION=0.37.0-alpha
 
 ENV APPLICATION airbyte-bootloader
 ENV VERSION ${VERSION}

--- a/airbyte-container-orchestrator/Dockerfile
+++ b/airbyte-container-orchestrator/Dockerfile
@@ -26,7 +26,7 @@ RUN echo "deb [signed-by=/usr/share/keyrings/kubernetes-archive-keyring.gpg] htt
 RUN apt-get update && apt-get install -y kubectl
 
 # Don't change this manually.  Bump version expects to make moves based on this string
-ARG VERSION=0.36.11-alpha
+ARG VERSION=0.37.0-alpha
 
 ENV APPLICATION airbyte-container-orchestrator
 ENV VERSION=${VERSION}

--- a/airbyte-metrics/reporter/Dockerfile
+++ b/airbyte-metrics/reporter/Dockerfile
@@ -1,7 +1,7 @@
 ARG JDK_VERSION=17.0.1
 FROM openjdk:${JDK_VERSION}-slim AS metrics-reporter
 
-ARG VERSION=0.36.11-alpha
+ARG VERSION=0.37.0-alpha
 
 ENV APPLICATION airbyte-metrics-reporter
 ENV VERSION ${VERSION}

--- a/airbyte-scheduler/app/Dockerfile
+++ b/airbyte-scheduler/app/Dockerfile
@@ -1,7 +1,7 @@
 ARG JDK_VERSION=17.0.1
 FROM openjdk:${JDK_VERSION}-slim AS scheduler
 
-ARG VERSION=0.36.11-alpha
+ARG VERSION=0.37.0-alpha
 
 ENV APPLICATION airbyte-scheduler
 ENV VERSION ${VERSION}

--- a/airbyte-server/Dockerfile
+++ b/airbyte-server/Dockerfile
@@ -3,7 +3,7 @@ FROM openjdk:${JDK_VERSION}-slim AS server
 
 EXPOSE 8000
 
-ARG VERSION=0.36.11-alpha
+ARG VERSION=0.37.0-alpha
 
 ENV APPLICATION airbyte-server
 ENV VERSION ${VERSION}

--- a/airbyte-webapp/package-lock.json
+++ b/airbyte-webapp/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "airbyte-webapp",
-  "version": "0.36.11-alpha",
+  "version": "0.37.0-alpha",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "airbyte-webapp",
-      "version": "0.36.11-alpha",
+      "version": "0.37.0-alpha",
       "dependencies": {
         "@fortawesome/fontawesome-svg-core": "^6.1.1",
         "@fortawesome/free-brands-svg-icons": "^6.1.1",

--- a/airbyte-webapp/package.json
+++ b/airbyte-webapp/package.json
@@ -1,6 +1,6 @@
 {
   "name": "airbyte-webapp",
-  "version": "0.36.11-alpha",
+  "version": "0.37.0-alpha",
   "private": true,
   "engines": {
     "node": ">=16.0.0"

--- a/airbyte-workers/Dockerfile
+++ b/airbyte-workers/Dockerfile
@@ -25,7 +25,7 @@ RUN curl -fsSLo /usr/share/keyrings/kubernetes-archive-keyring.gpg https://packa
 RUN echo "deb [signed-by=/usr/share/keyrings/kubernetes-archive-keyring.gpg] https://apt.kubernetes.io/ kubernetes-xenial main" | tee /etc/apt/sources.list.d/kubernetes.list
 RUN apt-get update && apt-get install -y kubectl
 
-ARG VERSION=0.36.11-alpha
+ARG VERSION=0.37.0-alpha
 
 ENV APPLICATION airbyte-workers
 ENV VERSION ${VERSION}

--- a/charts/airbyte/Chart.yaml
+++ b/charts/airbyte/Chart.yaml
@@ -21,7 +21,7 @@ version: 0.3.2
 # incremented each time you make changes to the application. Versions are not expected to
 # follow Semantic Versioning. They should reflect the version the application is using.
 # It is recommended to use it with quotes.
-appVersion: "0.36.11-alpha"
+appVersion: "0.37.0-alpha"
 
 dependencies:
   - name: common

--- a/charts/airbyte/README.md
+++ b/charts/airbyte/README.md
@@ -30,7 +30,7 @@ Helm charts for Airbyte.
 | `webapp.replicaCount`                       | Number of webapp replicas                                        | `1`              |
 | `webapp.image.repository`                   | The repository to use for the airbyte webapp image.              | `airbyte/webapp` |
 | `webapp.image.pullPolicy`                   | the pull policy to use for the airbyte webapp image              | `IfNotPresent`   |
-| `webapp.image.tag`                          | The airbyte webapp image tag. Defaults to the chart's AppVersion | `0.36.11-alpha`   |
+| `webapp.image.tag`                          | The airbyte webapp image tag. Defaults to the chart's AppVersion | `0.37.0-alpha`   |
 | `webapp.podAnnotations`                     | Add extra annotations to the webapp pod(s)                       | `{}`             |
 | `webapp.containerSecurityContext`           | Security context for the container                               | `{}`             |
 | `webapp.livenessProbe.enabled`              | Enable livenessProbe on the webapp                               | `true`           |
@@ -72,7 +72,7 @@ Helm charts for Airbyte.
 | `scheduler.replicaCount`                       | Number of scheduler replicas                                        | `1`                 |
 | `scheduler.image.repository`                   | The repository to use for the airbyte scheduler image.              | `airbyte/scheduler` |
 | `scheduler.image.pullPolicy`                   | the pull policy to use for the airbyte scheduler image              | `IfNotPresent`      |
-| `scheduler.image.tag`                          | The airbyte scheduler image tag. Defaults to the chart's AppVersion | `0.36.11-alpha`      |
+| `scheduler.image.tag`                          | The airbyte scheduler image tag. Defaults to the chart's AppVersion | `0.37.0-alpha`      |
 | `scheduler.podAnnotations`                     | Add extra annotations to the scheduler pod                          | `{}`                |
 | `scheduler.containerSecurityContext`           | Security context for the container                                  | `{}`                |
 | `scheduler.livenessProbe.enabled`              | Enable livenessProbe on the scheduler                               | `true`              |
@@ -135,7 +135,7 @@ Helm charts for Airbyte.
 | `server.replicaCount`                       | Number of server replicas                                        | `1`              |
 | `server.image.repository`                   | The repository to use for the airbyte server image.              | `airbyte/server` |
 | `server.image.pullPolicy`                   | the pull policy to use for the airbyte server image              | `IfNotPresent`   |
-| `server.image.tag`                          | The airbyte server image tag. Defaults to the chart's AppVersion | `0.36.11-alpha`   |
+| `server.image.tag`                          | The airbyte server image tag. Defaults to the chart's AppVersion | `0.37.0-alpha`   |
 | `server.podAnnotations`                     | Add extra annotations to the server pod                          | `{}`             |
 | `server.containerSecurityContext`           | Security context for the container                               | `{}`             |
 | `server.livenessProbe.enabled`              | Enable livenessProbe on the server                               | `true`           |
@@ -170,7 +170,7 @@ Helm charts for Airbyte.
 | `worker.replicaCount`                       | Number of worker replicas                                        | `1`              |
 | `worker.image.repository`                   | The repository to use for the airbyte worker image.              | `airbyte/worker` |
 | `worker.image.pullPolicy`                   | the pull policy to use for the airbyte worker image              | `IfNotPresent`   |
-| `worker.image.tag`                          | The airbyte worker image tag. Defaults to the chart's AppVersion | `0.36.11-alpha`   |
+| `worker.image.tag`                          | The airbyte worker image tag. Defaults to the chart's AppVersion | `0.37.0-alpha`   |
 | `worker.podAnnotations`                     | Add extra annotations to the worker pod(s)                       | `{}`             |
 | `worker.containerSecurityContext`           | Security context for the container                               | `{}`             |
 | `worker.livenessProbe.enabled`              | Enable livenessProbe on the worker                               | `true`           |
@@ -202,7 +202,7 @@ Helm charts for Airbyte.
 | ----------------------------- | -------------------------------------------------------------------- | -------------------- |
 | `bootloader.image.repository` | The repository to use for the airbyte bootloader image.              | `airbyte/bootloader` |
 | `bootloader.image.pullPolicy` | the pull policy to use for the airbyte bootloader image              | `IfNotPresent`       |
-| `bootloader.image.tag`        | The airbyte bootloader image tag. Defaults to the chart's AppVersion | `0.36.11-alpha`       |
+| `bootloader.image.tag`        | The airbyte bootloader image tag. Defaults to the chart's AppVersion | `0.37.0-alpha`       |
 | `bootloader.podAnnotations`   | Add extra annotations to the bootloader pod                          | `{}`                 |
 | `bootloader.nodeSelector`     | Node labels for pod assignment                                       | `{}`                 |
 | `bootloader.tolerations`      | Tolerations for worker pod assignment.                               | `[]`                 |

--- a/charts/airbyte/values.yaml
+++ b/charts/airbyte/values.yaml
@@ -41,7 +41,7 @@ webapp:
   image:
     repository: airbyte/webapp
     pullPolicy: IfNotPresent
-    tag: 0.36.11-alpha
+    tag: 0.37.0-alpha
 
   ## @param webapp.podAnnotations [object] Add extra annotations to the webapp pod(s)
   ##
@@ -207,7 +207,7 @@ scheduler:
   image:
     repository: airbyte/scheduler
     pullPolicy: IfNotPresent
-    tag: 0.36.11-alpha
+    tag: 0.37.0-alpha
 
   ## @param scheduler.podAnnotations [object] Add extra annotations to the scheduler pod
   ##
@@ -438,7 +438,7 @@ server:
   image:
     repository: airbyte/server
     pullPolicy: IfNotPresent
-    tag: 0.36.11-alpha
+    tag: 0.37.0-alpha
 
   ## @param server.podAnnotations [object] Add extra annotations to the server pod
   ##
@@ -565,7 +565,7 @@ worker:
   image:
     repository: airbyte/worker
     pullPolicy: IfNotPresent
-    tag: 0.36.11-alpha
+    tag: 0.37.0-alpha
 
   ## @param worker.podAnnotations [object] Add extra annotations to the worker pod(s)
   ##
@@ -683,7 +683,7 @@ bootloader:
   image:
     repository: airbyte/bootloader
     pullPolicy: IfNotPresent
-    tag: 0.36.11-alpha
+    tag: 0.37.0-alpha
 
   ## @param bootloader.podAnnotations [object] Add extra annotations to the bootloader pod
   ##

--- a/docs/operator-guides/upgrading-airbyte.md
+++ b/docs/operator-guides/upgrading-airbyte.md
@@ -103,7 +103,7 @@ If you are upgrading from (i.e. your current version of Airbyte is) Airbyte vers
    Here's an example of what it might look like with the values filled in. It assumes that the downloaded `airbyte_archive.tar.gz` is in `/tmp`.
 
    ```bash
-   docker run --rm -v /tmp:/config airbyte/migration:0.36.11-alpha --\
+   docker run --rm -v /tmp:/config airbyte/migration:0.37.0-alpha --\
    --input /config/airbyte_archive.tar.gz\
    --output /config/airbyte_archive_migrated.tar.gz
    ```

--- a/kube/overlays/stable-with-resource-limits/.env
+++ b/kube/overlays/stable-with-resource-limits/.env
@@ -1,4 +1,4 @@
-AIRBYTE_VERSION=0.36.11-alpha
+AIRBYTE_VERSION=0.37.0-alpha
 
 # Airbyte Internal Database, see https://docs.airbyte.io/operator-guides/configuring-airbyte-db
 DATABASE_HOST=airbyte-db-svc

--- a/kube/overlays/stable-with-resource-limits/kustomization.yaml
+++ b/kube/overlays/stable-with-resource-limits/kustomization.yaml
@@ -8,17 +8,17 @@ bases:
 
 images:
   - name: airbyte/db
-    newTag: 0.36.11-alpha
+    newTag: 0.37.0-alpha
   - name: airbyte/bootloader
-    newTag: 0.36.11-alpha
+    newTag: 0.37.0-alpha
   - name: airbyte/scheduler
-    newTag: 0.36.11-alpha
+    newTag: 0.37.0-alpha
   - name: airbyte/server
-    newTag: 0.36.11-alpha
+    newTag: 0.37.0-alpha
   - name: airbyte/webapp
-    newTag: 0.36.11-alpha
+    newTag: 0.37.0-alpha
   - name: airbyte/worker
-    newTag: 0.36.11-alpha
+    newTag: 0.37.0-alpha
   - name: temporalio/auto-setup
     newTag: 1.7.0
 

--- a/kube/overlays/stable/.env
+++ b/kube/overlays/stable/.env
@@ -1,4 +1,4 @@
-AIRBYTE_VERSION=0.36.11-alpha
+AIRBYTE_VERSION=0.37.0-alpha
 
 # Airbyte Internal Database, see https://docs.airbyte.io/operator-guides/configuring-airbyte-db
 DATABASE_HOST=airbyte-db-svc

--- a/kube/overlays/stable/kustomization.yaml
+++ b/kube/overlays/stable/kustomization.yaml
@@ -8,17 +8,17 @@ bases:
 
 images:
   - name: airbyte/db
-    newTag: 0.36.11-alpha
+    newTag: 0.37.0-alpha
   - name: airbyte/bootloader
-    newTag: 0.36.11-alpha
+    newTag: 0.37.0-alpha
   - name: airbyte/scheduler
-    newTag: 0.36.11-alpha
+    newTag: 0.37.0-alpha
   - name: airbyte/server
-    newTag: 0.36.11-alpha
+    newTag: 0.37.0-alpha
   - name: airbyte/webapp
-    newTag: 0.36.11-alpha
+    newTag: 0.37.0-alpha
   - name: airbyte/worker
-    newTag: 0.36.11-alpha
+    newTag: 0.37.0-alpha
   - name: temporalio/auto-setup
     newTag: 1.7.0
 

--- a/octavia-cli/Dockerfile
+++ b/octavia-cli/Dockerfile
@@ -14,5 +14,5 @@ USER octavia-cli
 WORKDIR /home/octavia-project
 ENTRYPOINT ["octavia"]
 
-LABEL io.airbyte.version=0.36.11-alpha
+LABEL io.airbyte.version=0.37.0-alpha
 LABEL io.airbyte.name=airbyte/octavia-cli

--- a/octavia-cli/README.md
+++ b/octavia-cli/README.md
@@ -105,7 +105,7 @@ This script:
 ```bash
 touch ~/.octavia # Create a file to store env variables that will be mapped the octavia-cli container
 mkdir my_octavia_project_directory # Create your octavia project directory where YAML configurations will be stored.
-docker run --name octavia-cli -i --rm -v my_octavia_project_directory:/home/octavia-project --network host --user $(id -u):$(id -g) --env-file ~/.octavia airbyte/octavia-cli:0.36.11-alpha
+docker run --name octavia-cli -i --rm -v my_octavia_project_directory:/home/octavia-project --network host --user $(id -u):$(id -g) --env-file ~/.octavia airbyte/octavia-cli:0.37.0-alpha
 ```
 
 ### Using `docker-compose`

--- a/octavia-cli/install.sh
+++ b/octavia-cli/install.sh
@@ -3,7 +3,7 @@
 # This install scripts currently only works for ZSH and Bash profiles.
 # It creates an octavia alias in your profile bound to a docker run command and your current user.
 
-VERSION=0.36.11-alpha
+VERSION=0.37.0-alpha
 OCTAVIA_ENV_FILE=${HOME}/.octavia
 
 detect_profile() {

--- a/octavia-cli/setup.py
+++ b/octavia-cli/setup.py
@@ -15,7 +15,7 @@ README = (HERE / "README.md").read_text()
 
 setup(
     name="octavia-cli",
-    version="0.36.11",
+    version="0.37.0",
     description="A command line interface to manage Airbyte configurations",
     long_description=README,
     author="Airbyte",


### PR DESCRIPTION
*IMPORTANT: Only merge if the platform build is passing!*

Changelog:

b480440e2 Clean up (#12682)
455decc01 Migrate to a secret store by default (#12516)
0291d62df explicitly close socat socket (#12632)
60cbf0d0d Add timeout to publish-image task (#12679)
07068b0fe 🐙 octavia-cli: use model serialization (#12133)
28355db81 print notice logs for socat (#12638)
ce1774b87 Dynamically set y-axis label width for credits chart (#12625)
6ed9dcca0 Source Amplitude: set releaseStage to beta (#12659)
66d760955 Fix typo in spec.json for destination AWS Datalake & fix python license plugin setup (#11811)
6eacd183b update smartsheets release stage to beta (#12646)

Steps After Merging PR:
1. Pull most recent version of master
2. Run ./tools/bin/tag_version.sh
3. Create a GitHub release with the changelog