### PR TITLE
🎉  New source: Babelforce

### DIFF
--- a/airbyte-config/init/src/main/resources/seed/source_definitions.yaml
+++ b/airbyte-config/init/src/main/resources/seed/source_definitions.yaml
@@ -143,6 +143,14 @@
   icon: azureblobstorage.svg
   sourceType: database
   releaseStage: alpha
+- name: Babelforce
+  sourceDefinitionId: 971c3e1e-78a5-411e-ad56-c4052b50876b
+  dockerRepository: airbyte/source-babelforce
+  dockerImageTag: 0.1.0
+  documentationUrl: https://docs.airbyte.com/integrations/sources/babelforce
+  icon: bamboohr.svg
+  sourceType: api
+  releaseStage: alpha
 - name: BambooHR
   sourceDefinitionId: 90916976-a132-4ce9-8bce-82a03dd58788
   dockerRepository: airbyte/source-bamboo-hr

--- a/airbyte-config/init/src/main/resources/seed/source_definitions.yaml
+++ b/airbyte-config/init/src/main/resources/seed/source_definitions.yaml
@@ -148,7 +148,6 @@
   dockerRepository: airbyte/source-babelforce
   dockerImageTag: 0.1.0
   documentationUrl: https://docs.airbyte.com/integrations/sources/babelforce
-  icon: bamboohr.svg
   sourceType: api
   releaseStage: alpha
 - name: BambooHR

--- a/airbyte-config/init/src/main/resources/seed/source_specs.yaml
+++ b/airbyte-config/init/src/main/resources/seed/source_specs.yaml
@@ -1607,6 +1607,60 @@
     supportsNormalization: false
     supportsDBT: false
     supported_destination_sync_modes: []
+- dockerImage: "airbyte/source-babelforce:0.1.0"
+  spec:
+    documentationUrl: "https://docsurl.com"
+    connectionSpecification:
+      $schema: "http://json-schema.org/draft-07/schema#"
+      title: "Babelforce Spec"
+      type: "object"
+      required:
+      - "region"
+      - "access_key_id"
+      - "access_token"
+      additionalProperties: false
+      properties:
+        region:
+          type: "string"
+          title: "Region"
+          default: "services"
+          description: "Babelforce region"
+          enum:
+          - "services"
+          - "us-east"
+          - "ap-southeast"
+          order: 1
+        access_key_id:
+          type: "string"
+          title: "Access Key ID"
+          description: "The Babelforce access key ID"
+          airbyte_secret: true
+          order: 2
+        access_token:
+          type: "string"
+          title: "Access Token"
+          description: "The Babelforce access token"
+          airbyte_secret: true
+          order: 3
+        date_created_from:
+          type: "integer"
+          title: "Date Created from"
+          description: "Timestamp in Unix the replication from Babelforce API will\
+            \ start from. For example 1651363200 which corresponds to 2022-05-01 00:00:00."
+          examples:
+          - 1651363200
+          order: 4
+        date_created_to:
+          type: "integer"
+          title: "Date Created to"
+          description: "Timestamp in Unix the replication from Babelforce will be\
+            \ up to. For example 1651363200 which corresponds to 2022-05-01 00:00:00."
+          examples:
+          - 1651363200
+          order: 5
+    supportsNormalization: false
+    supportsDBT: false
+    supported_destination_sync_modes: []
 - dockerImage: "airbyte/source-bamboo-hr:0.2.2"
   spec:
     documentationUrl: "https://docs.airbyte.com/integrations/sources/bamboo-hr"

--- a/airbyte-integrations/connectors/source-babelforce/.dockerignore
+++ b/airbyte-integrations/connectors/source-babelforce/.dockerignore
@@ -1,0 +1,6 @@
+*
+!Dockerfile
+!main.py
+!source_babelforce
+!setup.py
+!secrets

--- a/airbyte-integrations/connectors/source-babelforce/.python-version
+++ b/airbyte-integrations/connectors/source-babelforce/.python-version
@@ -1,1 +1,0 @@
-3.9.7/envs/source-babelforce

--- a/airbyte-integrations/connectors/source-babelforce/.python-version
+++ b/airbyte-integrations/connectors/source-babelforce/.python-version
@@ -1,0 +1,1 @@
+3.9.7/envs/source-babelforce

--- a/airbyte-integrations/connectors/source-babelforce/Dockerfile
+++ b/airbyte-integrations/connectors/source-babelforce/Dockerfile
@@ -34,5 +34,5 @@ COPY source_babelforce ./source_babelforce
 ENV AIRBYTE_ENTRYPOINT "python /airbyte/integration_code/main.py"
 ENTRYPOINT ["python", "/airbyte/integration_code/main.py"]
 
-LABEL io.airbyte.version=0.1.7
+LABEL io.airbyte.version=0.1.0
 LABEL io.airbyte.name=airbyte/source-babelforce

--- a/airbyte-integrations/connectors/source-babelforce/Dockerfile
+++ b/airbyte-integrations/connectors/source-babelforce/Dockerfile
@@ -1,0 +1,38 @@
+FROM python:3.9.11-alpine3.15 as base
+
+# build and load all requirements
+FROM base as builder
+WORKDIR /airbyte/integration_code
+
+# upgrade pip to the latest version
+RUN apk --no-cache upgrade \
+    && pip install --upgrade pip \
+    && apk --no-cache add tzdata build-base
+
+
+COPY setup.py ./
+# install necessary packages to a temporary folder
+RUN pip install --prefix=/install .
+
+# build a clean environment
+FROM base
+WORKDIR /airbyte/integration_code
+
+# copy all loaded and built libraries to a pure basic image
+COPY --from=builder /install /usr/local
+# add default timezone settings
+COPY --from=builder /usr/share/zoneinfo/Etc/UTC /etc/localtime
+RUN echo "Etc/UTC" > /etc/timezone
+
+# bash is installed for more convenient debugging.
+RUN apk --no-cache add bash
+
+# copy payload code only
+COPY main.py ./
+COPY source_babelforce ./source_babelforce
+
+ENV AIRBYTE_ENTRYPOINT "python /airbyte/integration_code/main.py"
+ENTRYPOINT ["python", "/airbyte/integration_code/main.py"]
+
+LABEL io.airbyte.version=0.1.7
+LABEL io.airbyte.name=airbyte/source-babelforce

--- a/airbyte-integrations/connectors/source-babelforce/README.md
+++ b/airbyte-integrations/connectors/source-babelforce/README.md
@@ -1,0 +1,132 @@
+# Babelforce Source
+
+This is the repository for the Babelforce source connector, written in Python.
+For information about how to use this connector within Airbyte, see [the documentation](https://docs.airbyte.io/integrations/sources/babelforce).
+
+## Local development
+
+### Prerequisites
+**To iterate on this connector, make sure to complete this prerequisites section.**
+
+#### Minimum Python version required `= 3.7.0`
+
+#### Build & Activate Virtual Environment and install dependencies
+From this connector directory, create a virtual environment:
+```
+python -m venv .venv
+```
+
+This will generate a virtualenv for this module in `.venv/`. Make sure this venv is active in your
+development environment of choice. To activate it from the terminal, run:
+```
+source .venv/bin/activate
+pip install -r requirements.txt
+pip install '.[tests]'
+```
+If you are in an IDE, follow your IDE's instructions to activate the virtualenv.
+
+Note that while we are installing dependencies from `requirements.txt`, you should only edit `setup.py` for your dependencies. `requirements.txt` is
+used for editable installs (`pip install -e`) to pull in Python dependencies from the monorepo and will call `setup.py`.
+If this is mumbo jumbo to you, don't worry about it, just put your deps in `setup.py` but install using `pip install -r requirements.txt` and everything
+should work as you expect.
+
+#### Building via Gradle
+You can also build the connector in Gradle. This is typically used in CI and not needed for your development workflow.
+
+To build using Gradle, from the Airbyte repository root, run:
+```
+./gradlew :airbyte-integrations:connectors:source-babelforce:build
+```
+
+#### Create credentials
+**If you are a community contributor**, follow the instructions in the [documentation](https://docs.airbyte.io/integrations/sources/babelforce)
+to generate the necessary credentials. Then create a file `secrets/config.json` conforming to the `source_babelforce/spec.json` file.
+Note that any directory named `secrets` is gitignored across the entire Airbyte repo, so there is no danger of accidentally checking in sensitive information.
+See `integration_tests/sample_config.json` for a sample config file.
+
+**If you are an Airbyte core member**, copy the credentials in Lastpass under the secret name `source babelforce test creds`
+and place them into `secrets/config.json`.
+
+### Locally running the connector
+```
+python main.py spec
+python main.py check --config secrets/config.json
+python main.py discover --config secrets/config.json
+python main.py read --config secrets/config.json --catalog integration_tests/configured_catalog.json
+```
+
+### Locally running the connector docker image
+
+#### Build
+First, make sure you build the latest Docker image:
+```
+docker build . -t airbyte/source-babelforce:dev
+```
+
+You can also build the connector image via Gradle:
+```
+./gradlew :airbyte-integrations:connectors:source-babelforce:airbyteDocker
+```
+When building via Gradle, the docker image name and tag, respectively, are the values of the `io.airbyte.name` and `io.airbyte.version` `LABEL`s in
+the Dockerfile.
+
+#### Run
+Then run any of the connector commands as follows:
+```
+docker run --rm airbyte/source-babelforce:dev spec
+docker run --rm -v $(pwd)/secrets:/secrets airbyte/source-babelforce:dev check --config /secrets/config.json
+docker run --rm -v $(pwd)/secrets:/secrets airbyte/source-babelforce:dev discover --config /secrets/config.json
+docker run --rm -v $(pwd)/secrets:/secrets -v $(pwd)/integration_tests:/integration_tests airbyte/source-babelforce:dev read --config /secrets/config.json --catalog /integration_tests/configured_catalog.json
+```
+## Testing
+Make sure to familiarize yourself with [pytest test discovery](https://docs.pytest.org/en/latest/goodpractices.html#test-discovery) to know how your test files and methods should be named.
+First install test dependencies into your virtual environment:
+```
+pip install .[tests]
+```
+### Unit Tests
+To run unit tests locally, from the connector directory run:
+```
+python -m pytest unit_tests
+```
+
+### Integration Tests
+There are two types of integration tests: Acceptance Tests (Airbyte's test suite for all source connectors) and custom integration tests (which are specific to this connector).
+#### Custom Integration tests
+Place custom tests inside `integration_tests/` folder, then, from the connector root, run
+```
+python -m pytest integration_tests
+```
+#### Acceptance Tests
+Customize `acceptance-test-config.yml` file to configure tests. See [Source Acceptance Tests](https://docs.airbyte.io/connector-development/testing-connectors/source-acceptance-tests-reference) for more information.
+If your connector requires to create or destroy resources for use during acceptance tests create fixtures for it and place them inside integration_tests/acceptance.py.
+To run your integration tests with acceptance tests, from the connector root, run
+```
+python -m pytest integration_tests -p integration_tests.acceptance
+```
+To run your integration tests with docker
+
+### Using gradle to run tests
+All commands should be run from airbyte project root.
+To run unit tests:
+```
+./gradlew :airbyte-integrations:connectors:source-babelforce:unitTest
+```
+To run acceptance and custom integration tests:
+```
+./gradlew :airbyte-integrations:connectors:source-babelforce:integrationTest
+```
+
+## Dependency Management
+All of your dependencies should go in `setup.py`, NOT `requirements.txt`. The requirements file is only used to connect internal Airbyte dependencies in the monorepo for local development.
+We split dependencies between two groups, dependencies that are:
+* required for your connector to work need to go to `MAIN_REQUIREMENTS` list.
+* required for the testing need to go to `TEST_REQUIREMENTS` list
+
+### Publishing a new version of the connector
+You've checked out the repo, implemented a million dollar feature, and you're ready to share your changes with the world. Now what?
+1. Make sure your changes are passing unit and integration tests.
+1. Bump the connector version in `Dockerfile` -- just increment the value of the `LABEL io.airbyte.version` appropriately (we use [SemVer](https://semver.org/)).
+1. Create a Pull Request.
+1. Pat yourself on the back for being an awesome contributor.
+1. Someone from Airbyte will take a look at your PR and iterate with you to merge it into master.

--- a/airbyte-integrations/connectors/source-babelforce/acceptance-test-config.yml
+++ b/airbyte-integrations/connectors/source-babelforce/acceptance-test-config.yml
@@ -1,0 +1,23 @@
+# See [Source Acceptance Tests](https://docs.airbyte.io/connector-development/testing-connectors/source-acceptance-tests-reference)
+# for more information about how to configure these tests
+connector_image: airbyte/source-babelforce:dev
+tests:
+  spec:
+    - spec_path: "source_babelforce/spec.json"
+  connection:
+    - config_path: "secrets/config.json"
+      status: "succeed"
+    - config_path: "integration_tests/invalid_config.json"
+      status: "failed"
+  discovery:
+    - config_path: "secrets/config.json"
+  basic_read:
+    - config_path: "secrets/config.json"
+      configured_catalog_path: "integration_tests/configured_catalog.json"
+      empty_streams: []
+  incremental:
+    - config_path: "secrets/config.json"
+      configured_catalog_path: "integration_tests/configured_catalog.json"
+  full_refresh:
+    - config_path: "secrets/config.json"
+      configured_catalog_path: "integration_tests/configured_catalog.json"

--- a/airbyte-integrations/connectors/source-babelforce/acceptance-test-docker.sh
+++ b/airbyte-integrations/connectors/source-babelforce/acceptance-test-docker.sh
@@ -1,0 +1,16 @@
+#!/usr/bin/env sh
+
+# Build latest connector image
+docker build . -t $(cat acceptance-test-config.yml | grep "connector_image" | head -n 1 | cut -d: -f2-)
+
+# Pull latest acctest image
+docker pull airbyte/source-acceptance-test:latest
+
+# Run
+docker run --rm -it \
+    -v /var/run/docker.sock:/var/run/docker.sock \
+    -v /tmp:/tmp \
+    -v $(pwd):/test_input \
+    airbyte/source-acceptance-test \
+    --acceptance-test-config /test_input
+

--- a/airbyte-integrations/connectors/source-babelforce/build.gradle
+++ b/airbyte-integrations/connectors/source-babelforce/build.gradle
@@ -1,0 +1,9 @@
+plugins {
+    id 'airbyte-python'
+    id 'airbyte-docker'
+    id 'airbyte-source-acceptance-test'
+}
+
+airbytePython {
+    moduleDirectory 'source_babelforce'
+}

--- a/airbyte-integrations/connectors/source-babelforce/integration_tests/__init__.py
+++ b/airbyte-integrations/connectors/source-babelforce/integration_tests/__init__.py
@@ -1,0 +1,3 @@
+#
+# Copyright (c) 2021 Airbyte, Inc., all rights reserved.
+#

--- a/airbyte-integrations/connectors/source-babelforce/integration_tests/acceptance.py
+++ b/airbyte-integrations/connectors/source-babelforce/integration_tests/acceptance.py
@@ -1,5 +1,5 @@
 #
-# Copyright (c) 2021 Airbyte, Inc., all rights reserved.
+# Copyright (c) 2022 Airbyte, Inc., all rights reserved.
 #
 
 

--- a/airbyte-integrations/connectors/source-babelforce/integration_tests/acceptance.py
+++ b/airbyte-integrations/connectors/source-babelforce/integration_tests/acceptance.py
@@ -1,0 +1,13 @@
+#
+# Copyright (c) 2021 Airbyte, Inc., all rights reserved.
+#
+
+
+import pytest
+
+pytest_plugins = ("source_acceptance_test.plugin",)
+
+
+@pytest.fixture(scope="session", autouse=True)
+def connector_setup():
+    yield

--- a/airbyte-integrations/connectors/source-babelforce/integration_tests/configured_catalog.json
+++ b/airbyte-integrations/connectors/source-babelforce/integration_tests/configured_catalog.json
@@ -1,0 +1,16 @@
+{
+  "streams": [
+    {
+      "stream": {
+        "name": "calls",
+        "supported_sync_modes": ["full_refresh", "incremental"],
+        "source_defined_cursor": true,
+        "default_cursor_field": ["dateCreated"],
+        "source_defined_primary_key": [["id"]],
+        "json_schema": {}
+      },
+      "sync_mode": "incremental",
+      "destination_sync_mode": "overwrite"
+    }
+  ]
+}

--- a/airbyte-integrations/connectors/source-babelforce/integration_tests/invalid_config.json
+++ b/airbyte-integrations/connectors/source-babelforce/integration_tests/invalid_config.json
@@ -1,0 +1,5 @@
+{
+  "region": "services",
+  "access_key_id": "wrong",
+  "access_token": "wrong"
+}

--- a/airbyte-integrations/connectors/source-babelforce/main.py
+++ b/airbyte-integrations/connectors/source-babelforce/main.py
@@ -1,5 +1,5 @@
 #
-# Copyright (c) 2021 Airbyte, Inc., all rights reserved.
+# Copyright (c) 2022 Airbyte, Inc., all rights reserved.
 #
 
 

--- a/airbyte-integrations/connectors/source-babelforce/main.py
+++ b/airbyte-integrations/connectors/source-babelforce/main.py
@@ -1,0 +1,13 @@
+#
+# Copyright (c) 2021 Airbyte, Inc., all rights reserved.
+#
+
+
+import sys
+
+from airbyte_cdk.entrypoint import launch
+from source_babelforce import SourceBabelforce
+
+if __name__ == "__main__":
+    source = SourceBabelforce()
+    launch(source, sys.argv[1:])

--- a/airbyte-integrations/connectors/source-babelforce/requirements.txt
+++ b/airbyte-integrations/connectors/source-babelforce/requirements.txt
@@ -1,0 +1,2 @@
+-e ../../bases/source-acceptance-test
+-e .

--- a/airbyte-integrations/connectors/source-babelforce/setup.py
+++ b/airbyte-integrations/connectors/source-babelforce/setup.py
@@ -1,5 +1,5 @@
 #
-# Copyright (c) 2021 Airbyte, Inc., all rights reserved.
+# Copyright (c) 2022 Airbyte, Inc., all rights reserved.
 #
 
 

--- a/airbyte-integrations/connectors/source-babelforce/setup.py
+++ b/airbyte-integrations/connectors/source-babelforce/setup.py
@@ -1,0 +1,27 @@
+#
+# Copyright (c) 2021 Airbyte, Inc., all rights reserved.
+#
+
+
+from setuptools import find_packages, setup
+
+MAIN_REQUIREMENTS = ["airbyte-cdk~=0.1", "python-dateutil==2.8.2"]
+
+TEST_REQUIREMENTS = [
+    "pytest~=6.1",
+    "pytest-mock~=3.6.1",
+    "source-acceptance-test",
+]
+
+setup(
+    name="source_babelforce",
+    description="Source implementation for Babelforce.",
+    author="Airbyte",
+    author_email="contact@airbyte.io",
+    packages=find_packages(),
+    install_requires=MAIN_REQUIREMENTS,
+    package_data={"": ["*.json", "schemas/*.json", "schemas/shared/*.json"]},
+    extras_require={
+        "tests": TEST_REQUIREMENTS,
+    },
+)

--- a/airbyte-integrations/connectors/source-babelforce/source_babelforce/__init__.py
+++ b/airbyte-integrations/connectors/source-babelforce/source_babelforce/__init__.py
@@ -1,0 +1,8 @@
+#
+# Copyright (c) 2021 Airbyte, Inc., all rights reserved.
+#
+
+
+from .source import SourceBabelforce
+
+__all__ = ["SourceBabelforce"]

--- a/airbyte-integrations/connectors/source-babelforce/source_babelforce/schemas/calls.json
+++ b/airbyte-integrations/connectors/source-babelforce/source_babelforce/schemas/calls.json
@@ -3,32 +3,26 @@
   "type": "object",
   "properties": {
     "id": {
-       "title": "id",
        "maxLength": 32,
        "type": "string"
     },
     "parentId": {
-      "title": "parentId",
       "maxLength": 32,
        "type": ["string", "null"]
     },
     "sessionId": {
-      "title": "sessionId",
       "maxLength": 32,
       "type": "string"
     },
     "conversationId": {
-      "title": "conversationId",
       "maxLength": 32,
       "type": "string"
     },
     "dateCreated": {
-      "title": "dateCreated",
       "type": "string",
       "format": "date-time"
     },
     "dateEstablished": {
-      "title": "dateEstablished",
       "format": "date-time",
       "type": [
         "string",
@@ -36,7 +30,6 @@
       ]
     },
     "dateFinished": {
-      "title": "dateFinished",
       "format": "date-time",
       "type": [
         "string",
@@ -44,132 +37,108 @@
       ]
     },
     "lastUpdated": {
-      "title": "lastUpdated",
       "type": "string",
       "format": "date-time"
     },
     "state": {
-      "title": "state",
       "maxLength": 256,
       "type": "string"
     },
     "finishReason": {
-      "title": "finishReason",
       "maxLength": 256,
       "type": "string"
     },
     "from": {
-      "title": "from",
       "type": [
         "string",
         "null"
       ]
     },
     "to": {
-      "title": "to",
       "type": [
         "string",
         "null"
       ]
     },
     "type": {
-      "title": "type",
       "maxLength": 256,
       "type": "string"
     },
     "source": {
-      "title": "source",
       "maxLength": 256,
       "type": "string"
     },
     "domain": {
-      "title": "domain",
       "maxLength": 256,
       "type": "string"
     },
     "duration": {
-      "title": "duration",
       "type": [
         "integer",
         "null"
       ]
     },
     "anonymous": {
-      "title": "anonymous",
       "type": [
         "boolean",
         "null"
       ]
     },
     "recordings": {
-      "title": "Recordings",
       "type": ["array", "null"],
       "items": {
-        "title": "CallRecording",
         "type": "object",
         "properties": {
            "id": {
-              "title": "id",
               "maxLength": 32,
               "type": "string"
            },
            "dateCreated": {
-              "title": "dateCreated",
               "type": "string",
               "format": "date-time"
            },
            "lastUpdated": {
-              "title": "lastUpdated",
               "type": "string",
               "format": "date-time"
            },
            "duration": {
-              "title": "duration",
               "type": "integer"
            },
            "url": {
-              "title": "url",
               "type": "string"
            },
            "tags": {
-              "title": "tags",
               "type": "array",
               "items": {
                  "type": "string"
               }
            },
            "file": {
-              "title": "file",
               "type": ["object", "null"],
               "properties": {
                  "id": {
-                    "title": "id",
                     "maxLength": 32,
                     "type": "string"
                  },
                  "state": {
-                    "title": "state",
                     "type": [
                        "string",
                        "null"
                     ]
                  },
                  "name": {
-                    "title": "name",
                     "type": [
                        "string",
                        "null"
                     ]
                  },
                  "size": {
-                    "title": "size",
                     "type": [
                        "integer",
                        "null"
                     ]
                  },
                  "contentType": {
-                    "title": "contentType",
                     "type": [
                        "string",
                        "null"
@@ -178,30 +147,25 @@
               }
            },
            "state": {
-              "title": "state",
               "maxLength": 256,
               "type": "string"
            },
            "agent": {
-              "title": "agent",
               "type": "object",
               "properties": {
                  "id": {
-                    "title": "id",
                     "type": [
                        "string",
                        "null"
                     ]
                  },
                  "name": {
-                    "title": "name",
                     "type": [
                        "string",
                        "null"
                     ]
                  },
                  "number": {
-                    "title": "number",
                     "type": [
                        "string",
                        "null"
@@ -213,25 +177,21 @@
       }
     },
     "bridged": {
-      "title": "bridged",
       "type": ["object", "null"],
       "properties": {
         "id": {
-          "title": "id",
           "type": [
              "string",
              "null"
           ]
         },
         "name": {
-          "title": "name",
           "type": [
              "string",
              "null"
           ]
         },
         "number": {
-          "title": "number",
           "type": [
              "string",
              "null"

--- a/airbyte-integrations/connectors/source-babelforce/source_babelforce/schemas/calls.json
+++ b/airbyte-integrations/connectors/source-babelforce/source_babelforce/schemas/calls.json
@@ -1,0 +1,243 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "type": "object",
+  "properties": {
+    "id": {
+       "title": "id",
+       "maxLength": 32,
+       "type": "string"
+    },
+    "parentId": {
+      "title": "parentId",
+      "maxLength": 32,
+       "type": ["string", "null"]
+    },
+    "sessionId": {
+      "title": "sessionId",
+      "maxLength": 32,
+      "type": "string"
+    },
+    "conversationId": {
+      "title": "conversationId",
+      "maxLength": 32,
+      "type": "string"
+    },
+    "dateCreated": {
+      "title": "dateCreated",
+      "type": "string",
+      "format": "date-time"
+    },
+    "dateEstablished": {
+      "title": "dateEstablished",
+      "format": "date-time",
+      "type": [
+        "string",
+        "null"
+      ]
+    },
+    "dateFinished": {
+      "title": "dateFinished",
+      "format": "date-time",
+      "type": [
+        "string",
+        "null"
+      ]
+    },
+    "lastUpdated": {
+      "title": "lastUpdated",
+      "type": "string",
+      "format": "date-time"
+    },
+    "state": {
+      "title": "state",
+      "maxLength": 256,
+      "type": "string"
+    },
+    "finishReason": {
+      "title": "finishReason",
+      "maxLength": 256,
+      "type": "string"
+    },
+    "from": {
+      "title": "from",
+      "type": [
+        "string",
+        "null"
+      ]
+    },
+    "to": {
+      "title": "to",
+      "type": [
+        "string",
+        "null"
+      ]
+    },
+    "type": {
+      "title": "type",
+      "maxLength": 256,
+      "type": "string"
+    },
+    "source": {
+      "title": "source",
+      "maxLength": 256,
+      "type": "string"
+    },
+    "domain": {
+      "title": "domain",
+      "maxLength": 256,
+      "type": "string"
+    },
+    "duration": {
+      "title": "duration",
+      "type": [
+        "integer",
+        "null"
+      ]
+    },
+    "anonymous": {
+      "title": "anonymous",
+      "type": [
+        "boolean",
+        "null"
+      ]
+    },
+    "recordings": {
+      "title": "Recordings",
+      "type": ["array", "null"],
+      "items": {
+        "title": "CallRecording",
+        "type": "object",
+        "properties": {
+           "id": {
+              "title": "id",
+              "maxLength": 32,
+              "type": "string"
+           },
+           "dateCreated": {
+              "title": "dateCreated",
+              "type": "string",
+              "format": "date-time"
+           },
+           "lastUpdated": {
+              "title": "lastUpdated",
+              "type": "string",
+              "format": "date-time"
+           },
+           "duration": {
+              "title": "duration",
+              "type": "integer"
+           },
+           "url": {
+              "title": "url",
+              "type": "string"
+           },
+           "tags": {
+              "title": "tags",
+              "type": "array",
+              "items": {
+                 "type": "string"
+              }
+           },
+           "file": {
+              "title": "file",
+              "type": ["object", "null"],
+              "properties": {
+                 "id": {
+                    "title": "id",
+                    "maxLength": 32,
+                    "type": "string"
+                 },
+                 "state": {
+                    "title": "state",
+                    "type": [
+                       "string",
+                       "null"
+                    ]
+                 },
+                 "name": {
+                    "title": "name",
+                    "type": [
+                       "string",
+                       "null"
+                    ]
+                 },
+                 "size": {
+                    "title": "size",
+                    "type": [
+                       "integer",
+                       "null"
+                    ]
+                 },
+                 "contentType": {
+                    "title": "contentType",
+                    "type": [
+                       "string",
+                       "null"
+                    ]
+                 }
+              }
+           },
+           "state": {
+              "title": "state",
+              "maxLength": 256,
+              "type": "string"
+           },
+           "agent": {
+              "title": "agent",
+              "type": "object",
+              "properties": {
+                 "id": {
+                    "title": "id",
+                    "type": [
+                       "string",
+                       "null"
+                    ]
+                 },
+                 "name": {
+                    "title": "name",
+                    "type": [
+                       "string",
+                       "null"
+                    ]
+                 },
+                 "number": {
+                    "title": "number",
+                    "type": [
+                       "string",
+                       "null"
+                    ]
+                 }
+              }
+           }
+        }
+      }
+    },
+    "bridged": {
+      "title": "bridged",
+      "type": ["object", "null"],
+      "properties": {
+        "id": {
+          "title": "id",
+          "type": [
+             "string",
+             "null"
+          ]
+        },
+        "name": {
+          "title": "name",
+          "type": [
+             "string",
+             "null"
+          ]
+        },
+        "number": {
+          "title": "number",
+          "type": [
+             "string",
+             "null"
+          ]
+        }
+      }
+    }
+  }
+}

--- a/airbyte-integrations/connectors/source-babelforce/source_babelforce/source.py
+++ b/airbyte-integrations/connectors/source-babelforce/source_babelforce/source.py
@@ -37,13 +37,6 @@ class BabelforceStream(HttpStream, ABC):
 
     def next_page_token(self, response: requests.Response) -> Optional[Mapping[str, Any]]:
         """
-        This method should return a Mapping (e.g: dict) containing whatever information required to make paginated requests. This dict is passed
-        to most other methods in this class to help you form headers, request bodies, query params, etc..
-
-        For example, if the API accepts a 'page' parameter to determine which page of the result to return, and a response from the API contains a
-        'page' number, then this method should probably return a dict {'page': response.json()['page'] + 1} to increment the page count by 1.
-        The request_params method should then read the input next_page_token and set the 'page' param to next_page_token['page'].
-
         :param response: the most recent response from the API
         :return If there is another page in the result, a mapping (e.g: dict) containing information needed to query the next page in the response.
                 If there are no more pages in the result, return None.

--- a/airbyte-integrations/connectors/source-babelforce/source_babelforce/source.py
+++ b/airbyte-integrations/connectors/source-babelforce/source_babelforce/source.py
@@ -118,11 +118,10 @@ class Calls(IncrementalBabelforceStream):
         return params
 
 
-# Source
 class SourceBabelforce(AbstractSource):
     def check_connection(self, logger, config) -> Tuple[bool, any]:
         try:
-            authenticator = self.authenticator(access_key_id=config.get("access_key_id"), access_token=config.get("access_token"))
+            authenticator = BabelforceAuthenticator(access_key_id=config.get("access_key_id"), access_token=config.get("access_token"))
             calls = Calls(region=config.get("region"), authenticator=authenticator)
 
             test_url = f"{calls.url_base}{calls.path()}?max=1"
@@ -140,12 +139,8 @@ class SourceBabelforce(AbstractSource):
         date_created_to = config.get("date_created_to")
         region = config.get("region")
 
-        auth = self.authenticator(access_key_id=config.get("access_key_id"), access_token=config.get("access_token"))
+        auth = BabelforceAuthenticator(access_key_id=config.get("access_key_id"), access_token=config.get("access_token"))
         return [Calls(authenticator=auth, region=region, date_created_from=date_created_from, date_created_to=date_created_to)]
-
-    @staticmethod
-    def authenticator(access_key_id: str, access_token: str) -> HttpAuthenticator:
-        return BabelforceAuthenticator(access_key_id=access_key_id, access_token=access_token)
 
 
 class BabelforceAuthenticator(HttpAuthenticator):

--- a/airbyte-integrations/connectors/source-babelforce/source_babelforce/source.py
+++ b/airbyte-integrations/connectors/source-babelforce/source_babelforce/source.py
@@ -1,0 +1,157 @@
+#
+# Copyright (c) 2021 Airbyte, Inc., all rights reserved.
+#
+import operator
+from abc import ABC
+from datetime import datetime
+from time import mktime
+from typing import Any, Iterable, List, Mapping, MutableMapping, Optional, Tuple
+
+import requests
+from airbyte_cdk.sources import AbstractSource
+from airbyte_cdk.sources.streams import Stream
+from airbyte_cdk.sources.streams.http import HttpStream
+from airbyte_cdk.sources.streams.http.auth import HttpAuthenticator
+from dateutil import parser
+from dateutil.tz import tzutc
+
+DEFAULT_CURSOR = "dateCreated"
+
+
+# Basic full refresh stream
+class BabelforceStream(HttpStream, ABC):
+    page_size = 100
+
+    def __init__(self, region: str, **args):
+        super().__init__(**args)
+
+        self.region = region
+
+    @property
+    def url_base(self) -> str:
+        return f"https://{self.region}.babelforce.com/api/v2/"
+
+    def next_page_token(self, response: requests.Response) -> Optional[Mapping[str, Any]]:
+        """
+        This method should return a Mapping (e.g: dict) containing whatever information required to make paginated requests. This dict is passed
+        to most other methods in this class to help you form headers, request bodies, query params, etc..
+
+        For example, if the API accepts a 'page' parameter to determine which page of the result to return, and a response from the API contains a
+        'page' number, then this method should probably return a dict {'page': response.json()['page'] + 1} to increment the page count by 1.
+        The request_params method should then read the input next_page_token and set the 'page' param to next_page_token['page'].
+
+        :param response: the most recent response from the API
+        :return If there is another page in the result, a mapping (e.g: dict) containing information needed to query the next page in the response.
+                If there are no more pages in the result, return None.
+        """
+        pagination = response.json().get("pagination")
+
+        if pagination.get("current"):
+            return {"page": response.json().get("pagination").get("current") + 1}
+        else:
+            return None
+
+    def parse_response(self, response: requests.Response, **kwargs) -> Iterable[Mapping]:
+        """
+        :return an iterable containing each record in the response
+        """
+        # Babelforce calls are sorted in reverse order. To process the calls in ascending order an
+        # in-memory sort is performed
+        items = response.json().get("items")
+        items.sort(key=operator.itemgetter("dateCreated"))
+        keys = self.get_json_schema().get("properties").keys()
+
+        for item in items:
+            yield {key: val for key, val in item.items() if key in keys}
+
+
+# Basic incremental stream
+class IncrementalBabelforceStream(BabelforceStream, ABC):
+    cursor_field = DEFAULT_CURSOR
+
+    def get_updated_state(self, current_stream_state: MutableMapping[str, Any], latest_record: Mapping[str, Any]) -> Mapping[str, Any]:
+        current_updated_at = datetime(1970, 1, 1)
+
+        if current_stream_state:
+            try:
+                current_updated_at = parser.parse(current_stream_state.get(self.cursor_field))
+            except ValueError:
+                pass
+
+        current_updated_at = current_updated_at.replace(tzinfo=tzutc())
+        latest_record_updated_at = parser.parse(latest_record.get(self.cursor_field)).replace(tzinfo=tzutc())
+
+        return {self.cursor_field: max(latest_record_updated_at, current_updated_at).isoformat(timespec="seconds")}
+
+
+class Calls(IncrementalBabelforceStream):
+    primary_key = "id"
+
+    def __init__(self, date_created_from: str = None, date_created_to: str = None, **args):
+        super(Calls, self).__init__(**args)
+
+        self.date_created_from = date_created_from
+        self.date_created_to = date_created_to
+
+    def path(
+            self, stream_state: Mapping[str, Any] = None, stream_slice: Mapping[str, Any] = None, next_page_token: Mapping[str, Any] = None
+    ) -> str:
+        return "calls/reporting"
+
+    def request_params(
+            self, stream_state: Mapping[str, Any], stream_slice: Mapping[str, any] = None, next_page_token: Mapping[str, Any] = None
+    ) -> MutableMapping[str, Any]:
+        page = next_page_token.get("page", 1) if next_page_token else 1
+
+        params = {"page": page, "max": self.page_size}
+
+        if stream_state:
+            cursor_value = parser.parse(stream_state[self.cursor_field])
+            self.date_created_from = int(mktime(cursor_value.timetuple()))
+
+        if self.date_created_from:
+            params.update({"filters.dateCreated.from": self.date_created_from})
+
+        if self.date_created_to:
+            params.update({"filters.dateCreated.to": self.date_created_to})
+
+        return params
+
+
+# Source
+class SourceBabelforce(AbstractSource):
+    def check_connection(self, logger, config) -> Tuple[bool, any]:
+        try:
+            authenticator = self.authenticator(access_key_id=config.get("access_key_id"), access_token=config.get("access_token"))
+            calls = Calls(region=config.get("region"), authenticator=authenticator)
+
+            test_url = f"{calls.url_base}{calls.path()}?max=1"
+            response = requests.request("GET", url=test_url, headers=authenticator.get_auth_header())
+
+            if response.ok:
+                return True, None
+            else:
+                response.raise_for_status()
+        except Exception as exception:
+            return False, exception
+
+    def streams(self, config: Mapping[str, Any]) -> List[Stream]:
+        date_created_from = config.get("date_created_from")
+        date_created_to = config.get("date_created_to")
+        region = config.get("region")
+
+        auth = self.authenticator(access_key_id=config.get("access_key_id"), access_token=config.get("access_token"))
+        return [Calls(authenticator=auth, region=region, date_created_from=date_created_from, date_created_to=date_created_to)]
+
+    @staticmethod
+    def authenticator(access_key_id: str, access_token: str) -> HttpAuthenticator:
+        return BabelforceAuthenticator(access_key_id=access_key_id, access_token=access_token)
+
+
+class BabelforceAuthenticator(HttpAuthenticator):
+    def __init__(self, access_key_id: str, access_token: str):
+        self.access_key_id = access_key_id
+        self.access_token = access_token
+
+    def get_auth_header(self) -> Mapping[str, Any]:
+        return {"X-Auth-Access-ID": self.access_key_id, "X-Auth-Access-Token": self.access_token}

--- a/airbyte-integrations/connectors/source-babelforce/source_babelforce/source.py
+++ b/airbyte-integrations/connectors/source-babelforce/source_babelforce/source.py
@@ -51,7 +51,7 @@ class BabelforceStream(HttpStream, ABC):
         pagination = response.json().get("pagination")
 
         if pagination.get("current"):
-            return {"page": response.json().get("pagination").get("current") + 1}
+            return {"page": pagination.get("current", 0) + 1}
         else:
             return None
 

--- a/airbyte-integrations/connectors/source-babelforce/source_babelforce/source.py
+++ b/airbyte-integrations/connectors/source-babelforce/source_babelforce/source.py
@@ -1,6 +1,7 @@
 #
-# Copyright (c) 2021 Airbyte, Inc., all rights reserved.
+# Copyright (c) 2022 Airbyte, Inc., all rights reserved.
 #
+
 import operator
 from abc import ABC
 from datetime import datetime
@@ -88,12 +89,12 @@ class Calls(IncrementalBabelforceStream):
         self.date_created_to = date_created_to
 
     def path(
-            self, stream_state: Mapping[str, Any] = None, stream_slice: Mapping[str, Any] = None, next_page_token: Mapping[str, Any] = None
+        self, stream_state: Mapping[str, Any] = None, stream_slice: Mapping[str, Any] = None, next_page_token: Mapping[str, Any] = None
     ) -> str:
         return "calls/reporting"
 
     def request_params(
-            self, stream_state: Mapping[str, Any], stream_slice: Mapping[str, any] = None, next_page_token: Mapping[str, Any] = None
+        self, stream_state: Mapping[str, Any], stream_slice: Mapping[str, any] = None, next_page_token: Mapping[str, Any] = None
     ) -> MutableMapping[str, Any]:
         page = next_page_token.get("page", 1) if next_page_token else 1
 

--- a/airbyte-integrations/connectors/source-babelforce/source_babelforce/source.py
+++ b/airbyte-integrations/connectors/source-babelforce/source_babelforce/source.py
@@ -57,10 +57,10 @@ class BabelforceStream(HttpStream, ABC):
 
     def parse_response(self, response: requests.Response, **kwargs) -> Iterable[Mapping]:
         """
+        Babelforce calls are sorted in reverse order. To process the calls in ascending order an in-memory sort is performed
+
         :return an iterable containing each record in the response
         """
-        # Babelforce calls are sorted in reverse order. To process the calls in ascending order an
-        # in-memory sort is performed
         items = response.json().get("items")
         items.sort(key=operator.itemgetter("dateCreated"))
         keys = self.get_json_schema().get("properties").keys()

--- a/airbyte-integrations/connectors/source-babelforce/source_babelforce/spec.json
+++ b/airbyte-integrations/connectors/source-babelforce/source_babelforce/spec.json
@@ -1,0 +1,49 @@
+{
+  "documentationUrl": "https://docsurl.com",
+  "connectionSpecification": {
+    "$schema": "http://json-schema.org/draft-07/schema#",
+    "title": "Babelforce Spec",
+    "type": "object",
+    "required": ["region", "access_key_id", "access_token"],
+    "additionalProperties": false,
+    "properties": {
+      "region": {
+        "type": "string",
+        "title": "Region",
+        "default": "services",
+        "description": "Babelforce region",
+        "enum": ["services", "us-east", "ap-southeast"],
+        "order": 1
+      },
+      "access_key_id": {
+        "type": "string",
+        "title": "Access Key ID",
+        "description": "The Babelforce access key ID",
+        "airbyte_secret": true,
+        "order": 2
+      },
+      "access_token": {
+        "type": "string",
+        "title": "Access Token",
+        "description": "The Babelforce access token",
+        "airbyte_secret": true,
+        "order": 3
+      },
+      "date_created_from": {
+        "type": "integer",
+        "title": "Date Created from",
+        "description": "Timestamp in Unix the replication from Babelfoce API will start from.",
+        "pattern": "^$|^[0-9]{10,}$",
+        "order": 4
+      },
+      "date_created_to": {
+        "type": "integer",
+        "title": "Date Created to",
+        "description": "Timestamp in Unix the replication from Babelfoce will be up to.",
+        "examples": ["2021-12-01T00:00:00"],
+        "pattern": "^$|^[0-9]{10,}$",
+        "order": 5
+      }
+    }
+  }
+}

--- a/airbyte-integrations/connectors/source-babelforce/source_babelforce/spec.json
+++ b/airbyte-integrations/connectors/source-babelforce/source_babelforce/spec.json
@@ -32,16 +32,15 @@
       "date_created_from": {
         "type": "integer",
         "title": "Date Created from",
-        "description": "Timestamp in Unix the replication from Babelforce API will start from.",
-        "pattern": "^$|^[0-9]{10,}$",
+        "description": "Timestamp in Unix the replication from Babelforce API will start from. For example 1651363200 which corresponds to 2022-05-01 00:00:00.",
+        "examples": [1651363200],
         "order": 4
       },
       "date_created_to": {
         "type": "integer",
         "title": "Date Created to",
-        "description": "Timestamp in Unix the replication from Babelforce will be up to.",
-        "examples": ["2021-12-01T00:00:00"],
-        "pattern": "^$|^[0-9]{10,}$",
+        "description": "Timestamp in Unix the replication from Babelforce will be up to. For example 1651363200 which corresponds to 2022-05-01 00:00:00.",
+        "examples": [1651363200],
         "order": 5
       }
     }

--- a/airbyte-integrations/connectors/source-babelforce/source_babelforce/spec.json
+++ b/airbyte-integrations/connectors/source-babelforce/source_babelforce/spec.json
@@ -32,14 +32,14 @@
       "date_created_from": {
         "type": "integer",
         "title": "Date Created from",
-        "description": "Timestamp in Unix the replication from Babelfoce API will start from.",
+        "description": "Timestamp in Unix the replication from Babelforce API will start from.",
         "pattern": "^$|^[0-9]{10,}$",
         "order": 4
       },
       "date_created_to": {
         "type": "integer",
         "title": "Date Created to",
-        "description": "Timestamp in Unix the replication from Babelfoce will be up to.",
+        "description": "Timestamp in Unix the replication from Babelforce will be up to.",
         "examples": ["2021-12-01T00:00:00"],
         "pattern": "^$|^[0-9]{10,}$",
         "order": 5

--- a/airbyte-integrations/connectors/source-babelforce/unit_tests/__init__.py
+++ b/airbyte-integrations/connectors/source-babelforce/unit_tests/__init__.py
@@ -1,0 +1,3 @@
+#
+# Copyright (c) 2021 Airbyte, Inc., all rights reserved.
+#

--- a/airbyte-integrations/connectors/source-babelforce/unit_tests/test_call_stream.py
+++ b/airbyte-integrations/connectors/source-babelforce/unit_tests/test_call_stream.py
@@ -1,8 +1,11 @@
+#
+# Copyright (c) 2022 Airbyte, Inc., all rights reserved.
+#
+
 from datetime import datetime
 from unittest.mock import MagicMock
 
 import pytest
-
 from source_babelforce.source import Calls, InvalidStartAndEndDateException
 
 
@@ -69,5 +72,4 @@ def test_parse_response(patch_base_class):
         "items": [fake_item]
     }
     inputs = {"response": MagicMock(json=MagicMock(return_value=fake_call_json))}
-    expected_parsed_object = {}
     assert next(stream.parse_response(**inputs)) == fake_item

--- a/airbyte-integrations/connectors/source-babelforce/unit_tests/test_call_stream.py
+++ b/airbyte-integrations/connectors/source-babelforce/unit_tests/test_call_stream.py
@@ -1,0 +1,57 @@
+from datetime import datetime
+from unittest.mock import MagicMock
+
+import pytest
+
+from source_babelforce.source import Calls
+
+
+@pytest.fixture
+def patch_base_class(mocker):
+    # Mock abstract methods to enable instantiating abstract class
+    mocker.patch.object(Calls, "path", "v0/example_endpoint")
+    mocker.patch.object(Calls, "primary_key", "test_primary_key")
+    mocker.patch.object(Calls, "__abstractmethods__", set())
+
+
+def test_request_params(patch_base_class):
+    stream = Calls(region="services")
+    inputs = {"stream_slice": None, "stream_state": None, "next_page_token": {"page": 1}}
+    expected_params = {"max": 100, "page": 1}
+    assert stream.request_params(**inputs) == expected_params
+
+
+def test_parse_response(patch_base_class):
+    stream = Calls(region="services")
+
+    fake_date_str = "2022-04-27T00:00:00"
+    fake_date = datetime.strptime(fake_date_str, "%Y-%m-%dT%H:%M:%S")
+
+    fake_item = {
+        "id": "abc",
+        "parentId": "abc",
+        "sessionId": "abc",
+        "conversationId": "abc",
+        "dateCreated": fake_date,
+        "dateEstablished": None,
+        "dateFinished": fake_date,
+        "lastUpdated": fake_date,
+        "state": "completed",
+        "finishReason": "unreachable",
+        "from": "123",
+        "to": "123",
+        "type": "outbound",
+        "source": "queue",
+        "domain": "internal",
+        "duration": 0,
+        "anonymous": False,
+        "recordings": [],
+        "bridged": {}
+    }
+
+    fake_call_json = {
+        "items": [fake_item]
+    }
+    inputs = {"response": MagicMock(json=MagicMock(return_value=fake_call_json))}
+    expected_parsed_object = {}
+    assert next(stream.parse_response(**inputs)) == fake_item

--- a/airbyte-integrations/connectors/source-babelforce/unit_tests/test_call_stream.py
+++ b/airbyte-integrations/connectors/source-babelforce/unit_tests/test_call_stream.py
@@ -3,7 +3,7 @@ from unittest.mock import MagicMock
 
 import pytest
 
-from source_babelforce.source import Calls
+from source_babelforce.source import Calls, InvalidStartAndEndDateException
 
 
 @pytest.fixture
@@ -19,6 +19,22 @@ def test_request_params(patch_base_class):
     inputs = {"stream_slice": None, "stream_state": None, "next_page_token": {"page": 1}}
     expected_params = {"max": 100, "page": 1}
     assert stream.request_params(**inputs) == expected_params
+
+
+def test_date_created_from_less_than_date_created_to_not_raise_exception(patch_base_class):
+    try:
+        stream = Calls(region="services", date_created_from=1, date_created_to=2)
+        inputs = {"stream_slice": None, "stream_state": None, "next_page_token": {"page": 1}}
+        stream.request_params(**inputs)
+    except InvalidStartAndEndDateException as exception:
+        assert False, exception
+
+
+def test_date_created_from_less_than_date_created_to_raise_exception(patch_base_class):
+    with pytest.raises(InvalidStartAndEndDateException):
+        stream = Calls(region="services", date_created_from=2, date_created_to=1)
+        inputs = {"stream_slice": None, "stream_state": None, "next_page_token": {"page": 1}}
+        stream.request_params(**inputs)
 
 
 def test_parse_response(patch_base_class):

--- a/airbyte-integrations/connectors/source-babelforce/unit_tests/test_incremental_streams.py
+++ b/airbyte-integrations/connectors/source-babelforce/unit_tests/test_incremental_streams.py
@@ -1,13 +1,11 @@
 #
-# Copyright (c) 2021 Airbyte, Inc., all rights reserved.
+# Copyright (c) 2022 Airbyte, Inc., all rights reserved.
 #
-from datetime import timezone
 
 from dateutil.parser import parse
 from dateutil.tz import tzutc
 from pytest import fixture
-
-from source_babelforce.source import IncrementalBabelforceStream, DEFAULT_CURSOR
+from source_babelforce.source import DEFAULT_CURSOR, IncrementalBabelforceStream
 
 
 @fixture

--- a/airbyte-integrations/connectors/source-babelforce/unit_tests/test_incremental_streams.py
+++ b/airbyte-integrations/connectors/source-babelforce/unit_tests/test_incremental_streams.py
@@ -1,0 +1,43 @@
+#
+# Copyright (c) 2021 Airbyte, Inc., all rights reserved.
+#
+from datetime import timezone
+
+from dateutil.parser import parse
+from dateutil.tz import tzutc
+from pytest import fixture
+
+from source_babelforce.source import IncrementalBabelforceStream, DEFAULT_CURSOR
+
+
+@fixture
+def patch_incremental_base_class(mocker):
+    # Mock abstract methods to enable instantiating abstract class
+    mocker.patch.object(IncrementalBabelforceStream, "path", "v0/example_endpoint")
+    mocker.patch.object(IncrementalBabelforceStream, "primary_key", "test_primary_key")
+    mocker.patch.object(IncrementalBabelforceStream, "__abstractmethods__", set())
+
+
+def test_cursor_field(patch_incremental_base_class):
+    stream = IncrementalBabelforceStream(region="services")
+    expected_cursor_field = DEFAULT_CURSOR
+    assert stream.cursor_field == expected_cursor_field
+
+
+def test_get_updated_state(patch_incremental_base_class):
+    stream = IncrementalBabelforceStream(region="services")
+    fake_date = "2022-02-01T00:00:00"
+    inputs = {"current_stream_state": None, "latest_record": {DEFAULT_CURSOR: fake_date}}
+    expected_state = {DEFAULT_CURSOR: parse(fake_date).replace(tzinfo=tzutc()).isoformat(timespec="seconds")}
+    assert stream.get_updated_state(**inputs) == expected_state
+
+
+def test_supports_incremental(patch_incremental_base_class, mocker):
+    mocker.patch.object(IncrementalBabelforceStream, "cursor_field", "dummy_field")
+    stream = IncrementalBabelforceStream(region="services")
+    assert stream.supports_incremental
+
+
+def test_source_defined_cursor(patch_incremental_base_class):
+    stream = IncrementalBabelforceStream(region="services")
+    assert stream.source_defined_cursor

--- a/airbyte-integrations/connectors/source-babelforce/unit_tests/test_source.py
+++ b/airbyte-integrations/connectors/source-babelforce/unit_tests/test_source.py
@@ -1,0 +1,24 @@
+#
+# Copyright (c) 2021 Airbyte, Inc., all rights reserved.
+#
+
+from unittest.mock import MagicMock
+
+import requests
+
+from source_babelforce.source import SourceBabelforce
+
+
+def test_check_connection(mocker):
+    source = SourceBabelforce()
+    logger_mock, config_mock = MagicMock(), MagicMock()
+    mocker.patch.object(requests, "request", return_value=MagicMock(ok=True))
+    assert source.check_connection(logger_mock, config_mock) == (True, None)
+
+
+def test_streams(mocker):
+    source = SourceBabelforce()
+    config_mock = MagicMock()
+    streams = source.streams(config_mock)
+    expected_streams_number = 1
+    assert len(streams) == expected_streams_number

--- a/airbyte-integrations/connectors/source-babelforce/unit_tests/test_source.py
+++ b/airbyte-integrations/connectors/source-babelforce/unit_tests/test_source.py
@@ -1,11 +1,10 @@
 #
-# Copyright (c) 2021 Airbyte, Inc., all rights reserved.
+# Copyright (c) 2022 Airbyte, Inc., all rights reserved.
 #
 
 from unittest.mock import MagicMock
 
 import requests
-
 from source_babelforce.source import SourceBabelforce
 
 

--- a/airbyte-integrations/connectors/source-babelforce/unit_tests/test_streams.py
+++ b/airbyte-integrations/connectors/source-babelforce/unit_tests/test_streams.py
@@ -1,5 +1,5 @@
 #
-# Copyright (c) 2021 Airbyte, Inc., all rights reserved.
+# Copyright (c) 2022 Airbyte, Inc., all rights reserved.
 #
 
 from http import HTTPStatus

--- a/airbyte-integrations/connectors/source-babelforce/unit_tests/test_streams.py
+++ b/airbyte-integrations/connectors/source-babelforce/unit_tests/test_streams.py
@@ -1,0 +1,64 @@
+#
+# Copyright (c) 2021 Airbyte, Inc., all rights reserved.
+#
+
+from http import HTTPStatus
+from unittest.mock import MagicMock
+
+import pytest
+from source_babelforce.source import BabelforceStream
+
+
+@pytest.fixture
+def patch_base_class(mocker):
+    # Mock abstract methods to enable instantiating abstract class
+    mocker.patch.object(BabelforceStream, "path", "v0/example_endpoint")
+    mocker.patch.object(BabelforceStream, "primary_key", "test_primary_key")
+    mocker.patch.object(BabelforceStream, "__abstractmethods__", set())
+
+
+def test_next_page_token(patch_base_class):
+    stream = BabelforceStream(region="services")
+
+    json_response_mock = MagicMock()
+    json_response_mock.json.return_value = {"pagination": {"current": 1}}
+
+    inputs = {"response": json_response_mock}
+    expected_token = {"page": 2}
+    assert stream.next_page_token(**inputs) == expected_token
+
+
+def test_request_headers(patch_base_class):
+    stream = BabelforceStream(region="services")
+    inputs = {"stream_slice": None, "stream_state": None, "next_page_token": None}
+    expected_headers = {}
+    assert stream.request_headers(**inputs) == expected_headers
+
+
+def test_http_method(patch_base_class):
+    stream = BabelforceStream(region="services")
+    expected_method = "GET"
+    assert stream.http_method == expected_method
+
+
+@pytest.mark.parametrize(
+    ("http_status", "should_retry"),
+    [
+        (HTTPStatus.OK, False),
+        (HTTPStatus.BAD_REQUEST, False),
+        (HTTPStatus.TOO_MANY_REQUESTS, True),
+        (HTTPStatus.INTERNAL_SERVER_ERROR, True),
+    ],
+)
+def test_should_retry(patch_base_class, http_status, should_retry):
+    response_mock = MagicMock()
+    response_mock.status_code = http_status
+    stream = BabelforceStream(region="services")
+    assert stream.should_retry(response_mock) == should_retry
+
+
+def test_backoff_time(patch_base_class):
+    response_mock = MagicMock()
+    stream = BabelforceStream(region="services")
+    expected_backoff_time = None
+    assert stream.backoff_time(response_mock) == expected_backoff_time

--- a/docs/integrations/sources/babelforce.md
+++ b/docs/integrations/sources/babelforce.md
@@ -45,6 +45,6 @@ Generate a API access key ID and token using the [Babelforce documentation](http
 
 ## CHANGELOG
 
-| Version | Date       | Pull Request                                           | Subject                     |
-|:--------|:-----------| :------------------------------------------------------| :---------------------------|
- 0.1.0    | 2022-05-09 | [<id>](https://github.com/airbytehq/airbyte/pull/<id>) | Introduce Babelforce source |
+| Version | Date       | Pull Request                                             | Subject                     |
+|:--------|:-----------|:---------------------------------------------------------|:----------------------------|
+ 0.1.0    | 2022-05-09 | [12700](https://github.com/airbytehq/airbyte/pull/12700) | Introduce Babelforce source |

--- a/docs/integrations/sources/babelforce.md
+++ b/docs/integrations/sources/babelforce.md
@@ -1,0 +1,50 @@
+# Recurly
+
+## Overview
+
+The Babelforce source supports _Full Refresh_ as well as _Incremental_ syncs. 
+
+_Full Refresh_ sync means every time a sync is run, Airbyte will copy all rows in the tables and columns you set up for replication into the destination in a new table.
+_Incremental_ syn means only changed resources are copied from Babelformce. For the first run, it will be a Full Refresh sync.
+
+### Output schema
+
+Several output streams are available from this source:
+
+* [Calls](https://api.babelforce.com/#af7a6b6e-b262-487f-aabd-c59e6fe7ba41)
+
+
+If there are more endpoints you'd like Airbyte to support, please [create an issue.](https://github.com/airbytehq/airbyte/issues/new/choose)
+
+### Features
+
+| Feature | Supported? |
+| :--- | :--- |
+| Full Refresh Sync | Yes |
+| Incremental Sync | Yes |
+| Replicate Incremental Deletes | Coming soon |
+| SSL connection | Yes |
+| Namespaces | No |
+
+### Performance considerations
+
+There are no performance consideration in the current version.
+
+## Getting started
+
+### Requirements
+
+* Region/environment as listed in the `Regions & environments` section [here](https://api.babelforce.com/#intro)
+* Babelforce access key ID 
+* Babelforce access token
+* (Optional) start date from when the import starts in epoch Unix timestamp
+
+### Setup guide
+
+Generate a API access key ID and token using the [Babelforce documentation](https://help.babelforce.com/hc/en-us/articles/360035622132-API-documentation-and-endpoints-an-introduction)
+
+## CHANGELOG
+
+| Version | Date       | Pull Request                                           | Subject                     |
+|:--------|:-----------| :------------------------------------------------------| :---------------------------|
+ 0.1.0    | 2022-05-09 | [<id>](https://github.com/airbytehq/airbyte/pull/<id>) | Introduce Babelforce source |


### PR DESCRIPTION
## What
Introduce [Babelforce Source](https://www.babelforce.com/)

## 🚨 User Impact 🚨
This is a new source. No user impact is expected.

## Pre-merge Checklist
### Community member or Airbyter

- [x] **Community member?** Grant edit access to maintainers ([instructions](https://docs.github.com/en/github/collaborating-with-pull-requests/working-with-forks/allowing-changes-to-a-pull-request-branch-created-from-a-fork#enabling-repository-maintainer-permissions-on-existing-pull-requests))
- [x] Secrets in the connector's spec are annotated with `airbyte_secret`
- [x] Unit & integration tests added and passing. Community members, please provide proof of success locally e.g: screenshot or copy-paste unit, integration, and acceptance test output. To run acceptance tests for a Python connector, follow instructions in the README. For java connectors run `./gradlew :airbyte-integrations:connectors:<name>:integrationTest`.
- [ ] Code reviews completed
- [ ] Documentation updated
    - [x] Connector's `README.md`
    - [ ] Connector's `bootstrap.md`. See [description and examples](https://docs.google.com/document/d/1ypdgmwmEHWv-TrO4_YOQ7pAJGVrMp5BOkEVh831N260/edit?usp=sharing)
    - [x] `docs/SUMMARY.md`
    - [x] `docs/integrations/<source or destination>/<name>.md` including changelog. See changelog [example](https://docs.airbyte.io/integrations/sources/stripe#changelog)
    - [x] `docs/integrations/README.md`
    - [ ] `airbyte-integrations/builds.md`
- [x] PR name follows [PR naming conventions](https://docs.airbyte.io/contributing-to-airbyte/updating-documentation#issues-and-pull-requests)

## Tests

<details><summary><strong>Unit</strong></summary>

```shell
Test session starts (platform: darwin, Python 3.9.7, pytest 6.2.5, pytest-sugar 0.9.4)
cachedir: .pytest_cache
rootdir: /Users/mohamedmagdy/projects/airbyte/airbyte, configfile: pytest.ini
plugins: sugar-0.9.4, mock-3.6.1, timeout-1.4.2
collecting ...
 airbyte-integrations/connectors/source-babelforce/unit_tests/test_call_stream.py::test_request_params ✓                                                                                                                         6% ▋
 airbyte-integrations/connectors/source-babelforce/unit_tests/test_call_stream.py::test_parse_response ✓                                                                                                                        12% █▍
 airbyte-integrations/connectors/source-babelforce/unit_tests/test_incremental_streams.py::test_cursor_field ✓                                                                                                                  19% █▉
 airbyte-integrations/connectors/source-babelforce/unit_tests/test_incremental_streams.py::test_get_updated_state ✓                                                                                                             25% ██▌
 airbyte-integrations/connectors/source-babelforce/unit_tests/test_incremental_streams.py::test_supports_incremental ✓                                                                                                          31% ███▎
 airbyte-integrations/connectors/source-babelforce/unit_tests/test_incremental_streams.py::test_source_defined_cursor ✓                                                                                                         38% ███▊
 airbyte-integrations/connectors/source-babelforce/unit_tests/test_source.py::test_check_connection ✓                                                                                                                           44% ████▍
 airbyte-integrations/connectors/source-babelforce/unit_tests/test_source.py::test_streams ✓                                                                                                                                    50% █████
 airbyte-integrations/connectors/source-babelforce/unit_tests/test_streams.py::test_next_page_token ✓                                                                                                                           56% █████▋
 airbyte-integrations/connectors/source-babelforce/unit_tests/test_streams.py::test_request_headers ✓                                                                                                                           62% ██████▍
 airbyte-integrations/connectors/source-babelforce/unit_tests/test_streams.py::test_http_method ✓                                                                                                                               69% ██████▉
 airbyte-integrations/connectors/source-babelforce/unit_tests/test_streams.py::test_should_retry[HTTPStatus.OK-False] ✓                                                                                                         75% ███████▌
 airbyte-integrations/connectors/source-babelforce/unit_tests/test_streams.py::test_should_retry[HTTPStatus.BAD_REQUEST-False] ✓                                                                                                81% ████████▎
 airbyte-integrations/connectors/source-babelforce/unit_tests/test_streams.py::test_should_retry[HTTPStatus.TOO_MANY_REQUESTS-True] ✓                                                                                           88% ████████▊
 airbyte-integrations/connectors/source-babelforce/unit_tests/test_streams.py::test_should_retry[HTTPStatus.INTERNAL_SERVER_ERROR-True] ✓                                                                                       94% █████████▍
 airbyte-integrations/connectors/source-babelforce/unit_tests/test_streams.py::test_backoff_time ✓                                                                                                                             100% ██████████
============================================================================================================== warnings summary ==============================================================================================================
../../../../../../.pyenv/versions/3.9.7/envs/source-babelforce/lib/python3.9/site-packages/airbyte_cdk/sources/utils/transform.py:12
  /Users/mohamedmagdy/.pyenv/versions/3.9.7/envs/source-babelforce/lib/python3.9/site-packages/airbyte_cdk/sources/utils/transform.py:12: DeprecationWarning: Call to deprecated class AirbyteLogger. (Use logging.getLogger('airbyte') instead) -- Deprecated since version 0.1.47.
    logger = AirbyteLogger()

../../../../../../.pyenv/versions/3.9.7/envs/source-babelforce/lib/python3.9/site-packages/airbyte_cdk/sources/streams/http/rate_limiting.py:19
  /Users/mohamedmagdy/.pyenv/versions/3.9.7/envs/source-babelforce/lib/python3.9/site-packages/airbyte_cdk/sources/streams/http/rate_limiting.py:19: DeprecationWarning: Call to deprecated class AirbyteLogger. (Use logging.getLogger('airbyte') instead) -- Deprecated since version 0.1.47.
    logger = AirbyteLogger()

../../../../../../.pyenv/versions/3.9.7/envs/source-babelforce/lib/python3.9/site-packages/airbyte_cdk/utils/event_timing.py:13
  /Users/mohamedmagdy/.pyenv/versions/3.9.7/envs/source-babelforce/lib/python3.9/site-packages/airbyte_cdk/utils/event_timing.py:13: DeprecationWarning: Call to deprecated class AirbyteLogger. (Use logging.getLogger('airbyte') instead) -- Deprecated since version 0.1.47.
    logger = AirbyteLogger()

airbyte-integrations/connectors/source-babelforce/unit_tests/test_call_stream.py: 2 warnings
airbyte-integrations/connectors/source-babelforce/unit_tests/test_incremental_streams.py: 4 warnings
airbyte-integrations/connectors/source-babelforce/unit_tests/test_source.py: 2 warnings
airbyte-integrations/connectors/source-babelforce/unit_tests/test_streams.py: 8 warnings
  /Users/mohamedmagdy/.pyenv/versions/3.9.7/envs/source-babelforce/lib/python3.9/site-packages/airbyte_cdk/sources/streams/http/http.py:43: DeprecationWarning: Call to deprecated class NoAuth. (Set `authenticator=None` instead) -- Deprecated since version 0.1.20.
    self._authenticator: HttpAuthenticator = NoAuth()

airbyte-integrations/connectors/source-babelforce/unit_tests/test_call_stream.py: 2 warnings
airbyte-integrations/connectors/source-babelforce/unit_tests/test_incremental_streams.py: 4 warnings
airbyte-integrations/connectors/source-babelforce/unit_tests/test_source.py: 2 warnings
airbyte-integrations/connectors/source-babelforce/unit_tests/test_streams.py: 8 warnings
  /Users/mohamedmagdy/.pyenv/versions/3.9.7/envs/source-babelforce/lib/python3.9/site-packages/deprecated/classic.py:173: DeprecationWarning: Call to deprecated class HttpAuthenticator. (Use requests.auth.AuthBase instead) -- Deprecated since version 0.1.20.
    return old_new1(cls, *args, **kwargs)

airbyte-integrations/connectors/source-babelforce/unit_tests/test_source.py::test_check_connection
airbyte-integrations/connectors/source-babelforce/unit_tests/test_source.py::test_streams
  /Users/mohamedmagdy/projects/airbyte/airbyte/airbyte-integrations/connectors/source-babelforce/source_babelforce/source.py:148: DeprecationWarning: Call to deprecated class HttpAuthenticator. (Use requests.auth.AuthBase instead) -- Deprecated since version 0.1.20.
    return BabelforceAuthenticator(access_key_id=access_key_id, access_token=access_token)

-- Docs: https://docs.pytest.org/en/stable/warnings.html

Results (0.92s):
      16 passed
```

</details>

<details><summary><strong>Integration</strong></summary>

```shell
cachedir: .pytest_cache
rootdir: /Users/mohamedmagdy/projects/airbyte/airbyte, configfile: pytest.ini
plugins: sugar-0.9.4, mock-3.6.1, timeout-1.4.2
collecting ...

Results (0.03s):
```

</details>

<details><summary><strong>Acceptance</strong></summary>

```shell
cachedir: .pytest_cache
rootdir: /Users/mohamedmagdy/projects/airbyte/airbyte, configfile: pytest.ini
plugins: sugar-0.9.4, mock-3.6.1, timeout-1.4.2
collecting ...
 ../../canary/airbyte/airbyte-integrations/bases/source-acceptance-test/source_acceptance_test/tests/test_core.py::TestSpec.test_config_match_spec[inputs0] ✓                                                                    5% ▌
 ../../canary/airbyte/airbyte-integrations/bases/source-acceptance-test/source_acceptance_test/tests/test_core.py::TestSpec.test_match_expected[inputs0] ✓                                                                       9% ▉
 ../../canary/airbyte/airbyte-integrations/bases/source-acceptance-test/source_acceptance_test/tests/test_core.py::TestSpec.test_docker_env[inputs0] ✓                                                                          14% █▍
 ../../canary/airbyte/airbyte-integrations/bases/source-acceptance-test/source_acceptance_test/tests/test_core.py::TestSpec.test_oneof_usage[inputs0] ✓                                                                         18% █▊
 ../../canary/airbyte/airbyte-integrations/bases/source-acceptance-test/source_acceptance_test/tests/test_core.py::TestSpec.test_required[inputs0] ✓                                                                            23% ██▍
 ../../canary/airbyte/airbyte-integrations/bases/source-acceptance-test/source_acceptance_test/tests/test_core.py::TestSpec.test_optional[inputs0] ✓                                                                            27% ██▊
 ../../canary/airbyte/airbyte-integrations/bases/source-acceptance-test/source_acceptance_test/tests/test_core.py::TestSpec.test_has_secret[inputs0] ✓                                                                          32% ███▎
 ../../canary/airbyte/airbyte-integrations/bases/source-acceptance-test/source_acceptance_test/tests/test_core.py::TestSpec.test_secret_never_in_the_output[inputs0] ✓                                                          36% ███▋
 ../../canary/airbyte/airbyte-integrations/bases/source-acceptance-test/source_acceptance_test/tests/test_core.py::TestSpec.test_defined_refs_exist_in_json_spec_file[inputs0] ✓                                                41% ████▏
 ../../canary/airbyte/airbyte-integrations/bases/source-acceptance-test/source_acceptance_test/tests/test_core.py::TestSpec.test_oauth_flow_parameters[inputs0] ✓                                                               45% ████▋
 ../../canary/airbyte/airbyte-integrations/bases/source-acceptance-test/source_acceptance_test/tests/test_core.py::TestConnection.test_check[inputs0] ✓                                                                         50% █████
 ../../canary/airbyte/airbyte-integrations/bases/source-acceptance-test/source_acceptance_test/tests/test_core.py::TestConnection.test_check[inputs1] ✓                                                                         55% █████▌
 ../../canary/airbyte/airbyte-integrations/bases/source-acceptance-test/source_acceptance_test/tests/test_core.py::TestDiscovery.test_discover[inputs0] ✓                                                                       59% █████▉
 ../../canary/airbyte/airbyte-integrations/bases/source-acceptance-test/source_acceptance_test/tests/test_core.py::TestDiscovery.test_defined_cursors_exist_in_schema[inputs0] ✓                                                64% ██████▍
 ../../canary/airbyte/airbyte-integrations/bases/source-acceptance-test/source_acceptance_test/tests/test_core.py::TestDiscovery.test_defined_refs_exist_in_schema[inputs0] ✓                                                   68% ██████▊
 ../../canary/airbyte/airbyte-integrations/bases/source-acceptance-test/source_acceptance_test/tests/test_core.py::TestDiscovery.test_defined_keyword_exist_in_schema[inputs0-allOf] ✓                                          73% ███████▍
 ../../canary/airbyte/airbyte-integrations/bases/source-acceptance-test/source_acceptance_test/tests/test_core.py::TestDiscovery.test_defined_keyword_exist_in_schema[inputs0-not] ✓                                            77% ███████▊
 ../../canary/airbyte/airbyte-integrations/bases/source-acceptance-test/source_acceptance_test/tests/test_core.py::TestDiscovery.test_primary_keys_exist_in_schema[inputs0] ✓                                                   82% ████████▎
 ../../canary/airbyte/airbyte-integrations/bases/source-acceptance-test/source_acceptance_test/tests/test_core.py::TestBasicRead.test_read[inputs0] ✓                                                                           86% ████████▋
 ../../canary/airbyte/airbyte-integrations/bases/source-acceptance-test/source_acceptance_test/tests/test_full_refresh.py::TestFullRefresh.test_sequential_reads[inputs0] ✓                                                     91% █████████▏
 ../../canary/airbyte/airbyte-integrations/bases/source-acceptance-test/source_acceptance_test/tests/test_incremental.py::TestIncremental.test_two_sequential_reads[inputs0] ✓                                                  95% █████████▋
 ../../canary/airbyte/airbyte-integrations/bases/source-acceptance-test/source_acceptance_test/tests/test_incremental.py::TestIncremental.test_state_with_abnormally_large_values[inputs0] s                                   100% ██████████
{"type": "LOG", "log": {"level": "INFO", "message": "/Users/mohamedmagdy/projects/airbyte/airbyte/airbyte-integrations/connectors/source-babelforce - SAT run - e3de55e402e6f79cd0837fc7f43116cc5ea72cd2 - PASSED"}}

========================================================================================================== short test summary info ===========================================================================================================
SKIPPED [1] ../../../../../canary/airbyte/airbyte-integrations/bases/source-acceptance-test/source_acceptance_test/tests/test_incremental.py:21: `future_state_path` not specified, skipping

Results (51.61s):
      21 passed
       1 skipped
```
