### PR TITLE
SAT: add `threshold_days` incremental test option

### DIFF
--- a/airbyte-integrations/bases/source-acceptance-test/CHANGELOG.md
+++ b/airbyte-integrations/bases/source-acceptance-test/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## 0.1.51
+- Add `threshold_days` option for lookback window support in incremental tests.
+- Update CDK to prevent warnings when encountering new `AirbyteTraceMessage`s.
+
 ## 0.1.50
 Added support for passing a `.yaml` file as `spec_path`.
 

--- a/airbyte-integrations/bases/source-acceptance-test/Dockerfile
+++ b/airbyte-integrations/bases/source-acceptance-test/Dockerfile
@@ -33,7 +33,7 @@ COPY pytest.ini setup.py ./
 COPY source_acceptance_test ./source_acceptance_test
 RUN pip install .
 
-LABEL io.airbyte.version=0.1.50
+LABEL io.airbyte.version=0.1.51
 LABEL io.airbyte.name=airbyte/source-acceptance-test
 
 ENTRYPOINT ["python", "-m", "pytest", "-p", "source_acceptance_test.plugin", "-r", "fEsx"]

--- a/airbyte-integrations/bases/source-acceptance-test/setup.py
+++ b/airbyte-integrations/bases/source-acceptance-test/setup.py
@@ -6,7 +6,7 @@
 import setuptools
 
 MAIN_REQUIREMENTS = [
-    "airbyte-cdk~=0.1.25",
+    "airbyte-cdk~=0.1.56",
     "docker~=5.0.3",
     "PyYAML~=5.4",
     "icdiff~=1.9",

--- a/airbyte-integrations/bases/source-acceptance-test/source_acceptance_test/config.py
+++ b/airbyte-integrations/bases/source-acceptance-test/source_acceptance_test/config.py
@@ -105,6 +105,11 @@ class IncrementalConfig(BaseConfig):
     )
     future_state_path: Optional[str] = Field(description="Path to a state file with values in far future")
     timeout_seconds: int = timeout_seconds
+    threshold_days: int = Field(
+        description="Allow records to be emitted with a cursor value this number of days before the state cursor",
+        default=0,
+        ge=0,
+    )
 
 
 class TestConfig(BaseConfig):

--- a/airbyte-integrations/bases/source-acceptance-test/source_acceptance_test/tests/test_incremental.py
+++ b/airbyte-integrations/bases/source-acceptance-test/source_acceptance_test/tests/test_incremental.py
@@ -3,7 +3,7 @@
 #
 
 import json
-from datetime import datetime, timedelta
+from datetime import datetime
 from pathlib import Path
 from typing import Any, Iterable, Mapping, Tuple
 
@@ -89,7 +89,7 @@ def compare_cursor_with_threshold(record_value, state_value, threshold_days: int
         record_date_value = record_value if isinstance(record_value, datetime) else pendulum.parse(record_value)
         state_date_value = state_value if isinstance(state_value, datetime) else pendulum.parse(state_value)
 
-        return record_date_value >= (state_date_value - timedelta(days=threshold_days))
+        return record_date_value >= (state_date_value - pendulum.duration(days=threshold_days))
 
     return record_value >= state_value
 

--- a/airbyte-integrations/bases/source-acceptance-test/source_acceptance_test/tests/test_incremental.py
+++ b/airbyte-integrations/bases/source-acceptance-test/source_acceptance_test/tests/test_incremental.py
@@ -7,7 +7,7 @@ from datetime import datetime, timedelta
 from pathlib import Path
 from typing import Any, Iterable, Mapping, Tuple
 
-import dateutil.parser
+import pendulum
 import pytest
 from airbyte_cdk.models import ConfiguredAirbyteCatalog, Type
 from source_acceptance_test import BaseTest
@@ -78,16 +78,16 @@ def records_with_state(records, state, stream_mapping, state_cursor_paths) -> It
         yield record_value, state_value, stream_name
 
 
-def compare_cursor_with_threshold(record_value, state_value, threshold_days) -> bool:
+def compare_cursor_with_threshold(record_value, state_value, threshold_days: int) -> bool:
     """
     Checks if the record's cursor value is older or equal to the state cursor value.
 
     If the threshold_days option is set, the values will be converted to dates so that the time-based offset can be applied.
-    :raises dateutil.parser._parser.ParserError: if threshold_days is passed with non-date cursor values.
+    :raises: dateutil.parser._parser.ParserError: if threshold_days is passed with non-date cursor values.
     """
     if threshold_days:
-        record_date_value = record_value if isinstance(record_value, datetime) else dateutil.parser.parse(record_value)
-        state_date_value = state_value if isinstance(state_value, datetime) else dateutil.parser.parse(state_value)
+        record_date_value = record_value if isinstance(record_value, datetime) else pendulum.parse(record_value)
+        state_date_value = state_value if isinstance(state_value, datetime) else pendulum.parse(state_value)
 
         return record_date_value >= (state_date_value - timedelta(days=threshold_days))
 

--- a/airbyte-integrations/bases/source-acceptance-test/source_acceptance_test/tests/test_incremental.py
+++ b/airbyte-integrations/bases/source-acceptance-test/source_acceptance_test/tests/test_incremental.py
@@ -2,15 +2,17 @@
 # Copyright (c) 2021 Airbyte, Inc., all rights reserved.
 #
 
-
 import json
+from datetime import timedelta
 from pathlib import Path
 from typing import Any, Iterable, Mapping, Tuple
 
+import dateutil.parser
 import pytest
 from airbyte_cdk.models import ConfiguredAirbyteCatalog, Type
 from source_acceptance_test import BaseTest
-from source_acceptance_test.utils import ConnectorRunner, JsonSchemaHelper, filter_output, incremental_only_catalog
+from source_acceptance_test.config import IncrementalConfig
+from source_acceptance_test.utils import ConnectorRunner, JsonSchemaHelper, SecretDict, filter_output, incremental_only_catalog
 
 
 @pytest.fixture(name="future_state_path")
@@ -76,9 +78,33 @@ def records_with_state(records, state, stream_mapping, state_cursor_paths) -> It
         yield record_value, state_value, stream_name
 
 
+def compare_cursor_with_threshold(record_value, state_value, threshold_days) -> bool:
+    """
+    Checks if the record's cursor value is older or equal to the state cursor value.
+
+    If the threshold_days option is set, the values will be converted to dates so that the time-based offset can be applied.
+    Note that a ParserError will be raised if threshold_days is passed with non-date cursor values.
+    """
+    if threshold_days:
+        record_date_value = dateutil.parser.parse(record_value)
+        state_date_value = dateutil.parser.parse(state_value)
+
+        return record_date_value >= (state_date_value - timedelta(days=threshold_days))
+
+    return record_value >= state_value
+
+
 @pytest.mark.default_timeout(20 * 60)
 class TestIncremental(BaseTest):
-    def test_two_sequential_reads(self, connector_config, configured_catalog_for_incremental, cursor_paths, docker_runner: ConnectorRunner):
+    def test_two_sequential_reads(
+        self,
+        inputs: IncrementalConfig,
+        connector_config: SecretDict,
+        configured_catalog_for_incremental: ConfiguredAirbyteCatalog,
+        cursor_paths: dict[str, list[str]],
+        docker_runner: ConnectorRunner,
+    ):
+        threshold_days = getattr(inputs, "threshold_days") or 0
         stream_mapping = {stream.stream.name: stream for stream in configured_catalog_for_incremental.streams}
 
         output = docker_runner.call_read(connector_config, configured_catalog_for_incremental)
@@ -98,8 +124,8 @@ class TestIncremental(BaseTest):
         records_2 = filter_output(output, type_=Type.RECORD)
 
         for record_value, state_value, stream_name in records_with_state(records_2, latest_state, stream_mapping, cursor_paths):
-            assert (
-                record_value >= state_value
+            assert compare_cursor_with_threshold(
+                record_value, state_value, threshold_days
             ), f"Second incremental sync should produce records older or equal to cursor value from the state. Stream: {stream_name}"
 
     def test_state_with_abnormally_large_values(self, connector_config, configured_catalog, future_state, docker_runner: ConnectorRunner):

--- a/airbyte-integrations/bases/source-acceptance-test/source_acceptance_test/tests/test_incremental.py
+++ b/airbyte-integrations/bases/source-acceptance-test/source_acceptance_test/tests/test_incremental.py
@@ -89,7 +89,7 @@ def compare_cursor_with_threshold(record_value, state_value, threshold_days) -> 
         record_date_value = record_value if isinstance(record_value, datetime) else dateutil.parser.parse(record_value)
         state_date_value = state_value if isinstance(state_value, datetime) else dateutil.parser.parse(state_value)
 
-        return record_date_value >= (state_date_value - timedelta(days=1))
+        return record_date_value >= (state_date_value - timedelta(days=threshold_days))
 
     return record_value >= state_value
 

--- a/airbyte-integrations/bases/source-acceptance-test/source_acceptance_test/tests/test_incremental.py
+++ b/airbyte-integrations/bases/source-acceptance-test/source_acceptance_test/tests/test_incremental.py
@@ -83,11 +83,19 @@ def compare_cursor_with_threshold(record_value, state_value, threshold_days: int
     Checks if the record's cursor value is older or equal to the state cursor value.
 
     If the threshold_days option is set, the values will be converted to dates so that the time-based offset can be applied.
-    :raises: dateutil.parser._parser.ParserError: if threshold_days is passed with non-date cursor values.
+    :raises: pendulum.parsing.exceptions.ParserError: if threshold_days is passed with non-date cursor values.
     """
     if threshold_days:
-        record_date_value = record_value if isinstance(record_value, datetime) else pendulum.parse(record_value)
-        state_date_value = state_value if isinstance(state_value, datetime) else pendulum.parse(state_value)
+
+        def _parse_date_value(value) -> datetime:
+            if isinstance(value, datetime):
+                return value
+            if isinstance(value, (int, float)):
+                return pendulum.from_timestamp(value / 1000)
+            return pendulum.parse(value)
+
+        record_date_value = _parse_date_value(record_value)
+        state_date_value = _parse_date_value(state_value)
 
         return record_date_value >= (state_date_value - pendulum.duration(days=threshold_days))
 

--- a/airbyte-integrations/bases/source-acceptance-test/source_acceptance_test/tests/test_incremental.py
+++ b/airbyte-integrations/bases/source-acceptance-test/source_acceptance_test/tests/test_incremental.py
@@ -3,7 +3,7 @@
 #
 
 import json
-from datetime import timedelta
+from datetime import datetime, timedelta
 from pathlib import Path
 from typing import Any, Iterable, Mapping, Tuple
 
@@ -83,13 +83,13 @@ def compare_cursor_with_threshold(record_value, state_value, threshold_days) -> 
     Checks if the record's cursor value is older or equal to the state cursor value.
 
     If the threshold_days option is set, the values will be converted to dates so that the time-based offset can be applied.
-    Note that a ParserError will be raised if threshold_days is passed with non-date cursor values.
+    :raises dateutil.parser._parser.ParserError: if threshold_days is passed with non-date cursor values.
     """
     if threshold_days:
-        record_date_value = dateutil.parser.parse(record_value)
-        state_date_value = dateutil.parser.parse(state_value)
+        record_date_value = record_value if isinstance(record_value, datetime) else dateutil.parser.parse(record_value)
+        state_date_value = state_value if isinstance(state_value, datetime) else dateutil.parser.parse(state_value)
 
-        return record_date_value >= (state_date_value - timedelta(days=threshold_days))
+        return record_date_value >= (state_date_value - timedelta(days=1))
 
     return record_value >= state_value
 

--- a/airbyte-integrations/bases/source-acceptance-test/unit_tests/test_incremental.py
+++ b/airbyte-integrations/bases/source-acceptance-test/unit_tests/test_incremental.py
@@ -36,7 +36,7 @@ def build_state_message(state: dict) -> AirbyteMessage:
         ([{"date": "2020-01-02"}, {"date": "2020-01-03"}], [], "2020-01-02", 0, "First incremental sync should produce records younger"),
         ([{"date": "2020-01-01"}, {"date": "2020-01-02"}], [{"date": "2020-01-02"}, {"date": "2020-01-03"}], "2020-01-02", 0, None),
         ([{"date": "2020-01-01"}], [{"date": "2020-01-01"}], "2020-01-02", 0, "Second incremental sync should produce records older"),
-        ([{"date": "2020-01-01"}], [{"date": "2020-01-01"}], "2020-01-02", 2, None),
+        ([{"date": "2020-01-01"}, {"date": "2020-01-02"}], [{"date": "2020-01-01"}, {"date": "2020-01-02"}], "2020-01-03", 2, None),
         ([{"date": "2020-01-02"}, {"date": "2020-01-03"}], [], "2020-01-02", 2, "First incremental sync should produce records younger"),
         ([{"date": "2020-01-01"}], [{"date": "2020-01-02"}], "2020-01-06", 3, "Second incremental sync should produce records older"),
     ],

--- a/airbyte-integrations/bases/source-acceptance-test/unit_tests/test_incremental.py
+++ b/airbyte-integrations/bases/source-acceptance-test/unit_tests/test_incremental.py
@@ -1,0 +1,82 @@
+#
+# Copyright (c) 2021 Airbyte, Inc., all rights reserved.
+#
+
+from unittest.mock import MagicMock
+
+import pytest
+from airbyte_cdk.models import (
+    AirbyteMessage,
+    AirbyteRecordMessage,
+    AirbyteStateMessage,
+    AirbyteStream,
+    ConfiguredAirbyteCatalog,
+    ConfiguredAirbyteStream,
+    Type,
+)
+from source_acceptance_test.config import IncrementalConfig
+from source_acceptance_test.tests.test_incremental import TestIncremental as _TestIncremental
+
+
+def build_messages_from_record_data(records: list[dict]) -> list[AirbyteMessage]:
+    return [
+        AirbyteMessage(type=Type.RECORD, record=AirbyteRecordMessage(stream="test_stream", data=data, emitted_at=111)) for data in records
+    ]
+
+
+def build_state_message(state: dict) -> AirbyteMessage:
+    return AirbyteMessage(type=Type.STATE, state=AirbyteStateMessage(data=state))
+
+
+@pytest.mark.parametrize(
+    "records1, records2, latest_state, threshold_days, expected_error",
+    [
+        ([{"date": "2020-01-01"}, {"date": "2020-01-02"}], [], "2020-01-02", 0, None),
+        ([{"date": "2020-01-02"}, {"date": "2020-01-03"}], [], "2020-01-02", 0, "First incremental sync should produce records younger"),
+        ([{"date": "2020-01-01"}, {"date": "2020-01-02"}], [{"date": "2020-01-02"}, {"date": "2020-01-03"}], "2020-01-02", 0, None),
+        ([{"date": "2020-01-01"}], [{"date": "2020-01-01"}], "2020-01-02", 0, "Second incremental sync should produce records older"),
+        ([{"date": "2020-01-01"}], [{"date": "2020-01-01"}], "2020-01-02", 2, None),
+        ([{"date": "2020-01-02"}, {"date": "2020-01-03"}], [], "2020-01-02", 2, "First incremental sync should produce records younger"),
+        ([{"date": "2020-01-01"}], [{"date": "2020-01-02"}], "2020-01-06", 3, "Second incremental sync should produce records older"),
+    ],
+)
+def test_incremental_two_sequential_reads(records1, records2, latest_state, threshold_days, expected_error):
+    input_config = IncrementalConfig(threshold_days=threshold_days)
+    cursor_paths = {"test_stream": ["date"]}
+    catalog = ConfiguredAirbyteCatalog(
+        streams=[
+            ConfiguredAirbyteStream(
+                stream=AirbyteStream(
+                    name="test_stream",
+                    json_schema={"type": "object", "properties": {"date": {"type": "string"}}},
+                    supported_sync_modes=["full_refresh", "incremental"],
+                ),
+                sync_mode="incremental",
+                destination_sync_mode="overwrite",
+                cursor_field=["date"],
+            )
+        ]
+    )
+
+    docker_runner_mock = MagicMock()
+    docker_runner_mock.call_read.return_value = [*build_messages_from_record_data(records1), build_state_message({"date": latest_state})]
+    docker_runner_mock.call_read_with_state.return_value = build_messages_from_record_data(records2)
+
+    t = _TestIncremental()
+    if expected_error:
+        with pytest.raises(AssertionError, match=expected_error):
+            t.test_two_sequential_reads(
+                inputs=input_config,
+                connector_config=MagicMock(),
+                configured_catalog_for_incremental=catalog,
+                cursor_paths=cursor_paths,
+                docker_runner=docker_runner_mock,
+            )
+    else:
+        t.test_two_sequential_reads(
+            inputs=input_config,
+            connector_config=MagicMock(),
+            configured_catalog_for_incremental=catalog,
+            cursor_paths=cursor_paths,
+            docker_runner=docker_runner_mock,
+        )

--- a/airbyte-integrations/bases/source-acceptance-test/unit_tests/test_incremental.py
+++ b/airbyte-integrations/bases/source-acceptance-test/unit_tests/test_incremental.py
@@ -28,6 +28,7 @@ def build_state_message(state: dict) -> AirbyteMessage:
     return AirbyteMessage(type=Type.STATE, state=AirbyteStateMessage(data=state))
 
 
+@pytest.mark.parametrize("cursor_type", ["date", "string"])
 @pytest.mark.parametrize(
     "records1, records2, latest_state, threshold_days, expected_error",
     [
@@ -40,7 +41,7 @@ def build_state_message(state: dict) -> AirbyteMessage:
         ([{"date": "2020-01-01"}], [{"date": "2020-01-02"}], "2020-01-06", 3, "Second incremental sync should produce records older"),
     ],
 )
-def test_incremental_two_sequential_reads(records1, records2, latest_state, threshold_days, expected_error):
+def test_incremental_two_sequential_reads(records1, records2, latest_state, threshold_days, cursor_type, expected_error):
     input_config = IncrementalConfig(threshold_days=threshold_days)
     cursor_paths = {"test_stream": ["date"]}
     catalog = ConfiguredAirbyteCatalog(
@@ -48,7 +49,7 @@ def test_incremental_two_sequential_reads(records1, records2, latest_state, thre
             ConfiguredAirbyteStream(
                 stream=AirbyteStream(
                     name="test_stream",
-                    json_schema={"type": "object", "properties": {"date": {"type": "string"}}},
+                    json_schema={"type": "object", "properties": {"date": {"type": cursor_type}}},
                     supported_sync_modes=["full_refresh", "incremental"],
                 ),
                 sync_mode="incremental",

--- a/docs/connector-development/testing-connectors/source-acceptance-tests-reference.md
+++ b/docs/connector-development/testing-connectors/source-acceptance-tests-reference.md
@@ -185,12 +185,13 @@ This test performs two read operations on all streams which support full refresh
 
 This test verifies that all streams in the input catalog which support incremental sync can do so correctly. It does this by running two read operations: the first takes the configured catalog and config provided to this test as input. It then verifies that the sync produced a non-zero number of `RECORD` and `STATE` messages. The second read takes the same catalog and config used in the first test, plus the last `STATE` message output by the first read operation as the input state file. It verifies that either no records are produced \(since we read all records in the first sync\) or all records that produced have cursor value greater or equal to cursor value from `STATE` message. This test is performed only for streams that support incremental. Streams that do not support incremental sync are ignored. If no streams in the input catalog support incremental sync, this test is skipped.
 
-| Input | Type | Default | Note |
-| :--- | :--- | :--- | :--- |
-| `config_path` | string | `secrets/config.json` | Path to a JSON object representing a valid connector configuration |
-| `configured_catalog_path` | string | `integration_tests/configured_catalog.json` | Path to configured catalog |
-| `cursor_paths` | dict | {} | For each stream, the path of its cursor field in the output state messages. If omitted the path will be taken from the last piece of path from stream cursor\_field. |
-| `timeout_seconds` | int | 20\*60 | Test execution timeout in seconds |
+| Input                     | Type   | Default                                     | Note                                                                                                                                                                 |
+|:--------------------------|:-------|:--------------------------------------------|:---------------------------------------------------------------------------------------------------------------------------------------------------------------------|
+| `config_path`             | string | `secrets/config.json`                       | Path to a JSON object representing a valid connector configuration                                                                                                   |
+| `configured_catalog_path` | string | `integration_tests/configured_catalog.json` | Path to configured catalog                                                                                                                                           |
+| `cursor_paths`            | dict   | {}                                          | For each stream, the path of its cursor field in the output state messages. If omitted the path will be taken from the last piece of path from stream cursor\_field. |
+| `timeout_seconds`         | int    | 20\*60                                      | Test execution timeout in seconds                                                                                                                                    |
+| `threshold_days`          | int    | 0                                           | For date-based cursors, allow records to be emitted with a cursor value this number of days before the state value.                                                  |
 
 ### TestStateWithAbnormallyLargeValues
 


### PR DESCRIPTION
## What
Support running incremental source acceptance tests for sources that use a lookback window to include records older than the requested state cursor.

close #12467

## How
- Adds `threshold_days` option for incremental tests to control the amount of days to allow before the state cursor 
    - If the option is used for cursor values that are not dates or strings parseable by `dateutil.parser.parse`, a `ParserError` will be raised.
 - Adds tests for the two sequential reads SAT case

This has been confirmed to allow enabling the incremental tests for the Google Analytics connector.

## Recommended reading order
1. `source_acceptance_test/config.py`
2. `source_acceptance_test/test_incremental.py`
3. `unit_tests/test_incremental.py`

## Tests

<details><summary><strong>Unit</strong></summary>

```
 unit_tests/test_asserts.py::test_verify_records_schema ✓                                                                                                                                                                       1% ▏         
 unit_tests/test_asserts.py::test_validate_records_format[record0-configured_catalog0-False] ✓                                                                                                                                  1% ▎         
 unit_tests/test_asserts.py::test_validate_records_format[record1-configured_catalog1-False] ✓                                                                                                                                  2% ▎         
 unit_tests/test_asserts.py::test_validate_records_format[record2-configured_catalog2-False] ✓                                                                                                                                  2% ▎         
 unit_tests/test_asserts.py::test_validate_records_format[record3-configured_catalog3-False] ✓                                                                                                                                  3% ▍         
 unit_tests/test_asserts.py::test_validate_records_format[record4-configured_catalog4-True] ✓                                                                                                                                   3% ▍         
 unit_tests/test_asserts.py::test_validate_records_format[record5-configured_catalog5-False] ✓                                                                                                                                  4% ▌         
 unit_tests/test_asserts.py::test_validate_records_format[record6-configured_catalog6-True] ✓                                                                                                                                   5% ▌         
 unit_tests/test_asserts.py::test_validate_records_format[record7-configured_catalog7-False] ✓                                                                                                                                  5% ▌         
 unit_tests/test_asserts.py::test_validate_records_format[record8-configured_catalog8-False] ✓                                                                                                                                  6% ▋         
 unit_tests/test_asserts.py::test_validate_records_format[record9-configured_catalog9-True] ✓                                                                                                                                   6% ▋         
 unit_tests/test_asserts.py::test_validate_records_format[record10-configured_catalog10-True] ✓                                                                                                                                 7% ▋         
 unit_tests/test_asserts.py::test_validate_records_format[record11-configured_catalog11-True] ✓                                                                                                                                 7% ▊         
 unit_tests/test_asserts.py::test_validate_records_format[record12-configured_catalog12-True] ✓                                                                                                                                 8% ▊         
 unit_tests/test_asserts.py::test_validate_records_format[record13-configured_catalog13-False] ✓                                                                                                                                8% ▉         
 unit_tests/test_asserts.py::test_validate_records_format[record14-configured_catalog14-False] ✓                                                                                                                                9% ▉         
 unit_tests/test_asserts.py::test_validate_records_format[record15-configured_catalog15-False] ✓                                                                                                                               10% ▉         
 unit_tests/test_asserts.py::test_validate_records_format[record16-configured_catalog16-True] ✓                                                                                                                                10% █         
 unit_tests/test_asserts.py::test_validate_records_format[record17-configured_catalog17-False] ✓                                                                                                                               11% █▏        
 unit_tests/test_asserts.py::test_validate_records_format[record18-configured_catalog18-True] ✓                                                                                                                                11% █▎        
 unit_tests/test_asserts.py::test_validate_records_format[record19-configured_catalog19-True] ✓                                                                                                                                12% █▎        
 unit_tests/test_asserts.py::test_validate_records_format[record20-configured_catalog20-True] ✓                                                                                                                                12% █▎        
 unit_tests/test_asserts.py::test_validate_records_format[record21-configured_catalog21-False] ✓                                                                                                                               13% █▍        
 unit_tests/test_asserts.py::test_validate_records_format[record22-configured_catalog22-False] ✓                                                                                                                               14% █▍        
 unit_tests/test_asserts.py::test_validate_records_format[record23-configured_catalog23-True] ✓                                                                                                                                14% █▌        
 unit_tests/test_asserts.py::test_validate_records_format[record24-configured_catalog24-True] ✓                                                                                                                                15% █▌        
 unit_tests/test_asserts.py::test_validate_records_format[record25-configured_catalog25-False] ✓                                                                                                                               15% █▌        
 unit_tests/test_asserts.py::test_validate_records_format[record26-configured_catalog26-False] ✓                                                                                                                               16% █▋        
 unit_tests/test_asserts.py::test_validate_records_format[record27-configured_catalog27-True] ✓                                                                                                                                16% █▋        
 unit_tests/test_asserts.py::test_validate_records_format[record28-configured_catalog28-False] ✓                                                                                                                               17% █▊        
 unit_tests/test_asserts.py::test_validate_records_format[record29-configured_catalog29-True] ✓                                                                                                                                18% █▊        
 unit_tests/test_asserts.py::test_validate_records_format[record30-configured_catalog30-True] ✓                                                                                                                                18% █▊        
 unit_tests/test_asserts.py::test_validate_records_format[record31-configured_catalog31-True] ✓                                                                                                                                19% █▉        
 unit_tests/test_core.py::test_discovery[schema0-cursors0-True] ✓                                                                                                                                                              19% █▉        
 unit_tests/test_core.py::test_discovery[schema1-cursors1-False] ✓                                                                                                                                                             20% ██        
 unit_tests/test_core.py::test_discovery[schema2-cursors2-True] ✓                                                                                                                                                              20% ██        
 unit_tests/test_core.py::test_discovery[schema3-cursors3-True] ✓                                                                                                                                                              21% ██▏       
 unit_tests/test_core.py::test_discovery[schema4-cursors4-False] ✓                                                                                                                                                             21% ██▎       
 unit_tests/test_core.py::test_discovery[schema5-cursors5-True] ✓                                                                                                                                                              22% ██▎       
 unit_tests/test_core.py::test_ref_in_discovery_schemas[schema0-False] ✓                                                                                                                                                       23% ██▍       
 unit_tests/test_core.py::test_ref_in_discovery_schemas[schema1-True] ✓                                                                                                                                                        23% ██▍       
 unit_tests/test_core.py::test_ref_in_discovery_schemas[schema2-True] ✓                                                                                                                                                        24% ██▍       
 unit_tests/test_core.py::test_ref_in_discovery_schemas[schema3-True] ✓                                                                                                                                                        24% ██▌       
 unit_tests/test_core.py::test_ref_in_discovery_schemas[schema4-False] ✓                                                                                                                                                       25% ██▌       
 unit_tests/test_core.py::test_ref_in_discovery_schemas[schema5-True] ✓                                                                                                                                                        25% ██▋       
 unit_tests/test_core.py::test_ref_in_discovery_schemas[schema6-True] ✓                                                                                                                                                        26% ██▋       
 unit_tests/test_core.py::test_keyword_in_discovery_schemas[schema0-allOf-False] ✓                                                                                                                                             27% ██▋       
 unit_tests/test_core.py::test_keyword_in_discovery_schemas[schema1-allOf-True] ✓                                                                                                                                              27% ██▊       
 unit_tests/test_core.py::test_keyword_in_discovery_schemas[schema2-allOf-False] ✓                                                                                                                                             28% ██▊       
 unit_tests/test_core.py::test_keyword_in_discovery_schemas[schema3-allOf-True] ✓                                                                                                                                              28% ██▉       
 unit_tests/test_core.py::test_keyword_in_discovery_schemas[schema4-allOf-True] ✓                                                                                                                                              29% ██▉       
 unit_tests/test_core.py::test_keyword_in_discovery_schemas[schema5-allOf-True] ✓                                                                                                                                              29% ██▉       
 unit_tests/test_core.py::test_keyword_in_discovery_schemas[schema6-not-True] ✓                                                                                                                                                30% ███       
 unit_tests/test_core.py::test_keyword_in_discovery_schemas[schema7-not-False] ✓                                                                                                                                               31% ███▏      
 unit_tests/test_core.py::test_keyword_in_discovery_schemas[schema8-not-True] ✓                                                                                                                                                31% ███▎      
 unit_tests/test_core.py::test_read[schema0-record0-False] ✓                                                                                                                                                                   32% ███▎      
 unit_tests/test_core.py::test_read[schema1-record1-False] ✓                                                                                                                                                                   32% ███▎      
 unit_tests/test_core.py::test_read[schema2-record2-True] ✓                                                                                                                                                                    33% ███▍      
 unit_tests/test_core.py::test_read[schema3-record3-False] ✓                                                                                                                                                                   33% ███▍      
 unit_tests/test_core.py::test_read[schema4-record4-True] ✓                                                                                                                                                                    34% ███▍      
 unit_tests/test_core.py::test_read[schema5-record5-False] ✓                                                                                                                                                                   34% ███▌      
 unit_tests/test_core.py::test_validate_field_appears_at_least_once[records0-configured_catalog0-] ✓                                                                                                                           35% ███▌      
 unit_tests/test_core.py::test_validate_field_appears_at_least_once[records1-configured_catalog1-`test1` stream has `\\['/f2'\\]`] ✓                                                                                           36% ███▋      
 unit_tests/test_core.py::test_validate_field_appears_at_least_once[records2-configured_catalog2-] ✓                                                                                                                           36% ███▋      
 unit_tests/test_core.py::test_validate_field_appears_at_least_once[records3-configured_catalog3-] ✓                                                                                                                           37% ███▋      
 unit_tests/test_core.py::test_validate_field_appears_at_least_once[records4-configured_catalog4-`test1` stream has `\\['/f3/\\[\\]'\\]`] ✓                                                                                    37% ███▊      
 unit_tests/test_core.py::test_validate_field_appears_at_least_once[records5-configured_catalog5-] ✓                                                                                                                           38% ███▊      
 unit_tests/test_core.py::test_validate_field_appears_at_least_once[records6-configured_catalog6-`test1` stream has `\\['/f3/f5/\\[\\]'\\]`] ✓                                                                                 38% ███▉      
 unit_tests/test_core.py::test_validate_field_appears_at_least_once[records7-configured_catalog7-`test1` stream has `\\['/f3/f5/\\[\\]/f6', '/f3/f5/\\[\\]/f7/\\[\\]'\\]`] ✓                                                   39% ███▉      
 unit_tests/test_core.py::test_validate_field_appears_at_least_once[records8-configured_catalog8-] ✓                                                                                                                           40% ███▉      
 unit_tests/test_core.py::test_validate_field_appears_at_least_once[records9-configured_catalog9-(`test1` stream has `\\['/f3/f5/\\[\\]/f7/\\[\\]']`)|(`test2` `\\['/f8'\\]`)] ✓                                               40% ████      
 unit_tests/test_core.py::test_validate_field_appears_at_least_once[records10-configured_catalog10-] ✓                                                                                                                         41% ████▏     
 unit_tests/test_core.py::test_validate_field_appears_at_least_once[records11-configured_catalog11-] ✓                                                                                                                         41% ████▎     
 unit_tests/test_core.py::test_validate_field_appears_at_least_once[records12-configured_catalog12-`test1` stream has `\\['/f3\\(0\\)/f4', '/f3\\(1\\)/f5\\(0\\)/f6', '/f3\\(1\\)/f5\\(1\\)/f7'\\]`] ✓                         42% ████▎     
 unit_tests/test_incremental.py::test_compare_cursor_with_threshold[record_value0-state_value0-0-True] ✓                                                                                                                       42% ████▎     
 unit_tests/test_incremental.py::test_compare_cursor_with_threshold[record_value1-state_value1-0-False] ✓                                                                                                                      43% ████▍     
 unit_tests/test_incremental.py::test_compare_cursor_with_threshold[record_value2-state_value2-1-True] ✓                                                                                                                       44% ████▍     
 unit_tests/test_incremental.py::test_compare_cursor_with_threshold[record_value3-state_value3-0-True] ✓                                                                                                                       44% ████▌     
 unit_tests/test_incremental.py::test_compare_cursor_with_threshold[record_value4-state_value4-0-False] ✓                                                                                                                      45% ████▌     
 unit_tests/test_incremental.py::test_compare_cursor_with_threshold[record_value5-state_value5-1-True] ✓                                                                                                                       45% ████▌     
 unit_tests/test_incremental.py::test_compare_cursor_with_threshold[2020-10-10-2020-10-09-0-True] ✓                                                                                                                            46% ████▋     
 unit_tests/test_incremental.py::test_compare_cursor_with_threshold[2020-10-10-2020-10-11-0-False] ✓                                                                                                                           46% ████▋     
 unit_tests/test_incremental.py::test_compare_cursor_with_threshold[2020-10-10-2020-10-11-1-True] ✓                                                                                                                            47% ████▊     
 unit_tests/test_incremental.py::test_compare_cursor_with_threshold[1602288000000-1602201600000-0-True] ✓                                                                                                                      47% ████▊     
 unit_tests/test_incremental.py::test_compare_cursor_with_threshold[1602288000000-1602374400000-0-False] ✓                                                                                                                     48% ████▊     
 unit_tests/test_incremental.py::test_compare_cursor_with_threshold[1602288000000-1602374400000-1-True] ✓                                                                                                                      49% ████▉     
 unit_tests/test_incremental.py::test_compare_cursor_with_threshold[1602288000-1602201600-0-True] ✓                                                                                                                            49% ████▉     
 unit_tests/test_incremental.py::test_compare_cursor_with_threshold[1602288000-1602374400-0-False] ✓                                                                                                                           50% █████     
 unit_tests/test_incremental.py::test_compare_cursor_with_threshold[1602288000-1602374400-1-True] ✓                                                                                                                            50% █████     
 unit_tests/test_incremental.py::test_compare_cursor_with_threshold[aaa-bbb-0-False] ✓                                                                                                                                         51% █████▏    
 unit_tests/test_incremental.py::test_compare_cursor_with_threshold[bbb-aaa-0-True] ✓                                                                                                                                          51% █████▎    
 unit_tests/test_incremental.py::test_incremental_two_sequential_reads[records10-records20-2020-01-02-0-None-date] ✓                                                                                                           52% █████▎    
 unit_tests/test_incremental.py::test_incremental_two_sequential_reads[records10-records20-2020-01-02-0-None-string] ✓                                                                                                         53% █████▍    
 unit_tests/test_incremental.py::test_incremental_two_sequential_reads[records11-records21-2020-01-02-0-First incremental sync should produce records younger-date] ✓                                                          53% █████▍    
 unit_tests/test_incremental.py::test_incremental_two_sequential_reads[records11-records21-2020-01-02-0-First incremental sync should produce records younger-string] ✓                                                        54% █████▍    
 unit_tests/test_incremental.py::test_incremental_two_sequential_reads[records12-records22-2020-01-02-0-None-date] ✓                                                                                                           54% █████▌    
 unit_tests/test_incremental.py::test_incremental_two_sequential_reads[records12-records22-2020-01-02-0-None-string] ✓                                                                                                         55% █████▌    
 unit_tests/test_incremental.py::test_incremental_two_sequential_reads[records13-records23-2020-01-02-0-Second incremental sync should produce records older-date] ✓                                                           55% █████▋    
 unit_tests/test_incremental.py::test_incremental_two_sequential_reads[records13-records23-2020-01-02-0-Second incremental sync should produce records older-string] ✓                                                         56% █████▋    
 unit_tests/test_incremental.py::test_incremental_two_sequential_reads[records14-records24-2020-01-03-2-None-date] ✓                                                                                                           56% █████▋    
 unit_tests/test_incremental.py::test_incremental_two_sequential_reads[records14-records24-2020-01-03-2-None-string] ✓                                                                                                         57% █████▊    
 unit_tests/test_incremental.py::test_incremental_two_sequential_reads[records15-records25-2020-01-02-2-First incremental sync should produce records younger-date] ✓                                                          58% █████▊    
 unit_tests/test_incremental.py::test_incremental_two_sequential_reads[records15-records25-2020-01-02-2-First incremental sync should produce records younger-string] ✓                                                        58% █████▊    
 unit_tests/test_incremental.py::test_incremental_two_sequential_reads[records16-records26-2020-01-06-3-Second incremental sync should produce records older-date] ✓                                                           59% █████▉    
 unit_tests/test_incremental.py::test_incremental_two_sequential_reads[records16-records26-2020-01-06-3-Second incremental sync should produce records older-string] ✓                                                         59% █████▉    
 unit_tests/test_json_schema_helper.py::test_simple_path ✓                                                                                                                                                                     60% ██████    
 unit_tests/test_json_schema_helper.py::test_nested_path ✓                                                                                                                                                                     60% ██████▏   
 unit_tests/test_json_schema_helper.py::test_nested_path_unknown ✓                                                                                                                                                             61% ██████▏   
 unit_tests/test_json_schema_helper.py::test_absolute_path ✓                                                                                                                                                                   62% ██████▎   
 unit_tests/test_json_schema_helper.py::test_json_schema_helper_pydantic_generated ✓                                                                                                                                           62% ██████▎   
 unit_tests/test_json_schema_helper.py::test_get_object_strucutre[object0-pathes0] ✓                                                                                                                                           63% ██████▍   
 unit_tests/test_json_schema_helper.py::test_get_object_strucutre[object1-pathes1] ✓                                                                                                                                           63% ██████▍   
 unit_tests/test_json_schema_helper.py::test_get_object_strucutre[object2-pathes2] ✓                                                                                                                                           64% ██████▍   
 unit_tests/test_json_schema_helper.py::test_get_object_strucutre[object3-pathes3] ✓                                                                                                                                           64% ██████▌   
 unit_tests/test_json_schema_helper.py::test_get_object_strucutre[object4-pathes4] ✓                                                                                                                                           65% ██████▌   
 unit_tests/test_json_schema_helper.py::test_get_object_strucutre[object5-pathes5] ✓                                                                                                                                           66% ██████▋   
 unit_tests/test_json_schema_helper.py::test_get_object_strucutre[object6-pathes6] ✓                                                                                                                                           66% ██████▋   
 unit_tests/test_json_schema_helper.py::test_get_expected_schema_structure[schema0-pathes0] ✓                                                                                                                                  67% ██████▋   
 unit_tests/test_json_schema_helper.py::test_get_expected_schema_structure[schema1-pathes1] ✓                                                                                                                                  67% ██████▊   
 unit_tests/test_json_schema_helper.py::test_get_expected_schema_structure[schema2-pathes2] ✓                                                                                                                                  68% ██████▊   
 unit_tests/test_json_schema_helper.py::test_get_expected_schema_structure[schema3-pathes3] ✓                                                                                                                                  68% ██████▉   
 unit_tests/test_json_schema_helper.py::test_get_expected_schema_structure[schema4-pathes4] ✓                                                                                                                                  69% ██████▉   
 unit_tests/test_json_schema_helper.py::test_get_expected_schema_structure[schema5-pathes5] ✓                                                                                                                                  69% ██████▉   
 unit_tests/test_json_schema_helper.py::test_get_expected_schema_structure[schema6-pathes6] ✓                                                                                                                                  70% ███████   
 unit_tests/test_json_schema_helper.py::test_get_expected_schema_structure[schema7-pathes7] ✓                                                                                                                                  71% ███████▏  
 unit_tests/test_json_schema_helper.py::test_get_expected_schema_structure[schema8-pathes8] ✓                                                                                                                                  71% ███████▎  
 unit_tests/test_json_schema_helper.py::test_get_expected_schema_structure[schema9-pathes9] ✓                                                                                                                                  72% ███████▎  
 unit_tests/test_spec.py::test_ref_in_spec_schemas[connector_spec0-True] ✓                                                                                                                                                     72% ███████▎  
 unit_tests/test_spec.py::test_ref_in_spec_schemas[connector_spec1-True] ✓                                                                                                                                                     73% ███████▍  
 unit_tests/test_spec.py::test_ref_in_spec_schemas[connector_spec2-True] ✓                                                                                                                                                     73% ███████▍  
 unit_tests/test_spec.py::test_ref_in_spec_schemas[connector_spec3-True] ✓                                                                                                                                                     74% ███████▌  
 unit_tests/test_spec.py::test_ref_in_spec_schemas[connector_spec4-False] ✓                                                                                                                                                    75% ███████▌  
 unit_tests/test_spec.py::test_ref_in_spec_schemas[connector_spec5-False] ✓                                                                                                                                                    75% ███████▌  
 unit_tests/test_spec.py::test_ref_in_spec_schemas[connector_spec6-True] ✓                                                                                                                                                     76% ███████▋  
 unit_tests/test_spec.py::test_ref_in_spec_schemas[connector_spec7-True] ✓                                                                                                                                                     76% ███████▋  
 unit_tests/test_spec.py::test_ref_in_spec_schemas[connector_spec8-True] ✓                                                                                                                                                     77% ███████▊  
 unit_tests/test_spec.py::test_ref_in_spec_schemas[connector_spec9-False] ✓                                                                                                                                                    77% ███████▊  
 unit_tests/test_spec.py::test_ref_in_spec_schemas[connector_spec10-True] ✓                                                                                                                                                    78% ███████▊  
 unit_tests/test_spec.py::test_oneof_usage[all_good] ✓                                                                                                                                                                         79% ███████▉  
 unit_tests/test_spec.py::test_oneof_usage[top_level_node_is_not_of_object_type] ✓                                                                                                                                             79% ███████▉  
 unit_tests/test_spec.py::test_oneof_usage[all_oneof_options_should_have_same_constant_attribute] ✓                                                                                                                            80% ████████  
 unit_tests/test_spec.py::test_oneof_usage[one_of_item_is_not_of_type_object] ✓                                                                                                                                                80% ████████  
 unit_tests/test_spec.py::test_oneof_usage[no_common_property_for_all_oneof_subobjects] ✓                                                                                                                                      81% ████████▏ 
 unit_tests/test_spec.py::test_oneof_usage[two_common_properties_with_const_keyword] ✓                                                                                                                                         81% ████████▎ 
 unit_tests/test_spec.py::test_oneof_usage[default_keyword_in_common_property] ✓                                                                                                                                               82% ████████▎ 
 unit_tests/test_spec.py::test_validate_oauth_flow[connector_spec0-] ✓                                                                                                                                                         82% ████████▎ 
 unit_tests/test_spec.py::test_validate_oauth_flow[connector_spec1-Specified oauth fields are missed from spec schema:] ✓                                                                                                      83% ████████▍ 
 unit_tests/test_spec.py::test_validate_oauth_flow[connector_spec2-] ✓                                                                                                                                                         84% ████████▍ 
 unit_tests/test_spec.py::test_validate_oauth_flow[connector_spec3-Specified oauth fields are missed from spec schema:] ✓                                                                                                      84% ████████▌ 
 unit_tests/test_spec.py::test_validate_oauth_flow[connector_spec4-] ✓                                                                                                                                                         85% ████████▌ 
 unit_tests/test_spec.py::test_validate_oauth_flow[connector_spec5-] ✓                                                                                                                                                         85% ████████▌ 
 unit_tests/test_spec.py::test_validate_oauth_flow[connector_spec6-Specified oauth fields are missed from spec schema:] ✓                                                                                                      86% ████████▋ 
 unit_tests/test_spec.py::test_validate_oauth_flow[connector_spec7-] ✓                                                                                                                                                         86% ████████▋ 
 unit_tests/test_spec_unit.py::TestEnvAttributes.test_correct_connector_image ✓                                                                                                                                                87% ████████▊ 
 unit_tests/test_spec_unit.py::TestEnvAttributes.test_connector_image_without_env ✓                                                                                                                                            88% ████████▊ 
 unit_tests/test_spec_unit.py::TestEnvAttributes.test_docker_image_env_ne_entrypoint ✓                                                                                                                                         88% ████████▊ 
 unit_tests/test_test_full_refresh.py::test_read_with_ignore_fields[no_ignored_fields_present] ✓                                                                                                                               89% ████████▉ 
 unit_tests/test_test_full_refresh.py::test_read_with_ignore_fields[with_ignored_field] ✓                                                                                                                                      89% ████████▉ 
 unit_tests/test_test_full_refresh.py::test_read_with_ignore_fields[ignore_field_present_but_a_required_is_not] ✓                                                                                                              90% █████████ 
 unit_tests/test_utils.py::test_compare_two_records_nested_with_different_orders[obj10-obj20-True] ✓                                                                                                                           90% █████████▏
 unit_tests/test_utils.py::test_compare_two_records_nested_with_different_orders[obj11-obj21-True] ✓                                                                                                                           91% █████████▏
 unit_tests/test_utils.py::test_compare_two_records_nested_with_different_orders[obj12-obj22-False] ✓                                                                                                                          92% █████████▎
 unit_tests/test_utils.py::test_compare_two_records_nested_with_different_orders[obj13-obj23-False] ✓                                                                                                                          92% █████████▎
 unit_tests/test_utils.py::test_compare_two_records_nested_with_different_orders[obj14-obj24-True] ✓                                                                                                                           93% █████████▍
 unit_tests/test_utils.py::test_compare_two_records_nested_with_different_orders[obj15-obj25-True] ✓                                                                                                                           93% █████████▍
 unit_tests/test_utils.py::test_compare_two_records_nested_with_different_orders[obj16-obj26-False] ✓                                                                                                                          94% █████████▍
 unit_tests/test_utils.py::test_exclude_fields ✓                                                                                                                                                                               94% █████████▌
 unit_tests/test_utils.py::test_successful_logs_reading ✓                                                                                                                                                                      95% █████████▌{"type": "LOG", "log": {"level": "ERROR", "message": "Docker container was failed, code 1, error:\nSome Container Error"}}

 unit_tests/test_utils.py::test_failed_reading[interal_error] ✓                                                                                                                                                                95% █████████▋{"type": "LOG", "log": {"level": "ERROR", "message": "Docker container was failed, code 1, error:\nTraceback (most recent call last):\n  File \"<stdin>\", line 1, in <module>\nKeyError: 'bbbb'"}}

 unit_tests/test_utils.py::test_failed_reading[traceback] ✓                                                                                                                                                                    96% █████████▋{"type": "LOG", "log": {"level": "ERROR", "message": "Docker container was failed, code 1, error:\nLast Container Logs Line"}}

 unit_tests/test_utils.py::test_failed_reading[last_line] ✓                                                                                                                                                                    97% █████████▋
 unit_tests/test_utils.py::test_docker_runner[standard] ✓                                                                                                                                                                      97% █████████▊
 unit_tests/test_utils.py::test_docker_runner[waiting] ✓                                                                                                                                                                       98% █████████▊
 unit_tests/test_utils.py::test_not_found_container ✓                                                                                                                                                                          98% █████████▉
 unit_tests/test_utils.py::TestLoadYamlOrJsonPath.test_load_json ✓                                                                                                                                                             99% █████████▉
 unit_tests/test_utils.py::TestLoadYamlOrJsonPath.test_load_yaml ✓                                                                                                                                                             99% █████████▉
 unit_tests/test_utils.py::TestLoadYamlOrJsonPath.test_load_other ✓                                                                                                                                                           100% ██████████

Results (4.99s):
     177 passed
```

</details>
