### PR TITLE
🐛#12606: Changed number to Integer in source database schemas

### DIFF
--- a/airbyte-db/lib/src/main/java/io/airbyte/db/jdbc/JdbcSourceOperations.java
+++ b/airbyte-db/lib/src/main/java/io/airbyte/db/jdbc/JdbcSourceOperations.java
@@ -106,7 +106,9 @@ public class JdbcSourceOperations extends AbstractJdbcCompatibleSourceOperations
     return switch (jdbcType) {
       case BIT, BOOLEAN -> JsonSchemaType.BOOLEAN;
       case TINYINT, SMALLINT -> JsonSchemaType.NUMBER;
-      case INTEGER -> JsonSchemaType.NUMBER;
+     // case INTEGER -> JsonSchemaType.NUMBER;
+      //SWE 265 Pull Request 1
+      case INTEGER -> JsonSchemaType.INTEGER;
       case BIGINT -> JsonSchemaType.NUMBER;
       case FLOAT, DOUBLE -> JsonSchemaType.NUMBER;
       case REAL -> JsonSchemaType.NUMBER;

--- a/airbyte-db/lib/src/main/java/io/airbyte/db/jdbc/JdbcSourceOperations.java
+++ b/airbyte-db/lib/src/main/java/io/airbyte/db/jdbc/JdbcSourceOperations.java
@@ -107,7 +107,7 @@ public class JdbcSourceOperations extends AbstractJdbcCompatibleSourceOperations
       case BIT, BOOLEAN -> JsonSchemaType.BOOLEAN;
       case TINYINT, SMALLINT -> JsonSchemaType.NUMBER;
      // case INTEGER -> JsonSchemaType.NUMBER;
-      //SWE 265 Pull Request 1
+      // Changed Integer case to JsonSchemaType Integer instead of Number
       case INTEGER -> JsonSchemaType.INTEGER;
       case BIGINT -> JsonSchemaType.NUMBER;
       case FLOAT, DOUBLE -> JsonSchemaType.NUMBER;

--- a/airbyte-db/lib/src/test/java/io/airbyte/db/jdbc/TestJdbcUtils.java
+++ b/airbyte-db/lib/src/test/java/io/airbyte/db/jdbc/TestJdbcUtils.java
@@ -250,7 +250,8 @@ public class TestJdbcUtils {
         .put("bit", JsonSchemaType.BOOLEAN)
         .put("boolean", JsonSchemaType.BOOLEAN)
         .put("smallint", JsonSchemaType.NUMBER)
-        .put("int", JsonSchemaType.NUMBER)
+            // Changed JsonSchemaType.NUMBER to JsonSchemaType.INTEGER
+        .put("int", JsonSchemaType.INTEGER)
         .put("bigint", JsonSchemaType.NUMBER)
         .put("float", JsonSchemaType.NUMBER)
         .put("double", JsonSchemaType.NUMBER)

--- a/airbyte-protocol/models/src/main/java/io/airbyte/protocol/models/JsonSchemaPrimitive.java
+++ b/airbyte-protocol/models/src/main/java/io/airbyte/protocol/models/JsonSchemaPrimitive.java
@@ -11,7 +11,7 @@ public enum JsonSchemaPrimitive {
   OBJECT,
   ARRAY,
   BOOLEAN,
-  //SWE 265 Pull Request 1
+  //Created Integer in JsonSchemaPrimitive enum
   INTEGER,
   NULL;
 

--- a/airbyte-protocol/models/src/main/java/io/airbyte/protocol/models/JsonSchemaPrimitive.java
+++ b/airbyte-protocol/models/src/main/java/io/airbyte/protocol/models/JsonSchemaPrimitive.java
@@ -11,6 +11,8 @@ public enum JsonSchemaPrimitive {
   OBJECT,
   ARRAY,
   BOOLEAN,
+  //SWE 265 Pull Request 1
+  INTEGER,
   NULL;
 
 }

--- a/airbyte-protocol/models/src/main/java/io/airbyte/protocol/models/JsonSchemaType.java
+++ b/airbyte-protocol/models/src/main/java/io/airbyte/protocol/models/JsonSchemaType.java
@@ -27,6 +27,8 @@ public class JsonSchemaType {
   public static final JsonSchemaType OBJECT = JsonSchemaType.builder(JsonSchemaPrimitive.OBJECT).build();
   public static final JsonSchemaType ARRAY = JsonSchemaType.builder(JsonSchemaPrimitive.ARRAY).build();
   public static final JsonSchemaType NULL = JsonSchemaType.builder(JsonSchemaPrimitive.NULL).build();
+  //SWE 265 Pull Request 1
+  public static final JsonSchemaType INTEGER = JsonSchemaType.builder(JsonSchemaPrimitive.INTEGER).build();
   public static final JsonSchemaType STRING_BASE_64 = JsonSchemaType.builder(JsonSchemaPrimitive.STRING).withContentEncoding(BASE_64).build();
 
   private final Map<String, String> jsonSchemaTypeMap;

--- a/airbyte-protocol/models/src/main/java/io/airbyte/protocol/models/JsonSchemaType.java
+++ b/airbyte-protocol/models/src/main/java/io/airbyte/protocol/models/JsonSchemaType.java
@@ -27,7 +27,7 @@ public class JsonSchemaType {
   public static final JsonSchemaType OBJECT = JsonSchemaType.builder(JsonSchemaPrimitive.OBJECT).build();
   public static final JsonSchemaType ARRAY = JsonSchemaType.builder(JsonSchemaPrimitive.ARRAY).build();
   public static final JsonSchemaType NULL = JsonSchemaType.builder(JsonSchemaPrimitive.NULL).build();
-  //SWE 265 Pull Request 1
+  //Initialized JsonSchemaType Integer with JasonSchemaPrimitive type Integer
   public static final JsonSchemaType INTEGER = JsonSchemaType.builder(JsonSchemaPrimitive.INTEGER).build();
   public static final JsonSchemaType STRING_BASE_64 = JsonSchemaType.builder(JsonSchemaPrimitive.STRING).withContentEncoding(BASE_64).build();
 


### PR DESCRIPTION
## What
*Describe what the change is solving*
JDBC connectors are currently typing integer as number in the source catalog. As a result, numbers are casted to float / decimal type at the destination. The changes in the pull request attempts to solve this issue. The integer in the source database schemas is defined as integer in this PR.

## How
*Describe the solution*

The below three files were modified:
JdbcSourceOperations.java : 
The getJsonType() function contains a switch case which assigns a JsonSchemaType based on the JDBC type. The 
case INTEGER -> JsonSchemaType.NUMBER has been changed to case INTEGER -> JsonSchemaType.INTEGER.

JsonSchemaType.java:
A JsonSchemaType Integer was initialized with JasonSchemaPrimitive type Integer.
public static final JsonSchemaType INTEGER = JsonSchemaType.builder(JsonSchemaPrimitive.INTEGER).build();

JsonSchemaPrimitive.java:
INTEGER type was added to the Enumerator class.

## Recommended reading order
1. JsonSchemaPrimitive.java
2. JsonSchemaType.java
3. JdbcSourceOperations.java

## Tests

<details><summary><strong>Unit</strong></summary>
<img width="320" alt="Screen Shot 2022-05-10 at 9 30 23 PM" src="https://user-images.githubusercontent.com/87378498/167769896-a0f5e40e-e4d8-4991-956b-fc682ac9e7e9.png">
<img width="320" alt="Screen Shot 2022-05-10 at 9 30 34 PM" src="https://user-images.githubusercontent.com/87378498/167769898-9b883055-7059-4142-a843-645cbcba6421.png">
<img width="320" alt="Screen Shot 2022-05-10 at 9 31 45 PM" src="https://user-images.githubusercontent.com/87378498/167769900-4ebac539-92af-48dc-8a26-2ae0616968aa.png">

