### PR TITLE
AzureBlobStorage destination: enable DAT tests

### DIFF
--- a/airbyte-integrations/connectors/destination-azure-blob-storage/src/test-integration/java/io/airbyte/integrations/destination/azure_blob_storage/AzureBlobStorageCsvDestinationAcceptanceTest.java
+++ b/airbyte-integrations/connectors/destination-azure-blob-storage/src/test-integration/java/io/airbyte/integrations/destination/azure_blob_storage/AzureBlobStorageCsvDestinationAcceptanceTest.java
@@ -76,10 +76,20 @@ public class AzureBlobStorageCsvDestinationAcceptanceTest extends
         case "boolean" -> json.put(key, Boolean.valueOf(value));
         case "integer" -> json.put(key, Integer.valueOf(value));
         case "number" -> json.put(key, Double.valueOf(value));
+        case "" -> addNoTypeValue(json, key, value);
         default -> json.put(key, value);
       }
     }
     return json;
+  }
+
+  private static void addNoTypeValue(ObjectNode json, String key, String value) {
+    if (value != null && (value.matches("^\\[.*\\]$")) || value.matches("^\\{.*\\}$")) {
+      var newNode = Jsons.deserialize(value);
+      json.set(key, newNode);
+    } else {
+      json.put(key, value);
+    }
   }
 
   @Override

--- a/airbyte-integrations/connectors/destination-azure-blob-storage/src/test-integration/java/io/airbyte/integrations/destination/azure_blob_storage/AzureBlobStorageDestinationAcceptanceTest.java
+++ b/airbyte-integrations/connectors/destination-azure-blob-storage/src/test-integration/java/io/airbyte/integrations/destination/azure_blob_storage/AzureBlobStorageDestinationAcceptanceTest.java
@@ -17,6 +17,8 @@ import io.airbyte.commons.io.IOs;
 import io.airbyte.commons.jackson.MoreMappers;
 import io.airbyte.commons.json.Jsons;
 import io.airbyte.integrations.standardtest.destination.DestinationAcceptanceTest;
+import io.airbyte.integrations.standardtest.destination.comparator.AdvancedTestDataComparator;
+import io.airbyte.integrations.standardtest.destination.comparator.TestDataComparator;
 import java.nio.file.Path;
 import java.util.ArrayList;
 import java.util.List;
@@ -80,7 +82,8 @@ public abstract class AzureBlobStorageDestinationAcceptanceTest extends Destinat
     var blobItemList = StreamSupport.stream(containerClient.listBlobs().spliterator(), false)
         .collect(Collectors.toList());
     var filteredBlobList = blobItemList.stream()
-        .filter(blob -> blob.getName().contains(streamName + "/")).collect(Collectors.toList());
+        .filter(blob -> blob.getName().startsWith(streamName + "/"))
+        .toList();
     if (!filteredBlobList.isEmpty()) {
       List<AppendBlobClient> clobClientList = new ArrayList<>();
       filteredBlobList.forEach(blobItem -> {
@@ -95,6 +98,26 @@ public abstract class AzureBlobStorageDestinationAcceptanceTest extends Destinat
   }
 
   protected abstract JsonNode getFormatConfig();
+
+  @Override
+  protected TestDataComparator getTestDataComparator() {
+    return new AdvancedTestDataComparator();
+  }
+
+  @Override
+  protected boolean supportBasicDataTypeTest() {
+    return true;
+  }
+
+  @Override
+  protected boolean supportArrayDataTypeTest() {
+    return true;
+  }
+
+  @Override
+  protected boolean supportObjectDataTypeTest() {
+    return true;
+  }
 
   /**
    * This method does the following:


### PR DESCRIPTION
## What
The AzureBlobStorage destination fails the DAT tests. It means that we can't guarantee full data type compliance.

## How
Enable DAT tests and fix all errors.

## Recommended reading order
1. `x.java`