### PR TITLE
Use `host.docker.internal` for acceptance testing on macs

### DIFF
--- a/airbyte-tests/src/acceptanceTests/java/io/airbyte/test/acceptance/AcceptanceTests.java
+++ b/airbyte-tests/src/acceptanceTests/java/io/airbyte/test/acceptance/AcceptanceTests.java
@@ -174,6 +174,7 @@ public class AcceptanceTests {
   private static final boolean IS_KUBE = System.getenv().containsKey("KUBE");
   private static final boolean IS_MINIKUBE = System.getenv().containsKey("IS_MINIKUBE");
   private static final boolean IS_GKE = System.getenv().containsKey("IS_GKE");
+  private static final boolean IS_MAC = System.getProperty("os.name").startsWith("Mac");
   private static final boolean USE_EXTERNAL_DEPLOYMENT =
       System.getenv("USE_EXTERNAL_DEPLOYMENT") != null && System.getenv("USE_EXTERNAL_DEPLOYMENT").equalsIgnoreCase("true");
 
@@ -1548,10 +1549,10 @@ public class AcceptanceTests {
         // used on a single node with docker driver
         dbConfig.put("host", "host.docker.internal");
       }
-    } else {
-      // Updated from localhost to host.docker.internal (appears to be needed on newer docker desktop
-      // versions + M1 macs)
+    } else if (IS_MAC) {
       dbConfig.put("host", "host.docker.internal");
+    } else {
+      dbConfig.put("host", "localhost");
     }
 
     if (hiddenPassword) {

--- a/airbyte-tests/src/acceptanceTests/java/io/airbyte/test/acceptance/AcceptanceTests.java
+++ b/airbyte-tests/src/acceptanceTests/java/io/airbyte/test/acceptance/AcceptanceTests.java
@@ -1549,7 +1549,8 @@ public class AcceptanceTests {
         dbConfig.put("host", "host.docker.internal");
       }
     } else {
-      // Updated from localhost to host.docker.internal (appears to be needed on newer docker desktop versions + M1 macs)
+      // Updated from localhost to host.docker.internal (appears to be needed on newer docker desktop
+      // versions + M1 macs)
       dbConfig.put("host", "host.docker.internal");
     }
 

--- a/airbyte-tests/src/acceptanceTests/java/io/airbyte/test/acceptance/AcceptanceTests.java
+++ b/airbyte-tests/src/acceptanceTests/java/io/airbyte/test/acceptance/AcceptanceTests.java
@@ -1549,7 +1549,8 @@ public class AcceptanceTests {
         dbConfig.put("host", "host.docker.internal");
       }
     } else {
-      dbConfig.put("host", "localhost");
+      // Updated from localhost to host.docker.internal (appears to be needed on newer docker desktop versions + M1 macs)
+      dbConfig.put("host", "host.docker.internal");
     }
 
     if (hiddenPassword) {


### PR DESCRIPTION
This PR updates the acceptance test host on Macs to be `host.docker.internal` rather than `localhost`.  This fixes a class of problems that prevented developers (me!) from running acceptance tests locally.  This change does not effect K8s test runners.

This bug may be due to a new version of Docker Desktop + M1 Macs. 