### PR TITLE
SAT: check that connectors emit an `AirbyteTraceMessage` on failure

### DIFF
--- a/airbyte-integrations/bases/source-acceptance-test/CHANGELOG.md
+++ b/airbyte-integrations/bases/source-acceptance-test/CHANGELOG.md
@@ -1,5 +1,8 @@
 # Changelog
 
+## 0.1.52
+Add test case for AirbyteTraceMessage emission on failure. 
+
 ## 0.1.51
 - Add `threshold_days` option for lookback window support in incremental tests.
 - Update CDK to prevent warnings when encountering new `AirbyteTraceMessage`s.

--- a/airbyte-integrations/bases/source-acceptance-test/CHANGELOG.md
+++ b/airbyte-integrations/bases/source-acceptance-test/CHANGELOG.md
@@ -1,7 +1,7 @@
 # Changelog
 
 ## 0.1.52
-Add test case for AirbyteTraceMessage emission on failure. 
+Add test case for `AirbyteTraceMessage` emission on connector failure: [#12796](https://github.com/airbytehq/airbyte/pull/12796/).
 
 ## 0.1.51
 - Add `threshold_days` option for lookback window support in incremental tests.

--- a/airbyte-integrations/bases/source-acceptance-test/Dockerfile
+++ b/airbyte-integrations/bases/source-acceptance-test/Dockerfile
@@ -33,7 +33,7 @@ COPY pytest.ini setup.py ./
 COPY source_acceptance_test ./source_acceptance_test
 RUN pip install .
 
-LABEL io.airbyte.version=0.1.51
+LABEL io.airbyte.version=0.1.52
 LABEL io.airbyte.name=airbyte/source-acceptance-test
 
 ENTRYPOINT ["python", "-m", "pytest", "-p", "source_acceptance_test.plugin", "-r", "fEsx"]

--- a/airbyte-integrations/bases/source-acceptance-test/source_acceptance_test/config.py
+++ b/airbyte-integrations/bases/source-acceptance-test/source_acceptance_test/config.py
@@ -65,7 +65,7 @@ class ExpectedRecordsConfig(BaseModel):
     @validator("extra_records", always=True)
     def validate_extra_records(cls, extra_records, values):
         if "extra_fields" in values and values["extra_fields"] and extra_records:
-            raise ValueError("extra_records must by off if extra_fields enabled")
+            raise ValueError("extra_records must be off if extra_fields enabled")
         return extra_records
 
 
@@ -79,6 +79,7 @@ class BasicReadTestConfig(BaseConfig):
     validate_data_points: bool = Field(
         False, description="Set whether we need to validate that all fields in all streams contained at least one data point"
     )
+    ensure_trace_message_on_failure: bool = Field(True, description="Ensure that a trace message is emitted when the connector crashes")
     timeout_seconds: int = timeout_seconds
 
 

--- a/airbyte-integrations/bases/source-acceptance-test/source_acceptance_test/config.py
+++ b/airbyte-integrations/bases/source-acceptance-test/source_acceptance_test/config.py
@@ -79,7 +79,7 @@ class BasicReadTestConfig(BaseConfig):
     validate_data_points: bool = Field(
         False, description="Set whether we need to validate that all fields in all streams contained at least one data point"
     )
-    ensure_trace_message_on_failure: bool = Field(True, description="Ensure that a trace message is emitted when the connector crashes")
+    expect_trace_message_on_failure: bool = Field(True, description="Ensure that a trace message is emitted when the connector crashes")
     timeout_seconds: int = timeout_seconds
 
 

--- a/airbyte-integrations/bases/source-acceptance-test/source_acceptance_test/tests/test_core.py
+++ b/airbyte-integrations/bases/source-acceptance-test/source_acceptance_test/tests/test_core.py
@@ -411,8 +411,8 @@ class TestBasicRead(BaseTest):
             )
 
     def test_airbyte_trace_message_on_failure(self, connector_config, inputs: BasicReadTestConfig, docker_runner: ConnectorRunner):
-        if not inputs.ensure_trace_message_on_failure:
-            pytest.skip("Skipping `test_airbyte_trace_message_on_failure` because `inputs.ensure_trace_message_on_failure=False`")
+        if not inputs.expect_trace_message_on_failure:
+            pytest.skip("Skipping `test_airbyte_trace_message_on_failure` because `inputs.expect_trace_message_on_failure=False`")
             return
 
         invalid_configured_catalog = ConfiguredAirbyteCatalog(

--- a/airbyte-integrations/bases/source-acceptance-test/source_acceptance_test/tests/test_core.py
+++ b/airbyte-integrations/bases/source-acceptance-test/source_acceptance_test/tests/test_core.py
@@ -19,7 +19,9 @@ from airbyte_cdk.models import (
     ConfiguredAirbyteCatalog,
     ConfiguredAirbyteStream,
     ConnectorSpecification,
+    DestinationSyncMode,
     Status,
+    SyncMode,
     TraceType,
     Type,
 )
@@ -421,10 +423,10 @@ class TestBasicRead(BaseTest):
                     stream=AirbyteStream(
                         name="__AIRBYTE__stream_that_does_not_exist",
                         json_schema={"type": "object", "properties": {"f1": {"type": "string"}}},
-                        supported_sync_modes=["full_refresh"],
+                        supported_sync_modes=[SyncMode.full_refresh],
                     ),
-                    sync_mode="full_refresh",
-                    destination_sync_mode="overwrite",
+                    sync_mode=SyncMode.full_refresh,
+                    destination_sync_mode=DestinationSyncMode.overwrite,
                 )
             ]
         )

--- a/airbyte-integrations/bases/source-acceptance-test/source_acceptance_test/tests/test_core.py
+++ b/airbyte-integrations/bases/source-acceptance-test/source_acceptance_test/tests/test_core.py
@@ -410,7 +410,11 @@ class TestBasicRead(BaseTest):
                 records=records, expected_records=expected_records, flags=inputs.expect_records, detailed_logger=detailed_logger
             )
 
-    def test_airbyte_trace_message_on_failure(self, connector_config, docker_runner: ConnectorRunner):
+    def test_airbyte_trace_message_on_failure(self, connector_config, inputs: BasicReadTestConfig, docker_runner: ConnectorRunner):
+        if not inputs.ensure_trace_message_on_failure:
+            pytest.skip("Skipping `test_airbyte_trace_message_on_failure` because `inputs.ensure_trace_message_on_failure=False`")
+            return
+
         invalid_configured_catalog = ConfiguredAirbyteCatalog(
             streams=[
                 ConfiguredAirbyteStream(

--- a/airbyte-integrations/bases/source-acceptance-test/source_acceptance_test/utils/connector_runner.py
+++ b/airbyte-integrations/bases/source-acceptance-test/source_acceptance_test/utils/connector_runner.py
@@ -88,7 +88,7 @@ class ConnectorRunner:
         output = list(self.run(cmd=cmd, config=config, catalog=catalog, state=state, **kwargs))
         return output
 
-    def run(self, cmd, config=None, state=None, catalog=None, **kwargs) -> Iterable[AirbyteMessage]:
+    def run(self, cmd, config=None, state=None, catalog=None, raise_container_error: bool = True, **kwargs) -> Iterable[AirbyteMessage]:
         self._runs += 1
         volumes = self._prepare_volumes(config, state, catalog)
         logging.debug(f"Docker run {self._image}: \n{cmd}\n" f"input: {self.input_folder}\noutput: {self.output_folder}")
@@ -103,7 +103,7 @@ class ConnectorRunner:
             **kwargs,
         )
         with open(self.output_folder / "raw", "wb+") as f:
-            for line in self.read(container, command=cmd):
+            for line in self.read(container, command=cmd, with_ext=raise_container_error):
                 f.write(line.encode())
                 try:
                     yield AirbyteMessage.parse_raw(line)

--- a/airbyte-integrations/bases/source-acceptance-test/unit_tests/test_core.py
+++ b/airbyte-integrations/bases/source-acceptance-test/unit_tests/test_core.py
@@ -2,10 +2,22 @@
 # Copyright (c) 2021 Airbyte, Inc., all rights reserved.
 #
 
-from unittest.mock import MagicMock
+from unittest.mock import MagicMock, patch
 
 import pytest
-from airbyte_cdk.models import AirbyteMessage, AirbyteRecordMessage, AirbyteStream, ConfiguredAirbyteCatalog, ConfiguredAirbyteStream, Type
+from airbyte_cdk.models import (
+    AirbyteErrorTraceMessage,
+    AirbyteLogMessage,
+    AirbyteMessage,
+    AirbyteRecordMessage,
+    AirbyteStream,
+    AirbyteTraceMessage,
+    ConfiguredAirbyteCatalog,
+    ConfiguredAirbyteStream,
+    Level,
+    TraceType,
+    Type,
+)
 from source_acceptance_test.config import BasicReadTestConfig
 from source_acceptance_test.tests.test_core import TestBasicRead as _TestBasicRead
 from source_acceptance_test.tests.test_core import TestDiscovery as _TestDiscovery
@@ -142,6 +154,95 @@ def test_read(schema, record, should_fail):
             t.test_read(None, catalog, input_config, [], docker_runner_mock, MagicMock())
     else:
         t.test_read(None, catalog, input_config, [], docker_runner_mock, MagicMock())
+
+
+@pytest.mark.parametrize(
+    "output, ensure_trace_message_on_failure, should_fail",
+    [
+        (
+            [
+                AirbyteMessage(
+                    type=Type.TRACE,
+                    trace=AirbyteTraceMessage(type=TraceType.ERROR, emitted_at=111, error=AirbyteErrorTraceMessage(message="oh no")),
+                )
+            ],
+            True,
+            False,
+        ),
+        (
+            [
+                AirbyteMessage(
+                    type=Type.LOG,
+                    log=AirbyteLogMessage(level=Level.ERROR, message="oh no"),
+                ),
+                AirbyteMessage(
+                    type=Type.TRACE,
+                    trace=AirbyteTraceMessage(type=TraceType.ERROR, emitted_at=111, error=AirbyteErrorTraceMessage(message="oh no")),
+                ),
+            ],
+            True,
+            False,
+        ),
+        (
+            [
+                AirbyteMessage(
+                    type=Type.TRACE,
+                    trace=AirbyteTraceMessage(type=TraceType.ERROR, emitted_at=111, error=AirbyteErrorTraceMessage(message="oh no")),
+                ),
+                AirbyteMessage(
+                    type=Type.TRACE,
+                    trace=AirbyteTraceMessage(type=TraceType.ERROR, emitted_at=112, error=AirbyteErrorTraceMessage(message="oh no!!")),
+                ),
+            ],
+            True,
+            False,
+        ),
+        (
+            [
+                AirbyteMessage(
+                    type=Type.LOG,
+                    log=AirbyteLogMessage(level=Level.ERROR, message="oh no"),
+                )
+            ],
+            True,
+            True,
+        ),
+        ([], True, True),
+        (
+            [
+                AirbyteMessage(
+                    type=Type.TRACE,
+                    trace=AirbyteTraceMessage(type=TraceType.ERROR, emitted_at=111, error=AirbyteErrorTraceMessage(message="oh no")),
+                )
+            ],
+            False,
+            False,
+        ),
+        (
+            [
+                AirbyteMessage(
+                    type=Type.LOG,
+                    log=AirbyteLogMessage(level=Level.ERROR, message="oh no"),
+                )
+            ],
+            False,
+            False,
+        ),
+        ([], False, False),
+    ],
+)
+def test_airbyte_trace_message_on_failure(output, ensure_trace_message_on_failure, should_fail):
+    t = _TestBasicRead()
+    input_config = BasicReadTestConfig(ensure_trace_message_on_failure=ensure_trace_message_on_failure)
+    docker_runner_mock = MagicMock()
+    docker_runner_mock.call_read.return_value = output
+
+    with patch.object(pytest, "skip", return_value=None):
+        if should_fail:
+            with pytest.raises(AssertionError, match="Connector should emit at least one error trace message"):
+                t.test_airbyte_trace_message_on_failure(None, input_config, docker_runner_mock)
+        else:
+            t.test_airbyte_trace_message_on_failure(None, input_config, docker_runner_mock)
 
 
 @pytest.mark.parametrize(

--- a/airbyte-integrations/bases/source-acceptance-test/unit_tests/test_core.py
+++ b/airbyte-integrations/bases/source-acceptance-test/unit_tests/test_core.py
@@ -157,7 +157,7 @@ def test_read(schema, record, should_fail):
 
 
 @pytest.mark.parametrize(
-    "output, ensure_trace_message_on_failure, should_fail",
+    "output, expect_trace_message_on_failure, should_fail",
     [
         (
             [
@@ -231,9 +231,9 @@ def test_read(schema, record, should_fail):
         ([], False, False),
     ],
 )
-def test_airbyte_trace_message_on_failure(output, ensure_trace_message_on_failure, should_fail):
+def test_airbyte_trace_message_on_failure(output, expect_trace_message_on_failure, should_fail):
     t = _TestBasicRead()
-    input_config = BasicReadTestConfig(ensure_trace_message_on_failure=ensure_trace_message_on_failure)
+    input_config = BasicReadTestConfig(expect_trace_message_on_failure=expect_trace_message_on_failure)
     docker_runner_mock = MagicMock()
     docker_runner_mock.call_read.return_value = output
 

--- a/docs/connector-development/testing-connectors/source-acceptance-tests-reference.md
+++ b/docs/connector-development/testing-connectors/source-acceptance-tests-reference.md
@@ -125,19 +125,20 @@ Verifies when a discover operation is run on the connector using the given confi
 Configuring all streams in the input catalog to full refresh mode verifies that a read operation produces some RECORD messages. Each stream should have some data, if you can't guarantee this for particular streams - add them to the `empty_streams` list.
 Set `validate_data_points=True` if possible. This validation is going to be enabled by default and won't be configurable in future releases.
 
-| Input | Type | Default | Note |
-| :--- | :--- | :--- | :--- |
-| `config_path` | string | `secrets/config.json` | Path to a JSON object representing a valid connector configuration |
-| `configured_catalog_path` | string | `integration_tests/configured_catalog.json` | Path to configured catalog |
-| `empty_streams` | array | \[\] | List of streams that might be empty |
-| `validate_schema` | boolean | True | Verify that structure and types of records matches the schema from discovery command |
-| `validate_data_points` | boolean | False | Validate that all fields in all streams contained at least one data point |
-| `timeout_seconds` | int | 5\*60 | Test execution timeout in seconds |
-| `expect_records` | object | None | Compare produced records with expected records, see details below |
-| `expect_records.path` | string |  | File with expected records |
-| `expect_records.extra_fields` | boolean | False | Allow output records to have other fields i.e: expected records are a subset |
-| `expect_records.exact_order` | boolean | False | Ensure  that records produced in exact same order |
-| `expect_records.extra_records` | boolean | True | Allow connector to produce extra records, but still enforce all records from the expected file to be produced |
+| Input                             | Type | Default | Note |
+|:----------------------------------| :--- | :--- | :--- |
+| `config_path`                     | string | `secrets/config.json` | Path to a JSON object representing a valid connector configuration |
+| `configured_catalog_path`         | string | `integration_tests/configured_catalog.json` | Path to configured catalog |
+| `empty_streams`                   | array | \[\] | List of streams that might be empty |
+| `validate_schema`                 | boolean | True | Verify that structure and types of records matches the schema from discovery command |
+| `validate_data_points`            | boolean | False | Validate that all fields in all streams contained at least one data point |
+| `timeout_seconds`                 | int | 5\*60 | Test execution timeout in seconds |
+| `expect_trace_message_on_failure` | boolean | True | Ensure that a trace message is emitted when the connector crashes |
+| `expect_records`                  | object | None | Compare produced records with expected records, see details below |
+| `expect_records.path`             | string |  | File with expected records |
+| `expect_records.extra_fields`     | boolean | False | Allow output records to have other fields i.e: expected records are a subset |
+| `expect_records.exact_order`      | boolean | False | Ensure  that records produced in exact same order |
+| `expect_records.extra_records`    | boolean | True | Allow connector to produce extra records, but still enforce all records from the expected file to be produced |
 
 `expect_records` is a nested configuration, if omitted - the part of the test responsible for record matching will be skipped. Due to the fact that we can't identify records without primary keys, only the following flag combinations are supported:
 


### PR DESCRIPTION
## What
Verify that connectors emit at least one `AirbyteTraceMessage` on crash. 

closes #12473

## How
- Call the connector's read method with an invalid configured catalog (specifically with a bogus stream name)
- Check that an `AirbyteTraceMessage` is present

## Recommended reading order
1. `tests/test_core.py`
2. `unit_tests/test_core.py`
3. other files

## 🚨 User Impact 🚨
Connectors will no longer pass the SAT if they do not emit an `AirbyteTraceMessage` on generic failures. For most cases, this should just mean updating to the latest version of the CDK (>= 0.1.56).

If the connector really shouldn't emit an airbyte trace message, it can opt out of the test by setting `expect_trace_message_on_failure=False` on the `basic_read` test config.

## Tests

<details><summary><strong>Unit</strong></summary>

```
 unit_tests/test_asserts.py::test_verify_records_schema ✓                                                                                                                                                                     1% ▏         
 unit_tests/test_asserts.py::test_validate_records_format[record0-configured_catalog0-False] ✓                                                                                                                                1% ▎         
 unit_tests/test_asserts.py::test_validate_records_format[record1-configured_catalog1-False] ✓                                                                                                                                2% ▎         
 unit_tests/test_asserts.py::test_validate_records_format[record2-configured_catalog2-False] ✓                                                                                                                                2% ▎         
 unit_tests/test_asserts.py::test_validate_records_format[record3-configured_catalog3-False] ✓                                                                                                                                3% ▍         
 unit_tests/test_asserts.py::test_validate_records_format[record4-configured_catalog4-True] ✓                                                                                                                                 3% ▍         
 unit_tests/test_asserts.py::test_validate_records_format[record5-configured_catalog5-False] ✓                                                                                                                                4% ▍         
 unit_tests/test_asserts.py::test_validate_records_format[record6-configured_catalog6-True] ✓                                                                                                                                 4% ▌         
 unit_tests/test_asserts.py::test_validate_records_format[record7-configured_catalog7-False] ✓                                                                                                                                5% ▌         
 unit_tests/test_asserts.py::test_validate_records_format[record8-configured_catalog8-False] ✓                                                                                                                                5% ▋         
 unit_tests/test_asserts.py::test_validate_records_format[record9-configured_catalog9-True] ✓                                                                                                                                 6% ▋         
 unit_tests/test_asserts.py::test_validate_records_format[record10-configured_catalog10-True] ✓                                                                                                                               6% ▋         
 unit_tests/test_asserts.py::test_validate_records_format[record11-configured_catalog11-True] ✓                                                                                                                               7% ▊         
 unit_tests/test_asserts.py::test_validate_records_format[record12-configured_catalog12-True] ✓                                                                                                                               8% ▊         
 unit_tests/test_asserts.py::test_validate_records_format[record13-configured_catalog13-False] ✓                                                                                                                              8% ▊         
 unit_tests/test_asserts.py::test_validate_records_format[record14-configured_catalog14-False] ✓                                                                                                                              9% ▉         
 unit_tests/test_asserts.py::test_validate_records_format[record15-configured_catalog15-False] ✓                                                                                                                              9% ▉         
 unit_tests/test_asserts.py::test_validate_records_format[record16-configured_catalog16-True] ✓                                                                                                                              10% █         
 unit_tests/test_asserts.py::test_validate_records_format[record17-configured_catalog17-False] ✓                                                                                                                             10% █         
 unit_tests/test_asserts.py::test_validate_records_format[record18-configured_catalog18-True] ✓                                                                                                                              11% █▏        
 unit_tests/test_asserts.py::test_validate_records_format[record19-configured_catalog19-True] ✓                                                                                                                              11% █▎        
 unit_tests/test_asserts.py::test_validate_records_format[record20-configured_catalog20-True] ✓                                                                                                                              12% █▎        
 unit_tests/test_asserts.py::test_validate_records_format[record21-configured_catalog21-False] ✓                                                                                                                             12% █▎        
 unit_tests/test_asserts.py::test_validate_records_format[record22-configured_catalog22-False] ✓                                                                                                                             13% █▍        
 unit_tests/test_asserts.py::test_validate_records_format[record23-configured_catalog23-True] ✓                                                                                                                              14% █▍        
 unit_tests/test_asserts.py::test_validate_records_format[record24-configured_catalog24-True] ✓                                                                                                                              14% █▌        
 unit_tests/test_asserts.py::test_validate_records_format[record25-configured_catalog25-False] ✓                                                                                                                             15% █▌        
 unit_tests/test_asserts.py::test_validate_records_format[record26-configured_catalog26-False] ✓                                                                                                                             15% █▌        
 unit_tests/test_asserts.py::test_validate_records_format[record27-configured_catalog27-True] ✓                                                                                                                              16% █▋        
 unit_tests/test_asserts.py::test_validate_records_format[record28-configured_catalog28-False] ✓                                                                                                                             16% █▋        
 unit_tests/test_asserts.py::test_validate_records_format[record29-configured_catalog29-True] ✓                                                                                                                              17% █▋        
 unit_tests/test_asserts.py::test_validate_records_format[record30-configured_catalog30-True] ✓                                                                                                                              17% █▊        
 unit_tests/test_asserts.py::test_validate_records_format[record31-configured_catalog31-True] ✓                                                                                                                              18% █▊        
 unit_tests/test_core.py::test_discovery[schema0-cursors0-True] ✓                                                                                                                                                            18% █▉        
 unit_tests/test_core.py::test_discovery[schema1-cursors1-False] ✓                                                                                                                                                           19% █▉        
 unit_tests/test_core.py::test_discovery[schema2-cursors2-True] ✓                                                                                                                                                            19% █▉        
 unit_tests/test_core.py::test_discovery[schema3-cursors3-True] ✓                                                                                                                                                            20% ██        
 unit_tests/test_core.py::test_discovery[schema4-cursors4-False] ✓                                                                                                                                                           21% ██▏       
 unit_tests/test_core.py::test_discovery[schema5-cursors5-True] ✓                                                                                                                                                            21% ██▎       
 unit_tests/test_core.py::test_ref_in_discovery_schemas[schema0-False] ✓                                                                                                                                                     22% ██▎       
 unit_tests/test_core.py::test_ref_in_discovery_schemas[schema1-True] ✓                                                                                                                                                      22% ██▎       
 unit_tests/test_core.py::test_ref_in_discovery_schemas[schema2-True] ✓                                                                                                                                                      23% ██▍       
 unit_tests/test_core.py::test_ref_in_discovery_schemas[schema3-True] ✓                                                                                                                                                      23% ██▍       
 unit_tests/test_core.py::test_ref_in_discovery_schemas[schema4-False] ✓                                                                                                                                                     24% ██▍       
 unit_tests/test_core.py::test_ref_in_discovery_schemas[schema5-True] ✓                                                                                                                                                      24% ██▌       
 unit_tests/test_core.py::test_ref_in_discovery_schemas[schema6-True] ✓                                                                                                                                                      25% ██▌       
 unit_tests/test_core.py::test_keyword_in_discovery_schemas[schema0-allOf-False] ✓                                                                                                                                           25% ██▋       
 unit_tests/test_core.py::test_keyword_in_discovery_schemas[schema1-allOf-True] ✓                                                                                                                                            26% ██▋       
 unit_tests/test_core.py::test_keyword_in_discovery_schemas[schema2-allOf-False] ✓                                                                                                                                           26% ██▋       
 unit_tests/test_core.py::test_keyword_in_discovery_schemas[schema3-allOf-True] ✓                                                                                                                                            27% ██▊       
 unit_tests/test_core.py::test_keyword_in_discovery_schemas[schema4-allOf-True] ✓                                                                                                                                            28% ██▊       
 unit_tests/test_core.py::test_keyword_in_discovery_schemas[schema5-allOf-True] ✓                                                                                                                                            28% ██▊       
 unit_tests/test_core.py::test_keyword_in_discovery_schemas[schema6-not-True] ✓                                                                                                                                              29% ██▉       
 unit_tests/test_core.py::test_keyword_in_discovery_schemas[schema7-not-False] ✓                                                                                                                                             29% ██▉       
 unit_tests/test_core.py::test_keyword_in_discovery_schemas[schema8-not-True] ✓                                                                                                                                              30% ███       
 unit_tests/test_core.py::test_read[schema0-record0-False] ✓                                                                                                                                                                 30% ███       
 unit_tests/test_core.py::test_read[schema1-record1-False] ✓                                                                                                                                                                 31% ███▏      
 unit_tests/test_core.py::test_read[schema2-record2-True] ✓                                                                                                                                                                  31% ███▎      
 unit_tests/test_core.py::test_read[schema3-record3-False] ✓                                                                                                                                                                 32% ███▎      
 unit_tests/test_core.py::test_read[schema4-record4-True] ✓                                                                                                                                                                  32% ███▎      
 unit_tests/test_core.py::test_read[schema5-record5-False] ✓                                                                                                                                                                 33% ███▍      
 unit_tests/test_core.py::test_airbyte_trace_message_on_failure[output0-True-False] ✓                                                                                                                                        34% ███▍      
 unit_tests/test_core.py::test_airbyte_trace_message_on_failure[output1-True-False] ✓                                                                                                                                        34% ███▌      
 unit_tests/test_core.py::test_airbyte_trace_message_on_failure[output2-True-False] ✓                                                                                                                                        35% ███▌      
 unit_tests/test_core.py::test_airbyte_trace_message_on_failure[output3-True-True] ✓                                                                                                                                         35% ███▌      
 unit_tests/test_core.py::test_airbyte_trace_message_on_failure[output4-True-True] ✓                                                                                                                                         36% ███▋      
 unit_tests/test_core.py::test_airbyte_trace_message_on_failure[output5-False-False] ✓                                                                                                                                       36% ███▋      
 unit_tests/test_core.py::test_airbyte_trace_message_on_failure[output6-False-False] ✓                                                                                                                                       37% ███▋      
 unit_tests/test_core.py::test_airbyte_trace_message_on_failure[output7-False-False] ✓                                                                                                                                       37% ███▊      
 unit_tests/test_core.py::test_validate_field_appears_at_least_once[records0-configured_catalog0-] ✓                                                                                                                         38% ███▊      
 unit_tests/test_core.py::test_validate_field_appears_at_least_once[records1-configured_catalog1-`test1` stream has `\\['/f2'\\]`] ✓                                                                                         38% ███▉      
 unit_tests/test_core.py::test_validate_field_appears_at_least_once[records2-configured_catalog2-] ✓                                                                                                                         39% ███▉      
 unit_tests/test_core.py::test_validate_field_appears_at_least_once[records3-configured_catalog3-] ✓                                                                                                                         39% ███▉      
 unit_tests/test_core.py::test_validate_field_appears_at_least_once[records4-configured_catalog4-`test1` stream has `\\['/f3/\\[\\]'\\]`] ✓                                                                                  40% ████      
 unit_tests/test_core.py::test_validate_field_appears_at_least_once[records5-configured_catalog5-] ✓                                                                                                                         41% ████▏     
 unit_tests/test_core.py::test_validate_field_appears_at_least_once[records6-configured_catalog6-`test1` stream has `\\['/f3/f5/\\[\\]'\\]`] ✓                                                                               41% ████▎     
 unit_tests/test_core.py::test_validate_field_appears_at_least_once[records7-configured_catalog7-`test1` stream has `\\['/f3/f5/\\[\\]/f6', '/f3/f5/\\[\\]/f7/\\[\\]'\\]`] ✓                                                 42% ████▎     
 unit_tests/test_core.py::test_validate_field_appears_at_least_once[records8-configured_catalog8-] ✓                                                                                                                         42% ████▎     
 unit_tests/test_core.py::test_validate_field_appears_at_least_once[records9-configured_catalog9-(`test1` stream has `\\['/f3/f5/\\[\\]/f7/\\[\\]']`)|(`test2` `\\['/f8'\\]`)] ✓                                             43% ████▍     
 unit_tests/test_core.py::test_validate_field_appears_at_least_once[records10-configured_catalog10-] ✓                                                                                                                       43% ████▍     
 unit_tests/test_core.py::test_validate_field_appears_at_least_once[records11-configured_catalog11-] ✓                                                                                                                       44% ████▍     
 unit_tests/test_core.py::test_validate_field_appears_at_least_once[records12-configured_catalog12-`test1` stream has `\\['/f3\\(0\\)/f4', '/f3\\(1\\)/f5\\(0\\)/f6', '/f3\\(1\\)/f5\\(1\\)/f7'\\]`] ✓                       44% ████▌     
 unit_tests/test_incremental.py::test_compare_cursor_with_threshold[record_value0-state_value0-0-True] ✓                                                                                                                     45% ████▌     
 unit_tests/test_incremental.py::test_compare_cursor_with_threshold[record_value1-state_value1-0-False] ✓                                                                                                                    45% ████▋     
 unit_tests/test_incremental.py::test_compare_cursor_with_threshold[record_value2-state_value2-1-True] ✓                                                                                                                     46% ████▋     
 unit_tests/test_incremental.py::test_compare_cursor_with_threshold[record_value3-state_value3-0-True] ✓                                                                                                                     46% ████▋     
 unit_tests/test_incremental.py::test_compare_cursor_with_threshold[record_value4-state_value4-0-False] ✓                                                                                                                    47% ████▊     
 unit_tests/test_incremental.py::test_compare_cursor_with_threshold[record_value5-state_value5-1-True] ✓                                                                                                                     48% ████▊     
 unit_tests/test_incremental.py::test_compare_cursor_with_threshold[2020-10-10-2020-10-09-0-True] ✓                                                                                                                          48% ████▊     
 unit_tests/test_incremental.py::test_compare_cursor_with_threshold[2020-10-10-2020-10-11-0-False] ✓                                                                                                                         49% ████▉     
 unit_tests/test_incremental.py::test_compare_cursor_with_threshold[2020-10-10-2020-10-11-1-True] ✓                                                                                                                          49% ████▉     
 unit_tests/test_incremental.py::test_compare_cursor_with_threshold[1602288000000-1602201600000-0-True] ✓                                                                                                                    50% █████     
 unit_tests/test_incremental.py::test_compare_cursor_with_threshold[1602288000000-1602374400000-0-False] ✓                                                                                                                   50% █████     
 unit_tests/test_incremental.py::test_compare_cursor_with_threshold[1602288000000-1602374400000-1-True] ✓                                                                                                                    51% █████▏    
 unit_tests/test_incremental.py::test_compare_cursor_with_threshold[1602288000-1602201600-0-True] ✓                                                                                                                          51% █████▎    
 unit_tests/test_incremental.py::test_compare_cursor_with_threshold[1602288000-1602374400-0-False] ✓                                                                                                                         52% █████▎    
 unit_tests/test_incremental.py::test_compare_cursor_with_threshold[1602288000-1602374400-1-True] ✓                                                                                                                          52% █████▎    
 unit_tests/test_incremental.py::test_compare_cursor_with_threshold[aaa-bbb-0-False] ✓                                                                                                                                       53% █████▍    
 unit_tests/test_incremental.py::test_compare_cursor_with_threshold[bbb-aaa-0-True] ✓                                                                                                                                        54% █████▍    
 unit_tests/test_incremental.py::test_incremental_two_sequential_reads[records10-records20-2020-01-02-0-None-date] ✓                                                                                                         54% █████▌    
 unit_tests/test_incremental.py::test_incremental_two_sequential_reads[records10-records20-2020-01-02-0-None-string] ✓                                                                                                       55% █████▌    
 unit_tests/test_incremental.py::test_incremental_two_sequential_reads[records11-records21-2020-01-02-0-First incremental sync should produce records younger-date] ✓                                                        55% █████▌    
 unit_tests/test_incremental.py::test_incremental_two_sequential_reads[records11-records21-2020-01-02-0-First incremental sync should produce records younger-string] ✓                                                      56% █████▋    
 unit_tests/test_incremental.py::test_incremental_two_sequential_reads[records12-records22-2020-01-02-0-None-date] ✓                                                                                                         56% █████▋    
 unit_tests/test_incremental.py::test_incremental_two_sequential_reads[records12-records22-2020-01-02-0-None-string] ✓                                                                                                       57% █████▋    
 unit_tests/test_incremental.py::test_incremental_two_sequential_reads[records13-records23-2020-01-02-0-Second incremental sync should produce records older-date] ✓                                                         57% █████▊    
 unit_tests/test_incremental.py::test_incremental_two_sequential_reads[records13-records23-2020-01-02-0-Second incremental sync should produce records older-string] ✓                                                       58% █████▊    
 unit_tests/test_incremental.py::test_incremental_two_sequential_reads[records14-records24-2020-01-03-2-None-date] ✓                                                                                                         58% █████▉    
 unit_tests/test_incremental.py::test_incremental_two_sequential_reads[records14-records24-2020-01-03-2-None-string] ✓                                                                                                       59% █████▉    
 unit_tests/test_incremental.py::test_incremental_two_sequential_reads[records15-records25-2020-01-02-2-First incremental sync should produce records younger-date] ✓                                                        59% █████▉    
 unit_tests/test_incremental.py::test_incremental_two_sequential_reads[records15-records25-2020-01-02-2-First incremental sync should produce records younger-string] ✓                                                      60% ██████    
 unit_tests/test_incremental.py::test_incremental_two_sequential_reads[records16-records26-2020-01-06-3-Second incremental sync should produce records older-date] ✓                                                         61% ██████▏   
 unit_tests/test_incremental.py::test_incremental_two_sequential_reads[records16-records26-2020-01-06-3-Second incremental sync should produce records older-string] ✓                                                       61% ██████▎   
 unit_tests/test_json_schema_helper.py::test_simple_path ✓                                                                                                                                                                   62% ██████▎   
 unit_tests/test_json_schema_helper.py::test_nested_path ✓                                                                                                                                                                   62% ██████▎   
 unit_tests/test_json_schema_helper.py::test_nested_path_unknown ✓                                                                                                                                                           63% ██████▍   
 unit_tests/test_json_schema_helper.py::test_absolute_path ✓                                                                                                                                                                 63% ██████▍   
 unit_tests/test_json_schema_helper.py::test_json_schema_helper_pydantic_generated ✓                                                                                                                                         64% ██████▍   
 unit_tests/test_json_schema_helper.py::test_get_object_strucutre[object0-pathes0] ✓                                                                                                                                         64% ██████▌   
 unit_tests/test_json_schema_helper.py::test_get_object_strucutre[object1-pathes1] ✓                                                                                                                                         65% ██████▌   
 unit_tests/test_json_schema_helper.py::test_get_object_strucutre[object2-pathes2] ✓                                                                                                                                         65% ██████▋   
 unit_tests/test_json_schema_helper.py::test_get_object_strucutre[object3-pathes3] ✓                                                                                                                                         66% ██████▋   
 unit_tests/test_json_schema_helper.py::test_get_object_strucutre[object4-pathes4] ✓                                                                                                                                         66% ██████▋   
 unit_tests/test_json_schema_helper.py::test_get_object_strucutre[object5-pathes5] ✓                                                                                                                                         67% ██████▊   
 unit_tests/test_json_schema_helper.py::test_get_object_strucutre[object6-pathes6] ✓                                                                                                                                         68% ██████▊   
 unit_tests/test_json_schema_helper.py::test_get_expected_schema_structure[schema0-pathes0] ✓                                                                                                                                68% ██████▊   
 unit_tests/test_json_schema_helper.py::test_get_expected_schema_structure[schema1-pathes1] ✓                                                                                                                                69% ██████▉   
 unit_tests/test_json_schema_helper.py::test_get_expected_schema_structure[schema2-pathes2] ✓                                                                                                                                69% ██████▉   
 unit_tests/test_json_schema_helper.py::test_get_expected_schema_structure[schema3-pathes3] ✓                                                                                                                                70% ███████   
 unit_tests/test_json_schema_helper.py::test_get_expected_schema_structure[schema4-pathes4] ✓                                                                                                                                70% ███████   
 unit_tests/test_json_schema_helper.py::test_get_expected_schema_structure[schema5-pathes5] ✓                                                                                                                                71% ███████▏  
 unit_tests/test_json_schema_helper.py::test_get_expected_schema_structure[schema6-pathes6] ✓                                                                                                                                71% ███████▎  
 unit_tests/test_json_schema_helper.py::test_get_expected_schema_structure[schema7-pathes7] ✓                                                                                                                                72% ███████▎  
 unit_tests/test_json_schema_helper.py::test_get_expected_schema_structure[schema8-pathes8] ✓                                                                                                                                72% ███████▎  
 unit_tests/test_json_schema_helper.py::test_get_expected_schema_structure[schema9-pathes9] ✓                                                                                                                                73% ███████▍  
 unit_tests/test_spec.py::test_ref_in_spec_schemas[connector_spec0-True] ✓                                                                                                                                                   74% ███████▍  
 unit_tests/test_spec.py::test_ref_in_spec_schemas[connector_spec1-True] ✓                                                                                                                                                   74% ███████▌  
 unit_tests/test_spec.py::test_ref_in_spec_schemas[connector_spec2-True] ✓                                                                                                                                                   75% ███████▌  
 unit_tests/test_spec.py::test_ref_in_spec_schemas[connector_spec3-True] ✓                                                                                                                                                   75% ███████▌  
 unit_tests/test_spec.py::test_ref_in_spec_schemas[connector_spec4-False] ✓                                                                                                                                                  76% ███████▋  
 unit_tests/test_spec.py::test_ref_in_spec_schemas[connector_spec5-False] ✓                                                                                                                                                  76% ███████▋  
 unit_tests/test_spec.py::test_ref_in_spec_schemas[connector_spec6-True] ✓                                                                                                                                                   77% ███████▋  
 unit_tests/test_spec.py::test_ref_in_spec_schemas[connector_spec7-True] ✓                                                                                                                                                   77% ███████▊  
 unit_tests/test_spec.py::test_ref_in_spec_schemas[connector_spec8-True] ✓                                                                                                                                                   78% ███████▊  
 unit_tests/test_spec.py::test_ref_in_spec_schemas[connector_spec9-False] ✓                                                                                                                                                  78% ███████▉  
 unit_tests/test_spec.py::test_ref_in_spec_schemas[connector_spec10-True] ✓                                                                                                                                                  79% ███████▉  
 unit_tests/test_spec.py::test_oneof_usage[all_good] ✓                                                                                                                                                                       79% ███████▉  
 unit_tests/test_spec.py::test_oneof_usage[top_level_node_is_not_of_object_type] ✓                                                                                                                                           80% ████████  
 unit_tests/test_spec.py::test_oneof_usage[all_oneof_options_should_have_same_constant_attribute] ✓                                                                                                                          81% ████████▏ 
 unit_tests/test_spec.py::test_oneof_usage[one_of_item_is_not_of_type_object] ✓                                                                                                                                              81% ████████▎ 
 unit_tests/test_spec.py::test_oneof_usage[no_common_property_for_all_oneof_subobjects] ✓                                                                                                                                    82% ████████▎ 
 unit_tests/test_spec.py::test_oneof_usage[two_common_properties_with_const_keyword] ✓                                                                                                                                       82% ████████▎ 
 unit_tests/test_spec.py::test_oneof_usage[default_keyword_in_common_property] ✓                                                                                                                                             83% ████████▍ 
 unit_tests/test_spec.py::test_validate_oauth_flow[connector_spec0-] ✓                                                                                                                                                       83% ████████▍ 
 unit_tests/test_spec.py::test_validate_oauth_flow[connector_spec1-Specified oauth fields are missed from spec schema:] ✓                                                                                                    84% ████████▍ 
 unit_tests/test_spec.py::test_validate_oauth_flow[connector_spec2-] ✓                                                                                                                                                       84% ████████▌ 
 unit_tests/test_spec.py::test_validate_oauth_flow[connector_spec3-Specified oauth fields are missed from spec schema:] ✓                                                                                                    85% ████████▌ 
 unit_tests/test_spec.py::test_validate_oauth_flow[connector_spec4-] ✓                                                                                                                                                       85% ████████▋ 
 unit_tests/test_spec.py::test_validate_oauth_flow[connector_spec5-] ✓                                                                                                                                                       86% ████████▋ 
 unit_tests/test_spec.py::test_validate_oauth_flow[connector_spec6-Specified oauth fields are missed from spec schema:] ✓                                                                                                    86% ████████▋ 
 unit_tests/test_spec.py::test_validate_oauth_flow[connector_spec7-] ✓                                                                                                                                                       87% ████████▊ 
 unit_tests/test_spec_unit.py::TestEnvAttributes.test_correct_connector_image ✓                                                                                                                                              88% ████████▊ 
 unit_tests/test_spec_unit.py::TestEnvAttributes.test_connector_image_without_env ✓                                                                                                                                          88% ████████▊ 
 unit_tests/test_spec_unit.py::TestEnvAttributes.test_docker_image_env_ne_entrypoint ✓                                                                                                                                       89% ████████▉ 
 unit_tests/test_test_full_refresh.py::test_read_with_ignore_fields[no_ignored_fields_present] ✓                                                                                                                             89% ████████▉ 
 unit_tests/test_test_full_refresh.py::test_read_with_ignore_fields[with_ignored_field] ✓                                                                                                                                    90% █████████ 
 unit_tests/test_test_full_refresh.py::test_read_with_ignore_fields[ignore_field_present_but_a_required_is_not] ✓                                                                                                            90% █████████ 
 unit_tests/test_utils.py::test_compare_two_records_nested_with_different_orders[obj10-obj20-True] ✓                                                                                                                         91% █████████▏
 unit_tests/test_utils.py::test_compare_two_records_nested_with_different_orders[obj11-obj21-True] ✓                                                                                                                         91% █████████▎
 unit_tests/test_utils.py::test_compare_two_records_nested_with_different_orders[obj12-obj22-False] ✓                                                                                                                        92% █████████▎
 unit_tests/test_utils.py::test_compare_two_records_nested_with_different_orders[obj13-obj23-False] ✓                                                                                                                        92% █████████▎
 unit_tests/test_utils.py::test_compare_two_records_nested_with_different_orders[obj14-obj24-True] ✓                                                                                                                         93% █████████▍
 unit_tests/test_utils.py::test_compare_two_records_nested_with_different_orders[obj15-obj25-True] ✓                                                                                                                         94% █████████▍
 unit_tests/test_utils.py::test_compare_two_records_nested_with_different_orders[obj16-obj26-False] ✓                                                                                                                        94% █████████▌
 unit_tests/test_utils.py::test_exclude_fields ✓                                                                                                                                                                             95% █████████▌
 unit_tests/test_utils.py::test_successful_logs_reading ✓                                                                                                                                                                    95% █████████▌{"type": "LOG", "log": {"level": "ERROR", "message": "Docker container was failed, code 1, error:\nSome Container Error"}}

 unit_tests/test_utils.py::test_failed_reading[interal_error] ✓                                                                                                                                                              96% █████████▋{"type": "LOG", "log": {"level": "ERROR", "message": "Docker container was failed, code 1, error:\nTraceback (most recent call last):\n  File \"<stdin>\", line 1, in <module>\nKeyError: 'bbbb'"}}

 unit_tests/test_utils.py::test_failed_reading[traceback] ✓                                                                                                                                                                  96% █████████▋{"type": "LOG", "log": {"level": "ERROR", "message": "Docker container was failed, code 1, error:\nLast Container Logs Line"}}

 unit_tests/test_utils.py::test_failed_reading[last_line] ✓                                                                                                                                                                  97% █████████▋
 unit_tests/test_utils.py::test_docker_runner[standard] ✓                                                                                                                                                                    97% █████████▊
 unit_tests/test_utils.py::test_docker_runner[waiting] ✓                                                                                                                                                                     98% █████████▊
 unit_tests/test_utils.py::test_not_found_container ✓                                                                                                                                                                        98% █████████▉
 unit_tests/test_utils.py::TestLoadYamlOrJsonPath.test_load_json ✓                                                                                                                                                           99% █████████▉
 unit_tests/test_utils.py::TestLoadYamlOrJsonPath.test_load_yaml ✓                                                                                                                                                           99% █████████▉
 unit_tests/test_utils.py::TestLoadYamlOrJsonPath.test_load_other ✓                                                                                                                                                         100% ██████████

Results (4.27s):
     185 passed

```

</details>

