### PR TITLE
#12605 Added "end_date" field for source Mixpanel in specs

### DIFF
--- a/airbyte-config/init/src/main/resources/seed/source_definitions.yaml
+++ b/airbyte-config/init/src/main/resources/seed/source_definitions.yaml
@@ -541,7 +541,7 @@
 - name: Mixpanel
   sourceDefinitionId: 12928b32-bf0a-4f1e-964f-07e12e37153a
   dockerRepository: airbyte/source-mixpanel
-  dockerImageTag: 0.1.15
+  dockerImageTag: 0.1.16
   documentationUrl: https://docs.airbyte.io/integrations/sources/mixpanel
   icon: mixpanel.svg
   sourceType: api

--- a/airbyte-config/init/src/main/resources/seed/source_specs.yaml
+++ b/airbyte-config/init/src/main/resources/seed/source_specs.yaml
@@ -5224,7 +5224,7 @@
               path_in_connector_config:
               - "credentials"
               - "client_secret"
-- dockerImage: "airbyte/source-mixpanel:0.1.15"
+- dockerImage: "airbyte/source-mixpanel:0.1.16"
   spec:
     documentationUrl: "https://docs.airbyte.io/integrations/sources/mixpanel"
     connectionSpecification:
@@ -5271,6 +5271,15 @@
           description: "UTC date and time in the format 2017-01-25T00:00:00Z. Any\
             \ data before this date will not be replicated. If this option is not\
             \ set, the connector will replicate data from up to one year ago by default."
+          examples:
+          - "2021-11-16"
+          pattern: "^[0-9]{4}-[0-9]{2}-[0-9]{2}(T[0-9]{2}:[0-9]{2}:[0-9]{2}Z)?$"
+        end_date:
+          title: "End Date"
+          type: "string"
+          description: "UTC date and time in the format 2017-01-25T00:00:00Z. Any\
+            \ data after this date will not be replicated. Left empty to always sync\
+            \ to most recent date"
           examples:
           - "2021-11-16"
           pattern: "^[0-9]{4}-[0-9]{2}-[0-9]{2}(T[0-9]{2}:[0-9]{2}:[0-9]{2}Z)?$"

--- a/airbyte-integrations/connectors/source-mixpanel/Dockerfile
+++ b/airbyte-integrations/connectors/source-mixpanel/Dockerfile
@@ -13,5 +13,5 @@ ENV AIRBYTE_ENTRYPOINT "python /airbyte/integration_code/main.py"
 ENTRYPOINT ["python", "/airbyte/integration_code/main.py"]
 
 
-LABEL io.airbyte.version=0.1.15
+LABEL io.airbyte.version=0.1.16
 LABEL io.airbyte.name=airbyte/source-mixpanel

--- a/airbyte-integrations/connectors/source-mixpanel/source_mixpanel/spec.json
+++ b/airbyte-integrations/connectors/source-mixpanel/source_mixpanel/spec.json
@@ -39,6 +39,13 @@
         "examples": ["2021-11-16"],
         "pattern": "^[0-9]{4}-[0-9]{2}-[0-9]{2}(T[0-9]{2}:[0-9]{2}:[0-9]{2}Z)?$"
       },
+      "end_date": {
+        "title": "End Date",
+        "type": "string",
+        "description": "UTC date and time in the format 2017-01-25T00:00:00Z. Any data after this date will not be replicated.",
+        "examples": ["2021-11-16"],
+        "pattern": "^[0-9]{4}-[0-9]{2}-[0-9]{2}(T[0-9]{2}:[0-9]{2}:[0-9]{2}Z)?$"
+      },
       "region": {
         "title": "Region",
         "description": "The region of mixpanel domain instance either US or EU.",

--- a/airbyte-integrations/connectors/source-mixpanel/source_mixpanel/spec.json
+++ b/airbyte-integrations/connectors/source-mixpanel/source_mixpanel/spec.json
@@ -42,7 +42,7 @@
       "end_date": {
         "title": "End Date",
         "type": "string",
-        "description": "UTC date and time in the format 2017-01-25T00:00:00Z. Any data after this date will not be replicated.",
+        "description": "UTC date and time in the format 2017-01-25T00:00:00Z. Any data after this date will not be replicated. Left empty to always sync to most recent date",
         "examples": ["2021-11-16"],
         "pattern": "^[0-9]{4}-[0-9]{2}-[0-9]{2}(T[0-9]{2}:[0-9]{2}:[0-9]{2}Z)?$"
       },

--- a/docs/integrations/sources/mixpanel.md
+++ b/docs/integrations/sources/mixpanel.md
@@ -59,6 +59,7 @@ Select the correct region \(EU or US\) for your Mixpanel project. See detail [he
 
 | Version  | Date       | Pull Request                                             | Subject                                                                                              |
 |:---------|:-----------|:---------------------------------------------------------|:-----------------------------------------------------------------------------------------------------|
+| `0.1.16` | 2022-05-30 | [\#12801](https://github.com/airbytehq/airbyte/pull/12801) | Add end_date parameter |
 | `0.1.15` | 2022-05-04 | [\#12482](https://github.com/airbytehq/airbyte/pull/12482) | Update input configuration copy |
 | `0.1.14` | 2022-05-02 | [11501](https://github.com/airbytehq/airbyte/pull/11501) | Improve incremental sync method to streams |  
 | `0.1.13` | 2022-04-27 | [12335](https://github.com/airbytehq/airbyte/pull/12335) | Adding fixtures to mock time.sleep for connectors that explicitly sleep                              |  


### PR DESCRIPTION
## What
Adding the "end_date" into the config map of specs.json because it is referred to in the source.py of the source_mixpanel.

## How
We followed the similar format of the "start_date" and also the "end_date" of other sources config files. 

## Recommended reading order
1. `spec.json`

## Tests

Since this is config related there are no test cases available. 