### PR TITLE
🐛 Source(Pipedrive): remove date-time format from schemas

### DIFF
--- a/airbyte-integrations/connectors/source-pipedrive/integration_tests/abnormal_state.json
+++ b/airbyte-integrations/connectors/source-pipedrive/integration_tests/abnormal_state.json
@@ -1,23 +1,23 @@
 {
   "deals": {
-    "update_time": "2217-06-26T21:20:07Z"
+    "update_time": "2217-06-26 21:20:07"
   },
   "activities": {
-    "update_time": "2217-06-26T21:20:07Z"
+    "update_time": "2217-06-26 21:20:07"
   },
   "persons": {
-    "update_time": "2217-06-26T21:20:07Z"
+    "update_time": "2217-06-26 21:20:07"
   },
   "pipelines": {
-    "update_time": "2217-06-26T21:20:07Z"
+    "update_time": "2217-06-26 21:20:07"
   },
   "stages": {
-    "update_time": "2217-06-26T21:20:07Z"
+    "update_time": "2217-06-26 21:20:07"
   },
   "users": {
-    "modified": "2217-06-26T21:20:07Z"
+    "modified": "2217-06-26 21:20:07"
   },
   "organizations": {
-    "update_time": "2217-06-26T21:20:07Z"
+    "update_time": "2217-06-26 21:20:07"
   }
 }

--- a/airbyte-integrations/connectors/source-pipedrive/integration_tests/sample_state.json
+++ b/airbyte-integrations/connectors/source-pipedrive/integration_tests/sample_state.json
@@ -1,20 +1,20 @@
 {
   "deals": {
-    "update_time": "2021-06-01T10:10:10Z"
+    "update_time": "2021-06-01 10:10:10"
   },
   "activities": {
-    "update_time": "2021-06-01T10:10:10Z"
+    "update_time": "2021-06-01 10:10:10"
   },
   "persons": {
-    "update_time": "2021-06-01T10:10:10Z"
+    "update_time": "2021-06-01 10:10:10"
   },
   "pipelines": {
-    "update_time": "2021-06-01T10:10:10Z"
+    "update_time": "2021-06-01 10:10:10"
   },
   "stages": {
-    "update_time": "2021-06-01T10:10:10Z"
+    "update_time": "2021-06-01 10:10:10"
   },
   "users": {
-    "modified": "2021-06-01T10:10:10Z"
+    "modified": "2021-06-01 10:10:10"
   }
 }

--- a/airbyte-integrations/connectors/source-pipedrive/source_pipedrive/schemas/activity_fields.json
+++ b/airbyte-integrations/connectors/source-pipedrive/source_pipedrive/schemas/activity_fields.json
@@ -18,12 +18,10 @@
       "type": ["null", "string"]
     },
     "add_time": {
-      "type": ["null", "string"],
-      "format": "date-time"
+      "type": ["null", "string"]
     },
     "update_time": {
-      "type": ["null", "string"],
-      "format": "date-time"
+      "type": ["null", "string"]
     },
     "last_updated_by_user_id": {
       "type": ["null", "integer"]

--- a/airbyte-integrations/connectors/source-pipedrive/source_pipedrive/schemas/deal_fields.json
+++ b/airbyte-integrations/connectors/source-pipedrive/source_pipedrive/schemas/deal_fields.json
@@ -18,12 +18,10 @@
       "type": ["null", "string"]
     },
     "add_time": {
-      "type": ["null", "string"],
-      "format": "date-time"
+      "type": ["null", "string"]
     },
     "update_time": {
-      "type": ["null", "string"],
-      "format": "date-time"
+      "type": ["null", "string"]
     },
     "last_updated_by_user_id": {
       "type": ["null", "integer"]

--- a/airbyte-integrations/connectors/source-pipedrive/source_pipedrive/schemas/deals.json
+++ b/airbyte-integrations/connectors/source-pipedrive/source_pipedrive/schemas/deals.json
@@ -30,16 +30,13 @@
       "type": ["null", "string"]
     },
     "add_time": {
-      "type": ["null", "string"],
-      "format": "date-time"
+      "type": ["null", "string"]
     },
     "update_time": {
-      "type": ["null", "string"],
-      "format": "date-time"
+      "type": ["null", "string"]
     },
     "stage_change_time": {
-      "type": ["null", "string"],
-      "format": "date-time"
+      "type": ["null", "string"]
     },
     "active": {
       "type": ["null", "boolean"]
@@ -77,23 +74,19 @@
       "type": ["null", "string"]
     },
     "close_time": {
-      "type": ["null", "string"],
-      "format": "date-time"
+      "type": ["null", "string"]
     },
     "pipeline_id": {
       "type": ["null", "integer"]
     },
     "won_time": {
-      "type": ["null", "string"],
-      "format": "date-time"
+      "type": ["null", "string"]
     },
     "first_won_time": {
-      "type": ["null", "string"],
-      "format": "date-time"
+      "type": ["null", "string"]
     },
     "lost_time": {
-      "type": ["null", "string"],
-      "format": "date-time"
+      "type": ["null", "string"]
     },
     "products_count": {
       "type": ["null", "integer"]
@@ -127,12 +120,10 @@
       "format": "date"
     },
     "last_incoming_mail_time": {
-      "type": ["null", "string"],
-      "format": "date-time"
+      "type": ["null", "string"]
     },
     "last_outgoing_mail_time": {
-      "type": ["null", "string"],
-      "format": "date-time"
+      "type": ["null", "string"]
     },
     "label": {
       "type": ["null", "string"]

--- a/airbyte-integrations/connectors/source-pipedrive/source_pipedrive/schemas/leads.json
+++ b/airbyte-integrations/connectors/source-pipedrive/source_pipedrive/schemas/leads.json
@@ -51,12 +51,10 @@
       "type": ["null", "integer"]
     },
     "add_time": {
-      "type": ["null", "string"],
-      "format": "date-time"
+      "type": ["null", "string"]
     },
     "update_time": {
-      "type": ["null", "string"],
-      "format": "date-time"
+      "type": ["null", "string"]
     }
   }
 }

--- a/airbyte-integrations/connectors/source-pipedrive/source_pipedrive/schemas/organization_fields.json
+++ b/airbyte-integrations/connectors/source-pipedrive/source_pipedrive/schemas/organization_fields.json
@@ -18,12 +18,10 @@
       "type": ["null", "string"]
     },
     "add_time": {
-      "type": ["null", "string"],
-      "format": "date-time"
+      "type": ["null", "string"]
     },
     "update_time": {
-      "type": ["null", "string"],
-      "format": "date-time"
+      "type": ["null", "string"]
     },
     "last_updated_by_user_id": {
       "type": ["null", "integer"]

--- a/airbyte-integrations/connectors/source-pipedrive/source_pipedrive/schemas/person_fields.json
+++ b/airbyte-integrations/connectors/source-pipedrive/source_pipedrive/schemas/person_fields.json
@@ -18,12 +18,10 @@
       "type": ["null", "string"]
     },
     "add_time": {
-      "type": ["null", "string"],
-      "format": "date-time"
+      "type": ["null", "string"]
     },
     "update_time": {
-      "type": ["null", "string"],
-      "format": "date-time"
+      "type": ["null", "string"]
     },
     "last_updated_by_user_id": {
       "type": ["null", "integer"]

--- a/airbyte-integrations/connectors/source-pipedrive/source_pipedrive/schemas/persons.json
+++ b/airbyte-integrations/connectors/source-pipedrive/source_pipedrive/schemas/persons.json
@@ -115,12 +115,10 @@
       "type": ["null", "string"]
     },
     "update_time": {
-      "type": ["null", "string"],
-      "format": "date-time"
+      "type": ["null", "string"]
     },
     "add_time": {
-      "type": ["null", "string"],
-      "format": "date-time"
+      "type": ["null", "string"]
     },
     "visible_to": {
       "type": ["null", "string"]
@@ -138,8 +136,7 @@
           "type": ["null", "boolean"]
         },
         "add_time": {
-          "type": ["null", "string"],
-          "format": "date-time"
+          "type": ["null", "string"]
         },
         "update_time": {
           "type": ["null", "string"]
@@ -178,16 +175,13 @@
       "type": ["null", "integer"]
     },
     "last_activity_date": {
-      "type": ["null", "string"],
-      "format": "date-time"
+      "type": ["null", "string"]
     },
     "last_incoming_mail_time": {
-      "type": ["null", "string"],
-      "format": "date-time"
+      "type": ["null", "string"]
     },
     "last_outgoing_mail_time": {
-      "type": ["null", "string"],
-      "format": "date-time"
+      "type": ["null", "string"]
     },
     "label": {
       "type": ["null", "integer"]

--- a/airbyte-integrations/connectors/source-pipedrive/source_pipedrive/schemas/pipelines.json
+++ b/airbyte-integrations/connectors/source-pipedrive/source_pipedrive/schemas/pipelines.json
@@ -21,12 +21,10 @@
       "type": ["null", "boolean"]
     },
     "add_time": {
-      "type": ["null", "string"],
-      "format": "date-time"
+      "type": ["null", "string"]
     },
     "update_time": {
-      "type": ["null", "string"],
-      "format": "date-time"
+      "type": ["null", "string"]
     },
     "selected": {
       "type": ["null", "boolean"]

--- a/airbyte-integrations/connectors/source-pipedrive/source_pipedrive/schemas/stages.json
+++ b/airbyte-integrations/connectors/source-pipedrive/source_pipedrive/schemas/stages.json
@@ -27,12 +27,10 @@
       "type": ["null", "integer"]
     },
     "add_time": {
-      "type": ["null", "string"],
-      "format": "date-time"
+      "type": ["null", "string"]
     },
     "update_time": {
-      "type": ["null", "string"],
-      "format": "date-time"
+      "type": ["null", "string"]
     },
     "pipeline_name": {
       "type": ["null", "string"]

--- a/airbyte-integrations/connectors/source-pipedrive/source_pipedrive/schemas/users.json
+++ b/airbyte-integrations/connectors/source-pipedrive/source_pipedrive/schemas/users.json
@@ -27,16 +27,13 @@
       "type": ["null", "boolean"]
     },
     "last_login": {
-      "type": ["null", "string"],
-      "format": "date-time"
+      "type": ["null", "string"]
     },
     "created": {
-      "type": ["null", "string"],
-      "format": "date-time"
+      "type": ["null", "string"]
     },
     "modified": {
-      "type": ["null", "string"],
-      "format": "date-time"
+      "type": ["null", "string"]
     },
     "signup_flow_variation": {
       "type": ["null", "string"]

--- a/docs/integrations/sources/pipedrive.md
+++ b/docs/integrations/sources/pipedrive.md
@@ -87,6 +87,7 @@ See [How to find the API token](https://pipedrive.readme.io/docs/how-to-find-the
 
 | Version | Date       | Pull Request | Subject |
 | :------ | :--------  | :-----       | :------ |
+| 0.1.11   | 2022-05-12 | [12806](https://github.com/airbytehq/airbyte/pull/12806) | Remove date-time format from schemas |
 | 0.1.10   | 2022-04-26 | [11870](https://github.com/airbytehq/airbyte/pull/11870) | Add 3 streams: DealFields, OrganizationFields and PersonFields |
 | 0.1.9   | 2021-12-07 | [8582](https://github.com/airbytehq/airbyte/pull/8582) | Update connector fields title/description |
 | 0.1.8   | 2021-11-16 | [7875](https://github.com/airbytehq/airbyte/pull/7875) | Extend schema for "persons" stream |


### PR DESCRIPTION
## What
Pipedrive doesn't work with ISO format of date times. Example of format by Pipedrive: 2020-04-15 12:58:48

Now for each record (and inproper datetime formatted value) the worker logs something along as
```
Errors: $.rotten_time: does not match the time pattern ^\d{2}:\d{2}:\d{2}$, $.last_outgoing_mail_time: 2020-04-15 12:58:48 is an invalid date-time, $.update_time: 2022-05-10 07:40:58 is an invalid date-time, $.stage_change_time: 2022-05-05 23:22:05 is an invalid date-time, $.add_time: 2019-01-04 18:45:25 is an invalid date-time
```

## How
Removed the `date-time` format

