### PR TITLE
Vertically center group label in connector form

### DIFF
--- a/airbyte-webapp/src/views/Connector/ServiceForm/components/Sections/ConditionSection.tsx
+++ b/airbyte-webapp/src/views/Connector/ServiceForm/components/Sections/ConditionSection.tsx
@@ -16,7 +16,10 @@ import { FormSection } from "./FormSection";
 const GroupLabel = styled(Label)`
   width: auto;
   margin-right: 8px;
+  padding-top: 8px;
   display: inline-block;
+  padding-bottom: 0px;
+  vertical-align: middle;
 `;
 
 const ConditionControls = styled.div`


### PR DESCRIPTION
## What
Closes https://github.com/airbytehq/airbyte/issues/12199

Previously, the group label (in this screenshot "File Format", though that label varies by connector) was vertically off-center.

<img width="615" alt="Screen Shot 2022-05-12 at 10 10 30 AM" src="https://user-images.githubusercontent.com/63751206/168094962-94cbf177-2abb-49cf-bacc-53d7342452f1.png">

## How
For now I've just adjusted padding and vertical-align.  These components have a redesign coming down the pipeline, so I do not believe a more elegant solution is warranted currently.  

## Recommended reading order
1. `x.tsx`