### PR TITLE
Generated python connectors use CDK version with YAML spec support

### DIFF
--- a/airbyte-integrations/connector-templates/source-python-http-api/README.md.hbs
+++ b/airbyte-integrations/connector-templates/source-python-http-api/README.md.hbs
@@ -8,7 +8,7 @@ For information about how to use this connector within Airbyte, see [the documen
 ### Prerequisites
 **To iterate on this connector, make sure to complete this prerequisites section.**
 
-#### Minimum Python version required `= 3.7.0`
+#### Minimum Python version required `= 3.9.0`
 
 #### Build & Activate Virtual Environment and install dependencies
 From this connector directory, create a virtual environment:

--- a/airbyte-integrations/connector-templates/source-python-http-api/setup.py.hbs
+++ b/airbyte-integrations/connector-templates/source-python-http-api/setup.py.hbs
@@ -6,7 +6,7 @@
 from setuptools import find_packages, setup
 
 MAIN_REQUIREMENTS = [
-    "airbyte-cdk~=0.1",
+    "airbyte-cdk~=0.1.56",
 ]
 
 TEST_REQUIREMENTS = [

--- a/airbyte-integrations/connector-templates/source-python/README.md.hbs
+++ b/airbyte-integrations/connector-templates/source-python/README.md.hbs
@@ -8,7 +8,7 @@ For information about how to use this connector within Airbyte, see [the documen
 ### Prerequisites
 **To iterate on this connector, make sure to complete this prerequisites section.**
 
-#### Minimum Python version required `= 3.7.0`
+#### Minimum Python version required `= 3.9.0`
 
 #### Build & Activate Virtual Environment and install dependencies
 From this connector directory, create a virtual environment:

--- a/airbyte-integrations/connector-templates/source-python/setup.py.hbs
+++ b/airbyte-integrations/connector-templates/source-python/setup.py.hbs
@@ -6,7 +6,7 @@
 from setuptools import find_packages, setup
 
 MAIN_REQUIREMENTS = [
-    "airbyte-cdk~=0.1",
+    "airbyte-cdk~=0.1.56",
 ]
 
 TEST_REQUIREMENTS = [

--- a/airbyte-integrations/connector-templates/source-singer/README.md.hbs
+++ b/airbyte-integrations/connector-templates/source-singer/README.md.hbs
@@ -8,7 +8,7 @@ For information about how to use this connector within Airbyte, see [the User Do
 ### Prerequisites
 **To iterate on this connector, make sure to complete this prerequisites section.**
 
-#### Minimum Python version required `= 3.7.0`
+#### Minimum Python version required `= 3.9.0`
 
 #### Build & Activate Virtual Environment and install dependencies
 From this connector directory, create a virtual environment:

--- a/airbyte-integrations/connector-templates/source-singer/setup.py.hbs
+++ b/airbyte-integrations/connector-templates/source-singer/setup.py.hbs
@@ -7,7 +7,7 @@ from setuptools import find_packages, setup
 
 MAIN_REQUIREMENTS = [
     "{{ tap_name }}",
-    "airbyte-cdk",
+    "airbyte-cdk~=0.1.56",
 ]
 
 TEST_REQUIREMENTS = [

--- a/airbyte-integrations/connectors/source-scaffold-source-http/README.md
+++ b/airbyte-integrations/connectors/source-scaffold-source-http/README.md
@@ -8,7 +8,7 @@ For information about how to use this connector within Airbyte, see [the documen
 ### Prerequisites
 **To iterate on this connector, make sure to complete this prerequisites section.**
 
-#### Minimum Python version required `= 3.7.0`
+#### Minimum Python version required `= 3.9.0`
 
 #### Build & Activate Virtual Environment and install dependencies
 From this connector directory, create a virtual environment:

--- a/airbyte-integrations/connectors/source-scaffold-source-http/setup.py
+++ b/airbyte-integrations/connectors/source-scaffold-source-http/setup.py
@@ -6,7 +6,7 @@
 from setuptools import find_packages, setup
 
 MAIN_REQUIREMENTS = [
-    "airbyte-cdk~=0.1",
+    "airbyte-cdk~=0.1.56",
 ]
 
 TEST_REQUIREMENTS = [

--- a/airbyte-integrations/connectors/source-scaffold-source-python/README.md
+++ b/airbyte-integrations/connectors/source-scaffold-source-python/README.md
@@ -8,7 +8,7 @@ For information about how to use this connector within Airbyte, see [the documen
 ### Prerequisites
 **To iterate on this connector, make sure to complete this prerequisites section.**
 
-#### Minimum Python version required `= 3.7.0`
+#### Minimum Python version required `= 3.9.0`
 
 #### Build & Activate Virtual Environment and install dependencies
 From this connector directory, create a virtual environment:

--- a/airbyte-integrations/connectors/source-scaffold-source-python/setup.py
+++ b/airbyte-integrations/connectors/source-scaffold-source-python/setup.py
@@ -6,7 +6,7 @@
 from setuptools import find_packages, setup
 
 MAIN_REQUIREMENTS = [
-    "airbyte-cdk~=0.1",
+    "airbyte-cdk~=0.1.56",
 ]
 
 TEST_REQUIREMENTS = [


### PR DESCRIPTION
## What
In #12245 we updated the generators to use `spec.yaml` files, however, YAML spec support was introduced in CDK v0.1.55. Some users were having issues using the generator if an older version of the CDK had been installed (which could have happened more frequently due to 0.1.55 also being one of the first versions to drop support for Python version < 3.9). This caused an error when running the connector's `spec` command, since older versions did not know how to look up YAML files.

closes #12794

## How
Set the version requirement in the generated `setup.py` to be for a version that includes YAML specs

## 🚨 User Impact 🚨
This will move people to using Python v3.9, since attempting to install the dependencies for the generated python project on an older python version will correctly produce an error telling them to upgrade.

## Pre-merge Checklist
Expand the relevant checklist and delete the others.

<details><summary><strong>Connector Generator</strong></summary>

- [ ] Issue acceptance criteria met
- [ ] PR name follows [PR naming conventions](https://docs.airbyte.io/contributing-to-airbyte/updating-documentation#issues-and-pull-requests)
- [x] If adding a new generator, add it to the [list of scaffold modules being tested](https://github.com/airbytehq/airbyte/blob/master/airbyte-integrations/connector-templates/generator/build.gradle#L41)
- [x] The generator test modules (all connectors with `-scaffold` in their name) have been updated with the latest scaffold by running `./gradlew :airbyte-integrations:connector-templates:generator:testScaffoldTemplates` then checking in your changes
- [ ] Documentation which references the generator is updated as needed

</details>
