### PR TITLE
🐞 Postgres source: fix azure database catalog retrieval

### DIFF
--- a/airbyte-config/init/src/main/resources/seed/source_definitions.yaml
+++ b/airbyte-config/init/src/main/resources/seed/source_definitions.yaml
@@ -715,7 +715,7 @@
 - name: Postgres
   sourceDefinitionId: decd338e-5647-4c0b-adf4-da0e75f5a750
   dockerRepository: airbyte/source-postgres
-  dockerImageTag: 0.4.14
+  dockerImageTag: 0.4.15
   documentationUrl: https://docs.airbyte.io/integrations/sources/postgres
   icon: postgresql.svg
   sourceType: database

--- a/airbyte-config/init/src/main/resources/seed/source_specs.yaml
+++ b/airbyte-config/init/src/main/resources/seed/source_specs.yaml
@@ -6540,7 +6540,7 @@
     supportsNormalization: false
     supportsDBT: false
     supported_destination_sync_modes: []
-- dockerImage: "airbyte/source-postgres:0.4.14"
+- dockerImage: "airbyte/source-postgres:0.4.15"
   spec:
     documentationUrl: "https://docs.airbyte.com/integrations/sources/postgres"
     connectionSpecification:

--- a/airbyte-integrations/connectors/source-postgres-strict-encrypt/Dockerfile
+++ b/airbyte-integrations/connectors/source-postgres-strict-encrypt/Dockerfile
@@ -16,5 +16,5 @@ ENV APPLICATION source-postgres-strict-encrypt
 
 COPY --from=build /airbyte /airbyte
 
-LABEL io.airbyte.version=0.4.14
+LABEL io.airbyte.version=0.4.15
 LABEL io.airbyte.name=airbyte/source-postgres-strict-encrypt

--- a/airbyte-integrations/connectors/source-postgres/Dockerfile
+++ b/airbyte-integrations/connectors/source-postgres/Dockerfile
@@ -16,5 +16,5 @@ ENV APPLICATION source-postgres
 
 COPY --from=build /airbyte /airbyte
 
-LABEL io.airbyte.version=0.4.14
+LABEL io.airbyte.version=0.4.15
 LABEL io.airbyte.name=airbyte/source-postgres

--- a/airbyte-integrations/connectors/source-postgres/src/main/java/io/airbyte/integrations/source/postgres/PostgresSource.java
+++ b/airbyte-integrations/connectors/source-postgres/src/main/java/io/airbyte/integrations/source/postgres/PostgresSource.java
@@ -332,7 +332,7 @@ public class PostgresSource extends AbstractJdbcSource<JDBCType> implements Sour
                 WHERE t.grpid = m.oid AND t.userid = r.oid)
                  AND             privilege_type = 'SELECT';
           """);
-      final String username = database.getDatabaseConfig().get("username").asText();
+      final String username = getUsername(database.getDatabaseConfig());
       ps.setString(1, username);
       ps.setString(2, username);
       ps.setString(3, username);
@@ -347,6 +347,22 @@ public class PostgresSource extends AbstractJdbcSource<JDBCType> implements Sour
             .tableName(e.get("table_name").asText())
             .build())
         .collect(toSet());
+  }
+
+  static String getUsername(final JsonNode databaseConfig) {
+    final String host = databaseConfig.get("host").asText();
+    final String username = databaseConfig.get("username").asText();
+
+    // Azure Postgres server has this username pattern: <username>@<host>.
+    // Inside Postgres, the true username is just <username>.
+    if (username.contains("@") && host.endsWith("azure.com")) {
+      final String[] tokens = username.split("@");
+      final String postgresUsername = tokens[0];
+      LOGGER.info("Azure username \"{}\" is detected; use \"{}\" to check permission", username, postgresUsername);
+      return postgresUsername;
+    }
+
+    return username;
   }
 
   @Override

--- a/airbyte-integrations/connectors/source-postgres/src/main/java/io/airbyte/integrations/source/postgres/PostgresSource.java
+++ b/airbyte-integrations/connectors/source-postgres/src/main/java/io/airbyte/integrations/source/postgres/PostgresSource.java
@@ -351,15 +351,13 @@ public class PostgresSource extends AbstractJdbcSource<JDBCType> implements Sour
 
   @VisibleForTesting
   static String getUsername(final JsonNode databaseConfig) {
-    final String host = databaseConfig.get("host") == null
-        // host can be null in test
-        ? ""
-        : databaseConfig.get("host").asText();
+    final String jdbcUrl = databaseConfig.get("jdbc_url").asText();
     final String username = databaseConfig.get("username").asText();
 
     // Azure Postgres server has this username pattern: <username>@<host>.
     // Inside Postgres, the true username is just <username>.
-    if (username.contains("@") && host.endsWith("azure.com")) {
+    // The jdbc_url is constructed in the toDatabaseConfigStatic method.
+    if (username.contains("@") && jdbcUrl.contains("azure.com:")) {
       final String[] tokens = username.split("@");
       final String postgresUsername = tokens[0];
       LOGGER.info("Azure username \"{}\" is detected; use \"{}\" to check permission", username, postgresUsername);

--- a/airbyte-integrations/connectors/source-postgres/src/main/java/io/airbyte/integrations/source/postgres/PostgresSource.java
+++ b/airbyte-integrations/connectors/source-postgres/src/main/java/io/airbyte/integrations/source/postgres/PostgresSource.java
@@ -349,8 +349,12 @@ public class PostgresSource extends AbstractJdbcSource<JDBCType> implements Sour
         .collect(toSet());
   }
 
+  @VisibleForTesting
   static String getUsername(final JsonNode databaseConfig) {
-    final String host = databaseConfig.get("host").asText();
+    final String host = databaseConfig.get("host") == null
+        // host can be null in test
+        ? ""
+        : databaseConfig.get("host").asText();
     final String username = databaseConfig.get("username").asText();
 
     // Azure Postgres server has this username pattern: <username>@<host>.

--- a/airbyte-integrations/connectors/source-postgres/src/test/java/io/airbyte/integrations/source/postgres/PostgresSourceTest.java
+++ b/airbyte-integrations/connectors/source-postgres/src/test/java/io/airbyte/integrations/source/postgres/PostgresSourceTest.java
@@ -34,6 +34,7 @@ import io.airbyte.protocol.models.SyncMode;
 import io.airbyte.test.utils.PostgreSQLContainerHelper;
 import java.math.BigDecimal;
 import java.util.List;
+import java.util.Map;
 import java.util.Optional;
 import java.util.Set;
 import java.util.stream.Collectors;
@@ -357,6 +358,19 @@ class PostgresSourceTest {
         "replication_slot", "slot",
         "publication", "ab_pub")));
     assertTrue(PostgresSource.isCdc(config));
+  }
+
+  @Test
+  void testGetUsername() {
+    final String username = "airbyte-user";
+
+    // normal host
+    final JsonNode normalConfig = Jsons.jsonNode(Map.of("username", username, "host", "airbyte.aws.com"));
+    assertEquals(username, PostgresSource.getUsername(normalConfig));
+
+    // azure host
+    final JsonNode azureConfig = Jsons.jsonNode(Map.of("username", username + "@airbyte", "host", "airbyte.azure.com"));
+    assertEquals(username, PostgresSource.getUsername(azureConfig));
   }
 
 }

--- a/airbyte-integrations/connectors/source-postgres/src/test/java/io/airbyte/integrations/source/postgres/PostgresSourceTest.java
+++ b/airbyte-integrations/connectors/source-postgres/src/test/java/io/airbyte/integrations/source/postgres/PostgresSourceTest.java
@@ -365,11 +365,15 @@ class PostgresSourceTest {
     final String username = "airbyte-user";
 
     // normal host
-    final JsonNode normalConfig = Jsons.jsonNode(Map.of("username", username, "host", "airbyte.aws.com"));
+    final JsonNode normalConfig = Jsons.jsonNode(Map.of(
+        "username", username,
+        "jdbc_url", "jdbc:postgresql://airbyte.database.com:5432:airbyte"));
     assertEquals(username, PostgresSource.getUsername(normalConfig));
 
     // azure host
-    final JsonNode azureConfig = Jsons.jsonNode(Map.of("username", username + "@airbyte", "host", "airbyte.azure.com"));
+    final JsonNode azureConfig = Jsons.jsonNode(Map.of(
+        "username", username + "@airbyte",
+        "jdbc_url", "jdbc:postgresql://airbyte.azure.com:5432:airbyte"));
     assertEquals(username, PostgresSource.getUsername(azureConfig));
   }
 

--- a/docs/integrations/sources/postgres.md
+++ b/docs/integrations/sources/postgres.md
@@ -270,6 +270,7 @@ According to Postgres [documentation](https://www.postgresql.org/docs/14/datatyp
 
 | Version | Date       | Pull Request                                           | Subject                                                                                                         |
 |:--------|:-----------|:-------------------------------------------------------|:----------------------------------------------------------------------------------------------------------------|
+| 0.4.15  | 2022-05-13 | [12834](https://github.com/airbytehq/airbyte/pull/12834) | Fix the bug that the connector returns empty catalog for Azure Postgres database |
 | 0.4.14  | 2022-05-08 | [12689](https://github.com/airbytehq/airbyte/pull/12689) | Add table retrieval according to role-based `SELECT` privilege |
 | 0.4.13  | 2022-05-05 | [10230](https://github.com/airbytehq/airbyte/pull/10230) | Explicitly set null value for field in json  |
 | 0.4.12  | 2022-04-29 | [12480](https://github.com/airbytehq/airbyte/pull/12480) | Query tables with adaptive fetch size to optimize JDBC memory consumption |
@@ -278,7 +279,7 @@ According to Postgres [documentation](https://www.postgresql.org/docs/14/datatyp
 | 0.4.8   | 2022-02-21 | [10242](https://github.com/airbytehq/airbyte/pull/10242) | Fixed cursor for old connectors that use non-microsecond format. Now connectors work with both formats |
 | 0.4.7   | 2022-02-18 | [10242](https://github.com/airbytehq/airbyte/pull/10242) | Updated timestamp transformation with microseconds |
 | 0.4.6   | 2022-02-14 | [10256](https://github.com/airbytehq/airbyte/pull/10256) | (unpublished) Add `-XX:+ExitOnOutOfMemoryError` JVM option |
-| 0.4.5   | 2022-02-08 | [10173](https://github.com/airbytehq/airbyte/pull/10173) | Improved  discovering tables in case if user does not have permissions to any table                                                                       |
+| 0.4.5   | 2022-02-08 | [10173](https://github.com/airbytehq/airbyte/pull/10173) | Improved  discovering tables in case if user does not have permissions to any table |
 | 0.4.4   | 2022-01-26 | [9807](https://github.com/airbytehq/airbyte/pull/9807) | Update connector fields title/description                                                                       |
 | 0.4.3   | 2022-01-24 | [9554](https://github.com/airbytehq/airbyte/pull/9554) | Allow handling of java sql date in CDC                                                                          |
 | 0.4.2   | 2022-01-13 | [9360](https://github.com/airbytehq/airbyte/pull/9360) | Added schema selection                                                                                          |


### PR DESCRIPTION
## What
- Azure Postgres server has this username pattern: `<username>@<host>`.
- However, inside Postgres, the true username is `<username>`.
- We need the true username to retrieve tables that are accessible to the user. Using the full username results in an empty catalog.
- Resolve https://github.com/airbytehq/oncall/issues/225.

## How
- This PR adds a method to return the true username when checking for table permissions.

## 🚨 User Impact 🚨
- Currently, users cannot sync any data using the latest Postgres source connector `0.4.14`.
- After this PR is deployed, this issue will be fixed.
