### PR TITLE
fix: postgres string type

### DIFF
--- a/airbyte-integrations/bases/base-normalization/dbt-project-template/macros/cross_db_utils/datatypes.sql
+++ b/airbyte-integrations/bases/base-normalization/dbt-project-template/macros/cross_db_utils/datatypes.sql
@@ -59,7 +59,7 @@
     String
 {%- endmacro -%}
 
-{#-- TODO: Remove this macro when dbt issue regarding unlimited varchars on postgres is resolved (https://github.com/airbytehq/airbyte/issues/12775) --#}
+{#-- TODO: Remove this macro when dbt issue regarding unlimited varchars on postgres is resolved (https://github.com/dbt-labs/dbt-core/issues/5238) and we've upgraded to the latest version of dbt --#}
 {%- macro postgres__type_string() -%}
     text
 {%- endmacro -%}

--- a/airbyte-integrations/bases/base-normalization/dbt-project-template/macros/cross_db_utils/datatypes.sql
+++ b/airbyte-integrations/bases/base-normalization/dbt-project-template/macros/cross_db_utils/datatypes.sql
@@ -59,6 +59,9 @@
     String
 {%- endmacro -%}
 
+{%- macro postgres__type_string() -%}
+    text
+{%- endmacro -%}
 
 {# float ------------------------------------------------- #}
 {% macro mysql__type_float() %}

--- a/airbyte-integrations/bases/base-normalization/dbt-project-template/macros/cross_db_utils/datatypes.sql
+++ b/airbyte-integrations/bases/base-normalization/dbt-project-template/macros/cross_db_utils/datatypes.sql
@@ -59,6 +59,7 @@
     String
 {%- endmacro -%}
 
+{# TODO: Remove this macro when dbt issue regarding unlimited varchars on postgres is resolved (https://github.com/airbytehq/airbyte/issues/12775) #}
 {%- macro postgres__type_string() -%}
     text
 {%- endmacro -%}

--- a/airbyte-integrations/bases/base-normalization/dbt-project-template/macros/cross_db_utils/datatypes.sql
+++ b/airbyte-integrations/bases/base-normalization/dbt-project-template/macros/cross_db_utils/datatypes.sql
@@ -59,7 +59,7 @@
     String
 {%- endmacro -%}
 
-{# TODO: Remove this macro when dbt issue regarding unlimited varchars on postgres is resolved (https://github.com/airbytehq/airbyte/issues/12775) #}
+{#-- TODO: Remove this macro when dbt issue regarding unlimited varchars on postgres is resolved (https://github.com/airbytehq/airbyte/issues/12775) --#}
 {%- macro postgres__type_string() -%}
     text
 {%- endmacro -%}


### PR DESCRIPTION
## What
Solves an issue with normalization on incremental sync on postgres destination when adding some columns after initial full refresh sync which type infers to string and whose length > 256
These columns were created with a 256 columns limit due to a DBT behaviour (already opened an issue [here](https://github.com/dbt-labs/dbt-core/issues/5238). They have something coming out about that in dbt_utils, but in the meantime I think it is better to override the type_string macro to use text instead of varchar (text is correctly handled by dbt)

## How
Added an override on the type_string macro for postgres in normalization macros

## 🚨 User Impact 🚨
No breaking change, except the fact that string columns will now have type text instead of varchar

Linked to [this Issue](https://github.com/airbytehq/airbyte/issues/12775) for more context