### PR TITLE
Reduce error boundaries for connections, sources, destinations and onboarding, add retry button.

### DIFF
--- a/airbyte-webapp/src/components/ApiErrorBoundary/ApiErrorBoundary.tsx
+++ b/airbyte-webapp/src/components/ApiErrorBoundary/ApiErrorBoundary.tsx
@@ -87,7 +87,8 @@ class ApiErrorBoundary extends React.Component<
             <RetryContainer>
               <Button
                 onClick={() => {
-                  this.setState({ didRetry: true, errorId: undefined }, () => onRetry?.());
+                  this.setState({ didRetry: true, errorId: undefined });
+                  onRetry?.();
                 }}
               >
                 <FormattedMessage id="errorView.retry" />

--- a/airbyte-webapp/src/components/ApiErrorBoundary/ApiErrorBoundary.tsx
+++ b/airbyte-webapp/src/components/ApiErrorBoundary/ApiErrorBoundary.tsx
@@ -2,7 +2,7 @@ import React from "react";
 import { FormattedMessage } from "react-intl";
 import styled from "styled-components";
 
-// import { Button } from "components/base";
+import { Button } from "components/base/Button";
 
 import { isVersionError } from "core/request/VersionError";
 import { ErrorOccurredView } from "views/common/ErrorOccurredView";
@@ -66,13 +66,13 @@ class ApiErrorBoundary extends React.Component<ApiErrorBoundaryProps, ApiErrorBo
         <ErrorOccurredView message={<FormattedMessage id="webapp.cannotReachServer" />}>
           {this.props.onReset && (
             <RetryContainer>
-              <button
+              <Button
                 onClick={() => {
                   this.setState({ wasReset: true, errorId: undefined }, () => onReset?.());
                 }}
               >
-                Retry
-              </button>
+                <FormattedMessage id="errorView.retry" />
+              </Button>
             </RetryContainer>
           )}
         </ErrorOccurredView>
@@ -82,7 +82,7 @@ class ApiErrorBoundary extends React.Component<ApiErrorBoundaryProps, ApiErrorBo
     return !errorId ? (
       <ResourceNotFoundErrorBoundary errorComponent={<StartOverErrorView />}>{children}</ResourceNotFoundErrorBoundary>
     ) : (
-      <ErrorOccurredView message="Unknown error occurred" />
+      <ErrorOccurredView message={<FormattedMessage id="errorView.unknownError" />} />
     );
   }
 }

--- a/airbyte-webapp/src/components/ApiErrorBoundary/ApiErrorBoundary.tsx
+++ b/airbyte-webapp/src/components/ApiErrorBoundary/ApiErrorBoundary.tsx
@@ -30,12 +30,19 @@ enum ErrorId {
   UnknownError = "unknown",
 }
 
+interface ApiErrorBoundaryProps {
+  hideHeader?: boolean;
+}
+
 interface ApiErrorBoundaryHookProps {
   location: LocationSensorState;
   onRetry?: () => void;
 }
 
-class ApiErrorBoundary extends React.Component<ApiErrorBoundaryHookProps, ApiErrorBoundaryState> {
+class ApiErrorBoundary extends React.Component<
+  ApiErrorBoundaryProps & ApiErrorBoundaryHookProps,
+  ApiErrorBoundaryState
+> {
   state: ApiErrorBoundaryState = {};
 
   static getDerivedStateFromError(error: { message: string; status?: number; __type?: string }): ApiErrorBoundaryState {
@@ -67,7 +74,7 @@ class ApiErrorBoundary extends React.Component<ApiErrorBoundaryHookProps, ApiErr
 
   render(): React.ReactNode {
     const { errorId, didRetry, message } = this.state;
-    const { onRetry, children } = this.props;
+    const { onRetry, hideHeader, children } = this.props;
 
     if (errorId === ErrorId.VersionMismatch) {
       return <ErrorOccurredView message={message} />;
@@ -75,7 +82,7 @@ class ApiErrorBoundary extends React.Component<ApiErrorBoundaryHookProps, ApiErr
 
     if (errorId === ErrorId.ServerUnavailable && !didRetry) {
       return (
-        <ErrorOccurredView message={<FormattedMessage id="webapp.cannotReachServer" />}>
+        <ErrorOccurredView message={<FormattedMessage id="webapp.cannotReachServer" />} hideHeader={hideHeader}>
           {onRetry && (
             <RetryContainer>
               <Button
@@ -92,19 +99,21 @@ class ApiErrorBoundary extends React.Component<ApiErrorBoundaryHookProps, ApiErr
     }
 
     return !errorId ? (
-      <ResourceNotFoundErrorBoundary errorComponent={<StartOverErrorView />}>{children}</ResourceNotFoundErrorBoundary>
+      <ResourceNotFoundErrorBoundary errorComponent={<StartOverErrorView hideHeader={hideHeader} />}>
+        {children}
+      </ResourceNotFoundErrorBoundary>
     ) : (
-      <ErrorOccurredView message={<FormattedMessage id="errorView.unknownError" />} />
+      <ErrorOccurredView message={<FormattedMessage id="errorView.unknownError" />} hideHeader={hideHeader} />
     );
   }
 }
 
-const ApiErrorBoundaryWithHooks: React.FC = ({ children }) => {
+const ApiErrorBoundaryWithHooks: React.FC<ApiErrorBoundaryProps> = ({ children, hideHeader }) => {
   const { reset } = useQueryErrorResetBoundary();
   const location = useLocation();
 
   return (
-    <ApiErrorBoundary location={location} onRetry={reset}>
+    <ApiErrorBoundary location={location} onRetry={reset} hideHeader={hideHeader}>
       {children}
     </ApiErrorBoundary>
   );

--- a/airbyte-webapp/src/components/ApiErrorBoundary/ApiErrorBoundary.tsx
+++ b/airbyte-webapp/src/components/ApiErrorBoundary/ApiErrorBoundary.tsx
@@ -30,23 +30,12 @@ enum ErrorId {
   UnknownError = "unknown",
 }
 
-interface ApiErrorBoundaryProps {
-  /**
-   * If the error should clear out when the user navigates to another page
-   */
-  resetOnLocationChange?: boolean;
-  /**
-   * Whether the user should be allowed to retry the request
-   */
-  withRetry?: boolean;
-}
-
-interface ApiErrorBoundaryHooks {
+interface ApiErrorBoundaryHookProps {
   location: LocationSensorState;
   onRetry?: () => void;
 }
 
-class ApiErrorBoundary extends React.Component<ApiErrorBoundaryProps & ApiErrorBoundaryHooks, ApiErrorBoundaryState> {
+class ApiErrorBoundary extends React.Component<ApiErrorBoundaryHookProps, ApiErrorBoundaryState> {
   state: ApiErrorBoundaryState = {};
 
   static getDerivedStateFromError(error: { message: string; status?: number; __type?: string }): ApiErrorBoundaryState {
@@ -65,10 +54,10 @@ class ApiErrorBoundary extends React.Component<ApiErrorBoundaryProps & ApiErrorB
     return { errorId: ErrorId.UnknownError, didRetry: false };
   }
 
-  componentDidUpdate(prevProps: ApiErrorBoundaryProps & ApiErrorBoundaryHooks) {
-    const { location, resetOnLocationChange } = this.props;
+  componentDidUpdate(prevProps: ApiErrorBoundaryHookProps) {
+    const { location } = this.props;
 
-    if (resetOnLocationChange && location !== prevProps.location) {
+    if (location !== prevProps.location) {
       this.setState({ errorId: undefined, didRetry: false });
     }
   }
@@ -78,7 +67,7 @@ class ApiErrorBoundary extends React.Component<ApiErrorBoundaryProps & ApiErrorB
 
   render(): React.ReactNode {
     const { errorId, didRetry, message } = this.state;
-    const { withRetry, onRetry, children } = this.props;
+    const { onRetry, children } = this.props;
 
     if (errorId === ErrorId.VersionMismatch) {
       return <ErrorOccurredView message={message} />;
@@ -87,7 +76,7 @@ class ApiErrorBoundary extends React.Component<ApiErrorBoundaryProps & ApiErrorB
     if (errorId === ErrorId.ServerUnavailable && !didRetry) {
       return (
         <ErrorOccurredView message={<FormattedMessage id="webapp.cannotReachServer" />}>
-          {withRetry && onRetry && (
+          {onRetry && (
             <RetryContainer>
               <Button
                 onClick={() => {
@@ -110,12 +99,12 @@ class ApiErrorBoundary extends React.Component<ApiErrorBoundaryProps & ApiErrorB
   }
 }
 
-const ApiErrorBoundaryWithHooks: React.FC<ApiErrorBoundaryProps> = ({ children, ...props }) => {
+const ApiErrorBoundaryWithHooks: React.FC = ({ children }) => {
   const { reset } = useQueryErrorResetBoundary();
   const location = useLocation();
 
   return (
-    <ApiErrorBoundary {...props} location={location} onRetry={reset}>
+    <ApiErrorBoundary location={location} onRetry={reset}>
       {children}
     </ApiErrorBoundary>
   );

--- a/airbyte-webapp/src/components/BaseClearView/BaseClearView.tsx
+++ b/airbyte-webapp/src/components/BaseClearView/BaseClearView.tsx
@@ -22,6 +22,7 @@ const LogoImg = styled.img`
 `;
 
 const MainInfo = styled.div`
+  min-width: 550px;
   display: flex;
   align-items: center;
   flex-direction: column;
@@ -29,16 +30,19 @@ const MainInfo = styled.div`
 
 interface BaseClearViewProps {
   onBackClick?: React.MouseEventHandler;
+  hideHeader?: boolean;
 }
 
-const BaseClearView: React.FC<BaseClearViewProps> = ({ children, onBackClick }) => {
+const BaseClearView: React.FC<BaseClearViewProps> = ({ children, onBackClick, hideHeader }) => {
   const { formatMessage } = useIntl();
   return (
     <Content>
       <MainInfo>
-        <Link to=".." onClick={onBackClick}>
-          <LogoImg src="/logo.png" alt={formatMessage({ id: "ui.goBack" })} />
-        </Link>
+        {!hideHeader && (
+          <Link to=".." onClick={onBackClick}>
+            <LogoImg src="/logo.png" alt={formatMessage({ id: "ui.goBack" })} />
+          </Link>
+        )}
         {children}
       </MainInfo>
       <Version />

--- a/airbyte-webapp/src/locales/en.json
+++ b/airbyte-webapp/src/locales/en.json
@@ -494,7 +494,9 @@
   "docs.notFoundError": "We were not able to receive docs. Please click the link above to open docs on our website",
   "errorView.notFound": "Resource not found.",
   "errorView.notAuthorized": "You don’t have permission to access this page.",
+  "errorView.retry": "Retry",
   "errorView.unknown": "Unknown",
+  "errorView.unknownError": "Unknown error occurred",
 
   "ui.goBack": "Go back",
   "ui.input.showPassword": "Show password",

--- a/airbyte-webapp/src/packages/cloud/cloudRoutes.tsx
+++ b/airbyte-webapp/src/packages/cloud/cloudRoutes.tsx
@@ -1,5 +1,4 @@
 import React, { Suspense, useMemo } from "react";
-import { useQueryErrorResetBoundary } from "react-query";
 import { Navigate, Route, Routes, useLocation } from "react-router-dom";
 import { useEffectOnce } from "react-use";
 
@@ -57,7 +56,6 @@ export const CloudRoutes = {
 } as const;
 
 const MainRoutes: React.FC = () => {
-  const { reset } = useQueryErrorResetBoundary();
   const workspace = useCurrentWorkspace();
   const cloudWorkspace = useGetCloudWorkspace(workspace.workspaceId);
 
@@ -84,7 +82,7 @@ const MainRoutes: React.FC = () => {
   useFeatureRegisterValues(features);
 
   return (
-    <ApiErrorBoundary onReset={reset} clearOnLocationChange>
+    <ApiErrorBoundary withRetry resetOnLocationChange>
       <Routes>
         <Route path={`${RoutePaths.Destination}/*`} element={<DestinationPage />} />
         <Route path={`${RoutePaths.Source}/*`} element={<SourcesPage />} />

--- a/airbyte-webapp/src/packages/cloud/cloudRoutes.tsx
+++ b/airbyte-webapp/src/packages/cloud/cloudRoutes.tsx
@@ -1,7 +1,9 @@
 import React, { Suspense, useMemo } from "react";
+import { useQueryErrorResetBoundary } from "react-query";
 import { Navigate, Route, Routes, useLocation } from "react-router-dom";
 import { useEffectOnce } from "react-use";
 
+import ApiErrorBoundary from "components/ApiErrorBoundary";
 import LoadingPage from "components/LoadingPage";
 
 import { useAnalyticsIdentifyUser, useAnalyticsRegisterValues } from "hooks/services/Analytics/useAnalyticsService";
@@ -55,6 +57,7 @@ export const CloudRoutes = {
 } as const;
 
 const MainRoutes: React.FC = () => {
+  const { reset } = useQueryErrorResetBoundary();
   const workspace = useCurrentWorkspace();
   const cloudWorkspace = useGetCloudWorkspace(workspace.workspaceId);
 
@@ -81,25 +84,27 @@ const MainRoutes: React.FC = () => {
   useFeatureRegisterValues(features);
 
   return (
-    <Routes>
-      <Route path={`${RoutePaths.Destination}/*`} element={<DestinationPage />} />
-      <Route path={`${RoutePaths.Source}/*`} element={<SourcesPage />} />
-      <Route path={`${RoutePaths.Connections}/*`} element={<ConnectionPage />} />
-      <Route path={`${RoutePaths.Settings}/*`} element={<CloudSettingsPage />} />
-      <Route path={CloudRoutes.Credits} element={<CreditsPage />} />
+    <ApiErrorBoundary onReset={reset}>
+      <Routes>
+        <Route path={`${RoutePaths.Destination}/*`} element={<DestinationPage />} />
+        <Route path={`${RoutePaths.Source}/*`} element={<SourcesPage />} />
+        <Route path={`${RoutePaths.Connections}/*`} element={<ConnectionPage />} />
+        <Route path={`${RoutePaths.Settings}/*`} element={<CloudSettingsPage />} />
+        <Route path={CloudRoutes.Credits} element={<CreditsPage />} />
 
-      {workspace.displaySetupWizard && (
-        <Route
-          path={RoutePaths.Onboarding}
-          element={
-            <OnboardingServiceProvider>
-              <OnboardingPage />
-            </OnboardingServiceProvider>
-          }
-        />
-      )}
-      <Route path="*" element={<Navigate to={mainNavigate} replace />} />
-    </Routes>
+        {workspace.displaySetupWizard && (
+          <Route
+            path={RoutePaths.Onboarding}
+            element={
+              <OnboardingServiceProvider>
+                <OnboardingPage />
+              </OnboardingServiceProvider>
+            }
+          />
+        )}
+        <Route path="*" element={<Navigate to={mainNavigate} replace />} />
+      </Routes>
+    </ApiErrorBoundary>
   );
 };
 

--- a/airbyte-webapp/src/packages/cloud/cloudRoutes.tsx
+++ b/airbyte-webapp/src/packages/cloud/cloudRoutes.tsx
@@ -82,7 +82,7 @@ const MainRoutes: React.FC = () => {
   useFeatureRegisterValues(features);
 
   return (
-    <ApiErrorBoundary withRetry resetOnLocationChange>
+    <ApiErrorBoundary>
       <Routes>
         <Route path={`${RoutePaths.Destination}/*`} element={<DestinationPage />} />
         <Route path={`${RoutePaths.Source}/*`} element={<SourcesPage />} />

--- a/airbyte-webapp/src/packages/cloud/cloudRoutes.tsx
+++ b/airbyte-webapp/src/packages/cloud/cloudRoutes.tsx
@@ -84,7 +84,7 @@ const MainRoutes: React.FC = () => {
   useFeatureRegisterValues(features);
 
   return (
-    <ApiErrorBoundary onReset={reset}>
+    <ApiErrorBoundary onReset={reset} clearOnLocationChange>
       <Routes>
         <Route path={`${RoutePaths.Destination}/*`} element={<DestinationPage />} />
         <Route path={`${RoutePaths.Source}/*`} element={<SourcesPage />} />

--- a/airbyte-webapp/src/packages/cloud/locales/en.json
+++ b/airbyte-webapp/src/packages/cloud/locales/en.json
@@ -118,5 +118,7 @@
   "password.validation": "Your password is too weak",
   "password.invalid": "Invalid password",
 
-  "verifyEmail.notification": "You successfully verified your email. Thank you."
+  "verifyEmail.notification": "You successfully verified your email. Thank you.",
+
+  "webapp.cannotReachServer": "Cannot reach server."
 }

--- a/airbyte-webapp/src/pages/DestinationPage/pages/DestinationItemPage/DestinationItemPage.tsx
+++ b/airbyte-webapp/src/pages/DestinationPage/pages/DestinationItemPage/DestinationItemPage.tsx
@@ -3,6 +3,7 @@ import { FormattedMessage } from "react-intl";
 import { Route, Routes } from "react-router-dom";
 
 import { DropDownRow, LoadingPage, PageTitle } from "components";
+import ApiErrorBoundary from "components/ApiErrorBoundary";
 import Breadcrumbs from "components/Breadcrumbs";
 import { ItemTabs, StepsTypes, TableItemTitle } from "components/ConnectorBlocks";
 import { ConnectorIcon } from "components/ConnectorIcon";
@@ -92,38 +93,40 @@ const DestinationItemPage: React.FC = () => {
       />
 
       <Suspense fallback={<LoadingPage />}>
-        <Routes>
-          <Route
-            path="/settings"
-            element={
-              <DestinationSettings
-                currentDestination={destination}
-                connectionsWithDestination={connectionsWithDestination}
-              />
-            }
-          />
-          <Route
-            index
-            element={
-              <>
-                <TableItemTitle
-                  type="source"
-                  dropDownData={sourcesDropDownData}
-                  onSelect={onSelect}
-                  entityName={destination.name}
-                  entity={destination.destinationName}
-                  entityIcon={destinationDefinition.icon ? getIcon(destinationDefinition.icon) : null}
-                  releaseStage={destinationDefinition.releaseStage}
+        <ApiErrorBoundary withRetry resetOnLocationChange>
+          <Routes>
+            <Route
+              path="/settings"
+              element={
+                <DestinationSettings
+                  currentDestination={destination}
+                  connectionsWithDestination={connectionsWithDestination}
                 />
-                {connectionsWithDestination.length ? (
-                  <DestinationConnectionTable connections={connectionsWithDestination} />
-                ) : (
-                  <Placeholder resource={ResourceTypes.Sources} />
-                )}
-              </>
-            }
-          />
-        </Routes>
+              }
+            />
+            <Route
+              index
+              element={
+                <>
+                  <TableItemTitle
+                    type="source"
+                    dropDownData={sourcesDropDownData}
+                    onSelect={onSelect}
+                    entityName={destination.name}
+                    entity={destination.destinationName}
+                    entityIcon={destinationDefinition.icon ? getIcon(destinationDefinition.icon) : null}
+                    releaseStage={destinationDefinition.releaseStage}
+                  />
+                  {connectionsWithDestination.length ? (
+                    <DestinationConnectionTable connections={connectionsWithDestination} />
+                  ) : (
+                    <Placeholder resource={ResourceTypes.Sources} />
+                  )}
+                </>
+              }
+            />
+          </Routes>
+        </ApiErrorBoundary>
       </Suspense>
     </ConnectorDocumentationWrapper>
   );

--- a/airbyte-webapp/src/pages/DestinationPage/pages/DestinationItemPage/DestinationItemPage.tsx
+++ b/airbyte-webapp/src/pages/DestinationPage/pages/DestinationItemPage/DestinationItemPage.tsx
@@ -93,7 +93,7 @@ const DestinationItemPage: React.FC = () => {
       />
 
       <Suspense fallback={<LoadingPage />}>
-        <ApiErrorBoundary withRetry resetOnLocationChange>
+        <ApiErrorBoundary>
           <Routes>
             <Route
               path="/settings"

--- a/airbyte-webapp/src/pages/DestinationPage/pages/DestinationItemPage/DestinationItemPage.tsx
+++ b/airbyte-webapp/src/pages/DestinationPage/pages/DestinationItemPage/DestinationItemPage.tsx
@@ -93,7 +93,7 @@ const DestinationItemPage: React.FC = () => {
       />
 
       <Suspense fallback={<LoadingPage />}>
-        <ApiErrorBoundary>
+        <ApiErrorBoundary hideHeader>
           <Routes>
             <Route
               path="/settings"

--- a/airbyte-webapp/src/pages/OnboardingPage/OnboardingPage.tsx
+++ b/airbyte-webapp/src/pages/OnboardingPage/OnboardingPage.tsx
@@ -4,6 +4,7 @@ import { useEffectOnce } from "react-use";
 import styled from "styled-components";
 
 import { Button } from "components";
+import ApiErrorBoundary from "components/ApiErrorBoundary";
 import HeadTitle from "components/HeadTitle";
 import LoadingPage from "components/LoadingPage";
 
@@ -95,35 +96,35 @@ const OnboardingPage: React.FC = () => {
         >
           <HeadTitle titles={[{ id: "onboarding.headTitle" }]} />
           <StepsCounter steps={steps} currentStep={currentStep} />
-
           <Suspense fallback={<LoadingPage />}>
-            {currentStep === StepType.INSTRUCTION && (
-              <WelcomeStep onNextStep={() => setCurrentStep(StepType.CREATE_SOURCE)} />
-            )}
-            {currentStep === StepType.CREATE_SOURCE && (
-              <SourceStep
-                onSuccess={() => setAnimateExit(true)}
-                onNextStep={() => setCurrentStep(StepType.CREATE_DESTINATION)}
-              />
-            )}
-            {currentStep === StepType.CREATE_DESTINATION && (
-              <DestinationStep
-                onSuccess={() => setAnimateExit(true)}
-                onNextStep={() => setCurrentStep(StepType.SET_UP_CONNECTION)}
-              />
-            )}
-            {currentStep === StepType.SET_UP_CONNECTION && (
-              <ConnectionStep onNextStep={() => setCurrentStep(StepType.FINAL)} />
-            )}
-            {currentStep === StepType.FINAL && <FinalStep />}
+            <ApiErrorBoundary>
+              {currentStep === StepType.INSTRUCTION && (
+                <WelcomeStep onNextStep={() => setCurrentStep(StepType.CREATE_SOURCE)} />
+              )}
+              {currentStep === StepType.CREATE_SOURCE && (
+                <SourceStep
+                  onSuccess={() => setAnimateExit(true)}
+                  onNextStep={() => setCurrentStep(StepType.CREATE_DESTINATION)}
+                />
+              )}
+              {currentStep === StepType.CREATE_DESTINATION && (
+                <DestinationStep
+                  onSuccess={() => setAnimateExit(true)}
+                  onNextStep={() => setCurrentStep(StepType.SET_UP_CONNECTION)}
+                />
+              )}
+              {currentStep === StepType.SET_UP_CONNECTION && (
+                <ConnectionStep onNextStep={() => setCurrentStep(StepType.FINAL)} />
+              )}
+              {currentStep === StepType.FINAL && <FinalStep />}
+            </ApiErrorBoundary>
           </Suspense>
-
           <Footer>
             <Button secondary onClick={() => handleFinishOnboarding()}>
               {currentStep === StepType.FINAL ? (
                 <FormattedMessage id="onboarding.closeOnboarding" />
               ) : (
-                <FormattedMessage id={"onboarding.skipOnboarding"} />
+                <FormattedMessage id="onboarding.skipOnboarding" />
               )}
             </Button>
           </Footer>

--- a/airbyte-webapp/src/pages/OnboardingPage/OnboardingPage.tsx
+++ b/airbyte-webapp/src/pages/OnboardingPage/OnboardingPage.tsx
@@ -119,7 +119,7 @@ const OnboardingPage: React.FC = () => {
                 <FormattedMessage id={`onboarding.create${TITLE_BY_STEP[currentStep]}.text`} />
               </TitlesBlock>
             )}
-            <ApiErrorBoundary>
+            <ApiErrorBoundary hideHeader>
               {currentStep === StepType.INSTRUCTION && (
                 <WelcomeStep onNextStep={() => setCurrentStep(StepType.CREATE_SOURCE)} />
               )}

--- a/airbyte-webapp/src/pages/OnboardingPage/OnboardingPage.tsx
+++ b/airbyte-webapp/src/pages/OnboardingPage/OnboardingPage.tsx
@@ -18,9 +18,11 @@ import { RoutePaths } from "../routePaths";
 import ConnectionStep from "./components/ConnectionStep";
 import DestinationStep from "./components/DestinationStep";
 import FinalStep from "./components/FinalStep";
+import HighlightedText from "./components/HighlightedText";
 import LetterLine from "./components/LetterLine";
 import SourceStep from "./components/SourceStep";
 import StepsCounter from "./components/StepsCounter";
+import TitlesBlock from "./components/TitlesBlock";
 import WelcomeStep from "./components/WelcomeStep";
 import { StepType } from "./types";
 import useGetStepsConfig from "./useStepsConfig";
@@ -52,6 +54,12 @@ const ScreenContent = styled.div`
   width: 100%;
   position: relative;
 `;
+
+const TITLE_BY_STEP: Partial<Record<StepType, string>> = {
+  [StepType.CREATE_SOURCE]: "FirstSource",
+  [StepType.CREATE_DESTINATION]: "FirstDestination",
+  [StepType.SET_UP_CONNECTION]: "Connection",
+};
 
 const OnboardingPage: React.FC = () => {
   const analyticsService = useAnalyticsService();
@@ -97,6 +105,20 @@ const OnboardingPage: React.FC = () => {
           <HeadTitle titles={[{ id: "onboarding.headTitle" }]} />
           <StepsCounter steps={steps} currentStep={currentStep} />
           <Suspense fallback={<LoadingPage />}>
+            {TITLE_BY_STEP[currentStep] && (
+              <TitlesBlock
+                title={
+                  <FormattedMessage
+                    id={`onboarding.create${TITLE_BY_STEP[currentStep]}`}
+                    values={{
+                      name: (name: React.ReactNode[]) => <HighlightedText>{name}</HighlightedText>,
+                    }}
+                  />
+                }
+              >
+                <FormattedMessage id={`onboarding.create${TITLE_BY_STEP[currentStep]}.text`} />
+              </TitlesBlock>
+            )}
             <ApiErrorBoundary>
               {currentStep === StepType.INSTRUCTION && (
                 <WelcomeStep onNextStep={() => setCurrentStep(StepType.CREATE_SOURCE)} />

--- a/airbyte-webapp/src/pages/OnboardingPage/components/ConnectionStep.tsx
+++ b/airbyte-webapp/src/pages/OnboardingPage/components/ConnectionStep.tsx
@@ -1,13 +1,9 @@
 import React from "react";
-import { FormattedMessage } from "react-intl";
 
 import CreateConnectionContent from "components/CreateConnectionContent";
 
 import { useDestinationList } from "hooks/services/useDestinationHook";
 import { useSourceList } from "hooks/services/useSourceHook";
-
-import HighlightedText from "./HighlightedText";
-import TitlesBlock from "./TitlesBlock";
 
 type IProps = {
   onNextStep: () => void;
@@ -18,26 +14,12 @@ const ConnectionStep: React.FC<IProps> = ({ onNextStep: afterSubmitConnection })
   const { destinations } = useDestinationList();
 
   return (
-    <>
-      <TitlesBlock
-        title={
-          <FormattedMessage
-            id="onboarding.createConnection"
-            values={{
-              name: (name: React.ReactNode[]) => <HighlightedText>{name}</HighlightedText>,
-            }}
-          />
-        }
-      >
-        <FormattedMessage id="onboarding.createConnection.text" />
-      </TitlesBlock>
-      <CreateConnectionContent
-        noTitles
-        source={sources[0]}
-        destination={destinations[0]}
-        afterSubmitConnection={afterSubmitConnection}
-      />
-    </>
+    <CreateConnectionContent
+      noTitles
+      source={sources[0]}
+      destination={destinations[0]}
+      afterSubmitConnection={afterSubmitConnection}
+    />
   );
 };
 

--- a/airbyte-webapp/src/pages/OnboardingPage/components/DestinationStep.tsx
+++ b/airbyte-webapp/src/pages/OnboardingPage/components/DestinationStep.tsx
@@ -1,5 +1,4 @@
 import React, { useEffect, useState } from "react";
-import { FormattedMessage } from "react-intl";
 
 import { ConnectionConfiguration } from "core/domain/connection";
 import { JobInfo } from "core/domain/job";
@@ -10,9 +9,6 @@ import { useGetDestinationDefinitionSpecificationAsync } from "services/connecto
 import { createFormErrorMessage } from "utils/errorStatusMessage";
 import { ConnectorCard } from "views/Connector/ConnectorCard";
 import { useDocumentationPanelContext } from "views/Connector/ConnectorDocumentationLayout/DocumentationPanelContext";
-
-import HighlightedText from "./HighlightedText";
-import TitlesBlock from "./TitlesBlock";
 
 type Props = {
   onNextStep: () => void;
@@ -93,31 +89,17 @@ const DestinationStep: React.FC<Props> = ({ onNextStep, onSuccess }) => {
   const errorMessage = error ? createFormErrorMessage(error) : null;
 
   return (
-    <>
-      <TitlesBlock
-        title={
-          <FormattedMessage
-            id="onboarding.createFirstDestination"
-            values={{
-              name: (name: React.ReactNode[]) => <HighlightedText>{name}</HighlightedText>,
-            }}
-          />
-        }
-      >
-        <FormattedMessage id="onboarding.createFirstDestination.text" />
-      </TitlesBlock>
-      <ConnectorCard
-        full
-        formType="destination"
-        onServiceSelect={onDropDownSelect}
-        onSubmit={onSubmitForm}
-        hasSuccess={successRequest}
-        availableServices={destinationDefinitions}
-        errorMessage={errorMessage}
-        selectedConnectorDefinitionSpecification={destinationDefinitionSpecification}
-        isLoading={isLoading}
-      />
-    </>
+    <ConnectorCard
+      full
+      formType="destination"
+      onServiceSelect={onDropDownSelect}
+      onSubmit={onSubmitForm}
+      hasSuccess={successRequest}
+      availableServices={destinationDefinitions}
+      errorMessage={errorMessage}
+      selectedConnectorDefinitionSpecification={destinationDefinitionSpecification}
+      isLoading={isLoading}
+    />
   );
 };
 

--- a/airbyte-webapp/src/pages/OnboardingPage/components/SourceStep.tsx
+++ b/airbyte-webapp/src/pages/OnboardingPage/components/SourceStep.tsx
@@ -1,5 +1,4 @@
 import React, { useEffect, useState } from "react";
-import { FormattedMessage } from "react-intl";
 
 import { ConnectionConfiguration } from "core/domain/connection";
 import { JobInfo } from "core/domain/job";
@@ -11,9 +10,6 @@ import { useGetSourceDefinitionSpecificationAsync } from "services/connector/Sou
 import { createFormErrorMessage } from "utils/errorStatusMessage";
 import { ConnectorCard } from "views/Connector/ConnectorCard";
 import { useDocumentationPanelContext } from "views/Connector/ConnectorDocumentationLayout/DocumentationPanelContext";
-
-import HighlightedText from "./HighlightedText";
-import TitlesBlock from "./TitlesBlock";
 
 interface SourcesStepProps {
   onSuccess: () => void;
@@ -95,32 +91,18 @@ const SourceStep: React.FC<SourcesStepProps> = ({ onNextStep, onSuccess }) => {
   const errorMessage = error ? createFormErrorMessage(error) : "";
 
   return (
-    <>
-      <TitlesBlock
-        title={
-          <FormattedMessage
-            id="onboarding.createFirstSource"
-            values={{
-              name: (name: React.ReactNode) => <HighlightedText>{name}</HighlightedText>,
-            }}
-          />
-        }
-      >
-        <FormattedMessage id="onboarding.createFirstSource.text" />
-      </TitlesBlock>
-      <ConnectorCard
-        full
-        jobInfo={LogsRequestError.extractJobInfo(error)}
-        onServiceSelect={onServiceSelect}
-        onSubmit={onSubmitForm}
-        formType="source"
-        availableServices={sourceDefinitions}
-        hasSuccess={successRequest}
-        errorMessage={errorMessage}
-        selectedConnectorDefinitionSpecification={sourceDefinitionSpecification}
-        isLoading={isLoading}
-      />
-    </>
+    <ConnectorCard
+      full
+      jobInfo={LogsRequestError.extractJobInfo(error)}
+      onServiceSelect={onServiceSelect}
+      onSubmit={onSubmitForm}
+      formType="source"
+      availableServices={sourceDefinitions}
+      hasSuccess={successRequest}
+      errorMessage={errorMessage}
+      selectedConnectorDefinitionSpecification={sourceDefinitionSpecification}
+      isLoading={isLoading}
+    />
   );
 };
 

--- a/airbyte-webapp/src/pages/SourcesPage/pages/SourceItemPage/SourceItemPage.tsx
+++ b/airbyte-webapp/src/pages/SourcesPage/pages/SourceItemPage/SourceItemPage.tsx
@@ -91,7 +91,7 @@ const SourceItemPage: React.FC = () => {
       />
 
       <Suspense fallback={<LoadingPage />}>
-        <ApiErrorBoundary withRetry resetOnLocationChange>
+        <ApiErrorBoundary>
           <Routes>
             <Route
               path="/settings"

--- a/airbyte-webapp/src/pages/SourcesPage/pages/SourceItemPage/SourceItemPage.tsx
+++ b/airbyte-webapp/src/pages/SourcesPage/pages/SourceItemPage/SourceItemPage.tsx
@@ -91,7 +91,7 @@ const SourceItemPage: React.FC = () => {
       />
 
       <Suspense fallback={<LoadingPage />}>
-        <ApiErrorBoundary>
+        <ApiErrorBoundary hideHeader>
           <Routes>
             <Route
               path="/settings"

--- a/airbyte-webapp/src/pages/SourcesPage/pages/SourceItemPage/SourceItemPage.tsx
+++ b/airbyte-webapp/src/pages/SourcesPage/pages/SourceItemPage/SourceItemPage.tsx
@@ -3,6 +3,7 @@ import { FormattedMessage } from "react-intl";
 import { Route, Routes } from "react-router-dom";
 
 import { DropDownRow } from "components";
+import ApiErrorBoundary from "components/ApiErrorBoundary";
 import Breadcrumbs from "components/Breadcrumbs";
 import { ItemTabs, StepsTypes, TableItemTitle } from "components/ConnectorBlocks";
 import { ConnectorIcon } from "components/ConnectorIcon";
@@ -90,33 +91,35 @@ const SourceItemPage: React.FC = () => {
       />
 
       <Suspense fallback={<LoadingPage />}>
-        <Routes>
-          <Route
-            path="/settings"
-            element={<SourceSettings currentSource={source} connectionsWithSource={connectionsWithSource} />}
-          />
-          <Route
-            index
-            element={
-              <>
-                <TableItemTitle
-                  type="destination"
-                  dropDownData={destinationsDropDownData}
-                  onSelect={onSelect}
-                  entity={source.sourceName}
-                  entityName={source.name}
-                  entityIcon={sourceDefinition ? getIcon(sourceDefinition.icon) : null}
-                  releaseStage={sourceDefinition.releaseStage}
-                />
-                {connectionsWithSource.length ? (
-                  <SourceConnectionTable connections={connectionsWithSource} />
-                ) : (
-                  <Placeholder resource={ResourceTypes.Destinations} />
-                )}
-              </>
-            }
-          ></Route>
-        </Routes>
+        <ApiErrorBoundary withRetry resetOnLocationChange>
+          <Routes>
+            <Route
+              path="/settings"
+              element={<SourceSettings currentSource={source} connectionsWithSource={connectionsWithSource} />}
+            />
+            <Route
+              index
+              element={
+                <>
+                  <TableItemTitle
+                    type="destination"
+                    dropDownData={destinationsDropDownData}
+                    onSelect={onSelect}
+                    entity={source.sourceName}
+                    entityName={source.name}
+                    entityIcon={sourceDefinition ? getIcon(sourceDefinition.icon) : null}
+                    releaseStage={sourceDefinition.releaseStage}
+                  />
+                  {connectionsWithSource.length ? (
+                    <SourceConnectionTable connections={connectionsWithSource} />
+                  ) : (
+                    <Placeholder resource={ResourceTypes.Destinations} />
+                  )}
+                </>
+              }
+            />
+          </Routes>
+        </ApiErrorBoundary>
       </Suspense>
     </ConnectorDocumentationWrapper>
   );

--- a/airbyte-webapp/src/pages/routes.tsx
+++ b/airbyte-webapp/src/pages/routes.tsx
@@ -59,7 +59,7 @@ const useAddAnalyticsContextForWorkspace = (workspace: WorkspaceRead): void => {
 const MainViewRoutes: React.FC<{ workspace: WorkspaceRead }> = ({ workspace }) => {
   return (
     <MainView>
-      <ApiErrorBoundary withRetry resetOnLocationChange>
+      <ApiErrorBoundary>
         <Routes>
           <Route path={`${RoutePaths.Destination}/*`} element={<DestinationPage />} />
           <Route path={`${RoutePaths.Source}/*`} element={<SourcesPage />} />

--- a/airbyte-webapp/src/pages/routes.tsx
+++ b/airbyte-webapp/src/pages/routes.tsx
@@ -1,6 +1,5 @@
 import React, { useMemo } from "react";
 import { useIntl } from "react-intl";
-import { useQueryErrorResetBoundary } from "react-query";
 import { Navigate, Route, Routes, useLocation } from "react-router-dom";
 import { useEffectOnce } from "react-use";
 
@@ -58,10 +57,9 @@ const useAddAnalyticsContextForWorkspace = (workspace: WorkspaceRead): void => {
 };
 
 const MainViewRoutes: React.FC<{ workspace: WorkspaceRead }> = ({ workspace }) => {
-  const { reset } = useQueryErrorResetBoundary();
   return (
     <MainView>
-      <ApiErrorBoundary onReset={reset}>
+      <ApiErrorBoundary withRetry resetOnLocationChange>
         <Routes>
           <Route path={`${RoutePaths.Destination}/*`} element={<DestinationPage />} />
           <Route path={`${RoutePaths.Source}/*`} element={<SourcesPage />} />

--- a/airbyte-webapp/src/pages/routes.tsx
+++ b/airbyte-webapp/src/pages/routes.tsx
@@ -1,7 +1,10 @@
 import React, { useMemo } from "react";
 import { useIntl } from "react-intl";
+import { useQueryErrorResetBoundary } from "react-query";
 import { Navigate, Route, Routes, useLocation } from "react-router-dom";
 import { useEffectOnce } from "react-use";
+
+import ApiErrorBoundary from "components/ApiErrorBoundary";
 
 import { useConfig } from "config";
 import { useAnalyticsIdentifyUser, useAnalyticsRegisterValues } from "hooks/services/Analytics";
@@ -55,21 +58,24 @@ const useAddAnalyticsContextForWorkspace = (workspace: WorkspaceRead): void => {
 };
 
 const MainViewRoutes: React.FC<{ workspace: WorkspaceRead }> = ({ workspace }) => {
+  const { reset } = useQueryErrorResetBoundary();
   return (
     <MainView>
-      <Routes>
-        <Route path={`${RoutePaths.Destination}/*`} element={<DestinationPage />} />
-        <Route path={`${RoutePaths.Source}/*`} element={<SourcesPage />} />
-        <Route path={`${RoutePaths.Connections}/*`} element={<ConnectionPage />} />
-        <Route path={`${RoutePaths.Settings}/*`} element={<SettingsPage />} />
-        {workspace.displaySetupWizard ? (
-          <Route path={`${RoutePaths.Onboarding}/*`} element={<OnboardingPage />} />
-        ) : null}
-        <Route
-          path="*"
-          element={<Navigate to={workspace.displaySetupWizard ? RoutePaths.Onboarding : RoutePaths.Connections} />}
-        />
-      </Routes>
+      <ApiErrorBoundary onReset={reset}>
+        <Routes>
+          <Route path={`${RoutePaths.Destination}/*`} element={<DestinationPage />} />
+          <Route path={`${RoutePaths.Source}/*`} element={<SourcesPage />} />
+          <Route path={`${RoutePaths.Connections}/*`} element={<ConnectionPage />} />
+          <Route path={`${RoutePaths.Settings}/*`} element={<SettingsPage />} />
+          {workspace.displaySetupWizard ? (
+            <Route path={`${RoutePaths.Onboarding}/*`} element={<OnboardingPage />} />
+          ) : null}
+          <Route
+            path="*"
+            element={<Navigate to={workspace.displaySetupWizard ? RoutePaths.Onboarding : RoutePaths.Connections} />}
+          />
+        </Routes>
+      </ApiErrorBoundary>
     </MainView>
   );
 };

--- a/airbyte-webapp/src/views/common/ErrorOccurredView.tsx
+++ b/airbyte-webapp/src/views/common/ErrorOccurredView.tsx
@@ -13,11 +13,12 @@ const Content = styled(ContentCard)`
 interface ErrorOccurredViewProps {
   message: React.ReactNode;
   onBackClick?: React.MouseEventHandler;
+  hideHeader?: boolean;
 }
 
-export const ErrorOccurredView: React.FC<ErrorOccurredViewProps> = ({ message, onBackClick, children }) => {
+export const ErrorOccurredView: React.FC<ErrorOccurredViewProps> = ({ message, onBackClick, children, hideHeader }) => {
   return (
-    <BaseClearView onBackClick={onBackClick}>
+    <BaseClearView onBackClick={onBackClick} hideHeader={hideHeader}>
       <Content>
         <H4 center>{message}</H4>
         {children}

--- a/airbyte-webapp/src/views/common/StartOverErrorView.tsx
+++ b/airbyte-webapp/src/views/common/StartOverErrorView.tsx
@@ -6,15 +6,17 @@ import { ErrorOccurredView } from "views/common/ErrorOccurredView";
 interface StartOverErrorViewProps {
   message?: string;
   onReset?: () => void;
+  hideHeader?: boolean;
 }
 
-export const StartOverErrorView: React.FC<StartOverErrorViewProps> = ({ message, onReset }) => {
+export const StartOverErrorView: React.FC<StartOverErrorViewProps> = ({ message, onReset, hideHeader }) => {
   return (
     <ErrorOccurredView
       message={message ?? <FormattedMessage id="errorView.notFound" />}
       onBackClick={() => {
         onReset?.();
       }}
+      hideHeader={hideHeader}
     />
   );
 };


### PR DESCRIPTION
## What
This improves how we handle errors in the app. Previously, any network error would cause the app to go into a blank screen with an error. Now the navigation bar will remain present. Additionally, it enables the user to retry the request.

Related to [#12172](https://github.com/airbytehq/airbyte/issues/12172)

Onboarding error:

<img width="1198" alt="Screen Shot 2022-05-13 at 15 04 33" src="https://user-images.githubusercontent.com/168664/168373035-a4a34f7d-8e01-4c97-a886-ea7fb4b03c9f.png">

Source/Connection/Destination list error:
<img width="1197" alt="Screen Shot 2022-05-13 at 15 05 46" src="https://user-images.githubusercontent.com/168664/168373442-4e25164d-cc92-4da0-b8aa-ef6c7a0ab2d9.png">

Source/destination settings error:
<img width="912" alt="Screen Shot 2022-05-13 at 15 10 21" src="https://user-images.githubusercontent.com/168664/168374069-1098dc52-2ebf-4283-879b-16d9ed35961c.png">


## How
- Updates the `ApiErrorBoundary` component with retry functionality [react-query useQueryResetErrorBoundary](https://react-query.tanstack.com/reference/useQueryErrorResetBoundary). Resets on location change.
- Adds the `ApiErrorBoundary` to the main routes so that it doesn't error outside of the navigation
- Adds the `ApiErrorBoundary` component to onboarding, source, destination, and connection components so that it doesn't error the entire page

## Recommended reading order
Top to bottom


