### PR TITLE
[pokeapi connector] tweak suggested examples

### DIFF
--- a/airbyte-integrations/connectors/source-pokeapi/source_pokeapi/spec.json
+++ b/airbyte-integrations/connectors/source-pokeapi/source_pokeapi/spec.json
@@ -12,7 +12,7 @@
         "title": "Pokemon Name",
         "description": "Pokemon requested from the API.",
         "pattern": "^[a-z0-9_\\-]+$",
-        "examples": ["ditto, luxray, snorlax"]
+        "examples": ["pikachu"]
       }
     }
   }


### PR DESCRIPTION
## What
*Describe what the change is solving*

pokeapi connector only accepts 1 pokemon, not a comma separated list, this examples string gives the wrong expectation

*It helps to add screenshots if it affects the frontend.*

![image](https://user-images.githubusercontent.com/6764957/168376194-0dc69277-a90a-4283-a187-b517eabc04ac.png)


User confusion in airbyte internal slack: https://airbytehq-team.slack.com/archives/C0372JHKC2D/p1652303028586519

## How
*Describe the solution*

just reduce the examples for now since its an easy fix. 

ideally the more permanent fix in our UI is to distinguish between what's a valid example (which can be an array), and what is valid placeholder text  (which here can only be a single value)

