### PR TITLE
`AirbyteExceptionHandler` should exit with a non-0 exit code

### DIFF
--- a/airbyte-integrations/bases/base-java/src/main/java/io/airbyte/integrations/base/AirbyteExceptionHandler.java
+++ b/airbyte-integrations/bases/base-java/src/main/java/io/airbyte/integrations/base/AirbyteExceptionHandler.java
@@ -31,7 +31,7 @@ public class AirbyteExceptionHandler implements Thread.UncaughtExceptionHandler 
   // by doing this in a separate method we can mock it to avoid closing the jvm and therefore test
   // properly
   protected void terminate() {
-    System.exit(0);
+    System.exit(1);
   }
 
 }


### PR DESCRIPTION
After https://github.com/airbytehq/airbyte/pull/12614, when a Java connection throws an uncaught exception, we create an `AirbyteTraceMessage` in addition to logging the error to STDOUT.  However, an uncaught exception still should exit with a non-0 exit code.

Slack discussion [here](https://airbytehq-team.slack.com/archives/C02TL38U5L7/p1652475150822399).