### PR TITLE
🎉 Databricks destination: use new jdbc driver and open source the connector

### DIFF
--- a/airbyte-config/init/src/main/resources/seed/destination_definitions.yaml
+++ b/airbyte-config/init/src/main/resources/seed/destination_definitions.yaml
@@ -73,7 +73,7 @@
 - name: Databricks
   destinationDefinitionId: 072d5540-f236-4294-ba7c-ade8fd918496
   dockerRepository: airbyte/destination-databricks
-  dockerImageTag: 0.1.5
+  dockerImageTag: 0.2.0
   documentationUrl: https://docs.airbyte.io/integrations/destinations/databricks
   releaseStage: alpha
 - name: DynamoDB

--- a/airbyte-config/init/src/main/resources/seed/destination_definitions.yaml
+++ b/airbyte-config/init/src/main/resources/seed/destination_definitions.yaml
@@ -70,6 +70,12 @@
   dockerImageTag: 0.1.5
   documentationUrl: https://docs.airbyte.io/integrations/destinations/clickhouse
   releaseStage: alpha
+- name: Databricks
+  destinationDefinitionId: 072d5540-f236-4294-ba7c-ade8fd918496
+  dockerRepository: airbyte/destination-databricks
+  dockerImageTag: 0.1.5
+  documentationUrl: https://docs.airbyte.io/integrations/destinations/databricks
+  releaseStage: alpha
 - name: DynamoDB
   destinationDefinitionId: 8ccd8909-4e99-4141-b48d-4984b70b2d89
   dockerRepository: airbyte/destination-dynamodb

--- a/airbyte-config/init/src/main/resources/seed/destination_specs.yaml
+++ b/airbyte-config/init/src/main/resources/seed/destination_specs.yaml
@@ -961,6 +961,156 @@
     - "overwrite"
     - "append"
     - "append_dedup"
+- dockerImage: "airbyte/destination-databricks:0.2.0"
+  spec:
+    documentationUrl: "https://docs.airbyte.io/integrations/destinations/databricks"
+    connectionSpecification:
+      $schema: "http://json-schema.org/draft-07/schema#"
+      title: "Databricks Destination Spec"
+      type: "object"
+      required:
+      - "accept_terms"
+      - "databricks_server_hostname"
+      - "databricks_http_path"
+      - "databricks_personal_access_token"
+      - "data_source"
+      additionalProperties: false
+      properties:
+        accept_terms:
+          title: "Agree to the Databricks JDBC Driver Terms & Conditions"
+          type: "boolean"
+          description: "You must agree to the Databricks JDBC Driver <a href=\"https://databricks.com/jdbc-odbc-driver-license\"\
+            >Terms & Conditions</a> to use this connector."
+          default: false
+        databricks_server_hostname:
+          title: "Server Hostname"
+          type: "string"
+          description: "Databricks Cluster Server Hostname."
+          examples:
+          - "abc-12345678-wxyz.cloud.databricks.com"
+        databricks_http_path:
+          title: "HTTP Path"
+          type: "string"
+          description: "Databricks Cluster HTTP Path."
+          examples:
+          - "sql/protocolvx/o/1234567489/0000-1111111-abcd90"
+        databricks_port:
+          title: "Port"
+          type: "string"
+          description: "Databricks Cluster Port."
+          default: "443"
+          examples:
+          - "443"
+        databricks_personal_access_token:
+          title: "Access Token"
+          type: "string"
+          description: "Databricks Personal Access Token for making authenticated\
+            \ requests."
+          examples:
+          - "dapi0123456789abcdefghij0123456789AB"
+          airbyte_secret: true
+        database_schema:
+          title: "Database Schema"
+          type: "string"
+          description: "The default schema tables are written to if the source does\
+            \ not specify a namespace. Unless specifically configured, the usual value\
+            \ for this field is \"public\"."
+          default: "public"
+          examples:
+          - "public"
+        data_source:
+          title: "Data Source"
+          type: "object"
+          description: "Storage on which the delta lake is built."
+          oneOf:
+          - title: "Amazon S3"
+            required:
+            - "data_source_type"
+            - "s3_bucket_name"
+            - "s3_bucket_path"
+            - "s3_bucket_region"
+            - "s3_access_key_id"
+            - "s3_secret_access_key"
+            properties:
+              data_source_type:
+                type: "string"
+                enum:
+                - "S3"
+                default: "S3"
+              s3_bucket_name:
+                title: "S3 Bucket Name"
+                type: "string"
+                description: "The name of the S3 bucket to use for intermittent staging\
+                  \ of the data."
+                examples:
+                - "airbyte.staging"
+              s3_bucket_path:
+                title: "S3 Bucket Path"
+                type: "string"
+                description: "The directory under the S3 bucket where data will be\
+                  \ written."
+                examples:
+                - "data_sync/test"
+              s3_bucket_region:
+                title: "S3 Bucket Region"
+                type: "string"
+                default: ""
+                description: "The region of the S3 staging bucket to use if utilising\
+                  \ a copy strategy."
+                enum:
+                - ""
+                - "us-east-1"
+                - "us-east-2"
+                - "us-west-1"
+                - "us-west-2"
+                - "af-south-1"
+                - "ap-east-1"
+                - "ap-south-1"
+                - "ap-northeast-1"
+                - "ap-northeast-2"
+                - "ap-northeast-3"
+                - "ap-southeast-1"
+                - "ap-southeast-2"
+                - "ca-central-1"
+                - "cn-north-1"
+                - "cn-northwest-1"
+                - "eu-central-1"
+                - "eu-north-1"
+                - "eu-south-1"
+                - "eu-west-1"
+                - "eu-west-2"
+                - "eu-west-3"
+                - "sa-east-1"
+                - "me-south-1"
+                - "us-gov-east-1"
+                - "us-gov-west-1"
+              s3_access_key_id:
+                type: "string"
+                description: "The Access Key Id granting allow one to access the above\
+                  \ S3 staging bucket. Airbyte requires Read and Write permissions\
+                  \ to the given bucket."
+                title: "S3 Access Key ID"
+                examples:
+                - "A012345678910EXAMPLE"
+                airbyte_secret: true
+              s3_secret_access_key:
+                title: "S3 Secret Access Key"
+                type: "string"
+                description: "The corresponding secret to the above access key id."
+                examples:
+                - "a012345678910ABCDEFGH/AbCdEfGhEXAMPLEKEY"
+                airbyte_secret: true
+        purge_staging_data:
+          title: "Purge Staging Files and Tables"
+          type: "boolean"
+          description: "Default to 'true'. Switch it to 'false' for debugging purpose."
+          default: true
+    supportsIncremental: true
+    supportsNormalization: false
+    supportsDBT: false
+    supported_destination_sync_modes:
+    - "overwrite"
+    - "append"
 - dockerImage: "airbyte/destination-dynamodb:0.1.2"
   spec:
     documentationUrl: "https://docs.airbyte.io/integrations/destinations/dynamodb"

--- a/airbyte-db/lib/src/main/java/io/airbyte/db/factory/DatabaseDriver.java
+++ b/airbyte-db/lib/src/main/java/io/airbyte/db/factory/DatabaseDriver.java
@@ -10,8 +10,7 @@ package io.airbyte.db.factory;
 public enum DatabaseDriver {
 
   CLICKHOUSE("ru.yandex.clickhouse.ClickHouseDriver", "jdbc:clickhouse://%s:%d/%s"),
-  DATABRICKS("com.simba.spark.jdbc.Driver",
-      "jdbc:spark://%s:%s/default;transportMode=http;ssl=1;httpPath=%s;UserAgentEntry=Airbyte"),
+  DATABRICKS("com.databricks.client.jdbc.Driver", "jdbc:databricks://%s;HttpPath=%s;UserAgentEntry=Airbyte"),
   DB2("com.ibm.db2.jcc.DB2Driver", "jdbc:db2://%s:%d/%s"),
   MARIADB("org.mariadb.jdbc.Driver", "jdbc:mariadb://%s:%d/%s"),
   MSSQLSERVER("com.microsoft.sqlserver.jdbc.SQLServerDriver", "jdbc:sqlserver://%s:%d/%s"),

--- a/airbyte-integrations/connectors/destination-databricks/Dockerfile
+++ b/airbyte-integrations/connectors/destination-databricks/Dockerfile
@@ -16,5 +16,5 @@ ENV APPLICATION destination-databricks
 
 COPY --from=build /airbyte /airbyte
 
-LABEL io.airbyte.version=0.1.5
+LABEL io.airbyte.version=0.2.0
 LABEL io.airbyte.name=airbyte/destination-databricks

--- a/airbyte-integrations/connectors/destination-databricks/README.md
+++ b/airbyte-integrations/connectors/destination-databricks/README.md
@@ -4,15 +4,7 @@ This is the repository for the Databricks destination connector in Java.
 For information about how to use this connector within Airbyte, see [the User Documentation](https://docs.airbyte.io/integrations/destinations/databricks).
 
 ## Databricks JDBC Driver
-This connector requires a JDBC driver to connect to Databricks cluster. The driver is developed by Simba.
-
-WARNING:
-Before building, or using this connector, you must agree to the [JDBC ODBC driver license](https://databricks.com/jdbc-odbc-driver-license). This means that you can only use this driver to connector third party applications to Apache Spark SQL within a Databricks offering using the ODBC and/or JDBC protocols.
-
-This is currently a private connector that is only available on Airbyte Cloud. We are working on a solution to publicize it (issue [\#6043](https://github.com/airbytehq/airbyte/issues/6043)).
-
-- If you want to use this connector now, you can build the connector locally, and publish it to your own docker registry. See the "[Build](#build)" or "[Building via Gradle](#building-via-gradle)" sections below for details. Please do not publish this connector publicly.
-- If you want to work on the connector code, first build the connector. The building process will automatically download the driver to the [`lib`](./lib) directory. You can also manually download the driver from [here](https://databricks.com/spark/jdbc-drivers-download).
+This connector requires a JDBC driver to connect to Databricks cluster. Before using this connector, you must agree to the [JDBC ODBC driver license](https://databricks.com/jdbc-odbc-driver-license). This means that you can only use this driver to connector third party applications to Apache Spark SQL within a Databricks offering using the ODBC and/or JDBC protocols.
 
 ## Local development
 

--- a/airbyte-integrations/connectors/destination-databricks/build.gradle
+++ b/airbyte-integrations/connectors/destination-databricks/build.gradle
@@ -32,8 +32,7 @@ dependencies {
     implementation files(project(':airbyte-integrations:bases:base-java').airbyteDocker.outputs)
     implementation project(':airbyte-integrations:connectors:destination-jdbc')
     implementation project(':airbyte-integrations:connectors:destination-s3')
-    // Spark JDBC is not checked into the repo for legal reason
-    implementation files("lib/SparkJDBC42.jar")
+    implementation group: 'com.databricks', name: 'databricks-jdbc', version: '2.6.25'
 
     // parquet
     implementation group: 'org.apache.hadoop', name: 'hadoop-common', version: '3.3.0'
@@ -45,19 +44,3 @@ dependencies {
     integrationTestJavaImplementation project(':airbyte-integrations:bases:standard-destination-test')
     integrationTestJavaImplementation project(':airbyte-integrations:connectors:destination-databricks')
 }
-
-task downloadJdbcDriverZip(type: Download) {
-    src 'https://databricks-bi-artifacts.s3.us-east-2.amazonaws.com/simbaspark-drivers/jdbc/2.6.21/SimbaSparkJDBC42-2.6.21.1039.zip'
-    dest new File(buildDir, 'SimbaSparkJDBC42-2.6.21.1039.zip')
-    overwrite false
-}
-
-task extractJdbcDriverFile(dependsOn: downloadJdbcDriverZip, type: Copy) {
-    from {
-        zipTree(downloadJdbcDriverZip.dest)
-    }
-    into 'lib/'
-    include 'SparkJDBC42.jar'
-}
-
-compileJava.dependsOn tasks.extractJdbcDriverFile

--- a/airbyte-integrations/connectors/destination-databricks/src/main/java/io/airbyte/integrations/destination/databricks/DatabricksDestination.java
+++ b/airbyte-integrations/connectors/destination-databricks/src/main/java/io/airbyte/integrations/destination/databricks/DatabricksDestination.java
@@ -88,4 +88,5 @@ public class DatabricksDestination extends CopyDestination {
         databricksConfig.getDatabricksServerHostname(),
         databricksConfig.getDatabricksHttpPath());
   }
+
 }

--- a/airbyte-integrations/connectors/destination-databricks/src/main/java/io/airbyte/integrations/destination/databricks/DatabricksDestination.java
+++ b/airbyte-integrations/connectors/destination-databricks/src/main/java/io/airbyte/integrations/destination/databricks/DatabricksDestination.java
@@ -86,7 +86,6 @@ public class DatabricksDestination extends CopyDestination {
   static String getDatabricksConnectionString(final DatabricksDestinationConfig databricksConfig) {
     return String.format(DatabaseDriver.DATABRICKS.getUrlFormatString(),
         databricksConfig.getDatabricksServerHostname(),
-        databricksConfig.getDatabricksPort(),
         databricksConfig.getDatabricksHttpPath());
   }
 }

--- a/airbyte-integrations/connectors/destination-databricks/src/test-integration/java/io/airbyte/integrations/destination/databricks/DatabricksDestinationAcceptanceTest.java
+++ b/airbyte-integrations/connectors/destination-databricks/src/test-integration/java/io/airbyte/integrations/destination/databricks/DatabricksDestinationAcceptanceTest.java
@@ -149,4 +149,5 @@ public class DatabricksDestinationAcceptanceTest extends DestinationAcceptanceTe
         databricksConfig.getDatabricksPersonalAccessToken(), DatabricksConstants.DATABRICKS_DRIVER_CLASS,
         DatabricksDestination.getDatabricksConnectionString(databricksConfig), SQLDialect.DEFAULT);
   }
+
 }

--- a/docs/integrations/destinations/databricks.md
+++ b/docs/integrations/destinations/databricks.md
@@ -103,6 +103,7 @@ Under the hood, an Airbyte data stream in Json schema is first converted to an A
 
 | Version | Date | Pull Request | Subject |
 | :--- | :--- | :--- | :--- |
+| 0.2.0 | 2022-05-15 | [\#12861](https://github.com/airbytehq/airbyte/pull/12861) | Use new public Databricks JDBC driver, and open source the connector. |
 | 0.1.5 | 2022-05-04 | [\#12578](https://github.com/airbytehq/airbyte/pull/12578) | In JSON to Avro conversion, log JSON field values that do not follow Avro schema for debugging. |
 | 0.1.4 | 2022-02-14 | [\#10256](https://github.com/airbytehq/airbyte/pull/10256) | Add `-XX:+ExitOnOutOfMemoryError` JVM option |
 | 0.1.3 | 2022-01-06 | [\#7622](https://github.com/airbytehq/airbyte/pull/7622) [\#9153](https://github.com/airbytehq/airbyte/issues/9153) | Upgrade Spark JDBC driver to `2.6.21` to patch Log4j vulnerability; update connector fields title/description. |

--- a/docs/integrations/destinations/databricks.md
+++ b/docs/integrations/destinations/databricks.md
@@ -4,9 +4,9 @@
 
 This destination syncs data to Databricks cluster. Each stream is written to its own table.
 
-This connector requires a JDBC driver to connect to Databricks cluster. The driver is developed by Simba. Before using the driver and the connector, you must agree to the [JDBC ODBC driver license](https://databricks.com/jdbc-odbc-driver-license). This means that you can only use this connector to connector third party applications to Apache Spark SQL within a Databricks offering using the ODBC and/or JDBC protocols.
+This connector requires a JDBC driver to connect to Databricks cluster. By using the driver and the connector, you must agree to the [JDBC ODBC driver license](https://databricks.com/jdbc-odbc-driver-license). This means that you can only use this connector to connector third party applications to Apache Spark SQL within a Databricks offering using the ODBC and/or JDBC protocols.
 
-Due to legal reasons, this is currently a private connector that is only available on Airbyte Cloud. We are working on publicizing it. Please follow [this issue](https://github.com/airbytehq/airbyte/issues/6043) for progress. In the interim, you can build the connector locally, publish it to your own image registry, and use it privately. See the [developer doc](https://github.com/airbytehq/airbyte/blob/master/airbyte-integrations/connectors/destination-databricks/README.md) for details. Please do not publish this connector publicly.
+Currently, this connector requires 30+MB of memory for each stream. When syncing multiple streams, it may run into out-of-memory error if the allocated memory is too small. This performance bottleneck is tracked in [this issue](https://github.com/airbytehq/airbyte/issues/11424). Once this issue is resolved, the connector should be able to sync almost infinite number of streams with less than 500MB of memory.
 
 ## Sync Mode
 
@@ -103,7 +103,7 @@ Under the hood, an Airbyte data stream in Json schema is first converted to an A
 
 | Version | Date | Pull Request | Subject |
 | :--- | :--- | :--- | :--- |
-| 1.1.5 | 2022-05-04 | [\#12578](https://github.com/airbytehq/airbyte/pull/12578) | In JSON to Avro conversion, log JSON field values that do not follow Avro schema for debugging. |
+| 0.1.5 | 2022-05-04 | [\#12578](https://github.com/airbytehq/airbyte/pull/12578) | In JSON to Avro conversion, log JSON field values that do not follow Avro schema for debugging. |
 | 0.1.4 | 2022-02-14 | [\#10256](https://github.com/airbytehq/airbyte/pull/10256) | Add `-XX:+ExitOnOutOfMemoryError` JVM option |
 | 0.1.3 | 2022-01-06 | [\#7622](https://github.com/airbytehq/airbyte/pull/7622) [\#9153](https://github.com/airbytehq/airbyte/issues/9153) | Upgrade Spark JDBC driver to `2.6.21` to patch Log4j vulnerability; update connector fields title/description. |
 | 0.1.2 | 2021-11-03 | [\#7288](https://github.com/airbytehq/airbyte/issues/7288) | Support Json `additionalProperties`. |


### PR DESCRIPTION
## What
- Databricks has kindly released a new public JDBC driver that can be embedded and distributed by partners like Airbyte.
- Use this new JDBC driver will allow us to finally open source this connector.
- Relate to https://github.com/airbytehq/airbyte/issues/6043.

## 🚨 User Impact 🚨
- Previously users cannot use the Databricks connector publicly. They need to build the image themselves.
- After this PR, this connector can be made public. Users can use it in the OSS Airbyte just like other connectors.
    - I still need to upgrade this connector on cloud first and then delete the older connector versions that include the old JDBC driver. See TODOs in https://github.com/airbytehq/airbyte/issues/6043.
