### PR TITLE
Only log the first schema validation error

### DIFF
--- a/airbyte-workers/src/main/java/io/airbyte/workers/DefaultReplicationWorker.java
+++ b/airbyte-workers/src/main/java/io/airbyte/workers/DefaultReplicationWorker.java
@@ -304,7 +304,7 @@ public class DefaultReplicationWorker implements ReplicationWorker {
               try {
                 recordSchemaValidator.validateSchema(messageOptional.get().getRecord());
               } catch (final RecordSchemaValidationException e) {
-                if (validationErrors.size() < 10) {
+                if (validationErrors.size() < 100) {
                   final Integer exceptionCount = validationErrors.get(e.getMessage());
                   if (exceptionCount == null) {
                     validationErrors.put(e.getMessage(), 1);

--- a/airbyte-workers/src/main/java/io/airbyte/workers/DefaultReplicationWorker.java
+++ b/airbyte-workers/src/main/java/io/airbyte/workers/DefaultReplicationWorker.java
@@ -304,7 +304,7 @@ public class DefaultReplicationWorker implements ReplicationWorker {
                 recordSchemaValidator.validateSchema(messageOptional.get().getRecord());
               } catch (final RecordSchemaValidationException e) {
                 validationErrors += 1;
-                if(validationErrors == 1){
+                if (validationErrors == 1) {
                   LOGGER.warn(e.getMessage());
                 }
               }

--- a/airbyte-workers/src/main/java/io/airbyte/workers/DefaultReplicationWorker.java
+++ b/airbyte-workers/src/main/java/io/airbyte/workers/DefaultReplicationWorker.java
@@ -304,13 +304,11 @@ public class DefaultReplicationWorker implements ReplicationWorker {
               try {
                 recordSchemaValidator.validateSchema(messageOptional.get().getRecord());
               } catch (final RecordSchemaValidationException e) {
-                if (validationErrors.size() < 100) {
-                  final Integer exceptionCount = validationErrors.get(e.getMessage());
-                  if (exceptionCount == null) {
-                    validationErrors.put(e.getMessage(), 1);
-                  } else {
-                    validationErrors.put(e.getMessage(), exceptionCount + 1);
-                  }
+                final Integer exceptionCount = validationErrors.get(e.getMessage());
+                if (exceptionCount == null && validationErrors.size() < 100) {
+                  validationErrors.put(e.getMessage(), 1);
+                } else {
+                  validationErrors.put(e.getMessage(), exceptionCount + 1);
                 }
               }
             }

--- a/airbyte-workers/src/main/java/io/airbyte/workers/DefaultReplicationWorker.java
+++ b/airbyte-workers/src/main/java/io/airbyte/workers/DefaultReplicationWorker.java
@@ -34,6 +34,7 @@ import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.concurrent.atomic.AtomicReference;
 import java.util.stream.Collectors;
 import org.apache.commons.io.FileUtils;
+import org.apache.commons.lang3.tuple.ImmutablePair;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.slf4j.MDC;
@@ -290,7 +291,7 @@ public class DefaultReplicationWorker implements ReplicationWorker {
       MDC.setContextMap(mdc);
       LOGGER.info("Replication thread started.");
       var recordsRead = 0;
-      final Map<String, Integer> validationErrors = new HashMap<String, Integer>();
+      final Map<String, ImmutablePair<String, Integer>> validationErrors = new HashMap<String, ImmutablePair<String, Integer>>();
       try {
         while (!cancelled.get() && !source.isFinished()) {
           final Optional<AirbyteMessage> messageOptional;
@@ -304,13 +305,14 @@ public class DefaultReplicationWorker implements ReplicationWorker {
               try {
                 recordSchemaValidator.validateSchema(messageOptional.get().getRecord());
               } catch (final RecordSchemaValidationException e) {
-                final Integer exceptionCount = validationErrors.get(e.getMessage());
-                if (exceptionCount == null) {
+                final ImmutablePair<String, Integer> exceptionWithCount = validationErrors.get(e.stream);
+                if (exceptionWithCount == null) {
                   if (validationErrors.size() < 100) {
-                    validationErrors.put(e.getMessage(), 1);
+                    validationErrors.put(e.stream, new ImmutablePair<>(e.getMessage(), 1));
                   }
                 } else {
-                  validationErrors.put(e.getMessage(), exceptionCount + 1);
+                  final Integer currentCount = exceptionWithCount.getRight();
+                  validationErrors.put(e.stream, new ImmutablePair<>(e.getMessage(), currentCount + 1));
                 }
               }
             }
@@ -339,7 +341,9 @@ public class DefaultReplicationWorker implements ReplicationWorker {
         }
         LOGGER.info("Total records read: {} ({})", recordsRead, FileUtils.byteCountToDisplaySize(messageTracker.getTotalBytesEmitted()));
         if (!validationErrors.isEmpty()) {
-          LOGGER.warn("Record schema validation errors found: {}", validationErrors);
+          validationErrors.forEach((stream, errorPair) -> {
+            LOGGER.warn("{} schema validation errors found for stream {}. Error message: {}", errorPair.getRight(), stream, errorPair.getLeft());
+          });
         }
 
         try {

--- a/airbyte-workers/src/main/java/io/airbyte/workers/DefaultReplicationWorker.java
+++ b/airbyte-workers/src/main/java/io/airbyte/workers/DefaultReplicationWorker.java
@@ -305,8 +305,10 @@ public class DefaultReplicationWorker implements ReplicationWorker {
                 recordSchemaValidator.validateSchema(messageOptional.get().getRecord());
               } catch (final RecordSchemaValidationException e) {
                 final Integer exceptionCount = validationErrors.get(e.getMessage());
-                if (exceptionCount == null && validationErrors.size() < 100) {
-                  validationErrors.put(e.getMessage(), 1);
+                if (exceptionCount == null) {
+                  if (validationErrors.size() < 100) {
+                    validationErrors.put(e.getMessage(), 1);
+                  }
                 } else {
                   validationErrors.put(e.getMessage(), exceptionCount + 1);
                 }

--- a/airbyte-workers/src/main/java/io/airbyte/workers/RecordSchemaValidationException.java
+++ b/airbyte-workers/src/main/java/io/airbyte/workers/RecordSchemaValidationException.java
@@ -11,12 +11,16 @@ package io.airbyte.workers;
 
 public class RecordSchemaValidationException extends Exception {
 
-  public RecordSchemaValidationException(final String message) {
+  public final String stream;
+
+  public RecordSchemaValidationException(final String stream, final String message) {
     super(message);
+    this.stream = stream;
   }
 
-  public RecordSchemaValidationException(final String message, final Throwable cause) {
+  public RecordSchemaValidationException(final String stream, final String message, final Throwable cause) {
     super(message, cause);
+    this.stream = stream;
   }
 
 }

--- a/airbyte-workers/src/main/java/io/airbyte/workers/RecordSchemaValidator.java
+++ b/airbyte-workers/src/main/java/io/airbyte/workers/RecordSchemaValidator.java
@@ -49,8 +49,9 @@ public class RecordSchemaValidator {
     try {
       validator.ensure(matchingSchema, messageData);
     } catch (final JsonValidationException e) {
-      throw new RecordSchemaValidationException(
-          String.format("Record schema validation failed for stream %s. Expected schema: %s", messageStream, matchingSchema));
+      final String streamWithNamespace = message.getNamespace() == null ? message.getStream() : message.getNamespace() + "-" + message.getStream();
+      throw new RecordSchemaValidationException(streamWithNamespace,
+          String.format("Record schema validation failed for %s. Expected schema: %s", streamWithNamespace, matchingSchema));
     }
   }
 

--- a/airbyte-workers/src/main/java/io/airbyte/workers/RecordSchemaValidator.java
+++ b/airbyte-workers/src/main/java/io/airbyte/workers/RecordSchemaValidator.java
@@ -49,7 +49,7 @@ public class RecordSchemaValidator {
     try {
       validator.ensure(matchingSchema, messageData);
     } catch (final JsonValidationException e) {
-      throw new RecordSchemaValidationException(String.format("Record schema validation failed. Errors: %s", e.getMessage()), e);
+      throw new RecordSchemaValidationException(String.format("Record schema validation failed for %s. Expected schema: %s", messageStream, matchingSchema));
     }
   }
 

--- a/airbyte-workers/src/main/java/io/airbyte/workers/RecordSchemaValidator.java
+++ b/airbyte-workers/src/main/java/io/airbyte/workers/RecordSchemaValidator.java
@@ -49,7 +49,8 @@ public class RecordSchemaValidator {
     try {
       validator.ensure(matchingSchema, messageData);
     } catch (final JsonValidationException e) {
-      throw new RecordSchemaValidationException(String.format("Record schema validation failed for %s. Expected schema: %s", messageStream, matchingSchema));
+      throw new RecordSchemaValidationException(
+          String.format("Record schema validation failed for %s. Expected schema: %s", messageStream, matchingSchema));
     }
   }
 

--- a/airbyte-workers/src/main/java/io/airbyte/workers/RecordSchemaValidator.java
+++ b/airbyte-workers/src/main/java/io/airbyte/workers/RecordSchemaValidator.java
@@ -50,7 +50,7 @@ public class RecordSchemaValidator {
       validator.ensure(matchingSchema, messageData);
     } catch (final JsonValidationException e) {
       throw new RecordSchemaValidationException(
-          String.format("Record schema validation failed for %s. Expected schema: %s", messageStream, matchingSchema));
+          String.format("Record schema validation failed for stream %s. Expected schema: %s", messageStream, matchingSchema));
     }
   }
 


### PR DESCRIPTION
## What
Logging every validation error is causing logs to fill up when there are record validation errors: https://github.com/airbytehq/airbyte/issues/12804 

## How
Instead of logging every validation error, just log the first, and also log a count of errors in the sync.
