### PR TITLE
JobTracker reports enum values

### DIFF
--- a/airbyte-scheduler/persistence/src/main/java/io/airbyte/scheduler/persistence/job_tracker/JobTracker.java
+++ b/airbyte-scheduler/persistence/src/main/java/io/airbyte/scheduler/persistence/job_tracker/JobTracker.java
@@ -209,8 +209,8 @@ public class JobTracker {
    * array) then returns a map of {null: toMetadataValue(config)}.
    */
   private static Map<String, Object> configToMetadata(final JsonNode config, final JsonNode schema) {
-    if (schema.hasNonNull("const")) {
-      // If this schema is a const, then just dump it into a map:
+    if (schema.hasNonNull("const") || schema.hasNonNull("enum")) {
+      // If this schema is a const or an enum, then just dump it into a map:
       // * If it's an object, flatten it
       // * Otherwise, do some basic conversions to value-ish data.
       // It would be a weird thing to declare const: null, but in that case we don't want to report null
@@ -220,7 +220,7 @@ public class JobTracker {
       // If this schema is a oneOf, then find the first sub-schema which the config matches
       // and use that sub-schema to convert the config to a map
       final JsonSchemaValidator validator = new JsonSchemaValidator();
-      for (final Iterator<JsonNode> it = schema.get("oneOf").elements(); it.hasNext();) {
+      for (final Iterator<JsonNode> it = schema.get("oneOf").elements(); it.hasNext(); ) {
         final JsonNode subSchema = it.next();
         if (validator.test(subSchema, config)) {
           return configToMetadata(config, subSchema);

--- a/airbyte-scheduler/persistence/src/main/java/io/airbyte/scheduler/persistence/job_tracker/JobTracker.java
+++ b/airbyte-scheduler/persistence/src/main/java/io/airbyte/scheduler/persistence/job_tracker/JobTracker.java
@@ -220,7 +220,7 @@ public class JobTracker {
       // If this schema is a oneOf, then find the first sub-schema which the config matches
       // and use that sub-schema to convert the config to a map
       final JsonSchemaValidator validator = new JsonSchemaValidator();
-      for (final Iterator<JsonNode> it = schema.get("oneOf").elements(); it.hasNext(); ) {
+      for (final Iterator<JsonNode> it = schema.get("oneOf").elements(); it.hasNext();) {
         final JsonNode subSchema = it.next();
         if (validator.test(subSchema, config)) {
           return configToMetadata(config, subSchema);

--- a/airbyte-scheduler/persistence/src/main/resources/example_config.json
+++ b/airbyte-scheduler/persistence/src/main/resources/example_config.json
@@ -16,6 +16,7 @@
     }
   },
   "const_null": null,
+  "enum_string": "foo",
   "additionalPropertiesUnset": {
     "foo": "bar"
   },
@@ -27,5 +28,6 @@
   },
   "additionalPropertiesConst": {
     "foo": 42
-  }
+  },
+  "additionalPropertiesEnumString": "foo"
 }

--- a/airbyte-scheduler/persistence/src/main/resources/example_config_schema.json
+++ b/airbyte-scheduler/persistence/src/main/resources/example_config_schema.json
@@ -44,6 +44,10 @@
     "const_null": {
       "const": null
     },
+    "enum_string": {
+      "type": "string",
+      "enum": ["foo", "bar"]
+    },
     "additionalPropertiesUnset": {
       "type": "object"
     },
@@ -62,6 +66,10 @@
       "additionalProperties": {
         "const": 42
       }
+    },
+    "additionalPropertiesEnumString": {
+      "type": "string",
+      "enum": ["foo", "bar"]
     }
   }
 }

--- a/airbyte-scheduler/persistence/src/test/java/io/airbyte/scheduler/persistence/job_tracker/JobTrackerTest.java
+++ b/airbyte-scheduler/persistence/src/test/java/io/airbyte/scheduler/persistence/job_tracker/JobTrackerTest.java
@@ -320,10 +320,12 @@ class JobTrackerTest {
         .put(JobTracker.CONFIG + ".const_object.sub_key", "bar")
         .put(JobTracker.CONFIG + ".const_object.sub_array", "[1,2,3]")
         .put(JobTracker.CONFIG + ".const_object.sub_object.sub_sub_key", "baz")
+        .put(JobTracker.CONFIG + ".enum_string", "foo")
         .put(JobTracker.CONFIG + ".additionalPropertiesUnset.foo", JobTracker.SET)
         .put(JobTracker.CONFIG + ".additionalPropertiesBoolean.foo", JobTracker.SET)
         .put(JobTracker.CONFIG + ".additionalPropertiesSchema.foo", JobTracker.SET)
         .put(JobTracker.CONFIG + ".additionalPropertiesConst.foo", 42)
+        .put(JobTracker.CONFIG + ".additionalPropertiesEnumString", "foo")
         .build();
 
     final Map<String, Object> actual = JobTracker.configToMetadata(JobTracker.CONFIG, config, schema);


### PR DESCRIPTION
Similar to consts, enums are hardcoded and therefore non-sensitive. Track them.