### PR TITLE
Acceptance test scripts - kill containers using volumes on shutdown

### DIFF
--- a/tools/bin/acceptance_test.sh
+++ b/tools/bin/acceptance_test.sh
@@ -10,7 +10,10 @@ echo "Starting app..."
 
 # Detach so we can run subsequent commands
 VERSION=dev TRACKING_STRATEGY=logging docker-compose up -d
-trap "echo 'docker-compose logs:' && docker-compose logs -t --tail 1000 && docker-compose down -v" EXIT
+
+# Sometimes source/dest containers using airbyte volumes survive shutdown, which need to be killed in order to shut down properly.
+shutdown_cmd="docker-compose down -v || docker kill $(docker ps -a -f volume=airbyte_workspace -f volume=airbyte_data -f volume=airbyte_db -q) && docker-compose down -v"
+trap "echo 'docker-compose logs:' && docker-compose logs -t --tail 1000 && $shutdown_cmd" EXIT
 
 echo "Waiting for services to begin"
 while [[ "$(curl -s -o /dev/null -w ''%{http_code}'' localhost:8000/api/v1/health)" != "200" ]]; do echo "Waiting for docker deployment.."; sleep 5; done

--- a/tools/bin/acceptance_test.sh
+++ b/tools/bin/acceptance_test.sh
@@ -12,7 +12,7 @@ echo "Starting app..."
 VERSION=dev TRACKING_STRATEGY=logging docker-compose up -d
 
 # Sometimes source/dest containers using airbyte volumes survive shutdown, which need to be killed in order to shut down properly.
-shutdown_cmd="docker-compose down -v || docker kill $(docker ps -a -f volume=airbyte_workspace -f volume=airbyte_data -f volume=airbyte_db -q) && docker-compose down -v"
+shutdown_cmd="docker-compose down -v || docker kill \$(docker ps -a -f volume=airbyte_workspace -f volume=airbyte_data -f volume=airbyte_db -q) && docker-compose down -v"
 trap "echo 'docker-compose logs:' && docker-compose logs -t --tail 1000 && $shutdown_cmd" EXIT
 
 echo "Waiting for services to begin"

--- a/tools/bin/acceptance_test_with_new_scheduler.sh
+++ b/tools/bin/acceptance_test_with_new_scheduler.sh
@@ -10,7 +10,10 @@ echo "Starting app..."
 
 # Detach so we can run subsequent commands
 VERSION=dev TRACKING_STRATEGY=logging NEW_SCHEDULER=true docker-compose up -d
-trap "echo 'docker-compose logs:' && docker-compose logs -t --tail 1000 && docker-compose down -v" EXIT
+
+# Sometimes source/dest containers using airbyte volumes survive shutdown, which need to be killed in order to shut down properly.
+shutdown_cmd="docker-compose down -v || docker kill $(docker ps -a -f volume=airbyte_workspace -f volume=airbyte_data -f volume=airbyte_db -q) && docker-compose down -v"
+trap "echo 'docker-compose logs:' && docker-compose logs -t --tail 1000 && $shutdown_cmd" EXIT
 
 echo "Waiting for services to begin"
 while [[ "$(curl -s -o /dev/null -w ''%{http_code}'' localhost:8000/api/v1/health)" != "200" ]]; do echo "Waiting for docker deployment.."; sleep 5; done

--- a/tools/bin/acceptance_test_with_new_scheduler.sh
+++ b/tools/bin/acceptance_test_with_new_scheduler.sh
@@ -12,7 +12,7 @@ echo "Starting app..."
 VERSION=dev TRACKING_STRATEGY=logging NEW_SCHEDULER=true docker-compose up -d
 
 # Sometimes source/dest containers using airbyte volumes survive shutdown, which need to be killed in order to shut down properly.
-shutdown_cmd="docker-compose down -v || docker kill $(docker ps -a -f volume=airbyte_workspace -f volume=airbyte_data -f volume=airbyte_db -q) && docker-compose down -v"
+shutdown_cmd="docker-compose down -v || docker kill \$(docker ps -a -f volume=airbyte_workspace -f volume=airbyte_data -f volume=airbyte_db -q) && docker-compose down -v"
 trap "echo 'docker-compose logs:' && docker-compose logs -t --tail 1000 && $shutdown_cmd" EXIT
 
 echo "Waiting for services to begin"

--- a/tools/bin/integration_tests_octavia.sh
+++ b/tools/bin/integration_tests_octavia.sh
@@ -10,7 +10,10 @@ echo "Starting app..."
 
 # Detach so we can run subsequent commands
 VERSION=dev TRACKING_STRATEGY=logging docker-compose up -d
-trap "echo 'docker-compose logs:' && docker-compose logs -t --tail 1000 && docker-compose down -v" EXIT
+
+# Sometimes source/dest containers using airbyte volumes survive shutdown, which need to be killed in order to shut down properly.
+shutdown_cmd="docker-compose down -v || docker kill $(docker ps -a -f volume=airbyte_workspace -f volume=airbyte_data -f volume=airbyte_db -q) && docker-compose down -v"
+trap "echo 'docker-compose logs:' && docker-compose logs -t --tail 1000 && $shutdown_cmd" EXIT
 
 echo "Waiting for services to begin"
 while [[ "$(curl -s -o /dev/null -w ''%{http_code}'' localhost:8000/api/v1/health)" != "200" ]]; do echo "Waiting for docker deployment.."; sleep 5; done

--- a/tools/bin/integration_tests_octavia.sh
+++ b/tools/bin/integration_tests_octavia.sh
@@ -12,7 +12,7 @@ echo "Starting app..."
 VERSION=dev TRACKING_STRATEGY=logging docker-compose up -d
 
 # Sometimes source/dest containers using airbyte volumes survive shutdown, which need to be killed in order to shut down properly.
-shutdown_cmd="docker-compose down -v || docker kill $(docker ps -a -f volume=airbyte_workspace -f volume=airbyte_data -f volume=airbyte_db -q) && docker-compose down -v"
+shutdown_cmd="docker-compose down -v || docker kill \$(docker ps -a -f volume=airbyte_workspace -f volume=airbyte_data -f volume=airbyte_db -q) && docker-compose down -v"
 trap "echo 'docker-compose logs:' && docker-compose logs -t --tail 1000 && $shutdown_cmd" EXIT
 
 echo "Waiting for services to begin"


### PR DESCRIPTION
## What
See [slack thread](https://airbytehq-team.slack.com/archives/C02TXQ020QM/p1652727832350439) for details. 

Acceptance tests will sometimes fail despite all tests passing because the `docker-compose down -v` command fails due to an error like
```
Removing volume airbyte_workspace
remove airbyte_workspace: volume is in use - [70ad1a16cd7e0e15c7a169060505f7dfdfb01c65d16cbd42bc338261bf5cbba4]
Error: Process completed with exit code 1.
```

This happens because there are sometimes source/dest containers that are still running after the other containers are shut down. These containers are not in the docker-compose file, so `docker-compose down` does not kill them, but they use the airbyte volumes and therefore cause the above error when trying to remove the volumes.

## How
This PR fixes the issue by adding a fallback to the shutdown command in the acceptance test scripts that will kill any docker containers using the airbyte volumes if the first `docker-compose down -v` command fails, then retries that command.
