### PR TITLE
Add a link to our blog post about CDC

### DIFF
--- a/docs/understanding-airbyte/cdc.md
+++ b/docs/understanding-airbyte/cdc.md
@@ -39,3 +39,7 @@ We add some metadata columns for CDC sources:
 * Oracle DB
 * Please [create a ticket](https://github.com/airbytehq/airbyte/issues/new/choose) if you need CDC support on another database!
 
+## Additional information
+
+* Read our article: [Understanding Change Data Capture (CDC): Definition, Methods and Benefits](https://airbyte.com/blog/change-data-capture-definition-methods-and-benefits)
+


### PR DESCRIPTION
Adding a link to our [blog article](https://airbyte.com/blog/change-data-capture-definition-methods-and-benefits) about CDC as additional information – it might help SEO as well.