### PR TITLE
#12486 and #49 from alpha-beta-issues fixes

### DIFF
--- a/airbyte-config/init/src/main/resources/seed/source_definitions.yaml
+++ b/airbyte-config/init/src/main/resources/seed/source_definitions.yaml
@@ -311,7 +311,7 @@
 - name: Google Ads
   sourceDefinitionId: 253487c0-2246-43ba-a21f-5116b20a2c50
   dockerRepository: airbyte/source-google-ads
-  dockerImageTag: 0.1.38
+  dockerImageTag: 0.1.39
   documentationUrl: https://docs.airbyte.io/integrations/sources/google-ads
   icon: google-adwords.svg
   sourceType: api

--- a/airbyte-config/init/src/main/resources/seed/source_specs.yaml
+++ b/airbyte-config/init/src/main/resources/seed/source_specs.yaml
@@ -2688,7 +2688,7 @@
     supportsNormalization: false
     supportsDBT: false
     supported_destination_sync_modes: []
-- dockerImage: "airbyte/source-google-ads:0.1.38"
+- dockerImage: "airbyte/source-google-ads:0.1.39"
   spec:
     documentationUrl: "https://docs.airbyte.com/integrations/sources/google-ads"
     connectionSpecification:
@@ -2794,7 +2794,7 @@
                 title: "Custom Query"
                 description: "A custom defined GAQL query for building the report.\
                   \ Should not contain segments.date expression because it is used\
-                  \ by incremental streams. See Google's <a href=\"https://developers.google.com/google-ads/api/fields/v8/overview_query_builder\"\
+                  \ by incremental streams. See Google's <a href=\"https://developers.google.com/google-ads/api/fields/v9/overview_query_builder\"\
                   >query builder</a> for more information."
                 examples:
                 - "SELECT segments.ad_destination_type, campaign.advertising_channel_sub_type\

--- a/airbyte-integrations/connectors/source-google-ads/Dockerfile
+++ b/airbyte-integrations/connectors/source-google-ads/Dockerfile
@@ -13,5 +13,5 @@ COPY main.py ./
 
 ENTRYPOINT ["python", "/airbyte/integration_code/main.py"]
 
-LABEL io.airbyte.version=0.1.38
+LABEL io.airbyte.version=0.1.39
 LABEL io.airbyte.name=airbyte/source-google-ads

--- a/airbyte-integrations/connectors/source-google-ads/integration_tests/test_incremental.py
+++ b/airbyte-integrations/connectors/source-google-ads/integration_tests/test_incremental.py
@@ -58,7 +58,7 @@ def test_incremental_sync(config, configured_catalog):
             AirbyteLogger(),
             config,
             ConfiguredAirbyteCatalog.parse_obj(configured_catalog),
-            {"ad_group_ad_report": {"segments.date": latest_state}},
+            {"ad_group_ad_report": {config["customer_id"]: {"segments.date": latest_state}}},
         )
     )
 

--- a/airbyte-integrations/connectors/source-google-ads/source_google_ads/custom_query_stream.py
+++ b/airbyte-integrations/connectors/source-google-ads/source_google_ads/custom_query_stream.py
@@ -72,7 +72,7 @@ class CustomQuery(IncrementalGoogleAdsStream):
                 # Represents protobuf message and could be anything, set custom
                 # attribute "protobuf_message" to convert it to a string (or
                 # array of strings) later.
-                # https://developers.google.com/google-ads/api/reference/rpc/v8/GoogleAdsFieldDataTypeEnum.GoogleAdsFieldDataType?hl=en#message
+                # https://developers.google.com/google-ads/api/reference/rpc/v9/GoogleAdsFieldDataTypeEnum.GoogleAdsFieldDataType?hl=en#message
                 if node.is_repeated:
                     output_type = ["array", "null"]
                 else:
@@ -95,7 +95,8 @@ class CustomQuery(IncrementalGoogleAdsStream):
     WHERE_EXPR = re.compile("where.*", flags=RE_FLAGS)
     # list of keywords that can come after WHERE clause,
     # according to https://developers.google.com/google-ads/api/docs/query/grammar
-    KEYWORDS_EXPR = re.compile("(order by|limit|parameters)", flags=RE_FLAGS)
+    # each whitespace matters!
+    KEYWORDS_EXPR = re.compile("(order by| limit | parameters )", flags=RE_FLAGS)
 
     @staticmethod
     def get_query_fields(query: str) -> List[str]:

--- a/airbyte-integrations/connectors/source-google-ads/source_google_ads/google_ads.py
+++ b/airbyte-integrations/connectors/source-google-ads/source_google_ads/google_ads.py
@@ -11,7 +11,6 @@ from google.ads.googleads.client import GoogleAdsClient
 from google.ads.googleads.v9.services.types.google_ads_service import GoogleAdsRow, SearchGoogleAdsResponse
 from proto.marshal.collections import Repeated, RepeatedComposite
 
-
 REPORT_MAPPING = {
     "accounts": "customer",
     "service_accounts": "customer",

--- a/airbyte-integrations/connectors/source-google-ads/source_google_ads/google_ads.py
+++ b/airbyte-integrations/connectors/source-google-ads/source_google_ads/google_ads.py
@@ -4,15 +4,17 @@
 
 
 from enum import Enum
-from typing import Any, Iterator, List, Mapping
+from typing import Any, Iterator, List, Mapping, MutableMapping
 
 import pendulum
 from google.ads.googleads.client import GoogleAdsClient
-from google.ads.googleads.v8.services.types.google_ads_service import GoogleAdsRow, SearchGoogleAdsResponse
+from google.ads.googleads.v9.services.types.google_ads_service import GoogleAdsRow, SearchGoogleAdsResponse
 from proto.marshal.collections import Repeated, RepeatedComposite
+
 
 REPORT_MAPPING = {
     "accounts": "customer",
+    "service_accounts": "customer",
     "ad_group_ads": "ad_group_ad",
     "ad_group_ad_labels": "ad_group_ad_label",
     "ad_groups": "ad_group",
@@ -34,13 +36,11 @@ REPORT_MAPPING = {
 class GoogleAds:
     DEFAULT_PAGE_SIZE = 1000
 
-    def __init__(self, credentials: Mapping[str, Any], customer_id: str):
+    def __init__(self, credentials: MutableMapping[str, Any]):
         # `google-ads` library version `14.0.0` and higher requires an additional required parameter `use_proto_plus`.
         # More details can be found here: https://developers.google.com/google-ads/api/docs/client-libs/python/protobuf-messages
         credentials["use_proto_plus"] = True
-
         self.client = GoogleAdsClient.load_from_dict(credentials)
-        self.customer_ids = customer_id.split(",")
         self.ga_service = self.client.get_service("GoogleAdsService")
 
     def send_request(self, query: str, customer_id: str) -> Iterator[SearchGoogleAdsResponse]:

--- a/airbyte-integrations/connectors/source-google-ads/source_google_ads/models.py
+++ b/airbyte-integrations/connectors/source-google-ads/source_google_ads/models.py
@@ -1,5 +1,10 @@
+#
+# Copyright (c) 2021 Airbyte, Inc., all rights reserved.
+#
+
 from dataclasses import dataclass
 from typing import Any, Iterable, Mapping, Union
+
 from pendulum import timezone
 from pendulum.tz.timezone import Timezone
 
@@ -18,9 +23,7 @@ class Customer:
                 time_zone_name = account.get("customer.time_zone")
                 tz = Timezone(time_zone_name) if time_zone_name else "local"
 
-                data_objects.append(cls(
-                    id=str(account["customer.id"]),
-                    time_zone=tz,
-                    is_manager_account=bool(account.get("customer.manager"))
-                ))
+                data_objects.append(
+                    cls(id=str(account["customer.id"]), time_zone=tz, is_manager_account=bool(account.get("customer.manager")))
+                )
         return data_objects

--- a/airbyte-integrations/connectors/source-google-ads/source_google_ads/models.py
+++ b/airbyte-integrations/connectors/source-google-ads/source_google_ads/models.py
@@ -1,0 +1,26 @@
+from dataclasses import dataclass
+from typing import Any, Iterable, Mapping, Union
+from pendulum import timezone
+from pendulum.tz.timezone import Timezone
+
+
+@dataclass
+class Customer:
+    id: str
+    time_zone: Union[timezone, str] = "local"
+    is_manager_account: bool = False
+
+    @classmethod
+    def from_accounts(cls, accounts: Iterable[Iterable[Mapping[str, Any]]]):
+        data_objects = []
+        for account_list in accounts:
+            for account in account_list:
+                time_zone_name = account.get("customer.time_zone")
+                tz = Timezone(time_zone_name) if time_zone_name else "local"
+
+                data_objects.append(cls(
+                    id=str(account["customer.id"]),
+                    time_zone=tz,
+                    is_manager_account=bool(account.get("customer.manager"))
+                ))
+        return data_objects

--- a/airbyte-integrations/connectors/source-google-ads/source_google_ads/schemas/service_accounts.json
+++ b/airbyte-integrations/connectors/source-google-ads/source_google_ads/schemas/service_accounts.json
@@ -1,0 +1,69 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "type": "object",
+  "properties": {
+    "customer.auto_tagging_enabled": {
+      "type": ["null", "boolean"]
+    },
+    "customer.call_reporting_setting.call_conversion_action": {
+      "type": ["null", "string"]
+    },
+    "customer.call_reporting_setting.call_conversion_reporting_enabled": {
+      "type": ["null", "boolean"]
+    },
+    "customer.call_reporting_setting.call_reporting_enabled": {
+      "type": ["null", "boolean"]
+    },
+    "customer.conversion_tracking_setting.conversion_tracking_id": {
+      "type": ["null", "integer"]
+    },
+    "customer.conversion_tracking_setting.cross_account_conversion_tracking_id": {
+      "type": ["null", "integer"]
+    },
+    "customer.currency_code": {
+      "type": ["null", "string"]
+    },
+    "customer.descriptive_name": {
+      "type": ["null", "string"]
+    },
+    "customer.final_url_suffix": {
+      "type": ["null", "string"]
+    },
+    "customer.has_partners_badge": {
+      "type": ["null", "boolean"]
+    },
+    "customer.id": {
+      "type": ["null", "integer"]
+    },
+    "customer.manager": {
+      "type": ["null", "boolean"]
+    },
+    "customer.optimization_score": {
+      "type": ["null", "number"]
+    },
+    "customer.optimization_score_weight": {
+      "type": ["null", "number"]
+    },
+    "customer.pay_per_conversion_eligibility_failure_reasons": {
+      "type": ["null", "array"],
+      "items": {
+        "type": "string"
+      }
+    },
+    "customer.remarketing_setting.google_global_site_tag": {
+      "type": ["null", "string"]
+    },
+    "customer.resource_name": {
+      "type": ["null", "string"]
+    },
+    "customer.test_account": {
+      "type": ["null", "boolean"]
+    },
+    "customer.time_zone": {
+      "type": ["null", "string"]
+    },
+    "customer.tracking_url_template": {
+      "type": ["null", "string"]
+    }
+  }
+}

--- a/airbyte-integrations/connectors/source-google-ads/source_google_ads/source.py
+++ b/airbyte-integrations/connectors/source-google-ads/source_google_ads/source.py
@@ -4,7 +4,7 @@
 
 
 import traceback
-from typing import Any, List, Mapping, Tuple, Union
+from typing import Any, Iterable, List, Mapping, MutableMapping, Tuple
 
 from airbyte_cdk import AirbyteLogger
 from airbyte_cdk.models import SyncMode
@@ -12,13 +12,14 @@ from airbyte_cdk.sources import AbstractSource
 from airbyte_cdk.sources.streams import Stream
 from google.ads.googleads.errors import GoogleAdsException
 from pendulum import parse, timezone, today
-from pendulum.tz.timezone import Timezone
 
 from .custom_query_stream import CustomQuery
 from .google_ads import GoogleAds
+from .models import Customer
 from .streams import (
     AccountPerformanceReport,
     Accounts,
+    ServiceAccounts,
     AdGroupAdLabels,
     AdGroupAdReport,
     AdGroupAds,
@@ -38,7 +39,7 @@ from .streams import (
 
 class SourceGoogleAds(AbstractSource):
     @staticmethod
-    def get_credentials(config: Mapping[str, Any]) -> Mapping[str, Any]:
+    def get_credentials(config: Mapping[str, Any]) -> MutableMapping[str, Any]:
         credentials = config["credentials"]
         # use_proto_plus is set to True, because setting to False returned wrong value types, which breakes the backward compatibility.
         # For more info read the related PR's description: https://github.com/airbytehq/airbyte/pull/9996
@@ -50,36 +51,25 @@ class SourceGoogleAds(AbstractSource):
         return credentials
 
     @staticmethod
-    def get_incremental_stream_config(google_api: GoogleAds, config: Mapping[str, Any], tz: Union[timezone, str] = "local"):
+    def get_incremental_stream_config(google_api: GoogleAds, config: Mapping[str, Any], customers: List[Customer]):
         true_end_date = None
         configured_end_date = config.get("end_date")
         if configured_end_date is not None:
             true_end_date = min(today(), parse(configured_end_date)).to_date_string()
         incremental_stream_config = dict(
             api=google_api,
+            customers=customers,
             conversion_window_days=config["conversion_window_days"],
             start_date=config["start_date"],
-            time_zone=tz,
             end_date=true_end_date,
         )
         return incremental_stream_config
 
-    def get_account_info(self, google_api: GoogleAds, config: Mapping[str, Any]) -> dict:
-        incremental_stream_config = self.get_incremental_stream_config(google_api, config)
-        accounts_streams = Accounts(**incremental_stream_config)
-        for stream_slice in accounts_streams.stream_slices(sync_mode=SyncMode.full_refresh):
-            return next(accounts_streams.read_records(sync_mode=SyncMode.full_refresh, stream_slice=stream_slice), {})
-
-    @staticmethod
-    def get_time_zone(account: dict) -> Union[timezone, str]:
-        time_zone_name = account.get("customer.time_zone")
-        if time_zone_name:
-            return Timezone(time_zone_name)
-        return "local"
-
-    @staticmethod
-    def is_manager_account(account: dict) -> bool:
-        return bool(account.get("customer.manager"))
+    def get_account_info(self, google_api: GoogleAds, config: Mapping[str, Any]) -> Iterable[Iterable[Mapping[str, Any]]]:
+        dummy_customers = [Customer(id=_id) for _id in config["customer_id"].split(",")]
+        accounts_stream = ServiceAccounts(google_api, customers=dummy_customers)
+        for slice_ in accounts_stream.stream_slices():
+            yield accounts_stream.read_records(sync_mode=SyncMode.full_refresh, stream_slice=slice_)
 
     @staticmethod
     def is_metrics_in_custom_query(query: str) -> bool:
@@ -92,22 +82,23 @@ class SourceGoogleAds(AbstractSource):
     def check_connection(self, logger: AirbyteLogger, config: Mapping[str, Any]) -> Tuple[bool, any]:
         try:
             logger.info("Checking the config")
-            google_api = GoogleAds(credentials=self.get_credentials(config), customer_id=config["customer_id"])
-            account_info = self.get_account_info(google_api, config)
-            is_manager_account = self.is_manager_account(account_info)
+            google_api = GoogleAds(credentials=self.get_credentials(config))
 
+            accounts = self.get_account_info(google_api, config)
+            customers = Customer.from_accounts(accounts)
             # Check custom query request validity by sending metric request with non-existant time window
-            for query in config.get("custom_queries", []):
-                query = query.get("query")
-
-                if is_manager_account and self.is_metrics_in_custom_query(query):
-                    return False, f"Metrics are not available for manager account. Check fields in your custom query: {query}"
-                if CustomQuery.cursor_field in query:
-                    return False, f"Custom query should not contain {CustomQuery.cursor_field}"
-
-                req_q = CustomQuery.insert_segments_date_expr(query, "1980-01-01", "1980-01-01")
-                for customer_id in google_api.customer_ids:
-                    google_api.send_request(req_q, customer_id=customer_id)
+            for customer in customers:
+                for query in config.get("custom_queries", []):
+                    query = query.get("query")
+                    if customer.is_manager_account and self.is_metrics_in_custom_query(query):
+                        return False, f"Metrics are not available for manager account. Check fields in your custom query: {query}"
+                    if CustomQuery.cursor_field in query:
+                        return False, f"Custom query should not contain {CustomQuery.cursor_field}"
+                    req_q = CustomQuery.insert_segments_date_expr(query, "1980-01-01", "1980-01-01")
+                    response = google_api.send_request(req_q, customer_id=customer.id)
+                    # iterate over the response otherwise exceptions will not be raised!
+                    for _ in response:
+                        pass
             return True, None
         except GoogleAdsException as exception:
             error_messages = ", ".join([error.message for error in exception.failure.errors])
@@ -115,19 +106,18 @@ class SourceGoogleAds(AbstractSource):
             return False, f"Unable to connect to Google Ads API with the provided credentials - {error_messages}"
 
     def streams(self, config: Mapping[str, Any]) -> List[Stream]:
-        google_api = GoogleAds(credentials=self.get_credentials(config), customer_id=config["customer_id"])
-        account_info = self.get_account_info(google_api, config)
-        time_zone = self.get_time_zone(account_info)
-        incremental_stream_config = self.get_incremental_stream_config(google_api, config, tz=time_zone)
-
+        google_api = GoogleAds(credentials=self.get_credentials(config))
+        accounts = self.get_account_info(google_api, config)
+        customers = Customer.from_accounts(accounts)
+        incremental_stream_config = self.get_incremental_stream_config(google_api, config, customers)
         streams = [
             AdGroupAds(**incremental_stream_config),
-            AdGroupAdLabels(google_api),
+            AdGroupAdLabels(google_api, customers=customers),
             AdGroups(**incremental_stream_config),
-            AdGroupLabels(google_api),
+            AdGroupLabels(google_api, customers=customers),
             Accounts(**incremental_stream_config),
             Campaigns(**incremental_stream_config),
-            CampaignLabels(google_api),
+            CampaignLabels(google_api, customers=customers),
             ClickView(**incremental_stream_config),
         ]
         custom_query_streams = [
@@ -137,7 +127,9 @@ class SourceGoogleAds(AbstractSource):
         streams.extend(custom_query_streams)
 
         # Metrics streams cannot be requested for a manager account.
-        if not self.is_manager_account(account_info):
+        non_manager_accounts = [customer for customer in customers if not customer.is_manager_account]
+        if non_manager_accounts:
+            incremental_stream_config["customers"] = non_manager_accounts
             streams.extend(
                 [
                     UserLocationReport(**incremental_stream_config),

--- a/airbyte-integrations/connectors/source-google-ads/source_google_ads/source.py
+++ b/airbyte-integrations/connectors/source-google-ads/source_google_ads/source.py
@@ -11,7 +11,7 @@ from airbyte_cdk.models import SyncMode
 from airbyte_cdk.sources import AbstractSource
 from airbyte_cdk.sources.streams import Stream
 from google.ads.googleads.errors import GoogleAdsException
-from pendulum import parse, timezone, today
+from pendulum import parse, today
 
 from .custom_query_stream import CustomQuery
 from .google_ads import GoogleAds
@@ -19,7 +19,6 @@ from .models import Customer
 from .streams import (
     AccountPerformanceReport,
     Accounts,
-    ServiceAccounts,
     AdGroupAdLabels,
     AdGroupAdReport,
     AdGroupAds,
@@ -32,6 +31,7 @@ from .streams import (
     DisplayTopicsPerformanceReport,
     GeographicReport,
     KeywordReport,
+    ServiceAccounts,
     ShoppingPerformanceReport,
     UserLocationReport,
 )
@@ -103,7 +103,7 @@ class SourceGoogleAds(AbstractSource):
         except GoogleAdsException as exception:
             error_messages = ", ".join([error.message for error in exception.failure.errors])
             logger.error(traceback.format_exc())
-            return False, f"Unable to connect to Google Ads API with the provided credentials - {error_messages}"
+            return False, f"Unable to connect to Google Ads API with the provided configuration - {error_messages}"
 
     def streams(self, config: Mapping[str, Any]) -> List[Stream]:
         google_api = GoogleAds(credentials=self.get_credentials(config))

--- a/airbyte-integrations/connectors/source-google-ads/source_google_ads/spec.json
+++ b/airbyte-integrations/connectors/source-google-ads/source_google_ads/spec.json
@@ -90,7 +90,7 @@
             "query": {
               "type": "string",
               "title": "Custom Query",
-              "description": "A custom defined GAQL query for building the report. Should not contain segments.date expression because it is used by incremental streams. See Google's <a href=\"https://developers.google.com/google-ads/api/fields/v8/overview_query_builder\">query builder</a> for more information.",
+              "description": "A custom defined GAQL query for building the report. Should not contain segments.date expression because it is used by incremental streams. See Google's <a href=\"https://developers.google.com/google-ads/api/fields/v9/overview_query_builder\">query builder</a> for more information.",
               "examples": [
                 "SELECT segments.ad_destination_type, campaign.advertising_channel_sub_type FROM campaign WHERE campaign.status = 'PAUSED'"
               ]

--- a/airbyte-integrations/connectors/source-google-ads/source_google_ads/streams.py
+++ b/airbyte-integrations/connectors/source-google-ads/source_google_ads/streams.py
@@ -3,15 +3,17 @@
 #
 
 from abc import ABC
-from typing import Any, Iterable, List, Mapping, MutableMapping, Optional, Tuple, Union
+from typing import Any, Iterable, List, Mapping, MutableMapping, Optional, Tuple
 
 import pendulum
 from airbyte_cdk.models import SyncMode
-from airbyte_cdk.sources.streams import Stream
+from airbyte_cdk.sources.streams import Stream, IncrementalMixin
 from google.ads.googleads.errors import GoogleAdsException
-from google.ads.googleads.v8.services.services.google_ads_service.pagers import SearchPager
+from google.ads.googleads.v9.errors.types.request_error import RequestErrorEnum
+from google.ads.googleads.v9.services.services.google_ads_service.pagers import SearchPager
 
 from .google_ads import GoogleAds
+from .models import Customer
 
 
 def parse_dates(stream_slice):
@@ -48,7 +50,7 @@ def chunk_date_range(
     days_of_data_storage: int = None,
     range_days: int = None,
     time_zone=None,
-) -> Iterable[Optional[Mapping[str, any]]]:
+) -> Iterable[Optional[MutableMapping[str, any]]]:
     """
     Passing optional parameter end_date for testing
     Returns a list of the beginning and ending timestamps of each `range_days` between the start date and now.
@@ -82,9 +84,11 @@ def chunk_date_range(
 
 
 class GoogleAdsStream(Stream, ABC):
-    def __init__(self, api: GoogleAds):
+    IGNORE_API_ERRORS = False
+
+    def __init__(self, api: GoogleAds, customers: List[Customer]):
         self.google_ads_client = api
-        self._customer_id = None
+        self.customers = customers
 
     def get_query(self, stream_slice: Mapping[str, Any]) -> str:
         query = GoogleAds.convert_schema_into_query(schema=self.get_json_schema(), report_name=self.name)
@@ -95,42 +99,68 @@ class GoogleAdsStream(Stream, ABC):
             yield self.google_ads_client.parse_single_result(self.get_json_schema(), result)
 
     def stream_slices(self, stream_state: Mapping[str, Any] = None, **kwargs) -> Iterable[Optional[Mapping[str, any]]]:
-        for customer_id in self.google_ads_client.customer_ids:
-            self._customer_id = customer_id
-            yield {}
+        for customer in self.customers:
+            yield {"customer_id": customer.id}
 
     def read_records(self, sync_mode, stream_slice: Optional[Mapping[str, Any]] = None, **kwargs) -> Iterable[Mapping[str, Any]]:
-        if not stream_slice:
+        if stream_slice is None:
             return []
-        account_responses = self.google_ads_client.send_request(self.get_query(stream_slice), customer_id=self._customer_id)
-        for response in account_responses:
-            yield from self.parse_response(response)
+
+        customer_id = stream_slice["customer_id"]
+        response_records = self.google_ads_client.send_request(self.get_query(stream_slice), customer_id=customer_id)
+        try:
+            for response in response_records:
+                yield from self.parse_response(response)
+        except GoogleAdsException as exc:
+            if not self.IGNORE_API_ERRORS:
+                raise
+            for error in exc.failure.errors:
+                if (
+                    error.error_code.authentication_error or
+                    error.error_code.authorization_error or
+                    error.error_code.query_error
+                ):
+                    self.logger.error(error.message)
+                    continue
+                # log and ignore only auth and query errors, otherwise - raise further
+                raise
 
 
-class IncrementalGoogleAdsStream(GoogleAdsStream, ABC):
+class IncrementalGoogleAdsStream(GoogleAdsStream, IncrementalMixin, ABC):
     days_of_data_storage = None
     cursor_field = "segments.date"
     primary_key = None
-    range_days = 15  # date range is set to 15 days, because for conversion_window_days default value is 14. Range less than 15 days will break the integration tests.
+    # Date range is set to 15 days, because for conversion_window_days default value is 14.
+    # Range less than 15 days will break the integration tests.
+    range_days = 15
 
-    def __init__(
-        self, start_date: str, conversion_window_days: int, time_zone: Union[pendulum.timezone, str], end_date: str = None, **kwargs
-    ):
+    def __init__(self, start_date: str, conversion_window_days: int, end_date: str = None, **kwargs):
         self.conversion_window_days = conversion_window_days
         self._start_date = start_date
-        self.time_zone = time_zone
         self._end_date = end_date
+        self._state = {}
         super().__init__(**kwargs)
 
-    def stream_slices(self, stream_state: Mapping[str, Any] = None, **kwargs) -> Iterable[Optional[Mapping[str, any]]]:
-        for customer_id in self.google_ads_client.customer_ids:
-            self._customer_id = customer_id
+    @property
+    def state(self) -> MutableMapping[str, Any]:
+        return self._state
+
+    @state.setter
+    def state(self, value: MutableMapping[str, Any]):
+        self._state.update(value)
+
+    def current_state(self, customer_id, default=None):
+        default = default or self.state.get(self.cursor_field)
+        return self.state.get(customer_id, {}).get(self.cursor_field) or default
+
+    def stream_slices(self, stream_state: Mapping[str, Any] = None, **kwargs) -> Iterable[Optional[MutableMapping[str, any]]]:
+        for customer in self.customers:
             stream_state = stream_state or {}
-            if stream_state.get(customer_id):
-                start_date = stream_state[customer_id].get(self.cursor_field) or self._start_date
+            if stream_state.get(customer.id):
+                start_date = stream_state[customer.id].get(self.cursor_field) or self._start_date
 
             # We should keep backward compatibility with the previous version
-            elif stream_state.get(self.cursor_field) and len(self.google_ads_client.customer_ids) == 1:
+            elif stream_state.get(self.cursor_field) and len(self.customers) == 1:
                 start_date = stream_state.get(self.cursor_field) or self._start_date
             else:
                 start_date = self._start_date
@@ -144,69 +174,61 @@ class IncrementalGoogleAdsStream(GoogleAdsStream, ABC):
                 field=self.cursor_field,
                 days_of_data_storage=self.days_of_data_storage,
                 range_days=self.range_days,
-                time_zone=self.time_zone,
+                time_zone=customer.time_zone,
             ):
+                if chunk:
+                    chunk["customer_id"] = customer.id
                 yield chunk
 
     def read_records(
         self,
         sync_mode: SyncMode,
         cursor_field: List[str] = None,
-        stream_slice: Mapping[str, Any] = None,
-        stream_state: Mapping[str, Any] = None,
+        stream_slice: MutableMapping[str, Any] = None,
+        **kwargs
     ) -> Iterable[Mapping[str, Any]]:
         """
         This method is overridden to handle GoogleAdsException with EXPIRED_PAGE_TOKEN error code,
         and update `start_date` key in the `stream_slice` with the latest read record's cursor value, then retry the sync.
         """
-        state = stream_state or {}
         while True:
+            customer_id = stream_slice and stream_slice["customer_id"]
             try:
                 records = super().read_records(sync_mode, stream_slice=stream_slice)
                 for record in records:
-                    state = self.get_updated_state(state, record)
+                    current_state = self.current_state(customer_id)
+                    if current_state:
+                        date_in_current_stream = pendulum.parse(current_state)
+                        date_in_latest_record = pendulum.parse(record[self.cursor_field])
+                        cursor_value = (max(date_in_current_stream, date_in_latest_record)).to_date_string()
+                        self.state = {customer_id: {self.cursor_field: cursor_value}}
+                        yield record
+                        continue
+                    self.state = {customer_id: {self.cursor_field: record[self.cursor_field]}}
                     yield record
+                    continue
             except GoogleAdsException as exception:
-                if exception.failure._pb.errors[0].error_code.request_error == 8:
-                    # page token has expired (EXPIRED_PAGE_TOKEN = 8)
+                error = next(iter(exception.failure.errors))
+                if error.error_code.request_error == RequestErrorEnum.RequestError.EXPIRED_PAGE_TOKEN:
                     start_date, end_date = parse_dates(stream_slice)
+                    current_state = self.current_state(customer_id)
                     if (end_date - start_date).days == 1:
                         # If range days is 1, no need in retry, because it's the minimum date range
                         self.logger.error("Page token has expired.")
                         raise exception
-                    elif state.get(self._customer_id, {}).get(self.cursor_field) == stream_slice["start_date"]:
+                    elif current_state == stream_slice["start_date"]:
                         # It couldn't read all the records within one day, it will enter an infinite loop,
                         # so raise the error
                         self.logger.error("Page token has expired.")
                         raise exception
                     # Retry reading records from where it crushed
-                    stream_slice["start_date"] = state.get(self._customer_id, {}).get(self.cursor_field, stream_slice["start_date"])
+                    stream_slice["start_date"] = self.current_state(customer_id, default=stream_slice["start_date"])
                 else:
                     # raise caught error for other error statuses
                     raise exception
             else:
                 # return the control if no exception is raised
                 return
-
-    def get_updated_state(self, current_stream_state: MutableMapping[str, Any], latest_record: Mapping[str, Any]) -> Mapping[str, Any]:
-        current_stream_state = current_stream_state or {}
-
-        if current_stream_state.get(self.cursor_field):
-            stream_state = current_stream_state.pop(self.cursor_field)
-        elif current_stream_state.get(self._customer_id) and current_stream_state[self._customer_id].get(self.cursor_field):
-            stream_state = current_stream_state[self._customer_id][self.cursor_field]
-        else:
-            current_stream_state.update({self._customer_id: {self.cursor_field: latest_record[self.cursor_field]}})
-            return current_stream_state
-
-        date_in_current_stream = pendulum.parse(stream_state)
-        date_in_latest_record = pendulum.parse(latest_record[self.cursor_field])
-
-        current_stream_state.update(
-            {self._customer_id: {self.cursor_field: (max(date_in_current_stream, date_in_latest_record)).to_date_string()}}
-        )
-
-        return current_stream_state
 
     def get_query(self, stream_slice: Mapping[str, Any] = None) -> str:
         query = GoogleAds.convert_schema_into_query(
@@ -221,15 +243,24 @@ class IncrementalGoogleAdsStream(GoogleAdsStream, ABC):
 
 class Accounts(IncrementalGoogleAdsStream):
     """
-    Accounts stream: https://developers.google.com/google-ads/api/fields/v8/customer
+    Accounts stream: https://developers.google.com/google-ads/api/fields/v9/customer
     """
 
     primary_key = ["customer.id", "segments.date"]
 
 
+class ServiceAccounts(GoogleAdsStream):
+    """
+    This stream is intended to be used as a service class, not exposed to a user
+    """
+
+    IGNORE_API_ERRORS = True
+    primary_key = ["customer.id"]
+
+
 class Campaigns(IncrementalGoogleAdsStream):
     """
-    Campaigns stream: https://developers.google.com/google-ads/api/fields/v8/campaign
+    Campaigns stream: https://developers.google.com/google-ads/api/fields/v9/campaign
     """
 
     primary_key = ["campaign.id", "segments.date"]
@@ -237,7 +268,7 @@ class Campaigns(IncrementalGoogleAdsStream):
 
 class CampaignLabels(GoogleAdsStream):
     """
-    Campaign labels stream: https://developers.google.com/google-ads/api/fields/v8/campaign_label
+    Campaign labels stream: https://developers.google.com/google-ads/api/fields/v9/campaign_label
     """
 
     # Note that this is a string type. Google doesn't return a more convenient identifier.
@@ -246,7 +277,7 @@ class CampaignLabels(GoogleAdsStream):
 
 class AdGroups(IncrementalGoogleAdsStream):
     """
-    AdGroups stream: https://developers.google.com/google-ads/api/fields/v8/ad_group
+    AdGroups stream: https://developers.google.com/google-ads/api/fields/v9/ad_group
     """
 
     primary_key = ["ad_group.id", "segments.date"]
@@ -254,7 +285,7 @@ class AdGroups(IncrementalGoogleAdsStream):
 
 class AdGroupLabels(GoogleAdsStream):
     """
-    Ad Group Labels stream: https://developers.google.com/google-ads/api/fields/v8/ad_group_label
+    Ad Group Labels stream: https://developers.google.com/google-ads/api/fields/v9/ad_group_label
     """
 
     # Note that this is a string type. Google doesn't return a more convenient identifier.
@@ -263,7 +294,7 @@ class AdGroupLabels(GoogleAdsStream):
 
 class AdGroupAds(IncrementalGoogleAdsStream):
     """
-    AdGroups stream: https://developers.google.com/google-ads/api/fields/v8/ad_group_ad
+    AdGroups stream: https://developers.google.com/google-ads/api/fields/v9/ad_group_ad
     """
 
     primary_key = ["ad_group_ad.ad.id", "segments.date"]
@@ -271,7 +302,7 @@ class AdGroupAds(IncrementalGoogleAdsStream):
 
 class AdGroupAdLabels(GoogleAdsStream):
     """
-    Ad Group Ad Labels stream: https://developers.google.com/google-ads/api/fields/v8/ad_group_ad_label
+    Ad Group Ad Labels stream: https://developers.google.com/google-ads/api/fields/v9/ad_group_ad_label
     """
 
     # Note that this is a string type. Google doesn't return a more convenient identifier.
@@ -280,61 +311,61 @@ class AdGroupAdLabels(GoogleAdsStream):
 
 class AccountPerformanceReport(IncrementalGoogleAdsStream):
     """
-    AccountPerformanceReport stream: https://developers.google.com/google-ads/api/fields/v8/customer
+    AccountPerformanceReport stream: https://developers.google.com/google-ads/api/fields/v9/customer
     Google Ads API field mapping: https://developers.google.com/google-ads/api/docs/migration/mapping#account_performance
     """
 
 
 class AdGroupAdReport(IncrementalGoogleAdsStream):
     """
-    AdGroupAdReport stream: https://developers.google.com/google-ads/api/fields/v8/ad_group_ad
+    AdGroupAdReport stream: https://developers.google.com/google-ads/api/fields/v9/ad_group_ad
     Google Ads API field mapping: https://developers.google.com/google-ads/api/docs/migration/mapping#ad_performance
     """
 
 
 class DisplayKeywordPerformanceReport(IncrementalGoogleAdsStream):
     """
-    DisplayKeywordPerformanceReport stream: https://developers.google.com/google-ads/api/fields/v8/display_keyword_view
+    DisplayKeywordPerformanceReport stream: https://developers.google.com/google-ads/api/fields/v9/display_keyword_view
     Google Ads API field mapping: https://developers.google.com/google-ads/api/docs/migration/mapping#display_keyword_performance
     """
 
 
 class DisplayTopicsPerformanceReport(IncrementalGoogleAdsStream):
     """
-    DisplayTopicsPerformanceReport stream: https://developers.google.com/google-ads/api/fields/v8/topic_view
+    DisplayTopicsPerformanceReport stream: https://developers.google.com/google-ads/api/fields/v9/topic_view
     Google Ads API field mapping: https://developers.google.com/google-ads/api/docs/migration/mapping#display_topics_performance
     """
 
 
 class ShoppingPerformanceReport(IncrementalGoogleAdsStream):
     """
-    ShoppingPerformanceReport stream: https://developers.google.com/google-ads/api/fields/v8/shopping_performance_view
+    ShoppingPerformanceReport stream: https://developers.google.com/google-ads/api/fields/v9/shopping_performance_view
     Google Ads API field mapping: https://developers.google.com/google-ads/api/docs/migration/mapping#shopping_performance
     """
 
 
 class UserLocationReport(IncrementalGoogleAdsStream):
     """
-    UserLocationReport stream: https://developers.google.com/google-ads/api/fields/v8/user_location_view
+    UserLocationReport stream: https://developers.google.com/google-ads/api/fields/v9/user_location_view
     Google Ads API field mapping: https://developers.google.com/google-ads/api/docs/migration/mapping#geo_performance
     """
 
 
 class GeographicReport(IncrementalGoogleAdsStream):
     """
-    UserLocationReport stream: https://developers.google.com/google-ads/api/fields/v8/geographic_view
+    UserLocationReport stream: https://developers.google.com/google-ads/api/fields/v9/geographic_view
     """
 
 
 class KeywordReport(IncrementalGoogleAdsStream):
     """
-    UserLocationReport stream: https://developers.google.com/google-ads/api/fields/v8/keyword_view
+    UserLocationReport stream: https://developers.google.com/google-ads/api/fields/v9/keyword_view
     """
 
 
 class ClickView(IncrementalGoogleAdsStream):
     """
-    ClickView stream: https://developers.google.com/google-ads/api/reference/rpc/v8/ClickView
+    ClickView stream: https://developers.google.com/google-ads/api/reference/rpc/v9/ClickView
     """
 
     primary_key = ["click_view.gclid", "segments.date", "segments.ad_network_type"]

--- a/airbyte-integrations/connectors/source-google-ads/source_google_ads/streams.py
+++ b/airbyte-integrations/connectors/source-google-ads/source_google_ads/streams.py
@@ -9,6 +9,7 @@ import pendulum
 from airbyte_cdk.models import SyncMode
 from airbyte_cdk.sources.streams import IncrementalMixin, Stream
 from google.ads.googleads.errors import GoogleAdsException
+from google.ads.googleads.v9.errors.types.authorization_error import AuthorizationErrorEnum
 from google.ads.googleads.v9.errors.types.request_error import RequestErrorEnum
 from google.ads.googleads.v9.services.services.google_ads_service.pagers import SearchPager
 
@@ -115,10 +116,10 @@ class GoogleAdsStream(Stream, ABC):
             if not self.CATCH_API_ERRORS:
                 raise
             for error in exc.failure.errors:
-                if error.error_code.authentication_error or error.error_code.authorization_error or error.error_code.query_error:
+                if error.error_code.authorization_error == AuthorizationErrorEnum.AuthorizationError.CUSTOMER_NOT_ENABLED:
                     self.logger.error(error.message)
                     continue
-                # log and ignore only auth and query errors, otherwise - raise further
+                # log and ignore only CUSTOMER_NOT_ENABLED error, otherwise - raise further
                 raise
 
 

--- a/airbyte-integrations/connectors/source-google-ads/unit_tests/common.py
+++ b/airbyte-integrations/connectors/source-google-ads/unit_tests/common.py
@@ -45,11 +45,11 @@ class MockErroringGoogleAdsService:
         raise make_google_ads_exception(1)
 
 
-def make_google_ads_exception(failure_code: int):
+def make_google_ads_exception(failure_code: int = 1, failure_msg: str = "it failed", error_type: str = "request_error"):
     # There is no easy way I could find to mock a GoogleAdsException without doing something heinous like this
     # Following the definition of the object here
     # https://developers.google.com/google-ads/api/reference/rpc/v10/GoogleAdsFailure
-    protobuf_as_json = json.dumps({"errors": [{"error_code": {"request_error": failure_code}, "message": "it failed"}], "request_id": "1"})
+    protobuf_as_json = json.dumps({"errors": [{"error_code": {error_type: failure_code}, "message": failure_msg}], "request_id": "1"})
     failure = type(GoogleAdsFailure).from_json(GoogleAdsFailure, protobuf_as_json)
     return GoogleAdsException(None, None, failure, 1)
 

--- a/airbyte-integrations/connectors/source-google-ads/unit_tests/conftest.py
+++ b/airbyte-integrations/connectors/source-google-ads/unit_tests/conftest.py
@@ -3,6 +3,7 @@
 #
 
 import pytest
+from source_google_ads.models import Customer
 
 
 @pytest.fixture(scope="session", name="config")
@@ -47,3 +48,8 @@ def mock_oauth_call(requests_mock):
         "https://accounts.google.com/o/oauth2/token",
         json={"access_token": "access_token", "refresh_token": "refresh_token", "expires_in": 0},
     )
+
+
+@pytest.fixture
+def customers(config):
+    return [Customer(id=_id, time_zone="local", is_manager_account=False) for _id in config["customer_id"].split(",")]

--- a/airbyte-integrations/connectors/source-google-ads/unit_tests/test_custom_query.py
+++ b/airbyte-integrations/connectors/source-google-ads/unit_tests/test_custom_query.py
@@ -1,0 +1,25 @@
+#
+# Copyright (c) 2021 Airbyte, Inc., all rights reserved.
+#
+
+from source_google_ads.custom_query_stream import CustomQuery
+
+
+def test_custom_query():
+    input_q = """SELECT ad_group.resource_name, ad_group.status, ad_group.target_cpa_micros, ad_group.target_cpm_micros,
+     ad_group.target_roas, ad_group.targeting_setting.target_restrictions, ad_group.tracking_url_template, ad_group.type,
+     ad_group.url_custom_parameters, campaign.accessible_bidding_strategy, campaign.ad_serving_optimization_status,
+     campaign.advertising_channel_type, campaign.advertising_channel_sub_type, campaign.app_campaign_setting.app_id,
+     campaign.app_campaign_setting.app_store FROM search_term_view"""
+    output_q = CustomQuery.insert_segments_date_expr(input_q, "1980-01-01", "1980-01-01")
+    assert (
+        output_q
+        == """SELECT ad_group.resource_name, ad_group.status, ad_group.target_cpa_micros, ad_group.target_cpm_micros,
+     ad_group.target_roas, ad_group.targeting_setting.target_restrictions, ad_group.tracking_url_template, ad_group.type,
+     ad_group.url_custom_parameters, campaign.accessible_bidding_strategy, campaign.ad_serving_optimization_status,
+     campaign.advertising_channel_type, campaign.advertising_channel_sub_type, campaign.app_campaign_setting.app_id,
+     campaign.app_campaign_setting.app_store , segments.date
+FROM search_term_view
+WHERE segments.date BETWEEN '1980-01-01' AND '1980-01-01'
+"""
+    )

--- a/airbyte-integrations/connectors/source-google-ads/unit_tests/test_google_ads.py
+++ b/airbyte-integrations/connectors/source-google-ads/unit_tests/test_google_ads.py
@@ -8,6 +8,7 @@ import pendulum
 from freezegun import freeze_time
 from pendulum.tz.timezone import Timezone
 from source_google_ads.google_ads import GoogleAds
+from source_google_ads.models import Customer
 from source_google_ads.streams import IncrementalGoogleAdsStream, chunk_date_range, get_date_params
 
 from .common import MockGoogleAdsClient, MockGoogleAdsService
@@ -52,18 +53,17 @@ EXPECTED_CRED = {
 
 def test_google_ads_init(mocker):
     google_client_mocker = mocker.patch("source_google_ads.google_ads.GoogleAdsClient", return_value=MockGoogleAdsClient)
-    google_ads_client = GoogleAds(**SAMPLE_CONFIG)
-    assert google_ads_client.customer_ids == SAMPLE_CONFIG["customer_id"].split(",")
+    _ = GoogleAds(**SAMPLE_CONFIG)
     assert google_client_mocker.load_from_dict.call_args[0][0] == EXPECTED_CRED
 
 
-def test_send_request(mocker):
+def test_send_request(mocker, customers):
     mocker.patch("source_google_ads.google_ads.GoogleAdsClient.load_from_dict", return_value=MockGoogleAdsClient(SAMPLE_CONFIG))
     mocker.patch("source_google_ads.google_ads.GoogleAdsClient.get_service", return_value=MockGoogleAdsService())
     google_ads_client = GoogleAds(**SAMPLE_CONFIG)
     query = "Query"
     page_size = 1000
-    customer_id = SAMPLE_CONFIG["customer_id"].split(",")[0]
+    customer_id = next(iter(customers)).id
     response = list(google_ads_client.send_request(query, customer_id=customer_id))
 
     assert response[0].customer_id == customer_id
@@ -83,14 +83,14 @@ def test_interval_chunking():
         {"start_date": "2021-07-08", "end_date": "2021-07-17"},
         {"start_date": "2021-07-18", "end_date": "2021-07-27"},
         {"start_date": "2021-07-28", "end_date": "2021-08-06"},
-        {"start_date": "2021-08-07", "end_date": "2021-08-16"},
+        {"start_date": "2021-08-07", "end_date": "2021-08-15"},
     ]
     intervals = chunk_date_range("2021-07-01", 14, "segments.date", "2021-08-15", range_days=10)
 
     assert mock_intervals == intervals
 
 
-def test_get_date_params():
+def test_get_date_params(customers):
     # Please note that this is equal to inputted stream_slice start date + 1 day
     mock_start_date = "2021-05-19"
     mock_end_date = "2021-06-02"
@@ -100,23 +100,26 @@ def test_get_date_params():
         conversion_window_days=mock_conversion_window_days,
         start_date=mock_start_date,
         api=MockGoogleAdsClient(SAMPLE_CONFIG),
-        time_zone="local",
+        customers=customers,
     )
 
     stream = IncrementalGoogleAdsStream(**incremental_stream_config)
 
-    start_date, end_date = get_date_params(
-        start_date="2021-05-18", range_days=stream.range_days, time_zone=stream.time_zone, end_date=pendulum.parse("2021-08-15")
-    )
+    for customer in stream.customers:
+        start_date, end_date = get_date_params(
+            start_date="2021-05-18", range_days=stream.range_days, time_zone=customer.time_zone, end_date=pendulum.parse("2021-08-15")
+        )
 
-    assert mock_start_date == start_date and mock_end_date == end_date
+        assert mock_start_date == start_date and mock_end_date == end_date
 
 
 @freeze_time("2022-01-30 03:21:34", tz_offset=0)
 def test_get_date_params_with_time_zone():
     time_zone_chatham = Timezone("Pacific/Chatham")  # UTC+12:45
+    customer = Customer(id="id", time_zone=time_zone_chatham, is_manager_account=False)
     mock_start_date_chatham = pendulum.today(tz=time_zone_chatham).subtract(days=1).to_date_string()
     time_zone_honolulu = Timezone("Pacific/Honolulu")  # UTC-10:00
+    customer_2 = Customer(id="id_2", time_zone=time_zone_honolulu, is_manager_account=False)
     mock_start_date_honolulu = pendulum.today(tz=time_zone_honolulu).subtract(days=1).to_date_string()
 
     mock_conversion_window_days = 14
@@ -125,18 +128,18 @@ def test_get_date_params_with_time_zone():
         conversion_window_days=mock_conversion_window_days,
         start_date=mock_start_date_chatham,
         api=MockGoogleAdsClient(SAMPLE_CONFIG),
-        time_zone=time_zone_chatham,
+        customers=[customer],
     )
     stream = IncrementalGoogleAdsStream(**incremental_stream_config)
     start_date_chatham, end_date_chatham = get_date_params(
-        start_date=mock_start_date_chatham, time_zone=stream.time_zone, range_days=stream.range_days
+        start_date=mock_start_date_chatham, time_zone=customer.time_zone, range_days=stream.range_days
     )
 
-    incremental_stream_config.update({"start_date": mock_start_date_honolulu, "time_zone": time_zone_honolulu})
+    incremental_stream_config.update({"start_date": mock_start_date_honolulu, "customers": [customer_2]})
     stream_2 = IncrementalGoogleAdsStream(**incremental_stream_config)
 
     start_date_honolulu, end_date_honolulu = get_date_params(
-        start_date=mock_start_date_honolulu, time_zone=stream_2.time_zone, range_days=stream_2.range_days
+        start_date=mock_start_date_honolulu, time_zone=customer_2.time_zone, range_days=stream_2.range_days
     )
 
     assert start_date_honolulu != start_date_chatham and end_date_honolulu != end_date_chatham
@@ -176,7 +179,7 @@ SAMPLE_CONFIG_WITH_DATE = {
 }
 
 
-def test_get_date_params_with_date():
+def test_get_date_params_with_date(customers):
     # Please note that this is equal to inputted stream_slice start date + 1 day
     mock_start_date = SAMPLE_CONFIG_WITH_DATE["start_date"]
     mock_end_date = SAMPLE_CONFIG_WITH_DATE["end_date"]
@@ -184,14 +187,15 @@ def test_get_date_params_with_date():
         start_date=mock_start_date,
         end_date=mock_end_date,
         conversion_window_days=0,
-        time_zone="local",
+        customers=customers,
         api=MockGoogleAdsClient(SAMPLE_CONFIG_WITH_DATE),
     )
     stream = IncrementalGoogleAdsStream(**incremental_stream_config)
-    start_date, end_date = get_date_params(
-        start_date="2021-10-31", time_zone=stream.time_zone, range_days=stream.range_days, end_date=pendulum.parse("2021-11-15")
-    )
-    assert mock_start_date == start_date and mock_end_date == end_date
+    for customer in stream.customers:
+        start_date, end_date = get_date_params(
+            start_date="2021-10-31", time_zone=customer.time_zone, range_days=stream.range_days, end_date=pendulum.parse("2021-11-15")
+        )
+        assert mock_start_date == start_date and mock_end_date == end_date
 
 
 SAMPLE_CONFIG_WITHOUT_END_DATE = {
@@ -206,7 +210,7 @@ SAMPLE_CONFIG_WITHOUT_END_DATE = {
 }
 
 
-def test_get_date_params_without_end_date():
+def test_get_date_params_without_end_date(customers):
     # Please note that this is equal to inputted stream_slice start date + 1 day
     mock_start_date = SAMPLE_CONFIG_WITHOUT_END_DATE["start_date"]
     mock_end_date = "2021-11-30"
@@ -214,11 +218,12 @@ def test_get_date_params_without_end_date():
         start_date=mock_start_date,
         end_date=mock_end_date,
         conversion_window_days=0,
-        time_zone="local",
+        customers=customers,
         api=MockGoogleAdsClient(SAMPLE_CONFIG_WITHOUT_END_DATE),
     )
     stream = IncrementalGoogleAdsStream(**incremental_stream_config)
-    start_date, end_date = get_date_params(start_date="2021-10-31", range_days=stream.range_days, time_zone=stream.time_zone)
-    assert mock_start_date == start_date
-    # There is a Google limitation where we capture only a 15-day date range
-    assert end_date == "2021-11-15"
+    for customer in stream.customers:
+        start_date, end_date = get_date_params(start_date="2021-10-31", range_days=stream.range_days, time_zone=customer.time_zone)
+        assert mock_start_date == start_date
+        # There is a Google limitation where we capture only a 15-day date range
+        assert end_date == "2021-11-15"

--- a/airbyte-integrations/connectors/source-google-ads/unit_tests/test_google_ads.py
+++ b/airbyte-integrations/connectors/source-google-ads/unit_tests/test_google_ads.py
@@ -37,9 +37,9 @@ SAMPLE_CONFIG = {
         "client_id": "client_id",
         "client_secret": "client_secret",
         "refresh_token": "refresh_token",
-    },
-    "customer_id": "customer_id",
+    }
 }
+
 
 EXPECTED_CRED = {
     "developer_token": "developer_token",

--- a/airbyte-integrations/connectors/source-google-ads/unit_tests/test_models.py
+++ b/airbyte-integrations/connectors/source-google-ads/unit_tests/test_models.py
@@ -1,0 +1,21 @@
+#
+# Copyright (c) 2021 Airbyte, Inc., all rights reserved.
+#
+
+import pytest
+from source_google_ads.models import Customer
+
+
+def test_time_zone():
+    mock_account_info = [[{"customer.id": "8765"}]]
+    customers = Customer.from_accounts(mock_account_info)
+    for customer in customers:
+        assert customer.time_zone == "local"
+
+
+@pytest.mark.parametrize("is_manager_account", (True, False))
+def test_manager_account(is_manager_account):
+    mock_account_info = [[{"customer.manager": is_manager_account, "customer.id": "8765"}]]
+    customers = Customer.from_accounts(mock_account_info)
+    for customer in customers:
+        assert customer.is_manager_account is is_manager_account

--- a/airbyte-integrations/connectors/source-google-ads/unit_tests/test_source.py
+++ b/airbyte-integrations/connectors/source-google-ads/unit_tests/test_source.py
@@ -8,31 +8,52 @@ from unittest.mock import Mock
 import pytest
 from airbyte_cdk import AirbyteLogger
 from freezegun import freeze_time
+from google.ads.googleads.errors import GoogleAdsException
 from pendulum import today
 from source_google_ads.custom_query_stream import CustomQuery
 from source_google_ads.google_ads import GoogleAds
 from source_google_ads.source import SourceGoogleAds
-from source_google_ads.streams import AdGroupAdReport, chunk_date_range
+from source_google_ads.streams import AdGroupAdReport, AdGroupLabels, ServiceAccounts, chunk_date_range
 
-from .common import MockErroringGoogleAdsClient, MockGoogleAdsClient
+from .common import MockErroringGoogleAdsClient, MockGoogleAdsClient, make_google_ads_exception
 
 
 @pytest.fixture
 def mock_account_info(mocker):
     mocker.patch(
         "source_google_ads.source.SourceGoogleAds.get_account_info",
-        Mock(return_value={"customer.manager": False, "customer.time_zone": "Europe/Berlin"}),
+        Mock(return_value=[[{"customer.manager": False, "customer.time_zone": "Europe/Berlin", "customer.id": "8765"}]]),
     )
 
 
 @pytest.fixture()
-def client_mock(config):
-    google_api = GoogleAds(credentials=config["credentials"], customer_id=config["customer_id"])
-    client = AdGroupAdReport(
-        start_date=config["start_date"], api=google_api, conversion_window_days=config["conversion_window_days"], time_zone="local"
-    )
-    client._customer_id = "1234567890"
-    return client
+def stream_mock(mocker, config, customers):
+    def mock(latest_record):
+        mocker.patch("source_google_ads.streams.GoogleAdsStream.read_records", Mock(return_value=[latest_record]))
+        google_api = GoogleAds(credentials=config["credentials"])
+        client = AdGroupAdReport(
+            start_date=config["start_date"], api=google_api, conversion_window_days=config["conversion_window_days"], customers=customers
+        )
+        return client
+
+    return mock
+
+
+@pytest.fixture
+def mocked_gads_api(mocker):
+    def mock(response=None, failure_msg="", error_type=""):
+        def side_effect_func():
+            raise make_google_ads_exception(failure_msg=failure_msg, error_type=error_type)
+            yield
+
+        side_effect = []
+        if response:
+            side_effect.append(response)
+        if failure_msg or error_type:
+            side_effect.append(side_effect_func())
+        mocker.patch("source_google_ads.google_ads.GoogleAds.send_request", side_effect=side_effect)
+
+    return mock
 
 
 @pytest.fixture()
@@ -114,7 +135,7 @@ def test_chunk_date_range():
         {"start_date": "2021-03-31", "end_date": "2021-04-09"},
         {"start_date": "2021-04-10", "end_date": "2021-04-19"},
         {"start_date": "2021-04-20", "end_date": "2021-04-29"},
-        {"start_date": "2021-04-30", "end_date": "2021-05-09"},
+        {"start_date": "2021-04-30", "end_date": "2021-05-04"},
     ] == response
 
 
@@ -123,13 +144,6 @@ def test_streams_count(config, mock_account_info):
     streams = source.streams(config)
     expected_streams_number = 19
     assert len(streams) == expected_streams_number
-
-
-@pytest.mark.parametrize("is_manager_account", (True, False))
-def test_manager_account(is_manager_account):
-    mock_account_info = {"customer.manager": is_manager_account}
-    source = SourceGoogleAds()
-    assert source.is_manager_account(mock_account_info) is is_manager_account
 
 
 @pytest.mark.parametrize(
@@ -147,28 +161,20 @@ def test_metrics_in_custom_query(query, is_metrics_in_query):
     assert source.is_metrics_in_custom_query(query) is is_metrics_in_query
 
 
-def test_time_zone():
-    mock_account_info = {}
-    source = SourceGoogleAds()
-    time_zone = source.get_time_zone(mock_account_info)
-    assert time_zone == "local"
-
-
-def test_get_updated_state(client_mock):
-    current_state_stream = {}
-    latest_record = {"segments.date": "2020-01-01"}
-    new_stream_state = client_mock.get_updated_state(current_state_stream, latest_record)
-    assert new_stream_state == {"1234567890": {"segments.date": "2020-01-01"}}
-
-    current_state_stream = {"segments.date": "2020-01-01"}
-    latest_record = {"segments.date": "2020-02-01"}
-    new_stream_state = client_mock.get_updated_state(current_state_stream, latest_record)
-    assert new_stream_state == {"1234567890": {"segments.date": "2020-02-01"}}
-
-    current_state_stream = {"1234567890": {"segments.date": "2020-02-01"}}
-    latest_record = {"segments.date": "2021-03-03"}
-    new_stream_state = client_mock.get_updated_state(current_state_stream, latest_record)
-    assert new_stream_state == {"1234567890": {"segments.date": "2021-03-03"}}
+@pytest.mark.parametrize(
+    ("latest_record", "current_state", "expected_state"),
+    (
+        ({"segments.date": "2020-01-01"}, {}, {"segments.date": "2020-01-01"}),
+        ({"segments.date": "2020-02-01"}, {"segments.date": "2020-01-01"}, {"segments.date": "2020-02-01"}),
+        ({"segments.date": "2021-03-03"}, {"1234567890": {"segments.date": "2020-02-01"}}, {"segments.date": "2021-03-03"}),
+    ),
+)
+def test_updated_state(stream_mock, latest_record, current_state, expected_state):
+    mocked_stream = stream_mock(latest_record=latest_record)
+    mocked_stream.state = current_state
+    for _ in mocked_stream.read_records(sync_mode=Mock(), stream_slice={"customer_id": "1234567890"}):
+        pass
+    assert mocked_stream.state["1234567890"] == expected_state
 
 
 def stream_instance(query, api_mock, **kwargs):
@@ -178,7 +184,6 @@ def stream_instance(query, api_mock, **kwargs):
         api=api_mock,
         conversion_window_days=conversion_window_days,
         start_date=start_date,
-        time_zone="local",
         custom_query_config={"query": query, "table_name": "whatever_table"},
         **kwargs,
     )
@@ -323,7 +328,7 @@ def test_insert_date(original_query, expected_query):
     assert CustomQuery.insert_segments_date_expr(original_query, "1980-01-01", "2000-01-01") == expected_query
 
 
-def test_get_json_schema_parse_query(mock_fields_meta_data):
+def test_get_json_schema_parse_query(mock_fields_meta_data, customers):
     query = """
         SELECT
             campaign.accessible_bidding_strategy,
@@ -340,14 +345,14 @@ def test_get_json_schema_parse_query(mock_fields_meta_data):
         "segments.date",
     ]
 
-    instance = stream_instance(query=query, api_mock=mock_fields_meta_data)
+    instance = stream_instance(query=query, api_mock=mock_fields_meta_data, customers=customers)
     final_schema = instance.get_json_schema()
     schema_keys = final_schema["properties"]
     assert set(schema_keys) == set(final_fields)  # test 1
 
 
 # Test get json schema when start and end date are provided in the config file
-def test_get_json_schema_parse_query_with_end_date(mock_fields_meta_data):
+def test_get_json_schema_parse_query_with_end_date(mock_fields_meta_data, customers):
     query = """
         SELECT
             campaign.accessible_bidding_strategy,
@@ -364,13 +369,13 @@ def test_get_json_schema_parse_query_with_end_date(mock_fields_meta_data):
         "segments.date",
     ]
 
-    instance = stream_instance(query=query, api_mock=mock_fields_meta_data, end_date="2021-04-04")
+    instance = stream_instance(query=query, api_mock=mock_fields_meta_data, end_date="2021-04-04", customers=customers)
     final_schema = instance.get_json_schema()
     schema_keys = final_schema["properties"]
     assert set(schema_keys) == set(final_fields)  # test 1
 
 
-def test_google_type_conversion(mock_fields_meta_data):
+def test_google_type_conversion(mock_fields_meta_data, customers):
     """
     query may be invalid (fields incompatibility did not checked).
     But we are just testing types, without submitting the query and further steps.
@@ -403,7 +408,7 @@ def test_google_type_conversion(mock_fields_meta_data):
             bidding_strategy.enhanced_cpc
         FROM campaign
         """
-    instance = stream_instance(query=query, api_mock=mock_fields_meta_data)
+    instance = stream_instance(query=query, api_mock=mock_fields_meta_data, customers=customers)
     final_schema = instance.get_json_schema()
     schema_properties = final_schema.get("properties")
     for prop, value in schema_properties.items():
@@ -491,12 +496,72 @@ def test_check_connection_should_fail_when_api_call_fails(mocker):
         },
     )
     assert not check_successful
-    assert message.startswith("Unable to connect to Google Ads API with the provided credentials")
+    assert message.startswith("Unable to connect to Google Ads API with the provided configuration")
 
 
-def test_end_date_is_not_in_the_future():
+def test_end_date_is_not_in_the_future(customers):
     source = SourceGoogleAds()
     config = source.get_incremental_stream_config(
-        None, {"end_date": today().add(days=1).to_date_string(), "conversion_window_days": 14, "start_date": "2020-01-23"}
+        None, {"end_date": today().add(days=1).to_date_string(), "conversion_window_days": 14, "start_date": "2020-01-23"}, customers
     )
     assert config.get("end_date") == today().to_date_string()
+
+
+def test_invalid_custom_query_handled(mocked_gads_api, config):
+    # limit to one custom query, otherwise need to mock more side effects
+    config["custom_queries"] = [next(iter(config["custom_queries"]))]
+    mocked_gads_api(
+        response=[{"customer.id": "8765"}],
+        failure_msg="Unrecognized field in the query: 'ad_group_ad.ad.video_ad.media_file'",
+        error_type="request_error",
+    )
+    source = SourceGoogleAds()
+    status_ok, error = source.check_connection(AirbyteLogger(), config)
+    assert not status_ok
+    assert error == (
+        "Unable to connect to Google Ads API with the provided configuration - Unrecognized field in the query: "
+        "'ad_group_ad.ad.video_ad.media_file'"
+    )
+
+
+@pytest.mark.parametrize(
+    ("cls", "error", "raise_expected", "log_expected"),
+    (
+        (AdGroupLabels, "authentication_error", False, True),
+        (AdGroupLabels, "internal_error", True, False),
+        (ServiceAccounts, "authentication_error", True, False),
+        (ServiceAccounts, "internal_error", True, False),
+    ),
+)
+def test_read_record_error_handling(config, customers, caplog, mocked_gads_api, cls, error, raise_expected, log_expected):
+    error_msg = "Some unexpected error"
+    mocked_gads_api(failure_msg=error_msg, error_type=error)
+    google_api = GoogleAds(credentials=config["credentials"])
+    stream = cls(api=google_api, customers=customers)
+    if raise_expected:
+        with pytest.raises(GoogleAdsException):
+            for _ in stream.read_records(sync_mode=Mock(), stream_slice={"customer_id": "1234567890"}):
+                pass
+    else:
+        for _ in stream.read_records(sync_mode=Mock(), stream_slice={"customer_id": "1234567890"}):
+            pass
+    error_in_log = error_msg in caplog.text
+    assert error_in_log is log_expected
+
+
+def test_stream_slices(config, customers):
+    google_api = GoogleAds(credentials=config["credentials"])
+    stream = AdGroupAdReport(
+        start_date=config["start_date"],
+        api=google_api,
+        conversion_window_days=config["conversion_window_days"],
+        customers=customers,
+        end_date="2021-02-10",
+    )
+    slices = list(stream.stream_slices())
+    assert slices == [
+        {"start_date": "2020-12-19", "end_date": "2021-01-02", "customer_id": "123"},
+        {"start_date": "2021-01-03", "end_date": "2021-01-17", "customer_id": "123"},
+        {"start_date": "2021-01-18", "end_date": "2021-02-01", "customer_id": "123"},
+        {"start_date": "2021-02-02", "end_date": "2021-02-10", "customer_id": "123"},
+    ]

--- a/airbyte-integrations/connectors/source-google-ads/unit_tests/test_streams.py
+++ b/airbyte-integrations/connectors/source-google-ads/unit_tests/test_streams.py
@@ -65,21 +65,22 @@ class MockGoogleAds(GoogleAds):
             return mock_response_2()
 
 
-def test_page_token_expired_retry_succeeds(mock_ads_client, config):
+def test_page_token_expired_retry_succeeds(mock_ads_client, config, customers):
     """
     Page token expired while reading records on date 2021-01-03
     The latest read record is {"segments.date": "2021-01-03", "click_view.gclid": "4"}
     It should retry reading starting from 2021-01-03, already read records will be reread again from that date.
     It shouldn't read records on 2021-01-01, 2021-01-02
     """
-    stream_slice = {"start_date": "2021-01-01", "end_date": "2021-01-15"}
+    customer_id = next(iter(customers)).id
+    stream_slice = {"customer_id": customer_id, "start_date": "2021-01-01", "end_date": "2021-01-15"}
 
-    google_api = MockGoogleAds(credentials=config["credentials"], customer_id=config["customer_id"])
+    google_api = MockGoogleAds(credentials=config["credentials"])
     incremental_stream_config = dict(
         api=google_api,
         conversion_window_days=config["conversion_window_days"],
         start_date=config["start_date"],
-        time_zone="local",
+        customers=customers,
         end_date="2021-04-04",
     )
     stream = ClickView(**incremental_stream_config)
@@ -89,7 +90,7 @@ def test_page_token_expired_retry_succeeds(mock_ads_client, config):
     result = list(stream.read_records(sync_mode=SyncMode.incremental, cursor_field=["segments.date"], stream_slice=stream_slice))
     assert len(result) == 9
     assert stream.get_query.call_count == 2
-    stream.get_query.assert_called_with({"start_date": "2021-01-03", "end_date": "2021-01-15"})
+    stream.get_query.assert_called_with({"customer_id": customer_id, "start_date": "2021-01-03", "end_date": "2021-01-15"})
 
 
 def mock_response_fails_1():
@@ -123,20 +124,21 @@ class MockGoogleAdsFails(MockGoogleAds):
             return mock_response_fails_2()
 
 
-def test_page_token_expired_retry_fails(mock_ads_client, config):
+def test_page_token_expired_retry_fails(mock_ads_client, config, customers):
     """
     Page token has expired while reading records within date "2021-01-03", it should raise error,
     because Google Ads API doesn't allow filter by datetime.
     """
-    stream_slice = {"start_date": "2021-01-01", "end_date": "2021-01-15"}
+    customer_id = next(iter(customers)).id
+    stream_slice = {"customer_id": customer_id, "start_date": "2021-01-01", "end_date": "2021-01-15"}
 
-    google_api = MockGoogleAdsFails(credentials=config["credentials"], customer_id=config["customer_id"])
+    google_api = MockGoogleAdsFails(credentials=config["credentials"])
     incremental_stream_config = dict(
         api=google_api,
         conversion_window_days=config["conversion_window_days"],
         start_date=config["start_date"],
-        time_zone="local",
         end_date="2021-04-04",
+        customers=customers,
     )
     stream = ClickView(**incremental_stream_config)
     stream.get_query = Mock()
@@ -145,7 +147,7 @@ def test_page_token_expired_retry_fails(mock_ads_client, config):
     with pytest.raises(GoogleAdsException):
         list(stream.read_records(sync_mode=SyncMode.incremental, cursor_field=["segments.date"], stream_slice=stream_slice))
 
-    stream.get_query.assert_called_with({"start_date": "2021-01-03", "end_date": "2021-01-15"})
+    stream.get_query.assert_called_with({"customer_id": customer_id, "start_date": "2021-01-03", "end_date": "2021-01-15"})
     assert stream.get_query.call_count == 2
 
 
@@ -165,21 +167,22 @@ class MockGoogleAdsFailsOneDate(MockGoogleAds):
         return mock_response_fails_one_date()
 
 
-def test_page_token_expired_it_should_fail_date_range_1_day(mock_ads_client, config):
+def test_page_token_expired_it_should_fail_date_range_1_day(mock_ads_client, config, customers):
     """
     Page token has expired while reading records within date "2021-01-03",
     it should raise error, because Google Ads API doesn't allow filter by datetime.
     Minimum date range is 1 day.
     """
-    stream_slice = {"start_date": "2021-01-03", "end_date": "2021-01-04"}
+    customer_id = next(iter(customers)).id
+    stream_slice = {"customer_id": customer_id, "start_date": "2021-01-03", "end_date": "2021-01-04"}
 
-    google_api = MockGoogleAdsFailsOneDate(credentials=config["credentials"], customer_id=config["customer_id"])
+    google_api = MockGoogleAdsFailsOneDate(credentials=config["credentials"])
     incremental_stream_config = dict(
         api=google_api,
         conversion_window_days=config["conversion_window_days"],
         start_date=config["start_date"],
-        time_zone="local",
         end_date="2021-04-04",
+        customers=customers,
     )
     stream = ClickView(**incremental_stream_config)
     stream.get_query = Mock()
@@ -188,5 +191,5 @@ def test_page_token_expired_it_should_fail_date_range_1_day(mock_ads_client, con
     with pytest.raises(GoogleAdsException):
         list(stream.read_records(sync_mode=SyncMode.incremental, cursor_field=["segments.date"], stream_slice=stream_slice))
 
-    stream.get_query.assert_called_with({"start_date": "2021-01-03", "end_date": "2021-01-04"})
+    stream.get_query.assert_called_with({"customer_id": customer_id, "start_date": "2021-01-03", "end_date": "2021-01-04"})
     assert stream.get_query.call_count == 1

--- a/docs/integrations/sources/google-ads.md
+++ b/docs/integrations/sources/google-ads.md
@@ -112,6 +112,8 @@ Note that `ad_groups`, `ad_group_ads`, and `campaigns` contain a `labels` field,
 
 The Google Ads Query Language can query the Google Ads API. Check out [Google Ads Query Language](https://developers.google.com/google-ads/api/docs/query/overview) and the [query builder](https://developers.google.com/google-ads/api/docs/query/overview). You can add these as custom queries when configuring the Google Ads source.
 
+**Note**: Each custom query in the input configuration must work for all the customer account IDs. Otherwise, the customer ID will be skipped for every query that fails the validation test. For example, if your query contains `metrics` fields in the `select` clause, it will not be executed against manager accounts.
+
 ## Performance considerations
 
 This source is constrained by whatever API limits are set for the Google Ads that is used. You can read more about those limits in the [Google Developer docs](https://developers.google.com/google-ads/api/docs/best-practices/quotas).

--- a/docs/integrations/sources/google-ads.md
+++ b/docs/integrations/sources/google-ads.md
@@ -120,6 +120,7 @@ This source is constrained by whatever API limits are set for the Google Ads tha
 
 | Version  | Date       | Pull Request                                             | Subject                                                                                      |
 |:---------|:-----------|:---------------------------------------------------------|:---------------------------------------------------------------------------------------------|
+| `0.1.39` | 2022-05-18 | [12914](https://github.com/airbytehq/airbyte/pull/12914) | Fix GAQL query validation and log auth errors instead of failing the sync                    |
 | `0.1.38` | 2022-05-12 | [12807](https://github.com/airbytehq/airbyte/pull/12807) | Documentation updates                                                                        |
 | `0.1.37` | 2022-05-06 | [12651](https://github.com/airbytehq/airbyte/pull/12651) | Improve integration and unit tests                                                           |
 | `0.1.36` | 2022-04-19 | [12158](https://github.com/airbytehq/airbyte/pull/12158) | Fix `*_labels` streams data type                                                             |


### PR DESCRIPTION
## What
[Source Google Ads Sync option to skip inactive accounts rather than failing sync for all accounts](https://github.com/airbytehq/airbyte/issues/12486):
 - Since the standard `Accounts` stream was used to fetch the customers info, it used a `where` clause in its GAQL query with a `segment.date` filter which filtered out all the customers
  - Even more, only the first customer account among those that could be fetched(if any) was checked for being a manager
  - If that account was not a manager, all the streams were instantiated with a full `customer_ids` list, despite of that some of them could be managers which would lead to errors further when reading

[Source: Google Ads - with GAQL not able to create connection](https://github.com/airbytehq/alpha-beta-issues/issues/49):
 - After making the request for validating the GAQL query to Google Ads API, we get the generator, which would raise an exception in case of error only when being iterated over. Which wasn't done
 - A bug in formatting the custom query: some keyword patterns missed whitespaces, what led to making an invalid query (`parameters` in regex instead of `_parameters_` made the function insert `where` clause right inside the `select` clause)

Other bug fixes:
 - `end_date` param was partially ignored
## How
 - Added another service stream, not exposed to a user, that would fetch the customers by their IDs independent of date segments
- Refactored the code to check `is_manager` attribute of each customer, not only the first one.
- Instantiate the streams depending on the `customer.is_manager` field only with non-manager accounts as params
- Try-catch auth and query errors and log them when reading records and checking the connection instead of failing the stream for all customer accounts
- Fixed the bug in the custom query formatter (added whitespaces so that partial word matches would not be treated as key words)
- Added iteration over the response when validating the custom query so that API errors get raised instead of being ignored
- Updated all the imports and links from API v8 to API v9
- Fixed issue with the `end_date` parameter 
- Updated tests