### PR TITLE
Python CDK: fixed dependency install command

### DIFF
--- a/docs/connector-development/cdk-python/README.md
+++ b/docs/connector-development/cdk-python/README.md
@@ -76,7 +76,7 @@ Setup a virtual env:
 ```text
 python -m venv .venv
 source .venv/bin/activate
-pip install -e ".[dev]" # [dev] installs development-only dependencies
+pip install -e ".[tests]" # [tests] installs test-only dependencies
 ```
 
 #### Iteration


### PR DESCRIPTION
## What
The documented command to install development dependencies did not install the correct dependencies.

The command says to use `dev`, but in [the cdk `setup.py` there is only `tests`](https://github.com/airbytehq/airbyte/blob/master/airbyte-integrations/connector-templates/source-python-http-api/setup.py.hbs#L27). Running the documented command does not install the dependencies necessary for development as you cannot run tests.

## How
Fix the command in the documentation to use `tests` instead of `dev`.

## 🚨 User Impact 🚨
None