### PR TITLE
CDK: publish version 0.1.57

### DIFF
--- a/airbyte-cdk/python/CHANGELOG.md
+++ b/airbyte-cdk/python/CHANGELOG.md
@@ -1,5 +1,8 @@
 # Changelog
 
+## 0.1.57
+Update protocol models to support per-stream state: [#12829](https://github.com/airbytehq/airbyte/pull/12829).
+
 ## 0.1.56
 - Update protocol models to include `AirbyteTraceMessage`
 - Emit an `AirbyteTraceMessage` on uncaught exceptions

--- a/airbyte-cdk/python/setup.py
+++ b/airbyte-cdk/python/setup.py
@@ -15,7 +15,7 @@ README = (HERE / "README.md").read_text()
 
 setup(
     name="airbyte-cdk",
-    version="0.1.56",
+    version="0.1.57",
     description="A framework for writing Airbyte Connectors.",
     long_description=README,
     long_description_content_type="text/markdown",


### PR DESCRIPTION
## What
#12829 updated the CDK's protocol models - this PR bumps the CDK version, updates the changelog and publishes those changes to pypi.
