### PR TITLE
Destination Redshift: Fixed maximum record size for SUPER type

### DIFF
--- a/airbyte-config/init/src/main/resources/seed/destination_definitions.yaml
+++ b/airbyte-config/init/src/main/resources/seed/destination_definitions.yaml
@@ -225,7 +225,7 @@
 - name: Redshift
   destinationDefinitionId: f7a7d195-377f-cf5b-70a5-be6b819019dc
   dockerRepository: airbyte/destination-redshift
-  dockerImageTag: 0.3.34
+  dockerImageTag: 0.3.35
   documentationUrl: https://docs.airbyte.io/integrations/destinations/redshift
   icon: redshift.svg
   resourceRequirements:

--- a/airbyte-config/init/src/main/resources/seed/destination_specs.yaml
+++ b/airbyte-config/init/src/main/resources/seed/destination_specs.yaml
@@ -3612,7 +3612,7 @@
     supported_destination_sync_modes:
     - "overwrite"
     - "append"
-- dockerImage: "airbyte/destination-redshift:0.3.34"
+- dockerImage: "airbyte/destination-redshift:0.3.35"
   spec:
     documentationUrl: "https://docs.airbyte.io/integrations/destinations/redshift"
     connectionSpecification:

--- a/airbyte-integrations/bases/standard-destination-test/src/main/java/io/airbyte/integrations/standardtest/destination/DestinationAcceptanceTest.java
+++ b/airbyte-integrations/bases/standard-destination-test/src/main/java/io/airbyte/integrations/standardtest/destination/DestinationAcceptanceTest.java
@@ -93,8 +93,6 @@ public abstract class DestinationAcceptanceTest {
   private static final String JOB_ID = "0";
   private static final int JOB_ATTEMPT = 0;
 
-  protected static final int GENERATE_BIG_STRING_ADD_EXTRA_CHARS = 0;
-
   private static final Logger LOGGER = LoggerFactory.getLogger(DestinationAcceptanceTest.class);
 
   private TestDestinationEnv testEnv;
@@ -711,7 +709,7 @@ public abstract class DestinationAcceptanceTest {
             .withEmittedAt(Instant.now().toEpochMilli())
             .withData(Jsons.jsonNode(ImmutableMap.builder()
                 .put("id", 3)
-                .put("currency", generateBigString(GENERATE_BIG_STRING_ADD_EXTRA_CHARS))
+                .put("currency", generateBigString(getGenerateBigStringAddExtraCharacters()))
                 .put("date", "2020-10-10T00:00:00Z")
                 .put("HKD", 10.5)
                 .put("NZD", 1.14)
@@ -732,6 +730,10 @@ public abstract class DestinationAcceptanceTest {
         .limit(length)
         .collect(StringBuilder::new, StringBuilder::appendCodePoint, StringBuilder::append)
         .toString();
+  }
+
+  protected int getGenerateBigStringAddExtraCharacters() {
+    return 0;
   }
 
   /**

--- a/airbyte-integrations/bases/standard-destination-test/src/main/java/io/airbyte/integrations/standardtest/destination/DestinationAcceptanceTest.java
+++ b/airbyte-integrations/bases/standard-destination-test/src/main/java/io/airbyte/integrations/standardtest/destination/DestinationAcceptanceTest.java
@@ -93,6 +93,8 @@ public abstract class DestinationAcceptanceTest {
   private static final String JOB_ID = "0";
   private static final int JOB_ATTEMPT = 0;
 
+  protected static final int GENERATE_BIG_STRING_ADD_EXTRA_CHARS = 0;
+
   private static final Logger LOGGER = LoggerFactory.getLogger(DestinationAcceptanceTest.class);
 
   private TestDestinationEnv testEnv;
@@ -709,7 +711,7 @@ public abstract class DestinationAcceptanceTest {
             .withEmittedAt(Instant.now().toEpochMilli())
             .withData(Jsons.jsonNode(ImmutableMap.builder()
                 .put("id", 3)
-                .put("currency", generateBigString(0))
+                .put("currency", generateBigString(GENERATE_BIG_STRING_ADD_EXTRA_CHARS))
                 .put("date", "2020-10-10T00:00:00Z")
                 .put("HKD", 10.5)
                 .put("NZD", 1.14)

--- a/airbyte-integrations/connectors/destination-redshift/Dockerfile
+++ b/airbyte-integrations/connectors/destination-redshift/Dockerfile
@@ -16,5 +16,5 @@ ENV APPLICATION destination-redshift
 
 COPY --from=build /airbyte /airbyte
 
-LABEL io.airbyte.version=0.3.34
+LABEL io.airbyte.version=0.3.35
 LABEL io.airbyte.name=airbyte/destination-redshift

--- a/airbyte-integrations/connectors/destination-redshift/src/main/java/io/airbyte/integrations/destination/redshift/operations/RedshiftSqlOperations.java
+++ b/airbyte-integrations/connectors/destination-redshift/src/main/java/io/airbyte/integrations/destination/redshift/operations/RedshiftSqlOperations.java
@@ -99,14 +99,16 @@ public class RedshiftSqlOperations extends JdbcSqlOperations {
     final int dataSize = stringData.getBytes(StandardCharsets.UTF_8).length;
     boolean isValid = dataSize <= REDSHIFT_SUPER_MAX_BYTE_SIZE;
 
-    // check VARCHAR limits for VARCHAR fields within the SUPER object
-    Map<String, Object> dataMap = Jsons.flatten(data);
-    for (Object value : dataMap.values()) {
-      if (value instanceof String stringValue) {
-        final int stringDataSize = stringValue.getBytes(StandardCharsets.UTF_8).length;
-        isValid = stringDataSize <= REDSHIFT_VARCHAR_MAX_BYTE_SIZE;
-        if (!isValid) {
-          break;
+    // check VARCHAR limits for VARCHAR fields within the SUPER object, if overall object is valid
+    if (isValid) {
+      Map<String, Object> dataMap = Jsons.flatten(data);
+      for (Object value : dataMap.values()) {
+        if (value instanceof String stringValue) {
+          final int stringDataSize = stringValue.getBytes(StandardCharsets.UTF_8).length;
+          isValid = stringDataSize <= REDSHIFT_VARCHAR_MAX_BYTE_SIZE;
+          if (!isValid) {
+            break;
+          }
         }
       }
     }

--- a/airbyte-integrations/connectors/destination-redshift/src/main/java/io/airbyte/integrations/destination/redshift/operations/RedshiftSqlOperations.java
+++ b/airbyte-integrations/connectors/destination-redshift/src/main/java/io/airbyte/integrations/destination/redshift/operations/RedshiftSqlOperations.java
@@ -94,18 +94,15 @@ public class RedshiftSqlOperations extends JdbcSqlOperations {
 
   @Override
   public boolean isValidData(final JsonNode data) {
-    boolean isValid = true;
-
     // check overall size of the SUPER data
     final String stringData = Jsons.serialize(data);
     final int dataSize = stringData.getBytes(StandardCharsets.UTF_8).length;
-    isValid = dataSize <= REDSHIFT_SUPER_MAX_BYTE_SIZE;
+    boolean isValid = dataSize <= REDSHIFT_SUPER_MAX_BYTE_SIZE;
 
     // check VARCHAR limits for VARCHAR fields within the SUPER object
     Map<String, Object> dataMap = Jsons.flatten(data);
     for (Object value : dataMap.values()) {
-      if (value instanceof String) {
-        String stringValue = (String) value;
+      if (value instanceof String stringValue) {
         final int stringDataSize = stringValue.getBytes(StandardCharsets.UTF_8).length;
         isValid = stringDataSize <= REDSHIFT_VARCHAR_MAX_BYTE_SIZE;
         if (!isValid) {

--- a/airbyte-integrations/connectors/destination-redshift/src/test-integration/java/io/airbyte/integrations/destination/redshift/RedshiftStagingS3DestinationAcceptanceTest.java
+++ b/airbyte-integrations/connectors/destination-redshift/src/test-integration/java/io/airbyte/integrations/destination/redshift/RedshiftStagingS3DestinationAcceptanceTest.java
@@ -31,6 +31,7 @@ import org.slf4j.LoggerFactory;
 public class RedshiftStagingS3DestinationAcceptanceTest extends JdbcDestinationAcceptanceTest {
 
   private static final Logger LOGGER = LoggerFactory.getLogger(RedshiftStagingS3DestinationAcceptanceTest.class);
+  protected static final int GENERATE_BIG_STRING_ADD_EXTRA_CHARS = 1;
 
   // config from which to create / delete schemas.
   private JsonNode baseConfig;

--- a/airbyte-integrations/connectors/destination-redshift/src/test-integration/java/io/airbyte/integrations/destination/redshift/RedshiftStagingS3DestinationAcceptanceTest.java
+++ b/airbyte-integrations/connectors/destination-redshift/src/test-integration/java/io/airbyte/integrations/destination/redshift/RedshiftStagingS3DestinationAcceptanceTest.java
@@ -31,7 +31,6 @@ import org.slf4j.LoggerFactory;
 public class RedshiftStagingS3DestinationAcceptanceTest extends JdbcDestinationAcceptanceTest {
 
   private static final Logger LOGGER = LoggerFactory.getLogger(RedshiftStagingS3DestinationAcceptanceTest.class);
-  protected static final int GENERATE_BIG_STRING_ADD_EXTRA_CHARS = 1;
 
   // config from which to create / delete schemas.
   private JsonNode baseConfig;
@@ -178,6 +177,11 @@ public class RedshiftStagingS3DestinationAcceptanceTest extends JdbcDestinationA
   @Override
   protected int getMaxRecordValueLimit() {
     return RedshiftSqlOperations.REDSHIFT_VARCHAR_MAX_BYTE_SIZE;
+  }
+
+  @Override
+  protected int getGenerateBigStringAddExtraCharacters() {
+    return 1;
   }
 
 }

--- a/airbyte-integrations/connectors/destination-redshift/src/test/java/io/airbyte/integrations/destination/redshift/operations/RedshiftSqlOperationsTest.java
+++ b/airbyte-integrations/connectors/destination-redshift/src/test/java/io/airbyte/integrations/destination/redshift/operations/RedshiftSqlOperationsTest.java
@@ -1,0 +1,99 @@
+/*
+ * Copyright (c) 2021 Airbyte, Inc., all rights reserved.
+ */
+
+package io.airbyte.integrations.destination.redshift.operations;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+import java.util.Random;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import com.google.common.collect.ImmutableMap;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+import io.airbyte.commons.json.Jsons;
+import io.airbyte.integrations.destination.redshift.enums.RedshiftDataTmpTableMode;
+
+@DisplayName("RedshiftSqlOperations")
+public class RedshiftSqlOperationsTest {
+
+    private static final Random RANDOM = new Random();
+
+    private static final RedshiftDataTmpTableMode redshiftDataTmpTableMode = RedshiftDataTmpTableMode.SUPER;
+
+    private String generateBigString(final int addExtraCharacters) {
+        final int length = RedshiftSqlOperations.REDSHIFT_VARCHAR_MAX_BYTE_SIZE + addExtraCharacters;
+        return RANDOM
+                .ints('a', 'z' + 1)
+                .limit(length)
+                .collect(StringBuilder::new, StringBuilder::appendCodePoint, StringBuilder::append)
+                .toString();
+    }
+
+    @Test
+    @DisplayName("isValidData should return true for valid data")
+    public void isValidDataForValid() {
+        JsonNode testNode = Jsons.jsonNode(ImmutableMap.builder()
+                .put("id", 3)
+                .put("currency", generateBigString(0))
+                .put("date", "2020-10-10T00:00:00Z")
+                .put("HKD", 10.5)
+                .put("NZD", 1.14)
+                .build());
+
+        RedshiftSqlOperations uut = new RedshiftSqlOperations(redshiftDataTmpTableMode);
+        boolean isValid = uut.isValidData(testNode);
+        assertEquals(true, isValid);
+    }
+
+    @Test
+    @DisplayName("isValidData should return false for invalid data - string too long")
+    public void isValidDataForInvalidNode() {
+        JsonNode testNode = Jsons.jsonNode(ImmutableMap.builder()
+                .put("id", 3)
+                .put("currency", generateBigString(1))
+                .put("date", "2020-10-10T00:00:00Z")
+                .put("HKD", 10.5)
+                .put("NZD", 1.14)
+                .build());
+
+        RedshiftSqlOperations uut = new RedshiftSqlOperations(redshiftDataTmpTableMode);
+        boolean isValid = uut.isValidData(testNode);
+        assertEquals(false, isValid);
+    }
+
+    @Test
+    @DisplayName("isValidData should return false for invalid data - total object too big")
+    public void isValidDataForInvalidObject() {
+        JsonNode testNode = Jsons.jsonNode(ImmutableMap.builder()
+                .put("key1", generateBigString(-1))
+                .put("key2", generateBigString(-1))
+                .put("key3", generateBigString(-1))
+                .put("key4", generateBigString(-1))
+                .put("key5", generateBigString(-1))
+                .put("key6", generateBigString(-1))
+                .put("key7", generateBigString(-1))
+                .put("key8", generateBigString(-1))
+                .put("key9", generateBigString(-1))
+                .put("key10", generateBigString(-1))
+                .put("key11", generateBigString(-1))
+                .put("key12", generateBigString(-1))
+                .put("key13", generateBigString(-1))
+                .put("key14", generateBigString(-1))
+                .put("key15", generateBigString(-1))
+                .put("key16", generateBigString(-1))
+                .put("key17", generateBigString(-1))
+                .put("key18", generateBigString(-1))
+                .put("key19", generateBigString(-1))
+                .put("key20", generateBigString(-1))
+                .build());
+
+        RedshiftSqlOperations uut = new RedshiftSqlOperations(redshiftDataTmpTableMode);
+        boolean isValid = uut.isValidData(testNode);
+        assertEquals(false, isValid);
+    }
+
+}

--- a/docs/integrations/destinations/redshift.md
+++ b/docs/integrations/destinations/redshift.md
@@ -105,8 +105,8 @@ Therefore, Airbyte Redshift destination will create tables and schemas using the
 
 ### Data Size Limitations
 
-Redshift specifies a maximum limit of 65535 bytes to store the raw JSON record data. Thus, when a row is too big to fit, the Redshift destination fails to load such data and currently ignores that record.
-See [docs](https://docs.aws.amazon.com/redshift/latest/dg/r_Character_types.html)
+Redshift specifies a maximum limit of 1MB (and 65535 bytes for any VARCHAR fields within the JSON record) to store the raw JSON record data. Thus, when a row is too big to fit, the Redshift destination fails to load such data and currently ignores that record.
+See docs for [SUPER](https://docs.aws.amazon.com/redshift/latest/dg/r_SUPER_type.html) and [SUPER limitations](https://docs.aws.amazon.com/redshift/latest/dg/limitations-super.html)
 
 ### Encryption
 
@@ -138,6 +138,7 @@ Each stream will be output into its own raw table in Redshift. Each table will c
 
 | Version | Date       | Pull Request | Subject |
 |:--------|:-----------| :-----       | :------ |
+| 0.3.35  | 2022-05-18 | [12940](https://github.com/airbytehq/airbyte/pull/12940) | Fixed maximum record size for SUPER type |
 | 0.3.34  | 2022-05-16 | [12869](https://github.com/airbytehq/airbyte/pull/12869) | Fixed NPE in S3 staging check  |
 | 0.3.33  | 2022-05-04 | [12601](https://github.com/airbytehq/airbyte/pull/12601) | Apply buffering strategy for S3 staging  |
 | 0.3.32  | 2022-04-20 | [12085](https://github.com/airbytehq/airbyte/pull/12085) | Fixed bug with switching between INSERT and COPY config |


### PR DESCRIPTION
## What
See #12680: now that airbyte uses SUPER instead of VARCHAR, the max data size needs to be increased.

## How
Changes the constant. #12064 changes the type for all operations (not configurable), so we don't need to be clever.

https://docs.aws.amazon.com/redshift/latest/dg/r_SUPER_type.html

Also see https://docs.aws.amazon.com/redshift/latest/dg/limitations-super.html - the VARCHAR check is retained, but only used for fields within the SUPER object instead of the object overall.

## Recommended reading order
N/A

## 🚨 User Impact 🚨
N/A

## Pre-merge Checklist


<summary><strong>Updating a connector</strong></summary>

### Community member or Airbyter

- [x] Grant edit access to maintainers ([instructions](https://docs.github.com/en/github/collaborating-with-pull-requests/working-with-forks/allowing-changes-to-a-pull-request-branch-created-from-a-fork#enabling-repository-maintainer-permissions-on-existing-pull-requests))
- [ ] Secrets in the connector's spec are annotated with `airbyte_secret`
- [ ] Unit & integration tests added and passing. Community members, please provide proof of success locally e.g: screenshot or copy-paste unit, integration, and acceptance test output. To run acceptance tests for a Python connector, follow instructions in the README. For java connectors run `./gradlew :airbyte-integrations:connectors:<name>:integrationTest`.
- [ ] Code reviews completed
- [x] Documentation updated
    - [ ] Connector's `README.md`
    - [ ] Connector's `bootstrap.md`. See [description and examples](https://docs.google.com/document/d/1ypdgmwmEHWv-TrO4_YOQ7pAJGVrMp5BOkEVh831N260/edit?usp=sharing)
    - [x] Changelog updated in `docs/integrations/<source or destination>/<name>.md` including changelog. See changelog [example](https://docs.airbyte.io/integrations/sources/stripe#changelog)
- [x] PR name follows [PR naming conventions](https://docs.airbyte.io/contributing-to-airbyte/updating-documentation#issues-and-pull-requests)

### Airbyter

If this is a community PR, the Airbyte engineer reviewing this PR is responsible for the below items.

- [ ] Create a non-forked branch based on this PR and test the below items on it
- [ ] Build is successful
- [ ] If new credentials are required for use in CI, add them to GSM. [Instructions](https://docs.airbyte.io/connector-development#using-credentials-in-ci).
- [ ] [`/test connector=connectors/<name>` command](https://docs.airbyte.io/connector-development#updating-an-existing-connector) is passing
- [ ] New Connector version released on Dockerhub and connector version bumped by running the `/publish` command described [here](https://docs.airbyte.io/connector-development#updating-an-existing-connector)

## Tests

<details><summary><strong>Unit</strong></summary>

*Put your unit tests output here.*

</details>

<details><summary><strong>Integration</strong></summary>

*Put your integration tests output here.*

</details>

<details><summary><strong>Acceptance</strong></summary>

*Put your acceptance tests output here.*

</details>
