### PR TITLE
source-amazon-seller-partner: read the rate limit for retry waiting time in Orders stream

### DIFF
--- a/airbyte-config/init/src/main/resources/seed/source_definitions.yaml
+++ b/airbyte-config/init/src/main/resources/seed/source_definitions.yaml
@@ -25,7 +25,7 @@
 - name: Amazon Seller Partner
   sourceDefinitionId: e55879a8-0ef8-4557-abcf-ab34c53ec460
   dockerRepository: airbyte/source-amazon-seller-partner
-  dockerImageTag: 0.2.16
+  dockerImageTag: 0.2.17
   sourceType: api
   documentationUrl: https://docs.airbyte.io/integrations/sources/amazon-seller-partner
   icon: amazonsellerpartner.svg

--- a/airbyte-config/init/src/main/resources/seed/source_specs.yaml
+++ b/airbyte-config/init/src/main/resources/seed/source_specs.yaml
@@ -213,7 +213,7 @@
               type: "string"
               path_in_connector_config:
               - "client_secret"
-- dockerImage: "airbyte/source-amazon-seller-partner:0.2.16"
+- dockerImage: "airbyte/source-amazon-seller-partner:0.2.17"
   spec:
     documentationUrl: "https://docs.airbyte.io/integrations/sources/amazon-seller-partner"
     changelogUrl: "https://docs.airbyte.io/integrations/sources/amazon-seller-partner"

--- a/airbyte-integrations/connectors/source-amazon-seller-partner/Dockerfile
+++ b/airbyte-integrations/connectors/source-amazon-seller-partner/Dockerfile
@@ -12,5 +12,5 @@ RUN pip install .
 ENV AIRBYTE_ENTRYPOINT "python /airbyte/integration_code/main.py"
 ENTRYPOINT ["python", "/airbyte/integration_code/main.py"]
 
-LABEL io.airbyte.version=0.2.16
+LABEL io.airbyte.version=0.2.17
 LABEL io.airbyte.name=airbyte/source-amazon-seller-partner

--- a/airbyte-integrations/connectors/source-amazon-seller-partner/source_amazon_seller_partner/streams.py
+++ b/airbyte-integrations/connectors/source-amazon-seller-partner/source_amazon_seller_partner/streams.py
@@ -657,8 +657,7 @@ class Orders(IncrementalAmazonSPStream):
     def backoff_time(self, response: requests.Response) -> Optional[float]:
         rate_limit = response.headers.get("x-amzn-RateLimit-Limit", 0)
         if rate_limit:
-            backoff_time = 1 / float(rate_limit)
-            return backoff_time
+            return 1 / float(rate_limit)
         else:
             return self.default_backoff_time
 

--- a/airbyte-integrations/connectors/source-amazon-seller-partner/source_amazon_seller_partner/streams.py
+++ b/airbyte-integrations/connectors/source-amazon-seller-partner/source_amazon_seller_partner/streams.py
@@ -639,7 +639,8 @@ class Orders(IncrementalAmazonSPStream):
     replication_start_date_field = "LastUpdatedAfter"
     next_page_token_field = "NextToken"
     page_size_field = "MaxResultsPerPage"
-
+    default_backoff_time = 60
+    
     def path(self, **kwargs) -> str:
         return f"orders/{ORDERS_API_VERSION}/orders"
 
@@ -652,6 +653,14 @@ class Orders(IncrementalAmazonSPStream):
 
     def parse_response(self, response: requests.Response, stream_state: Mapping[str, Any], **kwargs) -> Iterable[Mapping]:
         yield from response.json().get(self.data_field, {}).get(self.name, [])
+
+    def backoff_time(self, response: requests.Response) -> Optional[float]:
+        rate_limit = response.headers.get("x-amzn-RateLimit-Limit", 0)
+        if rate_limit:
+            backoff_time = 1 / float(rate_limit)
+            return backoff_time
+        else:
+            return self.default_backoff_time
 
 
 class VendorDirectFulfillmentShipping(AmazonSPStream):

--- a/docs/integrations/sources/amazon-seller-partner.md
+++ b/docs/integrations/sources/amazon-seller-partner.md
@@ -67,8 +67,9 @@ Information about rate limits you may find [here](https://github.com/amzn/sellin
 ## CHANGELOG
 
 | Version  | Date       | Pull Request                                             | Subject                                                                |
-|:---------|:-----------|:---------------------------------------------------------| :--------------------------------------------------------------------- |
-| `0.2.16` | 2022-05-04 | [\#9789](https://github.com/airbytehq/airbyte/pull/12523)| allow to use IAM user arn or IAM role arn                             |
+|:---------|:-----------|:---------------------------------------------------------|:-----------------------------------------------------------------------|
+| `0.2.17` | 2022-05-19 | [\#12946](https://github.com/airbytehq/airbyte/pull/12946)| Add throttling exception managing in Orders streams                    |
+| `0.2.16` | 2022-05-04 | [\#12523](https://github.com/airbytehq/airbyte/pull/12523)| allow to use IAM user arn or IAM role arn                              |
 | `0.2.15` | 2022-01-25 | [\#9789](https://github.com/airbytehq/airbyte/pull/9789) | Add stream FbaReplacementsReports                                      |
 | `0.2.14` | 2022-01-19 | [\#9621](https://github.com/airbytehq/airbyte/pull/9621) | Add GET_FLAT_FILE_ALL_ORDERS_DATA_BY_LAST_UPDATE_GENERAL report        |
 | `0.2.13` | 2022-01-18 | [\#9581](https://github.com/airbytehq/airbyte/pull/9581) | Change createdSince parameter to dataStartTime                         |


### PR DESCRIPTION
## What

* Amazon sp-api for orders endpoint need to catch any 429 error and read the header `x-amzn-RateLimit-Limit` to wait the required time and avoid throttling
[amazon documentation](https://developer-docs.amazon.com/sp-api/docs/orders-api-v0-reference)
* This will keep trying to make the request after receiving the too many request response.

## How
just ovewrite the `backoff_time` function to read the value from the response header


## 🚨 User Impact 🚨
None
