### PR TITLE
SAT:  cause `AirbyteTraceMessage` by using invalid sync mode

### DIFF
--- a/airbyte-integrations/bases/source-acceptance-test/CHANGELOG.md
+++ b/airbyte-integrations/bases/source-acceptance-test/CHANGELOG.md
@@ -1,5 +1,8 @@
 # Changelog
 
+## 0.1.54
+Fixed `AirbyteTraceMessage` test case to make connectors fail more reliably.
+
 ## 0.1.53
 Add more granular incremental testing that walks through syncs and verifies records according to cursor value.
 

--- a/airbyte-integrations/bases/source-acceptance-test/Dockerfile
+++ b/airbyte-integrations/bases/source-acceptance-test/Dockerfile
@@ -33,7 +33,7 @@ COPY pytest.ini setup.py ./
 COPY source_acceptance_test ./source_acceptance_test
 RUN pip install .
 
-LABEL io.airbyte.version=0.1.53
+LABEL io.airbyte.version=0.1.54
 LABEL io.airbyte.name=airbyte/source-acceptance-test
 
 ENTRYPOINT ["python", "-m", "pytest", "-p", "source_acceptance_test.plugin", "-r", "fEsx"]

--- a/airbyte-integrations/bases/source-acceptance-test/source_acceptance_test/tests/test_core.py
+++ b/airbyte-integrations/bases/source-acceptance-test/source_acceptance_test/tests/test_core.py
@@ -425,7 +425,7 @@ class TestBasicRead(BaseTest):
                         json_schema={"type": "object", "properties": {"f1": {"type": "string"}}},
                         supported_sync_modes=[SyncMode.full_refresh],
                     ),
-                    sync_mode=SyncMode.full_refresh,
+                    sync_mode="INVALID",  # type: ignore
                     destination_sync_mode=DestinationSyncMode.overwrite,
                 )
             ]

--- a/airbyte-integrations/bases/source-acceptance-test/source_acceptance_test/tests/test_core.py
+++ b/airbyte-integrations/bases/source-acceptance-test/source_acceptance_test/tests/test_core.py
@@ -419,14 +419,15 @@ class TestBasicRead(BaseTest):
 
         invalid_configured_catalog = ConfiguredAirbyteCatalog(
             streams=[
-                ConfiguredAirbyteStream(
+                # create ConfiguredAirbyteStream without validation
+                ConfiguredAirbyteStream.construct(
                     stream=AirbyteStream(
                         name="__AIRBYTE__stream_that_does_not_exist",
                         json_schema={"type": "object", "properties": {"f1": {"type": "string"}}},
                         supported_sync_modes=[SyncMode.full_refresh],
                     ),
-                    sync_mode="INVALID",  # type: ignore
-                    destination_sync_mode=DestinationSyncMode.overwrite,
+                    sync_mode="INVALID",
+                    destination_sync_mode="INVALID",
                 )
             ]
         )

--- a/airbyte-integrations/bases/source-acceptance-test/source_acceptance_test/tests/test_core.py
+++ b/airbyte-integrations/bases/source-acceptance-test/source_acceptance_test/tests/test_core.py
@@ -19,7 +19,6 @@ from airbyte_cdk.models import (
     ConfiguredAirbyteCatalog,
     ConfiguredAirbyteStream,
     ConnectorSpecification,
-    DestinationSyncMode,
     Status,
     SyncMode,
     TraceType,


### PR DESCRIPTION
## What
The test case introduced in #12796 assumed that connectors will fail/crash if given a non-existent stream name as part of the configured catalog. However, this was not necessarily the case (for example, google sheets does not do this and instead exits silently). We should make this fail more reliably.

## How
In addition to supplying an invalid stream name, also supply invalid sync modes so validation should not pass.
