### PR TITLE
Refactor database initialization logic

### DIFF
--- a/airbyte-db/lib/src/main/java/io/airbyte/db/check/DatabaseAvailabilityCheck.java
+++ b/airbyte-db/lib/src/main/java/io/airbyte/db/check/DatabaseAvailabilityCheck.java
@@ -6,7 +6,6 @@ package io.airbyte.db.check;
 
 import static org.jooq.impl.DSL.select;
 
-import io.airbyte.commons.lang.Exceptions;
 import io.airbyte.db.Database;
 import java.util.Optional;
 import java.util.function.Function;
@@ -47,7 +46,7 @@ public interface DatabaseAvailabilityCheck extends DatabaseCheck {
         initialized = isDatabaseConnected(getDatabaseName()).apply(database);
         if (!initialized) {
           getLogger().info("Database is not ready yet. Please wait a moment, it might still be initializing...");
-          Exceptions.toRuntime(() -> Thread.sleep(sleepTime));
+          Thread.sleep(sleepTime);
           totalTime += sleepTime;
         }
       } else {

--- a/airbyte-db/lib/src/main/java/io/airbyte/db/check/DatabaseAvailabilityCheck.java
+++ b/airbyte-db/lib/src/main/java/io/airbyte/db/check/DatabaseAvailabilityCheck.java
@@ -1,0 +1,108 @@
+/*
+ * Copyright (c) 2021 Airbyte, Inc., all rights reserved.
+ */
+
+package io.airbyte.db.check;
+
+import static org.jooq.impl.DSL.select;
+
+import io.airbyte.commons.lang.Exceptions;
+import io.airbyte.db.Database;
+import java.util.Optional;
+import java.util.function.Function;
+import org.jooq.DSLContext;
+import org.slf4j.Logger;
+
+/**
+ * Performs a check to verify that the configured database is available.
+ */
+public interface DatabaseAvailabilityCheck extends DatabaseCheck {
+
+  /**
+   * The number of times to check if the database is available. TODO replace with a default value in a
+   * value injection annotation
+   */
+  int NUM_POLL_TIMES = 10;
+
+  /**
+   * Checks whether the configured database is available.
+   *
+   * @throws InterruptedException if unable to perform the check.
+   */
+  default void check() throws InterruptedException {
+    var initialized = false;
+    var totalTime = 0;
+    final var sleepTime = getTimeoutMs() / NUM_POLL_TIMES;
+
+    while (!initialized) {
+      getLogger().warn("Waiting for database to become available...");
+      if (totalTime >= getTimeoutMs()) {
+        throw new InterruptedException("Unable to connect to the database.");
+      }
+
+      final Optional<DSLContext> dslContext = getDslContext();
+
+      if(dslContext.isPresent()) {
+        final Database database = new Database(dslContext.get());
+        initialized = isDatabaseConnected(getDatabaseName()).apply(database);
+        if (!initialized) {
+          getLogger().info("Database is not ready yet. Please wait a moment, it might still be initializing...");
+          Exceptions.toRuntime(() -> Thread.sleep(sleepTime));
+          totalTime += sleepTime;
+        }
+      } else {
+        throw new InterruptedException("Database configuration not present.");
+      }
+    }
+  }
+
+  /**
+   * Generates a {@link Function} that is used to test if a connection can be made to the database by
+   * verifying that the {@code information_schema.tables} tables has been populated.
+   *
+   * @param databaseName The name of the database to test.
+   * @return A {@link Function} that can be invoked to test if the database is available.
+   */
+  default Function<Database, Boolean> isDatabaseConnected(final String databaseName) {
+    return database -> {
+      try {
+        getLogger().info("Testing {} database connection...", databaseName);
+        return database.query(ctx -> ctx.fetchExists(select().from("information_schema.tables")));
+      } catch (final Exception e) {
+        getLogger().error("Failed to verify database connection.", e);
+        return false;
+      }
+    };
+  }
+
+  /**
+   * Retrieves the configured database name to be tested.
+   *
+   * @return The name of the database to test.
+   */
+  String getDatabaseName();
+
+  /**
+   * Retrieves the configured {@link DSLContext} to be used to test the database availability.
+   *
+   * @return The configured {@link DSLContext} object.
+   */
+  Optional<DSLContext> getDslContext();
+
+  /**
+   * Retrieves the configured {@link Logger} object to be used to record progress of the migration
+   * check.
+   *
+   * @return The configured {@link Logger} object.
+   */
+  Logger getLogger();
+
+  /**
+   * Retrieves the timeout in milliseconds for the check. Once this timeout is exceeded, the check
+   * will fail with an {@link InterruptedException}.
+   *
+   * @return The timeout in milliseconds for the check.
+   */
+  long getTimeoutMs();
+
+}

--- a/airbyte-db/lib/src/main/java/io/airbyte/db/check/DatabaseAvailabilityCheck.java
+++ b/airbyte-db/lib/src/main/java/io/airbyte/db/check/DatabaseAvailabilityCheck.java
@@ -42,7 +42,7 @@ public interface DatabaseAvailabilityCheck extends DatabaseCheck {
 
       final Optional<DSLContext> dslContext = getDslContext();
 
-      if(dslContext.isPresent()) {
+      if (dslContext.isPresent()) {
         final Database database = new Database(dslContext.get());
         initialized = isDatabaseConnected(getDatabaseName()).apply(database);
         if (!initialized) {

--- a/airbyte-db/lib/src/main/java/io/airbyte/db/check/DatabaseCheck.java
+++ b/airbyte-db/lib/src/main/java/io/airbyte/db/check/DatabaseCheck.java
@@ -1,0 +1,19 @@
+/*
+ * Copyright (c) 2021 Airbyte, Inc., all rights reserved.
+ */
+
+package io.airbyte.db.check;
+
+/**
+ * Defines the interface for performing checks against a database.
+ */
+public interface DatabaseCheck {
+
+  /**
+   * Checks whether the configured database is available.
+   *
+   * @throws InterruptedException if unable to perform the check.
+   */
+  void check() throws InterruptedException;
+
+}

--- a/airbyte-db/lib/src/main/java/io/airbyte/db/check/DatabaseCheck.java
+++ b/airbyte-db/lib/src/main/java/io/airbyte/db/check/DatabaseCheck.java
@@ -12,8 +12,8 @@ public interface DatabaseCheck {
   /**
    * Checks whether the configured database is available.
    *
-   * @throws InterruptedException if unable to perform the check.
+   * @throws DatabaseCheckException if unable to perform the check.
    */
-  void check() throws InterruptedException;
+  void check() throws DatabaseCheckException;
 
 }

--- a/airbyte-db/lib/src/main/java/io/airbyte/db/check/DatabaseCheckException.java
+++ b/airbyte-db/lib/src/main/java/io/airbyte/db/check/DatabaseCheckException.java
@@ -1,0 +1,21 @@
+/*
+ * Copyright (c) 2021 Airbyte, Inc., all rights reserved.
+ */
+
+package io.airbyte.db.check;
+
+/**
+ * Custom exception that represents a failure that occurs during an attempt to check the
+ * availability or migration status of a database.
+ */
+public class DatabaseCheckException extends Exception {
+
+  public DatabaseCheckException(final String message) {
+    super(message);
+  }
+
+  public DatabaseCheckException(final String message, final Throwable cause) {
+    super(message, cause);
+  }
+
+}

--- a/airbyte-db/lib/src/main/java/io/airbyte/db/check/DatabaseMigrationCheck.java
+++ b/airbyte-db/lib/src/main/java/io/airbyte/db/check/DatabaseMigrationCheck.java
@@ -1,0 +1,84 @@
+/*
+ * Copyright (c) 2021 Airbyte, Inc., all rights reserved.
+ */
+
+package io.airbyte.db.check;
+
+import java.util.Optional;
+import org.flywaydb.core.Flyway;
+import org.slf4j.Logger;
+
+/**
+ * Performs a check to verify that the configured database has been migrated to the appropriate
+ * version.
+ */
+public interface DatabaseMigrationCheck {
+
+  /**
+   * The number of times to check if the database has been migrated to the required schema version.
+   * TODO replace with a default value in a value injection annotation
+   */
+  int NUM_POLL_TIMES = 10;
+
+  /**
+   * Checks whether the configured database has been migrated to the required minimum schema version.
+   *
+   * @throws InterruptedException if unable to perform the check.
+   */
+  default void check() throws InterruptedException {
+    final var startTime = System.currentTimeMillis();
+    final var sleepTime = getTimeoutMs() / NUM_POLL_TIMES;
+    final Optional<Flyway> flywayOptional = getFlyway();
+
+    if(flywayOptional.isPresent()) {
+      final var flyway = flywayOptional.get();
+      var currDatabaseMigrationVersion = flyway.info().current().getVersion().getVersion();
+      getLogger().info("Current database migration version {}.", currDatabaseMigrationVersion);
+      getLogger().info("Minimum Flyway version required {}.", getMinimumFlywayVersion());
+
+      while (currDatabaseMigrationVersion.compareTo(getMinimumFlywayVersion()) < 0) {
+        if (System.currentTimeMillis() - startTime >= getTimeoutMs()) {
+          throw new InterruptedException("Timeout while waiting for database to fulfill minimum flyway migration version..");
+        }
+
+        Thread.sleep(sleepTime);
+        currDatabaseMigrationVersion = flyway.info().current().getVersion().getVersion();
+      }
+      getLogger().info("Verified that database has been migrated to the required minimum version {}.", getTimeoutMs());
+    } else {
+      throw new InterruptedException("Flyway configuration not present.");
+    }
+  }
+
+  /**
+   * Retrieves the configured {@link Flyway} object to be used to check the migration status of the
+   * database.
+   *
+   * @return The configured {@link Flyway} object.
+   */
+  Optional<Flyway> getFlyway();
+
+  /**
+   * Retrieves the configured {@link Logger} object to be used to record progress of the migration
+   * check.
+   *
+   * @return The configured {@link Logger} object.
+   */
+  Logger getLogger();
+
+  /**
+   * Retrieves the required minimum migration version of the schema.
+   *
+   * @return The required minimum migration version of the schema.
+   */
+  String getMinimumFlywayVersion();
+
+  /**
+   * Retrieves the timeout in milliseconds for the check. Once this timeout is exceeded, the check
+   * will fail with an {@link InterruptedException}.
+   *
+   * @return The timeout in milliseconds for the check.
+   */
+  long getTimeoutMs();
+
+}

--- a/airbyte-db/lib/src/main/java/io/airbyte/db/check/DatabaseMigrationCheck.java
+++ b/airbyte-db/lib/src/main/java/io/airbyte/db/check/DatabaseMigrationCheck.java
@@ -30,7 +30,7 @@ public interface DatabaseMigrationCheck {
     final var sleepTime = getTimeoutMs() / NUM_POLL_TIMES;
     final Optional<Flyway> flywayOptional = getFlyway();
 
-    if(flywayOptional.isPresent()) {
+    if (flywayOptional.isPresent()) {
       final var flyway = flywayOptional.get();
       var currDatabaseMigrationVersion = flyway.info().current().getVersion().getVersion();
       getLogger().info("Current database migration version {}.", currDatabaseMigrationVersion);

--- a/airbyte-db/lib/src/main/java/io/airbyte/db/check/impl/ConfigsDatabaseAvailabilityCheck.java
+++ b/airbyte-db/lib/src/main/java/io/airbyte/db/check/impl/ConfigsDatabaseAvailabilityCheck.java
@@ -1,0 +1,52 @@
+/*
+ * Copyright (c) 2021 Airbyte, Inc., all rights reserved.
+ */
+
+package io.airbyte.db.check.impl;
+
+import io.airbyte.db.check.DatabaseAvailabilityCheck;
+import io.airbyte.db.instance.configs.ConfigsDatabaseInstance;
+import java.util.Optional;
+import org.jooq.DSLContext;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+/**
+ * Implementation of the {@link DatabaseAvailabilityCheck} for the Configurations database.
+ */
+public class ConfigsDatabaseAvailabilityCheck implements DatabaseAvailabilityCheck {
+
+  private static final Logger LOGGER = LoggerFactory.getLogger(ConfigsDatabaseAvailabilityCheck.class);
+
+  // TODO inject via dependency injection framework
+  private final DSLContext dslContext;
+
+  // TODO inject via dependency injection framework
+  private final long timeoutMs;
+
+  public ConfigsDatabaseAvailabilityCheck(final DSLContext dslContext, final long timeoutMs) {
+    this.dslContext = dslContext;
+    this.timeoutMs = timeoutMs;
+  }
+
+  @Override
+  public String getDatabaseName() {
+    return ConfigsDatabaseInstance.DATABASE_LOGGING_NAME;
+  }
+
+  @Override
+  public Optional<DSLContext> getDslContext() {
+    return Optional.ofNullable(dslContext);
+  }
+
+  @Override
+  public Logger getLogger() {
+    return LOGGER;
+  }
+
+  @Override
+  public long getTimeoutMs() {
+    return timeoutMs;
+  }
+
+}

--- a/airbyte-db/lib/src/main/java/io/airbyte/db/check/impl/ConfigsDatabaseAvailabilityCheck.java
+++ b/airbyte-db/lib/src/main/java/io/airbyte/db/check/impl/ConfigsDatabaseAvailabilityCheck.java
@@ -5,7 +5,7 @@
 package io.airbyte.db.check.impl;
 
 import io.airbyte.db.check.DatabaseAvailabilityCheck;
-import io.airbyte.db.instance.configs.ConfigsDatabaseInstance;
+import io.airbyte.db.instance.DatabaseConstants;
 import java.util.Optional;
 import org.jooq.DSLContext;
 import org.slf4j.Logger;
@@ -31,7 +31,7 @@ public class ConfigsDatabaseAvailabilityCheck implements DatabaseAvailabilityChe
 
   @Override
   public String getDatabaseName() {
-    return ConfigsDatabaseInstance.DATABASE_LOGGING_NAME;
+    return DatabaseConstants.CONFIGS_DATABASE_LOGGING_NAME;
   }
 
   @Override

--- a/airbyte-db/lib/src/main/java/io/airbyte/db/check/impl/ConfigsDatabaseMigrationCheck.java
+++ b/airbyte-db/lib/src/main/java/io/airbyte/db/check/impl/ConfigsDatabaseMigrationCheck.java
@@ -1,0 +1,55 @@
+/*
+ * Copyright (c) 2021 Airbyte, Inc., all rights reserved.
+ */
+
+package io.airbyte.db.check.impl;
+
+import io.airbyte.db.check.DatabaseMigrationCheck;
+import java.util.Optional;
+import org.flywaydb.core.Flyway;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+/**
+ * Implementation of the {@link DatabaseMigrationCheck} for the Configurations database.
+ */
+public class ConfigsDatabaseMigrationCheck implements DatabaseMigrationCheck {
+
+  private static final Logger LOGGER = LoggerFactory.getLogger(ConfigsDatabaseMigrationCheck.class);
+
+  // TODO inject via dependency injection framework
+  private final Flyway flyway;
+
+  // TODO inject via dependency injection framework
+  private final String minimumFlywayVersion;
+
+  // TODO inject via dependency injection framework
+  private final long timeoutMs;
+
+  public ConfigsDatabaseMigrationCheck(final Flyway flyway, final String minimumFlywayVersion, final long timeoutMs) {
+    this.flyway = flyway;
+    this.minimumFlywayVersion = minimumFlywayVersion;
+    this.timeoutMs = timeoutMs;
+  }
+
+  @Override
+  public Optional<Flyway> getFlyway() {
+    return Optional.ofNullable(flyway);
+  }
+
+  @Override
+  public Logger getLogger() {
+    return LOGGER;
+  }
+
+  @Override
+  public String getMinimumFlywayVersion() {
+    return minimumFlywayVersion;
+  }
+
+  @Override
+  public long getTimeoutMs() {
+    return timeoutMs;
+  }
+
+}

--- a/airbyte-db/lib/src/main/java/io/airbyte/db/check/impl/JobsDatabaseAvailabilityCheck.java
+++ b/airbyte-db/lib/src/main/java/io/airbyte/db/check/impl/JobsDatabaseAvailabilityCheck.java
@@ -1,0 +1,53 @@
+/*
+ * Copyright (c) 2021 Airbyte, Inc., all rights reserved.
+ */
+
+package io.airbyte.db.check.impl;
+
+import io.airbyte.db.check.DatabaseAvailabilityCheck;
+import java.util.Optional;
+import org.jooq.DSLContext;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+/**
+ * Implementation of the {@link DatabaseAvailabilityCheck} for the Jobs database.
+ */
+public class JobsDatabaseAvailabilityCheck implements DatabaseAvailabilityCheck {
+
+  private static final Logger LOGGER = LoggerFactory.getLogger(JobsDatabaseAvailabilityCheck.class);
+
+  private static final String DATABASE_NAME = "airbyte jobs";
+
+  // TODO inject via dependency injection framework
+  private final DSLContext dslContext;
+
+  // TODO inject via dependency injection framework
+  private final long timeoutMs;
+
+  public JobsDatabaseAvailabilityCheck(final DSLContext dslContext, final long timeoutMs) {
+    this.dslContext = dslContext;
+    this.timeoutMs = timeoutMs;
+  }
+
+  @Override
+  public String getDatabaseName() {
+    return DATABASE_NAME;
+  }
+
+  @Override
+  public Optional<DSLContext> getDslContext() {
+    return Optional.ofNullable(dslContext);
+  }
+
+  @Override
+  public Logger getLogger() {
+    return LOGGER;
+  }
+
+  @Override
+  public long getTimeoutMs() {
+    return timeoutMs;
+  }
+
+}

--- a/airbyte-db/lib/src/main/java/io/airbyte/db/check/impl/JobsDatabaseAvailabilityCheck.java
+++ b/airbyte-db/lib/src/main/java/io/airbyte/db/check/impl/JobsDatabaseAvailabilityCheck.java
@@ -5,6 +5,7 @@
 package io.airbyte.db.check.impl;
 
 import io.airbyte.db.check.DatabaseAvailabilityCheck;
+import io.airbyte.db.instance.DatabaseConstants;
 import java.util.Optional;
 import org.jooq.DSLContext;
 import org.slf4j.Logger;
@@ -16,8 +17,6 @@ import org.slf4j.LoggerFactory;
 public class JobsDatabaseAvailabilityCheck implements DatabaseAvailabilityCheck {
 
   private static final Logger LOGGER = LoggerFactory.getLogger(JobsDatabaseAvailabilityCheck.class);
-
-  private static final String DATABASE_NAME = "airbyte jobs";
 
   // TODO inject via dependency injection framework
   private final DSLContext dslContext;
@@ -32,7 +31,7 @@ public class JobsDatabaseAvailabilityCheck implements DatabaseAvailabilityCheck 
 
   @Override
   public String getDatabaseName() {
-    return DATABASE_NAME;
+    return DatabaseConstants.JOBS_DATABASE_LOGGING_NAME;
   }
 
   @Override

--- a/airbyte-db/lib/src/main/java/io/airbyte/db/check/impl/JobsDatabaseMigrationCheck.java
+++ b/airbyte-db/lib/src/main/java/io/airbyte/db/check/impl/JobsDatabaseMigrationCheck.java
@@ -1,0 +1,55 @@
+/*
+ * Copyright (c) 2021 Airbyte, Inc., all rights reserved.
+ */
+
+package io.airbyte.db.check.impl;
+
+import io.airbyte.db.check.DatabaseMigrationCheck;
+import java.util.Optional;
+import org.flywaydb.core.Flyway;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+/**
+ * Implementation of the {@link DatabaseMigrationCheck} for the Jobs database.
+ */
+public class JobsDatabaseMigrationCheck implements DatabaseMigrationCheck {
+
+  private static final Logger LOGGER = LoggerFactory.getLogger(JobsDatabaseMigrationCheck.class);
+
+  // TODO inject via dependency injection framework
+  private final Flyway flyway;
+
+  // TODO inject via dependency injection framework
+  private final String minimumFlywayVersion;
+
+  // TODO inject via dependency injection framework
+  private final long timeoutMs;
+
+  public JobsDatabaseMigrationCheck(final Flyway flyway, final String minimumFlywayVersion, final long timeoutMs) {
+    this.flyway = flyway;
+    this.minimumFlywayVersion = minimumFlywayVersion;
+    this.timeoutMs = timeoutMs;
+  }
+
+  @Override
+  public Optional<Flyway> getFlyway() {
+    return Optional.ofNullable(flyway);
+  }
+
+  @Override
+  public Logger getLogger() {
+    return LOGGER;
+  }
+
+  @Override
+  public String getMinimumFlywayVersion() {
+    return minimumFlywayVersion;
+  }
+
+  @Override
+  public long getTimeoutMs() {
+    return timeoutMs;
+  }
+
+}

--- a/airbyte-db/lib/src/main/java/io/airbyte/db/init/DatabaseInitializationException.java
+++ b/airbyte-db/lib/src/main/java/io/airbyte/db/init/DatabaseInitializationException.java
@@ -1,0 +1,21 @@
+/*
+ * Copyright (c) 2021 Airbyte, Inc., all rights reserved.
+ */
+
+package io.airbyte.db.init;
+
+/**
+ * Custom exception that represents a failure that occurs during an attempt to initialize a
+ * database.
+ */
+public class DatabaseInitializationException extends Exception {
+
+  public DatabaseInitializationException(final String message) {
+    super(message);
+  }
+
+  public DatabaseInitializationException(final String message, final Throwable cause) {
+    super(message, cause);
+  }
+
+}

--- a/airbyte-db/lib/src/main/java/io/airbyte/db/init/DatabaseInitializer.java
+++ b/airbyte-db/lib/src/main/java/io/airbyte/db/init/DatabaseInitializer.java
@@ -1,0 +1,141 @@
+/*
+ * Copyright (c) 2021 Airbyte, Inc., all rights reserved.
+ */
+
+package io.airbyte.db.init;
+
+import static org.jooq.impl.DSL.select;
+
+import io.airbyte.db.Database;
+import io.airbyte.db.ExceptionWrappingDatabase;
+import io.airbyte.db.check.DatabaseAvailabilityCheck;
+import java.io.IOException;
+import java.util.Collection;
+import java.util.List;
+import java.util.Optional;
+import org.jooq.DSLContext;
+import org.jooq.impl.DSL;
+import org.slf4j.Logger;
+
+/**
+ * Performs the initialization of the configured database if the database is available and has not
+ * yet been initialized.
+ *
+ * In the future, this logic could be completely removed if the schema initialization script is
+ * converted to a migration script.
+ */
+public interface DatabaseInitializer {
+
+  /**
+   * Initializes the configured database.
+   *
+   * @throws InterruptedException if unable to perform the initialization.
+   */
+  default void init() throws InterruptedException {
+    try {
+      initialize();
+    } catch (final IOException e) {
+      throw new InterruptedException("Unable to perform database initialization: " + e.getMessage());
+    }
+  }
+
+  /**
+   * Initializes the configured database by using the following steps:
+   *
+   * <ol>
+   *   <li>Verify that the database is available and accepting connections</li>
+   *   <li>Verify that the database is populated with the initial schema.  If not, create the initial schema.</li>
+   * </ol>
+   *
+   * @throws IOException if unable to perform the initial schema check/creation.
+   * @throws InterruptedException if unable to verify the database availability.
+   */
+  default void initialize() throws IOException, InterruptedException {
+    // Verify that the database is up and reachable first
+    final Optional<DatabaseAvailabilityCheck> availabilityCheck = getDatabaseAvailabilityCheck();
+    if(availabilityCheck.isPresent()) {
+      availabilityCheck.get().check();
+      final Optional<DSLContext> dslContext = getDslContext();
+      if(dslContext.isPresent()) {
+        final Database database = new Database(dslContext.get());
+        new ExceptionWrappingDatabase(database).transaction(ctx -> {
+          // Verify that all the required tables are present
+          if (getTableNames().stream().allMatch(tableName -> hasTable(dslContext.get(), tableName))) {
+            getLogger().info("The {} database is initialized", getDatabaseName());
+          } else {
+            getLogger().info("The {} database has not been initialized; initializing it with schema: \n{}", getDatabaseName(), getInitialSchema());
+            ctx.execute(getInitialSchema());
+            getLogger().info("The {} database successfully initialized with schema: \n{}.", getDatabaseName(), getInitialSchema());
+          }
+
+          // Always return true, as the tables either exist or were just initialized by this transaction
+          return true;
+        });
+      } else {
+        throw new InterruptedException("Database configuration not present.");
+      }
+    } else {
+      throw new InterruptedException("Availability check not configured.");
+    }
+  }
+
+  /**
+   * Tests whether the provided table exists in the database.
+   *
+   * @param ctx A {@link DSLContext} used to query the database.
+   * @param tableName The name of the table.
+   * @return {@code True} if the table exists or {@code false} otherwise.
+   */
+  default boolean hasTable(final DSLContext ctx, final String tableName) {
+    return ctx.fetchExists(select()
+        .from("information_schema.tables")
+        .where(DSL.field("table_name").eq(tableName)
+            .and(DSL.field("table_schema").eq("public"))));
+  }
+
+  /**
+   * Retrieves the {@link DatabaseAvailabilityCheck} used to verify that the database is running and
+   * available.
+   *
+   * @return The {@link DatabaseAvailabilityCheck}.
+   */
+  Optional<DatabaseAvailabilityCheck> getDatabaseAvailabilityCheck();
+
+  /**
+   * Retrieves the configured database name to be tested.
+   *
+   * @return The name of the database to test.
+   */
+  String getDatabaseName();
+
+  /**
+   * Retrieves the configured {@link DSLContext} to be used to test the database availability.
+   *
+   * @return The configured {@link DSLContext} object.
+   */
+  Optional<DSLContext> getDslContext();
+
+  /**
+   * Retrieve the initial schema to be applied to the database if the database is not already
+   * populated with the expected table(s).
+   *
+   * @return The initial schema.
+   */
+  String getInitialSchema();
+
+  /**
+   * Retrieves the configured {@link Logger} object to be used to record progress of the migration
+   * check.
+   *
+   * @return The configured {@link Logger} object.
+   */
+  Logger getLogger();
+
+  /**
+   * The collection of table names that will be used to confirm database availability.
+   *
+   * @return The collection of database table names.
+   */
+  default Collection<String> getTableNames() { return List.of(); }
+
+}

--- a/airbyte-db/lib/src/main/java/io/airbyte/db/init/DatabaseInitializer.java
+++ b/airbyte-db/lib/src/main/java/io/airbyte/db/init/DatabaseInitializer.java
@@ -43,8 +43,9 @@ public interface DatabaseInitializer {
    * Initializes the configured database by using the following steps:
    *
    * <ol>
-   *   <li>Verify that the database is available and accepting connections</li>
-   *   <li>Verify that the database is populated with the initial schema.  If not, create the initial schema.</li>
+   * <li>Verify that the database is available and accepting connections</li>
+   * <li>Verify that the database is populated with the initial schema. If not, create the initial
+   * schema.</li>
    * </ol>
    *
    * @throws IOException if unable to perform the initial schema check/creation.
@@ -53,10 +54,10 @@ public interface DatabaseInitializer {
   default void initialize() throws IOException, InterruptedException {
     // Verify that the database is up and reachable first
     final Optional<DatabaseAvailabilityCheck> availabilityCheck = getDatabaseAvailabilityCheck();
-    if(availabilityCheck.isPresent()) {
+    if (availabilityCheck.isPresent()) {
       availabilityCheck.get().check();
       final Optional<DSLContext> dslContext = getDslContext();
-      if(dslContext.isPresent()) {
+      if (dslContext.isPresent()) {
         final Database database = new Database(dslContext.get());
         new ExceptionWrappingDatabase(database).transaction(ctx -> {
           // Verify that all the required tables are present
@@ -136,6 +137,8 @@ public interface DatabaseInitializer {
    *
    * @return The collection of database table names.
    */
-  default Collection<String> getTableNames() { return List.of(); }
+  default Collection<String> getTableNames() {
+    return List.of();
+  }
 
 }

--- a/airbyte-db/lib/src/main/java/io/airbyte/db/init/DatabaseInitializer.java
+++ b/airbyte-db/lib/src/main/java/io/airbyte/db/init/DatabaseInitializer.java
@@ -12,7 +12,6 @@ import io.airbyte.db.check.DatabaseAvailabilityCheck;
 import io.airbyte.db.check.DatabaseCheckException;
 import java.io.IOException;
 import java.util.Collection;
-import java.util.List;
 import java.util.Optional;
 import org.jooq.DSLContext;
 import org.jooq.impl.DSL;
@@ -85,8 +84,8 @@ public interface DatabaseInitializer {
   /**
    * Initializes the schema in the database represented by the provided {@link DSLContext} instance.
    *
-   * If the initial tables already exist in the database, initialization is skipped.  Otherwise,
-   * the script provided by the {@link #getInitialSchema()} method is executed against the database.
+   * If the initial tables already exist in the database, initialization is skipped. Otherwise, the
+   * script provided by the {@link #getInitialSchema()} method is executed against the database.
    *
    * @param ctx The {@link DSLContext} used to execute the schema initialization.
    * @return {@code true} indicating that the operation ran
@@ -94,7 +93,7 @@ public interface DatabaseInitializer {
   default boolean initializeSchema(final DSLContext ctx) {
     final Optional<Collection<String>> tableNames = getTableNames();
 
-    if(tableNames.isPresent()) {
+    if (tableNames.isPresent()) {
       // Verify that all the required tables are present
       if (tableNames.get().stream().allMatch(tableName -> hasTable(ctx, tableName))) {
         getLogger().info("The {} database is initialized", getDatabaseName());

--- a/airbyte-db/lib/src/main/java/io/airbyte/db/init/impl/ConfigsDatabaseInitializer.java
+++ b/airbyte-db/lib/src/main/java/io/airbyte/db/init/impl/ConfigsDatabaseInitializer.java
@@ -64,8 +64,8 @@ public class ConfigsDatabaseInitializer implements DatabaseInitializer {
   }
 
   @Override
-  public Collection<String> getTableNames() {
-    return DatabaseConstants.CONFIGS_INITIAL_EXPECTED_TABLES;
+  public Optional<Collection<String>> getTableNames() {
+    return Optional.of(DatabaseConstants.CONFIGS_INITIAL_EXPECTED_TABLES);
   }
 
 }

--- a/airbyte-db/lib/src/main/java/io/airbyte/db/init/impl/ConfigsDatabaseInitializer.java
+++ b/airbyte-db/lib/src/main/java/io/airbyte/db/init/impl/ConfigsDatabaseInitializer.java
@@ -1,0 +1,71 @@
+/*
+ * Copyright (c) 2021 Airbyte, Inc., all rights reserved.
+ */
+
+package io.airbyte.db.init.impl;
+
+import io.airbyte.db.check.DatabaseAvailabilityCheck;
+import io.airbyte.db.init.DatabaseInitializer;
+import io.airbyte.db.instance.configs.ConfigsDatabaseInstance;
+import java.util.Collection;
+import java.util.Optional;
+import org.jooq.DSLContext;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+/**
+ * Implementation of the {@link DatabaseInitializer} for the Configurations database that creates
+ * the schema if it does not currently exist.
+ */
+public class ConfigsDatabaseInitializer implements DatabaseInitializer {
+
+  private static final Logger LOGGER = LoggerFactory.getLogger(ConfigsDatabaseInitializer.class);
+
+  // TODO inject via dependency injection framework
+  private final DatabaseAvailabilityCheck databaseAvailablityCheck;
+
+  // TODO inject via dependency injection framework
+  private final DSLContext dslContext;
+
+  // TODO inject via dependency injection framework
+  private final String initialSchema;
+
+  public ConfigsDatabaseInitializer(final DatabaseAvailabilityCheck databaseAvailablityCheck,
+                                    final DSLContext dslContext,
+                                    final String initialSchema) {
+    this.databaseAvailablityCheck = databaseAvailablityCheck;
+    this.dslContext = dslContext;
+    this.initialSchema = initialSchema;
+  }
+
+  @Override
+  public Optional<DatabaseAvailabilityCheck> getDatabaseAvailabilityCheck() {
+    return Optional.ofNullable(databaseAvailablityCheck);
+  }
+
+  @Override
+  public String getDatabaseName() {
+    return ConfigsDatabaseInstance.DATABASE_LOGGING_NAME;
+  }
+
+  @Override
+  public Optional<DSLContext> getDslContext() {
+    return Optional.ofNullable(dslContext);
+  }
+
+  @Override
+  public String getInitialSchema() {
+    return initialSchema;
+  }
+
+  @Override
+  public Logger getLogger() {
+    return LOGGER;
+  }
+
+  @Override
+  public Collection<String> getTableNames() {
+    return ConfigsDatabaseInstance.INITIAL_EXPECTED_TABLES;
+  }
+
+}

--- a/airbyte-db/lib/src/main/java/io/airbyte/db/init/impl/ConfigsDatabaseInitializer.java
+++ b/airbyte-db/lib/src/main/java/io/airbyte/db/init/impl/ConfigsDatabaseInitializer.java
@@ -6,7 +6,7 @@ package io.airbyte.db.init.impl;
 
 import io.airbyte.db.check.DatabaseAvailabilityCheck;
 import io.airbyte.db.init.DatabaseInitializer;
-import io.airbyte.db.instance.configs.ConfigsDatabaseInstance;
+import io.airbyte.db.instance.DatabaseConstants;
 import java.util.Collection;
 import java.util.Optional;
 import org.jooq.DSLContext;
@@ -45,7 +45,7 @@ public class ConfigsDatabaseInitializer implements DatabaseInitializer {
 
   @Override
   public String getDatabaseName() {
-    return ConfigsDatabaseInstance.DATABASE_LOGGING_NAME;
+    return DatabaseConstants.CONFIGS_DATABASE_LOGGING_NAME;
   }
 
   @Override
@@ -65,7 +65,7 @@ public class ConfigsDatabaseInitializer implements DatabaseInitializer {
 
   @Override
   public Collection<String> getTableNames() {
-    return ConfigsDatabaseInstance.INITIAL_EXPECTED_TABLES;
+    return DatabaseConstants.CONFIGS_INITIAL_EXPECTED_TABLES;
   }
 
 }

--- a/airbyte-db/lib/src/main/java/io/airbyte/db/init/impl/JobsDatabaseInitializer.java
+++ b/airbyte-db/lib/src/main/java/io/airbyte/db/init/impl/JobsDatabaseInitializer.java
@@ -64,8 +64,8 @@ public class JobsDatabaseInitializer implements DatabaseInitializer {
   }
 
   @Override
-  public Collection<String> getTableNames() {
-    return DatabaseConstants.JOBS_INITIAL_EXPECTED_TABLES;
+  public Optional<Collection<String>> getTableNames() {
+    return Optional.of(DatabaseConstants.JOBS_INITIAL_EXPECTED_TABLES);
   }
 
 }

--- a/airbyte-db/lib/src/main/java/io/airbyte/db/init/impl/JobsDatabaseInitializer.java
+++ b/airbyte-db/lib/src/main/java/io/airbyte/db/init/impl/JobsDatabaseInitializer.java
@@ -1,0 +1,72 @@
+/*
+ * Copyright (c) 2021 Airbyte, Inc., all rights reserved.
+ */
+
+package io.airbyte.db.init.impl;
+
+import io.airbyte.db.check.DatabaseAvailabilityCheck;
+import io.airbyte.db.init.DatabaseInitializer;
+import io.airbyte.db.instance.jobs.JobsDatabaseInstance;
+import io.airbyte.db.instance.jobs.JobsDatabaseSchema;
+import java.util.Collection;
+import java.util.Optional;
+import org.jooq.DSLContext;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+/**
+ * Implementation of the {@link DatabaseInitializer} for the Jobs database that creates the schema
+ * if it does not currently exist.
+ */
+public class JobsDatabaseInitializer implements DatabaseInitializer {
+
+  private static final Logger LOGGER = LoggerFactory.getLogger(JobsDatabaseInitializer.class);
+
+  // TODO inject via dependency injection framework
+  private final DatabaseAvailabilityCheck databaseAvailablityCheck;
+
+  // TODO inject via dependency injection framework
+  private final DSLContext dslContext;
+
+  // TODO inject via dependency injection framework
+  private final String initialSchema;
+
+  public JobsDatabaseInitializer(final DatabaseAvailabilityCheck databaseAvailablityCheck,
+                                 final DSLContext dslContext,
+                                 final String initialSchema) {
+    this.databaseAvailablityCheck = databaseAvailablityCheck;
+    this.dslContext = dslContext;
+    this.initialSchema = initialSchema;
+  }
+
+  @Override
+  public Optional<DatabaseAvailabilityCheck> getDatabaseAvailabilityCheck() {
+    return Optional.ofNullable(databaseAvailablityCheck);
+  }
+
+  @Override
+  public String getDatabaseName() {
+    return JobsDatabaseInstance.DATABASE_LOGGING_NAME;
+  }
+
+  @Override
+  public Optional<DSLContext> getDslContext() {
+    return Optional.ofNullable(dslContext);
+  }
+
+  @Override
+  public String getInitialSchema() {
+    return initialSchema;
+  }
+
+  @Override
+  public Logger getLogger() {
+    return LOGGER;
+  }
+
+  @Override
+  public Collection<String> getTableNames() {
+    return JobsDatabaseSchema.getTableNames();
+  }
+
+}

--- a/airbyte-db/lib/src/main/java/io/airbyte/db/init/impl/JobsDatabaseInitializer.java
+++ b/airbyte-db/lib/src/main/java/io/airbyte/db/init/impl/JobsDatabaseInitializer.java
@@ -6,8 +6,7 @@ package io.airbyte.db.init.impl;
 
 import io.airbyte.db.check.DatabaseAvailabilityCheck;
 import io.airbyte.db.init.DatabaseInitializer;
-import io.airbyte.db.instance.jobs.JobsDatabaseInstance;
-import io.airbyte.db.instance.jobs.JobsDatabaseSchema;
+import io.airbyte.db.instance.DatabaseConstants;
 import java.util.Collection;
 import java.util.Optional;
 import org.jooq.DSLContext;
@@ -46,7 +45,7 @@ public class JobsDatabaseInitializer implements DatabaseInitializer {
 
   @Override
   public String getDatabaseName() {
-    return JobsDatabaseInstance.DATABASE_LOGGING_NAME;
+    return DatabaseConstants.JOBS_DATABASE_LOGGING_NAME;
   }
 
   @Override
@@ -66,7 +65,7 @@ public class JobsDatabaseInitializer implements DatabaseInitializer {
 
   @Override
   public Collection<String> getTableNames() {
-    return JobsDatabaseSchema.getTableNames();
+    return DatabaseConstants.JOBS_INITIAL_EXPECTED_TABLES;
   }
 
 }

--- a/airbyte-db/lib/src/main/java/io/airbyte/db/instance/DatabaseConstants.java
+++ b/airbyte-db/lib/src/main/java/io/airbyte/db/instance/DatabaseConstants.java
@@ -1,0 +1,51 @@
+/*
+ * Copyright (c) 2021 Airbyte, Inc., all rights reserved.
+ */
+
+package io.airbyte.db.instance;
+
+import io.airbyte.db.instance.jobs.JobsDatabaseSchema;
+import java.util.Collections;
+import java.util.Set;
+
+/**
+ * Collection of database related constants.
+ */
+public final class DatabaseConstants {
+
+  /**
+   * Logical name of the Configurations database.
+   */
+  public static final String CONFIGS_DATABASE_LOGGING_NAME = "airbyte configs";
+
+  /**
+   * Collection of tables expected to be present in the Configurations database after creation.
+   */
+  public static final Set<String> CONFIGS_INITIAL_EXPECTED_TABLES = Collections.singleton("airbyte_configs");
+
+  /**
+   * Path to the script that contains the initial schema definition for the Configurations database.
+   */
+  public static final String CONFIGS_SCHEMA_PATH = "configs_database/schema.sql";
+
+  /**
+   * Logical name of the Jobs database.
+   */
+  public static final String JOBS_DATABASE_LOGGING_NAME = "airbyte jobs";
+
+  /**
+   * Collection of tables expected to be present in the Jobs database after creation.
+   */
+  public static final Set<String> JOBS_INITIAL_EXPECTED_TABLES = JobsDatabaseSchema.getTableNames();
+
+  /**
+   * Path to the script that contains the initial schema definition for the Jobs database.
+   */
+  public static final String JOBS_SCHEMA_PATH = "jobs_database/schema.sql";
+
+  /**
+   * Private constructor to prevent instantiation.
+   */
+  private DatabaseConstants() {}
+
+}

--- a/airbyte-db/lib/src/main/java/io/airbyte/db/instance/DatabaseInstance.java
+++ b/airbyte-db/lib/src/main/java/io/airbyte/db/instance/DatabaseInstance.java
@@ -11,17 +11,29 @@ public interface DatabaseInstance {
 
   /**
    * Check is a database has been initialized.
+   *
+   * @deprecated Will be removed in future versions that separate the initialization from
+   *             creation/retrieval of an instance.
    */
+  @Deprecated(forRemoval = true)
   boolean isInitialized() throws IOException;
 
   /**
    * Get a database that has been initialized and is ready to use.
+   *
+   * @deprecated Will be replaced in future versions that separate the initialization from
+   *             creation/retrieval of an instance.
    */
+  @Deprecated(forRemoval = true)
   Database getInitialized();
 
   /**
    * Get an empty database and initialize it.
+   *
+   * @deprecated Will be replaced in future versions that separate the initialization from
+   *             creation/retrieval of an instance.
    */
+  @Deprecated(forRemoval = true)
   Database getAndInitialize() throws IOException;
 
 }

--- a/airbyte-db/lib/src/main/java/io/airbyte/db/instance/MinimumFlywayMigrationVersionCheck.java
+++ b/airbyte-db/lib/src/main/java/io/airbyte/db/instance/MinimumFlywayMigrationVersionCheck.java
@@ -17,7 +17,11 @@ import org.slf4j.LoggerFactory;
  * start interacting with the database.
  * <p>
  * Methods have dynamic pool times, and have configurable timeouts.
+ *
+ * @deprecated This class has been marked as deprecated as we move to using an application framework
+ *             to manage resources. This class will be removed in a future release.
  */
+@Deprecated(forRemoval = true)
 public class MinimumFlywayMigrationVersionCheck {
 
   // Exposed so applications have a default timeout variable.

--- a/airbyte-db/lib/src/main/java/io/airbyte/db/instance/configs/ConfigsDatabaseInstance.java
+++ b/airbyte-db/lib/src/main/java/io/airbyte/db/instance/configs/ConfigsDatabaseInstance.java
@@ -8,10 +8,9 @@ import io.airbyte.commons.resources.MoreResources;
 import io.airbyte.db.Database;
 import io.airbyte.db.ExceptionWrappingDatabase;
 import io.airbyte.db.instance.BaseDatabaseInstance;
+import io.airbyte.db.instance.DatabaseConstants;
 import io.airbyte.db.instance.DatabaseInstance;
 import java.io.IOException;
-import java.util.Collections;
-import java.util.Set;
 import java.util.function.Function;
 import org.jooq.DSLContext;
 import org.slf4j.Logger;
@@ -20,9 +19,7 @@ import org.slf4j.LoggerFactory;
 public class ConfigsDatabaseInstance extends BaseDatabaseInstance implements DatabaseInstance {
 
   private static final Logger LOGGER = LoggerFactory.getLogger(ConfigsDatabaseInstance.class);
-  public static final Set<String> INITIAL_EXPECTED_TABLES = Collections.singleton("airbyte_configs");
-  public static final String DATABASE_LOGGING_NAME = "airbyte configs";
-  public static final String SCHEMA_PATH = "configs_database/schema.sql";
+
   private static final Function<Database, Boolean> IS_CONFIGS_DATABASE_READY = database -> {
     try {
       LOGGER.info("Testing if airbyte_configs has been created and seeded...");
@@ -39,7 +36,9 @@ public class ConfigsDatabaseInstance extends BaseDatabaseInstance implements Dat
   private Database database;
 
   public ConfigsDatabaseInstance(final DSLContext dslContext) throws IOException {
-    super(dslContext, DATABASE_LOGGING_NAME, MoreResources.readResource(SCHEMA_PATH), INITIAL_EXPECTED_TABLES,
+    super(dslContext, DatabaseConstants.CONFIGS_DATABASE_LOGGING_NAME,
+        MoreResources.readResource(DatabaseConstants.CONFIGS_SCHEMA_PATH),
+        DatabaseConstants.CONFIGS_INITIAL_EXPECTED_TABLES,
         IS_CONFIGS_DATABASE_READY);
   }
 

--- a/airbyte-db/lib/src/main/java/io/airbyte/db/instance/configs/ConfigsDatabaseInstance.java
+++ b/airbyte-db/lib/src/main/java/io/airbyte/db/instance/configs/ConfigsDatabaseInstance.java
@@ -20,9 +20,9 @@ import org.slf4j.LoggerFactory;
 public class ConfigsDatabaseInstance extends BaseDatabaseInstance implements DatabaseInstance {
 
   private static final Logger LOGGER = LoggerFactory.getLogger(ConfigsDatabaseInstance.class);
-  private static final Set<String> INITIAL_EXPECTED_TABLES = Collections.singleton("airbyte_configs");
-  private static final String DATABASE_LOGGING_NAME = "airbyte configs";
-  private static final String SCHEMA_PATH = "configs_database/schema.sql";
+  public static final Set<String> INITIAL_EXPECTED_TABLES = Collections.singleton("airbyte_configs");
+  public static final String DATABASE_LOGGING_NAME = "airbyte configs";
+  public static final String SCHEMA_PATH = "configs_database/schema.sql";
   private static final Function<Database, Boolean> IS_CONFIGS_DATABASE_READY = database -> {
     try {
       LOGGER.info("Testing if airbyte_configs has been created and seeded...");

--- a/airbyte-db/lib/src/main/java/io/airbyte/db/instance/jobs/JobsDatabaseInstance.java
+++ b/airbyte-db/lib/src/main/java/io/airbyte/db/instance/jobs/JobsDatabaseInstance.java
@@ -19,8 +19,8 @@ public class JobsDatabaseInstance extends BaseDatabaseInstance implements Databa
 
   private static final Logger LOGGER = LoggerFactory.getLogger(JobsDatabaseInstance.class);
 
-  private static final String DATABASE_LOGGING_NAME = "airbyte jobs";
-  private static final String SCHEMA_PATH = "jobs_database/schema.sql";
+  public static final String DATABASE_LOGGING_NAME = "airbyte jobs";
+  public static final String SCHEMA_PATH = "jobs_database/schema.sql";
   private static final Function<Database, Boolean> IS_JOBS_DATABASE_READY = database -> {
     try {
       LOGGER.info("Testing if jobs database is ready...");

--- a/airbyte-db/lib/src/main/java/io/airbyte/db/instance/jobs/JobsDatabaseInstance.java
+++ b/airbyte-db/lib/src/main/java/io/airbyte/db/instance/jobs/JobsDatabaseInstance.java
@@ -8,6 +8,7 @@ import com.google.common.annotations.VisibleForTesting;
 import io.airbyte.commons.resources.MoreResources;
 import io.airbyte.db.Database;
 import io.airbyte.db.instance.BaseDatabaseInstance;
+import io.airbyte.db.instance.DatabaseConstants;
 import io.airbyte.db.instance.DatabaseInstance;
 import java.io.IOException;
 import java.util.function.Function;
@@ -19,8 +20,6 @@ public class JobsDatabaseInstance extends BaseDatabaseInstance implements Databa
 
   private static final Logger LOGGER = LoggerFactory.getLogger(JobsDatabaseInstance.class);
 
-  public static final String DATABASE_LOGGING_NAME = "airbyte jobs";
-  public static final String SCHEMA_PATH = "jobs_database/schema.sql";
   private static final Function<Database, Boolean> IS_JOBS_DATABASE_READY = database -> {
     try {
       LOGGER.info("Testing if jobs database is ready...");
@@ -32,11 +31,12 @@ public class JobsDatabaseInstance extends BaseDatabaseInstance implements Databa
 
   @VisibleForTesting
   public JobsDatabaseInstance(final DSLContext dslContext, final String schema) {
-    super(dslContext, DATABASE_LOGGING_NAME, schema, JobsDatabaseSchema.getTableNames(), IS_JOBS_DATABASE_READY);
+    super(dslContext, DatabaseConstants.JOBS_DATABASE_LOGGING_NAME, schema,
+        DatabaseConstants.JOBS_INITIAL_EXPECTED_TABLES, IS_JOBS_DATABASE_READY);
   }
 
   public JobsDatabaseInstance(final DSLContext dslContext) throws IOException {
-    this(dslContext, MoreResources.readResource(SCHEMA_PATH));
+    this(dslContext, MoreResources.readResource(DatabaseConstants.JOBS_SCHEMA_PATH));
   }
 
 }

--- a/airbyte-db/lib/src/test/java/io/airbyte/db/check/impl/AbstractDatabaseAvailabilityCheckTest.java
+++ b/airbyte-db/lib/src/test/java/io/airbyte/db/check/impl/AbstractDatabaseAvailabilityCheckTest.java
@@ -1,0 +1,43 @@
+/*
+ * Copyright (c) 2021 Airbyte, Inc., all rights reserved.
+ */
+
+package io.airbyte.db.check.impl;
+
+import io.airbyte.db.factory.DSLContextFactory;
+import io.airbyte.db.factory.DataSourceFactory;
+import javax.sql.DataSource;
+import org.jooq.DSLContext;
+import org.jooq.SQLDialect;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.testcontainers.containers.PostgreSQLContainer;
+
+/**
+ * Common test setup for database availability check tests.
+ */
+public abstract class AbstractDatabaseAvailabilityCheckTest {
+
+  protected PostgreSQLContainer<?> container;
+
+  protected DataSource dataSource;
+
+  protected DSLContext dslContext;
+
+  @BeforeEach
+  void setup() {
+    container = new PostgreSQLContainer<>("postgres:13-alpine");
+    container.start();
+
+    dataSource = DataSourceFactory.create(container.getUsername(), container.getPassword(), container.getDriverClassName(), container.getJdbcUrl());
+    dslContext = DSLContextFactory.create(dataSource, SQLDialect.POSTGRES);
+  }
+
+  @AfterEach
+  void cleanup() throws Exception {
+    DataSourceFactory.close(dataSource);
+    dslContext.close();
+    container.stop();
+  }
+
+}

--- a/airbyte-db/lib/src/test/java/io/airbyte/db/check/impl/AbstractDatabaseAvailabilityCheckTest.java
+++ b/airbyte-db/lib/src/test/java/io/airbyte/db/check/impl/AbstractDatabaseAvailabilityCheckTest.java
@@ -18,6 +18,8 @@ import org.testcontainers.containers.PostgreSQLContainer;
  */
 public abstract class AbstractDatabaseAvailabilityCheckTest {
 
+  protected static final long TIMEOUT_MS = 500L;
+
   protected PostgreSQLContainer<?> container;
 
   protected DataSource dataSource;

--- a/airbyte-db/lib/src/test/java/io/airbyte/db/check/impl/ConfigsDatabaseAvailabilityCheckTest.java
+++ b/airbyte-db/lib/src/test/java/io/airbyte/db/check/impl/ConfigsDatabaseAvailabilityCheckTest.java
@@ -1,0 +1,42 @@
+/*
+ * Copyright (c) 2021 Airbyte, Inc., all rights reserved.
+ */
+
+package io.airbyte.db.check.impl;
+
+import static org.mockito.Mockito.any;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+import org.jooq.DSLContext;
+import org.jooq.Select;
+import org.jooq.exception.DataAccessException;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+
+/**
+ * Test suite for the {@link ConfigsDatabaseAvailabilityCheck} class.
+ */
+public class ConfigsDatabaseAvailabilityCheckTest extends AbstractDatabaseAvailabilityCheckTest {
+
+  @Test
+  void checkDatabaseAvailability() {
+    final var check = new ConfigsDatabaseAvailabilityCheck(dslContext, 60000L);
+    Assertions.assertDoesNotThrow(() -> check.check());
+  }
+
+  @Test
+  void checkDatabaseAvailabilityTimeout() {
+    final DSLContext dslContext = mock(DSLContext.class);
+    when(dslContext.fetchExists(any(Select.class))).thenThrow(new DataAccessException("test"));
+    final var check = new ConfigsDatabaseAvailabilityCheck(dslContext, 2000L);
+    Assertions.assertThrows(InterruptedException.class, () -> check.check());
+  }
+
+  @Test
+  void checkDatabaseAvailabilityNullDslContext() {
+    final var check = new ConfigsDatabaseAvailabilityCheck(null, 2000L);
+    Assertions.assertThrows(InterruptedException.class, () -> check.check());
+  }
+
+}

--- a/airbyte-db/lib/src/test/java/io/airbyte/db/check/impl/ConfigsDatabaseAvailabilityCheckTest.java
+++ b/airbyte-db/lib/src/test/java/io/airbyte/db/check/impl/ConfigsDatabaseAvailabilityCheckTest.java
@@ -21,7 +21,7 @@ public class ConfigsDatabaseAvailabilityCheckTest extends AbstractDatabaseAvaila
 
   @Test
   void checkDatabaseAvailability() {
-    final var check = new ConfigsDatabaseAvailabilityCheck(dslContext, 60000L);
+    final var check = new ConfigsDatabaseAvailabilityCheck(dslContext, TIMEOUT_MS);
     Assertions.assertDoesNotThrow(() -> check.check());
   }
 
@@ -29,13 +29,13 @@ public class ConfigsDatabaseAvailabilityCheckTest extends AbstractDatabaseAvaila
   void checkDatabaseAvailabilityTimeout() {
     final DSLContext dslContext = mock(DSLContext.class);
     when(dslContext.fetchExists(any(Select.class))).thenThrow(new DataAccessException("test"));
-    final var check = new ConfigsDatabaseAvailabilityCheck(dslContext, 2000L);
+    final var check = new ConfigsDatabaseAvailabilityCheck(dslContext, TIMEOUT_MS);
     Assertions.assertThrows(InterruptedException.class, () -> check.check());
   }
 
   @Test
   void checkDatabaseAvailabilityNullDslContext() {
-    final var check = new ConfigsDatabaseAvailabilityCheck(null, 2000L);
+    final var check = new ConfigsDatabaseAvailabilityCheck(null, TIMEOUT_MS);
     Assertions.assertThrows(InterruptedException.class, () -> check.check());
   }
 

--- a/airbyte-db/lib/src/test/java/io/airbyte/db/check/impl/ConfigsDatabaseAvailabilityCheckTest.java
+++ b/airbyte-db/lib/src/test/java/io/airbyte/db/check/impl/ConfigsDatabaseAvailabilityCheckTest.java
@@ -8,6 +8,7 @@ import static org.mockito.Mockito.any;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
+import io.airbyte.db.check.DatabaseCheckException;
 import org.jooq.DSLContext;
 import org.jooq.Select;
 import org.jooq.exception.DataAccessException;
@@ -30,13 +31,13 @@ public class ConfigsDatabaseAvailabilityCheckTest extends AbstractDatabaseAvaila
     final DSLContext dslContext = mock(DSLContext.class);
     when(dslContext.fetchExists(any(Select.class))).thenThrow(new DataAccessException("test"));
     final var check = new ConfigsDatabaseAvailabilityCheck(dslContext, TIMEOUT_MS);
-    Assertions.assertThrows(InterruptedException.class, () -> check.check());
+    Assertions.assertThrows(DatabaseCheckException.class, () -> check.check());
   }
 
   @Test
   void checkDatabaseAvailabilityNullDslContext() {
     final var check = new ConfigsDatabaseAvailabilityCheck(null, TIMEOUT_MS);
-    Assertions.assertThrows(InterruptedException.class, () -> check.check());
+    Assertions.assertThrows(DatabaseCheckException.class, () -> check.check());
   }
 
 }

--- a/airbyte-db/lib/src/test/java/io/airbyte/db/check/impl/ConfigsDatabaseMigrationCheckTest.java
+++ b/airbyte-db/lib/src/test/java/io/airbyte/db/check/impl/ConfigsDatabaseMigrationCheckTest.java
@@ -32,7 +32,7 @@ public class ConfigsDatabaseMigrationCheckTest {
     when(migrationInfoService.current()).thenReturn(migrationInfo);
     when(flyway.info()).thenReturn(migrationInfoService);
 
-    final var check = new ConfigsDatabaseMigrationCheck(flyway, minimumVersion, 60000L);
+    final var check = new ConfigsDatabaseMigrationCheck(flyway, minimumVersion, AbstractDatabaseAvailabilityCheckTest.TIMEOUT_MS);
     Assertions.assertDoesNotThrow(() -> check.check());
   }
 
@@ -49,7 +49,7 @@ public class ConfigsDatabaseMigrationCheckTest {
     when(migrationInfoService.current()).thenReturn(migrationInfo);
     when(flyway.info()).thenReturn(migrationInfoService);
 
-    final var check = new ConfigsDatabaseMigrationCheck(flyway, minimumVersion, 2000L);
+    final var check = new ConfigsDatabaseMigrationCheck(flyway, minimumVersion, AbstractDatabaseAvailabilityCheckTest.TIMEOUT_MS);
     Assertions.assertDoesNotThrow(() -> check.check());
   }
 
@@ -66,14 +66,14 @@ public class ConfigsDatabaseMigrationCheckTest {
     when(migrationInfoService.current()).thenReturn(migrationInfo);
     when(flyway.info()).thenReturn(migrationInfoService);
 
-    final var check = new ConfigsDatabaseMigrationCheck(flyway, minimumVersion, 2000L);
+    final var check = new ConfigsDatabaseMigrationCheck(flyway, minimumVersion, AbstractDatabaseAvailabilityCheckTest.TIMEOUT_MS);
     Assertions.assertThrows(InterruptedException.class, () -> check.check());
   }
 
   @Test
   void checkDatabaseAvailabilityNullFlyway() {
     final var minimumVersion = "2.0.0";
-    final var check = new ConfigsDatabaseMigrationCheck(null, minimumVersion, 2000L);
+    final var check = new ConfigsDatabaseMigrationCheck(null, minimumVersion, AbstractDatabaseAvailabilityCheckTest.TIMEOUT_MS);
     Assertions.assertThrows(InterruptedException.class, () -> check.check());
   }
 

--- a/airbyte-db/lib/src/test/java/io/airbyte/db/check/impl/ConfigsDatabaseMigrationCheckTest.java
+++ b/airbyte-db/lib/src/test/java/io/airbyte/db/check/impl/ConfigsDatabaseMigrationCheckTest.java
@@ -76,4 +76,5 @@ public class ConfigsDatabaseMigrationCheckTest {
     final var check = new ConfigsDatabaseMigrationCheck(null, minimumVersion, 2000L);
     Assertions.assertThrows(InterruptedException.class, () -> check.check());
   }
+
 }

--- a/airbyte-db/lib/src/test/java/io/airbyte/db/check/impl/ConfigsDatabaseMigrationCheckTest.java
+++ b/airbyte-db/lib/src/test/java/io/airbyte/db/check/impl/ConfigsDatabaseMigrationCheckTest.java
@@ -7,6 +7,7 @@ package io.airbyte.db.check.impl;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
+import io.airbyte.db.check.DatabaseCheckException;
 import org.flywaydb.core.Flyway;
 import org.flywaydb.core.api.MigrationInfo;
 import org.flywaydb.core.api.MigrationInfoService;
@@ -67,14 +68,14 @@ public class ConfigsDatabaseMigrationCheckTest {
     when(flyway.info()).thenReturn(migrationInfoService);
 
     final var check = new ConfigsDatabaseMigrationCheck(flyway, minimumVersion, AbstractDatabaseAvailabilityCheckTest.TIMEOUT_MS);
-    Assertions.assertThrows(InterruptedException.class, () -> check.check());
+    Assertions.assertThrows(DatabaseCheckException.class, () -> check.check());
   }
 
   @Test
   void checkDatabaseAvailabilityNullFlyway() {
     final var minimumVersion = "2.0.0";
     final var check = new ConfigsDatabaseMigrationCheck(null, minimumVersion, AbstractDatabaseAvailabilityCheckTest.TIMEOUT_MS);
-    Assertions.assertThrows(InterruptedException.class, () -> check.check());
+    Assertions.assertThrows(DatabaseCheckException.class, () -> check.check());
   }
 
 }

--- a/airbyte-db/lib/src/test/java/io/airbyte/db/check/impl/ConfigsDatabaseMigrationCheckTest.java
+++ b/airbyte-db/lib/src/test/java/io/airbyte/db/check/impl/ConfigsDatabaseMigrationCheckTest.java
@@ -1,0 +1,79 @@
+/*
+ * Copyright (c) 2021 Airbyte, Inc., all rights reserved.
+ */
+
+package io.airbyte.db.check.impl;
+
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+import org.flywaydb.core.Flyway;
+import org.flywaydb.core.api.MigrationInfo;
+import org.flywaydb.core.api.MigrationInfoService;
+import org.flywaydb.core.api.MigrationVersion;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+
+/**
+ * Test suite for the {@link ConfigsDatabaseMigrationCheck} class.
+ */
+public class ConfigsDatabaseMigrationCheckTest {
+
+  @Test
+  void testMigrationCheck() {
+    final var minimumVersion = "1.0.0";
+    final var currentVersion = "1.2.3";
+    final var migrationVersion = MigrationVersion.fromVersion(currentVersion);
+    final var migrationInfo = mock(MigrationInfo.class);
+    final var migrationInfoService = mock(MigrationInfoService.class);
+    final var flyway = mock(Flyway.class);
+
+    when(migrationInfo.getVersion()).thenReturn(migrationVersion);
+    when(migrationInfoService.current()).thenReturn(migrationInfo);
+    when(flyway.info()).thenReturn(migrationInfoService);
+
+    final var check = new ConfigsDatabaseMigrationCheck(flyway, minimumVersion, 60000L);
+    Assertions.assertDoesNotThrow(() -> check.check());
+  }
+
+  @Test
+  void testMigrationCheckEqualVersion() {
+    final var minimumVersion = "1.2.3";
+    final var currentVersion = minimumVersion;
+    final var migrationVersion = MigrationVersion.fromVersion(currentVersion);
+    final var migrationInfo = mock(MigrationInfo.class);
+    final var migrationInfoService = mock(MigrationInfoService.class);
+    final var flyway = mock(Flyway.class);
+
+    when(migrationInfo.getVersion()).thenReturn(migrationVersion);
+    when(migrationInfoService.current()).thenReturn(migrationInfo);
+    when(flyway.info()).thenReturn(migrationInfoService);
+
+    final var check = new ConfigsDatabaseMigrationCheck(flyway, minimumVersion, 2000L);
+    Assertions.assertDoesNotThrow(() -> check.check());
+  }
+
+  @Test
+  void testMigrationCheckTimeout() {
+    final var minimumVersion = "2.0.0";
+    final var currentVersion = "1.2.3";
+    final var migrationVersion = MigrationVersion.fromVersion(currentVersion);
+    final var migrationInfo = mock(MigrationInfo.class);
+    final var migrationInfoService = mock(MigrationInfoService.class);
+    final var flyway = mock(Flyway.class);
+
+    when(migrationInfo.getVersion()).thenReturn(migrationVersion);
+    when(migrationInfoService.current()).thenReturn(migrationInfo);
+    when(flyway.info()).thenReturn(migrationInfoService);
+
+    final var check = new ConfigsDatabaseMigrationCheck(flyway, minimumVersion, 2000L);
+    Assertions.assertThrows(InterruptedException.class, () -> check.check());
+  }
+
+  @Test
+  void checkDatabaseAvailabilityNullFlyway() {
+    final var minimumVersion = "2.0.0";
+    final var check = new ConfigsDatabaseMigrationCheck(null, minimumVersion, 2000L);
+    Assertions.assertThrows(InterruptedException.class, () -> check.check());
+  }
+}

--- a/airbyte-db/lib/src/test/java/io/airbyte/db/check/impl/JobsDatabaseAvailabilityCheckTest.java
+++ b/airbyte-db/lib/src/test/java/io/airbyte/db/check/impl/JobsDatabaseAvailabilityCheckTest.java
@@ -8,6 +8,7 @@ import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
+import io.airbyte.db.check.DatabaseCheckException;
 import org.jooq.DSLContext;
 import org.jooq.Select;
 import org.jooq.exception.DataAccessException;
@@ -30,13 +31,13 @@ public class JobsDatabaseAvailabilityCheckTest extends AbstractDatabaseAvailabil
     final DSLContext dslContext = mock(DSLContext.class);
     when(dslContext.fetchExists(any(Select.class))).thenThrow(new DataAccessException("test"));
     final var check = new JobsDatabaseAvailabilityCheck(dslContext, TIMEOUT_MS);
-    Assertions.assertThrows(InterruptedException.class, () -> check.check());
+    Assertions.assertThrows(DatabaseCheckException.class, () -> check.check());
   }
 
   @Test
   void checkDatabaseAvailabilityNullDslContext() {
     final var check = new JobsDatabaseAvailabilityCheck(null, TIMEOUT_MS);
-    Assertions.assertThrows(InterruptedException.class, () -> check.check());
+    Assertions.assertThrows(DatabaseCheckException.class, () -> check.check());
   }
 
 }

--- a/airbyte-db/lib/src/test/java/io/airbyte/db/check/impl/JobsDatabaseAvailabilityCheckTest.java
+++ b/airbyte-db/lib/src/test/java/io/airbyte/db/check/impl/JobsDatabaseAvailabilityCheckTest.java
@@ -21,7 +21,7 @@ public class JobsDatabaseAvailabilityCheckTest extends AbstractDatabaseAvailabil
 
   @Test
   void checkDatabaseAvailability() {
-    final var check = new JobsDatabaseAvailabilityCheck(dslContext, 60000L);
+    final var check = new JobsDatabaseAvailabilityCheck(dslContext, TIMEOUT_MS);
     Assertions.assertDoesNotThrow(() -> check.check());
   }
 
@@ -29,13 +29,13 @@ public class JobsDatabaseAvailabilityCheckTest extends AbstractDatabaseAvailabil
   void checkDatabaseAvailabilityTimeout() {
     final DSLContext dslContext = mock(DSLContext.class);
     when(dslContext.fetchExists(any(Select.class))).thenThrow(new DataAccessException("test"));
-    final var check = new JobsDatabaseAvailabilityCheck(dslContext, 2000L);
+    final var check = new JobsDatabaseAvailabilityCheck(dslContext, TIMEOUT_MS);
     Assertions.assertThrows(InterruptedException.class, () -> check.check());
   }
 
   @Test
   void checkDatabaseAvailabilityNullDslContext() {
-    final var check = new JobsDatabaseAvailabilityCheck(null, 2000L);
+    final var check = new JobsDatabaseAvailabilityCheck(null, TIMEOUT_MS);
     Assertions.assertThrows(InterruptedException.class, () -> check.check());
   }
 

--- a/airbyte-db/lib/src/test/java/io/airbyte/db/check/impl/JobsDatabaseAvailabilityCheckTest.java
+++ b/airbyte-db/lib/src/test/java/io/airbyte/db/check/impl/JobsDatabaseAvailabilityCheckTest.java
@@ -38,4 +38,5 @@ public class JobsDatabaseAvailabilityCheckTest extends AbstractDatabaseAvailabil
     final var check = new JobsDatabaseAvailabilityCheck(null, 2000L);
     Assertions.assertThrows(InterruptedException.class, () -> check.check());
   }
+
 }

--- a/airbyte-db/lib/src/test/java/io/airbyte/db/check/impl/JobsDatabaseAvailabilityCheckTest.java
+++ b/airbyte-db/lib/src/test/java/io/airbyte/db/check/impl/JobsDatabaseAvailabilityCheckTest.java
@@ -1,0 +1,41 @@
+/*
+ * Copyright (c) 2021 Airbyte, Inc., all rights reserved.
+ */
+
+package io.airbyte.db.check.impl;
+
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+import org.jooq.DSLContext;
+import org.jooq.Select;
+import org.jooq.exception.DataAccessException;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+
+/**
+ * Test suite for the {@link JobsDatabaseAvailabilityCheck} class.
+ */
+public class JobsDatabaseAvailabilityCheckTest extends AbstractDatabaseAvailabilityCheckTest {
+
+  @Test
+  void checkDatabaseAvailability() {
+    final var check = new JobsDatabaseAvailabilityCheck(dslContext, 60000L);
+    Assertions.assertDoesNotThrow(() -> check.check());
+  }
+
+  @Test
+  void checkDatabaseAvailabilityTimeout() {
+    final DSLContext dslContext = mock(DSLContext.class);
+    when(dslContext.fetchExists(any(Select.class))).thenThrow(new DataAccessException("test"));
+    final var check = new JobsDatabaseAvailabilityCheck(dslContext, 2000L);
+    Assertions.assertThrows(InterruptedException.class, () -> check.check());
+  }
+
+  @Test
+  void checkDatabaseAvailabilityNullDslContext() {
+    final var check = new JobsDatabaseAvailabilityCheck(null, 2000L);
+    Assertions.assertThrows(InterruptedException.class, () -> check.check());
+  }
+}

--- a/airbyte-db/lib/src/test/java/io/airbyte/db/check/impl/JobsDatabaseMigrationCheckTest.java
+++ b/airbyte-db/lib/src/test/java/io/airbyte/db/check/impl/JobsDatabaseMigrationCheckTest.java
@@ -76,4 +76,5 @@ public class JobsDatabaseMigrationCheckTest {
     final var check = new JobsDatabaseMigrationCheck(null, minimumVersion, 2000L);
     Assertions.assertThrows(InterruptedException.class, () -> check.check());
   }
+
 }

--- a/airbyte-db/lib/src/test/java/io/airbyte/db/check/impl/JobsDatabaseMigrationCheckTest.java
+++ b/airbyte-db/lib/src/test/java/io/airbyte/db/check/impl/JobsDatabaseMigrationCheckTest.java
@@ -1,0 +1,79 @@
+/*
+ * Copyright (c) 2021 Airbyte, Inc., all rights reserved.
+ */
+
+package io.airbyte.db.check.impl;
+
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+import org.flywaydb.core.Flyway;
+import org.flywaydb.core.api.MigrationInfo;
+import org.flywaydb.core.api.MigrationInfoService;
+import org.flywaydb.core.api.MigrationVersion;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+
+/**
+ * Test suite for the {@link JobsDatabaseMigrationCheck} class.
+ */
+public class JobsDatabaseMigrationCheckTest {
+
+  @Test
+  void testMigrationCheck() {
+    final var minimumVersion = "1.0.0";
+    final var currentVersion = "1.2.3";
+    final var migrationVersion = MigrationVersion.fromVersion(currentVersion);
+    final var migrationInfo = mock(MigrationInfo.class);
+    final var migrationInfoService = mock(MigrationInfoService.class);
+    final var flyway = mock(Flyway.class);
+
+    when(migrationInfo.getVersion()).thenReturn(migrationVersion);
+    when(migrationInfoService.current()).thenReturn(migrationInfo);
+    when(flyway.info()).thenReturn(migrationInfoService);
+
+    final var check = new JobsDatabaseMigrationCheck(flyway, minimumVersion, 60000L);
+    Assertions.assertDoesNotThrow(() -> check.check());
+  }
+
+  @Test
+  void testMigrationCheckEqualVersion() {
+    final var minimumVersion = "1.2.3";
+    final var currentVersion = minimumVersion;
+    final var migrationVersion = MigrationVersion.fromVersion(currentVersion);
+    final var migrationInfo = mock(MigrationInfo.class);
+    final var migrationInfoService = mock(MigrationInfoService.class);
+    final var flyway = mock(Flyway.class);
+
+    when(migrationInfo.getVersion()).thenReturn(migrationVersion);
+    when(migrationInfoService.current()).thenReturn(migrationInfo);
+    when(flyway.info()).thenReturn(migrationInfoService);
+
+    final var check = new JobsDatabaseMigrationCheck(flyway, minimumVersion, 2000L);
+    Assertions.assertDoesNotThrow(() -> check.check());
+  }
+
+  @Test
+  void testMigrationCheckTimeout() {
+    final var minimumVersion = "2.0.0";
+    final var currentVersion = "1.2.3";
+    final var migrationVersion = MigrationVersion.fromVersion(currentVersion);
+    final var migrationInfo = mock(MigrationInfo.class);
+    final var migrationInfoService = mock(MigrationInfoService.class);
+    final var flyway = mock(Flyway.class);
+
+    when(migrationInfo.getVersion()).thenReturn(migrationVersion);
+    when(migrationInfoService.current()).thenReturn(migrationInfo);
+    when(flyway.info()).thenReturn(migrationInfoService);
+
+    final var check = new JobsDatabaseMigrationCheck(flyway, minimumVersion, 2000L);
+    Assertions.assertThrows(InterruptedException.class, () -> check.check());
+  }
+
+  @Test
+  void checkDatabaseAvailabilityNullFlyway() {
+    final var minimumVersion = "2.0.0";
+    final var check = new JobsDatabaseMigrationCheck(null, minimumVersion, 2000L);
+    Assertions.assertThrows(InterruptedException.class, () -> check.check());
+  }
+}

--- a/airbyte-db/lib/src/test/java/io/airbyte/db/check/impl/JobsDatabaseMigrationCheckTest.java
+++ b/airbyte-db/lib/src/test/java/io/airbyte/db/check/impl/JobsDatabaseMigrationCheckTest.java
@@ -32,7 +32,7 @@ public class JobsDatabaseMigrationCheckTest {
     when(migrationInfoService.current()).thenReturn(migrationInfo);
     when(flyway.info()).thenReturn(migrationInfoService);
 
-    final var check = new JobsDatabaseMigrationCheck(flyway, minimumVersion, 60000L);
+    final var check = new JobsDatabaseMigrationCheck(flyway, minimumVersion, AbstractDatabaseAvailabilityCheckTest.TIMEOUT_MS);
     Assertions.assertDoesNotThrow(() -> check.check());
   }
 
@@ -49,7 +49,7 @@ public class JobsDatabaseMigrationCheckTest {
     when(migrationInfoService.current()).thenReturn(migrationInfo);
     when(flyway.info()).thenReturn(migrationInfoService);
 
-    final var check = new JobsDatabaseMigrationCheck(flyway, minimumVersion, 2000L);
+    final var check = new JobsDatabaseMigrationCheck(flyway, minimumVersion, AbstractDatabaseAvailabilityCheckTest.TIMEOUT_MS);
     Assertions.assertDoesNotThrow(() -> check.check());
   }
 
@@ -66,14 +66,14 @@ public class JobsDatabaseMigrationCheckTest {
     when(migrationInfoService.current()).thenReturn(migrationInfo);
     when(flyway.info()).thenReturn(migrationInfoService);
 
-    final var check = new JobsDatabaseMigrationCheck(flyway, minimumVersion, 2000L);
+    final var check = new JobsDatabaseMigrationCheck(flyway, minimumVersion, AbstractDatabaseAvailabilityCheckTest.TIMEOUT_MS);
     Assertions.assertThrows(InterruptedException.class, () -> check.check());
   }
 
   @Test
   void checkDatabaseAvailabilityNullFlyway() {
     final var minimumVersion = "2.0.0";
-    final var check = new JobsDatabaseMigrationCheck(null, minimumVersion, 2000L);
+    final var check = new JobsDatabaseMigrationCheck(null, minimumVersion, AbstractDatabaseAvailabilityCheckTest.TIMEOUT_MS);
     Assertions.assertThrows(InterruptedException.class, () -> check.check());
   }
 

--- a/airbyte-db/lib/src/test/java/io/airbyte/db/check/impl/JobsDatabaseMigrationCheckTest.java
+++ b/airbyte-db/lib/src/test/java/io/airbyte/db/check/impl/JobsDatabaseMigrationCheckTest.java
@@ -7,6 +7,7 @@ package io.airbyte.db.check.impl;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
+import io.airbyte.db.check.DatabaseCheckException;
 import org.flywaydb.core.Flyway;
 import org.flywaydb.core.api.MigrationInfo;
 import org.flywaydb.core.api.MigrationInfoService;
@@ -67,14 +68,14 @@ public class JobsDatabaseMigrationCheckTest {
     when(flyway.info()).thenReturn(migrationInfoService);
 
     final var check = new JobsDatabaseMigrationCheck(flyway, minimumVersion, AbstractDatabaseAvailabilityCheckTest.TIMEOUT_MS);
-    Assertions.assertThrows(InterruptedException.class, () -> check.check());
+    Assertions.assertThrows(DatabaseCheckException.class, () -> check.check());
   }
 
   @Test
   void checkDatabaseAvailabilityNullFlyway() {
     final var minimumVersion = "2.0.0";
     final var check = new JobsDatabaseMigrationCheck(null, minimumVersion, AbstractDatabaseAvailabilityCheckTest.TIMEOUT_MS);
-    Assertions.assertThrows(InterruptedException.class, () -> check.check());
+    Assertions.assertThrows(DatabaseCheckException.class, () -> check.check());
   }
 
 }

--- a/airbyte-db/lib/src/test/java/io/airbyte/db/init/DatabaseInitializerTest.java
+++ b/airbyte-db/lib/src/test/java/io/airbyte/db/init/DatabaseInitializerTest.java
@@ -5,7 +5,6 @@
 package io.airbyte.db.init;
 
 import io.airbyte.db.check.DatabaseAvailabilityCheck;
-import java.io.IOException;
 import java.util.Collection;
 import java.util.Optional;
 import org.jooq.DSLContext;
@@ -20,8 +19,8 @@ public class DatabaseInitializerTest {
     final var initializer = new DatabaseInitializer() {
 
       @Override
-      public void initialize() throws IOException, InterruptedException {
-        throw new IOException("test");
+      public void initialize() throws DatabaseInitializationException {
+        throw new DatabaseInitializationException("test");
       }
 
       @Override
@@ -56,7 +55,7 @@ public class DatabaseInitializerTest {
 
     };
 
-    Assertions.assertThrows(InterruptedException.class, () -> initializer.init());
+    Assertions.assertThrows(DatabaseInitializationException.class, () -> initializer.init());
   }
 
   @Test
@@ -64,7 +63,7 @@ public class DatabaseInitializerTest {
     final var initializer = new DatabaseInitializer() {
 
       @Override
-      public void initialize() throws IOException, InterruptedException {}
+      public void initialize() throws DatabaseInitializationException {}
 
       @Override
       public Optional<DatabaseAvailabilityCheck> getDatabaseAvailabilityCheck() {

--- a/airbyte-db/lib/src/test/java/io/airbyte/db/init/DatabaseInitializerTest.java
+++ b/airbyte-db/lib/src/test/java/io/airbyte/db/init/DatabaseInitializerTest.java
@@ -1,0 +1,100 @@
+/*
+ * Copyright (c) 2021 Airbyte, Inc., all rights reserved.
+ */
+
+package io.airbyte.db.init;
+
+import io.airbyte.db.check.DatabaseAvailabilityCheck;
+import java.io.IOException;
+import java.util.Collection;
+import java.util.Optional;
+import org.jooq.DSLContext;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+import org.slf4j.Logger;
+
+public class DatabaseInitializerTest {
+
+  @Test
+  void testExceptionHandling() {
+    final var initializer = new DatabaseInitializer() {
+
+      @Override
+      public void initialize() throws IOException, InterruptedException {
+        throw new IOException("test");
+      }
+
+      @Override
+      public Optional<DatabaseAvailabilityCheck> getDatabaseAvailabilityCheck() {
+        return Optional.empty();
+      }
+
+      @Override
+      public String getDatabaseName() {
+        return null;
+      }
+
+      @Override
+      public Optional<DSLContext> getDslContext() {
+        return Optional.empty();
+      }
+
+      @Override
+      public String getInitialSchema() {
+        return null;
+      }
+
+      @Override
+      public Logger getLogger() {
+        return null;
+      }
+
+      @Override
+      public Collection<String> getTableNames() {
+        return null;
+      }
+
+    };
+
+    Assertions.assertThrows(InterruptedException.class, () -> initializer.init());
+  }
+
+  @Test
+  void testDefaultTableNamesMethod() {
+    final var initializer = new DatabaseInitializer() {
+
+      @Override
+      public void initialize() throws IOException, InterruptedException {}
+
+      @Override
+      public Optional<DatabaseAvailabilityCheck> getDatabaseAvailabilityCheck() {
+        return Optional.empty();
+      }
+
+      @Override
+      public String getDatabaseName() {
+        return null;
+      }
+
+      @Override
+      public Optional<DSLContext> getDslContext() {
+        return Optional.empty();
+      }
+
+      @Override
+      public String getInitialSchema() {
+        return null;
+      }
+
+      @Override
+      public Logger getLogger() {
+        return null;
+      }
+
+    };
+
+    Assertions.assertNotNull(initializer.getTableNames());
+    Assertions.assertEquals(0, initializer.getTableNames().size());
+  }
+
+}

--- a/airbyte-db/lib/src/test/java/io/airbyte/db/init/DatabaseInitializerTest.java
+++ b/airbyte-db/lib/src/test/java/io/airbyte/db/init/DatabaseInitializerTest.java
@@ -4,6 +4,8 @@
 
 package io.airbyte.db.init;
 
+import static org.mockito.Mockito.mock;
+
 import io.airbyte.db.check.DatabaseAvailabilityCheck;
 import java.util.Collection;
 import java.util.Optional;
@@ -11,8 +13,11 @@ import org.jooq.DSLContext;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
 import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 public class DatabaseInitializerTest {
+
+  private static final Logger LOGGER = LoggerFactory.getLogger(DatabaseInitializerTest.class);
 
   @Test
   void testExceptionHandling() {
@@ -45,12 +50,12 @@ public class DatabaseInitializerTest {
 
       @Override
       public Logger getLogger() {
-        return null;
+        return LOGGER;
       }
 
       @Override
-      public Collection<String> getTableNames() {
-        return null;
+      public Optional<Collection<String>> getTableNames() {
+        return Optional.empty();
       }
 
     };
@@ -59,15 +64,13 @@ public class DatabaseInitializerTest {
   }
 
   @Test
-  void testDefaultTableNamesMethod() {
+  void testEmptyTableNames() {
+    final var dslContext = mock(DSLContext.class);
     final var initializer = new DatabaseInitializer() {
 
       @Override
-      public void initialize() throws DatabaseInitializationException {}
-
-      @Override
       public Optional<DatabaseAvailabilityCheck> getDatabaseAvailabilityCheck() {
-        return Optional.empty();
+        return Optional.of(mock(DatabaseAvailabilityCheck.class));
       }
 
       @Override
@@ -77,7 +80,7 @@ public class DatabaseInitializerTest {
 
       @Override
       public Optional<DSLContext> getDslContext() {
-        return Optional.empty();
+        return Optional.of(dslContext);
       }
 
       @Override
@@ -87,13 +90,18 @@ public class DatabaseInitializerTest {
 
       @Override
       public Logger getLogger() {
-        return null;
+        return LOGGER;
       }
 
+      @Override
+      public Optional<Collection<String>> getTableNames() {
+        return Optional.empty();
+      }
     };
 
+    Assertions.assertEquals(false, initializer.initializeSchema(dslContext));
     Assertions.assertNotNull(initializer.getTableNames());
-    Assertions.assertEquals(0, initializer.getTableNames().size());
+    Assertions.assertEquals(false, initializer.getTableNames().isPresent());
   }
 
 }

--- a/airbyte-db/lib/src/test/java/io/airbyte/db/init/DatabaseInitializerTest.java
+++ b/airbyte-db/lib/src/test/java/io/airbyte/db/init/DatabaseInitializerTest.java
@@ -97,6 +97,7 @@ public class DatabaseInitializerTest {
       public Optional<Collection<String>> getTableNames() {
         return Optional.empty();
       }
+
     };
 
     Assertions.assertEquals(false, initializer.initializeSchema(dslContext));

--- a/airbyte-db/lib/src/test/java/io/airbyte/db/init/impl/AbstractDatabaseInitializerTest.java
+++ b/airbyte-db/lib/src/test/java/io/airbyte/db/init/impl/AbstractDatabaseInitializerTest.java
@@ -1,0 +1,43 @@
+/*
+ * Copyright (c) 2021 Airbyte, Inc., all rights reserved.
+ */
+
+package io.airbyte.db.init.impl;
+
+import io.airbyte.db.factory.DSLContextFactory;
+import io.airbyte.db.factory.DataSourceFactory;
+import javax.sql.DataSource;
+import org.jooq.DSLContext;
+import org.jooq.SQLDialect;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.testcontainers.containers.PostgreSQLContainer;
+
+/**
+ * Common test setup for database initialization tests.
+ */
+public class AbstractDatabaseInitializerTest {
+
+  protected PostgreSQLContainer<?> container;
+
+  protected DataSource dataSource;
+
+  protected DSLContext dslContext;
+
+  @BeforeEach
+  void setup() {
+    container = new PostgreSQLContainer<>("postgres:13-alpine");
+    container.start();
+
+    dataSource = DataSourceFactory.create(container.getUsername(), container.getPassword(), container.getDriverClassName(), container.getJdbcUrl());
+    dslContext = DSLContextFactory.create(dataSource, SQLDialect.POSTGRES);
+  }
+
+  @AfterEach
+  void cleanup() throws Exception {
+    DataSourceFactory.close(dataSource);
+    dslContext.close();
+    container.stop();
+  }
+
+}

--- a/airbyte-db/lib/src/test/java/io/airbyte/db/init/impl/ConfigsDatabaseInitializerTest.java
+++ b/airbyte-db/lib/src/test/java/io/airbyte/db/init/impl/ConfigsDatabaseInitializerTest.java
@@ -29,7 +29,7 @@ public class ConfigsDatabaseInitializerTest extends AbstractDatabaseInitializerT
     final var initializer = new ConfigsDatabaseInitializer(databaseAvailabilityCheck, dslContext, initialSchema);
 
     Assertions.assertDoesNotThrow(() -> initializer.init());
-    assertTrue(initializer.hasTable(dslContext, initializer.getTableNames().stream().findFirst().get()));
+    assertTrue(initializer.hasTable(dslContext, initializer.getTableNames().get().stream().findFirst().get()));
   }
 
   @Test
@@ -40,7 +40,7 @@ public class ConfigsDatabaseInitializerTest extends AbstractDatabaseInitializerT
     final var initializer = new ConfigsDatabaseInitializer(databaseAvailabilityCheck, dslContext, initialSchema);
 
     Assertions.assertDoesNotThrow(() -> initializer.init());
-    assertTrue(initializer.hasTable(dslContext, initializer.getTableNames().stream().findFirst().get()));
+    assertTrue(initializer.hasTable(dslContext, initializer.getTableNames().get().stream().findFirst().get()));
   }
 
   @Test

--- a/airbyte-db/lib/src/test/java/io/airbyte/db/init/impl/ConfigsDatabaseInitializerTest.java
+++ b/airbyte-db/lib/src/test/java/io/airbyte/db/init/impl/ConfigsDatabaseInitializerTest.java
@@ -1,0 +1,55 @@
+/*
+ * Copyright (c) 2021 Airbyte, Inc., all rights reserved.
+ */
+
+package io.airbyte.db.init.impl;
+
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.Mockito.doThrow;
+import static org.mockito.Mockito.mock;
+
+import io.airbyte.commons.resources.MoreResources;
+import io.airbyte.db.check.DatabaseAvailabilityCheck;
+import io.airbyte.db.instance.configs.ConfigsDatabaseInstance;
+import java.io.IOException;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+
+/**
+ * Test suite for the {@link ConfigsDatabaseInitializer} class.
+ */
+public class ConfigsDatabaseInitializerTest extends AbstractDatabaseInitializerTest {
+
+  @Test
+  void testInitializingSchema() throws IOException {
+    final var databaseAvailabilityCheck = mock(DatabaseAvailabilityCheck.class);
+    final var initialSchema = MoreResources.readResource(ConfigsDatabaseInstance.SCHEMA_PATH);
+    final var initializer = new ConfigsDatabaseInitializer(databaseAvailabilityCheck, dslContext, initialSchema);
+
+    Assertions.assertDoesNotThrow(() -> initializer.init());
+    assertTrue(initializer.hasTable(dslContext, initializer.getTableNames().stream().findFirst().get()));
+  }
+
+  @Test
+  void testInitializingSchemaAlreadyExists() throws IOException {
+    final var databaseAvailabilityCheck = mock(DatabaseAvailabilityCheck.class);
+    final var initialSchema = MoreResources.readResource(ConfigsDatabaseInstance.SCHEMA_PATH);
+    dslContext.execute(initialSchema);
+    final var initializer = new ConfigsDatabaseInitializer(databaseAvailabilityCheck, dslContext, initialSchema);
+
+    Assertions.assertDoesNotThrow(() -> initializer.init());
+    assertTrue(initializer.hasTable(dslContext, initializer.getTableNames().stream().findFirst().get()));
+  }
+
+  @Test
+  void testInitializationException() throws IOException, InterruptedException {
+    final var databaseAvailabilityCheck = mock(DatabaseAvailabilityCheck.class);
+    final var initialSchema = MoreResources.readResource(ConfigsDatabaseInstance.SCHEMA_PATH);
+
+    doThrow(new InterruptedException("test")).when(databaseAvailabilityCheck).check();
+
+    final var initializer = new ConfigsDatabaseInitializer(databaseAvailabilityCheck, dslContext, initialSchema);
+    Assertions.assertThrows(InterruptedException.class, () -> initializer.init());
+  }
+
+}

--- a/airbyte-db/lib/src/test/java/io/airbyte/db/init/impl/ConfigsDatabaseInitializerTest.java
+++ b/airbyte-db/lib/src/test/java/io/airbyte/db/init/impl/ConfigsDatabaseInitializerTest.java
@@ -10,6 +10,8 @@ import static org.mockito.Mockito.mock;
 
 import io.airbyte.commons.resources.MoreResources;
 import io.airbyte.db.check.DatabaseAvailabilityCheck;
+import io.airbyte.db.check.DatabaseCheckException;
+import io.airbyte.db.init.DatabaseInitializationException;
 import io.airbyte.db.instance.DatabaseConstants;
 import java.io.IOException;
 import org.junit.jupiter.api.Assertions;
@@ -42,14 +44,14 @@ public class ConfigsDatabaseInitializerTest extends AbstractDatabaseInitializerT
   }
 
   @Test
-  void testInitializationException() throws IOException, InterruptedException {
+  void testInitializationException() throws IOException, DatabaseCheckException {
     final var databaseAvailabilityCheck = mock(DatabaseAvailabilityCheck.class);
     final var initialSchema = MoreResources.readResource(DatabaseConstants.CONFIGS_SCHEMA_PATH);
 
-    doThrow(new InterruptedException("test")).when(databaseAvailabilityCheck).check();
+    doThrow(new DatabaseCheckException("test")).when(databaseAvailabilityCheck).check();
 
     final var initializer = new ConfigsDatabaseInitializer(databaseAvailabilityCheck, dslContext, initialSchema);
-    Assertions.assertThrows(InterruptedException.class, () -> initializer.init());
+    Assertions.assertThrows(DatabaseInitializationException.class, () -> initializer.init());
   }
 
 }

--- a/airbyte-db/lib/src/test/java/io/airbyte/db/init/impl/ConfigsDatabaseInitializerTest.java
+++ b/airbyte-db/lib/src/test/java/io/airbyte/db/init/impl/ConfigsDatabaseInitializerTest.java
@@ -10,7 +10,7 @@ import static org.mockito.Mockito.mock;
 
 import io.airbyte.commons.resources.MoreResources;
 import io.airbyte.db.check.DatabaseAvailabilityCheck;
-import io.airbyte.db.instance.configs.ConfigsDatabaseInstance;
+import io.airbyte.db.instance.DatabaseConstants;
 import java.io.IOException;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
@@ -23,7 +23,7 @@ public class ConfigsDatabaseInitializerTest extends AbstractDatabaseInitializerT
   @Test
   void testInitializingSchema() throws IOException {
     final var databaseAvailabilityCheck = mock(DatabaseAvailabilityCheck.class);
-    final var initialSchema = MoreResources.readResource(ConfigsDatabaseInstance.SCHEMA_PATH);
+    final var initialSchema = MoreResources.readResource(DatabaseConstants.CONFIGS_SCHEMA_PATH);
     final var initializer = new ConfigsDatabaseInitializer(databaseAvailabilityCheck, dslContext, initialSchema);
 
     Assertions.assertDoesNotThrow(() -> initializer.init());
@@ -33,7 +33,7 @@ public class ConfigsDatabaseInitializerTest extends AbstractDatabaseInitializerT
   @Test
   void testInitializingSchemaAlreadyExists() throws IOException {
     final var databaseAvailabilityCheck = mock(DatabaseAvailabilityCheck.class);
-    final var initialSchema = MoreResources.readResource(ConfigsDatabaseInstance.SCHEMA_PATH);
+    final var initialSchema = MoreResources.readResource(DatabaseConstants.CONFIGS_SCHEMA_PATH);
     dslContext.execute(initialSchema);
     final var initializer = new ConfigsDatabaseInitializer(databaseAvailabilityCheck, dslContext, initialSchema);
 
@@ -44,7 +44,7 @@ public class ConfigsDatabaseInitializerTest extends AbstractDatabaseInitializerT
   @Test
   void testInitializationException() throws IOException, InterruptedException {
     final var databaseAvailabilityCheck = mock(DatabaseAvailabilityCheck.class);
-    final var initialSchema = MoreResources.readResource(ConfigsDatabaseInstance.SCHEMA_PATH);
+    final var initialSchema = MoreResources.readResource(DatabaseConstants.CONFIGS_SCHEMA_PATH);
 
     doThrow(new InterruptedException("test")).when(databaseAvailabilityCheck).check();
 

--- a/airbyte-db/lib/src/test/java/io/airbyte/db/init/impl/JobsDatabaseInitializerTest.java
+++ b/airbyte-db/lib/src/test/java/io/airbyte/db/init/impl/JobsDatabaseInitializerTest.java
@@ -29,7 +29,7 @@ public class JobsDatabaseInitializerTest extends AbstractDatabaseInitializerTest
     final var initializer = new JobsDatabaseInitializer(databaseAvailabilityCheck, dslContext, initialSchema);
 
     Assertions.assertDoesNotThrow(() -> initializer.init());
-    assertTrue(initializer.hasTable(dslContext, initializer.getTableNames().stream().findFirst().get()));
+    assertTrue(initializer.hasTable(dslContext, initializer.getTableNames().get().stream().findFirst().get()));
   }
 
   @Test
@@ -40,7 +40,7 @@ public class JobsDatabaseInitializerTest extends AbstractDatabaseInitializerTest
     final var initializer = new JobsDatabaseInitializer(databaseAvailabilityCheck, dslContext, initialSchema);
 
     Assertions.assertDoesNotThrow(() -> initializer.init());
-    assertTrue(initializer.hasTable(dslContext, initializer.getTableNames().stream().findFirst().get()));
+    assertTrue(initializer.hasTable(dslContext, initializer.getTableNames().get().stream().findFirst().get()));
   }
 
   @Test

--- a/airbyte-db/lib/src/test/java/io/airbyte/db/init/impl/JobsDatabaseInitializerTest.java
+++ b/airbyte-db/lib/src/test/java/io/airbyte/db/init/impl/JobsDatabaseInitializerTest.java
@@ -10,7 +10,7 @@ import static org.mockito.Mockito.mock;
 
 import io.airbyte.commons.resources.MoreResources;
 import io.airbyte.db.check.DatabaseAvailabilityCheck;
-import io.airbyte.db.instance.jobs.JobsDatabaseInstance;
+import io.airbyte.db.instance.DatabaseConstants;
 import java.io.IOException;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
@@ -23,7 +23,7 @@ public class JobsDatabaseInitializerTest extends AbstractDatabaseInitializerTest
   @Test
   void testInitializingSchema() throws IOException {
     final var databaseAvailabilityCheck = mock(DatabaseAvailabilityCheck.class);
-    final var initialSchema = MoreResources.readResource(JobsDatabaseInstance.SCHEMA_PATH);
+    final var initialSchema = MoreResources.readResource(DatabaseConstants.JOBS_SCHEMA_PATH);
     final var initializer = new JobsDatabaseInitializer(databaseAvailabilityCheck, dslContext, initialSchema);
 
     Assertions.assertDoesNotThrow(() -> initializer.init());
@@ -33,7 +33,7 @@ public class JobsDatabaseInitializerTest extends AbstractDatabaseInitializerTest
   @Test
   void testInitializingSchemaAlreadyExists() throws IOException {
     final var databaseAvailabilityCheck = mock(DatabaseAvailabilityCheck.class);
-    final var initialSchema = MoreResources.readResource(JobsDatabaseInstance.SCHEMA_PATH);
+    final var initialSchema = MoreResources.readResource(DatabaseConstants.JOBS_SCHEMA_PATH);
     dslContext.execute(initialSchema);
     final var initializer = new JobsDatabaseInitializer(databaseAvailabilityCheck, dslContext, initialSchema);
 
@@ -44,7 +44,7 @@ public class JobsDatabaseInitializerTest extends AbstractDatabaseInitializerTest
   @Test
   void testInitializationException() throws IOException, InterruptedException {
     final var databaseAvailabilityCheck = mock(DatabaseAvailabilityCheck.class);
-    final var initialSchema = MoreResources.readResource(JobsDatabaseInstance.SCHEMA_PATH);
+    final var initialSchema = MoreResources.readResource(DatabaseConstants.JOBS_SCHEMA_PATH);
 
     doThrow(new InterruptedException("test")).when(databaseAvailabilityCheck).check();
 
@@ -54,7 +54,7 @@ public class JobsDatabaseInitializerTest extends AbstractDatabaseInitializerTest
 
   @Test
   void testInitializationNullAvailabilityCheck() throws IOException {
-    final var initialSchema = MoreResources.readResource(JobsDatabaseInstance.SCHEMA_PATH);
+    final var initialSchema = MoreResources.readResource(DatabaseConstants.JOBS_SCHEMA_PATH);
     final var initializer = new JobsDatabaseInitializer(null, dslContext, initialSchema);
     Assertions.assertThrows(InterruptedException.class, () -> initializer.init());
   }
@@ -62,7 +62,7 @@ public class JobsDatabaseInitializerTest extends AbstractDatabaseInitializerTest
   @Test
   void testInitializationNullDslContext() throws IOException {
     final var databaseAvailabilityCheck = mock(DatabaseAvailabilityCheck.class);
-    final var initialSchema = MoreResources.readResource(JobsDatabaseInstance.SCHEMA_PATH);
+    final var initialSchema = MoreResources.readResource(DatabaseConstants.JOBS_SCHEMA_PATH);
     final var initializer = new JobsDatabaseInitializer(databaseAvailabilityCheck, null, initialSchema);
     Assertions.assertThrows(InterruptedException.class, () -> initializer.init());
   }

--- a/airbyte-db/lib/src/test/java/io/airbyte/db/init/impl/JobsDatabaseInitializerTest.java
+++ b/airbyte-db/lib/src/test/java/io/airbyte/db/init/impl/JobsDatabaseInitializerTest.java
@@ -1,0 +1,70 @@
+/*
+ * Copyright (c) 2021 Airbyte, Inc., all rights reserved.
+ */
+
+package io.airbyte.db.init.impl;
+
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.Mockito.doThrow;
+import static org.mockito.Mockito.mock;
+
+import io.airbyte.commons.resources.MoreResources;
+import io.airbyte.db.check.DatabaseAvailabilityCheck;
+import io.airbyte.db.instance.jobs.JobsDatabaseInstance;
+import java.io.IOException;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+
+/**
+ * Test suite for the {@link JobsDatabaseInitializer} class.
+ */
+public class JobsDatabaseInitializerTest extends AbstractDatabaseInitializerTest {
+
+  @Test
+  void testInitializingSchema() throws IOException {
+    final var databaseAvailabilityCheck = mock(DatabaseAvailabilityCheck.class);
+    final var initialSchema = MoreResources.readResource(JobsDatabaseInstance.SCHEMA_PATH);
+    final var initializer = new JobsDatabaseInitializer(databaseAvailabilityCheck, dslContext, initialSchema);
+
+    Assertions.assertDoesNotThrow(() -> initializer.init());
+    assertTrue(initializer.hasTable(dslContext, initializer.getTableNames().stream().findFirst().get()));
+  }
+
+  @Test
+  void testInitializingSchemaAlreadyExists() throws IOException {
+    final var databaseAvailabilityCheck = mock(DatabaseAvailabilityCheck.class);
+    final var initialSchema = MoreResources.readResource(JobsDatabaseInstance.SCHEMA_PATH);
+    dslContext.execute(initialSchema);
+    final var initializer = new JobsDatabaseInitializer(databaseAvailabilityCheck, dslContext, initialSchema);
+
+    Assertions.assertDoesNotThrow(() -> initializer.init());
+    assertTrue(initializer.hasTable(dslContext, initializer.getTableNames().stream().findFirst().get()));
+  }
+
+  @Test
+  void testInitializationException() throws IOException, InterruptedException {
+    final var databaseAvailabilityCheck = mock(DatabaseAvailabilityCheck.class);
+    final var initialSchema = MoreResources.readResource(JobsDatabaseInstance.SCHEMA_PATH);
+
+    doThrow(new InterruptedException("test")).when(databaseAvailabilityCheck).check();
+
+    final var initializer = new JobsDatabaseInitializer(databaseAvailabilityCheck, dslContext, initialSchema);
+    Assertions.assertThrows(InterruptedException.class, () -> initializer.init());
+  }
+
+  @Test
+  void testInitializationNullAvailabilityCheck() throws IOException {
+    final var initialSchema = MoreResources.readResource(JobsDatabaseInstance.SCHEMA_PATH);
+    final var initializer = new JobsDatabaseInitializer(null, dslContext, initialSchema);
+    Assertions.assertThrows(InterruptedException.class, () -> initializer.init());
+  }
+
+  @Test
+  void testInitializationNullDslContext() throws IOException {
+    final var databaseAvailabilityCheck = mock(DatabaseAvailabilityCheck.class);
+    final var initialSchema = MoreResources.readResource(JobsDatabaseInstance.SCHEMA_PATH);
+    final var initializer = new JobsDatabaseInitializer(databaseAvailabilityCheck, null, initialSchema);
+    Assertions.assertThrows(InterruptedException.class, () -> initializer.init());
+  }
+
+}

--- a/airbyte-db/lib/src/test/java/io/airbyte/db/init/impl/JobsDatabaseInitializerTest.java
+++ b/airbyte-db/lib/src/test/java/io/airbyte/db/init/impl/JobsDatabaseInitializerTest.java
@@ -10,6 +10,8 @@ import static org.mockito.Mockito.mock;
 
 import io.airbyte.commons.resources.MoreResources;
 import io.airbyte.db.check.DatabaseAvailabilityCheck;
+import io.airbyte.db.check.DatabaseCheckException;
+import io.airbyte.db.init.DatabaseInitializationException;
 import io.airbyte.db.instance.DatabaseConstants;
 import java.io.IOException;
 import org.junit.jupiter.api.Assertions;
@@ -42,21 +44,21 @@ public class JobsDatabaseInitializerTest extends AbstractDatabaseInitializerTest
   }
 
   @Test
-  void testInitializationException() throws IOException, InterruptedException {
+  void testInitializationException() throws IOException, DatabaseCheckException {
     final var databaseAvailabilityCheck = mock(DatabaseAvailabilityCheck.class);
     final var initialSchema = MoreResources.readResource(DatabaseConstants.JOBS_SCHEMA_PATH);
 
-    doThrow(new InterruptedException("test")).when(databaseAvailabilityCheck).check();
+    doThrow(new DatabaseCheckException("test")).when(databaseAvailabilityCheck).check();
 
     final var initializer = new JobsDatabaseInitializer(databaseAvailabilityCheck, dslContext, initialSchema);
-    Assertions.assertThrows(InterruptedException.class, () -> initializer.init());
+    Assertions.assertThrows(DatabaseInitializationException.class, () -> initializer.init());
   }
 
   @Test
   void testInitializationNullAvailabilityCheck() throws IOException {
     final var initialSchema = MoreResources.readResource(DatabaseConstants.JOBS_SCHEMA_PATH);
     final var initializer = new JobsDatabaseInitializer(null, dslContext, initialSchema);
-    Assertions.assertThrows(InterruptedException.class, () -> initializer.init());
+    Assertions.assertThrows(DatabaseInitializationException.class, () -> initializer.init());
   }
 
   @Test
@@ -64,7 +66,7 @@ public class JobsDatabaseInitializerTest extends AbstractDatabaseInitializerTest
     final var databaseAvailabilityCheck = mock(DatabaseAvailabilityCheck.class);
     final var initialSchema = MoreResources.readResource(DatabaseConstants.JOBS_SCHEMA_PATH);
     final var initializer = new JobsDatabaseInitializer(databaseAvailabilityCheck, null, initialSchema);
-    Assertions.assertThrows(InterruptedException.class, () -> initializer.init());
+    Assertions.assertThrows(DatabaseInitializationException.class, () -> initializer.init());
   }
 
 }


### PR DESCRIPTION
## What

* https://github.com/airbytehq/airbyte/issues/12377
* Refactor the database initialization/availability logic in preparation for the move to a dependency injection framework.  

## How

* Decouples the database availability, migration and initialization operations from the database connection classes.  This is to make it easier to turn the database connection objects into singletons to be managed by a dependency injection framework, while still maintaining the ability to perform those pre-startup actions within the framework.  Ultimately, the new classes in this PR will replace the existing logic and will be injected into a startup listener which will guarantee the execution of the checks prior to allowing the service to handle requests/perform operations.
* In addition to the refactor, the PR also performs some cleanup on the logic copied to the new checks.  In particular, the decision has been made to remove the `hasTable` check from the code that verifies the database is available and the migration has been performed.  The logic behind this decision is that if the migration has been completed successfully, then the tables that the current code verifies would be present, making this check redundant.
* For now, the code that initializes the schema if the database has not yet been created has been maintained in the refactored code.  There is an [open issue](https://github.com/airbytehq/airbyte-internal-issues/issues/625) to remove this/convert this logic into a migration script, so that the migration process handles ALL of the database object creation, not just some of it.
* Mark the `MinimumFlywayMigrationVersionCheck` and `Database` classes/methods as deprecated and to be removed in the future once the conversion to the new implementation has been completed.

### More Details

To explain what is changing/moving to the new approach, here are some diagrams of the current code and the proposed code:

#### Existing Database Availability/Migration/Initialization Logic
![Existing Database Validation (1)](https://user-images.githubusercontent.com/450956/169079903-21de4cd2-19a7-4803-a5f4-be38e9d0369d.png)

#### Proposed Database Availability/Migration/Initialization Logic
![Proposed Database Validation (1)](https://user-images.githubusercontent.com/450956/169079547-32553942-f6e6-431d-9a06-bc5277774c82.png)

One of the key differences, besides being more dependency-injection friendly, is that the proposed change in this PR re-uses the availability check logic, instead of duplicating it.  In the current code, the check to verify that the database is available and accepting connections is currently duplicated between the `MinimumFlywayMigrationVersionCheck` and `Database` classes.

## Recommended reading order
1. `DatabaseCheck.java`
2. `DatabaseAvailabilityCheck.java`
3. `DatabaseMigrationCheck.java`
4. `DatabaseInitializer.java`
5. All other classes are implementations of the interfaces (one per database type) and tests

## 🚨 User Impact 🚨

There is no user impact as a result of this PR, as the code being added is not currently being utilized.  That will occur in a future PR.

## Tests

<details><summary><strong>Unit</strong></summary>

* Unit tests have been added for all of the new classes, with 100% instruction and branch coverage.

</details>

<details><summary><strong>Integration</strong></summary>

* The new classes were added to both the `airbyte-bootloader` and `airbyte-server` and tested locally to validate that the services still performed the required checks and could start successful/perform their operations successfully when using the new logic.

</details>
