### PR TITLE
Update email placeholder example

### DIFF
--- a/airbyte-webapp/src/packages/cloud/locales/en.json
+++ b/airbyte-webapp/src/packages/cloud/locales/en.json
@@ -6,7 +6,7 @@
   "login.loginTitle": "Sign in to Airbyte",
   "login.resendEmail": "Didn’t receive the email? Send it again",
   "login.yourEmail": "Your work email*",
-  "login.yourEmail.placeholder": "christophersmith@gmail.com",
+  "login.yourEmail.placeholder": "work.email@example.com",
   "login.yourEmail.notFound": "User not found",
   "login.unknownError": "An unknown error has occurred",
   "login.password": "Enter your password*",


### PR DESCRIPTION
## What
Updates the email placeholder to move away from using a potentially real email address.

## How
Uses the reserved domain `example.com`