### PR TITLE
helm-chart: Add annotations on webapp service

### DIFF
--- a/charts/airbyte/Chart.yaml
+++ b/charts/airbyte/Chart.yaml
@@ -15,7 +15,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.3.2
+version: 0.3.3
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to

--- a/charts/airbyte/README.md
+++ b/charts/airbyte/README.md
@@ -47,6 +47,7 @@ Helm charts for Airbyte.
 | `webapp.readinessProbe.successThreshold`    | Success threshold for readinessProbe                             | `1`              |
 | `webapp.service.type`                       | The service type to use for the webapp service                   | `ClusterIP`      |
 | `webapp.service.port`                       | The service port to expose the webapp on                         | `80`             |
+| `webapp.service.annotations`                | Service annotations done as key:value pairs                      | `{}`             |
 | `webapp.resources.limits`                   | The resources limits for the Web container                       | `{}`             |
 | `webapp.resources.requests`                 | The requested resources for the Web container                    | `{}`             |
 | `webapp.nodeSelector`                       | Node labels for pod assignment                                   | `{}`             |

--- a/charts/airbyte/README.md
+++ b/charts/airbyte/README.md
@@ -47,7 +47,7 @@ Helm charts for Airbyte.
 | `webapp.readinessProbe.successThreshold`    | Success threshold for readinessProbe                             | `1`              |
 | `webapp.service.type`                       | The service type to use for the webapp service                   | `ClusterIP`      |
 | `webapp.service.port`                       | The service port to expose the webapp on                         | `80`             |
-| `webapp.service.annotations`                | Service annotations done as key:value pairs                      | `{}`             |
+| `webapp.service.annotations`                | Annotations for the webapp service resource                      | `{}`             |
 | `webapp.resources.limits`                   | The resources limits for the Web container                       | `{}`             |
 | `webapp.resources.requests`                 | The requested resources for the Web container                    | `{}`             |
 | `webapp.nodeSelector`                       | Node labels for pod assignment                                   | `{}`             |

--- a/charts/airbyte/templates/webapp/service.yaml
+++ b/charts/airbyte/templates/webapp/service.yaml
@@ -3,6 +3,10 @@ apiVersion: v1
 kind: Service
 metadata:
   name: {{ include "common.names.fullname" . }}-webapp
+  {{- if .Values.webapp.service.annotations }}
+  annotations:
+    {{- include "common.tplvalues.render" (dict "value" .Values.webapp.service.annotations "context" $) | nindent 4 }}
+  {{- end }}
 spec:
   type: {{ .Values.webapp.service.type }}
   ports:

--- a/charts/airbyte/templates/webapp/service.yaml
+++ b/charts/airbyte/templates/webapp/service.yaml
@@ -3,9 +3,9 @@ apiVersion: v1
 kind: Service
 metadata:
   name: {{ include "common.names.fullname" . }}-webapp
-  {{- if .Values.webapp.service.annotations }}
+  {{- with .Values.webapp.service.annotations }}
   annotations:
-    {{- include "common.tplvalues.render" (dict "value" .Values.webapp.service.annotations "context" $) | nindent 4 }}
+    {{- toYaml . | nindent 4 }}
   {{- end }}
 spec:
   type: {{ .Values.webapp.service.type }}

--- a/charts/airbyte/values.yaml
+++ b/charts/airbyte/values.yaml
@@ -89,6 +89,7 @@ webapp:
 
   ## @param webapp.service.type The service type to use for the webapp service
   ## @param webapp.service.port The service port to expose the webapp on
+  ## @param webapp.service.annotations Annotations for the webapp service resource
   service:
     type: ClusterIP
     port: 80

--- a/charts/airbyte/values.yaml
+++ b/charts/airbyte/values.yaml
@@ -92,6 +92,7 @@ webapp:
   service:
     type: ClusterIP
     port: 80
+    annotations: {}
 
   ## Web app resource requests and limits
   ## ref: http://kubernetes.io/docs/user-guide/compute-resources/


### PR DESCRIPTION
## What
Added the possibility of creating annotations on the service in the helm chart.

## How
Updated the helm chart to allow service annotations.

## 🚨 User Impact 🚨
There are no breaking changes you can still deploy without using annotations.
