### PR TITLE
Publish connector Docker images for multiple platform architectures

### DIFF
--- a/tools/integrations/manage.sh
+++ b/tools/integrations/manage.sh
@@ -237,7 +237,7 @@ cmd_publish() {
 
     cd $original_pwd
   else
-    echo "Publishing new version ($versioned_image)"
+    echo "Publishing new version ($versioned_image) from $path"
     docker buildx build       \
       -t $versioned_image     \
       -t $latest_image        \

--- a/tools/integrations/manage.sh
+++ b/tools/integrations/manage.sh
@@ -221,18 +221,18 @@ cmd_publish() {
     echo "Publishing normalization images (version: $versioned_image)"
     GIT_REVISION=$(git rev-parse HEAD)
 
-    # Note: "buildx bake" needs to be run within the right directory
+    # Note: "buildx bake" needs to be run within the directory
     local original_pwd=$PWD
     cd airbyte-integrations/bases/base-normalization
 
-    VERSION=$image_version GIT_REVISION=$GIT_REVISION  docker buildx bake \
-      --set "*.platform=$build_arch"                                      \
-      -f docker-compose.build.yaml                                        \
+    VERSION=$image_version GIT_REVISION=$GIT_REVISION docker buildx bake \
+      --set "*.platform=$build_arch"                                     \
+      -f docker-compose.build.yaml                                       \
       --push
 
-    VERSION=latest GIT_REVISION=$GIT_REVISION  docker buildx bake \
-      --set "*.platform=$build_arch"                              \
-      -f docker-compose.build.yaml                                \
+    VERSION=latest GIT_REVISION=$GIT_REVISION docker buildx bake \
+      --set "*.platform=$build_arch"                             \
+      -f docker-compose.build.yaml                               \
       --push
 
     cd $original_pwd

--- a/tools/integrations/manage.sh
+++ b/tools/integrations/manage.sh
@@ -41,6 +41,8 @@ cmd_build() {
   local run_tests=$1; shift || run_tests=true
 
   echo "Building $path"
+  # Note that we are only building (and testing) once on this build machine's achetecure
+  # Learn more @ https://github.com/airbytehq/airbyte/pull/13004
   ./gradlew --no-daemon "$(_to_gradle_path "$path" clean)"
   ./gradlew --no-daemon "$(_to_gradle_path "$path" build)"
 

--- a/tools/integrations/manage.sh
+++ b/tools/integrations/manage.sh
@@ -259,6 +259,8 @@ cmd_publish() {
 
     docker manifest push $latest_image
     docker manifest push $versioned_image
+    docker manifest rm $latest_image
+    docker manifest rm $versioned_image
 
     # delete the temporary image tags made with arch_versioned_image
     sleep 5
@@ -266,7 +268,7 @@ cmd_publish() {
     do
       local arch_versioned_tag=`echo $arch | sed "s/\//-/g"`-$image_version
       echo "deleting temporary tag: ${image_name}/tags/${arch_versioned_tag}"
-      TAG_URL="https://hub.docker.com/v2/repositories/${image_name}/tags/${arch_versioned_tag}"
+      TAG_URL="https://hub.docker.com/v2/repositories/${image_name}/tags/${arch_versioned_tag}/" # trailing slash is needed!
       curl -X DELETE -H "Authorization: JWT ${DOCKER_TOKEN}" "$TAG_URL"
     done
 

--- a/tools/integrations/manage.sh
+++ b/tools/integrations/manage.sh
@@ -197,12 +197,15 @@ cmd_publish() {
   fi
 
   # setting local variables for docker image versioning
-  local docker_user="airbytebot"
   local image_name; image_name=$(_get_docker_image_name "$path"/Dockerfile)
   local image_version; image_version=$(_get_docker_image_version "$path"/Dockerfile)
   local versioned_image=$image_name:$image_version
   local latest_image="$image_name" # don't include ":latest", that's assumed here
   local build_arch="linux/amd64,linux/arm64"
+
+  # log into docker
+  DOCKER_USERNAME=${DOCKER_USERNAME:-airbytebot}
+  DOCKER_TOKEN=$(curl -s -H "Content-Type: application/json" -X POST -d '{"username": "'${DOCKER_USERNAME}'", "password": "'${DOCKER_PASSWORD}'"}' https://hub.docker.com/v2/users/login/ | jq -r .token)
 
   echo "image_name $image_name"
   echo "versioned_image $versioned_image"
@@ -258,22 +261,15 @@ cmd_publish() {
     docker manifest push $versioned_image
 
     # delete the temporary image tags made with arch_versioned_image
-    if [ -z "$DOCKER_PASSWORD" ]; then
-      echo "DOCKER_PASSWORD is not set, cannot delete arch_versioned_image tags..."
-    else
-      sleep 5
-      auth_data="{\"username\":\"$docker_user\", \"password\":\"$DOCKER_PASSWORD\"}"
-      docker_auth_token=`curl -s -H "Content-Type: application/json" -X POST -d "$auth_data" "https://hub.docker.com/v2/users/login/" | jq -r .token`
+    sleep 5
+    for arch in $(echo $build_arch | sed "s/,/ /g")
+    do
+      local arch_versioned_tag=`echo $arch | sed "s/\//-/g"`-$image_version
+      echo "deleting temporary tag: ${image_name}/tags/${arch_versioned_tag}"
+      TAG_URL="https://hub.docker.com/v2/repositories/${image_name}/tags/${arch_versioned_tag}"
+      curl -X DELETE -H "Authorization: JWT ${DOCKER_TOKEN}" "$TAG_URL"
+    done
 
-      for arch in $(echo $build_arch | sed "s/,/ /g")
-      do
-        local arch_versioned_tag=`echo $arch | sed "s/\//-/g"`-$image_version
-        echo "deleting temporary tag: ${image_name}/tags/${arch_versioned_tag}"
-        curl "https://hub.docker.com/v2/repositories/${image_name}/tags/${arch_versioned_tag}/" \
-          -X DELETE \
-          -H "Authorization: JWT ${docker_auth_token}"
-      done
-    fi
   fi
 
   # Checking if the image was successfully registered on DockerHub
@@ -281,8 +277,6 @@ cmd_publish() {
   sleep 5
 
   # To work for private repos we need a token as well
-  DOCKER_USERNAME=${DOCKER_USERNAME:-airbytebot}
-  DOCKER_TOKEN=$(curl -s -H "Content-Type: application/json" -X POST -d '{"username": "'${DOCKER_USERNAME}'", "password": "'${DOCKER_PASSWORD}'"}' https://hub.docker.com/v2/users/login/ | jq -r .token)
   TAG_URL="https://hub.docker.com/v2/repositories/${image_name}/tags/${image_version}"
   DOCKERHUB_RESPONSE_CODE=$(curl --silent --output /dev/null --write-out "%{http_code}" -H "Authorization: JWT ${DOCKER_TOKEN}" ${TAG_URL})
   if [[ "${DOCKERHUB_RESPONSE_CODE}" == "404" ]]; then


### PR DESCRIPTION
# What?

This PR modifies our connector build pipeline to publish images for all `connectors`, `SAT`, and `normalization` images for both `amd64` and `arm64` architectures (e.g. M1 macs)!

## User Facing Impact: 
* No more errors like: `image with reference sha256:abc123 was found but does not match the specified platform: wanted linux/arm64, actual: linux/amd64`
* Slightly faster boot time for connectors
* We can assume that any errors after this PR are "real" connector errors, and not architecture issues. 

## Things to keep in mind
* The base images we use for our Docker images (e.g. [`python:3.9.11-alpine3.15`](https://hub.docker.com/_/python?tab=tags&page=1&name=3.9.11-alpine3.15) and [`openjdk:17.0.1-slim`](https://hub.docker.com/_/openjdk?tab=tags&page=1&name=17.0.1-slim)) need to be multi-platform themselves. Check the links - they are!
* For the normalization images, the `latest` tag and `vx.x.x` tags will be built in separate passes, yielding potentially different build SHAs.  This is because we are building these images via docker-compose, which limits you to building just one tag at a time.  This risk exists today.

## TODO

- [x] Set up matrix builds (like the platform images) for all connectors
- [x] `:airbyte-integrations:bases:base-java` needs to be built for multiple architectures 
- [x] no need to build all connectors, but from here on out, ARM images will be made
- [x] Publish M1 images for SAT and Normalization images as well

## Deprioritized

- [x] Run unit tests for the connector in both ARM and AMD before publish (and with `/test command). This should happen automatically via the build step, but we may want to prevent integrations/SAT from running on ARM (no need to run integration tests 2x) (and we would hit rate limits)


# Testing

This kind of thing is tricky without updating the Github action, so I've been publishing images to my personal namespace using the command snippets below.  Note that the images that are produced have multiple architectures & tags. 

## Testing normalization

> produced https://hub.docker.com/repository/docker/evantahler/normalization-clickhouse/tags and https://hub.docker.com/repository/docker/evantahler/normalization-redshift/tags

```bash
# NOTE! change the image name org to "evantahler" from "airbyte" in the docker-compose file

organization="evantahler" # we need a new org to test publication within
build_arch="linux/amd64,linux/arm64"
image_name="$organization/normalization"
image_version="0.0.1"
GIT_REVISION=$(git rev-parse HEAD)
versioned_image=$image_name:$image_version

echo "Publishing normalization images (version: $versioned_image)"

# Build first
./gradlew :airbyte-integrations:bases:base-normalization:build

# Note: "buildx bake" needs to be run within the right directory
local original_pwd=$PWD
cd airbyte-integrations/bases/base-normalization

VERSION=$image_version GIT_REVISION=$GIT_REVISION  docker buildx bake \
  --set "*.platform=$build_arch"                                      \
  -f docker-compose.build.yaml                                        \
  --push

VERSION=latest GIT_REVISION=$GIT_REVISION  docker buildx bake \
  --set "*.platform=$build_arch"                              \
  -f docker-compose.build.yaml                                \
  --push

cd $original_pwd
```

## Testing a Connector

> Produced https://hub.docker.com/repository/docker/evantahler/source-faker/tags

```bash
organization="evantahler" # we need a new org to test publication within
build_arch="linux/amd64,linux/arm64"
image_name="$organization/source-faker"
image_version="0.0.1"
latest_image="$image_name" # don't include ":latest", that's assumed here
versioned_image=$image_name:$image_version
_path_="airbyte-integrations/connectors/source-faker"

echo "Publishing new version ($versioned_image) from $_path_"

docker buildx build       \
  -t $versioned_image     \
  -t $latest_image        \
  --platform $build_arch  \
  --push                  \
  $_path_
```
