### PR TITLE
Toph cron double rights

### DIFF
--- a/airbyte-config/models/src/main/resources/types/StandardSync.yaml
+++ b/airbyte-config/models/src/main/resources/types/StandardSync.yaml
@@ -75,22 +75,22 @@ properties:
   # schedule field double writes to schedule_type
   # schedule_type will eventually cover all schedules
   # as of writing schedule_type just writes to db and isn't used
-  ScheduleType:
+  scheduleType:
     type: string
     enum:
       - manual
       - basicSchedule
       - cron
-    scheduleCron:
-      required: [cronExpression, cronTimeZone]
-      properties:
-        cronExpression: string
-        crontTimeZone: string
-    scheduleBasic:
-      required: [timeUnits, units]
-    properties:
-      timeUnits: TimeUnit
-      units: number
+#    scheduleCron:
+#      required: [cronExpression, cronTimeZone]
+#      properties:
+#        cronExpression: string
+#        crontTimeZone: string
+#    scheduleBasic:
+#      required: [timeUnits, units]
+#    properties:
+#      timeUnits: TimeUnit
+#      units: number
   # When manual is true, schedule should be null, and will be ignored.
   manual:
     type: boolean

--- a/airbyte-config/models/src/main/resources/types/StandardSync.yaml
+++ b/airbyte-config/models/src/main/resources/types/StandardSync.yaml
@@ -11,6 +11,7 @@ required:
   - catalog
   - manual
   - namespaceDefinition
+  - scheduleType
 additionalProperties: false
 properties:
   namespaceDefinition:
@@ -46,6 +47,10 @@ properties:
       - active
       - inactive
       - deprecated
+  # ------------ schedule_type
+  # schedule field will be deprecated!
+  # see comments for scheduleType
+  # ------------- schedule and manual should be a union
   # Ideally schedule and manual should be a union, but java
   # codegen does not handle the union type properly.
   # When schedule is defined, manual should be false.
@@ -66,6 +71,26 @@ properties:
           - months
       units:
         type: integer
+  # current state 5.18.22:
+  # schedule field double writes to schedule_type
+  # schedule_type will eventually cover all schedules
+  # as of writing schedule_type just writes to db and isn't used
+  ScheduleType:
+    type: string
+    enum:
+      - manual
+      - basicSchedule
+      - cron
+    scheduleCron:
+      required: [cronExpression, cronTimeZone]
+      properties:
+        cronExpression: string
+        crontTimeZone: string
+    scheduleBasic:
+      required: [timeUnits, units]
+    properties:
+      timeUnits: TimeUnit
+      units: number
   # When manual is true, schedule should be null, and will be ignored.
   manual:
     type: boolean

--- a/airbyte-config/persistence/src/main/java/io/airbyte/config/persistence/ConfigRepository.java
+++ b/airbyte-config/persistence/src/main/java/io/airbyte/config/persistence/ConfigRepository.java
@@ -586,16 +586,6 @@ public class ConfigRepository {
     persistence.writeConfig(ConfigSchema.STANDARD_SYNC, standardSync.getConnectionId().toString(), standardSync);
   }
 
-  public ScheduleType getScheduleType(final UUID connId) throws IOException {
-    return database.query(ctx -> ctx.select(CONNECTION.SCHEDULE_TYPE).from(CONNECTION)
-        .where(CONNECTION.ID.eq(connId)).fetchOne()).value1();
-  }
-
-  public void writeScheduleType(final UUID connId, final ScheduleType type) throws IOException {
-    database.transaction(ctx -> ctx.update(CONNECTION).set(CONNECTION.SCHEDULE_TYPE, type)
-        .where(CONNECTION.ID.eq(connId)).execute());
-  }
-
   public List<StandardSync> listStandardSyncs() throws ConfigNotFoundException, IOException, JsonValidationException {
     return persistence.listConfigs(ConfigSchema.STANDARD_SYNC, StandardSync.class);
   }

--- a/airbyte-config/persistence/src/main/java/io/airbyte/config/persistence/ConfigRepository.java
+++ b/airbyte-config/persistence/src/main/java/io/airbyte/config/persistence/ConfigRepository.java
@@ -23,25 +23,12 @@ import com.google.common.hash.HashFunction;
 import com.google.common.hash.Hashing;
 import io.airbyte.commons.json.Jsons;
 import io.airbyte.commons.lang.MoreBooleans;
-import io.airbyte.config.ActorCatalog;
-import io.airbyte.config.AirbyteConfig;
-import io.airbyte.config.ConfigSchema;
-import io.airbyte.config.DestinationConnection;
-import io.airbyte.config.DestinationOAuthParameter;
-import io.airbyte.config.SourceConnection;
-import io.airbyte.config.SourceOAuthParameter;
-import io.airbyte.config.StandardDestinationDefinition;
-import io.airbyte.config.StandardSourceDefinition;
-import io.airbyte.config.StandardSync;
-import io.airbyte.config.StandardSyncOperation;
-import io.airbyte.config.StandardSyncState;
-import io.airbyte.config.StandardWorkspace;
-import io.airbyte.config.State;
-import io.airbyte.config.WorkspaceServiceAccount;
+import io.airbyte.config.*;
 import io.airbyte.db.Database;
 import io.airbyte.db.ExceptionWrappingDatabase;
 import io.airbyte.db.instance.configs.jooq.enums.ActorType;
 import io.airbyte.db.instance.configs.jooq.enums.ReleaseStage;
+import io.airbyte.db.instance.configs.jooq.enums.ScheduleType;
 import io.airbyte.db.instance.configs.jooq.enums.StatusType;
 import io.airbyte.metrics.lib.MetricQueries;
 import io.airbyte.protocol.models.AirbyteCatalog;
@@ -597,6 +584,16 @@ public class ConfigRepository {
 
   public void writeStandardSync(final StandardSync standardSync) throws JsonValidationException, IOException {
     persistence.writeConfig(ConfigSchema.STANDARD_SYNC, standardSync.getConnectionId().toString(), standardSync);
+  }
+
+  public ScheduleType getScheduleType(final UUID connId) throws IOException {
+    return database.query(ctx -> ctx.select(CONNECTION.SCHEDULE_TYPE).from(CONNECTION)
+        .where(CONNECTION.ID.eq(connId)).fetchOne()).value1();
+  }
+
+  public void writeScheduleType(final UUID connId, final ScheduleType type) throws IOException {
+    database.transaction(ctx -> ctx.update(CONNECTION).set(CONNECTION.SCHEDULE_TYPE, type)
+        .where(CONNECTION.ID.eq(connId)).execute());
   }
 
   public List<StandardSync> listStandardSyncs() throws ConfigNotFoundException, IOException, JsonValidationException {

--- a/airbyte-config/persistence/src/main/java/io/airbyte/config/persistence/DatabaseConfigPersistence.java
+++ b/airbyte-config/persistence/src/main/java/io/airbyte/config/persistence/DatabaseConfigPersistence.java
@@ -51,6 +51,8 @@ import io.airbyte.config.persistence.split_secrets.JsonSecretsProcessor;
 import io.airbyte.db.Database;
 import io.airbyte.db.ExceptionWrappingDatabase;
 import io.airbyte.db.instance.configs.jooq.enums.ActorType;
+import io.airbyte.db.instance.configs.jooq.enums.ReleaseStage;
+import io.airbyte.db.instance.configs.jooq.enums.ScheduleType;
 import io.airbyte.protocol.models.ConnectorSpecification;
 import io.airbyte.validation.json.JsonValidationException;
 import java.io.IOException;
@@ -1090,6 +1092,8 @@ public class DatabaseConfigPersistence implements ConfigPersistence {
                 : Enums.toEnum(standardSync.getStatus().value(),
                     io.airbyte.db.instance.configs.jooq.enums.StatusType.class).orElseThrow())
             .set(CONNECTION.SCHEDULE, JSONB.valueOf(Jsons.serialize(standardSync.getSchedule())))
+            .set(CONNECTION.SCHEDULE_TYPE, standardSync.getScheduleType() == null ? null
+                    : Enums.toEnum(standardSync.getScheduleType().value(), ScheduleType.class).orElseThrow())
             .set(CONNECTION.MANUAL, standardSync.getManual())
             .set(CONNECTION.RESOURCE_REQUIREMENTS, JSONB.valueOf(Jsons.serialize(standardSync.getResourceRequirements())))
             .set(CONNECTION.UPDATED_AT, timestamp)

--- a/airbyte-config/persistence/src/main/java/io/airbyte/config/persistence/DatabaseConfigPersistence.java
+++ b/airbyte-config/persistence/src/main/java/io/airbyte/config/persistence/DatabaseConfigPersistence.java
@@ -1094,6 +1094,7 @@ public class DatabaseConfigPersistence implements ConfigPersistence {
             .set(CONNECTION.SCHEDULE, JSONB.valueOf(Jsons.serialize(standardSync.getSchedule())))
             .set(CONNECTION.SCHEDULE_TYPE, standardSync.getScheduleType() == null ? null
                     : Enums.toEnum(standardSync.getScheduleType().value(), ScheduleType.class).orElseThrow())
+                // create another column schedule_type_schedule
             .set(CONNECTION.MANUAL, standardSync.getManual())
             .set(CONNECTION.RESOURCE_REQUIREMENTS, JSONB.valueOf(Jsons.serialize(standardSync.getResourceRequirements())))
             .set(CONNECTION.UPDATED_AT, timestamp)

--- a/airbyte-config/persistence/src/test/java/io/airbyte/config/persistence/ConfigRepositoryE2EReadWriteTest.java
+++ b/airbyte-config/persistence/src/test/java/io/airbyte/config/persistence/ConfigRepositoryE2EReadWriteTest.java
@@ -196,15 +196,6 @@ public class ConfigRepositoryE2EReadWriteTest {
   }
 
   @Test
-  public void testWriteReadScheduleType() throws IOException {
-    final var id = MockData.standardSyncs().get(0).getConnectionId();
-    final var scheduleType = ScheduleType.basic_schedule;
-    configRepository.writeScheduleType(id, scheduleType);
-    final var resType = configRepository.getScheduleType(id);
-    assertEquals(resType, scheduleType);
-  }
-
-  @Test
   public void testListWorkspaceStandardSync() throws IOException {
 
     final List<StandardSync> syncs = configRepository.listWorkspaceStandardSyncs(MockData.standardWorkspaces().get(0).getWorkspaceId());

--- a/airbyte-config/persistence/src/test/java/io/airbyte/config/persistence/ConfigRepositoryE2EReadWriteTest.java
+++ b/airbyte-config/persistence/src/test/java/io/airbyte/config/persistence/ConfigRepositoryE2EReadWriteTest.java
@@ -32,6 +32,7 @@ import io.airbyte.db.factory.DSLContextFactory;
 import io.airbyte.db.factory.FlywayFactory;
 import io.airbyte.db.instance.configs.ConfigsDatabaseInstance;
 import io.airbyte.db.instance.configs.ConfigsDatabaseMigrator;
+import io.airbyte.db.instance.configs.jooq.enums.ScheduleType;
 import io.airbyte.db.instance.development.DevDatabaseMigrator;
 import io.airbyte.db.instance.development.MigrationDevHelper;
 import io.airbyte.protocol.models.AirbyteCatalog;
@@ -192,6 +193,15 @@ public class ConfigRepositoryE2EReadWriteTest {
 
     final int catalogDbEntry = database.query(ctx -> ctx.selectCount().from(ACTOR_CATALOG)).fetchOne().into(int.class);
     assertEquals(1, catalogDbEntry);
+  }
+
+  @Test
+  public void testWriteReadScheduleType() throws IOException {
+    final var id = MockData.standardSyncs().get(0).getConnectionId();
+    final var scheduleType = ScheduleType.basic_schedule;
+    configRepository.writeScheduleType(id, scheduleType);
+    final var resType = configRepository.getScheduleType(id);
+    assertEquals(resType, scheduleType);
   }
 
   @Test

--- a/airbyte-server/src/main/java/io/airbyte/server/handlers/ConnectionsHandler.java
+++ b/airbyte-server/src/main/java/io/airbyte/server/handlers/ConnectionsHandler.java
@@ -120,6 +120,7 @@ public class ConnectionsHandler {
     final UUID connectionId = uuidGenerator.get();
 
     // persist sync
+    // topher - write to new sync columns
     final StandardSync standardSync = new StandardSync()
         .withConnectionId(connectionId)
         .withName(connectionCreate.getName() != null ? connectionCreate.getName() : defaultName)
@@ -154,9 +155,6 @@ public class ConnectionsHandler {
     }
 
     configRepository.writeStandardSync(standardSync);
-
-    // depending on connectionSchedule, we want to write to the scheduleType column.
-    // configRepository.writeScheduleType();
 
     trackNewConnection(standardSync);
 
@@ -225,9 +223,6 @@ public class ConnectionsHandler {
         new HashSet<>(connectionUpdate.getOperationIds()));
 
     configRepository.writeStandardSync(newConnection);
-
-    // depending on connectionSchedule, we want to write to the scheduleType column.
-    // configRepository.writeScheduleType();
 
     if (featureFlags.usesNewScheduler()) {
       eventRunner.update(connectionUpdate.getConnectionId());

--- a/airbyte-server/src/main/java/io/airbyte/server/handlers/ConnectionsHandler.java
+++ b/airbyte-server/src/main/java/io/airbyte/server/handlers/ConnectionsHandler.java
@@ -155,6 +155,9 @@ public class ConnectionsHandler {
 
     configRepository.writeStandardSync(standardSync);
 
+    // depending on connectionSchedule, we want to write to the scheduleType column.
+    // configRepository.writeScheduleType();
+
     trackNewConnection(standardSync);
 
     if (featureFlags.usesNewScheduler()) {
@@ -222,6 +225,9 @@ public class ConnectionsHandler {
         new HashSet<>(connectionUpdate.getOperationIds()));
 
     configRepository.writeStandardSync(newConnection);
+
+    // depending on connectionSchedule, we want to write to the scheduleType column.
+    // configRepository.writeScheduleType();
 
     if (featureFlags.usesNewScheduler()) {
       eventRunner.update(connectionUpdate.getConnectionId());

--- a/airbyte-workers/src/main/java/io/airbyte/workers/helper/ConnectionHelper.java
+++ b/airbyte-workers/src/main/java/io/airbyte/workers/helper/ConnectionHelper.java
@@ -85,12 +85,17 @@ public class ConnectionHelper {
 
     // update sync schedule
     if (update.getSchedule() != null) {
+      // topher
       final Schedule newSchedule = new Schedule()
           .withTimeUnit(update.getSchedule().getTimeUnit())
           .withUnits(update.getSchedule().getUnits());
       newConnection.withManual(false).withSchedule(newSchedule);
+      newConnection.withScheduleType(StandardSync.ScheduleType.BASIC_SCHEDULE);
     } else {
+      // topher
       newConnection.withManual(true).withSchedule(null);
+      newConnection.withScheduleType(StandardSync.ScheduleType.MANUAL);
+      // add the new column
     }
 
     return newConnection;

--- a/airbyte-workers/src/main/java/io/airbyte/workers/temporal/scheduling/activities/ConfigFetchActivityImpl.java
+++ b/airbyte-workers/src/main/java/io/airbyte/workers/temporal/scheduling/activities/ConfigFetchActivityImpl.java
@@ -57,6 +57,8 @@ public class ConfigFetchActivityImpl implements ConfigFetchActivity {
         time_interval_schedule = ScheduleHelpers.getIntervalInSecond(standardSync.getSchedule());
       } else if (standardSync.getScheduleType() != null){
         // i don't understand how to detect the enum type here
+        // psuedo-code, check enum type, if type is schedule then set time_interval_schedule
+        // currently ignore use cases that other enum types here (manual and cron)
         time_interval_schedule = ScheduleHelpers.getIntervalInSecond(standardSync.getScheduleType());
       }
 

--- a/airbyte-workers/src/main/java/io/airbyte/workers/temporal/scheduling/activities/ConfigFetchActivityImpl.java
+++ b/airbyte-workers/src/main/java/io/airbyte/workers/temporal/scheduling/activities/ConfigFetchActivityImpl.java
@@ -55,11 +55,11 @@ public class ConfigFetchActivityImpl implements ConfigFetchActivity {
       long time_interval_schedule = 0;
       if (standardSync.getSchedule() != null) {
         time_interval_schedule = ScheduleHelpers.getIntervalInSecond(standardSync.getSchedule());
-      } else if (standardSync.getScheduleType() != null){
+      } else if (standardSync.getScheduleType() != null) {
         // i don't understand how to detect the enum type here
         // psuedo-code, check enum type, if type is schedule then set time_interval_schedule
         // currently ignore use cases that other enum types here (manual and cron)
-        time_interval_schedule = ScheduleHelpers.getIntervalInSecond(standardSync.getScheduleType());
+        // time_interval_schedule = ScheduleHelpers.getIntervalInSecond();
       }
 
       final long nextRunStart = prevRunStart + time_interval_schedule;

--- a/davin_readme.md
+++ b/davin_readme.md
@@ -1,0 +1,23 @@
+Looking at [ConfigRepository.java](https://github.com/airbytehq/airbyte/blob/master/airbyte-config/persistence/src/main/java/io/airbyte/config/persistence/ConfigRepository.java#L527) it looks like the pointer has moved some.  I assume the method we want here is `writeSourceConnectionNoSecret` now located at [ConfigRepository.java:536](https://github.com/airbytehq/airbyte/blob/master/airbyte-config/persistence/src/main/java/io/airbyte/config/persistence/ConfigRepository.java#L536)
+
+When I look here it looks like a bit like magic to me.  I was confused by this at first reading leading to alot of my lost effort below.  I was expecting to impliment double write in here, but `getTimeToWait` seems like read only logic.  I still don't see where i can write the logic to double write scheduleType and schedule
+
+I command clicked my way from there to the [StandardSync.yaml](https://github.com/airbytehq/airbyte/blob/master/airbyte-config/models/src/main/resources/types/StandardSync.yaml).  I added tims yaml there
+
+Looking at [configfetch](https://github.com/airbytehq/airbyte/blob/master/airbyte-workers/src/main/java/io/airbyte/workers/temporal/scheduling/activities/ConfigFetchActivityImpl.java#L34) My first question to myself is how do i get inside this thing to test it.  I found the test file quickly, i'm not sure how to run this specific test though
+
+I added the new property to StandardSync but i am unable to grok the enum for double write in this context, and i don't see obvious parallels at the moment
+
+I don't understand what `StandardSyncInput` or output are meant to be, and in these files it's hard to tell what is generated and what isn't
+
+Turns out i was editing generated files.  I didn't look at the folder higherarchy closely enough
+
+looking again at [configfetch](https://github.com/airbytehq/airbyte/blob/master/airbyte-workers/src/main/java/io/airbyte/workers/temporal/scheduling/activities/ConfigFetchActivityImpl.java#L36) I know that i want to double write, but the strict typing here has me confused
+
+Looked up how to use gradle tasks to list known tasks. Some questions:
+Why do we wrap gradle in the local `./gradlew`
+double you tee eff is this `./gradlew knows`
+not understanding that i could run `./gradlew tasks` earlier makes me feel silly
+
+
+Getting stuck on enum use [tried this article](https://www.baeldung.com/a-guide-to-java-enums)


### PR DESCRIPTION
@davinchia I fully intend to get some more up here tonight but I want to WIP commit this in case I don't

I tried to write down my thoughts as they were happening in the hopes that I can understand more Java. 

**this comment exists in it's entirety in the PR for easier commenting**

Looking at [ConfigRepository.java](https://github.com/airbytehq/airbyte/blob/master/airbyte-config/persistence/src/main/java/io/airbyte/config/persistence/ConfigRepository.java#L527) it looks like the pointer has moved some.  I assume the method we want here is `writeSourceConnectionNoSecret` now located at [ConfigRepository.java:536](https://github.com/airbytehq/airbyte/blob/master/airbyte-config/persistence/src/main/java/io/airbyte/config/persistence/ConfigRepository.java#L536)

When I look here it looks like a bit like magic to me.  I was confused by this at first reading leading to alot of my lost effort below.  I was expecting to impliment double write in here, but `getTimeToWait` seems like read only logic.  I still don't see where i can write the logic to double write scheduleType and schedule

I command clicked my way from there to the [StandardSync.yaml](https://github.com/airbytehq/airbyte/blob/master/airbyte-config/models/src/main/resources/types/StandardSync.yaml).  I added tims yaml there

Looking at [configfetch](https://github.com/airbytehq/airbyte/blob/master/airbyte-workers/src/main/java/io/airbyte/workers/temporal/scheduling/activities/ConfigFetchActivityImpl.java#L34) My first question to myself is how do i get inside this thing to test it.  I found the test file quickly, i'm not sure how to run this specific test though

I added the new property to StandardSync but i am unable to grok the enum for double write in this context, and i don't see obvious parallels at the moment

I don't understand what `StandardSyncInput` or output are meant to be, and in these files it's hard to tell what is generated and what isn't

Turns out i was editing generated files.  I didn't look at the folder higherarchy closely enough

looking again at [configfetch](https://github.com/airbytehq/airbyte/blob/master/airbyte-workers/src/main/java/io/airbyte/workers/temporal/scheduling/activities/ConfigFetchActivityImpl.java#L36) I know that i want to double write, but the strict typing here has me confused 

Looked up how to use gradle tasks to list known tasks. Some questions:
  Why do we wrap gradle in the local `./gradlew`
  double you tee eff is this `./gradlew knows`
  not understanding that i could run `./gradlew tasks` earlier makes me feel silly


Getting stuck on enum use [tried this article](https://www.baeldung.com/a-guide-to-java-enums)
