### PR TITLE
Added a test case for GetSuccessOutput() method in the Job.java

### DIFF
--- a/airbyte-scheduler/models/src/test/java/io/airbyte/scheduler/models/JobTest.java
+++ b/airbyte-scheduler/models/src/test/java/io/airbyte/scheduler/models/JobTest.java
@@ -18,6 +18,26 @@ import org.junit.jupiter.api.Test;
 
 class JobTest {
 
+  // Create a non-empty new JobOutput of sync type
+  private static final JobOutput JOB_OUTPUT = new JobOutput()
+          .withOutputType(JobOutput.OutputType.SYNC)
+          .withSync(new StandardSyncOutput()
+                  .withStandardSyncSummary(new StandardSyncSummary()
+                          .withRecordsSynced(15L)
+                          .withBytesSynced(100L)
+                          .withTotalStats(new SyncStats()
+                                  .withRecordsEmitted(10L)
+                                  .withBytesEmitted(100L)
+                                  .withStateMessagesEmitted(2L)
+                                  .withRecordsCommitted(10L))
+                          .withStreamStats(Lists.newArrayList(new StreamSyncStats()
+                                  .withStreamName("Job Output")
+                                  .withStats(new SyncStats()
+                                          .withRecordsEmitted(15L)
+                                          .withBytesEmitted(100L)
+                                          .withStateMessagesEmitted(2L)
+                                          .withRecordsCommitted(10L))))));
+
   @Test
   void testIsJobInTerminalState() {
     assertFalse(jobWithStatus(JobStatus.PENDING).isJobInTerminalState());
@@ -61,25 +81,7 @@ class JobTest {
     assertEquals(job.getAttempts().get(1), job.getSuccessfulAttempt().get());
   }
 
-  // Create a non-empty new JobOutput of sync type
-  private static final JobOutput JOB_OUTPUT = new JobOutput()
-          .withOutputType(JobOutput.OutputType.SYNC)
-          .withSync(new StandardSyncOutput()
-                  .withStandardSyncSummary(new StandardSyncSummary()
-                          .withRecordsSynced(15L)
-                          .withBytesSynced(100L)
-                          .withTotalStats(new SyncStats()
-                                  .withRecordsEmitted(10L)
-                                  .withBytesEmitted(100L)
-                                  .withStateMessagesEmitted(2L)
-                                  .withRecordsCommitted(10L))
-                          .withStreamStats(Lists.newArrayList(new StreamSyncStats()
-                                  .withStreamName("Job Output")
-                                  .withStats(new SyncStats()
-                                          .withRecordsEmitted(15L)
-                                          .withBytesEmitted(100L)
-                                          .withStateMessagesEmitted(2L)
-                                          .withRecordsCommitted(10L))))));
+
 
   private static Job jobWithAttemptWithStatusWithOutput(final AttemptStatus... attemptStatuses) {
     final List<Attempt> attempts = Arrays.stream(attemptStatuses)
@@ -91,7 +93,6 @@ class JobTest {
   @Test
   void TestGetSuccessOutput() {
     final Job job = jobWithAttemptWithStatusWithOutput(AttemptStatus.FAILED, AttemptStatus.SUCCEEDED);
-    System.out.println("OUR TEST: " + job.getSuccessOutput().toString());
     assertFalse(job.getSuccessOutput().isEmpty());
   }
 }


### PR DESCRIPTION
## What
Added a new unit test for GetSuccessOutput() method in the Job.java.


## How
We created a Joboutput with an output type of sync. We test by calling the getSuccessOutput method,  then we assert that the result from the methods is not empty.

## Recommended reading order
1. airbyte-scheduler/models/src/test/java/io/airbyte/scheduler/models/JobTest.java


## Tests

<details><summary><strong>Unit</strong></summary>

*Put your unit tests output here.*
![Picture1](https://user-images.githubusercontent.com/35242621/169216709-4ce44775-f9c9-4395-a060-a5c58250ab8b.png)


</details>

<details><summary><strong>Integration</strong></summary>

*Put your integration tests output here.*

</details>

<details><summary><strong>Acceptance</strong></summary>

*Put your acceptance tests output here.*

</details>
