### PR TITLE
 Added a new unit test for getDeploymentMode() in the EnvConfigs.java

### DIFF
--- a/airbyte-config/models/src/test/java/io/airbyte/config/EnvConfigsTest.java
+++ b/airbyte-config/models/src/test/java/io/airbyte/config/EnvConfigsTest.java
@@ -163,6 +163,21 @@ class EnvConfigsTest {
   }
 
   @Test
+  void testDeploymentMode() {
+    envMap.put(EnvConfigs.DEPLOYMENT_MODE, null);
+    assertEquals(Configs.DeploymentMode.OSS, config.getDeploymentMode());
+
+    envMap.put(EnvConfigs.DEPLOYMENT_MODE, "CLOUD");
+    assertEquals(Configs.DeploymentMode.CLOUD, config.getDeploymentMode());
+
+    envMap.put(EnvConfigs.DEPLOYMENT_MODE, "oss");
+    assertEquals(Configs.DeploymentMode.OSS, config.getDeploymentMode());
+
+    envMap.put(EnvConfigs.DEPLOYMENT_MODE, "OSS");
+    assertEquals(Configs.DeploymentMode.OSS, config.getDeploymentMode());
+  }
+
+  @Test
   void testworkerKubeTolerations() {
     envMap.put(EnvConfigs.JOB_KUBE_TOLERATIONS, null);
     assertEquals(config.getJobKubeTolerations(), List.of());


### PR DESCRIPTION
## What
 Added a new unit test for getDeploymentMode() in the EnvConfigs.java

## How
We added a new unit test that tested three different behaviors of the deployment mode function in the EnvConfigs.java file.

## Recommended reading order
1. airbyte-config/models/src/main/java/io/airbyte/config/Configs.java
2. airbyte-config/models/src/main/java/io/airbyte/config/EnvConfigs.java
3. airbyte-config/models/src/test/java/io/airbyte/config/EnvConfigsTest.java



## Tests

<details><summary><strong>Unit</strong></summary>
<img width="1363" alt="Screen Shot 2022-05-18 at 11 46 41 PM" src="https://user-images.githubusercontent.com/35242621/169231422-1a629651-091e-4ab4-aade-2d8c82046046.png">


</details>

<details><summary><strong>Integration</strong></summary>

*Put your integration tests output here.*

</details>

<details><summary><strong>Acceptance</strong></summary>

*Put your acceptance tests output here.*

</details>
