### PR TITLE
Adds schedule_data json column

### DIFF
--- a/airbyte-bootloader/src/test/java/io/airbyte/bootloader/BootloaderAppTest.java
+++ b/airbyte-bootloader/src/test/java/io/airbyte/bootloader/BootloaderAppTest.java
@@ -128,7 +128,7 @@ public class BootloaderAppTest {
       val configsMigrator = new ConfigsDatabaseMigrator(configDatabase, configsFlyway);
       // this line should change with every new migration
       // to show that you meant to make a new migration to the prod database
-      assertEquals("0.36.3.001", configsMigrator.getLatestMigration().getVersion().getVersion());
+      assertEquals("0.38.4.001", configsMigrator.getLatestMigration().getVersion().getVersion());
 
       val jobsPersistence = new DefaultJobPersistence(jobDatabase);
       assertEquals(version, jobsPersistence.getVersion().get());

--- a/airbyte-db/lib/src/main/java/io/airbyte/db/instance/configs/migrations/V0_38_4_001__AddScheduleDataToConfigsTable.java
+++ b/airbyte-db/lib/src/main/java/io/airbyte/db/instance/configs/migrations/V0_38_4_001__AddScheduleDataToConfigsTable.java
@@ -1,0 +1,31 @@
+package io.airbyte.db.instance.configs.migrations;
+
+import org.flywaydb.core.api.migration.BaseJavaMigration;
+import org.flywaydb.core.api.migration.Context;
+import org.jooq.DSLContext;
+import org.jooq.impl.SQLDataType;
+import org.jooq.impl.DSL;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+
+public class V0_38_4_001__AddScheduleDataToConfigsTable extends BaseJavaMigration {
+
+  private static final Logger LOGGER = LoggerFactory.getLogger(V0_38_4_001__AddScheduleDataToConfigsTable.class);
+
+  @Override
+  public void migrate(final Context context) throws Exception {
+    LOGGER.info("Running migration: {}", this.getClass().getSimpleName());
+    final DSLContext ctx = DSL.using(context.getConnection());
+    addPublicColumn(ctx);
+  }
+
+
+  private static void addPublicColumn(final DSLContext ctx) {
+    ctx.alterTable("connection")
+        .addColumnIfNotExists(DSL.field(
+            "schedule_data",
+            SQLDataType.JSONB.nullable(true)))
+        .execute();
+  }
+}

--- a/airbyte-db/lib/src/main/java/io/airbyte/db/instance/configs/migrations/V0_38_4_001__AddScheduleDataToConfigsTable.java
+++ b/airbyte-db/lib/src/main/java/io/airbyte/db/instance/configs/migrations/V0_38_4_001__AddScheduleDataToConfigsTable.java
@@ -1,13 +1,16 @@
+/*
+ * Copyright (c) 2021 Airbyte, Inc., all rights reserved.
+ */
+
 package io.airbyte.db.instance.configs.migrations;
 
 import org.flywaydb.core.api.migration.BaseJavaMigration;
 import org.flywaydb.core.api.migration.Context;
 import org.jooq.DSLContext;
-import org.jooq.impl.SQLDataType;
 import org.jooq.impl.DSL;
+import org.jooq.impl.SQLDataType;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
-
 
 public class V0_38_4_001__AddScheduleDataToConfigsTable extends BaseJavaMigration {
 
@@ -20,7 +23,6 @@ public class V0_38_4_001__AddScheduleDataToConfigsTable extends BaseJavaMigratio
     addPublicColumn(ctx);
   }
 
-
   private static void addPublicColumn(final DSLContext ctx) {
     ctx.alterTable("connection")
         .addColumnIfNotExists(DSL.field(
@@ -28,4 +30,5 @@ public class V0_38_4_001__AddScheduleDataToConfigsTable extends BaseJavaMigratio
             SQLDataType.JSONB.nullable(true)))
         .execute();
   }
+
 }

--- a/airbyte-db/lib/src/main/resources/configs_database/schema_dump.txt
+++ b/airbyte-db/lib/src/main/resources/configs_database/schema_dump.txt
@@ -102,6 +102,7 @@ create table "public"."connection"(
   "updated_at" timestamptz(35) not null default null,
   "source_catalog_id" uuid null,
   "schedule_type" schedule_type null,
+  "schedule_data" jsonb null,
   constraint "connection_pkey"
     primary key ("id")
 );


### PR DESCRIPTION
updates the version test thingy
schema dumped

## What
We have an enum, based on that enum some JSON will be stored.  
We could use the existing `schedule` column but while we build this out it seems alot safer to have another column


## How
Add a JSON column


![](https://1428elm.com/wp-content/blogs.dir/304/files/2017/01/jason-8-1.jpg)
