### PR TITLE
🐛 Update Qualaroo Spec

### DIFF
--- a/airbyte-config/init/src/main/resources/seed/source_definitions.yaml
+++ b/airbyte-config/init/src/main/resources/seed/source_definitions.yaml
@@ -731,7 +731,7 @@
 - name: Qualaroo
   sourceDefinitionId: b08e4776-d1de-4e80-ab5c-1e51dad934a2
   dockerRepository: airbyte/source-qualaroo
-  dockerImageTag: 0.1.0
+  dockerImageTag: 0.1.1
   documentationUrl: https://docs.airbyte.io/integrations/sources/qualaroo
   icon: qualaroo.svg
   sourceType: api

--- a/airbyte-config/init/src/main/resources/seed/source_specs.yaml
+++ b/airbyte-config/init/src/main/resources/seed/source_specs.yaml
@@ -6806,7 +6806,7 @@
     supportsNormalization: false
     supportsDBT: false
     supported_destination_sync_modes: []
-- dockerImage: "airbyte/source-qualaroo:0.1.0"
+- dockerImage: "airbyte/source-qualaroo:0.1.1"
   spec:
     documentationUrl: "https://docs.airbyte.io/integrations/sources/qualaroo"
     connectionSpecification:

--- a/airbyte-integrations/connectors/source-qualaroo/Dockerfile
+++ b/airbyte-integrations/connectors/source-qualaroo/Dockerfile
@@ -29,5 +29,5 @@ COPY source_qualaroo ./source_qualaroo
 ENV AIRBYTE_ENTRYPOINT "python /airbyte/integration_code/main.py"
 ENTRYPOINT ["python", "/airbyte/integration_code/main.py"]
 
-LABEL io.airbyte.version=0.1.0
+LABEL io.airbyte.version=0.1.1
 LABEL io.airbyte.name=airbyte/source-qualaroo

--- a/airbyte-integrations/connectors/source-qualaroo/source_qualaroo/schemas/responses.json
+++ b/airbyte-integrations/connectors/source-qualaroo/source_qualaroo/schemas/responses.json
@@ -2,35 +2,35 @@
   "type": "object",
   "properties": {
     "id": {
-      "type": "integer"
+      "type": ["null", "integer"]
     },
     "time": {
-      "type": "string",
+       "type": ["null", "string"],
       "format": "date-time"
     },
     "identity": {
       "type": ["null", "string"]
     },
     "page": {
-      "type": "string"
+       "type": ["null", "string"]
     },
     "referrer": {
       "type": ["null", "string"]
     },
     "user_agent": {
-      "type": "string"
+       "type": ["null", "string"]
     },
     "nudge_id": {
-      "type": "integer"
+      "type": ["null", "integer"]
     },
     "nudge_name": {
-      "type": "string"
+       "type": ["null", "string"]
     },
     "anon_visitor_id": {
-      "type": "string"
+       "type": ["null", "string"]
     },
     "ip_address": {
-      "type": "string"
+       "type": ["null", "string"]
     },
     "answered_questions": {
       "type": "array",
@@ -45,23 +45,23 @@
       "type": "object",
       "properties": {
         "score": {
-          "type": "integer"
+          "type": ["null", "integer"]
         },
         "reason": {
-          "type": "string"
+           "type": ["null", "string"]
         },
         "respondent_id": {
-          "type": "integer"
+          "type": ["null", "integer"]
         },
         "time": {
-          "type": "string",
+           "type": ["null", "string"],
           "format": "date-time"
         },
         "category": {
-          "type": "string"
+           "type": ["null", "string"]
         },
         "response_uri": {
-          "type": "string"
+           "type": ["null", "string"]
         }
       }
     }

--- a/airbyte-integrations/connectors/source-qualaroo/source_qualaroo/schemas/responses.json
+++ b/airbyte-integrations/connectors/source-qualaroo/source_qualaroo/schemas/responses.json
@@ -35,14 +35,14 @@
     "answered_questions": {
       "type": "array",
       "items": {
-        "type": "object"
+        "type":["null",  "object"]
       }
     },
     "properties": {
-      "type": "object"
+      "type":["null",  "object"]
     },
     "nps": {
-      "type": "object",
+      "type": ["null", "object"],
       "properties": {
         "score": {
           "type": ["null", "integer"]

--- a/airbyte-integrations/connectors/source-qualaroo/source_qualaroo/schemas/surveys.json
+++ b/airbyte-integrations/connectors/source-qualaroo/source_qualaroo/schemas/surveys.json
@@ -2,32 +2,32 @@
   "type": "object",
   "properties": {
     "id": {
-      "type": "integer"
+      "type": ["null", "integer"]
     },
     "site_id": {
-      "type": "integer"
+      "type": ["null", "integer"]
     },
     "uuid": {
       "type": ["null", "string"]
     },
     "name": {
-      "type": "string"
+      "type": ["null", "string"]
     },
     "active": {
-      "type": "boolean"
+      "type": ["null", "boolean"]
     },
     "kind": {
-      "type": "string"
+      "type": ["null", "string"]
     },
     "canonical_name": {
       "type": ["null", "string"]
     },
     "created_at": {
-      "type": "string",
+      "type": ["null", "string"],
       "format": "date-time"
     },
     "survey_url": {
-      "type": "string"
+      "type": ["null", "string"]
     }
   }
 }

--- a/docs/integrations/sources/qualaroo.md
+++ b/docs/integrations/sources/qualaroo.md
@@ -43,5 +43,6 @@ Please read [How to get your APIs Token and Key](https://help.qualaroo.com/hc/en
 
 | Version | Date | Pull Request | Subject |
 | :--- | :--- | :--- | :--- |
+| 0.1.1 | 2022-05-20 | [13042](https://github.com/airbytehq/airbyte/pull/13042) | Update stream specs |
 | 0.1.0 | 2021-08-18 | [8623](https://github.com/airbytehq/airbyte/pull/8623) | New source: Qualaroo |
 


### PR DESCRIPTION
## What
Fix NULL objects in spec

```
2022-05-19 21:40:35 [33mWARN[m i.a.w.DefaultReplicationWorker(lambda$getReplicationRunnable$5):298 - Record schema validation failed. Errors: json schema validation failed when comparing the data to the json schema. 
Errors: $.nps: null found, object expected 
```

## How


## Recommended reading order
1. `x.java`
2. `y.python`

## 🚨 User Impact 🚨
Are there any breaking changes? What is the end result perceived by the user? If yes, please merge this PR with the 🚨🚨 emoji so changelog authors can further highlight this if needed.

## Pre-merge Checklist
Expand the relevant checklist and delete the others.

<details><summary><strong>New Connector</strong></summary>

### Community member or Airbyter

- [ ] **Community member?** Grant edit access to maintainers ([instructions](https://docs.github.com/en/github/collaborating-with-pull-requests/working-with-forks/allowing-changes-to-a-pull-request-branch-created-from-a-fork#enabling-repository-maintainer-permissions-on-existing-pull-requests))
- [ ] Secrets in the connector's spec are annotated with `airbyte_secret`
- [ ] Unit & integration tests added and passing. Community members, please provide proof of success locally e.g: screenshot or copy-paste unit, integration, and acceptance test output. To run acceptance tests for a Python connector, follow instructions in the README. For java connectors run `./gradlew :airbyte-integrations:connectors:<name>:integrationTest`.
- [ ] Code reviews completed
- [ ] Documentation updated
    - [ ] Connector's `README.md`
    - [ ] Connector's `bootstrap.md`. See [description and examples](https://docs.google.com/document/d/1ypdgmwmEHWv-TrO4_YOQ7pAJGVrMp5BOkEVh831N260/edit?usp=sharing)
    - [ ] `docs/SUMMARY.md`
    - [ ] `docs/integrations/<source or destination>/<name>.md` including changelog. See changelog [example](https://docs.airbyte.io/integrations/sources/stripe#changelog)
    - [ ] `docs/integrations/README.md`
    - [ ] `airbyte-integrations/builds.md`
- [ ] PR name follows [PR naming conventions](https://docs.airbyte.io/contributing-to-airbyte/updating-documentation#issues-and-pull-requests)

### Airbyter

If this is a community PR, the Airbyte engineer reviewing this PR is responsible for the below items.

- [ ] Create a non-forked branch based on this PR and test the below items on it
- [ ] Build is successful
- [ ] If new credentials are required for use in CI, add them to GSM. [Instructions](https://docs.airbyte.io/connector-development#using-credentials-in-ci).
- [ ] [`/test connector=connectors/<name>` command](https://docs.airbyte.io/connector-development#updating-an-existing-connector) is passing
- [ ] New Connector version released on Dockerhub by running the `/publish` command described [here](https://docs.airbyte.io/connector-development#updating-an-existing-connector)
- [ ] After the connector is published, connector added to connector index as described [here](https://docs.airbyte.io/connector-development#publishing-a-connector)
- [ ] Seed specs have been re-generated by building the platform and committing the changes to the seed spec files, as described [here](https://docs.airbyte.io/connector-development#publishing-a-connector)

</details>

<details><summary><strong>Updating a connector</strong></summary>

### Community member or Airbyter

- [x] Grant edit access to maintainers ([instructions](https://docs.github.com/en/github/collaborating-with-pull-requests/working-with-forks/allowing-changes-to-a-pull-request-branch-created-from-a-fork#enabling-repository-maintainer-permissions-on-existing-pull-requests))
- [x] Secrets in the connector's spec are annotated with `airbyte_secret`
- [x] Unit & integration tests added and passing. Community members, please provide proof of success locally e.g: screenshot or copy-paste unit, integration, and acceptance test output. To run acceptance tests for a Python connector, follow instructions in the README. For java connectors run `./gradlew :airbyte-integrations:connectors:<name>:integrationTest`.
- [x] Code reviews completed
- [x] Documentation updated
    - [ ] Connector's `README.md`
    - [ ] Connector's `bootstrap.md`. See [description and examples](https://docs.google.com/document/d/1ypdgmwmEHWv-TrO4_YOQ7pAJGVrMp5BOkEVh831N260/edit?usp=sharing)
    - [ ] Changelog updated in `docs/integrations/<source or destination>/<name>.md` including changelog. See changelog [example](https://docs.airbyte.io/integrations/sources/stripe#changelog)
- [x] PR name follows [PR naming conventions](https://docs.airbyte.io/contributing-to-airbyte/updating-documentation#issues-and-pull-requests)

### Airbyter

If this is a community PR, the Airbyte engineer reviewing this PR is responsible for the below items.

- [ ] Create a non-forked branch based on this PR and test the below items on it
- [ ] Build is successful
- [ ] If new credentials are required for use in CI, add them to GSM. [Instructions](https://docs.airbyte.io/connector-development#using-credentials-in-ci).
- [ ] [`/test connector=connectors/<name>` command](https://docs.airbyte.io/connector-development#updating-an-existing-connector) is passing
- [ ] New Connector version released on Dockerhub and connector version bumped by running the `/publish` command described [here](https://docs.airbyte.io/connector-development#updating-an-existing-connector)

</details>

<details><summary><strong>Connector Generator</strong></summary>

- [ ] Issue acceptance criteria met
- [ ] PR name follows [PR naming conventions](https://docs.airbyte.io/contributing-to-airbyte/updating-documentation#issues-and-pull-requests)
- [ ] If adding a new generator, add it to the [list of scaffold modules being tested](https://github.com/airbytehq/airbyte/blob/master/airbyte-integrations/connector-templates/generator/build.gradle#L41)
- [ ] The generator test modules (all connectors with `-scaffold` in their name) have been updated with the latest scaffold by running `./gradlew :airbyte-integrations:connector-templates:generator:testScaffoldTemplates` then checking in your changes
- [ ] Documentation which references the generator is updated as needed

</details>

## Tests

<details><summary><strong>Unit</strong></summary>

python -m pytest unit_tests
Test session starts (platform: darwin, Python 3.9.12, pytest 6.2.4, pytest-sugar 0.9.4)
cachedir: .pytest_cache
rootdir: /Users/danieldiamond/repos/airbyte, configfile: pytest.ini
plugins: sugar-0.9.4, requests-mock-1.9.3, mock-3.7.0, timeout-1.4.2
collecting ...
 airbyte-integrations/connectors/source-qualaroo/unit_tests/test_streams.py::test_request_params ✓                25% ██▌
 airbyte-integrations/connectors/source-qualaroo/unit_tests/test_streams.py::test_next_page_token ✓               50% █████
 airbyte-integrations/connectors/source-qualaroo/unit_tests/test_streams.py::test_surveys_stream ✓                75% ███████▌
 airbyte-integrations/connectors/source-qualaroo/unit_tests/test_streams.py::test_responses_stream ✓             100% ██████████
======================================================= warnings summary =======================================================
airbyte-integrations/connectors/source-qualaroo/unit_tests/test_streams.py: 11 warnings
  /Users/danieldiamond/.virtualenvs/airbyte/lib/python3.9/site-packages/airbyte_cdk/sources/streams/http/http.py:42: DeprecationWarning: Call to deprecated class NoAuth. (Set `authenticator=None` instead) -- Deprecated since version 0.1.20.
    self._authenticator: HttpAuthenticator = NoAuth()

airbyte-integrations/connectors/source-qualaroo/unit_tests/test_streams.py: 11 warnings
  /Users/danieldiamond/.virtualenvs/airbyte/lib/python3.9/site-packages/deprecated/classic.py:173: DeprecationWarning: Call to deprecated class HttpAuthenticator. (Use requests.auth.AuthBase instead) -- Deprecated since version 0.1.20.
    return old_new1(cls, *args, **kwargs)

-- Docs: https://docs.pytest.org/en/stable/warnings.html

Results (0.29s):
       4 passed

</details>

<details><summary><strong>Integration</strong></summary>

> Task :airbyte-integrations:connectors:source-qualaroo:sourceAcceptanceTest
============================= test session starts ==============================
platform linux -- Python 3.7.11, pytest-6.2.5, py-1.11.0, pluggy-1.0.0
rootdir: /test_input
plugins: sugar-0.9.4, timeout-1.4.2
collected 13 items / 1 skipped / 12 selected

test_core.py ............                                                [ 92%]
test_full_refresh.py .                                                   [100%]

=========================== short test summary info ============================
SKIPPED [1] ../usr/local/lib/python3.7/site-packages/source_acceptance_test/plugin.py:56: Skipping TestIncremental.test_two_sequential_reads because not found in the config
================== 13 passed, 1 skipped in 389.79s (0:06:29) ===================

Deprecated Gradle features were used in this build, making it incompatible with Gradle 8.0.

You can use '--warning-mode all' to show the individual deprecation warnings and determine if they come from your own scripts or plugins.

See https://docs.gradle.org/7.4/userguide/command_line_interface.html#sec:command_line_warnings

Execution optimizations have been disabled for 1 invalid unit(s) of work during this build to ensure correctness.
Please consult deprecation warnings for more details.

BUILD SUCCESSFUL in 8m 42s
48 actionable tasks: 35 executed, 13 up-to-date
</details>

<details><summary><strong>Acceptance</strong></summary>

*Put your acceptance tests output here.*

</details>
