### PR TITLE
Set HTTP client version to 1.1 in tests to mitigate CI failures

### DIFF
--- a/airbyte-tests/src/acceptanceTests/java/io/airbyte/test/acceptance/AcceptanceTests.java
+++ b/airbyte-tests/src/acceptanceTests/java/io/airbyte/test/acceptance/AcceptanceTests.java
@@ -96,6 +96,7 @@ import java.net.Inet4Address;
 import java.net.URI;
 import java.net.URISyntaxException;
 import java.net.UnknownHostException;
+import java.net.http.HttpClient;
 import java.nio.charset.Charset;
 import java.nio.charset.StandardCharsets;
 import java.nio.file.Path;
@@ -262,7 +263,9 @@ public class AcceptanceTests {
         new ApiClient().setScheme("http")
             .setHost("localhost")
             .setPort(8001)
-            .setBasePath("/api"));
+            .setBasePath("/api")
+            .setHttpClientBuilder(HttpClient.newBuilder()
+                .version(HttpClient.Version.HTTP_1_1)));
 
     // work in whatever default workspace is present.
     workspaceId = apiClient.getWorkspaceApi().listWorkspaces().getWorkspaces().get(0).getWorkspaceId();

--- a/airbyte-tests/src/main/java/io/airbyte/test/airbyte_test_container/AirbyteTestContainer.java
+++ b/airbyte-tests/src/main/java/io/airbyte/test/airbyte_test_container/AirbyteTestContainer.java
@@ -18,6 +18,7 @@ import java.io.IOException;
 import java.lang.reflect.Field;
 import java.lang.reflect.InvocationTargetException;
 import java.lang.reflect.Method;
+import java.net.http.HttpClient;
 import java.nio.charset.StandardCharsets;
 import java.nio.file.Files;
 import java.nio.file.Path;
@@ -121,7 +122,9 @@ public class AirbyteTestContainer {
         new ApiClient().setScheme("http")
             .setHost("localhost")
             .setPort(8001)
-            .setBasePath("/api"));
+            .setBasePath("/api")
+            .setHttpClientBuilder(HttpClient.newBuilder()
+                .version(HttpClient.Version.HTTP_1_1)));
     final HealthApi healthApi = apiClient.getHealthApi();
 
     final AtomicReference<ApiException> lastException = new AtomicReference<>();


### PR DESCRIPTION
## What
CI has been failing on master repeatedly due to errors like this: https://github.com/airbytehq/airbyte/runs/6528776383?check_suite_focus=true#step:11:43878
```
AcceptanceTests > testBackpressure() > io.airbyte.test.acceptance.AcceptanceTests.testBackpressure()[1] FAILED
    io.airbyte.api.client.invoker.ApiException: java.io.IOException: HTTP/1.1 header parser received no bytes
        at app//io.airbyte.api.client.DestinationApi.deleteDestinationWithHttpInfo(DestinationApi.java:414)
        at app//io.airbyte.api.client.DestinationApi.deleteDestination(DestinationApi.java:386)
        at app//io.airbyte.test.acceptance.AcceptanceTests.deleteDestination(AcceptanceTests.java:1760)
        at app//io.airbyte.test.acceptance.AcceptanceTests.tearDown(AcceptanceTests.java:327)

        Caused by:
        java.io.IOException: HTTP/1.1 header parser received no bytes
            at java.net.http/jdk.internal.net.http.HttpClientImpl.send(HttpClientImpl.java:586)
            at java.net.http/jdk.internal.net.http.HttpClientFacade.send(HttpClientFacade.java:123)
            at io.airbyte.api.client.DestinationApi.deleteDestinationWithHttpInfo(DestinationApi.java:399)
            ... 3 more

            Caused by:
            java.io.IOException: HTTP/1.1 header parser received no bytes
                at java.net.http/jdk.internal.net.http.common.Utils.wrapWithExtraDetail(Utils.java:348)
                at java.net.http/jdk.internal.net.http.Http1Response$HeadersReader.onReadError(Http1Response.java:675)
                at java.net.http/jdk.internal.net.http.Http1AsyncReceiver.checkForErrors(Http1AsyncReceiver.java:302)
                at java.net.http/jdk.internal.net.http.Http1AsyncReceiver.flush(Http1AsyncReceiver.java:268)
                at java.net.http/jdk.internal.net.http.common.SequentialScheduler$LockingRestartableTask.run(SequentialScheduler.java:205)
                at java.net.http/jdk.internal.net.http.common.SequentialScheduler$CompleteRestartableTask.run(SequentialScheduler.java:149)
                at java.net.http/jdk.internal.net.http.common.SequentialScheduler$SchedulableTask.run(SequentialScheduler.java:230)
                at java.base/java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1136)
                at java.base/java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:635)
                at java.base/java.lang.Thread.run(Thread.java:833)

                Caused by:
                java.io.EOFException: EOF reached while reading
                    at java.net.http/jdk.internal.net.http.Http1AsyncReceiver$Http1TubeSubscriber.onComplete(Http1AsyncReceiver.java:596)
                    at java.net.http/jdk.internal.net.http.SocketTube$InternalReadPublisher$ReadSubscription.signalCompletion(SocketTube.java:640)
                    at java.net.http/jdk.internal.net.http.SocketTube$InternalReadPublisher$InternalReadSubscription.read(SocketTube.java:845)
                    at java.net.http/jdk.internal.net.http.SocketTube$SocketFlowTask.run(SocketTube.java:181)
                    at java.net.http/jdk.internal.net.http.common.SequentialScheduler$SchedulableTask.run(SequentialScheduler.java:230)
                    at java.net.http/jdk.internal.net.http.common.SequentialScheduler.runOrSchedule(SequentialScheduler.java:303)
                    at java.net.http/jdk.internal.net.http.common.SequentialScheduler.runOrSchedule(SequentialScheduler.java:256)
                    at java.net.http/jdk.internal.net.http.SocketTube$InternalReadPublisher$InternalReadSubscription.signalReadable(SocketTube.java:774)
                    at java.net.http/jdk.internal.net.http.SocketTube$InternalReadPublisher$ReadEvent.signalEvent(SocketTube.java:957)
                    at java.net.http/jdk.internal.net.http.SocketTube$SocketFlowEvent.handle(SocketTube.java:253)
                    at java.net.http/jdk.internal.net.http.HttpClientImpl$SelectorManager.handleEvent(HttpClientImpl.java:979)
                    at java.net.http/jdk.internal.net.http.HttpClientImpl$SelectorManager.lambda$run$3(HttpClientImpl.java:934)
                    at java.base/java.util.ArrayList.forEach(ArrayList.java:1511)
                    at java.net.http/jdk.internal.net.http.HttpClientImpl$SelectorManager.run(HttpClientImpl.java:934)
```
This PR is an attempt to mitigate these errors.

## How
Some quick searching of this issue revealed several suggestions (e.g. [this SO post](https://stackoverflow.com/questions/64353620/caused-by-java-io-ioexception-http-1-1-header-parser-received-no-bytes)) of setting the Http Client version to 1.1 explicitly, as this issue may be caused by a mismatch between the version of the request being sent and the version that the server can handle. This PR is an experiment to try out that change and see if it helps