### PR TITLE
Destination Redshift: fixed array contents verification for SUPER

### DIFF
--- a/airbyte-commons/src/main/java/io/airbyte/commons/json/Jsons.java
+++ b/airbyte-commons/src/main/java/io/airbyte/commons/json/Jsons.java
@@ -232,6 +232,15 @@ public class Jsons {
         mergeMaps(output, field, flatten(value));
       }
       return output;
+    } else if (node.isArray()) {
+      final Map<String, Object> output = new HashMap<>();
+      final int arrayLen = node.size();
+      for (int i = 0; i < arrayLen; i++) {
+        final String field = String.format("[%d]", i);
+        final JsonNode value = node.get(i);
+        mergeMaps(output, field, flatten(value));
+      }
+      return output;
     } else {
       final Object value;
       if (node.isBoolean()) {
@@ -245,7 +254,7 @@ public class Jsons {
       } else if (node.isValueNode() && !node.isNull()) {
         value = node.asText();
       } else {
-        // Fallback handling for e.g. arrays
+        // Fallback handling
         value = node.toString();
       }
       return singletonMap(null, value);

--- a/airbyte-config/init/src/main/resources/seed/destination_definitions.yaml
+++ b/airbyte-config/init/src/main/resources/seed/destination_definitions.yaml
@@ -225,7 +225,7 @@
 - name: Redshift
   destinationDefinitionId: f7a7d195-377f-cf5b-70a5-be6b819019dc
   dockerRepository: airbyte/destination-redshift
-  dockerImageTag: 0.3.37
+  dockerImageTag: 0.3.38
   documentationUrl: https://docs.airbyte.io/integrations/destinations/redshift
   icon: redshift.svg
   resourceRequirements:

--- a/airbyte-config/init/src/main/resources/seed/destination_specs.yaml
+++ b/airbyte-config/init/src/main/resources/seed/destination_specs.yaml
@@ -3629,7 +3629,7 @@
     supported_destination_sync_modes:
     - "overwrite"
     - "append"
-- dockerImage: "airbyte/destination-redshift:0.3.37"
+- dockerImage: "airbyte/destination-redshift:0.3.38"
   spec:
     documentationUrl: "https://docs.airbyte.io/integrations/destinations/redshift"
     connectionSpecification:

--- a/airbyte-integrations/connectors/destination-redshift/Dockerfile
+++ b/airbyte-integrations/connectors/destination-redshift/Dockerfile
@@ -16,5 +16,5 @@ ENV APPLICATION destination-redshift
 
 COPY --from=build /airbyte /airbyte
 
-LABEL io.airbyte.version=0.3.37
+LABEL io.airbyte.version=0.3.38
 LABEL io.airbyte.name=airbyte/destination-redshift

--- a/docs/integrations/destinations/redshift.md
+++ b/docs/integrations/destinations/redshift.md
@@ -138,6 +138,7 @@ Each stream will be output into its own raw table in Redshift. Each table will c
 
 | Version | Date       | Pull Request                                               | Subject                                                                                                                                             |
 |:--------|:-----------|:-----------------------------------------------------------|:----------------------------------------------------------------------------------------------------------------------------------------------------|
+| 0.3.38  | 2022-05-25 | [13069](https://github.com/airbytehq/airbyte/pull/13069) | Fixed array contents verification for SUPER type |
 | 0.3.37  | 2022-05-23 | [13090](https://github.com/airbytehq/airbyte/pull/13090)   | Removed redshiftDataTmpTableMode. Some refactoring.                                                                                                 | 
 | 0.3.36  | 2022-05-23 | [12820](https://github.com/airbytehq/airbyte/pull/12820) | Improved 'check' operation performance |
 | 0.3.35  | 2022-05-18 | [12940](https://github.com/airbytehq/airbyte/pull/12940) | Fixed maximum record size for SUPER type |


### PR DESCRIPTION
## What
Follow up to #12940. That solution relies on `Jsons.flatten`, which previously did not actually flatten arrays, but rather just converted them to strings. Redshift can store arrays within a SUPER.

## How
Added a case to `flatten` to handle arrays. This function is only used one other location: https://github.com/airbytehq/airbyte/blob/a1b1c1cb8cefbb04e3721cba564b6707a12f66c2/airbyte-scheduler/persistence/src/main/java/io/airbyte/scheduler/persistence/job_tracker/JobTracker.java#L218

As far as I can tell, that case (enum/const) should never encounter an array, so I do not believe adding this handling will result in any other negative consequences. Someone with more knowledge of the codebase than me, feel free to disagree! I can always add a switch to enable this behavior.

When flatten encounters an array, it will now flatten it into a map with keys `[<index>]` and the corresponding values. This should allow flatten to truly flatten arbitrary data.

As an example:
```
{"foo": [{"blue": "apple"}]}
```
would have previously been flattened to: `{"foo": "[{\"blue\": \"apple\"}]"}`
It will now flatten to: `{"foo.[0].blue": "apple"}`

## Recommended reading order
1. `x.java`
2. `y.python`

## 🚨 User Impact 🚨
Are there any breaking changes? What is the end result perceived by the user? If yes, please merge this PR with the 🚨🚨 emoji so changelog authors can further highlight this if needed.

## Pre-merge Checklist
Expand the relevant checklist and delete the others.
<summary><strong>Updating a connector</strong></summary>

### Community member or Airbyter

- [x] Grant edit access to maintainers ([instructions](https://docs.github.com/en/github/collaborating-with-pull-requests/working-with-forks/allowing-changes-to-a-pull-request-branch-created-from-a-fork#enabling-repository-maintainer-permissions-on-existing-pull-requests))
- [ ] Secrets in the connector's spec are annotated with `airbyte_secret`
- [ ] Unit & integration tests added and passing. Community members, please provide proof of success locally e.g: screenshot or copy-paste unit, integration, and acceptance test output. To run acceptance tests for a Python connector, follow instructions in the README. For java connectors run `./gradlew :airbyte-integrations:connectors:<name>:integrationTest`.
- [ ] Code reviews completed
- [x] Documentation updated
    - [ ] Connector's `README.md`
    - [ ] Connector's `bootstrap.md`. See [description and examples](https://docs.google.com/document/d/1ypdgmwmEHWv-TrO4_YOQ7pAJGVrMp5BOkEVh831N260/edit?usp=sharing)
    - [x] Changelog updated in `docs/integrations/<source or destination>/<name>.md` including changelog. See changelog [example](https://docs.airbyte.io/integrations/sources/stripe#changelog)
- [x] PR name follows [PR naming conventions](https://docs.airbyte.io/contributing-to-airbyte/updating-documentation#issues-and-pull-requests)

### Airbyter

If this is a community PR, the Airbyte engineer reviewing this PR is responsible for the below items.

- [ ] Create a non-forked branch based on this PR and test the below items on it
- [ ] Build is successful
- [ ] If new credentials are required for use in CI, add them to GSM. [Instructions](https://docs.airbyte.io/connector-development#using-credentials-in-ci).
- [ ] [`/test connector=connectors/<name>` command](https://docs.airbyte.io/connector-development#updating-an-existing-connector) is passing
- [ ] New Connector version released on Dockerhub and connector version bumped by running the `/publish` command described [here](https://docs.airbyte.io/connector-development#updating-an-existing-connector)


## Tests

<details><summary><strong>Unit</strong></summary>

*Put your unit tests output here.*

</details>

<details><summary><strong>Integration</strong></summary>

*Put your integration tests output here.*

</details>

<details><summary><strong>Acceptance</strong></summary>

*Put your acceptance tests output here.*

</details>
