### PR TITLE
Show integration test results on the Action Summary

### DIFF
--- a/.github/workflows/test-command.yml
+++ b/.github/workflows/test-command.yml
@@ -159,7 +159,7 @@ jobs:
           body: |
             > :white_check_mark: ${{github.event.inputs.connector}} https://github.com/${{github.repository}}/actions/runs/${{github.run_id}}
             ${{env.PYTHON_UNITTEST_COVERAGE_REPORT}}
-            > ${{env.PYTHON_SHORT_TEST_SUMMARY_INFO}}
+            > ${{env.TEST_SUMMARY_INFO}}
       - name: Add Failure Comment
         if: github.event.inputs.comment-id && failure()
         uses: peter-evans/create-or-update-comment@v1
@@ -168,7 +168,7 @@ jobs:
           body: |
             > :x: ${{github.event.inputs.connector}} https://github.com/${{github.repository}}/actions/runs/${{github.run_id}}
             > :bug: ${{env.GRADLE_SCAN_LINK}}
-            > ${{env.PYTHON_SHORT_TEST_SUMMARY_INFO}}
+            > ${{env.TEST_SUMMARY_INFO}}
   # In case of self-hosted EC2 errors, remove this block.
   stop-test-runner:
     name: Stop Build EC2 Runner

--- a/tools/bin/ci_integration_test.sh
+++ b/tools/bin/ci_integration_test.sh
@@ -83,6 +83,7 @@ write_logs() {
   show_run_details 'ERRORS'
 }
 
+echo 'testing GITHUB_STEP_SUMMARY'
 echo "# $connector" >> $GITHUB_STEP_SUMMARY
 echo "" >> $GITHUB_STEP_SUMMARY
 

--- a/tools/bin/ci_integration_test.sh
+++ b/tools/bin/ci_integration_test.sh
@@ -83,7 +83,7 @@ write_results_summary() {
   then
     result="Build Passed"
     info='All Passed'
-    echo '### Build Passed\n' >> $GITHUB_STEP_SUMMARY
+    echo '### Build Passed' >> $GITHUB_STEP_SUMMARY
     echo '' >> $GITHUB_STEP_SUMMARY
   else
     result="Build Failed"

--- a/tools/bin/ci_integration_test.sh
+++ b/tools/bin/ci_integration_test.sh
@@ -44,7 +44,6 @@ fi
 }
 
 show_run_details() {
-   echo "Run Details: $1" >> $GITHUB_STEP_SUMMARY
    run_info=`sed -n "/=* $1 =*/,/========/p" build.out`
    if ! test -z "$run_info"
    then
@@ -56,7 +55,6 @@ show_run_details() {
 }
 
 show_skipped_failed_info() {
-   echo "show_skipped_failed_info function" >> $GITHUB_STEP_SUMMARY
    skipped_failed_info=`sed -n '/=* short test summary info =*/,/========/p' build.out`
    if ! test -z "$skipped_failed_info"
       then
@@ -83,7 +81,6 @@ write_logs() {
   show_run_details 'ERRORS'
 }
 
-echo 'testing GITHUB_STEP_SUMMARY'
 echo "# $connector" >> $GITHUB_STEP_SUMMARY
 echo "" >> $GITHUB_STEP_SUMMARY
 

--- a/tools/bin/ci_integration_test.sh
+++ b/tools/bin/ci_integration_test.sh
@@ -44,6 +44,7 @@ fi
 }
 
 show_run_details() {
+   echo "Run Details: $1" >> $GITHUB_STEP_SUMMARY
    run_info=`sed -n "/=* $1 =*/,/========/p" build.out`
    if ! test -z "$run_info"
    then
@@ -55,6 +56,7 @@ show_run_details() {
 }
 
 show_skipped_failed_info() {
+   echo "show_skipped_failed_info function" >> $GITHUB_STEP_SUMMARY
    skipped_failed_info=`sed -n '/=* short test summary info =*/,/========/p' build.out`
    if ! test -z "$skipped_failed_info"
       then
@@ -80,6 +82,9 @@ write_logs() {
   show_run_details 'FAILURES'
   show_run_details 'ERRORS'
 }
+
+echo "# $connector" >> $GITHUB_STEP_SUMMARY
+echo "" >> $GITHUB_STEP_SUMMARY
 
 # Copy command output to extract gradle scan link.
 run | tee build.out


### PR DESCRIPTION
## What
Bubbling up errors on our integration test actions so we don't have to look through the logs.
Even just getting the name of the connector at the top level seems helpful.

Also making it so that we can report short summaries on Java connectors. Was previously only Python.

Examples:
1. Python failing: https://github.com/airbytehq/airbyte/actions/runs/2361505767
2. Python passing: https://github.com/airbytehq/airbyte/actions/runs/2361506689 (note: I fixed `\n`)
3. Java failing: https://github.com/airbytehq/airbyte/actions/runs/2361508418
4. Java passing: https://github.com/airbytehq/airbyte/actions/runs/2361612733 (note: I fixed `\n`)

<img width="827" alt="Screen Shot 2022-05-20 at 7 18 42 PM" src="https://user-images.githubusercontent.com/36106/169630657-d0e1ea50-163d-46a7-9c99-7a291ea13f18.png">

## How
Used `$GITHUB_STEP_SUMMARY` as described [here](https://github.blog/2022-05-09-supercharging-github-actions-with-job-summaries/).