### PR TITLE
Switch team notification to the team/frontend label

### DIFF
--- a/.github/labeler.yml
+++ b/.github/labeler.yml
@@ -17,7 +17,7 @@ area/platform:
   - charts/*
   - charts/**/*
 
-area/frontend:
+team/frontend:
   - airbyte-webapp/*
   - airbyte-webapp/**/*
 

--- a/.github/workflows/assign-issue-to-project.yml
+++ b/.github/workflows/assign-issue-to-project.yml
@@ -18,5 +18,5 @@ jobs:
             # Specify which label should get added to which project. The project number can be found
             # as part of the URL after projects/<id> when viewing the project on GitHub.
             projects: |
-              area/frontend=7
+              team/frontend=7
               project/onboarding-improvements=16

--- a/.github/workflows/notify-on-label.yml
+++ b/.github/workflows/notify-on-label.yml
@@ -14,4 +14,4 @@ jobs:
             message: 'cc {recipients}'
             # Specify a map of label -> team/user to notify
             recipients: |
-              area/frontend=@airbytehq/frontend
+              team/frontend=@airbytehq/frontend


### PR DESCRIPTION
## What

Makes sure to use the new `team/frontend` label instead of `area/frontend` for all concerns around team pinging and labeling.