### PR TITLE
🐞 Postgres destination: add missing jdbc param from 0.3.19 in connector spec

### DIFF
--- a/airbyte-config/init/src/main/resources/seed/destination_specs.yaml
+++ b/airbyte-config/init/src/main/resources/seed/destination_specs.yaml
@@ -3259,6 +3259,13 @@
           type: "boolean"
           default: false
           order: 6
+        jdbc_url_params:
+          description: "Additional properties to pass to the JDBC URL string when\
+            \ connecting to the database formatted as 'key=value' pairs separated\
+            \ by the symbol '&'. (example: key1=value1&key2=value2&key3=value3)."
+          title: "JDBC URL Params"
+          type: "string"
+          order: 7
         tunnel_method:
           type: "object"
           title: "SSH Tunnel Method"


### PR DESCRIPTION
## What
- The JDBC param was added to Postgres destination `0.3.19`. However, its spec was not updated.
- My suspicion is that the publication did not correctly push the latest spec to the spec cache.
- Relate to https://github.com/airbytehq/airbyte/pull/12195.
- This PR fixes this issue.
