### PR TITLE
Java integration test update

### DIFF
--- a/tools/bin/ci_integration_test.sh
+++ b/tools/bin/ci_integration_test.sh
@@ -67,7 +67,10 @@ show_java_run_details() {
 }
 
 write_results_summary() {
-  echo "write_results_summary"
+  file_contents=`tail -n 1000 build.out`
+  echo "write_results_summary: $file_contents"
+  echo "write_results_summary_end"
+  
   success="$1"
   python_info=`sed -n '/=* short test summary info =*/,/========/p' build.out`
   java_info=`sed -n '/tests completed,/p' build.out`

--- a/tools/bin/ci_integration_test.sh
+++ b/tools/bin/ci_integration_test.sh
@@ -111,7 +111,8 @@ write_results_summary() {
   fi
 
   echo "TEST_SUMMARY_INFO<<EOF" >> $GITHUB_ENV
-  echo "$result" >> $GITHUB_ENV
+  echo '' >> $GITHUB_ENV
+  echo "### $result" >> $GITHUB_ENV
   echo '' >> $GITHUB_ENV
   echo "Test summary info:" >> $GITHUB_ENV
   echo '```' >> $GITHUB_ENV

--- a/tools/bin/ci_integration_test.sh
+++ b/tools/bin/ci_integration_test.sh
@@ -67,19 +67,15 @@ show_java_run_details() {
 }
 
 write_results_summary() {
-  file_contents=`tail -n 1000 build.out`
-  echo "write_results_summary: $file_contents"
-  echo "write_results_summary_end"
-  
   success="$1"
   python_info=`sed -n '/=* short test summary info =*/,/========/p' build.out`
-  java_info=`sed -n '/tests completed,/p' build.out`
+  java_info=`sed -n '/tests completed,/p' build.out` # this doesn't seem to work, not in build.out
 
   echo "success: $success"
   echo "python_info: $python_info"
   echo "java_info: $java_info"
 
-  info='Could not find result details'
+  info='Could not find result summary'
   result='Unknown result'
 
   if [ "$success" = true ]

--- a/tools/bin/ci_integration_test.sh
+++ b/tools/bin/ci_integration_test.sh
@@ -56,7 +56,7 @@ show_python_run_details() {
 
 show_java_run_details() {
   # show few lines after stack trace
-  run_info=`awk '/] FAILED/{x=NR+8}(NR<=x){print}' build.out`
+  run_info=`awk '/[\]\)] FAILED/{x=NR+8}(NR<=x){print}' build.out`
   if ! test -z "$run_info"
   then
     echo '```' >> $GITHUB_STEP_SUMMARY


### PR DESCRIPTION
Updating the output log as a followup to https://github.com/airbytehq/airbyte/pull/13072
This catches more Java errors.
For some reason, though, the summary (`203 tests completed, 175 failed, 6 skipped`) is not there in `build.out` but is in the logs from Github.
Either way, it's better than it was, so moving on.