### PR TITLE
🐛 Source Qualaroo: Fix start_date & custom survey_ids

### DIFF
--- a/airbyte-config/init/src/main/resources/seed/source_definitions.yaml
+++ b/airbyte-config/init/src/main/resources/seed/source_definitions.yaml
@@ -731,7 +731,7 @@
 - name: Qualaroo
   sourceDefinitionId: b08e4776-d1de-4e80-ab5c-1e51dad934a2
   dockerRepository: airbyte/source-qualaroo
-  dockerImageTag: 0.1.1
+  dockerImageTag: 0.1.2
   documentationUrl: https://docs.airbyte.io/integrations/sources/qualaroo
   icon: qualaroo.svg
   sourceType: api

--- a/airbyte-config/init/src/main/resources/seed/source_specs.yaml
+++ b/airbyte-config/init/src/main/resources/seed/source_specs.yaml
@@ -6796,7 +6796,7 @@
     supportsNormalization: false
     supportsDBT: false
     supported_destination_sync_modes: []
-- dockerImage: "airbyte/source-qualaroo:0.1.1"
+- dockerImage: "airbyte/source-qualaroo:0.1.2"
   spec:
     documentationUrl: "https://docs.airbyte.io/integrations/sources/qualaroo"
     connectionSpecification:
@@ -6833,7 +6833,7 @@
           type: "array"
           items:
             type: "string"
-            pattern: "^[0-9a-fA-F]{24}$"
+            pattern: "^[0-9]{1,8}$"
           title: "Qualaroo survey IDs"
           description: "IDs of the surveys from which you'd like to replicate data.\
             \ If left empty, data from all surveys to which you have access will be\

--- a/airbyte-integrations/connectors/source-qualaroo/Dockerfile
+++ b/airbyte-integrations/connectors/source-qualaroo/Dockerfile
@@ -29,5 +29,5 @@ COPY source_qualaroo ./source_qualaroo
 ENV AIRBYTE_ENTRYPOINT "python /airbyte/integration_code/main.py"
 ENTRYPOINT ["python", "/airbyte/integration_code/main.py"]
 
-LABEL io.airbyte.version=0.1.1
+LABEL io.airbyte.version=0.1.2
 LABEL io.airbyte.name=airbyte/source-qualaroo

--- a/airbyte-integrations/connectors/source-qualaroo/source_qualaroo/schemas/responses.json
+++ b/airbyte-integrations/connectors/source-qualaroo/source_qualaroo/schemas/responses.json
@@ -2,66 +2,130 @@
   "type": "object",
   "properties": {
     "id": {
-      "type": ["null", "integer"]
+      "type": [
+        "null",
+        "integer"
+      ]
     },
     "time": {
-       "type": ["null", "string"],
+      "type": [
+        "null",
+        "string"
+      ],
+      "format": "date-time"
+    },
+    "emitted_at": {
+      "type": [
+        "null",
+        "string"
+      ],
       "format": "date-time"
     },
     "identity": {
-      "type": ["null", "string"]
+      "type": [
+        "null",
+        "string"
+      ]
     },
     "page": {
-       "type": ["null", "string"]
+      "type": [
+        "null",
+        "string"
+      ]
     },
     "referrer": {
-      "type": ["null", "string"]
+      "type": [
+        "null",
+        "string"
+      ]
     },
     "user_agent": {
-       "type": ["null", "string"]
+      "type": [
+        "null",
+        "string"
+      ]
     },
     "nudge_id": {
-      "type": ["null", "integer"]
+      "type": [
+        "null",
+        "integer"
+      ]
     },
     "nudge_name": {
-       "type": ["null", "string"]
+      "type": [
+        "null",
+        "string"
+      ]
     },
     "anon_visitor_id": {
-       "type": ["null", "string"]
+      "type": [
+        "null",
+        "string"
+      ]
     },
     "ip_address": {
-       "type": ["null", "string"]
+      "type": [
+        "null",
+        "string"
+      ]
     },
     "answered_questions": {
       "type": "array",
       "items": {
-        "type":["null",  "object"]
+        "type": [
+          "null",
+          "object"
+        ]
       }
     },
     "properties": {
-      "type":["null",  "object"]
+      "type": [
+        "null",
+        "object"
+      ]
     },
     "nps": {
-      "type": ["null", "object"],
+      "type": [
+        "null",
+        "object"
+      ],
       "properties": {
         "score": {
-          "type": ["null", "integer"]
+          "type": [
+            "null",
+            "integer"
+          ]
         },
         "reason": {
-           "type": ["null", "string"]
+          "type": [
+            "null",
+            "string"
+          ]
         },
         "respondent_id": {
-          "type": ["null", "integer"]
+          "type": [
+            "null",
+            "integer"
+          ]
         },
         "time": {
-           "type": ["null", "string"],
+          "type": [
+            "null",
+            "string"
+          ],
           "format": "date-time"
         },
         "category": {
-           "type": ["null", "string"]
+          "type": [
+            "null",
+            "string"
+          ]
         },
         "response_uri": {
-           "type": ["null", "string"]
+          "type": [
+            "null",
+            "string"
+          ]
         }
       }
     }

--- a/airbyte-integrations/connectors/source-qualaroo/source_qualaroo/schemas/responses.json
+++ b/airbyte-integrations/connectors/source-qualaroo/source_qualaroo/schemas/responses.json
@@ -2,130 +2,70 @@
   "type": "object",
   "properties": {
     "id": {
-      "type": [
-        "null",
-        "integer"
-      ]
+      "type": ["null", "integer"]
     },
     "time": {
-      "type": [
-        "null",
-        "string"
-      ],
+      "type": ["null", "string"],
       "format": "date-time"
     },
     "emitted_at": {
-      "type": [
-        "null",
-        "string"
-      ],
+      "type": ["null", "string"],
       "format": "date-time"
     },
     "identity": {
-      "type": [
-        "null",
-        "string"
-      ]
+      "type": ["null", "string"]
     },
     "page": {
-      "type": [
-        "null",
-        "string"
-      ]
+      "type": ["null", "string"]
     },
     "referrer": {
-      "type": [
-        "null",
-        "string"
-      ]
+      "type": ["null", "string"]
     },
     "user_agent": {
-      "type": [
-        "null",
-        "string"
-      ]
+      "type": ["null", "string"]
     },
     "nudge_id": {
-      "type": [
-        "null",
-        "integer"
-      ]
+      "type": ["null", "integer"]
     },
     "nudge_name": {
-      "type": [
-        "null",
-        "string"
-      ]
+      "type": ["null", "string"]
     },
     "anon_visitor_id": {
-      "type": [
-        "null",
-        "string"
-      ]
+      "type": ["null", "string"]
     },
     "ip_address": {
-      "type": [
-        "null",
-        "string"
-      ]
+      "type": ["null", "string"]
     },
     "answered_questions": {
       "type": "array",
       "items": {
-        "type": [
-          "null",
-          "object"
-        ]
+        "type": ["null", "object"]
       }
     },
     "properties": {
-      "type": [
-        "null",
-        "object"
-      ]
+      "type": ["null", "object"]
     },
     "nps": {
-      "type": [
-        "null",
-        "object"
-      ],
+      "type": ["null", "object"],
       "properties": {
         "score": {
-          "type": [
-            "null",
-            "integer"
-          ]
+          "type": ["null", "integer"]
         },
         "reason": {
-          "type": [
-            "null",
-            "string"
-          ]
+          "type": ["null", "string"]
         },
         "respondent_id": {
-          "type": [
-            "null",
-            "integer"
-          ]
+          "type": ["null", "integer"]
         },
         "time": {
-          "type": [
-            "null",
-            "string"
-          ],
+          "type": ["null", "string"],
           "format": "date-time"
         },
         "category": {
-          "type": [
-            "null",
-            "string"
-          ]
+          "type": ["null", "string"]
         },
         "response_uri": {
-          "type": [
-            "null",
-            "string"
-          ]
+          "type": ["null", "string"]
         }
       }
     }

--- a/airbyte-integrations/connectors/source-qualaroo/source_qualaroo/source.py
+++ b/airbyte-integrations/connectors/source-qualaroo/source_qualaroo/source.py
@@ -7,93 +7,14 @@ from abc import ABC
 from base64 import b64encode
 from typing import Any, Iterable, List, Mapping, MutableMapping, Optional, Tuple
 
+import pendulum
 import requests
 from airbyte_cdk.sources import AbstractSource
 from airbyte_cdk.sources.streams import Stream
 from airbyte_cdk.sources.streams.http import HttpStream
 from airbyte_cdk.sources.streams.http.auth import HttpAuthenticator
 
-
-class QualarooStream(HttpStream, ABC):
-    url_base = "https://api.qualaroo.com/api/v1/"
-
-    # Define primary key as sort key for full_refresh, or very first sync for incremental_refresh
-    primary_key = "id"
-
-    # Page size
-    limit = 500
-
-    extra_params = None
-
-    def __init__(self, config: Mapping[str, Any]):
-        super().__init__(authenticator=config["authenticator"])
-        self.start_date = config["start_date"]
-        self.config = config
-
-    def next_page_token(self, response: requests.Response) -> Optional[Mapping[str, Any]]:
-        return None
-
-    def request_params(
-        self, stream_state: Mapping[str, Any], stream_slice: Mapping[str, Any] = None, next_page_token: Mapping[str, Any] = None
-    ) -> MutableMapping[str, Any]:
-        params = {"limit": self.limit, "start_date": self.start_date}
-        if next_page_token:
-            params.update(**next_page_token)
-        if self.extra_params:
-            params.update(self.extra_params)
-        return params
-
-    def parse_response(self, response: requests.Response, **kwargs) -> Iterable[Mapping]:
-        json_response = response.json()
-        for record in json_response:
-            yield record
-
-
-class ChildStreamMixin:
-    parent_stream_class: Optional[QualarooStream] = None
-
-    def stream_slices(self, sync_mode, **kwargs) -> Iterable[Optional[Mapping[str, any]]]:
-        for item in self.parent_stream_class(config=self.config).read_records(sync_mode=sync_mode):
-            yield {"id": item["id"]}
-
-
-class Surveys(QualarooStream):
-    """Return list of all Surveys.
-    API Docs: https://help.qualaroo.com/hc/en-us/articles/201969438-The-REST-Reporting-API
-    Endpoint: https://api.qualaroo.com/api/v1/nudges/
-    """
-
-    def path(self, stream_slice: Mapping[str, Any] = None, **kwargs) -> str:
-        return "nudges"
-
-    def parse_response(self, response: requests.Response, **kwargs) -> Iterable[Mapping]:
-        survey_ids = self.config.get("survey_ids", [])
-        for record in super().parse_response(response, **kwargs):
-            if not survey_ids or record["id"] in survey_ids:
-                yield record
-
-
-class Responses(ChildStreamMixin, QualarooStream):
-    """Return list of all responses of a survey.
-    API Docs: hhttps://help.qualaroo.com/hc/en-us/articles/201969438-The-REST-Reporting-API
-    Endpoint: https://api.qualaroo.com/api/v1/nudges/<id>/responses.json
-    """
-
-    parent_stream_class = Surveys
-    limit = 500
-    extra_params = {}
-
-    def parse_response(self, response: requests.Response, **kwargs) -> Iterable[Mapping]:
-        response_data = response.json()
-
-        # de-nest the answered_questions object if exists
-        for rec in response_data:
-            if "answered_questions" in rec:
-                rec["answered_questions"] = list(rec["answered_questions"].values())
-        yield from response_data
-
-    def path(self, stream_slice: Mapping[str, Any] = None, **kwargs) -> str:
-        return f"nudges/{stream_slice['id']}/responses.json"
+from .streams import Surveys, Responses, QualarooStream
 
 
 class QualarooAuthenticator(HttpAuthenticator):
@@ -110,8 +31,8 @@ class QualarooAuthenticator(HttpAuthenticator):
         token_header: str = "oauth_token",
     ):
         self._key = key
-        self._token = token
-        self._token = b64encode(b":".join((key.encode("latin1"), token.encode("latin1")))).strip().decode("ascii")
+        self._token = b64encode(b":".join(
+            (key.encode("latin1"), token.encode("latin1")))).strip().decode("ascii")
         self.auth_header = auth_header
         self.key_header = key_header
         self.token_header = token_header
@@ -140,7 +61,8 @@ class SourceQualaroo(AbstractSource):
 
             authenticator = self._get_authenticator(config)
 
-            response = requests.get(url, headers=authenticator.get_auth_header())
+            response = requests.get(
+                url, headers=authenticator.get_auth_header())
 
             response.raise_for_status()
             available_surveys = {row.get("id") for row in response.json()}
@@ -155,5 +77,10 @@ class SourceQualaroo(AbstractSource):
         """
         :param config: A Mapping of the user input configuration as defined in the connector spec.
         """
-        config["authenticator"] = self._get_authenticator(config)
-        return [Surveys(config), Responses(config)]
+        args = {}
+        # convert start_date to epoch time for qualaroo API
+        args["start_date"] = pendulum.parse(
+            config["start_date"]).strftime("%s")
+        args["survey_ids"] = config.get("survey_ids", [])
+        args["authenticator"] = self._get_authenticator(config)
+        return [Surveys(**args), Responses(**args)]

--- a/airbyte-integrations/connectors/source-qualaroo/source_qualaroo/source.py
+++ b/airbyte-integrations/connectors/source-qualaroo/source_qualaroo/source.py
@@ -31,7 +31,8 @@ class QualarooAuthenticator(HttpAuthenticator):
         token_header: str = "oauth_token",
     ):
         self._key = key
-        self._token = b64encode(b":".join((key.encode("latin1"), token.encode("latin1")))).strip().decode("ascii")
+        self._token = b64encode(b":".join(
+            (key.encode("latin1"), token.encode("latin1")))).strip().decode("ascii")
         self.auth_header = auth_header
         self.key_header = key_header
         self.token_header = token_header
@@ -60,7 +61,8 @@ class SourceQualaroo(AbstractSource):
 
             authenticator = self._get_authenticator(config)
 
-            response = requests.get(url, headers=authenticator.get_auth_header())
+            response = requests.get(
+                url, headers=authenticator.get_auth_header())
 
             response.raise_for_status()
             available_surveys = {row.get("id") for row in response.json()}
@@ -77,7 +79,8 @@ class SourceQualaroo(AbstractSource):
         """
         args = {}
         # convert start_date to epoch time for qualaroo API
-        args["start_date"] = pendulum.parse(config["start_date"]).strftime("%s")
+        args["start_date"] = pendulum.parse(
+            config["start_date"]).strftime("%s")
         args["survey_ids"] = config.get("survey_ids", [])
         args["authenticator"] = self._get_authenticator(config)
         return [Surveys(**args), Responses(**args)]

--- a/airbyte-integrations/connectors/source-qualaroo/source_qualaroo/source.py
+++ b/airbyte-integrations/connectors/source-qualaroo/source_qualaroo/source.py
@@ -31,8 +31,7 @@ class QualarooAuthenticator(HttpAuthenticator):
         token_header: str = "oauth_token",
     ):
         self._key = key
-        self._token = b64encode(b":".join(
-            (key.encode("latin1"), token.encode("latin1")))).strip().decode("ascii")
+        self._token = b64encode(b":".join((key.encode("latin1"), token.encode("latin1")))).strip().decode("ascii")
         self.auth_header = auth_header
         self.key_header = key_header
         self.token_header = token_header
@@ -61,8 +60,7 @@ class SourceQualaroo(AbstractSource):
 
             authenticator = self._get_authenticator(config)
 
-            response = requests.get(
-                url, headers=authenticator.get_auth_header())
+            response = requests.get(url, headers=authenticator.get_auth_header())
 
             response.raise_for_status()
             available_surveys = {row.get("id") for row in response.json()}
@@ -79,8 +77,7 @@ class SourceQualaroo(AbstractSource):
         """
         args = {}
         # convert start_date to epoch time for qualaroo API
-        args["start_date"] = pendulum.parse(
-            config["start_date"]).strftime("%s")
+        args["start_date"] = pendulum.parse(config["start_date"]).strftime("%s")
         args["survey_ids"] = config.get("survey_ids", [])
         args["authenticator"] = self._get_authenticator(config)
         return [Surveys(**args), Responses(**args)]

--- a/airbyte-integrations/connectors/source-qualaroo/source_qualaroo/source.py
+++ b/airbyte-integrations/connectors/source-qualaroo/source_qualaroo/source.py
@@ -3,15 +3,13 @@
 #
 
 
-from abc import ABC
 from base64 import b64encode
-from typing import Any, Iterable, List, Mapping, MutableMapping, Optional, Tuple
+from typing import Any, List, Mapping, Tuple
 
 import pendulum
 import requests
 from airbyte_cdk.sources import AbstractSource
 from airbyte_cdk.sources.streams import Stream
-from airbyte_cdk.sources.streams.http import HttpStream
 from airbyte_cdk.sources.streams.http.auth import HttpAuthenticator
 
 from .streams import QualarooStream, Responses, Surveys

--- a/airbyte-integrations/connectors/source-qualaroo/source_qualaroo/source.py
+++ b/airbyte-integrations/connectors/source-qualaroo/source_qualaroo/source.py
@@ -14,7 +14,7 @@ from airbyte_cdk.sources.streams import Stream
 from airbyte_cdk.sources.streams.http import HttpStream
 from airbyte_cdk.sources.streams.http.auth import HttpAuthenticator
 
-from .streams import Surveys, Responses, QualarooStream
+from .streams import QualarooStream, Responses, Surveys
 
 
 class QualarooAuthenticator(HttpAuthenticator):
@@ -31,8 +31,7 @@ class QualarooAuthenticator(HttpAuthenticator):
         token_header: str = "oauth_token",
     ):
         self._key = key
-        self._token = b64encode(b":".join(
-            (key.encode("latin1"), token.encode("latin1")))).strip().decode("ascii")
+        self._token = b64encode(b":".join((key.encode("latin1"), token.encode("latin1")))).strip().decode("ascii")
         self.auth_header = auth_header
         self.key_header = key_header
         self.token_header = token_header
@@ -61,8 +60,7 @@ class SourceQualaroo(AbstractSource):
 
             authenticator = self._get_authenticator(config)
 
-            response = requests.get(
-                url, headers=authenticator.get_auth_header())
+            response = requests.get(url, headers=authenticator.get_auth_header())
 
             response.raise_for_status()
             available_surveys = {row.get("id") for row in response.json()}
@@ -79,8 +77,7 @@ class SourceQualaroo(AbstractSource):
         """
         args = {}
         # convert start_date to epoch time for qualaroo API
-        args["start_date"] = pendulum.parse(
-            config["start_date"]).strftime("%s")
+        args["start_date"] = pendulum.parse(config["start_date"]).strftime("%s")
         args["survey_ids"] = config.get("survey_ids", [])
         args["authenticator"] = self._get_authenticator(config)
         return [Surveys(**args), Responses(**args)]

--- a/airbyte-integrations/connectors/source-qualaroo/source_qualaroo/spec.json
+++ b/airbyte-integrations/connectors/source-qualaroo/source_qualaroo/spec.json
@@ -4,11 +4,7 @@
     "$schema": "http://json-schema.org/draft-07/schema#",
     "title": "Qualaroo Spec",
     "type": "object",
-    "required": [
-      "token",
-      "key",
-      "start_date"
-    ],
+    "required": ["token", "key", "start_date"],
     "additionalProperties": true,
     "properties": {
       "token": {
@@ -28,9 +24,7 @@
         "title": "Start Date",
         "pattern": "^[0-9]{4}-[0-9]{2}-[0-9]{2}T[0-9]{2}:[0-9]{2}:[0-9]{2}.[0-9]{3}Z$",
         "description": "UTC date and time in the format 2017-01-25T00:00:00Z. Any data before this date will not be replicated.",
-        "examples": [
-          "2021-03-01T00:00:00.000Z"
-        ]
+        "examples": ["2021-03-01T00:00:00.000Z"]
       },
       "survey_ids": {
         "type": "array",
@@ -48,14 +42,7 @@
     "oauth2Specification": {
       "rootObject": [],
       "oauthFlowInitParameters": [],
-      "oauthFlowOutputParameters": [
-        [
-          "token"
-        ],
-        [
-          "key"
-        ]
-      ]
+      "oauthFlowOutputParameters": [["token"], ["key"]]
     }
   }
 }

--- a/airbyte-integrations/connectors/source-qualaroo/source_qualaroo/spec.json
+++ b/airbyte-integrations/connectors/source-qualaroo/source_qualaroo/spec.json
@@ -4,7 +4,11 @@
     "$schema": "http://json-schema.org/draft-07/schema#",
     "title": "Qualaroo Spec",
     "type": "object",
-    "required": ["token", "key", "start_date"],
+    "required": [
+      "token",
+      "key",
+      "start_date"
+    ],
     "additionalProperties": true,
     "properties": {
       "token": {
@@ -24,13 +28,15 @@
         "title": "Start Date",
         "pattern": "^[0-9]{4}-[0-9]{2}-[0-9]{2}T[0-9]{2}:[0-9]{2}:[0-9]{2}.[0-9]{3}Z$",
         "description": "UTC date and time in the format 2017-01-25T00:00:00Z. Any data before this date will not be replicated.",
-        "examples": ["2021-03-01T00:00:00.000Z"]
+        "examples": [
+          "2021-03-01T00:00:00.000Z"
+        ]
       },
       "survey_ids": {
         "type": "array",
         "items": {
           "type": "string",
-          "pattern": "^[0-9a-fA-F]{24}$"
+          "pattern": "^[0-9]{1,8}$"
         },
         "title": "Qualaroo survey IDs",
         "description": "IDs of the surveys from which you'd like to replicate data. If left empty, data from all surveys to which you have access will be replicated."
@@ -42,7 +48,14 @@
     "oauth2Specification": {
       "rootObject": [],
       "oauthFlowInitParameters": [],
-      "oauthFlowOutputParameters": [["token"], ["key"]]
+      "oauthFlowOutputParameters": [
+        [
+          "token"
+        ],
+        [
+          "key"
+        ]
+      ]
     }
   }
 }

--- a/airbyte-integrations/connectors/source-qualaroo/source_qualaroo/streams.py
+++ b/airbyte-integrations/connectors/source-qualaroo/source_qualaroo/streams.py
@@ -1,0 +1,104 @@
+#
+# Copyright (c) 2021 Airbyte, Inc., all rights reserved.
+#
+
+from abc import ABC
+from typing import Any, Iterable, List, Mapping, MutableMapping, Optional
+
+import pendulum
+import requests
+from airbyte_cdk.models import SyncMode
+from airbyte_cdk.sources.streams.http import HttpStream
+
+
+class QualarooStream(HttpStream, ABC):
+    url_base = "https://api.qualaroo.com/api/v1/"
+
+    # Define primary key as sort key for full_refresh, or very first sync for incremental_refresh
+    primary_key = "id"
+
+    # Page size
+    limit = 500
+
+    extra_params = None
+
+    def __init__(self, start_date: pendulum.datetime, survey_ids: List[str], **kwargs):
+        super().__init__(**kwargs)
+        self._start_date = start_date
+        self._survey_ids = survey_ids
+        self._offset = 0
+
+    def next_page_token(self, response: requests.Response) -> Optional[Mapping[str, Any]]:
+        resp_json = response.json()
+
+        if len(resp_json) == 500:
+            self._offset += 500
+            return {"offset": self._offset}
+
+    def request_params(
+        self, stream_state: Mapping[str, Any], stream_slice: Mapping[str, Any] = None, next_page_token: Mapping[str, Any] = None
+    ) -> MutableMapping[str, Any]:
+        params = {"limit": self.limit, "start_date": self._start_date}
+        if next_page_token:
+            params.update(**next_page_token)
+        if self.extra_params:
+            params.update(self.extra_params)
+        return params
+
+    def parse_response(self, response: requests.Response, **kwargs) -> Iterable[Mapping]:
+        json_response = response.json()
+        for record in json_response:
+            yield record
+
+
+class ChildStreamMixin:
+    parent_stream_class: Optional[QualarooStream] = None
+
+    def stream_slices(self, sync_mode, **kwargs) -> Iterable[Optional[Mapping[str, any]]]:
+        for item in self.parent_stream_class(config=self.config).read_records(sync_mode=sync_mode):
+            yield {"id": item["id"]}
+
+
+class Surveys(QualarooStream):
+    """Return list of all Surveys.
+    API Docs: https://help.qualaroo.com/hc/en-us/articles/201969438-The-REST-Reporting-API
+    Endpoint: https://api.qualaroo.com/api/v1/nudges/
+    """
+
+    def path(self, stream_slice: Mapping[str, Any] = None, **kwargs) -> str:
+        return "nudges"
+
+    def parse_response(self, response: requests.Response, **kwargs) -> Iterable[Mapping]:
+        survey_ids = self._survey_ids
+        result = super().parse_response(response=response, **kwargs)
+        for record in result:
+            if not survey_ids or str(record["id"]) in survey_ids:
+                yield record
+
+
+class Responses(ChildStreamMixin, QualarooStream):
+    """Return list of all responses of a survey.
+    API Docs: hhttps://help.qualaroo.com/hc/en-us/articles/201969438-The-REST-Reporting-API
+    Endpoint: https://api.qualaroo.com/api/v1/nudges/<id>/responses.json
+    """
+
+    parent_stream_class = Surveys
+
+    def path(self, stream_slice: Mapping[str, Any] = None, **kwargs) -> str:
+        survey_id = stream_slice["survey_id"]
+        return f"nudges/{survey_id}/responses.json"
+
+    def stream_slices(self, **kwargs):
+        survey_stream = Surveys(start_date=self._start_date,
+                                survey_ids=self._survey_ids, authenticator=self.authenticator)
+        for survey in survey_stream.read_records(sync_mode=SyncMode.full_refresh):
+            yield {"survey_id": survey["id"]}
+
+    def parse_response(self, response: requests.Response, **kwargs) -> Iterable[Mapping]:
+        response_data = response.json()
+        # de-nest the answered_questions object if exists
+        for rec in response_data:
+            if "answered_questions" in rec:
+                rec["answered_questions"] = list(
+                    rec["answered_questions"].values())
+        yield from response_data

--- a/airbyte-integrations/connectors/source-qualaroo/source_qualaroo/streams.py
+++ b/airbyte-integrations/connectors/source-qualaroo/source_qualaroo/streams.py
@@ -89,8 +89,7 @@ class Responses(ChildStreamMixin, QualarooStream):
         return f"nudges/{survey_id}/responses.json"
 
     def stream_slices(self, **kwargs):
-        survey_stream = Surveys(start_date=self._start_date,
-                                survey_ids=self._survey_ids, authenticator=self.authenticator)
+        survey_stream = Surveys(start_date=self._start_date, survey_ids=self._survey_ids, authenticator=self.authenticator)
         for survey in survey_stream.read_records(sync_mode=SyncMode.full_refresh):
             yield {"survey_id": survey["id"]}
 
@@ -99,6 +98,5 @@ class Responses(ChildStreamMixin, QualarooStream):
         # de-nest the answered_questions object if exists
         for rec in response_data:
             if "answered_questions" in rec:
-                rec["answered_questions"] = list(
-                    rec["answered_questions"].values())
+                rec["answered_questions"] = list(rec["answered_questions"].values())
         yield from response_data

--- a/airbyte-integrations/connectors/source-qualaroo/source_qualaroo/streams.py
+++ b/airbyte-integrations/connectors/source-qualaroo/source_qualaroo/streams.py
@@ -22,7 +22,7 @@ class QualarooStream(HttpStream, ABC):
 
     extra_params = None
 
-    def __init__(self, start_date: pendulum.datetime, survey_ids: List[str], **kwargs):
+    def __init__(self, start_date: pendulum.datetime, survey_ids: List[str] = [], **kwargs):
         super().__init__(**kwargs)
         self._start_date = start_date
         self._survey_ids = survey_ids
@@ -89,7 +89,8 @@ class Responses(ChildStreamMixin, QualarooStream):
         return f"nudges/{survey_id}/responses.json"
 
     def stream_slices(self, **kwargs):
-        survey_stream = Surveys(start_date=self._start_date, survey_ids=self._survey_ids, authenticator=self.authenticator)
+        survey_stream = Surveys(start_date=self._start_date,
+                                survey_ids=self._survey_ids, authenticator=self.authenticator)
         for survey in survey_stream.read_records(sync_mode=SyncMode.full_refresh):
             yield {"survey_id": survey["id"]}
 
@@ -98,5 +99,6 @@ class Responses(ChildStreamMixin, QualarooStream):
         # de-nest the answered_questions object if exists
         for rec in response_data:
             if "answered_questions" in rec:
-                rec["answered_questions"] = list(rec["answered_questions"].values())
+                rec["answered_questions"] = list(
+                    rec["answered_questions"].values())
         yield from response_data

--- a/airbyte-integrations/connectors/source-qualaroo/unit_tests/test_streams.py
+++ b/airbyte-integrations/connectors/source-qualaroo/unit_tests/test_streams.py
@@ -20,14 +20,14 @@ def patch_base_class(mocker):
 
 
 def test_request_params(patch_base_class, config):
-    stream = QualarooStream(config)
+    stream = QualarooStream(**config)
     inputs = {"stream_slice": None, "stream_state": None, "next_page_token": {"before": "id"}}
     expected_params = {"limit": 500, "start_date": "start_date", "before": "id"}
     assert stream.request_params(**inputs) == expected_params
 
 
 def test_next_page_token(patch_base_class, config):
-    stream = QualarooStream(config)
+    stream = QualarooStream(**config)
     inputs = {"response": MagicMock()}
     expected_token = None
     assert stream.next_page_token(**inputs) == expected_token
@@ -40,16 +40,18 @@ def test_surveys_stream(requests_mock):
         json=[{"id": "b11111111111111111111111", "name": "survey_1"}, {"id": "b22222222222222222222222", "name": "survey_2"}],
     )
 
-    config = {"authenticator": None, "start_date": "2021-02-11T08:35:49.540Z"}
-    stream1 = Surveys(config=config)
+    args = {"authenticator": None, "start_date": "2021-02-11T08:35:49.540Z", "survey_ids": []}
+    stream1 = Surveys(**args)
     records = read_all_records(stream1)
     assert records == [{"id": "b11111111111111111111111", "name": "survey_1"}, {"id": "b22222222222222222222222", "name": "survey_2"}]
 
-    stream2 = Surveys(config={**config, "survey_ids": ["b22222222222222222222222"]})
+    args["survey_ids"] = ["b22222222222222222222222"]
+    stream2 = Surveys(**args)
     records = read_all_records(stream2)
     assert records == [{"id": "b22222222222222222222222", "name": "survey_2"}]
 
-    stream3 = Surveys(config={**config, "survey_ids": ["not-found"]})
+    args["survey_ids"] = ["not-found"]
+    stream3 = Surveys(**args)
     records = read_all_records(stream3)
     assert records == []
 
@@ -75,8 +77,8 @@ def test_responses_stream(requests_mock):
         json=[{"id": "c33333333333333333333333", "name": "response_3"}, {"id": "c44444444444444444444444", "name": "response_4"}],
     )
 
-    config = {"authenticator": None, "start_date": "2021-02-11T08:35:49.540Z"}
-    stream1 = Responses(config=config)
+    args = {"authenticator": None, "start_date": "2021-02-11T08:35:49.540Z", "survey_ids": []}
+    stream1 = Responses(**args)
     records = read_all_records(stream1)
     assert records == [
         {"id": "c11111111111111111111111", "name": "response_1"},
@@ -85,11 +87,13 @@ def test_responses_stream(requests_mock):
         {"id": "c44444444444444444444444", "name": "response_4"},
     ]
 
-    stream2 = Responses(config={**config, "survey_ids": ["b22222222222222222222222"]})
+    args["survey_ids"] = ["b22222222222222222222222"]
+    stream2 = Responses(**args)
     records = read_all_records(stream2)
     assert records == [{"id": "c33333333333333333333333", "name": "response_3"}, {"id": "c44444444444444444444444", "name": "response_4"}]
 
-    stream3 = Responses(config={**config, "survey_ids": ["not-found"]})
+    args["survey_ids"] = ["not-found"]
+    stream3 = Responses(**args)
     records = read_all_records(stream3)
     assert records == []
 

--- a/docs/integrations/sources/qualaroo.md
+++ b/docs/integrations/sources/qualaroo.md
@@ -43,6 +43,7 @@ Please read [How to get your APIs Token and Key](https://help.qualaroo.com/hc/en
 
 | Version | Date | Pull Request | Subject |
 | :--- | :--- | :--- | :--- |
+| 0.1.2 | 2022-05-24 | [13121](https://github.com/airbytehq/airbyte/pull/13121) | Fix `start_date` and `survey_ids` schema formatting. Separate source and stream files. Add stream_slices |
 | 0.1.1 | 2022-05-20 | [13042](https://github.com/airbytehq/airbyte/pull/13042) | Update stream specs |
 | 0.1.0 | 2021-08-18 | [8623](https://github.com/airbytehq/airbyte/pull/8623) | New source: Qualaroo |
 


### PR DESCRIPTION
## What
- Fix issue with incorrect `survey_ids` schema
- Fix issue when `start_date` is not properly formatted to epoch time
- Add stream_slices
- Seperate streams and sources

## How
- Convert `start_date` to epoch time
- Convert `survey_ids` to strings for comparison

## Recommended reading order
1. `x.java`
2. `y.python`

## 🚨 User Impact 🚨
Are there any breaking changes? What is the end result perceived by the user? If yes, please merge this PR with the 🚨🚨 emoji so changelog authors can further highlight this if needed.

## Pre-merge Checklist
Expand the relevant checklist and delete the others.

<details><summary><strong>New Connector</strong></summary>

### Community member or Airbyter

- [ ] **Community member?** Grant edit access to maintainers ([instructions](https://docs.github.com/en/github/collaborating-with-pull-requests/working-with-forks/allowing-changes-to-a-pull-request-branch-created-from-a-fork#enabling-repository-maintainer-permissions-on-existing-pull-requests))
- [ ] Secrets in the connector's spec are annotated with `airbyte_secret`
- [ ] Unit & integration tests added and passing. Community members, please provide proof of success locally e.g: screenshot or copy-paste unit, integration, and acceptance test output. To run acceptance tests for a Python connector, follow instructions in the README. For java connectors run `./gradlew :airbyte-integrations:connectors:<name>:integrationTest`.
- [ ] Code reviews completed
- [ ] Documentation updated
    - [ ] Connector's `README.md`
    - [ ] Connector's `bootstrap.md`. See [description and examples](https://docs.google.com/document/d/1ypdgmwmEHWv-TrO4_YOQ7pAJGVrMp5BOkEVh831N260/edit?usp=sharing)
    - [ ] `docs/SUMMARY.md`
    - [ ] `docs/integrations/<source or destination>/<name>.md` including changelog. See changelog [example](https://docs.airbyte.io/integrations/sources/stripe#changelog)
    - [ ] `docs/integrations/README.md`
    - [ ] `airbyte-integrations/builds.md`
- [ ] PR name follows [PR naming conventions](https://docs.airbyte.io/contributing-to-airbyte/updating-documentation#issues-and-pull-requests)

### Airbyter

If this is a community PR, the Airbyte engineer reviewing this PR is responsible for the below items.

- [ ] Create a non-forked branch based on this PR and test the below items on it
- [ ] Build is successful
- [ ] If new credentials are required for use in CI, add them to GSM. [Instructions](https://docs.airbyte.io/connector-development#using-credentials-in-ci).
- [ ] [`/test connector=connectors/<name>` command](https://docs.airbyte.io/connector-development#updating-an-existing-connector) is passing
- [ ] New Connector version released on Dockerhub by running the `/publish` command described [here](https://docs.airbyte.io/connector-development#updating-an-existing-connector)
- [ ] After the connector is published, connector added to connector index as described [here](https://docs.airbyte.io/connector-development#publishing-a-connector)
- [ ] Seed specs have been re-generated by building the platform and committing the changes to the seed spec files, as described [here](https://docs.airbyte.io/connector-development#publishing-a-connector)

</details>

<details><summary><strong>Updating a connector</strong></summary>

### Community member or Airbyter

- [x] Grant edit access to maintainers ([instructions](https://docs.github.com/en/github/collaborating-with-pull-requests/working-with-forks/allowing-changes-to-a-pull-request-branch-created-from-a-fork#enabling-repository-maintainer-permissions-on-existing-pull-requests))
- [x] Secrets in the connector's spec are annotated with `airbyte_secret`
- [x] Unit & integration tests added and passing. Community members, please provide proof of success locally e.g: screenshot or copy-paste unit, integration, and acceptance test output. To run acceptance tests for a Python connector, follow instructions in the README. For java connectors run `./gradlew :airbyte-integrations:connectors:<name>:integrationTest`.
- [ ] Code reviews completed
- [x] Documentation updated
    - [x] Connector's `README.md`
    - [ ] Connector's `bootstrap.md`. See [description and examples](https://docs.google.com/document/d/1ypdgmwmEHWv-TrO4_YOQ7pAJGVrMp5BOkEVh831N260/edit?usp=sharing)
    - [x] Changelog updated in `docs/integrations/<source or destination>/<name>.md` including changelog. See changelog [example](https://docs.airbyte.io/integrations/sources/stripe#changelog)
- [ ] PR name follows [PR naming conventions](https://docs.airbyte.io/contributing-to-airbyte/updating-documentation#issues-and-pull-requests)

### Airbyter

If this is a community PR, the Airbyte engineer reviewing this PR is responsible for the below items.

- [ ] Create a non-forked branch based on this PR and test the below items on it
- [ ] Build is successful
- [ ] If new credentials are required for use in CI, add them to GSM. [Instructions](https://docs.airbyte.io/connector-development#using-credentials-in-ci).
- [ ] [`/test connector=connectors/<name>` command](https://docs.airbyte.io/connector-development#updating-an-existing-connector) is passing
- [ ] New Connector version released on Dockerhub and connector version bumped by running the `/publish` command described [here](https://docs.airbyte.io/connector-development#updating-an-existing-connector)

</details>

<details><summary><strong>Connector Generator</strong></summary>

- [ ] Issue acceptance criteria met
- [ ] PR name follows [PR naming conventions](https://docs.airbyte.io/contributing-to-airbyte/updating-documentation#issues-and-pull-requests)
- [ ] If adding a new generator, add it to the [list of scaffold modules being tested](https://github.com/airbytehq/airbyte/blob/master/airbyte-integrations/connector-templates/generator/build.gradle#L41)
- [ ] The generator test modules (all connectors with `-scaffold` in their name) have been updated with the latest scaffold by running `./gradlew :airbyte-integrations:connector-templates:generator:testScaffoldTemplates` then checking in your changes
- [ ] Documentation which references the generator is updated as needed

</details>

## Tests

<details><summary><strong>Unit</strong></summary>

```

➜ python -m pytest unit_tests
==================================================== test session starts =====================================================
platform darwin -- Python 3.9.12, pytest-6.2.5, py-1.11.0, pluggy-1.0.0 -- /Users/danieldiamond/.virtualenvs/airbyte/bin/python
cachedir: .pytest_cache
rootdir: /Users/danieldiamond/repos/airbyte, configfile: pytest.ini
plugins: requests-mock-1.9.3, mock-3.7.0
collected 4 items

unit_tests/test_streams.py::test_request_params PASSED
unit_tests/test_streams.py::test_next_page_token PASSED
unit_tests/test_streams.py::test_surveys_stream PASSED
unit_tests/test_streams.py::test_responses_stream PASSED

====================================================== warnings summary ======================================================
airbyte-integrations/connectors/source-qualaroo/unit_tests/test_streams.py: 11 warnings
  /Users/danieldiamond/.virtualenvs/airbyte/lib/python3.9/site-packages/airbyte_cdk/sources/streams/http/http.py:42: DeprecationWarning: Call to deprecated class NoAuth. (Set `authenticator=None` instead) -- Deprecated since version 0.1.20.
    self._authenticator: HttpAuthenticator = NoAuth()

airbyte-integrations/connectors/source-qualaroo/unit_tests/test_streams.py: 11 warnings
  /Users/danieldiamond/.virtualenvs/airbyte/lib/python3.9/site-packages/deprecated/classic.py:173: DeprecationWarning: Call to deprecated class HttpAuthenticator. (Use requests.auth.AuthBase instead) -- Deprecated since version 0.1.20.
    return old_new1(cls, *args, **kwargs)

-- Docs: https://docs.pytest.org/en/stable/warnings.html
=============================================== 4 passed, 22 warnings in 0.43s ===============================================
```
</details>

<details><summary><strong>Integration</strong></summary>

NA
</details>

<details><summary><strong>Acceptance</strong></summary>

NA
</details>
