### PR TITLE
Disable form inputs while testing and saving source and destination

### DIFF
--- a/airbyte-webapp/src/components/ArrayOfObjectsEditor/ArrayOfObjectsEditor.tsx
+++ b/airbyte-webapp/src/components/ArrayOfObjectsEditor/ArrayOfObjectsEditor.tsx
@@ -39,6 +39,7 @@ export interface ArrayOfObjectsEditorProps<T extends { name: string }> {
   onDone?: () => void;
   onRemove: (index: number) => void;
   mode?: ConnectionFormMode;
+  disabled?: boolean;
 }
 
 export function ArrayOfObjectsEditor<T extends { name: string } = { name: string }>({
@@ -52,10 +53,12 @@ export function ArrayOfObjectsEditor<T extends { name: string } = { name: string
   mainTitle,
   addButtonText,
   mode,
+  disabled,
 }: ArrayOfObjectsEditorProps<T>): JSX.Element {
   const onAddItem = React.useCallback(() => onStartEdit(items.length), [onStartEdit, items]);
 
   const isEditable = editableItemIndex !== null && editableItemIndex !== undefined;
+
   if (mode !== "readonly" && isEditable) {
     const item = typeof editableItemIndex === "number" ? items[editableItemIndex] : undefined;
     return (
@@ -64,12 +67,12 @@ export function ArrayOfObjectsEditor<T extends { name: string } = { name: string
         {onCancelEdit || onDone ? (
           <ButtonContainer>
             {onCancelEdit && (
-              <SmallButton onClick={onCancelEdit} type="button" secondary>
+              <SmallButton onClick={onCancelEdit} type="button" secondary disabled={disabled}>
                 <FormattedMessage id="form.cancel" />
               </SmallButton>
             )}
             {onDone && (
-              <SmallButton onClick={onDone} type="button" data-testid="done-button">
+              <SmallButton onClick={onDone} type="button" data-testid="done-button" disabled={disabled}>
                 <FormattedMessage id="form.done" />
               </SmallButton>
             )}
@@ -87,11 +90,19 @@ export function ArrayOfObjectsEditor<T extends { name: string } = { name: string
         mainTitle={mainTitle}
         addButtonText={addButtonText}
         mode={mode}
+        disabled={disabled}
       />
       {items.length ? (
         <ItemsList>
           {items.map((item, key) => (
-            <EditorRow key={`form-item-${key}`} name={item.name} id={key} onEdit={onStartEdit} onRemove={onRemove} />
+            <EditorRow
+              key={`form-item-${key}`}
+              name={item.name}
+              id={key}
+              onEdit={onStartEdit}
+              onRemove={onRemove}
+              disabled={disabled}
+            />
           ))}
         </ItemsList>
       ) : null}

--- a/airbyte-webapp/src/components/ArrayOfObjectsEditor/components/EditorHeader.tsx
+++ b/airbyte-webapp/src/components/ArrayOfObjectsEditor/components/EditorHeader.tsx
@@ -18,20 +18,28 @@ const Content = styled.div`
   margin: 5px 0;
 `;
 
-type EditorHeaderProps = {
+interface EditorHeaderProps {
   mainTitle?: React.ReactNode;
   addButtonText?: React.ReactNode;
   itemsCount: number;
   onAddItem: () => void;
   mode?: ConnectionFormMode;
-};
+  disabled?: boolean;
+}
 
-const EditorHeader: React.FC<EditorHeaderProps> = ({ itemsCount, onAddItem, mainTitle, addButtonText, mode }) => {
+const EditorHeader: React.FC<EditorHeaderProps> = ({
+  itemsCount,
+  onAddItem,
+  mainTitle,
+  addButtonText,
+  mode,
+  disabled,
+}) => {
   return (
     <Content>
       {mainTitle || <FormattedMessage id="form.items" values={{ count: itemsCount }} />}
       {mode !== "readonly" && (
-        <Button secondary type="button" onClick={onAddItem} data-testid="addItemButton">
+        <Button secondary type="button" onClick={onAddItem} data-testid="addItemButton" disabled={disabled}>
           {addButtonText || <FormattedMessage id="form.addItems" />}
         </Button>
       )}

--- a/airbyte-webapp/src/components/ArrayOfObjectsEditor/components/EditorRow.tsx
+++ b/airbyte-webapp/src/components/ArrayOfObjectsEditor/components/EditorRow.tsx
@@ -1,7 +1,7 @@
 import { faTimes } from "@fortawesome/free-solid-svg-icons";
 import { FontAwesomeIcon } from "@fortawesome/react-fontawesome";
 import React from "react";
-import { FormattedMessage } from "react-intl";
+import { FormattedMessage, useIntl } from "react-intl";
 import styled from "styled-components";
 
 import { Button } from "components";
@@ -23,31 +23,32 @@ const Content = styled.div`
   }
 `;
 
-const Delete = styled(FontAwesomeIcon)`
-  color: ${({ theme }) => theme.greyColor55};
-  font-weight: 300;
-  font-size: 14px;
-  line-height: 24px;
+const DeleteButton = styled(Button)`
   margin-left: 7px;
-  cursor: pointer;
 `;
 
-type EditorRowProps = {
+interface EditorRowProps {
   name: string;
   id: number;
   onEdit: (id: number) => void;
   onRemove: (id: number) => void;
-};
+  disabled?: boolean;
+}
 
-const EditorRow: React.FC<EditorRowProps> = ({ name, id, onEdit, onRemove }) => {
+const EditorRow: React.FC<EditorRowProps> = ({ name, id, onEdit, onRemove, disabled }) => {
+  const { formatMessage } = useIntl();
+  const buttonLabel = formatMessage({ id: "form.delete" });
+
   return (
     <Content>
       <div>{name || id}</div>
       <div>
-        <Button secondary onClick={() => onEdit(id)} type="button">
+        <Button secondary onClick={() => onEdit(id)} type="button" disabled={disabled}>
           <FormattedMessage id="form.edit" />
         </Button>
-        <Delete icon={faTimes} onClick={() => onRemove(id)} />
+        <DeleteButton iconOnly onClick={() => onRemove(id)} disabled={disabled} aria-label={buttonLabel}>
+          <FontAwesomeIcon icon={faTimes} />
+        </DeleteButton>
       </div>
     </Content>
   );

--- a/airbyte-webapp/src/components/base/DropDown/DropDown.tsx
+++ b/airbyte-webapp/src/components/base/DropDown/DropDown.tsx
@@ -14,13 +14,14 @@ import { SelectContainer } from "./SelectContainer";
 
 // eslint-disable-next-line @typescript-eslint/no-explicit-any
 export type OptionType = any;
-type DropdownProps = Props<OptionType> & {
+
+export interface DropdownProps extends Props<OptionType> {
   withBorder?: boolean;
   fullText?: boolean;
   error?: boolean;
-};
+}
 
-const DropDown: React.FC<DropdownProps> = React.forwardRef((props, ref) => {
+export const DropDown: React.FC<DropdownProps> = React.forwardRef((props, ref) => {
   const propsComponents = props.components;
 
   const components = React.useMemo<SelectComponentsConfig<OptionType, boolean>>(
@@ -77,8 +78,6 @@ const DropDown: React.FC<DropdownProps> = React.forwardRef((props, ref) => {
   );
 });
 
-const defaultDataItemSort = naturalComparatorBy<IDataItem>((dataItem) => dataItem.label || "");
+export const defaultDataItemSort = naturalComparatorBy<IDataItem>((dataItem) => dataItem.label || "");
 
 export default DropDown;
-export { DropDown, defaultDataItemSort };
-export type { DropdownProps };

--- a/airbyte-webapp/src/components/base/Input/Input.tsx
+++ b/airbyte-webapp/src/components/base/Input/Input.tsx
@@ -35,10 +35,11 @@ const InputContainer = styled.div<InputProps>`
   ${({ disabled, theme, light, error }) =>
     !disabled &&
     `
-  &:not(.input-container--disabled):hover {
-    background: ${light ? theme.whiteColor : theme.greyColor20};
-    border-color: ${error ? theme.dangerColor : theme.greyColor20};
-  }`}
+      &:hover {
+        background: ${light ? theme.whiteColor : theme.greyColor20};
+        border-color: ${error ? theme.dangerColor : theme.greyColor20};
+      }
+    `}
 
   &.input-container--focused {
     background: ${({ theme, light }) => (light ? theme.whiteColor : theme.primaryColor12)};

--- a/airbyte-webapp/src/components/base/Input/Input.tsx
+++ b/airbyte-webapp/src/components/base/Input/Input.tsx
@@ -32,10 +32,13 @@ const InputContainer = styled.div<InputProps>`
   border: 1px solid ${(props) => (props.error ? props.theme.dangerColor : props.theme.greyColor0)};
   border-radius: 4px;
 
-  &:hover {
-    background: ${({ theme, light }) => (light ? theme.whiteColor : theme.greyColor20)};
-    border-color: ${(props) => (props.error ? props.theme.dangerColor : props.theme.greyColor20)};
-  }
+  ${({ disabled, theme, light, error }) =>
+    !disabled &&
+    `
+  &:not(.input-container--disabled):hover {
+    background: ${light ? theme.whiteColor : theme.greyColor20};
+    border-color: ${error ? theme.dangerColor : theme.greyColor20};
+  }`}
 
   &.input-container--focused {
     background: ${({ theme, light }) => (light ? theme.whiteColor : theme.primaryColor12)};
@@ -45,7 +48,7 @@ const InputContainer = styled.div<InputProps>`
 
 const InputComponent = styled.input<InputProps & { isPassword?: boolean }>`
   outline: none;
-  width: ${({ isPassword }) => (isPassword ? "calc(100% - 22px)" : "100%")};
+  width: ${({ isPassword, disabled }) => (isPassword && !disabled ? "calc(100% - 22px)" : "100%")};
   padding: 7px 8px 7px 8px;
   font-size: 14px;
   line-height: 20px;

--- a/airbyte-webapp/src/components/base/TagInput/TagInput.tsx
+++ b/airbyte-webapp/src/components/base/TagInput/TagInput.tsx
@@ -3,7 +3,7 @@ import styled from "styled-components";
 
 import TagItem, { IItemProps } from "./TagItem";
 
-const MainContainer = styled.div<{ error?: boolean }>`
+const MainContainer = styled.div<{ error?: boolean; disabled?: boolean }>`
   width: 100%;
   min-height: 36px;
   border-radius: 4px;
@@ -19,10 +19,14 @@ const MainContainer = styled.div<{ error?: boolean }>`
   background: ${(props) => (props.error ? props.theme.greyColor10 : props.theme.greyColor0)};
   caret-color: ${({ theme }) => theme.primaryColor};
 
-  &:hover {
-    background: ${({ theme }) => theme.greyColor20};
-    border-color: ${(props) => (props.error ? props.theme.dangerColor : props.theme.greyColor20)};
-  }
+  ${({ disabled, theme, error }) =>
+    !disabled &&
+    `
+      &:hover {
+        background: ${theme.greyColor20};
+        border-color: ${error ? theme.dangerColor : theme.greyColor20};
+      }
+    `}
 
   &:focus,
   &:focus-within {
@@ -47,7 +51,7 @@ const InputElement = styled.input`
   }
 `;
 
-type TagInputProps = {
+export interface TagInputProps {
   inputProps?: React.InputHTMLAttributes<HTMLInputElement>;
   value: IItemProps[];
   className?: string;
@@ -60,9 +64,9 @@ type TagInputProps = {
   onEnter: (value?: string | number | readonly string[]) => void;
   onDelete: (value: string) => void;
   onError?: () => void;
-};
+}
 
-const TagInput: React.FC<TagInputProps> = ({
+export const TagInput: React.FC<TagInputProps> = ({
   inputProps,
   onEnter,
   value,
@@ -131,7 +135,13 @@ const TagInput: React.FC<TagInputProps> = ({
   const inputPlaceholder = !value.length && inputProps?.placeholder ? inputProps.placeholder : "";
 
   return (
-    <MainContainer onBlur={handleContainerBlur} onClick={handleContainerClick} className={className} error={error}>
+    <MainContainer
+      onBlur={handleContainerBlur}
+      onClick={handleContainerClick}
+      className={className}
+      error={error}
+      disabled={disabled}
+    >
       {value.map((item, key) => (
         <TagItem
           disabled={disabled}
@@ -159,6 +169,3 @@ const TagInput: React.FC<TagInputProps> = ({
     </MainContainer>
   );
 };
-
-export { TagInput };
-export type { TagInputProps };

--- a/airbyte-webapp/src/core/form/types.ts
+++ b/airbyte-webapp/src/core/form/types.ts
@@ -48,3 +48,6 @@ export type { FormBlock, FormConditionItem, FormGroupItem, FormObjectArrayItem }
 // eslint-disable-next-line @typescript-eslint/no-explicit-any
 export type WidgetConfig = { [key: string]: any };
 export type WidgetConfigMap = { [key: string]: WidgetConfig };
+
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+export type FormComponentOverrideProps = Record<string, any>;

--- a/airbyte-webapp/src/views/Connector/ServiceForm/FormRoot.tsx
+++ b/airbyte-webapp/src/views/Connector/ServiceForm/FormRoot.tsx
@@ -53,7 +53,7 @@ const FormRoot: React.FC<FormRootProps> = ({
 
   return (
     <FormContainer>
-      <FormSection blocks={formFields} />
+      <FormSection blocks={formFields} disabled={isSubmitting || isTestConnectionInProgress} />
       {isLoadingSchema && (
         <LoaderContainer>
           <Spinner />

--- a/airbyte-webapp/src/views/Connector/ServiceForm/ServiceForm.tsx
+++ b/airbyte-webapp/src/views/Connector/ServiceForm/ServiceForm.tsx
@@ -8,7 +8,7 @@ import { FormChangeTracker } from "components/FormChangeTracker";
 import { ConnectorDefinition, ConnectorDefinitionSpecification } from "core/domain/connector";
 import { isDestinationDefinitionSpecification } from "core/domain/connector/destination";
 import { isSourceDefinition, isSourceDefinitionSpecification } from "core/domain/connector/source";
-import { FormBaseItem } from "core/form/types";
+import { FormBaseItem, FormComponentOverrideProps } from "core/form/types";
 import { useFormChangeTrackerService, useUniqueFormId } from "hooks/services/FormChangeTracker";
 import { isDefined } from "utils/common";
 import RequestConnectorModal from "views/Connector/RequestConnectorModal";
@@ -174,10 +174,12 @@ const ServiceForm: React.FC<ServiceFormProps> = (props) => {
   const uiOverrides = useMemo(
     () => ({
       name: {
-        component: (property: FormBaseItem) => <ConnectorNameControl property={property} formType={formType} />,
+        component: (property: FormBaseItem, componentProps: FormComponentOverrideProps) => (
+          <ConnectorNameControl property={property} formType={formType} {...componentProps} />
+        ),
       },
       serviceType: {
-        component: (property: FormBaseItem) => (
+        component: (property: FormBaseItem, componentProps: FormComponentOverrideProps) => (
           <ConnectorServiceTypeControl
             property={property}
             formType={formType}
@@ -189,6 +191,7 @@ const ServiceForm: React.FC<ServiceFormProps> = (props) => {
               setInitialRequestName(name);
               toggleOpenRequestModal();
             }}
+            {...componentProps}
           />
         ),
       },

--- a/airbyte-webapp/src/views/Connector/ServiceForm/components/Controls/ConnectorNameControl.tsx
+++ b/airbyte-webapp/src/views/Connector/ServiceForm/components/Controls/ConnectorNameControl.tsx
@@ -6,11 +6,14 @@ import { Input, ControlLabels } from "components";
 
 import { FormBaseItem } from "core/form/types";
 
-const ConnectorNameControl: React.FC<{
+interface ConnnectorNameControlProps {
   property: FormBaseItem;
   formType: "source" | "destination";
-}> = ({ property, formType }) => {
-  const formatMessage = useIntl().formatMessage;
+  disabled?: boolean;
+}
+
+export const ConnectorNameControl: React.FC<ConnnectorNameControlProps> = ({ property, formType, disabled }) => {
+  const { formatMessage } = useIntl();
   const [field, fieldMeta] = useField(property.path);
 
   return (
@@ -28,9 +31,8 @@ const ConnectorNameControl: React.FC<{
         placeholder={formatMessage({
           id: `form.${formType}Name.placeholder`,
         })}
+        disabled={disabled}
       />
     </ControlLabels>
   );
 };
-
-export { ConnectorNameControl };

--- a/airbyte-webapp/src/views/Connector/ServiceForm/components/Controls/ConnectorServiceTypeControl.tsx
+++ b/airbyte-webapp/src/views/Connector/ServiceForm/components/Controls/ConnectorServiceTypeControl.tsx
@@ -152,7 +152,7 @@ const SingleValue: React.FC<SingleValueProps> = (props) => {
   );
 };
 
-const ConnectorServiceTypeControl: React.FC<{
+interface ConnectorServiceTypeControlProps {
   property: FormBaseItem;
   formType: "source" | "destination";
   availableServices: ConnectorDefinition[];
@@ -160,7 +160,10 @@ const ConnectorServiceTypeControl: React.FC<{
   documentationUrl?: string;
   onChangeServiceType?: (id: string) => void;
   onOpenRequestConnectorModal: (initialName: string) => void;
-}> = ({
+  disabled?: boolean;
+}
+
+const ConnectorServiceTypeControl: React.FC<ConnectorServiceTypeControlProps> = ({
   property,
   formType,
   isEditMode,
@@ -168,6 +171,7 @@ const ConnectorServiceTypeControl: React.FC<{
   availableServices,
   documentationUrl,
   onOpenRequestConnectorModal,
+  disabled,
 }) => {
   const { formatMessage } = useIntl();
   const orderOverwrite = useExperiment("connector.orderOverwrite", {});
@@ -278,7 +282,7 @@ const ConnectorServiceTypeControl: React.FC<{
           }}
           selectProps={{ onOpenRequestConnectorModal }}
           error={!!fieldMeta.error && fieldMeta.touched}
-          isDisabled={isEditMode}
+          isDisabled={isEditMode || disabled}
           isSearchable
           placeholder={formatMessage({
             id: "form.selectConnector",

--- a/airbyte-webapp/src/views/Connector/ServiceForm/components/Property/ConfirmationControl.tsx
+++ b/airbyte-webapp/src/views/Connector/ServiceForm/components/Property/ConfirmationControl.tsx
@@ -15,14 +15,15 @@ const SmallButton = styled(Button)`
   padding: 6px 8px 7px;
 `;
 
-type ConfirmationControlProps = {
+interface ConfirmationControlProps {
   component: React.ReactElement;
   showButtons?: boolean;
   isEditInProgress?: boolean;
   onStart: () => void;
   onCancel: () => void;
   onDone: () => void;
-};
+  disabled?: boolean;
+}
 
 const ConfirmationControl: React.FC<ConfirmationControlProps> = ({
   isEditInProgress,
@@ -31,6 +32,7 @@ const ConfirmationControl: React.FC<ConfirmationControlProps> = ({
   onCancel,
   onDone,
   component,
+  disabled,
 }) => {
   const controlRef = useRef<HTMLElement>(null);
 
@@ -51,19 +53,19 @@ const ConfirmationControl: React.FC<ConfirmationControlProps> = ({
       {React.cloneElement(component, {
         ref: controlRef,
         autoFocus: isEditInProgress,
-        disabled: !isEditInProgress,
+        disabled: !isEditInProgress || disabled,
       })}
       {isEditInProgress ? (
         <>
-          <SmallButton onClick={onDone} type="button">
+          <SmallButton onClick={onDone} type="button" disabled={disabled}>
             <FormattedMessage id="form.done" />
           </SmallButton>
-          <SmallButton onClick={onCancel} type="button" secondary>
+          <SmallButton onClick={onCancel} type="button" secondary disabled={disabled}>
             <FormattedMessage id="form.cancel" />
           </SmallButton>
         </>
       ) : (
-        <SmallButton onClick={handleStartEdit} type="button">
+        <SmallButton onClick={handleStartEdit} type="button" disabled={disabled}>
           <FormattedMessage id="form.edit" />
         </SmallButton>
       )}

--- a/airbyte-webapp/src/views/Connector/ServiceForm/components/Property/Control.tsx
+++ b/airbyte-webapp/src/views/Connector/ServiceForm/components/Property/Control.tsx
@@ -8,15 +8,23 @@ import { isDefined } from "utils/common";
 
 import ConfirmationControl from "./ConfirmationControl";
 
-type IProps = {
+interface ControlProps {
   property: FormBaseItem;
   name: string;
   unfinishedFlows: Record<string, { startValue: string }>;
   addUnfinishedFlow: (key: string, info?: Record<string, unknown>) => void;
   removeUnfinishedFlow: (key: string) => void;
-};
+  disabled?: boolean;
+}
 
-const Control: React.FC<IProps> = ({ property, name, addUnfinishedFlow, removeUnfinishedFlow, unfinishedFlows }) => {
+export const Control: React.FC<ControlProps> = ({
+  property,
+  name,
+  addUnfinishedFlow,
+  removeUnfinishedFlow,
+  unfinishedFlows,
+  disabled,
+}) => {
   const [field, meta, form] = useField(name);
 
   // TODO: think what to do with other cases
@@ -51,6 +59,7 @@ const Control: React.FC<IProps> = ({ property, name, addUnfinishedFlow, removeUn
             onDelete={(item) => arrayHelpers.remove(Number.parseInt(item))}
             addOnBlur
             error={!!meta.error}
+            disabled={disabled}
           />
         )}
       />
@@ -69,6 +78,7 @@ const Control: React.FC<IProps> = ({ property, name, addUnfinishedFlow, removeUn
         data={data}
         onChange={(dataItems) => form.setValue(dataItems)}
         value={field.value}
+        disabled={disabled}
       />
     );
   }
@@ -85,10 +95,20 @@ const Control: React.FC<IProps> = ({ property, name, addUnfinishedFlow, removeUn
         }))}
         onChange={(selectedItem) => selectedItem && form.setValue(selectedItem.value)}
         value={value}
+        isDisabled={disabled}
       />
     );
   } else if (property.multiline && !property.isSecret) {
-    return <TextArea {...field} placeholder={placeholder} autoComplete="off" value={value ?? ""} rows={3} />;
+    return (
+      <TextArea
+        {...field}
+        placeholder={placeholder}
+        autoComplete="off"
+        value={value ?? ""}
+        rows={3}
+        disabled={disabled}
+      />
+    );
   } else if (property.isSecret) {
     const unfinishedSecret = unfinishedFlows[name];
     const isEditInProgress = !!unfinishedSecret;
@@ -97,9 +117,23 @@ const Control: React.FC<IProps> = ({ property, name, addUnfinishedFlow, removeUn
       <ConfirmationControl
         component={
           property.multiline && (isEditInProgress || !isFormInEditMode) ? (
-            <TextArea {...field} autoComplete="off" placeholder={placeholder} value={value ?? ""} rows={3} />
+            <TextArea
+              {...field}
+              autoComplete="off"
+              placeholder={placeholder}
+              value={value ?? ""}
+              rows={3}
+              disabled={disabled}
+            />
           ) : (
-            <Input {...field} autoComplete="off" placeholder={placeholder} value={value ?? ""} type="password" />
+            <Input
+              {...field}
+              autoComplete="off"
+              placeholder={placeholder}
+              value={value ?? ""}
+              type="password"
+              disabled={disabled}
+            />
           )
         }
         showButtons={isFormInEditMode}
@@ -115,13 +149,21 @@ const Control: React.FC<IProps> = ({ property, name, addUnfinishedFlow, removeUn
             form.setValue(unfinishedSecret.startValue);
           }
         }}
+        disabled={disabled}
       />
     );
   } else {
     const inputType = property.type === "integer" ? "number" : "text";
 
-    return <Input {...field} placeholder={placeholder} autoComplete="off" type={inputType} value={value ?? ""} />;
+    return (
+      <Input
+        {...field}
+        placeholder={placeholder}
+        autoComplete="off"
+        type={inputType}
+        value={value ?? ""}
+        disabled={disabled}
+      />
+    );
   }
 };
-
-export { Control };

--- a/airbyte-webapp/src/views/Connector/ServiceForm/components/Sections/ArraySection.tsx
+++ b/airbyte-webapp/src/views/Connector/ServiceForm/components/Sections/ArraySection.tsx
@@ -10,16 +10,19 @@ import { useServiceForm } from "../../serviceFormContext";
 import { SectionContainer } from "./common";
 import { FormSection } from "./FormSection";
 
+interface ArraySectionProps {
+  formField: FormObjectArrayItem;
+  path: string;
+  disabled?: boolean;
+}
+
 /**
  * ArraySection is responsible for handling array of objects
  * @param formField
  * @param path
  * @constructor
  */
-export const ArraySection: React.FC<{
-  formField: FormObjectArrayItem;
-  path: string;
-}> = ({ formField, path }) => {
+export const ArraySection: React.FC<ArraySectionProps> = ({ formField, path, disabled }) => {
   const { addUnfinishedFlow, removeUnfinishedFlow, unfinishedFlows } = useServiceForm();
   const [field, , form] = useField(path);
 
@@ -55,8 +58,11 @@ export const ArraySection: React.FC<{
               }}
               onRemove={arrayHelpers.remove}
               items={items}
+              disabled={disabled}
             >
-              {() => <FormSection blocks={formField.properties} path={`${path}.${flow.id}`} skipAppend />}
+              {() => (
+                <FormSection blocks={formField.properties} path={`${path}.${flow.id}`} disabled={disabled} skipAppend />
+              )}
             </ArrayOfObjectsEditor>
           )}
         />

--- a/airbyte-webapp/src/views/Connector/ServiceForm/components/Sections/ConditionSection.tsx
+++ b/airbyte-webapp/src/views/Connector/ServiceForm/components/Sections/ConditionSection.tsx
@@ -26,13 +26,16 @@ const ConditionControls = styled.div`
   padding-top: 25px;
 `;
 
+interface ConditionSectionProps {
+  formField: FormConditionItem;
+  path?: string;
+  disabled?: boolean;
+}
+
 /**
  * ConditionSection is responsible for handling oneOf sections of form
  */
-export const ConditionSection: React.FC<{
-  formField: FormConditionItem;
-  path?: string;
-}> = ({ formField, path }) => {
+export const ConditionSection: React.FC<ConditionSectionProps> = ({ formField, path, disabled }) => {
   const { widgetsInfo, setUiWidgetsInfo } = useServiceForm();
   const { values, setValues } = useFormikContext<ServiceFormValues>();
 
@@ -83,12 +86,18 @@ export const ConditionSection: React.FC<{
             onChange={onOptionChange}
             value={currentlySelectedCondition}
             name={formField.path}
+            isDisabled={disabled}
           />
         </>
       }
     >
       <ConditionControls>
-        <FormSection blocks={formField.conditions[currentlySelectedCondition]} path={path} skipAppend />
+        <FormSection
+          blocks={formField.conditions[currentlySelectedCondition]}
+          path={path}
+          disabled={disabled}
+          skipAppend
+        />
       </ConditionControls>
     </GroupControls>
   );

--- a/airbyte-webapp/src/views/Connector/ServiceForm/components/Sections/FormSection.tsx
+++ b/airbyte-webapp/src/views/Connector/ServiceForm/components/Sections/FormSection.tsx
@@ -10,33 +10,41 @@ import { SectionContainer } from "./common";
 import { ConditionSection } from "./ConditionSection";
 import { PropertySection } from "./PropertySection";
 
-const FormNode: React.FC<{
+interface FormNodeProps {
   sectionPath: string;
   formField: FormBlock;
-}> = ({ sectionPath, formField }) => {
+  disabled?: boolean;
+}
+
+const FormNode: React.FC<FormNodeProps> = ({ sectionPath, formField, disabled }) => {
   if (formField._type === "formGroup") {
-    return <FormSection path={sectionPath} blocks={formField.properties} hasOauth={formField.hasOauth} />;
+    return (
+      <FormSection path={sectionPath} blocks={formField.properties} hasOauth={formField.hasOauth} disabled={disabled} />
+    );
   } else if (formField._type === "formCondition") {
-    return <ConditionSection path={sectionPath} formField={formField} />;
+    return <ConditionSection path={sectionPath} formField={formField} disabled={disabled} />;
   } else if (formField._type === "objectArray") {
-    return <ArraySection path={sectionPath} formField={formField} />;
+    return <ArraySection path={sectionPath} formField={formField} disabled={disabled} />;
   } else if (formField.const !== undefined) {
     return null;
   } else {
     return (
       <SectionContainer>
-        <PropertySection property={formField} path={sectionPath} />
+        <PropertySection property={formField} path={sectionPath} disabled={disabled} />
       </SectionContainer>
     );
   }
 };
 
-const FormSection: React.FC<{
+interface FormSectionProps {
   blocks: FormBlock[] | FormBlock;
   path?: string;
   skipAppend?: boolean;
   hasOauth?: boolean;
-}> = ({ blocks = [], path, skipAppend, hasOauth }) => {
+  disabled?: boolean;
+}
+
+const FormSection: React.FC<FormSectionProps> = ({ blocks = [], path, skipAppend, hasOauth, disabled }) => {
   const sections = useMemo(() => {
     const flattenedBlocks = [blocks].flat();
 
@@ -70,7 +78,7 @@ const FormSection: React.FC<{
           return (
             <React.Fragment key={sectionPath}>
               {isAuthSection && <AuthSection />}
-              <FormNode formField={formField} sectionPath={sectionPath} />
+              <FormNode formField={formField} sectionPath={sectionPath} disabled={disabled} />
             </React.Fragment>
           );
         })}

--- a/airbyte-webapp/src/views/Connector/ServiceForm/components/Sections/PropertySection.tsx
+++ b/airbyte-webapp/src/views/Connector/ServiceForm/components/Sections/PropertySection.tsx
@@ -9,7 +9,13 @@ import { useServiceForm } from "../../serviceFormContext";
 import { Control } from "../Property/Control";
 import { Label } from "../Property/Label";
 
-const PropertySection: React.FC<{ property: FormBaseItem; path?: string }> = ({ property, path }) => {
+interface PropertySectionProps {
+  property: FormBaseItem;
+  path?: string;
+  disabled?: boolean;
+}
+
+const PropertySection: React.FC<PropertySectionProps> = ({ property, path, disabled }) => {
   const propertyPath = path ?? property.path;
   const formikBag = useField(propertyPath);
   const [field, meta] = formikBag;
@@ -17,7 +23,7 @@ const PropertySection: React.FC<{ property: FormBaseItem; path?: string }> = ({ 
 
   const overriddenComponent = widgetsInfo[propertyPath]?.component;
   if (overriddenComponent) {
-    return <>{overriddenComponent(property)}</>;
+    return <>{overriddenComponent(property, { disabled })}</>;
   }
 
   if (property.type === "boolean") {
@@ -27,6 +33,7 @@ const PropertySection: React.FC<{ property: FormBaseItem; path?: string }> = ({ 
         label={property.title || property.fieldKey}
         message={<TextWithHTML text={property.description} />}
         value={field.value ?? property.default}
+        disabled={disabled}
       />
     );
   }
@@ -39,6 +46,7 @@ const PropertySection: React.FC<{ property: FormBaseItem; path?: string }> = ({ 
         addUnfinishedFlow={addUnfinishedFlow}
         removeUnfinishedFlow={removeUnfinishedFlow}
         unfinishedFlows={unfinishedFlows}
+        disabled={disabled}
       />
     </Label>
   );


### PR DESCRIPTION
## What
This disables all inputs while the user is saving or testing a source or destination.

Fixes airbytehq/airbyte#12575

## How
It adds disabled fields to all the components. Additionally:
* Replaces delete button in EditorRow with real button
* Fixed input and tagged input disabled state so it doesn't hover on disable
* TypeScript cleanup: Moving types to interfaces and fix a few indirect exports

## Recommended reading order
Top to bottom

## Tests

Tested:
1. Creating a new source and destination
2. Editing a source and destination
3. Sources or destinations with conditional fields, array fields, tagged inputs
4. Run and cancel test source/destination
