### PR TITLE
🎉 Source Amazon Ads: increase SAT test_read timeout (900 seconds)

### DIFF
--- a/airbyte-integrations/connectors/source-amazon-ads/acceptance-test-config.yml
+++ b/airbyte-integrations/connectors/source-amazon-ads/acceptance-test-config.yml
@@ -22,7 +22,7 @@ tests:
         extra_fields: no
         exact_order: no
         extra_records: no
-      timeout_seconds: 600
+      timeout_seconds: 900
     - config_path: "secrets/config.json"
       configured_catalog_path: "integration_tests/configured_catalog_sponsored_display.json"
       empty_streams: ["sponsored_display_targetings"]
@@ -34,6 +34,6 @@ tests:
   full_refresh:
     - config_path: "secrets/config_test_account.json"
       configured_catalog_path: "integration_tests/configured_catalog.json"
-      timeout_seconds: 1500
+      timeout_seconds: 1800
     - config_path: "secrets/config.json"
       configured_catalog_path: "integration_tests/configured_catalog_sponsored_display.json"


### PR DESCRIPTION
Signed-off-by: Sergey Chvalyuk <grubberr@gmail.com>

## What
increase SAT test_read timeout: 900 sec