### PR TITLE
renames in `DefaultAirbyteDestination` to disambiguate from Airbyte Protocol

### DIFF
--- a/airbyte-integrations/bases/standard-destination-test/src/main/java/io/airbyte/integrations/standardtest/destination/DestinationAcceptanceTest.java
+++ b/airbyte-integrations/bases/standard-destination-test/src/main/java/io/airbyte/integrations/standardtest/destination/DestinationAcceptanceTest.java
@@ -1085,7 +1085,7 @@ public abstract class DestinationAcceptanceTest {
 
     destination.start(destinationConfig, jobRoot);
     messages.forEach(message -> Exceptions.toRuntime(() -> destination.accept(message)));
-    destination.notifyEndOfStream();
+    destination.notifyEndOfInput();
 
     final List<AirbyteMessage> destinationOutput = new ArrayList<>();
     while (!destination.isFinished()) {
@@ -1344,7 +1344,7 @@ public abstract class DestinationAcceptanceTest {
         .format("Added %s messages to each of %s streams", currentRecordNumberForStream,
             currentStreamNumber));
     // Close destination
-    destination.notifyEndOfStream();
+    destination.notifyEndOfInput();
   }
 
   private final static String LOREM_IPSUM =

--- a/airbyte-integrations/bases/standard-destination-test/src/main/java/io/airbyte/integrations/standardtest/destination/LocalAirbyteDestination.java
+++ b/airbyte-integrations/bases/standard-destination-test/src/main/java/io/airbyte/integrations/standardtest/destination/LocalAirbyteDestination.java
@@ -40,7 +40,7 @@ public class LocalAirbyteDestination implements AirbyteDestination {
   }
 
   @Override
-  public void notifyEndOfStream() {
+  public void notifyEndOfInput() {
     // nothing to do here
   }
 

--- a/airbyte-workers/src/main/java/io/airbyte/workers/general/DefaultReplicationWorker.java
+++ b/airbyte-workers/src/main/java/io/airbyte/workers/general/DefaultReplicationWorker.java
@@ -350,7 +350,7 @@ public class DefaultReplicationWorker implements ReplicationWorker {
         }
 
         try {
-          destination.notifyEndOfStream();
+          destination.notifyEndOfInput();
         } catch (final Exception e) {
           throw new DestinationException("Destination process end of stream notification failed", e);
         }

--- a/airbyte-workers/src/main/java/io/airbyte/workers/internal/AirbyteDestination.java
+++ b/airbyte-workers/src/main/java/io/airbyte/workers/internal/AirbyteDestination.java
@@ -49,7 +49,7 @@ public interface AirbyteDestination extends CheckedConsumer<AirbyteMessage, Exce
    *
    * @throws Exception - throws if there is any failure when flushing.
    */
-  void notifyEndOfStream() throws Exception;
+  void notifyEndOfInput() throws Exception;
 
   /**
    * Means no more data will be emitted by the Destination. This may be because all data has already

--- a/airbyte-workers/src/main/java/io/airbyte/workers/internal/DefaultAirbyteDestination.java
+++ b/airbyte-workers/src/main/java/io/airbyte/workers/internal/DefaultAirbyteDestination.java
@@ -42,7 +42,7 @@ public class DefaultAirbyteDestination implements AirbyteDestination {
   private final IntegrationLauncher integrationLauncher;
   private final AirbyteStreamFactory streamFactory;
 
-  private final AtomicBoolean endOfDestinationInput = new AtomicBoolean(false);
+  private final AtomicBoolean inputHasEnded = new AtomicBoolean(false);
 
   private Process destinationProcess = null;
   private BufferedWriter writer = null;
@@ -85,7 +85,7 @@ public class DefaultAirbyteDestination implements AirbyteDestination {
 
   @Override
   public void accept(final AirbyteMessage message) throws IOException {
-    Preconditions.checkState(destinationProcess != null && !endOfDestinationInput.get());
+    Preconditions.checkState(destinationProcess != null && !inputHasEnded.get());
 
     writer.write(Jsons.serialize(message));
     writer.newLine();
@@ -93,11 +93,11 @@ public class DefaultAirbyteDestination implements AirbyteDestination {
 
   @Override
   public void notifyEndOfInput() throws IOException {
-    Preconditions.checkState(destinationProcess != null && !endOfDestinationInput.get());
+    Preconditions.checkState(destinationProcess != null && !inputHasEnded.get());
 
     writer.flush();
     writer.close();
-    endOfDestinationInput.set(true);
+    inputHasEnded.set(true);
   }
 
   @Override
@@ -107,7 +107,7 @@ public class DefaultAirbyteDestination implements AirbyteDestination {
       return;
     }
 
-    if (!endOfDestinationInput.get()) {
+    if (!inputHasEnded.get()) {
       notifyEndOfInput();
     }
 

--- a/airbyte-workers/src/main/java/io/airbyte/workers/internal/DefaultAirbyteDestination.java
+++ b/airbyte-workers/src/main/java/io/airbyte/workers/internal/DefaultAirbyteDestination.java
@@ -42,7 +42,7 @@ public class DefaultAirbyteDestination implements AirbyteDestination {
   private final IntegrationLauncher integrationLauncher;
   private final AirbyteStreamFactory streamFactory;
 
-  private final AtomicBoolean endOfStream = new AtomicBoolean(false);
+  private final AtomicBoolean endOfDestinationInput = new AtomicBoolean(false);
 
   private Process destinationProcess = null;
   private BufferedWriter writer = null;
@@ -85,19 +85,19 @@ public class DefaultAirbyteDestination implements AirbyteDestination {
 
   @Override
   public void accept(final AirbyteMessage message) throws IOException {
-    Preconditions.checkState(destinationProcess != null && !endOfStream.get());
+    Preconditions.checkState(destinationProcess != null && !endOfDestinationInput.get());
 
     writer.write(Jsons.serialize(message));
     writer.newLine();
   }
 
   @Override
-  public void notifyEndOfStream() throws IOException {
-    Preconditions.checkState(destinationProcess != null && !endOfStream.get());
+  public void notifyEndOfInput() throws IOException {
+    Preconditions.checkState(destinationProcess != null && !endOfDestinationInput.get());
 
     writer.flush();
     writer.close();
-    endOfStream.set(true);
+    endOfDestinationInput.set(true);
   }
 
   @Override
@@ -107,8 +107,8 @@ public class DefaultAirbyteDestination implements AirbyteDestination {
       return;
     }
 
-    if (!endOfStream.get()) {
-      notifyEndOfStream();
+    if (!endOfDestinationInput.get()) {
+      notifyEndOfInput();
     }
 
     LOGGER.debug("Closing destination process");

--- a/airbyte-workers/src/test/java/io/airbyte/workers/general/DefaultReplicationWorkerTest.java
+++ b/airbyte-workers/src/test/java/io/airbyte/workers/general/DefaultReplicationWorkerTest.java
@@ -299,7 +299,7 @@ class DefaultReplicationWorkerTest {
   void testDestinationRunnableDestinationFailure() throws Exception {
     final String DESTINATION_ERROR_MESSAGE = "the destination had a failure";
 
-    doThrow(new RuntimeException(DESTINATION_ERROR_MESSAGE)).when(destination).notifyEndOfStream();
+    doThrow(new RuntimeException(DESTINATION_ERROR_MESSAGE)).when(destination).notifyEndOfInput();
 
     final ReplicationWorker worker = new DefaultReplicationWorker(
         JOB_ID,

--- a/airbyte-workers/src/test/java/io/airbyte/workers/internal/DefaultAirbyteDestinationTest.java
+++ b/airbyte-workers/src/test/java/io/airbyte/workers/internal/DefaultAirbyteDestinationTest.java
@@ -138,7 +138,7 @@ class DefaultAirbyteDestinationTest {
 
     verify(outputStream, never()).close();
 
-    destination.notifyEndOfStream();
+    destination.notifyEndOfInput();
 
     verify(outputStream).close();
 
@@ -171,7 +171,7 @@ class DefaultAirbyteDestinationTest {
 
     when(process.isAlive()).thenReturn(false);
 
-    destination.notifyEndOfStream();
+    destination.notifyEndOfInput();
 
     destination.close();
 


### PR DESCRIPTION
## What
just a cosmetic change, no functional impact

renames `AirbyteDestination::notifyEndOfStream()` to `notifyEndOfInput` 
renames `endOfStream` to `inputHasEnded`

Evan and I were getting hung up on the fact that this is called `notifyEndOfStream` because we thought it was referring to Airbyte Streams when really it was just referring to the stdin input stream

## Recommended reading order
1. `DefaultAirbyteDestination.java` and `AirbyteDestination.java`
2. everything else is just auto refactor from intellij

## 🚨 User Impact 🚨
no
