### PR TITLE
Source google ads: disabling the test because it is not stable

### DIFF
--- a/airbyte-integrations/connectors/source-google-ads/acceptance-test-config.yml
+++ b/airbyte-integrations/connectors/source-google-ads/acceptance-test-config.yml
@@ -37,6 +37,7 @@ tests:
   #      future_state_path: "integration_tests/abnormal_state.json"
   #      cursor_paths:
   #        ad_group_ad_report: ["segments.date"]
-  full_refresh:
-    - config_path: "secrets/config.json"
-      configured_catalog_path: "integration_tests/configured_catalog.json"
+# This one is disabled due to the issue https://github.com/airbytehq/airbyte/issues/13148
+#  full_refresh:
+#    - config_path: "secrets/config.json"
+#      configured_catalog_path: "integration_tests/configured_catalog.json"


### PR DESCRIPTION
Disabling the test because it is unstable. Should be enabled back again after fixing https://github.com/airbytehq/airbyte/issues/13148