### PR TITLE
Jira Source: Added resolutiondate to fields on issues stream 

### DIFF
--- a/airbyte-config/init/src/main/resources/seed/source_definitions.yaml
+++ b/airbyte-config/init/src/main/resources/seed/source_definitions.yaml
@@ -438,7 +438,7 @@
 - name: Jira
   sourceDefinitionId: 68e63de2-bb83-4c7e-93fa-a8a9051e3993
   dockerRepository: airbyte/source-jira
-  dockerImageTag: 0.2.19
+  dockerImageTag: 0.2.20
   documentationUrl: https://docs.airbyte.io/integrations/sources/jira
   icon: jira.svg
   sourceType: api

--- a/airbyte-config/init/src/main/resources/seed/source_specs.yaml
+++ b/airbyte-config/init/src/main/resources/seed/source_specs.yaml
@@ -3957,7 +3957,7 @@
     supportsNormalization: false
     supportsDBT: false
     supported_destination_sync_modes: []
-- dockerImage: "airbyte/source-jira:0.2.19"
+- dockerImage: "airbyte/source-jira:0.2.20"
   spec:
     documentationUrl: "https://docs.airbyte.io/integrations/sources/jira"
     connectionSpecification:

--- a/airbyte-integrations/connectors/source-jira/Dockerfile
+++ b/airbyte-integrations/connectors/source-jira/Dockerfile
@@ -12,5 +12,5 @@ RUN pip install .
 ENV AIRBYTE_ENTRYPOINT "python /airbyte/integration_code/main.py"
 ENTRYPOINT ["python", "/airbyte/integration_code/main.py"]
 
-LABEL io.airbyte.version=0.2.19
+LABEL io.airbyte.version=0.2.20
 LABEL io.airbyte.name=airbyte/source-jira

--- a/airbyte-integrations/connectors/source-jira/acceptance-test-config.yml
+++ b/airbyte-integrations/connectors/source-jira/acceptance-test-config.yml
@@ -29,6 +29,7 @@ tests:
     - config_path: "secrets/config.json"
       configured_catalog_path: "integration_tests/configured_catalog.json"
       empty_streams: ["epics", "screen_tab_fields", "sprint_issues", "sprints"]
+      timeout_seconds: 1800
 #  incremental:
 #    - config_path: "secrets/config.json"
 #      configured_catalog_path: "integration_tests/inc_configured_catalog.json"

--- a/airbyte-integrations/connectors/source-jira/source_jira/schemas/application_roles.json
+++ b/airbyte-integrations/connectors/source-jira/source_jira/schemas/application_roles.json
@@ -50,8 +50,13 @@
     "platform": {
       "type": "boolean",
       "description": "Indicates if the application role belongs to Jira platform (`jira-core`)."
+    },
+    "groupDetails": {
+      "type": ["null", "array"],
+      "description": "Group Details",
+      "items": { "type": ["null", "object"] }
     }
   },
-  "additionalProperties": false,
+  "additionalProperties": true,
   "description": "Details of an application role."
 }

--- a/airbyte-integrations/connectors/source-jira/source_jira/schemas/epics.json
+++ b/airbyte-integrations/connectors/source-jira/source_jira/schemas/epics.json
@@ -34,7 +34,7 @@
           "description": "Epic summary"
         },
         "description": {
-          "type": ["string", "null"],
+          "type": ["string", "null", "object"],
           "description": "Epic description"
         },
         "status": {

--- a/airbyte-integrations/connectors/source-jira/source_jira/schemas/sprint_issues.json
+++ b/airbyte-integrations/connectors/source-jira/source_jira/schemas/sprint_issues.json
@@ -57,10 +57,10 @@
       }
     },
     "issueId": {
-      "type": "number"
+      "type": "string"
     },
     "sprintId": {
-      "type": "number"
+      "type": "integer"
     }
   }
 }

--- a/airbyte-integrations/connectors/source-jira/source_jira/streams.py
+++ b/airbyte-integrations/connectors/source-jira/source_jira/streams.py
@@ -531,6 +531,8 @@ class IssueProperties(StartDateJiraStream):
     https://developer.atlassian.com/cloud/jira/platform/rest/v3/api-group-issue-properties/#api-rest-api-3-issue-issueidorkey-properties-propertykey-get
     """
 
+    primary_key = "key"
+
     def path(self, stream_slice: Mapping[str, Any], **kwargs) -> str:
         key = stream_slice["key"]
         issue_key = stream_slice["issue_key"]

--- a/airbyte-integrations/connectors/source-jira/source_jira/streams.py
+++ b/airbyte-integrations/connectors/source-jira/source_jira/streams.py
@@ -373,6 +373,7 @@ class Issues(IncrementalJiraStream):
             "parent",
             "priority",
             "project",
+            "resolutiondate",
             "security",
             "status",
             "subtasks",

--- a/docs/integrations/sources/jira.md
+++ b/docs/integrations/sources/jira.md
@@ -95,6 +95,7 @@ The Jira connector should not run into Jira API limitations under normal usage. 
 
 | Version | Date | Pull Request | Subject |
 | :--- | :--- | :--- | :--- |
+| 0.2.20 | 2022-05-25 | [\#13202](https://github.com/airbytehq/airbyte/pull/13202) | Adds resolutiondate to `fields` object on `issues` stream |
 | 0.2.19 | 2022-05-04 | [\#10835](https://github.com/airbytehq/airbyte/pull/10835) | Change description for array fields |
 | 0.2.18 | 2021-12-23 | [\#7378](https://github.com/airbytehq/airbyte/pull/7378) | Adds experimental endpoint Pull Request |
 | 0.2.17 | 2021-12-23 | [\#9079](https://github.com/airbytehq/airbyte/pull/9079) | Update schema for `filters` stream + fix fetching `filters` stream |


### PR DESCRIPTION
## What
This PR solves the problem of mapping the date and time when an issue was completed, which is extremely important for projects that use Airbyte to pull data from Jira and monitor the progress of activities.

## How
I added the resolutiondate field in the `fields` object present in the stream `issues`,

## Recommended reading order
1. `x.java`
2. `y.python`

## User Impact
There is no breakchanges, just more information being returned in the stream `issues`.

## Pre-merge Checklist


<details><summary><strong>Updating a connector</strong></summary>

### Community member or Airbyter

- [ ] Grant edit access to maintainers ([instructions](https://docs.github.com/en/github/collaborating-with-pull-requests/working-with-forks/allowing-changes-to-a-pull-request-branch-created-from-a-fork#enabling-repository-maintainer-permissions-on-existing-pull-requests))
- [ ] Secrets in the connector's spec are annotated with `airbyte_secret`
- [ ] Unit & integration tests added and passing. Community members, please provide proof of success locally e.g: screenshot or copy-paste unit, integration, and acceptance test output. To run acceptance tests for a Python connector, follow instructions in the README. For java connectors run `./gradlew :airbyte-integrations:connectors:<name>:integrationTest`.
- [ ] Code reviews completed
- [ ] Documentation updated
    - [ ] Connector's `README.md`
    - [ ] Connector's `bootstrap.md`. See [description and examples](https://docs.google.com/document/d/1ypdgmwmEHWv-TrO4_YOQ7pAJGVrMp5BOkEVh831N260/edit?usp=sharing)
    - [ ] Changelog updated in `docs/integrations/<source or destination>/<name>.md` including changelog. See changelog [example](https://docs.airbyte.io/integrations/sources/stripe#changelog)
- [ ] PR name follows [PR naming conventions](https://docs.airbyte.io/contributing-to-airbyte/updating-documentation#issues-and-pull-requests)

