### PR TITLE
🐛 Source Intercom: fix `conversation_parts` stream schema

### DIFF
--- a/airbyte-config/init/src/main/resources/seed/source_definitions.yaml
+++ b/airbyte-config/init/src/main/resources/seed/source_definitions.yaml
@@ -414,7 +414,7 @@
 - name: Intercom
   sourceDefinitionId: d8313939-3782-41b0-be29-b3ca20d8dd3a
   dockerRepository: airbyte/source-intercom
-  dockerImageTag: 0.1.18
+  dockerImageTag: 0.1.19
   documentationUrl: https://docs.airbyte.io/integrations/sources/intercom
   icon: intercom.svg
   sourceType: api

--- a/airbyte-config/init/src/main/resources/seed/source_specs.yaml
+++ b/airbyte-config/init/src/main/resources/seed/source_specs.yaml
@@ -3759,7 +3759,7 @@
         oauthFlowInitParameters: []
         oauthFlowOutputParameters:
         - - "access_token"
-- dockerImage: "airbyte/source-intercom:0.1.18"
+- dockerImage: "airbyte/source-intercom:0.1.19"
   spec:
     documentationUrl: "https://docs.airbyte.io/integrations/sources/intercom"
     connectionSpecification:

--- a/airbyte-integrations/connectors/source-intercom/Dockerfile
+++ b/airbyte-integrations/connectors/source-intercom/Dockerfile
@@ -35,5 +35,5 @@ COPY source_intercom ./source_intercom
 ENV AIRBYTE_ENTRYPOINT "python /airbyte/integration_code/main.py"
 ENTRYPOINT ["python", "/airbyte/integration_code/main.py"]
 
-LABEL io.airbyte.version=0.1.18
+LABEL io.airbyte.version=0.1.19
 LABEL io.airbyte.name=airbyte/source-intercom

--- a/airbyte-integrations/connectors/source-intercom/source_intercom/schemas/conversation_parts.json
+++ b/airbyte-integrations/connectors/source-intercom/source_intercom/schemas/conversation_parts.json
@@ -12,10 +12,10 @@
             "properties": {
               "type": {
                 "type": ["null", "string"]
+              },
+              "id": {
+                "type": ["null", "string"]
               }
-            },
-            "id": {
-              "type": ["null", "string"]
             }
           }
         },

--- a/docs/integrations/sources/intercom.md
+++ b/docs/integrations/sources/intercom.md
@@ -57,6 +57,7 @@ The Intercom connector should not run into Intercom API limitations under normal
 
 | Version | Date | Pull Request | Subject |
 |:--------| :--- | :--- | :--- |
+| 0.1.19  | 2022-05-25 | [13204](https://github.com/airbytehq/airbyte/pull/13204) | Fixed `conversation_parts` stream schema definition                       |
 | 0.1.18   | 2022-05-04 | [12482](https://github.com/airbytehq/airbyte/pull/12482) | Update input configuration copy |
 | 0.1.17  | 2022-04-29 | [12374](https://github.com/airbytehq/airbyte/pull/12374)  | Fixed filtering of conversation_parts |
 | 0.1.16  | 2022-03-23 | [11206](https://github.com/airbytehq/airbyte/pull/11206)  | Added conversation_id field to conversation_part records |


### PR DESCRIPTION
## What
An error in the schema definition for the `conversation_parts` stream was causing syncs to fail due to schema validations occurring after https://github.com/airbytehq/airbyte/pull/12231

This was failing against a valid record:

```
{
  "type" : "conversation_part",
  "id" : "9871038696",
  "part_type" : "message_assignment",
  "body" : null,
  "created_at" : 1625749234,
  "updated_at" : 1625749234,
  "notified_at" : 1625749234,
  "assigned_to" : {
    "type" : "admin",
    "id" : "4423433"
  },
  "author" : {
    "id" : "4423434",
    "type" : "bot",
    "name" : "Operator",
    "email" : "operator+wjw5eps7@intercom.io"
  },
  "attachments" : [ ],
  "external_id" : null,
  "redacted" : false,
  "conversation_id" : "2"
}
```

## How
Fix the schema definition


