### PR TITLE
Mask certain keys from GitHub output

### DIFF
--- a/tools/ci_credentials/README.md
+++ b/tools/ci_credentials/README.md
@@ -19,17 +19,20 @@ Download a Service account json key that has access to Google Secrets Manager.
 export GCP_GSM_CREDENTIALS=`cat ~/Downloads/key.json`
 ```
 
-I found it necessary to change this code: `base_folder = Path("/actions-runner/_work/airbyte/airbyte")`
-to something more local like: `base_folder = Path("/Users/brian/airbytehq/airbyte")`
-
-I assume this is because that's the place the GitHub actions is doing its work.
-
 After making a change, you have to reinstall it to run the bash command: `pip install --quiet -e ./tools/ci_*`
 
 ## Run it
 
+The `VERSION=dev` will make it so it knows to use your local current working directory and not the Github Action one.
+
 Pass in a connector name. For example:
 
 ```bash
-ci_credentials destination-snowflake
+VERSION=dev ci_credentials destination-snowflake
+```
+
+To make sure it get's all changes every time, you can run this:
+
+```bash
+pip install --quiet -e ./tools/ci_* && VERSION=dev ci_credentials destination-snowflake
 ```

--- a/tools/ci_credentials/README.md
+++ b/tools/ci_credentials/README.md
@@ -1,0 +1,35 @@
+# CI Credentials
+
+Connects to GSM to download connection details.
+
+## Development
+
+Set up the world the same way Google Actions does it in `test-command.yml`.
+
+```
+source venv/bin/activate
+pip install --quiet tox==3.24.4
+tox -r -c ./tools/tox_ci.ini
+pip install --quiet -e ./tools/ci_*
+```
+
+Download a Service account json key that has access to Google Secrets Manager.
+
+```bash
+export GCP_GSM_CREDENTIALS=`cat ~/Downloads/key.json`
+```
+
+I found it necessary to change this code: `base_folder = Path("/actions-runner/_work/airbyte/airbyte")`
+to something more local like: `base_folder = Path("/Users/brian/airbytehq/airbyte")`
+
+I assume this is because that's the place the GitHub actions is doing its work.
+
+After making a change, you have to reinstall it to run the bash command: `pip install --quiet -e ./tools/ci_*`
+
+## Run it
+
+Pass in a connector name. For example:
+
+```bash
+ci_credentials destination-snowflake
+```

--- a/tools/ci_credentials/ci_credentials/secrets_loader.py
+++ b/tools/ci_credentials/ci_credentials/secrets_loader.py
@@ -143,8 +143,12 @@ class SecretsLoader:
                 for pattern in MASK_KEY_PATTERNS:
                     if re.search(pattern, key):
                         self.logger.info(f"Add mask for key: {key}")
-                        # has to be at the beginning of line for Github to notice it
-                        print(f"::add-mask::{value}")
+                        for line in value.splitlines():
+                            line = str(line).strip()
+                            # don't output } and such
+                            if len(line) > 1:
+                                # has to be at the beginning of line for Github to notice it
+                                print(f"::add-mask::{line}")
                         break
             # see if it's really embedded json and get those values too
             try:

--- a/tools/ci_credentials/ci_credentials/secrets_loader.py
+++ b/tools/ci_credentials/ci_credentials/secrets_loader.py
@@ -3,6 +3,7 @@
 #
 import base64
 import json
+import os
 import re
 from json.decoder import JSONDecodeError
 from pathlib import Path
@@ -46,12 +47,16 @@ class SecretsLoader:
     """Loading and saving all requested secrets into connector folders"""
 
     logger: ClassVar[Logger] = Logger()
-    base_folder = Path("/actions-runner/_work/airbyte/airbyte")
+    if os.getenv("VERSION") == "dev":
+        base_folder = Path(os.getcwd())
+    else:
+        base_folder = Path("/actions-runner/_work/airbyte/airbyte")
 
     def __init__(self, connector_name: str, gsm_credentials: Mapping[str, Any]):
         self.gsm_credentials = gsm_credentials
         self.connector_name = connector_name
         self._api = None
+        self.logger.info(f"base_folder: {self.base_folder}")
 
     @property
     def api(self) -> GoogleApi:

--- a/tools/ci_credentials/ci_credentials/secrets_loader.py
+++ b/tools/ci_credentials/ci_credentials/secrets_loader.py
@@ -127,7 +127,6 @@ class SecretsLoader:
             if not next_token:
                 break
 
-        self.logger.info("Here is a test value to check and see.")
         return secrets
 
     def mask_secrets_from_action_log(self, key, value):
@@ -145,8 +144,7 @@ class SecretsLoader:
                     if re.search(pattern, key):
                         self.logger.info(f"Add mask for key: {key}")
                         # has to be at the beginning of line for Github to notice it
-                        # print(f"::add-mask::{value}")
-                        print("::add-mask::test value")
+                        print(f"::add-mask::{value}")
                         break
             # see if it's really embedded json and get those values too
             try:

--- a/tools/ci_credentials/ci_credentials/secrets_loader.py
+++ b/tools/ci_credentials/ci_credentials/secrets_loader.py
@@ -138,12 +138,20 @@ class SecretsLoader:
             for item in value:
                 self.mask_secrets_from_action_log(key, item)
         else:
-            # regular value, check for what to mask
-            for pattern in MASK_KEY_PATTERNS:
-                if re.search(pattern, key):
-                    self.logger.info(f"Add mask for key: {key}")
-                    self.logger.info(f"::add-mask::{value}")
-                    continue
+            if key:
+                # regular value, check for what to mask
+                for pattern in MASK_KEY_PATTERNS:
+                    if re.search(pattern, key):
+                        self.logger.info(f"Add mask for key: {key}")
+                        self.logger.info(f"::add-mask::{value}")
+                        break
+            # see if it's really embedded json and get those values too
+            try:
+                json_value = json.loads(value)
+                self.mask_secrets_from_action_log(None, json_value)
+            except Exception:
+                # carry on
+                pass
 
     @staticmethod
     def generate_secret_name(connector_name: str, filename: str) -> str:

--- a/tools/ci_credentials/ci_credentials/secrets_loader.py
+++ b/tools/ci_credentials/ci_credentials/secrets_loader.py
@@ -56,7 +56,6 @@ class SecretsLoader:
         self.gsm_credentials = gsm_credentials
         self.connector_name = connector_name
         self._api = None
-        self.logger.info(f"base_folder: {self.base_folder}")
 
     @property
     def api(self) -> GoogleApi:
@@ -144,7 +143,7 @@ class SecretsLoader:
                     if re.search(pattern, key):
                         self.logger.info(f"Add mask for key: {key}")
                         # self.logger.info(f"::add-mask::{value}")
-                        self.logger.info("::add-mask::test value")
+                        print("::add-mask::test value")
                         break
             # see if it's really embedded json and get those values too
             try:

--- a/tools/ci_credentials/ci_credentials/secrets_loader.py
+++ b/tools/ci_credentials/ci_credentials/secrets_loader.py
@@ -1,15 +1,21 @@
+#
+# Copyright (c) 2022 Airbyte, Inc., all rights reserved.
+#
 import base64
 import json
+import re
 from json.decoder import JSONDecodeError
-from typing import Mapping, Any, Tuple, ClassVar
 from pathlib import Path
-from ci_common_utils import GoogleApi
-from ci_common_utils import Logger
+from typing import Any, ClassVar, Mapping, Tuple
+
+from ci_common_utils import GoogleApi, Logger
 
 DEFAULT_SECRET_FILE = "config"
 DEFAULT_SECRET_FILE_WITH_EXT = DEFAULT_SECRET_FILE + ".json"
 
 GSM_SCOPES = ("https://www.googleapis.com/auth/cloud-platform",)
+
+MASK_KEY_PATTERNS = ["password", "host", "user", "_key", "token", "secret", "bucket"]
 
 
 class SecretsLoader:
@@ -78,29 +84,46 @@ class SecretsLoader:
                 if not secret_value:
                     self.logger.warning(f"{log_name} has empty value")
                     continue
-                secret_value = base64.b64decode(secret_value.encode()).decode('utf-8')
+                secret_value = base64.b64decode(secret_value.encode()).decode("utf-8")
                 try:
                     # minimize and validate its JSON value
-                    secret_value = json.dumps(json.loads(secret_value), separators=(',', ':'))
+                    json_value = json.loads(secret_value)
+                    secret_value = json.dumps(json_value, separators=(",", ":"))
+                    self.mask_secrets_from_action_log(None, json_value)
                 except JSONDecodeError as err:
                     self.logger.error(f"{log_name} has non-JSON value!!! Error: {err}")
                     continue
                 secrets[(connector_name, filename)] = secret_value
+
             next_token = data.get("nextPageToken")
             if not next_token:
                 break
         return secrets
 
+    def mask_secrets_from_action_log(self, key, value):
+        # recursive masking of json based on leaf key
+        if isinstance(value, dict):
+            for child, item in value.items():
+                self.mask_secrets_from_action_log(child, item)
+        elif isinstance(value, list):
+            for item in value:
+                self.mask_secrets_from_action_log(key, item)
+        else:
+            # regular value, check for what to mask
+            for pattern in MASK_KEY_PATTERNS:
+                if re.search(pattern, key):
+                    self.logger.info(f"::add-mask::{value}")
+
     @staticmethod
     def generate_secret_name(connector_name: str, filename: str) -> str:
         """
-           Generates an unique GSM secret name.
-           Format of secret name: SECRET_<CAPITAL_CONNECTOR_NAME>_<OPTIONAL_UNIQUE_FILENAME_PART>__CREDS
-           Examples:
-               1. connector_name: source-linnworks, filename: dsdssds_a-b---_---_config.json
-                  => SECRET_SOURCE-LINNWORKS_DSDSSDS_A-B__CREDS
-               2. connector_name: source-s3, filename: config.json
-                  => SECRET_SOURCE-LINNWORKS__CREDS
+        Generates an unique GSM secret name.
+        Format of secret name: SECRET_<CAPITAL_CONNECTOR_NAME>_<OPTIONAL_UNIQUE_FILENAME_PART>__CREDS
+        Examples:
+            1. connector_name: source-linnworks, filename: dsdssds_a-b---_---_config.json
+               => SECRET_SOURCE-LINNWORKS_DSDSSDS_A-B__CREDS
+            2. connector_name: source-s3, filename: config.json
+               => SECRET_SOURCE-LINNWORKS__CREDS
         """
         name_parts = ["secret", connector_name]
         filename_wo_ext = filename.replace(".json", "")
@@ -111,7 +134,7 @@ class SecretsLoader:
 
     def create_secret(self, connector_name: str, filename: str, secret_value: str) -> bool:
         """
-           Creates a new GSM secret with auto-generated name.
+        Creates a new GSM secret with auto-generated name.
         """
         secret_name = self.generate_secret_name(connector_name, filename)
         self.logger.info(f"Generated the new secret name '{secret_name}' for {connector_name}({filename})")
@@ -133,10 +156,8 @@ class SecretsLoader:
         # try to create a new version
         secret_name = data["name"]
         self.logger.info(f"the GSM secret {secret_name} was created")
-        secret_url = f'https://secretmanager.googleapis.com/v1/{secret_name}:addVersion'
-        body = {
-            "payload": {"data": base64.b64encode(secret_value.encode()).decode("utf-8")}
-        }
+        secret_url = f"https://secretmanager.googleapis.com/v1/{secret_name}:addVersion"
+        body = {"payload": {"data": base64.b64encode(secret_value.encode()).decode("utf-8")}}
         self.api.post(secret_url, json=body)
         return True
 

--- a/tools/ci_credentials/ci_credentials/secrets_loader.py
+++ b/tools/ci_credentials/ci_credentials/secrets_loader.py
@@ -126,6 +126,8 @@ class SecretsLoader:
             next_token = data.get("nextPageToken")
             if not next_token:
                 break
+
+        self.logger.info("Here is a test value to check and see.")
         return secrets
 
     def mask_secrets_from_action_log(self, key, value):
@@ -142,7 +144,8 @@ class SecretsLoader:
                 for pattern in MASK_KEY_PATTERNS:
                     if re.search(pattern, key):
                         self.logger.info(f"Add mask for key: {key}")
-                        # self.logger.info(f"::add-mask::{value}")
+                        # has to be at the beginning of line for Github to notice it
+                        # print(f"::add-mask::{value}")
                         print("::add-mask::test value")
                         break
             # see if it's really embedded json and get those values too

--- a/tools/ci_credentials/ci_credentials/secrets_loader.py
+++ b/tools/ci_credentials/ci_credentials/secrets_loader.py
@@ -15,7 +15,31 @@ DEFAULT_SECRET_FILE_WITH_EXT = DEFAULT_SECRET_FILE + ".json"
 
 GSM_SCOPES = ("https://www.googleapis.com/auth/cloud-platform",)
 
-MASK_KEY_PATTERNS = ["password", "host", "user", "_key", "token", "secret", "bucket"]
+MASK_KEY_PATTERNS = [
+    "password",
+    "host",
+    "user",
+    "_key",
+    "_id",
+    "token",
+    "secret",
+    "bucket",
+    "role_arn",
+    "service_account_info",
+    "account_id",
+    "api",
+    "domain_url",
+    "client_id",
+    "access",
+    "jwt",
+    "base_url",
+    "key",
+    "credentials",
+    "_sid",
+    "survey_",
+    "appid",
+    "apikey",
+]
 
 
 class SecretsLoader:
@@ -112,7 +136,9 @@ class SecretsLoader:
             # regular value, check for what to mask
             for pattern in MASK_KEY_PATTERNS:
                 if re.search(pattern, key):
+                    self.logger.info(f"Add mask for key: {key}")
                     self.logger.info(f"::add-mask::{value}")
+                    continue
 
     @staticmethod
     def generate_secret_name(connector_name: str, filename: str) -> str:

--- a/tools/ci_credentials/ci_credentials/secrets_loader.py
+++ b/tools/ci_credentials/ci_credentials/secrets_loader.py
@@ -143,7 +143,8 @@ class SecretsLoader:
                 for pattern in MASK_KEY_PATTERNS:
                     if re.search(pattern, key):
                         self.logger.info(f"Add mask for key: {key}")
-                        self.logger.info(f"::add-mask::{value}")
+                        # self.logger.info(f"::add-mask::{value}")
+                        self.logger.info("::add-mask::test value")
                         break
             # see if it's really embedded json and get those values too
             try:


### PR DESCRIPTION
## What
Teaches github actions about things we don't want to show just in case.

## How
`add-mask` as described here: https://docs.github.com/en/actions/using-workflows/workflow-commands-for-github-actions#masking-a-value-in-log