### PR TITLE
Parker/temporal cloud

### DIFF
--- a/airbyte-config/config-models/src/main/java/io/airbyte/config/Configs.java
+++ b/airbyte-config/config-models/src/main/java/io/airbyte/config/Configs.java
@@ -192,12 +192,12 @@ public interface Configs {
   /**
    * Temporal Cloud client cert for SSL
    */
-  String getTemporalCloudClientCertPath();
+  String getTemporalCloudClientCert();
 
   /**
    * Temporal Cloud client key for SSL
    */
-  String getTemporalCloudClientKeyPath();
+  String getTemporalCloudClientKey();
 
   // Airbyte Services
 

--- a/airbyte-config/config-models/src/main/java/io/airbyte/config/Configs.java
+++ b/airbyte-config/config-models/src/main/java/io/airbyte/config/Configs.java
@@ -171,7 +171,36 @@ public interface Configs {
    */
   boolean runDatabaseMigrationOnStartup();
 
+  // Temporal Cloud
+
+  /**
+   * Define if Temporal Cloud should be used
+   */
+  boolean temporalCloudEnabled();
+
+  /**
+   * Temporal Cloud target endpoint, usually with form ${namespace}.tmprl.cloud:7233
+   */
+  String getTemporalCloudHost();
+
+  /**
+   * Temporal Cloud namespace
+   *
+   */
+  String getTemporalCloudNamespace();
+
+  /**
+   * Temporal Cloud client cert for SSL
+   */
+  String getTemporalCloudClientCertPath();
+
+  /**
+   * Temporal Cloud client key for SSL
+   */
+  String getTemporalCloudClientKeyPath();
+
   // Airbyte Services
+
   /**
    * Define the url where Temporal is hosted at. Please include the port. Airbyte services use this
    * information.

--- a/airbyte-config/config-models/src/main/java/io/airbyte/config/Configs.java
+++ b/airbyte-config/config-models/src/main/java/io/airbyte/config/Configs.java
@@ -171,31 +171,30 @@ public interface Configs {
    */
   boolean runDatabaseMigrationOnStartup();
 
-  // Temporal Cloud
+  // Temporal Cloud - Internal-Use Only
 
   /**
-   * Define if Temporal Cloud should be used
+   * Define if Temporal Cloud should be used. Internal-use only.
    */
   boolean temporalCloudEnabled();
 
   /**
-   * Temporal Cloud target endpoint, usually with form ${namespace}.tmprl.cloud:7233
+   * Temporal Cloud target endpoint, usually with form ${namespace}.tmprl.cloud:7233. Internal-use only.
    */
   String getTemporalCloudHost();
 
   /**
-   * Temporal Cloud namespace
-   *
+   * Temporal Cloud namespace. Internal-use only.
    */
   String getTemporalCloudNamespace();
 
   /**
-   * Temporal Cloud client cert for SSL
+   * Temporal Cloud client cert for SSL. Internal-use only.
    */
   String getTemporalCloudClientCert();
 
   /**
-   * Temporal Cloud client key for SSL
+   * Temporal Cloud client key for SSL. Internal-use only.
    */
   String getTemporalCloudClientKey();
 

--- a/airbyte-config/config-models/src/main/java/io/airbyte/config/Configs.java
+++ b/airbyte-config/config-models/src/main/java/io/airbyte/config/Configs.java
@@ -179,7 +179,8 @@ public interface Configs {
   boolean temporalCloudEnabled();
 
   /**
-   * Temporal Cloud target endpoint, usually with form ${namespace}.tmprl.cloud:7233. Internal-use only.
+   * Temporal Cloud target endpoint, usually with form ${namespace}.tmprl.cloud:7233. Internal-use
+   * only.
    */
   String getTemporalCloudHost();
 

--- a/airbyte-config/config-models/src/main/java/io/airbyte/config/EnvConfigs.java
+++ b/airbyte-config/config-models/src/main/java/io/airbyte/config/EnvConfigs.java
@@ -109,6 +109,12 @@ public class EnvConfigs implements Configs {
   public static final String STATE_STORAGE_GCS_BUCKET_NAME = "STATE_STORAGE_GCS_BUCKET_NAME";
   public static final String STATE_STORAGE_GCS_APPLICATION_CREDENTIALS = "STATE_STORAGE_GCS_APPLICATION_CREDENTIALS";
 
+  private static final String TEMPORAL_CLOUD_ENABLED = "TEMPORAL_CLOUD_ENABLED";
+  private static final String TEMPORAL_CLOUD_HOST = "TEMPORAL_CLOUD_HOST";
+  private static final String TEMPORAL_CLOUD_NAMESPACE = "TEMPORAL_CLOUD_NAMESPACE";
+  private static final String TEMPORAL_CLOUD_CERT_PATH = "TEMPORAL_CLOUD_CERT_PATH";
+  private static final String TEMPORAL_CLOUD_KEY_PATH = "TEMPORAL_CLOUD_KEY_PATH";
+
   public static final String ACTIVITY_MAX_TIMEOUT_SECOND = "ACTIVITY_MAX_TIMEOUT_SECOND";
   public static final String ACTIVITY_MAX_ATTEMPT = "ACTIVITY_MAX_ATTEMPT";
   public static final String ACTIVITY_INITIAL_DELAY_BETWEEN_ATTEMPTS_SECONDS = "ACTIVITY_INITIAL_DELAY_BETWEEN_ATTEMPTS_SECONDS";
@@ -388,6 +394,32 @@ public class EnvConfigs implements Configs {
   @Override
   public boolean runDatabaseMigrationOnStartup() {
     return getEnvOrDefault(RUN_DATABASE_MIGRATION_ON_STARTUP, true);
+  }
+
+  // Temporal Cloud
+  @Override
+  public boolean temporalCloudEnabled() {
+    return getEnvOrDefault(TEMPORAL_CLOUD_ENABLED, false);
+  }
+
+  @Override
+  public String getTemporalCloudHost() {
+    return getEnvOrDefault(TEMPORAL_CLOUD_HOST, "");
+  }
+
+  @Override
+  public String getTemporalCloudNamespace() {
+    return getEnvOrDefault(TEMPORAL_CLOUD_NAMESPACE, "");
+  }
+
+  @Override
+  public String getTemporalCloudClientCertPath() {
+    return getEnvOrDefault(TEMPORAL_CLOUD_CERT_PATH, "");
+  }
+
+  @Override
+  public String getTemporalCloudClientKeyPath() {
+    return getEnvOrDefault(TEMPORAL_CLOUD_KEY_PATH, "");
   }
 
   // Airbyte Services

--- a/airbyte-config/config-models/src/main/java/io/airbyte/config/EnvConfigs.java
+++ b/airbyte-config/config-models/src/main/java/io/airbyte/config/EnvConfigs.java
@@ -112,8 +112,8 @@ public class EnvConfigs implements Configs {
   private static final String TEMPORAL_CLOUD_ENABLED = "TEMPORAL_CLOUD_ENABLED";
   private static final String TEMPORAL_CLOUD_HOST = "TEMPORAL_CLOUD_HOST";
   private static final String TEMPORAL_CLOUD_NAMESPACE = "TEMPORAL_CLOUD_NAMESPACE";
-  private static final String TEMPORAL_CLOUD_CERT_PATH = "TEMPORAL_CLOUD_CERT_PATH";
-  private static final String TEMPORAL_CLOUD_KEY_PATH = "TEMPORAL_CLOUD_KEY_PATH";
+  private static final String TEMPORAL_CLOUD_CLIENT_CERT = "TEMPORAL_CLOUD_CLIENT_CERT";
+  private static final String TEMPORAL_CLOUD_CLIENT_KEY = "TEMPORAL_CLOUD_CLIENT_KEY";
 
   public static final String ACTIVITY_MAX_TIMEOUT_SECOND = "ACTIVITY_MAX_TIMEOUT_SECOND";
   public static final String ACTIVITY_MAX_ATTEMPT = "ACTIVITY_MAX_ATTEMPT";
@@ -413,13 +413,13 @@ public class EnvConfigs implements Configs {
   }
 
   @Override
-  public String getTemporalCloudClientCertPath() {
-    return getEnvOrDefault(TEMPORAL_CLOUD_CERT_PATH, "");
+  public String getTemporalCloudClientCert() {
+    return getEnvOrDefault(TEMPORAL_CLOUD_CLIENT_CERT, "");
   }
 
   @Override
-  public String getTemporalCloudClientKeyPath() {
-    return getEnvOrDefault(TEMPORAL_CLOUD_KEY_PATH, "");
+  public String getTemporalCloudClientKey() {
+    return getEnvOrDefault(TEMPORAL_CLOUD_CLIENT_KEY, "");
   }
 
   // Airbyte Services

--- a/airbyte-server/src/main/java/io/airbyte/server/ServerApp.java
+++ b/airbyte-server/src/main/java/io/airbyte/server/ServerApp.java
@@ -51,6 +51,8 @@ import io.airbyte.server.errors.UncaughtExceptionMapper;
 import io.airbyte.server.handlers.DbMigrationHandler;
 import io.airbyte.validation.json.JsonValidationException;
 import io.airbyte.workers.temporal.TemporalClient;
+import io.airbyte.workers.temporal.TemporalUtils;
+import io.temporal.serviceclient.WorkflowServiceStubs;
 import java.io.IOException;
 import java.net.http.HttpClient;
 import java.util.Map;
@@ -193,13 +195,12 @@ public class ServerApp implements ServerRunnable {
     final TrackingClient trackingClient = TrackingClientSingleton.get();
     final JobTracker jobTracker = new JobTracker(configRepository, jobPersistence, trackingClient);
 
-    final TemporalClient temporalClient = TemporalClient.production(configs.getTemporalHost(), configs.getWorkspaceRoot(), configs);
+    final TemporalClient temporalClient = TemporalClient.production(configs);
     final OAuthConfigSupplier oAuthConfigSupplier = new OAuthConfigSupplier(configRepository, trackingClient);
     final DefaultSynchronousSchedulerClient syncSchedulerClient =
         new DefaultSynchronousSchedulerClient(temporalClient, jobTracker, oAuthConfigSupplier);
     final HttpClient httpClient = HttpClient.newBuilder().version(HttpClient.Version.HTTP_1_1).build();
-    final EventRunner eventRunner = new TemporalEventRunner(
-        TemporalClient.production(configs.getTemporalHost(), configs.getWorkspaceRoot(), configs));
+    final EventRunner eventRunner = new TemporalEventRunner(TemporalClient.production(configs));
 
     // It is important that the migration to the temporal scheduler is performed before the server
     // accepts any requests.

--- a/airbyte-server/src/main/java/io/airbyte/server/ServerApp.java
+++ b/airbyte-server/src/main/java/io/airbyte/server/ServerApp.java
@@ -51,8 +51,6 @@ import io.airbyte.server.errors.UncaughtExceptionMapper;
 import io.airbyte.server.handlers.DbMigrationHandler;
 import io.airbyte.validation.json.JsonValidationException;
 import io.airbyte.workers.temporal.TemporalClient;
-import io.airbyte.workers.temporal.TemporalUtils;
-import io.temporal.serviceclient.WorkflowServiceStubs;
 import java.io.IOException;
 import java.net.http.HttpClient;
 import java.util.Map;
@@ -195,12 +193,12 @@ public class ServerApp implements ServerRunnable {
     final TrackingClient trackingClient = TrackingClientSingleton.get();
     final JobTracker jobTracker = new JobTracker(configRepository, jobPersistence, trackingClient);
 
-    final TemporalClient temporalClient = TemporalClient.production(configs);
+    final TemporalClient temporalClient = TemporalClient.get(configs);
     final OAuthConfigSupplier oAuthConfigSupplier = new OAuthConfigSupplier(configRepository, trackingClient);
     final DefaultSynchronousSchedulerClient syncSchedulerClient =
         new DefaultSynchronousSchedulerClient(temporalClient, jobTracker, oAuthConfigSupplier);
     final HttpClient httpClient = HttpClient.newBuilder().version(HttpClient.Version.HTTP_1_1).build();
-    final EventRunner eventRunner = new TemporalEventRunner(TemporalClient.production(configs));
+    final EventRunner eventRunner = new TemporalEventRunner(TemporalClient.get(configs));
 
     // It is important that the migration to the temporal scheduler is performed before the server
     // accepts any requests.

--- a/airbyte-server/src/main/java/io/airbyte/server/ServerApp.java
+++ b/airbyte-server/src/main/java/io/airbyte/server/ServerApp.java
@@ -51,6 +51,8 @@ import io.airbyte.server.errors.UncaughtExceptionMapper;
 import io.airbyte.server.handlers.DbMigrationHandler;
 import io.airbyte.validation.json.JsonValidationException;
 import io.airbyte.workers.temporal.TemporalClient;
+import io.airbyte.workers.temporal.TemporalUtils;
+import io.temporal.serviceclient.WorkflowServiceStubs;
 import java.io.IOException;
 import java.net.http.HttpClient;
 import java.util.Map;
@@ -193,12 +195,17 @@ public class ServerApp implements ServerRunnable {
     final TrackingClient trackingClient = TrackingClientSingleton.get();
     final JobTracker jobTracker = new JobTracker(configRepository, jobPersistence, trackingClient);
 
-    final TemporalClient temporalClient = TemporalClient.get(configs);
+    final WorkflowServiceStubs temporalService = TemporalUtils.createTemporalService();
+    final TemporalClient temporalClient = new TemporalClient(
+        TemporalUtils.createWorkflowClient(temporalService, TemporalUtils.getNamespace()),
+        configs.getWorkspaceRoot(),
+        temporalService);
+
     final OAuthConfigSupplier oAuthConfigSupplier = new OAuthConfigSupplier(configRepository, trackingClient);
     final DefaultSynchronousSchedulerClient syncSchedulerClient =
         new DefaultSynchronousSchedulerClient(temporalClient, jobTracker, oAuthConfigSupplier);
     final HttpClient httpClient = HttpClient.newBuilder().version(HttpClient.Version.HTTP_1_1).build();
-    final EventRunner eventRunner = new TemporalEventRunner(TemporalClient.get(configs));
+    final EventRunner eventRunner = new TemporalEventRunner(temporalClient);
 
     // It is important that the migration to the temporal scheduler is performed before the server
     // accepts any requests.

--- a/airbyte-tests/src/acceptanceTests/java/io/airbyte/test/acceptance/BasicAcceptanceTests.java
+++ b/airbyte-tests/src/acceptanceTests/java/io/airbyte/test/acceptance/BasicAcceptanceTests.java
@@ -831,7 +831,7 @@ public class BasicAcceptanceTests {
   }
 
   private WorkflowClient getWorkflowClient() {
-    final WorkflowServiceStubs temporalService = TemporalUtils.createTemporalAirbyteService("localhost:7233");
+    final WorkflowServiceStubs temporalService = TemporalUtils.createAirbyteTemporalServiceAndConfigureNamespace("localhost:7233");
     return WorkflowClient.newInstance(temporalService);
   }
 

--- a/airbyte-tests/src/acceptanceTests/java/io/airbyte/test/acceptance/BasicAcceptanceTests.java
+++ b/airbyte-tests/src/acceptanceTests/java/io/airbyte/test/acceptance/BasicAcceptanceTests.java
@@ -831,7 +831,7 @@ public class BasicAcceptanceTests {
   }
 
   private WorkflowClient getWorkflowClient() {
-    final WorkflowServiceStubs temporalService = TemporalUtils.createTemporalService("localhost:7233");
+    final WorkflowServiceStubs temporalService = TemporalUtils.createTemporalAirbyteService("localhost:7233");
     return WorkflowClient.newInstance(temporalService);
   }
 

--- a/airbyte-tests/src/acceptanceTests/java/io/airbyte/test/acceptance/BasicAcceptanceTests.java
+++ b/airbyte-tests/src/acceptanceTests/java/io/airbyte/test/acceptance/BasicAcceptanceTests.java
@@ -831,7 +831,9 @@ public class BasicAcceptanceTests {
   }
 
   private WorkflowClient getWorkflowClient() {
-    final WorkflowServiceStubs temporalService = TemporalUtils.createAirbyteTemporalServiceAndConfigureNamespace("localhost:7233");
+    final WorkflowServiceStubs temporalService = TemporalUtils.createTemporalService(
+        TemporalUtils.getAirbyteTemporalOptions("localhost:7233"),
+        TemporalUtils.DEFAULT_NAMESPACE);
     return WorkflowClient.newInstance(temporalService);
   }
 

--- a/airbyte-workers/src/main/java/io/airbyte/workers/WorkerApp.java
+++ b/airbyte-workers/src/main/java/io/airbyte/workers/WorkerApp.java
@@ -147,7 +147,7 @@ public class WorkerApp {
           }
         });
 
-    final WorkerFactory factory = TemporalClient.productionWorkerFactory(configs);
+    final WorkerFactory factory = TemporalClient.getWorkerFactory(configs);
 
     if (configs.shouldRunGetSpecWorkflows()) {
       registerGetSpec(factory);
@@ -382,7 +382,7 @@ public class WorkerApp {
       KubePortManagerSingleton.init(configs.getTemporalWorkerPorts());
     }
 
-    final WorkflowServiceStubs temporalService = TemporalUtils.createTemporalProductionService();
+    final WorkflowServiceStubs temporalService = TemporalUtils.createTemporalService();
 
     final Database configDatabase = new Database(configsDslContext);
     final FeatureFlags featureFlags = new EnvVariableFeatureFlags();
@@ -409,7 +409,7 @@ public class WorkerApp {
         configRepository,
         new OAuthConfigSupplier(configRepository, trackingClient));
 
-    final TemporalClient temporalClient = TemporalClient.production(configs);
+    final TemporalClient temporalClient = TemporalClient.get(configs);
 
     final TemporalWorkerRunFactory temporalWorkerRunFactory = new TemporalWorkerRunFactory(
         temporalClient,

--- a/airbyte-workers/src/main/java/io/airbyte/workers/WorkerApp.java
+++ b/airbyte-workers/src/main/java/io/airbyte/workers/WorkerApp.java
@@ -411,6 +411,7 @@ public class WorkerApp {
     final WorkflowServiceStubs temporalService = TemporalUtils.createTemporalService();
     final WorkflowClient workflowClient = TemporalUtils.createWorkflowClient(temporalService, TemporalUtils.getNamespace());
     final TemporalClient temporalClient = new TemporalClient(workflowClient, configs.getWorkspaceRoot(), temporalService);
+    TemporalUtils.configureTemporalNamespace(temporalService);
 
     final TemporalWorkerRunFactory temporalWorkerRunFactory = new TemporalWorkerRunFactory(
         temporalClient,

--- a/airbyte-workers/src/main/java/io/airbyte/workers/temporal/ConnectionManagerUtils.java
+++ b/airbyte-workers/src/main/java/io/airbyte/workers/temporal/ConnectionManagerUtils.java
@@ -205,10 +205,12 @@ public class ConnectionManagerUtils {
   }
 
   static WorkflowExecutionStatus getConnectionManagerWorkflowStatus(final WorkflowClient workflowClient, final UUID connectionId) {
+    log.info("PARKER: getConnectionManagerWorkflowStatus namespace: {}", workflowClient.getOptions().getNamespace());
     final DescribeWorkflowExecutionRequest describeWorkflowExecutionRequest = DescribeWorkflowExecutionRequest.newBuilder()
-        .setExecution(WorkflowExecution.newBuilder().setWorkflowId(getConnectionManagerName(connectionId)).build())
-        .setNamespace(workflowClient.getOptions().getNamespace())
-        .build();
+        .setExecution(WorkflowExecution.newBuilder()
+            .setWorkflowId(getConnectionManagerName(connectionId))
+            .build())
+        .setNamespace(workflowClient.getOptions().getNamespace()).build();
 
     final DescribeWorkflowExecutionResponse describeWorkflowExecutionResponse = workflowClient.getWorkflowServiceStubs().blockingStub()
         .describeWorkflowExecution(describeWorkflowExecutionRequest);

--- a/airbyte-workers/src/main/java/io/airbyte/workers/temporal/ConnectionManagerUtils.java
+++ b/airbyte-workers/src/main/java/io/airbyte/workers/temporal/ConnectionManagerUtils.java
@@ -142,14 +142,10 @@ public class ConnectionManagerUtils {
   }
 
   static ConnectionManagerWorkflow startConnectionManagerNoSignal(final WorkflowClient client, final UUID connectionId) {
-    log.info("PARKER: inside startConnectionManagerNoSignal...");
     final ConnectionManagerWorkflow connectionManagerWorkflow = newConnectionManagerWorkflowStub(client, connectionId);
-    log.info("PARKER: created  connectionManagerWorkflow stub...");
     final ConnectionUpdaterInput input = buildStartWorkflowInput(connectionId);
-    log.info("PARKER: built ConnectionUpdaterInput... about to call WorkflowClient.start");
     WorkflowClient.start(connectionManagerWorkflow::run, input);
 
-    log.info("PARKER: called start, returning the workflow...");
     return connectionManagerWorkflow;
   }
 
@@ -208,7 +204,6 @@ public class ConnectionManagerUtils {
   }
 
   static WorkflowExecutionStatus getConnectionManagerWorkflowStatus(final WorkflowClient workflowClient, final UUID connectionId) {
-    log.info("PARKER: getConnectionManagerWorkflowStatus namespace: {}", workflowClient.getOptions().getNamespace());
     final DescribeWorkflowExecutionRequest describeWorkflowExecutionRequest = DescribeWorkflowExecutionRequest.newBuilder()
         .setExecution(WorkflowExecution.newBuilder()
             .setWorkflowId(getConnectionManagerName(connectionId))

--- a/airbyte-workers/src/main/java/io/airbyte/workers/temporal/ConnectionManagerUtils.java
+++ b/airbyte-workers/src/main/java/io/airbyte/workers/temporal/ConnectionManagerUtils.java
@@ -142,11 +142,14 @@ public class ConnectionManagerUtils {
   }
 
   static ConnectionManagerWorkflow startConnectionManagerNoSignal(final WorkflowClient client, final UUID connectionId) {
+    log.info("PARKER: inside startConnectionManagerNoSignal...");
     final ConnectionManagerWorkflow connectionManagerWorkflow = newConnectionManagerWorkflowStub(client, connectionId);
+    log.info("PARKER: created  connectionManagerWorkflow stub...");
     final ConnectionUpdaterInput input = buildStartWorkflowInput(connectionId);
-
+    log.info("PARKER: built ConnectionUpdaterInput... about to call WorkflowClient.start");
     WorkflowClient.start(connectionManagerWorkflow::run, input);
 
+    log.info("PARKER: called start, returning the workflow...");
     return connectionManagerWorkflow;
   }
 

--- a/airbyte-workers/src/main/java/io/airbyte/workers/temporal/TemporalClient.java
+++ b/airbyte-workers/src/main/java/io/airbyte/workers/temporal/TemporalClient.java
@@ -130,8 +130,7 @@ public class TemporalClient {
   /**
    * Direct termination of Temporal Workflows should generally be avoided. This method exists for some
    * rare circumstances where this may be required. Originally added to facilitate Airbyte's migration
-   * to Temporal Cloud.
-   * TODO consider deleting this after Temporal Cloud migration
+   * to Temporal Cloud. TODO consider deleting this after Temporal Cloud migration
    */
   public void dangerouslyTerminateWorkflow(final String workflowId, final String reason) {
     this.client.newUntypedWorkflowStub(workflowId).terminate(reason);

--- a/airbyte-workers/src/main/java/io/airbyte/workers/temporal/TemporalClient.java
+++ b/airbyte-workers/src/main/java/io/airbyte/workers/temporal/TemporalClient.java
@@ -82,6 +82,7 @@ public class TemporalClient {
     return WorkerFactory.newInstance(airbyteWorkflowClient(TemporalUtils.createTemporalAirbyteService()));
   }
 
+  // TODO consider making this private after the Temporal Cloud migration
   public static TemporalClient cloud(final Configs configs) {
     log.info("Using Temporal Cloud with:\nhost: {}\nnamespace: {}", configs.getTemporalCloudHost(), configs.getTemporalCloudNamespace());
     final WorkflowServiceStubs temporalCloudService = TemporalUtils.createTemporalCloudService();
@@ -95,6 +96,7 @@ public class TemporalClient {
         temporalCloudService);
   }
 
+  // TODO consider making this private after the Temporal Cloud migration
   public static TemporalClient airbyte(final Configs configs) {
     final String temporalHost = configs.getTemporalHost();
     log.info("Using Temporal Airbyte with:\nhost: {}\nnamespace: {}", temporalHost, TemporalUtils.DEFAULT_NAMESPACE);
@@ -129,6 +131,7 @@ public class TemporalClient {
    * Direct termination of Temporal Workflows should generally be avoided. This method exists for some
    * rare circumstances where this may be required. Originally added to facilitate Airbyte's migration
    * to Temporal Cloud.
+   * TODO consider deleting this after Temporal Cloud migration
    */
   public void dangerouslyTerminateWorkflow(final String workflowId, final String reason) {
     this.client.newUntypedWorkflowStub(workflowId).terminate(reason);

--- a/airbyte-workers/src/main/java/io/airbyte/workers/temporal/TemporalClient.java
+++ b/airbyte-workers/src/main/java/io/airbyte/workers/temporal/TemporalClient.java
@@ -118,17 +118,17 @@ public class TemporalClient {
   // one. either temporal decides and can report it or it is injected into temporal runs.
   @VisibleForTesting
   protected TemporalClient(final WorkflowClient client,
-      final Path workspaceRoot,
-      final WorkflowServiceStubs workflowServiceStubs) {
+                           final Path workspaceRoot,
+                           final WorkflowServiceStubs workflowServiceStubs) {
     this.client = client;
     this.workspaceRoot = workspaceRoot;
     this.service = workflowServiceStubs;
   }
 
   /**
-   * Direct termination of Temporal Workflows should generally be avoided.
-   * This method exists for some rare circumstances where this may be required. Originally added
-   * to facilitate Airbyte's migration to Temporal Cloud.
+   * Direct termination of Temporal Workflows should generally be avoided. This method exists for some
+   * rare circumstances where this may be required. Originally added to facilitate Airbyte's migration
+   * to Temporal Cloud.
    */
   public void dangerouslyTerminateWorkflow(final String workflowId, final String reason) {
     this.client.newUntypedWorkflowStub(workflowId).terminate(reason);

--- a/airbyte-workers/src/main/java/io/airbyte/workers/temporal/TemporalClient.java
+++ b/airbyte-workers/src/main/java/io/airbyte/workers/temporal/TemporalClient.java
@@ -92,7 +92,8 @@ public class TemporalClient {
   }
 
   // TODO consider making this private after the Temporal Cloud migration.
-  // This method only exists to allow the migrator to instantiate a cloud and non-cloud temporal client at the same time.
+  // This method only exists to allow the migrator to instantiate a cloud and non-cloud temporal
+  // client at the same time.
   public static TemporalClient cloud(final Configs configs) {
     final WorkflowServiceStubs temporalCloudService = TemporalUtils.createTemporalService(true);
     return new TemporalClient(
@@ -106,7 +107,8 @@ public class TemporalClient {
   }
 
   // TODO consider making this private after the Temporal Cloud migration
-  // This method only exists to allow the migrator to instantiate a cloud and non-cloud temporal client at the same time.
+  // This method only exists to allow the migrator to instantiate a cloud and non-cloud temporal
+  // client at the same time.
   public static TemporalClient airbyte(final Configs configs) {
     final WorkflowServiceStubs temporalService = TemporalUtils.createTemporalService(false);
     return new TemporalClient(WorkflowClient.newInstance(temporalService), configs.getWorkspaceRoot(), temporalService);
@@ -264,8 +266,9 @@ public class TemporalClient {
   }
 
   /**
-   * Refreshes the cache of running workflows, and returns their names. Currently called by the Temporal Cloud migrator to generate a list of
-   * workflows that should be migrated. After the Temporal Migration is complete, this could be removed, though it may be handy for a future use
+   * Refreshes the cache of running workflows, and returns their names. Currently called by the
+   * Temporal Cloud migrator to generate a list of workflows that should be migrated. After the
+   * Temporal Migration is complete, this could be removed, though it may be handy for a future use
    * case.
    */
   public Set<String> getAllRunningWorkflows() {

--- a/airbyte-workers/src/main/java/io/airbyte/workers/temporal/TemporalClient.java
+++ b/airbyte-workers/src/main/java/io/airbyte/workers/temporal/TemporalClient.java
@@ -228,7 +228,6 @@ public class TemporalClient {
   public ConnectionManagerWorkflow submitConnectionUpdaterAsync(final UUID connectionId) {
     log.info("Starting the scheduler temporal wf");
     final ConnectionManagerWorkflow connectionManagerWorkflow = ConnectionManagerUtils.startConnectionManagerNoSignal(client, connectionId);
-        connectionManagerWorkflow.getState());
     try {
       CompletableFuture.supplyAsync(() -> {
         try {

--- a/airbyte-workers/src/main/java/io/airbyte/workers/temporal/TemporalClient.java
+++ b/airbyte-workers/src/main/java/io/airbyte/workers/temporal/TemporalClient.java
@@ -228,19 +228,14 @@ public class TemporalClient {
   public ConnectionManagerWorkflow submitConnectionUpdaterAsync(final UUID connectionId) {
     log.info("Starting the scheduler temporal wf");
     final ConnectionManagerWorkflow connectionManagerWorkflow = ConnectionManagerUtils.startConnectionManagerNoSignal(client, connectionId);
-    log.info("PARKER: called startConnectionManagerNoSignal, got this: {} with getState: {}", connectionManagerWorkflow,
         connectionManagerWorkflow.getState());
     try {
-      log.info("PARKER: about to create while loop");
       CompletableFuture.supplyAsync(() -> {
         try {
           do {
-            log.info("PARKER: sleeping between queries");
             Thread.sleep(DELAY_BETWEEN_QUERY_MS);
           } while (!isWorkflowReachable(connectionId));
-        } catch (final InterruptedException e) {
-          log.error("PARKER: caught an interrupted exception:", e);
-        }
+        } catch (final InterruptedException e) {}
         return null;
       }).get(60, TimeUnit.SECONDS);
     } catch (final InterruptedException | ExecutionException e) {
@@ -476,7 +471,6 @@ public class TemporalClient {
       ConnectionManagerUtils.getConnectionManagerWorkflow(client, connectionId);
       return true;
     } catch (final Exception e) {
-      log.error("PARKER: caught isWorkflowReachable exception.", e);
       return false;
     }
   }

--- a/airbyte-workers/src/main/java/io/airbyte/workers/temporal/TemporalUtils.java
+++ b/airbyte-workers/src/main/java/io/airbyte/workers/temporal/TemporalUtils.java
@@ -66,8 +66,10 @@ public class TemporalUtils {
     return createTemporalService(configs.temporalCloudEnabled());
   }
 
-  // TODO consider consolidating this into above method after the Temporal Cloud migration is complete.
-  // This method only exists to allow the migrator to instantiate a cloud and non-cloud temporal client at the same time.
+  // TODO consider consolidating this into above method after the Temporal Cloud migration is
+  // complete.
+  // This method only exists to allow the migrator to instantiate a cloud and non-cloud temporal
+  // client at the same time.
   public static WorkflowServiceStubs createTemporalService(final boolean isCloud) {
     if (isCloud) {
       log.info("createTemporalService chose Cloud...");
@@ -92,7 +94,12 @@ public class TemporalUtils {
       }
     }
     log.info("createTemporalService chose Airbyte...");
-    log.info("Using Temporal Airbyte with:\nhost: {}\nnamespace: {}", configs.getTemporalHost(), DEFAULT_NAMESPACE);
+    return createAirbyteTemporalServiceAndConfigureNamespace(configs.getTemporalHost());
+  }
+
+  @VisibleForTesting
+  public static WorkflowServiceStubs createAirbyteTemporalServiceAndConfigureNamespace(final String temporalHost) {
+    log.info("Using Temporal Airbyte with:\nhost: {}\nnamespace: {}", temporalHost, DEFAULT_NAMESPACE);
     final WorkflowServiceStubsOptions options = WorkflowServiceStubsOptions.newBuilder()
         .setTarget(configs.getTemporalHost())
         .build();
@@ -147,7 +154,8 @@ public class TemporalUtils {
   public static WorkflowOptions getWorkflowOptions(final TemporalJobType jobType) {
     return WorkflowOptions.newBuilder()
         .setTaskQueue(jobType.name())
-        .setWorkflowTaskTimeout(Duration.ofSeconds(27)) // TODO parker - temporarily increasing this to a recognizable number to see if it changes error I'm seeing
+        .setWorkflowTaskTimeout(Duration.ofSeconds(27)) // TODO parker - temporarily increasing this to a recognizable number to see if it changes
+        // error I'm seeing
         // todo (cgardens) we do not leverage Temporal retries.
         .setRetryOptions(RetryOptions.newBuilder().setMaximumAttempts(1).build())
         .build();

--- a/airbyte-workers/src/main/java/io/airbyte/workers/temporal/TemporalUtils.java
+++ b/airbyte-workers/src/main/java/io/airbyte/workers/temporal/TemporalUtils.java
@@ -4,8 +4,7 @@
 
 package io.airbyte.workers.temporal;
 
-import static java.util.stream.Collectors.toSet;
-
+import com.google.common.annotations.VisibleForTesting;
 import io.airbyte.commons.lang.Exceptions;
 import io.airbyte.config.Configs;
 import io.airbyte.config.EnvConfigs;
@@ -15,20 +14,20 @@ import io.temporal.api.common.v1.WorkflowExecution;
 import io.temporal.api.namespace.v1.NamespaceConfig;
 import io.temporal.api.namespace.v1.NamespaceInfo;
 import io.temporal.api.workflowservice.v1.DescribeNamespaceRequest;
-import io.temporal.api.workflowservice.v1.DescribeNamespaceResponse;
-import io.temporal.api.workflowservice.v1.ListNamespacesRequest;
 import io.temporal.api.workflowservice.v1.UpdateNamespaceRequest;
 import io.temporal.client.ActivityCompletionException;
 import io.temporal.client.WorkflowClient;
 import io.temporal.client.WorkflowOptions;
 import io.temporal.client.WorkflowStub;
 import io.temporal.common.RetryOptions;
+import io.temporal.serviceclient.SimpleSslContextBuilder;
 import io.temporal.serviceclient.WorkflowServiceStubs;
 import io.temporal.serviceclient.WorkflowServiceStubsOptions;
 import io.temporal.workflow.Functions;
+import java.io.FileInputStream;
+import java.io.InputStream;
 import java.io.Serializable;
 import java.time.Duration;
-import java.util.Set;
 import java.util.UUID;
 import java.util.concurrent.Callable;
 import java.util.concurrent.CompletableFuture;
@@ -37,60 +36,117 @@ import java.util.concurrent.ScheduledExecutorService;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicReference;
 import java.util.function.Supplier;
+import lombok.extern.slf4j.Slf4j;
 import org.apache.commons.lang3.time.DurationFormatUtils;
 import org.apache.commons.lang3.tuple.ImmutablePair;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 
+@Slf4j
 public class TemporalUtils {
 
-  private static final Logger LOGGER = LoggerFactory.getLogger(TemporalUtils.class);
+  private static final Configs configs = new EnvConfigs();
+  private static final Duration WORKFLOW_EXECUTION_TTL = Duration.ofDays(configs.getTemporalRetentionInDays());
+  private static final Duration WAIT_INTERVAL = Duration.ofSeconds(2);
+  private static final Duration MAX_TIME_TO_CONNECT = Duration.ofMinutes(2);
+  private static final Duration WAIT_TIME_AFTER_CONNECT = Duration.ofSeconds(5);
+  private static final String HUMAN_READABLE_WORKFLOW_EXECUTION_TTL =
+      DurationFormatUtils.formatDurationWords(WORKFLOW_EXECUTION_TTL.toMillis(), true, true);
 
+  public static final String DEFAULT_NAMESPACE = "default";
   public static final Duration SEND_HEARTBEAT_INTERVAL = Duration.ofSeconds(10);
   public static final Duration HEARTBEAT_TIMEOUT = Duration.ofSeconds(30);
-
-  public static WorkflowServiceStubs createTemporalService(final String temporalHost) {
-    final WorkflowServiceStubsOptions options = WorkflowServiceStubsOptions.newBuilder()
-        .setTarget(temporalHost) // todo: move to EnvConfigs
-        .build();
-
-    return getTemporalClientWhenConnected(
-        Duration.ofSeconds(2),
-        Duration.ofMinutes(2),
-        Duration.ofSeconds(5),
-        () -> WorkflowServiceStubs.newInstance(options));
-  }
-
   public static final RetryOptions NO_RETRY = RetryOptions.newBuilder().setMaximumAttempts(1).build();
-
-  private static final Configs configs = new EnvConfigs();
   public static final RetryOptions RETRY = RetryOptions.newBuilder()
       .setMaximumAttempts(configs.getActivityNumberOfAttempt())
       .setInitialInterval(Duration.ofSeconds(configs.getInitialDelayBetweenActivityAttemptsSeconds()))
       .setMaximumInterval(Duration.ofSeconds(configs.getMaxDelayBetweenActivityAttemptsSeconds()))
       .build();
 
-  public static final String DEFAULT_NAMESPACE = "default";
+  public static WorkflowServiceStubs createTemporalProductionService() {
+    if (configs.temporalCloudEnabled()) {
+      log.info("createTemporalProductionService chose Cloud...");
+      return createTemporalCloudService();
+    }
+    log.info("createTemporalProductionService chose Airbyte...");
+    final WorkflowServiceStubs temporalService = createTemporalAirbyteService();
+    configureTemporalAirbyteNamespace(temporalService);
+    return temporalService;
+  }
 
-  private static final Duration WORKFLOW_EXECUTION_TTL = Duration.ofDays(configs.getTemporalRetentionInDays());
-  private static final String HUMAN_READABLE_WORKFLOW_EXECUTION_TTL =
-      DurationFormatUtils.formatDurationWords(WORKFLOW_EXECUTION_TTL.toMillis(), true, true);
+  public static WorkflowServiceStubs createTemporalCloudService() {
+    return createTemporalCloudService(
+        configs.getTemporalCloudClientCertPath(),
+        configs.getTemporalCloudClientKeyPath(),
+        configs.getTemporalCloudHost(),
+        configs.getTemporalCloudNamespace());
+  }
 
-  public static void configureTemporalNamespace(final WorkflowServiceStubs temporalService) {
+  @VisibleForTesting
+  public static WorkflowServiceStubs createTemporalCloudService(
+                                                                final String temporalCloudClientCertPath,
+                                                                final String temporalCloudClientKeyPath,
+                                                                final String temporalHost,
+                                                                final String temporalNamespace) {
+    try {
+      final InputStream clientCert = new FileInputStream(temporalCloudClientCertPath);
+      final InputStream clientKey = new FileInputStream(temporalCloudClientKeyPath);
+
+      final WorkflowServiceStubsOptions options = WorkflowServiceStubsOptions.newBuilder()
+          .setSslContext(SimpleSslContextBuilder.forPKCS8(clientCert, clientKey).build())
+          .setTarget(temporalHost)
+          .build();
+
+      return getTemporalClientWhenConnected(
+          WAIT_INTERVAL,
+          MAX_TIME_TO_CONNECT,
+          WAIT_TIME_AFTER_CONNECT,
+          () -> WorkflowServiceStubs.newInstance(options),
+          temporalNamespace);
+    } catch (final Exception e) {
+      throw new RuntimeException(e);
+    }
+  }
+
+  public static WorkflowServiceStubs createTemporalAirbyteService() {
+    return createTemporalAirbyteService(configs.getTemporalHost());
+  }
+
+  @VisibleForTesting
+  public static WorkflowServiceStubs createTemporalAirbyteService(final String temporalHost) {
+    final WorkflowServiceStubsOptions options = WorkflowServiceStubsOptions.newBuilder()
+        .setTarget(temporalHost)
+        .build();
+
+    final WorkflowServiceStubs temporalService = getTemporalClientWhenConnected(
+        WAIT_INTERVAL,
+        MAX_TIME_TO_CONNECT,
+        WAIT_TIME_AFTER_CONNECT,
+        () -> WorkflowServiceStubs.newInstance(options),
+        DEFAULT_NAMESPACE);
+
+    configureTemporalAirbyteNamespace(temporalService);
+
+    return temporalService;
+  }
+
+  public static String getProductionNamespace() {
+    return configs.temporalCloudEnabled() ? configs.getTemporalCloudNamespace() : TemporalUtils.DEFAULT_NAMESPACE;
+  }
+
+  private static void configureTemporalAirbyteNamespace(final WorkflowServiceStubs temporalService) {
     final var client = temporalService.blockingStub();
     final var describeNamespaceRequest = DescribeNamespaceRequest.newBuilder().setNamespace(DEFAULT_NAMESPACE).build();
     final var currentRetentionGrpcDuration = client.describeNamespace(describeNamespaceRequest).getConfig().getWorkflowExecutionRetentionTtl();
     final var currentRetention = Duration.ofSeconds(currentRetentionGrpcDuration.getSeconds());
 
     if (currentRetention.equals(WORKFLOW_EXECUTION_TTL)) {
-      LOGGER.info("Workflow execution TTL already set for namespace " + DEFAULT_NAMESPACE + ". Remains unchanged as: "
+      log.info("Workflow execution TTL already set for namespace " + DEFAULT_NAMESPACE + ". Remains unchanged as: "
           + HUMAN_READABLE_WORKFLOW_EXECUTION_TTL);
     } else {
       final var newGrpcDuration = com.google.protobuf.Duration.newBuilder().setSeconds(WORKFLOW_EXECUTION_TTL.getSeconds()).build();
       final var humanReadableCurrentRetention = DurationFormatUtils.formatDurationWords(currentRetention.toMillis(), true, true);
       final var namespaceConfig = NamespaceConfig.newBuilder().setWorkflowExecutionRetentionTtl(newGrpcDuration).build();
       final var updateNamespaceRequest = UpdateNamespaceRequest.newBuilder().setNamespace(DEFAULT_NAMESPACE).setConfig(namespaceConfig).build();
-      LOGGER.info("Workflow execution TTL differs for namespace " + DEFAULT_NAMESPACE + ". Changing from (" + humanReadableCurrentRetention + ") to ("
+      log.info("Workflow execution TTL differs for namespace " + DEFAULT_NAMESPACE + ". Changing from (" + humanReadableCurrentRetention + ") to ("
           + HUMAN_READABLE_WORKFLOW_EXECUTION_TTL + "). ");
       client.updateNamespace(updateNamespaceRequest);
     }
@@ -163,7 +219,7 @@ public class TemporalUtils {
 
   /**
    * Loops and waits for the Temporal service to become available and returns a client.
-   *
+   * <p>
    * This function uses a supplier as input since the creation of a WorkflowServiceStubs can result in
    * connection exceptions as well.
    */
@@ -171,47 +227,45 @@ public class TemporalUtils {
                                                                     final Duration waitInterval,
                                                                     final Duration maxTimeToConnect,
                                                                     final Duration waitAfterConnection,
-                                                                    final Supplier<WorkflowServiceStubs> temporalServiceSupplier) {
-    LOGGER.info("Waiting for temporal server...");
+                                                                    final Supplier<WorkflowServiceStubs> temporalServiceSupplier,
+                                                                    final String namespace) {
+    log.info("Waiting for temporal server...");
 
-    boolean temporalStatus = false;
+    boolean temporalNamespaceInitialized = false;
     WorkflowServiceStubs temporalService = null;
     long millisWaited = 0;
 
-    while (!temporalStatus) {
+    while (!temporalNamespaceInitialized) {
       if (millisWaited >= maxTimeToConnect.toMillis()) {
         throw new RuntimeException("Could not create Temporal client within max timeout!");
       }
 
-      LOGGER.warn("Waiting for default namespace to be initialized in temporal...");
+      log.warn("Waiting for namespace {} to be initialized in temporal...", namespace);
       Exceptions.toRuntime(() -> Thread.sleep(waitInterval.toMillis()));
       millisWaited = millisWaited + waitInterval.toMillis();
 
       try {
         temporalService = temporalServiceSupplier.get();
-        temporalStatus = getNamespaces(temporalService).contains("default");
+        final var namespaceInfo = getNamespaceInfo(temporalService, namespace);
+        temporalNamespaceInitialized = namespaceInfo.isInitialized();
       } catch (final Exception e) {
         // Ignore the exception because this likely means that the Temporal service is still initializing.
-        LOGGER.warn("Ignoring exception while trying to request Temporal namespaces:", e);
+        log.warn("Ignoring exception while trying to request Temporal namespace:", e);
       }
     }
 
     // sometimes it takes a few additional seconds for workflow queue listening to be available
     Exceptions.toRuntime(() -> Thread.sleep(waitAfterConnection.toMillis()));
 
-    LOGGER.info("Found temporal default namespace!");
+    log.info("Temporal namespace {} initialized!", namespace);
 
     return temporalService;
   }
 
-  protected static Set<String> getNamespaces(final WorkflowServiceStubs temporalService) {
+  protected static NamespaceInfo getNamespaceInfo(final WorkflowServiceStubs temporalService, final String namespace) {
     return temporalService.blockingStub()
-        .listNamespaces(ListNamespacesRequest.newBuilder().build())
-        .getNamespacesList()
-        .stream()
-        .map(DescribeNamespaceResponse::getNamespaceInfo)
-        .map(NamespaceInfo::getName)
-        .collect(toSet());
+        .describeNamespace(DescribeNamespaceRequest.newBuilder().setNamespace(namespace).build())
+        .getNamespaceInfo();
   }
 
   /**
@@ -229,12 +283,12 @@ public class TemporalUtils {
 
       return callable.call();
     } catch (final ActivityCompletionException e) {
-      LOGGER.warn("Job either timed out or was cancelled.");
+      log.warn("Job either timed out or was cancelled.");
       throw new RuntimeException(e);
     } catch (final Exception e) {
       throw new RuntimeException(e);
     } finally {
-      LOGGER.info("Stopping temporal heartbeating...");
+      log.info("Stopping temporal heartbeating...");
       scheduledExecutor.shutdown();
     }
   }
@@ -260,12 +314,12 @@ public class TemporalUtils {
 
       return callable.call();
     } catch (final ActivityCompletionException e) {
-      LOGGER.warn("Job either timed out or was cancelled.");
+      log.warn("Job either timed out or was cancelled.");
       throw new RuntimeException(e);
     } catch (final Exception e) {
       throw new RuntimeException(e);
     } finally {
-      LOGGER.info("Stopping temporal heartbeating...");
+      log.info("Stopping temporal heartbeating...");
       scheduledExecutor.shutdown();
     }
   }

--- a/airbyte-workers/src/main/java/io/airbyte/workers/temporal/TemporalUtils.java
+++ b/airbyte-workers/src/main/java/io/airbyte/workers/temporal/TemporalUtils.java
@@ -24,9 +24,10 @@ import io.temporal.serviceclient.SimpleSslContextBuilder;
 import io.temporal.serviceclient.WorkflowServiceStubs;
 import io.temporal.serviceclient.WorkflowServiceStubsOptions;
 import io.temporal.workflow.Functions;
-import java.io.FileInputStream;
+import java.io.ByteArrayInputStream;
 import java.io.InputStream;
 import java.io.Serializable;
+import java.nio.charset.StandardCharsets;
 import java.time.Duration;
 import java.util.UUID;
 import java.util.concurrent.Callable;
@@ -74,21 +75,21 @@ public class TemporalUtils {
 
   public static WorkflowServiceStubs createTemporalCloudService() {
     return createTemporalCloudService(
-        configs.getTemporalCloudClientCertPath(),
-        configs.getTemporalCloudClientKeyPath(),
+        configs.getTemporalCloudClientCert(),
+        configs.getTemporalCloudClientKey(),
         configs.getTemporalCloudHost(),
         configs.getTemporalCloudNamespace());
   }
 
   @VisibleForTesting
   public static WorkflowServiceStubs createTemporalCloudService(
-                                                                final String temporalCloudClientCertPath,
-                                                                final String temporalCloudClientKeyPath,
+                                                                final String temporalCloudClientCert,
+                                                                final String temporalCloudClientKey,
                                                                 final String temporalHost,
                                                                 final String temporalNamespace) {
     try {
-      final InputStream clientCert = new FileInputStream(temporalCloudClientCertPath);
-      final InputStream clientKey = new FileInputStream(temporalCloudClientKeyPath);
+      final InputStream clientCert = new ByteArrayInputStream(temporalCloudClientCert.getBytes(StandardCharsets.UTF_8));
+      final InputStream clientKey = new ByteArrayInputStream(temporalCloudClientKey.getBytes(StandardCharsets.UTF_8));
 
       final WorkflowServiceStubsOptions options = WorkflowServiceStubsOptions.newBuilder()
           .setSslContext(SimpleSslContextBuilder.forPKCS8(clientCert, clientKey).build())

--- a/airbyte-workers/src/main/java/io/airbyte/workers/temporal/TemporalUtils.java
+++ b/airbyte-workers/src/main/java/io/airbyte/workers/temporal/TemporalUtils.java
@@ -83,10 +83,10 @@ public class TemporalUtils {
   }
 
   private static WorkflowServiceStubs createTemporalCloudService(
-                                                                final String temporalCloudClientCert,
-                                                                final String temporalCloudClientKey,
-                                                                final String temporalHost,
-                                                                final String temporalNamespace) {
+                                                                 final String temporalCloudClientCert,
+                                                                 final String temporalCloudClientKey,
+                                                                 final String temporalHost,
+                                                                 final String temporalNamespace) {
     try {
       final InputStream clientCert = new ByteArrayInputStream(temporalCloudClientCert.getBytes(StandardCharsets.UTF_8));
       final InputStream clientKey = new ByteArrayInputStream(temporalCloudClientKey.getBytes(StandardCharsets.UTF_8));

--- a/airbyte-workers/src/main/java/io/airbyte/workers/temporal/TemporalUtils.java
+++ b/airbyte-workers/src/main/java/io/airbyte/workers/temporal/TemporalUtils.java
@@ -174,6 +174,7 @@ public class TemporalUtils {
   public static WorkflowOptions getWorkflowOptions(final TemporalJobType jobType) {
     return WorkflowOptions.newBuilder()
         .setTaskQueue(jobType.name())
+        .setWorkflowTaskTimeout(Duration.ofSeconds(27)) // TODO parker - temporarily increasing this to a recognizable number to see if it changes error I'm seeing
         // todo (cgardens) we do not leverage Temporal retries.
         .setRetryOptions(RetryOptions.newBuilder().setMaximumAttempts(1).build())
         .build();

--- a/airbyte-workers/src/main/java/io/airbyte/workers/temporal/TemporalUtils.java
+++ b/airbyte-workers/src/main/java/io/airbyte/workers/temporal/TemporalUtils.java
@@ -73,6 +73,7 @@ public class TemporalUtils {
     return temporalService;
   }
 
+  // TODO consider making this private after the Temporal Cloud migration
   public static WorkflowServiceStubs createTemporalCloudService() {
     return createTemporalCloudService(
         configs.getTemporalCloudClientCert(),
@@ -81,8 +82,7 @@ public class TemporalUtils {
         configs.getTemporalCloudNamespace());
   }
 
-  @VisibleForTesting
-  public static WorkflowServiceStubs createTemporalCloudService(
+  private static WorkflowServiceStubs createTemporalCloudService(
                                                                 final String temporalCloudClientCert,
                                                                 final String temporalCloudClientKey,
                                                                 final String temporalHost,
@@ -107,10 +107,12 @@ public class TemporalUtils {
     }
   }
 
+  // TODO consider making this private after the Temporal Cloud migration
   public static WorkflowServiceStubs createTemporalAirbyteService() {
     return createTemporalAirbyteService(configs.getTemporalHost());
   }
 
+  // Public so that AcceptanceTests can call this with localhost input
   @VisibleForTesting
   public static WorkflowServiceStubs createTemporalAirbyteService(final String temporalHost) {
     final WorkflowServiceStubsOptions options = WorkflowServiceStubsOptions.newBuilder()

--- a/airbyte-workers/src/test/java/io/airbyte/workers/temporal/TemporalClientTest.java
+++ b/airbyte-workers/src/test/java/io/airbyte/workers/temporal/TemporalClientTest.java
@@ -21,7 +21,6 @@ import static org.mockito.Mockito.when;
 
 import com.google.common.collect.Sets;
 import io.airbyte.commons.json.Jsons;
-import io.airbyte.config.Configs;
 import io.airbyte.config.JobCheckConnectionConfig;
 import io.airbyte.config.JobDiscoverCatalogConfig;
 import io.airbyte.config.JobGetSpecConfig;
@@ -92,7 +91,6 @@ class TemporalClientTest {
   private Path logPath;
   private WorkflowServiceStubs workflowServiceStubs;
   private WorkflowServiceBlockingStub workflowServiceBlockingStub;
-  private Configs configs;
 
   @BeforeEach
   void setup() throws IOException {
@@ -105,7 +103,7 @@ class TemporalClientTest {
     workflowServiceBlockingStub = mock(WorkflowServiceBlockingStub.class);
     when(workflowServiceStubs.blockingStub()).thenReturn(workflowServiceBlockingStub);
     mockWorkflowStatus(WorkflowExecutionStatus.WORKFLOW_EXECUTION_STATUS_RUNNING);
-    temporalClient = spy(new TemporalClient(workflowClient, workspaceRoot, workflowServiceStubs, configs));
+    temporalClient = spy(new TemporalClient(workflowClient, workspaceRoot, workflowServiceStubs));
   }
 
   @Nested

--- a/airbyte-workers/src/test/java/io/airbyte/workers/temporal/TemporalUtilsTest.java
+++ b/airbyte-workers/src/test/java/io/airbyte/workers/temporal/TemporalUtilsTest.java
@@ -43,11 +43,13 @@ import java.util.concurrent.atomic.AtomicInteger;
 import java.util.concurrent.atomic.AtomicReference;
 import java.util.function.Supplier;
 import org.apache.commons.lang3.tuple.ImmutablePair;
+import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Test;
 import org.mockito.Mockito;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+@Disabled
 class TemporalUtilsTest {
 
   private static final String TASK_QUEUE = "default";
@@ -100,8 +102,9 @@ class TemporalUtilsTest {
     final DescribeNamespaceResponse describeNamespaceResponse = mock(DescribeNamespaceResponse.class);
     final NamespaceInfo namespaceInfo = mock(NamespaceInfo.class);
     final Supplier<WorkflowServiceStubs> serviceSupplier = mock(Supplier.class);
+    final String namespace = "default";
 
-    when(namespaceInfo.getName()).thenReturn("default");
+    when(namespaceInfo.getName()).thenReturn(namespace);
     when(describeNamespaceResponse.getNamespaceInfo()).thenReturn(namespaceInfo);
     when(serviceSupplier.get())
         .thenThrow(RuntimeException.class)
@@ -109,7 +112,7 @@ class TemporalUtilsTest {
     when(workflowServiceStubs.blockingStub().listNamespaces(any()).getNamespacesList())
         .thenThrow(RuntimeException.class)
         .thenReturn(List.of(describeNamespaceResponse));
-    getTemporalClientWhenConnected(Duration.ofMillis(10), Duration.ofSeconds(1), Duration.ofSeconds(0), serviceSupplier);
+    getTemporalClientWhenConnected(Duration.ofMillis(10), Duration.ofSeconds(1), Duration.ofSeconds(0), serviceSupplier, namespace);
   }
 
   @Test
@@ -118,8 +121,9 @@ class TemporalUtilsTest {
     final DescribeNamespaceResponse describeNamespaceResponse = mock(DescribeNamespaceResponse.class);
     final NamespaceInfo namespaceInfo = mock(NamespaceInfo.class);
     final Supplier<WorkflowServiceStubs> serviceSupplier = mock(Supplier.class);
+    final String namespace = "default";
 
-    when(namespaceInfo.getName()).thenReturn("default");
+    when(namespaceInfo.getName()).thenReturn(namespace);
     when(describeNamespaceResponse.getNamespaceInfo()).thenReturn(namespaceInfo);
     when(serviceSupplier.get())
         .thenThrow(RuntimeException.class)
@@ -128,7 +132,7 @@ class TemporalUtilsTest {
         .thenThrow(RuntimeException.class)
         .thenReturn(List.of(describeNamespaceResponse));
     assertThrows(RuntimeException.class, () -> {
-      getTemporalClientWhenConnected(Duration.ofMillis(100), Duration.ofMillis(10), Duration.ofSeconds(0), serviceSupplier);
+      getTemporalClientWhenConnected(Duration.ofMillis(100), Duration.ofMillis(10), Duration.ofSeconds(0), serviceSupplier, namespace);
     });
   }
 

--- a/airbyte-workers/src/test/java/io/airbyte/workers/temporal/TemporalUtilsTest.java
+++ b/airbyte-workers/src/test/java/io/airbyte/workers/temporal/TemporalUtilsTest.java
@@ -102,6 +102,7 @@ class TemporalUtilsTest {
     final Supplier<WorkflowServiceStubs> serviceSupplier = mock(Supplier.class);
     final String namespace = "default";
 
+    when(namespaceInfo.isInitialized()).thenReturn(true);
     when(namespaceInfo.getName()).thenReturn(namespace);
     when(describeNamespaceResponse.getNamespaceInfo()).thenReturn(namespaceInfo);
     when(serviceSupplier.get())

--- a/airbyte-workers/src/test/java/io/airbyte/workers/temporal/TemporalUtilsTest.java
+++ b/airbyte-workers/src/test/java/io/airbyte/workers/temporal/TemporalUtilsTest.java
@@ -49,7 +49,6 @@ import org.mockito.Mockito;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-@Disabled
 class TemporalUtilsTest {
 
   private static final String TASK_QUEUE = "default";

--- a/airbyte-workers/src/test/java/io/airbyte/workers/temporal/TemporalUtilsTest.java
+++ b/airbyte-workers/src/test/java/io/airbyte/workers/temporal/TemporalUtilsTest.java
@@ -43,7 +43,6 @@ import java.util.concurrent.atomic.AtomicInteger;
 import java.util.concurrent.atomic.AtomicReference;
 import java.util.function.Supplier;
 import org.apache.commons.lang3.tuple.ImmutablePair;
-import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Test;
 import org.mockito.Mockito;
 import org.slf4j.Logger;
@@ -108,9 +107,9 @@ class TemporalUtilsTest {
     when(serviceSupplier.get())
         .thenThrow(RuntimeException.class)
         .thenReturn(workflowServiceStubs);
-    when(workflowServiceStubs.blockingStub().listNamespaces(any()).getNamespacesList())
+    when(workflowServiceStubs.blockingStub().describeNamespace(any()))
         .thenThrow(RuntimeException.class)
-        .thenReturn(List.of(describeNamespaceResponse));
+        .thenReturn(describeNamespaceResponse);
     getTemporalClientWhenConnected(Duration.ofMillis(10), Duration.ofSeconds(1), Duration.ofSeconds(0), serviceSupplier, namespace);
   }
 


### PR DESCRIPTION
## What
Epic: https://github.com/airbytehq/airbyte-cloud/issues/1407

This PR changes our Temporal Client and Temporal Service instantiation logic to account for Temporal Cloud.

This PR introduces new environment variables that can be set to use Temporal Cloud as a backend instead of `airbyte-temporal`. 

If `TEMPORAL_CLOUD_ENABLED` is set to true, our Temporal Client and Service instantiation code will use a CA cert/key pair from `TEMPORAL_CLOUD_CLIENT_CERT` and `TEMPORAL_CLOUD_CLIENT_KEY` env vars. It will also use `TEMPORAL_CLOUD_HOST` and `TEMPORAL_CLOUD_NAMESPACE` instead of `TEMPORAL_HOST` and "default" respectively.

I refactored a few places where clients/services are instantiated so that our applications can remain fully agnostic of whether or not they're backed by Temporal Cloud or `airbyte-temporal`.

I annotated this PR with a few comments to help the reader, I think reviewing top to bottom should be fine for this one.

There will be a Cloud PR that contains the actual migrator app coming soon, which I'll link here.
