### PR TITLE
Prevent 'cannot read properties of undefined' error for attempt logs

### DIFF
--- a/airbyte-webapp/src/components/JobItem/components/JobLogs.tsx
+++ b/airbyte-webapp/src/components/JobItem/components/JobLogs.tsx
@@ -52,7 +52,7 @@ const JobLogs: React.FC<JobLogsProps> = ({ jobIsFailed, job }) => {
   });
 
   if (isSynchronousJobRead) {
-    return <Logs logsArray={debugInfo?.attempts[attemptNumber].logs.logLines ?? job.logs?.logLines} />;
+    return <Logs logsArray={debugInfo?.attempts[attemptNumber]?.logs?.logLines ?? job.logs?.logLines} />;
   }
 
   const currentAttempt = job.attempts?.[attemptNumber];
@@ -84,7 +84,7 @@ const JobLogs: React.FC<JobLogsProps> = ({ jobIsFailed, job }) => {
         currentAttempt={currentAttempt}
         jobDebugInfo={debugInfo}
         showAttemptStats={attempts > 1}
-        logs={debugInfo?.attempts[attemptNumber].logs.logLines}
+        logs={debugInfo?.attempts[attemptNumber]?.logs?.logLines}
       />
     </>
   );

--- a/airbyte-webapp/src/components/JobItem/components/JobLogs.tsx
+++ b/airbyte-webapp/src/components/JobItem/components/JobLogs.tsx
@@ -52,7 +52,7 @@ const JobLogs: React.FC<JobLogsProps> = ({ jobIsFailed, job }) => {
   });
 
   if (isSynchronousJobRead) {
-    return <Logs logsArray={debugInfo?.attempts[attemptNumber]?.logs?.logLines ?? job.logs?.logLines} />;
+    return <Logs logsArray={debugInfo?.attempts[attemptNumber]?.logs.logLines ?? job.logs?.logLines} />;
   }
 
   const currentAttempt = job.attempts?.[attemptNumber];
@@ -84,7 +84,7 @@ const JobLogs: React.FC<JobLogsProps> = ({ jobIsFailed, job }) => {
         currentAttempt={currentAttempt}
         jobDebugInfo={debugInfo}
         showAttemptStats={attempts > 1}
-        logs={debugInfo?.attempts[attemptNumber]?.logs?.logLines}
+        logs={debugInfo?.attempts[attemptNumber]?.logs.logLines}
       />
     </>
   );


### PR DESCRIPTION
## What
When testing out an unrelated change, I noticed that if I clicked into an attempt too quickly after the attempt was created (i.e. before there are any logs available for that attempt), the webapp would crash with the following error:
<img width="1675" alt="Screen Shot 2022-05-26 at 4 06 33 PM" src="https://user-images.githubusercontent.com/22731524/170593935-e3f589f6-32ba-4256-976a-c743458520b7.png">

## How
Taking a quick look at the code, I noticed that the logic for fetching logs from the debugInfo object was not using the `?.` operator all the way down the chain, which led to the above issue when there are no logs available.

I am submitting a quick fix in this PR to use the `?.` operator in each place where the attempt logs are being retrieved, which seems to have fixed the issue from my local testing.

One thing I noticed when testing the fix in this PR is that if I click into an attempt just after it is created, it properly says `Waiting for logs...`, but this never changes even after I know the logs are being populated, and it required me to refresh the page completely to actually see the logs in the UI. If this is not expected then feel free to modify this PR!

**I am by no means a typescript expert, so the frontend team should feel totally free to modify or change this PR in any way if anything seems off!**