### PR TITLE
Cleaner migration wait logic

### DIFF
--- a/airbyte-db/lib/src/test/java/io/airbyte/db/check/impl/ConfigsDatabaseMigrationCheckTest.java
+++ b/airbyte-db/lib/src/test/java/io/airbyte/db/check/impl/ConfigsDatabaseMigrationCheckTest.java
@@ -101,4 +101,17 @@ class ConfigsDatabaseMigrationCheckTest {
     Assertions.assertThrows(DatabaseCheckException.class, () -> check.check());
   }
 
+  @Test
+  void unavailableFlywayMigrationVersion() {
+    final var minimumVersion = "2.0.0";
+    final var migrationInfoService = mock(MigrationInfoService.class);
+    final var flyway = mock(Flyway.class);
+    final var databaseAvailabilityCheck = mock(ConfigsDatabaseAvailabilityCheck.class);
+
+    when(migrationInfoService.current()).thenReturn(null);
+    when(flyway.info()).thenReturn(migrationInfoService);
+
+    final var check = new ConfigsDatabaseMigrationCheck(databaseAvailabilityCheck, flyway, minimumVersion, CommonDatabaseCheckTest.TIMEOUT_MS);
+    Assertions.assertThrows(DatabaseCheckException.class, () -> check.check());
+  }
 }

--- a/airbyte-db/lib/src/test/java/io/airbyte/db/check/impl/JobsDatabaseMigrationCheckTest.java
+++ b/airbyte-db/lib/src/test/java/io/airbyte/db/check/impl/JobsDatabaseMigrationCheckTest.java
@@ -101,4 +101,17 @@ class JobsDatabaseMigrationCheckTest {
     Assertions.assertThrows(DatabaseCheckException.class, () -> check.check());
   }
 
+  @Test
+  void unavailableFlywayMigrationVersion() {
+    final var minimumVersion = "2.0.0";
+    final var migrationInfoService = mock(MigrationInfoService.class);
+    final var flyway = mock(Flyway.class);
+    final var databaseAvailabilityCheck = mock(JobsDatabaseAvailabilityCheck.class);
+
+    when(migrationInfoService.current()).thenReturn(null);
+    when(flyway.info()).thenReturn(migrationInfoService);
+
+    final var check = new JobsDatabaseMigrationCheck(databaseAvailabilityCheck, flyway, minimumVersion, CommonDatabaseCheckTest.TIMEOUT_MS);
+    Assertions.assertThrows(DatabaseCheckException.class, () -> check.check());
+  }
 }


### PR DESCRIPTION
## What
* Improve readability of database migration wait logic

## How
* Return a default migration current version value to force a sleep/retest of the check

## Recommended reading order
1. `DatabaseMigrationCheck.java`

## 🚨 User Impact 🚨

None

## Tests

<details><summary><strong>Unit</strong></summary>

* Added unit tests to verify behavior
* All other tests pass

</details>