### PR TITLE
🐛 Source Google Sheets: fixed issue with timeout

### DIFF
--- a/airbyte-config/init/src/main/resources/seed/source_definitions.yaml
+++ b/airbyte-config/init/src/main/resources/seed/source_definitions.yaml
@@ -343,7 +343,7 @@
 - name: Google Sheets
   sourceDefinitionId: 71607ba1-c0ac-4799-8049-7f4b90dd50f7
   dockerRepository: airbyte/source-google-sheets
-  dockerImageTag: 0.2.13
+  dockerImageTag: 0.2.14
   documentationUrl: https://docs.airbyte.io/integrations/sources/google-sheets
   icon: google-sheets.svg
   sourceType: file

--- a/airbyte-config/init/src/main/resources/seed/source_specs.yaml
+++ b/airbyte-config/init/src/main/resources/seed/source_specs.yaml
@@ -3188,7 +3188,7 @@
         oauthFlowOutputParameters:
         - - "access_token"
         - - "refresh_token"
-- dockerImage: "airbyte/source-google-sheets:0.2.13"
+- dockerImage: "airbyte/source-google-sheets:0.2.14"
   spec:
     documentationUrl: "https://docs.airbyte.io/integrations/sources/google-sheets"
     connectionSpecification:

--- a/airbyte-integrations/connectors/source-google-sheets/Dockerfile
+++ b/airbyte-integrations/connectors/source-google-sheets/Dockerfile
@@ -34,5 +34,5 @@ COPY google_sheets_source ./google_sheets_source
 ENV AIRBYTE_ENTRYPOINT "python /airbyte/integration_code/main.py"
 ENTRYPOINT ["python", "/airbyte/integration_code/main.py"]
 
-LABEL io.airbyte.version=0.2.13
+LABEL io.airbyte.version=0.2.14
 LABEL io.airbyte.name=airbyte/source-google-sheets

--- a/airbyte-integrations/connectors/source-google-sheets/README.md
+++ b/airbyte-integrations/connectors/source-google-sheets/README.md
@@ -47,10 +47,10 @@ and place them into `secrets/config.json`.
 
 ### Locally running the connector
 ```
-python main_dev.py spec
-python main_dev.py check --config secrets/config.json
-python main_dev.py discover --config secrets/config.json
-python main_dev.py read --config secrets/config.json --catalog sample_files/configured_catalog.json
+python main.py spec
+python main.py check --config secrets/config.json
+python main.py discover --config secrets/config.json
+python main.py read --config secrets/config.json --catalog sample_files/configured_catalog.json
 ```
 
 ### Unit Tests

--- a/airbyte-integrations/connectors/source-google-sheets/google_sheets_source/google_sheets_source.py
+++ b/airbyte-integrations/connectors/source-google-sheets/google_sheets_source/google_sheets_source.py
@@ -32,6 +32,7 @@ ROW_BATCH_SIZE = 200
 DEFAULT_SOCKET_TIMEOUT: int = 600
 socket.setdefaulttimeout(DEFAULT_SOCKET_TIMEOUT)
 
+
 class GoogleSheetsSource(Source):
     """
     Spreadsheets API Reference: https://developers.google.com/sheets/api/reference/rest/v4/spreadsheets

--- a/airbyte-integrations/connectors/source-google-sheets/google_sheets_source/google_sheets_source.py
+++ b/airbyte-integrations/connectors/source-google-sheets/google_sheets_source/google_sheets_source.py
@@ -4,6 +4,7 @@
 
 
 import json
+import socket
 from typing import Dict, Generator
 
 from airbyte_cdk.logger import AirbyteLogger
@@ -24,8 +25,12 @@ from .helpers import Helpers
 from .models.spreadsheet import Spreadsheet
 from .models.spreadsheet_values import SpreadsheetValues
 
+# set default batch read size
 ROW_BATCH_SIZE = 200
-
+# override default socket timeout to be 10 mins instead of 60 sec.
+# on behalf of https://github.com/airbytehq/oncall/issues/242
+DEFAULT_SOCKET_TIMEOUT: int = 600
+socket.setdefaulttimeout(DEFAULT_SOCKET_TIMEOUT)
 
 class GoogleSheetsSource(Source):
     """


### PR DESCRIPTION
## What
Resolving: https://github.com/airbytehq/oncall/issues/242

## How
- increased the `default timeout` for opened socket from 60 sec to 10 mins.

## 🚨 User Impact 🚨
No user impact expected.

## Pre-merge Checklist
Expand the relevant checklist and delete the others.

<details><summary><strong>Updating a connector</strong></summary>

### Community member or Airbyter

- [X] Unit & integration tests added and passing. Community members, please provide proof of success locally e.g: screenshot or copy-paste unit, integration, and acceptance test output. To run acceptance tests for a Python connector, follow instructions in the README. For java connectors run `./gradlew :airbyte-integrations:connectors:<name>:integrationTest`.
- [ ] Code reviews completed
- [X] Documentation updated
    - [X] Connector's `README.md`
    - [X] Changelog updated in `docs/integrations/<source or destination>/<name>.md` including changelog. See changelog [example](https://docs.airbyte.io/integrations/sources/stripe#changelog)
- [X] PR name follows [PR naming conventions](https://docs.airbyte.io/contributing-to-airbyte/updating-documentation#issues-and-pull-requests)

### Airbyter

If this is a community PR, the Airbyte engineer reviewing this PR is responsible for the below items.

- [ ] Create a non-forked branch based on this PR and test the below items on it
- [ ] Build is successful
- [ ] If new credentials are required for use in CI, add them to GSM. [Instructions](https://docs.airbyte.io/connector-development#using-credentials-in-ci).
- [ ] [`/test connector=connectors/<name>` command](https://docs.airbyte.io/connector-development#updating-an-existing-connector) is passing
- [ ] New Connector version released on Dockerhub and connector version bumped by running the `/publish` command described [here](https://docs.airbyte.io/connector-development#updating-an-existing-connector)

</details>