### PR TITLE
[Github Actions] Rename docker secrets and parameterize docker user

### DIFF
--- a/.github/actions/build-and-push-branch/action.yml
+++ b/.github/actions/build-and-push-branch/action.yml
@@ -19,7 +19,7 @@ runs:
     - name: Login to Docker (on Master)
       uses: docker/login-action@v1
       with:
-        username: airbytebot
+        username: ${{ secrets.DOCKER_HUB_USERNAME }}
         password: ${{ inputs.dockerhub_token }}
 
     - name: Push Docker Images

--- a/.github/workflows/build-connector-command.yml
+++ b/.github/workflows/build-connector-command.yml
@@ -186,7 +186,8 @@ jobs:
         id: build
         env:
           PR_NUMBER: ${{ github.event.number }}
-          DOCKER_PASSWORD: ${{ secrets.DOCKER_PASSWORD }}
+          DOCKER_HUB_USERNAME: ${{ secrets.DOCKER_HUB_USERNAME }}
+          DOCKER_HUB_PASSWORD: ${{ secrets.DOCKER_HUB_PASSWORD }}
           # Oracle expects this variable to be set. Although usually present, this is not set by default on Github virtual runners.
           TZ: UTC
   #      - name: Test ${{ github.event.inputs.connector }}

--- a/.github/workflows/gke-kube-test-command.yml
+++ b/.github/workflows/gke-kube-test-command.yml
@@ -116,7 +116,8 @@ jobs:
         env:
           USER: root
           HOME: /home/runner
-          DOCKER_PASSWORD: ${{ secrets.DOCKER_PASSWORD }}
+          DOCKER_HUB_USERNAME: ${{ secrets.DOCKER_HUB_USERNAME }}
+          DOCKER_HUB_PASSWORD: ${{ secrets.DOCKER_HUB_PASSWORD }}
           ACTION_RUN_ID: ${{github.run_id}}
         run: |
           ./tools/bin/gke-kube-acceptance-test/acceptance_test_kube_gke.sh

--- a/.github/workflows/publish-command.yml
+++ b/.github/workflows/publish-command.yml
@@ -153,12 +153,12 @@ jobs:
           SENTRY_PROJECT: airbyte-connectors
       - name: Publish ${{ github.event.inputs.connector }}
         run: |
-          echo "$SPEC_CACHE_SERVICE_ACCOUNT_KEY" > spec_cache_key_file.json && docker login -u ${DOCKER_USERNAME} -p ${DOCKER_PASSWORD}
+          echo "$SPEC_CACHE_SERVICE_ACCOUNT_KEY" > spec_cache_key_file.json && docker login -u ${DOCKER_HUB_USERNAME} -p ${DOCKER_HUB_PASSWORD}
           ./tools/integrations/manage.sh publish airbyte-integrations/${{ github.event.inputs.connector }} ${{ github.event.inputs.run-tests }} --publish_spec_to_cache
         id: publish
         env:
-          DOCKER_USERNAME: airbytebot
-          DOCKER_PASSWORD: ${{ secrets.DOCKER_PASSWORD }}
+          DOCKER_HUB_USERNAME: ${{ secrets.DOCKER_HUB_USERNAME }}
+          DOCKER_HUB_PASSWORD: ${{ secrets.DOCKER_HUB_PASSWORD }}
           # Oracle expects this variable to be set. Although usually present, this is not set by default on Github virtual runners.
           TZ: UTC
       - name: Finalize Sentry release

--- a/.github/workflows/publish-external-command.yml
+++ b/.github/workflows/publish-external-command.yml
@@ -85,12 +85,13 @@ jobs:
           repository: ${{ gituhb.event.inputs.repo }}
           ref: ${{ github.event.inputs.gitref }}
       - run: |
-          echo "$SPEC_CACHE_SERVICE_ACCOUNT_KEY" > spec_cache_key_file.json && docker login -u airbytebot -p ${DOCKER_PASSWORD}
+          echo "$SPEC_CACHE_SERVICE_ACCOUNT_KEY" > spec_cache_key_file.json && docker login -u ${DOCKER_HUB_USERNAME} -p ${DOCKER_HUB_PASSWORD}
           ./tools/integrations/manage.sh publish_external ${{ github.event.inputs.connector }} ${{ github.event.inputs.version }}
         name: publish ${{ github.event.inputs.connector }}
         id: publish
         env:
-          DOCKER_PASSWORD: ${{ secrets.DOCKER_PASSWORD }}
+          DOCKER_HUB_USERNAME: ${{ secrets.DOCKER_HUB_USERNAME }}
+          DOCKER_HUB_PASSWORD: ${{ secrets.DOCKER_HUB_PASSWORD }}
           # Oracle expects this variable to be set. Although usually present, this is not set by default on Github virtual runners.
           TZ: UTC
       - name: Add Success Comment

--- a/.github/workflows/release-airbyte-os.yml
+++ b/.github/workflows/release-airbyte-os.yml
@@ -70,7 +70,8 @@ jobs:
       - name: Release Airbyte
         id: release_airbyte
         env:
-          DOCKER_PASSWORD: ${{ secrets.DOCKER_PASSWORD }}
+          DOCKER_HUB_USERNAME: ${{ secrets.DOCKER_HUB_USERNAME }}
+          DOCKER_HUB_PASSWORD: ${{ secrets.DOCKER_HUB_PASSWORD }}
           PART_TO_BUMP: ${{ github.event.inputs.partToBump }}
           CLOUDREPO_USER: ${{ secrets.CLOUDREPO_USER }}
           CLOUDREPO_PASSWORD: ${{ secrets.CLOUDREPO_PASSWORD }}
@@ -100,7 +101,8 @@ jobs:
       - name: Release Octavia
         id: release_octavia
         env:
-          DOCKER_PASSWORD: ${{ secrets.DOCKER_PASSWORD }}
+          DOCKER_HUB_USERNAME: ${{ secrets.DOCKER_HUB_USERNAME }}
+          DOCKER_HUB_PASSWORD: ${{ secrets.DOCKER_HUB_PASSWORD }}
           PART_TO_BUMP: ${{ github.event.inputs.partToBump }}
         run: ./tools/bin/release_version_octavia.sh
 

--- a/tools/bin/gke-kube-acceptance-test/acceptance_test_kube_gke.sh
+++ b/tools/bin/gke-kube-acceptance-test/acceptance_test_kube_gke.sh
@@ -13,7 +13,7 @@ echo "Namespace" $NAMESPACE
 TAG=$(openssl rand -hex 12)
 echo "Tag" $TAG
 
-docker login -u airbytebot -p $DOCKER_PASSWORD
+docker login -u "$DOCKER_HUB_USERNAME" -p "$DOCKER_HUB_PASSWORD"
 VERSION=$TAG ./gradlew build
 VERSION=$TAG docker-compose -f docker-compose.build.yaml push
 
@@ -44,7 +44,7 @@ function findAndDeleteTag () {
 }
 
 function cleanUpImages () {
-    TOKEN=$(curl --request POST 'https://hub.docker.com/v2/users/login/' --header 'Content-Type: application/json' --data-raw '{"username":"airbytebot","password":"'$DOCKER_PASSWORD'"}' | jq '.token')
+    TOKEN=$(curl --request POST 'https://hub.docker.com/v2/users/login/' --header 'Content-Type: application/json' --data-raw '{"username":"'$DOCKER_HUB_USERNAME'","password":"'$DOCKER_HUB_PASSWORD'"}' | jq '.token')
     TOKEN="${TOKEN%\"}"
     TOKEN="${TOKEN#\"}"
 

--- a/tools/bin/release_version.sh
+++ b/tools/bin/release_version.sh
@@ -15,7 +15,7 @@ if [[ -z "${CLOUDREPO_PASSWORD}" ]]; then
 fi
 
 if [[ -z "${DOCKER_HUB_USERNAME}" ]]; then
-  echo 'DOCKER_HUB_USENAME not set.';
+  echo 'DOCKER_HUB_USERNAME not set.';
   exit 1;
 fi
 

--- a/tools/bin/release_version.sh
+++ b/tools/bin/release_version.sh
@@ -14,12 +14,17 @@ if [[ -z "${CLOUDREPO_PASSWORD}" ]]; then
   exit 1;
 fi
 
-if [[ -z "${DOCKER_PASSWORD}" ]]; then
-  echo 'DOCKER_PASSWORD for airbytebot not set.';
+if [[ -z "${DOCKER_HUB_USERNAME}" ]]; then
+  echo 'DOCKER_HUB_USENAME not set.';
   exit 1;
 fi
 
-docker login -u airbytebot -p "${DOCKER_PASSWORD}"
+if [[ -z "${DOCKER_HUB_PASSWORD}" ]]; then
+  echo 'DOCKER_HUB_PASSWORD for docker user not set.';
+  exit 1;
+fi
+
+docker login -u "${DOCKER_HUB_USERNAME}" -p "${DOCKER_HUB_PASSWORD}"
 
 source ./tools/bin/bump_version.sh
 

--- a/tools/bin/release_version_octavia.sh
+++ b/tools/bin/release_version_octavia.sh
@@ -4,12 +4,17 @@ set -e
 
 . tools/lib/lib.sh
 
-if test -z "${DOCKER_PASSWORD}"; then
-  echo 'DOCKER_PASSWORD for airbytebot not set.';
+if test -z "${DOCKER_HUB_USERNAME}"; then
+  echo 'DOCKER_HUB_USERNNAME not set.';
   exit 1;
 fi
 
-docker login --username airbytebot --password "${DOCKER_PASSWORD}"
+if test -z "${DOCKER_HUB_PASSWORD}"; then
+  echo 'DOCKER_HUB_PASSWORD for docker user not set.';
+  exit 1;
+fi
+
+docker login --username "${DOCKER_HUB_USERNAME}" --password "${DOCKER_HUB_PASSWORD}"
 
 source ./tools/bin/bump_version.sh
 

--- a/tools/integrations/manage.sh
+++ b/tools/integrations/manage.sh
@@ -213,9 +213,18 @@ cmd_publish() {
   docker run --rm --privileged multiarch/qemu-user-static --reset -p yes
 
   # log into docker
-  DOCKER_USERNAME=${DOCKER_USERNAME:-airbytebot}
+  if test -z "${DOCKER_HUB_USERNAME}"; then
+    echo 'DOCKER_HUB_USERNNAME not set.';
+    exit 1;
+  fi
+
+  if test -z "${DOCKER_HUB_PASSWORD}"; then
+    echo 'DOCKER_HUB_PASSWORD for docker user not set.';
+    exit 1;
+  fi
+
   set +x
-  DOCKER_TOKEN=$(curl -s -H "Content-Type: application/json" -X POST -d '{"username": "'${DOCKER_USERNAME}'", "password": "'${DOCKER_PASSWORD}'"}' https://hub.docker.com/v2/users/login/ | jq -r .token)
+  DOCKER_TOKEN=$(curl -s -H "Content-Type: application/json" -X POST -d '{"username": "'${DOCKER_HUB_USERNAME}'", "password": "'${DOCKER_HUB_PASSWORD}'"}' https://hub.docker.com/v2/users/login/ | jq -r .token)
   set -x
 
   echo "image_name $image_name"

--- a/tools/integrations/manage.sh
+++ b/tools/integrations/manage.sh
@@ -214,7 +214,7 @@ cmd_publish() {
 
   # log into docker
   if test -z "${DOCKER_HUB_USERNAME}"; then
-    echo 'DOCKER_HUB_USERNNAME not set.';
+    echo 'DOCKER_HUB_USERNAME not set.';
     exit 1;
   fi
 


### PR DESCRIPTION
Related to https://github.com/airbytehq/airbyte-cloud/issues/1763

This PR renames the secrets so that old branches stop working and folks will need to rebase from master to publish from here on out.  I also require a secret for the docker username.

Note: DO NOT update the secrets until this PR is merged to master!