### PR TITLE
use /list instead of /list_for_workspace

### DIFF
--- a/airbyte-webapp/src/core/domain/connector/DestinationDefinitionService.ts
+++ b/airbyte-webapp/src/core/domain/connector/DestinationDefinitionService.ts
@@ -5,7 +5,7 @@ import {
   DestinationDefinitionCreate,
   DestinationDefinitionUpdate,
   getDestinationDefinition,
-  listDestinationDefinitionsForWorkspace,
+  listDestinationDefinitions,
   listLatestDestinationDefinitions,
   updateDestinationDefinition,
 } from "../../request/AirbyteClient";
@@ -15,8 +15,8 @@ export class DestinationDefinitionService extends AirbyteRequestService {
     return getDestinationDefinition({ destinationDefinitionId }, this.requestOptions);
   }
 
-  public list(workspaceId: string) {
-    return listDestinationDefinitionsForWorkspace({ workspaceId }, this.requestOptions);
+  public list() {
+    return listDestinationDefinitions(this.requestOptions);
   }
 
   public listLatest() {

--- a/airbyte-webapp/src/core/domain/connector/SourceDefinitionService.ts
+++ b/airbyte-webapp/src/core/domain/connector/SourceDefinitionService.ts
@@ -4,7 +4,7 @@ import {
   createSourceDefinition,
   getSourceDefinition,
   listLatestSourceDefinitions,
-  listSourceDefinitionsForWorkspace,
+  listSourceDefinitions,
   SourceDefinitionCreate,
   SourceDefinitionUpdate,
   updateSourceDefinition,
@@ -15,8 +15,8 @@ export class SourceDefinitionService extends AirbyteRequestService {
     return getSourceDefinition({ sourceDefinitionId }, this.requestOptions);
   }
 
-  public list(workspaceId: string) {
-    return listSourceDefinitionsForWorkspace({ workspaceId }, this.requestOptions);
+  public list() {
+    return listSourceDefinitions(this.requestOptions);
   }
 
   public listLatest() {

--- a/airbyte-webapp/src/services/connector/DestinationDefinitionService.ts
+++ b/airbyte-webapp/src/services/connector/DestinationDefinitionService.ts
@@ -4,7 +4,6 @@ import { useConfig } from "config";
 import { DestinationDefinitionService } from "core/domain/connector/DestinationDefinitionService";
 import { useDefaultRequestMiddlewares } from "services/useDefaultRequestMiddlewares";
 import { useInitService } from "services/useInitService";
-import { useCurrentWorkspace } from "services/workspaces/WorkspacesService";
 import { isDefined } from "utils/common";
 
 import { DestinationDefinitionCreate, DestinationDefinitionRead } from "../../core/request/AirbyteClient";
@@ -36,13 +35,9 @@ const useDestinationDefinitionList = (): {
   destinationDefinitions: DestinationDefinitionReadWithLatestTag[];
 } => {
   const service = useGetDestinationDefinitionService();
-  const workspace = useCurrentWorkspace();
 
   return useSuspenseQuery(destinationDefinitionKeys.lists(), async () => {
-    const [definition, latestDefinition] = await Promise.all([
-      service.list(workspace.workspaceId),
-      service.listLatest(),
-    ]);
+    const [definition, latestDefinition] = await Promise.all([service.list(), service.listLatest()]);
 
     const destinationDefinitions: DestinationDefinitionRead[] = definition.destinationDefinitions.map(
       (destination: DestinationDefinitionRead) => {

--- a/airbyte-webapp/src/services/connector/SourceDefinitionService.ts
+++ b/airbyte-webapp/src/services/connector/SourceDefinitionService.ts
@@ -4,7 +4,6 @@ import { useConfig } from "config";
 import { SourceDefinitionService } from "core/domain/connector/SourceDefinitionService";
 import { useDefaultRequestMiddlewares } from "services/useDefaultRequestMiddlewares";
 import { useInitService } from "services/useInitService";
-import { useCurrentWorkspace } from "services/workspaces/WorkspacesService";
 import { isDefined } from "utils/common";
 
 import { SourceDefinitionCreate, SourceDefinitionRead } from "../../core/request/AirbyteClient";
@@ -36,13 +35,9 @@ const useSourceDefinitionList = (): {
   sourceDefinitions: SourceDefinitionReadWithLatestTag[];
 } => {
   const service = useGetSourceDefinitionService();
-  const workspace = useCurrentWorkspace();
 
   return useSuspenseQuery(sourceDefinitionKeys.lists(), async () => {
-    const [definition, latestDefinition] = await Promise.all([
-      service.list(workspace.workspaceId),
-      service.listLatest(),
-    ]);
+    const [definition, latestDefinition] = await Promise.all([service.list(), service.listLatest()]);
 
     const sourceDefinitions = definition.sourceDefinitions.map((source) => {
       const withLatest = latestDefinition.sourceDefinitions.find(


### PR DESCRIPTION
## What
As part of #12071, the api calls for getting all definitions changed from `/v1/(source|destination)_definitions/list` to `/v1/(source|destination)_definitions/list_for_workspace`

The `list_for_workspace` APIs are part of this [epic](https://github.com/airbytehq/airbyte/issues/9652) that is not yet completed however so we can't use them atm (they depend on us also migrating to new APIs for creating definitions that set some new fields introduced in the epic).

This change will revert the frontend behavior back to using the existing definition list APIs.