### PR TITLE
Updated to read_records instructions

### DIFF
--- a/docs/connector-development/cdk-python/full-refresh-stream.md
+++ b/docs/connector-development/cdk-python/full-refresh-stream.md
@@ -35,7 +35,7 @@ def get_json_schema(self):
 
 ## Reading records from the data source
 
-The only method required to implement a `Stream` is `Stream.read_records`. Given some information about how the stream should be read, this method should output an iterable object containing records from the data source. We recommend using generators as they are very efficient with regards to memory requirements.
+If custom functionality is required for reading a stream, you may need to override `Stream.read_records`. Given some information about how the stream should be read, this method should output an iterable object containing records from the data source. We recommend using generators as they are very efficient with regards to memory requirements.
 
 ## Incremental Streams
 


### PR DESCRIPTION
Address concerns raised in https://github.com/airbytehq/airbyte/issues/13342

[Reading records from the data source](https://docs.airbyte.com/connector-development/cdk-python/full-refresh-stream/#reading-records-from-the-data-source) in Connector Development documentation states the following:

The only method required to implement a Stream is Stream.read_records. Given some information about how the stream should be read, this method should output an iterable object containing records from the data source. We recommend using generators as they are very efficient with regards to memory requirements.

However, this is not required to implement this, as it is already implemented in the HttpStream class which streams inherit from.