### PR TITLE
update OSS action to take in docker username input

### DIFF
--- a/.github/actions/build-and-push-branch/action.yml
+++ b/.github/actions/build-and-push-branch/action.yml
@@ -4,6 +4,9 @@ inputs:
   branch_version_tag:
     description: 'Used to tag jars and docker images with a branch-specific version (should use the form "dev-<commit_hash>" to pass AirbyteVersion validation)'
     required: false
+  dockerhub_username:
+    description: "Used to log in to dockerhub for pushing images"
+    required: true
   dockerhub_token:
     description: "Used to log in to dockerhub for pushing images"
     required: true
@@ -19,7 +22,7 @@ runs:
     - name: Login to Docker (on Master)
       uses: docker/login-action@v1
       with:
-        username: ${{ secrets.DOCKER_HUB_USERNAME }}
+        username: ${{ inputs.dockerhub_username }}
         password: ${{ inputs.dockerhub_token }}
 
     - name: Push Docker Images


### PR DESCRIPTION
Fix Cloud's OSS-branch deploy workflow by passing dockerhub username into the action as an input. Actions can't access `secrets` like workflows can.

Relates to Cloud PR here: https://github.com/airbytehq/airbyte-cloud/pull/1780