### PR TITLE
Source Salesforce: fix build

### DIFF
--- a/airbyte-integrations/connectors/source-salesforce/integration_tests/bulk_error_test.py
+++ b/airbyte-integrations/connectors/source-salesforce/integration_tests/bulk_error_test.py
@@ -87,6 +87,13 @@ def test_failed_jobs_with_successful_switching(caplog, input_sandbox_config, str
         m.register_uri("DELETE", job_matcher, json={})
         with caplog.at_level(logging.WARNING):
             loaded_record_ids = set(record["Id"] for record in stream.read_records(sync_mode=SyncMode.full_refresh))
-        for i, log_message in enumerate(log_messages, 1):
-            assert log_message in caplog.records[-i].message
+
+        caplog_rec_counter = len(caplog.records) - 1
+        for log_message in log_messages:
+            for index in range(caplog_rec_counter, -1, -1):
+                if log_message in caplog.records[index].message:
+                    caplog_rec_counter = index - 1
+                    break
+            else:
+                pytest.fail(f"{log_message} is missing from captured log")
     assert loaded_record_ids == expected_record_ids


### PR DESCRIPTION
## What
One of the test cases asserted couple of log records to be captured during the sync. The records(a warning and an error log) were expected to be in the reversed output strictly one by one. Because the CDK recently started logging errors as well, one record was logged twice so the test failed.
![image](https://user-images.githubusercontent.com/7703835/171402562-d1a66217-d408-4f3b-9182-4599048bd52d.png)
![image](https://user-images.githubusercontent.com/7703835/171402727-4d5a5d63-456b-437b-be60-bd23260d1203.png)

## How

Change the way the expected log records are compared to the actual captured log. Allow duplicate items but still require all expected logs to be in the output and keep the sequence order