### PR TITLE
Prepare YamlSeedConfigPersistence for dependency injection

### DIFF
--- a/airbyte-bootloader/src/main/java/io/airbyte/bootloader/BootloaderApp.java
+++ b/airbyte-bootloader/src/main/java/io/airbyte/bootloader/BootloaderApp.java
@@ -64,6 +64,7 @@ public class BootloaderApp {
   private final FeatureFlags featureFlags;
   private final SecretMigrator secretMigrator;
   private ConfigPersistence configPersistence;
+  private ConfigPersistence yamlSeedConfigPersistence;
   private Database configDatabase;
   private Database jobDatabase;
   private JobPersistence jobPersistence;
@@ -122,7 +123,7 @@ public class BootloaderApp {
 
     postLoadExecution = () -> {
       try {
-        configPersistence.loadData(YamlSeedConfigPersistence.getDefault());
+        configPersistence.loadData(yamlSeedConfigPersistence);
 
         if (featureFlags.forceSecretMigration() || !jobPersistence.isSecretMigrated()) {
           if (this.secretMigrator != null) {
@@ -190,6 +191,10 @@ public class BootloaderApp {
     return DatabaseConfigPersistence.createWithValidation(configDatabase, jsonSecretsProcessor);
   }
 
+  private static ConfigPersistence getYamlSeedConfigPersistence() throws IOException {
+    return new YamlSeedConfigPersistence(YamlSeedConfigPersistence.DEFAULT_SEED_DEFINITION_RESOURCE_CLASS);
+  }
+
   private static Database getJobDatabase(final DSLContext dslContext) throws IOException {
     return new Database(dslContext);
   }
@@ -202,6 +207,7 @@ public class BootloaderApp {
     try {
       configDatabase = getConfigDatabase(configsDslContext);
       configPersistence = getConfigPersistence(configDatabase);
+      yamlSeedConfigPersistence = getYamlSeedConfigPersistence();
       jobDatabase = getJobDatabase(jobsDslContext);
       jobPersistence = getJobPersistence(jobDatabase);
     } catch (final IOException e) {

--- a/airbyte-bootloader/src/test/java/io/airbyte/bootloader/BootloaderAppTest.java
+++ b/airbyte-bootloader/src/test/java/io/airbyte/bootloader/BootloaderAppTest.java
@@ -190,7 +190,7 @@ public class BootloaderAppTest {
       val initBootloader = new BootloaderApp(mockedConfigs, mockedFeatureFlags, null, configsDslContext, jobsDslContext, configsFlyway, jobsFlyway);
       initBootloader.load();
 
-      final ConfigPersistence localSchema = YamlSeedConfigPersistence.getDefault();
+      final ConfigPersistence localSchema = new YamlSeedConfigPersistence(YamlSeedConfigPersistence.DEFAULT_SEED_DEFINITION_RESOURCE_CLASS);
       final ConfigRepository configRepository = new ConfigRepository(configPersistence, configDatabase);
       configRepository.loadDataNoSecrets(localSchema);
 

--- a/airbyte-config/init/src/main/java/io/airbyte/config/init/YamlSeedConfigPersistence.java
+++ b/airbyte-config/init/src/main/java/io/airbyte/config/init/YamlSeedConfigPersistence.java
@@ -43,19 +43,22 @@ final public class YamlSeedConfigPersistence implements ConfigPersistence {
       ConfigSchema.STANDARD_DESTINATION_DEFINITION, SeedType.STANDARD_DESTINATION_DEFINITION);
 
   // A mapping from seed config type to config UUID to config.
-  private final ImmutableMap<SeedType, Map<String, JsonNode>> allSeedConfigs;
+  private ImmutableMap<SeedType, Map<String, JsonNode>> allSeedConfigs;
 
-  public static YamlSeedConfigPersistence getDefault() throws IOException {
-    return new YamlSeedConfigPersistence(DEFAULT_SEED_DEFINITION_RESOURCE_CLASS);
+  // TODO inject via dependency injection framework
+  private final Class<?> seedResourceClass;
+
+  public YamlSeedConfigPersistence(final Class<?> seedResourceClass) throws IOException {
+    this.seedResourceClass = seedResourceClass;
+
+    // TODO remove this call once dependency injection framework manages object creation
+    initialize();
   }
 
-  public static YamlSeedConfigPersistence get(final Class<?> seedDefinitionsResourceClass) throws IOException {
-    return new YamlSeedConfigPersistence(seedDefinitionsResourceClass);
-  }
-
-  private YamlSeedConfigPersistence(final Class<?> seedResourceClass) throws IOException {
-    final Map<String, JsonNode> sourceDefinitionConfigs = getConfigs(seedResourceClass, SeedType.STANDARD_SOURCE_DEFINITION);
-    final Map<String, JsonNode> sourceSpecConfigs = getConfigs(seedResourceClass, SeedType.SOURCE_SPEC);
+  // TODO will be called automatically by the dependency injection framework on object creation
+  public void initialize() throws IOException {
+    final Map<String, JsonNode> sourceDefinitionConfigs = getConfigs(this.seedResourceClass, SeedType.STANDARD_SOURCE_DEFINITION);
+    final Map<String, JsonNode> sourceSpecConfigs = getConfigs(this.seedResourceClass, SeedType.SOURCE_SPEC);
     final Map<String, JsonNode> fullSourceDefinitionConfigs = sourceDefinitionConfigs.entrySet().stream()
         .collect(Collectors.toMap(Entry::getKey, e -> {
           final JsonNode withMissingFields =
@@ -67,8 +70,8 @@ final public class YamlSeedConfigPersistence implements ConfigPersistence {
           return output;
         }));
 
-    final Map<String, JsonNode> destinationDefinitionConfigs = getConfigs(seedResourceClass, SeedType.STANDARD_DESTINATION_DEFINITION);
-    final Map<String, JsonNode> destinationSpecConfigs = getConfigs(seedResourceClass, SeedType.DESTINATION_SPEC);
+    final Map<String, JsonNode> destinationDefinitionConfigs = getConfigs(this.seedResourceClass, SeedType.STANDARD_DESTINATION_DEFINITION);
+    final Map<String, JsonNode> destinationSpecConfigs = getConfigs(this.seedResourceClass, SeedType.DESTINATION_SPEC);
     final Map<String, JsonNode> fullDestinationDefinitionConfigs = destinationDefinitionConfigs.entrySet().stream()
         .collect(Collectors.toMap(Entry::getKey, e -> {
           final JsonNode withMissingFields =

--- a/airbyte-config/init/src/test/java/io/airbyte/config/init/SpecFormatTest.java
+++ b/airbyte-config/init/src/test/java/io/airbyte/config/init/SpecFormatTest.java
@@ -24,7 +24,7 @@ class SpecFormatTest {
 
   @Test
   void testOnAllExistingConfig() throws IOException, JsonValidationException {
-    final ConfigPersistence configPersistence = YamlSeedConfigPersistence.getDefault();
+    final ConfigPersistence configPersistence = new YamlSeedConfigPersistence(YamlSeedConfigPersistence.DEFAULT_SEED_DEFINITION_RESOURCE_CLASS);
 
     final List<JsonNode> sourceSpecs = configPersistence.listConfigs(
         ConfigSchema.STANDARD_SOURCE_DEFINITION, StandardSourceDefinition.class)

--- a/airbyte-config/init/src/test/java/io/airbyte/config/init/YamlSeedConfigPersistenceTest.java
+++ b/airbyte-config/init/src/test/java/io/airbyte/config/init/YamlSeedConfigPersistenceTest.java
@@ -29,7 +29,7 @@ class YamlSeedConfigPersistenceTest {
 
   @BeforeAll
   static void setup() throws IOException {
-    persistence = YamlSeedConfigPersistence.getDefault();
+    persistence = new YamlSeedConfigPersistence(YamlSeedConfigPersistence.DEFAULT_SEED_DEFINITION_RESOURCE_CLASS);
   }
 
   @Test

--- a/airbyte-server/src/main/java/io/airbyte/server/ServerApp.java
+++ b/airbyte-server/src/main/java/io/airbyte/server/ServerApp.java
@@ -292,9 +292,10 @@ public class ServerApp implements ServerRunnable {
             ConfigsDatabaseMigrator.DB_IDENTIFIER, ConfigsDatabaseMigrator.MIGRATION_FILE_LOCATION);
         final Flyway jobsFlyway = FlywayFactory.create(jobsDataSource, DbMigrationHandler.class.getSimpleName(), JobsDatabaseMigrator.DB_IDENTIFIER,
             JobsDatabaseMigrator.MIGRATION_FILE_LOCATION);
+        final ConfigPersistence yamlSeedConfigPersistence =
+            new YamlSeedConfigPersistence(YamlSeedConfigPersistence.DEFAULT_SEED_DEFINITION_RESOURCE_CLASS);
 
-        getServer(new ServerFactory.Api(), YamlSeedConfigPersistence.getDefault(),
-            configs, configsDslContext, configsFlyway, jobsDslContext, jobsFlyway).start();
+        getServer(new ServerFactory.Api(), yamlSeedConfigPersistence, configs, configsDslContext, configsFlyway, jobsDslContext, jobsFlyway).start();
       }
     } catch (final Throwable e) {
       LOGGER.error("Server failed", e);

--- a/airbyte-server/src/test/java/io/airbyte/server/handlers/ArchiveHandlerTest.java
+++ b/airbyte-server/src/test/java/io/airbyte/server/handlers/ArchiveHandlerTest.java
@@ -125,7 +125,7 @@ public class ArchiveHandlerTest {
     jobDatabase = databaseProviders.createNewJobsDatabase();
     configDatabase = databaseProviders.createNewConfigsDatabase();
     jobPersistence = new DefaultJobPersistence(jobDatabase);
-    seedPersistence = YamlSeedConfigPersistence.getDefault();
+    seedPersistence = new YamlSeedConfigPersistence(YamlSeedConfigPersistence.DEFAULT_SEED_DEFINITION_RESOURCE_CLASS);
     jsonSecretsProcessor = JsonSecretsProcessor.builder()
         .maskSecrets(false)
         .copySecrets(false)
@@ -145,7 +145,7 @@ public class ArchiveHandlerTest {
         secretsRepositoryReader,
         secretsRepositoryWriter,
         jobPersistence,
-        YamlSeedConfigPersistence.getDefault(),
+        seedPersistence,
         new WorkspaceHelper(configRepository, jobPersistence),
         new NoOpFileTtlManager(),
         true);


### PR DESCRIPTION
## What
* https://github.com/airbytehq/airbyte/issues/12379
* Perpare the seed loading logic for dependency injection

## How
* Refactor the `YamlSeedConfigPerisstence` class to be dependency injection friendly

## Recommended reading order
1. `YamlSeedConfigPersistence.java`
2. All other changes are reactions to the changes to the class in #1

## 🚨 User Impact 🚨
N/A

## Tests

<details><summary><strong>Unit</strong></summary>

* All unit tests pass

</details>

<details><summary><strong>Integration</strong></summary>

* Application starts locally and connectors exists in seeded database

</details>

