### PR TITLE
Explicitly set HTTP version for acceptance tests

### DIFF
--- a/airbyte-tests/src/acceptanceTests/java/io/airbyte/test/acceptance/AcceptanceTests.java
+++ b/airbyte-tests/src/acceptanceTests/java/io/airbyte/test/acceptance/AcceptanceTests.java
@@ -96,6 +96,8 @@ import java.net.Inet4Address;
 import java.net.URI;
 import java.net.URISyntaxException;
 import java.net.UnknownHostException;
+import java.net.http.HttpClient;
+import java.net.http.HttpClient.Version;
 import java.nio.charset.Charset;
 import java.nio.charset.StandardCharsets;
 import java.nio.file.Path;
@@ -259,7 +261,9 @@ public class AcceptanceTests {
   @BeforeEach
   public void setup() throws ApiException, URISyntaxException, SQLException, IOException {
     apiClient = new AirbyteApiClient(
-        new ApiClient().setScheme("http")
+        new ApiClient()
+            .setHttpClientBuilder(HttpClient.newBuilder().version(Version.HTTP_1_1))
+            .setScheme("http")
             .setHost("localhost")
             .setPort(8001)
             .setBasePath("/api"));


### PR DESCRIPTION
## What
* Attempt to fix transient acceptance test failure:

```AcceptanceTests > testBackpressure() > io.airbyte.test.acceptance.AcceptanceTests.testBackpressure()[1] FAILED
    io.airbyte.api.client.invoker.generated.ApiException: java.io.IOException: HTTP/1.1 header parser received no bytes
```

## How
* Explicitly set the HTTP version for requests made by the acceptance test client.

## Recommended reading order
1. `AcceptanceTests.java`

## 🚨 User Impact 🚨
N/A

**N.B.** I am unable to reproduce this locally, so this is an attempt to see if this helps with the transient failures seen when executed by GitHub.