### PR TITLE
Check for invalidFields size before accessing

### DIFF
--- a/airbyte-workers/src/main/java/io/airbyte/workers/RecordSchemaValidator.java
+++ b/airbyte-workers/src/main/java/io/airbyte/workers/RecordSchemaValidator.java
@@ -58,7 +58,14 @@ public class RecordSchemaValidator {
 
       final Set<String> validationMessagesToDisplay = new HashSet<>();
       for (int i = 0; i < invalidFields.size(); i++) {
-        final String newMessage = String.format("Expected %s to be %s.", invalidFields.get(i), invalidRecordDataAndType.get(i)[1]);
+        String expectedType = "";
+        if (invalidRecordDataAndType.size() > i && invalidRecordDataAndType.get(i).length > 0) {
+          expectedType = invalidRecordDataAndType.get(i)[1];
+        }
+        String newMessage = String.format("%s is of an incorrect type.", invalidFields.get(i));
+        if (expectedType != "") {
+          newMessage = newMessage + " Expected it to be " + expectedType;
+        }
         validationMessagesToDisplay.add(newMessage);
       }
 

--- a/airbyte-workers/src/main/java/io/airbyte/workers/RecordSchemaValidator.java
+++ b/airbyte-workers/src/main/java/io/airbyte/workers/RecordSchemaValidator.java
@@ -58,15 +58,17 @@ public class RecordSchemaValidator {
 
       final Set<String> validationMessagesToDisplay = new HashSet<>();
       for (int i = 0; i < invalidFields.size(); i++) {
-        String expectedType = "";
+        final StringBuilder expectedType = new StringBuilder();
         if (invalidRecordDataAndType.size() > i && invalidRecordDataAndType.get(i).length > 1) {
-          expectedType = invalidRecordDataAndType.get(i)[1];
+          expectedType.append(invalidRecordDataAndType.get(i)[1]);
         }
-        String newMessage = String.format("%s is of an incorrect type.", invalidFields.get(i));
-        if (expectedType != "") {
-          newMessage = newMessage + " Expected it to be " + expectedType;
+        final StringBuilder newMessage = new StringBuilder();
+        newMessage.append(invalidFields.get(i));
+        newMessage.append(" is of an incorrect type.");
+        if (expectedType.length() > 0) {
+          newMessage.append(" Expected it to be " + expectedType);
         }
-        validationMessagesToDisplay.add(newMessage);
+        validationMessagesToDisplay.add(newMessage.toString());
       }
 
       throw new RecordSchemaValidationException(validationMessagesToDisplay,

--- a/airbyte-workers/src/main/java/io/airbyte/workers/RecordSchemaValidator.java
+++ b/airbyte-workers/src/main/java/io/airbyte/workers/RecordSchemaValidator.java
@@ -59,7 +59,7 @@ public class RecordSchemaValidator {
       final Set<String> validationMessagesToDisplay = new HashSet<>();
       for (int i = 0; i < invalidFields.size(); i++) {
         String expectedType = "";
-        if (invalidRecordDataAndType.size() > i && invalidRecordDataAndType.get(i).length > 0) {
+        if (invalidRecordDataAndType.size() > i && invalidRecordDataAndType.get(i).length > 1) {
           expectedType = invalidRecordDataAndType.get(i)[1];
         }
         String newMessage = String.format("%s is of an incorrect type.", invalidFields.get(i));


### PR DESCRIPTION
## What
Resolves https://github.com/airbytehq/oncall/issues/255

The expected data types returned by the JsonSchemaValidator library do not consistently align with the fields that have incorrect data types, so check for the array length before accessing.