### PR TITLE
Add stream key and stream reset persistence methods

### DIFF
--- a/airbyte-config/config-models/src/main/java/io/airbyte/config/StreamResetRecord.java
+++ b/airbyte-config/config-models/src/main/java/io/airbyte/config/StreamResetRecord.java
@@ -7,6 +7,9 @@ package io.airbyte.config;
 import java.util.UUID;
 import javax.annotation.Nullable;
 
+/*
+ * A stream reset record is a reference to a stream that has a reset pending or running
+ */
 public record StreamResetRecord(UUID connectionId,
                                 String streamName,
                                 @Nullable String streamNamespace) {

--- a/airbyte-config/config-models/src/main/java/io/airbyte/config/StreamResetRecord.java
+++ b/airbyte-config/config-models/src/main/java/io/airbyte/config/StreamResetRecord.java
@@ -1,0 +1,14 @@
+/*
+ * Copyright (c) 2022 Airbyte, Inc., all rights reserved.
+ */
+
+package io.airbyte.config;
+
+import java.util.UUID;
+import javax.annotation.Nullable;
+
+public record StreamResetRecord(UUID connectionId,
+                                String streamName,
+                                @Nullable String streamNamespace) {
+
+}

--- a/airbyte-config/config-models/src/main/java/io/airbyte/config/StreamResetRecord.java
+++ b/airbyte-config/config-models/src/main/java/io/airbyte/config/StreamResetRecord.java
@@ -6,12 +6,13 @@ package io.airbyte.config;
 
 import java.util.UUID;
 import javax.annotation.Nullable;
+import lombok.NonNull;
 
 /*
  * A stream reset record is a reference to a stream that has a reset pending or running
  */
-public record StreamResetRecord(UUID connectionId,
-                                String streamName,
+public record StreamResetRecord(@NonNull UUID connectionId,
+                                @NonNull String streamName,
                                 @Nullable String streamNamespace) {
 
 }

--- a/airbyte-config/config-models/src/main/resources/types/StreamKey.yaml
+++ b/airbyte-config/config-models/src/main/resources/types/StreamKey.yaml
@@ -1,0 +1,16 @@
+---
+"$schema": http://json-schema.org/draft-07/schema#
+"$id": https://github.com/airbytehq/airbyte/blob/master/airbyte-config/models/src/main/resources/types/StreamKey.yaml
+title: StreamKey
+description: Name and namespace of a stream
+type: object
+required:
+  - name
+additionalProperties: false
+properties:
+  name:
+    description: Stream name
+    type: String
+  namespace:
+    description: Stream namespace
+    type: String

--- a/airbyte-config/config-persistence/src/main/java/io/airbyte/config/persistence/StreamResetPersistence.java
+++ b/airbyte-config/config-persistence/src/main/java/io/airbyte/config/persistence/StreamResetPersistence.java
@@ -14,7 +14,6 @@ import java.io.IOException;
 import java.time.OffsetDateTime;
 import java.util.List;
 import java.util.UUID;
-import java.util.stream.Collectors;
 import java.util.stream.Stream;
 import org.jooq.Condition;
 import org.jooq.Record;
@@ -45,14 +44,16 @@ public class StreamResetPersistence {
         .fetch(getStreamResetRecordMapper())
         .stream()
         .flatMap(row -> Stream.of(new StreamKey().withName(row.streamName()).withNamespace(row.streamNamespace())))
-        .collect(Collectors.toList());
+        .toList();
   }
 
   public void deleteStreamResets(final UUID connectionId, final List<StreamKey> streamsToDelete) throws IOException {
     final Condition condition = noCondition();
     for (final StreamKey streamKey : streamsToDelete) {
-      condition.or(DSL.field(CONNECTION_ID_COL).eq(connectionId).and(DSL.field(STREAM_NAME_COL).eq(streamKey.getName()))
-          .and(DSL.field(STREAM_NAMESPACE_COL).eq(streamKey.getNamespace())));
+      condition.or(
+          DSL.field(CONNECTION_ID_COL).eq(connectionId)
+              .and(DSL.field(STREAM_NAME_COL).eq(streamKey.getName()))
+              .and(DSL.field(STREAM_NAMESPACE_COL).eq(streamKey.getNamespace())));
     }
 
     database.query(ctx -> ctx.deleteFrom(DSL_TABLE_STREAM_RESET)).where(condition).execute();

--- a/airbyte-config/config-persistence/src/main/java/io/airbyte/config/persistence/StreamResetPersistence.java
+++ b/airbyte-config/config-persistence/src/main/java/io/airbyte/config/persistence/StreamResetPersistence.java
@@ -37,6 +37,9 @@ public class StreamResetPersistence {
     this.database = new ExceptionWrappingDatabase(database);
   }
 
+  /*
+   * Get a list of streamKeys for streams that have pending or running resets
+   */
   public List<StreamKey> getStreamResets(final UUID connectionId) throws IOException {
     return database.query(ctx -> ctx.select(DSL.asterisk())
         .from(DSL_TABLE_STREAM_RESET))
@@ -47,6 +50,10 @@ public class StreamResetPersistence {
         .toList();
   }
 
+  /*
+   * Delete stream resets for a given connection. This is called to delete stream reset records for
+   * resets that are successfully completed.
+   */
   public void deleteStreamResets(final UUID connectionId, final List<StreamKey> streamsToDelete) throws IOException {
     final Condition condition = noCondition();
     for (final StreamKey streamKey : streamsToDelete) {
@@ -59,6 +66,10 @@ public class StreamResetPersistence {
     database.query(ctx -> ctx.deleteFrom(DSL_TABLE_STREAM_RESET)).where(condition).execute();
   }
 
+  /*
+   * Create stream resets for a given connection. This is called to create stream reset records for
+   * resets that are going to be run.
+   */
   public void createStreamResets(final UUID connectionId, final List<StreamKey> streamsToCreate) throws IOException {
     for (final StreamKey streamKey : streamsToCreate) {
       final OffsetDateTime timestamp = OffsetDateTime.now();

--- a/airbyte-config/config-persistence/src/main/java/io/airbyte/config/persistence/StreamResetPersistence.java
+++ b/airbyte-config/config-persistence/src/main/java/io/airbyte/config/persistence/StreamResetPersistence.java
@@ -1,0 +1,82 @@
+/*
+ * Copyright (c) 2022 Airbyte, Inc., all rights reserved.
+ */
+
+package io.airbyte.config.persistence;
+
+import static org.jooq.impl.DSL.noCondition;
+
+import io.airbyte.config.StreamKey;
+import io.airbyte.config.StreamResetRecord;
+import io.airbyte.db.Database;
+import io.airbyte.db.ExceptionWrappingDatabase;
+import java.io.IOException;
+import java.time.OffsetDateTime;
+import java.util.List;
+import java.util.UUID;
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
+import org.jooq.Condition;
+import org.jooq.Record;
+import org.jooq.RecordMapper;
+import org.jooq.Table;
+import org.jooq.impl.DSL;
+
+public class StreamResetPersistence {
+
+  private static final String ID_COL = "id";
+  private static final String STREAM_NAME_COL = "stream_name";
+  private static final String STREAM_NAMESPACE_COL = "stream_namespace";
+  private static final String CONNECTION_ID_COL = "connection_id";
+  private static final String CREATED_AT_COL = "created_at";
+  private static final String UPDATED_AT_COL = "updated_at";
+  private static final Table<Record> DSL_TABLE_STREAM_RESET = DSL.table("stream_reset");
+
+  private final ExceptionWrappingDatabase database;
+
+  public StreamResetPersistence(final Database database) {
+    this.database = new ExceptionWrappingDatabase(database);
+  }
+
+  public List<StreamKey> getStreamResets(final UUID connectionId) throws IOException {
+    return database.query(ctx -> ctx.select(DSL.asterisk())
+        .from(DSL_TABLE_STREAM_RESET))
+        .where(DSL.field(CONNECTION_ID_COL).eq(connectionId))
+        .fetch(getStreamResetRecordMapper())
+        .stream()
+        .flatMap(row -> Stream.of(new StreamKey().withName(row.streamName()).withNamespace(row.streamNamespace())))
+        .collect(Collectors.toList());
+  }
+
+  public void deleteStreamResets(final UUID connectionId, final List<StreamKey> streamsToDelete) throws IOException {
+    final Condition condition = noCondition();
+    for (final StreamKey streamKey : streamsToDelete) {
+      condition.or(DSL.field(CONNECTION_ID_COL).eq(connectionId).and(DSL.field(STREAM_NAME_COL).eq(streamKey.getName()))
+          .and(DSL.field(STREAM_NAMESPACE_COL).eq(streamKey.getNamespace())));
+    }
+
+    database.query(ctx -> ctx.deleteFrom(DSL_TABLE_STREAM_RESET)).where(condition).execute();
+  }
+
+  public void createStreamResets(final UUID connectionId, final List<StreamKey> streamsToCreate) throws IOException {
+    for (final StreamKey streamKey : streamsToCreate) {
+      final OffsetDateTime timestamp = OffsetDateTime.now();
+
+      database.query(ctx -> ctx.insertInto(DSL_TABLE_STREAM_RESET)
+          .set(DSL.field(ID_COL), UUID.randomUUID())
+          .set(DSL.field(CONNECTION_ID_COL), connectionId)
+          .set(DSL.field(STREAM_NAME_COL), streamKey.getName())
+          .set(DSL.field(STREAM_NAMESPACE_COL), streamKey.getNamespace())
+          .set(DSL.field(CREATED_AT_COL), timestamp)
+          .set(DSL.field(UPDATED_AT_COL), timestamp)).execute();
+    }
+  }
+
+  private static RecordMapper<Record, StreamResetRecord> getStreamResetRecordMapper() {
+    return record -> new StreamResetRecord(
+        UUID.fromString(record.get(CONNECTION_ID_COL, String.class)),
+        record.get(STREAM_NAME_COL, String.class),
+        record.get(STREAM_NAMESPACE_COL, String.class));
+  }
+
+}

--- a/airbyte-config/config-persistence/src/test/java/io/airbyte/config/persistence/StreamResetPersistenceTest.java
+++ b/airbyte-config/config-persistence/src/test/java/io/airbyte/config/persistence/StreamResetPersistenceTest.java
@@ -1,0 +1,75 @@
+/*
+ * Copyright (c) 2022 Airbyte, Inc., all rights reserved.
+ */
+
+package io.airbyte.config.persistence;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.Mockito.spy;
+
+import io.airbyte.config.StreamKey;
+import io.airbyte.db.factory.DSLContextFactory;
+import io.airbyte.db.factory.DataSourceFactory;
+import io.airbyte.db.factory.FlywayFactory;
+import io.airbyte.db.instance.configs.ConfigsDatabaseMigrator;
+import io.airbyte.db.instance.configs.ConfigsDatabaseTestProvider;
+import io.airbyte.db.instance.development.DevDatabaseMigrator;
+import io.airbyte.db.instance.development.MigrationDevHelper;
+import io.airbyte.test.utils.DatabaseConnectionHelper;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.UUID;
+import org.jooq.SQLDialect;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+class StreamResetPersistenceTest extends BaseDatabaseConfigPersistenceTest {
+
+  static StreamResetPersistence streamResetPersistence;
+
+  @BeforeEach
+  public void setup() throws Exception {
+    dataSource = DatabaseConnectionHelper.createDataSource(container);
+    dslContext = DSLContextFactory.create(dataSource, SQLDialect.POSTGRES);
+    flyway = FlywayFactory.create(dataSource, DatabaseConfigPersistenceLoadDataTest.class.getName(), ConfigsDatabaseMigrator.DB_IDENTIFIER,
+        ConfigsDatabaseMigrator.MIGRATION_FILE_LOCATION);
+    database = new ConfigsDatabaseTestProvider(dslContext, flyway).create(false);
+    streamResetPersistence = spy(new StreamResetPersistence(database));
+    final ConfigsDatabaseMigrator configsDatabaseMigrator =
+        new ConfigsDatabaseMigrator(database, flyway);
+    final DevDatabaseMigrator devDatabaseMigrator = new DevDatabaseMigrator(configsDatabaseMigrator);
+    MigrationDevHelper.runLastMigration(devDatabaseMigrator);
+    truncateAllTables();
+  }
+
+  @AfterEach
+  void tearDown() throws Exception {
+    dslContext.close();
+    DataSourceFactory.close(dataSource);
+  }
+
+  @Test
+  void testCreateAndGetAndDeleteStreamResets() throws Exception {
+    final List<StreamKey> streamResetList = new ArrayList<>();
+    final StreamKey streamKey1 = new StreamKey().withName("stream_name_1").withNamespace("stream_namespace_1");
+    final StreamKey streamKey2 = new StreamKey().withName("stream_name_2");
+    streamResetList.add(streamKey1);
+    streamResetList.add(streamKey2);
+    final UUID uuid = UUID.randomUUID();
+    streamResetPersistence.createStreamResets(uuid, streamResetList);
+
+    final List<StreamKey> result = streamResetPersistence.getStreamResets(uuid);
+    assertEquals(2, result.size());
+    assertTrue(
+        result.stream().anyMatch(streamKey -> streamKey.getName().equals("stream_name_1") && streamKey.getNamespace().equals("stream_namespace_1")));
+    assertTrue(result.stream().anyMatch(streamKey -> streamKey.getName().equals("stream_name_2") && streamKey.getNamespace() == null));
+
+    streamResetPersistence.deleteStreamResets(uuid, result);
+
+    final List<StreamKey> resultAfterDeleting = streamResetPersistence.getStreamResets(uuid);
+    assertEquals(0, resultAfterDeleting.size());
+  }
+
+}


### PR DESCRIPTION
This PR adds the StreamKey model and stream reset persistence methods for getting, creating, and deleting stream reset records in the db:

The new StreamKey model is added as a yaml and contains a stream name and an optional namespace.

- getStreamResets fetches all streamResets for a given connection, and returns a list of streamKeys.
- createStreamResets takes a connectionId and a list of streamKeys and creates a streamReset record for each stream in the list of streamKeys
- deleteStreamResets takes a connectionId and a list of streamKeys and deletes each streamReset record that is present in the list of streamKeys