### PR TITLE
Fix lost schedule when editing connection name and ensure connection name is not cleared in other connection updates

### DIFF
--- a/airbyte-webapp/src/components/EntityTable/hooks.tsx
+++ b/airbyte-webapp/src/components/EntityTable/hooks.tsx
@@ -21,6 +21,7 @@ const useSyncActions = (): {
       namespaceDefinition: connection.namespaceDefinition,
       namespaceFormat: connection.namespaceFormat,
       operations: connection.operations,
+      name: connection.name,
       status: connection.status === ConnectionStatus.active ? ConnectionStatus.inactive : ConnectionStatus.active,
     });
 

--- a/airbyte-webapp/src/pages/ConnectionPage/pages/ConnectionItemPage/components/ConnectionName.tsx
+++ b/airbyte-webapp/src/pages/ConnectionPage/pages/ConnectionItemPage/components/ConnectionName.tsx
@@ -1,6 +1,6 @@
 import { faPenToSquare } from "@fortawesome/free-regular-svg-icons";
 import { FontAwesomeIcon } from "@fortawesome/react-fontawesome";
-import { ChangeEvent, useState } from "react";
+import React, { ChangeEvent, useState } from "react";
 import styled from "styled-components";
 
 import { Input } from "components";
@@ -114,12 +114,14 @@ const ConnectionName: React.FC<Props> = ({ connection }) => {
     }
   };
 
-  const onEscape = () => {
+  const onEscape: React.KeyboardEventHandler<HTMLInputElement> = (event) => {
+    event.stopPropagation();
     setEditingState(false);
     setConnectionName(name);
   };
 
-  const onEnter = async () => {
+  const onEnter: React.KeyboardEventHandler<HTMLInputElement> = async (event) => {
+    event.stopPropagation();
     await updateConnectionAsync();
   };
 

--- a/airbyte-webapp/src/pages/ConnectionPage/pages/ConnectionItemPage/components/ConnectionName.tsx
+++ b/airbyte-webapp/src/pages/ConnectionPage/pages/ConnectionItemPage/components/ConnectionName.tsx
@@ -132,12 +132,15 @@ const ConnectionName: React.FC<Props> = ({ connection }) => {
     if (connection.name !== connectionName) {
       setLoading(true);
       await updateConnection({
-        name: connectionName,
         connectionId: connection.connectionId,
-        namespaceDefinition: connection.namespaceDefinition,
         syncCatalog: connection.syncCatalog,
-        status: connection.status,
         prefix: connection.prefix,
+        schedule: connection.schedule || null,
+        namespaceDefinition: connection.namespaceDefinition,
+        namespaceFormat: connection.namespaceFormat,
+        operations: connection.operations,
+        status: connection.status,
+        name: connectionName,
       });
       setLoading(false);
     }

--- a/airbyte-webapp/src/pages/ConnectionPage/pages/ConnectionItemPage/components/EnabledControl.tsx
+++ b/airbyte-webapp/src/pages/ConnectionPage/pages/ConnectionItemPage/components/EnabledControl.tsx
@@ -47,6 +47,7 @@ const EnabledControl: React.FC<EnabledControlProps> = ({ connection, disabled, f
       namespaceFormat: connection.namespaceFormat,
       prefix: connection.prefix,
       operations: connection.operations,
+      name: connection.name,
       status: connection.status === ConnectionStatus.active ? ConnectionStatus.inactive : ConnectionStatus.active,
     });
 

--- a/airbyte-webapp/src/pages/ConnectionPage/pages/ConnectionItemPage/components/ReplicationView.tsx
+++ b/airbyte-webapp/src/pages/ConnectionPage/pages/ConnectionItemPage/components/ReplicationView.tsx
@@ -75,6 +75,7 @@ export const ReplicationView: React.FC<ReplicationViewProps> = ({ onAfterSaveSch
       status: initialConnection.status || "",
       withRefreshedCatalog: activeUpdatingSchemaMode,
       sourceCatalogId: connection?.catalogId,
+      name: connection?.name,
     });
 
     setSaved(true);

--- a/airbyte-webapp/src/pages/ConnectionPage/pages/ConnectionItemPage/components/TransformationView.tsx
+++ b/airbyte-webapp/src/pages/ConnectionPage/pages/ConnectionItemPage/components/TransformationView.tsx
@@ -144,6 +144,7 @@ const TransformationView: React.FC<TransformationViewProps> = ({ connection }) =
       syncCatalog: connection.syncCatalog,
       connectionId: connection.connectionId,
       status: connection.status,
+      name: connection.name,
       operations: operations,
     });
 

--- a/airbyte-webapp/src/utils/addEnterEscFuncForInput.tsx
+++ b/airbyte-webapp/src/utils/addEnterEscFuncForInput.tsx
@@ -2,25 +2,19 @@ import * as React from "react";
 
 export default function addEnterEscFuncForInput(WrapperComponent: React.FC) {
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
-  return (props: any) => {
+  return ({ onEscape, onEnter, onKeyDown: onKeyDownProp, ...props }: any) => {
     const onKeyDown = (event: React.KeyboardEvent<HTMLInputElement>) => {
       // Escape Key Event
-      if (event.key === "Escape") {
-        if (props.onEscape) {
-          props.onEscape(event);
-        }
+      if (event.key === "Escape" && onEscape) {
+        onEscape(event);
       }
 
       // Enter Key Event
-      if (event.key === "Enter") {
-        if (props.onEnter) {
-          props.onEnter(event);
-        }
+      if (event.key === "Enter" && onEnter) {
+        onEnter(event);
       }
 
-      if (props.onKeyDown) {
-        props.onKeyDown(event);
-      }
+      onKeyDownProp?.(event);
     };
 
     return <WrapperComponent {...props} onKeyDown={onKeyDown} />;


### PR DESCRIPTION
## What
Fixes a few issues related to connection name:

1. Editing the connection name would clear the connection schedule
2. Editing anything but the connection name could clear the connection name

Related to #12803 

## How
Currently, the api used to edit the connection (`/web_backend/connections/update`) uses an all or nothing approach. We must dump the entire update state, otherwise, it will set those fields to null. The change ensures that all calls made to update the connection include all the fields.

Additionally, keyboard events in the name editor were causing the connection to update twice. This also resolves that issue.

