### PR TITLE
cdk: add link to forum in plopfile.js

### DIFF
--- a/airbyte-integrations/connector-templates/generator/plopfile.js
+++ b/airbyte-integrations/connector-templates/generator/plopfile.js
@@ -14,9 +14,8 @@ Your ${connectorName} connector has been created at .${path.resolve(outputPath)}
 
 Follow the TODOs in the generated module to implement your connector. 
 
-Questions, comments, or concerns? Let us know at:
-Slack: https://slack.airbyte.io
-Github: https://github.com/airbytehq/airbyte
+Questions, comments, or concerns? Let us know in our connector development forum:
+https://discuss.airbyte.io/c/connector-development/16
 
 We're always happy to provide any support!
 


### PR DESCRIPTION
## What
We still mentionned Slack and Github in the output of a new connector generation.

## How
Update `plopfile.js` to declare our connector development forum as our main support platform. 