### PR TITLE
properly handle correcting quarantined workflows when performing update

### DIFF
--- a/airbyte-workers/src/main/java/io/airbyte/workers/temporal/TemporalClient.java
+++ b/airbyte-workers/src/main/java/io/airbyte/workers/temporal/TemporalClient.java
@@ -256,6 +256,8 @@ public class TemporalClient {
       log.error(
           String.format("Failed to retrieve ConnectionManagerWorkflow for connection %s. Repairing state by creating new workflow.", connectionId),
           e);
+      ConnectionManagerUtils.safeTerminateWorkflow(client, connectionId,
+          "Terminating workflow in unreachable state before starting a new workflow for this connection");
       submitConnectionUpdaterAsync(connectionId);
       return;
     }

--- a/airbyte-workers/src/test/java/io/airbyte/workers/temporal/TemporalClientTest.java
+++ b/airbyte-workers/src/test/java/io/airbyte/workers/temporal/TemporalClientTest.java
@@ -390,11 +390,15 @@ class TemporalClientTest {
       when(workflowClient.newWorkflowStub(any(Class.class), any(String.class))).thenReturn(mConnectionManagerWorkflow);
       doReturn(mConnectionManagerWorkflow).when(temporalClient).submitConnectionUpdaterAsync(CONNECTION_ID);
 
+      final WorkflowStub untypedWorkflowStub = mock(WorkflowStub.class);
+      when(workflowClient.newUntypedWorkflowStub(anyString())).thenReturn(untypedWorkflowStub);
+
       temporalClient.update(CONNECTION_ID);
 
       // this is only called when updating an existing workflow
       verify(mConnectionManagerWorkflow, Mockito.never()).connectionUpdated();
 
+      verify(untypedWorkflowStub, Mockito.times(1)).terminate(anyString());
       verify(temporalClient, Mockito.times(1)).submitConnectionUpdaterAsync(CONNECTION_ID);
     }
 


### PR DESCRIPTION
## What
Currently, if a workflow is quarantined and an update is attempted on the connection, the server will try to start a new temporal workflow and fail because there is already a workflow running.

## How
This PR solves the issue by first terminating the workflow in the update request before attempting to start a new one.

Note that the `update` method in the Temporal client does not use the `signalWorkflowAndRepairIfNecessary` method that already includes this termination logic, because that causes the workflow to be started and then restarted again unnecessarily, due to the `isUpdated` logic in the connection manager workflow.