### PR TITLE
🐛 BigQuery destination: always run GCS destination check for GCS staging method

### DIFF
--- a/airbyte-config/init/src/main/resources/seed/destination_definitions.yaml
+++ b/airbyte-config/init/src/main/resources/seed/destination_definitions.yaml
@@ -27,7 +27,7 @@
 - name: BigQuery
   destinationDefinitionId: 22f6c74f-5699-40ff-833c-4a879ea40133
   dockerRepository: airbyte/destination-bigquery
-  dockerImageTag: 1.1.6
+  dockerImageTag: 1.1.8
   documentationUrl: https://docs.airbyte.io/integrations/destinations/bigquery
   icon: bigquery.svg
   resourceRequirements:

--- a/airbyte-config/init/src/main/resources/seed/destination_definitions.yaml
+++ b/airbyte-config/init/src/main/resources/seed/destination_definitions.yaml
@@ -40,7 +40,7 @@
 - name: BigQuery (denormalized typed struct)
   destinationDefinitionId: 079d5540-f236-4294-ba7c-ade8fd918496
   dockerRepository: airbyte/destination-bigquery-denormalized
-  dockerImageTag: 1.1.6
+  dockerImageTag: 1.1.8
   documentationUrl: https://docs.airbyte.io/integrations/destinations/bigquery
   icon: bigquery.svg
   resourceRequirements:

--- a/airbyte-config/init/src/main/resources/seed/destination_specs.yaml
+++ b/airbyte-config/init/src/main/resources/seed/destination_specs.yaml
@@ -285,7 +285,7 @@
     supported_destination_sync_modes:
     - "overwrite"
     - "append"
-- dockerImage: "airbyte/destination-bigquery:1.1.6"
+- dockerImage: "airbyte/destination-bigquery:1.1.8"
   spec:
     documentationUrl: "https://docs.airbyte.io/integrations/destinations/bigquery"
     connectionSpecification:
@@ -298,32 +298,20 @@
       - "dataset_id"
       additionalProperties: true
       properties:
-        big_query_client_buffer_size_mb:
-          title: "Google BigQuery Client Chunk Size (Optional)"
-          description: "Google BigQuery client's chunk (buffer) size (MIN=1, MAX =\
-            \ 15) for each table. The size that will be written by a single RPC. Written\
-            \ data will be buffered and only flushed upon reaching this size or closing\
-            \ the channel. The default 15MB value is used if not set explicitly. Read\
-            \ more <a href=\"https://googleapis.dev/python/bigquery/latest/generated/google.cloud.bigquery.client.Client.html\"\
-            >here</a>."
-          type: "integer"
-          minimum: 1
-          maximum: 15
-          default: 15
-          examples:
-          - "15"
         project_id:
           type: "string"
           description: "The GCP project ID for the project containing the target BigQuery\
             \ dataset. Read more <a href=\"https://cloud.google.com/resource-manager/docs/creating-managing-projects#identifying_projects\"\
             >here</a>."
           title: "Project ID"
+          order: 0
         dataset_location:
           type: "string"
           description: "The location of the dataset. Warning: Changes made after creation\
             \ will not be applied. Read more <a href=\"https://cloud.google.com/bigquery/docs/locations\"\
             >here</a>."
           title: "Dataset Location"
+          order: 1
           enum:
           - "US"
           - "EU"
@@ -362,29 +350,7 @@
             \ to if the source does not specify a namespace. Read more <a href=\"\
             https://cloud.google.com/bigquery/docs/datasets#create-dataset\">here</a>."
           title: "Default Dataset ID"
-        credentials_json:
-          type: "string"
-          description: "The contents of the JSON service account key. Check out the\
-            \ <a href=\"https://docs.airbyte.com/integrations/destinations/bigquery#service-account-key\"\
-            >docs</a> if you need help generating this key. Default credentials will\
-            \ be used if this field is left empty."
-          title: "Service Account Key JSON (Required for cloud, optional for open-source)"
-          airbyte_secret: true
-        transformation_priority:
-          type: "string"
-          description: "Interactive run type means that the query is executed as soon\
-            \ as possible, and these queries count towards concurrent rate limit and\
-            \ daily limit. Read more about interactive run type <a href=\"https://cloud.google.com/bigquery/docs/running-queries#queries\"\
-            >here</a>. Batch queries are queued and started as soon as idle resources\
-            \ are available in the BigQuery shared resource pool, which usually occurs\
-            \ within a few minutes. Batch queries don’t count towards your concurrent\
-            \ rate limit. Read more about batch queries <a href=\"https://cloud.google.com/bigquery/docs/running-queries#batch\"\
-            >here</a>. The default \"interactive\" value is used if not set explicitly."
-          title: "Transformation Query Run Type (Optional)"
-          default: "interactive"
-          enum:
-          - "interactive"
-          - "batch"
+          order: 2
         loading_method:
           type: "object"
           title: "Loading Method"
@@ -397,6 +363,7 @@
             \ the file. Recommended for most workloads for better speed and scalability.\
             \ Read more about GCS Staging <a href=\"https://docs.airbyte.com/integrations/destinations/bigquery#gcs-staging\"\
             >here</a>."
+          order: 3
           oneOf:
           - title: "Standard Inserts"
             additionalProperties: false
@@ -417,6 +384,45 @@
               method:
                 type: "string"
                 const: "GCS Staging"
+                order: 0
+              credential:
+                title: "Credential"
+                description: "An HMAC key is a type of credential and can be associated\
+                  \ with a service account or a user account in Cloud Storage. Read\
+                  \ more <a href=\"https://cloud.google.com/storage/docs/authentication/hmackeys\"\
+                  >here</a>."
+                type: "object"
+                order: 1
+                oneOf:
+                - title: "HMAC key"
+                  required:
+                  - "credential_type"
+                  - "hmac_key_access_id"
+                  - "hmac_key_secret"
+                  properties:
+                    credential_type:
+                      type: "string"
+                      const: "HMAC_KEY"
+                      order: 0
+                    hmac_key_access_id:
+                      type: "string"
+                      description: "HMAC key access ID. When linked to a service account,\
+                        \ this ID is 61 characters long; when linked to a user account,\
+                        \ it is 24 characters long."
+                      title: "HMAC Key Access ID"
+                      airbyte_secret: true
+                      examples:
+                      - "1234567890abcdefghij1234"
+                      order: 1
+                    hmac_key_secret:
+                      type: "string"
+                      description: "The corresponding secret for the access ID. It\
+                        \ is a 40-character base-64 encoded string."
+                      title: "HMAC Key Secret"
+                      airbyte_secret: true
+                      examples:
+                      - "1234567890abcdefghij1234567890ABCDEFGHIJ"
+                      order: 2
               gcs_bucket_name:
                 title: "GCS Bucket Name"
                 type: "string"
@@ -424,12 +430,14 @@
                   >here</a>."
                 examples:
                 - "airbyte_sync"
+                order: 2
               gcs_bucket_path:
                 title: "GCS Bucket Path"
                 description: "Directory under the GCS bucket where data will be written."
                 type: "string"
                 examples:
                 - "data_sync/test"
+                order: 3
               part_size_mb:
                 title: "Block Size (MB) for GCS Multipart Upload (Optional)"
                 description: "This is the size of a \"Part\" being buffered in memory.\
@@ -442,51 +450,59 @@
                 maximum: 525
                 examples:
                 - 5
+                order: 4
               keep_files_in_gcs-bucket:
                 type: "string"
                 description: "This upload method is supposed to temporary store records\
-                  \ in GCS bucket. What do you want to do with data in GCS bucket\
-                  \ when migration has finished? The default \"Delete all tmp files\
-                  \ from GCS\" value is used if not set explicitly."
+                  \ in GCS bucket. By this select you can chose if these records should\
+                  \ be removed from GCS when migration has finished. The default \"\
+                  Delete all tmp files from GCS\" value is used if not set explicitly."
                 title: "GCS Tmp Files Afterward Processing (Optional)"
                 default: "Delete all tmp files from GCS"
                 enum:
                 - "Delete all tmp files from GCS"
                 - "Keep all tmp files in GCS"
-              credential:
-                title: "Credential"
-                description: "An HMAC key is a type of credential and can be associated\
-                  \ with a service account or a user account in Cloud Storage. Read\
-                  \ more <a href=\"https://cloud.google.com/storage/docs/authentication/hmackeys\"\
-                  >here</a>."
-                type: "object"
-                oneOf:
-                - title: "HMAC key"
-                  required:
-                  - "credential_type"
-                  - "hmac_key_access_id"
-                  - "hmac_key_secret"
-                  properties:
-                    credential_type:
-                      type: "string"
-                      const: "HMAC_KEY"
-                    hmac_key_access_id:
-                      type: "string"
-                      description: "HMAC key access ID. When linked to a service account,\
-                        \ this ID is 61 characters long; when linked to a user account,\
-                        \ it is 24 characters long."
-                      title: "HMAC Key Access ID"
-                      airbyte_secret: true
-                      examples:
-                      - "1234567890abcdefghij1234"
-                    hmac_key_secret:
-                      type: "string"
-                      description: "The corresponding secret for the access ID. It\
-                        \ is a 40-character base-64 encoded string."
-                      title: "HMAC Key Secret"
-                      airbyte_secret: true
-                      examples:
-                      - "1234567890abcdefghij1234567890ABCDEFGHIJ"
+                order: 5
+        credentials_json:
+          type: "string"
+          description: "The contents of the JSON service account key. Check out the\
+            \ <a href=\"https://docs.airbyte.com/integrations/destinations/bigquery#service-account-key\"\
+            >docs</a> if you need help generating this key. Default credentials will\
+            \ be used if this field is left empty."
+          title: "Service Account Key JSON (Required for cloud, optional for open-source)"
+          airbyte_secret: true
+          order: 4
+        transformation_priority:
+          type: "string"
+          description: "Interactive run type means that the query is executed as soon\
+            \ as possible, and these queries count towards concurrent rate limit and\
+            \ daily limit. Read more about interactive run type <a href=\"https://cloud.google.com/bigquery/docs/running-queries#queries\"\
+            >here</a>. Batch queries are queued and started as soon as idle resources\
+            \ are available in the BigQuery shared resource pool, which usually occurs\
+            \ within a few minutes. Batch queries don’t count towards your concurrent\
+            \ rate limit. Read more about batch queries <a href=\"https://cloud.google.com/bigquery/docs/running-queries#batch\"\
+            >here</a>. The default \"interactive\" value is used if not set explicitly."
+          title: "Transformation Query Run Type (Optional)"
+          default: "interactive"
+          enum:
+          - "interactive"
+          - "batch"
+          order: 5
+        big_query_client_buffer_size_mb:
+          title: "Google BigQuery Client Chunk Size (Optional)"
+          description: "Google BigQuery client's chunk (buffer) size (MIN=1, MAX =\
+            \ 15) for each table. The size that will be written by a single RPC. Written\
+            \ data will be buffered and only flushed upon reaching this size or closing\
+            \ the channel. The default 15MB value is used if not set explicitly. Read\
+            \ more <a href=\"https://googleapis.dev/python/bigquery/latest/generated/google.cloud.bigquery.client.Client.html\"\
+            >here</a>."
+          type: "integer"
+          minimum: 1
+          maximum: 15
+          default: 15
+          examples:
+          - "15"
+          order: 6
     supportsIncremental: true
     supportsNormalization: true
     supportsDBT: true

--- a/airbyte-config/init/src/main/resources/seed/destination_specs.yaml
+++ b/airbyte-config/init/src/main/resources/seed/destination_specs.yaml
@@ -494,7 +494,7 @@
     - "overwrite"
     - "append"
     - "append_dedup"
-- dockerImage: "airbyte/destination-bigquery-denormalized:1.1.6"
+- dockerImage: "airbyte/destination-bigquery-denormalized:1.1.8"
   spec:
     documentationUrl: "https://docs.airbyte.io/integrations/destinations/bigquery"
     connectionSpecification:
@@ -506,32 +506,145 @@
       - "dataset_id"
       additionalProperties: true
       properties:
-        big_query_client_buffer_size_mb:
-          title: "Google BigQuery Client Chunk Size (Optional)"
-          description: "Google BigQuery client's chunk (buffer) size (MIN=1, MAX =\
-            \ 15) for each table. The size that will be written by a single RPC. Written\
-            \ data will be buffered and only flushed upon reaching this size or closing\
-            \ the channel. The default 15MB value is used if not set explicitly. Read\
-            \ more <a href=\"https://googleapis.dev/python/bigquery/latest/generated/google.cloud.bigquery.client.Client.html\"\
-            >here</a>."
-          type: "integer"
-          minimum: 1
-          maximum: 15
-          default: 15
-          examples:
-          - "15"
         project_id:
           type: "string"
           description: "The GCP project ID for the project containing the target BigQuery\
             \ dataset. Read more <a href=\"https://cloud.google.com/resource-manager/docs/creating-managing-projects#identifying_projects\"\
             >here</a>."
           title: "Project ID"
+          order: 0
         dataset_id:
           type: "string"
           description: "The default BigQuery Dataset ID that tables are replicated\
             \ to if the source does not specify a namespace. Read more <a href=\"\
             https://cloud.google.com/bigquery/docs/datasets#create-dataset\">here</a>."
           title: "Default Dataset ID"
+          order: 1
+        loading_method:
+          type: "object"
+          title: "Loading Method *"
+          description: "Loading method used to send select the way data will be uploaded\
+            \ to BigQuery. <br/><b>Standard Inserts</b> - Direct uploading using SQL\
+            \ INSERT statements. This method is extremely inefficient and provided\
+            \ only for quick testing. In almost all cases, you should use staging.\
+            \ <br/><b>GCS Staging</b> - Writes large batches of records to a file,\
+            \ uploads the file to GCS, then uses <b>COPY INTO table</b> to upload\
+            \ the file. Recommended for most workloads for better speed and scalability.\
+            \ Read more about GCS Staging <a href=\"https://docs.airbyte.com/integrations/destinations/bigquery#gcs-staging\"\
+            >here</a>."
+          order: 2
+          oneOf:
+          - title: "Standard Inserts"
+            additionalProperties: false
+            required:
+            - "method"
+            properties:
+              method:
+                type: "string"
+                const: "Standard"
+          - title: "GCS Staging"
+            additionalProperties: false
+            type: "object"
+            required:
+            - "method"
+            - "gcs_bucket_name"
+            - "gcs_bucket_path"
+            - "credential"
+            properties:
+              method:
+                type: "string"
+                const: "GCS Staging"
+                order: 0
+              credential:
+                title: "Credential"
+                description: "An HMAC key is a type of credential and can be associated\
+                  \ with a service account or a user account in Cloud Storage. Read\
+                  \ more <a href=\"https://cloud.google.com/storage/docs/authentication/hmackeys\"\
+                  >here</a>."
+                type: "object"
+                order: 1
+                oneOf:
+                - title: "HMAC key"
+                  order: 0
+                  required:
+                  - "credential_type"
+                  - "hmac_key_access_id"
+                  - "hmac_key_secret"
+                  properties:
+                    credential_type:
+                      type: "string"
+                      const: "HMAC_KEY"
+                      order: 0
+                    hmac_key_access_id:
+                      type: "string"
+                      description: "HMAC key access ID. When linked to a service account,\
+                        \ this ID is 61 characters long; when linked to a user account,\
+                        \ it is 24 characters long."
+                      title: "HMAC Key Access ID"
+                      airbyte_secret: true
+                      examples:
+                      - "1234567890abcdefghij1234"
+                      order: 1
+                    hmac_key_secret:
+                      type: "string"
+                      description: "The corresponding secret for the access ID. It\
+                        \ is a 40-character base-64 encoded string."
+                      title: "HMAC Key Secret"
+                      airbyte_secret: true
+                      examples:
+                      - "1234567890abcdefghij1234567890ABCDEFGHIJ"
+                      order: 2
+              gcs_bucket_name:
+                title: "GCS Bucket Name"
+                type: "string"
+                description: "The name of the GCS bucket. Read more <a href=\"https://cloud.google.com/storage/docs/naming-buckets\"\
+                  >here</a>."
+                examples:
+                - "airbyte_sync"
+                order: 2
+              gcs_bucket_path:
+                title: "GCS Bucket Path"
+                description: "Directory under the GCS bucket where data will be written.\
+                  \ Read more <a href=\"https://cloud.google.com/storage/docs/locations\"\
+                  >here</a>."
+                type: "string"
+                examples:
+                - "data_sync/test"
+                order: 3
+              part_size_mb:
+                title: "Block Size (MB) for GCS Multipart Upload (Optional)"
+                description: "This is the size of a \"Part\" being buffered in memory.\
+                  \ It limits the memory usage when writing. Larger values will allow\
+                  \ to upload a bigger files and improve the speed, but consumes more\
+                  \ memory. Allowed values: min=5MB, max=525MB Default: 5MB."
+                type: "integer"
+                default: 5
+                minimum: 5
+                maximum: 525
+                examples:
+                - 5
+                order: 4
+              keep_files_in_gcs-bucket:
+                type: "string"
+                description: "This upload method is supposed to temporary store records\
+                  \ in GCS bucket. By this select you can chose if these records should\
+                  \ be removed from GCS when migration has finished. The default \"\
+                  Delete all tmp files from GCS\" value is used if not set explicitly."
+                title: "GCS Tmp Files Afterward Processing (Optional)"
+                default: "Delete all tmp files from GCS"
+                enum:
+                - "Delete all tmp files from GCS"
+                - "Keep all tmp files in GCS"
+                order: 5
+        credentials_json:
+          type: "string"
+          description: "The contents of the JSON service account key. Check out the\
+            \ <a href=\"https://docs.airbyte.com/integrations/destinations/bigquery#service-account-key\"\
+            >docs</a> if you need help generating this key. Default credentials will\
+            \ be used if this field is left empty."
+          title: "Service Account Key JSON (Required for cloud, optional for open-source)"
+          airbyte_secret: true
+          order: 3
         dataset_location:
           type: "string"
           description: "The location of the dataset. Warning: Changes made after creation\
@@ -540,6 +653,7 @@
             >here</a>."
           title: "Dataset Location (Optional)"
           default: "US"
+          order: 4
           enum:
           - "US"
           - "EU"
@@ -572,116 +686,21 @@
           - "us-west2"
           - "us-west3"
           - "us-west4"
-        credentials_json:
-          type: "string"
-          description: "The contents of the JSON service account key. Check out the\
-            \ <a href=\"https://docs.airbyte.com/integrations/destinations/bigquery#service-account-key\"\
-            >docs</a> if you need help generating this key. Default credentials will\
-            \ be used if this field is left empty."
-          title: "Service Account Key JSON (Required for cloud, optional for open-source)"
-          airbyte_secret: true
-        loading_method:
-          type: "object"
-          title: "Loading Method *"
-          description: "Loading method used to send select the way data will be uploaded\
-            \ to BigQuery. <br/><b>Standard Inserts</b> - Direct uploading using SQL\
-            \ INSERT statements. This method is extremely inefficient and provided\
-            \ only for quick testing. In almost all cases, you should use staging.\
-            \ <br/><b>GCS Staging</b> - Writes large batches of records to a file,\
-            \ uploads the file to GCS, then uses <b>COPY INTO table</b> to upload\
-            \ the file. Recommended for most workloads for better speed and scalability.\
-            \ Read more about GCS Staging <a href=\"https://docs.airbyte.com/integrations/destinations/bigquery#gcs-staging\"\
+        big_query_client_buffer_size_mb:
+          title: "Google BigQuery Client Chunk Size (Optional)"
+          description: "Google BigQuery client's chunk (buffer) size (MIN=1, MAX =\
+            \ 15) for each table. The size that will be written by a single RPC. Written\
+            \ data will be buffered and only flushed upon reaching this size or closing\
+            \ the channel. The default 15MB value is used if not set explicitly. Read\
+            \ more <a href=\"https://googleapis.dev/python/bigquery/latest/generated/google.cloud.bigquery.client.Client.html\"\
             >here</a>."
-          oneOf:
-          - title: "Standard Inserts"
-            additionalProperties: false
-            required:
-            - "method"
-            properties:
-              method:
-                type: "string"
-                const: "Standard"
-          - title: "GCS Staging"
-            additionalProperties: false
-            required:
-            - "method"
-            - "gcs_bucket_name"
-            - "gcs_bucket_path"
-            - "credential"
-            properties:
-              method:
-                type: "string"
-                const: "GCS Staging"
-              gcs_bucket_name:
-                title: "GCS Bucket Name"
-                type: "string"
-                description: "The name of the GCS bucket. Read more <a href=\"https://cloud.google.com/storage/docs/naming-buckets\"\
-                  >here</a>."
-                examples:
-                - "airbyte_sync"
-              gcs_bucket_path:
-                title: "GCS Bucket Path"
-                description: "Directory under the GCS bucket where data will be written."
-                type: "string"
-                examples:
-                - "data_sync/test"
-              part_size_mb:
-                title: "Block Size (MB) for GCS Multipart Upload (Optional)"
-                description: "This is the size of a \"Part\" being buffered in memory.\
-                  \ It limits the memory usage when writing. Larger values will allow\
-                  \ to upload a bigger files and improve the speed, but consumes more\
-                  \ memory. Allowed values: min=5MB, max=525MB Default: 5MB."
-                type: "integer"
-                default: 5
-                minimum: 5
-                maximum: 525
-                examples:
-                - 5
-              keep_files_in_gcs-bucket:
-                type: "string"
-                description: "This upload method is supposed to temporary store records\
-                  \ in GCS bucket. What do you want to do with data in GCS bucket\
-                  \ when migration has finished? The default \"Delete all tmp files\
-                  \ from GCS\" value is used if not set explicitly."
-                title: "GCS Tmp Files Afterward Processing (Optional)"
-                default: "Delete all tmp files from GCS"
-                enum:
-                - "Delete all tmp files from GCS"
-                - "Keep all tmp files in GCS"
-              credential:
-                title: "Credential"
-                description: "An HMAC key is a type of credential and can be associated\
-                  \ with a service account or a user account in Cloud Storage. Read\
-                  \ more <a href=\"https://cloud.google.com/storage/docs/authentication/hmackeys\"\
-                  >here</a>."
-                type: "object"
-                oneOf:
-                - title: "HMAC key"
-                  required:
-                  - "credential_type"
-                  - "hmac_key_access_id"
-                  - "hmac_key_secret"
-                  properties:
-                    credential_type:
-                      type: "string"
-                      const: "HMAC_KEY"
-                    hmac_key_access_id:
-                      type: "string"
-                      description: "HMAC key access ID. When linked to a service account,\
-                        \ this ID is 61 characters long; when linked to a user account,\
-                        \ it is 24 characters long."
-                      title: "HMAC Key Access ID"
-                      airbyte_secret: true
-                      examples:
-                      - "1234567890abcdefghij1234"
-                    hmac_key_secret:
-                      type: "string"
-                      description: "The corresponding secret for the access ID. It\
-                        \ is a 40-character base-64 encoded string."
-                      title: "HMAC Key Secret"
-                      airbyte_secret: true
-                      examples:
-                      - "1234567890abcdefghij1234567890ABCDEFGHIJ"
+          type: "integer"
+          minimum: 1
+          maximum: 15
+          default: 15
+          examples:
+          - "15"
+          order: 5
     supportsIncremental: true
     supportsNormalization: false
     supportsDBT: true

--- a/airbyte-integrations/connectors/destination-bigquery-denormalized/Dockerfile
+++ b/airbyte-integrations/connectors/destination-bigquery-denormalized/Dockerfile
@@ -17,5 +17,5 @@ ENV ENABLE_SENTRY true
 
 COPY --from=build /airbyte /airbyte
 
-LABEL io.airbyte.version=1.1.7
+LABEL io.airbyte.version=1.1.8
 LABEL io.airbyte.name=airbyte/destination-bigquery-denormalized

--- a/airbyte-integrations/connectors/destination-bigquery/Dockerfile
+++ b/airbyte-integrations/connectors/destination-bigquery/Dockerfile
@@ -17,5 +17,5 @@ ENV ENABLE_SENTRY true
 
 COPY --from=build /airbyte /airbyte
 
-LABEL io.airbyte.version=1.1.7
+LABEL io.airbyte.version=1.1.8
 LABEL io.airbyte.name=airbyte/destination-bigquery

--- a/airbyte-integrations/connectors/destination-bigquery/src/main/java/io/airbyte/integrations/destination/bigquery/BigQueryDestination.java
+++ b/airbyte-integrations/connectors/destination-bigquery/src/main/java/io/airbyte/integrations/destination/bigquery/BigQueryDestination.java
@@ -142,8 +142,11 @@ public class BigQueryDestination extends BaseConnector implements Destination {
       final StringBuilder message = new StringBuilder("Cannot access the GCS bucket.");
       if (!missingPermissions.isEmpty()) {
         message.append(" The following permissions are missing on the service account: ")
-            .append(String.join(", ", missingPermissions));
+            .append(String.join(", ", missingPermissions))
+            .append(".");
       }
+      message.append(" Please make sure the service account can access the bucket path, and the HMAC keys are correct.");
+
       LOGGER.error(message.toString(), e);
 
       return new AirbyteConnectionStatus()

--- a/airbyte-integrations/connectors/destination-bigquery/src/main/java/io/airbyte/integrations/destination/bigquery/BigQueryDestination.java
+++ b/airbyte-integrations/connectors/destination-bigquery/src/main/java/io/airbyte/integrations/destination/bigquery/BigQueryDestination.java
@@ -47,6 +47,7 @@ import io.airbyte.protocol.models.ConfiguredAirbyteCatalog;
 import io.airbyte.protocol.models.ConfiguredAirbyteStream;
 import java.io.ByteArrayInputStream;
 import java.io.IOException;
+import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
@@ -118,6 +119,7 @@ public class BigQueryDestination extends BaseConnector implements Destination {
   public AirbyteConnectionStatus checkGcsPermission(final JsonNode config) {
     final JsonNode loadingMethod = config.get(BigQueryConsts.LOADING_METHOD);
     final String bucketName = loadingMethod.get(BigQueryConsts.GCS_BUCKET_NAME).asText();
+    final List<String> missingPermissions = new ArrayList<>();
 
     try {
       final GoogleCredentials credentials = getServiceAccountCredentials(config);
@@ -127,20 +129,22 @@ public class BigQueryDestination extends BaseConnector implements Destination {
           .build().getService();
       final List<Boolean> permissionsCheckStatusList = storage.testIamPermissions(bucketName, REQUIRED_PERMISSIONS);
 
-      final List<String> missingPermissions = StreamUtils
+      missingPermissions.addAll(StreamUtils
           .zipWithIndex(permissionsCheckStatusList.stream())
           .filter(i -> !i.getValue())
           .map(i -> REQUIRED_PERMISSIONS.get(Math.toIntExact(i.getIndex())))
-          .toList();
-      if (!missingPermissions.isEmpty()) {
-        LOGGER.warn("Please make sure you account has all of these permissions:{}", REQUIRED_PERMISSIONS);
-      }
+          .toList());
 
       final GcsDestination gcsDestination = new GcsDestination();
       final JsonNode gcsJsonNodeConfig = BigQueryUtils.getGcsJsonNodeConfig(config);
       return gcsDestination.check(gcsJsonNodeConfig);
     } catch (final Exception e) {
-      LOGGER.error("Cannot access the GCS bucket", e);
+      final StringBuilder message = new StringBuilder("Cannot access the GCS bucket.");
+      if (!missingPermissions.isEmpty()) {
+        message.append(" The following permissions are missing on the service account: ")
+            .append(String.join(", ", missingPermissions));
+      }
+      LOGGER.error(message.toString(), e);
 
       return new AirbyteConnectionStatus()
           .withStatus(AirbyteConnectionStatus.Status.FAILED)

--- a/docs/integrations/destinations/bigquery.md
+++ b/docs/integrations/destinations/bigquery.md
@@ -409,6 +409,7 @@ The HMAC key is wrong.
 
 | Version | Date       | Pull Request                                               | Subject                                                                                         |
 |:--------|:-----------|:-----------------------------------------------------------|:------------------------------------------------------------------------------------------------|
+| 1.1.8   | 2022-06-07 | [13579](https://github.com/airbytehq/airbyte/pull/13579)   | Always check GCS bucket for GCS loading method to catch invalid HMAC keys. |
 | 1.1.7   | 2022-06-07 | [13424](https://github.com/airbytehq/airbyte/pull/13424)   | Reordered fields for specification.                                                             |
 | 1.1.6   | 2022-05-15 | [12768](https://github.com/airbytehq/airbyte/pull/12768)   | Clarify that the service account key json field is required on cloud. |
 | 1.1.5   | 2022-05-12 | [12805](https://github.com/airbytehq/airbyte/pull/12805)   | Updated to latest base-java to emit AirbyteTraceMessage on error.                               |
@@ -446,6 +447,7 @@ The HMAC key is wrong.
 
 | Version | Date       | Pull Request                                               | Subject                                                                                                                 |
 |:--------|:-----------|:-----------------------------------------------------------|:------------------------------------------------------------------------------------------------------------------------|
+| 1.1.8   | 2022-06-07 | [13579](https://github.com/airbytehq/airbyte/pull/13579)   | Always check GCS bucket for GCS loading method to catch invalid HMAC keys. |
 | 1.1.7   | 2022-06-07 | [13424](https://github.com/airbytehq/airbyte/pull/13424)   | Reordered fields for specification.                                                                                     |
 | 1.1.6   | 2022-05-15 | [12768](https://github.com/airbytehq/airbyte/pull/12768)   | Clarify that the service account key json field is required on cloud.                                                   |
 | 0.3.5   | 2022-05-12 | [12805](https://github.com/airbytehq/airbyte/pull/12805)   | Updated to latest base-java to emit AirbyteTraceMessage on error.                                                       |


### PR DESCRIPTION
## What
- Resolve https://github.com/airbytehq/oncall/issues/261.

## How
- Always run GCS destination check, even when the service account has all the required permissions.

## 🚨 User Impact 🚨
- Currently users can enter the wrong HMAC keys and their BigQuery destination check will pass.
- Once this PR is merged and published, this false positive result will be gone. The connection check will fail if the HMAC keys are incorrect.
