### PR TITLE
Ignore custom connectors during connectors update

### DIFF
--- a/airbyte-config/config-persistence/src/main/java/io/airbyte/config/persistence/DatabaseConfigPersistence.java
+++ b/airbyte-config/config-persistence/src/main/java/io/airbyte/config/persistence/DatabaseConfigPersistence.java
@@ -51,6 +51,7 @@ import io.airbyte.config.persistence.split_secrets.JsonSecretsProcessor;
 import io.airbyte.db.Database;
 import io.airbyte.db.ExceptionWrappingDatabase;
 import io.airbyte.db.instance.configs.jooq.generated.enums.ActorType;
+import io.airbyte.db.instance.configs.jooq.generated.enums.ReleaseStage;
 import io.airbyte.protocol.models.ConnectorSpecification;
 import io.airbyte.validation.json.JsonValidationException;
 import java.io.IOException;
@@ -1686,6 +1687,7 @@ public class DatabaseConfigPersistence implements ConfigPersistence {
   Map<String, ConnectorInfo> getConnectorRepositoryToInfoMap(final DSLContext ctx) {
     return ctx.select(asterisk())
         .from(ACTOR_DEFINITION)
+        .where(ACTOR_DEFINITION.RELEASE_STAGE.isNull().or(ACTOR_DEFINITION.RELEASE_STAGE.ne(ReleaseStage.custom)))
         .fetch()
         .stream()
         .collect(Collectors.toMap(

--- a/airbyte-config/config-persistence/src/main/java/io/airbyte/config/persistence/DatabaseConfigPersistence.java
+++ b/airbyte-config/config-persistence/src/main/java/io/airbyte/config/persistence/DatabaseConfigPersistence.java
@@ -1688,8 +1688,7 @@ public class DatabaseConfigPersistence implements ConfigPersistence {
     return ctx.select(asterisk())
         .from(ACTOR_DEFINITION)
         .where(ACTOR_DEFINITION.RELEASE_STAGE.isNull()
-            .or(ACTOR_DEFINITION.RELEASE_STAGE.ne(ReleaseStage.custom).or(ACTOR_DEFINITION.CUSTOM))
-        )
+            .or(ACTOR_DEFINITION.RELEASE_STAGE.ne(ReleaseStage.custom).or(ACTOR_DEFINITION.CUSTOM)))
         .fetch()
         .stream()
         .collect(Collectors.toMap(

--- a/airbyte-config/config-persistence/src/main/java/io/airbyte/config/persistence/DatabaseConfigPersistence.java
+++ b/airbyte-config/config-persistence/src/main/java/io/airbyte/config/persistence/DatabaseConfigPersistence.java
@@ -1687,7 +1687,9 @@ public class DatabaseConfigPersistence implements ConfigPersistence {
   Map<String, ConnectorInfo> getConnectorRepositoryToInfoMap(final DSLContext ctx) {
     return ctx.select(asterisk())
         .from(ACTOR_DEFINITION)
-        .where(ACTOR_DEFINITION.RELEASE_STAGE.isNull().or(ACTOR_DEFINITION.RELEASE_STAGE.ne(ReleaseStage.custom)))
+        .where(ACTOR_DEFINITION.RELEASE_STAGE.isNull()
+            .or(ACTOR_DEFINITION.RELEASE_STAGE.ne(ReleaseStage.custom).or(ACTOR_DEFINITION.CUSTOM))
+        )
         .fetch()
         .stream()
         .collect(Collectors.toMap(


### PR DESCRIPTION
The bootloader continues to fails during startup because it tries to parse version number for custom connectors. The previous [change](https://github.com/airbytehq/airbyte/pull/12588) was attempting to skip such connectors based on the `custom` database column but this field is not set just yet.
This change identify and skip connectors based on the release_stage information instead.
