### PR TITLE
Add Release Airbyte action to automatically release OSS upon merging a version bump PR

### DIFF
--- a/.github/workflows/release-airbyte.yml
+++ b/.github/workflows/release-airbyte.yml
@@ -1,0 +1,67 @@
+name: Release Airbyte
+
+on:
+  push:
+    branches:
+      - master
+
+jobs:
+  release-airbyte:
+    if: startsWith(github.event.head_commit.message, 'Bump Airbyte version')
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+      pull-requests: read
+    steps:
+      - name: Fetch Version Bump PR Body
+        id: fetch_pr_body
+        env:
+          COMMIT_ID: ${{ github.event.head_commit.id }}
+        shell: bash
+        run: |-
+          set -x
+          PR=$(curl \
+          -H "Accept: application/vnd.github.v3+json" \
+          -H "Authorization: Bearer ${{ secrets.GITHUB_TOKEN }}" \
+          https://api.github.com/repos/${{ github.repository }}/commits/$COMMIT_ID/pulls)
+          # the printf helps escape characters so that jq can parse the output.
+          # the sed removes carriage returns so that the body is easier to parse later.
+          PR_BODY=$(printf '%s' "$PR" | jq '.[0].body' | sed 's/\\r//g')
+          echo ::set-output name=pr_body::${PR_BODY}
+      - name: Extract Changelog
+        id: extract_changelog
+        shell: bash
+        run: |-
+          set -x
+          PR_BODY=${{ steps.fetch_pr_body.outputs.pr_body}}
+          if [[ $PR_BODY = "null" ]]; then
+            echo "No PR body exists for this commit, so a release cannot be generated."
+            exit 1
+          fi
+          # this regex extracts just the changelog contents
+          if [[ $PR_BODY =~ Changelog:(\\n)*(.*)\\n\\n ]]; then
+            CHANGELOG="${BASH_REMATCH[2]}"
+          else
+            echo "PR body does not match the changelog extraction regex"
+            exit 1
+          fi
+          # save CHANGELOG into a multiline env var on the action itself, since Github Actions do not support outputting multiline strings well
+          echo "CHANGELOG<<EOF" >> $GITHUB_ENV
+          echo -e "$CHANGELOG" >> $GITHUB_ENV
+          echo "EOF" >> $GITHUB_ENV
+      - name: Checkout Airbyte
+        uses: actions/checkout@v2
+      - name: Get Version
+        id: get_version
+        shell: bash
+        run: |
+          VERSION=$(grep -w VERSION .env | cut -d"=" -f2)
+          echo ::set-output name=VERSION::${VERSION}
+      - name: Create Release
+        id: create_release
+        uses: ncipollo/release-action@v1
+        with:
+          body: ${{ env.CHANGELOG }}
+          token: ${{ secrets.GITHUB_TOKEN }}
+          prerelease: true
+          tag: v${{ steps.get_version.outputs.VERSION }}

--- a/tools/bin/pr_body.sh
+++ b/tools/bin/pr_body.sh
@@ -8,11 +8,18 @@ set -e
 
 echo "*IMPORTANT: Only merge if the platform build is passing!*"
 echo
+# Do not change the following line - the Release Airbyte Github action relies on it
 echo "Changelog:"
 echo
 PAGER=cat git log v${PREV_VERSION}..${GIT_REVISION} --oneline --decorate=no
+# The following empty 'echo' is also important for marking the end of the changelog for the Release Airbyte Github action
 echo
-echo "Steps After Merging PR:"
-echo "1. Pull most recent version of master"
-echo "2. Run ./tools/bin/tag_version.sh"
-echo "3. Create a GitHub release with the changelog"
+echo "Instructions:"
+echo "- *SQUASH MERGE* this PR - this is necessary to ensure the automated Release Airbyte action is triggered."
+echo "- Double check that the Release Airbyte action was triggered and ran successfully on the commit to master \
+(this should only take a few seconds)."
+echo "- If the Release Airbyte action failed due to a transient issue, retry the action. If it failed due to \
+a non-transient issue, you will need to manually create a release by following these steps:"
+echo "    1. Pull most recent version of master"
+echo "    2. Run ./tools/bin/tag_version.sh"
+echo "    3. Create a GitHub release with the changelog"


### PR DESCRIPTION
## What
*HACKDAYS PROJECT*

Releasing OSS airbyte currently requires engineers to run a script and manually create a release after merging a version bump PR. These manual steps are prone to error and are sometimes forgotten completely, in which case future releases fail due to the previous release never having been created, causing confusion and wasting engineering time.

This PR solves that problem by adding a Release Airbyte action that automatically runs upon merging a version bump PR into master. 

## How
The Release Airbyte action is triggered automatically when a `Bump Airbyte version` PR is merged into master. This action fetches the changelog from the version bump PR body, fetches the new version from the `.env` file, and automatically creates a new tag and release for that version containing the changelog. 

I also included some changes to the PR description generated for a version bump PR, to indicate that engineers should still confirm that the new release action ran successfully on a version bump merge, to ensure that any problems with this new action are not ignored completely.

This release action has been tested in the following repo: https://github.com/airbytehq/airbyte-release-testing