### PR TITLE
Webflow b4

### DIFF
--- a/airbyte-integrations/connectors/source-rki-covid/README.md
+++ b/airbyte-integrations/connectors/source-rki-covid/README.md
@@ -56,8 +56,20 @@ to generate the necessary credentials. Then create a file `secrets/config.json` 
 Note that any directory named `secrets` is gitignored across the entire Airbyte repo, so there is no danger of accidentally checking in sensitive information.
 See `integration_tests/sample_config.json` for a sample config file.
 
-**If you are an Airbyte core member**, copy the credentials in Lastpass under the secret name `source rki-covid test creds`
+
+**If you are an Airbyte core member**, copy the credentials in Lastpass under the secret name `source slack test creds`
 and place them into `secrets/config.json`.
+
+You should be able to create a Webflow API key at a URL such as:
+
+https://webflow.com/dashboard/sites/<your-site-name>/integrations. Once you have the API, you can confirm a
+list of available sites and get their "_id" by executing
+
+```
+curl https://api.webflow.com/sites \
+  -H "Authorization: Bearer <your API Key>" \
+  -H "accept-version: 1.0.0"
+```
 
 ### Locally running the connector
 ```


### PR DESCRIPTION
## What
This connector pulls collections out of Webflow.  


## How
Webflow uses [Collections](https://developers.webflow.com/#collections) to store different kinds of information. A collection can be "Blog Posts", or "Blog Authors", etc. Collection names are not pre-defined, the number of collections is not known in advance, and the schema for each collection may be different. Therefore this connector dynamically figures our which collections are available and downloads the schema for each collection from Webflow. Each collection is mapped to an [Airbyte Streams](https://docs.airbyte.com/connector-development/cdk-python/full-refresh-stream/)


## Pre-merge Checklist
Expand the relevant checklist and delete the others.

<details><summary><strong>New Connector</strong></summary>

### Community member or Airbyter

- [ ] **Community member?** Grant edit access to maintainers ([instructions](https://docs.github.com/en/github/collaborating-with-pull-requests/working-with-forks/allowing-changes-to-a-pull-request-branch-created-from-a-fork#enabling-repository-maintainer-permissions-on-existing-pull-requests))
- [ ] Secrets in the connector's spec are annotated with `airbyte_secret`
- [ ] Unit & integration tests added and passing. Community members, please provide proof of success locally e.g: screenshot or copy-paste unit, integration, and acceptance test output. To run acceptance tests for a Python connector, follow instructions in the README. For java connectors run `./gradlew :airbyte-integrations:connectors:<name>:integrationTest`.
- [ ] Code reviews completed
- [ ] Documentation updated
    - [ ] Connector's `README.md`
    - [ ] Connector's `bootstrap.md`. See [description and examples](https://docs.google.com/document/d/1ypdgmwmEHWv-TrO4_YOQ7pAJGVrMp5BOkEVh831N260/edit?usp=sharing)
    - [ ] `docs/integrations/<source or destination>/<name>.md` including changelog. See changelog [example](https://docs.airbyte.io/integrations/sources/stripe#changelog)
    - [ ] `docs/integrations/README.md`
    - [ ] `airbyte-integrations/builds.md`
- [ ] PR name follows [PR naming conventions](https://docs.airbyte.io/contributing-to-airbyte/updating-documentation#issues-and-pull-requests)

### Airbyter

If this is a community PR, the Airbyte engineer reviewing this PR is responsible for the below items.

- [ ] Create a non-forked branch based on this PR and test the below items on it
- [ ] Build is successful
- [ ] If new credentials are required for use in CI, add them to GSM. [Instructions](https://docs.airbyte.io/connector-development#using-credentials-in-ci).
- [ ] [`/test connector=connectors/<name>` command](https://docs.airbyte.io/connector-development#updating-an-existing-connector) is passing
- [ ] New Connector version released on Dockerhub by running the `/publish` command described [here](https://docs.airbyte.io/connector-development#updating-an-existing-connector)
- [ ] After the connector is published, connector added to connector index as described [here](https://docs.airbyte.io/connector-development#publishing-a-connector)
- [ ] Seed specs have been re-generated by building the platform and committing the changes to the seed spec files, as described [here](https://docs.airbyte.io/connector-development#publishing-a-connector)

</details>


## Tests

<details><summary><strong>Unit</strong></summary>

```
python -m pytest unit_tests

Test session starts (platform: darwin, Python 3.9.11, pytest 6.2.5, pytest-sugar 0.9.4)
cachedir: .pytest_cache
rootdir: /Users/arm/Documents/airbyte-webflow-source, configfile: pytest.ini
plugins: sugar-0.9.4, mock-3.6.1, timeout-1.4.2
collecting ... 
 airbyte-integrations/connectors/source-webflow/unit_tests/test_source.py::test_check_connection ✓                                                                                                 9% ▉         
 airbyte-integrations/connectors/source-webflow/unit_tests/test_source.py::test_streams ✓                                                                                                         18% █▊        
 airbyte-integrations/connectors/source-webflow/unit_tests/test_streams.py::test_request_params_of_collection_items ✓                                                                             27% ██▊       
 airbyte-integrations/connectors/source-webflow/unit_tests/test_streams.py::test_next_page_token_of_collection_items ✓                                                                            36% ███▋      
 airbyte-integrations/connectors/source-webflow/unit_tests/test_streams.py::test_parse_response_of_collection_items ✓                                                                             45% ████▋     
 airbyte-integrations/connectors/source-webflow/unit_tests/test_streams.py::test_http_method ✓                                                                                                    55% █████▌    
 airbyte-integrations/connectors/source-webflow/unit_tests/test_streams.py::test_should_retry[HTTPStatus.OK-False] ✓                                                                              64% ██████▍   
 airbyte-integrations/connectors/source-webflow/unit_tests/test_streams.py::test_should_retry[HTTPStatus.BAD_REQUEST-False] ✓                                                                     73% ███████▍  
 airbyte-integrations/connectors/source-webflow/unit_tests/test_streams.py::test_should_retry[HTTPStatus.TOO_MANY_REQUESTS-True] ✓                                                                82% ████████▎ 
 airbyte-integrations/connectors/source-webflow/unit_tests/test_streams.py::test_should_retry[HTTPStatus.INTERNAL_SERVER_ERROR-True] ✓                                                            91% █████████▏
 airbyte-integrations/connectors/source-webflow/unit_tests/test_streams.py::test_backoff_time ✓                                                                                                  100% ██████████
=============================================================================================== warnings summary ===============================================================================================
airbyte-integrations/connectors/source-webflow/unit_tests/test_source.py: 1 warning
airbyte-integrations/connectors/source-webflow/unit_tests/test_streams.py: 9 warnings
  /Users/arm/Documents/testing-airbyte/airbyte-integrations/connectors/source-webflow/venv/lib/python3.9/site-packages/airbyte_cdk/sources/streams/http/http.py:42: DeprecationWarning: Call to deprecated class NoAuth. (Set `authenticator=None` instead) -- Deprecated since version 0.1.20.
    self._authenticator: HttpAuthenticator = NoAuth()

airbyte-integrations/connectors/source-webflow/unit_tests/test_source.py: 1 warning
airbyte-integrations/connectors/source-webflow/unit_tests/test_streams.py: 9 warnings
  /Users/arm/Documents/testing-airbyte/airbyte-integrations/connectors/source-webflow/venv/lib/python3.9/site-packages/deprecated/classic.py:173: DeprecationWarning: Call to deprecated class HttpAuthenticator. (Use requests.auth.AuthBase instead) -- Deprecated since version 0.1.20.
    return old_new1(cls, *args, **kwargs)

-- Docs: https://docs.pytest.org/en/stable/warnings.html

Results (0.19s):
      11 passed


```

</details>

<details><summary><strong>Integration</strong></summary>

```
test_core.py ...................                                         [100%]


=========================== short test summary info ============================
SKIPPED [1] ../usr/local/lib/python3.9/site-packages/source_acceptance_test/plugin.py:56: Skipping TestFullRefresh.test_sequential_reads because not found in the config
SKIPPED [1] ../usr/local/lib/python3.9/site-packages/source_acceptance_test/plugin.py:56: Skipping TestIncremental.test_two_sequential_reads because not found in the config
======================== 19 passed, 2 skipped in 56.27s ========================

Deprecated Gradle features were used in this build, making it incompatible with Gradle 8.0.

You can use '--warning-mode all' to show the individual deprecation warnings and determine if they come from your own scripts or plugins.

See https://docs.gradle.org/7.4/userguide/command_line_interface.html#sec:command_line_warnings

Execution optimizations have been disabled for 1 invalid unit(s) of work during this build to ensure correctness.
Please consult deprecation warnings for more details.

BUILD SUCCESSFUL in 1m 14s
48 actionable tasks: 24 executed, 24 up-to-date

```


</details>

<details><summary><strong>Acceptance</strong></summary>

```

-- Docs: https://docs.pytest.org/en/stable/warnings.html
=========================================================================================== short test summary info ============================================================================================
SKIPPED [1] ../../../../testing-airbyte/airbyte-integrations/bases/source-acceptance-test/source_acceptance_test/plugin.py:56: Skipping TestFullRefresh.test_sequential_reads because not found in the config
SKIPPED [1] ../../../../testing-airbyte/airbyte-integrations/bases/source-acceptance-test/source_acceptance_test/plugin.py:56: Skipping TestIncremental.test_two_sequential_reads because not found in the config

Results (51.57s):
      18 passed

```
</details>
