### PR TITLE
Reinitialize Account Settings form

### DIFF
--- a/airbyte-webapp/src/pages/SettingsPage/pages/AccountPage/components/AccountForm.tsx
+++ b/airbyte-webapp/src/pages/SettingsPage/pages/AccountPage/components/AccountForm.tsx
@@ -60,6 +60,7 @@ const AccountForm: React.FC<AccountFormProps> = ({ email, onSubmit, successMessa
       validateOnBlur={true}
       validateOnChange={false}
       validationSchema={accountValidationSchema}
+      enableReinitialize
       onSubmit={onSubmit}
     >
       {({ isSubmitting, dirty, values }) => (


### PR DESCRIPTION
## What
Closes https://github.com/airbytehq/airbyte/issues/12847

The Account Settings form was buggy in that it would only sometimes display the success message and disable the button, even if the email in the form was updated.

## How
Using Formik's [enableReinitialize](https://formik.org/docs/api/withFormik#enablereinitialize-boolean) property on the form seems to fix things up.

NOTE: This change only affects OSS as editing emails is not enabled in Cloud.