### PR TITLE
Fix Connectors Base Build: CDK tests fail after `requests` update

### DIFF
--- a/airbyte-cdk/python/unit_tests/sources/streams/http/test_http.py
+++ b/airbyte-cdk/python/unit_tests/sources/streams/http/test_http.py
@@ -476,10 +476,10 @@ def test_default_parse_response_error_message(api_response: dict, expected_messa
     assert message == expected_message
 
 
-def test_default_parse_response_error_message_not_json():
+def test_default_parse_response_error_message_not_json(requests_mock):
     stream = StubBasicReadHttpStream()
-    response = MagicMock()
-    response.json.side_effect = requests.exceptions.JSONDecodeError()
+    requests_mock.register_uri("GET", "mock://test.com/not_json", text="this is not json")
+    response = requests.get("mock://test.com/not_json")
 
     message = stream.parse_response_error_message(response)
     assert message is None


### PR DESCRIPTION
## What
[requests v2.28.0](https://github.com/psf/requests/releases/tag/v2.28.0) was just released, which changed some things around how the `JSONDecodeError` exception was initialized. This broke one of our tests in the CDK, and in turn the Connectors Base build started failing.

## How
Fix the failing test by using a real response instead of a half-mocked one.
