### PR TITLE
Refactor state management out of BufferStrategy

### DIFF
--- a/airbyte-integrations/bases/base-java/src/main/java/io/airbyte/integrations/destination/buffered_stream_consumer/BufferedStreamConsumer.java
+++ b/airbyte-integrations/bases/base-java/src/main/java/io/airbyte/integrations/destination/buffered_stream_consumer/BufferedStreamConsumer.java
@@ -84,9 +84,11 @@ public class BufferedStreamConsumer extends FailureTrackingAirbyteMessageConsume
   private boolean hasStarted;
   private boolean hasClosed;
 
-  // represents the last state message for which all of it records have been flushed to tmp storage in the destination.
+  // represents the last state message for which all of it records have been flushed to tmp storage in
+  // the destination.
   private AirbyteMessage lastFlushedToTmpDstState;
-  // presents the last state message whose state is waitint to be flushed to tmp storage in the destination.
+  // presents the last state message whose state is waitint to be flushed to tmp storage in the
+  // destination.
   private AirbyteMessage pendingState;
 
   public BufferedStreamConsumer(final Consumer<AirbyteMessage> outputRecordCollector,
@@ -136,7 +138,7 @@ public class BufferedStreamConsumer extends FailureTrackingAirbyteMessageConsume
       }
 
       // if the buffer flushes, update the states appropriately.
-      if(bufferingStrategy.addRecord(stream, message)) {
+      if (bufferingStrategy.addRecord(stream, message)) {
         markStatesAsFlushesToTmpDestination();
       }
 

--- a/airbyte-integrations/bases/base-java/src/main/java/io/airbyte/integrations/destination/buffered_stream_consumer/BufferedStreamConsumer.java
+++ b/airbyte-integrations/bases/base-java/src/main/java/io/airbyte/integrations/destination/buffered_stream_consumer/BufferedStreamConsumer.java
@@ -87,7 +87,7 @@ public class BufferedStreamConsumer extends FailureTrackingAirbyteMessageConsume
   // represents the last state message for which all of it records have been flushed to tmp storage in
   // the destination.
   private AirbyteMessage lastFlushedToTmpDstState;
-  // presents the last state message whose state is waitint to be flushed to tmp storage in the
+  // presents the last state message whose state is waiting to be flushed to tmp storage in the
   // destination.
   private AirbyteMessage pendingState;
 

--- a/airbyte-integrations/bases/base-java/src/main/java/io/airbyte/integrations/destination/buffered_stream_consumer/BufferedStreamConsumer.java
+++ b/airbyte-integrations/bases/base-java/src/main/java/io/airbyte/integrations/destination/buffered_stream_consumer/BufferedStreamConsumer.java
@@ -139,7 +139,7 @@ public class BufferedStreamConsumer extends FailureTrackingAirbyteMessageConsume
 
       // if the buffer flushes, update the states appropriately.
       if (bufferingStrategy.addRecord(stream, message)) {
-        markStatesAsFlushesToTmpDestination();
+        markStatesAsFlushedToTmpDestination();
       }
 
     } else if (message.getType() == Type.STATE) {
@@ -150,7 +150,7 @@ public class BufferedStreamConsumer extends FailureTrackingAirbyteMessageConsume
 
   }
 
-  private void markStatesAsFlushesToTmpDestination() {
+  private void markStatesAsFlushedToTmpDestination() {
     if (pendingState != null) {
       lastFlushedToTmpDstState = pendingState;
       pendingState = null;
@@ -176,7 +176,7 @@ public class BufferedStreamConsumer extends FailureTrackingAirbyteMessageConsume
     } else {
       LOGGER.info("executing on success close procedure.");
       bufferingStrategy.flushAll();
-      markStatesAsFlushesToTmpDestination();
+      markStatesAsFlushedToTmpDestination();
     }
     bufferingStrategy.close();
 

--- a/airbyte-integrations/bases/base-java/src/main/java/io/airbyte/integrations/destination/record_buffer/BufferingStrategy.java
+++ b/airbyte-integrations/bases/base-java/src/main/java/io/airbyte/integrations/destination/record_buffer/BufferingStrategy.java
@@ -22,8 +22,13 @@ public interface BufferingStrategy extends AutoCloseable {
 
   /**
    * Add a new message to the buffer while consuming streams
+   *
+   * @param stream - stream associated with record
+   * @param message - message to buffer
+   * @return true if this record cause the buffer to flush, otherwise false.
+   * @throws Exception throw on failure
    */
-  void addRecord(AirbyteStreamNameNamespacePair stream, AirbyteMessage message) throws Exception;
+  boolean addRecord(AirbyteStreamNameNamespacePair stream, AirbyteMessage message) throws Exception;
 
   /**
    * Flush buffered messages in a writer from a particular stream
@@ -39,13 +44,5 @@ public interface BufferingStrategy extends AutoCloseable {
    * Removes all stream buffers.
    */
   void clear() throws Exception;
-
-  /**
-   * When all buffers are being flushed, we can signal some parent function of this event for further
-   * processing.
-   *
-   * THis install such a hook to be triggered when that happens.
-   */
-  void registerFlushAllEventHook(VoidCallable onFlushAllEventHook);
 
 }

--- a/airbyte-integrations/bases/base-java/src/main/java/io/airbyte/integrations/destination/record_buffer/BufferingStrategy.java
+++ b/airbyte-integrations/bases/base-java/src/main/java/io/airbyte/integrations/destination/record_buffer/BufferingStrategy.java
@@ -24,7 +24,7 @@ public interface BufferingStrategy extends AutoCloseable {
    *
    * @param stream - stream associated with record
    * @param message - message to buffer
-   * @return true if this record cause the buffer to flush, otherwise false.
+   * @return true if this record cause ALL records in the buffer to flush, otherwise false.
    * @throws Exception throw on failure
    */
   boolean addRecord(AirbyteStreamNameNamespacePair stream, AirbyteMessage message) throws Exception;

--- a/airbyte-integrations/bases/base-java/src/main/java/io/airbyte/integrations/destination/record_buffer/BufferingStrategy.java
+++ b/airbyte-integrations/bases/base-java/src/main/java/io/airbyte/integrations/destination/record_buffer/BufferingStrategy.java
@@ -4,7 +4,6 @@
 
 package io.airbyte.integrations.destination.record_buffer;
 
-import io.airbyte.commons.concurrency.VoidCallable;
 import io.airbyte.integrations.base.AirbyteStreamNameNamespacePair;
 import io.airbyte.protocol.models.AirbyteMessage;
 

--- a/airbyte-integrations/bases/base-java/src/main/java/io/airbyte/integrations/destination/record_buffer/InMemoryRecordBufferingStrategy.java
+++ b/airbyte-integrations/bases/base-java/src/main/java/io/airbyte/integrations/destination/record_buffer/InMemoryRecordBufferingStrategy.java
@@ -4,7 +4,6 @@
 
 package io.airbyte.integrations.destination.record_buffer;
 
-import io.airbyte.commons.concurrency.VoidCallable;
 import io.airbyte.integrations.base.AirbyteStreamNameNamespacePair;
 import io.airbyte.integrations.base.sentry.AirbyteSentry;
 import io.airbyte.integrations.destination.buffered_stream_consumer.CheckAndRemoveRecordWriter;

--- a/airbyte-integrations/bases/base-java/src/main/java/io/airbyte/integrations/destination/record_buffer/SerializedBufferingStrategy.java
+++ b/airbyte-integrations/bases/base-java/src/main/java/io/airbyte/integrations/destination/record_buffer/SerializedBufferingStrategy.java
@@ -68,8 +68,21 @@ public class SerializedBufferingStrategy implements BufferingStrategy {
       totalBufferSizeInBytes = 0;
     } else if (streamBuffer.getByteCount() >= streamBuffer.getMaxPerStreamBufferSizeInBytes()) {
       flushWriter(stream, streamBuffer);
-      // cannot mark didFlush here, because there is no guarantee that all records for a given state have
-      // been flushed.
+      /*
+       * Note: We intentionally do not mark didFlush as true in the branch of this conditional. Because
+       * this branch flushes individual streams, there is no guaranteee that it will flush records in the
+       * same order that state messages were received. The outcome here is that records get flushed but
+       * our updating of which state messages have been flushed falls behind.
+       *
+       * This is not ideal from a checkpoint point of view, because it means in the case where there is a
+       * failure, we will not be able to report that those records that were flushed and committed were
+       * committed because there corresponding state messages weren't marked as flushed. Thus, it weakens
+       * checkpointing, but it does not cause a correctness issue.
+       *
+       * In non-failure cases, using this conditional branch relies on the state messages getting flushed
+       * by some other means. That can be caused by the previous branch in this conditional. It is
+       * guaranteed by the fact that we always flush all state messages at the end of a sync.
+       */
     }
 
     return didFlush;

--- a/airbyte-integrations/bases/base-java/src/main/java/io/airbyte/integrations/destination/record_buffer/SerializedBufferingStrategy.java
+++ b/airbyte-integrations/bases/base-java/src/main/java/io/airbyte/integrations/destination/record_buffer/SerializedBufferingStrategy.java
@@ -4,7 +4,6 @@
 
 package io.airbyte.integrations.destination.record_buffer;
 
-import io.airbyte.commons.concurrency.VoidCallable;
 import io.airbyte.commons.functional.CheckedBiConsumer;
 import io.airbyte.commons.functional.CheckedBiFunction;
 import io.airbyte.commons.string.Strings;
@@ -69,7 +68,8 @@ public class SerializedBufferingStrategy implements BufferingStrategy {
       totalBufferSizeInBytes = 0;
     } else if (streamBuffer.getByteCount() >= streamBuffer.getMaxPerStreamBufferSizeInBytes()) {
       flushWriter(stream, streamBuffer);
-      // cannot mark didFlush here, because there is no guarantee that all records for a given state have been flushed.
+      // cannot mark didFlush here, because there is no guarantee that all records for a given state have
+      // been flushed.
     }
 
     return didFlush;

--- a/airbyte-integrations/bases/base-java/src/test/java/io/airbyte/integrations/destination/record_buffer/InMemoryRecordBufferingStrategyTest.java
+++ b/airbyte-integrations/bases/base-java/src/test/java/io/airbyte/integrations/destination/record_buffer/InMemoryRecordBufferingStrategyTest.java
@@ -36,17 +36,12 @@ public class InMemoryRecordBufferingStrategyTest {
     final AirbyteMessage message2 = generateMessage(stream2);
     final AirbyteMessage message3 = generateMessage(stream2);
     final AirbyteMessage message4 = generateMessage(stream2);
-    final VoidCallable hook = mock(VoidCallable.class);
-    buffering.registerFlushAllEventHook(hook);
 
     buffering.addRecord(stream1, message1);
     buffering.addRecord(stream2, message2);
     // Buffer still has room
-    verify(hook, times(0)).call();
-
     buffering.addRecord(stream2, message3);
     // Buffer limit reach, flushing all messages so far before adding the new incoming one
-    verify(hook, times(1)).call();
     verify(recordWriter, times(1)).accept(stream1, List.of(message1.getRecord()));
     verify(recordWriter, times(1)).accept(stream2, List.of(message2.getRecord()));
 
@@ -54,7 +49,6 @@ public class InMemoryRecordBufferingStrategyTest {
 
     // force flush to terminate test
     buffering.flushAll();
-    verify(hook, times(2)).call();
     verify(recordWriter, times(1)).accept(stream2, List.of(message3.getRecord(), message4.getRecord()));
   }
 

--- a/airbyte-integrations/bases/base-java/src/test/java/io/airbyte/integrations/destination/record_buffer/InMemoryRecordBufferingStrategyTest.java
+++ b/airbyte-integrations/bases/base-java/src/test/java/io/airbyte/integrations/destination/record_buffer/InMemoryRecordBufferingStrategyTest.java
@@ -4,6 +4,8 @@
 
 package io.airbyte.integrations.destination.record_buffer;
 
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
@@ -24,6 +26,7 @@ public class InMemoryRecordBufferingStrategyTest {
   // instances
   private static final int MAX_QUEUE_SIZE_IN_BYTES = 130;
 
+  @SuppressWarnings("unchecked")
   private final RecordWriter<AirbyteRecordMessage> recordWriter = mock(RecordWriter.class);
 
   @Test
@@ -36,10 +39,10 @@ public class InMemoryRecordBufferingStrategyTest {
     final AirbyteMessage message3 = generateMessage(stream2);
     final AirbyteMessage message4 = generateMessage(stream2);
 
-    buffering.addRecord(stream1, message1);
-    buffering.addRecord(stream2, message2);
+    assertFalse(buffering.addRecord(stream1, message1));
+    assertFalse(buffering.addRecord(stream2, message2));
     // Buffer still has room
-    buffering.addRecord(stream2, message3);
+    assertTrue(buffering.addRecord(stream2, message3));
     // Buffer limit reach, flushing all messages so far before adding the new incoming one
     verify(recordWriter, times(1)).accept(stream1, List.of(message1.getRecord()));
     verify(recordWriter, times(1)).accept(stream2, List.of(message2.getRecord()));

--- a/airbyte-integrations/bases/base-java/src/test/java/io/airbyte/integrations/destination/record_buffer/InMemoryRecordBufferingStrategyTest.java
+++ b/airbyte-integrations/bases/base-java/src/test/java/io/airbyte/integrations/destination/record_buffer/InMemoryRecordBufferingStrategyTest.java
@@ -9,7 +9,6 @@ import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 
 import com.fasterxml.jackson.databind.JsonNode;
-import io.airbyte.commons.concurrency.VoidCallable;
 import io.airbyte.commons.json.Jsons;
 import io.airbyte.integrations.base.AirbyteStreamNameNamespacePair;
 import io.airbyte.integrations.destination.buffered_stream_consumer.RecordWriter;

--- a/airbyte-integrations/bases/base-java/src/test/java/io/airbyte/integrations/destination/record_buffer/SerializedBufferingStrategyTest.java
+++ b/airbyte-integrations/bases/base-java/src/test/java/io/airbyte/integrations/destination/record_buffer/SerializedBufferingStrategyTest.java
@@ -39,7 +39,6 @@ public class SerializedBufferingStrategyTest {
   private final ConfiguredAirbyteCatalog catalog = mock(ConfiguredAirbyteCatalog.class);
   private final CheckedBiConsumer<AirbyteStreamNameNamespacePair, SerializableBuffer, Exception> perStreamFlushHook =
       mock(CheckedBiConsumer.class);
-  private final VoidCallable flushAllHook = mock(VoidCallable.class);
 
   private final SerializableBuffer recordWriter1 = mock(SerializableBuffer.class);
   private final SerializableBuffer recordWriter2 = mock(SerializableBuffer.class);
@@ -73,7 +72,6 @@ public class SerializedBufferingStrategyTest {
     final AirbyteMessage message3 = generateMessage(stream2);
     final AirbyteMessage message4 = generateMessage(stream2);
     final AirbyteMessage message5 = generateMessage(stream2);
-    buffering.registerFlushAllEventHook(flushAllHook);
 
     when(recordWriter1.getByteCount()).thenReturn(10L); // one record in recordWriter1
     buffering.addRecord(stream1, message1);
@@ -81,7 +79,6 @@ public class SerializedBufferingStrategyTest {
     buffering.addRecord(stream2, message2);
 
     // Total and per stream Buffers still have room
-    verify(flushAllHook, times(0)).call();
     verify(perStreamFlushHook, times(0)).accept(stream1, recordWriter1);
     verify(perStreamFlushHook, times(0)).accept(stream2, recordWriter2);
 
@@ -91,7 +88,6 @@ public class SerializedBufferingStrategyTest {
     buffering.addRecord(stream2, message4);
 
     // The buffer limit is now reached for stream2, flushing that single stream only
-    verify(flushAllHook, times(0)).call();
     verify(perStreamFlushHook, times(0)).accept(stream1, recordWriter1);
     verify(perStreamFlushHook, times(1)).accept(stream2, recordWriter2);
 
@@ -100,7 +96,6 @@ public class SerializedBufferingStrategyTest {
 
     // force flush to terminate test
     buffering.flushAll();
-    verify(flushAllHook, times(1)).call();
     verify(perStreamFlushHook, times(1)).accept(stream1, recordWriter1);
     verify(perStreamFlushHook, times(2)).accept(stream2, recordWriter2);
   }
@@ -119,12 +114,10 @@ public class SerializedBufferingStrategyTest {
     final AirbyteMessage message4 = generateMessage(stream1);
     final AirbyteMessage message5 = generateMessage(stream2);
     final AirbyteMessage message6 = generateMessage(stream3);
-    buffering.registerFlushAllEventHook(flushAllHook);
 
     buffering.addRecord(stream1, message1);
     buffering.addRecord(stream2, message2);
     // Total and per stream Buffers still have room
-    verify(flushAllHook, times(0)).call();
     verify(perStreamFlushHook, times(0)).accept(stream1, recordWriter1);
     verify(perStreamFlushHook, times(0)).accept(stream2, recordWriter2);
     verify(perStreamFlushHook, times(0)).accept(stream3, recordWriter3);
@@ -135,7 +128,6 @@ public class SerializedBufferingStrategyTest {
     when(recordWriter2.getByteCount()).thenReturn(20L); // second record in recordWriter2
     buffering.addRecord(stream2, message5);
     // Buffer limit reached for total streams, flushing all streams
-    verify(flushAllHook, times(1)).call();
     verify(perStreamFlushHook, times(1)).accept(stream1, recordWriter1);
     verify(perStreamFlushHook, times(1)).accept(stream2, recordWriter2);
     verify(perStreamFlushHook, times(1)).accept(stream3, recordWriter3);
@@ -143,7 +135,6 @@ public class SerializedBufferingStrategyTest {
     buffering.addRecord(stream3, message6);
     // force flush to terminate test
     buffering.flushAll();
-    verify(flushAllHook, times(2)).call();
     verify(perStreamFlushHook, times(1)).accept(stream1, recordWriter1);
     verify(perStreamFlushHook, times(1)).accept(stream2, recordWriter2);
     verify(perStreamFlushHook, times(2)).accept(stream3, recordWriter3);
@@ -162,20 +153,17 @@ public class SerializedBufferingStrategyTest {
     final AirbyteMessage message3 = generateMessage(stream3);
     final AirbyteMessage message4 = generateMessage(stream4);
     final AirbyteMessage message5 = generateMessage(stream1);
-    buffering.registerFlushAllEventHook(flushAllHook);
 
     buffering.addRecord(stream1, message1);
     buffering.addRecord(stream2, message2);
     buffering.addRecord(stream3, message3);
     // Total and per stream Buffers still have room
-    verify(flushAllHook, times(0)).call();
     verify(perStreamFlushHook, times(0)).accept(stream1, recordWriter1);
     verify(perStreamFlushHook, times(0)).accept(stream2, recordWriter2);
     verify(perStreamFlushHook, times(0)).accept(stream3, recordWriter3);
 
     buffering.addRecord(stream4, message4);
     // Buffer limit reached for concurrent streams, flushing all streams
-    verify(flushAllHook, times(1)).call();
     verify(perStreamFlushHook, times(1)).accept(stream1, recordWriter1);
     verify(perStreamFlushHook, times(1)).accept(stream2, recordWriter2);
     verify(perStreamFlushHook, times(1)).accept(stream3, recordWriter3);
@@ -184,7 +172,6 @@ public class SerializedBufferingStrategyTest {
     buffering.addRecord(stream1, message5);
     // force flush to terminate test
     buffering.flushAll();
-    verify(flushAllHook, times(2)).call();
     verify(perStreamFlushHook, times(2)).accept(stream1, recordWriter1);
     verify(perStreamFlushHook, times(1)).accept(stream2, recordWriter2);
     verify(perStreamFlushHook, times(1)).accept(stream3, recordWriter3);

--- a/airbyte-integrations/bases/base-java/src/test/java/io/airbyte/integrations/destination/record_buffer/SerializedBufferingStrategyTest.java
+++ b/airbyte-integrations/bases/base-java/src/test/java/io/airbyte/integrations/destination/record_buffer/SerializedBufferingStrategyTest.java
@@ -12,7 +12,6 @@ import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
 import com.fasterxml.jackson.databind.JsonNode;
-import io.airbyte.commons.concurrency.VoidCallable;
 import io.airbyte.commons.functional.CheckedBiConsumer;
 import io.airbyte.commons.functional.CheckedBiFunction;
 import io.airbyte.commons.json.Jsons;


### PR DESCRIPTION
## What
I was looking into how to update state handling in destinations to handle the new version of the protocol. In the meanwhile, I noticed that we had a weird pattern where the record buffers had a callback to handle tracking state messages. This is not idiomatic to java and mixes two different concerns.

Refactor the code to keep them separate.

See comment in line, but there's one thing in there that I want to make sure it isn't a bug.