### PR TITLE
escape backticks in create-release action so that they are handled properly

### DIFF
--- a/.github/workflows/create-release.yml
+++ b/.github/workflows/create-release.yml
@@ -28,7 +28,7 @@ jobs:
           -H "Authorization: Bearer ${{ secrets.GITHUB_TOKEN }}" \
           https://api.github.com/repos/${{ github.repository }}/commits/$COMMIT_ID/pulls)
           # the printf helps escape characters so that jq can parse the output.
-          # the sed removes carriage returns and escapes backticks so that the body is easier to parse later.
+          # the sed removes carriage returns that the body is easier to parse later, and escapes backticks so that they are not executed as commands.
           PR_BODY=$(printf '%s' "$PR" | jq '.[0].body' | sed 's/\\r//g' | sed 's/`/\\`/g')
           echo ::set-output name=pr_body::${PR_BODY}
       - name: Extract Changelog

--- a/.github/workflows/create-release.yml
+++ b/.github/workflows/create-release.yml
@@ -27,8 +27,9 @@ jobs:
           -H "Accept: application/vnd.github.v3+json" \
           -H "Authorization: Bearer ${{ secrets.GITHUB_TOKEN }}" \
           https://api.github.com/repos/${{ github.repository }}/commits/$COMMIT_ID/pulls)
-          # the printf helps escape characters so that jq can parse the output.
-          # the sed removes carriage returns that the body is easier to parse later, and escapes backticks so that they are not executed as commands.
+          # The printf helps escape characters so that jq can parse the output.
+          # The sed removes carriage returns so that the body is easier to parse later, and
+          #   escapes backticks so that they are not executed as commands.
           PR_BODY=$(printf '%s' "$PR" | jq '.[0].body' | sed 's/\\r//g' | sed 's/`/\\`/g')
           echo ::set-output name=pr_body::${PR_BODY}
       - name: Extract Changelog

--- a/.github/workflows/create-release.yml
+++ b/.github/workflows/create-release.yml
@@ -28,8 +28,8 @@ jobs:
           -H "Authorization: Bearer ${{ secrets.GITHUB_TOKEN }}" \
           https://api.github.com/repos/${{ github.repository }}/commits/$COMMIT_ID/pulls)
           # the printf helps escape characters so that jq can parse the output.
-          # the sed removes carriage returns so that the body is easier to parse later.
-          PR_BODY=$(printf '%s' "$PR" | jq '.[0].body' | sed 's/\\r//g')
+          # the sed removes carriage returns and escapes backticks so that the body is easier to parse later.
+          PR_BODY=$(printf '%s' "$PR" | jq '.[0].body' | sed 's/\\r//g' | sed 's/`/\\`/g')
           echo ::set-output name=pr_body::${PR_BODY}
       - name: Extract Changelog
         id: extract_changelog


### PR DESCRIPTION
The Create Release action currently doesn't handle backticks in commit names properly. See an example of this failure here: https://github.com/airbytehq/airbyte/runs/6815988297?check_suite_focus=true

This PR makes the action escape backticks so that they are not executed by bash. This change has been successfully tested in https://github.com/airbytehq/airbyte-release-testing/