### PR TITLE
Render Google Ads docs for users with Adblockers

### DIFF
--- a/airbyte-webapp/build.gradle
+++ b/airbyte-webapp/build.gradle
@@ -66,6 +66,8 @@ task copyDocs(type: Copy) {
 
     from "${project.rootProject.projectDir}/docs/integrations"
     into "build/docker/bin/docs/integrations"
+    //google-ads.md is blocked by Ad Blockers
+    rename ('google-ads.md', 'gglad.md')
     duplicatesStrategy DuplicatesStrategy.INCLUDE
 }
 

--- a/airbyte-webapp/src/setupProxy.js
+++ b/airbyte-webapp/src/setupProxy.js
@@ -15,5 +15,10 @@ module.exports = (app) => {
   });
   // Serve the doc markdowns and assets that are also bundled into the docker image
   app.use("/docs/integrations", express.static(`${__dirname}/../../docs/integrations`));
+  //workaround for adblockers to serve google ads docs in development
+  app.use(
+    "/docs/integrations/sources/ggl.md",
+    express.static(`${__dirname}/../../docs/integrations/sources/google-ads.md`)
+  );
   app.use("/docs/.gitbook", express.static(`${__dirname}/../../docs/.gitbook`));
 };

--- a/airbyte-webapp/src/setupProxy.js
+++ b/airbyte-webapp/src/setupProxy.js
@@ -17,7 +17,7 @@ module.exports = (app) => {
   app.use("/docs/integrations", express.static(`${__dirname}/../../docs/integrations`));
   //workaround for adblockers to serve google ads docs in development
   app.use(
-    "/docs/integrations/sources/ggl.md",
+    "/docs/integrations/sources/gglad.md",
     express.static(`${__dirname}/../../docs/integrations/sources/google-ads.md`)
   );
   app.use("/docs/.gitbook", express.static(`${__dirname}/../../docs/.gitbook`));

--- a/airbyte-webapp/src/views/Connector/ConnectorDocumentationLayout/DocumentationPanelContext.tsx
+++ b/airbyte-webapp/src/views/Connector/ConnectorDocumentationLayout/DocumentationPanelContext.tsx
@@ -1,11 +1,23 @@
-import { createContext, useContext, useEffect, useState } from "react";
+import { createContext, useCallback, useContext, useEffect, useState } from "react";
 
 // @ts-expect-error Default value provided at implementation
 const DocumentationPanelContext = createContext<ReturnType<typeof useDocumentationPanelState>>();
 
 export const useDocumentationPanelState = () => {
   const [documentationPanelOpen, setDocumentationPanelOpen] = useState(false);
-  const [documentationUrl, setDocumentationUrl] = useState("");
+  const [documentationUrl, setDocumentationUrlState] = useState("");
+
+  /* Ad blockers prevent the Google Ads docs .md file from rendering.  Because these URLs are
+   * standardized, we work around this without changing the main file URL by:
+   *   1. Changing the name of the .md in the Gradle build
+   *       a. the docs we render aren't actually fetching from our website, they're compiled with our build
+   *       b. when running on localhost, we fetch them with our proxy, so there is an additional piece in setupProxy.js for that case
+   *   2. Changing the URL here to match the renamed .md file
+   */
+
+  const setDocumentationUrl = useCallback((url: string) => {
+    setDocumentationUrlState(url.replace("google-ads", "ggl"));
+  }, []);
 
   return {
     documentationPanelOpen,

--- a/airbyte-webapp/src/views/Connector/ConnectorDocumentationLayout/DocumentationPanelContext.tsx
+++ b/airbyte-webapp/src/views/Connector/ConnectorDocumentationLayout/DocumentationPanelContext.tsx
@@ -16,7 +16,7 @@ export const useDocumentationPanelState = () => {
    */
 
   const setDocumentationUrl = useCallback((url: string) => {
-    setDocumentationUrlState(url.replace("google-ads", "ggl"));
+    setDocumentationUrlState(url.replace("google-ads", "gglad"));
   }, []);
 
   return {


### PR DESCRIPTION
## What

Adresses part of https://github.com/airbytehq/airbyte/issues/13555

**Before**: Users with adblocker browser plugins would not see our Google Ads documentation in our documentation side panel.  They would instead see "no documentation found for this connector".  But we do have (beautiful) docs for it!

This only appears to have affected Google Ads.  Not other plugins with the word Ad and not other plugins with the word Google.

**Now**: Users can see the docs 🎉  

![Screen Shot 2022-06-10 at 9 59 51 AM](https://user-images.githubusercontent.com/63751206/173082065-3da5e1cb-d3c9-4685-9ba3-e3eb64e7413e.png)

Note: The H1 is still stripped out.  This appears to affect a few docs when Adblockers are on.  I'm not addressing that in this PR.

## How
1. In the gradle build, we now rename `google-ads.md` as `gglad.md`
2. We also tell our proxy to point to `google-ads.md` if `gglad.md` is requested so users on localhost see the right docs
3. Where we set the documentation URL in the context, we now ensure that `google-ads` is replaced by `gglad`

## Recommended reading order
1. `DocumenationPanelContext.tsx`
2. `build.gradle`
3. `setupProxy.js`

## Testing
Testing this with various ad-blocking plugins may be helpful.  I've tested it manually using Adblock Plus on Firefox and Chrome. 

1. At the root of the repo in this branch, run `SUB_BUILD=PLATFORM ./gradlew :airbyte-webapp:copyDocs --rerun-tasks`.  This will rebuild the docs.
2. In `airbyte-webapp` run `npm start` 
3. Try adding a Google Ads source, verify that you can see the documentation