### PR TITLE
Use buildx docker-container driver for publishing normalization containers

### DIFF
--- a/tools/integrations/manage.sh
+++ b/tools/integrations/manage.sh
@@ -241,6 +241,8 @@ cmd_publish() {
   # in case curing the build / tests someone this version has been published.
   _error_if_tag_exists "$versioned_image"
 
+  docker buildx create --name connector-buildx --driver docker
+
   if [[ "airbyte/normalization" == "${image_name}" ]]; then
     echo "Publishing normalization images (version: $versioned_image)"
     GIT_REVISION=$(git rev-parse HEAD)
@@ -295,6 +297,8 @@ cmd_publish() {
     done
 
   fi
+
+  docker buildx rm connector-buildx
 
   # Checking if the image was successfully registered on DockerHub
   # see the description of this PR to understand why this is needed https://github.com/airbytehq/airbyte/pull/11654/

--- a/tools/integrations/manage.sh
+++ b/tools/integrations/manage.sh
@@ -241,7 +241,7 @@ cmd_publish() {
   # in case curing the build / tests someone this version has been published.
   _error_if_tag_exists "$versioned_image"
 
-  docker buildx create --name connector-buildx --driver docker
+  docker buildx create --name connector-buildx --driver docker --use
 
   if [[ "airbyte/normalization" == "${image_name}" ]]; then
     echo "Publishing normalization images (version: $versioned_image)"

--- a/tools/integrations/manage.sh
+++ b/tools/integrations/manage.sh
@@ -241,7 +241,7 @@ cmd_publish() {
   # in case curing the build / tests someone this version has been published.
   _error_if_tag_exists "$versioned_image"
 
-  docker buildx create --name connector-buildx --driver docker --use
+  docker buildx create --name connector-buildx --driver docker-container --use
 
   if [[ "airbyte/normalization" == "${image_name}" ]]; then
     echo "Publishing normalization images (version: $versioned_image)"

--- a/tools/integrations/manage.sh
+++ b/tools/integrations/manage.sh
@@ -245,7 +245,7 @@ cmd_publish() {
     echo "Publishing normalization images (version: $versioned_image)"
     GIT_REVISION=$(git rev-parse HEAD)
 
-    # We use a buildx docker continer when building multi-stage builds from one docker compose file
+    # We use a buildx docker container when building multi-stage builds from one docker compose file
     # This works because all the images depend only on already public images
     docker buildx create --name connector-buildx --driver docker-container --use
 


### PR DESCRIPTION
Fixes a problem when publishing normalization connectors:

> error: multiple platforms feature is currently not supported for docker driver. Please switch to a different driver (eg. "docker buildx create --use")