### PR TITLE
Change JDBC ClickHouse version into 0.3.2-patch9

### DIFF
--- a/airbyte-db/db-lib/src/main/java/io/airbyte/db/factory/DatabaseDriver.java
+++ b/airbyte-db/db-lib/src/main/java/io/airbyte/db/factory/DatabaseDriver.java
@@ -9,7 +9,7 @@ package io.airbyte.db.factory;
  */
 public enum DatabaseDriver {
 
-  CLICKHOUSE("ru.yandex.clickhouse.ClickHouseDriver", "jdbc:clickhouse://%s:%d/%s"),
+  CLICKHOUSE("com.clickhouse.jdbc.ClickHouseDriver", "jdbc:clickhouse://%s:%d/%s"),
   DATABRICKS("com.databricks.client.jdbc.Driver", "jdbc:databricks://%s;HttpPath=%s;UserAgentEntry=Airbyte"),
   DB2("com.ibm.db2.jcc.DB2Driver", "jdbc:db2://%s:%d/%s"),
   MARIADB("org.mariadb.jdbc.Driver", "jdbc:mariadb://%s:%d/%s"),

--- a/airbyte-integrations/connectors/destination-clickhouse/Dockerfile
+++ b/airbyte-integrations/connectors/destination-clickhouse/Dockerfile
@@ -16,5 +16,5 @@ ENV APPLICATION destination-clickhouse
 
 COPY --from=build /airbyte /airbyte
 
-LABEL io.airbyte.version=0.1.8
+LABEL io.airbyte.version=0.1.9
 LABEL io.airbyte.name=airbyte/destination-clickhouse

--- a/airbyte-integrations/connectors/destination-clickhouse/Dockerfile
+++ b/airbyte-integrations/connectors/destination-clickhouse/Dockerfile
@@ -17,4 +17,5 @@ ENV APPLICATION destination-clickhouse
 COPY --from=build /airbyte /airbyte
 
 LABEL io.airbyte.version=0.1.9
+
 LABEL io.airbyte.name=airbyte/destination-clickhouse

--- a/airbyte-integrations/connectors/destination-clickhouse/build.gradle
+++ b/airbyte-integrations/connectors/destination-clickhouse/build.gradle
@@ -18,7 +18,7 @@ dependencies {
     implementation files(project(':airbyte-integrations:bases:base-java').airbyteDocker.outputs)
 
     // https://mvnrepository.com/artifact/ru.yandex.clickhouse/clickhouse-jdbc
-    implementation 'ru.yandex.clickhouse:clickhouse-jdbc:0.3.1-patch'
+    implementation group: 'com.clickhouse', name: 'clickhouse-jdbc', version: '0.3.2-patch9'
 
     // https://mvnrepository.com/artifact/org.testcontainers/clickhouse
     testImplementation libs.connectors.destination.testcontainers.clickhouse

--- a/airbyte-integrations/connectors/destination-clickhouse/src/main/java/io/airbyte/integrations/destination/clickhouse/ClickhouseSqlOperations.java
+++ b/airbyte-integrations/connectors/destination-clickhouse/src/main/java/io/airbyte/integrations/destination/clickhouse/ClickhouseSqlOperations.java
@@ -15,9 +15,9 @@ import java.sql.SQLException;
 import java.util.List;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
-import ru.yandex.clickhouse.ClickHouseConnection;
-import ru.yandex.clickhouse.ClickHouseStatement;
-import ru.yandex.clickhouse.domain.ClickHouseFormat;
+import com.clickhouse.jdbc.ClickHouseConnection;
+import com.clickhouse.jdbc.ClickHouseStatement;
+import com.clickhouse.client.ClickHouseFormat;
 
 public class ClickhouseSqlOperations extends JdbcSqlOperations {
 
@@ -82,7 +82,8 @@ public class ClickhouseSqlOperations extends JdbcSqlOperations {
         ClickHouseStatement sth = conn.createStatement();
         sth.write() // Write API entrypoint
             .table(String.format("%s.%s", schemaName, tmpTableName)) // where to write data
-            .data(tmpFile, ClickHouseFormat.CSV) // specify input
+            .format(ClickHouseFormat.CSV) // set a format
+            .data(tmpFile.getAbsolutePath()) // specify input
             .send();
 
       } catch (final Exception e) {

--- a/docs/integrations/destinations/clickhouse.md
+++ b/docs/integrations/destinations/clickhouse.md
@@ -79,8 +79,9 @@ Therefore, Airbyte ClickHouse destination will create tables and schemas using t
 
 | Version | Date       | Pull Request | Subject                                      |
 |:--------|:-----------| :--- |:---------------------------------------------|
-| 0.1.8 | 2022-07-05 | [\#13516](https://github.com/airbytehq/airbyte/pull/13516) | Added JDBC default parameter socket timeout |
-| 0.1.7 | 2022-06-16 | [\#13852](https://github.com/airbytehq/airbyte/pull/13852) | Updated stacktrace format for any trace message errors |
+| 0.1.9   | 2022-07-05 | [\#13516](https://github.com/airbytehq/airbyte/pull/13516) | Added JDBC default parameter socket timeout |
+| 0.1.8   | 2022-06-16 | [\#13852](https://github.com/airbytehq/airbyte/pull/13852) | Updated stacktrace format for any trace message errors |
+| 0.1.7   | 2022-05-17 | [12820](https://github.com/airbytehq/airbyte/pull/13694) | Change JDBC ClickHouse version into 0.3.2-patch9 |
 | 0.1.6   | 2022-05-17 | [12820](https://github.com/airbytehq/airbyte/pull/12820) | Improved 'check' operation performance |
 | 0.1.5   | 2022-04-06 | [11729](https://github.com/airbytehq/airbyte/pull/11729) | Bump mina-sshd from 2.7.0 to 2.8.0           |
 | 0.1.4   | 2022-02-25 | [10421](https://github.com/airbytehq/airbyte/pull/10421) | Refactor JDBC parameters handling            |


### PR DESCRIPTION
# What
This is a followup on [community PR](https://github.com/airbytehq/airbyte/pull/13639) by @[mzitnik](https://github.com/mzitnik)

Changing ClickHouse JDBC Client to a newer version 0.3.2-patch9

# How
Change dependency implementation group: 'com.clickhouse', name: 'clickhouse-jdbc', version: '0.3.2-patch9'
Fixing some method interface change

