### PR TITLE
remove slack notification from publish command

### DIFF
--- a/.github/workflows/publish-command.yml
+++ b/.github/workflows/publish-command.yml
@@ -183,16 +183,6 @@ jobs:
           comment-id: ${{ github.event.inputs.comment-id }}
           body: |
             > :x: Failed to publish ${{github.event.inputs.connector}}
-      - name: Slack Notification - Failure
-        if: failure()
-        uses: rtCamp/action-slack-notify@master
-        env:
-          SLACK_WEBHOOK: ${{ secrets.BUILD_SLACK_WEBHOOK }}
-          SLACK_USERNAME: Buildozer
-          SLACK_ICON: https://avatars.slack-edge.com/temp/2020-09-01/1342729352468_209b10acd6ff13a649a1.jpg
-          SLACK_COLOR: DC143C
-          SLACK_TITLE: "Failed to publish connector ${{ github.event.inputs.connector }} from branch ${{ github.ref	 }}"
-          SLACK_FOOTER: ""
       - name: Check if connector in definitions yaml
         if: github.event.inputs.auto-bump-version == 'true' && success()
         run: |


### PR DESCRIPTION
This actually has not been working in a long time, and no one seems to need it, so just removing it

