### PR TITLE
Fix modal z-index bug

### DIFF
--- a/airbyte-webapp/src/components/Modal/Modal.tsx
+++ b/airbyte-webapp/src/components/Modal/Modal.tsx
@@ -4,7 +4,7 @@ import styled, { keyframes } from "styled-components";
 
 import ContentCard from "components/ContentCard";
 
-export interface IProps {
+export interface ModalProps {
   title?: string | React.ReactNode;
   onClose?: () => void;
   clear?: boolean;
@@ -26,10 +26,10 @@ const Overlay = styled.div`
   display: flex;
   justify-content: center;
   align-items: center;
-  z-index: 10;
+  z-index: 100;
 `;
 
-const Modal: React.FC<IProps> = ({ children, title, onClose, clear, closeOnBackground }) => {
+const Modal: React.FC<ModalProps> = ({ children, title, onClose, clear, closeOnBackground }) => {
   const handleUserKeyPress = useCallback((event, closeModal) => {
     const { keyCode } = event;
     if (keyCode === 27) {


### PR DESCRIPTION
## What
Before:
Pieces of the layer beneath the modal poking through.
<img width="1220" alt="Screenshot 2022-06-13 at 17 04 44" src="https://user-images.githubusercontent.com/63751206/173414446-f0d1a595-20d6-4e4f-a1a2-324c0fe7eb8e.png">

After:
Clean.
<img width="664" alt="Screen Shot 2022-06-13 at 1 52 15 PM" src="https://user-images.githubusercontent.com/63751206/173414534-497a215b-c78f-43fc-b328-7284d54db98a.png">


## How
Tested a handful of z-indices on the modal... 100 works.

## Recommended reading order
1. `Modal.tsx`
