### PR TITLE
fix stream descriptor typo

### DIFF
--- a/airbyte-config/config-models/src/main/resources/types/StreamDescriptor.yaml
+++ b/airbyte-config/config-models/src/main/resources/types/StreamDescriptor.yaml
@@ -10,7 +10,7 @@ additionalProperties: false
 properties:
   name:
     description: Stream name
-    type: String
+    type: string
   namespace:
     description: Stream namespace
-    type: String
+    type: string


### PR DESCRIPTION
## What

Fix a small typo.

Json2pojo type format is `string` and not `String`