### PR TITLE
skeleton for reporting connector errors to sentry

### DIFF
--- a/.env
+++ b/.env
@@ -70,6 +70,7 @@ JOB_MAIN_CONTAINER_MEMORY_LIMIT=
 
 ### LOGGING/MONITORING/TRACKING ###
 TRACKING_STRATEGY=segment
+ERROR_REPORTING_STRATEGY=sentry # TODO change to logging, and do sentry only in cloud
 # Although not present as an env var, expected by Log4J configuration.
 LOG_LEVEL=INFO
 # Although not present as an env var, helps Airbyte track job healthiness.

--- a/airbyte-config/config-models/src/main/java/io/airbyte/config/Configs.java
+++ b/airbyte-config/config-models/src/main/java/io/airbyte/config/Configs.java
@@ -420,6 +420,12 @@ public interface Configs {
    */
   TrackingStrategy getTrackingStrategy();
 
+  /**
+   *  Define whether to send job failure events to Sentry or log-only. Airbyte internal use.
+   */
+  ErrorReportingStrategy getErrorReportingStrategy();
+
+
   // APPLICATIONS
   // Worker
   /**
@@ -519,6 +525,11 @@ public interface Configs {
 
   enum TrackingStrategy {
     SEGMENT,
+    LOGGING
+  }
+
+  enum ErrorReportingStrategy {
+    SENTRY,
     LOGGING
   }
 

--- a/airbyte-config/config-models/src/main/java/io/airbyte/config/EnvConfigs.java
+++ b/airbyte-config/config-models/src/main/java/io/airbyte/config/EnvConfigs.java
@@ -50,6 +50,7 @@ public class EnvConfigs implements Configs {
   public static final String CONFIG_ROOT = "CONFIG_ROOT";
   public static final String DOCKER_NETWORK = "DOCKER_NETWORK";
   public static final String TRACKING_STRATEGY = "TRACKING_STRATEGY";
+  public static final String ERROR_REPORTING_STRATEGY = "ERROR_REPORTING_STRATEGY";
   public static final String DEPLOYMENT_MODE = "DEPLOYMENT_MODE";
   public static final String DATABASE_USER = "DATABASE_USER";
   public static final String DATABASE_PASSWORD = "DATABASE_PASSWORD";
@@ -747,6 +748,18 @@ public class EnvConfigs implements Configs {
       } catch (final IllegalArgumentException e) {
         LOGGER.info(s + " not recognized, defaulting to " + TrackingStrategy.LOGGING);
         return TrackingStrategy.LOGGING;
+      }
+    });
+  }
+
+  @Override
+  public ErrorReportingStrategy getErrorReportingStrategy() {
+    return getEnvOrDefault(ERROR_REPORTING_STRATEGY, ErrorReportingStrategy.LOGGING, s -> {
+      try {
+        return ErrorReportingStrategy.valueOf(s.toUpperCase());
+      } catch (final IllegalArgumentException e) {
+        LOGGER.info(s + " not recognized, defaulting to " + ErrorReportingStrategy.LOGGING);
+        return ErrorReportingStrategy.LOGGING;
       }
     });
   }

--- a/airbyte-scheduler/scheduler-persistence/src/main/java/io/airbyte/scheduler/persistence/JobErrorReporter.java
+++ b/airbyte-scheduler/scheduler-persistence/src/main/java/io/airbyte/scheduler/persistence/JobErrorReporter.java
@@ -1,0 +1,50 @@
+package io.airbyte.scheduler.persistence;
+
+import io.airbyte.config.AttemptFailureSummary;
+import io.airbyte.config.FailureReason;
+import io.airbyte.config.FailureReason.FailureOrigin;
+import io.airbyte.config.JobSyncConfig;
+import io.airbyte.config.persistence.ConfigPersistence;
+import io.airbyte.scheduler.persistence.error_reporting.ErrorReportingClient;
+import java.util.List;
+import java.util.UUID;
+
+public class JobErrorReporter {
+  
+  private final ConfigPersistence configPersistence;
+  private final WorkspaceHelper workspaceHelper;
+  private final ErrorReportingClient errorReportingClient;
+
+  public JobErrorReporter(
+      final ConfigPersistence configPersistence,
+      final WorkspaceHelper workspaceHelper,
+      final ErrorReportingClient errorReportingClient) {
+
+    this.configPersistence = configPersistence;
+    this.workspaceHelper = workspaceHelper;
+    this.errorReportingClient = errorReportingClient;
+  }
+
+  public void reportSyncJobFailure(final AttemptFailureSummary failureSummary, final UUID connectionId, final JobSyncConfig job) {
+
+    // airbyte/source-marketo:0.11 -- what happens if not semver? e.g: custom tag or "latest" or "dev"
+    // connector_definition_id, docker_image_name+version, connection_id, connection_id, workspace_id
+    // do something like this to get cert level -- configPersistence.getConfig(ConfigSchema.STANDARD_DESTINATION_DEFINITION, "<>", );
+
+    final UUID workspaceId = workspaceHelper.getWorkspaceForConnectionIdIgnoreExceptions(connectionId);
+    final List<FailureReason> sourceFailures = failureSummary.getFailures().stream()
+        .filter(failure -> failure.getFailureOrigin() == FailureOrigin.SOURCE).toList();
+    final List<FailureReason> destinationFailures = failureSummary.getFailures().stream()
+        .filter(failure -> failure.getFailureOrigin() == FailureOrigin.DESTINATION).toList();
+
+    for (final FailureReason sourceFailure : sourceFailures) {
+      // report failure about source
+      errorReportingClient.report();
+    }
+
+    for (final FailureReason destinationFailure : destinationFailures) {
+      // report failure about destination
+      errorReportingClient.report();
+    }
+  }
+}

--- a/airbyte-scheduler/scheduler-persistence/src/main/java/io/airbyte/scheduler/persistence/error_reporting/ErrorReportingClient.java
+++ b/airbyte-scheduler/scheduler-persistence/src/main/java/io/airbyte/scheduler/persistence/error_reporting/ErrorReportingClient.java
@@ -1,0 +1,13 @@
+package io.airbyte.scheduler.persistence.error_reporting;
+
+import io.airbyte.config.Configs.ErrorReportingStrategy;
+
+// TODO should live in airbyte-analytics, or maybe some other module e.g; airbyte-sentry??
+public interface ErrorReportingClient {
+  void report();
+
+  static ErrorReportingClient getClient(final ErrorReportingStrategy strategy){
+    // TODO
+    return null;
+  }
+}

--- a/airbyte-scheduler/scheduler-persistence/src/main/java/io/airbyte/scheduler/persistence/error_reporting/LoggingErrorReportingClient.java
+++ b/airbyte-scheduler/scheduler-persistence/src/main/java/io/airbyte/scheduler/persistence/error_reporting/LoggingErrorReportingClient.java
@@ -1,0 +1,9 @@
+package io.airbyte.scheduler.persistence.error_reporting;
+
+public class LoggingErrorReportingClient implements ErrorReportingClient{
+
+  @Override
+  public void report() {
+
+  }
+}

--- a/airbyte-scheduler/scheduler-persistence/src/main/java/io/airbyte/scheduler/persistence/error_reporting/SentryErrorReportingClient.java
+++ b/airbyte-scheduler/scheduler-persistence/src/main/java/io/airbyte/scheduler/persistence/error_reporting/SentryErrorReportingClient.java
@@ -1,0 +1,9 @@
+package io.airbyte.scheduler.persistence.error_reporting;
+
+public class SentryErrorReportingClient implements ErrorReportingClient {
+
+  @Override
+  public void report() {
+
+  }
+}


### PR DESCRIPTION
## What

Skeleton for how we would report failures to an error tracking tool (e.g. Sentry).
This PR is meant to illustrate the proposal outlined in the doc https://docs.google.com/document/d/1grrkxdvgAzjYiwG02gwo1JdAEc6pGHJLtJFsfRexR4I/edit#

## How

- Introduce the concept of an JobErrorReporter, called on failed sync attempts.
- ErrorReportingClient, called by the error reporter to send to external tool.
- SentryErrorReportingClient, specific reporting client implementation for sentry. Would use the Sentry SDK to build an event and report it.

This follows similar approach to the existing JobTracker and JobNotifier implementations.

