### PR TITLE
Fail the connection state instead of throwing an exception

### DIFF
--- a/airbyte-workers/src/main/java/io/airbyte/workers/general/DefaultCheckConnectionWorker.java
+++ b/airbyte-workers/src/main/java/io/airbyte/workers/general/DefaultCheckConnectionWorker.java
@@ -88,7 +88,7 @@ public class DefaultCheckConnectionWorker implements CheckConnectionWorker {
       }
 
     } catch (final Exception e) {
-      LOGGER.error("Error while getting checking connection.", e);
+      LOGGER.error("Error while checking connection: ", e);
       return new StandardCheckConnectionOutput()
           .withStatus(Status.FAILED)
           .withMessage("Error while getting checking connection, because of: " + e.getMessage());

--- a/airbyte-workers/src/main/java/io/airbyte/workers/general/DefaultCheckConnectionWorker.java
+++ b/airbyte-workers/src/main/java/io/airbyte/workers/general/DefaultCheckConnectionWorker.java
@@ -79,11 +79,19 @@ public class DefaultCheckConnectionWorker implements CheckConnectionWorker {
         LOGGER.debug("Check connection job received output: {}", output);
         return output;
       } else {
-        throw new WorkerException(String.format("Error checking connection, status: %s, exit code: %d", status, exitCode));
+        String message = String.format("Error checking connection, status: %s, exit code: %d", status, exitCode);
+
+        LOGGER.error(message);
+        return new StandardCheckConnectionOutput()
+            .withStatus(Status.FAILED)
+            .withMessage(message);
       }
 
     } catch (final Exception e) {
-      throw new WorkerException("Error while getting checking connection.", e);
+      LOGGER.error("Error while getting checking connection.", e);
+      return new StandardCheckConnectionOutput()
+          .withStatus(Status.FAILED)
+          .withMessage("Error while getting checking connection, because of: " + e.getMessage());
     }
   }
 

--- a/airbyte-workers/src/test/java/io/airbyte/workers/general/DefaultCheckConnectionWorkerTest.java
+++ b/airbyte-workers/src/test/java/io/airbyte/workers/general/DefaultCheckConnectionWorkerTest.java
@@ -6,7 +6,6 @@ package io.airbyte.workers.general;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNull;
-import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.mockito.Mockito.RETURNS_DEEP_STUBS;
 import static org.mockito.Mockito.doThrow;
 import static org.mockito.Mockito.mock;

--- a/airbyte-workers/src/test/java/io/airbyte/workers/general/DefaultCheckConnectionWorkerTest.java
+++ b/airbyte-workers/src/test/java/io/airbyte/workers/general/DefaultCheckConnectionWorkerTest.java
@@ -101,11 +101,13 @@ public class DefaultCheckConnectionWorkerTest {
   }
 
   @Test
-  public void testProcessFail() {
+  public void testProcessFail() throws WorkerException {
     when(process.exitValue()).thenReturn(1);
 
     final DefaultCheckConnectionWorker worker = new DefaultCheckConnectionWorker(workerConfigs, integrationLauncher, failureStreamFactory);
-    assertThrows(WorkerException.class, () -> worker.run(input, jobRoot));
+    final StandardCheckConnectionOutput output = worker.run(input, jobRoot);
+
+    assertEquals(Status.FAILED, output.getStatus());
   }
 
   @Test
@@ -113,7 +115,9 @@ public class DefaultCheckConnectionWorkerTest {
     doThrow(new RuntimeException()).when(integrationLauncher).check(jobRoot, WorkerConstants.SOURCE_CONFIG_JSON_FILENAME, Jsons.serialize(CREDS));
 
     final DefaultCheckConnectionWorker worker = new DefaultCheckConnectionWorker(workerConfigs, integrationLauncher, failureStreamFactory);
-    assertThrows(WorkerException.class, () -> worker.run(input, jobRoot));
+    final StandardCheckConnectionOutput output = worker.run(input, jobRoot);
+
+    assertEquals(Status.FAILED, output.getStatus());
   }
 
   @Test


### PR DESCRIPTION
## What
Throwing an exception instead of returning a failed status will result in the workflow to be in a quarantined state. This will make sure that the job will fail instead of being in quarantined state.