### PR TITLE
Bump version in Dockerfile to match source-postgres version

### DIFF
--- a/airbyte-integrations/connectors/source-postgres-strict-encrypt/Dockerfile
+++ b/airbyte-integrations/connectors/source-postgres-strict-encrypt/Dockerfile
@@ -16,5 +16,5 @@ ENV APPLICATION source-postgres-strict-encrypt
 
 COPY --from=build /airbyte /airbyte
 
-LABEL io.airbyte.version=0.4.21
+LABEL io.airbyte.version=0.4.22
 LABEL io.airbyte.name=airbyte/source-postgres-strict-encrypt


### PR DESCRIPTION
## What
bump version of source-postgres-strict-encrypt to release version 0.4.22