### PR TITLE
Bump source-postgres-strict-encrypt version to 0.4.23 to match source…

### DIFF
--- a/airbyte-integrations/connectors/source-postgres-strict-encrypt/Dockerfile
+++ b/airbyte-integrations/connectors/source-postgres-strict-encrypt/Dockerfile
@@ -16,5 +16,5 @@ ENV APPLICATION source-postgres-strict-encrypt
 
 COPY --from=build /airbyte /airbyte
 
-LABEL io.airbyte.version=0.4.22
+LABEL io.airbyte.version=0.4.23
 LABEL io.airbyte.name=airbyte/source-postgres-strict-encrypt


### PR DESCRIPTION
Bump source-postgres-strict-encrypt version to 0.4.23 to match source-postgres to fix https://github.com/airbytehq/airbyte/issues/13743