### PR TITLE
cdk: fix typo in `build.gradle.hbs`

### DIFF
--- a/airbyte-integrations/connector-templates/destination-java/build.gradle.hbs
+++ b/airbyte-integrations/connector-templates/destination-java/build.gradle.hbs
@@ -9,8 +9,8 @@ application {
 }
 
 dependencies {
-    implementation project(':airbyte-config:models')
-    implementation project(':airbyte-protocol:models')
+    implementation project(':airbyte-config:config-models')
+    implementation project(':airbyte-protocol:protocol-models')
     implementation project(':airbyte-integrations:bases:base-java')
     implementation files(project(':airbyte-integrations:bases:base-java').airbyteDocker.outputs)
 


### PR DESCRIPTION
## What
https://github.com/airbytehq/airbyte/pull/13478 renamed some dir but forgot to propagate the refactoring to the template used to generate `destination-java`

## How
In `airbyte-integrations/connector-templates/destination-java/build.gradle.hbs`
* Rename airbyte-config:models to airbyte-config:config-models.
* Rename airbyte-config:persistence to airbyte-config:config-persistence.

