### PR TITLE
Add some dev-facing normalization docs

### DIFF
--- a/.prettierignore
+++ b/.prettierignore
@@ -1,0 +1,1 @@
+airbyte-integrations/bases/base-normalization/integration_tests/normalization_test_output

--- a/airbyte-integrations/bases/base-normalization/README.md
+++ b/airbyte-integrations/bases/base-normalization/README.md
@@ -1,6 +1,7 @@
 # Normalization
 
 * [Normalization](#normalization)
+    * [Under the hood](#under-the-hood)
     * [Developer workflow](#developer-workflow)
         * [Setting up your environment](#setting-up-your-environment)
         * [Running dbt](#running-dbt)
@@ -31,6 +32,16 @@ Related documentation on normalization is available here:
 
 * [architecture / Basic Normalization](../../../docs/understanding-airbyte/basic-normalization.md)
 * [tutorials / Custom dbt normalization](../../../docs/operator-guides/transformation-and-normalization/transformations-with-dbt.md)
+
+## Under the hood
+
+Normalization has two Python modules:
+* `transform_config` parses the destination connector config and generates a profile.yml file,
+  which configures how dbt will connect to the destination database.
+* `transform_catalog` parses the connection's catalog and generates a dbt_project.yml file,
+  which configures the models that dbt will run and how they should be materialized.
+
+`entrypoint.sh` (the entrypoint to normalization's Docker image) invokes these two modules, then calls `dbt run` on their output.
 
 ## Developer workflow
 

--- a/airbyte-integrations/bases/base-normalization/README.md
+++ b/airbyte-integrations/bases/base-normalization/README.md
@@ -218,6 +218,8 @@ transmitted by a source. In this integration test, the files is read and "cat" t
 each destination connectors to populate `_airbyte_raw_tables`. These tables are finally used as input
 data for dbt to run from.
 
+Note that `test_simple_streams` has additional message files, each representing a separate sync (`messages_incremental.txt` and `messages_schema_change.txt`).
+
 ##### data_input/replace_identifiers.json:
 The `replace_identifiers.json` contains maps of string patterns and values to replace in the `dbt_schema_tests`
 and `dbt_data_tests` files to handle cross database compatibility.
@@ -244,7 +246,9 @@ So, for each target destination, the steps run by the tests are:
 8. Optional checks (nothing for the moment)
 
 Note that the tests are using the normalization code from the python files directly, so it is not necessary to rebuild the docker images
-in between when iterating on the code base. However, dbt cli and destination connectors are invoked thanks to the dev docker images.
+in between when iterating on the code base. However, dbt cli and destination connectors are invoked via the dev docker images. This means that if your
+`airbyte/normalization:dev` image doesn't have a working dbt installation, tests _will_ fail. Similarly, if your `destination-xyz:dev` image doesn't
+work, then the base-normalization integration tests will fail.
 
 #### Integration Test Checks:
 

--- a/airbyte-integrations/bases/base-normalization/README.md
+++ b/airbyte-integrations/bases/base-normalization/README.md
@@ -54,20 +54,21 @@ Then we only need to find records from the source table with `_airbyte_emitted_a
 (equal to is necessary in case a previous normalization run was interrupted).
 
 This handles the two error scenarios quite cleanly:
-* If a sync fails but succeeds after a retry, such that the first attempt commits some records and the retry commits a superset of those records,
-  then normalization will see that the SCD table has none of those records. The SCD model has a deduping stage,
+* If a sync fails but succeeds after a retry, such that the first attempt commits some records and the retry commits a superse
+  of those records, then normalization will see that the SCD table has none of those records. The SCD model has a deduping stage,
   which removes the records which were synced multiple times.
-* If normalization fails partway through, such that (for example) the SCD model is updated, but the final table is not, and then the sync is retried,
-  then the source should not re-emit any old records (because the destination will have emitted a state message ack-ing all of the records).
-  If the retry emits some new records, then normalization will append them to the SCD table as usual (because, from the SCD's point of view, this
-  is just a normal sync). Then the final table's latest `__airbyte_emitted_at` will be older than the original attempt, so it will pull both the new
-  records _and_ the first attempt's records from the SCD table.
+* If normalization fails partway through, such that (for example) the SCD model is updated, but the final table is not, and then the sync
+  is retried, then the source should not re-emit any old records (because the destination will have emitted a state message ack-ing
+  all of the records). If the retry emits some new records, then normalization will append them to the SCD table as usual
+  (because, from the SCD's point of view, this is just a normal sync). Then the final table's latest `__airbyte_emitted_at`
+  will be older than the original attempt, so it will pull both the new records _and_ the first attempt's records from the SCD table.
 
 ## Developer workflow
 
 At a high level, this is the recommended workflow for updating base-normalization:
 1. Manually edit the models in `integration_tests/normalization_test_output/postgres/test_simple_streams/models/generated`.
-   Run `dbt compile` and manually execute the SQL queries. This requires manual setup and validation, but allows you to quickly experiment with different inputs.
+   Run `dbt compile` and manually execute the SQL queries. This requires manual setup and validation, but allows you to quickly experiment
+   with different inputs.
     1. You can substitute your preferred database/warehouse. This document will use Postgres because it's easy to set up.
 1. Once `dbt run` succeeds, edit `stream_processor.py` until it generates the models you hand-wrote in step 1.
 1. Run the `test_normalization[DestinationType.POSTGRES-test_simple_streams]` integration test case.
@@ -77,8 +78,8 @@ At a high level, this is the recommended workflow for updating base-normalizatio
 ### Setting up your environment
 
 If you have a fullly-featured Python dev environment, you can just set a breakpoint at [this line]([integration_tests/test_normalization.py#L105](https://github.com/airbytehq/airbyte/blob/17ee3ad44ff71164765b97ff439c7ffd51bf9bfe/airbyte-integrations/bases/base-normalization/integration_tests/test_normalization.py#L108))
-and run the `test_normalization[DestinationType.POSTGRES-test_simple_streams]` test case. You can terminate the run after it hits the breakpoint.
-This will start Postgres in a Docker container with some prepopulated data and configure profiles.yml to match the container.
+and run the `test_normalization[DestinationType.POSTGRES-test_simple_streams]` test case. You can terminate the run after it hits the
+breakpoint. This will start Postgres in a Docker container with some prepopulated data and configure profiles.yml to match the container.
 
 Otherwise, you can run this command:
 ```shell
@@ -136,8 +137,9 @@ docker run \
   --project-dir=/workspace
 ```
 
-This will modify the files in `build/compiled/airbyte_utils/models/generated`. For example, if you edit `models/generated/airbyte_incremental/scd/test_normalization/dedup_cdc_excluded_scd.sql`,
-then after compiling, you can see the results in `build/compiled/airbyte_utils/models/generated/airbyte_incremental/scd/test_normalization/dedup_cdc_excluded_scd.sql`.
+This will modify the files in `build/compiled/airbyte_utils/models/generated`.
+For example, if you edit `models/generated/airbyte_incremental/scd/test_normalization/dedup_cdc_excluded_scd.sql`, then after compiling,
+you can see the results in `build/compiled/airbyte_utils/models/generated/airbyte_incremental/scd/test_normalization/dedup_cdc_excluded_scd.sql`.
 
 ## Testing normalization
 
@@ -328,7 +330,8 @@ transmitted by a source. In this integration test, the files is read and "cat" t
 each destination connectors to populate `_airbyte_raw_tables`. These tables are finally used as input
 data for dbt to run from.
 
-Note that `test_simple_streams` has additional message files, each representing a separate sync (`messages_incremental.txt` and `messages_schema_change.txt`).
+Note that `test_simple_streams` has additional message files, each representing a separate sync
+(`messages_incremental.txt` and `messages_schema_change.txt`).
 
 ##### data_input/replace_identifiers.json:
 The `replace_identifiers.json` contains maps of string patterns and values to replace in the `dbt_schema_tests`
@@ -356,9 +359,9 @@ So, for each target destination, the steps run by the tests are:
 8. Optional checks (nothing for the moment)
 
 Note that the tests are using the normalization code from the python files directly, so it is not necessary to rebuild the docker images
-in between when iterating on the code base. However, dbt cli and destination connectors are invoked via the dev docker images. This means that if your
-`airbyte/normalization:dev` image doesn't have a working dbt installation, tests _will_ fail. Similarly, if your `destination-xyz:dev` image doesn't
-work, then the base-normalization integration tests will fail.
+in between when iterating on the code base. However, dbt cli and destination connectors are invoked via the dev docker images.
+This means that if your `airbyte/normalization:dev` image doesn't have a working dbt installation, tests _will_ fail.
+Similarly, if your `destination-xyz:dev` image doesn't work, then the base-normalization integration tests will fail.
 
 #### Integration Test Checks:
 

--- a/airbyte-integrations/bases/base-normalization/README.md
+++ b/airbyte-integrations/bases/base-normalization/README.md
@@ -54,11 +54,11 @@ Then we only need to find records from the source table with `_airbyte_emitted_a
 (equal to is necessary in case a previous normalization run was interrupted).
 
 This handles the two error scenarios quite cleanly:
-* If a sync fails but succeeds after a retry, such that the first attempt commits some records and the retry commits a superse
+* If a sync fails but succeeds after a retry, such that the first attempt commits some records and the retry commits a superset
   of those records, then normalization will see that the SCD table has none of those records. The SCD model has a deduping stage,
   which removes the records which were synced multiple times.
-* If normalization fails partway through, such that (for example) the SCD model is updated, but the final table is not, and then the sync
-  is retried, then the source should not re-emit any old records (because the destination will have emitted a state message ack-ing
+* If normalization fails partway through, such that (for example) the SCD model is updated but the final table is not, and then the sync
+  is retried, then the source will not re-emit any old records (because the destination will have emitted a state message ack-ing
   all of the records). If the retry emits some new records, then normalization will append them to the SCD table as usual
   (because, from the SCD's point of view, this is just a normal sync). Then the final table's latest `__airbyte_emitted_at`
   will be older than the original attempt, so it will pull both the new records _and_ the first attempt's records from the SCD table.

--- a/airbyte-integrations/bases/base-normalization/integration_tests/dbt_integration_test.py
+++ b/airbyte-integrations/bases/base-normalization/integration_tests/dbt_integration_test.py
@@ -367,7 +367,8 @@ class DbtIntegrationTest(object):
                             line = input_data.readline()
                             if not line:
                                 break
-                            process.stdin.write(line)
+                            if not line.startswith(b"#"):
+                                process.stdin.write(line)
                 process.stdin.close()
 
             thread = threading.Thread(target=writer)

--- a/airbyte-integrations/bases/base-normalization/integration_tests/resources/test_simple_streams/data_input/messages.txt
+++ b/airbyte-integrations/bases/base-normalization/integration_tests/resources/test_simple_streams/data_input/messages.txt
@@ -24,6 +24,7 @@
 {"type": "RECORD", "record": {"stream": "dedup_exchange_rate", "emitted_at": 1602637991100, "data": { "id": 5, "currency": "USD", "NZD": 0.01, "HKD@spéçiäl & characters": 8.12, "HKD_special___characters": "column name collision?", "column`_'with\"_quotes":"ma\"z`d'a"}}}
 {"type": "RECORD", "record": {"stream": "dedup_exchange_rate", "emitted_at": 1602637991200, "data": { "id": 5, "currency": "USD", "NZD": 0.01, "HKD@spéçiäl & characters": 9.23, "HKD_special___characters": "column name collision?", "column`_'with\"_quotes":"ma\"z`d'a"}}}
 
+# Note that some of the IDs are inserted and then deleted; this should be reflected as a single row in the SCD model with _airbyte_active_row set to 0.
 {"type":"RECORD","record":{"stream":"dedup_cdc_excluded","data":{"id":1,"name":"mazda","_ab_cdc_updated_at":1623849130530,"_ab_cdc_lsn":26971624,"_ab_cdc_deleted_at":null},"emitted_at":1623859926}}
 {"type":"RECORD","record":{"stream":"dedup_cdc_excluded","data":{"id":2,"name":"toyata","_ab_cdc_updated_at":1623849130549,"_ab_cdc_lsn":26971624,"_ab_cdc_deleted_at":null},"emitted_at":1623859926}}
 {"type":"RECORD","record":{"stream":"dedup_cdc_excluded","data":{"id":4,"name":"bmw","_ab_cdc_updated_at":1623849314535,"_ab_cdc_lsn":26974776,"_ab_cdc_deleted_at":null},"emitted_at":1623860160}}

--- a/airbyte-integrations/bases/base-normalization/integration_tests/resources/test_simple_streams/data_input/messages.txt
+++ b/airbyte-integrations/bases/base-normalization/integration_tests/resources/test_simple_streams/data_input/messages.txt
@@ -31,6 +31,7 @@
 {"type":"RECORD","record":{"stream":"dedup_cdc_excluded","data":{"id":4,"name":null,"_ab_cdc_updated_at":1623849314791,"_ab_cdc_lsn":26975440,"_ab_cdc_deleted_at":1623849314791},"emitted_at":1623860160}}
 {"type":"RECORD","record":{"stream":"dedup_cdc_excluded","data":{"id":6,"name":"opel","_ab_cdc_updated_at":1623850868109,"_ab_cdc_lsn":27009440,"_ab_cdc_deleted_at":null},"emitted_at":1623861660}}
 {"type":"RECORD","record":{"stream":"dedup_cdc_excluded","data":{"id":7,"name":"lotus","_ab_cdc_updated_at":1623850868237,"_ab_cdc_lsn":27010048,"_ab_cdc_deleted_at":null},"emitted_at":1623861660}}
+# messages_incremental.txt has a dedup_cdc_excluded record with emitted_at=1623860160, i.e. older than this record. If you delete/modify this record, make sure to maintain that relationship.
 {"type":"RECORD","record":{"stream":"dedup_cdc_excluded","data":{"id":6,"name":null,"_ab_cdc_updated_at":1623850868371,"_ab_cdc_lsn":27010232,"_ab_cdc_deleted_at":1623850868371},"emitted_at":1623861660}}
 
 {"type":"RECORD","record":{"stream":"pos_dedup_cdcx","data":{"id":1,"name":"mazda","_ab_cdc_updated_at":1623849130530,"_ab_cdc_lsn":26971624,"_ab_cdc_log_pos": 33274,"_ab_cdc_deleted_at":null},"emitted_at":1623859926}}

--- a/airbyte-integrations/bases/base-normalization/integration_tests/resources/test_simple_streams/data_input/messages_incremental.txt
+++ b/airbyte-integrations/bases/base-normalization/integration_tests/resources/test_simple_streams/data_input/messages_incremental.txt
@@ -1,21 +1,33 @@
+# Some records are duplicated from messages.txt - this mimics our "at-least-once" delivery policy.
+
+# Other records "go back in time", i.e. are new data but have an older emitted_at timestamp than some of the those duplicated records.
+# (I think?) This mimics an interruption to normalization, such that some records were normalized but others were not.
+
+# These first records are old data.
 {"type": "RECORD", "record": {"stream": "exchange_rate", "emitted_at": 1602637990800, "data": { "id": 2, "currency": "EUR", "date": "", "timestamp_col": "", "NZD": 2.43, "HKD@spéçiäl & characters": 5.4, "HKD_special___characters": "column name collision?", "column`_'with\"_quotes":"ma\"z`d'a"}}}
 {"type": "RECORD", "record": {"stream": "exchange_rate", "emitted_at": 1602637990900, "data": { "id": 3, "currency": "GBP", "NZD": 3.14, "HKD@spéçiäl & characters": 9.2, "HKD_special___characters": "column name collision?", "column`_'with\"_quotes":"ma\"z`d'a"}}}
+# These records are new data.
 {"type": "RECORD", "record": {"stream": "exchange_rate", "emitted_at": 1602650000000, "data": { "id": 2, "currency": "EUR", "NZD": 3.89, "HKD@spéçiäl & characters": 14.05, "HKD_special___characters": "column name collision?", "column`_'with\"_quotes":"ma\"z`d'a"}}}
 {"type": "RECORD", "record": {"stream": "exchange_rate", "emitted_at": 1602650010000, "data": { "id": 4, "currency": "HKD", "NZD": 1.19, "HKD@spéçiäl & characters": 0.01, "HKD_special___characters": "column name collision?", "column`_'with\"_quotes":"ma\"z`d'a"}}}
 {"type": "RECORD", "record": {"stream": "exchange_rate", "emitted_at": 1602650011000, "data": { "id": 1, "currency": "USD", "date": "2020-10-14", "timestamp_col": "2020-10-14T00:00:00.000-00", "NZD": 1.14, "HKD@spéçiäl & characters": 9.5, "HKD_special___characters": "column name collision?", "column`_'with\"_quotes":"ma\"z`d'a"}}}
 {"type": "RECORD", "record": {"stream": "exchange_rate", "emitted_at": 1602650012000, "data": { "id": 5, "currency": "USD", "NZD": 0.01, "HKD@spéçiäl & characters": 6.39, "HKD_special___characters": "column name collision?", "column`_'with\"_quotes":"ma\"z`d'a"}}}
 
+# These first records are old data.
 {"type": "RECORD", "record": {"stream": "dedup_exchange_rate", "emitted_at": 1602637990800, "data": { "id": 2, "currency": "EUR", "date": "", "timestamp_col": "", "NZD": 2.43, "HKD@spéçiäl & characters": 5.4, "HKD_special___characters": "column name collision?", "column`_'with\"_quotes":"ma\"z`d'a"}}}
 {"type": "RECORD", "record": {"stream": "dedup_exchange_rate", "emitted_at": 1602637990900, "data": { "id": 3, "currency": "GBP", "NZD": 3.14, "HKD@spéçiäl & characters": 9.2, "HKD_special___characters": "column name collision?", "column`_'with\"_quotes":"ma\"z`d'a"}}}
+# These records are new data.
 {"type": "RECORD", "record": {"stream": "dedup_exchange_rate", "emitted_at": 1602650000000, "data": { "id": 2, "currency": "EUR", "NZD": 3.89, "HKD@spéçiäl & characters": 14.05, "HKD_special___characters": "column name collision?", "column`_'with\"_quotes":"ma\"z`d'a"}}}
 {"type": "RECORD", "record": {"stream": "dedup_exchange_rate", "emitted_at": 1602650010000, "data": { "id": 4, "currency": "HKD", "NZD": 1.19, "HKD@spéçiäl & characters": 0.01, "HKD_special___characters": "column name collision?", "column`_'with\"_quotes":"ma\"z`d'a"}}}
 {"type": "RECORD", "record": {"stream": "dedup_exchange_rate", "emitted_at": 1602650011000, "data": { "id": 1, "currency": "USD", "date": "2020-10-14", "timestamp_col": "2020-10-14T00:00:00.000-00", "NZD": 1.14, "HKD@spéçiäl & characters": 9.5, "HKD_special___characters": "column name collision?", "column`_'with\"_quotes":"ma\"z`d'a"}}}
 {"type": "RECORD", "record": {"stream": "dedup_exchange_rate", "emitted_at": 1602650012000, "data": { "id": 5, "currency": "USD", "NZD": 0.01, "HKD@spéçiäl & characters": 6.39, "HKD_special___characters": "column name collision?", "column`_'with\"_quotes":"ma\"z`d'a"}}}
 
+# All of these records are new data.
+# This record has an _older_ emitted_at than the latest dedup_cdc_excluded record in messages.txt
 {"type":"RECORD","record":{"stream":"dedup_cdc_excluded","data":{"id":5,"name":"vw","column`_'with\"_quotes":"ma\"z`d'a","_ab_cdc_updated_at":1623849314663,"_ab_cdc_lsn":26975264,"_ab_cdc_deleted_at":null},"emitted_at":1623860160}}
 {"type":"RECORD","record":{"stream":"dedup_cdc_excluded","data":{"id":5,"name":null,"column`_'with\"_quotes":"ma\"z`d'a","_ab_cdc_updated_at":1623900000000,"_ab_cdc_lsn":28010252,"_ab_cdc_deleted_at":1623900000000},"emitted_at":1623900000000}}
 {"type":"RECORD","record":{"stream":"dedup_cdc_excluded","data":{"id":8,"name":"ford","column`_'with\"_quotes":"ma\"z`d'a","_ab_cdc_updated_at":1624000000000,"_ab_cdc_lsn":29010252,"_ab_cdc_deleted_at":null},"emitted_at":1624000000000}}
 
+# All of these records are old data.
 {"type":"RECORD","record":{"stream":"pos_dedup_cdcx","data":{"id":1,"name":"mazda","_ab_cdc_updated_at":1623849130530,"_ab_cdc_lsn":26971624,"_ab_cdc_log_pos": 33274,"_ab_cdc_deleted_at":null},"emitted_at":1623859926}}
 {"type":"RECORD","record":{"stream":"pos_dedup_cdcx","data":{"id":2,"name":"toyata","_ab_cdc_updated_at":1623849130549,"_ab_cdc_lsn":26971624,"_ab_cdc_log_pos": 33275,"_ab_cdc_deleted_at":null},"emitted_at":1623859926}}
 {"type":"RECORD","record":{"stream":"pos_dedup_cdcx","data":{"id":2,"name":"bmw","_ab_cdc_updated_at":1623849314535,"_ab_cdc_lsn":26974776,"_ab_cdc_log_pos": 33278,"_ab_cdc_deleted_at":null},"emitted_at":1623860160}}

--- a/airbyte-integrations/bases/base-normalization/integration_tests/resources/test_simple_streams/data_input/messages_incremental.txt
+++ b/airbyte-integrations/bases/base-normalization/integration_tests/resources/test_simple_streams/data_input/messages_incremental.txt
@@ -25,6 +25,8 @@
 # This record has an _older_ emitted_at than the latest dedup_cdc_excluded record in messages.txt
 {"type":"RECORD","record":{"stream":"dedup_cdc_excluded","data":{"id":5,"name":"vw","column`_'with\"_quotes":"ma\"z`d'a","_ab_cdc_updated_at":1623849314663,"_ab_cdc_lsn":26975264,"_ab_cdc_deleted_at":null},"emitted_at":1623860160}}
 {"type":"RECORD","record":{"stream":"dedup_cdc_excluded","data":{"id":5,"name":null,"column`_'with\"_quotes":"ma\"z`d'a","_ab_cdc_updated_at":1623900000000,"_ab_cdc_lsn":28010252,"_ab_cdc_deleted_at":1623900000000},"emitted_at":1623900000000}}
+# Previously we had a bug where we only respected deletions from the most recent  _airbyte_emitted_at. This message tests that ID 5 is still correctly deleted (i.e. marked with _airbyte_active_row = 0).
+# This record is also deleted in messages_schema_change.txt.
 {"type":"RECORD","record":{"stream":"dedup_cdc_excluded","data":{"id":8,"name":"ford","column`_'with\"_quotes":"ma\"z`d'a","_ab_cdc_updated_at":1624000000000,"_ab_cdc_lsn":29010252,"_ab_cdc_deleted_at":null},"emitted_at":1624000000000}}
 
 # All of these records are old data.

--- a/airbyte-integrations/bases/base-normalization/integration_tests/resources/test_simple_streams/data_input/messages_schema_change.txt
+++ b/airbyte-integrations/bases/base-normalization/integration_tests/resources/test_simple_streams/data_input/messages_schema_change.txt
@@ -12,4 +12,5 @@
 {"type":"RECORD","record":{"stream":"renamed_dedup_cdc_excluded","data":{"id":9,"name":"opel","column`_'with\"_quotes":"ma\"z`d'a","_ab_cdc_updated_at":1623950868109,"_ab_cdc_lsn":28009440,"_ab_cdc_deleted_at":null},"emitted_at":1623961660}}
 {"type":"RECORD","record":{"stream":"renamed_dedup_cdc_excluded","data":{"id":9,"name":null,"column`_'with\"_quotes":"ma\"z`d'a","_ab_cdc_updated_at":1623950868371,"_ab_cdc_lsn":28010232,"_ab_cdc_deleted_at":1623950868371},"emitted_at":1623961660}}
 
+# This message tests the ability to delete a record which was inserted in a previous sync. See messages_incremental.txt for how it was inserted.
 {"type":"RECORD","record":{"stream":"dedup_cdc_excluded","data":{"id":8,"name":"ford","column`_'with\"_quotes":"ma\"z`d'a","_ab_cdc_updated_at":1625000000000,"_ab_cdc_lsn":29020252,"_ab_cdc_deleted_at":1625000000000},"emitted_at":1625000000000}}

--- a/docs/understanding-airbyte/basic-normalization.md
+++ b/docs/understanding-airbyte/basic-normalization.md
@@ -62,12 +62,12 @@ You'll notice that some metadata are added to keep track of important informatio
 
 Additional metadata columns can be added on some tables depending on the usage:
 - On the Slowly Changing Dimension (SCD) tables:
-- `_airbyte_start_at`: equivalent to the cursor column defined on the table, denotes when the row was first seen
-- `_airbyte_end_at`: denotes until when the row was seen with these particular values. If this column is not NULL, then the record has been updated and is no longer the most up to date one. If NULL, then the row is the latest version for the record.
-- `_airbyte_active_row`: denotes if the row for the record is the latest version or not.
-- `_airbyte_unique_key_scd`: hash of primary keys + cursors used to de-duplicate the scd table.
-- On de-duplicated (and SCD) tables:
-- `_airbyte_unique_key`: hash of primary keys used to de-duplicate the final table.
+  - `_airbyte_start_at`: equivalent to the cursor column defined on the table, denotes when the row was first seen
+  - `_airbyte_end_at`: denotes until when the row was seen with these particular values. If this column is not NULL, then the record has been updated and is no longer the most up to date one. If NULL, then the row is the latest version for the record.
+  - `_airbyte_active_row`: denotes if the row for the record is the latest version or not.
+  - `_airbyte_unique_key_scd`: hash of primary keys + cursors used to de-duplicate the scd table.
+  - On de-duplicated (and SCD) tables:
+  - `_airbyte_unique_key`: hash of primary keys used to de-duplicate the final table.
 
 The [normalization rules](basic-normalization.md#Rules) are _not_ configurable. They are designed to pick a reasonable set of defaults to hit the 80/20 rule of data normalization. We respect that normalization is a detail-oriented problem and that with a fixed set of rules, we cannot normalize your data in such a way that covers all use cases. If this feature does not meet your normalization needs, we always put the full json blob in destination as well, so that you can parse that object however best meets your use case. We will be adding more advanced normalization functionality shortly. Airbyte is focused on the EL of ELT. If you need a really featureful tool for the transformations then, we suggest trying out dbt.
 


### PR DESCRIPTION
adding some docs that would have been nice to have before working on https://github.com/airbytehq/airbyte/pull/12846.

* misc some markdown linter warnings / reformattings to make headers and bullet levels cleaner
* add `.prettierignore` so we stop reformatting the normalization test output
* add the ability to put comments in the `messages.txt` input files, plus some basic explanations of what different messages are testing for
* some slightly rambly explanations of how to work in this module + what it's doing conceptually.
* really basic comments in stream_processor.py