### PR TITLE
Remove AirbyteCatalog Reference from sidebar

### DIFF
--- a/docusaurus/sidebars.js
+++ b/docusaurus/sidebars.js
@@ -247,7 +247,6 @@ module.exports = {
       label: 'Understand Airbyte',
       items: [
         'understanding-airbyte/beginners-guide-to-catalog',
-        'understanding-airbyte/catalog',
         'understanding-airbyte/airbyte-protocol',
         'understanding-airbyte/airbyte-protocol-docker',
         'understanding-airbyte/basic-normalization',


### PR DESCRIPTION
The AirbyteCatalog Reference file has been deleted in [this PR](https://github.com/airbytehq/airbyte/commit/22b727c0ea213376b7164ffd8cdbbfa7fd74c26c) but still referenced from the sidebar, causing deploy failures. Removed the reference from the sidebar.