### PR TITLE
fix: duplicate resource allocations in `airbyte-temporal` deployment

### DIFF
--- a/charts/airbyte/Chart.yaml
+++ b/charts/airbyte/Chart.yaml
@@ -15,7 +15,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.3.5
+version: 0.3.6
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to

--- a/charts/airbyte/templates/temporal/deployment.yaml
+++ b/charts/airbyte/templates/temporal/deployment.yaml
@@ -66,7 +66,6 @@ spec:
         {{- if .Values.temporal.containerSecurityContext }}
         securityContext: {{- toYaml .Values.temporal.containerSecurityContext | nindent 10 }}
         {{- end }}
-        resources: {{- toYaml .Values.temporal.resources | nindent 10 }}
         volumeMounts:
         - name: airbyte-temporal-dynamicconfig
           mountPath: "/etc/temporal/config/dynamicconfig/"


### PR DESCRIPTION
## What
*Describe what the change is solving*
When attempting to build from `helm` charts, the following error occurs:
```bash
Error: map[string]interface {}(nil): yaml: unmarshal errors:
  line 57: mapping key "resources" already defined at line 51
make: *** [airbyte.yaml] Error 1
```

## How
There is a conditional resource allocation in the chart in line 57, which follows an unconditional allocation on line 51.

As resources are an optional field in k8s yamls, solution is to remove the aforementioned unconditional allocation on line 51.

Upon removal, build succeeds.

## 🚨 User Impact 🚨
No breaking changes
