### PR TITLE
use built-in check for checking is a JSONPath is definite

### DIFF
--- a/airbyte-commons/src/main/java/io/airbyte/commons/json/JsonPaths.java
+++ b/airbyte-commons/src/main/java/io/airbyte/commons/json/JsonPaths.java
@@ -117,7 +117,7 @@ public class JsonPaths {
    * @param jsonPath - path to validate
    */
   public static void assertIsSingleReturnQuery(final String jsonPath) {
-    Preconditions.checkArgument(!jsonPath.contains("*"), "Cannot accept paths with wildcards because they may return more than one item.");
+    Preconditions.checkArgument(JsonPath.isPathDefinite(jsonPath), "Cannot accept paths with wildcards because they may return more than one item.");
   }
 
   /**


### PR DESCRIPTION
## What
We use a java library called `JsonPath` that helps us index into JSON objects. One of the helpers we wrote is to check if, given a JSONPath we can determine if it will return at most one value (i.e. the path points to exactly one field in a JSON object as opposed to many e.g. `$.[*]`) . The original implementation of this was hack. The library we use actually supports a robust check for this. This PR switches to using that check.
