### PR TITLE
:bug: Source Relational DB : remove unicode nulls from cursors

### DIFF
--- a/airbyte-integrations/connectors/source-relational-db/Dockerfile
+++ b/airbyte-integrations/connectors/source-relational-db/Dockerfile
@@ -16,5 +16,5 @@ ENV APPLICATION source-relational-db
 
 COPY --from=build /airbyte /airbyte
 
-LABEL io.airbyte.version=0.3.0
+LABEL io.airbyte.version=0.3.1
 LABEL io.airbyte.name=airbyte/source-relational-db

--- a/airbyte-integrations/connectors/source-relational-db/src/main/java/io/airbyte/integrations/source/relationaldb/StateDecoratingIterator.java
+++ b/airbyte-integrations/connectors/source-relational-db/src/main/java/io/airbyte/integrations/source/relationaldb/StateDecoratingIterator.java
@@ -43,12 +43,17 @@ public class StateDecoratingIterator extends AbstractIterator<AirbyteMessage> im
     stateManager.setIsCdc(false);
   }
 
+  private String getCursorCandidate(final AirbyteMessage message) {
+    String cursorCandidate = message.getRecord().getData().get(cursorField).asText();
+    return (cursorCandidate != null ? cursorCandidate.replaceAll("\u0000", "") : null);
+  }
+
   @Override
   protected AirbyteMessage computeNext() {
     if (messageIterator.hasNext()) {
       final AirbyteMessage message = messageIterator.next();
       if (message.getRecord().getData().hasNonNull(cursorField)) {
-        final String cursorCandidate = message.getRecord().getData().get(cursorField).asText();
+        final String cursorCandidate = getCursorCandidate(message);
         if (IncrementalUtils.compareCursors(maxCursor, cursorCandidate, cursorType) < 0) {
           maxCursor = cursorCandidate;
         }


### PR DESCRIPTION
## What
Make sure that cursors don't contain unicode nulls (`\u0000`), because Postgress (used for storing states) fails on insert/update.

## Recommended reading order
1. `x.java`
2. `y.python`