### PR TITLE
🐛 Server can display streams with the same name in different namespaces

### DIFF
--- a/airbyte-server/src/test/java/io/airbyte/server/handlers/WebBackendConnectionsHandlerTest.java
+++ b/airbyte-server/src/test/java/io/airbyte/server/handlers/WebBackendConnectionsHandlerTest.java
@@ -17,6 +17,7 @@ import static org.mockito.Mockito.when;
 
 import com.google.common.collect.Lists;
 import io.airbyte.api.model.generated.AirbyteCatalog;
+import io.airbyte.api.model.generated.AirbyteStream;
 import io.airbyte.api.model.generated.AirbyteStreamAndConfiguration;
 import io.airbyte.api.model.generated.AttemptRead;
 import io.airbyte.api.model.generated.AttemptStatus;
@@ -773,4 +774,51 @@ class WebBackendConnectionsHandlerTest {
     assertEquals(expected, actual);
   }
 
+  @Test
+  public void testUpdateSchemaWithNamespacedStreams() {
+    final AirbyteCatalog original = ConnectionHelpers.generateBasicApiCatalog();
+    final AirbyteStreamAndConfiguration stream1Config = original.getStreams().get(0);
+    final AirbyteStream stream1 = stream1Config.getStream();
+    final AirbyteStream stream2 = new AirbyteStream()
+        .name(stream1.getName())
+        .namespace("second_namespace")
+        .jsonSchema(stream1.getJsonSchema())
+        .defaultCursorField(stream1.getDefaultCursorField())
+        .supportedSyncModes(stream1.getSupportedSyncModes())
+        .sourceDefinedCursor(stream1.getSourceDefinedCursor())
+        .sourceDefinedPrimaryKey(stream1.getSourceDefinedPrimaryKey());
+    final AirbyteStreamAndConfiguration stream2Config = new AirbyteStreamAndConfiguration()
+        .config(stream1Config.getConfig())
+        .stream(stream2);
+    original.getStreams().add(stream2Config);
+
+    final AirbyteCatalog discovered = ConnectionHelpers.generateBasicApiCatalog();
+    discovered.getStreams().get(0).getStream()
+        .name("stream1")
+        .jsonSchema(CatalogHelpers.fieldsToJsonSchema(Field.of("field1", JsonSchemaType.STRING)))
+        .supportedSyncModes(List.of(SyncMode.FULL_REFRESH));
+    discovered.getStreams().get(0).getConfig()
+        .syncMode(SyncMode.FULL_REFRESH)
+        .cursorField(Collections.emptyList())
+        .destinationSyncMode(DestinationSyncMode.OVERWRITE)
+        .primaryKey(Collections.emptyList())
+        .aliasName("stream1");
+
+    final AirbyteCatalog expected = ConnectionHelpers.generateBasicApiCatalog();
+    expected.getStreams().get(0).getStream()
+        .name("stream1")
+        .jsonSchema(CatalogHelpers.fieldsToJsonSchema(Field.of("field1", JsonSchemaType.STRING)))
+        .supportedSyncModes(List.of(SyncMode.FULL_REFRESH));
+    expected.getStreams().get(0).getConfig()
+        .syncMode(SyncMode.FULL_REFRESH)
+        .cursorField(Collections.emptyList())
+        .destinationSyncMode(DestinationSyncMode.OVERWRITE)
+        .primaryKey(Collections.emptyList())
+        .aliasName("stream1")
+        .setSelected(false);
+
+    final AirbyteCatalog actual = WebBackendConnectionsHandler.updateSchemaWithDiscovery(original, discovered);
+
+    assertEquals(expected, actual);
+  }
 }

--- a/airbyte-server/src/test/java/io/airbyte/server/handlers/WebBackendConnectionsHandlerTest.java
+++ b/airbyte-server/src/test/java/io/airbyte/server/handlers/WebBackendConnectionsHandlerTest.java
@@ -821,4 +821,5 @@ class WebBackendConnectionsHandlerTest {
 
     assertEquals(expected, actual);
   }
+
 }


### PR DESCRIPTION
## What
Closes https://github.com/airbytehq/airbyte/issues/9552

## How
Server keeps namespace when checking for existing streams. Manually verified on an OSS deployment.

## 🚨 User Impact 🚨
none; pure bugfix