### PR TITLE
🪟🔧Update Segment tracking event names

### DIFF
--- a/airbyte-webapp/src/components/CreateConnectionContent/CreateConnectionContent.tsx
+++ b/airbyte-webapp/src/components/CreateConnectionContent/CreateConnectionContent.tsx
@@ -93,7 +93,7 @@ const CreateConnectionContent: React.FC<CreateConnectionContentProps> = ({
     const enabledStreams = connection.syncCatalog.streams.filter((stream) => stream.config?.selected).length;
 
     if (item) {
-      trackNewConnectionAction("Select a frequency", [TrackActionActions.FREQUENCY], {
+      trackNewConnectionAction("Select a frequency", TrackActionActions.FREQUENCY, {
         frequency: item.label,
         connector_source_definition: source?.sourceName,
         connector_source_definition_id: source?.sourceDefinitionId,

--- a/airbyte-webapp/src/components/CreateConnectionContent/CreateConnectionContent.tsx
+++ b/airbyte-webapp/src/components/CreateConnectionContent/CreateConnectionContent.tsx
@@ -9,7 +9,7 @@ import LoadingSchema from "components/LoadingSchema";
 
 import { LogsRequestError } from "core/request/LogsRequestError";
 import { useCreateConnection, ValuesProps } from "hooks/services/useConnectionHook";
-import { LegacyTrackActionType, TrackActionActions, TrackActionNamespace, useTrackAction } from "hooks/useTrackAction";
+import { TrackActionLegacyType, TrackActionType, TrackActionNamespace, useTrackAction } from "hooks/useTrackAction";
 import ConnectionForm from "views/Connection/ConnectionForm";
 import { ConnectionFormProps } from "views/Connection/ConnectionForm/ConnectionForm";
 import { FormikConnectionFormValues } from "views/Connection/ConnectionForm/formConfig";
@@ -45,7 +45,7 @@ const CreateConnectionContent: React.FC<CreateConnectionContentProps> = ({
   const { mutateAsync: createConnection } = useCreateConnection();
   const trackNewConnectionAction = useTrackAction(
     TrackActionNamespace.CONNECTION,
-    LegacyTrackActionType.NEW_CONNECTION
+    TrackActionLegacyType.NEW_CONNECTION
   );
 
   const { schema, isLoading, schemaErrorStatus, catalogId, onDiscoverSchema } = useDiscoverSchema(source.sourceId);
@@ -93,7 +93,7 @@ const CreateConnectionContent: React.FC<CreateConnectionContentProps> = ({
     const enabledStreams = connection.syncCatalog.streams.filter((stream) => stream.config?.selected).length;
 
     if (item) {
-      trackNewConnectionAction("Select a frequency", TrackActionActions.FREQUENCY, {
+      trackNewConnectionAction("Select a frequency", TrackActionType.FREQUENCY, {
         frequency: item.label,
         connector_source_definition: source?.sourceName,
         connector_source_definition_id: source?.sourceDefinitionId,

--- a/airbyte-webapp/src/components/CreateConnectionContent/CreateConnectionContent.tsx
+++ b/airbyte-webapp/src/components/CreateConnectionContent/CreateConnectionContent.tsx
@@ -8,8 +8,8 @@ import { JobItem } from "components/JobItem/JobItem";
 import LoadingSchema from "components/LoadingSchema";
 
 import { LogsRequestError } from "core/request/LogsRequestError";
-import { useAnalyticsService } from "hooks/services/Analytics/useAnalyticsService";
 import { useCreateConnection, ValuesProps } from "hooks/services/useConnectionHook";
+import { LegacyTrackActionType, TrackActionActions, TrackActionNamespace, useTrackAction } from "hooks/useTrackAction";
 import ConnectionForm from "views/Connection/ConnectionForm";
 import { ConnectionFormProps } from "views/Connection/ConnectionForm/ConnectionForm";
 import { FormikConnectionFormValues } from "views/Connection/ConnectionForm/formConfig";
@@ -43,7 +43,10 @@ const CreateConnectionContent: React.FC<CreateConnectionContentProps> = ({
   noTitles,
 }) => {
   const { mutateAsync: createConnection } = useCreateConnection();
-  const analyticsService = useAnalyticsService();
+  const trackNewConnectionAction = useTrackAction(
+    TrackActionNamespace.CONNECTION,
+    LegacyTrackActionType.NEW_CONNECTION
+  );
 
   const { schema, isLoading, schemaErrorStatus, catalogId, onDiscoverSchema } = useDiscoverSchema(source.sourceId);
 
@@ -87,14 +90,15 @@ const CreateConnectionContent: React.FC<CreateConnectionContentProps> = ({
   };
 
   const onSelectFrequency = (item: IDataItem | null) => {
-    analyticsService.track("New Connection - Action", {
-      action: "Select a frequency",
-      frequency: item?.label,
-      connector_source_definition: source?.sourceName,
-      connector_source_definition_id: source?.sourceDefinitionId,
-      connector_destination_definition: destination?.destinationName,
-      connector_destination_definition_id: destination?.destinationDefinitionId,
-    });
+    if (item) {
+      trackNewConnectionAction("Select a frequency", [TrackActionActions.FREQUENCY, TrackActionActions.SELECT], {
+        frequency: item.label,
+        connector_source_definition: source?.sourceName,
+        connector_source_definition_id: source?.sourceDefinitionId,
+        connector_destination_definition: destination?.destinationName,
+        connector_destination_definition_id: destination?.destinationDefinitionId,
+      });
+    }
   };
 
   if (schemaErrorStatus) {

--- a/airbyte-webapp/src/components/CreateConnectionContent/CreateConnectionContent.tsx
+++ b/airbyte-webapp/src/components/CreateConnectionContent/CreateConnectionContent.tsx
@@ -90,13 +90,17 @@ const CreateConnectionContent: React.FC<CreateConnectionContentProps> = ({
   };
 
   const onSelectFrequency = (item: IDataItem | null) => {
+    const enabledStreams = connection.syncCatalog.streams.filter((stream) => stream.config?.selected).length;
+
     if (item) {
-      trackNewConnectionAction("Select a frequency", [TrackActionActions.FREQUENCY, TrackActionActions.SELECT], {
+      trackNewConnectionAction("Select a frequency", [TrackActionActions.FREQUENCY], {
         frequency: item.label,
         connector_source_definition: source?.sourceName,
         connector_source_definition_id: source?.sourceDefinitionId,
         connector_destination_definition: destination?.destinationName,
         connector_destination_definition_id: destination?.destinationDefinitionId,
+        available_streams: connection.syncCatalog.streams.length,
+        enabled_streams: enabledStreams,
       });
     }
   };

--- a/airbyte-webapp/src/components/EntityTable/hooks.tsx
+++ b/airbyte-webapp/src/components/EntityTable/hooks.tsx
@@ -29,7 +29,7 @@ const useSyncActions = (): {
 
     const trackableActionString = `${trackableAction} connection`;
 
-    trackSourceAction(trackableActionString, [trackableAction], {
+    trackSourceAction(trackableActionString, trackableAction, {
       frequency: frequency?.type,
       connector_source: connection.source?.sourceName,
       connector_source_definition_id: connection.source?.sourceDefinitionId,

--- a/airbyte-webapp/src/components/EntityTable/hooks.tsx
+++ b/airbyte-webapp/src/components/EntityTable/hooks.tsx
@@ -1,7 +1,7 @@
 import { getFrequencyConfig } from "config/utils";
 import { buildConnectionUpdate } from "core/domain/connection";
 import { useSyncConnection, useUpdateConnection } from "hooks/services/useConnectionHook";
-import { LegacyTrackActionType, TrackActionActions, TrackActionNamespace, useTrackAction } from "hooks/useTrackAction";
+import { TrackActionLegacyType, TrackActionType, TrackActionNamespace, useTrackAction } from "hooks/useTrackAction";
 
 import { ConnectionStatus, WebBackendConnectionRead } from "../../core/request/AirbyteClient";
 
@@ -11,7 +11,7 @@ const useSyncActions = (): {
 } => {
   const { mutateAsync: updateConnection } = useUpdateConnection();
   const { mutateAsync: syncConnection } = useSyncConnection();
-  const trackSourceAction = useTrackAction(TrackActionNamespace.CONNECTION, LegacyTrackActionType.SOURCE);
+  const trackSourceAction = useTrackAction(TrackActionNamespace.CONNECTION, TrackActionLegacyType.SOURCE);
 
   const changeStatus = async (connection: WebBackendConnectionRead) => {
     await updateConnection(
@@ -25,7 +25,7 @@ const useSyncActions = (): {
     const enabledStreams = connection.syncCatalog.streams.filter((stream) => stream.config?.selected).length;
 
     const trackableAction =
-      connection.status === ConnectionStatus.active ? TrackActionActions.DISABLE : TrackActionActions.REENABLE;
+      connection.status === ConnectionStatus.active ? TrackActionType.DISABLE : TrackActionType.REENABLE;
 
     const trackableActionString = `${trackableAction} connection`;
 

--- a/airbyte-webapp/src/components/EntityTable/hooks.tsx
+++ b/airbyte-webapp/src/components/EntityTable/hooks.tsx
@@ -1,6 +1,5 @@
 import { getFrequencyConfig } from "config/utils";
 import { buildConnectionUpdate } from "core/domain/connection";
-import { useAnalyticsService } from "hooks/services/Analytics/useAnalyticsService";
 import { useSyncConnection, useUpdateConnection } from "hooks/services/useConnectionHook";
 import { LegacyTrackActionType, TrackActionActions, TrackActionNamespace, useTrackAction } from "hooks/useTrackAction";
 
@@ -12,8 +11,7 @@ const useSyncActions = (): {
 } => {
   const { mutateAsync: updateConnection } = useUpdateConnection();
   const { mutateAsync: syncConnection } = useSyncConnection();
-  const analyticsService = useAnalyticsService();
-  const trackSourceAction = useTrackAction(TrackActionNamespace.SOURCE, LegacyTrackActionType.SOURCE);
+  const trackSourceAction = useTrackAction(TrackActionNamespace.CONNECTION, LegacyTrackActionType.SOURCE);
 
   const changeStatus = async (connection: WebBackendConnectionRead) => {
     await updateConnection(
@@ -24,6 +22,8 @@ const useSyncActions = (): {
 
     const frequency = getFrequencyConfig(connection.schedule);
 
+    const enabledStreams = connection.syncCatalog.streams.filter((stream) => stream.config?.selected).length;
+
     const trackableAction =
       connection.status === ConnectionStatus.active ? TrackActionActions.DISABLE : TrackActionActions.REENABLE;
 
@@ -32,9 +32,11 @@ const useSyncActions = (): {
     trackSourceAction(trackableActionString, [trackableAction], {
       frequency: frequency?.type,
       connector_source: connection.source?.sourceName,
-      connector_source_definition_id: connection.source?.sourceDefinitionId, //another place I'm changing a label... clarify if that's ok
+      connector_source_definition_id: connection.source?.sourceDefinitionId,
       connector_destination: connection.destination?.name,
       connector_destination_definition_id: connection.destination?.destinationDefinitionId,
+      available_streams: connection.syncCatalog.streams.length,
+      enabled_streams: enabledStreams,
     });
   };
 

--- a/airbyte-webapp/src/components/EntityTable/hooks.tsx
+++ b/airbyte-webapp/src/components/EntityTable/hooks.tsx
@@ -2,6 +2,7 @@ import { getFrequencyConfig } from "config/utils";
 import { buildConnectionUpdate } from "core/domain/connection";
 import { useAnalyticsService } from "hooks/services/Analytics/useAnalyticsService";
 import { useSyncConnection, useUpdateConnection } from "hooks/services/useConnectionHook";
+import { LegacyTrackActionType, TrackActionActions, TrackActionNamespace, useTrackAction } from "hooks/useTrackAction";
 
 import { ConnectionStatus, WebBackendConnectionRead } from "../../core/request/AirbyteClient";
 
@@ -12,6 +13,7 @@ const useSyncActions = (): {
   const { mutateAsync: updateConnection } = useUpdateConnection();
   const { mutateAsync: syncConnection } = useSyncConnection();
   const analyticsService = useAnalyticsService();
+  const trackSourceAction = useTrackAction(TrackActionNamespace.SOURCE, LegacyTrackActionType.SOURCE);
 
   const changeStatus = async (connection: WebBackendConnectionRead) => {
     await updateConnection(
@@ -22,13 +24,17 @@ const useSyncActions = (): {
 
     const frequency = getFrequencyConfig(connection.schedule);
 
-    analyticsService.track("Source - Action", {
-      action: connection.status === "active" ? "Disable connection" : "Reenable connection",
-      connector_source: connection.source?.sourceName,
-      connector_source_id: connection.source?.sourceDefinitionId,
-      connector_destination: connection.destination?.destinationName,
-      connector_destination_definition_id: connection.destination?.destinationDefinitionId,
+    const trackableAction =
+      connection.status === ConnectionStatus.active ? TrackActionActions.DISABLE : TrackActionActions.REENABLE;
+
+    const trackableActionString = `${trackableAction} connection`;
+
+    trackSourceAction(trackableActionString, [trackableAction], {
       frequency: frequency?.type,
+      connector_source: connection.source?.sourceName,
+      connector_source_definition_id: connection.source?.sourceDefinitionId, //another place I'm changing a label... clarify if that's ok
+      connector_destination: connection.destination?.name,
+      connector_destination_definition_id: connection.destination?.destinationDefinitionId,
     });
   };
 

--- a/airbyte-webapp/src/hooks/services/useConnectionHook.tsx
+++ b/airbyte-webapp/src/hooks/services/useConnectionHook.tsx
@@ -93,7 +93,7 @@ export const useSyncConnection = () => {
   return useMutation((connection: WebBackendConnectionRead) => {
     const frequency = getFrequencyConfig(connection.schedule);
 
-    trackSourceAction("Full refresh sync", [TrackActionActions.SYNC], {
+    trackSourceAction("Full refresh sync", TrackActionActions.SYNC, {
       connector_source: connection.source?.sourceName,
       connector_source_definition_id: connection.source?.sourceDefinitionId,
       connector_destination: connection.destination?.name,
@@ -146,7 +146,7 @@ const useCreateConnection = () => {
 
       const frequencyData = getFrequencyConfig(values.schedule);
 
-      trackNewConnectionAction("Set up connection", [TrackActionActions.CREATE], {
+      trackNewConnectionAction("Set up connection", TrackActionActions.CREATE, {
         frequency: frequencyData?.type || "",
         connector_source_definition: source?.sourceName,
         connector_source_definition_id: sourceDefinition?.sourceDefinitionId,

--- a/airbyte-webapp/src/hooks/services/useConnectionHook.tsx
+++ b/airbyte-webapp/src/hooks/services/useConnectionHook.tsx
@@ -4,7 +4,7 @@ import { getFrequencyConfig } from "config/utils";
 import { SyncSchema } from "core/domain/catalog";
 import { WebBackendConnectionService } from "core/domain/connection";
 import { ConnectionService } from "core/domain/connection/ConnectionService";
-import { LegacyTrackActionType, useTrackAction, TrackActionNamespace, TrackActionActions } from "hooks/useTrackAction";
+import { TrackActionLegacyType, useTrackAction, TrackActionNamespace, TrackActionType } from "hooks/useTrackAction";
 import { useInitService } from "services/useInitService";
 
 import { useConfig } from "../../config";
@@ -88,12 +88,12 @@ export const useConnectionLoad = (
 
 export const useSyncConnection = () => {
   const service = useConnectionService();
-  const trackSourceAction = useTrackAction(TrackActionNamespace.SOURCE, LegacyTrackActionType.SOURCE);
+  const trackSourceAction = useTrackAction(TrackActionNamespace.SOURCE, TrackActionLegacyType.SOURCE);
 
   return useMutation((connection: WebBackendConnectionRead) => {
     const frequency = getFrequencyConfig(connection.schedule);
 
-    trackSourceAction("Full refresh sync", TrackActionActions.SYNC, {
+    trackSourceAction("Full refresh sync", TrackActionType.SYNC, {
       connector_source: connection.source?.sourceName,
       connector_source_definition_id: connection.source?.sourceDefinitionId,
       connector_destination: connection.destination?.name,
@@ -122,7 +122,7 @@ const useCreateConnection = () => {
   const queryClient = useQueryClient();
   const trackNewConnectionAction = useTrackAction(
     TrackActionNamespace.CONNECTION,
-    LegacyTrackActionType.NEW_CONNECTION
+    TrackActionLegacyType.NEW_CONNECTION
   );
 
   return useMutation(
@@ -146,7 +146,7 @@ const useCreateConnection = () => {
 
       const frequencyData = getFrequencyConfig(values.schedule);
 
-      trackNewConnectionAction("Set up connection", TrackActionActions.CREATE, {
+      trackNewConnectionAction("Set up connection", TrackActionType.CREATE, {
         frequency: frequencyData?.type || "",
         connector_source_definition: source?.sourceName,
         connector_source_definition_id: sourceDefinition?.sourceDefinitionId,

--- a/airbyte-webapp/src/hooks/services/useConnectionHook.tsx
+++ b/airbyte-webapp/src/hooks/services/useConnectionHook.tsx
@@ -4,7 +4,7 @@ import { getFrequencyConfig } from "config/utils";
 import { SyncSchema } from "core/domain/catalog";
 import { WebBackendConnectionService } from "core/domain/connection";
 import { ConnectionService } from "core/domain/connection/ConnectionService";
-import { useAnalyticsService } from "hooks/services/Analytics/useAnalyticsService";
+import { LegacyTrackActionType, useTrackAction, TrackActionNamespace, TrackActionActions } from "hooks/useTrackAction";
 import { useInitService } from "services/useInitService";
 
 import { useConfig } from "../../config";
@@ -88,15 +88,14 @@ export const useConnectionLoad = (
 
 export const useSyncConnection = () => {
   const service = useConnectionService();
-  const analyticsService = useAnalyticsService();
+  const trackSourceAction = useTrackAction(TrackActionNamespace.SOURCE, LegacyTrackActionType.SOURCE);
 
   return useMutation((connection: WebBackendConnectionRead) => {
     const frequency = getFrequencyConfig(connection.schedule);
 
-    analyticsService.track("Source - Action", {
-      action: "Full refresh sync",
+    trackSourceAction("Full refresh sync", [TrackActionActions.SYNC], {
       connector_source: connection.source?.sourceName,
-      connector_source_id: connection.source?.sourceDefinitionId,
+      connector_source_definition_id: connection.source?.sourceDefinitionId,
       connector_destination: connection.destination?.name,
       connector_destination_definition_id: connection.destination?.destinationDefinitionId,
       frequency: frequency?.type,
@@ -121,7 +120,10 @@ const useGetConnection = (connectionId: string, options?: { refetchInterval: num
 const useCreateConnection = () => {
   const service = useWebConnectionService();
   const queryClient = useQueryClient();
-  const analyticsService = useAnalyticsService();
+  const trackNewConnectionAction = useTrackAction(
+    TrackActionNamespace.CONNECTION,
+    LegacyTrackActionType.NEW_CONNECTION
+  );
 
   return useMutation(
     async ({
@@ -144,9 +146,8 @@ const useCreateConnection = () => {
 
       const frequencyData = getFrequencyConfig(values.schedule);
 
-      analyticsService.track("New Connection - Action", {
-        action: "Set up connection",
-        frequency: frequencyData?.type,
+      trackNewConnectionAction("Set up connection", [TrackActionActions.CREATE], {
+        frequency: frequencyData?.type || "",
         connector_source_definition: source?.sourceName,
         connector_source_definition_id: sourceDefinition?.sourceDefinitionId,
         connector_destination_definition: destination?.destinationName,

--- a/airbyte-webapp/src/hooks/services/useDestinationHook.tsx
+++ b/airbyte-webapp/src/hooks/services/useDestinationHook.tsx
@@ -2,7 +2,7 @@ import { useMutation, useQueryClient } from "react-query";
 
 import { ConnectionConfiguration } from "core/domain/connection";
 import { DestinationService } from "core/domain/connector/DestinationService";
-import { LegacyTrackActionType, TrackActionActions, TrackActionNamespace, useTrackAction } from "hooks/useTrackAction";
+import { TrackActionLegacyType, TrackActionType, TrackActionNamespace, useTrackAction } from "hooks/useTrackAction";
 import { useInitService } from "services/useInitService";
 import { isDefined } from "utils/common";
 
@@ -92,14 +92,14 @@ const useCreateDestination = () => {
 const useDeleteDestination = () => {
   const service = useDestinationService();
   const queryClient = useQueryClient();
-  const trackDestinationAction = useTrackAction(TrackActionNamespace.DESTINATION, LegacyTrackActionType.SOURCE);
+  const trackDestinationAction = useTrackAction(TrackActionNamespace.DESTINATION, TrackActionLegacyType.SOURCE);
 
   return useMutation(
     (payload: { destination: DestinationRead; connectionsWithDestination: WebBackendConnectionRead[] }) =>
       service.delete(payload.destination.destinationId),
     {
       onSuccess: (_data, ctx) => {
-        trackDestinationAction("Delete destination", TrackActionActions.DELETE, {
+        trackDestinationAction("Delete destination", TrackActionType.DELETE, {
           connector_destination: ctx.destination.destinationName,
           connector_destination_definition_id: ctx.destination.destinationDefinitionId, //another change to match the data we send
         });

--- a/airbyte-webapp/src/hooks/services/useDestinationHook.tsx
+++ b/airbyte-webapp/src/hooks/services/useDestinationHook.tsx
@@ -2,7 +2,7 @@ import { useMutation, useQueryClient } from "react-query";
 
 import { ConnectionConfiguration } from "core/domain/connection";
 import { DestinationService } from "core/domain/connector/DestinationService";
-import { useAnalyticsService } from "hooks/services/Analytics/useAnalyticsService";
+import { LegacyTrackActionType, TrackActionActions, TrackActionNamespace, useTrackAction } from "hooks/useTrackAction";
 import { useInitService } from "services/useInitService";
 import { isDefined } from "utils/common";
 
@@ -92,17 +92,16 @@ const useCreateDestination = () => {
 const useDeleteDestination = () => {
   const service = useDestinationService();
   const queryClient = useQueryClient();
-  const analyticsService = useAnalyticsService();
+  const trackDestinationAction = useTrackAction(TrackActionNamespace.DESTINATION, LegacyTrackActionType.SOURCE);
 
   return useMutation(
     (payload: { destination: DestinationRead; connectionsWithDestination: WebBackendConnectionRead[] }) =>
       service.delete(payload.destination.destinationId),
     {
       onSuccess: (_data, ctx) => {
-        analyticsService.track("Destination - Action", {
-          action: "Delete destination",
+        trackDestinationAction("Delete destination", [TrackActionActions.DELETE], {
           connector_destination: ctx.destination.destinationName,
-          connector_destination_id: ctx.destination.destinationDefinitionId,
+          connector_destination_definition_id: ctx.destination.destinationDefinitionId, //another change to match the data we send
         });
 
         queryClient.removeQueries(destinationsKeys.detail(ctx.destination.destinationId));

--- a/airbyte-webapp/src/hooks/services/useDestinationHook.tsx
+++ b/airbyte-webapp/src/hooks/services/useDestinationHook.tsx
@@ -99,7 +99,7 @@ const useDeleteDestination = () => {
       service.delete(payload.destination.destinationId),
     {
       onSuccess: (_data, ctx) => {
-        trackDestinationAction("Delete destination", [TrackActionActions.DELETE], {
+        trackDestinationAction("Delete destination", TrackActionActions.DELETE, {
           connector_destination: ctx.destination.destinationName,
           connector_destination_definition_id: ctx.destination.destinationDefinitionId, //another change to match the data we send
         });

--- a/airbyte-webapp/src/hooks/services/useDestinationHook.tsx
+++ b/airbyte-webapp/src/hooks/services/useDestinationHook.tsx
@@ -101,7 +101,7 @@ const useDeleteDestination = () => {
       onSuccess: (_data, ctx) => {
         trackDestinationAction("Delete destination", TrackActionType.DELETE, {
           connector_destination: ctx.destination.destinationName,
-          connector_destination_definition_id: ctx.destination.destinationDefinitionId, //another change to match the data we send
+          connector_destination_definition_id: ctx.destination.destinationDefinitionId,
         });
 
         queryClient.removeQueries(destinationsKeys.detail(ctx.destination.destinationId));

--- a/airbyte-webapp/src/hooks/services/useSourceHook.tsx
+++ b/airbyte-webapp/src/hooks/services/useSourceHook.tsx
@@ -6,7 +6,7 @@ import { SyncSchema } from "core/domain/catalog";
 import { ConnectionConfiguration } from "core/domain/connection";
 import { SourceService } from "core/domain/connector/SourceService";
 import { JobInfo } from "core/domain/job";
-import { useAnalyticsService } from "hooks/services/Analytics/useAnalyticsService";
+import { LegacyTrackActionType, TrackActionActions, TrackActionNamespace, useTrackAction } from "hooks/useTrackAction";
 import { useInitService } from "services/useInitService";
 import { isDefined } from "utils/common";
 
@@ -98,17 +98,16 @@ const useCreateSource = () => {
 const useDeleteSource = () => {
   const service = useSourceService();
   const queryClient = useQueryClient();
-  const analyticsService = useAnalyticsService();
+  const trackSourceAction = useTrackAction(TrackActionNamespace.SOURCE, LegacyTrackActionType.SOURCE);
 
   return useMutation(
     (payload: { source: SourceRead; connectionsWithSource: WebBackendConnectionRead[] }) =>
       service.delete(payload.source.sourceId),
     {
       onSuccess: (_data, ctx) => {
-        analyticsService.track("Source - Action", {
-          action: "Delete source",
+        trackSourceAction("Delete source", [TrackActionActions.DELETE], {
           connector_source: ctx.source.sourceName,
-          connector_source_id: ctx.source.sourceDefinitionId,
+          connector_source_definition_id: ctx.source.sourceDefinitionId, //another change to match the data we're sending
         });
 
         queryClient.removeQueries(sourcesKeys.detail(ctx.source.sourceId));

--- a/airbyte-webapp/src/hooks/services/useSourceHook.tsx
+++ b/airbyte-webapp/src/hooks/services/useSourceHook.tsx
@@ -107,7 +107,7 @@ const useDeleteSource = () => {
       onSuccess: (_data, ctx) => {
         trackSourceAction("Delete source", [TrackActionActions.DELETE], {
           connector_source: ctx.source.sourceName,
-          connector_source_definition_id: ctx.source.sourceDefinitionId, //another change to match the data we're sending
+          connector_source_definition_id: ctx.source.sourceDefinitionId,
         });
 
         queryClient.removeQueries(sourcesKeys.detail(ctx.source.sourceId));

--- a/airbyte-webapp/src/hooks/services/useSourceHook.tsx
+++ b/airbyte-webapp/src/hooks/services/useSourceHook.tsx
@@ -6,7 +6,7 @@ import { SyncSchema } from "core/domain/catalog";
 import { ConnectionConfiguration } from "core/domain/connection";
 import { SourceService } from "core/domain/connector/SourceService";
 import { JobInfo } from "core/domain/job";
-import { LegacyTrackActionType, TrackActionActions, TrackActionNamespace, useTrackAction } from "hooks/useTrackAction";
+import { TrackActionLegacyType, TrackActionType, TrackActionNamespace, useTrackAction } from "hooks/useTrackAction";
 import { useInitService } from "services/useInitService";
 import { isDefined } from "utils/common";
 
@@ -98,14 +98,14 @@ const useCreateSource = () => {
 const useDeleteSource = () => {
   const service = useSourceService();
   const queryClient = useQueryClient();
-  const trackSourceAction = useTrackAction(TrackActionNamespace.SOURCE, LegacyTrackActionType.SOURCE);
+  const trackSourceAction = useTrackAction(TrackActionNamespace.SOURCE, TrackActionLegacyType.SOURCE);
 
   return useMutation(
     (payload: { source: SourceRead; connectionsWithSource: WebBackendConnectionRead[] }) =>
       service.delete(payload.source.sourceId),
     {
       onSuccess: (_data, ctx) => {
-        trackSourceAction("Delete source", TrackActionActions.DELETE, {
+        trackSourceAction("Delete source", TrackActionType.DELETE, {
           connector_source: ctx.source.sourceName,
           connector_source_definition_id: ctx.source.sourceDefinitionId,
         });

--- a/airbyte-webapp/src/hooks/services/useSourceHook.tsx
+++ b/airbyte-webapp/src/hooks/services/useSourceHook.tsx
@@ -105,7 +105,7 @@ const useDeleteSource = () => {
       service.delete(payload.source.sourceId),
     {
       onSuccess: (_data, ctx) => {
-        trackSourceAction("Delete source", [TrackActionActions.DELETE], {
+        trackSourceAction("Delete source", TrackActionActions.DELETE, {
           connector_source: ctx.source.sourceName,
           connector_source_definition_id: ctx.source.sourceDefinitionId,
         });

--- a/airbyte-webapp/src/hooks/useTrackAction.test.tsx
+++ b/airbyte-webapp/src/hooks/useTrackAction.test.tsx
@@ -1,0 +1,19 @@
+import { act, renderHook } from "@testing-library/react-hooks";
+
+import { TrackActionLegacyType, TrackActionNamespace, useTrackAction } from "./useTrackAction";
+
+describe("With legacy namespace", () => {
+  const mockUseTrackAction = renderHook(() =>
+    useTrackAction(TrackActionNamespace.SOURCE, TrackActionLegacyType.NEW_SOURCE)
+  );
+  test("it parses namespace and legacy name when calling the hook", () => {
+    act(mockUseTrackAction("hi", {}));
+    expect(2 + 2).toEqual(4);
+  });
+});
+
+describe("Without legacy namespace", () => {
+  const mockUseTrackAction = renderHook(() => useTrackAction(TrackActionNamespace.SOURCE));
+  test.todo("it parses namespace when calling the hook");
+  test.todo("legacy namespace can be undefined");
+});

--- a/airbyte-webapp/src/hooks/useTrackAction.test.tsx
+++ b/airbyte-webapp/src/hooks/useTrackAction.test.tsx
@@ -1,19 +1,36 @@
-import { act, renderHook } from "@testing-library/react-hooks";
+import { renderHook } from "@testing-library/react-hooks";
 
-import { TrackActionLegacyType, TrackActionNamespace, useTrackAction } from "./useTrackAction";
+import { useAnalyticsService } from "./services/Analytics/useAnalyticsService";
+import { TrackActionLegacyType, TrackActionNamespace, TrackActionType, useTrackAction } from "./useTrackAction";
+
+jest.mock("./services/Analytics/useAnalyticsService", () => {
+  const mockTrack = jest.fn();
+  return { useAnalyticsService: () => ({ track: mockTrack }) };
+});
 
 describe("With legacy namespace", () => {
-  const mockUseTrackAction = renderHook(() =>
-    useTrackAction(TrackActionNamespace.SOURCE, TrackActionLegacyType.NEW_SOURCE)
-  );
   test("it parses namespace and legacy name when calling the hook", () => {
-    act(mockUseTrackAction("hi", {}));
-    expect(2 + 2).toEqual(4);
+    const mockUseTrackAction = renderHook(() =>
+      useTrackAction(TrackActionNamespace.SOURCE, TrackActionLegacyType.NEW_SOURCE)
+    );
+    mockUseTrackAction.result.current("test action sent", TrackActionType.CREATE, {});
+    const analyticsService = useAnalyticsService();
+
+    expect(analyticsService.track).toHaveBeenCalledWith(
+      "Airbyte.UI.Source.Create",
+      expect.objectContaining({ legacy_event_name: "New Source - Action" })
+    );
   });
 });
 
 describe("Without legacy namespace", () => {
-  const mockUseTrackAction = renderHook(() => useTrackAction(TrackActionNamespace.SOURCE));
-  test.todo("it parses namespace when calling the hook");
-  test.todo("legacy namespace can be undefined");
+  test("legacy namespace is passed as empty string if none is received", () => {
+    const mockUseTrackAction = renderHook(() => useTrackAction(TrackActionNamespace.CONNECTION));
+    mockUseTrackAction.result.current("another test action", TrackActionType.CREATE, {});
+    const analyticsService = useAnalyticsService();
+    expect(analyticsService.track).toHaveBeenCalledWith(
+      "Airbyte.UI.Connection.Create",
+      expect.objectContaining({ legacy_event_name: "" })
+    );
+  });
 });

--- a/airbyte-webapp/src/hooks/useTrackAction.ts
+++ b/airbyte-webapp/src/hooks/useTrackAction.ts
@@ -14,12 +14,34 @@ interface TrackActionProperties {
   connector_destination_definition_id?: string;
 }
 
+interface NewTrackActionProperties {
+  connector_source?: string;
+  connector_source_definition_id?: string;
+  connector_destination?: string;
+  connector_destination_definition_id?: string;
+}
+
 export const useTrackAction = (type: TrackActionType) => {
   const analyticsService = useAnalyticsService();
 
   return useCallback(
     (action: string, properties: TrackActionProperties) => {
       analyticsService.track(`${type} - Action`, { action, ...properties });
+    },
+    [analyticsService, type]
+  );
+};
+
+export const useNewTrackAction = (type: TrackActionType) => {
+  const analyticsService = useAnalyticsService();
+
+  return useCallback(
+    (action: string, properties: NewTrackActionProperties) => {
+      analyticsService.track(`AIRBYTE.UI.${namespace}.${action_type}`, {
+        action,
+        ...properties,
+        legacy_event_name: `${type} - Action`,
+      });
     },
     [analyticsService, type]
   );

--- a/airbyte-webapp/src/hooks/useTrackAction.ts
+++ b/airbyte-webapp/src/hooks/useTrackAction.ts
@@ -56,7 +56,7 @@ export const useTrackAction = (namespace: TrackActionNamespace, legacyType?: Tra
       properties: TrackConnectorActionProperties | TrackConnectionActionProperties
     ) => {
       // Calls that did not exist in the legacy format will not have a legacy event name
-      const legacyEventName = legacyType ? `${legacyType} - Action)` : "";
+      const legacyEventName = legacyType ? `${legacyType} - Action` : "";
 
       analyticsService.track(`Airbyte.UI.${namespace}.${actionType}`, {
         actionDescription,

--- a/airbyte-webapp/src/hooks/useTrackAction.ts
+++ b/airbyte-webapp/src/hooks/useTrackAction.ts
@@ -48,6 +48,7 @@ interface TrackConnectionActionProperties {
 
 export const useTrackAction = (namespace: TrackActionNamespace, legacyType?: TrackActionLegacyType) => {
   const analyticsService = useAnalyticsService();
+  console.log(analyticsService);
 
   return useCallback(
     (

--- a/airbyte-webapp/src/hooks/useTrackAction.ts
+++ b/airbyte-webapp/src/hooks/useTrackAction.ts
@@ -48,7 +48,6 @@ interface TrackConnectionActionProperties {
 
 export const useTrackAction = (namespace: TrackActionNamespace, legacyType?: TrackActionLegacyType) => {
   const analyticsService = useAnalyticsService();
-  console.log(analyticsService);
 
   return useCallback(
     (

--- a/airbyte-webapp/src/hooks/useTrackAction.ts
+++ b/airbyte-webapp/src/hooks/useTrackAction.ts
@@ -53,7 +53,7 @@ export const useTrackAction = (namespace: TrackActionNamespace, legacyType?: Leg
   return useCallback(
     (
       action: string,
-      actionTypes: TrackActionActions[],
+      actionTypes: TrackActionActions[], //actionType is typically one entry (ie: CREATE) but is sometimes nested (ie: TEST.SUCCESS)
       properties: TrackConnectorActionProperties | TrackConnectionActionProperties
     ) => {
       const actionTypesString = actionTypes.toString().replaceAll(",", ".");

--- a/airbyte-webapp/src/hooks/useTrackAction.ts
+++ b/airbyte-webapp/src/hooks/useTrackAction.ts
@@ -15,7 +15,7 @@ export const enum TrackActionActions {
   SELECT = "Select",
   SUCCESS = "Success",
   FAILURE = "Failure",
-  FREQUENCY = "Frequency",
+  FREQUENCY = "FrequencySet",
   SYNC = "FullRefreshSync",
   SCHEMA = "EditSchema",
   DISABLE = "Disable",
@@ -34,7 +34,6 @@ interface TrackConnectorActionProperties {
   connector_source_definition_id?: string;
   connector_destination?: string;
   connector_destination_definition_id?: string;
-  frequency?: string; //todo: i don't like this here... but the disable/reenable call in the EntityTable hooks sends it with the other data for this type of call?  get clarification on what data should be sent with what calls...
 }
 
 interface TrackConnectionActionProperties {

--- a/airbyte-webapp/src/hooks/useTrackAction.ts
+++ b/airbyte-webapp/src/hooks/useTrackAction.ts
@@ -47,7 +47,7 @@ interface TrackConnectionActionProperties {
   enabled_streams: number;
 }
 
-export const useTrackAction = (namespace: TrackActionNamespace, type: LegacyTrackActionType) => {
+export const useTrackAction = (namespace: TrackActionNamespace, legacyType?: LegacyTrackActionType) => {
   const analyticsService = useAnalyticsService();
 
   return useCallback(
@@ -58,12 +58,15 @@ export const useTrackAction = (namespace: TrackActionNamespace, type: LegacyTrac
     ) => {
       const actionTypesString = actionTypes.toString().replaceAll(",", ".");
 
+      // Calls that did not exist in the legacy format will not have a legacy event name
+      const legacyEventName = legacyType ? `${legacyType} - Action)` : "";
+
       analyticsService.track(`Airbyte.UI.${namespace}.${actionTypesString}`, {
         action,
         ...properties,
-        legacy_event_name: `${type} - Action`,
+        legacy_event_name: legacyEventName,
       });
     },
-    [analyticsService, namespace, type]
+    [analyticsService, namespace, legacyType]
   );
 };

--- a/airbyte-webapp/src/hooks/useTrackAction.ts
+++ b/airbyte-webapp/src/hooks/useTrackAction.ts
@@ -5,6 +5,8 @@ import { useAnalyticsService } from "./services/Analytics/useAnalyticsService";
 export const enum LegacyTrackActionType {
   NEW_SOURCE = "New Source",
   NEW_DESTINATION = "New Destination",
+  NEW_CONNECTION = "New Connection",
+  SOURCE = "Source",
 }
 
 export const enum TrackActionActions {
@@ -13,25 +15,47 @@ export const enum TrackActionActions {
   SELECT = "Select",
   SUCCESS = "Success",
   FAILURE = "Failure",
+  FREQUENCY = "Frequency",
+  SYNC = "FullRefreshSync",
+  SCHEMA = "EditSchema",
+  DISABLE = "Disable",
+  REENABLE = "Reenable",
+  DELETE = "Delete",
 }
 
 export const enum TrackActionNamespace {
   SOURCE = "Source",
   DESTINATION = "Destination",
+  CONNECTION = "Connection",
 }
 
-interface TrackActionProperties {
+interface TrackConnectorActionProperties {
   connector_source?: string;
   connector_source_definition_id?: string;
   connector_destination?: string;
   connector_destination_definition_id?: string;
+  frequency?: string; //todo: i don't like this here... but the disable/reenable call in the EntityTable hooks sends it with the other data for this type of call?  get clarification on what data should be sent with what calls...
+}
+
+interface TrackConnectionActionProperties {
+  frequency: string;
+  connector_source_definition: string;
+  connector_source_definition_id: string;
+  connector_destination_definition: string;
+  connector_destination_definition_id: string;
+  available_streams: number;
+  enabled_streams: number;
 }
 
 export const useTrackAction = (namespace: TrackActionNamespace, type: LegacyTrackActionType) => {
   const analyticsService = useAnalyticsService();
 
   return useCallback(
-    (action: string, actionTypes: TrackActionActions[], properties: TrackActionProperties) => {
+    (
+      action: string,
+      actionTypes: TrackActionActions[],
+      properties: TrackConnectorActionProperties | TrackConnectionActionProperties
+    ) => {
       const actionTypesString = actionTypes.toString().replaceAll(",", ".");
 
       analyticsService.track(`Airbyte.UI.${namespace}.${actionTypesString}`, {

--- a/airbyte-webapp/src/hooks/useTrackAction.ts
+++ b/airbyte-webapp/src/hooks/useTrackAction.ts
@@ -13,8 +13,8 @@ export const enum TrackActionActions {
   CREATE = "Create",
   TEST = "Test",
   SELECT = "Select",
-  SUCCESS = "Success",
-  FAILURE = "Failure",
+  SUCCESS = "TestSuccess",
+  FAILURE = "TestFailure",
   FREQUENCY = "FrequencySet",
   SYNC = "FullRefreshSync",
   SCHEMA = "EditSchema",
@@ -52,15 +52,13 @@ export const useTrackAction = (namespace: TrackActionNamespace, legacyType?: Leg
   return useCallback(
     (
       action: string,
-      actionTypes: TrackActionActions[], //actionType is typically one entry (ie: CREATE) but is sometimes nested (ie: TEST.SUCCESS)
+      actionType: TrackActionActions,
       properties: TrackConnectorActionProperties | TrackConnectionActionProperties
     ) => {
-      const actionTypesString = actionTypes.toString().replaceAll(",", ".");
-
       // Calls that did not exist in the legacy format will not have a legacy event name
       const legacyEventName = legacyType ? `${legacyType} - Action)` : "";
 
-      analyticsService.track(`Airbyte.UI.${namespace}.${actionTypesString}`, {
+      analyticsService.track(`Airbyte.UI.${namespace}.${actionType}`, {
         action,
         ...properties,
         legacy_event_name: legacyEventName,

--- a/airbyte-webapp/src/hooks/useTrackAction.ts
+++ b/airbyte-webapp/src/hooks/useTrackAction.ts
@@ -2,9 +2,22 @@ import { useCallback } from "react";
 
 import { useAnalyticsService } from "./services/Analytics/useAnalyticsService";
 
-export const enum TrackActionType {
+export const enum LegacyTrackActionType {
   NEW_SOURCE = "New Source",
   NEW_DESTINATION = "New Destination",
+}
+
+export const enum TrackActionActions {
+  CREATE = "Create",
+  TEST = "Test",
+  SELECT = "Select",
+  SUCCESS = "Success",
+  FAILURE = "Failure",
+}
+
+export const enum TrackActionNamespace {
+  SOURCE = "Source",
+  DESTINATION = "Destination",
 }
 
 interface TrackActionProperties {
@@ -14,35 +27,19 @@ interface TrackActionProperties {
   connector_destination_definition_id?: string;
 }
 
-interface NewTrackActionProperties {
-  connector_source?: string;
-  connector_source_definition_id?: string;
-  connector_destination?: string;
-  connector_destination_definition_id?: string;
-}
-
-export const useTrackAction = (type: TrackActionType) => {
+export const useTrackAction = (namespace: TrackActionNamespace, type: LegacyTrackActionType) => {
   const analyticsService = useAnalyticsService();
 
   return useCallback(
-    (action: string, properties: TrackActionProperties) => {
-      analyticsService.track(`${type} - Action`, { action, ...properties });
-    },
-    [analyticsService, type]
-  );
-};
+    (action: string, actionTypes: TrackActionActions[], properties: TrackActionProperties) => {
+      const actionTypesString = actionTypes.toString().replaceAll(",", ".");
 
-export const useNewTrackAction = (type: TrackActionType) => {
-  const analyticsService = useAnalyticsService();
-
-  return useCallback(
-    (action: string, properties: NewTrackActionProperties) => {
-      analyticsService.track(`AIRBYTE.UI.${namespace}.${action_type}`, {
+      analyticsService.track(`Airbyte.UI.${namespace}.${actionTypesString}`, {
         action,
         ...properties,
         legacy_event_name: `${type} - Action`,
       });
     },
-    [analyticsService, type]
+    [analyticsService, namespace, type]
   );
 };

--- a/airbyte-webapp/src/hooks/useTrackAction.ts
+++ b/airbyte-webapp/src/hooks/useTrackAction.ts
@@ -2,14 +2,14 @@ import { useCallback } from "react";
 
 import { useAnalyticsService } from "./services/Analytics/useAnalyticsService";
 
-export const enum LegacyTrackActionType {
+export const enum TrackActionLegacyType {
   NEW_SOURCE = "New Source",
   NEW_DESTINATION = "New Destination",
   NEW_CONNECTION = "New Connection",
   SOURCE = "Source",
 }
 
-export const enum TrackActionActions {
+export const enum TrackActionType {
   CREATE = "Create",
   TEST = "Test",
   SELECT = "Select",
@@ -46,20 +46,20 @@ interface TrackConnectionActionProperties {
   enabled_streams: number;
 }
 
-export const useTrackAction = (namespace: TrackActionNamespace, legacyType?: LegacyTrackActionType) => {
+export const useTrackAction = (namespace: TrackActionNamespace, legacyType?: TrackActionLegacyType) => {
   const analyticsService = useAnalyticsService();
 
   return useCallback(
     (
-      action: string,
-      actionType: TrackActionActions,
+      actionDescription: string,
+      actionType: TrackActionType,
       properties: TrackConnectorActionProperties | TrackConnectionActionProperties
     ) => {
       // Calls that did not exist in the legacy format will not have a legacy event name
       const legacyEventName = legacyType ? `${legacyType} - Action)` : "";
 
       analyticsService.track(`Airbyte.UI.${namespace}.${actionType}`, {
-        action,
+        actionDescription,
         ...properties,
         legacy_event_name: legacyEventName,
       });

--- a/airbyte-webapp/src/pages/ConnectionPage/pages/ConnectionItemPage/ConnectionItemPage.tsx
+++ b/airbyte-webapp/src/pages/ConnectionPage/pages/ConnectionItemPage/ConnectionItemPage.tsx
@@ -36,7 +36,7 @@ const ConnectionItemPage: React.FC = () => {
   const onAfterSaveSchema = () => {
     trackSourceAction("Edit schema", [TrackActionActions.SCHEMA], {
       connector_source: source.sourceName,
-      connector_source_definition_id: source.sourceDefinitionId, //todo: ask natalie if this _should_ be changed or if I should make the call more flexible to use the old (incorrect?) label
+      connector_source_definition_id: source.sourceDefinitionId,
       connector_destination: destination.destinationName,
       connector_destination_definition_id: destination.destinationDefinitionId,
       frequency: frequency?.type,

--- a/airbyte-webapp/src/pages/ConnectionPage/pages/ConnectionItemPage/ConnectionItemPage.tsx
+++ b/airbyte-webapp/src/pages/ConnectionPage/pages/ConnectionItemPage/ConnectionItemPage.tsx
@@ -7,8 +7,8 @@ import HeadTitle from "components/HeadTitle";
 
 import { getFrequencyConfig } from "config/utils";
 import { ConnectionStatus } from "core/request/AirbyteClient";
-import { useAnalyticsService } from "hooks/services/Analytics/useAnalyticsService";
 import { useGetConnection } from "hooks/services/useConnectionHook";
+import { LegacyTrackActionType, TrackActionActions, TrackActionNamespace, useTrackAction } from "hooks/useTrackAction";
 import TransformationView from "pages/ConnectionPage/pages/ConnectionItemPage/components/TransformationView";
 
 import ConnectionPageTitle from "./components/ConnectionPageTitle";
@@ -29,15 +29,14 @@ const ConnectionItemPage: React.FC = () => {
 
   const { source, destination } = connection;
 
-  const analyticsService = useAnalyticsService();
-
   const frequency = getFrequencyConfig(connection.schedule);
 
+  const trackSourceAction = useTrackAction(TrackActionNamespace.SOURCE, LegacyTrackActionType.SOURCE);
+
   const onAfterSaveSchema = () => {
-    analyticsService.track("Source - Action", {
-      action: "Edit schema",
+    trackSourceAction("Edit schema", [TrackActionActions.SCHEMA], {
       connector_source: source.sourceName,
-      connector_source_id: source.sourceDefinitionId,
+      connector_source_definition_id: source.sourceDefinitionId, //todo: ask natalie if this _should_ be changed or if I should make the call more flexible to use the old (incorrect?) label
       connector_destination: destination.destinationName,
       connector_destination_definition_id: destination.destinationDefinitionId,
       frequency: frequency?.type,

--- a/airbyte-webapp/src/pages/ConnectionPage/pages/ConnectionItemPage/ConnectionItemPage.tsx
+++ b/airbyte-webapp/src/pages/ConnectionPage/pages/ConnectionItemPage/ConnectionItemPage.tsx
@@ -34,7 +34,7 @@ const ConnectionItemPage: React.FC = () => {
   const trackSourceAction = useTrackAction(TrackActionNamespace.SOURCE, LegacyTrackActionType.SOURCE);
 
   const onAfterSaveSchema = () => {
-    trackSourceAction("Edit schema", [TrackActionActions.SCHEMA], {
+    trackSourceAction("Edit schema", TrackActionActions.SCHEMA, {
       connector_source: source.sourceName,
       connector_source_definition_id: source.sourceDefinitionId,
       connector_destination: destination.destinationName,

--- a/airbyte-webapp/src/pages/ConnectionPage/pages/ConnectionItemPage/ConnectionItemPage.tsx
+++ b/airbyte-webapp/src/pages/ConnectionPage/pages/ConnectionItemPage/ConnectionItemPage.tsx
@@ -8,7 +8,7 @@ import HeadTitle from "components/HeadTitle";
 import { getFrequencyConfig } from "config/utils";
 import { ConnectionStatus } from "core/request/AirbyteClient";
 import { useGetConnection } from "hooks/services/useConnectionHook";
-import { LegacyTrackActionType, TrackActionActions, TrackActionNamespace, useTrackAction } from "hooks/useTrackAction";
+import { TrackActionLegacyType, TrackActionType, TrackActionNamespace, useTrackAction } from "hooks/useTrackAction";
 import TransformationView from "pages/ConnectionPage/pages/ConnectionItemPage/components/TransformationView";
 
 import ConnectionPageTitle from "./components/ConnectionPageTitle";
@@ -31,10 +31,10 @@ const ConnectionItemPage: React.FC = () => {
 
   const frequency = getFrequencyConfig(connection.schedule);
 
-  const trackSourceAction = useTrackAction(TrackActionNamespace.SOURCE, LegacyTrackActionType.SOURCE);
+  const trackSourceAction = useTrackAction(TrackActionNamespace.SOURCE, TrackActionLegacyType.SOURCE);
 
   const onAfterSaveSchema = () => {
-    trackSourceAction("Edit schema", TrackActionActions.SCHEMA, {
+    trackSourceAction("Edit schema", TrackActionType.SCHEMA, {
       connector_source: source.sourceName,
       connector_source_definition_id: source.sourceDefinitionId,
       connector_destination: destination.destinationName,

--- a/airbyte-webapp/src/pages/ConnectionPage/pages/ConnectionItemPage/components/EnabledControl.tsx
+++ b/airbyte-webapp/src/pages/ConnectionPage/pages/ConnectionItemPage/components/EnabledControl.tsx
@@ -53,7 +53,7 @@ const EnabledControl: React.FC<EnabledControlProps> = ({ connection, disabled, f
 
     trackSourceAction(trackableActionString, [trackableAction], {
       connector_source: connection.source?.sourceName,
-      connector_source_definition_id: connection.source?.sourceDefinitionId, //another place I'm changing a label... clarify if that's ok
+      connector_source_definition_id: connection.source?.sourceDefinitionId,
       connector_destination: connection.destination?.name,
       connector_destination_definition_id: connection.destination?.destinationDefinitionId,
       frequency: frequencyType,

--- a/airbyte-webapp/src/pages/ConnectionPage/pages/ConnectionItemPage/components/EnabledControl.tsx
+++ b/airbyte-webapp/src/pages/ConnectionPage/pages/ConnectionItemPage/components/EnabledControl.tsx
@@ -51,7 +51,7 @@ const EnabledControl: React.FC<EnabledControlProps> = ({ connection, disabled, f
 
     const trackableActionString = `${trackableAction} connection`;
 
-    trackSourceAction(trackableActionString, [trackableAction], {
+    trackSourceAction(trackableActionString, trackableAction, {
       connector_source: connection.source?.sourceName,
       connector_source_definition_id: connection.source?.sourceDefinitionId,
       connector_destination: connection.destination?.name,

--- a/airbyte-webapp/src/pages/ConnectionPage/pages/ConnectionItemPage/components/EnabledControl.tsx
+++ b/airbyte-webapp/src/pages/ConnectionPage/pages/ConnectionItemPage/components/EnabledControl.tsx
@@ -7,7 +7,7 @@ import { Switch } from "components";
 
 import { buildConnectionUpdate } from "core/domain/connection";
 import { useUpdateConnection } from "hooks/services/useConnectionHook";
-import { LegacyTrackActionType, TrackActionActions, TrackActionNamespace, useTrackAction } from "hooks/useTrackAction";
+import { TrackActionLegacyType, TrackActionType, TrackActionNamespace, useTrackAction } from "hooks/useTrackAction";
 
 import { ConnectionStatus, WebBackendConnectionRead } from "../../../../../core/request/AirbyteClient";
 
@@ -37,7 +37,7 @@ interface EnabledControlProps {
 
 const EnabledControl: React.FC<EnabledControlProps> = ({ connection, disabled, frequencyType, onStatusUpdating }) => {
   const { mutateAsync: updateConnection, isLoading } = useUpdateConnection();
-  const trackSourceAction = useTrackAction(TrackActionNamespace.SOURCE, LegacyTrackActionType.SOURCE);
+  const trackSourceAction = useTrackAction(TrackActionNamespace.SOURCE, TrackActionLegacyType.SOURCE);
 
   const onChangeStatus = async () => {
     await updateConnection(
@@ -47,7 +47,7 @@ const EnabledControl: React.FC<EnabledControlProps> = ({ connection, disabled, f
     );
 
     const trackableAction =
-      connection.status === ConnectionStatus.active ? TrackActionActions.DISABLE : TrackActionActions.REENABLE;
+      connection.status === ConnectionStatus.active ? TrackActionType.DISABLE : TrackActionType.REENABLE;
 
     const trackableActionString = `${trackableAction} connection`;
 

--- a/airbyte-webapp/src/pages/ConnectionPage/pages/ConnectionItemPage/components/EnabledControl.tsx
+++ b/airbyte-webapp/src/pages/ConnectionPage/pages/ConnectionItemPage/components/EnabledControl.tsx
@@ -6,8 +6,8 @@ import styled from "styled-components";
 import { Switch } from "components";
 
 import { buildConnectionUpdate } from "core/domain/connection";
-import { useAnalyticsService } from "hooks/services/Analytics/useAnalyticsService";
 import { useUpdateConnection } from "hooks/services/useConnectionHook";
+import { LegacyTrackActionType, TrackActionActions, TrackActionNamespace, useTrackAction } from "hooks/useTrackAction";
 
 import { ConnectionStatus, WebBackendConnectionRead } from "../../../../../core/request/AirbyteClient";
 
@@ -37,7 +37,7 @@ interface EnabledControlProps {
 
 const EnabledControl: React.FC<EnabledControlProps> = ({ connection, disabled, frequencyType, onStatusUpdating }) => {
   const { mutateAsync: updateConnection, isLoading } = useUpdateConnection();
-  const analyticsService = useAnalyticsService();
+  const trackSourceAction = useTrackAction(TrackActionNamespace.SOURCE, LegacyTrackActionType.SOURCE);
 
   const onChangeStatus = async () => {
     await updateConnection(
@@ -46,10 +46,14 @@ const EnabledControl: React.FC<EnabledControlProps> = ({ connection, disabled, f
       })
     );
 
-    analyticsService.track("Source - Action", {
-      action: connection.status === ConnectionStatus.active ? "Disable connection" : "Reenable connection",
+    const trackableAction =
+      connection.status === ConnectionStatus.active ? TrackActionActions.DISABLE : TrackActionActions.REENABLE;
+
+    const trackableActionString = `${trackableAction} connection`;
+
+    trackSourceAction(trackableActionString, [trackableAction], {
       connector_source: connection.source?.sourceName,
-      connector_source_id: connection.source?.sourceDefinitionId,
+      connector_source_definition_id: connection.source?.sourceDefinitionId, //another place I'm changing a label... clarify if that's ok
       connector_destination: connection.destination?.name,
       connector_destination_definition_id: connection.destination?.destinationDefinitionId,
       frequency: frequencyType,

--- a/airbyte-webapp/src/pages/DestinationPage/pages/CreateDestinationPage/components/DestinationForm.tsx
+++ b/airbyte-webapp/src/pages/DestinationPage/pages/CreateDestinationPage/components/DestinationForm.tsx
@@ -5,7 +5,7 @@ import { ConnectionConfiguration } from "core/domain/connection";
 import { DestinationDefinitionRead } from "core/request/AirbyteClient";
 import { LogsRequestError } from "core/request/LogsRequestError";
 import useRouter from "hooks/useRouter";
-import { LegacyTrackActionType, TrackActionActions, TrackActionNamespace, useTrackAction } from "hooks/useTrackAction";
+import { TrackActionLegacyType, TrackActionType, TrackActionNamespace, useTrackAction } from "hooks/useTrackAction";
 import { useGetDestinationDefinitionSpecificationAsync } from "services/connector/DestinationDefinitionSpecificationService";
 import { createFormErrorMessage } from "utils/errorStatusMessage";
 import { ConnectorCard } from "views/Connector/ConnectorCard";
@@ -41,7 +41,7 @@ export const DestinationForm: React.FC<DestinationFormProps> = ({
   const { location } = useRouter();
   const trackNewDestinationAction = useTrackAction(
     TrackActionNamespace.DESTINATION,
-    LegacyTrackActionType.NEW_DESTINATION
+    TrackActionLegacyType.NEW_DESTINATION
   );
 
   const [destinationDefinitionId, setDestinationDefinitionId] = useState(
@@ -63,7 +63,7 @@ export const DestinationForm: React.FC<DestinationFormProps> = ({
       afterSelectConnector();
     }
 
-    trackNewDestinationAction("Select a connector", TrackActionActions.SELECT, {
+    trackNewDestinationAction("Select a connector", TrackActionType.SELECT, {
       connector_destination: connector?.name,
       connector_destination_definition_id: destinationDefinitionId,
     });

--- a/airbyte-webapp/src/pages/DestinationPage/pages/CreateDestinationPage/components/DestinationForm.tsx
+++ b/airbyte-webapp/src/pages/DestinationPage/pages/CreateDestinationPage/components/DestinationForm.tsx
@@ -63,7 +63,7 @@ export const DestinationForm: React.FC<DestinationFormProps> = ({
       afterSelectConnector();
     }
 
-    trackNewDestinationAction("Select a connector", [TrackActionActions.SELECT], {
+    trackNewDestinationAction("Select a connector", TrackActionActions.SELECT, {
       connector_destination: connector?.name,
       connector_destination_definition_id: destinationDefinitionId,
     });

--- a/airbyte-webapp/src/pages/DestinationPage/pages/CreateDestinationPage/components/DestinationForm.tsx
+++ b/airbyte-webapp/src/pages/DestinationPage/pages/CreateDestinationPage/components/DestinationForm.tsx
@@ -5,7 +5,7 @@ import { ConnectionConfiguration } from "core/domain/connection";
 import { DestinationDefinitionRead } from "core/request/AirbyteClient";
 import { LogsRequestError } from "core/request/LogsRequestError";
 import useRouter from "hooks/useRouter";
-import { TrackActionType, useTrackAction } from "hooks/useTrackAction";
+import { LegacyTrackActionType, TrackActionActions, TrackActionNamespace, useTrackAction } from "hooks/useTrackAction";
 import { useGetDestinationDefinitionSpecificationAsync } from "services/connector/DestinationDefinitionSpecificationService";
 import { createFormErrorMessage } from "utils/errorStatusMessage";
 import { ConnectorCard } from "views/Connector/ConnectorCard";
@@ -39,7 +39,10 @@ export const DestinationForm: React.FC<DestinationFormProps> = ({
   afterSelectConnector,
 }) => {
   const { location } = useRouter();
-  const trackNewDestinationAction = useTrackAction(TrackActionType.NEW_DESTINATION);
+  const trackNewDestinationAction = useTrackAction(
+    TrackActionNamespace.DESTINATION,
+    LegacyTrackActionType.NEW_DESTINATION
+  );
 
   const [destinationDefinitionId, setDestinationDefinitionId] = useState(
     hasDestinationDefinitionId(location.state) ? location.state.destinationDefinitionId : null
@@ -60,7 +63,7 @@ export const DestinationForm: React.FC<DestinationFormProps> = ({
       afterSelectConnector();
     }
 
-    trackNewDestinationAction("Select a connector", {
+    trackNewDestinationAction("Select a connector", [TrackActionActions.SELECT], {
       connector_destination: connector?.name,
       connector_destination_definition_id: destinationDefinitionId,
     });

--- a/airbyte-webapp/src/pages/OnboardingPage/components/DestinationStep.tsx
+++ b/airbyte-webapp/src/pages/OnboardingPage/components/DestinationStep.tsx
@@ -75,7 +75,7 @@ const DestinationStep: React.FC<Props> = ({ onNextStep, onSuccess }) => {
     const destinationConnector = getDestinationDefinitionById(destinationDefinitionId);
     setDocumentationUrl(destinationConnector?.documentationUrl || "");
 
-    trackNewDestinationAction("Select a connector", [TrackActionActions.SELECT], {
+    trackNewDestinationAction("Select a connector", TrackActionActions.SELECT, {
       connector_destination: destinationConnector?.name,
       connector_destination_definition_id: destinationConnector?.destinationDefinitionId,
     });

--- a/airbyte-webapp/src/pages/OnboardingPage/components/DestinationStep.tsx
+++ b/airbyte-webapp/src/pages/OnboardingPage/components/DestinationStep.tsx
@@ -3,7 +3,7 @@ import React, { useEffect, useState } from "react";
 import { ConnectionConfiguration } from "core/domain/connection";
 import { JobInfo } from "core/domain/job";
 import { useCreateDestination } from "hooks/services/useDestinationHook";
-import { TrackActionType, useTrackAction } from "hooks/useTrackAction";
+import { LegacyTrackActionType, TrackActionActions, TrackActionNamespace, useTrackAction } from "hooks/useTrackAction";
 import { useDestinationDefinitionList } from "services/connector/DestinationDefinitionService";
 import { useGetDestinationDefinitionSpecificationAsync } from "services/connector/DestinationDefinitionSpecificationService";
 import { createFormErrorMessage } from "utils/errorStatusMessage";
@@ -29,7 +29,11 @@ const DestinationStep: React.FC<Props> = ({ onNextStep, onSuccess }) => {
   } | null>(null);
 
   const { mutateAsync: createDestination } = useCreateDestination();
-  const trackNewDestinationAction = useTrackAction(TrackActionType.NEW_DESTINATION);
+
+  const trackNewDestinationAction = useTrackAction(
+    TrackActionNamespace.DESTINATION,
+    LegacyTrackActionType.NEW_DESTINATION
+  );
 
   const getDestinationDefinitionById = (id: string) =>
     destinationDefinitions.find((item) => item.destinationDefinitionId === id);
@@ -71,7 +75,7 @@ const DestinationStep: React.FC<Props> = ({ onNextStep, onSuccess }) => {
     const destinationConnector = getDestinationDefinitionById(destinationDefinitionId);
     setDocumentationUrl(destinationConnector?.documentationUrl || "");
 
-    trackNewDestinationAction("Select a connector", {
+    trackNewDestinationAction("Select a connector", [TrackActionActions.SELECT], {
       connector_destination: destinationConnector?.name,
       connector_destination_definition_id: destinationConnector?.destinationDefinitionId,
     });

--- a/airbyte-webapp/src/pages/OnboardingPage/components/DestinationStep.tsx
+++ b/airbyte-webapp/src/pages/OnboardingPage/components/DestinationStep.tsx
@@ -3,7 +3,7 @@ import React, { useEffect, useState } from "react";
 import { ConnectionConfiguration } from "core/domain/connection";
 import { JobInfo } from "core/domain/job";
 import { useCreateDestination } from "hooks/services/useDestinationHook";
-import { LegacyTrackActionType, TrackActionActions, TrackActionNamespace, useTrackAction } from "hooks/useTrackAction";
+import { TrackActionLegacyType, TrackActionType, TrackActionNamespace, useTrackAction } from "hooks/useTrackAction";
 import { useDestinationDefinitionList } from "services/connector/DestinationDefinitionService";
 import { useGetDestinationDefinitionSpecificationAsync } from "services/connector/DestinationDefinitionSpecificationService";
 import { createFormErrorMessage } from "utils/errorStatusMessage";
@@ -32,7 +32,7 @@ const DestinationStep: React.FC<Props> = ({ onNextStep, onSuccess }) => {
 
   const trackNewDestinationAction = useTrackAction(
     TrackActionNamespace.DESTINATION,
-    LegacyTrackActionType.NEW_DESTINATION
+    TrackActionLegacyType.NEW_DESTINATION
   );
 
   const getDestinationDefinitionById = (id: string) =>
@@ -75,7 +75,7 @@ const DestinationStep: React.FC<Props> = ({ onNextStep, onSuccess }) => {
     const destinationConnector = getDestinationDefinitionById(destinationDefinitionId);
     setDocumentationUrl(destinationConnector?.documentationUrl || "");
 
-    trackNewDestinationAction("Select a connector", TrackActionActions.SELECT, {
+    trackNewDestinationAction("Select a connector", TrackActionType.SELECT, {
       connector_destination: destinationConnector?.name,
       connector_destination_definition_id: destinationConnector?.destinationDefinitionId,
     });

--- a/airbyte-webapp/src/pages/OnboardingPage/components/SourceStep.tsx
+++ b/airbyte-webapp/src/pages/OnboardingPage/components/SourceStep.tsx
@@ -4,7 +4,7 @@ import { ConnectionConfiguration } from "core/domain/connection";
 import { JobInfo } from "core/domain/job";
 import { LogsRequestError } from "core/request/LogsRequestError";
 import { useCreateSource } from "hooks/services/useSourceHook";
-import { TrackActionType, useTrackAction } from "hooks/useTrackAction";
+import { LegacyTrackActionType, TrackActionActions, TrackActionNamespace, useTrackAction } from "hooks/useTrackAction";
 import { useSourceDefinitionList } from "services/connector/SourceDefinitionService";
 import { useGetSourceDefinitionSpecificationAsync } from "services/connector/SourceDefinitionSpecificationService";
 import { createFormErrorMessage } from "utils/errorStatusMessage";
@@ -29,7 +29,7 @@ const SourceStep: React.FC<SourcesStepProps> = ({ onNextStep, onSuccess }) => {
   const { setDocumentationUrl, setDocumentationPanelOpen } = useDocumentationPanelContext();
   const { mutateAsync: createSource } = useCreateSource();
 
-  const trackNewSourceAction = useTrackAction(TrackActionType.NEW_SOURCE);
+  const trackNewSourceAction = useTrackAction(TrackActionNamespace.SOURCE, LegacyTrackActionType.NEW_SOURCE);
 
   const getSourceDefinitionById = (id: string) => sourceDefinitions.find((item) => item.sourceDefinitionId === id);
 
@@ -74,7 +74,8 @@ const SourceStep: React.FC<SourcesStepProps> = ({ onNextStep, onSuccess }) => {
     setDocumentationPanelOpen(false);
     const sourceDefinition = getSourceDefinitionById(sourceId);
     setDocumentationUrl(sourceDefinition?.documentationUrl || "");
-    trackNewSourceAction("Select a connector", {
+
+    trackNewSourceAction("Select a connector", [TrackActionActions.SELECT], {
       connector_source: sourceDefinition?.name,
       connector_source_definition_id: sourceDefinition?.sourceDefinitionId,
     });

--- a/airbyte-webapp/src/pages/OnboardingPage/components/SourceStep.tsx
+++ b/airbyte-webapp/src/pages/OnboardingPage/components/SourceStep.tsx
@@ -75,7 +75,7 @@ const SourceStep: React.FC<SourcesStepProps> = ({ onNextStep, onSuccess }) => {
     const sourceDefinition = getSourceDefinitionById(sourceId);
     setDocumentationUrl(sourceDefinition?.documentationUrl || "");
 
-    trackNewSourceAction("Select a connector", [TrackActionActions.SELECT], {
+    trackNewSourceAction("Select a connector", TrackActionActions.SELECT, {
       connector_source: sourceDefinition?.name,
       connector_source_definition_id: sourceDefinition?.sourceDefinitionId,
     });

--- a/airbyte-webapp/src/pages/OnboardingPage/components/SourceStep.tsx
+++ b/airbyte-webapp/src/pages/OnboardingPage/components/SourceStep.tsx
@@ -4,7 +4,7 @@ import { ConnectionConfiguration } from "core/domain/connection";
 import { JobInfo } from "core/domain/job";
 import { LogsRequestError } from "core/request/LogsRequestError";
 import { useCreateSource } from "hooks/services/useSourceHook";
-import { LegacyTrackActionType, TrackActionActions, TrackActionNamespace, useTrackAction } from "hooks/useTrackAction";
+import { TrackActionLegacyType, TrackActionType, TrackActionNamespace, useTrackAction } from "hooks/useTrackAction";
 import { useSourceDefinitionList } from "services/connector/SourceDefinitionService";
 import { useGetSourceDefinitionSpecificationAsync } from "services/connector/SourceDefinitionSpecificationService";
 import { createFormErrorMessage } from "utils/errorStatusMessage";
@@ -29,7 +29,7 @@ const SourceStep: React.FC<SourcesStepProps> = ({ onNextStep, onSuccess }) => {
   const { setDocumentationUrl, setDocumentationPanelOpen } = useDocumentationPanelContext();
   const { mutateAsync: createSource } = useCreateSource();
 
-  const trackNewSourceAction = useTrackAction(TrackActionNamespace.SOURCE, LegacyTrackActionType.NEW_SOURCE);
+  const trackNewSourceAction = useTrackAction(TrackActionNamespace.SOURCE, TrackActionLegacyType.NEW_SOURCE);
 
   const getSourceDefinitionById = (id: string) => sourceDefinitions.find((item) => item.sourceDefinitionId === id);
 
@@ -75,7 +75,7 @@ const SourceStep: React.FC<SourcesStepProps> = ({ onNextStep, onSuccess }) => {
     const sourceDefinition = getSourceDefinitionById(sourceId);
     setDocumentationUrl(sourceDefinition?.documentationUrl || "");
 
-    trackNewSourceAction("Select a connector", TrackActionActions.SELECT, {
+    trackNewSourceAction("Select a connector", TrackActionType.SELECT, {
       connector_source: sourceDefinition?.name,
       connector_source_definition_id: sourceDefinition?.sourceDefinitionId,
     });

--- a/airbyte-webapp/src/pages/SourcesPage/pages/CreateSourcePage/components/SourceForm.tsx
+++ b/airbyte-webapp/src/pages/SourcesPage/pages/CreateSourcePage/components/SourceForm.tsx
@@ -60,7 +60,7 @@ export const SourceForm: React.FC<SourceFormProps> = ({
     if (afterSelectConnector) {
       afterSelectConnector();
     }
-    trackNewSourceAction("Select a connector", [TrackActionActions.SELECT], {
+    trackNewSourceAction("Select a connector", TrackActionActions.SELECT, {
       connector_source: connector?.name,
       connector_source_definition_id: sourceDefinitionId,
     });

--- a/airbyte-webapp/src/pages/SourcesPage/pages/CreateSourcePage/components/SourceForm.tsx
+++ b/airbyte-webapp/src/pages/SourcesPage/pages/CreateSourcePage/components/SourceForm.tsx
@@ -4,7 +4,7 @@ import { FormattedMessage } from "react-intl";
 import { ConnectionConfiguration } from "core/domain/connection";
 import { LogsRequestError } from "core/request/LogsRequestError";
 import useRouter from "hooks/useRouter";
-import { TrackActionType, useTrackAction } from "hooks/useTrackAction";
+import { LegacyTrackActionType, TrackActionActions, TrackActionNamespace, useTrackAction } from "hooks/useTrackAction";
 import { SourceDefinitionReadWithLatestTag } from "services/connector/SourceDefinitionService";
 import { useGetSourceDefinitionSpecificationAsync } from "services/connector/SourceDefinitionSpecificationService";
 import { createFormErrorMessage } from "utils/errorStatusMessage";
@@ -40,7 +40,7 @@ export const SourceForm: React.FC<SourceFormProps> = ({
   afterSelectConnector,
 }) => {
   const { location } = useRouter();
-  const trackNewSourceAction = useTrackAction(TrackActionType.NEW_SOURCE);
+  const trackNewSourceAction = useTrackAction(TrackActionNamespace.SOURCE, LegacyTrackActionType.NEW_SOURCE);
 
   const [sourceDefinitionId, setSourceDefinitionId] = useState<string | null>(
     hasSourceDefinitionId(location.state) ? location.state.sourceDefinitionId : null
@@ -60,8 +60,7 @@ export const SourceForm: React.FC<SourceFormProps> = ({
     if (afterSelectConnector) {
       afterSelectConnector();
     }
-
-    trackNewSourceAction("Select a connector", {
+    trackNewSourceAction("Select a connector", [TrackActionActions.SELECT], {
       connector_source: connector?.name,
       connector_source_definition_id: sourceDefinitionId,
     });

--- a/airbyte-webapp/src/pages/SourcesPage/pages/CreateSourcePage/components/SourceForm.tsx
+++ b/airbyte-webapp/src/pages/SourcesPage/pages/CreateSourcePage/components/SourceForm.tsx
@@ -4,7 +4,7 @@ import { FormattedMessage } from "react-intl";
 import { ConnectionConfiguration } from "core/domain/connection";
 import { LogsRequestError } from "core/request/LogsRequestError";
 import useRouter from "hooks/useRouter";
-import { LegacyTrackActionType, TrackActionActions, TrackActionNamespace, useTrackAction } from "hooks/useTrackAction";
+import { TrackActionLegacyType, TrackActionType, TrackActionNamespace, useTrackAction } from "hooks/useTrackAction";
 import { SourceDefinitionReadWithLatestTag } from "services/connector/SourceDefinitionService";
 import { useGetSourceDefinitionSpecificationAsync } from "services/connector/SourceDefinitionSpecificationService";
 import { createFormErrorMessage } from "utils/errorStatusMessage";
@@ -40,7 +40,7 @@ export const SourceForm: React.FC<SourceFormProps> = ({
   afterSelectConnector,
 }) => {
   const { location } = useRouter();
-  const trackNewSourceAction = useTrackAction(TrackActionNamespace.SOURCE, LegacyTrackActionType.NEW_SOURCE);
+  const trackNewSourceAction = useTrackAction(TrackActionNamespace.SOURCE, TrackActionLegacyType.NEW_SOURCE);
 
   const [sourceDefinitionId, setSourceDefinitionId] = useState<string | null>(
     hasSourceDefinitionId(location.state) ? location.state.sourceDefinitionId : null
@@ -60,7 +60,7 @@ export const SourceForm: React.FC<SourceFormProps> = ({
     if (afterSelectConnector) {
       afterSelectConnector();
     }
-    trackNewSourceAction("Select a connector", TrackActionActions.SELECT, {
+    trackNewSourceAction("Select a connector", TrackActionType.SELECT, {
       connector_source: connector?.name,
       connector_source_definition_id: sourceDefinitionId,
     });

--- a/airbyte-webapp/src/views/Connector/ConnectorCard/ConnectorCard.tsx
+++ b/airbyte-webapp/src/views/Connector/ConnectorCard/ConnectorCard.tsx
@@ -7,7 +7,7 @@ import { JobItem } from "components/JobItem/JobItem";
 import { Connector, ConnectorT } from "core/domain/connector";
 import { CheckConnectionRead } from "core/request/AirbyteClient";
 import { LogsRequestError, SynchronousJobReadWithStatus } from "core/request/LogsRequestError";
-import { LegacyTrackActionType, TrackActionActions, TrackActionNamespace, useTrackAction } from "hooks/useTrackAction";
+import { TrackActionLegacyType, TrackActionType, TrackActionNamespace, useTrackAction } from "hooks/useTrackAction";
 import { createFormErrorMessage } from "utils/errorStatusMessage";
 import { ServiceForm, ServiceFormProps, ServiceFormValues } from "views/Connector/ServiceForm";
 
@@ -45,10 +45,10 @@ export const ConnectorCard: React.FC<
     setErrorStatusRequest(null);
   }, [props.selectedConnectorDefinitionSpecification, reset]);
 
-  const trackNewSourceAction = useTrackAction(TrackActionNamespace.SOURCE, LegacyTrackActionType.NEW_SOURCE);
+  const trackNewSourceAction = useTrackAction(TrackActionNamespace.SOURCE, TrackActionLegacyType.NEW_SOURCE);
   const trackNewDestinationAction = useTrackAction(
     TrackActionNamespace.DESTINATION,
-    LegacyTrackActionType.NEW_DESTINATION
+    TrackActionLegacyType.NEW_DESTINATION
   );
 
   const onHandleSubmit = async (values: ServiceFormValues) => {
@@ -56,7 +56,7 @@ export const ConnectorCard: React.FC<
 
     const connector = props.availableServices.find((item) => Connector.id(item) === values.serviceType);
 
-    const trackAction = (action: string, actionType: TrackActionActions) => {
+    const trackAction = (action: string, actionType: TrackActionType) => {
       if (!connector) {
         return;
       }
@@ -75,12 +75,12 @@ export const ConnectorCard: React.FC<
     };
 
     const testConnectorWithTracking = async () => {
-      trackAction("Test a connector", TrackActionActions.TEST);
+      trackAction("Test a connector", TrackActionType.TEST);
       try {
         await testConnector(values);
-        trackAction("Tested connector - success", TrackActionActions.SUCCESS);
+        trackAction("Tested connector - success", TrackActionType.SUCCESS);
       } catch (e) {
-        trackAction("Tested connector - failure", TrackActionActions.FAILURE);
+        trackAction("Tested connector - failure", TrackActionType.FAILURE);
         throw e;
       }
     };

--- a/airbyte-webapp/src/views/Connector/ConnectorCard/ConnectorCard.tsx
+++ b/airbyte-webapp/src/views/Connector/ConnectorCard/ConnectorCard.tsx
@@ -56,18 +56,18 @@ export const ConnectorCard: React.FC<
 
     const connector = props.availableServices.find((item) => Connector.id(item) === values.serviceType);
 
-    const trackAction = (action: string, actionTypes: TrackActionActions[]) => {
+    const trackAction = (action: string, actionType: TrackActionActions) => {
       if (!connector) {
         return;
       }
 
       if (props.formType === "source") {
-        trackNewSourceAction(action, actionTypes, {
+        trackNewSourceAction(action, actionType, {
           connector_source: connector?.name,
           connector_source_definition_id: Connector.id(connector),
         });
       } else {
-        trackNewDestinationAction(action, actionTypes, {
+        trackNewDestinationAction(action, actionType, {
           connector_destination: connector?.name,
           connector_destination_definition_id: Connector.id(connector),
         });
@@ -75,12 +75,12 @@ export const ConnectorCard: React.FC<
     };
 
     const testConnectorWithTracking = async () => {
-      trackAction("Test a connector", [TrackActionActions.TEST]);
+      trackAction("Test a connector", TrackActionActions.TEST);
       try {
         await testConnector(values);
-        trackAction("Tested connector - success", [TrackActionActions.TEST, TrackActionActions.SUCCESS]);
+        trackAction("Tested connector - success", TrackActionActions.SUCCESS);
       } catch (e) {
-        trackAction("Tested connector - failure", [TrackActionActions.TEST, TrackActionActions.FAILURE]);
+        trackAction("Tested connector - failure", TrackActionActions.FAILURE);
         throw e;
       }
     };


### PR DESCRIPTION
## What
closes #10954

Applies a more unified naming format to our segment calls.  This naming format will be mirrored/extended on the backend as well.  The new hook also adds some better checks for parameters around some of our calls.

## How
All Segment calls for Sources, Destinations, and Connections in the front end now use the `useTrackAction` hook.  

The hook is initiated with the namespace and "legacy name" of the call.  When the hook is implemented, it passes the human-readable action and the rest of the call body.  The hook merges this together and generates the Segment call.

The objects being sent are now in the format:

```
Airbyte.UI.${NAMESPACE}.${ACTION} , { 
  action: "a human-friendly description of the action"
  legacy_name: //whatever we called this call before... usually something like "New Source - Action"
  ...all the rest of the data
}

//NOTE: sometimes Action is nested (ie: `Airbyte.UI.Source.Test.Success`), hence why we use an array
```

## Recommended reading order
1. `useTrackAction.tsx`
2. others
