### PR TITLE
Emit orphan running jobs metrics

### DIFF
--- a/airbyte-metrics/metrics-lib/src/main/java/io/airbyte/metrics/lib/OssMetricsRegistry.java
+++ b/airbyte-metrics/metrics-lib/src/main/java/io/airbyte/metrics/lib/OssMetricsRegistry.java
@@ -79,6 +79,10 @@ public enum OssMetricsRegistry implements MetricsRegistry {
       MetricEmittingApps.METRICS_REPORTER,
       "num_running_jobs",
       "number of running jobs"),
+  NUM_ORPHAN_RUNNING_JOBS(
+      MetricEmittingApps.METRICS_REPORTER,
+      "num_orphan_running_jobs",
+      "number of jobs reported as running that as associated to connection inactive or deprecated"),
   NUM_ACTIVE_CONN_PER_WORKSPACE(
       MetricEmittingApps.METRICS_REPORTER,
       "num_active_conn_per_workspace",

--- a/airbyte-metrics/reporter/src/main/java/io/airbyte/metrics/reporter/ToEmit.java
+++ b/airbyte-metrics/reporter/src/main/java/io/airbyte/metrics/reporter/ToEmit.java
@@ -30,6 +30,10 @@ public enum ToEmit {
     final var runningJobs = ReporterApp.configDatabase.query(MetricQueries::numberOfRunningJobs);
     MetricClientFactory.getMetricClient().gauge(OssMetricsRegistry.NUM_RUNNING_JOBS, runningJobs);
   })),
+  NUM_ORPHAN_RUNNING_JOB(countMetricEmission(() -> {
+    final var orphanRunningJobs = ReporterApp.configDatabase.query(MetricQueries::numberOfOrphanRunningJobs);
+    MetricClientFactory.getMetricClient().gauge(OssMetricsRegistry.NUM_ORPHAN_RUNNING_JOBS, orphanRunningJobs);
+  })),
   OLDEST_RUNNING_JOB_AGE_SECS(countMetricEmission(() -> {
     final var age = ReporterApp.configDatabase.query(MetricQueries::oldestRunningJobAgeSecs);
     MetricClientFactory.getMetricClient().gauge(OssMetricsRegistry.OLDEST_RUNNING_JOB_AGE_SECS, age);


### PR DESCRIPTION
That metrics show the number of jobs currently flagged as running that
are associated to inactive or deprecated connections.

Follow up on https://github.com/airbytehq/airbyte/pull/13833 to ensure the new metric is regularly reported.