### PR TITLE
Persist state to reset connection job config

### DIFF
--- a/airbyte-config/config-models/src/main/resources/types/JobResetConnectionConfig.yaml
+++ b/airbyte-config/config-models/src/main/resources/types/JobResetConnectionConfig.yaml
@@ -41,3 +41,6 @@ properties:
     existingJavaType: io.airbyte.config.ResourceRequirements
   resetSourceConfiguration:
     "$ref": ResetSourceConfiguration.yaml
+  state:
+    description: optional current state of the connection
+    "$ref": State.yaml

--- a/airbyte-scheduler/scheduler-persistence/src/main/java/io/airbyte/scheduler/persistence/DefaultJobCreator.java
+++ b/airbyte-scheduler/scheduler-persistence/src/main/java/io/airbyte/scheduler/persistence/DefaultJobCreator.java
@@ -127,7 +127,7 @@ public class DefaultJobCreator implements JobCreator {
   }
 
   // TODO (https://github.com/airbytehq/airbyte/issues/13620): update this method implementation
-  //  to fetch and serialize the new per-stream state format into a State object
+  // to fetch and serialize the new per-stream state format into a State object
   private Optional<State> getCurrentConnectionState(final UUID connectionId) throws IOException {
     return configRepository.getConnectionState(connectionId);
   }

--- a/airbyte-scheduler/scheduler-persistence/src/main/java/io/airbyte/scheduler/persistence/DefaultJobCreator.java
+++ b/airbyte-scheduler/scheduler-persistence/src/main/java/io/airbyte/scheduler/persistence/DefaultJobCreator.java
@@ -16,6 +16,7 @@ import io.airbyte.config.ResourceRequirements;
 import io.airbyte.config.SourceConnection;
 import io.airbyte.config.StandardSync;
 import io.airbyte.config.StandardSyncOperation;
+import io.airbyte.config.State;
 import io.airbyte.config.StreamDescriptor;
 import io.airbyte.config.persistence.ConfigRepository;
 import io.airbyte.protocol.models.ConfiguredAirbyteCatalog;
@@ -24,6 +25,7 @@ import io.airbyte.protocol.models.SyncMode;
 import java.io.IOException;
 import java.util.List;
 import java.util.Optional;
+import java.util.UUID;
 import javax.annotation.Nullable;
 
 public class DefaultJobCreator implements JobCreator {
@@ -76,7 +78,7 @@ public class DefaultJobCreator implements JobCreator {
             workerResourceRequirements,
             JobType.SYNC));
 
-    configRepository.getConnectionState(standardSync.getConnectionId()).ifPresent(jobSyncConfig::withState);
+    getCurrentConnectionState(standardSync.getConnectionId()).ifPresent(jobSyncConfig::withState);
 
     final JobConfig jobConfig = new JobConfig()
         .withConfigType(ConfigType.SYNC)
@@ -116,10 +118,18 @@ public class DefaultJobCreator implements JobCreator {
             workerResourceRequirements))
         .withResetSourceConfiguration(new ResetSourceConfiguration().withStreamsToReset(streamsToReset));
 
+    getCurrentConnectionState(standardSync.getConnectionId()).ifPresent(resetConnectionConfig::withState);
+
     final JobConfig jobConfig = new JobConfig()
         .withConfigType(ConfigType.RESET_CONNECTION)
         .withResetConnection(resetConnectionConfig);
     return jobPersistence.enqueueJob(standardSync.getConnectionId().toString(), jobConfig);
+  }
+
+  // TODO (https://github.com/airbytehq/airbyte/issues/13620): update this method implementation
+  //  to fetch and serialize the new per-stream state format into a State object
+  private Optional<State> getCurrentConnectionState(final UUID connectionId) throws IOException {
+    return configRepository.getConnectionState(connectionId);
   }
 
 }

--- a/airbyte-scheduler/scheduler-persistence/src/test/java/io/airbyte/scheduler/persistence/DefaultJobCreatorTest.java
+++ b/airbyte-scheduler/scheduler-persistence/src/test/java/io/airbyte/scheduler/persistence/DefaultJobCreatorTest.java
@@ -31,6 +31,7 @@ import io.airbyte.config.SourceConnection;
 import io.airbyte.config.StandardSync;
 import io.airbyte.config.StandardSyncOperation;
 import io.airbyte.config.StandardSyncOperation.OperatorType;
+import io.airbyte.config.State;
 import io.airbyte.config.StreamDescriptor;
 import io.airbyte.config.persistence.ConfigRepository;
 import io.airbyte.protocol.models.CatalogHelpers;
@@ -42,6 +43,7 @@ import io.airbyte.protocol.models.JsonSchemaType;
 import java.io.IOException;
 import java.util.Collections;
 import java.util.List;
+import java.util.Map;
 import java.util.Optional;
 import java.util.UUID;
 import org.junit.jupiter.api.BeforeEach;
@@ -333,6 +335,9 @@ public class DefaultJobCreatorTest {
           configuredAirbyteStream.setDestinationSyncMode(DestinationSyncMode.OVERWRITE);
         });
 
+    final State connectionState = new State().withState(Jsons.jsonNode(Map.of("key", "val")));
+    when(configRepository.getConnectionState(STANDARD_SYNC.getConnectionId())).thenReturn(Optional.of(connectionState));
+
     final JobResetConnectionConfig JobResetConnectionConfig = new JobResetConnectionConfig()
         .withNamespaceDefinition(STANDARD_SYNC.getNamespaceDefinition())
         .withNamespaceFormat(STANDARD_SYNC.getNamespaceFormat())
@@ -342,7 +347,8 @@ public class DefaultJobCreatorTest {
         .withConfiguredAirbyteCatalog(expectedCatalog)
         .withOperationSequence(List.of(STANDARD_SYNC_OPERATION))
         .withResourceRequirements(workerResourceRequirements)
-        .withResetSourceConfiguration(new ResetSourceConfiguration().withStreamsToReset(List.of(STREAM_DESCRIPTOR1, STREAM_DESCRIPTOR2)));
+        .withResetSourceConfiguration(new ResetSourceConfiguration().withStreamsToReset(List.of(STREAM_DESCRIPTOR1, STREAM_DESCRIPTOR2)))
+        .withState(connectionState);
 
     final JobConfig jobConfig = new JobConfig()
         .withConfigType(ConfigType.RESET_CONNECTION)
@@ -351,13 +357,16 @@ public class DefaultJobCreatorTest {
     final String expectedScope = STANDARD_SYNC.getConnectionId().toString();
     when(jobPersistence.enqueueJob(expectedScope, jobConfig)).thenReturn(Optional.of(JOB_ID));
 
-    final long jobId = jobCreator.createResetConnectionJob(
+    final Optional<Long> jobId = jobCreator.createResetConnectionJob(
         DESTINATION_CONNECTION,
         STANDARD_SYNC,
         DESTINATION_IMAGE_NAME,
         List.of(STANDARD_SYNC_OPERATION),
-        List.of(STREAM_DESCRIPTOR1, STREAM_DESCRIPTOR2)).orElseThrow();
-    assertEquals(JOB_ID, jobId);
+        List.of(STREAM_DESCRIPTOR1, STREAM_DESCRIPTOR2));
+
+    verify(jobPersistence).enqueueJob(expectedScope, jobConfig);
+    assertTrue(jobId.isPresent());
+    assertEquals(JOB_ID, jobId.get());
   }
 
   @Test
@@ -369,6 +378,9 @@ public class DefaultJobCreatorTest {
           configuredAirbyteStream.setDestinationSyncMode(DestinationSyncMode.OVERWRITE);
         });
 
+    final State connectionState = new State().withState(Jsons.jsonNode(Map.of("key", "val")));
+    when(configRepository.getConnectionState(STANDARD_SYNC.getConnectionId())).thenReturn(Optional.of(connectionState));
+
     final JobResetConnectionConfig JobResetConnectionConfig = new JobResetConnectionConfig()
         .withNamespaceDefinition(STANDARD_SYNC.getNamespaceDefinition())
         .withNamespaceFormat(STANDARD_SYNC.getNamespaceFormat())
@@ -378,7 +390,8 @@ public class DefaultJobCreatorTest {
         .withConfiguredAirbyteCatalog(expectedCatalog)
         .withOperationSequence(List.of(STANDARD_SYNC_OPERATION))
         .withResourceRequirements(workerResourceRequirements)
-        .withResetSourceConfiguration(new ResetSourceConfiguration().withStreamsToReset(List.of(STREAM_DESCRIPTOR1, STREAM_DESCRIPTOR2)));
+        .withResetSourceConfiguration(new ResetSourceConfiguration().withStreamsToReset(List.of(STREAM_DESCRIPTOR1, STREAM_DESCRIPTOR2)))
+        .withState(connectionState);
 
     final JobConfig jobConfig = new JobConfig()
         .withConfigType(ConfigType.RESET_CONNECTION)
@@ -387,12 +400,15 @@ public class DefaultJobCreatorTest {
     final String expectedScope = STANDARD_SYNC.getConnectionId().toString();
     when(jobPersistence.enqueueJob(expectedScope, jobConfig)).thenReturn(Optional.empty());
 
-    assertTrue(jobCreator.createResetConnectionJob(
+    final Optional<Long> jobId = jobCreator.createResetConnectionJob(
         DESTINATION_CONNECTION,
         STANDARD_SYNC,
         DESTINATION_IMAGE_NAME,
         List.of(STANDARD_SYNC_OPERATION),
-        List.of(STREAM_DESCRIPTOR1, STREAM_DESCRIPTOR2)).isEmpty());
+        List.of(STREAM_DESCRIPTOR1, STREAM_DESCRIPTOR2));
+
+    verify(jobPersistence).enqueueJob(expectedScope, jobConfig);
+    assertTrue(jobId.isEmpty());
   }
 
 }

--- a/airbyte-scheduler/scheduler-persistence/src/test/java/io/airbyte/scheduler/persistence/DefaultJobCreatorTest.java
+++ b/airbyte-scheduler/scheduler-persistence/src/test/java/io/airbyte/scheduler/persistence/DefaultJobCreatorTest.java
@@ -338,7 +338,7 @@ public class DefaultJobCreatorTest {
     final State connectionState = new State().withState(Jsons.jsonNode(Map.of("key", "val")));
     when(configRepository.getConnectionState(STANDARD_SYNC.getConnectionId())).thenReturn(Optional.of(connectionState));
 
-    final JobResetConnectionConfig JobResetConnectionConfig = new JobResetConnectionConfig()
+    final JobResetConnectionConfig jobResetConnectionConfig = new JobResetConnectionConfig()
         .withNamespaceDefinition(STANDARD_SYNC.getNamespaceDefinition())
         .withNamespaceFormat(STANDARD_SYNC.getNamespaceFormat())
         .withPrefix(STANDARD_SYNC.getPrefix())
@@ -352,7 +352,7 @@ public class DefaultJobCreatorTest {
 
     final JobConfig jobConfig = new JobConfig()
         .withConfigType(ConfigType.RESET_CONNECTION)
-        .withResetConnection(JobResetConnectionConfig);
+        .withResetConnection(jobResetConnectionConfig);
 
     final String expectedScope = STANDARD_SYNC.getConnectionId().toString();
     when(jobPersistence.enqueueJob(expectedScope, jobConfig)).thenReturn(Optional.of(JOB_ID));
@@ -381,7 +381,7 @@ public class DefaultJobCreatorTest {
     final State connectionState = new State().withState(Jsons.jsonNode(Map.of("key", "val")));
     when(configRepository.getConnectionState(STANDARD_SYNC.getConnectionId())).thenReturn(Optional.of(connectionState));
 
-    final JobResetConnectionConfig JobResetConnectionConfig = new JobResetConnectionConfig()
+    final JobResetConnectionConfig jobResetConnectionConfig = new JobResetConnectionConfig()
         .withNamespaceDefinition(STANDARD_SYNC.getNamespaceDefinition())
         .withNamespaceFormat(STANDARD_SYNC.getNamespaceFormat())
         .withPrefix(STANDARD_SYNC.getPrefix())
@@ -395,7 +395,7 @@ public class DefaultJobCreatorTest {
 
     final JobConfig jobConfig = new JobConfig()
         .withConfigType(ConfigType.RESET_CONNECTION)
-        .withResetConnection(JobResetConnectionConfig);
+        .withResetConnection(jobResetConnectionConfig);
 
     final String expectedScope = STANDARD_SYNC.getConnectionId().toString();
     when(jobPersistence.enqueueJob(expectedScope, jobConfig)).thenReturn(Optional.empty());

--- a/airbyte-workers/src/main/java/io/airbyte/workers/temporal/scheduling/activities/GenerateInputActivityImpl.java
+++ b/airbyte-workers/src/main/java/io/airbyte/workers/temporal/scheduling/activities/GenerateInputActivityImpl.java
@@ -45,7 +45,8 @@ public class GenerateInputActivityImpl implements GenerateInputActivity {
             .withDestinationConfiguration(resetConnection.getDestinationConfiguration())
             .withConfiguredAirbyteCatalog(resetConnection.getConfiguredAirbyteCatalog())
             .withOperationSequence(resetConnection.getOperationSequence())
-            .withResourceRequirements(resetConnection.getResourceRequirements());
+            .withResourceRequirements(resetConnection.getResourceRequirements())
+            .withState(resetConnection.getState());
       }
 
       final JobRunConfig jobRunConfig = TemporalUtils.createJobRunConfig(jobId, attempt);


### PR DESCRIPTION
## What
In order to implement per-stream reset logic in the EmptyAirbyteSource, the current state of the connection needs to be passed to it. Currently, the current connection state is not being fetched or stored in the Reset Job Config case. This PR adds the logic to do so, so that it is available in the EmptyAirbyteSource.

## How
In the DefaultJobCreator, fetch the current connection state and store it in the JobResetConnectionConfig. Then in the GenerateInputActivity, pass that state over to the StandardSyncInput, which is eventually passed to the EmptyAirbyteSource in the case of a reset.