### PR TITLE
Fix medium and large spacing scss var names

### DIFF
--- a/airbyte-webapp/src/scss/_variables.scss
+++ b/airbyte-webapp/src/scss/_variables.scss
@@ -5,8 +5,8 @@ $border-thick: 2px;
 
 $spacing-xs: 3px;
 $spacing-sm: 5px;
-$spacing-m: 10px;
-$spacing-l: 15px;
+$spacing-md: 10px;
+$spacing-lg: 15px;
 $spacing-xl: 20px;
 $spacing-2xl: 40px;
 $spacing-page-bottom: 150px;


### PR DESCRIPTION
## What
Fixes the naming convention on scss vars for medium and large spacing to follow common convention in other css libraries.
