### PR TITLE
Do not hide unexpected errors in the check connection

### DIFF
--- a/airbyte-workers/src/main/java/io/airbyte/workers/general/DefaultCheckConnectionWorker.java
+++ b/airbyte-workers/src/main/java/io/airbyte/workers/general/DefaultCheckConnectionWorker.java
@@ -14,7 +14,9 @@ import io.airbyte.config.StandardCheckConnectionOutput.Status;
 import io.airbyte.protocol.models.AirbyteConnectionStatus;
 import io.airbyte.protocol.models.AirbyteMessage;
 import io.airbyte.protocol.models.AirbyteMessage.Type;
-import io.airbyte.workers.*;
+import io.airbyte.workers.WorkerConfigs;
+import io.airbyte.workers.WorkerConstants;
+import io.airbyte.workers.WorkerUtils;
 import io.airbyte.workers.exception.WorkerException;
 import io.airbyte.workers.internal.AirbyteStreamFactory;
 import io.airbyte.workers.internal.DefaultAirbyteStreamFactory;
@@ -79,7 +81,7 @@ public class DefaultCheckConnectionWorker implements CheckConnectionWorker {
         LOGGER.debug("Check connection job received output: {}", output);
         return output;
       } else {
-        String message = String.format("Error checking connection, status: %s, exit code: %d", status, exitCode);
+        final String message = String.format("Error checking connection, status: %s, exit code: %d", status, exitCode);
 
         LOGGER.error(message);
         return new StandardCheckConnectionOutput()
@@ -88,10 +90,8 @@ public class DefaultCheckConnectionWorker implements CheckConnectionWorker {
       }
 
     } catch (final Exception e) {
-      LOGGER.error("Error while checking connection: ", e);
-      return new StandardCheckConnectionOutput()
-          .withStatus(Status.FAILED)
-          .withMessage("Error while getting checking connection, because of: " + e.getMessage());
+      LOGGER.error("Unexpected error while checking connection: ", e);
+      throw new WorkerException("Unexpected error while getting checking connection.", e);
     }
   }
 

--- a/airbyte-workers/src/test/java/io/airbyte/workers/general/DefaultCheckConnectionWorkerTest.java
+++ b/airbyte-workers/src/test/java/io/airbyte/workers/general/DefaultCheckConnectionWorkerTest.java
@@ -115,7 +115,6 @@ public class DefaultCheckConnectionWorkerTest {
     doThrow(new RuntimeException()).when(integrationLauncher).check(jobRoot, WorkerConstants.SOURCE_CONFIG_JSON_FILENAME, Jsons.serialize(CREDS));
 
     final DefaultCheckConnectionWorker worker = new DefaultCheckConnectionWorker(workerConfigs, integrationLauncher, failureStreamFactory);
-    final StandardCheckConnectionOutput output = worker.run(input, jobRoot);
 
     assertThrows(WorkerException.class, () -> worker.run(input, jobRoot));
   }

--- a/airbyte-workers/src/test/java/io/airbyte/workers/general/DefaultCheckConnectionWorkerTest.java
+++ b/airbyte-workers/src/test/java/io/airbyte/workers/general/DefaultCheckConnectionWorkerTest.java
@@ -6,6 +6,7 @@ package io.airbyte.workers.general;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.mockito.Mockito.RETURNS_DEEP_STUBS;
 import static org.mockito.Mockito.doThrow;
 import static org.mockito.Mockito.mock;
@@ -116,7 +117,7 @@ public class DefaultCheckConnectionWorkerTest {
     final DefaultCheckConnectionWorker worker = new DefaultCheckConnectionWorker(workerConfigs, integrationLauncher, failureStreamFactory);
     final StandardCheckConnectionOutput output = worker.run(input, jobRoot);
 
-    assertEquals(Status.FAILED, output.getStatus());
+    assertThrows(WorkerException.class, () -> worker.run(input, jobRoot));
   }
 
   @Test


### PR DESCRIPTION
## What
We we silently swallowing RuntimeException and make the check connection to be a fail check connection. This should be considered as what we used to call quarantine so it got properly reported.

This shouldn't be merge before the new quarantine state management.