### PR TITLE
Added Buy Credits section to Managing Airbyte Cloud

### DIFF
--- a/docs/cloud/managing-airbyte-cloud.md
+++ b/docs/cloud/managing-airbyte-cloud.md
@@ -89,8 +89,8 @@ This section guides you through purchasing credits on Airbyte Cloud. An Airbyte 
 
     :::note 
     Purchase limits:
-        * Minimum: 100 credits
-        * Maximum: 999 credits
+    * Minimum: 100 credits
+    * Maximum: 999 credits
     :::
 
     If you would like to purchase 1,000 credits or more at one time, reach out to [Sales](https://airbyte.com/talk-to-sales).
@@ -106,3 +106,4 @@ This section guides you through purchasing credits on Airbyte Cloud. An Airbyte 
      :::note
      Credits expire after one year if they are not used.
      :::
+

--- a/docs/cloud/managing-airbyte-cloud.md
+++ b/docs/cloud/managing-airbyte-cloud.md
@@ -108,4 +108,3 @@ This section guides you through purchasing credits on Airbyte Cloud. An Airbyte 
     Credits expire after one year if they are not used.
     
     :::
-

--- a/docs/cloud/managing-airbyte-cloud.md
+++ b/docs/cloud/managing-airbyte-cloud.md
@@ -70,3 +70,39 @@ Understanding the following limitations will help you better manage Airbyte Clou
 * Size of a single record: 100MB
 * Shortest sync schedule: Every 60 min
 * Schedule accuracy: +/- 30 min
+
+## Buy Credits
+
+This section guides you through purchasing credits on Airbyte Cloud. An Airbyte [credit](https://docs.airbyte.com/cloud/core-concepts/#credits) is a unit of measure used to pay for Airbyte resources when you run a sync. See [Pricing](https://airbyte.com/pricing) for more information.
+
+ To buy credits:
+
+1. On the [Airbyte Cloud](http://cloud.airbyte.io) dashboard, click the **star icon**.
+    
+    The Credits page displays.
+
+2. If you are unsure of how many credits you need, click **Talk to sales** to find the right amount for your team.
+
+3. Click **Buy credits**. The Stripe payment page displays.
+
+4. If you want to change the amount of credits, click Qty **200**. **Update quantity** displays, and you can either type the amount or use minus (**-**) or plus (**+**) to change the quantity. Click **Update**. 
+
+    :::note 
+    Purchase limits:
+        * Minimum: 100 credits
+        * Maximum: 999 credits
+    :::
+
+    If you would like to purchase 1,000 credits or more at one time, reach out to [Sales](https://airbyte.com/talk-to-sales).
+
+5. Fill out the payment information.
+
+6. Click **Pay**.
+    
+    Your payment is processed, and the Credits page displays the updated quantity of credits, total credit usage, and the credit usage per connection. 
+
+    A receipt for your purchase is sent to your email. Invoices are not currently available.
+
+     :::note
+     Credits expire after one year if they are not used.
+     :::

--- a/docs/cloud/managing-airbyte-cloud.md
+++ b/docs/cloud/managing-airbyte-cloud.md
@@ -93,7 +93,7 @@ This section guides you through purchasing credits on Airbyte Cloud. An Airbyte 
     * Maximum: 999 credits
     :::
 
-    If you would like to buy a large amount of credits or a subscription plan, reach out to [Sales](https://airbyte.com/talk-to-sales).
+    To buy more credits or a subscription plan, reach out to [Sales](https://airbyte.com/talk-to-sales).
 
 5. Fill out the payment information.
 

--- a/docs/cloud/managing-airbyte-cloud.md
+++ b/docs/cloud/managing-airbyte-cloud.md
@@ -93,7 +93,7 @@ This section guides you through purchasing credits on Airbyte Cloud. An Airbyte 
     * Maximum: 999 credits
     :::
 
-    If you would like to purchase 1,000 credits or more at one time, reach out to [Sales](https://airbyte.com/talk-to-sales).
+    If you would like to buy a large amount of credits or a subscription plan, reach out to [Sales](https://airbyte.com/talk-to-sales).
 
 5. Fill out the payment information.
 
@@ -101,9 +101,11 @@ This section guides you through purchasing credits on Airbyte Cloud. An Airbyte 
     
     Your payment is processed, and the Credits page displays the updated quantity of credits, total credit usage, and the credit usage per connection. 
 
-    A receipt for your purchase is sent to your email. Invoices are not currently available.
+    A receipt for your purchase is sent to your email. For an invoice, reach out to [ar@airbyte.io](ar@airbyte.io)
 
-     :::note
-     Credits expire after one year if they are not used.
-     :::
+    :::note 
+    
+    Credits expire after one year if they are not used.
+    
+    :::
 

--- a/docs/cloud/managing-airbyte-cloud.md
+++ b/docs/cloud/managing-airbyte-cloud.md
@@ -101,7 +101,7 @@ This section guides you through purchasing credits on Airbyte Cloud. An Airbyte 
     
     Your payment is processed, and the Credits page displays the updated quantity of credits, total credit usage, and the credit usage per connection. 
 
-    A receipt for your purchase is sent to your email. For an invoice, reach out to ar@airbyte.io.
+    A receipt for your purchase is sent to your email. [Email us](mailto:ar@airbyte.io) for an invoice.
 
     :::note 
     

--- a/docs/cloud/managing-airbyte-cloud.md
+++ b/docs/cloud/managing-airbyte-cloud.md
@@ -101,7 +101,7 @@ This section guides you through purchasing credits on Airbyte Cloud. An Airbyte 
     
     Your payment is processed, and the Credits page displays the updated quantity of credits, total credit usage, and the credit usage per connection. 
 
-    A receipt for your purchase is sent to your email. For an invoice, reach out to [ar@airbyte.io](ar@airbyte.io)
+    A receipt for your purchase is sent to your email. For an invoice, reach out to ar@airbyte.io.
 
     :::note 
     


### PR DESCRIPTION
Added the Buy Credits section to the Managing Airbyte Cloud documentation. Instructions on how to purchase Airbyte Credits. Information on credit purchase limits, receipts, invoices, expiration. Includes links to more resources and Sales contact information.


Relates to:
[Documentation issue](https://app.zenhub.com/workspaces/documentation-6266ed73c9cbb400119b1e54/issues/airbytehq/airbyte/12110) 

[airbytehq/airbyte/pull/11506](https://github.com/airbytehq/airbyte/pull/11506)