### PR TITLE
add streams to reset to job info

### DIFF
--- a/airbyte-api/src/main/openapi/config.yaml
+++ b/airbyte-api/src/main/openapi/config.yaml
@@ -3729,7 +3729,12 @@ components:
           format: int64
         status:
           $ref: "#/components/schemas/JobStatus"
-        streams:
+        resetConfig:
+          $ref: "#/components/schemas/ResetConfig"
+    ResetConfig:
+      type: object
+      properties:
+        streamsToReset:
           type: array
           items:
             $ref: "#/components/schemas/StreamDescriptor"

--- a/airbyte-api/src/main/openapi/config.yaml
+++ b/airbyte-api/src/main/openapi/config.yaml
@@ -3733,6 +3733,7 @@ components:
           $ref: "#/components/schemas/ResetConfig"
     ResetConfig:
       type: object
+      description: contains information about how a reset was configured. only populated if the job was a reset.
       properties:
         streamsToReset:
           type: array

--- a/airbyte-protocol/protocol-models/src/main/java/io/airbyte/protocol/models/CatalogHelpers.java
+++ b/airbyte-protocol/protocol-models/src/main/java/io/airbyte/protocol/models/CatalogHelpers.java
@@ -80,7 +80,7 @@ public class CatalogHelpers {
         configuredCatalog.getStreams()
             .stream()
             .map(ConfiguredAirbyteStream::getStream)
-            .collect(Collectors.toList()));
+            .toList());
   }
 
   /**
@@ -122,7 +122,7 @@ public class CatalogHelpers {
   public static List<StreamDescriptor> extractStreamDescriptors(final AirbyteCatalog catalog) {
     return catalog.getStreams()
         .stream()
-        .map(abStream -> new StreamDescriptor().withName(abStream.getName()).withNamespace(abStream.getNamespace()))
+        .map(CatalogHelpers::extractDescriptor)
         .toList();
   }
 
@@ -138,7 +138,7 @@ public class CatalogHelpers {
         .withStreams(catalog.getStreams()
             .stream()
             .map(CatalogHelpers::toDefaultConfiguredStream)
-            .collect(Collectors.toList()));
+            .toList());
   }
 
   public static ConfiguredAirbyteStream toDefaultConfiguredStream(final AirbyteStream stream) {

--- a/airbyte-server/src/main/java/io/airbyte/server/converters/JobConverter.java
+++ b/airbyte-server/src/main/java/io/airbyte/server/converters/JobConverter.java
@@ -100,7 +100,7 @@ public class JobConverter {
    * @return api representation of reset config
    */
   private static Optional<ResetConfig> extractResetConfigIfReset(final Job job) {
-    if (job.getConfigType() == ConfigType.SYNC) {
+    if (job.getConfigType() == ConfigType.RESET_CONNECTION) {
       return Optional.ofNullable(
           new ResetConfig().streamsToReset(job.getConfig().getResetConnection().getResetSourceConfiguration().getStreamsToReset()
               .stream()

--- a/airbyte-server/src/main/java/io/airbyte/server/converters/JobConverter.java
+++ b/airbyte-server/src/main/java/io/airbyte/server/converters/JobConverter.java
@@ -89,7 +89,7 @@ public class JobConverter {
             .createdAt(job.getCreatedAtInSecond())
             .updatedAt(job.getUpdatedAtInSecond())
             .status(Enums.convertTo(job.getStatus(), JobStatus.class)))
-        .attempts(job.getAttempts().stream().map(JobConverter::getAttemptRead).collect(Collectors.toList()));
+        .attempts(job.getAttempts().stream().map(JobConverter::getAttemptRead).toList());
   }
 
   /**

--- a/airbyte-server/src/main/java/io/airbyte/server/converters/ProtocolConverters.java
+++ b/airbyte-server/src/main/java/io/airbyte/server/converters/ProtocolConverters.java
@@ -11,6 +11,10 @@ import io.airbyte.api.model.generated.StreamDescriptor;
  */
 public class ProtocolConverters {
 
+  public static StreamDescriptor streamDescriptorToApi(final io.airbyte.config.StreamDescriptor protocolStreamDescriptor) {
+    return new StreamDescriptor().name(protocolStreamDescriptor.getName()).namespace(protocolStreamDescriptor.getNamespace());
+  }
+
   public static StreamDescriptor streamDescriptorToApi(final io.airbyte.protocol.models.StreamDescriptor protocolStreamDescriptor) {
     return new StreamDescriptor().name(protocolStreamDescriptor.getName()).namespace(protocolStreamDescriptor.getNamespace());
   }

--- a/airbyte-server/src/main/java/io/airbyte/server/handlers/JobHistoryHandler.java
+++ b/airbyte-server/src/main/java/io/airbyte/server/handlers/JobHistoryHandler.java
@@ -137,7 +137,7 @@ public class JobHistoryHandler {
     final DestinationRead destination = getDestinationRead(connection);
     final SourceDefinitionRead sourceDefinitionRead = getSourceDefinitionRead(source);
     final DestinationDefinitionRead destinationDefinitionRead = getDestinationDefinitionRead(destination);
-    final JobDebugRead jobDebugRead = jobConverter.getDebugJobInfoRead(jobInfoRead, sourceDefinitionRead, destinationDefinitionRead, airbyteVersion);
+    final JobDebugRead jobDebugRead = JobConverter.getDebugJobInfoRead(jobInfoRead, sourceDefinitionRead, destinationDefinitionRead, airbyteVersion);
 
     return new JobDebugInfoRead()
         .attempts(jobInfoRead.getAttempts())

--- a/airbyte-server/src/test/java/io/airbyte/server/converters/JobConverterTest.java
+++ b/airbyte-server/src/test/java/io/airbyte/server/converters/JobConverterTest.java
@@ -234,7 +234,7 @@ class JobConverterTest {
 
   // this test intentionally only looks at the reset config as the rest is the same here.
   @Test
-  void testRestIncludesResetConfig() {
+  void testResetJobIncludesResetConfig() {
     final JobConfig resetConfig = new JobConfig()
         .withConfigType(ConfigType.RESET_CONNECTION)
         .withResetConnection(new JobResetConnectionConfig().withResetSourceConfiguration(new ResetSourceConfiguration().withStreamsToReset(List.of(

--- a/docs/reference/api/generated-api-html/index.html
+++ b/docs/reference/api/generated-api-html/index.html
@@ -11637,7 +11637,7 @@ if oauth parameters were contained inside the top level, rootObject=[] If they w
   </div>
   <div class="model">
     <h3><a name="ResetConfig"><code>ResetConfig</code> - </a> <a class="up" href="#__Models">Up</a></h3>
-    <div class='model-description'></div>
+    <div class='model-description'>contains information about how a reset was configured. only populated if the job was a reset.</div>
     <div class="field-items">
       <div class="param">streamsToReset (optional)</div><div class="param-desc"><span class="param-type"><a href="#StreamDescriptor">array[StreamDescriptor]</a></span>  </div>
     </div>  <!-- field-items -->

--- a/docs/reference/api/generated-api-html/index.html
+++ b/docs/reference/api/generated-api-html/index.html
@@ -1145,14 +1145,16 @@ font-style: italic;
   "job" : {
     "createdAt" : 6,
     "configId" : "configId",
-    "streams" : [ {
-      "name" : "name",
-      "namespace" : "namespace"
-    }, {
-      "name" : "name",
-      "namespace" : "namespace"
-    } ],
     "id" : 0,
+    "resetConfig" : {
+      "streamsToReset" : [ {
+        "name" : "name",
+        "namespace" : "namespace"
+      }, {
+        "name" : "name",
+        "namespace" : "namespace"
+      } ]
+    },
     "updatedAt" : 1
   },
   "attempts" : [ {
@@ -1477,14 +1479,16 @@ font-style: italic;
   "job" : {
     "createdAt" : 6,
     "configId" : "configId",
-    "streams" : [ {
-      "name" : "name",
-      "namespace" : "namespace"
-    }, {
-      "name" : "name",
-      "namespace" : "namespace"
-    } ],
     "id" : 0,
+    "resetConfig" : {
+      "streamsToReset" : [ {
+        "name" : "name",
+        "namespace" : "namespace"
+      }, {
+        "name" : "name",
+        "namespace" : "namespace"
+      } ]
+    },
     "updatedAt" : 1
   },
   "attempts" : [ {
@@ -4060,14 +4064,16 @@ font-style: italic;
   "job" : {
     "createdAt" : 6,
     "configId" : "configId",
-    "streams" : [ {
-      "name" : "name",
-      "namespace" : "namespace"
-    }, {
-      "name" : "name",
-      "namespace" : "namespace"
-    } ],
     "id" : 0,
+    "resetConfig" : {
+      "streamsToReset" : [ {
+        "name" : "name",
+        "namespace" : "namespace"
+      }, {
+        "name" : "name",
+        "namespace" : "namespace"
+      } ]
+    },
     "updatedAt" : 1
   },
   "attempts" : [ {
@@ -4462,14 +4468,16 @@ font-style: italic;
   "job" : {
     "createdAt" : 6,
     "configId" : "configId",
-    "streams" : [ {
-      "name" : "name",
-      "namespace" : "namespace"
-    }, {
-      "name" : "name",
-      "namespace" : "namespace"
-    } ],
     "id" : 0,
+    "resetConfig" : {
+      "streamsToReset" : [ {
+        "name" : "name",
+        "namespace" : "namespace"
+      }, {
+        "name" : "name",
+        "namespace" : "namespace"
+      } ]
+    },
     "updatedAt" : 1
   },
   "attempts" : [ {
@@ -4636,14 +4644,16 @@ font-style: italic;
     "job" : {
       "createdAt" : 6,
       "configId" : "configId",
-      "streams" : [ {
-        "name" : "name",
-        "namespace" : "namespace"
-      }, {
-        "name" : "name",
-        "namespace" : "namespace"
-      } ],
       "id" : 0,
+      "resetConfig" : {
+        "streamsToReset" : [ {
+          "name" : "name",
+          "namespace" : "namespace"
+        }, {
+          "name" : "name",
+          "namespace" : "namespace"
+        } ]
+      },
       "updatedAt" : 1
     },
     "attempts" : [ {
@@ -4743,14 +4753,16 @@ font-style: italic;
     "job" : {
       "createdAt" : 6,
       "configId" : "configId",
-      "streams" : [ {
-        "name" : "name",
-        "namespace" : "namespace"
-      }, {
-        "name" : "name",
-        "namespace" : "namespace"
-      } ],
       "id" : 0,
+      "resetConfig" : {
+        "streamsToReset" : [ {
+          "name" : "name",
+          "namespace" : "namespace"
+        }, {
+          "name" : "name",
+          "namespace" : "namespace"
+        } ]
+      },
       "updatedAt" : 1
     },
     "attempts" : [ {
@@ -10619,6 +10631,7 @@ font-style: italic;
     <li><a href="#PrivateSourceDefinitionRead"><code>PrivateSourceDefinitionRead</code> - </a></li>
     <li><a href="#PrivateSourceDefinitionReadList"><code>PrivateSourceDefinitionReadList</code> - </a></li>
     <li><a href="#ReleaseStage"><code>ReleaseStage</code> - </a></li>
+    <li><a href="#ResetConfig"><code>ResetConfig</code> - </a></li>
     <li><a href="#ResourceRequirements"><code>ResourceRequirements</code> - </a></li>
     <li><a href="#SetInstancewideDestinationOauthParamsRequestBody"><code>SetInstancewideDestinationOauthParamsRequestBody</code> - </a></li>
     <li><a href="#SetInstancewideSourceOauthParamsRequestBody"><code>SetInstancewideSourceOauthParamsRequestBody</code> - </a></li>
@@ -11360,7 +11373,7 @@ font-style: italic;
 <div class="param">createdAt </div><div class="param-desc"><span class="param-type"><a href="#long">Long</a></span>  format: int64</div>
 <div class="param">updatedAt </div><div class="param-desc"><span class="param-type"><a href="#long">Long</a></span>  format: int64</div>
 <div class="param">status </div><div class="param-desc"><span class="param-type"><a href="#JobStatus">JobStatus</a></span>  </div>
-<div class="param">streams (optional)</div><div class="param-desc"><span class="param-type"><a href="#StreamDescriptor">array[StreamDescriptor]</a></span>  </div>
+<div class="param">resetConfig (optional)</div><div class="param-desc"><span class="param-type"><a href="#ResetConfig">ResetConfig</a></span>  </div>
     </div>  <!-- field-items -->
   </div>
   <div class="model">
@@ -11621,6 +11634,13 @@ if oauth parameters were contained inside the top level, rootObject=[] If they w
     <div class='model-description'></div>
     <div class="field-items">
           </div>  <!-- field-items -->
+  </div>
+  <div class="model">
+    <h3><a name="ResetConfig"><code>ResetConfig</code> - </a> <a class="up" href="#__Models">Up</a></h3>
+    <div class='model-description'></div>
+    <div class="field-items">
+      <div class="param">streamsToReset (optional)</div><div class="param-desc"><span class="param-type"><a href="#StreamDescriptor">array[StreamDescriptor]</a></span>  </div>
+    </div>  <!-- field-items -->
   </div>
   <div class="model">
     <h3><a name="ResourceRequirements"><code>ResourceRequirements</code> - </a> <a class="up" href="#__Models">Up</a></h3>


### PR DESCRIPTION
closes https://github.com/airbytehq/airbyte/issues/13256

## How
* exposes the streams that were reset.
* @timroes this deviates slightly from what the implementation suggested in the issue. instead of having a generic streams field, the information about which fields are reset is exposed as a reset config object. the behavior from the caller's point of view is the same. when it is a reset the streams that were reset will be populated. otherwise it'll be null.