### PR TITLE
:bug: Source Amazon Ads: fix broken SAT tests

### DIFF
--- a/airbyte-integrations/connectors/source-amazon-ads/acceptance-test-config.yml
+++ b/airbyte-integrations/connectors/source-amazon-ads/acceptance-test-config.yml
@@ -5,14 +5,18 @@ tests:
   spec:
     - spec_path: "integration_tests/spec.json"
   connection:
-    - config_path: "secrets/config.json"
-      status: "succeed"
+    # THIS TEST IS COMMENTED OUT BECAUSE OF
+    # https://advertising.amazon.com/API/docs/en-us/info/release-notes#sandbox-deprecation-on-june-28-2022
+    # - config_path: "secrets/config.json"
+    #   status: "succeed"
     - config_path: "secrets/config_test_account.json"
       status: "succeed"
     - config_path: "integration_tests/invalid_config.json"
       status: "failed"
   discovery:
-    - config_path: "secrets/config.json"
+    # THIS TEST IS COMMENTED OUT BECAUSE OF LOST ACCESS TO SANDBOX
+    # - config_path: "secrets/config.json"
+    - config_path: "secrets/config_test_account.json"
   basic_read:
     - config_path: "secrets/config_test_account.json"
       configured_catalog_path: "integration_tests/configured_catalog.json"
@@ -23,17 +27,21 @@ tests:
         exact_order: no
         extra_records: no
       timeout_seconds: 900
-    - config_path: "secrets/config.json"
-      configured_catalog_path: "integration_tests/configured_catalog_sponsored_display.json"
-      empty_streams: ["sponsored_display_targetings"]
-      expect_records:
-        path: "integration_tests/expected_records_sponsored_display.txt"
-        extra_fields: no
-        exact_order: no
-        extra_records: no
+    # THIS TEST IS COMMENTED OUT BECAUSE OF
+    # https://advertising.amazon.com/API/docs/en-us/info/release-notes#sandbox-deprecation-on-june-28-2022
+    # - config_path: "secrets/config.json"
+    #   configured_catalog_path: "integration_tests/configured_catalog_sponsored_display.json"
+    #   empty_streams: ["sponsored_display_targetings"]
+    #   expect_records:
+    #     path: "integration_tests/expected_records_sponsored_display.txt"
+    #     extra_fields: no
+    #     exact_order: no
+    #     extra_records: no
   full_refresh:
     - config_path: "secrets/config_test_account.json"
       configured_catalog_path: "integration_tests/configured_catalog.json"
       timeout_seconds: 1800
-    - config_path: "secrets/config.json"
-      configured_catalog_path: "integration_tests/configured_catalog_sponsored_display.json"
+    # THIS TEST IS COMMENTED OUT BECAUSE OF
+    # https://advertising.amazon.com/API/docs/en-us/info/release-notes#sandbox-deprecation-on-june-28-2022
+    # - config_path: "secrets/config.json"
+    #   configured_catalog_path: "integration_tests/configured_catalog_sponsored_display.json"


### PR DESCRIPTION
## What
Resolving: https://github.com/airbytehq/airbyte/issues/13939

## How
- commented out non-relevant tests from `acceptance-tests-config.yaml`