### PR TITLE
postgres source: fix CDC setup order docs

### DIFF
--- a/docs/integrations/sources/postgres.md
+++ b/docs/integrations/sources/postgres.md
@@ -125,17 +125,7 @@ We recommend using a user specifically for Airbyte's replication so you can mini
 
 We recommend using a `pgoutput` plugin as it is the standard logical decoding plugin in Postgres. In case the replication table contains a lot of big JSON blobs and table size exceeds 1 GB, we recommend using a `wal2json` instead. Please note that `wal2json` may require additional installation for Bare Metal, VMs \(EC2/GCE/etc\), Docker, etc. For more information read [wal2json documentation](https://github.com/eulerto/wal2json).
 
-#### 4. Create replication slot
-
-Next, you will need to create a replication slot. Here is the query used to create a replication slot called `airbyte_slot`:
-
-```text
-SELECT pg_create_logical_replication_slot('airbyte_slot', 'pgoutput');
-```
-
-If you would like to use `wal2json` plugin, please change `pgoutput` to `wal2json` value in the above query.
-
-#### 5. Create publications and replication identities for tables
+#### 4. Create publications and replication identities for tables
 
 For each table you want to replicate with CDC, you should add the replication identity \(the method of distinguishing between rows\) first. We recommend using `ALTER TABLE tbl1 REPLICA IDENTITY DEFAULT;` to use primary keys to distinguish between rows. After setting the replication identity, you will need to run `CREATE PUBLICATION airbyte_publication FOR TABLE <tbl1, tbl2, tbl3>;`. This publication name is customizable. Please refer to the [Postgres docs](https://www.postgresql.org/docs/10/sql-alterpublication.html) if you need to add or remove tables from your publication in the future.
 
@@ -144,6 +134,16 @@ Please note that:
 - The publication should **include all the tables and only the tables that need to be synced**. Otherwise, data from these tables may not be replicated correctly.
 
 The UI currently allows selecting any tables for CDC. If a table is selected that is not part of the publication, it will not replicate even though it is selected. If a table is part of the publication but does not have a replication identity, that replication identity will be created automatically on the first run if the Airbyte user has the necessary permissions.
+
+#### 5. Create replication slot
+
+Next, you will need to create a replication slot. Here is the query used to create a replication slot called `airbyte_slot`:
+
+```text
+SELECT pg_create_logical_replication_slot('airbyte_slot', 'pgoutput');
+```
+
+If you would like to use `wal2json` plugin, please change `pgoutput` to `wal2json` value in the above query.
 
 #### 6. Start syncing
 

--- a/docs/integrations/sources/postgres.md
+++ b/docs/integrations/sources/postgres.md
@@ -137,7 +137,9 @@ The UI currently allows selecting any tables for CDC. If a table is selected tha
 
 #### 5. Create replication slot
 
-Next, you will need to create a replication slot. Here is the query used to create a replication slot called `airbyte_slot`:
+Next, you will need to create a replication slot. It's important to create the publication first (as in step 4) before creating the replication slot. Otherwise, you can run into exceptions if there is any update to the database between the creation of the two.
+
+Here is the query used to create a replication slot called `airbyte_slot`:
 
 ```text
 SELECT pg_create_logical_replication_slot('airbyte_slot', 'pgoutput');


### PR DESCRIPTION
## What
The current documentation has publication/replication slot creation in the wrong order. If there is database activity occurring between the creation of the replication slot and publication, subsequent replication will fail with the following error:

```
ERROR:  publication "airbyte_publication" does not exist
CONTEXT:  slot "airbyte_slot", output plugin "pgoutput", in the change callback, associated LSN 0/2773C20
```
The LSN will have been recorded in the replication slot, but before the publication existed. Uh oh!

To avoid this, create them in the opposite order. Or ensure that no writes occur in the database in between, but that may not be possible to prevent in a production environment.

Here's a quick proof:

```
vault=# SELECT pg_create_logical_replication_slot('airbyte_slot', 'pgoutput');
 pg_create_logical_replication_slot
------------------------------------
 (airbyte_slot,0/2771768)
vault=# insert into environments values ('71282342-36ec-4e85-bafa-b518c37730c2', 'foo', 'foo', now(), now(), null);
INSERT 0 1
vault=# CREATE PUBLICATION airbyte_publication FOR TABLE environments;
CREATE PUBLICATION
vault=# SELECT * FROM pg_logical_slot_get_binary_changes('airbyte_slot',
NULL, NULL,'proto_version','1','publication_names','airbyte_publication');
ERROR:  publication "airbyte_publication" does not exist
CONTEXT:  slot "airbyte_slot", output plugin "pgoutput", in the change callback, associated LSN 0/2773C20
vault=# drop publication airbyte_publication;
DROP PUBLICATION
vault=# select pg_drop_replication_slot('airbyte_slot');
 pg_drop_replication_slot
--------------------------

(1 row)

vault=# CREATE PUBLICATION airbyte_publication FOR TABLE environments;
CREATE PUBLICATION
vault=# insert into environments values ('94222046-c6d2-4824-a2ba-a303fa453824', 'foo2', 'foo2', now(), now(), null);
INSERT 0 1
vault=# SELECT pg_create_logical_replication_slot('airbyte_slot', 'pgoutput');
 pg_create_logical_replication_slot
------------------------------------
 (airbyte_slot,0/2777D68)
(1 row)

vault=# SELECT * FROM pg_logical_slot_get_binary_changes('airbyte_slot',
NULL, NULL,'proto_version','1','publication_names','airbyte_publication');
 lsn | xid | data
-----+-----+------
```

## How
*Describe the solution*

## Recommended reading order
1. `x.java`
2. `y.python`

## 🚨 User Impact 🚨
Are there any breaking changes? What is the end result perceived by the user? If yes, please merge this PR with the 🚨🚨 emoji so changelog authors can further highlight this if needed.

## Pre-merge Checklist
Expand the relevant checklist and delete the others.

<details><summary><strong>New Connector</strong></summary>

### Community member or Airbyter

- [ ] **Community member?** Grant edit access to maintainers ([instructions](https://docs.github.com/en/github/collaborating-with-pull-requests/working-with-forks/allowing-changes-to-a-pull-request-branch-created-from-a-fork#enabling-repository-maintainer-permissions-on-existing-pull-requests))
- [ ] Secrets in the connector's spec are annotated with `airbyte_secret`
- [ ] Unit & integration tests added and passing. Community members, please provide proof of success locally e.g: screenshot or copy-paste unit, integration, and acceptance test output. To run acceptance tests for a Python connector, follow instructions in the README. For java connectors run `./gradlew :airbyte-integrations:connectors:<name>:integrationTest`.
- [ ] Code reviews completed
- [ ] Documentation updated
    - [ ] Connector's `README.md`
    - [ ] Connector's `bootstrap.md`. See [description and examples](https://docs.google.com/document/d/1ypdgmwmEHWv-TrO4_YOQ7pAJGVrMp5BOkEVh831N260/edit?usp=sharing)
    - [ ] `docs/integrations/<source or destination>/<name>.md` including changelog. See changelog [example](https://docs.airbyte.io/integrations/sources/stripe#changelog)
    - [ ] `docs/integrations/README.md`
    - [ ] `airbyte-integrations/builds.md`
- [ ] PR name follows [PR naming conventions](https://docs.airbyte.io/contributing-to-airbyte/updating-documentation#issues-and-pull-requests)

### Airbyter

If this is a community PR, the Airbyte engineer reviewing this PR is responsible for the below items.

- [ ] Create a non-forked branch based on this PR and test the below items on it
- [ ] Build is successful
- [ ] If new credentials are required for use in CI, add them to GSM. [Instructions](https://docs.airbyte.io/connector-development#using-credentials-in-ci).
- [ ] [`/test connector=connectors/<name>` command](https://docs.airbyte.io/connector-development#updating-an-existing-connector) is passing
- [ ] New Connector version released on Dockerhub by running the `/publish` command described [here](https://docs.airbyte.io/connector-development#updating-an-existing-connector)
- [ ] After the connector is published, connector added to connector index as described [here](https://docs.airbyte.io/connector-development#publishing-a-connector)
- [ ] Seed specs have been re-generated by building the platform and committing the changes to the seed spec files, as described [here](https://docs.airbyte.io/connector-development#publishing-a-connector)

</details>

<details><summary><strong>Updating a connector</strong></summary>

### Community member or Airbyter

- [ ] Grant edit access to maintainers ([instructions](https://docs.github.com/en/github/collaborating-with-pull-requests/working-with-forks/allowing-changes-to-a-pull-request-branch-created-from-a-fork#enabling-repository-maintainer-permissions-on-existing-pull-requests))
- [ ] Secrets in the connector's spec are annotated with `airbyte_secret`
- [ ] Unit & integration tests added and passing. Community members, please provide proof of success locally e.g: screenshot or copy-paste unit, integration, and acceptance test output. To run acceptance tests for a Python connector, follow instructions in the README. For java connectors run `./gradlew :airbyte-integrations:connectors:<name>:integrationTest`.
- [ ] Code reviews completed
- [ ] Documentation updated
    - [ ] Connector's `README.md`
    - [ ] Connector's `bootstrap.md`. See [description and examples](https://docs.google.com/document/d/1ypdgmwmEHWv-TrO4_YOQ7pAJGVrMp5BOkEVh831N260/edit?usp=sharing)
    - [ ] Changelog updated in `docs/integrations/<source or destination>/<name>.md` including changelog. See changelog [example](https://docs.airbyte.io/integrations/sources/stripe#changelog)
- [ ] PR name follows [PR naming conventions](https://docs.airbyte.io/contributing-to-airbyte/updating-documentation#issues-and-pull-requests)

### Airbyter

If this is a community PR, the Airbyte engineer reviewing this PR is responsible for the below items.

- [ ] Create a non-forked branch based on this PR and test the below items on it
- [ ] Build is successful
- [ ] If new credentials are required for use in CI, add them to GSM. [Instructions](https://docs.airbyte.io/connector-development#using-credentials-in-ci).
- [ ] [`/test connector=connectors/<name>` command](https://docs.airbyte.io/connector-development#updating-an-existing-connector) is passing
- [ ] New Connector version released on Dockerhub and connector version bumped by running the `/publish` command described [here](https://docs.airbyte.io/connector-development#updating-an-existing-connector)

</details>

<details><summary><strong>Connector Generator</strong></summary>

- [ ] Issue acceptance criteria met
- [ ] PR name follows [PR naming conventions](https://docs.airbyte.io/contributing-to-airbyte/updating-documentation#issues-and-pull-requests)
- [ ] If adding a new generator, add it to the [list of scaffold modules being tested](https://github.com/airbytehq/airbyte/blob/master/airbyte-integrations/connector-templates/generator/build.gradle#L41)
- [ ] The generator test modules (all connectors with `-scaffold` in their name) have been updated with the latest scaffold by running `./gradlew :airbyte-integrations:connector-templates:generator:testScaffoldTemplates` then checking in your changes
- [ ] Documentation which references the generator is updated as needed

</details>

## Tests

<details><summary><strong>Unit</strong></summary>

*Put your unit tests output here.*

</details>

<details><summary><strong>Integration</strong></summary>

*Put your integration tests output here.*

</details>

<details><summary><strong>Acceptance</strong></summary>

*Put your acceptance tests output here.*

</details>
