### PR TITLE
:window: :wrench: Add eslint rules for CSS modules

### DIFF
--- a/airbyte-webapp/.eslintrc
+++ b/airbyte-webapp/.eslintrc
@@ -19,6 +19,13 @@
     "curly": "error",
     "css-modules/no-undef-class": [2, { "camelCase": true }],
     "css-modules/no-unused-class": [2, { "camelCase": true }],
+    "no-restricted-imports": [1, {
+      "paths": [
+        {
+          "name": "styled-components",
+          "message": "Please use CSS Modules instead of Styled Components"
+        }
+      ]}],
     "prettier/prettier": "error",
     "unused-imports/no-unused-imports": "error",
     "import/order": [

--- a/airbyte-webapp/.eslintrc
+++ b/airbyte-webapp/.eslintrc
@@ -17,8 +17,8 @@
   },
   "rules": {
     "curly": "error",
-    "css-modules/no-undef-class": [1, { "camelCase": true }],
-    "css-modules/no-unused-class": [1],
+    "css-modules/no-undef-class": [2, { "camelCase": true }],
+    "css-modules/no-unused-class": [2, { "camelCase": true }],
     "prettier/prettier": "error",
     "unused-imports/no-unused-imports": "error",
     "import/order": [

--- a/airbyte-webapp/.eslintrc
+++ b/airbyte-webapp/.eslintrc
@@ -19,13 +19,6 @@
     "curly": "error",
     "css-modules/no-undef-class": [2, { "camelCase": true }],
     "css-modules/no-unused-class": [2, { "camelCase": true }],
-    "no-restricted-imports": [1, {
-      "paths": [
-        {
-          "name": "styled-components",
-          "message": "Please use CSS Modules instead of Styled Components"
-        }
-      ]}],
     "prettier/prettier": "error",
     "unused-imports/no-unused-imports": "error",
     "import/order": [

--- a/airbyte-webapp/.eslintrc
+++ b/airbyte-webapp/.eslintrc
@@ -4,9 +4,10 @@
     "plugin:@typescript-eslint/recommended",
     "plugin:jest/recommended",
     "prettier",
-    "plugin:prettier/recommended"
+    "plugin:prettier/recommended",
+    "plugin:css-modules/recommended"
   ],
-  "plugins": ["react", "@typescript-eslint", "prettier", "unused-imports"],
+  "plugins": ["react", "@typescript-eslint", "prettier", "unused-imports", "css-modules"],
   "parserOptions": {
     "ecmaVersion": 2020,
     "sourceType": "module",
@@ -16,6 +17,8 @@
   },
   "rules": {
     "curly": "error",
+    "css-modules/no-undef-class": [1, { "camelCase": true }],
+    "css-modules/no-unused-class": [1],
     "prettier/prettier": "error",
     "unused-imports/no-unused-imports": "error",
     "import/order": [

--- a/airbyte-webapp/.eslintrc
+++ b/airbyte-webapp/.eslintrc
@@ -17,8 +17,8 @@
   },
   "rules": {
     "curly": "error",
-    "css-modules/no-undef-class": [2, { "camelCase": true }],
-    "css-modules/no-unused-class": [2, { "camelCase": true }],
+    "css-modules/no-undef-class": ["warn", { "camelCase": true }],
+    "css-modules/no-unused-class": ["warn", { "camelCase": true }],
     "prettier/prettier": "error",
     "unused-imports/no-unused-imports": "error",
     "import/order": [

--- a/airbyte-webapp/package-lock.json
+++ b/airbyte-webapp/package-lock.json
@@ -83,6 +83,7 @@
         "@typescript-eslint/parser": "^5.27.1",
         "eslint-config-prettier": "^8.5.0",
         "eslint-config-react-app": "^7.0.1",
+        "eslint-plugin-css-modules": "^2.11.0",
         "eslint-plugin-jest": "^26.5.3",
         "eslint-plugin-prettier": "^4.0.0",
         "eslint-plugin-unused-imports": "^2.0.0",
@@ -21143,6 +21144,22 @@
         "node": ">=4"
       }
     },
+    "node_modules/eslint-plugin-css-modules": {
+      "version": "2.11.0",
+      "resolved": "https://registry.npmjs.org/eslint-plugin-css-modules/-/eslint-plugin-css-modules-2.11.0.tgz",
+      "integrity": "sha512-CLvQvJOMlCywZzaI4HVu7QH/ltgNXvCg7giJGiE+sA9wh5zQ+AqTgftAzrERV22wHe1p688wrU/Zwxt1Ry922w==",
+      "dev": true,
+      "dependencies": {
+        "gonzales-pe": "^4.0.3",
+        "lodash": "^4.17.2"
+      },
+      "engines": {
+        "node": ">=4.0.0"
+      },
+      "peerDependencies": {
+        "eslint": ">=2.0.0"
+      }
+    },
     "node_modules/eslint-plugin-flowtype": {
       "version": "8.0.3",
       "resolved": "https://registry.npmjs.org/eslint-plugin-flowtype/-/eslint-plugin-flowtype-8.0.3.tgz",
@@ -23631,6 +23648,21 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/gonzales-pe": {
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/gonzales-pe/-/gonzales-pe-4.3.0.tgz",
+      "integrity": "sha512-otgSPpUmdWJ43VXyiNgEYE4luzHCL2pz4wQ0OnDluC6Eg4Ko3Vexy/SrSynglw/eR+OhkzmqFCZa/OFa/RgAOQ==",
+      "dev": true,
+      "dependencies": {
+        "minimist": "^1.2.5"
+      },
+      "bin": {
+        "gonzales": "bin/gonzales.js"
+      },
+      "engines": {
+        "node": ">=0.6.0"
       }
     },
     "node_modules/got": {
@@ -62795,6 +62827,16 @@
         }
       }
     },
+    "eslint-plugin-css-modules": {
+      "version": "2.11.0",
+      "resolved": "https://registry.npmjs.org/eslint-plugin-css-modules/-/eslint-plugin-css-modules-2.11.0.tgz",
+      "integrity": "sha512-CLvQvJOMlCywZzaI4HVu7QH/ltgNXvCg7giJGiE+sA9wh5zQ+AqTgftAzrERV22wHe1p688wrU/Zwxt1Ry922w==",
+      "dev": true,
+      "requires": {
+        "gonzales-pe": "^4.0.3",
+        "lodash": "^4.17.2"
+      }
+    },
     "eslint-plugin-flowtype": {
       "version": "8.0.3",
       "resolved": "https://registry.npmjs.org/eslint-plugin-flowtype/-/eslint-plugin-flowtype-8.0.3.tgz",
@@ -64589,6 +64631,15 @@
         "ignore": "^5.2.0",
         "merge2": "^1.4.1",
         "slash": "^3.0.0"
+      }
+    },
+    "gonzales-pe": {
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/gonzales-pe/-/gonzales-pe-4.3.0.tgz",
+      "integrity": "sha512-otgSPpUmdWJ43VXyiNgEYE4luzHCL2pz4wQ0OnDluC6Eg4Ko3Vexy/SrSynglw/eR+OhkzmqFCZa/OFa/RgAOQ==",
+      "dev": true,
+      "requires": {
+        "minimist": "^1.2.5"
       }
     },
     "got": {

--- a/airbyte-webapp/package.json
+++ b/airbyte-webapp/package.json
@@ -94,6 +94,7 @@
     "@typescript-eslint/parser": "^5.27.1",
     "eslint-config-prettier": "^8.5.0",
     "eslint-config-react-app": "^7.0.1",
+    "eslint-plugin-css-modules": "^2.11.0",
     "eslint-plugin-jest": "^26.5.3",
     "eslint-plugin-prettier": "^4.0.0",
     "eslint-plugin-unused-imports": "^2.0.0",

--- a/airbyte-webapp/src/views/Connection/CatalogTree/StreamHeader.module.scss
+++ b/airbyte-webapp/src/views/Connection/CatalogTree/StreamHeader.module.scss
@@ -2,10 +2,6 @@
 @use "../../../scss/variables";
 @forward "./CatalogTree.module.scss";
 
-.removedStream {
-  color: colors.$red;
-}
-
 .icon {
   margin-right: 7px;
   margin-top: -1px;

--- a/airbyte-webapp/src/views/Connection/CatalogTree/StreamHeader.tsx
+++ b/airbyte-webapp/src/views/Connection/CatalogTree/StreamHeader.tsx
@@ -95,7 +95,8 @@ export const StreamHeader: React.FC<StreamHeaderProps> = ({
     [styles.purpleBackground]: isSelected,
     [styles.redBorder]: hasError,
   });
-
+  //  FIXME: find out why checkboxCell warns as unused
+  // eslint-disable-next-line css-modules/no-undef-class
   const checkboxCellCustomStyle = classnames(styles.checkboxCell, { [styles.streamRowCheckboxCell]: true });
 
   return (

--- a/airbyte-webapp/src/views/Connection/ConnectionForm/components/SyncCatalogField.module.scss
+++ b/airbyte-webapp/src/views/Connection/ConnectionForm/components/SyncCatalogField.module.scss
@@ -31,10 +31,3 @@
   padding-top: 10px;
   margin-left: 115px;
 }
-
-.treeViewContainer {
-  margin-bottom: 29px;
-  max-height: 600px;
-  overflow-y: auto;
-  width: 100%;
-}

--- a/airbyte-webapp/src/views/Connector/ConnectorDocumentationLayout/ConnectorDocumentationLayout.module.scss
+++ b/airbyte-webapp/src/views/Connector/ConnectorDocumentationLayout/ConnectorDocumentationLayout.module.scss
@@ -34,10 +34,6 @@
   height: 100%;
 }
 
-.scroll {
-  overflow: scroll;
-}
-
 .lightOverlay {
   height: 100%;
   width: 100%;


### PR DESCRIPTION
## What
Improve development experience and code quality during working with CSS  modules

## How
Add `eslint-plugin-css-modules`. And since we already have some issues with scss I switched the rules to "warning" mode, at least for a transition period.
<img width="623" alt="Screenshot at Jun 16 18-54-07" src="https://user-images.githubusercontent.com/20929344/174115157-44d1acd7-c05c-44cf-b12c-35206b75ba5c.png">




