### PR TITLE
Small fix to /publish in case of transient fail

### DIFF
--- a/.github/workflows/publish-command.yml
+++ b/.github/workflows/publish-command.yml
@@ -373,7 +373,7 @@ jobs:
     needs:
       - start-publish-image-runner-0 # required to get output from the start-runner job
       - publish-image # required to wait when the main job is done
-    runs-on: ${{ needs.start-publish-image-runner-0.outputs.label }}
+    runs-on: ubuntu-latest
     steps:
       - name: Add hint for manual seed definition update
         uses: peter-evans/create-or-update-comment@v1


### PR DESCRIPTION
## What
In case runners fail to spin up, the always() commands at the end need to run on github-hosted runners
