### PR TITLE
Make /publish comment output table headers look less like successes

### DIFF
--- a/.github/workflows/publish-command.yml
+++ b/.github/workflows/publish-command.yml
@@ -196,7 +196,7 @@ jobs:
           body: |
             <br>
 
-            | Connector | Published | Definitions generated |
+            | Connector | Did it publish? | Were definitions generated? |
       - name: Create table separator
         uses: peter-evans/create-or-update-comment@v1
         with:


### PR DESCRIPTION
## What
This kind of looks like a success message whereas it is actually headers for the table, so I've made it more clear

<img width="501" alt="Screenshot 2022-06-22 at 12 41 43" src="https://user-images.githubusercontent.com/27702686/175020742-8b77a5da-6ce1-4a00-b947-a52e7f8bc8d4.png">

