### PR TITLE
Remove new state types for destination compatibility

### DIFF
--- a/airbyte-integrations/connectors/source-jdbc/src/test/java/io/airbyte/integrations/source/jdbc/AbstractJdbcSourceAcceptanceTest.java
+++ b/airbyte-integrations/connectors/source-jdbc/src/test/java/io/airbyte/integrations/source/jdbc/AbstractJdbcSourceAcceptanceTest.java
@@ -15,14 +15,8 @@ import io.airbyte.db.jdbc.streaming.AdaptiveStreamingQueryConfig;
 import io.airbyte.integrations.base.IntegrationRunner;
 import io.airbyte.integrations.base.Source;
 import io.airbyte.integrations.source.jdbc.test.JdbcSourceAcceptanceTest;
-import io.airbyte.integrations.source.relationaldb.models.CdcState;
-import io.airbyte.protocol.models.AirbyteGlobalState;
-import io.airbyte.protocol.models.AirbyteStateMessage;
-import io.airbyte.protocol.models.AirbyteStateMessage.AirbyteStateType;
-import io.airbyte.protocol.models.AirbyteStreamState;
 import io.airbyte.test.utils.PostgreSQLContainerHelper;
 import java.sql.JDBCType;
-import java.util.List;
 import java.util.Set;
 import org.junit.jupiter.api.AfterAll;
 import org.junit.jupiter.api.BeforeAll;
@@ -129,26 +123,26 @@ class AbstractJdbcSourceAcceptanceTest extends JdbcSourceAcceptanceTest {
       return Set.of("information_schema", "pg_catalog", "pg_internal", "catalog_history");
     }
 
-    // TODO This is a temporary override so that the Postgres source can take advantage of per-stream
-    // state
-    @Override
-    protected List<AirbyteStateMessage> generateEmptyInitialState(final JsonNode config) {
-      if (getSupportedStateType(config) == AirbyteStateType.GLOBAL) {
-        final AirbyteGlobalState globalState = new AirbyteGlobalState()
-            .withSharedState(Jsons.jsonNode(new CdcState()))
-            .withStreamStates(List.of());
-        return List.of(new AirbyteStateMessage().withStateType(AirbyteStateType.GLOBAL).withGlobal(globalState));
-      } else {
-        return List.of(new AirbyteStateMessage()
-            .withStateType(AirbyteStateType.STREAM)
-            .withStream(new AirbyteStreamState()));
-      }
-    }
-
-    @Override
-    protected AirbyteStateType getSupportedStateType(final JsonNode config) {
-      return AirbyteStateType.STREAM;
-    }
+//    // TODO This is a temporary override so that the Postgres source can take advantage of per-stream
+//    // state
+//    @Override
+//    protected List<AirbyteStateMessage> generateEmptyInitialState(final JsonNode config) {
+//      if (getSupportedStateType(config) == AirbyteStateType.GLOBAL) {
+//        final AirbyteGlobalState globalState = new AirbyteGlobalState()
+//            .withSharedState(Jsons.jsonNode(new CdcState()))
+//            .withStreamStates(List.of());
+//        return List.of(new AirbyteStateMessage().withStateType(AirbyteStateType.GLOBAL).withGlobal(globalState));
+//      } else {
+//        return List.of(new AirbyteStateMessage()
+//            .withStateType(AirbyteStateType.STREAM)
+//            .withStream(new AirbyteStreamState()));
+//      }
+//    }
+//
+//    @Override
+//    protected AirbyteStateType getSupportedStateType(final JsonNode config) {
+//      return AirbyteStateType.STREAM;
+//    }
 
     public static void main(final String[] args) throws Exception {
       final Source source = new PostgresTestSource();

--- a/airbyte-integrations/connectors/source-jdbc/src/testFixtures/java/io/airbyte/integrations/source/jdbc/test/JdbcSourceAcceptanceTest.java
+++ b/airbyte-integrations/connectors/source-jdbc/src/testFixtures/java/io/airbyte/integrations/source/jdbc/test/JdbcSourceAcceptanceTest.java
@@ -892,7 +892,7 @@ public abstract class JdbcSourceAcceptanceTest {
                         .withData(Jsons.jsonNode(new DbState().withCdc(false).withStreams(states)))))
             .collect(
                 Collectors.toList())
-        : List.of(new AirbyteMessage().withType(Type.STATE).withState(new AirbyteStateMessage().withStateType(AirbyteStateType.LEGACY)
+        : List.of(new AirbyteMessage().withType(Type.STATE).withState(new AirbyteStateMessage() //.withStateType(AirbyteStateType.LEGACY)
             .withData(Jsons.jsonNode(new DbState().withCdc(false).withStreams(states)))));
   }
 
@@ -905,7 +905,8 @@ public abstract class JdbcSourceAcceptanceTest {
                     .withStreamState(Jsons.jsonNode(s))))
             .collect(
                 Collectors.toList())
-        : List.of(new AirbyteStateMessage().withStateType(AirbyteStateType.LEGACY).withData(Jsons.jsonNode(new DbState().withStreams(states))));
+        : List.of(new AirbyteStateMessage() //.withStateType(AirbyteStateType.LEGACY)
+             .withData(Jsons.jsonNode(new DbState().withStreams(states))));
   }
 
   protected ConfiguredAirbyteStream createTableWithSpaces() throws SQLException {
@@ -1056,7 +1057,8 @@ public abstract class JdbcSourceAcceptanceTest {
                       .withStreamState(Jsons.jsonNode(dbStreamState)))
                   .withData(Jsons.jsonNode(new DbState().withCdc(false).withStreams(legacyStates))));
     } else {
-      return new AirbyteMessage().withType(Type.STATE).withState(new AirbyteStateMessage().withStateType(AirbyteStateType.LEGACY)
+      return new AirbyteMessage().withType(Type.STATE).withState(new AirbyteStateMessage()
+          //.withStateType(AirbyteStateType.LEGACY)
           .withData(Jsons.jsonNode(new DbState().withCdc(false).withStreams(legacyStates))));
     }
   }

--- a/airbyte-integrations/connectors/source-mssql-strict-encrypt/Dockerfile
+++ b/airbyte-integrations/connectors/source-mssql-strict-encrypt/Dockerfile
@@ -16,5 +16,5 @@ ENV APPLICATION source-mssql-strict-encrypt
 
 COPY --from=build /airbyte /airbyte
 
-LABEL io.airbyte.version=0.4.3
+LABEL io.airbyte.version=0.4.4
 LABEL io.airbyte.name=airbyte/source-mssql-strict-encrypt

--- a/airbyte-integrations/connectors/source-mssql/Dockerfile
+++ b/airbyte-integrations/connectors/source-mssql/Dockerfile
@@ -16,5 +16,5 @@ ENV APPLICATION source-mssql
 
 COPY --from=build /airbyte /airbyte
 
-LABEL io.airbyte.version=0.4.3
+LABEL io.airbyte.version=0.4.4
 LABEL io.airbyte.name=airbyte/source-mssql

--- a/airbyte-integrations/connectors/source-mysql-strict-encrypt/Dockerfile
+++ b/airbyte-integrations/connectors/source-mysql-strict-encrypt/Dockerfile
@@ -16,5 +16,5 @@ ENV APPLICATION source-mysql-strict-encrypt
 
 COPY --from=build /airbyte /airbyte
 
-LABEL io.airbyte.version=0.5.10
+LABEL io.airbyte.version=0.5.14
 LABEL io.airbyte.name=airbyte/source-mysql-strict-encrypt

--- a/airbyte-integrations/connectors/source-mysql/Dockerfile
+++ b/airbyte-integrations/connectors/source-mysql/Dockerfile
@@ -16,5 +16,5 @@ ENV APPLICATION source-mysql
 
 COPY --from=build /airbyte /airbyte
 
-LABEL io.airbyte.version=0.5.13
+LABEL io.airbyte.version=0.5.14
 LABEL io.airbyte.name=airbyte/source-mysql

--- a/airbyte-integrations/connectors/source-postgres-strict-encrypt/Dockerfile
+++ b/airbyte-integrations/connectors/source-postgres-strict-encrypt/Dockerfile
@@ -16,5 +16,5 @@ ENV APPLICATION source-postgres-strict-encrypt
 
 COPY --from=build /airbyte /airbyte
 
-LABEL io.airbyte.version=0.4.26
+LABEL io.airbyte.version=0.4.27
 LABEL io.airbyte.name=airbyte/source-postgres-strict-encrypt

--- a/airbyte-integrations/connectors/source-postgres/Dockerfile
+++ b/airbyte-integrations/connectors/source-postgres/Dockerfile
@@ -16,5 +16,5 @@ ENV APPLICATION source-postgres
 
 COPY --from=build /airbyte /airbyte
 
-LABEL io.airbyte.version=0.4.26
+LABEL io.airbyte.version=0.4.27
 LABEL io.airbyte.name=airbyte/source-postgres

--- a/airbyte-integrations/connectors/source-postgres/src/main/java/io/airbyte/integrations/source/postgres/PostgresSource.java
+++ b/airbyte-integrations/connectors/source-postgres/src/main/java/io/airbyte/integrations/source/postgres/PostgresSource.java
@@ -27,16 +27,11 @@ import io.airbyte.integrations.debezium.AirbyteDebeziumHandler;
 import io.airbyte.integrations.source.jdbc.AbstractJdbcSource;
 import io.airbyte.integrations.source.jdbc.dto.JdbcPrivilegeDto;
 import io.airbyte.integrations.source.relationaldb.TableInfo;
-import io.airbyte.integrations.source.relationaldb.models.CdcState;
 import io.airbyte.integrations.source.relationaldb.state.StateManager;
 import io.airbyte.protocol.models.AirbyteCatalog;
 import io.airbyte.protocol.models.AirbyteConnectionStatus;
-import io.airbyte.protocol.models.AirbyteGlobalState;
 import io.airbyte.protocol.models.AirbyteMessage;
-import io.airbyte.protocol.models.AirbyteStateMessage;
-import io.airbyte.protocol.models.AirbyteStateMessage.AirbyteStateType;
 import io.airbyte.protocol.models.AirbyteStream;
-import io.airbyte.protocol.models.AirbyteStreamState;
 import io.airbyte.protocol.models.CommonField;
 import io.airbyte.protocol.models.ConfiguredAirbyteCatalog;
 import io.airbyte.protocol.models.ConfiguredAirbyteStream;
@@ -409,26 +404,26 @@ public class PostgresSource extends AbstractJdbcSource<JDBCType> implements Sour
     return stream;
   }
 
-  // TODO This is a temporary override so that the Postgres source can take advantage of per-stream
-  // state
-  @Override
-  protected List<AirbyteStateMessage> generateEmptyInitialState(final JsonNode config) {
-    if (getSupportedStateType(config) == AirbyteStateType.GLOBAL) {
-      final AirbyteGlobalState globalState = new AirbyteGlobalState()
-          .withSharedState(Jsons.jsonNode(new CdcState()))
-          .withStreamStates(List.of());
-      return List.of(new AirbyteStateMessage().withStateType(AirbyteStateType.GLOBAL).withGlobal(globalState));
-    } else {
-      return List.of(new AirbyteStateMessage()
-          .withStateType(AirbyteStateType.STREAM)
-          .withStream(new AirbyteStreamState()));
-    }
-  }
-
-  @Override
-  protected AirbyteStateType getSupportedStateType(final JsonNode config) {
-    return isCdc(config) ? AirbyteStateType.GLOBAL : AirbyteStateType.STREAM;
-  }
+//  // TODO This is a temporary override so that the Postgres source can take advantage of per-stream
+//  // state
+//  @Override
+//  protected List<AirbyteStateMessage> generateEmptyInitialState(final JsonNode config) {
+//    if (getSupportedStateType(config) == AirbyteStateType.GLOBAL) {
+//      final AirbyteGlobalState globalState = new AirbyteGlobalState()
+//          .withSharedState(Jsons.jsonNode(new CdcState()))
+//          .withStreamStates(List.of());
+//      return List.of(new AirbyteStateMessage().withStateType(AirbyteStateType.GLOBAL).withGlobal(globalState));
+//    } else {
+//      return List.of(new AirbyteStateMessage()
+//          .withStateType(AirbyteStateType.STREAM)
+//          .withStream(new AirbyteStreamState()));
+//    }
+//  }
+//
+//  @Override
+//  protected AirbyteStateType getSupportedStateType(final JsonNode config) {
+//    return isCdc(config) ? AirbyteStateType.GLOBAL : AirbyteStateType.STREAM;
+//  }
 
   public static void main(final String[] args) throws Exception {
     final Source source = PostgresSource.sshWrappedSource();

--- a/airbyte-integrations/connectors/source-postgres/src/test-integration/java/io/airbyte/integrations/io/airbyte/integration_tests/sources/AbstractSshPostgresSourceAcceptanceTest.java
+++ b/airbyte-integrations/connectors/source-postgres/src/test-integration/java/io/airbyte/integrations/io/airbyte/integration_tests/sources/AbstractSshPostgresSourceAcceptanceTest.java
@@ -137,9 +137,9 @@ public abstract class AbstractSshPostgresSourceAcceptanceTest extends SourceAcce
     return Jsons.jsonNode(new HashMap<>());
   }
 
-  @Override
-  protected boolean supportsPerStream() {
-    return true;
-  }
+//  @Override
+//  protected boolean supportsPerStream() {
+//    return true;
+//  }
 
 }

--- a/airbyte-integrations/connectors/source-postgres/src/test-integration/java/io/airbyte/integrations/io/airbyte/integration_tests/sources/PostgresSourceAcceptanceTest.java
+++ b/airbyte-integrations/connectors/source-postgres/src/test-integration/java/io/airbyte/integrations/io/airbyte/integration_tests/sources/PostgresSourceAcceptanceTest.java
@@ -134,9 +134,9 @@ public class PostgresSourceAcceptanceTest extends SourceAcceptanceTest {
     return Jsons.jsonNode(new HashMap<>());
   }
 
-  @Override
-  protected boolean supportsPerStream() {
-    return true;
-  }
+//  @Override
+//  protected boolean supportsPerStream() {
+//    return true;
+//  }
 
 }

--- a/airbyte-integrations/connectors/source-postgres/src/test/java/io/airbyte/integrations/source/postgres/PostgresJdbcSourceAcceptanceTest.java
+++ b/airbyte-integrations/connectors/source-postgres/src/test/java/io/airbyte/integrations/source/postgres/PostgresJdbcSourceAcceptanceTest.java
@@ -437,9 +437,9 @@ class PostgresJdbcSourceAcceptanceTest extends JdbcSourceAcceptanceTest {
     return expectedMessages;
   }
 
-  @Override
-  protected boolean supportsPerStream() {
-    return true;
-  }
+//  @Override
+//  protected boolean supportsPerStream() {
+//    return true;
+//  }
 
 }

--- a/airbyte-integrations/connectors/source-relational-db/src/main/java/io/airbyte/integrations/source/relationaldb/AbstractDbSource.java
+++ b/airbyte-integrations/connectors/source-relational-db/src/main/java/io/airbyte/integrations/source/relationaldb/AbstractDbSource.java
@@ -528,7 +528,8 @@ public abstract class AbstractDbSource<DataType, Database extends AbstractDataba
         return Jsons.object(initialStateJson, new AirbyteStateMessageListTypeReference());
       } catch (final IllegalArgumentException e) {
         LOGGER.warn("Defaulting to legacy state object...");
-        return List.of(new AirbyteStateMessage().withStateType(AirbyteStateType.LEGACY).withData(initialStateJson));
+        return List.of(new AirbyteStateMessage()  //.withStateType(AirbyteStateType.LEGACY)
+            .withData(initialStateJson));
       }
     }
   }
@@ -541,7 +542,8 @@ public abstract class AbstractDbSource<DataType, Database extends AbstractDataba
    */
   protected List<AirbyteStateMessage> generateEmptyInitialState(final JsonNode config) {
     // For backwards compatibility with existing connectors
-    return List.of(new AirbyteStateMessage().withStateType(AirbyteStateType.LEGACY).withData(Jsons.jsonNode(new DbState())));
+    return List.of(new AirbyteStateMessage()  //.withStateType(AirbyteStateType.LEGACY)
+         .withData(Jsons.jsonNode(new DbState())));
   }
 
   /**

--- a/airbyte-integrations/connectors/source-relational-db/src/main/java/io/airbyte/integrations/source/relationaldb/state/LegacyStateManager.java
+++ b/airbyte-integrations/connectors/source-relational-db/src/main/java/io/airbyte/integrations/source/relationaldb/state/LegacyStateManager.java
@@ -94,7 +94,8 @@ public class LegacyStateManager extends AbstractStateManager<DbState, DbStreamSt
         .withCdcState(getCdcStateManager().getCdcState());
 
     LOGGER.info("Generated legacy state for {} streams", dbState.getStreams().size());
-    return new AirbyteStateMessage().withStateType(AirbyteStateType.LEGACY).withData(Jsons.jsonNode(dbState));
+    return new AirbyteStateMessage()    //.withStateType(AirbyteStateType.LEGACY)
+        .withData(Jsons.jsonNode(dbState));
   }
 
   @Override

--- a/airbyte-integrations/connectors/source-relational-db/src/test/java/io/airbyte/integrations/source/relationaldb/state/LegacyStateManagerTest.java
+++ b/airbyte-integrations/connectors/source-relational-db/src/test/java/io/airbyte/integrations/source/relationaldb/state/LegacyStateManagerTest.java
@@ -82,7 +82,7 @@ public class LegacyStateManagerTest {
     final StateManager stateManager = new LegacyStateManager(new DbState(), catalog);
 
     final AirbyteStateMessage expectedFirstEmission = new AirbyteStateMessage()
-        .withStateType(AirbyteStateType.LEGACY)
+//        .withStateType(AirbyteStateType.LEGACY)
         .withData(Jsons.jsonNode(new DbState().withStreams(List.of(
             new DbStreamState().withStreamName(STREAM_NAME1).withStreamNamespace(NAMESPACE).withCursorField(List.of(CURSOR_FIELD1))
                 .withCursor("a"),
@@ -93,7 +93,7 @@ public class LegacyStateManagerTest {
     final AirbyteStateMessage actualFirstEmission = stateManager.updateAndEmit(NAME_NAMESPACE_PAIR1, "a");
     assertEquals(expectedFirstEmission, actualFirstEmission);
     final AirbyteStateMessage expectedSecondEmission = new AirbyteStateMessage()
-        .withStateType(AirbyteStateType.LEGACY)
+//        .withStateType(AirbyteStateType.LEGACY)
         .withData(Jsons.jsonNode(new DbState().withStreams(List.of(
             new DbStreamState().withStreamName(STREAM_NAME1).withStreamNamespace(NAMESPACE).withCursorField(List.of(CURSOR_FIELD1))
                 .withCursor("a"),
@@ -118,7 +118,7 @@ public class LegacyStateManagerTest {
     final StateManager stateManager = new LegacyStateManager(new DbState(), catalog);
 
     final AirbyteStateMessage expectedFirstEmission = new AirbyteStateMessage()
-        .withStateType(AirbyteStateType.LEGACY)
+//        .withStateType(AirbyteStateType.LEGACY)
         .withData(Jsons.jsonNode(new DbState().withStreams(List.of(
             new DbStreamState().withStreamName(STREAM_NAME1).withStreamNamespace(NAMESPACE).withCursorField(List.of(CURSOR_FIELD1))
                 .withCursor("a"),
@@ -145,7 +145,7 @@ public class LegacyStateManagerTest {
     final StateManager stateManager = new LegacyStateManager(state, catalog);
 
     final AirbyteStateMessage expectedFirstEmission = new AirbyteStateMessage()
-        .withStateType(AirbyteStateType.LEGACY)
+//        .withStateType(AirbyteStateType.LEGACY)
         .withData(Jsons.jsonNode(new DbState().withStreams(List.of(
             new DbStreamState().withStreamName(STREAM_NAME1).withStreamNamespace(NAMESPACE).withCursorField(List.of(CURSOR_FIELD1))
                 .withCursor(null),
@@ -155,7 +155,7 @@ public class LegacyStateManagerTest {
     final AirbyteStateMessage actualFirstEmission = stateManager.updateAndEmit(NAME_NAMESPACE_PAIR1, "a");
     assertEquals(expectedFirstEmission, actualFirstEmission);
     final AirbyteStateMessage expectedSecondEmission = new AirbyteStateMessage()
-        .withStateType(AirbyteStateType.LEGACY)
+//        .withStateType(AirbyteStateType.LEGACY)
         .withData(Jsons.jsonNode(new DbState().withStreams(List.of(
             new DbStreamState().withStreamName(STREAM_NAME1).withStreamNamespace(NAMESPACE).withCursorField(List.of(CURSOR_FIELD1))
                 .withCursor(null),


### PR DESCRIPTION
## What
* Revert use of new per-stream/global/legacy state types

## How
* Comment out overrides to revert all sources to the legacy state message format
* Restore revert of source versions to avoid conflict