### PR TITLE
Fix per stream state protocol backward compatibility

### DIFF
--- a/airbyte-cdk/python/airbyte_cdk/models/airbyte_protocol.py
+++ b/airbyte-cdk/python/airbyte_cdk/models/airbyte_protocol.py
@@ -281,7 +281,7 @@ class AirbyteStateMessage(BaseModel):
     class Config:
         extra = Extra.allow
 
-    state_type: Optional[AirbyteStateType] = None
+    type: Optional[AirbyteStateType] = None
     stream: Optional[AirbyteStreamState] = None
     global_: Optional[AirbyteGlobalState] = Field(None, alias="global")
     data: Optional[Dict[str, Any]] = Field(None, description="(Deprecated) the state data")

--- a/airbyte-config/config-models/src/main/java/io/airbyte/config/helpers/StateMessageHelper.java
+++ b/airbyte-config/config-models/src/main/java/io/airbyte/config/helpers/StateMessageHelper.java
@@ -38,12 +38,12 @@ public class StateMessageHelper {
       if (stateMessages.stream().anyMatch(streamMessage -> !streamMessage.getAdditionalProperties().isEmpty())) {
         return Optional.of(getLegacyStateWrapper(state));
       }
-      if (stateMessages.size() == 1 && stateMessages.get(0).getStateType() == AirbyteStateType.GLOBAL) {
+      if (stateMessages.size() == 1 && stateMessages.get(0).getType() == AirbyteStateType.GLOBAL) {
         return Optional.of(new StateWrapper()
             .withStateType(StateType.GLOBAL)
             .withGlobal(stateMessages.get(0)));
       } else if (stateMessages.size() >= 1
-          && stateMessages.stream().allMatch(stateMessage -> stateMessage.getStateType() == AirbyteStateType.STREAM)) {
+          && stateMessages.stream().allMatch(stateMessage -> stateMessage.getType() == AirbyteStateType.STREAM)) {
         return Optional.of(new StateWrapper()
             .withStateType(StateType.STREAM)
             .withStateMessages(stateMessages));

--- a/airbyte-config/config-models/src/test/java/io/airbyte/config/helpers/StateMessageHelperTest.java
+++ b/airbyte-config/config-models/src/test/java/io/airbyte/config/helpers/StateMessageHelperTest.java
@@ -45,7 +45,7 @@ public class StateMessageHelperTest {
   @Test
   public void testGlobal() {
     final AirbyteStateMessage stateMessage = new AirbyteStateMessage()
-        .withStateType(AirbyteStateType.GLOBAL)
+        .withType(AirbyteStateType.GLOBAL)
         .withGlobal(
             new AirbyteGlobalState()
                 .withSharedState(Jsons.emptyObject())
@@ -61,11 +61,11 @@ public class StateMessageHelperTest {
   @Test
   public void testStream() {
     final AirbyteStateMessage stateMessage1 = new AirbyteStateMessage()
-        .withStateType(AirbyteStateType.STREAM)
+        .withType(AirbyteStateType.STREAM)
         .withStream(
             new AirbyteStreamState().withStreamDescriptor(new StreamDescriptor().withName("a")).withStreamState(Jsons.emptyObject()));
     final AirbyteStateMessage stateMessage2 = new AirbyteStateMessage()
-        .withStateType(AirbyteStateType.STREAM)
+        .withType(AirbyteStateType.STREAM)
         .withStream(
             new AirbyteStreamState().withStreamDescriptor(new StreamDescriptor().withName("b")).withStreamState(Jsons.emptyObject()));
     final Optional<StateWrapper> stateWrapper = StateMessageHelper.getTypedState(Jsons.jsonNode(Lists.newArrayList(stateMessage1, stateMessage2)));
@@ -77,11 +77,11 @@ public class StateMessageHelperTest {
   @Test
   public void testInvalidMixedState() {
     final AirbyteStateMessage stateMessage1 = new AirbyteStateMessage()
-        .withStateType(AirbyteStateType.STREAM)
+        .withType(AirbyteStateType.STREAM)
         .withStream(
             new AirbyteStreamState().withStreamDescriptor(new StreamDescriptor().withName("a")).withStreamState(Jsons.emptyObject()));
     final AirbyteStateMessage stateMessage2 = new AirbyteStateMessage()
-        .withStateType(AirbyteStateType.GLOBAL)
+        .withType(AirbyteStateType.GLOBAL)
         .withGlobal(
             new AirbyteGlobalState()
                 .withSharedState(Jsons.emptyObject())
@@ -95,7 +95,7 @@ public class StateMessageHelperTest {
   @Test
   public void testDuplicatedGlobalState() {
     final AirbyteStateMessage stateMessage1 = new AirbyteStateMessage()
-        .withStateType(AirbyteStateType.GLOBAL)
+        .withType(AirbyteStateType.GLOBAL)
         .withGlobal(
             new AirbyteGlobalState()
                 .withSharedState(Jsons.emptyObject())
@@ -103,7 +103,7 @@ public class StateMessageHelperTest {
                     new AirbyteStreamState().withStreamDescriptor(new StreamDescriptor().withName("a")).withStreamState(Jsons.emptyObject()),
                     new AirbyteStreamState().withStreamDescriptor(new StreamDescriptor().withName("b")).withStreamState(Jsons.emptyObject()))));
     final AirbyteStateMessage stateMessage2 = new AirbyteStateMessage()
-        .withStateType(AirbyteStateType.GLOBAL)
+        .withType(AirbyteStateType.GLOBAL)
         .withGlobal(
             new AirbyteGlobalState()
                 .withSharedState(Jsons.emptyObject())

--- a/airbyte-integrations/bases/base-java/src/main/java/io/airbyte/integrations/destination/dest_state_lifecycle_manager/DefaultDestStateLifecycleManager.java
+++ b/airbyte-integrations/bases/base-java/src/main/java/io/airbyte/integrations/destination/dest_state_lifecycle_manager/DefaultDestStateLifecycleManager.java
@@ -51,7 +51,7 @@ public class DefaultDestStateLifecycleManager implements DestStateLifecycleManag
   @Override
   public void addState(final AirbyteMessage message) {
     Preconditions.checkArgument(message.getType() == Type.STATE, "Messages passed to State Manager must be of type STATE.");
-    Preconditions.checkArgument(isStateTypeCompatible(stateType, message.getState().getStateType()));
+    Preconditions.checkArgument(isStateTypeCompatible(stateType, message.getState().getType()));
 
     setManagerStateTypeIfNotSet(message);
 
@@ -83,10 +83,10 @@ public class DefaultDestStateLifecycleManager implements DestStateLifecycleManag
   private void setManagerStateTypeIfNotSet(final AirbyteMessage message) {
     // detect and set state type.
     if (stateType == null) {
-      if (message.getState().getStateType() == null) {
+      if (message.getState().getType() == null) {
         stateType = AirbyteStateType.LEGACY;
       } else {
-        stateType = message.getState().getStateType();
+        stateType = message.getState().getType();
       }
     }
   }

--- a/airbyte-integrations/bases/base-java/src/main/java/io/airbyte/integrations/destination/dest_state_lifecycle_manager/DestStreamStateLifecycleManager.java
+++ b/airbyte-integrations/bases/base-java/src/main/java/io/airbyte/integrations/destination/dest_state_lifecycle_manager/DestStreamStateLifecycleManager.java
@@ -41,7 +41,7 @@ public class DestStreamStateLifecycleManager implements DestStateLifecycleManage
 
   @Override
   public void addState(final AirbyteMessage message) {
-    Preconditions.checkArgument(message.getState().getStateType() == AirbyteStateType.STREAM);
+    Preconditions.checkArgument(message.getState().getType() == AirbyteStateType.STREAM);
     streamToLastPendingState.put(message.getState().getStream().getStreamDescriptor(), message);
   }
 

--- a/airbyte-integrations/bases/base-java/src/test/java/io/airbyte/integrations/destination/dest_state_lifecycle_manager/DefaultDestStateLifecycleManagerTest.java
+++ b/airbyte-integrations/bases/base-java/src/test/java/io/airbyte/integrations/destination/dest_state_lifecycle_manager/DefaultDestStateLifecycleManagerTest.java
@@ -24,14 +24,14 @@ class DefaultDestStateLifecycleManagerTest {
       .withState(new AirbyteStateMessage());
   private static final AirbyteMessage LEGACY_MESSAGE = new AirbyteMessage()
       .withType(Type.STATE)
-      .withState(new AirbyteStateMessage().withStateType(AirbyteStateType.LEGACY));
+      .withState(new AirbyteStateMessage().withType(AirbyteStateType.LEGACY));
   private static final AirbyteMessage GLOBAL_MESSAGE = new AirbyteMessage()
       .withType(Type.STATE)
-      .withState(new AirbyteStateMessage().withStateType(AirbyteStateType.GLOBAL));
+      .withState(new AirbyteStateMessage().withType(AirbyteStateType.GLOBAL));
   private static final AirbyteMessage STREAM_MESSAGE = new AirbyteMessage()
       .withType(Type.STATE)
       .withState(new AirbyteStateMessage()
-          .withStateType(AirbyteStateType.STREAM)
+          .withType(AirbyteStateType.STREAM)
           .withStream(new AirbyteStreamState().withStreamDescriptor(new StreamDescriptor().withName("users"))));
 
   private DestStateLifecycleManager mgr1;

--- a/airbyte-integrations/bases/base-java/src/test/java/io/airbyte/integrations/destination/dest_state_lifecycle_manager/DestSingleStateLifecycleManagerTest.java
+++ b/airbyte-integrations/bases/base-java/src/test/java/io/airbyte/integrations/destination/dest_state_lifecycle_manager/DestSingleStateLifecycleManagerTest.java
@@ -19,10 +19,10 @@ class DestSingleStateLifecycleManagerTest {
 
   private static final AirbyteMessage MESSAGE1 = new AirbyteMessage()
       .withType(Type.STATE)
-      .withState(new AirbyteStateMessage().withStateType(AirbyteStateType.GLOBAL).withData(Jsons.jsonNode("a")));
+      .withState(new AirbyteStateMessage().withType(AirbyteStateType.GLOBAL).withData(Jsons.jsonNode("a")));
   private static final AirbyteMessage MESSAGE2 = new AirbyteMessage()
       .withType(Type.STATE)
-      .withState(new AirbyteStateMessage().withStateType(AirbyteStateType.GLOBAL).withData(Jsons.jsonNode("b")));
+      .withState(new AirbyteStateMessage().withType(AirbyteStateType.GLOBAL).withData(Jsons.jsonNode("b")));
 
   private DestSingleStateLifecycleManager mgr;
 

--- a/airbyte-integrations/bases/base-java/src/test/java/io/airbyte/integrations/destination/dest_state_lifecycle_manager/DestStreamStateLifecycleManagerTest.java
+++ b/airbyte-integrations/bases/base-java/src/test/java/io/airbyte/integrations/destination/dest_state_lifecycle_manager/DestStreamStateLifecycleManagerTest.java
@@ -23,17 +23,17 @@ class DestStreamStateLifecycleManagerTest {
   private static final AirbyteMessage STREAM1_MESSAGE1 = new AirbyteMessage()
       .withType(Type.STATE)
       .withState(new AirbyteStateMessage()
-          .withStateType(AirbyteStateType.STREAM)
+          .withType(AirbyteStateType.STREAM)
           .withStream(new AirbyteStreamState().withStreamDescriptor(new StreamDescriptor().withName("apples")).withStreamState(Jsons.jsonNode("a"))));
   private static final AirbyteMessage STREAM1_MESSAGE2 = new AirbyteMessage()
       .withType(Type.STATE)
       .withState(new AirbyteStateMessage()
-          .withStateType(AirbyteStateType.STREAM)
+          .withType(AirbyteStateType.STREAM)
           .withStream(new AirbyteStreamState().withStreamDescriptor(new StreamDescriptor().withName("apples")).withStreamState(Jsons.jsonNode("b"))));
   private static final AirbyteMessage STREAM2_MESSAGE1 = new AirbyteMessage()
       .withType(Type.STATE)
       .withState(new AirbyteStateMessage()
-          .withStateType(AirbyteStateType.STREAM)
+          .withType(AirbyteStateType.STREAM)
           .withStream(
               new AirbyteStreamState().withStreamDescriptor(new StreamDescriptor().withName("bananas")).withStreamState(Jsons.jsonNode("10"))));
 

--- a/airbyte-integrations/connectors/source-jdbc/src/test/java/io/airbyte/integrations/source/jdbc/AbstractJdbcSourceAcceptanceTest.java
+++ b/airbyte-integrations/connectors/source-jdbc/src/test/java/io/airbyte/integrations/source/jdbc/AbstractJdbcSourceAcceptanceTest.java
@@ -137,10 +137,10 @@ class AbstractJdbcSourceAcceptanceTest extends JdbcSourceAcceptanceTest {
         final AirbyteGlobalState globalState = new AirbyteGlobalState()
             .withSharedState(Jsons.jsonNode(new CdcState()))
             .withStreamStates(List.of());
-        return List.of(new AirbyteStateMessage().withStateType(AirbyteStateType.GLOBAL).withGlobal(globalState));
+        return List.of(new AirbyteStateMessage().withType(AirbyteStateType.GLOBAL).withGlobal(globalState));
       } else {
         return List.of(new AirbyteStateMessage()
-            .withStateType(AirbyteStateType.STREAM)
+            .withType(AirbyteStateType.STREAM)
             .withStream(new AirbyteStreamState()));
       }
     }

--- a/airbyte-integrations/connectors/source-jdbc/src/testFixtures/java/io/airbyte/integrations/source/jdbc/test/JdbcSourceAcceptanceTest.java
+++ b/airbyte-integrations/connectors/source-jdbc/src/testFixtures/java/io/airbyte/integrations/source/jdbc/test/JdbcSourceAcceptanceTest.java
@@ -885,27 +885,27 @@ public abstract class JdbcSourceAcceptanceTest {
         ? states.stream()
             .map(s -> new AirbyteMessage().withType(Type.STATE)
                 .withState(
-                    new AirbyteStateMessage().withStateType(AirbyteStateType.STREAM)
+                    new AirbyteStateMessage().withType(AirbyteStateType.STREAM)
                         .withStream(new AirbyteStreamState()
                             .withStreamDescriptor(new StreamDescriptor().withNamespace(s.getStreamNamespace()).withName(s.getStreamName()))
                             .withStreamState(Jsons.jsonNode(s)))
                         .withData(Jsons.jsonNode(new DbState().withCdc(false).withStreams(states)))))
             .collect(
                 Collectors.toList())
-        : List.of(new AirbyteMessage().withType(Type.STATE).withState(new AirbyteStateMessage().withStateType(AirbyteStateType.LEGACY)
+        : List.of(new AirbyteMessage().withType(Type.STATE).withState(new AirbyteStateMessage().withType(AirbyteStateType.LEGACY)
             .withData(Jsons.jsonNode(new DbState().withCdc(false).withStreams(states)))));
   }
 
   protected List<AirbyteStateMessage> createState(final List<DbStreamState> states) {
     return supportsPerStream()
         ? states.stream()
-            .map(s -> new AirbyteStateMessage().withStateType(AirbyteStateType.STREAM)
+            .map(s -> new AirbyteStateMessage().withType(AirbyteStateType.STREAM)
                 .withStream(new AirbyteStreamState()
                     .withStreamDescriptor(new StreamDescriptor().withNamespace(s.getStreamNamespace()).withName(s.getStreamName()))
                     .withStreamState(Jsons.jsonNode(s))))
             .collect(
                 Collectors.toList())
-        : List.of(new AirbyteStateMessage().withStateType(AirbyteStateType.LEGACY).withData(Jsons.jsonNode(new DbState().withStreams(states))));
+        : List.of(new AirbyteStateMessage().withType(AirbyteStateType.LEGACY).withData(Jsons.jsonNode(new DbState().withStreams(states))));
   }
 
   protected ConfiguredAirbyteStream createTableWithSpaces() throws SQLException {
@@ -1020,7 +1020,7 @@ public abstract class JdbcSourceAcceptanceTest {
   protected JsonNode createEmptyState(final String streamName, final String streamNamespace) {
     if (supportsPerStream()) {
       final AirbyteStateMessage airbyteStateMessage = new AirbyteStateMessage()
-          .withStateType(AirbyteStateType.STREAM)
+          .withType(AirbyteStateType.STREAM)
           .withStream(new AirbyteStreamState().withStreamDescriptor(new StreamDescriptor().withName(streamName).withNamespace(streamNamespace)));
       return Jsons.jsonNode(List.of(airbyteStateMessage));
     } else {
@@ -1049,14 +1049,14 @@ public abstract class JdbcSourceAcceptanceTest {
     if (supportsPerStream()) {
       return new AirbyteMessage().withType(Type.STATE)
           .withState(
-              new AirbyteStateMessage().withStateType(AirbyteStateType.STREAM)
+              new AirbyteStateMessage().withType(AirbyteStateType.STREAM)
                   .withStream(new AirbyteStreamState()
                       .withStreamDescriptor(new StreamDescriptor().withNamespace(dbStreamState.getStreamNamespace())
                           .withName(dbStreamState.getStreamName()))
                       .withStreamState(Jsons.jsonNode(dbStreamState)))
                   .withData(Jsons.jsonNode(new DbState().withCdc(false).withStreams(legacyStates))));
     } else {
-      return new AirbyteMessage().withType(Type.STATE).withState(new AirbyteStateMessage().withStateType(AirbyteStateType.LEGACY)
+      return new AirbyteMessage().withType(Type.STATE).withState(new AirbyteStateMessage().withType(AirbyteStateType.LEGACY)
           .withData(Jsons.jsonNode(new DbState().withCdc(false).withStreams(legacyStates))));
     }
   }

--- a/airbyte-integrations/connectors/source-postgres/src/main/java/io/airbyte/integrations/source/postgres/PostgresSource.java
+++ b/airbyte-integrations/connectors/source-postgres/src/main/java/io/airbyte/integrations/source/postgres/PostgresSource.java
@@ -417,10 +417,10 @@ public class PostgresSource extends AbstractJdbcSource<JDBCType> implements Sour
       final AirbyteGlobalState globalState = new AirbyteGlobalState()
           .withSharedState(Jsons.jsonNode(new CdcState()))
           .withStreamStates(List.of());
-      return List.of(new AirbyteStateMessage().withStateType(AirbyteStateType.GLOBAL).withGlobal(globalState));
+      return List.of(new AirbyteStateMessage().withType(AirbyteStateType.GLOBAL).withGlobal(globalState));
     } else {
       return List.of(new AirbyteStateMessage()
-          .withStateType(AirbyteStateType.STREAM)
+          .withType(AirbyteStateType.STREAM)
           .withStream(new AirbyteStreamState()));
     }
   }

--- a/airbyte-integrations/connectors/source-relational-db/src/main/java/io/airbyte/integrations/source/relationaldb/AbstractDbSource.java
+++ b/airbyte-integrations/connectors/source-relational-db/src/main/java/io/airbyte/integrations/source/relationaldb/AbstractDbSource.java
@@ -528,7 +528,7 @@ public abstract class AbstractDbSource<DataType, Database extends AbstractDataba
         return Jsons.object(initialStateJson, new AirbyteStateMessageListTypeReference());
       } catch (final IllegalArgumentException e) {
         LOGGER.warn("Defaulting to legacy state object...");
-        return List.of(new AirbyteStateMessage().withStateType(AirbyteStateType.LEGACY).withData(initialStateJson));
+        return List.of(new AirbyteStateMessage().withType(AirbyteStateType.LEGACY).withData(initialStateJson));
       }
     }
   }
@@ -541,7 +541,7 @@ public abstract class AbstractDbSource<DataType, Database extends AbstractDataba
    */
   protected List<AirbyteStateMessage> generateEmptyInitialState(final JsonNode config) {
     // For backwards compatibility with existing connectors
-    return List.of(new AirbyteStateMessage().withStateType(AirbyteStateType.LEGACY).withData(Jsons.jsonNode(new DbState())));
+    return List.of(new AirbyteStateMessage().withType(AirbyteStateType.LEGACY).withData(Jsons.jsonNode(new DbState())));
   }
 
   /**

--- a/airbyte-integrations/connectors/source-relational-db/src/main/java/io/airbyte/integrations/source/relationaldb/state/GlobalStateManager.java
+++ b/airbyte-integrations/connectors/source-relational-db/src/main/java/io/airbyte/integrations/source/relationaldb/state/GlobalStateManager.java
@@ -75,7 +75,7 @@ public class GlobalStateManager extends AbstractStateManager<AirbyteStateMessage
         .withCdcState(getCdcStateManager().getCdcState());
 
     return new AirbyteStateMessage()
-        .withStateType(AirbyteStateType.GLOBAL)
+        .withType(AirbyteStateType.GLOBAL)
         // Temporarily include legacy state for backwards compatibility with the platform
         .withData(Jsons.jsonNode(dbState))
         .withGlobal(globalState);
@@ -91,7 +91,7 @@ public class GlobalStateManager extends AbstractStateManager<AirbyteStateMessage
    *         but may be empty.
    */
   private CdcState extractCdcState(final AirbyteStateMessage airbyteStateMessage) {
-    if (airbyteStateMessage.getStateType() == AirbyteStateType.GLOBAL) {
+    if (airbyteStateMessage.getType() == AirbyteStateType.GLOBAL) {
       return Jsons.object(airbyteStateMessage.getGlobal().getSharedState(), CdcState.class);
     } else {
       return Jsons.object(airbyteStateMessage.getData(), DbState.class).getCdcState();
@@ -113,7 +113,7 @@ public class GlobalStateManager extends AbstractStateManager<AirbyteStateMessage
      * storing state in the legacy "data" field.
      */
     return () -> {
-      if (airbyteStateMessage.getStateType() == AirbyteStateType.GLOBAL) {
+      if (airbyteStateMessage.getType() == AirbyteStateType.GLOBAL) {
         return airbyteStateMessage.getGlobal().getStreamStates();
       } else if (airbyteStateMessage.getData() != null) {
         return Jsons.object(airbyteStateMessage.getData(), DbState.class).getStreams().stream()

--- a/airbyte-integrations/connectors/source-relational-db/src/main/java/io/airbyte/integrations/source/relationaldb/state/LegacyStateManager.java
+++ b/airbyte-integrations/connectors/source-relational-db/src/main/java/io/airbyte/integrations/source/relationaldb/state/LegacyStateManager.java
@@ -94,7 +94,7 @@ public class LegacyStateManager extends AbstractStateManager<DbState, DbStreamSt
         .withCdcState(getCdcStateManager().getCdcState());
 
     LOGGER.info("Generated legacy state for {} streams", dbState.getStreams().size());
-    return new AirbyteStateMessage().withStateType(AirbyteStateType.LEGACY).withData(Jsons.jsonNode(dbState));
+    return new AirbyteStateMessage().withType(AirbyteStateType.LEGACY).withData(Jsons.jsonNode(dbState));
   }
 
   @Override

--- a/airbyte-integrations/connectors/source-relational-db/src/main/java/io/airbyte/integrations/source/relationaldb/state/StateGeneratorUtils.java
+++ b/airbyte-integrations/connectors/source-relational-db/src/main/java/io/airbyte/integrations/source/relationaldb/state/StateGeneratorUtils.java
@@ -180,7 +180,7 @@ public class StateGeneratorUtils {
                 .withStreamState(Jsons.jsonNode(s)))
             .collect(
                 Collectors.toList()));
-    return new AirbyteStateMessage().withStateType(AirbyteStateType.GLOBAL).withGlobal(globalState);
+    return new AirbyteStateMessage().withType(AirbyteStateType.GLOBAL).withGlobal(globalState);
   }
 
   /**
@@ -192,7 +192,7 @@ public class StateGeneratorUtils {
    */
   public static List<AirbyteStateMessage> convertGlobalStateToStreamState(final AirbyteStateMessage airbyteStateMessage) {
     return airbyteStateMessage.getGlobal().getStreamStates().stream()
-        .map(s -> new AirbyteStateMessage().withStateType(AirbyteStateType.STREAM)
+        .map(s -> new AirbyteStateMessage().withType(AirbyteStateType.STREAM)
             .withStream(new AirbyteStreamState().withStreamDescriptor(s.getStreamDescriptor()).withStreamState(s.getStreamState())))
         .collect(Collectors.toList());
   }
@@ -206,7 +206,7 @@ public class StateGeneratorUtils {
    */
   public static List<AirbyteStateMessage> convertLegacyStateToStreamState(final AirbyteStateMessage airbyteStateMessage) {
     return Jsons.object(airbyteStateMessage.getData(), DbState.class).getStreams().stream()
-        .map(s -> new AirbyteStateMessage().withStateType(AirbyteStateType.STREAM)
+        .map(s -> new AirbyteStateMessage().withType(AirbyteStateType.STREAM)
             .withStream(new AirbyteStreamState()
                 .withStreamDescriptor(new StreamDescriptor().withNamespace(s.getStreamNamespace()).withName(s.getStreamName()))
                 .withStreamState(Jsons.jsonNode(s))))

--- a/airbyte-integrations/connectors/source-relational-db/src/main/java/io/airbyte/integrations/source/relationaldb/state/StateManagerFactory.java
+++ b/airbyte-integrations/connectors/source-relational-db/src/main/java/io/airbyte/integrations/source/relationaldb/state/StateManagerFactory.java
@@ -45,14 +45,14 @@ public class StateManagerFactory {
       final AirbyteStateMessage airbyteStateMessage = initialState.get(0);
       switch (supportedStateType) {
         case LEGACY:
-          LOGGER.info("Legacy state manager selected to manage state object with type {}.", airbyteStateMessage.getStateType());
+          LOGGER.info("Legacy state manager selected to manage state object with type {}.", airbyteStateMessage.getType());
           return new LegacyStateManager(Jsons.object(airbyteStateMessage.getData(), DbState.class), catalog);
         case GLOBAL:
-          LOGGER.info("Global state manager selected to manage state object with type {}.", airbyteStateMessage.getStateType());
+          LOGGER.info("Global state manager selected to manage state object with type {}.", airbyteStateMessage.getType());
           return new GlobalStateManager(generateGlobalState(airbyteStateMessage), catalog);
         case STREAM:
         default:
-          LOGGER.info("Stream state manager selected to manage state object with type {}.", airbyteStateMessage.getStateType());
+          LOGGER.info("Stream state manager selected to manage state object with type {}.", airbyteStateMessage.getType());
           return new StreamStateManager(generateStreamState(initialState), catalog);
       }
     } else {
@@ -76,12 +76,12 @@ public class StateManagerFactory {
   private static AirbyteStateMessage generateGlobalState(final AirbyteStateMessage airbyteStateMessage) {
     AirbyteStateMessage globalStateMessage = airbyteStateMessage;
 
-    switch (airbyteStateMessage.getStateType()) {
+    switch (airbyteStateMessage.getType()) {
       case STREAM:
         throw new IllegalArgumentException("Unable to convert connector state from stream to global.  Please reset the connection to continue.");
       case LEGACY:
         globalStateMessage = StateGeneratorUtils.convertLegacyStateToGlobalState(airbyteStateMessage);
-        LOGGER.info("Legacy state converted to global state.", airbyteStateMessage.getStateType());
+        LOGGER.info("Legacy state converted to global state.", airbyteStateMessage.getType());
         break;
       case GLOBAL:
       default:
@@ -107,7 +107,7 @@ public class StateManagerFactory {
   private static List<AirbyteStateMessage> generateStreamState(final List<AirbyteStateMessage> states) {
     final AirbyteStateMessage airbyteStateMessage = states.get(0);
     final List<AirbyteStateMessage> streamStates = new ArrayList<>();
-    switch (airbyteStateMessage.getStateType()) {
+    switch (airbyteStateMessage.getType()) {
       case GLOBAL:
         throw new IllegalArgumentException("Unable to convert connector state from global to stream.  Please reset the connection to continue.");
       case LEGACY:

--- a/airbyte-integrations/connectors/source-relational-db/src/main/java/io/airbyte/integrations/source/relationaldb/state/StreamStateManager.java
+++ b/airbyte-integrations/connectors/source-relational-db/src/main/java/io/airbyte/integrations/source/relationaldb/state/StreamStateManager.java
@@ -64,17 +64,17 @@ public class StreamStateManager extends AbstractStateManager<AirbyteStateMessage
       if (cursorInfo.isPresent()) {
         LOGGER.debug("Generating state message for {}...", pair);
         return new AirbyteStateMessage()
-            .withStateType(AirbyteStateType.STREAM)
+            .withType(AirbyteStateType.STREAM)
             // Temporarily include legacy state for backwards compatibility with the platform
             .withData(Jsons.jsonNode(StateGeneratorUtils.generateDbState(pairToCursorInfoMap)))
             .withStream(StateGeneratorUtils.generateStreamState(pair.get(), cursorInfo.get()));
       } else {
         LOGGER.warn("Cursor information could not be located in state for stream {}.  Returning a new, empty state message...", pair);
-        return new AirbyteStateMessage().withStateType(AirbyteStateType.STREAM).withStream(new AirbyteStreamState());
+        return new AirbyteStateMessage().withType(AirbyteStateType.STREAM).withStream(new AirbyteStreamState());
       }
     } else {
       LOGGER.warn("Stream not provided.  Returning a new, empty state message...");
-      return new AirbyteStateMessage().withStateType(AirbyteStateType.STREAM).withStream(new AirbyteStreamState());
+      return new AirbyteStateMessage().withType(AirbyteStateType.STREAM).withStream(new AirbyteStreamState());
     }
   }
 

--- a/airbyte-integrations/connectors/source-relational-db/src/test/java/io/airbyte/integrations/source/relationaldb/state/GlobalStateManagerTest.java
+++ b/airbyte-integrations/connectors/source-relational-db/src/test/java/io/airbyte/integrations/source/relationaldb/state/GlobalStateManagerTest.java
@@ -46,7 +46,7 @@ public class GlobalStateManagerTest {
         .withStreamStates(List.of(new AirbyteStreamState().withStreamDescriptor(new StreamDescriptor().withNamespace("namespace").withName("name"))
             .withStreamState(Jsons.jsonNode(new DbStreamState()))));
     final StateManager stateManager =
-        new GlobalStateManager(new AirbyteStateMessage().withStateType(AirbyteStateType.GLOBAL).withGlobal(globalState), catalog);
+        new GlobalStateManager(new AirbyteStateMessage().withType(AirbyteStateType.GLOBAL).withGlobal(globalState), catalog);
     assertNotNull(stateManager.getCdcStateManager());
     assertEquals(cdcState, stateManager.getCdcStateManager().getCdcState());
   }
@@ -127,7 +127,7 @@ public class GlobalStateManagerTest {
     final AirbyteStateMessage expected = new AirbyteStateMessage()
         .withData(Jsons.jsonNode(expectedDbState))
         .withGlobal(expectedGlobalState)
-        .withStateType(AirbyteStateType.GLOBAL);
+        .withType(AirbyteStateType.GLOBAL);
 
     final AirbyteStateMessage actualFirstEmission = stateManager.updateAndEmit(NAME_NAMESPACE_PAIR1, "a");
     assertEquals(expected, actualFirstEmission);
@@ -150,7 +150,7 @@ public class GlobalStateManagerTest {
     final AirbyteGlobalState globalState = new AirbyteGlobalState().withSharedState(Jsons.jsonNode(new DbState())).withStreamStates(
         List.of(new AirbyteStreamState().withStreamDescriptor(new StreamDescriptor()).withStreamState(Jsons.jsonNode(new DbStreamState()))));
     final StateManager stateManager =
-        new GlobalStateManager(new AirbyteStateMessage().withStateType(AirbyteStateType.GLOBAL).withGlobal(globalState), catalog);
+        new GlobalStateManager(new AirbyteStateMessage().withType(AirbyteStateType.GLOBAL).withGlobal(globalState), catalog);
     stateManager.getCdcStateManager().setCdcState(cdcState);
 
     final DbState expectedDbState = new DbState()
@@ -196,7 +196,7 @@ public class GlobalStateManagerTest {
     final AirbyteStateMessage expected = new AirbyteStateMessage()
         .withData(Jsons.jsonNode(expectedDbState))
         .withGlobal(expectedGlobalState)
-        .withStateType(AirbyteStateType.GLOBAL);
+        .withType(AirbyteStateType.GLOBAL);
 
     final AirbyteStateMessage actualFirstEmission = stateManager.updateAndEmit(NAME_NAMESPACE_PAIR1, "a");
     assertEquals(expected, actualFirstEmission);

--- a/airbyte-integrations/connectors/source-relational-db/src/test/java/io/airbyte/integrations/source/relationaldb/state/LegacyStateManagerTest.java
+++ b/airbyte-integrations/connectors/source-relational-db/src/test/java/io/airbyte/integrations/source/relationaldb/state/LegacyStateManagerTest.java
@@ -82,7 +82,7 @@ public class LegacyStateManagerTest {
     final StateManager stateManager = new LegacyStateManager(new DbState(), catalog);
 
     final AirbyteStateMessage expectedFirstEmission = new AirbyteStateMessage()
-        .withStateType(AirbyteStateType.LEGACY)
+        .withType(AirbyteStateType.LEGACY)
         .withData(Jsons.jsonNode(new DbState().withStreams(List.of(
             new DbStreamState().withStreamName(STREAM_NAME1).withStreamNamespace(NAMESPACE).withCursorField(List.of(CURSOR_FIELD1))
                 .withCursor("a"),
@@ -93,7 +93,7 @@ public class LegacyStateManagerTest {
     final AirbyteStateMessage actualFirstEmission = stateManager.updateAndEmit(NAME_NAMESPACE_PAIR1, "a");
     assertEquals(expectedFirstEmission, actualFirstEmission);
     final AirbyteStateMessage expectedSecondEmission = new AirbyteStateMessage()
-        .withStateType(AirbyteStateType.LEGACY)
+        .withType(AirbyteStateType.LEGACY)
         .withData(Jsons.jsonNode(new DbState().withStreams(List.of(
             new DbStreamState().withStreamName(STREAM_NAME1).withStreamNamespace(NAMESPACE).withCursorField(List.of(CURSOR_FIELD1))
                 .withCursor("a"),
@@ -118,7 +118,7 @@ public class LegacyStateManagerTest {
     final StateManager stateManager = new LegacyStateManager(new DbState(), catalog);
 
     final AirbyteStateMessage expectedFirstEmission = new AirbyteStateMessage()
-        .withStateType(AirbyteStateType.LEGACY)
+        .withType(AirbyteStateType.LEGACY)
         .withData(Jsons.jsonNode(new DbState().withStreams(List.of(
             new DbStreamState().withStreamName(STREAM_NAME1).withStreamNamespace(NAMESPACE).withCursorField(List.of(CURSOR_FIELD1))
                 .withCursor("a"),
@@ -145,7 +145,7 @@ public class LegacyStateManagerTest {
     final StateManager stateManager = new LegacyStateManager(state, catalog);
 
     final AirbyteStateMessage expectedFirstEmission = new AirbyteStateMessage()
-        .withStateType(AirbyteStateType.LEGACY)
+        .withType(AirbyteStateType.LEGACY)
         .withData(Jsons.jsonNode(new DbState().withStreams(List.of(
             new DbStreamState().withStreamName(STREAM_NAME1).withStreamNamespace(NAMESPACE).withCursorField(List.of(CURSOR_FIELD1))
                 .withCursor(null),
@@ -155,7 +155,7 @@ public class LegacyStateManagerTest {
     final AirbyteStateMessage actualFirstEmission = stateManager.updateAndEmit(NAME_NAMESPACE_PAIR1, "a");
     assertEquals(expectedFirstEmission, actualFirstEmission);
     final AirbyteStateMessage expectedSecondEmission = new AirbyteStateMessage()
-        .withStateType(AirbyteStateType.LEGACY)
+        .withType(AirbyteStateType.LEGACY)
         .withData(Jsons.jsonNode(new DbState().withStreams(List.of(
             new DbStreamState().withStreamName(STREAM_NAME1).withStreamNamespace(NAMESPACE).withCursorField(List.of(CURSOR_FIELD1))
                 .withCursor(null),

--- a/airbyte-integrations/connectors/source-relational-db/src/test/java/io/airbyte/integrations/source/relationaldb/state/StateManagerFactoryTest.java
+++ b/airbyte-integrations/connectors/source-relational-db/src/test/java/io/airbyte/integrations/source/relationaldb/state/StateManagerFactoryTest.java
@@ -77,7 +77,7 @@ public class StateManagerFactoryTest {
         new AirbyteGlobalState().withSharedState(Jsons.jsonNode(new DbState().withCdcState(new CdcState().withState(Jsons.jsonNode(new DbState())))))
             .withStreamStates(List.of(new AirbyteStreamState().withStreamDescriptor(new StreamDescriptor().withNamespace(NAMESPACE).withName(NAME))
                 .withStreamState(Jsons.jsonNode(new DbStreamState()))));
-    final AirbyteStateMessage airbyteStateMessage = new AirbyteStateMessage().withStateType(AirbyteStateType.GLOBAL).withGlobal(globalState);
+    final AirbyteStateMessage airbyteStateMessage = new AirbyteStateMessage().withType(AirbyteStateType.GLOBAL).withGlobal(globalState);
 
     final StateManager stateManager = StateManagerFactory.createStateManager(AirbyteStateType.GLOBAL, List.of(airbyteStateMessage), catalog);
 
@@ -93,7 +93,7 @@ public class StateManagerFactoryTest {
         .withCdcState(cdcState)
         .withStreams(List.of(new DbStreamState().withStreamName(NAME).withStreamNamespace(NAMESPACE)));
     final AirbyteStateMessage airbyteStateMessage =
-        new AirbyteStateMessage().withStateType(AirbyteStateType.LEGACY).withData(Jsons.jsonNode(dbState));
+        new AirbyteStateMessage().withType(AirbyteStateType.LEGACY).withData(Jsons.jsonNode(dbState));
 
     final StateManager stateManager = StateManagerFactory.createStateManager(AirbyteStateType.GLOBAL, List.of(airbyteStateMessage), catalog);
 
@@ -104,7 +104,7 @@ public class StateManagerFactoryTest {
   @Test
   void testGlobalStateManagerCreationFromStreamState() {
     final ConfiguredAirbyteCatalog catalog = mock(ConfiguredAirbyteCatalog.class);
-    final AirbyteStateMessage airbyteStateMessage = new AirbyteStateMessage().withStateType(AirbyteStateType.STREAM)
+    final AirbyteStateMessage airbyteStateMessage = new AirbyteStateMessage().withType(AirbyteStateType.STREAM)
         .withStream(new AirbyteStreamState().withStreamDescriptor(new StreamDescriptor().withName(NAME).withNamespace(
             NAMESPACE)).withStreamState(Jsons.jsonNode(new DbStreamState())));
 
@@ -120,7 +120,7 @@ public class StateManagerFactoryTest {
             .withStreamStates(List.of(new AirbyteStreamState().withStreamDescriptor(new StreamDescriptor().withNamespace(NAMESPACE).withName(NAME))
                 .withStreamState(Jsons.jsonNode(new DbStreamState()))));
     final AirbyteStateMessage airbyteStateMessage =
-        new AirbyteStateMessage().withStateType(AirbyteStateType.GLOBAL).withGlobal(globalState).withData(Jsons.jsonNode(new DbState()));
+        new AirbyteStateMessage().withType(AirbyteStateType.GLOBAL).withGlobal(globalState).withData(Jsons.jsonNode(new DbState()));
 
     final StateManager stateManager = StateManagerFactory.createStateManager(AirbyteStateType.GLOBAL, List.of(airbyteStateMessage), catalog);
 
@@ -131,7 +131,7 @@ public class StateManagerFactoryTest {
   @Test
   void testStreamStateManagerCreation() {
     final ConfiguredAirbyteCatalog catalog = mock(ConfiguredAirbyteCatalog.class);
-    final AirbyteStateMessage airbyteStateMessage = new AirbyteStateMessage().withStateType(AirbyteStateType.STREAM)
+    final AirbyteStateMessage airbyteStateMessage = new AirbyteStateMessage().withType(AirbyteStateType.STREAM)
         .withStream(new AirbyteStreamState().withStreamDescriptor(new StreamDescriptor().withName(NAME).withNamespace(
             NAMESPACE)).withStreamState(Jsons.jsonNode(new DbStreamState())));
 
@@ -149,7 +149,7 @@ public class StateManagerFactoryTest {
         .withCdcState(cdcState)
         .withStreams(List.of(new DbStreamState().withStreamName(NAME).withStreamNamespace(NAMESPACE)));
     final AirbyteStateMessage airbyteStateMessage =
-        new AirbyteStateMessage().withStateType(AirbyteStateType.LEGACY).withData(Jsons.jsonNode(dbState));
+        new AirbyteStateMessage().withType(AirbyteStateType.LEGACY).withData(Jsons.jsonNode(dbState));
 
     final StateManager stateManager = StateManagerFactory.createStateManager(AirbyteStateType.STREAM, List.of(airbyteStateMessage), catalog);
 
@@ -164,7 +164,7 @@ public class StateManagerFactoryTest {
         new AirbyteGlobalState().withSharedState(Jsons.jsonNode(new DbState().withCdcState(new CdcState().withState(Jsons.jsonNode(new DbState())))))
             .withStreamStates(List.of(new AirbyteStreamState().withStreamDescriptor(new StreamDescriptor().withNamespace(NAMESPACE).withName(NAME))
                 .withStreamState(Jsons.jsonNode(new DbStreamState()))));
-    final AirbyteStateMessage airbyteStateMessage = new AirbyteStateMessage().withStateType(AirbyteStateType.GLOBAL).withGlobal(globalState);
+    final AirbyteStateMessage airbyteStateMessage = new AirbyteStateMessage().withType(AirbyteStateType.GLOBAL).withGlobal(globalState);
 
     Assertions.assertThrows(IllegalArgumentException.class,
         () -> StateManagerFactory.createStateManager(AirbyteStateType.STREAM, List.of(airbyteStateMessage), catalog));
@@ -173,7 +173,7 @@ public class StateManagerFactoryTest {
   @Test
   void testStreamStateManagerCreationWithLegacyDataPresent() {
     final ConfiguredAirbyteCatalog catalog = mock(ConfiguredAirbyteCatalog.class);
-    final AirbyteStateMessage airbyteStateMessage = new AirbyteStateMessage().withStateType(AirbyteStateType.STREAM)
+    final AirbyteStateMessage airbyteStateMessage = new AirbyteStateMessage().withType(AirbyteStateType.STREAM)
         .withStream(new AirbyteStreamState().withStreamDescriptor(new StreamDescriptor().withName(NAME).withNamespace(
             NAMESPACE)).withStreamState(Jsons.jsonNode(new DbStreamState())))
         .withData(Jsons.jsonNode(new DbState()));

--- a/airbyte-integrations/connectors/source-relational-db/src/test/java/io/airbyte/integrations/source/relationaldb/state/StreamStateManagerTest.java
+++ b/airbyte-integrations/connectors/source-relational-db/src/test/java/io/airbyte/integrations/source/relationaldb/state/StreamStateManagerTest.java
@@ -45,7 +45,7 @@ public class StreamStateManagerTest {
   @Test
   void testCreationFromInvalidState() {
     final AirbyteStateMessage airbyteStateMessage = new AirbyteStateMessage()
-        .withStateType(AirbyteStateType.STREAM)
+        .withType(AirbyteStateType.STREAM)
         .withStream(new AirbyteStreamState()
             .withStreamDescriptor(new StreamDescriptor().withName(STREAM_NAME1).withNamespace(NAMESPACE))
             .withStreamState(Jsons.jsonNode("Not a state object")));
@@ -162,7 +162,7 @@ public class StreamStateManagerTest {
     final StateManager stateManager = new StreamStateManager(createDefaultState(), catalog);
     final AirbyteStateMessage airbyteStateMessage = stateManager.toState(Optional.of(airbyteStreamNameNamespacePair));
     assertNotNull(airbyteStateMessage);
-    assertEquals(AirbyteStateType.STREAM, airbyteStateMessage.getStateType());
+    assertEquals(AirbyteStateType.STREAM, airbyteStateMessage.getType());
     assertNotNull(airbyteStateMessage.getStream());
   }
 
@@ -182,7 +182,7 @@ public class StreamStateManagerTest {
     final StateManager stateManager = new StreamStateManager(createDefaultState(), catalog);
     final AirbyteStateMessage airbyteStateMessage = stateManager.toState(Optional.empty());
     assertNotNull(airbyteStateMessage);
-    assertEquals(AirbyteStateType.STREAM, airbyteStateMessage.getStateType());
+    assertEquals(AirbyteStateType.STREAM, airbyteStateMessage.getType());
     assertNotNull(airbyteStateMessage.getStream());
     assertNull(airbyteStateMessage.getStream().getStreamState());
   }
@@ -221,12 +221,12 @@ public class StreamStateManagerTest {
   void testCdcStateManager() {
     final ConfiguredAirbyteCatalog catalog = mock(ConfiguredAirbyteCatalog.class);
     final StateManager stateManager = new StreamStateManager(
-        List.of(new AirbyteStateMessage().withStateType(AirbyteStateType.STREAM).withStream(new AirbyteStreamState())), catalog);
+        List.of(new AirbyteStateMessage().withType(AirbyteStateType.STREAM).withStream(new AirbyteStreamState())), catalog);
     Assertions.assertThrows(UnsupportedOperationException.class, () -> stateManager.getCdcStateManager());
   }
 
   private List<AirbyteStateMessage> createDefaultState() {
-    return List.of(new AirbyteStateMessage().withStateType(AirbyteStateType.STREAM).withStream(new AirbyteStreamState()));
+    return List.of(new AirbyteStateMessage().withType(AirbyteStateType.STREAM).withStream(new AirbyteStreamState()));
   }
 
   private AirbyteStateMessage createStreamState(final String name,
@@ -246,7 +246,7 @@ public class StreamStateManagerTest {
     }
 
     return new AirbyteStateMessage()
-        .withStateType(AirbyteStateType.STREAM)
+        .withType(AirbyteStateType.STREAM)
         .withStream(new AirbyteStreamState()
             .withStreamDescriptor(new StreamDescriptor().withName(name).withNamespace(namespace))
             .withStreamState(Jsons.jsonNode(dbStreamState)));

--- a/airbyte-protocol/protocol-models/src/main/resources/airbyte_protocol/airbyte_protocol.yaml
+++ b/airbyte-protocol/protocol-models/src/main/resources/airbyte_protocol/airbyte_protocol.yaml
@@ -72,7 +72,7 @@ definitions:
     type: object
     additionalProperties: true
     properties:
-      state_type:
+      type:
         "$ref": "#/definitions/AirbyteStateType"
       stream:
         "$ref": "#/definitions/AirbyteStreamState"


### PR DESCRIPTION
## What
On 12 May 2022, the Airbyte protocol was updated to include the following enum values for `AirbyteStateType` (call this `intermediate protocol`): https://github.com/airbytehq/airbyte/commit/b3373b97422b9ec0b4127e3b1f1bf3202fe2af4f#diff-7b7bbf243d46f3cf9472f40a52d091011bd57d82695d323a9adcd7ea656dfd15R95-R97
On 10 June 2022, the Airbyte protocol was updated again with the following change to these enum values (call this `current protocol`): https://github.com/airbytehq/airbyte/commit/704dd8b53497036160ae1594690d85b0d58ca509#diff-23f6bc12d2cf0cbb40771b96abb371d79d04b0eeccfe92d276f314325600b029R96-R99

It was not realized at that time that the second change introduced a compatibility issue. Several destination connectors had been published using the intermediate protocol during that ~1 month window between when the two changes were made. 

Now, when an Airbyte source that is running with the current protocol tries to emit a state message with `state_type` set to either `STREAM` or `LEGACY`, the destinations built on the intermediate protocol will fail to deserialize those messages at [this line](https://github.com/airbytehq/airbyte/blob/cb90d7be0cc618450c965afc22a402793a2b2060/airbyte-integrations/bases/base-java/src/main/java/io/airbyte/integrations/base/IntegrationRunner.java#L192) of code, because those enum values are not present in the intermediate protocol. 

This PR aims to solve this issue by changing the name of the `state_type` field.

## How
Changing the `state_type` field name to `type` should solve this incompatibility issue, because it will mean that sources on the newest protocol will be emitting state messages with `type: STREAM` or `type: LEGACY`, which destinations on the intermediate protocol will ignore because that `type` key doesn't exist in the intermediate protocol, so they will treat those as additional properties.

Since we do not actually rely on these new fields to correctly perform state logic at the moment (the platform currently just cares about the `data` field), this should be a safe change to make.

## Recommended reading order
1. airbyte_protocol.yaml
2. airbyte_protocol.py
3. The rest of the changes replace usages of `stateType` with `type` on AirbyteStateMessages