### PR TITLE
📝 Kustomize: Use `resources` since `bases` is deprecated

### DIFF
--- a/docs/deploying-airbyte/on-kubernetes.md
+++ b/docs/deploying-airbyte/on-kubernetes.md
@@ -201,7 +201,7 @@ Example `kustomization.yaml` file:
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 
-bases:
+resources:
   - https://github.com/airbytehq/airbyte.git/kube/overlays/stable?ref=master
 ```
 

--- a/kube/overlays/dev-integration-test/kustomization.yaml
+++ b/kube/overlays/dev-integration-test/kustomization.yaml
@@ -3,7 +3,7 @@ kind: Kustomization
 
 namespace: default
 
-bases:
+resources:
   - ../../resources
 
 images:

--- a/kube/overlays/dev/kustomization.yaml
+++ b/kube/overlays/dev/kustomization.yaml
@@ -3,7 +3,7 @@ kind: Kustomization
 
 namespace: default
 
-bases:
+resources:
   - ../../resources
 
 images:

--- a/kube/overlays/stable-with-resource-limits/kustomization.yaml
+++ b/kube/overlays/stable-with-resource-limits/kustomization.yaml
@@ -3,7 +3,7 @@ kind: Kustomization
 
 namespace: default
 
-bases:
+resources:
   - ../../resources
 
 images:

--- a/kube/overlays/stable/kustomization.yaml
+++ b/kube/overlays/stable/kustomization.yaml
@@ -3,7 +3,7 @@ kind: Kustomization
 
 namespace: default
 
-bases:
+resources:
   - ../../resources
 
 images:


### PR DESCRIPTION
## What
Issue: #14036

>I was deploying Airbyte and got an error when trying to modify the configuration using [Customizing Airbyte Manifests](https://docs.airbyte.com/deploying-airbyte/on-kubernetes/#customizing-airbyte-manifests).
>
>While researching, I found the issue I had was related to bases [being deprecated in Kustomize](https://kubectl.docs.kubernetes.io/references/kustomize/kustomization/bases/) with resources being recommended to use instead.

This PR update the `kustomization.yaml` example in the [Deploying > On Kubernetes > Customizing Airbyte Manifests](https://docs.airbyte.com/deploying-airbyte/on-kubernetes/#customizing-airbyte-manifests) documentation.

## How
*Describe the solution*

[Per the Kustomize Documentation](https://kubectl.docs.kubernetes.io/references/kustomize/kustomization/bases/), `bases` has been deprecated and `resources` is the recommended replacement.
This PR updates the documentation to reflect that change.

## 🚨 User Impact 🚨
Are there any breaking changes? What is the end result perceived by the user? If yes, please merge this PR with the 🚨🚨 emoji so changelog authors can further highlight this if needed.

Since `bases` has been deprecated, eventually anyone using `bases` in their `kustomization.yaml` will need to update their files to use `resources` instead. Also worth mentioning that this is a change outside of Airbyte; I'm not sure what your metric of breaking change in this case.