### PR TITLE
fix stream name in stream transformation update

### DIFF
--- a/airbyte-api/src/main/openapi/config.yaml
+++ b/airbyte-api/src/main/openapi/config.yaml
@@ -4139,7 +4139,7 @@ components:
         newSchema:
           $ref: "#/components/schemas/FieldSchema"
     FieldName:
-      description: A field name is a list of strings that for the path to the field.
+      description: A field name is a list of strings that form the path to the field.
       type: array
       items:
         type: string

--- a/airbyte-api/src/main/openapi/config.yaml
+++ b/airbyte-api/src/main/openapi/config.yaml
@@ -4082,6 +4082,7 @@ components:
       type: object
       required:
         - transformType
+        - streamDescriptor
       properties:
         transformType:
           type: string
@@ -4089,9 +4090,7 @@ components:
             - add_stream
             - remove_stream
             - update_stream
-        addStream:
-          $ref: "#/components/schemas/StreamDescriptor"
-        removeStream:
+        streamDescriptor:
           $ref: "#/components/schemas/StreamDescriptor"
         updateStream:
           type: array
@@ -4103,6 +4102,7 @@ components:
       description: "Describes the difference between two Streams."
       required:
         - transformType
+        - fieldName
       properties:
         transformType:
           type: string
@@ -4110,39 +4110,39 @@ components:
             - add_field
             - remove_field
             - update_field_schema
+        fieldName:
+          $ref: "#/components/schemas/FieldName"
         addField:
-          $ref: "#/components/schemas/FieldNameAndSchema"
+          $ref: "#/components/schemas/FieldAdd"
         removeField:
-          $ref: "#/components/schemas/FieldNameAndSchema"
+          $ref: "#/components/schemas/FieldRemove"
         updateFieldSchema:
           $ref: "#/components/schemas/FieldSchemaUpdate"
-    FieldNameAndSchema:
+    FieldAdd:
       type: object
-      required:
-        - fieldName
-        - fieldSchema
       properties:
-        fieldName:
-          type: array
-          items:
-            type: string
-        fieldSchema:
+        schema:
+          $ref: "#/components/schemas/FieldSchema"
+    FieldRemove:
+      type: object
+      properties:
+        schema:
           $ref: "#/components/schemas/FieldSchema"
     FieldSchemaUpdate:
       type: object
       required:
-        - fieldName
         - oldSchema
         - newSchema
       properties:
-        fieldName:
-          type: array
-          items:
-            type: string
         oldSchema:
           $ref: "#/components/schemas/FieldSchema"
         newSchema:
           $ref: "#/components/schemas/FieldSchema"
+    FieldName:
+      description: A field name is a list of strings that for the path to the field.
+      type: array
+      items:
+        type: string
     FieldSchema:
       description: JSONSchema representation of the field
       type: object

--- a/airbyte-protocol/protocol-models/src/main/java/io/airbyte/protocol/models/CatalogHelpers.java
+++ b/airbyte-protocol/protocol-models/src/main/java/io/airbyte/protocol/models/CatalogHelpers.java
@@ -16,7 +16,7 @@ import io.airbyte.commons.util.MoreIterators;
 import io.airbyte.commons.util.MoreLists;
 import io.airbyte.protocol.models.transform_models.FieldTransform;
 import io.airbyte.protocol.models.transform_models.StreamTransform;
-import io.airbyte.protocol.models.transform_models.UpdateFieldTransform;
+import io.airbyte.protocol.models.transform_models.UpdateFieldSchemaTransform;
 import io.airbyte.protocol.models.transform_models.UpdateStreamTransform;
 import java.util.ArrayList;
 import java.util.Arrays;
@@ -306,7 +306,7 @@ public class CatalogHelpers {
           final AirbyteStream streamOld = descriptorToStreamOld.get(descriptor);
           final AirbyteStream streamNew = descriptorToStreamNew.get(descriptor);
           if (!streamOld.equals(streamNew)) {
-            streamTransforms.add(StreamTransform.createUpdateStreamTransform(getStreamDiff(descriptor, streamOld, streamNew)));
+            streamTransforms.add(StreamTransform.createUpdateStreamTransform(descriptor, getStreamDiff(descriptor, streamOld, streamNew)));
           }
         });
 
@@ -333,10 +333,10 @@ public class CatalogHelpers {
       final JsonNode newType = fieldNameToTypeNew.get(fieldName);
 
       if (!oldType.equals(newType)) {
-        fieldTransforms.add(FieldTransform.createUpdateFieldTransform(new UpdateFieldTransform(fieldName, oldType, newType)));
+        fieldTransforms.add(FieldTransform.createUpdateFieldTransform(fieldName, new UpdateFieldSchemaTransform(oldType, newType)));
       }
     });
-    return new UpdateStreamTransform(descriptor, fieldTransforms);
+    return new UpdateStreamTransform(fieldTransforms);
   }
 
 }

--- a/airbyte-protocol/protocol-models/src/main/java/io/airbyte/protocol/models/transform_models/AddFieldTransform.java
+++ b/airbyte-protocol/protocol-models/src/main/java/io/airbyte/protocol/models/transform_models/AddFieldTransform.java
@@ -5,8 +5,6 @@
 package io.airbyte.protocol.models.transform_models;
 
 import com.fasterxml.jackson.databind.JsonNode;
-import java.util.ArrayList;
-import java.util.List;
 import lombok.AllArgsConstructor;
 import lombok.EqualsAndHashCode;
 import lombok.ToString;

--- a/airbyte-protocol/protocol-models/src/main/java/io/airbyte/protocol/models/transform_models/AddFieldTransform.java
+++ b/airbyte-protocol/protocol-models/src/main/java/io/airbyte/protocol/models/transform_models/AddFieldTransform.java
@@ -19,12 +19,7 @@ import lombok.ToString;
 @ToString
 public class AddFieldTransform {
 
-  private final List<String> fieldName;
   private final JsonNode schema;
-
-  public List<String> getFieldName() {
-    return new ArrayList<>(fieldName);
-  }
 
   public JsonNode getSchema() {
     return schema;

--- a/airbyte-protocol/protocol-models/src/main/java/io/airbyte/protocol/models/transform_models/FieldTransform.java
+++ b/airbyte-protocol/protocol-models/src/main/java/io/airbyte/protocol/models/transform_models/FieldTransform.java
@@ -19,32 +19,37 @@ import lombok.ToString;
 public final class FieldTransform {
 
   private final FieldTransformType transformType;
+  private final List<String> fieldName;
   private final AddFieldTransform addFieldTransform;
   private final RemoveFieldTransform removeFieldTransform;
-  private final UpdateFieldTransform updateFieldTransform;
+  private final UpdateFieldSchemaTransform updateFieldTransform;
 
   public static FieldTransform createAddFieldTransform(final List<String> fieldName, final JsonNode schema) {
-    return createAddFieldTransform(new AddFieldTransform(fieldName, schema));
+    return createAddFieldTransform(fieldName, new AddFieldTransform(schema));
   }
 
-  public static FieldTransform createAddFieldTransform(final AddFieldTransform addFieldTransform) {
-    return new FieldTransform(FieldTransformType.ADD_FIELD, addFieldTransform, null, null);
+  public static FieldTransform createAddFieldTransform(final List<String> fieldName, final AddFieldTransform addFieldTransform) {
+    return new FieldTransform(FieldTransformType.ADD_FIELD, fieldName, addFieldTransform, null, null);
   }
 
   public static FieldTransform createRemoveFieldTransform(final List<String> fieldName, final JsonNode schema) {
-    return createRemoveFieldTransform(new RemoveFieldTransform(fieldName, schema));
+    return createRemoveFieldTransform(fieldName, new RemoveFieldTransform(fieldName, schema));
   }
 
-  public static FieldTransform createRemoveFieldTransform(final RemoveFieldTransform removeFieldTransform) {
-    return new FieldTransform(FieldTransformType.REMOVE_FIELD, null, removeFieldTransform, null);
+  public static FieldTransform createRemoveFieldTransform(final List<String> fieldName, final RemoveFieldTransform removeFieldTransform) {
+    return new FieldTransform(FieldTransformType.REMOVE_FIELD, fieldName, null, removeFieldTransform, null);
   }
 
-  public static FieldTransform createUpdateFieldTransform(final UpdateFieldTransform updateFieldTransform) {
-    return new FieldTransform(FieldTransformType.UPDATE_FIELD, null, null, updateFieldTransform);
+  public static FieldTransform createUpdateFieldTransform(final List<String> fieldName, final UpdateFieldSchemaTransform updateFieldTransform) {
+    return new FieldTransform(FieldTransformType.UPDATE_FIELD, fieldName, null,null, updateFieldTransform);
   }
 
   public FieldTransformType getTransformType() {
     return transformType;
+  }
+
+  public List<String> getFieldName() {
+    return fieldName;
   }
 
   public AddFieldTransform getAddFieldTransform() {
@@ -55,7 +60,7 @@ public final class FieldTransform {
     return removeFieldTransform;
   }
 
-  public UpdateFieldTransform getUpdateFieldTransform() {
+  public UpdateFieldSchemaTransform getUpdateFieldTransform() {
     return updateFieldTransform;
   }
 

--- a/airbyte-protocol/protocol-models/src/main/java/io/airbyte/protocol/models/transform_models/FieldTransform.java
+++ b/airbyte-protocol/protocol-models/src/main/java/io/airbyte/protocol/models/transform_models/FieldTransform.java
@@ -41,7 +41,7 @@ public final class FieldTransform {
   }
 
   public static FieldTransform createUpdateFieldTransform(final List<String> fieldName, final UpdateFieldSchemaTransform updateFieldTransform) {
-    return new FieldTransform(FieldTransformType.UPDATE_FIELD, fieldName, null,null, updateFieldTransform);
+    return new FieldTransform(FieldTransformType.UPDATE_FIELD, fieldName, null, null, updateFieldTransform);
   }
 
   public FieldTransformType getTransformType() {

--- a/airbyte-protocol/protocol-models/src/main/java/io/airbyte/protocol/models/transform_models/StreamTransform.java
+++ b/airbyte-protocol/protocol-models/src/main/java/io/airbyte/protocol/models/transform_models/StreamTransform.java
@@ -29,7 +29,8 @@ public final class StreamTransform {
     return new StreamTransform(StreamTransformType.REMOVE_STREAM, streamDescriptor, null);
   }
 
-  public static StreamTransform createUpdateStreamTransform(final StreamDescriptor streamDescriptor, final UpdateStreamTransform updateStreamTransform) {
+  public static StreamTransform createUpdateStreamTransform(final StreamDescriptor streamDescriptor,
+                                                            final UpdateStreamTransform updateStreamTransform) {
     return new StreamTransform(StreamTransformType.UPDATE_STREAM, streamDescriptor, updateStreamTransform);
   }
 

--- a/airbyte-protocol/protocol-models/src/main/java/io/airbyte/protocol/models/transform_models/StreamTransform.java
+++ b/airbyte-protocol/protocol-models/src/main/java/io/airbyte/protocol/models/transform_models/StreamTransform.java
@@ -18,40 +18,27 @@ import lombok.ToString;
 public final class StreamTransform {
 
   private final StreamTransformType transformType;
-  private final AddStreamTransform addStreamTransform;
-  private final RemoveStreamTransform removeStreamTransform;
+  private final StreamDescriptor streamDescriptor;
   private final UpdateStreamTransform updateStreamTransform;
 
   public static StreamTransform createAddStreamTransform(final StreamDescriptor streamDescriptor) {
-    return createAddStreamTransform(new AddStreamTransform(streamDescriptor));
-  }
-
-  public static StreamTransform createAddStreamTransform(final AddStreamTransform addStreamTransform) {
-    return new StreamTransform(StreamTransformType.ADD_STREAM, addStreamTransform, null, null);
+    return new StreamTransform(StreamTransformType.ADD_STREAM, streamDescriptor, null);
   }
 
   public static StreamTransform createRemoveStreamTransform(final StreamDescriptor streamDescriptor) {
-    return createRemoveStreamTransform(new RemoveStreamTransform(streamDescriptor));
+    return new StreamTransform(StreamTransformType.REMOVE_STREAM, streamDescriptor, null);
   }
 
-  public static StreamTransform createRemoveStreamTransform(final RemoveStreamTransform removeStreamTransform) {
-    return new StreamTransform(StreamTransformType.REMOVE_STREAM, null, removeStreamTransform, null);
-  }
-
-  public static StreamTransform createUpdateStreamTransform(final UpdateStreamTransform updateStreamTransform) {
-    return new StreamTransform(StreamTransformType.UPDATE_STREAM, null, null, updateStreamTransform);
+  public static StreamTransform createUpdateStreamTransform(final StreamDescriptor streamDescriptor, final UpdateStreamTransform updateStreamTransform) {
+    return new StreamTransform(StreamTransformType.UPDATE_STREAM, streamDescriptor, updateStreamTransform);
   }
 
   public StreamTransformType getTransformType() {
     return transformType;
   }
 
-  public AddStreamTransform getAddStreamTransform() {
-    return addStreamTransform;
-  }
-
-  public RemoveStreamTransform getRemoveStreamTransform() {
-    return removeStreamTransform;
+  public StreamDescriptor getStreamDescriptor() {
+    return streamDescriptor;
   }
 
   public UpdateStreamTransform getUpdateStreamTransform() {

--- a/airbyte-protocol/protocol-models/src/main/java/io/airbyte/protocol/models/transform_models/UpdateFieldSchemaTransform.java
+++ b/airbyte-protocol/protocol-models/src/main/java/io/airbyte/protocol/models/transform_models/UpdateFieldSchemaTransform.java
@@ -5,8 +5,6 @@
 package io.airbyte.protocol.models.transform_models;
 
 import com.fasterxml.jackson.databind.JsonNode;
-import java.util.ArrayList;
-import java.util.List;
 import lombok.AllArgsConstructor;
 import lombok.EqualsAndHashCode;
 import lombok.ToString;

--- a/airbyte-protocol/protocol-models/src/main/java/io/airbyte/protocol/models/transform_models/UpdateFieldSchemaTransform.java
+++ b/airbyte-protocol/protocol-models/src/main/java/io/airbyte/protocol/models/transform_models/UpdateFieldSchemaTransform.java
@@ -17,15 +17,10 @@ import lombok.ToString;
 @AllArgsConstructor
 @EqualsAndHashCode
 @ToString
-public class UpdateFieldTransform {
+public class UpdateFieldSchemaTransform {
 
-  private final List<String> fieldName;
   private final JsonNode oldSchema;
   private final JsonNode newSchema;
-
-  public List<String> getFieldName() {
-    return new ArrayList<>(fieldName);
-  }
 
   public JsonNode getOldSchema() {
     return oldSchema;

--- a/airbyte-protocol/protocol-models/src/main/java/io/airbyte/protocol/models/transform_models/UpdateStreamTransform.java
+++ b/airbyte-protocol/protocol-models/src/main/java/io/airbyte/protocol/models/transform_models/UpdateStreamTransform.java
@@ -19,7 +19,6 @@ import lombok.ToString;
 @ToString
 public class UpdateStreamTransform {
 
-  private final StreamDescriptor streamDescriptor;
   private final Set<FieldTransform> fieldTransforms;
 
   public Set<FieldTransform> getFieldTransforms() {

--- a/airbyte-protocol/protocol-models/src/main/java/io/airbyte/protocol/models/transform_models/UpdateStreamTransform.java
+++ b/airbyte-protocol/protocol-models/src/main/java/io/airbyte/protocol/models/transform_models/UpdateStreamTransform.java
@@ -4,7 +4,6 @@
 
 package io.airbyte.protocol.models.transform_models;
 
-import io.airbyte.protocol.models.StreamDescriptor;
 import java.util.HashSet;
 import java.util.Set;
 import lombok.AllArgsConstructor;

--- a/airbyte-protocol/protocol-models/src/test/java/io/airbyte/protocol/models/CatalogHelpersTest.java
+++ b/airbyte-protocol/protocol-models/src/test/java/io/airbyte/protocol/models/CatalogHelpersTest.java
@@ -12,7 +12,7 @@ import io.airbyte.commons.json.Jsons;
 import io.airbyte.commons.resources.MoreResources;
 import io.airbyte.protocol.models.transform_models.FieldTransform;
 import io.airbyte.protocol.models.transform_models.StreamTransform;
-import io.airbyte.protocol.models.transform_models.UpdateFieldTransform;
+import io.airbyte.protocol.models.transform_models.UpdateFieldSchemaTransform;
 import io.airbyte.protocol.models.transform_models.UpdateStreamTransform;
 import java.io.IOException;
 import java.util.Comparator;
@@ -103,12 +103,11 @@ class CatalogHelpersTest {
     final List<StreamTransform> expectedDiff = Stream.of(
         StreamTransform.createAddStreamTransform(new StreamDescriptor().withName("sales")),
         StreamTransform.createRemoveStreamTransform(new StreamDescriptor().withName("accounts")),
-        StreamTransform.createUpdateStreamTransform(new UpdateStreamTransform(new StreamDescriptor().withName("users"), Set.of(
+        StreamTransform.createUpdateStreamTransform(new StreamDescriptor().withName("users"), new UpdateStreamTransform(Set.of(
             FieldTransform.createAddFieldTransform(List.of("COD"), schema2.get("properties").get("COD")),
             FieldTransform.createRemoveFieldTransform(List.of("something2"), schema1.get("properties").get("something2")),
             FieldTransform.createRemoveFieldTransform(List.of("HKD"), schema1.get("properties").get("HKD")),
-            FieldTransform.createUpdateFieldTransform(new UpdateFieldTransform(
-                List.of("CAD"),
+            FieldTransform.createUpdateFieldTransform(List.of("CAD"), new UpdateFieldSchemaTransform(
                 schema1.get("properties").get("CAD"),
                 schema2.get("properties").get("CAD")))))))
         .sorted(STREAM_TRANSFORM_COMPARATOR)

--- a/airbyte-server/src/main/java/io/airbyte/server/converters/CatalogDiffConverters.java
+++ b/airbyte-server/src/main/java/io/airbyte/server/converters/CatalogDiffConverters.java
@@ -4,10 +4,10 @@
 
 package io.airbyte.server.converters;
 
-import io.airbyte.api.model.generated.FieldNameAndSchema;
+import io.airbyte.api.model.generated.FieldAdd;
+import io.airbyte.api.model.generated.FieldRemove;
 import io.airbyte.api.model.generated.FieldSchemaUpdate;
 import io.airbyte.api.model.generated.FieldTransform;
-import io.airbyte.api.model.generated.StreamDescriptor;
 import io.airbyte.api.model.generated.StreamTransform;
 import io.airbyte.commons.enums.Enums;
 import io.airbyte.protocol.models.transform_models.FieldTransformType;
@@ -23,25 +23,8 @@ public class CatalogDiffConverters {
   public static StreamTransform streamTransformToApi(final io.airbyte.protocol.models.transform_models.StreamTransform transform) {
     return new StreamTransform()
         .transformType(Enums.convertTo(transform.getTransformType(), StreamTransform.TransformTypeEnum.class))
-        .addStream(addStreamToApi(transform).orElse(null))
-        .removeStream(removeStreamToApi(transform).orElse(null))
+        .streamDescriptor(ProtocolConverters.streamDescriptorToApi(transform.getStreamDescriptor()))
         .updateStream(updateStreamToApi(transform).orElse(null));
-  }
-
-  public static Optional<StreamDescriptor> addStreamToApi(final io.airbyte.protocol.models.transform_models.StreamTransform transform) {
-    if (transform.getTransformType() == StreamTransformType.ADD_STREAM) {
-      return Optional.ofNullable(ProtocolConverters.streamDescriptorToApi(transform.getAddStreamTransform().getStreamDescriptor()));
-    } else {
-      return Optional.empty();
-    }
-  }
-
-  public static Optional<StreamDescriptor> removeStreamToApi(final io.airbyte.protocol.models.transform_models.StreamTransform transform) {
-    if (transform.getTransformType() == StreamTransformType.REMOVE_STREAM) {
-      return Optional.ofNullable(ProtocolConverters.streamDescriptorToApi(transform.getRemoveStreamTransform().getStreamDescriptor()));
-    } else {
-      return Optional.empty();
-    }
   }
 
   public static Optional<List<FieldTransform>> updateStreamToApi(final io.airbyte.protocol.models.transform_models.StreamTransform transform) {
@@ -59,26 +42,25 @@ public class CatalogDiffConverters {
   public static FieldTransform fieldTransformToApi(final io.airbyte.protocol.models.transform_models.FieldTransform transform) {
     return new FieldTransform()
         .transformType(Enums.convertTo(transform.getTransformType(), FieldTransform.TransformTypeEnum.class))
+        .fieldName(transform.getFieldName())
         .addField(addFieldToApi(transform).orElse(null))
         .removeField(removeFieldToApi(transform).orElse(null))
         .updateFieldSchema(updateFieldToApi(transform).orElse(null));
   }
 
-  private static Optional<FieldNameAndSchema> addFieldToApi(final io.airbyte.protocol.models.transform_models.FieldTransform transform) {
+  private static Optional<FieldAdd> addFieldToApi(final io.airbyte.protocol.models.transform_models.FieldTransform transform) {
     if (transform.getTransformType() == FieldTransformType.ADD_FIELD) {
-      return Optional.of(new FieldNameAndSchema()
-          .fieldName(transform.getAddFieldTransform().getFieldName())
-          .fieldSchema(transform.getAddFieldTransform().getSchema()));
+      return Optional.of(new FieldAdd()
+          .schema(transform.getAddFieldTransform().getSchema()));
     } else {
       return Optional.empty();
     }
   }
 
-  private static Optional<FieldNameAndSchema> removeFieldToApi(final io.airbyte.protocol.models.transform_models.FieldTransform transform) {
+  private static Optional<FieldRemove> removeFieldToApi(final io.airbyte.protocol.models.transform_models.FieldTransform transform) {
     if (transform.getTransformType() == FieldTransformType.REMOVE_FIELD) {
-      return Optional.of(new FieldNameAndSchema()
-          .fieldName(transform.getRemoveFieldTransform().getFieldName())
-          .fieldSchema(transform.getRemoveFieldTransform().getSchema()));
+      return Optional.of(new FieldRemove()
+          .schema(transform.getRemoveFieldTransform().getSchema()));
     } else {
       return Optional.empty();
     }
@@ -87,7 +69,6 @@ public class CatalogDiffConverters {
   private static Optional<FieldSchemaUpdate> updateFieldToApi(final io.airbyte.protocol.models.transform_models.FieldTransform transform) {
     if (transform.getTransformType() == FieldTransformType.UPDATE_FIELD) {
       return Optional.of(new FieldSchemaUpdate()
-          .fieldName(transform.getUpdateFieldTransform().getFieldName())
           .oldSchema(transform.getUpdateFieldTransform().getOldSchema())
           .newSchema(transform.getUpdateFieldTransform().getNewSchema()));
     } else {

--- a/airbyte-server/src/test/java/io/airbyte/server/handlers/WebBackendConnectionsHandlerTest.java
+++ b/airbyte-server/src/test/java/io/airbyte/server/handlers/WebBackendConnectionsHandlerTest.java
@@ -231,7 +231,7 @@ class WebBackendConnectionsHandlerTest {
         .isSyncing(expected.getIsSyncing())
         .catalogDiff(new CatalogDiff().transforms(List.of(
             new StreamTransform().transformType(TransformTypeEnum.ADD_STREAM)
-                .addStream(new StreamDescriptor().name("users-data1"))
+                .streamDescriptor(new StreamDescriptor().name("users-data1"))
                 .updateStream(null))))
         .resourceRequirements(new ResourceRequirements()
             .cpuRequest(ConnectionHelpers.TESTING_RESOURCE_REQUIREMENTS.getCpuRequest())

--- a/docs/reference/api/generated-api-html/index.html
+++ b/docs/reference/api/generated-api-html/index.html
@@ -11009,7 +11009,7 @@ font-style: italic;
       <div class="param">transformType </div><div class="param-desc"><span class="param-type"><a href="#string">String</a></span>  </div>
         <div class="param-enum-header">Enum:</div>
         <div class="param-enum">add_field</div><div class="param-enum">remove_field</div><div class="param-enum">update_field_schema</div>
-<div class="param">fieldName </div><div class="param-desc"><span class="param-type"><a href="#string">array[String]</a></span> A field name is a list of strings that for the path to the field. </div>
+<div class="param">fieldName </div><div class="param-desc"><span class="param-type"><a href="#string">array[String]</a></span> A field name is a list of strings that form the path to the field. </div>
 <div class="param">addField (optional)</div><div class="param-desc"><span class="param-type"><a href="#FieldAdd">FieldAdd</a></span>  </div>
 <div class="param">removeField (optional)</div><div class="param-desc"><span class="param-type"><a href="#FieldRemove">FieldRemove</a></span>  </div>
 <div class="param">updateFieldSchema (optional)</div><div class="param-desc"><span class="param-type"><a href="#FieldSchemaUpdate">FieldSchemaUpdate</a></span>  </div>

--- a/docs/reference/api/generated-api-html/index.html
+++ b/docs/reference/api/generated-api-html/index.html
@@ -8017,70 +8017,42 @@ font-style: italic;
   "destinationId" : "046b6c7f-0b8a-43b9-b35d-6489e6daee91",
   "catalogDiff" : {
     "transforms" : [ {
-      "removeStream" : {
+      "streamDescriptor" : {
         "name" : "name",
         "namespace" : "namespace"
       },
       "transformType" : "add_stream",
-      "addStream" : {
-        "name" : "name",
-        "namespace" : "namespace"
-      },
       "updateStream" : [ {
-        "updateFieldSchema" : {
-          "fieldName" : [ "fieldName", "fieldName" ]
-        },
-        "addField" : {
-          "fieldName" : [ "fieldName", "fieldName" ]
-        },
+        "updateFieldSchema" : { },
+        "fieldName" : [ "fieldName", "fieldName" ],
+        "addField" : { },
         "transformType" : "add_field",
-        "removeField" : {
-          "fieldName" : [ "fieldName", "fieldName" ]
-        }
+        "removeField" : { }
       }, {
-        "updateFieldSchema" : {
-          "fieldName" : [ "fieldName", "fieldName" ]
-        },
-        "addField" : {
-          "fieldName" : [ "fieldName", "fieldName" ]
-        },
+        "updateFieldSchema" : { },
+        "fieldName" : [ "fieldName", "fieldName" ],
+        "addField" : { },
         "transformType" : "add_field",
-        "removeField" : {
-          "fieldName" : [ "fieldName", "fieldName" ]
-        }
+        "removeField" : { }
       } ]
     }, {
-      "removeStream" : {
+      "streamDescriptor" : {
         "name" : "name",
         "namespace" : "namespace"
       },
       "transformType" : "add_stream",
-      "addStream" : {
-        "name" : "name",
-        "namespace" : "namespace"
-      },
       "updateStream" : [ {
-        "updateFieldSchema" : {
-          "fieldName" : [ "fieldName", "fieldName" ]
-        },
-        "addField" : {
-          "fieldName" : [ "fieldName", "fieldName" ]
-        },
+        "updateFieldSchema" : { },
+        "fieldName" : [ "fieldName", "fieldName" ],
+        "addField" : { },
         "transformType" : "add_field",
-        "removeField" : {
-          "fieldName" : [ "fieldName", "fieldName" ]
-        }
+        "removeField" : { }
       }, {
-        "updateFieldSchema" : {
-          "fieldName" : [ "fieldName", "fieldName" ]
-        },
-        "addField" : {
-          "fieldName" : [ "fieldName", "fieldName" ]
-        },
+        "updateFieldSchema" : { },
+        "fieldName" : [ "fieldName", "fieldName" ],
+        "addField" : { },
         "transformType" : "add_field",
-        "removeField" : {
-          "fieldName" : [ "fieldName", "fieldName" ]
-        }
+        "removeField" : { }
       } ]
     } ]
   },
@@ -8244,70 +8216,42 @@ font-style: italic;
   "destinationId" : "046b6c7f-0b8a-43b9-b35d-6489e6daee91",
   "catalogDiff" : {
     "transforms" : [ {
-      "removeStream" : {
+      "streamDescriptor" : {
         "name" : "name",
         "namespace" : "namespace"
       },
       "transformType" : "add_stream",
-      "addStream" : {
-        "name" : "name",
-        "namespace" : "namespace"
-      },
       "updateStream" : [ {
-        "updateFieldSchema" : {
-          "fieldName" : [ "fieldName", "fieldName" ]
-        },
-        "addField" : {
-          "fieldName" : [ "fieldName", "fieldName" ]
-        },
+        "updateFieldSchema" : { },
+        "fieldName" : [ "fieldName", "fieldName" ],
+        "addField" : { },
         "transformType" : "add_field",
-        "removeField" : {
-          "fieldName" : [ "fieldName", "fieldName" ]
-        }
+        "removeField" : { }
       }, {
-        "updateFieldSchema" : {
-          "fieldName" : [ "fieldName", "fieldName" ]
-        },
-        "addField" : {
-          "fieldName" : [ "fieldName", "fieldName" ]
-        },
+        "updateFieldSchema" : { },
+        "fieldName" : [ "fieldName", "fieldName" ],
+        "addField" : { },
         "transformType" : "add_field",
-        "removeField" : {
-          "fieldName" : [ "fieldName", "fieldName" ]
-        }
+        "removeField" : { }
       } ]
     }, {
-      "removeStream" : {
+      "streamDescriptor" : {
         "name" : "name",
         "namespace" : "namespace"
       },
       "transformType" : "add_stream",
-      "addStream" : {
-        "name" : "name",
-        "namespace" : "namespace"
-      },
       "updateStream" : [ {
-        "updateFieldSchema" : {
-          "fieldName" : [ "fieldName", "fieldName" ]
-        },
-        "addField" : {
-          "fieldName" : [ "fieldName", "fieldName" ]
-        },
+        "updateFieldSchema" : { },
+        "fieldName" : [ "fieldName", "fieldName" ],
+        "addField" : { },
         "transformType" : "add_field",
-        "removeField" : {
-          "fieldName" : [ "fieldName", "fieldName" ]
-        }
+        "removeField" : { }
       }, {
-        "updateFieldSchema" : {
-          "fieldName" : [ "fieldName", "fieldName" ]
-        },
-        "addField" : {
-          "fieldName" : [ "fieldName", "fieldName" ]
-        },
+        "updateFieldSchema" : { },
+        "fieldName" : [ "fieldName", "fieldName" ],
+        "addField" : { },
         "transformType" : "add_field",
-        "removeField" : {
-          "fieldName" : [ "fieldName", "fieldName" ]
-        }
+        "removeField" : { }
       } ]
     } ]
   },
@@ -8535,70 +8479,42 @@ font-style: italic;
     "destinationId" : "046b6c7f-0b8a-43b9-b35d-6489e6daee91",
     "catalogDiff" : {
       "transforms" : [ {
-        "removeStream" : {
+        "streamDescriptor" : {
           "name" : "name",
           "namespace" : "namespace"
         },
         "transformType" : "add_stream",
-        "addStream" : {
-          "name" : "name",
-          "namespace" : "namespace"
-        },
         "updateStream" : [ {
-          "updateFieldSchema" : {
-            "fieldName" : [ "fieldName", "fieldName" ]
-          },
-          "addField" : {
-            "fieldName" : [ "fieldName", "fieldName" ]
-          },
+          "updateFieldSchema" : { },
+          "fieldName" : [ "fieldName", "fieldName" ],
+          "addField" : { },
           "transformType" : "add_field",
-          "removeField" : {
-            "fieldName" : [ "fieldName", "fieldName" ]
-          }
+          "removeField" : { }
         }, {
-          "updateFieldSchema" : {
-            "fieldName" : [ "fieldName", "fieldName" ]
-          },
-          "addField" : {
-            "fieldName" : [ "fieldName", "fieldName" ]
-          },
+          "updateFieldSchema" : { },
+          "fieldName" : [ "fieldName", "fieldName" ],
+          "addField" : { },
           "transformType" : "add_field",
-          "removeField" : {
-            "fieldName" : [ "fieldName", "fieldName" ]
-          }
+          "removeField" : { }
         } ]
       }, {
-        "removeStream" : {
+        "streamDescriptor" : {
           "name" : "name",
           "namespace" : "namespace"
         },
         "transformType" : "add_stream",
-        "addStream" : {
-          "name" : "name",
-          "namespace" : "namespace"
-        },
         "updateStream" : [ {
-          "updateFieldSchema" : {
-            "fieldName" : [ "fieldName", "fieldName" ]
-          },
-          "addField" : {
-            "fieldName" : [ "fieldName", "fieldName" ]
-          },
+          "updateFieldSchema" : { },
+          "fieldName" : [ "fieldName", "fieldName" ],
+          "addField" : { },
           "transformType" : "add_field",
-          "removeField" : {
-            "fieldName" : [ "fieldName", "fieldName" ]
-          }
+          "removeField" : { }
         }, {
-          "updateFieldSchema" : {
-            "fieldName" : [ "fieldName", "fieldName" ]
-          },
-          "addField" : {
-            "fieldName" : [ "fieldName", "fieldName" ]
-          },
+          "updateFieldSchema" : { },
+          "fieldName" : [ "fieldName", "fieldName" ],
+          "addField" : { },
           "transformType" : "add_field",
-          "removeField" : {
-            "fieldName" : [ "fieldName", "fieldName" ]
-          }
+          "removeField" : { }
         } ]
       } ]
     },
@@ -8709,70 +8625,42 @@ font-style: italic;
     "destinationId" : "046b6c7f-0b8a-43b9-b35d-6489e6daee91",
     "catalogDiff" : {
       "transforms" : [ {
-        "removeStream" : {
+        "streamDescriptor" : {
           "name" : "name",
           "namespace" : "namespace"
         },
         "transformType" : "add_stream",
-        "addStream" : {
-          "name" : "name",
-          "namespace" : "namespace"
-        },
         "updateStream" : [ {
-          "updateFieldSchema" : {
-            "fieldName" : [ "fieldName", "fieldName" ]
-          },
-          "addField" : {
-            "fieldName" : [ "fieldName", "fieldName" ]
-          },
+          "updateFieldSchema" : { },
+          "fieldName" : [ "fieldName", "fieldName" ],
+          "addField" : { },
           "transformType" : "add_field",
-          "removeField" : {
-            "fieldName" : [ "fieldName", "fieldName" ]
-          }
+          "removeField" : { }
         }, {
-          "updateFieldSchema" : {
-            "fieldName" : [ "fieldName", "fieldName" ]
-          },
-          "addField" : {
-            "fieldName" : [ "fieldName", "fieldName" ]
-          },
+          "updateFieldSchema" : { },
+          "fieldName" : [ "fieldName", "fieldName" ],
+          "addField" : { },
           "transformType" : "add_field",
-          "removeField" : {
-            "fieldName" : [ "fieldName", "fieldName" ]
-          }
+          "removeField" : { }
         } ]
       }, {
-        "removeStream" : {
+        "streamDescriptor" : {
           "name" : "name",
           "namespace" : "namespace"
         },
         "transformType" : "add_stream",
-        "addStream" : {
-          "name" : "name",
-          "namespace" : "namespace"
-        },
         "updateStream" : [ {
-          "updateFieldSchema" : {
-            "fieldName" : [ "fieldName", "fieldName" ]
-          },
-          "addField" : {
-            "fieldName" : [ "fieldName", "fieldName" ]
-          },
+          "updateFieldSchema" : { },
+          "fieldName" : [ "fieldName", "fieldName" ],
+          "addField" : { },
           "transformType" : "add_field",
-          "removeField" : {
-            "fieldName" : [ "fieldName", "fieldName" ]
-          }
+          "removeField" : { }
         }, {
-          "updateFieldSchema" : {
-            "fieldName" : [ "fieldName", "fieldName" ]
-          },
-          "addField" : {
-            "fieldName" : [ "fieldName", "fieldName" ]
-          },
+          "updateFieldSchema" : { },
+          "fieldName" : [ "fieldName", "fieldName" ],
+          "addField" : { },
           "transformType" : "add_field",
-          "removeField" : {
-            "fieldName" : [ "fieldName", "fieldName" ]
-          }
+          "removeField" : { }
         } ]
       } ]
     },
@@ -8941,70 +8829,42 @@ font-style: italic;
     "destinationId" : "046b6c7f-0b8a-43b9-b35d-6489e6daee91",
     "catalogDiff" : {
       "transforms" : [ {
-        "removeStream" : {
+        "streamDescriptor" : {
           "name" : "name",
           "namespace" : "namespace"
         },
         "transformType" : "add_stream",
-        "addStream" : {
-          "name" : "name",
-          "namespace" : "namespace"
-        },
         "updateStream" : [ {
-          "updateFieldSchema" : {
-            "fieldName" : [ "fieldName", "fieldName" ]
-          },
-          "addField" : {
-            "fieldName" : [ "fieldName", "fieldName" ]
-          },
+          "updateFieldSchema" : { },
+          "fieldName" : [ "fieldName", "fieldName" ],
+          "addField" : { },
           "transformType" : "add_field",
-          "removeField" : {
-            "fieldName" : [ "fieldName", "fieldName" ]
-          }
+          "removeField" : { }
         }, {
-          "updateFieldSchema" : {
-            "fieldName" : [ "fieldName", "fieldName" ]
-          },
-          "addField" : {
-            "fieldName" : [ "fieldName", "fieldName" ]
-          },
+          "updateFieldSchema" : { },
+          "fieldName" : [ "fieldName", "fieldName" ],
+          "addField" : { },
           "transformType" : "add_field",
-          "removeField" : {
-            "fieldName" : [ "fieldName", "fieldName" ]
-          }
+          "removeField" : { }
         } ]
       }, {
-        "removeStream" : {
+        "streamDescriptor" : {
           "name" : "name",
           "namespace" : "namespace"
         },
         "transformType" : "add_stream",
-        "addStream" : {
-          "name" : "name",
-          "namespace" : "namespace"
-        },
         "updateStream" : [ {
-          "updateFieldSchema" : {
-            "fieldName" : [ "fieldName", "fieldName" ]
-          },
-          "addField" : {
-            "fieldName" : [ "fieldName", "fieldName" ]
-          },
+          "updateFieldSchema" : { },
+          "fieldName" : [ "fieldName", "fieldName" ],
+          "addField" : { },
           "transformType" : "add_field",
-          "removeField" : {
-            "fieldName" : [ "fieldName", "fieldName" ]
-          }
+          "removeField" : { }
         }, {
-          "updateFieldSchema" : {
-            "fieldName" : [ "fieldName", "fieldName" ]
-          },
-          "addField" : {
-            "fieldName" : [ "fieldName", "fieldName" ]
-          },
+          "updateFieldSchema" : { },
+          "fieldName" : [ "fieldName", "fieldName" ],
+          "addField" : { },
           "transformType" : "add_field",
-          "removeField" : {
-            "fieldName" : [ "fieldName", "fieldName" ]
-          }
+          "removeField" : { }
         } ]
       } ]
     },
@@ -9115,70 +8975,42 @@ font-style: italic;
     "destinationId" : "046b6c7f-0b8a-43b9-b35d-6489e6daee91",
     "catalogDiff" : {
       "transforms" : [ {
-        "removeStream" : {
+        "streamDescriptor" : {
           "name" : "name",
           "namespace" : "namespace"
         },
         "transformType" : "add_stream",
-        "addStream" : {
-          "name" : "name",
-          "namespace" : "namespace"
-        },
         "updateStream" : [ {
-          "updateFieldSchema" : {
-            "fieldName" : [ "fieldName", "fieldName" ]
-          },
-          "addField" : {
-            "fieldName" : [ "fieldName", "fieldName" ]
-          },
+          "updateFieldSchema" : { },
+          "fieldName" : [ "fieldName", "fieldName" ],
+          "addField" : { },
           "transformType" : "add_field",
-          "removeField" : {
-            "fieldName" : [ "fieldName", "fieldName" ]
-          }
+          "removeField" : { }
         }, {
-          "updateFieldSchema" : {
-            "fieldName" : [ "fieldName", "fieldName" ]
-          },
-          "addField" : {
-            "fieldName" : [ "fieldName", "fieldName" ]
-          },
+          "updateFieldSchema" : { },
+          "fieldName" : [ "fieldName", "fieldName" ],
+          "addField" : { },
           "transformType" : "add_field",
-          "removeField" : {
-            "fieldName" : [ "fieldName", "fieldName" ]
-          }
+          "removeField" : { }
         } ]
       }, {
-        "removeStream" : {
+        "streamDescriptor" : {
           "name" : "name",
           "namespace" : "namespace"
         },
         "transformType" : "add_stream",
-        "addStream" : {
-          "name" : "name",
-          "namespace" : "namespace"
-        },
         "updateStream" : [ {
-          "updateFieldSchema" : {
-            "fieldName" : [ "fieldName", "fieldName" ]
-          },
-          "addField" : {
-            "fieldName" : [ "fieldName", "fieldName" ]
-          },
+          "updateFieldSchema" : { },
+          "fieldName" : [ "fieldName", "fieldName" ],
+          "addField" : { },
           "transformType" : "add_field",
-          "removeField" : {
-            "fieldName" : [ "fieldName", "fieldName" ]
-          }
+          "removeField" : { }
         }, {
-          "updateFieldSchema" : {
-            "fieldName" : [ "fieldName", "fieldName" ]
-          },
-          "addField" : {
-            "fieldName" : [ "fieldName", "fieldName" ]
-          },
+          "updateFieldSchema" : { },
+          "fieldName" : [ "fieldName", "fieldName" ],
+          "addField" : { },
           "transformType" : "add_field",
-          "removeField" : {
-            "fieldName" : [ "fieldName", "fieldName" ]
-          }
+          "removeField" : { }
         } ]
       } ]
     },
@@ -9347,70 +9179,42 @@ font-style: italic;
     "destinationId" : "046b6c7f-0b8a-43b9-b35d-6489e6daee91",
     "catalogDiff" : {
       "transforms" : [ {
-        "removeStream" : {
+        "streamDescriptor" : {
           "name" : "name",
           "namespace" : "namespace"
         },
         "transformType" : "add_stream",
-        "addStream" : {
-          "name" : "name",
-          "namespace" : "namespace"
-        },
         "updateStream" : [ {
-          "updateFieldSchema" : {
-            "fieldName" : [ "fieldName", "fieldName" ]
-          },
-          "addField" : {
-            "fieldName" : [ "fieldName", "fieldName" ]
-          },
+          "updateFieldSchema" : { },
+          "fieldName" : [ "fieldName", "fieldName" ],
+          "addField" : { },
           "transformType" : "add_field",
-          "removeField" : {
-            "fieldName" : [ "fieldName", "fieldName" ]
-          }
+          "removeField" : { }
         }, {
-          "updateFieldSchema" : {
-            "fieldName" : [ "fieldName", "fieldName" ]
-          },
-          "addField" : {
-            "fieldName" : [ "fieldName", "fieldName" ]
-          },
+          "updateFieldSchema" : { },
+          "fieldName" : [ "fieldName", "fieldName" ],
+          "addField" : { },
           "transformType" : "add_field",
-          "removeField" : {
-            "fieldName" : [ "fieldName", "fieldName" ]
-          }
+          "removeField" : { }
         } ]
       }, {
-        "removeStream" : {
+        "streamDescriptor" : {
           "name" : "name",
           "namespace" : "namespace"
         },
         "transformType" : "add_stream",
-        "addStream" : {
-          "name" : "name",
-          "namespace" : "namespace"
-        },
         "updateStream" : [ {
-          "updateFieldSchema" : {
-            "fieldName" : [ "fieldName", "fieldName" ]
-          },
-          "addField" : {
-            "fieldName" : [ "fieldName", "fieldName" ]
-          },
+          "updateFieldSchema" : { },
+          "fieldName" : [ "fieldName", "fieldName" ],
+          "addField" : { },
           "transformType" : "add_field",
-          "removeField" : {
-            "fieldName" : [ "fieldName", "fieldName" ]
-          }
+          "removeField" : { }
         }, {
-          "updateFieldSchema" : {
-            "fieldName" : [ "fieldName", "fieldName" ]
-          },
-          "addField" : {
-            "fieldName" : [ "fieldName", "fieldName" ]
-          },
+          "updateFieldSchema" : { },
+          "fieldName" : [ "fieldName", "fieldName" ],
+          "addField" : { },
           "transformType" : "add_field",
-          "removeField" : {
-            "fieldName" : [ "fieldName", "fieldName" ]
-          }
+          "removeField" : { }
         } ]
       } ]
     },
@@ -9521,70 +9325,42 @@ font-style: italic;
     "destinationId" : "046b6c7f-0b8a-43b9-b35d-6489e6daee91",
     "catalogDiff" : {
       "transforms" : [ {
-        "removeStream" : {
+        "streamDescriptor" : {
           "name" : "name",
           "namespace" : "namespace"
         },
         "transformType" : "add_stream",
-        "addStream" : {
-          "name" : "name",
-          "namespace" : "namespace"
-        },
         "updateStream" : [ {
-          "updateFieldSchema" : {
-            "fieldName" : [ "fieldName", "fieldName" ]
-          },
-          "addField" : {
-            "fieldName" : [ "fieldName", "fieldName" ]
-          },
+          "updateFieldSchema" : { },
+          "fieldName" : [ "fieldName", "fieldName" ],
+          "addField" : { },
           "transformType" : "add_field",
-          "removeField" : {
-            "fieldName" : [ "fieldName", "fieldName" ]
-          }
+          "removeField" : { }
         }, {
-          "updateFieldSchema" : {
-            "fieldName" : [ "fieldName", "fieldName" ]
-          },
-          "addField" : {
-            "fieldName" : [ "fieldName", "fieldName" ]
-          },
+          "updateFieldSchema" : { },
+          "fieldName" : [ "fieldName", "fieldName" ],
+          "addField" : { },
           "transformType" : "add_field",
-          "removeField" : {
-            "fieldName" : [ "fieldName", "fieldName" ]
-          }
+          "removeField" : { }
         } ]
       }, {
-        "removeStream" : {
+        "streamDescriptor" : {
           "name" : "name",
           "namespace" : "namespace"
         },
         "transformType" : "add_stream",
-        "addStream" : {
-          "name" : "name",
-          "namespace" : "namespace"
-        },
         "updateStream" : [ {
-          "updateFieldSchema" : {
-            "fieldName" : [ "fieldName", "fieldName" ]
-          },
-          "addField" : {
-            "fieldName" : [ "fieldName", "fieldName" ]
-          },
+          "updateFieldSchema" : { },
+          "fieldName" : [ "fieldName", "fieldName" ],
+          "addField" : { },
           "transformType" : "add_field",
-          "removeField" : {
-            "fieldName" : [ "fieldName", "fieldName" ]
-          }
+          "removeField" : { }
         }, {
-          "updateFieldSchema" : {
-            "fieldName" : [ "fieldName", "fieldName" ]
-          },
-          "addField" : {
-            "fieldName" : [ "fieldName", "fieldName" ]
-          },
+          "updateFieldSchema" : { },
+          "fieldName" : [ "fieldName", "fieldName" ],
+          "addField" : { },
           "transformType" : "add_field",
-          "removeField" : {
-            "fieldName" : [ "fieldName", "fieldName" ]
-          }
+          "removeField" : { }
         } ]
       } ]
     },
@@ -9749,70 +9525,42 @@ font-style: italic;
   "destinationId" : "046b6c7f-0b8a-43b9-b35d-6489e6daee91",
   "catalogDiff" : {
     "transforms" : [ {
-      "removeStream" : {
+      "streamDescriptor" : {
         "name" : "name",
         "namespace" : "namespace"
       },
       "transformType" : "add_stream",
-      "addStream" : {
-        "name" : "name",
-        "namespace" : "namespace"
-      },
       "updateStream" : [ {
-        "updateFieldSchema" : {
-          "fieldName" : [ "fieldName", "fieldName" ]
-        },
-        "addField" : {
-          "fieldName" : [ "fieldName", "fieldName" ]
-        },
+        "updateFieldSchema" : { },
+        "fieldName" : [ "fieldName", "fieldName" ],
+        "addField" : { },
         "transformType" : "add_field",
-        "removeField" : {
-          "fieldName" : [ "fieldName", "fieldName" ]
-        }
+        "removeField" : { }
       }, {
-        "updateFieldSchema" : {
-          "fieldName" : [ "fieldName", "fieldName" ]
-        },
-        "addField" : {
-          "fieldName" : [ "fieldName", "fieldName" ]
-        },
+        "updateFieldSchema" : { },
+        "fieldName" : [ "fieldName", "fieldName" ],
+        "addField" : { },
         "transformType" : "add_field",
-        "removeField" : {
-          "fieldName" : [ "fieldName", "fieldName" ]
-        }
+        "removeField" : { }
       } ]
     }, {
-      "removeStream" : {
+      "streamDescriptor" : {
         "name" : "name",
         "namespace" : "namespace"
       },
       "transformType" : "add_stream",
-      "addStream" : {
-        "name" : "name",
-        "namespace" : "namespace"
-      },
       "updateStream" : [ {
-        "updateFieldSchema" : {
-          "fieldName" : [ "fieldName", "fieldName" ]
-        },
-        "addField" : {
-          "fieldName" : [ "fieldName", "fieldName" ]
-        },
+        "updateFieldSchema" : { },
+        "fieldName" : [ "fieldName", "fieldName" ],
+        "addField" : { },
         "transformType" : "add_field",
-        "removeField" : {
-          "fieldName" : [ "fieldName", "fieldName" ]
-        }
+        "removeField" : { }
       }, {
-        "updateFieldSchema" : {
-          "fieldName" : [ "fieldName", "fieldName" ]
-        },
-        "addField" : {
-          "fieldName" : [ "fieldName", "fieldName" ]
-        },
+        "updateFieldSchema" : { },
+        "fieldName" : [ "fieldName", "fieldName" ],
+        "addField" : { },
         "transformType" : "add_field",
-        "removeField" : {
-          "fieldName" : [ "fieldName", "fieldName" ]
-        }
+        "removeField" : { }
       } ]
     } ]
   },
@@ -10583,7 +10331,8 @@ font-style: italic;
     <li><a href="#DestinationSearch"><code>DestinationSearch</code> - </a></li>
     <li><a href="#DestinationSyncMode"><code>DestinationSyncMode</code> - </a></li>
     <li><a href="#DestinationUpdate"><code>DestinationUpdate</code> - </a></li>
-    <li><a href="#FieldNameAndSchema"><code>FieldNameAndSchema</code> - </a></li>
+    <li><a href="#FieldAdd"><code>FieldAdd</code> - </a></li>
+    <li><a href="#FieldRemove"><code>FieldRemove</code> - </a></li>
     <li><a href="#FieldSchemaUpdate"><code>FieldSchemaUpdate</code> - </a></li>
     <li><a href="#FieldTransform"><code>FieldTransform</code> - </a></li>
     <li><a href="#GlobalState"><code>GlobalState</code> - </a></li>
@@ -11232,19 +10981,24 @@ font-style: italic;
     </div>  <!-- field-items -->
   </div>
   <div class="model">
-    <h3><a name="FieldNameAndSchema"><code>FieldNameAndSchema</code> - </a> <a class="up" href="#__Models">Up</a></h3>
+    <h3><a name="FieldAdd"><code>FieldAdd</code> - </a> <a class="up" href="#__Models">Up</a></h3>
     <div class='model-description'></div>
     <div class="field-items">
-      <div class="param">fieldName </div><div class="param-desc"><span class="param-type"><a href="#string">array[String]</a></span>  </div>
-<div class="param">fieldSchema </div><div class="param-desc"><span class="param-type"><a href="#FieldSchema">FieldSchema</a></span>  </div>
+      <div class="param">schema (optional)</div><div class="param-desc"><span class="param-type"><a href="#FieldSchema">FieldSchema</a></span>  </div>
+    </div>  <!-- field-items -->
+  </div>
+  <div class="model">
+    <h3><a name="FieldRemove"><code>FieldRemove</code> - </a> <a class="up" href="#__Models">Up</a></h3>
+    <div class='model-description'></div>
+    <div class="field-items">
+      <div class="param">schema (optional)</div><div class="param-desc"><span class="param-type"><a href="#FieldSchema">FieldSchema</a></span>  </div>
     </div>  <!-- field-items -->
   </div>
   <div class="model">
     <h3><a name="FieldSchemaUpdate"><code>FieldSchemaUpdate</code> - </a> <a class="up" href="#__Models">Up</a></h3>
     <div class='model-description'></div>
     <div class="field-items">
-      <div class="param">fieldName </div><div class="param-desc"><span class="param-type"><a href="#string">array[String]</a></span>  </div>
-<div class="param">oldSchema </div><div class="param-desc"><span class="param-type"><a href="#FieldSchema">FieldSchema</a></span>  </div>
+      <div class="param">oldSchema </div><div class="param-desc"><span class="param-type"><a href="#FieldSchema">FieldSchema</a></span>  </div>
 <div class="param">newSchema </div><div class="param-desc"><span class="param-type"><a href="#FieldSchema">FieldSchema</a></span>  </div>
     </div>  <!-- field-items -->
   </div>
@@ -11255,8 +11009,9 @@ font-style: italic;
       <div class="param">transformType </div><div class="param-desc"><span class="param-type"><a href="#string">String</a></span>  </div>
         <div class="param-enum-header">Enum:</div>
         <div class="param-enum">add_field</div><div class="param-enum">remove_field</div><div class="param-enum">update_field_schema</div>
-<div class="param">addField (optional)</div><div class="param-desc"><span class="param-type"><a href="#FieldNameAndSchema">FieldNameAndSchema</a></span>  </div>
-<div class="param">removeField (optional)</div><div class="param-desc"><span class="param-type"><a href="#FieldNameAndSchema">FieldNameAndSchema</a></span>  </div>
+<div class="param">fieldName </div><div class="param-desc"><span class="param-type"><a href="#string">array[String]</a></span> A field name is a list of strings that for the path to the field. </div>
+<div class="param">addField (optional)</div><div class="param-desc"><span class="param-type"><a href="#FieldAdd">FieldAdd</a></span>  </div>
+<div class="param">removeField (optional)</div><div class="param-desc"><span class="param-type"><a href="#FieldRemove">FieldRemove</a></span>  </div>
 <div class="param">updateFieldSchema (optional)</div><div class="param-desc"><span class="param-type"><a href="#FieldSchemaUpdate">FieldSchemaUpdate</a></span>  </div>
     </div>  <!-- field-items -->
   </div>
@@ -11867,8 +11622,7 @@ if oauth parameters were contained inside the top level, rootObject=[] If they w
       <div class="param">transformType </div><div class="param-desc"><span class="param-type"><a href="#string">String</a></span>  </div>
         <div class="param-enum-header">Enum:</div>
         <div class="param-enum">add_stream</div><div class="param-enum">remove_stream</div><div class="param-enum">update_stream</div>
-<div class="param">addStream (optional)</div><div class="param-desc"><span class="param-type"><a href="#StreamDescriptor">StreamDescriptor</a></span>  </div>
-<div class="param">removeStream (optional)</div><div class="param-desc"><span class="param-type"><a href="#StreamDescriptor">StreamDescriptor</a></span>  </div>
+<div class="param">streamDescriptor </div><div class="param-desc"><span class="param-type"><a href="#StreamDescriptor">StreamDescriptor</a></span>  </div>
 <div class="param">updateStream (optional)</div><div class="param-desc"><span class="param-type"><a href="#FieldTransform">array[FieldTransform]</a></span> list of field transformations. order does not matter. </div>
     </div>  <!-- field-items -->
   </div>


### PR DESCRIPTION
## What
* @alovew pointed out that stream name was missing in the stream transformation for update.
* this PR adds it. it also restructures the diff structs a little bit to decrease the risk of this sort of mistake in the future. the changes moves stream descriptor into the `StreamTransformation` wrapper object and `fieldName` into the `FieldTransformation` wrapper object. This allows the common attribute (the stream name and field name respectively) to be present in all transformations.
* This change allowed me to reduce some of the struct boilerplate as well.