### PR TITLE
helm chart: Fix/double printing of extra volume mounts

### DIFF
--- a/charts/airbyte/Chart.yaml
+++ b/charts/airbyte/Chart.yaml
@@ -15,7 +15,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.3.6
+version: 0.3.7
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to

--- a/charts/airbyte/templates/temporal/deployment.yaml
+++ b/charts/airbyte/templates/temporal/deployment.yaml
@@ -69,11 +69,11 @@ spec:
         volumeMounts:
         - name: airbyte-temporal-dynamicconfig
           mountPath: "/etc/temporal/config/dynamicconfig/"
-        {{- if .Values.temporal.resources }}
-        resources: {{- toYaml .Values.temporal.resources | nindent 10 }}
-        {{- end }}
         {{- if .Values.temporal.extraVolumeMounts }}
   {{ toYaml .Values.temporal.extraVolumeMounts | nindent 8 }}
+        {{- end }}
+        {{- if .Values.temporal.resources }}
+        resources: {{- toYaml .Values.temporal.resources | nindent 10 }}
         {{- end }}
         {{- if .Values.temporal.livenessProbe.enabled }}
         livenessProbe:


### PR DESCRIPTION
## What
In the `helm` chart,  there is a variable in `values.yaml` called `extraVolumeMount` for the `temporal` deployment, as is true for `worker`, `server`, et cetera.

Unfortunately, if you designate this for the `temporal` charts, `helm` attempts to insert a second `volumeMounts` section below resources, which conflicts with the already-denoted static `volumeMount` set a couple of lines earlier.

## How
Following the same standard set in the repo's other charts, fix is to render `extraVolumeMounts` incrementally. This amounts to just a rearrangement in the deployment yaml.

Resources now follows the conditional check for extra volume mounts, which is now contained within the same static block detailed above.

Upon readjustment, build succeeds.

## 🚨 User Impact 🚨
No breaking changes
