### PR TITLE
13523 Fix integration tests destination-cassandra Mac OS

### DIFF
--- a/airbyte-integrations/connectors/destination-cassandra/src/test-integration/java/io/airbyte/integrations/destination/cassandra/CassandraDestinationAcceptanceTest.java
+++ b/airbyte-integrations/connectors/destination-cassandra/src/test-integration/java/io/airbyte/integrations/destination/cassandra/CassandraDestinationAcceptanceTest.java
@@ -7,6 +7,7 @@ package io.airbyte.integrations.destination.cassandra;
 import com.fasterxml.jackson.databind.JsonNode;
 import io.airbyte.commons.json.Jsons;
 import io.airbyte.integrations.standardtest.destination.DestinationAcceptanceTest;
+import io.airbyte.integrations.util.HostPortResolver;
 import java.util.Comparator;
 import java.util.List;
 import java.util.stream.Collectors;
@@ -15,8 +16,6 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 public class CassandraDestinationAcceptanceTest extends DestinationAcceptanceTest {
-
-  private static final Logger LOGGER = LoggerFactory.getLogger(CassandraDestinationAcceptanceTest.class);
 
   private JsonNode configJson;
 
@@ -36,8 +35,8 @@ public class CassandraDestinationAcceptanceTest extends DestinationAcceptanceTes
     configJson = TestDataFactory.createJsonConfig(
         cassandraContainer.getUsername(),
         cassandraContainer.getPassword(),
-        cassandraContainer.getHost(),
-        cassandraContainer.getFirstMappedPort());
+        HostPortResolver.resolveHost(cassandraContainer),
+        HostPortResolver.resolvePort(cassandraContainer));
     var cassandraConfig = new CassandraConfig(configJson);
     cassandraCqlProvider = new CassandraCqlProvider(cassandraConfig);
     cassandraNameTransformer = new CassandraNameTransformer(cassandraConfig);


### PR DESCRIPTION
## What
Fixed integration tests for Mac OS. 
Before:
<img width="816" alt="on cassandra" src="https://user-images.githubusercontent.com/5124694/175782271-2aa37515-1092-4c21-b525-1dea191d07ff.png">
After: 
<img width="818" alt="Screenshot 2022-06-25 at 23 18 59" src="https://user-images.githubusercontent.com/5124694/175782284-b829476b-5819-4723-a8d0-ab1953f70bbb.png">


