### PR TITLE
🐛 Source Amazon Ads: increase timeout for SAT

### DIFF
--- a/airbyte-integrations/connectors/source-amazon-ads/acceptance-test-config.yml
+++ b/airbyte-integrations/connectors/source-amazon-ads/acceptance-test-config.yml
@@ -26,7 +26,7 @@ tests:
         extra_fields: no
         exact_order: no
         extra_records: no
-      timeout_seconds: 900
+      timeout_seconds: 3600
     # THIS TEST IS COMMENTED OUT BECAUSE OF
     # https://advertising.amazon.com/API/docs/en-us/info/release-notes#sandbox-deprecation-on-june-28-2022
     # - config_path: "secrets/config.json"
@@ -40,7 +40,7 @@ tests:
   full_refresh:
     - config_path: "secrets/config_test_account.json"
       configured_catalog_path: "integration_tests/configured_catalog.json"
-      timeout_seconds: 1800
+      timeout_seconds: 3600
     # THIS TEST IS COMMENTED OUT BECAUSE OF
     # https://advertising.amazon.com/API/docs/en-us/info/release-notes#sandbox-deprecation-on-june-28-2022
     # - config_path: "secrets/config.json"


### PR DESCRIPTION
## What
Resolving: https://github.com/airbytehq/airbyte/issues/14164

## How
- increased `timeout` for SAT to 3600.