### PR TITLE
Handle legacy state object in list of AirbyteStateMessages

### DIFF
--- a/airbyte-config/config-models/src/main/java/io/airbyte/config/helpers/StateMessageHelper.java
+++ b/airbyte-config/config-models/src/main/java/io/airbyte/config/helpers/StateMessageHelper.java
@@ -42,6 +42,8 @@ public class StateMessageHelper {
         return Optional.of(new StateWrapper()
             .withStateType(StateType.GLOBAL)
             .withGlobal(stateMessages.get(0)));
+      } else if (stateMessages.size() == 1 && stateMessages.get(0).getType() == AirbyteStateType.LEGACY) {
+        return Optional.of(getLegacyStateWrapper(stateMessages.get(0).getData()));
       } else if (stateMessages.size() >= 1
           && stateMessages.stream().allMatch(stateMessage -> stateMessage.getType() == AirbyteStateType.STREAM)) {
         return Optional.of(new StateWrapper()


### PR DESCRIPTION
## What
* Properly parse state message when a legacy state object is included in a list of `AirbyteStateMessage` objectrs

## How
* Add conditional case to `StateMessageHelper` to handle case where a list with a single `AirbyteStateMessage` containing a legacy state object is provided.

## Recommended reading order
1. `StateMessageHelper.java`
2. `StateMessageHelperTest.java`