### PR TITLE
source-orbit: add definition and specs for orbit

### DIFF
--- a/airbyte-config/init/src/main/resources/seed/source_definitions.yaml
+++ b/airbyte-config/init/src/main/resources/seed/source_definitions.yaml
@@ -641,6 +641,14 @@
   icon: orb.svg
   sourceType: api
   releaseStage: alpha
+- name: Orbit
+  sourceDefinitionId: 95bcc041-1d1a-4c2e-8802-0ca5b1bfa36a
+  dockerRepository: airbyte/source-orbit
+  dockerImageTag: 0.1.0
+  documentationUrl: https://docs.airbyte.io/integrations/sources/orbit
+  icon: orbit.svg
+  sourceType: api
+  releaseStage: alpha
 - sourceDefinitionId: 3490c201-5d95-4783-b600-eaf07a4c7787
   name: Outreach
   dockerRepository: airbyte/source-outreach

--- a/airbyte-config/init/src/main/resources/seed/source_specs.yaml
+++ b/airbyte-config/init/src/main/resources/seed/source_specs.yaml
@@ -6313,6 +6313,41 @@
     supportsNormalization: false
     supportsDBT: false
     supported_destination_sync_modes: []
+- dockerImage: "airbyte/source-orbit:0.1.0"
+  spec:
+    documentationUrl: "https://docs.airbyte.com/integrations/sources/orbit"
+    connectionSpecification:
+      $schema: "http://json-schema.org/draft-07/schema#"
+      title: "Orbit Source Spec"
+      type: "object"
+      required:
+      - "api_token"
+      - "workspace"
+      additionalProperties: false
+      properties:
+        api_token:
+          type: "string"
+          airbyte_secret: true
+          title: "API Token"
+          description: "Authorizes you to work with Orbit workspaces associated with\
+            \ the token."
+          order: 0
+        workspace:
+          type: "string"
+          title: "Workspace"
+          description: "The unique name of the workspace that your API token is associated\
+            \ with."
+          order: 1
+        start_date:
+          type: "string"
+          title: "Start Date"
+          description: "Date in the format 2022-06-26. Only load members whose last\
+            \ activities are after this date."
+          pattern: "^[0-9]{4}-[0-9]{2}-[0-9]{2}$"
+          order: 2
+    supportsNormalization: false
+    supportsDBT: false
+    supported_destination_sync_modes: []
 - dockerImage: "airbyte/source-outreach:0.1.1"
   spec:
     documentationUrl: "https://docs.airbyte.io/integrations/sources/outreach"


### PR DESCRIPTION
Forgot to create source definition and spec after merging #13390