### PR TITLE
🪟 🐛 Fix OAuth validation not allowing to create source or destination

### DIFF
--- a/airbyte-webapp/src/views/Connector/ServiceForm/FormRoot.tsx
+++ b/airbyte-webapp/src/views/Connector/ServiceForm/FormRoot.tsx
@@ -89,6 +89,7 @@ const FormRoot: React.FC<FormRootProps> = ({
           isLoadSchema={isLoadingSchema}
           fetchingConnectorError={fetchingConnectorError}
           hasSuccess={hasSuccess}
+          isValid={isValid}
         />
       )}
     </FormContainer>

--- a/airbyte-webapp/src/views/Connector/ServiceForm/ServiceForm.tsx
+++ b/airbyte-webapp/src/views/Connector/ServiceForm/ServiceForm.tsx
@@ -43,7 +43,7 @@ const PatchInitialValuesWithWidgetConfig: React.FC<{
   initialValues: ServiceFormValues;
 }> = ({ schema, initialValues }) => {
   const { widgetsInfo } = useServiceForm();
-  const { values, setFieldValue } = useFormikContext<ServiceFormValues>();
+  const { setFieldValue } = useFormikContext<ServiceFormValues>();
 
   useDeepCompareEffect(() => {
     const widgetsInfoEntries = Object.entries(widgetsInfo);

--- a/airbyte-webapp/src/views/Connector/ServiceForm/components/CreateControls.tsx
+++ b/airbyte-webapp/src/views/Connector/ServiceForm/components/CreateControls.tsx
@@ -8,7 +8,7 @@ import { TestingConnectionError, FetchingConnectorError } from "./TestingConnect
 import TestingConnectionSpinner from "./TestingConnectionSpinner";
 import TestingConnectionSuccess from "./TestingConnectionSuccess";
 
-interface IProps {
+interface CreateControlProps {
   formType: "source" | "destination";
   isSubmitting: boolean;
   errorMessage?: React.ReactNode;
@@ -18,6 +18,7 @@ interface IProps {
 
   isTestConnectionInProgress: boolean;
   onCancelTesting?: () => void;
+  isValid: boolean;
 }
 
 const ButtonContainer = styled.div`
@@ -31,7 +32,7 @@ const SubmitButton = styled(Button)`
   margin-left: auto;
 `;
 
-const CreateControls: React.FC<IProps> = ({
+const CreateControls: React.FC<CreateControlProps> = ({
   isTestConnectionInProgress,
   isSubmitting,
   formType,
@@ -40,6 +41,7 @@ const CreateControls: React.FC<IProps> = ({
   fetchingConnectorError,
   isLoadSchema,
   onCancelTesting,
+  isValid,
 }) => {
   if (isSubmitting) {
     return <TestingConnectionSpinner isCancellable={isTestConnectionInProgress} onCancelTesting={onCancelTesting} />;
@@ -53,7 +55,7 @@ const CreateControls: React.FC<IProps> = ({
     <ButtonContainer>
       {errorMessage && !fetchingConnectorError && <TestingConnectionError errorMessage={errorMessage} />}
       {fetchingConnectorError && <FetchingConnectorError />}
-      <SubmitButton type="submit" disabled={isLoadSchema}>
+      <SubmitButton type="submit" disabled={isLoadSchema || !isValid}>
         <FormattedMessage id={`onboarding.${formType}SetUp.buttonText`} />
       </SubmitButton>
     </ButtonContainer>

--- a/airbyte-webapp/src/views/Connector/ServiceForm/components/Sections/auth/useOauthFlowAdapter.tsx
+++ b/airbyte-webapp/src/views/Connector/ServiceForm/components/Sections/auth/useOauthFlowAdapter.tsx
@@ -34,7 +34,7 @@ function useFormikOauthAdapter(connector: ConnectorDefinitionSpecification): {
       );
     } else {
       newValues = merge(values, {
-        connectionConfiguration: completeOauthResponse,
+        connectionConfiguration: { credentials: completeOauthResponse },
       });
     }
 


### PR DESCRIPTION
## What
This fixes an issue when setting up a source or destination with OAuth, it may prevent the connection from getting created after clicking on the "Set up source/destination button" (it happens)

It also fixes an issue where the "Set up source/destination" button was not disabled when the form is not valid.

## How
There's a helper component that resets the initial values when switching connector schemas. This component applies the default values to the initial values.

However, the values were not being applied correctly for a few reasons:
1. When switching connector types, some of the values from the previous values were still carried over.
2. Sometimes it would merge `{ connectionConfiguration: {...} }` as a nested `{ connectionConfiguration: { connectionConfiguration: { ... } }` - This is what was causing the OAuth to block the create source/destination action because it could not validate.
3. The behavior changed #12186 from just updating the `connectionConfiguration` to resetting all the values in the form (but the errors above were still present prior to this change.)