### PR TITLE
Wait indefinitely if connection is not active

### DIFF
--- a/airbyte-workers/src/main/java/io/airbyte/workers/temporal/scheduling/activities/ConfigFetchActivityImpl.java
+++ b/airbyte-workers/src/main/java/io/airbyte/workers/temporal/scheduling/activities/ConfigFetchActivityImpl.java
@@ -35,7 +35,7 @@ public class ConfigFetchActivityImpl implements ConfigFetchActivity {
     try {
       final StandardSync standardSync = configRepository.getStandardSync(input.getConnectionId());
 
-      if (standardSync.getSchedule() == null || standardSync.getStatus() == Status.INACTIVE) {
+      if (standardSync.getSchedule() == null || standardSync.getStatus() != Status.ACTIVE) {
         // Manual syncs wait for their first run
         return new ScheduleRetrieverOutput(Duration.ofDays(100 * 365));
       }

--- a/airbyte-workers/src/test/java/io/airbyte/workers/temporal/scheduling/activities/ConfigFetchActivityTest.java
+++ b/airbyte-workers/src/test/java/io/airbyte/workers/temporal/scheduling/activities/ConfigFetchActivityTest.java
@@ -50,7 +50,8 @@ public class ConfigFetchActivityTest {
   private final static StandardSync standardSyncWithSchedule = new StandardSync()
       .withSchedule(new Schedule()
           .withTimeUnit(TimeUnit.MINUTES)
-          .withUnits(5L));
+          .withUnits(5L))
+      .withStatus(Status.ACTIVE);
 
   private final static StandardSync standardSyncWithScheduleDisable = new StandardSync()
       .withSchedule(new Schedule()

--- a/airbyte-workers/src/test/java/io/airbyte/workers/temporal/scheduling/activities/ConfigFetchActivityTest.java
+++ b/airbyte-workers/src/test/java/io/airbyte/workers/temporal/scheduling/activities/ConfigFetchActivityTest.java
@@ -57,6 +57,12 @@ public class ConfigFetchActivityTest {
           .withTimeUnit(TimeUnit.MINUTES)
           .withUnits(5L))
       .withStatus(Status.INACTIVE);
+
+  private final static StandardSync standardSyncWithScheduleDeleted = new StandardSync()
+      .withSchedule(new Schedule()
+          .withTimeUnit(TimeUnit.MINUTES)
+          .withUnits(5L))
+      .withStatus(Status.DEPRECATED);
   private static final StandardSync standardSyncWithoutSchedule = new StandardSync();
 
   @Nested
@@ -103,6 +109,22 @@ public class ConfigFetchActivityTest {
 
       Mockito.when(mConfigRepository.getStandardSync(connectionId))
           .thenReturn(standardSyncWithScheduleDisable);
+
+      final ScheduleRetrieverInput input = new ScheduleRetrieverInput(connectionId);
+
+      final ScheduleRetrieverOutput output = configFetchActivity.getTimeToWait(input);
+
+      Assertions.assertThat(output.getTimeToWait())
+          .hasDays(100 * 365);
+    }
+
+    @Test
+    @DisplayName("Test that the connection will wait for a long time if it is deleted")
+    public void testDeleted() throws IOException, JsonValidationException, ConfigNotFoundException {
+      configFetchActivity = new ConfigFetchActivityImpl(mConfigRepository, mJobPersistence, mConfigs, () -> Instant.now().getEpochSecond());
+
+      Mockito.when(mConfigRepository.getStandardSync(connectionId))
+          .thenReturn(standardSyncWithScheduleDeleted);
 
       final ScheduleRetrieverInput input = new ScheduleRetrieverInput(connectionId);
 


### PR DESCRIPTION
## What
From investigating [this OC issue](https://github.com/airbytehq/oncall/issues/299), it was discovered that if a connection manager workflow is somehow restarted for a connection that is deleted, it will schedule and run jobs like normal.

This PR changes the ConfigFetch activity to wait indefinitely if the connection is deleted, so that we don't mistakenly run syncs for these connections again.

