### PR TITLE
Handle null reset source config

### DIFF
--- a/airbyte-server/src/main/java/io/airbyte/server/converters/JobConverter.java
+++ b/airbyte-server/src/main/java/io/airbyte/server/converters/JobConverter.java
@@ -29,6 +29,7 @@ import io.airbyte.commons.version.AirbyteVersion;
 import io.airbyte.config.Configs.WorkerEnvironment;
 import io.airbyte.config.JobConfig.ConfigType;
 import io.airbyte.config.JobOutput;
+import io.airbyte.config.ResetSourceConfiguration;
 import io.airbyte.config.StandardSyncOutput;
 import io.airbyte.config.StandardSyncSummary;
 import io.airbyte.config.StreamSyncStats;
@@ -101,6 +102,10 @@ public class JobConverter {
    */
   private static Optional<ResetConfig> extractResetConfigIfReset(final Job job) {
     if (job.getConfigType() == ConfigType.RESET_CONNECTION) {
+      final ResetSourceConfiguration resetSourceConfiguration = job.getConfig().getResetConnection().getResetSourceConfiguration();
+      if (resetSourceConfiguration == null) {
+        return Optional.empty();
+      }
       return Optional.ofNullable(
           new ResetConfig().streamsToReset(job.getConfig().getResetConnection().getResetSourceConfiguration().getStreamsToReset()
               .stream()

--- a/airbyte-server/src/test/java/io/airbyte/server/converters/JobConverterTest.java
+++ b/airbyte-server/src/test/java/io/airbyte/server/converters/JobConverterTest.java
@@ -4,6 +4,7 @@
 
 package io.airbyte.server.converters;
 
+import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.Mockito.mock;
@@ -255,6 +256,25 @@ class JobConverterTest {
         new StreamDescriptor().name("users"),
         new StreamDescriptor().name("accounts")));
     assertEquals(expectedResetConfig, jobConverter.getJobInfoRead(resetJob).getJob().getResetConfig());
+  }
+
+  @Test
+  void testResetJobExcludesConfigIfNull() {
+    final JobConfig resetConfig = new JobConfig()
+        .withConfigType(ConfigType.RESET_CONNECTION)
+        .withResetConnection(new JobResetConnectionConfig().withResetSourceConfiguration(null));
+    final Job resetJob = new Job(
+        JOB_ID,
+        ConfigType.RESET_CONNECTION,
+        JOB_CONFIG_ID,
+        resetConfig,
+        Collections.emptyList(),
+        JobStatus.SUCCEEDED,
+        CREATED_AT,
+        CREATED_AT,
+        CREATED_AT);
+
+    assertNull(jobConverter.getJobInfoRead(resetJob).getJob().getResetConfig());
   }
 
 }

--- a/airbyte-server/src/test/java/io/airbyte/server/converters/JobConverterTest.java
+++ b/airbyte-server/src/test/java/io/airbyte/server/converters/JobConverterTest.java
@@ -4,8 +4,8 @@
 
 package io.airbyte.server.converters;
 
-import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;


### PR DESCRIPTION
## What
From investigating [this OC issue](https://github.com/airbytehq/oncall/issues/300), I found that an NPE is thrown when trying to access the connection page of any connection that has a Reset job that was created before the `resetSourceConfiguration` field was added to Reset job configs, because the JobConverter tries to access the `streamsToReset` field without first checking if the resetSourceConfiguration is null.

It is expected that `resetSourceConfiguration` will be `null` for any Reset jobs that were created before that field was added. 

## How
This PR solves the issue by adding a null check before accessing the object.