### PR TITLE
Fix: 🐛 plural login redirecting to wrong URL

### DIFF
--- a/docs/deploying-airbyte/on-plural.md
+++ b/docs/deploying-airbyte/on-plural.md
@@ -10,7 +10,7 @@
 If you'd prefer to follow along with a video, check out the Plural Airbyte deployment guide video [here](https://youtu.be/suvTJyJ6PzI)
 :::
 
-First, create an account on https://app.plural.sh.  This is simply to track your installations and allow for the delivery of automated upgrades, you will not be asked to provide any infrastructure credentials or sensitive information.
+First, create an account on [https://app.plural.sh](https://app.plural.sh).  This is simply to track your installations and allow for the delivery of automated upgrades, you will not be asked to provide any infrastructure credentials or sensitive information.
 
 Then, install the Plural CLI by following steps 1, 2, and 3 of the instructions [here](https://docs.plural.sh/getting-started). Through this, you will also configure your cloud provider and the domain name under which your application will be deployed to.
 


### PR DESCRIPTION
## What
*In the docs to deploy Airbyte on Plural, it is redirecting to `https://app.plural.sh.` (with dot at end)*

## How
*Added the clickable href with the same name as URL*

## 🚨 User Impact 🚨
There are no breaking changes. It will just fix the redirection URL on docs so login would work seamlessly on Plural.