### PR TITLE
fix sentry org slug change

### DIFF
--- a/.github/workflows/publish-command.yml
+++ b/.github/workflows/publish-command.yml
@@ -297,7 +297,7 @@ jobs:
           sentry-cli releases finalize "$SENTRY_RELEASE_NAME"
         env:
           SENTRY_AUTH_TOKEN: ${{ secrets.SENTRY_CONNECTOR_RELEASE_AUTH_TOKEN }}
-          SENTRY_ORG: airbyte-5j
+          SENTRY_ORG: airbytehq
           SENTRY_PROJECT: connector-incident-management
       - name: Check if connector in definitions yaml
         if: github.event.inputs.auto-bump-version == 'true' && success()


### PR DESCRIPTION
## What

The sentry org slug was changed from `airbyte-5j` to `airbytehq`, which caused our release creation workflow to start failing unable to find the project.

Example of a failing run here https://github.com/airbytehq/airbyte/runs/7095533189?check_suite_focus=true#step:15:26

## How

Update the workflow to use the new org slug.
