### PR TITLE
Remove all @ts-ignore

### DIFF
--- a/airbyte-webapp/.eslintrc
+++ b/airbyte-webapp/.eslintrc
@@ -64,7 +64,6 @@
     "@typescript-eslint/ban-ts-comment": [
       "warn",
       {
-        "ts-ignore": "allow-with-description",
         "ts-expect-error": "allow-with-description"
       }
     ],

--- a/airbyte-webapp/src/components/EntityTable/utils.tsx
+++ b/airbyte-webapp/src/components/EntityTable/utils.tsx
@@ -46,7 +46,7 @@ export function getEntityTableData<
 
     const connectEntities = entityConnections.map((connection) => ({
       name: connection[connectType]?.name || "",
-      // @ts-ignore ts is not that clever to infer such types
+      // @ts-expect-error ts is not that clever to infer such types
       connector: connection[connectType]?.[`${connectType}Name`] || "",
       status: connection.status,
       lastSyncStatus: getConnectionSyncStatus(connection.status, connection.latestSyncJobStatus),

--- a/airbyte-webapp/src/components/Table/Table.tsx
+++ b/airbyte-webapp/src/components/Table/Table.tsx
@@ -161,22 +161,19 @@ const Table: React.FC<IProps> = ({ columns, data, onClickRow, erroredRows, sortB
               onClick={() => onClickRow?.(row.original)}
               erroredRows={erroredRows && !!row.original.error}
             >
-              {
-                // @ts-ignore needs to address proper types for table
-                row.cells.map((cell: ICellProps, key) => {
-                  return (
-                    <Td
-                      {...cell.getCellProps()}
-                      collapse={cell.column.collapse}
-                      customPadding={cell.column.customPadding}
-                      customWidth={cell.column.customWidth}
-                      key={`table-cell-${row.id}-${key}`}
-                    >
-                      {cell.render("Cell")}
-                    </Td>
-                  );
-                })
-              }
+              {row.cells.map((cell: ICellProps, key) => {
+                return (
+                  <Td
+                    {...cell.getCellProps()}
+                    collapse={cell.column.collapse}
+                    customPadding={cell.column.customPadding}
+                    customWidth={cell.column.customWidth}
+                    key={`table-cell-${row.id}-${key}`}
+                  >
+                    {cell.render("Cell")}
+                  </Td>
+                );
+              })}
             </Tr>
           );
         })}

--- a/airbyte-webapp/src/core/domain/connector/SourceService.ts
+++ b/airbyte-webapp/src/core/domain/connector/SourceService.ts
@@ -86,7 +86,7 @@ export class SourceService extends AirbyteRequestService {
       const e = new CommonRequestError(result);
       // Generate error with failed status and received logs
       e._status = 400;
-      // @ts-ignore address this case
+      // @ts-expect-error address this case
       e.response = result.jobInfo;
       throw e;
     }

--- a/airbyte-webapp/src/core/jsonSchema/schemaToYup.ts
+++ b/airbyte-webapp/src/core/jsonSchema/schemaToYup.ts
@@ -119,17 +119,17 @@ export const buildYupFormForJsonSchema = (
     const hasDefault = isDefined(jsonSchema.default);
 
     if (hasDefault) {
-      // @ts-ignore can't infer correct type here so lets just use default from json_schema
+      // @ts-expect-error can't infer correct type here so lets just use default from json_schema
       schema = schema.default(jsonSchema.default);
     }
 
     if (!hasDefault && jsonSchema.const) {
-      // @ts-ignore can't infer correct type here so lets just use default from json_schema
+      // @ts-expect-error can't infer correct type here so lets just use default from json_schema
       schema = schema.oneOf([jsonSchema.const]).default(jsonSchema.const);
     }
 
     if (jsonSchema.enum) {
-      // @ts-ignore as enum is array we are going to use it as oneOf for yup
+      // @ts-expect-error as enum is array we are going to use it as oneOf for yup
       schema = schema.oneOf(jsonSchema.enum);
     }
 

--- a/airbyte-webapp/src/core/request/AirbyteRequestService.ts
+++ b/airbyte-webapp/src/core/request/AirbyteRequestService.ts
@@ -59,7 +59,7 @@ async function parseResponse<T>(response: Response): Promise<T> {
       return await response.json();
     }
 
-    // @ts-ignore TODO: needs refactoring of services
+    // @ts-expect-error TODO: needs refactoring of services
     return response;
   }
   // eslint-disable-next-line @typescript-eslint/no-explicit-any

--- a/airbyte-webapp/src/packages/cloud/views/auth/components/News.tsx
+++ b/airbyte-webapp/src/packages/cloud/views/auth/components/News.tsx
@@ -53,7 +53,6 @@ const News: React.FC = () => {
           <FormattedMessage id="login.selfhosting" />
         </H2>
         <GitBlock>
-          {/*@ts-ignore github icon fails here*/}
           <GitIcon icon={faGithub} />
           <div>
             <H4>

--- a/airbyte-webapp/src/views/layout/SideBar/components/SidebarPopout.tsx
+++ b/airbyte-webapp/src/views/layout/SideBar/components/SidebarPopout.tsx
@@ -56,7 +56,6 @@ const SidebarPopout: React.FC<{
               label: (
                 <Item href={config.links.slackLink} target="_blank">
                   <Icon>
-                    {/*@ts-ignore slack icon fails here*/}
                     <FontAwesomeIcon icon={faSlack} />
                   </Icon>
                   <FormattedMessage id="sidebar.joinSlack" />


### PR DESCRIPTION
## What

Fixes https://github.com/airbytehq/airbyte/issues/9759

This replaces all existing `@ts-ignore` by `@ts-expect-error`, removes the ones that were already not needed anymore (which is the reason why `ts-expect-error` should be prefered over `ts-ignore`, so they won't be forgotten when they are not needed anymore) and change the linting rule to forbid `@ts-ignore` from now on.