### PR TITLE
Use workflow internal state to retrieve job id

### DIFF
--- a/airbyte-workers/src/main/java/io/airbyte/workers/temporal/scheduling/ConnectionManagerWorkflowImpl.java
+++ b/airbyte-workers/src/main/java/io/airbyte/workers/temporal/scheduling/ConnectionManagerWorkflowImpl.java
@@ -302,7 +302,7 @@ public class ConnectionManagerWorkflowImpl implements ConnectionManagerWorkflow 
     } else {
       final String failureReason = failureType == FailureType.CONFIG_ERROR ? "Connection Check Failed " + connectionId
           : "Job failed after too many retries for connection " + connectionId;
-      runMandatoryActivity(jobCreationAndStatusUpdateActivity::jobFailure, new JobFailureInput(connectionUpdaterInput.getJobId(), failureReason));
+      runMandatoryActivity(jobCreationAndStatusUpdateActivity::jobFailure, new JobFailureInput(workflowInternalState.getJobId(), failureReason));
 
       final int autoDisableConnectionVersion =
           Workflow.getVersion("auto_disable_failing_connection", Workflow.DEFAULT_VERSION, AUTO_DISABLE_FAILING_CONNECTION_CHANGE_CURRENT_VERSION);


### PR DESCRIPTION
## What
The `reportFailure` method is currently retrieving the job ID from the `ConnectionUpdaterInput` when marking a job as failed. This is bad because the job ID is not set on the ConnectionUpdaterInput during the first attempt of a job, because the job id is created during that run of the connection manager workflow. The current logic can cause NPEs such as those in this workflow: http://tui.cloud.airbyte.io/namespaces/default/workflows/connection_manager_29d50c19-32e2-479b-ab63-b8f9f4019a0c/4d9fc187-548c-4598-bc59-155f2a4de924/history?eventId=21#

## How
This PR changes the logic to retrieve the job ID from the WorkflowInternalState instead, which has the job id set as soon as the job is created.