### PR TITLE
🪟 🎨 Front end/Design tweaks

### DIFF
--- a/airbyte-webapp/src/components/ConnectorIcon/ConnectorIcon.tsx
+++ b/airbyte-webapp/src/components/ConnectorIcon/ConnectorIcon.tsx
@@ -9,14 +9,14 @@ interface Props {
   small?: boolean;
 }
 
-export const Content = styled.div<{ $small?: boolean }>`
+export const Content = styled.div`
   height: 25px;
   width: 25px;
   overflow: hidden;
 `;
 
-export const ConnectorIcon: React.FC<Props> = ({ icon, className, small }) => (
-  <Content className={className} $small={small} aria-hidden="true">
+export const ConnectorIcon: React.FC<Props> = ({ icon, className }) => (
+  <Content className={className} aria-hidden="true">
     {getIcon(icon)}
   </Content>
 );

--- a/airbyte-webapp/src/components/ConnectorIcon/ConnectorIcon.tsx
+++ b/airbyte-webapp/src/components/ConnectorIcon/ConnectorIcon.tsx
@@ -12,7 +12,6 @@ interface Props {
 export const Content = styled.div<{ $small?: boolean }>`
   height: 25px;
   width: 25px;
-  border-radius: ${({ $small }) => ($small ? 0 : 50)}%;
   overflow: hidden;
 `;
 

--- a/airbyte-webapp/src/components/ContentCard/ContentCard.tsx
+++ b/airbyte-webapp/src/components/ContentCard/ContentCard.tsx
@@ -14,7 +14,7 @@ interface IProps {
 const Title = styled(H5)<{ light?: boolean }>`
   padding: ${({ light }) => (light ? "19px 20px 20px" : "25px 25px 22px")};
   color: ${({ theme }) => theme.darkPrimaryColor};
-  box-shadow: ${({ light, theme }) => (light ? "none" : `0 1px 2px ${theme.shadowColor}`)};
+  border-bottom: #e8e8ed 1px solid;
   font-weight: 600;
   letter-spacing: 0.008em;
   border-radius: 10px 10px 0 0;

--- a/airbyte-webapp/src/components/ContentCard/ContentCard.tsx
+++ b/airbyte-webapp/src/components/ContentCard/ContentCard.tsx
@@ -14,7 +14,7 @@ interface IProps {
 const Title = styled(H5)<{ light?: boolean }>`
   padding: ${({ light }) => (light ? "19px 20px 20px" : "25px 25px 22px")};
   color: ${({ theme }) => theme.darkPrimaryColor};
-  border-bottom: #e8e8ed 1px solid;
+  border-bottom: ${({ light }) => (light ? "none" : "#e8e8ed 1px solid")};
   font-weight: 600;
   letter-spacing: 0.008em;
   border-radius: 10px 10px 0 0;

--- a/airbyte-webapp/src/components/EntityTable/components/ConnectorCell.tsx
+++ b/airbyte-webapp/src/components/EntityTable/components/ConnectorCell.tsx
@@ -23,7 +23,7 @@ const Image = styled(ConnectorIcon)`
 const ConnectorCell: React.FC<IProps> = ({ value, enabled, img }) => {
   return (
     <Content enabled={enabled}>
-      <Image small icon={img} />
+      <Image icon={img} />
       {value}
     </Content>
   );

--- a/airbyte-webapp/src/components/EntityTable/components/NameCell.tsx
+++ b/airbyte-webapp/src/components/EntityTable/components/NameCell.tsx
@@ -79,7 +79,7 @@ const NameCell: React.FC<Props> = ({ value, enabled, status, icon, img }) => {
   return (
     <Content>
       {status ? <StatusIcon title={title} status={statusIconStatus} /> : <Space />}
-      {icon && <Image small icon={img} />}
+      {icon && <Image icon={img} />}
       <Name enabled={enabled}>{value}</Name>
     </Content>
   );

--- a/airbyte-webapp/src/packages/cloud/views/credits/CreditsPage/components/ConnectionCell.tsx
+++ b/airbyte-webapp/src/packages/cloud/views/credits/CreditsPage/components/ConnectionCell.tsx
@@ -40,12 +40,12 @@ const ConnectionCell: React.FC<ConnectionCellProps> = ({
   return (
     <>
       <Connector>
-        <Icon small icon={sourceIcon} />
+        <Icon icon={sourceIcon} />
         {sourceDefinitionName}
       </Connector>
       <Connector>
         <Arrow icon={faArrowRight} />
-        <Icon small icon={destinationIcon} />
+        <Icon icon={destinationIcon} />
         {destinationDefinitionName}
       </Connector>
     </>


### PR DESCRIPTION
## What
- Display full logos instead of adding the circular mask (notably, the Google Sheets logo is no longer cut off along the edges).  This affects all places logos are displayed (connection/connector lists, dropdowns, etc.)
![Screen Shot 2022-06-29 at 11 46 59 AM](https://user-images.githubusercontent.com/63751206/176479814-e37f0103-7061-41ef-918d-7a487def4930.png)

- Replace drop shadow with simple border for cards with title (such as our modals)
![Screen Shot 2022-06-29 at 11 47 46 AM](https://user-images.githubusercontent.com/63751206/176479996-45ebfb08-d7a7-45ff-abd6-37a754ca55a1.png)



## How
- Pairing session with Nico
