### PR TITLE
Add ability to provide source/destination connector docker image

### DIFF
--- a/airbyte-test-utils/src/main/java/io/airbyte/test/utils/AirbyteAcceptanceTestHarness.java
+++ b/airbyte-test-utils/src/main/java/io/airbyte/test/utils/AirbyteAcceptanceTestHarness.java
@@ -108,6 +108,8 @@ public class AirbyteAcceptanceTestHarness {
   // assume env file is one directory level up from airbyte-tests.
   private final static File ENV_FILE = Path.of(System.getProperty("user.dir")).getParent().resolve(".env").toFile();
 
+  private static final String DEFAULT_POSTGRES_DOCKER_IMAGE_NAME = "postgres:13-alpine";
+
   private static final String SOURCE_E2E_TEST_CONNECTOR_VERSION = "0.1.1";
   private static final String DESTINATION_E2E_TEST_CONNECTOR_VERSION = "0.1.1";
 
@@ -162,9 +164,17 @@ public class AirbyteAcceptanceTestHarness {
     this.apiClient = apiClient;
   }
 
-  @SuppressWarnings("UnstableApiUsage")
   public AirbyteAcceptanceTestHarness(final AirbyteApiClient apiClient, final UUID defaultWorkspaceId)
-      throws URISyntaxException, IOException, InterruptedException, ApiException {
+      throws URISyntaxException, IOException, InterruptedException {
+    this(apiClient, defaultWorkspaceId, DEFAULT_POSTGRES_DOCKER_IMAGE_NAME, DEFAULT_POSTGRES_DOCKER_IMAGE_NAME);
+  }
+
+  @SuppressWarnings("UnstableApiUsage")
+  public AirbyteAcceptanceTestHarness(final AirbyteApiClient apiClient,
+                                      final UUID defaultWorkspaceId,
+                                      final String sourceDatabaseDockerImageName,
+                                      final String destinationDatabaseDockerImageName)
+      throws URISyntaxException, IOException, InterruptedException {
     // reads env vars to assign static variables
     assignEnvVars();
     this.apiClient = apiClient;
@@ -174,12 +184,12 @@ public class AirbyteAcceptanceTestHarness {
       throw new RuntimeException("KUBE Flag should also be enabled if GKE flag is enabled");
     }
     if (!isGke) {
-      sourcePsql = new PostgreSQLContainer("postgres:13-alpine")
+      sourcePsql = new PostgreSQLContainer(sourceDatabaseDockerImageName)
           .withUsername(SOURCE_USERNAME)
           .withPassword(SOURCE_PASSWORD);
       sourcePsql.start();
 
-      destinationPsql = new PostgreSQLContainer("postgres:13-alpine");
+      destinationPsql = new PostgreSQLContainer(destinationDatabaseDockerImageName);
       destinationPsql.start();
     }
 

--- a/airbyte-test-utils/src/main/java/io/airbyte/test/utils/AirbyteAcceptanceTestHarness.java
+++ b/airbyte-test-utils/src/main/java/io/airbyte/test/utils/AirbyteAcceptanceTestHarness.java
@@ -108,7 +108,7 @@ public class AirbyteAcceptanceTestHarness {
   // assume env file is one directory level up from airbyte-tests.
   private final static File ENV_FILE = Path.of(System.getProperty("user.dir")).getParent().resolve(".env").toFile();
 
-  private static final String DEFAULT_POSTGRES_DOCKER_IMAGE_NAME = "postgres:13-alpine";
+  public static final String DEFAULT_POSTGRES_DOCKER_IMAGE_NAME = "postgres:13-alpine";
 
   private static final String SOURCE_E2E_TEST_CONNECTOR_VERSION = "0.1.1";
   private static final String DESTINATION_E2E_TEST_CONNECTOR_VERSION = "0.1.1";


### PR DESCRIPTION
## What
* Support CDC acceptance test cases

## How
* Add ability to provide the container image to use for the source/destination database.  This will unlock the ability to use something like [Debezium Postgres docker image](https://hub.docker.com/r/debezium/postgres) that instead of the plain Postgres image which does not have log replication set up by default.

## Recommended reading order
1. `AirbyteAcceptanceTestHarness.java`