### PR TITLE
13538 Fix integration tests destination-scylla Mac OS

### DIFF
--- a/airbyte-integrations/connectors/destination-scylla/src/main/java/io/airbyte/integrations/destination/scylla/ScyllaConfig.java
+++ b/airbyte-integrations/connectors/destination-scylla/src/main/java/io/airbyte/integrations/destination/scylla/ScyllaConfig.java
@@ -35,7 +35,7 @@ public class ScyllaConfig {
     this.username = jsonNode.get("username").asText();
     this.password = jsonNode.get("password").asText();
     this.address = jsonNode.get("address").asText();
-    this.port = jsonNode.get("port").asInt(9042);
+    this.port = jsonNode.get("port").asInt();
     this.replication = jsonNode.get("replication").asInt(1);
   }
 

--- a/airbyte-integrations/connectors/destination-scylla/src/test-integration/java/io/airbyte/integrations/destination/scylla/ScyllaCqlProviderTest.java
+++ b/airbyte-integrations/connectors/destination-scylla/src/test-integration/java/io/airbyte/integrations/destination/scylla/ScyllaCqlProviderTest.java
@@ -9,6 +9,7 @@ import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 
 import com.datastax.driver.core.exceptions.InvalidQueryException;
+import io.airbyte.integrations.util.HostPortResolver;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;
@@ -29,8 +30,8 @@ class ScyllaCqlProviderTest {
   void setup() {
     var scyllaContainer = ScyllaContainerInitializr.initContainer();
     var scyllaConfig = TestDataFactory.scyllaConfig(
-        scyllaContainer.getHost(),
-        scyllaContainer.getFirstMappedPort());
+        HostPortResolver.resolveHost(scyllaContainer),
+        HostPortResolver.resolvePort(scyllaContainer));
     this.scyllaCqlProvider = new ScyllaCqlProvider(scyllaConfig);
     this.nameTransformer = new ScyllaNameTransformer(scyllaConfig);
     this.scyllaCqlProvider.createKeyspaceIfNotExists(SCYLLA_KEYSPACE);

--- a/airbyte-integrations/connectors/destination-scylla/src/test-integration/java/io/airbyte/integrations/destination/scylla/ScyllaDestinationAcceptanceTest.java
+++ b/airbyte-integrations/connectors/destination-scylla/src/test-integration/java/io/airbyte/integrations/destination/scylla/ScyllaDestinationAcceptanceTest.java
@@ -15,12 +15,8 @@ import java.util.Comparator;
 import java.util.List;
 import java.util.stream.Collectors;
 import org.junit.jupiter.api.BeforeAll;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 
 class ScyllaDestinationAcceptanceTest extends DestinationAcceptanceTest {
-
-  private static final Logger LOGGER = LoggerFactory.getLogger(ScyllaDestinationAcceptanceTest.class);
 
   private JsonNode configJson;
 

--- a/airbyte-integrations/connectors/destination-scylla/src/test-integration/java/io/airbyte/integrations/destination/scylla/ScyllaDestinationAcceptanceTest.java
+++ b/airbyte-integrations/connectors/destination-scylla/src/test-integration/java/io/airbyte/integrations/destination/scylla/ScyllaDestinationAcceptanceTest.java
@@ -10,6 +10,7 @@ import io.airbyte.integrations.destination.scylla.ScyllaContainerInitializr.Scyl
 import io.airbyte.integrations.standardtest.destination.DestinationAcceptanceTest;
 import io.airbyte.integrations.standardtest.destination.comparator.AdvancedTestDataComparator;
 import io.airbyte.integrations.standardtest.destination.comparator.TestDataComparator;
+import io.airbyte.integrations.util.HostPortResolver;
 import java.util.Comparator;
 import java.util.List;
 import java.util.stream.Collectors;
@@ -42,8 +43,8 @@ class ScyllaDestinationAcceptanceTest extends DestinationAcceptanceTest {
   @Override
   protected void setup(TestDestinationEnv testEnv) {
     configJson = TestDataFactory.jsonConfig(
-        scyllaContainer.getHost(),
-        scyllaContainer.getFirstMappedPort());
+        HostPortResolver.resolveHost(scyllaContainer),
+        HostPortResolver.resolvePort(scyllaContainer));
     var scyllaConfig = new ScyllaConfig(configJson);
     this.scyllaCqlProvider = new ScyllaCqlProvider(scyllaConfig);
     this.nameTransformer = new ScyllaNameTransformer(scyllaConfig);

--- a/airbyte-integrations/connectors/destination-scylla/src/test-integration/java/io/airbyte/integrations/destination/scylla/ScyllaDestinationTest.java
+++ b/airbyte-integrations/connectors/destination-scylla/src/test-integration/java/io/airbyte/integrations/destination/scylla/ScyllaDestinationTest.java
@@ -7,6 +7,7 @@ package io.airbyte.integrations.destination.scylla;
 import static org.assertj.core.api.Assertions.assertThat;
 
 import io.airbyte.integrations.destination.scylla.ScyllaContainerInitializr.ScyllaContainer;
+import io.airbyte.integrations.util.HostPortResolver;
 import io.airbyte.protocol.models.AirbyteConnectionStatus;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;
@@ -29,8 +30,8 @@ class ScyllaDestinationTest {
   void testCheckWithStatusSucceeded() {
 
     var jsonConfiguration = TestDataFactory.jsonConfig(
-        scyllaContainer.getHost(),
-        scyllaContainer.getFirstMappedPort());
+        HostPortResolver.resolveHost(scyllaContainer),
+        HostPortResolver.resolvePort(scyllaContainer));
 
     var connectionStatus = scyllaDestination.check(jsonConfiguration);
 


### PR DESCRIPTION
## What
Fixed integration tests destination-scylla Mac OS

Local reports
Before the change:
<img width="1280" alt="Screenshot 2022-07-01 at 00 27 50" src="https://user-images.githubusercontent.com/5124694/176740277-207a07ca-805a-416f-ae56-ec0e63cd36f9.png">

After the change:
<img width="1127" alt="Screenshot 2022-07-01 at 00 28 07" src="https://user-images.githubusercontent.com/5124694/176740336-0c2f5756-e9b3-45fc-8db2-282ba240103d.png">
