### PR TITLE
Run some DATs as part of base-normalization tests

### DIFF
--- a/.github/workflows/build-connector-command.yml
+++ b/.github/workflows/build-connector-command.yml
@@ -135,6 +135,12 @@ jobs:
         run: |
           source venv/bin/activate
           ci_credentials ${{ github.event.inputs.connector }}
+          # normalization also runs destination-specific tests, so fetch their creds also
+          if test 'base-normalization' -eq ${{ github.event.inputs.connector }}; then
+            ci_credentials destination-bigquery
+            ci_credentials destination-postgres
+            ci_credentials destination-snowflake
+          fi
         env:
           GCP_GSM_CREDENTIALS: ${{ secrets.GCP_GSM_CREDENTIALS }}
       # TODO: seems like this should run in post-merge workflow

--- a/.github/workflows/build-connector-command.yml
+++ b/.github/workflows/build-connector-command.yml
@@ -136,7 +136,7 @@ jobs:
           source venv/bin/activate
           ci_credentials ${{ github.event.inputs.connector }}
           # normalization also runs destination-specific tests, so fetch their creds also
-          if test 'bases/base-normalization' -eq ${{ github.event.inputs.connector }}; then
+          if test 'bases/base-normalization' '=' ${{ github.event.inputs.connector }}; then
             ci_credentials destination-bigquery
             ci_credentials destination-postgres
             ci_credentials destination-snowflake

--- a/.github/workflows/build-connector-command.yml
+++ b/.github/workflows/build-connector-command.yml
@@ -136,7 +136,7 @@ jobs:
           source venv/bin/activate
           ci_credentials ${{ github.event.inputs.connector }}
           # normalization also runs destination-specific tests, so fetch their creds also
-          if test 'base-normalization' -eq ${{ github.event.inputs.connector }}; then
+          if test 'bases/base-normalization' -eq ${{ github.event.inputs.connector }}; then
             ci_credentials destination-bigquery
             ci_credentials destination-postgres
             ci_credentials destination-snowflake

--- a/.github/workflows/build-connector-command.yml
+++ b/.github/workflows/build-connector-command.yml
@@ -136,7 +136,7 @@ jobs:
           source venv/bin/activate
           ci_credentials ${{ github.event.inputs.connector }}
           # normalization also runs destination-specific tests, so fetch their creds also
-          if test 'bases/base-normalization' '=' ${{ github.event.inputs.connector }}; then
+          if [ 'bases/base-normalization' = "${{ github.event.inputs.connector }}" ]; then
             ci_credentials destination-bigquery
             ci_credentials destination-postgres
             ci_credentials destination-snowflake

--- a/.github/workflows/publish-command.yml
+++ b/.github/workflows/publish-command.yml
@@ -266,6 +266,12 @@ jobs:
         run: |
           source venv/bin/activate
           ci_credentials ${{ matrix.connector }}
+          # normalization also runs destination-specific tests, so fetch their creds also
+          if test 'base-normalization' -eq ${{ matrix.connector }}; then
+            ci_credentials destination-bigquery
+            ci_credentials destination-postgres
+            ci_credentials destination-snowflake
+          fi
         env:
           GCP_GSM_CREDENTIALS: ${{ secrets.GCP_GSM_CREDENTIALS }}
       - name: Set Name and Version Environment Vars

--- a/.github/workflows/publish-command.yml
+++ b/.github/workflows/publish-command.yml
@@ -267,7 +267,7 @@ jobs:
           source venv/bin/activate
           ci_credentials ${{ matrix.connector }}
           # normalization also runs destination-specific tests, so fetch their creds also
-          if test 'bases/base-normalization' '=' ${{ matrix.connector }}; then
+          if [ 'bases/base-normalization' = "${{ matrix.connector }}" ]; then
             ci_credentials destination-bigquery
             ci_credentials destination-postgres
             ci_credentials destination-snowflake

--- a/.github/workflows/publish-command.yml
+++ b/.github/workflows/publish-command.yml
@@ -267,7 +267,7 @@ jobs:
           source venv/bin/activate
           ci_credentials ${{ matrix.connector }}
           # normalization also runs destination-specific tests, so fetch their creds also
-          if test 'base-normalization' -eq ${{ matrix.connector }}; then
+          if test 'bases/base-normalization' -eq ${{ matrix.connector }}; then
             ci_credentials destination-bigquery
             ci_credentials destination-postgres
             ci_credentials destination-snowflake

--- a/.github/workflows/publish-command.yml
+++ b/.github/workflows/publish-command.yml
@@ -267,7 +267,7 @@ jobs:
           source venv/bin/activate
           ci_credentials ${{ matrix.connector }}
           # normalization also runs destination-specific tests, so fetch their creds also
-          if test 'bases/base-normalization' -eq ${{ matrix.connector }}; then
+          if test 'bases/base-normalization' '=' ${{ matrix.connector }}; then
             ci_credentials destination-bigquery
             ci_credentials destination-postgres
             ci_credentials destination-snowflake

--- a/.github/workflows/test-command.yml
+++ b/.github/workflows/test-command.yml
@@ -111,11 +111,9 @@ jobs:
           source venv/bin/activate
           ci_credentials ${{ github.event.inputs.connector }}
           # normalization also runs destination-specific tests, so fetch their creds also
-          if test 'bases/base-normalization' '=' ${{ github.event.inputs.connector }}; then
-            ci_credentials destination-bigquery
-            ci_credentials destination-postgres
-            ci_credentials destination-snowflake
-          fi
+          ci_credentials destination-bigquery
+          ci_credentials destination-postgres
+          ci_credentials destination-snowflake
         env:
           GCP_GSM_CREDENTIALS: ${{ secrets.GCP_GSM_CREDENTIALS }}
 

--- a/.github/workflows/test-command.yml
+++ b/.github/workflows/test-command.yml
@@ -111,7 +111,7 @@ jobs:
           source venv/bin/activate
           ci_credentials ${{ github.event.inputs.connector }}
           # normalization also runs destination-specific tests, so fetch their creds also
-          if test 'bases/base-normalization' '=' ${{ matrix.connector }}; then
+          if [ 'bases/base-normalization' = "${{ github.event.inputs.connector }}" ]; then
             ci_credentials destination-bigquery
             ci_credentials destination-postgres
             ci_credentials destination-snowflake

--- a/.github/workflows/test-command.yml
+++ b/.github/workflows/test-command.yml
@@ -109,8 +109,10 @@ jobs:
       - name: Write Integration Test Credentials for ${{ github.event.inputs.connector }}
         run: |
           source venv/bin/activate
+          echo 'fetching for ${{ github.event.inputs.connector }}'
           ci_credentials ${{ github.event.inputs.connector }}
           # normalization also runs destination-specific tests, so fetch their creds also
+          echo 'fetching for destinations'
           ci_credentials destination-bigquery
           ci_credentials destination-postgres
           ci_credentials destination-snowflake

--- a/.github/workflows/test-command.yml
+++ b/.github/workflows/test-command.yml
@@ -111,7 +111,7 @@ jobs:
           source venv/bin/activate
           ci_credentials ${{ github.event.inputs.connector }}
           # normalization also runs destination-specific tests, so fetch their creds also
-          if test 'bases/base-normalization' -eq ${{ github.event.inputs.connector }}; then
+          if test 'bases/base-normalization' '=' ${{ github.event.inputs.connector }}; then
             ci_credentials destination-bigquery
             ci_credentials destination-postgres
             ci_credentials destination-snowflake

--- a/.github/workflows/test-command.yml
+++ b/.github/workflows/test-command.yml
@@ -109,13 +109,13 @@ jobs:
       - name: Write Integration Test Credentials for ${{ github.event.inputs.connector }}
         run: |
           source venv/bin/activate
-          echo 'fetching for ${{ github.event.inputs.connector }}'
           ci_credentials ${{ github.event.inputs.connector }}
           # normalization also runs destination-specific tests, so fetch their creds also
-          echo 'fetching for destinations'
-          ci_credentials destination-bigquery
-          ci_credentials destination-postgres
-          ci_credentials destination-snowflake
+          if test 'bases/base-normalization' '=' ${{ matrix.connector }}; then
+            ci_credentials destination-bigquery
+            ci_credentials destination-postgres
+            ci_credentials destination-snowflake
+          fi
         env:
           GCP_GSM_CREDENTIALS: ${{ secrets.GCP_GSM_CREDENTIALS }}
 

--- a/.github/workflows/test-command.yml
+++ b/.github/workflows/test-command.yml
@@ -111,7 +111,7 @@ jobs:
           source venv/bin/activate
           ci_credentials ${{ github.event.inputs.connector }}
           # normalization also runs destination-specific tests, so fetch their creds also
-          if test 'base-normalization' -eq ${{ github.event.inputs.connector }}; then
+          if test 'bases/base-normalization' -eq ${{ github.event.inputs.connector }}; then
             ci_credentials destination-bigquery
             ci_credentials destination-postgres
             ci_credentials destination-snowflake

--- a/.github/workflows/test-command.yml
+++ b/.github/workflows/test-command.yml
@@ -110,6 +110,12 @@ jobs:
         run: |
           source venv/bin/activate
           ci_credentials ${{ github.event.inputs.connector }}
+          # normalization also runs destination-specific tests, so fetch their creds also
+          if test 'base-normalization' -eq ${{ github.event.inputs.connector }}; then
+            ci_credentials destination-bigquery
+            ci_credentials destination-postgres
+            ci_credentials destination-snowflake
+          fi
         env:
           GCP_GSM_CREDENTIALS: ${{ secrets.GCP_GSM_CREDENTIALS }}
 

--- a/.github/workflows/test-performance-command.yml
+++ b/.github/workflows/test-performance-command.yml
@@ -117,7 +117,7 @@ jobs:
           source venv/bin/activate
           ci_credentials ${{ github.event.inputs.connector }}
           # normalization also runs destination-specific tests, so fetch their creds also
-          if test 'base-normalization' -eq ${{ github.event.inputs.connector }}; then
+          if test 'bases/base-normalization' -eq ${{ github.event.inputs.connector }}; then
             ci_credentials destination-bigquery
             ci_credentials destination-postgres
             ci_credentials destination-snowflake

--- a/.github/workflows/test-performance-command.yml
+++ b/.github/workflows/test-performance-command.yml
@@ -117,7 +117,7 @@ jobs:
           source venv/bin/activate
           ci_credentials ${{ github.event.inputs.connector }}
           # normalization also runs destination-specific tests, so fetch their creds also
-          if test 'bases/base-normalization' -eq ${{ github.event.inputs.connector }}; then
+          if test 'bases/base-normalization' '=' ${{ github.event.inputs.connector }}; then
             ci_credentials destination-bigquery
             ci_credentials destination-postgres
             ci_credentials destination-snowflake

--- a/.github/workflows/test-performance-command.yml
+++ b/.github/workflows/test-performance-command.yml
@@ -116,6 +116,12 @@ jobs:
         run: |
           source venv/bin/activate
           ci_credentials ${{ github.event.inputs.connector }}
+          # normalization also runs destination-specific tests, so fetch their creds also
+          if test 'base-normalization' -eq ${{ github.event.inputs.connector }}; then
+            ci_credentials destination-bigquery
+            ci_credentials destination-postgres
+            ci_credentials destination-snowflake
+          fi
         env:
           GCP_GSM_CREDENTIALS: ${{ secrets.GCP_GSM_CREDENTIALS }}
       - run: |

--- a/.github/workflows/test-performance-command.yml
+++ b/.github/workflows/test-performance-command.yml
@@ -117,7 +117,7 @@ jobs:
           source venv/bin/activate
           ci_credentials ${{ github.event.inputs.connector }}
           # normalization also runs destination-specific tests, so fetch their creds also
-          if test 'bases/base-normalization' '=' ${{ github.event.inputs.connector }}; then
+          if [ 'bases/base-normalization' = "${{ github.event.inputs.connector }}" ]; then
             ci_credentials destination-bigquery
             ci_credentials destination-postgres
             ci_credentials destination-snowflake

--- a/airbyte-integrations/bases/base-normalization/build.gradle
+++ b/airbyte-integrations/bases/base-normalization/build.gradle
@@ -104,6 +104,8 @@ task("customIntegrationTestPython", type: PythonTask, dependsOn: installTestReqs
 
 // DATs have some additional tests that exercise normalization code paths,
 // so we want to run these in addition to the base-normalization integration tests.
+// If you add more items here, make sure to also to have CI fetch their credentials.
+// See git history for an example.
 integrationTest.dependsOn(":airbyte-integrations:connectors:destination-bigquery:integrationTest")
 integrationTest.dependsOn(":airbyte-integrations:connectors:destination-postgres:integrationTest")
 integrationTest.dependsOn(":airbyte-integrations:connectors:destination-snowflake:integrationTest")

--- a/airbyte-integrations/bases/base-normalization/build.gradle
+++ b/airbyte-integrations/bases/base-normalization/build.gradle
@@ -102,6 +102,12 @@ task("customIntegrationTestPython", type: PythonTask, dependsOn: installTestReqs
     dependsOn ':airbyte-integrations:connectors:destination-clickhouse:airbyteDocker'
 }
 
+// DATs have some additional tests that exercise normalization code paths,
+// so we want to run these in addition to the base-normalization integration tests.
+integrationTest.dependsOn(":airbyte-integrations:connectors:destination-bigquery:integrationTest")
+integrationTest.dependsOn(":airbyte-integrations:connectors:destination-postgres:integrationTest")
+integrationTest.dependsOn(":airbyte-integrations:connectors:destination-snowflake:integrationTest")
+
 integrationTest.dependsOn("customIntegrationTestPython")
 customIntegrationTests.dependsOn("customIntegrationTestPython")
 


### PR DESCRIPTION
## What
DATs test some additional code paths to normalization, and are important for verifying that a normalization change doesn't somehow break compatibility with a destination. We should run DATs as part of the normalization integration tests.

## How
Run bigquery, snowflake, and postgres tests as part of the integrationTest task. `base-normalization:customIntegrationTestPython` is the task that actually runs the normalization tests, and is itself also a dependency of `base-normalization:integrationTest`, so all of these tasks will execute in parallel.

These three destinations are pretty representative of our destinations, but I could be convinced that we should be running against a larger set of destinations.