### PR TITLE
Use Debezium Postgres image for CDC tests

### DIFF
--- a/airbyte-test-utils/src/main/java/io/airbyte/test/utils/AirbyteAcceptanceTestHarness.java
+++ b/airbyte-test-utils/src/main/java/io/airbyte/test/utils/AirbyteAcceptanceTestHarness.java
@@ -420,11 +420,11 @@ public class AirbyteAcceptanceTestHarness {
   }
 
   public ConnectionRead createConnection(final String name,
-      final UUID sourceId,
-      final UUID destinationId,
-      final List<UUID> operationIds,
-      final AirbyteCatalog catalog,
-      final ConnectionSchedule schedule)
+                                         final UUID sourceId,
+                                         final UUID destinationId,
+                                         final List<UUID> operationIds,
+                                         final AirbyteCatalog catalog,
+                                         final ConnectionSchedule schedule)
       throws ApiException {
     final ConnectionRead connection = apiClient.getConnectionApi().createConnection(
         new ConnectionCreate()
@@ -703,9 +703,9 @@ public class AirbyteAcceptanceTestHarness {
 
   @SuppressWarnings("BusyWait")
   public static JobRead waitWhileJobHasStatus(final JobsApi jobsApi,
-      final JobRead originalJob,
-      final Set<JobStatus> jobStatuses,
-      final Duration maxWaitTime)
+                                              final JobRead originalJob,
+                                              final Set<JobStatus> jobStatuses,
+                                              final Duration maxWaitTime)
       throws InterruptedException, ApiException {
     JobRead job = originalJob;
 

--- a/tools/bin/gke-kube-acceptance-test/postgres-source.yaml
+++ b/tools/bin/gke-kube-acceptance-test/postgres-source.yaml
@@ -25,7 +25,7 @@ spec:
     spec:
       containers:
         - name: postgres-source
-          image: postgres:13-alpine
+          image: debezium/postgres:13-alpine
           imagePullPolicy: "IfNotPresent"
           ports:
             - containerPort: 5432


### PR DESCRIPTION
## What
* Support writing acceptance tests for a CDC configured source connector

## How
* Utilize the [Debezium Postgres image](https://hub.docker.com/r/debezium/postgres) for the source database in order to be able to write tests for the CDC case.
* Update the `AirbyteAcceptanceTestHarness` to use the [Debezium Postgres image](https://hub.docker.com/r/debezium/postgres) for the source database.
* Update the K8 acceptance test source configuration to use the [Debezium Postgres image](https://hub.docker.com/r/debezium/postgres).

## Recommended reading order
1. `AirbyteAcceptancetestHarness.java`
2. `postgres-source.yaml`

## More Details

This PR reverts the earlier PR that added the ability to provide the source image name when starting the source database as part of the acceptance tests.  This is for two reasons:

1. Testcontainers does not accept the [Debezium Postgres image](https://hub.docker.com/r/debezium/postgres) as is -- there are some additional code bits required to mark it as a suitable stand-in for the standard Postgres image (see PR for those bits)
2. The K8-based flavor of the tests specifies the image to use when starting the pod.

An alternative solution was considered where we start two different source containers via the K8 deployment descriptor on different ports -- one for regular Postgres and one for CDC.  We would also have needed to do something similar in the test harness and would have required the test to know which method to call when running locally/not in K8 to create the proper source database container.  That seems liked a lot of extra work for very little gain, as the [Debezium Postgres image](https://hub.docker.com/r/debezium/postgres) is really the same as the regular one, with some additional configuration bits in the Postgres configuration to enable log-based replication.  Therefore, it makes sense to just always run with this image for the source to support both test cases.

## Tests

<details><summary><strong>Acceptance</strong></summary>

Ran all of the `BasicAcceptanceTests` using the new source image.  All tests passed.

</details>
