### PR TITLE
Avoid error when creating dupl stream reset

### DIFF
--- a/airbyte-config/config-persistence/src/test/java/io/airbyte/config/persistence/BaseDatabaseConfigPersistenceTest.java
+++ b/airbyte-config/config-persistence/src/test/java/io/airbyte/config/persistence/BaseDatabaseConfigPersistenceTest.java
@@ -127,7 +127,7 @@ class BaseDatabaseConfigPersistenceTest {
     database.query(ctx -> ctx
         .execute(
             "TRUNCATE TABLE workspace_service_account, state, actor_catalog, actor_catalog_fetch_event, connection_operation, connection, operation, actor_oauth_parameter, "
-                + "actor, actor_definition, actor_definition_workspace_grant, workspace"));
+                + "actor, actor_definition, actor_definition_workspace_grant, workspace, stream_reset"));
   }
 
   void writeSource(final ConfigPersistence configPersistence, final StandardSourceDefinition source) throws Exception {

--- a/airbyte-config/config-persistence/src/test/java/io/airbyte/config/persistence/StreamResetPersistenceTest.java
+++ b/airbyte-config/config-persistence/src/test/java/io/airbyte/config/persistence/StreamResetPersistenceTest.java
@@ -51,6 +51,27 @@ class StreamResetPersistenceTest extends BaseDatabaseConfigPersistenceTest {
   }
 
   @Test
+  void testCreateSameResetTwiceOnlyCreateItOnce() throws Exception {
+    final UUID connectionId = UUID.randomUUID();
+    final StreamDescriptor streamDescriptor1 = new StreamDescriptor().withName("n1").withNamespace("ns2");
+    final StreamDescriptor streamDescriptor2 = new StreamDescriptor().withName("n2");
+
+    streamResetPersistence.createStreamResets(connectionId, List.of(streamDescriptor1, streamDescriptor2));
+
+    final List<StreamDescriptor> result = streamResetPersistence.getStreamResets(connectionId);
+    System.out.println(dslContext.selectFrom("stream_reset").fetch());
+    assertEquals(2, result.size());
+
+    streamResetPersistence.createStreamResets(connectionId, List.of(streamDescriptor1));
+    System.out.println(dslContext.selectFrom("stream_reset").fetch());
+    assertEquals(2, streamResetPersistence.getStreamResets(connectionId).size());
+
+    streamResetPersistence.createStreamResets(connectionId, List.of(streamDescriptor2));
+    System.out.println(dslContext.selectFrom("stream_reset").fetch());
+    assertEquals(2, streamResetPersistence.getStreamResets(connectionId).size());
+  }
+
+  @Test
   void testCreateAndGetAndDeleteStreamResets() throws Exception {
     final List<StreamDescriptor> streamResetList = new ArrayList<>();
     final StreamDescriptor streamDescriptor1 = new StreamDescriptor().withName("stream_name_1").withNamespace("stream_namespace_1");


### PR DESCRIPTION
## What
* Creating duplicated stream reset entries for the same stream should not be an error

## How
* Add a check to not create duplicated stream reset entries
* Wrap the stream reset create in a transaction to maintain consistent state. We do not want to have partial entries in case of a legacy state since that would result in an error later on.

