### PR TITLE
:bug: Source Mixpanel: fix SAT tests

### DIFF
--- a/airbyte-integrations/connectors/source-mixpanel/acceptance-test-config.yml
+++ b/airbyte-integrations/connectors/source-mixpanel/acceptance-test-config.yml
@@ -16,7 +16,7 @@ tests:
     - config_path: "secrets/config.json"
       configured_catalog_path: "integration_tests/configured_catalog.json"
       timeout_seconds: 3600
-      empty_streams: ['export']
+      empty_streams: ['export', 'annotations']
   full_refresh:
     - config_path: "secrets/config.json"
       configured_catalog_path: "integration_tests/configured_catalog.json"


### PR DESCRIPTION
## What
Resolving: https://github.com/airbytehq/airbyte/issues/14348

## How
- adjusted `acceptance-test-config.yml` to accept that `annotations` stream could be empty.