### PR TITLE
Source Stripe: external account streams

### DIFF
--- a/airbyte-config/init/src/main/resources/seed/source_definitions.yaml
+++ b/airbyte-config/init/src/main/resources/seed/source_definitions.yaml
@@ -937,7 +937,7 @@
 - name: Stripe
   sourceDefinitionId: e094cb9a-26de-4645-8761-65c0c425d1de
   dockerRepository: airbyte/source-stripe
-  dockerImageTag: 0.1.34
+  dockerImageTag: 0.1.35
   documentationUrl: https://docs.airbyte.io/integrations/sources/stripe
   icon: stripe.svg
   sourceType: api

--- a/airbyte-config/init/src/main/resources/seed/source_specs.yaml
+++ b/airbyte-config/init/src/main/resources/seed/source_specs.yaml
@@ -9291,7 +9291,7 @@
               type: "string"
               path_in_connector_config:
               - "client_secret"
-- dockerImage: "airbyte/source-stripe:0.1.34"
+- dockerImage: "airbyte/source-stripe:0.1.35"
   spec:
     documentationUrl: "https://docs.airbyte.io/integrations/sources/stripe"
     connectionSpecification:

--- a/airbyte-integrations/connectors/source-stripe/Dockerfile
+++ b/airbyte-integrations/connectors/source-stripe/Dockerfile
@@ -12,5 +12,5 @@ RUN pip install .
 ENV AIRBYTE_ENTRYPOINT "python /airbyte/integration_code/main.py"
 ENTRYPOINT ["python", "/airbyte/integration_code/main.py"]
 
-LABEL io.airbyte.version=0.1.34
+LABEL io.airbyte.version=0.1.35
 LABEL io.airbyte.name=airbyte/source-stripe

--- a/airbyte-integrations/connectors/source-stripe/source_stripe/schemas/external_account_bank_accounts.json
+++ b/airbyte-integrations/connectors/source-stripe/source_stripe/schemas/external_account_bank_accounts.json
@@ -33,7 +33,7 @@
       "type": ["string", "null"]
     },
     "metadata": {
-      "type": "object"
+      "type": ["object", "null"]
     },
     "routing_number": {
       "type": ["string", "null"]

--- a/airbyte-integrations/connectors/source-stripe/source_stripe/schemas/external_account_bank_accounts.json
+++ b/airbyte-integrations/connectors/source-stripe/source_stripe/schemas/external_account_bank_accounts.json
@@ -1,0 +1,48 @@
+{
+  "$schema": "http://json-schema.org/draft-04/schema#",
+  "type": "object",
+  "properties": {
+    "id": {
+      "type": "string"
+    },
+    "object": {
+      "type": ["string", "null"]
+    },
+    "account_holder_name": {
+      "type": ["string", "null"]
+    },
+    "account_holder_type": {
+      "type": ["string", "null"]
+    },
+    "account_type": {
+        "type": ["string", "null"]
+    },
+    "bank_name": {
+      "type": ["string", "null"]
+    },
+    "country": {
+      "type": ["string", "null"]
+    },
+    "currency": {
+      "type": ["string", "null"]
+    },
+    "fingerprint": {
+      "type": ["string", "null"]
+    },
+    "last4": {
+      "type": ["string", "null"]
+    },
+    "metadata": {
+      "type": "object"
+    },
+    "routing_number": {
+      "type": ["string", "null"]
+    },
+    "status": {
+      "type": ["string", "null"]
+    },
+    "account": {
+      "type": ["string", "null"]
+    }
+  }
+}

--- a/airbyte-integrations/connectors/source-stripe/source_stripe/schemas/external_account_bank_accounts.json
+++ b/airbyte-integrations/connectors/source-stripe/source_stripe/schemas/external_account_bank_accounts.json
@@ -15,7 +15,7 @@
       "type": ["string", "null"]
     },
     "account_type": {
-        "type": ["string", "null"]
+      "type": ["string", "null"]
     },
     "bank_name": {
       "type": ["string", "null"]

--- a/airbyte-integrations/connectors/source-stripe/source_stripe/schemas/external_account_cards.json
+++ b/airbyte-integrations/connectors/source-stripe/source_stripe/schemas/external_account_cards.json
@@ -1,0 +1,147 @@
+{
+  "$schema": "http://json-schema.org/draft-04/schema#",
+  "type": "object",
+  "properties": {
+    "id": {
+      "type": "string"
+    },
+    "object": {
+      "type": [
+        "string",
+        "null"
+      ]
+    },
+    "address_city": {
+      "type": [
+        "string",
+        "null"
+      ]
+    },
+    "address_country": {
+      "type": [
+        "string",
+        "null"
+      ]
+    },
+    "address_line1": {
+      "type": [
+        "string",
+        "null"
+      ]
+    },
+    "address_line1_check": {
+      "type": [
+        "string",
+        "null"
+      ]
+    },
+    "address_line2": {
+      "type": [
+        "string",
+        "null"
+      ]
+    },
+    "address_state": {
+      "type": [
+        "string",
+        "null"
+      ]
+    },
+    "address_zip": {
+      "type": [
+        "string",
+        "null"
+      ]
+    },
+    "address_zip_check": {
+      "type": [
+        "string",
+        "null"
+      ]
+    },
+    "brand": {
+      "type": [
+        "string",
+        "null"
+      ]
+    },
+    "country": {
+      "type": [
+        "string",
+        "null"
+      ]
+    },
+    "cvc_check": {
+      "type": [
+        "string",
+        "null"
+      ]
+    },
+    "dynamic_last4": {
+      "type": [
+        "string",
+        "null"
+      ]
+    },
+    "exp_month": {
+      "type": [
+        "integer",
+        "null"
+      ]
+    },
+    "exp_year": {
+      "type": [
+        "integer",
+        "null"
+      ]
+    },
+    "fingerprint": {
+      "type": [
+        "string",
+        "null"
+      ]
+    },
+    "funding": {
+      "type": [
+        "string",
+        "null"
+      ]
+    },
+    "last4": {
+      "type": [
+        "string",
+        "null"
+      ]
+    },
+    "metadata": {
+      "type": [
+        "object",
+        "null"
+      ]
+    },
+    "name": {
+      "type": [
+        "string",
+        "null"
+      ]
+    },
+    "redaction": {
+      "type": [
+        "string",
+        "null"
+      ]
+    },
+    "tokenization_method": {
+      "type": [
+        "string",
+        "null"
+      ]
+    },
+    "account": {
+      "type": [
+        "string",
+        "null"
+      ]
+    }
+  }
+}

--- a/airbyte-integrations/connectors/source-stripe/source_stripe/schemas/external_account_cards.json
+++ b/airbyte-integrations/connectors/source-stripe/source_stripe/schemas/external_account_cards.json
@@ -114,10 +114,7 @@
       ]
     },
     "metadata": {
-      "type": [
-        "object",
-        "null"
-      ]
+      "type": ["object", "null"]
     },
     "name": {
       "type": [

--- a/airbyte-integrations/connectors/source-stripe/source_stripe/schemas/external_account_cards.json
+++ b/airbyte-integrations/connectors/source-stripe/source_stripe/schemas/external_account_cards.json
@@ -6,139 +6,73 @@
       "type": "string"
     },
     "object": {
-      "type": [
-        "string",
-        "null"
-      ]
+      "type": ["string", "null"]
     },
     "address_city": {
-      "type": [
-        "string",
-        "null"
-      ]
+      "type": ["string", "null"]
     },
     "address_country": {
-      "type": [
-        "string",
-        "null"
-      ]
+      "type": ["string", "null"]
     },
     "address_line1": {
-      "type": [
-        "string",
-        "null"
-      ]
+      "type": ["string", "null"]
     },
     "address_line1_check": {
-      "type": [
-        "string",
-        "null"
-      ]
+      "type": ["string", "null"]
     },
     "address_line2": {
-      "type": [
-        "string",
-        "null"
-      ]
+      "type": ["string", "null"]
     },
     "address_state": {
-      "type": [
-        "string",
-        "null"
-      ]
+      "type": ["string", "null"]
     },
     "address_zip": {
-      "type": [
-        "string",
-        "null"
-      ]
+      "type": ["string", "null"]
     },
     "address_zip_check": {
-      "type": [
-        "string",
-        "null"
-      ]
+      "type": ["string", "null"]
     },
     "brand": {
-      "type": [
-        "string",
-        "null"
-      ]
+      "type": ["string", "null"]
     },
     "country": {
-      "type": [
-        "string",
-        "null"
-      ]
+      "type": ["string", "null"]
     },
     "cvc_check": {
-      "type": [
-        "string",
-        "null"
-      ]
+      "type": ["string", "null"]
     },
     "dynamic_last4": {
-      "type": [
-        "string",
-        "null"
-      ]
+      "type": ["string", "null"]
     },
     "exp_month": {
-      "type": [
-        "integer",
-        "null"
-      ]
+      "type": ["integer", "null"]
     },
     "exp_year": {
-      "type": [
-        "integer",
-        "null"
-      ]
+      "type": ["integer", "null"]
     },
     "fingerprint": {
-      "type": [
-        "string",
-        "null"
-      ]
+      "type": ["string", "null"]
     },
     "funding": {
-      "type": [
-        "string",
-        "null"
-      ]
+      "type": ["string", "null"]
     },
     "last4": {
-      "type": [
-        "string",
-        "null"
-      ]
+      "type": ["string", "null"]
     },
     "metadata": {
       "type": ["object", "null"]
     },
     "name": {
-      "type": [
-        "string",
-        "null"
-      ]
+      "type": ["string", "null"]
     },
     "redaction": {
-      "type": [
-        "string",
-        "null"
-      ]
+      "type": ["string", "null"]
     },
     "tokenization_method": {
-      "type": [
-        "string",
-        "null"
-      ]
+      "type": ["string", "null"]
     },
     "account": {
-      "type": [
-        "string",
-        "null"
-      ]
+      "type": ["string", "null"]
     }
   }
 }

--- a/airbyte-integrations/connectors/source-stripe/source_stripe/source.py
+++ b/airbyte-integrations/connectors/source-stripe/source_stripe/source.py
@@ -22,6 +22,8 @@ from source_stripe.streams import (
     Customers,
     Disputes,
     Events,
+    ExternalAccountBankAccounts,
+    ExternalAccountCards,
     InvoiceItems,
     InvoiceLineItems,
     Invoices,
@@ -74,4 +76,6 @@ class SourceStripe(AbstractSource):
             SubscriptionItems(**args),
             Subscriptions(**incremental_args),
             Transfers(**incremental_args),
+            ExternalAccountBankAccounts(**args),
+            ExternalAccountCards(**args),
         ]

--- a/airbyte-integrations/connectors/source-stripe/source_stripe/streams.py
+++ b/airbyte-integrations/connectors/source-stripe/source_stripe/streams.py
@@ -590,7 +590,7 @@ class ExternalAccountBankAccounts(ExternalAccount):
 
 class ExternalAccountCards(ExternalAccount):
     """
-    https://stripe.com/docs/api/external_account_bank_accounts/list
+    https://stripe.com/docs/api/external_account_cards/list
     """
 
     object = "card"

--- a/airbyte-integrations/connectors/source-stripe/source_stripe/streams.py
+++ b/airbyte-integrations/connectors/source-stripe/source_stripe/streams.py
@@ -563,3 +563,34 @@ class PromotionCodes(IncrementalStripeStream):
 
     def path(self, **kwargs):
         return "promotion_codes"
+
+
+class ExternalAccount(StripeStream, ABC):
+    """
+    Bank Accounts and Cards are separate streams because they have different schemas
+    """
+
+    object = ""
+
+    def path(self, **kwargs):
+        return f"accounts/{self.account_id}/external_accounts"
+
+    def request_params(self, **kwargs):
+        params = super().request_params(**kwargs)
+        return {**params, **{"object": self.object}}
+
+
+class ExternalAccountBankAccounts(ExternalAccount):
+    """
+    https://stripe.com/docs/api/external_account_bank_accounts/list
+    """
+
+    object = "bank_account"
+
+
+class ExternalAccountCards(ExternalAccount):
+    """
+    https://stripe.com/docs/api/external_account_bank_accounts/list
+    """
+
+    object = "card"

--- a/airbyte-integrations/connectors/source-stripe/unit_tests/test_source.py
+++ b/airbyte-integrations/connectors/source-stripe/unit_tests/test_source.py
@@ -36,7 +36,7 @@ def test_source_streams():
     with open("sample_files/config.json") as f:
         config = json.load(f)
     streams = SourceStripe().streams(config=config)
-    assert len(streams) == 22
+    assert len(streams) == 24
 
 
 @pytest.fixture(name="config")

--- a/airbyte-integrations/connectors/source-stripe/unit_tests/test_streams.py
+++ b/airbyte-integrations/connectors/source-stripe/unit_tests/test_streams.py
@@ -15,6 +15,9 @@ from source_stripe.streams import (
     Customers,
     Disputes,
     Events,
+    ExternalAccount,
+    ExternalAccountBankAccounts,
+    ExternalAccountCards,
     InvoiceItems,
     InvoiceLineItems,
     Invoices,
@@ -166,6 +169,7 @@ def config_fixture():
         (CheckoutSessions, {}, "checkout/sessions"),
         (CheckoutSessionsLineItems, {"stream_slice": {"checkout_session_id": "CS1"}}, "checkout/sessions/CS1/line_items"),
         (PromotionCodes, {}, "promotion_codes"),
+        (ExternalAccount, {}, "accounts/<account_id>/external_accounts"),
     ],
 )
 def test_path(
@@ -188,6 +192,8 @@ def test_path(
         (BankAccounts, {"stream_state": {}, "stream_slice": {"subscription_id": "SI"}}, {"limit": 100, "object": "bank_account"}),
         (CheckoutSessions, {"stream_state": None}, {"limit": 100}),
         (CheckoutSessionsLineItems, {"stream_state": None}, {"limit": 100, "expand[]": ["data.discounts", "data.taxes"]}),
+        (ExternalAccountBankAccounts, {"stream_state": None}, {"limit": 100, "object": "bank_account"}),
+        (ExternalAccountCards, {"stream_state": None}, {"limit": 100, "object": "card"}),
     ],
 )
 def test_request_params(

--- a/docs/integrations/sources/stripe.md
+++ b/docs/integrations/sources/stripe.md
@@ -61,6 +61,8 @@ The Stripe source connector supports the following streams:
 * [Subscription Items](https://stripe.com/docs/api/subscription_items/list)
 * [Subscriptions](https://stripe.com/docs/api/subscriptions/list) \(Incremental\)
 * [Transfers](https://stripe.com/docs/api/transfers/list) \(Incremental\)
+* [ExternalAccountBankAccounts](https://stripe.com/docs/api/external_account_bank_accounts/list)\(Full Refresh\)
+* [ExternalAccountCards](https://stripe.com/docs/api/external_account_cards/list)\(Full Refresh\)
 
 ### Data type mapping
 
@@ -74,7 +76,8 @@ The Stripe connector should not run into Stripe API limitations under normal usa
 
 | Version | Date       | Pull Request | Subject                                                                                                                                                |
 |:--------|:-----------| :--- |:-------------------------------------------------------------------------------------------------------------------------------------------------------|
-| 0.1.34  | 2022-07-21 | [14924](https://github.com/airbytehq/airbyte/pull/14924) | Remove `additionalProperties` field from spec and schema |
+| 0.1.35  | 2022-07-21 | [14924](https://github.com/airbytehq/airbyte/pull/14924) | Remove `additionalProperties` field from spec and schema |
+| 0.1.34  | 2022-07-01 | [14357](https://github.com/airbytehq/airbyte/pull/14357) | added external account streams |
 | 0.1.33  | 2022-06-06 | [13449](https://github.com/airbytehq/airbyte/pull/13449) | added semi-incremental support for CheckoutSessions and CheckoutSessionsLineItems streams, fixed big in StripeSubStream, added unittests, updated docs |
 | 0.1.32  | 2022-04-30 | [12500](https://github.com/airbytehq/airbyte/pull/12500) | Improve input configuration copy                                                                                                                       |
 | 0.1.31  | 2022-04-20 | [12230](https://github.com/airbytehq/airbyte/pull/12230) | Update connector to use a `spec.yaml`                                                                                                                  |


### PR DESCRIPTION
## What
Adds two new streams to the stripe connector.

## How
Add two new streams

## 🚨 User Impact 🚨
Adds new streams

## Pre-merge Checklist
Expand the relevant checklist and delete the others.

<details><summary><strong>Updating a connector</strong></summary>

### Community member or Airbyter

- [x] Grant edit access to maintainers ([instructions](https://docs.github.com/en/github/collaborating-with-pull-requests/working-with-forks/allowing-changes-to-a-pull-request-branch-created-from-a-fork#enabling-repository-maintainer-permissions-on-existing-pull-requests))
- [x] Secrets in the connector's spec are annotated with `airbyte_secret`
- [x] Unit & integration tests added and passing. Community members, please provide proof of success locally e.g: screenshot or copy-paste unit, integration, and acceptance test output. To run acceptance tests for a Python connector, follow instructions in the README. For java connectors run `./gradlew :airbyte-integrations:connectors:<name>:integrationTest`.
- [x] Code reviews completed
- [x] Documentation updated
    - [x] Connector's `README.md`
    - [x] Connector's `bootstrap.md`. See [description and examples](https://docs.google.com/document/d/1ypdgmwmEHWv-TrO4_YOQ7pAJGVrMp5BOkEVh831N260/edit?usp=sharing)
    - [ ] Changelog updated in `docs/integrations/<source or destination>/<name>.md` including changelog. See changelog [example](https://docs.airbyte.io/integrations/sources/stripe#changelog)
- [x] PR name follows [PR naming conventions](https://docs.airbyte.io/contributing-to-airbyte/updating-documentation#issues-and-pull-requests)

### Airbyter

If this is a community PR, the Airbyte engineer reviewing this PR is responsible for the below items.

- [ ] Create a non-forked branch based on this PR and test the below items on it
- [ ] Build is successful
- [ ] If new credentials are required for use in CI, add them to GSM. [Instructions](https://docs.airbyte.io/connector-development#using-credentials-in-ci).
- [ ] [`/test connector=connectors/<name>` command](https://docs.airbyte.io/connector-development#updating-an-existing-connector) is passing
- [ ] New Connector version released on Dockerhub and connector version bumped by running the `/publish` command described [here](https://docs.airbyte.io/connector-development#updating-an-existing-connector)

</details>

<details>
  <summary>Tests</summary>

```
Test session starts (platform: darwin, Python 3.9.13, pytest 6.2.5, pytest-sugar 0.9.4)
cachedir: .pytest_cache
rootdir: /Users/willwatkinson/src/github.com/airbytehq/airbyte, configfile: pytest.ini
plugins: sugar-0.9.4, requests-mock-1.9.3, timeout-1.4.2
collecting ...
 airbyte-integrations/connectors/source-stripe/unit_tests/test_source.py::test_lookback_window[None-1656694636.688665-1656694636.688665-if lookback_window_days is not set should not affect cursor value] ✓2% ▎
 airbyte-integrations/connectors/source-stripe/unit_tests/test_source.py::test_lookback_window[0-1656694636.688665-1656694636.688665-if lookback_window_days is not set should not affect cursor value] ✓5% ▌         {"type": "LOG", "log": {"level": "INFO", "message": "Applying lookback window of 10 days to stream invoices"}}

 airbyte-integrations/connectors/source-stripe/unit_tests/test_source.py::test_lookback_window[10-1656694636.688665-1655830636-Should calculate cursor value as expected] ✓7% ▊         {"type": "LOG", "log": {"level": "INFO", "message": "Applying lookback window of -10 days to stream invoices"}}

 airbyte-integrations/connectors/source-stripe/unit_tests/test_source.py::test_lookback_window[-10-1656694636.688665-1655830636-Should not care for the sign, use the module] ✓10% ▉
 airbyte-integrations/connectors/source-stripe/unit_tests/test_source.py::test_source_streams ✓12% █▎
 airbyte-integrations/connectors/source-stripe/unit_tests/test_source.py::test_source_check_connection_ok ✓14% █▌
 airbyte-integrations/connectors/source-stripe/unit_tests/test_source.py::test_source_check_connection_failure ✓17% █▋        {"type": "LOG", "log": {"level": "INFO", "message": "Applying lookback window of 1 days to stream checkout_sessions"}}
{"type": "LOG", "log": {"level": "INFO", "message": "Applying lookback window of 1 days to stream checkout_sessions"}}
{"type": "LOG", "log": {"level": "INFO", "message": "Applying lookback window of 1 days to stream checkout_sessions_line_items"}}
{"type": "LOG", "log": {"level": "WARN", "message": "{'error': {'code': 'resource_missing', 'doc_url': 'https://stripe.com/docs/error-codes/resource-missing', 'message': \"No such checkout session: 'cs_test_a165K4wNihuJlp2u3tknuohrvjAxyXFUB7nxZH3lwXRKJsadNEvIEWMUJ9'\", 'param': 'session', 'type': 'invalid_request_error'}}"}}
{"type": "LOG", "log": {"level": "INFO", "message": "Applying lookback window of 1 days to stream checkout_sessions_line_items"}}
stream_slice: {'checkout_session_id': 'cs_test_a1RjRHNyGUQOFVF3OkL8V8J0lZUASyVoCtsnZYG74VrBv3qz4245BLA1BP', 'expires_at': 100000}

 airbyte-integrations/connectors/source-stripe/unit_tests/test_streams.py::test_missed_id_child_stream ✓19% █▉
 airbyte-integrations/connectors/source-stripe/unit_tests/test_streams.py::test_sub_stream ✓21% ██▎
 airbyte-integrations/connectors/source-stripe/unit_tests/test_streams.py::test_path[Customers-kwargs0-customers] ✓24% ██▍
 airbyte-integrations/connectors/source-stripe/unit_tests/test_streams.py::test_path[BalanceTransactions-kwargs1-balance_transactions] ✓26% ██▋
 airbyte-integrations/connectors/source-stripe/unit_tests/test_streams.py::test_path[Charges-kwargs2-charges] ✓29% ██▉
 airbyte-integrations/connectors/source-stripe/unit_tests/test_streams.py::test_path[CustomerBalanceTransactions-kwargs3-customers/C1/balance_transactions] ✓31% ███▏
 airbyte-integrations/connectors/source-stripe/unit_tests/test_streams.py::test_path[Coupons-kwargs4-coupons] ✓33% ███▍
 airbyte-integrations/connectors/source-stripe/unit_tests/test_streams.py::test_path[Disputes-kwargs5-disputes] ✓36% ███▋
 airbyte-integrations/connectors/source-stripe/unit_tests/test_streams.py::test_path[Events-kwargs6-events] ✓38% ███▊
 airbyte-integrations/connectors/source-stripe/unit_tests/test_streams.py::test_path[Invoices-kwargs7-invoices] ✓40% ████▏
 airbyte-integrations/connectors/source-stripe/unit_tests/test_streams.py::test_path[InvoiceLineItems-kwargs8-invoices/I1/lines] ✓43% ████▍
 airbyte-integrations/connectors/source-stripe/unit_tests/test_streams.py::test_path[InvoiceItems-kwargs9-invoiceitems] ✓45% ████▌
 airbyte-integrations/connectors/source-stripe/unit_tests/test_streams.py::test_path[Payouts-kwargs10-payouts] ✓48% ████▊
 airbyte-integrations/connectors/source-stripe/unit_tests/test_streams.py::test_path[Plans-kwargs11-plans] ✓50% █████
 airbyte-integrations/connectors/source-stripe/unit_tests/test_streams.py::test_path[Products-kwargs12-products] ✓52% █████▎
 airbyte-integrations/connectors/source-stripe/unit_tests/test_streams.py::test_path[Subscriptions-kwargs13-subscriptions] ✓55% █████▌
 airbyte-integrations/connectors/source-stripe/unit_tests/test_streams.py::test_path[SubscriptionItems-kwargs14-subscription_items] ✓57% █████▊
 airbyte-integrations/connectors/source-stripe/unit_tests/test_streams.py::test_path[Transfers-kwargs15-transfers] ✓60% █████▉
 airbyte-integrations/connectors/source-stripe/unit_tests/test_streams.py::test_path[Refunds-kwargs16-refunds] ✓62% ██████▎
 airbyte-integrations/connectors/source-stripe/unit_tests/test_streams.py::test_path[PaymentIntents-kwargs17-payment_intents] ✓64% ██████▌
 airbyte-integrations/connectors/source-stripe/unit_tests/test_streams.py::test_path[BankAccounts-kwargs18-customers/C1/sources] ✓67% ██████▋
 airbyte-integrations/connectors/source-stripe/unit_tests/test_streams.py::test_path[CheckoutSessions-kwargs19-checkout/sessions] ✓69% ██████▉
 airbyte-integrations/connectors/source-stripe/unit_tests/test_streams.py::test_path[CheckoutSessionsLineItems-kwargs20-checkout/sessions/CS1/line_items] ✓71% ███████▎
 airbyte-integrations/connectors/source-stripe/unit_tests/test_streams.py::test_path[PromotionCodes-kwargs21-promotion_codes] ✓74% ███████▍
 airbyte-integrations/connectors/source-stripe/unit_tests/test_streams.py::test_path[ExternalAccount-kwargs22-accounts/<account_id>/external_accounts] ✓76% ███████▋
 airbyte-integrations/connectors/source-stripe/unit_tests/test_streams.py::test_request_params[CustomerBalanceTransactions-kwargs0-expected0] ✓79% ███████▉
 airbyte-integrations/connectors/source-stripe/unit_tests/test_streams.py::test_request_params[Customers-kwargs1-expected1] ✓81% ████████▏
 airbyte-integrations/connectors/source-stripe/unit_tests/test_streams.py::test_request_params[InvoiceLineItems-kwargs2-expected2] ✓83% ████████▍
 airbyte-integrations/connectors/source-stripe/unit_tests/test_streams.py::test_request_params[Subscriptions-kwargs3-expected3] ✓86% ████████▋
 airbyte-integrations/connectors/source-stripe/unit_tests/test_streams.py::test_request_params[SubscriptionItems-kwargs4-expected4] ✓88% ████████▊
 airbyte-integrations/connectors/source-stripe/unit_tests/test_streams.py::test_request_params[BankAccounts-kwargs5-expected5] ✓90% █████████▏{"type": "LOG", "log": {"level": "INFO", "message": "Applying lookback window of 1 days to stream checkout_sessions"}}

 airbyte-integrations/connectors/source-stripe/unit_tests/test_streams.py::test_request_params[CheckoutSessions-kwargs6-expected6] ✓93% █████████▍{"type": "LOG", "log": {"level": "INFO", "message": "Applying lookback window of 1 days to stream checkout_sessions_line_items"}}

 airbyte-integrations/connectors/source-stripe/unit_tests/test_streams.py::test_request_params[CheckoutSessionsLineItems-kwargs7-expected7] ✓95% █████████▌
 airbyte-integrations/connectors/source-stripe/unit_tests/test_streams.py::test_request_params[ExternalAccountBankAccounts-kwargs8-expected8] ✓98% █████████▊
 airbyte-integrations/connectors/source-stripe/unit_tests/test_streams.py::test_request_params[ExternalAccountCards-kwargs9-expected9] ✓100% ██████████
=============================== warnings summary ===============================
airbyte-integrations/connectors/source-stripe/unit_tests/test_source.py: 28 warnings
airbyte-integrations/connectors/source-stripe/unit_tests/test_streams.py: 37 warnings
  /Users/willwatkinson/src/github.com/airbytehq/airbyte/airbyte-integrations/connectors/source-stripe/.venv/lib/python3.9/site-packages/airbyte_cdk/sources/streams/http/http.py:41: DeprecationWarning: Call to deprecated class NoAuth. (Set `authenticator=None` instead) -- Deprecated since version 0.1.20.
    self._authenticator: HttpAuthenticator = NoAuth()

airbyte-integrations/connectors/source-stripe/unit_tests/test_source.py: 29 warnings
airbyte-integrations/connectors/source-stripe/unit_tests/test_streams.py: 37 warnings
  /Users/willwatkinson/src/github.com/airbytehq/airbyte/airbyte-integrations/connectors/source-stripe/.venv/lib/python3.9/site-packages/deprecated/classic.py:173: DeprecationWarning: Call to deprecated class HttpAuthenticator. (Use requests.auth.AuthBase instead) -- Deprecated since version 0.1.20.
    return old_new1(cls, *args, **kwargs)

airbyte-integrations/connectors/source-stripe/unit_tests/test_source.py::test_source_streams
  /Users/willwatkinson/src/github.com/airbytehq/airbyte/airbyte-integrations/connectors/source-stripe/source_stripe/source.py:52: DeprecationWarning: Call to deprecated class TokenAuthenticator. (Use airbyte_cdk.sources.streams.http.requests_native_auth.TokenAuthenticator instead) -- Deprecated since version 0.1.20.
    authenticator = TokenAuthenticator(config["client_secret"])

-- Docs: https://docs.pytest.org/en/stable/warnings.html

Results (1.41s):
      42 passed
```

</details>
