### PR TITLE
source-outreach: fix record parsing and cursor field access

### DIFF
--- a/airbyte-config/init/src/main/resources/seed/source_definitions.yaml
+++ b/airbyte-config/init/src/main/resources/seed/source_definitions.yaml
@@ -660,7 +660,7 @@
 - sourceDefinitionId: 3490c201-5d95-4783-b600-eaf07a4c7787
   name: Outreach
   dockerRepository: airbyte/source-outreach
-  dockerImageTag: 0.1.1
+  dockerImageTag: 0.1.2
   documentationUrl: https://docs.airbyte.io/integrations/sources/outreach
   icon: outreach.svg
   sourceType: api

--- a/airbyte-config/init/src/main/resources/seed/source_specs.yaml
+++ b/airbyte-config/init/src/main/resources/seed/source_specs.yaml
@@ -6407,7 +6407,7 @@
     supportsNormalization: false
     supportsDBT: false
     supported_destination_sync_modes: []
-- dockerImage: "airbyte/source-outreach:0.1.1"
+- dockerImage: "airbyte/source-outreach:0.1.2"
   spec:
     documentationUrl: "https://docs.airbyte.io/integrations/sources/outreach"
     connectionSpecification:

--- a/airbyte-integrations/connectors/source-outreach/Dockerfile
+++ b/airbyte-integrations/connectors/source-outreach/Dockerfile
@@ -34,5 +34,5 @@ COPY source_outreach ./source_outreach
 ENV AIRBYTE_ENTRYPOINT "python /airbyte/integration_code/main.py"
 ENTRYPOINT ["python", "/airbyte/integration_code/main.py"]
 
-LABEL io.airbyte.version=0.1.1
+LABEL io.airbyte.version=0.1.2
 LABEL io.airbyte.name=airbyte/source-outreach

--- a/airbyte-integrations/connectors/source-outreach/integration_tests/configured_catalog.json
+++ b/airbyte-integrations/connectors/source-outreach/integration_tests/configured_catalog.json
@@ -11,7 +11,7 @@
       },
       "sync_mode": "incremental",
       "destination_sync_mode": "overwrite",
-      "cursor_field": ["attributes", "updatedAt"]
+      "cursor_field": ["updatedAt"]
     },
     {
       "stream": {

--- a/airbyte-integrations/connectors/source-outreach/integration_tests/configured_catalog.json
+++ b/airbyte-integrations/connectors/source-outreach/integration_tests/configured_catalog.json
@@ -6,7 +6,7 @@
         "json_schema": {},
         "supported_sync_modes": ["full_refresh", "incremental"],
         "source_defined_cursor": true,
-        "default_cursor_field": ["attributes/updatedAt"],
+        "default_cursor_field": ["updatedAt"],
         "source_defined_primary_key": [["id"]]
       },
       "sync_mode": "incremental",
@@ -19,12 +19,12 @@
         "json_schema": {},
         "supported_sync_modes": ["full_refresh", "incremental"],
         "source_defined_cursor": true,
-        "default_cursor_field": ["attributes/updatedAt"],
+        "default_cursor_field": ["updatedAt"],
         "source_defined_primary_key": [["id"]]
       },
       "sync_mode": "incremental",
       "destination_sync_mode": "overwrite",
-      "cursor_field": ["attributes", "updatedAt"]
+      "cursor_field": ["updatedAt"]
     },
     {
       "stream": {
@@ -32,12 +32,12 @@
         "json_schema": {},
         "supported_sync_modes": ["full_refresh", "incremental"],
         "source_defined_cursor": true,
-        "default_cursor_field": ["attributes/updatedAt"],
+        "default_cursor_field": ["updatedAt"],
         "source_defined_primary_key": [["id"]]
       },
       "sync_mode": "incremental",
       "destination_sync_mode": "overwrite",
-      "cursor_field": ["attributes", "updatedAt"]
+      "cursor_field": ["updatedAt"]
     }
   ]
 }

--- a/airbyte-integrations/connectors/source-outreach/source_outreach/schemas/prospects.json
+++ b/airbyte-integrations/connectors/source-outreach/source_outreach/schemas/prospects.json
@@ -2,742 +2,734 @@
   "$schema": "http://json-schema.org/draft-07/schema#",
   "type": "object",
   "properties": {
-    "type": {
+    "id": {
+      "type": "integer"
+    },
+    "addedAt": {
+      "type": ["null", "string"],
+      "format": "date-time"
+    },
+    "addressCity": {
       "type": ["null", "string"]
     },
-    "id": {
+    "addressCountry": {
+      "type": ["null", "string"]
+    },
+    "addressState": {
+      "type": ["null", "string"]
+    },
+    "addressStreet": {
+      "type": ["null", "string"]
+    },
+    "addressStreet2": {
+      "type": ["null", "string"]
+    },
+    "addressZip": {
+      "type": ["null", "string"]
+    },
+    "angelListUrl": {
+      "type": ["null", "string"]
+    },
+    "availableAt": {
+      "type": ["null", "string"],
+      "format": "date-time"
+    },
+    "callOptedOut": {
+      "type": ["null", "boolean"]
+    },
+    "callsOptStatus": {
+      "type": ["null", "string"]
+    },
+    "callsOptedAt": {
+      "type": ["null", "string"],
+      "format": "date-time"
+    },
+    "campaignName": {
+      "type": ["null", "string"]
+    },
+    "clickCount": {
       "type": ["null", "integer"]
     },
-    "attributes": {
-      "type": ["null", "object"],
-      "properties": {
-        "addedAt": {
-          "type": ["null", "string"],
-          "format": "date-time"
-        },
-        "addressCity": {
-          "type": ["null", "string"]
-        },
-        "addressCountry": {
-          "type": ["null", "string"]
-        },
-        "addressState": {
-          "type": ["null", "string"]
-        },
-        "addressStreet": {
-          "type": ["null", "string"]
-        },
-        "addressStreet2": {
-          "type": ["null", "string"]
-        },
-        "addressZip": {
-          "type": ["null", "string"]
-        },
-        "angelListUrl": {
-          "type": ["null", "string"]
-        },
-        "availableAt": {
-          "type": ["null", "string"],
-          "format": "date-time"
-        },
-        "callOptedOut": {
-          "type": ["null", "boolean"]
-        },
-        "callsOptStatus": {
-          "type": ["null", "string"]
-        },
-        "callsOptedAt": {
-          "type": ["null", "string"],
-          "format": "date-time"
-        },
-        "campaignName": {
-          "type": ["null", "string"]
-        },
-        "clickCount": {
-          "type": ["null", "integer"]
-        },
-        "company": {
-          "type": ["null", "string"]
-        },
-        "contactHistogram": {
-          "type": ["null", "array"],
-          "items": {
-            "type": "array",
-            "items": {
-              "type": "integer"
-            }
-          }
-        },
-        "createdAt": {
-          "type": ["null", "string"],
-          "format": "date-time"
-        },
-        "custom1": {
-          "type": ["null", "string"]
-        },
-        "custom10": {
-          "type": ["null", "string"]
-        },
-        "custom100": {
-          "type": ["null", "string"]
-        },
-        "custom101": {
-          "type": ["null", "string"]
-        },
-        "custom102": {
-          "type": ["null", "string"]
-        },
-        "custom103": {
-          "type": ["null", "string"]
-        },
-        "custom104": {
-          "type": ["null", "string"]
-        },
-        "custom105": {
-          "type": ["null", "string"]
-        },
-        "custom106": {
-          "type": ["null", "string"]
-        },
-        "custom107": {
-          "type": ["null", "string"]
-        },
-        "custom108": {
-          "type": ["null", "string"]
-        },
-        "custom109": {
-          "type": ["null", "string"]
-        },
-        "custom11": {
-          "type": ["null", "string"]
-        },
-        "custom110": {
-          "type": ["null", "string"]
-        },
-        "custom111": {
-          "type": ["null", "string"]
-        },
-        "custom112": {
-          "type": ["null", "string"]
-        },
-        "custom113": {
-          "type": ["null", "string"]
-        },
-        "custom114": {
-          "type": ["null", "string"]
-        },
-        "custom115": {
-          "type": ["null", "string"]
-        },
-        "custom116": {
-          "type": ["null", "string"]
-        },
-        "custom117": {
-          "type": ["null", "string"]
-        },
-        "custom118": {
-          "type": ["null", "string"]
-        },
-        "custom119": {
-          "type": ["null", "string"]
-        },
-        "custom12": {
-          "type": ["null", "string"]
-        },
-        "custom120": {
-          "type": ["null", "string"]
-        },
-        "custom121": {
-          "type": ["null", "string"]
-        },
-        "custom122": {
-          "type": ["null", "string"]
-        },
-        "custom123": {
-          "type": ["null", "string"]
-        },
-        "custom124": {
-          "type": ["null", "string"]
-        },
-        "custom125": {
-          "type": ["null", "string"]
-        },
-        "custom126": {
-          "type": ["null", "string"]
-        },
-        "custom127": {
-          "type": ["null", "string"]
-        },
-        "custom128": {
-          "type": ["null", "string"]
-        },
-        "custom129": {
-          "type": ["null", "string"]
-        },
-        "custom13": {
-          "type": ["null", "string"]
-        },
-        "custom130": {
-          "type": ["null", "string"]
-        },
-        "custom131": {
-          "type": ["null", "string"]
-        },
-        "custom132": {
-          "type": ["null", "string"]
-        },
-        "custom133": {
-          "type": ["null", "string"]
-        },
-        "custom134": {
-          "type": ["null", "string"]
-        },
-        "custom135": {
-          "type": ["null", "string"]
-        },
-        "custom136": {
-          "type": ["null", "string"]
-        },
-        "custom137": {
-          "type": ["null", "string"]
-        },
-        "custom138": {
-          "type": ["null", "string"]
-        },
-        "custom139": {
-          "type": ["null", "string"]
-        },
-        "custom14": {
-          "type": ["null", "string"]
-        },
-        "custom140": {
-          "type": ["null", "string"]
-        },
-        "custom141": {
-          "type": ["null", "string"]
-        },
-        "custom142": {
-          "type": ["null", "string"]
-        },
-        "custom143": {
-          "type": ["null", "string"]
-        },
-        "custom144": {
-          "type": ["null", "string"]
-        },
-        "custom145": {
-          "type": ["null", "string"]
-        },
-        "custom146": {
-          "type": ["null", "string"]
-        },
-        "custom147": {
-          "type": ["null", "string"]
-        },
-        "custom148": {
-          "type": ["null", "string"]
-        },
-        "custom149": {
-          "type": ["null", "string"]
-        },
-        "custom15": {
-          "type": ["null", "string"]
-        },
-        "custom150": {
-          "type": ["null", "string"]
-        },
-        "custom16": {
-          "type": ["null", "string"]
-        },
-        "custom17": {
-          "type": ["null", "string"]
-        },
-        "custom18": {
-          "type": ["null", "string"]
-        },
-        "custom19": {
-          "type": ["null", "string"]
-        },
-        "custom2": {
-          "type": ["null", "string"]
-        },
-        "custom20": {
-          "type": ["null", "string"]
-        },
-        "custom21": {
-          "type": ["null", "string"]
-        },
-        "custom22": {
-          "type": ["null", "string"]
-        },
-        "custom23": {
-          "type": ["null", "string"]
-        },
-        "custom24": {
-          "type": ["null", "string"]
-        },
-        "custom25": {
-          "type": ["null", "string"]
-        },
-        "custom26": {
-          "type": ["null", "string"]
-        },
-        "custom27": {
-          "type": ["null", "string"]
-        },
-        "custom28": {
-          "type": ["null", "string"]
-        },
-        "custom29": {
-          "type": ["null", "string"]
-        },
-        "custom3": {
-          "type": ["null", "string"]
-        },
-        "custom30": {
-          "type": ["null", "string"]
-        },
-        "custom31": {
-          "type": ["null", "string"]
-        },
-        "custom32": {
-          "type": ["null", "string"]
-        },
-        "custom33": {
-          "type": ["null", "string"]
-        },
-        "custom34": {
-          "type": ["null", "string"]
-        },
-        "custom35": {
-          "type": ["null", "string"]
-        },
-        "custom36": {
-          "type": ["null", "string"]
-        },
-        "custom37": {
-          "type": ["null", "string"]
-        },
-        "custom38": {
-          "type": ["null", "string"]
-        },
-        "custom39": {
-          "type": ["null", "string"]
-        },
-        "custom4": {
-          "type": ["null", "string"]
-        },
-        "custom40": {
-          "type": ["null", "string"]
-        },
-        "custom41": {
-          "type": ["null", "string"]
-        },
-        "custom42": {
-          "type": ["null", "string"]
-        },
-        "custom43": {
-          "type": ["null", "string"]
-        },
-        "custom44": {
-          "type": ["null", "string"]
-        },
-        "custom45": {
-          "type": ["null", "string"]
-        },
-        "custom46": {
-          "type": ["null", "string"]
-        },
-        "custom47": {
-          "type": ["null", "string"]
-        },
-        "custom48": {
-          "type": ["null", "string"]
-        },
-        "custom49": {
-          "type": ["null", "string"]
-        },
-        "custom50": {
-          "type": ["null", "string"]
-        },
-        "custom51": {
-          "type": ["null", "string"]
-        },
-        "custom52": {
-          "type": ["null", "string"]
-        },
-        "custom53": {
-          "type": ["null", "string"]
-        },
-        "custom54": {
-          "type": ["null", "string"]
-        },
-        "custom55": {
-          "type": ["null", "string"]
-        },
-        "custom56": {
-          "type": ["null", "string"]
-        },
-        "custom57": {
-          "type": ["null", "string"]
-        },
-        "custom58": {
-          "type": ["null", "string"]
-        },
-        "custom59": {
-          "type": ["null", "string"]
-        },
-        "custom6": {
-          "type": ["null", "string"]
-        },
-        "custom60": {
-          "type": ["null", "string"]
-        },
-        "custom61": {
-          "type": ["null", "string"]
-        },
-        "custom62": {
-          "type": ["null", "string"]
-        },
-        "custom63": {
-          "type": ["null", "string"]
-        },
-        "custom64": {
-          "type": ["null", "string"]
-        },
-        "custom65": {
-          "type": ["null", "string"]
-        },
-        "custom66": {
-          "type": ["null", "string"]
-        },
-        "custom67": {
-          "type": ["null", "string"]
-        },
-        "custom68": {
-          "type": ["null", "string"]
-        },
-        "custom69": {
-          "type": ["null", "string"]
-        },
-        "custom7": {
-          "type": ["null", "string"]
-        },
-        "custom70": {
-          "type": ["null", "string"]
-        },
-        "custom71": {
-          "type": ["null", "string"]
-        },
-        "custom72": {
-          "type": ["null", "string"]
-        },
-        "custom73": {
-          "type": ["null", "string"]
-        },
-        "custom74": {
-          "type": ["null", "string"]
-        },
-        "custom75": {
-          "type": ["null", "string"]
-        },
-        "custom76": {
-          "type": ["null", "string"]
-        },
-        "custom77": {
-          "type": ["null", "string"]
-        },
-        "custom78": {
-          "type": ["null", "string"]
-        },
-        "custom79": {
-          "type": ["null", "string"]
-        },
-        "custom8": {
-          "type": ["null", "string"]
-        },
-        "custom80": {
-          "type": ["null", "string"]
-        },
-        "custom81": {
-          "type": ["null", "string"]
-        },
-        "custom82": {
-          "type": ["null", "string"]
-        },
-        "custom83": {
-          "type": ["null", "string"]
-        },
-        "custom84": {
-          "type": ["null", "string"]
-        },
-        "custom85": {
-          "type": ["null", "string"]
-        },
-        "custom86": {
-          "type": ["null", "string"]
-        },
-        "custom87": {
-          "type": ["null", "string"]
-        },
-        "custom88": {
-          "type": ["null", "string"]
-        },
-        "custom89": {
-          "type": ["null", "string"]
-        },
-        "custom9": {
-          "type": ["null", "string"]
-        },
-        "custom90": {
-          "type": ["null", "string"]
-        },
-        "custom91": {
-          "type": ["null", "string"]
-        },
-        "custom92": {
-          "type": ["null", "string"]
-        },
-        "custom93": {
-          "type": ["null", "string"]
-        },
-        "custom94": {
-          "type": ["null", "string"]
-        },
-        "custom95": {
-          "type": ["null", "string"]
-        },
-        "custom96": {
-          "type": ["null", "string"]
-        },
-        "custom97": {
-          "type": ["null", "string"]
-        },
-        "custom98": {
-          "type": ["null", "string"]
-        },
-        "custom99": {
-          "type": ["null", "string"]
-        },
-        "dateOfBirth": {
-          "type": ["null", "string"],
-          "format": "date-time"
-        },
-        "degree": {
-          "type": ["null", "string"]
-        },
-        "emailOptedOut": {
-          "type": ["null", "boolean"]
-        },
-        "emails": {
-          "type": ["null", "array"],
-          "items": {
-            "type": "string"
-          }
-        },
-        "emailsOptStatus": {
-          "type": ["null", "string"]
-        },
-        "emailsOptedAt": {
-          "type": ["null", "string"],
-          "format": "date-time"
-        },
-        "engagedAt": {
-          "type": ["null", "string"],
-          "format": "date-time"
-        },
-        "engagedScore": {
-          "type": ["null", "number"]
-        },
-        "eventName": {
-          "type": ["null", "string"]
-        },
-        "externalId": {
-          "type": ["null", "string"]
-        },
-        "externalOwner": {
-          "type": ["null", "string"]
-        },
-        "externalSource": {
-          "type": ["null", "string"]
-        },
-        "facebookUrl": {
-          "type": ["null", "string"]
-        },
-        "firstName": {
-          "type": ["null", "string"]
-        },
-        "gender": {
-          "type": ["null", "string"]
-        },
-        "githubUrl": {
-          "type": ["null", "string"]
-        },
-        "githubUsername": {
-          "type": ["null", "string"]
-        },
-        "googlePlusUrl": {
-          "type": ["null", "string"]
-        },
-        "graduationDate": {
-          "type": ["null", "string"],
-          "format": "date-time"
-        },
-        "homePhones": {
-          "type": ["null", "array"],
-          "items": {
-            "type": "string"
-          }
-        },
-        "jobStartDate": {
-          "type": ["null", "string"],
-          "format": "date-time"
-        },
-        "lastName": {
-          "type": ["null", "string"]
-        },
-        "linkedInConnections": {
-          "type": ["null", "integer"]
-        },
-        "linkedInId": {
-          "type": ["null", "string"]
-        },
-        "linkedInSlug": {
-          "type": ["null", "string"]
-        },
-        "linkedInUrl": {
-          "type": ["null", "string"]
-        },
-        "middleName": {
-          "type": ["null", "string"]
-        },
-        "mobilePhones": {
-          "type": ["null", "array"],
-          "items": {
-            "type": "string"
-          }
-        },
-        "name": {
-          "type": ["null", "string"]
-        },
-        "nickname": {
-          "type": ["null", "string"]
-        },
-        "occupation": {
-          "type": ["null", "string"]
-        },
-        "openCount": {
-          "type": ["null", "integer"]
-        },
-        "optedOut": {
-          "type": ["null", "boolean"]
-        },
-        "optedOutAt": {
-          "type": ["null", "string"],
-          "format": "date-time"
-        },
-        "otherPhones": {
-          "type": ["null", "array"],
-          "items": {
-            "type": "string"
-          }
-        },
-        "personalNote1": {
-          "type": ["null", "string"]
-        },
-        "personalNote2": {
-          "type": ["null", "string"]
-        },
-        "preferredContact": {
-          "type": ["null", "string"]
-        },
-        "quoraUrl": {
-          "type": ["null", "string"]
-        },
-        "region": {
-          "type": ["null", "string"]
-        },
-        "replyCount": {
-          "type": ["null", "integer"]
-        },
-        "school": {
-          "type": ["null", "string"]
-        },
-        "score": {
-          "type": ["null", "number"]
-        },
-        "sharingTeamId": {
-          "type": ["null", "string"]
-        },
-        "source": {
-          "type": ["null", "string"]
-        },
-        "specialties": {
-          "type": ["null", "string"]
-        },
-        "stackOverflowId": {
-          "type": ["null", "string"]
-        },
-        "stackOverflowUrl": {
-          "type": ["null", "string"]
-        },
-        "tags": {
-          "type": ["null", "array"],
-          "items": {
-            "type": ["null", "string"]
-          }
-        },
-        "timeZone": {
-          "type": ["null", "string"]
-        },
-        "timeZoneIana": {
-          "type": ["null", "string"]
-        },
-        "timeZoneInferred": {
-          "type": ["null", "string"]
-        },
-        "title": {
-          "type": ["null", "string"]
-        },
-        "touchedAt": {
-          "type": ["null", "string"],
-          "format": "date-time"
-        },
-        "trashedAt": {
-          "type": ["null", "string"],
-          "format": "date-time"
-        },
-        "twitterUrl": {
-          "type": ["null", "string"]
-        },
-        "twitterUsername": {
-          "type": ["null", "string"]
-        },
-        "updatedAt": {
-          "type": ["null", "string"],
-          "format": "date-time"
-        },
-        "voipPhones": {
-          "type": ["null", "array"],
-          "items": {
-            "type": "string"
-          }
-        },
-        "websiteUrl1": {
-          "type": ["null", "string"]
-        },
-        "websiteUrl2": {
-          "type": ["null", "string"]
-        },
-        "websiteUrl3": {
-          "type": ["null", "string"]
-        },
-        "workPhones": {
-          "type": ["null", "array"],
-          "items": {
-            "type": "string"
-          }
+    "company": {
+      "type": ["null", "string"]
+    },
+    "contactHistogram": {
+      "type": ["null", "array"],
+      "items": {
+        "type": "array",
+        "items": {
+          "type": "integer"
         }
+      }
+    },
+    "createdAt": {
+      "type": ["null", "string"],
+      "format": "date-time"
+    },
+    "custom1": {
+      "type": ["null", "string"]
+    },
+    "custom10": {
+      "type": ["null", "string"]
+    },
+    "custom100": {
+      "type": ["null", "string"]
+    },
+    "custom101": {
+      "type": ["null", "string"]
+    },
+    "custom102": {
+      "type": ["null", "string"]
+    },
+    "custom103": {
+      "type": ["null", "string"]
+    },
+    "custom104": {
+      "type": ["null", "string"]
+    },
+    "custom105": {
+      "type": ["null", "string"]
+    },
+    "custom106": {
+      "type": ["null", "string"]
+    },
+    "custom107": {
+      "type": ["null", "string"]
+    },
+    "custom108": {
+      "type": ["null", "string"]
+    },
+    "custom109": {
+      "type": ["null", "string"]
+    },
+    "custom11": {
+      "type": ["null", "string"]
+    },
+    "custom110": {
+      "type": ["null", "string"]
+    },
+    "custom111": {
+      "type": ["null", "string"]
+    },
+    "custom112": {
+      "type": ["null", "string"]
+    },
+    "custom113": {
+      "type": ["null", "string"]
+    },
+    "custom114": {
+      "type": ["null", "string"]
+    },
+    "custom115": {
+      "type": ["null", "string"]
+    },
+    "custom116": {
+      "type": ["null", "string"]
+    },
+    "custom117": {
+      "type": ["null", "string"]
+    },
+    "custom118": {
+      "type": ["null", "string"]
+    },
+    "custom119": {
+      "type": ["null", "string"]
+    },
+    "custom12": {
+      "type": ["null", "string"]
+    },
+    "custom120": {
+      "type": ["null", "string"]
+    },
+    "custom121": {
+      "type": ["null", "string"]
+    },
+    "custom122": {
+      "type": ["null", "string"]
+    },
+    "custom123": {
+      "type": ["null", "string"]
+    },
+    "custom124": {
+      "type": ["null", "string"]
+    },
+    "custom125": {
+      "type": ["null", "string"]
+    },
+    "custom126": {
+      "type": ["null", "string"]
+    },
+    "custom127": {
+      "type": ["null", "string"]
+    },
+    "custom128": {
+      "type": ["null", "string"]
+    },
+    "custom129": {
+      "type": ["null", "string"]
+    },
+    "custom13": {
+      "type": ["null", "string"]
+    },
+    "custom130": {
+      "type": ["null", "string"]
+    },
+    "custom131": {
+      "type": ["null", "string"]
+    },
+    "custom132": {
+      "type": ["null", "string"]
+    },
+    "custom133": {
+      "type": ["null", "string"]
+    },
+    "custom134": {
+      "type": ["null", "string"]
+    },
+    "custom135": {
+      "type": ["null", "string"]
+    },
+    "custom136": {
+      "type": ["null", "string"]
+    },
+    "custom137": {
+      "type": ["null", "string"]
+    },
+    "custom138": {
+      "type": ["null", "string"]
+    },
+    "custom139": {
+      "type": ["null", "string"]
+    },
+    "custom14": {
+      "type": ["null", "string"]
+    },
+    "custom140": {
+      "type": ["null", "string"]
+    },
+    "custom141": {
+      "type": ["null", "string"]
+    },
+    "custom142": {
+      "type": ["null", "string"]
+    },
+    "custom143": {
+      "type": ["null", "string"]
+    },
+    "custom144": {
+      "type": ["null", "string"]
+    },
+    "custom145": {
+      "type": ["null", "string"]
+    },
+    "custom146": {
+      "type": ["null", "string"]
+    },
+    "custom147": {
+      "type": ["null", "string"]
+    },
+    "custom148": {
+      "type": ["null", "string"]
+    },
+    "custom149": {
+      "type": ["null", "string"]
+    },
+    "custom15": {
+      "type": ["null", "string"]
+    },
+    "custom150": {
+      "type": ["null", "string"]
+    },
+    "custom16": {
+      "type": ["null", "string"]
+    },
+    "custom17": {
+      "type": ["null", "string"]
+    },
+    "custom18": {
+      "type": ["null", "string"]
+    },
+    "custom19": {
+      "type": ["null", "string"]
+    },
+    "custom2": {
+      "type": ["null", "string"]
+    },
+    "custom20": {
+      "type": ["null", "string"]
+    },
+    "custom21": {
+      "type": ["null", "string"]
+    },
+    "custom22": {
+      "type": ["null", "string"]
+    },
+    "custom23": {
+      "type": ["null", "string"]
+    },
+    "custom24": {
+      "type": ["null", "string"]
+    },
+    "custom25": {
+      "type": ["null", "string"]
+    },
+    "custom26": {
+      "type": ["null", "string"]
+    },
+    "custom27": {
+      "type": ["null", "string"]
+    },
+    "custom28": {
+      "type": ["null", "string"]
+    },
+    "custom29": {
+      "type": ["null", "string"]
+    },
+    "custom3": {
+      "type": ["null", "string"]
+    },
+    "custom30": {
+      "type": ["null", "string"]
+    },
+    "custom31": {
+      "type": ["null", "string"]
+    },
+    "custom32": {
+      "type": ["null", "string"]
+    },
+    "custom33": {
+      "type": ["null", "string"]
+    },
+    "custom34": {
+      "type": ["null", "string"]
+    },
+    "custom35": {
+      "type": ["null", "string"]
+    },
+    "custom36": {
+      "type": ["null", "string"]
+    },
+    "custom37": {
+      "type": ["null", "string"]
+    },
+    "custom38": {
+      "type": ["null", "string"]
+    },
+    "custom39": {
+      "type": ["null", "string"]
+    },
+    "custom4": {
+      "type": ["null", "string"]
+    },
+    "custom40": {
+      "type": ["null", "string"]
+    },
+    "custom41": {
+      "type": ["null", "string"]
+    },
+    "custom42": {
+      "type": ["null", "string"]
+    },
+    "custom43": {
+      "type": ["null", "string"]
+    },
+    "custom44": {
+      "type": ["null", "string"]
+    },
+    "custom45": {
+      "type": ["null", "string"]
+    },
+    "custom46": {
+      "type": ["null", "string"]
+    },
+    "custom47": {
+      "type": ["null", "string"]
+    },
+    "custom48": {
+      "type": ["null", "string"]
+    },
+    "custom49": {
+      "type": ["null", "string"]
+    },
+    "custom50": {
+      "type": ["null", "string"]
+    },
+    "custom51": {
+      "type": ["null", "string"]
+    },
+    "custom52": {
+      "type": ["null", "string"]
+    },
+    "custom53": {
+      "type": ["null", "string"]
+    },
+    "custom54": {
+      "type": ["null", "string"]
+    },
+    "custom55": {
+      "type": ["null", "string"]
+    },
+    "custom56": {
+      "type": ["null", "string"]
+    },
+    "custom57": {
+      "type": ["null", "string"]
+    },
+    "custom58": {
+      "type": ["null", "string"]
+    },
+    "custom59": {
+      "type": ["null", "string"]
+    },
+    "custom6": {
+      "type": ["null", "string"]
+    },
+    "custom60": {
+      "type": ["null", "string"]
+    },
+    "custom61": {
+      "type": ["null", "string"]
+    },
+    "custom62": {
+      "type": ["null", "string"]
+    },
+    "custom63": {
+      "type": ["null", "string"]
+    },
+    "custom64": {
+      "type": ["null", "string"]
+    },
+    "custom65": {
+      "type": ["null", "string"]
+    },
+    "custom66": {
+      "type": ["null", "string"]
+    },
+    "custom67": {
+      "type": ["null", "string"]
+    },
+    "custom68": {
+      "type": ["null", "string"]
+    },
+    "custom69": {
+      "type": ["null", "string"]
+    },
+    "custom7": {
+      "type": ["null", "string"]
+    },
+    "custom70": {
+      "type": ["null", "string"]
+    },
+    "custom71": {
+      "type": ["null", "string"]
+    },
+    "custom72": {
+      "type": ["null", "string"]
+    },
+    "custom73": {
+      "type": ["null", "string"]
+    },
+    "custom74": {
+      "type": ["null", "string"]
+    },
+    "custom75": {
+      "type": ["null", "string"]
+    },
+    "custom76": {
+      "type": ["null", "string"]
+    },
+    "custom77": {
+      "type": ["null", "string"]
+    },
+    "custom78": {
+      "type": ["null", "string"]
+    },
+    "custom79": {
+      "type": ["null", "string"]
+    },
+    "custom8": {
+      "type": ["null", "string"]
+    },
+    "custom80": {
+      "type": ["null", "string"]
+    },
+    "custom81": {
+      "type": ["null", "string"]
+    },
+    "custom82": {
+      "type": ["null", "string"]
+    },
+    "custom83": {
+      "type": ["null", "string"]
+    },
+    "custom84": {
+      "type": ["null", "string"]
+    },
+    "custom85": {
+      "type": ["null", "string"]
+    },
+    "custom86": {
+      "type": ["null", "string"]
+    },
+    "custom87": {
+      "type": ["null", "string"]
+    },
+    "custom88": {
+      "type": ["null", "string"]
+    },
+    "custom89": {
+      "type": ["null", "string"]
+    },
+    "custom9": {
+      "type": ["null", "string"]
+    },
+    "custom90": {
+      "type": ["null", "string"]
+    },
+    "custom91": {
+      "type": ["null", "string"]
+    },
+    "custom92": {
+      "type": ["null", "string"]
+    },
+    "custom93": {
+      "type": ["null", "string"]
+    },
+    "custom94": {
+      "type": ["null", "string"]
+    },
+    "custom95": {
+      "type": ["null", "string"]
+    },
+    "custom96": {
+      "type": ["null", "string"]
+    },
+    "custom97": {
+      "type": ["null", "string"]
+    },
+    "custom98": {
+      "type": ["null", "string"]
+    },
+    "custom99": {
+      "type": ["null", "string"]
+    },
+    "dateOfBirth": {
+      "type": ["null", "string"],
+      "format": "date-time"
+    },
+    "degree": {
+      "type": ["null", "string"]
+    },
+    "emailOptedOut": {
+      "type": ["null", "boolean"]
+    },
+    "emails": {
+      "type": ["null", "array"],
+      "items": {
+        "type": "string"
+      }
+    },
+    "emailsOptStatus": {
+      "type": ["null", "string"]
+    },
+    "emailsOptedAt": {
+      "type": ["null", "string"],
+      "format": "date-time"
+    },
+    "engagedAt": {
+      "type": ["null", "string"],
+      "format": "date-time"
+    },
+    "engagedScore": {
+      "type": ["null", "number"]
+    },
+    "eventName": {
+      "type": ["null", "string"]
+    },
+    "externalId": {
+      "type": ["null", "string"]
+    },
+    "externalOwner": {
+      "type": ["null", "string"]
+    },
+    "externalSource": {
+      "type": ["null", "string"]
+    },
+    "facebookUrl": {
+      "type": ["null", "string"]
+    },
+    "firstName": {
+      "type": ["null", "string"]
+    },
+    "gender": {
+      "type": ["null", "string"]
+    },
+    "githubUrl": {
+      "type": ["null", "string"]
+    },
+    "githubUsername": {
+      "type": ["null", "string"]
+    },
+    "googlePlusUrl": {
+      "type": ["null", "string"]
+    },
+    "graduationDate": {
+      "type": ["null", "string"],
+      "format": "date-time"
+    },
+    "homePhones": {
+      "type": ["null", "array"],
+      "items": {
+        "type": "string"
+      }
+    },
+    "jobStartDate": {
+      "type": ["null", "string"],
+      "format": "date-time"
+    },
+    "lastName": {
+      "type": ["null", "string"]
+    },
+    "linkedInConnections": {
+      "type": ["null", "integer"]
+    },
+    "linkedInId": {
+      "type": ["null", "string"]
+    },
+    "linkedInSlug": {
+      "type": ["null", "string"]
+    },
+    "linkedInUrl": {
+      "type": ["null", "string"]
+    },
+    "middleName": {
+      "type": ["null", "string"]
+    },
+    "mobilePhones": {
+      "type": ["null", "array"],
+      "items": {
+        "type": "string"
+      }
+    },
+    "name": {
+      "type": ["null", "string"]
+    },
+    "nickname": {
+      "type": ["null", "string"]
+    },
+    "occupation": {
+      "type": ["null", "string"]
+    },
+    "openCount": {
+      "type": ["null", "integer"]
+    },
+    "optedOut": {
+      "type": ["null", "boolean"]
+    },
+    "optedOutAt": {
+      "type": ["null", "string"],
+      "format": "date-time"
+    },
+    "otherPhones": {
+      "type": ["null", "array"],
+      "items": {
+        "type": "string"
+      }
+    },
+    "personalNote1": {
+      "type": ["null", "string"]
+    },
+    "personalNote2": {
+      "type": ["null", "string"]
+    },
+    "preferredContact": {
+      "type": ["null", "string"]
+    },
+    "quoraUrl": {
+      "type": ["null", "string"]
+    },
+    "region": {
+      "type": ["null", "string"]
+    },
+    "replyCount": {
+      "type": ["null", "integer"]
+    },
+    "school": {
+      "type": ["null", "string"]
+    },
+    "score": {
+      "type": ["null", "number"]
+    },
+    "sharingTeamId": {
+      "type": ["null", "string"]
+    },
+    "source": {
+      "type": ["null", "string"]
+    },
+    "specialties": {
+      "type": ["null", "string"]
+    },
+    "stackOverflowId": {
+      "type": ["null", "string"]
+    },
+    "stackOverflowUrl": {
+      "type": ["null", "string"]
+    },
+    "tags": {
+      "type": ["null", "array"],
+      "items": {
+        "type": ["null", "string"]
+      }
+    },
+    "timeZone": {
+      "type": ["null", "string"]
+    },
+    "timeZoneIana": {
+      "type": ["null", "string"]
+    },
+    "timeZoneInferred": {
+      "type": ["null", "string"]
+    },
+    "title": {
+      "type": ["null", "string"]
+    },
+    "touchedAt": {
+      "type": ["null", "string"],
+      "format": "date-time"
+    },
+    "trashedAt": {
+      "type": ["null", "string"],
+      "format": "date-time"
+    },
+    "twitterUrl": {
+      "type": ["null", "string"]
+    },
+    "twitterUsername": {
+      "type": ["null", "string"]
+    },
+    "updatedAt": {
+      "type": ["null", "string"],
+      "format": "date-time"
+    },
+    "voipPhones": {
+      "type": ["null", "array"],
+      "items": {
+        "type": "string"
+      }
+    },
+    "websiteUrl1": {
+      "type": ["null", "string"]
+    },
+    "websiteUrl2": {
+      "type": ["null", "string"]
+    },
+    "websiteUrl3": {
+      "type": ["null", "string"]
+    },
+    "workPhones": {
+      "type": ["null", "array"],
+      "items": {
+        "type": "string"
       }
     }
   }

--- a/airbyte-integrations/connectors/source-outreach/source_outreach/schemas/prospects.json
+++ b/airbyte-integrations/connectors/source-outreach/source_outreach/schemas/prospects.json
@@ -10,7 +10,6 @@
     },
     "attributes": {
       "type": ["null", "object"],
-      "additionalProperties": true,
       "properties": {
         "addedAt": {
           "type": ["null", "string"],
@@ -741,6 +740,5 @@
         }
       }
     }
-  },
-  "additionalProperties": true
+  }
 }

--- a/airbyte-integrations/connectors/source-outreach/source_outreach/schemas/sequence_states.json
+++ b/airbyte-integrations/connectors/source-outreach/source_outreach/schemas/sequence_states.json
@@ -10,7 +10,6 @@
     },
     "attributes": {
       "type": ["null", "object"],
-      "additionalProperties": true,
       "properties": {
         "activeAt": {
           "type": ["null", "string"],
@@ -80,6 +79,5 @@
         }
       }
     }
-  },
-  "additionalProperties": true
+  }
 }

--- a/airbyte-integrations/connectors/source-outreach/source_outreach/schemas/sequence_states.json
+++ b/airbyte-integrations/connectors/source-outreach/source_outreach/schemas/sequence_states.json
@@ -2,82 +2,74 @@
   "$schema": "http://json-schema.org/draft-07/schema#",
   "type": "object",
   "properties": {
-    "type": {
-      "type": ["null", "string"]
-    },
     "id": {
+      "type": "integer"
+    },
+    "activeAt": {
+      "type": ["null", "string"],
+      "format": "date-time"
+    },
+    "bounceCount": {
       "type": ["null", "integer"]
     },
-    "attributes": {
-      "type": ["null", "object"],
-      "properties": {
-        "activeAt": {
-          "type": ["null", "string"],
-          "format": "date-time"
-        },
-        "bounceCount": {
-          "type": ["null", "integer"]
-        },
-        "callCompletedAt": {
-          "type": ["null", "string"],
-          "format": "date-time"
-        },
-        "clickCount": {
-          "type": ["null", "integer"]
-        },
-        "createdAt": {
-          "type": ["null", "string"],
-          "format": "date-time"
-        },
-        "deliverCount": {
-          "type": ["null", "integer"]
-        },
-        "errorReason": {
-          "type": ["null", "string"]
-        },
-        "failureCount": {
-          "type": ["null", "integer"]
-        },
-        "negativeReplyCount": {
-          "type": ["null", "integer"]
-        },
-        "neutralReplyCount": {
-          "type": ["null", "integer"]
-        },
-        "openCount": {
-          "type": ["null", "integer"]
-        },
-        "optOutCount": {
-          "type": ["null", "integer"]
-        },
-        "pauseReason": {
-          "type": ["null", "string"]
-        },
-        "positiveReplyCount": {
-          "type": ["null", "integer"]
-        },
-        "repliedAt": {
-          "type": ["null", "string"],
-          "format": "date-time"
-        },
-        "replyCount": {
-          "type": ["null", "integer"]
-        },
-        "scheduleCount": {
-          "type": ["null", "integer"]
-        },
-        "state": {
-          "type": ["null", "string"]
-        },
-        "stateChangedAt": {
-          "type": ["null", "string"],
-          "format": "date-time"
-        },
-        "updatedAt": {
-          "type": ["null", "string"],
-          "format": "date-time"
-        }
-      }
+    "callCompletedAt": {
+      "type": ["null", "string"],
+      "format": "date-time"
+    },
+    "clickCount": {
+      "type": ["null", "integer"]
+    },
+    "createdAt": {
+      "type": ["null", "string"],
+      "format": "date-time"
+    },
+    "deliverCount": {
+      "type": ["null", "integer"]
+    },
+    "errorReason": {
+      "type": ["null", "string"]
+    },
+    "failureCount": {
+      "type": ["null", "integer"]
+    },
+    "negativeReplyCount": {
+      "type": ["null", "integer"]
+    },
+    "neutralReplyCount": {
+      "type": ["null", "integer"]
+    },
+    "openCount": {
+      "type": ["null", "integer"]
+    },
+    "optOutCount": {
+      "type": ["null", "integer"]
+    },
+    "pauseReason": {
+      "type": ["null", "string"]
+    },
+    "positiveReplyCount": {
+      "type": ["null", "integer"]
+    },
+    "repliedAt": {
+      "type": ["null", "string"],
+      "format": "date-time"
+    },
+    "replyCount": {
+      "type": ["null", "integer"]
+    },
+    "scheduleCount": {
+      "type": ["null", "integer"]
+    },
+    "state": {
+      "type": ["null", "string"]
+    },
+    "stateChangedAt": {
+      "type": ["null", "string"],
+      "format": "date-time"
+    },
+    "updatedAt": {
+      "type": ["null", "string"],
+      "format": "date-time"
     }
   }
 }

--- a/airbyte-integrations/connectors/source-outreach/source_outreach/schemas/sequences.json
+++ b/airbyte-integrations/connectors/source-outreach/source_outreach/schemas/sequences.json
@@ -2,145 +2,137 @@
   "$schema": "http://json-schema.org/draft-07/schema#",
   "type": "object",
   "properties": {
-    "type": {
-      "type": ["null", "string"]
-    },
     "id": {
+      "type": "integer"
+    },
+    "automationPercentage": {
+      "type": ["null", "number"]
+    },
+    "bounceCount": {
       "type": ["null", "integer"]
     },
-    "attributes": {
-      "type": ["null", "object"],
-      "properties": {
-        "automationPercentage": {
-          "type": ["null", "number"]
-        },
-        "bounceCount": {
-          "type": ["null", "integer"]
-        },
-        "clickCount": {
-          "type": ["null", "integer"]
-        },
-        "createdAt": {
-          "type": ["null", "string"],
-          "format": "date-time"
-        },
-        "deliverCount": {
-          "type": ["null", "integer"]
-        },
-        "description": {
-          "type": ["null", "string"]
-        },
-        "durationInDays": {
-          "type": ["null", "integer"]
-        },
-        "enabled": {
-          "type": ["null", "boolean"]
-        },
-        "enabledAt": {
-          "type": ["null", "string"],
-          "format": "date-time"
-        },
-        "failureCount": {
-          "type": ["null", "integer"]
-        },
-        "finishOnReply": {
-          "type": ["null", "boolean"]
-        },
-        "lastUsedAt": {
-          "type": ["null", "string"],
-          "format": "date-time"
-        },
-        "locked": {
-          "type": ["null", "boolean"]
-        },
-        "lockedAt": {
-          "type": ["null", "string"],
-          "format": "date-time"
-        },
-        "maxActivations": {
-          "type": ["null", "integer"]
-        },
-        "name": {
-          "type": ["null", "string"]
-        },
-        "negativeReplyCount": {
-          "type": ["null", "integer"]
-        },
-        "neutralReplyCount": {
-          "type": ["null", "integer"]
-        },
-        "numContactedProspects": {
-          "type": ["null", "integer"]
-        },
-        "numRepliedProspects": {
-          "type": ["null", "integer"]
-        },
-        "openCount": {
-          "type": ["null", "integer"]
-        },
-        "optOutCount": {
-          "type": ["null", "integer"]
-        },
-        "positiveReplyCount": {
-          "type": ["null", "integer"]
-        },
-        "primaryReplyAction": {
-          "type": ["null", "string"]
-        },
-        "primaryReplyPauseDuration": {
-          "type": ["null", "integer"]
-        },
-        "replyCount": {
-          "type": ["null", "integer"]
-        },
-        "scheduleCount": {
-          "type": ["null", "integer"]
-        },
-        "scheduleIntervalType": {
-          "type": ["null", "string"]
-        },
-        "secondaryReplyAction": {
-          "type": ["null", "string"]
-        },
-        "secondaryReplyPauseDuration": {
-          "type": ["null", "integer"]
-        },
-        "sequenceStepCount": {
-          "type": ["null", "integer"]
-        },
-        "sequenceType": {
-          "type": ["null", "string"]
-        },
-        "shareType": {
-          "type": ["null", "string"]
-        },
-        "tags": {
-          "type": ["null", "array"],
-          "items": {
-            "type": ["null", "string"]
-          }
-        },
-        "throttleCapacity": {
-          "type": ["null", "integer"]
-        },
-        "throttleMaxAddsPerDay": {
-          "type": ["null", "integer"]
-        },
-        "throttlePaused": {
-          "type": ["null", "boolean"]
-        },
-        "throttlePausedAt": {
-          "type": ["null", "string"],
-          "format": "date-time"
-        },
-        "transactional": {
-          "type": ["null", "boolean"]
-        },
-        "updatedAt": {
-          "type": ["null", "string"],
-          "format": "date-time"
-        }
+    "clickCount": {
+      "type": ["null", "integer"]
+    },
+    "createdAt": {
+      "type": ["null", "string"],
+      "format": "date-time"
+    },
+    "deliverCount": {
+      "type": ["null", "integer"]
+    },
+    "description": {
+      "type": ["null", "string"]
+    },
+    "durationInDays": {
+      "type": ["null", "integer"]
+    },
+    "enabled": {
+      "type": ["null", "boolean"]
+    },
+    "enabledAt": {
+      "type": ["null", "string"],
+      "format": "date-time"
+    },
+    "failureCount": {
+      "type": ["null", "integer"]
+    },
+    "finishOnReply": {
+      "type": ["null", "boolean"]
+    },
+    "lastUsedAt": {
+      "type": ["null", "string"],
+      "format": "date-time"
+    },
+    "locked": {
+      "type": ["null", "boolean"]
+    },
+    "lockedAt": {
+      "type": ["null", "string"],
+      "format": "date-time"
+    },
+    "maxActivations": {
+      "type": ["null", "integer"]
+    },
+    "name": {
+      "type": ["null", "string"]
+    },
+    "negativeReplyCount": {
+      "type": ["null", "integer"]
+    },
+    "neutralReplyCount": {
+      "type": ["null", "integer"]
+    },
+    "numContactedProspects": {
+      "type": ["null", "integer"]
+    },
+    "numRepliedProspects": {
+      "type": ["null", "integer"]
+    },
+    "openCount": {
+      "type": ["null", "integer"]
+    },
+    "optOutCount": {
+      "type": ["null", "integer"]
+    },
+    "positiveReplyCount": {
+      "type": ["null", "integer"]
+    },
+    "primaryReplyAction": {
+      "type": ["null", "string"]
+    },
+    "primaryReplyPauseDuration": {
+      "type": ["null", "integer"]
+    },
+    "replyCount": {
+      "type": ["null", "integer"]
+    },
+    "scheduleCount": {
+      "type": ["null", "integer"]
+    },
+    "scheduleIntervalType": {
+      "type": ["null", "string"]
+    },
+    "secondaryReplyAction": {
+      "type": ["null", "string"]
+    },
+    "secondaryReplyPauseDuration": {
+      "type": ["null", "integer"]
+    },
+    "sequenceStepCount": {
+      "type": ["null", "integer"]
+    },
+    "sequenceType": {
+      "type": ["null", "string"]
+    },
+    "shareType": {
+      "type": ["null", "string"]
+    },
+    "tags": {
+      "type": ["null", "array"],
+      "items": {
+        "type": ["null", "string"]
       }
+    },
+    "throttleCapacity": {
+      "type": ["null", "integer"]
+    },
+    "throttleMaxAddsPerDay": {
+      "type": ["null", "integer"]
+    },
+    "throttlePaused": {
+      "type": ["null", "boolean"]
+    },
+    "throttlePausedAt": {
+      "type": ["null", "string"],
+      "format": "date-time"
+    },
+    "transactional": {
+      "type": ["null", "boolean"]
+    },
+    "updatedAt": {
+      "type": ["null", "string"],
+      "format": "date-time"
     }
   }
 }

--- a/airbyte-integrations/connectors/source-outreach/source_outreach/schemas/sequences.json
+++ b/airbyte-integrations/connectors/source-outreach/source_outreach/schemas/sequences.json
@@ -10,7 +10,6 @@
     },
     "attributes": {
       "type": ["null", "object"],
-      "additionalProperties": true,
       "properties": {
         "automationPercentage": {
           "type": ["null", "number"]
@@ -143,6 +142,5 @@
         }
       }
     }
-  },
-  "additionalProperties": true
+  }
 }

--- a/airbyte-integrations/connectors/source-outreach/source_outreach/source.py
+++ b/airbyte-integrations/connectors/source-outreach/source_outreach/source.py
@@ -22,6 +22,7 @@ _URL_BASE = "https://api.outreach.io/api/v2/"
 class OutreachStream(HttpStream, ABC):
 
     url_base = _URL_BASE
+    primary_key = "id"
 
     def __init__(
         self,
@@ -59,29 +60,29 @@ class OutreachStream(HttpStream, ABC):
         if not data:
             return
         for element in data:
-            yield element
+            yield {**element.get("attributes"), **{self.primary_key: element[self.primary_key]}}
 
 
 # Basic incremental stream
 class IncrementalOutreachStream(OutreachStream, ABC):
     @property
     def cursor_field(self) -> str:
-        return "attributes/properties/updatedAt"
+        return "updatedAt"
 
     def get_updated_state(self, current_stream_state: MutableMapping[str, Any], latest_record: Mapping[str, Any]) -> Mapping[str, Any]:
         current_stream_state = current_stream_state or {}
 
-        current_stream_state_date = current_stream_state.get("updatedAt", self.start_date)
-        latest_record_date = latest_record.get("attributes", {}).get("updatedAt", self.start_date)
+        current_stream_state_date = current_stream_state.get(self.cursor_field, self.start_date)
+        latest_record_date = latest_record.get(self.cursor_field, self.start_date)
 
-        return {"updatedAt": max(current_stream_state_date, latest_record_date)}
+        return {self.cursor_field: max(current_stream_state_date, latest_record_date)}
 
     def request_params(
         self, stream_state: Mapping[str, Any], stream_slice: Mapping[str, any] = None, next_page_token: Mapping[str, Any] = None
     ) -> MutableMapping[str, Any]:
         params = super().request_params(stream_state=stream_state, stream_slice=stream_slice, next_page_token=next_page_token)
-        if "updatedAt" in stream_state:
-            params["filter[updatedAt]"] = stream_state["updatedAt"] + "..inf"
+        if self.cursor_field in stream_state:
+            params[f"filter[{self.cursor_field}]"] = stream_state[self.cursor_field] + "..inf"
         return params
 
 
@@ -90,8 +91,6 @@ class Prospects(IncrementalOutreachStream):
     Prospect stream. Yields data from the GET /prospects endpoint.
     See https://api.outreach.io/api/v2/docs#prospect
     """
-
-    primary_key = "id"
 
     def path(self, **kwargs) -> str:
         return "prospects"
@@ -103,8 +102,6 @@ class Sequences(IncrementalOutreachStream):
     See https://api.outreach.io/api/v2/docs#sequence
     """
 
-    primary_key = "id"
-
     def path(self, **kwargs) -> str:
         return "sequences"
 
@@ -114,8 +111,6 @@ class SequenceStates(IncrementalOutreachStream):
     Sequence stream. Yields data from the GET /sequences endpoint.
     See https://api.outreach.io/api/v2/docs#sequenceState
     """
-
-    primary_key = "id"
 
     def path(self, **kwargs) -> str:
         return "sequenceStates"

--- a/airbyte-integrations/connectors/source-outreach/unit_tests/test_incremental_streams.py
+++ b/airbyte-integrations/connectors/source-outreach/unit_tests/test_incremental_streams.py
@@ -20,7 +20,7 @@ def patch_incremental_base_class(mocker):
 
 def test_cursor_field(patch_incremental_base_class):
     stream = IncrementalOutreachStream(authenticator=MagicMock())
-    expected_cursor_field = "attributes/properties/updatedAt"
+    expected_cursor_field = "updatedAt"
     assert stream.cursor_field == expected_cursor_field
 
 

--- a/airbyte-integrations/connectors/source-outreach/unit_tests/test_streams.py
+++ b/airbyte-integrations/connectors/source-outreach/unit_tests/test_streams.py
@@ -13,7 +13,7 @@ from source_outreach.source import OutreachStream
 def patch_base_class(mocker):
     # Mock abstract methods to enable instantiating abstract class
     mocker.patch.object(OutreachStream, "path", "v0/example_endpoint")
-    mocker.patch.object(OutreachStream, "primary_key", "test_primary_key")
+    mocker.patch.object(OutreachStream, "primary_key", "id")
     mocker.patch.object(OutreachStream, "__abstractmethods__", set())
 
 
@@ -40,11 +40,7 @@ def test_parse_response(patch_base_class):
         "data": [{"id": 123, "attributes": {"name": "John Doe"}, "relationships": {"account": {"data": {"type": "account", "id": 4}}}}]
     }
     inputs = {"response": response}
-    expected_parsed_object = {
-        "id": 123,
-        "attributes": {"name": "John Doe"},
-        "relationships": {"account": {"data": {"type": "account", "id": 4}}},
-    }
+    expected_parsed_object = {"id": 123, "name": "John Doe"}
     assert next(stream.parse_response(**inputs)) == expected_parsed_object
 
 

--- a/docs/integrations/sources/outreach.md
+++ b/docs/integrations/sources/outreach.md
@@ -39,6 +39,8 @@ List of available streams:
 ## Changelog
 
 | Version | Date       | Pull Request | Subject |
+
 | :------ | :--------  | :-----       | :------ |
+| 0.1.2   | 2022-07-04 | [14386](https://github.com/airbytehq/airbyte/pull/14386) | Fix stream schema and cursor field |
 | 0.1.1   | 2021-12-07 | [8582](https://github.com/airbytehq/airbyte/pull/8582) | Update connector fields title/description |
 | 0.1.0   | 2021-11-03 | [7507](https://github.com/airbytehq/airbyte/pull/7507) | Outreach Connector |


### PR DESCRIPTION
## What
I think the schemas and the record parsing in this connectors were defined wrongly: 
* The source API returns records in the following structures: 
```
{
  "data": [{
    "type": "prospect",
    "id": 1,
    "attributes": {
      "firstName": "Sally",
      "lastName": null,
      ...
    },
    "relationships": {
      "account": {
        "data": {
          "type": "account",
          "id": 1
        }
      },
      "mailings": {
        "links": {
          "related": "https://api.outreach.io/api/v2/mailings?filter[prospect][id]=1"
        }
      },
      ...
    }
  },
  ...]
}
```

The connector defined the right schema for the streams but did not unnest the `attributes` field in the `parse_response` function. The connector was working because of the abuse of `additional_properties = True` set in the stream schemas.
Moreover the `cursor_field` path was not declared in a valid manner.