### PR TITLE
Add more metadata to the JobErrorReporter

### DIFF
--- a/airbyte-scheduler/scheduler-persistence/src/main/java/io/airbyte/scheduler/persistence/JobNotifier.java
+++ b/airbyte-scheduler/scheduler-persistence/src/main/java/io/airbyte/scheduler/persistence/JobNotifier.java
@@ -39,21 +39,17 @@ public class JobNotifier {
   public static final String CONNECTION_DISABLED_WARNING_NOTIFICATION = "Connection Disabled Warning Notification";
   public static final String CONNECTION_DISABLED_NOTIFICATION = "Connection Disabled Notification";
 
-  private final String connectionPageUrl;
   private final ConfigRepository configRepository;
   private final TrackingClient trackingClient;
+  private final WebUrlHelper webUrlHelper;
   private final WorkspaceHelper workspaceHelper;
 
-  public JobNotifier(final String webappUrl,
+  public JobNotifier(final WebUrlHelper webUrlHelper,
                      final ConfigRepository configRepository,
                      final WorkspaceHelper workspaceHelper,
                      final TrackingClient trackingClient) {
+    this.webUrlHelper = webUrlHelper;
     this.workspaceHelper = workspaceHelper;
-    if (webappUrl.endsWith("/")) {
-      this.connectionPageUrl = String.format("%sconnections/", webappUrl);
-    } else {
-      this.connectionPageUrl = String.format("%s/connections/", webappUrl);
-    }
     this.configRepository = configRepository;
     this.trackingClient = trackingClient;
   }
@@ -82,7 +78,7 @@ public class JobNotifier {
       final String destinationConnector = destinationDefinition.getName();
       final String failReason = Strings.isNullOrEmpty(reason) ? "" : String.format(", as the %s", reason);
       final String jobDescription = getJobDescription(job, failReason);
-      final String logUrl = connectionPageUrl + connectionId;
+      final String logUrl = webUrlHelper.getConnectionUrl(workspaceId, connectionId);
       final ImmutableMap<String, Object> jobMetadata = TrackingMetadata.generateJobAttemptMetadata(job);
       final ImmutableMap<String, Object> sourceMetadata = TrackingMetadata.generateSourceDefinitionMetadata(sourceDefinition);
       final ImmutableMap<String, Object> destinationMetadata = TrackingMetadata.generateDestinationDefinitionMetadata(destinationDefinition);

--- a/airbyte-scheduler/scheduler-persistence/src/main/java/io/airbyte/scheduler/persistence/WebUrlHelper.java
+++ b/airbyte-scheduler/scheduler-persistence/src/main/java/io/airbyte/scheduler/persistence/WebUrlHelper.java
@@ -1,0 +1,28 @@
+package io.airbyte.scheduler.persistence;
+
+import java.util.UUID;
+
+public class WebUrlHelper {
+
+  private final String webAppUrl;
+
+  public WebUrlHelper(final String webAppUrl) {
+    this.webAppUrl = webAppUrl;
+  }
+
+  public String getBaseUrl() {
+    if(webAppUrl.endsWith("/")) {
+      return webAppUrl.substring(0, webAppUrl.length() - 1);
+    }
+
+    return webAppUrl;
+  }
+
+  public String getWorkspaceUrl(final UUID workspaceId) {
+    return String.format("%s/workspaces/%s", getBaseUrl(), workspaceId);
+  }
+
+  public String getConnectionUrl(final UUID workspaceId, final UUID connectionId) {
+    return String.format("%s/connections/%s", getWorkspaceUrl(workspaceId), connectionId);
+  }
+}

--- a/airbyte-scheduler/scheduler-persistence/src/main/java/io/airbyte/scheduler/persistence/WebUrlHelper.java
+++ b/airbyte-scheduler/scheduler-persistence/src/main/java/io/airbyte/scheduler/persistence/WebUrlHelper.java
@@ -1,3 +1,7 @@
+/*
+ * Copyright (c) 2022 Airbyte, Inc., all rights reserved.
+ */
+
 package io.airbyte.scheduler.persistence;
 
 import java.util.UUID;
@@ -11,7 +15,7 @@ public class WebUrlHelper {
   }
 
   public String getBaseUrl() {
-    if(webAppUrl.endsWith("/")) {
+    if (webAppUrl.endsWith("/")) {
       return webAppUrl.substring(0, webAppUrl.length() - 1);
     }
 
@@ -25,4 +29,5 @@ public class WebUrlHelper {
   public String getConnectionUrl(final UUID workspaceId, final UUID connectionId) {
     return String.format("%s/connections/%s", getWorkspaceUrl(workspaceId), connectionId);
   }
+
 }

--- a/airbyte-scheduler/scheduler-persistence/src/main/java/io/airbyte/scheduler/persistence/job_error_reporter/JobErrorReporter.java
+++ b/airbyte-scheduler/scheduler-persistence/src/main/java/io/airbyte/scheduler/persistence/job_error_reporter/JobErrorReporter.java
@@ -28,8 +28,10 @@ public class JobErrorReporter {
   private static final String AIRBYTE_VERSION_META_KEY = "airbyte_version";
   private static final String FAILURE_ORIGIN_META_KEY = "failure_origin";
   private static final String FAILURE_TYPE_META_KEY = "failure_type";
+  private static final String WORKSPACE_ID_META_KEY = "workspace_id";
   private static final String CONNECTION_ID_META_KEY = "connection_id";
   private static final String CONNECTOR_NAME_META_KEY = "connector_name";
+  private static final String CONNECTOR_REPOSITORY_META_KEY = "connector_repository";
   private static final String CONNECTOR_DEFINITION_ID_META_KEY = "connector_definition_id";
   private static final String CONNECTOR_RELEASE_STAGE_META_KEY = "connector_release_stage";
 
@@ -67,6 +69,7 @@ public class JobErrorReporter {
       final FailureOrigin failureOrigin = failureReason.getFailureOrigin();
 
       final HashMap<String, String> metadata = new HashMap<>();
+      metadata.put(WORKSPACE_ID_META_KEY, workspace.getWorkspaceId().toString());
       metadata.put(CONNECTION_ID_META_KEY, connectionId.toString());
       metadata.put(AIRBYTE_VERSION_META_KEY, airbyteVersion);
       metadata.put(DEPLOYMENT_MODE_META_KEY, deploymentMode.name());
@@ -80,6 +83,7 @@ public class JobErrorReporter {
 
           metadata.put(CONNECTOR_DEFINITION_ID_META_KEY, sourceDefinition.getSourceDefinitionId().toString());
           metadata.put(CONNECTOR_NAME_META_KEY, sourceDefinition.getName());
+          metadata.put(CONNECTOR_REPOSITORY_META_KEY, sourceDefinition.getDockerRepository());
           metadata.put(CONNECTOR_RELEASE_STAGE_META_KEY, sourceDefinition.getReleaseStage().value());
 
           jobErrorReportingClient.reportJobFailureReason(workspace, failureReason, dockerImage, metadata);
@@ -89,6 +93,7 @@ public class JobErrorReporter {
 
           metadata.put(CONNECTOR_DEFINITION_ID_META_KEY, destinationDefinition.getDestinationDefinitionId().toString());
           metadata.put(CONNECTOR_NAME_META_KEY, destinationDefinition.getName());
+          metadata.put(CONNECTOR_REPOSITORY_META_KEY, destinationDefinition.getDockerRepository());
           metadata.put(CONNECTOR_RELEASE_STAGE_META_KEY, destinationDefinition.getReleaseStage().value());
 
           jobErrorReportingClient.reportJobFailureReason(workspace, failureReason, dockerImage, metadata);

--- a/airbyte-scheduler/scheduler-persistence/src/test/java/io/airbyte/scheduler/persistence/JobNotifierTest.java
+++ b/airbyte-scheduler/scheduler-persistence/src/test/java/io/airbyte/scheduler/persistence/JobNotifierTest.java
@@ -47,6 +47,8 @@ class JobNotifierTest {
   private static final String TEST_DOCKER_TAG = "0.1.0";
   private static final UUID WORKSPACE_ID = UUID.randomUUID();
 
+  private final WebUrlHelper webUrlHelper = new WebUrlHelper(WEBAPP_URL);
+
   private ConfigRepository configRepository;
   private WorkspaceHelper workspaceHelper;
   private JobNotifier jobNotifier;
@@ -59,7 +61,7 @@ class JobNotifierTest {
     workspaceHelper = mock(WorkspaceHelper.class);
     trackingClient = mock(TrackingClient.class);
 
-    jobNotifier = spy(new JobNotifier(WEBAPP_URL, configRepository, workspaceHelper, trackingClient));
+    jobNotifier = spy(new JobNotifier(webUrlHelper, configRepository, workspaceHelper, trackingClient));
     notificationClient = mock(NotificationClient.class);
     when(jobNotifier.getNotificationClient(getSlackNotification())).thenReturn(notificationClient);
   }
@@ -92,7 +94,7 @@ class JobNotifierTest {
         "destination-test",
         String.format("sync started on %s, running for 1 day 10 hours 17 minutes 36 seconds, as the JobNotifierTest was running.",
             formatter.format(Instant.ofEpochSecond(job.getStartedAtInSecond().get()))),
-        "http://localhost:8000/connections/" + job.getScope());
+        String.format("http://localhost:8000/workspaces/%s/connections/%s", WORKSPACE_ID, job.getScope()));
 
     final Builder<String, Object> metadata = ImmutableMap.builder();
     metadata.put("connection_id", UUID.fromString(job.getScope()));

--- a/airbyte-scheduler/scheduler-persistence/src/test/java/io/airbyte/scheduler/persistence/WebUrlHelperTest.java
+++ b/airbyte-scheduler/scheduler-persistence/src/test/java/io/airbyte/scheduler/persistence/WebUrlHelperTest.java
@@ -1,3 +1,7 @@
+/*
+ * Copyright (c) 2022 Airbyte, Inc., all rights reserved.
+ */
+
 package io.airbyte.scheduler.persistence;
 
 import java.util.UUID;
@@ -5,6 +9,7 @@ import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
 
 public class WebUrlHelperTest {
+
   private static final UUID WORKSPACE_ID = UUID.randomUUID();
   private static final UUID CONNECTION_ID = UUID.randomUUID();
 
@@ -35,4 +40,5 @@ public class WebUrlHelperTest {
     final String expectedUrl = String.format("http://localhost:8000/workspaces/%s/connections/%s", WORKSPACE_ID, CONNECTION_ID);
     Assertions.assertEquals(expectedUrl, connectionUrl);
   }
+
 }

--- a/airbyte-scheduler/scheduler-persistence/src/test/java/io/airbyte/scheduler/persistence/WebUrlHelperTest.java
+++ b/airbyte-scheduler/scheduler-persistence/src/test/java/io/airbyte/scheduler/persistence/WebUrlHelperTest.java
@@ -1,0 +1,38 @@
+package io.airbyte.scheduler.persistence;
+
+import java.util.UUID;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+
+public class WebUrlHelperTest {
+  private static final UUID WORKSPACE_ID = UUID.randomUUID();
+  private static final UUID CONNECTION_ID = UUID.randomUUID();
+
+  @Test
+  void testGetBaseUrl() {
+    final WebUrlHelper webUrlHelper = new WebUrlHelper("http://localhost:8000");
+    Assertions.assertEquals("http://localhost:8000", webUrlHelper.getBaseUrl());
+  }
+
+  @Test
+  void testGetBaseUrlTrailingSlash() {
+    final WebUrlHelper webUrlHelper = new WebUrlHelper("http://localhost:8001/");
+    Assertions.assertEquals("http://localhost:8001", webUrlHelper.getBaseUrl());
+  }
+
+  @Test
+  void testGetWorkspaceUrl() {
+    final WebUrlHelper webUrlHelper = new WebUrlHelper("http://localhost:8000");
+    final String workspaceUrl = webUrlHelper.getWorkspaceUrl(WORKSPACE_ID);
+    final String expectedUrl = String.format("http://localhost:8000/workspaces/%s", WORKSPACE_ID);
+    Assertions.assertEquals(expectedUrl, workspaceUrl);
+  }
+
+  @Test
+  void testGetConnectionUrl() {
+    final WebUrlHelper webUrlHelper = new WebUrlHelper("http://localhost:8000");
+    final String connectionUrl = webUrlHelper.getConnectionUrl(WORKSPACE_ID, CONNECTION_ID);
+    final String expectedUrl = String.format("http://localhost:8000/workspaces/%s/connections/%s", WORKSPACE_ID, CONNECTION_ID);
+    Assertions.assertEquals(expectedUrl, connectionUrl);
+  }
+}

--- a/airbyte-scheduler/scheduler-persistence/src/test/java/io/airbyte/scheduler/persistence/job_error_reporter/JobErrorReporterTest.java
+++ b/airbyte-scheduler/scheduler-persistence/src/test/java/io/airbyte/scheduler/persistence/job_error_reporter/JobErrorReporterTest.java
@@ -17,6 +17,7 @@ import io.airbyte.config.StandardDestinationDefinition;
 import io.airbyte.config.StandardSourceDefinition;
 import io.airbyte.config.StandardWorkspace;
 import io.airbyte.config.persistence.ConfigRepository;
+import io.airbyte.scheduler.persistence.WebUrlHelper;
 import java.util.List;
 import java.util.Map;
 import java.util.UUID;
@@ -29,6 +30,7 @@ public class JobErrorReporterTest {
 
   private static final UUID WORKSPACE_ID = UUID.randomUUID();
   private static final UUID CONNECTION_ID = UUID.randomUUID();
+  private static final String CONNECTION_URL = "http://localhost:8000/connection/my_connection";
   private static final DeploymentMode DEPLOYMENT_MODE = DeploymentMode.OSS;
   private static final String AIRBYTE_VERSION = "0.1.40";
   private static final UUID SOURCE_DEFINITION_ID = UUID.randomUUID();
@@ -44,13 +46,15 @@ public class JobErrorReporterTest {
 
   private ConfigRepository configRepository;
   private JobErrorReportingClient jobErrorReportingClient;
+  private WebUrlHelper webUrlHelper;
   private JobErrorReporter jobErrorReporter;
 
   @BeforeEach
   void setup() {
     configRepository = mock(ConfigRepository.class);
     jobErrorReportingClient = mock(JobErrorReportingClient.class);
-    jobErrorReporter = new JobErrorReporter(configRepository, DEPLOYMENT_MODE, AIRBYTE_VERSION, jobErrorReportingClient);
+    webUrlHelper = mock(WebUrlHelper.class);
+    jobErrorReporter = new JobErrorReporter(configRepository, DEPLOYMENT_MODE, AIRBYTE_VERSION, webUrlHelper, jobErrorReportingClient);
   }
 
   @Test
@@ -77,6 +81,8 @@ public class JobErrorReporterTest {
     Mockito.when(mJobSyncConfig.getSourceDockerImage()).thenReturn(SOURCE_DOCKER_IMAGE);
     Mockito.when(mJobSyncConfig.getDestinationDockerImage()).thenReturn(DESTINATION_DOCKER_IMAGE);
 
+    Mockito.when(webUrlHelper.getConnectionUrl(WORKSPACE_ID, CONNECTION_ID)).thenReturn(CONNECTION_URL);
+
     Mockito.when(configRepository.getSourceDefinitionFromConnection(CONNECTION_ID))
         .thenReturn(new StandardSourceDefinition()
             .withDockerRepository(SOURCE_DOCKER_REPOSITORY)
@@ -97,29 +103,31 @@ public class JobErrorReporterTest {
 
     jobErrorReporter.reportSyncJobFailure(CONNECTION_ID, mFailureSummary, mJobSyncConfig);
 
-    final Map<String, String> expectedSourceMetadata = Map.of(
-        "workspace_id", WORKSPACE_ID.toString(),
-        "connection_id", CONNECTION_ID.toString(),
-        "deployment_mode", DEPLOYMENT_MODE.name(),
-        "airbyte_version", AIRBYTE_VERSION,
-        "failure_origin", "source",
-        "failure_type", "system_error",
-        "connector_definition_id", SOURCE_DEFINITION_ID.toString(),
-        "connector_repository", SOURCE_DOCKER_REPOSITORY,
-        "connector_name", SOURCE_DEFINITION_NAME,
-        "connector_release_stage", SOURCE_RELEASE_STAGE.toString());
+    final Map<String, String> expectedSourceMetadata = Map.ofEntries(
+        Map.entry("workspace_id", WORKSPACE_ID.toString()),
+        Map.entry("connection_id", CONNECTION_ID.toString()),
+        Map.entry("connection_url", CONNECTION_URL),
+        Map.entry("deployment_mode", DEPLOYMENT_MODE.name()),
+        Map.entry("airbyte_version", AIRBYTE_VERSION),
+        Map.entry("failure_origin", "source"),
+        Map.entry("failure_type", "system_error"),
+        Map.entry("connector_definition_id", SOURCE_DEFINITION_ID.toString()),
+        Map.entry("connector_repository", SOURCE_DOCKER_REPOSITORY),
+        Map.entry("connector_name", SOURCE_DEFINITION_NAME),
+        Map.entry("connector_release_stage", SOURCE_RELEASE_STAGE.toString()));
 
-    final Map<String, String> expectedDestinationMetadata = Map.of(
-        "workspace_id", WORKSPACE_ID.toString(),
-        "connection_id", CONNECTION_ID.toString(),
-        "deployment_mode", DEPLOYMENT_MODE.name(),
-        "airbyte_version", AIRBYTE_VERSION,
-        "failure_origin", "destination",
-        "failure_type", "system_error",
-        "connector_definition_id", DESTINATION_DEFINITION_ID.toString(),
-        "connector_repository", DESTINATION_DOCKER_REPOSITORY,
-        "connector_name", DESTINATION_DEFINITION_NAME,
-        "connector_release_stage", DESTINATION_RELEASE_STAGE.toString());
+    final Map<String, String> expectedDestinationMetadata = Map.ofEntries(
+        Map.entry("workspace_id", WORKSPACE_ID.toString()),
+        Map.entry("connection_id", CONNECTION_ID.toString()),
+        Map.entry("connection_url", CONNECTION_URL),
+        Map.entry("deployment_mode", DEPLOYMENT_MODE.name()),
+        Map.entry("airbyte_version", AIRBYTE_VERSION),
+        Map.entry("failure_origin", "destination"),
+        Map.entry("failure_type", "system_error"),
+        Map.entry("connector_definition_id", DESTINATION_DEFINITION_ID.toString()),
+        Map.entry("connector_repository", DESTINATION_DOCKER_REPOSITORY),
+        Map.entry("connector_name", DESTINATION_DEFINITION_NAME),
+        Map.entry("connector_release_stage", DESTINATION_RELEASE_STAGE.toString()));
 
     Mockito.verify(jobErrorReportingClient).reportJobFailureReason(mWorkspace, sourceFailureReason, SOURCE_DOCKER_IMAGE, expectedSourceMetadata);
     Mockito.verify(jobErrorReportingClient).reportJobFailureReason(mWorkspace, destinationFailureReason, DESTINATION_DOCKER_IMAGE,

--- a/airbyte-scheduler/scheduler-persistence/src/test/java/io/airbyte/scheduler/persistence/job_error_reporter/JobErrorReporterTest.java
+++ b/airbyte-scheduler/scheduler-persistence/src/test/java/io/airbyte/scheduler/persistence/job_error_reporter/JobErrorReporterTest.java
@@ -153,6 +153,10 @@ public class JobErrorReporterTest {
             .withSourceDefinitionId(SOURCE_DEFINITION_ID)
             .withName(SOURCE_DEFINITION_NAME));
 
+    final StandardWorkspace mWorkspace = Mockito.mock(StandardWorkspace.class);
+    Mockito.when(configRepository.getStandardWorkspaceFromConnection(CONNECTION_ID, true)).thenReturn(mWorkspace);
+    Mockito.when(mWorkspace.getWorkspaceId()).thenReturn(WORKSPACE_ID);
+
     Mockito.doThrow(new RuntimeException("some exception"))
         .when(jobErrorReportingClient)
         .reportJobFailureReason(Mockito.any(), Mockito.eq(sourceFailureReason), Mockito.any(), Mockito.any());

--- a/airbyte-workers/src/main/java/io/airbyte/workers/WorkerApp.java
+++ b/airbyte-workers/src/main/java/io/airbyte/workers/WorkerApp.java
@@ -41,6 +41,7 @@ import io.airbyte.scheduler.persistence.DefaultJobPersistence;
 import io.airbyte.scheduler.persistence.JobCreator;
 import io.airbyte.scheduler.persistence.JobNotifier;
 import io.airbyte.scheduler.persistence.JobPersistence;
+import io.airbyte.scheduler.persistence.WebUrlHelper;
 import io.airbyte.scheduler.persistence.WorkspaceHelper;
 import io.airbyte.scheduler.persistence.job_error_reporter.JobErrorReporter;
 import io.airbyte.scheduler.persistence.job_error_reporter.JobErrorReportingClient;
@@ -446,6 +447,8 @@ public class WorkerApp {
 
     final Optional<ContainerOrchestratorConfig> containerOrchestratorConfig = getContainerOrchestratorConfig(configs);
 
+    final WebUrlHelper webUrlHelper = new WebUrlHelper(configs.getWebappUrl());
+
     final JobNotifier jobNotifier = new JobNotifier(
         configs.getWebappUrl(),
         configRepository,
@@ -456,7 +459,12 @@ public class WorkerApp {
 
     final JobErrorReportingClient jobErrorReportingClient = JobErrorReportingClientFactory.getClient(configs.getJobErrorReportingStrategy(), configs);
     final JobErrorReporter jobErrorReporter =
-        new JobErrorReporter(configRepository, configs.getDeploymentMode(), configs.getAirbyteVersionOrWarning(), jobErrorReportingClient);
+        new JobErrorReporter(
+            configRepository,
+            configs.getDeploymentMode(),
+            configs.getAirbyteVersionOrWarning(),
+            webUrlHelper,
+            jobErrorReportingClient);
 
     new WorkerApp(
         workspaceRoot,

--- a/airbyte-workers/src/main/java/io/airbyte/workers/WorkerApp.java
+++ b/airbyte-workers/src/main/java/io/airbyte/workers/WorkerApp.java
@@ -450,7 +450,7 @@ public class WorkerApp {
     final WebUrlHelper webUrlHelper = new WebUrlHelper(configs.getWebappUrl());
 
     final JobNotifier jobNotifier = new JobNotifier(
-        configs.getWebappUrl(),
+        webUrlHelper,
         configRepository,
         workspaceHelper,
         TrackingClientSingleton.get());


### PR DESCRIPTION
## What

Adds the following tags when reporting sync job failures:
- `workspace_id`
- `connector_repository`
- `connection_url`

![image](https://user-images.githubusercontent.com/4368928/177197252-73010242-df31-4609-847b-dee0713fc17f.png)

This also fixes an issue with the JobNotifier sending notifications with an invalid URL (presumably the url structure changed from `/connections/:connectionId` to `/workspaces/:workspaceId/connections/:connectionId` after the job notifier was introduced)

closes #14306 

## How

Introduce a `WebUrlHelper` for getting public URLs to resources from the platform. This uses the existing `WEBAPP_URL` env var that was used for job notifications, but moves it to a helper class so that it can be re-used. 

Setting the tags for sentry is done by adding to the metadata created for sync jobs in JobErrorReporter.

## Recommended reading order
1. `JobErrorReporter.java`
2. `WebUrlHelper.java`
3. `JobNotifier.java`

