### PR TITLE
SentryJobErrorReporter: better handling of multiline chained java exceptions

### DIFF
--- a/airbyte-scheduler/scheduler-persistence/src/main/java/io/airbyte/scheduler/persistence/job_error_reporter/SentryExceptionHelper.java
+++ b/airbyte-scheduler/scheduler-persistence/src/main/java/io/airbyte/scheduler/persistence/job_error_reporter/SentryExceptionHelper.java
@@ -103,8 +103,8 @@ public class SentryExceptionHelper {
     final List<SentryException> sentryExceptions = new ArrayList<>();
 
     // separate chained exceptions
-    // e.g "\nCaused By: "
-    final String exceptionSeparator = "\n[\\w ]+: ";
+    // e.g "\nCaused by: "
+    final String exceptionSeparator = "\nCaused by: ";
     final String[] exceptions = stacktrace.split(exceptionSeparator);
 
     for (final String exceptionStr : exceptions) {

--- a/airbyte-scheduler/scheduler-persistence/src/test/java/io/airbyte/scheduler/persistence/job_error_reporter/SentryExceptionHelperTest.java
+++ b/airbyte-scheduler/scheduler-persistence/src/test/java/io/airbyte/scheduler/persistence/job_error_reporter/SentryExceptionHelperTest.java
@@ -292,28 +292,38 @@ public class SentryExceptionHelperTest {
         }
         	at com.google.api.client.googleapis.json.GoogleJsonResponseException.from(GoogleJsonResponseException.java:146)
           ... 22 more
+        Caused by: org.postgresql.util.PSQLException: ERROR: publication "airbyte_publication" does not exist
+          Where: slot "airbyte_slot", output plugin "pgoutput", in the change callback, associated LSN 0/48029520
+        	at org.postgresql.core.v3.QueryExecutorImpl.receiveErrorResponse(QueryExecutorImpl.java:2675)
         """;
 
     final Optional<List<SentryException>> optionalSentryExceptions = exceptionHelper.buildSentryExceptions(stacktrace);
     Assertions.assertTrue(optionalSentryExceptions.isPresent());
     final List<SentryException> exceptionList = optionalSentryExceptions.get();
-    Assertions.assertEquals(1, exceptionList.size());
+    Assertions.assertEquals(2, exceptionList.size());
 
-    final String expectedValue =
+    assertExceptionContent(exceptionList.get(0), "io.temporal.failure.ApplicationFailure",
         """
         GET https://storage.googleapis.com/
         {
           "code" : 401,
           "message" : "Invalid Credentials"
-        }""";
-
-    assertExceptionContent(exceptionList.get(0), "io.temporal.failure.ApplicationFailure",
-        expectedValue, List.of(
+        }""", List.of(
             Map.of(
                 "filename", "GoogleJsonResponseException.java",
                 "lineno", 146,
                 "module", "com.google.api.client.googleapis.json.GoogleJsonResponseException",
                 "function", "from")));
+
+    assertExceptionContent(exceptionList.get(1), "org.postgresql.util.PSQLException",
+        """
+        ERROR: publication "airbyte_publication" does not exist
+          Where: slot "airbyte_slot", output plugin "pgoutput", in the change callback, associated LSN 0/48029520""", List.of(
+            Map.of(
+                "filename", "QueryExecutorImpl.java",
+                "lineno", 2675,
+                "module", "org.postgresql.core.v3.QueryExecutorImpl",
+                "function", "receiveErrorResponse")));
   }
 
   private void assertExceptionContent(final SentryException exception,


### PR DESCRIPTION
## What

I noticed in [this sentry issue](https://sentry.io/organizations/airbytehq/issues/3398275741/?project=6527718) that the last chained exception was not parsed correctly due to having an exception value that was handled like a chained exception.

```
Caused by: org.postgresql.util.PSQLException: ERROR: publication "airbyte_publication" does not exist
  Where: slot "airbyte_slot", output plugin "pgoutput", in the change callback, associated LSN 0/48029520
```

Was interpreted as:
```
// exception 1
org.postgresql.util.PSQLException: ERROR: publication "airbyte_publication" does not exist

// exception 2
slot "airbyte_slot", output plugin "pgoutput", in the change callback, associated LSN 0/48029520
```

## How

This PR fixes the issue by being more strict in what is considered a chained exception. Previously I was trying to be more lenient towards potential changes to the java text for chained exceptions, but to prevent this and correctly handle them I think it's ok to directly use `Caused by: ` as the separator for now.
