### PR TITLE
🪟 🐛 Fix Setup Source Button on OAuth Sources

### DIFF
--- a/airbyte-webapp/src/views/Connector/ServiceForm/FormRoot.tsx
+++ b/airbyte-webapp/src/views/Connector/ServiceForm/FormRoot.tsx
@@ -89,7 +89,6 @@ const FormRoot: React.FC<FormRootProps> = ({
           isLoadSchema={isLoadingSchema}
           fetchingConnectorError={fetchingConnectorError}
           hasSuccess={hasSuccess}
-          isValid={isValid}
         />
       )}
     </FormContainer>

--- a/airbyte-webapp/src/views/Connector/ServiceForm/components/CreateControls.tsx
+++ b/airbyte-webapp/src/views/Connector/ServiceForm/components/CreateControls.tsx
@@ -18,7 +18,6 @@ interface CreateControlProps {
 
   isTestConnectionInProgress: boolean;
   onCancelTesting?: () => void;
-  isValid: boolean;
 }
 
 const ButtonContainer = styled.div`
@@ -41,7 +40,6 @@ const CreateControls: React.FC<CreateControlProps> = ({
   fetchingConnectorError,
   isLoadSchema,
   onCancelTesting,
-  isValid,
 }) => {
   if (isSubmitting) {
     return <TestingConnectionSpinner isCancellable={isTestConnectionInProgress} onCancelTesting={onCancelTesting} />;

--- a/airbyte-webapp/src/views/Connector/ServiceForm/components/CreateControls.tsx
+++ b/airbyte-webapp/src/views/Connector/ServiceForm/components/CreateControls.tsx
@@ -55,7 +55,7 @@ const CreateControls: React.FC<CreateControlProps> = ({
     <ButtonContainer>
       {errorMessage && !fetchingConnectorError && <TestingConnectionError errorMessage={errorMessage} />}
       {fetchingConnectorError && <FetchingConnectorError />}
-      <SubmitButton type="submit" disabled={isLoadSchema || !isValid}>
+      <SubmitButton type="submit" disabled={isLoadSchema}>
         <FormattedMessage id={`onboarding.${formType}SetUp.buttonText`} />
       </SubmitButton>
     </ButtonContainer>

--- a/airbyte-webapp/src/views/Connector/ServiceForm/components/Sections/auth/useOauthFlowAdapter.tsx
+++ b/airbyte-webapp/src/views/Connector/ServiceForm/components/Sections/auth/useOauthFlowAdapter.tsx
@@ -7,7 +7,6 @@ import pick from "lodash/pick";
 import { ConnectorDefinitionSpecification } from "core/domain/connector";
 import { useRunOauthFlow } from "hooks/services/useConnectorAuth";
 
-import { isSourceDefinitionSpecification } from "../../../../../../core/domain/connector/source";
 import { useServiceForm } from "../../../serviceFormContext";
 import { ServiceFormValues } from "../../../types";
 import { makeConnectionConfigurationPath, serverProvidedOauthPaths } from "../../../utils";
@@ -24,7 +23,7 @@ function useFormikOauthAdapter(connector: ConnectorDefinitionSpecification): {
   const onDone = (completeOauthResponse: Record<string, unknown>) => {
     let newValues: ServiceFormValues;
 
-    if (connector.advancedAuth && !isSourceDefinitionSpecification(connector)) {
+    if (connector.advancedAuth) {
       const oauthPaths = serverProvidedOauthPaths(connector);
 
       newValues = Object.entries(oauthPaths).reduce(
@@ -34,7 +33,7 @@ function useFormikOauthAdapter(connector: ConnectorDefinitionSpecification): {
       );
     } else {
       newValues = merge(values, {
-        connectionConfiguration: { credentials: completeOauthResponse },
+        connectionConfiguration: completeOauthResponse,
       });
     }
 


### PR DESCRIPTION
## What
Closes https://github.com/airbytehq/oncall/issues/310 by reverting one of the changes from https://github.com/airbytehq/airbyte/pull/14197 for now.

## How
Removes validation for enabling the Setup Source button.  This allows users to get feedback from the UI about missing required fields.

In the future, we will want to add an error message if the missing field is the OAuth credentials.  Currently, the user receives no visual feedback if OAuth credentials are missing and they try to submit the form.

Also, we are now, correctly, using the connector specification to get the shape the connector needs its OAuth credentials in. This broke as part of https://github.com/airbytehq/airbyte/pull/12071, and wasn't correctly handled for source connectors anymore.