### PR TITLE
Revert "Kustomize: Use `resources` since `bases` is deprecated (#14037)"

### DIFF
--- a/docs/deploying-airbyte/on-kubernetes.md
+++ b/docs/deploying-airbyte/on-kubernetes.md
@@ -201,7 +201,7 @@ Example `kustomization.yaml` file:
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 
-resources:
+bases:
   - https://github.com/airbytehq/airbyte.git/kube/overlays/stable?ref=master
 ```
 

--- a/kube/overlays/dev-integration-test/kustomization.yaml
+++ b/kube/overlays/dev-integration-test/kustomization.yaml
@@ -3,7 +3,7 @@ kind: Kustomization
 
 namespace: default
 
-resources:
+bases:
   - ../../resources
 
 images:

--- a/kube/overlays/dev/kustomization.yaml
+++ b/kube/overlays/dev/kustomization.yaml
@@ -3,7 +3,7 @@ kind: Kustomization
 
 namespace: default
 
-resources:
+bases:
   - ../../resources
 
 images:

--- a/kube/overlays/stable-with-resource-limits/kustomization.yaml
+++ b/kube/overlays/stable-with-resource-limits/kustomization.yaml
@@ -3,7 +3,7 @@ kind: Kustomization
 
 namespace: default
 
-resources:
+bases:
   - ../../resources
 
 images:

--- a/kube/overlays/stable/kustomization.yaml
+++ b/kube/overlays/stable/kustomization.yaml
@@ -3,7 +3,7 @@ kind: Kustomization
 
 namespace: default
 
-resources:
+bases:
   - ../../resources
 
 images:


### PR DESCRIPTION
This reverts commit 5c9a6a5fc655a9e597f755be8fc8ccf805a2537a.

## What
Kustomize was recently changes to use `resources` instead of the deprecated `bases` in this PR: https://github.com/airbytehq/airbyte/pull/14037.

The acceptance tests have been broken because of this change.
The error that shows up is:
```
Applying dev-integration-test manifests to kubernetes...
error: rawResources failed to read Resources: Load from path ../../resources failed: '../../resources' must be a file (got d='/actions-runner/_work/airbyte/airbyte/kube/resources')
Error: Process completed with exit code 1.
```

Attempts to utilize `resources` without breaking acceptance tests were attempted here: https://github.com/airbytehq/airbyte/pull/14400, but as of time of reverting, all attempts have been unsuccessful without reverting to using `bases`.