### PR TITLE
📝  MySql source: make it clear about tinyint (size > 1)

### DIFF
--- a/docs/integrations/sources/mysql.md
+++ b/docs/integrations/sources/mysql.md
@@ -148,7 +148,7 @@ MySQL data types are mapped to the following data types when synchronizing data.
 | `bit(>1)`                                 | base64 binary string   |                                                                                                                |
 | `boolean`                                 | boolean                |                                                                                                                |
 | `tinyint(1)`                              | boolean                |                                                                                                                |
-| `tinyint`                                 | number                 |                                                                                                                |
+| `tinyint(>1)`                             | number                 |                                                                                                                |
 | `smallint`                                | number                 |                                                                                                                |
 | `mediumint`                               | number                 |                                                                                                                |
 | `int`                                     | number                 |                                                                                                                |


### PR DESCRIPTION
## What
- Make it clear that `tinyint(>1)` is converted to `number`, not all `tinyint`.
