### PR TITLE
Source Sentry: classify connector type as API

### DIFF
--- a/airbyte-config/init/src/main/resources/seed/source_definitions.yaml
+++ b/airbyte-config/init/src/main/resources/seed/source_definitions.yaml
@@ -1067,6 +1067,7 @@
   dockerImageTag: 0.1.1
   documentationUrl: https://docs.airbyte.io/integrations/sources/sentry
   icon: sentry.svg
+  sourceType: api
   releaseStage: alpha
 - name: Zoom
   sourceDefinitionId: aea2fd0d-377d-465e-86c0-4fdc4f688e51


### PR DESCRIPTION
## What
Classify Sentry source as an API type