### PR TITLE
also recognize short name

### DIFF
--- a/.github/workflows/build-connector-command.yml
+++ b/.github/workflows/build-connector-command.yml
@@ -136,7 +136,7 @@ jobs:
           source venv/bin/activate
           ci_credentials ${{ github.event.inputs.connector }}
           # normalization also runs destination-specific tests, so fetch their creds also
-          if [ 'bases/base-normalization' = "${{ github.event.inputs.connector }}" ]; then
+          if [ 'bases/base-normalization' = "${{ github.event.inputs.connector }}" ] || [ 'base-normalization' = "${{ github.event.inputs.connector }}" ]; then
             ci_credentials destination-bigquery
             ci_credentials destination-postgres
             ci_credentials destination-snowflake

--- a/.github/workflows/publish-command.yml
+++ b/.github/workflows/publish-command.yml
@@ -267,7 +267,7 @@ jobs:
           source venv/bin/activate
           ci_credentials ${{ matrix.connector }}
           # normalization also runs destination-specific tests, so fetch their creds also
-          if [ 'bases/base-normalization' = "${{ matrix.connector }}" ]; then
+          if [ 'bases/base-normalization' = "${{ matrix.connector }}" ] || [ 'base-normalization' = "${{ matrix.connector }}" ]; then
             ci_credentials destination-bigquery
             ci_credentials destination-postgres
             ci_credentials destination-snowflake

--- a/.github/workflows/test-command.yml
+++ b/.github/workflows/test-command.yml
@@ -111,7 +111,7 @@ jobs:
           source venv/bin/activate
           ci_credentials ${{ github.event.inputs.connector }}
           # normalization also runs destination-specific tests, so fetch their creds also
-          if [ 'bases/base-normalization' = "${{ github.event.inputs.connector }}" ]; then
+          if [ 'bases/base-normalization' = "${{ github.event.inputs.connector }}" ] || [ 'base-normalization' = "${{ github.event.inputs.connector }}" ]; then
             ci_credentials destination-bigquery
             ci_credentials destination-postgres
             ci_credentials destination-snowflake

--- a/.github/workflows/test-performance-command.yml
+++ b/.github/workflows/test-performance-command.yml
@@ -117,7 +117,7 @@ jobs:
           source venv/bin/activate
           ci_credentials ${{ github.event.inputs.connector }}
           # normalization also runs destination-specific tests, so fetch their creds also
-          if [ 'bases/base-normalization' = "${{ github.event.inputs.connector }}" ]; then
+          if [ 'bases/base-normalization' = "${{ github.event.inputs.connector }}" ] || [ 'base-normalization' = "${{ github.event.inputs.connector }}" ]; then
             ci_credentials destination-bigquery
             ci_credentials destination-postgres
             ci_credentials destination-snowflake


### PR DESCRIPTION
followup to https://github.com/airbytehq/airbyte/pull/14312 - we should also recognize just `base-normalization` as the connector name when fetching additional credentials.

Test run here https://github.com/airbytehq/airbyte/runs/7217780684?check_suite_focus=true#step:10:145 - note that it now correctly fetches creds for destination-snowflake.