### PR TITLE
Fail fast if catalog struct bigger than 4mb during schema discovery

### DIFF
--- a/airbyte-workers/src/main/java/io/airbyte/workers/general/DefaultDiscoverCatalogWorker.java
+++ b/airbyte-workers/src/main/java/io/airbyte/workers/general/DefaultDiscoverCatalogWorker.java
@@ -72,6 +72,8 @@ public class DefaultDiscoverCatalogWorker implements DiscoverCatalogWorker {
           throw new WorkerException("Integration failed to output a catalog struct.");
         }
 
+        // This message is sent through temporal that utilizes GRPC as is set to limit messages to 4mb.
+        // We fail fast here so users will not have to wait the 10 minutes before a timeout error occurs.
         if (catalog.get().toString().length() > FOUR_MB) {
           throw new WorkerException("Output a catalog struct bigger than 4mb. Larger than grpc max message limit.");
         }

--- a/airbyte-workers/src/main/java/io/airbyte/workers/general/DefaultDiscoverCatalogWorker.java
+++ b/airbyte-workers/src/main/java/io/airbyte/workers/general/DefaultDiscoverCatalogWorker.java
@@ -26,6 +26,7 @@ import org.slf4j.LoggerFactory;
 public class DefaultDiscoverCatalogWorker implements DiscoverCatalogWorker {
 
   private static final Logger LOGGER = LoggerFactory.getLogger(DefaultDiscoverCatalogWorker.class);
+  private static final int FOUR_MB = 1024 * 1024 * 4;
 
   private final WorkerConfigs workerConfigs;
   private final IntegrationLauncher integrationLauncher;
@@ -69,6 +70,10 @@ public class DefaultDiscoverCatalogWorker implements DiscoverCatalogWorker {
       if (exitCode == 0) {
         if (catalog.isEmpty()) {
           throw new WorkerException("Integration failed to output a catalog struct.");
+        }
+
+        if (catalog.get().toString().length() > FOUR_MB) {
+          throw new WorkerException("Output a catalog struct bigger than 4mb. Larger than grpc max message limit.");
         }
 
         return catalog.get();

--- a/airbyte-workers/src/main/java/io/airbyte/workers/general/DefaultDiscoverCatalogWorker.java
+++ b/airbyte-workers/src/main/java/io/airbyte/workers/general/DefaultDiscoverCatalogWorker.java
@@ -26,7 +26,7 @@ import org.slf4j.LoggerFactory;
 public class DefaultDiscoverCatalogWorker implements DiscoverCatalogWorker {
 
   private static final Logger LOGGER = LoggerFactory.getLogger(DefaultDiscoverCatalogWorker.class);
-  private static final int FOUR_MB = 1024 * 1024 * 4;
+  private static final int TEMPORAL_MESSAGE_LIMIT_MB = 1024 * 1024 * 4;
 
   private final WorkerConfigs workerConfigs;
   private final IntegrationLauncher integrationLauncher;
@@ -74,7 +74,7 @@ public class DefaultDiscoverCatalogWorker implements DiscoverCatalogWorker {
 
         // This message is sent through temporal that utilizes GRPC as is set to limit messages to 4mb.
         // We fail fast here so users will not have to wait the 10 minutes before a timeout error occurs.
-        if (catalog.get().toString().length() > FOUR_MB) {
+        if (catalog.get().toString().length() > TEMPORAL_MESSAGE_LIMIT_MB) {
           throw new WorkerException("Output a catalog struct bigger than 4mb. Larger than grpc max message limit.");
         }
 


### PR DESCRIPTION
## What
If you send anything (but mostly a schema) via temporal, this request is sent under the hood using GRPC.
GRPC by default maxed out at 4MB.

This commit will fail fast if catalog struct bigger than 4mb so users will not have to wait for the 10 minute timeout.

The real solution for this problem is tracked in airbytehq/airbyte-internal-issues#599 .