### PR TITLE
🪟🐛 Fixes connector status icon alignment

### DIFF
--- a/airbyte-webapp/src/components/StatusIcon/StatusIcon.tsx
+++ b/airbyte-webapp/src/components/StatusIcon/StatusIcon.tsx
@@ -54,13 +54,16 @@ const Badge = styled(Container)<StatusIconProps>`
     height: 1em;
     vertical-align: -0.125em;
   }
+
+  > span {
+    vertical-align: ${({ status }) => (status === "inactive" ? "bottom" : "top")};
+  }
 `;
 
 const Value = styled.span`
   font-weight: 500;
   font-size: 12px;
   padding-left: 3px;
-  vertical-align: top;
 `;
 
 const StatusIcon: React.FC<StatusIconProps> = ({ title, status, ...props }) => {

--- a/airbyte-webapp/src/components/StatusIcon/index.stories.tsx
+++ b/airbyte-webapp/src/components/StatusIcon/index.stories.tsx
@@ -5,7 +5,9 @@ import StatusIconComponent from "./StatusIcon";
 export default {
   title: "Ui/StatusIcon",
   component: StatusIconComponent,
-  argTypes: {},
+  argTypes: {
+    value: { type: { name: "number", required: false } },
+  },
 } as ComponentMeta<typeof StatusIconComponent>;
 
 const Template: ComponentStory<typeof StatusIconComponent> = (args) => <StatusIconComponent {...args} />;


### PR DESCRIPTION
## What
Fixes #14260 

## How
Sets `vertical-align` of the icon value to bottom when the icon's status is `inactive`.

![508E04C5-ADC6-48C9-B001-AD2EA6770064_4_5005_c](https://user-images.githubusercontent.com/65251165/177633996-254e2079-c201-4cbc-9b98-e2bfc444d75d.jpeg)
![8B2B18CA-8450-4065-A9CA-D0E51F97A847_4_5005_c](https://user-images.githubusercontent.com/65251165/177634051-393deef6-6aa1-4541-ab0a-1899b4523aeb.jpeg)

