### PR TITLE
Remove withRefreshedCatalog param from updateConnection endpoint

### DIFF
--- a/airbyte-config/config-persistence/src/main/java/io/airbyte/config/persistence/ConfigRepository.java
+++ b/airbyte-config/config-persistence/src/main/java/io/airbyte/config/persistence/ConfigRepository.java
@@ -47,6 +47,7 @@ import io.airbyte.metrics.lib.MetricQueries;
 import io.airbyte.protocol.models.AirbyteCatalog;
 import io.airbyte.protocol.models.CatalogHelpers;
 import io.airbyte.protocol.models.StreamDescriptor;
+import io.airbyte.protocol.models.ConfiguredAirbyteCatalog;
 import io.airbyte.validation.json.JsonValidationException;
 import java.io.IOException;
 import java.time.OffsetDateTime;
@@ -989,4 +990,9 @@ public class ConfigRepository {
     return CatalogHelpers.extractStreamDescriptors(standardSync.getCatalog());
   }
 
+  public ConfiguredAirbyteCatalog getConfiguredCatalogForConnection(final UUID connectionId)
+      throws JsonValidationException, ConfigNotFoundException, IOException {
+    final StandardSync standardSync = getStandardSync(connectionId);
+    return standardSync.getCatalog();
+  }
 }

--- a/airbyte-config/config-persistence/src/main/java/io/airbyte/config/persistence/ConfigRepository.java
+++ b/airbyte-config/config-persistence/src/main/java/io/airbyte/config/persistence/ConfigRepository.java
@@ -46,8 +46,8 @@ import io.airbyte.db.instance.configs.jooq.generated.enums.StatusType;
 import io.airbyte.metrics.lib.MetricQueries;
 import io.airbyte.protocol.models.AirbyteCatalog;
 import io.airbyte.protocol.models.CatalogHelpers;
-import io.airbyte.protocol.models.StreamDescriptor;
 import io.airbyte.protocol.models.ConfiguredAirbyteCatalog;
+import io.airbyte.protocol.models.StreamDescriptor;
 import io.airbyte.validation.json.JsonValidationException;
 import java.io.IOException;
 import java.time.OffsetDateTime;
@@ -995,4 +995,5 @@ public class ConfigRepository {
     final StandardSync standardSync = getStandardSync(connectionId);
     return standardSync.getCatalog();
   }
+
 }

--- a/airbyte-server/src/main/java/io/airbyte/server/apis/ConfigurationApi.java
+++ b/airbyte-server/src/main/java/io/airbyte/server/apis/ConfigurationApi.java
@@ -822,6 +822,11 @@ public class ConfigurationApi implements io.airbyte.api.generated.V1Api {
     return execute(() -> webBackendConnectionsHandler.webBackendUpdateConnection(webBackendConnectionUpdate));
   }
 
+  // @Override
+  public WebBackendConnectionRead webBackendUpdateConnectionNew(final WebBackendConnectionUpdate webBackendConnectionUpdate) {
+    return execute(() -> webBackendConnectionsHandler.webBackendUpdateConnectionNew(webBackendConnectionUpdate));
+  }
+
   @Override
   public ConnectionStateType getStateType(final ConnectionIdRequestBody connectionIdRequestBody) {
     return execute(() -> webBackendConnectionsHandler.getStateType(connectionIdRequestBody));

--- a/airbyte-server/src/main/java/io/airbyte/server/converters/ProtocolConverters.java
+++ b/airbyte-server/src/main/java/io/airbyte/server/converters/ProtocolConverters.java
@@ -15,4 +15,9 @@ public class ProtocolConverters {
     return new StreamDescriptor().name(protocolStreamDescriptor.getName()).namespace(protocolStreamDescriptor.getNamespace());
   }
 
+  public static io.airbyte.protocol.models.StreamDescriptor streamDescriptorToProtocol(final StreamDescriptor apiStreamDescriptor) {
+    return new io.airbyte.protocol.models.StreamDescriptor().withName(apiStreamDescriptor.getName())
+        .withNamespace(apiStreamDescriptor.getNamespace());
+  }
+
 }

--- a/airbyte-server/src/main/java/io/airbyte/server/handlers/ConnectionsHandler.java
+++ b/airbyte-server/src/main/java/io/airbyte/server/handlers/ConnectionsHandler.java
@@ -259,7 +259,7 @@ public class ConnectionsHandler {
     return buildConnectionRead(connectionId);
   }
 
-  public static CatalogDiff getDiff(final AirbyteCatalog oldCatalog, final AirbyteCatalog newCatalog) {
+  public CatalogDiff getDiff(final AirbyteCatalog oldCatalog, final AirbyteCatalog newCatalog) {
     return new CatalogDiff().transforms(CatalogHelpers.getCatalogDiff(
         CatalogHelpers.configuredCatalogToCatalog(CatalogConverter.toProtocolKeepAllStreams(oldCatalog)),
         CatalogHelpers.configuredCatalogToCatalog(CatalogConverter.toProtocolKeepAllStreams(newCatalog)))

--- a/airbyte-server/src/main/java/io/airbyte/server/handlers/WebBackendConnectionsHandler.java
+++ b/airbyte-server/src/main/java/io/airbyte/server/handlers/WebBackendConnectionsHandler.java
@@ -35,6 +35,7 @@ import io.airbyte.api.model.generated.SourceDiscoverSchemaRead;
 import io.airbyte.api.model.generated.SourceDiscoverSchemaRequestBody;
 import io.airbyte.api.model.generated.SourceIdRequestBody;
 import io.airbyte.api.model.generated.SourceRead;
+import io.airbyte.api.model.generated.StreamDescriptor;
 import io.airbyte.api.model.generated.StreamTransform.TransformTypeEnum;
 import io.airbyte.api.model.generated.WebBackendConnectionCreate;
 import io.airbyte.api.model.generated.WebBackendConnectionRead;
@@ -371,7 +372,7 @@ public class WebBackendConnectionsHandler {
       final AirbyteCatalog modelExisting = CatalogConverter.toApi(existingCatalog);
       final AirbyteCatalog newAirbyteCatalog = webBackendConnectionUpdate.getSyncCatalog();
       final CatalogDiff catalogDiff = ConnectionsHandler.getDiff(modelExisting, newAirbyteCatalog);
-      final List<TransformTypeEnum> streamsToReset = getStreamsToReset(catalogDiff);
+      final List<StreamDescriptor> streamsToReset = getStreamsToReset(catalogDiff);
       ManualOperationResult manualOperationResult = eventRunner.synchronousResetConnection(
           webBackendConnectionUpdate.getConnectionId(),
           streamsToReset);
@@ -497,8 +498,8 @@ public class WebBackendConnectionsHandler {
         .status(webBackendConnectionSearch.getStatus());
   }
 
-  public static List<TransformTypeEnum> getStreamsToReset(final CatalogDiff catalogDiff) {
-    return catalogDiff.getTransforms().stream().map(sT -> sT.getTransformType()).toList();
+  public static List<StreamDescriptor> getStreamsToReset(final CatalogDiff catalogDiff) {
+    return catalogDiff.getTransforms().stream().map(sT -> sT.getStreamDescriptor()).toList();
   }
 
   /**

--- a/airbyte-server/src/main/java/io/airbyte/server/handlers/WebBackendConnectionsHandler.java
+++ b/airbyte-server/src/main/java/io/airbyte/server/handlers/WebBackendConnectionsHandler.java
@@ -36,7 +36,6 @@ import io.airbyte.api.model.generated.SourceDiscoverSchemaRequestBody;
 import io.airbyte.api.model.generated.SourceIdRequestBody;
 import io.airbyte.api.model.generated.SourceRead;
 import io.airbyte.api.model.generated.StreamDescriptor;
-import io.airbyte.api.model.generated.StreamTransform.TransformTypeEnum;
 import io.airbyte.api.model.generated.WebBackendConnectionCreate;
 import io.airbyte.api.model.generated.WebBackendConnectionRead;
 import io.airbyte.api.model.generated.WebBackendConnectionReadList;
@@ -369,9 +368,9 @@ public class WebBackendConnectionsHandler {
       final ConfiguredAirbyteCatalog existingConfiguredCatalog =
           configRepository.getConfiguredCatalogForConnection(webBackendConnectionUpdate.getConnectionId());
       final io.airbyte.protocol.models.AirbyteCatalog existingCatalog = CatalogHelpers.configuredCatalogToCatalog(existingConfiguredCatalog);
-      final AirbyteCatalog modelExisting = CatalogConverter.toApi(existingCatalog);
+      final AirbyteCatalog apiExistingCatalog = CatalogConverter.toApi(existingCatalog);
       final AirbyteCatalog newAirbyteCatalog = webBackendConnectionUpdate.getSyncCatalog();
-      final CatalogDiff catalogDiff = ConnectionsHandler.getDiff(modelExisting, newAirbyteCatalog);
+      final CatalogDiff catalogDiff = ConnectionsHandler.getDiff(apiExistingCatalog, newAirbyteCatalog);
       final List<StreamDescriptor> streamsToReset = getStreamsToReset(catalogDiff);
       ManualOperationResult manualOperationResult = eventRunner.synchronousResetConnection(
           webBackendConnectionUpdate.getConnectionId(),

--- a/airbyte-server/src/main/java/io/airbyte/server/handlers/WebBackendConnectionsHandler.java
+++ b/airbyte-server/src/main/java/io/airbyte/server/handlers/WebBackendConnectionsHandler.java
@@ -365,8 +365,6 @@ public class WebBackendConnectionsHandler {
     connectionRead = connectionsHandler.updateConnection(connectionUpdate);
 
     final UUID connectionId = webBackendConnectionUpdate.getConnectionId();
-    final ConnectionIdRequestBody connectionIdRequestBody = new ConnectionIdRequestBody().connectionId(connectionId);
-    final ConnectionStateType stateType = getStateType(connectionIdRequestBody);
 
     final ConfiguredAirbyteCatalog existingConfiguredCatalog =
         configRepository.getConfiguredCatalogForConnection(connectionId);
@@ -380,6 +378,9 @@ public class WebBackendConnectionsHandler {
         apiStreamsToReset.stream().map(ProtocolConverters::streamDescriptorToProtocol).toList();
 
     if (!streamsToReset.isEmpty()) {
+      final ConnectionIdRequestBody connectionIdRequestBody = new ConnectionIdRequestBody().connectionId(connectionId);
+      final ConnectionStateType stateType = getStateType(connectionIdRequestBody);
+
       if (stateType == ConnectionStateType.LEGACY || stateType == ConnectionStateType.NOT_SET || stateType == ConnectionStateType.GLOBAL) {
         streamsToReset = configRepository.getAllStreamsForConnection(connectionId);
       }

--- a/airbyte-server/src/main/java/io/airbyte/server/handlers/WebBackendConnectionsHandler.java
+++ b/airbyte-server/src/main/java/io/airbyte/server/handlers/WebBackendConnectionsHandler.java
@@ -361,9 +361,6 @@ public class WebBackendConnectionsHandler {
     final List<UUID> operationIds = updateOperations(webBackendConnectionUpdate);
     final ConnectionUpdate connectionUpdate = toConnectionUpdate(webBackendConnectionUpdate, operationIds);
 
-    ConnectionRead connectionRead;
-    connectionRead = connectionsHandler.updateConnection(connectionUpdate);
-
     final UUID connectionId = webBackendConnectionUpdate.getConnectionId();
 
     final ConfiguredAirbyteCatalog existingConfiguredCatalog =
@@ -376,6 +373,9 @@ public class WebBackendConnectionsHandler {
     final List<StreamDescriptor> apiStreamsToReset = getStreamsToReset(catalogDiff);
     List<io.airbyte.protocol.models.StreamDescriptor> streamsToReset =
         apiStreamsToReset.stream().map(ProtocolConverters::streamDescriptorToProtocol).toList();
+
+    ConnectionRead connectionRead;
+    connectionRead = connectionsHandler.updateConnection(connectionUpdate);
 
     if (!streamsToReset.isEmpty()) {
       final ConnectionIdRequestBody connectionIdRequestBody = new ConnectionIdRequestBody().connectionId(connectionId);

--- a/airbyte-server/src/main/java/io/airbyte/server/handlers/WebBackendConnectionsHandler.java
+++ b/airbyte-server/src/main/java/io/airbyte/server/handlers/WebBackendConnectionsHandler.java
@@ -382,7 +382,7 @@ public class WebBackendConnectionsHandler {
         final AirbyteCatalog newAirbyteCatalog = webBackendConnectionUpdate.getSyncCatalog();
         final CatalogDiff catalogDiff = connectionsHandler.getDiff(apiExistingCatalog, newAirbyteCatalog);
         final List<StreamDescriptor> apiStreamsToReset = getStreamsToReset(catalogDiff);
-        streamsToReset = apiStreamsToReset.stream().map(streamDescriptor -> ProtocolConverters.streamDescriptorToProtocol(streamDescriptor)).toList();
+        streamsToReset = apiStreamsToReset.stream().map(ProtocolConverters::streamDescriptorToProtocol).toList();
       }
 
       ManualOperationResult manualOperationResult = eventRunner.synchronousResetConnection(
@@ -511,7 +511,7 @@ public class WebBackendConnectionsHandler {
   }
 
   @VisibleForTesting
-  protected static List<StreamDescriptor> getStreamsToReset(final CatalogDiff catalogDiff) {
+  static List<StreamDescriptor> getStreamsToReset(final CatalogDiff catalogDiff) {
     return catalogDiff.getTransforms().stream().map(StreamTransform::getStreamDescriptor).toList();
   }
 

--- a/airbyte-server/src/main/java/io/airbyte/server/handlers/WebBackendConnectionsHandler.java
+++ b/airbyte-server/src/main/java/io/airbyte/server/handlers/WebBackendConnectionsHandler.java
@@ -361,6 +361,30 @@ public class WebBackendConnectionsHandler {
     final List<UUID> operationIds = updateOperations(webBackendConnectionUpdate);
     final ConnectionUpdate connectionUpdate = toConnectionUpdate(webBackendConnectionUpdate, operationIds);
 
+    ConnectionRead connectionRead;
+    final boolean needReset = MoreBooleans.isTruthy(webBackendConnectionUpdate.getWithRefreshedCatalog());
+
+    connectionRead = connectionsHandler.updateConnection(connectionUpdate);
+
+    if (needReset) {
+      ManualOperationResult manualOperationResult = eventRunner.synchronousResetConnection(
+          webBackendConnectionUpdate.getConnectionId(),
+          // TODO (https://github.com/airbytehq/airbyte/issues/12741): change this to only get new/updated
+          // streams, instead of all
+          configRepository.getAllStreamsForConnection(webBackendConnectionUpdate.getConnectionId()));
+      verifyManualOperationResult(manualOperationResult);
+      manualOperationResult = eventRunner.startNewManualSync(webBackendConnectionUpdate.getConnectionId());
+      verifyManualOperationResult(manualOperationResult);
+      connectionRead = connectionsHandler.getConnection(connectionUpdate.getConnectionId());
+    }
+    return buildWebBackendConnectionRead(connectionRead);
+  }
+
+  public WebBackendConnectionRead webBackendUpdateConnectionNew(final WebBackendConnectionUpdate webBackendConnectionUpdate)
+      throws ConfigNotFoundException, IOException, JsonValidationException {
+    final List<UUID> operationIds = updateOperations(webBackendConnectionUpdate);
+    final ConnectionUpdate connectionUpdate = toConnectionUpdate(webBackendConnectionUpdate, operationIds);
+
     final UUID connectionId = webBackendConnectionUpdate.getConnectionId();
 
     final ConfiguredAirbyteCatalog existingConfiguredCatalog =

--- a/airbyte-server/src/main/java/io/airbyte/server/handlers/WebBackendConnectionsHandler.java
+++ b/airbyte-server/src/main/java/io/airbyte/server/handlers/WebBackendConnectionsHandler.java
@@ -35,7 +35,6 @@ import io.airbyte.api.model.generated.SourceDiscoverSchemaRead;
 import io.airbyte.api.model.generated.SourceDiscoverSchemaRequestBody;
 import io.airbyte.api.model.generated.SourceIdRequestBody;
 import io.airbyte.api.model.generated.SourceRead;
-import io.airbyte.api.model.generated.StreamDescriptor;
 import io.airbyte.api.model.generated.WebBackendConnectionCreate;
 import io.airbyte.api.model.generated.WebBackendConnectionRead;
 import io.airbyte.api.model.generated.WebBackendConnectionReadList;
@@ -53,6 +52,7 @@ import io.airbyte.config.persistence.ConfigNotFoundException;
 import io.airbyte.config.persistence.ConfigRepository;
 import io.airbyte.protocol.models.CatalogHelpers;
 import io.airbyte.protocol.models.ConfiguredAirbyteCatalog;
+import io.airbyte.protocol.models.StreamDescriptor;
 import io.airbyte.scheduler.client.EventRunner;
 import io.airbyte.server.handlers.helpers.CatalogConverter;
 import io.airbyte.validation.json.JsonValidationException;
@@ -359,7 +359,7 @@ public class WebBackendConnectionsHandler {
     final List<UUID> operationIds = updateOperations(webBackendConnectionUpdate);
     final ConnectionUpdate connectionUpdate = toConnectionUpdate(webBackendConnectionUpdate, operationIds);
 
-    final ConnectionRead connectionRead;
+    ConnectionRead connectionRead;
     final boolean needReset = MoreBooleans.isTruthy(webBackendConnectionUpdate.getWithRefreshedCatalog());
 
     connectionRead = connectionsHandler.updateConnection(connectionUpdate);

--- a/airbyte-server/src/main/java/io/airbyte/server/handlers/WebBackendConnectionsHandler.java
+++ b/airbyte-server/src/main/java/io/airbyte/server/handlers/WebBackendConnectionsHandler.java
@@ -385,12 +385,14 @@ public class WebBackendConnectionsHandler {
         streamsToReset = apiStreamsToReset.stream().map(ProtocolConverters::streamDescriptorToProtocol).toList();
       }
 
-      ManualOperationResult manualOperationResult = eventRunner.synchronousResetConnection(
-          webBackendConnectionUpdate.getConnectionId(),
-          streamsToReset);
-      verifyManualOperationResult(manualOperationResult);
-      manualOperationResult = eventRunner.startNewManualSync(webBackendConnectionUpdate.getConnectionId());
-      verifyManualOperationResult(manualOperationResult);
+      if (!streamsToReset.isEmpty()) {
+        ManualOperationResult manualOperationResult = eventRunner.synchronousResetConnection(
+            webBackendConnectionUpdate.getConnectionId(),
+            streamsToReset);
+        verifyManualOperationResult(manualOperationResult);
+        manualOperationResult = eventRunner.startNewManualSync(webBackendConnectionUpdate.getConnectionId());
+        verifyManualOperationResult(manualOperationResult);
+      }
       connectionRead = connectionsHandler.getConnection(connectionUpdate.getConnectionId());
     }
 

--- a/airbyte-server/src/main/java/io/airbyte/server/handlers/WebBackendConnectionsHandler.java
+++ b/airbyte-server/src/main/java/io/airbyte/server/handlers/WebBackendConnectionsHandler.java
@@ -499,19 +499,7 @@ public class WebBackendConnectionsHandler {
   }
 
   public static List<TransformTypeEnum> getStreamsToReset(final CatalogDiff catalogDiff) {
-    final List<TransformTypeEnum> streamsToReset = catalogDiff.getTransforms().stream()
-        .filter(streamTransform ->
-            TransformTypeEnum.ADD_STREAM == streamTransform.getTransformType() ||
-                TransformTypeEnum.UPDATE_STREAM == streamTransform.getTransformType())
-        .map(sT -> sT.getTransformType()).toList();
-
-//    catalogDiff.getTransforms().forEach(stream -> {
-//      final TransformTypeEnum transformType = stream.getTransformType();
-//      if(TransformTypeEnum.ADD_STREAM == transformType || TransformTypeEnum.UPDATE_STREAM == transformType){
-//        streamsToReset.add(stream.getTransformType());
-//      };
-//    });
-    return streamsToReset;
+    return catalogDiff.getTransforms().stream().map(sT -> sT.getTransformType()).toList();
   }
 
   /**

--- a/airbyte-server/src/main/java/io/airbyte/server/handlers/WebBackendConnectionsHandler.java
+++ b/airbyte-server/src/main/java/io/airbyte/server/handlers/WebBackendConnectionsHandler.java
@@ -372,7 +372,7 @@ public class WebBackendConnectionsHandler {
       final ConnectionStateType stateType = getStateType(connectionIdRequestBody);
       final List<io.airbyte.protocol.models.StreamDescriptor> streamsToReset;
 
-      if (stateType == ConnectionStateType.LEGACY || stateType == ConnectionStateType.NOT_SET) {
+      if (stateType == ConnectionStateType.LEGACY || stateType == ConnectionStateType.NOT_SET || stateType == ConnectionStateType.GLOBAL) {
         streamsToReset = configRepository.getAllStreamsForConnection(connectionId);
       } else {
         final ConfiguredAirbyteCatalog existingConfiguredCatalog =

--- a/airbyte-server/src/main/java/io/airbyte/server/handlers/WebBackendConnectionsHandler.java
+++ b/airbyte-server/src/main/java/io/airbyte/server/handlers/WebBackendConnectionsHandler.java
@@ -53,8 +53,6 @@ import io.airbyte.config.persistence.ConfigNotFoundException;
 import io.airbyte.config.persistence.ConfigRepository;
 import io.airbyte.protocol.models.CatalogHelpers;
 import io.airbyte.protocol.models.ConfiguredAirbyteCatalog;
-import io.airbyte.protocol.models.StreamDescriptor;
-import io.airbyte.protocol.models.transform_models.StreamTransform;
 import io.airbyte.scheduler.client.EventRunner;
 import io.airbyte.server.handlers.helpers.CatalogConverter;
 import io.airbyte.validation.json.JsonValidationException;
@@ -367,7 +365,8 @@ public class WebBackendConnectionsHandler {
     connectionRead = connectionsHandler.updateConnection(connectionUpdate);
 
     if (needReset) {
-      final ConfiguredAirbyteCatalog existingConfiguredCatalog = configRepository.getConfiguredCatalogForConnection(webBackendConnectionUpdate.getConnectionId());
+      final ConfiguredAirbyteCatalog existingConfiguredCatalog =
+          configRepository.getConfiguredCatalogForConnection(webBackendConnectionUpdate.getConnectionId());
       final io.airbyte.protocol.models.AirbyteCatalog existingCatalog = CatalogHelpers.configuredCatalogToCatalog(existingConfiguredCatalog);
       final AirbyteCatalog modelExisting = CatalogConverter.toApi(existingCatalog);
       final AirbyteCatalog newAirbyteCatalog = webBackendConnectionUpdate.getSyncCatalog();

--- a/airbyte-server/src/test/java/io/airbyte/server/handlers/WebBackendConnectionsHandlerTest.java
+++ b/airbyte-server/src/test/java/io/airbyte/server/handlers/WebBackendConnectionsHandlerTest.java
@@ -75,7 +75,6 @@ import io.airbyte.config.persistence.ConfigRepository;
 import io.airbyte.protocol.models.CatalogHelpers;
 import io.airbyte.protocol.models.Field;
 import io.airbyte.protocol.models.JsonSchemaType;
-import io.airbyte.protocol.models.transform_models.StreamTransformType;
 import io.airbyte.scheduler.client.EventRunner;
 import io.airbyte.server.helpers.ConnectionHelpers;
 import io.airbyte.server.helpers.DestinationDefinitionHelpers;

--- a/airbyte-server/src/test/java/io/airbyte/server/handlers/WebBackendConnectionsHandlerTest.java
+++ b/airbyte-server/src/test/java/io/airbyte/server/handlers/WebBackendConnectionsHandlerTest.java
@@ -4,7 +4,6 @@
 
 package io.airbyte.server.handlers;
 
-import static io.airbyte.server.helpers.ConnectionHelpers.generateBasicConfiguredAirbyteCatalog;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertTrue;
@@ -74,7 +73,6 @@ import io.airbyte.config.StandardSync;
 import io.airbyte.config.persistence.ConfigNotFoundException;
 import io.airbyte.config.persistence.ConfigRepository;
 import io.airbyte.protocol.models.CatalogHelpers;
-import io.airbyte.protocol.models.ConfiguredAirbyteCatalog;
 import io.airbyte.protocol.models.Field;
 import io.airbyte.protocol.models.JsonSchemaType;
 import io.airbyte.scheduler.client.EventRunner;
@@ -95,7 +93,6 @@ import java.util.Optional;
 import java.util.Set;
 import java.util.UUID;
 import java.util.stream.Collectors;
-import org.junit.Assert;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.mockito.InOrder;
@@ -847,9 +844,12 @@ class WebBackendConnectionsHandlerTest {
 
   @Test
   public void testGetStreamsToReset() {
-    final StreamTransform streamTransformAdd = new StreamTransform().addStream(new StreamDescriptor().name("added_stream")).transformType(TransformTypeEnum.ADD_STREAM);
-    final StreamTransform streamTransformRemove = new StreamTransform().addStream(new StreamDescriptor().name("removed_stream")).transformType(TransformTypeEnum.REMOVE_STREAM);;
-    final StreamTransform streamTransformUpdate = new StreamTransform().addStream(new StreamDescriptor().name("updated_stream")).transformType(TransformTypeEnum.UPDATE_STREAM);;
+    final StreamTransform streamTransformAdd =
+        new StreamTransform().addStream(new StreamDescriptor().name("added_stream")).transformType(TransformTypeEnum.ADD_STREAM);
+    final StreamTransform streamTransformRemove =
+        new StreamTransform().addStream(new StreamDescriptor().name("removed_stream")).transformType(TransformTypeEnum.REMOVE_STREAM);;
+    final StreamTransform streamTransformUpdate =
+        new StreamTransform().addStream(new StreamDescriptor().name("updated_stream")).transformType(TransformTypeEnum.UPDATE_STREAM);;
     final CatalogDiff catalogDiff = new CatalogDiff().transforms(List.of(streamTransformAdd, streamTransformRemove, streamTransformUpdate));
     final List<TransformTypeEnum> resultList = WebBackendConnectionsHandler.getStreamsToReset(catalogDiff);
     System.out.println(resultList);
@@ -863,4 +863,5 @@ class WebBackendConnectionsHandlerTest {
         resultList.stream().anyMatch(
             transformType -> transformType == TransformTypeEnum.REMOVE_STREAM));
   }
+
 }

--- a/airbyte-server/src/test/java/io/airbyte/server/handlers/WebBackendConnectionsHandlerTest.java
+++ b/airbyte-server/src/test/java/io/airbyte/server/handlers/WebBackendConnectionsHandlerTest.java
@@ -859,7 +859,7 @@ class WebBackendConnectionsHandlerTest {
     assertTrue(
         resultList.stream().anyMatch(
             transformType -> transformType == TransformTypeEnum.UPDATE_STREAM));
-    assertFalse(
+    assertTrue(
         resultList.stream().anyMatch(
             transformType -> transformType == TransformTypeEnum.REMOVE_STREAM));
   }

--- a/airbyte-server/src/test/java/io/airbyte/server/handlers/WebBackendConnectionsHandlerTest.java
+++ b/airbyte-server/src/test/java/io/airbyte/server/handlers/WebBackendConnectionsHandlerTest.java
@@ -75,6 +75,7 @@ import io.airbyte.config.persistence.ConfigRepository;
 import io.airbyte.protocol.models.CatalogHelpers;
 import io.airbyte.protocol.models.Field;
 import io.airbyte.protocol.models.JsonSchemaType;
+import io.airbyte.protocol.models.transform_models.StreamTransformType;
 import io.airbyte.scheduler.client.EventRunner;
 import io.airbyte.server.helpers.ConnectionHelpers;
 import io.airbyte.server.helpers.DestinationDefinitionHelpers;
@@ -845,23 +846,22 @@ class WebBackendConnectionsHandlerTest {
   @Test
   public void testGetStreamsToReset() {
     final StreamTransform streamTransformAdd =
-        new StreamTransform().addStream(new StreamDescriptor().name("added_stream")).transformType(TransformTypeEnum.ADD_STREAM);
+        new StreamTransform().transformType(TransformTypeEnum.ADD_STREAM).streamDescriptor(new StreamDescriptor().name("added_stream"));
     final StreamTransform streamTransformRemove =
-        new StreamTransform().addStream(new StreamDescriptor().name("removed_stream")).transformType(TransformTypeEnum.REMOVE_STREAM);;
+        new StreamTransform().transformType(TransformTypeEnum.REMOVE_STREAM).streamDescriptor(new StreamDescriptor().name("removed_stream"));
     final StreamTransform streamTransformUpdate =
-        new StreamTransform().addStream(new StreamDescriptor().name("updated_stream")).transformType(TransformTypeEnum.UPDATE_STREAM);;
+        new StreamTransform().transformType(TransformTypeEnum.UPDATE_STREAM).streamDescriptor(new StreamDescriptor().name("updated_stream"));
     final CatalogDiff catalogDiff = new CatalogDiff().transforms(List.of(streamTransformAdd, streamTransformRemove, streamTransformUpdate));
-    final List<TransformTypeEnum> resultList = WebBackendConnectionsHandler.getStreamsToReset(catalogDiff);
-    System.out.println(resultList);
+    final List<StreamDescriptor> resultList = WebBackendConnectionsHandler.getStreamsToReset(catalogDiff);
     assertTrue(
         resultList.stream().anyMatch(
-            transformType -> transformType == TransformTypeEnum.ADD_STREAM));
+            streamDescriptor -> streamDescriptor == new StreamDescriptor().name("added_stream")));
     assertTrue(
         resultList.stream().anyMatch(
-            transformType -> transformType == TransformTypeEnum.UPDATE_STREAM));
+            streamDescriptor -> streamDescriptor == new StreamDescriptor().name("updated_stream")));
     assertTrue(
         resultList.stream().anyMatch(
-            transformType -> transformType == TransformTypeEnum.REMOVE_STREAM));
+            streamDescriptor -> streamDescriptor == new StreamDescriptor().name("removed_stream")));
   }
 
 }

--- a/airbyte-server/src/test/java/io/airbyte/server/handlers/WebBackendConnectionsHandlerTest.java
+++ b/airbyte-server/src/test/java/io/airbyte/server/handlers/WebBackendConnectionsHandlerTest.java
@@ -574,11 +574,7 @@ class WebBackendConnectionsHandlerTest {
     when(configRepository.getConfiguredCatalogForConnection(expected.getConnectionId()))
         .thenReturn(ConnectionHelpers.generateBasicConfiguredAirbyteCatalog());
 
-    final StreamDescriptor streamDescriptorAdd = new StreamDescriptor().name("addStream");
-    final StreamTransform streamTransformAdd =
-        new StreamTransform().streamDescriptor(streamDescriptorAdd).transformType(TransformTypeEnum.ADD_STREAM);
-
-    final CatalogDiff catalogDiff = new CatalogDiff().transforms(List.of(streamTransformAdd));
+    final CatalogDiff catalogDiff = new CatalogDiff().transforms(List.of());
     when(connectionsHandler.getDiff(any(), any())).thenReturn(catalogDiff);
     final ConnectionIdRequestBody connectionIdRequestBody = new ConnectionIdRequestBody().connectionId(expected.getConnectionId());
     when(stateHandler.getState(connectionIdRequestBody)).thenReturn(new ConnectionState().stateType(ConnectionStateType.LEGACY));
@@ -602,6 +598,7 @@ class WebBackendConnectionsHandlerTest {
             .schedule(expected.getSchedule()));
     when(operationsHandler.updateOperation(operationUpdate)).thenReturn(new OperationRead().operationId(operationUpdate.getOperationId()));
     when(operationsHandler.listOperationsForConnection(any())).thenReturn(operationReadList);
+
     final WebBackendConnectionRead actualConnectionRead = wbHandler.webBackendUpdateConnection(updateBody);
 
     assertEquals(connectionRead.getOperationIds(), actualConnectionRead.getOperationIds());

--- a/airbyte-server/src/test/java/io/airbyte/server/handlers/WebBackendConnectionsHandlerTest.java
+++ b/airbyte-server/src/test/java/io/airbyte/server/handlers/WebBackendConnectionsHandlerTest.java
@@ -429,6 +429,7 @@ class WebBackendConnectionsHandlerTest {
     assertEquals(expected, actual);
   }
 
+  // TODO: remove withRefreshedCatalog param from this test when param is removed from code
   @Test
   public void testToConnectionUpdate() throws IOException {
     final SourceConnection source = SourceHelpers.generateSource(UUID.randomUUID());
@@ -523,12 +524,6 @@ class WebBackendConnectionsHandlerTest {
         .syncCatalog(expected.getSyncCatalog())
         .sourceCatalogId(expected.getCatalogId());
 
-    when(configRepository.getConfiguredCatalogForConnection(expected.getConnectionId()))
-        .thenReturn(ConnectionHelpers.generateBasicConfiguredAirbyteCatalog());
-
-    final CatalogDiff catalogDiff = new CatalogDiff().transforms(List.of());
-    when(connectionsHandler.getDiff(any(), any())).thenReturn(catalogDiff);
-
     when(connectionsHandler.getConnection(expected.getConnectionId())).thenReturn(
         new ConnectionRead().connectionId(expected.getConnectionId()));
     when(connectionsHandler.updateConnection(any())).thenReturn(
@@ -545,7 +540,6 @@ class WebBackendConnectionsHandlerTest {
             .schedule(expected.getSchedule()));
     when(operationsHandler.listOperationsForConnection(any())).thenReturn(operationReadList);
     final ConnectionIdRequestBody connectionId = new ConnectionIdRequestBody().connectionId(connectionRead.getConnectionId());
-    when(stateHandler.getState(connectionId)).thenReturn(new ConnectionState().stateType(ConnectionStateType.LEGACY));
 
     final WebBackendConnectionRead connectionRead = wbHandler.webBackendUpdateConnection(updateBody);
 
@@ -557,6 +551,48 @@ class WebBackendConnectionsHandlerTest {
 
   @Test
   void testUpdateConnectionWithOperations() throws JsonValidationException, ConfigNotFoundException, IOException {
+    final WebBackendOperationCreateOrUpdate operationCreateOrUpdate = new WebBackendOperationCreateOrUpdate()
+        .name("Test Operation")
+        .operationId(connectionRead.getOperationIds().get(0));
+    final OperationUpdate operationUpdate = WebBackendConnectionsHandler.toOperationUpdate(operationCreateOrUpdate);
+    final WebBackendConnectionUpdate updateBody = new WebBackendConnectionUpdate()
+        .namespaceDefinition(expected.getNamespaceDefinition())
+        .namespaceFormat(expected.getNamespaceFormat())
+        .prefix(expected.getPrefix())
+        .connectionId(expected.getConnectionId())
+        .schedule(expected.getSchedule())
+        .status(expected.getStatus())
+        .syncCatalog(expected.getSyncCatalog())
+        .operations(List.of(operationCreateOrUpdate));
+
+    when(connectionsHandler.getConnection(expected.getConnectionId())).thenReturn(
+        new ConnectionRead()
+            .connectionId(expected.getConnectionId())
+            .operationIds(connectionRead.getOperationIds()));
+    when(connectionsHandler.updateConnection(any())).thenReturn(
+        new ConnectionRead()
+            .connectionId(expected.getConnectionId())
+            .sourceId(expected.getSourceId())
+            .destinationId(expected.getDestinationId())
+            .operationIds(connectionRead.getOperationIds())
+            .name(expected.getName())
+            .namespaceDefinition(expected.getNamespaceDefinition())
+            .namespaceFormat(expected.getNamespaceFormat())
+            .prefix(expected.getPrefix())
+            .syncCatalog(expected.getSyncCatalog())
+            .status(expected.getStatus())
+            .schedule(expected.getSchedule()));
+    when(operationsHandler.updateOperation(operationUpdate)).thenReturn(new OperationRead().operationId(operationUpdate.getOperationId()));
+    when(operationsHandler.listOperationsForConnection(any())).thenReturn(operationReadList);
+
+    final WebBackendConnectionRead actualConnectionRead = wbHandler.webBackendUpdateConnection(updateBody);
+
+    assertEquals(connectionRead.getOperationIds(), actualConnectionRead.getOperationIds());
+    verify(operationsHandler, times(1)).updateOperation(operationUpdate);
+  }
+
+  @Test
+  void testUpdateConnectionWithOperationsNew() throws JsonValidationException, ConfigNotFoundException, IOException {
     final WebBackendOperationCreateOrUpdate operationCreateOrUpdate = new WebBackendOperationCreateOrUpdate()
         .name("Test Operation")
         .operationId(connectionRead.getOperationIds().get(0));
@@ -599,10 +635,60 @@ class WebBackendConnectionsHandlerTest {
     when(operationsHandler.updateOperation(operationUpdate)).thenReturn(new OperationRead().operationId(operationUpdate.getOperationId()));
     when(operationsHandler.listOperationsForConnection(any())).thenReturn(operationReadList);
 
-    final WebBackendConnectionRead actualConnectionRead = wbHandler.webBackendUpdateConnection(updateBody);
+    final WebBackendConnectionRead actualConnectionRead = wbHandler.webBackendUpdateConnectionNew(updateBody);
 
     assertEquals(connectionRead.getOperationIds(), actualConnectionRead.getOperationIds());
     verify(operationsHandler, times(1)).updateOperation(operationUpdate);
+  }
+
+  // TODO: remove in favor of test below when update endpoint is switched to new endpoint
+  @Test
+  void testUpdateConnectionWithUpdatedSchema() throws JsonValidationException, ConfigNotFoundException, IOException {
+    final WebBackendConnectionUpdate updateBody = new WebBackendConnectionUpdate()
+        .namespaceDefinition(expected.getNamespaceDefinition())
+        .namespaceFormat(expected.getNamespaceFormat())
+        .prefix(expected.getPrefix())
+        .connectionId(expected.getConnectionId())
+        .schedule(expected.getSchedule())
+        .status(expected.getStatus())
+        .syncCatalog(expectedWithNewSchema.getSyncCatalog())
+        .withRefreshedCatalog(true);
+
+    when(operationsHandler.listOperationsForConnection(any())).thenReturn(operationReadList);
+    when(connectionsHandler.getConnection(expected.getConnectionId())).thenReturn(
+        new ConnectionRead().connectionId(expected.getConnectionId()));
+    final ConnectionRead connectionRead = new ConnectionRead()
+        .connectionId(expected.getConnectionId())
+        .sourceId(expected.getSourceId())
+        .destinationId(expected.getDestinationId())
+        .name(expected.getName())
+        .namespaceDefinition(expected.getNamespaceDefinition())
+        .namespaceFormat(expected.getNamespaceFormat())
+        .prefix(expected.getPrefix())
+        .syncCatalog(expectedWithNewSchema.getSyncCatalog())
+        .status(expected.getStatus())
+        .schedule(expected.getSchedule());
+    when(connectionsHandler.updateConnection(any())).thenReturn(connectionRead);
+    when(connectionsHandler.getConnection(expected.getConnectionId())).thenReturn(connectionRead);
+
+    final List<io.airbyte.protocol.models.StreamDescriptor> connectionStreams = List.of(ConnectionHelpers.STREAM_DESCRIPTOR);
+    when(configRepository.getAllStreamsForConnection(expected.getConnectionId())).thenReturn(connectionStreams);
+
+    final ManualOperationResult successfulResult = ManualOperationResult.builder().jobId(Optional.empty()).failingReason(Optional.empty()).build();
+    when(eventRunner.synchronousResetConnection(any(), any())).thenReturn(successfulResult);
+    when(eventRunner.startNewManualSync(any())).thenReturn(successfulResult);
+
+    final WebBackendConnectionRead result = wbHandler.webBackendUpdateConnection(updateBody);
+
+    assertEquals(expectedWithNewSchema.getSyncCatalog(), result.getSyncCatalog());
+
+    final ConnectionIdRequestBody connectionId = new ConnectionIdRequestBody().connectionId(result.getConnectionId());
+    verify(schedulerHandler, times(0)).resetConnection(connectionId);
+    verify(schedulerHandler, times(0)).syncConnection(connectionId);
+    verify(connectionsHandler, times(1)).updateConnection(any());
+    final InOrder orderVerifier = inOrder(eventRunner);
+    orderVerifier.verify(eventRunner, times(1)).synchronousResetConnection(connectionId.getConnectionId(), connectionStreams);
+    orderVerifier.verify(eventRunner, times(1)).startNewManualSync(connectionId.getConnectionId());
   }
 
   @Test
@@ -653,7 +739,7 @@ class WebBackendConnectionsHandlerTest {
     when(eventRunner.synchronousResetConnection(any(), any())).thenReturn(successfulResult);
     when(eventRunner.startNewManualSync(any())).thenReturn(successfulResult);
 
-    final WebBackendConnectionRead result = wbHandler.webBackendUpdateConnection(updateBody);
+    final WebBackendConnectionRead result = wbHandler.webBackendUpdateConnectionNew(updateBody);
 
     assertEquals(expectedWithNewSchema.getSyncCatalog(), result.getSyncCatalog());
 
@@ -718,7 +804,7 @@ class WebBackendConnectionsHandlerTest {
     when(eventRunner.synchronousResetConnection(any(), any())).thenReturn(successfulResult);
     when(eventRunner.startNewManualSync(any())).thenReturn(successfulResult);
 
-    final WebBackendConnectionRead result = wbHandler.webBackendUpdateConnection(updateBody);
+    final WebBackendConnectionRead result = wbHandler.webBackendUpdateConnectionNew(updateBody);
 
     assertEquals(expectedWithNewSchema.getSyncCatalog(), result.getSyncCatalog());
 
@@ -771,7 +857,7 @@ class WebBackendConnectionsHandlerTest {
     when(connectionsHandler.updateConnection(any())).thenReturn(connectionRead);
     when(connectionsHandler.getConnection(expected.getConnectionId())).thenReturn(connectionRead);
 
-    final WebBackendConnectionRead result = wbHandler.webBackendUpdateConnection(updateBody);
+    final WebBackendConnectionRead result = wbHandler.webBackendUpdateConnectionNew(updateBody);
 
     assertEquals(expectedWithNewSchema.getSyncCatalog(), result.getSyncCatalog());
 

--- a/tools/openapi2jsonschema/examples/airbyte.local/openapi.yaml
+++ b/tools/openapi2jsonschema/examples/airbyte.local/openapi.yaml
@@ -1262,7 +1262,7 @@ paths:
         - web_backend
   /v1/web_backend/connections/updateNew:
     post:
-      operationId: webBackendUpdateConnection
+      operationId: webBackendUpdateConnectionNew
       requestBody:
         content:
           application/json:

--- a/tools/openapi2jsonschema/examples/airbyte.local/openapi.yaml
+++ b/tools/openapi2jsonschema/examples/airbyte.local/openapi.yaml
@@ -1260,6 +1260,27 @@ paths:
       summary: Update a connection
       tags:
         - web_backend
+  /v1/web_backend/connections/updateNew:
+    post:
+      operationId: webBackendUpdateConnection
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: "#/components/schemas/WebBackendConnectionUpdate"
+        required: true
+      responses:
+        "200":
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/WebBackendConnectionRead"
+          description: Successful operation
+        "422":
+          $ref: "#/components/responses/InvalidInputResponse"
+      summary: Update a connection
+      tags:
+        - web_backend
   /v1/web_backend/destinations/recreate:
     post:
       operationId: webBackendRecreateDestination
@@ -2740,6 +2761,8 @@ components:
         syncCatalog:
           $ref: "#/components/schemas/AirbyteCatalog"
         withRefreshedCatalog:
+          type: boolean
+        skipReset:
           type: boolean
       required:
         - connectionId


### PR DESCRIPTION
Instead of relying on a flag from the front end, the backend will now decide whether a connection needs a reset or not, so this PR removes the use of the withRefreshedCatalog param in the updateConnection endpoint.

The endpoint:
1. calculates a diff between the existing configured catalog and the catalog sent by the front end
2. determines which streams need to be reset based on the diff between the two catalogs
3. if there are streams to reset it checks the state of the connection
4.     if the state is LEGACY, GLOBAL, or NOT_SET, it submits a reset for all streams
5.     if the state is STREAM, it submits a reset just for the individual streams that need to be reset
