### PR TITLE
Allow transition from INCOMPLETE to INCOMPLETE

### DIFF
--- a/airbyte-scheduler/scheduler-models/src/main/java/io/airbyte/scheduler/models/JobStatus.java
+++ b/airbyte-scheduler/scheduler-models/src/main/java/io/airbyte/scheduler/models/JobStatus.java
@@ -23,7 +23,7 @@ public enum JobStatus {
   public static final Map<JobStatus, Set<JobStatus>> VALID_STATUS_CHANGES = Map.of(
       PENDING, Set.of(RUNNING, FAILED, CANCELLED),
       RUNNING, Set.of(INCOMPLETE, SUCCEEDED, FAILED, CANCELLED),
-      INCOMPLETE, Set.of(PENDING, RUNNING, FAILED, CANCELLED),
+      INCOMPLETE, Set.of(PENDING, RUNNING, FAILED, CANCELLED, INCOMPLETE),
       SUCCEEDED, Set.of(),
       FAILED, Set.of(),
       CANCELLED, Set.of());


### PR DESCRIPTION
It's possible for a job to transition from INCOMPLETE to INCOMPLETE if multiple attempts fail, so update VALID_JOB_STATUSES to allow this transition.