### PR TITLE
Use single state aggregator when per-stream feature flag is off

### DIFF
--- a/airbyte-test-utils/src/main/java/io/airbyte/test/utils/AirbyteAcceptanceTestHarness.java
+++ b/airbyte-test-utils/src/main/java/io/airbyte/test/utils/AirbyteAcceptanceTestHarness.java
@@ -130,6 +130,10 @@ public class AirbyteAcceptanceTestHarness {
   private static final String COLUMN_NAME_DATA = "_airbyte_data";
   private static final String SOURCE_USERNAME = "sourceusername";
   public static final String SOURCE_PASSWORD = "hunter2";
+  public static final String PUBLIC_SCHEMA_NAME = "public";
+  public static final String STAGING_SCHEMA_NAME = "staging";
+  public static final String COOL_EMPLOYEES_TABLE_NAME = "cool_employees";
+  public static final String AWESOME_PEOPLE_TABLE_NAME = "awesome_people";
 
   private static boolean isKube;
   private static boolean isMinikube;

--- a/airbyte-tests/src/acceptanceTests/java/io/airbyte/test/acceptance/BasicAcceptanceTests.java
+++ b/airbyte-tests/src/acceptanceTests/java/io/airbyte/test/acceptance/BasicAcceptanceTests.java
@@ -5,8 +5,12 @@
 package io.airbyte.test.acceptance;
 
 import static io.airbyte.api.client.model.generated.ConnectionSchedule.TimeUnitEnum.MINUTES;
+import static io.airbyte.test.utils.AirbyteAcceptanceTestHarness.AWESOME_PEOPLE_TABLE_NAME;
 import static io.airbyte.test.utils.AirbyteAcceptanceTestHarness.COLUMN_ID;
 import static io.airbyte.test.utils.AirbyteAcceptanceTestHarness.COLUMN_NAME;
+import static io.airbyte.test.utils.AirbyteAcceptanceTestHarness.COOL_EMPLOYEES_TABLE_NAME;
+import static io.airbyte.test.utils.AirbyteAcceptanceTestHarness.PUBLIC_SCHEMA_NAME;
+import static io.airbyte.test.utils.AirbyteAcceptanceTestHarness.STAGING_SCHEMA_NAME;
 import static io.airbyte.test.utils.AirbyteAcceptanceTestHarness.STREAM_NAME;
 import static io.airbyte.test.utils.AirbyteAcceptanceTestHarness.waitForSuccessfulJob;
 import static io.airbyte.test.utils.AirbyteAcceptanceTestHarness.waitWhileJobHasStatus;
@@ -851,6 +855,99 @@ public class BasicAcceptanceTests {
     assertEquals(0, result.get().getAttempt().getRecordsSynced());
     assertEquals(0, result.get().getAttempt().getTotalStats().getRecordsEmitted());
     testHarness.assertSourceAndDestinationDbInSync(WITHOUT_SCD_TABLE);
+  }
+
+  @Test
+  public void testIncrementalSyncMultipleStreams() throws Exception {
+    LOGGER.info("Starting testIncrementalSyncMultipleStreams()");
+
+    PostgreSQLContainerHelper.runSqlScript(MountableFile.forClasspathResource("postgres_second_schema_multiple_tables.sql"), sourcePsql);
+
+    final String connectionName = "test-connection";
+    final UUID sourceId = testHarness.createPostgresSource().getSourceId();
+    final UUID destinationId = testHarness.createDestination().getDestinationId();
+    final UUID operationId = testHarness.createOperation().getOperationId();
+    final AirbyteCatalog catalog = testHarness.discoverSourceSchema(sourceId);
+
+    for (AirbyteStreamAndConfiguration streamAndConfig : catalog.getStreams()) {
+      final AirbyteStream stream = streamAndConfig.getStream();
+      assertEquals(Lists.newArrayList(SyncMode.FULL_REFRESH, SyncMode.INCREMENTAL), stream.getSupportedSyncModes());
+      // instead of assertFalse to avoid NPE from unboxed.
+      assertNull(stream.getSourceDefinedCursor());
+      assertTrue(stream.getDefaultCursorField().isEmpty());
+      assertTrue(stream.getSourceDefinedPrimaryKey().isEmpty());
+    }
+
+    final SyncMode syncMode = SyncMode.INCREMENTAL;
+    final DestinationSyncMode destinationSyncMode = DestinationSyncMode.APPEND;
+    catalog.getStreams().forEach(s -> s.getConfig()
+        .syncMode(syncMode)
+        .cursorField(List.of(COLUMN_ID))
+        .destinationSyncMode(destinationSyncMode));
+    final UUID connectionId =
+        testHarness.createConnection(connectionName, sourceId, destinationId, List.of(operationId), catalog, null).getConnectionId();
+    LOGGER.info("Beginning testIncrementalSync() sync 1");
+
+    final JobInfoRead connectionSyncRead1 = apiClient.getConnectionApi()
+        .syncConnection(new ConnectionIdRequestBody().connectionId(connectionId));
+    waitForSuccessfulJob(apiClient.getJobsApi(), connectionSyncRead1.getJob());
+    LOGGER.info("state after sync 1: {}", apiClient.getConnectionApi().getState(new ConnectionIdRequestBody().connectionId(connectionId)));
+
+    testHarness.assertSourceAndDestinationDbInSync(WITHOUT_SCD_TABLE);
+
+    // add new records and run again.
+    final Database source = testHarness.getSourceDatabase();
+    // get contents of source before mutating records.
+    final List<JsonNode> expectedRecordsIdAndName = testHarness.retrieveSourceRecords(source, STREAM_NAME);
+    final List<JsonNode> expectedRecordsCoolEmployees =
+        testHarness.retrieveSourceRecords(source, STAGING_SCHEMA_NAME + "." + COOL_EMPLOYEES_TABLE_NAME);
+    final List<JsonNode> expectedRecordsAwesomePeople =
+        testHarness.retrieveSourceRecords(source, STAGING_SCHEMA_NAME + "." + AWESOME_PEOPLE_TABLE_NAME);
+    expectedRecordsIdAndName.add(Jsons.jsonNode(ImmutableMap.builder().put(COLUMN_ID, 6).put(COLUMN_NAME, "geralt").build()));
+    expectedRecordsCoolEmployees.add(Jsons.jsonNode(ImmutableMap.builder().put(COLUMN_ID, 6).put(COLUMN_NAME, "geralt").build()));
+    expectedRecordsAwesomePeople.add(Jsons.jsonNode(ImmutableMap.builder().put(COLUMN_ID, 3).put(COLUMN_NAME, "geralt").build()));
+    // add a new record to each table
+    source.query(ctx -> ctx.execute("INSERT INTO id_and_name(id, name) VALUES(6, 'geralt')"));
+    source.query(ctx -> ctx.execute("INSERT INTO staging.cool_employees(id, name) VALUES(6, 'geralt')"));
+    source.query(ctx -> ctx.execute("INSERT INTO staging.awesome_people(id, name) VALUES(3, 'geralt')"));
+    // mutate a record that was already synced with out updating its cursor value. if we are actually
+    // full refreshing, this record will appear in the output and cause the test to fail. if we are,
+    // correctly, doing incremental, we will not find this value in the destination.
+    source.query(ctx -> ctx.execute("UPDATE id_and_name SET name='yennefer' WHERE id=2"));
+    source.query(ctx -> ctx.execute("UPDATE staging.cool_employees SET name='yennefer' WHERE id=2"));
+    source.query(ctx -> ctx.execute("UPDATE staging.awesome_people SET name='yennefer' WHERE id=2"));
+
+    LOGGER.info("Starting testIncrementalSync() sync 2");
+    final JobInfoRead connectionSyncRead2 = apiClient.getConnectionApi()
+        .syncConnection(new ConnectionIdRequestBody().connectionId(connectionId));
+    waitForSuccessfulJob(apiClient.getJobsApi(), connectionSyncRead2.getJob());
+    LOGGER.info("state after sync 2: {}", apiClient.getConnectionApi().getState(new ConnectionIdRequestBody().connectionId(connectionId)));
+
+    testHarness.assertRawDestinationContains(expectedRecordsIdAndName, new SchemaTableNamePair(PUBLIC_SCHEMA_NAME, STREAM_NAME));
+    testHarness.assertRawDestinationContains(expectedRecordsCoolEmployees, new SchemaTableNamePair(STAGING_SCHEMA_NAME, COOL_EMPLOYEES_TABLE_NAME));
+    testHarness.assertRawDestinationContains(expectedRecordsAwesomePeople, new SchemaTableNamePair(STAGING_SCHEMA_NAME, AWESOME_PEOPLE_TABLE_NAME));
+
+    // reset back to no data.
+
+    LOGGER.info("Starting testIncrementalSync() reset");
+    final JobInfoRead jobInfoRead = apiClient.getConnectionApi().resetConnection(new ConnectionIdRequestBody().connectionId(connectionId));
+    waitWhileJobHasStatus(apiClient.getJobsApi(), jobInfoRead.getJob(),
+        Sets.newHashSet(JobStatus.PENDING, JobStatus.RUNNING, JobStatus.INCOMPLETE, JobStatus.FAILED));
+
+    LOGGER.info("state after reset: {}", apiClient.getConnectionApi().getState(new ConnectionIdRequestBody().connectionId(connectionId)));
+
+    testHarness.assertRawDestinationContains(Collections.emptyList(), new SchemaTableNamePair("public",
+        STREAM_NAME));
+
+    // sync one more time. verify it is the equivalent of a full refresh.
+    LOGGER.info("Starting testIncrementalSync() sync 3");
+    final JobInfoRead connectionSyncRead3 =
+        apiClient.getConnectionApi().syncConnection(new ConnectionIdRequestBody().connectionId(connectionId));
+    waitForSuccessfulJob(apiClient.getJobsApi(), connectionSyncRead3.getJob());
+    LOGGER.info("state after sync 3: {}", apiClient.getConnectionApi().getState(new ConnectionIdRequestBody().connectionId(connectionId)));
+
+    testHarness.assertSourceAndDestinationDbInSync(WITHOUT_SCD_TABLE);
+
   }
 
   // This test is disabled because it takes a couple of minutes to run, as it is testing timeouts.

--- a/airbyte-workers/src/main/java/io/airbyte/workers/internal/AirbyteMessageTracker.java
+++ b/airbyte-workers/src/main/java/io/airbyte/workers/internal/AirbyteMessageTracker.java
@@ -10,6 +10,7 @@ import com.google.common.collect.BiMap;
 import com.google.common.collect.HashBiMap;
 import com.google.common.hash.HashFunction;
 import com.google.common.hash.Hashing;
+import io.airbyte.commons.features.EnvVariableFeatureFlags;
 import io.airbyte.commons.json.Jsons;
 import io.airbyte.config.FailureReason;
 import io.airbyte.config.State;
@@ -62,7 +63,8 @@ public class AirbyteMessageTracker implements MessageTracker {
   }
 
   public AirbyteMessageTracker() {
-    this(new StateDeltaTracker(STATE_DELTA_TRACKER_MEMORY_LIMIT_BYTES), new DefaultStateAggregator());
+    this(new StateDeltaTracker(STATE_DELTA_TRACKER_MEMORY_LIMIT_BYTES),
+        new DefaultStateAggregator(new EnvVariableFeatureFlags().useStreamCapableState()));
   }
 
   @VisibleForTesting

--- a/airbyte-workers/src/main/java/io/airbyte/workers/internal/state_aggregator/DefaultStateAggregator.java
+++ b/airbyte-workers/src/main/java/io/airbyte/workers/internal/state_aggregator/DefaultStateAggregator.java
@@ -14,7 +14,7 @@ public class DefaultStateAggregator implements StateAggregator {
   private AirbyteStateType stateType = null;
   private final StateAggregator streamStateAggregator = new StreamStateAggregator();
   private final StateAggregator singleStateAggregator = new SingleStateAggregator();
-  private boolean useStreamCapableState;
+  private final boolean useStreamCapableState;
 
   public DefaultStateAggregator(boolean useStreamCapableState) {
     this.useStreamCapableState = useStreamCapableState;

--- a/airbyte-workers/src/main/java/io/airbyte/workers/internal/state_aggregator/DefaultStateAggregator.java
+++ b/airbyte-workers/src/main/java/io/airbyte/workers/internal/state_aggregator/DefaultStateAggregator.java
@@ -14,6 +14,11 @@ public class DefaultStateAggregator implements StateAggregator {
   private AirbyteStateType stateType = null;
   private final StateAggregator streamStateAggregator = new StreamStateAggregator();
   private final StateAggregator singleStateAggregator = new SingleStateAggregator();
+  private boolean useStreamCapableState;
+
+  public DefaultStateAggregator(boolean useStreamCapableState) {
+    this.useStreamCapableState = useStreamCapableState;
+  }
 
   @Override
   public void ingest(final AirbyteStateMessage stateMessage) {
@@ -31,10 +36,14 @@ public class DefaultStateAggregator implements StateAggregator {
    * Return the state aggregator that match the state type.
    */
   private StateAggregator getStateAggregator() {
-    return switch (stateType) {
-      case STREAM -> streamStateAggregator;
-      case GLOBAL, LEGACY -> singleStateAggregator;
-    };
+    if (!useStreamCapableState) {
+      return singleStateAggregator;
+    } else {
+      return switch (stateType) {
+        case STREAM -> streamStateAggregator;
+        case GLOBAL, LEGACY -> singleStateAggregator;
+      };
+    }
   }
 
   /**

--- a/airbyte-workers/src/test/java/io/airbyte/workers/internal/state_aggregator/StateAggregatorTest.java
+++ b/airbyte-workers/src/test/java/io/airbyte/workers/internal/state_aggregator/StateAggregatorTest.java
@@ -28,10 +28,12 @@ import org.junit.jupiter.params.provider.EnumSource;
 public class StateAggregatorTest {
 
   StateAggregator stateAggregator;
+  boolean USE_STREAM_CAPABLE_STATE = true;
+  boolean DONT_USE_STREAM_CAPABLE_STATE = false;
 
   @BeforeEach
   public void init() {
-    stateAggregator = new DefaultStateAggregator();
+    stateAggregator = new DefaultStateAggregator(DONT_USE_STREAM_CAPABLE_STATE);
   }
 
   @ParameterizedTest
@@ -99,10 +101,31 @@ public class StateAggregatorTest {
   }
 
   @Test
-  public void testStreamState() {
+  public void testStreamStateWithFeatureFlagOff() {
     final AirbyteStateMessage state1 = getStreamMessage("a", 1);
     final AirbyteStateMessage state2 = getStreamMessage("b", 2);
     final AirbyteStateMessage state3 = getStreamMessage("b", 3);
+
+    stateAggregator.ingest(state1);
+    Assertions.assertThat(stateAggregator.getAggregated()).isEqualTo(new State()
+        .withState(Jsons.jsonNode(List.of(state1))));
+
+    stateAggregator.ingest(state2);
+    Assertions.assertThat(stateAggregator.getAggregated()).isEqualTo(new State()
+        .withState(Jsons.jsonNode(List.of(state2))));
+
+    stateAggregator.ingest(state3);
+    Assertions.assertThat(stateAggregator.getAggregated()).isEqualTo(new State()
+        .withState(Jsons.jsonNode(List.of(state3))));
+  }
+
+  @Test
+  public void testStreamStateWithFeatureFlagOn() {
+    final AirbyteStateMessage state1 = getStreamMessage("a", 1);
+    final AirbyteStateMessage state2 = getStreamMessage("b", 2);
+    final AirbyteStateMessage state3 = getStreamMessage("b", 3);
+
+    stateAggregator = new DefaultStateAggregator(USE_STREAM_CAPABLE_STATE);
 
     stateAggregator.ingest(state1);
     Assertions.assertThat(stateAggregator.getAggregated()).isEqualTo(new State()


### PR DESCRIPTION
## What
Relates to https://github.com/airbytehq/oncall/issues/316

A bug was introduced by https://github.com/airbytehq/airbyte/pull/14364 in which AirbyteStateMessages were being [written to a map of stream descriptor to state message](https://github.com/airbytehq/airbyte/blob/74fe26058f4e00a9391446dfc7803a7f9e6eccdd/airbyte-workers/src/main/java/io/airbyte/workers/internal/state_aggregator/StreamStateAggregator.java#L20) by the `StreamStateAggregator`, then all values in the map were being serialized into a State blob [here](https://github.com/airbytehq/airbyte/blob/74fe26058f4e00a9391446dfc7803a7f9e6eccdd/airbyte-workers/src/main/java/io/airbyte/workers/internal/state_aggregator/StreamStateAggregator.java#L28). Then, in StateMessageHelper, we were [retrieving the last state message in that blob](https://github.com/airbytehq/airbyte/blob/74fe26058f4e00a9391446dfc7803a7f9e6eccdd/airbyte-config/config-models/src/main/java/io/airbyte/config/helpers/StateMessageHelper.java#L124). 

The issue is that these messages do not have a defined order, since they are just being retrieved from the `map.values()` call, so it is possible that `Iterables.getLast()` does not actually retrieve the most up-to-date state message from that list. 

## How
This PR fixes the issue by forcing the StateAggregator to use the SingleStateAggregator when the per-stream feature flag is off. This way, we will only be keeping track of the last state message from the source/dest in the AirbyteMessageTracker, so when we get to the StateMessageHelper, there is only the single state message in the State blob, so Iterables.getLast() will retrieve that one up-to-date state and persist that to the db.

This PR also adds an acceptance test for an incremental sync with multiple streams as a sanity check that this fix is working as expected.