### PR TITLE
Fix empty airbyte source check

### DIFF
--- a/airbyte-workers/src/main/java/io/airbyte/workers/internal/EmptyAirbyteSource.java
+++ b/airbyte-workers/src/main/java/io/airbyte/workers/internal/EmptyAirbyteSource.java
@@ -180,9 +180,8 @@ public class EmptyAirbyteSource implements AirbyteSource {
             .withName(configuredAirbyteStream.getStream().getName())
             .withNamespace(configuredAirbyteStream.getStream().getNamespace()))
         .collect(Collectors.toSet());
-    final Set<StreamDescriptor> configStreamDescriptors = new HashSet<>(streamsToReset);
-
-    return catalogStreamDescriptors.equals(configStreamDescriptors);
+    final Set<StreamDescriptor> streamsToResetDescriptors = new HashSet<>(streamsToReset);
+    return streamsToResetDescriptors.containsAll(catalogStreamDescriptors);
   }
 
   private AirbyteMessage getNullStreamStateMessage(final StreamDescriptor streamsToReset) {

--- a/airbyte-workers/src/main/java/io/airbyte/workers/internal/EmptyAirbyteSource.java
+++ b/airbyte-workers/src/main/java/io/airbyte/workers/internal/EmptyAirbyteSource.java
@@ -88,7 +88,7 @@ public class EmptyAirbyteSource implements AirbyteSource {
 
           if (stateWrapper.isPresent() &&
               stateWrapper.get().getStateType() == StateType.LEGACY &&
-              !isResetAllStreamsInCatalog(workerSourceConfig)) {
+              !resettingAllCatalogStreams(workerSourceConfig)) {
             log.error("The state a legacy one but we are trying to do a partial update, this is not supported.");
             throw new IllegalStateException("Try to perform a partial reset on a legacy state");
           }
@@ -174,7 +174,7 @@ public class EmptyAirbyteSource implements AirbyteSource {
     }
   }
 
-  private boolean isResetAllStreamsInCatalog(final WorkerSourceConfig sourceConfig) {
+  private boolean resettingAllCatalogStreams(final WorkerSourceConfig sourceConfig) {
     final Set<StreamDescriptor> catalogStreamDescriptors = sourceConfig.getCatalog().getStreams().stream().map(
         configuredAirbyteStream -> new StreamDescriptor()
             .withName(configuredAirbyteStream.getStream().getName())


### PR DESCRIPTION
We are doing a check for resets with LEGACY state to ensure that all streams in a Catalog are being reset. The existing check just checked that streams_to_reset == streams_in_catalog. But since it's ok for streams that are NOT in the catalog to be reset, what we actually want is streams_to_reset.containsAll(streams_in_catalog). 

This PR updates the logic, renames a few things, and adds an extra test for this case.