### PR TITLE
feat: move serviceType selection out of serviceForm

### DIFF
--- a/airbyte-webapp/src/components/SelectServiceType/SelectServiceType.tsx
+++ b/airbyte-webapp/src/components/SelectServiceType/SelectServiceType.tsx
@@ -1,0 +1,38 @@
+import { useState } from "react";
+import { useToggle } from "react-use";
+
+import { ServiceTypeDropdown } from "components/ServiceTypeDropdown/ServiceTypeDropdown";
+
+import RequestConnectorModal from "views/Connector/RequestConnectorModal";
+
+import { ServiceTypeControlProps } from "../ServiceTypeDropdown/ServiceTypeDropdown";
+
+const SelectServiceType: React.FC<Omit<ServiceTypeControlProps, "onOpenRequestConnectorModal">> = ({
+  formType,
+  ...restProps
+}) => {
+  const [isOpenRequestModal, toggleOpenRequestModal] = useToggle(false);
+  const [initialRequestName, setInitialRequestName] = useState<string>();
+
+  return (
+    <>
+      <ServiceTypeDropdown
+        formType={formType}
+        onOpenRequestConnectorModal={(name) => {
+          setInitialRequestName(name);
+          toggleOpenRequestModal();
+        }}
+        {...restProps}
+      />
+      {isOpenRequestModal && (
+        <RequestConnectorModal
+          connectorType="source"
+          initialName={initialRequestName}
+          onClose={toggleOpenRequestModal}
+        />
+      )}
+    </>
+  );
+};
+
+export { SelectServiceType };

--- a/airbyte-webapp/src/components/ServiceTypeDropdown/ServiceTypeDropdown.module.scss
+++ b/airbyte-webapp/src/components/ServiceTypeDropdown/ServiceTypeDropdown.module.scss
@@ -1,0 +1,64 @@
+@import "../../scss/variables";
+
+.buttonElement {
+  background: $grey-30;
+  padding: 6px 16px 8px;
+  width: 100%;
+  min-height: 34px;
+  border-top: 1px solid $grey-200;
+}
+
+.block {
+  cursor: pointer;
+  color: $dark-blue;
+
+  &:hover {
+    color: $blue;
+  }
+}
+
+.text {
+  display: flex;
+  flex-direction: row;
+  align-items: center;
+}
+
+.label {
+  margin-left: $spacing-l;
+  font-weight: 500;
+  font-size: 14px;
+  line-height: 17px;
+}
+
+.stage {
+  padding: 2px 6px;
+  height: 14px;
+  background: $grey-100;
+  border-radius: 25px;
+  text-transform: uppercase;
+  font-weight: 500;
+  font-size: 8px;
+  line-height: 10px;
+  color: $dark-blue;
+}
+
+.singleValueView {
+  display: flex;
+  flex-direction: row;
+  justify-content: left;
+  align-items: center;
+}
+
+.singleValueContent {
+  width: 100%;
+  padding-right: 38px;
+  display: flex;
+  flex-direction: row;
+  justify-content: space-between;
+  align-items: center;
+}
+
+.icon {
+  margin-right: 6px;
+  display: inline-block;
+}

--- a/airbyte-webapp/src/components/ServiceTypeDropdown/ServiceTypeDropdown.tsx
+++ b/airbyte-webapp/src/components/ServiceTypeDropdown/ServiceTypeDropdown.tsx
@@ -1,0 +1,214 @@
+import React, { useCallback, useEffect, useMemo } from "react";
+import { FormattedMessage, useIntl } from "react-intl";
+import { components } from "react-select";
+import { MenuListComponentProps } from "react-select/src/components/Menu";
+
+import { ControlLabels, DropDown, DropDownRow } from "components";
+import { IDataItem, IProps as OptionProps, OptionView } from "components/base/DropDown/components/Option";
+import { IProps as SingleValueProps } from "components/base/DropDown/components/SingleValue";
+import { ConnectorIcon } from "components/ConnectorIcon";
+import { GAIcon } from "components/icons/GAIcon";
+
+import { Connector, ConnectorDefinition } from "core/domain/connector";
+import { ReleaseStage } from "core/request/AirbyteClient";
+import { useAvailableConnectorDefinitions } from "hooks/domain/connector/useAvailableConnectorDefinitions";
+import { useAnalyticsService } from "hooks/services/Analytics";
+import { useExperiment } from "hooks/services/Experiment";
+import { useCurrentWorkspace } from "hooks/services/useWorkspace";
+import { naturalComparator } from "utils/objects";
+import { useDocumentationPanelContext } from "views/Connector/ConnectorDocumentationLayout/DocumentationPanelContext";
+
+import styles from "./ServiceTypeDropdown.module.scss";
+
+type MenuWithRequestButtonProps = MenuListComponentProps<IDataItem, false>;
+
+/**
+ * Returns the order for a specific release stage label. This will define
+ * in what order the different release stages are shown inside the select.
+ * They will be shown in an increasing order (i.e. 0 on top), unless not overwritten
+ * by ORDER_OVERWRITE above.
+ */
+function getOrderForReleaseStage(stage?: ReleaseStage): number {
+  switch (stage) {
+    case ReleaseStage.beta:
+      return 1;
+    case ReleaseStage.alpha:
+      return 2;
+    default:
+      return 0;
+  }
+}
+
+const ConnectorList: React.FC<MenuWithRequestButtonProps> = ({ children, ...props }) => (
+  <>
+    <components.MenuList {...props}>{children}</components.MenuList>
+    <div className={styles.buttonElement}>
+      <div
+        className={styles.block}
+        onClick={() => props.selectProps.selectProps.onOpenRequestConnectorModal(props.selectProps.inputValue)}
+      >
+        <FormattedMessage id="connector.requestConnectorBlock" />
+      </div>
+    </div>
+  </>
+);
+
+const StageLabel: React.FC<{ releaseStage?: ReleaseStage }> = ({ releaseStage }) => {
+  if (!releaseStage) {
+    return null;
+  }
+
+  if (releaseStage === ReleaseStage.generally_available) {
+    return <GAIcon />;
+  }
+
+  return (
+    <div className={styles.stage}>
+      <FormattedMessage id={`connector.releaseStage.${releaseStage}`} defaultMessage={releaseStage} />
+    </div>
+  );
+};
+
+const Option: React.FC<OptionProps> = (props) => {
+  return (
+    <components.Option {...props}>
+      <OptionView data-testid={props.data.label} isSelected={props.isSelected} isDisabled={props.isDisabled}>
+        <div className={styles.text}>
+          {props.data.img || null}
+          <div className={styles.label}>{props.label}</div>
+        </div>
+        <StageLabel releaseStage={props.data.releaseStage} />
+      </OptionView>
+    </components.Option>
+  );
+};
+
+const SingleValue: React.FC<SingleValueProps> = (props) => {
+  return (
+    <div className={styles.singleValueView}>
+      {props.data.img && <div className={styles.icon}>{props.data.img}</div>}
+      <div>
+        <div {...props} className={styles.singleValueContent}>
+          {props.data.label}
+          <StageLabel releaseStage={props.data.releaseStage} />
+        </div>
+      </div>
+    </div>
+  );
+};
+
+export interface ServiceTypeControlProps {
+  formType: "source" | "destination";
+  availableServices: ConnectorDefinition[];
+  isEditMode?: boolean;
+  documentationUrl?: string;
+  value?: string | null;
+  onChangeServiceType?: (id: string) => void;
+  onOpenRequestConnectorModal: (initialName: string) => void;
+  disabled?: boolean;
+}
+
+const ServiceTypeDropdown: React.FC<ServiceTypeControlProps> = ({
+  formType,
+  isEditMode,
+  onChangeServiceType,
+  availableServices,
+  documentationUrl,
+  onOpenRequestConnectorModal,
+  disabled,
+  value,
+}) => {
+  const { formatMessage } = useIntl();
+  const orderOverwrite = useExperiment("connector.orderOverwrite", {});
+  const analytics = useAnalyticsService();
+  const workspace = useCurrentWorkspace();
+  const availableConnectorDefinitions = useAvailableConnectorDefinitions(availableServices, workspace);
+  const sortedDropDownData = useMemo(
+    () =>
+      availableConnectorDefinitions
+        .map((item) => ({
+          label: item.name,
+          value: Connector.id(item),
+          img: <ConnectorIcon icon={item.icon} />,
+          releaseStage: item.releaseStage,
+        }))
+        .sort((a, b) => {
+          const priorityA = orderOverwrite[a.value] ?? 0;
+          const priorityB = orderOverwrite[b.value] ?? 0;
+          // If they have different priority use the higher priority first, otherwise use the label
+          if (priorityA !== priorityB) {
+            return priorityB - priorityA;
+          } else if (a.releaseStage !== b.releaseStage) {
+            return getOrderForReleaseStage(a.releaseStage) - getOrderForReleaseStage(b.releaseStage);
+          }
+          return naturalComparator(a.label, b.label);
+        }),
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+    [availableServices, orderOverwrite]
+  );
+
+  const { setDocumentationUrl } = useDocumentationPanelContext();
+
+  useEffect(() => setDocumentationUrl(documentationUrl ?? ""), [documentationUrl, setDocumentationUrl]);
+
+  const getNoOptionsMessage = useCallback(
+    ({ inputValue }: { inputValue: string }) => {
+      analytics.track(
+        formType === "source"
+          ? "Airbyte.UI.NewSource.NoMatchingConnector"
+          : "Airbyte.UI.NewDestination.NoMatchingConnector",
+        {
+          query: inputValue,
+        }
+      );
+      return formatMessage({ id: "form.noConnectorFound" });
+    },
+    [analytics, formType, formatMessage]
+  );
+
+  const handleSelect = useCallback(
+    (item: DropDownRow.IDataItem | null) => {
+      if (item) {
+        if (onChangeServiceType) {
+          onChangeServiceType(item.value);
+        }
+      }
+    },
+    [onChangeServiceType]
+  );
+
+  const onMenuOpen = () => {
+    const eventName =
+      formType === "source" ? "Airbyte.UI.NewSource.SelectionOpened" : "Airbyte.UI.NewDestination.SelectionOpened";
+    analytics.track(eventName, {});
+  };
+
+  return (
+    <ControlLabels
+      label={formatMessage({
+        id: `form.${formType}Type`,
+      })}
+    >
+      <DropDown
+        value={value}
+        components={{
+          MenuList: ConnectorList,
+          Option,
+          SingleValue,
+        }}
+        selectProps={{ onOpenRequestConnectorModal }}
+        isDisabled={isEditMode || disabled}
+        isSearchable
+        placeholder={formatMessage({
+          id: "form.selectConnector",
+        })}
+        options={sortedDropDownData}
+        onChange={handleSelect}
+        onMenuOpen={onMenuOpen}
+        noOptionsMessage={getNoOptionsMessage}
+      />
+    </ControlLabels>
+  );
+};
+
+export { ServiceTypeDropdown };

--- a/airbyte-webapp/src/components/TitleBlock/TitleBlock.module.scss
+++ b/airbyte-webapp/src/components/TitleBlock/TitleBlock.module.scss
@@ -1,0 +1,14 @@
+@import "../../scss/variables";
+
+.titleBlock {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+}
+
+.titleContainer {
+  font-size: 11px;
+  line-height: 13px;
+  color: $grey-400;
+  white-space: pre-line;
+}

--- a/airbyte-webapp/src/components/TitleBlock/TitleBlock.tsx
+++ b/airbyte-webapp/src/components/TitleBlock/TitleBlock.tsx
@@ -1,0 +1,23 @@
+import React from "react";
+
+import { H5 } from "components";
+
+import styles from "./TitleBlock.module.scss";
+
+interface IProps {
+  title: React.ReactElement;
+  actions?: React.ReactElement;
+}
+
+const TitleBlock: React.FC<IProps> = ({ title, actions }) => {
+  return (
+    <div className={styles.titleBlock}>
+      <div className={styles.titleContainer}>
+        <H5 bold>{title}</H5>
+      </div>
+      {actions && <div>{actions}</div>}
+    </div>
+  );
+};
+
+export default TitleBlock;

--- a/airbyte-webapp/src/pages/DestinationPage/pages/CreateDestinationPage/components/DestinationForm.module.scss
+++ b/airbyte-webapp/src/pages/DestinationPage/pages/CreateDestinationPage/components/DestinationForm.module.scss
@@ -1,0 +1,10 @@
+@import "../../../../../scss/variables";
+
+.contentCard {
+  margin-bottom: $spacing-xl;
+  padding: $spacing-xl $spacing-xl $spacing-xl;
+}
+
+.serviceTypeContainer {
+  margin-top: $spacing-l;
+}

--- a/airbyte-webapp/src/pages/DestinationPage/pages/DestinationItemPage/components/DestinationSettings.tsx
+++ b/airbyte-webapp/src/pages/DestinationPage/pages/DestinationItemPage/components/DestinationSettings.tsx
@@ -4,7 +4,6 @@ import { FormattedMessage } from "react-intl";
 import DeleteBlock from "components/DeleteBlock";
 
 import { ConnectionConfiguration } from "core/domain/connection";
-import { Connector } from "core/domain/connector";
 import { DestinationRead, WebBackendConnectionRead } from "core/request/AirbyteClient";
 import { useDeleteDestination, useUpdateDestination } from "hooks/services/useDestinationHook";
 import { useDestinationDefinition } from "services/connector/DestinationDefinitionService";
@@ -29,11 +28,7 @@ const DestinationsSettings: React.FC<DestinationsSettingsProps> = ({
   const { mutateAsync: updateDestination } = useUpdateDestination();
   const { mutateAsync: deleteDestination } = useDeleteDestination();
 
-  const onSubmitForm = async (values: {
-    name: string;
-    serviceType: string;
-    connectionConfiguration?: ConnectionConfiguration;
-  }) => {
+  const onSubmitForm = async (values: { name: string; connectionConfiguration?: ConnectionConfiguration }) => {
     await updateDestination({
       values,
       destinationId: currentDestination.destinationId,
@@ -52,14 +47,11 @@ const DestinationsSettings: React.FC<DestinationsSettingsProps> = ({
         isEditMode
         onSubmit={onSubmitForm}
         formType="destination"
-        availableServices={[destinationDefinition]}
-        formValues={{
-          ...currentDestination,
-          serviceType: Connector.id(destinationDefinition),
-        }}
+        formValues={currentDestination}
         connector={currentDestination}
         selectedConnectorDefinitionSpecification={destinationSpecification}
         title={<FormattedMessage id="destination.destinationSettings" />}
+        selectedService={destinationDefinition}
       />
       <DeleteBlock type="destination" onDelete={onDelete} />
     </div>

--- a/airbyte-webapp/src/pages/OnboardingPage/components/DestinationStep.tsx
+++ b/airbyte-webapp/src/pages/OnboardingPage/components/DestinationStep.tsx
@@ -1,6 +1,10 @@
-import React, { useEffect, useState } from "react";
+import React, { useEffect, useMemo, useState } from "react";
+
+import { ContentCard } from "components";
+import { SelectServiceType } from "components/SelectServiceType/SelectServiceType";
 
 import { ConnectionConfiguration } from "core/domain/connection";
+import { Connector } from "core/domain/connector";
 import { JobInfo } from "core/domain/job";
 import { useCreateDestination } from "hooks/services/useDestinationHook";
 import { TrackActionType, useTrackAction } from "hooks/useTrackAction";
@@ -9,6 +13,8 @@ import { useGetDestinationDefinitionSpecificationAsync } from "services/connecto
 import { createFormErrorMessage } from "utils/errorStatusMessage";
 import { ConnectorCard } from "views/Connector/ConnectorCard";
 import { useDocumentationPanelContext } from "views/Connector/ConnectorDocumentationLayout/DocumentationPanelContext";
+
+import styles from "./StepsCommonStyling.module.scss";
 
 interface Props {
   onNextStep: () => void;
@@ -79,27 +85,44 @@ const DestinationStep: React.FC<Props> = ({ onNextStep, onSuccess }) => {
     setError(null);
     setDestinationDefinitionId(destinationDefinitionId);
   };
-  const onSubmitForm = async (values: { name: string; serviceType: string }) => {
+  const onSubmitForm = async (values: { name: string }) => {
     await onSubmitDestinationStep({
       ...values,
+      serviceType: "asdfasdf",
       destinationDefinitionId: destinationDefinitionSpecification?.destinationDefinitionId,
     });
   };
 
   const errorMessage = error ? createFormErrorMessage(error) : null;
 
+  const selectedService = useMemo(
+    () => destinationDefinitions.find((s) => Connector.id(s) === destinationDefinitionId),
+    [destinationDefinitions, destinationDefinitionId]
+  );
+
   return (
-    <ConnectorCard
-      full
-      formType="destination"
-      onServiceSelect={onDropDownSelect}
-      onSubmit={onSubmitForm}
-      hasSuccess={successRequest}
-      availableServices={destinationDefinitions}
-      errorMessage={errorMessage}
-      selectedConnectorDefinitionSpecification={destinationDefinitionSpecification}
-      isLoading={isLoading}
-    />
+    <>
+      <ContentCard className={styles.contentCard}>
+        <SelectServiceType
+          formType="destination"
+          value={destinationDefinitionId}
+          onChangeServiceType={onDropDownSelect}
+          availableServices={destinationDefinitions}
+        />
+      </ContentCard>
+      {selectedService && (
+        <ConnectorCard
+          full
+          formType="destination"
+          onSubmit={onSubmitForm}
+          hasSuccess={successRequest}
+          errorMessage={errorMessage}
+          selectedConnectorDefinitionSpecification={destinationDefinitionSpecification}
+          isLoading={isLoading}
+          selectedService={selectedService}
+        />
+      )}
+    </>
   );
 };
 

--- a/airbyte-webapp/src/pages/OnboardingPage/components/SourceStep.tsx
+++ b/airbyte-webapp/src/pages/OnboardingPage/components/SourceStep.tsx
@@ -1,6 +1,10 @@
-import React, { useEffect, useState } from "react";
+import React, { useEffect, useMemo, useState } from "react";
+
+import { ContentCard } from "components";
+import { SelectServiceType } from "components/SelectServiceType/SelectServiceType";
 
 import { ConnectionConfiguration } from "core/domain/connection";
+import { Connector } from "core/domain/connector";
 import { JobInfo } from "core/domain/job";
 import { LogsRequestError } from "core/request/LogsRequestError";
 import { useCreateSource } from "hooks/services/useSourceHook";
@@ -10,6 +14,8 @@ import { useGetSourceDefinitionSpecificationAsync } from "services/connector/Sou
 import { createFormErrorMessage } from "utils/errorStatusMessage";
 import { ConnectorCard } from "views/Connector/ConnectorCard";
 import { useDocumentationPanelContext } from "views/Connector/ConnectorDocumentationLayout/DocumentationPanelContext";
+
+import styles from "./StepsCommonStyling.module.scss";
 
 interface SourcesStepProps {
   onSuccess: () => void;
@@ -83,26 +89,44 @@ const SourceStep: React.FC<SourcesStepProps> = ({ onNextStep, onSuccess }) => {
     setSourceDefinitionId(sourceId);
   };
 
-  const onSubmitForm = async (values: { name: string; serviceType: string }) =>
+  const onSubmitForm = async (values: { name: string }) =>
     onSubmitSourceStep({
       ...values,
+      serviceType: "asdfsadf",
     });
 
   const errorMessage = error ? createFormErrorMessage(error) : "";
 
+  const selectedService = useMemo(
+    () => sourceDefinitions.find((s) => Connector.id(s) === sourceDefinitionId),
+    [sourceDefinitions, sourceDefinitionId]
+  );
+
   return (
-    <ConnectorCard
-      full
-      jobInfo={LogsRequestError.extractJobInfo(error)}
-      onServiceSelect={onServiceSelect}
-      onSubmit={onSubmitForm}
-      formType="source"
-      availableServices={sourceDefinitions}
-      hasSuccess={successRequest}
-      errorMessage={errorMessage}
-      selectedConnectorDefinitionSpecification={sourceDefinitionSpecification}
-      isLoading={isLoading}
-    />
+    <>
+      <ContentCard className={styles.contentCard}>
+        <SelectServiceType
+          formType="source"
+          value={sourceDefinitionId}
+          onChangeServiceType={onServiceSelect}
+          availableServices={sourceDefinitions}
+        />
+      </ContentCard>
+
+      {selectedService && (
+        <ConnectorCard
+          full
+          jobInfo={LogsRequestError.extractJobInfo(error)}
+          onSubmit={onSubmitForm}
+          formType="source"
+          hasSuccess={successRequest}
+          errorMessage={errorMessage}
+          selectedConnectorDefinitionSpecification={sourceDefinitionSpecification}
+          isLoading={isLoading}
+          selectedService={selectedService}
+        />
+      )}
+    </>
   );
 };
 

--- a/airbyte-webapp/src/pages/OnboardingPage/components/StepsCommonStyling.module.scss
+++ b/airbyte-webapp/src/pages/OnboardingPage/components/StepsCommonStyling.module.scss
@@ -1,0 +1,7 @@
+@import "../../../scss/variables";
+
+.contentCard {
+  width: 100% !important;
+  margin-bottom: $spacing-xl;
+  padding: $spacing-xl $spacing-xl $spacing-xl;
+}

--- a/airbyte-webapp/src/pages/OnboardingPage/useStepsConfig.tsx
+++ b/airbyte-webapp/src/pages/OnboardingPage/useStepsConfig.tsx
@@ -26,7 +26,9 @@ const useStepsConfig = (
     return StepType.INSTRUCTION;
   };
 
-  const [currentStep, setCurrentStep] = useState<StepType>(getInitialStep);
+  console.log(getInitialStep());
+
+  const [currentStep, setCurrentStep] = useState<StepType>(StepType.INSTRUCTION);
   const updateStep = useCallback(
     (step: StepType) => {
       setCurrentStep(step);

--- a/airbyte-webapp/src/pages/SourcesPage/pages/CreateSourcePage/components/SourceForm.module.scss
+++ b/airbyte-webapp/src/pages/SourcesPage/pages/CreateSourcePage/components/SourceForm.module.scss
@@ -1,0 +1,10 @@
+@import "../../../../../scss/variables";
+
+.contentCard {
+  margin-bottom: $spacing-xl;
+  padding: $spacing-xl $spacing-xl $spacing-xl;
+}
+
+.serviceTypeContainer {
+  margin-top: $spacing-l;
+}

--- a/airbyte-webapp/src/pages/SourcesPage/pages/SourceItemPage/components/SourceSettings.tsx
+++ b/airbyte-webapp/src/pages/SourcesPage/pages/SourceItemPage/components/SourceSettings.tsx
@@ -34,11 +34,7 @@ const SourceSettings: React.FC<SourceSettingsProps> = ({ currentSource, connecti
 
   const sourceDefinition = useSourceDefinition(currentSource.sourceDefinitionId);
 
-  const onSubmit = async (values: {
-    name: string;
-    serviceType: string;
-    connectionConfiguration?: ConnectionConfiguration;
-  }) =>
+  const onSubmit = async (values: { name: string; connectionConfiguration?: ConnectionConfiguration }) =>
     await updateSource({
       values,
       sourceId: currentSource.sourceId,
@@ -54,12 +50,9 @@ const SourceSettings: React.FC<SourceSettingsProps> = ({ currentSource, connecti
         onSubmit={onSubmit}
         formType="source"
         connector={currentSource}
-        availableServices={[sourceDefinition]}
-        formValues={{
-          ...currentSource,
-          serviceType: currentSource.sourceDefinitionId,
-        }}
+        formValues={currentSource}
         selectedConnectorDefinitionSpecification={sourceDefinitionSpecification}
+        selectedService={sourceDefinition}
       />
       <DeleteBlock type="source" onDelete={onDelete} />
     </div>

--- a/airbyte-webapp/src/scss/_variables.scss
+++ b/airbyte-webapp/src/scss/_variables.scss
@@ -1,3 +1,5 @@
+@import "./colors";
+
 $transition: 0.3s;
 
 $border-thin: 1px;

--- a/airbyte-webapp/src/views/Connector/ConnectorCard/ConnectorCard.tsx
+++ b/airbyte-webapp/src/views/Connector/ConnectorCard/ConnectorCard.tsx
@@ -4,7 +4,7 @@ import { FormattedMessage } from "react-intl";
 import { ContentCard } from "components";
 import { JobItem } from "components/JobItem/JobItem";
 
-import { Connector, ConnectorT } from "core/domain/connector";
+import { Connector, ConnectorDefinition, ConnectorT } from "core/domain/connector";
 import { CheckConnectionRead } from "core/request/AirbyteClient";
 import { LogsRequestError, SynchronousJobReadWithStatus } from "core/request/LogsRequestError";
 import { TrackActionType, useTrackAction } from "hooks/useTrackAction";
@@ -25,6 +25,7 @@ export const ConnectorCard: React.FC<
     title?: React.ReactNode;
     full?: boolean;
     jobInfo?: SynchronousJobReadWithStatus | null;
+    selectedService: ConnectorDefinition;
   } & Omit<ServiceFormProps, keyof ConnectorCardProvidedProps> &
     (
       | {
@@ -51,7 +52,7 @@ export const ConnectorCard: React.FC<
   const onHandleSubmit = async (values: ServiceFormValues) => {
     setErrorStatusRequest(null);
 
-    const connector = props.availableServices.find((item) => Connector.id(item) === values.serviceType);
+    const connector = props.selectedService;
 
     const trackAction = (action: string) => {
       if (!connector) {
@@ -74,7 +75,7 @@ export const ConnectorCard: React.FC<
     const testConnectorWithTracking = async () => {
       trackAction("Test a connector");
       try {
-        await testConnector(values);
+        await testConnector({ ...values, serviceType: Connector.id(connector) });
         trackAction("Tested connector - success");
       } catch (e) {
         trackAction("Tested connector - failure");

--- a/airbyte-webapp/src/views/Connector/ConnectorCard/useTestConnector.tsx
+++ b/airbyte-webapp/src/views/Connector/ConnectorCard/useTestConnector.tsx
@@ -7,6 +7,8 @@ import { ServiceFormValues } from "views/Connector/ServiceForm";
 
 import { CheckConnectionRead } from "../../../core/request/AirbyteClient";
 
+export type TestConnectorProps = ServiceFormValues & { serviceType: string };
+
 export const useTestConnector = (
   props: {
     formType: "source" | "destination";
@@ -20,7 +22,7 @@ export const useTestConnector = (
   isTestConnectionInProgress: boolean;
   isSuccess: boolean;
   onStopTesting: () => void;
-  testConnector: (v?: ServiceFormValues) => Promise<CheckConnectionRead>;
+  testConnector: (v?: TestConnectorProps) => Promise<CheckConnectionRead>;
   error: Error | null;
   reset: () => void;
 } => {

--- a/airbyte-webapp/src/views/Connector/ServiceForm/ServiceForm.test.tsx
+++ b/airbyte-webapp/src/views/Connector/ServiceForm/ServiceForm.test.tsx
@@ -3,6 +3,7 @@ import userEvent from "@testing-library/user-event";
 import React from "react";
 import selectEvent from "react-select-event";
 
+import { ConnectorDefinition } from "core/domain/connector";
 import { AirbyteJSONSchema } from "core/jsonSchema";
 import { render } from "utils/testutils";
 import { ServiceForm } from "views/Connector/ServiceForm";
@@ -129,7 +130,16 @@ describe("Service Form", () => {
                 documentationUrl: "",
               } as DestinationDefinitionSpecificationRead
             }
-            availableServices={[]}
+            selectedService={
+              {
+                connectionSpecification: schema,
+                sourceDefinitionId: "1",
+                documentationUrl: "",
+                dockerImageTag: "0.1.0",
+                dockerRepository: "docker-repo",
+                name: "source-definitaion-name",
+              } as ConnectorDefinition
+            }
           />
         </ConnectorDocumentationWrapper>
       );
@@ -205,7 +215,7 @@ describe("Service Form", () => {
         <ConnectorDocumentationWrapper>
           <ServiceForm
             formType="source"
-            formValues={{ name: "test-name", serviceType: "test-service-type" }}
+            formValues={{ name: "test-name" }}
             onSubmit={(values) => (result = values)}
             selectedConnectorDefinitionSpecification={
               // @ts-expect-error Partial objects for testing
@@ -215,7 +225,16 @@ describe("Service Form", () => {
                 documentationUrl: "",
               } as DestinationDefinitionSpecificationRead
             }
-            availableServices={[]}
+            selectedService={
+              {
+                connectionSpecification: schema,
+                sourceDefinitionId: "1",
+                documentationUrl: "",
+                dockerImageTag: "0.1.0",
+                dockerRepository: "docker-repo",
+                name: "destination-definitaion-name",
+              } as ConnectorDefinition
+            }
           />
         </ConnectorDocumentationWrapper>
       );

--- a/airbyte-webapp/src/views/Connector/ServiceForm/ServiceForm.tsx
+++ b/airbyte-webapp/src/views/Connector/ServiceForm/ServiceForm.tsx
@@ -1,22 +1,19 @@
 import { Formik, getIn, setIn, useFormikContext } from "formik";
 import { JSONSchema7 } from "json-schema";
-import React, { useCallback, useEffect, useMemo, useState } from "react";
-import { useDeepCompareEffect, useToggle } from "react-use";
+import React, { useCallback, useEffect, useMemo } from "react";
+import { useDeepCompareEffect } from "react-use";
 
 import { FormChangeTracker } from "components/FormChangeTracker";
 
 import { ConnectorDefinition, ConnectorDefinitionSpecification } from "core/domain/connector";
-import { isDestinationDefinitionSpecification } from "core/domain/connector/destination";
-import { isSourceDefinition, isSourceDefinitionSpecification } from "core/domain/connector/source";
 import { FormBaseItem, FormComponentOverrideProps } from "core/form/types";
 import { useFormChangeTrackerService, useUniqueFormId } from "hooks/services/FormChangeTracker";
 import { isDefined } from "utils/common";
-import RequestConnectorModal from "views/Connector/RequestConnectorModal";
 
 import { CheckConnectionRead } from "../../../core/request/AirbyteClient";
+import { TestConnectorProps } from "../ConnectorCard/useTestConnector";
 import { useDocumentationPanelContext } from "../ConnectorDocumentationLayout/DocumentationPanelContext";
 import { ConnectorNameControl } from "./components/Controls/ConnectorNameControl";
-import { ConnectorServiceTypeControl } from "./components/Controls/ConnectorServiceTypeControl";
 import { FormRoot } from "./FormRoot";
 import { ServiceFormContextProvider, useServiceForm } from "./serviceFormContext";
 import { ServiceFormValues } from "./types";
@@ -69,37 +66,9 @@ const PatchInitialValuesWithWidgetConfig: React.FC<{
   return null;
 };
 
-/**
- * A component that will observe whenever the serviceType (selected connector)
- * changes and set the name of the connector to match the connector definition name.
- */
-const SetDefaultName: React.FC = () => {
-  const { setFieldValue } = useFormikContext();
-  const { selectedService } = useServiceForm();
-
-  useEffect(() => {
-    if (!selectedService) {
-      return;
-    }
-
-    const timeout = setTimeout(() => {
-      // We need to push this out one execution slot, so the form isn't still in its
-      // initialization status and won't react to this call but would just take the initialValues instead.
-      setFieldValue("name", selectedService.name);
-    });
-    return () => clearTimeout(timeout);
-
-    // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [selectedService]);
-
-  return null;
-};
-
 export interface ServiceFormProps {
   formType: "source" | "destination";
-  availableServices: ConnectorDefinition[];
   selectedConnectorDefinitionSpecification?: ConnectorDefinitionSpecification;
-  onServiceSelect?: (id: string) => void;
   onSubmit: (values: ServiceFormValues) => void;
   isLoading?: boolean;
   isEditMode?: boolean;
@@ -108,18 +77,17 @@ export interface ServiceFormProps {
   fetchingConnectorError?: Error | null;
   errorMessage?: React.ReactNode;
   successMessage?: React.ReactNode;
+  selectedService: ConnectorDefinition;
 
   isTestConnectionInProgress?: boolean;
   onStopTesting?: () => void;
-  testConnector?: (v?: ServiceFormValues) => Promise<CheckConnectionRead>;
+  testConnector?: (v?: TestConnectorProps) => Promise<CheckConnectionRead>;
 }
 
 const ServiceForm: React.FC<ServiceFormProps> = (props) => {
   const formId = useUniqueFormId();
   const { clearFormChange } = useFormChangeTrackerService();
 
-  const [isOpenRequestModal, toggleOpenRequestModal] = useToggle(false);
-  const [initialRequestName, setInitialRequestName] = useState<string>();
   const {
     formType,
     formValues,
@@ -129,7 +97,7 @@ const ServiceForm: React.FC<ServiceFormProps> = (props) => {
     onStopTesting,
     testConnector,
     selectedConnectorDefinitionSpecification,
-    availableServices,
+    selectedService,
   } = props;
 
   const specifications = useBuildInitialSchema(selectedConnectorDefinitionSpecification);
@@ -138,7 +106,6 @@ const ServiceForm: React.FC<ServiceFormProps> = (props) => {
     () => ({
       type: "object",
       properties: {
-        serviceType: { type: "string" },
         ...(selectedConnectorDefinitionSpecification ? { name: { type: "string" } } : {}),
         ...Object.fromEntries(
           Object.entries({
@@ -158,24 +125,9 @@ const ServiceForm: React.FC<ServiceFormProps> = (props) => {
     if (!selectedConnectorDefinitionSpecification) {
       return;
     }
-
-    const selectedServiceDefinition = availableServices.find((service) => {
-      if (isSourceDefinition(service)) {
-        const serviceDefinitionId = service.sourceDefinitionId;
-        return (
-          isSourceDefinitionSpecification(selectedConnectorDefinitionSpecification) &&
-          serviceDefinitionId === selectedConnectorDefinitionSpecification.sourceDefinitionId
-        );
-      }
-      const serviceDefinitionId = service.destinationDefinitionId;
-      return (
-        isDestinationDefinitionSpecification(selectedConnectorDefinitionSpecification) &&
-        serviceDefinitionId === selectedConnectorDefinitionSpecification.destinationDefinitionId
-      );
-    });
-    setDocumentationUrl(selectedServiceDefinition?.documentationUrl ?? "");
+    setDocumentationUrl(selectedService?.documentationUrl ?? "");
     setDocumentationPanelOpen(true);
-  }, [availableServices, selectedConnectorDefinitionSpecification, setDocumentationPanelOpen, setDocumentationUrl]);
+  }, [selectedConnectorDefinitionSpecification, setDocumentationPanelOpen, setDocumentationUrl, selectedService]);
 
   const uiOverrides = useMemo(
     () => ({
@@ -184,24 +136,8 @@ const ServiceForm: React.FC<ServiceFormProps> = (props) => {
           <ConnectorNameControl property={property} formType={formType} {...componentProps} />
         ),
       },
-      serviceType: {
-        component: (property: FormBaseItem, componentProps: FormComponentOverrideProps) => (
-          <ConnectorServiceTypeControl
-            property={property}
-            formType={formType}
-            onChangeServiceType={props.onServiceSelect}
-            availableServices={props.availableServices}
-            isEditMode={props.isEditMode}
-            onOpenRequestConnectorModal={(name) => {
-              setInitialRequestName(name);
-              toggleOpenRequestModal();
-            }}
-            {...componentProps}
-          />
-        ),
-      },
     }),
-    [formType, props.onServiceSelect, props.availableServices, props.isEditMode, toggleOpenRequestModal]
+    [formType]
   );
 
   const { uiWidgetsInfo, setUiWidgetsInfo } = useBuildUiWidgetsContext(formFields, initialValues, uiOverrides);
@@ -241,12 +177,11 @@ const ServiceForm: React.FC<ServiceFormProps> = (props) => {
           getValues={getValues}
           setUiWidgetsInfo={setUiWidgetsInfo}
           formType={formType}
+          selectedService={selectedService}
           selectedConnector={selectedConnectorDefinitionSpecification}
-          availableServices={props.availableServices}
           isEditMode={props.isEditMode}
           isLoadingSchema={props.isLoading}
         >
-          {!props.isEditMode && <SetDefaultName />}
           <FormikPatch />
           <FormChangeTracker changed={dirty} formId={formId} />
           <PatchInitialValuesWithWidgetConfig schema={jsonSchema} initialValues={initialValues} />
@@ -258,13 +193,6 @@ const ServiceForm: React.FC<ServiceFormProps> = (props) => {
             onRetest={testConnector ? async () => await testConnector() : undefined}
             formFields={formFields}
           />
-          {isOpenRequestModal && (
-            <RequestConnectorModal
-              connectorType={formType}
-              initialName={initialRequestName}
-              onClose={toggleOpenRequestModal}
-            />
-          )}
         </ServiceFormContextProvider>
       )}
     </Formik>

--- a/airbyte-webapp/src/views/Connector/ServiceForm/serviceFormContext.tsx
+++ b/airbyte-webapp/src/views/Connector/ServiceForm/serviceFormContext.tsx
@@ -1,7 +1,7 @@
 import { getIn, useFormikContext } from "formik";
 import React, { useContext, useMemo } from "react";
 
-import { Connector, ConnectorDefinition, ConnectorDefinitionSpecification } from "core/domain/connector";
+import { ConnectorDefinition, ConnectorDefinitionSpecification } from "core/domain/connector";
 import { WidgetConfigMap } from "core/form/types";
 import { FeatureItem, useFeatureService } from "hooks/services/Feature";
 
@@ -41,11 +41,10 @@ const ServiceFormContextProvider: React.FC<{
   formType: "source" | "destination";
   isLoadingSchema?: boolean;
   isEditMode?: boolean;
-  availableServices: ConnectorDefinition[];
   getValues: (values: ServiceFormValues) => ServiceFormValues;
   selectedConnector?: ConnectorDefinitionSpecification;
+  selectedService: ConnectorDefinition;
 }> = ({
-  availableServices,
   children,
   widgetsInfo,
   setUiWidgetsInfo,
@@ -54,15 +53,10 @@ const ServiceFormContextProvider: React.FC<{
   formType,
   isLoadingSchema,
   isEditMode,
+  selectedService,
 }) => {
   const { values } = useFormikContext<ServiceFormValues>();
   const { hasFeature } = useFeatureService();
-
-  const { serviceType } = values;
-  const selectedService = useMemo(
-    () => availableServices.find((s) => Connector.id(s) === serviceType),
-    [availableServices, serviceType]
-  );
 
   const isAuthFlowSelected = useMemo(
     () =>

--- a/airbyte-webapp/src/views/Connector/ServiceForm/types.ts
+++ b/airbyte-webapp/src/views/Connector/ServiceForm/types.ts
@@ -2,6 +2,5 @@
 // eslint-disable-next-line @typescript-eslint/consistent-type-definitions
 export type ServiceFormValues<T = unknown> = {
   name: string;
-  serviceType: string;
   connectionConfiguration: T;
 };


### PR DESCRIPTION
## What
While I was building this feature, I had a problem: https://github.com/airbytehq/airbyte/pull/14462 that the name is not taken from initialValues for formik. 

I think the proper fix here would be to move the serviceType selection out of formik and move it into the parent component thus should avoid a lot of rerenders and multiple handlers. 

This is just a quick take on how that could look like 


https://user-images.githubusercontent.com/17528887/177956428-a08e19ff-5286-441b-bd01-8c532cd0e47e.mov

