### PR TITLE
remove CONTAINER_ORCHESTRATOR env var from acceptance tests

### DIFF
--- a/airbyte-tests/src/acceptanceTests/java/io/airbyte/test/acceptance/ContainerOrchestratorAcceptanceTests.java
+++ b/airbyte-tests/src/acceptanceTests/java/io/airbyte/test/acceptance/ContainerOrchestratorAcceptanceTests.java
@@ -46,12 +46,12 @@ import org.slf4j.MDC;
  * This class tests behavior that is specific to container-orchestrator deployments, such as scaling
  * down and back up workers while a sync is running to ensure it is not affected by a deployment.
  * <p>
- * This test class is only enabled if the CONTAINER_ORCHESTRATOR environment variable is true. At
- * the time of writing, this is only the case for kubernetes deployments, as container orchestrators
- * have not yet been ported over to docker.
+ * This test class is only enabled if the KUBE environment variable is true, because container
+ * orchestrators are currently only used by kuberenetes deployments, as container orchestrators have
+ * not yet been ported over to docker.
  */
 @SuppressWarnings({"rawtypes", "ConstantConditions"})
-@EnabledIfEnvironmentVariable(named = "CONTAINER_ORCHESTRATOR",
+@EnabledIfEnvironmentVariable(named = "KUBE",
                               matches = "true")
 public class ContainerOrchestratorAcceptanceTests {
 

--- a/tools/bin/acceptance_test_kube.sh
+++ b/tools/bin/acceptance_test_kube.sh
@@ -76,4 +76,4 @@ if [ -n "$CI" ]; then
 fi
 
 echo "Running e2e tests via gradle..."
-KUBE=true CONTAINER_ORCHESTRATOR=true SUB_BUILD=PLATFORM USE_EXTERNAL_DEPLOYMENT=true ./gradlew :airbyte-tests:acceptanceTests --scan
+KUBE=true SUB_BUILD=PLATFORM USE_EXTERNAL_DEPLOYMENT=true ./gradlew :airbyte-tests:acceptanceTests --scan

--- a/tools/bin/gke-kube-acceptance-test/acceptance_test_kube_gke.sh
+++ b/tools/bin/gke-kube-acceptance-test/acceptance_test_kube_gke.sh
@@ -68,5 +68,5 @@ kubectl port-forward svc/postgres-destination-svc 3000:5432 --namespace=$NAMESPA
 sleep 10s
 
 echo "Running e2e tests via gradle..."
-KUBE=true IS_GKE=true CONTAINER_ORCHESTRATOR=true SUB_BUILD=PLATFORM USE_EXTERNAL_DEPLOYMENT=true ./gradlew :airbyte-tests:acceptanceTests --scan -i
+KUBE=true IS_GKE=true SUB_BUILD=PLATFORM USE_EXTERNAL_DEPLOYMENT=true ./gradlew :airbyte-tests:acceptanceTests --scan -i
 


### PR DESCRIPTION
## What
The ContainerOrchestratorAcceptanceTests were recently added in this PR: https://github.com/airbytehq/airbyte/pull/13699

However, very quickly after merging I realized that it is redundant to use the `CONTAINER_ORCHESTRATOR` env variable in the acceptance test files, because we could just use the `KUBE` flag to achieve the same result (since all kube deploys now use container orchestrators).

## How
This PR simply uses the `KUBE` flag to decide to run the container orchestrator tests instead.