### PR TITLE
Destination MongoDB: use SHA256 instead of MD5

### DIFF
--- a/airbyte-config/init/src/main/resources/seed/destination_definitions.yaml
+++ b/airbyte-config/init/src/main/resources/seed/destination_definitions.yaml
@@ -182,7 +182,7 @@
 - name: MongoDB
   destinationDefinitionId: 8b746512-8c2e-6ac1-4adc-b59faafd473c
   dockerRepository: airbyte/destination-mongodb
-  dockerImageTag: 0.1.4
+  dockerImageTag: 0.1.5
   documentationUrl: https://docs.airbyte.io/integrations/destinations/mongodb
   icon: mongodb.svg
   releaseStage: alpha

--- a/airbyte-config/init/src/main/resources/seed/destination_specs.yaml
+++ b/airbyte-config/init/src/main/resources/seed/destination_specs.yaml
@@ -2763,7 +2763,7 @@
     supported_destination_sync_modes:
     - "overwrite"
     - "append"
-- dockerImage: "airbyte/destination-mongodb:0.1.4"
+- dockerImage: "airbyte/destination-mongodb:0.1.5"
   spec:
     documentationUrl: "https://docs.airbyte.io/integrations/destinations/mongodb"
     connectionSpecification:

--- a/airbyte-integrations/connectors/destination-mongodb-strict-encrypt/Dockerfile
+++ b/airbyte-integrations/connectors/destination-mongodb-strict-encrypt/Dockerfile
@@ -16,5 +16,5 @@ ENV APPLICATION destination-mongodb-strict-encrypt
 
 COPY --from=build /airbyte /airbyte
 
-LABEL io.airbyte.version=0.1.1
+LABEL io.airbyte.version=0.1.4
 LABEL io.airbyte.name=airbyte/destination-mongodb-strict-encrypt

--- a/airbyte-integrations/connectors/destination-mongodb-strict-encrypt/Dockerfile
+++ b/airbyte-integrations/connectors/destination-mongodb-strict-encrypt/Dockerfile
@@ -16,5 +16,5 @@ ENV APPLICATION destination-mongodb-strict-encrypt
 
 COPY --from=build /airbyte /airbyte
 
-LABEL io.airbyte.version=0.1.4
+LABEL io.airbyte.version=0.1.5
 LABEL io.airbyte.name=airbyte/destination-mongodb-strict-encrypt

--- a/airbyte-integrations/connectors/destination-mongodb/Dockerfile
+++ b/airbyte-integrations/connectors/destination-mongodb/Dockerfile
@@ -16,5 +16,5 @@ ENV APPLICATION destination-mongodb
 
 COPY --from=build /airbyte /airbyte
 
-LABEL io.airbyte.version=0.1.4
+LABEL io.airbyte.version=0.1.5
 LABEL io.airbyte.name=airbyte/destination-mongodb

--- a/airbyte-integrations/connectors/destination-mongodb/src/main/java/io/airbyte/integrations/destination/mongodb/MongodbRecordConsumer.java
+++ b/airbyte-integrations/connectors/destination-mongodb/src/main/java/io/airbyte/integrations/destination/mongodb/MongodbRecordConsumer.java
@@ -117,7 +117,7 @@ public class MongodbRecordConsumer extends FailureTrackingAirbyteMessageConsumer
     try {
       final AirbyteRecordMessage recordMessage = message.getRecord();
       final Map<String, Object> result = objectMapper.convertValue(recordMessage.getData(), new TypeReference<>() {});
-      final var newDocumentDataHashCode = UUID.nameUUIDFromBytes(DigestUtils.md5Hex(Jsons.toBytes(recordMessage.getData())).getBytes(
+      final var newDocumentDataHashCode = UUID.nameUUIDFromBytes(DigestUtils.sha256Hex(Jsons.toBytes(recordMessage.getData())).getBytes(
           Charset.defaultCharset())).toString();
       final var newDocument = new Document();
       newDocument.put(AIRBYTE_DATA, new Document(result));

--- a/docs/integrations/destinations/mongodb.md
+++ b/docs/integrations/destinations/mongodb.md
@@ -93,6 +93,7 @@ Collection names should begin with an underscore or a letter character, and cann
 
 | Version | Date | Pull Request | Subject |
 | :--- | :--- | :--- | :--- |
+| 0.1.5 | 2022-07-27 | [14561](https://github.com/airbytehq/airbyte/pull/14561) | Change Airbyte Id from MD5 to SHA256 |
 | 0.1.4 | 2022-02-14 | [10256](https://github.com/airbytehq/airbyte/pull/10256) | (unpublished) Add `-XX:+ExitOnOutOfMemoryError` JVM option |
 | 0.1.3 | 2021-12-30 | [8809](https://github.com/airbytehq/airbyte/pull/8809) | Update connector fields title/description |
 | 0.1.2 | 2021-10-18 | [6945](https://github.com/airbytehq/airbyte/pull/6945) | Create a secure-only MongoDb destination |


### PR DESCRIPTION
## What
*SpotBugs report shows that the algorithms MD2, MD4 and MD5 are not a recommended MessageDigest*
*The security of the MD5 hash function is severely compromised.*

## How
*use SHA256 instead of MD5*