### PR TITLE
📝 doc:  fix deadlink in repo readme.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,7 +44,7 @@ Here is a [step-by-step guide](https://github.com/airbytehq/airbyte/tree/e378d40
 
 We love contributions to Airbyte, big or small.
 
-See our [Contributing guide](docs/contributing-to-airbyte/) on how to get started. Not sure where to start? We’ve listed some [good first issues](https://github.com/airbytehq/airbyte/labels/good%20first%20issue) to start with. If you have any questions, please open a draft PR or visit our [slack channel](https://github.com/airbytehq/airbyte/tree/a9b1c6c0420550ad5069aca66c295223e0d05e27/slack.airbyte.io) where the core team can help answer your questions.
+See our [Contributing guide](docs/09-contributing-to-airbyte/README.md) on how to get started. Not sure where to start? We’ve listed some [good first issues](https://github.com/airbytehq/airbyte/labels/good%20first%20issue) to start with. If you have any questions, please open a draft PR or visit our [slack channel](https://github.com/airbytehq/airbyte/tree/a9b1c6c0420550ad5069aca66c295223e0d05e27/slack.airbyte.io) where the core team can help answer your questions.
 
 **Note that you are able to create connectors using the language you want, as Airbyte connections run as Docker containers.**
 


### PR DESCRIPTION
Fixes https://github.com/airbytehq/airbyte/issues/14562

## What
Repo readme.md has a dead link to the Contributing Guide.

## How
The old link was to a Contributing Guide markdown in this repo, so I replaced it with [what appears to be the same page](https://github.com/airbytehq/airbyte/blob/master/docs/09-contributing-to-airbyte/README.md).

Maybe we'd rather link out to the nice and rendered [Contributing Guide](https://docs.airbyte.com/contributing-to-airbyte/), though?