### PR TITLE
Adds a missing redirect from legacy docs

### DIFF
--- a/docusaurus/docusaurus.config.js
+++ b/docusaurus/docusaurus.config.js
@@ -41,6 +41,10 @@ const config = {
                             from: '/integrations/sources/google-analytics-data-api',
                             to: '/integrations/sources/google-analytics-v4',
                         },
+                        {
+                            from: '/connector-development/tutorials/cdk-tutorial-python-http',
+                            to: '/connector-development/cdk-tutorial-python-http/',
+                        },
 //                        {
 //                         from: '/some-lame-path',
 //                         to: '/a-much-cooler-uri',


### PR DESCRIPTION
addressed report of missing link @ https://docs.airbyte.com/connector-development/tutorials/cdk-tutorial-python-http

tested locally with localhost:3000/connector-development/tutorials/cdk-tutorial-python-http

working as intended