### PR TITLE
Fix md and lg scss var names

### DIFF
--- a/airbyte-webapp/src/pages/ConnectionPage/pages/ConnectionItemPage/components/ConnectionName.module.scss
+++ b/airbyte-webapp/src/pages/ConnectionPage/pages/ConnectionItemPage/components/ConnectionName.module.scss
@@ -2,7 +2,7 @@
 @use "../../../../../scss/variables";
 
 .container {
-  margin-top: variables.$spacing-m;
+  margin-top: variables.$spacing-md;
   display: flex;
   align-items: center;
   justify-content: center;
@@ -32,7 +32,7 @@
       line-height: 29px;
       text-align: center;
       color: colors.$dark-blue-900;
-      margin: variables.$spacing-m;
+      margin: variables.$spacing-md;
       word-wrap: break-word;
     }
   }

--- a/airbyte-webapp/src/scss/_variables.scss
+++ b/airbyte-webapp/src/scss/_variables.scss
@@ -4,12 +4,12 @@ $border-thin: 1px;
 $border-thick: 2px;
 
 $border-radius-sm: 8px;
-$border-radius-m: 10px;
+$border-radius-md: 10px;
 
 $spacing-xs: 3px;
 $spacing-sm: 5px;
-$spacing-m: 10px;
-$spacing-l: 15px;
+$spacing-md: 10px;
+$spacing-lg: 15px;
 $spacing-xl: 20px;
 $spacing-2xl: 40px;
 $spacing-page-bottom: 150px;


### PR DESCRIPTION
## What
This updates recent variable names in scss that should be set to `md` or `lg` instead of `m` and `l`.

Restores changes in #13886.

## How
Search and replace the var names
