### PR TITLE
adding prefix option for datadog

### DIFF
--- a/airbyte-config/config-models/src/main/java/io/airbyte/config/Configs.java
+++ b/airbyte-config/config-models/src/main/java/io/airbyte/config/Configs.java
@@ -462,6 +462,12 @@ public interface Configs {
   String getDDDogStatsDPort();
 
   /**
+   * Set the prefix to use when sending metrics to datadog. This is useful when you have multiple environments
+   * and want to hard-code a prefix per environment.
+   */
+  String getDDPrefix();
+
+  /**
    * Define whether to publish tracking events to Segment or log-only. Airbyte internal use.
    */
   TrackingStrategy getTrackingStrategy();

--- a/airbyte-config/config-models/src/main/java/io/airbyte/config/EnvConfigs.java
+++ b/airbyte-config/config-models/src/main/java/io/airbyte/config/EnvConfigs.java
@@ -29,6 +29,8 @@ import java.util.function.Function;
 import java.util.function.Supplier;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
+
+import org.apache.commons.lang3.StringUtils;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -798,7 +800,13 @@ public class EnvConfigs implements Configs {
   }
 
   @Override
-  public String getDDPrefix() { return getEnvOrDefault(DD_PREFIX, ""); }
+  public String getDDPrefix() {
+    String prefix = getEnvOrDefault(DD_PREFIX, "").strip();
+    if (StringUtils.isNotEmpty(prefix) &&  !prefix.endsWith(".")){
+      prefix = prefix + ".";
+    }
+    return prefix;
+  }
   @Override
   public TrackingStrategy getTrackingStrategy() {
     return getEnvOrDefault(TRACKING_STRATEGY, TrackingStrategy.LOGGING, s -> {

--- a/airbyte-config/config-models/src/main/java/io/airbyte/config/EnvConfigs.java
+++ b/airbyte-config/config-models/src/main/java/io/airbyte/config/EnvConfigs.java
@@ -100,6 +100,8 @@ public class EnvConfigs implements Configs {
   private static final String DD_AGENT_HOST = "DD_AGENT_HOST";
   private static final String DD_DOGSTATSD_PORT = "DD_DOGSTATSD_PORT";
 
+  private static final String DD_PREFIX = "DD_PREFIX";
+
   public static final String STATE_STORAGE_S3_BUCKET_NAME = "STATE_STORAGE_S3_BUCKET_NAME";
   public static final String STATE_STORAGE_S3_REGION = "STATE_STORAGE_S3_REGION";
   public static final String STATE_STORAGE_S3_ACCESS_KEY = "STATE_STORAGE_S3_ACCESS_KEY";
@@ -795,6 +797,8 @@ public class EnvConfigs implements Configs {
     return getEnvOrDefault(DD_DOGSTATSD_PORT, "");
   }
 
+  @Override
+  public String getDDPrefix() { return getEnvOrDefault(DD_PREFIX, ""); }
   @Override
   public TrackingStrategy getTrackingStrategy() {
     return getEnvOrDefault(TRACKING_STRATEGY, TrackingStrategy.LOGGING, s -> {

--- a/airbyte-config/config-models/src/main/java/io/airbyte/config/EnvConfigs.java
+++ b/airbyte-config/config-models/src/main/java/io/airbyte/config/EnvConfigs.java
@@ -802,9 +802,7 @@ public class EnvConfigs implements Configs {
   @Override
   public String getDDPrefix() {
     String prefix = getEnvOrDefault(DD_PREFIX, "").strip();
-    if (StringUtils.isNotEmpty(prefix) &&  !prefix.endsWith(".")){
-      prefix = prefix + ".";
-    }
+    prefix = StringUtils.appendIfMissing(prefix, ".");
     return prefix;
   }
   @Override

--- a/airbyte-metrics/metrics-lib/src/main/java/io/airbyte/metrics/lib/DatadogClientConfiguration.java
+++ b/airbyte-metrics/metrics-lib/src/main/java/io/airbyte/metrics/lib/DatadogClientConfiguration.java
@@ -17,10 +17,13 @@ public class DatadogClientConfiguration {
   public final String ddPort;
   public final boolean publish;
 
+  public final String ddPrefix;
+
   public DatadogClientConfiguration(final Configs configs) {
     this.ddAgentHost = configs.getDDAgentHost();
     this.ddPort = configs.getDDDogStatsDPort();
     this.publish = configs.getPublishMetrics();
+    this.ddPrefix = configs.getDDPrefix();
   }
 
 }

--- a/airbyte-metrics/metrics-lib/src/main/java/io/airbyte/metrics/lib/DogStatsDMetricClient.java
+++ b/airbyte-metrics/metrics-lib/src/main/java/io/airbyte/metrics/lib/DogStatsDMetricClient.java
@@ -43,11 +43,7 @@ public class DogStatsDMetricClient implements MetricClient {
     }
 
 
-    String prefix = config.ddPrefix;
-    if (StringUtils.isNotEmpty(prefix) &&  !prefix.endsWith(".")){
-      prefix = prefix + ".";
-    }
-    prefix = prefix + app.getApplicationName();
+    String prefix = config.ddPrefix + app.getApplicationName();
 
     log.info("Starting DogStatsD client..");
     instancePublish = config.publish;

--- a/airbyte-metrics/metrics-lib/src/main/java/io/airbyte/metrics/lib/DogStatsDMetricClient.java
+++ b/airbyte-metrics/metrics-lib/src/main/java/io/airbyte/metrics/lib/DogStatsDMetricClient.java
@@ -9,6 +9,7 @@ import com.timgroup.statsd.NonBlockingStatsDClientBuilder;
 import com.timgroup.statsd.StatsDClient;
 import io.airbyte.config.Configs;
 import lombok.extern.slf4j.Slf4j;
+import org.apache.commons.lang3.StringUtils;
 
 /**
  * Light wrapper around the DogsStatsD client to make using the client slightly more ergonomic.
@@ -41,10 +42,17 @@ public class DogStatsDMetricClient implements MetricClient {
       return;
     }
 
+
+    String prefix = config.ddPrefix;
+    if (StringUtils.isNotEmpty(prefix) &&  !prefix.endsWith(".")){
+      prefix = prefix + ".";
+    }
+    prefix = prefix + app.getApplicationName();
+
     log.info("Starting DogStatsD client..");
     instancePublish = config.publish;
     statsDClient = new NonBlockingStatsDClientBuilder()
-        .prefix(app.getApplicationName())
+        .prefix(prefix)
         .hostname(config.ddAgentHost)
         .port(Integer.parseInt(config.ddPort))
         .build();

--- a/airbyte-metrics/metrics-lib/src/main/java/io/airbyte/metrics/lib/DogStatsDMetricClient.java
+++ b/airbyte-metrics/metrics-lib/src/main/java/io/airbyte/metrics/lib/DogStatsDMetricClient.java
@@ -9,7 +9,6 @@ import com.timgroup.statsd.NonBlockingStatsDClientBuilder;
 import com.timgroup.statsd.StatsDClient;
 import io.airbyte.config.Configs;
 import lombok.extern.slf4j.Slf4j;
-import org.apache.commons.lang3.StringUtils;
 
 /**
  * Light wrapper around the DogsStatsD client to make using the client slightly more ergonomic.
@@ -41,7 +40,6 @@ public class DogStatsDMetricClient implements MetricClient {
       // do nothing if we do not want to publish. All metrics methods also do nothing.
       return;
     }
-
 
     String prefix = config.ddPrefix + app.getApplicationName();
 

--- a/airbyte-metrics/metrics-lib/src/main/java/io/airbyte/metrics/lib/DogStatsDMetricSingleton.java
+++ b/airbyte-metrics/metrics-lib/src/main/java/io/airbyte/metrics/lib/DogStatsDMetricSingleton.java
@@ -9,6 +9,7 @@ import com.timgroup.statsd.NonBlockingStatsDClientBuilder;
 import com.timgroup.statsd.StatsDClient;
 import io.airbyte.config.Configs;
 import lombok.extern.slf4j.Slf4j;
+import org.apache.commons.lang3.StringUtils;
 
 /**
  * Light wrapper around the DogsStatsD client to make using the client slightly more ergonomic.
@@ -40,10 +41,11 @@ public class DogStatsDMetricSingleton {
       return;
     }
 
+    String prefix = config.ddPrefix + app.getApplicationName();
     log.info("Starting DogStatsD client..");
     instancePublish = config.publish;
     statsDClient = new NonBlockingStatsDClientBuilder()
-        .prefix(app.getApplicationName())
+        .prefix(prefix)
         .hostname(config.ddAgentHost)
         .port(Integer.parseInt(config.ddPort))
         .build();

--- a/airbyte-metrics/metrics-lib/src/main/java/io/airbyte/metrics/lib/DogStatsDMetricSingleton.java
+++ b/airbyte-metrics/metrics-lib/src/main/java/io/airbyte/metrics/lib/DogStatsDMetricSingleton.java
@@ -9,7 +9,6 @@ import com.timgroup.statsd.NonBlockingStatsDClientBuilder;
 import com.timgroup.statsd.StatsDClient;
 import io.airbyte.config.Configs;
 import lombok.extern.slf4j.Slf4j;
-import org.apache.commons.lang3.StringUtils;
 
 /**
  * Light wrapper around the DogsStatsD client to make using the client slightly more ergonomic.
@@ -42,6 +41,7 @@ public class DogStatsDMetricSingleton {
     }
 
     String prefix = config.ddPrefix + app.getApplicationName();
+    
     log.info("Starting DogStatsD client..");
     instancePublish = config.publish;
     statsDClient = new NonBlockingStatsDClientBuilder()

--- a/airbyte-metrics/metrics-lib/src/main/java/io/airbyte/metrics/lib/DogStatsDMetricSingleton.java
+++ b/airbyte-metrics/metrics-lib/src/main/java/io/airbyte/metrics/lib/DogStatsDMetricSingleton.java
@@ -41,7 +41,7 @@ public class DogStatsDMetricSingleton {
     }
 
     String prefix = config.ddPrefix + app.getApplicationName();
-    
+
     log.info("Starting DogStatsD client..");
     instancePublish = config.publish;
     statsDClient = new NonBlockingStatsDClientBuilder()

--- a/airbyte-metrics/metrics-lib/src/test/java/io/airbyte/metrics/lib/DogStatsDMetricClientTest.java
+++ b/airbyte-metrics/metrics-lib/src/test/java/io/airbyte/metrics/lib/DogStatsDMetricClientTest.java
@@ -17,7 +17,7 @@ public class DogStatsDMetricClientTest {
   @BeforeEach
   void setUp() {
     dogStatsDMetricClient = new DogStatsDMetricClient();
-    dogStatsDMetricClient.initialize(MetricEmittingApps.WORKER, new DatadogClientConfiguration("localhost", "1000", false));
+    dogStatsDMetricClient.initialize(MetricEmittingApps.WORKER, new DatadogClientConfiguration("localhost", "1000", false, ""));
   }
 
   @AfterEach

--- a/airbyte-metrics/metrics-lib/src/test/java/io/airbyte/metrics/lib/DogStatsDMetricSingletonTest.java
+++ b/airbyte-metrics/metrics-lib/src/test/java/io/airbyte/metrics/lib/DogStatsDMetricSingletonTest.java
@@ -20,7 +20,7 @@ public class DogStatsDMetricSingletonTest {
   @DisplayName("there should be no exception if we attempt to emit metrics while publish is false")
   public void testPublishTrueNoEmitError() {
     Assertions.assertDoesNotThrow(() -> {
-      DogStatsDMetricSingleton.initialize(MetricEmittingApps.WORKER, new DatadogClientConfiguration("localhost", "1000", false));
+      DogStatsDMetricSingleton.initialize(MetricEmittingApps.WORKER, new DatadogClientConfiguration("localhost", "1000", false, ""));
       DogStatsDMetricSingleton.gauge(OssMetricsRegistry.KUBE_POD_PROCESS_CREATE_TIME_MILLISECS, 1);
     });
   }
@@ -29,11 +29,19 @@ public class DogStatsDMetricSingletonTest {
   @DisplayName("there should be no exception if we attempt to emit metrics while publish is true")
   public void testPublishFalseNoEmitError() {
     Assertions.assertDoesNotThrow(() -> {
-      DogStatsDMetricSingleton.initialize(MetricEmittingApps.WORKER, new DatadogClientConfiguration("localhost", "1000", true));
+      DogStatsDMetricSingleton.initialize(MetricEmittingApps.WORKER, new DatadogClientConfiguration("localhost", "1000", true, ""));
       DogStatsDMetricSingleton.gauge(OssMetricsRegistry.KUBE_POD_PROCESS_CREATE_TIME_MILLISECS, 1);
     });
   }
 
+  @Test
+  @DisplayName("there should be no exception if we attempt to emit metrics while publish is true and prefix is specified")
+  public void testPublishTrueWithPrefixNoEmitError() {
+    Assertions.assertDoesNotThrow(() -> {
+      DogStatsDMetricSingleton.initialize(MetricEmittingApps.WORKER, new DatadogClientConfiguration("localhost", "1000", true, "airbyte_dev"));
+      DogStatsDMetricSingleton.gauge(OssMetricsRegistry.KUBE_POD_PROCESS_CREATE_TIME_MILLISECS, 1);
+    });
+  }
   @Test
   @DisplayName("there should be no exception if we attempt to emit metrics without initializing")
   public void testNoInitializeNoEmitError() {


### PR DESCRIPTION
## What
Trying to add a prefix for datadog metrics as an easy way to distinguish between environments sending metrics to the same datadog instance. 

## How
Adding a `DD_PREFIX` environment variable that gets tacked on to the prefix when initializing the datadog client.

## Recommended reading order
1. `EnvConfig.java`
2. `DatadogClientConfiguration.java`
3. `DogStatsDMetricSingleton`
4. `DogStatsDMetricClient`

## 🚨 User Impact 🚨
No user impact.

