### PR TITLE
Validate state during migration to per stream

### DIFF
--- a/airbyte-config/config-persistence/src/main/java/io/airbyte/config/persistence/StatePersistence.java
+++ b/airbyte-config/config-persistence/src/main/java/io/airbyte/config/persistence/StatePersistence.java
@@ -18,7 +18,6 @@ import io.airbyte.protocol.models.AirbyteGlobalState;
 import io.airbyte.protocol.models.AirbyteStateMessage;
 import io.airbyte.protocol.models.AirbyteStateMessage.AirbyteStateType;
 import io.airbyte.protocol.models.AirbyteStreamState;
-import io.airbyte.protocol.models.ConfiguredAirbyteCatalog;
 import io.airbyte.protocol.models.StreamDescriptor;
 import java.io.IOException;
 import java.time.OffsetDateTime;
@@ -86,24 +85,17 @@ public class StatePersistence {
    * @param state
    * @throws IOException
    */
-  public void updateOrCreateState(final UUID connectionId, final StateWrapper state, final ConfiguredAirbyteCatalog configuredCatalog)
+  public void updateOrCreateState(final UUID connectionId, final StateWrapper state)
       throws IOException {
     final Optional<StateWrapper> previousState = getCurrentState(connectionId);
     final StateType currentStateType = state.getStateType();
-    final boolean isMigration = previousState.isPresent() && previousState.get().getStateType() == StateType.LEGACY &&
-        currentStateType != StateType.LEGACY;
+    final boolean isMigration = isMigration(connectionId, currentStateType);
 
-    LOGGER.info("is migration?");
-    LOGGER.info(String.valueOf(isMigration));
     // The only case where we allow a state migration is moving from LEGACY.
     // We expect any other migration to go through an explicit reset.
     if (!isMigration && previousState.isPresent() && previousState.get().getStateType() != currentStateType) {
       throw new IllegalStateException("Unexpected type migration from '" + previousState.get().getStateType() + "' to '" + currentStateType +
           "'. Migration of StateType need to go through an explicit reset.");
-    }
-
-    if (isMigration && currentStateType == StateType.STREAM) {
-      validateStreamStates(state, configuredCatalog);
     }
 
     this.database.transaction(ctx -> {
@@ -119,26 +111,10 @@ public class StatePersistence {
     });
   }
 
-  private static void validateStreamStates(final StateWrapper state, final ConfiguredAirbyteCatalog configuredCatalog) {
-    final List<StreamDescriptor> stateStreamDescriptors =
-        state.getStateMessages().stream().map(stateMessage -> stateMessage.getStream().getStreamDescriptor()).toList();
-    LOGGER.info("stream descriptors are:");
-    stateStreamDescriptors.forEach(sd -> {
-      LOGGER.info("stream name and namespace");
-      LOGGER.info(sd.getName());
-      LOGGER.info(sd.getNamespace());
-    });
-    LOGGER.info("configured catalog streams");
-    configuredCatalog.getStreams().forEach(stream -> {
-      final StreamDescriptor streamDescriptor = new StreamDescriptor().withName(stream.getStream().getName()).withNamespace(stream.getStream().getNamespace());
-      LOGGER.info("configured stream name and namespace");
-      LOGGER.info(streamDescriptor.getName());
-      LOGGER.info(streamDescriptor.getNamespace());
-      if (!stateStreamDescriptors.contains(streamDescriptor)) {
-        throw new IllegalStateException(
-            "Job ran during migration from Legacy State to Per Stream State. This job must be retried in order to properly store state.");
-      }
-    });
+  public Boolean isMigration(final UUID connectionId, final StateType currentStateType) throws IOException {
+    final Optional<StateWrapper> previousState = getCurrentState(connectionId);
+    return previousState.isPresent() && previousState.get().getStateType() == StateType.LEGACY &&
+        currentStateType != StateType.LEGACY;
   }
 
   private static void clearLegacyState(final DSLContext ctx, final UUID connectionId) {

--- a/airbyte-config/config-persistence/src/main/java/io/airbyte/config/persistence/StatePersistence.java
+++ b/airbyte-config/config-persistence/src/main/java/io/airbyte/config/persistence/StatePersistence.java
@@ -32,8 +32,6 @@ import org.jooq.JSONB;
 import org.jooq.Record;
 import org.jooq.RecordMapper;
 import org.jooq.impl.DSL;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 
 /**
  * State Persistence
@@ -44,8 +42,6 @@ import org.slf4j.LoggerFactory;
  * reset. (an exception will be thrown)
  */
 public class StatePersistence {
-
-  private static final Logger LOGGER = LoggerFactory.getLogger(StatePersistence.class);
 
   private final ExceptionWrappingDatabase database;
 

--- a/airbyte-config/config-persistence/src/main/java/io/airbyte/config/persistence/StatePersistence.java
+++ b/airbyte-config/config-persistence/src/main/java/io/airbyte/config/persistence/StatePersistence.java
@@ -85,7 +85,7 @@ public class StatePersistence {
       throws IOException {
     final Optional<StateWrapper> previousState = getCurrentState(connectionId);
     final StateType currentStateType = state.getStateType();
-    final boolean isMigration = isMigration(connectionId, currentStateType);
+    final boolean isMigration = isMigration(connectionId, currentStateType, previousState);
 
     // The only case where we allow a state migration is moving from LEGACY.
     // We expect any other migration to go through an explicit reset.
@@ -107,8 +107,8 @@ public class StatePersistence {
     });
   }
 
-  public Boolean isMigration(final UUID connectionId, final StateType currentStateType) throws IOException {
-    final Optional<StateWrapper> previousState = getCurrentState(connectionId);
+  public Boolean isMigration(final UUID connectionId, final StateType currentStateType, final Optional<StateWrapper> previousState)
+      throws IOException {
     return previousState.isPresent() && previousState.get().getStateType() == StateType.LEGACY &&
         currentStateType != StateType.LEGACY;
   }

--- a/airbyte-config/config-persistence/src/test/java/io/airbyte/config/persistence/StatePersistenceTest.java
+++ b/airbyte-config/config-persistence/src/test/java/io/airbyte/config/persistence/StatePersistenceTest.java
@@ -27,9 +27,7 @@ import io.airbyte.db.instance.configs.ConfigsDatabaseTestProvider;
 import io.airbyte.protocol.models.AirbyteGlobalState;
 import io.airbyte.protocol.models.AirbyteStateMessage;
 import io.airbyte.protocol.models.AirbyteStateMessage.AirbyteStateType;
-import io.airbyte.protocol.models.AirbyteStream;
 import io.airbyte.protocol.models.AirbyteStreamState;
-import io.airbyte.protocol.models.ConfiguredAirbyteStream;
 import io.airbyte.protocol.models.StreamDescriptor;
 import io.airbyte.test.utils.DatabaseConnectionHelper;
 import io.airbyte.validation.json.JsonValidationException;
@@ -119,9 +117,6 @@ public class StatePersistenceTest extends BaseDatabaseConfigPersistenceTest {
     final StateWrapper state0 = new StateWrapper()
         .withStateType(StateType.LEGACY)
         .withLegacyState(Jsons.deserialize("{\"woot\": \"legacy states is passthrough\"}"));
-
-    final ConfiguredAirbyteStream stream = new ConfiguredAirbyteStream().withStream(new AirbyteStream().withName("s1").withNamespace("n1"));
-    final ConfiguredAirbyteStream stream2 = new ConfiguredAirbyteStream().withStream(new AirbyteStream().withName("s2"));
 
     statePersistence.updateOrCreateState(connectionId, state0);
 

--- a/airbyte-workers/src/main/java/io/airbyte/workers/temporal/sync/PersistStateActivity.java
+++ b/airbyte-workers/src/main/java/io/airbyte/workers/temporal/sync/PersistStateActivity.java
@@ -5,6 +5,7 @@
 package io.airbyte.workers.temporal.sync;
 
 import io.airbyte.config.StandardSyncOutput;
+import io.airbyte.protocol.models.ConfiguredAirbyteCatalog;
 import io.temporal.activity.ActivityInterface;
 import io.temporal.activity.ActivityMethod;
 import java.util.UUID;
@@ -13,6 +14,6 @@ import java.util.UUID;
 public interface PersistStateActivity {
 
   @ActivityMethod
-  boolean persist(final UUID connectionId, final StandardSyncOutput syncOutput);
+  boolean persist(final UUID connectionId, final StandardSyncOutput syncOutput, final ConfiguredAirbyteCatalog configuredCatalog);
 
 }

--- a/airbyte-workers/src/main/java/io/airbyte/workers/temporal/sync/PersistStateActivityImpl.java
+++ b/airbyte-workers/src/main/java/io/airbyte/workers/temporal/sync/PersistStateActivityImpl.java
@@ -10,6 +10,7 @@ import io.airbyte.config.State;
 import io.airbyte.config.StateWrapper;
 import io.airbyte.config.helpers.StateMessageHelper;
 import io.airbyte.config.persistence.StatePersistence;
+import io.airbyte.protocol.models.ConfiguredAirbyteCatalog;
 import java.io.IOException;
 import java.util.Optional;
 import java.util.UUID;
@@ -24,11 +25,12 @@ public class PersistStateActivityImpl implements PersistStateActivity {
   @Override
   public boolean persist(final UUID connectionId, final StandardSyncOutput syncOutput) {
     final State state = syncOutput.getState();
+    final ConfiguredAirbyteCatalog configuredCatalog = syncOutput.getOutputCatalog();
     if (state != null) {
       try {
         final Optional<StateWrapper> maybeStateWrapper = StateMessageHelper.getTypedState(state.getState(), featureFlags.useStreamCapableState());
         if (maybeStateWrapper.isPresent()) {
-          statePersistence.updateOrCreateState(connectionId, maybeStateWrapper.get());
+          statePersistence.updateOrCreateState(connectionId, maybeStateWrapper.get(), configuredCatalog);
         }
       } catch (final IOException e) {
         throw new RuntimeException(e);

--- a/airbyte-workers/src/main/java/io/airbyte/workers/temporal/sync/PersistStateActivityImpl.java
+++ b/airbyte-workers/src/main/java/io/airbyte/workers/temporal/sync/PersistStateActivityImpl.java
@@ -7,30 +7,40 @@ package io.airbyte.workers.temporal.sync;
 import io.airbyte.commons.features.FeatureFlags;
 import io.airbyte.config.StandardSyncOutput;
 import io.airbyte.config.State;
+import io.airbyte.config.StateType;
 import io.airbyte.config.StateWrapper;
 import io.airbyte.config.helpers.StateMessageHelper;
 import io.airbyte.config.persistence.StatePersistence;
 import io.airbyte.protocol.models.ConfiguredAirbyteCatalog;
+import io.airbyte.protocol.models.StreamDescriptor;
 import java.io.IOException;
+import java.util.List;
 import java.util.Optional;
 import java.util.UUID;
 import lombok.AllArgsConstructor;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 @AllArgsConstructor
 public class PersistStateActivityImpl implements PersistStateActivity {
 
   private final StatePersistence statePersistence;
   private final FeatureFlags featureFlags;
+  private static final Logger LOGGER = LoggerFactory.getLogger(PersistStateActivityImpl.class);
 
   @Override
   public boolean persist(final UUID connectionId, final StandardSyncOutput syncOutput) {
     final State state = syncOutput.getState();
-    final ConfiguredAirbyteCatalog configuredCatalog = syncOutput.getOutputCatalog();
     if (state != null) {
       try {
         final Optional<StateWrapper> maybeStateWrapper = StateMessageHelper.getTypedState(state.getState(), featureFlags.useStreamCapableState());
         if (maybeStateWrapper.isPresent()) {
-          statePersistence.updateOrCreateState(connectionId, maybeStateWrapper.get(), configuredCatalog);
+          final StateType currentStateType = maybeStateWrapper.get().getStateType();
+          if (statePersistence.isMigration(connectionId, currentStateType) && currentStateType == StateType.LEGACY) {
+            validateStreamStates(maybeStateWrapper.get(), syncOutput.getOutputCatalog());
+          }
+
+          statePersistence.updateOrCreateState(connectionId, maybeStateWrapper.get());
         }
       } catch (final IOException e) {
         throw new RuntimeException(e);
@@ -39,6 +49,28 @@ public class PersistStateActivityImpl implements PersistStateActivity {
     } else {
       return false;
     }
+  }
+
+  private static void validateStreamStates(final StateWrapper state, final ConfiguredAirbyteCatalog configuredCatalog) {
+    final List<StreamDescriptor> stateStreamDescriptors =
+        state.getStateMessages().stream().map(stateMessage -> stateMessage.getStream().getStreamDescriptor()).toList();
+    stateStreamDescriptors.forEach(sd -> {
+      LOGGER.info("stream name and namespace");
+      LOGGER.info(sd.getName());
+      LOGGER.info(sd.getNamespace());
+    });
+    LOGGER.info("configured catalog streams");
+    configuredCatalog.getStreams().forEach(stream -> {
+      final StreamDescriptor streamDescriptor = new StreamDescriptor().withName(stream.getStream().getName())
+          .withNamespace(stream.getStream().getNamespace());
+      LOGGER.info("configured stream name and namespace");
+      LOGGER.info(streamDescriptor.getName());
+      LOGGER.info(streamDescriptor.getNamespace());
+      if (!stateStreamDescriptors.contains(streamDescriptor)) {
+        throw new IllegalStateException(
+            "Job ran during migration from Legacy State to Per Stream State. This job must be retried in order to properly store state.");
+      }
+    });
   }
 
 }

--- a/airbyte-workers/src/main/java/io/airbyte/workers/temporal/sync/PersistStateActivityImpl.java
+++ b/airbyte-workers/src/main/java/io/airbyte/workers/temporal/sync/PersistStateActivityImpl.java
@@ -36,7 +36,7 @@ public class PersistStateActivityImpl implements PersistStateActivity {
         final Optional<StateWrapper> maybeStateWrapper = StateMessageHelper.getTypedState(state.getState(), featureFlags.useStreamCapableState());
         if (maybeStateWrapper.isPresent()) {
           final StateType currentStateType = maybeStateWrapper.get().getStateType();
-          if (statePersistence.isMigration(connectionId, currentStateType) && currentStateType == StateType.LEGACY) {
+          if (statePersistence.isMigration(connectionId, currentStateType)) {
             validateStreamStates(maybeStateWrapper.get(), syncOutput.getOutputCatalog());
           }
 
@@ -54,18 +54,9 @@ public class PersistStateActivityImpl implements PersistStateActivity {
   private static void validateStreamStates(final StateWrapper state, final ConfiguredAirbyteCatalog configuredCatalog) {
     final List<StreamDescriptor> stateStreamDescriptors =
         state.getStateMessages().stream().map(stateMessage -> stateMessage.getStream().getStreamDescriptor()).toList();
-    stateStreamDescriptors.forEach(sd -> {
-      LOGGER.info("stream name and namespace");
-      LOGGER.info(sd.getName());
-      LOGGER.info(sd.getNamespace());
-    });
-    LOGGER.info("configured catalog streams");
     configuredCatalog.getStreams().forEach(stream -> {
       final StreamDescriptor streamDescriptor = new StreamDescriptor().withName(stream.getStream().getName())
           .withNamespace(stream.getStream().getNamespace());
-      LOGGER.info("configured stream name and namespace");
-      LOGGER.info(streamDescriptor.getName());
-      LOGGER.info(streamDescriptor.getNamespace());
       if (!stateStreamDescriptors.contains(streamDescriptor)) {
         throw new IllegalStateException(
             "Job ran during migration from Legacy State to Per Stream State. This job must be retried in order to properly store state.");

--- a/airbyte-workers/src/main/java/io/airbyte/workers/temporal/sync/PersistStateActivityImpl.java
+++ b/airbyte-workers/src/main/java/io/airbyte/workers/temporal/sync/PersistStateActivityImpl.java
@@ -18,15 +18,12 @@ import java.util.List;
 import java.util.Optional;
 import java.util.UUID;
 import lombok.AllArgsConstructor;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 
 @AllArgsConstructor
 public class PersistStateActivityImpl implements PersistStateActivity {
 
   private final StatePersistence statePersistence;
   private final FeatureFlags featureFlags;
-  private static final Logger LOGGER = LoggerFactory.getLogger(PersistStateActivityImpl.class);
 
   @Override
   public boolean persist(final UUID connectionId, final StandardSyncOutput syncOutput) {

--- a/airbyte-workers/src/main/java/io/airbyte/workers/temporal/sync/PersistStateActivityImpl.java
+++ b/airbyte-workers/src/main/java/io/airbyte/workers/temporal/sync/PersistStateActivityImpl.java
@@ -12,6 +12,7 @@ import io.airbyte.config.StateType;
 import io.airbyte.config.StateWrapper;
 import io.airbyte.config.helpers.StateMessageHelper;
 import io.airbyte.config.persistence.StatePersistence;
+import io.airbyte.protocol.models.CatalogHelpers;
 import io.airbyte.protocol.models.ConfiguredAirbyteCatalog;
 import io.airbyte.protocol.models.StreamDescriptor;
 import java.io.IOException;
@@ -54,9 +55,8 @@ public class PersistStateActivityImpl implements PersistStateActivity {
   void validateStreamStates(final StateWrapper state, final ConfiguredAirbyteCatalog configuredCatalog) {
     final List<StreamDescriptor> stateStreamDescriptors =
         state.getStateMessages().stream().map(stateMessage -> stateMessage.getStream().getStreamDescriptor()).toList();
-    configuredCatalog.getStreams().forEach(stream -> {
-      final StreamDescriptor streamDescriptor = new StreamDescriptor().withName(stream.getStream().getName())
-          .withNamespace(stream.getStream().getNamespace());
+    final List<StreamDescriptor> catalogStreamDescriptors = CatalogHelpers.extractStreamDescriptors(configuredCatalog);
+    catalogStreamDescriptors.forEach(streamDescriptor -> {
       if (!stateStreamDescriptors.contains(streamDescriptor)) {
         throw new IllegalStateException(
             "Job ran during migration from Legacy State to Per Stream State. One of the streams that did not have state is: " + streamDescriptor

--- a/airbyte-workers/src/main/java/io/airbyte/workers/temporal/sync/SyncWorkflowImpl.java
+++ b/airbyte-workers/src/main/java/io/airbyte/workers/temporal/sync/SyncWorkflowImpl.java
@@ -11,6 +11,7 @@ import io.airbyte.config.StandardSyncInput;
 import io.airbyte.config.StandardSyncOperation;
 import io.airbyte.config.StandardSyncOperation.OperatorType;
 import io.airbyte.config.StandardSyncOutput;
+import io.airbyte.protocol.models.ConfiguredAirbyteCatalog;
 import io.airbyte.scheduler.models.IntegrationLauncherConfig;
 import io.airbyte.scheduler.models.JobRunConfig;
 import io.airbyte.workers.temporal.scheduling.shared.ActivityConfiguration;
@@ -47,7 +48,8 @@ public class SyncWorkflowImpl implements SyncWorkflow {
       // the state is persisted immediately after the replication succeeded, because the
       // state is a checkpoint of the raw data that has been copied to the destination;
       // normalization & dbt does not depend on it
-      persistActivity.persist(connectionId, syncOutput);
+      final ConfiguredAirbyteCatalog configuredCatalog = syncInput.getCatalog();
+      persistActivity.persist(connectionId, syncOutput, configuredCatalog);
     }
 
     if (syncInput.getOperationSequence() != null && !syncInput.getOperationSequence().isEmpty()) {

--- a/airbyte-workers/src/test/java/io/airbyte/workers/temporal/SyncWorkflowTest.java
+++ b/airbyte-workers/src/test/java/io/airbyte/workers/temporal/SyncWorkflowTest.java
@@ -139,7 +139,7 @@ class SyncWorkflowTest {
     final StandardSyncOutput actualOutput = execute();
 
     verifyReplication(replicationActivity, syncInput, sync.getConnectionId());
-    verifyPersistState(persistStateActivity, sync, replicationSuccessOutput, new ConfiguredAirbyteCatalog());
+    verifyPersistState(persistStateActivity, sync, replicationSuccessOutput, syncInput.getCatalog());
     verifyNormalize(normalizationActivity, normalizationInput);
     verifyDbtTransform(dbtTransformationActivity, syncInput.getResourceRequirements(), operatorDbtInput);
     assertEquals(replicationSuccessOutput.withNormalizationSummary(normalizationSummary), actualOutput);
@@ -177,7 +177,7 @@ class SyncWorkflowTest {
     assertThrows(WorkflowFailedException.class, this::execute);
 
     verifyReplication(replicationActivity, syncInput, sync.getConnectionId());
-    verifyPersistState(persistStateActivity, sync, replicationSuccessOutput, new ConfiguredAirbyteCatalog());
+    verifyPersistState(persistStateActivity, sync, replicationSuccessOutput, syncInput.getCatalog());
     verifyNormalize(normalizationActivity, normalizationInput);
     verifyNoInteractions(dbtTransformationActivity);
   }
@@ -220,7 +220,7 @@ class SyncWorkflowTest {
     assertThrows(WorkflowFailedException.class, this::execute);
 
     verifyReplication(replicationActivity, syncInput, sync.getConnectionId());
-    verifyPersistState(persistStateActivity, sync, replicationSuccessOutput, new ConfiguredAirbyteCatalog());
+    verifyPersistState(persistStateActivity, sync, replicationSuccessOutput, syncInput.getCatalog());
     verifyNormalize(normalizationActivity, normalizationInput);
     verifyNoInteractions(dbtTransformationActivity);
   }

--- a/airbyte-workers/src/test/java/io/airbyte/workers/temporal/SyncWorkflowTest.java
+++ b/airbyte-workers/src/test/java/io/airbyte/workers/temporal/SyncWorkflowTest.java
@@ -20,6 +20,7 @@ import io.airbyte.config.ResourceRequirements;
 import io.airbyte.config.StandardSync;
 import io.airbyte.config.StandardSyncInput;
 import io.airbyte.config.StandardSyncOutput;
+import io.airbyte.protocol.models.ConfiguredAirbyteCatalog;
 import io.airbyte.scheduler.models.IntegrationLauncherConfig;
 import io.airbyte.scheduler.models.JobRunConfig;
 import io.airbyte.workers.TestConfigHelpers;
@@ -138,7 +139,7 @@ class SyncWorkflowTest {
     final StandardSyncOutput actualOutput = execute();
 
     verifyReplication(replicationActivity, syncInput, sync.getConnectionId());
-    verifyPersistState(persistStateActivity, sync, replicationSuccessOutput);
+    verifyPersistState(persistStateActivity, sync, replicationSuccessOutput, new ConfiguredAirbyteCatalog());
     verifyNormalize(normalizationActivity, normalizationInput);
     verifyDbtTransform(dbtTransformationActivity, syncInput.getResourceRequirements(), operatorDbtInput);
     assertEquals(replicationSuccessOutput.withNormalizationSummary(normalizationSummary), actualOutput);
@@ -176,7 +177,7 @@ class SyncWorkflowTest {
     assertThrows(WorkflowFailedException.class, this::execute);
 
     verifyReplication(replicationActivity, syncInput, sync.getConnectionId());
-    verifyPersistState(persistStateActivity, sync, replicationSuccessOutput);
+    verifyPersistState(persistStateActivity, sync, replicationSuccessOutput, new ConfiguredAirbyteCatalog());
     verifyNormalize(normalizationActivity, normalizationInput);
     verifyNoInteractions(dbtTransformationActivity);
   }
@@ -219,7 +220,7 @@ class SyncWorkflowTest {
     assertThrows(WorkflowFailedException.class, this::execute);
 
     verifyReplication(replicationActivity, syncInput, sync.getConnectionId());
-    verifyPersistState(persistStateActivity, sync, replicationSuccessOutput);
+    verifyPersistState(persistStateActivity, sync, replicationSuccessOutput, new ConfiguredAirbyteCatalog());
     verifyNormalize(normalizationActivity, normalizationInput);
     verifyNoInteractions(dbtTransformationActivity);
   }
@@ -251,10 +252,12 @@ class SyncWorkflowTest {
 
   private static void verifyPersistState(final PersistStateActivity persistStateActivity,
                                          final StandardSync sync,
-                                         final StandardSyncOutput syncOutput) {
+                                         final StandardSyncOutput syncOutput,
+                                         final ConfiguredAirbyteCatalog configuredCatalog) {
     verify(persistStateActivity).persist(
         sync.getConnectionId(),
-        syncOutput);
+        syncOutput,
+        configuredCatalog);
   }
 
   private static void verifyNormalize(final NormalizationActivity normalizationActivity, final NormalizationInput normalizationInput) {

--- a/airbyte-workers/src/test/java/io/airbyte/workers/temporal/sync/PersistStateActivityTest.java
+++ b/airbyte-workers/src/test/java/io/airbyte/workers/temporal/sync/PersistStateActivityTest.java
@@ -11,6 +11,7 @@ import io.airbyte.config.StandardSyncOutput;
 import io.airbyte.config.State;
 import io.airbyte.config.StateWrapper;
 import io.airbyte.config.persistence.StatePersistence;
+import io.airbyte.protocol.models.ConfiguredAirbyteCatalog;
 import java.io.IOException;
 import java.util.UUID;
 import org.elasticsearch.common.collect.Map;
@@ -54,7 +55,8 @@ public class PersistStateActivityTest {
     persistStateActivity.persist(CONNECTION_ID, new StandardSyncOutput().withState(state));
 
     // The ser/der of the state into a state wrapper is tested in StateMessageHelperTest
-    Mockito.verify(statePersistence).updateOrCreateState(Mockito.eq(CONNECTION_ID), Mockito.any(StateWrapper.class));
+    Mockito.verify(statePersistence).updateOrCreateState(Mockito.eq(CONNECTION_ID), Mockito.any(StateWrapper.class), Mockito.any(
+        ConfiguredAirbyteCatalog.class));
   }
 
 }

--- a/airbyte-workers/src/test/java/io/airbyte/workers/temporal/sync/PersistStateActivityTest.java
+++ b/airbyte-workers/src/test/java/io/airbyte/workers/temporal/sync/PersistStateActivityTest.java
@@ -9,11 +9,21 @@ import io.airbyte.commons.features.FeatureFlags;
 import io.airbyte.commons.json.Jsons;
 import io.airbyte.config.StandardSyncOutput;
 import io.airbyte.config.State;
+import io.airbyte.config.StateType;
 import io.airbyte.config.StateWrapper;
 import io.airbyte.config.persistence.StatePersistence;
+import io.airbyte.protocol.models.AirbyteStateMessage;
+import io.airbyte.protocol.models.AirbyteStateMessage.AirbyteStateType;
+import io.airbyte.protocol.models.AirbyteStream;
+import io.airbyte.protocol.models.AirbyteStreamState;
+import io.airbyte.protocol.models.ConfiguredAirbyteCatalog;
+import io.airbyte.protocol.models.ConfiguredAirbyteStream;
+import io.airbyte.protocol.models.StreamDescriptor;
 import java.io.IOException;
+import java.util.List;
 import java.util.UUID;
 import org.elasticsearch.common.collect.Map;
+import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.InjectMocks;
@@ -58,8 +68,45 @@ public class PersistStateActivityTest {
   }
 
   @Test
-  public void testPersistWithInvalidState() {
+  public void testPersistWithInvalidStateDuringMigration() throws IOException {
+    final AirbyteStateMessage stateMessage1 = new AirbyteStateMessage()
+        .withType(AirbyteStateType.STREAM)
+        .withStream(
+            new AirbyteStreamState().withStreamDescriptor(new StreamDescriptor().withName("a").withNamespace("a1"))
+                .withStreamState(Jsons.emptyObject()));
+    final JsonNode jsonState = Jsons.jsonNode(List.of(stateMessage1));
+    final State state = new State().withState(jsonState);
 
+    final ConfiguredAirbyteStream stream = new ConfiguredAirbyteStream().withStream(new AirbyteStream().withName("a").withNamespace("a1"));
+    final ConfiguredAirbyteStream stream2 = new ConfiguredAirbyteStream().withStream(new AirbyteStream().withName("b"));
+    final ConfiguredAirbyteCatalog migrationConfiguredCatalog = new ConfiguredAirbyteCatalog().withStreams(List.of(stream, stream2));
+    final StandardSyncOutput syncOutput = new StandardSyncOutput().withState(state).withOutputCatalog(migrationConfiguredCatalog);
+    Mockito.when(featureFlags.useStreamCapableState()).thenReturn(true);
+    Mockito.when(statePersistence.isMigration(CONNECTION_ID, StateType.STREAM)).thenReturn(true);
+    Assertions.assertThrows(IllegalStateException.class, () -> persistStateActivity.persist(CONNECTION_ID, syncOutput));
+  }
+
+  @Test
+  public void testPersistWithValidStateDuringMigration() throws IOException {
+    final AirbyteStateMessage stateMessage1 = new AirbyteStateMessage()
+        .withType(AirbyteStateType.STREAM)
+        .withStream(
+            new AirbyteStreamState().withStreamDescriptor(new StreamDescriptor().withName("a").withNamespace("a1"))
+                .withStreamState(Jsons.emptyObject()));
+    final AirbyteStateMessage stateMessage2 = new AirbyteStateMessage()
+        .withType(AirbyteStateType.STREAM)
+        .withStream(
+            new AirbyteStreamState().withStreamDescriptor(new StreamDescriptor().withName("b")).withStreamState(Jsons.emptyObject()));
+    final JsonNode jsonState = Jsons.jsonNode(List.of(stateMessage1, stateMessage2));
+    final State state = new State().withState(jsonState);
+
+    final ConfiguredAirbyteStream stream = new ConfiguredAirbyteStream().withStream(new AirbyteStream().withName("a").withNamespace("a1"));
+    final ConfiguredAirbyteStream stream2 = new ConfiguredAirbyteStream().withStream(new AirbyteStream().withName("b"));
+    final ConfiguredAirbyteCatalog migrationConfiguredCatalog = new ConfiguredAirbyteCatalog().withStreams(List.of(stream, stream2));
+    final StandardSyncOutput syncOutput = new StandardSyncOutput().withState(state).withOutputCatalog(migrationConfiguredCatalog);
+    Mockito.when(featureFlags.useStreamCapableState()).thenReturn(true);
+    Mockito.when(statePersistence.isMigration(CONNECTION_ID, StateType.STREAM)).thenReturn(true);
+    persistStateActivity.persist(CONNECTION_ID, syncOutput);
   }
 
 }

--- a/airbyte-workers/src/test/java/io/airbyte/workers/temporal/sync/PersistStateActivityTest.java
+++ b/airbyte-workers/src/test/java/io/airbyte/workers/temporal/sync/PersistStateActivityTest.java
@@ -11,7 +11,6 @@ import io.airbyte.config.StandardSyncOutput;
 import io.airbyte.config.State;
 import io.airbyte.config.StateWrapper;
 import io.airbyte.config.persistence.StatePersistence;
-import io.airbyte.protocol.models.ConfiguredAirbyteCatalog;
 import java.io.IOException;
 import java.util.UUID;
 import org.elasticsearch.common.collect.Map;
@@ -55,8 +54,12 @@ public class PersistStateActivityTest {
     persistStateActivity.persist(CONNECTION_ID, new StandardSyncOutput().withState(state));
 
     // The ser/der of the state into a state wrapper is tested in StateMessageHelperTest
-    Mockito.verify(statePersistence).updateOrCreateState(Mockito.eq(CONNECTION_ID), Mockito.any(StateWrapper.class), Mockito.any(
-        ConfiguredAirbyteCatalog.class));
+    Mockito.verify(statePersistence).updateOrCreateState(Mockito.eq(CONNECTION_ID), Mockito.any(StateWrapper.class));
+  }
+
+  @Test
+  public void testPersistWithInvalidState() {
+
   }
 
 }

--- a/airbyte-workers/src/test/java/io/airbyte/workers/temporal/sync/PersistStateActivityTest.java
+++ b/airbyte-workers/src/test/java/io/airbyte/workers/temporal/sync/PersistStateActivityTest.java
@@ -73,7 +73,7 @@ public class PersistStateActivityTest {
   // For per-stream state, we expect there to be state for each stream within the configured catalog
   // input into a job
   // This test is to ensure that we correctly throw an error if not every stream in the configured
-  // catalog has a state message
+  // catalog has a state message when migrating from Legacy to Per-Stream
   @Test
   public void testPersistWithInvalidStateDuringMigration() throws IOException {
     final ConfiguredAirbyteStream stream = new ConfiguredAirbyteStream().withStream(new AirbyteStream().withName("a").withNamespace("a1"));


### PR DESCRIPTION
Resolves https://app.zenhub.com/workspaces/oss-platform-625a01eb010e82001390f49e/issues/airbytehq/airbyte/14519

We need to validate that if the state we are trying to persist is per stream, then there should be a state for each stream in the catalog. If not, the sync should fail. This will be an issue for jobs that are running when we flip on the per stream flag, so this happens within a check that we are in the middle of a migration.

Link to slack thread on this: https://airbytehq-team.slack.com/archives/C03AS1GAQV6/p1657237534615179