### PR TITLE
Fix HubSpot documentation, remove mentioning of Mailchimp

### DIFF
--- a/docs/integrations/sources/hubspot.md
+++ b/docs/integrations/sources/hubspot.md
@@ -121,7 +121,7 @@ HubSpot's API will [rate limit](https://developers.hubspot.com/docs/api/usage-de
 
 ## Tutorials
 
-Now that you have set up the Mailchimp source connector, check out the following Hubspot tutorial:
+Now that you have set up the HubSpot source connector, check out the following HubSpot tutorial:
 
 [Build a single customer view with open-source tools](https://airbyte.com/tutorials/single-customer-view)
 


### PR DESCRIPTION
## What
In the HubSpot connector documentation there was still a copy/paste error mentioning Mailchimp instead of HubSpot. This change resolves this.

## How
Changed ~Mailchimp~ into HubSpot
