### PR TITLE
Kubernetes: Datadog Constant Tags

### DIFF
--- a/airbyte-config/config-models/src/main/java/io/airbyte/config/Configs.java
+++ b/airbyte-config/config-models/src/main/java/io/airbyte/config/Configs.java
@@ -462,6 +462,11 @@ public interface Configs {
   String getDDDogStatsDPort();
 
   /**
+   * Set constant tags to be attached to all metrics. Useful for distinguishing between environments.
+   */
+  List<String> getDDConstantTags();
+
+  /**
    * Define whether to publish tracking events to Segment or log-only. Airbyte internal use.
    */
   TrackingStrategy getTrackingStrategy();

--- a/airbyte-config/config-models/src/main/java/io/airbyte/config/Configs.java
+++ b/airbyte-config/config-models/src/main/java/io/airbyte/config/Configs.java
@@ -463,6 +463,7 @@ public interface Configs {
 
   /**
    * Set constant tags to be attached to all metrics. Useful for distinguishing between environments.
+   * Example: airbyte_instance:dev,k8s-cluster:aws-dev
    */
   List<String> getDDConstantTags();
 

--- a/airbyte-config/config-models/src/main/java/io/airbyte/config/EnvConfigs.java
+++ b/airbyte-config/config-models/src/main/java/io/airbyte/config/EnvConfigs.java
@@ -100,6 +100,7 @@ public class EnvConfigs implements Configs {
   private static final String DD_AGENT_HOST = "DD_AGENT_HOST";
   private static final String DD_DOGSTATSD_PORT = "DD_DOGSTATSD_PORT";
 
+  private static final String DD_CONSTANT_TAGS = "DD_CONSTANT_TAGS";
   public static final String STATE_STORAGE_S3_BUCKET_NAME = "STATE_STORAGE_S3_BUCKET_NAME";
   public static final String STATE_STORAGE_S3_REGION = "STATE_STORAGE_S3_REGION";
   public static final String STATE_STORAGE_S3_ACCESS_KEY = "STATE_STORAGE_S3_ACCESS_KEY";
@@ -794,6 +795,12 @@ public class EnvConfigs implements Configs {
   @Override
   public String getDDDogStatsDPort() {
     return getEnvOrDefault(DD_DOGSTATSD_PORT, "");
+  }
+
+  @Override
+  public List<String> getDDConstantTags() {
+    String tagsString = getEnvOrDefault(DD_CONSTANT_TAGS, "");
+    return Splitter.on(",").splitToList(tagsString);
   }
 
   @Override

--- a/airbyte-config/config-models/src/main/java/io/airbyte/config/EnvConfigs.java
+++ b/airbyte-config/config-models/src/main/java/io/airbyte/config/EnvConfigs.java
@@ -99,7 +99,7 @@ public class EnvConfigs implements Configs {
   private static final String CONTAINER_ORCHESTRATOR_IMAGE = "CONTAINER_ORCHESTRATOR_IMAGE";
   private static final String DD_AGENT_HOST = "DD_AGENT_HOST";
   private static final String DD_DOGSTATSD_PORT = "DD_DOGSTATSD_PORT";
-  private static final String DD_CONSTANT_TAGS = "DD_CONSTANT_TAGS";
+  public static final String DD_CONSTANT_TAGS = "DD_CONSTANT_TAGS";
   public static final String STATE_STORAGE_S3_BUCKET_NAME = "STATE_STORAGE_S3_BUCKET_NAME";
   public static final String STATE_STORAGE_S3_REGION = "STATE_STORAGE_S3_REGION";
   public static final String STATE_STORAGE_S3_ACCESS_KEY = "STATE_STORAGE_S3_ACCESS_KEY";
@@ -799,7 +799,10 @@ public class EnvConfigs implements Configs {
   @Override
   public List<String> getDDConstantTags() {
     String tagsString = getEnvOrDefault(DD_CONSTANT_TAGS, "");
-    return Splitter.on(",").splitToList(tagsString);
+    return Splitter.on(",")
+            .splitToStream(tagsString)
+            .filter(s -> !s.trim().isBlank())
+            .collect(Collectors.toList());
   }
 
   @Override

--- a/airbyte-config/config-models/src/main/java/io/airbyte/config/EnvConfigs.java
+++ b/airbyte-config/config-models/src/main/java/io/airbyte/config/EnvConfigs.java
@@ -99,7 +99,6 @@ public class EnvConfigs implements Configs {
   private static final String CONTAINER_ORCHESTRATOR_IMAGE = "CONTAINER_ORCHESTRATOR_IMAGE";
   private static final String DD_AGENT_HOST = "DD_AGENT_HOST";
   private static final String DD_DOGSTATSD_PORT = "DD_DOGSTATSD_PORT";
-
   private static final String DD_CONSTANT_TAGS = "DD_CONSTANT_TAGS";
   public static final String STATE_STORAGE_S3_BUCKET_NAME = "STATE_STORAGE_S3_BUCKET_NAME";
   public static final String STATE_STORAGE_S3_REGION = "STATE_STORAGE_S3_REGION";

--- a/airbyte-config/config-models/src/test/java/io/airbyte/config/EnvConfigsTest.java
+++ b/airbyte-config/config-models/src/test/java/io/airbyte/config/EnvConfigsTest.java
@@ -359,10 +359,11 @@ class EnvConfigsTest {
   @DisplayName("Should parse constant tags")
   void testDDConstantTags() {
     assertTrue(config.getDDConstantTags().isEmpty());
+    assertEquals(List.of(), config.getDDConstantTags());
 
     envMap.put(EnvConfigs.DD_CONSTANT_TAGS,"airbyte_instance:dev,k8s-cluster:eks-dev");
-    assertTrue(config.getDDConstantTags().contains("airbyte_instance:dev"));
-    assertTrue(config.getDDConstantTags().contains("k8s-cluster:eks-dev"));
+    List<String> expected = List.of("airbyte_instance:dev", "k8s-cluster:eks-dev");
+    assertEquals(expected, config.getDDConstantTags());
     assertEquals(2, config.getDDConstantTags().size());
   }
   @Nested

--- a/airbyte-config/config-models/src/test/java/io/airbyte/config/EnvConfigsTest.java
+++ b/airbyte-config/config-models/src/test/java/io/airbyte/config/EnvConfigsTest.java
@@ -355,7 +355,16 @@ class EnvConfigsTest {
     envMap.put(EnvConfigs.PUBLISH_METRICS, "");
     assertFalse(config.getPublishMetrics());
   }
+  @Test
+  @DisplayName("Should parse constant tags")
+  void testDDConstantTags() {
+    assertTrue(config.getDDConstantTags().isEmpty());
 
+    envMap.put(EnvConfigs.DD_CONSTANT_TAGS,"airbyte_instance:dev,k8s-cluster:eks-dev");
+    assertTrue(config.getDDConstantTags().contains("airbyte_instance:dev"));
+    assertTrue(config.getDDConstantTags().contains("k8s-cluster:eks-dev"));
+    assertEquals(2, config.getDDConstantTags().size());
+  }
   @Nested
   @DisplayName("CheckJobResourceSettings")
   class CheckJobResourceSettings {

--- a/airbyte-config/config-models/src/test/java/io/airbyte/config/EnvConfigsTest.java
+++ b/airbyte-config/config-models/src/test/java/io/airbyte/config/EnvConfigsTest.java
@@ -358,7 +358,9 @@ class EnvConfigsTest {
   @Test
   @DisplayName("Should parse constant tags")
   void testDDConstantTags() {
-    assertTrue(config.getDDConstantTags().isEmpty());
+    assertEquals(List.of(), config.getDDConstantTags());
+
+    envMap.put(EnvConfigs.DD_CONSTANT_TAGS, " ");
     assertEquals(List.of(), config.getDDConstantTags());
 
     envMap.put(EnvConfigs.DD_CONSTANT_TAGS,"airbyte_instance:dev,k8s-cluster:eks-dev");

--- a/airbyte-metrics/metrics-lib/src/main/java/io/airbyte/metrics/lib/DatadogClientConfiguration.java
+++ b/airbyte-metrics/metrics-lib/src/main/java/io/airbyte/metrics/lib/DatadogClientConfiguration.java
@@ -7,6 +7,8 @@ package io.airbyte.metrics.lib;
 import io.airbyte.config.Configs;
 import lombok.AllArgsConstructor;
 
+import java.util.List;
+
 /**
  * POJO of configuration required for publishing metrics.
  */
@@ -17,10 +19,12 @@ public class DatadogClientConfiguration {
   public final String ddPort;
   public final boolean publish;
 
+  public final List<String> constantTags;
   public DatadogClientConfiguration(final Configs configs) {
     this.ddAgentHost = configs.getDDAgentHost();
     this.ddPort = configs.getDDDogStatsDPort();
     this.publish = configs.getPublishMetrics();
+    this.constantTags = configs.getDDConstantTags();
   }
 
 }

--- a/airbyte-metrics/metrics-lib/src/main/java/io/airbyte/metrics/lib/DogStatsDMetricClient.java
+++ b/airbyte-metrics/metrics-lib/src/main/java/io/airbyte/metrics/lib/DogStatsDMetricClient.java
@@ -47,6 +47,7 @@ public class DogStatsDMetricClient implements MetricClient {
         .prefix(app.getApplicationName())
         .hostname(config.ddAgentHost)
         .port(Integer.parseInt(config.ddPort))
+        .constantTags(config.constantTags.toArray(new String[0]))
         .build();
   }
 

--- a/airbyte-metrics/metrics-lib/src/main/java/io/airbyte/metrics/lib/DogStatsDMetricSingleton.java
+++ b/airbyte-metrics/metrics-lib/src/main/java/io/airbyte/metrics/lib/DogStatsDMetricSingleton.java
@@ -46,6 +46,7 @@ public class DogStatsDMetricSingleton {
         .prefix(app.getApplicationName())
         .hostname(config.ddAgentHost)
         .port(Integer.parseInt(config.ddPort))
+        .constantTags(config.constantTags.toArray(new String[0]))
         .build();
   }
 

--- a/airbyte-metrics/metrics-lib/src/test/java/io/airbyte/metrics/lib/DogStatsDMetricClientTest.java
+++ b/airbyte-metrics/metrics-lib/src/test/java/io/airbyte/metrics/lib/DogStatsDMetricClientTest.java
@@ -9,15 +9,17 @@ import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
+import java.util.Collections;
 
-class DogStatsDMetricClientTest {
+public class DogStatsDMetricClientTest {
+
 
   DogStatsDMetricClient dogStatsDMetricClient;
 
   @BeforeEach
   void setUp() {
     dogStatsDMetricClient = new DogStatsDMetricClient();
-    dogStatsDMetricClient.initialize(MetricEmittingApps.WORKER, new DatadogClientConfiguration("localhost", "1000", false));
+    dogStatsDMetricClient.initialize(MetricEmittingApps.WORKER, new DatadogClientConfiguration("localhost", "1000", false, Collections.emptyList()));
   }
 
   @AfterEach

--- a/airbyte-metrics/metrics-lib/src/test/java/io/airbyte/metrics/lib/DogStatsDMetricSingletonTest.java
+++ b/airbyte-metrics/metrics-lib/src/test/java/io/airbyte/metrics/lib/DogStatsDMetricSingletonTest.java
@@ -8,8 +8,10 @@ import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
+import java.util.Collections;
 
-class DogStatsDMetricSingletonTest {
+public class DogStatsDMetricSingletonTest {
+
 
   @AfterEach
   void tearDown() {
@@ -20,7 +22,7 @@ class DogStatsDMetricSingletonTest {
   @DisplayName("there should be no exception if we attempt to emit metrics while publish is false")
   void testPublishTrueNoEmitError() {
     Assertions.assertDoesNotThrow(() -> {
-      DogStatsDMetricSingleton.initialize(MetricEmittingApps.WORKER, new DatadogClientConfiguration("localhost", "1000", false));
+      DogStatsDMetricSingleton.initialize(MetricEmittingApps.WORKER, new DatadogClientConfiguration("localhost", "1000", false, Collections.emptyList()));
       DogStatsDMetricSingleton.gauge(OssMetricsRegistry.KUBE_POD_PROCESS_CREATE_TIME_MILLISECS, 1);
     });
   }
@@ -29,7 +31,7 @@ class DogStatsDMetricSingletonTest {
   @DisplayName("there should be no exception if we attempt to emit metrics while publish is true")
   void testPublishFalseNoEmitError() {
     Assertions.assertDoesNotThrow(() -> {
-      DogStatsDMetricSingleton.initialize(MetricEmittingApps.WORKER, new DatadogClientConfiguration("localhost", "1000", true));
+      DogStatsDMetricSingleton.initialize(MetricEmittingApps.WORKER, new DatadogClientConfiguration("localhost", "1000", true, Collections.emptyList() ));
       DogStatsDMetricSingleton.gauge(OssMetricsRegistry.KUBE_POD_PROCESS_CREATE_TIME_MILLISECS, 1);
     });
   }


### PR DESCRIPTION
adding option for constant tags to be sent to datadog for split environments

## What
Adding a configuration option to specify tags per Airbyte instance.

## How
*Describe the solution*

## Recommended reading order
1. `EnvConfigs.java`
2. `DatadogClientConfiguration.java`
3. `DogStatsDMetricClient.java`

## 🚨 User Impact 🚨
No user impact.

