### PR TITLE
Bump mongoDb strict encrypt connector

### DIFF
--- a/airbyte-integrations/connectors/destination-mongodb-strict-encrypt/Dockerfile
+++ b/airbyte-integrations/connectors/destination-mongodb-strict-encrypt/Dockerfile
@@ -16,5 +16,5 @@ ENV APPLICATION destination-mongodb-strict-encrypt
 
 COPY --from=build /airbyte /airbyte
 
-LABEL io.airbyte.version=0.1.2
+LABEL io.airbyte.version=0.1.5
 LABEL io.airbyte.name=airbyte/destination-mongodb-strict-encrypt

--- a/airbyte-integrations/connectors/destination-mongodb-strict-encrypt/Dockerfile
+++ b/airbyte-integrations/connectors/destination-mongodb-strict-encrypt/Dockerfile
@@ -16,5 +16,5 @@ ENV APPLICATION destination-mongodb-strict-encrypt
 
 COPY --from=build /airbyte /airbyte
 
-LABEL io.airbyte.version=0.1.1
+LABEL io.airbyte.version=0.1.2
 LABEL io.airbyte.name=airbyte/destination-mongodb-strict-encrypt


### PR DESCRIPTION
## What
Bump the connector version to make sure that the state lifecycle manager is included.