### PR TITLE
Fix precision of timestamps in comparison in CDC acceptance tests

### DIFF
--- a/airbyte-tests/src/acceptanceTests/java/io/airbyte/test/acceptance/CdcAcceptanceTests.java
+++ b/airbyte-tests/src/acceptanceTests/java/io/airbyte/test/acceptance/CdcAcceptanceTests.java
@@ -320,15 +320,15 @@ public class CdcAcceptanceTests {
             .allMatch(column -> Objects.equals(sourceRecordMap.get(column), destRecordMap.get(column)));
 
         final Object cdcUpdatedAtValue = destRecordMap.get(CDC_UPDATED_AT_COLUMN);
-        // use !isBefore instead of isAfter so that the match still succeeds if the timestamps are equal
+        // use epoch millis to guarantee the two values are at the same precision
         boolean cdcUpdatedAtMatches = cdcUpdatedAtValue != null
-            && !Instant.parse(String.valueOf(cdcUpdatedAtValue)).isBefore(recordMatcher.minUpdatedAt);
+            && Instant.parse(String.valueOf(cdcUpdatedAtValue)).toEpochMilli() >= recordMatcher.minUpdatedAt.toEpochMilli();
 
         final Object cdcDeletedAtValue = destRecordMap.get(CDC_DELETED_AT_COLUMN);
         boolean cdcDeletedAtMatches;
         if (recordMatcher.minDeletedAt.isPresent()) {
           cdcDeletedAtMatches = cdcDeletedAtValue != null
-              && !Instant.parse(String.valueOf(cdcDeletedAtValue)).isBefore(recordMatcher.minDeletedAt.get());
+              && Instant.parse(String.valueOf(cdcDeletedAtValue)).toEpochMilli() >= recordMatcher.minDeletedAt.get().toEpochMilli();
         } else {
           cdcDeletedAtMatches = cdcDeletedAtValue == null;
         }


### PR DESCRIPTION
## What

Fixes an issue in which the precision of timestamps in the database was lower than the precision of the timestamps in the test (e.g. `Instant.now()`), which caused test failures like these: https://github.com/airbytehq/airbyte/runs/7307850190?check_suite_focus=true#step:11:13209

This PR fixes the issue by guaranteeing that the precision of both timestamps in the comparison is the same, which should solve the issue.