### PR TITLE
Added _id and _cid to the schema for generated streams 

### DIFF
--- a/airbyte-integrations/connectors/source-webflow/source_webflow/source.py
+++ b/airbyte-integrations/connectors/source-webflow/source_webflow/source.py
@@ -238,6 +238,14 @@ class CollectionContents(WebflowStream):
         for schema_property in schema_records:
             json_schema.update(schema_property)
 
+        # Manually add in _cid and _id, which are not included in the list of fields sent back from Webflow,
+        # but which are necessary for joining data in the database
+        extra_fields = {
+            "_id": {"type": ["null", "string"]},
+            "_cid": {"type": ["null", "string"]},
+        }
+        json_schema.update(extra_fields)
+
         return {
             "$schema": "http://json-schema.org/draft-07/schema#",
             "additionalProperties": True,


### PR DESCRIPTION
## What
This connector automatically populates the json schema, however the schema that is pulled back from Webflow does not include the `_id` (record id) or the `_cid` (collection id) fields in the records that are returned. These are now manually added in after pulling the webflow schema back to Airbyte. 


## How
These two fields are added into the dictionary returned by the `get_json_schema` method inside `CollectionContents`

I have confirmed on my local version of Airbyte that these fields now appear in the catalog, as demonstrated in the image below: 


<img width="1230" alt="image" src="https://user-images.githubusercontent.com/2364589/178595631-158e68cf-87af-4955-b258-a546a0bce6e7.png">
