### PR TITLE
🪟 🎨 Update Modal to SCSS, add modal body and footer components

### DIFF
--- a/airbyte-webapp/src/components/Modal/Modal.module.scss
+++ b/airbyte-webapp/src/components/Modal/Modal.module.scss
@@ -1,0 +1,27 @@
+@use "../../scss/colors";
+@use "../../scss/variables";
+
+@keyframes fadeIn {
+  from {
+    opacity: 0;
+  }
+}
+
+.modal {
+  animation: fadeIn 0.2s ease-out;
+  position: absolute;
+  top: 0;
+  left: 0;
+  width: 100vw;
+  height: 100vh;
+  background: rgba(colors.$black, 0.5);
+  display: flex;
+  justify-content: center;
+  align-items: center;
+  z-index: 100;
+}
+
+.card {
+  margin-left: 93px;
+  max-width: calc(100% - 93px - variables.$spacing-lg * 2);
+}

--- a/airbyte-webapp/src/components/Modal/Modal.module.scss
+++ b/airbyte-webapp/src/components/Modal/Modal.module.scss
@@ -22,6 +22,22 @@
 }
 
 .card {
-  margin-left: 93px;
-  max-width: calc(100% - 93px - variables.$spacing-lg * 2);
+  margin-left: variables.$width-size-menu;
+  max-width: calc(100% - variables.$width-size-menu - variables.$spacing-lg * 2);
+
+  &.sm {
+    width: variables.$width-modal-sm;
+  }
+
+  &.md {
+    width: variables.$width-modal-md;
+  }
+
+  &.lg {
+    width: variables.$width-modal-lg;
+  }
+
+  &.xl {
+    width: variables.$width-modal-xl;
+  }
 }

--- a/airbyte-webapp/src/components/Modal/Modal.tsx
+++ b/airbyte-webapp/src/components/Modal/Modal.tsx
@@ -1,3 +1,4 @@
+import classNames from "classnames";
 import React, { useEffect, useCallback } from "react";
 import { createPortal } from "react-dom";
 
@@ -10,9 +11,17 @@ export interface ModalProps {
   onClose?: () => void;
   clear?: boolean;
   closeOnBackground?: boolean;
+  size?: "sm" | "md" | "lg" | "xl";
 }
 
-const Modal: React.FC<ModalProps> = ({ children, title, onClose, clear, closeOnBackground }) => {
+const cardStyleBySize = {
+  sm: styles.sm,
+  md: styles.md,
+  lg: styles.lg,
+  xl: styles.xl,
+};
+
+const Modal: React.FC<ModalProps> = ({ children, title, onClose, clear, closeOnBackground, size }) => {
   const handleUserKeyPress = useCallback((event, closeModal) => {
     const { keyCode } = event;
     // Escape key
@@ -39,7 +48,7 @@ const Modal: React.FC<ModalProps> = ({ children, title, onClose, clear, closeOnB
       {clear ? (
         children
       ) : (
-        <ContentCard title={title} className={styles.card}>
+        <ContentCard title={title} className={classNames(styles.card, size ? cardStyleBySize[size] : undefined)}>
           {children}
         </ContentCard>
       )}

--- a/airbyte-webapp/src/components/Modal/Modal.tsx
+++ b/airbyte-webapp/src/components/Modal/Modal.tsx
@@ -1,8 +1,9 @@
 import React, { useEffect, useCallback } from "react";
 import { createPortal } from "react-dom";
-import styled, { keyframes } from "styled-components";
 
 import ContentCard from "components/ContentCard";
+
+import styles from "./Modal.module.scss";
 
 export interface ModalProps {
   title?: string | React.ReactNode;
@@ -11,44 +12,38 @@ export interface ModalProps {
   closeOnBackground?: boolean;
 }
 
-const fadeIn = keyframes`
-  from { opacity: 0; }
-`;
-
-const Overlay = styled.div`
-  animation: ${fadeIn} 0.2s ease-out;
-  position: absolute;
-  top: 0;
-  left: 0;
-  width: 100vw;
-  height: 100vh;
-  background: rgba(15, 15, 23, 0.5);
-  display: flex;
-  justify-content: center;
-  align-items: center;
-  z-index: 100;
-`;
-
 const Modal: React.FC<ModalProps> = ({ children, title, onClose, clear, closeOnBackground }) => {
   const handleUserKeyPress = useCallback((event, closeModal) => {
     const { keyCode } = event;
+    // Escape key
     if (keyCode === 27) {
       closeModal();
     }
   }, []);
 
   useEffect(() => {
-    onClose && window.addEventListener("keydown", (event) => handleUserKeyPress(event, onClose));
+    if (!onClose) {
+      return;
+    }
+
+    const onKeyDown = (event: KeyboardEvent) => handleUserKeyPress(event, onClose);
+    window.addEventListener("keydown", onKeyDown);
 
     return () => {
-      onClose && window.removeEventListener("keydown", (event) => handleUserKeyPress(event, onClose));
+      window.removeEventListener("keydown", onKeyDown);
     };
   }, [handleUserKeyPress, onClose]);
 
   return createPortal(
-    <Overlay onClick={() => (closeOnBackground && onClose ? onClose() : null)}>
-      {clear ? children : <ContentCard title={title}>{children}</ContentCard>}
-    </Overlay>,
+    <div className={styles.modal} onClick={() => (closeOnBackground && onClose ? onClose() : null)}>
+      {clear ? (
+        children
+      ) : (
+        <ContentCard title={title} className={styles.card}>
+          {children}
+        </ContentCard>
+      )}
+    </div>,
     document.body
   );
 };

--- a/airbyte-webapp/src/components/Modal/ModalBody.module.scss
+++ b/airbyte-webapp/src/components/Modal/ModalBody.module.scss
@@ -1,0 +1,7 @@
+@use "../../scss/variables";
+
+.modalBody {
+  padding: variables.$spacing-lg variables.$spacing-xl;
+  overflow: scroll;
+  max-width: 100%;
+}

--- a/airbyte-webapp/src/components/Modal/ModalBody.tsx
+++ b/airbyte-webapp/src/components/Modal/ModalBody.tsx
@@ -1,13 +1,12 @@
 import styles from "./ModalBody.module.scss";
 
 interface ModalBodyProps {
-  width: number | string;
   maxHeight?: number | string;
 }
 
-export const ModalBody: React.FC<ModalBodyProps> = ({ children, maxHeight, width }) => {
+export const ModalBody: React.FC<ModalBodyProps> = ({ children, maxHeight }) => {
   return (
-    <div className={styles.modalBody} style={{ maxHeight, width }}>
+    <div className={styles.modalBody} style={{ maxHeight }}>
       {children}
     </div>
   );

--- a/airbyte-webapp/src/components/Modal/ModalBody.tsx
+++ b/airbyte-webapp/src/components/Modal/ModalBody.tsx
@@ -1,0 +1,14 @@
+import styles from "./ModalBody.module.scss";
+
+interface ModalBodyProps {
+  width: number | string;
+  maxHeight?: number | string;
+}
+
+export const ModalBody: React.FC<ModalBodyProps> = ({ children, maxHeight, width }) => {
+  return (
+    <div className={styles.modalBody} style={{ maxHeight, width }}>
+      {children}
+    </div>
+  );
+};

--- a/airbyte-webapp/src/components/Modal/ModalFooter.module.scss
+++ b/airbyte-webapp/src/components/Modal/ModalFooter.module.scss
@@ -1,0 +1,18 @@
+@use "../../scss/colors";
+@use "../../scss/variables";
+
+.modalFooter {
+  display: flex;
+  flex-direction: row;
+  justify-content: flex-end;
+  border-top: variables.$border-thin solid colors.$grey-100;
+  padding: variables.$spacing-lg variables.$spacing-xl;
+
+  & > * {
+    margin-left: variables.$spacing-md;
+
+    &:first-child {
+      margin-left: 0;
+    }
+  }
+}

--- a/airbyte-webapp/src/components/Modal/ModalFooter.module.scss
+++ b/airbyte-webapp/src/components/Modal/ModalFooter.module.scss
@@ -7,12 +7,5 @@
   justify-content: flex-end;
   border-top: variables.$border-thin solid colors.$grey-100;
   padding: variables.$spacing-lg variables.$spacing-xl;
-
-  & > * {
-    margin-left: variables.$spacing-md;
-
-    &:first-child {
-      margin-left: 0;
-    }
-  }
+  gap: variables.$spacing-md;
 }

--- a/airbyte-webapp/src/components/Modal/ModalFooter.tsx
+++ b/airbyte-webapp/src/components/Modal/ModalFooter.tsx
@@ -1,0 +1,5 @@
+import styles from "./ModalFooter.module.scss";
+
+export const ModalFooter: React.FC = ({ children }) => {
+  return <div className={styles.modalFooter}>{children}</div>;
+};

--- a/airbyte-webapp/src/components/Modal/index.stories.tsx
+++ b/airbyte-webapp/src/components/Modal/index.stories.tsx
@@ -1,0 +1,33 @@
+import { ComponentStory, ComponentMeta } from "@storybook/react";
+
+import { Modal, ModalBody, ModalFooter } from "./";
+
+export default {
+  title: "Ui/Modal",
+  component: Modal,
+  argTypes: {
+    title: { type: { name: "string", required: false } },
+  },
+} as ComponentMeta<typeof Modal>;
+
+const Template: ComponentStory<typeof Modal> = (args) => {
+  if (args.clear) {
+    return <Modal {...args} />;
+  }
+
+  return (
+    <Modal {...args}>
+      <ModalBody width="450px">{args.children}</ModalBody>
+      <ModalFooter>
+        <button>Button 1</button>
+        <button>Button 2</button>
+      </ModalFooter>
+    </Modal>
+  );
+};
+
+export const Primary = Template.bind({});
+Primary.args = {
+  children: "Modal children go here.",
+  title: "Modal Title",
+};

--- a/airbyte-webapp/src/components/Modal/index.stories.tsx
+++ b/airbyte-webapp/src/components/Modal/index.stories.tsx
@@ -17,7 +17,7 @@ const Template: ComponentStory<typeof Modal> = (args) => {
 
   return (
     <Modal {...args}>
-      <ModalBody width="450px">{args.children}</ModalBody>
+      <ModalBody>{args.children}</ModalBody>
       <ModalFooter>
         <button>Button 1</button>
         <button>Button 2</button>

--- a/airbyte-webapp/src/components/Modal/index.tsx
+++ b/airbyte-webapp/src/components/Modal/index.tsx
@@ -1,4 +1,7 @@
 import Modal from "./Modal";
 
+export * from "./ModalBody";
+export * from "./ModalFooter";
+
 export default Modal;
 export { Modal };

--- a/airbyte-webapp/src/scss/_variables.scss
+++ b/airbyte-webapp/src/scss/_variables.scss
@@ -13,3 +13,10 @@ $spacing-lg: 15px;
 $spacing-xl: 20px;
 $spacing-2xl: 40px;
 $spacing-page-bottom: 150px;
+
+$width-size-menu: 93px;
+
+$width-modal-sm: 492px;
+$width-modal-md: 585px;
+$width-modal-lg: 940px;
+$width-modal-xl: 1008px;


### PR DESCRIPTION
## What
Updates the modal to use SCSS and adds a `<ModalBody />` and `<ModalFooter />` component to match the design guide.

`<ModalBody />` requires a width and a maxHeight in order to enable when to scroll.
`<ModalFooter />` is designed to place buttons along the right side.

<img width="549" alt="image" src="https://user-images.githubusercontent.com/168664/178768469-1e93e47b-560b-4e42-b83b-7bfb31e67a0b.png">

Isolated from #14514

## How
* Update Modal component to use SCSS
* Add new sub components
* Add basic storybook


## Recommended reading order
Top to bottom
