### PR TITLE
disable DATs in normalization test

### DIFF
--- a/airbyte-integrations/bases/base-normalization/build.gradle
+++ b/airbyte-integrations/bases/base-normalization/build.gradle
@@ -106,9 +106,10 @@ task("customIntegrationTestPython", type: PythonTask, dependsOn: installTestReqs
 // so we want to run these in addition to the base-normalization integration tests.
 // If you add more items here, make sure to also to have CI fetch their credentials.
 // See git history for an example.
-integrationTest.dependsOn(":airbyte-integrations:connectors:destination-bigquery:integrationTest")
-integrationTest.dependsOn(":airbyte-integrations:connectors:destination-postgres:integrationTest")
-integrationTest.dependsOn(":airbyte-integrations:connectors:destination-snowflake:integrationTest")
+// TODO reenable these - they're causing flakiness in our test results, need to figure that out
+// integrationTest.dependsOn(":airbyte-integrations:connectors:destination-bigquery:integrationTest")
+// integrationTest.dependsOn(":airbyte-integrations:connectors:destination-postgres:integrationTest")
+// integrationTest.dependsOn(":airbyte-integrations:connectors:destination-snowflake:integrationTest")
 
 integrationTest.dependsOn("customIntegrationTestPython")
 customIntegrationTests.dependsOn("customIntegrationTestPython")


### PR DESCRIPTION
these have been causing some severe flakiness in test/publish, so disable them for now. In the meantime, normalization reviewers should make sure that the postgres/bigquery/snowflake tests get run on normalization PRs.