### PR TITLE
🪟🎨 card and icon ui tweaks

### DIFF
--- a/airbyte-webapp/src/components/ContentCard/ContentCard.tsx
+++ b/airbyte-webapp/src/components/ContentCard/ContentCard.tsx
@@ -11,19 +11,19 @@ interface IProps {
   light?: boolean;
 }
 
-const Title = styled(H5)<{ light?: boolean; hasChildren?: boolean }>`
+const Title = styled(H5)<{ light?: boolean; roundedBottom?: boolean }>`
   padding: ${({ light }) => (light ? "19px 20px 20px" : "25px 25px 22px")};
   color: ${({ theme }) => theme.darkPrimaryColor};
   border-bottom: ${({ light }) => (light ? "none" : "#e8e8ed 1px solid")};
   font-weight: 600;
   letter-spacing: 0.008em;
-  border-radius: ${({ hasChildren }) => (hasChildren ? "10px 10px 0px 0px" : "10px 10px 10px 10px")};
+  border-radius: ${({ roundedBottom }) => (roundedBottom ? "10px 10px 0px 0px" : "10px 10px 10px 10px")};
 `;
 
 const ContentCard: React.FC<IProps> = (props) => (
   <Card className={props.className} onClick={props.onClick} full={props.full}>
     {props.title ? (
-      <Title light={props.light || !props.children} hasChildren={!!props.children}>
+      <Title light={props.light || !props.children} roundedBottom={!!props.children}>
         {props.title}
       </Title>
     ) : null}

--- a/airbyte-webapp/src/components/ContentCard/ContentCard.tsx
+++ b/airbyte-webapp/src/components/ContentCard/ContentCard.tsx
@@ -11,18 +11,22 @@ interface IProps {
   light?: boolean;
 }
 
-const Title = styled(H5)<{ light?: boolean }>`
+const Title = styled(H5)<{ light?: boolean; hasChildren?: boolean }>`
   padding: ${({ light }) => (light ? "19px 20px 20px" : "25px 25px 22px")};
   color: ${({ theme }) => theme.darkPrimaryColor};
   border-bottom: ${({ light }) => (light ? "none" : "#e8e8ed 1px solid")};
   font-weight: 600;
   letter-spacing: 0.008em;
-  border-radius: 10px 10px 0 0;
+  border-radius: ${({ hasChildren }) => (hasChildren ? "10px 10px 0px 0px" : "10px 10px 10px 10px")};
 `;
 
 const ContentCard: React.FC<IProps> = (props) => (
   <Card className={props.className} onClick={props.onClick} full={props.full}>
-    {props.title ? <Title light={props.light}>{props.title}</Title> : null}
+    {props.title ? (
+      <Title light={props.light || !props.children} hasChildren={!!props.children}>
+        {props.title}
+      </Title>
+    ) : null}
     {props.children}
   </Card>
 );

--- a/airbyte-webapp/src/components/EntityTable/ImplementationTable.module.scss
+++ b/airbyte-webapp/src/components/EntityTable/ImplementationTable.module.scss
@@ -1,0 +1,7 @@
+.content {
+  margin: 0 32px 0 27px;
+
+  > table > tbody > tr > td:first-of-type {
+    padding-left: 32px !important;
+  }
+}

--- a/airbyte-webapp/src/components/EntityTable/ImplementationTable.tsx
+++ b/airbyte-webapp/src/components/EntityTable/ImplementationTable.tsx
@@ -2,7 +2,6 @@ import queryString from "query-string";
 import React, { useCallback } from "react";
 import { FormattedMessage } from "react-intl";
 import { CellProps } from "react-table";
-import styled from "styled-components";
 
 import Table from "components/Table";
 
@@ -14,11 +13,8 @@ import ConnectorCell from "./components/ConnectorCell";
 import LastSyncCell from "./components/LastSyncCell";
 import NameCell from "./components/NameCell";
 import SortButton from "./components/SortButton";
+import styles from "./ImplementationTable.module.scss";
 import { EntityTableDataItem, SortOrderEnum } from "./types";
-
-const Content = styled.div`
-  margin: 0 32px 0 27px;
-`;
 
 interface IProps {
   data: EntityTableDataItem[];
@@ -137,9 +133,9 @@ const ImplementationTable: React.FC<IProps> = ({ data, entity, onClickRow }) => 
   );
 
   return (
-    <Content>
+    <div className={styles.content}>
       <Table columns={columns} data={sortingData} onClickRow={onClickRow} erroredRows />
-    </Content>
+    </div>
   );
 };
 

--- a/airbyte-webapp/src/components/EntityTable/components/LastSyncCell.tsx
+++ b/airbyte-webapp/src/components/EntityTable/components/LastSyncCell.tsx
@@ -2,13 +2,6 @@ import React from "react";
 import { FormattedRelativeTime } from "react-intl";
 import styled from "styled-components";
 
-// const CalendarIcon = styled(FontAwesomeIcon)`
-//   color: ${({ theme }) => theme.greyColor40};
-//   font-size: 14px;
-//   line-height: 14px;
-//   margin-right: 5px;
-// `;
-
 const Content = styled.div<{ enabled?: boolean }>`
   color: ${({ theme, enabled }) => (!enabled ? theme.greyColor40 : "inheret")};
 `;
@@ -25,7 +18,6 @@ const LastSyncCell: React.FC<IProps> = ({ timeInSecond, enabled }) => {
 
   return (
     <Content enabled={enabled}>
-      {/* <CalendarIcon icon={faCalendarAlt} /> */}
       <FormattedRelativeTime value={timeInSecond - Date.now() / 1000} updateIntervalInSeconds={60} />
     </Content>
   );

--- a/airbyte-webapp/src/components/EntityTable/components/LastSyncCell.tsx
+++ b/airbyte-webapp/src/components/EntityTable/components/LastSyncCell.tsx
@@ -3,7 +3,7 @@ import { FormattedRelativeTime } from "react-intl";
 import styled from "styled-components";
 
 const Content = styled.div<{ enabled?: boolean }>`
-  color: ${({ theme, enabled }) => (!enabled ? theme.greyColor40 : "inheret")};
+  color: ${({ theme, enabled }) => (!enabled ? theme.greyColor40 : "inherit")};
 `;
 
 interface IProps {

--- a/airbyte-webapp/src/components/EntityTable/components/LastSyncCell.tsx
+++ b/airbyte-webapp/src/components/EntityTable/components/LastSyncCell.tsx
@@ -1,15 +1,13 @@
-import { faCalendarAlt } from "@fortawesome/free-regular-svg-icons";
-import { FontAwesomeIcon } from "@fortawesome/react-fontawesome";
 import React from "react";
 import { FormattedRelativeTime } from "react-intl";
 import styled from "styled-components";
 
-const CalendarIcon = styled(FontAwesomeIcon)`
-  color: ${({ theme }) => theme.greyColor40};
-  font-size: 14px;
-  line-height: 14px;
-  margin-right: 5px;
-`;
+// const CalendarIcon = styled(FontAwesomeIcon)`
+//   color: ${({ theme }) => theme.greyColor40};
+//   font-size: 14px;
+//   line-height: 14px;
+//   margin-right: 5px;
+// `;
 
 const Content = styled.div<{ enabled?: boolean }>`
   color: ${({ theme, enabled }) => (!enabled ? theme.greyColor40 : "inheret")};
@@ -27,7 +25,7 @@ const LastSyncCell: React.FC<IProps> = ({ timeInSecond, enabled }) => {
 
   return (
     <Content enabled={enabled}>
-      <CalendarIcon icon={faCalendarAlt} />
+      {/* <CalendarIcon icon={faCalendarAlt} /> */}
       <FormattedRelativeTime value={timeInSecond - Date.now() / 1000} updateIntervalInSeconds={60} />
     </Content>
   );

--- a/airbyte-webapp/src/components/EntityTable/components/NameCell.tsx
+++ b/airbyte-webapp/src/components/EntityTable/components/NameCell.tsx
@@ -30,12 +30,6 @@ const Name = styled.div<{ enabled?: boolean }>`
   color: ${({ theme, enabled }) => (!enabled ? theme.greyColor40 : "inherit")};
 `;
 
-const Space = styled.div`
-  width: 30px;
-  height: 20px;
-  opacity: 0;
-`;
-
 const Image = styled(ConnectorIcon)`
   margin-right: 6px;
 `;
@@ -78,7 +72,7 @@ const NameCell: React.FC<Props> = ({ value, enabled, status, icon, img }) => {
 
   return (
     <Content>
-      {status ? <StatusIcon title={title} status={statusIconStatus} /> : <Space />}
+      {status && <StatusIcon title={title} status={statusIconStatus} />}
       {icon && <Image icon={img} />}
       <Name enabled={enabled}>{value}</Name>
     </Content>

--- a/airbyte-webapp/src/pages/ConnectionPage/pages/ConnectionItemPage/components/StatusMainInfo.module.scss
+++ b/airbyte-webapp/src/pages/ConnectionPage/pages/ConnectionItemPage/components/StatusMainInfo.module.scss
@@ -1,4 +1,5 @@
 @use "../../../../../scss/colors";
+@use "../../../../../scss/variables";
 
 .connectorLink {
   cursor: pointer;
@@ -14,7 +15,7 @@
   width: 650px;
   display: flex;
   justify-content: space-between;
-  padding: 10px 20px;
+  padding: variables.$spacing-md variables.$spacing-xl;
   background-color: white;
   border-radius: 10px;
   align-items: center;

--- a/airbyte-webapp/src/pages/ConnectionPage/pages/ConnectionItemPage/components/StatusMainInfo.module.scss
+++ b/airbyte-webapp/src/pages/ConnectionPage/pages/ConnectionItemPage/components/StatusMainInfo.module.scss
@@ -1,0 +1,21 @@
+@use "../../../../../scss/colors";
+
+.connectorLink {
+  cursor: pointer;
+  text-decoration: none;
+  border-radius: 10px;
+
+  &:hover {
+    background-color: colors.$grey-50;
+  }
+}
+
+.container {
+  width: 650px;
+  display: flex;
+  justify-content: space-between;
+  padding: 10px 20px;
+  background-color: white;
+  border-radius: 10px;
+  align-items: center;
+}

--- a/airbyte-webapp/src/pages/ConnectionPage/pages/ConnectionItemPage/components/StatusMainInfo.tsx
+++ b/airbyte-webapp/src/pages/ConnectionPage/pages/ConnectionItemPage/components/StatusMainInfo.tsx
@@ -1,7 +1,7 @@
 import { faArrowRight } from "@fortawesome/free-solid-svg-icons";
 import { FontAwesomeIcon } from "@fortawesome/react-fontawesome";
 import React from "react";
-import { Link as ReactLink } from "react-router-dom";
+import { Link } from "react-router-dom";
 
 import ConnectorCard from "components/ConnectorCard";
 
@@ -41,23 +41,23 @@ export const StatusMainInfo: React.FC<StatusMainInfoProps> = ({
 
   return (
     <div className={styles.container}>
-      <ReactLink to={sourceConnectionPath} className={styles.connectorLink}>
+      <Link to={sourceConnectionPath} className={styles.connectorLink}>
         <ConnectorCard
           connectionName={source.sourceName}
           icon={sourceDefinition?.icon}
           connectorName={source.name}
           releaseStage={sourceDefinition?.releaseStage}
         />
-      </ReactLink>
+      </Link>
       <FontAwesomeIcon icon={faArrowRight} />
-      <ReactLink to={destinationConnectionPath} className={styles.connectorLink}>
+      <Link to={destinationConnectionPath} className={styles.connectorLink}>
         <ConnectorCard
           connectionName={destination.destinationName}
           icon={destinationDefinition?.icon}
           connectorName={destination.name}
           releaseStage={destinationDefinition?.releaseStage}
         />
-      </ReactLink>
+      </Link>
       {connection.status !== ConnectionStatus.deprecated && (
         <EnabledControl
           onStatusUpdating={onStatusUpdating}

--- a/airbyte-webapp/src/pages/ConnectionPage/pages/ConnectionItemPage/components/StatusMainInfo.tsx
+++ b/airbyte-webapp/src/pages/ConnectionPage/pages/ConnectionItemPage/components/StatusMainInfo.tsx
@@ -2,7 +2,6 @@ import { faArrowRight } from "@fortawesome/free-solid-svg-icons";
 import { FontAwesomeIcon } from "@fortawesome/react-fontawesome";
 import React from "react";
 import { Link as ReactLink } from "react-router-dom";
-import styled from "styled-components";
 
 import ConnectorCard from "components/ConnectorCard";
 
@@ -14,26 +13,7 @@ import { useDestinationDefinition } from "services/connector/DestinationDefiniti
 import { useSourceDefinition } from "services/connector/SourceDefinitionService";
 
 import EnabledControl from "./EnabledControl";
-
-const MainContainer = styled.div`
-  width: 650px;
-  display: flex;
-  justify-content: space-between;
-  padding: 10px 20px;
-  background-color: white;
-  border-radius: 10px;
-  align-items: center;
-`;
-
-const ConnectorsLink = styled(ReactLink)`
-  cursor: pointer;
-  text-decoration: none;
-  border-radius: 10px;
-
-  &:hover {
-    background-color: ${({ theme }) => theme.greyColor10};
-  }
-`;
+import styles from "./StatusMainInfo.module.scss";
 
 interface StatusMainInfoProps {
   connection: WebBackendConnectionRead;
@@ -60,24 +40,24 @@ export const StatusMainInfo: React.FC<StatusMainInfoProps> = ({
   const destinationConnectionPath = `../../${RoutePaths.Destination}/${destination.destinationId}`;
 
   return (
-    <MainContainer>
-      <ConnectorsLink to={sourceConnectionPath}>
+    <div className={styles.container}>
+      <ReactLink to={sourceConnectionPath} className={styles.connectorLink}>
         <ConnectorCard
           connectionName={source.sourceName}
           icon={sourceDefinition?.icon}
           connectorName={source.name}
           releaseStage={sourceDefinition?.releaseStage}
         />
-      </ConnectorsLink>
+      </ReactLink>
       <FontAwesomeIcon icon={faArrowRight} />
-      <ConnectorsLink to={destinationConnectionPath}>
+      <ReactLink to={destinationConnectionPath} className={styles.connectorLink}>
         <ConnectorCard
           connectionName={destination.destinationName}
           icon={destinationDefinition?.icon}
           connectorName={destination.name}
           releaseStage={destinationDefinition?.releaseStage}
         />
-      </ConnectorsLink>
+      </ReactLink>
       {connection.status !== ConnectionStatus.deprecated && (
         <EnabledControl
           onStatusUpdating={onStatusUpdating}
@@ -86,6 +66,6 @@ export const StatusMainInfo: React.FC<StatusMainInfoProps> = ({
           frequencyType={frequency?.type}
         />
       )}
-    </MainContainer>
+    </div>
   );
 };


### PR DESCRIPTION
## What
Four small tweaks from pairing with design today:

**1. Fix extra border and shadow under title-only card**

Before (may need to zoom in to see): 
![Screen Shot 2022-07-13 at 11 24 30 AM](https://user-images.githubusercontent.com/63751206/178771785-65e41daa-3a43-4345-b376-5db574fb6b38.png)

After: 
![Screen Shot 2022-07-13 at 11 26 47 AM](https://user-images.githubusercontent.com/63751206/178771841-cac68221-a4d4-404e-9c6b-93a49f5abd15.png)


**2. Fix hover color on Connector cards Connections page (also converted it to scss module)**

Before:
![Screen Shot 2022-07-13 at 11 33 42 AM](https://user-images.githubusercontent.com/63751206/178773340-1e92f1f5-fa5b-45eb-b680-620e76b37b1b.png)

After:
![Screen Shot 2022-07-13 at 11 27 45 AM](https://user-images.githubusercontent.com/63751206/178772011-59ef3bde-f23f-47c3-9701-fd795d86180a.png)

**3. Remove calendar icon from "last sync" column (Nico requested it just be commented out for now rather than fully removed)**

Before:
![Screen Shot 2022-07-13 at 11 30 15 AM](https://user-images.githubusercontent.com/63751206/178772602-d55835a1-d693-4a00-aea4-4bc5125a3fea.png)

After:
![Screen Shot 2022-07-13 at 11 28 48 AM](https://user-images.githubusercontent.com/63751206/178772259-313adc05-ffbd-421e-b95d-e5b1096bf39e.png)
    

**4. Removed extra spacing before Source/Destination name in Connections table**

Before:
![Screen Shot 2022-07-13 at 11 30 11 AM](https://user-images.githubusercontent.com/63751206/178772876-f259393d-32c0-4854-88fe-172b797fa596.png)

After: 
![Screen Shot 2022-07-13 at 11 35 20 AM](https://user-images.githubusercontent.com/63751206/178773581-a563d5ee-df43-4a37-b7b7-3de944684c4e.png)


## Recommended reading order
1. `ContentCard.tsx` 
2. `StatusMainInfo.*` 
3. `LastSyncCell.tsx`
4. `NameCell.tsx`
5. `ImplementationTable.*`