### PR TITLE
forgot to publish a new version of airbyte-cdk to PyPi

### DIFF
--- a/airbyte-cdk/python/CHANGELOG.md
+++ b/airbyte-cdk/python/CHANGELOG.md
@@ -1,5 +1,8 @@
 # Changelog
 
+## 0.1.65
+- Allow for detailed debug messages to be enabled using the --debug command.
+
 ## 0.1.64
 - Add support for configurable oauth request payload and declarative oauth authenticator.
 

--- a/airbyte-cdk/python/setup.py
+++ b/airbyte-cdk/python/setup.py
@@ -15,7 +15,7 @@ README = (HERE / "README.md").read_text()
 
 setup(
     name="airbyte-cdk",
-    version="0.1.64",
+    version="0.1.65",
     description="A framework for writing Airbyte Connectors.",
     long_description=README,
     long_description_content_type="text/markdown",


### PR DESCRIPTION
## What
Forgot to run the publish commands for https://github.com/airbytehq/airbyte/pull/14521

## How
Just bumps the version and adds the relevant changelog.

## Recommended reading order
w/e
