### PR TITLE
lower sleep after wait for successful job

### DIFF
--- a/airbyte-test-utils/src/main/java/io/airbyte/test/utils/AirbyteAcceptanceTestHarness.java
+++ b/airbyte-test-utils/src/main/java/io/airbyte/test/utils/AirbyteAcceptanceTestHarness.java
@@ -737,7 +737,7 @@ public class AirbyteAcceptanceTestHarness {
       }
     }
     assertEquals(JobStatus.SUCCEEDED, job.getStatus());
-    Thread.sleep(10000);
+    Thread.sleep(200);
   }
 
   public static JobRead waitWhileJobHasStatus(final JobsApi jobsApi, final JobRead originalJob, final Set<JobStatus> jobStatuses)


### PR DESCRIPTION
## What

The sleep likely doesnt need to be so long, so lowering it here to speed up our builds.