### PR TITLE
Update public documentation to include restrictions for backwards incompatible changes

### DIFF
--- a/docs/connector-development/best-practices.md
+++ b/docs/connector-development/best-practices.md
@@ -49,3 +49,16 @@ When reviewing connectors, we'll use the following "checklist" to verify whether
 
 Most APIs enforce rate limits. Your connector should gracefully handle those \(i.e: without failing the connector process\). The most common way to handle rate limits is to implement backoff.
 
+## Maintaining connectors
+
+Once a connector has been published for use within Airbyte, we must take special care to account for the customer impact of updates to the connector.
+
+### Schema Breaking Changes
+
+For connectors that are GA certified or highly used by customers, we should not introduce backwards incompatible changes into a stream's schema that impact how existing data is replicated and represented in the downstream destination. The schema serves as a contract with customers to define how data is synchronized and subtractive changes can negatively impact their workflows built on top of Airbyte. The following types of changes are to be considered to be breaking:
+
+* Removing a property field from a schema
+* Renaming a property field in a schema
+* Changing a property's data type
+
+Exceptions can be made on a case by case basis, but if your updates require a subtractive change to the schema, you should consider whether the change is necessary or if there is an alternative that will not break backwards compatibility.

--- a/docs/connector-development/best-practices.md
+++ b/docs/connector-development/best-practices.md
@@ -55,7 +55,9 @@ Once a connector has been published for use within Airbyte, we must take special
 
 ### Schema Breaking Changes
 
-For connectors that are GA certified or highly used by customers, we should not introduce backwards incompatible changes into a stream's schema that impact how existing data is replicated and represented in the downstream destination. The schema serves as a contract with customers to define how data is synchronized and subtractive changes can negatively impact their workflows built on top of Airbyte. The following types of changes are to be considered to be breaking:
+For connectors that are GA certified or highly used by customers, we should not introduce backwards incompatible changes into a stream's schema that impact how existing data is replicated and represented in the downstream destination. The schema serves as a contract with customers to define how data is synchronized. Subtractive changes can COMPLETELY BREAK a customer's workflows built on top of Airbyte, sometimes in a silent way. 
+
+The following types of changes are to be considered to be breaking:
 
 * Removing a property field from a schema
 * Renaming a property field in a schema

--- a/docs/connector-development/cdk-python/schemas.md
+++ b/docs/connector-development/cdk-python/schemas.md
@@ -12,10 +12,6 @@ By default, `Stream.get_json_schema` reads a `.json` file in the `schemas/` dire
 
 Important note: any objects referenced via `$ref` should be placed in the `shared/` directory in their own `.json` files.
 
-### Backwards Compatibility
-
-Because statically defined schemas explicitly define how data is represented in a destination, updates to a schema must be backwards compatible with prior versions. More information about breaking changes can be found [here](../best-practices.md#schema-breaking-changes)
-
 ### Generating schemas from OpenAPI definitions
 
 If you are implementing a connector to pull data from an API which publishes an [OpenAPI/Swagger spec](https://swagger.io/specification/), you can use a tool we've provided for generating JSON schemas from the OpenAPI definition file. Detailed information can be found [here](https://github.com/airbytehq/airbyte/tree/master/tools/openapi2jsonschema/).
@@ -24,6 +20,9 @@ If you are implementing a connector to pull data from an API which publishes an 
 
 We also provide a tool for generating schemas using a connector's `read` command output. Detailed information can be found [here](https://github.com/airbytehq/airbyte/tree/master/tools/schema_generator/).
 
+### Backwards Compatibility
+
+Because statically defined schemas explicitly define how data is represented in a destination, updates to a schema must be backwards compatible with prior versions. More information about breaking changes can be found [here](../best-practices.md#schema-breaking-changes)
 
 ## Dynamic schemas
 

--- a/docs/connector-development/cdk-python/schemas.md
+++ b/docs/connector-development/cdk-python/schemas.md
@@ -12,6 +12,10 @@ By default, `Stream.get_json_schema` reads a `.json` file in the `schemas/` dire
 
 Important note: any objects referenced via `$ref` should be placed in the `shared/` directory in their own `.json` files.
 
+### Backwards Compatibility
+
+Because statically defined schemas explicitly define how data is represented in a destination, updates to a schema must be backwards compatible with prior versions. More information about breaking changes can be found [here](../best-practices.md#schema-breaking-changes)
+
 ### Generating schemas from OpenAPI definitions
 
 If you are implementing a connector to pull data from an API which publishes an [OpenAPI/Swagger spec](https://swagger.io/specification/), you can use a tool we've provided for generating JSON schemas from the OpenAPI definition file. Detailed information can be found [here](https://github.com/airbytehq/airbyte/tree/master/tools/openapi2jsonschema/).


### PR DESCRIPTION
Update the public documentation to include new restrictions around schema breaking changes.

## Recommended reading order
1. `best-practices.md`
2. `schemas.md`