### PR TITLE
Source Okta: add permission stream under a custom role

### DIFF
--- a/airbyte-config/init/src/main/resources/seed/source_definitions.yaml
+++ b/airbyte-config/init/src/main/resources/seed/source_definitions.yaml
@@ -628,7 +628,7 @@
 - name: Okta
   sourceDefinitionId: 1d4fdb25-64fc-4569-92da-fcdca79a8372
   dockerRepository: airbyte/source-okta
-  dockerImageTag: 0.1.10
+  dockerImageTag: 0.1.11
   documentationUrl: https://docs.airbyte.io/integrations/sources/okta
   icon: okta.svg
   sourceType: api

--- a/airbyte-config/init/src/main/resources/seed/source_specs.yaml
+++ b/airbyte-config/init/src/main/resources/seed/source_specs.yaml
@@ -6027,7 +6027,7 @@
         - - "client_secret"
         oauthFlowOutputParameters:
         - - "access_token"
-- dockerImage: "airbyte/source-okta:0.1.10"
+- dockerImage: "airbyte/source-okta:0.1.11"
   spec:
     documentationUrl: "https://docs.airbyte.io/integrations/sources/okta"
     connectionSpecification:

--- a/airbyte-integrations/bases/source-acceptance-test/setup.py
+++ b/airbyte-integrations/bases/source-acceptance-test/setup.py
@@ -20,6 +20,8 @@ MAIN_REQUIREMENTS = [
     "dpath~=2.0.1",
     "jsonschema~=3.2.0",
     "jsonref==0.2",
+    "requests-mock",
+    "pytest-mock~=3.6.1",
 ]
 
 setuptools.setup(

--- a/airbyte-integrations/connectors/source-okta/Dockerfile
+++ b/airbyte-integrations/connectors/source-okta/Dockerfile
@@ -12,5 +12,5 @@ RUN pip install .
 ENV AIRBYTE_ENTRYPOINT "python /airbyte/integration_code/main.py"
 ENTRYPOINT ["python", "/airbyte/integration_code/main.py"]
 
-LABEL io.airbyte.version=0.1.10
+LABEL io.airbyte.version=0.1.11
 LABEL io.airbyte.name=airbyte/source-okta

--- a/airbyte-integrations/connectors/source-okta/README.md
+++ b/airbyte-integrations/connectors/source-okta/README.md
@@ -6,20 +6,25 @@ For information about how to use this connector within Airbyte, see [the documen
 ## Local development
 
 ### Prerequisites
+
 **To iterate on this connector, make sure to complete this prerequisites section.**
 
 #### Build & Activate Virtual Environment and install dependencies
+
 From this connector directory, create a virtual environment:
-```
+
+```shell
 python -m venv .venv
 ```
 
 This will generate a virtualenv for this module in `.venv/`. Make sure this venv is active in your
 development environment of choice. To activate it from the terminal, run:
-```
+
+```shell
 source .venv/bin/activate
 pip install -r requirements.txt
 ```
+
 If you are in an IDE, follow your IDE's instructions to activate the virtualenv.
 
 Note that while we are installing dependencies from `requirements.txt`, you should only edit `setup.py` for your dependencies. `requirements.txt` is
@@ -28,14 +33,17 @@ If this is mumbo jumbo to you, don't worry about it, just put your deps in `setu
 should work as you expect.
 
 #### Building via Gradle
+
 You can also build the connector in Gradle. This is typically used in CI and not needed for your development workflow.
 
 To build using Gradle, from the Airbyte repository root, run:
-```
+
+```shell
 ./gradlew :airbyte-integrations:connectors:source-okta:build
 ```
 
 #### Create credentials
+
 **If you are a community contributor**, follow the instructions in the [documentation](https://docs.airbyte.io/integrations/sources/okta)
 to generate the necessary credentials. Then create a file `secrets/config.json` conforming to the `source_okta/spec.json` file.
 Note that any directory named `secrets` is gitignored across the entire Airbyte repo, so there is no danger of accidentally checking in sensitive information.
@@ -45,7 +53,8 @@ See `integration_tests/sample_config.json` for a sample config file.
 and place them into `secrets/config.json`.
 
 ### Locally running the connector
-```
+
+```shell
 python main.py spec
 python main.py check --config secrets/config.json
 python main.py discover --config secrets/config.json
@@ -55,76 +64,104 @@ python main.py read --config secrets/config.json --catalog integration_tests/con
 ### Locally running the connector docker image
 
 #### Build
+
 First, make sure you build the latest Docker image:
-```
+
+```shell
 docker build . -t airbyte/source-okta:dev
 ```
 
 You can also build the connector image via Gradle:
-```
+
+```shell
 ./gradlew :airbyte-integrations:connectors:source-okta:airbyteDocker
 ```
+
 When building via Gradle, the docker image name and tag, respectively, are the values of the `io.airbyte.name` and `io.airbyte.version` `LABEL`s in
 the Dockerfile.
 
 #### Run
+
 Then run any of the connector commands as follows:
-```
+
+```shell
 docker run --rm airbyte/source-okta:dev spec
 docker run --rm -v $(pwd)/secrets:/secrets airbyte/source-okta:dev check --config /secrets/config.json
 docker run --rm -v $(pwd)/secrets:/secrets airbyte/source-okta:dev discover --config /secrets/config.json
 docker run --rm -v $(pwd)/secrets:/secrets -v $(pwd)/integration_tests:/integration_tests airbyte/source-okta:dev read --config /secrets/config.json --catalog /integration_tests/configured_catalog.json
 ```
+
 ## Testing
+
 Make sure to familiarize yourself with [pytest test discovery](https://docs.pytest.org/en/latest/goodpractices.html#test-discovery) to know how your test files and methods should be named.
 First install test dependencies into your virtual environment:
-```
+
+```shell
 pip install .[tests]
 ```
+
 ### Unit Tests
+
 To run unit tests locally, from the connector directory run:
-```
+
+```shell
 python -m pytest unit_tests
 ```
 
 ### Integration Tests
+
 There are two types of integration tests: Acceptance Tests (Airbyte's test suite for all source connectors) and custom integration tests (which are specific to this connector).
+
 #### Custom Integration tests
-Place custom tests inside `integration_tests/` folder, then, from the connector root, run
+
+Place custom tests inside the `integration_tests``/` folder, then, from the connector root, run
+
 ```
 python -m pytest integration_tests
 ```
+
 #### Acceptance Tests
+
 Customize `acceptance-test-config.yml` file to configure tests. See [Source Acceptance Tests](https://docs.airbyte.io/connector-development/testing-connectors/source-acceptance-tests-reference) for more information.
 If your connector requires to create or destroy resources for use during acceptance tests create fixtures for it and place them inside integration_tests/acceptance.py.
 To run your integration tests with acceptance tests, from the connector root, run
+
 ```
 docker build . --no-cache -t airbyte/source-okta:dev \
 && python -m pytest -p source_acceptance_test.plugin
 ```
+
 To run your integration tests with docker
 
 ### Using gradle to run tests
+
 All commands should be run from airbyte project root.
 To run unit tests:
+
 ```
 ./gradlew :airbyte-integrations:connectors:source-okta:unitTest
 ```
+
 To run acceptance and custom integration tests:
+
 ```
 ./gradlew :airbyte-integrations:connectors:source-okta:integrationTest
 ```
 
 ## Dependency Management
+
 All of your dependencies should go in `setup.py`, NOT `requirements.txt`. The requirements file is only used to connect internal Airbyte dependencies in the monorepo for local development.
 We split dependencies between two groups, dependencies that are:
+
 * required for your connector to work need to go to `MAIN_REQUIREMENTS` list.
 * required for the testing need to go to `TEST_REQUIREMENTS` list
 
 ### Publishing a new version of the connector
+
 You've checked out the repo, implemented a million dollar feature, and you're ready to share your changes with the world. Now what?
+
 1. Make sure your changes are passing unit and integration tests.
-1. Bump the connector version in `Dockerfile` -- just increment the value of the `LABEL io.airbyte.version` appropriately (we use [SemVer](https://semver.org/)).
-1. Create a Pull Request.
-1. Pat yourself on the back for being an awesome contributor.
-1. Someone from Airbyte will take a look at your PR and iterate with you to merge it into master.
+2. Bump the connector version in `Dockerfile` -- just increment the value of the `LABEL io.airbyte.version` appropriately (we use [SemVer](https://semver.org/)).
+3. Create a Pull Request.
+4. Pat yourself on the back for being an awesome contributor.
+5. Someone from Airbyte will take a look at your PR and iterate with you to merge it into master.

--- a/airbyte-integrations/connectors/source-okta/integration_tests/catalog.json
+++ b/airbyte-integrations/connectors/source-okta/integration_tests/catalog.json
@@ -66,6 +66,15 @@
       "sync_mode": "full_refresh",
       "destination_sync_mode": "overwrite",
       "primary_key": [["id"]]
+    },
+    {
+      "stream": {
+        "name": "permissions",
+        "json_schema": {}
+      },
+      "sync_mode": "full_refresh",
+      "destination_sync_mode": "overwrite",
+      "primary_key": [["label"]]
     }
   ]
 }

--- a/airbyte-integrations/connectors/source-okta/integration_tests/configured_catalog.json
+++ b/airbyte-integrations/connectors/source-okta/integration_tests/configured_catalog.json
@@ -70,6 +70,16 @@
       },
       "sync_mode": "full_refresh",
       "destination_sync_mode": "overwrite"
+    },
+    {
+      "stream": {
+        "name": "permissions",
+        "json_schema": {},
+        "supported_sync_modes": ["full_refresh"]
+      },
+      "sync_mode": "full_refresh",
+      "destination_sync_mode": "overwrite",
+      "primary_key": [["label"]]
     }
   ]
 }

--- a/airbyte-integrations/connectors/source-okta/sample_files/catalog.json
+++ b/airbyte-integrations/connectors/source-okta/sample_files/catalog.json
@@ -60,6 +60,25 @@
       "sync_mode": "full_refresh",
       "destination_sync_mode": "overwrite",
       "primary_key": [["id"]]
+    },
+    {
+      "stream": {
+        "name": "custom_roles",
+        "json_schema": {}
+      },
+      "sync_mode": "full_refresh",
+      "destination_sync_mode": "overwrite",
+      "primary_key": [["id"]]
+    },
+    {
+      "stream": {
+        "name": "permissions",
+        "json_schema": {},
+        "supported_sync_modes": ["full_refresh"]
+      },
+      "sync_mode": "full_refresh",
+      "destination_sync_mode": "overwrite",
+      "primary_key": [["label"]]
     }
   ]
 }

--- a/airbyte-integrations/connectors/source-okta/source_okta/schemas/custom_roles.json
+++ b/airbyte-integrations/connectors/source-okta/source_okta/schemas/custom_roles.json
@@ -1,6 +1,7 @@
 {
   "type": ["null", "object"],
   "additionalProperties": true,
+  "description": "Gets a paginated list of Custom Roles",
   "properties": {
     "id": {
       "type": ["null", "string"]

--- a/airbyte-integrations/connectors/source-okta/source_okta/schemas/permissions.json
+++ b/airbyte-integrations/connectors/source-okta/source_okta/schemas/permissions.json
@@ -1,0 +1,79 @@
+{
+  "description": "Gets the list of permissions included in a Custom Role identified by its id",
+  "properties": {
+    "label": {
+      "enum": [
+        "okta.users.manage",
+        "okta.users.create",
+        "okta.users.read",
+        "okta.users.credentials.manage",
+        "okta.users.credentials.resetFactors",
+        "okta.users.credentials.resetPassword",
+        "okta.users.credentials.expirePassword",
+        "okta.users.userprofile.manage",
+        "okta.users.lifecycle.manage",
+        "okta.users.lifecycle.activate",
+        "okta.users.lifecycle.deactivate",
+        "okta.users.lifecycle.suspend",
+        "okta.users.lifecycle.unsuspend",
+        "okta.users.lifecycle.delete",
+        "okta.users.lifecycle.unlock",
+        "okta.users.lifecycle.clearSessions",
+        "okta.users.groupMembership.manage",
+        "okta.users.appAssignment.manage",
+        "okta.groups.manage",
+        "okta.groups.create",
+        "okta.groups.members.manage",
+        "okta.groups.read",
+        "okta.groups.appAssignment.manage",
+        "okta.apps.read",
+        "okta.apps.manage",
+        "okta.apps.assignment.manage",
+        "okta.profilesources.import.run",
+        "okta.authzServers.read",
+        "okta.authzServers.manage",
+        "okta.customizations.read",
+        "okta.customizations.manage",
+        "okta.workflows.invoke"
+      ],
+      "type": "string",
+      "description": "Type of permissions"
+    },
+    "created": {
+      "format": "date-time",
+      "type": "string"
+    },
+    "lastUpdated": {
+      "format": "date-time",
+      "type": "string"
+    },
+    "_links": {
+      "properties": {
+        "assignee": {
+          "properties": {
+            "self": {
+              "type": ["null", "object"],
+              "additionalProperties": true,
+              "properties": {
+                "href": {
+                  "type": ["null", "string"]
+                }
+              }
+            },
+            "role": {
+              "type": ["null", "object"],
+              "additionalProperties": true,
+              "properties": {
+                "href": {
+                  "type": ["null", "string"]
+                }
+              }
+            }
+          }
+        }
+      },
+      "type": ["object", "null"]
+    }
+  },
+  "type": "object"
+}

--- a/airbyte-integrations/connectors/source-okta/unit_tests/conftest.py
+++ b/airbyte-integrations/connectors/source-okta/unit_tests/conftest.py
@@ -144,6 +144,24 @@ def custom_role_instance(api_url):
 
 
 @pytest.fixture()
+def permission_instance(api_url):
+    """
+    Custom Role instance object response
+    """
+    _role_id = "test_role_id"
+    _id = "okta.users.read"
+    return {
+        "label": _id,
+        "created": "2022-07-09T20:54:54.000Z",
+        "lastUpdated": "2022-07-09T20:54:54.000Z",
+        "_links": {
+            "role": {"href": f"{api_url}/api/v1/iam/roles/{_role_id}"},
+            "self": {"href": f"{api_url}/api/v1/iam/roles/{_role_id}/permissions/{_id}"},
+        },
+    }
+
+
+@pytest.fixture()
 def groups_instance(api_url):
     """
     Groups instance object response

--- a/airbyte-integrations/connectors/source-okta/unit_tests/test_streams.py
+++ b/airbyte-integrations/connectors/source-okta/unit_tests/test_streams.py
@@ -19,6 +19,7 @@ from source_okta.source import (
     IncrementalOktaStream,
     Logs,
     OktaStream,
+    Permissions,
     UserRoleAssignments,
     Users,
 )
@@ -210,6 +211,22 @@ class TestStreamCustomRoles:
         record = {"roles": [custom_role_instance]}
         requests_mock.get(f"{api_url}", json=record)
         assert list(stream.parse_response(response=requests.get(f"{api_url}"))) == [custom_role_instance]
+
+
+class TestStreamPermissions:
+    def test_permissions(self, requests_mock, patch_base_class, permission_instance, url_base, api_url):
+        stream = Permissions(url_base=url_base)
+        record = {"permissions": [permission_instance]}
+        role_id = "test_role_id"
+        requests_mock.get(f"{api_url}/iam/roles/{role_id}/permissions", json=record)
+        inputs = {"sync_mode": SyncMode.full_refresh, "stream_state": {}, "stream_slice": {"role_id": role_id}}
+        assert list(stream.read_records(**inputs)) == record["permissions"]
+
+    def test_permissions_parse_response(self, requests_mock, patch_base_class, permission_instance, url_base, api_url):
+        stream = Permissions(url_base=url_base)
+        record = {"permissions": [permission_instance]}
+        requests_mock.get(f"{api_url}", json=record)
+        assert list(stream.parse_response(response=requests.get(f"{api_url}"))) == [permission_instance]
 
 
 class TestStreamGroups:

--- a/docs/integrations/sources/okta.md
+++ b/docs/integrations/sources/okta.md
@@ -62,8 +62,8 @@ Different Okta APIs require different admin privilege levels. API tokens inherit
 
 | Version | Date       | Pull Request                                             | Subject                                                                        |
 |:--------|:-----------|:---------------------------------------------------------|:-------------------------------------------------------------------------------|
-| 0.1.11  | 2022-07-20 | [14739](https://github.com/airbytehq/airbyte/pull/14739) | add permissions for custom roles |
-| 0.1.10   | 2022-08-01 | [15179](https://github.com/airbytehq/airbyte/pull/15179) | Fixed broken schemas for all streams
+| 0.1.11  | 2022-08-03 | [14739](https://github.com/airbytehq/airbyte/pull/14739) | add permissions for custom roles |
+| 0.1.10  | 2022-08-01 | [15179](https://github.com/airbytehq/airbyte/pull/15179) | Fixed broken schemas for all streams
 | 0.1.9   | 2022-07-25 | [15001](https://github.com/airbytehq/airbyte/pull/15001) | Return deprovisioned users                                                     |
 | 0.1.8   | 2022-07-19 | [14710](https://github.com/airbytehq/airbyte/pull/14710) | Implement OAuth2.0 authorization method                                        |
 | 0.1.7   | 2022-07-13 | [14556](https://github.com/airbytehq/airbyte/pull/14556) | add User_Role_Assignments and Group_Role_Assignments streams (full fetch only) |

--- a/docs/integrations/sources/okta.md
+++ b/docs/integrations/sources/okta.md
@@ -15,6 +15,7 @@ This Source is capable of syncing the following core Streams:
 - [Group Role Assignments](https://developer.okta.com/docs/reference/api/roles/#list-roles-assigned-to-a-group)
 - [System Log](https://developer.okta.com/docs/reference/api/system-log/#get-started)
 - [Custom Roles](https://developer.okta.com/docs/reference/api/roles/#list-roles)
+- [Permissions](https://developer.okta.com/docs/reference/api/roles/#list-permissions)
 
 ### Data type mapping
 
@@ -61,6 +62,7 @@ Different Okta APIs require different admin privilege levels. API tokens inherit
 
 | Version | Date       | Pull Request                                             | Subject                                                                        |
 |:--------|:-----------|:---------------------------------------------------------|:-------------------------------------------------------------------------------|
+| 0.1.11  | 2022-07-20 | [14739](https://github.com/airbytehq/airbyte/pull/14739) | add permissions for custom roles |
 | 0.1.10   | 2022-08-01 | [15179](https://github.com/airbytehq/airbyte/pull/15179) | Fixed broken schemas for all streams
 | 0.1.9   | 2022-07-25 | [15001](https://github.com/airbytehq/airbyte/pull/15001) | Return deprovisioned users                                                     |
 | 0.1.8   | 2022-07-19 | [14710](https://github.com/airbytehq/airbyte/pull/14710) | Implement OAuth2.0 authorization method                                        |


### PR DESCRIPTION

## What
Add permissions to okta source connectors 
https://developer.okta.com/docs/reference/api/roles/#list-permissions
Each org is allowed to create at most 100 custom roles (added in this PR https://github.com/airbytehq/airbyte/pull/14610), and each custom roles can add at most 32 permission. The API always returns all permission given a role id, so it's a full refresh

## How
*Describe the solution*

## Recommended reading order
1. `source.python`

## 🚨 User Impact 🚨
No impact, new API stream

## Pre-merge Checklist
Expand the relevant checklist and delete the others.

<details><summary><strong>New Connector</strong></summary>

### Community member or Airbyter

- [x] **Community member?** Grant edit access to maintainers ([instructions](https://docs.github.com/en/github/collaborating-with-pull-requests/working-with-forks/allowing-changes-to-a-pull-request-branch-created-from-a-fork#enabling-repository-maintainer-permissions-on-existing-pull-requests))
- [ ] Secrets in the connector's spec are annotated with `airbyte_secret`
- [x] Unit & integration tests added and passing. Community members, please provide proof of success locally e.g: screenshot or copy-paste unit, integration, and acceptance test output. To run acceptance tests for a Python connector, follow instructions in the README. For java connectors run `./gradlew :airbyte-integrations:connectors:<name>:integrationTest`.
- [ ] Code reviews completed
- [ ] Documentation updated
    - [ ] Connector's `README.md`
    - [ ] Connector's `bootstrap.md`. See [description and examples](https://docs.google.com/document/d/1ypdgmwmEHWv-TrO4_YOQ7pAJGVrMp5BOkEVh831N260/edit?usp=sharing)
    - [x] `docs/integrations/<source or destination>/<name>.md` including changelog. See changelog [example](https://docs.airbyte.io/integrations/sources/stripe#changelog)
    - [ ] `docs/integrations/README.md`
    - [ ] `airbyte-integrations/builds.md`
- [ ] PR name follows [PR naming conventions](https://docs.airbyte.io/contributing-to-airbyte/updating-documentation#issues-and-pull-requests)

### Airbyter

If this is a community PR, the Airbyte engineer reviewing this PR is responsible for the below items.

- [ ] Create a non-forked branch based on this PR and test the below items on it
- [ ] Build is successful
- [ ] If new credentials are required for use in CI, add them to GSM. [Instructions](https://docs.airbyte.io/connector-development#using-credentials-in-ci).
- [ ] [`/test connector=connectors/<name>` command](https://docs.airbyte.io/connector-development#updating-an-existing-connector) is passing
- [ ] New Connector version released on Dockerhub by running the `/publish` command described [here](https://docs.airbyte.io/connector-development#updating-an-existing-connector)
- [ ] After the connector is published, connector added to connector index as described [here](https://docs.airbyte.io/connector-development#publishing-a-connector)
- [ ] Seed specs have been re-generated by building the platform and committing the changes to the seed spec files, as described [here](https://docs.airbyte.io/connector-development#publishing-a-connector)

</details>

<details><summary><strong>Updating a connector</strong></summary>

### Community member or Airbyter

- [ ] Grant edit access to maintainers ([instructions](https://docs.github.com/en/github/collaborating-with-pull-requests/working-with-forks/allowing-changes-to-a-pull-request-branch-created-from-a-fork#enabling-repository-maintainer-permissions-on-existing-pull-requests))
- [ ] Secrets in the connector's spec are annotated with `airbyte_secret`
- [ ] Unit & integration tests added and passing. Community members, please provide proof of success locally e.g: screenshot or copy-paste unit, integration, and acceptance test output. To run acceptance tests for a Python connector, follow instructions in the README. For java connectors run `./gradlew :airbyte-integrations:connectors:<name>:integrationTest`.
- [ ] Code reviews completed
- [ ] Documentation updated
    - [ ] Connector's `README.md`
    - [ ] Connector's `bootstrap.md`. See [description and examples](https://docs.google.com/document/d/1ypdgmwmEHWv-TrO4_YOQ7pAJGVrMp5BOkEVh831N260/edit?usp=sharing)
    - [ ] Changelog updated in `docs/integrations/<source or destination>/<name>.md` including changelog. See changelog [example](https://docs.airbyte.io/integrations/sources/stripe#changelog)
- [ ] PR name follows [PR naming conventions](https://docs.airbyte.io/contributing-to-airbyte/updating-documentation#issues-and-pull-requests)

### Airbyter

If this is a community PR, the Airbyte engineer reviewing this PR is responsible for the below items.

- [ ] Create a non-forked branch based on this PR and test the below items on it
- [ ] Build is successful
- [ ] If new credentials are required for use in CI, add them to GSM. [Instructions](https://docs.airbyte.io/connector-development#using-credentials-in-ci).
- [ ] [`/test connector=connectors/<name>` command](https://docs.airbyte.io/connector-development#updating-an-existing-connector) is passing
- [ ] New Connector version released on Dockerhub and connector version bumped by running the `/publish` command described [here](https://docs.airbyte.io/connector-development#updating-an-existing-connector)

</details>

<details><summary><strong>Connector Generator</strong></summary>

- [ ] Issue acceptance criteria met
- [ ] PR name follows [PR naming conventions](https://docs.airbyte.io/contributing-to-airbyte/updating-documentation#issues-and-pull-requests)
- [ ] If adding a new generator, add it to the [list of scaffold modules being tested](https://github.com/airbytehq/airbyte/blob/master/airbyte-integrations/connector-templates/generator/build.gradle#L41)
- [ ] The generator test modules (all connectors with `-scaffold` in their name) have been updated with the latest scaffold by running `./gradlew :airbyte-integrations:connector-templates:generator:testScaffoldTemplates` then checking in your changes
- [ ] Documentation which references the generator is updated as needed

</details>

## Tests

<details><summary><strong>Unit</strong></summary>

*Put your unit tests output here.*

</details>

<details><summary><strong>Integration</strong></summary>

*Put your integration tests output here.*

</details>

<details><summary><strong>Acceptance</strong></summary>

```
collecting ... 
 airbyte-integrations/bases/source-acceptance-test/source_acceptance_test/tests/test_core.py::TestSpec.test_config_match_spec[inputs0] ✓                                                                                                                       4% ▌         
 airbyte-integrations/bases/source-acceptance-test/source_acceptance_test/tests/test_core.py::TestSpec.test_match_expected[inputs0] ✓                                                                                                                          8% ▉         
 airbyte-integrations/bases/source-acceptance-test/source_acceptance_test/tests/test_core.py::TestSpec.test_docker_env[inputs0] ✓                                                                                                                             12% █▍        
 airbyte-integrations/bases/source-acceptance-test/source_acceptance_test/tests/test_core.py::TestSpec.test_oneof_usage[inputs0] ✓                                                                                                                            17% █▋        
 airbyte-integrations/bases/source-acceptance-test/source_acceptance_test/tests/test_core.py::TestSpec.test_required[inputs0] ✓                                                                                                                               21% ██▏       
 airbyte-integrations/bases/source-acceptance-test/source_acceptance_test/tests/test_core.py::TestSpec.test_optional[inputs0] ✓                                                                                                                               25% ██▌       
 airbyte-integrations/bases/source-acceptance-test/source_acceptance_test/tests/test_core.py::TestSpec.test_has_secret[inputs0] ✓                                                                                                                             29% ██▉       
 airbyte-integrations/bases/source-acceptance-test/source_acceptance_test/tests/test_core.py::TestSpec.test_secret_never_in_the_output[inputs0] ✓                                                                                                             33% ███▍      
 airbyte-integrations/bases/source-acceptance-test/source_acceptance_test/tests/test_core.py::TestSpec.test_defined_refs_exist_in_json_spec_file[inputs0] ✓                                                                                                   38% ███▊      
 airbyte-integrations/bases/source-acceptance-test/source_acceptance_test/tests/test_core.py::TestSpec.test_oauth_flow_parameters[inputs0] ✓                                                                                                                  42% ████▎     
 airbyte-integrations/bases/source-acceptance-test/source_acceptance_test/tests/test_core.py::TestConnection.test_check[inputs0] ✓                                                                                                                            46% ████▋     
 airbyte-integrations/bases/source-acceptance-test/source_acceptance_test/tests/test_core.py::TestConnection.test_check[inputs1] ✓                                                                                                                            50% █████     
 airbyte-integrations/bases/source-acceptance-test/source_acceptance_test/tests/test_core.py::TestDiscovery.test_discover[inputs0] ✓                                                                                                                          54% █████▌    
 airbyte-integrations/bases/source-acceptance-test/source_acceptance_test/tests/test_core.py::TestDiscovery.test_defined_cursors_exist_in_schema[inputs0] ✓                                                                                                   58% █████▉    
 airbyte-integrations/bases/source-acceptance-test/source_acceptance_test/tests/test_core.py::TestDiscovery.test_defined_refs_exist_in_schema[inputs0] ✓                                                                                                      62% ██████▍   
 airbyte-integrations/bases/source-acceptance-test/source_acceptance_test/tests/test_core.py::TestDiscovery.test_defined_keyword_exist_in_schema[inputs0-allOf] ✓                                                                                             67% ██████▋   
 airbyte-integrations/bases/source-acceptance-test/source_acceptance_test/tests/test_core.py::TestDiscovery.test_defined_keyword_exist_in_schema[inputs0-not] ✓                                                                                               71% ███████▏  
 airbyte-integrations/bases/source-acceptance-test/source_acceptance_test/tests/test_core.py::TestDiscovery.test_primary_keys_exist_in_schema[inputs0] ✓                                                                                                      75% ███████▌  
 airbyte-integrations/bases/source-acceptance-test/source_acceptance_test/tests/test_core.py::TestBasicRead.test_read[inputs0] ✓                                                                                                                              79% ███████▉  {"type": "LOG", "log": {"level": "ERROR", "message": "Docker container was failed, code 1, error:\n{\"type\": \"TRACE\", \"trace\": {\"type\": \"ERROR\", \"emitted_at\": 1657855159900.5042, \"error\": {\"message\": \"Something went wrong in the connector. See the logs for more details.\", \"internal_message\": \"2 validation errors for ConfiguredAirbyteCatalog\\nstreams -> 0 -> sync_mode\\n  value is not a valid enumeration member; permitted: 'full_refresh', 'incremental' (type=type_error.enum; enum_values=[<SyncMode.full_refresh: 'full_refresh'>, <SyncMode.incremental: 'incremental'>])\\nstreams -> 0 -> destination_sync_mode\\n  value is not a valid enumeration member; permitted: 'append', 'overwrite', 'append_dedup' (type=type_error.enum; enum_values=[<DestinationSyncMode.append: 'append'>, <DestinationSyncMode.overwrite: 'overwrite'>, <DestinationSyncMode.append_dedup: 'append_dedup'>])\", \"stack_trace\": \"Traceback (most recent call last):\\n  File \\\"/airbyte/integration_code/main.py\\\", line 13, in <module>\\n    launch(source, sys.argv[1:])\\n  File \\\"/usr/local/lib/python3.9/site-packages/airbyte_cdk/entrypoint.py\\\", line 123, in launch\\n    for message in source_entrypoint.run(parsed_args):\\n  File \\\"/usr/local/lib/python3.9/site-packages/airbyte_cdk/entrypoint.py\\\", line 111, in run\\n    config_catalog = self.source.read_catalog(parsed_args.catalog)\\n  File \\\"/usr/local/lib/python3.9/site-packages/airbyte_cdk/sources/source.py\\\", line 54, in read_catalog\\n    return ConfiguredAirbyteCatalog.parse_obj(self.read_config(catalog_path))\\n  File \\\"/usr/local/lib/python3.9/site-packages/pydantic/main.py\\\", line 521, in parse_obj\\n    return cls(**obj)\\n  File \\\"/usr/local/lib/python3.9/site-packages/pydantic/main.py\\\", line 341, in __init__\\n    raise validation_error\\npydantic.error_wrappers.ValidationError: 2 validation errors for ConfiguredAirbyteCatalog\\nstreams -> 0 -> sync_mode\\n  value is not a valid enumeration member; permitted: 'full_refresh', 'incremental' (type=type_error.enum; enum_values=[<SyncMode.full_refresh: 'full_refresh'>, <SyncMode.incremental: 'incremental'>])\\nstreams -> 0 -> destination_sync_mode\\n  value is not a valid enumeration member; permitted: 'append', 'overwrite', 'append_dedup' (type=type_error.enum; enum_values=[<DestinationSyncMode.append: 'append'>, <DestinationSyncMode.overwrite: 'overwrite'>, <DestinationSyncMode.append_dedup: 'append_dedup'>])\\n\", \"failure_type\": \"system_error\"}}}\n"}}

 airbyte-integrations/bases/source-acceptance-test/source_acceptance_test/tests/test_core.py::TestBasicRead.test_airbyte_trace_message_on_failure[inputs0] ✓                                                                                                  83% ████████▍ 
 airbyte-integrations/bases/source-acceptance-test/source_acceptance_test/tests/test_full_refresh.py::TestFullRefresh.test_sequential_reads[inputs0] ✓                                                                                                        88% ████████▊ 
 airbyte-integrations/bases/source-acceptance-test/source_acceptance_test/tests/test_incremental.py::TestIncremental.test_two_sequential_reads[inputs0] ✓                                                                                                     92% █████████▎
 airbyte-integrations/bases/source-acceptance-test/source_acceptance_test/tests/test_incremental.py::TestIncremental.test_read_sequential_slices[inputs0] ✓                                                                                                   96% █████████▋
 airbyte-integrations/bases/source-acceptance-test/source_acceptance_test/tests/test_incremental.py::TestIncremental.test_state_with_abnormally_large_values[inputs0] ✓                                                                                      100% ██████████
{"type": "LOG", "log": {"level": "INFO", "message": "/Users/bartdev/Playground/airbyte/airbyte-integrations/connectors/source-okta - SAT run - 59689040345ec87fd6f68a3e3ac60907e37f9eb9 - PASSED"}}

============================================================================================================================= warnings summary =============================================================================================================================
airbyte-integrations/bases/source-acceptance-test/source_acceptance_test/tests/test_core.py: 17 warnings
airbyte-integrations/bases/source-acceptance-test/source_acceptance_test/tests/test_full_refresh.py: 1 warning
airbyte-integrations/bases/source-acceptance-test/source_acceptance_test/tests/test_incremental.py: 3 warnings
  /Users/bartdev/Playground/airbyte/airbyte-integrations/connectors/source-okta/.venv/lib/python3.9/site-packages/docker/utils/utils.py:52: DeprecationWarning: distutils Version classes are deprecated. Use packaging.version instead.
    s1 = StrictVersion(v1)

airbyte-integrations/bases/source-acceptance-test/source_acceptance_test/tests/test_core.py: 17 warnings
airbyte-integrations/bases/source-acceptance-test/source_acceptance_test/tests/test_full_refresh.py: 1 warning
airbyte-integrations/bases/source-acceptance-test/source_acceptance_test/tests/test_incremental.py: 3 warnings
  /Users/bartdev/Playground/airbyte/airbyte-integrations/connectors/source-okta/.venv/lib/python3.9/site-packages/docker/utils/utils.py:53: DeprecationWarning: distutils Version classes are deprecated. Use packaging.version instead.
    s2 = StrictVersion(v2)

-- Docs: https://docs.pytest.org/en/stable/warnings.html

Results (153.22s):
```

</details>
