### PR TITLE
Match image version in code to docker hub

### DIFF
--- a/airbyte-integrations/connectors/destination-oracle/Dockerfile
+++ b/airbyte-integrations/connectors/destination-oracle/Dockerfile
@@ -16,5 +16,5 @@ ENV APPLICATION destination-oracle
 
 COPY --from=build /airbyte /airbyte
 
-LABEL io.airbyte.version=0.1.18
+LABEL io.airbyte.version=0.1.16
 LABEL io.airbyte.name=airbyte/destination-oracle

--- a/docs/integrations/destinations/oracle.md
+++ b/docs/integrations/destinations/oracle.md
@@ -92,8 +92,6 @@ Airbite has the ability to connect to the Oracle source with 3 network connectiv
 
 | Version | Date | Pull Request                                             | Subject                                                                                             |
 |:--------| :--- |:---------------------------------------------------------|:----------------------------------------------------------------------------------------------------|
-| 0.1.18  | 2022-07-14 | [\#14618](https://github.com/airbytehq/airbyte/pull/14618) | Removed additionalProperties: false from JDBC destination connectors |
-| 0.1.17  | 2022-05-17 | [12820](https://github.com/airbytehq/airbyte/pull/12820) | Improved 'check' operation performance |
 | 0.1.16  | 2022-04-06 | [11514](https://github.com/airbytehq/airbyte/pull/11514) | Bump mina-sshd from 2.7.0 to 2.8.0                                                                  |
 | 0.1.15  | 2022-02-25 | [10421](https://github.com/airbytehq/airbyte/pull/10421) | Refactor JDBC parameters handling and remove DBT support                                            |
 | 0.1.14  | 2022-02-14 | [10256](https://github.com/airbytehq/airbyte/pull/10256) | (unpublished) Add `-XX:+ExitOnOutOfMemoryError` JVM option                                          |


### PR DESCRIPTION
The latest image of destination oracle connector in Docker Hub is 0.1.16. Later images must have failed to get published. Having newer images referenced in Dockerfile and seed files breaks the build. This PR unbreaks the build until destination oracle 0.1.18 is published.