### PR TITLE
Apply Best Practices PMD rules

### DIFF
--- a/airbyte-bootloader/src/main/java/io/airbyte/bootloader/BootloaderApp.java
+++ b/airbyte-bootloader/src/main/java/io/airbyte/bootloader/BootloaderApp.java
@@ -53,6 +53,7 @@ import org.slf4j.LoggerFactory;
  * <p>
  * - setting all required Airbyte metadata information.
  */
+@SuppressWarnings("PMD.UnusedPrivateField")
 public class BootloaderApp {
 
   private static final Logger LOGGER = LoggerFactory.getLogger(BootloaderApp.class);

--- a/airbyte-commons/src/main/java/io/airbyte/commons/io/Archives.java
+++ b/airbyte-commons/src/main/java/io/airbyte/commons/io/Archives.java
@@ -18,13 +18,8 @@ import org.apache.commons.compress.archivers.tar.TarArchiveEntry;
 import org.apache.commons.compress.archivers.tar.TarArchiveInputStream;
 import org.apache.commons.compress.archivers.tar.TarArchiveOutputStream;
 import org.apache.commons.compress.compressors.gzip.GzipCompressorInputStream;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 
 public class Archives {
-
-  private static final Logger LOGGER = LoggerFactory.getLogger(Archives.class);
-
   /**
    * Compress a @param sourceFolder into a Gzip Tarball @param archiveFile
    */

--- a/airbyte-commons/src/main/java/io/airbyte/commons/io/Archives.java
+++ b/airbyte-commons/src/main/java/io/airbyte/commons/io/Archives.java
@@ -20,6 +20,7 @@ import org.apache.commons.compress.archivers.tar.TarArchiveOutputStream;
 import org.apache.commons.compress.compressors.gzip.GzipCompressorInputStream;
 
 public class Archives {
+
   /**
    * Compress a @param sourceFolder into a Gzip Tarball @param archiveFile
    */

--- a/airbyte-commons/src/main/java/io/airbyte/commons/json/JsonSchemas.java
+++ b/airbyte-commons/src/main/java/io/airbyte/commons/json/JsonSchemas.java
@@ -43,14 +43,9 @@ public class JsonSchemas {
   private static final String ARRAY_TYPE = "array";
   private static final String OBJECT_TYPE = "object";
   private static final String STRING_TYPE = "string";
-  private static final String NUMBER_TYPE = "number";
-  private static final String BOOLEAN_TYPE = "boolean";
-  private static final String NULL_TYPE = "null";
   private static final String ONE_OF_TYPE = "oneOf";
   private static final String ALL_OF_TYPE = "allOf";
   private static final String ANY_OF_TYPE = "anyOf";
-
-  private static final String ARRAY_JSON_PATH = "[]";
 
   private static final Set<String> COMPOSITE_KEYWORDS = Set.of(ONE_OF_TYPE, ALL_OF_TYPE, ANY_OF_TYPE);
 

--- a/airbyte-db/db-lib/src/main/java/io/airbyte/db/DataTypeUtils.java
+++ b/airbyte-db/db-lib/src/main/java/io/airbyte/db/DataTypeUtils.java
@@ -15,12 +15,8 @@ import java.time.LocalDateTime;
 import java.time.OffsetDateTime;
 import java.time.format.DateTimeFormatter;
 import java.util.function.Function;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 
 public class DataTypeUtils {
-
-  private static final Logger LOGGER = LoggerFactory.getLogger(DataTypeUtils.class);
 
   public static final String DATE_FORMAT_PATTERN = "yyyy-MM-dd'T'HH:mm:ss'Z'";
 

--- a/airbyte-db/db-lib/src/main/java/io/airbyte/db/instance/configs/migrations/V0_30_22_001__Store_last_sync_state.java
+++ b/airbyte-db/db-lib/src/main/java/io/airbyte/db/instance/configs/migrations/V0_30_22_001__Store_last_sync_state.java
@@ -136,7 +136,6 @@ public class V0_30_22_001__Store_last_sync_state extends BaseJavaMigration {
 
     final Table<?> attemptsTable = DSL.table("attempts");
     final Field<Long> attemptJobId = DSL.field("attempts.job_id", SQLDataType.BIGINT);
-    final Field<Integer> attemptNumber = DSL.field("attempts.attempt_number", SQLDataType.INTEGER);
     final Field<OffsetDateTime> attemptCreatedAt = DSL.field("attempts.created_at", SQLDataType.TIMESTAMPWITHTIMEZONE);
 
     // output schema: JobOutput.yaml

--- a/airbyte-db/db-lib/src/main/java/io/airbyte/db/instance/configs/migrations/V0_30_22_001__Store_last_sync_state.java
+++ b/airbyte-db/db-lib/src/main/java/io/airbyte/db/instance/configs/migrations/V0_30_22_001__Store_last_sync_state.java
@@ -4,9 +4,7 @@
 
 package io.airbyte.db.instance.configs.migrations;
 
-import com.fasterxml.jackson.databind.ObjectMapper;
 import com.google.common.annotations.VisibleForTesting;
-import io.airbyte.commons.jackson.MoreMappers;
 import io.airbyte.commons.json.Jsons;
 import io.airbyte.config.ConfigSchema;
 import io.airbyte.config.EnvConfigs;
@@ -38,7 +36,6 @@ import org.slf4j.LoggerFactory;
  */
 public class V0_30_22_001__Store_last_sync_state extends BaseJavaMigration {
 
-  private static final ObjectMapper MAPPER = MoreMappers.initMapper();
   private static final String MIGRATION_NAME = "Configs db migration 0.30.22.001";
   private static final Logger LOGGER = LoggerFactory.getLogger(V0_30_22_001__Store_last_sync_state.class);
 

--- a/airbyte-db/db-lib/src/test/java/io/airbyte/db/instance/configs/migrations/V0_30_22_001__Store_last_sync_state_test.java
+++ b/airbyte-db/db-lib/src/test/java/io/airbyte/db/instance/configs/migrations/V0_30_22_001__Store_last_sync_state_test.java
@@ -19,8 +19,6 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
-import com.fasterxml.jackson.databind.ObjectMapper;
-import io.airbyte.commons.jackson.MoreMappers;
 import io.airbyte.commons.json.Jsons;
 import io.airbyte.commons.resources.MoreResources;
 import io.airbyte.config.ConfigSchema;
@@ -62,7 +60,6 @@ import org.junit.jupiter.api.Timeout;
 @TestMethodOrder(MethodOrderer.OrderAnnotation.class)
 class V0_30_22_001__Store_last_sync_state_test extends AbstractConfigsDatabaseTest {
 
-  private static final ObjectMapper OBJECT_MAPPER = MoreMappers.initMapper();
   private static final OffsetDateTime TIMESTAMP = OffsetDateTime.now();
 
   private static final Table<?> JOBS_TABLE = table("jobs");

--- a/airbyte-db/db-lib/src/test/java/io/airbyte/db/instance/configs/migrations/V0_30_22_001__Store_last_sync_state_test.java
+++ b/airbyte-db/db-lib/src/test/java/io/airbyte/db/instance/configs/migrations/V0_30_22_001__Store_last_sync_state_test.java
@@ -283,4 +283,5 @@ class V0_30_22_001__Store_last_sync_state_test extends AbstractConfigsDatabaseTe
       }
     }
   }
+
 }

--- a/airbyte-db/db-lib/src/test/java/io/airbyte/db/instance/configs/migrations/V0_30_22_001__Store_last_sync_state_test.java
+++ b/airbyte-db/db-lib/src/test/java/io/airbyte/db/instance/configs/migrations/V0_30_22_001__Store_last_sync_state_test.java
@@ -20,7 +20,6 @@ import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
 import io.airbyte.commons.json.Jsons;
-import io.airbyte.commons.resources.MoreResources;
 import io.airbyte.config.ConfigSchema;
 import io.airbyte.config.Configs;
 import io.airbyte.config.JobOutput;
@@ -29,9 +28,7 @@ import io.airbyte.config.StandardSyncOutput;
 import io.airbyte.config.StandardSyncState;
 import io.airbyte.config.State;
 import io.airbyte.db.Database;
-import io.airbyte.db.factory.DatabaseCheckFactory;
 import io.airbyte.db.init.DatabaseInitializationException;
-import io.airbyte.db.instance.DatabaseConstants;
 import io.airbyte.db.instance.configs.AbstractConfigsDatabaseTest;
 import io.airbyte.db.instance.jobs.JobsDatabaseTestProvider;
 import java.io.IOException;
@@ -286,10 +283,4 @@ class V0_30_22_001__Store_last_sync_state_test extends AbstractConfigsDatabaseTe
       }
     }
   }
-
-  private void initializeJobsDatabase(final DSLContext dslContext) throws DatabaseInitializationException, IOException {
-    final String initialSchema = MoreResources.readResource(DatabaseConstants.JOBS_SCHEMA_PATH);
-    DatabaseCheckFactory.createJobsDatabaseInitializer(dslContext, DatabaseConstants.DEFAULT_CONNECTION_TIMEOUT_MS, initialSchema).initialize();
-  }
-
 }

--- a/airbyte-metrics/metrics-lib/src/test/java/io/airbyte/metrics/lib/MetricsQueriesTest.java
+++ b/airbyte-metrics/metrics-lib/src/test/java/io/airbyte/metrics/lib/MetricsQueriesTest.java
@@ -206,7 +206,6 @@ public class MetricsQueriesTest {
       configDb.transaction(
           ctx -> ctx.insertInto(JOBS, JOBS.ID, JOBS.SCOPE, JOBS.STATUS).values(5L, inactiveConnectionId.toString(), JobStatus.running).execute());
 
-      final var res = configDb.query(MetricQueries::numberOfRunningJobs);
       assertEquals(2, configDb.query(MetricQueries::numberOfRunningJobs));
       assertEquals(1, configDb.query(MetricQueries::numberOfOrphanRunningJobs));
     }

--- a/airbyte-oauth/src/main/java/io/airbyte/oauth/OAuthImplementationFactory.java
+++ b/airbyte-oauth/src/main/java/io/airbyte/oauth/OAuthImplementationFactory.java
@@ -49,7 +49,7 @@ public class OAuthImplementationFactory {
         .put("airbyte/source-square", new SquareOAuthFlow(configRepository, httpClient))
         .put("airbyte/source-strava", new StravaOAuthFlow(configRepository, httpClient))
         .put("airbyte/source-surveymonkey", new SurveymonkeyOAuthFlow(configRepository, httpClient))
-        .put("airbyte/source-trello", new TrelloOAuthFlow(configRepository, httpClient))
+        .put("airbyte/source-trello", new TrelloOAuthFlow(configRepository))
         .put("airbyte/source-youtube-analytics", new YouTubeAnalyticsOAuthFlow(configRepository, httpClient))
         .put("airbyte/source-drift", new DriftOAuthFlow(configRepository, httpClient))
         .put("airbyte/source-zendesk-chat", new ZendeskChatOAuthFlow(configRepository, httpClient))

--- a/airbyte-oauth/src/main/java/io/airbyte/oauth/flows/TrelloOAuthFlow.java
+++ b/airbyte-oauth/src/main/java/io/airbyte/oauth/flows/TrelloOAuthFlow.java
@@ -19,7 +19,6 @@ import io.airbyte.oauth.BaseOAuthFlow;
 import io.airbyte.protocol.models.OAuthConfigSpecification;
 import io.airbyte.validation.json.JsonValidationException;
 import java.io.IOException;
-import java.net.http.HttpClient;
 import java.util.List;
 import java.util.Map;
 import java.util.UUID;
@@ -42,7 +41,7 @@ public class TrelloOAuthFlow extends BaseOAuthFlow {
   private static final OAuthHmacSigner signer = new OAuthHmacSigner();
   private final HttpTransport transport;
 
-  public TrelloOAuthFlow(final ConfigRepository configRepository, final HttpClient httpClient) {
+  public TrelloOAuthFlow(final ConfigRepository configRepository) {
     super(configRepository);
     transport = new NetHttpTransport();
   }

--- a/airbyte-oauth/src/test-integration/java/io.airbyte.oauth.flows/TrelloOAuthFlowIntegrationTest.java
+++ b/airbyte-oauth/src/test-integration/java/io.airbyte.oauth.flows/TrelloOAuthFlowIntegrationTest.java
@@ -21,7 +21,6 @@ import io.airbyte.validation.json.JsonValidationException;
 import java.io.IOException;
 import java.io.OutputStream;
 import java.net.InetSocketAddress;
-import java.net.http.HttpClient;
 import java.nio.charset.StandardCharsets;
 import java.nio.file.Files;
 import java.nio.file.Path;
@@ -45,7 +44,6 @@ public class TrelloOAuthFlowIntegrationTest {
   private TrelloOAuthFlow trelloOAuthFlow;
   private HttpServer server;
   private ServerHandler serverHandler;
-  private HttpClient httpClient;
 
   @BeforeEach
   public void setup() throws IOException {
@@ -54,7 +52,6 @@ public class TrelloOAuthFlowIntegrationTest {
           "Must provide path to a oauth credentials file.");
     }
     configRepository = mock(ConfigRepository.class);
-    httpClient = HttpClient.newBuilder().version(HttpClient.Version.HTTP_1_1).build();
     trelloOAuthFlow = new TrelloOAuthFlow(configRepository);
 
     server = HttpServer.create(new InetSocketAddress(8000), 0);

--- a/airbyte-oauth/src/test-integration/java/io.airbyte.oauth.flows/TrelloOAuthFlowIntegrationTest.java
+++ b/airbyte-oauth/src/test-integration/java/io.airbyte.oauth.flows/TrelloOAuthFlowIntegrationTest.java
@@ -55,7 +55,7 @@ public class TrelloOAuthFlowIntegrationTest {
     }
     configRepository = mock(ConfigRepository.class);
     httpClient = HttpClient.newBuilder().version(HttpClient.Version.HTTP_1_1).build();
-    trelloOAuthFlow = new TrelloOAuthFlow(configRepository, httpClient);
+    trelloOAuthFlow = new TrelloOAuthFlow(configRepository);
 
     server = HttpServer.create(new InetSocketAddress(8000), 0);
     server.setExecutor(null); // creates a default executor

--- a/airbyte-protocol/protocol-models/src/main/java/io/airbyte/protocol/models/CatalogHelpers.java
+++ b/airbyte-protocol/protocol-models/src/main/java/io/airbyte/protocol/models/CatalogHelpers.java
@@ -306,15 +306,14 @@ public class CatalogHelpers {
           final AirbyteStream streamOld = descriptorToStreamOld.get(descriptor);
           final AirbyteStream streamNew = descriptorToStreamNew.get(descriptor);
           if (!streamOld.equals(streamNew)) {
-            streamTransforms.add(StreamTransform.createUpdateStreamTransform(descriptor, getStreamDiff(descriptor, streamOld, streamNew)));
+            streamTransforms.add(StreamTransform.createUpdateStreamTransform(descriptor, getStreamDiff(streamOld, streamNew)));
           }
         });
 
     return streamTransforms;
   }
 
-  private static UpdateStreamTransform getStreamDiff(final StreamDescriptor descriptor,
-                                                     final AirbyteStream streamOld,
+  private static UpdateStreamTransform getStreamDiff(final AirbyteStream streamOld,
                                                      final AirbyteStream streamNew) {
     final Set<FieldTransform> fieldTransforms = new HashSet<>();
     final Map<List<String>, JsonNode> fieldNameToTypeOld = getFullyQualifiedFieldNamesWithTypes(streamOld.getJsonSchema())

--- a/airbyte-queue/src/test/java/io/airbyte/queue/OnDiskQueueTest.java
+++ b/airbyte-queue/src/test/java/io/airbyte/queue/OnDiskQueueTest.java
@@ -19,12 +19,9 @@ import java.util.Objects;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 
 class OnDiskQueueTest {
 
-  private static final Logger LOGGER = LoggerFactory.getLogger(OnDiskQueueTest.class);
   private static final Path TEST_ROOT = Path.of("/tmp/airbyte_tests");
   private CloseableQueue<byte[]> queue;
   private Path queueRoot;

--- a/airbyte-scheduler/scheduler-persistence/src/main/java/io/airbyte/scheduler/persistence/DefaultJobPersistence.java
+++ b/airbyte-scheduler/scheduler-persistence/src/main/java/io/airbyte/scheduler/persistence/DefaultJobPersistence.java
@@ -709,7 +709,7 @@ public class DefaultJobPersistence implements JobPersistence {
       final String JOB_HISTORY_PURGE_SQL = MoreResources.readResource("job_history_purge.sql");
       // interval '?' days cannot use a ? bind, so we're using %d instead.
       final String sql = String.format(JOB_HISTORY_PURGE_SQL, (JOB_HISTORY_MINIMUM_AGE_IN_DAYS - 1));
-      final Integer rows = jobDatabase.query(ctx -> ctx.execute(sql,
+      jobDatabase.query(ctx -> ctx.execute(sql,
           asOfDate.format(DateTimeFormatter.ofPattern("YYYY-MM-dd")),
           JOB_HISTORY_EXCESSIVE_NUMBER_OF_JOBS,
           JOB_HISTORY_MINIMUM_RECENCY));

--- a/airbyte-scheduler/scheduler-persistence/src/main/java/io/airbyte/scheduler/persistence/JobNotifier.java
+++ b/airbyte-scheduler/scheduler-persistence/src/main/java/io/airbyte/scheduler/persistence/JobNotifier.java
@@ -181,15 +181,4 @@ public class JobNotifier {
   protected NotificationClient getNotificationClient(final Notification notification) {
     return NotificationClient.createNotificationClient(notification);
   }
-
-  private static String formatDurationPart(final long durationPart, final String timeUnit) {
-    if (durationPart == 1) {
-      return String.format(" %s %s", durationPart, timeUnit);
-    } else if (durationPart > 1) {
-      // Use plural timeUnit
-      return String.format(" %s %ss", durationPart, timeUnit);
-    }
-    return "";
-  }
-
 }

--- a/airbyte-scheduler/scheduler-persistence/src/main/java/io/airbyte/scheduler/persistence/JobNotifier.java
+++ b/airbyte-scheduler/scheduler-persistence/src/main/java/io/airbyte/scheduler/persistence/JobNotifier.java
@@ -181,4 +181,5 @@ public class JobNotifier {
   protected NotificationClient getNotificationClient(final Notification notification) {
     return NotificationClient.createNotificationClient(notification);
   }
+
 }

--- a/airbyte-scheduler/scheduler-persistence/src/test/java/io/airbyte/scheduler/persistence/job_tracker/JobTrackerTest.java
+++ b/airbyte-scheduler/scheduler-persistence/src/test/java/io/airbyte/scheduler/persistence/job_tracker/JobTrackerTest.java
@@ -241,7 +241,7 @@ class JobTrackerTest {
     when(configRepository.getStandardWorkspace(WORKSPACE_ID, true))
         .thenReturn(new StandardWorkspace().withWorkspaceId(WORKSPACE_ID).withName(WORKSPACE_NAME));
     assertCorrectMessageForEachState((jobState) -> jobTracker.trackDiscover(JOB_ID, UUID1, WORKSPACE_ID, jobState), metadata);
-    assertCorrectMessageForEachState((jobState) -> jobTracker.trackDiscover(JOB_ID, UUID1, null, jobState), metadata, false);
+    assertCorrectMessageForEachState((jobState) -> jobTracker.trackDiscover(JOB_ID, UUID1, null, jobState), metadata);
   }
 
   @Test
@@ -600,10 +600,6 @@ class JobTrackerTest {
     }
   }
 
-  private void assertCorrectMessageForEachState(final Consumer<JobState> jobStateConsumer, final Map<String, Object> expectedMetadata) {
-    assertCorrectMessageForEachState(jobStateConsumer, expectedMetadata, true);
-  }
-
   /**
    * Tests that the tracker emits the correct message for when the job starts, succeeds, and fails.
    *
@@ -612,8 +608,7 @@ class JobTrackerTest {
    * @param expectedMetadata - expected metadata (except job state).
    */
   private void assertCorrectMessageForEachState(final Consumer<JobState> jobStateConsumer,
-                                                final Map<String, Object> expectedMetadata,
-                                                final boolean workspaceSet) {
+                                                final Map<String, Object> expectedMetadata) {
     jobStateConsumer.accept(JobState.STARTED);
     assertCorrectMessageForStartedState(expectedMetadata);
     jobStateConsumer.accept(JobState.SUCCEEDED);

--- a/airbyte-server/src/main/java/io/airbyte/server/ConfigDumpImporter.java
+++ b/airbyte-server/src/main/java/io/airbyte/server/ConfigDumpImporter.java
@@ -62,7 +62,6 @@ public class ConfigDumpImporter {
 
   private static final Logger LOGGER = LoggerFactory.getLogger(ConfigDumpImporter.class);
   private static final String CONFIG_FOLDER_NAME = "airbyte_config";
-  private static final String DB_FOLDER_NAME = "airbyte_db";
   private static final String VERSION_FILE_NAME = "VERSION";
   private static final Path TMP_AIRBYTE_STAGED_RESOURCES = Path.of("/tmp/airbyte_staged_resources");
 

--- a/airbyte-server/src/main/java/io/airbyte/server/handlers/DestinationDefinitionsHandler.java
+++ b/airbyte-server/src/main/java/io/airbyte/server/handlers/DestinationDefinitionsHandler.java
@@ -45,12 +45,8 @@ import java.util.Map.Entry;
 import java.util.UUID;
 import java.util.function.Supplier;
 import java.util.stream.Collectors;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 
 public class DestinationDefinitionsHandler {
-
-  private static final Logger LOGGER = LoggerFactory.getLogger(DestinationDefinitionsHandler.class);
 
   private final ConfigRepository configRepository;
   private final Supplier<UUID> uuidSupplier;

--- a/airbyte-server/src/main/java/io/airbyte/server/handlers/DestinationHandler.java
+++ b/airbyte-server/src/main/java/io/airbyte/server/handlers/DestinationHandler.java
@@ -34,12 +34,8 @@ import java.io.IOException;
 import java.util.List;
 import java.util.UUID;
 import java.util.function.Supplier;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 
 public class DestinationHandler {
-
-  private static final Logger LOGGER = LoggerFactory.getLogger(DestinationHandler.class);
 
   private final ConnectionsHandler connectionsHandler;
   private final Supplier<UUID> uuidGenerator;

--- a/airbyte-server/src/main/java/io/airbyte/server/handlers/SchedulerHandler.java
+++ b/airbyte-server/src/main/java/io/airbyte/server/handlers/SchedulerHandler.java
@@ -69,12 +69,9 @@ import java.io.IOException;
 import java.util.ArrayList;
 import java.util.Optional;
 import java.util.UUID;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 
 public class SchedulerHandler {
 
-  private static final Logger LOGGER = LoggerFactory.getLogger(SchedulerHandler.class);
   private static final HashFunction HASH_FUNCTION = Hashing.md5();
 
   private static final ImmutableSet<ErrorCode> VALUE_CONFLICT_EXCEPTION_ERROR_CODE_SET =

--- a/airbyte-server/src/test/java/io/airbyte/server/converters/ConfigurationUpdateTest.java
+++ b/airbyte-server/src/test/java/io/airbyte/server/converters/ConfigurationUpdateTest.java
@@ -33,7 +33,6 @@ class ConfigurationUpdateTest {
 
   private static final String IMAGE_REPOSITORY = "foo";
   private static final String IMAGE_TAG = "bar";
-  private static final String IMAGE_NAME = IMAGE_REPOSITORY + ":" + IMAGE_TAG;
   private static final UUID UUID1 = UUID.randomUUID();
   private static final UUID UUID2 = UUID.randomUUID();
   private static final JsonNode SPEC = CatalogHelpers.fieldsToJsonSchema(

--- a/airbyte-server/src/test/java/io/airbyte/server/handlers/ConnectionsHandlerTest.java
+++ b/airbyte-server/src/test/java/io/airbyte/server/handlers/ConnectionsHandlerTest.java
@@ -44,7 +44,6 @@ import io.airbyte.config.SourceConnection;
 import io.airbyte.config.StandardDestinationDefinition;
 import io.airbyte.config.StandardSourceDefinition;
 import io.airbyte.config.StandardSync;
-import io.airbyte.config.StandardSyncOperation;
 import io.airbyte.config.persistence.ConfigNotFoundException;
 import io.airbyte.config.persistence.ConfigRepository;
 import io.airbyte.protocol.models.ConfiguredAirbyteCatalog;
@@ -73,10 +72,7 @@ class ConnectionsHandlerTest {
 
   private ConnectionsHandler connectionsHandler;
   private UUID workspaceId;
-  private UUID sourceDefinitionId;
   private UUID sourceId;
-  private UUID deletedSourceId;
-  private UUID destinationDefinitionId;
   private UUID destinationId;
 
   private SourceConnection source;
@@ -85,7 +81,6 @@ class ConnectionsHandlerTest {
   private StandardSync standardSyncDeleted;
   private UUID connectionId;
   private UUID operationId;
-  private StandardSyncOperation standardSyncOperation;
   private WorkspaceHelper workspaceHelper;
   private TrackingClient trackingClient;
   private EventRunner eventRunner;
@@ -95,9 +90,7 @@ class ConnectionsHandlerTest {
   void setUp() throws IOException, JsonValidationException, ConfigNotFoundException {
 
     workspaceId = UUID.randomUUID();
-    sourceDefinitionId = UUID.randomUUID();
     sourceId = UUID.randomUUID();
-    destinationDefinitionId = UUID.randomUUID();
     destinationId = UUID.randomUUID();
     connectionId = UUID.randomUUID();
     operationId = UUID.randomUUID();
@@ -140,10 +133,6 @@ class ConnectionsHandlerTest {
         .withSchedule(ConnectionHelpers.generateBasicSchedule())
         .withResourceRequirements(ConnectionHelpers.TESTING_RESOURCE_REQUIREMENTS);
 
-    standardSyncOperation = new StandardSyncOperation()
-        .withOperationId(operationId)
-        .withWorkspaceId(workspaceId);
-
     configRepository = mock(ConfigRepository.class);
     uuidGenerator = mock(Supplier.class);
     workspaceHelper = mock(WorkspaceHelper.class);
@@ -151,7 +140,6 @@ class ConnectionsHandlerTest {
     eventRunner = mock(EventRunner.class);
 
     when(workspaceHelper.getWorkspaceForSourceIdIgnoreExceptions(sourceId)).thenReturn(workspaceId);
-    when(workspaceHelper.getWorkspaceForSourceIdIgnoreExceptions(deletedSourceId)).thenReturn(workspaceId);
     when(workspaceHelper.getWorkspaceForDestinationIdIgnoreExceptions(destinationId)).thenReturn(workspaceId);
     when(workspaceHelper.getWorkspaceForOperationIdIgnoreExceptions(operationId)).thenReturn(workspaceId);
   }

--- a/airbyte-server/src/test/java/io/airbyte/server/handlers/DestinationDefinitionsHandlerTest.java
+++ b/airbyte-server/src/test/java/io/airbyte/server/handlers/DestinationDefinitionsHandlerTest.java
@@ -411,7 +411,6 @@ class DestinationDefinitionsHandlerTest {
         .getDestinationDefinition(
             new DestinationDefinitionIdRequestBody().destinationDefinitionId(destinationDefinition.getDestinationDefinitionId()));
     final String currentTag = currentDestination.getDockerImageTag();
-    final String dockerRepository = currentDestination.getDockerRepository();
     final String newDockerImageTag = "averydifferenttag";
     assertNotEquals(newDockerImageTag, currentTag);
 

--- a/airbyte-server/src/test/java/io/airbyte/server/handlers/DestinationHandlerTest.java
+++ b/airbyte-server/src/test/java/io/airbyte/server/handlers/DestinationHandlerTest.java
@@ -15,7 +15,6 @@ import com.google.common.collect.Lists;
 import io.airbyte.api.model.generated.DestinationCloneConfiguration;
 import io.airbyte.api.model.generated.DestinationCloneRequestBody;
 import io.airbyte.api.model.generated.DestinationCreate;
-import io.airbyte.api.model.generated.DestinationDefinitionIdRequestBody;
 import io.airbyte.api.model.generated.DestinationDefinitionSpecificationRead;
 import io.airbyte.api.model.generated.DestinationIdRequestBody;
 import io.airbyte.api.model.generated.DestinationRead;
@@ -80,9 +79,6 @@ class DestinationHandlerTest {
         .withDockerImageTag("thelatesttag")
         .withDocumentationUrl("https://wikipedia.org")
         .withSpec(connectorSpecification);
-
-    final DestinationDefinitionIdRequestBody destinationDefinitionIdRequestBody = new DestinationDefinitionIdRequestBody().destinationDefinitionId(
-        standardDestinationDefinition.getDestinationDefinitionId());
 
     destinationDefinitionSpecificationRead = new DestinationDefinitionSpecificationRead()
         .connectionSpecification(connectorSpecification.getConnectionSpecification())

--- a/airbyte-server/src/test/java/io/airbyte/server/handlers/DestinationHandlerTest.java
+++ b/airbyte-server/src/test/java/io/airbyte/server/handlers/DestinationHandlerTest.java
@@ -23,7 +23,6 @@ import io.airbyte.api.model.generated.DestinationReadList;
 import io.airbyte.api.model.generated.DestinationSearch;
 import io.airbyte.api.model.generated.DestinationUpdate;
 import io.airbyte.api.model.generated.WorkspaceIdRequestBody;
-import io.airbyte.commons.docker.DockerUtils;
 import io.airbyte.commons.json.Jsons;
 import io.airbyte.config.DestinationConnection;
 import io.airbyte.config.StandardDestinationDefinition;
@@ -59,7 +58,6 @@ class DestinationHandlerTest {
   private Supplier<UUID> uuidGenerator;
   private JsonSecretsProcessor secretsProcessor;
   private ConnectorSpecification connectorSpecification;
-  private String imageName;
 
   @SuppressWarnings("unchecked")
   @BeforeEach
@@ -82,9 +80,6 @@ class DestinationHandlerTest {
         .withDockerImageTag("thelatesttag")
         .withDocumentationUrl("https://wikipedia.org")
         .withSpec(connectorSpecification);
-
-    imageName =
-        DockerUtils.getTaggedImageName(standardDestinationDefinition.getDockerRepository(), standardDestinationDefinition.getDockerImageTag());
 
     final DestinationDefinitionIdRequestBody destinationDefinitionIdRequestBody = new DestinationDefinitionIdRequestBody().destinationDefinitionId(
         standardDestinationDefinition.getDestinationDefinitionId());

--- a/airbyte-server/src/test/java/io/airbyte/server/handlers/SchedulerHandlerTest.java
+++ b/airbyte-server/src/test/java/io/airbyte/server/handlers/SchedulerHandlerTest.java
@@ -52,7 +52,6 @@ import io.airbyte.config.helpers.LogConfigs;
 import io.airbyte.config.persistence.ConfigNotFoundException;
 import io.airbyte.config.persistence.ConfigRepository;
 import io.airbyte.config.persistence.SecretsRepositoryWriter;
-import io.airbyte.config.persistence.StatePersistence;
 import io.airbyte.protocol.models.AirbyteCatalog;
 import io.airbyte.protocol.models.CatalogHelpers;
 import io.airbyte.protocol.models.ConnectorSpecification;
@@ -95,8 +94,6 @@ class SchedulerHandlerTest {
   private static final String DESTINATION_DOCKER_TAG = "tag";
   private static final String DESTINATION_DOCKER_IMAGE = DockerUtils.getTaggedImageName(DESTINATION_DOCKER_REPO, DESTINATION_DOCKER_TAG);
 
-  private static final String OPERATION_NAME = "transfo";
-
   private static final SourceConnection SOURCE = new SourceConnection()
       .withName("my postgres db")
       .withWorkspaceId(UUID.randomUUID())
@@ -131,7 +128,6 @@ class SchedulerHandlerTest {
   private JobPersistence jobPersistence;
   private EventRunner eventRunner;
   private JobConverter jobConverter;
-  private StatePersistence statePersistence;
 
   @BeforeEach
   void setup() {
@@ -147,7 +143,6 @@ class SchedulerHandlerTest {
     configRepository = mock(ConfigRepository.class);
     secretsRepositoryWriter = mock(SecretsRepositoryWriter.class);
     jobPersistence = mock(JobPersistence.class);
-    statePersistence = mock(StatePersistence.class);
     eventRunner = mock(EventRunner.class);
 
     jobConverter = spy(new JobConverter(WorkerEnvironment.DOCKER, LogConfigs.EMPTY));

--- a/airbyte-server/src/test/java/io/airbyte/server/handlers/SchedulerHandlerTest.java
+++ b/airbyte-server/src/test/java/io/airbyte/server/handlers/SchedulerHandlerTest.java
@@ -239,7 +239,6 @@ class SchedulerHandlerTest {
     final SourceDefinitionIdWithWorkspaceId sourceDefinitionIdWithWorkspaceId =
         new SourceDefinitionIdWithWorkspaceId().sourceDefinitionId(UUID.randomUUID()).workspaceId(UUID.randomUUID());
 
-    final SynchronousResponse<ConnectorSpecification> specResponse = (SynchronousResponse<ConnectorSpecification>) jobResponse;
     final StandardSourceDefinition sourceDefinition = new StandardSourceDefinition()
         .withName("name")
         .withDockerRepository(SOURCE_DOCKER_REPO)

--- a/airbyte-server/src/test/java/io/airbyte/server/handlers/SourceDefinitionsHandlerTest.java
+++ b/airbyte-server/src/test/java/io/airbyte/server/handlers/SourceDefinitionsHandlerTest.java
@@ -405,7 +405,6 @@ class SourceDefinitionsHandlerTest {
     final String newDockerImageTag = "averydifferenttag";
     final SourceDefinitionRead sourceDefinition = sourceDefinitionsHandler
         .getSourceDefinition(new SourceDefinitionIdRequestBody().sourceDefinitionId(this.sourceDefinition.getSourceDefinitionId()));
-    final String dockerRepository = sourceDefinition.getDockerRepository();
     final String currentTag = sourceDefinition.getDockerImageTag();
     assertNotEquals(newDockerImageTag, currentTag);
 

--- a/airbyte-server/src/test/java/io/airbyte/server/handlers/SourceHandlerTest.java
+++ b/airbyte-server/src/test/java/io/airbyte/server/handlers/SourceHandlerTest.java
@@ -12,7 +12,6 @@ import static org.mockito.Mockito.when;
 import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.node.ObjectNode;
 import com.google.common.collect.Lists;
-import io.airbyte.api.model.generated.ConnectionIdRequestBody;
 import io.airbyte.api.model.generated.ConnectionRead;
 import io.airbyte.api.model.generated.ConnectionReadList;
 import io.airbyte.api.model.generated.SourceCloneConfiguration;
@@ -344,8 +343,6 @@ class SourceHandlerTest {
 
     verify(secretsRepositoryWriter).writeSourceConnection(expectedSourceConnection, connectorSpecification);
     verify(connectionsHandler).listConnectionsForWorkspace(workspaceIdRequestBody);
-    final ConnectionIdRequestBody connectionIdRequestBody = new ConnectionIdRequestBody()
-        .connectionId(connectionRead.getConnectionId());
     verify(connectionsHandler).deleteConnection(connectionRead.getConnectionId());
   }
 

--- a/airbyte-server/src/test/java/io/airbyte/server/handlers/SourceHandlerTest.java
+++ b/airbyte-server/src/test/java/io/airbyte/server/handlers/SourceHandlerTest.java
@@ -26,7 +26,6 @@ import io.airbyte.api.model.generated.SourceReadList;
 import io.airbyte.api.model.generated.SourceSearch;
 import io.airbyte.api.model.generated.SourceUpdate;
 import io.airbyte.api.model.generated.WorkspaceIdRequestBody;
-import io.airbyte.commons.docker.DockerUtils;
 import io.airbyte.commons.json.Jsons;
 import io.airbyte.config.SourceConnection;
 import io.airbyte.config.StandardSourceDefinition;
@@ -65,7 +64,6 @@ class SourceHandlerTest {
   private Supplier<UUID> uuidGenerator;
   private JsonSecretsProcessor secretsProcessor;
   private ConnectorSpecification connectorSpecification;
-  private String imageName;
 
   @SuppressWarnings("unchecked")
   @BeforeEach
@@ -88,8 +86,6 @@ class SourceHandlerTest {
         .withDockerImageTag("thelatesttag")
         .withDocumentationUrl("https://wikipedia.org")
         .withSpec(connectorSpecification);
-
-    imageName = DockerUtils.getTaggedImageName(standardSourceDefinition.getDockerRepository(), standardSourceDefinition.getDockerImageTag());
 
     sourceDefinitionSpecificationRead = new SourceDefinitionSpecificationRead()
         .sourceDefinitionId(standardSourceDefinition.getSourceDefinitionId())

--- a/airbyte-server/src/test/java/io/airbyte/server/helpers/ConnectionHelpers.java
+++ b/airbyte-server/src/test/java/io/airbyte/server/helpers/ConnectionHelpers.java
@@ -228,10 +228,6 @@ public class ConnectionHelpers {
         .selected(true);
   }
 
-  private static AirbyteStream generateBasicApiStream() {
-    return generateBasicApiStream(null);
-  }
-
   private static AirbyteStream generateBasicApiStream(final String nameSuffix) {
     return new AirbyteStream()
         .name(nameSuffix == null ? STREAM_NAME : STREAM_NAME_BASE + nameSuffix)

--- a/airbyte-test-utils/src/main/java/io/airbyte/test/airbyte_test_container/AirbyteTestContainer.java
+++ b/airbyte-test-utils/src/main/java/io/airbyte/test/airbyte_test_container/AirbyteTestContainer.java
@@ -4,7 +4,6 @@
 
 package io.airbyte.test.airbyte_test_container;
 
-import com.google.api.client.util.Preconditions;
 import com.google.common.collect.Maps;
 import io.airbyte.api.client.AirbyteApiClient;
 import io.airbyte.api.client.generated.HealthApi;
@@ -12,7 +11,6 @@ import io.airbyte.api.client.invoker.generated.ApiClient;
 import io.airbyte.api.client.invoker.generated.ApiException;
 import io.airbyte.commons.concurrency.WaitingUtils;
 import java.io.File;
-import java.io.FileInputStream;
 import java.io.FileWriter;
 import java.io.IOException;
 import java.lang.reflect.Field;
@@ -81,15 +79,6 @@ public class AirbyteTestContainer {
     serviceLogConsumer(dockerComposeContainer, "server");
 
     dockerComposeContainer.start();
-  }
-
-  private static Map<String, String> prepareDockerComposeEnvVariables(final File envFile) throws IOException {
-    LOGGER.info("Searching for environment in {}", envFile);
-    Preconditions.checkArgument(envFile.exists(), "could not find docker compose environment");
-
-    final Properties prop = new Properties();
-    prop.load(new FileInputStream(envFile));
-    return Maps.fromProperties(prop);
   }
 
   /**

--- a/airbyte-tests/src/acceptanceTests/java/io/airbyte/test/acceptance/AdvancedAcceptanceTests.java
+++ b/airbyte-tests/src/acceptanceTests/java/io/airbyte/test/acceptance/AdvancedAcceptanceTests.java
@@ -42,7 +42,6 @@ import io.airbyte.api.client.model.generated.SyncMode;
 import io.airbyte.commons.json.Jsons;
 import io.airbyte.commons.lang.MoreBooleans;
 import io.airbyte.test.utils.AirbyteAcceptanceTestHarness;
-import io.fabric8.kubernetes.client.KubernetesClient;
 import java.io.IOException;
 import java.net.URISyntaxException;
 import java.nio.charset.Charset;
@@ -88,7 +87,6 @@ public class AdvancedAcceptanceTests {
   private static AirbyteAcceptanceTestHarness testHarness;
   private static AirbyteApiClient apiClient;
   private static UUID workspaceId;
-  private static KubernetesClient kubernetesClient;
 
   @SuppressWarnings("UnstableApiUsage")
   @BeforeAll
@@ -113,7 +111,6 @@ public class AdvancedAcceptanceTests {
     LOGGER.info("pg destination definition: {}", destinationDef.getDockerImageTag());
 
     testHarness = new AirbyteAcceptanceTestHarness(apiClient, workspaceId);
-    kubernetesClient = testHarness.getKubernetesClient();
   }
 
   @AfterAll

--- a/airbyte-tests/src/acceptanceTests/java/io/airbyte/test/acceptance/BasicAcceptanceTests.java
+++ b/airbyte-tests/src/acceptanceTests/java/io/airbyte/test/acceptance/BasicAcceptanceTests.java
@@ -965,7 +965,7 @@ public class BasicAcceptanceTests {
         .status(connection.getStatus())
         .resourceRequirements(connection.getResourceRequirements())
         .withRefreshedCatalog(true);
-    final WebBackendConnectionRead connectionUpdateRead = webBackendApi.webBackendUpdateConnection(update);
+    webBackendApi.webBackendUpdateConnection(update);
 
     LOGGER.info("Inspecting Destination DB after the update request, tables should be empty");
     destDb.query(ctx -> {
@@ -1020,7 +1020,7 @@ public class BasicAcceptanceTests {
     final UUID operationId = testHarness.createOperation().getOperationId();
     final AirbyteCatalog catalog = testHarness.discoverSourceSchema(sourceId);
 
-    for (AirbyteStreamAndConfiguration streamAndConfig : catalog.getStreams()) {
+    for (final AirbyteStreamAndConfiguration streamAndConfig : catalog.getStreams()) {
       final AirbyteStream stream = streamAndConfig.getStream();
       assertEquals(Lists.newArrayList(SyncMode.FULL_REFRESH, SyncMode.INCREMENTAL), stream.getSupportedSyncModes());
       // instead of assertFalse to avoid NPE from unboxed.

--- a/airbyte-workers/src/main/java/io/airbyte/workers/RecordSchemaValidator.java
+++ b/airbyte-workers/src/main/java/io/airbyte/workers/RecordSchemaValidator.java
@@ -14,8 +14,6 @@ import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 
 /**
  * Validates that AirbyteRecordMessage data conforms to the JSON schema defined by the source's
@@ -25,7 +23,6 @@ import org.slf4j.LoggerFactory;
 public class RecordSchemaValidator {
 
   private final Map<String, JsonNode> streams;
-  private static final Logger LOGGER = LoggerFactory.getLogger(RecordSchemaValidator.class);
 
   public RecordSchemaValidator(final Map<String, JsonNode> streamNamesToSchemas) {
     // streams is Map of a stream source namespace + name mapped to the stream schema

--- a/airbyte-workers/src/main/java/io/airbyte/workers/helper/EntrypointEnvChecker.java
+++ b/airbyte-workers/src/main/java/io/airbyte/workers/helper/EntrypointEnvChecker.java
@@ -51,7 +51,7 @@ public class EntrypointEnvChecker {
 
     String outputLine = null;
 
-    String line = null;
+    String line;
     while (((line = stdout.readLine()) != null) && outputLine == null) {
       if (line.contains("AIRBYTE_ENTRYPOINT")) {
         outputLine = line;

--- a/airbyte-workers/src/main/java/io/airbyte/workers/run/TemporalWorkerRunFactory.java
+++ b/airbyte-workers/src/main/java/io/airbyte/workers/run/TemporalWorkerRunFactory.java
@@ -96,4 +96,5 @@ public class TemporalWorkerRunFactory {
     }
     return new OutputAndStatus<>(status, new JobOutput().withSync(response.getOutput().orElse(null)));
   }
+
 }

--- a/airbyte-workers/src/main/java/io/airbyte/workers/run/TemporalWorkerRunFactory.java
+++ b/airbyte-workers/src/main/java/io/airbyte/workers/run/TemporalWorkerRunFactory.java
@@ -96,12 +96,4 @@ public class TemporalWorkerRunFactory {
     }
     return new OutputAndStatus<>(status, new JobOutput().withSync(response.getOutput().orElse(null)));
   }
-
-  private OutputAndStatus<JobOutput> toOutputAndStatusConnector() {
-    // Since we are async we technically can't fail
-    final JobStatus status = JobStatus.SUCCEEDED;
-
-    return new OutputAndStatus<>(status, new JobOutput().withSync(null));
-  }
-
 }

--- a/airbyte-workers/src/main/java/io/airbyte/workers/temporal/TemporalAttemptExecution.java
+++ b/airbyte-workers/src/main/java/io/airbyte/workers/temporal/TemporalAttemptExecution.java
@@ -39,8 +39,6 @@ public class TemporalAttemptExecution<INPUT, OUTPUT> implements Supplier<OUTPUT>
   private static final Logger LOGGER = LoggerFactory.getLogger(TemporalAttemptExecution.class);
 
   private final JobRunConfig jobRunConfig;
-  private final WorkerEnvironment workerEnvironment;
-  private final LogConfigs logConfigs;
   private final Path jobRoot;
   private final CheckedSupplier<Worker<INPUT, OUTPUT>, Exception> workerSupplier;
   private final Supplier<INPUT> inputSupplier;
@@ -85,8 +83,6 @@ public class TemporalAttemptExecution<INPUT, OUTPUT> implements Supplier<OUTPUT>
                            final Supplier<String> workflowIdProvider,
                            final String airbyteVersion) {
     this.jobRunConfig = jobRunConfig;
-    this.workerEnvironment = workerEnvironment;
-    this.logConfigs = logConfigs;
 
     this.jobRoot = WorkerUtils.getJobRoot(workspaceRoot, jobRunConfig.getJobId(), jobRunConfig.getAttemptId());
     this.workerSupplier = workerSupplier;

--- a/airbyte-workers/src/main/java/io/airbyte/workers/temporal/TemporalAttemptExecution.java
+++ b/airbyte-workers/src/main/java/io/airbyte/workers/temporal/TemporalAttemptExecution.java
@@ -34,6 +34,7 @@ import org.slf4j.MDC;
  * outputs are passed to the selected worker. It also makes sures that the outputs of the worker are
  * persisted to the db.
  */
+@SuppressWarnings("PMD.UnusedFormalParameter")
 public class TemporalAttemptExecution<INPUT, OUTPUT> implements Supplier<OUTPUT> {
 
   private static final Logger LOGGER = LoggerFactory.getLogger(TemporalAttemptExecution.class);

--- a/airbyte-workers/src/main/java/io/airbyte/workers/temporal/TemporalClient.java
+++ b/airbyte-workers/src/main/java/io/airbyte/workers/temporal/TemporalClient.java
@@ -450,10 +450,6 @@ public class TemporalClient {
     return client.newWorkflowStub(workflowClass, TemporalUtils.getWorkflowOptions(jobType));
   }
 
-  private <T> T getWorkflowOptionsWithWorkflowId(final Class<T> workflowClass, final TemporalJobType jobType, final String name) {
-    return client.newWorkflowStub(workflowClass, TemporalUtils.getWorkflowOptionsWithWorkflowId(jobType, name));
-  }
-
   @VisibleForTesting
   <T> TemporalResponse<T> execute(final JobRunConfig jobRunConfig, final Supplier<T> executor) {
     final Path jobRoot = WorkerUtils.getJobRoot(workspaceRoot, jobRunConfig);

--- a/airbyte-workers/src/test-integration/java/io/airbyte/workers/process/KubePodProcessIntegrationTest.java
+++ b/airbyte-workers/src/test-integration/java/io/airbyte/workers/process/KubePodProcessIntegrationTest.java
@@ -84,7 +84,6 @@ public class KubePodProcessIntegrationTest {
   private static final ResourceRequirements DEFAULT_RESOURCE_REQUIREMENTS = new WorkerConfigs(new EnvConfigs()).getResourceRequirements();
   private static final String ENV_KEY = "ENV_VAR_1";
   private static final String ENV_VALUE = "ENV_VALUE_1";
-  private static final Map<String, String> ENV_MAP = ImmutableMap.of(ENV_KEY, ENV_VALUE);
 
   private WorkerHeartbeatServer server;
 

--- a/airbyte-workers/src/test-integration/java/io/airbyte/workers/process/KubePodProcessIntegrationTest.java
+++ b/airbyte-workers/src/test-integration/java/io/airbyte/workers/process/KubePodProcessIntegrationTest.java
@@ -82,8 +82,6 @@ public class KubePodProcessIntegrationTest {
   private static KubernetesClient fabricClient;
   private static KubeProcessFactory processFactory;
   private static final ResourceRequirements DEFAULT_RESOURCE_REQUIREMENTS = new WorkerConfigs(new EnvConfigs()).getResourceRequirements();
-  private static final String ENV_KEY = "ENV_VAR_1";
-  private static final String ENV_VALUE = "ENV_VALUE_1";
 
   private WorkerHeartbeatServer server;
 

--- a/airbyte-workers/src/test/java/io/airbyte/workers/process/AirbyteIntegrationLauncherTest.java
+++ b/airbyte-workers/src/test/java/io/airbyte/workers/process/AirbyteIntegrationLauncherTest.java
@@ -16,7 +16,6 @@ import static io.airbyte.workers.process.AirbyteIntegrationLauncher.WRITE_STEP;
 import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.Lists;
 import io.airbyte.commons.features.EnvVariableFeatureFlags;
-import io.airbyte.commons.features.FeatureFlags;
 import io.airbyte.config.EnvConfigs;
 import io.airbyte.config.WorkerEnvConstants;
 import io.airbyte.workers.WorkerConfigs;
@@ -57,8 +56,6 @@ class AirbyteIntegrationLauncherTest {
   @Mock
   private ProcessFactory processFactory;
   private AirbyteIntegrationLauncher launcher;
-  @Mock
-  private FeatureFlags featureFlags;
 
   @BeforeEach
   void setUp() {

--- a/airbyte-workers/src/test/java/io/airbyte/workers/process/KubePodProcessTest.java
+++ b/airbyte-workers/src/test/java/io/airbyte/workers/process/KubePodProcessTest.java
@@ -28,8 +28,6 @@ public class KubePodProcessTest {
 
   private static final KubernetesClient K8s = new DefaultKubernetesClient();
 
-  private static final String ENTRYPOINT = "sh";
-
   private static final String TEST_IMAGE_WITH_VAR_PATH = "Dockerfile.with_var";
   private static final String TEST_IMAGE_WITH_VAR_NAME = "worker-test:with-var";
 

--- a/airbyte-workers/src/test/java/io/airbyte/workers/temporal/HeartbeatWorkflow.java
+++ b/airbyte-workers/src/test/java/io/airbyte/workers/temporal/HeartbeatWorkflow.java
@@ -12,8 +12,6 @@ import io.temporal.workflow.Workflow;
 import io.temporal.workflow.WorkflowInterface;
 import io.temporal.workflow.WorkflowMethod;
 import java.time.Duration;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 
 @WorkflowInterface
 public interface HeartbeatWorkflow {
@@ -47,8 +45,6 @@ public interface HeartbeatWorkflow {
   }
 
   class HeartbeatActivityImpl implements HeartbeatActivity {
-
-    private static final Logger LOGGER = LoggerFactory.getLogger(HeartbeatActivityImpl.class);
 
     private final Runnable runnable;
 

--- a/airbyte-workers/src/test/java/io/airbyte/workers/temporal/SyncWorkflowTest.java
+++ b/airbyte-workers/src/test/java/io/airbyte/workers/temporal/SyncWorkflowTest.java
@@ -42,7 +42,6 @@ import io.temporal.client.WorkflowFailedException;
 import io.temporal.client.WorkflowOptions;
 import io.temporal.testing.TestWorkflowEnvironment;
 import io.temporal.worker.Worker;
-import java.util.UUID;
 import org.apache.commons.lang3.tuple.ImmutablePair;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
@@ -138,7 +137,7 @@ class SyncWorkflowTest {
 
     final StandardSyncOutput actualOutput = execute();
 
-    verifyReplication(replicationActivity, syncInput, sync.getConnectionId());
+    verifyReplication(replicationActivity, syncInput);
     verifyPersistState(persistStateActivity, sync, replicationSuccessOutput, syncInput.getCatalog());
     verifyNormalize(normalizationActivity, normalizationInput);
     verifyDbtTransform(dbtTransformationActivity, syncInput.getResourceRequirements(), operatorDbtInput);
@@ -155,7 +154,7 @@ class SyncWorkflowTest {
 
     assertThrows(WorkflowFailedException.class, this::execute);
 
-    verifyReplication(replicationActivity, syncInput, sync.getConnectionId());
+    verifyReplication(replicationActivity, syncInput);
     verifyNoInteractions(persistStateActivity);
     verifyNoInteractions(normalizationActivity);
     verifyNoInteractions(dbtTransformationActivity);
@@ -176,7 +175,7 @@ class SyncWorkflowTest {
 
     assertThrows(WorkflowFailedException.class, this::execute);
 
-    verifyReplication(replicationActivity, syncInput, sync.getConnectionId());
+    verifyReplication(replicationActivity, syncInput);
     verifyPersistState(persistStateActivity, sync, replicationSuccessOutput, syncInput.getCatalog());
     verifyNormalize(normalizationActivity, normalizationInput);
     verifyNoInteractions(dbtTransformationActivity);
@@ -195,7 +194,7 @@ class SyncWorkflowTest {
 
     assertThrows(WorkflowFailedException.class, this::execute);
 
-    verifyReplication(replicationActivity, syncInput, sync.getConnectionId());
+    verifyReplication(replicationActivity, syncInput);
     verifyNoInteractions(persistStateActivity);
     verifyNoInteractions(normalizationActivity);
     verifyNoInteractions(dbtTransformationActivity);
@@ -219,7 +218,7 @@ class SyncWorkflowTest {
 
     assertThrows(WorkflowFailedException.class, this::execute);
 
-    verifyReplication(replicationActivity, syncInput, sync.getConnectionId());
+    verifyReplication(replicationActivity, syncInput);
     verifyPersistState(persistStateActivity, sync, replicationSuccessOutput, syncInput.getCatalog());
     verifyNormalize(normalizationActivity, normalizationInput);
     verifyNoInteractions(dbtTransformationActivity);
@@ -242,7 +241,7 @@ class SyncWorkflowTest {
     testEnv.getWorkflowService().blockingStub().requestCancelWorkflowExecution(cancelRequest);
   }
 
-  private static void verifyReplication(final ReplicationActivity replicationActivity, final StandardSyncInput syncInput, final UUID connectionId) {
+  private static void verifyReplication(final ReplicationActivity replicationActivity, final StandardSyncInput syncInput) {
     verify(replicationActivity).replicate(
         JOB_RUN_CONFIG,
         SOURCE_LAUNCHER_CONFIG,

--- a/airbyte-workers/src/test/java/io/airbyte/workers/temporal/scheduling/testsyncworkflow/SyncWorkflowFailingOutputWorkflow.java
+++ b/airbyte-workers/src/test/java/io/airbyte/workers/temporal/scheduling/testsyncworkflow/SyncWorkflowFailingOutputWorkflow.java
@@ -6,12 +6,9 @@ package io.airbyte.workers.temporal.scheduling.testsyncworkflow;
 
 import io.airbyte.config.StandardSyncInput;
 import io.airbyte.config.StandardSyncOutput;
-import io.airbyte.config.StandardSyncSummary;
-import io.airbyte.config.StandardSyncSummary.ReplicationStatus;
 import io.airbyte.scheduler.models.IntegrationLauncherConfig;
 import io.airbyte.scheduler.models.JobRunConfig;
 import io.airbyte.workers.temporal.sync.SyncWorkflow;
-import java.util.ArrayList;
 import java.util.UUID;
 
 public class SyncWorkflowFailingOutputWorkflow implements SyncWorkflow {
@@ -26,14 +23,6 @@ public class SyncWorkflowFailingOutputWorkflow implements SyncWorkflow {
                                 final IntegrationLauncherConfig destinationLauncherConfig,
                                 final StandardSyncInput syncInput,
                                 final UUID connectionId) {
-    final StandardSyncSummary standardSyncSummary = new StandardSyncSummary()
-        .withStatus(ReplicationStatus.FAILED)
-        .withRecordsSynced(0L);
-
-    final StandardSyncOutput standardSyncOutput = new StandardSyncOutput()
-        .withStandardSyncSummary(standardSyncSummary)
-        .withFailures(new ArrayList<>());
-
     return null;
   }
 

--- a/tools/gradle/pmd/rules.xml
+++ b/tools/gradle/pmd/rules.xml
@@ -34,7 +34,6 @@
         <exclude name="PreserveStackTrace"/>
         <exclude name="SwitchStmtsShouldHaveDefault"/>
         <exclude name="SystemPrintln"/>
-        <exclude name="UnusedFormalParameter"/>
         <exclude name="UnusedLocalVariable"/>
         <exclude name="UseCollectionIsEmpty"/>
         <exclude name="UseVarargs"/>

--- a/tools/gradle/pmd/rules.xml
+++ b/tools/gradle/pmd/rules.xml
@@ -37,7 +37,6 @@
         <exclude name="UnusedAssignment"/>
         <exclude name="UnusedFormalParameter"/>
         <exclude name="UnusedLocalVariable"/>
-        <exclude name="UnusedPrivateMethod"/>
         <exclude name="UseCollectionIsEmpty"/>
         <exclude name="UseVarargs"/>
     </rule>

--- a/tools/gradle/pmd/rules.xml
+++ b/tools/gradle/pmd/rules.xml
@@ -34,7 +34,6 @@
         <exclude name="PreserveStackTrace"/>
         <exclude name="SwitchStmtsShouldHaveDefault"/>
         <exclude name="SystemPrintln"/>
-        <exclude name="UnusedLocalVariable"/>
         <exclude name="UseCollectionIsEmpty"/>
         <exclude name="UseVarargs"/>
     </rule>

--- a/tools/gradle/pmd/rules.xml
+++ b/tools/gradle/pmd/rules.xml
@@ -37,7 +37,6 @@
         <exclude name="UnusedAssignment"/>
         <exclude name="UnusedFormalParameter"/>
         <exclude name="UnusedLocalVariable"/>
-        <exclude name="UnusedPrivateField"/>
         <exclude name="UnusedPrivateMethod"/>
         <exclude name="UseCollectionIsEmpty"/>
         <exclude name="UseVarargs"/>

--- a/tools/gradle/pmd/rules.xml
+++ b/tools/gradle/pmd/rules.xml
@@ -34,7 +34,6 @@
         <exclude name="PreserveStackTrace"/>
         <exclude name="SwitchStmtsShouldHaveDefault"/>
         <exclude name="SystemPrintln"/>
-        <exclude name="UnusedAssignment"/>
         <exclude name="UnusedFormalParameter"/>
         <exclude name="UnusedLocalVariable"/>
         <exclude name="UseCollectionIsEmpty"/>


### PR DESCRIPTION
This PR applies the following PMD rules and fixes existing violations:
- UnusedPrivateField
- UnusedPrivateMethod
- UnusedAssignment
- UnusedFormalParameter
- UnusedLocalVariable

Where you see variables & methods removed, it is because they are not used. There is a little bit of a gotcha in this for cases where there is an unused variable, but the assignment of the variable itself has side effects (like a database delete/create). In these cases, just the variable assignment is removed.