### PR TITLE
Java integration tests also depend on `spotbugsMain`

### DIFF
--- a/buildSrc/src/main/groovy/airbyte-integration-test-java.gradle
+++ b/buildSrc/src/main/groovy/airbyte-integration-test-java.gradle
@@ -56,5 +56,6 @@ class AirbyteIntegrationTestJavaPlugin implements Plugin<Project> {
         }
 
         project.integrationTest.dependsOn(project.integrationTestJava)
+        project.integrationTest.dependsOn(project.spotbugsMain)
     }
 }


### PR DESCRIPTION
Closes https://github.com/airbytehq/airbyte/issues/14729

This PR makes spotBugs a dependency of our java integration tests.  Per https://github.com/airbytehq/airbyte/issues/14729, right now our `/publish` command checks spotBugs but our `/test` command does not.  This means that we are not alerted to these types of problems until we try to publish... and then we are delayed in publishing.

This PR will have the immediate effect of the MongoDB Destination failing nightly integration tests until fixed. 