### PR TITLE
Fix catalog conversion issue in new update endpoint

### DIFF
--- a/airbyte-server/src/main/java/io/airbyte/server/handlers/WebBackendConnectionsHandler.java
+++ b/airbyte-server/src/main/java/io/airbyte/server/handlers/WebBackendConnectionsHandler.java
@@ -52,7 +52,6 @@ import io.airbyte.commons.json.Jsons;
 import io.airbyte.commons.lang.MoreBooleans;
 import io.airbyte.config.persistence.ConfigNotFoundException;
 import io.airbyte.config.persistence.ConfigRepository;
-import io.airbyte.protocol.models.CatalogHelpers;
 import io.airbyte.protocol.models.ConfiguredAirbyteCatalog;
 import io.airbyte.scheduler.client.EventRunner;
 import io.airbyte.server.converters.ProtocolConverters;
@@ -393,8 +392,7 @@ public class WebBackendConnectionsHandler {
 
     final Boolean skipReset = webBackendConnectionUpdate.getSkipReset() != null ? webBackendConnectionUpdate.getSkipReset() : false;
     if (!skipReset) {
-      final io.airbyte.protocol.models.AirbyteCatalog existingCatalog = CatalogHelpers.configuredCatalogToCatalog(existingConfiguredCatalog);
-      final AirbyteCatalog apiExistingCatalog = CatalogConverter.toApi(existingCatalog);
+      final AirbyteCatalog apiExistingCatalog = CatalogConverter.toApi(existingConfiguredCatalog);
       final AirbyteCatalog newAirbyteCatalog = webBackendConnectionUpdate.getSyncCatalog();
       final CatalogDiff catalogDiff = connectionsHandler.getDiff(apiExistingCatalog, newAirbyteCatalog);
       final List<StreamDescriptor> apiStreamsToReset = getStreamsToReset(catalogDiff);

--- a/airbyte-server/src/test/java/io/airbyte/server/handlers/WebBackendConnectionsHandlerTest.java
+++ b/airbyte-server/src/test/java/io/airbyte/server/handlers/WebBackendConnectionsHandlerTest.java
@@ -823,7 +823,7 @@ class WebBackendConnectionsHandlerTest {
   }
 
   @Test
-  void testUpdateConnectionWithUpdatedSchemaPerStreamNoStreamsToReset() throws JsonValidationException, ConfigNotFoundException, IOException {
+  void testUpdateConnectionNoStreamsToReset() throws JsonValidationException, ConfigNotFoundException, IOException {
     final WebBackendConnectionUpdate updateBody = new WebBackendConnectionUpdate()
         .namespaceDefinition(expected.getNamespaceDefinition())
         .namespaceFormat(expected.getNamespaceFormat())
@@ -831,7 +831,7 @@ class WebBackendConnectionsHandlerTest {
         .connectionId(expected.getConnectionId())
         .schedule(expected.getSchedule())
         .status(expected.getStatus())
-        .syncCatalog(expectedWithNewSchema.getSyncCatalog());
+        .syncCatalog(expected.getSyncCatalog());
 
     // state is per-stream
     final ConnectionIdRequestBody connectionIdRequestBody = new ConnectionIdRequestBody().connectionId(expected.getConnectionId());
@@ -864,6 +864,8 @@ class WebBackendConnectionsHandlerTest {
     assertEquals(expectedWithNewSchema.getSyncCatalog(), result.getSyncCatalog());
 
     final ConnectionIdRequestBody connectionId = new ConnectionIdRequestBody().connectionId(result.getConnectionId());
+    verify(connectionsHandler).getDiff(expected.getSyncCatalog(), expected.getSyncCatalog());
+    verify(connectionsHandler).getConfigurationDiff(expected.getSyncCatalog(), expected.getSyncCatalog());
     verify(schedulerHandler, times(0)).resetConnection(connectionId);
     verify(schedulerHandler, times(0)).syncConnection(connectionId);
     verify(connectionsHandler, times(1)).updateConnection(any());


### PR DESCRIPTION
## What
I discovered a bug in the new update endpoint that was causing one of my CDC acceptance tests to fail. 

The issue is when the new update endpoint tries to convert the existing `ConfiguredAirbyteCatalog` that was stored in the db to an api `AirbyteCatalog` to then compare with the catalog provided in the update input.

This code first [converts the configured catalog to a "protocol" AirbyteCatalog](https://github.com/airbytehq/airbyte/blob/5edf3fed7189fe13531468fad64998787e50ef49/airbyte-server/src/main/java/io/airbyte/server/handlers/WebBackendConnectionsHandler.java#L396), and then converts that to the "api" AirbyteCatalog [on the next line](https://github.com/airbytehq/airbyte/blob/5edf3fed7189fe13531468fad64998787e50ef49/airbyte-server/src/main/java/io/airbyte/server/handlers/WebBackendConnectionsHandler.java#L397).

The problem is that the `CatalogHelpers.configuredCatalogToCatalog()` method loses the stream configurations in the conversion, as it just grabs the "stream" half of the ConfiguredAirbyteStream object for each stream: https://github.com/airbytehq/airbyte/blob/5edf3fed7189fe13531468fad64998787e50ef49/airbyte-protocol/protocol-models/src/main/java/io/airbyte/protocol/models/CatalogHelpers.java#L82

Then, the `CatalogConverter.toApi()` method just [fills in a default configuration](https://github.com/airbytehq/airbyte/blob/5edf3fed7189fe13531468fad64998787e50ef49/airbyte-server/src/main/java/io/airbyte/server/handlers/helpers/CatalogConverter.java#L49) for each stream, and that is then used in the `getConfigurationDiff` comparison. This is bad because it is always comparing the update endpoint input configuration with some default configuration of each stream, instead of comparing the actual configuration in the database. 

## How
This PR fixes the issue by just using the proper `toApi()` endpoint in the CatalogConverter class to convert the configured catalog directly to an "api" AirbyteCatalog which preserves the stream configurations, just skipping the bad intermediate convert.

I also updated the "no streams to reset" unit test to validate that it is actually calling `getConfigurationDiff` on the correct catalogs (and I verified that this caused the test to fail before I added my fix).