### PR TITLE
Skip running CI again when bumping connector version with `/publish` command

### DIFF
--- a/.github/workflows/publish-command.yml
+++ b/.github/workflows/publish-command.yml
@@ -343,7 +343,7 @@ jobs:
         if: github.event.inputs.auto-bump-version == 'true' && success()
         run: |
           git add -u
-          git commit -m "auto-bump connector version"
+          git commit -m "auto-bump connector version [ci skip]"
           git pull origin ${{ github.event.inputs.gitref }}
           git push origin ${{ github.event.inputs.gitref }}
         id: auto-bump


### PR DESCRIPTION
When a connector is published with the `/publish` command, upon success, the last thing the action does is commit back changes to the manifest files ([like this, for example](https://github.com/airbytehq/airbyte/pull/14751/commits/ececb742a970276c812d90a49323498705a50f15)).  

Since we shouldn't `/publish` until CI is green, and the side-effects of the publish command don't modify any code in the connector's directory, running CI again seems unnecessary.  Waiting until this new batch of tests is complete slows down the publishing workflow. 

This PR adds the magic phase `[ci skip]` to the git comment the bot adds to not run CI again after a successful `/publish`.  Learn more [here](https://docs.github.com/en/actions/managing-workflow-runs/skipping-workflow-runs).