### PR TITLE
fix missing db image in cloud KIND step

### DIFF
--- a/docker-compose-cloud.buildx.yaml
+++ b/docker-compose-cloud.buildx.yaml
@@ -68,3 +68,19 @@ services:
         platforms:
           - linux/amd64
           - linux/arm64
+  db:
+    image: airbyte/db:${VERSION}
+    build:
+      dockerfile: Dockerfile
+      context: airbyte-db/db-lib/build/docker
+      labels:
+        io.airbyte.git-revision: ${GIT_REVISION}
+      args:
+        VERSION: ${VERSION}
+      x-bake:
+        tags:
+          - airbyte/db:${VERSION}
+          - airbyte/db:${ALT_TAG:-${VERSION}}
+        platforms:
+          - linux/amd64
+          - linux/arm64


### PR DESCRIPTION
looks like we are actually missing the db image needed for the KIND step when using commit sha based tags because the Publish OSS Artifacts for Cloud workflow doesn't publish airbyte-db images.  This should fix that.