### PR TITLE
Align strict-encrypt connector version with the actual connector

### DIFF
--- a/airbyte-integrations/connectors/destination-oracle-strict-encrypt/Dockerfile
+++ b/airbyte-integrations/connectors/destination-oracle-strict-encrypt/Dockerfile
@@ -16,5 +16,5 @@ ENV APPLICATION destination-oracle-strict-encrypt
 
 COPY --from=build /airbyte /airbyte
 
-LABEL io.airbyte.version=0.1.7
+LABEL io.airbyte.version=0.1.18
 LABEL io.airbyte.name=airbyte/destination-oracle-strict-encrypt


### PR DESCRIPTION
Change the version of destination-oracle-strict-encrypt to match the version of destination-oracle connector