### PR TITLE
SAT: add test case to check `supported_sync_modes` field is not empty

### DIFF
--- a/airbyte-integrations/bases/source-acceptance-test/CHANGELOG.md
+++ b/airbyte-integrations/bases/source-acceptance-test/CHANGELOG.md
@@ -1,5 +1,8 @@
 # Changelog
 
+## 0.1.55
+Add test case in `TestDiscovery` to assert `supported_sync_modes` stream field in catalog is set and not empty.
+
 ## 0.1.54
 Fixed `AirbyteTraceMessage` test case to make connectors fail more reliably.
 

--- a/airbyte-integrations/bases/source-acceptance-test/Dockerfile
+++ b/airbyte-integrations/bases/source-acceptance-test/Dockerfile
@@ -33,7 +33,7 @@ COPY pytest.ini setup.py ./
 COPY source_acceptance_test ./source_acceptance_test
 RUN pip install .
 
-LABEL io.airbyte.version=0.1.54
+LABEL io.airbyte.version=0.1.55
 LABEL io.airbyte.name=airbyte/source-acceptance-test
 
 ENTRYPOINT ["python", "-m", "pytest", "-p", "source_acceptance_test.plugin", "-r", "fEsx"]

--- a/airbyte-integrations/bases/source-acceptance-test/source_acceptance_test/tests/test_core.py
+++ b/airbyte-integrations/bases/source-acceptance-test/source_acceptance_test/tests/test_core.py
@@ -243,6 +243,12 @@ class TestDiscovery(BaseTest):
                 pk_field_location = dpath.util.search(schema["properties"], pk_path)
                 assert pk_field_location, f"One of the PKs ({pk}) is not specified in discover schema for {stream_name} stream"
 
+    def test_streams_has_sync_modes(self, discovered_catalog: Mapping[str, Any]):
+        """Checking that the supported_sync_modes is a not empty field in streams of the catalog."""
+        for _, stream in discovered_catalog.items():
+            assert stream.supported_sync_modes is not None, f"The stream {stream.name} is missing supported_sync_modes field declaration."
+            assert len(stream.supported_sync_modes) > 0, f"supported_sync_modes list on stream {stream.name} should not be empty."
+
 
 def primary_keys_for_records(streams, records):
     streams_with_primary_key = [stream for stream in streams if stream.stream.source_defined_primary_key]

--- a/airbyte-integrations/bases/source-acceptance-test/unit_tests/test_core.py
+++ b/airbyte-integrations/bases/source-acceptance-test/unit_tests/test_core.py
@@ -2,6 +2,7 @@
 # Copyright (c) 2022 Airbyte, Inc., all rights reserved.
 #
 
+from contextlib import contextmanager
 from unittest.mock import MagicMock, patch
 
 import pytest
@@ -21,6 +22,11 @@ from airbyte_cdk.models import (
 from source_acceptance_test.config import BasicReadTestConfig
 from source_acceptance_test.tests.test_core import TestBasicRead as _TestBasicRead
 from source_acceptance_test.tests.test_core import TestDiscovery as _TestDiscovery
+
+
+@contextmanager
+def does_not_raise():
+    yield
 
 
 @pytest.mark.parametrize(
@@ -115,6 +121,38 @@ def test_keyword_in_discovery_schemas(schema, keyword, should_fail):
             t.test_defined_keyword_exist_in_schema(keyword, discovered_catalog)
     else:
         t.test_defined_keyword_exist_in_schema(keyword, discovered_catalog)
+
+
+@pytest.mark.parametrize(
+    "discovered_catalog, expectation",
+    [
+        ({"test_stream": AirbyteStream.parse_obj({"name": "test_stream", "json_schema": {}})}, pytest.raises(AssertionError)),
+        (
+            {"test_stream": AirbyteStream.parse_obj({"name": "test_stream", "json_schema": {}, "supported_sync_modes": []})},
+            pytest.raises(AssertionError),
+        ),
+        (
+            {
+                "test_stream": AirbyteStream.parse_obj(
+                    {"name": "test_stream", "json_schema": {}, "supported_sync_modes": ["full_refresh", "incremental"]}
+                )
+            },
+            does_not_raise(),
+        ),
+        (
+            {"test_stream": AirbyteStream.parse_obj({"name": "test_stream", "json_schema": {}, "supported_sync_modes": ["full_refresh"]})},
+            does_not_raise(),
+        ),
+        (
+            {"test_stream": AirbyteStream.parse_obj({"name": "test_stream", "json_schema": {}, "supported_sync_modes": ["incremental"]})},
+            does_not_raise(),
+        ),
+    ],
+)
+def test_supported_sync_modes_in_stream(discovered_catalog, expectation):
+    t = _TestDiscovery()
+    with expectation:
+        t.test_streams_has_sync_modes(discovered_catalog)
 
 
 @pytest.mark.parametrize(


### PR DESCRIPTION
## What
Closing airbytehq/airbyte#13027
Pydantic is already validating that the list of `supported_sync_modes` contains only `full_refresh` or/and `incremental` but this [field](https://github.com/airbytehq/airbyte/blob/master/airbyte-protocol/protocol-models/src/main/resources/airbyte_protocol/airbyte_protocol.yaml#L228)  is not declared as required (it's a TODO). 
Before attempting a protocol change, SAT can ensure this rule is enforced.
 I don't think this will solve https://github.com/airbytehq/airbyte-internal-issues/issues/587 as the `source-e2e-test` is a java connector. @pedroslopez do you confirm I can't run SAT on a java source?
 
## How
Add a test to check that all streams defined in a catalog have the `supported_sync_modes` field set to a nonempty list.

NB: I added some Pytest syntactic sugar to lighten the conditional raise in the unit test with the `does_not_raise` context.

## 🚨 User Impact 🚨
All connector builds that are not passing this new test will fail.

