### PR TITLE
sleep 1 second every connector lookup

### DIFF
--- a/tools/bin/check_images_exist.sh
+++ b/tools/bin/check_images_exist.sh
@@ -49,6 +49,8 @@ checkConnectorImages() {
       else
           printf "\tERROR: not found!\n" && exit 1
       fi
+      # Docker hub has a rate limit of 180 requests per minute, so slow down our rate of calling the API
+      # https://docs.docker.com/docker-hub/api/latest/#tag/rate-limiting
       sleep 1
   done <<< "${CONNECTOR_DEFINITIONS}"
 

--- a/tools/bin/check_images_exist.sh
+++ b/tools/bin/check_images_exist.sh
@@ -49,6 +49,7 @@ checkConnectorImages() {
       else
           printf "\tERROR: not found!\n" && exit 1
       fi
+      sleep 1
   done <<< "${CONNECTOR_DEFINITIONS}"
 
   echo "Success! All connector images exist!"


### PR DESCRIPTION
to prevent running into docker hub API rate limits

rate limits:
```
x-ratelimit-limit: 180
x-ratelimit-reset: 1658170291
x-ratelimit-remaining: 180
```
https://docs.docker.com/docker-hub/api/latest/#tag/rate-limiting