### PR TITLE
[low-code connectors] Bugfix transformations

### DIFF
--- a/airbyte-cdk/python/airbyte_cdk/sources/declarative/parsers/factory.py
+++ b/airbyte-cdk/python/airbyte_cdk/sources/declarative/parsers/factory.py
@@ -46,7 +46,6 @@ class DeclarativeComponentFactory:
             kwargs["options"] = {k: self._create_subcomponent(k, v, kwargs, config, class_) for k, v in kwargs["options"].items()}
 
         updated_kwargs = {k: self._create_subcomponent(k, v, kwargs, config, class_) for k, v in kwargs.items()}
-
         return create(class_, config=config, **updated_kwargs)
 
     @staticmethod

--- a/airbyte-cdk/python/airbyte_cdk/sources/declarative/transformations/transformation.py
+++ b/airbyte-cdk/python/airbyte_cdk/sources/declarative/transformations/transformation.py
@@ -15,7 +15,7 @@ class RecordTransformation(ABC):
 
     @abstractmethod
     def transform(
-        self, record: Mapping[str, Any], config: Config = None, state: StreamState = None, slice: StreamSlice = None
+        self, record: Mapping[str, Any], config: Config = None, stream_state: StreamState = None, stream_slice: StreamSlice = None
     ) -> Mapping[str, Any]:
         """
         :param record: the input record to be transformed


### PR DESCRIPTION
## What
`config` wasn't being passed into `DeclarativeStream`, which meant transformations couldn't reference any fields in the config. This PR fixes that. 

## How
Adds `config` as an init param to declarative stream. The factory magically injects this during initialization. 

This bug happened because I didn't adjust `declarative_stream` to correctly pass `config`. There was also no E2E test which verified that a YAML specification containing a transformation interpolating the config worked correctly. 