### PR TITLE
fix chart formatting for stream capable

### DIFF
--- a/charts/airbyte/templates/worker/deployment.yaml
+++ b/charts/airbyte/templates/worker/deployment.yaml
@@ -269,10 +269,10 @@ spec:
               name: {{ include "common.names.fullname" . }}-env
               key: WORKFLOW_FAILURE_RESTART_DELAY_SECONDS
         - name: USE_STREAM_CAPABLE_STATE
-            valueFrom:
-              configMapKeyRef:
-                name: { { include "common.names.fullname" . } }-env
-                key: USE_STREAM_CAPABLE_STATE
+          valueFrom:
+            configMapKeyRef:
+              name: { { include "common.names.fullname" . } }-env
+              key: USE_STREAM_CAPABLE_STATE
         {{- if .Values.worker.extraEnv }}
         {{ .Values.worker.extraEnv | toYaml | nindent 8 }}
         {{- end }}


### PR DESCRIPTION
## What
The helm chart cannot be installed currently because of a formatting error in the worker.yaml file.

## How
This PR corrects the formatting error in the worker.yaml file so that the helm chart can be installed.