### PR TITLE
fix(Helm Charts):  stream capable formatting for worker

### DIFF
--- a/charts/airbyte/templates/worker/deployment.yaml
+++ b/charts/airbyte/templates/worker/deployment.yaml
@@ -269,10 +269,10 @@ spec:
               name: {{ include "common.names.fullname" . }}-env
               key: WORKFLOW_FAILURE_RESTART_DELAY_SECONDS
         - name: USE_STREAM_CAPABLE_STATE
-            valueFrom:
-              configMapKeyRef:
-                name: { { include "common.names.fullname" . } }-env
-                key: USE_STREAM_CAPABLE_STATE
+          valueFrom:
+            configMapKeyRef:
+              name: {{ include "common.names.fullname" . }}-env
+              key: USE_STREAM_CAPABLE_STATE
         {{- if .Values.worker.extraEnv }}
         {{ .Values.worker.extraEnv | toYaml | nindent 8 }}
         {{- end }}


### PR DESCRIPTION
## What
Currently the helm chart cannot be installed because of a formatting error in the yaml for the worker

## How
This PR corrects the formatting for stream capable setting, allowing the chart to be installed successfully.

