### PR TITLE
Make Temporal workflows use new schema for scheduling to support cronstrings

### DIFF
--- a/airbyte-config/config-models/src/main/java/io/airbyte/config/helpers/ScheduleHelpers.java
+++ b/airbyte-config/config-models/src/main/java/io/airbyte/config/helpers/ScheduleHelpers.java
@@ -4,6 +4,7 @@
 
 package io.airbyte.config.helpers;
 
+import io.airbyte.config.BasicSchedule;
 import io.airbyte.config.Schedule;
 import java.util.concurrent.TimeUnit;
 
@@ -27,7 +28,28 @@ public class ScheduleHelpers {
     }
   }
 
+  public static Long getSecondsInUnit(final BasicSchedule.TimeUnit timeUnitEnum) {
+    switch (timeUnitEnum) {
+      case MINUTES:
+        return TimeUnit.MINUTES.toSeconds(1);
+      case HOURS:
+        return TimeUnit.HOURS.toSeconds(1);
+      case DAYS:
+        return TimeUnit.DAYS.toSeconds(1);
+      case WEEKS:
+        return TimeUnit.DAYS.toSeconds(1) * 7;
+      case MONTHS:
+        return TimeUnit.DAYS.toSeconds(1) * 30;
+      default:
+        throw new RuntimeException("Unhandled TimeUnitEnum: " + timeUnitEnum);
+    }
+  }
+
   public static Long getIntervalInSecond(final Schedule schedule) {
+    return getSecondsInUnit(schedule.getTimeUnit()) * schedule.getUnits();
+  }
+
+  public static Long getIntervalInSecond(final BasicSchedule schedule) {
     return getSecondsInUnit(schedule.getTimeUnit()) * schedule.getUnits();
   }
 

--- a/airbyte-config/config-models/src/main/resources/types/StandardSync.yaml
+++ b/airbyte-config/config-models/src/main/resources/types/StandardSync.yaml
@@ -46,16 +46,38 @@ properties:
       - active
       - inactive
       - deprecated
-  # Ideally schedule and manual should be a union, but java
-  # codegen does not handle the union type properly.
-  # When schedule is defined, manual should be false.
+  # This should be populated when scheduleType is BasicSchedule.
   schedule:
     type: object
-    required:
-      - timeUnit
-      - units
     additionalProperties: false
     properties:
+      basicSchedule:
+        type: object
+        required:
+          - timeUnit
+          - units
+        properties:
+          timeUnit:
+            type: string
+            enum:
+              - minutes
+              - hours
+              - days
+              - weeks
+              - months
+          units:
+            type: integer
+      cron:
+        type: object
+        required:
+          - cronExpression
+          - cronTimeZone
+        properties:
+          cronExpression:
+            type: string
+          cronTimeZone:
+            type: string
+      # TODO(https://github.com/airbytehq/airbyte/issues/11432): remove. Prefer the basicSchedule property.
       timeUnit:
         type: string
         enum:
@@ -64,11 +86,20 @@ properties:
           - days
           - weeks
           - months
+      # TODO(https://github.com/airbytehq/airbyte/issues/11432): remove. Prefer the basicSchedule property.
       units:
         type: integer
+  # This should be populated when scheduleType is Cron
   # When manual is true, schedule should be null, and will be ignored.
   manual:
     type: boolean
+  # TODO: deprecate/remove `manual`.
+  scheduleType:
+    type: string
+    enum:
+      - Manual
+      - BasicSchedule
+      - Cron
   source_catalog_id:
     type: string
     format: uuid

--- a/airbyte-workers/build.gradle
+++ b/airbyte-workers/build.gradle
@@ -18,6 +18,7 @@ dependencies {
     implementation 'org.apache.commons:commons-text:1.9'
     implementation 'org.eclipse.jetty:jetty-server:9.4.31.v20200723'
     implementation 'org.eclipse.jetty:jetty-servlet:9.4.31.v20200723'
+    implementation 'org.quartz-scheduler:quartz:2.3.2'
     implementation libs.flyway.core
 
     implementation project(':airbyte-analytics')

--- a/airbyte-workers/src/main/java/io/airbyte/workers/temporal/scheduling/activities/ConfigFetchActivityImpl.java
+++ b/airbyte-workers/src/main/java/io/airbyte/workers/temporal/scheduling/activities/ConfigFetchActivityImpl.java
@@ -5,7 +5,9 @@
 package io.airbyte.workers.temporal.scheduling.activities;
 
 import io.airbyte.config.Configs;
+import io.airbyte.config.Cron;
 import io.airbyte.config.StandardSync;
+import io.airbyte.config.StandardSync.ScheduleType;
 import io.airbyte.config.StandardSync.Status;
 import io.airbyte.config.helpers.ScheduleHelpers;
 import io.airbyte.config.persistence.ConfigNotFoundException;
@@ -15,11 +17,18 @@ import io.airbyte.scheduler.persistence.JobPersistence;
 import io.airbyte.validation.json.JsonValidationException;
 import io.airbyte.workers.temporal.exception.RetryableException;
 import java.io.IOException;
+import java.text.ParseException;
+import java.time.DateTimeException;
 import java.time.Duration;
+import java.util.Date;
 import java.util.Optional;
+import java.util.TimeZone;
+import java.util.UUID;
 import java.util.function.Supplier;
 import lombok.AllArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
+import org.joda.time.DateTimeZone;
+import org.quartz.CronExpression;
 
 @AllArgsConstructor
 @Slf4j
@@ -35,30 +44,75 @@ public class ConfigFetchActivityImpl implements ConfigFetchActivity {
     try {
       final StandardSync standardSync = configRepository.getStandardSync(input.getConnectionId());
 
-      if (standardSync.getSchedule() == null || standardSync.getStatus() != Status.ACTIVE) {
-        // Manual syncs wait for their first run
-        return new ScheduleRetrieverOutput(Duration.ofDays(100 * 365));
+      if (standardSync.getScheduleType() != null) {
+        return this.getTimeToWaitFromScheduleType(standardSync, input.getConnectionId());
       }
-
-      final Optional<Job> previousJobOptional = jobPersistence.getLastReplicationJob(input.getConnectionId());
-
-      if (previousJobOptional.isEmpty() && standardSync.getSchedule() != null) {
-        // Non-manual syncs don't wait for their first run
-        return new ScheduleRetrieverOutput(Duration.ZERO);
-      }
-
-      final Job previousJob = previousJobOptional.get();
-      final long prevRunStart = previousJob.getStartedAtInSecond().orElse(previousJob.getCreatedAtInSecond());
-
-      final long nextRunStart = prevRunStart + ScheduleHelpers.getIntervalInSecond(standardSync.getSchedule());
-
-      final Duration timeToWait = Duration.ofSeconds(
-          Math.max(0, nextRunStart - currentSecondsSupplier.get()));
-
-      return new ScheduleRetrieverOutput(timeToWait);
+      return this.getTimeToWaitFromLegacy(standardSync, input.getConnectionId());
     } catch (final IOException | JsonValidationException | ConfigNotFoundException e) {
       throw new RetryableException(e);
     }
+  }
+
+  private ScheduleRetrieverOutput getTimeToWaitFromScheduleType(final StandardSync standardSync, UUID connectionId) throws IOException {
+    if (standardSync.getScheduleType() == ScheduleType.MANUAL || standardSync.getStatus() != Status.ACTIVE) {
+      // Manual syncs wait for their first run
+      return new ScheduleRetrieverOutput(Duration.ofDays(100 * 365));
+    }
+
+    final Optional<Job> previousJobOptional = jobPersistence.getLastReplicationJob(connectionId);
+
+    if (standardSync.getScheduleType() == ScheduleType.BASIC_SCHEDULE) {
+      if (previousJobOptional.isEmpty()) {
+        // Basic schedules don't wait for their first run.
+        return new ScheduleRetrieverOutput(Duration.ZERO);
+      }
+      final Job previousJob = previousJobOptional.get();
+      final long prevRunStart = previousJob.getStartedAtInSecond().orElse(previousJob.getCreatedAtInSecond());
+      final long nextRunStart = prevRunStart + ScheduleHelpers.getIntervalInSecond(standardSync.getSchedule().getBasicSchedule());
+      final Duration timeToWait = Duration.ofSeconds(
+          Math.max(0, nextRunStart - currentSecondsSupplier.get()));
+      return new ScheduleRetrieverOutput(timeToWait);
+    }
+
+    else { // standardSync.getScheduleType() == ScheduleType.CRON
+      final Cron scheduleCron = standardSync.getSchedule().getCron();
+      final TimeZone timeZone = DateTimeZone.forID(scheduleCron.getCronTimeZone()).toTimeZone();
+      try {
+        final CronExpression cronExpression = new CronExpression(scheduleCron.getCronExpression());
+        cronExpression.setTimeZone(timeZone);
+        final Date nextRunStart = cronExpression.getNextValidTimeAfter(new Date(currentSecondsSupplier.get() * 1000L));
+        final Duration timeToWait = Duration.ofSeconds(
+            Math.max(0, nextRunStart.getTime() / 1000L - currentSecondsSupplier.get()));
+        return new ScheduleRetrieverOutput(timeToWait);
+      } catch (ParseException e) {
+        throw new DateTimeException(e.getMessage());
+      }
+    }
+  }
+
+  private ScheduleRetrieverOutput getTimeToWaitFromLegacy(final StandardSync standardSync, UUID connectionId) throws IOException {
+    if (standardSync.getSchedule() == null || standardSync.getStatus() != Status.ACTIVE) {
+      // Manual syncs wait for their first run
+      return new ScheduleRetrieverOutput(Duration.ofDays(100 * 365));
+    }
+
+    final Optional<Job> previousJobOptional = jobPersistence.getLastReplicationJob(connectionId);
+
+    if (previousJobOptional.isEmpty() && standardSync.getSchedule() != null) {
+      // Non-manual syncs don't wait for their first run
+      return new ScheduleRetrieverOutput(Duration.ZERO);
+    }
+
+    final Job previousJob = previousJobOptional.get();
+    final long prevRunStart = previousJob.getStartedAtInSecond().orElse(previousJob.getCreatedAtInSecond());
+
+    final long nextRunStart = prevRunStart + ScheduleHelpers.getIntervalInSecond(standardSync.getSchedule());
+
+    final Duration timeToWait = Duration.ofSeconds(
+        Math.max(0, nextRunStart - currentSecondsSupplier.get()));
+
+    return new ScheduleRetrieverOutput(timeToWait);
+
   }
 
   @Override

--- a/deps.toml
+++ b/deps.toml
@@ -86,6 +86,7 @@ otel-bom = {module = "io.opentelemetry:opentelemetry-bom", version = "1.14.0"}
 otel-semconv = {module = "io.opentelemetry:opentelemetry-semconv", version = "1.14.0-alpha"}
 otel-sdk = {module = "io.opentelemetry:opentelemetry-sdk-metrics", version = "1.14.0"}
 otel-sdk-testing = {module = "io.opentelemetry:opentelemetry-sdk-metrics-testing", version = "1.13.0-alpha"}
+quartz-scheduler = {module="org.quartz-scheduler:quartz", version = "2.3.2"}
 
 [bundles]
 jackson = ["jackson-databind", "jackson-annotations", "jackson-dataformat", "jackson-datatype"]


### PR DESCRIPTION
## What
Support cron strings in the temporal workflow scheduling.

Related to https://github.com/airbytehq/airbyte/issues/11419 - a subsequent PR will dual write in the persistence layer.

## How
- Add support for cronstrings in the StandardSync schema
- Consume the new schema if populated in the temporal worker scheduling

## Recommended reading order
1. `airbyte-config/config-models/src/main/resources/types/StandardSync.yaml`
2. `airbyte-workers/src/main/java/io/airbyte/workers/temporal/scheduling/activities/ConfigFetchActivityImpl.java`

## 🚨 User Impact 🚨
None

## Pre-merge Checklist
Expand the relevant checklist and delete the others.

## Tests

<details><summary><strong>Unit</strong></summary>

*Put your unit tests output here.*

Introduced new unit tests for ConfigFetchActivityImpl.
