### PR TITLE
🪟 🐛 Fix connector form cancellation logic to ensure all fields are reset

### DIFF
--- a/airbyte-webapp/src/views/Connector/ServiceForm/FormRoot.tsx
+++ b/airbyte-webapp/src/views/Connector/ServiceForm/FormRoot.tsx
@@ -47,9 +47,8 @@ const FormRoot: React.FC<FormRootProps> = ({
   hasSuccess,
   onStopTestingConnector,
 }) => {
-  const { resetForm, dirty, isSubmitting, isValid } = useFormikContext<ServiceFormValues>();
-
-  const { resetUiFormProgress, isLoadingSchema, selectedService, isEditMode, formType } = useServiceForm();
+  const { dirty, isSubmitting, isValid } = useFormikContext<ServiceFormValues>();
+  const { resetServiceForm, isLoadingSchema, selectedService, isEditMode, formType } = useServiceForm();
 
   return (
     <FormContainer>
@@ -70,12 +69,11 @@ const FormRoot: React.FC<FormRootProps> = ({
           isSubmitting={isSubmitting || isTestConnectionInProgress}
           errorMessage={errorMessage}
           formType={formType}
-          onRetest={onRetest}
+          onRetestClick={onRetest}
           isValid={isValid}
           dirty={dirty}
-          resetForm={() => {
-            resetForm();
-            resetUiFormProgress();
+          onCancelClick={() => {
+            resetServiceForm();
           }}
           successMessage={successMessage}
         />

--- a/airbyte-webapp/src/views/Connector/ServiceForm/ServiceForm.tsx
+++ b/airbyte-webapp/src/views/Connector/ServiceForm/ServiceForm.tsx
@@ -204,7 +204,11 @@ const ServiceForm: React.FC<ServiceFormProps> = (props) => {
     [formType, props.onServiceSelect, props.availableServices, props.isEditMode, toggleOpenRequestModal]
   );
 
-  const { uiWidgetsInfo, setUiWidgetsInfo } = useBuildUiWidgetsContext(formFields, initialValues, uiOverrides);
+  const { uiWidgetsInfo, setUiWidgetsInfo, resetUiWidgetsInfo } = useBuildUiWidgetsContext(
+    formFields,
+    initialValues,
+    uiOverrides
+  );
 
   const validationSchema = useConstructValidationSchema(jsonSchema, uiWidgetsInfo);
 
@@ -240,6 +244,7 @@ const ServiceForm: React.FC<ServiceFormProps> = (props) => {
           widgetsInfo={uiWidgetsInfo}
           getValues={getValues}
           setUiWidgetsInfo={setUiWidgetsInfo}
+          resetUiWidgetsInfo={resetUiWidgetsInfo}
           formType={formType}
           selectedConnector={selectedConnectorDefinitionSpecification}
           availableServices={props.availableServices}

--- a/airbyte-webapp/src/views/Connector/ServiceForm/components/EditControls.tsx
+++ b/airbyte-webapp/src/views/Connector/ServiceForm/components/EditControls.tsx
@@ -25,8 +25,8 @@ interface IProps {
   isSubmitting: boolean;
   isValid: boolean;
   dirty: boolean;
-  resetForm: () => void;
-  onRetest?: () => void;
+  onCancelClick: () => void;
+  onRetestClick?: () => void;
   onCancelTesting?: () => void;
   isTestConnectionInProgress?: boolean;
   successMessage?: React.ReactNode;
@@ -38,9 +38,9 @@ const EditControls: React.FC<IProps> = ({
   isTestConnectionInProgress,
   isValid,
   dirty,
-  resetForm,
+  onCancelClick,
   formType,
-  onRetest,
+  onRetestClick,
   successMessage,
   errorMessage,
   onCancelTesting,
@@ -51,7 +51,7 @@ const EditControls: React.FC<IProps> = ({
     return <TestingConnectionSpinner isCancellable={isTestConnectionInProgress} onCancelTesting={onCancelTesting} />;
   }
 
-  const showStatusMessage = () => {
+  const renderStatusMessage = () => {
     if (errorMessage) {
       return <TestingConnectionError errorMessage={errorMessage} />;
     }
@@ -63,7 +63,7 @@ const EditControls: React.FC<IProps> = ({
 
   return (
     <>
-      {showStatusMessage()}
+      {renderStatusMessage()}
       <Controls>
         <div>
           <Button
@@ -73,13 +73,13 @@ const EditControls: React.FC<IProps> = ({
             <FormattedMessage id="form.saveChangesAndTest" />
           </Button>
           <ButtonContainer>
-            <Button type="button" secondary disabled={isSubmitting || !isValid || !dirty} onClick={resetForm}>
+            <Button type="button" secondary disabled={isSubmitting || !dirty} onClick={onCancelClick}>
               <FormattedMessage id="form.cancel" />
             </Button>
           </ButtonContainer>
         </div>
-        {onRetest && (
-          <Button type="button" onClick={onRetest} disabled={!isValid}>
+        {onRetestClick && (
+          <Button type="button" onClick={onRetestClick} disabled={!isValid}>
             <FormattedMessage id={`form.${formType}Retest`} />
           </Button>
         )}

--- a/airbyte-webapp/src/views/Connector/ServiceForm/useBuildForm.tsx
+++ b/airbyte-webapp/src/views/Connector/ServiceForm/useBuildForm.tsx
@@ -42,7 +42,7 @@ function upgradeSchemaLegacyAuth(
   );
 }
 
-function useBuildInitialSchema(
+export function useBuildInitialSchema(
   connectorSpecification?: ConnectorDefinitionSpecification
 ): JSONSchema7Definition | undefined {
   const allowOAuthConnector = useFeature(FeatureItem.AllowOAuthConnector);
@@ -61,13 +61,12 @@ function useBuildInitialSchema(
   }, [allowOAuthConnector, connectorSpecification]);
 }
 
-function useBuildForm(
-  jsonSchema: JSONSchema7,
-  initialValues?: Partial<ServiceFormValues>
-): {
+export interface BuildFormHook {
   initialValues: ServiceFormValues;
   formFields: FormBlock;
-} {
+}
+
+export function useBuildForm(jsonSchema: JSONSchema7, initialValues?: Partial<ServiceFormValues>): BuildFormHook {
   const startValues = useMemo<ServiceFormValues>(
     () => ({
       name: "",
@@ -86,14 +85,17 @@ function useBuildForm(
   };
 }
 
-const useBuildUiWidgetsContext = (
+interface BuildUiWidgetsContextHook {
+  uiWidgetsInfo: WidgetConfigMap;
+  setUiWidgetsInfo: (widgetId: string, updatedValues: WidgetConfig) => void;
+  resetUiWidgetsInfo: () => void;
+}
+
+export const useBuildUiWidgetsContext = (
   formFields: FormBlock[] | FormBlock,
   formValues: ServiceFormValues,
   uiOverrides?: WidgetConfigMap
-): {
-  uiWidgetsInfo: WidgetConfigMap;
-  setUiWidgetsInfo: (widgetId: string, updatedValues: WidgetConfig) => void;
-} => {
+): BuildUiWidgetsContextHook => {
   const [overriddenWidgetState, setUiWidgetsInfo] = useState<WidgetConfigMap>(uiOverrides ?? {});
 
   // As schema is dynamic, it is possible, that new updated values, will differ from one stored.
@@ -111,17 +113,22 @@ const useBuildUiWidgetsContext = (
     [mergedState, setUiWidgetsInfo]
   );
 
+  const resetUiWidgetsInfo = useCallback(() => {
+    setUiWidgetsInfo(uiOverrides ?? {});
+  }, [uiOverrides]);
+
   return {
     uiWidgetsInfo: mergedState,
     setUiWidgetsInfo: setUiWidgetsInfoSubState,
+    resetUiWidgetsInfo,
   };
 };
 
 // As validation schema depends on what path of oneOf is currently selected in jsonschema
-const useConstructValidationSchema = (jsonSchema: JSONSchema7, uiWidgetsInfo: WidgetConfigMap): AnySchema =>
+export const useConstructValidationSchema = (jsonSchema: JSONSchema7, uiWidgetsInfo: WidgetConfigMap): AnySchema =>
   useMemo(() => buildYupFormForJsonSchema(jsonSchema, uiWidgetsInfo), [uiWidgetsInfo, jsonSchema]);
 
-const usePatchFormik = (): void => {
+export const usePatchFormik = (): void => {
   const { setFieldTouched, isSubmitting, isValidating, validationSchema, validateForm, errors } = useFormikContext();
   // Formik doesn't validate values again, when validationSchema was changed on the fly.
   useEffect(() => {
@@ -148,5 +155,3 @@ const usePatchFormik = (): void => {
     }
   }, [errors, isSubmitting, isValidating, setFieldTouched]);
 };
-
-export { useBuildForm, useBuildInitialSchema, useBuildUiWidgetsContext, useConstructValidationSchema, usePatchFormik };


### PR DESCRIPTION
## What
Fixes #8291

This fixes an issue in editing a connector (source or destination) where, after pressing the Cancel button, not all values were reset, particularly conditional values.

It also fixes an issue where the cancel button remains disabled when the form is valid. Instead, the cancel button should rely on whether the form is dirty or not to disable.

Finally, lots of type cleanup and improved naming across files updated.

## How

The service form tracks its values in two different states:

- Formik's values. These can be reset back to their initial values with `reset form()`
- `uiWidgetsInfo` is a custom state that tracks additional values that Formik does not track for complex objects. For example, on a conditional node which current node is selected

What was happening before is that the `uiWidgetsInfo` values were not reset completely. Now when the user presses "Cancel," the uiWidgetsInfo state is reset back to the initial state.

Changes include:
* Add resetUiWidgetsInfo function to buildUiWidgetsContext to reset the uiWidgetsInfo to its original state
* Add resetServiceForm function to service form context that both resets service form values and Formik values
* Update "Cancel" button in EditControls to avoid disabling it when form values are valid
* Cleanup typing

## Recommended reading order
Top to bottom

## Tests

- Cancel edit after switching condition
- Cancel edit on text input fields
- Cancel edit on variable input fields
- Cancel edit on switches
