### PR TITLE
fix build: update connector command worker output usage in tests

### DIFF
--- a/airbyte-integrations/bases/standard-destination-test/src/main/java/io/airbyte/integrations/standardtest/destination/DestinationAcceptanceTest.java
+++ b/airbyte-integrations/bases/standard-destination-test/src/main/java/io/airbyte/integrations/standardtest/destination/DestinationAcceptanceTest.java
@@ -1040,20 +1040,20 @@ public abstract class DestinationAcceptanceTest {
   private ConnectorSpecification runSpec() throws WorkerException {
     return new DefaultGetSpecWorker(
         workerConfigs, new AirbyteIntegrationLauncher(JOB_ID, JOB_ATTEMPT, getImageName(), processFactory, null))
-            .run(new JobGetSpecConfig().withDockerImage(getImageName()), jobRoot);
+            .run(new JobGetSpecConfig().withDockerImage(getImageName()), jobRoot).getSpec();
   }
 
   protected StandardCheckConnectionOutput runCheck(final JsonNode config) throws WorkerException {
     return new DefaultCheckConnectionWorker(
         workerConfigs, new AirbyteIntegrationLauncher(JOB_ID, JOB_ATTEMPT, getImageName(), processFactory, null))
-            .run(new StandardCheckConnectionInput().withConnectionConfiguration(config), jobRoot);
+            .run(new StandardCheckConnectionInput().withConnectionConfiguration(config), jobRoot).getCheckConnection();
   }
 
   protected StandardCheckConnectionOutput.Status runCheckWithCatchedException(final JsonNode config) {
     try {
       final StandardCheckConnectionOutput standardCheckConnectionOutput = new DefaultCheckConnectionWorker(
           workerConfigs, new AirbyteIntegrationLauncher(JOB_ID, JOB_ATTEMPT, getImageName(), processFactory, null))
-              .run(new StandardCheckConnectionInput().withConnectionConfiguration(config), jobRoot);
+              .run(new StandardCheckConnectionInput().withConnectionConfiguration(config), jobRoot).getCheckConnection();
       return standardCheckConnectionOutput.getStatus();
     } catch (final Exception e) {
       LOGGER.error("Failed to check connection:" + e.getMessage());

--- a/airbyte-integrations/bases/standard-source-test/src/main/java/io/airbyte/integrations/standardtest/source/AbstractSourceConnectorTest.java
+++ b/airbyte-integrations/bases/standard-source-test/src/main/java/io/airbyte/integrations/standardtest/source/AbstractSourceConnectorTest.java
@@ -130,28 +130,28 @@ public abstract class AbstractSourceConnectorTest {
     return new DefaultGetSpecWorker(
         workerConfigs,
         new AirbyteIntegrationLauncher(JOB_ID, JOB_ATTEMPT, getImageName(), processFactory, workerConfigs.getResourceRequirements()))
-            .run(new JobGetSpecConfig().withDockerImage(getImageName()), jobRoot);
+            .run(new JobGetSpecConfig().withDockerImage(getImageName()), jobRoot).getSpec();
   }
 
   protected StandardCheckConnectionOutput runCheck() throws Exception {
     return new DefaultCheckConnectionWorker(
         workerConfigs,
         new AirbyteIntegrationLauncher(JOB_ID, JOB_ATTEMPT, getImageName(), processFactory, workerConfigs.getResourceRequirements()))
-            .run(new StandardCheckConnectionInput().withConnectionConfiguration(getConfig()), jobRoot);
+            .run(new StandardCheckConnectionInput().withConnectionConfiguration(getConfig()), jobRoot).getCheckConnection();
   }
 
-  protected String runCheckAndGetStatusAsString(JsonNode config) throws Exception {
+  protected String runCheckAndGetStatusAsString(final JsonNode config) throws Exception {
     return new DefaultCheckConnectionWorker(
         workerConfigs,
         new AirbyteIntegrationLauncher(JOB_ID, JOB_ATTEMPT, getImageName(), processFactory, workerConfigs.getResourceRequirements()))
-            .run(new StandardCheckConnectionInput().withConnectionConfiguration(config), jobRoot).getStatus().toString();
+            .run(new StandardCheckConnectionInput().withConnectionConfiguration(config), jobRoot).getCheckConnection().getStatus().toString();
   }
 
   protected AirbyteCatalog runDiscover() throws Exception {
     return new DefaultDiscoverCatalogWorker(
         workerConfigs,
         new AirbyteIntegrationLauncher(JOB_ID, JOB_ATTEMPT, getImageName(), processFactory, workerConfigs.getResourceRequirements()))
-            .run(new StandardDiscoverCatalogInput().withConnectionConfiguration(getConfig()), jobRoot);
+            .run(new StandardDiscoverCatalogInput().withConnectionConfiguration(getConfig()), jobRoot).getDiscoverCatalog();
   }
 
   protected void checkEntrypointEnvVariable() throws Exception {
@@ -205,10 +205,10 @@ public abstract class AbstractSourceConnectorTest {
     source.start(sourceConfig, jobRoot);
 
     while (!source.isFinished()) {
-      Optional<AirbyteMessage> airbyteMessageOptional = source.attemptRead();
+      final Optional<AirbyteMessage> airbyteMessageOptional = source.attemptRead();
       if (airbyteMessageOptional.isPresent() && airbyteMessageOptional.get().getType().equals(Type.RECORD)) {
-        AirbyteMessage airbyteMessage = airbyteMessageOptional.get();
-        AirbyteRecordMessage record = airbyteMessage.getRecord();
+        final AirbyteMessage airbyteMessage = airbyteMessageOptional.get();
+        final AirbyteRecordMessage record = airbyteMessage.getRecord();
 
         final String streamName = record.getStream();
         mapOfExpectedRecordsCount.put(streamName, mapOfExpectedRecordsCount.get(streamName) - 1);
@@ -218,16 +218,16 @@ public abstract class AbstractSourceConnectorTest {
     return mapOfExpectedRecordsCount;
   }
 
-  protected ResourceRequirements prepareResourceRequirements(Map<String, String> mapOfResourceRequirementsParams) {
+  protected ResourceRequirements prepareResourceRequirements(final Map<String, String> mapOfResourceRequirementsParams) {
     return new ResourceRequirements().withCpuRequest(mapOfResourceRequirementsParams.get(CPU_REQUEST_FIELD_NAME))
         .withCpuLimit(mapOfResourceRequirementsParams.get(CPU_LIMIT_FIELD_NAME))
         .withMemoryRequest(mapOfResourceRequirementsParams.get(MEMORY_REQUEST_FIELD_NAME))
         .withMemoryLimit(mapOfResourceRequirementsParams.get(MEMORY_LIMIT_FIELD_NAME));
   }
 
-  private AirbyteSource prepareAirbyteSource(ResourceRequirements resourceRequirements) {
-    var workerConfigs = new WorkerConfigs(new EnvConfigs());
-    var integrationLauncher = resourceRequirements == null
+  private AirbyteSource prepareAirbyteSource(final ResourceRequirements resourceRequirements) {
+    final var workerConfigs = new WorkerConfigs(new EnvConfigs());
+    final var integrationLauncher = resourceRequirements == null
         ? new AirbyteIntegrationLauncher(JOB_ID, JOB_ATTEMPT, getImageName(), processFactory, workerConfigs.getResourceRequirements())
         : new AirbyteIntegrationLauncher(JOB_ID, JOB_ATTEMPT, getImageName(), processFactory, resourceRequirements);
     return new DefaultAirbyteSource(workerConfigs, integrationLauncher);
@@ -236,7 +236,7 @@ public abstract class AbstractSourceConnectorTest {
   private static Map<String, String> prepareResourceRequestMapBySystemProperties() {
     var cpuLimit = System.getProperty(CPU_LIMIT_FIELD_NAME);
     var memoryLimit = System.getProperty(MEMORY_LIMIT_FIELD_NAME);
-    var workerConfigs = new WorkerConfigs(new EnvConfigs());
+    final var workerConfigs = new WorkerConfigs(new EnvConfigs());
     if (cpuLimit.isBlank() || cpuLimit.isEmpty()) {
       cpuLimit = workerConfigs.getResourceRequirements().getCpuLimit();
     }
@@ -245,7 +245,7 @@ public abstract class AbstractSourceConnectorTest {
     }
     LOGGER.info("Container CPU Limit = {}", cpuLimit);
     LOGGER.info("Container Memory Limit = {}", memoryLimit);
-    Map<String, String> result = new HashMap<>();
+    final Map<String, String> result = new HashMap<>();
     result.put(CPU_REQUEST_FIELD_NAME, workerConfigs.getResourceRequirements().getCpuRequest());
     result.put(CPU_LIMIT_FIELD_NAME, cpuLimit);
     result.put(MEMORY_REQUEST_FIELD_NAME, workerConfigs.getResourceRequirements().getMemoryRequest());


### PR DESCRIPTION
## What
#14715 changed the output type of our connector command workers to be `ConnectorJobOutput`, which broke the Connectors Base / `standard-source-test` / `standard-destination-test` build (see failure example [here](https://github.com/airbytehq/airbyte/runs/7418125178?check_suite_focus=true))

## How
Fix the build by considering this new output and getting the right type from it for each job.
