### PR TITLE
Make Temporal workflows use new schema for scheduling to support cronstrings

### DIFF
--- a/airbyte-config/config-models/src/main/java/io/airbyte/config/helpers/ScheduleHelpers.java
+++ b/airbyte-config/config-models/src/main/java/io/airbyte/config/helpers/ScheduleHelpers.java
@@ -4,6 +4,7 @@
 
 package io.airbyte.config.helpers;
 
+import io.airbyte.config.BasicSchedule;
 import io.airbyte.config.Schedule;
 import java.util.concurrent.TimeUnit;
 
@@ -27,7 +28,28 @@ public class ScheduleHelpers {
     }
   }
 
+  public static Long getSecondsInUnit(final BasicSchedule.TimeUnit timeUnitEnum) {
+    switch (timeUnitEnum) {
+      case MINUTES:
+        return TimeUnit.MINUTES.toSeconds(1);
+      case HOURS:
+        return TimeUnit.HOURS.toSeconds(1);
+      case DAYS:
+        return TimeUnit.DAYS.toSeconds(1);
+      case WEEKS:
+        return TimeUnit.DAYS.toSeconds(1) * 7;
+      case MONTHS:
+        return TimeUnit.DAYS.toSeconds(1) * 30;
+      default:
+        throw new RuntimeException("Unhandled TimeUnitEnum: " + timeUnitEnum);
+    }
+  }
+
   public static Long getIntervalInSecond(final Schedule schedule) {
+    return getSecondsInUnit(schedule.getTimeUnit()) * schedule.getUnits();
+  }
+
+  public static Long getIntervalInSecond(final BasicSchedule schedule) {
     return getSecondsInUnit(schedule.getTimeUnit()) * schedule.getUnits();
   }
 

--- a/airbyte-config/config-models/src/main/resources/types/StandardSync.yaml
+++ b/airbyte-config/config-models/src/main/resources/types/StandardSync.yaml
@@ -46,9 +46,7 @@ properties:
       - active
       - inactive
       - deprecated
-  # Ideally schedule and manual should be a union, but java
-  # codegen does not handle the union type properly.
-  # When schedule is defined, manual should be false.
+  # TODO(https://github.com/airbytehq/airbyte/issues/11432): remove. Prefer the scheduleType and scheduleData properties.
   schedule:
     type: object
     required:
@@ -67,8 +65,50 @@ properties:
       units:
         type: integer
   # When manual is true, schedule should be null, and will be ignored.
+  # TODO(https://github.com/airbytehq/airbyte/issues/11432): remove. Prefer setting the scheduleType property to Manual.
   manual:
     type: boolean
+  # If this property is set to BasicSchedule or Cron, the corresponding field in the scheduleData property should be set.
+  # NOTE: if this is set, it takes precedence over the `manual` property.
+  scheduleType:
+    type: string
+    enum:
+      - Manual
+      - BasicSchedule
+      - Cron
+  scheduleData:
+    type: object
+    additionalProperties: false
+    # Ideally basicSchedule and cron should be a union, but java codegen does not handle the union type properly.
+    properties:
+      # This should be populated when scheduleType is BasicSchedule.
+      basicSchedule:
+        type: object
+        required:
+          - timeUnit
+          - units
+        properties:
+          timeUnit:
+            type: string
+            enum:
+              - minutes
+              - hours
+              - days
+              - weeks
+              - months
+          units:
+            type: integer
+      # This should be populated when scheduleType is Cron.
+      cron:
+        type: object
+        required:
+          - cronExpression
+          - cronTimeZone
+        properties:
+          cronExpression:
+            type: string
+          cronTimeZone:
+            type: string
   source_catalog_id:
     type: string
     format: uuid

--- a/airbyte-config/config-persistence/src/main/java/io/airbyte/config/persistence/DbConverter.java
+++ b/airbyte-config/config-persistence/src/main/java/io/airbyte/config/persistence/DbConverter.java
@@ -20,11 +20,13 @@ import io.airbyte.config.JobSyncConfig.NamespaceDefinitionType;
 import io.airbyte.config.Notification;
 import io.airbyte.config.ResourceRequirements;
 import io.airbyte.config.Schedule;
+import io.airbyte.config.ScheduleData;
 import io.airbyte.config.SourceOAuthParameter;
 import io.airbyte.config.StandardDestinationDefinition;
 import io.airbyte.config.StandardSourceDefinition;
 import io.airbyte.config.StandardSourceDefinition.SourceType;
 import io.airbyte.config.StandardSync;
+import io.airbyte.config.StandardSync.ScheduleType;
 import io.airbyte.config.StandardSync.Status;
 import io.airbyte.config.StandardWorkspace;
 import io.airbyte.config.WorkspaceServiceAccount;
@@ -55,6 +57,10 @@ public class DbConverter {
             record.get(CONNECTION.STATUS) == null ? null : Enums.toEnum(record.get(CONNECTION.STATUS, String.class), Status.class).orElseThrow())
         .withSchedule(Jsons.deserialize(record.get(CONNECTION.SCHEDULE).data(), Schedule.class))
         .withManual(record.get(CONNECTION.MANUAL))
+        .withScheduleType(record.get(CONNECTION.SCHEDULE_TYPE) == null ? null
+            : Enums.toEnum(record.get(CONNECTION.SCHEDULE_TYPE, String.class), ScheduleType.class).orElseThrow())
+        .withScheduleData(
+            record.get(CONNECTION.SCHEDULE_DATA) == null ? null : Jsons.deserialize(record.get(CONNECTION.SCHEDULE_DATA).data(), ScheduleData.class))
         .withOperationIds(connectionOperationId)
         .withResourceRequirements(Jsons.deserialize(record.get(CONNECTION.RESOURCE_REQUIREMENTS).data(), ResourceRequirements.class))
         .withSourceCatalogId(record.get(CONNECTION.SOURCE_CATALOG_ID));

--- a/airbyte-workers/build.gradle
+++ b/airbyte-workers/build.gradle
@@ -18,6 +18,7 @@ dependencies {
     implementation 'org.apache.commons:commons-text:1.9'
     implementation 'org.eclipse.jetty:jetty-server:9.4.31.v20200723'
     implementation 'org.eclipse.jetty:jetty-servlet:9.4.31.v20200723'
+    implementation 'org.quartz-scheduler:quartz:2.3.2'
     implementation libs.flyway.core
 
     implementation project(':airbyte-analytics')

--- a/airbyte-workers/src/main/java/io/airbyte/workers/temporal/scheduling/activities/ConfigFetchActivityImpl.java
+++ b/airbyte-workers/src/main/java/io/airbyte/workers/temporal/scheduling/activities/ConfigFetchActivityImpl.java
@@ -5,7 +5,9 @@
 package io.airbyte.workers.temporal.scheduling.activities;
 
 import io.airbyte.config.Configs;
+import io.airbyte.config.Cron;
 import io.airbyte.config.StandardSync;
+import io.airbyte.config.StandardSync.ScheduleType;
 import io.airbyte.config.StandardSync.Status;
 import io.airbyte.config.helpers.ScheduleHelpers;
 import io.airbyte.config.persistence.ConfigNotFoundException;
@@ -15,15 +17,25 @@ import io.airbyte.scheduler.persistence.JobPersistence;
 import io.airbyte.validation.json.JsonValidationException;
 import io.airbyte.workers.temporal.exception.RetryableException;
 import java.io.IOException;
+import java.text.ParseException;
+import java.time.DateTimeException;
 import java.time.Duration;
+import java.util.Date;
 import java.util.Optional;
+import java.util.TimeZone;
+import java.util.UUID;
 import java.util.function.Supplier;
 import lombok.AllArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
+import org.joda.time.DateTimeZone;
+import org.quartz.CronExpression;
 
 @AllArgsConstructor
 @Slf4j
 public class ConfigFetchActivityImpl implements ConfigFetchActivity {
+
+  private final static long MS_PER_SECOND = 1000L;
+  private final static long MIN_CRON_INTERVAL_SECONDS = 60;
 
   private ConfigRepository configRepository;
   private JobPersistence jobPersistence;
@@ -35,30 +47,99 @@ public class ConfigFetchActivityImpl implements ConfigFetchActivity {
     try {
       final StandardSync standardSync = configRepository.getStandardSync(input.getConnectionId());
 
-      if (standardSync.getSchedule() == null || standardSync.getStatus() != Status.ACTIVE) {
-        // Manual syncs wait for their first run
-        return new ScheduleRetrieverOutput(Duration.ofDays(100 * 365));
+      if (standardSync.getScheduleType() != null) {
+        return this.getTimeToWaitFromScheduleType(standardSync, input.getConnectionId());
       }
-
-      final Optional<Job> previousJobOptional = jobPersistence.getLastReplicationJob(input.getConnectionId());
-
-      if (previousJobOptional.isEmpty() && standardSync.getSchedule() != null) {
-        // Non-manual syncs don't wait for their first run
-        return new ScheduleRetrieverOutput(Duration.ZERO);
-      }
-
-      final Job previousJob = previousJobOptional.get();
-      final long prevRunStart = previousJob.getStartedAtInSecond().orElse(previousJob.getCreatedAtInSecond());
-
-      final long nextRunStart = prevRunStart + ScheduleHelpers.getIntervalInSecond(standardSync.getSchedule());
-
-      final Duration timeToWait = Duration.ofSeconds(
-          Math.max(0, nextRunStart - currentSecondsSupplier.get()));
-
-      return new ScheduleRetrieverOutput(timeToWait);
+      return this.getTimeToWaitFromLegacy(standardSync, input.getConnectionId());
     } catch (final IOException | JsonValidationException | ConfigNotFoundException e) {
       throw new RetryableException(e);
     }
+  }
+
+  /**
+   * @param standardSync
+   * @param connectionId
+   * @return
+   * @throws IOException
+   *
+   *         This method consumes the `scheduleType` and `scheduleData` fields.
+   */
+  private ScheduleRetrieverOutput getTimeToWaitFromScheduleType(final StandardSync standardSync, UUID connectionId) throws IOException {
+    if (standardSync.getScheduleType() == ScheduleType.MANUAL || standardSync.getStatus() != Status.ACTIVE) {
+      // Manual syncs wait for their first run
+      return new ScheduleRetrieverOutput(Duration.ofDays(100 * 365));
+    }
+
+    final Optional<Job> previousJobOptional = jobPersistence.getLastReplicationJob(connectionId);
+
+    if (standardSync.getScheduleType() == ScheduleType.BASIC_SCHEDULE) {
+      if (previousJobOptional.isEmpty()) {
+        // Basic schedules don't wait for their first run.
+        return new ScheduleRetrieverOutput(Duration.ZERO);
+      }
+      final Job previousJob = previousJobOptional.get();
+      final long prevRunStart = previousJob.getStartedAtInSecond().orElse(previousJob.getCreatedAtInSecond());
+      final long nextRunStart = prevRunStart + ScheduleHelpers.getIntervalInSecond(standardSync.getScheduleData().getBasicSchedule());
+      final Duration timeToWait = Duration.ofSeconds(
+          Math.max(0, nextRunStart - currentSecondsSupplier.get()));
+      return new ScheduleRetrieverOutput(timeToWait);
+    }
+
+    else { // standardSync.getScheduleType() == ScheduleType.CRON
+      final Cron scheduleCron = standardSync.getScheduleData().getCron();
+      final TimeZone timeZone = DateTimeZone.forID(scheduleCron.getCronTimeZone()).toTimeZone();
+      try {
+        final CronExpression cronExpression = new CronExpression(scheduleCron.getCronExpression());
+        cronExpression.setTimeZone(timeZone);
+        // Ensure that at least a minimum interval -- one minute -- passes between executions. This prevents
+        // us from multiple executions for the same scheduled time, since cron only has a 1-minute
+        // resolution.
+        final long earliestNextRun = Math.max(currentSecondsSupplier.get() * MS_PER_SECOND,
+            (previousJobOptional.isPresent()
+                ? previousJobOptional.get().getStartedAtInSecond().orElse(previousJobOptional.get().getCreatedAtInSecond())
+                    + MIN_CRON_INTERVAL_SECONDS
+                : currentSecondsSupplier.get()) * MS_PER_SECOND);
+        final Date nextRunStart = cronExpression.getNextValidTimeAfter(new Date(earliestNextRun));
+        final Duration timeToWait = Duration.ofSeconds(
+            Math.max(0, nextRunStart.getTime() / MS_PER_SECOND - currentSecondsSupplier.get()));
+        return new ScheduleRetrieverOutput(timeToWait);
+      } catch (ParseException e) {
+        throw (DateTimeException) new DateTimeException(e.getMessage()).initCause(e);
+      }
+    }
+  }
+
+  /**
+   * @param standardSync
+   * @param connectionId
+   * @return
+   * @throws IOException
+   *
+   *         This method consumes the `schedule` field.
+   */
+  private ScheduleRetrieverOutput getTimeToWaitFromLegacy(final StandardSync standardSync, UUID connectionId) throws IOException {
+    if (standardSync.getSchedule() == null || standardSync.getStatus() != Status.ACTIVE) {
+      // Manual syncs wait for their first run
+      return new ScheduleRetrieverOutput(Duration.ofDays(100 * 365));
+    }
+
+    final Optional<Job> previousJobOptional = jobPersistence.getLastReplicationJob(connectionId);
+
+    if (previousJobOptional.isEmpty() && standardSync.getSchedule() != null) {
+      // Non-manual syncs don't wait for their first run
+      return new ScheduleRetrieverOutput(Duration.ZERO);
+    }
+
+    final Job previousJob = previousJobOptional.get();
+    final long prevRunStart = previousJob.getStartedAtInSecond().orElse(previousJob.getCreatedAtInSecond());
+
+    final long nextRunStart = prevRunStart + ScheduleHelpers.getIntervalInSecond(standardSync.getSchedule());
+
+    final Duration timeToWait = Duration.ofSeconds(
+        Math.max(0, nextRunStart - currentSecondsSupplier.get()));
+
+    return new ScheduleRetrieverOutput(timeToWait);
+
   }
 
   @Override

--- a/airbyte-workers/src/test/java/io/airbyte/workers/temporal/scheduling/activities/ConfigFetchActivityTest.java
+++ b/airbyte-workers/src/test/java/io/airbyte/workers/temporal/scheduling/activities/ConfigFetchActivityTest.java
@@ -4,10 +4,13 @@
 
 package io.airbyte.workers.temporal.scheduling.activities;
 
+import io.airbyte.config.BasicSchedule;
 import io.airbyte.config.Configs;
+import io.airbyte.config.Cron;
 import io.airbyte.config.Schedule;
-import io.airbyte.config.Schedule.TimeUnit;
+import io.airbyte.config.ScheduleData;
 import io.airbyte.config.StandardSync;
+import io.airbyte.config.StandardSync.ScheduleType;
 import io.airbyte.config.StandardSync.Status;
 import io.airbyte.config.persistence.ConfigNotFoundException;
 import io.airbyte.config.persistence.ConfigRepository;
@@ -18,7 +21,9 @@ import io.airbyte.workers.temporal.scheduling.activities.ConfigFetchActivity.Sch
 import io.airbyte.workers.temporal.scheduling.activities.ConfigFetchActivity.ScheduleRetrieverOutput;
 import java.io.IOException;
 import java.time.Instant;
+import java.util.Calendar;
 import java.util.Optional;
+import java.util.TimeZone;
 import java.util.UUID;
 import org.assertj.core.api.Assertions;
 import org.junit.jupiter.api.DisplayName;
@@ -47,21 +52,41 @@ class ConfigFetchActivityTest {
   private ConfigFetchActivity configFetchActivity;
 
   private final static UUID connectionId = UUID.randomUUID();
-  private final static StandardSync standardSyncWithSchedule = new StandardSync()
+  private final static StandardSync standardSyncWithLegacySchedule = new StandardSync()
       .withSchedule(new Schedule()
-          .withTimeUnit(TimeUnit.MINUTES)
+          .withTimeUnit(Schedule.TimeUnit.MINUTES)
           .withUnits(5L))
       .withStatus(Status.ACTIVE);
 
+  private final static StandardSync standardSyncWithManualScheduleType = new StandardSync()
+      .withScheduleType(ScheduleType.MANUAL)
+      .withStatus(Status.ACTIVE);
+
+  private final static StandardSync standardSyncWithBasicScheduleType = new StandardSync()
+      .withScheduleType(ScheduleType.BASIC_SCHEDULE)
+      .withStatus(Status.ACTIVE)
+      .withScheduleData(new ScheduleData()
+          .withBasicSchedule(new BasicSchedule()
+              .withTimeUnit(BasicSchedule.TimeUnit.MINUTES)
+              .withUnits(5L)));
+
+  private final static StandardSync standardSyncWithCronScheduleType = new StandardSync()
+      .withScheduleType(ScheduleType.CRON)
+      .withStatus(Status.ACTIVE)
+      .withScheduleData(new ScheduleData()
+          .withCron(new Cron()
+              .withCronExpression("0 0 12 * * ?")
+              .withCronTimeZone("UTC")));
+
   private final static StandardSync standardSyncWithScheduleDisable = new StandardSync()
       .withSchedule(new Schedule()
-          .withTimeUnit(TimeUnit.MINUTES)
+          .withTimeUnit(Schedule.TimeUnit.MINUTES)
           .withUnits(5L))
       .withStatus(Status.INACTIVE);
 
   private final static StandardSync standardSyncWithScheduleDeleted = new StandardSync()
       .withSchedule(new Schedule()
-          .withTimeUnit(TimeUnit.MINUTES)
+          .withTimeUnit(Schedule.TimeUnit.MINUTES)
           .withUnits(5L))
       .withStatus(Status.DEPRECATED);
   private static final StandardSync standardSyncWithoutSchedule = new StandardSync();
@@ -70,14 +95,14 @@ class ConfigFetchActivityTest {
   class TimeToWaitTest {
 
     @Test
-    @DisplayName("Test that the job get scheduled if it is not manual and if it is the first run")
+    @DisplayName("Test that the job gets scheduled if it is not manual and if it is the first run with legacy schedule schema")
     void testFirstJobNonManual() throws IOException, JsonValidationException, ConfigNotFoundException {
       configFetchActivity = new ConfigFetchActivityImpl(mConfigRepository, mJobPersistence, mConfigs, () -> Instant.now().getEpochSecond());
       Mockito.when(mJobPersistence.getLastReplicationJob(connectionId))
           .thenReturn(Optional.empty());
 
       Mockito.when(mConfigRepository.getStandardSync(connectionId))
-          .thenReturn(standardSyncWithSchedule);
+          .thenReturn(standardSyncWithLegacySchedule);
 
       final ScheduleRetrieverInput input = new ScheduleRetrieverInput(connectionId);
 
@@ -88,7 +113,7 @@ class ConfigFetchActivityTest {
     }
 
     @Test
-    @DisplayName("Test that the job will wait for a long time if it is manual")
+    @DisplayName("Test that the job will wait for a long time if it is manual in the legacy schedule schema")
     void testManual() throws IOException, JsonValidationException, ConfigNotFoundException {
       configFetchActivity = new ConfigFetchActivityImpl(mConfigRepository, mJobPersistence, mConfigs, () -> Instant.now().getEpochSecond());
 
@@ -136,7 +161,7 @@ class ConfigFetchActivityTest {
     }
 
     @Test
-    @DisplayName("Test we will wait the required amount of time")
+    @DisplayName("Test we will wait the required amount of time with legacy config")
     void testWait() throws IOException, JsonValidationException, ConfigNotFoundException {
       configFetchActivity = new ConfigFetchActivityImpl(mConfigRepository, mJobPersistence, mConfigs, () -> 60L * 3);
 
@@ -147,7 +172,7 @@ class ConfigFetchActivityTest {
           .thenReturn(Optional.of(mJob));
 
       Mockito.when(mConfigRepository.getStandardSync(connectionId))
-          .thenReturn(standardSyncWithSchedule);
+          .thenReturn(standardSyncWithLegacySchedule);
 
       final ScheduleRetrieverInput input = new ScheduleRetrieverInput(connectionId);
 
@@ -158,7 +183,7 @@ class ConfigFetchActivityTest {
     }
 
     @Test
-    @DisplayName("Test we will not wait if we are late")
+    @DisplayName("Test we will not wait if we are late in the legacy schedule schema")
     void testNotWaitIfLate() throws IOException, JsonValidationException, ConfigNotFoundException {
       configFetchActivity = new ConfigFetchActivityImpl(mConfigRepository, mJobPersistence, mConfigs, () -> 60L * 10);
 
@@ -169,7 +194,7 @@ class ConfigFetchActivityTest {
           .thenReturn(Optional.of(mJob));
 
       Mockito.when(mConfigRepository.getStandardSync(connectionId))
-          .thenReturn(standardSyncWithSchedule);
+          .thenReturn(standardSyncWithLegacySchedule);
 
       final ScheduleRetrieverInput input = new ScheduleRetrieverInput(connectionId);
 
@@ -179,6 +204,111 @@ class ConfigFetchActivityTest {
           .isZero();
     }
 
+  }
+
+  @Test
+  @DisplayName("Test that the job will wait a long time if it is MANUAL scheduleType")
+  void testManualScheduleType() throws IOException, JsonValidationException, ConfigNotFoundException {
+    configFetchActivity = new ConfigFetchActivityImpl(mConfigRepository, mJobPersistence, mConfigs, () -> Instant.now().getEpochSecond());
+
+    Mockito.when(mConfigRepository.getStandardSync(connectionId))
+        .thenReturn(standardSyncWithManualScheduleType);
+
+    final ScheduleRetrieverInput input = new ScheduleRetrieverInput(connectionId);
+
+    final ScheduleRetrieverOutput output = configFetchActivity.getTimeToWait(input);
+
+    Assertions.assertThat(output.getTimeToWait())
+        .hasDays(100 * 365);
+  }
+
+  @Test
+  @DisplayName("Test that the job will be immediately scheduled if it is a BASIC_SCHEDULE type on the first run")
+  void testBasicScheduleTypeFirstRun() throws IOException, JsonValidationException, ConfigNotFoundException {
+    configFetchActivity = new ConfigFetchActivityImpl(mConfigRepository, mJobPersistence, mConfigs, () -> Instant.now().getEpochSecond());
+    Mockito.when(mJobPersistence.getLastReplicationJob(connectionId))
+        .thenReturn(Optional.empty());
+
+    Mockito.when(mConfigRepository.getStandardSync(connectionId))
+        .thenReturn(standardSyncWithBasicScheduleType);
+
+    final ScheduleRetrieverInput input = new ScheduleRetrieverInput(connectionId);
+
+    final ScheduleRetrieverOutput output = configFetchActivity.getTimeToWait(input);
+
+    Assertions.assertThat(output.getTimeToWait())
+        .isZero();
+  }
+
+  @Test
+  @DisplayName("Test that we will wait the required amount of time with a BASIC_SCHEDULE type on a subsequent run")
+  void testBasicScheduleSubsequentRun() throws IOException, JsonValidationException, ConfigNotFoundException {
+    configFetchActivity = new ConfigFetchActivityImpl(mConfigRepository, mJobPersistence, mConfigs, () -> 60L * 3);
+
+    Mockito.when(mJob.getStartedAtInSecond())
+        .thenReturn(Optional.of(60L));
+
+    Mockito.when(mJobPersistence.getLastReplicationJob(connectionId))
+        .thenReturn(Optional.of(mJob));
+
+    Mockito.when(mConfigRepository.getStandardSync(connectionId))
+        .thenReturn(standardSyncWithBasicScheduleType);
+
+    final ScheduleRetrieverInput input = new ScheduleRetrieverInput(connectionId);
+
+    final ScheduleRetrieverOutput output = configFetchActivity.getTimeToWait(input);
+
+    Assertions.assertThat(output.getTimeToWait())
+        .hasMinutes(3);
+  }
+
+  @Test
+  @DisplayName("Test that the job will wait to be scheduled if it is a CRON type")
+  void testCronScheduleSubsequentRun() throws IOException, JsonValidationException, ConfigNotFoundException {
+    Calendar mockRightNow = Calendar.getInstance(TimeZone.getTimeZone("UTC"));
+    mockRightNow.set(Calendar.HOUR_OF_DAY, 0);
+    mockRightNow.set(Calendar.MINUTE, 0);
+    mockRightNow.set(Calendar.SECOND, 0);
+    mockRightNow.set(Calendar.MILLISECOND, 0);
+    configFetchActivity = new ConfigFetchActivityImpl(mConfigRepository, mJobPersistence, mConfigs, () -> mockRightNow.getTimeInMillis() / 1000L);
+
+    Mockito.when(mJobPersistence.getLastReplicationJob(connectionId))
+        .thenReturn(Optional.of(mJob));
+
+    Mockito.when(mConfigRepository.getStandardSync(connectionId))
+        .thenReturn(standardSyncWithCronScheduleType);
+
+    final ScheduleRetrieverInput input = new ScheduleRetrieverInput(connectionId);
+
+    final ScheduleRetrieverOutput output = configFetchActivity.getTimeToWait(input);
+
+    Assertions.assertThat(output.getTimeToWait())
+        .hasHours(12);
+  }
+
+  @Test
+  @DisplayName("Test that the job will only be scheduled once per minimum cron interval")
+  void testCronScheduleMinimumInterval() throws IOException, JsonValidationException, ConfigNotFoundException {
+    Calendar mockRightNow = Calendar.getInstance(TimeZone.getTimeZone("UTC"));
+    mockRightNow.set(Calendar.HOUR_OF_DAY, 12);
+    mockRightNow.set(Calendar.MINUTE, 0);
+    mockRightNow.set(Calendar.SECOND, 0);
+    mockRightNow.set(Calendar.MILLISECOND, 0);
+    configFetchActivity = new ConfigFetchActivityImpl(mConfigRepository, mJobPersistence, mConfigs, () -> mockRightNow.getTimeInMillis() / 1000L);
+
+    Mockito.when(mJob.getStartedAtInSecond()).thenReturn(Optional.of(mockRightNow.getTimeInMillis() / 1000L));
+    Mockito.when(mJobPersistence.getLastReplicationJob(connectionId))
+        .thenReturn(Optional.of(mJob));
+
+    Mockito.when(mConfigRepository.getStandardSync(connectionId))
+        .thenReturn(standardSyncWithCronScheduleType);
+
+    final ScheduleRetrieverInput input = new ScheduleRetrieverInput(connectionId);
+
+    final ScheduleRetrieverOutput output = configFetchActivity.getTimeToWait(input);
+
+    Assertions.assertThat(output.getTimeToWait())
+        .hasHours(24);
   }
 
   @Nested

--- a/deps.toml
+++ b/deps.toml
@@ -86,6 +86,7 @@ otel-bom = {module = "io.opentelemetry:opentelemetry-bom", version = "1.14.0"}
 otel-semconv = {module = "io.opentelemetry:opentelemetry-semconv", version = "1.14.0-alpha"}
 otel-sdk = {module = "io.opentelemetry:opentelemetry-sdk-metrics", version = "1.14.0"}
 otel-sdk-testing = {module = "io.opentelemetry:opentelemetry-sdk-metrics-testing", version = "1.13.0-alpha"}
+quartz-scheduler = {module="org.quartz-scheduler:quartz", version = "2.3.2"}
 
 [bundles]
 jackson = ["jackson-databind", "jackson-annotations", "jackson-dataformat", "jackson-datatype"]


### PR DESCRIPTION
## What
Support cron strings in the temporal workflow scheduling.

Related to https://github.com/airbytehq/airbyte/issues/11419 - a subsequent PR will dual write in the persistence layer.

## How
- Add support for cronstrings in the StandardSync schema
- Consume the new schema if populated in the temporal worker scheduling

## Recommended reading order
1. `airbyte-config/config-models/src/main/resources/types/StandardSync.yaml`
2. `airbyte-workers/src/main/java/io/airbyte/workers/temporal/scheduling/activities/ConfigFetchActivityImpl.java`

## 🚨 User Impact 🚨
None

## Pre-merge Checklist
Expand the relevant checklist and delete the others.

## Tests

<details><summary><strong>Unit</strong></summary>

*Put your unit tests output here.*

Introduced new unit tests for ConfigFetchActivityImpl.
