### PR TITLE
cdk and docs: remove `"additionalProperties"`

### DIFF
--- a/airbyte-cdk/python/docs/tutorials/cdk-tutorial-any-percent/cdk-speedrun.md
+++ b/airbyte-cdk/python/docs/tutorials/cdk-tutorial-any-percent/cdk-speedrun.md
@@ -42,7 +42,6 @@ We're working with the Exchange Rates API, so we need to define our input schema
     "title": "Python Http Tutorial Spec",
     "type": "object",
     "required": ["start_date", "currency_base"],
-    "additionalProperties": true,
     "properties": {
       "start_date": {
         "type": "string",

--- a/airbyte-cdk/python/docs/tutorials/cdk-tutorial-any-percent/cdk-speedrun.md
+++ b/airbyte-cdk/python/docs/tutorials/cdk-tutorial-any-percent/cdk-speedrun.md
@@ -42,7 +42,7 @@ We're working with the Exchange Rates API, so we need to define our input schema
     "title": "Python Http Tutorial Spec",
     "type": "object",
     "required": ["start_date", "currency_base"],
-    "additionalProperties": false,
+    "additionalProperties": true,
     "properties": {
       "start_date": {
         "type": "string",

--- a/airbyte-cdk/python/docs/tutorials/cdk-tutorial-python-http/2-install-dependencies.md
+++ b/airbyte-cdk/python/docs/tutorials/cdk-tutorial-python-http/2-install-dependencies.md
@@ -20,7 +20,7 @@ python main.py spec
 You should see some output:
 
 ```text
-{"type": "SPEC", "spec": {"documentationUrl": "https://docsurl.com", "connectionSpecification": {"$schema": "http://json-schema.org/draft-07/schema#", "title": "Python Http Tutorial Spec", "type": "object", "required": ["TODO"], "additionalProperties": false, "properties": {"TODO: This schema defines the configuration required for the source. This usually involves metadata such as database and/or authentication information.": {"type": "string", "description": "describe me"}}}}}
+{"type": "SPEC", "spec": {"documentationUrl": "https://docsurl.com", "connectionSpecification": {"$schema": "http://json-schema.org/draft-07/schema#", "title": "Python Http Tutorial Spec", "type": "object", "required": ["TODO"], "properties": {"TODO: This schema defines the configuration required for the source. This usually involves metadata such as database and/or authentication information.": {"type": "string", "description": "describe me"}}}}}
 ```
 
 We just ran Airbyte Protocol's `spec` command! We'll talk more about this later, but this is a simple sanity check to make sure everything is wired up correctly.

--- a/airbyte-cdk/python/docs/tutorials/cdk-tutorial-python-http/3-define-inputs.md
+++ b/airbyte-cdk/python/docs/tutorials/cdk-tutorial-python-http/3-define-inputs.md
@@ -18,7 +18,6 @@ Given that we'll pulling currency data for our example source, we'll define the 
     "title": "Python Http Tutorial Spec",
     "type": "object",
     "required": ["start_date", "currency_base"],
-    "additionalProperties": true,
     "properties": {
       "start_date": {
         "type": "string",

--- a/airbyte-cdk/python/docs/tutorials/cdk-tutorial-python-http/3-define-inputs.md
+++ b/airbyte-cdk/python/docs/tutorials/cdk-tutorial-python-http/3-define-inputs.md
@@ -18,7 +18,7 @@ Given that we'll pulling currency data for our example source, we'll define the 
     "title": "Python Http Tutorial Spec",
     "type": "object",
     "required": ["start_date", "currency_base"],
-    "additionalProperties": false,
+    "additionalProperties": true,
     "properties": {
       "start_date": {
         "type": "string",

--- a/airbyte-cdk/python/docs/tutorials/http_api_source.md
+++ b/airbyte-cdk/python/docs/tutorials/http_api_source.md
@@ -60,7 +60,7 @@ python main_dev.py spec
 
 You should see some output:
 ```
-{"type": "SPEC", "spec": {"documentationUrl": "https://docsurl.com", "connectionSpecification": {"$schema": "http://json-schema.org/draft-07/schema#", "title": "Python Http Tutorial Spec", "type": "object", "required": ["TODO"], "additionalProperties": true, "properties": {"TODO: This schema defines the configuration required for the source. This usually involves metadata such as database and/or authentication information.": {"type": "string", "description": "describe me"}}}}}
+{"type": "SPEC", "spec": {"documentationUrl": "https://docsurl.com", "connectionSpecification": {"$schema": "http://json-schema.org/draft-07/schema#", "title": "Python Http Tutorial Spec", "type": "object", "required": ["TODO"], "properties": {"TODO: This schema defines the configuration required for the source. This usually involves metadata such as database and/or authentication information.": {"type": "string", "description": "describe me"}}}}}
 ```
 
 We just ran Airbyte Protocol's `spec` command! We'll talk more about this later, but this is a simple sanity check to make sure everything is wired up correctly.
@@ -133,7 +133,6 @@ Given that we'll pulling currency data for our example source, we'll define the 
     "title": "Python Http Tutorial Spec",
     "type": "object",
     "required": ["start_date", "currency_base"],
-    "additionalProperties": true,
     "properties": {
       "start_date": {
         "type": "string",

--- a/airbyte-cdk/python/docs/tutorials/http_api_source.md
+++ b/airbyte-cdk/python/docs/tutorials/http_api_source.md
@@ -60,7 +60,7 @@ python main_dev.py spec
 
 You should see some output:
 ```
-{"type": "SPEC", "spec": {"documentationUrl": "https://docsurl.com", "connectionSpecification": {"$schema": "http://json-schema.org/draft-07/schema#", "title": "Python Http Tutorial Spec", "type": "object", "required": ["TODO"], "additionalProperties": false, "properties": {"TODO: This schema defines the configuration required for the source. This usually involves metadata such as database and/or authentication information.": {"type": "string", "description": "describe me"}}}}}
+{"type": "SPEC", "spec": {"documentationUrl": "https://docsurl.com", "connectionSpecification": {"$schema": "http://json-schema.org/draft-07/schema#", "title": "Python Http Tutorial Spec", "type": "object", "required": ["TODO"], "additionalProperties": true, "properties": {"TODO: This schema defines the configuration required for the source. This usually involves metadata such as database and/or authentication information.": {"type": "string", "description": "describe me"}}}}}
 ```
 
 We just ran Airbyte Protocol's `spec` command! We'll talk more about this later, but this is a simple sanity check to make sure everything is wired up correctly.
@@ -133,7 +133,7 @@ Given that we'll pulling currency data for our example source, we'll define the 
     "title": "Python Http Tutorial Spec",
     "type": "object",
     "required": ["start_date", "currency_base"],
-    "additionalProperties": false,
+    "additionalProperties": true,
     "properties": {
       "start_date": {
         "type": "string",

--- a/airbyte-integrations/connector-templates/destination-java/spec.json.hbs
+++ b/airbyte-integrations/connector-templates/destination-java/spec.json.hbs
@@ -9,7 +9,7 @@
     "required": [
       "TODO"
     ],
-    "additionalProperties": false,
+    "additionalProperties": true,
     "properties": {
       "TODO_sample_field": {
         "title": "Sample Field",

--- a/airbyte-integrations/connector-templates/destination-java/spec.json.hbs
+++ b/airbyte-integrations/connector-templates/destination-java/spec.json.hbs
@@ -9,7 +9,6 @@
     "required": [
       "TODO"
     ],
-    "additionalProperties": true,
     "properties": {
       "TODO_sample_field": {
         "title": "Sample Field",

--- a/airbyte-integrations/connector-templates/source-java-jdbc/src/main/resources/spec.json.hbs
+++ b/airbyte-integrations/connector-templates/source-java-jdbc/src/main/resources/spec.json.hbs
@@ -5,7 +5,7 @@
     "title": "{{pascalCase name}} Source Spec",
     "type": "object",
     "required": ["host", "port", "database", "username", "replication_method"],
-    "additionalProperties": false,
+    "additionalProperties": true,
     "properties": {
       "host": {
         "description": "Hostname of the database.",

--- a/airbyte-integrations/connector-templates/source-java-jdbc/src/main/resources/spec.json.hbs
+++ b/airbyte-integrations/connector-templates/source-java-jdbc/src/main/resources/spec.json.hbs
@@ -7,11 +7,13 @@
     "required": ["host", "port", "database", "username", "replication_method"],
     "properties": {
       "host": {
+        "title": "Host",
         "description": "Hostname of the database.",
         "type": "string",
         "order": 0
       },
       "port": {
+        "title": "Port",
         "description": "Port of the database.",
         "type": "integer",
         "minimum": 0,
@@ -21,27 +23,32 @@
         "order": 1
       },
       "database": {
+        "title": "Database",
         "description": "Name of the database.",
         "type": "string",
         "order": 2
       },
       "username": {
+        "title": "Username",
         "description": "Username to use to access the database.",
         "type": "string",
         "order": 3
       },
       "password": {
+        "title": "Password",
         "description": "Password associated with the username.",
         "type": "string",
         "airbyte_secret": true,
         "order": 4
       },
       "jdbc_url_params": {
+        "title": "JDBC URL params",
         "description": "Additional properties to pass to the JDBC URL string when connecting to the database formatted as 'key=value' pairs separated by the symbol '&'. (example: key1=value1&key2=value2&key3=value3)",
         "type": "string",
         "order": 5
       },
       "replication_method": {
+        "title": "Replication method",
         "type": "string",
         "title": "Replication Method",
         "description": "Replication method to use for extracting data from the database. STANDARD replication requires no setup on the DB side but will not be able to represent deletions incrementally. CDC uses the Binlog to detect inserts, updates, and deletes. This needs to be configured on the source database itself.",

--- a/airbyte-integrations/connector-templates/source-java-jdbc/src/main/resources/spec.json.hbs
+++ b/airbyte-integrations/connector-templates/source-java-jdbc/src/main/resources/spec.json.hbs
@@ -49,9 +49,8 @@
       },
       "replication_method": {
         "title": "Replication method",
-        "type": "string",
-        "title": "Replication Method",
         "description": "Replication method to use for extracting data from the database. STANDARD replication requires no setup on the DB side but will not be able to represent deletions incrementally. CDC uses the Binlog to detect inserts, updates, and deletes. This needs to be configured on the source database itself.",
+        "type": "string",
         "order": 6,
         "default": "STANDARD",
         "enum": ["STANDARD", "CDC"]

--- a/airbyte-integrations/connector-templates/source-java-jdbc/src/main/resources/spec.json.hbs
+++ b/airbyte-integrations/connector-templates/source-java-jdbc/src/main/resources/spec.json.hbs
@@ -5,7 +5,6 @@
     "title": "{{pascalCase name}} Source Spec",
     "type": "object",
     "required": ["host", "port", "database", "username", "replication_method"],
-    "additionalProperties": true,
     "properties": {
       "host": {
         "description": "Hostname of the database.",

--- a/airbyte-integrations/connector-templates/source-python-http-api/source_{{snakeCase name}}/spec.yaml.hbs
+++ b/airbyte-integrations/connector-templates/source-python-http-api/source_{{snakeCase name}}/spec.yaml.hbs
@@ -5,7 +5,6 @@ connectionSpecification:
   type: object
   required:
     - TODO
-  additionalProperties: true
   properties:
     # 'TODO: This schema defines the configuration required for the source. This usually involves metadata such as database and/or authentication information.':
     TODO:

--- a/airbyte-integrations/connector-templates/source-python-http-api/source_{{snakeCase name}}/spec.yaml.hbs
+++ b/airbyte-integrations/connector-templates/source-python-http-api/source_{{snakeCase name}}/spec.yaml.hbs
@@ -5,7 +5,7 @@ connectionSpecification:
   type: object
   required:
     - TODO
-  additionalProperties: false
+  additionalProperties: true
   properties:
     # 'TODO: This schema defines the configuration required for the source. This usually involves metadata such as database and/or authentication information.':
     TODO:

--- a/airbyte-integrations/connector-templates/source-python/source_{{snakeCase name}}/spec.yaml.hbs
+++ b/airbyte-integrations/connector-templates/source-python/source_{{snakeCase name}}/spec.yaml.hbs
@@ -5,7 +5,6 @@ connectionSpecification:
   type: object
   required:
     - fix-me
-  additionalProperties: true
   properties:
     fix-me:
       type: string

--- a/airbyte-integrations/connector-templates/source-python/source_{{snakeCase name}}/spec.yaml.hbs
+++ b/airbyte-integrations/connector-templates/source-python/source_{{snakeCase name}}/spec.yaml.hbs
@@ -5,7 +5,7 @@ connectionSpecification:
   type: object
   required:
     - fix-me
-  additionalProperties: false
+  additionalProperties: true
   properties:
     fix-me:
       type: string

--- a/airbyte-integrations/connector-templates/source-singer/source_{{snakeCase name}}_singer/spec.yaml.hbs
+++ b/airbyte-integrations/connector-templates/source-singer/source_{{snakeCase name}}_singer/spec.yaml.hbs
@@ -5,7 +5,6 @@ connectionSpecification:
   type: object
   required:
     - TODO
-  additionalProperties: true
   properties:
     # TODO -- add all the properties required to configure this tap e.g: username, password, api token, etc.
     TODO:

--- a/airbyte-integrations/connectors/source-scaffold-java-jdbc/src/main/resources/spec.json
+++ b/airbyte-integrations/connectors/source-scaffold-java-jdbc/src/main/resources/spec.json
@@ -49,9 +49,8 @@
       },
       "replication_method": {
         "title": "Replication method",
-        "type": "string",
-        "title": "Replication Method",
         "description": "Replication method to use for extracting data from the database. STANDARD replication requires no setup on the DB side but will not be able to represent deletions incrementally. CDC uses the Binlog to detect inserts, updates, and deletes. This needs to be configured on the source database itself.",
+        "type": "string",
         "order": 6,
         "default": "STANDARD",
         "enum": ["STANDARD", "CDC"]

--- a/airbyte-integrations/connectors/source-scaffold-java-jdbc/src/main/resources/spec.json
+++ b/airbyte-integrations/connectors/source-scaffold-java-jdbc/src/main/resources/spec.json
@@ -5,14 +5,15 @@
     "title": "ScaffoldJavaJdbc Source Spec",
     "type": "object",
     "required": ["host", "port", "database", "username", "replication_method"],
-    "additionalProperties": false,
     "properties": {
       "host": {
+        "title": "Host",
         "description": "Hostname of the database.",
         "type": "string",
         "order": 0
       },
       "port": {
+        "title": "Port",
         "description": "Port of the database.",
         "type": "integer",
         "minimum": 0,
@@ -22,27 +23,32 @@
         "order": 1
       },
       "database": {
+        "title": "Database",
         "description": "Name of the database.",
         "type": "string",
         "order": 2
       },
       "username": {
+        "title": "Username",
         "description": "Username to use to access the database.",
         "type": "string",
         "order": 3
       },
       "password": {
+        "title": "Password",
         "description": "Password associated with the username.",
         "type": "string",
         "airbyte_secret": true,
         "order": 4
       },
       "jdbc_url_params": {
+        "title": "JDBC URL params",
         "description": "Additional properties to pass to the JDBC URL string when connecting to the database formatted as 'key=value' pairs separated by the symbol '&'. (example: key1=value1&key2=value2&key3=value3)",
         "type": "string",
         "order": 5
       },
       "replication_method": {
+        "title": "Replication method",
         "type": "string",
         "title": "Replication Method",
         "description": "Replication method to use for extracting data from the database. STANDARD replication requires no setup on the DB side but will not be able to represent deletions incrementally. CDC uses the Binlog to detect inserts, updates, and deletes. This needs to be configured on the source database itself.",

--- a/airbyte-integrations/connectors/source-scaffold-source-http/source_scaffold_source_http/spec.yaml
+++ b/airbyte-integrations/connectors/source-scaffold-source-http/source_scaffold_source_http/spec.yaml
@@ -5,7 +5,6 @@ connectionSpecification:
   type: object
   required:
     - TODO
-  additionalProperties: false
   properties:
     # 'TODO: This schema defines the configuration required for the source. This usually involves metadata such as database and/or authentication information.':
     TODO:

--- a/airbyte-integrations/connectors/source-scaffold-source-python/source_scaffold_source_python/spec.yaml
+++ b/airbyte-integrations/connectors/source-scaffold-source-python/source_scaffold_source_python/spec.yaml
@@ -5,7 +5,6 @@ connectionSpecification:
   type: object
   required:
     - fix-me
-  additionalProperties: false
   properties:
     fix-me:
       type: string

--- a/airbyte-webapp/docs/HowTo-ConnectionSpecification.md
+++ b/airbyte-webapp/docs/HowTo-ConnectionSpecification.md
@@ -11,7 +11,6 @@ e.g.
     "title": "BigQuery Destination Spec",
     "type": "object",
     "required": ["project_id", "dataset_id"],
-    "additionalProperties": true,
     "properties": {
       "project_id": {
         "type": "string",

--- a/docs/connector-development/connector-specification-reference.md
+++ b/docs/connector-development/connector-specification-reference.md
@@ -127,7 +127,7 @@ In each item in the `oneOf` array, the `option_title` string field exists with t
     "$schema": "http://json-schema.org/draft-07/schema#",
     "title": "File Source Spec",
     "type": "object",
-    "additionalProperties": false,
+    "additionalProperties": true,
     "required": ["dataset_name", "format", "url", "provider"],
     "properties": {
       "dataset_name": {

--- a/docs/connector-development/connector-specification-reference.md
+++ b/docs/connector-development/connector-specification-reference.md
@@ -127,7 +127,6 @@ In each item in the `oneOf` array, the `option_title` string field exists with t
     "$schema": "http://json-schema.org/draft-07/schema#",
     "title": "File Source Spec",
     "type": "object",
-    "additionalProperties": true,
     "required": ["dataset_name", "format", "url", "provider"],
     "properties": {
       "dataset_name": {

--- a/docs/connector-development/tutorials/build-a-connector-the-hard-way.md
+++ b/docs/connector-development/tutorials/build-a-connector-the-hard-way.md
@@ -124,7 +124,6 @@ Let's create a [JSONSchema](http://json-schema.org/) file `spec.json` encoding t
     "$schema": "http://json-schema.org/draft-07/schema#",
     "type": "object",
     "required": ["stock_ticker", "api_key"],
-    "additionalProperties": true,
     "properties": {
       "stock_ticker": {
         "type": "string",
@@ -233,7 +232,7 @@ Now if we run `python source.py spec` we should see the specification printed ou
 
 ```bash
 python source.py spec
-{"type": "SPEC", "spec": {"documentationUrl": "https://polygon.io/docs/stocks/get_v2_aggs_ticker__stocksticker__range__multiplier___timespan___from___to", "connectionSpecification": {"$schema": "http://json-schema.org/draft-07/schema#", "type": "object", "required": ["stock_ticker", "api_key"], "additionalProperties": true, "properties": {"stock_ticker": {"type": "string", "title": "Stock Ticker", "description": "The stock ticker to track", "examples": ["AAPL", "TSLA", "AMZN"]}, "api_key": {"type": "string", "description": "The Polygon.io Stocks API key to use to hit the API.", "airbyte_secret": true}}}}}
+{"type": "SPEC", "spec": {"documentationUrl": "https://polygon.io/docs/stocks/get_v2_aggs_ticker__stocksticker__range__multiplier___timespan___from___to", "connectionSpecification": {"$schema": "http://json-schema.org/draft-07/schema#", "type": "object", "required": ["stock_ticker", "api_key"], "properties": {"stock_ticker": {"type": "string", "title": "Stock Ticker", "description": "The stock ticker to track", "examples": ["AAPL", "TSLA", "AMZN"]}, "api_key": {"type": "string", "description": "The Polygon.io Stocks API key to use to hit the API.", "airbyte_secret": true}}}}}
 ```
 
 We've implemented the first command! Three more and we'll have a working connector.
@@ -920,7 +919,7 @@ to run any of our commands, we'll need to mount all the inputs into the Docker c
 
 ```bash
 $ docker run airbyte/source-stock-ticker-api:dev spec
-{"type": "SPEC", "spec": {"documentationUrl": "https://polygon.io/docs/stocks/get_v2_aggs_ticker__stocksticker__range__multiplier___timespan___from___to", "connectionSpecification": {"$schema": "http://json-schema.org/draft-07/schema#", "type": "object", "required": ["stock_ticker", "api_key"], "additionalProperties": true, "properties": {"stock_ticker": {"type": "string", "title": "Stock Ticker", "description": "The stock ticker to track", "examples": ["AAPL", "TSLA", "AMZN"]}, "api_key": {"type": "string", "description": "The Polygon.io Stocks API key to use to hit the API.", "airbyte_secret": true}}}}}
+{"type": "SPEC", "spec": {"documentationUrl": "https://polygon.io/docs/stocks/get_v2_aggs_ticker__stocksticker__range__multiplier___timespan___from___to", "connectionSpecification": {"$schema": "http://json-schema.org/draft-07/schema#", "type": "object", "required": ["stock_ticker", "api_key"], "properties": {"stock_ticker": {"type": "string", "title": "Stock Ticker", "description": "The stock ticker to track", "examples": ["AAPL", "TSLA", "AMZN"]}, "api_key": {"type": "string", "description": "The Polygon.io Stocks API key to use to hit the API.", "airbyte_secret": true}}}}}
 
 $ docker run -v $(pwd)/secrets/valid_config.json:/data/config.json airbyte/source-stock-ticker-api:dev check --config /data/config.json
 {'type': 'CONNECTION_STATUS', 'connectionStatus': {'status': 'SUCCEEDED'}}

--- a/docs/connector-development/tutorials/build-a-connector-the-hard-way.md
+++ b/docs/connector-development/tutorials/build-a-connector-the-hard-way.md
@@ -124,7 +124,7 @@ Let's create a [JSONSchema](http://json-schema.org/) file `spec.json` encoding t
     "$schema": "http://json-schema.org/draft-07/schema#",
     "type": "object",
     "required": ["stock_ticker", "api_key"],
-    "additionalProperties": false,
+    "additionalProperties": true,
     "properties": {
       "stock_ticker": {
         "type": "string",
@@ -233,7 +233,7 @@ Now if we run `python source.py spec` we should see the specification printed ou
 
 ```bash
 python source.py spec
-{"type": "SPEC", "spec": {"documentationUrl": "https://polygon.io/docs/stocks/get_v2_aggs_ticker__stocksticker__range__multiplier___timespan___from___to", "connectionSpecification": {"$schema": "http://json-schema.org/draft-07/schema#", "type": "object", "required": ["stock_ticker", "api_key"], "additionalProperties": false, "properties": {"stock_ticker": {"type": "string", "title": "Stock Ticker", "description": "The stock ticker to track", "examples": ["AAPL", "TSLA", "AMZN"]}, "api_key": {"type": "string", "description": "The Polygon.io Stocks API key to use to hit the API.", "airbyte_secret": true}}}}}
+{"type": "SPEC", "spec": {"documentationUrl": "https://polygon.io/docs/stocks/get_v2_aggs_ticker__stocksticker__range__multiplier___timespan___from___to", "connectionSpecification": {"$schema": "http://json-schema.org/draft-07/schema#", "type": "object", "required": ["stock_ticker", "api_key"], "additionalProperties": true, "properties": {"stock_ticker": {"type": "string", "title": "Stock Ticker", "description": "The stock ticker to track", "examples": ["AAPL", "TSLA", "AMZN"]}, "api_key": {"type": "string", "description": "The Polygon.io Stocks API key to use to hit the API.", "airbyte_secret": true}}}}}
 ```
 
 We've implemented the first command! Three more and we'll have a working connector.
@@ -920,7 +920,7 @@ to run any of our commands, we'll need to mount all the inputs into the Docker c
 
 ```bash
 $ docker run airbyte/source-stock-ticker-api:dev spec
-{"type": "SPEC", "spec": {"documentationUrl": "https://polygon.io/docs/stocks/get_v2_aggs_ticker__stocksticker__range__multiplier___timespan___from___to", "connectionSpecification": {"$schema": "http://json-schema.org/draft-07/schema#", "type": "object", "required": ["stock_ticker", "api_key"], "additionalProperties": false, "properties": {"stock_ticker": {"type": "string", "title": "Stock Ticker", "description": "The stock ticker to track", "examples": ["AAPL", "TSLA", "AMZN"]}, "api_key": {"type": "string", "description": "The Polygon.io Stocks API key to use to hit the API.", "airbyte_secret": true}}}}}
+{"type": "SPEC", "spec": {"documentationUrl": "https://polygon.io/docs/stocks/get_v2_aggs_ticker__stocksticker__range__multiplier___timespan___from___to", "connectionSpecification": {"$schema": "http://json-schema.org/draft-07/schema#", "type": "object", "required": ["stock_ticker", "api_key"], "additionalProperties": true, "properties": {"stock_ticker": {"type": "string", "title": "Stock Ticker", "description": "The stock ticker to track", "examples": ["AAPL", "TSLA", "AMZN"]}, "api_key": {"type": "string", "description": "The Polygon.io Stocks API key to use to hit the API.", "airbyte_secret": true}}}}}
 
 $ docker run -v $(pwd)/secrets/valid_config.json:/data/config.json airbyte/source-stock-ticker-api:dev check --config /data/config.json
 {'type': 'CONNECTION_STATUS', 'connectionStatus': {'status': 'SUCCEEDED'}}

--- a/docs/connector-development/tutorials/cdk-speedrun-deprecated.md
+++ b/docs/connector-development/tutorials/cdk-speedrun-deprecated.md
@@ -44,7 +44,7 @@ We're working with the Exchange Rates API, so we need to define our input schema
     "title": "Python Http Example Spec",
     "type": "object",
     "required": ["start_date", "currency_base"],
-    "additionalProperties": false,
+    "additionalProperties": true,
     "properties": {
       "start_date": {
         "type": "string",

--- a/docs/connector-development/tutorials/cdk-speedrun-deprecated.md
+++ b/docs/connector-development/tutorials/cdk-speedrun-deprecated.md
@@ -44,7 +44,6 @@ We're working with the Exchange Rates API, so we need to define our input schema
     "title": "Python Http Example Spec",
     "type": "object",
     "required": ["start_date", "currency_base"],
-    "additionalProperties": true,
     "properties": {
       "start_date": {
         "type": "string",

--- a/docs/connector-development/tutorials/cdk-speedrun.md
+++ b/docs/connector-development/tutorials/cdk-speedrun.md
@@ -51,7 +51,7 @@ connectionSpecification:
   type: object
   required:
     - pokemon_name
-  additionalProperties: false
+  additionalProperties: true
   properties:
     pokemon_name:
       type: string

--- a/docs/connector-development/tutorials/cdk-speedrun.md
+++ b/docs/connector-development/tutorials/cdk-speedrun.md
@@ -51,7 +51,6 @@ connectionSpecification:
   type: object
   required:
     - pokemon_name
-  additionalProperties: true
   properties:
     pokemon_name:
       type: string

--- a/docs/connector-development/tutorials/cdk-tutorial-python-http/define-inputs.md
+++ b/docs/connector-development/tutorials/cdk-tutorial-python-http/define-inputs.md
@@ -20,7 +20,6 @@ connectionSpecification:
     - access_key
     - start_date
     - base
-  additionalProperties: true
   properties:
     access_key:
       type: string

--- a/docs/connector-development/tutorials/cdk-tutorial-python-http/define-inputs.md
+++ b/docs/connector-development/tutorials/cdk-tutorial-python-http/define-inputs.md
@@ -20,7 +20,7 @@ connectionSpecification:
     - access_key
     - start_date
     - base
-  additionalProperties: false
+  additionalProperties: true
   properties:
     access_key:
       type: string

--- a/docs/connector-development/tutorials/cdk-tutorial-python-http/install-dependencies.md
+++ b/docs/connector-development/tutorials/cdk-tutorial-python-http/install-dependencies.md
@@ -20,7 +20,7 @@ python main.py spec
 You should see some output:
 
 ```text
-{"type": "SPEC", "spec": {"documentationUrl": "https://docsurl.com", "connectionSpecification": {"$schema": "http://json-schema.org/draft-07/schema#", "title": "Python Http Tutorial Spec", "type": "object", "required": ["TODO"], "additionalProperties": false, "properties": {"TODO: This schema defines the configuration required for the source. This usually involves metadata such as database and/or authentication information.": {"type": "string", "description": "describe me"}}}}}
+{"type": "SPEC", "spec": {"documentationUrl": "https://docsurl.com", "connectionSpecification": {"$schema": "http://json-schema.org/draft-07/schema#", "title": "Python Http Tutorial Spec", "type": "object", "required": ["TODO"], "properties": {"TODO: This schema defines the configuration required for the source. This usually involves metadata such as database and/or authentication information.": {"type": "string", "description": "describe me"}}}}}
 ```
 
 We just ran Airbyte Protocol's `spec` command! We'll talk more about this later, but this is a simple sanity check to make sure everything is wired up correctly.

--- a/docs/understanding-airbyte/airbyte-protocol.md
+++ b/docs/understanding-airbyte/airbyte-protocol.md
@@ -160,7 +160,6 @@ The following are fields that still exist in the specification but are slated to
     type: object
     required:
       - connectionSpecification
-    additionalProperties: true
     properties:
       # General Properties (Common to all connectors)
       documentationUrl:
@@ -306,7 +305,6 @@ This section will document the meaning of each field in an `ConfiguredAirbyteStr
 ```yaml
   ConfiguredAirbyteStream:
     type: object
-    additionalProperties: true
     required:
       - stream
       - sync_mode
@@ -444,7 +442,7 @@ This table breaks down attributes of these state types.
 
 # Messages
 ## Common
-For forwards compatibility all messages should allow for unknown properties (in JSONSchema parlance that is `additionalProperties: true`).
+For forwards compatibility all messages should allow for unknown properties (in JSONSchema parlance that is `additionalProperties: true`, which is the default value).
 
 Messages are structs emitted by actors.
 
@@ -460,7 +458,6 @@ This is the new pattern for referring to a stream. As structs are updated, they 
 ```yaml
   StreamDescriptor:
     type: object
-    additionalProperties: true
     required:
       - name
     properties:
@@ -478,7 +475,6 @@ The envelope has a required `type` which described the type of the wrapped messa
 ```yaml
 AirbyteMessage:
   type: object
-  additionalProperties: true
   required:
     - type
   properties:
@@ -526,7 +522,6 @@ The `emitted_at` field contains when the source extracted the record. It is a re
 ```yaml
   AirbyteRecordMessage:
     type: object
-    additionalProperties: true
     required:
       - stream
       - data
@@ -555,7 +550,6 @@ The state message is a wrapper around the state that a Source emits. The state t
 ```yaml
   AirbyteStateMessage:
     type: object
-    additionalProperties: true
     required:
       - data
     properties:
@@ -579,7 +573,6 @@ In the `GLOBAL` case, the state for the whole Source is encapsulated in the mess
 ```yaml
   AirbyteStateMessage:
     type: object
-    additionalProperties: true
     properties:
       state_type:
         "$ref": "#/definitions/AirbyteStateType"
@@ -607,7 +600,6 @@ In the `GLOBAL` case, the state for the whole Source is encapsulated in the mess
       - LEGACY
   AirbyteStreamState:
     type: object
-    additionalProperties: true
     required:
       - stream_descriptor
     properties:
@@ -617,7 +609,6 @@ In the `GLOBAL` case, the state for the whole Source is encapsulated in the mess
         "$ref": "#/definitions/AirbyteStateBlob"
   AirbyteGlobalState:
     type: object
-    additionalProperties: true
     required:
       - stream_states
     properties:
@@ -636,7 +627,6 @@ This message reports whether an Actor was able to connect to its underlying data
   AirbyteConnectionStatus:
     description: Airbyte connection status
     type: object
-    additionalProperties: true
     required:
       - status
     properties:
@@ -663,7 +653,6 @@ The Airbyte implementation of the protocol does attempt to parse any data emitte
 ```yaml
   AirbyteLogMessage:
     type: object
-    additionalProperties: true
     required:
       - level
       - message
@@ -689,7 +678,6 @@ The trace message allows an Actor to emit metadata about the runtime of the Acto
 ```yaml
   AirbyteTraceMessage:
     type: object
-    additionalProperties: true
     required:
       - type
       - emitted_at
@@ -708,7 +696,6 @@ The trace message allows an Actor to emit metadata about the runtime of the Acto
         "$ref": "#/definitions/AirbyteErrorTraceMessage"
   AirbyteErrorTraceMessage:
     type: object
-    additionalProperties: true
     required:
       - message
     properties:

--- a/docs/understanding-airbyte/airbyte-protocol.md
+++ b/docs/understanding-airbyte/airbyte-protocol.md
@@ -160,6 +160,7 @@ The following are fields that still exist in the specification but are slated to
     type: object
     required:
       - connectionSpecification
+    additionalProperties: true
     properties:
       # General Properties (Common to all connectors)
       documentationUrl:
@@ -442,7 +443,7 @@ This table breaks down attributes of these state types.
 
 # Messages
 ## Common
-For forwards compatibility all messages should allow for unknown properties (in JSONSchema parlance that is `additionalProperties: true`, which is the default value).
+For forwards compatibility all messages should allow for unknown properties (in JSONSchema parlance that is `additionalProperties: true`).
 
 Messages are structs emitted by actors.
 
@@ -458,6 +459,7 @@ This is the new pattern for referring to a stream. As structs are updated, they 
 ```yaml
   StreamDescriptor:
     type: object
+    additionalProperties: true
     required:
       - name
     properties:
@@ -475,6 +477,7 @@ The envelope has a required `type` which described the type of the wrapped messa
 ```yaml
 AirbyteMessage:
   type: object
+  additionalProperties: true
   required:
     - type
   properties:
@@ -522,6 +525,7 @@ The `emitted_at` field contains when the source extracted the record. It is a re
 ```yaml
   AirbyteRecordMessage:
     type: object
+    additionalProperties: true
     required:
       - stream
       - data
@@ -550,6 +554,7 @@ The state message is a wrapper around the state that a Source emits. The state t
 ```yaml
   AirbyteStateMessage:
     type: object
+    additionalProperties: true
     required:
       - data
     properties:
@@ -573,6 +578,7 @@ In the `GLOBAL` case, the state for the whole Source is encapsulated in the mess
 ```yaml
   AirbyteStateMessage:
     type: object
+    additionalProperties: true
     properties:
       state_type:
         "$ref": "#/definitions/AirbyteStateType"
@@ -609,6 +615,7 @@ In the `GLOBAL` case, the state for the whole Source is encapsulated in the mess
         "$ref": "#/definitions/AirbyteStateBlob"
   AirbyteGlobalState:
     type: object
+    additionalProperties: true
     required:
       - stream_states
     properties:
@@ -627,6 +634,7 @@ This message reports whether an Actor was able to connect to its underlying data
   AirbyteConnectionStatus:
     description: Airbyte connection status
     type: object
+    additionalProperties: true
     required:
       - status
     properties:
@@ -653,6 +661,7 @@ The Airbyte implementation of the protocol does attempt to parse any data emitte
 ```yaml
   AirbyteLogMessage:
     type: object
+    additionalProperties: true
     required:
       - level
       - message
@@ -678,6 +687,7 @@ The trace message allows an Actor to emit metadata about the runtime of the Acto
 ```yaml
   AirbyteTraceMessage:
     type: object
+    additionalProperties: true
     required:
       - type
       - emitted_at
@@ -696,6 +706,7 @@ The trace message allows an Actor to emit metadata about the runtime of the Acto
         "$ref": "#/definitions/AirbyteErrorTraceMessage"
   AirbyteErrorTraceMessage:
     type: object
+    additionalProperties: true
     required:
       - message
     properties:

--- a/docs/understanding-airbyte/airbyte-protocol.md
+++ b/docs/understanding-airbyte/airbyte-protocol.md
@@ -306,6 +306,7 @@ This section will document the meaning of each field in an `ConfiguredAirbyteStr
 ```yaml
   ConfiguredAirbyteStream:
     type: object
+    additionalProperties: true
     required:
       - stream
       - sync_mode
@@ -606,6 +607,7 @@ In the `GLOBAL` case, the state for the whole Source is encapsulated in the mess
       - LEGACY
   AirbyteStreamState:
     type: object
+    additionalProperties: true
     required:
       - stream_descriptor
     properties:


### PR DESCRIPTION
## What
https://github.com/airbytehq/airbyte/pull/14878 added a test to make acceptance tests fail if `additionalProperties: false`. But most of our CDK docs show `additionalProperties: false` and the connectors-template generate specs with `additionalProperties: false`. This PR makes the required changes in connectors templates and docs.


## How
Change `additionalProperties: false` to `additionalProperties: true` on `*.md` and `*.hbs`
