### PR TITLE
fix: fix wrong directory invocation in publish helm charts workflow

### DIFF
--- a/.github/workflows/publish-helm-charts.yml
+++ b/.github/workflows/publish-helm-charts.yml
@@ -51,7 +51,7 @@ jobs:
         shell: bash
         working-directory: ./airbyte/charts
         run: |
-          sed -i "s/    version: placeholder/      version: ${{ needs.generate-semantic-version.outputs.next-version }}/g" charts/airbyte/Chart.yaml
+          sed -i "s/    version: placeholder/      version: ${{ needs.generate-semantic-version.outputs.next-version }}/g" airbyte/Chart.yaml
 
       - name: "Helm package"
         shell: bash

--- a/.github/workflows/publish-helm-charts.yml
+++ b/.github/workflows/publish-helm-charts.yml
@@ -74,7 +74,7 @@ jobs:
         shell: bash
         run: |
           echo "Waiting for published charts to be synced in helm-charts repo"
-          sleep 120
+          sleep 300
           declare -a StringArray=("airbyte")
           for val in ${StringArray[@]}; do
             cd ./airbyte/charts/${val} && cat Chart.yaml && helm dep update && cd $GITHUB_WORKSPACE

--- a/.github/workflows/publish-helm-charts.yml
+++ b/.github/workflows/publish-helm-charts.yml
@@ -51,7 +51,7 @@ jobs:
         shell: bash
         working-directory: ./airbyte/charts
         run: |
-          sed -i "s/    version: placeholder/      version: ${{ needs.generate-semantic-version.outputs.next-version }}/g" airbyte/Chart.yaml
+          sed -i "s/    version: placeholder/    version: ${{ needs.generate-semantic-version.outputs.next-version }}/g" airbyte/Chart.yaml
 
       - name: "Helm package"
         shell: bash


### PR DESCRIPTION
## What
*Describe what the change is solving*
*It helps to add screenshots if it affects the frontend.*

Fixed error when sed tried to access wrong directory to update dependant helm chart versions in Chart.yaml file
Successful workflow run: https://github.com/airbytehq/airbyte/runs/7431871949?check_suite_focus=true