### PR TITLE
cdk: do not call `init_uncaught_exception_handler` from modules' root

### DIFF
--- a/airbyte-cdk/python/CHANGELOG.md
+++ b/airbyte-cdk/python/CHANGELOG.md
@@ -1,10 +1,8 @@
 # Changelog
 
-## Unreleased
-- Add the ability to remove & add records in YAML-based sources
-
 ## 0.1.66
 - Call init_uncaught_exception_handler from AirbyteEntrypoint.__init__ and Destination.run_cmd
+- Add the ability to remove & add records in YAML-based sources
 
 ## 0.1.65
 - Allow for detailed debug messages to be enabled using the --debug command.

--- a/airbyte-cdk/python/CHANGELOG.md
+++ b/airbyte-cdk/python/CHANGELOG.md
@@ -3,6 +3,9 @@
 ## Unreleased
 - Add the ability to remove & add records in YAML-based sources
 
+## 0.1.66
+- Call init_uncaught_exception_handler from AirbyteEntrypoint.__init__ and Destination.run_cmd
+
 ## 0.1.65
 - Allow for detailed debug messages to be enabled using the --debug command.
 

--- a/airbyte-cdk/python/airbyte_cdk/destinations/destination.py
+++ b/airbyte-cdk/python/airbyte_cdk/destinations/destination.py
@@ -84,7 +84,6 @@ class Destination(Connector, ABC):
         return parsed_args
 
     def run_cmd(self, parsed_args: argparse.Namespace) -> Iterable[AirbyteMessage]:
-        init_uncaught_exception_handler(logger)
 
         cmd = parsed_args.command
         if cmd not in self.VALID_CMDS:
@@ -106,6 +105,7 @@ class Destination(Connector, ABC):
             yield from self._run_write(config=config, configured_catalog_path=parsed_args.catalog, input_stream=wrapped_stdin)
 
     def run(self, args: List[str]):
+        init_uncaught_exception_handler(logger)
         parsed_args = self.parse_args(args)
         output_messages = self.run_cmd(parsed_args)
         for message in output_messages:

--- a/airbyte-cdk/python/airbyte_cdk/destinations/destination.py
+++ b/airbyte-cdk/python/airbyte_cdk/destinations/destination.py
@@ -10,6 +10,7 @@ from abc import ABC, abstractmethod
 from typing import Any, Iterable, List, Mapping
 
 from airbyte_cdk.connector import Connector
+from airbyte_cdk.exception_handler import init_uncaught_exception_handler
 from airbyte_cdk.models import AirbyteMessage, ConfiguredAirbyteCatalog, Type
 from airbyte_cdk.sources.utils.schema_helpers import check_config_against_spec_or_exit
 from pydantic import ValidationError
@@ -83,6 +84,8 @@ class Destination(Connector, ABC):
         return parsed_args
 
     def run_cmd(self, parsed_args: argparse.Namespace) -> Iterable[AirbyteMessage]:
+        init_uncaught_exception_handler(logger)
+
         cmd = parsed_args.command
         if cmd not in self.VALID_CMDS:
             raise Exception(f"Unrecognized command: {cmd}")

--- a/airbyte-cdk/python/airbyte_cdk/entrypoint.py
+++ b/airbyte-cdk/python/airbyte_cdk/entrypoint.py
@@ -20,11 +20,11 @@ from airbyte_cdk.sources.utils.schema_helpers import check_config_against_spec_o
 from airbyte_cdk.utils.airbyte_secrets_utils import get_secrets, update_secrets
 
 logger = init_logger("airbyte")
-init_uncaught_exception_handler(logger)
 
 
 class AirbyteEntrypoint(object):
     def __init__(self, source: Source):
+        init_uncaught_exception_handler(logger)
         self.source = source
         self.logger = logging.getLogger(f"airbyte.{getattr(source, 'name', '')}")
 

--- a/airbyte-cdk/python/setup.py
+++ b/airbyte-cdk/python/setup.py
@@ -15,7 +15,7 @@ README = (HERE / "README.md").read_text()
 
 setup(
     name="airbyte-cdk",
-    version="0.1.65",
+    version="0.1.66",
     description="A framework for writing Airbyte Connectors.",
     long_description=README,
     long_description_content_type="text/markdown",

--- a/airbyte-cdk/python/unit_tests/destinations/test_destination.py
+++ b/airbyte-cdk/python/unit_tests/destinations/test_destination.py
@@ -11,6 +11,7 @@ from unittest.mock import ANY
 
 import pytest
 from airbyte_cdk.destinations import Destination
+from airbyte_cdk.destinations import destination as destination_module
 from airbyte_cdk.models import (
     AirbyteCatalog,
     AirbyteConnectionStatus,
@@ -136,6 +137,13 @@ class OrderedIterableMatcher(Iterable):
 
 
 class TestRun:
+    def test_run_cmd(self, mocker, destination: Destination):
+        mocker.patch.object(destination_module, "init_uncaught_exception_handler")
+        parsed_args = argparse.Namespace(command="dummy")
+        with pytest.raises(Exception):
+            destination.run_cmd(parsed_args)
+            destination_module.init_uncaught_exception_handler_mock.assert_called_once_with(destination_module.logger)
+
     def test_run_spec(self, mocker, destination: Destination):
         args = {"command": "spec"}
         parsed_args = argparse.Namespace(**args)

--- a/airbyte-cdk/python/unit_tests/destinations/test_destination.py
+++ b/airbyte-cdk/python/unit_tests/destinations/test_destination.py
@@ -137,12 +137,12 @@ class OrderedIterableMatcher(Iterable):
 
 
 class TestRun:
-    def test_run_cmd(self, mocker, destination: Destination):
+    def test_run_initializes_exception_handler(self, mocker, destination: Destination):
         mocker.patch.object(destination_module, "init_uncaught_exception_handler")
-        parsed_args = argparse.Namespace(command="dummy")
-        with pytest.raises(Exception):
-            destination.run_cmd(parsed_args)
-            destination_module.init_uncaught_exception_handler_mock.assert_called_once_with(destination_module.logger)
+        mocker.patch.object(destination, "parse_args")
+        mocker.patch.object(destination, "run_cmd")
+        destination.run(["dummy"])
+        destination_module.init_uncaught_exception_handler.assert_called_once_with(destination_module.logger)
 
     def test_run_spec(self, mocker, destination: Destination):
         args = {"command": "spec"}

--- a/airbyte-cdk/python/unit_tests/test_entrypoint.py
+++ b/airbyte-cdk/python/unit_tests/test_entrypoint.py
@@ -10,6 +10,7 @@ from unittest.mock import MagicMock
 
 import pytest
 from airbyte_cdk import AirbyteEntrypoint
+from airbyte_cdk import entrypoint as entrypoint_module
 from airbyte_cdk.models import (
     AirbyteCatalog,
     AirbyteConnectionStatus,
@@ -54,6 +55,12 @@ def spec_mock(mocker):
 @pytest.fixture
 def entrypoint() -> AirbyteEntrypoint:
     return AirbyteEntrypoint(MockSource())
+
+
+def test_airbyte_entrypoint_init(mocker):
+    mocker.patch.object(entrypoint_module, "init_uncaught_exception_handler")
+    AirbyteEntrypoint(MockSource)
+    entrypoint_module.init_uncaught_exception_handler.assert_called_once_with(entrypoint_module.logger)
 
 
 @pytest.mark.parametrize(

--- a/airbyte-cdk/python/unit_tests/test_entrypoint.py
+++ b/airbyte-cdk/python/unit_tests/test_entrypoint.py
@@ -59,7 +59,7 @@ def entrypoint() -> AirbyteEntrypoint:
 
 def test_airbyte_entrypoint_init(mocker):
     mocker.patch.object(entrypoint_module, "init_uncaught_exception_handler")
-    AirbyteEntrypoint(MockSource)
+    AirbyteEntrypoint(MockSource())
     entrypoint_module.init_uncaught_exception_handler.assert_called_once_with(entrypoint_module.logger)
 
 


### PR DESCRIPTION
## What
Closing https://github.com/airbytehq/airbyte/issues/14453
Calling `init_uncaught_exception_handler` from the module root affects the stack trace of projects using the CDK's model.

```python
>>> raise RuntimeError("hi")
Traceback (most recent call last):
  File "<stdin>", line 1, in <module>
RuntimeError: hi
>>> import airbyte_cdk
>>> raise RuntimeError("hi")
{"type": "LOG", "log": {"level": "FATAL", "message": "hi\nTraceback (most recent call last):\n  File \"<stdin>\", line 1, in <module>\nRuntimeError: hi"}}
{"type": "TRACE", "trace": {"type": "ERROR", "emitted_at": 1657117935965.3152, "error": {"message": "Something went wrong in the connector. See the logs for more details.", "internal_message": "hi", "stack_trace": "Traceback (most recent call last):\n  File \"<stdin>\", line 1, in <module>\nRuntimeError: hi\n", "failure_type": "system_error"}}}
```

## How
To overcome this problem I moved the call to `init_uncaught_exception_handler` when real execution logic happens: in `AirbyteEntrypoint.__init__` for sources and in `Destination.run_cmd` for destinations.
