### PR TITLE
[#14909] Fix for duplicate key isue when diffing catalogs with arrays

### DIFF
--- a/airbyte-protocol/protocol-models/src/main/java/io/airbyte/protocol/models/CatalogHelpers.java
+++ b/airbyte-protocol/protocol-models/src/main/java/io/airbyte/protocol/models/CatalogHelpers.java
@@ -10,7 +10,6 @@ import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.Lists;
 import com.google.common.collect.Sets;
 import io.airbyte.commons.json.JsonSchemas;
-import io.airbyte.commons.json.JsonSchemas.FieldNameOrList;
 import io.airbyte.commons.json.Jsons;
 import io.airbyte.commons.util.MoreIterators;
 import io.airbyte.commons.util.MoreLists;
@@ -32,6 +31,8 @@ import org.apache.commons.lang3.tuple.Pair;
  * Helper class for Catalog and Stream related operations. Generally only used in tests.
  */
 public class CatalogHelpers {
+
+  private static final String ITEMS_KEY = "items";
 
   public static AirbyteCatalog createAirbyteCatalog(final String streamName, final Field... fields) {
     return new AirbyteCatalog().withStreams(Lists.newArrayList(createAirbyteStream(streamName, fields)));
@@ -222,7 +223,7 @@ public class CatalogHelpers {
     final Set<List<String>> fieldNamesThatAreOneOfs = new HashSet<>();
 
     return JsonSchemas.traverseJsonSchemaWithCollector(jsonSchema, (node, basicPath) -> {
-      final List<String> fieldName = basicPath.stream().filter(fieldOrList -> !fieldOrList.isList()).map(FieldNameOrList::getFieldName).toList();
+      final List<String> fieldName = basicPath.stream().map(fieldOrList -> fieldOrList.isList() ? ITEMS_KEY : fieldOrList.getFieldName()).toList();
       return Pair.of(fieldName, node);
     })
         .stream()

--- a/airbyte-protocol/protocol-models/src/test/java/io/airbyte/protocol/models/CatalogHelpersTest.java
+++ b/airbyte-protocol/protocol-models/src/test/java/io/airbyte/protocol/models/CatalogHelpersTest.java
@@ -82,7 +82,7 @@ class CatalogHelpersTest {
     final JsonNode node = Jsons.deserialize(MoreResources.readResource("valid_schema.json"));
     final Set<String> actualFieldNames = CatalogHelpers.getAllFieldNames(node);
     final List<String> expectedFieldNames =
-        List.of("CAD", "DKK", "HKD", "HUF", "ISK", "PHP", "date", "nestedkey", "somekey", "something", "something2", "文");
+        List.of("CAD", "DKK", "HKD", "HUF", "ISK", "PHP", "date", "nestedkey", "somekey", "something", "something2", "文", "someArray", "items", "oldName");
 
     // sort so that the diff is easier to read.
     assertEquals(expectedFieldNames.stream().sorted().toList(), actualFieldNames.stream().sorted().toList());
@@ -109,7 +109,17 @@ class CatalogHelpersTest {
             FieldTransform.createRemoveFieldTransform(List.of("HKD"), schema1.get("properties").get("HKD")),
             FieldTransform.createUpdateFieldTransform(List.of("CAD"), new UpdateFieldSchemaTransform(
                 schema1.get("properties").get("CAD"),
-                schema2.get("properties").get("CAD")))))))
+                schema2.get("properties").get("CAD"))),
+            FieldTransform.createUpdateFieldTransform(List.of("someArray"), new UpdateFieldSchemaTransform(
+                schema1.get("properties").get("someArray"),
+                schema2.get("properties").get("someArray"))),
+            FieldTransform.createUpdateFieldTransform(List.of("someArray", "items"), new UpdateFieldSchemaTransform(
+                schema1.get("properties").get("someArray").get("items"),
+                schema2.get("properties").get("someArray").get("items"))),
+            FieldTransform.createRemoveFieldTransform(List.of("someArray", "items", "oldName"),
+                schema1.get("properties").get("someArray").get("items").get("properties").get("oldName")),
+            FieldTransform.createAddFieldTransform(List.of("someArray", "items", "newName"),
+                schema2.get("properties").get("someArray").get("items").get("properties").get("newName"))))))
         .sorted(STREAM_TRANSFORM_COMPARATOR)
         .toList();
     assertEquals(expectedDiff, actualDiff.stream().sorted(STREAM_TRANSFORM_COMPARATOR).toList());

--- a/airbyte-protocol/protocol-models/src/test/resources/valid_schema.json
+++ b/airbyte-protocol/protocol-models/src/test/resources/valid_schema.json
@@ -44,6 +44,27 @@
           }
         }
       ]
+    },
+    "someArray": {
+      "type": [
+        "array",
+        "null"
+      ],
+      "items": {
+        "type": [
+          "object",
+          "null"
+        ],
+        "properties": {
+          "oldName": {
+            "type": [
+              "string",
+              "null"
+            ],
+            "maxLength": 100
+          }
+        }
+      }
     }
   }
 }

--- a/airbyte-protocol/protocol-models/src/test/resources/valid_schema2.json
+++ b/airbyte-protocol/protocol-models/src/test/resources/valid_schema2.json
@@ -24,6 +24,27 @@
       "patternProperties": {
         ".+": {}
       }
+    },
+    "someArray": {
+      "type": [
+        "array",
+        "null"
+      ],
+      "items": {
+        "type": [
+          "object",
+          "null"
+        ],
+        "properties": {
+          "newName": {
+            "type": [
+              "string",
+              "null"
+            ],
+            "maxLength": 100
+          }
+        }
+      }
     }
   }
 }


### PR DESCRIPTION
## What

Fix for duplicateKeyException thrown when diffing catalogs that contain arrays in the schema (see #14909 ).   This exception is due to the `CatalogHelpers.getFullyQualifiedFieldNamesWithTypes()` method returning the same names for both the array node and also the child "items" node, causing a collision during `Stream.collect()'  in `CatalogHelpers.getStreamDiff()`.    

Please see the updated unit test and also #14460 for examples of schemas that trigger this exception with the existing code.

## How

The issue was caused by `getFullyQualifiedFieldNamesWithTypes()` filtering out the `FieldNameOrList` instances from the path list (so that the "items" node ends up with the same name list as the parent array node).   The proposed fix here just adds a string "items" to the name list instead of ignoring that list instance altogether.   However, this does introduce a new "items" node that could be included in the final Catalog diff.   I honestly don't know how/where this diff is used upstream (including the frontend), so I'm not sure if this would cause any issues.

Another alternative would be to just exclude either the array node or the "items" node from the result of the `getFullyQualifiedFieldNamesWithTypes()` method.   The only downside to that approach is that it wouldn't be able to detect diffs in cases where an array field turned into an object field (with the same child schema), or vice versa, since the resulting field list would look the same (though this is probably an edge case).  

## Recommended reading order
1. `CatalogHelpers.java`
2. `CatalogHelpersTest.java`

## 🚨 User Impact 🚨

Unknown, depending on how/where the results of `CatalogHelpers.getCatalogDiff()` are used.

Close https://github.com/airbytehq/airbyte/issues/14909