### PR TITLE
Bugfix: sweep-pod.sh never deleting certain Failed pods (#14925)

### DIFF
--- a/charts/airbyte-pod-sweeper/files/sweep-pod.sh
+++ b/charts/airbyte-pod-sweeper/files/sweep-pod.sh
@@ -3,7 +3,7 @@
 get_worker_pods () {
     kubectl -n ${KUBE_NAMESPACE} -L airbyte -l airbyte=worker-pod \
       --field-selector status.phase!=Running get pods \
-      -o=jsonpath='{range .items[*]} {.metadata.name} {.status.phase} {.status.conditions[0].lastTransitionTime}{"\n"}{end}'
+      -o=jsonpath='{range .items[*]} {.metadata.name} {.status.phase} {.status.conditions[0].lastTransitionTime} {.status.startTime}{"\n"}{end}'
 }
 
 delete_worker_pod() {
@@ -26,7 +26,8 @@ do
             POD_NAME=`echo $POD | cut -d " " -f 1`
             POD_STATUS=`echo $POD | cut -d " " -f 2`
             POD_DATE_STR=`echo $POD | cut -d " " -f 3`
-            POD_DATE=`date -d $POD_DATE_STR '+%s'`
+            POD_START_DATE_STR=`echo $POD | cut -d " " -f 4`
+            POD_DATE=`date -d ${POD_DATE_STR:-$POD_START_DATE_STR} '+%s'`
             if [ "$POD_STATUS" = "Succeeded" ]; then
             if [ "$POD_DATE" -lt "$SUCCESS_DATE" ]; then
                 delete_worker_pod "$POD_NAME" "$POD_STATUS" "$POD_DATE_STR"

--- a/kube/resources/pod-sweeper.yaml
+++ b/kube/resources/pod-sweeper.yaml
@@ -9,7 +9,7 @@ data:
     get_worker_pods () {
       kubectl -n ${KUBE_NAMESPACE} -L airbyte -l airbyte=worker-pod \
         --field-selector status.phase!=Running get pods \
-        -o=jsonpath='{range .items[*]} {.metadata.name} {.status.phase} {.status.conditions[0].lastTransitionTime}{"\n"}{end}'
+        -o=jsonpath='{range .items[*]} {.metadata.name} {.status.phase} {.status.conditions[0].lastTransitionTime} {.status.startTime}{"\n"}{end}'
     }
 
     delete_worker_pod() {
@@ -25,8 +25,6 @@ data:
       # Longer time window for pods in error (to debug)
       NON_SUCCESS_DATE_STR=`date -d 'now - 24 hours' --utc -Ins`
       NON_SUCCESS_DATE=`date -d $NON_SUCCESS_DATE_STR +%s`
-      # default time to use in case its unavailable from kubectl
-      DEFAULT=`date --utc -Ins`
       (
           IFS=$'\n'
           for POD in `get_worker_pods`; do
@@ -34,7 +32,8 @@ data:
               POD_NAME=`echo $POD | cut -d " " -f 1`
               POD_STATUS=`echo $POD | cut -d " " -f 2`
               POD_DATE_STR=`echo $POD | cut -d " " -f 3`
-              POD_DATE=`date -d ${POD_DATE_STR:-$DEFAULT} '+%s'`
+              POD_START_DATE_STR=`echo $POD | cut -d " " -f 4`
+              POD_DATE=`date -d ${POD_DATE_STR:-$POD_START_DATE_STR} '+%s'`
               if [ "$POD_STATUS" = "Succeeded" ]; then
                 if [ "$POD_DATE" -lt "$SUCCESS_DATE" ]; then
                   delete_worker_pod "$POD_NAME" "$POD_STATUS" "$POD_DATE_STR"


### PR DESCRIPTION
## What
Bugfix: sweep-pod.sh never deleting certain Failed pods

We have noticed that overtime certain Failed worker pods are building up over time in Kubernetes and are being skipped over by the pod-sweeper script, despite them being over 24 hours old. In most cases they are in status OutOfmemory.

There was a PR that addressed a bug in the pod-sweeper script (https://github.com/airbytehq/airbyte/pull/11781) but this only appears to have made the issue silent rather than noisy.

## How
https://github.com/airbytehq/airbyte/blob/master/kube/resources/pod-sweeper.yaml#L39

Current script logic for failed jobs:

1. If `.status.conditions[0].lastTransitionTime` is not `null`, use it else get the date `NOW`.
2. If this is > 24 hours old, delete the pod.

The problem with the above, is that for `null` `lastTransitionTime` (which in our case is always the case), we are always checking if NOW is older than 24 hours (which it will never be) - so the pod never gets deleted.

I have fixed the pod-sweeper script issue locally and it now deletes our old Failed pods, even when `.status.conditions[0].lastTransitionTime` is `null` by falling back to `.status.startTime` instead of `NOW`.

## Recommended reading order
1. `kube/resources/pod-sweeper.yaml` (and the identical fix in `charts/airbyte-pod-sweeper/files/sweep-pod.sh`)

## 🚨 User Impact 🚨
None, other than a pod-sweeper working more closely to how it is documented to function.

## Pre-merge Checklist

- [ ] **Community member?** Grant edit access to maintainers ([instructions](https://docs.github.com/en/github/collaborating-with-pull-requests/working-with-forks/allowing-changes-to-a-pull-request-branch-created-from-a-fork#enabling-repository-maintainer-permissions-on-existing-pull-requests))
- [ ] Secrets in the connector's spec are annotated with `airbyte_secret`
- [ ] Unit & integration tests added and passing. Community members, please provide proof of success locally e.g: screenshot or copy-paste unit, integration, and acceptance test output. To run acceptance tests for a Python connector, follow instructions in the README. For java connectors run `./gradlew :airbyte-integrations:connectors:<name>:integrationTest`.
- [ ] Code reviews completed
- [ ] Documentation updated
    - [ ] Connector's `README.md`
    - [ ] Connector's `bootstrap.md`. See [description and examples](https://docs.google.com/document/d/1ypdgmwmEHWv-TrO4_YOQ7pAJGVrMp5BOkEVh831N260/edit?usp=sharing)
    - [ ] `docs/integrations/<source or destination>/<name>.md` including changelog. See changelog [example](https://docs.airbyte.io/integrations/sources/stripe#changelog)
    - [ ] `docs/integrations/README.md`
    - [ ] `airbyte-integrations/builds.md`
- [ ] PR name follows [PR naming conventions](https://docs.airbyte.io/contributing-to-airbyte/updating-documentation#issues-and-pull-requests)

### Airbyter

If this is a community PR, the Airbyte engineer reviewing this PR is responsible for the below items.

- [ ] Create a non-forked branch based on this PR and test the below items on it
- [ ] Build is successful
- [ ] If new credentials are required for use in CI, add them to GSM. [Instructions](https://docs.airbyte.io/connector-development#using-credentials-in-ci).
- [ ] [`/test connector=connectors/<name>` command](https://docs.airbyte.io/connector-development#updating-an-existing-connector) is passing
- [ ] New Connector version released on Dockerhub by running the `/publish` command described [here](https://docs.airbyte.io/connector-development#updating-an-existing-connector)
- [ ] After the connector is published, connector added to connector index as described [here](https://docs.airbyte.io/connector-development#publishing-a-connector)
- [ ] Seed specs have been re-generated by building the platform and committing the changes to the seed spec files, as described [here](https://docs.airbyte.io/connector-development#publishing-a-connector)

</details>

<details><summary><strong>Updating a connector</strong></summary>

### Community member or Airbyter

- [ ] Grant edit access to maintainers ([instructions](https://docs.github.com/en/github/collaborating-with-pull-requests/working-with-forks/allowing-changes-to-a-pull-request-branch-created-from-a-fork#enabling-repository-maintainer-permissions-on-existing-pull-requests))
- [ ] Secrets in the connector's spec are annotated with `airbyte_secret`
- [ ] Unit & integration tests added and passing. Community members, please provide proof of success locally e.g: screenshot or copy-paste unit, integration, and acceptance test output. To run acceptance tests for a Python connector, follow instructions in the README. For java connectors run `./gradlew :airbyte-integrations:connectors:<name>:integrationTest`.
- [ ] Code reviews completed
- [ ] Documentation updated
    - [ ] Connector's `README.md`
    - [ ] Connector's `bootstrap.md`. See [description and examples](https://docs.google.com/document/d/1ypdgmwmEHWv-TrO4_YOQ7pAJGVrMp5BOkEVh831N260/edit?usp=sharing)
    - [ ] Changelog updated in `docs/integrations/<source or destination>/<name>.md` including changelog. See changelog [example](https://docs.airbyte.io/integrations/sources/stripe#changelog)
- [ ] PR name follows [PR naming conventions](https://docs.airbyte.io/contributing-to-airbyte/updating-documentation#issues-and-pull-requests)

### Airbyter

If this is a community PR, the Airbyte engineer reviewing this PR is responsible for the below items.

- [ ] Create a non-forked branch based on this PR and test the below items on it
- [ ] Build is successful
- [ ] If new credentials are required for use in CI, add them to GSM. [Instructions](https://docs.airbyte.io/connector-development#using-credentials-in-ci).
- [ ] [`/test connector=connectors/<name>` command](https://docs.airbyte.io/connector-development#updating-an-existing-connector) is passing
- [ ] New Connector version released on Dockerhub and connector version bumped by running the `/publish` command described [here](https://docs.airbyte.io/connector-development#updating-an-existing-connector)

</details>

<details><summary><strong>Connector Generator</strong></summary>

- [ ] Issue acceptance criteria met
- [ ] PR name follows [PR naming conventions](https://docs.airbyte.io/contributing-to-airbyte/updating-documentation#issues-and-pull-requests)
- [ ] If adding a new generator, add it to the [list of scaffold modules being tested](https://github.com/airbytehq/airbyte/blob/master/airbyte-integrations/connector-templates/generator/build.gradle#L41)
- [ ] The generator test modules (all connectors with `-scaffold` in their name) have been updated with the latest scaffold by running `./gradlew :airbyte-integrations:connector-templates:generator:testScaffoldTemplates` then checking in your changes
- [ ] Documentation which references the generator is updated as needed

</details>

## Tests

Uncleaned failed pods:-

```
$ kubectl get pods
<snip>
source-mssql-check-4324-1-emrtv                                   0/4     OutOfmemory   0          13d
source-mssql-check-4704-0-mlmxh                                   0/4     OutOfmemory   0          5d19h
source-mssql-check-4750-0-vmjmp                                   0/4     OutOfmemory   0          4d19h
source-mssql-check-4796-0-iydrz                                   0/4     OutOfmemory   0          3d19h
source-mssql-check-4844-0-sorht                                   0/4     OutOfmemory   0          2d19h
source-mssql-read-4702-0-tlwge                                    0/4     OutOfmemory   0          5d19h
source-mssql-read-4795-0-kporl                                    0/4     OutOfmemory   0          3d19h
source-mysql-check-4463-0-clmau                                   0/4     OutOfmemory   0          10d
source-mysql-check-4563-0-jsurh                                   0/4     OutOfmemory   0          8d
```

Console output showing very old Failed pods being deleted with the fixed pod-sweeper.sh script.

```
airbyte-pod-sweeper-7bd48b4879-vlq5d airbyte-pod-sweeper From status 'Failed' since '2022-07-07T23:59:54Z', pod "source-mssql-check-4324-1-emrtv" deleted
airbyte-pod-sweeper-7bd48b4879-vlq5d airbyte-pod-sweeper From status 'Failed' since '2022-07-15T16:59:23Z', pod "source-mssql-check-4704-0-mlmxh" deleted
airbyte-pod-sweeper-7bd48b4879-vlq5d airbyte-pod-sweeper From status 'Failed' since '2022-07-16T16:59:27Z', pod "source-mssql-check-4750-0-vmjmp" deleted
airbyte-pod-sweeper-7bd48b4879-vlq5d airbyte-pod-sweeper From status 'Failed' since '2022-07-17T16:59:35Z', pod "source-mssql-check-4796-0-iydrz" deleted
airbyte-pod-sweeper-7bd48b4879-vlq5d airbyte-pod-sweeper From status 'Failed' since '2022-07-18T16:59:40Z', pod "source-mssql-check-4844-0-sorht" deleted
airbyte-pod-sweeper-7bd48b4879-vlq5d airbyte-pod-sweeper From status 'Failed' since '2022-07-15T16:59:32Z', pod "source-mssql-read-4702-0-tlwge" deleted
airbyte-pod-sweeper-7bd48b4879-vlq5d airbyte-pod-sweeper From status 'Failed' since '2022-07-17T16:59:42Z', pod "source-mssql-read-4795-0-kporl" deleted
airbyte-pod-sweeper-7bd48b4879-vlq5d airbyte-pod-sweeper From status 'Failed' since '2022-07-10T23:52:49Z', pod "source-mysql-check-4463-0-clmau" deleted
airbyte-pod-sweeper-7bd48b4879-vlq5d airbyte-pod-sweeper From status 'Failed' since '2022-07-12T23:53:00Z', pod "source-mysql-check-4563-0-jsurh" deleted
```

</details>
