### PR TITLE
🎉 Source Oracle: Use Service Name to connect to database

### DIFF
--- a/airbyte-config/init/src/main/resources/seed/source_definitions.yaml
+++ b/airbyte-config/init/src/main/resources/seed/source_definitions.yaml
@@ -651,7 +651,7 @@
 - name: Oracle DB
   sourceDefinitionId: b39a7370-74c3-45a6-ac3a-380d48520a83
   dockerRepository: airbyte/source-oracle
-  dockerImageTag: 0.3.18
+  dockerImageTag: 0.3.19
   documentationUrl: https://docs.airbyte.io/integrations/sources/oracle
   icon: oracle.svg
   sourceType: database

--- a/airbyte-config/init/src/main/resources/seed/source_specs.yaml
+++ b/airbyte-config/init/src/main/resources/seed/source_specs.yaml
@@ -6297,7 +6297,7 @@
     supportsNormalization: false
     supportsDBT: false
     supported_destination_sync_modes: []
-- dockerImage: "airbyte/source-oracle:0.3.18"
+- dockerImage: "airbyte/source-oracle:0.3.19"
   spec:
     documentationUrl: "https://docs.airbyte.io/integrations/sources/oracle"
     connectionSpecification:
@@ -6307,7 +6307,6 @@
       required:
       - "host"
       - "port"
-      - "sid"
       - "username"
       properties:
         host:
@@ -6326,10 +6325,40 @@
           maximum: 65536
           default: 1521
           order: 2
-        sid:
-          title: "SID (Oracle System Identifier)"
-          type: "string"
+        connection_data:
+          title: "Connect by"
+          type: "object"
+          description: "Connect data that will be used for DB connection"
           order: 3
+          oneOf:
+          - title: "Service name"
+            description: "Use service name"
+            required:
+            - "service_name"
+            properties:
+              connection_type:
+                type: "string"
+                const: "service_name"
+                default: "service_name"
+                order: 0
+              service_name:
+                title: "Service name"
+                type: "string"
+                order: 1
+          - title: "System ID (SID)"
+            description: "Use SID (Oracle System Identifier)"
+            required:
+            - "sid"
+            properties:
+              connection_type:
+                type: "string"
+                const: "sid"
+                default: "sid"
+                order: 0
+              sid:
+                title: "System ID (SID)"
+                type: "string"
+                order: 1
         username:
           title: "User"
           description: "The username which is used to access the database."

--- a/airbyte-integrations/connectors/source-oracle-strict-encrypt/Dockerfile
+++ b/airbyte-integrations/connectors/source-oracle-strict-encrypt/Dockerfile
@@ -17,5 +17,5 @@ ENV TZ UTC
 
 COPY --from=build /airbyte /airbyte
 
-LABEL io.airbyte.version=0.3.16
+LABEL io.airbyte.version=0.3.17
 LABEL io.airbyte.name=airbyte/source-oracle-strict-encrypt

--- a/airbyte-integrations/connectors/source-oracle-strict-encrypt/src/test/resources/expected_spec.json
+++ b/airbyte-integrations/connectors/source-oracle-strict-encrypt/src/test/resources/expected_spec.json
@@ -4,7 +4,7 @@
     "$schema": "http://json-schema.org/draft-07/schema#",
     "title": "Oracle Source Spec",
     "type": "object",
-    "required": ["host", "port", "sid", "username", "encryption"],
+    "required": ["host", "port", "username", "encryption"],
     "properties": {
       "host": {
         "title": "Host",
@@ -21,10 +21,53 @@
         "default": 1521,
         "order": 2
       },
-      "sid": {
-        "title": "SID (Oracle System Identifier)",
-        "type": "string",
-        "order": 3
+      "connection_data": {
+        "title": "Connect by",
+        "type": "object",
+        "description": "Connect data that will be used for DB connection",
+        "order": 3,
+        "oneOf": [
+          {
+            "title": "Service name",
+            "description": "Use service name",
+            "required": [
+              "service_name"
+            ],
+            "properties": {
+              "connection_type": {
+                "type": "string",
+                "const": "service_name",
+                "default": "service_name",
+                "order": 0
+              },
+              "service_name": {
+                "title": "Service name",
+                "type": "string",
+                "order": 1
+              }
+            }
+          },
+          {
+            "title": "System ID (SID)",
+            "description": "Use SID (Oracle System Identifier)",
+            "required": [
+              "sid"
+            ],
+            "properties": {
+              "connection_type": {
+                "type": "string",
+                "const": "sid",
+                "default": "sid",
+                "order": 0
+              },
+              "sid": {
+                "title": "System ID (SID)",
+                "type": "string",
+                "order": 1
+              }
+            }
+          }
+        ]
       },
       "username": {
         "title": "User",

--- a/airbyte-integrations/connectors/source-oracle/Dockerfile
+++ b/airbyte-integrations/connectors/source-oracle/Dockerfile
@@ -8,5 +8,5 @@ ENV TZ UTC
 COPY build/distributions/${APPLICATION}*.tar ${APPLICATION}.tar
 RUN tar xf ${APPLICATION}.tar --strip-components=1
 
-LABEL io.airbyte.version=0.3.18
+LABEL io.airbyte.version=0.3.19
 LABEL io.airbyte.name=airbyte/source-oracle

--- a/airbyte-integrations/connectors/source-oracle/src/main/java/io/airbyte/integrations/source/oracle/OracleSource.java
+++ b/airbyte-integrations/connectors/source-oracle/src/main/java/io/airbyte/integrations/source/oracle/OracleSource.java
@@ -41,6 +41,11 @@ public class OracleSource extends AbstractJdbcSource<JDBCType> implements Source
   private static final String KEY_STORE_FILE_PATH = "clientkeystore.jks";
   private static final String KEY_STORE_PASS = RandomStringUtils.randomAlphanumeric(8);
 
+  private static final String SID = "sid";
+  private static final String SERVICE_NAME = "service_name";
+  private static final String UNRECOGNIZED = "Unrecognized";
+  private static final String CONNECTION_DATA = "connection_data";
+
   enum Protocol {
     TCP,
     TCPS
@@ -70,12 +75,21 @@ public class OracleSource extends AbstractJdbcSource<JDBCType> implements Source
     final Protocol protocol = config.has(JdbcUtils.ENCRYPTION_KEY)
         ? obtainConnectionProtocol(config.get(JdbcUtils.ENCRYPTION_KEY), additionalParameters)
         : Protocol.TCP;
-    final String connectionString = String.format(
-        "jdbc:oracle:thin:@(DESCRIPTION=(ADDRESS=(PROTOCOL=%s)(HOST=%s)(PORT=%s))(CONNECT_DATA=(SID=%s)))",
-        protocol,
-        config.get(JdbcUtils.HOST_KEY).asText(),
-        config.get(JdbcUtils.PORT_KEY).asText(),
-        config.get("sid").asText());
+    String connectionString;
+    if (config.has(CONNECTION_DATA)) {
+      JsonNode connectionData = config.get(CONNECTION_DATA);
+      final String connectionType = connectionData.has("connection_type") ? connectionData.get("connection_type").asText()
+          : UNRECOGNIZED;
+      connectionString = switch (connectionType) {
+        case SERVICE_NAME -> buildConnectionString(config, protocol.toString(), SERVICE_NAME.toUpperCase(), config.get(CONNECTION_DATA).get(SERVICE_NAME).asText());
+        case SID -> buildConnectionString(config, protocol.toString(), SID.toUpperCase(), config.get(CONNECTION_DATA).get(SID).asText());
+        default -> throw new IllegalArgumentException("Unrecognized connection type: " + connectionType);
+      };
+    } else {
+      // To keep backward compatibility with existing connectors which doesn't have connection_data
+      // and use only sid.
+      connectionString = buildConnectionString(config, protocol.toString(), SID.toUpperCase(), config.get(SID).asText());
+    }
 
     final ImmutableMap.Builder<Object, Object> configBuilder = ImmutableMap.builder()
         .put(JdbcUtils.USERNAME_KEY, config.get(JdbcUtils.USERNAME_KEY).asText())
@@ -189,4 +203,13 @@ public class OracleSource extends AbstractJdbcSource<JDBCType> implements Source
     LOGGER.info("completed source: {}", OracleSource.class);
   }
 
+  private String buildConnectionString(JsonNode config, String protocol, String connectionTypeName, String connectionTypeValue) {
+    return String.format(
+        "jdbc:oracle:thin:@(DESCRIPTION=(ADDRESS=(PROTOCOL=%s)(HOST=%s)(PORT=%s))(CONNECT_DATA=(%s=%s)))",
+        protocol,
+        config.get(JdbcUtils.HOST_KEY).asText(),
+        config.get(JdbcUtils.PORT_KEY).asText(),
+        connectionTypeName,
+        connectionTypeValue);
+  }
 }

--- a/airbyte-integrations/connectors/source-oracle/src/main/resources/spec.json
+++ b/airbyte-integrations/connectors/source-oracle/src/main/resources/spec.json
@@ -4,7 +4,7 @@
     "$schema": "http://json-schema.org/draft-07/schema#",
     "title": "Oracle Source Spec",
     "type": "object",
-    "required": ["host", "port", "connection_data", "username"],
+    "required": ["host", "port", "username"],
     "properties": {
       "host": {
         "title": "Host",

--- a/airbyte-integrations/connectors/source-oracle/src/main/resources/spec.json
+++ b/airbyte-integrations/connectors/source-oracle/src/main/resources/spec.json
@@ -4,7 +4,7 @@
     "$schema": "http://json-schema.org/draft-07/schema#",
     "title": "Oracle Source Spec",
     "type": "object",
-    "required": ["host", "port", "sid", "username"],
+    "required": ["host", "port", "connection_data", "username"],
     "properties": {
       "host": {
         "title": "Host",
@@ -21,10 +21,53 @@
         "default": 1521,
         "order": 2
       },
-      "sid": {
-        "title": "SID (Oracle System Identifier)",
-        "type": "string",
-        "order": 3
+      "connection_data": {
+        "title": "Connect by",
+        "type": "object",
+        "description": "Connect data that will be used for DB connection",
+        "order": 3,
+        "oneOf": [
+          {
+            "title": "Service name",
+            "description": "Use service name",
+            "required": [
+              "service_name"
+            ],
+            "properties": {
+              "connection_type": {
+                "type": "string",
+                "const": "service_name",
+                "default": "service_name",
+                "order": 0
+              },
+              "service_name": {
+                "title": "Service name",
+                "type": "string",
+                "order": 1
+              }
+            }
+          },
+          {
+            "title": "System ID (SID)",
+            "description": "Use SID (Oracle System Identifier)",
+            "required": [
+              "sid"
+            ],
+            "properties": {
+              "connection_type": {
+                "type": "string",
+                "const": "sid",
+                "default": "sid",
+                "order": 0
+              },
+              "sid": {
+                "title": "System ID (SID)",
+                "type": "string",
+                "order": 1
+              }
+            }
+          }
+        ]
       },
       "username": {
         "title": "User",

--- a/airbyte-integrations/connectors/source-oracle/src/test-integration/java/io/airbyte/integrations/source/oracle/AbstractSshOracleSourceAcceptanceTest.java
+++ b/airbyte-integrations/connectors/source-oracle/src/test-integration/java/io/airbyte/integrations/source/oracle/AbstractSshOracleSourceAcceptanceTest.java
@@ -57,7 +57,7 @@ public abstract class AbstractSshOracleSourceAcceptanceTest extends SourceAccept
         String.format(DatabaseDriver.ORACLE.getUrlFormatString(),
             config.get("host").asText(),
             config.get("port").asInt(),
-            config.get("sid").asText()));
+            config.get("connection_data").get("service_name").asText()));
 
     try {
       final JdbcDatabase database = new DefaultJdbcDatabase(dataSource);
@@ -117,7 +117,9 @@ public abstract class AbstractSshOracleSourceAcceptanceTest extends SourceAccept
         .put("username", db.getUsername())
         .put("password", db.getPassword())
         .put("port", db.getExposedPorts().get(0))
-        .put("sid", db.getSid())
+        .put("connection_data", ImmutableMap.builder()
+            .put("service_name", db.getSid())
+            .put("connection_type", "service_name").build())
         .put("schemas", List.of("JDBC_SPACE"))
         .put("encryption", Jsons.jsonNode(ImmutableMap.builder()
             .put("encryption_method", "unencrypted")

--- a/airbyte-integrations/connectors/source-oracle/src/test-integration/java/io/airbyte/integrations/source/oracle/OracleSourceAcceptanceTest.java
+++ b/airbyte-integrations/connectors/source-oracle/src/test-integration/java/io/airbyte/integrations/source/oracle/OracleSourceAcceptanceTest.java
@@ -45,7 +45,9 @@ public class OracleSourceAcceptanceTest extends SourceAcceptanceTest {
     config = Jsons.jsonNode(ImmutableMap.builder()
         .put("host", container.getHost())
         .put("port", container.getFirstMappedPort())
-        .put("sid", container.getSid())
+        .put("connection_data", ImmutableMap.builder()
+            .put("service_name", container.getSid())
+            .put("connection_type", "service_name").build())
         .put("username", container.getUsername())
         .put("password", container.getPassword())
         .put("schemas", List.of("JDBC_SPACE"))
@@ -61,7 +63,7 @@ public class OracleSourceAcceptanceTest extends SourceAcceptanceTest {
         String.format(DatabaseDriver.ORACLE.getUrlFormatString(),
             config.get("host").asText(),
             config.get("port").asInt(),
-            config.get("sid").asText()));
+            config.get("connection_data").get("service_name").asText()));
 
     try {
       final JdbcDatabase database = new DefaultJdbcDatabase(dataSource);

--- a/airbyte-integrations/connectors/source-oracle/src/test-integration/java/io/airbyte/integrations/source/oracle/OracleSourceDatatypeTest.java
+++ b/airbyte-integrations/connectors/source-oracle/src/test-integration/java/io/airbyte/integrations/source/oracle/OracleSourceDatatypeTest.java
@@ -44,7 +44,9 @@ public class OracleSourceDatatypeTest extends AbstractSourceDatabaseTypeTest {
     config = Jsons.jsonNode(ImmutableMap.builder()
         .put("host", container.getHost())
         .put("port", container.getFirstMappedPort())
-        .put("sid", container.getSid())
+        .put("connection_data", ImmutableMap.builder()
+            .put("service_name", container.getSid())
+            .put("connection_type", "service_name").build())
         .put("username", container.getUsername())
         .put("password", container.getPassword())
         .put("schemas", List.of("TEST"))
@@ -57,7 +59,7 @@ public class OracleSourceDatatypeTest extends AbstractSourceDatabaseTypeTest {
         String.format(DatabaseDriver.ORACLE.getUrlFormatString(),
             config.get("host").asText(),
             config.get("port").asInt(),
-            config.get("sid").asText()),
+            config.get("connection_data").get("service_name").asText()),
         null);
     final Database database = new Database(dslContext);
     LOGGER.warn("config: " + config);

--- a/airbyte-integrations/connectors/source-oracle/src/test-integration/java/io/airbyte/integrations/source/oracle/OracleSourceNneAcceptanceTest.java
+++ b/airbyte-integrations/connectors/source-oracle/src/test-integration/java/io/airbyte/integrations/source/oracle/OracleSourceNneAcceptanceTest.java
@@ -41,7 +41,7 @@ public class OracleSourceNneAcceptanceTest extends OracleSourceAcceptanceTest {
             String.format("jdbc:oracle:thin:@//%s:%d/%s",
                 clone.get(JdbcUtils.HOST_KEY).asText(),
                 clone.get(JdbcUtils.PORT_KEY).asInt(),
-                clone.get("sid").asText()),
+                clone.get("connection_data").get("service_name").asText()),
             JdbcUtils.parseJdbcParameters("oracle.net.encryption_client=REQUIRED&" +
                 "oracle.net.encryption_types_client=( "
                 + algorithm + " )")));
@@ -64,7 +64,7 @@ public class OracleSourceNneAcceptanceTest extends OracleSourceAcceptanceTest {
             String.format(DatabaseDriver.ORACLE.getUrlFormatString(),
                 config.get(JdbcUtils.HOST_KEY).asText(),
                 config.get(JdbcUtils.PORT_KEY).asInt(),
-                config.get("sid").asText())));
+                config.get("connection_data").get("service_name").asText())));
 
     final String networkServiceBanner =
         "select network_service_banner from v$session_connect_info where sid in (select distinct sid from v$mystat)";

--- a/airbyte-integrations/connectors/source-oracle/src/test-integration/java/io/airbyte/integrations/source/oracle/OracleSourceNneAcceptanceTest.java
+++ b/airbyte-integrations/connectors/source-oracle/src/test-integration/java/io/airbyte/integrations/source/oracle/OracleSourceNneAcceptanceTest.java
@@ -92,7 +92,7 @@ public class OracleSourceNneAcceptanceTest extends OracleSourceAcceptanceTest {
             String.format(DatabaseDriver.ORACLE.getUrlFormatString(),
                 config.get(JdbcUtils.HOST_KEY).asText(),
                 config.get(JdbcUtils.PORT_KEY).asInt(),
-                config.get("sid").asText()),
+                config.get("connection_data").get("service_name").asText()),
             JdbcUtils.parseJdbcParameters("oracle.net.encryption_client=REQUIRED&" +
                 "oracle.net.encryption_types_client=( "
                 + algorithm + " )")));

--- a/airbyte-integrations/connectors/source-oracle/src/test/java/io/airbyte/integrations/source/oracle/OracleSpecTest.java
+++ b/airbyte-integrations/connectors/source-oracle/src/test/java/io/airbyte/integrations/source/oracle/OracleSpecTest.java
@@ -32,12 +32,14 @@ public class OracleSpecTest {
                                               {
                                                 "host": "localhost",
                                                 "port": 1521,
-                                                "sid": "ora_db",
                                                 "username": "ora",
                                                 "password": "pwd",
                                                 "schemas": [
                                                   "public"
                                                 ],
+                                                "connection_data": {
+                                                  "sid": "ora_db"
+                                                },
                                                 "jdbc_url_params": "property1=pValue1&property2=pValue2"
                                               }
                                               """;
@@ -70,7 +72,7 @@ public class OracleSpecTest {
   @Test
   void testSsidMissing() {
     final JsonNode config = Jsons.deserialize(CONFIGURATION);
-    ((ObjectNode) config).remove("sid");
+    ((ObjectNode) (config.get("connection_data"))).remove("sid");
     assertFalse(validator.test(schema, config));
   }
 

--- a/docs/integrations/sources/oracle.md
+++ b/docs/integrations/sources/oracle.md
@@ -130,8 +130,9 @@ Airbite has the ability to connect to the Oracle source with 3 network connectiv
 
 ## Changelog
 
-| Version | Date | Pull Request | Subject                                         |
-|:--------| :--- | :--- |:------------------------------------------------|
+| Version | Date       | Pull Request | Subject                                         |
+|:--------|:-----------| :--- |:------------------------------------------------|
+| 0.3.19  | 2022-08-03 | [14953](https://github.com/airbytehq/airbyte/pull/14953) | Use Service Name to connect to database |
 | 0.3.18  | 2022-07-14 | [14574](https://github.com/airbytehq/airbyte/pull/14574) | Removed additionalProperties:false from JDBC source connectors |
 | 0.3.17  | 2022-06-24 | [14092](https://github.com/airbytehq/airbyte/pull/14092) | Introduced a custom jdbc param field |
 | 0.3.16  | 2022-06-22 | [13997](https://github.com/airbytehq/airbyte/pull/13997) | Fixed tests |


### PR DESCRIPTION
## What
Fixes #11348 

## How
Added option to choose which property should be used to connect to Oracle DB SID or service name. On the UI it has a following look:


![Screenshot from 2022-07-25 14-25-40](https://user-images.githubusercontent.com/35812734/180767363-f2f0c388-e39d-445a-94b5-a7a435fe0259.png)

Saved backward compatibility for existing connectors that have SID as connection property 

## Recommended reading order
1. `OracleSource.java`
2. `spec.json`

## 🚨 User Impact 🚨
There will be error in the case when user needs to downgrade connector version for existing connection without changing connector setting. To avoid such issue, user needs to update connection configuration as well
For the opposite case when user needs to upgrade connector version without changing setting it works well

## Pre-merge Checklist
Expand the relevant checklist and delete the others.

<details><summary><strong>New Connector</strong></summary>

### Community member or Airbyter

- [ ] **Community member?** Grant edit access to maintainers ([instructions](https://docs.github.com/en/github/collaborating-with-pull-requests/working-with-forks/allowing-changes-to-a-pull-request-branch-created-from-a-fork#enabling-repository-maintainer-permissions-on-existing-pull-requests))
- [ ] Secrets in the connector's spec are annotated with `airbyte_secret`
- [ ] Unit & integration tests added and passing. Community members, please provide proof of success locally e.g: screenshot or copy-paste unit, integration, and acceptance test output. To run acceptance tests for a Python connector, follow instructions in the README. For java connectors run `./gradlew :airbyte-integrations:connectors:<name>:integrationTest`.
- [ ] Code reviews completed
- [ ] Documentation updated
    - [ ] Connector's `README.md`
    - [ ] Connector's `bootstrap.md`. See [description and examples](https://docs.google.com/document/d/1ypdgmwmEHWv-TrO4_YOQ7pAJGVrMp5BOkEVh831N260/edit?usp=sharing)
    - [ ] `docs/integrations/<source or destination>/<name>.md` including changelog. See changelog [example](https://docs.airbyte.io/integrations/sources/stripe#changelog)
    - [ ] `docs/integrations/README.md`
    - [ ] `airbyte-integrations/builds.md`
- [ ] PR name follows [PR naming conventions](https://docs.airbyte.io/contributing-to-airbyte/updating-documentation#issues-and-pull-requests)

### Airbyter

If this is a community PR, the Airbyte engineer reviewing this PR is responsible for the below items.

- [ ] Create a non-forked branch based on this PR and test the below items on it
- [ ] Build is successful
- [ ] If new credentials are required for use in CI, add them to GSM. [Instructions](https://docs.airbyte.io/connector-development#using-credentials-in-ci).
- [ ] [`/test connector=connectors/<name>` command](https://docs.airbyte.io/connector-development#updating-an-existing-connector) is passing
- [ ] New Connector version released on Dockerhub by running the `/publish` command described [here](https://docs.airbyte.io/connector-development#updating-an-existing-connector)
- [ ] After the connector is published, connector added to connector index as described [here](https://docs.airbyte.io/connector-development#publishing-a-connector)
- [ ] Seed specs have been re-generated by building the platform and committing the changes to the seed spec files, as described [here](https://docs.airbyte.io/connector-development#publishing-a-connector)

</details>

<details><summary><strong>Updating a connector</strong></summary>

### Community member or Airbyter

- [ ] Grant edit access to maintainers ([instructions](https://docs.github.com/en/github/collaborating-with-pull-requests/working-with-forks/allowing-changes-to-a-pull-request-branch-created-from-a-fork#enabling-repository-maintainer-permissions-on-existing-pull-requests))
- [ ] Secrets in the connector's spec are annotated with `airbyte_secret`
- [ ] Unit & integration tests added and passing. Community members, please provide proof of success locally e.g: screenshot or copy-paste unit, integration, and acceptance test output. To run acceptance tests for a Python connector, follow instructions in the README. For java connectors run `./gradlew :airbyte-integrations:connectors:<name>:integrationTest`.
- [ ] Code reviews completed
- [ ] Documentation updated
    - [ ] Connector's `README.md`
    - [ ] Connector's `bootstrap.md`. See [description and examples](https://docs.google.com/document/d/1ypdgmwmEHWv-TrO4_YOQ7pAJGVrMp5BOkEVh831N260/edit?usp=sharing)
    - [ ] Changelog updated in `docs/integrations/<source or destination>/<name>.md` including changelog. See changelog [example](https://docs.airbyte.io/integrations/sources/stripe#changelog)
- [ ] PR name follows [PR naming conventions](https://docs.airbyte.io/contributing-to-airbyte/updating-documentation#issues-and-pull-requests)

### Airbyter

If this is a community PR, the Airbyte engineer reviewing this PR is responsible for the below items.

- [ ] Create a non-forked branch based on this PR and test the below items on it
- [ ] Build is successful
- [ ] If new credentials are required for use in CI, add them to GSM. [Instructions](https://docs.airbyte.io/connector-development#using-credentials-in-ci).
- [ ] [`/test connector=connectors/<name>` command](https://docs.airbyte.io/connector-development#updating-an-existing-connector) is passing
- [ ] New Connector version released on Dockerhub and connector version bumped by running the `/publish` command described [here](https://docs.airbyte.io/connector-development#updating-an-existing-connector)

</details>

<details><summary><strong>Connector Generator</strong></summary>

- [ ] Issue acceptance criteria met
- [ ] PR name follows [PR naming conventions](https://docs.airbyte.io/contributing-to-airbyte/updating-documentation#issues-and-pull-requests)
- [ ] If adding a new generator, add it to the [list of scaffold modules being tested](https://github.com/airbytehq/airbyte/blob/master/airbyte-integrations/connector-templates/generator/build.gradle#L41)
- [ ] The generator test modules (all connectors with `-scaffold` in their name) have been updated with the latest scaffold by running `./gradlew :airbyte-integrations:connector-templates:generator:testScaffoldTemplates` then checking in your changes
- [ ] Documentation which references the generator is updated as needed

</details>

## Tests

<details><summary><strong>Unit</strong></summary>

*Put your unit tests output here.*

</details>

<details><summary><strong>Integration</strong></summary>

*Put your integration tests output here.*

</details>

<details><summary><strong>Acceptance</strong></summary>

*Put your acceptance tests output here.*

</details>
