### PR TITLE
Fail on invalid state message

### DIFF
--- a/airbyte-integrations/bases/base-java/build.gradle
+++ b/airbyte-integrations/bases/base-java/build.gradle
@@ -18,6 +18,7 @@ dependencies {
     implementation 'org.bouncycastle:bcpkix-jdk15on:1.66'
     implementation 'org.bouncycastle:bctls-jdk15on:1.66'
 
+    implementation libs.jackson.annotations
     implementation libs.connectors.testcontainers
     implementation libs.connectors.testcontainers.jdbc
 

--- a/airbyte-integrations/bases/base-java/src/main/java/io/airbyte/integrations/base/IntegrationRunner.java
+++ b/airbyte-integrations/bases/base-java/src/main/java/io/airbyte/integrations/base/IntegrationRunner.java
@@ -4,6 +4,8 @@
 
 package io.airbyte.integrations.base;
 
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.annotation.JsonPropertyDescription;
 import com.fasterxml.jackson.databind.JsonNode;
 import com.google.common.annotations.VisibleForTesting;
 import com.google.common.base.Preconditions;
@@ -167,13 +169,7 @@ public class IntegrationRunner {
     final Scanner input = new Scanner(System.in, StandardCharsets.UTF_8).useDelimiter("[\r\n]+");
     consumer.start();
     while (input.hasNext()) {
-      final String inputString = input.next();
-      final Optional<AirbyteMessage> messageOptional = Jsons.tryDeserialize(inputString, AirbyteMessage.class);
-      if (messageOptional.isPresent()) {
-        consumer.accept(messageOptional.get());
-      } else {
-        LOGGER.error("Received invalid message: " + inputString);
-      }
+      consumeMessage(consumer, input.next());
     }
   }
 
@@ -245,6 +241,31 @@ public class IntegrationRunner {
     }
   }
 
+  /**
+   * Consumes an {@link AirbyteMessage} for processing.
+   *
+   * If the provided JSON string is invalid AND represents a {@link AirbyteMessage.Type#STATE}
+   * message, processing is halted. Otherwise, the invalid message is logged and execution continues.
+   *
+   * @param consumer An {@link AirbyteMessageConsumer} that can handle the provided message.
+   * @param inputString JSON representation of an {@link AirbyteMessage}.
+   * @throws Exception if an invalid state message is provided or the consumer is unable to accept the
+   *         provided message.
+   */
+  @VisibleForTesting
+  static void consumeMessage(final AirbyteMessageConsumer consumer, final String inputString) throws Exception {
+    final Optional<AirbyteMessage> messageOptional = Jsons.tryDeserialize(inputString, AirbyteMessage.class);
+    if (messageOptional.isPresent()) {
+      consumer.accept(messageOptional.get());
+    } else {
+      if (isStateMessage(inputString)) {
+        throw new IllegalStateException("Invalid state message: " + inputString);
+      } else {
+        LOGGER.error("Received invalid message: " + inputString);
+      }
+    }
+  }
+
   private static String dumpThread(final Thread thread) {
     return String.format("%s (%s)\n Thread stacktrace: %s", thread.getName(), thread.getState(),
         Strings.join(List.of(thread.getStackTrace()), "\n        at "));
@@ -278,6 +299,43 @@ public class IntegrationRunner {
 
     final String[] tokens = connectorImage.split(":");
     return tokens[tokens.length - 1];
+  }
+
+  /**
+   * Tests whether the provided JSON string represents a state message.
+   *
+   * @param input a JSON string that represents an {@link AirbyteMessage}.
+   * @return {@code true} if the message is a state message, {@code false} otherwise.
+   */
+  private static boolean isStateMessage(final String input) {
+    final Optional<AirbyteTypeMessage> deserialized = Jsons.tryDeserialize(input, AirbyteTypeMessage.class);
+    if (deserialized.isPresent()) {
+      return deserialized.get().getType() == Type.STATE;
+    } else {
+      return false;
+    }
+  }
+
+  /**
+   * Custom class that can be used to parse a JSON message to determine the type of the represented
+   * {@link AirbyteMessage}.
+   */
+  private static class AirbyteTypeMessage {
+
+    @JsonProperty("type")
+    @JsonPropertyDescription("Message type")
+    private AirbyteMessage.Type type;
+
+    @JsonProperty("type")
+    public AirbyteMessage.Type getType() {
+      return type;
+    }
+
+    @JsonProperty("type")
+    public void setType(final AirbyteMessage.Type type) {
+      this.type = type;
+    }
+
   }
 
 }

--- a/airbyte-integrations/bases/base-java/src/test/java/io/airbyte/integrations/base/IntegrationRunnerTest.java
+++ b/airbyte-integrations/bases/base-java/src/test/java/io/airbyte/integrations/base/IntegrationRunnerTest.java
@@ -12,6 +12,7 @@ import static org.mockito.Mockito.doThrow;
 import static org.mockito.Mockito.inOrder;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.spy;
+import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
@@ -375,6 +376,50 @@ class IntegrationRunnerTest {
     assertEquals("dev", IntegrationRunner.parseConnectorVersion("airbyte/destination-test:dev"));
     assertEquals("1.0.1-alpha", IntegrationRunner.parseConnectorVersion("destination-test:1.0.1-alpha"));
     assertEquals("1.0.1-alpha", IntegrationRunner.parseConnectorVersion(":1.0.1-alpha"));
+  }
+
+  @Test
+  void testConsumptionOfInvalidStateMessage() {
+    final String invalidStateMessage = """
+                                       {
+                                         "type" : "STATE",
+                                         "state" : {
+                                           "type": "NOT_RECOGNIZED",
+                                           "global": {
+                                             "streamStates": {
+                                               "foo" : "bar"
+                                             }
+                                           }
+                                         }
+                                       }
+                                       """;
+
+    Assertions.assertThrows(IllegalStateException.class, () -> {
+      try (final AirbyteMessageConsumer consumer = mock(AirbyteMessageConsumer.class)) {
+        IntegrationRunner.consumeMessage(consumer, invalidStateMessage);
+      }
+    });
+  }
+
+  @Test
+  void testConsumptionOfInvalidNonStateMessage() {
+    final String invalidNonStateMessage = """
+                                          {
+                                            "type" : "NOT_RECOGNIZED",
+                                            "record" : {
+                                              "namespace": "namespace",
+                                              "stream": "stream",
+                                              "emittedAt": 123456789
+                                            }
+                                          }
+                                          """;
+
+    Assertions.assertDoesNotThrow(() -> {
+      try (final AirbyteMessageConsumer consumer = mock(AirbyteMessageConsumer.class)) {
+        IntegrationRunner.consumeMessage(consumer, invalidNonStateMessage);
+        verify(consumer, times(0)).accept(any(AirbyteMessage.class));
+      }
+    });
   }
 
 }


### PR DESCRIPTION
## What
* https://github.com/airbytehq/airbyte/issues/14067
* Prevent connector execution if state message is invalid.

## How
* Attempts to check the type of the message on deserialization failure.  If the type is `STATE`, an exception is thrown instead of silently continuing with execution.

## Recommended reading order
1. `IntegrationRunner.java`
2. `IntegrationRunnerTest.java`

## Tests

<details><summary><strong>Unit</strong></summary>

* Added unit tests to validate correct behavior on an invalid state message and an invalid non-state message.  Tests already covered the valid case.

</details>