### PR TITLE
Validate only on incremental

### DIFF
--- a/airbyte-protocol/protocol-models/src/main/java/io/airbyte/protocol/models/CatalogHelpers.java
+++ b/airbyte-protocol/protocol-models/src/main/java/io/airbyte/protocol/models/CatalogHelpers.java
@@ -130,7 +130,8 @@ public class CatalogHelpers {
   }
 
   /**
-   * Extracts {@link StreamDescriptor}s for each stream with an incremental {@link SyncMode} in a given {@link ConfiguredAirbyteCatalog}
+   * Extracts {@link StreamDescriptor}s for each stream with an incremental {@link SyncMode} in a
+   * given {@link ConfiguredAirbyteCatalog}
    *
    * @param configuredCatalog catalog
    * @return list of stream descriptors

--- a/airbyte-protocol/protocol-models/src/main/java/io/airbyte/protocol/models/CatalogHelpers.java
+++ b/airbyte-protocol/protocol-models/src/main/java/io/airbyte/protocol/models/CatalogHelpers.java
@@ -84,22 +84,6 @@ public class CatalogHelpers {
   }
 
   /**
-   * Converts a {@link ConfiguredAirbyteCatalog} into an {@link AirbyteCatalog}. This is possible
-   * because the latter is a subset of the former. It filters out the non incremental streams.
-   *
-   * @param configuredCatalog - catalog to convert
-   * @return - airbyte catalog
-   */
-  public static AirbyteCatalog configuredCatalogToCatalogOnlyIncremental(final ConfiguredAirbyteCatalog configuredCatalog) {
-    return new AirbyteCatalog().withStreams(
-        configuredCatalog.getStreams()
-            .stream()
-            .filter(streamAndConfig -> streamAndConfig.getSyncMode() == SyncMode.INCREMENTAL)
-            .map(ConfiguredAirbyteStream::getStream)
-            .toList());
-  }
-
-  /**
    * Extracts {@link StreamDescriptor} for a given {@link AirbyteStream}
    *
    * @param airbyteStream stream
@@ -137,7 +121,11 @@ public class CatalogHelpers {
    * @return list of stream descriptors
    */
   public static List<StreamDescriptor> extractIncrementalStreamDescriptors(final ConfiguredAirbyteCatalog configuredCatalog) {
-    return extractStreamDescriptors(configuredCatalogToCatalogOnlyIncremental(configuredCatalog));
+    return configuredCatalog.getStreams()
+        .stream()
+        .filter(configuredStream -> configuredStream.getSyncMode() == SyncMode.INCREMENTAL)
+        .map(configuredStream -> extractDescriptor(configuredStream.getStream()))
+        .toList();
   }
 
   /**

--- a/airbyte-protocol/protocol-models/src/main/java/io/airbyte/protocol/models/CatalogHelpers.java
+++ b/airbyte-protocol/protocol-models/src/main/java/io/airbyte/protocol/models/CatalogHelpers.java
@@ -84,6 +84,22 @@ public class CatalogHelpers {
   }
 
   /**
+   * Converts a {@link ConfiguredAirbyteCatalog} into an {@link AirbyteCatalog}. This is possible
+   * because the latter is a subset of the former. It filters out the non incremental streams.
+   *
+   * @param configuredCatalog - catalog to convert
+   * @return - airbyte catalog
+   */
+  public static AirbyteCatalog configuredCatalogToCatalogOnlyIncremental(final ConfiguredAirbyteCatalog configuredCatalog) {
+    return new AirbyteCatalog().withStreams(
+        configuredCatalog.getStreams()
+            .stream()
+            .filter(streamAndConfig -> streamAndConfig.getSyncMode() == SyncMode.INCREMENTAL)
+            .map(ConfiguredAirbyteStream::getStream)
+            .toList());
+  }
+
+  /**
    * Extracts {@link StreamDescriptor} for a given {@link AirbyteStream}
    *
    * @param airbyteStream stream
@@ -111,6 +127,16 @@ public class CatalogHelpers {
    */
   public static List<StreamDescriptor> extractStreamDescriptors(final ConfiguredAirbyteCatalog configuredCatalog) {
     return extractStreamDescriptors(configuredCatalogToCatalog(configuredCatalog));
+  }
+
+  /**
+   * Extracts {@link StreamDescriptor}s for each stream with an incremental {@link SyncMode} in a given {@link ConfiguredAirbyteCatalog}
+   *
+   * @param configuredCatalog catalog
+   * @return list of stream descriptors
+   */
+  public static List<StreamDescriptor> extractIncrementalStreamDescriptors(final ConfiguredAirbyteCatalog configuredCatalog) {
+    return extractStreamDescriptors(configuredCatalogToCatalogOnlyIncremental(configuredCatalog));
   }
 
   /**

--- a/airbyte-protocol/protocol-models/src/test/java/io/airbyte/protocol/models/CatalogHelpersTest.java
+++ b/airbyte-protocol/protocol-models/src/test/java/io/airbyte/protocol/models/CatalogHelpersTest.java
@@ -116,7 +116,7 @@ class CatalogHelpersTest {
   }
 
   @Test
-  void testConfiguredCatalogToCatalogOnlyIncremental() {
+  void testExtractIncrementalStreamDescriptors() {
     final ConfiguredAirbyteCatalog configuredCatalog = new ConfiguredAirbyteCatalog()
         .withStreams(List.of(
             new ConfiguredAirbyteStream()

--- a/airbyte-protocol/protocol-models/src/test/java/io/airbyte/protocol/models/CatalogHelpersTest.java
+++ b/airbyte-protocol/protocol-models/src/test/java/io/airbyte/protocol/models/CatalogHelpersTest.java
@@ -130,10 +130,10 @@ class CatalogHelpersTest {
                     new AirbyteStream()
                         .withName("one"))));
 
-    final AirbyteCatalog catalog = CatalogHelpers.configuredCatalogToCatalogOnlyIncremental(configuredCatalog);
+    final List<StreamDescriptor> streamDescriptors = CatalogHelpers.extractIncrementalStreamDescriptors(configuredCatalog);
 
-    assertEquals(1, catalog.getStreams().size());
-    assertEquals("one", catalog.getStreams().get(0).getName());
+    assertEquals(1, streamDescriptors.size());
+    assertEquals("one", streamDescriptors.get(0).getName());
   }
 
 }

--- a/airbyte-protocol/protocol-models/src/test/java/io/airbyte/protocol/models/CatalogHelpersTest.java
+++ b/airbyte-protocol/protocol-models/src/test/java/io/airbyte/protocol/models/CatalogHelpersTest.java
@@ -115,4 +115,27 @@ class CatalogHelpersTest {
     assertEquals(expectedDiff, actualDiff.stream().sorted(STREAM_TRANSFORM_COMPARATOR).toList());
   }
 
+  @Test
+  public void testConfiguredCatalogToCatalogOnlyIncremental() {
+    final ConfiguredAirbyteCatalog configuredCatalog = new ConfiguredAirbyteCatalog()
+        .withStreams(List.of(
+            new ConfiguredAirbyteStream()
+                .withSyncMode(SyncMode.INCREMENTAL)
+                .withStream(
+                    new AirbyteStream()
+                        .withName("one")
+                ),
+            new ConfiguredAirbyteStream()
+                .withSyncMode(SyncMode.FULL_REFRESH)
+                .withStream(
+                    new AirbyteStream()
+                        .withName("one")
+                )
+        ));
+
+    final AirbyteCatalog catalog = CatalogHelpers.configuredCatalogToCatalogOnlyIncremental(configuredCatalog);
+
+    assertEquals(1, catalog.getStreams().size());
+    assertEquals("one", catalog.getStreams().get(0).getName());
+  }
 }

--- a/airbyte-protocol/protocol-models/src/test/java/io/airbyte/protocol/models/CatalogHelpersTest.java
+++ b/airbyte-protocol/protocol-models/src/test/java/io/airbyte/protocol/models/CatalogHelpersTest.java
@@ -116,26 +116,24 @@ class CatalogHelpersTest {
   }
 
   @Test
-  public void testConfiguredCatalogToCatalogOnlyIncremental() {
+  void testConfiguredCatalogToCatalogOnlyIncremental() {
     final ConfiguredAirbyteCatalog configuredCatalog = new ConfiguredAirbyteCatalog()
         .withStreams(List.of(
             new ConfiguredAirbyteStream()
                 .withSyncMode(SyncMode.INCREMENTAL)
                 .withStream(
                     new AirbyteStream()
-                        .withName("one")
-                ),
+                        .withName("one")),
             new ConfiguredAirbyteStream()
                 .withSyncMode(SyncMode.FULL_REFRESH)
                 .withStream(
                     new AirbyteStream()
-                        .withName("one")
-                )
-        ));
+                        .withName("one"))));
 
     final AirbyteCatalog catalog = CatalogHelpers.configuredCatalogToCatalogOnlyIncremental(configuredCatalog);
 
     assertEquals(1, catalog.getStreams().size());
     assertEquals("one", catalog.getStreams().get(0).getName());
   }
+
 }

--- a/airbyte-workers/src/main/java/io/airbyte/workers/temporal/sync/PersistStateActivityImpl.java
+++ b/airbyte-workers/src/main/java/io/airbyte/workers/temporal/sync/PersistStateActivityImpl.java
@@ -55,7 +55,7 @@ public class PersistStateActivityImpl implements PersistStateActivity {
   void validateStreamStates(final StateWrapper state, final ConfiguredAirbyteCatalog configuredCatalog) {
     final List<StreamDescriptor> stateStreamDescriptors =
         state.getStateMessages().stream().map(stateMessage -> stateMessage.getStream().getStreamDescriptor()).toList();
-    final List<StreamDescriptor> catalogStreamDescriptors = CatalogHelpers.extractStreamDescriptors(configuredCatalog);
+    final List<StreamDescriptor> catalogStreamDescriptors = CatalogHelpers.extractIncrementalStreamDescriptors(configuredCatalog);
     catalogStreamDescriptors.forEach(streamDescriptor -> {
       if (!stateStreamDescriptors.contains(streamDescriptor)) {
         throw new IllegalStateException(

--- a/airbyte-workers/src/test/java/io/airbyte/workers/temporal/sync/PersistStateActivityTest.java
+++ b/airbyte-workers/src/test/java/io/airbyte/workers/temporal/sync/PersistStateActivityTest.java
@@ -27,7 +27,6 @@ import java.util.List;
 import java.util.Optional;
 import java.util.UUID;
 import org.elasticsearch.common.collect.Map;
-import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.InjectMocks;
@@ -76,7 +75,7 @@ class PersistStateActivityTest {
   // This test is to ensure that we correctly throw an error if not every stream in the configured
   // catalog has a state message when migrating from Legacy to Per-Stream
   @Test
-  void testPersistWithInvalidStateDuringMigration() throws IOException {
+  void testPersistWithValidMissingStateDuringMigration() throws IOException {
     final ConfiguredAirbyteStream stream = new ConfiguredAirbyteStream().withStream(new AirbyteStream().withName("a").withNamespace("a1"));
     final ConfiguredAirbyteStream stream2 = new ConfiguredAirbyteStream().withStream(new AirbyteStream().withName("b"));
 
@@ -92,7 +91,8 @@ class PersistStateActivityTest {
     final StandardSyncOutput syncOutput = new StandardSyncOutput().withState(state);
     Mockito.when(featureFlags.useStreamCapableState()).thenReturn(true);
     Mockito.when(statePersistence.isMigration(Mockito.eq(CONNECTION_ID), Mockito.eq(StateType.STREAM), Mockito.any(Optional.class))).thenReturn(true);
-    Assertions.assertThrows(IllegalStateException.class, () -> persistStateActivity.persist(CONNECTION_ID, syncOutput, migrationConfiguredCatalog));
+    persistStateActivity.persist(CONNECTION_ID, syncOutput, migrationConfiguredCatalog);
+    Mockito.verify(statePersistence).updateOrCreateState(Mockito.eq(CONNECTION_ID), Mockito.any(StateWrapper.class));
   }
 
   @Test

--- a/airbyte-workers/src/test/java/io/airbyte/workers/temporal/sync/PersistStateActivityTest.java
+++ b/airbyte-workers/src/test/java/io/airbyte/workers/temporal/sync/PersistStateActivityTest.java
@@ -99,7 +99,8 @@ class PersistStateActivityTest {
   void testPersistWithValidStateDuringMigration() throws IOException {
     final ConfiguredAirbyteStream stream = new ConfiguredAirbyteStream().withStream(new AirbyteStream().withName("a").withNamespace("a1"));
     final ConfiguredAirbyteStream stream2 = new ConfiguredAirbyteStream().withStream(new AirbyteStream().withName("b"));
-    final ConfiguredAirbyteStream stream3 = new ConfiguredAirbyteStream().withStream(new AirbyteStream().withName("c")).withSyncMode(SyncMode.FULL_REFRESH);
+    final ConfiguredAirbyteStream stream3 =
+        new ConfiguredAirbyteStream().withStream(new AirbyteStream().withName("c")).withSyncMode(SyncMode.FULL_REFRESH);
 
     final AirbyteStateMessage stateMessage1 = new AirbyteStateMessage()
         .withType(AirbyteStateType.STREAM)

--- a/airbyte-workers/src/test/java/io/airbyte/workers/temporal/sync/PersistStateActivityTest.java
+++ b/airbyte-workers/src/test/java/io/airbyte/workers/temporal/sync/PersistStateActivityTest.java
@@ -21,6 +21,7 @@ import io.airbyte.protocol.models.AirbyteStreamState;
 import io.airbyte.protocol.models.CatalogHelpers;
 import io.airbyte.protocol.models.ConfiguredAirbyteCatalog;
 import io.airbyte.protocol.models.ConfiguredAirbyteStream;
+import io.airbyte.protocol.models.SyncMode;
 import java.io.IOException;
 import java.util.List;
 import java.util.Optional;
@@ -98,6 +99,7 @@ class PersistStateActivityTest {
   void testPersistWithValidStateDuringMigration() throws IOException {
     final ConfiguredAirbyteStream stream = new ConfiguredAirbyteStream().withStream(new AirbyteStream().withName("a").withNamespace("a1"));
     final ConfiguredAirbyteStream stream2 = new ConfiguredAirbyteStream().withStream(new AirbyteStream().withName("b"));
+    final ConfiguredAirbyteStream stream3 = new ConfiguredAirbyteStream().withStream(new AirbyteStream().withName("c")).withSyncMode(SyncMode.FULL_REFRESH);
 
     final AirbyteStateMessage stateMessage1 = new AirbyteStateMessage()
         .withType(AirbyteStateType.STREAM)
@@ -111,7 +113,7 @@ class PersistStateActivityTest {
     final JsonNode jsonState = Jsons.jsonNode(List.of(stateMessage1, stateMessage2));
     final State state = new State().withState(jsonState);
 
-    final ConfiguredAirbyteCatalog migrationConfiguredCatalog = new ConfiguredAirbyteCatalog().withStreams(List.of(stream, stream2));
+    final ConfiguredAirbyteCatalog migrationConfiguredCatalog = new ConfiguredAirbyteCatalog().withStreams(List.of(stream, stream2, stream3));
     final StandardSyncOutput syncOutput = new StandardSyncOutput().withState(state);
     Mockito.when(featureFlags.useStreamCapableState()).thenReturn(true);
     Mockito.when(statePersistence.isMigration(Mockito.eq(CONNECTION_ID), Mockito.eq(StateType.STREAM), Mockito.any(Optional.class))).thenReturn(true);


### PR DESCRIPTION
## What
Resolves https://github.com/airbytehq/airbyte/issues/14962

Change the validation before persisting the state to only include the incremental state.

The full refresh don't produce states and and it should be remove from the validation.