### PR TITLE
Make loadBalancerIP configurable for webapp

### DIFF
--- a/charts/airbyte-webapp/templates/service.yaml
+++ b/charts/airbyte-webapp/templates/service.yaml
@@ -16,3 +16,6 @@ spec:
     name: http
   selector:
     airbyte: webapp
+  {{- if .Values.service.loadBalancerIP }}
+  loadBalancerIP: {{ .Values.service.loadBalancerIP }}
+  {{- end }}


### PR DESCRIPTION
## What
Fixing https://github.com/airbytehq/airbyte/issues/14991
Currently, loadBalancerIP should be hardcorded in the yaml file, but we can be changed it to a configurable value in the yaml file.

## How
Add a configurable value to values.yaml and change the service yaml accordingly.
```
  {{- if .Values.service.loadBalancerIP }}
  loadBalancerIP: {{ .Values.service.loadBalancerIP }}
  {{- end }}
```

## Recommended reading order
1. `service.yaml`

## 🚨 User Impact 🚨
Are there any breaking changes? No
