### PR TITLE
Add metrics for temporal workflow resets

### DIFF
--- a/airbyte-metrics/metrics-lib/src/main/java/io/airbyte/metrics/lib/DogStatsDMetricClient.java
+++ b/airbyte-metrics/metrics-lib/src/main/java/io/airbyte/metrics/lib/DogStatsDMetricClient.java
@@ -21,9 +21,15 @@ import lombok.extern.slf4j.Slf4j;
  * Open source users are free to turn this on and consume the same metrics.
  * <p>
  * This class is intended to be used in conjunction with {@link Configs#getPublishMetrics()}.
+ * <p>
+ * Any {@link MetricAttribute}s provided with the metric data are sent as tags created by joining
+ * the {@code key} and {@code value} property of each {@link MetricAttribute} with a
+ * {@link #TAG_DELIMITER} delimiter.
  */
 @Slf4j
 public class DogStatsDMetricClient implements MetricClient {
+
+  private static final String TAG_DELIMITER = ":";
 
   private boolean instancePublish = false;
   private StatsDClient statsDClient;
@@ -122,7 +128,7 @@ public class DogStatsDMetricClient implements MetricClient {
    * @return An array of tag values.
    */
   private String[] toTags(final MetricAttribute... attributes) {
-    return Stream.of(attributes).map(a -> a.value()).collect(Collectors.toList()).toArray(new String[] {});
+    return Stream.of(attributes).map(a -> String.join(TAG_DELIMITER, a.key(), a.value())).collect(Collectors.toList()).toArray(new String[] {});
   }
 
 }

--- a/airbyte-metrics/metrics-lib/src/main/java/io/airbyte/metrics/lib/DogStatsDMetricClient.java
+++ b/airbyte-metrics/metrics-lib/src/main/java/io/airbyte/metrics/lib/DogStatsDMetricClient.java
@@ -8,6 +8,8 @@ import com.google.common.annotations.VisibleForTesting;
 import com.timgroup.statsd.NonBlockingStatsDClientBuilder;
 import com.timgroup.statsd.StatsDClient;
 import io.airbyte.config.Configs;
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
 import lombok.extern.slf4j.Slf4j;
 
 /**
@@ -18,7 +20,7 @@ import lombok.extern.slf4j.Slf4j;
  * <p>
  * Open source users are free to turn this on and consume the same metrics.
  * <p>
- * This class is intended to be used in conjection with {@link Configs#getPublishMetrics()}.
+ * This class is intended to be used in conjunction with {@link Configs#getPublishMetrics()}.
  */
 @Slf4j
 public class DogStatsDMetricClient implements MetricClient {
@@ -62,10 +64,10 @@ public class DogStatsDMetricClient implements MetricClient {
    *
    * @param metric
    * @param amt to adjust.
-   * @param tags
+   * @param attributes
    */
   @Override
-  public void count(final MetricsRegistry metric, final long amt, final String... tags) {
+  public void count(final MetricsRegistry metric, final long amt, final MetricAttribute... attributes) {
     if (instancePublish) {
       if (statsDClient == null) {
         // do not loudly fail to prevent application disruption
@@ -73,8 +75,8 @@ public class DogStatsDMetricClient implements MetricClient {
         return;
       }
 
-      log.info("publishing count, name: {}, value: {}, tags: {}", metric, amt, tags);
-      statsDClient.count(metric.getMetricName(), amt, tags);
+      log.info("publishing count, name: {}, value: {}, attributes: {}", metric, amt, attributes);
+      statsDClient.count(metric.getMetricName(), amt, toTags(attributes));
     }
   }
 
@@ -83,10 +85,10 @@ public class DogStatsDMetricClient implements MetricClient {
    *
    * @param metric
    * @param val to record.
-   * @param tags
+   * @param attributes
    */
   @Override
-  public void gauge(final MetricsRegistry metric, final double val, final String... tags) {
+  public void gauge(final MetricsRegistry metric, final double val, final MetricAttribute... attributes) {
     if (instancePublish) {
       if (statsDClient == null) {
         // do not loudly fail to prevent application disruption
@@ -94,13 +96,13 @@ public class DogStatsDMetricClient implements MetricClient {
         return;
       }
 
-      log.info("publishing gauge, name: {}, value: {}, tags: {}", metric, val, tags);
-      statsDClient.gauge(metric.getMetricName(), val, tags);
+      log.info("publishing gauge, name: {}, value: {}, attributes: {}", metric, val, attributes);
+      statsDClient.gauge(metric.getMetricName(), val, toTags(attributes));
     }
   }
 
   @Override
-  public void distribution(MetricsRegistry metric, double val, final String... tags) {
+  public void distribution(final MetricsRegistry metric, final double val, final MetricAttribute... attributes) {
     if (instancePublish) {
       if (statsDClient == null) {
         // do not loudly fail to prevent application disruption
@@ -108,9 +110,19 @@ public class DogStatsDMetricClient implements MetricClient {
         return;
       }
 
-      log.info("recording distribution, name: {}, value: {}, tags: {}", metric, val, tags);
-      statsDClient.distribution(metric.getMetricName(), val, tags);
+      log.info("recording distribution, name: {}, value: {}, attributes: {}", metric, val, attributes);
+      statsDClient.distribution(metric.getMetricName(), val, toTags(attributes));
     }
+  }
+
+  /**
+   * Converts each {@link MetricAttribute} tuple to a list of tags consumable by StatsD.
+   *
+   * @param attributes An array of {@link MetricAttribute} tuples.
+   * @return An array of tag values.
+   */
+  private String[] toTags(final MetricAttribute... attributes) {
+    return Stream.of(attributes).map(a -> a.value()).collect(Collectors.toList()).toArray(new String[] {});
   }
 
 }

--- a/airbyte-metrics/metrics-lib/src/main/java/io/airbyte/metrics/lib/MetricAttribute.java
+++ b/airbyte-metrics/metrics-lib/src/main/java/io/airbyte/metrics/lib/MetricAttribute.java
@@ -1,0 +1,10 @@
+/*
+ * Copyright (c) 2022 Airbyte, Inc., all rights reserved.
+ */
+
+package io.airbyte.metrics.lib;
+
+/**
+ * Custom tuple that represents a key/value pair to be included with a metric.
+ */
+public record MetricAttribute(String key, String value) {}

--- a/airbyte-metrics/metrics-lib/src/main/java/io/airbyte/metrics/lib/MetricAttribute.java
+++ b/airbyte-metrics/metrics-lib/src/main/java/io/airbyte/metrics/lib/MetricAttribute.java
@@ -6,5 +6,9 @@ package io.airbyte.metrics.lib;
 
 /**
  * Custom tuple that represents a key/value pair to be included with a metric.
+ * <p>
+ * It is up to each {@link MetricClient} implementation to decide what data from this record is used
+ * when generating a metric. See the specific implementations of the {@link MetricClient} interface
+ * for actual usage.
  */
 public record MetricAttribute(String key, String value) {}

--- a/airbyte-metrics/metrics-lib/src/main/java/io/airbyte/metrics/lib/MetricClient.java
+++ b/airbyte-metrics/metrics-lib/src/main/java/io/airbyte/metrics/lib/MetricClient.java
@@ -14,18 +14,18 @@ public interface MetricClient {
    *
    * @param metric
    * @param val to record.
-   * @param tags
+   * @param attributes
    */
-  void count(MetricsRegistry metric, long val, final String... tags);
+  void count(MetricsRegistry metric, long val, final MetricAttribute... attributes);
 
   /**
    * Record the latest value for a gauge.
    *
    * @param metric
    * @param val to record.
-   * @param tags
+   * @param attributes
    */
-  void gauge(MetricsRegistry metric, double val, final String... tags);
+  void gauge(MetricsRegistry metric, double val, final MetricAttribute... attributes);
 
   /*
    * Accepts value on the metrics, and report the distribution of these values. Useful to analysis how
@@ -35,9 +35,9 @@ public interface MetricClient {
    *
    * @param val to record.
    *
-   * @param tags
+   * @param attributes
    */
-  void distribution(MetricsRegistry metric, double val, final String... tags);
+  void distribution(MetricsRegistry metric, double val, final MetricAttribute... attributes);
 
   /*
    * Reset initialization. Can be used in a unit test to reset metric client state.

--- a/airbyte-metrics/metrics-lib/src/main/java/io/airbyte/metrics/lib/MetricTags.java
+++ b/airbyte-metrics/metrics-lib/src/main/java/io/airbyte/metrics/lib/MetricTags.java
@@ -13,12 +13,12 @@ import io.airbyte.db.instance.jobs.jooq.generated.enums.JobStatus;
  */
 public class MetricTags {
 
-  public static final String RELEASE_STAGE = "release_stage";
-  public static final String FAILURE_ORIGIN = "failure_origin";
-  public static final String JOB_STATUS = "job_status";
-  public static final String RESET_WORKFLOW_FAILURE_CAUSE = "failure_cause";
   public static final String CONNECTION_ID = "connection_id";
+  public static final String FAILURE_ORIGIN = "failure_origin";
   public static final String JOB_ID = "job_id";
+  public static final String JOB_STATUS = "job_status";
+  public static final String RELEASE_STAGE = "release_stage";
+  public static final String RESET_WORKFLOW_FAILURE_CAUSE = "failure_cause";
   public static final String WORKFLOW_TYPE = "workflow_type";
 
   public static String getReleaseStage(final ReleaseStage stage) {

--- a/airbyte-metrics/metrics-lib/src/main/java/io/airbyte/metrics/lib/MetricTags.java
+++ b/airbyte-metrics/metrics-lib/src/main/java/io/airbyte/metrics/lib/MetricTags.java
@@ -16,7 +16,6 @@ public class MetricTags {
   public static final String RELEASE_STAGE = "release_stage";
   public static final String FAILURE_ORIGIN = "failure_origin";
   public static final String JOB_STATUS = "job_status";
-
   public static final String RESET_WORKFLOW_FAILURE = "cause";
 
   public static String getReleaseStage(final ReleaseStage stage) {

--- a/airbyte-metrics/metrics-lib/src/main/java/io/airbyte/metrics/lib/MetricTags.java
+++ b/airbyte-metrics/metrics-lib/src/main/java/io/airbyte/metrics/lib/MetricTags.java
@@ -13,24 +13,22 @@ import io.airbyte.db.instance.jobs.jooq.generated.enums.JobStatus;
  */
 public class MetricTags {
 
-  private static final String RELEASE_STAGE = "release_stage";
-  private static final String FAILURE_ORIGIN = "failure_origin";
-  private static final String JOB_STATUS = "job_status";
+  public static final String RELEASE_STAGE = "release_stage";
+  public static final String FAILURE_ORIGIN = "failure_origin";
+  public static final String JOB_STATUS = "job_status";
+
+  public static final String RESET_WORKFLOW_FAILURE = "cause";
 
   public static String getReleaseStage(final ReleaseStage stage) {
-    return tagDelimit(RELEASE_STAGE, stage.getLiteral());
+    return stage.getLiteral();
   }
 
   public static String getFailureOrigin(final FailureOrigin origin) {
-    return tagDelimit(FAILURE_ORIGIN, origin.value());
+    return origin.value();
   }
 
   public static String getJobStatus(final JobStatus status) {
-    return tagDelimit(JOB_STATUS, status.getLiteral());
-  }
-
-  private static String tagDelimit(final String tagName, final String tagVal) {
-    return String.join(":", tagName, tagVal);
+    return status.getLiteral();
   }
 
 }

--- a/airbyte-metrics/metrics-lib/src/main/java/io/airbyte/metrics/lib/MetricTags.java
+++ b/airbyte-metrics/metrics-lib/src/main/java/io/airbyte/metrics/lib/MetricTags.java
@@ -16,7 +16,10 @@ public class MetricTags {
   public static final String RELEASE_STAGE = "release_stage";
   public static final String FAILURE_ORIGIN = "failure_origin";
   public static final String JOB_STATUS = "job_status";
-  public static final String RESET_WORKFLOW_FAILURE = "cause";
+  public static final String RESET_WORKFLOW_FAILURE_CAUSE = "failure_cause";
+  public static final String CONNECTION_ID = "connection_id";
+  public static final String JOB_ID = "job_id";
+  public static final String WORKFLOW_TYPE = "workflow_type";
 
   public static String getReleaseStage(final ReleaseStage stage) {
     return stage.getLiteral();

--- a/airbyte-metrics/metrics-lib/src/main/java/io/airbyte/metrics/lib/NotImplementedMetricClient.java
+++ b/airbyte-metrics/metrics-lib/src/main/java/io/airbyte/metrics/lib/NotImplementedMetricClient.java
@@ -12,17 +12,17 @@ package io.airbyte.metrics.lib;
 public class NotImplementedMetricClient implements MetricClient {
 
   @Override
-  public void count(MetricsRegistry metric, long val, String... tags) {
+  public void count(final MetricsRegistry metric, final long val, final MetricAttribute... attributes) {
     // Not Implemented.
   }
 
   @Override
-  public void gauge(MetricsRegistry metric, double val, String... tags) {
+  public void gauge(final MetricsRegistry metric, final double val, final MetricAttribute... attributes) {
     // Not Implemented.
   }
 
   @Override
-  public void distribution(MetricsRegistry metric, double val, String... tags) {
+  public void distribution(final MetricsRegistry metric, final double val, final MetricAttribute... attributes) {
     // Not Implemented.
   }
 

--- a/airbyte-metrics/metrics-lib/src/main/java/io/airbyte/metrics/lib/OpenTelemetryMetricClient.java
+++ b/airbyte-metrics/metrics-lib/src/main/java/io/airbyte/metrics/lib/OpenTelemetryMetricClient.java
@@ -27,6 +27,13 @@ import io.opentelemetry.sdk.resources.Resource;
 import io.opentelemetry.sdk.trace.SdkTracerProvider;
 import io.opentelemetry.sdk.trace.export.BatchSpanProcessor;
 
+/**
+ * Implementation of the {@link MetricClient} that sends the provided metric data to an
+ * OpenTelemetry compliant metrics store.
+ * <p>
+ * Any {@link MetricAttribute}s provided along with the metric data are passed as key/value pairs
+ * annotating the metric.
+ */
 public class OpenTelemetryMetricClient implements MetricClient {
 
   private Meter meter;

--- a/airbyte-metrics/metrics-lib/src/main/java/io/airbyte/metrics/lib/OpenTelemetryMetricClient.java
+++ b/airbyte-metrics/metrics-lib/src/main/java/io/airbyte/metrics/lib/OpenTelemetryMetricClient.java
@@ -33,52 +33,41 @@ public class OpenTelemetryMetricClient implements MetricClient {
   private SdkMeterProvider meterProvider;
 
   @Override
-  public void count(MetricsRegistry metric, long val, String... tags) {
-    LongCounter counter = meter
+  public void count(final MetricsRegistry metric, final long val, final MetricAttribute... attributes) {
+    final LongCounter counter = meter
         .counterBuilder(metric.getMetricName())
         .setDescription(metric.getMetricDescription())
         .build();
 
-    AttributesBuilder attributesBuilder = Attributes.builder();
-    for (String tag : tags) {
-      attributesBuilder.put(stringKey(tag), tag);
-    }
-
+    final AttributesBuilder attributesBuilder = buildAttributes(attributes);
     counter.add(val, attributesBuilder.build());
   }
 
   @Override
-  public void gauge(MetricsRegistry metric, double val, String... tags) {
-    AttributesBuilder attributesBuilder = Attributes.builder();
-    for (String tag : tags) {
-      attributesBuilder.put(stringKey(tag), tag);
-    }
+  public void gauge(final MetricsRegistry metric, final double val, final MetricAttribute... attributes) {
+    final AttributesBuilder attributesBuilder = buildAttributes(attributes);
     meter.gaugeBuilder(metric.getMetricName()).setDescription(metric.getMetricDescription())
         .buildWithCallback(measurement -> measurement.record(val, attributesBuilder.build()));
   }
 
   @Override
-  public void distribution(MetricsRegistry metric, double val, String... tags) {
-    DoubleHistogram histogramMeter = meter.histogramBuilder(metric.getMetricName()).setDescription(metric.getMetricDescription()).build();
-    AttributesBuilder attributesBuilder = Attributes.builder();
-
-    for (String tag : tags) {
-      attributesBuilder.put(stringKey(tag), tag);
-    }
+  public void distribution(final MetricsRegistry metric, final double val, final MetricAttribute... attributes) {
+    final DoubleHistogram histogramMeter = meter.histogramBuilder(metric.getMetricName()).setDescription(metric.getMetricDescription()).build();
+    final AttributesBuilder attributesBuilder = buildAttributes(attributes);
     histogramMeter.record(val, attributesBuilder.build());
   }
 
-  public void initialize(MetricEmittingApp metricEmittingApp, String otelEndpoint) {
-    Resource resource = Resource.getDefault().toBuilder().put(SERVICE_NAME, metricEmittingApp.getApplicationName()).build();
+  public void initialize(final MetricEmittingApp metricEmittingApp, final String otelEndpoint) {
+    final Resource resource = Resource.getDefault().toBuilder().put(SERVICE_NAME, metricEmittingApp.getApplicationName()).build();
 
-    SdkTracerProvider sdkTracerProvider = SdkTracerProvider.builder()
+    final SdkTracerProvider sdkTracerProvider = SdkTracerProvider.builder()
         .addSpanProcessor(
             BatchSpanProcessor
                 .builder(OtlpGrpcSpanExporter.builder().setEndpoint(otelEndpoint).build())
                 .build())
         .setResource(resource)
         .build();
-    MetricExporter metricExporter = OtlpGrpcMetricExporter.builder()
+    final MetricExporter metricExporter = OtlpGrpcMetricExporter.builder()
         .setEndpoint(otelEndpoint).build();
     initialize(metricEmittingApp, metricExporter, sdkTracerProvider, resource);
   }
@@ -89,13 +78,17 @@ public class OpenTelemetryMetricClient implements MetricClient {
   }
 
   @VisibleForTesting
-  void initialize(MetricEmittingApp metricEmittingApp, MetricExporter metricExporter, SdkTracerProvider sdkTracerProvider, Resource resource) {
+  void initialize(
+                  final MetricEmittingApp metricEmittingApp,
+                  final MetricExporter metricExporter,
+                  final SdkTracerProvider sdkTracerProvider,
+                  final Resource resource) {
     meterProvider = SdkMeterProvider.builder()
         .registerMetricReader(PeriodicMetricReader.builder(metricExporter).build())
         .setResource(resource)
         .build();
 
-    OpenTelemetry openTelemetry = OpenTelemetrySdk.builder()
+    final OpenTelemetry openTelemetry = OpenTelemetrySdk.builder()
         .setTracerProvider(sdkTracerProvider)
         .setMeterProvider(meterProvider)
         .setPropagators(ContextPropagators.create(W3CTraceContextPropagator.getInstance()))
@@ -108,6 +101,14 @@ public class OpenTelemetryMetricClient implements MetricClient {
   @Override
   public void shutdown() {
     resetForTest();
+  }
+
+  private AttributesBuilder buildAttributes(final MetricAttribute... attributes) {
+    final AttributesBuilder attributesBuilder = Attributes.builder();
+    for (final MetricAttribute attribute : attributes) {
+      attributesBuilder.put(stringKey(attribute.key()), attribute.value());
+    }
+    return attributesBuilder;
   }
 
 }

--- a/airbyte-metrics/metrics-lib/src/main/java/io/airbyte/metrics/lib/OssMetricsRegistry.java
+++ b/airbyte-metrics/metrics-lib/src/main/java/io/airbyte/metrics/lib/OssMetricsRegistry.java
@@ -105,17 +105,9 @@ public enum OssMetricsRegistry implements MetricsRegistry {
       "temporal.workflow.restart.success",
       "count of number of successful restarts performed by the workflow connection manager."),
 
-  TEMPORAL_WORKFLOW_RESTART_CANCELED(MetricEmittingApps.WORKER,
-      "temporal.workflow.restart.canceled",
-      "count of number of canceled workflow restart attempts"),
-
-  TEMPORAL_WORKFLOW_RESTART_ACTIVITY_FAILURE(MetricEmittingApps.WORKER,
-      "temporal.workflow.restart.failure.activity",
-      "count of the number of restart failures due to the attempted activity."),
-
-  TEMPORAL_WORKFLOW_RESTART_WORKFLOW_FAILURE(MetricEmittingApps.WORKER,
-      "temporal.workflow.restart.failure.workflow",
-      "count of the number of restart failures do to the workflow");
+  TEMPORAL_WORKFLOW_RESTART_FAILURE(MetricEmittingApps.WORKER,
+      "temporal.workflow.restart.failure",
+      "count of the number of workflow restart failures");
 
   private final MetricEmittingApp application;
   private final String metricName;

--- a/airbyte-metrics/metrics-lib/src/main/java/io/airbyte/metrics/lib/OssMetricsRegistry.java
+++ b/airbyte-metrics/metrics-lib/src/main/java/io/airbyte/metrics/lib/OssMetricsRegistry.java
@@ -98,15 +98,15 @@ public enum OssMetricsRegistry implements MetricsRegistry {
       "overall job runtime - scheduling and execution for all attempts - for jobs that reach terminal states in the last hour. tagged by terminal states."),
 
   TEMPORAL_WORKFLOW_RESTART_ATTEMPT(MetricEmittingApps.WORKER,
-      "temporal.workflow.restart.attempt",
+      "temporal_workflow_restart_attempt",
       "count of number of attempts to restart a workflow"),
 
   TEMPORAL_WORKFLOW_RESTART_SUCCESS(MetricEmittingApps.WORKER,
-      "temporal.workflow.restart.success",
+      "temporal_workflow_restart_success",
       "count of number of successful restarts performed by the workflow connection manager."),
 
   TEMPORAL_WORKFLOW_RESTART_FAILURE(MetricEmittingApps.WORKER,
-      "temporal.workflow.restart.failure",
+      "temporal_workflow_restart_failure",
       "count of the number of workflow restart failures");
 
   private final MetricEmittingApp application;

--- a/airbyte-metrics/metrics-lib/src/main/java/io/airbyte/metrics/lib/OssMetricsRegistry.java
+++ b/airbyte-metrics/metrics-lib/src/main/java/io/airbyte/metrics/lib/OssMetricsRegistry.java
@@ -95,7 +95,27 @@ public enum OssMetricsRegistry implements MetricsRegistry {
       "oldest running job in seconds"),
   OVERALL_JOB_RUNTIME_IN_LAST_HOUR_BY_TERMINAL_STATE_SECS(MetricEmittingApps.METRICS_REPORTER,
       "overall_job_runtime_in_last_hour_by_terminal_state_secs",
-      "overall job runtime - scheduling and execution for all attempts - for jobs that reach terminal states in the last hour. tagged by terminal states.");
+      "overall job runtime - scheduling and execution for all attempts - for jobs that reach terminal states in the last hour. tagged by terminal states."),
+
+  TEMPORAL_WORKFLOW_RESTART_ATTEMPT(MetricEmittingApps.WORKER,
+      "temporal.workflow.restart.attempt",
+      "count of number of attempts to restart a workflow"),
+
+  TEMPORAL_WORKFLOW_RESTART_SUCCESS(MetricEmittingApps.WORKER,
+      "temporal.workflow.restart.success",
+      "count of number of successful restarts performed by the workflow connection manager."),
+
+  TEMPORAL_WORKFLOW_RESTART_CANCELED(MetricEmittingApps.WORKER,
+      "temporal.workflow.restart.canceled",
+      "count of number of canceled workflow restart attempts"),
+
+  TEMPORAL_WORKFLOW_RESTART_ACTIVITY_FAILURE(MetricEmittingApps.WORKER,
+      "temporal.workflow.restart.failure.activity",
+      "count of the number of restart failures due to the attempted activity."),
+
+  TEMPORAL_WORKFLOW_RESTART_WORKFLOW_FAILURE(MetricEmittingApps.WORKER,
+      "temporal.workflow.restart.failure.workflow",
+      "count of the number of restart failures do to the workflow");
 
   private final MetricEmittingApp application;
   private final String metricName;

--- a/airbyte-metrics/metrics-lib/src/main/java/io/airbyte/metrics/lib/OssMetricsRegistry.java
+++ b/airbyte-metrics/metrics-lib/src/main/java/io/airbyte/metrics/lib/OssMetricsRegistry.java
@@ -97,17 +97,17 @@ public enum OssMetricsRegistry implements MetricsRegistry {
       "overall_job_runtime_in_last_hour_by_terminal_state_secs",
       "overall job runtime - scheduling and execution for all attempts - for jobs that reach terminal states in the last hour. tagged by terminal states."),
 
-  TEMPORAL_WORKFLOW_RESTART_ATTEMPT(MetricEmittingApps.WORKER,
-      "temporal_workflow_restart_attempt",
-      "count of number of attempts to restart a workflow"),
+  TEMPORAL_WORKFLOW_ATTEMPT(MetricEmittingApps.WORKER,
+      "temporal_workflow_attempt",
+      "count of the number of workflow attempts"),
 
-  TEMPORAL_WORKFLOW_RESTART_SUCCESS(MetricEmittingApps.WORKER,
-      "temporal_workflow_restart_success",
-      "count of number of successful restarts performed by the workflow connection manager."),
+  TEMPORAL_WORKFLOW_SUCCESS(MetricEmittingApps.WORKER,
+      "temporal_workflow_success",
+      "count of the number of successful workflow syncs."),
 
-  TEMPORAL_WORKFLOW_RESTART_FAILURE(MetricEmittingApps.WORKER,
-      "temporal_workflow_restart_failure",
-      "count of the number of workflow restart failures");
+  TEMPORAL_WORKFLOW_FAILURE(MetricEmittingApps.WORKER,
+      "temporal_workflow_failure",
+      "count of the number of workflow failures");
 
   private final MetricEmittingApp application;
   private final String metricName;

--- a/airbyte-metrics/metrics-lib/src/test/java/io/airbyte/metrics/lib/OpenTelemetryMetricClientTest.java
+++ b/airbyte-metrics/metrics-lib/src/test/java/io/airbyte/metrics/lib/OpenTelemetryMetricClientTest.java
@@ -65,7 +65,7 @@ class OpenTelemetryMetricClientTest {
   @Test
   @DisplayName("Tags should be passed into metrics")
   void testCountWithTagSuccess() {
-    openTelemetryMetricClient.count(OssMetricsRegistry.KUBE_POD_PROCESS_CREATE_TIME_MILLISECS, 1, TAG);
+    openTelemetryMetricClient.count(OssMetricsRegistry.KUBE_POD_PROCESS_CREATE_TIME_MILLISECS, 1, new MetricAttribute(TAG, TAG));
 
     metricProvider.forceFlush();
     final List<MetricData> metricDataList = metricExporter.getFinishedMetricItems();

--- a/airbyte-metrics/reporter/src/main/java/io/airbyte/metrics/reporter/ToEmit.java
+++ b/airbyte-metrics/reporter/src/main/java/io/airbyte/metrics/reporter/ToEmit.java
@@ -6,6 +6,7 @@ package io.airbyte.metrics.reporter;
 
 import io.airbyte.commons.lang.Exceptions.Procedure;
 import io.airbyte.db.instance.jobs.jooq.generated.enums.JobStatus;
+import io.airbyte.metrics.lib.MetricAttribute;
 import io.airbyte.metrics.lib.MetricClientFactory;
 import io.airbyte.metrics.lib.MetricQueries;
 import io.airbyte.metrics.lib.MetricTags;
@@ -52,7 +53,8 @@ public enum ToEmit {
     final var times = ReporterApp.configDatabase.query(MetricQueries::overallJobRuntimeForTerminalJobsInLastHour);
     for (Pair<JobStatus, Double> pair : times) {
       MetricClientFactory.getMetricClient().distribution(
-          OssMetricsRegistry.OVERALL_JOB_RUNTIME_IN_LAST_HOUR_BY_TERMINAL_STATE_SECS, pair.getRight(), MetricTags.getJobStatus(pair.getLeft()));
+          OssMetricsRegistry.OVERALL_JOB_RUNTIME_IN_LAST_HOUR_BY_TERMINAL_STATE_SECS, pair.getRight(),
+          new MetricAttribute("job_status", MetricTags.getJobStatus(pair.getLeft())));
     }
   }), 1, TimeUnit.HOURS);
 

--- a/airbyte-metrics/reporter/src/main/java/io/airbyte/metrics/reporter/ToEmit.java
+++ b/airbyte-metrics/reporter/src/main/java/io/airbyte/metrics/reporter/ToEmit.java
@@ -54,7 +54,7 @@ public enum ToEmit {
     for (Pair<JobStatus, Double> pair : times) {
       MetricClientFactory.getMetricClient().distribution(
           OssMetricsRegistry.OVERALL_JOB_RUNTIME_IN_LAST_HOUR_BY_TERMINAL_STATE_SECS, pair.getRight(),
-          new MetricAttribute("job_status", MetricTags.getJobStatus(pair.getLeft())));
+          new MetricAttribute(MetricTags.JOB_STATUS, MetricTags.getJobStatus(pair.getLeft())));
     }
   }), 1, TimeUnit.HOURS);
 

--- a/airbyte-workers/src/main/java/io/airbyte/workers/temporal/scheduling/ConnectionManagerWorkflowImpl.java
+++ b/airbyte-workers/src/main/java/io/airbyte/workers/temporal/scheduling/ConnectionManagerWorkflowImpl.java
@@ -138,7 +138,7 @@ public class ConnectionManagerWorkflowImpl implements ConnectionManagerWorkflow 
 
   @Override
   public void run(final ConnectionUpdaterInput connectionUpdaterInput) throws RetryableException {
-    recordCountMetric(connectionUpdaterInput, OssMetricsRegistry.TEMPORAL_WORKFLOW_ATTEMPT);
+    recordWorkflowCountMetric(connectionUpdaterInput, OssMetricsRegistry.TEMPORAL_WORKFLOW_ATTEMPT);
     try {
       try {
         cancellableSyncWorkflow = generateSyncWorkflowRunnable(connectionUpdaterInput);
@@ -147,7 +147,7 @@ public class ConnectionManagerWorkflowImpl implements ConnectionManagerWorkflow 
         // When a scope is cancelled temporal will throw a CanceledFailure as you can see here:
         // https://github.com/temporalio/sdk-java/blob/master/temporal-sdk/src/main/java/io/temporal/workflow/CancellationScope.java#L72
         // The naming is very misleading, it is not a failure but the expected behavior...
-        recordFailureCountMetric(connectionUpdaterInput, FailureCause.CANCELED);
+        recordWorkflowFailureCountMetric(connectionUpdaterInput, FailureCause.CANCELED);
       }
 
       if (workflowState.isDeleted()) {
@@ -245,7 +245,7 @@ public class ConnectionManagerWorkflowImpl implements ConnectionManagerWorkflow 
         // silently ignore it.
         if (childWorkflowFailure.getCause() instanceof CanceledFailure) {
           // do nothing, cancellation handled by cancellationScope
-          recordFailureCountMetric(connectionUpdaterInput, FailureCause.CANCELED);
+          recordWorkflowFailureCountMetric(connectionUpdaterInput, FailureCause.CANCELED);
         } else if (childWorkflowFailure.getCause()instanceof final ActivityFailure af) {
           // Allows us to classify unhandled failures from the sync workflow. e.g. If the normalization
           // activity throws an exception, for
@@ -289,7 +289,7 @@ public class ConnectionManagerWorkflowImpl implements ConnectionManagerWorkflow 
     deleteResetJobStreams();
 
     // Record the success metric
-    recordCountMetric(connectionUpdaterInput, OssMetricsRegistry.TEMPORAL_WORKFLOW_SUCCESS);
+    recordWorkflowCountMetric(connectionUpdaterInput, OssMetricsRegistry.TEMPORAL_WORKFLOW_SUCCESS);
 
     resetNewConnectionInput(connectionUpdaterInput);
   }
@@ -343,7 +343,7 @@ public class ConnectionManagerWorkflowImpl implements ConnectionManagerWorkflow 
       }
 
       // Record the failure metric
-      recordFailureCountMetric(connectionUpdaterInput, failureCause);
+      recordWorkflowFailureCountMetric(connectionUpdaterInput, failureCause);
 
       resetNewConnectionInput(connectionUpdaterInput);
     }
@@ -823,20 +823,20 @@ public class ConnectionManagerWorkflowImpl implements ConnectionManagerWorkflow 
    *        be executed.
    * @param failureCause The cause of the workflow failure.
    */
-  private void recordFailureCountMetric(final ConnectionUpdaterInput connectionUpdaterInput, final FailureCause failureCause) {
-    recordCountMetric(connectionUpdaterInput, OssMetricsRegistry.TEMPORAL_WORKFLOW_FAILURE,
+  private void recordWorkflowFailureCountMetric(final ConnectionUpdaterInput connectionUpdaterInput, final FailureCause failureCause) {
+    recordWorkflowCountMetric(connectionUpdaterInput, OssMetricsRegistry.TEMPORAL_WORKFLOW_FAILURE,
         new MetricAttribute(MetricTags.RESET_WORKFLOW_FAILURE_CAUSE, failureCause.name()));
   }
 
   /**
-   * Records a counter for the specified metric.
+   * Records a workflow counter for the specified metric.
    *
    * @param connectionUpdaterInput The {@link ConnectionUpdaterInput} that represents the workflow to
    *        * be executed.
    * @param metricName The name of the metric
    * @param metricAttributes Additional metric attributes.
    */
-  private void recordCountMetric(final ConnectionUpdaterInput connectionUpdaterInput,
+  private void recordWorkflowCountMetric(final ConnectionUpdaterInput connectionUpdaterInput,
                                  final OssMetricsRegistry metricName,
                                  final MetricAttribute... metricAttributes) {
     final List<MetricAttribute> baseMetricAttributes = generateMetricAttributes(connectionUpdaterInput);

--- a/airbyte-workers/src/main/java/io/airbyte/workers/temporal/scheduling/ConnectionManagerWorkflowImpl.java
+++ b/airbyte-workers/src/main/java/io/airbyte/workers/temporal/scheduling/ConnectionManagerWorkflowImpl.java
@@ -837,8 +837,8 @@ public class ConnectionManagerWorkflowImpl implements ConnectionManagerWorkflow 
    * @param metricAttributes Additional metric attributes.
    */
   private void recordWorkflowCountMetric(final ConnectionUpdaterInput connectionUpdaterInput,
-                                 final OssMetricsRegistry metricName,
-                                 final MetricAttribute... metricAttributes) {
+                                         final OssMetricsRegistry metricName,
+                                         final MetricAttribute... metricAttributes) {
     final List<MetricAttribute> baseMetricAttributes = generateMetricAttributes(connectionUpdaterInput);
     if (metricAttributes != null) {
       baseMetricAttributes.addAll(Stream.of(metricAttributes).collect(Collectors.toList()));

--- a/airbyte-workers/src/main/java/io/airbyte/workers/temporal/scheduling/ConnectionManagerWorkflowImpl.java
+++ b/airbyte-workers/src/main/java/io/airbyte/workers/temporal/scheduling/ConnectionManagerWorkflowImpl.java
@@ -16,6 +16,7 @@ import io.airbyte.config.StandardSyncInput;
 import io.airbyte.config.StandardSyncOutput;
 import io.airbyte.config.StandardSyncSummary;
 import io.airbyte.config.StandardSyncSummary.ReplicationStatus;
+import io.airbyte.metrics.lib.MetricAttribute;
 import io.airbyte.metrics.lib.MetricClient;
 import io.airbyte.metrics.lib.MetricClientFactory;
 import io.airbyte.metrics.lib.OssMetricsRegistry;
@@ -100,6 +101,8 @@ public class ConnectionManagerWorkflowImpl implements ConnectionManagerWorkflow 
 
   private static final String DELETE_RESET_JOB_STREAMS_TAG = "delete_reset_job_streams";
   private static final int DELETE_RESET_JOB_STREAMS_CURRENT_VERSION = 1;
+
+  private static final String RESET_WORKFLOW_FAILURE_ATTRIBUTE_KEY = "cause";
 
   static final Duration WORKFLOW_FAILURE_RESTART_DELAY = Duration.ofSeconds(new EnvConfigs().getWorkflowFailureRestartDelaySeconds());
 
@@ -239,7 +242,8 @@ public class ConnectionManagerWorkflowImpl implements ConnectionManagerWorkflow 
         // silently ignore it.
         if (childWorkflowFailure.getCause() instanceof CanceledFailure) {
           // do nothing, cancellation handled by cancellationScope
-          metricClient.count(OssMetricsRegistry.TEMPORAL_WORKFLOW_RESTART_CANCELED, 1L);
+          metricClient.count(OssMetricsRegistry.TEMPORAL_WORKFLOW_RESTART_FAILURE, 1L,
+              new MetricAttribute(RESET_WORKFLOW_FAILURE_ATTRIBUTE_KEY, "CANCELED"));
         } else if (childWorkflowFailure.getCause()instanceof final ActivityFailure af) {
           // Allows us to classify unhandled failures from the sync workflow. e.g. If the normalization
           // activity throws an exception, for
@@ -252,14 +256,16 @@ public class ConnectionManagerWorkflowImpl implements ConnectionManagerWorkflow 
               workflowInternalState.getAttemptNumber()));
           reportFailure(connectionUpdaterInput, standardSyncOutput);
           prepareForNextRunAndContinueAsNew(connectionUpdaterInput);
-          metricClient.count(OssMetricsRegistry.TEMPORAL_WORKFLOW_RESTART_ACTIVITY_FAILURE, 1L);
+          metricClient.count(OssMetricsRegistry.TEMPORAL_WORKFLOW_RESTART_FAILURE, 1L,
+              new MetricAttribute(RESET_WORKFLOW_FAILURE_ATTRIBUTE_KEY, "ACTIVITY"));
         } else {
           workflowInternalState.getFailures().add(
               FailureHelper.unknownOriginFailure(childWorkflowFailure.getCause(), workflowInternalState.getJobId(),
                   workflowInternalState.getAttemptNumber()));
           reportFailure(connectionUpdaterInput, standardSyncOutput);
           prepareForNextRunAndContinueAsNew(connectionUpdaterInput);
-          metricClient.count(OssMetricsRegistry.TEMPORAL_WORKFLOW_RESTART_WORKFLOW_FAILURE, 1L);
+          metricClient.count(OssMetricsRegistry.TEMPORAL_WORKFLOW_RESTART_FAILURE, 1L,
+              new MetricAttribute(RESET_WORKFLOW_FAILURE_ATTRIBUTE_KEY, "WORKFLOW"));
         }
       }
     });

--- a/airbyte-workers/src/main/java/io/airbyte/workers/temporal/scheduling/activities/JobCreationAndStatusUpdateActivityImpl.java
+++ b/airbyte-workers/src/main/java/io/airbyte/workers/temporal/scheduling/activities/JobCreationAndStatusUpdateActivityImpl.java
@@ -53,8 +53,6 @@ import lombok.extern.slf4j.Slf4j;
 @Slf4j
 public class JobCreationAndStatusUpdateActivityImpl implements JobCreationAndStatusUpdateActivity {
 
-  private static final String RELEASE_STAGE_ATTRIBUTE_KEY = "release_stage";
-
   private final SyncJobFactory jobFactory;
   private final JobPersistence jobPersistence;
   private final TemporalWorkerRunFactory temporalWorkerRunFactory;
@@ -123,7 +121,7 @@ public class JobCreationAndStatusUpdateActivityImpl implements JobCreationAndSta
     for (final ReleaseStage stage : releaseStages) {
       if (stage != null) {
         MetricClientFactory.getMetricClient().count(OssMetricsRegistry.JOB_CREATED_BY_RELEASE_STAGE, 1,
-            new MetricAttribute(RELEASE_STAGE_ATTRIBUTE_KEY, MetricTags.getReleaseStage(stage)));
+            new MetricAttribute(MetricTags.RELEASE_STAGE, MetricTags.getReleaseStage(stage)));
       }
     }
   }
@@ -233,7 +231,7 @@ public class JobCreationAndStatusUpdateActivityImpl implements JobCreationAndSta
       emitJobIdToReleaseStagesMetric(OssMetricsRegistry.ATTEMPT_FAILED_BY_RELEASE_STAGE, jobId);
       for (final FailureReason reason : failureSummary.getFailures()) {
         MetricClientFactory.getMetricClient().count(OssMetricsRegistry.ATTEMPT_FAILED_BY_FAILURE_ORIGIN, 1,
-            new MetricAttribute("failure_origin", MetricTags.getFailureOrigin(reason.getFailureOrigin())));
+            new MetricAttribute(MetricTags.FAILURE_ORIGIN, MetricTags.getFailureOrigin(reason.getFailureOrigin())));
       }
 
     } catch (final IOException e) {
@@ -333,7 +331,7 @@ public class JobCreationAndStatusUpdateActivityImpl implements JobCreationAndSta
     for (final ReleaseStage stage : releaseStages) {
       if (stage != null) {
         MetricClientFactory.getMetricClient().count(metric, 1,
-            new MetricAttribute(RELEASE_STAGE_ATTRIBUTE_KEY, MetricTags.getReleaseStage(stage)));
+            new MetricAttribute(MetricTags.RELEASE_STAGE, MetricTags.getReleaseStage(stage)));
       }
     }
   }

--- a/airbyte-workers/src/main/java/io/airbyte/workers/temporal/scheduling/activities/JobCreationAndStatusUpdateActivityImpl.java
+++ b/airbyte-workers/src/main/java/io/airbyte/workers/temporal/scheduling/activities/JobCreationAndStatusUpdateActivityImpl.java
@@ -21,6 +21,7 @@ import io.airbyte.config.persistence.ConfigNotFoundException;
 import io.airbyte.config.persistence.ConfigRepository;
 import io.airbyte.config.persistence.StreamResetPersistence;
 import io.airbyte.db.instance.configs.jooq.generated.enums.ReleaseStage;
+import io.airbyte.metrics.lib.MetricAttribute;
 import io.airbyte.metrics.lib.MetricClientFactory;
 import io.airbyte.metrics.lib.MetricTags;
 import io.airbyte.metrics.lib.OssMetricsRegistry;
@@ -51,6 +52,8 @@ import lombok.extern.slf4j.Slf4j;
 @AllArgsConstructor
 @Slf4j
 public class JobCreationAndStatusUpdateActivityImpl implements JobCreationAndStatusUpdateActivity {
+
+  private static final String RELEASE_STAGE_ATTRIBUTE_KEY = "release_stage";
 
   private final SyncJobFactory jobFactory;
   private final JobPersistence jobPersistence;
@@ -119,7 +122,8 @@ public class JobCreationAndStatusUpdateActivityImpl implements JobCreationAndSta
 
     for (final ReleaseStage stage : releaseStages) {
       if (stage != null) {
-        MetricClientFactory.getMetricClient().count(OssMetricsRegistry.JOB_CREATED_BY_RELEASE_STAGE, 1, MetricTags.getReleaseStage(stage));
+        MetricClientFactory.getMetricClient().count(OssMetricsRegistry.JOB_CREATED_BY_RELEASE_STAGE, 1,
+            new MetricAttribute(RELEASE_STAGE_ATTRIBUTE_KEY, MetricTags.getReleaseStage(stage)));
       }
     }
   }
@@ -229,7 +233,7 @@ public class JobCreationAndStatusUpdateActivityImpl implements JobCreationAndSta
       emitJobIdToReleaseStagesMetric(OssMetricsRegistry.ATTEMPT_FAILED_BY_RELEASE_STAGE, jobId);
       for (final FailureReason reason : failureSummary.getFailures()) {
         MetricClientFactory.getMetricClient().count(OssMetricsRegistry.ATTEMPT_FAILED_BY_FAILURE_ORIGIN, 1,
-            MetricTags.getFailureOrigin(reason.getFailureOrigin()));
+            new MetricAttribute("failure_origin", MetricTags.getFailureOrigin(reason.getFailureOrigin())));
       }
 
     } catch (final IOException e) {
@@ -328,7 +332,8 @@ public class JobCreationAndStatusUpdateActivityImpl implements JobCreationAndSta
 
     for (final ReleaseStage stage : releaseStages) {
       if (stage != null) {
-        MetricClientFactory.getMetricClient().count(metric, 1, MetricTags.getReleaseStage(stage));
+        MetricClientFactory.getMetricClient().count(metric, 1,
+            new MetricAttribute(RELEASE_STAGE_ATTRIBUTE_KEY, MetricTags.getReleaseStage(stage)));
       }
     }
   }


### PR DESCRIPTION
## What
* Add visibility into execution of Temporal workflow reset jobs
* Support grouping of metrics by attribute key

## How
* Record custom metrics tracking the reset attempt and success or failure.

## Recommended reading order
1. `MetricAttribute.java`
2. `MetricClient.java`
3. `OssMetricsRegistry.java`
4. `ConnectionManagerWorkflowImpl.java`

All other changes are reactions to the signature changes in the metric client.

## Additional Details

Per #13773, this PR records metrics for the cases mentioned in that ticket, plus two additional ones:  attempts and cancellations.  The reason for adding attempts is to make it possible to compute rates of success/failure, if necessary.  With it out, you would need to add all of the metrics together to get a total number of reset job attempts.  

~~This is probably a good first pass, but ultimately, this would be better served by something like DD or OTEL traces, which would allow for dimensions to be set on the value.  The benefit of this approach would be to be able to pivot by additional information (e.g. connector type, etc).~~

cc: @davinchia @lmossman 