### PR TITLE
Display new per-stream and global state to users when viewing connection settings

### DIFF
--- a/airbyte-webapp/src/pages/ConnectionPage/pages/ConnectionItemPage/components/StateBlock.tsx
+++ b/airbyte-webapp/src/pages/ConnectionPage/pages/ConnectionItemPage/components/StateBlock.tsx
@@ -6,6 +6,19 @@ import { H5, Card } from "components";
 import { ConnectionState } from "core/request/AirbyteClient";
 import { useGetConnectionState } from "hooks/services/useConnectionHook";
 
+function formatState(
+  legacyState: ConnectionState["state"],
+  globalState: ConnectionState["globalState"],
+  streamState: ConnectionState["streamState"],
+  formatMessage: ReturnType<typeof useIntl>["formatMessage"]
+) {
+  // This hierarchy assumes that for those connections which have both global and per-stream state, the global state contains a meaningful copy of any state which would also be saved per-stream
+  const formattedState = legacyState ?? globalState ?? streamState ?? null;
+  return formattedState
+    ? JSON.stringify(formattedState, null, 2)
+    : formatMessage({ id: "tables.connectionState.noConnectionState" });
+}
+
 interface StateBlockProps {
   connectionId: string;
 }
@@ -15,7 +28,7 @@ export const StateBlock: React.FC<StateBlockProps> = ({ connectionId }) => {
   const state = useGetConnectionState(connectionId);
 
   const stateString = useMemo(
-    () => displayState(state.state, state.globalState, state.streamState, formatMessage),
+    () => formatState(state.state, state.globalState, state.streamState, formatMessage),
     [formatMessage, state.state, state.globalState, state.streamState]
   );
 
@@ -28,16 +41,3 @@ export const StateBlock: React.FC<StateBlockProps> = ({ connectionId }) => {
     </Card>
   );
 };
-
-function displayState(
-  legacyState: ConnectionState["state"],
-  globalState: ConnectionState["globalState"],
-  streamState: ConnectionState["streamState"],
-  formatMessage: ReturnType<typeof useIntl>["formatMessage"]
-) {
-  // This hierarchy assumes that for those connections which have both global and per-stream state, the global state contains a meaningful copy of any state which would also be saved per-stream
-  const displayState = legacyState ?? globalState ?? streamState ?? null;
-  return displayState
-    ? JSON.stringify(displayState, null, 2)
-    : formatMessage({ id: "tables.connectionState.noConnectionState" });
-}

--- a/airbyte-webapp/src/pages/ConnectionPage/pages/ConnectionItemPage/components/StateBlock.tsx
+++ b/airbyte-webapp/src/pages/ConnectionPage/pages/ConnectionItemPage/components/StateBlock.tsx
@@ -4,7 +4,6 @@ import { FormattedMessage, useIntl } from "react-intl";
 import { H5, Card } from "components";
 
 import { useGetConnectionState } from "hooks/services/useConnectionHook";
-
 import { ConnectionState } from "core/request/AirbyteClient";
 
 interface StateBlockProps {

--- a/airbyte-webapp/src/pages/ConnectionPage/pages/ConnectionItemPage/components/StateBlock.tsx
+++ b/airbyte-webapp/src/pages/ConnectionPage/pages/ConnectionItemPage/components/StateBlock.tsx
@@ -3,8 +3,8 @@ import { FormattedMessage, useIntl } from "react-intl";
 
 import { H5, Card } from "components";
 
-import { useGetConnectionState } from "hooks/services/useConnectionHook";
 import { ConnectionState } from "core/request/AirbyteClient";
+import { useGetConnectionState } from "hooks/services/useConnectionHook";
 
 interface StateBlockProps {
   connectionId: string;
@@ -15,7 +15,7 @@ export const StateBlock: React.FC<StateBlockProps> = ({ connectionId }) => {
   const state = useGetConnectionState(connectionId);
 
   const stateString = useMemo(
-    () => displayState(state, formatMessage),
+    () => displayState(state.state, state.globalState, state.streamState, formatMessage),
     [formatMessage, state.state, state.globalState, state.streamState]
   );
 
@@ -29,9 +29,14 @@ export const StateBlock: React.FC<StateBlockProps> = ({ connectionId }) => {
   );
 };
 
-function displayState(state: ConnectionState, formatMessage: ReturnType<typeof useIntl>["formatMessage"]) {
+function displayState(
+  legacyState: ConnectionState["state"],
+  globalState: ConnectionState["globalState"],
+  streamState: ConnectionState["streamState"],
+  formatMessage: ReturnType<typeof useIntl>["formatMessage"]
+) {
   // This hierarchy assumes that for those connections which have both global and per-stream state, the global state contains a meaningful copy of any state which would also be saved per-stream
-  const displayState = state?.state ?? state?.globalState ?? state?.streamState ?? null;
+  const displayState = legacyState ?? globalState ?? streamState ?? null;
   return displayState
     ? JSON.stringify(displayState, null, 2)
     : formatMessage({ id: "tables.connectionState.noConnectionState" });

--- a/airbyte-webapp/src/pages/ConnectionPage/pages/ConnectionItemPage/components/StateBlock.tsx
+++ b/airbyte-webapp/src/pages/ConnectionPage/pages/ConnectionItemPage/components/StateBlock.tsx
@@ -15,9 +15,7 @@ export const StateBlock: React.FC<StateBlockProps> = ({ connectionId }) => {
   const { formatMessage } = useIntl();
   const state = useGetConnectionState(connectionId);
 
-  const stateString = useMemo(() => {
-    return displayState(state) ?? formatMessage({ id: "tables.connectionState.noConnectionState" });
-  }, [formatMessage, state.state]);
+  const stateString = useMemo(() => displayState(state, formatMessage), [formatMessage, state.state]);
 
   return (
     <Card $withPadding>
@@ -29,8 +27,10 @@ export const StateBlock: React.FC<StateBlockProps> = ({ connectionId }) => {
   );
 };
 
-function displayState(state: ConnectionState) {
+function displayState(state: ConnectionState, formatMessage: ReturnType<typeof useIntl>["formatMessage"]) {
   // This hierarchy assumes that for those connections which have both global and per-stream state, the global state contains a meaningful copy of any state which would also be saved per-stream
   const displayState = state?.state ?? state?.globalState ?? state?.streamState ?? null;
-  return displayState ? JSON.stringify(displayState, null, 2) : null;
+  return displayState
+    ? JSON.stringify(displayState, null, 2)
+    : formatMessage({ id: "tables.connectionState.noConnectionState" });
 }

--- a/airbyte-webapp/src/pages/ConnectionPage/pages/ConnectionItemPage/components/StateBlock.tsx
+++ b/airbyte-webapp/src/pages/ConnectionPage/pages/ConnectionItemPage/components/StateBlock.tsx
@@ -14,7 +14,10 @@ export const StateBlock: React.FC<StateBlockProps> = ({ connectionId }) => {
   const { formatMessage } = useIntl();
   const state = useGetConnectionState(connectionId);
 
-  const stateString = useMemo(() => displayState(state, formatMessage), [formatMessage, state.state]);
+  const stateString = useMemo(
+    () => displayState(state, formatMessage),
+    [formatMessage, state.state, state.globalState, state.streamState]
+  );
 
   return (
     <Card $withPadding>

--- a/airbyte-webapp/src/pages/ConnectionPage/pages/ConnectionItemPage/components/StateBlock.tsx
+++ b/airbyte-webapp/src/pages/ConnectionPage/pages/ConnectionItemPage/components/StateBlock.tsx
@@ -5,6 +5,8 @@ import { H5, Card } from "components";
 
 import { useGetConnectionState } from "hooks/services/useConnectionHook";
 
+import { ConnectionState } from "core/request/AirbyteClient";
+
 interface StateBlockProps {
   connectionId: string;
 }
@@ -14,9 +16,7 @@ export const StateBlock: React.FC<StateBlockProps> = ({ connectionId }) => {
   const state = useGetConnectionState(connectionId);
 
   const stateString = useMemo(() => {
-    return state?.state
-      ? JSON.stringify(state.state, null, 2)
-      : formatMessage({ id: "tables.connectionState.noConnectionState" });
+    return displayState(state) ?? formatMessage({ id: "tables.connectionState.noConnectionState" });
   }, [formatMessage, state.state]);
 
   return (
@@ -28,3 +28,9 @@ export const StateBlock: React.FC<StateBlockProps> = ({ connectionId }) => {
     </Card>
   );
 };
+
+function displayState(state: ConnectionState) {
+  // This hierarchy assumes that for those connections which have both global and per-stream state, the global state contains a meaningful copy of any state which would also be saved per-stream
+  const displayState = state?.state ?? state?.globalState ?? state?.streamState ?? null;
+  return displayState ? JSON.stringify(displayState, null, 2) : null;
+}


### PR DESCRIPTION
Now with per-stream (and global) state, the `/workspaces/ID/connections/ID/settings` page needed to be updated to show one of the 3 possible state types, rather than only LEGACY state.

For a source using a per-stream  postgres source:

Before:
<img width="1633" alt="Screen Shot 2022-07-25 at 1 28 09 PM" src="https://user-images.githubusercontent.com/303226/180869012-4b810720-5b0e-4c3a-85bf-367a45d24d75.png">


After:
<img width="1633" alt="Screen Shot 2022-07-25 at 1 28 14 PM" src="https://user-images.githubusercontent.com/303226/180869026-e44f6b2c-ccb9-4907-a2bd-8f5a07076949.png">

Closes https://github.com/airbytehq/airbyte/issues/15017