### PR TITLE
don't set workdir to /data when running SAT

### DIFF
--- a/airbyte-integrations/bases/source-acceptance-test/source_acceptance_test/utils/connector_runner.py
+++ b/airbyte-integrations/bases/source-acceptance-test/source_acceptance_test/utils/connector_runner.py
@@ -93,8 +93,6 @@ class ConnectorRunner:
         volumes = self._prepare_volumes(config, state, catalog)
         logging.debug(f"Docker run {self._image}: \n{cmd}\n" f"input: {self.input_folder}\noutput: {self.output_folder}")
 
-        logging.debug("HELLO!")
-
         container = self._client.containers.run(
             image=self._image,
             command=cmd,

--- a/airbyte-integrations/bases/source-acceptance-test/source_acceptance_test/utils/connector_runner.py
+++ b/airbyte-integrations/bases/source-acceptance-test/source_acceptance_test/utils/connector_runner.py
@@ -69,22 +69,22 @@ class ConnectorRunner:
         return output
 
     def call_check(self, config, **kwargs) -> List[AirbyteMessage]:
-        cmd = "check --config tap_config.json"
+        cmd = "check --config /data/tap_config.json"
         output = list(self.run(cmd=cmd, config=config, **kwargs))
         return output
 
     def call_discover(self, config, **kwargs) -> List[AirbyteMessage]:
-        cmd = "discover --config tap_config.json"
+        cmd = "discover --config /data/tap_config.json"
         output = list(self.run(cmd=cmd, config=config, **kwargs))
         return output
 
     def call_read(self, config, catalog, **kwargs) -> List[AirbyteMessage]:
-        cmd = "read --config tap_config.json --catalog catalog.json"
+        cmd = "read --config /data/tap_config.json --catalog /data/catalog.json"
         output = list(self.run(cmd=cmd, config=config, catalog=catalog, **kwargs))
         return output
 
     def call_read_with_state(self, config, catalog, state, **kwargs) -> List[AirbyteMessage]:
-        cmd = "read --config tap_config.json --catalog catalog.json --state state.json"
+        cmd = "read --config /data/tap_config.json --catalog /data/catalog.json --state /data/state.json"
         output = list(self.run(cmd=cmd, config=config, catalog=catalog, state=state, **kwargs))
         return output
 
@@ -93,10 +93,11 @@ class ConnectorRunner:
         volumes = self._prepare_volumes(config, state, catalog)
         logging.debug(f"Docker run {self._image}: \n{cmd}\n" f"input: {self.input_folder}\noutput: {self.output_folder}")
 
+        logging.debug("HELLO!")
+
         container = self._client.containers.run(
             image=self._image,
             command=cmd,
-            working_dir="/data",
             volumes=volumes,
             network_mode="host",
             detach=True,


### PR DESCRIPTION
## What
The connector runner in SAT sets the workdir to /data/ when running connector commands.
This is a problem for low-code connectors because it prevents us from loading the connector's yaml definition.

The solution is to keep the default workdir and point to the config files using an absolute path when running SAT.

An alternative solution would be to point to the yaml file using an absolute path: `/airbyte/integration_code/...`, but this would prevent us from running connectors without building the docker image.

## How
* Remove `working_dir` parameter from container run command
* prepend path to config files with `/data`

## Recommended reading order
1. `airbyte-integrations/bases/source-acceptance-test/source_acceptance_test/utils/connector_runner.py`

## 🚨 User Impact 🚨
Are there any breaking changes? What is the end result perceived by the user? If yes, please merge this PR with the 🚨🚨 emoji so changelog authors can further highlight this if needed.

## Pre-merge Checklist
Expand the relevant checklist and delete the others.

<details><summary><strong>New Connector</strong></summary>

### Community member or Airbyter

- [ ] **Community member?** Grant edit access to maintainers ([instructions](https://docs.github.com/en/github/collaborating-with-pull-requests/working-with-forks/allowing-changes-to-a-pull-request-branch-created-from-a-fork#enabling-repository-maintainer-permissions-on-existing-pull-requests))
- [ ] Secrets in the connector's spec are annotated with `airbyte_secret`
- [ ] Unit & integration tests added and passing. Community members, please provide proof of success locally e.g: screenshot or copy-paste unit, integration, and acceptance test output. To run acceptance tests for a Python connector, follow instructions in the README. For java connectors run `./gradlew :airbyte-integrations:connectors:<name>:integrationTest`.
- [ ] Code reviews completed
- [ ] Documentation updated
    - [ ] Connector's `README.md`
    - [ ] Connector's `bootstrap.md`. See [description and examples](https://docs.google.com/document/d/1ypdgmwmEHWv-TrO4_YOQ7pAJGVrMp5BOkEVh831N260/edit?usp=sharing)
    - [ ] `docs/integrations/<source or destination>/<name>.md` including changelog. See changelog [example](https://docs.airbyte.io/integrations/sources/stripe#changelog)
    - [ ] `docs/integrations/README.md`
    - [ ] `airbyte-integrations/builds.md`
- [ ] PR name follows [PR naming conventions](https://docs.airbyte.io/contributing-to-airbyte/updating-documentation#issues-and-pull-requests)

### Airbyter

If this is a community PR, the Airbyte engineer reviewing this PR is responsible for the below items.

- [ ] Create a non-forked branch based on this PR and test the below items on it
- [ ] Build is successful
- [ ] If new credentials are required for use in CI, add them to GSM. [Instructions](https://docs.airbyte.io/connector-development#using-credentials-in-ci).
- [ ] [`/test connector=connectors/<name>` command](https://docs.airbyte.io/connector-development#updating-an-existing-connector) is passing
- [ ] New Connector version released on Dockerhub by running the `/publish` command described [here](https://docs.airbyte.io/connector-development#updating-an-existing-connector)
- [ ] After the connector is published, connector added to connector index as described [here](https://docs.airbyte.io/connector-development#publishing-a-connector)
- [ ] Seed specs have been re-generated by building the platform and committing the changes to the seed spec files, as described [here](https://docs.airbyte.io/connector-development#publishing-a-connector)

</details>

<details><summary><strong>Updating a connector</strong></summary>

### Community member or Airbyter

- [ ] Grant edit access to maintainers ([instructions](https://docs.github.com/en/github/collaborating-with-pull-requests/working-with-forks/allowing-changes-to-a-pull-request-branch-created-from-a-fork#enabling-repository-maintainer-permissions-on-existing-pull-requests))
- [ ] Secrets in the connector's spec are annotated with `airbyte_secret`
- [ ] Unit & integration tests added and passing. Community members, please provide proof of success locally e.g: screenshot or copy-paste unit, integration, and acceptance test output. To run acceptance tests for a Python connector, follow instructions in the README. For java connectors run `./gradlew :airbyte-integrations:connectors:<name>:integrationTest`.
- [ ] Code reviews completed
- [ ] Documentation updated
    - [ ] Connector's `README.md`
    - [ ] Connector's `bootstrap.md`. See [description and examples](https://docs.google.com/document/d/1ypdgmwmEHWv-TrO4_YOQ7pAJGVrMp5BOkEVh831N260/edit?usp=sharing)
    - [ ] Changelog updated in `docs/integrations/<source or destination>/<name>.md` including changelog. See changelog [example](https://docs.airbyte.io/integrations/sources/stripe#changelog)
- [ ] PR name follows [PR naming conventions](https://docs.airbyte.io/contributing-to-airbyte/updating-documentation#issues-and-pull-requests)

### Airbyter

If this is a community PR, the Airbyte engineer reviewing this PR is responsible for the below items.

- [ ] Create a non-forked branch based on this PR and test the below items on it
- [ ] Build is successful
- [ ] If new credentials are required for use in CI, add them to GSM. [Instructions](https://docs.airbyte.io/connector-development#using-credentials-in-ci).
- [ ] [`/test connector=connectors/<name>` command](https://docs.airbyte.io/connector-development#updating-an-existing-connector) is passing
- [ ] New Connector version released on Dockerhub and connector version bumped by running the `/publish` command described [here](https://docs.airbyte.io/connector-development#updating-an-existing-connector)

</details>

<details><summary><strong>Connector Generator</strong></summary>

- [ ] Issue acceptance criteria met
- [ ] PR name follows [PR naming conventions](https://docs.airbyte.io/contributing-to-airbyte/updating-documentation#issues-and-pull-requests)
- [ ] If adding a new generator, add it to the [list of scaffold modules being tested](https://github.com/airbytehq/airbyte/blob/master/airbyte-integrations/connector-templates/generator/build.gradle#L41)
- [ ] The generator test modules (all connectors with `-scaffold` in their name) have been updated with the latest scaffold by running `./gradlew :airbyte-integrations:connector-templates:generator:testScaffoldTemplates` then checking in your changes
- [ ] Documentation which references the generator is updated as needed

</details>

## Tests

<details><summary><strong>Unit</strong></summary>

*Put your unit tests output here.*

</details>

<details><summary><strong>Integration</strong></summary>

*Put your integration tests output here.*

</details>

<details><summary><strong>Acceptance</strong></summary>

*Put your acceptance tests output here.*

</details>
