### PR TITLE
non-jdbc source connectors: Update additional properties from beta/GA specs and schemas

### DIFF
--- a/airbyte-config/init/src/main/resources/seed/source_definitions.yaml
+++ b/airbyte-config/init/src/main/resources/seed/source_definitions.yaml
@@ -612,7 +612,7 @@
 - name: Notion
   sourceDefinitionId: 6e00b415-b02e-4160-bf02-58176a0ae687
   dockerRepository: airbyte/source-notion
-  dockerImageTag: 0.1.6
+  dockerImageTag: 0.1.7
   documentationUrl: https://docs.airbyte.io/integrations/sources/notion
   icon: notion.svg
   sourceType: api

--- a/airbyte-config/init/src/main/resources/seed/source_definitions.yaml
+++ b/airbyte-config/init/src/main/resources/seed/source_definitions.yaml
@@ -327,7 +327,7 @@
 - name: Google Analytics
   sourceDefinitionId: eff3616a-f9c3-11eb-9a03-0242ac130003
   dockerRepository: airbyte/source-google-analytics-v4
-  dockerImageTag: 0.1.23
+  dockerImageTag: 0.1.24
   documentationUrl: https://docs.airbyte.io/integrations/sources/google-analytics-v4
   icon: google-analytics.svg
   sourceType: api

--- a/airbyte-config/init/src/main/resources/seed/source_definitions.yaml
+++ b/airbyte-config/init/src/main/resources/seed/source_definitions.yaml
@@ -17,7 +17,7 @@
 - name: Amazon Ads
   sourceDefinitionId: c6b0a29e-1da9-4512-9002-7bfd0cba2246
   dockerRepository: airbyte/source-amazon-ads
-  dockerImageTag: 0.1.9
+  dockerImageTag: 0.1.10
   documentationUrl: https://docs.airbyte.io/integrations/sources/amazon-ads
   icon: amazonads.svg
   sourceType: api

--- a/airbyte-config/init/src/main/resources/seed/source_specs.yaml
+++ b/airbyte-config/init/src/main/resources/seed/source_specs.yaml
@@ -87,7 +87,7 @@
     supportsNormalization: false
     supportsDBT: false
     supported_destination_sync_modes: []
-- dockerImage: "airbyte/source-amazon-ads:0.1.9"
+- dockerImage: "airbyte/source-amazon-ads:0.1.10"
   spec:
     documentationUrl: "https://docs.airbyte.com/integrations/sources/amazon-ads"
     connectionSpecification:
@@ -187,7 +187,7 @@
       oauth_config_specification:
         complete_oauth_output_specification:
           type: "object"
-          additionalProperties: false
+          additionalProperties: true
           properties:
             refresh_token:
               type: "string"
@@ -195,7 +195,7 @@
               - "refresh_token"
         complete_oauth_server_input_specification:
           type: "object"
-          additionalProperties: false
+          additionalProperties: true
           properties:
             client_id:
               type: "string"
@@ -203,7 +203,7 @@
               type: "string"
         complete_oauth_server_output_specification:
           type: "object"
-          additionalProperties: false
+          additionalProperties: true
           properties:
             client_id:
               type: "string"

--- a/airbyte-config/init/src/main/resources/seed/source_specs.yaml
+++ b/airbyte-config/init/src/main/resources/seed/source_specs.yaml
@@ -2937,7 +2937,7 @@
         oauthFlowOutputParameters:
         - - "access_token"
         - - "refresh_token"
-- dockerImage: "airbyte/source-google-analytics-v4:0.1.23"
+- dockerImage: "airbyte/source-google-analytics-v4:0.1.24"
   spec:
     documentationUrl: "https://docs.airbyte.io/integrations/sources/google-analytics-v4"
     connectionSpecification:

--- a/airbyte-config/init/src/main/resources/seed/source_specs.yaml
+++ b/airbyte-config/init/src/main/resources/seed/source_specs.yaml
@@ -5930,7 +5930,7 @@
     supportsNormalization: false
     supportsDBT: false
     supported_destination_sync_modes: []
-- dockerImage: "airbyte/source-notion:0.1.6"
+- dockerImage: "airbyte/source-notion:0.1.7"
   spec:
     documentationUrl: "https://docs.airbyte.io/integrations/sources/notion"
     connectionSpecification:

--- a/airbyte-integrations/connectors/source-amazon-ads/Dockerfile
+++ b/airbyte-integrations/connectors/source-amazon-ads/Dockerfile
@@ -12,5 +12,5 @@ RUN pip install .
 ENV AIRBYTE_ENTRYPOINT "python /airbyte/integration_code/main.py"
 ENTRYPOINT ["python", "/airbyte/integration_code/main.py"]
 
-LABEL io.airbyte.version=0.1.9
+LABEL io.airbyte.version=0.1.10
 LABEL io.airbyte.name=airbyte/source-amazon-ads

--- a/airbyte-integrations/connectors/source-amazon-ads/integration_tests/spec.json
+++ b/airbyte-integrations/connectors/source-amazon-ads/integration_tests/spec.json
@@ -81,7 +81,7 @@
     "oauth_config_specification": {
       "complete_oauth_output_specification": {
         "type": "object",
-        "additionalProperties": false,
+        "additionalProperties": true,
         "properties": {
           "refresh_token": {
             "type": "string",
@@ -91,7 +91,7 @@
       },
       "complete_oauth_server_input_specification": {
         "type": "object",
-        "additionalProperties": false,
+        "additionalProperties": true,
         "properties": {
           "client_id": {
             "type": "string"
@@ -103,7 +103,7 @@
       },
       "complete_oauth_server_output_specification": {
         "type": "object",
-        "additionalProperties": false,
+        "additionalProperties": true,
         "properties": {
           "client_id": {
             "type": "string",

--- a/airbyte-integrations/connectors/source-amazon-ads/source_amazon_ads/schemas/common.py
+++ b/airbyte-integrations/connectors/source-amazon-ads/source_amazon_ads/schemas/common.py
@@ -20,9 +20,14 @@ class CatalogModel(BaseModel):
             schema.pop("description", None)
             # Remove required section so any missing attribute from API wont break object validation.
             schema.pop("required", None)
+            # According to https://github.com/airbytehq/airbyte/issues/14196 set additionalProperties to True
+            if schema.pop("additionalProperties", None):
+                schema["additionalProperties"] = True
             for name, prop in schema.get("properties", {}).items():
                 prop.pop("title", None)
                 prop.pop("description", None)
+                if prop.pop("additionalProperties", None):
+                    prop["additionalProperties"] = True
                 allow_none = model.__fields__[name].allow_none
                 # Pydantic doesnt treat Union[None, Any] type correctly when
                 # generation jsonschema so we cant set field as nullable (i.e.

--- a/airbyte-integrations/connectors/source-amazon-ads/source_amazon_ads/spec.yaml
+++ b/airbyte-integrations/connectors/source-amazon-ads/source_amazon_ads/spec.yaml
@@ -100,7 +100,7 @@ advanced_auth:
   oauth_config_specification:
     complete_oauth_output_specification:
       type: object
-      additionalProperties: false
+      additionalProperties: true
       properties:
         refresh_token:
           type: string
@@ -108,7 +108,7 @@ advanced_auth:
             - refresh_token
     complete_oauth_server_input_specification:
       type: object
-      additionalProperties: false
+      additionalProperties: true
       properties:
         client_id:
           type: string
@@ -116,7 +116,7 @@ advanced_auth:
           type: string
     complete_oauth_server_output_specification:
       type: object
-      additionalProperties: false
+      additionalProperties: true
       properties:
         client_id:
           type: string

--- a/airbyte-integrations/connectors/source-google-analytics-v4/Dockerfile
+++ b/airbyte-integrations/connectors/source-google-analytics-v4/Dockerfile
@@ -12,5 +12,5 @@ COPY main.py ./
 ENV AIRBYTE_ENTRYPOINT "python /airbyte/integration_code/main.py"
 ENTRYPOINT ["python", "/airbyte/integration_code/main.py"]
 
-LABEL io.airbyte.version=0.1.23
+LABEL io.airbyte.version=0.1.24
 LABEL io.airbyte.name=airbyte/source-google-analytics-v4

--- a/airbyte-integrations/connectors/source-google-analytics-v4/integration_tests/catalog.json
+++ b/airbyte-integrations/connectors/source-google-analytics-v4/integration_tests/catalog.json
@@ -5,7 +5,7 @@
         "name": "website_overview",
         "json_schema": {
           "type": ["null", "object"],
-          "additionalProperties": false,
+          "additionalProperties": true,
           "properties": {
             "ga_date": {
               "type": ["string"]
@@ -60,7 +60,7 @@
         "name": "traffic_sources",
         "json_schema": {
           "type": ["null", "object"],
-          "additionalProperties": false,
+          "additionalProperties": true,
           "properties": {
             "ga_date": {
               "type": ["string"]

--- a/airbyte-integrations/connectors/source-google-analytics-v4/source_google_analytics_v4/source.py
+++ b/airbyte-integrations/connectors/source-google-analytics-v4/source_google_analytics_v4/source.py
@@ -192,7 +192,7 @@ class GoogleAnalyticsV4Stream(HttpStream, ABC):
         schema: Dict[str, Any] = {
             "$schema": "http://json-schema.org/draft-07/schema#",
             "type": ["null", "object"],
-            "additionalProperties": False,
+            "additionalProperties": True,
             "properties": {
                 "view_id": {"type": ["string"]},
             },

--- a/airbyte-integrations/connectors/source-notion/Dockerfile
+++ b/airbyte-integrations/connectors/source-notion/Dockerfile
@@ -34,5 +34,5 @@ COPY source_notion ./source_notion
 ENV AIRBYTE_ENTRYPOINT "python /airbyte/integration_code/main.py"
 ENTRYPOINT ["python", "/airbyte/integration_code/main.py"]
 
-LABEL io.airbyte.version=0.1.6
+LABEL io.airbyte.version=0.1.7
 LABEL io.airbyte.name=airbyte/source-notion

--- a/airbyte-integrations/connectors/source-notion/source_notion/schemas/shared/child.json
+++ b/airbyte-integrations/connectors/source-notion/source_notion/schemas/shared/child.json
@@ -1,7 +1,7 @@
 {
   "$schema": "http://json-schema.org/draft-07/schema#",
   "type": "object",
-  "additionalProperties": false,
+  "additionalProperties": true,
   "properties": {
     "title": { "type": "string" }
   }

--- a/airbyte-integrations/connectors/source-notion/source_notion/schemas/shared/file.json
+++ b/airbyte-integrations/connectors/source-notion/source_notion/schemas/shared/file.json
@@ -14,7 +14,7 @@
     },
     "external": {
       "type": ["null", "object"],
-      "additionalProperties": false,
+      "additionalProperties": true,
       "properties": {
         "url": {
           "type": "string"

--- a/airbyte-integrations/connectors/source-notion/source_notion/schemas/shared/heading.json
+++ b/airbyte-integrations/connectors/source-notion/source_notion/schemas/shared/heading.json
@@ -1,7 +1,7 @@
 {
   "$schema": "http://json-schema.org/draft-07/schema#",
   "type": ["null", "object"],
-  "additionalProperties": false,
+  "additionalProperties": true,
   "properties": {
     "color": { "type": "string" },
     "text": { "type": "array", "items": { "$ref": "rich_text.json" } }

--- a/airbyte-integrations/connectors/source-notion/source_notion/schemas/shared/options.json
+++ b/airbyte-integrations/connectors/source-notion/source_notion/schemas/shared/options.json
@@ -1,7 +1,7 @@
 {
   "$schema": "http://json-schema.org/draft-07/schema#",
   "type": ["null", "object"],
-  "additionalProperties": false,
+  "additionalProperties": true,
   "properties": {
     "id": {
       "type": "string"

--- a/airbyte-integrations/connectors/source-notion/source_notion/schemas/shared/parent.json
+++ b/airbyte-integrations/connectors/source-notion/source_notion/schemas/shared/parent.json
@@ -1,7 +1,7 @@
 {
   "$schema": "http://json-schema.org/draft-07/schema#",
   "type": "object",
-  "additionalProperties": false,
+  "additionalProperties": true,
   "properties": {
     "type": {
       "enum": ["database_id", "page_id", "workspace"]

--- a/airbyte-integrations/connectors/source-notion/source_notion/schemas/shared/rich_text.json
+++ b/airbyte-integrations/connectors/source-notion/source_notion/schemas/shared/rich_text.json
@@ -7,14 +7,14 @@
     },
     "text": {
       "type": ["null", "object"],
-      "additionalProperties": false,
+      "additionalProperties": true,
       "properties": {
         "content": {
           "type": ["null", "string"]
         },
         "link": {
           "type": ["null", "object"],
-          "additionalProperties": false,
+          "additionalProperties": true,
           "properties": {
             "type": {
               "enum": ["url"]
@@ -28,14 +28,14 @@
     },
     "rich_text": {
       "type": ["null", "object"],
-      "additionalProperties": false,
+      "additionalProperties": true,
       "properties": {
         "content": {
           "type": ["null", "string"]
         },
         "link": {
           "type": ["null", "object"],
-          "additionalProperties": false,
+          "additionalProperties": true,
           "properties": {
             "type": {
               "enum": ["url"]
@@ -49,7 +49,7 @@
     },
     "annotations": {
       "type": ["null", "object"],
-      "additionalProperties": false,
+      "additionalProperties": true,
       "properties": {
         "bold": {
           "type": ["null", "boolean"]

--- a/airbyte-integrations/connectors/source-notion/source_notion/schemas/shared/text_element.json
+++ b/airbyte-integrations/connectors/source-notion/source_notion/schemas/shared/text_element.json
@@ -1,7 +1,7 @@
 {
   "$schema": "http://json-schema.org/draft-07/schema#",
   "type": "object",
-  "additionalProperties": false,
+  "additionalProperties": true,
   "properties": {
     "color": { "type": "string" },
     "text": { "type": "array", "items": { "$ref": "rich_text.json" } },

--- a/airbyte-integrations/connectors/source-notion/source_notion/schemas/shared/title.json
+++ b/airbyte-integrations/connectors/source-notion/source_notion/schemas/shared/title.json
@@ -7,7 +7,7 @@
       "type": ["null", "array"],
       "items": {
         "type": ["null", "object"],
-        "additionalProperties": false,
+        "additionalProperties": true,
         "properties": {
           "type": {
             "type": ["null", "string"]
@@ -20,7 +20,7 @@
               },
               "link": {
                 "type": ["null", "object"],
-                "additionalProperties": false,
+                "additionalProperties": true,
                 "properties": {
                   "type": {
                     "enum": ["url"]
@@ -34,7 +34,7 @@
           },
           "annotations": {
             "type": ["null", "object"],
-            "additionalProperties": false,
+            "additionalProperties": true,
             "properties": {
               "bold": {
                 "type": ["null", "boolean"]

--- a/airbyte-integrations/connectors/source-notion/source_notion/schemas/shared/user.json
+++ b/airbyte-integrations/connectors/source-notion/source_notion/schemas/shared/user.json
@@ -1,7 +1,7 @@
 {
   "$schema": "http://json-schema.org/draft-07/schema#",
   "type": "object",
-  "additionalProperties": false,
+  "additionalProperties": true,
   "properties": {
     "object": {
       "enum": ["user"]

--- a/docs/integrations/sources/amazon-ads.md
+++ b/docs/integrations/sources/amazon-ads.md
@@ -90,13 +90,14 @@ Information about expected report generation waiting time you may find [here](ht
 
 | Version | Date       | Pull Request                                               | Subject                                                                                                           |
 |:--------|:-----------|:-----------------------------------------------------------|:------------------------------------------------------------------------------------------------------------------|
-| `0.1.9` | 2022-05-08 | [\#12541](https://github.com/airbytehq/airbyte/pull/12541) | Improve documentation for Beta                                                                                    |
-| `0.1.8` | 2022-05-04 | [\#12482](https://github.com/airbytehq/airbyte/pull/12482) | Update input configuration copy                                                                                   |
-| `0.1.7` | 2022-04-27 | [\#11730](https://github.com/airbytehq/airbyte/pull/11730) | Update fields in source-connectors specifications                                                                 |
-| `0.1.6` | 2022-04-20 | [\#11659](https://github.com/airbytehq/airbyte/pull/11659) | Add adId to products report                                                                                       |
-| `0.1.5` | 2022-04-08 | [\#11430](https://github.com/airbytehq/airbyte/pull/11430) | `Added support OAuth2.0`                                                                                          |
-| `0.1.4` | 2022-02-21 | [\#10513](https://github.com/airbytehq/airbyte/pull/10513) | `Increasing REPORT_WAIT_TIMEOUT for supporting report generation which takes longer time `                        |
-| `0.1.3` | 2021-12-28 | [\#8388](https://github.com/airbytehq/airbyte/pull/8388)   | `Add retry if recoverable error  occured for reporting stream processing`                                         |
-| `0.1.2` | 2021-10-01 | [\#6367](https://github.com/airbytehq/airbyte/pull/6461)   | `Add option to pull data for different regions. Add option to choose profiles we want to pull data. Add lookback` |
-| `0.1.1` | 2021-09-22 | [\#6367](https://github.com/airbytehq/airbyte/pull/6367)   | `Add seller and vendor filters to profiles stream`                                                                |
-| `0.1.0` | 2021-08-13 | [\#5023](https://github.com/airbytehq/airbyte/pull/5023)   | `Initial version`                                                                                                 |
+| 0.1.10 | 2022-07-26 | [00000](https://github.com/airbytehq/airbyte/pull/00000)    | Update `additionalProperties` field to true from schemas                                                          |
+| 0.1.9  | 2022-05-08 | [12541](https://github.com/airbytehq/airbyte/pull/12541)    | Improve documentation for Beta                                                                                    |
+| 0.1.8  | 2022-05-04 | [12482](https://github.com/airbytehq/airbyte/pull/12482)    | Update input configuration copy                                                                                   |
+| 0.1.7  | 2022-04-27 | [11730](https://github.com/airbytehq/airbyte/pull/11730)    | Update fields in source-connectors specifications                                                                 |
+| 0.1.6  | 2022-04-20 | [11659](https://github.com/airbytehq/airbyte/pull/11659)    | Add adId to products report                                                                                       |
+| 0.1.5  | 2022-04-08 | [11430](https://github.com/airbytehq/airbyte/pull/11430)    | Added support OAuth2.0                                                                                            |
+| 0.1.4  | 2022-02-21 | [10513](https://github.com/airbytehq/airbyte/pull/10513)    | Increasing REPORT_WAIT_TIMEOUT for supporting report generation which takes longer time                           |
+| 0.1.3  | 2021-12-28 | [8388](https://github.com/airbytehq/airbyte/pull/8388)      | Add retry if recoverable error  occured for reporting stream processing                                           |
+| 0.1.2  | 2021-10-01 | [6367](https://github.com/airbytehq/airbyte/pull/6461)      | Add option to pull data for different regions. Add option to choose profiles we want to pull data. Add lookback   |
+| 0.1.1  | 2021-09-22 | [6367](https://github.com/airbytehq/airbyte/pull/6367)      | Add seller and vendor filters to profiles stream                                                                  |
+| 0.1.0  | 2021-08-13 | [5023](https://github.com/airbytehq/airbyte/pull/5023)      | Initial version                                                                                                   |

--- a/docs/integrations/sources/amazon-ads.md
+++ b/docs/integrations/sources/amazon-ads.md
@@ -90,7 +90,7 @@ Information about expected report generation waiting time you may find [here](ht
 
 | Version | Date       | Pull Request                                               | Subject                                                                                                           |
 |:--------|:-----------|:-----------------------------------------------------------|:------------------------------------------------------------------------------------------------------------------|
-| 0.1.10 | 2022-07-26 | [00000](https://github.com/airbytehq/airbyte/pull/00000)    | Update `additionalProperties` field to true from schemas                                                          |
+| 0.1.10 | 2022-07-26 | [15042](https://github.com/airbytehq/airbyte/pull/15042)    | Update `additionalProperties` field to true from schemas                                                          |
 | 0.1.9  | 2022-05-08 | [12541](https://github.com/airbytehq/airbyte/pull/12541)    | Improve documentation for Beta                                                                                    |
 | 0.1.8  | 2022-05-04 | [12482](https://github.com/airbytehq/airbyte/pull/12482)    | Update input configuration copy                                                                                   |
 | 0.1.7  | 2022-04-27 | [11730](https://github.com/airbytehq/airbyte/pull/11730)    | Update fields in source-connectors specifications                                                                 |

--- a/docs/integrations/sources/google-analytics-universal-analytics.md
+++ b/docs/integrations/sources/google-analytics-universal-analytics.md
@@ -167,8 +167,8 @@ Incremental sync is supported only if you add `ga:date` dimension to your custom
 
 | Version | Date       | Pull Request                                             | Subject                                                                                      |
 |:--------|:-----------|:---------------------------------------------------------|:---------------------------------------------------------------------------------------------|
-| 0.1.24  | 2022-07-26 | [00000](https://github.com/airbytehq/airbyte/pull/00000) | Update `additionalProperties` field to true from schemas                                     |
-| 0.1.23  | 2022-07-22 | [00000](https://github.com/airbytehq/airbyte/pull/00000) | Add handle request daily quota error                                                         |
+| 0.1.24  | 2022-07-26 | [15042](https://github.com/airbytehq/airbyte/pull/15042) | Update `additionalProperties` field to true from schemas                                     |
+| 0.1.23  | 2022-07-22 | [14949](https://github.com/airbytehq/airbyte/pull/14949) | Add handle request daily quota error                                                         |
 | 0.1.22  | 2022-06-30 | [14298](https://github.com/airbytehq/airbyte/pull/14298) | Specify integer type for ga:dateHourMinute dimension                                         |
 | 0.1.21  | 2022-04-30 | [12500](https://github.com/airbytehq/airbyte/pull/12500) | Improve input configuration copy                                                             |
 | 0.1.20  | 2022-04-28 | [12426](https://github.com/airbytehq/airbyte/pull/12426) | Expose `isDataGOlden` field and always resync data two days back to make sure it is golden   |

--- a/docs/integrations/sources/google-analytics-universal-analytics.md
+++ b/docs/integrations/sources/google-analytics-universal-analytics.md
@@ -167,6 +167,7 @@ Incremental sync is supported only if you add `ga:date` dimension to your custom
 
 | Version | Date       | Pull Request                                             | Subject                                                                                      |
 |:--------|:-----------|:---------------------------------------------------------|:---------------------------------------------------------------------------------------------|
+| 0.1.24  | 2022-07-26 | [00000](https://github.com/airbytehq/airbyte/pull/00000) | Update `additionalProperties` field to true from schemas                                     |
 | 0.1.23  | 2022-07-22 | [00000](https://github.com/airbytehq/airbyte/pull/00000) | Add handle request daily quota error                                                         |
 | 0.1.22  | 2022-06-30 | [14298](https://github.com/airbytehq/airbyte/pull/14298) | Specify integer type for ga:dateHourMinute dimension                                         |
 | 0.1.21  | 2022-04-30 | [12500](https://github.com/airbytehq/airbyte/pull/12500) | Improve input configuration copy                                                             |

--- a/docs/integrations/sources/notion.md
+++ b/docs/integrations/sources/notion.md
@@ -75,6 +75,7 @@ The Notion connector should not run into Notion API limitations under normal usa
 
 | Version | Date       | Pull Request                                             | Subject                                                   |
 |:--------|:-----------|:---------------------------------------------------------|:----------------------------------------------------------|
+| 0.1.7   | 2022-07-26 | [00000](https://github.com/airbytehq/airbyte/pull/00000) | Update `additionalProperties` field to true from shared schemas |
 | 0.1.6   | 2022-07-21 | [14924](https://github.com/airbytehq/airbyte/pull/14924) | Remove `additionalProperties` field from schemas and spec |
 | 0.1.5   | 2022-07-14 | [14706](https://github.com/airbytehq/airbyte/pull/14706) | Added OAuth2.0 authentication                             |
 | 0.1.4   | 2022-07-07 | [14505](https://github.com/airbytehq/airbyte/pull/14505) | Fixed bug when normalization didn't run through           |

--- a/docs/integrations/sources/notion.md
+++ b/docs/integrations/sources/notion.md
@@ -75,7 +75,7 @@ The Notion connector should not run into Notion API limitations under normal usa
 
 | Version | Date       | Pull Request                                             | Subject                                                   |
 |:--------|:-----------|:---------------------------------------------------------|:----------------------------------------------------------|
-| 0.1.7   | 2022-07-26 | [00000](https://github.com/airbytehq/airbyte/pull/00000) | Update `additionalProperties` field to true from shared schemas |
+| 0.1.7   | 2022-07-26 | [15042](https://github.com/airbytehq/airbyte/pull/15042) | Update `additionalProperties` field to true from shared schemas |
 | 0.1.6   | 2022-07-21 | [14924](https://github.com/airbytehq/airbyte/pull/14924) | Remove `additionalProperties` field from schemas and spec |
 | 0.1.5   | 2022-07-14 | [14706](https://github.com/airbytehq/airbyte/pull/14706) | Added OAuth2.0 authentication                             |
 | 0.1.4   | 2022-07-07 | [14505](https://github.com/airbytehq/airbyte/pull/14505) | Fixed bug when normalization didn't run through           |


### PR DESCRIPTION
## What
According to https://github.com/airbytehq/airbyte/pull/14878 `additionalProperties` should be `true` in their JSON spec and stream schemas.

## How
* Edit `spec.json` and schemas of the following connectors:

 | source_name                           | status                      |
|:------------------------------|:-------------------|
| source-google-analytics-v4   | generally_available |
| source-amazon-ads                | beta                          |
| source-notion                           | beta                         |