### PR TITLE
Source-posthog: manually bumps up version.

### DIFF
--- a/airbyte-config/init/src/main/resources/seed/source_definitions.yaml
+++ b/airbyte-config/init/src/main/resources/seed/source_definitions.yaml
@@ -746,7 +746,7 @@
 - name: PostHog
   sourceDefinitionId: af6d50ee-dddf-4126-a8ee-7faee990774f
   dockerRepository: airbyte/source-posthog
-  dockerImageTag: 0.1.7
+  dockerImageTag: 0.1.6
   documentationUrl: https://docs.airbyte.io/integrations/sources/posthog
   icon: posthog.svg
   sourceType: api

--- a/airbyte-config/init/src/main/resources/seed/source_definitions.yaml
+++ b/airbyte-config/init/src/main/resources/seed/source_definitions.yaml
@@ -746,7 +746,7 @@
 - name: PostHog
   sourceDefinitionId: af6d50ee-dddf-4126-a8ee-7faee990774f
   dockerRepository: airbyte/source-posthog
-  dockerImageTag: 0.1.6
+  dockerImageTag: 0.1.7
   documentationUrl: https://docs.airbyte.io/integrations/sources/posthog
   icon: posthog.svg
   sourceType: api

--- a/airbyte-config/init/src/main/resources/seed/source_specs.yaml
+++ b/airbyte-config/init/src/main/resources/seed/source_specs.yaml
@@ -7005,7 +7005,7 @@
     supportsNormalization: false
     supportsDBT: false
     supported_destination_sync_modes: []
-- dockerImage: "airbyte/source-posthog:0.1.6"
+- dockerImage: "airbyte/source-posthog:0.1.7"
   spec:
     documentationUrl: "https://docs.airbyte.com/integrations/sources/posthog"
     connectionSpecification:
@@ -7015,7 +7015,6 @@
       required:
       - "api_key"
       - "start_date"
-      additionalProperties: false
       properties:
         start_date:
           title: "Start Date"

--- a/airbyte-integrations/connectors/source-posthog/Dockerfile
+++ b/airbyte-integrations/connectors/source-posthog/Dockerfile
@@ -12,5 +12,5 @@ RUN pip install .
 ENV AIRBYTE_ENTRYPOINT "python /airbyte/integration_code/main.py"
 ENTRYPOINT ["python", "/airbyte/integration_code/main.py"]
 
-LABEL io.airbyte.version=0.1.6
+LABEL io.airbyte.version=0.1.7
 LABEL io.airbyte.name=airbyte/source-posthog

--- a/airbyte-integrations/connectors/source-posthog/source_posthog/schemas/persons.json
+++ b/airbyte-integrations/connectors/source-posthog/source_posthog/schemas/persons.json
@@ -2,7 +2,7 @@
   "type": "object",
   "properties": {
     "id": {
-      "type": "integer"
+      "type": "string"
     },
     "name": {
       "type": "string"

--- a/airbyte-integrations/connectors/source-posthog/source_posthog/spec.json
+++ b/airbyte-integrations/connectors/source-posthog/source_posthog/spec.json
@@ -5,7 +5,6 @@
     "title": "PostHog Spec",
     "type": "object",
     "required": ["api_key", "start_date"],
-    "additionalProperties": false,
     "properties": {
       "start_date": {
         "title": "Start Date",


### PR DESCRIPTION
## What
The connector was not published before #14585 was merged, now the /publish script throws an error because the current version has already been released.

## How
This manually bumps up the version so the connector can be published.