### PR TITLE
📄 Source Recharge: Fix typo in public docs

### DIFF
--- a/docs/integrations/sources/recharge.md
+++ b/docs/integrations/sources/recharge.md
@@ -1,7 +1,7 @@
 # Recharge
 
-his page guides you through the process of setting up the Recharge source connector.
 This source can sync data for the [Recharge API](https://developer.rechargepayments.com/).
+This page guides you through the process of setting up the Recharge source connector.
 
 ## Prerequisites (Airbyte Cloud & Airbyte Open Source)
 * A Recharge account with permission to access data from accounts you want to sync.


### PR DESCRIPTION
Fixed typo 'his' > 'this' in the public documentation.