### PR TITLE
Error silence

### DIFF
--- a/airbyte-commons/src/main/java/io/airbyte/commons/json/JsonSchemas.java
+++ b/airbyte-commons/src/main/java/io/airbyte/commons/json/JsonSchemas.java
@@ -205,8 +205,7 @@ public class JsonSchemas {
               traverseJsonSchemaInternal(arrayItem, path, consumer);
             }
           } else {
-            throw new IllegalArgumentException(
-                "malformed JsonSchema object type, must have one of the following fields: properties, oneOf, allOf, anyOf in " + jsonSchemaNode);
+            log.warn("The object is a properties key or a combo keyword. The traversal is silently stopped. Current schema: " + jsonSchemaNode);
           }
         }
       }

--- a/airbyte-commons/src/main/java/io/airbyte/commons/json/JsonSchemas.java
+++ b/airbyte-commons/src/main/java/io/airbyte/commons/json/JsonSchemas.java
@@ -189,8 +189,7 @@ public class JsonSchemas {
             // hit every node.
             traverseJsonSchemaInternal(jsonSchemaNode.get(JSON_SCHEMA_ITEMS_KEY), newPath, consumer);
           } else {
-            throw new IllegalArgumentException(
-                "malformed JsonSchema array type, must have items field in " + jsonSchemaNode);
+            log.warn("The array is missing an items field. The traversal is silently stopped.");
           }
         }
         case OBJECT_TYPE -> {

--- a/airbyte-commons/src/main/java/io/airbyte/commons/json/JsonSchemas.java
+++ b/airbyte-commons/src/main/java/io/airbyte/commons/json/JsonSchemas.java
@@ -189,7 +189,7 @@ public class JsonSchemas {
             // hit every node.
             traverseJsonSchemaInternal(jsonSchemaNode.get(JSON_SCHEMA_ITEMS_KEY), newPath, consumer);
           } else {
-            log.warn("The array is missing an items field. The traversal is silently stopped.");
+            log.warn("The array is missing an items field. The traversal is silently stopped. Current schema: " + jsonSchemaNode);
           }
         }
         case OBJECT_TYPE -> {

--- a/airbyte-commons/src/test/java/io/airbyte/commons/json/JsonSchemasTest.java
+++ b/airbyte-commons/src/test/java/io/airbyte/commons/json/JsonSchemasTest.java
@@ -5,7 +5,6 @@
 package io.airbyte.commons.json;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.mockito.Mockito.mock;
 
 import com.fasterxml.jackson.databind.JsonNode;
@@ -136,11 +135,11 @@ class JsonSchemasTest {
 
   @SuppressWarnings("unchecked")
   @Test
-  void testTraverseArrayTypeWithNoItemsThrowsException() throws IOException {
+  void testTraverseArrayTypeWithNoItemsDoNotThrowsException() throws IOException {
     final JsonNode jsonWithAllTypes = Jsons.deserialize(MoreResources.readResource("json_schemas/json_with_array_type_fields_no_items.json"));
     final BiConsumer<JsonNode, List<FieldNameOrList>> mock = mock(BiConsumer.class);
 
-    assertThrows(IllegalArgumentException.class, () -> JsonSchemas.traverseJsonSchema(jsonWithAllTypes, mock));
+    JsonSchemas.traverseJsonSchema(jsonWithAllTypes, mock);
   }
 
 }


### PR DESCRIPTION
## What
This is fixing: https://github.com/airbytehq/oncall/issues/351#issuecomment-1195682856

Our validation is more strict than the JSONSchema specs and currently don't allow array without items. But some catalogs have arrays without items which makes the diff to fail. This is avoiding throwing an exception if no items are specified and stop the traversal.