### PR TITLE
All objects in the Airbyte Proticol have `additionalProperties: true`

### DIFF
--- a/airbyte-cdk/python/airbyte_cdk/models/airbyte_protocol.py
+++ b/airbyte-cdk/python/airbyte_cdk/models/airbyte_protocol.py
@@ -153,6 +153,9 @@ class AuthFlowType(Enum):
 
 
 class OAuthConfigSpecification(BaseModel):
+    class Config:
+        extra = Extra.allow
+
     oauth_user_input_from_connector_config_specification: Optional[Dict[str, Any]] = Field(
         None,
         description="OAuth specific blob. This is a Json Schema used to validate Json configurations used as input to OAuth.\nMust be a valid non-nested JSON that refers to properties from ConnectorSpecification.connectionSpecification\nusing special annotation 'path_in_connector_config'.\nThese are input values the user is entering through the UI to authenticate to the connector, that might also shared\nas inputs for syncing data via the connector.\n\nExamples:\n\nif no connector values is shared during oauth flow, oauth_user_input_from_connector_config_specification=[]\nif connector values such as 'app_id' inside the top level are used to generate the API url for the oauth flow,\n  oauth_user_input_from_connector_config_specification={\n    app_id: {\n      type: string\n      path_in_connector_config: ['app_id']\n    }\n  }\nif connector values such as 'info.app_id' nested inside another object are used to generate the API url for the oauth flow,\n  oauth_user_input_from_connector_config_specification={\n    app_id: {\n      type: string\n      path_in_connector_config: ['info', 'app_id']\n    }\n  }",

--- a/airbyte-protocol/protocol-models/src/main/resources/airbyte_protocol/airbyte_protocol.yaml
+++ b/airbyte-protocol/protocol-models/src/main/resources/airbyte_protocol/airbyte_protocol.yaml
@@ -130,8 +130,8 @@ definitions:
         type: string
   AirbyteStateBlob:
     type: object
-    description: "the state data"
     additionalProperties: true
+    description: "the state data"
     existingJavaType: com.fasterxml.jackson.databind.JsonNode
   AirbyteLogMessage:
     type: object
@@ -194,8 +194,8 @@ definitions:
           - system_error
           - config_error
   AirbyteConnectionStatus:
-    description: Airbyte connection status
     type: object
+    description: Airbyte connection status
     additionalProperties: true
     required:
       - status
@@ -208,9 +208,9 @@ definitions:
       message:
         type: string
   AirbyteCatalog:
-    description: Airbyte stream schema catalog
     type: object
     additionalProperties: true
+    description: Airbyte stream schema catalog
     required:
       - streams
     properties:
@@ -257,9 +257,9 @@ definitions:
         description: Optional Source-defined namespace. Currently only used by JDBC destinations to determine what schema to write to. Airbyte streams from the same sources should have the same namespace.
         type: string
   ConfiguredAirbyteCatalog:
-    description: Airbyte stream schema catalog
     type: object
     additionalProperties: true
+    description: Airbyte stream schema catalog
     required:
       - streams
     properties:
@@ -308,9 +308,9 @@ definitions:
       #- upsert_dedup # TODO chris: SCD Type 1 can be implemented later
       - append_dedup # SCD Type 1 & 2
   OAuth2Specification:
-    description: An object containing any metadata needed to describe this connector's Oauth flow. Deprecated, switching to advanced_auth instead
     type: object
     additionalProperties: true
+    description: An object containing any metadata needed to describe this connector's Oauth flow. Deprecated, switching to advanced_auth instead
     properties:
       rootObject:
         description:
@@ -354,11 +354,11 @@ definitions:
           items:
             type: string
   ConnectorSpecification:
-    description: Specification of a connector (source/destination)
     type: object
+    additionalProperties: true
+    description: Specification of a connector (source/destination)
     required:
       - connectionSpecification
-    additionalProperties: true
     properties:
       # todo - split ConnectorSpecification into general vs connector type sections of properties
       # General Properties (Common to all connectors)

--- a/airbyte-protocol/protocol-models/src/main/resources/airbyte_protocol/airbyte_protocol.yaml
+++ b/airbyte-protocol/protocol-models/src/main/resources/airbyte_protocol/airbyte_protocol.yaml
@@ -133,7 +133,6 @@ definitions:
     description: "the state data"
     additionalProperties: true
     existingJavaType: com.fasterxml.jackson.databind.JsonNode
-
   AirbyteLogMessage:
     type: object
     additionalProperties: true
@@ -430,6 +429,7 @@ definitions:
             "$ref": "#/definitions/OAuthConfigSpecification"
   OAuthConfigSpecification:
     type: object
+    additionalProperties: true
     properties:
       oauth_user_input_from_connector_config_specification:
         description: |-


### PR DESCRIPTION
This will allow future changes to the protocol that add additional properties to not be breaking when new fields appear.

Notes: 
* Only `OAuthConfigSpecification` was missing `additionalProperties`
* ENUMS do not have additional properties. 
* I also did some orginization so that "type" and "additionalProperties" were defined first


Closes https://github.com/airbytehq/airbyte/issues/15052