### PR TITLE
🐛 Source Kustomer: fix `KeyError: 'user_agent'` when retrieving schema

### DIFF
--- a/airbyte-integrations/connectors/source-kustomer-singer/Dockerfile
+++ b/airbyte-integrations/connectors/source-kustomer-singer/Dockerfile
@@ -36,5 +36,5 @@ COPY source_kustomer_singer ./source_kustomer_singer
 ENV AIRBYTE_ENTRYPOINT "python /airbyte/integration_code/main.py"
 ENTRYPOINT ["python", "/airbyte/integration_code/main.py"]
 
-LABEL io.airbyte.version=0.1.2
+LABEL io.airbyte.version=0.1.3
 LABEL io.airbyte.name=airbyte/source-kustomer-singer

--- a/airbyte-integrations/connectors/source-kustomer-singer/integration_tests/invalid_config.json
+++ b/airbyte-integrations/connectors/source-kustomer-singer/integration_tests/invalid_config.json
@@ -1,4 +1,5 @@
 {
   "api_token": "invalid_api_token",
-  "start_date": "0000-01-01T00:00:00Z"
+  "start_date": "0000-01-01T00:00:00Z",
+  "user_agent": "tap-kustomer <test@test.com>"
 }

--- a/airbyte-integrations/connectors/source-kustomer-singer/source_kustomer_singer/spec.json
+++ b/airbyte-integrations/connectors/source-kustomer-singer/source_kustomer_singer/spec.json
@@ -4,7 +4,7 @@
     "$schema": "http://json-schema.org/draft-07/schema#",
     "title": "Source Kustomer Singer Spec",
     "type": "object",
-    "required": ["api_token", "start_date"],
+    "required": ["api_token", "start_date", "user_agent"],
     "additionalProperties": true,
     "properties": {
       "api_token": {
@@ -18,6 +18,12 @@
         "type": "string",
         "description": "The date from which you'd like to replicate the data",
         "examples": ["2019-01-01T00:00:00Z"]
+      },
+      "user_agent": {
+        "type": "string",
+        "title": "User Agent",
+        "description": "Kustomer API User Agent",
+        "examples": ["tap-kustomer <api_user_email@your_company.com>"]
       }
     }
   }


### PR DESCRIPTION
## What

Currently the Kustomer source connector is broken (see https://github.com/airbytehq/airbyte/issues/14965).

With current master branch:
<img width="300" alt="image" src="https://user-images.githubusercontent.com/815440/181649090-01139f1d-9e0c-4f52-826f-5b43ca289cf2.png">
<img width="300" alt="image" src="https://user-images.githubusercontent.com/815440/181648448-fd37033d-2531-45e2-bc56-831269c5feb6.png">

With this PR:
<img width="300" alt="image" src="https://user-images.githubusercontent.com/815440/181648579-327e282f-a7ac-43d6-91f1-c5e9af77cc33.png">
<img width="300" alt="image" src="https://user-images.githubusercontent.com/815440/181649007-13ec6827-4dd1-47b5-94d4-f1f9f4f1a163.png">

## How

The User Agent field is required in the `config.json`, it was removed in a previous PR but the documentation does not state why. This parameter is used when initializing the tap:

https://github.com/singer-io/tap-kustomer/blob/b56a2cc3646d57b8c1eb8876a335073a8968fd00/tap_kustomer/__init__.py#L36-L37

Background:
- https://github.com/airbytehq/airbyte/issues/14965
- https://github.com/airbytehq/airbyte/issues/8697
- https://github.com/airbytehq/airbyte/pull/8738

## 🚨 User Impact 🚨

The connector configuration now requires to specify the User Agent to be used for Kustomer API.

## Pre-merge Checklist
Expand the relevant checklist and delete the others.

<details><summary><strong>Updating a connector</strong></summary>

### Community member or Airbyter

- [ ] Grant edit access to maintainers ([instructions](https://docs.github.com/en/github/collaborating-with-pull-requests/working-with-forks/allowing-changes-to-a-pull-request-branch-created-from-a-fork#enabling-repository-maintainer-permissions-on-existing-pull-requests))
- [ ] Secrets in the connector's spec are annotated with `airbyte_secret`
- [ ] Unit & integration tests added and passing. Community members, please provide proof of success locally e.g: screenshot or copy-paste unit, integration, and acceptance test output. To run acceptance tests for a Python connector, follow instructions in the README. For java connectors run `./gradlew :airbyte-integrations:connectors:<name>:integrationTest`.
- [ ] Code reviews completed
- [ ] Documentation updated
    - [ ] Connector's `README.md`
    - [ ] Connector's `bootstrap.md`. See [description and examples](https://docs.google.com/document/d/1ypdgmwmEHWv-TrO4_YOQ7pAJGVrMp5BOkEVh831N260/edit?usp=sharing)
    - [ ] Changelog updated in `docs/integrations/<source or destination>/<name>.md` including changelog. See changelog [example](https://docs.airbyte.io/integrations/sources/stripe#changelog)
- [x] PR name follows [PR naming conventions](https://docs.airbyte.io/contributing-to-airbyte/updating-documentation#issues-and-pull-requests)

### Airbyter

If this is a community PR, the Airbyte engineer reviewing this PR is responsible for the below items.

- [ ] Create a non-forked branch based on this PR and test the below items on it
- [ ] Build is successful
- [ ] If new credentials are required for use in CI, add them to GSM. [Instructions](https://docs.airbyte.io/connector-development#using-credentials-in-ci).
- [ ] [`/test connector=connectors/<name>` command](https://docs.airbyte.io/connector-development#updating-an-existing-connector) is passing
- [ ] New Connector version released on Dockerhub and connector version bumped by running the `/publish` command described [here](https://docs.airbyte.io/connector-development#updating-an-existing-connector)

</details>