### PR TITLE
🐛  Helm Chart: gcs-logs-creds error

### DIFF
--- a/charts/airbyte/templates/gcs-log-creds-secret.yaml
+++ b/charts/airbyte/templates/gcs-log-creds-secret.yaml
@@ -2,7 +2,7 @@
 apiVersion: v1
 kind: Secret
 metadata:
-  name: {{ include "common.names.fullname" . }}-gcs-log-creds
+  name: {{ include "common.names.fullname" . }}-airbyte-gcs-log-creds
 type: Opaque
 data:
   gcp.json: "{{ .Values.global.logs.gcs.credentialsJson }}"


### PR DESCRIPTION
**Helm Chart** 
For helm chart `airbyte`  gcs-logs-creds secrets is released under name 
```
{{ include "common.names.fullname" . }}-gcs-log-creds 
```
when `airbyte-server`  calls for secret
```
 {{ .Release.Name }}-airbyte-gcs-log-creds
 ```
 Causing error for airbyte server :`MountVolume.SetUp failed for volume "gcs-log-creds-volume" : secret "airbyte-airbyte-gcs-log-creds" not found.`

Syncing naming pattern by modifying secret name rather than other sevrer & worker env variables. 

