### PR TITLE
:bug: Helm Chart: fix connect err when setting off pg bitnami chart

### DIFF
--- a/charts/airbyte-temporal/templates/deployment.yaml
+++ b/charts/airbyte-temporal/templates/deployment.yaml
@@ -60,7 +60,7 @@ spec:
                 name: {{ .Values.global.database.secretName | default (printf "%s-postgresql" .Release.Name ) }}
                 key: {{ .Values.global.database.secretValue | default "DATABASE_PASSWORD" }}
           - name: POSTGRES_SEEDS
-            value: {{ .Release.Name }}-postgresql
+            value: {{ .Values.global.database.host | default (printf "%s-postgresql" .Release.Name ) }}
           - name: DYNAMIC_CONFIG_FILE_PATH
             value: "config/dynamicconfig/development.yaml"
         {{- end }}


### PR DESCRIPTION
Current status of chart would only set POSTGRES_SEEDS to the default bitnami pg deployed. 

However for production usage it was not possible to set an external host database with temporal . Now chart takes the database host set in global, if none is set it defaults to bitnami pg host deployed with the chart.

