### PR TITLE
[Helm] [Airbyte-temporal] Fix yaml formatting error

### DIFF
--- a/charts/airbyte-temporal/templates/deployment.yaml
+++ b/charts/airbyte-temporal/templates/deployment.yaml
@@ -65,7 +65,7 @@ spec:
             value: "config/dynamicconfig/development.yaml"
         {{- end }}
         {{- if .Values.extraEnv }}
-        {{ .Values.extraEnv | toYaml | nindent 8 }}
+        {{ .Values.extraEnv | toYaml | nindent 10 }}
         {{- end }}
         ports:
         - containerPort: 7233


### PR DESCRIPTION
## What
Fix https://github.com/airbytehq/airbyte/issues/15149

Helm chart validation fails with temporal extra variables.
`Error: YAML parse error on temporal/templates/deployment.yaml: error converting YAML to JSON: yaml: line 47: did not find expected key`
## How
`nindent` should be equal to 10.


```
        {{- if .Values.extraEnv }}
        {{ .Values.extraEnv | toYaml | nindent 10 }}
        {{- end }}
```

## Recommended reading order
1. `deployment.yaml`

## 🚨 User Impact 🚨
Are there any breaking changes? What is the end result perceived by the user? If yes, please merge this PR with the 🚨🚨 emoji so changelog authors can further highlight this if needed.
