### PR TITLE
fix build: re-generate scaffold connectors

### DIFF
--- a/airbyte-integrations/connectors/source-scaffold-source-http/Dockerfile
+++ b/airbyte-integrations/connectors/source-scaffold-source-http/Dockerfile
@@ -1,4 +1,4 @@
-FROM python:3.9.11-alpine3.15 as base
+FROM python:3.9.13-alpine3.15 as base
 
 # build and load all requirements
 FROM base as builder


### PR DESCRIPTION
## What

https://github.com/airbytehq/airbyte/pull/15111 made a change to the generator templates but did not re-generate the scaffold connectors, so the Connectors Base build is now failing. 

```
diff --git a/airbyte-integrations/connectors/source-scaffold-source-http/Dockerfile b/airbyte-integrations/connectors/source-scaffold-source-http/Dockerfile
index add764c..0f081bb 100644
--- a/airbyte-integrations/connectors/source-scaffold-source-http/Dockerfile
+++ b/airbyte-integrations/connectors/source-scaffold-source-http/Dockerfile
@@ -1,4 +1,4 @@
-FROM python:3.9.[11](https://github.com/airbytehq/airbyte/runs/7618743994?check_suite_focus=true#step:13:12)-alpine3.15 as base
+FROM python:3.9.[13](https://github.com/airbytehq/airbyte/runs/7618743994?check_suite_focus=true#step:13:14)-alpine3.[15](https://github.com/airbytehq/airbyte/runs/7618743994?check_suite_focus=true#step:13:16) as base
 
 # build and load all requirements
 FROM base as builder
Error: Process completed with exit code 1.
```

This fixes the build by applying the changes to the templates.

## How

Run `./gradlew :airbyte-integrations:connector-templates:generator:testScaffoldTemplates`
