### PR TITLE
fix: use correct case in helm chart templates

### DIFF
--- a/charts/airbyte-server/templates/deployment.yaml
+++ b/charts/airbyte-server/templates/deployment.yaml
@@ -230,7 +230,7 @@ spec:
   {{ toYaml .Values.extraVolumeMounts | nindent 8 }}
         {{- end }}
       {{- if .Values.extraContainers }}
-      {{ toyaml .Values.extraInitContainers | indent 8 }}
+      {{ toYaml .Values.extraInitContainers | indent 8 }}
       {{- end }}
       volumes:
       - name: gcs-log-creds-volume

--- a/charts/airbyte-temporal/templates/deployment.yaml
+++ b/charts/airbyte-temporal/templates/deployment.yaml
@@ -110,7 +110,7 @@ spec:
           failureThreshold: {{ .Values.readinessProbe.failureThreshold }}
         {{- end }}
         {{- if .Values.extraContainers }}
-        {{ toyaml .Values.extraInitContainers | indent 8 }}
+        {{ toYaml .Values.extraInitContainers | indent 8 }}
         {{- end }}
       volumes:
       - name: airbyte-temporal-dynamicconfig

--- a/charts/airbyte-webapp/templates/deployment.yaml
+++ b/charts/airbyte-webapp/templates/deployment.yaml
@@ -115,7 +115,7 @@ spec:
   {{ toYaml .Values.extraVolumeMounts | nindent 8 }}
         {{- end }}
       {{- if .Values.extraContainers }}
-      {{ toyaml .Values.extraInitContainers | indent 8 }}
+      {{ toYaml .Values.extraInitContainers | indent 8 }}
       {{- end }}
       volumes:
       {{- if .Values.extraVolumes }}

--- a/charts/airbyte-worker/templates/deployment.yaml
+++ b/charts/airbyte-worker/templates/deployment.yaml
@@ -358,7 +358,7 @@ spec:
         - containerPort: 9028
         - containerPort: 9029
         - containerPort: 9030 # end temporal worker port pool
-        {{- if .Values.resources   }}
+        {{- if .Values.resources }}
         resources: {{- toYaml .Values.resources | nindent 10 }}
         {{- end }}
         {{- if .Values.containerSecurityContext }}

--- a/charts/airbyte-worker/templates/deployment.yaml
+++ b/charts/airbyte-worker/templates/deployment.yaml
@@ -358,7 +358,7 @@ spec:
         - containerPort: 9028
         - containerPort: 9029
         - containerPort: 9030 # end temporal worker port pool
-        {{- if .Values.resources }}
+        {{- if .Values.resources   }}
         resources: {{- toYaml .Values.resources | nindent 10 }}
         {{- end }}
         {{- if .Values.containerSecurityContext }}
@@ -372,7 +372,7 @@ spec:
 {{ toYaml .Values.extraVolumeMounts | nindent 8 }}
         {{- end }}
       {{- if .Values.extraContainers }}
-      {{ toyaml .Values.extraInitContainers | indent 8 }}
+      {{ toYaml .Values.extraInitContainers | indent 8 }}
       {{- end }}
       volumes:
       - name: gcs-log-creds-volume


### PR DESCRIPTION
## What
*Describe what the change is solving*
*It helps to add screenshots if it affects the frontend.*

- Currently Helm chart installation is failing with the error 'Error: INSTALLATION FAILED: parse error at (airbyte/charts/worker/templates/deployment.yaml:375): function "toyaml" not defined'


## How
*Describe the solution*

- Use the right syntax toYaml instead of toyaml

## Recommended reading order
N/A

## 🚨 User Impact 🚨
Are there any breaking changes? What is the end result perceived by the user? If yes, please merge this PR with the 🚨🚨 emoji so changelog authors can further highlight this if needed.
No