### PR TITLE
🪟 🐛 Connection Creation form should use existing values before using retreived values

### DIFF
--- a/airbyte-webapp/src/components/CreateConnectionContent/CreateConnectionContent.tsx
+++ b/airbyte-webapp/src/components/CreateConnectionContent/CreateConnectionContent.tsx
@@ -113,7 +113,6 @@ const CreateConnectionContent: React.FC<CreateConnectionContentProps> = ({
       </ContentCard>
     );
   }
-  console.log(connection);
   return isLoading ? (
     <LoadingSchema />
   ) : (

--- a/airbyte-webapp/src/components/CreateConnectionContent/CreateConnectionContent.tsx
+++ b/airbyte-webapp/src/components/CreateConnectionContent/CreateConnectionContent.tsx
@@ -54,7 +54,7 @@ const CreateConnectionContent: React.FC<CreateConnectionContentProps> = ({
       namespaceFormat: connectionFormValues?.namespaceFormat,
       prefix: connectionFormValues?.prefix,
       schedule: connectionFormValues?.schedule ?? undefined,
-      syncCatalog: schema,
+      syncCatalog: connectionFormValues?.syncCatalog ?? schema,
       destination,
       source,
       catalogId,
@@ -113,7 +113,7 @@ const CreateConnectionContent: React.FC<CreateConnectionContentProps> = ({
       </ContentCard>
     );
   }
-
+  console.log(connection);
   return isLoading ? (
     <LoadingSchema />
   ) : (


### PR DESCRIPTION
## What
Closes #14844 

Previously, when creating a Connection, if an item from outside the `syncCatalog` object was updated, when the form reinitialized, any user-configured values in the `syncCatalog` fields would be overwritten.

## How
Now, we grab the `syncCatalog` from the `formValues` object if it exists, or else grab it from the value we got from the API.

## Recommended reading order
There is only one file.

## Testing
Create a new connection.
Change some of the items in the `syncCatalog` section (enable/disable streams, change their sync modes, etc.).
Change the value in a text input field at the top of the form.
Values on the form should not change (except for the text input field you purposely changed).

I have also manually tested other inputs on this form... changing the values of any one should not affect any of the others now.  We will likely want to add unit testing to this as part of our epic to improve connection creation/editing in Q3.