### PR TITLE
🪟 🐛 Trial end banner calculation

### DIFF
--- a/airbyte-webapp/src/packages/cloud/views/layout/MainView/MainView.tsx
+++ b/airbyte-webapp/src/packages/cloud/views/layout/MainView/MainView.tsx
@@ -65,11 +65,12 @@ const MainView: React.FC = (props) => {
     } else if (alertToShow === "trial") {
       const { trialExpiryTimestamp } = cloudWorkspace;
 
-      //calculate difference between timestamp (in epoch seconds) and now (in epoch seconds)
-      const trialRemainingSeconds = trialExpiryTimestamp ? trialExpiryTimestamp - Date.now() / 1000 : 0;
+      //calculate difference between timestamp (in epoch milliseconds) and now (in epoch milliseconds)
+      //empty timestamp is 0
+      const trialRemainingMilliseconds = trialExpiryTimestamp ? trialExpiryTimestamp - Date.now() : 0;
 
       //calculate days (rounding up if decimal)
-      const trialRemainingDays = Math.ceil(trialRemainingSeconds / (24 * 60 * 60));
+      const trialRemainingDays = Math.ceil(trialRemainingMilliseconds / (1000 * 60 * 60 * 24));
 
       return formatMessage({ id: "trial.alertMessage" }, { value: trialRemainingDays });
     }


### PR DESCRIPTION
## What
When we implemented the initial trial end banner, we assumed that the timestamp was being returned as epoch seconds.  It appears to be milliseconds instead.

Before:
![screenshot-20220802-155857](https://user-images.githubusercontent.com/63751206/182410817-e6830c5f-01c1-4907-927a-a60f80f40971.png)

After:
![Screen Shot 2022-08-02 at 12 54 27 PM](https://user-images.githubusercontent.com/63751206/182431260-713e80dd-dddc-45f4-aa18-fa40992793de.png)

