### PR TITLE
Make `connectionTimeoutMs` configurable

### DIFF
--- a/airbyte-config/init/src/main/resources/seed/source_definitions.yaml
+++ b/airbyte-config/init/src/main/resources/seed/source_definitions.yaml
@@ -762,7 +762,7 @@
 - name: Postgres
   sourceDefinitionId: decd338e-5647-4c0b-adf4-da0e75f5a750
   dockerRepository: airbyte/source-postgres
-  dockerImageTag: 0.4.42
+  dockerImageTag: 0.4.43
   documentationUrl: https://docs.airbyte.io/integrations/sources/postgres
   icon: postgresql.svg
   sourceType: database

--- a/airbyte-config/init/src/main/resources/seed/source_specs.yaml
+++ b/airbyte-config/init/src/main/resources/seed/source_specs.yaml
@@ -7140,7 +7140,7 @@
     supportsNormalization: false
     supportsDBT: false
     supported_destination_sync_modes: []
-- dockerImage: "airbyte/source-postgres:0.4.42"
+- dockerImage: "airbyte/source-postgres:0.4.43"
   spec:
     documentationUrl: "https://docs.airbyte.com/integrations/sources/postgres"
     connectionSpecification:

--- a/airbyte-db/db-lib/src/main/java/io/airbyte/db/factory/DataSourceFactory.java
+++ b/airbyte-db/db-lib/src/main/java/io/airbyte/db/factory/DataSourceFactory.java
@@ -8,9 +8,9 @@ import com.google.common.base.Preconditions;
 import com.zaxxer.hikari.HikariConfig;
 import com.zaxxer.hikari.HikariDataSource;
 import java.io.Closeable;
+import java.time.Duration;
 import java.util.Map;
 import javax.sql.DataSource;
-import java.time.Duration;
 
 /**
  * Temporary factory class that provides convenience methods for creating a {@link DataSource}

--- a/airbyte-db/db-lib/src/main/java/io/airbyte/db/factory/DataSourceFactory.java
+++ b/airbyte-db/db-lib/src/main/java/io/airbyte/db/factory/DataSourceFactory.java
@@ -55,14 +55,14 @@ public class DataSourceFactory {
                                   final String driverClassName,
                                   final String jdbcConnectionString,
                                   final Map<String, String> connectionProperties) {
-    final DataSourceBuilder builder = new DataSourceBuilder()
+    return new DataSourceBuilder()
         .withConnectionProperties(connectionProperties)
         .withDriverClassName(driverClassName)
         .withJdbcUrl(jdbcConnectionString)
         .withPassword(password)
         .withUsername(username)
-        .withConnectionTimeoutMs(DataSourceBuilder.getConnectionTimeoutMs(connectionProperties));
-    return builder.build();
+        .withConnectionTimeoutMs(DataSourceBuilder.getConnectionTimeoutMs(connectionProperties))
+        .build();
   }
 
   /**
@@ -181,6 +181,7 @@ public class DataSourceFactory {
     private String username;
     private static final String CONNECT_TIMEOUT_KEY = "connectTimeout";
     private static final Duration CONNECT_TIMEOUT_DEFAULT = Duration.ofSeconds(60);
+
     private DataSourceBuilder() {}
 
     /**
@@ -199,8 +200,11 @@ public class DataSourceFactory {
      */
     private static long getConnectionTimeoutMs(final Map<String, String> connectionProperties) {
       final Duration connectionTimeout;
-      // TODO: the usage of CONNECT_TIMEOUT_KEY is Postgres specific, may need to extend for other databases
-      connectionTimeout = connectionProperties.containsKey(CONNECT_TIMEOUT_KEY) ? Duration.ofSeconds(Long.parseLong(connectionProperties.get(CONNECT_TIMEOUT_KEY))) : CONNECT_TIMEOUT_DEFAULT;
+      // TODO: the usage of CONNECT_TIMEOUT_KEY is Postgres specific, may need to extend for other
+      // databases
+      connectionTimeout =
+          connectionProperties.containsKey(CONNECT_TIMEOUT_KEY) ? Duration.ofSeconds(Long.parseLong(connectionProperties.get(CONNECT_TIMEOUT_KEY)))
+              : CONNECT_TIMEOUT_DEFAULT;
       if (connectionTimeout.getSeconds() == 0) {
         return connectionTimeout.toMillis();
       } else {

--- a/airbyte-db/db-lib/src/main/java/io/airbyte/db/factory/DataSourceFactory.java
+++ b/airbyte-db/db-lib/src/main/java/io/airbyte/db/factory/DataSourceFactory.java
@@ -10,7 +10,7 @@ import com.zaxxer.hikari.HikariDataSource;
 import java.io.Closeable;
 import java.util.Map;
 import javax.sql.DataSource;
-import org.threeten.bp.Duration;
+import java.time.Duration;
 
 /**
  * Temporary factory class that provides convenience methods for creating a {@link DataSource}

--- a/airbyte-db/db-lib/src/main/java/io/airbyte/db/factory/DataSourceFactory.java
+++ b/airbyte-db/db-lib/src/main/java/io/airbyte/db/factory/DataSourceFactory.java
@@ -7,7 +7,6 @@ package io.airbyte.db.factory;
 import com.google.common.base.Preconditions;
 import com.zaxxer.hikari.HikariConfig;
 import com.zaxxer.hikari.HikariDataSource;
-import io.airbyte.db.jdbc.JdbcUtils;
 import java.io.Closeable;
 import java.util.Map;
 import javax.sql.DataSource;
@@ -76,10 +75,10 @@ public class DataSourceFactory {
    * @return The configured {@link DataSource}.
    */
   public static DataSource createWithConnectionTimeout(final String username,
-      final String password,
-      final String driverClassName,
-      final String jdbcConnectionString,
-      final Map<String, String> connectionProperties) {
+                                                       final String password,
+                                                       final String driverClassName,
+                                                       final String jdbcConnectionString,
+                                                       final Map<String, String> connectionProperties) {
     return new DataSourceBuilder()
         .withConnectionProperties(connectionProperties)
         .withDriverClassName(driverClassName)
@@ -211,16 +210,17 @@ public class DataSourceFactory {
     private DataSourceBuilder() {}
 
     /**
-     * Retrieves connectionTimeout value from connection properties in seconds,
-     * default minimum timeout is 60 seconds since Hikari default of 30 seconds
-     * is not enough for acceptance tests. In the case the value is 0, pass the
-     * value along as Hikari and Postgres use default max value for 0 timeout value
+     * Retrieves connectionTimeout value from connection properties in seconds, default minimum timeout
+     * is 60 seconds since Hikari default of 30 seconds is not enough for acceptance tests. In the case
+     * the value is 0, pass the value along as Hikari and Postgres use default max value for 0 timeout
+     * value
      *
-     * NOTE: HikariCP uses milliseconds for all time values: https://github.com/brettwooldridge/HikariCP#gear-configuration-knobs-baby
-     * whereas Postgres is measured in seconds: https://jdbc.postgresql.org/documentation/head/connect.html
+     * NOTE: HikariCP uses milliseconds for all time values:
+     * https://github.com/brettwooldridge/HikariCP#gear-configuration-knobs-baby whereas Postgres is
+     * measured in seconds: https://jdbc.postgresql.org/documentation/head/connect.html
      *
-     * @param connectionProperties custom jdbc_url_parameters containing
-     *                             information on connection properties
+     * @param connectionProperties custom jdbc_url_parameters containing information on connection
+     *        properties
      * @return DataSourceBuilder class used to create dynamic fields for DataSource
      */
     public DataSourceBuilder getConnectionTimeoutMs(final Map<String, String> connectionProperties) {

--- a/airbyte-db/db-lib/src/test/java/io/airbyte/db/factory/DataSourceFactoryTest.java
+++ b/airbyte-db/db-lib/src/test/java/io/airbyte/db/factory/DataSourceFactoryTest.java
@@ -46,7 +46,7 @@ class DataSourceFactoryTest extends CommonFactoryTest {
   void testCreatingDataSourceWithConnectionTimeoutSetAboveDefault() {
     final Map<String, String> connectionProperties = Map.of(
         "connectTimeout", "61");
-    final DataSource dataSource = DataSourceFactory.createWithConnectionTimeout(
+    final DataSource dataSource = DataSourceFactory.create(
         username,
         password,
         driverClassName,
@@ -61,7 +61,7 @@ class DataSourceFactoryTest extends CommonFactoryTest {
   void testCreatingDataSourceWithConnectionTimeoutSetBelowDefault() {
     final Map<String, String> connectionProperties = Map.of(
         "connectTimeout", "30");
-    final DataSource dataSource = DataSourceFactory.createWithConnectionTimeout(
+    final DataSource dataSource = DataSourceFactory.create(
         username,
         password,
         driverClassName,
@@ -76,7 +76,7 @@ class DataSourceFactoryTest extends CommonFactoryTest {
   void testCreatingDataSourceWithConnectionTimeoutSetWithZero() {
     final Map<String, String> connectionProperties = Map.of(
         "connectTimeout", "0");
-    final DataSource dataSource = DataSourceFactory.createWithConnectionTimeout(
+    final DataSource dataSource = DataSourceFactory.create(
         username,
         password,
         driverClassName,
@@ -90,7 +90,7 @@ class DataSourceFactoryTest extends CommonFactoryTest {
   @Test
   void testCreatingDataSourceWithConnectionTimeoutNotSet() {
     final Map<String, String> connectionProperties = Map.of();
-    final DataSource dataSource = DataSourceFactory.createWithConnectionTimeout(
+    final DataSource dataSource = DataSourceFactory.create(
         username,
         password,
         driverClassName,

--- a/airbyte-db/db-lib/src/test/java/io/airbyte/db/factory/DataSourceFactoryTest.java
+++ b/airbyte-db/db-lib/src/test/java/io/airbyte/db/factory/DataSourceFactoryTest.java
@@ -12,7 +12,6 @@ import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 
 import com.zaxxer.hikari.HikariDataSource;
-import java.io.IOException;
 import java.util.Map;
 import javax.sql.DataSource;
 import org.junit.jupiter.api.Assertions;
@@ -46,8 +45,7 @@ class DataSourceFactoryTest extends CommonFactoryTest {
   @Test
   void testCreatingDataSourceWithConnectionTimeoutSetAboveDefault() {
     final Map<String, String> connectionProperties = Map.of(
-        "connectTimeout", "61"
-    );
+        "connectTimeout", "61");
     final DataSource dataSource = DataSourceFactory.createWithConnectionTimeout(
         username,
         password,
@@ -62,8 +60,7 @@ class DataSourceFactoryTest extends CommonFactoryTest {
   @Test
   void testCreatingDataSourceWithConnectionTimeoutSetBelowDefault() {
     final Map<String, String> connectionProperties = Map.of(
-        "connectTimeout", "30"
-    );
+        "connectTimeout", "30");
     final DataSource dataSource = DataSourceFactory.createWithConnectionTimeout(
         username,
         password,
@@ -78,8 +75,7 @@ class DataSourceFactoryTest extends CommonFactoryTest {
   @Test
   void testCreatingDataSourceWithConnectionTimeoutSetWithZero() {
     final Map<String, String> connectionProperties = Map.of(
-        "connectTimeout", "0"
-    );
+        "connectTimeout", "0");
     final DataSource dataSource = DataSourceFactory.createWithConnectionTimeout(
         username,
         password,

--- a/airbyte-db/db-lib/src/test/java/io/airbyte/db/factory/DataSourceFactoryTest.java
+++ b/airbyte-db/db-lib/src/test/java/io/airbyte/db/factory/DataSourceFactoryTest.java
@@ -12,9 +12,11 @@ import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 
 import com.zaxxer.hikari.HikariDataSource;
+import java.io.IOException;
 import java.util.Map;
 import javax.sql.DataSource;
 import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;
 
 /**
@@ -22,13 +24,89 @@ import org.junit.jupiter.api.Test;
  */
 class DataSourceFactoryTest extends CommonFactoryTest {
 
+  static String database;
+  static String driverClassName;
+  static String host;
+  static String jdbcUrl;
+  static String password;
+  static Integer port;
+  static String username;
+
+  @BeforeAll
+  static void setup() {
+    host = container.getHost();
+    port = container.getFirstMappedPort();
+    database = container.getDatabaseName();
+    username = container.getUsername();
+    password = container.getPassword();
+    driverClassName = container.getDriverClassName();
+    jdbcUrl = container.getJdbcUrl();
+  }
+
+  @Test
+  void testCreatingDataSourceWithConnectionTimeoutSetAboveDefault() {
+    final Map<String, String> connectionProperties = Map.of(
+        "connectTimeout", "61"
+    );
+    final DataSource dataSource = DataSourceFactory.createWithConnectionTimeout(
+        username,
+        password,
+        driverClassName,
+        jdbcUrl,
+        connectionProperties);
+    assertNotNull(dataSource);
+    assertEquals(HikariDataSource.class, dataSource.getClass());
+    assertEquals(61000, ((HikariDataSource) dataSource).getHikariConfigMXBean().getConnectionTimeout());
+  }
+
+  @Test
+  void testCreatingDataSourceWithConnectionTimeoutSetBelowDefault() {
+    final Map<String, String> connectionProperties = Map.of(
+        "connectTimeout", "30"
+    );
+    final DataSource dataSource = DataSourceFactory.createWithConnectionTimeout(
+        username,
+        password,
+        driverClassName,
+        jdbcUrl,
+        connectionProperties);
+    assertNotNull(dataSource);
+    assertEquals(HikariDataSource.class, dataSource.getClass());
+    assertEquals(60000, ((HikariDataSource) dataSource).getHikariConfigMXBean().getConnectionTimeout());
+  }
+
+  @Test
+  void testCreatingDataSourceWithConnectionTimeoutSetWithZero() {
+    final Map<String, String> connectionProperties = Map.of(
+        "connectTimeout", "0"
+    );
+    final DataSource dataSource = DataSourceFactory.createWithConnectionTimeout(
+        username,
+        password,
+        driverClassName,
+        jdbcUrl,
+        connectionProperties);
+    assertNotNull(dataSource);
+    assertEquals(HikariDataSource.class, dataSource.getClass());
+    assertEquals(Integer.MAX_VALUE, ((HikariDataSource) dataSource).getHikariConfigMXBean().getConnectionTimeout());
+  }
+
+  @Test
+  void testCreatingDataSourceWithConnectionTimeoutNotSet() {
+    final Map<String, String> connectionProperties = Map.of();
+    final DataSource dataSource = DataSourceFactory.createWithConnectionTimeout(
+        username,
+        password,
+        driverClassName,
+        jdbcUrl,
+        connectionProperties);
+    assertNotNull(dataSource);
+    assertEquals(HikariDataSource.class, dataSource.getClass());
+    assertEquals(60000, ((HikariDataSource) dataSource).getHikariConfigMXBean().getConnectionTimeout());
+  }
+
   @Test
   void testCreatingADataSourceWithJdbcUrl() {
-    final String username = container.getUsername();
-    final String password = container.getPassword();
-    final String driverClassName = container.getDriverClassName();
-    final String jdbcUrl = container.getJdbcUrl();
-
     final DataSource dataSource = DataSourceFactory.create(username, password, driverClassName, jdbcUrl);
     assertNotNull(dataSource);
     assertEquals(HikariDataSource.class, dataSource.getClass());
@@ -37,10 +115,6 @@ class DataSourceFactoryTest extends CommonFactoryTest {
 
   @Test
   void testCreatingADataSourceWithJdbcUrlAndConnectionProperties() {
-    final String username = container.getUsername();
-    final String password = container.getPassword();
-    final String driverClassName = container.getDriverClassName();
-    final String jdbcUrl = container.getJdbcUrl();
     final Map<String, String> connectionProperties = Map.of("foo", "bar");
 
     final DataSource dataSource = DataSourceFactory.create(username, password, driverClassName, jdbcUrl, connectionProperties);
@@ -51,13 +125,6 @@ class DataSourceFactoryTest extends CommonFactoryTest {
 
   @Test
   void testCreatingADataSourceWithHostAndPort() {
-    final String username = container.getUsername();
-    final String password = container.getPassword();
-    final String driverClassName = container.getDriverClassName();
-    final String host = container.getHost();
-    final Integer port = container.getFirstMappedPort();
-    final String database = container.getDatabaseName();
-
     final DataSource dataSource = DataSourceFactory.create(username, password, host, port, database, driverClassName);
     assertNotNull(dataSource);
     assertEquals(HikariDataSource.class, dataSource.getClass());
@@ -66,12 +133,6 @@ class DataSourceFactoryTest extends CommonFactoryTest {
 
   @Test
   void testCreatingADataSourceWithHostPortAndConnectionProperties() {
-    final String username = container.getUsername();
-    final String password = container.getPassword();
-    final String driverClassName = container.getDriverClassName();
-    final String host = container.getHost();
-    final Integer port = container.getFirstMappedPort();
-    final String database = container.getDatabaseName();
     final Map<String, String> connectionProperties = Map.of("foo", "bar");
 
     final DataSource dataSource = DataSourceFactory.create(username, password, host, port, database, driverClassName, connectionProperties);
@@ -82,12 +143,7 @@ class DataSourceFactoryTest extends CommonFactoryTest {
 
   @Test
   void testCreatingAnInvalidDataSourceWithHostAndPort() {
-    final String username = container.getUsername();
-    final String password = container.getPassword();
     final String driverClassName = "Unknown";
-    final String host = container.getHost();
-    final Integer port = container.getFirstMappedPort();
-    final String database = container.getDatabaseName();
 
     assertThrows(RuntimeException.class, () -> {
       DataSourceFactory.create(username, password, host, port, database, driverClassName);
@@ -96,12 +152,6 @@ class DataSourceFactoryTest extends CommonFactoryTest {
 
   @Test
   void testCreatingAPostgresqlDataSource() {
-    final String username = container.getUsername();
-    final String password = container.getPassword();
-    final String host = container.getHost();
-    final Integer port = container.getFirstMappedPort();
-    final String database = container.getDatabaseName();
-
     final DataSource dataSource = DataSourceFactory.createPostgres(username, password, host, port, database);
     assertNotNull(dataSource);
     assertEquals(HikariDataSource.class, dataSource.getClass());

--- a/airbyte-integrations/connectors/source-jdbc/src/main/java/io/airbyte/integrations/source/jdbc/AbstractJdbcSource.java
+++ b/airbyte-integrations/connectors/source-jdbc/src/main/java/io/airbyte/integrations/source/jdbc/AbstractJdbcSource.java
@@ -299,7 +299,7 @@ public abstract class AbstractJdbcSource<Datatype> extends AbstractRelationalDbS
 
   protected DataSource createDataSource(final JsonNode config) {
     final JsonNode jdbcConfig = toDatabaseConfig(config);
-    final DataSource dataSource = DataSourceFactory.create(
+    final DataSource dataSource = DataSourceFactory.createWithConnectionTimeout(
         jdbcConfig.has(JdbcUtils.USERNAME_KEY) ? jdbcConfig.get(JdbcUtils.USERNAME_KEY).asText() : null,
         jdbcConfig.has(JdbcUtils.PASSWORD_KEY) ? jdbcConfig.get(JdbcUtils.PASSWORD_KEY).asText() : null,
         driverClass,

--- a/airbyte-integrations/connectors/source-jdbc/src/main/java/io/airbyte/integrations/source/jdbc/AbstractJdbcSource.java
+++ b/airbyte-integrations/connectors/source-jdbc/src/main/java/io/airbyte/integrations/source/jdbc/AbstractJdbcSource.java
@@ -299,7 +299,7 @@ public abstract class AbstractJdbcSource<Datatype> extends AbstractRelationalDbS
 
   protected DataSource createDataSource(final JsonNode config) {
     final JsonNode jdbcConfig = toDatabaseConfig(config);
-    final DataSource dataSource = DataSourceFactory.createWithConnectionTimeout(
+    final DataSource dataSource = DataSourceFactory.create(
         jdbcConfig.has(JdbcUtils.USERNAME_KEY) ? jdbcConfig.get(JdbcUtils.USERNAME_KEY).asText() : null,
         jdbcConfig.has(JdbcUtils.PASSWORD_KEY) ? jdbcConfig.get(JdbcUtils.PASSWORD_KEY).asText() : null,
         driverClass,

--- a/airbyte-integrations/connectors/source-postgres-strict-encrypt/Dockerfile
+++ b/airbyte-integrations/connectors/source-postgres-strict-encrypt/Dockerfile
@@ -16,5 +16,5 @@ ENV APPLICATION source-postgres-strict-encrypt
 
 COPY --from=build /airbyte /airbyte
 
-LABEL io.airbyte.version=0.4.42
+LABEL io.airbyte.version=0.4.43
 LABEL io.airbyte.name=airbyte/source-postgres-strict-encrypt

--- a/airbyte-integrations/connectors/source-postgres/Dockerfile
+++ b/airbyte-integrations/connectors/source-postgres/Dockerfile
@@ -16,5 +16,5 @@ ENV APPLICATION source-postgres
 
 COPY --from=build /airbyte /airbyte
 
-LABEL io.airbyte.version=0.4.42
+LABEL io.airbyte.version=0.4.43
 LABEL io.airbyte.name=airbyte/source-postgres

--- a/docs/integrations/sources/postgres.md
+++ b/docs/integrations/sources/postgres.md
@@ -353,17 +353,17 @@ Possible solutions include:
 ## Changelog
 
 | Version | Date       | Pull Request                                             | Subject                                                                                                           |
-|:--------|:-----------|:---------------------------------------------------------|:------------------------------------------------------------------------------------------------------------------|
-| 0.4.42  | 2022-08-03 | [15273](https://github.com/airbytehq/airbyte/pull/15273) | Fix a bug in `0.4.36` and correctly parse the CDC initial record waiting time |
-| 0.4.41  | 2022-08-03 | [15077](https://github.com/airbytehq/airbyte/pull/15077) | Sync data from beginning if the LSN is no longer valid in CDC | 
-|         | 2022-08-03 | [14903](https://github.com/airbytehq/airbyte/pull/14903) | Emit state messages more frequently |
-| 0.4.40  | 2022-08-03 | [15187](https://github.com/airbytehq/airbyte/pull/15187) | Add support for BCE dates/timestamps |
-|         | 2022-08-03 | [14534](https://github.com/airbytehq/airbyte/pull/14534) | Align regular and CDC integration tests and data mappers |
-| 0.4.39  | 2022-08-02 | [14801](https://github.com/airbytehq/airbyte/pull/14801) | Fix multiply log bindings |
-| 0.4.38  | 2022-07-26 | [14362](https://github.com/airbytehq/airbyte/pull/14362) | Integral columns are now discovered as int64 fields. |
-| 0.4.37  | 2022-07-22 | [14714](https://github.com/airbytehq/airbyte/pull/14714) | Clarified error message when invalid cursor column selected |
-| 0.4.36  | 2022-07-21 | [14451](https://github.com/airbytehq/airbyte/pull/14451) | Make initial CDC waiting time configurable (⛔ this version has a bug and will not work; use `0.4.42` instead) |
-| 0.4.35  | 2022-07-14 | [14574](https://github.com/airbytehq/airbyte/pull/14574) | Removed additionalProperties:false from JDBC source connectors |
+| 0.4.43  | 2022-08-03 | [15226](https://github.com/airbytehq/airbyte/pull/15226) | Make connectionTimeoutMs configurable through JDBC url parameters                                                 |
+| 0.4.42  | 2022-08-03 | [15273](https://github.com/airbytehq/airbyte/pull/15273) | Fix a bug in `0.4.36` and correctly parse the CDC initial record waiting time                                     |
+| 0.4.41  | 2022-08-03 | [15077](https://github.com/airbytehq/airbyte/pull/15077) | Sync data from beginning if the LSN is no longer valid in CDC                                                     | 
+|         | 2022-08-03 | [14903](https://github.com/airbytehq/airbyte/pull/14903) | Emit state messages more frequently                                                                               |
+| 0.4.40  | 2022-08-03 | [15187](https://github.com/airbytehq/airbyte/pull/15187) | Add support for BCE dates/timestamps                                                                              |
+|         | 2022-08-03 | [14534](https://github.com/airbytehq/airbyte/pull/14534) | Align regular and CDC integration tests and data mappers                                                          |
+| 0.4.39  | 2022-08-02 | [14801](https://github.com/airbytehq/airbyte/pull/14801) | Fix multiply log bindings                                                                                         |
+| 0.4.38  | 2022-07-26 | [14362](https://github.com/airbytehq/airbyte/pull/14362) | Integral columns are now discovered as int64 fields.                                                              |
+| 0.4.37  | 2022-07-22 | [14714](https://github.com/airbytehq/airbyte/pull/14714) | Clarified error message when invalid cursor column selected                                                       |
+| 0.4.36  | 2022-07-21 | [14451](https://github.com/airbytehq/airbyte/pull/14451) | Make initial CDC waiting time configurable (⛔ this version has a bug and will not work; use `0.4.42` instead)    |
+| 0.4.35  | 2022-07-14 | [14574](https://github.com/airbytehq/airbyte/pull/14574) | Removed additionalProperties:false from JDBC source connectors                                                    |
 | 0.4.34  | 2022-07-17 | [13840](https://github.com/airbytehq/airbyte/pull/13840) | Added the ability to connect using different SSL modes and SSL certificates.                                      |
 | 0.4.33  | 2022-07-14 | [14586](https://github.com/airbytehq/airbyte/pull/14586) | Validate source JDBC url parameters                                                                               |
 | 0.4.32  | 2022-07-07 | [14694](https://github.com/airbytehq/airbyte/pull/14694) | Force to produce LEGACY state if the use stream capable feature flag is set to false                              |


### PR DESCRIPTION
## What
`connectionTimeout` parameter for our Hikari JDBC connection defaults automatically to 60 seconds. Customers want to have this field configurable. Addresses https://github.com/airbytehq/airbyte/issues/14498

## How
In the `DataSourceFactory` we now extract the `connectTimeout` field that is passed as a custom field in `jdbc_url_param`

Potentially a change for the future is to have this value be an explicit field that is passed from the frontend since there is already `withConnectionTimeoutMs` function. Another comment is that previously while the value _could_ have been passed in through custom `jdbc_url_params` the key that HikariCP uses is `connectionTimeout` which differs from Postgres's key of `connectTimeout` which resulted in the default value of 60 seconds to be always passed

NOTES: This will introduce some new logic where a 0 timeout value will be passed along to Hikari since Postgres and Hikari both use this value to "disable" timeout meaning they use the largest number available for timeout. Additionally, Hikari uses milliseconds for it's measurement of time whereas Postgres uses seconds so parameters from `jdbc_url_params` should be marked as using seconds 

## Recommended reading order
1. `DataSourceFactory.java`
2. `AbstractJdbcSource.java`
3. `DataSourceFactoryTest.java`

## 🚨 User Impact 🚨
Are there any breaking changes? What is the end result perceived by the user? If yes, please merge this PR with the 🚨🚨 emoji so changelog authors can further highlight this if needed.

There is no breaking changes, this will introduce backwards compatibility with the existing expectation that anything will be at minimum of 60 seconds

## Pre-merge Checklist
Expand the relevant checklist and delete the others.

<details><summary><strong>New Connector</strong></summary>

### Community member or Airbyter

- [ ] **Community member?** Grant edit access to maintainers ([instructions](https://docs.github.com/en/github/collaborating-with-pull-requests/working-with-forks/allowing-changes-to-a-pull-request-branch-created-from-a-fork#enabling-repository-maintainer-permissions-on-existing-pull-requests))
- [ ] Secrets in the connector's spec are annotated with `airbyte_secret`
- [ ] Unit & integration tests added and passing. Community members, please provide proof of success locally e.g: screenshot or copy-paste unit, integration, and acceptance test output. To run acceptance tests for a Python connector, follow instructions in the README. For java connectors run `./gradlew :airbyte-integrations:connectors:<name>:integrationTest`.
- [ ] Code reviews completed
- [ ] Documentation updated
    - [ ] Connector's `README.md`
    - [ ] Connector's `bootstrap.md`. See [description and examples](https://docs.google.com/document/d/1ypdgmwmEHWv-TrO4_YOQ7pAJGVrMp5BOkEVh831N260/edit?usp=sharing)
    - [ ] `docs/integrations/<source or destination>/<name>.md` including changelog. See changelog [example](https://docs.airbyte.io/integrations/sources/stripe#changelog)
    - [ ] `docs/integrations/README.md`
    - [ ] `airbyte-integrations/builds.md`
- [ ] PR name follows [PR naming conventions](https://docs.airbyte.io/contributing-to-airbyte/updating-documentation#issues-and-pull-requests)

### Airbyter

If this is a community PR, the Airbyte engineer reviewing this PR is responsible for the below items.

- [ ] Create a non-forked branch based on this PR and test the below items on it
- [ ] Build is successful
- [ ] If new credentials are required for use in CI, add them to GSM. [Instructions](https://docs.airbyte.io/connector-development#using-credentials-in-ci).
- [ ] [`/test connector=connectors/<name>` command](https://docs.airbyte.io/connector-development#updating-an-existing-connector) is passing
- [ ] New Connector version released on Dockerhub by running the `/publish` command described [here](https://docs.airbyte.io/connector-development#updating-an-existing-connector)
- [ ] After the connector is published, connector added to connector index as described [here](https://docs.airbyte.io/connector-development#publishing-a-connector)
- [ ] Seed specs have been re-generated by building the platform and committing the changes to the seed spec files, as described [here](https://docs.airbyte.io/connector-development#publishing-a-connector)

</details>

<details><summary><strong>Updating a connector</strong></summary>

### Community member or Airbyter

- [ ] Grant edit access to maintainers ([instructions](https://docs.github.com/en/github/collaborating-with-pull-requests/working-with-forks/allowing-changes-to-a-pull-request-branch-created-from-a-fork#enabling-repository-maintainer-permissions-on-existing-pull-requests))
- [ ] Secrets in the connector's spec are annotated with `airbyte_secret`
- [ ] Unit & integration tests added and passing. Community members, please provide proof of success locally e.g: screenshot or copy-paste unit, integration, and acceptance test output. To run acceptance tests for a Python connector, follow instructions in the README. For java connectors run `./gradlew :airbyte-integrations:connectors:<name>:integrationTest`.
- [ ] Code reviews completed
- [ ] Documentation updated
    - [ ] Connector's `README.md`
    - [ ] Connector's `bootstrap.md`. See [description and examples](https://docs.google.com/document/d/1ypdgmwmEHWv-TrO4_YOQ7pAJGVrMp5BOkEVh831N260/edit?usp=sharing)
    - [ ] Changelog updated in `docs/integrations/<source or destination>/<name>.md` including changelog. See changelog [example](https://docs.airbyte.io/integrations/sources/stripe#changelog)
- [ ] PR name follows [PR naming conventions](https://docs.airbyte.io/contributing-to-airbyte/updating-documentation#issues-and-pull-requests)

### Airbyter

If this is a community PR, the Airbyte engineer reviewing this PR is responsible for the below items.

- [ ] Create a non-forked branch based on this PR and test the below items on it
- [ ] Build is successful
- [ ] If new credentials are required for use in CI, add them to GSM. [Instructions](https://docs.airbyte.io/connector-development#using-credentials-in-ci).
- [ ] [`/test connector=connectors/<name>` command](https://docs.airbyte.io/connector-development#updating-an-existing-connector) is passing
- [ ] New Connector version released on Dockerhub and connector version bumped by running the `/publish` command described [here](https://docs.airbyte.io/connector-development#updating-an-existing-connector)

</details>

<details><summary><strong>Connector Generator</strong></summary>

- [ ] Issue acceptance criteria met
- [ ] PR name follows [PR naming conventions](https://docs.airbyte.io/contributing-to-airbyte/updating-documentation#issues-and-pull-requests)
- [ ] If adding a new generator, add it to the [list of scaffold modules being tested](https://github.com/airbytehq/airbyte/blob/master/airbyte-integrations/connector-templates/generator/build.gradle#L41)
- [ ] The generator test modules (all connectors with `-scaffold` in their name) have been updated with the latest scaffold by running `./gradlew :airbyte-integrations:connector-templates:generator:testScaffoldTemplates` then checking in your changes
- [ ] Documentation which references the generator is updated as needed

</details>

## Tests

<details><summary><strong>Unit</strong></summary>

*Put your unit tests output here.*

</details>

<details><summary><strong>Integration</strong></summary>

*Put your integration tests output here.*

</details>

<details><summary><strong>Acceptance</strong></summary>

*Put your acceptance tests output here.*

</details>
