### PR TITLE
🪟 🔧 Update css-modules lint rules from warnings to errors

### DIFF
--- a/airbyte-webapp/.eslintrc
+++ b/airbyte-webapp/.eslintrc
@@ -17,8 +17,8 @@
   },
   "rules": {
     "curly": "warn",
-    "css-modules/no-undef-class": ["warn", { "camelCase": true }],
-    "css-modules/no-unused-class": ["warn", { "camelCase": true }],
+    "css-modules/no-undef-class": ["error", { "camelCase": true }],
+    "css-modules/no-unused-class": ["error", { "camelCase": true }],
     "dot-location": "warn",
     "eqeqeq": "error",
     "prettier/prettier": "warn",


### PR DESCRIPTION
## What
Updates the css-modules rules from warnings to error so that they can be fixed more promptly instead of finding out later during a CI run.
