### PR TITLE
Align Postgres Destination regular and strict encrypt versions

### DIFF
--- a/airbyte-integrations/connectors/destination-postgres-strict-encrypt/Dockerfile
+++ b/airbyte-integrations/connectors/destination-postgres-strict-encrypt/Dockerfile
@@ -16,5 +16,5 @@ ENV APPLICATION destination-postgres-strict-encrypt
 
 COPY --from=build /airbyte /airbyte
 
-LABEL io.airbyte.version=0.1.8
+LABEL io.airbyte.version=0.3.21
 LABEL io.airbyte.name=airbyte/destination-postgres-strict-encrypt


### PR DESCRIPTION
## What
Make the version of Postgres destination Strict Encrypt connector match the version of regular Postgres destination connector

## Why
- We cannot unpin the version of mysql destination connector in Airbyte Cloud unless it matches the strict encrypt version
- Strict encrypt connector is a wrapper around regular connector, so there are no functional differences