### PR TITLE
Deleted trial info

### DIFF
--- a/docs/cloud/getting-started-with-airbyte-cloud.md
+++ b/docs/cloud/getting-started-with-airbyte-cloud.md
@@ -8,7 +8,7 @@ To use Airbyte Cloud:
 
 1. If you haven't already, [sign up for Airbyte Cloud](https://cloud.airbyte.io/signup?utm_campaign=22Q1_AirbyteCloudSignUpCampaign_Trial&utm_source=Docs&utm_content=SetupGuide). 
 
-    Try Airbyte Cloud for free. For more information, see [Pricing](https://airbyte.com/pricing).
+    Airbyte Cloud offers a 14-day free trial. For more information, see [Pricing](https://airbyte.com/pricing).
 
 2. Airbyte will send you an email with a verification link. On clicking the link, you'll be taken to your new workspace.
 

--- a/docs/cloud/getting-started-with-airbyte-cloud.md
+++ b/docs/cloud/getting-started-with-airbyte-cloud.md
@@ -8,7 +8,7 @@ To use Airbyte Cloud:
 
 1. If you haven't already, [sign up for Airbyte Cloud](https://cloud.airbyte.io/signup?utm_campaign=22Q1_AirbyteCloudSignUpCampaign_Trial&utm_source=Docs&utm_content=SetupGuide). 
 
-    Start a free trial of Airbyte Cloud. For more information, see [Pricing](https://airbyte.com/pricing).
+    Try Airbyte Cloud for free. For more information, see [Pricing](https://airbyte.com/pricing).
 
 2. Airbyte will send you an email with a verification link. On clicking the link, you'll be taken to your new workspace.
 

--- a/docs/cloud/getting-started-with-airbyte-cloud.md
+++ b/docs/cloud/getting-started-with-airbyte-cloud.md
@@ -8,7 +8,7 @@ To use Airbyte Cloud:
 
 1. If you haven't already, [sign up for Airbyte Cloud](https://cloud.airbyte.io/signup?utm_campaign=22Q1_AirbyteCloudSignUpCampaign_Trial&utm_source=Docs&utm_content=SetupGuide). 
 
-    Airbyte Cloud offers a 14-day free trial with $1000 worth of [credits](core-concepts.md#credits), whichever expires first. For more information, see [Pricing](https://airbyte.com/pricing).
+    Start a free trial of Airbyte Cloud. For more information, see [Pricing](https://airbyte.com/pricing).
 
 2. Airbyte will send you an email with a verification link. On clicking the link, you'll be taken to your new workspace.
 


### PR DESCRIPTION
Pricing and free trial have been updated. Edited the [Getting Started with Airbyte Cloud](https://docs.airbyte.com/cloud/getting-started-with-airbyte-cloud) doc to get rid of outdated info. 

Related to this [ticket](https://app.zenhub.com/workspaces/documentation-6266ed73c9cbb400119b1e54/issues/airbytehq/airbyte/15275). 
