### PR TITLE
Multi-Cloud Phase 1: Configs and new activity to allocate Data Plane tasks

### DIFF
--- a/airbyte-config/config-models/src/main/java/io/airbyte/config/Configs.java
+++ b/airbyte-config/config-models/src/main/java/io/airbyte/config/Configs.java
@@ -541,6 +541,21 @@ public interface Configs {
    */
   boolean shouldRunConnectionManagerWorkflows();
 
+  // Worker - Control/Data Plane configs
+  /**
+   * Define if the worker should register a workflow handler for the SYNC Task Queue. - Requires
+   * `shouldRunSyncWorkflows` to be `true`. - Should be `true` only for Control-plane workers.
+   * Internal-use only.
+   */
+  boolean shouldHandleSyncWorkflowTasks();
+
+  /**
+   * Define a set of Temporal Task Queue names for which the worker should register sync activity
+   * handlers for. - Requires `shouldRunSyncWorkflows` to be `true`. - Entries should correspond with
+   * the Data Plane where the worker is deployed. Internal-use only.
+   */
+  Set<String> getSyncActivityTaskQueues();
+
   // Worker - Kube only
   /**
    * Define the local ports the Airbyte Worker pod uses to connect to the various Job pods.

--- a/airbyte-config/config-models/src/main/java/io/airbyte/config/Configs.java
+++ b/airbyte-config/config-models/src/main/java/io/airbyte/config/Configs.java
@@ -542,21 +542,35 @@ public interface Configs {
   boolean shouldRunConnectionManagerWorkflows();
 
   // Worker - Control/Data Plane configs
+
   /**
    * Define if the worker should register a workflow handler for the SYNC Task Queue. - Requires
    * `shouldRunSyncWorkflows` to be `true`. - Should be `true` only for Control-plane workers.
    * Internal-use only.
    */
-  boolean shouldHandleSyncWorkflowTasks();
+  boolean shouldHandleSyncControlPlaneTasks();
+
+  /**
+   * Define the default task queue for sync activities that are not routed to a separate data plane.
+   * Internal-use only.
+   */
+  String primarySyncDataPlaneTaskQueue();
+
+  /**
+   * TEMPORARY: Define a set of connection IDs that should run in Airbyte's AWS Data Plane. Will be
+   * removed in favor of the Routing Service in the future. Internal-use only.
+   */
+  Set<String> connectionIdsForAwsDataPlane();
 
   /**
    * Define a set of Temporal Task Queue names for which the worker should register sync activity
    * handlers for. - Requires `shouldRunSyncWorkflows` to be `true`. - Entries should correspond with
    * the Data Plane where the worker is deployed. Internal-use only.
    */
-  Set<String> getSyncActivityTaskQueues();
+  Set<String> getSyncDataPlaneTaskQueues();
 
   // Worker - Kube only
+
   /**
    * Define the local ports the Airbyte Worker pod uses to connect to the various Job pods.
    */

--- a/airbyte-config/config-models/src/main/java/io/airbyte/config/Configs.java
+++ b/airbyte-config/config-models/src/main/java/io/airbyte/config/Configs.java
@@ -557,8 +557,9 @@ public interface Configs {
   String primarySyncDataPlaneTaskQueue();
 
   /**
-   * TEMPORARY: Define a set of connection IDs that should run in Airbyte's AWS Data Plane. Will be
-   * removed in favor of the Routing Service in the future. Internal-use only.
+   * TEMPORARY: Define a set of connection IDs that should run in Airbyte's AWS Data Plane.
+   * - This should only be set on Control-plane workers, since those workers decide which Data Plane task queue to use based on connectionId.
+   * - Will be removed in favor of the Routing Service in the future. Internal-use only.
    */
   Set<String> connectionIdsForAwsDataPlane();
 

--- a/airbyte-config/config-models/src/main/java/io/airbyte/config/Configs.java
+++ b/airbyte-config/config-models/src/main/java/io/airbyte/config/Configs.java
@@ -557,9 +557,10 @@ public interface Configs {
   String primarySyncDataPlaneTaskQueue();
 
   /**
-   * TEMPORARY: Define a set of connection IDs that should run in Airbyte's AWS Data Plane.
-   * - This should only be set on Control-plane workers, since those workers decide which Data Plane task queue to use based on connectionId.
-   * - Will be removed in favor of the Routing Service in the future. Internal-use only.
+   * TEMPORARY: Define a set of connection IDs that should run in Airbyte's AWS Data Plane. - This
+   * should only be set on Control-plane workers, since those workers decide which Data Plane task
+   * queue to use based on connectionId. - Will be removed in favor of the Routing Service in the
+   * future. Internal-use only.
    */
   Set<String> connectionIdsForAwsDataPlane();
 

--- a/airbyte-config/config-models/src/main/java/io/airbyte/config/EnvConfigs.java
+++ b/airbyte-config/config-models/src/main/java/io/airbyte/config/EnvConfigs.java
@@ -131,7 +131,9 @@ public class EnvConfigs implements Configs {
 
   // Control/Data plane configs
   private static final String SHOULD_HANDLE_SYNC_WORKFLOW_TASKS = "SHOULD_HANDLE_SYNC_WORKFLOW_TASKS";
+  private static final String PRIMARY_SYNC_ACTIVITY_TASK_QUEUE = "PRIMARY_SYNC_ACTIVITY_TASK_QUEUE";
   private static final String SYNC_ACTIVITY_TASK_QUEUES = "SYNC_ACTIVITY_TASK_QUEUES";
+  private static final String CONNECTION_IDS_FOR_AWS_DATA_PLANE = "CONNECTION_IDS_FOR_AWS_DATA_PLANE";
 
   private static final String MAX_FAILED_JOBS_IN_A_ROW_BEFORE_CONNECTION_DISABLE = "MAX_FAILED_JOBS_IN_A_ROW_BEFORE_CONNECTION_DISABLE";
   private static final String MAX_DAYS_OF_ONLY_FAILED_JOBS_BEFORE_CONNECTION_DISABLE = "MAX_DAYS_OF_ONLY_FAILED_JOBS_BEFORE_CONNECTION_DISABLE";
@@ -187,7 +189,7 @@ public class EnvConfigs implements Configs {
 
   public static final String DEFAULT_NETWORK = "host";
 
-  public static final String DEFAULT_SYNC_ACTIVITY_TASK_QUEUE = "SYNC_ACTIVITIES";
+  public static final String DEFAULT_PRIMARY_SYNC_ACTIVITY_TASK_QUEUE = "SYNC_ACTIVITIES";
 
   public static final Map<String, Function<EnvConfigs, String>> JOB_SHARED_ENVS = Map.of(
       AIRBYTE_VERSION, (instance) -> instance.getAirbyteVersion().serialize(),
@@ -904,7 +906,7 @@ public class EnvConfigs implements Configs {
   }
 
   @Override
-  public boolean shouldHandleSyncWorkflowTasks() {
+  public boolean shouldHandleSyncControlPlaneTasks() {
     final boolean result = getEnvOrDefault(SHOULD_HANDLE_SYNC_WORKFLOW_TASKS, true);
     if (result && !shouldRunSyncWorkflows()) {
       throw new IllegalArgumentException(
@@ -914,8 +916,22 @@ public class EnvConfigs implements Configs {
   }
 
   @Override
-  public Set<String> getSyncActivityTaskQueues() {
-    final var taskQueues = getEnvOrDefault(SYNC_ACTIVITY_TASK_QUEUES, DEFAULT_SYNC_ACTIVITY_TASK_QUEUE);
+  public String primarySyncDataPlaneTaskQueue() {
+    return getEnvOrDefault(PRIMARY_SYNC_ACTIVITY_TASK_QUEUE, DEFAULT_PRIMARY_SYNC_ACTIVITY_TASK_QUEUE);
+  }
+
+  @Override
+  public Set<String> connectionIdsForAwsDataPlane() {
+    final var connectionIds = getEnvOrDefault(CONNECTION_IDS_FOR_AWS_DATA_PLANE, "");
+    if (connectionIds.isEmpty()) {
+      return new HashSet<>();
+    }
+    return Arrays.stream(connectionIds.split(",")).collect(Collectors.toSet());
+  }
+
+  @Override
+  public Set<String> getSyncDataPlaneTaskQueues() {
+    final var taskQueues = getEnvOrDefault(SYNC_ACTIVITY_TASK_QUEUES, primarySyncDataPlaneTaskQueue());
     if (taskQueues.isEmpty()) {
       return new HashSet<>();
     }
@@ -929,7 +945,7 @@ public class EnvConfigs implements Configs {
    */
   private void validateSyncWorkflowConfigs() {
     if (shouldRunSyncWorkflows()) {
-      if (!shouldHandleSyncWorkflowTasks() && getSyncActivityTaskQueues().isEmpty()) {
+      if (!shouldHandleSyncControlPlaneTasks() && getSyncDataPlaneTaskQueues().isEmpty()) {
         throw new IllegalArgumentException(String.format(
             "When %s is true, either %s must also be true, or %s must be non-empty.",
             SHOULD_RUN_SYNC_WORKFLOWS,

--- a/airbyte-config/config-models/src/main/java/io/airbyte/config/EnvConfigs.java
+++ b/airbyte-config/config-models/src/main/java/io/airbyte/config/EnvConfigs.java
@@ -189,7 +189,7 @@ public class EnvConfigs implements Configs {
 
   public static final String DEFAULT_NETWORK = "host";
 
-  public static final String DEFAULT_PRIMARY_SYNC_DATA_PLANE_TASK_QUEUE = "SYNC_DATA_PLANE";
+  public static final String DEFAULT_PRIMARY_SYNC_DATA_PLANE_TASK_QUEUE = "SYNC";
 
   public static final Map<String, Function<EnvConfigs, String>> JOB_SHARED_ENVS = Map.of(
       AIRBYTE_VERSION, (instance) -> instance.getAirbyteVersion().serialize(),

--- a/airbyte-config/config-models/src/main/java/io/airbyte/config/EnvConfigs.java
+++ b/airbyte-config/config-models/src/main/java/io/airbyte/config/EnvConfigs.java
@@ -129,6 +129,10 @@ public class EnvConfigs implements Configs {
   private static final String SHOULD_RUN_SYNC_WORKFLOWS = "SHOULD_RUN_SYNC_WORKFLOWS";
   private static final String SHOULD_RUN_CONNECTION_MANAGER_WORKFLOWS = "SHOULD_RUN_CONNECTION_MANAGER_WORKFLOWS";
 
+  // Control/Data plane configs
+  private static final String SHOULD_HANDLE_SYNC_WORKFLOW_TASKS = "SHOULD_HANDLE_SYNC_WORKFLOW_TASKS";
+  private static final String SYNC_ACTIVITY_TASK_QUEUES = "SYNC_ACTIVITY_TASK_QUEUES";
+
   private static final String MAX_FAILED_JOBS_IN_A_ROW_BEFORE_CONNECTION_DISABLE = "MAX_FAILED_JOBS_IN_A_ROW_BEFORE_CONNECTION_DISABLE";
   private static final String MAX_DAYS_OF_ONLY_FAILED_JOBS_BEFORE_CONNECTION_DISABLE = "MAX_DAYS_OF_ONLY_FAILED_JOBS_BEFORE_CONNECTION_DISABLE";
 
@@ -183,6 +187,8 @@ public class EnvConfigs implements Configs {
 
   public static final String DEFAULT_NETWORK = "host";
 
+  public static final String DEFAULT_SYNC_ACTIVITY_TASK_QUEUE = "SYNC_ACTIVITIES";
+
   public static final Map<String, Function<EnvConfigs, String>> JOB_SHARED_ENVS = Map.of(
       AIRBYTE_VERSION, (instance) -> instance.getAirbyteVersion().serialize(),
       AIRBYTE_ROLE, EnvConfigs::getAirbyteRole,
@@ -215,6 +221,8 @@ public class EnvConfigs implements Configs {
     this.getAllEnvKeys = envMap::keySet;
     this.logConfigs = new LogConfigs(getLogConfiguration().orElse(null));
     this.stateStorageCloudConfigs = getStateStorageConfiguration().orElse(null);
+
+    validateSyncWorkflowConfigs();
   }
 
   private Optional<CloudStorageConfigs> getLogConfiguration() {
@@ -893,6 +901,42 @@ public class EnvConfigs implements Configs {
   @Override
   public boolean shouldRunConnectionManagerWorkflows() {
     return getEnvOrDefault(SHOULD_RUN_CONNECTION_MANAGER_WORKFLOWS, true);
+  }
+
+  @Override
+  public boolean shouldHandleSyncWorkflowTasks() {
+    final boolean result = getEnvOrDefault(SHOULD_HANDLE_SYNC_WORKFLOW_TASKS, true);
+    if (result && !shouldRunSyncWorkflows()) {
+      throw new IllegalArgumentException(
+          String.format("%s cannot be true when %s is false", SHOULD_HANDLE_SYNC_WORKFLOW_TASKS, SHOULD_RUN_SYNC_WORKFLOWS));
+    }
+    return result;
+  }
+
+  @Override
+  public Set<String> getSyncActivityTaskQueues() {
+    final var taskQueues = getEnvOrDefault(SYNC_ACTIVITY_TASK_QUEUES, DEFAULT_SYNC_ACTIVITY_TASK_QUEUE);
+    if (taskQueues.isEmpty()) {
+      return new HashSet<>();
+    }
+    return Arrays.stream(taskQueues.split(",")).collect(Collectors.toSet());
+  }
+
+  /**
+   * Ensures the user hasn't configured themselves into a corner by making sure that the worker is set
+   * up to properly process sync workflows. With sensible defaults, it should be hard to fail this
+   * validation, but this provides a safety net regardless.
+   */
+  private void validateSyncWorkflowConfigs() {
+    if (shouldRunSyncWorkflows()) {
+      if (!shouldHandleSyncWorkflowTasks() && getSyncActivityTaskQueues().isEmpty()) {
+        throw new IllegalArgumentException(String.format(
+            "When %s is true, either %s must also be true, or %s must be non-empty.",
+            SHOULD_RUN_SYNC_WORKFLOWS,
+            SHOULD_HANDLE_SYNC_WORKFLOW_TASKS,
+            SYNC_ACTIVITY_TASK_QUEUES));
+      }
+    }
   }
 
   @Override

--- a/airbyte-config/config-models/src/main/java/io/airbyte/config/EnvConfigs.java
+++ b/airbyte-config/config-models/src/main/java/io/airbyte/config/EnvConfigs.java
@@ -130,9 +130,9 @@ public class EnvConfigs implements Configs {
   private static final String SHOULD_RUN_CONNECTION_MANAGER_WORKFLOWS = "SHOULD_RUN_CONNECTION_MANAGER_WORKFLOWS";
 
   // Control/Data plane configs
-  private static final String SHOULD_HANDLE_SYNC_WORKFLOW_TASKS = "SHOULD_HANDLE_SYNC_WORKFLOW_TASKS";
-  private static final String PRIMARY_SYNC_ACTIVITY_TASK_QUEUE = "PRIMARY_SYNC_ACTIVITY_TASK_QUEUE";
-  private static final String SYNC_ACTIVITY_TASK_QUEUES = "SYNC_ACTIVITY_TASK_QUEUES";
+  private static final String SHOULD_HANDLE_SYNC_CONTROL_PLANE_TASKS = "SHOULD_HANDLE_SYNC_CONTROL_PLANE_TASKS";
+  private static final String PRIMARY_SYNC_DATA_PLANE_TASK_QUEUE = "PRIMARY_SYNC_DATA_PLANE_TASK_QUEUE";
+  private static final String SYNC_DATA_PLANE_TASK_QUEUES = "SYNC_DATA_PLANE_TASK_QUEUES";
   private static final String CONNECTION_IDS_FOR_AWS_DATA_PLANE = "CONNECTION_IDS_FOR_AWS_DATA_PLANE";
 
   private static final String MAX_FAILED_JOBS_IN_A_ROW_BEFORE_CONNECTION_DISABLE = "MAX_FAILED_JOBS_IN_A_ROW_BEFORE_CONNECTION_DISABLE";
@@ -189,7 +189,7 @@ public class EnvConfigs implements Configs {
 
   public static final String DEFAULT_NETWORK = "host";
 
-  public static final String DEFAULT_PRIMARY_SYNC_ACTIVITY_TASK_QUEUE = "SYNC_ACTIVITIES";
+  public static final String DEFAULT_PRIMARY_SYNC_DATA_PLANE_TASK_QUEUE = "SYNC_DATA_PLANE";
 
   public static final Map<String, Function<EnvConfigs, String>> JOB_SHARED_ENVS = Map.of(
       AIRBYTE_VERSION, (instance) -> instance.getAirbyteVersion().serialize(),
@@ -907,17 +907,17 @@ public class EnvConfigs implements Configs {
 
   @Override
   public boolean shouldHandleSyncControlPlaneTasks() {
-    final boolean result = getEnvOrDefault(SHOULD_HANDLE_SYNC_WORKFLOW_TASKS, true);
+    final boolean result = getEnvOrDefault(SHOULD_HANDLE_SYNC_CONTROL_PLANE_TASKS, true);
     if (result && !shouldRunSyncWorkflows()) {
       throw new IllegalArgumentException(
-          String.format("%s cannot be true when %s is false", SHOULD_HANDLE_SYNC_WORKFLOW_TASKS, SHOULD_RUN_SYNC_WORKFLOWS));
+          String.format("%s cannot be true when %s is false", SHOULD_HANDLE_SYNC_CONTROL_PLANE_TASKS, SHOULD_RUN_SYNC_WORKFLOWS));
     }
     return result;
   }
 
   @Override
   public String primarySyncDataPlaneTaskQueue() {
-    return getEnvOrDefault(PRIMARY_SYNC_ACTIVITY_TASK_QUEUE, DEFAULT_PRIMARY_SYNC_ACTIVITY_TASK_QUEUE);
+    return getEnvOrDefault(PRIMARY_SYNC_DATA_PLANE_TASK_QUEUE, DEFAULT_PRIMARY_SYNC_DATA_PLANE_TASK_QUEUE);
   }
 
   @Override
@@ -931,7 +931,7 @@ public class EnvConfigs implements Configs {
 
   @Override
   public Set<String> getSyncDataPlaneTaskQueues() {
-    final var taskQueues = getEnvOrDefault(SYNC_ACTIVITY_TASK_QUEUES, primarySyncDataPlaneTaskQueue());
+    final var taskQueues = getEnvOrDefault(SYNC_DATA_PLANE_TASK_QUEUES, primarySyncDataPlaneTaskQueue());
     if (taskQueues.isEmpty()) {
       return new HashSet<>();
     }
@@ -949,8 +949,8 @@ public class EnvConfigs implements Configs {
         throw new IllegalArgumentException(String.format(
             "When %s is true, either %s must also be true, or %s must be non-empty.",
             SHOULD_RUN_SYNC_WORKFLOWS,
-            SHOULD_HANDLE_SYNC_WORKFLOW_TASKS,
-            SYNC_ACTIVITY_TASK_QUEUES));
+            SHOULD_HANDLE_SYNC_CONTROL_PLANE_TASKS,
+            SYNC_DATA_PLANE_TASK_QUEUES));
       }
     }
   }

--- a/airbyte-workers/src/main/java/io/airbyte/workers/WorkerApp.java
+++ b/airbyte-workers/src/main/java/io/airbyte/workers/WorkerApp.java
@@ -76,6 +76,7 @@ import io.airbyte.workers.temporal.scheduling.activities.StreamResetActivityImpl
 import io.airbyte.workers.temporal.spec.SpecActivityImpl;
 import io.airbyte.workers.temporal.spec.SpecWorkflowImpl;
 import io.airbyte.workers.temporal.sync.DbtTransformationActivityImpl;
+import io.airbyte.workers.temporal.sync.DecideDataPlaneTaskQueueActivityImpl;
 import io.airbyte.workers.temporal.sync.NormalizationActivityImpl;
 import io.airbyte.workers.temporal.sync.PersistStateActivityImpl;
 import io.airbyte.workers.temporal.sync.ReplicationActivityImpl;
@@ -221,12 +222,16 @@ public class WorkerApp {
   }
 
   private void registerSync(final WorkerFactory factory) {
-    registerSyncActivityWorkers(factory);
-    registerSyncWorkflowWorkers(factory);
+    registerSyncDataPlaneWorkers(factory);
+    registerSyncControlPlaneWorkers(factory);
   }
 
-  private void registerSyncActivityWorkers(final WorkerFactory factory) {
-    if (!configs.getSyncActivityTaskQueues().isEmpty()) {
+  /**
+   * Data Plane workers handle the subset of SyncWorkflow activity tasks that should run within a Data
+   * Plane.
+   */
+  private void registerSyncDataPlaneWorkers(final WorkerFactory factory) {
+    if (!configs.getSyncDataPlaneTaskQueues().isEmpty()) {
       final ReplicationActivityImpl replicationActivity = getReplicationActivityImpl(replicationWorkerConfigs, replicationProcessFactory);
       // Note that the configuration injected here is for the normalization orchestrator, and not the
       // normalization pod itself.
@@ -237,19 +242,26 @@ public class WorkerApp {
           defaultProcessFactory);
       final PersistStateActivityImpl persistStateActivity = new PersistStateActivityImpl(statePersistence, featureFlags);
 
-      for (final String activityTaskQueue : configs.getSyncActivityTaskQueues()) {
+      for (final String taskQueue : configs.getSyncDataPlaneTaskQueues()) {
         // TODO (parker) consider separating out maxSyncActivityWorkers and maxSyncWorkflowWorkers
-        final Worker worker = factory.newWorker(activityTaskQueue, getWorkerOptions(maxWorkers.getMaxSyncWorkers()));
+        final Worker worker = factory.newWorker(taskQueue, getWorkerOptions(maxWorkers.getMaxSyncWorkers()));
         worker.registerActivitiesImplementations(replicationActivity, normalizationActivity, dbtTransformationActivity, persistStateActivity);
       }
     }
   }
 
-  private void registerSyncWorkflowWorkers(final WorkerFactory factory) {
-    if (configs.shouldHandleSyncWorkflowTasks()) {
+  /**
+   * Control Plane workers handle all workflow tasks for the SyncWorkflow, as well as the activity
+   * task to decide which task queue to use for Data Plane tasks.
+   */
+  private void registerSyncControlPlaneWorkers(final WorkerFactory factory) {
+    if (configs.shouldHandleSyncControlPlaneTasks()) {
       // TODO (parker) consider separating out maxSyncActivityWorkers and maxSyncWorkflowWorkers
       final Worker syncWorker = factory.newWorker(TemporalJobType.SYNC.name(), getWorkerOptions(maxWorkers.getMaxSyncWorkers()));
       syncWorker.registerWorkflowImplementationTypes(SyncWorkflowImpl.class);
+
+      final DecideDataPlaneTaskQueueActivityImpl decideTaskQueueActivity = getDecideTaskQueueActivityImpl();
+      syncWorker.registerActivitiesImplementations(decideTaskQueueActivity);
     }
   }
 
@@ -325,6 +337,10 @@ public class WorkerApp {
         logConfigs,
         jobPersistence,
         airbyteVersion);
+  }
+
+  private DecideDataPlaneTaskQueueActivityImpl getDecideTaskQueueActivityImpl() {
+    return new DecideDataPlaneTaskQueueActivityImpl(configs);
   }
 
   /**

--- a/airbyte-workers/src/main/java/io/airbyte/workers/temporal/sync/DecideDataPlaneTaskQueueActivity.java
+++ b/airbyte-workers/src/main/java/io/airbyte/workers/temporal/sync/DecideDataPlaneTaskQueueActivity.java
@@ -1,0 +1,17 @@
+/*
+ * Copyright (c) 2022 Airbyte, Inc., all rights reserved.
+ */
+
+package io.airbyte.workers.temporal.sync;
+
+import io.temporal.activity.ActivityInterface;
+import io.temporal.activity.ActivityMethod;
+import java.util.UUID;
+
+@ActivityInterface
+public interface DecideDataPlaneTaskQueueActivity {
+
+  @ActivityMethod
+  String decideDataPlaneTaskQueue(final UUID connectionId);
+
+}

--- a/airbyte-workers/src/main/java/io/airbyte/workers/temporal/sync/DecideDataPlaneTaskQueueActivityImpl.java
+++ b/airbyte-workers/src/main/java/io/airbyte/workers/temporal/sync/DecideDataPlaneTaskQueueActivityImpl.java
@@ -9,7 +9,7 @@ import java.util.UUID;
 
 public class DecideDataPlaneTaskQueueActivityImpl implements DecideDataPlaneTaskQueueActivity {
 
-  private static final String AWS_DATA_PLANE_TASK_QUEUE = "AWS_DEV_SYNC_ACTIVITIES";
+  private static final String AWS_DATA_PLANE_TASK_QUEUE = "AWS_DEV_SYNC_DATA_PLANE";
 
   private final Configs configs;
 

--- a/airbyte-workers/src/main/java/io/airbyte/workers/temporal/sync/DecideDataPlaneTaskQueueActivityImpl.java
+++ b/airbyte-workers/src/main/java/io/airbyte/workers/temporal/sync/DecideDataPlaneTaskQueueActivityImpl.java
@@ -1,0 +1,28 @@
+/*
+ * Copyright (c) 2022 Airbyte, Inc., all rights reserved.
+ */
+
+package io.airbyte.workers.temporal.sync;
+
+import io.airbyte.config.Configs;
+import java.util.UUID;
+
+public class DecideDataPlaneTaskQueueActivityImpl implements DecideDataPlaneTaskQueueActivity {
+
+  private static final String AWS_DATA_PLANE_TASK_QUEUE = "AWS_DEV_SYNC_ACTIVITIES";
+
+  private final Configs configs;
+
+  public DecideDataPlaneTaskQueueActivityImpl(final Configs configs) {
+    this.configs = configs;
+  }
+
+  @Override
+  public String decideDataPlaneTaskQueue(final UUID connectionId) {
+    if (configs.connectionIdsForAwsDataPlane().contains(connectionId.toString())) {
+      return AWS_DATA_PLANE_TASK_QUEUE;
+    }
+    return configs.primarySyncDataPlaneTaskQueue();
+  }
+
+}

--- a/airbyte-workers/src/main/java/io/airbyte/workers/temporal/sync/SyncWorkflowImpl.java
+++ b/airbyte-workers/src/main/java/io/airbyte/workers/temporal/sync/SyncWorkflowImpl.java
@@ -28,7 +28,8 @@ public class SyncWorkflowImpl implements SyncWorkflow {
 
   private static final Logger LOGGER = LoggerFactory.getLogger(SyncWorkflowImpl.class);
   private static final String VERSION_LABEL = "sync-workflow";
-  private static final int CURRENT_VERSION = 1;
+  private static final int CURRENT_VERSION = 2;
+  private static final int PREV_VERSION = 1;
 
   @Override
   public StandardSyncOutput run(final JobRunConfig jobRunConfig,
@@ -37,25 +38,40 @@ public class SyncWorkflowImpl implements SyncWorkflow {
                                 final StandardSyncInput syncInput,
                                 final UUID connectionId) {
 
-    final DecideDataPlaneTaskQueueActivity decideDataPlaneTaskQueueActivity =
-        Workflow.newActivityStub(DecideDataPlaneTaskQueueActivity.class, ActivityConfiguration.SHORT_ACTIVITY_OPTIONS);
+    final int version = Workflow.getVersion(VERSION_LABEL, Workflow.DEFAULT_VERSION, CURRENT_VERSION);
 
-    final String dataPlaneTaskQueue = decideDataPlaneTaskQueueActivity.decideDataPlaneTaskQueue(connectionId);
+    final ReplicationActivity replicationActivity;
+    final NormalizationActivity normalizationActivity;
+    final DbtTransformationActivity dbtTransformationActivity;
+    final PersistStateActivity persistActivity;
 
-    final ReplicationActivity replicationActivity =
-        Workflow.newActivityStub(ReplicationActivity.class, setTaskQueue(ActivityConfiguration.LONG_RUN_OPTIONS, dataPlaneTaskQueue));
+    /**
+     * The current version calls a new activity to determine which Task Queue to use for other
+     * activities. The previous version doesn't call this new activity, and instead lets each activity
+     * inherit the workflow's Task Queue.
+     */
+    if (version > PREV_VERSION) {
+      final DecideDataPlaneTaskQueueActivity decideTaskQueueActivity =
+          Workflow.newActivityStub(DecideDataPlaneTaskQueueActivity.class, ActivityConfiguration.SHORT_ACTIVITY_OPTIONS);
 
-    final PersistStateActivity persistActivity =
-        Workflow.newActivityStub(PersistStateActivity.class, setTaskQueue(ActivityConfiguration.SHORT_ACTIVITY_OPTIONS, dataPlaneTaskQueue));
+      final String activityTaskQueue = decideTaskQueueActivity.decideDataPlaneTaskQueue(connectionId);
 
-    final NormalizationActivity normalizationActivity =
-        Workflow.newActivityStub(NormalizationActivity.class, setTaskQueue(ActivityConfiguration.LONG_RUN_OPTIONS, dataPlaneTaskQueue));
-
-    final DbtTransformationActivity dbtTransformationActivity =
-        Workflow.newActivityStub(DbtTransformationActivity.class, setTaskQueue(ActivityConfiguration.LONG_RUN_OPTIONS, dataPlaneTaskQueue));
+      replicationActivity =
+          Workflow.newActivityStub(ReplicationActivity.class, setTaskQueue(ActivityConfiguration.LONG_RUN_OPTIONS, activityTaskQueue));
+      persistActivity =
+          Workflow.newActivityStub(PersistStateActivity.class, setTaskQueue(ActivityConfiguration.SHORT_ACTIVITY_OPTIONS, activityTaskQueue));
+      normalizationActivity =
+          Workflow.newActivityStub(NormalizationActivity.class, setTaskQueue(ActivityConfiguration.LONG_RUN_OPTIONS, activityTaskQueue));
+      dbtTransformationActivity =
+          Workflow.newActivityStub(DbtTransformationActivity.class, setTaskQueue(ActivityConfiguration.LONG_RUN_OPTIONS, activityTaskQueue));
+    } else {
+      replicationActivity = Workflow.newActivityStub(ReplicationActivity.class, ActivityConfiguration.LONG_RUN_OPTIONS);
+      normalizationActivity = Workflow.newActivityStub(NormalizationActivity.class, ActivityConfiguration.LONG_RUN_OPTIONS);
+      dbtTransformationActivity = Workflow.newActivityStub(DbtTransformationActivity.class, ActivityConfiguration.LONG_RUN_OPTIONS);
+      persistActivity = Workflow.newActivityStub(PersistStateActivity.class, ActivityConfiguration.SHORT_ACTIVITY_OPTIONS);
+    }
 
     StandardSyncOutput syncOutput = replicationActivity.replicate(jobRunConfig, sourceLauncherConfig, destinationLauncherConfig, syncInput);
-    final int version = Workflow.getVersion(VERSION_LABEL, Workflow.DEFAULT_VERSION, CURRENT_VERSION);
 
     if (version > Workflow.DEFAULT_VERSION) {
       // the state is persisted immediately after the replication succeeded, because the

--- a/airbyte-workers/src/main/java/io/airbyte/workers/temporal/sync/SyncWorkflowImpl.java
+++ b/airbyte-workers/src/main/java/io/airbyte/workers/temporal/sync/SyncWorkflowImpl.java
@@ -33,10 +33,10 @@ public class SyncWorkflowImpl implements SyncWorkflow {
 
   @Override
   public StandardSyncOutput run(final JobRunConfig jobRunConfig,
-      final IntegrationLauncherConfig sourceLauncherConfig,
-      final IntegrationLauncherConfig destinationLauncherConfig,
-      final StandardSyncInput syncInput,
-      final UUID connectionId) {
+                                final IntegrationLauncherConfig sourceLauncherConfig,
+                                final IntegrationLauncherConfig destinationLauncherConfig,
+                                final StandardSyncInput syncInput,
+                                final UUID connectionId) {
 
     final int version = Workflow.getVersion(VERSION_LABEL, Workflow.DEFAULT_VERSION, CURRENT_VERSION);
 
@@ -46,8 +46,9 @@ public class SyncWorkflowImpl implements SyncWorkflow {
     final PersistStateActivity persistActivity;
 
     /**
-     * The current version calls a new activity to determine which Task Queue to use for other activities.
-     * The previous version doesn't call this new activity, and instead lets each activity inherit the workflow's Task Queue.
+     * The current version calls a new activity to determine which Task Queue to use for other
+     * activities. The previous version doesn't call this new activity, and instead lets each activity
+     * inherit the workflow's Task Queue.
      */
     if (version > PREV_VERSION) {
       final DecideDataPlaneTaskQueueActivity decideTaskQueueActivity =

--- a/airbyte-workers/src/main/java/io/airbyte/workers/temporal/sync/SyncWorkflowImpl.java
+++ b/airbyte-workers/src/main/java/io/airbyte/workers/temporal/sync/SyncWorkflowImpl.java
@@ -54,16 +54,16 @@ public class SyncWorkflowImpl implements SyncWorkflow {
       final DecideDataPlaneTaskQueueActivity decideTaskQueueActivity =
           Workflow.newActivityStub(DecideDataPlaneTaskQueueActivity.class, ActivityConfiguration.SHORT_ACTIVITY_OPTIONS);
 
-      final String activityTaskQueue = decideTaskQueueActivity.decideDataPlaneTaskQueue(connectionId);
+      final String dataPlaneTaskQueue = decideTaskQueueActivity.decideDataPlaneTaskQueue(connectionId);
 
       replicationActivity =
-          Workflow.newActivityStub(ReplicationActivity.class, setTaskQueue(ActivityConfiguration.LONG_RUN_OPTIONS, activityTaskQueue));
+          Workflow.newActivityStub(ReplicationActivity.class, setTaskQueue(ActivityConfiguration.LONG_RUN_OPTIONS, dataPlaneTaskQueue));
       persistActivity =
-          Workflow.newActivityStub(PersistStateActivity.class, setTaskQueue(ActivityConfiguration.SHORT_ACTIVITY_OPTIONS, activityTaskQueue));
+          Workflow.newActivityStub(PersistStateActivity.class, setTaskQueue(ActivityConfiguration.SHORT_ACTIVITY_OPTIONS, dataPlaneTaskQueue));
       normalizationActivity =
-          Workflow.newActivityStub(NormalizationActivity.class, setTaskQueue(ActivityConfiguration.LONG_RUN_OPTIONS, activityTaskQueue));
+          Workflow.newActivityStub(NormalizationActivity.class, setTaskQueue(ActivityConfiguration.LONG_RUN_OPTIONS, dataPlaneTaskQueue));
       dbtTransformationActivity =
-          Workflow.newActivityStub(DbtTransformationActivity.class, setTaskQueue(ActivityConfiguration.LONG_RUN_OPTIONS, activityTaskQueue));
+          Workflow.newActivityStub(DbtTransformationActivity.class, setTaskQueue(ActivityConfiguration.LONG_RUN_OPTIONS, dataPlaneTaskQueue));
     } else {
       replicationActivity = Workflow.newActivityStub(ReplicationActivity.class, ActivityConfiguration.LONG_RUN_OPTIONS);
       normalizationActivity = Workflow.newActivityStub(NormalizationActivity.class, ActivityConfiguration.LONG_RUN_OPTIONS);

--- a/airbyte-workers/src/main/java/io/airbyte/workers/temporal/sync/SyncWorkflowImpl.java
+++ b/airbyte-workers/src/main/java/io/airbyte/workers/temporal/sync/SyncWorkflowImpl.java
@@ -37,8 +37,10 @@ public class SyncWorkflowImpl implements SyncWorkflow {
                                 final StandardSyncInput syncInput,
                                 final UUID connectionId) {
 
-    // TODO (parker) add an activity that decides the task queue based on the connectionId
-    final String activityTaskQueue = EnvConfigs.DEFAULT_SYNC_ACTIVITY_TASK_QUEUE;
+    final DecideDataPlaneTaskQueueActivity decideTaskQueueActivity =
+        Workflow.newActivityStub(DecideDataPlaneTaskQueueActivity.class, ActivityConfiguration.SHORT_ACTIVITY_OPTIONS);
+
+    final String activityTaskQueue = decideTaskQueueActivity.decideDataPlaneTaskQueue(connectionId);
 
     final ReplicationActivity replicationActivity =
         Workflow.newActivityStub(ReplicationActivity.class, setTaskQueue(ActivityConfiguration.LONG_RUN_OPTIONS, activityTaskQueue));

--- a/airbyte-workers/src/main/java/io/airbyte/workers/temporal/sync/SyncWorkflowImpl.java
+++ b/airbyte-workers/src/main/java/io/airbyte/workers/temporal/sync/SyncWorkflowImpl.java
@@ -18,6 +18,7 @@ import io.airbyte.protocol.models.ConfiguredAirbyteCatalog;
 import io.airbyte.scheduler.models.IntegrationLauncherConfig;
 import io.airbyte.scheduler.models.JobRunConfig;
 import io.airbyte.workers.temporal.scheduling.shared.ActivityConfiguration;
+import io.temporal.activity.ActivityOptions;
 import io.temporal.workflow.Workflow;
 import java.util.UUID;
 import org.slf4j.Logger;
@@ -28,14 +29,6 @@ public class SyncWorkflowImpl implements SyncWorkflow {
   private static final Logger LOGGER = LoggerFactory.getLogger(SyncWorkflowImpl.class);
   private static final String VERSION_LABEL = "sync-workflow";
   private static final int CURRENT_VERSION = 1;
-  private final ReplicationActivity replicationActivity =
-      Workflow.newActivityStub(ReplicationActivity.class, ActivityConfiguration.LONG_RUN_OPTIONS);
-  private final NormalizationActivity normalizationActivity =
-      Workflow.newActivityStub(NormalizationActivity.class, ActivityConfiguration.LONG_RUN_OPTIONS);
-  private final DbtTransformationActivity dbtTransformationActivity =
-      Workflow.newActivityStub(DbtTransformationActivity.class, ActivityConfiguration.LONG_RUN_OPTIONS);
-  private final PersistStateActivity persistActivity =
-      Workflow.newActivityStub(PersistStateActivity.class, ActivityConfiguration.SHORT_ACTIVITY_OPTIONS);
 
   @Override
   public StandardSyncOutput run(final JobRunConfig jobRunConfig,
@@ -43,6 +36,12 @@ public class SyncWorkflowImpl implements SyncWorkflow {
                                 final IntegrationLauncherConfig destinationLauncherConfig,
                                 final StandardSyncInput syncInput,
                                 final UUID connectionId) {
+
+    // TODO (parker) add an activity that decides the task queue based on the connectionId
+    final String activityTaskQueue = EnvConfigs.DEFAULT_SYNC_ACTIVITY_TASK_QUEUE;
+
+    final ReplicationActivity replicationActivity =
+        Workflow.newActivityStub(ReplicationActivity.class, setTaskQueue(ActivityConfiguration.LONG_RUN_OPTIONS, activityTaskQueue));
 
     StandardSyncOutput syncOutput = replicationActivity.replicate(jobRunConfig, sourceLauncherConfig, destinationLauncherConfig, syncInput);
     final int version = Workflow.getVersion(VERSION_LABEL, Workflow.DEFAULT_VERSION, CURRENT_VERSION);
@@ -52,6 +51,10 @@ public class SyncWorkflowImpl implements SyncWorkflow {
       // state is a checkpoint of the raw data that has been copied to the destination;
       // normalization & dbt does not depend on it
       final ConfiguredAirbyteCatalog configuredCatalog = syncInput.getCatalog();
+
+      final PersistStateActivity persistActivity =
+          Workflow.newActivityStub(PersistStateActivity.class, setTaskQueue(ActivityConfiguration.SHORT_ACTIVITY_OPTIONS, activityTaskQueue));
+
       persistActivity.persist(connectionId, syncOutput, configuredCatalog);
     }
 
@@ -60,6 +63,10 @@ public class SyncWorkflowImpl implements SyncWorkflow {
         if (standardSyncOperation.getOperatorType() == OperatorType.NORMALIZATION) {
           final Configs configs = new EnvConfigs();
           final NormalizationInput normalizationInput = generateNormalizationInput(syncInput, syncOutput, configs);
+
+          final NormalizationActivity normalizationActivity =
+              Workflow.newActivityStub(NormalizationActivity.class, setTaskQueue(ActivityConfiguration.LONG_RUN_OPTIONS, activityTaskQueue));
+
           final NormalizationSummary normalizationSummary =
               normalizationActivity.normalize(jobRunConfig, destinationLauncherConfig, normalizationInput);
           syncOutput = syncOutput.withNormalizationSummary(normalizationSummary);
@@ -67,6 +74,9 @@ public class SyncWorkflowImpl implements SyncWorkflow {
           final OperatorDbtInput operatorDbtInput = new OperatorDbtInput()
               .withDestinationConfiguration(syncInput.getDestinationConfiguration())
               .withOperatorDbt(standardSyncOperation.getOperatorDbt());
+
+          final DbtTransformationActivity dbtTransformationActivity =
+              Workflow.newActivityStub(DbtTransformationActivity.class, setTaskQueue(ActivityConfiguration.LONG_RUN_OPTIONS, activityTaskQueue));
 
           dbtTransformationActivity.run(jobRunConfig, destinationLauncherConfig, syncInput.getResourceRequirements(), operatorDbtInput);
         } else {
@@ -93,6 +103,9 @@ public class SyncWorkflowImpl implements SyncWorkflow {
         .withDestinationConfiguration(syncInput.getDestinationConfiguration())
         .withCatalog(syncOutput.getOutputCatalog())
         .withResourceRequirements(resourceReqs);
+  }
+  private ActivityOptions setTaskQueue(final ActivityOptions activityOptions, final String taskQueue) {
+    return ActivityOptions.newBuilder(activityOptions).setTaskQueue(taskQueue).build();
   }
 
 }

--- a/airbyte-workers/src/main/java/io/airbyte/workers/temporal/sync/SyncWorkflowImpl.java
+++ b/airbyte-workers/src/main/java/io/airbyte/workers/temporal/sync/SyncWorkflowImpl.java
@@ -121,6 +121,7 @@ public class SyncWorkflowImpl implements SyncWorkflow {
         .withCatalog(syncOutput.getOutputCatalog())
         .withResourceRequirements(resourceReqs);
   }
+
   private ActivityOptions setTaskQueue(final ActivityOptions activityOptions, final String taskQueue) {
     return ActivityOptions.newBuilder(activityOptions).setTaskQueue(taskQueue).build();
   }

--- a/airbyte-workers/src/test/java/io/airbyte/workers/temporal/SyncWorkflowTest.java
+++ b/airbyte-workers/src/test/java/io/airbyte/workers/temporal/SyncWorkflowTest.java
@@ -258,7 +258,7 @@ class SyncWorkflowTest {
 
   private static void verifyDecideDataPlaneTaskQueue(final DecideDataPlaneTaskQueueActivity decideDataPlaneTaskQueueActivity,
                                                      final UUID connectionId) {
-    final String taskQueue = verify(decideDataPlaneTaskQueueActivity).decideDataPlaneTaskQueue(connectionId);
+    verify(decideDataPlaneTaskQueueActivity).decideDataPlaneTaskQueue(connectionId);
   }
 
   private static void verifyReplication(final ReplicationActivity replicationActivity, final StandardSyncInput syncInput) {

--- a/airbyte-workers/src/test/java/io/airbyte/workers/temporal/SyncWorkflowTest.java
+++ b/airbyte-workers/src/test/java/io/airbyte/workers/temporal/SyncWorkflowTest.java
@@ -13,8 +13,6 @@ import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.verifyNoInteractions;
 
-import io.airbyte.config.Configs;
-import io.airbyte.config.EnvConfigs;
 import io.airbyte.config.NormalizationInput;
 import io.airbyte.config.NormalizationSummary;
 import io.airbyte.config.OperatorDbtInput;
@@ -70,7 +68,6 @@ class SyncWorkflowTest {
   // AIRBYTE CONFIGURATION
   private static final long JOB_ID = 11L;
   private static final int ATTEMPT_ID = 21;
-  private static final Configs configs = new EnvConfigs();
   private static final JobRunConfig JOB_RUN_CONFIG = new JobRunConfig()
       .withJobId(String.valueOf(JOB_ID))
       .withAttemptId((long) ATTEMPT_ID);


### PR DESCRIPTION
## What
This PR addresses the following Cloud issues:
- https://github.com/airbytehq/airbyte-cloud/issues/2093
- https://github.com/airbytehq/airbyte-cloud/issues/2097


## How
- Adds new Configs that can be used to set up an airbyte-worker as a Control plane worker and/or a Data Plane worker.
- Updates Temporal worker registration in WorkerApp.java to respect new Configs
- Adds a new activity in the SyncWorkflow that uses the connectionId to decide which task queue should be used for data plane activities
  - Right now, the activity reads a list of connectionIds that should run on the AWS data plane from EnvConfigs. This is to make our MVP as simple as possible to configure.
  - In a future phase, this activity's implementation will change to call a Routing Service with the connectionId, and return a task queue based on the output of the Routing Service.
- Modifies existing SyncWorkflow activities to run on the task queue returned by the new activity. 

## Demo
With all new configs left on their default values, syncs work just like they usually do. `airbyte-workers` handle all Temporal tasks, both on the Control plane side and on the Data plane side. 

~The only difference is that Data plane tasks go to a separate task queue called `SYNC_DATA_PLANE`, while Control plane tasks go to the existing `SYNC` task queue, but functionally everything works the same as it did before this PR, because `airbyte-workers` register both task queues by default.~  
_Edit_: After testing on dev, I decided to default all Data plane tasks to `SYNC` going forward, which will guarantee that running syncs can seamlessly resume upon deploy of these changes.

Expand the screenshot below and notice that the same `airbyte-worker` instance is processing all tasks across both queues.
<details>
  <summary>Screenshot: Sync output with configs left at default</summary>

![image](https://user-images.githubusercontent.com/7798112/182735493-b3c15b38-c380-43bd-8963-8f33874a3aa6.png)

</details>

Now, I'll set that `connectionId` in the new EnvConfig called `CONNECTION_IDS_FOR_AWS_DATA_PLANE`. This will cause our `airbyte-worker` to place Data plane tasks onto a different task queue. 

For this demo, I'm running a secondary `airbyte-worker` helm chart called `airbyte-worker-data-plane`, where I've set an environment variable to only process Data plane tasks for the `AWS_DEV_SYNC_DATA_PLANE` task queue:
https://github.com/airbytehq/airbyte-cloud/pull/2264/files#diff-ad6a9f51d57d2bb6d91cc30b4cff2fd8c92397be2c6a2fba0e3d892353ad45f8R74-R76

Expand the screenshot below and notice that the `airbyte-worker` instance in the "Control plane" decides to place tasks on the `AWS_DEV_SYNC_DATA_PLANE` instead of the default `SYNC_DATA_PLANE`. Then, notice that an `airbyte-worker-data-plane` instance actually processes the `Replicate` activity.
<details>
  <summary>Screenshot: Sync output with Data plane configs in use</summary>

![image](https://user-images.githubusercontent.com/7798112/182736672-3ad6443c-7650-4907-b0a9-deeb63428bcc.png)

</details>

## Recommended reading order
1. Actually the current file order is perfect, Configs, then WorkerApp, then the new Activity, then the changes to SyncWorkflow to use the new activity. Also review the env vars set in the testing helm chart here: https://github.com/airbytehq/airbyte-cloud/pull/2264/files#diff-ad6a9f51d57d2bb6d91cc30b4cff2fd8c92397be2c6a2fba0e3d892353ad45f8R58-R76

## Todo
- Still need to add unit tests for the new activity
- Going to test on dev to see if workflow versioning is necessary for these changes

