### PR TITLE
🪟  Add Segment call for Connection Delete

### DIFF
--- a/airbyte-webapp/src/pages/ConnectionPage/pages/ConnectionItemPage/ConnectionItemPage.tsx
+++ b/airbyte-webapp/src/pages/ConnectionPage/pages/ConnectionItemPage/ConnectionItemPage.tsx
@@ -87,7 +87,7 @@ const ConnectionItemPage: React.FC = () => {
           />
           <Route
             path={ConnectionSettingsRoutes.SETTINGS}
-            element={isConnectionDeleted ? <Navigate replace to=".." /> : <SettingsView connectionId={connectionId} />}
+            element={isConnectionDeleted ? <Navigate replace to=".." /> : <SettingsView connection={connection} />}
           />
           <Route index element={<Navigate to={ConnectionSettingsRoutes.STATUS} replace />} />
         </Routes>

--- a/airbyte-webapp/src/pages/ConnectionPage/pages/ConnectionItemPage/components/SettingsView.module.scss
+++ b/airbyte-webapp/src/pages/ConnectionPage/pages/ConnectionItemPage/components/SettingsView.module.scss
@@ -1,0 +1,5 @@
+.container {
+  max-width: 647px;
+  margin: 0 auto;
+  padding-bottom: 10px;
+}

--- a/airbyte-webapp/src/pages/ConnectionPage/pages/ConnectionItemPage/components/SettingsView.tsx
+++ b/airbyte-webapp/src/pages/ConnectionPage/pages/ConnectionItemPage/components/SettingsView.tsx
@@ -1,32 +1,27 @@
 import React from "react";
-import styled from "styled-components";
 
 import DeleteBlock from "components/DeleteBlock";
 
 import { useDeleteConnection } from "hooks/services/useConnectionHook";
 
+import { WebBackendConnectionRead } from "../../../../../core/request/AirbyteClient";
+import styles from "./SettingsView.module.scss";
 import { StateBlock } from "./StateBlock";
 
-interface IProps {
-  connectionId: string;
+interface SettingsViewProps {
+  connection: WebBackendConnectionRead;
 }
 
-const Content = styled.div`
-  max-width: 647px;
-  margin: 0 auto;
-  padding-bottom: 10px;
-`;
-
-const SettingsView: React.FC<IProps> = ({ connectionId }) => {
+const SettingsView: React.FC<SettingsViewProps> = ({ connection }) => {
   const { mutateAsync: deleteConnection } = useDeleteConnection();
 
-  const onDelete = () => deleteConnection(connectionId);
+  const onDelete = () => deleteConnection(connection);
 
   return (
-    <Content>
-      <StateBlock connectionId={connectionId} />
+    <div className={styles.container}>
+      <StateBlock connectionId={connection.connectionId} />
       <DeleteBlock type="connection" onDelete={onDelete} />
-    </Content>
+    </div>
   );
 };
 


### PR DESCRIPTION
## What
Closes [#13863](https://github.com/airbytehq/airbyte/issues/13863)

## How
Add segment call for Connection Delete action

Request body example:
<img width="853" alt="Screenshot at Aug 05 16-39-09" src="https://user-images.githubusercontent.com/20929344/183090186-73e62eec-a8bd-42d9-bf1e-d22704b7b5d7.png">


## Recommended reading order
1. `useConnectionHook.tsx`
2. `SettingsView.tsx`
3. `ConnectionItemPage.tsx`