### PR TITLE
Remove forced ssl_key config in acceptance test harness

### DIFF
--- a/airbyte-test-utils/src/main/java/io/airbyte/test/utils/AirbyteAcceptanceTestHarness.java
+++ b/airbyte-test-utils/src/main/java/io/airbyte/test/utils/AirbyteAcceptanceTestHarness.java
@@ -627,7 +627,6 @@ public class AirbyteAcceptanceTestHarness {
     dbConfig.put(JdbcUtils.PORT_KEY, psql.getFirstMappedPort());
     dbConfig.put(JdbcUtils.DATABASE_KEY, psql.getDatabaseName());
     dbConfig.put(JdbcUtils.USERNAME_KEY, psql.getUsername());
-    dbConfig.put(JdbcUtils.SSL_KEY, false);
     // Some database docker images labeled strict-enforce do not contain an option to ssl off, so it is
     // not included in the schema.
     if (!strictEnforce) {


### PR DESCRIPTION
## What
In the acceptance test harness, we create a config for postgres to be used. We specify if the ssl key should be included or not through a parameter when setting up the config. We do not include this key in the config for our cloud acceptance test as we always assume ssl is true, so we do not allow it to be configurable.

This change was introduced through this PR: https://github.com/airbytehq/airbyte/pull/14749,
but it seems like it was added back in this PR: https://github.com/airbytehq/airbyte/pull/14781.

Probably some timing conflict since they were both merged on the same day.