### PR TITLE
Set initial waiting seconds to 5 to speed up acceptance tests

### DIFF
--- a/airbyte-tests/src/acceptanceTests/java/io/airbyte/test/acceptance/CdcAcceptanceTests.java
+++ b/airbyte-tests/src/acceptanceTests/java/io/airbyte/test/acceptance/CdcAcceptanceTests.java
@@ -94,7 +94,7 @@ class CdcAcceptanceTests {
   private static final String REPLICATION_SLOT = "airbyte_slot";
   // must match publication name used in the above POSTGRES_INIT_SQL_FILE
   private static final String PUBLICATION = "airbyte_publication";
-  private static final Integer INITIAL_WAITING_SECONDS = 30;
+  private static final Integer INITIAL_WAITING_SECONDS = 120;
 
   private static final String SOURCE_NAME = "CDC Source";
   private static final String CONNECTION_NAME = "test-connection";

--- a/airbyte-tests/src/acceptanceTests/java/io/airbyte/test/acceptance/CdcAcceptanceTests.java
+++ b/airbyte-tests/src/acceptanceTests/java/io/airbyte/test/acceptance/CdcAcceptanceTests.java
@@ -94,6 +94,7 @@ class CdcAcceptanceTests {
   private static final String REPLICATION_SLOT = "airbyte_slot";
   // must match publication name used in the above POSTGRES_INIT_SQL_FILE
   private static final String PUBLICATION = "airbyte_publication";
+  private static final Integer INITIAL_WAITING_SECONDS = 30;
 
   private static final String SOURCE_NAME = "CDC Source";
   private static final String CONNECTION_NAME = "test-connection";
@@ -490,6 +491,7 @@ class CdcAcceptanceTests {
         .put("method", CDC_METHOD)
         .put("replication_slot", REPLICATION_SLOT)
         .put("publication", PUBLICATION)
+        .put("initial_waiting_seconds", INITIAL_WAITING_SECONDS)
         .build());
     LOGGER.info("final sourceDbConfigMap: {}", sourceDbConfigMap);
 

--- a/airbyte-tests/src/acceptanceTests/java/io/airbyte/test/acceptance/CdcAcceptanceTests.java
+++ b/airbyte-tests/src/acceptanceTests/java/io/airbyte/test/acceptance/CdcAcceptanceTests.java
@@ -94,7 +94,7 @@ class CdcAcceptanceTests {
   private static final String REPLICATION_SLOT = "airbyte_slot";
   // must match publication name used in the above POSTGRES_INIT_SQL_FILE
   private static final String PUBLICATION = "airbyte_publication";
-  private static final Integer INITIAL_WAITING_SECONDS = 120;
+  private static final Integer INITIAL_WAITING_SECONDS = 5;
 
   private static final String SOURCE_NAME = "CDC Source";
   private static final String CONNECTION_NAME = "test-connection";
@@ -487,6 +487,7 @@ class CdcAcceptanceTests {
     final UUID postgresSourceDefinitionId = testHarness.getPostgresSourceDefinitionId();
     final JsonNode sourceDbConfig = testHarness.getSourceDbConfig();
     final Map<Object, Object> sourceDbConfigMap = Jsons.object(sourceDbConfig, Map.class);
+    sourceDbConfigMap.put("is_test", true);
     sourceDbConfigMap.put("replication_method", ImmutableMap.builder()
         .put("method", CDC_METHOD)
         .put("replication_slot", REPLICATION_SLOT)


### PR DESCRIPTION
## What
See full context here: https://airbytehq-team.slack.com/archives/C03AS1GAQV6/p1657924333217139

To summarize, CDC postgres source was configured to wait for 5 minutes when launched to figure out whether there is new data to sync or not. This caused the CDC acceptance tests to be pretty slow, since each sync required this 5 minute wait time at the beginning, causing the platform build to be slow. 

## How
With the merge of https://github.com/airbytehq/airbyte/pull/14451, this wait time is now configurable with the `initial_waiting_seconds` source configuration field. This PR sets that field to `5` (the minimum value) for the CDC acceptance tests, as those do not rely on the "waiting" behavior at all.