### PR TITLE
Remove `automaticMigrationAcceptanceTest`

### DIFF
--- a/airbyte-tests/src/automaticMigrationAcceptanceTest/java/io/airbyte/test/automaticMigrationAcceptance/MigrationAcceptanceTest.java
+++ b/airbyte-tests/src/automaticMigrationAcceptanceTest/java/io/airbyte/test/automaticMigrationAcceptance/MigrationAcceptanceTest.java
@@ -42,6 +42,7 @@ import java.util.Properties;
 import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.function.Consumer;
 import java.util.function.Supplier;
+import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Test;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -79,6 +80,7 @@ class MigrationAcceptanceTest {
   private static final String TEST_LOCAL_DOCKER_MOUNT = "/tmp/airbyte_local_migration_test";
 
   @Test
+  @Disabled
   void testAutomaticMigration() throws Exception {
     // run version 17 (the oldest version of airbyte that supports auto migration)
     final File version17DockerComposeFile = MoreResources.readResourceAsFile("docker-compose-migration-test-0-17-0-alpha.yaml");


### PR DESCRIPTION
This test is currently *very* flaky and breaking the build

After a chat with @davinchia, we don't feel that this test is providing much value, so we are comfortable disabling it for now to get the build green.

In general, now that we use Flyaway for migrations, what is the benefit of this test?  If there are particularly complex migrations in which we modify data, having a unit test makes sense for that migration, but testing that our migrations work all the way back to X version (v0.17.0 in this case) seems to be like we are testing the migration engine itself, and isn't necessary.  If we trust our migration engine, and each incremental migration, we should be in a safe place.

Reviewers: In the comments below, please let us know what you think about removing this test entirely, or should we just disable it for now until we can solve the flakiness?

* This commit just disables the test - https://github.com/airbytehq/airbyte/pull/15418/commits/177596b4d97c964e3e3c2f4d86d52279f56ebfba
* This commit removes the test entirely (along with related resources) -  https://github.com/airbytehq/airbyte/pull/15418/commits/977f06f3c453a9ea36bfe7b2fa37b0b8dd2906e2