### PR TITLE
🪟 🔧 Add testing and storybook component for CatalogDiffModal

### DIFF
--- a/airbyte-webapp/.storybook/withProvider.tsx
+++ b/airbyte-webapp/.storybook/withProvider.tsx
@@ -13,7 +13,6 @@ import { FeatureService } from "../src/hooks/services/Feature";
 import { ConfigServiceProvider, defaultConfig } from "../src/config";
 import { DocumentationPanelProvider } from "../src/views/Connector/ConnectorDocumentationLayout/DocumentationPanelContext";
 import { ServicesProvider } from "../src/core/servicesProvider";
-import { ModalServiceProvider } from "../src/hooks/services/Modal";
 import { analyticsServiceContext, AnalyticsServiceProviderValue } from "../src/hooks/services/Analytics";
 
 const AnalyticsContextMock: AnalyticsServiceProviderValue = {

--- a/airbyte-webapp/.storybook/withProvider.tsx
+++ b/airbyte-webapp/.storybook/withProvider.tsx
@@ -13,6 +13,7 @@ import { FeatureService } from "../src/hooks/services/Feature";
 import { ConfigServiceProvider, defaultConfig } from "../src/config";
 import { DocumentationPanelProvider } from "../src/views/Connector/ConnectorDocumentationLayout/DocumentationPanelContext";
 import { ServicesProvider } from "../src/core/servicesProvider";
+import { ModalServiceProvider } from "../src/hooks/services/Modal";
 import { analyticsServiceContext, AnalyticsServiceProviderValue } from "../src/hooks/services/Analytics";
 
 const AnalyticsContextMock: AnalyticsServiceProviderValue = {

--- a/airbyte-webapp/src/views/Connection/CatalogDiffModal/CatalogDiffModal.test.tsx
+++ b/airbyte-webapp/src/views/Connection/CatalogDiffModal/CatalogDiffModal.test.tsx
@@ -67,8 +67,6 @@ describe("catalog diff modal", () => {
   afterEach(cleanup);
 
   test("it renders the correct section for each type of transform", () => {
-    //todo: should this render w the modal service here or not?
-
     mockCatalogDiff.transforms.push(...addedItems, ...removedItems, ...updatedItems);
 
     render(

--- a/airbyte-webapp/src/views/Connection/CatalogDiffModal/CatalogDiffModal.test.tsx
+++ b/airbyte-webapp/src/views/Connection/CatalogDiffModal/CatalogDiffModal.test.tsx
@@ -1,80 +1,168 @@
-import { render, screen } from "@testing-library/react";
+import { cleanup, render, screen } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
 import { IntlProvider } from "react-intl";
 
-import { CatalogDiff } from "core/request/AirbyteClient";
+import { CatalogDiff, StreamTransform } from "core/request/AirbyteClient";
 
 import messages from "../../../locales/en.json";
 import { CatalogDiffModal } from "./CatalogDiffModal";
 
 const mockCatalogDiff: CatalogDiff = {
-  transforms: [
-    {
-      transformType: "remove_stream",
-      streamDescriptor: { namespace: "apple", name: "dragonfruit" },
-    },
-    {
-      transformType: "remove_stream",
-      streamDescriptor: { namespace: "apple", name: "eclair" },
-    },
-    {
-      transformType: "remove_stream",
-      streamDescriptor: { namespace: "apple", name: "fishcake" },
-    },
-    {
-      transformType: "remove_stream",
-      streamDescriptor: { namespace: "apple", name: "gelatin_mold" },
-    },
-    // {
-    //   transformType: "update_stream",
-    //   streamDescriptor: { namespace: "apple", name: "harissa_paste" },
-    //   updateStream: [
-    //     { transformType: "add_field", fieldName: ["users", "phone"] },
-    //     { transformType: "add_field", fieldName: ["users", "email"] },
-    //     { transformType: "remove_field", fieldName: ["users", "lastName"] },
-
-    //     {
-    //       transformType: "update_field_schema",
-    //       fieldName: ["users", "address"],
-    //       updateFieldSchema: { oldSchema: { type: "number" }, newSchema: { type: "string" } },
-    //     },
-    //   ],
-    // },
-    {
-      transformType: "add_stream",
-      streamDescriptor: { namespace: "apple", name: "banana" },
-    },
-    {
-      transformType: "add_stream",
-      streamDescriptor: { namespace: "apple", name: "carrot" },
-    },
-  ],
+  transforms: [],
 };
+
+const removedItems: StreamTransform[] = [
+  {
+    transformType: "remove_stream",
+    streamDescriptor: { namespace: "apple", name: "dragonfruit" },
+  },
+  {
+    transformType: "remove_stream",
+    streamDescriptor: { namespace: "apple", name: "eclair" },
+  },
+  {
+    transformType: "remove_stream",
+    streamDescriptor: { namespace: "apple", name: "fishcake" },
+  },
+  {
+    transformType: "remove_stream",
+    streamDescriptor: { namespace: "apple", name: "gelatin_mold" },
+  },
+];
+
+const addedItems: StreamTransform[] = [
+  {
+    transformType: "add_stream",
+    streamDescriptor: { namespace: "apple", name: "banana" },
+  },
+  {
+    transformType: "add_stream",
+    streamDescriptor: { namespace: "apple", name: "carrot" },
+  },
+];
+
+const updatedItems: StreamTransform[] = [
+  {
+    transformType: "update_stream",
+    streamDescriptor: { namespace: "apple", name: "harissa_paste" },
+    updateStream: [
+      { transformType: "add_field", fieldName: ["users", "phone"] },
+      { transformType: "add_field", fieldName: ["users", "email"] },
+      { transformType: "remove_field", fieldName: ["users", "lastName"] },
+
+      {
+        transformType: "update_field_schema",
+        fieldName: ["users", "address"],
+        updateFieldSchema: { oldSchema: { type: "number" }, newSchema: { type: "string" } },
+      },
+    ],
+  },
+];
 
 const mockCatalog = {
   streams: [],
 };
 
-test("it renders the correct section for added streams", () => {
-  //todo: should this render w the modal service here or not?
-  render(
-    <IntlProvider messages={messages} locale="en">
-      <CatalogDiffModal
-        catalogDiff={mockCatalogDiff}
-        catalog={mockCatalog}
-        onClose={() => {
-          return null;
-        }}
-      />
-    </IntlProvider>
-  );
+describe("catalog diff modal", () => {
+  afterEach(cleanup);
 
-  const newStreamsTable = screen.getByRole("table", { name: /new streams/ });
-  expect(newStreamsTable).toBeInTheDocument();
+  test("it renders the correct section for each type of transform", () => {
+    //todo: should this render w the modal service here or not?
 
-  const removedStreamsTable = screen.getByRole("table", { name: /removed streams/ });
-  expect(removedStreamsTable).toBeInTheDocument();
+    mockCatalogDiff.transforms.push(...addedItems, ...removedItems, ...updatedItems);
+
+    render(
+      <IntlProvider messages={messages} locale="en">
+        <CatalogDiffModal
+          catalogDiff={mockCatalogDiff}
+          catalog={mockCatalog}
+          onClose={() => {
+            return null;
+          }}
+        />
+      </IntlProvider>
+    );
+
+    const newStreamsTable = screen.getByRole("table", { name: /new streams/ });
+    expect(newStreamsTable).toBeInTheDocument();
+
+    const removedStreamsTable = screen.getByRole("table", { name: /removed streams/ });
+    expect(removedStreamsTable).toBeInTheDocument();
+
+    const updatedStreamsSection = screen.getByRole("list", { name: /table with changes/ });
+    expect(updatedStreamsSection).toBeInTheDocument();
+
+    mockCatalogDiff.transforms = [];
+  });
+
+  test("added fields are not rendered when not in the diff", () => {
+    mockCatalogDiff.transforms.push(...removedItems, ...updatedItems);
+
+    render(
+      <IntlProvider messages={messages} locale="en">
+        <CatalogDiffModal
+          catalogDiff={mockCatalogDiff}
+          catalog={mockCatalog}
+          onClose={() => {
+            return null;
+          }}
+        />
+      </IntlProvider>
+    );
+
+    const newStreamsTable = screen.queryByRole("table", { name: /new streams/ });
+    expect(newStreamsTable).not.toBeInTheDocument();
+    mockCatalogDiff.transforms = [];
+  });
+
+  test("removed fields are not rendered when not in the diff", () => {
+    mockCatalogDiff.transforms.push(...addedItems, ...updatedItems);
+
+    render(
+      <IntlProvider messages={messages} locale="en">
+        <CatalogDiffModal
+          catalogDiff={mockCatalogDiff}
+          catalog={mockCatalog}
+          onClose={() => {
+            return null;
+          }}
+        />
+      </IntlProvider>
+    );
+
+    const removedStreamsTable = screen.queryByRole("table", { name: /removed streams/ });
+    expect(removedStreamsTable).not.toBeInTheDocument();
+    mockCatalogDiff.transforms = [];
+  });
+
+  test("changed streams accordion opens/closes on clicking the description row", () => {
+    mockCatalogDiff.transforms.push(...addedItems, ...updatedItems);
+
+    render(
+      <IntlProvider messages={messages} locale="en">
+        <CatalogDiffModal
+          catalogDiff={mockCatalogDiff}
+          catalog={mockCatalog}
+          onClose={() => {
+            return null;
+          }}
+        />
+      </IntlProvider>
+    );
+
+    const accordionHeader = screen.getByRole("button", { name: /toggle accordion/ });
+
+    expect(accordionHeader).toBeInTheDocument();
+
+    const nullAccordionBody = screen.queryByRole("table", { name: /removed fields/ });
+    expect(nullAccordionBody).not.toBeInTheDocument();
+
+    userEvent.click(accordionHeader);
+    const openAccordionBody = screen.getByRole("table", { name: /removed fields/ });
+    expect(openAccordionBody).toBeInTheDocument();
+
+    userEvent.click(accordionHeader);
+    const nullAccordionBodyAgain = screen.queryByRole("table", { name: /removed fields/ });
+    expect(nullAccordionBodyAgain).not.toBeInTheDocument();
+  });
 });
-test("it renders the correct section for removed streams", () => {});
-test("it renders the correct section for changed streams", () => {});
-test("changed streams accordion displays correct information", () => {});
-test("changed streams accordion opens/closes on clicking the description row", () => {});

--- a/airbyte-webapp/src/views/Connection/CatalogDiffModal/CatalogDiffModal.test.tsx
+++ b/airbyte-webapp/src/views/Connection/CatalogDiffModal/CatalogDiffModal.test.tsx
@@ -65,6 +65,9 @@ const mockCatalog = {
 
 describe("catalog diff modal", () => {
   afterEach(cleanup);
+  beforeEach(() => {
+    mockCatalogDiff.transforms = [];
+  });
 
   test("it renders the correct section for each type of transform", () => {
     mockCatalogDiff.transforms.push(...addedItems, ...removedItems, ...updatedItems);
@@ -89,8 +92,6 @@ describe("catalog diff modal", () => {
 
     const updatedStreamsSection = screen.getByRole("list", { name: /table with changes/ });
     expect(updatedStreamsSection).toBeInTheDocument();
-
-    mockCatalogDiff.transforms = [];
   });
 
   test("added fields are not rendered when not in the diff", () => {
@@ -110,7 +111,6 @@ describe("catalog diff modal", () => {
 
     const newStreamsTable = screen.queryByRole("table", { name: /new streams/ });
     expect(newStreamsTable).not.toBeInTheDocument();
-    mockCatalogDiff.transforms = [];
   });
 
   test("removed fields are not rendered when not in the diff", () => {
@@ -130,7 +130,6 @@ describe("catalog diff modal", () => {
 
     const removedStreamsTable = screen.queryByRole("table", { name: /removed streams/ });
     expect(removedStreamsTable).not.toBeInTheDocument();
-    mockCatalogDiff.transforms = [];
   });
 
   test("changed streams accordion opens/closes on clicking the description row", () => {
@@ -162,5 +161,6 @@ describe("catalog diff modal", () => {
     userEvent.click(accordionHeader);
     const nullAccordionBodyAgain = screen.queryByRole("table", { name: /removed fields/ });
     expect(nullAccordionBodyAgain).not.toBeInTheDocument();
+    mockCatalogDiff.transforms = [];
   });
 });

--- a/airbyte-webapp/src/views/Connection/CatalogDiffModal/CatalogDiffModal.test.tsx
+++ b/airbyte-webapp/src/views/Connection/CatalogDiffModal/CatalogDiffModal.test.tsx
@@ -1,0 +1,80 @@
+import { render, screen } from "@testing-library/react";
+import { IntlProvider } from "react-intl";
+
+import { CatalogDiff } from "core/request/AirbyteClient";
+
+import messages from "../../../locales/en.json";
+import { CatalogDiffModal } from "./CatalogDiffModal";
+
+const mockCatalogDiff: CatalogDiff = {
+  transforms: [
+    {
+      transformType: "remove_stream",
+      streamDescriptor: { namespace: "apple", name: "dragonfruit" },
+    },
+    {
+      transformType: "remove_stream",
+      streamDescriptor: { namespace: "apple", name: "eclair" },
+    },
+    {
+      transformType: "remove_stream",
+      streamDescriptor: { namespace: "apple", name: "fishcake" },
+    },
+    {
+      transformType: "remove_stream",
+      streamDescriptor: { namespace: "apple", name: "gelatin_mold" },
+    },
+    // {
+    //   transformType: "update_stream",
+    //   streamDescriptor: { namespace: "apple", name: "harissa_paste" },
+    //   updateStream: [
+    //     { transformType: "add_field", fieldName: ["users", "phone"] },
+    //     { transformType: "add_field", fieldName: ["users", "email"] },
+    //     { transformType: "remove_field", fieldName: ["users", "lastName"] },
+
+    //     {
+    //       transformType: "update_field_schema",
+    //       fieldName: ["users", "address"],
+    //       updateFieldSchema: { oldSchema: { type: "number" }, newSchema: { type: "string" } },
+    //     },
+    //   ],
+    // },
+    {
+      transformType: "add_stream",
+      streamDescriptor: { namespace: "apple", name: "banana" },
+    },
+    {
+      transformType: "add_stream",
+      streamDescriptor: { namespace: "apple", name: "carrot" },
+    },
+  ],
+};
+
+const mockCatalog = {
+  streams: [],
+};
+
+test("it renders the correct section for added streams", () => {
+  //todo: should this render w the modal service here or not?
+  render(
+    <IntlProvider messages={messages} locale="en">
+      <CatalogDiffModal
+        catalogDiff={mockCatalogDiff}
+        catalog={mockCatalog}
+        onClose={() => {
+          return null;
+        }}
+      />
+    </IntlProvider>
+  );
+
+  const newStreamsTable = screen.getByRole("table", { name: /new streams/ });
+  expect(newStreamsTable).toBeInTheDocument();
+
+  const removedStreamsTable = screen.getByRole("table", { name: /removed streams/ });
+  expect(removedStreamsTable).toBeInTheDocument();
+});
+test("it renders the correct section for removed streams", () => {});
+test("it renders the correct section for changed streams", () => {});
+test("changed streams accordion displays correct information", () => {});
+test("changed streams accordion opens/closes on clicking the description row", () => {});

--- a/airbyte-webapp/src/views/Connection/CatalogDiffModal/CatalogDiffModal.test.tsx
+++ b/airbyte-webapp/src/views/Connection/CatalogDiffModal/CatalogDiffModal.test.tsx
@@ -2,7 +2,13 @@ import { cleanup, render, screen } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 import { IntlProvider } from "react-intl";
 
-import { CatalogDiff, StreamTransform } from "core/request/AirbyteClient";
+import {
+  AirbyteCatalog,
+  CatalogDiff,
+  DestinationSyncMode,
+  StreamTransform,
+  SyncMode,
+} from "core/request/AirbyteClient";
 
 import messages from "../../../locales/en.json";
 import { CatalogDiffModal } from "./CatalogDiffModal";
@@ -59,8 +65,79 @@ const updatedItems: StreamTransform[] = [
   },
 ];
 
-const mockCatalog = {
-  streams: [],
+const mockCatalog: AirbyteCatalog = {
+  streams: [
+    {
+      stream: {
+        namespace: "apple",
+        name: "banana",
+      },
+      config: {
+        syncMode: SyncMode.full_refresh,
+        destinationSyncMode: DestinationSyncMode.overwrite,
+      },
+    },
+    {
+      stream: {
+        namespace: "apple",
+        name: "carrot",
+      },
+      config: {
+        syncMode: SyncMode.full_refresh,
+        destinationSyncMode: DestinationSyncMode.overwrite,
+      },
+    },
+    {
+      stream: {
+        namespace: "apple",
+        name: "dragonfruit",
+      },
+      config: {
+        syncMode: SyncMode.full_refresh,
+        destinationSyncMode: DestinationSyncMode.overwrite,
+      },
+    },
+    {
+      stream: {
+        namespace: "apple",
+        name: "eclair",
+      },
+      config: {
+        syncMode: SyncMode.full_refresh,
+        destinationSyncMode: DestinationSyncMode.overwrite,
+      },
+    },
+    {
+      stream: {
+        namespace: "apple",
+        name: "fishcake",
+      },
+      config: {
+        syncMode: SyncMode.incremental,
+        destinationSyncMode: DestinationSyncMode.append_dedup,
+      },
+    },
+    {
+      stream: {
+        namespace: "apple",
+        name: "gelatin_mold",
+      },
+      config: {
+        syncMode: SyncMode.incremental,
+        destinationSyncMode: DestinationSyncMode.append_dedup,
+      },
+    },
+    {
+      stream: {
+        namespace: "apple",
+        name: "harissa_paste",
+      },
+      config: {
+        syncMode: SyncMode.full_refresh,
+        destinationSyncMode: DestinationSyncMode.overwrite,
+      },
+    },
+  ],
 };
 
 describe("catalog diff modal", () => {
@@ -84,14 +161,36 @@ describe("catalog diff modal", () => {
       </IntlProvider>
     );
 
+    /**
+     * tests for:
+     * - proper sections being created
+     * - syncmode string is only rendered for removed streams
+     */
+
     const newStreamsTable = screen.getByRole("table", { name: /new streams/ });
     expect(newStreamsTable).toBeInTheDocument();
+
+    const newStreamRow = screen.getByRole("row", { name: "apple banana" });
+    expect(newStreamRow).toBeInTheDocument();
+
+    const newStreamRowWithSyncMode = screen.queryByRole("row", { name: "apple carrot incremental | append_dedup" });
+    expect(newStreamRowWithSyncMode).not.toBeInTheDocument();
 
     const removedStreamsTable = screen.getByRole("table", { name: /removed streams/ });
     expect(removedStreamsTable).toBeInTheDocument();
 
+    const removedStreamRowWithSyncMode = screen.getByRole("row", {
+      name: "apple dragonfruit full_refresh | overwrite",
+    });
+    expect(removedStreamRowWithSyncMode).toBeInTheDocument();
+
     const updatedStreamsSection = screen.getByRole("list", { name: /table with changes/ });
     expect(updatedStreamsSection).toBeInTheDocument();
+
+    const updatedStreamRowWithSyncMode = screen.queryByRole("row", {
+      name: "apple harissa_paste full_refresh | overwrite",
+    });
+    expect(updatedStreamRowWithSyncMode).not.toBeInTheDocument();
   });
 
   test("added fields are not rendered when not in the diff", () => {

--- a/airbyte-webapp/src/views/Connection/CatalogDiffModal/components/DiffAccordion.tsx
+++ b/airbyte-webapp/src/views/Connection/CatalogDiffModal/components/DiffAccordion.tsx
@@ -23,7 +23,7 @@ export const DiffAccordion: React.FC<DiffAccordionProps> = ({ streamTransform })
       <Disclosure>
         {({ open }) => (
           <>
-            <Disclosure.Button className={styles.accordionButton}>
+            <Disclosure.Button className={styles.accordionButton} aria-label="toggle accordion">
               <DiffAccordionHeader
                 streamDescriptor={streamTransform.streamDescriptor}
                 removedCount={removedItems.length}

--- a/airbyte-webapp/src/views/Connection/CatalogDiffModal/components/DiffFieldTable.tsx
+++ b/airbyte-webapp/src/views/Connection/CatalogDiffModal/components/DiffFieldTable.tsx
@@ -14,7 +14,7 @@ interface DiffFieldTableProps {
 
 export const DiffFieldTable: React.FC<DiffFieldTableProps> = ({ fieldTransforms, diffVerb }) => {
   return (
-    <table className={styles.table}>
+    <table className={styles.table} aria-label={`${diffVerb} fields`}>
       <thead>
         <tr className={styles.accordionSubHeader}>
           <th>

--- a/airbyte-webapp/src/views/Connection/CatalogDiffModal/components/DiffIconBlock.tsx
+++ b/airbyte-webapp/src/views/Connection/CatalogDiffModal/components/DiffIconBlock.tsx
@@ -19,13 +19,13 @@ export const DiffIconBlock: React.FC<DiffIconBlockProps> = ({ newCount, removedC
           num={removedCount}
           color="red"
           light
-          ariaLabel={`${removedCount} ${formatMessage(
+          ariaLabel={`${formatMessage(
             {
               id: "connection.updateSchema.removed",
             },
             {
               value: removedCount,
-              item: formatMessage({ id: "field" }, { values: { count: removedCount } }),
+              item: formatMessage({ id: "connection.updateSchema.field" }, { count: removedCount }),
             }
           )}`}
         />
@@ -35,13 +35,13 @@ export const DiffIconBlock: React.FC<DiffIconBlockProps> = ({ newCount, removedC
           num={newCount}
           color="green"
           light
-          ariaLabel={`${newCount} ${formatMessage(
+          ariaLabel={`${formatMessage(
             {
               id: "connection.updateSchema.new",
             },
             {
               value: newCount,
-              item: formatMessage({ id: "field" }, { values: { count: newCount } }),
+              item: formatMessage({ id: "connection.updateSchema.field" }, { count: newCount }),
             }
           )}`}
         />
@@ -51,13 +51,13 @@ export const DiffIconBlock: React.FC<DiffIconBlockProps> = ({ newCount, removedC
           num={changedCount}
           color="blue"
           light
-          ariaLabel={`${changedCount} ${formatMessage(
+          ariaLabel={`${formatMessage(
             {
               id: "connection.updateSchema.changed",
             },
             {
               value: changedCount,
-              item: formatMessage({ id: "field" }, { values: { count: changedCount } }),
+              item: formatMessage({ id: "connection.updateSchema.field" }, { count: changedCount }),
             }
           )}`}
         />

--- a/airbyte-webapp/src/views/Connection/CatalogDiffModal/components/DiffSection.tsx
+++ b/airbyte-webapp/src/views/Connection/CatalogDiffModal/components/DiffSection.tsx
@@ -31,7 +31,7 @@ export const DiffSection: React.FC<DiffSectionProps> = ({ streams, catalog, diff
       <div className={styles.sectionHeader}>
         <DiffHeader diffCount={streams.length} diffVerb={diffVerb} diffType="stream" />
       </div>
-      <table>
+      <table aria-label={`${diffVerb} streams table`}>
         <thead className={styles.sectionSubHeader}>
           <tr>
             <th>

--- a/airbyte-webapp/src/views/Connection/CatalogDiffModal/components/FieldRow.tsx
+++ b/airbyte-webapp/src/views/Connection/CatalogDiffModal/components/FieldRow.tsx
@@ -28,7 +28,7 @@ export const FieldRow: React.FC<FieldRowProps> = ({ transform }) => {
     [styles.mod]: diffType === "update",
   });
 
-  const contentStyle = classnames(styles.content, {
+  const contentStyle = classnames(styles.content, styles.cell, {
     [styles.add]: diffType === "add",
     [styles.remove]: diffType === "remove",
     [styles.update]: diffType === "update",
@@ -50,16 +50,16 @@ export const FieldRow: React.FC<FieldRowProps> = ({ transform }) => {
         )}
       </td>
       <td className={contentStyle}>
-        <td className={styles.cell}>
+        <div className={styles.cell}>
           <span>{fieldName}</span>
-        </td>
-        <td className={updateCellStyle}>
+        </div>
+        <div className={updateCellStyle}>
           {oldType && newType && (
             <span>
               {oldType} <FontAwesomeIcon icon={faArrowRight} /> {newType}
             </span>
           )}
-        </td>
+        </div>
       </td>
     </tr>
   );

--- a/airbyte-webapp/src/views/Connection/CatalogDiffModal/components/FieldSection.tsx
+++ b/airbyte-webapp/src/views/Connection/CatalogDiffModal/components/FieldSection.tsx
@@ -32,7 +32,15 @@ export const FieldSection: React.FC<FieldSectionProps> = ({ streams, diffVerb })
       </div>
       <div className={styles.fieldRowsContainer}>
         {streams.length > 0 && (
-          <ul>
+          <ul
+            aria-label={formatMessage(
+              { id: "connection.updateSchema.changed" },
+              {
+                value: streams.length,
+                item: formatMessage({ id: "connection.updateSchema.stream" }, { count: streams.length }),
+              }
+            )}
+          >
             {streams.map((stream) => {
               return (
                 <li key={`${stream.streamDescriptor.namespace}.${stream.streamDescriptor.name}`}>

--- a/airbyte-webapp/src/views/Connection/CatalogDiffModal/components/StreamRow.tsx
+++ b/airbyte-webapp/src/views/Connection/CatalogDiffModal/components/StreamRow.tsx
@@ -45,7 +45,7 @@ export const StreamRow: React.FC<StreamRowProps> = ({ streamTransform, syncMode,
         )}
       </td>
       <td className={styles.nameCell}>{namespace}</td>
-      <td className={styles.nameCell}>{itemName}</td>{" "}
+      <td className={styles.nameCell}>{itemName}</td>
       <td>{diffVerb === "removed" && syncMode && <SyncModeBox syncModeString={syncMode} />} </td>
     </tr>
   );

--- a/airbyte-webapp/src/views/Connection/CatalogDiffModal/index.stories.tsx
+++ b/airbyte-webapp/src/views/Connection/CatalogDiffModal/index.stories.tsx
@@ -1,0 +1,76 @@
+import { ComponentStory, ComponentMeta } from "@storybook/react";
+import { useIntl } from "react-intl";
+
+import Modal from "components/Modal";
+
+import { CatalogDiffModal } from "./CatalogDiffModal";
+
+export default {
+  title: "Ui/CatalogDiffModal",
+  component: CatalogDiffModal,
+} as ComponentMeta<typeof CatalogDiffModal>;
+
+const Template: ComponentStory<typeof CatalogDiffModal> = (args) => {
+  const { formatMessage } = useIntl();
+
+  return (
+    <Modal title={formatMessage({ id: "connection.updateSchema.completed" })}>
+      <CatalogDiffModal
+        catalogDiff={args.catalogDiff}
+        catalog={args.catalog}
+        onClose={() => {
+          return null;
+        }}
+      />
+    </Modal>
+  );
+};
+
+export const Primary = Template.bind({});
+
+Primary.args = {
+  catalogDiff: {
+    transforms: [
+      {
+        transformType: "update_stream",
+        streamDescriptor: { namespace: "apple", name: "harissa_paste" },
+        updateStream: [
+          { transformType: "add_field", fieldName: ["users", "phone"] },
+          { transformType: "add_field", fieldName: ["users", "email"] },
+          { transformType: "remove_field", fieldName: ["users", "lastName"] },
+
+          {
+            transformType: "update_field_schema",
+            fieldName: ["users", "address"],
+            updateFieldSchema: { oldSchema: { type: "number" }, newSchema: { type: "string" } },
+          },
+        ],
+      },
+      {
+        transformType: "add_stream",
+        streamDescriptor: { namespace: "apple", name: "banana" },
+      },
+      {
+        transformType: "add_stream",
+        streamDescriptor: { namespace: "apple", name: "carrot" },
+      },
+      {
+        transformType: "remove_stream",
+        streamDescriptor: { namespace: "apple", name: "dragonfruit" },
+      },
+      {
+        transformType: "remove_stream",
+        streamDescriptor: { namespace: "apple", name: "eclair" },
+      },
+      {
+        transformType: "remove_stream",
+        streamDescriptor: { namespace: "apple", name: "fishcake" },
+      },
+      {
+        transformType: "remove_stream",
+        streamDescriptor: { namespace: "apple", name: "gelatin_mold" },
+      },
+    ],
+  },
+  catalog: { streams: [] },
+};

--- a/airbyte-webapp/src/views/Connection/CatalogDiffModal/index.stories.tsx
+++ b/airbyte-webapp/src/views/Connection/CatalogDiffModal/index.stories.tsx
@@ -1,5 +1,5 @@
 import { ComponentStory, ComponentMeta } from "@storybook/react";
-import { useIntl } from "react-intl";
+import { FormattedMessage } from "react-intl";
 
 import Modal from "components/Modal";
 
@@ -11,10 +11,8 @@ export default {
 } as ComponentMeta<typeof CatalogDiffModal>;
 
 const Template: ComponentStory<typeof CatalogDiffModal> = (args) => {
-  const { formatMessage } = useIntl();
-
   return (
-    <Modal title={formatMessage({ id: "connection.updateSchema.completed" })}>
+    <Modal title={<FormattedMessage id="connection.updateSchema.completed" />}>
       <CatalogDiffModal
         catalogDiff={args.catalogDiff}
         catalog={args.catalog}


### PR DESCRIPTION
## What
Closes #15417 

Adds the Catalog Change Modal to Storybook.
Adds unit testing for the catalog change modal.
Minor adjustments to code, adding `aria-labels` which help both the testing and general accessibility and doing a little cleanup.

**There should be no user-facing changes from this**.  Modal still renders the same:

<img width="515" alt="Screen Shot 2022-08-10 at 1 55 21 PM" src="https://user-images.githubusercontent.com/63751206/183983177-b66eb83e-ffbc-4037-828a-b2264e0a7346.png">


## Recommended reading order
1. `index.stories.tsx`
2. `CatalogDiffModal.test.tsx`
3. others
