### PR TITLE
14895 Update tests instance type to ATLAS

### DIFF
--- a/airbyte-integrations/connectors/destination-mongodb-strict-encrypt/src/test-integration/java/io/airbyte/integrations/destination/mongodb/MongodbDestinationStrictEncryptAcceptanceTest.java
+++ b/airbyte-integrations/connectors/destination-mongodb-strict-encrypt/src/test-integration/java/io/airbyte/integrations/destination/mongodb/MongodbDestinationStrictEncryptAcceptanceTest.java
@@ -47,9 +47,8 @@ public class MongodbDestinationStrictEncryptAcceptanceTest extends DestinationAc
     final JsonNode credentialsJson = Jsons.deserialize(credentialsJsonString);
 
     final JsonNode instanceConfig = Jsons.jsonNode(ImmutableMap.builder()
-        .put("instance", MongoInstanceType.STANDALONE.getType())
-        .put(JdbcUtils.HOST_KEY, credentialsJson.get(JdbcUtils.HOST_KEY).asText())
-        .put(JdbcUtils.PORT_KEY, credentialsJson.get(JdbcUtils.PORT_KEY).asInt())
+        .put("instance", MongoInstanceType.ATLAS.getType())
+        .put("cluster_url", credentialsJson.get("cluster_url").asText())
         .build());
 
     final JsonNode authConfig = Jsons.jsonNode(ImmutableMap.builder()
@@ -105,11 +104,11 @@ public class MongodbDestinationStrictEncryptAcceptanceTest extends DestinationAc
 
   @Override
   protected void setup(final TestDestinationEnv testEnv) {
-    final String connectionString = String.format("mongodb://%s:%s@%s:%s/%s?authSource=admin&ssl=true",
-        config.get(AUTH_TYPE).get(JdbcUtils.USERNAME_KEY).asText(),
-        config.get(AUTH_TYPE).get(JdbcUtils.PASSWORD_KEY).asText(),
-        config.get(INSTANCE_TYPE).get(JdbcUtils.HOST_KEY).asText(),
-        config.get(INSTANCE_TYPE).get(JdbcUtils.PORT_KEY).asText(),
+    var credentials = String.format("%s:%s@", config.get(AUTH_TYPE).get(JdbcUtils.USERNAME_KEY).asText(),
+        config.get(AUTH_TYPE).get(JdbcUtils.PASSWORD_KEY).asText());
+    final String connectionString = String.format("mongodb+srv://%s%s/%s?retryWrites=true&w=majority&tls=true",
+        credentials,
+        config.get(INSTANCE_TYPE).get("cluster_url").asText(),
         config.get(JdbcUtils.DATABASE_KEY).asText());
 
     mongoDatabase = new MongoDatabase(connectionString, config.get(JdbcUtils.DATABASE_KEY).asText());


### PR DESCRIPTION
## What
Destination mongodb strict encrypt integration tests used wrong STANDALONE connection type

## How
Updated to use ATLAS one

## Recommended reading order
1. `x.java`
2. `y.python`

## 🚨 User Impact 🚨
No user impact 

