### PR TITLE
14899 Update tests instance type to ATLAS

### DIFF
--- a/airbyte-integrations/connectors/source-mongodb-strict-encrypt/src/test-integration/java/io/airbyte/integrations/source/mongodb/MongodbSourceStrictEncryptAcceptanceTest.java
+++ b/airbyte-integrations/connectors/source-mongodb-strict-encrypt/src/test-integration/java/io/airbyte/integrations/source/mongodb/MongodbSourceStrictEncryptAcceptanceTest.java
@@ -100,7 +100,9 @@ public class MongodbSourceStrictEncryptAcceptanceTest extends SourceAcceptanceTe
 
   @Override
   protected void tearDown(final TestDestinationEnv testEnv) throws Exception {
-    database.getDatabase().getCollection(COLLECTION_NAME).drop();
+    for (final String collectionName : database.getCollectionNames()) {
+      database.getDatabase().getCollection(collectionName).drop();
+    }
     database.close();
   }
 

--- a/airbyte-integrations/connectors/source-mongodb-strict-encrypt/src/test-integration/java/io/airbyte/integrations/source/mongodb/MongodbSourceStrictEncryptAcceptanceTest.java
+++ b/airbyte-integrations/connectors/source-mongodb-strict-encrypt/src/test-integration/java/io/airbyte/integrations/source/mongodb/MongodbSourceStrictEncryptAcceptanceTest.java
@@ -4,7 +4,6 @@
 
 package io.airbyte.integrations.source.mongodb;
 
-import static io.airbyte.db.mongodb.MongoUtils.MongoInstanceType.STANDALONE;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 
 import com.fasterxml.jackson.databind.JsonNode;
@@ -15,6 +14,7 @@ import io.airbyte.commons.json.Jsons;
 import io.airbyte.commons.resources.MoreResources;
 import io.airbyte.db.jdbc.JdbcUtils;
 import io.airbyte.db.mongodb.MongoDatabase;
+import io.airbyte.db.mongodb.MongoUtils.MongoInstanceType;
 import io.airbyte.integrations.standardtest.source.SourceAcceptanceTest;
 import io.airbyte.integrations.standardtest.source.TestDestinationEnv;
 import io.airbyte.protocol.models.CatalogHelpers;
@@ -36,10 +36,10 @@ import org.junit.jupiter.api.Test;
 
 public class MongodbSourceStrictEncryptAcceptanceTest extends SourceAcceptanceTest {
 
+  private static final String DATABASE_NAME = "test";
+  private static final String COLLECTION_NAME = "acceptance_test";
   private static final Path CREDENTIALS_PATH = Path.of("secrets/credentials.json");
-
-  protected static final String DATABASE_NAME = "test";
-  protected static final String COLLECTION_NAME = "acceptance_test";
+  private static final String INSTANCE_TYPE = "instance_type";
 
   protected JsonNode config;
   protected MongoDatabase database;
@@ -66,24 +66,23 @@ public class MongodbSourceStrictEncryptAcceptanceTest extends SourceAcceptanceTe
     final JsonNode credentialsJson = Jsons.deserialize(credentialsJsonString);
 
     final JsonNode instanceConfig = Jsons.jsonNode(ImmutableMap.builder()
-        .put("instance", STANDALONE.getType())
-        .put(JdbcUtils.HOST_KEY, credentialsJson.get(JdbcUtils.HOST_KEY).asText())
-        .put(JdbcUtils.PORT_KEY, credentialsJson.get(JdbcUtils.PORT_KEY).asInt())
+        .put("instance", MongoInstanceType.ATLAS.getType())
+        .put("cluster_url", credentialsJson.get("cluster_url").asText())
         .build());
 
     config = Jsons.jsonNode(ImmutableMap.builder()
         .put("user", credentialsJson.get("user").asText())
         .put(JdbcUtils.PASSWORD_KEY, credentialsJson.get(JdbcUtils.PASSWORD_KEY).asText())
-        .put("instance_type", instanceConfig)
+        .put(INSTANCE_TYPE, instanceConfig)
         .put(JdbcUtils.DATABASE_KEY, DATABASE_NAME)
         .put("auth_source", "admin")
         .build());
 
-    final String connectionString = String.format("mongodb://%s:%s@%s:%s/%s?authSource=admin&directConnection=false&ssl=true",
-        config.get("user").asText(),
-        config.get(JdbcUtils.PASSWORD_KEY).asText(),
-        config.get("instance_type").get(JdbcUtils.HOST_KEY).asText(),
-        config.get("instance_type").get(JdbcUtils.PORT_KEY).asText(),
+    var credentials = String.format("%s:%s@", config.get("user").asText(),
+        config.get(JdbcUtils.PASSWORD_KEY).asText());
+    final String connectionString = String.format("mongodb+srv://%s%s/%s?retryWrites=true&w=majority&tls=true",
+        credentials,
+        config.get(INSTANCE_TYPE).get("cluster_url").asText(),
         config.get(JdbcUtils.DATABASE_KEY).asText());
 
     database = new MongoDatabase(connectionString, DATABASE_NAME);


### PR DESCRIPTION
## What
Source mongodb strict encrypt integration tests used wrong STANDALONE connection type

## How
Updated to use ATLAS one

## Recommended reading order
1. `x.java`
2. `y.python`

## 🚨 User Impact 🚨
No user impact
