### PR TITLE
[Helm Chart] Fix temporal helm chart database host issue

### DIFF
--- a/charts/airbyte-temporal/templates/deployment.yaml
+++ b/charts/airbyte-temporal/templates/deployment.yaml
@@ -61,7 +61,10 @@ spec:
                 name: {{ .Values.global.database.secretName | default (printf "%s-postgresql" .Release.Name ) }}
                 key: {{ .Values.global.database.secretValue | default "postgresql-password" }}
           - name: POSTGRES_SEEDS
-            value: {{ .Release.Name }}-postgresql
+            valueFrom:
+              configMapKeyRef:
+                name: {{ .Release.Name }}-airbyte-env
+                key: DATABASE_HOST
           - name: DYNAMIC_CONFIG_FILE_PATH
             value: "config/dynamicconfig/development.yaml"
         {{- end }}


### PR DESCRIPTION
## What
Fix #15432

Temporal does not pick the DB host value defined in the values.yaml

## How
```
 - name: POSTGRES_SEEDS
    valueFrom:
      configMapKeyRef:
        name: {{ .Release.Name }}-airbyte-env
        key: DATABASE_HOST
```
## Recommended reading order
1. `charts/airbyte-temporal/templates/deployment.yaml`

## 🚨 User Impact 🚨
Are there any breaking changes? What is the end result perceived by the user? If yes, please merge this PR with the 🚨🚨 emoji so changelog authors can further highlight this if needed.
