### PR TITLE
fix: helm chart ingress and temporal values

### DIFF
--- a/charts/airbyte-temporal/templates/deployment.yaml
+++ b/charts/airbyte-temporal/templates/deployment.yaml
@@ -61,7 +61,7 @@ spec:
                 name: {{ .Values.global.database.secretName | default (printf "%s-postgresql" .Release.Name ) }}
                 key: {{ .Values.global.database.secretValue | default "postgresql-password" }}
           - name: POSTGRES_SEEDS
-            value: {{ .Release.Name }}-postgresql
+            value: {{ .Values.externalHost | default (printf "%s-postgresql" .Release.Name ) }}
           - name: DYNAMIC_CONFIG_FILE_PATH
             value: "config/dynamicconfig/development.yaml"
         {{- end }}

--- a/charts/airbyte-temporal/values.yaml
+++ b/charts/airbyte-temporal/values.yaml
@@ -24,6 +24,9 @@ image:
   pullPolicy: IfNotPresent
   tag: "1.7.0"
 
+## @param temporal.externalHost The external postgresql host for temporal instance
+externalHost: ""
+
 ## @param temporal.service.type The Kubernetes Service Type
 ## @param temporal.service.port The temporal port and exposed kubernetes port
 service:

--- a/charts/airbyte-webapp/templates/ingress.yaml
+++ b/charts/airbyte-webapp/templates/ingress.yaml
@@ -54,11 +54,11 @@ spec:
             backend:
               {{- if semverCompare ">=1.19-0" $.Capabilities.KubeVersion.GitVersion }}
               service:
-                name: {{ $fullName }}-webapp
+                name: {{ $fullName }}
                 port:
                   number: {{ $svcPort }}
               {{- else }}
-              serviceName: {{ $fullName }}-webapp
+              serviceName: {{ $fullName }}
               servicePort: {{ $svcPort }}
               {{- end }}
           {{- end }}


### PR DESCRIPTION
## What
*Describe what the change is solving*
*It helps to add screenshots if it affects the frontend.*

- Helm chart issues.
- Backend in ingress doesn't match the service name.
- No option to specify external postgresql hostname for temporal.

## How
*Describe the solution*

- Modified the ingress template to use the correct backend name.
- Provided an option in temporal chart to pass the external hostname for temporal.Set the default value to match the current value so existing chart users are not impacted.

## Recommended reading order
1. `ingress.yaml`
2. `deployment.yaml`
3. `values.yaml`

## 🚨 User Impact 🚨
Are there any breaking changes? What is the end result perceived by the user? If yes, please merge this PR with the 🚨🚨 emoji so changelog authors can further highlight this if needed.

No breaking changes