### PR TITLE
source-file-secure bump to 0.2.16

### DIFF
--- a/airbyte-integrations/connectors/source-file-secure/Dockerfile
+++ b/airbyte-integrations/connectors/source-file-secure/Dockerfile
@@ -1,4 +1,4 @@
-FROM airbyte/source-file:0.2.15
+FROM airbyte/source-file:0.2.16
 
 WORKDIR /airbyte/integration_code
 COPY source_file_secure ./source_file_secure
@@ -9,5 +9,5 @@ RUN pip install .
 ENV AIRBYTE_ENTRYPOINT "python /airbyte/integration_code/main.py"
 ENTRYPOINT ["python", "/airbyte/integration_code/main.py"]
 
-LABEL io.airbyte.version=0.2.15
+LABEL io.airbyte.version=0.2.16
 LABEL io.airbyte.name=airbyte/source-file-secure

--- a/airbyte-integrations/connectors/source-file-secure/source_file_secure/source.py
+++ b/airbyte-integrations/connectors/source-file-secure/source_file_secure/source.py
@@ -36,11 +36,11 @@ class URLFileSecure(ParentURLFile):
     This connector shouldn't work with local files.
     """
 
-    def __init__(self, url: str, provider: dict):
+    def __init__(self, url: str, provider: dict, binary=None, encoding=None):
         storage_name = provider["storage"].lower()
         if url.startswith("file://") or storage_name == LOCAL_STORAGE_NAME:
             raise RuntimeError("the local file storage is not supported by this connector.")
-        super().__init__(url, provider)
+        super().__init__(url, provider, binary, encoding)
 
 
 class SourceFileSecure(ParentSourceFile):


### PR DESCRIPTION
## What
With the publish of `source-file` to 0.2.16, we also need to publish `source-file-secure`.

## How
Bumps the version. The time we did this we needed to update the spec, to fix some SAT tests, we'll see what happens this time.