### PR TITLE
🐛 SAT: source-freshdesk failed due to invalid deps version

### DIFF
--- a/airbyte-integrations/connectors/source-freshdesk/setup.py
+++ b/airbyte-integrations/connectors/source-freshdesk/setup.py
@@ -15,7 +15,7 @@ MAIN_REQUIREMENTS = [
 TEST_REQUIREMENTS = [
     "pytest==6.1.2",
     "pytest-mock~=3.6",
-    "requests_mock==1.8.0",
+    "requests_mock~=1.9.3",
     "source-acceptance-test",
 ]
 


### PR DESCRIPTION
## What
Build Report: https://github.com/airbytehq/airbyte/actions/runs/2839339849

## How
- changed the `request-mock` version to reflect the same one as `SAT` has.