### PR TITLE
No relative parent imports

### DIFF
--- a/airbyte-webapp/.eslintrc
+++ b/airbyte-webapp/.eslintrc
@@ -36,6 +36,7 @@
     "prefer-destructuring": ["warn", { "AssignmentExpression": { "array": true } }],
     "prefer-object-spread": "warn",
     "prefer-template": "warn",
+    "import/no-relative-parent-imports": "error",
     "yoda": "warn",
     "import/order": [
       "warn",

--- a/airbyte-webapp/src/packages/cloud/views/auth/components/GitBlock/GitBlock.test.tsx
+++ b/airbyte-webapp/src/packages/cloud/views/auth/components/GitBlock/GitBlock.test.tsx
@@ -2,8 +2,8 @@ import { render } from "@testing-library/react";
 import { IntlProvider } from "react-intl";
 
 import { ConfigContext, defaultConfig } from "config";
+import en from "locales/en.json";
 
-import en from "../../../../locales/en.json";
 import { GitBlock, GitBlockProps } from "./GitBlock";
 
 const renderGitBlock = (props?: GitBlockProps) =>

--- a/airbyte-webapp/src/utils/useTranslateDataType.test.tsx
+++ b/airbyte-webapp/src/utils/useTranslateDataType.test.tsx
@@ -2,7 +2,8 @@ import { renderHook } from "@testing-library/react-hooks";
 import React from "react";
 import { IntlProvider } from "react-intl";
 
-import messages from "../locales/en.json";
+import messages from "locales/en.json";
+
 import { AirbyteConnectorData, useTranslateDataType } from "./useTranslateDataType";
 
 const wrapper: React.FC = ({ children }) => (

--- a/airbyte-webapp/src/views/Connection/CatalogDiffModal/CatalogDiffModal.test.tsx
+++ b/airbyte-webapp/src/views/Connection/CatalogDiffModal/CatalogDiffModal.test.tsx
@@ -9,8 +9,8 @@ import {
   StreamTransform,
   SyncMode,
 } from "core/request/AirbyteClient";
+import messages from "locales/en.json";
 
-import messages from "../../../locales/en.json";
 import { CatalogDiffModal } from "./CatalogDiffModal";
 
 const mockCatalogDiff: CatalogDiff = {


### PR DESCRIPTION
Solves #15572
Eslint will now prevent relative imports upwards.