### PR TITLE
SAT: update reference about backward compatibility tests

### DIFF
--- a/docs/connector-development/testing-connectors/source-acceptance-tests-reference.md
+++ b/docs/connector-development/testing-connectors/source-acceptance-tests-reference.md
@@ -93,7 +93,9 @@ tests:  # Tests configuration
 
 ## Test Spec
 
-Verify that a spec operation issued to the connector returns a valid spec.
+Verify that a `spec` operation issued to the connector returns a valid connector specification. 
+Additional tests are validating the backward compatibility of the current specification compared to the specification of the previous connector version. 
+These backward compatibility tests can be bypassed by changing the value of the `backward_compatibility_tests_config.disable_for_version` input in `acceptance-test-config.yml` (see below).
 
 | Input | Type | Default | Note                                                                                             |
 | :--- | :--- | :--- |:-------------------------------------------------------------------------------------------------|
@@ -114,7 +116,9 @@ Verify that a check operation issued to the connector with the input config file
 
 ## Test Discovery
 
-Verifies when a discover operation is run on the connector using the given config file, a valid catalog is produced by the connector.
+Verifies when a `discover` operation is run on the connector using the given config file, a valid catalog is produced by the connector.
+Additional tests are validating the backward compatibility of the discovered catalog compared to the catalog of the previous connector version. 
+These backward compatibility tests can be bypassed by changing the value of the `backward_compatibility_tests_config.disable_for_version` input in `acceptance-test-config.yml` (see below).
 
 | Input | Type | Default | Note |
 | :--- | :--- | :--- | :--- |

--- a/docs/connector-development/testing-connectors/source-acceptance-tests-reference.md
+++ b/docs/connector-development/testing-connectors/source-acceptance-tests-reference.md
@@ -94,7 +94,7 @@ tests:  # Tests configuration
 ## Test Spec
 
 Verify that a `spec` operation issued to the connector returns a valid connector specification. 
-Additional tests are validating the backward compatibility of the current specification compared to the specification of the previous connector version. 
+Additional tests are validating the backward compatibility of the current specification compared to the specification of the previous connector version. If no previous connector version is found (by default the test looks for a docker image with the same name but with the `latest` tag), this test is skipped. 
 These backward compatibility tests can be bypassed by changing the value of the `backward_compatibility_tests_config.disable_for_version` input in `acceptance-test-config.yml` (see below).
 
 | Input | Type | Default | Note                                                                                             |

--- a/docs/connector-development/testing-connectors/source-acceptance-tests-reference.md
+++ b/docs/connector-development/testing-connectors/source-acceptance-tests-reference.md
@@ -117,7 +117,7 @@ Verify that a check operation issued to the connector with the input config file
 ## Test Discovery
 
 Verifies when a `discover` operation is run on the connector using the given config file, a valid catalog is produced by the connector.
-Additional tests are validating the backward compatibility of the discovered catalog compared to the catalog of the previous connector version. 
+Additional tests are validating the backward compatibility of the discovered catalog compared to the catalog of the previous connector version. If no previous connector version is found (by default the test looks for a docker image with the same name but with the `latest` tag), this test is skipped. 
 These backward compatibility tests can be bypassed by changing the value of the `backward_compatibility_tests_config.disable_for_version` input in `acceptance-test-config.yml` (see below).
 
 | Input | Type | Default | Note |


### PR DESCRIPTION
Closes https://github.com/airbytehq/airbyte/issues/15564

Mentioning in the SAT reference doc that backward compatibility tests are running for `Test Spec` and `Test Discover`/