### PR TITLE
Experimentally hide the Name and Company Name fields on the signup page

### DIFF
--- a/airbyte-webapp/src/hooks/services/Experiment/experiments.ts
+++ b/airbyte-webapp/src/hooks/services/Experiment/experiments.ts
@@ -7,4 +7,6 @@ export interface Experiments {
   "connector.orderOverwrite": Record<string, number>;
   "authPage.rightSideUrl": string | undefined;
   "authPage.hideSelfHostedCTA": boolean;
+  "authPage.signup.hideName": boolean;
+  "authPage.signup.hideCompanyName": boolean;
 }


### PR DESCRIPTION
## What
Resolves https://github.com/airbytehq/airbyte-cloud/issues/1430

## How
This PR adds logic to hide the Full Name and Company Name fields on the signup page based on respective feature flags in LaunchDarkly.

When these fields are hidden, users will be created with empty strings set for both the name and company name columns on the user record. The backend handles this gracefully, and in the case of an empty company name it uses the email as the name of the workspace created for the new user.

Example screenshot of the signup page with both fields set to hidden in LaunchDarkly:
<img width="1277" alt="image" src="https://user-images.githubusercontent.com/22731524/184428700-5735421a-8e4e-47d9-b794-aacaa29a8213.png">
