### PR TITLE
🪟 🐛 Truncate Displayed External Message for Failure/Partial Failure Jobs

### DIFF
--- a/airbyte-webapp/src/components/JobItem/components/AttemptDetails.module.scss
+++ b/airbyte-webapp/src/components/JobItem/components/AttemptDetails.module.scss
@@ -5,3 +5,9 @@
   line-height: 15px;
   color: colors.$grey;
 }
+
+.truncate {
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+}

--- a/airbyte-webapp/src/components/JobItem/components/AttemptDetails.tsx
+++ b/airbyte-webapp/src/components/JobItem/components/AttemptDetails.tsx
@@ -54,7 +54,7 @@ const AttemptDetails: React.FC<IProps> = ({ attempt, className, configType }) =>
 
   const truncateExternalMessage = (failureMessage?: string) => {
     if (failureMessage && failureMessage.length > 140) {
-      return failureMessage.slice(0, 140).concat("...");
+      return failureMessage.slice(0, 136).concat("...");
     }
     return failureMessage;
   };

--- a/airbyte-webapp/src/components/JobItem/components/AttemptDetails.tsx
+++ b/airbyte-webapp/src/components/JobItem/components/AttemptDetails.tsx
@@ -52,9 +52,17 @@ const AttemptDetails: React.FC<IProps> = ({ attempt, className, configType }) =>
     })}: ${failureOrigin}`;
   };
 
+  const truncateExternalMessage = (failureMessage?: string) => {
+    if (failureMessage && failureMessage.length > 140) {
+      return failureMessage.slice(0, 140).concat("...");
+    }
+    return failureMessage;
+  };
+
   const getExternalFailureMessage = (attempt: AttemptRead) => {
     const failure = getFailureFromAttempt(attempt);
-    const failureMessage = failure?.externalMessage?.slice(0, 140) ?? formatMessage({ id: "errorView.unknown" });
+    const failureMessage =
+      truncateExternalMessage(failure?.externalMessage) ?? formatMessage({ id: "errorView.unknown" });
 
     return `${formatMessage({
       id: "sources.message",

--- a/airbyte-webapp/src/components/JobItem/components/AttemptDetails.tsx
+++ b/airbyte-webapp/src/components/JobItem/components/AttemptDetails.tsx
@@ -54,7 +54,7 @@ const AttemptDetails: React.FC<IProps> = ({ attempt, className, configType }) =>
 
   const getExternalFailureMessage = (attempt: AttemptRead) => {
     const failure = getFailureFromAttempt(attempt);
-    const failureMessage = failure?.externalMessage ?? formatMessage({ id: "errorView.unknown" });
+    const failureMessage = failure?.externalMessage?.slice(0, 140) ?? formatMessage({ id: "errorView.unknown" });
 
     return `${formatMessage({
       id: "sources.message",

--- a/airbyte-webapp/src/components/JobItem/components/AttemptDetails.tsx
+++ b/airbyte-webapp/src/components/JobItem/components/AttemptDetails.tsx
@@ -52,17 +52,9 @@ const AttemptDetails: React.FC<IProps> = ({ attempt, className, configType }) =>
     })}: ${failureOrigin}`;
   };
 
-  const truncateExternalMessage = (failureMessage?: string) => {
-    if (failureMessage && failureMessage.length > 140) {
-      return failureMessage.slice(0, 136).concat("...");
-    }
-    return failureMessage;
-  };
-
   const getExternalFailureMessage = (attempt: AttemptRead) => {
     const failure = getFailureFromAttempt(attempt);
-    const failureMessage =
-      truncateExternalMessage(failure?.externalMessage) ?? formatMessage({ id: "errorView.unknown" });
+    const failureMessage = failure?.externalMessage ?? formatMessage({ id: "errorView.unknown" });
 
     return `${formatMessage({
       id: "sources.message",
@@ -107,7 +99,7 @@ const AttemptDetails: React.FC<IProps> = ({ attempt, className, configType }) =>
         ) : null}
       </div>
       {isFailed && (
-        <div>
+        <div className={styles.truncate}>
           {formatMessage(
             {
               id: "ui.keyValuePairV3",

--- a/airbyte-webapp/src/components/JobItem/components/MainInfo.module.scss
+++ b/airbyte-webapp/src/components/JobItem/components/MainInfo.module.scss
@@ -8,12 +8,14 @@
   .titleCell {
     display: flex;
     color: colors.$dark-blue;
+    min-width: 0;
 
     .statusIcon {
       display: flex;
       align-items: center;
       justify-content: center;
       width: 75px;
+      min-width: 75px;
 
       & > div {
         margin: 0;
@@ -28,8 +30,10 @@
 
     .justification {
       display: flex;
+      flex-grow: 1;
       flex-direction: column;
       justify-content: center;
+      min-width: 0;
     }
   }
 


### PR DESCRIPTION
## What
Limit error message to not overflow the default cell size on the Jobs Log page. 

**Note**: this does not guarantee a useful error message (see example).  

I imagine we may want to approach this on the back end to parse the body of the external message as something more useful.  

BEFORE:
<img width="1207" alt="Screen Shot 2022-08-13 at 11 05 17 AM" src="https://user-images.githubusercontent.com/63751206/184499858-2521b04f-3e3c-4845-84d6-d7e1f8098ae5.png">

AFTER:
<img width="1342" alt="Screen Shot 2022-08-15 at 3 11 13 PM" src="https://user-images.githubusercontent.com/63751206/184701556-3016217b-74f2-4e23-ab7d-4a7b72ec3d04.png">


## How
Use CSS to truncate the message at the width of the cell it's within.
