### PR TITLE
Source tiktok marketing: rm field `placement` for audience reports

### DIFF
--- a/airbyte-integrations/connectors/source-tiktok-marketing/Dockerfile
+++ b/airbyte-integrations/connectors/source-tiktok-marketing/Dockerfile
@@ -32,5 +32,5 @@ COPY source_tiktok_marketing ./source_tiktok_marketing
 ENV AIRBYTE_ENTRYPOINT "python /airbyte/integration_code/main.py"
 ENTRYPOINT ["python", "/airbyte/integration_code/main.py"]
 
-LABEL io.airbyte.version=0.1.14
+LABEL io.airbyte.version=0.1.15
 LABEL io.airbyte.name=airbyte/source-tiktok-marketing

--- a/airbyte-integrations/connectors/source-tiktok-marketing/integration_tests/configured_prod_catalog.json
+++ b/airbyte-integrations/connectors/source-tiktok-marketing/integration_tests/configured_prod_catalog.json
@@ -197,9 +197,6 @@
                 "adgroup_name": {
                   "type": ["null", "string"]
                 },
-                "placement": {
-                  "type": ["null", "string"]
-                },
                 "adgroup_id": {
                   "type": ["null", "integer"]
                 },
@@ -427,9 +424,6 @@
                 "adgroup_name": {
                   "type": ["null", "string"]
                 },
-                "placement": {
-                  "type": ["null", "string"]
-                },
                 "adgroup_id": {
                   "type": ["null", "integer"]
                 },
@@ -583,12 +577,6 @@
             "placement_type": {
               "type": "string",
               "enum": ["PLACEMENT_TYPE_AUTOMATIC", "PLACEMENT_TYPE_NORMAL"]
-            },
-            "placement": {
-              "type": ["null", "array"],
-              "items": {
-                "type": "string"
-              }
             },
             "enable_inventory_filter": {
               "type": ["null", "boolean"]
@@ -967,9 +955,6 @@
                 "adgroup_name": {
                   "type": ["null", "string"]
                 },
-                "placement": {
-                  "type": ["null", "string"]
-                },
                 "adgroup_id": {
                   "type": ["null", "integer"]
                 },
@@ -1185,9 +1170,6 @@
                   "type": ["null", "integer"]
                 },
                 "adgroup_name": {
-                  "type": ["null", "string"]
-                },
-                "placement": {
                   "type": ["null", "string"]
                 },
                 "adgroup_id": {

--- a/airbyte-integrations/connectors/source-tiktok-marketing/source_tiktok_marketing/schemas/audience_reports.json
+++ b/airbyte-integrations/connectors/source-tiktok-marketing/source_tiktok_marketing/schemas/audience_reports.json
@@ -13,9 +13,6 @@
         "adgroup_name": {
           "type": ["null", "string"]
         },
-        "placement": {
-          "type": ["null", "string"]
-        },
         "adgroup_id": {
           "type": ["null", "integer"]
         },
@@ -144,9 +141,6 @@
           "type": ["null", "string"]
         },
         "interest_category": {
-          "type": ["null", "string"]
-        },
-        "placement": {
           "type": ["null", "string"]
         }
       }

--- a/airbyte-integrations/connectors/source-tiktok-marketing/source_tiktok_marketing/schemas/basic_reports.json
+++ b/airbyte-integrations/connectors/source-tiktok-marketing/source_tiktok_marketing/schemas/basic_reports.json
@@ -13,9 +13,6 @@
         "adgroup_name": {
           "type": ["null", "string"]
         },
-        "placement": {
-          "type": ["null", "string"]
-        },
         "adgroup_id": {
           "type": ["null", "integer"]
         },

--- a/airbyte-integrations/connectors/source-tiktok-marketing/source_tiktok_marketing/streams.py
+++ b/airbyte-integrations/connectors/source-tiktok-marketing/source_tiktok_marketing/streams.py
@@ -50,7 +50,6 @@ NOT_AUDIENCE_METRICS = [
     "real_time_app_install",
     "real_time_app_install_cost",
     "app_install",
-    "placement",
 ]
 
 T = TypeVar("T")
@@ -566,7 +565,6 @@ class BasicReports(IncrementalTiktokStream, ABC):
                 [
                     "campaign_id",
                     "adgroup_name",
-                    "placement",
                     "tt_app_id",
                     "tt_app_name",
                     "mobile_app_id",

--- a/airbyte-integrations/connectors/source-tiktok-marketing/source_tiktok_marketing/streams.py
+++ b/airbyte-integrations/connectors/source-tiktok-marketing/source_tiktok_marketing/streams.py
@@ -50,6 +50,7 @@ NOT_AUDIENCE_METRICS = [
     "real_time_app_install",
     "real_time_app_install_cost",
     "app_install",
+    "placement",
 ]
 
 T = TypeVar("T")

--- a/airbyte-integrations/connectors/source-tiktok-marketing/unit_tests/streams_test.py
+++ b/airbyte-integrations/connectors/source-tiktok-marketing/unit_tests/streams_test.py
@@ -126,8 +126,8 @@ def test_stream_slices_report(advertiser_ids, granularity, slices_expected, pend
 @pytest.mark.parametrize(
     "stream, metrics_number",
     [
-        (AdsReports, 54),
-        (AdGroupsReports, 51),
+        (AdsReports, 53),
+        (AdGroupsReports, 50),
         (AdvertisersReports, 29),
         (CampaignsReports, 28),
         (AdvertisersAudienceReports, 6),
@@ -142,8 +142,8 @@ def test_basic_reports_get_metrics_day(stream, metrics_number):
 @pytest.mark.parametrize(
     "stream, metrics_number",
     [
-        (AdsReports, 54),
-        (AdGroupsReports, 51),
+        (AdsReports, 53),
+        (AdGroupsReports, 50),
         (AdvertisersReports, 27),
         (CampaignsReports, 28),
         (AdvertisersAudienceReports, 6),

--- a/airbyte-integrations/connectors/source-tiktok-marketing/unit_tests/streams_test.py
+++ b/airbyte-integrations/connectors/source-tiktok-marketing/unit_tests/streams_test.py
@@ -131,7 +131,7 @@ def test_stream_slices_report(advertiser_ids, granularity, slices_expected, pend
         (AdvertisersReports, 29),
         (CampaignsReports, 28),
         (AdvertisersAudienceReports, 6),
-        (AdsAudienceReports, 30),
+        (AdsAudienceReports, 29),
     ],
 )
 def test_basic_reports_get_metrics_day(stream, metrics_number):

--- a/docs/integrations/sources/tiktok-marketing.md
+++ b/docs/integrations/sources/tiktok-marketing.md
@@ -537,6 +537,7 @@ The connector is restricted by [requests limitation](https://ads.tiktok.com/mark
 
 | Version | Date       | Pull Request                                             | Subject                                                                                       |
 |:--------|:-----------|:---------------------------------------------------------|:----------------------------------------------------------------------------------------------|
+| 0.1.15  | 2022-08-15 | [15644](https://github.com/airbytehq/airbyte/pull/15644) | Removed `placement` metric for Audience reports                                               |                                               |
 | 0.1.14  | 2022-06-29 | [13890](https://github.com/airbytehq/airbyte/pull/13890) | Removed granularity config option                                                             |                                               |
 | 0.1.13  | 2022-06-28 | [13650](https://github.com/airbytehq/airbyte/pull/13650) | Added video metrics to report streams                                                         |                                                        |
 | 0.1.12  | 2022-05-24 | [13127](https://github.com/airbytehq/airbyte/pull/13127) | Fixed integration test                                                                        |


### PR DESCRIPTION
## What
https://github.com/airbytehq/oncall/issues/402
https://github.com/airbytehq/airbyte/actions/runs/2855514261

## How
This is definitely an API issue, since I get two different results when running two sequential syncs using same codebase:
```
(.venv) ddavydov@LWO1-LHP-A10584:~/airbyte/airbyte-integrations/connectors/source-tiktok-marketing$ python main.py read --config secrets/prod_config.json --catalog integration_tests/streams_reports_daily.json 
{"type": "LOG", "log": {"level": "INFO", "message": "Starting syncing SourceTiktokMarketing"}}
{"type": "LOG", "log": {"level": "INFO", "message": "Syncing stream: ad_group_audience_reports_daily "}}
{"type": "STATE", "state": {"data": {"ad_group_audience_reports_daily": {}}}}
{"type": "STATE", "state": {"data": {"ad_group_audience_reports_daily": {}}}}
{"type": "STATE", "state": {"data": {"ad_group_audience_reports_daily": {}}}}
{"type": "STATE", "state": {"data": {"ad_group_audience_reports_daily": {}}}}
{"type": "STATE", "state": {"data": {"ad_group_audience_reports_daily": {}}}}
{"type": "STATE", "state": {"data": {"ad_group_audience_reports_daily": {}}}}
{"type": "STATE", "state": {"data": {"ad_group_audience_reports_daily": {}}}}
{"type": "STATE", "state": {"data": {"ad_group_audience_reports_daily": {}}}}
{"type": "STATE", "state": {"data": {"ad_group_audience_reports_daily": {}}}}
{"type": "STATE", "state": {"data": {"ad_group_audience_reports_daily": {}}}}
{"type": "STATE", "state": {"data": {"ad_group_audience_reports_daily": {}}}}
{"type": "STATE", "state": {"data": {"ad_group_audience_reports_daily": {}}}}
{"type": "STATE", "state": {"data": {"ad_group_audience_reports_daily": {}}}}
{"type": "STATE", "state": {"data": {"ad_group_audience_reports_daily": {}}}}
{"type": "STATE", "state": {"data": {"ad_group_audience_reports_daily": {}}}}
{"type": "STATE", "state": {"data": {"ad_group_audience_reports_daily": {}}}}
{"type": "STATE", "state": {"data": {"ad_group_audience_reports_daily": {}}}}
{"type": "STATE", "state": {"data": {"ad_group_audience_reports_daily": {}}}}
{"type": "STATE", "state": {"data": {"ad_group_audience_reports_daily": {}}}}
{"type": "STATE", "state": {"data": {"ad_group_audience_reports_daily": {}}}}
{"type": "STATE", "state": {"data": {"ad_group_audience_reports_daily": {}}}}
{"type": "STATE", "state": {"data": {"ad_group_audience_reports_daily": {}}}}
{"type": "STATE", "state": {"data": {"ad_group_audience_reports_daily": {}}}}
{"type": "STATE", "state": {"data": {"ad_group_audience_reports_daily": {}}}}
{"type": "STATE", "state": {"data": {"ad_group_audience_reports_daily": {}}}}
{"type": "LOG", "log": {"level": "ERROR", "message": "Encountered an exception while reading stream ad_group_audience_reports_daily\nTraceback (most recent call last):\n  File \"/home/ddavydov/airbyte/airbyte-integrations/connectors/source-tiktok-marketing/.venv/lib/python3.9/site-packages/airbyte_cdk/sources/abstract_source.py\", line 114, in read\n    yield from self._read_stream(\n  File \"/home/ddavydov/airbyte/airbyte-integrations/connectors/source-tiktok-marketing/.venv/lib/python3.9/site-packages/airbyte_cdk/sources/abstract_source.py\", line 179, in _read_stream\n    for record in record_iterator:\n  File \"/home/ddavydov/airbyte/airbyte-integrations/connectors/source-tiktok-marketing/.venv/lib/python3.9/site-packages/airbyte_cdk/sources/abstract_source.py\", line 241, in _read_incremental\n    for record_counter, record_data in enumerate(records, start=1):\n  File \"/home/ddavydov/airbyte/airbyte-integrations/connectors/source-tiktok-marketing/.venv/lib/python3.9/site-packages/airbyte_cdk/sources/streams/http/http.py\", line 422, in read_records\n    yield from self.parse_response(response, stream_state=stream_state, stream_slice=stream_slice)\n  File \"/home/ddavydov/airbyte/airbyte-integrations/connectors/source-tiktok-marketing/source_tiktok_marketing/streams.py\", line 361, in parse_response\n    for record in super().parse_response(response=response, stream_state=stream_state, **kwargs):\n  File \"/home/ddavydov/airbyte/airbyte-integrations/connectors/source-tiktok-marketing/source_tiktok_marketing/streams.py\", line 177, in parse_response\n    raise TiktokException(data)\nsource_tiktok_marketing.streams.TiktokException: {'code': 40002, 'message': \"Please correct the information in invalid metric fields and try again. Invalid metric fields: ['placement']. \", 'request_id': '20220815075928010245244144100137E8', 'data': {}}"}}
{"type": "LOG", "log": {"level": "INFO", "message": "Finished syncing ad_group_audience_reports_daily"}}
{"type": "LOG", "log": {"level": "INFO", "message": "SourceTiktokMarketing runtimes:\nSyncing stream ad_group_audience_reports_daily 0:00:24.389904"}}
{"type": "LOG", "log": {"level": "FATAL", "message": "{'code': 40002, 'message': \"Please correct the information in invalid metric fields and try again. Invalid metric fields: ['placement']. \", 'request_id': '20220815075928010245244144100137E8', 'data': {}}\nTraceback (most recent call last):\n  File \"/home/ddavydov/airbyte/airbyte-integrations/connectors/source-tiktok-marketing/main.py\", line 13, in <module>\n    launch(source, sys.argv[1:])\n  File \"/home/ddavydov/airbyte/airbyte-integrations/connectors/source-tiktok-marketing/.venv/lib/python3.9/site-packages/airbyte_cdk/entrypoint.py\", line 123, in launch\n    for message in source_entrypoint.run(parsed_args):\n  File \"/home/ddavydov/airbyte/airbyte-integrations/connectors/source-tiktok-marketing/.venv/lib/python3.9/site-packages/airbyte_cdk/entrypoint.py\", line 114, in run\n    for message in generator:\n  File \"/home/ddavydov/airbyte/airbyte-integrations/connectors/source-tiktok-marketing/.venv/lib/python3.9/site-packages/airbyte_cdk/sources/abstract_source.py\", line 128, in read\n    raise e\n  File \"/home/ddavydov/airbyte/airbyte-integrations/connectors/source-tiktok-marketing/.venv/lib/python3.9/site-packages/airbyte_cdk/sources/abstract_source.py\", line 114, in read\n    yield from self._read_stream(\n  File \"/home/ddavydov/airbyte/airbyte-integrations/connectors/source-tiktok-marketing/.venv/lib/python3.9/site-packages/airbyte_cdk/sources/abstract_source.py\", line 179, in _read_stream\n    for record in record_iterator:\n  File \"/home/ddavydov/airbyte/airbyte-integrations/connectors/source-tiktok-marketing/.venv/lib/python3.9/site-packages/airbyte_cdk/sources/abstract_source.py\", line 241, in _read_incremental\n    for record_counter, record_data in enumerate(records, start=1):\n  File \"/home/ddavydov/airbyte/airbyte-integrations/connectors/source-tiktok-marketing/.venv/lib/python3.9/site-packages/airbyte_cdk/sources/streams/http/http.py\", line 422, in read_records\n    yield from self.parse_response(response, stream_state=stream_state, stream_slice=stream_slice)\n  File \"/home/ddavydov/airbyte/airbyte-integrations/connectors/source-tiktok-marketing/source_tiktok_marketing/streams.py\", line 361, in parse_response\n    for record in super().parse_response(response=response, stream_state=stream_state, **kwargs):\n  File \"/home/ddavydov/airbyte/airbyte-integrations/connectors/source-tiktok-marketing/source_tiktok_marketing/streams.py\", line 177, in parse_response\n    raise TiktokException(data)\nsource_tiktok_marketing.streams.TiktokException: {'code': 40002, 'message': \"Please correct the information in invalid metric fields and try again. Invalid metric fields: ['placement']. \", 'request_id': '20220815075928010245244144100137E8', 'data': {}}"}}
{"type": "TRACE", "trace": {"type": "ERROR", "emitted_at": 1660550368939.012, "error": {"message": "Something went wrong in the connector. See the logs for more details.", "internal_message": "{'code': 40002, 'message': \"Please correct the information in invalid metric fields and try again. Invalid metric fields: ['placement']. \", 'request_id': '20220815075928010245244144100137E8', 'data': {}}", "stack_trace": "Traceback (most recent call last):\n  File \"/home/ddavydov/airbyte/airbyte-integrations/connectors/source-tiktok-marketing/main.py\", line 13, in <module>\n    launch(source, sys.argv[1:])\n  File \"/home/ddavydov/airbyte/airbyte-integrations/connectors/source-tiktok-marketing/.venv/lib/python3.9/site-packages/airbyte_cdk/entrypoint.py\", line 123, in launch\n    for message in source_entrypoint.run(parsed_args):\n  File \"/home/ddavydov/airbyte/airbyte-integrations/connectors/source-tiktok-marketing/.venv/lib/python3.9/site-packages/airbyte_cdk/entrypoint.py\", line 114, in run\n    for message in generator:\n  File \"/home/ddavydov/airbyte/airbyte-integrations/connectors/source-tiktok-marketing/.venv/lib/python3.9/site-packages/airbyte_cdk/sources/abstract_source.py\", line 128, in read\n    raise e\n  File \"/home/ddavydov/airbyte/airbyte-integrations/connectors/source-tiktok-marketing/.venv/lib/python3.9/site-packages/airbyte_cdk/sources/abstract_source.py\", line 114, in read\n    yield from self._read_stream(\n  File \"/home/ddavydov/airbyte/airbyte-integrations/connectors/source-tiktok-marketing/.venv/lib/python3.9/site-packages/airbyte_cdk/sources/abstract_source.py\", line 179, in _read_stream\n    for record in record_iterator:\n  File \"/home/ddavydov/airbyte/airbyte-integrations/connectors/source-tiktok-marketing/.venv/lib/python3.9/site-packages/airbyte_cdk/sources/abstract_source.py\", line 241, in _read_incremental\n    for record_counter, record_data in enumerate(records, start=1):\n  File \"/home/ddavydov/airbyte/airbyte-integrations/connectors/source-tiktok-marketing/.venv/lib/python3.9/site-packages/airbyte_cdk/sources/streams/http/http.py\", line 422, in read_records\n    yield from self.parse_response(response, stream_state=stream_state, stream_slice=stream_slice)\n  File \"/home/ddavydov/airbyte/airbyte-integrations/connectors/source-tiktok-marketing/source_tiktok_marketing/streams.py\", line 361, in parse_response\n    for record in super().parse_response(response=response, stream_state=stream_state, **kwargs):\n  File \"/home/ddavydov/airbyte/airbyte-integrations/connectors/source-tiktok-marketing/source_tiktok_marketing/streams.py\", line 177, in parse_response\n    raise TiktokException(data)\nsource_tiktok_marketing.streams.TiktokException: {'code': 40002, 'message': \"Please correct the information in invalid metric fields and try again. Invalid metric fields: ['placement']. \", 'request_id': '20220815075928010245244144100137E8', 'data': {}}\n", "failure_type": "system_error"}}}

(.venv) ddavydov@LWO1-LHP-A10584:~/airbyte/airbyte-integrations/connectors/source-tiktok-marketing$ python main.py read --config secrets/prod_config.json --catalog integration_tests/streams_reports_daily.json 
{"type": "LOG", "log": {"level": "INFO", "message": "Starting syncing SourceTiktokMarketing"}}
{"type": "LOG", "log": {"level": "INFO", "message": "Syncing stream: ad_group_audience_reports_daily "}}
{"type": "STATE", "state": {"data": {"ad_group_audience_reports_daily": {}}}}
{"type": "STATE", "state": {"data": {"ad_group_audience_reports_daily": {}}}}
{"type": "STATE", "state": {"data": {"ad_group_audience_reports_daily": {}}}}
{"type": "STATE", "state": {"data": {"ad_group_audience_reports_daily": {}}}}
{"type": "STATE", "state": {"data": {"ad_group_audience_reports_daily": {}}}}
{"type": "STATE", "state": {"data": {"ad_group_audience_reports_daily": {}}}}
{"type": "STATE", "state": {"data": {"ad_group_audience_reports_daily": {}}}}
{"type": "STATE", "state": {"data": {"ad_group_audience_reports_daily": {}}}}
{"type": "STATE", "state": {"data": {"ad_group_audience_reports_daily": {}}}}
{"type": "STATE", "state": {"data": {"ad_group_audience_reports_daily": {}}}}
{"type": "STATE", "state": {"data": {"ad_group_audience_reports_daily": {}}}}
{"type": "STATE", "state": {"data": {"ad_group_audience_reports_daily": {}}}}
{"type": "STATE", "state": {"data": {"ad_group_audience_reports_daily": {}}}}
{"type": "STATE", "state": {"data": {"ad_group_audience_reports_daily": {}}}}
{"type": "STATE", "state": {"data": {"ad_group_audience_reports_daily": {}}}}
{"type": "STATE", "state": {"data": {"ad_group_audience_reports_daily": {}}}}
{"type": "STATE", "state": {"data": {"ad_group_audience_reports_daily": {}}}}
{"type": "STATE", "state": {"data": {"ad_group_audience_reports_daily": {}}}}
{"type": "STATE", "state": {"data": {"ad_group_audience_reports_daily": {}}}}
{"type": "STATE", "state": {"data": {"ad_group_audience_reports_daily": {}}}}
{"type": "STATE", "state": {"data": {"ad_group_audience_reports_daily": {}}}}
{"type": "STATE", "state": {"data": {"ad_group_audience_reports_daily": {}}}}
{"type": "STATE", "state": {"data": {"ad_group_audience_reports_daily": {}}}}
{"type": "STATE", "state": {"data": {"ad_group_audience_reports_daily": {}}}}
{"type": "STATE", "state": {"data": {"ad_group_audience_reports_daily": {}}}}
{"type": "STATE", "state": {"data": {"ad_group_audience_reports_daily": {}}}}
{"type": "STATE", "state": {"data": {"ad_group_audience_reports_daily": {}}}}
{"type": "STATE", "state": {"data": {"ad_group_audience_reports_daily": {}}}}
{"type": "STATE", "state": {"data": {"ad_group_audience_reports_daily": {}}}}
{"type": "STATE", "state": {"data": {"ad_group_audience_reports_daily": {}}}}
{"type": "STATE", "state": {"data": {"ad_group_audience_reports_daily": {}}}}
{"type": "STATE", "state": {"data": {"ad_group_audience_reports_daily": {}}}}
{"type": "STATE", "state": {"data": {"ad_group_audience_reports_daily": {}}}}
{"type": "STATE", "state": {"data": {"ad_group_audience_reports_daily": {}}}}
{"type": "STATE", "state": {"data": {"ad_group_audience_reports_daily": {}}}}
{"type": "STATE", "state": {"data": {"ad_group_audience_reports_daily": {}}}}
{"type": "STATE", "state": {"data": {"ad_group_audience_reports_daily": {}}}}
{"type": "STATE", "state": {"data": {"ad_group_audience_reports_daily": {}}}}
{"type": "STATE", "state": {"data": {"ad_group_audience_reports_daily": {}}}}
{"type": "STATE", "state": {"data": {"ad_group_audience_reports_daily": {}}}}
{"type": "RECORD", "record": {"stream": "ad_group_audience_reports_daily", "data": {"metrics": {"ctr": 0, "campaign_name": "Website Traffic20211019110444", "cost_per_conversion": 0, "cpc": 0, "impressions": 18, "campaign_id": 1714073078669329, "result": 0, "clicks": 0, "real_time_cost_per_result": 0, "cpm": 0, "real_time_conversion_rate": 0, "conversion_rate": 0, "promotion_type": "Website", "real_time_result_rate": 0, "mobile_app_id": 0, "conversion": 0, "real_time_cost_per_conversion": 0, "real_time_conversion": 0, "result_rate": 0, "dpa_target_audience_type": null, "tt_app_name": "0", "spend": 0, "tt_app_id": 0, "real_time_result": 0, "cost_per_result": 0, "placement": "Automatic Placement", "adgroup_name": "Ad Group20211019111040"}, "dimensions": {"gender": "MALE", "stat_time_day": "2021-10-19 00:00:00", "adgroup_id": 1714073022392322, "age": "AGE_45_54"}}, "emitted_at": 1660550408248}}
{"type": "RECORD", "record": {"stream": "ad_group_audience_reports_daily", "data": {"metrics": {"ctr": 0, "campaign_name": "Website Traffic20211019110444", "cost_per_conversion": 0, "cpc": 0, "impressions": 0, "campaign_id": 1714073078669329, "result": 0, "clicks": 0, "real_time_cost_per_result": 0, "cpm": 0, "real_time_conversion_rate": 0, "conversion_rate": 0, "promotion_type": "Website", "real_time_result_rate": 0, "mobile_app_id": 0, "conversion": 0, "real_time_cost_per_conversion": 0, "real_time_conversion": 0, "result_rate": 0, "dpa_target_audience_type": null, "tt_app_name": "0", "spend": 0, "tt_app_id": 0, "real_time_result": 0, "cost_per_result": 0, "placement": "Automatic Placement", "adgroup_name": "Ad Group20211019111040"}, "dimensions": {"gender": "MALE", "stat_time_day": "2021-10-22 00:00:00", "adgroup_id": 1714073022392322, "age": "AGE_25_34"}}, "emitted_at": 1660550408257}}
```
Perhaps it's related to a new API version being introduced.
Removing `placement` metric for audience report streams does the trick. This should be a short term solution. For a long term we should switch to a new API version (1.3).
