### PR TITLE
CDK: Improve `filter_secrets` skip empty secret

### DIFF
--- a/airbyte-cdk/python/CHANGELOG.md
+++ b/airbyte-cdk/python/CHANGELOG.md
@@ -1,5 +1,8 @@
 # Changelog
 
+## 0.1.75
+- Improve `filter_secrets` skip empty string
+
 ## 0.1.74
 - Replace JelloRecordExtractor with DpathRecordExtractor
 

--- a/airbyte-cdk/python/CHANGELOG.md
+++ b/airbyte-cdk/python/CHANGELOG.md
@@ -1,7 +1,7 @@
 # Changelog
 
 ## 0.1.75
-- Improve `filter_secrets` skip empty string
+- Improve `filter_secrets` skip empty secret
 
 ## 0.1.74
 - Replace JelloRecordExtractor with DpathRecordExtractor

--- a/airbyte-cdk/python/airbyte_cdk/utils/airbyte_secrets_utils.py
+++ b/airbyte-cdk/python/airbyte_cdk/utils/airbyte_secrets_utils.py
@@ -67,5 +67,6 @@ def filter_secrets(string: str) -> str:
     # TODO this should perform a maximal match for each secret. if "x" and "xk" are both secret values, and this method is called twice on
     #  the input "xk", then depending on call order it might only obfuscate "*k". This is a bug.
     for secret in __SECRETS_FROM_CONFIG:
-        string = string.replace(str(secret), "****")
+        if secret:
+            string = string.replace(str(secret), "****")
     return string

--- a/airbyte-cdk/python/setup.py
+++ b/airbyte-cdk/python/setup.py
@@ -15,7 +15,7 @@ README = (HERE / "README.md").read_text()
 
 setup(
     name="airbyte-cdk",
-    version="0.1.74",
+    version="0.1.75",
     description="A framework for writing Airbyte Connectors.",
     long_description=README,
     long_description_content_type="text/markdown",

--- a/airbyte-cdk/python/unit_tests/utils/test_secret_utils.py
+++ b/airbyte-cdk/python/unit_tests/utils/test_secret_utils.py
@@ -113,6 +113,11 @@ def test_secret_filtering():
     filtered = filter_secrets(sensitive_str)
     assert filtered == sensitive_str
 
+    # the empty secret should not affect the result
+    update_secrets([""])
+    filtered = filter_secrets(sensitive_str)
+    assert filtered == sensitive_str
+
     update_secrets([SECRET_STRING_VALUE, SECRET_STRING_2_VALUE])
     filtered = filter_secrets(sensitive_str)
     assert filtered == f"**** {NOT_SECRET_VALUE} **** ****"


### PR DESCRIPTION
Signed-off-by: Sergey Chvalyuk <grubberr@gmail.com>

## What
`source-bing-ads` has empty secret value on purpose:
```
$ cat secrets/config.json |  jq .client_secret
""
```

it produce "strange" log output like this:
```
{"type": "LOG", "log": {"level": "INFO", "message": "****C****h****e****c****k**** ****s****u****c****c****e****e****d****e****d****"}}
```

## How
Don't replace empty string with 4 starts