### PR TITLE
Postgres file reader now assumes UTF8

### DIFF
--- a/airbyte-integrations/bases/base-java/src/main/java/io/airbyte/integrations/util/PostgresSslConnectionUtils.java
+++ b/airbyte-integrations/bases/base-java/src/main/java/io/airbyte/integrations/util/PostgresSslConnectionUtils.java
@@ -85,7 +85,7 @@ public class PostgresSslConnectionUtils {
 
   private static String readFile(final File file) {
     try {
-      BufferedReader reader = new BufferedReader(new FileReader(file));
+      BufferedReader reader = new BufferedReader(new FileReader(file, StandardCharsets.UTF_8));
       String currentLine = reader.readLine();
       reader.close();
       return currentLine;

--- a/airbyte-integrations/connectors/source-postgres/src/main/java/io/airbyte/integrations/source/postgres/PostgresSource.java
+++ b/airbyte-integrations/connectors/source-postgres/src/main/java/io/airbyte/integrations/source/postgres/PostgresSource.java
@@ -16,6 +16,7 @@ import static java.util.stream.Collectors.toSet;
 import com.fasterxml.jackson.databind.JsonNode;
 import com.google.common.annotations.VisibleForTesting;
 import com.google.common.collect.ImmutableMap;
+import com.google.common.collect.ImmutableMap.Builder;
 import com.google.common.collect.Sets;
 import io.airbyte.commons.features.EnvVariableFeatureFlags;
 import io.airbyte.commons.features.FeatureFlags;


### PR DESCRIPTION
This fixes a failing test, `:airbyte-integrations:bases:base-java:spotbugsMain`

So, 
![bailey-computer1](https://user-images.githubusercontent.com/303226/184932379-05e89ef5-6225-4895-869d-44c57e82edf0.jpeg)

but I think that assuming that all of our users/servers will be using a UTF8 is reasonable in 2022...
