### PR TITLE
MySQL file reader now assumes UTF8

### DIFF
--- a/airbyte-integrations/bases/base-java/src/main/java/io/airbyte/integrations/util/MySqlSslConnectionUtils.java
+++ b/airbyte-integrations/bases/base-java/src/main/java/io/airbyte/integrations/util/MySqlSslConnectionUtils.java
@@ -79,7 +79,7 @@ public class MySqlSslConnectionUtils {
 
   private static String readFile(final File file) {
     try {
-      BufferedReader reader = new BufferedReader(new FileReader(file));
+      BufferedReader reader = new BufferedReader(new FileReader(file, StandardCharsets.UTF_8));
       String currentLine = reader.readLine();
       reader.close();
       return currentLine;


### PR DESCRIPTION
Just like https://github.com/airbytehq/airbyte/pull/15697, but now for MySQL - this fixes a CI/Build issue