### PR TITLE
[low code connectors] add missing/mistyped values for declarative sendgrid + sentry

### DIFF
--- a/airbyte-config/init/src/main/resources/seed/source_definitions.yaml
+++ b/airbyte-config/init/src/main/resources/seed/source_definitions.yaml
@@ -900,7 +900,7 @@
 - name: Sendgrid
   sourceDefinitionId: fbb5fbe2-16ad-4cf4-af7d-ff9d9c316c87
   dockerRepository: airbyte/source-sendgrid
-  dockerImageTag: 0.2.9
+  dockerImageTag: 0.2.10
   documentationUrl: https://docs.airbyte.io/integrations/sources/sendgrid
   icon: sendgrid.svg
   sourceType: api

--- a/airbyte-config/init/src/main/resources/seed/source_definitions.yaml
+++ b/airbyte-config/init/src/main/resources/seed/source_definitions.yaml
@@ -1131,7 +1131,7 @@
 - sourceDefinitionId: cdaf146a-9b75-49fd-9dd2-9d64a0bb4781
   name: Sentry
   dockerRepository: airbyte/source-sentry
-  dockerImageTag: 0.1.2
+  dockerImageTag: 0.1.3
   documentationUrl: https://docs.airbyte.io/integrations/sources/sentry
   icon: sentry.svg
   sourceType: api

--- a/airbyte-config/init/src/main/resources/seed/source_specs.yaml
+++ b/airbyte-config/init/src/main/resources/seed/source_specs.yaml
@@ -11049,7 +11049,7 @@
     supportsNormalization: false
     supportsDBT: false
     supported_destination_sync_modes: []
-- dockerImage: "airbyte/source-sentry:0.1.2"
+- dockerImage: "airbyte/source-sentry:0.1.3"
   spec:
     documentationUrl: "https://docs.airbyte.io/integrations/sources/sentry"
     connectionSpecification:

--- a/airbyte-config/init/src/main/resources/seed/source_specs.yaml
+++ b/airbyte-config/init/src/main/resources/seed/source_specs.yaml
@@ -8880,7 +8880,7 @@
     supportsNormalization: false
     supportsDBT: false
     supported_destination_sync_modes: []
-- dockerImage: "airbyte/source-sendgrid:0.2.9"
+- dockerImage: "airbyte/source-sendgrid:0.2.10"
   spec:
     documentationUrl: "https://docs.airbyte.io/integrations/sources/sendgrid"
     connectionSpecification:

--- a/airbyte-integrations/connectors/source-sendgrid/Dockerfile
+++ b/airbyte-integrations/connectors/source-sendgrid/Dockerfile
@@ -12,5 +12,5 @@ RUN pip install .
 ENV AIRBYTE_ENTRYPOINT "python /airbyte/integration_code/main.py"
 ENTRYPOINT ["python", "/airbyte/integration_code/main.py"]
 
-LABEL io.airbyte.version=0.2.9
+LABEL io.airbyte.version=0.2.10
 LABEL io.airbyte.name=airbyte/source-sendgrid

--- a/airbyte-integrations/connectors/source-sendgrid/source_sendgrid/sendgrid.yaml
+++ b/airbyte-integrations/connectors/source-sendgrid/source_sendgrid/sendgrid.yaml
@@ -1,3 +1,4 @@
+version: "0.1.0"
 definitions:
   page_size: 50
   step: "30d"
@@ -247,7 +248,7 @@ streams:
         $ref: "*ref(definitions.requester)"
         request_options_provider:
           request_parameters:
-            limit: 1000
+            limit: "1000"
             query: 'last_event_time BETWEEN TIMESTAMP "{{stream_slice.start_time}}" AND TIMESTAMP "{{stream_slice.end_time}}"'
       stream_slicer:
         $ref: "*ref(definitions.messages_stream_slicer)"

--- a/airbyte-integrations/connectors/source-sentry/Dockerfile
+++ b/airbyte-integrations/connectors/source-sentry/Dockerfile
@@ -34,5 +34,5 @@ COPY source_sentry ./source_sentry
 ENV AIRBYTE_ENTRYPOINT "python /airbyte/integration_code/main.py"
 ENTRYPOINT ["python", "/airbyte/integration_code/main.py"]
 
-LABEL io.airbyte.version=0.1.2
+LABEL io.airbyte.version=0.1.3
 LABEL io.airbyte.name=airbyte/source-sentry

--- a/airbyte-integrations/connectors/source-sentry/source_sentry/sentry.yaml
+++ b/airbyte-integrations/connectors/source-sentry/source_sentry/sentry.yaml
@@ -1,3 +1,4 @@
+version: "0.1.0"
 definitions:
   page_size: 50
   schema_loader:

--- a/docs/integrations/sources/sendgrid.md
+++ b/docs/integrations/sources/sendgrid.md
@@ -47,7 +47,8 @@ To consume Messages resources requires to purchase an extra on Sendgrid. You can
 
 | Version | Date | Pull Request                                             | Subject                                            |
 |:--------| :--- |:---------------------------------------------------------|:---------------------------------------------------|
-| 0.2.9   | 2022-06-07 | [15257](https://github.com/airbytehq/airbyte/pull/15257) | Migrate to config-based framework                  |
+| 0.2.10  | 2022-08-17 | [15734](https://github.com/airbytehq/airbyte/pull/15734) | Fix yaml based on the new schema validator         |
+| 0.2.9   | 2022-08-11 | [15257](https://github.com/airbytehq/airbyte/pull/15257) | Migrate to config-based framework                  |
 | 0.2.8   | 2022-06-07 | [13571](https://github.com/airbytehq/airbyte/pull/13571) | Add Message stream                                 |
 | 0.2.7   | 2021-09-08 | [5910](https://github.com/airbytehq/airbyte/pull/5910)   | Add Single Sends Stats stream                      |
 | 0.2.6   | 2021-07-19 | [4839](https://github.com/airbytehq/airbyte/pull/4839)   | Gracefully handle malformed responses from the API |

--- a/docs/integrations/sources/sentry.md
+++ b/docs/integrations/sources/sentry.md
@@ -46,6 +46,7 @@ You can find or create authentication tokens within [Sentry](https://sentry.io/s
 
 | Version | Date | Pull Request | Subject                                           |
 |:--------| :--- | :--- |:--------------------------------------------------|
+| 0.1.3   | 2022-08-17 | [15734](https://github.com/airbytehq/airbyte/pull/15734) | Fix yaml based on the new schema validator        |
 | 0.1.2   | 2021-12-28 | [15345](https://github.com/airbytehq/airbyte/pull/15345) | Migrate to config-based framework                 |
 | 0.1.1   | 2021-12-28 | [8628](https://github.com/airbytehq/airbyte/pull/8628) | Update fields in source-connectors specifications |
 | 0.1.0   | 2021-10-12 | [6975](https://github.com/airbytehq/airbyte/pull/6975) | New Source: Sentry                                |


### PR DESCRIPTION
## What
After running schema validation against our existing connectors, there were a few small things that got flagged. These should be fixed before we merge the validation code, otherwise we'll break our daily connector testing

## How
A few connectors were missing version, and we should be sending all query parameters as strings as per our type definition