### PR TITLE
Fix build by marking id columns as primary keys in test files

### DIFF
--- a/airbyte-tests/src/acceptanceTests/resources/postgres_init.sql
+++ b/airbyte-tests/src/acceptanceTests/resources/postgres_init.sql
@@ -1,7 +1,7 @@
 CREATE
     TABLE
         id_and_name(
-            id INTEGER,
+            id INTEGER NOT NULL,
             name VARCHAR(200)
         );
 

--- a/airbyte-tests/src/acceptanceTests/resources/postgres_second_schema_multiple_tables.sql
+++ b/airbyte-tests/src/acceptanceTests/resources/postgres_second_schema_multiple_tables.sql
@@ -4,7 +4,7 @@ CREATE
 CREATE
     TABLE
         staging.cool_employees(
-            id INTEGER,
+            id INTEGER NOT NULL,
             name VARCHAR(200)
         );
 
@@ -38,7 +38,7 @@ INSERT
 CREATE
     TABLE
         staging.awesome_people(
-            id INTEGER,
+            id INTEGER NOT NULL,
             name VARCHAR(200)
         );
 

--- a/airbyte-tests/src/acceptanceTests/resources/postgres_separate_schema_same_table.sql
+++ b/airbyte-tests/src/acceptanceTests/resources/postgres_separate_schema_same_table.sql
@@ -4,7 +4,7 @@ CREATE
 CREATE
     TABLE
         staging.id_and_name(
-            id INTEGER,
+            id INTEGER NOT NULL,
             name VARCHAR(200)
         );
 


### PR DESCRIPTION
In https://github.com/airbytehq/airbyte/pull/14356 we changed how supported sync modes are determined: a source stream must have at least one field that can be used as a cursor in order for the stream to support incremental syncing. 

The Postgres sources that we use in acceptance test weren't declaring `id` columns as primary keys, which meant they were nullable and thus could not be used as cursor columns. 

This broke some of our acceptance tests that tested the behavior of incremental syncs. This PR modifies the seed sql we use in these tests to declare the `id` column as a primary key, so that incremental can be supported.