### PR TITLE
source instagram: ask for pages_show_list,pages_read_engagement scopes during oauth

### DIFF
--- a/airbyte-oauth/src/main/java/io/airbyte/oauth/flows/facebook/InstagramOAuthFlow.java
+++ b/airbyte-oauth/src/main/java/io/airbyte/oauth/flows/facebook/InstagramOAuthFlow.java
@@ -12,7 +12,7 @@ import java.util.function.Supplier;
 // Instagram Graph API require Facebook API User token
 public class InstagramOAuthFlow extends FacebookMarketingOAuthFlow {
 
-  private static final String SCOPES = "ads_management,instagram_basic,instagram_manage_insights";
+  private static final String SCOPES = "ads_management,instagram_basic,instagram_manage_insights,pages_show_list,pages_read_engagement";
 
   public InstagramOAuthFlow(final ConfigRepository configRepository, final HttpClient httpClient) {
     super(configRepository, httpClient);

--- a/airbyte-oauth/src/test/java/io/airbyte/oauth/flows/facebook/InstagramOAuthFlowTest.java
+++ b/airbyte-oauth/src/test/java/io/airbyte/oauth/flows/facebook/InstagramOAuthFlowTest.java
@@ -20,7 +20,7 @@ public class InstagramOAuthFlowTest extends BaseOAuthFlowTest {
 
   @Override
   protected String getExpectedConsentUrl() {
-    return "https://www.facebook.com/v12.0/dialog/oauth?client_id=test_client_id&redirect_uri=https%3A%2F%2Fairbyte.io&state=state&scope=ads_management%2Cinstagram_basic%2Cinstagram_manage_insights";
+    return "https://www.facebook.com/v12.0/dialog/oauth?client_id=test_client_id&redirect_uri=https%3A%2F%2Fairbyte.io&state=state&scope=ads_management%2Cinstagram_basic%2Cinstagram_manage_insights%2Cpages_show_list%2Cpages_read_engagement";
   }
 
   @Override


### PR DESCRIPTION
## What
Context in https://github.com/airbytehq/oncall/issues/322

## How
This is a shot in the dark because reproducing this error is hard. It requires having an instagram business account, linked to a facebook page, accessible by a user who is not a member of Airbyte's business account. Setting this up will take time because Facebook requires real people to sign up for these accounts and requires actual business verification etc.. I'm also not sure how to mock this or if it's possible to do via some facebook provided sandbox. So here goes nothing. 

Something which stood out to me is that [facebook mentions](https://developers.facebook.com/docs/graph-api/reference/user/accounts/) we need the `pages_show_list` permission to get a customer's accounts, which [we clearly do in this step](https://github.com/airbytehq/airbyte/blob/master/airbyte-integrations/connectors/source-instagram/source_instagram/api.py#L94). We even say [in our docs for OSS users ](https://docs.airbyte.com/integrations/sources/instagram/#step-2-set-up-the-instagram-connector-in-airbyte) that this is required. So it certainly seems like a valid shot in the dark. I also added the `pages_read_engagement` permission for good measure since it allows an app to `read metadata and other insights about the Page` which seems vague enough that it is probably relevant. Again I would prefer to have exact reproducible scenarios here but we're sort of pressed for time on the linked issue. 