### PR TITLE
Update Airbyte Protocol docs self-referencing link to Namespaces

### DIFF
--- a/docs/understanding-airbyte/airbyte-protocol.md
+++ b/docs/understanding-airbyte/airbyte-protocol.md
@@ -277,7 +277,7 @@ Technical systems often group their underlying data into namespaces with each na
 
 An example of a namespace is the RDBMS's `schema` concept. An API namespace might be used for multiple accounts (e.g. `company_a` vs `company_b`, each having a "users" and "purchases" stream).  Some common use cases for schemas are enforcing permissions, segregating test and production data and general data organization.
 
-The `AirbyteStream` represents this concept through an optional field called `namespace`. Additional documentation on Namespaces can be found [here](#namespace).
+The `AirbyteStream` represents this concept through an optional field called `namespace`. Additional documentation on Namespaces can be found [here](namespaces.md).
 
 
 ## Cursor


### PR DESCRIPTION
## What

The Airbyte docs were pointing for further reading to themselves, rather than the actual additional documentation.

## How

Fixing the link.

## 🚨 User Impact 🚨

No breaking changes

## Pre-merge Checklist
Expand the relevant checklist and delete the others.
