### PR TITLE
[low code connectors] replace file retrieval with pkgutil to fix getting schema files

### DIFF
--- a/airbyte-cdk/python/CHANGELOG.md
+++ b/airbyte-cdk/python/CHANGELOG.md
@@ -1,5 +1,8 @@
 # Changelog
 
+## 0.1.79
+- Fix yaml schema parsing when running from docker container
+
 ## 0.1.78
 - Fix yaml config parsing when running from docker container
 

--- a/airbyte-cdk/python/airbyte_cdk/sources/declarative/parsers/factory.py
+++ b/airbyte-cdk/python/airbyte_cdk/sources/declarative/parsers/factory.py
@@ -9,6 +9,7 @@ import enum
 import importlib
 import inspect
 import typing
+import warnings
 from dataclasses import fields
 from typing import Any, List, Literal, Mapping, Type, Union, get_args, get_origin, get_type_hints
 
@@ -153,7 +154,12 @@ class DeclarativeComponentFactory:
             # concrete classes that implement the interface before generating the schema
             class_copy = copy.deepcopy(class_)
             DeclarativeComponentFactory._transform_interface_to_union(class_copy)
-            schema = class_copy.json_schema()
+
+            # dataclasses_jsonschema can throw warnings when a declarative component has a fields cannot be turned into a schema.
+            # Some builtin field types like Any or DateTime get flagged, but are not as critical to schema generation and validation
+            with warnings.catch_warnings():
+                warnings.simplefilter("ignore", category=UserWarning)
+                schema = class_copy.json_schema()
 
             component_definition = {
                 **updated_kwargs,

--- a/airbyte-cdk/python/airbyte_cdk/sources/declarative/schema/json_schema.py
+++ b/airbyte-cdk/python/airbyte_cdk/sources/declarative/schema/json_schema.py
@@ -35,11 +35,15 @@ class JsonSchema(SchemaLoader, JsonSchemaMixin):
     def get_json_schema(self) -> Mapping[str, Any]:
         json_schema_path = self._get_json_filepath()
         resource, schema_path = self.extract_resource_and_schema_path(json_schema_path)
-        json_schema = pkgutil.get_data(resource, schema_path)
+        raw_json_file = pkgutil.get_data(resource, schema_path)
 
-        if not json_schema:
-            raise FileNotFoundError("File not found: " + json_schema_path)
-        return json.loads(json_schema)
+        if not raw_json_file:
+            raise IOError(f"Cannot find file {json_schema_path}")
+        try:
+            raw_schema = json.loads(raw_json_file)
+        except ValueError as err:
+            raise RuntimeError(f"Invalid JSON file format for file {json_schema_path}") from err
+        return raw_schema
 
     def _get_json_filepath(self):
         return self.file_path.eval(self.config)

--- a/airbyte-cdk/python/airbyte_cdk/sources/declarative/schema/json_schema.py
+++ b/airbyte-cdk/python/airbyte_cdk/sources/declarative/schema/json_schema.py
@@ -33,6 +33,8 @@ class JsonSchema(SchemaLoader, JsonSchemaMixin):
         self.file_path = InterpolatedString.create(self.file_path, options=options)
 
     def get_json_schema(self) -> Mapping[str, Any]:
+        # todo: It is worth revisiting if we can replace file_path with just file_name if every schema is in the /schemas directory
+        # this would require that we find a creative solution to store or retrieve source_name in here since the files are mounted there
         json_schema_path = self._get_json_filepath()
         resource, schema_path = self.extract_resource_and_schema_path(json_schema_path)
         raw_json_file = pkgutil.get_data(resource, schema_path)

--- a/airbyte-cdk/python/setup.py
+++ b/airbyte-cdk/python/setup.py
@@ -15,7 +15,7 @@ README = (HERE / "README.md").read_text()
 
 setup(
     name="airbyte-cdk",
-    version="0.1.78",
+    version="0.1.79",
     description="A framework for writing Airbyte Connectors.",
     long_description=README,
     long_description_content_type="text/markdown",

--- a/airbyte-cdk/python/unit_tests/sources/declarative/schema/test_json_schema.py
+++ b/airbyte-cdk/python/unit_tests/sources/declarative/schema/test_json_schema.py
@@ -1,0 +1,26 @@
+#
+# Copyright (c) 2022 Airbyte, Inc., all rights reserved.
+#
+
+import pytest
+from airbyte_cdk.sources.declarative.schema import JsonSchema
+
+
+@pytest.mark.parametrize(
+    "test_name, input_path, expected_resource, expected_path",
+    [
+        ("path_prefixed_with_dot", "./source_example/schemas/lists.json", "source_example", "schemas/lists.json"),
+        ("path_prefixed_with_slash", "/source_example/schemas/lists.json", "source_example", "schemas/lists.json"),
+        ("path_starting_with_source", "source_example/schemas/lists.json", "source_example", "schemas/lists.json"),
+        ("path_starting_missing_source", "schemas/lists.json", "schemas", "lists.json"),
+        ("path_with_file_only", "lists.json", "", "lists.json"),
+        ("empty_path_does_not_crash", "", "", ""),
+        ("empty_path_with_slash_does_not_crash", "/", "", ""),
+    ],
+)
+def test_extract_resource_and_schema_path(test_name, input_path, expected_resource, expected_path):
+    json_schema = JsonSchema(input_path, {}, {})
+    actual_resource, actual_path = json_schema.extract_resource_and_schema_path(input_path)
+
+    assert actual_resource == expected_resource
+    assert actual_path == expected_path


### PR DESCRIPTION
## What
Similar to the bug that we can't read files from the running Docker container. We need to read them using pkgutils when they're accessible at runtime using `package_data` in setup.py . The same applies for schema files.

This change should not require any changes to the existing yaml configs and I tested this locally for each of the integrations currently running in prod.

Example format of the json schema path:
```
schema_loader:
    file_path: "./source_greenhouse/schemas/{{ options['name'] }}.json"
```

## How
Same concept as reading yaml configs. However, for slightly better DX, we should accept file structure that supports `.` prefix, `/` prefix, and the start of resource all the same so we do some string manipulation. All the existing declarative configs in prod at the moment shouldn't be affected by this change

**Note:** I also added a small fix to filter out schema gen warnings for some builtin types that would get flagged by the dataclasses_json helper library. The annoying part about these is they get flagged by the platform as ERROR which is confusing to see when debugging and could lead to a lot of red herrings during OC. We should hide these. An example of the warnings:
```
/Users/brian.lai/dev/airbyte/airbyte-integrations/connectors/source-greenhouse/.venv/lib/python3.9/site-packages/dataclasses_jsonschema/__init__.py:732: UserWarning: Unable to create schema for 'Any'
  warnings.warn(f"Unable to create schema for '{field_type_name}'")
/Users/brian.lai/dev/airbyte/airbyte-integrations/connectors/source-greenhouse/.venv/lib/python3.9/site-packages/dataclasses_jsonschema/__init__.py:732: UserWarning: Unable to create schema for 'DateTime'
  warnings.warn(f"Unable to create schema for '{field_type_name}'")
```