### PR TITLE
SAT: improve `check_if_cursor_field_was_changed` to make it less strict

### DIFF
--- a/airbyte-integrations/bases/source-acceptance-test/CHANGELOG.md
+++ b/airbyte-integrations/bases/source-acceptance-test/CHANGELOG.md
@@ -1,5 +1,8 @@
 # Changelog
 
+## 0.2.2
+Backward compatibility tests: improve `check_if_cursor_field_was_changed` to make it less radical and allow stream addition to catalog.[#15835](https://github.com/airbytehq/airbyte/pull/15835/)
+
 ## 0.2.1
 Don't fail on updating `additionalProperties`: fix IndexError [#15532](https://github.com/airbytehq/airbyte/pull/15532/)
 

--- a/airbyte-integrations/bases/source-acceptance-test/Dockerfile
+++ b/airbyte-integrations/bases/source-acceptance-test/Dockerfile
@@ -33,7 +33,7 @@ COPY pytest.ini setup.py ./
 COPY source_acceptance_test ./source_acceptance_test
 RUN pip install .
 
-LABEL io.airbyte.version=0.2.1
+LABEL io.airbyte.version=0.2.2
 LABEL io.airbyte.name=airbyte/source-acceptance-test
 
 ENTRYPOINT ["python", "-m", "pytest", "-p", "source_acceptance_test.plugin", "-r", "fEsx"]

--- a/airbyte-integrations/bases/source-acceptance-test/source_acceptance_test/utils/backward_compatibility.py
+++ b/airbyte-integrations/bases/source-acceptance-test/source_acceptance_test/utils/backward_compatibility.py
@@ -227,5 +227,6 @@ class CatalogDiffChecker(BaseDiffChecker):
 
     def check_if_cursor_field_was_changed(self, diff: DeepDiff):
         """Check if a default cursor field value was changed."""
-        if diff:
+        invalid_changes = {"values_changed", "iterable_item_added", "iterable_item_removed"}
+        if diff and set(diff.keys()).issubset(invalid_changes):
             self._raise_error("The value of 'default_cursor_field' was changed", diff)

--- a/airbyte-integrations/bases/source-acceptance-test/source_acceptance_test/utils/backward_compatibility.py
+++ b/airbyte-integrations/bases/source-acceptance-test/source_acceptance_test/utils/backward_compatibility.py
@@ -228,5 +228,5 @@ class CatalogDiffChecker(BaseDiffChecker):
     def check_if_cursor_field_was_changed(self, diff: DeepDiff):
         """Check if a default cursor field value was changed."""
         invalid_changes = {"values_changed", "iterable_item_added", "iterable_item_removed"}
-        if diff and set(diff.keys()).issubset(invalid_changes):
+        if any([change in invalid_changes for change in diff.keys()]):
             self._raise_error("The value of 'default_cursor_field' was changed", diff)

--- a/airbyte-integrations/bases/source-acceptance-test/unit_tests/test_backward_compatibility.py
+++ b/airbyte-integrations/bases/source-acceptance-test/unit_tests/test_backward_compatibility.py
@@ -944,7 +944,7 @@ VALID_SPEC_TRANSITIONS = [
 # Checking that all transitions in FAILING_SPEC_TRANSITIONS have should_fail == True to prevent typos
 assert all([transition.should_fail for transition in FAILING_SPEC_TRANSITIONS])
 # Checking that all transitions in VALID_SPEC_TRANSITIONS have should_fail = False to prevent typos
-assert not any([transition.should_fail for transition in VALID_SPEC_TRANSITIONS])
+assert all([not transition.should_fail for transition in VALID_SPEC_TRANSITIONS])
 
 ALL_SPEC_TRANSITIONS_PARAMS = [transition.as_pytest_param() for transition in FAILING_SPEC_TRANSITIONS + VALID_SPEC_TRANSITIONS]
 
@@ -1103,6 +1103,34 @@ FAILING_CATALOG_TRANSITIONS = [
             ),
         },
     ),
+    Transition(
+        name="Adding a stream but changing cursor should fail.",
+        should_fail=True,
+        previous={
+            "test_stream": AirbyteStream.parse_obj(
+                {
+                    "name": "test_stream",
+                    "json_schema": {"properties": {"user": {"type": "object", "properties": {"username": {"type": "string"}}}}},
+                    "default_cursor_field": ["a"],
+                }
+            ),
+        },
+        current={
+            "test_stream": AirbyteStream.parse_obj(
+                {
+                    "name": "test_stream",
+                    "json_schema": {"properties": {"user": {"type": "object", "properties": {"username": {"type": "string"}}}}},
+                    "default_cursor_field": ["b"],
+                }
+            ),
+            "other_test_stream": AirbyteStream.parse_obj(
+                {
+                    "name": "other_test_stream",
+                    "json_schema": {"properties": {"user": {"type": "object", "properties": {"username": {"type": "string"}}}}},
+                }
+            ),
+        },
+    ),
 ]
 
 VALID_CATALOG_TRANSITIONS = [
@@ -1223,7 +1251,7 @@ VALID_CATALOG_TRANSITIONS = [
 # Checking that all transitions in FAILING_CATALOG_TRANSITIONS have should_fail == True to prevent typos
 assert all([transition.should_fail for transition in FAILING_CATALOG_TRANSITIONS])
 # Checking that all transitions in VALID_CATALOG_TRANSITIONS have should_fail = False to prevent typos
-assert not any([transition.should_fail for transition in VALID_CATALOG_TRANSITIONS])
+assert all([not transition.should_fail for transition in VALID_CATALOG_TRANSITIONS])
 
 ALL_CATALOG_TRANSITIONS_PARAMS = [transition.as_pytest_param() for transition in FAILING_CATALOG_TRANSITIONS + VALID_CATALOG_TRANSITIONS]
 

--- a/airbyte-integrations/bases/source-acceptance-test/unit_tests/test_backward_compatibility.py
+++ b/airbyte-integrations/bases/source-acceptance-test/unit_tests/test_backward_compatibility.py
@@ -944,7 +944,7 @@ VALID_SPEC_TRANSITIONS = [
 # Checking that all transitions in FAILING_SPEC_TRANSITIONS have should_fail == True to prevent typos
 assert all([transition.should_fail for transition in FAILING_SPEC_TRANSITIONS])
 # Checking that all transitions in VALID_SPEC_TRANSITIONS have should_fail = False to prevent typos
-assert not all([transition.should_fail for transition in VALID_SPEC_TRANSITIONS])
+assert not any([transition.should_fail for transition in VALID_SPEC_TRANSITIONS])
 
 ALL_SPEC_TRANSITIONS_PARAMS = [transition.as_pytest_param() for transition in FAILING_SPEC_TRANSITIONS + VALID_SPEC_TRANSITIONS]
 
@@ -1107,6 +1107,32 @@ FAILING_CATALOG_TRANSITIONS = [
 
 VALID_CATALOG_TRANSITIONS = [
     Transition(
+        name="Adding a stream to a catalog should not fail.",
+        should_fail=False,
+        previous={
+            "test_stream": AirbyteStream.parse_obj(
+                {
+                    "name": "test_stream",
+                    "json_schema": {"properties": {"user": {"type": "object", "properties": {"username": {"type": "string"}}}}},
+                }
+            )
+        },
+        current={
+            "test_stream": AirbyteStream.parse_obj(
+                {
+                    "name": "test_stream",
+                    "json_schema": {"properties": {"user": {"type": "object", "properties": {"username": {"type": "string"}}}}},
+                }
+            ),
+            "other_test_stream": AirbyteStream.parse_obj(
+                {
+                    "name": "other_test_stream",
+                    "json_schema": {"properties": {"user": {"type": "object", "properties": {"username": {"type": "string"}}}}},
+                }
+            ),
+        },
+    ),
+    Transition(
         name="Making a field nullable should not fail.",
         should_fail=False,
         previous={
@@ -1197,7 +1223,7 @@ VALID_CATALOG_TRANSITIONS = [
 # Checking that all transitions in FAILING_CATALOG_TRANSITIONS have should_fail == True to prevent typos
 assert all([transition.should_fail for transition in FAILING_CATALOG_TRANSITIONS])
 # Checking that all transitions in VALID_CATALOG_TRANSITIONS have should_fail = False to prevent typos
-assert not all([transition.should_fail for transition in VALID_CATALOG_TRANSITIONS])
+assert not any([transition.should_fail for transition in VALID_CATALOG_TRANSITIONS])
 
 ALL_CATALOG_TRANSITIONS_PARAMS = [transition.as_pytest_param() for transition in FAILING_CATALOG_TRANSITIONS + VALID_CATALOG_TRANSITIONS]
 


### PR DESCRIPTION
## What
Closing https://github.com/airbytehq/airbyte/issues/15692

The current [implementation](https://github.com/airbytehq/airbyte/blob/master/airbyte-integrations/bases/source-acceptance-test/source_acceptance_test/utils/backward_compatibility.py#L228-L232) of `check_if_cursor_field_was_changed` is too strict: it fails if a new stream is added to the catalog:.

## How
* Add a test case to make sure adding a stream to a catalog does not fail
* Explicitly fail if a diff exists for specific changes:
https://github.com/airbytehq/airbyte/blob/26a4e1931b66761ad553300d9b1ff641835dda2b/airbyte-integrations/bases/source-acceptance-test/source_acceptance_test/utils/backward_compatibility.py#L228-L232

## Recommended reading order
1. [`test_backward_compatibility.py`](https://github.com/airbytehq/airbyte/blob/26a4e1931b66761ad553300d9b1ff641835dda2b/airbyte-integrations/bases/source-acceptance-test/unit_tests/test_backward_compatibility.py#L1109-L1134)
2. [`backward_compatibility.py`](https://github.com/airbytehq/airbyte/blob/26a4e1931b66761ad553300d9b1ff641835dda2b/airbyte-integrations/bases/source-acceptance-test/source_acceptance_test/utils/backward_compatibility.py#L228-L232)

## 🚨 User Impact 🚨
PRs adding new streams to a connector catalog should have their acceptance test pass now.
