### PR TITLE
Update outdated default version of Airbyte's docker image

### DIFF
--- a/.env
+++ b/.env
@@ -10,7 +10,7 @@
 
 
 ### SHARED ###
-VERSION=0.40.0
+VERSION=0.40.0-alpha
 
 # When using the airbyte-db via default docker image
 CONFIG_ROOT=/data


### PR DESCRIPTION
## What
<img width="705" alt="Screenshot 2022-08-22 at 12 43 28 PM" src="https://user-images.githubusercontent.com/12984659/186005858-d1f09caa-0a60-4769-bb95-8c8a2f4a0608.png">
The command `docker-compose up`, for getting started with the project, didn't work because the default version of Airbyte's docker image doesn't exist (0.40.0 doesn't exist, but 0.40.0-alpha exists)

## How
*Describe the solution*
Updating the default version to a version that exists e.g. 0.40.0-alpha
<img width="707" alt="Screenshot 2022-08-22 at 12 58 05 PM" src="https://user-images.githubusercontent.com/12984659/186007886-f32cdb5a-8345-4a68-97c7-465fe268875a.png">


## 🚨 User Impact 🚨
Making it easier for others to get started with Airbyte open source version without facing any errors