### PR TITLE
Add `airbyte/cron` docker image to publish script

### DIFF
--- a/tools/bin/publish_docker.sh
+++ b/tools/bin/publish_docker.sh
@@ -44,6 +44,9 @@ for workdir in "${projectDir[@]}"
         ;;
     esac
 
+    echo "Publishing airbyte/$artifactName..."
+    sleep 1
+
     docker buildx create --use --name $artifactName &&      \
     docker buildx build -t "airbyte/$artifactName:$VERSION" \
       --platform linux/amd64,linux/arm64                    \

--- a/tools/bin/publish_docker.sh
+++ b/tools/bin/publish_docker.sh
@@ -2,9 +2,10 @@
 set -e
 
 # List of directories without "airbyte-" prefix.
-projectDir=( 
+projectDir=(
   "workers"
   "cli"
+  "cron"
   "webapp"
   "server"
   "temporal"
@@ -22,7 +23,7 @@ ALPINE_IMAGE=${ALPINE_IMAGE:-alpine:3.14}
 POSTGRES_IMAGE=${POSTGRES_IMAGE:-postgres:13-alpine}
 
 # Iterate over all directories in list to build one by one.
-# metrics-reporter are exception due to wrong artifact naming 
+# metrics-reporter are exception due to wrong artifact naming
 for workdir in "${projectDir[@]}"
   do
     case $workdir in


### PR DESCRIPTION
As part of this PR, I manually published the missing docker image via:

```bash
SUB_BUILD=PLATFORM ./gradlew build -x test
# Comment all lines except for `cron` out in `tools/bin/publish_docker.sh`
./tools/bin/publish_docker.sh
```