### PR TITLE
Remove "prerelease" label from Github versions

### DIFF
--- a/.github/workflows/create-release.yml
+++ b/.github/workflows/create-release.yml
@@ -67,5 +67,4 @@ jobs:
         with:
           body: ${{ env.CHANGELOG }}
           token: ${{ secrets.GITHUB_TOKEN }}
-          prerelease: true
           tag: v${{ steps.get_version.outputs.VERSION }}


### PR DESCRIPTION
Following the removal of our `-alpha` version names, we should also remove the "prerelease" label on our Github versions.

![Screen Shot 2022-08-22 at 4 11 25 PM](https://user-images.githubusercontent.com/303226/186034832-a8bf4cf9-eeab-43e1-ba3a-02b0a2eb4327.png)

