### PR TITLE
Source file: fix csv schema discovery

### DIFF
--- a/airbyte-config/init/src/main/resources/seed/source_definitions.yaml
+++ b/airbyte-config/init/src/main/resources/seed/source_definitions.yaml
@@ -279,7 +279,7 @@
 - name: File
   sourceDefinitionId: 778daa7c-feaf-4db6-96f3-70fd645acc77
   dockerRepository: airbyte/source-file
-  dockerImageTag: 0.2.19
+  dockerImageTag: 0.2.20
   documentationUrl: https://docs.airbyte.io/integrations/sources/file
   icon: file.svg
   sourceType: file

--- a/airbyte-config/init/src/main/resources/seed/source_specs.yaml
+++ b/airbyte-config/init/src/main/resources/seed/source_specs.yaml
@@ -2291,7 +2291,7 @@
     supportsNormalization: false
     supportsDBT: false
     supported_destination_sync_modes: []
-- dockerImage: "airbyte/source-file:0.2.19"
+- dockerImage: "airbyte/source-file:0.2.20"
   spec:
     documentationUrl: "https://docs.airbyte.io/integrations/sources/file"
     connectionSpecification:

--- a/airbyte-integrations/connectors/source-file/Dockerfile
+++ b/airbyte-integrations/connectors/source-file/Dockerfile
@@ -17,5 +17,5 @@ COPY source_file ./source_file
 ENV AIRBYTE_ENTRYPOINT "python /airbyte/integration_code/main.py"
 ENTRYPOINT ["python", "/airbyte/integration_code/main.py"]
 
-LABEL io.airbyte.version=0.2.19
+LABEL io.airbyte.version=0.2.20
 LABEL io.airbyte.name=airbyte/source-file

--- a/airbyte-integrations/connectors/source-file/integration_tests/file_formats_test.py
+++ b/airbyte-integrations/connectors/source-file/integration_tests/file_formats_test.py
@@ -9,6 +9,7 @@ import pytest
 from airbyte_cdk import AirbyteLogger
 from source_file import SourceFile
 from source_file.client import Client
+from unittest.mock import patch
 
 SAMPLE_DIRECTORY = Path(__file__).resolve().parent.joinpath("sample_files/formats")
 
@@ -56,3 +57,29 @@ def run_load_nested_json_schema(config, expected_columns=10, expected_rows=42):
     df = data_list[0]
     assert len(df) == expected_rows  # DataFrame should have 42 items
     return df
+
+
+# https://github.com/airbytehq/alpha-beta-issues/issues/174
+# this is to ensure we make all conditions under which the bug is reproduced, i.e.
+# - chunk size < file size
+# - column type in the last chunk is not `string`
+@patch("source_file.client.Client.CSV_CHUNK_SIZE", 1)
+def test_csv_schema():
+    source = SourceFile()
+    file_path = str(SAMPLE_DIRECTORY.parent.joinpath("discover.csv"))
+    config = {"dataset_name": "test", "format": "csv", "url": file_path, "provider": {"storage": "local"}}
+    catalog = source.discover(logger=AirbyteLogger(), config=config).dict()
+    assert len(catalog["streams"]) == 1
+    schema = catalog["streams"][0]["json_schema"]
+    assert schema == {
+        "$schema": "http://json-schema.org/draft-07/schema#",
+        "properties": {
+            "Address": {"type": ["string", "null"]},
+            "City": {"type": ["string", "null"]},
+            "First Name": {"type": ["string", "null"]},
+            "Last Name": {"type": ["string", "null"]},
+            "State": {"type": ["string", "null"]},
+            "zip_code": {"type": ["string", "null"]}
+        },
+        "type": "object"
+    }

--- a/airbyte-integrations/connectors/source-file/integration_tests/file_formats_test.py
+++ b/airbyte-integrations/connectors/source-file/integration_tests/file_formats_test.py
@@ -4,12 +4,12 @@
 
 
 from pathlib import Path
+from unittest.mock import patch
 
 import pytest
 from airbyte_cdk import AirbyteLogger
 from source_file import SourceFile
 from source_file.client import Client
-from unittest.mock import patch
 
 SAMPLE_DIRECTORY = Path(__file__).resolve().parent.joinpath("sample_files/formats")
 
@@ -79,7 +79,7 @@ def test_csv_schema():
             "First Name": {"type": ["string", "null"]},
             "Last Name": {"type": ["string", "null"]},
             "State": {"type": ["string", "null"]},
-            "zip_code": {"type": ["string", "null"]}
+            "zip_code": {"type": ["string", "null"]},
         },
-        "type": "object"
+        "type": "object",
     }

--- a/airbyte-integrations/connectors/source-file/integration_tests/sample_files/discover.csv
+++ b/airbyte-integrations/connectors/source-file/integration_tests/sample_files/discover.csv
@@ -1,0 +1,7 @@
+First Name,Last Name,Address,City,State,zip_code
+John,Doe,120 jefferson st.,Riverside, NJ,8075
+Jack,McGinnis,220 hobo Av.,Phila, PA,9119
+"John ""Da Man""",Repici,120 Jefferson St.,Riverside, NJ,8075
+Stephen,Tyler,"7452 Terrace ""At the Plaza"" road",SomeTown,SD,91234
+,Blankman,,SomeTown, SD,unknown
+"Joan ""the bone"", Anne",Jet,"9th, at Terrace plc",Desert City,CO,3333

--- a/docs/integrations/sources/file.md
+++ b/docs/integrations/sources/file.md
@@ -127,6 +127,7 @@ In order to read large files from a remote location, this connector uses the [sm
 
 | Version | Date       | Pull Request                                             | Subject                                           |
 |---------|------------|----------------------------------------------------------|---------------------------------------------------|
+| 0.2.20  | 2022-08-23 | [00000](https://github.com/airbytehq/airbyte/pull/00000) | Fix CSV schema discovery                          |
 | 0.2.19  | 2022-08-19 | [15768](https://github.com/airbytehq/airbyte/pull/15768) | Convert 'nan' to 'null'                           |
 | 0.2.18  | 2022-08-16 | [15698](https://github.com/airbytehq/airbyte/pull/15698) | Cache binary stream to file for discover          |
 | 0.2.17  | 2022-08-11 | [15501](https://github.com/airbytehq/airbyte/pull/15501) | Cache binary stream to file                       |

--- a/docs/integrations/sources/file.md
+++ b/docs/integrations/sources/file.md
@@ -127,7 +127,7 @@ In order to read large files from a remote location, this connector uses the [sm
 
 | Version | Date       | Pull Request                                             | Subject                                           |
 |---------|------------|----------------------------------------------------------|---------------------------------------------------|
-| 0.2.20  | 2022-08-23 | [00000](https://github.com/airbytehq/airbyte/pull/00000) | Fix CSV schema discovery                          |
+| 0.2.20  | 2022-08-23 | [15870](https://github.com/airbytehq/airbyte/pull/15870) | Fix CSV schema discovery                          |
 | 0.2.19  | 2022-08-19 | [15768](https://github.com/airbytehq/airbyte/pull/15768) | Convert 'nan' to 'null'                           |
 | 0.2.18  | 2022-08-16 | [15698](https://github.com/airbytehq/airbyte/pull/15698) | Cache binary stream to file for discover          |
 | 0.2.17  | 2022-08-11 | [15501](https://github.com/airbytehq/airbyte/pull/15501) | Cache binary stream to file                       |


### PR DESCRIPTION
## What
https://github.com/airbytehq/alpha-beta-issues/issues/174
When trying to discover the schema of a csv file, the connector iterates over dataframes and maps columns to its types. The problem is the type is overwritten every iteration, so the final schema is equivalent to the last dataframe types

## How
Do not ignore dataframes. Do not narrow data types, make them only wider