### PR TITLE
Bump airbyte/cron image from 0.40.1-alpha to 0.40.1

### DIFF
--- a/kube/overlays/stable-with-resource-limits/kustomization.yaml
+++ b/kube/overlays/stable-with-resource-limits/kustomization.yaml
@@ -20,7 +20,7 @@ images:
   - name: temporalio/auto-setup
     newTag: 1.7.0
   - name: airbyte/cron
-    newTag: 0.40.1-alpha
+    newTag: 0.40.1
 
 configMapGenerator:
   - name: airbyte-env

--- a/kube/overlays/stable/kustomization.yaml
+++ b/kube/overlays/stable/kustomization.yaml
@@ -20,7 +20,7 @@ images:
   - name: temporalio/auto-setup
     newTag: 1.7.0
   - name: airbyte/cron
-    newTag: 0.40.1-alpha
+    newTag: 0.40.1
 
 configMapGenerator:
   - name: airbyte-env


### PR DESCRIPTION
Replaces https://github.com/airbytehq/airbyte/pull/15876
After https://github.com/airbytehq/airbyte/pull/15766 the kustomize files were not properly updated.  They should be going forward on the next version bump.