### PR TITLE
Multi-Cloud MVP: New Configs

### DIFF
--- a/airbyte-config/config-models/src/main/java/io/airbyte/config/Configs.java
+++ b/airbyte-config/config-models/src/main/java/io/airbyte/config/Configs.java
@@ -246,16 +246,6 @@ public interface Configs {
   int getAirbyteApiPort();
 
   /**
-   * Define the header name used to authenticate with the Airbyte API
-   */
-  String getAirbyteApiAuthHeaderName();
-
-  /**
-   * Define the header value used to authenticate with the Airbyte API
-   */
-  String getAirbyteApiAuthHeaderValue();
-
-  /**
    * Define the url the Airbyte Webapp is hosted at. Airbyte services use this information.
    */
   String getWebappUrl();
@@ -528,6 +518,16 @@ public interface Configs {
   // Worker
 
   /**
+   * Define the header name used to authenticate from an Airbyte Worker to the Airbyte API
+   */
+  String getAirbyteApiAuthHeaderName();
+
+  /**
+   * Define the header value used to authenticate from an Airbyte Worker to the Airbyte API
+   */
+  String getAirbyteApiAuthHeaderValue();
+
+  /**
    * Define the maximum number of workers each Airbyte Worker container supports. Multiple variables
    * are involved here. Please see {@link MaxWorkersConfig} for more info.
    */
@@ -560,48 +560,37 @@ public interface Configs {
   boolean shouldRunConnectionManagerWorkflows();
 
   /**
-   * Define if the worker is operating as a Control Plane worker, a Data Plane worker, or as a
-   * combined worker. - Control plane workers process tasks related to control-flow, like scheduling
-   * and routing. - Data plane workers process tasks related to data syncing, and are typically
-   * deployed outside of Airbyte's internal network. - Combined workers process all tasks, and are the
-   * default for OSS deployments. - Internal-use only.
+   * Define if the worker is operating within Airbyte's Control Plane, or within an external Data
+   * Plane. - Workers in the Control Plane process tasks related to control-flow, like scheduling and
+   * routing, as well as data syncing tasks that are enqueued for the Control Plane's default task
+   * queue. - Workers in a Data Plane process only tasks related to data syncing that are specifically
+   * enqueued for that worker's particular Data Plane.
    */
   WorkerPlane getWorkerPlane();
 
   // Worker - Control Plane configs
 
   /**
-   * Return true if the WorkerPlane is CONTROL_PLANE or COMBINED. Derived from the result of
-   * {@link Configs#getWorkerPlane()}. Internal-use only.
-   */
-  boolean isControlPlaneWorker();
-
-  /**
-   * TEMPORARY: Define a set of connection IDs that should run in Airbyte's AWS Data Plane. - This
+   * TEMPORARY: Define a set of connection IDs that should run in Airbyte's MVP Data Plane. - This
    * should only be set on Control-plane workers, since those workers decide which Data Plane task
    * queue to use based on connectionId. - Will be removed in favor of the Routing Service in the
    * future. Internal-use only.
    */
-  Set<String> connectionIdsForDataPlane();
+  Set<String> connectionIdsForMvpDataPlane();
 
   // Worker - Data Plane configs
 
   /**
-   * Return true if the WorkerPlane is DATA_PLANE or COMBINED. Derived from the result of
-   * {@link Configs#getWorkerPlane()}. Internal-use only.
+   * Define a set of Temporal Task Queue names for which the worker should register handlers for to
+   * process tasks related to syncing data. - For workers within Airbyte's Control Plane, this returns
+   * the Control Plane's default task queue. - For workers within a Data Plane, this returns only task
+   * queue names specific to that Data Plane. Internal-use only.
    */
-  boolean isDataPlaneWorker();
+  Set<String> getDataSyncTaskQueues();
 
   /**
-   * Define a set of Temporal Task Queue names for which the Data Plane worker should register
-   * handlers for. Entries should correspond with the Data Plane where the worker is deployed.
-   * Internal-use only.
-   */
-  Set<String> getDataPlaneTaskQueues();
-
-  /**
-   * Return the control plane endpoint a data plane will hit for authentication. This is separate from
-   * the actual endpoint being hit for application logic. Internal-use only.
+   * Return the Control Plane endpoint that workers in a Data Plane will hit for authentication. This
+   * is separate from the actual endpoint being hit for application logic. Internal-use only.
    */
   String getControlPlaneAuthEndpoint();
 

--- a/airbyte-config/config-models/src/main/java/io/airbyte/config/Configs.java
+++ b/airbyte-config/config-models/src/main/java/io/airbyte/config/Configs.java
@@ -30,6 +30,7 @@ public interface Configs {
 
   // CORE
   // General
+
   /**
    * Distinguishes internal Airbyte deployments. Internal-use only.
    */
@@ -71,6 +72,7 @@ public interface Configs {
   Path getWorkspaceRoot();
 
   // Docker Only
+
   /**
    * Defines the name of the Airbyte docker volume.
    */
@@ -90,6 +92,7 @@ public interface Configs {
   Path getLocalRoot();
 
   // Secrets
+
   /**
    * Defines the GCP Project to store secrets in. Alpha support.
    */
@@ -126,6 +129,7 @@ public interface Configs {
   String getVaultToken();
 
   // Database
+
   /**
    * Define the Jobs Database user.
    */
@@ -242,11 +246,22 @@ public interface Configs {
   int getAirbyteApiPort();
 
   /**
+   * Define the header name used to authenticate with the Airbyte API
+   */
+  String getAirbyteApiAuthHeaderName();
+
+  /**
+   * Define the header value used to authenticate with the Airbyte API
+   */
+  String getAirbyteApiAuthHeaderValue();
+
+  /**
    * Define the url the Airbyte Webapp is hosted at. Airbyte services use this information.
    */
   String getWebappUrl();
 
   // Jobs
+
   /**
    * Define the number of attempts a sync will attempt before failing.
    */
@@ -319,6 +334,7 @@ public interface Configs {
   int getMaxDaysOfOnlyFailedJobsBeforeConnectionDisable();
 
   // Jobs - Kube only
+
   /**
    * Define the check job container's minimum CPU request. Defaults to
    * {@link #getJobMainContainerCpuRequest()} if not set. Internal-use only.
@@ -451,6 +467,7 @@ public interface Configs {
   String getJobKubeNamespace();
 
   // Logging/Monitoring/Tracking
+
   /**
    * Define either S3, Minio or GCS as a logging backend. Kubernetes only. Multiple variables are
    * involved here. Please see {@link CloudStorageConfigs} for more info.
@@ -509,6 +526,7 @@ public interface Configs {
 
   // APPLICATIONS
   // Worker
+
   /**
    * Define the maximum number of workers each Airbyte Worker container supports. Multiple variables
    * are involved here. Please see {@link MaxWorkersConfig} for more info.
@@ -541,13 +559,73 @@ public interface Configs {
    */
   boolean shouldRunConnectionManagerWorkflows();
 
+  /**
+   * Define if the worker is operating as a Control Plane worker, a Data Plane worker, or as a
+   * combined worker. - Control plane workers process tasks related to control-flow, like scheduling
+   * and routing. - Data plane workers process tasks related to data syncing, and are typically
+   * deployed outside of Airbyte's internal network. - Combined workers process all tasks, and are the
+   * default for OSS deployments. - Internal-use only.
+   */
+  WorkerPlane getWorkerPlane();
+
+  // Worker - Control Plane configs
+
+  /**
+   * Return true if the WorkerPlane is CONTROL_PLANE or COMBINED. Derived from the result of
+   * {@link Configs#getWorkerPlane()}. Internal-use only.
+   */
+  boolean isControlPlaneWorker();
+
+  /**
+   * TEMPORARY: Define a set of connection IDs that should run in Airbyte's AWS Data Plane. - This
+   * should only be set on Control-plane workers, since those workers decide which Data Plane task
+   * queue to use based on connectionId. - Will be removed in favor of the Routing Service in the
+   * future. Internal-use only.
+   */
+  Set<String> connectionIdsForDataPlane();
+
+  // Worker - Data Plane configs
+
+  /**
+   * Return true if the WorkerPlane is DATA_PLANE or COMBINED. Derived from the result of
+   * {@link Configs#getWorkerPlane()}. Internal-use only.
+   */
+  boolean isDataPlaneWorker();
+
+  /**
+   * Define a set of Temporal Task Queue names for which the Data Plane worker should register
+   * handlers for. Entries should correspond with the Data Plane where the worker is deployed.
+   * Internal-use only.
+   */
+  Set<String> getDataPlaneTaskQueues();
+
+  /**
+   * Return the control plane endpoint a data plane will hit for authentication. This is separate from
+   * the actual endpoint being hit for application logic. Internal-use only.
+   */
+  String getControlPlaneAuthEndpoint();
+
+  /**
+   * Return the service account a data plane uses to authenticate with a control plane. Internal-use
+   * only.
+   */
+  String getDataPlaneServiceAccountCredentialsPath();
+
+  /**
+   * Return the service account email a data plane uses to authenticate with a control plane.
+   * Internal-use only.
+   */
+  String getDataPlaneServiceAccountEmail();
+
   // Worker - Kube only
+
   /**
    * Define the local ports the Airbyte Worker pod uses to connect to the various Job pods.
    */
   Set<Integer> getTemporalWorkerPorts();
 
   // Container Orchestrator
+
   /**
    * Define if Airbyte should use the container orchestrator. Internal-use only.
    */
@@ -639,6 +717,12 @@ public interface Configs {
     TESTING_CONFIG_DB_TABLE,
     GOOGLE_SECRET_MANAGER,
     VAULT
+  }
+
+  enum WorkerPlane {
+    CONTROL_PLANE,
+    DATA_PLANE,
+    COMBINED
   }
 
 }

--- a/airbyte-config/config-models/src/main/java/io/airbyte/config/Configs.java
+++ b/airbyte-config/config-models/src/main/java/io/airbyte/config/Configs.java
@@ -710,8 +710,7 @@ public interface Configs {
 
   enum WorkerPlane {
     CONTROL_PLANE,
-    DATA_PLANE,
-    COMBINED
+    DATA_PLANE
   }
 
 }

--- a/airbyte-config/config-models/src/main/java/io/airbyte/config/EnvConfigs.java
+++ b/airbyte-config/config-models/src/main/java/io/airbyte/config/EnvConfigs.java
@@ -41,6 +41,8 @@ public class EnvConfigs implements Configs {
   public static final String AIRBYTE_ROLE = "AIRBYTE_ROLE";
   public static final String AIRBYTE_VERSION = "AIRBYTE_VERSION";
   public static final String INTERNAL_API_HOST = "INTERNAL_API_HOST";
+  public static final String AIRBYTE_API_AUTH_HEADER_NAME = "AIRBYTE_API_AUTH_HEADER_NAME";
+  public static final String AIRBYTE_API_AUTH_HEADER_VALUE = "AIRBYTE_API_AUTH_HEADER_VALUE";
   public static final String WORKER_ENVIRONMENT = "WORKER_ENVIRONMENT";
   public static final String SPEC_CACHE_BUCKET = "SPEC_CACHE_BUCKET";
   public static final String WORKSPACE_ROOT = "WORKSPACE_ROOT";
@@ -128,6 +130,17 @@ public class EnvConfigs implements Configs {
   private static final String SHOULD_RUN_DISCOVER_WORKFLOWS = "SHOULD_RUN_DISCOVER_WORKFLOWS";
   private static final String SHOULD_RUN_SYNC_WORKFLOWS = "SHOULD_RUN_SYNC_WORKFLOWS";
   private static final String SHOULD_RUN_CONNECTION_MANAGER_WORKFLOWS = "SHOULD_RUN_CONNECTION_MANAGER_WORKFLOWS";
+  private static final String WORKER_PLANE = "WORKER_PLANE";
+
+  // Worker - Control plane configs
+  private static final String DEFAULT_DATA_PLANE_TASK_QUEUES = "SYNC"; // should match TemporalJobType.SYNC.name()
+  private static final String CONNECTION_IDS_FOR_AWS_DATA_PLANE = "CONNECTION_IDS_FOR_AWS_DATA_PLANE";
+
+  // Worker - Data Plane configs
+  private static final String DATA_PLANE_TASK_QUEUES = "DATA_PLANE_TASK_QUEUES";
+  private static final String CONTROL_PLANE_AUTH_ENDPOINT = "CONTROL_PLANE_AUTH_ENDPOINT";
+  private static final String DATA_PLANE_SERVICE_ACCOUNT_CREDENTIALS_PATH = "DATA_PLANE_SERVICE_ACCOUNT_CREDENTIALS_PATH";
+  private static final String DATA_PLANE_SERVICE_ACCOUNT_EMAIL = "DATA_PLANE_SERVICE_ACCOUNT_EMAIL";
 
   private static final String MAX_FAILED_JOBS_IN_A_ROW_BEFORE_CONNECTION_DISABLE = "MAX_FAILED_JOBS_IN_A_ROW_BEFORE_CONNECTION_DISABLE";
   private static final String MAX_DAYS_OF_ONLY_FAILED_JOBS_BEFORE_CONNECTION_DISABLE = "MAX_DAYS_OF_ONLY_FAILED_JOBS_BEFORE_CONNECTION_DISABLE";
@@ -158,9 +171,13 @@ public class EnvConfigs implements Configs {
   static final String NORMALIZATION_JOB_MAIN_CONTAINER_MEMORY_REQUEST = "NORMALIZATION_JOB_MAIN_CONTAINER_MEMORY_REQUEST";
   static final String NORMALIZATION_JOB_MAIN_CONTAINER_MEMORY_LIMIT = "NORMALIZATION_JOB_MAIN_CONTAINER_MEMORY_LIMIT";
 
+  private static final String VAULT_ADDRESS = "VAULT_ADDRESS";
+  private static final String VAULT_PREFIX = "VAULT_PREFIX";
+  private static final String VAULT_AUTH_TOKEN = "VAULT_AUTH_TOKEN";
+
   // defaults
   private static final String DEFAULT_SPEC_CACHE_BUCKET = "io-airbyte-cloud-spec-cache";
-  public static final String DEFAULT_JOB_KUBE_NAMESPACE = "default";
+  private static final String DEFAULT_JOB_KUBE_NAMESPACE = "default";
   private static final String DEFAULT_JOB_CPU_REQUIREMENT = null;
   private static final String DEFAULT_JOB_MEMORY_REQUIREMENT = null;
   private static final String DEFAULT_JOB_KUBE_MAIN_CONTAINER_IMAGE_PULL_POLICY = "IfNotPresent";
@@ -171,17 +188,11 @@ public class EnvConfigs implements Configs {
   private static final String DEFAULT_JOB_KUBE_BUSYBOX_IMAGE = "busybox:1.28";
   private static final String DEFAULT_JOB_KUBE_CURL_IMAGE = "curlimages/curl:7.83.1";
   private static final int DEFAULT_DATABASE_INITIALIZATION_TIMEOUT_MS = 60 * 1000;
-
-  private static final String VAULT_ADDRESS = "VAULT_ADDRESS";
-  private static final String VAULT_PREFIX = "VAULT_PREFIX";
-  private static final String VAULT_AUTH_TOKEN = "VAULT_AUTH_TOKEN";
-
-  public static final long DEFAULT_MAX_SPEC_WORKERS = 5;
-  public static final long DEFAULT_MAX_CHECK_WORKERS = 5;
-  public static final long DEFAULT_MAX_DISCOVER_WORKERS = 5;
-  public static final long DEFAULT_MAX_SYNC_WORKERS = 5;
-
-  public static final String DEFAULT_NETWORK = "host";
+  private static final long DEFAULT_MAX_SPEC_WORKERS = 5;
+  private static final long DEFAULT_MAX_CHECK_WORKERS = 5;
+  private static final long DEFAULT_MAX_DISCOVER_WORKERS = 5;
+  private static final long DEFAULT_MAX_SYNC_WORKERS = 5;
+  private static final String DEFAULT_NETWORK = "host";
 
   public static final Map<String, Function<EnvConfigs, String>> JOB_SHARED_ENVS = Map.of(
       AIRBYTE_VERSION, (instance) -> instance.getAirbyteVersion().serialize(),
@@ -215,6 +226,8 @@ public class EnvConfigs implements Configs {
     this.getAllEnvKeys = envMap::keySet;
     this.logConfigs = new LogConfigs(getLogConfiguration().orElse(null));
     this.stateStorageCloudConfigs = getStateStorageConfiguration().orElse(null);
+
+    validateSyncWorkflowConfigs();
   }
 
   private Optional<CloudStorageConfigs> getLogConfiguration() {
@@ -467,6 +480,16 @@ public class EnvConfigs implements Configs {
   @Override
   public int getAirbyteApiPort() {
     return Integer.parseInt(getEnsureEnv(INTERNAL_API_HOST).split(":")[1]);
+  }
+
+  @Override
+  public String getAirbyteApiAuthHeaderName() {
+    return getEnvOrDefault(AIRBYTE_API_AUTH_HEADER_NAME, "");
+  }
+
+  @Override
+  public String getAirbyteApiAuthHeaderValue() {
+    return getEnvOrDefault(AIRBYTE_API_AUTH_HEADER_VALUE, "");
   }
 
   @Override
@@ -893,6 +916,74 @@ public class EnvConfigs implements Configs {
   @Override
   public boolean shouldRunConnectionManagerWorkflows() {
     return getEnvOrDefault(SHOULD_RUN_CONNECTION_MANAGER_WORKFLOWS, true);
+  }
+
+  @Override
+  public WorkerPlane getWorkerPlane() {
+    return getEnvOrDefault(WORKER_PLANE, WorkerPlane.COMBINED, s -> WorkerPlane.valueOf(s.toUpperCase()));
+  }
+
+  // Worker - Control plane
+
+  @Override
+  public boolean isControlPlaneWorker() {
+    return getWorkerPlane().equals(WorkerPlane.CONTROL_PLANE) || getWorkerPlane().equals(WorkerPlane.COMBINED);
+  }
+
+  @Override
+  public Set<String> connectionIdsForDataPlane() {
+    final var connectionIds = getEnvOrDefault(CONNECTION_IDS_FOR_AWS_DATA_PLANE, "");
+    if (connectionIds.isEmpty()) {
+      return new HashSet<>();
+    }
+    return Arrays.stream(connectionIds.split(",")).collect(Collectors.toSet());
+  }
+
+  // Worker - Data plane
+
+  @Override
+  public boolean isDataPlaneWorker() {
+    return getWorkerPlane().equals(WorkerPlane.DATA_PLANE) || getWorkerPlane().equals(WorkerPlane.COMBINED);
+  }
+
+  @Override
+  public Set<String> getDataPlaneTaskQueues() {
+    final var taskQueues = getEnvOrDefault(DATA_PLANE_TASK_QUEUES, DEFAULT_DATA_PLANE_TASK_QUEUES);
+    if (taskQueues.isEmpty()) {
+      return new HashSet<>();
+    }
+    return Arrays.stream(taskQueues.split(",")).collect(Collectors.toSet());
+  }
+
+  @Override
+  public String getControlPlaneAuthEndpoint() {
+    return getEnvOrDefault(CONTROL_PLANE_AUTH_ENDPOINT, "");
+  }
+
+  @Override
+  public String getDataPlaneServiceAccountCredentialsPath() {
+    return getEnvOrDefault(DATA_PLANE_SERVICE_ACCOUNT_CREDENTIALS_PATH, "");
+  }
+
+  @Override
+  public String getDataPlaneServiceAccountEmail() {
+    return getEnvOrDefault(DATA_PLANE_SERVICE_ACCOUNT_EMAIL, "");
+  }
+
+  /**
+   * Ensures the user hasn't configured themselves into a corner by making sure that the worker is set
+   * up to properly process sync workflows. With sensible defaults, it should be hard to fail this
+   * validation, but this provides a safety net regardless.
+   */
+  private void validateSyncWorkflowConfigs() {
+    if (shouldRunSyncWorkflows()) {
+      if (!isControlPlaneWorker() && getDataPlaneTaskQueues().isEmpty()) {
+        throw new IllegalArgumentException(String.format(
+            "When %s is true, the worker must either be configured as a Control Plane worker, or %s must be non-empty.",
+            SHOULD_RUN_SYNC_WORKFLOWS,
+            DATA_PLANE_TASK_QUEUES));
+      }
+    }
   }
 
   @Override


### PR DESCRIPTION
## What
Child of giant Multi-Cloud MVP PR here: https://github.com/airbytehq/airbyte/pull/15798, this smaller PR contains just the files changed to add new configs.

## How
Add new EnvConfigs so that Airbyte deployers can configure a worker to operate as a Control Plane worker, a Data Plane worker, or (by default) a Combined worker. 
  - Control Plane workers also have new configs available for specifying where Data Plane tasks should be routed.
  - Data Plane workers have new configs available for authenticating with the Control Plane, and for specifying from which task queue they should poll for work.

