### PR TITLE
Multi-Cloud MVP: Route Task Queue Activity

### DIFF
--- a/airbyte-workers/src/main/java/io/airbyte/workers/temporal/sync/RouteToTaskQueueActivity.java
+++ b/airbyte-workers/src/main/java/io/airbyte/workers/temporal/sync/RouteToTaskQueueActivity.java
@@ -1,0 +1,17 @@
+/*
+ * Copyright (c) 2022 Airbyte, Inc., all rights reserved.
+ */
+
+package io.airbyte.workers.temporal.sync;
+
+import io.temporal.activity.ActivityInterface;
+import io.temporal.activity.ActivityMethod;
+import java.util.UUID;
+
+@ActivityInterface
+public interface RouteToTaskQueueActivity {
+
+  @ActivityMethod
+  String routeToTaskQueue(final UUID connectionId);
+
+}

--- a/airbyte-workers/src/main/java/io/airbyte/workers/temporal/sync/RouteToTaskQueueActivityImpl.java
+++ b/airbyte-workers/src/main/java/io/airbyte/workers/temporal/sync/RouteToTaskQueueActivityImpl.java
@@ -4,27 +4,19 @@
 
 package io.airbyte.workers.temporal.sync;
 
-import io.airbyte.config.Configs;
-import io.airbyte.workers.temporal.TemporalJobType;
 import java.util.UUID;
 
 public class RouteToTaskQueueActivityImpl implements RouteToTaskQueueActivity {
 
-  // To be replaced by proper Routing Service. For now, our MVP supports a single external Data Plane
-  private static final String MVP_DATA_PLANE_TASK_QUEUE = "MVP_DATA_PLANE";
+  private final RouterService routerService;
 
-  private final Configs configs;
-
-  public RouteToTaskQueueActivityImpl(final Configs configs) {
-    this.configs = configs;
+  public RouteToTaskQueueActivityImpl(final RouterService routerService) {
+    this.routerService = routerService;
   }
 
   @Override
   public String routeToTaskQueue(final UUID connectionId) {
-    if (configs.connectionIdsForDataPlane().contains(connectionId.toString())) {
-      return MVP_DATA_PLANE_TASK_QUEUE;
-    }
-    return TemporalJobType.SYNC.name();
+    return routerService.getTaskQueue(connectionId);
   }
 
 }

--- a/airbyte-workers/src/main/java/io/airbyte/workers/temporal/sync/RouteToTaskQueueActivityImpl.java
+++ b/airbyte-workers/src/main/java/io/airbyte/workers/temporal/sync/RouteToTaskQueueActivityImpl.java
@@ -1,0 +1,30 @@
+/*
+ * Copyright (c) 2022 Airbyte, Inc., all rights reserved.
+ */
+
+package io.airbyte.workers.temporal.sync;
+
+import io.airbyte.config.Configs;
+import io.airbyte.workers.temporal.TemporalJobType;
+import java.util.UUID;
+
+public class RouteToTaskQueueActivityImpl implements RouteToTaskQueueActivity {
+
+  // To be replaced by proper Routing Service. For now, our MVP supports a single external Data Plane
+  private static final String MVP_DATA_PLANE_TASK_QUEUE = "MVP_DATA_PLANE";
+
+  private final Configs configs;
+
+  public RouteToTaskQueueActivityImpl(final Configs configs) {
+    this.configs = configs;
+  }
+
+  @Override
+  public String routeToTaskQueue(final UUID connectionId) {
+    if (configs.connectionIdsForDataPlane().contains(connectionId.toString())) {
+      return MVP_DATA_PLANE_TASK_QUEUE;
+    }
+    return TemporalJobType.SYNC.name();
+  }
+
+}

--- a/airbyte-workers/src/main/java/io/airbyte/workers/temporal/sync/RouterService.java
+++ b/airbyte-workers/src/main/java/io/airbyte/workers/temporal/sync/RouterService.java
@@ -1,0 +1,30 @@
+/*
+ * Copyright (c) 2022 Airbyte, Inc., all rights reserved.
+ */
+
+package io.airbyte.workers.temporal.sync;
+
+import io.airbyte.config.Configs;
+import io.airbyte.workers.temporal.TemporalJobType;
+import java.util.UUID;
+import lombok.AllArgsConstructor;
+
+@AllArgsConstructor
+public class RouterService {
+
+  private static final String MVP_DATA_PLANE_TASK_QUEUE = "MVP_DATA_PLANE";
+
+  private final Configs configs;
+
+  /**
+   * For now, returns a Task Queue by checking to see if the connectionId is on the env var list for
+   * usage in the MVP Data Plane. This will be replaced by a proper Router Service in the future.
+   */
+  public String getTaskQueue(final UUID connectionId) {
+    if (configs.connectionIdsForMvpDataPlane().contains(connectionId.toString())) {
+      return MVP_DATA_PLANE_TASK_QUEUE;
+    }
+    return TemporalJobType.SYNC.name();
+  }
+
+}

--- a/airbyte-workers/src/main/java/io/airbyte/workers/temporal/sync/SyncWorkflowImpl.java
+++ b/airbyte-workers/src/main/java/io/airbyte/workers/temporal/sync/SyncWorkflowImpl.java
@@ -18,6 +18,7 @@ import io.airbyte.protocol.models.ConfiguredAirbyteCatalog;
 import io.airbyte.scheduler.models.IntegrationLauncherConfig;
 import io.airbyte.scheduler.models.JobRunConfig;
 import io.airbyte.workers.temporal.scheduling.shared.ActivityConfiguration;
+import io.temporal.activity.ActivityOptions;
 import io.temporal.workflow.Workflow;
 import java.util.UUID;
 import org.slf4j.Logger;
@@ -27,15 +28,8 @@ public class SyncWorkflowImpl implements SyncWorkflow {
 
   private static final Logger LOGGER = LoggerFactory.getLogger(SyncWorkflowImpl.class);
   private static final String VERSION_LABEL = "sync-workflow";
-  private static final int CURRENT_VERSION = 1;
-  private final ReplicationActivity replicationActivity =
-      Workflow.newActivityStub(ReplicationActivity.class, ActivityConfiguration.LONG_RUN_OPTIONS);
-  private final NormalizationActivity normalizationActivity =
-      Workflow.newActivityStub(NormalizationActivity.class, ActivityConfiguration.LONG_RUN_OPTIONS);
-  private final DbtTransformationActivity dbtTransformationActivity =
-      Workflow.newActivityStub(DbtTransformationActivity.class, ActivityConfiguration.LONG_RUN_OPTIONS);
-  private final PersistStateActivity persistActivity =
-      Workflow.newActivityStub(PersistStateActivity.class, ActivityConfiguration.SHORT_ACTIVITY_OPTIONS);
+  private static final int CURRENT_VERSION = 2;
+  private static final int PREV_VERSION = 1;
 
   @Override
   public StandardSyncOutput run(final JobRunConfig jobRunConfig,
@@ -44,8 +38,40 @@ public class SyncWorkflowImpl implements SyncWorkflow {
                                 final StandardSyncInput syncInput,
                                 final UUID connectionId) {
 
-    StandardSyncOutput syncOutput = replicationActivity.replicate(jobRunConfig, sourceLauncherConfig, destinationLauncherConfig, syncInput);
     final int version = Workflow.getVersion(VERSION_LABEL, Workflow.DEFAULT_VERSION, CURRENT_VERSION);
+
+    final ReplicationActivity replicationActivity;
+    final NormalizationActivity normalizationActivity;
+    final DbtTransformationActivity dbtTransformationActivity;
+    final PersistStateActivity persistActivity;
+
+    /**
+     * The current version calls a new activity to determine which Task Queue to use for other
+     * activities. The previous version doesn't call this new activity, and instead lets each activity
+     * inherit the workflow's Task Queue.
+     */
+    if (version > PREV_VERSION) {
+      final RouteToTaskQueueActivity decideTaskQueueActivity =
+          Workflow.newActivityStub(RouteToTaskQueueActivity.class, ActivityConfiguration.SHORT_ACTIVITY_OPTIONS);
+
+      final String dataPlaneTaskQueue = decideTaskQueueActivity.routeToTaskQueue(connectionId);
+
+      replicationActivity =
+          Workflow.newActivityStub(ReplicationActivity.class, setTaskQueue(ActivityConfiguration.LONG_RUN_OPTIONS, dataPlaneTaskQueue));
+      persistActivity =
+          Workflow.newActivityStub(PersistStateActivity.class, setTaskQueue(ActivityConfiguration.SHORT_ACTIVITY_OPTIONS, dataPlaneTaskQueue));
+      normalizationActivity =
+          Workflow.newActivityStub(NormalizationActivity.class, setTaskQueue(ActivityConfiguration.LONG_RUN_OPTIONS, dataPlaneTaskQueue));
+      dbtTransformationActivity =
+          Workflow.newActivityStub(DbtTransformationActivity.class, setTaskQueue(ActivityConfiguration.LONG_RUN_OPTIONS, dataPlaneTaskQueue));
+    } else {
+      replicationActivity = Workflow.newActivityStub(ReplicationActivity.class, ActivityConfiguration.LONG_RUN_OPTIONS);
+      normalizationActivity = Workflow.newActivityStub(NormalizationActivity.class, ActivityConfiguration.LONG_RUN_OPTIONS);
+      dbtTransformationActivity = Workflow.newActivityStub(DbtTransformationActivity.class, ActivityConfiguration.LONG_RUN_OPTIONS);
+      persistActivity = Workflow.newActivityStub(PersistStateActivity.class, ActivityConfiguration.SHORT_ACTIVITY_OPTIONS);
+    }
+
+    StandardSyncOutput syncOutput = replicationActivity.replicate(jobRunConfig, sourceLauncherConfig, destinationLauncherConfig, syncInput);
 
     if (version > Workflow.DEFAULT_VERSION) {
       // the state is persisted immediately after the replication succeeded, because the
@@ -60,6 +86,7 @@ public class SyncWorkflowImpl implements SyncWorkflow {
         if (standardSyncOperation.getOperatorType() == OperatorType.NORMALIZATION) {
           final Configs configs = new EnvConfigs();
           final NormalizationInput normalizationInput = generateNormalizationInput(syncInput, syncOutput, configs);
+
           final NormalizationSummary normalizationSummary =
               normalizationActivity.normalize(jobRunConfig, destinationLauncherConfig, normalizationInput);
           syncOutput = syncOutput.withNormalizationSummary(normalizationSummary);
@@ -93,6 +120,10 @@ public class SyncWorkflowImpl implements SyncWorkflow {
         .withDestinationConfiguration(syncInput.getDestinationConfiguration())
         .withCatalog(syncOutput.getOutputCatalog())
         .withResourceRequirements(resourceReqs);
+  }
+
+  private ActivityOptions setTaskQueue(final ActivityOptions activityOptions, final String taskQueue) {
+    return ActivityOptions.newBuilder(activityOptions).setTaskQueue(taskQueue).build();
   }
 
 }

--- a/airbyte-workers/src/main/java/io/airbyte/workers/temporal/sync/SyncWorkflowImpl.java
+++ b/airbyte-workers/src/main/java/io/airbyte/workers/temporal/sync/SyncWorkflowImpl.java
@@ -51,10 +51,10 @@ public class SyncWorkflowImpl implements SyncWorkflow {
      * inherit the workflow's Task Queue.
      */
     if (version > PREV_VERSION) {
-      final RouteToTaskQueueActivity decideTaskQueueActivity =
+      final RouteToTaskQueueActivity routeToTaskQueueActivity =
           Workflow.newActivityStub(RouteToTaskQueueActivity.class, ActivityConfiguration.SHORT_ACTIVITY_OPTIONS);
 
-      final String dataPlaneTaskQueue = decideTaskQueueActivity.routeToTaskQueue(connectionId);
+      final String dataPlaneTaskQueue = routeToTaskQueueActivity.routeToTaskQueue(connectionId);
 
       replicationActivity =
           Workflow.newActivityStub(ReplicationActivity.class, setTaskQueue(ActivityConfiguration.LONG_RUN_OPTIONS, dataPlaneTaskQueue));

--- a/airbyte-workers/src/test/java/io/airbyte/workers/temporal/SyncWorkflowTest.java
+++ b/airbyte-workers/src/test/java/io/airbyte/workers/temporal/SyncWorkflowTest.java
@@ -32,6 +32,8 @@ import io.airbyte.workers.temporal.sync.PersistStateActivity;
 import io.airbyte.workers.temporal.sync.PersistStateActivityImpl;
 import io.airbyte.workers.temporal.sync.ReplicationActivity;
 import io.airbyte.workers.temporal.sync.ReplicationActivityImpl;
+import io.airbyte.workers.temporal.sync.RouteToTaskQueueActivity;
+import io.airbyte.workers.temporal.sync.RouteToTaskQueueActivityImpl;
 import io.airbyte.workers.temporal.sync.SyncWorkflow;
 import io.airbyte.workers.temporal.sync.SyncWorkflowImpl;
 import io.temporal.api.common.v1.WorkflowExecution;
@@ -42,6 +44,7 @@ import io.temporal.client.WorkflowFailedException;
 import io.temporal.client.WorkflowOptions;
 import io.temporal.testing.TestWorkflowEnvironment;
 import io.temporal.worker.Worker;
+import java.util.UUID;
 import org.apache.commons.lang3.tuple.ImmutablePair;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
@@ -52,12 +55,16 @@ class SyncWorkflowTest {
   // TEMPORAL
 
   private TestWorkflowEnvironment testEnv;
-  private Worker syncWorker;
+  private Worker syncControlPlaneWorker;
+  private Worker syncDataPlaneWorker;
   private WorkflowClient client;
   private ReplicationActivityImpl replicationActivity;
   private NormalizationActivityImpl normalizationActivity;
   private DbtTransformationActivityImpl dbtTransformationActivity;
   private PersistStateActivityImpl persistStateActivity;
+  private RouteToTaskQueueActivityImpl routeToTaskQueueActivity;
+
+  private static final String DATA_PLANE_TASK_QUEUE = "SYNC_DATA_PLANE";
 
   // AIRBYTE CONFIGURATION
   private static final long JOB_ID = 11L;
@@ -87,8 +94,10 @@ class SyncWorkflowTest {
   @BeforeEach
   public void setUp() {
     testEnv = TestWorkflowEnvironment.newInstance();
-    syncWorker = testEnv.newWorker(TemporalJobType.SYNC.name());
-    syncWorker.registerWorkflowImplementationTypes(SyncWorkflowImpl.class);
+    syncControlPlaneWorker = testEnv.newWorker(TemporalJobType.SYNC.name());
+    syncControlPlaneWorker.registerWorkflowImplementationTypes(SyncWorkflowImpl.class);
+
+    syncDataPlaneWorker = testEnv.newWorker(DATA_PLANE_TASK_QUEUE);
 
     client = testEnv.getWorkflowClient();
 
@@ -111,11 +120,15 @@ class SyncWorkflowTest {
     normalizationActivity = mock(NormalizationActivityImpl.class);
     dbtTransformationActivity = mock(DbtTransformationActivityImpl.class);
     persistStateActivity = mock(PersistStateActivityImpl.class);
+    routeToTaskQueueActivity = mock(RouteToTaskQueueActivityImpl.class);
+    doReturn(DATA_PLANE_TASK_QUEUE).when(routeToTaskQueueActivity).routeToTaskQueue(sync.getConnectionId());
   }
 
   // bundle up all the temporal worker setup / execution into one method.
   private StandardSyncOutput execute() {
-    syncWorker.registerActivitiesImplementations(replicationActivity, normalizationActivity, dbtTransformationActivity, persistStateActivity);
+    syncControlPlaneWorker.registerActivitiesImplementations(routeToTaskQueueActivity);
+    syncDataPlaneWorker.registerActivitiesImplementations(replicationActivity, normalizationActivity, dbtTransformationActivity,
+        persistStateActivity);
     testEnv.start();
     final SyncWorkflow workflow =
         client.newWorkflowStub(SyncWorkflow.class, WorkflowOptions.newBuilder().setTaskQueue(TemporalJobType.SYNC.name()).build());
@@ -138,6 +151,7 @@ class SyncWorkflowTest {
 
     final StandardSyncOutput actualOutput = execute();
 
+    verifyRouteToTaskQueue(routeToTaskQueueActivity, sync.getConnectionId());
     verifyReplication(replicationActivity, syncInput);
     verifyPersistState(persistStateActivity, sync, replicationSuccessOutput, syncInput.getCatalog());
     verifyNormalize(normalizationActivity, normalizationInput);
@@ -240,6 +254,11 @@ class SyncWorkflowTest {
         .build();
 
     testEnv.getWorkflowService().blockingStub().requestCancelWorkflowExecution(cancelRequest);
+  }
+
+  private static void verifyRouteToTaskQueue(final RouteToTaskQueueActivity routeToTaskQueueActivity,
+                                             final UUID connectionId) {
+    verify(routeToTaskQueueActivity).routeToTaskQueue(connectionId);
   }
 
   private static void verifyReplication(final ReplicationActivity replicationActivity, final StandardSyncInput syncInput) {


### PR DESCRIPTION
## What
Child of giant Multi-Cloud MVP PR here: https://github.com/airbytehq/airbyte/pull/15798, this smaller PR contains just the files changed to add the new activity that routes sync activity tasks to a Data Plane-specific task queue.

## How
Add a new activity to the SyncWorkflow called DecideDataPlaneTaskQueue. 
  - For now, the implementation of this activity is simple, it just checks to see if the current connectionId matches an environment variable.
  - In the future, the implementation of this activity will change to contact a Routing Service that will determine where the Data Plane work should be routed.
  - Because we're introducing a brand new activity, we need [Workflow Versioning](https://docs.temporal.io/php/versioning/) to avoid breaking existing Temporal workflows.

