### PR TITLE
[source-sendgrid] [source-sentry] use latest cdk w/ file parse fixes and fix sendgrid messages stream bug

### DIFF
--- a/airbyte-config/init/src/main/resources/seed/source_definitions.yaml
+++ b/airbyte-config/init/src/main/resources/seed/source_definitions.yaml
@@ -1131,7 +1131,7 @@
 - sourceDefinitionId: cdaf146a-9b75-49fd-9dd2-9d64a0bb4781
   name: Sentry
   dockerRepository: airbyte/source-sentry
-  dockerImageTag: 0.1.4
+  dockerImageTag: 0.1.5
   documentationUrl: https://docs.airbyte.io/integrations/sources/sentry
   icon: sentry.svg
   sourceType: api

--- a/airbyte-config/init/src/main/resources/seed/source_definitions.yaml
+++ b/airbyte-config/init/src/main/resources/seed/source_definitions.yaml
@@ -900,7 +900,7 @@
 - name: Sendgrid
   sourceDefinitionId: fbb5fbe2-16ad-4cf4-af7d-ff9d9c316c87
   dockerRepository: airbyte/source-sendgrid
-  dockerImageTag: 0.2.11
+  dockerImageTag: 0.2.12
   documentationUrl: https://docs.airbyte.io/integrations/sources/sendgrid
   icon: sendgrid.svg
   sourceType: api

--- a/airbyte-config/init/src/main/resources/seed/source_specs.yaml
+++ b/airbyte-config/init/src/main/resources/seed/source_specs.yaml
@@ -11049,7 +11049,7 @@
     supportsNormalization: false
     supportsDBT: false
     supported_destination_sync_modes: []
-- dockerImage: "airbyte/source-sentry:0.1.4"
+- dockerImage: "airbyte/source-sentry:0.1.5"
   spec:
     documentationUrl: "https://docs.airbyte.io/integrations/sources/sentry"
     connectionSpecification:

--- a/airbyte-config/init/src/main/resources/seed/source_specs.yaml
+++ b/airbyte-config/init/src/main/resources/seed/source_specs.yaml
@@ -8880,7 +8880,7 @@
     supportsNormalization: false
     supportsDBT: false
     supported_destination_sync_modes: []
-- dockerImage: "airbyte/source-sendgrid:0.2.11"
+- dockerImage: "airbyte/source-sendgrid:0.2.12"
   spec:
     documentationUrl: "https://docs.airbyte.io/integrations/sources/sendgrid"
     connectionSpecification:

--- a/airbyte-integrations/connectors/source-sendgrid/Dockerfile
+++ b/airbyte-integrations/connectors/source-sendgrid/Dockerfile
@@ -12,5 +12,5 @@ RUN pip install .
 ENV AIRBYTE_ENTRYPOINT "python /airbyte/integration_code/main.py"
 ENTRYPOINT ["python", "/airbyte/integration_code/main.py"]
 
-LABEL io.airbyte.version=0.2.11
+LABEL io.airbyte.version=0.2.12
 LABEL io.airbyte.name=airbyte/source-sendgrid

--- a/airbyte-integrations/connectors/source-sendgrid/setup.py
+++ b/airbyte-integrations/connectors/source-sendgrid/setup.py
@@ -11,6 +11,6 @@ setup(
     author="Airbyte",
     author_email="contact@airbyte.io",
     packages=find_packages(),
-    install_requires=["airbyte-cdk>=0.1.78", "backoff", "requests", "pytest==6.1.2", "pytest-mock"],
+    install_requires=["airbyte-cdk>=0.1.79", "backoff", "requests", "pytest==6.1.2", "pytest-mock"],
     package_data={"": ["*.json", "*.yaml", "schemas/*.json"]},
 )

--- a/airbyte-integrations/connectors/source-sendgrid/source_sendgrid/sendgrid.yaml
+++ b/airbyte-integrations/connectors/source-sendgrid/source_sendgrid/sendgrid.yaml
@@ -67,7 +67,7 @@ definitions:
       datetime: "{{ config['start_time'] }}"
       datetime_format: "%s"
     end_datetime:
-      datetime: "{{ now_utc() }}}"
+      datetime: "{{ now_utc() }}"
       datetime_format: "%Y-%m-%d %H:%M:%S.%f%z"
     step: "*ref(definitions.step)"
     cursor_field: "{{ options.stream_cursor_field }}"

--- a/airbyte-integrations/connectors/source-sentry/Dockerfile
+++ b/airbyte-integrations/connectors/source-sentry/Dockerfile
@@ -34,5 +34,5 @@ COPY source_sentry ./source_sentry
 ENV AIRBYTE_ENTRYPOINT "python /airbyte/integration_code/main.py"
 ENTRYPOINT ["python", "/airbyte/integration_code/main.py"]
 
-LABEL io.airbyte.version=0.1.4
+LABEL io.airbyte.version=0.1.5
 LABEL io.airbyte.name=airbyte/source-sentry

--- a/airbyte-integrations/connectors/source-sentry/setup.py
+++ b/airbyte-integrations/connectors/source-sentry/setup.py
@@ -6,7 +6,7 @@
 from setuptools import find_packages, setup
 
 MAIN_REQUIREMENTS = [
-    "airbyte-cdk~=0.1.78",
+    "airbyte-cdk~=0.1.79",
 ]
 
 TEST_REQUIREMENTS = [

--- a/docs/integrations/sources/sendgrid.md
+++ b/docs/integrations/sources/sendgrid.md
@@ -78,6 +78,7 @@ The connector is restricted by normal Sendgrid [requests limitation](https://sen
 
 | Version | Date       | Pull Request                                             | Subject                                            |
 |:--------| :--------- |:---------------------------------------------------------|:---------------------------------------------------|
+| 0.2.12  | 2022-08-24 | [15911](https://github.com/airbytehq/airbyte/pull/15911) | Bugfix to allowing reading schemas at runtime      |
 | 0.2.11  | 2022-08-19 | [15800](https://github.com/airbytehq/airbyte/pull/15800) | Bugfix to allow reading sentry.yaml at runtime     |
 | 0.2.10  | 2022-08-17 | [15734](https://github.com/airbytehq/airbyte/pull/15734) | Fix yaml based on the new schema validator         |
 | 0.2.9   | 2022-08-11 | [15257](https://github.com/airbytehq/airbyte/pull/15257) | Migrate to config-based framework                  |

--- a/docs/integrations/sources/sentry.md
+++ b/docs/integrations/sources/sentry.md
@@ -59,6 +59,7 @@ The Sentry source connector supports the following [sync modes](https://docs.air
 
 | Version | Date       | Pull Request                                             | Subject                                           |
 |:--------| :--------- | :------------------------------------------------------- |:--------------------------------------------------|
+| 0.1.5   | 2022-08-24 | [15911](https://github.com/airbytehq/airbyte/pull/15911) | Bugfix to allowing reading schemas at runtime     |
 | 0.1.4   | 2022-08-19 | [15800](https://github.com/airbytehq/airbyte/pull/15800) | Bugfix to allow reading sentry.yaml at runtime    |
 | 0.1.3   | 2022-08-17 | [15734](https://github.com/airbytehq/airbyte/pull/15734) | Fix yaml based on the new schema validator        |
 | 0.1.2   | 2021-12-28 | [15345](https://github.com/airbytehq/airbyte/pull/15345) | Migrate to config-based framework                 |


### PR DESCRIPTION
## What
Upgrade the sendgrid and sentry connectors to use the latest CDK which fixes a json schema parse issue as per `0.1.79`.

## How
The latest CDK can properly read json files via https://github.com/airbytehq/airbyte/pull/15814