### PR TITLE
apply shutdown hook to airbyte server to allow graceful termination

### DIFF
--- a/airbyte-server/src/main/java/io/airbyte/server/ServerApp.java
+++ b/airbyte-server/src/main/java/io/airbyte/server/ServerApp.java
@@ -133,6 +133,15 @@ public class ServerApp implements ServerRunnable {
     final String banner = MoreResources.readResource("banner/banner.txt");
     LOGGER.info(banner + String.format("Version: %s\n", airbyteVersion.serialize()));
     server.join();
+
+    Runtime.getRuntime().addShutdownHook(new Thread(() -> {
+      try {
+        server.stop();
+      } catch (Exception ex) {
+        // silently fail at this stage because server is terminating.
+        LOGGER.warn("exception: " + ex);
+      }
+    }));
   }
 
   private static void assertDatabasesReady(final Configs configs,


### PR DESCRIPTION
## What
apply shutdown hook to airbyte server to allow graceful termination

When K8s terminate the airbyte server in events like rollout, it will send SIGTERM - adding this shutdownhook allows airbyte server to terminate gracefully.