### PR TITLE
fix: revert extraEnv. Move updated extraEnv to env_vars

### DIFF
--- a/charts/airbyte-bootloader/templates/pod.yaml
+++ b/charts/airbyte-bootloader/templates/pod.yaml
@@ -83,10 +83,17 @@ spec:
         {{- end }}
 
         # Values from env
-        {{- if .Values.extraEnv }}
-        {{- range $k, $v := mergeOverwrite .Values.extraEnv .Values.global.env_vars }}
+        {{- if .Values.env_vars }}
+        {{- range $k, $v := mergeOverwrite .Values.env_vars .Values.global.env_vars }}
         - name: {{ $k }}
           value: {{ $v | quote }}
         {{- end }}
         {{- end }}
+
+        # Values from extraEnv for more compability(if you want to use external secret source or other stuff)
+        {{- if .Values.extraEnv }}
+        {{- toYaml .Values.extraEnv | nindent 8 }}
+        {{- end }}
+
+
       resources: {{- toYaml .Values.resources | nindent 8 }}

--- a/charts/airbyte-bootloader/values.yaml
+++ b/charts/airbyte-bootloader/values.yaml
@@ -63,7 +63,8 @@ resources:
 ## ref: https://kubernetes.io/docs/concepts/scheduling-eviction/assign-pod-node/#affinity-and-anti-affinity
 ##
 affinity: {}
-extraEnv: {}
+extraEnv: []
 secrets: {}
+env_vars: {}
 
 

--- a/charts/airbyte-server/templates/deployment.yaml
+++ b/charts/airbyte-server/templates/deployment.yaml
@@ -197,11 +197,16 @@ spec:
         {{- end }}
 
         # Values from env
-        {{- if .Values.extraEnv }}
-        {{- range $k, $v := mergeOverwrite .Values.extraEnv .Values.global.env_vars }}
+        {{- if .Values.env_vars }}
+        {{- range $k, $v := mergeOverwrite .Values.env_vars .Values.global.env_vars }}
         - name: {{ $k }}
           value: {{ $v | quote }}
         {{- end }}
+        {{- end }}
+
+        # Values from extraEnv for more compability(if you want to use external secret source or other stuff)
+        {{- if .Values.extraEnv }}
+        {{- toYaml .Values.extraEnv | nindent 8 }}
         {{- end }}
         
         {{- if .Values.livenessProbe.enabled }}

--- a/charts/airbyte-server/values.yaml
+++ b/charts/airbyte-server/values.yaml
@@ -165,7 +165,7 @@ log:
 ## extraEnv:
 ## - name: SAMPLE_ENV_VAR
 ##   value: "key=sample-value"
-extraEnv: {}
+extraEnv: []
 
 ## @param server.extraVolumeMounts [array] Additional volumeMounts for server container(s).
 ## Examples (when using `server.containerSecurityContext.readOnlyRootFilesystem=true`):
@@ -188,3 +188,4 @@ extraContainers: []
 extraInitContainers: []
 
 secrets: {}
+env_vars: {}

--- a/charts/airbyte-webapp/templates/deployment.yaml
+++ b/charts/airbyte-webapp/templates/deployment.yaml
@@ -83,12 +83,19 @@ spec:
         {{- end }}
 
         # Values from env
-        {{- if .Values.extraEnv }}
-        {{- range $k, $v := mergeOverwrite .Values.extraEnv .Values.global.env_vars }}
+        {{- if .Values.env_vars }}
+        {{- range $k, $v := mergeOverwrite .Values.env_vars .Values.global.env_vars }}
         - name: {{ $k }}
           value: {{ $v | quote }}
         {{- end }}
         {{- end }}
+
+        # Values from extraEnv for more compability(if you want to use external secret source or other stuff)
+        {{- if .Values.extraEnv }}
+        {{- toYaml .Values.extraEnv | nindent 8 }}
+        {{- end }}
+
+
         {{- if .Values.livenessProbe.enabled }}
         livenessProbe:
           tcpSocket:

--- a/charts/airbyte-webapp/values.yaml
+++ b/charts/airbyte-webapp/values.yaml
@@ -146,7 +146,7 @@ fullstory:
 ## extraEnv:
 ## - name: SAMPLE_ENV_VAR
 ##   value: "key=sample-value"
-extraEnv: {}
+extraEnv: []
 
 ## @param webapp.extraVolumeMounts [array] Additional volumeMounts for webapp container(s).
 ## Examples (when using `webapp.containerSecurityContext.readOnlyRootFilesystem=true`):
@@ -175,3 +175,5 @@ extraVolumes: []
 extraContainers: []
 
 secrets: {}
+
+env_vars: []

--- a/charts/airbyte-worker/templates/deployment.yaml
+++ b/charts/airbyte-worker/templates/deployment.yaml
@@ -312,11 +312,16 @@ spec:
         {{- end }}
 
         # Values from env
-        {{- if .Values.extraEnv }}
-        {{- range $k, $v := mergeOverwrite .Values.extraEnv .Values.global.env_vars }}
+        {{- if .Values.env_vars }}
+        {{- range $k, $v := mergeOverwrite .Values.env_vars .Values.global.env_vars }}
         - name: {{ $k }}
           value: {{ $v | quote }}
         {{- end }}
+        {{- end }}
+
+        # Values from extraEnv for more compability(if you want to use external secret source or other stuff)
+        {{- if .Values.extraEnv }}
+        {{- toYaml .Values.extraEnv | nindent 8 }}
         {{- end }}
 
         {{- if .Values.livenessProbe.enabled }}

--- a/charts/airbyte-worker/values.yaml
+++ b/charts/airbyte-worker/values.yaml
@@ -204,7 +204,7 @@ log:
 ## extraEnv:
 ## - name: JOB_KUBE_TOLERATIONS
 ##   value: "key=airbyte-server,operator=Equals,value=true,effect=NoSchedule"
-extraEnv: {}
+extraEnv: []
 
 secrets: {}
 
@@ -226,4 +226,4 @@ extraVolumes: []
 
 extraContainers: []
 
-
+env_vars: {}


### PR DESCRIPTION
## What
* Reverted changes to extraEnv and moved it to separate env_vars values

## How
* See `What`


## 🚨 User Impact 🚨
Are there any breaking changes? What is the end result perceived by the user? If yes, please merge this PR with the 🚨🚨 emoji so changelog authors can further highlight this if needed.

