### PR TITLE
Force space at beginning of comments

### DIFF
--- a/airbyte-webapp/.eslintrc
+++ b/airbyte-webapp/.eslintrc
@@ -36,6 +36,7 @@
     "prefer-destructuring": ["warn", { "AssignmentExpression": { "array": true } }],
     "prefer-object-spread": "warn",
     "prefer-template": "warn",
+    "spaced-comment": ["warn", "always", { "markers": ["/"] }],
     "yoda": "warn",
     "import/order": [
       "warn",

--- a/airbyte-webapp/src/components/Link/Link.tsx
+++ b/airbyte-webapp/src/components/Link/Link.tsx
@@ -11,7 +11,7 @@ export interface ILinkProps {
 }
 
 // TODO: fix typings
-const Link = styled(ReactLink)<ILinkProps /*& ReactLinkProps */>`
+const Link = styled(ReactLink)<ILinkProps /* & ReactLinkProps */>`
   color: ${({ theme, $light }) => ($light ? theme.darkGreyColor : theme.primaryColor)};
 
   font-weight: ${({ bold }) => (bold ? "bold" : "normal")};

--- a/airbyte-webapp/src/packages/cloud/views/layout/MainView/MainView.tsx
+++ b/airbyte-webapp/src/packages/cloud/views/layout/MainView/MainView.tsx
@@ -46,11 +46,11 @@ const MainView: React.FC = (props) => {
     } else if (alertToShow === "trial") {
       const { trialExpiryTimestamp } = cloudWorkspace;
 
-      //calculate difference between timestamp (in epoch milliseconds) and now (in epoch milliseconds)
-      //empty timestamp is 0
+      // calculate difference between timestamp (in epoch milliseconds) and now (in epoch milliseconds)
+      // empty timestamp is 0
       const trialRemainingMilliseconds = trialExpiryTimestamp ? trialExpiryTimestamp - Date.now() : 0;
 
-      //calculate days (rounding up if decimal)
+      // calculate days (rounding up if decimal)
       const trialRemainingDays = Math.ceil(trialRemainingMilliseconds / (1000 * 60 * 60 * 24));
 
       return formatMessage({ id: "trial.alertMessage" }, { value: trialRemainingDays });

--- a/airbyte-webapp/src/setupProxy.js
+++ b/airbyte-webapp/src/setupProxy.js
@@ -15,7 +15,7 @@ module.exports = (app) => {
   });
   // Serve the doc markdowns and assets that are also bundled into the docker image
   app.use("/docs/integrations", express.static(`${__dirname}/../../docs/integrations`));
-  //workaround for adblockers to serve google ads docs in development
+  // workaround for adblockers to serve google ads docs in development
   app.use(
     "/docs/integrations/sources/gglad.md",
     express.static(`${__dirname}/../../docs/integrations/sources/google-ads.md`)

--- a/airbyte-webapp/src/views/Connector/ConnectorDocumentationLayout/ConnectorDocumentationLayout.tsx
+++ b/airbyte-webapp/src/views/Connector/ConnectorDocumentationLayout/ConnectorDocumentationLayout.tsx
@@ -55,7 +55,7 @@ const RightPanelContainer: React.FC<React.PropsWithChildren<PanelContainerProps>
     </>
   );
 };
-//NOTE: ReflexElement will not load its contents if wrapped in an empty jsx tag along with ReflexSplitter.  They must be evaluated/rendered separately.
+// NOTE: ReflexElement will not load its contents if wrapped in an empty jsx tag along with ReflexSplitter.  They must be evaluated/rendered separately.
 
 export const ConnectorDocumentationLayout: React.FC = ({ children }) => {
   const { documentationPanelOpen } = useDocumentationPanelContext();

--- a/airbyte-webapp/src/views/Connector/ServiceForm/ServiceForm.tsx
+++ b/airbyte-webapp/src/views/Connector/ServiceForm/ServiceForm.tsx
@@ -33,7 +33,7 @@ const FormikPatch: React.FC = () => {
   return null;
 };
 
-/***
+/**
  * This function sets all initial const values in the form to current values
  * @param schema
  * @constructor


### PR DESCRIPTION
## What

Add a linting rule to enforce a space between the comment marker and the comment text (except for the triple `///` in type definition files, which is what the `marker` does). Also auto fixed all breakages.