### PR TITLE
documentation(feat): updating collecting metrics page

### DIFF
--- a/docs/operator-guides/collecting-metrics.md
+++ b/docs/operator-guides/collecting-metrics.md
@@ -251,7 +251,17 @@ spec:
 
 
 # Datadog
-TBD
+The set up for Datadog is pretty straightforward. 
+
+Set two env vars:
+
+1) `METRIC_CLIENT` to `datadog`.
+2) `PUBLISH_METRICS` to `true`.
+
+Configure two additional env vars to the Datadog endpoint:
+
+1) Set `DD_AGENT_HOST` to the IP where the Datadog agent is running.
+2) Set `DD_DOGSTATSD_PORT` to the port the Datadog agent is using.
 
 ## Metrics
 Visit [OssMetricsRegistry.java](https://github.com/airbytehq/airbyte/blob/master/airbyte-metrics/metrics-lib/src/main/java/io/airbyte/metrics/lib/OssMetricsRegistry.java) to get a complete list of metrics Airbyte is sending.


### PR DESCRIPTION
## What
Updating the `Datadog` section on [Collecting metrics page](https://docs.airbyte.com/operator-guides/collecting-metrics/) page with the help of [ this comment](https://github.com/airbytehq/airbyte/issues/15772#issuecomment-1223090442).

## Closes
Update Collecting metrics page #15772 
