### PR TITLE
🪟 🔧 Upgrade array-type lint rule to error

### DIFF
--- a/airbyte-webapp/.eslintrc
+++ b/airbyte-webapp/.eslintrc
@@ -61,7 +61,7 @@
         }
       }
     ],
-    "@typescript-eslint/array-type": ["warn", { "default": "array-simple" }],
+    "@typescript-eslint/array-type": ["error", { "default": "array-simple" }],
     "@typescript-eslint/ban-ts-comment": [
       "warn",
       {


### PR DESCRIPTION
## What
Upgrades the `@typescript-eslint/array-type` rule from `warn` to `error` because this is one of the linting rules that will fail CI if it's not fixed for whatever reason (however, it is auto-fixable with a linter on auto save.)

Found in #15924 
