### PR TITLE
Select sync mode dropdown with a data-testid

### DIFF
--- a/airbyte-webapp-e2e-tests/cypress/pages/replicationPage.ts
+++ b/airbyte-webapp-e2e-tests/cypress/pages/replicationPage.ts
@@ -6,8 +6,7 @@ const destinationNamespace = "div[data-testid='namespaceDefinition']";
 const destinationNamespaceCustom = "div[data-testid='namespaceDefinition-customformat']";
 const destinationNamespaceSource = "div[data-testid='namespaceDefinition-source']";
 const destinationNamespaceCustomInput = "input[data-testid='input']";
-const syncModeDropdown = "div.sc-lbxAil.hgSxej";
-const syncModeFullAppendValue = "div.sc-ftvSup.sc-jDDxOa.sEMqZ.kVUvAu";
+const syncModeDropdown = "div[data-testid='syncSettingsDropdown'] input";
 const successResult = "span[data-id='success-result']";
 const saveStreamChangesButton = "button[data-testid='resetModal-save']";
 const connectionNameInput = "input[data-testid='connectionName']";
@@ -41,9 +40,12 @@ export const setupDestinationNamespaceSourceFormat = () => {
 }
 
 export const selectFullAppendSyncMode = () => {
-    cy.get(syncModeDropdown).click();
-    cy.get(syncModeFullAppendValue).click();
-}
+  cy.get(syncModeDropdown).first().click({ force: true });
+
+  cy.get(`.react-select__menu`)
+    .contains("Append") // it would be nice to select for "Full refresh" is there too
+    .click();
+};
 
 export const checkSuccessResult = () => {
     cy.get(successResult).should("exist");

--- a/airbyte-webapp/src/views/Connection/CatalogTree/components/SyncSettingsDropdown.tsx
+++ b/airbyte-webapp/src/views/Connection/CatalogTree/components/SyncSettingsDropdown.tsx
@@ -106,6 +106,7 @@ const SyncSettingsDropdown: React.FC<DropdownProps> = (props) => (
       Option,
       Control: DropdownControl,
     }}
+    data-testid="syncSettingsDropdown"
     $withBorder
   />
 );


### PR DESCRIPTION
## What
Adds a `data-testid` selector to the dropdown so it can be selected in cypress tests without relying on unreliable generated class names; also adjusts the strategy for selecting the dropdown option. While using a `data-testid` attribute is usually the best way to select parts of the UI in tests, the menu items within the dropdown are dynamically constructed by the `react-select` library after being passed around multiple files: customizing this would be confusing to write and maintain. Instead, we can use the `.react-select__menu` class to identify the dropdown menu (since only one will be open at a time) and use `cy.contains` to select specific dropdown items by their text content.