### PR TITLE
Source Redshift: added custom JDBC parameters

### DIFF
--- a/airbyte-config/init/src/main/resources/seed/source_definitions.yaml
+++ b/airbyte-config/init/src/main/resources/seed/source_definitions.yaml
@@ -845,7 +845,7 @@
 - name: Redshift
   sourceDefinitionId: e87ffa8e-a3b5-f69c-9076-6011339de1f6
   dockerRepository: airbyte/source-redshift
-  dockerImageTag: 0.3.12
+  dockerImageTag: 0.3.13
   documentationUrl: https://docs.airbyte.io/integrations/sources/redshift
   icon: redshift.svg
   sourceType: database

--- a/airbyte-config/init/src/main/resources/seed/source_specs.yaml
+++ b/airbyte-config/init/src/main/resources/seed/source_specs.yaml
@@ -8115,7 +8115,7 @@
     supportsNormalization: false
     supportsDBT: false
     supported_destination_sync_modes: []
-- dockerImage: "airbyte/source-redshift:0.3.12"
+- dockerImage: "airbyte/source-redshift:0.3.13"
   spec:
     documentationUrl: "https://docs.airbyte.io/integrations/destinations/redshift"
     connectionSpecification:
@@ -8175,6 +8175,13 @@
           type: "string"
           airbyte_secret: true
           order: 6
+        jdbc_url_params:
+          title: "JDBC URL Params"
+          description: "Additional properties to pass to the JDBC URL string when\
+            \ connecting to the database formatted as 'key=value' pairs separated\
+            \ by the symbol '&'. (example: key1=value1&key2=value2&key3=value3)."
+          type: "string"
+          order: 7
     supportsNormalization: false
     supportsDBT: false
     supported_destination_sync_modes: []

--- a/airbyte-integrations/connectors/source-redshift/Dockerfile
+++ b/airbyte-integrations/connectors/source-redshift/Dockerfile
@@ -16,5 +16,5 @@ ENV APPLICATION source-redshift
 
 COPY --from=build /airbyte /airbyte
 
-LABEL io.airbyte.version=0.3.12
+LABEL io.airbyte.version=0.3.13
 LABEL io.airbyte.name=airbyte/source-redshift

--- a/airbyte-integrations/connectors/source-redshift/build.gradle
+++ b/airbyte-integrations/connectors/source-redshift/build.gradle
@@ -25,6 +25,8 @@ dependencies {
     testImplementation 'org.apache.commons:commons-text:1.9'
     testImplementation 'org.apache.commons:commons-lang3:3.11'
     testImplementation 'org.apache.commons:commons-dbcp2:2.7.0'
+    testImplementation testFixtures(project(':airbyte-integrations:connectors:source-jdbc'))
+    testImplementation project(":airbyte-json-validation")
 
     integrationTestJavaImplementation project(':airbyte-integrations:bases:standard-source-test')
     integrationTestJavaImplementation testFixtures(project(':airbyte-integrations:connectors:source-jdbc'))

--- a/airbyte-integrations/connectors/source-redshift/src/main/java/io/airbyte/integrations/source/redshift/RedshiftSource.java
+++ b/airbyte-integrations/connectors/source-redshift/src/main/java/io/airbyte/integrations/source/redshift/RedshiftSource.java
@@ -27,7 +27,7 @@ import java.util.Set;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-public class RedshiftSource extends AbstractJdbcSource<JDBCType> implements Source {
+public class RedshiftSource extends AbstractJdbcSource<JDBCType> {
 
   private static final Logger LOGGER = LoggerFactory.getLogger(RedshiftSource.class);
   public static final String DRIVER_CLASS = DatabaseDriver.REDSHIFT.getDriverClassName();
@@ -62,6 +62,10 @@ public class RedshiftSource extends AbstractJdbcSource<JDBCType> implements Sour
     }
 
     addSsl(additionalProperties);
+
+    if (redshiftConfig.get(JdbcUtils.JDBC_URL_PARAMS_KEY) != null && !redshiftConfig.get(JdbcUtils.JDBC_URL_PARAMS_KEY).asText().isEmpty()) {
+      additionalProperties.addAll(List.of(redshiftConfig.get(JdbcUtils.JDBC_URL_PARAMS_KEY).asText().split("&")));
+    }
 
     builder.put(JdbcUtils.CONNECTION_PROPERTIES_KEY, String.join("&", additionalProperties));
 

--- a/airbyte-integrations/connectors/source-redshift/src/main/resources/spec.json
+++ b/airbyte-integrations/connectors/source-redshift/src/main/resources/spec.json
@@ -53,6 +53,12 @@
         "type": "string",
         "airbyte_secret": true,
         "order": 6
+      },
+      "jdbc_url_params": {
+        "title": "JDBC URL Params",
+        "description": "Additional properties to pass to the JDBC URL string when connecting to the database formatted as 'key=value' pairs separated by the symbol '&'. (example: key1=value1&key2=value2&key3=value3).",
+        "type": "string",
+        "order": 7
       }
     }
   }

--- a/airbyte-integrations/connectors/source-redshift/src/test/java/io/airbyte/integrations/source/redshift/RedshiftSpecTest.java
+++ b/airbyte-integrations/connectors/source-redshift/src/test/java/io/airbyte/integrations/source/redshift/RedshiftSpecTest.java
@@ -1,0 +1,118 @@
+/*
+ * Copyright (c) 2022 Airbyte, Inc., all rights reserved.
+ */
+
+package io.airbyte.integrations.source.redshift;
+
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.node.ObjectNode;
+import io.airbyte.commons.io.IOs;
+import io.airbyte.commons.json.Jsons;
+import io.airbyte.commons.resources.MoreResources;
+import io.airbyte.protocol.models.ConnectorSpecification;
+import io.airbyte.validation.json.JsonSchemaValidator;
+import java.io.File;
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
+
+/**
+ * Tests that the Redshift spec passes JsonSchema validation. While this may seem like overkill, we
+ * are doing it because there are some gotchas in correctly configuring the oneOf.
+ */
+public class RedshiftSpecTest {
+
+  private static final String CONFIGURATION = """
+                                              {
+                                                "host": "localhost",
+                                                "port": 1521,
+                                                "database": "db",
+                                                "schemas": [
+                                                  "public"
+                                                ],
+                                                "username": "redshift",
+                                                "password": "password",
+                                                "jdbc_url_params": "property1=pValue1&property2=pValue2"
+                                              }
+                                              """;
+
+
+  private static JsonNode schema;
+  private static JsonSchemaValidator validator;
+
+  @BeforeAll
+  static void init() throws IOException {
+    final String spec = MoreResources.readResource("spec.json");
+    final File schemaFile = IOs.writeFile(Files.createTempDirectory(Path.of("/tmp"), "pg-spec-test"), "schema.json", spec).toFile();
+    schema = JsonSchemaValidator.getSchema(schemaFile).get("connectionSpecification");
+    validator = new JsonSchemaValidator();
+  }
+
+  @Test
+  void testHostMissing() {
+    final JsonNode config = Jsons.deserialize(CONFIGURATION);
+    ((ObjectNode) config).remove("host");
+    assertFalse(validator.test(schema, config));
+  }
+
+  @Test
+  void testPortMissing() {
+    final JsonNode config = Jsons.deserialize(CONFIGURATION);
+    ((ObjectNode) config).remove("port");
+    assertFalse(validator.test(schema, config));
+  }
+
+  @Test
+  void testDatabaseMissing() {
+    final JsonNode config = Jsons.deserialize(CONFIGURATION);
+    ((ObjectNode) config).remove("database");
+    assertFalse(validator.test(schema, config));
+  }
+
+  @Test
+  void testUsernameMissing() {
+    final JsonNode config = Jsons.deserialize(CONFIGURATION);
+    ((ObjectNode) config).remove("username");
+    assertFalse(validator.test(schema, config));
+  }
+
+  @Test
+  void testPasswordMissing() {
+    final JsonNode config = Jsons.deserialize(CONFIGURATION);
+    ((ObjectNode) config).remove("password");
+    assertFalse(validator.test(schema, config));
+  }
+
+  @Test
+  void testSchemaMissing() {
+    final JsonNode config = Jsons.deserialize(CONFIGURATION);
+    ((ObjectNode) config).remove("schemas");
+    assertTrue(validator.test(schema, config));
+  }
+
+  @Test
+  void testAdditionalJdbcParamMissing() {
+    final JsonNode config = Jsons.deserialize(CONFIGURATION);
+    ((ObjectNode) config).remove("jdbc_url_params");
+    assertTrue(validator.test(schema, config));
+  }
+
+  @Test
+  void testWithJdbcAdditionalProperty() {
+    final JsonNode config = Jsons.deserialize(CONFIGURATION);
+    assertTrue(validator.test(schema, config));
+  }
+
+  @Test
+  void testJdbcAdditionalProperty() throws Exception {
+    final ConnectorSpecification spec = new RedshiftSource().spec();
+    assertNotNull(spec.getConnectionSpecification().get("properties").get("jdbc_url_params"));
+  }
+
+}

--- a/airbyte-integrations/connectors/source-redshift/src/test/resources/config-test.json
+++ b/airbyte-integrations/connectors/source-redshift/src/test/resources/config-test.json
@@ -1,0 +1,11 @@
+{
+  "host": "localhost",
+  "port": 1521,
+  "database": "db",
+  "schemas": [
+    "public"
+  ],
+  "username": "redshift",
+  "password": "password",
+  "jdbc_url_params": "property1=pValue1&property2=pValue2"
+}

--- a/docs/integrations/sources/redshift.md
+++ b/docs/integrations/sources/redshift.md
@@ -53,8 +53,8 @@ All Redshift connections are encrypted using SSL
 ## Changelog
 
 | Version | Date       | Pull Request | Subject                                                                                                   |
-| :------ |:-----------| :-----       |:----------------------------------------------------------------------------------------------------------|
-| 0.3.12  | 2022-05-25 |  | Added JDBC URL params                                                                                     |
+|:--------|:-----------| :-----       |:----------------------------------------------------------------------------------------------------------|
+| 0.3.13  | 2022-05-25 |  | Added JDBC URL params                                                                                     |
 | 0.3.12  | 2022-08-18 | [14356](https://github.com/airbytehq/airbyte/pull/14356) | DB Sources: only show a table can sync incrementally if at least one column can be used as a cursor field |
 | 0.3.11  | 2022-07-14 | [14574](https://github.com/airbytehq/airbyte/pull/14574) | Removed additionalProperties:false from JDBC source connectors                                            |
 | 0.3.10  | 2022-04-29 | [12480](https://github.com/airbytehq/airbyte/pull/12480) | Query tables with adaptive fetch size to optimize JDBC memory consumption                                 |0

--- a/docs/integrations/sources/redshift.md
+++ b/docs/integrations/sources/redshift.md
@@ -52,16 +52,17 @@ All Redshift connections are encrypted using SSL
 
 ## Changelog
 
-| Version | Date       | Pull Request | Subject |
-| :------ | :--------  | :-----       | :------ |
+| Version | Date       | Pull Request | Subject                                                                                                   |
+| :------ |:-----------| :-----       |:----------------------------------------------------------------------------------------------------------|
+| 0.3.12  | 2022-05-25 |  | Added JDBC URL params                                                                                     |
 | 0.3.12  | 2022-08-18 | [14356](https://github.com/airbytehq/airbyte/pull/14356) | DB Sources: only show a table can sync incrementally if at least one column can be used as a cursor field |
-| 0.3.11  | 2022-07-14 | [14574](https://github.com/airbytehq/airbyte/pull/14574) | Removed additionalProperties:false from JDBC source connectors |
-| 0.3.10  | 2022-04-29 | [12480](https://github.com/airbytehq/airbyte/pull/12480) | Query tables with adaptive fetch size to optimize JDBC memory consumption |0
-| 0.3.9   | 2022-02-21 | [9744](https://github.com/airbytehq/airbyte/pull/9744) | List only the tables on which the user has SELECT permissions.
-| 0.3.8   | 2022-02-14 | [10256](https://github.com/airbytehq/airbyte/pull/10256) | Add `-XX:+ExitOnOutOfMemoryError` JVM option |
-| 0.3.7   | 2022-01-26 | [9721](https://github.com/airbytehq/airbyte/pull/9721) | Added schema selection |
-| 0.3.6   | 2022-01-20 | [8617](https://github.com/airbytehq/airbyte/pull/8617) | Update connector fields title/description |
-| 0.3.5   | 2021-12-24 | [8958](https://github.com/airbytehq/airbyte/pull/8958) | Add support for JdbcType.ARRAY |
-| 0.3.4   | 2021-10-21 | [7234](https://github.com/airbytehq/airbyte/pull/7234) | Allow SSL traffic only |
-| 0.3.3   | 2021-10-12 | [6965](https://github.com/airbytehq/airbyte/pull/6965) | Added SSL Support |
-| 0.3.2   | 2021-08-13 | [4699](https://github.com/airbytehq/airbyte/pull/4699) | Added json config validator |
+| 0.3.11  | 2022-07-14 | [14574](https://github.com/airbytehq/airbyte/pull/14574) | Removed additionalProperties:false from JDBC source connectors                                            |
+| 0.3.10  | 2022-04-29 | [12480](https://github.com/airbytehq/airbyte/pull/12480) | Query tables with adaptive fetch size to optimize JDBC memory consumption                                 |0
+| 0.3.9   | 2022-02-21 | [9744](https://github.com/airbytehq/airbyte/pull/9744) | List only the tables on which the user has SELECT permissions.                                            
+| 0.3.8   | 2022-02-14 | [10256](https://github.com/airbytehq/airbyte/pull/10256) | Add `-XX:+ExitOnOutOfMemoryError` JVM option                                                              |
+| 0.3.7   | 2022-01-26 | [9721](https://github.com/airbytehq/airbyte/pull/9721) | Added schema selection                                                                                    |
+| 0.3.6   | 2022-01-20 | [8617](https://github.com/airbytehq/airbyte/pull/8617) | Update connector fields title/description                                                                 |
+| 0.3.5   | 2021-12-24 | [8958](https://github.com/airbytehq/airbyte/pull/8958) | Add support for JdbcType.ARRAY                                                                            |
+| 0.3.4   | 2021-10-21 | [7234](https://github.com/airbytehq/airbyte/pull/7234) | Allow SSL traffic only                                                                                    |
+| 0.3.3   | 2021-10-12 | [6965](https://github.com/airbytehq/airbyte/pull/6965) | Added SSL Support                                                                                         |
+| 0.3.2   | 2021-08-13 | [4699](https://github.com/airbytehq/airbyte/pull/4699) | Added json config validator                                                                               |


### PR DESCRIPTION
## What
Add support for Redshift Source to take in a JDBC URL Params input to specify any additional JDBC parameters for the connection.

## Recommended reading order
1. `x.java`
2. `y.python`

## Pre-merge Checklist
Expand the relevant checklist and delete the others.


<details><summary><strong>Updating a connector</strong></summary>


### Airbyter

If this is a community PR, the Airbyte engineer reviewing this PR is responsible for the below items.

- [ ] Create a non-forked branch based on this PR and test the below items on it
- [ ] Build is successful
- [ ] If new credentials are required for use in CI, add them to GSM. [Instructions](https://docs.airbyte.io/connector-development#using-credentials-in-ci).
- [ ] [`/test connector=connectors/<name>` command](https://docs.airbyte.io/connector-development#updating-an-existing-connector) is passing
- [ ] New Connector version released on Dockerhub and connector version bumped by running the `/publish` command described [here](https://docs.airbyte.io/connector-development#updating-an-existing-connector)

</details>


## Tests

<details><summary><strong>Unit</strong></summary>

*Put your unit tests output here.*

</details>

<details><summary><strong>Integration</strong></summary>

*Put your integration tests output here.*

</details>

<details><summary><strong>Acceptance</strong></summary>

*Put your acceptance tests output here.*

</details>
