### PR TITLE
Source google ads：support segments.date is option and fix messy code

### DIFF
--- a/airbyte-integrations/connectors/source-google-ads/source_google_ads/google_ads.py
+++ b/airbyte-integrations/connectors/source-google-ads/source_google_ads/google_ads.py
@@ -3,6 +3,8 @@
 #
 
 
+import re
+import urllib.parse
 from enum import Enum
 from typing import Any, Iterator, List, Mapping, MutableMapping
 
@@ -32,6 +34,17 @@ REPORT_MAPPING = {
 }
 API_VERSION = "v11"
 
+
+def change_coding(s):
+  p=re.compile(r'(?P<s>(\\\d\d\d){3,})')
+  for i in p.finditer(s):
+      old=i.group('s')
+      name=old.split('\\')
+      name=['%x' %int(g,8) for g in name if g.isdigit() ]
+      name='%'+'%'.join(name)
+      CN_name= urllib.parse.unquote(name).encode().decode('utf-8')
+      s = s.replace(old,CN_name)
+  return s.strip('"')
 
 class GoogleAds:
     DEFAULT_PAGE_SIZE = 1000
@@ -166,7 +179,7 @@ class GoogleAds:
         # string if it has "repeated" flag on metadata
         if schema_type.get("protobuf_message"):
             if "array" in schema_type.get("type"):
-                field_value = [str(field) for field in field_value]
+                field_value = [change_coding(str(field)) for field in field_value]
             else:
                 field_value = str(field_value)
 

--- a/airbyte-integrations/connectors/source-google-ads/source_google_ads/spec.json
+++ b/airbyte-integrations/connectors/source-google-ads/source_google_ads/spec.json
@@ -99,6 +99,12 @@
               "type": "string",
               "title": "Destination Table Name",
               "description": "The table name in your destination database for choosen query."
+            },
+            "use_segments_date": {
+              "type": "boolean",
+              "title": "Sometimes doesn't need segments.date",
+              "description": "True for use segment_date,and false for no segments.date field when query",
+              "default": true
             }
           }
         }

--- a/airbyte-integrations/connectors/source-google-ads/unit_tests/test_custom_query.py
+++ b/airbyte-integrations/connectors/source-google-ads/unit_tests/test_custom_query.py
@@ -23,3 +23,21 @@ FROM search_term_view
 WHERE segments.date BETWEEN '1980-01-01' AND '1980-01-01'
 """
     )
+
+def test_custom_query_without_segments_date():
+    input_q = """SELECT ad_group.resource_name, ad_group.status, ad_group.target_cpa_micros, ad_group.target_cpm_micros,
+     ad_group.target_roas, ad_group.targeting_setting.target_restrictions, ad_group.tracking_url_template, ad_group.type,
+     ad_group.url_custom_parameters, campaign.accessible_bidding_strategy, campaign.ad_serving_optimization_status,
+     campaign.advertising_channel_type, campaign.advertising_channel_sub_type, campaign.app_campaign_setting.app_id,
+     campaign.app_campaign_setting.app_store FROM search_term_view"""
+    output_q = CustomQuery.insert_segments_date_expr(input_q, "1980-01-01", "1980-01-01",{"use_segments_date":False})
+    assert (
+        output_q
+        == """SELECT ad_group.resource_name, ad_group.status, ad_group.target_cpa_micros, ad_group.target_cpm_micros,
+     ad_group.target_roas, ad_group.targeting_setting.target_restrictions, ad_group.tracking_url_template, ad_group.type,
+     ad_group.url_custom_parameters, campaign.accessible_bidding_strategy, campaign.ad_serving_optimization_status,
+     campaign.advertising_channel_type, campaign.advertising_channel_sub_type, campaign.app_campaign_setting.app_id,
+     campaign.app_campaign_setting.app_store FROM search_term_view
+WHERE segments.date BETWEEN '1980-01-01' AND '1980-01-01'
+"""
+    )


### PR DESCRIPTION
## What
1. support use_segments_date field in spec for custom query
2. fix the messy code that when get_field_value

## How
1. Add new field `use_segments_date` in `spec.json` for custom query. You can switch it for custom query. Because sometimes does not need `segemts.date` on custom query.

![image](https://user-images.githubusercontent.com/241873/187138882-ba6ca549-6e98-4be2-a9fb-4710029d7ab1.png)


2. I get messy code when get ad's headline, description etc. for Chinese or Korean. So I fix it.





