### PR TITLE
Revert "Refactor test harness in preparation for cloud acceptance tes…

### DIFF
--- a/airbyte-test-utils/src/main/java/io/airbyte/test/utils/AirbyteAcceptanceTestHarness.java
+++ b/airbyte-test-utils/src/main/java/io/airbyte/test/utils/AirbyteAcceptanceTestHarness.java
@@ -144,15 +144,7 @@ public class AirbyteAcceptanceTestHarness {
   public static final String COOL_EMPLOYEES_TABLE_NAME = "cool_employees";
   public static final String AWESOME_PEOPLE_TABLE_NAME = "awesome_people";
 
-  public static final String TYPE = "type";
-  public static final String PUBLIC = "public";
-  public static final String TEST_CONNECTION = "test-connection";
-  public static final String STATE_AFTER_SYNC_ONE = "state after sync 1: {}";
-  public static final String STATE_AFTER_SYNC_TWO = "state after sync 2: {}";
-  public static final String GERALT = "geralt";
-
   private static final String DEFAULT_POSTGRES_INIT_SQL_FILE = "postgres_init.sql";
-  private static final String IS_TEST = "is_test";
 
   private static boolean isKube;
   private static boolean isMinikube;
@@ -504,6 +496,14 @@ public class AirbyteAcceptanceTestHarness {
         getDestinationDbConfig());
   }
 
+  public DestinationRead createPostgresStrictEnforceDestination() throws ApiException {
+    return createDestination(
+        "AccTestDestination-" + UUID.randomUUID(),
+        defaultWorkspaceId,
+        getPostgresDestinationDefinitionId(),
+        getDestinationDbStrictEnforceConfig());
+  }
+
   public DestinationRead createDestination(final String name,
                                            final UUID workspaceId,
                                            final UUID destinationDefId,
@@ -565,24 +565,33 @@ public class AirbyteAcceptanceTestHarness {
   }
 
   public JsonNode getSourceDbConfig() {
-    return getDbConfig(sourcePsql, false, false, Type.SOURCE);
+    return getDbConfig(sourcePsql, false, false, false, Type.SOURCE);
+  }
+
+  public JsonNode getSourceDbStrictEnforceConfig() {
+    return getDbConfig(sourcePsql, false, false, true, Type.SOURCE);
   }
 
   public JsonNode getDestinationDbConfig() {
-    return getDbConfig(destinationPsql, false, true, Type.DESTINATION);
+    return getDbConfig(destinationPsql, false, true, false, Type.DESTINATION);
+  }
+
+  public JsonNode getDestinationDbStrictEnforceConfig() {
+    return getDbConfig(destinationPsql, false, true, true, Type.DESTINATION);
   }
 
   public JsonNode getDestinationDbConfigWithHiddenPassword() {
-    return getDbConfig(destinationPsql, true, true, Type.DESTINATION);
+    return getDbConfig(destinationPsql, true, true, false, Type.DESTINATION);
   }
 
   public JsonNode getDbConfig(final PostgreSQLContainer psql,
                               final boolean hiddenPassword,
                               final boolean withSchema,
+                              final boolean strictEnforce,
                               final Type connectorType) {
     try {
       final Map<Object, Object> dbConfig = (isKube && isGke) ? GKEPostgresConfig.dbConfig(connectorType, hiddenPassword, withSchema)
-          : localConfig(psql, hiddenPassword, withSchema);
+          : localConfig(psql, hiddenPassword, withSchema, strictEnforce);
       return Jsons.jsonNode(dbConfig);
     } catch (final Exception e) {
       throw new RuntimeException(e);
@@ -591,7 +600,8 @@ public class AirbyteAcceptanceTestHarness {
 
   private Map<Object, Object> localConfig(final PostgreSQLContainer psql,
                                           final boolean hiddenPassword,
-                                          final boolean withSchema)
+                                          final boolean withSchema,
+                                          final boolean strictEnforce)
       throws UnknownHostException {
     final Map<Object, Object> dbConfig = new HashMap<>();
     // don't use psql.getHost() directly since the ip we need differs depending on environment
@@ -618,10 +628,11 @@ public class AirbyteAcceptanceTestHarness {
     dbConfig.put(JdbcUtils.PORT_KEY, psql.getFirstMappedPort());
     dbConfig.put(JdbcUtils.DATABASE_KEY, psql.getDatabaseName());
     dbConfig.put(JdbcUtils.USERNAME_KEY, psql.getUsername());
-
-    // bypasses the SSL modification for cloud acceptance tests
-    dbConfig.put(IS_TEST, true);
-    dbConfig.put(JdbcUtils.SSL_KEY, false);
+    // Some database docker images labeled strict-enforce do not contain an option to ssl off, so it is
+    // not included in the schema.
+    if (!strictEnforce) {
+      dbConfig.put(JdbcUtils.SSL_KEY, false);
+    }
 
     if (withSchema) {
       dbConfig.put(JdbcUtils.SCHEMA_KEY, "public");
@@ -651,6 +662,14 @@ public class AirbyteAcceptanceTestHarness {
         defaultWorkspaceId,
         getPostgresSourceDefinitionId(),
         getSourceDbConfig());
+  }
+
+  public SourceRead createPostgresStrictEnforceSource() throws ApiException {
+    return createSource(
+        "acceptanceTestDb-" + UUID.randomUUID(),
+        defaultWorkspaceId,
+        getPostgresSourceDefinitionId(),
+        getSourceDbStrictEnforceConfig());
   }
 
   public SourceRead createSource(final String name, final UUID workspaceId, final UUID sourceDefId, final JsonNode sourceConfig)

--- a/airbyte-tests/src/acceptanceTests/java/io/airbyte/test/acceptance/BasicAcceptanceTests.java
+++ b/airbyte-tests/src/acceptanceTests/java/io/airbyte/test/acceptance/BasicAcceptanceTests.java
@@ -9,15 +9,9 @@ import static io.airbyte.test.utils.AirbyteAcceptanceTestHarness.AWESOME_PEOPLE_
 import static io.airbyte.test.utils.AirbyteAcceptanceTestHarness.COLUMN_ID;
 import static io.airbyte.test.utils.AirbyteAcceptanceTestHarness.COLUMN_NAME;
 import static io.airbyte.test.utils.AirbyteAcceptanceTestHarness.COOL_EMPLOYEES_TABLE_NAME;
-import static io.airbyte.test.utils.AirbyteAcceptanceTestHarness.GERALT;
-import static io.airbyte.test.utils.AirbyteAcceptanceTestHarness.PUBLIC;
 import static io.airbyte.test.utils.AirbyteAcceptanceTestHarness.PUBLIC_SCHEMA_NAME;
 import static io.airbyte.test.utils.AirbyteAcceptanceTestHarness.STAGING_SCHEMA_NAME;
-import static io.airbyte.test.utils.AirbyteAcceptanceTestHarness.STATE_AFTER_SYNC_ONE;
-import static io.airbyte.test.utils.AirbyteAcceptanceTestHarness.STATE_AFTER_SYNC_TWO;
 import static io.airbyte.test.utils.AirbyteAcceptanceTestHarness.STREAM_NAME;
-import static io.airbyte.test.utils.AirbyteAcceptanceTestHarness.TEST_CONNECTION;
-import static io.airbyte.test.utils.AirbyteAcceptanceTestHarness.TYPE;
 import static io.airbyte.test.utils.AirbyteAcceptanceTestHarness.waitForSuccessfulJob;
 import static io.airbyte.test.utils.AirbyteAcceptanceTestHarness.waitWhileJobHasStatus;
 import static java.lang.Thread.sleep;
@@ -131,6 +125,7 @@ class BasicAcceptanceTests {
   private static final Logger LOGGER = LoggerFactory.getLogger(BasicAcceptanceTests.class);
 
   private static final Boolean WITH_SCD_TABLE = true;
+
   private static final Boolean WITHOUT_SCD_TABLE = false;
 
   private static AirbyteAcceptanceTestHarness testHarness;
@@ -139,10 +134,16 @@ class BasicAcceptanceTests {
   private static UUID workspaceId;
   private static PostgreSQLContainer sourcePsql;
 
+  private static final String TYPE = "type";
+  private static final String PUBLIC = "public";
   private static final String E2E_TEST_SOURCE = "E2E Test Source -";
   private static final String INFINITE_FEED = "INFINITE_FEED";
   private static final String MESSAGE_INTERVAL = "message_interval";
   private static final String MAX_RECORDS = "max_records";
+  private static final String TEST_CONNECTION = "test-connection";
+  private static final String STATE_AFTER_SYNC_ONE = "state after sync 1: {}";
+  private static final String STATE_AFTER_SYNC_TWO = "state after sync 2: {}";
+  private static final String GERALT = "geralt";
   private static final String NAME = "name";
   private static final String VALUE = "value";
   private static final String LOCATION = "location";
@@ -576,6 +577,7 @@ class BasicAcceptanceTests {
     LOGGER.info("state after sync 3: {}", apiClient.getConnectionApi().getState(new ConnectionIdRequestBody().connectionId(connectionId)));
 
     testHarness.assertSourceAndDestinationDbInSync(WITHOUT_SCD_TABLE);
+
   }
 
   @Test


### PR DESCRIPTION
…ts (#15932)"

This reverts commit dae056c552a545d331b9af2bf57ba6ecc01e4998.

## What
*Describe what the change is solving*
*It helps to add screenshots if it affects the frontend.*

## How
*Describe the solution*

## Recommended reading order
1. `x.java`
2. `y.python`

## 🚨 User Impact 🚨
Are there any breaking changes? What is the end result perceived by the user? If yes, please merge this PR with the 🚨🚨 emoji so changelog authors can further highlight this if needed.

## Pre-merge Checklist
Expand the relevant checklist and delete the others.

<details><summary><strong>New Connector</strong></summary>

### Community member or Airbyter

- [ ] **Community member?** Grant edit access to maintainers ([instructions](https://docs.github.com/en/github/collaborating-with-pull-requests/working-with-forks/allowing-changes-to-a-pull-request-branch-created-from-a-fork#enabling-repository-maintainer-permissions-on-existing-pull-requests))
- [ ] Secrets in the connector's spec are annotated with `airbyte_secret`
- [ ] Unit & integration tests added and passing. Community members, please provide proof of success locally e.g: screenshot or copy-paste unit, integration, and acceptance test output. To run acceptance tests for a Python connector, follow instructions in the README. For java connectors run `./gradlew :airbyte-integrations:connectors:<name>:integrationTest`.
- [ ] Code reviews completed
- [ ] Documentation updated
    - [ ] Connector's `README.md`
    - [ ] Connector's `bootstrap.md`. See [description and examples](https://docs.google.com/document/d/1ypdgmwmEHWv-TrO4_YOQ7pAJGVrMp5BOkEVh831N260/edit?usp=sharing)
    - [ ] `docs/integrations/<source or destination>/<name>.md` including changelog. See changelog [example](https://docs.airbyte.io/integrations/sources/stripe#changelog)
    - [ ] `docs/integrations/README.md`
    - [ ] `airbyte-integrations/builds.md`
- [ ] PR name follows [PR naming conventions](https://docs.airbyte.io/contributing-to-airbyte/updating-documentation#issues-and-pull-requests)

### Airbyter

If this is a community PR, the Airbyte engineer reviewing this PR is responsible for the below items.

- [ ] Create a non-forked branch based on this PR and test the below items on it
- [ ] Build is successful
- [ ] If new credentials are required for use in CI, add them to GSM. [Instructions](https://docs.airbyte.io/connector-development#using-credentials-in-ci).
- [ ] [`/test connector=connectors/<name>` command](https://docs.airbyte.io/connector-development#updating-an-existing-connector) is passing
- [ ] New Connector version released on Dockerhub by running the `/publish` command described [here](https://docs.airbyte.io/connector-development#updating-an-existing-connector)
- [ ] After the connector is published, connector added to connector index as described [here](https://docs.airbyte.io/connector-development#publishing-a-connector)
- [ ] Seed specs have been re-generated by building the platform and committing the changes to the seed spec files, as described [here](https://docs.airbyte.io/connector-development#publishing-a-connector)

</details>

<details><summary><strong>Updating a connector</strong></summary>

### Community member or Airbyter

- [ ] Grant edit access to maintainers ([instructions](https://docs.github.com/en/github/collaborating-with-pull-requests/working-with-forks/allowing-changes-to-a-pull-request-branch-created-from-a-fork#enabling-repository-maintainer-permissions-on-existing-pull-requests))
- [ ] Secrets in the connector's spec are annotated with `airbyte_secret`
- [ ] Unit & integration tests added and passing. Community members, please provide proof of success locally e.g: screenshot or copy-paste unit, integration, and acceptance test output. To run acceptance tests for a Python connector, follow instructions in the README. For java connectors run `./gradlew :airbyte-integrations:connectors:<name>:integrationTest`.
- [ ] Code reviews completed
- [ ] Documentation updated
    - [ ] Connector's `README.md`
    - [ ] Connector's `bootstrap.md`. See [description and examples](https://docs.google.com/document/d/1ypdgmwmEHWv-TrO4_YOQ7pAJGVrMp5BOkEVh831N260/edit?usp=sharing)
    - [ ] Changelog updated in `docs/integrations/<source or destination>/<name>.md` including changelog. See changelog [example](https://docs.airbyte.io/integrations/sources/stripe#changelog)
- [ ] PR name follows [PR naming conventions](https://docs.airbyte.io/contributing-to-airbyte/updating-documentation#issues-and-pull-requests)

### Airbyter

If this is a community PR, the Airbyte engineer reviewing this PR is responsible for the below items.

- [ ] Create a non-forked branch based on this PR and test the below items on it
- [ ] Build is successful
- [ ] If new credentials are required for use in CI, add them to GSM. [Instructions](https://docs.airbyte.io/connector-development#using-credentials-in-ci).
- [ ] [`/test connector=connectors/<name>` command](https://docs.airbyte.io/connector-development#updating-an-existing-connector) is passing
- [ ] New Connector version released on Dockerhub and connector version bumped by running the `/publish` command described [here](https://docs.airbyte.io/connector-development#updating-an-existing-connector)

</details>

<details><summary><strong>Connector Generator</strong></summary>

- [ ] Issue acceptance criteria met
- [ ] PR name follows [PR naming conventions](https://docs.airbyte.io/contributing-to-airbyte/updating-documentation#issues-and-pull-requests)
- [ ] If adding a new generator, add it to the [list of scaffold modules being tested](https://github.com/airbytehq/airbyte/blob/master/airbyte-integrations/connector-templates/generator/build.gradle#L41)
- [ ] The generator test modules (all connectors with `-scaffold` in their name) have been updated with the latest scaffold by running `./gradlew :airbyte-integrations:connector-templates:generator:testScaffoldTemplates` then checking in your changes
- [ ] Documentation which references the generator is updated as needed

</details>

## Tests

<details><summary><strong>Unit</strong></summary>

*Put your unit tests output here.*

</details>

<details><summary><strong>Integration</strong></summary>

*Put your integration tests output here.*

</details>

<details><summary><strong>Acceptance</strong></summary>

*Put your acceptance tests output here.*

</details>
