### PR TITLE
:window: :art: Add tooltip to source-defined cursors and primary keys

### DIFF
--- a/airbyte-webapp/src/views/Connection/CatalogTree/components/PathPopout.module.scss
+++ b/airbyte-webapp/src/views/Connection/CatalogTree/components/PathPopout.module.scss
@@ -1,5 +1,3 @@
-@use "../../../../scss/variables";
-
 .text {
   max-width: 300px;
   overflow: hidden;

--- a/airbyte-webapp/src/views/Connection/CatalogTree/components/PathPopout.module.scss
+++ b/airbyte-webapp/src/views/Connection/CatalogTree/components/PathPopout.module.scss
@@ -1,0 +1,7 @@
+@use "../../../../scss/variables";
+
+.text {
+  max-width: 300px;
+  overflow: hidden;
+  text-overflow: ellipsis;
+}

--- a/airbyte-webapp/src/views/Connection/CatalogTree/components/PathPopout.tsx
+++ b/airbyte-webapp/src/views/Connection/CatalogTree/components/PathPopout.tsx
@@ -1,6 +1,7 @@
 import React from "react";
 
 import { Popout } from "components";
+import { Tooltip } from "components/base/Tooltip";
 
 import { Path } from "core/domain/catalog";
 
@@ -41,7 +42,7 @@ export const PathPopout: React.FC<PathPopoutProps> = (props) => {
           : pathDisplayName(props.path)
         : "";
 
-      return <>{text}</>;
+      return <Tooltip control={<>{text}</>}>{text}</Tooltip>;
     }
     return <>{"<sourceDefined>"}</>;
   }

--- a/airbyte-webapp/src/views/Connection/CatalogTree/components/PathPopout.tsx
+++ b/airbyte-webapp/src/views/Connection/CatalogTree/components/PathPopout.tsx
@@ -42,7 +42,11 @@ export const PathPopout: React.FC<PathPopoutProps> = (props) => {
           : pathDisplayName(props.path)
         : "";
 
-      return <Tooltip control={<>{text}</>}>{text}</Tooltip>;
+      return (
+        <Tooltip placement="bottom-start" control={<>{text}</>}>
+          {text}
+        </Tooltip>
+      );
     }
     return <>{"<sourceDefined>"}</>;
   }

--- a/airbyte-webapp/src/views/Connection/CatalogTree/components/PathPopout.tsx
+++ b/airbyte-webapp/src/views/Connection/CatalogTree/components/PathPopout.tsx
@@ -5,6 +5,7 @@ import { Tooltip } from "components/base/Tooltip";
 
 import { Path } from "core/domain/catalog";
 
+import styles from "./PathPopout.module.scss";
 import { PathPopoutButton } from "./PathPopoutButton";
 
 export function pathDisplayName(path: Path): string {
@@ -43,7 +44,7 @@ export const PathPopout: React.FC<PathPopoutProps> = (props) => {
         : "";
 
       return (
-        <Tooltip placement="bottom-start" control={<>{text}</>}>
+        <Tooltip placement="bottom-start" control={<div className={styles.text}>{text}</div>}>
           {text}
         </Tooltip>
       );


### PR DESCRIPTION
## What
I noticed when someone was screen-sharing today that there was no tooltip shown for a cursor or primary key in the case that it is source-defined. This is not great, because source-defined cursors and primary keys can be cut off due to them being too long, in which case there is no way for the user to see the full string in the UI, as shown in this screen recording:

https://user-images.githubusercontent.com/22731524/187309227-baa98592-bc80-4f30-807c-9376892de8e5.mov

## How
This PR solves the issue by adding a `Tooltip` around the path text in the case that it is source-defined, so users can now see the full string when hovering over it:

https://user-images.githubusercontent.com/22731524/187309478-f0e95abe-bd71-445d-996f-ca9a915a5438.mov

## Recommended reading order
1. `x.java`
2. `y.python`

## 🚨 User Impact 🚨
Users can now see a tooltip with the full cursor or primary key when hovering over it in the connection replication view

