### PR TITLE
Add is_test db config to test harness

### DIFF
--- a/airbyte-test-utils/src/main/java/io/airbyte/test/utils/AirbyteAcceptanceTestHarness.java
+++ b/airbyte-test-utils/src/main/java/io/airbyte/test/utils/AirbyteAcceptanceTestHarness.java
@@ -145,6 +145,7 @@ public class AirbyteAcceptanceTestHarness {
   public static final String AWESOME_PEOPLE_TABLE_NAME = "awesome_people";
 
   private static final String DEFAULT_POSTGRES_INIT_SQL_FILE = "postgres_init.sql";
+  private static final String IS_TEST = "is_test";
 
   private static boolean isKube;
   private static boolean isMinikube;
@@ -488,20 +489,16 @@ public class AirbyteAcceptanceTestHarness {
     );
   }
 
-  public DestinationRead createPostgresDestination() throws ApiException {
+  public DestinationRead createPostgresDestination(final boolean isLegacy) throws ApiException {
     return createDestination(
         "AccTestDestination-" + UUID.randomUUID(),
         defaultWorkspaceId,
         getPostgresDestinationDefinitionId(),
-        getDestinationDbConfig());
+        getDestinationDbConfig(isLegacy));
   }
 
-  public DestinationRead createPostgresStrictEnforceDestination() throws ApiException {
-    return createDestination(
-        "AccTestDestination-" + UUID.randomUUID(),
-        defaultWorkspaceId,
-        getPostgresDestinationDefinitionId(),
-        getDestinationDbStrictEnforceConfig());
+  public DestinationRead createPostgresDestination() throws ApiException {
+    return createPostgresDestination(false);
   }
 
   public DestinationRead createDestination(final String name,
@@ -564,20 +561,20 @@ public class AirbyteAcceptanceTestHarness {
     return retrieveDestinationRecords(destination, rawTablePair.getFullyQualifiedTableName());
   }
 
-  public JsonNode getSourceDbConfig() {
-    return getDbConfig(sourcePsql, false, false, false, Type.SOURCE);
+  public JsonNode getSourceDbConfig(final boolean isLegacy) {
+    return getDbConfig(sourcePsql, false, false, isLegacy, Type.SOURCE);
   }
 
-  public JsonNode getSourceDbStrictEnforceConfig() {
-    return getDbConfig(sourcePsql, false, false, true, Type.SOURCE);
+  public JsonNode getSourceDbConfig() {
+    return getSourceDbConfig(false);
+  }
+
+  public JsonNode getDestinationDbConfig(final boolean isLegacy) {
+    return getDbConfig(destinationPsql, false, true, isLegacy, Type.DESTINATION);
   }
 
   public JsonNode getDestinationDbConfig() {
-    return getDbConfig(destinationPsql, false, true, false, Type.DESTINATION);
-  }
-
-  public JsonNode getDestinationDbStrictEnforceConfig() {
-    return getDbConfig(destinationPsql, false, true, true, Type.DESTINATION);
+    return getDestinationDbConfig(false);
   }
 
   public JsonNode getDestinationDbConfigWithHiddenPassword() {
@@ -587,11 +584,11 @@ public class AirbyteAcceptanceTestHarness {
   public JsonNode getDbConfig(final PostgreSQLContainer psql,
                               final boolean hiddenPassword,
                               final boolean withSchema,
-                              final boolean strictEnforce,
+                              final boolean isLegacy,
                               final Type connectorType) {
     try {
       final Map<Object, Object> dbConfig = (isKube && isGke) ? GKEPostgresConfig.dbConfig(connectorType, hiddenPassword, withSchema)
-          : localConfig(psql, hiddenPassword, withSchema, strictEnforce);
+          : localConfig(psql, hiddenPassword, withSchema, isLegacy);
       return Jsons.jsonNode(dbConfig);
     } catch (final Exception e) {
       throw new RuntimeException(e);
@@ -601,7 +598,7 @@ public class AirbyteAcceptanceTestHarness {
   private Map<Object, Object> localConfig(final PostgreSQLContainer psql,
                                           final boolean hiddenPassword,
                                           final boolean withSchema,
-                                          final boolean strictEnforce)
+                                          final boolean isLegacy)
       throws UnknownHostException {
     final Map<Object, Object> dbConfig = new HashMap<>();
     // don't use psql.getHost() directly since the ip we need differs depending on environment
@@ -628,11 +625,12 @@ public class AirbyteAcceptanceTestHarness {
     dbConfig.put(JdbcUtils.PORT_KEY, psql.getFirstMappedPort());
     dbConfig.put(JdbcUtils.DATABASE_KEY, psql.getDatabaseName());
     dbConfig.put(JdbcUtils.USERNAME_KEY, psql.getUsername());
-    // Some database docker images labeled strict-enforce do not contain an option to ssl off, so it is
-    // not included in the schema.
-    if (!strictEnforce) {
-      dbConfig.put(JdbcUtils.SSL_KEY, false);
+
+    // bypasses the SSL modification for cloud acceptance tests
+    if (!isLegacy) {
+      dbConfig.put(IS_TEST, true);
     }
+    dbConfig.put(JdbcUtils.SSL_KEY, false);
 
     if (withSchema) {
       dbConfig.put(JdbcUtils.SCHEMA_KEY, "public");
@@ -656,20 +654,16 @@ public class AirbyteAcceptanceTestHarness {
         .documentationUrl(URI.create("https://example.com")));
   }
 
-  public SourceRead createPostgresSource() throws ApiException {
+  public SourceRead createPostgresSource(final boolean isLegacy) throws ApiException {
     return createSource(
         "acceptanceTestDb-" + UUID.randomUUID(),
         defaultWorkspaceId,
         getPostgresSourceDefinitionId(),
-        getSourceDbConfig());
+        getSourceDbConfig(isLegacy));
   }
 
-  public SourceRead createPostgresStrictEnforceSource() throws ApiException {
-    return createSource(
-        "acceptanceTestDb-" + UUID.randomUUID(),
-        defaultWorkspaceId,
-        getPostgresSourceDefinitionId(),
-        getSourceDbStrictEnforceConfig());
+  public SourceRead createPostgresSource() throws ApiException {
+    return createPostgresSource(false);
   }
 
   public SourceRead createSource(final String name, final UUID workspaceId, final UUID sourceDefId, final JsonNode sourceConfig)

--- a/airbyte-test-utils/src/main/java/io/airbyte/test/utils/AirbyteAcceptanceTestHarness.java
+++ b/airbyte-test-utils/src/main/java/io/airbyte/test/utils/AirbyteAcceptanceTestHarness.java
@@ -145,6 +145,8 @@ public class AirbyteAcceptanceTestHarness {
   public static final String AWESOME_PEOPLE_TABLE_NAME = "awesome_people";
 
   private static final String DEFAULT_POSTGRES_INIT_SQL_FILE = "postgres_init.sql";
+
+  // Used for bypassing SSL modification for db configs
   private static final String IS_TEST = "is_test";
 
   private static boolean isKube;
@@ -626,7 +628,9 @@ public class AirbyteAcceptanceTestHarness {
     dbConfig.put(JdbcUtils.DATABASE_KEY, psql.getDatabaseName());
     dbConfig.put(JdbcUtils.USERNAME_KEY, psql.getUsername());
 
-    // bypasses the SSL modification for cloud acceptance tests
+    // bypasses the SSL modification for cloud acceptance tests. This use useful in cloud since it
+    // enforces most databases to have SSL on, but the postgres containers we use for testing does not
+    // allow SSL.
     if (!isLegacy) {
       dbConfig.put(IS_TEST, true);
     }

--- a/airbyte-tests/src/acceptanceTests/java/io/airbyte/test/acceptance/BasicAcceptanceTests.java
+++ b/airbyte-tests/src/acceptanceTests/java/io/airbyte/test/acceptance/BasicAcceptanceTests.java
@@ -954,11 +954,11 @@ class BasicAcceptanceTests {
       return null;
     });
 
-    final SourceRead source = testHarness.createPostgresSource();
+    final SourceRead source = testHarness.createPostgresSource(true);
     final UUID sourceId = source.getSourceId();
     final UUID sourceDefinitionId = source.getSourceDefinitionId();
     final AirbyteCatalog catalog = testHarness.discoverSourceSchema(sourceId);
-    final UUID destinationId = testHarness.createPostgresDestination().getDestinationId();
+    final UUID destinationId = testHarness.createPostgresDestination(true).getDestinationId();
     final OperationRead operation = testHarness.createOperation();
     final String name = "test_reset_when_schema_is_modified_" + UUID.randomUUID();
 


### PR DESCRIPTION
Sets the is_test flag to true in the config to bypass the SSL modification for cloud acceptance tests.

Fixes issues first caused by https://github.com/airbytehq/airbyte/pull/15932, where the original change caused acceptance test failures for legacy versions of postgres.