### PR TITLE
🪟 🔧 🧹 Migrate attempt `bytesSynced` to `totalStats.bytesEmitted` and cleanup `AttemptDetails` component

### DIFF
--- a/airbyte-webapp/src/components/JobItem/components/AttemptDetails.module.scss
+++ b/airbyte-webapp/src/components/JobItem/components/AttemptDetails.module.scss
@@ -1,12 +1,18 @@
 @use "../../../scss/colors";
+@use "../../../scss/variables";
 
-.details {
+.container {
   font-size: 12px;
   line-height: 15px;
   color: colors.$grey;
 }
 
-.truncate {
+.details > *:not(:last-child):after {
+  content: "|";
+  padding: 0 variables.$spacing-sm;
+}
+
+.failedMessage {
   white-space: nowrap;
   overflow: hidden;
   text-overflow: ellipsis;

--- a/airbyte-webapp/src/components/JobItem/components/AttemptDetails.module.scss
+++ b/airbyte-webapp/src/components/JobItem/components/AttemptDetails.module.scss
@@ -7,7 +7,7 @@
   color: colors.$grey;
 }
 
-.details > *:not(:last-child):after {
+.details > *:not(:last-child)::after {
   content: "|";
   padding: 0 variables.$spacing-sm;
 }

--- a/airbyte-webapp/src/components/JobItem/components/AttemptDetails.tsx
+++ b/airbyte-webapp/src/components/JobItem/components/AttemptDetails.tsx
@@ -71,7 +71,7 @@ const AttemptDetails: React.FC<IProps> = ({ attempt, className, configType }) =>
   return (
     <div className={classNames(styles.details, className)}>
       <div>
-        <span>{formatBytes(attempt?.bytesSynced)} | </span>
+        <span>{formatBytes(attempt?.totalStats?.bytesEmitted)} | </span>
         <span>
           <FormattedMessage
             id="sources.countEmittedRecords"

--- a/airbyte-webapp/src/components/JobItem/components/AttemptDetails.tsx
+++ b/airbyte-webapp/src/components/JobItem/components/AttemptDetails.tsx
@@ -69,37 +69,34 @@ const AttemptDetails: React.FC<IProps> = ({ attempt, className, configType }) =>
   const isFailed = attempt.status === Status.FAILED;
 
   return (
-    <div className={classNames(styles.details, className)}>
-      <div>
-        <span>{formatBytes(attempt?.totalStats?.bytesEmitted)} | </span>
+    <div className={classNames(styles.container, className)}>
+      <div className={styles.details}>
+        <span>{formatBytes(attempt?.totalStats?.bytesEmitted)}</span>
         <span>
           <FormattedMessage
             id="sources.countEmittedRecords"
             values={{ count: attempt.totalStats?.recordsEmitted || 0 }}
-          />{" "}
-          |{" "}
+          />
         </span>
         <span>
           <FormattedMessage
             id="sources.countCommittedRecords"
             values={{ count: attempt.totalStats?.recordsCommitted || 0 }}
-          />{" "}
-          |{" "}
+          />
         </span>
         <span>
           {hours ? <FormattedMessage id="sources.hour" values={{ hour: hours }} /> : null}
           {hours || minutes ? <FormattedMessage id="sources.minute" values={{ minute: minutes }} /> : null}
           <FormattedMessage id="sources.second" values={{ second: seconds }} />
         </span>
-        {configType ? (
+        {configType && (
           <span>
-            {" "}
-            | <FormattedMessage id={`sources.${configType}`} defaultMessage={configType} />
+            <FormattedMessage id={`sources.${configType}`} defaultMessage={configType} />
           </span>
-        ) : null}
+        )}
       </div>
       {isFailed && (
-        <div className={styles.truncate}>
+        <div className={styles.failedMessage}>
           {formatMessage(
             {
               id: "ui.keyValuePairV3",


### PR DESCRIPTION
## What
Resolves #15333 

* Migrates the use of `ReadAttempt.bytesSynced` to `ReadAttempt.totalStats.bytesEmitted`
* Cleans up the way the component renders the `|` in between each stat
