### PR TITLE
fix: run.delete() not available in pygithub

### DIFF
--- a/tools/bin/cleanup-workflow-runs.py
+++ b/tools/bin/cleanup-workflow-runs.py
@@ -71,7 +71,7 @@ def main():
                     break # don't clean up if it has a run newer than 90 days
                 if args.delete is not None:
                     print("Deleting run id " + str(run.id))
-                    run.delete()
+                    run._requester.requestJson("DELETE", run.url) # normally we would use run.delete() but even though it's been merged it's not yet in pypi: https://github.com/PyGithub/PyGithub/pull/2078
                 else:
                     runs_to_delete.append((workflow.name, run.id, run.created_at.strftime("%m/%d/%Y, %H:%M:%S")))
                 


### PR DESCRIPTION
## What
WorkflowRun.delete() is available in the PyGitHub repo but it hasn't yet been released to PyPi.

## How
This PR uses the underlying methodology that the class  uses to perform the delete instead.
