### PR TITLE
🐛 Source Tiktok: unnest `cursor` and `primary key` to the root-level

### DIFF
--- a/airbyte-config/init/src/main/resources/seed/source_definitions.yaml
+++ b/airbyte-config/init/src/main/resources/seed/source_definitions.yaml
@@ -1012,7 +1012,7 @@
 - name: TikTok Marketing
   sourceDefinitionId: 4bfac00d-ce15-44ff-95b9-9e3c3e8fbd35
   dockerRepository: airbyte/source-tiktok-marketing
-  dockerImageTag: 0.1.14
+  dockerImageTag: 0.1.15
   documentationUrl: https://docs.airbyte.io/integrations/sources/tiktok-marketing
   icon: tiktok.svg
   sourceType: api

--- a/airbyte-config/init/src/main/resources/seed/source_specs.yaml
+++ b/airbyte-config/init/src/main/resources/seed/source_specs.yaml
@@ -10053,7 +10053,7 @@
     supportsNormalization: false
     supportsDBT: false
     supported_destination_sync_modes: []
-- dockerImage: "airbyte/source-tiktok-marketing:0.1.14"
+- dockerImage: "airbyte/source-tiktok-marketing:0.1.15"
   spec:
     documentationUrl: "https://docs.airbyte.io/integrations/sources/tiktok-marketing"
     changelogUrl: "https://docs.airbyte.io/integrations/sources/tiktok-marketing"

--- a/airbyte-integrations/connectors/source-tiktok-marketing/Dockerfile
+++ b/airbyte-integrations/connectors/source-tiktok-marketing/Dockerfile
@@ -32,5 +32,5 @@ COPY source_tiktok_marketing ./source_tiktok_marketing
 ENV AIRBYTE_ENTRYPOINT "python /airbyte/integration_code/main.py"
 ENTRYPOINT ["python", "/airbyte/integration_code/main.py"]
 
-LABEL io.airbyte.version=0.1.14
+LABEL io.airbyte.version=0.1.15
 LABEL io.airbyte.name=airbyte/source-tiktok-marketing

--- a/airbyte-integrations/connectors/source-tiktok-marketing/README.md
+++ b/airbyte-integrations/connectors/source-tiktok-marketing/README.md
@@ -99,7 +99,8 @@ Customize `acceptance-test-config.yml` file to configure tests. See [Source Acce
 If your connector requires to create or destroy resources for use during acceptance tests create fixtures for it and place them inside integration_tests/acceptance.py.
 To run your integration tests with acceptance tests, from the connector root, run
 ```
-python -m pytest integration_tests -p integration_tests.acceptance
+docker build . --no-cache -t airbyte/source-tiktok-marketing:dev \
+&& python -m pytest -p source_acceptance_test.plugin
 ```
 To run your integration tests with docker
 

--- a/airbyte-integrations/connectors/source-tiktok-marketing/acceptance-test-config.yml
+++ b/airbyte-integrations/connectors/source-tiktok-marketing/acceptance-test-config.yml
@@ -13,11 +13,6 @@ tests:
       status: "succeed"
     - config_path: "secrets/prod_config_with_lifetime_granularity.json"
       status: "succeed"
-# Sandbox creds are not working temporary because of issues from APi side
-#    - config_path: "secrets/config.json"
-#      status: "succeed"
-#    - config_path: "secrets/new_config_sandbox.json"
-#      status: "succeed"
     - config_path: "secrets/new_config_prod.json"
       status: "succeed"
     - config_path: "secrets/config_oauth.json"
@@ -31,11 +26,23 @@ tests:
 
   discovery:
     - config_path: "secrets/prod_config.json"
+      backward_compatibility_tests_config:
+        disable_for_version: "0.1.14"
     - config_path: "secrets/prod_config_with_day_granularity.json"
+      backward_compatibility_tests_config:
+        disable_for_version: "0.1.14"
     - config_path: "secrets/prod_config_with_lifetime_granularity.json"
+      backward_compatibility_tests_config:
+        disable_for_version: "0.1.14"
     - config_path: "secrets/config.json"
+      backward_compatibility_tests_config:
+        disable_for_version: "0.1.14"
     - config_path: "secrets/new_config_prod.json"
+      backward_compatibility_tests_config:
+        disable_for_version: "0.1.14"
     - config_path: "secrets/config_oauth.json"
+      backward_compatibility_tests_config:
+        disable_for_version: "0.1.14"
 
   basic_read:
     # New style streams (for >= 0.1.13):

--- a/airbyte-integrations/connectors/source-tiktok-marketing/integration_tests/abnormal_state.json
+++ b/airbyte-integrations/connectors/source-tiktok-marketing/integration_tests/abnormal_state.json
@@ -10,42 +10,50 @@
   },
 
   "ads_reports_daily": {
+    "stat_time_day": "2030-01-01",
     "dimensions": {
       "stat_time_day": "2030-01-01"
     }
   },
   "advertisers_reports_daily": {
+    "stat_time_day": "2030-01-01",
     "dimensions": {
       "stat_time_day": "2030-01-01"
     }
   },
   "ad_groups_reports_daily": {
+    "stat_time_day": "2030-01-01",
     "dimensions": {
       "stat_time_day": "2030-01-01"
     }
   },
   "campaigns_reports_daily": {
+    "stat_time_day": "2030-01-01",
     "dimensions": {
       "stat_time_day": "2030-01-01"
     }
   },
 
   "ads_audience_reports_daily": {
+    "stat_time_day": "2030-01-01",
     "dimensions": {
       "stat_time_day": "2030-01-01"
     }
   },
   "advertisers_audience_reports_daily": {
+    "stat_time_day": "2030-01-01",
     "dimensions": {
       "stat_time_day": "2030-01-01"
     }
   },
   "ad_group_audience_reports_daily": {
+    "stat_time_day": "2030-01-01",
     "dimensions": {
       "stat_time_day": "2030-01-01"
     }
   },
   "campaigns_audience_reports_by_country_daily": {
+    "stat_time_day": "2030-01-01",
     "dimensions": {
       "stat_time_day": "2030-01-01"
     }

--- a/airbyte-integrations/connectors/source-tiktok-marketing/integration_tests/abnormal_state_with_granullarity.json
+++ b/airbyte-integrations/connectors/source-tiktok-marketing/integration_tests/abnormal_state_with_granullarity.json
@@ -10,42 +10,49 @@
   },
 
   "ads_reports": {
+    "stat_time_day": "2030-01-01",
     "dimensions": {
       "stat_time_day": "2030-01-01"
     }
   },
   "advertisers_reports": {
+    "stat_time_day": "2030-01-01",
     "dimensions": {
       "stat_time_day": "2030-01-01"
     }
   },
   "ad_groups_reports": {
+    "stat_time_day": "2030-01-01",
     "dimensions": {
       "stat_time_day": "2030-01-01"
     }
   },
   "campaigns_reports": {
+    "stat_time_day": "2030-01-01",
     "dimensions": {
       "stat_time_day": "2030-01-01"
     }
   },
-
   "ads_audience_reports": {
+    "stat_time_day": "2030-01-01",
     "dimensions": {
       "stat_time_day": "2030-01-01"
     }
   },
   "advertisers_audience_reports": {
+    "stat_time_day": "2030-01-01",
     "dimensions": {
       "stat_time_day": "2030-01-01"
     }
   },
   "ad_group_audience_reports": {
+    "stat_time_day": "2030-01-01",
     "dimensions": {
       "stat_time_day": "2030-01-01"
     }
   },
   "campaigns_audience_reports_by_country": {
+    "stat_time_day": "2030-01-01",
     "dimensions": {
       "stat_time_day": "2030-01-01"
     }

--- a/airbyte-integrations/connectors/source-tiktok-marketing/integration_tests/configured_catalog.json
+++ b/airbyte-integrations/connectors/source-tiktok-marketing/integration_tests/configured_catalog.json
@@ -16,7 +16,9 @@
       "stream": {
         "name": "ads_reports",
         "json_schema": {},
-        "supported_sync_modes": ["full_refresh"]
+        "supported_sync_modes": ["full_refresh"],
+        "source_defined_cursor": true,
+        "default_cursor_field": ["stat_time_day"]
       },
       "sync_mode": "full_refresh",
       "destination_sync_mode": "append"
@@ -27,7 +29,7 @@
         "json_schema": {},
         "supported_sync_modes": ["full_refresh", "incremental"],
         "source_defined_cursor": true,
-        "default_cursor_field": ["dimensions", "stat_time_day"]
+        "default_cursor_field": ["stat_time_day"]
       },
       "sync_mode": "full_refresh",
       "destination_sync_mode": "append"

--- a/airbyte-integrations/connectors/source-tiktok-marketing/integration_tests/streams.json
+++ b/airbyte-integrations/connectors/source-tiktok-marketing/integration_tests/streams.json
@@ -37,14 +37,14 @@
         "json_schema": {},
         "supported_sync_modes": ["full_refresh", "incremental"],
         "source_defined_cursor": true,
-        "default_cursor_field": ["dimensions", "stat_time_hour"]
+        "default_cursor_field": ["stat_time_hour"]
       },
       {
         "name": "ads_reports_daily",
         "json_schema": {},
         "supported_sync_modes": ["full_refresh", "incremental"],
         "source_defined_cursor": true,
-        "default_cursor_field": ["dimensions", "stat_time_day"]
+        "default_cursor_field": ["stat_time_day"]
       },
       {
         "name": "ads_reports_lifetime",
@@ -56,14 +56,14 @@
         "json_schema": {},
         "supported_sync_modes": ["full_refresh", "incremental"],
         "source_defined_cursor": true,
-        "default_cursor_field": ["dimensions", "stat_time_hour"]
+        "default_cursor_field": ["stat_time_hour"]
       },
       {
         "name": "ad_groups_reports_daily",
         "json_schema": {},
         "supported_sync_modes": ["full_refresh", "incremental"],
         "source_defined_cursor": true,
-        "default_cursor_field": ["dimensions", "stat_time_day"]
+        "default_cursor_field": ["stat_time_day"]
       },
       {
         "name": "ad_groups_reports_lifetime",
@@ -75,14 +75,14 @@
         "json_schema": {},
         "supported_sync_modes": ["full_refresh", "incremental"],
         "source_defined_cursor": true,
-        "default_cursor_field": ["dimensions", "stat_time_hour"]
+        "default_cursor_field": ["stat_time_hour"]
       },
       {
         "name": "campaigns_reports_daily",
         "json_schema": {},
         "supported_sync_modes": ["full_refresh", "incremental"],
         "source_defined_cursor": true,
-        "default_cursor_field": ["dimensions", "stat_time_day"]
+        "default_cursor_field": ["stat_time_day"]
       },
       {
         "name": "campaigns_reports_lifetime",
@@ -94,14 +94,14 @@
         "json_schema": {},
         "supported_sync_modes": ["full_refresh", "incremental"],
         "source_defined_cursor": true,
-        "default_cursor_field": ["dimensions", "stat_time_hour"]
+        "default_cursor_field": ["stat_time_hour"]
       },
       {
         "name": "advertisers_reports_daily",
         "json_schema": {},
         "supported_sync_modes": ["full_refresh", "incremental"],
         "source_defined_cursor": true,
-        "default_cursor_field": ["dimensions", "stat_time_day"]
+        "default_cursor_field": ["stat_time_day"]
       },
       {
         "name": "advertisers_reports_lifetime",
@@ -113,14 +113,14 @@
         "json_schema": {},
         "supported_sync_modes": ["full_refresh", "incremental"],
         "source_defined_cursor": true,
-        "default_cursor_field": ["dimensions", "stat_time_hour"]
+        "default_cursor_field": ["stat_time_hour"]
       },
       {
         "name": "advertisers_audience_reports_daily",
         "json_schema": {},
         "supported_sync_modes": ["full_refresh", "incremental"],
         "source_defined_cursor": true,
-        "default_cursor_field": ["dimensions", "stat_time_day"]
+        "default_cursor_field": ["stat_time_day"]
       },
       {
         "name": "advertisers_audience_reports_lifetime",
@@ -132,42 +132,42 @@
         "json_schema": {},
         "supported_sync_modes": ["full_refresh", "incremental"],
         "source_defined_cursor": true,
-        "default_cursor_field": ["dimensions", "stat_time_hour"]
+        "default_cursor_field": ["stat_time_hour"]
       },
       {
         "name": "ads_audience_reports_daily",
         "json_schema": {},
         "supported_sync_modes": ["full_refresh", "incremental"],
         "source_defined_cursor": true,
-        "default_cursor_field": ["dimensions", "stat_time_day"]
+        "default_cursor_field": ["stat_time_day"]
       },
       {
         "name": "ad_group_audience_reports_hourly",
         "json_schema": {},
         "supported_sync_modes": ["full_refresh", "incremental"],
         "source_defined_cursor": true,
-        "default_cursor_field": ["dimensions", "stat_time_hour"]
+        "default_cursor_field": ["stat_time_hour"]
       },
       {
         "name": "ad_group_audience_reports_daily",
         "json_schema": {},
         "supported_sync_modes": ["full_refresh", "incremental"],
         "source_defined_cursor": true,
-        "default_cursor_field": ["dimensions", "stat_time_day"]
+        "default_cursor_field": ["stat_time_day"]
       },
       {
         "name": "campaigns_audience_reports_by_country_hourly",
         "json_schema": {},
         "supported_sync_modes": ["full_refresh", "incremental"],
         "source_defined_cursor": true,
-        "default_cursor_field": ["dimensions", "stat_time_hour"]
+        "default_cursor_field": ["stat_time_hour"]
       },
       {
         "name": "campaigns_audience_reports_by_country_daily",
         "json_schema": {},
         "supported_sync_modes": ["full_refresh", "incremental"],
         "source_defined_cursor": true,
-        "default_cursor_field": ["dimensions", "stat_time_day"]
+        "default_cursor_field": ["stat_time_day"]
       }
     ]
   }

--- a/airbyte-integrations/connectors/source-tiktok-marketing/integration_tests/streams_all.json
+++ b/airbyte-integrations/connectors/source-tiktok-marketing/integration_tests/streams_all.json
@@ -54,7 +54,7 @@
         "json_schema": {},
         "supported_sync_modes": ["full_refresh", "incremental"],
         "source_defined_cursor": true,
-        "default_cursor_field": ["dimensions", "stat_time_day"]
+        "default_cursor_field": ["stat_time_day"]
       },
       "sync_mode": "full_refresh",
       "destination_sync_mode": "append"
@@ -65,7 +65,7 @@
         "json_schema": {},
         "supported_sync_modes": ["full_refresh", "incremental"],
         "source_defined_cursor": true,
-        "default_cursor_field": ["dimensions", "stat_time_day"]
+        "default_cursor_field": ["stat_time_day"]
       },
       "sync_mode": "full_refresh",
       "destination_sync_mode": "append"
@@ -76,7 +76,7 @@
         "json_schema": {},
         "supported_sync_modes": ["full_refresh", "incremental"],
         "source_defined_cursor": true,
-        "default_cursor_field": ["dimensions", "stat_time_day"]
+        "default_cursor_field": ["stat_time_day"]
       },
       "sync_mode": "full_refresh",
       "destination_sync_mode": "append"
@@ -87,7 +87,7 @@
         "json_schema": {},
         "supported_sync_modes": ["full_refresh", "incremental"],
         "source_defined_cursor": true,
-        "default_cursor_field": ["dimensions", "stat_time_day"]
+        "default_cursor_field": ["stat_time_day"]
       },
       "sync_mode": "full_refresh",
       "destination_sync_mode": "append"
@@ -99,7 +99,7 @@
         "json_schema": {},
         "supported_sync_modes": ["full_refresh", "incremental"],
         "source_defined_cursor": true,
-        "default_cursor_field": ["dimensions", "stat_time_day"]
+        "default_cursor_field": ["stat_time_day"]
       },
       "sync_mode": "incremental",
       "destination_sync_mode": "append"
@@ -110,7 +110,7 @@
         "json_schema": {},
         "supported_sync_modes": ["full_refresh", "incremental"],
         "source_defined_cursor": true,
-        "default_cursor_field": ["dimensions", "stat_time_day"]
+        "default_cursor_field": ["stat_time_day"]
       },
       "sync_mode": "full_refresh",
       "destination_sync_mode": "append"
@@ -121,7 +121,7 @@
         "json_schema": {},
         "supported_sync_modes": ["full_refresh", "incremental"],
         "source_defined_cursor": true,
-        "default_cursor_field": ["dimensions", "stat_time_day"]
+        "default_cursor_field": ["stat_time_day"]
       },
       "sync_mode": "full_refresh",
       "destination_sync_mode": "append"
@@ -132,7 +132,7 @@
         "json_schema": {},
         "supported_sync_modes": ["full_refresh", "incremental"],
         "source_defined_cursor": true,
-        "default_cursor_field": ["dimensions", "stat_time_day"]
+        "default_cursor_field": ["stat_time_day"]
       },
       "sync_mode": "full_refresh",
       "destination_sync_mode": "append"

--- a/airbyte-integrations/connectors/source-tiktok-marketing/integration_tests/streams_all_incremental.json
+++ b/airbyte-integrations/connectors/source-tiktok-marketing/integration_tests/streams_all_incremental.json
@@ -54,7 +54,7 @@
         "json_schema": {},
         "supported_sync_modes": ["full_refresh", "incremental"],
         "source_defined_cursor": true,
-        "default_cursor_field": ["dimensions", "stat_time_day"]
+        "default_cursor_field": ["stat_time_day"]
       },
       "sync_mode": "incremental",
       "destination_sync_mode": "append"
@@ -65,7 +65,7 @@
         "json_schema": {},
         "supported_sync_modes": ["full_refresh", "incremental"],
         "source_defined_cursor": true,
-        "default_cursor_field": ["dimensions", "stat_time_day"]
+        "default_cursor_field": ["stat_time_day"]
       },
       "sync_mode": "incremental",
       "destination_sync_mode": "append"
@@ -76,7 +76,7 @@
         "json_schema": {},
         "supported_sync_modes": ["full_refresh", "incremental"],
         "source_defined_cursor": true,
-        "default_cursor_field": ["dimensions", "stat_time_day"]
+        "default_cursor_field": ["stat_time_day"]
       },
       "sync_mode": "incremental",
       "destination_sync_mode": "append"
@@ -87,7 +87,7 @@
         "json_schema": {},
         "supported_sync_modes": ["full_refresh", "incremental"],
         "source_defined_cursor": true,
-        "default_cursor_field": ["dimensions", "stat_time_day"]
+        "default_cursor_field": ["stat_time_day"]
       },
       "sync_mode": "incremental",
       "destination_sync_mode": "append"

--- a/airbyte-integrations/connectors/source-tiktok-marketing/integration_tests/streams_audience_incremental.json
+++ b/airbyte-integrations/connectors/source-tiktok-marketing/integration_tests/streams_audience_incremental.json
@@ -6,7 +6,7 @@
         "json_schema": {},
         "supported_sync_modes": ["full_refresh", "incremental"],
         "source_defined_cursor": true,
-        "default_cursor_field": ["dimensions", "stat_time_day"]
+        "default_cursor_field": ["stat_time_day"]
       },
       "sync_mode": "incremental",
       "destination_sync_mode": "append"
@@ -17,7 +17,7 @@
         "json_schema": {},
         "supported_sync_modes": ["full_refresh", "incremental"],
         "source_defined_cursor": true,
-        "default_cursor_field": ["dimensions", "stat_time_day"]
+        "default_cursor_field": ["stat_time_day"]
       },
       "sync_mode": "incremental",
       "destination_sync_mode": "append"
@@ -28,7 +28,7 @@
         "json_schema": {},
         "supported_sync_modes": ["full_refresh", "incremental"],
         "source_defined_cursor": true,
-        "default_cursor_field": ["dimensions", "stat_time_day"]
+        "default_cursor_field": ["stat_time_day"]
       },
       "sync_mode": "incremental",
       "destination_sync_mode": "append"

--- a/airbyte-integrations/connectors/source-tiktok-marketing/integration_tests/streams_reports_daily.json
+++ b/airbyte-integrations/connectors/source-tiktok-marketing/integration_tests/streams_reports_daily.json
@@ -6,7 +6,7 @@
         "json_schema": {},
         "supported_sync_modes": ["full_refresh", "incremental"],
         "source_defined_cursor": true,
-        "default_cursor_field": ["dimensions", "stat_time_day"]
+        "default_cursor_field": ["stat_time_day"]
       },
       "sync_mode": "incremental",
       "destination_sync_mode": "append"
@@ -17,7 +17,7 @@
         "json_schema": {},
         "supported_sync_modes": ["full_refresh", "incremental"],
         "source_defined_cursor": true,
-        "default_cursor_field": ["dimensions", "stat_time_day"]
+        "default_cursor_field": ["stat_time_day"]
       },
       "sync_mode": "incremental",
       "destination_sync_mode": "append"
@@ -28,7 +28,7 @@
         "json_schema": {},
         "supported_sync_modes": ["full_refresh", "incremental"],
         "source_defined_cursor": true,
-        "default_cursor_field": ["dimensions", "stat_time_day"]
+        "default_cursor_field": ["stat_time_day"]
       },
       "sync_mode": "incremental",
       "destination_sync_mode": "append"
@@ -39,7 +39,7 @@
         "json_schema": {},
         "supported_sync_modes": ["full_refresh", "incremental"],
         "source_defined_cursor": true,
-        "default_cursor_field": ["dimensions", "stat_time_day"]
+        "default_cursor_field": ["stat_time_day"]
       },
       "sync_mode": "incremental",
       "destination_sync_mode": "append"
@@ -51,7 +51,7 @@
         "json_schema": {},
         "supported_sync_modes": ["full_refresh", "incremental"],
         "source_defined_cursor": true,
-        "default_cursor_field": ["dimensions", "stat_time_day"]
+        "default_cursor_field": ["stat_time_day"]
       },
       "sync_mode": "incremental",
       "destination_sync_mode": "append"
@@ -62,7 +62,7 @@
         "json_schema": {},
         "supported_sync_modes": ["full_refresh", "incremental"],
         "source_defined_cursor": true,
-        "default_cursor_field": ["dimensions", "stat_time_day"]
+        "default_cursor_field": ["stat_time_day"]
       },
       "sync_mode": "incremental",
       "destination_sync_mode": "append"
@@ -73,7 +73,7 @@
         "json_schema": {},
         "supported_sync_modes": ["full_refresh", "incremental"],
         "source_defined_cursor": true,
-        "default_cursor_field": ["dimensions", "stat_time_day"]
+        "default_cursor_field": ["stat_time_day"]
       },
       "sync_mode": "incremental",
       "destination_sync_mode": "append"
@@ -84,7 +84,7 @@
         "json_schema": {},
         "supported_sync_modes": ["full_refresh", "incremental"],
         "source_defined_cursor": true,
-        "default_cursor_field": ["dimensions", "stat_time_day"]
+        "default_cursor_field": ["stat_time_day"]
       },
       "sync_mode": "incremental",
       "destination_sync_mode": "append"

--- a/airbyte-integrations/connectors/source-tiktok-marketing/integration_tests/streams_reports_lifetime.json
+++ b/airbyte-integrations/connectors/source-tiktok-marketing/integration_tests/streams_reports_lifetime.json
@@ -6,7 +6,7 @@
         "json_schema": {},
         "supported_sync_modes": ["full_refresh", "incremental"],
         "source_defined_cursor": true,
-        "default_cursor_field": ["dimensions", "stat_time_day"]
+        "default_cursor_field": ["stat_time_day"]
       },
       "sync_mode": "full_refresh",
       "destination_sync_mode": "append"
@@ -17,7 +17,7 @@
         "json_schema": {},
         "supported_sync_modes": ["full_refresh", "incremental"],
         "source_defined_cursor": true,
-        "default_cursor_field": ["dimensions", "stat_time_day"]
+        "default_cursor_field": ["stat_time_day"]
       },
       "sync_mode": "full_refresh",
       "destination_sync_mode": "append"
@@ -28,7 +28,7 @@
         "json_schema": {},
         "supported_sync_modes": ["full_refresh", "incremental"],
         "source_defined_cursor": true,
-        "default_cursor_field": ["dimensions", "stat_time_day"]
+        "default_cursor_field": ["stat_time_day"]
       },
       "sync_mode": "full_refresh",
       "destination_sync_mode": "append"
@@ -39,7 +39,7 @@
         "json_schema": {},
         "supported_sync_modes": ["full_refresh", "incremental"],
         "source_defined_cursor": true,
-        "default_cursor_field": ["dimensions", "stat_time_day"]
+        "default_cursor_field": ["stat_time_day"]
       },
       "sync_mode": "full_refresh",
       "destination_sync_mode": "append"
@@ -51,7 +51,7 @@
         "json_schema": {},
         "supported_sync_modes": ["full_refresh", "incremental"],
         "source_defined_cursor": true,
-        "default_cursor_field": ["dimensions", "stat_time_day"]
+        "default_cursor_field": ["stat_time_day"]
       },
       "sync_mode": "full_refresh",
       "destination_sync_mode": "append"

--- a/airbyte-integrations/connectors/source-tiktok-marketing/integration_tests/streams_with_day_granularity.json
+++ b/airbyte-integrations/connectors/source-tiktok-marketing/integration_tests/streams_with_day_granularity.json
@@ -6,7 +6,7 @@
         "json_schema": {},
         "supported_sync_modes": ["full_refresh", "incremental"],
         "source_defined_cursor": true,
-        "default_cursor_field": ["dimensions", "stat_time_day"]
+        "default_cursor_field": ["stat_time_day"]
       },
       "sync_mode": "incremental",
       "destination_sync_mode": "append"
@@ -17,7 +17,7 @@
         "json_schema": {},
         "supported_sync_modes": ["full_refresh", "incremental"],
         "source_defined_cursor": true,
-        "default_cursor_field": ["dimensions", "stat_time_day"]
+        "default_cursor_field": ["stat_time_day"]
       },
       "sync_mode": "incremental",
       "destination_sync_mode": "append"
@@ -28,7 +28,7 @@
         "json_schema": {},
         "supported_sync_modes": ["full_refresh", "incremental"],
         "source_defined_cursor": true,
-        "default_cursor_field": ["dimensions", "stat_time_day"]
+        "default_cursor_field": ["stat_time_day"]
       },
       "sync_mode": "incremental",
       "destination_sync_mode": "append"
@@ -39,7 +39,7 @@
         "json_schema": {},
         "supported_sync_modes": ["full_refresh", "incremental"],
         "source_defined_cursor": true,
-        "default_cursor_field": ["dimensions", "stat_time_day"]
+        "default_cursor_field": ["stat_time_day"]
       },
       "sync_mode": "incremental",
       "destination_sync_mode": "append"
@@ -51,7 +51,7 @@
         "json_schema": {},
         "supported_sync_modes": ["full_refresh", "incremental"],
         "source_defined_cursor": true,
-        "default_cursor_field": ["dimensions", "stat_time_day"]
+        "default_cursor_field": ["stat_time_day"]
       },
       "sync_mode": "incremental",
       "destination_sync_mode": "append"
@@ -62,7 +62,7 @@
         "json_schema": {},
         "supported_sync_modes": ["full_refresh", "incremental"],
         "source_defined_cursor": true,
-        "default_cursor_field": ["dimensions", "stat_time_day"]
+        "default_cursor_field": ["stat_time_day"]
       },
       "sync_mode": "incremental",
       "destination_sync_mode": "append"
@@ -73,7 +73,7 @@
         "json_schema": {},
         "supported_sync_modes": ["full_refresh", "incremental"],
         "source_defined_cursor": true,
-        "default_cursor_field": ["dimensions", "stat_time_day"]
+        "default_cursor_field": ["stat_time_day"]
       },
       "sync_mode": "incremental",
       "destination_sync_mode": "append"
@@ -84,7 +84,7 @@
         "json_schema": {},
         "supported_sync_modes": ["full_refresh", "incremental"],
         "source_defined_cursor": true,
-        "default_cursor_field": ["dimensions", "stat_time_day"]
+        "default_cursor_field": ["stat_time_day"]
       },
       "sync_mode": "incremental",
       "destination_sync_mode": "append"

--- a/airbyte-integrations/connectors/source-tiktok-marketing/integration_tests/streams_with_lifetime_granularity.json
+++ b/airbyte-integrations/connectors/source-tiktok-marketing/integration_tests/streams_with_lifetime_granularity.json
@@ -6,7 +6,7 @@
         "json_schema": {},
         "supported_sync_modes": ["full_refresh", "incremental"],
         "source_defined_cursor": true,
-        "default_cursor_field": ["dimensions", "stat_time_day"]
+        "default_cursor_field": ["stat_time_day"]
       },
       "sync_mode": "full_refresh",
       "destination_sync_mode": "append"
@@ -17,7 +17,7 @@
         "json_schema": {},
         "supported_sync_modes": ["full_refresh", "incremental"],
         "source_defined_cursor": true,
-        "default_cursor_field": ["dimensions", "stat_time_day"]
+        "default_cursor_field": ["stat_time_day"]
       },
       "sync_mode": "full_refresh",
       "destination_sync_mode": "append"
@@ -28,7 +28,7 @@
         "json_schema": {},
         "supported_sync_modes": ["full_refresh", "incremental"],
         "source_defined_cursor": true,
-        "default_cursor_field": ["dimensions", "stat_time_day"]
+        "default_cursor_field": ["stat_time_day"]
       },
       "sync_mode": "full_refresh",
       "destination_sync_mode": "append"
@@ -39,7 +39,7 @@
         "json_schema": {},
         "supported_sync_modes": ["full_refresh", "incremental"],
         "source_defined_cursor": true,
-        "default_cursor_field": ["dimensions", "stat_time_day"]
+        "default_cursor_field": ["stat_time_day"]
       },
       "sync_mode": "full_refresh",
       "destination_sync_mode": "append"
@@ -51,7 +51,7 @@
         "json_schema": {},
         "supported_sync_modes": ["full_refresh", "incremental"],
         "source_defined_cursor": true,
-        "default_cursor_field": ["dimensions", "stat_time_day"]
+        "default_cursor_field": ["stat_time_day"]
       },
       "sync_mode": "full_refresh",
       "destination_sync_mode": "append"

--- a/airbyte-integrations/connectors/source-tiktok-marketing/source_tiktok_marketing/schemas/audience_reports.json
+++ b/airbyte-integrations/connectors/source-tiktok-marketing/source_tiktok_marketing/schemas/audience_reports.json
@@ -2,6 +2,15 @@
   "type": ["null", "object"],
   "additionalProperties": true,
   "properties": {
+    "advertiser_id": {
+      "type": ["null", "integer"]
+    },
+    "adgroup_id": {
+      "type": ["null", "integer"]
+    },
+    "campaign_id": {
+      "type": ["null", "integer"]
+    },
     "ad_id": {
       "type": ["null", "integer"]
     },

--- a/airbyte-integrations/connectors/source-tiktok-marketing/source_tiktok_marketing/schemas/audience_reports.json
+++ b/airbyte-integrations/connectors/source-tiktok-marketing/source_tiktok_marketing/schemas/audience_reports.json
@@ -1,6 +1,18 @@
 {
   "type": ["null", "object"],
+  "additionalProperties": true,
   "properties": {
+    "ad_id": {
+      "type": ["null", "integer"]
+    },
+    "stat_time_day": {
+      "type": ["null", "string"],
+      "format": "date-time"
+    },
+    "stat_time_hour": {
+      "type": ["null", "string"],
+      "format": "date-time"
+    },
     "metrics": {
       "type": ["null", "object"],
       "properties": {

--- a/airbyte-integrations/connectors/source-tiktok-marketing/source_tiktok_marketing/schemas/basic_reports.json
+++ b/airbyte-integrations/connectors/source-tiktok-marketing/source_tiktok_marketing/schemas/basic_reports.json
@@ -2,9 +2,6 @@
   "type": ["null", "object"],
   "additionalProperties": true,
   "properties": {
-    "ad_id": {
-      "type": ["null", "integer"]
-    },
     "stat_time_day": {
       "type": ["null", "string"],
       "format": "date-time"
@@ -12,6 +9,18 @@
     "stat_time_hour": {
       "type": ["null", "string"],
       "format": "date-time"
+    },
+    "campaign_id": {
+      "type": ["null", "integer"]
+    },
+    "adgroup_id": {
+      "type": ["null", "integer"]
+    },
+    "ad_id": {
+      "type": ["null", "integer"]
+    },
+    "advertiser_id": {
+      "type": ["null", "integer"]
     },
     "metrics": {
       "type": ["null", "object"],

--- a/airbyte-integrations/connectors/source-tiktok-marketing/source_tiktok_marketing/schemas/basic_reports.json
+++ b/airbyte-integrations/connectors/source-tiktok-marketing/source_tiktok_marketing/schemas/basic_reports.json
@@ -1,6 +1,18 @@
 {
   "type": ["null", "object"],
+  "additionalProperties": true,
   "properties": {
+    "ad_id": {
+      "type": ["null", "integer"]
+    },
+    "stat_time_day": {
+      "type": ["null", "string"],
+      "format": "date-time"
+    },
+    "stat_time_hour": {
+      "type": ["null", "string"],
+      "format": "date-time"
+    },
     "metrics": {
       "type": ["null", "object"],
       "properties": {

--- a/airbyte-integrations/connectors/source-tiktok-marketing/source_tiktok_marketing/source.py
+++ b/airbyte-integrations/connectors/source-tiktok-marketing/source_tiktok_marketing/source.py
@@ -5,18 +5,12 @@
 from typing import Any, List, Mapping, Tuple
 
 from airbyte_cdk.logger import AirbyteLogger
-from airbyte_cdk.models import AdvancedAuth, AuthFlowType, ConnectorSpecification, OAuthConfigSpecification, SyncMode
-from airbyte_cdk.models.airbyte_protocol import DestinationSyncMode
+from airbyte_cdk.models import SyncMode
 from airbyte_cdk.sources import AbstractSource
 from airbyte_cdk.sources.streams import Stream
 from airbyte_cdk.sources.streams.http.auth import TokenAuthenticator
 
-from .spec import (
-    CompleteOauthOutputSpecification,
-    CompleteOauthServerInputSpecification,
-    CompleteOauthServerOutputSpecification,
-    SourceTiktokMarketingSpec,
-)
+
 from .streams import (
     DEFAULT_END_DATE,
     DEFAULT_START_DATE,
@@ -63,26 +57,6 @@ class TiktokTokenAuthenticator(TokenAuthenticator):
 
 
 class SourceTiktokMarketing(AbstractSource):
-    def spec(self, *args, **kwargs) -> ConnectorSpecification:
-        """Returns the spec for this integration."""
-        return ConnectorSpecification(
-            documentationUrl=DOCUMENTATION_URL,
-            changelogUrl=DOCUMENTATION_URL,
-            supportsIncremental=True,
-            supported_destination_sync_modes=[DestinationSyncMode.overwrite, DestinationSyncMode.append, DestinationSyncMode.append_dedup],
-            connectionSpecification=SourceTiktokMarketingSpec.schema(),
-            additionalProperties=True,
-            advanced_auth=AdvancedAuth(
-                auth_flow_type=AuthFlowType.oauth2_0,
-                predicate_key=["credentials", "auth_type"],
-                predicate_value="oauth2.0",
-                oauth_config_specification=OAuthConfigSpecification(
-                    complete_oauth_output_specification=CompleteOauthOutputSpecification.schema(),
-                    complete_oauth_server_input_specification=CompleteOauthServerInputSpecification.schema(),
-                    complete_oauth_server_output_specification=CompleteOauthServerOutputSpecification.schema(),
-                ),
-            ),
-        )
 
     @staticmethod
     def _prepare_stream_args(config: Mapping[str, Any]) -> Mapping[str, Any]:

--- a/airbyte-integrations/connectors/source-tiktok-marketing/source_tiktok_marketing/source.py
+++ b/airbyte-integrations/connectors/source-tiktok-marketing/source_tiktok_marketing/source.py
@@ -10,7 +10,6 @@ from airbyte_cdk.sources import AbstractSource
 from airbyte_cdk.sources.streams import Stream
 from airbyte_cdk.sources.streams.http.auth import TokenAuthenticator
 
-
 from .streams import (
     DEFAULT_END_DATE,
     DEFAULT_START_DATE,
@@ -57,7 +56,6 @@ class TiktokTokenAuthenticator(TokenAuthenticator):
 
 
 class SourceTiktokMarketing(AbstractSource):
-
     @staticmethod
     def _prepare_stream_args(config: Mapping[str, Any]) -> Mapping[str, Any]:
         """Converts an input configure to stream arguments"""

--- a/airbyte-integrations/connectors/source-tiktok-marketing/source_tiktok_marketing/spec.json
+++ b/airbyte-integrations/connectors/source-tiktok-marketing/source_tiktok_marketing/spec.json
@@ -1,0 +1,186 @@
+{
+    "documentationUrl": "https://docs.airbyte.io/integrations/sources/tiktok-marketing",
+    "changelogUrl": "https://docs.airbyte.io/integrations/sources/tiktok-marketing",
+    "connectionSpecification": {
+        "title": "TikTok Marketing Source Spec",
+        "type": "object",
+        "properties": {
+            "credentials": {
+                "title": "Authentication Method",
+                "description": "Authentication method",
+                "default": {},
+                "order": 0,
+                "type": "object",
+                "oneOf": [
+                    {
+                        "title": "OAuth2.0",
+                        "type": "object",
+                        "properties": {
+                            "auth_type": {
+                                "title": "Auth Type",
+                                "const": "oauth2.0",
+                                "order": 0,
+                                "type": "string"
+                            },
+                            "app_id": {
+                                "title": "App ID",
+                                "description": "The Developer Application App ID.",
+                                "airbyte_secret": true,
+                                "type": "string"
+                            },
+                            "secret": {
+                                "title": "Secret",
+                                "description": "The Developer Application Secret.",
+                                "airbyte_secret": true,
+                                "type": "string"
+                            },
+                            "access_token": {
+                                "title": "Access Token",
+                                "description": "Long-term Authorized Access Token.",
+                                "airbyte_secret": true,
+                                "type": "string"
+                            }
+                        },
+                        "required": [
+                            "app_id",
+                            "secret",
+                            "access_token"
+                        ]
+                    },
+                    {
+                        "title": "Sandbox Access Token",
+                        "type": "object",
+                        "properties": {
+                            "auth_type": {
+                                "title": "Auth Type",
+                                "const": "sandbox_access_token",
+                                "order": 0,
+                                "type": "string"
+                            },
+                            "advertiser_id": {
+                                "title": "Advertiser ID",
+                                "description": "The Advertiser ID which generated for the developer's Sandbox application.",
+                                "type": "string"
+                            },
+                            "access_token": {
+                                "title": "Access Token",
+                                "description": "The long-term authorized access token.",
+                                "airbyte_secret": true,
+                                "type": "string"
+                            }
+                        },
+                        "required": [
+                            "advertiser_id",
+                            "access_token"
+                        ]
+                    }
+                ]
+            },
+            "start_date": {
+                "title": "Replication Start Date *",
+                "description": "The Start Date in format: YYYY-MM-DD. Any data before this date will not be replicated. If this parameter is not set, all data will be replicated.",
+                "default": "2016-09-01",
+                "pattern": "^[0-9]{4}-[0-9]{2}-[0-9]{2}$",
+                "order": 1,
+                "type": "string"
+            },
+            "end_date": {
+                "title": "End Date",
+                "description": "The date until which you'd like to replicate data for all incremental streams, in the format YYYY-MM-DD. All data generated between start_date and this date will be replicated. Not setting this option will result in always syncing the data till the current date.",
+                "pattern": "^[0-9]{4}-[0-9]{2}-[0-9]{2}$",
+                "order": 2,
+                "type": "string"
+            },
+            "report_granularity": {
+                "title": "Report Aggregation Granularity",
+                "description": "The granularity used for aggregating performance data in reports. See <a href=\"https://docs.airbyte.com/integrations/sources/tiktok-marketing/#report-aggregation\">the docs</a>.",
+                "enum": [
+                    "LIFETIME",
+                    "DAY",
+                    "HOUR"
+                ],
+                "order": 3,
+                "airbyte_hidden": true,
+                "type": "string"
+            }
+        }
+    },
+    "supportsIncremental": true,
+    "supported_destination_sync_modes": [
+        "overwrite",
+        "append",
+        "append_dedup"
+    ],
+    "advanced_auth": {
+        "auth_flow_type": "oauth2.0",
+        "predicate_key": [
+            "credentials",
+            "auth_type"
+        ],
+        "predicate_value": "oauth2.0",
+        "oauth_config_specification": {
+            "complete_oauth_output_specification": {
+                "title": "CompleteOauthOutputSpecification",
+                "type": "object",
+                "properties": {
+                    "access_token": {
+                        "title": "Access Token",
+                        "path_in_connector_config": [
+                            "credentials",
+                            "access_token"
+                        ],
+                        "type": "string"
+                    }
+                },
+                "required": [
+                    "access_token"
+                ]
+            },
+            "complete_oauth_server_input_specification": {
+                "title": "CompleteOauthServerInputSpecification",
+                "type": "object",
+                "properties": {
+                    "app_id": {
+                        "title": "App Id",
+                        "type": "string"
+                    },
+                    "secret": {
+                        "title": "Secret",
+                        "type": "string"
+                    }
+                },
+                "required": [
+                    "app_id",
+                    "secret"
+                ]
+            },
+            "complete_oauth_server_output_specification": {
+                "title": "CompleteOauthServerOutputSpecification",
+                "type": "object",
+                "properties": {
+                    "app_id": {
+                        "title": "App Id",
+                        "path_in_connector_config": [
+                            "credentials",
+                            "app_id"
+                        ],
+                        "type": "string"
+                    },
+                    "secret": {
+                        "title": "Secret",
+                        "path_in_connector_config": [
+                            "credentials",
+                            "secret"
+                        ],
+                        "type": "string"
+                    }
+                },
+                "required": [
+                    "app_id",
+                    "secret"
+                ]
+            }
+        }
+    },
+    "additionalProperties": true
+}

--- a/airbyte-integrations/connectors/source-tiktok-marketing/source_tiktok_marketing/streams.py
+++ b/airbyte-integrations/connectors/source-tiktok-marketing/source_tiktok_marketing/streams.py
@@ -683,7 +683,7 @@ class AdvertisersReports(BasicReports):
     """Custom reports for advertiser"""
 
     primary_key = "advertiser_id"
-    
+
     report_level = ReportLevel.ADVERTISER
 
 
@@ -691,7 +691,7 @@ class CampaignsReports(BasicReports):
     """Custom reports for campaigns"""
 
     primary_key = "campaign_id"
-    
+
     report_level = ReportLevel.CAMPAIGN
 
 
@@ -699,7 +699,7 @@ class AdGroupsReports(BasicReports):
     """Custom reports for adgroups"""
 
     primary_key = "adgroup_id"
-    
+
     report_level = ReportLevel.ADGROUP
 
 
@@ -730,20 +730,19 @@ class AudienceReport(BasicReports):
 class AdGroupAudienceReports(AudienceReport):
 
     primary_key = "adgroup_id"
-    
+
     report_level = ReportLevel.ADGROUP
 
 
 class AdsAudienceReports(AudienceReport):
 
-    
     report_level = ReportLevel.AD
 
 
 class AdvertisersAudienceReports(AudienceReport):
 
     primary_key = "advertiser_id"
-    
+
     report_level = ReportLevel.ADVERTISER
 
 
@@ -751,6 +750,6 @@ class CampaignsAudienceReportsByCountry(AudienceReport):
     """Custom reports for campaigns by country"""
 
     primary_key = "campaign_id"
-    
+
     report_level = ReportLevel.CAMPAIGN
     audience_dimensions = ["country_code"]

--- a/airbyte-integrations/connectors/source-tiktok-marketing/unit_tests/streams_test.py
+++ b/airbyte-integrations/connectors/source-tiktok-marketing/unit_tests/streams_test.py
@@ -189,7 +189,7 @@ def test_basic_reports_get_reporting_dimensions_day(stream, dimensions_expected)
     [
         (Daily, "stat_time_day"),
         (Hourly, "stat_time_hour"),
-        (Lifetime, []),
+        (Lifetime, "stat_time_day"),
     ],
 )
 def test_basic_reports_cursor_field(granularity, cursor_field_expected):

--- a/airbyte-integrations/connectors/source-tiktok-marketing/unit_tests/streams_test.py
+++ b/airbyte-integrations/connectors/source-tiktok-marketing/unit_tests/streams_test.py
@@ -187,8 +187,8 @@ def test_basic_reports_get_reporting_dimensions_day(stream, dimensions_expected)
 @pytest.mark.parametrize(
     "granularity, cursor_field_expected",
     [
-        (Daily, ["stat_time_day"]),
-        (Hourly, ["stat_time_hour"]),
+        (Daily, "stat_time_day"),
+        (Hourly, "stat_time_hour"),
         (Lifetime, []),
     ],
 )

--- a/airbyte-integrations/connectors/source-tiktok-marketing/unit_tests/streams_test.py
+++ b/airbyte-integrations/connectors/source-tiktok-marketing/unit_tests/streams_test.py
@@ -187,8 +187,8 @@ def test_basic_reports_get_reporting_dimensions_day(stream, dimensions_expected)
 @pytest.mark.parametrize(
     "granularity, cursor_field_expected",
     [
-        (Daily, ["dimensions", "stat_time_day"]),
-        (Hourly, ["dimensions", "stat_time_hour"]),
+        (Daily, ["stat_time_day"]),
+        (Hourly, ["stat_time_hour"]),
         (Lifetime, []),
     ],
 )

--- a/airbyte-integrations/connectors/source-tiktok-marketing/unit_tests/unit_test.py
+++ b/airbyte-integrations/connectors/source-tiktok-marketing/unit_tests/unit_test.py
@@ -145,7 +145,7 @@ def test_source_streams(config, stream_len):
 
 
 def test_source_spec():
-    spec = SourceTiktokMarketing().spec()
+    spec = SourceTiktokMarketing().spec(logger=None)
     assert isinstance(spec, ConnectorSpecification)
 
 

--- a/airbyte-integrations/connectors/source-tiktok-marketing/unit_tests/unit_test.py
+++ b/airbyte-integrations/connectors/source-tiktok-marketing/unit_tests/unit_test.py
@@ -133,8 +133,8 @@ def test_random_items(prepared_prod_args):
 @pytest.mark.parametrize(
     "config, stream_len",
     [
-        (PROD_CONFIG_FILE, 10),
-        (SANDBOX_CONFIG_FILE, 7),
+        (PROD_CONFIG_FILE, 26),
+        (SANDBOX_CONFIG_FILE, 19),
     ],
 )
 def test_source_streams(config, stream_len):

--- a/airbyte-integrations/connectors/source-tiktok-marketing/unit_tests/unit_test.py
+++ b/airbyte-integrations/connectors/source-tiktok-marketing/unit_tests/unit_test.py
@@ -133,8 +133,8 @@ def test_random_items(prepared_prod_args):
 @pytest.mark.parametrize(
     "config, stream_len",
     [
-        (PROD_CONFIG_FILE, 26),
-        (SANDBOX_CONFIG_FILE, 19),
+        (PROD_CONFIG_FILE, 10),
+        (SANDBOX_CONFIG_FILE, 7),
     ],
 )
 def test_source_streams(config, stream_len):

--- a/docs/integrations/sources/tiktok-marketing.md
+++ b/docs/integrations/sources/tiktok-marketing.md
@@ -537,6 +537,7 @@ The connector is restricted by [requests limitation](https://ads.tiktok.com/mark
 
 | Version | Date       | Pull Request                                             | Subject                                                                                       |
 |:--------|:-----------|:---------------------------------------------------------|:----------------------------------------------------------------------------------------------|
+| 0.1.15  | 2022-08-30 | [16137](https://github.com/airbytehq/airbyte/pull/16137) | Fixed bug with normalization caused by unsupported nested cursor field                                                             |                                               |
 | 0.1.14  | 2022-06-29 | [13890](https://github.com/airbytehq/airbyte/pull/13890) | Removed granularity config option                                                             |                                               |
 | 0.1.13  | 2022-06-28 | [13650](https://github.com/airbytehq/airbyte/pull/13650) | Added video metrics to report streams                                                         |                                                        |
 | 0.1.12  | 2022-05-24 | [13127](https://github.com/airbytehq/airbyte/pull/13127) | Fixed integration test                                                                        |


### PR DESCRIPTION
## What
Resolving:
https://github.com/airbytehq/airbyte/issues/15984
https://github.com/airbytehq/oncall/issues/406

## How
- added `unnest_field` static method to unnest nested fields at runtime
- added new properties to the schemas to reflect changes
- fixed unit_tests up to the latest changes
- tested normalization flow on Postgres

## 🚨 User Impact 🚨
The existing users should `update the schema` to pick up the latest changes.

## Pre-merge Checklist
Expand the relevant checklist and delete the others.

<details><summary><strong>Updating a connector</strong></summary>

### Community member or Airbyter

- [X] Unit & integration tests added and passing. Community members, please provide proof of success locally e.g: screenshot or copy-paste unit, integration, and acceptance test output. To run acceptance tests for a Python connector, follow instructions in the README. For java connectors run `./gradlew :airbyte-integrations:connectors:<name>:integrationTest`.
- [X] Code reviews completed
- [X] Documentation updated
    - [X] Changelog updated in `docs/integrations/<source or destination>/<name>.md` including changelog. See changelog [example](https://docs.airbyte.io/integrations/sources/stripe#changelog)
- [X] PR name follows [PR naming conventions](https://docs.airbyte.io/contributing-to-airbyte/updating-documentation#issues-and-pull-requests)

### Airbyter

If this is a community PR, the Airbyte engineer reviewing this PR is responsible for the below items.

- [ ] Create a non-forked branch based on this PR and test the below items on it
- [ ] Build is successful
- [ ] If new credentials are required for use in CI, add them to GSM. [Instructions](https://docs.airbyte.io/connector-development#using-credentials-in-ci).
- [ ] [`/test connector=connectors/<name>` command](https://docs.airbyte.io/connector-development#updating-an-existing-connector) is passing
- [ ] New Connector version released on Dockerhub and connector version bumped by running the `/publish` command described [here](https://docs.airbyte.io/connector-development#updating-an-existing-connector)

</details>