### PR TITLE
Fix error finding PostgreSQLContainer in migration tasks

### DIFF
--- a/airbyte-db/db-lib/build.gradle
+++ b/airbyte-db/db-lib/build.gradle
@@ -2,6 +2,7 @@ plugins {
     id 'java-library'
 }
 
+// Add a configuration for our migrations tasks defined below to encapsulate their dependencies
 configurations {
     migrations.extendsFrom implementation
 }

--- a/airbyte-db/db-lib/build.gradle
+++ b/airbyte-db/db-lib/build.gradle
@@ -17,11 +17,11 @@ dependencies {
     implementation project(':airbyte-config:config-models')
     implementation libs.flyway.core
 
-    compileOnly libs.platform.testcontainers.postgresql
     migrations libs.platform.testcontainers.postgresql
     migrations sourceSets.main.output
 
     // Mark as compile only to avoid leaking transitively to connectors
+    compileOnly libs.platform.testcontainers.postgresql
     compileOnly libs.connectors.testcontainers.mysql
 
     // These are required because gradle might be using lower version of Jna from other

--- a/airbyte-db/db-lib/build.gradle
+++ b/airbyte-db/db-lib/build.gradle
@@ -2,6 +2,10 @@ plugins {
     id 'java-library'
 }
 
+configurations {
+    migrations.extendsFrom implementation
+}
+
 dependencies {
     api libs.hikaricp
     api libs.jooq.meta
@@ -12,7 +16,10 @@ dependencies {
     implementation project(':airbyte-json-validation')
     implementation project(':airbyte-config:config-models')
     implementation libs.flyway.core
-    implementation libs.platform.testcontainers.postgresql
+
+    compileOnly libs.platform.testcontainers.postgresql
+    migrations libs.platform.testcontainers.postgresql
+    migrations sourceSets.main.output
 
     // Mark as compile only to avoid leaking transitively to connectors
     compileOnly libs.connectors.testcontainers.mysql
@@ -41,37 +48,37 @@ dependencies {
 
 task(newConfigsMigration, dependsOn: 'classes', type: JavaExec) {
     main = 'io.airbyte.db.instance.development.MigrationDevCenter'
-    classpath = sourceSets.main.runtimeClasspath
+    classpath = files(configurations.migrations.files)
     args 'configs', 'create'
 }
 
 task(runConfigsMigration, dependsOn: 'classes', type: JavaExec) {
     main = 'io.airbyte.db.instance.development.MigrationDevCenter'
-    classpath = sourceSets.main.runtimeClasspath
+    classpath = files(configurations.migrations.files)
     args 'configs', 'migrate'
 }
 
 task(dumpConfigsSchema, dependsOn: 'classes', type: JavaExec) {
     main = 'io.airbyte.db.instance.development.MigrationDevCenter'
-    classpath = sourceSets.main.runtimeClasspath
+    classpath = files(configurations.migrations.files)
     args 'configs', 'dump_schema'
 }
 
 task(newJobsMigration, dependsOn: 'classes', type: JavaExec) {
     main = 'io.airbyte.db.instance.development.MigrationDevCenter'
-    classpath = sourceSets.main.runtimeClasspath
+    classpath = files(configurations.migrations.files)
     args 'jobs', 'create'
 }
 
 task(runJobsMigration, dependsOn: 'classes', type: JavaExec) {
     main = 'io.airbyte.db.instance.development.MigrationDevCenter'
-    classpath = sourceSets.main.runtimeClasspath
+    classpath = files(configurations.migrations.files)
     args 'jobs', 'migrate'
 }
 
 task(dumpJobsSchema, dependsOn: 'classes', type: JavaExec) {
     main = 'io.airbyte.db.instance.development.MigrationDevCenter'
-    classpath = sourceSets.main.runtimeClasspath
+    classpath = files(configurations.migrations.files)
     args 'jobs', 'dump_schema'
 }
 

--- a/airbyte-db/db-lib/build.gradle
+++ b/airbyte-db/db-lib/build.gradle
@@ -12,9 +12,9 @@ dependencies {
     implementation project(':airbyte-json-validation')
     implementation project(':airbyte-config:config-models')
     implementation libs.flyway.core
+    implementation libs.platform.testcontainers.postgresql
 
     // Mark as compile only to avoid leaking transitively to connectors
-    compileOnly libs.platform.testcontainers.postgresql
     compileOnly libs.connectors.testcontainers.mysql
 
     // These are required because gradle might be using lower version of Jna from other


### PR DESCRIPTION
## What

When trying to run the gradle tasks described in https://github.com/airbytehq/airbyte/blob/029085a56f364a8a10ef438df0621bda6485d25f/airbyte-db/db-lib/README.md to create and run migrations, the task fails with:

```
./gradlew :airbyte-db:db-lib:newConfigsMigration

> Task :airbyte-db:db-lib:newConfigsMigration FAILED
Exception in thread "main" java.lang.NoClassDefFoundError: org/testcontainers/containers/PostgreSQLContainer
        at io.airbyte.db.instance.development.MigrationDevCenter.createContainer(MigrationDevCenter.java:45)
        at io.airbyte.db.instance.development.MigrationDevCenter.createMigration(MigrationDevCenter.java:60)
        at io.airbyte.db.instance.development.MigrationDevCenter.main(MigrationDevCenter.java:121)
Caused by: java.lang.ClassNotFoundException: org.testcontainers.containers.PostgreSQLContainer
        at java.base/jdk.internal.loader.BuiltinClassLoader.loadClass(BuiltinClassLoader.java:641)
        at java.base/jdk.internal.loader.ClassLoaders$AppClassLoader.loadClass(ClassLoaders.java:188)
        at java.base/java.lang.ClassLoader.loadClass(ClassLoader.java:520)
        ... 3 more

```

This seems to be caused by the postgres testcontainer dependency being marked as `compileOnly`

https://github.com/airbytehq/airbyte/blob/aab03770c90c14b5a8d0eb40908e9fd349fb7e1a/airbyte-db/db-lib/build.gradle#L16-L17

## How

- Change the dependency to be `implementation`

After this change, the task runs successfully:

```
./gradlew :airbyte-db:db-lib:newConfigsMigration

> Task :airbyte-db:db-lib:newConfigsMigration
2022-08-30 22:28:36 INFO o.t.u.ImageNameSubstitutor(instance):50 - Image name substitution will be performed by: DefaultImageNameSubstitutor (composite of 'ConfigurationFileImageNameSubstitutor' and 'PrefixingImageNameSubstitutor')
2022-08-30 22:28:36 INFO o.t.d.DockerClientProviderStrategy(lambda$loadConfiguredStrategy$8):250 - Loaded org.testcontainers.dockerclient.UnixSocketClientProviderStrategy from ~/.testcontainers.properties, will try it first
2022-08-30 22:28:36 INFO o.t.d.DockerClientProviderStrategy(tryOutStrategy):178 - Found Docker environment with local Unix socket (unix:///var/run/docker.sock)
2022-08-30 22:28:36 INFO o.t.DockerClientFactory(client):200 - Docker host IP address is localhost
2022-08-30 22:28:36 INFO o.t.DockerClientFactory(client):206 - Connected to docker: 
  Server Version: 20.10.13
  API Version: 1.41
  Operating System: Docker Desktop
  Total Memory: 7851 MB
2022-08-30 22:28:37 INFO o.t.u.RegistryAuthLocator(runCredentialProvider):245 - Credential helper/store (docker-credential-desktop) does not have credentials for index.docker.io
2022-08-30 22:28:38 INFO o.t.u.RyukResourceReaper(init):65 - Ryuk started - will monitor and terminate Testcontainers containers on JVM exit
2022-08-30 22:28:38 INFO o.t.DockerClientFactory(client):227 - Checking the system...
2022-08-30 22:28:38 INFO o.t.DockerClientFactory(check):305 - ✔︎ Docker server version should be at least 1.6.0
2022-08-30 22:28:38 INFO o.t.DockerClientFactory(check):305 - ✔︎ Docker environment should have more than 2GB free disk space
2022-08-30 22:28:38 INFO o.t.c.GenericContainer(tryStart):372 - Creating container for image: postgres:13-alpine
2022-08-30 22:28:38 INFO o.t.c.GenericContainer(tryStart):436 - Container postgres:13-alpine is starting: 18aa571122c93ae35e3050a4e4f0e452e00acef4e559218b2821cf8921a8f29c
2022-08-30 22:28:40 INFO o.t.c.GenericContainer(tryStart):515 - Container postgres:13-alpine started in PT1.764596S
2022-08-30 22:28:40 INFO c.z.h.HikariDataSource(<init>):80 - HikariPool-1 - Starting...
2022-08-30 22:28:40 INFO c.z.h.HikariDataSource(<init>):82 - HikariPool-1 - Start completed.
2022-08-30 22:28:40 INFO i.a.c.EnvConfigs(getEnvOrDefault):1083 - Using default value for environment variable SHOULD_RUN_SYNC_WORKFLOWS: 'true'
2022-08-30 22:28:40 INFO i.a.c.EnvConfigs(getEnvOrDefault):1083 - Using default value for environment variable WORKER_PLANE: 'CONTROL_PLANE'
2022-08-30 22:28:40 WARN o.f.c.i.l.s.Slf4jLog(warn):53 - Skipping io.airbyte.db.instance.configs.migrations.V0_30_22_001__Store_last_sync_state: (InvocationTargetException: null) caused by (IllegalArgumentException: 'DATABASE_USER' environment variable cannot be null) at com.google.common.base.Preconditions.checkArgument:220
2022-08-30 22:28:40 INFO i.a.d.i.d.MigrationDevHelper(getNextMigrationVersion):204 - Use the current airbyte version (AirbyteVersion{version='0.40.3', major='0', minor='40', patch='3'}), since it is greater than the last migration version (AirbyteVersion{version='0.39.17', major='0', minor='39', patch='17'})
2022-08-30 22:28:40 INFO i.a.d.i.d.MigrationDevHelper(createNextMigrationFile):76 - 
==== New Migration File ====
src/main/java/io/airbyte/db/instance/configs/migrations/V0_40_3_001__New_migration.java

Deprecated Gradle features were used in this build, making it incompatible with Gradle 8.0.

You can use '--warning-mode all' to show the individual deprecation warnings and determine if they come from your own scripts or plugins.

See https://docs.gradle.org/7.4/userguide/command_line_interface.html#sec:command_line_warnings

BUILD SUCCESSFUL in 17s
```

