### PR TITLE
🪟 🔧 Publish webapp storybook to chromatic in CI

### DIFF
--- a/.github/workflows/gradle.yml
+++ b/.github/workflows/gradle.yml
@@ -341,8 +341,8 @@ jobs:
         with:
           projectToken: ${{ secrets.CHROMATIC_PROJECT_TOKEN }}
           token: ${{ secrets.GITHUB_TOKEN }}
-          workingDir: airbyte-webapp/
-          storybookBuildDir: airbyte-webapp/build/storybook/
+          workingDir: ./airbyte-webapp/
+          storybookBuildDir: ./airbyte-webapp/build/storybook/
 
   frontend-test:
     name: "Frontend: Run End-to-End Tests"

--- a/.github/workflows/gradle.yml
+++ b/.github/workflows/gradle.yml
@@ -341,8 +341,8 @@ jobs:
         with:
           projectToken: ${{ secrets.CHROMATIC_PROJECT_TOKEN }}
           token: ${{ secrets.GITHUB_TOKEN }}
-          workingDir: ./airbyte-webapp/
-          storybookBuildDir: ./airbyte-webapp/build/storybook/
+          workingDir: /actions-runner/_work/airbyte/airbyte/airbyte-webapp/
+          storybookBuildDir: /actions-runner/_work/airbyte/airbyte/airbyte-webapp/build/storybook/
 
   frontend-test:
     name: "Frontend: Run End-to-End Tests"

--- a/.github/workflows/gradle.yml
+++ b/.github/workflows/gradle.yml
@@ -341,8 +341,8 @@ jobs:
         with:
           projectToken: ${{ secrets.CHROMATIC_PROJECT_TOKEN }}
           token: ${{ secrets.GITHUB_TOKEN }}
-          workingDir: /actions-runner/_work/airbyte/airbyte/airbyte-webapp/
-          storybookBuildDir: /actions-runner/_work/airbyte/airbyte/airbyte-webapp/build/storybook/
+          workingDir: ./airbyte-webapp/
+          storybookBuildDir: build/storybook/
 
   frontend-test:
     name: "Frontend: Run End-to-End Tests"

--- a/.github/workflows/gradle.yml
+++ b/.github/workflows/gradle.yml
@@ -342,7 +342,7 @@ jobs:
           projectToken: ${{ secrets.CHROMATIC_PROJECT_TOKEN }}
           token: ${{ secrets.GITHUB_TOKEN }}
           workingDir: airbyte-webapp/
-          storybookBuldDir: airbyte-webapp/build/storybook/
+          storybookBuildDir: airbyte-webapp/build/storybook/
 
   frontend-test:
     name: "Frontend: Run End-to-End Tests"

--- a/.github/workflows/gradle.yml
+++ b/.github/workflows/gradle.yml
@@ -333,6 +333,15 @@ jobs:
 
       - name: Build :airbyte-webapp
         run: SUB_BUILD=PLATFORM ./gradlew --no-daemon :airbyte-webapp:build --scan
+
+      - name: Publish Storybook to Chromatic
+        uses: chromaui/action@v1
+        with:
+          projectToken: ${{ secrets.CHROMATIC_PROJECT_TOKEN }}
+          token: ${{ secrets.GITHUB_TOKEN }}
+          workingDir: airbyte-webapp/
+          storybookBuldDir: airbyte-webapp/build/storybook/
+
   frontend-test:
     name: "Frontend: Run End-to-End Tests"
     needs:

--- a/.github/workflows/gradle.yml
+++ b/.github/workflows/gradle.yml
@@ -303,7 +303,7 @@ jobs:
     steps:
       - name: Checkout Airbyte
         uses: actions/checkout@v2
-        width:
+        with:
           fetch-depth: 0
 
       - name: Cache Build Artifacts

--- a/.github/workflows/gradle.yml
+++ b/.github/workflows/gradle.yml
@@ -303,6 +303,8 @@ jobs:
     steps:
       - name: Checkout Airbyte
         uses: actions/checkout@v2
+        width:
+          fetch-depth: 0
 
       - name: Cache Build Artifacts
         uses: ./.github/actions/cache-build-artifacts

--- a/.github/workflows/gradle.yml
+++ b/.github/workflows/gradle.yml
@@ -344,6 +344,7 @@ jobs:
           projectToken: ${{ secrets.CHROMATIC_PROJECT_TOKEN }}
           token: ${{ needs.find_valid_pat.outputs.pat }}
           workingDir: ./airbyte-webapp/
+          storybookBuildDir: build/storybook/
 
 
   frontend-test:

--- a/.github/workflows/gradle.yml
+++ b/.github/workflows/gradle.yml
@@ -340,7 +340,7 @@ jobs:
         uses: chromaui/action@v1
         with:
           projectToken: ${{ secrets.CHROMATIC_PROJECT_TOKEN }}
-          token: ${{ secrets.LABEL_BOT_TOKEN }}
+          token: ${{ secrets.GITHUB_TOKEN }}
           workingDir: ./airbyte-webapp/
           storybookBuildDir: build/storybook/
 

--- a/.github/workflows/gradle.yml
+++ b/.github/workflows/gradle.yml
@@ -344,7 +344,7 @@ jobs:
           projectToken: ${{ secrets.CHROMATIC_PROJECT_TOKEN }}
           token: ${{ needs.find_valid_pat.outputs.pat }}
           workingDir: ./airbyte-webapp/
-          storybookBuildDir: build/storybook/
+
 
   frontend-test:
     name: "Frontend: Run End-to-End Tests"

--- a/.github/workflows/gradle.yml
+++ b/.github/workflows/gradle.yml
@@ -303,8 +303,6 @@ jobs:
     steps:
       - name: Checkout Airbyte
         uses: actions/checkout@v2
-        with:
-          fetch-depth: 0
 
       - name: Cache Build Artifacts
         uses: ./.github/actions/cache-build-artifacts
@@ -336,13 +334,26 @@ jobs:
       - name: Build :airbyte-webapp
         run: SUB_BUILD=PLATFORM ./gradlew --no-daemon :airbyte-webapp:build --scan
 
-      - name: Publish Storybook to Chromatic
-        uses: chromaui/action@v1
-        with:
-          projectToken: ${{ secrets.CHROMATIC_PROJECT_TOKEN }}
-          token: ${{ secrets.GITHUB_TOKEN }}
-          workingDir: ./airbyte-webapp/
-          storybookBuildDir: build/storybook/
+  frontend-publish-storybook:
+      name: "Frontend: Publish Storybook"
+      needs: start-frontend-runner
+      runs-on: ${{ needs.start-frontend-runner.outputs.label }}
+      steps:
+        - name: Checkout Airbyte
+          uses: actions/checkout@v2
+          with:
+            fetch-depth: 0
+
+        - name: Install dependencies
+          run: cd && airbyte-webapp && npm install
+
+        - name: Publish Storybook to Chromatic
+          uses: chromaui/action@v1
+          with:
+            projectToken: ${{ secrets.CHROMATIC_PROJECT_TOKEN }}
+            token: ${{ secrets.GITHUB_TOKEN }}
+            workingDir: ./airbyte-webapp/
+            storybookBuildDir: build/storybook/
 
   frontend-test:
     name: "Frontend: Run End-to-End Tests"
@@ -397,6 +408,7 @@ jobs:
       - frontend-test # required to wait when the e2e-test job is done
       - frontend-build # required to wait when then build job is done
       - find_valid_pat
+      - frontend-publish-storybook
     runs-on: ubuntu-latest
     # Always is required to stop the runner even if the previous job has errors. However always() runs even if the previous step is skipped.
     # Thus, we check for skipped here.

--- a/.github/workflows/gradle.yml
+++ b/.github/workflows/gradle.yml
@@ -345,6 +345,7 @@ jobs:
           token: ${{ needs.find_valid_pat.outputs.pat }}
           workingDir: ./airbyte-webapp/
           storybookBuildDir: build/storybook/
+          exitOnceUploaded: true
 
 
   frontend-test:

--- a/.github/workflows/gradle.yml
+++ b/.github/workflows/gradle.yml
@@ -298,11 +298,15 @@ jobs:
           github-token: ${{ needs.find_valid_pat.outputs.pat }}
   frontend-build:
     name: "Frontend: Build"
-    needs: start-frontend-runner
+    needs:
+      - start-frontend-runner
+      - find_valid_pat
     runs-on: ${{ needs.start-frontend-runner.outputs.label }}
     steps:
       - name: Checkout Airbyte
         uses: actions/checkout@v2
+        with:
+          fetch-depth: 0
 
       - name: Cache Build Artifacts
         uses: ./.github/actions/cache-build-artifacts
@@ -334,26 +338,13 @@ jobs:
       - name: Build :airbyte-webapp
         run: SUB_BUILD=PLATFORM ./gradlew --no-daemon :airbyte-webapp:build --scan
 
-  frontend-publish-storybook:
-      name: "Frontend: Publish Storybook"
-      needs: start-frontend-runner
-      runs-on: ${{ needs.start-frontend-runner.outputs.label }}
-      steps:
-        - name: Checkout Airbyte
-          uses: actions/checkout@v2
-          with:
-            fetch-depth: 0
-
-        - name: Install dependencies
-          run: cd airbyte-webapp && npm install
-
-        - name: Publish Storybook to Chromatic
-          uses: chromaui/action@v1
-          with:
-            projectToken: ${{ secrets.CHROMATIC_PROJECT_TOKEN }}
-            token: ${{ secrets.GITHUB_TOKEN }}
-            workingDir: ./airbyte-webapp/
-            storybookBuildDir: build/storybook/
+      - name: Publish Storybook to Chromatic
+        uses: chromaui/action@v1
+        with:
+          projectToken: ${{ secrets.CHROMATIC_PROJECT_TOKEN }}
+          token: ${{ needs.find_valid_pat.outputs.pat }}
+          workingDir: ./airbyte-webapp/
+          storybookBuildDir: build/storybook/
 
   frontend-test:
     name: "Frontend: Run End-to-End Tests"
@@ -408,7 +399,6 @@ jobs:
       - frontend-test # required to wait when the e2e-test job is done
       - frontend-build # required to wait when then build job is done
       - find_valid_pat
-      - frontend-publish-storybook
     runs-on: ubuntu-latest
     # Always is required to stop the runner even if the previous job has errors. However always() runs even if the previous step is skipped.
     # Thus, we check for skipped here.

--- a/.github/workflows/gradle.yml
+++ b/.github/workflows/gradle.yml
@@ -340,7 +340,7 @@ jobs:
         uses: chromaui/action@v1
         with:
           projectToken: ${{ secrets.CHROMATIC_PROJECT_TOKEN }}
-          token: ${{ secrets.GITHUB_TOKEN }}
+          token: ${{ secrets.LABEL_BOT_TOKEN }}
           workingDir: ./airbyte-webapp/
           storybookBuildDir: build/storybook/
 

--- a/.github/workflows/gradle.yml
+++ b/.github/workflows/gradle.yml
@@ -345,7 +345,7 @@ jobs:
             fetch-depth: 0
 
         - name: Install dependencies
-          run: cd && airbyte-webapp && npm install
+          run: cd airbyte-webapp && npm install
 
         - name: Publish Storybook to Chromatic
           uses: chromaui/action@v1


### PR DESCRIPTION
## What
Closes #14846 

Adds step to publish [storybook](https://storybook.js.org/) to [chromatic](https://www.chromatic.com/) in CI 

![image](https://user-images.githubusercontent.com/168664/188165198-139c3621-315e-4999-ae2f-5c52c0f5ecc8.png)

## How
Uses the [@chromaui/action](https://github.com/chromaui/action) Github action to publish the storybook during the "Frontend: Build" CI workflow step

## Tests

* CI publishes storybook!
