### PR TITLE
🪟 🐛 Ensure scheduleType gets updated when connection is updated

### DIFF
--- a/airbyte-webapp/src/core/domain/connection/utils.ts
+++ b/airbyte-webapp/src/core/domain/connection/utils.ts
@@ -9,6 +9,7 @@ export const toWebBackendConnectionUpdate = (connection: WebBackendConnectionRea
   operationIds: connection.operationIds,
   syncCatalog: connection.syncCatalog,
   scheduleData: connection.scheduleData,
+  scheduleType: connection.scheduleType,
   status: connection.status,
   resourceRequirements: connection.resourceRequirements,
   operations: connection.operations,


### PR DESCRIPTION
## What
Caused by #15924

Fixes an issue where the connection schedule is reset to "manual" when the user disables the connection or updates the name.

## How
The `scheduleType` was not being updated in the buildConnectionUpdate function

## Recommended reading order
as is

## Tests

- Update status and name with set schedule
- Update status and name with manual schedule
- Update connection