### PR TITLE
Cypress initial cleanup pass

### DIFF
--- a/airbyte-webapp-e2e-tests/README.md
+++ b/airbyte-webapp-e2e-tests/README.md
@@ -1,10 +1,12 @@
-## Running Cypress tests locally with `cypress open`
-The most useful way to run tests locally is with the `cypress open` command. It opens a dispatcher window that lets you select which browser to run (including an Electron child window whose devtools will be very familiar to chrome users) and which tests to run in it. By default, this command is configured to visit page urls from port 3000 (as used by a locally-run dev server), not port 8000 (as used by docker-compose's `webapp` service). If you want to run tests against the dockerized UI instead, leave the `webapp` docker-compose service running in step 4) and start the test runner with `CYPRESS_BASE_URL=http://localhost:8000 npm run cypress:open` in step 8).
+## Running an interactive Cypress session with `npm run cypress:open`
+The most useful way to run tests locally is with the `cypress open` command. It opens a dispatcher window that lets you select which tests and browser to run; the Electron browser (whose devtools will be very familiar to chrome users) opens a child window, and having both cypress windows grouped behaves nicely when switching between applications. In an interactive session, you can use `it.skip` and `it.only` to focus on the tests you care about; any change to the source file of a running test will cause tests to be automatically rerun. At the end of a test run, the web page is left "dangling" with all state present at the end of the last test; you can click around, "inspect element", and interact with the page however you wish, which makes it easy to incrementally develop tests.
+
+By default, this command is configured to visit page urls from port 3000 (as used by a locally-run dev server), not port 8000 (as used by docker-compose's `webapp` service). If you want to run tests against the dockerized UI instead, leave the `webapp` docker-compose service running in step 4) and start the test runner with `CYPRESS_BASE_URL=http://localhost:8000 npm run cypress:open` in step 8).
 
 Except as noted, all commands are written as if run from inside the `airbyte-webapp-e2e-tests/` directory.
 
-Prerequisites:
-1) Install the e2e test dependencies and tooling with `npm install`.
+Steps:
+1) If you have not already done so, run `npm install` to install the e2e test dependencies.
 2) Build the OSS backend for the current commit with `SUB_BUILD=PLATFORM ../gradlew clean build`.
 3) Create the test database: `npm run createdb`.
 4) Start the OSS backend: `VERSION=dev docker-compose --file ../docker-compose.yaml up`. If you want, follow this with `docker-compose stop webapp` to turn off the dockerized frontend build; interactive cypress sessions don't use it.
@@ -12,3 +14,15 @@ Prerequisites:
 6) If you have not already done so, run `npm install` to install the frontend app's dependencies.
 7) Start the frontend development server with `npm start`.
 8) Back in the `airbyte-webapp-e2e-tests/` directory, start the cypress test runner with `npm run cypress:open`.
+
+## Reproducing CI test results with `npm run cypress:ci` or `npm run cypress:ci:record`
+Unlike `npm run cypress:open`, `npm run cypress:ci` and `npm run cypress:ci:record` use the dockerized UI (i.e. they expect the UI at port 8000, rather than port 3000). If the OSS backend is running but you have run `docker-compose stop webapp`, you'll have to re-enable it with `docker-compose start webapp`. These trigger headless runs: you won't have a live browser to interact with, just terminal output.
+
+Except as noted, all commands are written as if run from inside the `airbyte-webapp-e2e-tests/` directory.
+
+Steps:
+1) If you have not already done so, run `npm install` to install the e2e test dependencies.
+2) Build the OSS backend for the current commit with `SUB_BUILD=PLATFORM ../gradlew clean build`.
+3) Create the test database: `npm run createdb`.
+4) Start the OSS backend: `VERSION=dev docker-compose --file ../docker-compose.yaml up`.
+5) Start the cypress test run with `npm run cypress:ci` or `npm run cypress:ci:record`.

--- a/airbyte-webapp-e2e-tests/README.md
+++ b/airbyte-webapp-e2e-tests/README.md
@@ -1,17 +1,14 @@
-## Running Cypress tests locally
-Except as noted, commands are written as if run from inside the `airbyte-webapp-e2e-tests/` directory.
+## Running Cypress tests locally with `cypress open`
+The most useful way to run tests locally is with the `cypress open` command. It opens a dispatcher window that lets you select which browser to run (including an Electron child window whose devtools will be very familiar to chrome users) and which tests to run in it. By default, this command is configured to visit page urls from port 3000 (as used by a locally-run dev server), not port 8000 (as used by docker-compose's `webapp` service). If you want to run tests against the dockerized UI instead, leave the `webapp` docker-compose service running in step 4) and start the test runner with `CYPRESS_BASE_URL=http://localhost:8000 npm run cypress:open` in step 8).
+
+Except as noted, all commands are written as if run from inside the `airbyte-webapp-e2e-tests/` directory.
 
 Prerequisites:
-1) install the e2e test dependencies and tooling with `npm install`
-2) build the OSS backend for the current commit with `SUB_BUILD=PLATFORM ../gradlew clean build`
-3) create the test database: `npm run createdb`
-4) start the OSS backend: `VERSION=dev docker-compose --file ../docker-compose.yaml up`
-
-If you want the ability to change the frontend as you test (to add `data-testid` attributes to the components being tested, for example, or to practice test-driven development), there are a few additional steps. These are optional, but recommended:
-5) run `docker-compose stop webapp` to turn off the dockerized frontend build (which uses a production-style build instead of a hot-reloading dev server)
-6) the following two commands should be run separately, so open another terminal window and `cd` into the `airbyte-webapp/`
-7) if you have not already done so, run `npm install` to install the frontend app's dependencies
-8) start the frontend development server with `npm start`
-
-Now you're ready to start the test suite! Ensure you're back in the `airbyte-webapp-e2e-tests/` directory, and then
-9) start the cypress test runner with `npm run cypress:open`
+1) Install the e2e test dependencies and tooling with `npm install`.
+2) Build the OSS backend for the current commit with `SUB_BUILD=PLATFORM ../gradlew clean build`.
+3) Create the test database: `npm run createdb`.
+4) Start the OSS backend: `VERSION=dev docker-compose --file ../docker-compose.yaml up`. If you want, follow this with `docker-compose stop webapp` to turn off the dockerized frontend build; interactive cypress sessions don't use it.
+5) The following two commands will start a separate long-running server, so open another terminal window. In it, `cd` into the `airbyte-webapp/` directory.
+6) If you have not already done so, run `npm install` to install the frontend app's dependencies.
+7) Start the frontend development server with `npm start`.
+8) Back in the `airbyte-webapp-e2e-tests/` directory, start the cypress test runner with `npm run cypress:open`.

--- a/airbyte-webapp-e2e-tests/README.md
+++ b/airbyte-webapp-e2e-tests/README.md
@@ -1,5 +1,17 @@
-## Start Cypress
+## Running Cypress tests locally
+Except as noted, commands are written as if run from inside the `airbyte-webapp-e2e-tests/` directory.
 
-### `npm install`
+Prerequisites:
+1) install the e2e test dependencies and tooling with `npm install`
+2) build the OSS backend for the current commit with `SUB_BUILD=PLATFORM ../gradlew clean build`
+3) create the test database: `npm run createdb`
+4) start the OSS backend: `VERSION=dev docker-compose --file ../docker-compose.yaml up`
 
-### `npm run cypress:open`
+If you want the ability to change the frontend as you test (to add `data-testid` attributes to the components being tested, for example, or to practice test-driven development), there are a few additional steps. These are optional, but recommended:
+5) run `docker-compose stop webapp` to turn off the dockerized frontend build (which uses a production-style build instead of a hot-reloading dev server)
+6) the following two commands should be run separately, so open another terminal window and `cd` into the `airbyte-webapp/`
+7) if you have not already done so, run `npm install` to install the frontend app's dependencies
+8) start the frontend development server with `npm start`
+
+Now you're ready to start the test suite! Ensure you're back in the `airbyte-webapp-e2e-tests/` directory, and then
+9) start the cypress test runner with `npm run cypress:open`

--- a/airbyte-webapp-e2e-tests/cypress/integration/base.spec.ts
+++ b/airbyte-webapp-e2e-tests/cypress/integration/base.spec.ts
@@ -8,6 +8,8 @@ describe("Error handling view", () => {
       },
     });
 
+    cy.on("uncaught:exception", () => false);
+
     cy.visit("/");
 
     cy.get("div").contains("Version mismatch between 0.0.1-ci and 0.0.2-ci.").should("exist");
@@ -18,6 +20,8 @@ describe("Error handling view", () => {
       statusCode: 502,
       body: "Failed to fetch",
     });
+
+    cy.on("uncaught:exception", () => false);
 
     cy.visit("/");
 


### PR DESCRIPTION
I found running the cypress test suite to be pretty confusing and not well-documented; and when I got that working, I noticed that `base.spec.ts` was always failing due to uncaught (but intentionally-triggered) errors in the application's js runtime. That can be straightforwardly fixed with a spec-local handler for the `uncaught:exception` event (there are ways to register a global event handler for uncaught exceptions, but generally we _want_ errors to fail tests).

This is only a very quick initial pass at improving the developer experience for our Cypress tests. Here are a few follow-up tasks I'd like to tackle soon:
- run the `prettier` command to reformat all test typescript files according to our conventions. I think this should wait until @SofiiaZaitseva has finished and merged https://github.com/airbytehq/airbyte/pull/15701, to avoid creating a huge pile of merge conflicts for that PR; it should also be an isolated PR, because the file diffs from automated reformatting will be long and noisy, and would make any changes to the code's behavior unnecessarily hard to review.
- create a wrapper script to starting up all the server processes required for a local test run without so many manual steps.

I'd also like to create some custom cypress commands to give ourselves a streamlined, easy-to-use API for airbyte-specific logic and DOM interactions, but that's a less discrete/well-scoped task.