### PR TITLE
add CombinedConnectorCatalog schema

### DIFF
--- a/airbyte-config/config-models/src/main/resources/types/CombinedConnectorCatalog.yaml
+++ b/airbyte-config/config-models/src/main/resources/types/CombinedConnectorCatalog.yaml
@@ -1,0 +1,18 @@
+---
+"$schema": http://json-schema.org/draft-07/schema#
+"$id": https://github.com/airbytehq/airbyte/blob/master/airbyte-config/models/src/main/resources/types/CombinedConnectorCatalog.yaml
+title: CombinedConnectorCatalog
+description: Used to provide the connector catalog from a remote source
+type: object
+required:
+  - destinations
+  - sources
+properties:
+  destinations:
+    type: array
+    items:
+      existingJavaType: io.airbyte.config.StandardDestinationDefinition
+  sources:
+    type: array
+    items:
+      existingJavaType: io.airbyte.config.StandardSourceDefinition


### PR DESCRIPTION
## What

This was introduced in https://github.com/airbytehq/airbyte-cloud/pull/2485, this PR moves it to the OSS repo so that it can be used when reading the catalog (https://github.com/airbytehq/airbyte/pull/16018).

Once Cloud has been updated to use the latest OSS version, the cloud equivalent should be removed and we should import this from OSS instead.

I'm not totally sold on the naming here, so suggestions welcome, but I think it's ok for now.
