### PR TITLE
📝 S3 source: update doc about path_prefix + path_pattern

### DIFF
--- a/docs/integrations/sources/s3.md
+++ b/docs/integrations/sources/s3.md
@@ -145,11 +145,11 @@ For example:
 * `aws_access_key_id` : one half of the [required credentials](https://docs.aws.amazon.com/general/latest/gr/aws-sec-cred-types.html#access-keys-and-secret-access-keys) for accessing a private bucket.
 * `aws_secret_access_key` : other half of the [required credentials](https://docs.aws.amazon.com/general/latest/gr/aws-sec-cred-types.html#access-keys-and-secret-access-keys) for accessing a private bucket.
 * `path_prefix` : an optional string that limits the files returned by AWS when listing files to only that those starting with this prefix. This is different to path\_pattern as it gets pushed down to the API call made to S3 rather than filtered in Airbyte and it does not accept pattern-style symbols \(like wildcards `*`\). We recommend using this if your bucket has many folders and files that are unrelated to this stream and all the relevant files will always sit under this chosen prefix.
-  * Together with `path_pattern`, there are multiple ways to configure the connector. For example, all the following configs are equivalent:
+  * Together with `path_pattern`, there are multiple ways to specify the files to sync. For example, all the following configs are equivalent:
     * `path_prefix` = `<empty>`, `path_pattern` = `path1/path2/myFolder/**/*`.
     * `path_prefix` = `path1/`, `path_pattern` = `path2/myFolder/**/*.csv`.
     * `path_prefix` = `path1/path2/` and `path_pattern` = `myFolder/**/*.csv`
-    * `path_prefix` = `path1/path2/myFolder/`, `path_pattern` = `**/*.csv`. This is the most efficient one because the directories are filtered earlier in the S3 API call.
+    * `path_prefix` = `path1/path2/myFolder/`, `path_pattern` = `**/*.csv`. This is the most efficient one because the directories are filtered earlier in the S3 API call. However, the difference in efficiency is usually negligible.
   * The rationale of having both `path_prefix` and `path_pattern` is to accommodate as many use cases as possible. If you found them confusing, feel free to ignore `path_prefix` and just set the `path_pattern`.
 * `endpoint` : optional parameter that allow using of non Amazon S3 compatible services. Leave it blank for using default Amazon serivce.
 * `use_ssl` : Allows using custom servers that configured to use plain http. Ignored in case of using Amazon service.

--- a/docs/integrations/sources/s3.md
+++ b/docs/integrations/sources/s3.md
@@ -150,7 +150,7 @@ For example:
     * `path_prefix` = `path1/`, `path_pattern` = `path2/myFolder/**/*.csv`.
     * `path_prefix` = `path1/path2/` and `path_pattern` = `myFolder/**/*.csv`
     * `path_prefix` = `path1/path2/myFolder/`, `path_pattern` = `**/*.csv`. This is the most efficient one because the directories are filtered earlier in the S3 API call.
-  * The rationale of having both `path_prefix` and `path_pattern` is to maximize the flexibility to accommodate different use cases. If you found them confusing, feel free to ignore `path_prefix` and use `path_pattern` only.
+  * The rationale of having both `path_prefix` and `path_pattern` is to accommodate as many use cases as possible. If you found them confusing, feel free to ignore `path_prefix` and just set the `path_pattern`.
 * `endpoint` : optional parameter that allow using of non Amazon S3 compatible services. Leave it blank for using default Amazon serivce.
 * `use_ssl` : Allows using custom servers that configured to use plain http. Ignored in case of using Amazon service.
 * `verify_ssl_cert` : Skip ssl validity check in case of using custom servers with self signed certificates. Ignored in case of using Amazon service.

--- a/docs/integrations/sources/s3.md
+++ b/docs/integrations/sources/s3.md
@@ -145,6 +145,12 @@ For example:
 * `aws_access_key_id` : one half of the [required credentials](https://docs.aws.amazon.com/general/latest/gr/aws-sec-cred-types.html#access-keys-and-secret-access-keys) for accessing a private bucket.
 * `aws_secret_access_key` : other half of the [required credentials](https://docs.aws.amazon.com/general/latest/gr/aws-sec-cred-types.html#access-keys-and-secret-access-keys) for accessing a private bucket.
 * `path_prefix` : an optional string that limits the files returned by AWS when listing files to only that those starting with this prefix. This is different to path\_pattern as it gets pushed down to the API call made to S3 rather than filtered in Airbyte and it does not accept pattern-style symbols \(like wildcards `*`\). We recommend using this if your bucket has many folders and files that are unrelated to this stream and all the relevant files will always sit under this chosen prefix.
+  * Together with `path_pattern`, there are multiple ways to configure the connector. For example, all the following configs are equivalent:
+    * `path_prefix` = `<empty>`, `path_pattern` = `path1/path2/myFolder/**/*`.
+    * `path_prefix` = `path1/`, `path_pattern` = `path2/myFolder/**/*.csv`.
+    * `path_prefix` = `path1/path2/` and `path_pattern` = `myFolder/**/*.csv`
+    * `path_prefix` = `path1/path2/myFolder/`, `path_pattern` = `**/*.csv`. This is the most efficient one because the directories are filtered earlier in the S3 API call.
+  * The rationale of having both `path_prefix` and `path_pattern` is to maximize the flexibility to accommodate different use cases. If you found them confusing, feel free to ignore `path_prefix` and use `path_pattern` only.
 * `endpoint` : optional parameter that allow using of non Amazon S3 compatible services. Leave it blank for using default Amazon serivce.
 * `use_ssl` : Allows using custom servers that configured to use plain http. Ignored in case of using Amazon service.
 * `verify_ssl_cert` : Skip ssl validity check in case of using custom servers with self signed certificates. Ignored in case of using Amazon service.


### PR DESCRIPTION
## What
- S3 source has two related config fields: `path_prefix` and `path_pattern`.
- Currently the doc does not thoroughly explain how to combine these two fields.
- This PR addresses this issue by providing some examples.
