### PR TITLE
[cdk] pin dataclasses-jsonschema to 2.15.1

### DIFF
--- a/airbyte-cdk/python/setup.py
+++ b/airbyte-cdk/python/setup.py
@@ -44,7 +44,7 @@ setup(
     packages=find_packages(exclude=("unit_tests",)),
     install_requires=[
         "backoff",
-        "dataclasses-jsonschema~=2.15.1",
+        "dataclasses-jsonschema==2.15.1",  # pinned to the last working version for us temporarily while we fix
         "dpath~=2.0.1",
         "jsonschema~=3.2.0",
         "jsonref~=0.2",


### PR DESCRIPTION
## What
The recent release of `dataclasses-jsonschema` from `2.15.1` -> `2.15.2` triggered some new test failures when we updated to the latest minor version.
 https://github.com/s-knibbs/dataclasses-jsonschema/releases/tag/2.15.2

## How
Pins back the version to the last know working one, while we investigate why it broke and if we need to change our code to support the newer version.

testing process:
```
pinback version
> pip uninstall dataclasses-jsonschema
> pip install -e ".[dev]" 
> pytest
verify that tests are now passing
```