### PR TITLE
Skip unit tests when run-tests is false in publish command

### DIFF
--- a/tools/integrations/manage.sh
+++ b/tools/integrations/manage.sh
@@ -48,12 +48,13 @@ cmd_build() {
   # Note that we are only building (and testing) once on this build machine's architecture
   # Learn more @ https://github.com/airbytehq/airbyte/pull/13004
   ./gradlew --no-daemon "$(_to_gradle_path "$path" clean)"
-  ./gradlew --no-daemon "$(_to_gradle_path "$path" build)"
 
   if [ "$run_tests" = false ] ; then
-    echo "Skipping integration tests..."
+    echo "Building and skipping unit tests + integration tests..."
+    ./gradlew --no-daemon "$(_to_gradle_path "$path" build)" -x test
   else
-    echo "Running integration tests..."
+    echo "Building and running unit tests + integration tests..."
+    ./gradlew --no-daemon "$(_to_gradle_path "$path" build)"
 
     if test "$path" == "airbyte-integrations/bases/base-normalization"; then
       ./gradlew --no-daemon --scan :airbyte-integrations:bases:base-normalization:airbyteDocker


### PR DESCRIPTION
## What
- The `/publish` command has an option to skip the integration tests. However, unit tests can also take a long time to run.
  - An example here: https://github.com/airbytehq/airbyte/pull/16259 in which the unit tests for `source-mysql` takes 30 minutes.
- Since the option is supposed to skip tests, it might as well just skip all tests.
  - The rationale is that usually we should not skip tests. When we need to skip tests, we are probably certain about the correctness of the connector.
- Indirectly related to https://github.com/airbytehq/airbyte/issues/16265.
