### PR TITLE
Hide ES and Redis destination connectors from Cloud

### DIFF
--- a/airbyte-webapp/src/core/domain/connector/constants.ts
+++ b/airbyte-webapp/src/core/domain/connector/constants.ts
@@ -18,6 +18,8 @@ export const DEV_IMAGE_TAG = "dev";
 export const getExcludedConnectorIds = (workspaceId: string) =>
   isCloudApp()
     ? [
+        "68f351a7-2745-4bef-ad7f-996b8e51bb8c", // hide ElasticSearch Destination https://github.com/airbytehq/airbyte-cloud/issues/2594
+        "d4d3fef9-e319-45c2-881a-bd02ce44cc9f", // hide Redis Destination https://github.com/airbytehq/airbyte-cloud/issues/2593
         "2470e835-feaf-4db6-96f3-70fd645acc77", // Salesforce Singer
         ...(workspaceId !== "54135667-ce73-4820-a93c-29fe1510d348" // Shopify workspace for review
           ? ["9da77001-af33-4bcd-be46-6252bf9342b9"] // Shopify


### PR DESCRIPTION
## What

Hiding  Redis destination connector from Cloud until these issues are fixed:

- [16249](https://github.com/airbytehq/airbyte/issues/16249)
- [16250](https://github.com/airbytehq/airbyte/issues/16250) 

Hiding ES destination connector from Cloud  until these issues are fixed:
- [16251](https://github.com/airbytehq/airbyte/issues/16251)
- [16252](https://github.com/airbytehq/airbyte/issues/16252)

## How
Using the same hack we used for https://github.com/airbytehq/airbyte/issues/12967

[Filter out unavailable connectors in cloud connector settings](https://github.com/airbytehq/airbyte/pull/13174) PR

## 🚨 User Impact 🚨
Existing connections will continue to work (I checked that they are not sending unencrypted traffic), but users of Airbyte Cloud will not be able to create new connections with ES and Redis destinations.
