### PR TITLE
🪟 🧹 Display returned error messages on replication view

### DIFF
--- a/airbyte-webapp-e2e-tests/cypress/pages/replicationPage.ts
+++ b/airbyte-webapp-e2e-tests/cypress/pages/replicationPage.ts
@@ -7,7 +7,7 @@ const destinationNamespaceCustom = "div[data-testid='namespaceDefinition-customf
 const destinationNamespaceSource = "div[data-testid='namespaceDefinition-source']";
 const destinationNamespaceCustomInput = "input[data-testid='input']";
 const syncModeDropdown = "div[data-testid='syncSettingsDropdown'] input";
-const successResult = "span[data-id='success-result']";
+const successResult = "div[data-id='success-result']";
 const saveStreamChangesButton = "button[data-testid='resetModal-save']";
 const connectionNameInput = "input[data-testid='connectionName']";
 

--- a/airbyte-webapp/src/views/Connection/ConnectionForm/ConnectionForm.tsx
+++ b/airbyte-webapp/src/views/Connection/ConnectionForm/ConnectionForm.tsx
@@ -317,7 +317,9 @@ export const ConnectionForm: React.FC<ConnectionFormProps> = ({
                 onCancel?.();
               }}
               successMessage={successMessage}
-              errorMessage={errorMessage || !isValid ? formatMessage({ id: "connectionForm.validation.error" }) : null}
+              errorMessage={
+                errorMessage ? errorMessage : !isValid ? formatMessage({ id: "connectionForm.validation.error" }) : null
+              }
               enableControls={canSubmitUntouchedForm}
             />
           )}
@@ -337,7 +339,11 @@ export const ConnectionForm: React.FC<ConnectionFormProps> = ({
                 isSubmitting={isSubmitting}
                 isValid={isValid && !editingTransformation}
                 errorMessage={
-                  errorMessage || !isValid ? formatMessage({ id: "connectionForm.validation.error" }) : null
+                  errorMessage
+                    ? errorMessage
+                    : !isValid
+                    ? formatMessage({ id: "connectionForm.validation.error" })
+                    : null
                 }
               />
             </>

--- a/airbyte-webapp/src/views/Connection/ConnectionForm/ConnectionForm.tsx
+++ b/airbyte-webapp/src/views/Connection/ConnectionForm/ConnectionForm.tsx
@@ -186,7 +186,7 @@ export const ConnectionForm: React.FC<ConnectionFormProps> = ({
 
   const errorMessage = submitError ? generateMessageFromError(submitError) : null;
   const displayedErrorMessage = (isValid: boolean) => {
-    return errorMessage ?? !isValid ? formatMessage({ id: "connectionForm.validation.error" }) : null;
+    return errorMessage ?? (!isValid ? formatMessage({ id: "connectionForm.validation.error" }) : null);
   };
 
   return (

--- a/airbyte-webapp/src/views/Connection/ConnectionForm/ConnectionForm.tsx
+++ b/airbyte-webapp/src/views/Connection/ConnectionForm/ConnectionForm.tsx
@@ -185,7 +185,7 @@ export const ConnectionForm: React.FC<ConnectionFormProps> = ({
   );
 
   const errorMessage = submitError ? generateMessageFromError(submitError) : null;
-  const displayedErrorMessage = (isValid: boolean) => {
+  const determineErrorMessage = (isValid: boolean) => {
     return errorMessage ?? (!isValid ? formatMessage({ id: "connectionForm.validation.error" }) : null);
   };
 
@@ -320,7 +320,7 @@ export const ConnectionForm: React.FC<ConnectionFormProps> = ({
                 onCancel?.();
               }}
               successMessage={successMessage}
-              errorMessage={displayedErrorMessage(isValid)}
+              errorMessage={determineErrorMessage(isValid)}
               enableControls={canSubmitUntouchedForm}
             />
           )}
@@ -339,7 +339,7 @@ export const ConnectionForm: React.FC<ConnectionFormProps> = ({
               <CreateControls
                 isSubmitting={isSubmitting}
                 isValid={isValid && !editingTransformation}
-                errorMessage={displayedErrorMessage(isValid)}
+                errorMessage={determineErrorMessage(isValid)}
               />
             </>
           )}

--- a/airbyte-webapp/src/views/Connection/ConnectionForm/ConnectionForm.tsx
+++ b/airbyte-webapp/src/views/Connection/ConnectionForm/ConnectionForm.tsx
@@ -185,6 +185,9 @@ export const ConnectionForm: React.FC<ConnectionFormProps> = ({
   );
 
   const errorMessage = submitError ? generateMessageFromError(submitError) : null;
+  const displayedErrorMessage = (isValid: boolean) => {
+    return errorMessage ?? !isValid ? formatMessage({ id: "connectionForm.validation.error" }) : null;
+  };
 
   return (
     <Formik
@@ -317,9 +320,7 @@ export const ConnectionForm: React.FC<ConnectionFormProps> = ({
                 onCancel?.();
               }}
               successMessage={successMessage}
-              errorMessage={
-                errorMessage ? errorMessage : !isValid ? formatMessage({ id: "connectionForm.validation.error" }) : null
-              }
+              errorMessage={displayedErrorMessage(isValid)}
               enableControls={canSubmitUntouchedForm}
             />
           )}
@@ -338,13 +339,7 @@ export const ConnectionForm: React.FC<ConnectionFormProps> = ({
               <CreateControls
                 isSubmitting={isSubmitting}
                 isValid={isValid && !editingTransformation}
-                errorMessage={
-                  errorMessage
-                    ? errorMessage
-                    : !isValid
-                    ? formatMessage({ id: "connectionForm.validation.error" })
-                    : null
-                }
+                errorMessage={displayedErrorMessage(isValid)}
               />
             </>
           )}

--- a/airbyte-webapp/src/views/Connection/ConnectionForm/components/EditControls.module.scss
+++ b/airbyte-webapp/src/views/Connection/ConnectionForm/components/EditControls.module.scss
@@ -1,37 +1,40 @@
 @use "../../../../scss/colors";
+@use "../../../../scss/variables";
 
 .content {
   display: flex;
-  justify-content: space-between;
+  justify-content: flex-end;
   align-items: center;
   flex-direction: row;
-  margin-top: 16px;
-  gap: 18px;
+  margin-top: variables.$spacing-lg;
+  gap: variables.$spacing-lg;
+  padding: variables.$spacing-sm;
 }
 
 .controlButton {
-  margin-left: 10px;
+  margin-left: variables.$spacing-md;
 }
 
 .message {
-  font-size: 14px;
-  line-height: 17px;
   overflow: hidden;
   text-overflow: ellipsis;
   white-space: nowrap;
   flex: 1;
-
-  & .success {
-    color: colors.$green;
-  }
-  & .error {
-    color: colors.$red;
-  }
 }
 
+.success {
+  color: colors.$green;
+}
+
+.error {
+  color: colors.$red;
+}
+
+// currently only implemented on transformation view form card, margins are specific to that implementation
+// todo: standardize the margin sizes here
 .line {
   min-width: 100%;
-  height: 1px;
+  height: variables.$border-thin;
   background: colors.$grey;
-  margin: 16px -27px 0 -24px;
+  margin: variables.$spacing-lg -27px 0 -24px;
 }

--- a/airbyte-webapp/src/views/Connection/ConnectionForm/components/EditControls.module.scss
+++ b/airbyte-webapp/src/views/Connection/ConnectionForm/components/EditControls.module.scss
@@ -15,21 +15,6 @@
   margin-left: variables.$spacing-md;
 }
 
-.message {
-  overflow: hidden;
-  text-overflow: ellipsis;
-  white-space: nowrap;
-  flex: 1;
-}
-
-.success {
-  color: colors.$green;
-}
-
-.error {
-  color: colors.$red;
-}
-
 // currently only implemented on transformation view form card, margins are specific to that implementation
 // todo: standardize the margin sizes here
 .line {

--- a/airbyte-webapp/src/views/Connection/ConnectionForm/components/EditControls.module.scss
+++ b/airbyte-webapp/src/views/Connection/ConnectionForm/components/EditControls.module.scss
@@ -1,0 +1,37 @@
+@use "../../../../scss/colors";
+
+.content {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  flex-direction: row;
+  margin-top: 16px;
+  gap: 18px;
+}
+
+.controlButton {
+  margin-left: 10px;
+}
+
+.message {
+  font-size: 14px;
+  line-height: 17px;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+  flex: 1;
+
+  & .success {
+    color: colors.$green;
+  }
+  & .error {
+    color: colors.$red;
+  }
+}
+
+.line {
+  min-width: 100%;
+  height: 1px;
+  background: colors.$grey;
+  margin: 16px -27px 0 -24px;
+}

--- a/airbyte-webapp/src/views/Connection/ConnectionForm/components/EditControls.tsx
+++ b/airbyte-webapp/src/views/Connection/ConnectionForm/components/EditControls.tsx
@@ -1,11 +1,10 @@
-import classnames from "classnames";
 import React from "react";
 import { FormattedMessage } from "react-intl";
 
 import { Button, LoadingButton } from "components";
-import { Text } from "components/base/Text";
 
 import styles from "./EditControls.module.scss";
+import { ResponseMessage } from "./ResponseMessage";
 
 interface EditControlProps {
   isSubmitting: boolean;
@@ -28,34 +27,11 @@ const EditControls: React.FC<EditControlProps> = ({
   enableControls,
   withLine,
 }) => {
-  const showStatusMessage = () => {
-    const messageStyle = classnames(styles.message, {
-      [styles.success]: successMessage,
-      [styles.error]: errorMessage,
-    });
-    if (errorMessage) {
-      return (
-        <Text as="div" size="lg" className={messageStyle}>
-          {errorMessage}
-        </Text>
-      );
-    }
-
-    if (successMessage && !dirty) {
-      return (
-        <Text as="div" size="lg" className={messageStyle} data-id="success-result">
-          {successMessage}
-        </Text>
-      );
-    }
-    return null;
-  };
-
   return (
     <>
       {withLine && <div className={styles.line} />}
       <div className={styles.content}>
-        {showStatusMessage()}
+        <ResponseMessage dirty={dirty} successMessage={successMessage} errorMessage={errorMessage} />
         <div>
           <Button type="button" secondary disabled={isSubmitting || (!dirty && !enableControls)} onClick={resetForm}>
             <FormattedMessage id="form.cancel" />

--- a/airbyte-webapp/src/views/Connection/ConnectionForm/components/EditControls.tsx
+++ b/airbyte-webapp/src/views/Connection/ConnectionForm/components/EditControls.tsx
@@ -3,6 +3,7 @@ import React from "react";
 import { FormattedMessage } from "react-intl";
 
 import { Button, LoadingButton } from "components";
+import { Text } from "components/base/Text";
 
 import styles from "./EditControls.module.scss";
 
@@ -29,18 +30,22 @@ const EditControls: React.FC<EditControlProps> = ({
 }) => {
   const showStatusMessage = () => {
     const messageStyle = classnames(styles.message, {
-      [styles.success]: !!successMessage,
-      [styles.error]: !!errorMessage,
+      [styles.success]: successMessage,
+      [styles.error]: errorMessage,
     });
     if (errorMessage) {
-      return <div className={messageStyle}>{errorMessage}</div>;
+      return (
+        <Text as="div" size="lg" className={messageStyle}>
+          {errorMessage}
+        </Text>
+      );
     }
 
     if (successMessage && !dirty) {
       return (
-        <div className={messageStyle} data-id="success-result">
+        <Text as="div" size="lg" className={messageStyle}>
           {successMessage}
-        </div>
+        </Text>
       );
     }
     return null;

--- a/airbyte-webapp/src/views/Connection/ConnectionForm/components/EditControls.tsx
+++ b/airbyte-webapp/src/views/Connection/ConnectionForm/components/EditControls.tsx
@@ -43,7 +43,7 @@ const EditControls: React.FC<EditControlProps> = ({
 
     if (successMessage && !dirty) {
       return (
-        <Text as="div" size="lg" className={messageStyle}>
+        <Text as="div" size="lg" className={messageStyle} data-id="success-result">
           {successMessage}
         </Text>
       );

--- a/airbyte-webapp/src/views/Connection/ConnectionForm/components/EditControls.tsx
+++ b/airbyte-webapp/src/views/Connection/ConnectionForm/components/EditControls.tsx
@@ -15,12 +15,13 @@ interface EditControlProps {
   withLine?: boolean;
 }
 
-const Buttons = styled.div`
+const Content = styled.div`
   display: flex;
   justify-content: space-between;
   align-items: center;
   flex-direction: row;
   margin-top: 16px;
+  gap: 18px;
 `;
 
 const ControlButton = styled(LoadingButton)`
@@ -31,6 +32,10 @@ const Success = styled.span`
   color: ${({ theme }) => theme.successColor};
   font-size: 14px;
   line-height: 17px;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+  flex: 1;
 `;
 
 const Error = styled(Success)`
@@ -67,8 +72,8 @@ const EditControls: React.FC<EditControlProps> = ({
   return (
     <>
       {withLine && <Line />}
-      <Buttons>
-        <div>{showStatusMessage()}</div>
+      <Content>
+        {showStatusMessage()}
         <div>
           <Button type="button" secondary disabled={isSubmitting || (!dirty && !enableControls)} onClick={resetForm}>
             <FormattedMessage id="form.cancel" />
@@ -81,7 +86,7 @@ const EditControls: React.FC<EditControlProps> = ({
             <FormattedMessage id="form.saveChanges" />
           </ControlButton>
         </div>
-      </Buttons>
+      </Content>
     </>
   );
 };

--- a/airbyte-webapp/src/views/Connection/ConnectionForm/components/EditControls.tsx
+++ b/airbyte-webapp/src/views/Connection/ConnectionForm/components/EditControls.tsx
@@ -1,8 +1,10 @@
+import classnames from "classnames";
 import React from "react";
 import { FormattedMessage } from "react-intl";
-import styled from "styled-components";
 
 import { Button, LoadingButton } from "components";
+
+import styles from "./EditControls.module.scss";
 
 interface EditControlProps {
   isSubmitting: boolean;
@@ -15,40 +17,6 @@ interface EditControlProps {
   withLine?: boolean;
 }
 
-const Content = styled.div`
-  display: flex;
-  justify-content: space-between;
-  align-items: center;
-  flex-direction: row;
-  margin-top: 16px;
-  gap: 18px;
-`;
-
-const ControlButton = styled(LoadingButton)`
-  margin-left: 10px;
-`;
-
-const Success = styled.span`
-  color: ${({ theme }) => theme.successColor};
-  font-size: 14px;
-  line-height: 17px;
-  overflow: hidden;
-  text-overflow: ellipsis;
-  white-space: nowrap;
-  flex: 1;
-`;
-
-const Error = styled(Success)`
-  color: ${({ theme }) => theme.dangerColor};
-`;
-
-const Line = styled.div`
-  min-width: 100%;
-  height: 1px;
-  background: ${({ theme }) => theme.greyColor20};
-  margin: 16px -27px 0 -24px;
-`;
-
 const EditControls: React.FC<EditControlProps> = ({
   isSubmitting,
   dirty,
@@ -60,33 +28,43 @@ const EditControls: React.FC<EditControlProps> = ({
   withLine,
 }) => {
   const showStatusMessage = () => {
+    const messageStyle = classnames(styles.message, {
+      [styles.success]: !!successMessage,
+      [styles.error]: !!errorMessage,
+    });
     if (errorMessage) {
-      return <Error>{errorMessage}</Error>;
+      return <div className={messageStyle}>{errorMessage}</div>;
     }
+
     if (successMessage && !dirty) {
-      return <Success data-id="success-result">{successMessage}</Success>;
+      return (
+        <div className={messageStyle} data-id="success-result">
+          {successMessage}
+        </div>
+      );
     }
     return null;
   };
 
   return (
     <>
-      {withLine && <Line />}
-      <Content>
+      {withLine && <div className={styles.line} />}
+      <div className={styles.content}>
         {showStatusMessage()}
         <div>
           <Button type="button" secondary disabled={isSubmitting || (!dirty && !enableControls)} onClick={resetForm}>
             <FormattedMessage id="form.cancel" />
           </Button>
-          <ControlButton
+          <LoadingButton
+            className={styles.controlButton}
             type="submit"
             isLoading={isSubmitting}
             disabled={submitDisabled || isSubmitting || (!dirty && !enableControls)}
           >
             <FormattedMessage id="form.saveChanges" />
-          </ControlButton>
+          </LoadingButton>
         </div>
-      </Content>
+      </div>
     </>
   );
 };

--- a/airbyte-webapp/src/views/Connection/ConnectionForm/components/ResponseMessage.module.scss
+++ b/airbyte-webapp/src/views/Connection/ConnectionForm/components/ResponseMessage.module.scss
@@ -1,3 +1,5 @@
+@use "../../../../scss/colors";
+
 .message {
   overflow: hidden;
   text-overflow: ellipsis;

--- a/airbyte-webapp/src/views/Connection/ConnectionForm/components/ResponseMessage.module.scss
+++ b/airbyte-webapp/src/views/Connection/ConnectionForm/components/ResponseMessage.module.scss
@@ -1,0 +1,14 @@
+.message {
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+  flex: 1;
+}
+
+.success {
+  color: colors.$green;
+}
+
+.error {
+  color: colors.$red;
+}

--- a/airbyte-webapp/src/views/Connection/ConnectionForm/components/ResponseMessage.tsx
+++ b/airbyte-webapp/src/views/Connection/ConnectionForm/components/ResponseMessage.tsx
@@ -1,0 +1,33 @@
+import classnames from "classnames";
+
+import { Text } from "components/base/Text";
+
+import styles from "./ResponseMessage.module.scss";
+
+interface ResponseMessageProps {
+  successMessage?: React.ReactNode;
+  errorMessage?: React.ReactNode;
+  dirty: boolean;
+}
+export const ResponseMessage: React.FC<ResponseMessageProps> = ({ successMessage, errorMessage, dirty }) => {
+  const messageStyle = classnames(styles.message, {
+    [styles.success]: successMessage,
+    [styles.error]: errorMessage,
+  });
+  if (errorMessage) {
+    return (
+      <Text as="div" size="lg" className={messageStyle}>
+        {errorMessage}
+      </Text>
+    );
+  }
+
+  if (successMessage && !dirty) {
+    return (
+      <Text as="div" size="lg" className={messageStyle} data-id="success-result">
+        {successMessage}
+      </Text>
+    );
+  }
+  return null;
+};


### PR DESCRIPTION
## What
closes https://github.com/airbytehq/airbyte/issues/16244

Previously, we would always display a generic "Form is invalid" error for all error messages on Replication View due to bad ternary logic.

Now, we return whatever we get back _or_ the standard validation error.

Success message unchanged:
<img width="1138" alt="Screen Shot 2022-09-07 at 6 33 54 PM" src="https://user-images.githubusercontent.com/63751206/188995279-109f5c16-a513-4578-80af-140c4f71ee7a.png">

Validation message unchanged:
<img width="1123" alt="Screen Shot 2022-09-07 at 6 31 07 PM" src="https://user-images.githubusercontent.com/63751206/188994961-df074ce6-c79d-4ba8-b191-e78293999456.png">

Now show whatever was returned as the error message, including truncating it with CSS if it is excessively long:
<img width="1139" alt="Screen Shot 2022-09-07 at 6 31 41 PM" src="https://user-images.githubusercontent.com/63751206/188995027-d36b68f8-0c7c-4991-ac5f-88fac2831f21.png">

## How
- Fixed the bad ternary
- Also migrated the ConnectionForm EditControls to scss modules and using our variables, Text component, etc.

## Recommended reading order
1. `ConnectionForm.tsx`
2. others

