### PR TITLE
Source Google Analytics v4: Re-name google analytics connector

### DIFF
--- a/airbyte-config/init/src/main/resources/seed/source_definitions.yaml
+++ b/airbyte-config/init/src/main/resources/seed/source_definitions.yaml
@@ -360,7 +360,7 @@
   icon: google-analytics.svg
   sourceType: api
   releaseStage: generally_available
-- name: Google Analytics (v4)
+- name: Google Analytics 4 (GA4)
   sourceDefinitionId: 3cc2eafd-84aa-4dca-93af-322d9dfeec1a
   dockerRepository: airbyte/source-google-analytics-data-api
   dockerImageTag: 0.0.3

--- a/airbyte-config/init/src/main/resources/seed/source_definitions.yaml
+++ b/airbyte-config/init/src/main/resources/seed/source_definitions.yaml
@@ -352,7 +352,7 @@
   icon: google-adwords.svg
   sourceType: api
   releaseStage: generally_available
-- name: Google Analytics
+- name: Google Analytics (Universal Analytics)
   sourceDefinitionId: eff3616a-f9c3-11eb-9a03-0242ac130003
   dockerRepository: airbyte/source-google-analytics-v4
   dockerImageTag: 0.1.25
@@ -360,7 +360,7 @@
   icon: google-analytics.svg
   sourceType: api
   releaseStage: generally_available
-- name: Google Analytics Data API
+- name: Google Analytics (v4)
   sourceDefinitionId: 3cc2eafd-84aa-4dca-93af-322d9dfeec1a
   dockerRepository: airbyte/source-google-analytics-data-api
   dockerImageTag: 0.0.3

--- a/airbyte-config/init/src/main/resources/seed/source_specs.yaml
+++ b/airbyte-config/init/src/main/resources/seed/source_specs.yaml
@@ -3193,7 +3193,7 @@
     documentationUrl: "https://docs.airbyte.com/integrations/sources/google-analytics-v4"
     connectionSpecification:
       $schema: "http://json-schema.org/draft-07/schema#"
-      title: "Google Analytics (v4) Spec"
+      title: "Google Analytics 4 (GA4) Spec"
       type: "object"
       required:
       - "property_id"

--- a/airbyte-config/init/src/main/resources/seed/source_specs.yaml
+++ b/airbyte-config/init/src/main/resources/seed/source_specs.yaml
@@ -3063,7 +3063,7 @@
     documentationUrl: "https://docs.airbyte.com/integrations/sources/google-analytics-universal-analytics"
     connectionSpecification:
       $schema: "http://json-schema.org/draft-07/schema#"
-      title: "Google Analytics V4 Spec"
+      title: "Google Analytics (Universal Analytics) Spec"
       type: "object"
       required:
       - "view_id"
@@ -3193,7 +3193,7 @@
     documentationUrl: "https://docs.airbyte.com/integrations/sources/google-analytics-v4"
     connectionSpecification:
       $schema: "http://json-schema.org/draft-07/schema#"
-      title: "Google Analytics Data API Spec"
+      title: "Google Analytics (v4) Spec"
       type: "object"
       required:
       - "property_id"

--- a/airbyte-integrations/connectors/source-google-analytics-data-api/source_google_analytics_data_api/spec.json
+++ b/airbyte-integrations/connectors/source-google-analytics-data-api/source_google_analytics_data_api/spec.json
@@ -2,7 +2,7 @@
   "documentationUrl": "https://docs.airbyte.com/integrations/sources/google-analytics-v4",
   "connectionSpecification": {
     "$schema": "http://json-schema.org/draft-07/schema#",
-    "title": "Google Analytics Data API Spec",
+    "title": "Google Analytics (v4) Spec",
     "type": "object",
     "required": ["property_id", "date_ranges_start_date"],
     "additionalProperties": true,

--- a/airbyte-integrations/connectors/source-google-analytics-data-api/source_google_analytics_data_api/spec.json
+++ b/airbyte-integrations/connectors/source-google-analytics-data-api/source_google_analytics_data_api/spec.json
@@ -2,7 +2,7 @@
   "documentationUrl": "https://docs.airbyte.com/integrations/sources/google-analytics-v4",
   "connectionSpecification": {
     "$schema": "http://json-schema.org/draft-07/schema#",
-    "title": "Google Analytics (v4) Spec",
+    "title": "Google Analytics 4 (GA4) Spec",
     "type": "object",
     "required": ["property_id", "date_ranges_start_date"],
     "additionalProperties": true,

--- a/airbyte-integrations/connectors/source-google-analytics-v4/source_google_analytics_v4/spec.json
+++ b/airbyte-integrations/connectors/source-google-analytics-v4/source_google_analytics_v4/spec.json
@@ -2,7 +2,7 @@
   "documentationUrl": "https://docs.airbyte.com/integrations/sources/google-analytics-universal-analytics",
   "connectionSpecification": {
     "$schema": "http://json-schema.org/draft-07/schema#",
-    "title": "Google Analytics V4 Spec",
+    "title": "Google Analytics (Universal Analytics) Spec",
     "type": "object",
     "required": ["view_id", "start_date"],
     "additionalProperties": true,

--- a/docs/integrations/sources/google-analytics-v4.md
+++ b/docs/integrations/sources/google-analytics-v4.md
@@ -1,4 +1,4 @@
-# Google Analytics (v4)
+# Google Analytics 4 (GA4)
 
 This page guides you through the process of setting up the Google Analytics source connector.
 


### PR DESCRIPTION
## What
Re-name `source-google-analytics-data-api` to Google Analytics 4 (GA4). 

## How
Re-named seeds and spec.