### PR TITLE
Log sync summary and sync activity seperators

### DIFF
--- a/airbyte-commons/src/main/java/io/airbyte/commons/io/LineGobbler.java
+++ b/airbyte-commons/src/main/java/io/airbyte/commons/io/LineGobbler.java
@@ -34,8 +34,7 @@ public class LineGobbler implements VoidCallable {
   }
 
   public static void gobble(final String message) {
-    final InputStream stringAsSteam = new ByteArrayInputStream(message.getBytes(StandardCharsets.UTF_8));
-    gobble(stringAsSteam, LOGGER::info);
+    gobble(message, LOGGER::info);
   }
 
   /**

--- a/airbyte-commons/src/main/java/io/airbyte/commons/io/LineGobbler.java
+++ b/airbyte-commons/src/main/java/io/airbyte/commons/io/LineGobbler.java
@@ -7,8 +7,10 @@ package io.airbyte.commons.io;
 import io.airbyte.commons.concurrency.VoidCallable;
 import io.airbyte.commons.logging.MdcScope;
 import java.io.BufferedReader;
+import java.io.ByteArrayInputStream;
 import java.io.IOException;
 import java.io.InputStream;
+import java.nio.charset.StandardCharsets;
 import java.util.Map;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
@@ -24,6 +26,36 @@ public class LineGobbler implements VoidCallable {
 
   public static void gobble(final InputStream is, final Consumer<String> consumer) {
     gobble(is, consumer, GENERIC, MdcScope.DEFAULT_BUILDER);
+  }
+
+  public static void gobble(final String message, final Consumer<String> consumer) {
+    final InputStream stringAsSteam = new ByteArrayInputStream(message.getBytes(StandardCharsets.UTF_8));
+    gobble(stringAsSteam, consumer);
+  }
+
+  public static void gobble(final String message) {
+    final InputStream stringAsSteam = new ByteArrayInputStream(message.getBytes(StandardCharsets.UTF_8));
+    gobble(stringAsSteam, LOGGER::info);
+  }
+
+  /**
+   * Used to emit a visual separator in the user-facing logs indicating a start of a meaningful
+   * temporal activity
+   *
+   * @param message
+   */
+  public static void startSection(final String message) {
+    gobble("\r\n----- START " + message + " -----\r\n\r\n");
+  }
+
+  /**
+   * Used to emit a visual separator in the user-facing logs indicating a end of a meaningful temporal
+   * activity
+   *
+   * @param message
+   */
+  public static void endSection(final String message) {
+    gobble("\r\n----- END " + message + " -----\r\n\r\n");
   }
 
   public static void gobble(final InputStream is, final Consumer<String> consumer, final MdcScope.Builder mdcScopeBuilder) {

--- a/airbyte-workers/src/main/java/io/airbyte/workers/general/DbtTransformationWorker.java
+++ b/airbyte-workers/src/main/java/io/airbyte/workers/general/DbtTransformationWorker.java
@@ -4,6 +4,7 @@
 
 package io.airbyte.workers.general;
 
+import io.airbyte.commons.io.LineGobbler;
 import io.airbyte.config.OperatorDbtInput;
 import io.airbyte.config.ResourceRequirements;
 import io.airbyte.workers.Worker;
@@ -42,6 +43,7 @@ public class DbtTransformationWorker implements Worker<OperatorDbtInput, Void> {
   @Override
   public Void run(final OperatorDbtInput operatorDbtInput, final Path jobRoot) throws WorkerException {
     final long startTime = System.currentTimeMillis();
+    LineGobbler.startSection("DBT TRANSFORMATION");
 
     try (dbtTransformationRunner) {
       LOGGER.info("Running dbt transformation.");
@@ -65,6 +67,7 @@ public class DbtTransformationWorker implements Worker<OperatorDbtInput, Void> {
 
     final Duration duration = Duration.ofMillis(System.currentTimeMillis() - startTime);
     LOGGER.info("Dbt Transformation executed in {}.", duration.toMinutesPart());
+    LineGobbler.endSection("DBT TRANSFORMATION");
 
     return null;
   }

--- a/airbyte-workers/src/main/java/io/airbyte/workers/general/DefaultCheckConnectionWorker.java
+++ b/airbyte-workers/src/main/java/io/airbyte/workers/general/DefaultCheckConnectionWorker.java
@@ -58,6 +58,7 @@ public class DefaultCheckConnectionWorker implements CheckConnectionWorker {
 
   @Override
   public ConnectorJobOutput run(final StandardCheckConnectionInput input, final Path jobRoot) throws WorkerException {
+    LineGobbler.startSection("CHECK");
 
     try {
       process = integrationLauncher.check(
@@ -88,6 +89,7 @@ public class DefaultCheckConnectionWorker implements CheckConnectionWorker {
 
         LOGGER.debug("Check connection job subprocess finished with exit code {}", exitCode);
         LOGGER.debug("Check connection job received output: {}", output);
+        LineGobbler.endSection("CHECK");
         return new ConnectorJobOutput().withOutputType(OutputType.CHECK_CONNECTION).withCheckConnection(output);
       } else {
         final String message = String.format("Error checking connection, status: %s, exit code: %d", status, exitCode);

--- a/airbyte-workers/src/main/java/io/airbyte/workers/general/DefaultNormalizationWorker.java
+++ b/airbyte-workers/src/main/java/io/airbyte/workers/general/DefaultNormalizationWorker.java
@@ -53,10 +53,9 @@ public class DefaultNormalizationWorker implements NormalizationWorker {
   @Override
   public NormalizationSummary run(final NormalizationInput input, final Path jobRoot) throws WorkerException {
     final long startTime = System.currentTimeMillis();
-    LineGobbler.startSection("DEFAULT NORMALIZATION");
 
     try (normalizationRunner) {
-      LOGGER.info("Running normalization.");
+      LineGobbler.startSection("DEFAULT NORMALIZATION");
       normalizationRunner.start();
 
       Path normalizationRoot = null;

--- a/airbyte-workers/src/main/java/io/airbyte/workers/general/DefaultNormalizationWorker.java
+++ b/airbyte-workers/src/main/java/io/airbyte/workers/general/DefaultNormalizationWorker.java
@@ -4,6 +4,7 @@
 
 package io.airbyte.workers.general;
 
+import io.airbyte.commons.io.LineGobbler;
 import io.airbyte.config.Configs.WorkerEnvironment;
 import io.airbyte.config.FailureReason;
 import io.airbyte.config.NormalizationInput;
@@ -52,6 +53,7 @@ public class DefaultNormalizationWorker implements NormalizationWorker {
   @Override
   public NormalizationSummary run(final NormalizationInput input, final Path jobRoot) throws WorkerException {
     final long startTime = System.currentTimeMillis();
+    LineGobbler.startSection("DEFAULT NORMALIZATION");
 
     try (normalizationRunner) {
       LOGGER.info("Running normalization.");
@@ -92,6 +94,7 @@ public class DefaultNormalizationWorker implements NormalizationWorker {
     }
 
     LOGGER.info("Normalization summary: {}", summary);
+    LineGobbler.endSection("DEFAULT NORMALIZATION");
 
     return summary;
   }

--- a/airbyte-workers/src/main/java/io/airbyte/workers/general/DefaultReplicationWorker.java
+++ b/airbyte-workers/src/main/java/io/airbyte/workers/general/DefaultReplicationWorker.java
@@ -4,6 +4,7 @@
 
 package io.airbyte.workers.general;
 
+import com.fasterxml.jackson.databind.ObjectMapper;
 import io.airbyte.commons.io.LineGobbler;
 import io.airbyte.config.FailureReason;
 import io.airbyte.config.ReplicationAttemptSummary;
@@ -248,7 +249,6 @@ public class DefaultReplicationWorker implements ReplicationWorker {
           .withStartTime(startTime)
           .withEndTime(System.currentTimeMillis());
 
-      LOGGER.info("sync summary: {}", summary);
       final ReplicationOutput output = new ReplicationOutput()
           .withReplicationAttemptSummary(summary)
           .withOutputCatalog(destinationConfig.getCatalog());
@@ -294,6 +294,10 @@ public class DefaultReplicationWorker implements ReplicationWorker {
       if (messageTracker.getUnreliableStateTimingMetrics()) {
         metricReporter.trackStateMetricTrackerError();
       }
+
+      final ObjectMapper mapper = new ObjectMapper();
+      LOGGER.info("sync summary: {}", mapper.writerWithDefaultPrettyPrinter().writeValueAsString(summary));
+      LOGGER.info("failures: {}", mapper.writerWithDefaultPrettyPrinter().writeValueAsString(failures));
 
       LineGobbler.endSection("REPLICATION");
       return output;

--- a/airbyte-workers/src/main/java/io/airbyte/workers/general/DefaultReplicationWorker.java
+++ b/airbyte-workers/src/main/java/io/airbyte/workers/general/DefaultReplicationWorker.java
@@ -4,6 +4,7 @@
 
 package io.airbyte.workers.general;
 
+import io.airbyte.commons.io.LineGobbler;
 import io.airbyte.config.FailureReason;
 import io.airbyte.config.ReplicationAttemptSummary;
 import io.airbyte.config.ReplicationOutput;
@@ -117,6 +118,7 @@ public class DefaultReplicationWorker implements ReplicationWorker {
   @Override
   public final ReplicationOutput run(final StandardSyncInput syncInput, final Path jobRoot) throws WorkerException {
     LOGGER.info("start sync worker. job id: {} attempt id: {}", jobId, attempt);
+    LineGobbler.startSection("REPLICATION");
 
     // todo (cgardens) - this should not be happening in the worker. this is configuration information
     // that is independent of workflow executions.
@@ -293,6 +295,7 @@ public class DefaultReplicationWorker implements ReplicationWorker {
         metricReporter.trackStateMetricTrackerError();
       }
 
+      LineGobbler.endSection("REPLICATION");
       return output;
     } catch (final Exception e) {
       throw new WorkerException("Sync failed", e);


### PR DESCRIPTION
Closes https://github.com/airbytehq/airbyte/issues/12864

This PR attempts to add some structure to our user-facing sync logs.

**1. Clear separation of each Activity**
<img width="1364" alt="Screen Shot 2022-09-02 at 11 36 26 AM" src="https://user-images.githubusercontent.com/303226/188244271-3eea9764-6217-4f6f-95b9-79c2ce6716e6.png">
<img width="1353" alt="Screen Shot 2022-09-02 at 11 36 21 AM" src="https://user-images.githubusercontent.com/303226/188244275-bca297b9-b5b1-4a19-adca-5923f77cc8dc.png">

**2. Adding SyncSummaries and Failures to the log**
Thanks, JSON pretty-printing!
<img width="1367" alt="Screen Shot 2022-09-02 at 3 53 00 PM" src="https://user-images.githubusercontent.com/303226/188244298-c6d43267-72a9-44e4-b560-31bba2937ed8.png">


