### PR TITLE
Add `AirbyteNotificationTraceMessage`

### DIFF
--- a/airbyte-protocol/protocol-models/src/main/resources/airbyte_protocol/airbyte_protocol.yaml
+++ b/airbyte-protocol/protocol-models/src/main/resources/airbyte_protocol/airbyte_protocol.yaml
@@ -166,12 +166,16 @@ definitions:
         type: string
         enum:
           - ERROR
+          - NOTIFICATION
       emitted_at:
         description: "the time in ms that the message was emitted"
         type: number
       error:
         description: "error trace message: the error object"
         "$ref": "#/definitions/AirbyteErrorTraceMessage"
+      notification:
+        description: "notification trace message: the notification object"
+        "$ref": "#/definitions/AirbyteNotificationTraceMessage"
   AirbyteErrorTraceMessage:
     type: object
     additionalProperties: true
@@ -193,6 +197,18 @@ definitions:
         enum:
           - system_error
           - config_error
+  AirbyteNotificationTraceMessage:
+    type: object
+    additionalProperties: true
+    required:
+      - message
+    properties:
+      message:
+        description: A user-friendly message from the caller
+        type: string
+      data:
+        description: An additional information that the caller wishes to log
+        type: object
   AirbyteConnectionStatus:
     type: object
     description: Airbyte connection status

--- a/airbyte-protocol/protocol-models/src/main/resources/airbyte_protocol/airbyte_protocol.yaml
+++ b/airbyte-protocol/protocol-models/src/main/resources/airbyte_protocol/airbyte_protocol.yaml
@@ -207,7 +207,7 @@ definitions:
         description: A user-friendly message from the caller
         type: string
       data:
-        description: An additional information that the caller wishes to log
+        description: An additional information that the caller wishes to log.  This information will be shown to end-users along with message
         type: object
   AirbyteConnectionStatus:
     type: object

--- a/airbyte-workers/src/main/java/io/airbyte/workers/internal/AirbyteMessageTracker.java
+++ b/airbyte-workers/src/main/java/io/airbyte/workers/internal/AirbyteMessageTracker.java
@@ -15,6 +15,7 @@ import io.airbyte.commons.json.Jsons;
 import io.airbyte.config.FailureReason;
 import io.airbyte.config.State;
 import io.airbyte.protocol.models.AirbyteMessage;
+import io.airbyte.protocol.models.AirbyteNotificationTraceMessage;
 import io.airbyte.protocol.models.AirbyteRecordMessage;
 import io.airbyte.protocol.models.AirbyteStateMessage;
 import io.airbyte.protocol.models.AirbyteStateMessage.AirbyteStateType;
@@ -217,6 +218,7 @@ public class AirbyteMessageTracker implements MessageTracker {
   private void handleEmittedTrace(final AirbyteTraceMessage traceMessage, final ConnectorType connectorType) {
     switch (traceMessage.getType()) {
       case ERROR -> handleEmittedErrorTrace(traceMessage, connectorType);
+      case NOTIFICATION -> handleEmittedNotificationTrace(traceMessage, connectorType);
       default -> log.warn("Invalid message type for trace message: {}", traceMessage);
     }
   }
@@ -227,6 +229,14 @@ public class AirbyteMessageTracker implements MessageTracker {
     } else if (connectorType.equals(ConnectorType.SOURCE)) {
       sourceErrorTraceMessages.add(errorTraceMessage);
     }
+  }
+
+  private void handleEmittedNotificationTrace(final AirbyteTraceMessage notificationTraceMessage, final ConnectorType connectorType) {
+    final AirbyteNotificationTraceMessage notification = notificationTraceMessage.getNotification();
+    final String logMessage =
+        "[" + connectorType + " Notification] " + notification.getMessage()
+            + notification.getData() != null ? " -> " + Jsons.serialize(notification.getData()) : "";
+    log.info(logMessage);
   }
 
   private short getStreamIndex(final String streamName) {

--- a/airbyte-workers/src/main/java/io/airbyte/workers/internal/AirbyteMessageTracker.java
+++ b/airbyte-workers/src/main/java/io/airbyte/workers/internal/AirbyteMessageTracker.java
@@ -234,7 +234,7 @@ public class AirbyteMessageTracker implements MessageTracker {
   private void handleEmittedNotificationTrace(final AirbyteTraceMessage notificationTraceMessage, final ConnectorType connectorType) {
     final AirbyteNotificationTraceMessage notification = notificationTraceMessage.getNotification();
     final String logMessage =
-        "[" + connectorType + " Notification] " + notification.getMessage()
+        "[" + connectorType + " NOTIFICATION] " + notification.getMessage()
             + notification.getData() != null ? " -> " + Jsons.serialize(notification.getData()) : "";
     log.info(logMessage);
   }

--- a/airbyte-workers/src/main/java/io/airbyte/workers/internal/AirbyteMessageTracker.java
+++ b/airbyte-workers/src/main/java/io/airbyte/workers/internal/AirbyteMessageTracker.java
@@ -235,7 +235,7 @@ public class AirbyteMessageTracker implements MessageTracker {
     final AirbyteNotificationTraceMessage notification = notificationTraceMessage.getNotification();
     final String logMessage =
         "[" + connectorType + " NOTIFICATION] " + notification.getMessage()
-            + notification.getData() != null ? " -> " + Jsons.serialize(notification.getData()) : "";
+            + (notification.getData() != null ? " -> " + Jsons.serialize(notification.getData()) : "");
     log.info(logMessage);
   }
 


### PR DESCRIPTION
This PR is inspired by the conversation in https://github.com/airbytehq/airbyte/pull/15668#issuecomment-1234773047. Please read this thread first.  The goal of this PR is to allow connectors to pass structured messages (e.g. a "message" and additional metadata) to the worker for logging, and in the future, analysis.  Specifically, the first use case will be a connector capturing an exception and trying again, e.g. `log("caught error, trying again in 5s", exception)`

## Notes

- [ ] As this is a change to the [Airbyte Protocol](https://github.com/airbytehq/airbyte/blob/master/airbyte-protocol/protocol-models/src/main/resources/airbyte_protocol/airbyte_protocol.yaml), do not merge this PR until the [Protocol Change Process](https://docs.google.com/document/d/1544cfQST-WX9HQvJUq2borVSOLjRTWAJJJd2nmrJ9Io/edit#) has been completed

## Proposal

`AirbyteNotificationTraceMessage` was originally considered in the [PRD](https://docs.google.com/document/d/1ctrj3Yh_GjtQ93aND-WH3ocqGxsmxyC3jfiarrF6NY0/edit#heading=h.nktmxbx2ya9y), but not yet implemented.  

`AirbyteNotificationTraceMessage` is a type of `AirbyteTraceMessasge` which exists to allow connectors to pass information in real-time to the UI. Initially designed to present status information during slow CHECK commands to users, this message can also be used during replication to log more complex objects.

In an attempt to disambiguate `AirbyteNotificationTraceMessage` from `AirbyteErrorTraceMessage`, it was a conscious choice to make the only additional property an arbitrary `data`, rather than `stacktrace` or a more structured object.  It is to be assumed that the entire content of `data` is safe to show to end-users, with the additional context of the required `message` field. 

An emitted message like:

```js
{
  TYPE: "TRACE", 
  trace: {
    type: "NOTIFICATION", 
    "notification": {
      message: "The connector had a problem, but we are retrying in 10 seconds..."
      data: {
        stackTrace: "busted on line 2\r\n because of broken on line 1"
        sleepTime: 10
}}}}
```

Will be rendered in the logs like:

```
2022-10-10 00:11:22 [SOURCE NOTIFICATION] The connector had a problem, but we are retrying in 10 seconds... -> {"stackTrace": "busted on line 2\r\n because of broken on line 1", "sleepTime": 10}
```

The message formats described here can be produced with a Log4J formatter (See https://github.com/airbytehq/airbyte/pull/15668 for more details).

## Alternative Solutions Considered

1. Use `AirbyteLogMessage` and concatenate the "message" and the "stack-trace".  This idea was rejected because it would mean that all Java connectors could not use the native Log4J `LOGGER.error(message, error)` because contacting "message" and "error" is not possible.
2. Use an existing sub-type of `AirbyteTraceMessage`, `AirbyteErrorTraceMessage`.  This idea was rejected because AirbyteErrorTraceMessage have semantic meaning, and are to be used for fatal error messages, e.g. those that really do crash the connector.  As the exceptions being caught are non-fatal, they shouldn't be used in `failureReasons`, etc. and are therefore inappropriate for `AirbyteErrorTraceMessage`.
3. Add an additional data property to `AirbyteLogMessage`.  This idea was rejected because the intent of `AirbyteLogMessage` is to be as simple as possible, remaining just a string.  Adding additional structures to this message increases the likelihood that it will become used for more complex and unsupported things in the future. (@alovew to add notes)