### PR TITLE
Use forked slash-command-dispatcher to handle base64 encoded PAT

### DIFF
--- a/.github/workflows/slash-commands.yml
+++ b/.github/workflows/slash-commands.yml
@@ -3,10 +3,28 @@ on:
   issue_comment:
     types: [created]
 jobs:
+  find_valid_pat:
+    name: "Find a PAT with room for actions"
+    timeout-minutes: 10
+    runs-on: ubuntu-latest
+    outputs:
+      pat: ${{ steps.variables.outputs.pat }}
+    steps:
+      - name: Checkout Airbyte
+        uses: actions/checkout@v2
+      - name: Check PAT rate limits
+        id: variables
+        run: |
+          ./tools/bin/find_non_rate_limited_PAT \
+            ${{ secrets.AIRBYTEIO_PAT }} \
+            ${{ secrets.OSS_BUILD_RUNNER_GITHUB_PAT }} \
+            ${{ secrets.SUPERTOPHER_PAT }} \
+            ${{ secrets.DAVINCHIA_PAT }}
   slashCommandDispatch:
     # Only allow slash commands on pull request (not on issues)
     if: ${{ github.event.issue.pull_request }}
     runs-on: ubuntu-latest
+    needs: find_valid_pat
     steps:
       - name: Get PR repo and ref
         id: getref
@@ -16,9 +34,9 @@ jobs:
           echo ::set-output name=repo::"$(echo $pr_info | jq -r '.head.repo.full_name')"
       - name: Slash Command Dispatch
         id: scd
-        uses: peter-evans/slash-command-dispatch@v2
+        uses: airbytehq/slash-command-dispatch-find-a-pat-decode@v1 
         with:
-          token: ${{ secrets.SUPERTOPHER_PAT }}
+          token: ${{ needs.find_valid_pat.outputs.pat }} 
           commands: |
             test
             test-performance


### PR DESCRIPTION
## Summary
This reinstates the work of @tuliren's [PR](https://github.com/airbytehq/airbyte/pull/16144) by using our forked version of slash-command-dispatcher which handles base64 encoded tokens. 

## Testing
https://github.com/airbytehq/github-workflow-test-repo-base/actions/runs/2982386732
https://github.com/airbytehq/github-workflow-test-repo-base/actions/runs/2982380207
