### PR TITLE
use refactored find a pat script to pass token to slash command dispatch action via env

### DIFF
--- a/.github/workflows/slash-commands.yml
+++ b/.github/workflows/slash-commands.yml
@@ -8,17 +8,29 @@ jobs:
     if: ${{ github.event.issue.pull_request }}
     runs-on: ubuntu-latest
     steps:
+      - name: Checkout Airbyte
+        uses: actions/checkout@v2
+
+      - name: Check PAT rate limits
+        run: |
+          ./tools/bin/find_non_rate_limited_PAT \
+            ${{ secrets.AIRBYTEIO_PAT }} \
+            ${{ secrets.OSS_BUILD_RUNNER_GITHUB_PAT }} \
+            ${{ secrets.SUPERTOPHER_PAT }} \
+            ${{ secrets.DAVINCHIA_PAT }}
+
       - name: Get PR repo and ref
         id: getref
         run: |
           pr_info="$(curl ${{ github.event.issue.pull_request.url }})"
           echo ::set-output name=ref::"$(echo $pr_info | jq -r '.head.ref')"
           echo ::set-output name=repo::"$(echo $pr_info | jq -r '.head.repo.full_name')"
+
       - name: Slash Command Dispatch
         id: scd
         uses: peter-evans/slash-command-dispatch@v2
         with:
-          token: ${{ secrets.SUPERTOPHER_PAT }}
+          token: ${{ env.PAT }}
           commands: |
             test
             test-performance
@@ -34,6 +46,7 @@ jobs:
             gitref=${{ steps.getref.outputs.ref }}
             comment-id=${{ github.event.comment.id }}
           dispatch-type: workflow
+
       - name: Edit comment with error message
         if: steps.scd.outputs.error-message
         uses: peter-evans/create-or-update-comment@v1

--- a/tools/bin/find_non_rate_limited_PAT
+++ b/tools/bin/find_non_rate_limited_PAT
@@ -42,6 +42,7 @@ for personal_access_token in $@
       echo -e "$blue_text""Found a good PAT!!""$default_text"
       # ::set-output name is a github action magic string for output
       echo "::set-output name=pat::$base64_valid_pat"
+      echo "PAT=$personal_access_token" >> $GITHUB_ENV
       exit 0
     else
       echo -e "$red_text""Rate limit exceed for this PAT!""$default_text"


### PR DESCRIPTION
## Summary 
This reinstates the work of @tuliren's [PR](https://github.com/airbytehq/airbyte/pull/16144) by using a refactored `find_non_rate_limited_PAT` that writes the token to env (not base64 encoded). 

## Tests 
- https://github.com/airbytehq/github-workflow-test-repo-base/runs/8173224835?check_suite_focus=true
- https://github.com/airbytehq/github-workflow-test-repo-base/runs/8173220486?check_suite_focus=true

