### PR TITLE
Add email to identify users

### DIFF
--- a/airbyte-webapp/src/packages/cloud/cloudRoutes.tsx
+++ b/airbyte-webapp/src/packages/cloud/cloudRoutes.tsx
@@ -152,7 +152,7 @@ export const Routing: React.FC = () => {
     [user]
   );
   useAnalyticsRegisterValues(analyticsContext);
-  useAnalyticsIdentifyUser(user?.userId, { providers });
+  useAnalyticsIdentifyUser(user?.userId, { providers, email: user?.email });
   useTrackPageAnalytics();
 
   if (!inited) {


### PR DESCRIPTION
## What
Hubspot and Chameleon need this information to track users correctly.

## How
Just adding `email` on Segment `traits`
