### PR TITLE
:window: :art: Design fixes of the authentication page

### DIFF
--- a/airbyte-webapp/src/packages/cloud/views/auth/Auth.module.scss
+++ b/airbyte-webapp/src/packages/cloud/views/auth/Auth.module.scss
@@ -2,21 +2,22 @@
 
 .container {
   display: flex;
-  flex-direction: column;
+  flex-direction: row;
   width: 100%;
+  height: 100%;
   background: colors.$white;
 }
 
 .leftSide {
+  display: flex;
+  flex-direction: column;
+  overflow-y: auto;
   width: 100%;
   padding: 20px 36px 39px 46px;
 }
 
 .rightSide {
-  display: flex;
-  flex-direction: column;
-  justify-content: space-between;
-  width: 100%;
+  display: none;
 }
 
 .rightSideFrame {
@@ -26,10 +27,12 @@
   overflow: hidden;
 }
 
-@media (min-width: 992px) and (min-height: 720px) {
-  .container {
-    flex-direction: row;
-    height: 100%;
+@media (min-width: 992px) {
+  .rightSide {
+    display: flex;
+    flex-direction: column;
+    justify-content: space-between;
+    width: 100%;
   }
 
   .leftSide,

--- a/airbyte-webapp/src/packages/cloud/views/auth/OAuthLogin/OAuthLogin.module.scss
+++ b/airbyte-webapp/src/packages/cloud/views/auth/OAuthLogin/OAuthLogin.module.scss
@@ -45,6 +45,7 @@
 .github {
   background: #333;
   color: colors.$white;
+  border: none;
 }
 
 .google,
@@ -59,7 +60,6 @@
   padding: vars.$spacing-md;
   gap: vars.$spacing-md;
   border-radius: vars.$border-radius-sm;
-  border: none;
   transition: all vars.$transition;
   cursor: pointer;
 

--- a/airbyte-webapp/src/packages/cloud/views/auth/components/FormContent.tsx
+++ b/airbyte-webapp/src/packages/cloud/views/auth/components/FormContent.tsx
@@ -8,8 +8,8 @@ import { Header } from "./Header";
 
 const MainBlock = styled.div`
   width: 100%;
-  height: calc(100% - 100px);
   display: flex;
+  flex: 1 0 auto;
   align-items: center;
   justify-content: center;
 `;

--- a/airbyte-webapp/src/packages/cloud/views/auth/components/GitBlock/GitBlock.module.scss
+++ b/airbyte-webapp/src/packages/cloud/views/auth/components/GitBlock/GitBlock.module.scss
@@ -1,4 +1,5 @@
 @use "../../../../../../scss/colors";
+@use "../../../../../../scss/variables";
 
 .container {
   display: flex;
@@ -7,12 +8,12 @@
 
   .link {
     text-decoration: none;
+    margin-top: variables.$spacing-2xl;
 
     .content {
       display: flex;
       flex-direction: row;
       align-items: center;
-      margin-top: 17px;
 
       .icon {
         margin-right: 10px;

--- a/airbyte-webapp/src/packages/cloud/views/auth/components/Header/Header.module.scss
+++ b/airbyte-webapp/src/packages/cloud/views/auth/components/Header/Header.module.scss
@@ -1,10 +1,12 @@
 @use "../../../../../../scss/colors";
+@use "../../../../../../scss/variables";
 
 .links {
   width: 100%;
   display: flex;
   flex-direction: row;
   justify-content: flex-end;
+  margin-bottom: variables.$spacing-xl;
 
   .formLink {
     font-size: 11px;


### PR DESCRIPTION
## What

Fixes several design issues on the authentication page:

(1) The border of the google oauth button was gone (due to stylelint reordering the rules). Made sure this is no longer depending on rule ordering.
 
(2) Make the sign up page not being squished together when the screen height is small.
**Previous behavior:**
![cloud airbyte io_signup](https://user-images.githubusercontent.com/877229/188436150-f1c4fbc8-0a41-4d5a-bc20-7e74f42da545.png)
**New behavior: (scrollable left side)**
![localhost_3000_login](https://user-images.githubusercontent.com/877229/188436314-5cccdd4c-751d-47e8-a585-6d894a3814d3.png)

(3) Hide the right side (in sync with Natalie), if the screen gets to small instead of pushing it below it. Since when the iframe is enabled for the right side, we have no good idea what a proper height for that should be for the content to render nicely.