### PR TITLE
🪟 🔧 Add experiment information to page views events (Segment)

### DIFF
--- a/airbyte-webapp/src/core/analytics/AnalyticsService.ts
+++ b/airbyte-webapp/src/core/analytics/AnalyticsService.ts
@@ -7,7 +7,7 @@ export class AnalyticsService {
 
   alias = (newId: string): void => this.getSegmentAnalytics()?.alias?.(newId);
 
-  page = (name: string): void => this.getSegmentAnalytics()?.page?.(name);
+  page = (name: string): void => this.getSegmentAnalytics()?.page?.(name, { ...this.context });
 
   reset = (): void => this.getSegmentAnalytics()?.reset?.();
 


### PR DESCRIPTION
## What
We need to know what experiment the user is on when viewing different pages

## How
Thanks to a prior implementation, we were already adding experiments information to the context. The only thing we needed to do was adding that piece of context to `analytics.page()`


## 🚨 User Impact 🚨
None