### PR TITLE
Add data-testid to the cursorField field

### DIFF
--- a/airbyte-webapp/src/views/Connection/CatalogTree/components/BulkHeader.tsx
+++ b/airbyte-webapp/src/views/Connection/CatalogTree/components/BulkHeader.tsx
@@ -119,6 +119,7 @@ export const BulkHeader: React.FC<BulkHeaderProps> = ({ destinationSupportedSync
             pathType={cursorType}
             paths={paths}
             path={options.cursorField}
+            data-testid="cursorField"
           />
         )}
       </HeaderCell>


### PR DESCRIPTION
## What
This adds a `data-testid` attribute to the cursorField field in the connection form. I haven't had a chance to test these changes yet, however, which is why this PR remains in draft despite being so trivial.