### PR TITLE
doc: add `airbyte_secret` field in example

### DIFF
--- a/docs/connector-development/tutorials/cdk-tutorial-python-http/define-inputs.md
+++ b/docs/connector-development/tutorials/cdk-tutorial-python-http/define-inputs.md
@@ -24,6 +24,7 @@ connectionSpecification:
     access_key:
       type: string
       description: API access key used to retrieve data from the Exchange Rates API.
+      airbyte_secret: true
     start_date:
       type: string
       description: Start getting data from that date.


### PR DESCRIPTION
## What
In the *Define inputs* section of *Python CDK: Creating a HTTP API Source*  we did not show that the `access_token` field should be considered as secret.
