### PR TITLE
Remove US/Pacific-New timezone

### DIFF
--- a/airbyte-server/src/test/java/io/airbyte/server/handlers/ConnectionSchedulerHelperTest.java
+++ b/airbyte-server/src/test/java/io/airbyte/server/handlers/ConnectionSchedulerHelperTest.java
@@ -646,7 +646,6 @@ class ConnectionSchedulerHelperTest {
       "US/Michigan",
       "US/Mountain",
       "US/Pacific",
-      "US/Pacific-New",
       "US/Samoa",
       "UTC",
       "Universal",

--- a/airbyte-webapp/src/config/availableCronTimeZones.json
+++ b/airbyte-webapp/src/config/availableCronTimeZones.json
@@ -550,7 +550,6 @@
   "US/Michigan",
   "US/Mountain",
   "US/Pacific",
-  "US/Pacific-New",
   "US/Samoa",
   "UTC",
   "Universal",


### PR DESCRIPTION
This timezone causes an issue on our branch with Micronaut, some sort of dependency disagreement about whether or not this timezone exists. Also, apparently it's a whole thing https://github.com/moment/moment-timezone/issues/498

I don't think anybody would intentionally choose 'US/Pacific-New' over 'US/Pacific' regardless of whether or not it was valid.