### PR TITLE
Only STATE and RECORD messages from the Source should be sent to the Destination

### DIFF
--- a/airbyte-webapp/src/test-utils/mock-data/mockDestinationDefinition.json
+++ b/airbyte-webapp/src/test-utils/mock-data/mockDestinationDefinition.json
@@ -146,7 +146,12 @@
           },
           {
             "title": "verify-full",
-            "required": ["mode", "ca_certificate", "client_certificate", "client_key"],
+            "required": [
+              "mode",
+              "ca_certificate",
+              "client_certificate",
+              "client_key"
+            ],
             "properties": {
               "mode": {
                 "enum": ["verify-full"],
@@ -218,7 +223,13 @@
           },
           {
             "title": "SSH Key Authentication",
-            "required": ["tunnel_method", "tunnel_host", "tunnel_port", "tunnel_user", "ssh_key"],
+            "required": [
+              "tunnel_method",
+              "tunnel_host",
+              "tunnel_port",
+              "tunnel_user",
+              "ssh_key"
+            ],
             "properties": {
               "ssh_key": {
                 "type": "string",
@@ -260,7 +271,13 @@
           },
           {
             "title": "Password Authentication",
-            "required": ["tunnel_method", "tunnel_host", "tunnel_port", "tunnel_user", "tunnel_user_password"],
+            "required": [
+              "tunnel_method",
+              "tunnel_host",
+              "tunnel_port",
+              "tunnel_user",
+              "tunnel_user_password"
+            ],
             "properties": {
               "tunnel_host": {
                 "type": "string",

--- a/airbyte-webapp/src/test-utils/mock-data/mockDestinationDefinition.json
+++ b/airbyte-webapp/src/test-utils/mock-data/mockDestinationDefinition.json
@@ -146,12 +146,7 @@
           },
           {
             "title": "verify-full",
-            "required": [
-              "mode",
-              "ca_certificate",
-              "client_certificate",
-              "client_key"
-            ],
+            "required": ["mode", "ca_certificate", "client_certificate", "client_key"],
             "properties": {
               "mode": {
                 "enum": ["verify-full"],
@@ -223,13 +218,7 @@
           },
           {
             "title": "SSH Key Authentication",
-            "required": [
-              "tunnel_method",
-              "tunnel_host",
-              "tunnel_port",
-              "tunnel_user",
-              "ssh_key"
-            ],
+            "required": ["tunnel_method", "tunnel_host", "tunnel_port", "tunnel_user", "ssh_key"],
             "properties": {
               "ssh_key": {
                 "type": "string",
@@ -271,13 +260,7 @@
           },
           {
             "title": "Password Authentication",
-            "required": [
-              "tunnel_method",
-              "tunnel_host",
-              "tunnel_port",
-              "tunnel_user",
-              "tunnel_user_password"
-            ],
+            "required": ["tunnel_method", "tunnel_host", "tunnel_port", "tunnel_user", "tunnel_user_password"],
             "properties": {
               "tunnel_host": {
                 "type": "string",

--- a/airbyte-workers/src/test/java/io/airbyte/workers/general/DefaultReplicationWorkerTest.java
+++ b/airbyte-workers/src/test/java/io/airbyte/workers/general/DefaultReplicationWorkerTest.java
@@ -14,6 +14,7 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.Mockito.atLeastOnce;
 import static org.mockito.Mockito.doThrow;
 import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
@@ -40,6 +41,7 @@ import io.airbyte.config.helpers.LogClientSingleton;
 import io.airbyte.config.helpers.LogConfigs;
 import io.airbyte.metrics.lib.MetricClient;
 import io.airbyte.metrics.lib.MetricClientFactory;
+import io.airbyte.protocol.models.AirbyteLogMessage.Level;
 import io.airbyte.protocol.models.AirbyteMessage;
 import io.airbyte.protocol.models.AirbyteTraceMessage;
 import io.airbyte.validation.json.JsonSchemaValidator;
@@ -290,6 +292,33 @@ class DefaultReplicationWorkerTest {
     assertEquals(ReplicationStatus.FAILED, output.getReplicationAttemptSummary().getStatus());
     assertTrue(output.getFailures().stream()
         .anyMatch(f -> f.getFailureOrigin().equals(FailureOrigin.REPLICATION) && f.getStacktrace().contains(WORKER_ERROR_MESSAGE)));
+  }
+
+  @Test
+  void testOnlyStateAndRecordMessagesDeliveredToDestination() throws Exception {
+    final AirbyteMessage LOG_MESSAGE = AirbyteMessageUtils.createLogMessage(Level.INFO, "a log message");
+    final AirbyteMessage TRACE_MESSAGE = AirbyteMessageUtils.createTraceMessage("a trace message", 123456.0);
+    when(source.attemptRead()).thenReturn(Optional.of(RECORD_MESSAGE1), Optional.of(LOG_MESSAGE), Optional.of(TRACE_MESSAGE),
+        Optional.of(RECORD_MESSAGE2), Optional.empty());
+
+    final ReplicationWorker worker = new DefaultReplicationWorker(
+        JOB_ID,
+        JOB_ATTEMPT,
+        source,
+        mapper,
+        destination,
+        messageTracker,
+        recordSchemaValidator,
+        workerMetricReporter);
+
+    worker.run(syncInput, jobRoot);
+
+    verify(source).start(sourceConfig, jobRoot);
+    verify(destination).start(destinationConfig, jobRoot);
+    verify(destination).accept(RECORD_MESSAGE1);
+    verify(destination).accept(RECORD_MESSAGE2);
+    verify(destination, never()).accept(LOG_MESSAGE);
+    verify(destination, never()).accept(TRACE_MESSAGE);
   }
 
   @Test

--- a/airbyte-workers/src/test/java/io/airbyte/workers/general/DefaultReplicationWorkerTest.java
+++ b/airbyte-workers/src/test/java/io/airbyte/workers/general/DefaultReplicationWorkerTest.java
@@ -183,6 +183,7 @@ class DefaultReplicationWorkerTest {
     verify(destination).start(destinationConfig, jobRoot);
     verify(destination).accept(RECORD_MESSAGE1);
     verify(destination).accept(RECORD_MESSAGE2);
+    verify(destination).accept(RECORD_MESSAGE3);
     verify(recordSchemaValidator).validateSchema(RECORD_MESSAGE1.getRecord(), STREAM_NAME);
     verify(recordSchemaValidator).validateSchema(RECORD_MESSAGE2.getRecord(), STREAM_NAME);
     verify(recordSchemaValidator).validateSchema(RECORD_MESSAGE3.getRecord(), STREAM_NAME);
@@ -298,8 +299,11 @@ class DefaultReplicationWorkerTest {
   void testOnlyStateAndRecordMessagesDeliveredToDestination() throws Exception {
     final AirbyteMessage LOG_MESSAGE = AirbyteMessageUtils.createLogMessage(Level.INFO, "a log message");
     final AirbyteMessage TRACE_MESSAGE = AirbyteMessageUtils.createTraceMessage("a trace message", 123456.0);
+    when(mapper.mapMessage(LOG_MESSAGE)).thenReturn(LOG_MESSAGE);
+    when(mapper.mapMessage(TRACE_MESSAGE)).thenReturn(TRACE_MESSAGE);
+    when(source.isFinished()).thenReturn(false, false, false, false, true);
     when(source.attemptRead()).thenReturn(Optional.of(RECORD_MESSAGE1), Optional.of(LOG_MESSAGE), Optional.of(TRACE_MESSAGE),
-        Optional.of(RECORD_MESSAGE2), Optional.empty());
+        Optional.of(RECORD_MESSAGE2));
 
     final ReplicationWorker worker = new DefaultReplicationWorker(
         JOB_ID,


### PR DESCRIPTION
Per the Airbyte Protocol, only STATE and RECORD messages from sources should be sent to destinations.  LOG and TRACE messages should not be forwarded.  Prior to this PR, TRACE and sometimes LOG messages could be sent to destination from the source. 

Closes https://github.com/airbytehq/airbyte/issues/16417