### PR TITLE
Exclude file from spotless styling to fix build

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -118,6 +118,7 @@ def createSpotlessTarget = { pattern ->
         'charts', // Helm charts often have injected template strings that will fail general linting. Helm linting is done separately.
         'resources/seed/*_specs.yaml', // Do not remove - this is necessary to prevent diffs in our github workflows, as the file diff check runs between the Format step and the Build step, the latter of which generates the file.
         'airbyte-integrations/connectors/source-amplitude/unit_tests/api_data/zipped.json', // Zipped file presents as non-UTF-8 making spotless sad
+        'airbyte-webapp/src/test-utils/mock-data/mockDestinationDefinition.json', // Prettier styling is conflicting with spotless styling in this file making the build fail if not excluded
     ]
 
     if (System.getenv().containsKey("SUB_BUILD")) {


### PR DESCRIPTION
## What
[This PR](https://github.com/airbytehq/airbyte/pull/16293) added the following json file to the repo, which is making our auto-formatting software unhappy: https://github.com/airbytehq/airbyte/blob/master/airbyte-webapp/src/test-utils/mock-data/mockDestinationDefinition.json

If someone tries to run `./gradlew format` on master, the following changes are produced:
```
--- a/airbyte-webapp/src/test-utils/mock-data/mockDestinationDefinition.json
+++ b/airbyte-webapp/src/test-utils/mock-data/mockDestinationDefinition.json
@@ -146,7 +146,12 @@
           },
           {
             "title": "verify-full",
-            "required": ["mode", "ca_certificate", "client_certificate", "client_key"],
+            "required": [
+              "mode",
+              "ca_certificate",
+              "client_certificate",
+              "client_key"
+            ],
             "properties": {
               "mode": {
                 "enum": ["verify-full"],
@@ -218,7 +223,13 @@
           },
           {
             "title": "SSH Key Authentication",
-            "required": ["tunnel_method", "tunnel_host", "tunnel_port", "tunnel_user", "ssh_key"],
+            "required": [
+              "tunnel_method",
+              "tunnel_host",
+              "tunnel_port",
+              "tunnel_user",
+              "ssh_key"
+            ],
```

However, if you then try to commit these changes, the `prettier` pre-commit hook undoes those changes, resulting in an empty commit.

## How
This PR is just a short-term fix to get the platform build back into a good state, by excluding that specific file from spotless styling so that `./gradlew format` does not produce any diff for that file.
