### PR TITLE
Source-instagram: fix incompatible metrics error for reels.

### DIFF
--- a/airbyte-config/init/src/main/resources/seed/source_definitions.yaml
+++ b/airbyte-config/init/src/main/resources/seed/source_definitions.yaml
@@ -465,7 +465,7 @@
 - name: Instagram
   sourceDefinitionId: 6acf6b55-4f1e-4fca-944e-1a3caef8aba8
   dockerRepository: airbyte/source-instagram
-  dockerImageTag: 0.1.10
+  dockerImageTag: 0.1.11
   documentationUrl: https://docs.airbyte.com/integrations/sources/instagram
   icon: instagram.svg
   sourceType: api

--- a/airbyte-config/init/src/main/resources/seed/source_specs.yaml
+++ b/airbyte-config/init/src/main/resources/seed/source_specs.yaml
@@ -4525,7 +4525,7 @@
     supportsNormalization: false
     supportsDBT: false
     supported_destination_sync_modes: []
-- dockerImage: "airbyte/source-instagram:0.1.10"
+- dockerImage: "airbyte/source-instagram:0.1.11"
   spec:
     documentationUrl: "https://docs.airbyte.io/integrations/sources/instagram"
     changelogUrl: "https://docs.airbyte.io/integrations/sources/instagram"

--- a/airbyte-integrations/connectors/source-instagram/Dockerfile
+++ b/airbyte-integrations/connectors/source-instagram/Dockerfile
@@ -12,5 +12,5 @@ RUN pip install .
 ENV AIRBYTE_ENTRYPOINT "python /airbyte/integration_code/main.py"
 ENTRYPOINT ["python", "/airbyte/integration_code/main.py"]
 
-LABEL io.airbyte.version=0.1.10
+LABEL io.airbyte.version=0.1.11
 LABEL io.airbyte.name=airbyte/source-instagram

--- a/airbyte-integrations/connectors/source-instagram/source_instagram/schemas/media_insights.json
+++ b/airbyte-integrations/connectors/source-instagram/source_instagram/schemas/media_insights.json
@@ -36,6 +36,21 @@
     },
     "carousel_album_saved": {
       "type": ["null", "integer"]
+    },
+    "comments": {
+      "type": ["null", "integer"]
+    },
+    "likes": {
+      "type": ["null", "integer"]
+    },
+    "shares": {
+      "type": ["null", "integer"]
+    },
+    "total_interactions": {
+      "type": ["null", "integer"]
+    },
+    "plays": {
+      "type": ["null", "integer"]
     }
   }
 }

--- a/airbyte-integrations/connectors/source-instagram/source_instagram/streams.py
+++ b/airbyte-integrations/connectors/source-instagram/source_instagram/streams.py
@@ -320,7 +320,7 @@ class MediaInsights(Media):
 
     MEDIA_METRICS = ["engagement", "impressions", "reach", "saved"]
     CAROUSEL_ALBUM_METRICS = ["carousel_album_engagement", "carousel_album_impressions", "carousel_album_reach", "carousel_album_saved"]
-    REEL_METRICS = ["comments", "likes", "play", "reach", "saved", "shares", "total_interactions"]
+    REELS_METRICS = ["comments", "likes", "reach", "saved", "shares", "total_interactions", "plays"]
 
     def read_records(
         self,
@@ -331,7 +331,7 @@ class MediaInsights(Media):
     ) -> Iterable[Mapping[str, Any]]:
         account = stream_slice["account"]
         ig_account = account["instagram_business_account"]
-        media = ig_account.get_media(params=self.request_params(), fields=["media_type"])
+        media = ig_account.get_media(params=self.request_params(), fields=["media_type", "media_product_type"])
         for ig_media in media:
             account_id = ig_account.get("id")
             insights = self._get_insights(ig_media, account_id)
@@ -345,9 +345,9 @@ class MediaInsights(Media):
 
     def _get_insights(self, item, account_id) -> Optional[MutableMapping[str, Any]]:
         """Get insights for specific media"""
-        if item.get("media_product_type") == "REEL":
-            metrics = self.REEL_METRICS
-        if item.get("media_type") == "VIDEO":
+        if item.get("media_product_type") == "REELS":
+            metrics = self.REELS_METRICS
+        elif item.get("media_type") == "VIDEO":
             metrics = self.MEDIA_METRICS + ["video_views"]
         elif item.get("media_type") == "CAROUSEL_ALBUM":
             metrics = self.CAROUSEL_ALBUM_METRICS

--- a/airbyte-integrations/connectors/source-instagram/source_instagram/streams.py
+++ b/airbyte-integrations/connectors/source-instagram/source_instagram/streams.py
@@ -320,6 +320,7 @@ class MediaInsights(Media):
 
     MEDIA_METRICS = ["engagement", "impressions", "reach", "saved"]
     CAROUSEL_ALBUM_METRICS = ["carousel_album_engagement", "carousel_album_impressions", "carousel_album_reach", "carousel_album_saved"]
+    REEL_METRICS = ["comments", "likes", "play", "reach", "saved", "shares", "total_interactions"]
 
     def read_records(
         self,
@@ -348,6 +349,8 @@ class MediaInsights(Media):
             metrics = self.MEDIA_METRICS + ["video_views"]
         elif item.get("media_type") == "CAROUSEL_ALBUM":
             metrics = self.CAROUSEL_ALBUM_METRICS
+        elif item.get("media_type") == "REEL":
+            metrics = self.REEL_METRICS
         else:
             metrics = self.MEDIA_METRICS
 

--- a/airbyte-integrations/connectors/source-instagram/source_instagram/streams.py
+++ b/airbyte-integrations/connectors/source-instagram/source_instagram/streams.py
@@ -345,12 +345,13 @@ class MediaInsights(Media):
 
     def _get_insights(self, item, account_id) -> Optional[MutableMapping[str, Any]]:
         """Get insights for specific media"""
+        if item.get("media_product_type") == "REEL":
+            metrics = self.REEL_METRICS
         if item.get("media_type") == "VIDEO":
             metrics = self.MEDIA_METRICS + ["video_views"]
         elif item.get("media_type") == "CAROUSEL_ALBUM":
             metrics = self.CAROUSEL_ALBUM_METRICS
-        elif item.get("media_type") == "REEL":
-            metrics = self.REEL_METRICS
+
         else:
             metrics = self.MEDIA_METRICS
 

--- a/docs/integrations/sources/instagram.md
+++ b/docs/integrations/sources/instagram.md
@@ -75,10 +75,10 @@ For more information, see the [Instagram API](https://developers.facebook.com/do
 
 ### Features
 
-| Feature | Supported?\(Yes/No\) | Notes |
-| :--- | :--- | :--- |
-| Full Refresh Sync | Yes |  |
-| Incremental Sync | Yes | only User Insights |
+| Feature           | Supported?\(Yes/No\) | Notes              |
+| :---------------- | :------------------- | :----------------- |
+| Full Refresh Sync | Yes                  |                    |
+| Incremental Sync  | Yes                  | only User Insights |
 
 ### Rate Limiting & Performance Considerations
 
@@ -90,19 +90,20 @@ See Facebook's [documentation on rate limiting](https://developers.facebook.com/
 ## Data type map
 
 | Integration Type | Airbyte Type |
-| :--- | :--- |
-| `string` | `string` |
-| `number` | `number` |
-| `array` | `array` |
-| `object` | `object` |
+| :--------------- | :----------- |
+| `string`         | `string`     |
+| `number`         | `number`     |
+| `array`          | `array`      |
+| `object`         | `object`     |
 
 
 ## Changelog
 
-| Version | Date       | Pull Request                                           | Subject                                                                                                         |
-|:--------|:-----------|:-------------------------------------------------------|:----------------------------------------------------------------------------------------------------------------|
+| Version | Date       | Pull Request                                             | Subject                                                                                                         |
+| :------ | :--------- | :------------------------------------------------------- | :-------------------------------------------------------------------------------------------------------------- |
+| 0.1.11  | 2022-09-08 | [16428](https://github.com/airbytehq/airbyte/pull/16428) | Fix requests metrics for Reels media product type                                                               |
 | 0.1.10  | 2022-09-05 | [16340](https://github.com/airbytehq/airbyte/pull/16340) | Update to latest version of the CDK (v0.1.81)                                                                   |
-| 0.1.9   | 2021-09-30 | [6438](https://github.com/airbytehq/airbyte/pull/6438) | Annotate Oauth2 flow initialization parameters in connector specification                                       |
-| 0.1.8   | 2021-08-11 | [5354](https://github.com/airbytehq/airbyte/pull/5354) | added check for empty state and fixed tests.                                                                    |
-| 0.1.7   | 2021-07-19 | [4805](https://github.com/airbytehq/airbyte/pull/4805) | Add support for previous format of STATE.                                                                       |
-| 0.1.6   | 2021-07-07 | [4210](https://github.com/airbytehq/airbyte/pull/4210) | Refactor connector to use CDK: - improve error handling. - fix sync fail with HTTP status 400. - integrate SAT. |
+| 0.1.9   | 2021-09-30 | [6438](https://github.com/airbytehq/airbyte/pull/6438)   | Annotate Oauth2 flow initialization parameters in connector specification                                       |
+| 0.1.8   | 2021-08-11 | [5354](https://github.com/airbytehq/airbyte/pull/5354)   | added check for empty state and fixed tests.                                                                    |
+| 0.1.7   | 2021-07-19 | [4805](https://github.com/airbytehq/airbyte/pull/4805)   | Add support for previous format of STATE.                                                                       |
+| 0.1.6   | 2021-07-07 | [4210](https://github.com/airbytehq/airbyte/pull/4210)   | Refactor connector to use CDK: - improve error handling. - fix sync fail with HTTP status 400. - integrate SAT. |


### PR DESCRIPTION
## What
Closes https://github.com/airbytehq/airbyte/issues/14524

# How
* `Reels` have a `VIDEO` `media_type` but its `metrics` are different from the video metrics we defined.
* According to the[ API documentation ](https://developers.facebook.com/docs/instagram-api/reference/ig-media/insights), the following metrics are compatible for reels:
`["comments", "likes", "plays", "reach", "saved", "shares", "total_interactions"]`
* To know if an IGMedia is a `REELS` we need to retrieve the `media_product_type` attribute on IGMedia items.
