### PR TITLE
🎉 Source Zendesk Chat: reverted `releaseStage` GA to Beta

### DIFF
--- a/airbyte-config/init/src/main/resources/seed/source_definitions.yaml
+++ b/airbyte-config/init/src/main/resources/seed/source_definitions.yaml
@@ -1104,7 +1104,7 @@
   documentationUrl: https://docs.airbyte.io/integrations/sources/zendesk-chat
   icon: zendesk.svg
   sourceType: api
-  releaseStage: generally_available
+  releaseStage: beta
 - name: Zendesk Sunshine
   sourceDefinitionId: 325e0640-e7b3-4e24-b823-3361008f603f
   dockerRepository: airbyte/source-zendesk-sunshine


### PR DESCRIPTION
## What
Reverting changes from: https://github.com/airbytehq/airbyte/pull/16431