### PR TITLE
DRAFT: Demo Python SAT to detect backwards breaking changes on mysql connector

### DIFF
--- a/airbyte-integrations/connectors/source-mysql/acceptance-test-config.yml
+++ b/airbyte-integrations/connectors/source-mysql/acceptance-test-config.yml
@@ -1,6 +1,8 @@
 # See [Source Acceptance Tests](https://docs.airbyte.io/connector-development/testing-connectors/source-acceptance-tests-reference)
 # for more information about how to configure these tests
-connector_image: airbyte/source-mysql:dev
+connector_image: airbyte/source-mysql:0.6.9
 tests:
   spec:
     - spec_path: "src/main/resources/spec.json"
+      backward_compatibility_tests_config:
+        previous_connector_version: 0.6.8

--- a/airbyte-integrations/connectors/source-mysql/acceptance-test-config.yml
+++ b/airbyte-integrations/connectors/source-mysql/acceptance-test-config.yml
@@ -1,8 +1,6 @@
 # See [Source Acceptance Tests](https://docs.airbyte.io/connector-development/testing-connectors/source-acceptance-tests-reference)
 # for more information about how to configure these tests
-connector_image: airbyte/source-mysql:0.6.9
+connector_image: airbyte/source-mysql:dev
 tests:
   spec:
     - spec_path: "src/main/resources/spec.json"
-      backward_compatibility_tests_config:
-        previous_connector_version: 0.6.8

--- a/airbyte-integrations/connectors/source-mysql/acceptance-test-docker.sh
+++ b/airbyte-integrations/connectors/source-mysql/acceptance-test-docker.sh
@@ -1,7 +1,7 @@
 #!/usr/bin/env sh
 
 # Build latest connector image
-docker build . -t $(cat acceptance-test-config.yml | grep "connector_image" | head -n 1 | cut -d: -f2)
+docker build . -t $(cat acceptance-test-config.yml | grep "connector_image" | head -n 1 | cut -d: -f2):dev
 
 # Pull latest acctest image
 docker pull airbyte/source-acceptance-test:latest

--- a/airbyte-integrations/connectors/source-mysql/acceptance-test-docker.sh
+++ b/airbyte-integrations/connectors/source-mysql/acceptance-test-docker.sh
@@ -1,0 +1,15 @@
+#!/usr/bin/env sh
+
+# Build latest connector image
+#docker build . -t $(cat acceptance-test-config.yml | grep "connector_image" | head -n 1 | cut -d: -f2)
+
+# Pull latest acctest image
+docker pull airbyte/source-acceptance-test:latest
+
+# Run
+docker run --rm -it \
+    -v /var/run/docker.sock:/var/run/docker.sock \
+    -v /tmp:/tmp \
+    -v $(pwd):/test_input \
+    airbyte/source-acceptance-test \
+    --acceptance-test-config /test_input

--- a/airbyte-integrations/connectors/source-mysql/acceptance-test-docker.sh
+++ b/airbyte-integrations/connectors/source-mysql/acceptance-test-docker.sh
@@ -1,7 +1,7 @@
 #!/usr/bin/env sh
 
 # Build latest connector image
-#docker build . -t $(cat acceptance-test-config.yml | grep "connector_image" | head -n 1 | cut -d: -f2)
+docker build . -t $(cat acceptance-test-config.yml | grep "connector_image" | head -n 1 | cut -d: -f2)
 
 # Pull latest acctest image
 docker pull airbyte/source-acceptance-test:latest

--- a/airbyte-integrations/connectors/source-mysql/build.gradle
+++ b/airbyte-integrations/connectors/source-mysql/build.gradle
@@ -3,6 +3,7 @@ plugins {
     id 'airbyte-docker'
     id 'airbyte-integration-test-java'
     id 'airbyte-performance-test-java'
+    id 'airbyte-source-acceptance-test'
 }
 
 application {


### PR DESCRIPTION
## What
Until #5176 is fully resolved, this PR demonstrates a "free" benefit we can get today from the Python acceptance tests in java connectors: this allows us to detect backwards incompatible spec changes. This was inspired by the recent breaking changes going from `0.6.8` --> `0.6.9` in the `source-mysql` connector

This PR shows all the changes needed to run these tests for a java connector. 

When I ran this test locally, it detected the backwards breaking changes in the spec. Had h this been incorporated into the build we would not have run into the issue that we are currently resolving w.r.t backwareds incompatibility.

Output of running the test locally (abridged): 

```
➜  source-mysql git:(sherif/mysql-sat-test) ✗ ./acctest.sh
latest: Pulling from airbyte/source-acceptance-test
Digest: sha256:58baf665484234a569cd0059e4c4d9de19ced79251023639989aaa4b18794185
Status: Image is up to date for airbyte/source-acceptance-test:latest
docker.io/airbyte/source-acceptance-test:latest
Test session starts (platform: linux, Python 3.9.11, pytest 6.2.5, pytest-sugar 0.9.5)
rootdir: /test_input
plugins: requests-mock-1.9.3, timeout-1.4.2, hypothesis-6.54.4, cov-3.0.0, sugar-0.9.5, mock-3.6.1
collecting ...

――――――――――――――――――――――――――――――― ERROR at setup of TestSpec.test_config_match_spec[inputs0] ――――――――――――――――――――――――――――――――

base_path = PosixPath('/test_input'), connector_config_path = PosixPath('/test_input/secrets/config.json')

    @pytest.fixture(name="connector_config")
    def connector_config_fixture(base_path, connector_config_path) -> SecretDict:
>       with open(str(connector_config_path), "r") as file:
E       FileNotFoundError: [Errno 2] No such file or directory: '/test_input/secrets/config.json'                                                                                              8% ▉

――――――――――――――――――――――――――――――――――――――――――――――――――――――――――――――――――――――――――――――――――――――――――――――――――――――――― TestSpec.test_match_expected[inputs0] ―――――――――――――――――――――――――――――――――――――――――――――――――――――――――――――――――――――――――――――――――――――――――――――――――――――――――

 test_core.py ⨯✓                                                                                                                                                                                                                           25% ██▌

―――――――――――――――――――――――――――――――――――――――――――――――――――――――――――――――――――――――――――――――――――――――――――――――――――――――――― TestSpec.test_oneof_usage[inputs0] ―――――――――――――――――――――――――――――――――――――――――――――――――――――――――――――――――――――――――――――――――――――――――――――――――――――――――――

 test_core.py ⨯✓✓✓✓✓✓                                                                                                                                                                                                                      83% ████████▍

――――――――――――――――――――――――――――――――――――――――――――――――――――――――――――――――――――――――――――――――――――――――――――――――――――― TestSpec.test_backward_compatibility[inputs0] ―――――――――――――――――――――――――――――――――――――――――――――――――――――――――――――――――――――――――――――――――――――――――――――――――――――

source_acceptance_test/tests/test_core.py:181:
_ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _
source_acceptance_test/utils/backward_compatibility.py:122: in assert_is_backward_compatible
    self.check_if_value_of_type_field_changed(self.connection_specification_diff)
source_acceptance_test/utils/backward_compatibility.py:60: in check_if_value_of_type_field_changed
    self._raise_error("The'type' field value was changed.", diff)
_ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _

self = <source_acceptance_test.utils.backward_compatibility.SpecDiffChecker object at 0x7f733aef9e80>, message = "The'type' field value was changed."
diff = {'values_changed': [<root['properties']['replication_method']['type'] t1:'string', t2:'object'>, <root['properties']['...>], 'dictionary_item_added': [<root['properties']['replication_method']['oneOf'] t1:not present, t2:[{'title': '...]>]}

    def _raise_error(self, message: str, diff: DeepDiff):
>       raise NonBackwardCompatibleError(f"{message}. Diff: {diff.pretty()}", self.context)
E       source_acceptance_test.utils.backward_compatibility.NonBackwardCompatibleError: BackwardIncompatibilityContext.SPEC - The'type' field value was changed.. Diff: Item root['properties']['replication_method']['oneOf'] added to dictionary.
E       Item root['properties']['replication_method']['default'] removed from dictionary.
E       Item root['properties']['replication_method']['enum'] removed from dictionary.
E       Value of root['properties']['replication_method']['type'] changed from "string" to "object".
E       Value of root['properties']['replication_method']['description'] changed from "Replication method which is used for data extraction from the database. STANDARD replication requires no setup on the DB side but will not be able to represent deletions incrementally. CDC uses the Binlog to detect inserts, updates, and deletes. This needs to be configured on the source database itself." to "Replication method to use for extracting data from the database.".
.....
Results (28.75s):
       8 passed
       3 failed
         - ../airbyte/source_acceptance_test/source_acceptance_test/tests/test_core.py:72 TestSpec.test_match_expected[inputs0]
         - ../airbyte/source_acceptance_test/source_acceptance_test/tests/test_core.py:84 TestSpec.test_oneof_usage[inputs0]
         - ../airbyte/source_acceptance_test/source_acceptance_test/tests/test_core.py:169 TestSpec.test_backward_compatibility[inputs0]
       1 error
```

More info about Source Acceptance Tests can be found [here](https://docs.airbyte.com/connector-development/testing-connectors/source-acceptance-tests-reference#test-spec). 

## How
*Describe the solution*

## Recommended reading order
1. `x.java`
2. `y.python`

## 🚨 User Impact 🚨
Are there any breaking changes? What is the end result perceived by the user? If yes, please merge this PR with the 🚨🚨 emoji so changelog authors can further highlight this if needed.

## Pre-merge Checklist
Expand the relevant checklist and delete the others.

<details><summary><strong>New Connector</strong></summary>

### Community member or Airbyter

- [ ] **Community member?** Grant edit access to maintainers ([instructions](https://docs.github.com/en/github/collaborating-with-pull-requests/working-with-forks/allowing-changes-to-a-pull-request-branch-created-from-a-fork#enabling-repository-maintainer-permissions-on-existing-pull-requests))
- [ ] Secrets in the connector's spec are annotated with `airbyte_secret`
- [ ] Unit & integration tests added and passing. Community members, please provide proof of success locally e.g: screenshot or copy-paste unit, integration, and acceptance test output. To run acceptance tests for a Python connector, follow instructions in the README. For java connectors run `./gradlew :airbyte-integrations:connectors:<name>:integrationTest`.
- [ ] Code reviews completed
- [ ] Documentation updated
    - [ ] Connector's `README.md`
    - [ ] Connector's `bootstrap.md`. See [description and examples](https://docs.google.com/document/d/1ypdgmwmEHWv-TrO4_YOQ7pAJGVrMp5BOkEVh831N260/edit?usp=sharing)
    - [ ] `docs/integrations/<source or destination>/<name>.md` including changelog. See changelog [example](https://docs.airbyte.io/integrations/sources/stripe#changelog)
    - [ ] `docs/integrations/README.md`
    - [ ] `airbyte-integrations/builds.md`
- [ ] PR name follows [PR naming conventions](https://docs.airbyte.io/contributing-to-airbyte/updating-documentation#issues-and-pull-requests)

### Airbyter

If this is a community PR, the Airbyte engineer reviewing this PR is responsible for the below items.

- [ ] Create a non-forked branch based on this PR and test the below items on it
- [ ] Build is successful
- [ ] If new credentials are required for use in CI, add them to GSM. [Instructions](https://docs.airbyte.io/connector-development#using-credentials-in-ci).
- [ ] [`/test connector=connectors/<name>` command](https://docs.airbyte.io/connector-development#updating-an-existing-connector) is passing
- [ ] New Connector version released on Dockerhub by running the `/publish` command described [here](https://docs.airbyte.io/connector-development#updating-an-existing-connector)
- [ ] After the connector is published, connector added to connector index as described [here](https://docs.airbyte.io/connector-development#publishing-a-connector)
- [ ] Seed specs have been re-generated by building the platform and committing the changes to the seed spec files, as described [here](https://docs.airbyte.io/connector-development#publishing-a-connector)

</details>

<details><summary><strong>Updating a connector</strong></summary>

### Community member or Airbyter

- [ ] Grant edit access to maintainers ([instructions](https://docs.github.com/en/github/collaborating-with-pull-requests/working-with-forks/allowing-changes-to-a-pull-request-branch-created-from-a-fork#enabling-repository-maintainer-permissions-on-existing-pull-requests))
- [ ] Secrets in the connector's spec are annotated with `airbyte_secret`
- [ ] Unit & integration tests added and passing. Community members, please provide proof of success locally e.g: screenshot or copy-paste unit, integration, and acceptance test output. To run acceptance tests for a Python connector, follow instructions in the README. For java connectors run `./gradlew :airbyte-integrations:connectors:<name>:integrationTest`.
- [ ] Code reviews completed
- [ ] Documentation updated
    - [ ] Connector's `README.md`
    - [ ] Connector's `bootstrap.md`. See [description and examples](https://docs.google.com/document/d/1ypdgmwmEHWv-TrO4_YOQ7pAJGVrMp5BOkEVh831N260/edit?usp=sharing)
    - [ ] Changelog updated in `docs/integrations/<source or destination>/<name>.md` including changelog. See changelog [example](https://docs.airbyte.io/integrations/sources/stripe#changelog)
- [ ] PR name follows [PR naming conventions](https://docs.airbyte.io/contributing-to-airbyte/updating-documentation#issues-and-pull-requests)

### Airbyter

If this is a community PR, the Airbyte engineer reviewing this PR is responsible for the below items.

- [ ] Create a non-forked branch based on this PR and test the below items on it
- [ ] Build is successful
- [ ] If new credentials are required for use in CI, add them to GSM. [Instructions](https://docs.airbyte.io/connector-development#using-credentials-in-ci).
- [ ] [`/test connector=connectors/<name>` command](https://docs.airbyte.io/connector-development#updating-an-existing-connector) is passing
- [ ] New Connector version released on Dockerhub and connector version bumped by running the `/publish` command described [here](https://docs.airbyte.io/connector-development#updating-an-existing-connector)

</details>

<details><summary><strong>Connector Generator</strong></summary>

- [ ] Issue acceptance criteria met
- [ ] PR name follows [PR naming conventions](https://docs.airbyte.io/contributing-to-airbyte/updating-documentation#issues-and-pull-requests)
- [ ] If adding a new generator, add it to the [list of scaffold modules being tested](https://github.com/airbytehq/airbyte/blob/master/airbyte-integrations/connector-templates/generator/build.gradle#L41)
- [ ] The generator test modules (all connectors with `-scaffold` in their name) have been updated with the latest scaffold by running `./gradlew :airbyte-integrations:connector-templates:generator:testScaffoldTemplates` then checking in your changes
- [ ] Documentation which references the generator is updated as needed

</details>

## Tests

<details><summary><strong>Unit</strong></summary>

*Put your unit tests output here.*

</details>

<details><summary><strong>Integration</strong></summary>

*Put your integration tests output here.*

</details>

<details><summary><strong>Acceptance</strong></summary>

*Put your acceptance tests output here.*

</details>
