### PR TITLE
Fix documentation typo

### DIFF
--- a/docs/integrations/destinations/google-sheets.md
+++ b/docs/integrations/destinations/google-sheets.md
@@ -32,7 +32,7 @@ Visit the [Google Support](https://support.google.com/accounts/answer/27441?hl=e
 2. In the left navigation bar, click **Destinations**. In the top-right corner, click **+ new destination**.
 3. On the source setup page, select **Google Sheets** from the Source type dropdown and enter a name for this connector.
 4. Select `Sign in with Google`.
-5. Log in and Authorize to the Instagram account and click `Set up source`.
+5. Log in and Authorize to the Google account and click `Set up source`.
 
 **For Airbyte Open Source:**
 


### PR DESCRIPTION
## What
Typo reads "Instagram" where it should read "Google"

<img width="1331" alt="CleanShot 2022-09-08 at 10 50 09@2x" src="https://user-images.githubusercontent.com/7691812/189191569-1df9d4a4-c5a4-4841-a036-b2128d464a81.png">


## How
Updated copy to read "Google"