### PR TITLE
Fix intercom

### DIFF
--- a/airbyte-config/init/src/main/resources/seed/source_definitions.yaml
+++ b/airbyte-config/init/src/main/resources/seed/source_definitions.yaml
@@ -473,7 +473,7 @@
 - name: Intercom
   sourceDefinitionId: d8313939-3782-41b0-be29-b3ca20d8dd3a
   dockerRepository: airbyte/source-intercom
-  dockerImageTag: 0.1.25
+  dockerImageTag: 0.1.26
   documentationUrl: https://docs.airbyte.io/integrations/sources/intercom
   icon: intercom.svg
   sourceType: api

--- a/airbyte-config/init/src/main/resources/seed/source_specs.yaml
+++ b/airbyte-config/init/src/main/resources/seed/source_specs.yaml
@@ -4565,7 +4565,7 @@
         oauthFlowInitParameters: []
         oauthFlowOutputParameters:
         - - "access_token"
-- dockerImage: "airbyte/source-intercom:0.1.25"
+- dockerImage: "airbyte/source-intercom:0.1.26"
   spec:
     documentationUrl: "https://docs.airbyte.io/integrations/sources/intercom"
     connectionSpecification:

--- a/airbyte-integrations/connectors/source-intercom/Dockerfile
+++ b/airbyte-integrations/connectors/source-intercom/Dockerfile
@@ -35,5 +35,5 @@ COPY source_intercom ./source_intercom
 ENV AIRBYTE_ENTRYPOINT "python /airbyte/integration_code/main.py"
 ENTRYPOINT ["python", "/airbyte/integration_code/main.py"]
 
-LABEL io.airbyte.version=0.1.25
+LABEL io.airbyte.version=0.1.26
 LABEL io.airbyte.name=airbyte/source-intercom

--- a/airbyte-integrations/connectors/source-intercom/source_intercom/schemas/companies.json
+++ b/airbyte-integrations/connectors/source-intercom/source_intercom/schemas/companies.json
@@ -44,22 +44,18 @@
         "tags": {
           "type": "array",
           "items": {
-            "anyOf": [
-              {
-                "type": "object",
-                "properties": {
-                  "type": {
-                    "type": "string"
-                  },
-                  "name": {
-                    "type": "string"
-                  },
-                  "id": {
-                    "type": "integer"
-                  }
-                }
+            "type": ["null", "object"],
+            "properties": {
+              "type": {
+                "type": "string"
+              },
+              "name": {
+                "type": "string"
+              },
+              "id": {
+                "type": "integer"
               }
-            ]
+            }
           }
         }
       }
@@ -73,19 +69,15 @@
         "segments": {
           "type": "array",
           "items": {
-            "anyOf": [
-              {
-                "type": "object",
-                "properties": {
-                  "type": {
-                    "type": "string"
-                  },
-                  "id": {
-                    "type": "string"
-                  }
-                }
+            "type": ["null", "object"],
+            "properties": {
+              "type": {
+                "type": "string"
+              },
+              "id": {
+                "type": "string"
               }
-            ]
+            }
           }
         }
       }

--- a/airbyte-integrations/connectors/source-intercom/source_intercom/schemas/companies.json
+++ b/airbyte-integrations/connectors/source-intercom/source_intercom/schemas/companies.json
@@ -44,7 +44,6 @@
         "tags": {
           "type": "array",
           "items": {
-            "type": ["null", "object"],
             "anyOf": [
               {
                 "type": "object",
@@ -74,7 +73,6 @@
         "segments": {
           "type": "array",
           "items": {
-            "type": ["null", "object"],
             "anyOf": [
               {
                 "type": "object",

--- a/build.gradle
+++ b/build.gradle
@@ -11,7 +11,7 @@ buildscript {
         }
     }
     dependencies {
-        classpath 'com.bmuschko:gradle-docker-plugin:7.2.0'
+        classpath 'com.bmuschko:gradle-docker-plugin:8.0.0'
         // 6.x version of OpenApi generator is only compatible with jackson-core 2.13.x onwards.
         // This conflicts with the jackson depencneis the bmuschko plugin is pulling in.
         // Since api generation is only used in the airbyte-api module and the base gradle files

--- a/build.gradle
+++ b/build.gradle
@@ -11,7 +11,7 @@ buildscript {
         }
     }
     dependencies {
-        classpath 'com.bmuschko:gradle-docker-plugin:8.0.0'
+        classpath 'com.bmuschko:gradle-docker-plugin:7.2.0'
         // 6.x version of OpenApi generator is only compatible with jackson-core 2.13.x onwards.
         // This conflicts with the jackson depencneis the bmuschko plugin is pulling in.
         // Since api generation is only used in the airbyte-api module and the base gradle files

--- a/docs/integrations/sources/intercom.md
+++ b/docs/integrations/sources/intercom.md
@@ -49,6 +49,7 @@ The Intercom connector should not run into Intercom API limitations under normal
 
 | Version | Date       | Pull Request | Subject |
 |:--------|:-----------| :--- | :--- |
+| 0.1.26  | 2022-08-18 | [16540](https://github.com/airbytehq/airbyte/pull/16540)  | Fix JSON schema    |
 | 0.1.25  | 2022-08-18 | [15681](https://github.com/airbytehq/airbyte/pull/15681)  | Update Intercom API to v 2.5    |
 | 0.1.24  | 2022-07-21 | [14924](https://github.com/airbytehq/airbyte/pull/14924)  | Remove `additionalProperties` field from schemas    |
 | 0.1.23  | 2022-07-19 | [14830](https://github.com/airbytehq/airbyte/pull/14830)  | Added `checkpoint_interval` for Incremental streams |


### PR DESCRIPTION
## What
Fix the intercom schema, related to https://github.com/airbytehq/oncall/issues/463

The check which is performed to see if a property/array is a oneOf/allOf/anyOf is based on the presence of the `type` field.
```
private static boolean isOneOfField(final JsonNode schema) {
    return !MoreIterators.toSet(schema.fieldNames()).contains("type");
  }
```

Because the type were specified if the oneOf is contains in an array, the array was not considered as containing a oneOf and thus was not excluded from the diff comparison which is expected.