### PR TITLE
Move json lint-staged from eslint to prettier

### DIFF
--- a/airbyte-webapp/package.json
+++ b/airbyte-webapp/package.json
@@ -137,10 +137,10 @@
     }
   },
   "lint-staged": {
-    "src/**/*.{js,jsx,ts,tsx,json}": [
+    "src/**/*.{js,jsx,ts,tsx}": [
       "eslint --fix"
     ],
-    "src/**/*.{css,scss,md}": [
+    "src/**/*.{css,scss,md,json}": [
       "prettier --write"
     ],
     "src/**/*.{css,scss}": [


### PR DESCRIPTION
## What
In the lint-staged step, move json files from being checked by eslint to just written by prettier. JSON and eslint are not friends.