### PR TITLE
Update last state message received at when source emits state message

### DIFF
--- a/airbyte-workers/src/main/java/io/airbyte/workers/internal/AirbyteMessageTracker.java
+++ b/airbyte-workers/src/main/java/io/airbyte/workers/internal/AirbyteMessageTracker.java
@@ -151,10 +151,10 @@ public class AirbyteMessageTracker implements MessageTracker {
    */
   private void handleSourceEmittedState(final AirbyteStateMessage stateMessage) {
     final LocalDateTime timeEmittedStateMessage = LocalDateTime.now();
-    stateMetricsTracker.setLastStateMessageReceivedAt(timeEmittedStateMessage);
-    stateMetricsTracker.updateMaxAndMeanSecondsToReceiveStateMessage(timeEmittedStateMessage);
-    sourceOutputState.set(new State().withState(stateMessage.getData()));
     stateMetricsTracker.incrementTotalSourceEmittedStateMessages();
+    stateMetricsTracker.updateMaxAndMeanSecondsToReceiveStateMessage(timeEmittedStateMessage);
+    stateMetricsTracker.setLastStateMessageReceivedAt(timeEmittedStateMessage);
+    sourceOutputState.set(new State().withState(stateMessage.getData()));
     final int stateHash = getStateHashCode(stateMessage);
 
     try {

--- a/airbyte-workers/src/main/java/io/airbyte/workers/internal/AirbyteMessageTracker.java
+++ b/airbyte-workers/src/main/java/io/airbyte/workers/internal/AirbyteMessageTracker.java
@@ -151,6 +151,7 @@ public class AirbyteMessageTracker implements MessageTracker {
    */
   private void handleSourceEmittedState(final AirbyteStateMessage stateMessage) {
     final LocalDateTime timeEmittedStateMessage = LocalDateTime.now();
+    stateMetricsTracker.setLastStateMessageReceivedAt(timeEmittedStateMessage);
     stateMetricsTracker.updateMaxAndMeanSecondsToReceiveStateMessage(timeEmittedStateMessage);
     sourceOutputState.set(new State().withState(stateMessage.getData()));
     stateMetricsTracker.incrementTotalSourceEmittedStateMessages();
@@ -410,7 +411,7 @@ public class AirbyteMessageTracker implements MessageTracker {
     return unreliableStateTimingMetrics;
   }
 
-  private void logMessageAsJSON(final String caller, AirbyteMessage message) {
+  private void logMessageAsJSON(final String caller, final AirbyteMessage message) {
     if (!logConnectorMessages) {
       return;
     }

--- a/airbyte-workers/src/main/java/io/airbyte/workers/internal/StateMetricsTracker.java
+++ b/airbyte-workers/src/main/java/io/airbyte/workers/internal/StateMetricsTracker.java
@@ -27,7 +27,7 @@ public class StateMetricsTracker {
   private final List<byte[]> stateHashesAndTimestamps;
   private final Map<String, List<byte[]>> streamStateHashesAndTimestamps;
   private LocalDateTime firstRecordReceivedAt;
-  private final LocalDateTime lastStateMessageReceivedAt;
+  private LocalDateTime lastStateMessageReceivedAt;
   private Long maxSecondsToReceiveSourceStateMessage;
   private Long meanSecondsToReceiveSourceStateMessage;
   private Long maxSecondsBetweenStateMessageEmittedandCommitted;
@@ -192,6 +192,10 @@ public class StateMetricsTracker {
 
   public void setFirstRecordReceivedAt(final LocalDateTime receivedAt) {
     firstRecordReceivedAt = receivedAt;
+  }
+
+  public void setLastStateMessageReceivedAt(final LocalDateTime receivedAt) {
+    lastStateMessageReceivedAt = receivedAt;
   }
 
   public void incrementTotalSourceEmittedStateMessages() {

--- a/airbyte-workers/src/test/java/io/airbyte/workers/internal/StateMetricsTrackerTest.java
+++ b/airbyte-workers/src/test/java/io/airbyte/workers/internal/StateMetricsTrackerTest.java
@@ -28,7 +28,6 @@ class StateMetricsTrackerTest {
   private static final String SECOND_FIVE = "2022-01-01 12:00:05";
   private static final String SECOND_SIX = "2022-01-01 12:00:06";
 
-
   @BeforeEach
   void setup() {
     this.stateMetricsTracker = new StateMetricsTracker(873813L);

--- a/airbyte-workers/src/test/java/io/airbyte/workers/internal/StateMetricsTrackerTest.java
+++ b/airbyte-workers/src/test/java/io/airbyte/workers/internal/StateMetricsTrackerTest.java
@@ -26,6 +26,8 @@ class StateMetricsTrackerTest {
   private static final String SECOND_ONE = "2022-01-01 12:00:01";
   private static final String SECOND_TWO = "2022-01-01 12:00:02";
   private static final String SECOND_FIVE = "2022-01-01 12:00:05";
+  private static final String SECOND_SIX = "2022-01-01 12:00:06";
+
 
   @BeforeEach
   void setup() {
@@ -135,6 +137,33 @@ class StateMetricsTrackerTest {
     // hashes
     assertThrows(StateMetricsTrackerNoStateMatchException.class,
         () -> stateMetricsTracker.updateStates(s3.getState(), 4, LocalDateTime.parse(SECOND_FIVE, FORMATTER)));
+  }
+
+  @Test
+  void testStreamMaxandMeanSecondsBeforeStateMessageEmitted() {
+    final AirbyteMessage s1 = AirbyteMessageUtils.createGlobalStateMessage(1, STREAM_1);
+    final AirbyteMessage s2 = AirbyteMessageUtils.createGlobalStateMessage(2, STREAM_1);
+    final AirbyteMessage s3 = AirbyteMessageUtils.createGlobalStateMessage(3, STREAM_1);
+
+    // first record received at second 0
+    stateMetricsTracker.setFirstRecordReceivedAt(LocalDateTime.parse(SECOND_ZERO, FORMATTER));
+
+    // receive state at second 2
+    stateMetricsTracker.incrementTotalSourceEmittedStateMessages();
+    stateMetricsTracker.updateMaxAndMeanSecondsToReceiveStateMessage(LocalDateTime.parse(SECOND_TWO, FORMATTER));
+    stateMetricsTracker.setLastStateMessageReceivedAt(LocalDateTime.parse(SECOND_TWO, FORMATTER));
+    // max and mean seconds to receive state message are both 2 seconds
+    assertEquals(2L, stateMetricsTracker.getMaxSecondsToReceiveSourceStateMessage());
+    assertEquals(2L, stateMetricsTracker.getMeanSecondsToReceiveSourceStateMessage());
+
+    // another state message received after 4 more seconds
+    stateMetricsTracker.incrementTotalSourceEmittedStateMessages();
+    stateMetricsTracker.updateMaxAndMeanSecondsToReceiveStateMessage(LocalDateTime.parse(SECOND_SIX, FORMATTER));
+    stateMetricsTracker.setLastStateMessageReceivedAt(LocalDateTime.parse(SECOND_SIX, FORMATTER));
+
+    // max and mean seconds to receive state message are both 2 seconds
+    assertEquals(4L, stateMetricsTracker.getMaxSecondsToReceiveSourceStateMessage());
+    assertEquals(3L, stateMetricsTracker.getMeanSecondsToReceiveSourceStateMessage());
   }
 
 }

--- a/airbyte-workers/src/test/java/io/airbyte/workers/internal/StateMetricsTrackerTest.java
+++ b/airbyte-workers/src/test/java/io/airbyte/workers/internal/StateMetricsTrackerTest.java
@@ -140,10 +140,6 @@ class StateMetricsTrackerTest {
 
   @Test
   void testStreamMaxandMeanSecondsBeforeStateMessageEmitted() {
-    final AirbyteMessage s1 = AirbyteMessageUtils.createGlobalStateMessage(1, STREAM_1);
-    final AirbyteMessage s2 = AirbyteMessageUtils.createGlobalStateMessage(2, STREAM_1);
-    final AirbyteMessage s3 = AirbyteMessageUtils.createGlobalStateMessage(3, STREAM_1);
-
     // first record received at second 0
     stateMetricsTracker.setFirstRecordReceivedAt(LocalDateTime.parse(SECOND_ZERO, FORMATTER));
 


### PR DESCRIPTION
We were seeing connector metrics that didn't make sense. In some cases, `max_seconds_before_source_state_message_emitted + max_seconds_between_state_message_emit_and_commit > attempt_duration`

max_seconds_before_source_state_message_emitted was not being calculated correctly because `lastStateMessageReceivedAt` was not being updated when a new source state message was received. This meant  max_time_before_source_state_message_emitted was always being calculated from the time the first record message was received.