### PR TITLE
fix cdk bug to send legacy format if connector overrides read()

### DIFF
--- a/airbyte-cdk/python/CHANGELOG.md
+++ b/airbyte-cdk/python/CHANGELOG.md
@@ -1,5 +1,8 @@
 # Changelog
 
+## 0.1.83
+- Fix per-stream to send legacy format for connectors that override read
+
 ## 0.1.82
 - Freeze dataclasses-jsonschema to 2.15.1
 

--- a/airbyte-cdk/python/airbyte_cdk/sources/source.py
+++ b/airbyte-cdk/python/airbyte_cdk/sources/source.py
@@ -66,7 +66,11 @@ class Source(
                     parsed_state_messages.append(parsed_message)
                 return parsed_state_messages
             else:
-                # When the legacy JSON object format is received, always outputting an AirbyteStateMessage simplifies processing downstream
+                # Existing connectors that override read() won't be able to interpret the new state format. We temporarily
+                # send state in the old format for these connectors, but once all have been upgraded, this block can be removed
+                # vars(self.__class__) checks if the current class directly overrides the read() function
+                if "read" in vars(self.__class__):
+                    return state_obj
                 return [AirbyteStateMessage(type=AirbyteStateType.LEGACY, data=state_obj)]
         return []
 

--- a/airbyte-cdk/python/airbyte_cdk/sources/source.py
+++ b/airbyte-cdk/python/airbyte_cdk/sources/source.py
@@ -66,7 +66,7 @@ class Source(
                     parsed_state_messages.append(parsed_message)
                 return parsed_state_messages
             else:
-                # Existing connectors that override read() won't be able to interpret the new state format. We temporarily
+                # Existing connectors that override read() might not be able to interpret the new state format. We temporarily
                 # send state in the old format for these connectors, but once all have been upgraded, this block can be removed
                 # vars(self.__class__) checks if the current class directly overrides the read() function
                 if "read" in vars(self.__class__):

--- a/airbyte-cdk/python/setup.py
+++ b/airbyte-cdk/python/setup.py
@@ -15,7 +15,7 @@ README = (HERE / "README.md").read_text()
 
 setup(
     name="airbyte-cdk",
-    version="0.1.82",
+    version="0.1.83",
     description="A framework for writing Airbyte Connectors.",
     long_description=README,
     long_description_content_type="text/markdown",


### PR DESCRIPTION
## What
For connectors like `source-faker` that override the `read()` function, they might not be able to support the new list based format that state arrives in. To guard against this, we should continue to send the old format for these types of connectors.

## How
While reading in state from `source.py` we can determine if the connector directly overrides the `read` function using `vars(self.__class__)`. In that case, we continue to send the flat state object instead of state in the new format

Tested against `source-faker` which implements its own read() which receives the old state format