### PR TITLE
:window: :wrench: Fix and add meta tags

### DIFF
--- a/airbyte-webapp/public/index.html
+++ b/airbyte-webapp/public/index.html
@@ -6,9 +6,10 @@
     <meta name="viewport" content="width=device-width, initial-scale=1" />
     <meta name="theme-color" content="#000000" />
     <meta
-          name="Airbyte | Open-Source Data Integration Pipelines To Your Warehouses"
+          name="description"
           content="Airbyte is the turnkey open-source data integration platform that syncs data from applications, APIs and databases to warehouses."
     />
+    <meta name="airbyte:sec-token" value="c82db11b-64df-413d-aba8-ee66b99c046f" />
     <link rel="apple-touch-icon" href="%PUBLIC_URL%/logo192.png" />
     <link rel="manifest" href="%PUBLIC_URL%/manifest.json" />
     <link rel="stylesheet" href="%PUBLIC_URL%/index.css">


### PR DESCRIPTION
## What

This fixes and adds a meta tag to our index.html:

* Fix the meta tag, that I assume was meant to be a description tag, but simply had a custom `name` attribute not doing anything therefore.
* Add a custom `airbyte:sec-token` meta tag. I'm planning to use this for scanning for open instances. I'm currently use the presence of `window.AIRBYTE_VERSION` for that, but with the refactoring of the config provider this will likely be gone completely, so I wanted to introduce a dedicated meta header, that I can filter for. **What's the token?** It's just a random UUIDv4, to have a value, that we could change in the future if it's required for any (yet unknown) purpose. I decided not to use the version in here (which I originally planned), since that has in the past often be flagged by security audits as "giving too much information" (especially on our Cloud), thus just a random UUID.

