### PR TITLE
Fix missing schedule dual write and consume the new format for tracking metadata

### DIFF
--- a/airbyte-server/src/main/java/io/airbyte/server/converters/ApiPojoConverters.java
+++ b/airbyte-server/src/main/java/io/airbyte/server/converters/ApiPojoConverters.java
@@ -180,6 +180,10 @@ public class ApiPojoConverters {
     return Enums.convertTo(apiTimeUnit, BasicSchedule.TimeUnit.class);
   }
 
+  public static Schedule.TimeUnit toLegacyScheduleTimeUnit(final ConnectionScheduleDataBasicSchedule.TimeUnitEnum timeUnit) {
+    return Enums.convertTo(timeUnit, Schedule.TimeUnit.class);
+  }
+
   public static ConnectionScheduleDataBasicSchedule.TimeUnitEnum toApiBasicScheduleTimeUnit(final BasicSchedule.TimeUnit timeUnit) {
     return Enums.convertTo(timeUnit, ConnectionScheduleDataBasicSchedule.TimeUnitEnum.class);
   }

--- a/airbyte-server/src/main/java/io/airbyte/server/handlers/helpers/ConnectionScheduleHelper.java
+++ b/airbyte-server/src/main/java/io/airbyte/server/handlers/helpers/ConnectionScheduleHelper.java
@@ -8,6 +8,7 @@ import io.airbyte.api.model.generated.ConnectionScheduleData;
 import io.airbyte.api.model.generated.ConnectionScheduleType;
 import io.airbyte.config.BasicSchedule;
 import io.airbyte.config.Cron;
+import io.airbyte.config.Schedule;
 import io.airbyte.config.ScheduleData;
 import io.airbyte.config.StandardSync;
 import io.airbyte.config.StandardSync.ScheduleType;
@@ -44,6 +45,14 @@ public class ConnectionScheduleHelper {
                 new BasicSchedule().withTimeUnit(ApiPojoConverters.toBasicScheduleTimeUnit(scheduleData.getBasicSchedule().getTimeUnit()))
                     .withUnits(scheduleData.getBasicSchedule().getUnits())))
             .withManual(false);
+        // Populate the legacy format for now as well, since some places still expect it to exist.
+        // TODO(https://github.com/airbytehq/airbyte/issues/11432): remove.
+        final Schedule schedule = new Schedule()
+            .withTimeUnit(ApiPojoConverters.toLegacyScheduleTimeUnit(scheduleData.getBasicSchedule().getTimeUnit()))
+            .withUnits(scheduleData.getBasicSchedule().getUnits());
+        standardSync
+            .withManual(false)
+            .withSchedule(schedule);
       }
       case CRON -> {
         if (scheduleData.getCron() == null) {

--- a/airbyte-server/src/test/java/io/airbyte/server/handlers/ConnectionSchedulerHelperTest.java
+++ b/airbyte-server/src/test/java/io/airbyte/server/handlers/ConnectionSchedulerHelperTest.java
@@ -16,6 +16,7 @@ import io.airbyte.api.model.generated.ConnectionScheduleDataBasicSchedule.TimeUn
 import io.airbyte.api.model.generated.ConnectionScheduleDataCron;
 import io.airbyte.api.model.generated.ConnectionScheduleType;
 import io.airbyte.config.BasicSchedule.TimeUnit;
+import io.airbyte.config.Schedule;
 import io.airbyte.config.StandardSync;
 import io.airbyte.config.StandardSync.ScheduleType;
 import io.airbyte.server.handlers.helpers.ConnectionScheduleHelper;
@@ -50,7 +51,9 @@ class ConnectionSchedulerHelperTest {
     assertEquals(ScheduleType.BASIC_SCHEDULE, actual.getScheduleType());
     assertEquals(TimeUnit.HOURS, actual.getScheduleData().getBasicSchedule().getTimeUnit());
     assertEquals(1L, actual.getScheduleData().getBasicSchedule().getUnits());
-    assertNull(actual.getSchedule());
+    // We expect the old format to be dual-written.
+    assertEquals(Schedule.TimeUnit.HOURS, actual.getSchedule().getTimeUnit());
+    assertEquals(1L, actual.getSchedule().getUnits());
   }
 
   @Test


### PR DESCRIPTION
## What
Fixes a null pointer exception when the old schedule format is expected.

## How
This change performs the dual write (in case there are others places that still expect the old format), and also consumes the new format if it's available.
