### PR TITLE
Fix missing modal fade in animation

### DIFF
--- a/airbyte-webapp/.stylelintrc
+++ b/airbyte-webapp/.stylelintrc
@@ -9,6 +9,7 @@
     "selector-class-pattern": "^[a-z][a-zA-Z0-9]+$",
     "color-function-notation": null,
     "font-family-name-quotes": null,
+    "no-unknown-animations": true,
     "scss/dollar-variable-empty-line-before": null,
     "scss/dollar-variable-pattern": null,
     "scss/percent-placeholder-pattern": null,

--- a/airbyte-webapp/src/components/Modal/Modal.module.scss
+++ b/airbyte-webapp/src/components/Modal/Modal.module.scss
@@ -2,7 +2,7 @@
 @use "../../scss/variables";
 @use "../../scss/z-indices";
 
-@keyframes fade-in {
+@keyframes fade-in-container {
   from {
     opacity: 0;
   }
@@ -28,7 +28,7 @@
   left: 0;
   right: 0;
   bottom: 0;
-  animation: fadeIn 0.2s ease-out;
+  animation: fade-in-container 0.2s ease-out;
   display: flex;
   justify-content: center;
   align-items: center;


### PR DESCRIPTION
## What
Restores the modal fade in animation that was lost recently.

Caused by #15859

## How
When stylelint was introduced, it renamed the animation's name from camelCase to snake-case, but it did not update the usage. This fixes the issue and introduces a new rule to stylelint to ensure that animation names are always defined.
