### PR TITLE
Source S3: choose between data types when merging master schema

### DIFF
--- a/airbyte-integrations/connectors/source-s3/Dockerfile
+++ b/airbyte-integrations/connectors/source-s3/Dockerfile
@@ -17,5 +17,5 @@ COPY source_s3 ./source_s3
 ENV AIRBYTE_ENTRYPOINT "python /airbyte/integration_code/main.py"
 ENTRYPOINT ["python", "/airbyte/integration_code/main.py"]
 
-LABEL io.airbyte.version=0.1.18
+LABEL io.airbyte.version=0.1.19
 LABEL io.airbyte.name=airbyte/source-s3

--- a/airbyte-integrations/connectors/source-s3/unit_tests/test_stream.py
+++ b/airbyte-integrations/connectors/source-s3/unit_tests/test_stream.py
@@ -593,6 +593,30 @@ class TestIncrementalFileStream:
                 False,
                 False,
             ),
+            (  # int becomes str in case of type mismatch in different files
+                "{}",
+                datetime(2020, 5, 5, 13, 5, 5),
+                [
+                    FileInfo(last_modified=datetime(2022, 1, 1, 13, 5, 5), key="first", size=128),
+                    FileInfo(last_modified=datetime(2022, 6, 7, 8, 9, 10), key="second", size=128),
+                ],
+                [
+                    {"pk": "string", "full_name": "string", "street_address": "string", "customer_code": "integer", "email": "string",
+                     "dob": "string"},
+                    {"pk": "integer", "full_name": "string", "street_address": "string", "customer_code": "integer", "email": "string",
+                     "dob": "string"}
+                ],
+                {
+                    "pk": "string",
+                    "full_name": "string",
+                    "street_address": "string",
+                    "customer_code": "integer",
+                    "email": "string",
+                    "dob": "string"
+                },
+                True,
+                False,
+            ),
         ),
     )
     @patch("source_s3.stream.IncrementalFileStreamS3.storagefile_class", MagicMock())

--- a/docs/integrations/sources/s3.md
+++ b/docs/integrations/sources/s3.md
@@ -205,7 +205,8 @@ The Jsonl parser uses pyarrow hence,only the line-delimited JSON format is suppo
 
 | Version | Date       | Pull Request                                                                                                    | Subject                                                                                 |
 |:--------|:-----------|:----------------------------------------------------------------------------------------------------------------|:----------------------------------------------------------------------------------------|
-| 0.1.18  | 2022-08-01 | [14213](https://github.com/airbytehq/airbyte/pull/14213)                                                        | Add support for jsonl format files.                                                        |
+| 0.1.19  | 2022-09-13 | [00000](https://github.com/airbytehq/airbyte/pull/00000)                                                        | Adjust column type to a broadest one when merging two or more json schemas              |
+| 0.1.18  | 2022-08-01 | [14213](https://github.com/airbytehq/airbyte/pull/14213)                                                        | Add support for jsonl format files.                                                     |
 | 0.1.17  | 2022-07-21 | [14911](https://github.com/airbytehq/airbyte/pull/14911)                                                        | "decimal" type added for parquet                                                        |
 | 0.1.16  | 2022-07-13 | [14669](https://github.com/airbytehq/airbyte/pull/14669)                                                        | Fixed bug when extra columns apeared to be non-present in master schema                 |
 | 0.1.15  | 2022-05-31 | [12568](https://github.com/airbytehq/airbyte/pull/12568)                                                        | Fixed possible case of files being missed during incremental syncs                      |

--- a/docs/integrations/sources/s3.md
+++ b/docs/integrations/sources/s3.md
@@ -205,7 +205,7 @@ The Jsonl parser uses pyarrow hence,only the line-delimited JSON format is suppo
 
 | Version | Date       | Pull Request                                                                                                    | Subject                                                                                 |
 |:--------|:-----------|:----------------------------------------------------------------------------------------------------------------|:----------------------------------------------------------------------------------------|
-| 0.1.19  | 2022-09-13 | [00000](https://github.com/airbytehq/airbyte/pull/00000)                                                        | Adjust column type to a broadest one when merging two or more json schemas              |
+| 0.1.19  | 2022-09-13 | [16631](https://github.com/airbytehq/airbyte/pull/16631)                                                        | Adjust column type to a broadest one when merging two or more json schemas              |
 | 0.1.18  | 2022-08-01 | [14213](https://github.com/airbytehq/airbyte/pull/14213)                                                        | Add support for jsonl format files.                                                     |
 | 0.1.17  | 2022-07-21 | [14911](https://github.com/airbytehq/airbyte/pull/14911)                                                        | "decimal" type added for parquet                                                        |
 | 0.1.16  | 2022-07-13 | [14669](https://github.com/airbytehq/airbyte/pull/14669)                                                        | Fixed bug when extra columns apeared to be non-present in master schema                 |


### PR DESCRIPTION
## What
When master schema is constructed of two or more json schemas, it is possible there is a type mismatch. In this case we log a warning and the type remains what it was in a user provided configuration. If user did not fill in the schema, an error is raised.

## How
If possible - try to choose the broadest of two datatypes. Otherwise, do what we used to do - raise an error
