### PR TITLE
Ignore .stories.tsx for coverage reports

### DIFF
--- a/airbyte-webapp/package.json
+++ b/airbyte-webapp/package.json
@@ -159,6 +159,9 @@
     ]
   },
   "jest": {
-    "transformIgnorePatterns": []
+    "transformIgnorePatterns": [],
+    "coveragePathIgnorePatterns": [
+      ".stories.tsx"
+    ]
   }
 }


### PR DESCRIPTION
## What
Jest coverage was reporting for .stories.tsx files.

## How
.stories.tsx was added to jest coverage ignore.
