### PR TITLE
🪟 🔧 Increase color palette consistency:  prohibit to use hex value for colors

### DIFF
--- a/airbyte-webapp/.stylelintrc
+++ b/airbyte-webapp/.stylelintrc
@@ -15,5 +15,5 @@
     "value-keyword-case": null,
     "color-no-hex": true
   },
-  "ignoreFiles": ["**/build/**", "**/dist/**", "**/**/_colors.scss", "**/**/index.css"]
+  "ignoreFiles": ["**/build/**", "**/dist/**"]
 }

--- a/airbyte-webapp/.stylelintrc
+++ b/airbyte-webapp/.stylelintrc
@@ -12,7 +12,8 @@
     "scss/dollar-variable-empty-line-before": null,
     "scss/dollar-variable-pattern": null,
     "scss/percent-placeholder-pattern": null,
-    "value-keyword-case": null
+    "value-keyword-case": null,
+    "color-no-hex": true
   },
-  "ignoreFiles": ["**/build/**", "**/dist/**"]
+  "ignoreFiles": ["**/build/**", "**/dist/**", "**/**/_colors.scss", "**/**/index.css"]
 }

--- a/airbyte-webapp/public/index.css
+++ b/airbyte-webapp/public/index.css
@@ -1,3 +1,4 @@
+/* stylelint-disable color-no-hex */
 body, html {
     margin: 0;
     height: 100%;

--- a/airbyte-webapp/src/components/base/Card/Card.module.scss
+++ b/airbyte-webapp/src/components/base/Card/Card.module.scss
@@ -18,7 +18,7 @@
 .title {
   padding: 25px 25px 22px;
   color: colors.$dark-blue;
-  border-bottom: #e8e8ed 1px solid;
+  border-bottom: colors.$grey-100 1px solid;
   font-weight: 600;
   letter-spacing: 0.008em;
   border-top-left-radius: 10px;

--- a/airbyte-webapp/src/components/base/Card/Card.module.scss
+++ b/airbyte-webapp/src/components/base/Card/Card.module.scss
@@ -1,4 +1,5 @@
 @use "../../../scss/colors";
+@use "../../../scss/variables" as vars;
 
 .container {
   width: auto;
@@ -18,7 +19,7 @@
 .title {
   padding: 25px 25px 22px;
   color: colors.$dark-blue;
-  border-bottom: colors.$grey-100 1px solid;
+  border-bottom: colors.$grey-100 vars.$border-thin solid;
   font-weight: 600;
   letter-spacing: 0.008em;
   border-top-left-radius: 10px;

--- a/airbyte-webapp/src/packages/cloud/views/auth/OAuthLogin/OAuthLogin.module.scss
+++ b/airbyte-webapp/src/packages/cloud/views/auth/OAuthLogin/OAuthLogin.module.scss
@@ -43,7 +43,8 @@
 }
 
 .github {
-  background: colors.$githubColor;
+  // stylelint-disable-next-line color-no-hex
+  background: #333;
   color: colors.$white;
   border: none;
 }

--- a/airbyte-webapp/src/packages/cloud/views/auth/OAuthLogin/OAuthLogin.module.scss
+++ b/airbyte-webapp/src/packages/cloud/views/auth/OAuthLogin/OAuthLogin.module.scss
@@ -43,7 +43,7 @@
 }
 
 .github {
-  // stylelint-disable-next-line color-no-hex
+  /* stylelint-disable-next-line color-no-hex */
   background: #333;
   color: colors.$white;
   border: none;

--- a/airbyte-webapp/src/packages/cloud/views/auth/OAuthLogin/OAuthLogin.module.scss
+++ b/airbyte-webapp/src/packages/cloud/views/auth/OAuthLogin/OAuthLogin.module.scss
@@ -43,7 +43,7 @@
 }
 
 .github {
-  background: #333;
+  background: colors.$githubColor;
   color: colors.$white;
   border: none;
 }

--- a/airbyte-webapp/src/scss/_colors.scss
+++ b/airbyte-webapp/src/scss/_colors.scss
@@ -91,6 +91,9 @@ $yellow-800: #f79000;
 $yellow-900: #f77100;
 $yellow: $yellow-500;
 
+// non-standard - for specific cases (e.g 3rd party service button color)
+$githubColor: #333;
+
 // LEGACY - DEPRECATED
 
 $primaryColor12: rgba(103, 87, 255, 12%);

--- a/airbyte-webapp/src/scss/_colors.scss
+++ b/airbyte-webapp/src/scss/_colors.scss
@@ -1,3 +1,4 @@
+/* stylelint-disable color-no-hex */
 $blue-50: #eae9ff;
 $blue-100: #cbc8ff;
 $blue-200: #a6a4ff;
@@ -90,9 +91,6 @@ $yellow-700: #f7a000;
 $yellow-800: #f79000;
 $yellow-900: #f77100;
 $yellow: $yellow-500;
-
-// non-standard - for specific cases (e.g 3rd party service button color)
-$githubColor: #333;
 
 // LEGACY - DEPRECATED
 


### PR DESCRIPTION
## What
Increase color palette consistency: since we have agreed on a color palette we need to prohibit to use of hex color values.

## How
Update stylelint config: add `"color-no-hex"` rule
Unfortunately, we can't provide some custom text messages like:
"_Please, use colors from \_colors.scss_"

<img width="552" alt="Screenshot at Sep 13 22-04-29" src="https://user-images.githubusercontent.com/20929344/189995348-5cbcdaad-53bb-4ea0-92d0-83f431fe0408.png">


## Recommended reading order
All
