### PR TITLE
🪟 🐛 Fix master build using updated card prop

### DIFF
--- a/airbyte-webapp/src/packages/cloud/views/users/AccountSettingsView/AccountSettingsView.tsx
+++ b/airbyte-webapp/src/packages/cloud/views/users/AccountSettingsView/AccountSettingsView.tsx
@@ -27,7 +27,7 @@ const AccountSettingsView: React.FC = () => {
       <EmailSection />
       {authService.hasPasswordLogin() && <PasswordSection />}
       <SettingsCard
-        light={false}
+        lightPadding={false}
         title={
           <Header>
             <FormattedMessage id="settings.accountSettings.logoutLabel" />


### PR DESCRIPTION
## What

fixes master build of `airbyte-webapp` by using new prop name

No visual regression:
![Screen Shot 2022-09-13 at 4 11 09 PM](https://user-images.githubusercontent.com/63751206/189999751-07844ee1-955a-4d8d-830c-25542bb5d875.png)

