### PR TITLE
🪟 🎨 Fix width of create connection view on onboarding page

### DIFF
--- a/airbyte-webapp/src/components/CreateConnectionContent/CreateConnectionContent.module.scss
+++ b/airbyte-webapp/src/components/CreateConnectionContent/CreateConnectionContent.module.scss
@@ -2,3 +2,8 @@
   margin: 0 10px -1px 0;
   font-size: 14px;
 }
+
+.connectionFormContainer {
+  width: 100%;
+  padding: 0 20px;
+}

--- a/airbyte-webapp/src/components/CreateConnectionContent/CreateConnectionContent.tsx
+++ b/airbyte-webapp/src/components/CreateConnectionContent/CreateConnectionContent.tsx
@@ -101,18 +101,20 @@ const CreateConnectionContent: React.FC<CreateConnectionContentProps> = ({
     <LoadingSchema />
   ) : (
     <Suspense fallback={<LoadingSchema />}>
-      <ConnectionForm
-        mode="create"
-        connection={connection}
-        onDropDownSelect={onSelectFrequency}
-        onSubmit={onSubmitConnectionStep}
-        additionalSchemaControl={
-          <Button onClick={onDiscoverSchema} type="button">
-            <FontAwesomeIcon className={styles.tryArrowIcon} icon={faRedoAlt} />
-            <FormattedMessage id="connection.refreshSchema" />
-          </Button>
-        }
-      />
+      <div className={styles.connectionFormContainer}>
+        <ConnectionForm
+          mode="create"
+          connection={connection}
+          onDropDownSelect={onSelectFrequency}
+          onSubmit={onSubmitConnectionStep}
+          additionalSchemaControl={
+            <Button onClick={onDiscoverSchema} type="button">
+              <FontAwesomeIcon className={styles.tryArrowIcon} icon={faRedoAlt} />
+              <FormattedMessage id="connection.refreshSchema" />
+            </Button>
+          }
+        />
+      </div>
     </Suspense>
   );
 };

--- a/airbyte-webapp/src/pages/OnboardingPage/OnboardingPage.tsx
+++ b/airbyte-webapp/src/pages/OnboardingPage/OnboardingPage.tsx
@@ -29,7 +29,7 @@ import useGetStepsConfig from "./useStepsConfig";
 
 const Content = styled.div<{ big?: boolean; medium?: boolean }>`
   width: 100%;
-  max-width: ${({ big, medium }) => (big ? 1140 : medium ? 730 : 550)}px;
+  max-width: ${({ big, medium }) => (big ? 1279 : medium ? 730 : 550)}px;
   margin: 0 auto;
   padding: 75px 0 30px;
   display: flex;


### PR DESCRIPTION
## What
When testing other changes on the Onboarding flow, I noticed that the width of the "create connection" content was very narrow when doing it through the Onboarding flow, even if there was enough space for it to be larger.
This caused some text inside the content to be wrapped unnecessarily (e.g. the headers of the stream editing section), which is not great since this may be a common "first impression" of airbyte on new users:

<img width="1000" alt="Screen Shot 2022-09-13 at 4 36 02 PM" src="https://user-images.githubusercontent.com/22731524/190032313-a3b0736a-37de-4a3b-85e3-f84c17d97734.png">

## How
This small PR fixes the issue by making the create connection form on the onboarding page take up the full width it can, and modifying its parent's max-width to match the [max-width used in the ReplicationView](https://github.com/airbytehq/airbyte/blob/8b67f03d194eb7587a2f498441ba168240433b11/airbyte-webapp/src/pages/ConnectionPage/pages/ConnectionItemPage/components/ReplicationView.tsx#L74).

This is what the create connection step in the onboarding flow looks like with these changes:
<img width="1000" alt="Screen Shot 2022-09-13 at 5 31 28 PM" src="https://user-images.githubusercontent.com/22731524/190032738-371c033f-1afb-4c22-a6e9-cabf32e1259c.png">

## 🚨 User Impact 🚨
Better looking form when creating a connection through the onboarding flow