### PR TITLE
feat: replace openjdk with eclipse-temurin based on ubuntu 22.04 for …

### DIFF
--- a/airbyte-bootloader/Dockerfile
+++ b/airbyte-bootloader/Dockerfile
@@ -1,5 +1,5 @@
-ARG JDK_VERSION=19-slim-bullseye
-ARG JDK_IMAGE=openjdk:${JDK_VERSION}
+ARG JDK_VERSION=17
+ARG JDK_IMAGE=eclipse-temurin:${JDK_VERSION}-jdk-jammy
 FROM ${JDK_IMAGE}
 
 ARG VERSION=0.40.5

--- a/airbyte-container-orchestrator/Dockerfile
+++ b/airbyte-container-orchestrator/Dockerfile
@@ -1,12 +1,12 @@
-ARG JDK_VERSION=19-slim-bullseye
-ARG JDK_IMAGE=openjdk:${JDK_VERSION}
+ARG JDK_VERSION=17
+ARG JDK_IMAGE=eclipse-temurin:${JDK_VERSION}-jdk-jammy
 FROM ${JDK_IMAGE} AS orchestrator
 
 ARG DOCKER_BUILD_ARCH=amd64
 
 # Install Docker to launch worker images. Eventually should be replaced with Docker-java.
 # See https://gitter.im/docker-java/docker-java?at=5f3eb87ba8c1780176603f4e for more information on why we are not currently using Docker-java
-# See https://docs.docker.com/engine/install/debian/ to understand what the following commands are
+# See https://docs.docker.com/engine/install/ubuntu/ to understand what the following commands are
 # doing.
 RUN apt-get update && apt-get install -y \
                           ca-certificates \
@@ -14,9 +14,9 @@ RUN apt-get update && apt-get install -y \
                           gnupg \
                           lsb-release
 RUN mkdir -p /etc/apt/keyrings && \
-        wget -O - https://download.docker.com/linux/debian/gpg | gpg --dearmor -o /etc/apt/keyrings/docker.gpg && \
+        wget -O - https://download.docker.com/linux/ubuntu/gpg | gpg --dearmor -o /etc/apt/keyrings/docker.gpg && \
         echo \
-          "deb [arch=$(dpkg --print-architecture) signed-by=/etc/apt/keyrings/docker.gpg] https://download.docker.com/linux/debian \
+          "deb [arch=$(dpkg --print-architecture) signed-by=/etc/apt/keyrings/docker.gpg] https://download.docker.com/linux/ubuntu \
           $(lsb_release -cs) stable" | tee /etc/apt/sources.list.d/docker.list > /dev/null
 RUN apt-get update && apt-get install -y docker-ce-cli jq
 

--- a/airbyte-cron/Dockerfile
+++ b/airbyte-cron/Dockerfile
@@ -1,5 +1,5 @@
-ARG JDK_VERSION=19-slim-bullseye
-ARG JDK_IMAGE=openjdk:${JDK_VERSION}
+ARG JDK_VERSION=17
+ARG JDK_IMAGE=eclipse-temurin:${JDK_VERSION}-jdk-jammy
 FROM ${JDK_IMAGE} AS cron
 
 ARG VERSION=0.40.5

--- a/airbyte-integrations/bases/base-java/Dockerfile
+++ b/airbyte-integrations/bases/base-java/Dockerfile
@@ -1,5 +1,5 @@
-ARG JDK_VERSION=17.0.1
-FROM openjdk:${JDK_VERSION}-slim
+ARG JDK_VERSION=17
+ARG JDK_IMAGE=eclipse-temurin:${JDK_VERSION}-jdk-jammy
 COPY --from=airbyte/integration-base:dev /airbyte /airbyte
 
 WORKDIR /airbyte

--- a/airbyte-integrations/bases/base-standard-source-test-file/Dockerfile
+++ b/airbyte-integrations/bases/base-standard-source-test-file/Dockerfile
@@ -1,5 +1,6 @@
-ARG JDK_VERSION=17.0.1
-FROM openjdk:${JDK_VERSION}-slim
+ARG JDK_VERSION=17
+ARG JDK_IMAGE=eclipse-temurin:${JDK_VERSION}-jdk-jammy
+FROM ${JDK_IMAGE}
 
 ARG DOCKER_BUILD_ARCH=amd64
 
@@ -11,9 +12,9 @@ RUN apt-get update && apt-get install -y \
                           curl \
                           gnupg-agent \
                           software-properties-common
-RUN curl -fsSL https://download.docker.com/linux/debian/gpg | apt-key add -
+RUN curl -fsSL https://download.docker.com/linux/ubuntu/gpg | apt-key add -
 RUN add-apt-repository \
-       "deb [arch=${DOCKER_BUILD_ARCH}] https://download.docker.com/linux/debian \
+       "deb [arch=${DOCKER_BUILD_ARCH}] https://download.docker.com/linux/ubuntu \
        $(lsb_release -cs) \
        stable"
 RUN apt-get update && apt-get install -y docker-ce-cli jq

--- a/airbyte-integrations/bases/base/Dockerfile
+++ b/airbyte-integrations/bases/base/Dockerfile
@@ -1,4 +1,4 @@
-FROM debian:10.5-slim
+FROM ubuntu:22.04
 
 WORKDIR /airbyte
 

--- a/airbyte-integrations/bases/standard-source-test/Dockerfile
+++ b/airbyte-integrations/bases/standard-source-test/Dockerfile
@@ -1,5 +1,6 @@
-ARG JDK_VERSION=17.0.1
-FROM openjdk:${JDK_VERSION}-slim
+ARG JDK_VERSION=17
+ARG JDK_IMAGE=eclipse-temurin:${JDK_VERSION}-jdk-jammy
+FROM ${JDK_IMAGE}
 
 ARG DOCKER_BUILD_ARCH=amd64
 
@@ -11,9 +12,9 @@ RUN apt-get update && apt-get install -y \
                           curl \
                           gnupg-agent \
                           software-properties-common
-RUN curl -fsSL https://download.docker.com/linux/debian/gpg | apt-key add -
+RUN curl -fsSL https://download.docker.com/linux/ubuntu/gpg | apt-key add -
 RUN add-apt-repository \
-       "deb [arch=${DOCKER_BUILD_ARCH}] https://download.docker.com/linux/debian \
+       "deb [arch=${DOCKER_BUILD_ARCH}] https://download.docker.com/linux/ubuntu \
        $(lsb_release -cs) \
        stable"
 RUN apt-get update && apt-get install -y docker-ce-cli jq

--- a/airbyte-metrics/reporter/Dockerfile
+++ b/airbyte-metrics/reporter/Dockerfile
@@ -1,5 +1,5 @@
-ARG JDK_VERSION=19-slim-bullseye
-ARG JDK_IMAGE=openjdk:${JDK_VERSION}
+ARG JDK_VERSION=17
+ARG JDK_IMAGE=eclipse-temurin:${JDK_VERSION}-jdk-jammy
 FROM ${JDK_IMAGE} AS metrics-reporter
 
 ARG VERSION=0.40.5

--- a/airbyte-server/Dockerfile
+++ b/airbyte-server/Dockerfile
@@ -1,5 +1,5 @@
-ARG JDK_VERSION=19-slim-bullseye
-ARG JDK_IMAGE=openjdk:${JDK_VERSION}
+ARG JDK_VERSION=17
+ARG JDK_IMAGE=eclipse-temurin:${JDK_VERSION}-jdk-jammy
 FROM ${JDK_IMAGE} AS server
 
 EXPOSE 8000

--- a/airbyte-workers/Dockerfile
+++ b/airbyte-workers/Dockerfile
@@ -1,12 +1,12 @@
-ARG JDK_VERSION=19-slim-bullseye
-ARG JDK_IMAGE=openjdk:${JDK_VERSION}
+ARG JDK_VERSION=17
+ARG JDK_IMAGE=eclipse-temurin:${JDK_VERSION}-jdk-jammy
 FROM ${JDK_IMAGE} AS worker
 
 ARG DOCKER_BUILD_ARCH=amd64
 
 # Install Docker to launch worker images. Eventually should be replaced with Docker-java.
 # See https://gitter.im/docker-java/docker-java?at=5f3eb87ba8c1780176603f4e for more information on why we are not currently using Docker-java
-# See https://docs.docker.com/engine/install/debian/ to understand what the following commands are
+# See https://docs.docker.com/engine/install/ubuntu/ to understand what the following commands are
 # doing.
 RUN apt-get update && apt-get install -y \
                           ca-certificates \
@@ -14,9 +14,9 @@ RUN apt-get update && apt-get install -y \
                           gnupg \
                           lsb-release
 RUN mkdir -p /etc/apt/keyrings && \
-        wget -O - https://download.docker.com/linux/debian/gpg | gpg --dearmor -o /etc/apt/keyrings/docker.gpg && \
+        wget -O - https://download.docker.com/linux/ubuntu/gpg | gpg --dearmor -o /etc/apt/keyrings/docker.gpg && \
         echo \
-          "deb [arch=$(dpkg --print-architecture) signed-by=/etc/apt/keyrings/docker.gpg] https://download.docker.com/linux/debian \
+          "deb [arch=$(dpkg --print-architecture) signed-by=/etc/apt/keyrings/docker.gpg] https://download.docker.com/linux/ubuntu \
           $(lsb_release -cs) stable" | tee /etc/apt/sources.list.d/docker.list > /dev/null
 RUN apt-get update && apt-get install -y docker-ce-cli jq
 

--- a/build.gradle
+++ b/build.gradle
@@ -231,7 +231,7 @@ subprojects { subproj ->
 
         tasks.register("buildDockerImage", DockerBuildImage) {
             // This is currently only used for connectors.
-            def jdkVersion = System.getenv('JDK_VERSION') ?: '17.0.1'
+            def jdkVersion = System.getenv('JDK_VERSION') ?: '17'
 
             def arch = System.getenv('BUILD_ARCH') ?: System.getProperty("os.arch").toLowerCase()
             def isArm64 = arch == "aarch64" || arch == "arm64"
@@ -239,7 +239,7 @@ subprojects { subproj ->
             def buildPlatform = System.getenv('DOCKER_BUILD_PLATFORM') ?: isArm64 ? 'linux/arm64' : 'linux/amd64'
             def alpineImage = System.getenv('ALPINE_IMAGE') ?: isArm64 ? 'arm64v8/alpine:3.14' : 'amd64/alpine:3.14'
             def nginxImage = System.getenv('NGINX_IMAGE') ?: isArm64 ? 'arm64v8/nginx:alpine' : 'amd64/nginx:alpine'
-            def openjdkImage = System.getenv('JDK_IMAGE') ?: isArm64 ? "arm64v8/openjdk:19-slim-bullseye" : "amd64/openjdk:19-slim-bullseye"
+            def openjdkImage = System.getenv('JDK_IMAGE') ?: isArm64 ? "arm64v8/eclipse-temurin:17-jdk-jammy" : "amd64/eclipse-temurin:17-jdk-jammy"
             def buildArch = System.getenv('DOCKER_BUILD_ARCH') ?: isArm64 ? 'arm64' : 'amd64'
 
             platform = buildPlatform

--- a/buildSrc/src/main/groovy/airbyte-docker.gradle
+++ b/buildSrc/src/main/groovy/airbyte-docker.gradle
@@ -117,8 +117,8 @@ class AirbyteDockerPlugin implements Plugin<Project> {
         return "$stdout".toString().trim()
     }
 
-    // Some image tags rely on environment variables (e.g. "FROM openjdk:${JDK_VERSION}-slim").
-    // dump those into a "sh -c 'echo ...'" command to resolve them (e.g. "openjdk:17-slim")
+    // Some image tags rely on environment variables (e.g. "FROM eclipse-temurin:${JDK_VERSION}-jdk-jammy").
+    // dump those into a "sh -c 'echo ...'" command to resolve them (e.g. "eclipse-temurin:17-jdk-jammy")
     static String resolveEnvironmentVariables(Project project, String str) {
         def stdout = new ByteArrayOutputStream()
 

--- a/tools/bin/build_image.sh
+++ b/tools/bin/build_image.sh
@@ -42,7 +42,7 @@ if [ "$FOLLOW_SYMLINKS" == "true" ]; then
   # to use as the build context
   tar cL "${exclusions[@]}" . | docker build - "${args[@]}"
 else
-  JDK_VERSION="${JDK_VERSION:-17.0.1}"
+  JDK_VERSION="${JDK_VERSION:-17}"
   if [[ -z "${DOCKER_BUILD_PLATFORM}" ]]; then
     docker build --build-arg JDK_VERSION="$JDK_VERSION" --build-arg DOCKER_BUILD_ARCH="$DOCKER_BUILD_ARCH" . "${args[@]}"
   else

--- a/tools/bin/publish_docker.sh
+++ b/tools/bin/publish_docker.sh
@@ -18,7 +18,7 @@ projectDir=(
 
 # Set default values to required vars. If set in env, values will be taken from there.
 # Primarily for testing.
-JDK_VERSION=${JDK_VERSION:-19-slim-bullseye}
+JDK_VERSION=${JDK_VERSION:-17}
 ALPINE_IMAGE=${ALPINE_IMAGE:-alpine:3.14}
 POSTGRES_IMAGE=${POSTGRES_IMAGE:-postgres:13-alpine}
 


### PR DESCRIPTION
…security compliance

## What
We want to improve the security rating of our docker images.

## How
Switch to eclipse-temurin as a base docker image. It is based on Ubuntu 22.04 with an updated kernel and packages.
