### PR TITLE
disable client-side cron schedule validation

### DIFF
--- a/airbyte-webapp/src/views/Connection/ConnectionForm/formConfig.tsx
+++ b/airbyte-webapp/src/views/Connection/ConnectionForm/formConfig.tsx
@@ -26,7 +26,6 @@ import {
 } from "core/request/AirbyteClient";
 import { ValuesProps } from "hooks/services/useConnectionHook";
 import { useCurrentWorkspace } from "services/workspaces/WorkspacesService";
-import { isValidCron } from "utils/cron";
 
 import calculateInitialCatalog from "./calculateInitialCatalog";
 import { ConnectionOrPartialConnection } from "./ConnectionForm";
@@ -104,7 +103,7 @@ export const connectionValidationSchema = yup
                 name: "cronExpression",
                 message: "Incorrect cron string",
                 test(value) {
-                  if (value && isValidCron(value, { seconds: true, allowBlankDay: true })) {
+                  if (value) {
                     return true;
                   }
 


### PR DESCRIPTION
## What
Stop rejecting valid cron strings in the frontend.

https://github.com/airbytehq/airbyte-cloud/issues/2772 reports that some valid cron strings are failing validation.

## How
Remove the validation until we are confident that it works as intended.

Client-side validation is a very nice feature to have, but can be released without it; on the other hand, false rejections are somewhat blocking.
