### PR TITLE
🪟 🧹 Add linting rule to make tests consistently use `it` instead of `test`

### DIFF
--- a/airbyte-webapp/.eslintrc
+++ b/airbyte-webapp/.eslintrc
@@ -81,6 +81,7 @@
         "unnamedComponents": "arrow-function"
       }
     ],
+    "jest/consistent-test-it": ["warn", { "fn": "it", "withinDescribe": "it" }],
     "react/jsx-boolean-value": "warn",
     "react/jsx-curly-brace-presence": "warn",
     "react/jsx-fragments": "warn",

--- a/airbyte-webapp/src/components/ArrayOfObjectsEditor/components/EditorHeader.test.tsx
+++ b/airbyte-webapp/src/components/ArrayOfObjectsEditor/components/EditorHeader.test.tsx
@@ -5,7 +5,7 @@ import { EditorHeader } from "./EditorHeader";
 describe("<ArrayOfObjectsEditor />", () => {
   let container: HTMLElement;
   describe("edit mode", () => {
-    test("it renders only relevant items for the mode", async () => {
+    it("renders only relevant items for the mode", async () => {
       const renderResult = await render(
         <EditorHeader
           mainTitle={<div data-testid="mainTitle">"This is the main title"</div>}
@@ -25,7 +25,7 @@ describe("<ArrayOfObjectsEditor />", () => {
     });
   });
   describe("readonly mode", () => {
-    test("it renders only relevant items for the mode", async () => {
+    it("renders only relevant items for the mode", async () => {
       const renderResult = await render(
         <EditorHeader
           mainTitle={<div data-testid="mainTitle">"This is the main title"</div>}

--- a/airbyte-webapp/src/components/StatusIcon/StatusIcon.test.tsx
+++ b/airbyte-webapp/src/components/StatusIcon/StatusIcon.test.tsx
@@ -3,7 +3,7 @@ import { render } from "@testing-library/react";
 import StatusIcon, { StatusIconStatus } from "./StatusIcon";
 
 describe("<StatusIcon />", () => {
-  test("renders with title and default icon", () => {
+  it("renders with title and default icon", () => {
     const title = "Pulpo";
     const value = 888;
 
@@ -23,7 +23,7 @@ describe("<StatusIcon />", () => {
     { status: "error", icon: "xmark" },
   ];
 
-  test.each(statusCases)("renders $status status", ({ status, icon }) => {
+  it.each(statusCases)("renders $status status", ({ status, icon }) => {
     const title = `Status is ${status}`;
     const value = 888;
     const props = {

--- a/airbyte-webapp/src/components/base/Input/Input.test.tsx
+++ b/airbyte-webapp/src/components/base/Input/Input.test.tsx
@@ -7,7 +7,7 @@ import { Input } from "./Input";
 import styles from "./Input.module.scss";
 
 describe("<Input />", () => {
-  test("renders text input", async () => {
+  it("renders text input", async () => {
     const value = "aribyte@example.com";
     const { getByTestId, queryByTestId } = await render(<Input type="text" defaultValue={value} />);
 
@@ -16,7 +16,7 @@ describe("<Input />", () => {
     expect(queryByTestId("toggle-password-visibility-button")).toBeFalsy();
   });
 
-  test("renders another type of input", async () => {
+  it("renders another type of input", async () => {
     const type = "number";
     const value = 888;
     const { getByTestId, queryByTestId } = await render(<Input type={type} defaultValue={value} />);
@@ -26,7 +26,7 @@ describe("<Input />", () => {
     expect(queryByTestId("toggle-password-visibility-button")).toBeFalsy();
   });
 
-  test("renders password input with visibilty button", async () => {
+  it("renders password input with visibilty button", async () => {
     const value = "eight888";
     const { getByTestId, getByRole } = await render(<Input type="password" defaultValue={value} />);
 
@@ -35,7 +35,7 @@ describe("<Input />", () => {
     expect(getByRole("img", { hidden: true })).toHaveAttribute("data-icon", "eye");
   });
 
-  test("renders visible password when visibility button is clicked", async () => {
+  it("renders visible password when visibility button is clicked", async () => {
     const value = "eight888";
     const { getByTestId, getByRole } = await render(<Input type="password" defaultValue={value} />);
 
@@ -49,7 +49,7 @@ describe("<Input />", () => {
     expect(getByRole("img", { hidden: true })).toHaveAttribute("data-icon", "eye-slash");
   });
 
-  test("showing password should remember cursor position", async () => {
+  it("showing password should remember cursor position", async () => {
     const value = "eight888";
     const selectionStart = Math.round(value.length / 2);
 
@@ -65,7 +65,7 @@ describe("<Input />", () => {
     expect(inputEl.selectionStart).toBe(selectionStart);
   });
 
-  test("hides password on blur", async () => {
+  it("hides password on blur", async () => {
     const value = "eight888";
     const { getByTestId, getByRole } = await render(<Input type="password" defaultValue={value} />);
 
@@ -82,7 +82,7 @@ describe("<Input />", () => {
     });
   });
 
-  test("cursor position should be at the end after blur and and clicking on show password button", async () => {
+  it("cursor position should be at the end after blur and and clicking on show password button", async () => {
     const value = "eight888";
     const { getByTestId } = await render(<Input type="password" defaultValue={value} />);
     const inputEl = getByTestId("input") as HTMLInputElement;
@@ -103,7 +103,7 @@ describe("<Input />", () => {
     expect(inputEl.selectionStart).toBe(value.length);
   });
 
-  test("should trigger onChange once", async () => {
+  it("should trigger onChange once", async () => {
     const onChange = jest.fn();
     const { getByTestId } = await render(<Input onChange={onChange} />);
     const inputEl = getByTestId("input");
@@ -112,7 +112,7 @@ describe("<Input />", () => {
     expect(onChange).toHaveBeenCalledTimes(1);
   });
 
-  test("has focused class after focus", async () => {
+  it("has focused class after focus", async () => {
     const { getByTestId } = await render(<Input />);
     const inputEl = getByTestId("input");
 
@@ -122,7 +122,7 @@ describe("<Input />", () => {
     expect(getByTestId("input-container")).toHaveClass(styles.focused);
   });
 
-  test("does not have focused class after blur", async () => {
+  it("does not have focused class after blur", async () => {
     const { getByTestId } = await render(<Input />);
     const inputEl = getByTestId("input");
 
@@ -133,7 +133,7 @@ describe("<Input />", () => {
     expect(getByTestId("input-container")).not.toHaveClass(styles.focused);
   });
 
-  test("calls onFocus if passed as prop", async () => {
+  it("calls onFocus if passed as prop", async () => {
     const onFocus = jest.fn();
     const { getByTestId } = await render(<Input onFocus={onFocus} />);
     const inputEl = getByTestId("input");
@@ -143,7 +143,7 @@ describe("<Input />", () => {
     expect(onFocus).toHaveBeenCalledTimes(1);
   });
 
-  test("calls onBlur if passed as prop", async () => {
+  it("calls onBlur if passed as prop", async () => {
     const onBlur = jest.fn();
     const { getByTestId } = await render(<Input onBlur={onBlur} />);
     const inputEl = getByTestId("input");

--- a/airbyte-webapp/src/config/configProviders.test.ts
+++ b/airbyte-webapp/src/config/configProviders.test.ts
@@ -15,7 +15,7 @@ interface Value {
   };
 }
 describe("applyProviders", () => {
-  test("should deepMerge config returned from providers", async () => {
+  it("should deepMerge config returned from providers", async () => {
     const defaultValue: Value = {
       prop1: {
         innerProp: "Alex",

--- a/airbyte-webapp/src/core/form/uiWidget.test.ts
+++ b/airbyte-webapp/src/core/form/uiWidget.test.ts
@@ -104,7 +104,7 @@ const formItems: FormBlock[] = [
   },
 ];
 
-test("should select first key by default", () => {
+it("should select first key by default", () => {
   const uiWidgetState = buildPathInitialState(formItems, {});
   expect(uiWidgetState).toEqual({
     "key.credentials": {
@@ -115,7 +115,7 @@ test("should select first key by default", () => {
   });
 });
 
-test("should select key selected in default values", () => {
+it("should select key selected in default values", () => {
   const uiWidgetState = buildPathInitialState(
     formItems,
     {
@@ -136,7 +136,7 @@ test("should select key selected in default values", () => {
   });
 });
 
-test("should select correct key for enum", () => {
+it("should select correct key for enum", () => {
   const fields = jsonSchemaToUiWidget(
     JSON.parse(
       `{"type":"object","title":"File Source Spec","$schema":"http://json-schema.org/draft-07/schema#","required":["dataset_name","format","url","provider"],"properties":{"url":{"type":"string","description":"URL path to access the file to be replicated"},"format":{"enum":["csv","json","html","excel","feather","parquet","orc","pickle"],"type":"string","default":"csv","description":"File Format of the file to be replicated (Warning: some format may be experimental, please refer to docs)."},"provider":{"type":"object","oneOf":[{"title":"HTTPS: Public Web","required":["storage"],"properties":{"storage":{"enum":["HTTPS"],"type":"string","default":"HTTPS"}}},{"title":"GCS: Google Cloud Storage","required":["storage","reader_impl"],"properties":{"storage":{"enum":["GCS"],"type":"string","default":"GCS"},"reader_impl":{"enum":["smart_open","gcsfs"],"type":"string","default":"gcsfs","description":"This connector provides multiple methods to retrieve data from GCS using either smart-open python libraries or GCSFS"},"service_account_json":{"type":"string","description":"In order to access private Buckets stored on Google Cloud, this connector would need a service account json credentials with the proper permissions as described <a href=\\"https://cloud.google.com/iam/docs/service-accounts\\" target=\\"_blank\\">here</a>. Please generate the credentials.json file and copy/paste its content to this field (expecting JSON formats). If accessing publicly available data, this field is not necessary."}}},{"title":"S3: Amazon Web Services","required":["storage","reader_impl"],"properties":{"storage":{"enum":["S3"],"type":"string","default":"S3"},"reader_impl":{"enum":["smart_open","s3fs"],"type":"string","default":"s3fs","description":"This connector provides multiple methods to retrieve data from AWS S3 using either smart-open python libraries or S3FS"},"aws_access_key_id":{"type":"string","description":"In order to access private Buckets stored on AWS S3, this connector would need credentials with the proper permissions. If accessing publicly available data, this field is not necessary."},"aws_secret_access_key":{"type":"string","description":"In order to access private Buckets stored on AWS S3, this connector would need credentials with the proper permissions. If accessing publicly available data, this field is not necessary.","airbyte_secret":true}}},{"title":"SSH: Secure Shell","required":["storage","user","host"],"properties":{"host":{"type":"string"},"user":{"type":"string"},"storage":{"enum":["SSH"],"type":"string","default":"SSH"},"password":{"type":"string","airbyte_secret":true}}},{"title":"SFTP: Secure File Transfer Protocol","required":["storage","user","host"],"properties":{"host":{"type":"string"},"user":{"type":"string"},"storage":{"enum":["SFTP"],"type":"string","default":"SFTP"},"password":{"type":"string","airbyte_secret":true}}},{"title":"WebHDFS: HDFS REST API (Untested)","required":["storage","host","port"],"properties":{"host":{"type":"string"},"port":{"type":"number"},"storage":{"enum":["WebHDFS"],"type":"string","default":"WebHDFS","description":"WARNING: smart_open library provides the ability to stream files over this protocol but we haven't been able to test this as part of Airbyte yet, please use with caution. We would love to hear feedbacks from you if you are able or fail to use this!"}}},{"title":"Local Filesystem (limited)","required":["storage"],"properties":{"storage":{"enum":["local"],"type":"string","default":"local","description":"WARNING: Note that local storage URL available for read must start with the local mount \\"/local/\\" at the moment until we implement more advanced docker mounting options..."}}}],"default":"Public Web","description":"Storage Provider or Location of the file(s) to be replicated."},"dataset_name":{"type":"string","description":"Name of the final table where to replicate this file (should include only letters, numbers dash and underscores)"},"reader_options":{"type":"string","examples":["{}","{'sep': ' '}"],"description":"This should be a valid JSON string used by each reader/parser to provide additional options and tune its behavior"}},"additionalProperties":false}`

--- a/airbyte-webapp/src/core/jsonSchema/schemaToUiWidget.test.ts
+++ b/airbyte-webapp/src/core/jsonSchema/schemaToUiWidget.test.ts
@@ -1,7 +1,7 @@
 import { jsonSchemaToUiWidget } from "./schemaToUiWidget";
 import { AirbyteJSONSchemaDefinition } from "./types";
 
-test("should reformat jsonSchema to internal widget representation", () => {
+it("should reformat jsonSchema to internal widget representation", () => {
   const schema: AirbyteJSONSchemaDefinition = {
     type: "object",
     required: ["host", "port", "user", "dbname"],
@@ -115,7 +115,7 @@ test("should reformat jsonSchema to internal widget representation", () => {
   expect(builtSchema).toEqual(expected);
 });
 
-test("should reformat jsonSchema to internal widget representation with parent schema", () => {
+it("should reformat jsonSchema to internal widget representation with parent schema", () => {
   const schema: AirbyteJSONSchemaDefinition = {
     type: "object",
     title: "Postgres Source Spec",
@@ -163,7 +163,7 @@ test("should reformat jsonSchema to internal widget representation with parent s
   expect(builtSchema).toEqual(expected);
 });
 
-test("should reformat jsonSchema to internal widget representation when has oneOf", () => {
+it("should reformat jsonSchema to internal widget representation when has oneOf", () => {
   const schema: AirbyteJSONSchemaDefinition = {
     type: "object",
     required: ["start_date", "credentials"],

--- a/airbyte-webapp/src/core/jsonSchema/schemaToYup.test.ts
+++ b/airbyte-webapp/src/core/jsonSchema/schemaToYup.test.ts
@@ -5,7 +5,7 @@ import { AirbyteJSONSchema } from "./types";
 
 // Note: We have to check yup schema with JSON.stringify
 // as exactly same objects throw now equality due to `Received: serializes to the same string` error
-test("should build schema for simple case", () => {
+it("should build schema for simple case", () => {
   const schema: AirbyteJSONSchema = {
     type: "object",
     title: "Postgres Source Spec",
@@ -59,7 +59,7 @@ test("should build schema for simple case", () => {
   expect(JSON.stringify(yupSchema)).toEqual(JSON.stringify(expectedSchema));
 });
 
-test("should build schema for conditional case", () => {
+it("should build schema for conditional case", () => {
   const yupSchema = buildYupFormForJsonSchema(
     {
       type: "object",
@@ -107,7 +107,7 @@ test("should build schema for conditional case", () => {
   expect(JSON.stringify(yupSchema)).toEqual(JSON.stringify(expectedSchema));
 });
 
-test("should build schema for conditional case with inner schema and selected uiwidget", () => {
+it("should build schema for conditional case with inner schema and selected uiwidget", () => {
   const yupSchema = buildYupFormForJsonSchema(
     {
       type: "object",

--- a/airbyte-webapp/src/core/jsonSchema/utils.test.ts
+++ b/airbyte-webapp/src/core/jsonSchema/utils.test.ts
@@ -1,7 +1,7 @@
 import { AirbyteJSONSchema } from "./types";
 import { applyFuncAt, removeNestedPaths } from "./utils";
 
-test("should filter paths", () => {
+it("should filter paths", () => {
   const schema: AirbyteJSONSchema = {
     type: "object",
     required: ["host", "name"],
@@ -49,7 +49,7 @@ test("should filter paths", () => {
   });
 });
 
-test("should exclude nested paths", () => {
+it("should exclude nested paths", () => {
   const schema: AirbyteJSONSchema = {
     type: "object",
     properties: {
@@ -102,7 +102,7 @@ test("should exclude nested paths", () => {
   });
 });
 
-test("should exclude paths in oneOf", () => {
+it("should exclude paths in oneOf", () => {
   const schema: AirbyteJSONSchema = {
     type: "object",
     properties: {
@@ -152,7 +152,7 @@ test("should exclude paths in oneOf", () => {
   });
 });
 
-test("apply func at", () => {
+it("apply func at", () => {
   const schema: AirbyteJSONSchema = {
     type: "object",
     properties: {

--- a/airbyte-webapp/src/hooks/services/useAdvancedModeSetting.test.ts
+++ b/airbyte-webapp/src/hooks/services/useAdvancedModeSetting.test.ts
@@ -15,7 +15,7 @@ jest.mock("hooks/services/useWorkspace", () => ({
   },
 }));
 
-test("it defaults to false before advanced mode is explicitly set", () => {
+it("defaults to false before advanced mode is explicitly set", () => {
   const { result } = renderHook(() => useAdvancedModeSetting());
   // eslint-disable-next-line prefer-const
   let [isAdvancedMode, setAdvancedMode] = result.current;
@@ -28,7 +28,7 @@ test("it defaults to false before advanced mode is explicitly set", () => {
   expect(isAdvancedMode).toBe(true);
 });
 
-test("it stores workspace-specific advanced mode settings", () => {
+it("stores workspace-specific advanced mode settings", () => {
   changeToWorkspace("workspaceA");
 
   const { result, rerender } = renderHook(() => useAdvancedModeSetting());

--- a/airbyte-webapp/src/hooks/services/useConnector.test.tsx
+++ b/airbyte-webapp/src/hooks/services/useConnector.test.tsx
@@ -42,7 +42,7 @@ jest.mock("services/connector/DestinationDefinitionService", () => ({
   }),
 }));
 
-test.skip("should not call sourceDefinition.updateVersion for deprecated call", async () => {
+it.skip("should not call sourceDefinition.updateVersion for deprecated call", async () => {
   const { result, waitForNextUpdate } = renderHook(() => useConnector());
 
   act(() => {
@@ -57,7 +57,7 @@ test.skip("should not call sourceDefinition.updateVersion for deprecated call", 
   // });
 });
 
-test.skip("should not call destinationDefinition.updateVersion for deprecated call", async () => {
+it.skip("should not call destinationDefinition.updateVersion for deprecated call", async () => {
   const { result, waitForNextUpdate } = renderHook(() => useConnector());
 
   act(() => {

--- a/airbyte-webapp/src/packages/cloud/views/auth/components/GitBlock/GitBlock.test.tsx
+++ b/airbyte-webapp/src/packages/cloud/views/auth/components/GitBlock/GitBlock.test.tsx
@@ -16,13 +16,13 @@ const renderGitBlock = (props?: GitBlockProps) =>
   );
 
 describe("<GitBlock />", () => {
-  test("should render with default props", () => {
+  it("should render with default props", () => {
     const { asFragment } = renderGitBlock();
 
     expect(asFragment()).toMatchSnapshot();
   });
 
-  test("should render with overwritten props", () => {
+  it("should render with overwritten props", () => {
     const { asFragment } = renderGitBlock({
       titleStyle: { fontSize: "30px" },
       messageStyle: { color: "blue" },

--- a/airbyte-webapp/src/pages/ConnectionPage/pages/ConnectionItemPage/components/SettingsView.test.tsx
+++ b/airbyte-webapp/src/pages/ConnectionPage/pages/ConnectionItemPage/components/SettingsView.test.tsx
@@ -34,7 +34,7 @@ jest.mock("components/DeleteBlock", () => () => {
 });
 
 describe("<SettingsView />", () => {
-  test("it only renders connection state when advanced mode is enabled", async () => {
+  it("only renders connection state when advanced mode is enabled", async () => {
     let container: HTMLElement;
 
     setMockIsAdvancedMode(false);

--- a/airbyte-webapp/src/utils/common.test.ts
+++ b/airbyte-webapp/src/utils/common.test.ts
@@ -1,6 +1,6 @@
 import { isDefined } from "./common";
 
-test.each([
+it.each([
   [null, false],
   [undefined, false],
   ["", true],

--- a/airbyte-webapp/src/views/Connection/CatalogDiffModal/CatalogDiffModal.test.tsx
+++ b/airbyte-webapp/src/views/Connection/CatalogDiffModal/CatalogDiffModal.test.tsx
@@ -146,7 +146,7 @@ describe("catalog diff modal", () => {
     mockCatalogDiff.transforms = [];
   });
 
-  test("it renders the correct section for each type of transform", () => {
+  it("renders the correct section for each type of transform", () => {
     mockCatalogDiff.transforms.push(...addedItems, ...removedItems, ...updatedItems);
 
     render(
@@ -193,7 +193,7 @@ describe("catalog diff modal", () => {
     expect(updatedStreamRowWithSyncMode).not.toBeInTheDocument();
   });
 
-  test("added fields are not rendered when not in the diff", () => {
+  it("added fields are not rendered when not in the diff", () => {
     mockCatalogDiff.transforms.push(...removedItems, ...updatedItems);
 
     render(
@@ -212,7 +212,7 @@ describe("catalog diff modal", () => {
     expect(newStreamsTable).not.toBeInTheDocument();
   });
 
-  test("removed fields are not rendered when not in the diff", () => {
+  it("removed fields are not rendered when not in the diff", () => {
     mockCatalogDiff.transforms.push(...addedItems, ...updatedItems);
 
     render(
@@ -231,7 +231,7 @@ describe("catalog diff modal", () => {
     expect(removedStreamsTable).not.toBeInTheDocument();
   });
 
-  test("changed streams accordion opens/closes on clicking the description row", () => {
+  it("changed streams accordion opens/closes on clicking the description row", () => {
     mockCatalogDiff.transforms.push(...addedItems, ...updatedItems);
 
     render(

--- a/airbyte-webapp/src/views/Connection/ConnectionForm/ConnectionForm.test.tsx
+++ b/airbyte-webapp/src/views/Connection/ConnectionForm/ConnectionForm.test.tsx
@@ -88,7 +88,7 @@ describe("<ConnectionForm />", () => {
 
       container = renderResult.container;
     });
-    test("it renders relevant items", async () => {
+    it("renders relevant items", async () => {
       const prefixInput = container.querySelector("input[data-testid='prefixInput']");
       expect(prefixInput).toBeInTheDocument();
 
@@ -96,7 +96,7 @@ describe("<ConnectionForm />", () => {
       userEvent.type(prefixInput!, "{selectall}{del}prefix");
       await waitFor(() => userEvent.keyboard("{enter}"));
     });
-    test("pointer events are not turned off anywhere in the component", async () => {
+    it("pointer events are not turned off anywhere in the component", async () => {
       expect(container.innerHTML).toContain("checkbox");
     });
   });
@@ -110,11 +110,11 @@ describe("<ConnectionForm />", () => {
 
       container = renderResult.container;
     });
-    test("it renders only relevant items for the mode", async () => {
+    it("renders only relevant items for the mode", async () => {
       const prefixInput = container.querySelector("input[data-testid='prefixInput']");
       expect(prefixInput).toBeInTheDocument();
     });
-    test("pointer events are turned off in the fieldset", async () => {
+    it("pointer events are turned off in the fieldset", async () => {
       expect(container.innerHTML).not.toContain("checkbox");
     });
   });

--- a/airbyte-webapp/src/views/Connection/ConnectionForm/calculateInitialCatalog.test.ts
+++ b/airbyte-webapp/src/views/Connection/ConnectionForm/calculateInitialCatalog.test.ts
@@ -24,7 +24,7 @@ const mockSyncSchemaStream: SyncSchemaStream = {
 };
 
 describe("calculateInitialCatalog", () => {
-  test("should assign ids to all streams", () => {
+  it("should assign ids to all streams", () => {
     const { id, ...restProps } = mockSyncSchemaStream;
 
     const values = calculateInitialCatalog(
@@ -40,7 +40,7 @@ describe("calculateInitialCatalog", () => {
     });
   });
 
-  test("should set default 'FullRefresh' if 'supportedSyncModes' in stream is empty(or null)", () => {
+  it("should set default 'FullRefresh' if 'supportedSyncModes' in stream is empty(or null)", () => {
     const { config, stream: sourceDefinedStream } = mockSyncSchemaStream;
 
     const values = calculateInitialCatalog(
@@ -65,7 +65,7 @@ describe("calculateInitialCatalog", () => {
     });
   });
 
-  test("should select 'Incremental(cursor defined) => Append Dedup'", () => {
+  it("should select 'Incremental(cursor defined) => Append Dedup'", () => {
     const { config, stream: sourceDefinedStream } = mockSyncSchemaStream;
 
     const values = calculateInitialCatalog(
@@ -128,7 +128,7 @@ describe("calculateInitialCatalog", () => {
     });
   });
 
-  test("should select 'Full Refresh => Overwrite'", () => {
+  it("should select 'Full Refresh => Overwrite'", () => {
     const { config, stream: sourceDefinedStream } = mockSyncSchemaStream;
 
     const values = calculateInitialCatalog(
@@ -185,7 +185,7 @@ describe("calculateInitialCatalog", () => {
     });
   });
 
-  test("should select 'Incremental => Append'", () => {
+  it("should select 'Incremental => Append'", () => {
     const { config, stream: sourceDefinedStream } = mockSyncSchemaStream;
 
     const values = calculateInitialCatalog(
@@ -242,7 +242,7 @@ describe("calculateInitialCatalog", () => {
     });
   });
 
-  test("should select 'Full Refresh => Append'", () => {
+  it("should select 'Full Refresh => Append'", () => {
     const { config, stream: sourceDefinedStream } = mockSyncSchemaStream;
 
     const values = calculateInitialCatalog(
@@ -299,7 +299,7 @@ describe("calculateInitialCatalog", () => {
     });
   });
 
-  test("should not change syncMode, destinationSyncMode in EditMode", () => {
+  it("should not change syncMode, destinationSyncMode in EditMode", () => {
     const { config, stream: sourceDefinedStream } = mockSyncSchemaStream;
 
     const { streams: calculatedStreams } = calculateInitialCatalog(
@@ -330,7 +330,7 @@ describe("calculateInitialCatalog", () => {
     expect(calculatedStreams[0]).toHaveProperty("config.destinationSyncMode", DestinationSyncMode.append);
   });
 
-  test("should set the default cursorField value when it's available and no cursorField is selected", () => {
+  it("should set the default cursorField value when it's available and no cursorField is selected", () => {
     const { stream: sourceDefinedStream, config } = mockSyncSchemaStream;
 
     const { streams: calculatedStreams } = calculateInitialCatalog(
@@ -389,7 +389,7 @@ describe("calculateInitialCatalog", () => {
     expect(calculatedStreams[2]).toHaveProperty("config.cursorField", []);
   });
 
-  test("source defined properties should override the saved properties", () => {
+  it("source defined properties should override the saved properties", () => {
     const { stream: sourceDefinedStream, config } = mockSyncSchemaStream;
 
     const { streams: calculatedStreams } = calculateInitialCatalog(
@@ -421,7 +421,7 @@ describe("calculateInitialCatalog", () => {
     expect(calculatedStreams[0].stream?.defaultCursorField).toEqual(sourceDefinedStream?.defaultCursorField);
     expect(calculatedStreams[0].config?.cursorField).toEqual(calculatedStreams[0].stream?.defaultCursorField);
   });
-  test("should keep original configured primary key if no source-defined primary key", () => {
+  it("should keep original configured primary key if no source-defined primary key", () => {
     const { stream: sourceDefinedStream, config } = mockSyncSchemaStream;
 
     const { streams: calculatedStreams } = calculateInitialCatalog(
@@ -451,7 +451,7 @@ describe("calculateInitialCatalog", () => {
 
     expect(calculatedStreams[0].config?.primaryKey).toEqual(config?.primaryKey);
   });
-  test("should not override config cursor if sourceDefinedCursor is false", () => {
+  it("should not override config cursor if sourceDefinedCursor is false", () => {
     const { stream: sourceDefinedStream, config } = mockSyncSchemaStream;
 
     const { streams: calculatedStreams } = calculateInitialCatalog(
@@ -478,7 +478,7 @@ describe("calculateInitialCatalog", () => {
 
     expect(calculatedStreams[0].config?.cursorField).toEqual(config?.cursorField);
   });
-  test("should keep its original config if source-defined primary key matches config primary key", () => {
+  it("should keep its original config if source-defined primary key matches config primary key", () => {
     const { stream: sourceDefinedStream, config } = mockSyncSchemaStream;
 
     const { streams: calculatedStreams } = calculateInitialCatalog(
@@ -506,7 +506,7 @@ describe("calculateInitialCatalog", () => {
     expect(calculatedStreams[0].config?.primaryKey).toEqual(calculatedStreams[0].stream?.sourceDefinedPrimaryKey);
   });
 
-  test("should not change primary key or cursor if isEditMode is false", () => {
+  it("should not change primary key or cursor if isEditMode is false", () => {
     const { stream: sourceDefinedStream, config } = mockSyncSchemaStream;
 
     const { streams: calculatedStreams } = calculateInitialCatalog(

--- a/airbyte-webapp/src/views/Connector/ServiceForm/ServiceForm.test.tsx
+++ b/airbyte-webapp/src/views/Connector/ServiceForm/ServiceForm.test.tsx
@@ -171,7 +171,7 @@ describe("Service Form", () => {
       container = renderResult.container;
     });
 
-    test("should display general components: submit button, name and serviceType fields", () => {
+    it("should display general components: submit button, name and serviceType fields", () => {
       const name = container.querySelector("input[name='name']");
       const serviceType = container.querySelector("div[data-testid='serviceType']");
       const submit = container.querySelector("button[type='submit']");
@@ -181,30 +181,30 @@ describe("Service Form", () => {
       expect(submit).toBeInTheDocument();
     });
 
-    test("should display text input field", () => {
+    it("should display text input field", () => {
       const host = container.querySelector("input[name='connectionConfiguration.host']");
       expect(host).toBeInTheDocument();
       expect(host?.getAttribute("type")).toEqual("text");
     });
 
-    test("should display number input field", () => {
+    it("should display number input field", () => {
       const port = container.querySelector("input[name='connectionConfiguration.port']");
       expect(port).toBeInTheDocument();
       expect(port?.getAttribute("type")).toEqual("number");
     });
 
-    test("should display secret input field", () => {
+    it("should display secret input field", () => {
       const password = container.querySelector("input[name='connectionConfiguration.password']");
       expect(password).toBeInTheDocument();
       expect(password?.getAttribute("type")).toEqual("password");
     });
 
-    test("should display textarea field", () => {
+    it("should display textarea field", () => {
       const message = container.querySelector("textarea[name='connectionConfiguration.message']");
       expect(message).toBeInTheDocument();
     });
 
-    test("should display oneOf field", () => {
+    it("should display oneOf field", () => {
       const credentials = container.querySelector("div[data-testid='connectionConfiguration.credentials']");
       const credentialsValue = credentials?.querySelector("input[value='api key']");
       const apiKey = container.querySelector("input[name='connectionConfiguration.credentials.api_key']");
@@ -214,17 +214,17 @@ describe("Service Form", () => {
       expect(apiKey).toBeInTheDocument();
     });
 
-    test("should display array of simple entity field", () => {
+    it("should display array of simple entity field", () => {
       const emails = container.querySelector("input[name='connectionConfiguration.emails']");
       expect(emails).toBeInTheDocument();
     });
 
-    test("should display array with items list field", () => {
+    it("should display array with items list field", () => {
       const workTime = container.querySelector("div[name='connectionConfiguration.workTime']");
       expect(workTime).toBeInTheDocument();
     });
 
-    test("should display array of objects field", () => {
+    it("should display array of objects field", () => {
       const priceList = container.querySelector("div[data-testid='connectionConfiguration.priceList']");
       const addButton = priceList?.querySelector("button[data-testid='addItemButton']");
       expect(priceList).toBeInTheDocument();
@@ -255,7 +255,7 @@ describe("Service Form", () => {
       container = renderResult.container;
     });
 
-    test("should fill all fields by right values", async () => {
+    it("should fill all fields by right values", async () => {
       const name = container.querySelector("input[name='name']");
       const host = container.querySelector("input[name='connectionConfiguration.host']");
       const port = container.querySelector("input[name='connectionConfiguration.port']");
@@ -296,7 +296,7 @@ describe("Service Form", () => {
       });
     });
 
-    test("should fill right values in array of simple entity field", async () => {
+    it("should fill right values in array of simple entity field", async () => {
       const emails = container.querySelector("input[name='connectionConfiguration.emails']");
       userEvent.type(emails!, "test1@test.com{enter}test2@test.com{enter}test3@test.com");
 
@@ -307,7 +307,7 @@ describe("Service Form", () => {
       expect(result.connectionConfiguration.emails).toEqual(["test1@test.com", "test2@test.com", "test3@test.com"]);
     });
 
-    test("should fill right values in array with items list field", async () => {
+    it("should fill right values in array with items list field", async () => {
       const workTime = container.querySelector("div[name='connectionConfiguration.workTime']");
       userEvent.type(workTime!.querySelector("input")!, "day{enter}abc{enter}ni{enter}");
 
@@ -318,7 +318,7 @@ describe("Service Form", () => {
       expect(result.connectionConfiguration.workTime).toEqual(["day", "night"]);
     });
 
-    test("change oneOf field value", async () => {
+    it("change oneOf field value", async () => {
       const credentials = screen.getByTestId("connectionConfiguration.credentials");
 
       const selectContainer = getByTestId(container, "connectionConfiguration.credentials");
@@ -334,7 +334,7 @@ describe("Service Form", () => {
       expect(uri).toBeInTheDocument();
     });
 
-    test("should fill right values oneOf field", async () => {
+    it("should fill right values oneOf field", async () => {
       const selectContainer = getByTestId(container, "connectionConfiguration.credentials");
 
       await selectEvent.select(selectContainer, "oauth", {
@@ -352,7 +352,7 @@ describe("Service Form", () => {
       });
     });
 
-    test("should fill right values in array of objects field", async () => {
+    it("should fill right values in array of objects field", async () => {
       // IntersectionObserver isn't available in test environment but is used by headless-ui dialog
       // used for this component
       useMockIntersectionObserver();

--- a/airbyte-webapp/src/views/Connector/ServiceForm/components/Sections/auth/AuthButton.test.tsx
+++ b/airbyte-webapp/src/views/Connector/ServiceForm/components/Sections/auth/AuthButton.test.tsx
@@ -46,7 +46,7 @@ describe("auth button", () => {
     jest.clearAllMocks();
   });
 
-  test("it initially renders with correct message and no status message", () => {
+  it("initially renders with correct message and no status message", () => {
     // no auth errors
     mockUseServiceForm.mockImplementationOnce(() => {
       const authErrors = {};
@@ -82,7 +82,7 @@ describe("auth button", () => {
     expect(successMessage).not.toBeInTheDocument();
   });
 
-  test("after successful authentication, it renders with correct message and success message", () => {
+  it("after successful authentication, it renders with correct message and success message", () => {
     // no auth errors
     mockUseServiceForm.mockImplementationOnce(() => {
       const authErrors = {};
@@ -114,7 +114,7 @@ describe("auth button", () => {
     expect(successMessage).toBeInTheDocument();
   });
 
-  test("if authError is true, it renders the correct message", () => {
+  it("if authError is true, it renders the correct message", () => {
     // auth errors
     mockUseServiceForm.mockImplementationOnce(() => {
       const authErrors = { field: "form.empty.error" };


### PR DESCRIPTION
## What / How
Adds an auto-fixable rule that ensures that the test convention is consistent across the app.
