### PR TITLE
kube test get more power and limits total run time

### DIFF
--- a/.github/workflows/gradle.yml
+++ b/.github/workflows/gradle.yml
@@ -590,7 +590,7 @@ jobs:
     needs: start-kube-acceptance-test-runner # required to start the main job when the runner is ready
     runs-on: ${{ needs.start-kube-acceptance-test-runner.outputs.label }} # run the job on the newly created runner
     environment: more-secrets
-    timeout-minutes: 30
+    timeout-minutes: 40
     steps:
       - name: Checkout Airbyte
         uses: actions/checkout@v2

--- a/.github/workflows/gradle.yml
+++ b/.github/workflows/gradle.yml
@@ -568,7 +568,7 @@ jobs:
     # Because scheduled builds on master require us to skip the changes job. Use always() to force this to run on master.
     if: needs.changes.outputs.backend == 'true' || needs.changes.outputs.build == 'true' || (always() && github.ref == 'refs/heads/master')
     timeout-minutes: 10
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-20.04-16core
     outputs:
       label: ${{ steps.start-ec2-runner.outputs.label }}
       ec2-instance-id: ${{ steps.start-ec2-runner.outputs.ec2-instance-id }}
@@ -590,7 +590,7 @@ jobs:
     needs: start-kube-acceptance-test-runner # required to start the main job when the runner is ready
     runs-on: ${{ needs.start-kube-acceptance-test-runner.outputs.label }} # run the job on the newly created runner
     environment: more-secrets
-    timeout-minutes: 90
+    timeout-minutes: 30
     steps:
       - name: Checkout Airbyte
         uses: actions/checkout@v2


### PR DESCRIPTION
Broken in prod.  not sure if this will run on the PR.

kube test get more power and limits total run time

using a beta test of GH workers for speed
context: [gh action speed story](https://github.com/airbytehq/airbyte-cloud/issues/2737)
[investigate this pipeline](https://github.com/airbytehq/airbyte-cloud/issues/2787)