### PR TITLE
:window: :bug: fix bug around re-opening modal and dropdown z-index

### DIFF
--- a/airbyte-webapp/src/components/ArrayOfObjectsEditor/ArrayOfObjectsEditor.tsx
+++ b/airbyte-webapp/src/components/ArrayOfObjectsEditor/ArrayOfObjectsEditor.tsx
@@ -24,6 +24,7 @@ export interface ArrayOfObjectsEditorProps<T extends ItemBase> {
   renderItemEditorForm: (item?: T) => React.ReactNode;
   onStartEdit: (n: number) => void;
   onRemove: (index: number) => void;
+  onCancel?: () => void;
   mode?: ConnectionFormMode;
   disabled?: boolean;
   editModalSize?: ModalProps["size"];
@@ -32,6 +33,7 @@ export interface ArrayOfObjectsEditorProps<T extends ItemBase> {
 export const ArrayOfObjectsEditor = <T extends ItemBase = ItemBase>({
   onStartEdit,
   onRemove,
+  onCancel,
   renderItemName = (item) => item.name,
   renderItemDescription = (item) => item.description,
   renderItemEditorForm,
@@ -54,6 +56,7 @@ export const ArrayOfObjectsEditor = <T extends ItemBase = ItemBase>({
         title={<FormattedMessage id={item ? "form.edit" : "form.add"} />}
         size={editModalSize}
         testId="arrayOfObjects-editModal"
+        onClose={onCancel}
       >
         {renderItemEditorForm(item)}
       </Modal>

--- a/airbyte-webapp/src/components/base/DropDown/DropDown.tsx
+++ b/airbyte-webapp/src/components/base/DropDown/DropDown.tsx
@@ -62,7 +62,6 @@ function DropDownInner<T = unknown>(
       zIndex: 9999,
     }),
   };
-
   return (
     <CustomSelect
       ref={ref}
@@ -70,7 +69,6 @@ function DropDownInner<T = unknown>(
       $error={props.error}
       menuPlacement="auto"
       menuPosition="fixed"
-      menuPortalTarget={document.body}
       menuShouldBlockScroll
       className="react-select-container"
       classNamePrefix="react-select"

--- a/airbyte-webapp/src/views/Connection/ConnectionForm/components/TransformationField.tsx
+++ b/airbyte-webapp/src/views/Connection/ConnectionForm/components/TransformationField.tsx
@@ -29,6 +29,7 @@ const TransformationField: React.FC<TransformationFieldProps> = ({
   onEndEdit,
 }) => {
   const [editableItemIdx, setEditableItem] = useState<number | null>(null);
+  const clearEditableItem = () => setEditableItem(null);
 
   return (
     <ArrayOfObjectsEditor
@@ -43,6 +44,7 @@ const TransformationField: React.FC<TransformationFieldProps> = ({
         setEditableItem(idx);
         onStartEdit?.();
       }}
+      onCancel={clearEditableItem}
       mode={mode}
       editModalSize="xl"
       renderItemEditorForm={(editableItem) => (
@@ -50,7 +52,7 @@ const TransformationField: React.FC<TransformationFieldProps> = ({
           transformation={editableItem ?? defaultTransformation}
           isNewTransformation={!editableItem}
           onCancel={() => {
-            setEditableItem(null);
+            clearEditableItem();
             onEndEdit?.();
           }}
           onDone={(transformation) => {
@@ -58,7 +60,7 @@ const TransformationField: React.FC<TransformationFieldProps> = ({
               editableItemIdx >= form.values.transformations.length
                 ? push(transformation)
                 : replace(editableItemIdx, transformation);
-              setEditableItem(null);
+              clearEditableItem();
               onEndEdit?.();
             }
           }}

--- a/airbyte-webapp/src/views/Connector/ServiceForm/components/Sections/ArraySection.tsx
+++ b/airbyte-webapp/src/views/Connector/ServiceForm/components/Sections/ArraySection.tsx
@@ -64,6 +64,8 @@ export const ArraySection: React.FC<ArraySectionProps> = ({ formField, path, dis
     };
   }, [items, formField.properties]);
 
+  const clearEditIndex = () => setEditIndex(undefined);
+
   return (
     <GroupControls
       name={path}
@@ -79,6 +81,7 @@ export const ArraySection: React.FC<ArraySectionProps> = ({ formField, path, dis
               editableItemIndex={editIndex}
               onStartEdit={setEditIndex}
               onRemove={arrayHelpers.remove}
+              onCancel={clearEditIndex}
               items={items}
               renderItemName={renderItemName}
               renderItemDescription={renderItemDescription}
@@ -97,11 +100,9 @@ export const ArraySection: React.FC<ArraySectionProps> = ({ formField, path, dis
                         : [...items, updatedItem];
 
                     fieldHelper.setValue(updatedValue);
-                    setEditIndex(undefined);
+                    clearEditIndex();
                   }}
-                  onCancel={() => {
-                    setEditIndex(undefined);
-                  }}
+                  onCancel={clearEditIndex}
                 />
               )}
             />


### PR DESCRIPTION
## What
Resolves https://github.com/airbytehq/oncall/issues/600

See issue for details. This PR addresses the two problems called out in that issue.

## How
- Remove the `menuPortalTarget={document.body}` prop from the `DropDown` component, which was causing dropdown menus to be portaled to the document body instead of being placed in the dom where the dropdown control is. This prop was causing dropdown menus coming from modals to be rendered underneath the modals themselves, and made it so that clicking a dropdown in a modal would close the modal itself as the app considered that to be an "outside click" Removing this prop and rendering the menu in the dom fixes this problem, as the menu is now a child of the modal. 
- Add an `onCancel` method to ArrayOfObjectsEditor, and point the modal `onClose` prop to that function. Set that function to set the edit index to `undefined`, as other places that close the modal do as well. This fixes the issue of not being able to re-open the modal after it is closed, as the edit index is now properly cleared out.

I tested out other dropdowns elsewhere in the app and they appear to be working as expected.

## Recommended reading order
1. `x.java`
2. `y.python`

## 🚨 User Impact 🚨
Users will now be able to properly use modals and dropdowns, such as those in the salesforce connector