### PR TITLE
fix: malform helper Golang template

### DIFF
--- a/charts/airbyte-metrics/templates/_helpers.tpl
+++ b/charts/airbyte-metrics/templates/_helpers.tpl
@@ -50,3 +50,4 @@ Define imageTag
 {{- else }}
     {{- printf "%s" .Chart.AppVersion }}
 {{- end }}
+{{- end }}


### PR DESCRIPTION
## What
Failed to render `airbyte-metrics` chart with simple command:

```
helm template .
```

## How
Add missing closing of `define` section in the `_helpers.tpl` file.

## 🚨 User Impact 🚨
Not sure, probably tiny.
