### PR TITLE
Check for nulls before adding metadata to tracking map

### DIFF
--- a/airbyte-scheduler/scheduler-persistence/src/main/java/io/airbyte/scheduler/persistence/job_tracker/TrackingMetadata.java
+++ b/airbyte-scheduler/scheduler-persistence/src/main/java/io/airbyte/scheduler/persistence/job_tracker/TrackingMetadata.java
@@ -110,20 +110,30 @@ public class TrackingMetadata {
           final JobOutput jobOutput = lastAttempt.getOutput().get();
           if (jobOutput.getSync() != null) {
             final StandardSyncSummary syncSummary = jobOutput.getSync().getStandardSyncSummary();
-            metadata.put("sync_start_time", syncSummary.getStartTime());
-            metadata.put("duration", Math.round((syncSummary.getEndTime() - syncSummary.getStartTime()) / 1000.0));
-            metadata.put("volume_mb", syncSummary.getBytesSynced());
-            metadata.put("volume_rows", syncSummary.getRecordsSynced());
-            metadata.put("count_state_messages_from_source", syncSummary.getTotalStats().getSourceStateMessagesEmitted());
-            metadata.put("count_state_messages_from_destination", syncSummary.getTotalStats().getDestinationStateMessagesEmitted());
-            metadata.put("max_seconds_before_source_state_message_emitted",
-                syncSummary.getTotalStats().getMaxSecondsBeforeSourceStateMessageEmitted());
-            metadata.put("mean_seconds_before_source_state_message_emitted",
-                syncSummary.getTotalStats().getMeanSecondsBeforeSourceStateMessageEmitted());
-            metadata.put("max_seconds_between_state_message_emit_and_commit",
-                syncSummary.getTotalStats().getMaxSecondsBetweenStateMessageEmittedandCommitted());
-            metadata.put("mean_seconds_between_state_message_emit_and_commit",
-                syncSummary.getTotalStats().getMeanSecondsBetweenStateMessageEmittedandCommitted());
+            if (syncSummary.getStartTime() != null)
+              metadata.put("sync_start_time", syncSummary.getStartTime());
+            if (syncSummary.getEndTime() != null && syncSummary.getStartTime() != null)
+              metadata.put("duration", Math.round((syncSummary.getEndTime() - syncSummary.getStartTime()) / 1000.0));
+            if (syncSummary.getBytesSynced() != null)
+              metadata.put("volume_mb", syncSummary.getBytesSynced());
+            if (syncSummary.getRecordsSynced() != null)
+              metadata.put("volume_rows", syncSummary.getRecordsSynced());
+            if (syncSummary.getTotalStats().getSourceStateMessagesEmitted() != null)
+              metadata.put("count_state_messages_from_source", syncSummary.getTotalStats().getSourceStateMessagesEmitted());
+            if (syncSummary.getTotalStats().getDestinationStateMessagesEmitted() != null)
+              metadata.put("count_state_messages_from_destination", syncSummary.getTotalStats().getDestinationStateMessagesEmitted());
+            if (syncSummary.getTotalStats().getMaxSecondsBeforeSourceStateMessageEmitted() != null)
+              metadata.put("max_seconds_before_source_state_message_emitted",
+                  syncSummary.getTotalStats().getMaxSecondsBeforeSourceStateMessageEmitted());
+            if (syncSummary.getTotalStats().getMeanSecondsBeforeSourceStateMessageEmitted() != null)
+              metadata.put("mean_seconds_before_source_state_message_emitted",
+                  syncSummary.getTotalStats().getMeanSecondsBeforeSourceStateMessageEmitted());
+            if (syncSummary.getTotalStats().getMaxSecondsBetweenStateMessageEmittedandCommitted() != null)
+              metadata.put("max_seconds_between_state_message_emit_and_commit",
+                  syncSummary.getTotalStats().getMaxSecondsBetweenStateMessageEmittedandCommitted());
+            if (syncSummary.getTotalStats().getMeanSecondsBetweenStateMessageEmittedandCommitted() != null)
+              metadata.put("mean_seconds_between_state_message_emit_and_commit",
+                  syncSummary.getTotalStats().getMeanSecondsBetweenStateMessageEmittedandCommitted());
           }
         }
 

--- a/airbyte-scheduler/scheduler-persistence/src/test/java/io/airbyte/scheduler/persistence/job_tracker/TrackingMetadataTest.java
+++ b/airbyte-scheduler/scheduler-persistence/src/test/java/io/airbyte/scheduler/persistence/job_tracker/TrackingMetadataTest.java
@@ -8,9 +8,18 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
+import io.airbyte.config.JobOutput;
 import io.airbyte.config.ResourceRequirements;
 import io.airbyte.config.StandardSync;
+import io.airbyte.config.StandardSyncOutput;
+import io.airbyte.config.StandardSyncSummary;
+import io.airbyte.config.SyncStats;
 import io.airbyte.protocol.models.ConfiguredAirbyteCatalog;
+import io.airbyte.scheduler.models.Attempt;
+import io.airbyte.scheduler.models.AttemptStatus;
+import io.airbyte.scheduler.models.Job;
+import java.nio.file.Path;
+import java.util.List;
 import java.util.Map;
 import java.util.UUID;
 import org.junit.jupiter.api.Test;
@@ -41,6 +50,26 @@ class TrackingMetadataTest {
         "operation_count", 0,
         "table_prefix", false);
     final Map<String, Object> actual = TrackingMetadata.generateSyncMetadata(standardSync);
+    assertEquals(expected, actual);
+  }
+
+  @Test
+  void testgenerateJobAttemptMetadataWithNulls() {
+    final SyncStats syncStats = new SyncStats().withRecordsCommitted(10L).withRecordsEmitted(10L).withBytesEmitted(100L)
+        .withMeanSecondsBetweenStateMessageEmittedandCommitted(5L).withMaxSecondsBeforeSourceStateMessageEmitted(8L)
+        .withMeanSecondsBeforeSourceStateMessageEmitted(2L).withMaxSecondsBetweenStateMessageEmittedandCommitted(null);
+    final StandardSyncSummary standardSyncSummary = new StandardSyncSummary().withTotalStats(syncStats);
+    final StandardSyncOutput standardSyncOutput = new StandardSyncOutput().withStandardSyncSummary(standardSyncSummary);
+    final JobOutput jobOutput = new JobOutput().withSync(standardSyncOutput);
+    final Attempt attempt = new Attempt(0, 10L, Path.of("test"), jobOutput, AttemptStatus.SUCCEEDED, null, 100L, 100L, 99L);
+    final Job job = mock(Job.class);
+    when(job.getAttempts()).thenReturn(List.of(attempt));
+
+    final Map<String, Object> actual = TrackingMetadata.generateJobAttemptMetadata(job);
+    final Map<String, Object> expected = Map.of(
+        "mean_seconds_before_source_state_message_emitted", 2L,
+        "mean_seconds_between_state_message_emit_and_commit", 5L,
+        "max_seconds_before_source_state_message_emitted", 8L);
     assertEquals(expected, actual);
   }
 


### PR DESCRIPTION
Resolves https://github.com/airbytehq/alpha-beta-issues/issues/251

We should check for null before adding metrics to the map of metrics to track to prevent NPEs