### PR TITLE
Fix request new connector button

### DIFF
--- a/airbyte-webapp/src/components/base/DropDown/DropDown.tsx
+++ b/airbyte-webapp/src/components/base/DropDown/DropDown.tsx
@@ -1,5 +1,6 @@
 import React from "react";
 import { CSSObjectWithLabel, GroupBase, Props, SelectComponentsConfig, StylesConfig } from "react-select";
+import { PortalStyleArgs } from "react-select/dist/declarations/src/components/Menu";
 import Select from "react-select/dist/declarations/src/Select";
 
 import { equal, naturalComparatorBy } from "utils/objects";
@@ -56,8 +57,7 @@ function DropDownInner<T = unknown>(
 
   const styles: StylesConfig = {
     ...(props.styles ?? {}),
-    // eslint-disable-next-line @typescript-eslint/no-explicit-any
-    menuPortal: (base: CSSObjectWithLabel, menuPortalProps: any) => ({
+    menuPortal: (base: CSSObjectWithLabel, menuPortalProps: PortalStyleArgs) => ({
       ...(props.styles?.menuPortal?.(base, menuPortalProps) ?? { ...base }),
       zIndex: 9999,
     }),

--- a/airbyte-webapp/src/packages/cloud/views/workspaces/WorkspacePopout/WorkspacePopout.tsx
+++ b/airbyte-webapp/src/packages/cloud/views/workspaces/WorkspacePopout/WorkspacePopout.tsx
@@ -12,7 +12,7 @@ import { useCurrentWorkspace } from "services/workspaces/WorkspacesService";
 import ExitIcon from "./components/ExitIcon";
 
 const BottomElement = styled.div`
-  background: ${(props) => props.theme.greyColro0};
+  background: ${(props) => props.theme.greyColor0};
   padding: 12px 16px 12px;
   width: 100%;
   min-height: 34px;

--- a/airbyte-webapp/src/views/Connector/ServiceForm/components/Controls/ConnectorServiceTypeControl.tsx
+++ b/airbyte-webapp/src/views/Connector/ServiceForm/components/Controls/ConnectorServiceTypeControl.tsx
@@ -28,17 +28,16 @@ import { useDocumentationPanelContext } from "views/Connector/ConnectorDocumenta
 import { WarningMessage } from "../WarningMessage";
 
 const BottomElement = styled.div`
-  background: ${(props) => props.theme.greyColro0};
+  background: ${({ theme }) => theme.greyColor0};
   padding: 6px 16px 8px;
   width: 100%;
   min-height: 34px;
-  border-top: 1px solid ${(props) => props.theme.greyColor20};
-`;
+  border-top: 1px solid ${({ theme }) => theme.greyColor20};
+  position: relative;
 
-const Block = styled.div`
   cursor: pointer;
-  color: ${({ theme }) => theme.textColor};
 
+  color: ${({ theme }) => theme.textColor};
   &:hover {
     color: ${({ theme }) => theme.primaryColor};
   }
@@ -101,10 +100,10 @@ function getOrderForReleaseStage(stage?: ReleaseStage): number {
 const ConnectorList: React.FC<React.PropsWithChildren<MenuWithRequestButtonProps>> = ({ children, ...props }) => (
   <>
     <components.MenuList {...props}>{children}</components.MenuList>
-    <BottomElement>
-      <Block onClick={() => props.selectProps.selectProps.onOpenRequestConnectorModal(props.selectProps.inputValue)}>
-        <FormattedMessage id="connector.requestConnectorBlock" />
-      </Block>
+    <BottomElement
+      onClick={() => props.selectProps.selectProps.onOpenRequestConnectorModal(props.selectProps.inputValue)}
+    >
+      <FormattedMessage id="connector.requestConnectorBlock" />
     </BottomElement>
   </>
 );
@@ -201,8 +200,7 @@ const ConnectorServiceTypeControl: React.FC<ConnectorServiceTypeControlProps> = 
           }
           return naturalComparator(a.label, b.label);
         }),
-    // eslint-disable-next-line react-hooks/exhaustive-deps
-    [availableServices, orderOverwrite]
+    [availableConnectorDefinitions, orderOverwrite]
   );
 
   const { setDocumentationUrl } = useDocumentationPanelContext();


### PR DESCRIPTION
## What
The Request New Connector button was not taking clicks. Likely due to the react-select upgrade.
Resolves https://github.com/airbytehq/oncall/issues/630

## How
Setting `position: relative;` let it be interacted with again.

## 🚨 User Impact 🚨
This should not affect anything besides the problem 

## Scope Creep?
There are two changes outside the strict scope of the PR:
1. Typing an `any`
2. The problem component had a reference to `greyColro0` which does not exist. I fixed it there and in one other place.