### PR TITLE
Add email autofill from search params

### DIFF
--- a/airbyte-webapp/src/packages/cloud/views/auth/SignupPage/components/SignupForm.tsx
+++ b/airbyte-webapp/src/packages/cloud/views/auth/SignupPage/components/SignupForm.tsx
@@ -1,6 +1,7 @@
 import { Field, FieldProps, Formik } from "formik";
 import React, { useMemo } from "react";
 import { FormattedMessage, useIntl } from "react-intl";
+import { useSearchParams } from "react-router-dom";
 import styled from "styled-components";
 import * as yup from "yup";
 
@@ -195,15 +196,27 @@ export const SignupForm: React.FC = () => {
     return yup.object().shape(shape);
   }, [showName, showCompanyName]);
 
-  return (
-    <Formik<FormValues>
-      initialValues={{
+  const [params, _] = useSearchParams();
+  const search = Object.fromEntries(params);
+
+  const initialValues = params.get("email")
+    ? {
+        name: search.firstname ? `${search.firstname} ${search.lastname}` : "",
+        companyName: search.company,
+        email: search.email,
+        password: "",
+        news: true,
+      }
+    : {
         name: "",
         companyName: "",
         email: "",
         password: "",
         news: true,
-      }}
+      };
+  return (
+    <Formik<FormValues>
+      initialValues={initialValues}
       validationSchema={validationSchema}
       onSubmit={async (values, { setFieldError, setStatus }) =>
         signUp(values).catch((err) => {

--- a/airbyte-webapp/src/packages/cloud/views/auth/SignupPage/components/SignupForm.tsx
+++ b/airbyte-webapp/src/packages/cloud/views/auth/SignupPage/components/SignupForm.tsx
@@ -199,21 +199,13 @@ export const SignupForm: React.FC = () => {
   const [params] = useSearchParams();
   const search = Object.fromEntries(params);
 
-  const initialValues = params.get("email")
-    ? {
-        name: search.firstname ? `${search.firstname} ${search.lastname}` : "",
-        companyName: search.company,
-        email: search.email,
-        password: "",
-        news: true,
-      }
-    : {
-        name: "",
-        companyName: "",
-        email: "",
-        password: "",
-        news: true,
-      };
+  const initialValues = {
+    name: `${search.firstname ?? ""} ${search.lastname ?? ""}`.trim(),
+    companyName: search.company ?? "",
+    email: search.email ?? "",
+    password: "",
+    news: true,
+  };
   return (
     <Formik<FormValues>
       initialValues={initialValues}

--- a/airbyte-webapp/src/packages/cloud/views/auth/SignupPage/components/SignupForm.tsx
+++ b/airbyte-webapp/src/packages/cloud/views/auth/SignupPage/components/SignupForm.tsx
@@ -196,7 +196,7 @@ export const SignupForm: React.FC = () => {
     return yup.object().shape(shape);
   }, [showName, showCompanyName]);
 
-  const [params, _] = useSearchParams();
+  const [params] = useSearchParams();
   const search = Object.fromEntries(params);
 
   const initialValues = params.get("email")


### PR DESCRIPTION
## What
We are implementing a new form in airbyte.com homepage, to allow users enter their email directly in the homepage.
Then, when they submit that form they will be redirected to cloud.airbyte.io/signup?email=xxx&firstname=xxx.....
![Screen Shot 2022-09-20 at 6 28 59 PM](https://user-images.githubusercontent.com/45267095/191322277-194b6f8c-062b-428d-8c66-25995674f1a9.png)

This change allow us to read `searchParams` and pre-fill the form with known values preventing the user to have to enter those details again.
![Screen Shot 2022-09-20 at 7 18 31 PM](https://user-images.githubusercontent.com/45267095/191323047-a3964bcd-6880-4276-a2a5-892d4c6a3707.png)



Also, by interacting with a Hubspot form in `airbyte.com` we will be able to track that user properly in Hubspot.

## How
- read  `searchParams`
- build `initialValues` with values coming from `searchParams` if those exist


## 🚨 User Impact 🚨
Users will see the pre-fill values if coming from entering their email in the homepage.
