### PR TITLE
Fix primary key select

### DIFF
--- a/airbyte-webapp/src/components/base/Popout/Popout.tsx
+++ b/airbyte-webapp/src/components/base/Popout/Popout.tsx
@@ -1,5 +1,5 @@
 import React, { ReactNode, useMemo } from "react";
-import { ActionMeta, ControlProps } from "react-select";
+import { ActionMeta, ControlProps, StylesConfig } from "react-select";
 import { useToggle } from "react-use";
 import styled from "styled-components";
 
@@ -51,7 +51,7 @@ const Popout: React.FC<PopoutProps> = ({ onChange, targetComponent, ...props }) 
     [props.components]
   );
 
-  const selectStyles = {
+  const selectStyles: StylesConfig = {
     ...(props.styles ?? {}),
     control: (provided: Value) => ({
       ...provided,
@@ -65,7 +65,11 @@ const Popout: React.FC<PopoutProps> = ({ onChange, targetComponent, ...props }) 
       <DropDown
         selectProps={{
           targetComponent,
-          onOpen: toggleOpen,
+          onOpen: (e: React.MouseEvent<HTMLButtonElement>) => {
+            // Causes a form submit
+            e?.preventDefault();
+            toggleOpen();
+          },
         }}
         backspaceRemovesValue={false}
         controlShouldRenderValue={false}
@@ -73,6 +77,7 @@ const Popout: React.FC<PopoutProps> = ({ onChange, targetComponent, ...props }) 
         isClearable={false}
         menuIsOpen={isOpen}
         // menuPosition={"fixed"}
+        menuShouldBlockScroll={false}
         placeholder={null}
         tabSelectsValue={false}
         {...props}

--- a/airbyte-webapp/src/components/base/Popout/Popout.tsx
+++ b/airbyte-webapp/src/components/base/Popout/Popout.tsx
@@ -76,7 +76,6 @@ const Popout: React.FC<PopoutProps> = ({ onChange, targetComponent, ...props }) 
         hideSelectedOptions={false}
         isClearable={false}
         menuIsOpen={isOpen}
-        // menuPosition={"fixed"}
         menuShouldBlockScroll={false}
         placeholder={null}
         tabSelectsValue={false}

--- a/airbyte-webapp/src/views/Connection/ConnectionForm/ConnectionForm.tsx
+++ b/airbyte-webapp/src/views/Connection/ConnectionForm/ConnectionForm.tsx
@@ -234,7 +234,7 @@ export const ConnectionForm: React.FC<ConnectionFormProps> = ({
                 onCancel?.();
               }}
               successMessage={successMessage}
-              errorMessage={errorMessage}
+              errorMessage={!isValid && errorMessage}
               enableControls={canSubmitUntouchedForm}
             />
           )}
@@ -247,7 +247,7 @@ export const ConnectionForm: React.FC<ConnectionFormProps> = ({
               <CreateControls
                 isSubmitting={isSubmitting}
                 isValid={isValid && !editingTransformation}
-                errorMessage={errorMessage}
+                errorMessage={!isValid && errorMessage}
               />
             </>
           )}


### PR DESCRIPTION
## What
Fix primary key selection on replication view
Resolves https://github.com/airbytehq/oncall/issues/634

## How
The DropDown component adds a complete-screen DOM element to prevent scrolling which conflicted with our "click outside to exit" DOM element. By telling the DropDown not to block scrolling it removes the conflict.
Playing with the z-index did not yield fruitful results.

## 🚨 User Impact 🚨
This affects dropdowns so there's always a chance for regression.
#16934 is in the same space so it will be important to test both throughly!