### PR TITLE
Allow scheduleData to be set for connection updates that set scheduleType to manual

### DIFF
--- a/airbyte-server/src/main/java/io/airbyte/server/handlers/ConnectionsHandler.java
+++ b/airbyte-server/src/main/java/io/airbyte/server/handlers/ConnectionsHandler.java
@@ -333,9 +333,6 @@ public class ConnectionsHandler {
           "ConnectionUpdate should not include any scheduleData without also specifying a valid scheduleType.");
     } else {
       switch (patch.getScheduleType()) {
-        case MANUAL -> Preconditions.checkArgument(
-            patch.getScheduleData() == null,
-            "ConnectionUpdate should not include any scheduleData when setting the Connection scheduleType to MANUAL.");
         case BASIC -> Preconditions.checkArgument(
             patch.getScheduleData() != null,
             "ConnectionUpdate should include scheduleData when setting the Connection scheduleType to BASIC.");

--- a/airbyte-server/src/main/java/io/airbyte/server/handlers/helpers/ConnectionScheduleHelper.java
+++ b/airbyte-server/src/main/java/io/airbyte/server/handlers/helpers/ConnectionScheduleHelper.java
@@ -35,6 +35,7 @@ public class ConnectionScheduleHelper {
     switch (scheduleType) {
       // NOTE: the `manual` column is marked required, so we populate it until it's removed.
       case MANUAL -> {
+        // ignore the scheduleData from the request and always insert null for manual schedules
         standardSync.withScheduleType(ScheduleType.MANUAL).withScheduleData(null).withManual(true);
 
         // explicitly null out the legacy `schedule` column until it's removed.


### PR DESCRIPTION
## What
This validation is breaking the front-end, which currently sends the existing scheduleData when setting scheduleType to MANUAL, instead of sending null like initially expected.

## How
Remove the precondition check for null scheduleData.

