### PR TITLE
Allow frequency selection to be set to Manual

### DIFF
--- a/airbyte-webapp/src/hooks/services/Connection/ConnectionFormService.tsx
+++ b/airbyte-webapp/src/hooks/services/Connection/ConnectionFormService.tsx
@@ -54,7 +54,7 @@ const useConnectionForm = ({
   const onFormSubmit = useCallback(
     async (values: FormikConnectionFormValues, formikHelpers: FormikHelpers<FormikConnectionFormValues>) => {
       // Set the scheduleType based on the schedule value
-      values["scheduleType"] = values.scheduleData?.basicSchedule
+      values.scheduleType = values.scheduleData?.basicSchedule
         ? ConnectionScheduleType.basic
         : ConnectionScheduleType.manual;
 
@@ -65,6 +65,11 @@ const useConnectionForm = ({
       }) as unknown as ConnectionFormValues;
 
       formValues.operations = mapFormPropsToOperation(values, connection.operations, workspaceId);
+
+      if (formValues.scheduleType === ConnectionScheduleType.manual) {
+        // Have to set this to undefined to override the existing scheduleData
+        formValues.scheduleData = undefined;
+      }
 
       setSubmitError(null);
       try {

--- a/airbyte-webapp/src/hooks/services/Connection/ConnectionFormService.tsx
+++ b/airbyte-webapp/src/hooks/services/Connection/ConnectionFormService.tsx
@@ -54,7 +54,7 @@ const useConnectionForm = ({
   const onFormSubmit = useCallback(
     async (values: FormikConnectionFormValues, formikHelpers: FormikHelpers<FormikConnectionFormValues>) => {
       // Set the scheduleType based on the schedule value
-      values.scheduleType = values.scheduleData?.basicSchedule
+      values["scheduleType"] = values.scheduleData?.basicSchedule
         ? ConnectionScheduleType.basic
         : ConnectionScheduleType.manual;
 

--- a/airbyte-webapp/src/hooks/services/useConnectionHook.tsx
+++ b/airbyte-webapp/src/hooks/services/useConnectionHook.tsx
@@ -36,7 +36,7 @@ export const connectionsKeys = {
 
 export interface ValuesProps {
   name?: string;
-  scheduleData: ConnectionScheduleData;
+  scheduleData: ConnectionScheduleData | undefined;
   scheduleType: ConnectionScheduleType;
   prefix: string;
   syncCatalog: SyncSchema;


### PR DESCRIPTION
## What
Setting the frequency type to manually did not null (`undefined`) out the schedule data preventing it from saving. It now correctly does so.

Resolves https://github.com/airbytehq/oncall/issues/642

## How
Manually sets `scheduleData` to `undefined` so it's nulled out in the backend.

## 🚨 User Impact 🚨
Changing the schedule type should be fixed. I don't anticipate anything broken from these changes.