### PR TITLE
:window: :wrench: Use PATCH Api for toggling connections

### DIFF
--- a/airbyte-webapp/src/components/EntityTable/ConnectionTable.tsx
+++ b/airbyte-webapp/src/components/EntityTable/ConnectionTable.tsx
@@ -28,11 +28,10 @@ interface IProps {
   data: ITableDataItem[];
   entity: "source" | "destination" | "connection";
   onClickRow?: (data: ITableDataItem) => void;
-  onChangeStatus: (id: string) => void;
   onSync: (id: string) => void;
 }
 
-const ConnectionTable: React.FC<IProps> = ({ data, entity, onClickRow, onChangeStatus, onSync }) => {
+const ConnectionTable: React.FC<IProps> = ({ data, entity, onClickRow, onSync }) => {
   const navigate = useNavigate();
   const query = useQuery<{ sortBy?: string; order?: SortOrderEnum }>();
   const allowSync = useFeature(FeatureItem.AllowSync);
@@ -177,7 +176,6 @@ const ConnectionTable: React.FC<IProps> = ({ data, entity, onClickRow, onChangeS
             id={row.original.connectionId}
             isSyncing={row.original.isSyncing}
             isManual={row.original.scheduleType === ConnectionScheduleType.manual}
-            onChangeStatus={onChangeStatus}
             onSync={onSync}
             allowSync={allowSync}
           />
@@ -190,7 +188,7 @@ const ConnectionTable: React.FC<IProps> = ({ data, entity, onClickRow, onChangeS
         Cell: ({ cell }: CellProps<ITableDataItem>) => <ConnectionSettingsCell id={cell.value} />,
       },
     ],
-    [allowSync, entity, onChangeStatus, onSync, onSortClick, sortBy, sortOrder]
+    [allowSync, entity, onSync, onSortClick, sortBy, sortOrder]
   );
 
   return (

--- a/airbyte-webapp/src/components/EntityTable/components/StatusCell.tsx
+++ b/airbyte-webapp/src/components/EntityTable/components/StatusCell.tsx
@@ -5,13 +5,14 @@ import styled from "styled-components";
 
 import { LoadingButton, Switch } from "components";
 
+import { useEnableConnection } from "hooks/services/useConnectionHook";
+
 interface IProps {
   allowSync?: boolean;
   enabled?: boolean;
   isSyncing?: boolean;
   isManual?: boolean;
   id: string;
-  onChangeStatus: (id: string) => void;
   onSync: (id: string) => void;
 }
 
@@ -23,16 +24,21 @@ const ProgressMessage = styled.div`
   padding: 7px 0;
 `;
 
-const StatusCell: React.FC<IProps> = ({ enabled, isManual, id, onChangeStatus, isSyncing, onSync, allowSync }) => {
+const StatusCell: React.FC<IProps> = ({ enabled, isManual, id, isSyncing, onSync, allowSync }) => {
+  const { mutateAsync: enableConnection, isLoading } = useEnableConnection();
+
   const [{ loading }, OnLaunch] = useAsyncFn(async (event: React.SyntheticEvent) => {
     event.stopPropagation();
-    await onSync(id);
+    onSync(id);
   }, []);
 
   if (!isManual) {
-    const onSwitchChange = (event: React.SyntheticEvent) => {
+    const onSwitchChange = async (event: React.SyntheticEvent) => {
       event.stopPropagation();
-      onChangeStatus(id);
+      await enableConnection({
+        connectionId: id,
+        enable: !enabled,
+      });
     };
 
     return (
@@ -42,7 +48,7 @@ const StatusCell: React.FC<IProps> = ({ enabled, isManual, id, onChangeStatus, i
         onClick={(event: React.SyntheticEvent) => event.stopPropagation()}
         onKeyPress={(event: React.SyntheticEvent) => event.stopPropagation()}
       >
-        <Switch checked={enabled} onChange={onSwitchChange} disabled={!allowSync} />
+        <Switch checked={enabled} onChange={onSwitchChange} disabled={!allowSync} loading={isLoading} />
       </div>
     );
   }

--- a/airbyte-webapp/src/components/EntityTable/hooks.tsx
+++ b/airbyte-webapp/src/components/EntityTable/hooks.tsx
@@ -1,45 +1,16 @@
-import { getFrequencyType } from "config/utils";
-import { Action, Namespace } from "core/analytics";
-import { buildConnectionUpdate } from "core/domain/connection";
-import { useAnalyticsService } from "hooks/services/Analytics";
-import { useSyncConnection, useUpdateConnection } from "hooks/services/useConnectionHook";
+import { useSyncConnection } from "hooks/services/useConnectionHook";
 
-import { ConnectionStatus, WebBackendConnectionRead } from "../../core/request/AirbyteClient";
+import { WebBackendConnectionRead } from "../../core/request/AirbyteClient";
 
 const useSyncActions = (): {
-  changeStatus: (connection: WebBackendConnectionRead) => Promise<void>;
   syncManualConnection: (connection: WebBackendConnectionRead) => Promise<void>;
 } => {
-  const { mutateAsync: updateConnection } = useUpdateConnection();
   const { mutateAsync: syncConnection } = useSyncConnection();
-  const analyticsService = useAnalyticsService();
-
-  const changeStatus = async (connection: WebBackendConnectionRead) => {
-    await updateConnection(
-      buildConnectionUpdate(connection, {
-        status: connection.status === ConnectionStatus.active ? ConnectionStatus.inactive : ConnectionStatus.active,
-      })
-    );
-
-    const enabledStreams = connection.syncCatalog.streams.filter((stream) => stream.config?.selected).length;
-
-    const trackableAction = connection.status === ConnectionStatus.active ? Action.DISABLE : Action.REENABLE;
-
-    analyticsService.track(Namespace.CONNECTION, trackableAction, {
-      frequency: getFrequencyType(connection.scheduleData?.basicSchedule),
-      connector_source: connection.source?.sourceName,
-      connector_source_definition_id: connection.source?.sourceDefinitionId,
-      connector_destination: connection.destination?.destinationName,
-      connector_destination_definition_id: connection.destination?.destinationDefinitionId,
-      available_streams: connection.syncCatalog.streams.length,
-      enabled_streams: enabledStreams,
-    });
-  };
 
   const syncManualConnection = async (connection: WebBackendConnectionRead) => {
     await syncConnection(connection);
   };
 
-  return { changeStatus, syncManualConnection };
+  return { syncManualConnection };
 };
 export default useSyncActions;

--- a/airbyte-webapp/src/hooks/services/useConnectionHook.tsx
+++ b/airbyte-webapp/src/hooks/services/useConnectionHook.tsx
@@ -200,15 +200,15 @@ const useUpdateConnection = () => {
   const queryClient = useQueryClient();
 
   return useMutation((connectionUpdate: WebBackendConnectionUpdate) => service.update(connectionUpdate), {
-    onSuccess: (connection) => {
-      queryClient.setQueryData(connectionsKeys.detail(connection.connectionId), connection);
+    onSuccess: (updatedConnection) => {
+      queryClient.setQueryData(connectionsKeys.detail(updatedConnection.connectionId), updatedConnection);
       // Update the connection inside the connections list response
       queryClient.setQueryData<ListConnection>(connectionsKeys.lists(), (ls) => ({
         ...ls,
         connections:
           ls?.connections.map((conn) => {
-            if (conn.connectionId === connection.connectionId) {
-              return connection;
+            if (conn.connectionId === updatedConnection.connectionId) {
+              return updatedConnection;
             }
             return conn;
           }) ?? [],

--- a/airbyte-webapp/src/hooks/services/useConnectionHook.tsx
+++ b/airbyte-webapp/src/hooks/services/useConnectionHook.tsx
@@ -1,5 +1,5 @@
 import { useCallback } from "react";
-import { QueryClient, useMutation, useQueryClient } from "react-query";
+import { useMutation, useQueryClient } from "react-query";
 
 import { getFrequencyType } from "config/utils";
 import { Action, Namespace } from "core/analytics";
@@ -12,6 +12,7 @@ import { useConfig } from "../../config";
 import {
   ConnectionScheduleData,
   ConnectionScheduleType,
+  ConnectionStatus,
   DestinationRead,
   NamespaceDefinitionType,
   OperationCreate,
@@ -201,8 +202,47 @@ const useUpdateConnection = () => {
   return useMutation((connectionUpdate: WebBackendConnectionUpdate) => service.update(connectionUpdate), {
     onSuccess: (connection) => {
       queryClient.setQueryData(connectionsKeys.detail(connection.connectionId), connection);
+      // Update the connection inside the connections list response
+      queryClient.setQueryData<ListConnection>(connectionsKeys.lists(), (ls) => ({
+        ...ls,
+        connections:
+          ls?.connections.map((conn) => {
+            if (conn.connectionId === connection.connectionId) {
+              return connection;
+            }
+            return conn;
+          }) ?? [],
+      }));
     },
   });
+};
+
+/**
+ * Sets the enable/disable status of a connection. It will use the useConnectionUpdate method
+ * to make sure all caches are properly updated, but in addition will trigger the Reenable/Disable
+ * analytic event.
+ */
+export const useEnableConnection = () => {
+  const analyticsService = useAnalyticsService();
+  const { mutateAsync: updateConnection } = useUpdateConnection();
+
+  return useMutation(
+    ({ connectionId, enable }: { connectionId: WebBackendConnectionUpdate["connectionId"]; enable: boolean }) =>
+      updateConnection({ connectionId, status: enable ? ConnectionStatus.active : ConnectionStatus.inactive }),
+    {
+      onSuccess: (connection) => {
+        const action = connection.status === ConnectionStatus.active ? Action.REENABLE : Action.DISABLE;
+
+        analyticsService.track(Namespace.CONNECTION, action, {
+          frequency: getFrequencyType(connection.scheduleData?.basicSchedule),
+          connector_source: connection.source?.sourceName,
+          connector_source_definition_id: connection.source?.sourceDefinitionId,
+          connector_destination: connection.destination?.destinationName,
+          connector_destination_definition_id: connection.destination?.destinationDefinitionId,
+        });
+      },
+    }
+  );
 };
 
 export const useRemoveConnectionsFromList = (): ((connectionIds: string[]) => void) => {
@@ -226,10 +266,6 @@ const useConnectionList = (): ListConnection => {
   return useSuspenseQuery(connectionsKeys.lists(), () => service.list(workspace.workspaceId));
 };
 
-const invalidateConnectionsList = async (queryClient: QueryClient) => {
-  await queryClient.invalidateQueries(connectionsKeys.lists());
-};
-
 const useGetConnectionState = (connectionId: string) => {
   const service = useConnectionService();
 
@@ -242,6 +278,5 @@ export {
   useUpdateConnection,
   useCreateConnection,
   useDeleteConnection,
-  invalidateConnectionsList,
   useGetConnectionState,
 };

--- a/airbyte-webapp/src/pages/ConnectionPage/pages/AllConnectionsPage/components/ConnectionsTable.tsx
+++ b/airbyte-webapp/src/pages/ConnectionPage/pages/AllConnectionsPage/components/ConnectionsTable.tsx
@@ -1,5 +1,4 @@
 import React, { useCallback } from "react";
-import { useQueryClient } from "react-query";
 import { useNavigate } from "react-router-dom";
 
 import { ConnectionTable } from "components/EntityTable";
@@ -7,7 +6,6 @@ import useSyncActions from "components/EntityTable/hooks";
 import { ITableDataItem } from "components/EntityTable/types";
 import { getConnectionTableData } from "components/EntityTable/utils";
 
-import { invalidateConnectionsList } from "hooks/services/useConnectionHook";
 import { useDestinationDefinitionList } from "services/connector/DestinationDefinitionService";
 import { useSourceDefinitionList } from "services/connector/SourceDefinitionService";
 
@@ -19,26 +17,13 @@ interface IProps {
 
 const ConnectionsTable: React.FC<IProps> = ({ connections }) => {
   const navigate = useNavigate();
-  const { changeStatus, syncManualConnection } = useSyncActions();
-  const queryClient = useQueryClient();
+  const { syncManualConnection } = useSyncActions();
 
   const { sourceDefinitions } = useSourceDefinitionList();
 
   const { destinationDefinitions } = useDestinationDefinitionList();
 
   const data = getConnectionTableData(connections, sourceDefinitions, destinationDefinitions, "connection");
-
-  const onChangeStatus = useCallback(
-    async (connectionId: string) => {
-      const connection = connections.find((item) => item.connectionId === connectionId);
-
-      if (connection) {
-        await changeStatus(connection);
-        await invalidateConnectionsList(queryClient);
-      }
-    },
-    [changeStatus, connections, queryClient]
-  );
 
   const onSync = useCallback(
     async (connectionId: string) => {
@@ -52,15 +37,7 @@ const ConnectionsTable: React.FC<IProps> = ({ connections }) => {
 
   const clickRow = (source: ITableDataItem) => navigate(`${source.connectionId}`);
 
-  return (
-    <ConnectionTable
-      data={data}
-      onClickRow={clickRow}
-      entity="connection"
-      onChangeStatus={onChangeStatus}
-      onSync={onSync}
-    />
-  );
+  return <ConnectionTable data={data} onClickRow={clickRow} entity="connection" onSync={onSync} />;
 };
 
 export default ConnectionsTable;

--- a/airbyte-webapp/src/pages/DestinationPage/pages/DestinationItemPage/components/DestinationConnectionTable.tsx
+++ b/airbyte-webapp/src/pages/DestinationPage/pages/DestinationItemPage/components/DestinationConnectionTable.tsx
@@ -1,5 +1,4 @@
 import React, { useCallback } from "react";
-import { useQueryClient } from "react-query";
 import { useNavigate } from "react-router-dom";
 
 import { ConnectionTable } from "components/EntityTable";
@@ -7,7 +6,6 @@ import useSyncActions from "components/EntityTable/hooks";
 import { ITableDataItem } from "components/EntityTable/types";
 import { getConnectionTableData } from "components/EntityTable/utils";
 
-import { invalidateConnectionsList } from "hooks/services/useConnectionHook";
 import { RoutePaths } from "pages/routePaths";
 import { useDestinationDefinitionList } from "services/connector/DestinationDefinitionService";
 import { useSourceDefinitionList } from "services/connector/SourceDefinitionService";
@@ -20,25 +18,12 @@ interface IProps {
 
 const DestinationConnectionTable: React.FC<IProps> = ({ connections }) => {
   const navigate = useNavigate();
-  const queryClient = useQueryClient();
-  const { changeStatus, syncManualConnection } = useSyncActions();
+  const { syncManualConnection } = useSyncActions();
 
   const { sourceDefinitions } = useSourceDefinitionList();
   const { destinationDefinitions } = useDestinationDefinitionList();
 
   const data = getConnectionTableData(connections, sourceDefinitions, destinationDefinitions, "destination");
-
-  const onChangeStatus = useCallback(
-    async (connectionId: string) => {
-      const connection = connections.find((item) => item.connectionId === connectionId);
-
-      if (connection) {
-        await changeStatus(connection);
-        await invalidateConnectionsList(queryClient);
-      }
-    },
-    [changeStatus, connections, queryClient]
-  );
 
   const onSync = useCallback(
     async (connectionId: string) => {
@@ -52,15 +37,7 @@ const DestinationConnectionTable: React.FC<IProps> = ({ connections }) => {
 
   const clickRow = (source: ITableDataItem) => navigate(`../../../${RoutePaths.Connections}/${source.connectionId}`);
 
-  return (
-    <ConnectionTable
-      data={data}
-      onClickRow={clickRow}
-      entity="destination"
-      onChangeStatus={onChangeStatus}
-      onSync={onSync}
-    />
-  );
+  return <ConnectionTable data={data} onClickRow={clickRow} entity="destination" onSync={onSync} />;
 };
 
 export default DestinationConnectionTable;

--- a/airbyte-webapp/src/pages/SourcesPage/pages/SourceItemPage/components/SourceConnectionTable.tsx
+++ b/airbyte-webapp/src/pages/SourcesPage/pages/SourceItemPage/components/SourceConnectionTable.tsx
@@ -1,5 +1,4 @@
 import React, { useCallback } from "react";
-import { useQueryClient } from "react-query";
 import { useNavigate } from "react-router-dom";
 
 import { ConnectionTable } from "components/EntityTable";
@@ -7,7 +6,6 @@ import useSyncActions from "components/EntityTable/hooks";
 import { ITableDataItem } from "components/EntityTable/types";
 import { getConnectionTableData } from "components/EntityTable/utils";
 
-import { invalidateConnectionsList } from "hooks/services/useConnectionHook";
 import { RoutePaths } from "pages/routePaths";
 import { useDestinationDefinitionList } from "services/connector/DestinationDefinitionService";
 import { useSourceDefinitionList } from "services/connector/SourceDefinitionService";
@@ -20,26 +18,13 @@ interface IProps {
 
 const SourceConnectionTable: React.FC<IProps> = ({ connections }) => {
   const navigate = useNavigate();
-  const queryClient = useQueryClient();
-  const { changeStatus, syncManualConnection } = useSyncActions();
+  const { syncManualConnection } = useSyncActions();
 
   const { sourceDefinitions } = useSourceDefinitionList();
 
   const { destinationDefinitions } = useDestinationDefinitionList();
 
   const data = getConnectionTableData(connections, sourceDefinitions, destinationDefinitions, "source");
-
-  const onChangeStatus = useCallback(
-    async (connectionId: string) => {
-      const connection = connections.find((item) => item.connectionId === connectionId);
-
-      if (connection) {
-        await changeStatus(connection);
-        await invalidateConnectionsList(queryClient);
-      }
-    },
-    [changeStatus, connections, queryClient]
-  );
 
   const onSync = useCallback(
     async (connectionId: string) => {
@@ -53,15 +38,7 @@ const SourceConnectionTable: React.FC<IProps> = ({ connections }) => {
 
   const clickRow = (source: ITableDataItem) => navigate(`../../../${RoutePaths.Connections}/${source.connectionId}`);
 
-  return (
-    <ConnectionTable
-      data={data}
-      onClickRow={clickRow}
-      entity="source"
-      onChangeStatus={onChangeStatus}
-      onSync={onSync}
-    />
-  );
+  return <ConnectionTable data={data} onClickRow={clickRow} entity="source" onSync={onSync} />;
 };
 
 export default SourceConnectionTable;


### PR DESCRIPTION
## What

Part of https://github.com/airbytehq/airbyte/issues/15669

To prepare for removing the `syncCatalog` from the connection list API, we're switching over the enable/disable switch in the table to no longer send the full connection object as an update, but only the `status`.

This also introduced proper loading state for the switch inside the table.

## How

This creates a new `useEnableConnection` hook, which can be used in addition to the `useUpdateConnection` to just enable/disable the connection, which will also trigger the correct analytics event in this case.

This moves the logic to toggle down into the StatusCell, to no longer need to property drill through several layers there (which was originally done to have access to the `connection`, which we won't need now anymore with the update being PATCH and the analytic event moved to the hook). We removed two properties from the event as well, since they require the `syncCatalog` which is planned to get rid of in this place (see originally linked issue).