### PR TITLE
Show "source defined" as cursor for CDC streams, move strings to i18n

### DIFF
--- a/airbyte-webapp/src/core/domain/catalog/fieldUtil.ts
+++ b/airbyte-webapp/src/core/domain/catalog/fieldUtil.ts
@@ -1,13 +1,12 @@
 import { JSONSchema7Definition } from "json-schema";
 
-import { NamespaceDefinitionType } from "../../request/AirbyteClient";
 import { SyncSchemaField } from "./models";
 
 type AirbyteJsonSchema = JSONSchema7Definition & {
   airbyte_type?: string;
 };
 
-const traverseSchemaToField = (
+export const traverseSchemaToField = (
   jsonSchema: AirbyteJsonSchema | undefined,
   key: string | undefined
 ): SyncSchemaField[] => {
@@ -46,24 +45,3 @@ const traverseJsonSchemaProperties = (
     },
   ];
 };
-
-interface NamespaceOptions {
-  namespaceDefinition:
-    | typeof NamespaceDefinitionType.source
-    | typeof NamespaceDefinitionType.destination
-    | typeof NamespaceDefinitionType.customformat;
-  namespaceFormat?: string;
-}
-
-function getDestinationNamespace(opt: NamespaceOptions) {
-  switch (opt.namespaceDefinition) {
-    case NamespaceDefinitionType.source:
-      return "<source schema>";
-    case NamespaceDefinitionType.destination:
-      return "<destination schema>";
-    case NamespaceDefinitionType.customformat:
-      return opt.namespaceFormat;
-  }
-}
-
-export { getDestinationNamespace, traverseSchemaToField };

--- a/airbyte-webapp/src/hooks/connection/useDestinationNamespace.ts
+++ b/airbyte-webapp/src/hooks/connection/useDestinationNamespace.ts
@@ -1,0 +1,24 @@
+import { useIntl } from "react-intl";
+
+import { NamespaceDefinitionType } from "core/request/AirbyteClient";
+
+interface NamespaceOptions {
+  namespaceDefinition:
+    | typeof NamespaceDefinitionType.source
+    | typeof NamespaceDefinitionType.destination
+    | typeof NamespaceDefinitionType.customformat;
+  namespaceFormat?: string;
+}
+
+export const useDestinationNamespace = (opt: NamespaceOptions): string | undefined => {
+  const { formatMessage } = useIntl();
+
+  switch (opt.namespaceDefinition) {
+    case NamespaceDefinitionType.source:
+      return formatMessage({ id: "connection.catalogTree.sourceSchema" });
+    case NamespaceDefinitionType.destination:
+      return formatMessage({ id: "connection.catalogTree.destinationSchema" });
+    case NamespaceDefinitionType.customformat:
+      return opt.namespaceFormat;
+  }
+};

--- a/airbyte-webapp/src/locales/en.json
+++ b/airbyte-webapp/src/locales/en.json
@@ -346,7 +346,9 @@
   "connection.updateSchema.namespace": "Namespace",
   "connection.updateSchema.dataType": "Data type",
 
-  "connection.catalogTree.sourceDefined": "source defined",
+  "connection.catalogTree.sourceDefined": "<source defined>",
+  "connection.catalogTree.sourceSchema": "<source schema>",
+  "connection.catalogTree.destinationSchema": "<destination schema>",
 
   "connection.newConnection": "+ New connection",
   "connection.newConnectionTitle": "New connection",

--- a/airbyte-webapp/src/locales/en.json
+++ b/airbyte-webapp/src/locales/en.json
@@ -346,6 +346,8 @@
   "connection.updateSchema.namespace": "Namespace",
   "connection.updateSchema.dataType": "Data type",
 
+  "connection.catalogTree.sourceDefined": "source defined",
+
   "connection.newConnection": "+ New connection",
   "connection.newConnectionTitle": "New connection",
   "connection.noConnections": "Connection list is empty",

--- a/airbyte-webapp/src/views/Connection/CatalogTree/CatalogSection.tsx
+++ b/airbyte-webapp/src/views/Connection/CatalogTree/CatalogSection.tsx
@@ -4,8 +4,9 @@ import { useToggle } from "react-use";
 
 import { DropDownRow } from "components";
 
-import { getDestinationNamespace, SyncSchemaField, SyncSchemaFieldObject, SyncSchemaStream } from "core/domain/catalog";
+import { SyncSchemaField, SyncSchemaFieldObject, SyncSchemaStream } from "core/domain/catalog";
 import { traverseSchemaToField } from "core/domain/catalog/fieldUtil";
+import { useDestinationNamespace } from "hooks/connection/useDestinationNamespace";
 import { useConnectionFormService } from "hooks/services/Connection/ConnectionFormService";
 import { equal, naturalComparatorBy } from "utils/objects";
 import { ConnectionFormValues, SUPPORTED_MODES } from "views/Connection/ConnectionForm/formConfig";
@@ -106,7 +107,7 @@ const CatalogSectionInner: React.FC<CatalogSectionInnerProps> = ({
     [stream?.supportedSyncModes, supportedDestinationSyncModes]
   );
 
-  const destNamespace = getDestinationNamespace({
+  const destNamespace = useDestinationNamespace({
     namespaceDefinition,
     namespaceFormat,
   });

--- a/airbyte-webapp/src/views/Connection/CatalogTree/components/PathPopout.tsx
+++ b/airbyte-webapp/src/views/Connection/CatalogTree/components/PathPopout.tsx
@@ -1,4 +1,5 @@
 import React from "react";
+import { useIntl } from "react-intl";
 
 import { Popout } from "components";
 import { Tooltip } from "components/base/Tooltip";
@@ -34,6 +35,13 @@ interface PathProps {
 
 type PathPopoutProps = PathPopoutBaseProps & (PathMultiProps | PathProps);
 
+const SourceDefinedPath: React.FC = () => {
+  const { formatMessage } = useIntl();
+  const message = formatMessage({ id: "connection.catalogTree.sourceDefined" });
+
+  return <>{`<${message}>`}</>;
+};
+
 export const PathPopout: React.FC<PathPopoutProps> = (props) => {
   if (props.pathType === "sourceDefined") {
     if (props.path && props.path.length > 0) {
@@ -45,7 +53,8 @@ export const PathPopout: React.FC<PathPopoutProps> = (props) => {
         </Tooltip>
       );
     }
-    return <>{"<source defined>"}</>;
+
+    return <SourceDefinedPath />;
   }
 
   const text = props.path

--- a/airbyte-webapp/src/views/Connection/CatalogTree/components/PathPopout.tsx
+++ b/airbyte-webapp/src/views/Connection/CatalogTree/components/PathPopout.tsx
@@ -1,5 +1,5 @@
 import React from "react";
-import { useIntl } from "react-intl";
+import { FormattedMessage } from "react-intl";
 
 import { Popout } from "components";
 import { Tooltip } from "components/base/Tooltip";
@@ -35,13 +35,6 @@ interface PathProps {
 
 type PathPopoutProps = PathPopoutBaseProps & (PathMultiProps | PathProps);
 
-const SourceDefinedPath: React.FC = () => {
-  const { formatMessage } = useIntl();
-  const message = formatMessage({ id: "connection.catalogTree.sourceDefined" });
-
-  return <>{`<${message}>`}</>;
-};
-
 export const PathPopout: React.FC<PathPopoutProps> = (props) => {
   if (props.pathType === "sourceDefined") {
     if (props.path && props.path.length > 0) {
@@ -54,7 +47,7 @@ export const PathPopout: React.FC<PathPopoutProps> = (props) => {
       );
     }
 
-    return <SourceDefinedPath />;
+    return <FormattedMessage id="connection.catalogTree.sourceDefined" />;
   }
 
   const text = props.path

--- a/airbyte-webapp/src/views/Connection/CatalogTree/components/PathPopout.tsx
+++ b/airbyte-webapp/src/views/Connection/CatalogTree/components/PathPopout.tsx
@@ -36,12 +36,8 @@ type PathPopoutProps = PathPopoutBaseProps & (PathMultiProps | PathProps);
 
 export const PathPopout: React.FC<PathPopoutProps> = (props) => {
   if (props.pathType === "sourceDefined") {
-    if (props.path) {
-      const text = props.path
-        ? props.isMulti
-          ? props.path.map(pathDisplayName).join(", ")
-          : pathDisplayName(props.path)
-        : "";
+    if (props.path && props.path.length > 0) {
+      const text = props.isMulti ? props.path.map(pathDisplayName).join(", ") : pathDisplayName(props.path);
 
       return (
         <Tooltip placement="bottom-start" control={<div className={styles.text}>{text}</div>}>
@@ -49,7 +45,7 @@ export const PathPopout: React.FC<PathPopoutProps> = (props) => {
         </Tooltip>
       );
     }
-    return <>{"<sourceDefined>"}</>;
+    return <>{"<source defined>"}</>;
   }
 
   const text = props.path


### PR DESCRIPTION
## What
Resolves #15448

This fixes an issue where the `<source defined>` string was not showing for CDC streams.
![Screen Shot 2022-09-21 at 15 22 20](https://user-images.githubusercontent.com/168664/191592658-ca31f339-eba8-4366-b993-c0eccf2be42b.png)

Additionally, some of the strings used were not in the en file, and they have been moved.

## How
The implementation was always there, but it wasn't checking for a certain condition where the path was an empty array.

## Recommended reading order
1. `PathPopout.tsx`
2. `CatalogSection.tsx`

