### PR TITLE
:window: :bug: Fix error message with missing docs

### DIFF
--- a/airbyte-webapp/src/components/DocumentationPanel/DocumentationPanel.tsx
+++ b/airbyte-webapp/src/components/DocumentationPanel/DocumentationPanel.tsx
@@ -21,7 +21,7 @@ export const DocumentationPanel: React.FC = () => {
   const { formatMessage } = useIntl();
   const config = useConfig();
   const { setDocumentationPanelOpen, documentationUrl } = useDocumentationPanelContext();
-  const { data: docs, isLoading } = useDocumentation(documentationUrl);
+  const { data: docs, isLoading, error } = useDocumentation(documentationUrl);
 
   // @ts-expect-error rehype-slug currently has type conflicts due to duplicate vfile dependencies
   const urlReplacerPlugin: PluggableList = useMemo<PluggableList>(() => {
@@ -55,7 +55,7 @@ export const DocumentationPanel: React.FC = () => {
       <PageTitle withLine title={<FormattedMessage id="connector.setupGuide" />} />
       <Markdown
         className={styles.content}
-        content={!docs?.includes("<!DOCTYPE html>") ? docs : formatMessage({ id: "connector.setupGuide.notFound" })}
+        content={docs && !error ? docs : formatMessage({ id: "connector.setupGuide.notFound" })}
         rehypePlugins={urlReplacerPlugin}
       />
     </div>

--- a/airbyte-webapp/src/core/domain/Documentation.test.ts
+++ b/airbyte-webapp/src/core/domain/Documentation.test.ts
@@ -1,0 +1,14 @@
+import { fetchDocumentation } from "./Documentation";
+
+describe("fetchDocumentation", () => {
+  afterEach(() => {
+    jest.resetAllMocks();
+  });
+
+  it("should throw on non markdown content-type", async () => {
+    global.fetch = jest.fn().mockResolvedValue({
+      Headers: new Headers([["Content-Type", "text/html; charset=utf-8"]]),
+    });
+    await expect(fetchDocumentation("/docs/integrations/destinations/firestore.md")).rejects.toThrow();
+  });
+});

--- a/airbyte-webapp/src/core/domain/Documentation.ts
+++ b/airbyte-webapp/src/core/domain/Documentation.ts
@@ -3,5 +3,11 @@ export const fetchDocumentation = async (url: string): Promise<string> => {
     method: "GET",
   });
 
+  const contentType = response.headers.get("content-type");
+
+  if (!contentType?.toLowerCase().includes("text/markdown")) {
+    throw new Error(`Documentation to be expected text/markdown, was ${contentType}`);
+  }
+
   return await response.text();
 };


### PR DESCRIPTION
## What

Fixes an error where if a markdown doesn't exist for an internal documentation will actually show part of our HTML instead:

![cloud airbyte io_workspaces_bed3b473-1518-4461-a37f-730ea3d3a848_connections](https://user-images.githubusercontent.com/877229/191628367-9d2d3ff2-a40f-4973-a823-7cf64f4e2ec6.png)

## How

This happened because if the markdown doesn't exist we actually (thanks to being a SPA) deliver our HTML instead. We had a check so far that checked if the response contained `<!DOCTYPE html>` and if so treat it as an error and show no documentation found. The problem was, that after minification this became `<!doctype html>` (lower case), and such the check didn't work anymore.

I've changed this logic a bit to actually check if the `content-type` after loading the documentation is actually `text/markdown` (which is what we expect and treat the response as), and if not throw actually and show the "Documentation not found" error instead. You can currently test this with the "Google Firestore" destination, which does not have a valid Markdown documentation.