### PR TITLE
feat: replace openjdk with amazoncorretto:17.0.4 on connectors for seсurity compliance

### DIFF
--- a/airbyte-integrations/bases/base-java/Dockerfile
+++ b/airbyte-integrations/bases/base-java/Dockerfile
@@ -1,6 +1,8 @@
-ARG JDK_VERSION=17.0.1
-FROM openjdk:${JDK_VERSION}-slim
+ARG JDK_VERSION=17.0.4
+FROM amazoncorretto:${JDK_VERSION}
 COPY --from=airbyte/integration-base:dev /airbyte /airbyte
+
+RUN yum install -y tar && yum clean all
 
 WORKDIR /airbyte
 

--- a/airbyte-integrations/bases/base-standard-source-test-file/Dockerfile
+++ b/airbyte-integrations/bases/base-standard-source-test-file/Dockerfile
@@ -1,22 +1,12 @@
-ARG JDK_VERSION=17.0.1
-FROM openjdk:${JDK_VERSION}-slim
+ARG JDK_VERSION=17.0.4
+FROM amazoncorretto:${JDK_VERSION}
 
 ARG DOCKER_BUILD_ARCH=amd64
 
 # Install Docker to launch worker images. Eventually should be replaced with Docker-java.
 # See https://gitter.im/docker-java/docker-java?at=5f3eb87ba8c1780176603f4e for more information on why we are not currently using Docker-java
-RUN apt-get update && apt-get install -y \
-                          apt-transport-https \
-                          ca-certificates \
-                          curl \
-                          gnupg-agent \
-                          software-properties-common
-RUN curl -fsSL https://download.docker.com/linux/debian/gpg | apt-key add -
-RUN add-apt-repository \
-       "deb [arch=${DOCKER_BUILD_ARCH}] https://download.docker.com/linux/debian \
-       $(lsb_release -cs) \
-       stable"
-RUN apt-get update && apt-get install -y docker-ce-cli jq
+RUN amazon-linux-extras install -y docker
+RUN yum install -y ca-certificates jq tar && yum clean all
 
 ENV APPLICATION base-standard-source-test-file
 

--- a/airbyte-integrations/bases/base/Dockerfile
+++ b/airbyte-integrations/bases/base/Dockerfile
@@ -1,4 +1,4 @@
-FROM debian:10.5-slim
+FROM amazonlinux:2022.0.20220831.1
 
 WORKDIR /airbyte
 

--- a/airbyte-integrations/bases/standard-source-test/Dockerfile
+++ b/airbyte-integrations/bases/standard-source-test/Dockerfile
@@ -1,22 +1,12 @@
-ARG JDK_VERSION=17.0.1
-FROM openjdk:${JDK_VERSION}-slim
+ARG JDK_VERSION=17.0.4
+FROM amazoncorretto:${JDK_VERSION}
 
 ARG DOCKER_BUILD_ARCH=amd64
 
 # Install Docker to launch worker images. Eventually should be replaced with Docker-java.
 # See https://gitter.im/docker-java/docker-java?at=5f3eb87ba8c1780176603f4e for more information on why we are not currently using Docker-java
-RUN apt-get update && apt-get install -y \
-                          apt-transport-https \
-                          ca-certificates \
-                          curl \
-                          gnupg-agent \
-                          software-properties-common
-RUN curl -fsSL https://download.docker.com/linux/debian/gpg | apt-key add -
-RUN add-apt-repository \
-       "deb [arch=${DOCKER_BUILD_ARCH}] https://download.docker.com/linux/debian \
-       $(lsb_release -cs) \
-       stable"
-RUN apt-get update && apt-get install -y docker-ce-cli jq
+RUN amazon-linux-extras install -y docker
+RUN yum install -y jq tar && yum clean all
 
 ENV APPLICATION standard-source-test
 

--- a/airbyte-integrations/connectors/destination-s3/Dockerfile
+++ b/airbyte-integrations/connectors/destination-s3/Dockerfile
@@ -19,12 +19,11 @@ RUN /bin/bash -c 'set -e && \
     ARCH=`uname -m` && \
     if [ "$ARCH" == "x86_64" ] || [ "$ARCH" = "amd64" ]; then \
        echo "$ARCH" && \
-       apt-get update; \
-       apt-get install lzop liblzo2-2 liblzo2-dev -y; \
+       yum install lzop lzo lzo-dev -y; \
     elif [ "$ARCH" == "aarch64" ] || [ "$ARCH" = "arm64" ]; then \
       echo "$ARCH" && \
-      apt-get update; \
-      apt-get install lzop liblzo2-2 liblzo2-dev wget curl unzip zip build-essential maven git -y; \
+      yum group install -y "Development Tools" \
+      yum install lzop lzo lzo-dev wget curl unzip zip maven git -y; \
       wget http://www.oberhumer.com/opensource/lzo/download/lzo-2.10.tar.gz -P /tmp; \
       cd /tmp && tar xvfz lzo-2.10.tar.gz; \
       cd /tmp/lzo-2.10/ && ./configure --enable-shared --prefix /usr/local/lzo-2.10; \

--- a/airbyte-integrations/connectors/destination-snowflake/Dockerfile
+++ b/airbyte-integrations/connectors/destination-snowflake/Dockerfile
@@ -1,7 +1,7 @@
 FROM airbyte/integration-base-java:dev
 
 # uncomment to run Yourkit java profiling
-#RUN apt-get update && apt-get install -y curl zip
+#RUN yum install -y curl zip
 #
 #RUN curl -o /tmp/YourKit-JavaProfiler-2021.3-docker.zip https://www.yourkit.com/download/docker/YourKit-JavaProfiler-2021.3-docker.zip && \
 #  unzip /tmp/YourKit-JavaProfiler-2021.3-docker.zip -d /usr/local && \

--- a/tools/bin/build_image.sh
+++ b/tools/bin/build_image.sh
@@ -42,7 +42,7 @@ if [ "$FOLLOW_SYMLINKS" == "true" ]; then
   # to use as the build context
   tar cL "${exclusions[@]}" . | docker build - "${args[@]}"
 else
-  JDK_VERSION="${JDK_VERSION:-17.0.1}"
+  JDK_VERSION="${JDK_VERSION:-17.0.4}"
   if [[ -z "${DOCKER_BUILD_PLATFORM}" ]]; then
     docker build --build-arg JDK_VERSION="$JDK_VERSION" --build-arg DOCKER_BUILD_ARCH="$DOCKER_BUILD_ARCH" . "${args[@]}"
   else


### PR DESCRIPTION
## What
We want to improve the security rating of our docker images.

## How
Switch to amazoncorretto:17.0.4 docker image as base one for the platform part of the application. It was created with Amazon Linux with all the latest patches.

Local run of snyk showed the following:

    no low/medium/critical issues on amazoncorretto:17.0.4 at all.
    40 issues with openjdk:19-slim-bullseye.
    18 issues on Ubuntu:22.04/eclipse-temurin:17 images (it's basically the same images).


## Recommended reading order
1. `x.java`
2. `y.python`

## Pre-merge Checklist
Expand the relevant checklist and delete the others.

<details><summary><strong>Updating a connector</strong></summary>

### Community member or Airbyter

- [ ] Unit & integration tests added and passing. Community members, please provide proof of success locally e.g: screenshot or copy-paste unit, integration, and acceptance test output. To run acceptance tests for a Python connector, follow instructions in the README. For java connectors run `./gradlew :airbyte-integrations:connectors:<name>:integrationTest`.
- [ ] Code reviews completed
- [ ] Documentation updated
    - [ ] Connector's `README.md`
    - [ ] Connector's `bootstrap.md`. See [description and examples](https://docs.google.com/document/d/1ypdgmwmEHWv-TrO4_YOQ7pAJGVrMp5BOkEVh831N260/edit?usp=sharing)
    - [ ] Changelog updated in `docs/integrations/<source or destination>/<name>.md` including changelog. See changelog [example](https://docs.airbyte.io/integrations/sources/stripe#changelog)
- [ ] PR name follows [PR naming conventions](https://docs.airbyte.com/contributing-to-airbyte/issues-and-pull-requests)

### Airbyter

If this is a community PR, the Airbyte engineer reviewing this PR is responsible for the below items.

- [ ] Create a non-forked branch based on this PR and test the below items on it
- [ ] Build is successful
- [ ] If new credentials are required for use in CI, add them to GSM. [Instructions](https://docs.airbyte.io/connector-development#using-credentials-in-ci).
- [ ] [`/test connector=connectors/<name>` command](https://docs.airbyte.io/connector-development#updating-an-existing-connector) is passing
- [ ] New Connector version released on Dockerhub and connector version bumped by running the `/publish` command described [here](https://docs.airbyte.io/connector-development#updating-an-existing-connector)

</details>

<details><summary><strong>Connector Generator</strong></summary>

- [ ] Issue acceptance criteria met
- [ ] PR name follows [PR naming conventions](https://docs.airbyte.com/contributing-to-airbyte/issues-and-pull-requests)
- [ ] If adding a new generator, add it to the [list of scaffold modules being tested](https://github.com/airbytehq/airbyte/blob/master/airbyte-integrations/connector-templates/generator/build.gradle#L41)
- [ ] The generator test modules (all connectors with `-scaffold` in their name) have been updated with the latest scaffold by running `./gradlew :airbyte-integrations:connector-templates:generator:testScaffoldTemplates` then checking in your changes
- [ ] Documentation which references the generator is updated as needed

</details>

## Tests

<details><summary><strong>Unit</strong></summary>

*Put your unit tests output here.*

</details>

<details><summary><strong>Integration</strong></summary>

*Put your integration tests output here.*

</details>

<details><summary><strong>Acceptance</strong></summary>

*Put your acceptance tests output here.*

</details>
