### PR TITLE
Added Google OAuth login info to docs

### DIFF
--- a/docs/cloud/getting-started-with-airbyte-cloud.md
+++ b/docs/cloud/getting-started-with-airbyte-cloud.md
@@ -6,20 +6,19 @@ This page guides you through setting up your Airbyte Cloud account, setting up a
 
 To use Airbyte Cloud:
 
-1. If you haven't already, [sign up for Airbyte Cloud](https://cloud.airbyte.io/signup?utm_campaign=22Q1_AirbyteCloudSignUpCampaign_Trial&utm_source=Docs&utm_content=SetupGuide).
+1. If you haven't already, [sign up for Airbyte Cloud](https://cloud.airbyte.io/signup?utm_campaign=22Q1_AirbyteCloudSignUpCampaign_Trial&utm_source=Docs&utm_content=SetupGuide) using your email address or Google login credentials.
 
    Airbyte Cloud offers a 14-day free trial. For more information, see [Pricing](https://airbyte.com/pricing).
 
-2. Airbyte will send you an email with a verification link. On clicking the link, you'll be taken to your new workspace.
+   :::note
+   If you are invited to a workspace, you cannot use your Google login to create a new Airbyte account.
+   :::
+
+2. If you signed up using your email address, Airbyte will send you an email with a verification link. On clicking the link, you'll be taken to your new workspace.
 
    :::info
    A workspace lets you collaborate with team members and share resources across your team under a shared billing account.
    :::
-
-3. Optionally, you can create a new account by using your Google login credentials.
-   
-   * If you have an existing Airbyte account that shares the same email address as your Google account, you can use your Google login credentials to sign in to your Airbyte account.
-   * If you are invited to a workspace, you cannot use your Google login to create a new Airbyte account.
 
 You will be greeted with an onboarding tutorial to help you set up your first connection. If you haven’t set up a connection on Airbyte Cloud before, we highly recommend following the tutorial. If you are familiar with the connection setup process, click **Skip Onboarding** and follow this guide to set up your next connection.
 

--- a/docs/cloud/getting-started-with-airbyte-cloud.md
+++ b/docs/cloud/getting-started-with-airbyte-cloud.md
@@ -16,6 +16,11 @@ To use Airbyte Cloud:
    A workspace lets you collaborate with team members and share resources across your team under a shared billing account.
    :::
 
+3. Optionally, you can create a new account by using your Google login credentials.
+   
+   * If you have an existing Airbyte account that shares the same email address as your Google account, you can use your Google login credentials to sign in to your Airbyte account.
+   * If you are invited to a workspace, you cannot use your Google login to create a new Airbyte account.
+
 You will be greeted with an onboarding tutorial to help you set up your first connection. If you haven’t set up a connection on Airbyte Cloud before, we highly recommend following the tutorial. If you are familiar with the connection setup process, click **Skip Onboarding** and follow this guide to set up your next connection.
 
 ## Set up a source


### PR DESCRIPTION
Added info about current limitations of OAuth for Airbyte Cloud to [Set up your Airbyte Cloud account](https://docs.airbyte.com/cloud/getting-started-with-airbyte-cloud#set-up-your-airbyte-cloud-account)

Related to this [issue](https://app.zenhub.com/workspaces/documentation-6266ed73c9cbb400119b1e54/issues/airbytehq/airbyte/16744)