### PR TITLE
Fix: Indentation error in helm templates with "extraContainers" values

### DIFF
--- a/charts/airbyte-bootloader/templates/pod.yaml
+++ b/charts/airbyte-bootloader/templates/pod.yaml
@@ -104,7 +104,7 @@ spec:
     {{ toYaml .Values.extraContainers | nindent 4 }}
     {{- end }}
     {{- if .Values.global.extraContainers }}
-    {{ toYaml .Values.global.extraContainers | indent 4 }}
+    {{ toYaml .Values.global.extraContainers | nindent 4 }}
     {{- end }}
   {{- if .Values.extraVolumes }}
   volumes:

--- a/charts/airbyte-server/templates/deployment.yaml
+++ b/charts/airbyte-server/templates/deployment.yaml
@@ -250,10 +250,10 @@ spec:
           {{ toYaml .Values.global.extraVolumeMounts | nindent 8 }}
         {{- end }}
       {{- if .Values.extraContainers }}
-        {{ toYaml .Values.extraContainers | indent 6 }}
+        {{ toYaml .Values.extraContainers | nindent 6 }}
       {{- end }}
       {{- if .Values.global.extraContainers }}
-        {{ toYaml .Values.global.extraContainers | indent 6 }}
+        {{ toYaml .Values.global.extraContainers | nindent 6 }}
       {{- end }}
       volumes:
       {{- if eq .Values.global.deploymentMode "oss" }}

--- a/charts/airbyte-temporal/templates/deployment.yaml
+++ b/charts/airbyte-temporal/templates/deployment.yaml
@@ -132,10 +132,10 @@ spec:
           failureThreshold: {{ .Values.readinessProbe.failureThreshold }}
         {{- end }}
         {{- if .Values.extraContainers }}
-        {{ toYaml .Values.extraContainers | indent 6 }}
+        {{ toYaml .Values.extraContainers | nindent 6 }}
         {{- end }}
         {{- if .Values.global.extraContainers }}
-        {{ toYaml .Values.global.extraContainers | indent 6 }}
+        {{ toYaml .Values.global.extraContainers | nindent 6 }}
         {{- end }}
       volumes:
       - name: airbyte-temporal-dynamicconfig

--- a/charts/airbyte-worker/templates/deployment.yaml
+++ b/charts/airbyte-worker/templates/deployment.yaml
@@ -409,10 +409,10 @@ spec:
 {{- toYaml .Values.global.extraVolumeMounts | nindent 8 }}
         {{- end }}
       {{- if .Values.extraContainers }}
-      {{ toYaml .Values.extraContainers | indent 6 }}
+      {{ toYaml .Values.extraContainers | nindent 6 }}
       {{- end }}
       {{- if .Values.global.extraContainers }}
-      {{ toYaml .Values.global.extraContainers | indent 6 }}
+      {{ toYaml .Values.global.extraContainers | nindent 6 }}
       {{- end }}
       volumes:
       {{- if eq .Values.global.deploymentMode "oss" }}

--- a/charts/airbyte/Chart.yaml
+++ b/charts/airbyte/Chart.yaml
@@ -15,7 +15,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.45.2
+version: 0.45.3
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to


### PR DESCRIPTION
## What
Helm templates don't render correctly the `extraContainers` values. The reason is a typo in the indentation function.

![example of a generated template](https://user-images.githubusercontent.com/9624579/191955016-8de21378-1c45-4e2c-b19f-332d074856c0.png)

## How
The `nindent` function is used instead of `indent`.