### PR TITLE
:window: :wrench: Prevent rerendering on stale queries

### DIFF
--- a/airbyte-webapp/src/views/common/StoreProvider.tsx
+++ b/airbyte-webapp/src/views/common/StoreProvider.tsx
@@ -8,6 +8,7 @@ const queryClient = new QueryClient({
       refetchOnWindowFocus: false,
       refetchOnReconnect: false,
       retry: 0,
+      notifyOnChangePropsExclusions: ["isStale"],
     },
   },
 });


### PR DESCRIPTION
## What

This prevents react-query from rerendering a component that uses a react-query hook in case the query turns stale. Since there is no new data we're not needing to rerender components in this case, especially since we have nowhere any specific logic that would require to detect whether a query is stale.

This will prevent some nasty rerenders e.g. of the connection listing page, that will always rerender twice (once for new data and then once for the stale query), which causing some hickups with the switch loading animation if you toggle connections to quickly.

**How to test?**
You can check that e.g. the connection list page (or any other page that has queries that turn stale) is not rerendering twice via the React dev tools. There should be no other affect than that.