### PR TITLE
Source Facebook Pages: Remove unused method `path_param`

### DIFF
--- a/airbyte-integrations/connectors/source-facebook-pages/Dockerfile
+++ b/airbyte-integrations/connectors/source-facebook-pages/Dockerfile
@@ -12,5 +12,5 @@ RUN pip install .
 ENV AIRBYTE_ENTRYPOINT "python /airbyte/integration_code/main.py"
 ENTRYPOINT ["python", "/airbyte/integration_code/main.py"]
 
-LABEL io.airbyte.version=0.1.6
+LABEL io.airbyte.version=0.1.7
 LABEL io.airbyte.name=airbyte/source-facebook-pages

--- a/airbyte-integrations/connectors/source-facebook-pages/source_facebook_pages/streams.py
+++ b/airbyte-integrations/connectors/source-facebook-pages/source_facebook_pages/streams.py
@@ -27,10 +27,6 @@ class FacebookPagesStream(HttpStream, ABC):
         self._access_token = access_token
         self._page_id = page_id
 
-    @property
-    def path_param(self):
-        return self.name[:-1]
-
     def next_page_token(self, response: requests.Response) -> Optional[Mapping[str, Any]]:
         data = response.json()
 

--- a/docs/integrations/sources/facebook-pages.md
+++ b/docs/integrations/sources/facebook-pages.md
@@ -81,8 +81,11 @@ You can easily get the page id from the page url. For example, if you have a pag
 
 ## Changelog
 
+https://github.com/airbytehq/airbyte/pull/17119
+
 | Version | Date | Pull Request | Subject |
 | :--- | :--- | :--- | :--- |
+| 0.1.7 | 2022-09-25 | [17119](https://github.com/airbytehq/airbyte/pull/17119) | Remove deprecated method `path_param` |
 | 0.1.6 | 2021-12-22 | [9032](https://github.com/airbytehq/airbyte/pull/9032) | Remove deprecated field `live_encoders` from Page stream |
 | 0.1.5 | 2021-11-26 | [8267](https://github.com/airbytehq/airbyte/pull/) | updated all empty objects in schemas for Page and Post streams |
 | 0.1.4 | 2021-11-26 | [](https://github.com/airbytehq/airbyte/pull/) | Remove unsupported insights_export field from Pages request |


### PR DESCRIPTION
## What
Removes unused method `path_param` from the Facebook Pages source.

## How
Removed the method.

## Recommended reading order
1. `streams.py`

## Pre-merge Checklist

<details><summary><strong>Updating a connector</strong></summary>

### Community member or Airbyter

- [x] Grant edit access to maintainers ([instructions](https://docs.github.com/en/github/collaborating-with-pull-requests/working-with-forks/allowing-changes-to-a-pull-request-branch-created-from-a-fork#enabling-repository-maintainer-permissions-on-existing-pull-requests))
- [x] Secrets in the connector's spec are annotated with `airbyte_secret`
- [x] Unit & integration tests added and passing. Community members, please provide proof of success locally e.g: screenshot or copy-paste unit, integration, and acceptance test output. To run acceptance tests for a Python connector, follow instructions in the README. For java connectors run `./gradlew :airbyte-integrations:connectors:<name>:integrationTest`.
- [ ] Code reviews completed
- [x] Documentation updated
    - [x] Connector's `README.md`
    - [x] Connector's `bootstrap.md`. See [description and examples](https://docs.google.com/document/d/1ypdgmwmEHWv-TrO4_YOQ7pAJGVrMp5BOkEVh831N260/edit?usp=sharing)
    - [x] Changelog updated in `docs/integrations/<source or destination>/<name>.md` including changelog. See changelog [example](https://docs.airbyte.io/integrations/sources/stripe#changelog)
- [x] PR name follows [PR naming conventions](https://docs.airbyte.com/contributing-to-airbyte/issues-and-pull-requests)

### Airbyter

If this is a community PR, the Airbyte engineer reviewing this PR is responsible for the below items.

- [ ] Create a non-forked branch based on this PR and test the below items on it
- [ ] Build is successful
- [ ] If new credentials are required for use in CI, add them to GSM. [Instructions](https://docs.airbyte.io/connector-development#using-credentials-in-ci).
- [ ] [`/test connector=connectors/<name>` command](https://docs.airbyte.io/connector-development#updating-an-existing-connector) is passing
- [ ] New Connector version released on Dockerhub and connector version bumped by running the `/publish` command described [here](https://docs.airbyte.io/connector-development#updating-an-existing-connector)

</details>

## Tests

<details><summary><strong>Unit</strong></summary>

```
Test session starts (platform: darwin, Python 3.10.3, pytest 6.2.5, pytest-sugar 0.9.5)
cachedir: .pytest_cache
hypothesis profile 'default' -> database=DirectoryBasedExampleDatabase('/Users/jarrod/code/wub-airbyte/airbyte-integrations/connectors/source-facebook-pages/.hypothesis/examples')
rootdir: /Users/jarrod/code/wub-airbyte, configfile: pytest.ini
plugins: hypothesis-6.54.6, sugar-0.9.5, requests-mock-1.9.3, mock-3.6.1, timeout-1.4.2, cov-3.0.0
collecting ... 
 airbyte-integrations/connectors/source-facebook-pages/unit_tests/unit_test.py::test_pagination[{"data":[1, 2, 3],"paging":{"cursors":{"after": "next"}}}-next] ✓                               33% ███▍      
 airbyte-integrations/connectors/source-facebook-pages/unit_tests/unit_test.py::test_pagination[{"data":[1, 2, 3]}-None] ✓                                                                      67% ██████▋   
 airbyte-integrations/connectors/source-facebook-pages/unit_tests/unit_test.py::test_pagination[{"data": []}-None] ✓                                                                           100% ██████████
============================================================================================== warnings summary ==============================================================================================
airbyte-integrations/connectors/source-facebook-pages/unit_tests/unit_test.py::test_pagination[{"data":[1, 2, 3],"paging":{"cursors":{"after": "next"}}}-next]
airbyte-integrations/connectors/source-facebook-pages/unit_tests/unit_test.py::test_pagination[{"data":[1, 2, 3]}-None]
airbyte-integrations/connectors/source-facebook-pages/unit_tests/unit_test.py::test_pagination[{"data": []}-None]
  /Users/jarrod/.pyenv/versions/.venv/lib/python3.10/site-packages/airbyte_cdk/sources/streams/http/http.py:41: DeprecationWarning: Call to deprecated class NoAuth. (Set `authenticator=None` instead) -- Deprecated since version 0.1.20.
    self._authenticator: HttpAuthenticator = NoAuth()

airbyte-integrations/connectors/source-facebook-pages/unit_tests/unit_test.py::test_pagination[{"data":[1, 2, 3],"paging":{"cursors":{"after": "next"}}}-next]
airbyte-integrations/connectors/source-facebook-pages/unit_tests/unit_test.py::test_pagination[{"data":[1, 2, 3]}-None]
airbyte-integrations/connectors/source-facebook-pages/unit_tests/unit_test.py::test_pagination[{"data": []}-None]
  /Users/jarrod/.pyenv/versions/.venv/lib/python3.10/site-packages/deprecated/classic.py:173: DeprecationWarning: Call to deprecated class HttpAuthenticator. (Use requests.auth.AuthBase instead) -- Deprecated since version 0.1.20.
    return old_new1(cls, *args, **kwargs)

-- Docs: https://docs.pytest.org/en/stable/warnings.html

Results (0.21s):
       3 passed
```

</details>

<details><summary><strong>Integration</strong></summary>

None

</details>

<details><summary><strong>Acceptance</strong></summary>

None

</details>
