### PR TITLE
switch some tests to use PATCH-style connection update

### DIFF
--- a/airbyte-test-utils/src/main/java/io/airbyte/test/utils/AirbyteAcceptanceTestHarness.java
+++ b/airbyte-test-utils/src/main/java/io/airbyte/test/utils/AirbyteAcceptanceTestHarness.java
@@ -725,15 +725,8 @@ public class AirbyteAcceptanceTestHarness {
   }
 
   private void disableConnection(final UUID connectionId) throws ApiException {
-    final ConnectionRead connection = apiClient.getConnectionApi().getConnection(new ConnectionIdRequestBody().connectionId(connectionId));
     final ConnectionUpdate connectionUpdate =
-        new ConnectionUpdate()
-            .prefix(connection.getPrefix())
-            .connectionId(connectionId)
-            .operationIds(connection.getOperationIds())
-            .status(ConnectionStatus.DEPRECATED)
-            .schedule(connection.getSchedule())
-            .syncCatalog(connection.getSyncCatalog());
+        new ConnectionUpdate().connectionId(connectionId).status(ConnectionStatus.DEPRECATED);
     apiClient.getConnectionApi().updateConnection(connectionUpdate);
   }
 

--- a/airbyte-tests/src/acceptanceTests/java/io/airbyte/test/acceptance/BasicAcceptanceTests.java
+++ b/airbyte-tests/src/acceptanceTests/java/io/airbyte/test/acceptance/BasicAcceptanceTests.java
@@ -71,7 +71,6 @@ import io.airbyte.api.client.model.generated.StreamDescriptor;
 import io.airbyte.api.client.model.generated.StreamState;
 import io.airbyte.api.client.model.generated.SyncMode;
 import io.airbyte.api.client.model.generated.WebBackendConnectionUpdate;
-import io.airbyte.api.client.model.generated.WebBackendOperationCreateOrUpdate;
 import io.airbyte.commons.json.Jsons;
 import io.airbyte.db.Database;
 import io.airbyte.db.jdbc.JdbcUtils;
@@ -1095,22 +1094,8 @@ class BasicAcceptanceTests {
       // Update with refreshed catalog
       LOGGER.info("Submit the update request");
       final WebBackendConnectionUpdate update = new WebBackendConnectionUpdate()
-          .name(connection.getName())
           .connectionId(connection.getConnectionId())
-          .namespaceDefinition(connection.getNamespaceDefinition())
-          .namespaceFormat(connection.getNamespaceFormat())
-          .prefix(connection.getPrefix())
-          .operations(List.of(
-              new WebBackendOperationCreateOrUpdate()
-                  .name(operation.getName())
-                  .operationId(operation.getOperationId())
-                  .workspaceId(operation.getWorkspaceId())
-                  .operatorConfiguration(operation.getOperatorConfiguration())))
-          .syncCatalog(updatedCatalog)
-          .schedule(connection.getSchedule())
-          .sourceCatalogId(connection.getSourceCatalogId())
-          .status(connection.getStatus())
-          .resourceRequirements(connection.getResourceRequirements());
+          .syncCatalog(updatedCatalog);
       webBackendApi.webBackendUpdateConnection(update);
 
       LOGGER.info("Inspecting Destination DB after the update request, tables should be empty");


### PR DESCRIPTION
## What
Some tests are failing or generating errors because they're using the old `schedule` format in update requests.

## How
This PR fixes that by simply not sending the schedule at all, which isn't required since the connections API supports PATCH-style updates.

