### PR TITLE
Disable `refresh` on submit for disabled connections

### DIFF
--- a/airbyte-webapp/src/pages/ConnectionPage/pages/ConnectionItemPage/components/ConnectionReplication.tsx
+++ b/airbyte-webapp/src/pages/ConnectionPage/pages/ConnectionItemPage/components/ConnectionReplication.tsx
@@ -163,7 +163,8 @@ export const ConnectionReplication: React.FC = () => {
         });
         if (result.type !== "canceled") {
           // Save the connection taking into account the correct skipRefresh value from the dialog choice.
-          await saveConnection(formValues, { skipReset: !result.reason });
+          // We also want to skip refresh if the connection is not "active" (ie: if it is disabled)
+          await saveConnection(formValues, { skipReset: !result.reason || connection.status !== "active" });
         } else {
           // We don't want to set saved to true or schema has been refreshed to false.
           return;


### PR DESCRIPTION
## What
Blocks a `refresh` sync for disabled connections

