### PR TITLE
Remove default value from namespaceDefinitionType

### DIFF
--- a/airbyte-api/src/main/openapi/config.yaml
+++ b/airbyte-api/src/main/openapi/config.yaml
@@ -3453,7 +3453,6 @@ components:
     NamespaceDefinitionType:
       type: string
       description: Method used for computing final namespace in destination
-      default: source
       enum:
         - source
         - destination

--- a/airbyte-server/src/main/java/io/airbyte/server/handlers/ConnectionsHandler.java
+++ b/airbyte-server/src/main/java/io/airbyte/server/handlers/ConnectionsHandler.java
@@ -121,11 +121,17 @@ public class ConnectionsHandler {
 
     final UUID connectionId = uuidGenerator.get();
 
+    // If not specified, default the NamespaceDefinition to 'source'
+    final NamespaceDefinitionType namespaceDefinitionType =
+        connectionCreate.getNamespaceDefinition() == null
+            ? NamespaceDefinitionType.SOURCE
+            : Enums.convertTo(connectionCreate.getNamespaceDefinition(), NamespaceDefinitionType.class);
+
     // persist sync
     final StandardSync standardSync = new StandardSync()
         .withConnectionId(connectionId)
         .withName(connectionCreate.getName() != null ? connectionCreate.getName() : defaultName)
-        .withNamespaceDefinition(Enums.convertTo(connectionCreate.getNamespaceDefinition(), NamespaceDefinitionType.class))
+        .withNamespaceDefinition(namespaceDefinitionType)
         .withNamespaceFormat(connectionCreate.getNamespaceFormat())
         .withPrefix(connectionCreate.getPrefix())
         .withSourceId(connectionCreate.getSourceId())

--- a/airbyte-server/src/test/java/io/airbyte/server/handlers/ConnectionsHandlerTest.java
+++ b/airbyte-server/src/test/java/io/airbyte/server/handlers/ConnectionsHandlerTest.java
@@ -720,6 +720,7 @@ class ConnectionsHandlerTest {
           .thenReturn(destinationDefinition);
 
       final ConnectionSearch connectionSearch = new ConnectionSearch();
+      connectionSearch.namespaceDefinition(NamespaceDefinitionType.SOURCE);
       ConnectionReadList actualConnectionReadList = connectionsHandler.searchConnections(connectionSearch);
       assertEquals(1, actualConnectionReadList.getConnections().size());
       assertEquals(connectionRead1, actualConnectionReadList.getConnections().get(0));

--- a/airbyte-test-utils/src/main/java/io/airbyte/test/utils/AirbyteAcceptanceTestHarness.java
+++ b/airbyte-test-utils/src/main/java/io/airbyte/test/utils/AirbyteAcceptanceTestHarness.java
@@ -725,15 +725,8 @@ public class AirbyteAcceptanceTestHarness {
   }
 
   private void disableConnection(final UUID connectionId) throws ApiException {
-    final ConnectionRead connection = apiClient.getConnectionApi().getConnection(new ConnectionIdRequestBody().connectionId(connectionId));
     final ConnectionUpdate connectionUpdate =
-        new ConnectionUpdate()
-            .prefix(connection.getPrefix())
-            .connectionId(connectionId)
-            .operationIds(connection.getOperationIds())
-            .status(ConnectionStatus.DEPRECATED)
-            .schedule(connection.getSchedule())
-            .syncCatalog(connection.getSyncCatalog());
+        new ConnectionUpdate().connectionId(connectionId).status(ConnectionStatus.DEPRECATED);
     apiClient.getConnectionApi().updateConnection(connectionUpdate);
   }
 

--- a/airbyte-tests/src/acceptanceTests/java/io/airbyte/test/acceptance/BasicAcceptanceTests.java
+++ b/airbyte-tests/src/acceptanceTests/java/io/airbyte/test/acceptance/BasicAcceptanceTests.java
@@ -71,7 +71,6 @@ import io.airbyte.api.client.model.generated.StreamDescriptor;
 import io.airbyte.api.client.model.generated.StreamState;
 import io.airbyte.api.client.model.generated.SyncMode;
 import io.airbyte.api.client.model.generated.WebBackendConnectionUpdate;
-import io.airbyte.api.client.model.generated.WebBackendOperationCreateOrUpdate;
 import io.airbyte.commons.json.Jsons;
 import io.airbyte.db.Database;
 import io.airbyte.db.jdbc.JdbcUtils;
@@ -1095,22 +1094,8 @@ class BasicAcceptanceTests {
       // Update with refreshed catalog
       LOGGER.info("Submit the update request");
       final WebBackendConnectionUpdate update = new WebBackendConnectionUpdate()
-          .name(connection.getName())
           .connectionId(connection.getConnectionId())
-          .namespaceDefinition(connection.getNamespaceDefinition())
-          .namespaceFormat(connection.getNamespaceFormat())
-          .prefix(connection.getPrefix())
-          .operations(List.of(
-              new WebBackendOperationCreateOrUpdate()
-                  .name(operation.getName())
-                  .operationId(operation.getOperationId())
-                  .workspaceId(operation.getWorkspaceId())
-                  .operatorConfiguration(operation.getOperatorConfiguration())))
-          .syncCatalog(updatedCatalog)
-          .schedule(connection.getSchedule())
-          .sourceCatalogId(connection.getSourceCatalogId())
-          .status(connection.getStatus())
-          .resourceRequirements(connection.getResourceRequirements());
+          .syncCatalog(updatedCatalog);
       webBackendApi.webBackendUpdateConnection(update);
 
       LOGGER.info("Inspecting Destination DB after the update request, tables should be empty");


### PR DESCRIPTION
## What
Fixes a bug where the Destination Namespace can be reset to the default of 'source'. 

Now that we can send partial updates for Connections, we need to remove the default value from namespaceDefinitionType so that partial updates that leave this value alone aren't defaulted to an unintended value.

## How
- Remove the 'default' property from NamespaceDefinitionType
- Add in logic to default to 'source' to the ConnectionCreation handler. This way, creation behavior should remain the same, while update behavior supports partial updates that leave the NamespaceDefinitionType unchanged

