### PR TITLE
Fixes Connections Table styles

### DIFF
--- a/airbyte-webapp/src/components/JobItem/components/MainInfo.module.scss
+++ b/airbyte-webapp/src/components/JobItem/components/MainInfo.module.scss
@@ -3,7 +3,8 @@
 
 .mainView {
   cursor: pointer;
-  height: auto;
+  height: unset !important;
+  min-height: 70px;
   padding: variables.$spacing-lg 0;
 
   .titleCell {

--- a/airbyte-webapp/src/components/SimpleTableComponents/SimpleTableComponents.tsx
+++ b/airbyte-webapp/src/components/SimpleTableComponents/SimpleTableComponents.tsx
@@ -5,7 +5,7 @@ export const Row = styled.div`
   flex-direction: row;
   justify-content: flex-start;
   align-items: center;
-  min-height: 70px;
+  height: 32px;
   position: relative;
 
   font-size: 14px;


### PR DESCRIPTION
## What
Fixes bug described in the comment in this PR https://github.com/airbytehq/airbyte/pull/16600.

## How
The problem here is that the general `Row` component used in different places is using the `height` property set to `32px` and using `styled-components`. On the other hand `MainInfo` component appears to have a height of `70px`, and also should expand in case we have a big reset streams list, and using the SCSS module. `styled-components` seems to override SCSS styles, so I decided to use `!important` statement here. @lmossman if you can think of better solution, let me know.