### PR TITLE
🪟 🔧 Restore SimpleTableComponents height. Update MainInfo height

### DIFF
--- a/airbyte-webapp/src/components/JobItem/components/MainInfo.module.scss
+++ b/airbyte-webapp/src/components/JobItem/components/MainInfo.module.scss
@@ -3,7 +3,8 @@
 
 .mainView {
   cursor: pointer;
-  height: auto;
+  min-height: 70px;
+  height: auto !important; // important to override Row styled component
   padding: variables.$spacing-lg 0;
 
   .titleCell {

--- a/airbyte-webapp/src/components/SimpleTableComponents/SimpleTableComponents.tsx
+++ b/airbyte-webapp/src/components/SimpleTableComponents/SimpleTableComponents.tsx
@@ -5,7 +5,7 @@ export const Row = styled.div`
   flex-direction: row;
   justify-content: flex-start;
   align-items: center;
-  min-height: 70px;
+  height: 32px;
   position: relative;
 
   font-size: 14px;


### PR DESCRIPTION
## What
Fixes an issue where the table height, mainly seen in the connection replication view, was too long.

![Screen Shot 2022-09-27 at 10 40 43](https://user-images.githubusercontent.com/168664/192565005-14aae565-2b95-4370-b688-7f35bc976d71.png)

Caused by #16600  

## How
Applies custom style to streams job list row
Restores the original height of the Row in SimpleTableComponents
