### PR TITLE
Expose required transitive dependencies

### DIFF
--- a/airbyte-config/config-models/build.gradle
+++ b/airbyte-config/config-models/build.gradle
@@ -1,12 +1,13 @@
 import org.jsonschema2pojo.SourceType
 
 plugins {
+    id "java-library"
     id "com.github.eirnym.js2p" version "1.0"
 }
 
 dependencies {
     annotationProcessor libs.bundles.micronaut.annotation.processor
-    implementation libs.bundles.micronaut.annotation
+    api libs.bundles.micronaut.annotation
 
     implementation project(':airbyte-json-validation')
     implementation project(':airbyte-protocol:protocol-models')


### PR DESCRIPTION
## What
* Ensure that required dependencies are exposed as transitive dependencies

## How
* Mark `config-models` as a `java-library` Gradle project
* Mark the Micronaut-related annotations as `api` so that they are exposed transitively

## Recommended reading order
1. `build.gradle`