### PR TITLE
Fix legacy reset behavior

### DIFF
--- a/airbyte-server/src/main/java/io/airbyte/server/handlers/WebBackendConnectionsHandler.java
+++ b/airbyte-server/src/main/java/io/airbyte/server/handlers/WebBackendConnectionsHandler.java
@@ -385,7 +385,7 @@ public class WebBackendConnectionsHandler {
         final ConnectionIdRequestBody connectionIdRequestBody = new ConnectionIdRequestBody().connectionId(connectionId);
         final ConnectionStateType stateType = getStateType(connectionIdRequestBody);
 
-        if (stateType == ConnectionStateType.LEGACY) {
+        if (stateType == ConnectionStateType.LEGACY || stateType == ConnectionStateType.NOT_SET) {
           streamsToReset = configRepository.getAllStreamsForConnection(connectionId);
         }
         ManualOperationResult manualOperationResult = eventRunner.synchronousResetConnection(

--- a/airbyte-tests/src/acceptanceTests/java/io/airbyte/test/acceptance/BasicAcceptanceTests.java
+++ b/airbyte-tests/src/acceptanceTests/java/io/airbyte/test/acceptance/BasicAcceptanceTests.java
@@ -1023,10 +1023,6 @@ class BasicAcceptanceTests {
     final SourceRead source = testHarness.createPostgresSource(true);
     final UUID sourceId = source.getSourceId();
     final UUID sourceDefinitionId = source.getSourceDefinitionId();
-    final AirbyteCatalog catalog = testHarness.discoverSourceSchema(sourceId);
-    final UUID destinationId = testHarness.createPostgresDestination(true).getDestinationId();
-    final OperationRead operation = testHarness.createOperation();
-    final String name = "test_reset_when_schema_is_modified_" + UUID.randomUUID();
 
     // Fetch the current/most recent source definition version
     final SourceDefinitionRead sourceDefinitionRead =
@@ -1038,6 +1034,11 @@ class BasicAcceptanceTests {
       LOGGER.info("Setting source connector to pre-per-stream state version {}...",
           AirbyteAcceptanceTestHarness.POSTGRES_SOURCE_LEGACY_CONNECTOR_VERSION);
       testHarness.updateSourceDefinitionVersion(sourceDefinitionId, AirbyteAcceptanceTestHarness.POSTGRES_SOURCE_LEGACY_CONNECTOR_VERSION);
+
+      final AirbyteCatalog catalog = testHarness.discoverSourceSchema(sourceId);
+      final UUID destinationId = testHarness.createPostgresDestination(true).getDestinationId();
+      final OperationRead operation = testHarness.createOperation();
+      final String name = "test_reset_when_schema_is_modified_" + UUID.randomUUID();
 
       LOGGER.info("Discovered catalog: {}", catalog);
 


### PR DESCRIPTION
## What

* Fix how we force an old version of a connector in the tests, scope was too narrow, we were discovering schema using a different version of the connector
* Fix reset endpoint behavior, State NOT_SET should be same as LEGACY
