### PR TITLE
Remove validation

### DIFF
--- a/airbyte-commons/src/main/java/io/airbyte/commons/features/EnvVariableFeatureFlags.java
+++ b/airbyte-commons/src/main/java/io/airbyte/commons/features/EnvVariableFeatureFlags.java
@@ -41,7 +41,8 @@ public class EnvVariableFeatureFlags implements FeatureFlags {
     return getEnvOrDefault(LOG_CONNECTOR_MESSAGES, false, Boolean::parseBoolean);
   }
 
-  @Override public boolean needStateValidation() {
+  @Override
+  public boolean needStateValidation() {
     return getEnvOrDefault(NEED_STATE_VALIDATION, true, Boolean::parseBoolean);
   }
 

--- a/airbyte-commons/src/main/java/io/airbyte/commons/features/EnvVariableFeatureFlags.java
+++ b/airbyte-commons/src/main/java/io/airbyte/commons/features/EnvVariableFeatureFlags.java
@@ -42,7 +42,7 @@ public class EnvVariableFeatureFlags implements FeatureFlags {
   }
 
   @Override public boolean needStateValidation() {
-    return getEnvOrDefault(LOG_CONNECTOR_MESSAGES, true, Boolean::parseBoolean);
+    return getEnvOrDefault(NEED_STATE_VALIDATION, true, Boolean::parseBoolean);
   }
 
   // TODO: refactor in order to use the same method than the ones in EnvConfigs.java

--- a/airbyte-commons/src/main/java/io/airbyte/commons/features/EnvVariableFeatureFlags.java
+++ b/airbyte-commons/src/main/java/io/airbyte/commons/features/EnvVariableFeatureFlags.java
@@ -12,6 +12,7 @@ public class EnvVariableFeatureFlags implements FeatureFlags {
 
   public static final String USE_STREAM_CAPABLE_STATE = "USE_STREAM_CAPABLE_STATE";
   public static final String LOG_CONNECTOR_MESSAGES = "LOG_CONNECTOR_MESSAGES";
+  public static final String NEED_STATE_VALIDATION = "NEED_STATE_VALIDATION";
 
   @Override
   public boolean autoDisablesFailingConnections() {
@@ -38,6 +39,10 @@ public class EnvVariableFeatureFlags implements FeatureFlags {
   @Override
   public boolean logConnectorMessages() {
     return getEnvOrDefault(LOG_CONNECTOR_MESSAGES, false, Boolean::parseBoolean);
+  }
+
+  @Override public boolean needStateValidation() {
+    return getEnvOrDefault(LOG_CONNECTOR_MESSAGES, true, Boolean::parseBoolean);
   }
 
   // TODO: refactor in order to use the same method than the ones in EnvConfigs.java

--- a/airbyte-commons/src/main/java/io/airbyte/commons/features/FeatureFlags.java
+++ b/airbyte-commons/src/main/java/io/airbyte/commons/features/FeatureFlags.java
@@ -21,4 +21,5 @@ public interface FeatureFlags {
   boolean logConnectorMessages();
 
   boolean needStateValidation();
+
 }

--- a/airbyte-commons/src/main/java/io/airbyte/commons/features/FeatureFlags.java
+++ b/airbyte-commons/src/main/java/io/airbyte/commons/features/FeatureFlags.java
@@ -20,4 +20,5 @@ public interface FeatureFlags {
 
   boolean logConnectorMessages();
 
+  boolean needStateValidation();
 }

--- a/airbyte-workers/src/main/java/io/airbyte/workers/temporal/sync/PersistStateActivityImpl.java
+++ b/airbyte-workers/src/main/java/io/airbyte/workers/temporal/sync/PersistStateActivityImpl.java
@@ -4,17 +4,27 @@
 
 package io.airbyte.workers.temporal.sync;
 
+import static io.airbyte.config.helpers.StateMessageHelper.isMigration;
+import static io.airbyte.workers.helper.StateConverter.convertClientStateTypeToInternal;
+
+import com.google.common.annotations.VisibleForTesting;
 import io.airbyte.api.client.AirbyteApiClient;
 import io.airbyte.api.client.invoker.generated.ApiException;
+import io.airbyte.api.client.model.generated.ConnectionIdRequestBody;
+import io.airbyte.api.client.model.generated.ConnectionState;
 import io.airbyte.api.client.model.generated.ConnectionStateCreateOrUpdate;
 import io.airbyte.commons.features.FeatureFlags;
 import io.airbyte.config.StandardSyncOutput;
 import io.airbyte.config.State;
+import io.airbyte.config.StateType;
 import io.airbyte.config.StateWrapper;
 import io.airbyte.config.helpers.StateMessageHelper;
+import io.airbyte.protocol.models.CatalogHelpers;
 import io.airbyte.protocol.models.ConfiguredAirbyteCatalog;
+import io.airbyte.protocol.models.StreamDescriptor;
 import io.airbyte.workers.helper.StateConverter;
 import jakarta.inject.Singleton;
+import java.util.List;
 import java.util.Optional;
 import java.util.UUID;
 
@@ -37,6 +47,17 @@ public class PersistStateActivityImpl implements PersistStateActivity {
       try {
         final Optional<StateWrapper> maybeStateWrapper = StateMessageHelper.getTypedState(state.getState(), featureFlags.useStreamCapableState());
         if (maybeStateWrapper.isPresent()) {
+          final ConnectionState previousState = airbyteApiClient.getConnectionApi()
+              .getState(new ConnectionIdRequestBody().connectionId(connectionId));
+          if (previousState != null) {
+            final StateType newStateType = maybeStateWrapper.get().getStateType();
+            final StateType prevStateType = convertClientStateTypeToInternal(previousState.getStateType());
+
+            if (isMigration(newStateType, prevStateType) && newStateType == StateType.STREAM) {
+              validateStreamStates(maybeStateWrapper.get(), configuredCatalog);
+            }
+          }
+
           airbyteApiClient.getConnectionApi().createOrUpdateState(
               new ConnectionStateCreateOrUpdate()
                   .connectionId(connectionId)
@@ -49,6 +70,20 @@ public class PersistStateActivityImpl implements PersistStateActivity {
     } else {
       return false;
     }
+  }
+
+  @VisibleForTesting
+  void validateStreamStates(final StateWrapper state, final ConfiguredAirbyteCatalog configuredCatalog) {
+    final List<StreamDescriptor> stateStreamDescriptors =
+        state.getStateMessages().stream().map(stateMessage -> stateMessage.getStream().getStreamDescriptor()).toList();
+    final List<StreamDescriptor> catalogStreamDescriptors = CatalogHelpers.extractIncrementalStreamDescriptors(configuredCatalog);
+    catalogStreamDescriptors.forEach(streamDescriptor -> {
+      if (!stateStreamDescriptors.contains(streamDescriptor)) {
+        throw new IllegalStateException(
+            "Job ran during migration from Legacy State to Per Stream State. One of the streams that did not have state is: " + streamDescriptor
+                + ". Job must be retried in order to properly store state.");
+      }
+    });
   }
 
 }

--- a/airbyte-workers/src/main/java/io/airbyte/workers/temporal/sync/PersistStateActivityImpl.java
+++ b/airbyte-workers/src/main/java/io/airbyte/workers/temporal/sync/PersistStateActivityImpl.java
@@ -49,7 +49,7 @@ public class PersistStateActivityImpl implements PersistStateActivity {
         if (maybeStateWrapper.isPresent()) {
           final ConnectionState previousState = airbyteApiClient.getConnectionApi()
               .getState(new ConnectionIdRequestBody().connectionId(connectionId));
-          if (previousState != null) {
+          if (featureFlags.needStateValidation() && previousState != null) {
             final StateType newStateType = maybeStateWrapper.get().getStateType();
             final StateType prevStateType = convertClientStateTypeToInternal(previousState.getStateType());
 

--- a/airbyte-workers/src/test/java/io/airbyte/workers/temporal/sync/PersistStateActivityTest.java
+++ b/airbyte-workers/src/test/java/io/airbyte/workers/temporal/sync/PersistStateActivityTest.java
@@ -160,7 +160,6 @@ class PersistStateActivityTest {
     mockedStateMessageHelper.when(() -> StateMessageHelper.isMigration(Mockito.eq(StateType.GLOBAL), Mockito.any(StateType.class))).thenReturn(true);
     persistStateActivity.persist(CONNECTION_ID, syncOutput, migrationConfiguredCatalog);
     final PersistStateActivityImpl persistStateSpy = spy(persistStateActivity);
-    Mockito.verify(persistStateSpy, Mockito.times(0)).validateStreamStates(Mockito.any(), Mockito.any());
     Mockito.verify(connectionApi).createOrUpdateState(Mockito.any(ConnectionStateCreateOrUpdate.class));
   }
 

--- a/airbyte-workers/src/test/java/io/airbyte/workers/temporal/sync/PersistStateActivityTest.java
+++ b/airbyte-workers/src/test/java/io/airbyte/workers/temporal/sync/PersistStateActivityTest.java
@@ -160,6 +160,7 @@ class PersistStateActivityTest {
     mockedStateMessageHelper.when(() -> StateMessageHelper.isMigration(Mockito.eq(StateType.GLOBAL), Mockito.any(StateType.class))).thenReturn(true);
     persistStateActivity.persist(CONNECTION_ID, syncOutput, migrationConfiguredCatalog);
     final PersistStateActivityImpl persistStateSpy = spy(persistStateActivity);
+    Mockito.verify(persistStateSpy, Mockito.times(0)).validateStreamStates(Mockito.any(), Mockito.any());
     Mockito.verify(connectionApi).createOrUpdateState(Mockito.any(ConnectionStateCreateOrUpdate.class));
   }
 


### PR DESCRIPTION
## What
Remove the stream migration validation

This is related to https://github.com/airbytehq/oncall/issues/698

Some connector don't emit all the state that should be emitted, resulting in a validation error.
This validation is deprecated for the cloud project because platform has been migrated a while ago and can aggregate state properly. Another review will be done in the cloud in order to properly set this feature flag. 

