### PR TITLE
comparison of type system approaches

### DIFF
--- a/airbyte-config/config-models/src/main/resources/AirbyteTypes.yaml
+++ b/airbyte-config/config-models/src/main/resources/AirbyteTypes.yaml
@@ -1,0 +1,13 @@
+definitions:
+  TimestampWithTimezone:
+    type: String
+    description: ISO8601 encoded
+  TimestampWithoutTimezone:
+    type: String
+    description: ISO8601 encoded
+  TimesWithTimezone:
+    type: String
+    description: ISO8601 encoded
+  TimeWithoutTimezone:
+    type: String
+    description: ISO8601 encoded

--- a/airbyte-config/config-models/src/main/resources/type_exploration/airbyte.proto
+++ b/airbyte-config/config-models/src/main/resources/type_exploration/airbyte.proto
@@ -1,5 +1,6 @@
 import "google/protobuf/timestamp.proto";
 
+// =============================== DEFINITIONS ================================
 // types supported by airbyte.
 enum FieldType {
   STRING = 0;
@@ -40,6 +41,8 @@ message AirbyteTimeWithoutTimezone {
   required google.protobuf.Timestamp timestamp = 1;
 }
 
+// ====================== EXAMPLE SCHEMA IN PROTOBUF ===========================
+
 // example schema we want to be able to model
 // users
 // id - int
@@ -69,3 +72,5 @@ message user {
   repeated friend friend = 5;
   optional address address = 6;
 }
+// ======================EXAMPLE SCHEMA IN JSONSCHEMA =========================
+

--- a/airbyte-config/config-models/src/main/resources/type_exploration/proposal_airbyte_type.yaml
+++ b/airbyte-config/config-models/src/main/resources/type_exploration/proposal_airbyte_type.yaml
@@ -1,0 +1,57 @@
+# proposed with airybte_type field. set type field to string for everything and then augment it with airbyte_type field
+definitions:
+  description: user
+  type: object
+  properties:
+    id:
+      type: string
+      airbyte_type: integer
+      airbyte_attributes:
+        bit_width: 8
+    name:
+      type: string
+      airbyte_type: string
+    created_at:
+      type: string
+      airbyte_type: timestamp_with_tomezone
+    tags:
+      type: string
+      airbyte_type: list
+      items:
+        type: string
+        airbyte_type: string
+    friends:
+      type: string
+      airbyte_type: list
+      items:
+        type: string
+        airbyte_type: object
+        properties:
+          id:
+            type: string
+            airbyte_type: integer
+            airbyte_attributes:
+              bit_width: 8
+          name:
+            type: string
+            airbyte_type: string
+    address:
+      type: string
+      airbyte_type: object
+      properties:
+        address_num:
+          type: string
+          airbyte_type: integer
+          airbyte_attributes:
+            bit_width: 8
+        street:
+          type: string
+          airbyte_type: string
+        city:
+          type: string
+          airbyte_type: string
+        zip:
+          type: string
+          airbyte_type: integer
+          airbyte_attributes:
+            bit_width: 8

--- a/airbyte-config/config-models/src/main/resources/type_exploration/proposal_custom_type.yaml
+++ b/airbyte-config/config-models/src/main/resources/type_exploration/proposal_custom_type.yaml
@@ -1,0 +1,45 @@
+# proposed reusing the jsonschema type field with custom type. use the JSONSchema type field, but provide custom Airbyte types.
+definitions:
+  description: user
+  type: object
+  properties:
+    id:
+      type: integer
+      airbyte_attributes:
+        bit_width: 8
+    name:
+      type: string
+    created_at:
+      "$ref": AirbyteTypes.yaml#definitions/TimestampWithTimezone
+    tags:
+      type: list
+      items:
+        type: string
+    friends:
+      type: list
+      items:
+        type: object
+        properties:
+          id:
+            type: integer
+            airbyte_attributes:
+              bit_width: 8
+          name:
+            type: string
+    address:
+      type: object
+      properties:
+        address_num:
+          type: integer
+          airbyte_attributes:
+            bit_width: 8
+        street:
+          type: string
+          airbyte_type: string
+        city:
+          type: string
+        zip:
+          type: integer
+          airbyte_attributes:
+            bit_width: 8
+

--- a/airbyte-config/config-models/src/main/resources/types/airbyte.proto
+++ b/airbyte-config/config-models/src/main/resources/types/airbyte.proto
@@ -1,0 +1,71 @@
+import "google/protobuf/timestamp.proto";
+
+// types supported by airbyte.
+enum FieldType {
+  STRING = 0;
+  INT = 1;
+  LONG = 2;
+  BOOLEAN = 3;
+  OBJECT = 4;
+  LIST = 5;
+  DATE = 6;
+  TIMESTAMP_WITH_TIMEZONE = 7;
+  TIMESTAMP_WITHOUT_TIMEZONE = 8;
+  TIME_WITH_TIMEZONE = 9;
+  TIME_WITHOUT_TIMEZONE = 10;
+}
+
+// custom struct for each type
+message AirbyteStringField {
+  required string value = 1;
+}
+
+message AirbyteIntField {
+  required int32 value = 1;
+}
+
+message AirbyteTimestampWithTimezone {
+  required google.protobuf.Timestamp timestamp = 1;
+}
+
+message AirbyteTimestampWithoutTimezone {
+  required google.protobuf.Timestamp timestamp = 1;
+}
+
+message AirbyteTimeWithTimezone {
+  required google.protobuf.Timestamp timestamp = 1;
+}
+
+message AirbyteTimeWithoutTimezone {
+  required google.protobuf.Timestamp timestamp = 1;
+}
+
+// example schema we want to be able to model
+// users
+// id - int
+// name - string
+// created_at - timestamp with timezone
+// tags - list strings
+// friends - list object { id, name }
+// address - object { address_num, street, city, zip }
+
+message address {
+  optional AirbyteIntField address_num = 1;
+  optional AirbyteStringField street = 2;
+  optional AirbyteStringField city = 3;
+  optional AirbyteIntField zip = 4;
+}
+
+message friend {
+  optional AirbyteIntField id = 1;
+  optional AirbyteStringField name = 2;
+}
+
+message user {
+  optional AirbyteIntField id = 1;
+  optional AirbyteStringField name = 2;
+  optional AirbyteTimestampWithTimezone created_at = 3;
+  repeated AirbyteStringField tags = 4;
+  repeated friend friend = 5;
+  optional address address = 6;
+}


### PR DESCRIPTION
## What
Based on the investigation into updating our type system @evantahler and I have spoken a little about what it would look like to move to protobuf for our type declarations. This PR tries to summarize and compare a few options (both protobuf and JSONSchema)

`airbyte-config/config-models/src/main/resources/type_exploration/proposal_airbyte_type.yaml`: describes what our type system would look like given the [current proposal](https://docs.google.com/document/d/1dZOEbCkW2uDHdvIEdQeGL8gigSwGSKCGX5bESFicE9I/edit#).

`airbyte-config/config-models/src/main/resources/type_exploration/proposal_custom_type.yaml`: describes what our type system would look like if we continued to use the `type` field in JSONSchema but enriched it with our own custom types. one benefit here is that it decreases how far outside of the JSONSchema ecosystem we step AND saves us having to come up with custom serialization protocols.

`airbyte-config/config-models/src/main/resources/type_exploration/airbyte.proto`: describes what our type system might look like if we moved to protobuf.

I think these examples might be the foundation to have a conversation to compare some of the approaches. @evantahler @edgao . I was pleasantly surprised that protobuf actually seemed more usable than I realized.

cc @bleonard and @grishick for visibility