### PR TITLE
🐞 CDK: properly emit state on empty slices when using iterators

### DIFF
--- a/airbyte-cdk/python/CHANGELOG.md
+++ b/airbyte-cdk/python/CHANGELOG.md
@@ -1,5 +1,8 @@
 # Changelog
 
+## 0.1.89
+- Fix: properly emit state when a stream has empty slices, provided by an iterator
+
 ## 0.1.88
 - Bugfix: Evaluate `response.text` only in debug mode
 

--- a/airbyte-cdk/python/setup.py
+++ b/airbyte-cdk/python/setup.py
@@ -15,7 +15,7 @@ README = (HERE / "README.md").read_text()
 
 setup(
     name="airbyte-cdk",
-    version="0.1.88",
+    version="0.1.89",
     description="A framework for writing Airbyte Connectors.",
     long_description=README,
     long_description_content_type="text/markdown",

--- a/airbyte-cdk/python/unit_tests/sources/test_abstract_source.py
+++ b/airbyte-cdk/python/unit_tests/sources/test_abstract_source.py
@@ -606,7 +606,14 @@ class TestIncrementalRead:
             pytest.param(False, id="test_source_emits_state_as_per_stream_format"),
         ],
     )
-    def test_no_slices(self, mocker, use_legacy, per_stream_enabled):
+    @pytest.mark.parametrize(
+        "slices",
+        [
+            pytest.param([], id="test_slices_as_list"),
+            pytest.param(iter([]), id="test_slices_as_iterator")
+        ]
+    )
+    def test_no_slices(self, mocker, use_legacy, per_stream_enabled, slices):
         """
         Tests that an incremental read returns at least one state messages even if no records were read:
             1. outputs a state message after reading the entire stream
@@ -615,7 +622,7 @@ class TestIncrementalRead:
             input_state = defaultdict(dict)
         else:
             input_state = []
-        slices = []
+
         stream_output = [{"k1": "v1"}, {"k2": "v2"}, {"k3": "v3"}]
         state = {"cursor": "value"}
         stream_1 = MockStreamWithState(

--- a/airbyte-cdk/python/unit_tests/sources/test_abstract_source.py
+++ b/airbyte-cdk/python/unit_tests/sources/test_abstract_source.py
@@ -606,13 +606,7 @@ class TestIncrementalRead:
             pytest.param(False, id="test_source_emits_state_as_per_stream_format"),
         ],
     )
-    @pytest.mark.parametrize(
-        "slices",
-        [
-            pytest.param([], id="test_slices_as_list"),
-            pytest.param(iter([]), id="test_slices_as_iterator")
-        ]
-    )
+    @pytest.mark.parametrize("slices", [pytest.param([], id="test_slices_as_list"), pytest.param(iter([]), id="test_slices_as_iterator")])
     def test_no_slices(self, mocker, use_legacy, per_stream_enabled, slices):
         """
         Tests that an incremental read returns at least one state messages even if no records were read:


### PR DESCRIPTION
## What

Addresses https://github.com/airbytehq/oncall/issues/698

The CDK had a check for ensuring state is emitted for empty slices (added in https://github.com/airbytehq/airbyte/pull/15067), but this only worked if slices were returned in a list. If the slices are returned as a generator, which most sources are doing, this check would not work.

This is causing an issue because of a validation during per-stream state migration that ensures that we have state for all streams, even if they are empty.

## How

Fix the logic of emitting state on empty slices to work with iterators.
