### PR TITLE
minor cleanup of airbyte-metrics-reporter

### DIFF
--- a/airbyte-metrics/reporter/src/main/java/io/airbyte/metrics/reporter/ReporterApp.java
+++ b/airbyte-metrics/reporter/src/main/java/io/airbyte/metrics/reporter/ReporterApp.java
@@ -18,6 +18,7 @@ import io.airbyte.db.instance.configs.ConfigsDatabaseMigrator;
 import io.airbyte.metrics.lib.MetricClientFactory;
 import io.airbyte.metrics.lib.MetricEmittingApps;
 import java.util.concurrent.Executors;
+import java.util.concurrent.TimeUnit;
 import javax.sql.DataSource;
 import lombok.extern.slf4j.Slf4j;
 import org.flywaydb.core.Flyway;
@@ -59,7 +60,7 @@ public class ReporterApp {
 
       log.info("Scheduling {} metrics for emission..", toEmits.length);
       for (final ToEmit toEmit : toEmits) {
-        pollers.scheduleAtFixedRate(toEmit.emitRunnable, 0, toEmit.period, toEmit.timeUnit);
+        pollers.scheduleAtFixedRate(toEmit.emit, 0, toEmit.duration.getSeconds(), TimeUnit.SECONDS);
       }
     }
   }

--- a/airbyte-metrics/reporter/src/main/java/io/airbyte/metrics/reporter/ToEmit.java
+++ b/airbyte-metrics/reporter/src/main/java/io/airbyte/metrics/reporter/ToEmit.java
@@ -4,75 +4,91 @@
 
 package io.airbyte.metrics.reporter;
 
-import io.airbyte.commons.lang.Exceptions.Procedure;
 import io.airbyte.db.instance.jobs.jooq.generated.enums.JobStatus;
 import io.airbyte.metrics.lib.MetricAttribute;
 import io.airbyte.metrics.lib.MetricClientFactory;
 import io.airbyte.metrics.lib.MetricQueries;
 import io.airbyte.metrics.lib.MetricTags;
 import io.airbyte.metrics.lib.OssMetricsRegistry;
-import java.util.concurrent.TimeUnit;
-import lombok.AllArgsConstructor;
-import lombok.extern.slf4j.Slf4j;
+import java.lang.invoke.MethodHandles;
+import java.time.Duration;
+import java.util.concurrent.Callable;
 import org.apache.commons.lang3.tuple.Pair;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 /**
  * This class contains all metrics emitted by the {@link ReporterApp}.
  */
-@Slf4j
-@AllArgsConstructor
 public enum ToEmit {
 
   NUM_PENDING_JOBS(countMetricEmission(() -> {
     final var pendingJobs = ReporterApp.configDatabase.query(MetricQueries::numberOfPendingJobs);
     MetricClientFactory.getMetricClient().gauge(OssMetricsRegistry.NUM_PENDING_JOBS, pendingJobs);
+    return null;
   })),
   NUM_RUNNING_JOBS(countMetricEmission(() -> {
     final var runningJobs = ReporterApp.configDatabase.query(MetricQueries::numberOfRunningJobs);
     MetricClientFactory.getMetricClient().gauge(OssMetricsRegistry.NUM_RUNNING_JOBS, runningJobs);
+    return null;
   })),
   NUM_ORPHAN_RUNNING_JOB(countMetricEmission(() -> {
     final var orphanRunningJobs = ReporterApp.configDatabase.query(MetricQueries::numberOfOrphanRunningJobs);
     MetricClientFactory.getMetricClient().gauge(OssMetricsRegistry.NUM_ORPHAN_RUNNING_JOBS, orphanRunningJobs);
+    return null;
   })),
   OLDEST_RUNNING_JOB_AGE_SECS(countMetricEmission(() -> {
     final var age = ReporterApp.configDatabase.query(MetricQueries::oldestRunningJobAgeSecs);
     MetricClientFactory.getMetricClient().gauge(OssMetricsRegistry.OLDEST_RUNNING_JOB_AGE_SECS, age);
+    return null;
   })),
   OLDEST_PENDING_JOB_AGE_SECS(countMetricEmission(() -> {
     final var age = ReporterApp.configDatabase.query(MetricQueries::oldestPendingJobAgeSecs);
     MetricClientFactory.getMetricClient().gauge(OssMetricsRegistry.OLDEST_PENDING_JOB_AGE_SECS, age);
+    return null;
   })),
   NUM_ACTIVE_CONN_PER_WORKSPACE(countMetricEmission(() -> {
     final var age = ReporterApp.configDatabase.query(MetricQueries::numberOfActiveConnPerWorkspace);
-    for (long count : age) {
+    for (final long count : age) {
       MetricClientFactory.getMetricClient().distribution(OssMetricsRegistry.NUM_ACTIVE_CONN_PER_WORKSPACE, count);
     }
+    return null;
   })),
-  NUM_ABNORMAL_SCHEDULED_SYNCS_LAST_DAY(countMetricEmission(() -> {
+  NUM_ABNORMAL_SCHEDULED_SYNCS_LAST_DAY(Duration.ofHours(1), countMetricEmission(() -> {
     final var count = ReporterApp.configDatabase.query(MetricQueries::numberOfJobsNotRunningOnScheduleInLastDay);
     MetricClientFactory.getMetricClient().gauge(OssMetricsRegistry.NUM_ABNORMAL_SCHEDULED_SYNCS_IN_LAST_DAY, count);
-  }), 1, TimeUnit.HOURS),
-  NUM_TOTAL_SCHEDULED_SYNCS_LAST_DAY(countMetricEmission(() -> {
+    return null;
+  })),
+  NUM_TOTAL_SCHEDULED_SYNCS_LAST_DAY(Duration.ofHours(1), countMetricEmission(() -> {
     final var count = ReporterApp.configDatabase.query(MetricQueries::numScheduledActiveConnectionsInLastDay);
     MetricClientFactory.getMetricClient().gauge(OssMetricsRegistry.NUM_TOTAL_SCHEDULED_SYNCS_IN_LAST_DAY, count);
-  }), 1, TimeUnit.HOURS),
-  OVERALL_JOB_RUNTIME_IN_LAST_HOUR_BY_TERMINAL_STATE_SECS(countMetricEmission(() -> {
+    return null;
+  })),
+  OVERALL_JOB_RUNTIME_IN_LAST_HOUR_BY_TERMINAL_STATE_SECS(Duration.ofHours(1), countMetricEmission(() -> {
     final var times = ReporterApp.configDatabase.query(MetricQueries::overallJobRuntimeForTerminalJobsInLastHour);
-    for (Pair<JobStatus, Double> pair : times) {
+    for (final Pair<JobStatus, Double> pair : times) {
       MetricClientFactory.getMetricClient().distribution(
           OssMetricsRegistry.OVERALL_JOB_RUNTIME_IN_LAST_HOUR_BY_TERMINAL_STATE_SECS, pair.getRight(),
           new MetricAttribute(MetricTags.JOB_STATUS, MetricTags.getJobStatus(pair.getLeft())));
     }
-  }), 1, TimeUnit.HOURS);
+    return null;
+  }));
+
+  private static final Logger log = LoggerFactory.getLogger(MethodHandles.lookup().lookupClass());
 
   // default constructor
-  final public Runnable emitRunnable;
-  final public long period;
-  final public TimeUnit timeUnit;
+  /** A runnable that emits a metric. */
+  final public Runnable emit;
+  /** How often this metric would emit data. */
+  final public Duration duration;
 
-  ToEmit(final Runnable toEmit) {
-    this(toEmit, 15, TimeUnit.SECONDS);
+  ToEmit(final Runnable emit) {
+    this(Duration.ofSeconds(15), emit);
+  }
+
+  ToEmit(final Duration duration, final Runnable emit) {
+    this.duration = duration;
+    this.emit = emit;
   }
 
   /**
@@ -82,7 +98,7 @@ public enum ToEmit {
    * @param metricQuery
    * @return
    */
-  private static Runnable countMetricEmission(final Procedure metricQuery) {
+  private static Runnable countMetricEmission(final Callable<Void> metricQuery) {
     return () -> {
       try {
         metricQuery.call();


### PR DESCRIPTION
## What
- minor clean-up of `metrics-reporter`

## How
- replace our custom `Procedure` interface with java's `Callable` interface
- remove lombok annotations
- replace two variables `period` and `timeUnit` with one variable `duration`
- add `final` keywords where applicable 

## Recommended reading order
1. `x.java`
