### PR TITLE
🚨 Add SSL documentation and check logic for S3 Destination 🚨 

### DIFF
--- a/airbyte-config/init/src/main/resources/seed/destination_definitions.yaml
+++ b/airbyte-config/init/src/main/resources/seed/destination_definitions.yaml
@@ -257,7 +257,7 @@
 - name: S3
   destinationDefinitionId: 4816b78f-1489-44c1-9060-4b19d5fa9362
   dockerRepository: airbyte/destination-s3
-  dockerImageTag: 0.3.15
+  dockerImageTag: 0.3.16
   documentationUrl: https://docs.airbyte.io/integrations/destinations/s3
   icon: s3.svg
   resourceRequirements:

--- a/airbyte-config/init/src/main/resources/seed/destination_specs.yaml
+++ b/airbyte-config/init/src/main/resources/seed/destination_specs.yaml
@@ -4420,7 +4420,7 @@
     supported_destination_sync_modes:
     - "append"
     - "overwrite"
-- dockerImage: "airbyte/destination-s3:0.3.15"
+- dockerImage: "airbyte/destination-s3:0.3.16"
   spec:
     documentationUrl: "https://docs.airbyte.io/integrations/destinations/s3"
     connectionSpecification:

--- a/airbyte-integrations/bases/base-java-s3/src/main/java/io/airbyte/integrations/destination/s3/BaseS3Destination.java
+++ b/airbyte-integrations/bases/base-java-s3/src/main/java/io/airbyte/integrations/destination/s3/BaseS3Destination.java
@@ -47,7 +47,6 @@ public abstract class BaseS3Destination extends BaseConnector implements Destina
       S3BaseChecks.attemptS3WriteAndDelete(storageOperations, destinationConfig, destinationConfig.getBucketName());
       S3BaseChecks.testSingleUpload(s3Client, destinationConfig.getBucketName(), destinationConfig.getBucketPath());
       S3BaseChecks.testMultipartUpload(s3Client, destinationConfig.getBucketName(), destinationConfig.getBucketPath());
-      S3BaseChecks.testCustomEndpointSecured(destinationConfig.getEndpoint());
 
       return new AirbyteConnectionStatus().withStatus(Status.SUCCEEDED);
     } catch (final Exception e) {

--- a/airbyte-integrations/bases/base-java-s3/src/main/java/io/airbyte/integrations/destination/s3/BaseS3Destination.java
+++ b/airbyte-integrations/bases/base-java-s3/src/main/java/io/airbyte/integrations/destination/s3/BaseS3Destination.java
@@ -38,7 +38,7 @@ public abstract class BaseS3Destination extends BaseConnector implements Destina
   }
 
   @Override
-  public AirbyteConnectionStatus check(JsonNode config) {
+  public AirbyteConnectionStatus check(final JsonNode config) {
     try {
       final S3DestinationConfig destinationConfig = configFactory.getS3DestinationConfig(config, storageProvider());
       final AmazonS3 s3Client = destinationConfig.getS3Client();
@@ -47,6 +47,7 @@ public abstract class BaseS3Destination extends BaseConnector implements Destina
       S3BaseChecks.attemptS3WriteAndDelete(storageOperations, destinationConfig, destinationConfig.getBucketName());
       S3BaseChecks.testSingleUpload(s3Client, destinationConfig.getBucketName(), destinationConfig.getBucketPath());
       S3BaseChecks.testMultipartUpload(s3Client, destinationConfig.getBucketName(), destinationConfig.getBucketPath());
+      S3BaseChecks.testCustomEndpointSecured(destinationConfig.getEndpoint());
 
       return new AirbyteConnectionStatus().withStatus(Status.SUCCEEDED);
     } catch (final Exception e) {
@@ -59,9 +60,9 @@ public abstract class BaseS3Destination extends BaseConnector implements Destina
   }
 
   @Override
-  public AirbyteMessageConsumer getConsumer(JsonNode config,
-                                            ConfiguredAirbyteCatalog catalog,
-                                            Consumer<AirbyteMessage> outputRecordCollector) {
+  public AirbyteMessageConsumer getConsumer(final JsonNode config,
+                                            final ConfiguredAirbyteCatalog catalog,
+                                            final Consumer<AirbyteMessage> outputRecordCollector) {
     final S3DestinationConfig s3Config = configFactory.getS3DestinationConfig(config, storageProvider());
     return new S3ConsumerFactory().create(
         outputRecordCollector,

--- a/airbyte-integrations/bases/base-java-s3/src/main/java/io/airbyte/integrations/destination/s3/BaseS3Destination.java
+++ b/airbyte-integrations/bases/base-java-s3/src/main/java/io/airbyte/integrations/destination/s3/BaseS3Destination.java
@@ -24,7 +24,7 @@ public abstract class BaseS3Destination extends BaseConnector implements Destina
 
   private static final Logger LOGGER = LoggerFactory.getLogger(BaseS3Destination.class);
 
-  private final S3DestinationConfigFactory configFactory;
+  protected final S3DestinationConfigFactory configFactory;
 
   private final NamingConventionTransformer nameTransformer;
 

--- a/airbyte-integrations/bases/base-java-s3/src/main/java/io/airbyte/integrations/destination/s3/S3BaseChecks.java
+++ b/airbyte-integrations/bases/base-java-s3/src/main/java/io/airbyte/integrations/destination/s3/S3BaseChecks.java
@@ -82,11 +82,8 @@ public final class S3BaseChecks {
    *
    * @param endpoint URL string representing an accessible S3 bucket
    */
-  public static void testCustomEndpointSecured(final String endpoint) {
-    if (!endpoint.contains("https://")) {
-      throw new RuntimeException(
-          "S3 custom endpoint does not ensure HTTPS only connection. Please use S3 Access Points endpoints for a secure connection");
-    }
+  public static boolean testCustomEndpointSecured(final String endpoint) {
+    return endpoint.contains("https://");
   }
 
   @VisibleForTesting

--- a/airbyte-integrations/bases/base-java-s3/src/main/java/io/airbyte/integrations/destination/s3/S3BaseChecks.java
+++ b/airbyte-integrations/bases/base-java-s3/src/main/java/io/airbyte/integrations/destination/s3/S3BaseChecks.java
@@ -77,6 +77,17 @@ public final class S3BaseChecks {
     LOGGER.info("Finished verification for multipart upload mode");
   }
 
+  /**
+   * Checks that S3 custom endpoint uses a variant that only uses HTTPS
+   * <p>https://docs.aws.amazon.com/general/latest/gr/s3.html</p>
+   * @param endpoint URL string representing an accessible S3 bucket
+   */
+  public static void testCustomEndpointSecured(final String endpoint) {
+    if (!endpoint.contains("s3-accesspoint")) {
+      throw new RuntimeException("S3 custom endpoint does not ensure HTTPS only connection");
+    }
+  }
+
   @VisibleForTesting
   static void attemptS3WriteAndDelete(final S3StorageOperations storageOperations,
                                       final S3DestinationConfig s3Config,

--- a/airbyte-integrations/bases/base-java-s3/src/main/java/io/airbyte/integrations/destination/s3/S3BaseChecks.java
+++ b/airbyte-integrations/bases/base-java-s3/src/main/java/io/airbyte/integrations/destination/s3/S3BaseChecks.java
@@ -84,7 +84,7 @@ public final class S3BaseChecks {
    */
   public static void testCustomEndpointSecured(final String endpoint) {
     if (!endpoint.contains("s3-accesspoint")) {
-      throw new RuntimeException("S3 custom endpoint does not ensure HTTPS only connection");
+      throw new RuntimeException("S3 custom endpoint does not ensure HTTPS only connection. Please use S3 Access Points endpoints for a secure connection");
     }
   }
 

--- a/airbyte-integrations/bases/base-java-s3/src/main/java/io/airbyte/integrations/destination/s3/S3BaseChecks.java
+++ b/airbyte-integrations/bases/base-java-s3/src/main/java/io/airbyte/integrations/destination/s3/S3BaseChecks.java
@@ -87,7 +87,7 @@ public final class S3BaseChecks {
     if (endpoint == null || endpoint.length() == 0) {
       return true;
     } else {
-      return endpoint.contains("https://");
+      return endpoint.startsWith("https://");
     }
   }
 

--- a/airbyte-integrations/bases/base-java-s3/src/main/java/io/airbyte/integrations/destination/s3/S3BaseChecks.java
+++ b/airbyte-integrations/bases/base-java-s3/src/main/java/io/airbyte/integrations/destination/s3/S3BaseChecks.java
@@ -79,12 +79,13 @@ public final class S3BaseChecks {
 
   /**
    * Checks that S3 custom endpoint uses a variant that only uses HTTPS
-   * <p>https://docs.aws.amazon.com/general/latest/gr/s3.html</p>
+   *
    * @param endpoint URL string representing an accessible S3 bucket
    */
   public static void testCustomEndpointSecured(final String endpoint) {
-    if (!endpoint.contains("s3-accesspoint")) {
-      throw new RuntimeException("S3 custom endpoint does not ensure HTTPS only connection. Please use S3 Access Points endpoints for a secure connection");
+    if (!endpoint.contains("https://")) {
+      throw new RuntimeException(
+          "S3 custom endpoint does not ensure HTTPS only connection. Please use S3 Access Points endpoints for a secure connection");
     }
   }
 

--- a/airbyte-integrations/bases/base-java-s3/src/main/java/io/airbyte/integrations/destination/s3/S3BaseChecks.java
+++ b/airbyte-integrations/bases/base-java-s3/src/main/java/io/airbyte/integrations/destination/s3/S3BaseChecks.java
@@ -83,7 +83,12 @@ public final class S3BaseChecks {
    * @param endpoint URL string representing an accessible S3 bucket
    */
   public static boolean testCustomEndpointSecured(final String endpoint) {
-    return endpoint.contains("https://");
+    // if user does not use a custom endpoint, do not fail
+    if (endpoint == null || endpoint.length() == 0) {
+      return true;
+    } else {
+      return endpoint.contains("https://");
+    }
   }
 
   @VisibleForTesting

--- a/airbyte-integrations/bases/base-java-s3/src/main/java/io/airbyte/integrations/destination/s3/S3DestinationConfig.java
+++ b/airbyte-integrations/bases/base-java-s3/src/main/java/io/airbyte/integrations/destination/s3/S3DestinationConfig.java
@@ -15,6 +15,7 @@ import static io.airbyte.integrations.destination.s3.constant.S3Constants.S_3_EN
 import static io.airbyte.integrations.destination.s3.constant.S3Constants.S_3_PATH_FORMAT;
 
 import com.amazonaws.ClientConfiguration;
+import com.amazonaws.Protocol;
 import com.amazonaws.auth.AWSCredentialsProvider;
 import com.amazonaws.client.builder.AwsClientBuilder;
 import com.amazonaws.services.s3.AmazonS3;
@@ -253,7 +254,7 @@ public class S3DestinationConfig {
           .build();
     }
 
-    final ClientConfiguration clientConfiguration = new ClientConfiguration();
+    final ClientConfiguration clientConfiguration = new ClientConfiguration().withProtocol(Protocol.HTTPS);
     clientConfiguration.setSignerOverride("AWSS3V4SignerType");
 
     return AmazonS3ClientBuilder.standard()

--- a/airbyte-integrations/bases/base-java/src/main/java/io/airbyte/integrations/base/adaptive/AdaptiveDestinationRunner.java
+++ b/airbyte-integrations/bases/base-java/src/main/java/io/airbyte/integrations/base/adaptive/AdaptiveDestinationRunner.java
@@ -19,7 +19,7 @@ public class AdaptiveDestinationRunner {
   private static final Logger LOGGER = LoggerFactory.getLogger(AdaptiveDestinationRunner.class);
 
   private static final String DEPLOYMENT_MODE_KEY = "DEPLOYMENT_MODE";
-  private static final String COULD_MODE = "CLOUD";
+  private static final String CLOUD_MODE = "CLOUD";
 
   public static OssDestinationBuilder baseOnEnv() {
     final String mode = System.getenv(DEPLOYMENT_MODE_KEY);
@@ -72,7 +72,7 @@ public class AdaptiveDestinationRunner {
 
     private Destination getDestination() {
       LOGGER.info("Running destination under deployment mode: {}", deploymentMode);
-      if (deploymentMode != null && deploymentMode.equals(COULD_MODE)) {
+      if (deploymentMode != null && deploymentMode.equals(CLOUD_MODE)) {
         return cloudDestinationSupplier.get();
       }
       if (deploymentMode == null) {

--- a/airbyte-integrations/connectors/destination-s3/Dockerfile
+++ b/airbyte-integrations/connectors/destination-s3/Dockerfile
@@ -41,5 +41,5 @@ RUN /bin/bash -c 'set -e && \
        echo "unknown arch" ;\
     fi'
 
-LABEL io.airbyte.version=0.3.15
+LABEL io.airbyte.version=0.3.16
 LABEL io.airbyte.name=airbyte/destination-s3

--- a/airbyte-integrations/connectors/destination-s3/build.gradle
+++ b/airbyte-integrations/connectors/destination-s3/build.gradle
@@ -5,7 +5,7 @@ plugins {
 }
 
 application {
-    mainClass = 'io.airbyte.integrations.destination.s3.S3Destination'
+    mainClass = 'io.airbyte.integrations.destination.s3.S3DestinationRunner'
     applicationDefaultJvmArgs = ['-XX:+ExitOnOutOfMemoryError', '-XX:MaxRAMPercentage=75.0']
 }
 

--- a/airbyte-integrations/connectors/destination-s3/src/main/java/io/airbyte/integrations/destination/s3/S3Destination.java
+++ b/airbyte-integrations/connectors/destination-s3/src/main/java/io/airbyte/integrations/destination/s3/S3Destination.java
@@ -4,17 +4,19 @@
 
 package io.airbyte.integrations.destination.s3;
 
+import com.google.common.annotations.VisibleForTesting;
 import io.airbyte.integrations.base.IntegrationRunner;
 
 public class S3Destination extends BaseS3Destination {
 
   public S3Destination() {}
 
-  public S3Destination(final S3DestinationConfigFactory s3DestinationConfigFactory) {
+  @VisibleForTesting
+  protected S3Destination(final S3DestinationConfigFactory s3DestinationConfigFactory) {
     super(s3DestinationConfigFactory);
   }
 
-  public static void main(String[] args) throws Exception {
+  public static void main(final String[] args) throws Exception {
     new IntegrationRunner(new S3Destination()).run(args);
   }
 

--- a/airbyte-integrations/connectors/destination-s3/src/main/java/io/airbyte/integrations/destination/s3/S3DestinationRunner.java
+++ b/airbyte-integrations/connectors/destination-s3/src/main/java/io/airbyte/integrations/destination/s3/S3DestinationRunner.java
@@ -1,0 +1,17 @@
+/*
+ * Copyright (c) 2022 Airbyte, Inc., all rights reserved.
+ */
+
+package io.airbyte.integrations.destination.s3;
+
+import io.airbyte.integrations.base.adaptive.AdaptiveDestinationRunner;
+
+public class S3DestinationRunner {
+
+  public static void main(final String[] args) throws Exception {
+    AdaptiveDestinationRunner.baseOnEnv()
+        .withOssDestination(S3Destination::new)
+        .withCloudDestination(S3DestinationStrictEncrypt::new)
+        .run(args);
+  }
+}

--- a/airbyte-integrations/connectors/destination-s3/src/main/java/io/airbyte/integrations/destination/s3/S3DestinationStrictEncrypt.java
+++ b/airbyte-integrations/connectors/destination-s3/src/main/java/io/airbyte/integrations/destination/s3/S3DestinationStrictEncrypt.java
@@ -5,12 +5,18 @@
 package io.airbyte.integrations.destination.s3;
 
 import com.fasterxml.jackson.databind.JsonNode;
+import com.google.common.annotations.VisibleForTesting;
 import io.airbyte.protocol.models.AirbyteConnectionStatus;
 import io.airbyte.protocol.models.AirbyteConnectionStatus.Status;
 
 public class S3DestinationStrictEncrypt extends S3Destination {
 
-  public S3DestinationStrictEncrypt(final S3DestinationConfigFactory configFactory) {
+  public S3DestinationStrictEncrypt() {
+    super();
+  }
+
+  @VisibleForTesting
+  protected S3DestinationStrictEncrypt(final S3DestinationConfigFactory configFactory) {
     super(configFactory);
   }
 

--- a/airbyte-integrations/connectors/destination-s3/src/main/java/io/airbyte/integrations/destination/s3/S3DestinationStrictEncrypt.java
+++ b/airbyte-integrations/connectors/destination-s3/src/main/java/io/airbyte/integrations/destination/s3/S3DestinationStrictEncrypt.java
@@ -24,6 +24,7 @@ public class S3DestinationStrictEncrypt extends S3Destination {
   public AirbyteConnectionStatus check(final JsonNode config) {
     final S3DestinationConfig destinationConfig = this.configFactory.getS3DestinationConfig(config, super.storageProvider());
 
+    // Fails early to avoid extraneous validations checks if custom endpoint is not secure
     if (!S3BaseChecks.testCustomEndpointSecured(destinationConfig.getEndpoint())) {
       return new AirbyteConnectionStatus()
           .withStatus(Status.FAILED)

--- a/airbyte-integrations/connectors/destination-s3/src/main/java/io/airbyte/integrations/destination/s3/S3DestinationStrictEncrypt.java
+++ b/airbyte-integrations/connectors/destination-s3/src/main/java/io/airbyte/integrations/destination/s3/S3DestinationStrictEncrypt.java
@@ -1,0 +1,28 @@
+/*
+ * Copyright (c) 2022 Airbyte, Inc., all rights reserved.
+ */
+
+package io.airbyte.integrations.destination.s3;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import io.airbyte.protocol.models.AirbyteConnectionStatus;
+import io.airbyte.protocol.models.AirbyteConnectionStatus.Status;
+
+public class S3DestinationStrictEncrypt extends S3Destination {
+
+  public S3DestinationStrictEncrypt(final S3DestinationConfigFactory configFactory) {
+    super(configFactory);
+  }
+
+  @Override
+  public AirbyteConnectionStatus check(final JsonNode config) {
+    final S3DestinationConfig destinationConfig = this.configFactory.getS3DestinationConfig(config, super.storageProvider());
+
+    if (!S3BaseChecks.testCustomEndpointSecured(destinationConfig.getEndpoint())) {
+      return new AirbyteConnectionStatus()
+          .withStatus(Status.FAILED)
+          .withMessage("Custom endpoint does not use HTTPS");
+    }
+    return super.check(config);
+  }
+}

--- a/airbyte-integrations/connectors/destination-s3/src/main/resources/spec.json
+++ b/airbyte-integrations/connectors/destination-s3/src/main/resources/spec.json
@@ -360,7 +360,7 @@
         "type": "string",
         "default": "",
         "description": "Your S3 endpoint url. Read more <a href=\"https://docs.aws.amazon.com/general/latest/gr/s3.html#:~:text=Service%20endpoints-,Amazon%20S3%20endpoints,-When%20you%20use\">here</a>",
-        "examples": ["s3-accesspoint.us-east-2.amazonaws.com"],
+        "examples": ["http://localhost:9000"],
         "order": 6
       },
       "s3_path_format": {

--- a/airbyte-integrations/connectors/destination-s3/src/main/resources/spec.json
+++ b/airbyte-integrations/connectors/destination-s3/src/main/resources/spec.json
@@ -360,7 +360,7 @@
         "type": "string",
         "default": "",
         "description": "Your S3 endpoint url. Read more <a href=\"https://docs.aws.amazon.com/general/latest/gr/s3.html#:~:text=Service%20endpoints-,Amazon%20S3%20endpoints,-When%20you%20use\">here</a>",
-        "examples": ["http://localhost:9000"],
+        "examples": ["s3-accesspoint.us-east-2.amazonaws.com"],
         "order": 6
       },
       "s3_path_format": {

--- a/airbyte-integrations/connectors/destination-s3/src/test/java/io/airbyte/integrations/destination/s3/S3DestinationStrictEncryptTest.java
+++ b/airbyte-integrations/connectors/destination-s3/src/test/java/io/airbyte/integrations/destination/s3/S3DestinationStrictEncryptTest.java
@@ -1,0 +1,76 @@
+/*
+ * Copyright (c) 2022 Airbyte, Inc., all rights reserved.
+ */
+
+package io.airbyte.integrations.destination.s3;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+import com.amazonaws.services.s3.AmazonS3;
+import com.amazonaws.services.s3.model.InitiateMultipartUploadRequest;
+import com.amazonaws.services.s3.model.InitiateMultipartUploadResult;
+import com.amazonaws.services.s3.model.UploadPartRequest;
+import com.amazonaws.services.s3.model.UploadPartResult;
+import com.fasterxml.jackson.databind.JsonNode;
+import io.airbyte.protocol.models.AirbyteConnectionStatus;
+import io.airbyte.protocol.models.AirbyteConnectionStatus.Status;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+public class S3DestinationStrictEncryptTest {
+
+  private AmazonS3 s3;
+  private S3DestinationConfigFactory factoryConfig;
+
+  @BeforeEach
+  public void setup() {
+    s3 = mock(AmazonS3.class);
+    final InitiateMultipartUploadResult uploadResult = mock(InitiateMultipartUploadResult.class);
+    final UploadPartResult uploadPartResult = mock(UploadPartResult.class);
+    when(s3.uploadPart(any(UploadPartRequest.class))).thenReturn(uploadPartResult);
+    when(s3.initiateMultipartUpload(any(InitiateMultipartUploadRequest.class))).thenReturn(uploadResult);
+
+    factoryConfig = new S3DestinationConfigFactory() {
+      public S3DestinationConfig getS3DestinationConfig(final JsonNode config, final StorageProvider storageProvider) {
+        return S3DestinationConfig.create("fake-bucket", "fake-bucketPath", "fake-region")
+            .withEndpoint("https://s3.example.com")
+            .withAccessKeyCredential("fake-accessKeyId", "fake-secretAccessKey")
+            .withS3Client(s3)
+            .get();
+      }
+    };
+  }
+
+
+  /**
+   * Test that checks if user is using a connection that is HTTPS only
+   */
+  @Test
+  public void checksCustomEndpointIsHttpsOnly() {
+    final S3Destination destinationWithHttpsOnlyEndpoint = new S3DestinationStrictEncrypt(factoryConfig);
+    final AirbyteConnectionStatus status = destinationWithHttpsOnlyEndpoint.check(null);
+    assertEquals(Status.SUCCEEDED, status.getStatus(), "custom endpoint did not contain `s3-accesspoint`");
+  }
+
+  /**
+   * Test that checks if user is using a connection that is deemed insecure since it does not always enforce HTTPS only
+   * <p>https://docs.aws.amazon.com/general/latest/gr/s3.html</p>
+   */
+  @Test
+  public void checksCustomEndpointIsNotHttpsOnly() {
+    final S3Destination destinationWithStandardUnsecuredEndpoint = new S3DestinationStrictEncrypt(new S3DestinationConfigFactory() {
+      public S3DestinationConfig getS3DestinationConfig(final JsonNode config, final StorageProvider storageProvider) {
+        return S3DestinationConfig.create("fake-bucket", "fake-bucketPath", "fake-region")
+            .withEndpoint("s3.us-west-1.amazonaws.com")
+            .withAccessKeyCredential("fake-accessKeyId", "fake-secretAccessKey")
+            .withS3Client(s3)
+            .get();
+      }
+    });
+    final AirbyteConnectionStatus status = destinationWithStandardUnsecuredEndpoint.check(null);
+    assertEquals(Status.FAILED, status.getStatus());
+  }
+}

--- a/airbyte-integrations/connectors/destination-s3/src/test/java/io/airbyte/integrations/destination/s3/S3DestinationTest.java
+++ b/airbyte-integrations/connectors/destination-s3/src/test/java/io/airbyte/integrations/destination/s3/S3DestinationTest.java
@@ -102,33 +102,4 @@ public class S3DestinationTest {
     verifyNoMoreInteractions(s3);
   }
 
-  /**
-   * Test that checks if user is using a connection that is HTTPS only
-   */
-  @Test
-  public void checksCustomEndpointIsHttpsOnly() {
-    final S3Destination destinationWithHttpsOnlyEndpoint = new S3Destination(factoryConfig);
-    final AirbyteConnectionStatus status = destinationWithHttpsOnlyEndpoint.check(null);
-    assertEquals(Status.SUCCEEDED, status.getStatus(), "custom endpoint did not contain `s3-accesspoint`");
-  }
-
-  /**
-   * Test that checks if user is using a connection that is deemed insecure since it does not always enforce HTTPS only
-   * <p>https://docs.aws.amazon.com/general/latest/gr/s3.html</p>
-   */
-  @Test
-  public void checksCustomEndpointIsNotHttpsOnly() {
-    final S3Destination destinationWithStandardUnsecuredEndpoint = new S3Destination(new S3DestinationConfigFactory() {
-      public S3DestinationConfig getS3DestinationConfig(final JsonNode config, final StorageProvider storageProvider) {
-        return S3DestinationConfig.create("fake-bucket", "fake-bucketPath", "fake-region")
-            .withEndpoint("s3.us-west-1.amazonaws.com")
-            .withAccessKeyCredential("fake-accessKeyId", "fake-secretAccessKey")
-            .withS3Client(s3)
-            .get();
-      }
-    });
-    final AirbyteConnectionStatus status = destinationWithStandardUnsecuredEndpoint.check(null);
-    assertEquals(Status.FAILED, status.getStatus());
-  }
-
 }

--- a/airbyte-integrations/connectors/destination-s3/src/test/java/io/airbyte/integrations/destination/s3/S3DestinationTest.java
+++ b/airbyte-integrations/connectors/destination-s3/src/test/java/io/airbyte/integrations/destination/s3/S3DestinationTest.java
@@ -51,16 +51,13 @@ public class S3DestinationTest {
         .get();
 
     factoryConfig = new S3DestinationConfigFactory() {
-
-      // endpoint defaults to "s3-accesspoint" to allow tests to pass with secured custom S3 endpoint
       public S3DestinationConfig getS3DestinationConfig(final JsonNode config, final StorageProvider storageProvider) {
         return S3DestinationConfig.create("fake-bucket", "fake-bucketPath", "fake-region")
-            .withEndpoint("s3-accesspoint.us-west-1.amazonaws.com")
+            .withEndpoint("https://s3.example.com")
             .withAccessKeyCredential("fake-accessKeyId", "fake-secretAccessKey")
             .withS3Client(s3)
             .get();
       }
-
     };
   }
 
@@ -122,7 +119,7 @@ public class S3DestinationTest {
   @Test
   public void checksCustomEndpointIsNotHttpsOnly() {
     final S3Destination destinationWithStandardUnsecuredEndpoint = new S3Destination(new S3DestinationConfigFactory() {
-      public S3DestinationConfig getS3DestinationConfig(final JsonNode config) {
+      public S3DestinationConfig getS3DestinationConfig(final JsonNode config, final StorageProvider storageProvider) {
         return S3DestinationConfig.create("fake-bucket", "fake-bucketPath", "fake-region")
             .withEndpoint("s3.us-west-1.amazonaws.com")
             .withAccessKeyCredential("fake-accessKeyId", "fake-secretAccessKey")

--- a/airbyte-webapp/src/core/domain/connector/constants.ts
+++ b/airbyte-webapp/src/core/domain/connector/constants.ts
@@ -30,7 +30,6 @@ export const getExcludedConnectorIds = (workspaceId: string) =>
         "2340cbba-358e-11ec-8d3d-0242ac130203", // hide Pular Destination https://github.com/airbytehq/airbyte-cloud/issues/2614
         "d4d3fef9-e319-45c2-881a-bd02ce44cc9f", // hide Redis Destination https://github.com/airbytehq/airbyte-cloud/issues/2593
         "2c9d93a7-9a17-4789-9de9-f46f0097eb70", // hide Rockset Destination https://github.com/airbytehq/airbyte-cloud/issues/2615
-        "4816b78f-1489-44c1-9060-4b19d5fa9362", // hide S3 Destination https://github.com/airbytehq/airbyte-cloud/issues/2616
         "69589781-7828-43c5-9f63-8925b1c1ccc2", // hide S3 Source https://github.com/airbytehq/airbyte-cloud/issues/2618
         "2470e835-feaf-4db6-96f3-70fd645acc77", // Salesforce Singer
         "3dc6f384-cd6b-4be3-ad16-a41450899bf0", // hide Scylla Destination https://github.com/airbytehq/airbyte-cloud/issues/2617

--- a/docs/integrations/destinations/s3.md
+++ b/docs/integrations/destinations/s3.md
@@ -12,7 +12,8 @@ List of required fields:
 * **S3 Bucket Region**
 
 1. Allow connections from Airbyte server to your AWS S3/ Minio S3 cluster \(if they exist in separate VPCs\).
-2. An S3 bucket with credentials or an instanceprofile with read/write permissions configured for the host (ec2, eks).
+2. An S3 bucket with credentials or an instance profile with read/write permissions configured for the host (ec2, eks).
+3. [Enforce encryption of data in transit](https://docs.aws.amazon.com/AmazonS3/latest/userguide/security-best-practices.html#transit)
 
 ## Step 1: Set up S3
 
@@ -20,6 +21,8 @@ List of required fields:
 Use an existing or create new [Access Key ID and Secret Access Key](https://docs.aws.amazon.com/general/latest/gr/aws-sec-cred-types.html#:~:text=IAM%20User%20Guide.-,Programmatic%20access,-You%20must%20provide).
 
 Prepare S3 bucket that will be used as destination, see [this](https://docs.aws.amazon.com/AmazonS3/latest/userguide/create-bucket-overview.html) to create an S3 bucket.
+
+NOTE: If the S3 cluster is not configured to use TLS, the connection to Amazon S3 silently reverts to an unencrypted connection. Airbyte recommends all connections be configured to use TLS/SSL as support for AWS's [shared responsibility model](https://aws.amazon.com/compliance/shared-responsibility-model/)
 
 ## Step 2: Set up the S3 destination connector in Airbyte
 


### PR DESCRIPTION
## What
Closes #16301 

Adds documentation for customers to secure their S3 destination connection. This follows after concerns brought up in this [slack thread](https://airbytehq-team.slack.com/archives/C03C4AVJWG4/p1664230521580769?thread_ts=1664197709.409579&cid=C03C4AVJWG4) which also references how other companies emphasis the need for customers to enforce only encrypted traffic for their S3 buckets/clusters

There is also a new "check" assertion that requires users to use "HTTPS only" custom endpoints as referred to by the original spec.json and [here](https://docs.aws.amazon.com/general/latest/gr/s3.html)

## How
Documentation for users to follow the shared responsibility model that AWS employs for securing a S3 destination endpoint and removes the ability for users to use a custom endpoint that is not _always_ HTTPS only

Removal of the line within `constants.ts` will revert the hiding of the destination connector within the UI. S3 destination still exists, only that it was previously hidden within the UI and so users could not update their connections if desired

## Recommended reading order
1. `S3BaseChecks.java`
2. `S3DestinationTest.java`
3. `s3.md`
4. `constants.ts`
5. `spec.json`

## 🚨 User Impact 🚨
Are there any breaking changes? What is the end result perceived by the user? If yes, please merge this PR with the 🚨🚨 emoji so changelog authors can further highlight this if needed.

This can potentially break users if they were using a custom endpoint that was not always HTTPS only

## Pre-merge Checklist
Expand the relevant checklist and delete the others.

<details><summary><strong>New Connector</strong></summary>

### Community member or Airbyter

- [ ] **Community member?** Grant edit access to maintainers ([instructions](https://docs.github.com/en/github/collaborating-with-pull-requests/working-with-forks/allowing-changes-to-a-pull-request-branch-created-from-a-fork#enabling-repository-maintainer-permissions-on-existing-pull-requests))
- [ ] Secrets in the connector's spec are annotated with `airbyte_secret`
- [ ] Unit & integration tests added and passing. Community members, please provide proof of success locally e.g: screenshot or copy-paste unit, integration, and acceptance test output. To run acceptance tests for a Python connector, follow instructions in the README. For java connectors run `./gradlew :airbyte-integrations:connectors:<name>:integrationTest`.
- [ ] Code reviews completed
- [ ] Documentation updated
    - [ ] Connector's `README.md`
    - [ ] Connector's `bootstrap.md`. See [description and examples](https://docs.google.com/document/d/1ypdgmwmEHWv-TrO4_YOQ7pAJGVrMp5BOkEVh831N260/edit?usp=sharing)
    - [ ] `docs/integrations/<source or destination>/<name>.md` including changelog. See changelog [example](https://docs.airbyte.io/integrations/sources/stripe#changelog)
    - [ ] `docs/integrations/README.md`
    - [ ] `airbyte-integrations/builds.md`
- [ ] PR name follows [PR naming conventions](https://docs.airbyte.com/contributing-to-airbyte/issues-and-pull-requests)

### Airbyter

If this is a community PR, the Airbyte engineer reviewing this PR is responsible for the below items.

- [ ] Create a non-forked branch based on this PR and test the below items on it
- [ ] Build is successful
- [ ] If new credentials are required for use in CI, add them to GSM. [Instructions](https://docs.airbyte.io/connector-development#using-credentials-in-ci).
- [ ] [`/test connector=connectors/<name>` command](https://docs.airbyte.io/connector-development#updating-an-existing-connector) is passing
- [ ] New Connector version released on Dockerhub by running the `/publish` command described [here](https://docs.airbyte.io/connector-development#updating-an-existing-connector)
- [ ] After the connector is published, connector added to connector index as described [here](https://docs.airbyte.io/connector-development#publishing-a-connector)
- [ ] Seed specs have been re-generated by building the platform and committing the changes to the seed spec files, as described [here](https://docs.airbyte.io/connector-development#publishing-a-connector)

</details>

<details><summary><strong>Updating a connector</strong></summary>

### Community member or Airbyter

- [ ] Grant edit access to maintainers ([instructions](https://docs.github.com/en/github/collaborating-with-pull-requests/working-with-forks/allowing-changes-to-a-pull-request-branch-created-from-a-fork#enabling-repository-maintainer-permissions-on-existing-pull-requests))
- [ ] Secrets in the connector's spec are annotated with `airbyte_secret`
- [ ] Unit & integration tests added and passing. Community members, please provide proof of success locally e.g: screenshot or copy-paste unit, integration, and acceptance test output. To run acceptance tests for a Python connector, follow instructions in the README. For java connectors run `./gradlew :airbyte-integrations:connectors:<name>:integrationTest`.
- [ ] Code reviews completed
- [ ] Documentation updated
    - [ ] Connector's `README.md`
    - [ ] Connector's `bootstrap.md`. See [description and examples](https://docs.google.com/document/d/1ypdgmwmEHWv-TrO4_YOQ7pAJGVrMp5BOkEVh831N260/edit?usp=sharing)
    - [ ] Changelog updated in `docs/integrations/<source or destination>/<name>.md` including changelog. See changelog [example](https://docs.airbyte.io/integrations/sources/stripe#changelog)
- [ ] PR name follows [PR naming conventions](https://docs.airbyte.com/contributing-to-airbyte/issues-and-pull-requests)

### Airbyter

If this is a community PR, the Airbyte engineer reviewing this PR is responsible for the below items.

- [ ] Create a non-forked branch based on this PR and test the below items on it
- [ ] Build is successful
- [ ] If new credentials are required for use in CI, add them to GSM. [Instructions](https://docs.airbyte.io/connector-development#using-credentials-in-ci).
- [ ] [`/test connector=connectors/<name>` command](https://docs.airbyte.io/connector-development#updating-an-existing-connector) is passing
- [ ] New Connector version released on Dockerhub and connector version bumped by running the `/publish` command described [here](https://docs.airbyte.io/connector-development#updating-an-existing-connector)

</details>

<details><summary><strong>Connector Generator</strong></summary>

- [ ] Issue acceptance criteria met
- [ ] PR name follows [PR naming conventions](https://docs.airbyte.com/contributing-to-airbyte/issues-and-pull-requests)
- [ ] If adding a new generator, add it to the [list of scaffold modules being tested](https://github.com/airbytehq/airbyte/blob/master/airbyte-integrations/connector-templates/generator/build.gradle#L41)
- [ ] The generator test modules (all connectors with `-scaffold` in their name) have been updated with the latest scaffold by running `./gradlew :airbyte-integrations:connector-templates:generator:testScaffoldTemplates` then checking in your changes
- [ ] Documentation which references the generator is updated as needed

</details>

## Tests

<details><summary><strong>Unit</strong></summary>

*Put your unit tests output here.*

</details>

<details><summary><strong>Integration</strong></summary>

*Put your integration tests output here.*

</details>

<details><summary><strong>Acceptance</strong></summary>

*Put your acceptance tests output here.*

</details>
