### PR TITLE
Remove a log that was exposing secrets

### DIFF
--- a/airbyte-workers/src/main/java/io/airbyte/workers/temporal/discover/catalog/DiscoverCatalogActivityImpl.java
+++ b/airbyte-workers/src/main/java/io/airbyte/workers/temporal/discover/catalog/DiscoverCatalogActivityImpl.java
@@ -77,8 +77,6 @@ public class DiscoverCatalogActivityImpl implements DiscoverCatalogActivity {
 
     final ActivityExecutionContext context = Activity.getExecutionContext();
 
-    log.info("Fetching catalog data {}", fullConfig);
-
     final TemporalAttemptExecution<StandardDiscoverCatalogInput, ConnectorJobOutput> temporalAttemptExecution =
         new TemporalAttemptExecution<>(
             workspaceRoot,


### PR DESCRIPTION
## What
Remove a log line that was exposing secrets.

If this line is needed, we should fetch the catalog schema and the call `prepareSecretsForOutput(final JsonNode obj, final JsonNode schema)` from `JsonSecretsProcessor` to sanitize it.

I believe that it is a debug line that can be remove, in order to stop exposing secrets as soon as possible the removing the line approach has been chosen.

