### PR TITLE
Efficient queries for connection list

### DIFF
--- a/airbyte-config/config-persistence/src/main/java/io/airbyte/config/persistence/ConfigRepository.java
+++ b/airbyte-config/config-persistence/src/main/java/io/airbyte/config/persistence/ConfigRepository.java
@@ -629,23 +629,18 @@ public class ConfigRepository {
         // SELECT connection.* plus the connection's associated operationIds as a concatenated list
         .select(
             CONNECTION.asterisk(),
-            groupConcat(CONNECTION_OPERATION.OPERATION_ID)
-                .separator(OPERATION_IDS_AGG_DELIMITER)
+            groupConcat(CONNECTION_OPERATION.OPERATION_ID).orderBy(CONNECTION_OPERATION.CREATED_AT.asc()).separator(OPERATION_IDS_AGG_DELIMITER)
                 .as(OPERATION_IDS_AGG_FIELD))
         .from(CONNECTION)
 
         // join with all connection_operation rows that match the connection's id
-        .join(CONNECTION_OPERATION)
-        .on(CONNECTION_OPERATION.CONNECTION_ID.eq(CONNECTION.ID))
+        .join(CONNECTION_OPERATION).on(CONNECTION_OPERATION.CONNECTION_ID.eq(CONNECTION.ID))
 
         // only keep rows for connections that have an operationId that matches the input.
         // needs to be a sub query because we want to keep all operationIds for matching connections
         // in the main query
         .where(CONNECTION.ID.in(
-            select(CONNECTION.ID)
-                .from(CONNECTION)
-                .join(CONNECTION_OPERATION)
-                .on(CONNECTION_OPERATION.CONNECTION_ID.eq(CONNECTION.ID))
+            select(CONNECTION.ID).from(CONNECTION).join(CONNECTION_OPERATION).on(CONNECTION_OPERATION.CONNECTION_ID.eq(CONNECTION.ID))
                 .where(CONNECTION_OPERATION.OPERATION_ID.eq(operationId))))
 
         // group by connection.id so that the groupConcat above works
@@ -659,14 +654,12 @@ public class ConfigRepository {
         // SELECT connection.* plus the connection's associated operationIds as a concatenated list
         .select(
             CONNECTION.asterisk(),
-            groupConcat(CONNECTION_OPERATION.OPERATION_ID)
-                .separator(OPERATION_IDS_AGG_DELIMITER)
+            groupConcat(CONNECTION_OPERATION.OPERATION_ID).orderBy(CONNECTION_OPERATION.CREATED_AT.asc()).separator(OPERATION_IDS_AGG_DELIMITER)
                 .as(OPERATION_IDS_AGG_FIELD))
         .from(CONNECTION)
 
         // join with all connection_operation rows that match the connection's id
-        .join(CONNECTION_OPERATION)
-        .on(CONNECTION_OPERATION.CONNECTION_ID.eq(CONNECTION.ID))
+        .join(CONNECTION_OPERATION).on(CONNECTION_OPERATION.CONNECTION_ID.eq(CONNECTION.ID))
 
         // join with source actors so that we can filter by workspaceId
         .join(ACTOR).on(CONNECTION.SOURCE_ID.eq(ACTOR.ID))

--- a/airbyte-config/config-persistence/src/main/java/io/airbyte/config/persistence/ConfigRepository.java
+++ b/airbyte-config/config-persistence/src/main/java/io/airbyte/config/persistence/ConfigRepository.java
@@ -20,6 +20,7 @@ import static org.jooq.impl.DSL.noCondition;
 import static org.jooq.impl.DSL.select;
 
 import com.fasterxml.jackson.databind.JsonNode;
+import com.google.common.annotations.VisibleForTesting;
 import com.google.common.base.Charsets;
 import com.google.common.collect.Sets;
 import com.google.common.hash.HashFunction;
@@ -839,10 +840,12 @@ public class ConfigRepository {
   // process combined information about a Source/Destination/Definition pair without requiring two
   // separate queries and in-memory join operation,
   // because the config models are grouped immediately in the repository layer.
+  @VisibleForTesting
   public record SourceAndDefinition(SourceConnection source, StandardSourceDefinition definition) {
 
   }
 
+  @VisibleForTesting
   public record DestinationAndDefinition(DestinationConnection destination, StandardDestinationDefinition definition) {
 
   }

--- a/airbyte-config/config-persistence/src/main/java/io/airbyte/config/persistence/ConfigRepository.java
+++ b/airbyte-config/config-persistence/src/main/java/io/airbyte/config/persistence/ConfigRepository.java
@@ -798,6 +798,60 @@ public class ConfigRepository {
     return result;
   }
 
+  public List<SourceConnection> getSourceConnections(final List<UUID> sourceIds) throws IOException {
+    return database.query(ctx -> getSourceConnections(sourceIds, ctx));
+  }
+
+  public List<SourceConnection> getSourceConnections(final List<UUID> sourceIds, final DSLContext ctx) {
+    return ctx
+        .select(asterisk())
+        .from(ACTOR)
+        .where(ACTOR.ACTOR_TYPE.eq(ActorType.source), ACTOR.ID.in(sourceIds))
+        .fetchInto(SourceConnection.class);
+  }
+
+  public List<DestinationConnection> getDestinationConnections(final List<UUID> destinationIds) throws IOException {
+    return database.query(ctx -> getDestinationConnections(destinationIds, ctx));
+  }
+
+  public List<DestinationConnection> getDestinationConnections(final List<UUID> destinationIds, final DSLContext ctx) {
+    return ctx
+        .select(asterisk())
+        .from(ACTOR)
+        .where(ACTOR.ACTOR_TYPE.eq(ActorType.destination), ACTOR.ID.in(destinationIds))
+        .fetchInto(DestinationConnection.class);
+  }
+
+  public List<StandardSourceDefinition> getSourceDefinitionsFromSourceIds(final List<UUID> sourceIds)
+      throws IOException {
+    return database.query(ctx -> getSourceDefinitionsFromSourceIds(sourceIds, ctx));
+  }
+
+  public List<StandardSourceDefinition> getSourceDefinitionsFromSourceIds(final List<UUID> sourceIds, final DSLContext ctx) {
+    return ctx
+        .select(ACTOR_DEFINITION.fields())
+        .from(ACTOR_DEFINITION)
+        .join(ACTOR)
+        .on(ACTOR.ACTOR_DEFINITION_ID.eq(ACTOR_DEFINITION.ID))
+        .where(ACTOR_DEFINITION.ACTOR_TYPE.eq(ActorType.source), ACTOR.ID.in(sourceIds))
+        .fetchInto(StandardSourceDefinition.class);
+  }
+
+  public List<StandardDestinationDefinition> getDestinationDefinitionsFromDestinationIds(final List<UUID> destinationIds)
+      throws IOException {
+    return database.query(ctx -> getDestinationDefinitionsFromDestinationIds(destinationIds, ctx));
+  }
+
+  public List<StandardDestinationDefinition> getDestinationDefinitionsFromDestinationIds(final List<UUID> destinationIds, final DSLContext ctx) {
+    return ctx
+        .select(ACTOR_DEFINITION.fields())
+        .from(ACTOR_DEFINITION)
+        .join(ACTOR)
+        .on(ACTOR.ACTOR_DEFINITION_ID.eq(ACTOR_DEFINITION.ID))
+        .where(ACTOR_DEFINITION.ACTOR_TYPE.eq(ActorType.destination), ACTOR.ID.in(destinationIds))
+        .fetchInto(StandardDestinationDefinition.class);
+  }
+
   public ActorCatalog getActorCatalogById(final UUID actorCatalogId)
       throws IOException, ConfigNotFoundException {
     final Result<Record> result = database.query(ctx -> ctx.select(ACTOR_CATALOG.asterisk())

--- a/airbyte-config/config-persistence/src/main/java/io/airbyte/config/persistence/ConfigRepository.java
+++ b/airbyte-config/config-persistence/src/main/java/io/airbyte/config/persistence/ConfigRepository.java
@@ -829,8 +829,10 @@ public class ConfigRepository {
     return result;
   }
 
-  // Data-carrier records to hold combined result of query for a Source or Destination and its corresponding Definition. This enables the API layer to
-  // process combined information about a Source/Destination/Definition pair without requiring two separate queries and in-memory join operation,
+  // Data-carrier records to hold combined result of query for a Source or Destination and its
+  // corresponding Definition. This enables the API layer to
+  // process combined information about a Source/Destination/Definition pair without requiring two
+  // separate queries and in-memory join operation,
   // because the config models are grouped immediately in the repository layer.
   public record SourceAndDefinition(SourceConnection source, StandardSourceDefinition definition) {
 

--- a/airbyte-config/config-persistence/src/main/java/io/airbyte/config/persistence/ConfigRepository.java
+++ b/airbyte-config/config-persistence/src/main/java/io/airbyte/config/persistence/ConfigRepository.java
@@ -803,11 +803,13 @@ public class ConfigRepository {
   }
 
   public List<SourceConnection> getSourceConnections(final List<UUID> sourceIds, final DSLContext ctx) {
-    return ctx
+    final Result<Record> records = ctx
         .select(asterisk())
         .from(ACTOR)
         .where(ACTOR.ACTOR_TYPE.eq(ActorType.source), ACTOR.ID.in(sourceIds))
-        .fetchInto(SourceConnection.class);
+        .fetch();
+
+    return records.stream().map(DbConverter::buildSourceConnection).toList();
   }
 
   public List<DestinationConnection> getDestinationConnections(final List<UUID> destinationIds) throws IOException {
@@ -815,11 +817,13 @@ public class ConfigRepository {
   }
 
   public List<DestinationConnection> getDestinationConnections(final List<UUID> destinationIds, final DSLContext ctx) {
-    return ctx
+    final Result<Record> records = ctx
         .select(asterisk())
         .from(ACTOR)
         .where(ACTOR.ACTOR_TYPE.eq(ActorType.destination), ACTOR.ID.in(destinationIds))
-        .fetchInto(DestinationConnection.class);
+        .fetch();
+
+    return records.stream().map(DbConverter::buildDestinationConnection).toList();
   }
 
   public List<StandardSourceDefinition> getSourceDefinitionsFromSourceIds(final List<UUID> sourceIds)
@@ -828,13 +832,15 @@ public class ConfigRepository {
   }
 
   public List<StandardSourceDefinition> getSourceDefinitionsFromSourceIds(final List<UUID> sourceIds, final DSLContext ctx) {
-    return ctx
-        .select(ACTOR_DEFINITION.fields())
+    final Result<Record> records = ctx
+        .select(asterisk())
         .from(ACTOR_DEFINITION)
         .join(ACTOR)
         .on(ACTOR.ACTOR_DEFINITION_ID.eq(ACTOR_DEFINITION.ID))
         .where(ACTOR_DEFINITION.ACTOR_TYPE.eq(ActorType.source), ACTOR.ID.in(sourceIds))
-        .fetchInto(StandardSourceDefinition.class);
+        .fetch();
+
+    return records.stream().map(DbConverter::buildStandardSourceDefinition).toList();
   }
 
   public List<StandardDestinationDefinition> getDestinationDefinitionsFromDestinationIds(final List<UUID> destinationIds)
@@ -843,13 +849,15 @@ public class ConfigRepository {
   }
 
   public List<StandardDestinationDefinition> getDestinationDefinitionsFromDestinationIds(final List<UUID> destinationIds, final DSLContext ctx) {
-    return ctx
-        .select(ACTOR_DEFINITION.fields())
+    final Result<Record> records = ctx
+        .select(asterisk())
         .from(ACTOR_DEFINITION)
         .join(ACTOR)
         .on(ACTOR.ACTOR_DEFINITION_ID.eq(ACTOR_DEFINITION.ID))
         .where(ACTOR_DEFINITION.ACTOR_TYPE.eq(ActorType.destination), ACTOR.ID.in(destinationIds))
-        .fetchInto(StandardDestinationDefinition.class);
+        .fetch();
+
+    return records.stream().map(DbConverter::buildStandardDestinationDefinition).toList();
   }
 
   public ActorCatalog getActorCatalogById(final UUID actorCatalogId)

--- a/airbyte-config/config-persistence/src/main/java/io/airbyte/config/persistence/DatabaseConfigPersistence.java
+++ b/airbyte-config/config-persistence/src/main/java/io/airbyte/config/persistence/DatabaseConfigPersistence.java
@@ -456,7 +456,7 @@ public class DatabaseConfigPersistence implements ConfigPersistence {
 
     final List<ConfigWithMetadata<SourceConnection>> sourceConnections = new ArrayList<>();
     for (final Record record : result) {
-      final SourceConnection sourceConnection = buildSourceConnection(record);
+      final SourceConnection sourceConnection = DbConverter.buildSourceConnection(record);
       sourceConnections.add(new ConfigWithMetadata<>(
           record.get(ACTOR.ID).toString(),
           ConfigSchema.SOURCE_CONNECTION.name(),
@@ -465,16 +465,6 @@ public class DatabaseConfigPersistence implements ConfigPersistence {
           sourceConnection));
     }
     return sourceConnections;
-  }
-
-  private SourceConnection buildSourceConnection(final Record record) {
-    return new SourceConnection()
-        .withSourceId(record.get(ACTOR.ID))
-        .withConfiguration(Jsons.deserialize(record.get(ACTOR.CONFIGURATION).data()))
-        .withWorkspaceId(record.get(ACTOR.WORKSPACE_ID))
-        .withSourceDefinitionId(record.get(ACTOR.ACTOR_DEFINITION_ID))
-        .withTombstone(record.get(ACTOR.TOMBSTONE))
-        .withName(record.get(ACTOR.NAME));
   }
 
   private List<ConfigWithMetadata<DestinationConnection>> listDestinationConnectionWithMetadata() throws IOException {
@@ -492,7 +482,7 @@ public class DatabaseConfigPersistence implements ConfigPersistence {
 
     final List<ConfigWithMetadata<DestinationConnection>> destinationConnections = new ArrayList<>();
     for (final Record record : result) {
-      final DestinationConnection destinationConnection = buildDestinationConnection(record);
+      final DestinationConnection destinationConnection = DbConverter.buildDestinationConnection(record);
       destinationConnections.add(new ConfigWithMetadata<>(
           record.get(ACTOR.ID).toString(),
           ConfigSchema.DESTINATION_CONNECTION.name(),
@@ -501,16 +491,6 @@ public class DatabaseConfigPersistence implements ConfigPersistence {
           destinationConnection));
     }
     return destinationConnections;
-  }
-
-  private DestinationConnection buildDestinationConnection(final Record record) {
-    return new DestinationConnection()
-        .withDestinationId(record.get(ACTOR.ID))
-        .withConfiguration(Jsons.deserialize(record.get(ACTOR.CONFIGURATION).data()))
-        .withWorkspaceId(record.get(ACTOR.WORKSPACE_ID))
-        .withDestinationDefinitionId(record.get(ACTOR.ACTOR_DEFINITION_ID))
-        .withTombstone(record.get(ACTOR.TOMBSTONE))
-        .withName(record.get(ACTOR.NAME));
   }
 
   private List<ConfigWithMetadata<SourceOAuthParameter>> listSourceOauthParamWithMetadata() throws IOException {

--- a/airbyte-config/config-persistence/src/main/java/io/airbyte/config/persistence/DbConverter.java
+++ b/airbyte-config/config-persistence/src/main/java/io/airbyte/config/persistence/DbConverter.java
@@ -35,7 +35,6 @@ import io.airbyte.config.StandardWorkspace;
 import io.airbyte.config.WorkspaceServiceAccount;
 import io.airbyte.protocol.models.ConfiguredAirbyteCatalog;
 import io.airbyte.protocol.models.ConnectorSpecification;
-import java.io.IOException;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.UUID;
@@ -43,7 +42,7 @@ import org.jooq.Record;
 
 public class DbConverter {
 
-  public static StandardSync buildStandardSync(final Record record, final List<UUID> connectionOperationId) throws IOException {
+  public static StandardSync buildStandardSync(final Record record, final List<UUID> connectionOperationId) {
     return new StandardSync()
         .withConnectionId(record.get(CONNECTION.ID))
         .withNamespaceDefinition(

--- a/airbyte-config/config-persistence/src/main/java/io/airbyte/config/persistence/DbConverter.java
+++ b/airbyte-config/config-persistence/src/main/java/io/airbyte/config/persistence/DbConverter.java
@@ -4,6 +4,7 @@
 
 package io.airbyte.config.persistence;
 
+import static io.airbyte.db.instance.configs.jooq.generated.Tables.ACTOR;
 import static io.airbyte.db.instance.configs.jooq.generated.Tables.ACTOR_CATALOG;
 import static io.airbyte.db.instance.configs.jooq.generated.Tables.ACTOR_DEFINITION;
 import static io.airbyte.db.instance.configs.jooq.generated.Tables.ACTOR_OAUTH_PARAMETER;
@@ -15,12 +16,14 @@ import io.airbyte.commons.enums.Enums;
 import io.airbyte.commons.json.Jsons;
 import io.airbyte.config.ActorCatalog;
 import io.airbyte.config.ActorDefinitionResourceRequirements;
+import io.airbyte.config.DestinationConnection;
 import io.airbyte.config.DestinationOAuthParameter;
 import io.airbyte.config.JobSyncConfig.NamespaceDefinitionType;
 import io.airbyte.config.Notification;
 import io.airbyte.config.ResourceRequirements;
 import io.airbyte.config.Schedule;
 import io.airbyte.config.ScheduleData;
+import io.airbyte.config.SourceConnection;
 import io.airbyte.config.SourceOAuthParameter;
 import io.airbyte.config.StandardDestinationDefinition;
 import io.airbyte.config.StandardSourceDefinition;
@@ -87,6 +90,26 @@ public class DbConverter {
         .withNotifications(notificationList)
         .withFirstCompletedSync(record.get(WORKSPACE.FIRST_SYNC_COMPLETE))
         .withFeedbackDone(record.get(WORKSPACE.FEEDBACK_COMPLETE));
+  }
+
+  public static SourceConnection buildSourceConnection(final Record record) {
+    return new SourceConnection()
+        .withSourceId(record.get(ACTOR.ID))
+        .withConfiguration(Jsons.deserialize(record.get(ACTOR.CONFIGURATION).data()))
+        .withWorkspaceId(record.get(ACTOR.WORKSPACE_ID))
+        .withSourceDefinitionId(record.get(ACTOR.ACTOR_DEFINITION_ID))
+        .withTombstone(record.get(ACTOR.TOMBSTONE))
+        .withName(record.get(ACTOR.NAME));
+  }
+
+  public static DestinationConnection buildDestinationConnection(final Record record) {
+    return new DestinationConnection()
+        .withDestinationId(record.get(ACTOR.ID))
+        .withConfiguration(Jsons.deserialize(record.get(ACTOR.CONFIGURATION).data()))
+        .withWorkspaceId(record.get(ACTOR.WORKSPACE_ID))
+        .withDestinationDefinitionId(record.get(ACTOR.ACTOR_DEFINITION_ID))
+        .withTombstone(record.get(ACTOR.TOMBSTONE))
+        .withName(record.get(ACTOR.NAME));
   }
 
   public static StandardSourceDefinition buildStandardSourceDefinition(final Record record) {

--- a/airbyte-config/config-persistence/src/main/java/io/airbyte/config/persistence/DbConverter.java
+++ b/airbyte-config/config-persistence/src/main/java/io/airbyte/config/persistence/DbConverter.java
@@ -40,6 +40,9 @@ import java.util.List;
 import java.util.UUID;
 import org.jooq.Record;
 
+/**
+ * Provides static methods for converting from repository layer results (often in the form of a jooq {@link Record}) to config models.
+ */
 public class DbConverter {
 
   public static StandardSync buildStandardSync(final Record record, final List<UUID> connectionOperationId) {

--- a/airbyte-config/config-persistence/src/main/java/io/airbyte/config/persistence/DbConverter.java
+++ b/airbyte-config/config-persistence/src/main/java/io/airbyte/config/persistence/DbConverter.java
@@ -41,7 +41,8 @@ import java.util.UUID;
 import org.jooq.Record;
 
 /**
- * Provides static methods for converting from repository layer results (often in the form of a jooq {@link Record}) to config models.
+ * Provides static methods for converting from repository layer results (often in the form of a jooq
+ * {@link Record}) to config models.
  */
 public class DbConverter {
 

--- a/airbyte-config/config-persistence/src/test/java/io/airbyte/config/persistence/ConfigRepositoryE2EReadWriteTest.java
+++ b/airbyte-config/config-persistence/src/test/java/io/airbyte/config/persistence/ConfigRepositoryE2EReadWriteTest.java
@@ -202,7 +202,19 @@ class ConfigRepositoryE2EReadWriteTest {
   void testListWorkspaceStandardSyncAll() throws IOException {
 
     final List<StandardSync> syncs = configRepository.listWorkspaceStandardSyncs(MockData.standardWorkspaces().get(0).getWorkspaceId(), true);
-    assertThat(MockData.standardSyncs().subList(0, 4)).hasSameElementsAs(syncs);
+    final List<StandardSync> expectedSyncs = MockData.standardSyncs().subList(0, 4);
+
+    for (final StandardSync actual : syncs) {
+      final var expected = expectedSyncs.stream().filter(s -> s.getConnectionId().equals(actual.getConnectionId())).findFirst().orElseThrow();
+
+      // operationIds can wind up in a different order, so validate them separately
+      assertThat(expected.getOperationIds()).hasSameElementsAs(actual.getOperationIds());
+
+      // now, clear operationIds so the rest of the sync can be compared
+      expected.setOperationIds(null);
+      actual.setOperationIds(null);
+      assertEquals(expected, actual);
+    }
   }
 
   @Test
@@ -416,8 +428,17 @@ class ConfigRepositoryE2EReadWriteTest {
 
     final List<StandardSync> syncs = configRepository.listStandardSyncsUsingOperation(operationId);
 
-    assertThat(syncs).hasSameElementsAs(expectedSyncs);
+    for (final StandardSync actual : syncs) {
+      final var expected = expectedSyncs.stream().filter(s -> s.getConnectionId().equals(actual.getConnectionId())).findFirst().orElseThrow();
 
+      // operationIds can wind up in a different order, so validate them separately
+      assertThat(expected.getOperationIds()).hasSameElementsAs(actual.getOperationIds());
+
+      // now, clear operationIds so the rest of the sync can be compared
+      expected.setOperationIds(null);
+      actual.setOperationIds(null);
+      assertEquals(expected, actual);
+    }
   }
 
   @Test

--- a/airbyte-config/config-persistence/src/test/java/io/airbyte/config/persistence/ConfigRepositoryE2EReadWriteTest.java
+++ b/airbyte-config/config-persistence/src/test/java/io/airbyte/config/persistence/ConfigRepositoryE2EReadWriteTest.java
@@ -26,6 +26,8 @@ import io.airbyte.config.StandardSourceDefinition.SourceType;
 import io.airbyte.config.StandardSync;
 import io.airbyte.config.StandardSyncOperation;
 import io.airbyte.config.StandardWorkspace;
+import io.airbyte.config.persistence.ConfigRepository.DestinationAndDefinition;
+import io.airbyte.config.persistence.ConfigRepository.SourceAndDefinition;
 import io.airbyte.config.persistence.split_secrets.JsonSecretsProcessor;
 import io.airbyte.db.Database;
 import io.airbyte.db.factory.DSLContextFactory;
@@ -208,7 +210,7 @@ class ConfigRepositoryE2EReadWriteTest {
       final var expected = expectedSyncs.stream().filter(s -> s.getConnectionId().equals(actual.getConnectionId())).findFirst().orElseThrow();
 
       // operationIds can wind up in a different order, so validate them separately
-      assertThat(expected.getOperationIds()).hasSameElementsAs(actual.getOperationIds());
+      assertThat(actual.getOperationIds()).hasSameElementsAs(expected.getOperationIds());
 
       // now, clear operationIds so the rest of the sync can be compared
       expected.setOperationIds(null);
@@ -432,7 +434,7 @@ class ConfigRepositoryE2EReadWriteTest {
       final var expected = expectedSyncs.stream().filter(s -> s.getConnectionId().equals(actual.getConnectionId())).findFirst().orElseThrow();
 
       // operationIds can wind up in a different order, so validate them separately
-      assertThat(expected.getOperationIds()).hasSameElementsAs(actual.getOperationIds());
+      assertThat(actual.getOperationIds()).hasSameElementsAs(expected.getOperationIds());
 
       // now, clear operationIds so the rest of the sync can be compared
       expected.setOperationIds(null);
@@ -458,6 +460,30 @@ class ConfigRepositoryE2EReadWriteTest {
         }
       }
     }
+  }
+
+  @Test
+  void testGetSourceAndDefinitionsFromSourceIds() throws IOException {
+    final List<UUID> sourceIds = MockData.sourceConnections().subList(0, 2).stream().map(SourceConnection::getSourceId).toList();
+
+    final List<SourceAndDefinition> expected = List.of(
+        new SourceAndDefinition(MockData.sourceConnections().get(0), MockData.standardSourceDefinitions().get(0)),
+        new SourceAndDefinition(MockData.sourceConnections().get(1), MockData.standardSourceDefinitions().get(1)));
+
+    final List<SourceAndDefinition> actual = configRepository.getSourceAndDefinitionsFromSourceIds(sourceIds);
+    assertThat(actual).hasSameElementsAs(expected);
+  }
+
+  @Test
+  void testGetDestinationAndDefinitionsFromDestinationIds() throws IOException {
+    final List<UUID> destinationIds = MockData.destinationConnections().subList(0, 2).stream().map(DestinationConnection::getDestinationId).toList();
+
+    final List<DestinationAndDefinition> expected = List.of(
+        new DestinationAndDefinition(MockData.destinationConnections().get(0), MockData.standardDestinationDefinitions().get(0)),
+        new DestinationAndDefinition(MockData.destinationConnections().get(1), MockData.standardDestinationDefinitions().get(1)));
+
+    final List<DestinationAndDefinition> actual = configRepository.getDestinationAndDefinitionsFromDestinationIds(destinationIds);
+    assertThat(actual).hasSameElementsAs(expected);
   }
 
 }

--- a/airbyte-config/config-persistence/src/test/java/io/airbyte/config/persistence/MockData.java
+++ b/airbyte-config/config-persistence/src/test/java/io/airbyte/config/persistence/MockData.java
@@ -481,7 +481,7 @@ public class MockData {
         .withSchedule(schedule);
 
     final StandardSync standardSync4 = new StandardSync()
-        .withOperationIds(Arrays.asList(OPERATION_ID_1, OPERATION_ID_2))
+        .withOperationIds(Collections.emptyList())
         .withConnectionId(CONNECTION_ID_4)
         .withSourceId(SOURCE_ID_2)
         .withDestinationId(DESTINATION_ID_2)

--- a/airbyte-persistence/job-persistence/src/main/java/io/airbyte/persistence/job/DefaultJobPersistence.java
+++ b/airbyte-persistence/job-persistence/src/main/java/io/airbyte/persistence/job/DefaultJobPersistence.java
@@ -110,6 +110,7 @@ public class DefaultJobPersistence implements JobPersistence {
   private static final String AIRBYTE_METADATA_TABLE = "airbyte_metadata";
   public static final String ORDER_BY_JOB_TIME_ATTEMPT_TIME =
       "ORDER BY jobs.created_at DESC, jobs.id DESC, attempts.created_at ASC, attempts.id ASC ";
+  public static final String ORDER_BY_JOB_CREATED_AT_DESC_LIMIT_1 = "ORDER BY jobs.created_at DESC LIMIT 1";
 
   private final ExceptionWrappingDatabase jobDatabase;
   private final Supplier<Instant> timeSupplier;
@@ -556,7 +557,7 @@ public class DefaultJobPersistence implements JobPersistence {
             "CAST(jobs.config_type AS VARCHAR) in " + Sqls.toSqlInFragment(Job.REPLICATION_TYPES) + AND +
             SCOPE_CLAUSE +
             "CAST(jobs.status AS VARCHAR) <> ? " +
-            "ORDER BY jobs.created_at DESC LIMIT 1",
+            ORDER_BY_JOB_CREATED_AT_DESC_LIMIT_1,
             connectionId.toString(),
             Sqls.toSqlName(JobStatus.CANCELLED))
         .stream()
@@ -570,12 +571,52 @@ public class DefaultJobPersistence implements JobPersistence {
         .fetch(BASE_JOB_SELECT_AND_JOIN + WHERE +
             "CAST(jobs.config_type AS VARCHAR) = ? " + AND +
             "scope = ? " +
-            "ORDER BY jobs.created_at DESC LIMIT 1",
+            ORDER_BY_JOB_CREATED_AT_DESC_LIMIT_1,
             Sqls.toSqlName(ConfigType.SYNC),
             connectionId.toString())
         .stream()
         .findFirst()
         .flatMap(r -> getJobOptional(ctx, r.get(JOB_ID, Long.class))));
+  }
+
+  /**
+   * For each connection ID in the input, find that connection's latest sync job and return it in an
+   * Optional if one exists.
+   */
+  @Override
+  public List<Optional<Job>> getLastSyncJobsForConnections(final List<UUID> connectionIds) throws IOException {
+    return jobDatabase.query(ctx -> ctx
+        .fetch(BASE_JOB_SELECT_AND_JOIN + WHERE +
+            "CAST(jobs.config_type AS VARCHAR) = ? " + AND +
+            "scope IN (?) " +
+            "GROUP BY jobs.scope " +
+            ORDER_BY_JOB_CREATED_AT_DESC_LIMIT_1,
+            Sqls.toSqlName(ConfigType.SYNC),
+            connectionIds.stream().map(UUID::toString).map(Names::singleQuote).collect(Collectors.joining(",")))
+        .stream()
+        .map(r -> getJobOptional(ctx, r.get(JOB_ID, Long.class)))
+        .collect(Collectors.toList()));
+  }
+
+  /**
+   * For each connection ID in the input, find that connection's most recent non-terminal sync job and
+   * return it in an Optional if one exists.
+   */
+  @Override
+  public List<Optional<Job>> getRunningSyncJobForConnections(final List<UUID> connectionIds) throws IOException {
+    return jobDatabase.query(ctx -> ctx
+        .fetch(BASE_JOB_SELECT_AND_JOIN + WHERE +
+            "CAST(jobs.config_type AS VARCHAR) = ? " + AND +
+            "scope IN (?) " + AND +
+            "status IN (?) " +
+            "GROUP BY jobs.scope " +
+            ORDER_BY_JOB_CREATED_AT_DESC_LIMIT_1,
+            Sqls.toSqlName(ConfigType.SYNC),
+            connectionIds.stream().map(UUID::toString).map(Names::singleQuote).collect(Collectors.joining(",")),
+            JobStatus.NON_TERMINAL_STATUSES.stream().map(Sqls::toSqlName).map(Names::singleQuote).collect(Collectors.joining(",")))
+        .stream()
+        .map(r -> getJobOptional(ctx, r.get(JOB_ID, Long.class)))
+        .collect(Collectors.toList()));
   }
 
   @Override

--- a/airbyte-persistence/job-persistence/src/main/java/io/airbyte/persistence/job/DefaultJobPersistence.java
+++ b/airbyte-persistence/job-persistence/src/main/java/io/airbyte/persistence/job/DefaultJobPersistence.java
@@ -592,7 +592,7 @@ public class DefaultJobPersistence implements JobPersistence {
    * Optional if one exists.
    */
   @Override
-  public List<Optional<Job>> getLastSyncJobsForConnections(final List<UUID> connectionIds) throws IOException {
+  public List<Job> getLastSyncJobForConnections(final List<UUID> connectionIds) throws IOException {
     if (connectionIds.isEmpty()) {
       return Collections.emptyList();
     }
@@ -605,7 +605,7 @@ public class DefaultJobPersistence implements JobPersistence {
             Sqls.toSqlName(ConfigType.SYNC),
             connectionIds.stream().map(UUID::toString).map(Names::singleQuote).collect(Collectors.joining(",")))
         .stream()
-        .map(r -> getJobOptional(ctx, r.get("id", Long.class)))
+        .flatMap(r -> getJobOptional(ctx, r.get("id", Long.class)).stream())
         .collect(Collectors.toList()));
   }
 
@@ -614,7 +614,7 @@ public class DefaultJobPersistence implements JobPersistence {
    * return it in an Optional if one exists.
    */
   @Override
-  public List<Optional<Job>> getRunningSyncJobForConnections(final List<UUID> connectionIds) throws IOException {
+  public List<Job> getRunningSyncJobForConnections(final List<UUID> connectionIds) throws IOException {
     if (connectionIds.isEmpty()) {
       return Collections.emptyList();
     }
@@ -629,7 +629,7 @@ public class DefaultJobPersistence implements JobPersistence {
             connectionIds.stream().map(UUID::toString).map(Names::singleQuote).collect(Collectors.joining(",")),
             JobStatus.NON_TERMINAL_STATUSES.stream().map(Sqls::toSqlName).map(Names::singleQuote).collect(Collectors.joining(",")))
         .stream()
-        .map(r -> getJobOptional(ctx, r.get("id", Long.class)))
+        .flatMap(r -> getJobOptional(ctx, r.get("id", Long.class)).stream())
         .collect(Collectors.toList()));
   }
 

--- a/airbyte-persistence/job-persistence/src/main/java/io/airbyte/persistence/job/DefaultJobPersistence.java
+++ b/airbyte-persistence/job-persistence/src/main/java/io/airbyte/persistence/job/DefaultJobPersistence.java
@@ -56,6 +56,7 @@ import java.time.format.DateTimeFormatter;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collection;
+import java.util.Collections;
 import java.util.HashMap;
 import java.util.Iterator;
 import java.util.List;
@@ -592,6 +593,10 @@ public class DefaultJobPersistence implements JobPersistence {
    */
   @Override
   public List<Optional<Job>> getLastSyncJobsForConnections(final List<UUID> connectionIds) throws IOException {
+    if (connectionIds.isEmpty()) {
+      return Collections.emptyList();
+    }
+
     return jobDatabase.query(ctx -> ctx
         .fetch("SELECT DISTINCT ON (scope) * FROM jobs "
             + WHERE + "CAST(jobs.config_type AS VARCHAR) = ? "
@@ -610,6 +615,10 @@ public class DefaultJobPersistence implements JobPersistence {
    */
   @Override
   public List<Optional<Job>> getRunningSyncJobForConnections(final List<UUID> connectionIds) throws IOException {
+    if (connectionIds.isEmpty()) {
+      return Collections.emptyList();
+    }
+
     return jobDatabase.query(ctx -> ctx
         .fetch("SELECT DISTINCT ON (scope) * FROM jobs "
             + WHERE + "CAST(jobs.config_type AS VARCHAR) = ? "

--- a/airbyte-persistence/job-persistence/src/main/java/io/airbyte/persistence/job/DefaultJobPersistence.java
+++ b/airbyte-persistence/job-persistence/src/main/java/io/airbyte/persistence/job/DefaultJobPersistence.java
@@ -599,11 +599,10 @@ public class DefaultJobPersistence implements JobPersistence {
 
     return jobDatabase.query(ctx -> ctx
         .fetch("SELECT DISTINCT ON (scope) * FROM jobs "
-            + WHERE + "CAST(jobs.config_type AS VARCHAR) = ? "
-            + AND + scopeInList(connectionIds)
-            + "ORDER BY scope, created_at DESC",
-            Sqls.toSqlName(ConfigType.SYNC),
-            connectionIds.stream().map(UUID::toString).map(Names::singleQuote).collect(Collectors.joining(",")))
+                + WHERE + "CAST(jobs.config_type AS VARCHAR) = ? "
+                + AND + scopeInList(connectionIds)
+                + "ORDER BY scope, created_at DESC",
+            Sqls.toSqlName(ConfigType.SYNC))
         .stream()
         .flatMap(r -> getJobOptional(ctx, r.get("id", Long.class)).stream())
         .collect(Collectors.toList()));
@@ -621,13 +620,11 @@ public class DefaultJobPersistence implements JobPersistence {
 
     return jobDatabase.query(ctx -> ctx
         .fetch("SELECT DISTINCT ON (scope) * FROM jobs "
-            + WHERE + "CAST(jobs.config_type AS VARCHAR) = ? "
-            + AND + scopeInList(connectionIds)
-            + AND + JOB_STATUS_IS_NON_TERMINAL
-            + "ORDER BY scope, created_at DESC",
-            Sqls.toSqlName(ConfigType.SYNC),
-            connectionIds.stream().map(UUID::toString).map(Names::singleQuote).collect(Collectors.joining(",")),
-            JobStatus.NON_TERMINAL_STATUSES.stream().map(Sqls::toSqlName).map(Names::singleQuote).collect(Collectors.joining(",")))
+                + WHERE + "CAST(jobs.config_type AS VARCHAR) = ? "
+                + AND + scopeInList(connectionIds)
+                + AND + JOB_STATUS_IS_NON_TERMINAL
+                + "ORDER BY scope, created_at DESC",
+            Sqls.toSqlName(ConfigType.SYNC))
         .stream()
         .flatMap(r -> getJobOptional(ctx, r.get("id", Long.class)).stream())
         .collect(Collectors.toList()));

--- a/airbyte-persistence/job-persistence/src/main/java/io/airbyte/persistence/job/DefaultJobPersistence.java
+++ b/airbyte-persistence/job-persistence/src/main/java/io/airbyte/persistence/job/DefaultJobPersistence.java
@@ -588,8 +588,8 @@ public class DefaultJobPersistence implements JobPersistence {
   }
 
   /**
-   * For each connection ID in the input, find that connection's latest sync job and return it in an
-   * Optional if one exists.
+   * For each connection ID in the input, find that connection's latest sync job and return it if one
+   * exists.
    */
   @Override
   public List<Job> getLastSyncJobForConnections(final List<UUID> connectionIds) throws IOException {
@@ -610,7 +610,7 @@ public class DefaultJobPersistence implements JobPersistence {
 
   /**
    * For each connection ID in the input, find that connection's most recent non-terminal sync job and
-   * return it in an Optional if one exists.
+   * return it if one exists.
    */
   @Override
   public List<Job> getRunningSyncJobForConnections(final List<UUID> connectionIds) throws IOException {

--- a/airbyte-persistence/job-persistence/src/main/java/io/airbyte/persistence/job/DefaultJobPersistence.java
+++ b/airbyte-persistence/job-persistence/src/main/java/io/airbyte/persistence/job/DefaultJobPersistence.java
@@ -599,9 +599,9 @@ public class DefaultJobPersistence implements JobPersistence {
 
     return jobDatabase.query(ctx -> ctx
         .fetch("SELECT DISTINCT ON (scope) * FROM jobs "
-                + WHERE + "CAST(jobs.config_type AS VARCHAR) = ? "
-                + AND + scopeInList(connectionIds)
-                + "ORDER BY scope, created_at DESC",
+            + WHERE + "CAST(jobs.config_type AS VARCHAR) = ? "
+            + AND + scopeInList(connectionIds)
+            + "ORDER BY scope, created_at DESC",
             Sqls.toSqlName(ConfigType.SYNC))
         .stream()
         .flatMap(r -> getJobOptional(ctx, r.get("id", Long.class)).stream())
@@ -620,10 +620,10 @@ public class DefaultJobPersistence implements JobPersistence {
 
     return jobDatabase.query(ctx -> ctx
         .fetch("SELECT DISTINCT ON (scope) * FROM jobs "
-                + WHERE + "CAST(jobs.config_type AS VARCHAR) = ? "
-                + AND + scopeInList(connectionIds)
-                + AND + JOB_STATUS_IS_NON_TERMINAL
-                + "ORDER BY scope, created_at DESC",
+            + WHERE + "CAST(jobs.config_type AS VARCHAR) = ? "
+            + AND + scopeInList(connectionIds)
+            + AND + JOB_STATUS_IS_NON_TERMINAL
+            + "ORDER BY scope, created_at DESC",
             Sqls.toSqlName(ConfigType.SYNC))
         .stream()
         .flatMap(r -> getJobOptional(ctx, r.get("id", Long.class)).stream())

--- a/airbyte-persistence/job-persistence/src/main/java/io/airbyte/persistence/job/JobPersistence.java
+++ b/airbyte-persistence/job-persistence/src/main/java/io/airbyte/persistence/job/JobPersistence.java
@@ -211,6 +211,10 @@ public interface JobPersistence {
 
   Optional<Job> getLastSyncJob(UUID connectionId) throws IOException;
 
+  List<Optional<Job>> getLastSyncJobsForConnections(final List<UUID> connectionIds) throws IOException;
+
+  List<Optional<Job>> getRunningSyncJobForConnections(final List<UUID> connectionIds) throws IOException;
+
   Optional<Job> getFirstReplicationJob(UUID connectionId) throws IOException;
 
   Optional<Job> getNextJob() throws IOException;

--- a/airbyte-persistence/job-persistence/src/main/java/io/airbyte/persistence/job/JobPersistence.java
+++ b/airbyte-persistence/job-persistence/src/main/java/io/airbyte/persistence/job/JobPersistence.java
@@ -211,9 +211,9 @@ public interface JobPersistence {
 
   Optional<Job> getLastSyncJob(UUID connectionId) throws IOException;
 
-  List<Optional<Job>> getLastSyncJobsForConnections(final List<UUID> connectionIds) throws IOException;
+  List<Job> getLastSyncJobForConnections(final List<UUID> connectionIds) throws IOException;
 
-  List<Optional<Job>> getRunningSyncJobForConnections(final List<UUID> connectionIds) throws IOException;
+  List<Job> getRunningSyncJobForConnections(final List<UUID> connectionIds) throws IOException;
 
   Optional<Job> getFirstReplicationJob(UUID connectionId) throws IOException;
 

--- a/airbyte-persistence/job-persistence/src/test/java/io/airbyte/persistence/job/DefaultJobPersistenceTest.java
+++ b/airbyte-persistence/job-persistence/src/test/java/io/airbyte/persistence/job/DefaultJobPersistenceTest.java
@@ -136,10 +136,7 @@ class DefaultJobPersistenceTest {
     container.close();
   }
 
-  private static Attempt createAttempt(final long id,
-                                       final long jobId,
-                                       final AttemptStatus status,
-                                       final Path logPath) {
+  private static Attempt createAttempt(final long id, final long jobId, final AttemptStatus status, final Path logPath) {
     return new Attempt(
         id,
         jobId,
@@ -152,10 +149,7 @@ class DefaultJobPersistenceTest {
         NOW.getEpochSecond());
   }
 
-  private static Attempt createUnfinishedAttempt(final long id,
-                                                 final long jobId,
-                                                 final AttemptStatus status,
-                                                 final Path logPath) {
+  private static Attempt createUnfinishedAttempt(final long id, final long jobId, final AttemptStatus status, final Path logPath) {
     return new Attempt(
         id,
         jobId,
@@ -168,11 +162,7 @@ class DefaultJobPersistenceTest {
         null);
   }
 
-  private static Job createJob(final long id,
-                               final JobConfig jobConfig,
-                               final JobStatus status,
-                               final List<Attempt> attempts,
-                               final long time) {
+  private static Job createJob(final long id, final JobConfig jobConfig, final JobStatus status, final List<Attempt> attempts, final long time) {
     return createJob(id, jobConfig, status, attempts, time, SCOPE);
   }
 
@@ -207,8 +197,7 @@ class DefaultJobPersistenceTest {
     timeSupplier = mock(Supplier.class);
     when(timeSupplier.get()).thenReturn(NOW);
 
-    jobPersistence = new DefaultJobPersistence(jobDatabase, timeSupplier, DEFAULT_MINIMUM_AGE_IN_DAYS,
-        DEFAULT_EXCESSIVE_NUMBER_OF_JOBS,
+    jobPersistence = new DefaultJobPersistence(jobDatabase, timeSupplier, DEFAULT_MINIMUM_AGE_IN_DAYS, DEFAULT_EXCESSIVE_NUMBER_OF_JOBS,
         DEFAULT_MINIMUM_RECENCY_COUNT);
   }
 
@@ -227,8 +216,7 @@ class DefaultJobPersistenceTest {
   }
 
   private Result<Record> getJobRecord(final long jobId) throws SQLException {
-    return jobDatabase.query(
-        ctx -> ctx.fetch(DefaultJobPersistence.BASE_JOB_SELECT_AND_JOIN + "WHERE jobs.id = ?", jobId));
+    return jobDatabase.query(ctx -> ctx.fetch(DefaultJobPersistence.BASE_JOB_SELECT_AND_JOIN + "WHERE jobs.id = ?", jobId));
   }
 
   @Test
@@ -274,27 +262,20 @@ class DefaultJobPersistenceTest {
     final int attemptNumber = jobPersistence.createAttempt(jobId, LOG_PATH);
     final Job created = jobPersistence.getJob(jobId);
     final SyncStats syncStats =
-        new SyncStats().withBytesEmitted(100L).withRecordsEmitted(9L).withRecordsCommitted(10L)
-            .withDestinationStateMessagesEmitted(1L)
-            .withSourceStateMessagesEmitted(4L).withMaxSecondsBeforeSourceStateMessageEmitted(5L)
-            .withMeanSecondsBeforeSourceStateMessageEmitted(2L)
-            .withMaxSecondsBetweenStateMessageEmittedandCommitted(10L)
-            .withMeanSecondsBetweenStateMessageEmittedandCommitted(3L);
-    final FailureReason failureReason1 = new FailureReason().withFailureOrigin(FailureOrigin.DESTINATION)
-        .withFailureType(FailureType.SYSTEM_ERROR)
+        new SyncStats().withBytesEmitted(100L).withRecordsEmitted(9L).withRecordsCommitted(10L).withDestinationStateMessagesEmitted(1L)
+            .withSourceStateMessagesEmitted(4L).withMaxSecondsBeforeSourceStateMessageEmitted(5L).withMeanSecondsBeforeSourceStateMessageEmitted(2L)
+            .withMaxSecondsBetweenStateMessageEmittedandCommitted(10L).withMeanSecondsBetweenStateMessageEmittedandCommitted(3L);
+    final FailureReason failureReason1 = new FailureReason().withFailureOrigin(FailureOrigin.DESTINATION).withFailureType(FailureType.SYSTEM_ERROR)
         .withExternalMessage("There was a normalization error");
-    final FailureReason failureReason2 = new FailureReason().withFailureOrigin(FailureOrigin.SOURCE)
-        .withFailureType(FailureType.CONFIG_ERROR)
+    final FailureReason failureReason2 = new FailureReason().withFailureOrigin(FailureOrigin.SOURCE).withFailureType(FailureType.CONFIG_ERROR)
         .withExternalMessage("There was another normalization error");
 
     final NormalizationSummary normalizationSummary =
-        new NormalizationSummary().withStartTime(10L).withEndTime(500L)
-            .withFailures(List.of(failureReason1, failureReason2));
+        new NormalizationSummary().withStartTime(10L).withEndTime(500L).withFailures(List.of(failureReason1, failureReason2));
     final StandardSyncOutput standardSyncOutput =
         new StandardSyncOutput().withStandardSyncSummary(new StandardSyncSummary().withTotalStats(syncStats))
             .withNormalizationSummary(normalizationSummary);
-    final JobOutput jobOutput = new JobOutput().withOutputType(JobOutput.OutputType.DISCOVER_CATALOG)
-        .withSync(standardSyncOutput);
+    final JobOutput jobOutput = new JobOutput().withOutputType(JobOutput.OutputType.DISCOVER_CATALOG).withSync(standardSyncOutput);
 
     when(timeSupplier.get()).thenReturn(Instant.ofEpochMilli(4242));
     jobPersistence.writeOutput(jobId, attemptNumber, jobOutput,
@@ -303,8 +284,7 @@ class DefaultJobPersistenceTest {
     final Job updated = jobPersistence.getJob(jobId);
 
     assertEquals(Optional.of(jobOutput), updated.getAttempts().get(0).getOutput());
-    assertNotEquals(created.getAttempts().get(0).getUpdatedAtInSecond(),
-        updated.getAttempts().get(0).getUpdatedAtInSecond());
+    assertNotEquals(created.getAttempts().get(0).getUpdatedAtInSecond(), updated.getAttempts().get(0).getUpdatedAtInSecond());
 
     final Optional<Record> record =
         jobDatabase.query(ctx -> ctx.fetch("SELECT id from attempts where job_id = ? AND attempt_number = ?", jobId,
@@ -323,8 +303,7 @@ class DefaultJobPersistenceTest {
     assertEquals(10L, storedSyncStats.getMaxSecondsBetweenStateMessageEmittedandCommitted());
     assertEquals(3L, storedSyncStats.getMeanSecondsBetweenStateMessageEmittedandCommitted());
 
-    final NormalizationSummary storedNormalizationSummary = jobPersistence.getNormalizationSummary(attemptId).stream()
-        .findFirst().get();
+    final NormalizationSummary storedNormalizationSummary = jobPersistence.getNormalizationSummary(attemptId).stream().findFirst().get();
     assertEquals(10L, storedNormalizationSummary.getStartTime());
     assertEquals(500L, storedNormalizationSummary.getEndTime());
     assertEquals(List.of(failureReason1, failureReason2), storedNormalizationSummary.getFailures());
@@ -344,8 +323,7 @@ class DefaultJobPersistenceTest {
 
     final Job updated = jobPersistence.getJob(jobId);
     assertEquals(Optional.of(failureSummary), updated.getAttempts().get(0).getFailureSummary());
-    assertNotEquals(created.getAttempts().get(0).getUpdatedAtInSecond(),
-        updated.getAttempts().get(0).getUpdatedAtInSecond());
+    assertNotEquals(created.getAttempts().get(0).getUpdatedAtInSecond(), updated.getAttempts().get(0).getUpdatedAtInSecond());
   }
 
   @Test
@@ -376,8 +354,7 @@ class DefaultJobPersistenceTest {
 
     final Optional<Job> actual = DefaultJobPersistence.getJobFromResult(getJobRecord(jobId));
 
-    final Job expected = createJob(jobId, SPEC_JOB_CONFIG, JobStatus.PENDING, Collections.emptyList(),
-        NOW.getEpochSecond());
+    final Job expected = createJob(jobId, SPEC_JOB_CONFIG, JobStatus.PENDING, Collections.emptyList(), NOW.getEpochSecond());
     assertEquals(Optional.of(expected), actual);
   }
 
@@ -405,8 +382,7 @@ class DefaultJobPersistenceTest {
 
     jobPersistence.importDatabase("test", outputStreams);
 
-    final List<Job> actualList = jobPersistence.listJobs(SPEC_JOB_CONFIG.getConfigType(), CONNECTION_ID.toString(),
-        9999, 0);
+    final List<Job> actualList = jobPersistence.listJobs(SPEC_JOB_CONFIG.getConfigType(), CONNECTION_ID.toString(), 9999, 0);
 
     final Job actual = actualList.get(0);
     final Job expected = createJob(
@@ -430,8 +406,7 @@ class DefaultJobPersistenceTest {
     final Instant now = Instant.parse("2021-01-01T00:00:00Z");
     final Supplier<Instant> timeSupplier = incrementingSecondSupplier(now);
 
-    jobPersistence = new DefaultJobPersistence(jobDatabase, timeSupplier, DEFAULT_MINIMUM_AGE_IN_DAYS,
-        DEFAULT_EXCESSIVE_NUMBER_OF_JOBS,
+    jobPersistence = new DefaultJobPersistence(jobDatabase, timeSupplier, DEFAULT_MINIMUM_AGE_IN_DAYS, DEFAULT_EXCESSIVE_NUMBER_OF_JOBS,
         DEFAULT_MINIMUM_RECENCY_COUNT);
     final long syncJobId = jobPersistence.enqueueJob(SCOPE, SYNC_JOB_CONFIG).orElseThrow();
     final int syncJobAttemptNumber0 = jobPersistence.createAttempt(syncJobId, LOG_PATH);
@@ -466,11 +441,9 @@ class DefaultJobPersistenceTest {
     jobPersistence.succeedAttempt(newSyncJobId, newSyncJobAttemptNumber1);
 
     final Long maxEndedAtTimestamp =
-        jobs.get(0).getAttempts().stream().map(c -> c.getEndedAtInSecond().orElseThrow()).max(Long::compareTo)
-            .orElseThrow();
+        jobs.get(0).getAttempts().stream().map(c -> c.getEndedAtInSecond().orElseThrow()).max(Long::compareTo).orElseThrow();
 
-    final List<Job> secondQueryJobs = jobPersistence.listJobs(ConfigType.SYNC,
-        Instant.ofEpochSecond(maxEndedAtTimestamp));
+    final List<Job> secondQueryJobs = jobPersistence.listJobs(ConfigType.SYNC, Instant.ofEpochSecond(maxEndedAtTimestamp));
     assertEquals(secondQueryJobs.size(), 2);
     assertEquals(secondQueryJobs.get(0).getId(), syncJobId);
     assertEquals(secondQueryJobs.get(0).getAttempts().size(), 1);
@@ -484,16 +457,14 @@ class DefaultJobPersistenceTest {
     Long maxEndedAtTimestampAfterSecondQuery = -1L;
     for (final Job c : secondQueryJobs) {
       final List<Attempt> attempts = c.getAttempts();
-      final Long maxEndedAtTimestampForJob = attempts.stream()
-          .map(attempt -> attempt.getEndedAtInSecond().orElseThrow())
+      final Long maxEndedAtTimestampForJob = attempts.stream().map(attempt -> attempt.getEndedAtInSecond().orElseThrow())
           .max(Long::compareTo).orElseThrow();
       if (maxEndedAtTimestampForJob > maxEndedAtTimestampAfterSecondQuery) {
         maxEndedAtTimestampAfterSecondQuery = maxEndedAtTimestampForJob;
       }
     }
 
-    assertEquals(0,
-        jobPersistence.listJobs(ConfigType.SYNC, Instant.ofEpochSecond(maxEndedAtTimestampAfterSecondQuery)).size());
+    assertEquals(0, jobPersistence.listJobs(ConfigType.SYNC, Instant.ofEpochSecond(maxEndedAtTimestampAfterSecondQuery)).size());
   }
 
   @Test
@@ -501,8 +472,7 @@ class DefaultJobPersistenceTest {
   void testListAttemptsWithJobInfo() throws IOException {
     final Instant now = Instant.parse("2021-01-01T00:00:00Z");
     final Supplier<Instant> timeSupplier = incrementingSecondSupplier(now);
-    jobPersistence = new DefaultJobPersistence(jobDatabase, timeSupplier, DEFAULT_MINIMUM_AGE_IN_DAYS,
-        DEFAULT_EXCESSIVE_NUMBER_OF_JOBS,
+    jobPersistence = new DefaultJobPersistence(jobDatabase, timeSupplier, DEFAULT_MINIMUM_AGE_IN_DAYS, DEFAULT_EXCESSIVE_NUMBER_OF_JOBS,
         DEFAULT_MINIMUM_RECENCY_COUNT);
 
     final long job1 = jobPersistence.enqueueJob(SCOPE + "-1", SYNC_JOB_CONFIG).orElseThrow();
@@ -523,8 +493,7 @@ class DefaultJobPersistenceTest {
     jobPersistence.succeedAttempt(job1, job1Attempt3);
     jobPersistence.succeedAttempt(job2, job2Attempt3);
 
-    final List<AttemptWithJobInfo> allAttempts = jobPersistence.listAttemptsWithJobInfo(ConfigType.SYNC,
-        Instant.ofEpochSecond(0));
+    final List<AttemptWithJobInfo> allAttempts = jobPersistence.listAttemptsWithJobInfo(ConfigType.SYNC, Instant.ofEpochSecond(0));
     assertEquals(6, allAttempts.size());
 
     assertEquals(job1, allAttempts.get(0).getJobInfo().getId());
@@ -659,8 +628,7 @@ class DefaultJobPersistenceTest {
       assertTrue(defaultWorkflowId.isEmpty());
 
       jobDatabase.query(ctx -> ctx.execute(
-          "UPDATE attempts SET temporal_workflow_id = '56a81f3a-006c-42d7-bce2-29d675d08ea4' WHERE job_id = ? AND attempt_number =?",
-          jobId,
+          "UPDATE attempts SET temporal_workflow_id = '56a81f3a-006c-42d7-bce2-29d675d08ea4' WHERE job_id = ? AND attempt_number =?", jobId,
           attemptNumber));
       final var workflowId = jobPersistence.getAttemptTemporalWorkflowId(jobId, attemptNumber).get();
       assertEquals(workflowId, "56a81f3a-006c-42d7-bce2-29d675d08ea4");
@@ -794,8 +762,7 @@ class DefaultJobPersistenceTest {
       final int attemptNumber2 = jobPersistence.createAttempt(jobId, LOG_PATH);
       final Job jobAfterTwoAttempts = jobPersistence.getJob(jobId);
       assertEquals(1, attemptNumber2);
-      assertEquals(Sets.newHashSet(0L, 1L),
-          jobAfterTwoAttempts.getAttempts().stream().map(Attempt::getId).collect(Collectors.toSet()));
+      assertEquals(Sets.newHashSet(0L, 1L), jobAfterTwoAttempts.getAttempts().stream().map(Attempt::getId).collect(Collectors.toSet()));
     }
 
     @Test
@@ -847,8 +814,7 @@ class DefaultJobPersistenceTest {
       final long jobId = jobPersistence.enqueueJob(SCOPE, SPEC_JOB_CONFIG).orElseThrow();
 
       final Job actual = jobPersistence.getJob(jobId);
-      final Job expected = createJob(jobId, SPEC_JOB_CONFIG, JobStatus.PENDING, Collections.emptyList(),
-          NOW.getEpochSecond());
+      final Job expected = createJob(jobId, SPEC_JOB_CONFIG, JobStatus.PENDING, Collections.emptyList(), NOW.getEpochSecond());
       assertEquals(expected, actual);
     }
 
@@ -862,8 +828,7 @@ class DefaultJobPersistenceTest {
       assertTrue(jobId2.isEmpty());
 
       final Job actual = jobPersistence.getJob(jobId1.get());
-      final Job expected = createJob(jobId1.get(), SYNC_JOB_CONFIG, JobStatus.PENDING, Collections.emptyList(),
-          NOW.getEpochSecond());
+      final Job expected = createJob(jobId1.get(), SYNC_JOB_CONFIG, JobStatus.PENDING, Collections.emptyList(), NOW.getEpochSecond());
       assertEquals(expected, actual);
     }
 
@@ -878,8 +843,7 @@ class DefaultJobPersistenceTest {
       assertTrue(jobId2.isPresent());
 
       final Job actual = jobPersistence.getJob(jobId2.get());
-      final Job expected = createJob(jobId2.get(), SYNC_JOB_CONFIG, JobStatus.PENDING, Collections.emptyList(),
-          NOW.getEpochSecond());
+      final Job expected = createJob(jobId2.get(), SYNC_JOB_CONFIG, JobStatus.PENDING, Collections.emptyList(), NOW.getEpochSecond());
       assertEquals(expected, actual);
     }
 
@@ -941,8 +905,7 @@ class DefaultJobPersistenceTest {
       final long jobId2 = jobPersistence.enqueueJob(SCOPE, SYNC_JOB_CONFIG).orElseThrow();
 
       final Optional<Job> actual = jobPersistence.getLastReplicationJob(CONNECTION_ID);
-      final Job expected = createJob(jobId2, SYNC_JOB_CONFIG, JobStatus.PENDING, Collections.emptyList(),
-          afterNow.getEpochSecond());
+      final Job expected = createJob(jobId2, SYNC_JOB_CONFIG, JobStatus.PENDING, Collections.emptyList(), afterNow.getEpochSecond());
 
       assertEquals(Optional.of(expected), actual);
     }
@@ -958,8 +921,7 @@ class DefaultJobPersistenceTest {
       final long jobId2 = jobPersistence.enqueueJob(SCOPE, RESET_JOB_CONFIG).orElseThrow();
 
       final Optional<Job> actual = jobPersistence.getLastReplicationJob(CONNECTION_ID);
-      final Job expected = createJob(jobId2, RESET_JOB_CONFIG, JobStatus.PENDING, Collections.emptyList(),
-          afterNow.getEpochSecond());
+      final Job expected = createJob(jobId2, RESET_JOB_CONFIG, JobStatus.PENDING, Collections.emptyList(), afterNow.getEpochSecond());
 
       assertEquals(Optional.of(expected), actual);
     }
@@ -995,8 +957,7 @@ class DefaultJobPersistenceTest {
       jobPersistence.failJob(jobId2);
 
       final Optional<Job> actual = jobPersistence.getLastSyncJob(CONNECTION_ID);
-      final Job expected = createJob(jobId2, SYNC_JOB_CONFIG, JobStatus.FAILED, List.of(attempt),
-          afterNow.getEpochSecond());
+      final Job expected = createJob(jobId2, SYNC_JOB_CONFIG, JobStatus.FAILED, List.of(attempt), afterNow.getEpochSecond());
 
       assertEquals(Optional.of(expected), actual);
     }
@@ -1183,8 +1144,7 @@ class DefaultJobPersistenceTest {
     void testGetFirstSyncJobForConnectionId() throws IOException {
       final long jobId1 = jobPersistence.enqueueJob(SCOPE, SYNC_JOB_CONFIG).orElseThrow();
       jobPersistence.succeedAttempt(jobId1, jobPersistence.createAttempt(jobId1, LOG_PATH));
-      final List<AttemptWithJobInfo> attemptsWithJobInfo = jobPersistence.listAttemptsWithJobInfo(
-          SYNC_JOB_CONFIG.getConfigType(), Instant.EPOCH);
+      final List<AttemptWithJobInfo> attemptsWithJobInfo = jobPersistence.listAttemptsWithJobInfo(SYNC_JOB_CONFIG.getConfigType(), Instant.EPOCH);
       final List<Attempt> attempts = Collections.singletonList(attemptsWithJobInfo.get(0).getAttempt());
 
       final Instant afterNow = NOW.plusSeconds(1000);
@@ -1211,8 +1171,7 @@ class DefaultJobPersistenceTest {
 
       final Optional<Job> actual = jobPersistence.getNextJob();
 
-      final Job expected = createJob(jobId, SPEC_JOB_CONFIG, JobStatus.PENDING, Collections.emptyList(),
-          NOW.getEpochSecond());
+      final Job expected = createJob(jobId, SPEC_JOB_CONFIG, JobStatus.PENDING, Collections.emptyList(), NOW.getEpochSecond());
       assertEquals(Optional.of(expected), actual);
     }
 
@@ -1262,8 +1221,7 @@ class DefaultJobPersistenceTest {
 
       final Optional<Job> actual = jobPersistence.getNextJob();
 
-      final Job expected = createJob(jobId2, SPEC_JOB_CONFIG, JobStatus.PENDING, Collections.emptyList(),
-          NOW.getEpochSecond());
+      final Job expected = createJob(jobId2, SPEC_JOB_CONFIG, JobStatus.PENDING, Collections.emptyList(), NOW.getEpochSecond());
       assertEquals(Optional.of(expected), actual);
     }
 
@@ -1279,8 +1237,7 @@ class DefaultJobPersistenceTest {
 
       final Optional<Job> actual = jobPersistence.getNextJob();
 
-      final Job expected = createJob(jobId2, SPEC_JOB_CONFIG, JobStatus.PENDING, Collections.emptyList(),
-          NOW.getEpochSecond());
+      final Job expected = createJob(jobId2, SPEC_JOB_CONFIG, JobStatus.PENDING, Collections.emptyList(), NOW.getEpochSecond());
       assertEquals(Optional.of(expected), actual);
     }
 
@@ -1297,8 +1254,7 @@ class DefaultJobPersistenceTest {
 
       final Optional<Job> actual = jobPersistence.getNextJob();
 
-      final Job expected = createJob(jobId2, SPEC_JOB_CONFIG, JobStatus.PENDING, Collections.emptyList(),
-          NOW.getEpochSecond());
+      final Job expected = createJob(jobId2, SPEC_JOB_CONFIG, JobStatus.PENDING, Collections.emptyList(), NOW.getEpochSecond());
       assertEquals(Optional.of(expected), actual);
     }
 
@@ -1349,8 +1305,7 @@ class DefaultJobPersistenceTest {
         jobPersistence.enqueueJob(CONNECTION_ID.toString(), SPEC_JOB_CONFIG);
       }
 
-      final Long actualJobCount = jobPersistence.getJobCount(Set.of(SPEC_JOB_CONFIG.getConfigType()),
-          CONNECTION_ID.toString());
+      final Long actualJobCount = jobPersistence.getJobCount(Set.of(SPEC_JOB_CONFIG.getConfigType()), CONNECTION_ID.toString());
 
       assertEquals(numJobsToCreate, actualJobCount);
     }
@@ -1364,8 +1319,7 @@ class DefaultJobPersistenceTest {
       jobPersistence.enqueueJob(otherConnectionId1.toString(), SPEC_JOB_CONFIG);
       jobPersistence.enqueueJob(otherConnectionId2.toString(), SPEC_JOB_CONFIG);
 
-      final Long actualJobCount = jobPersistence.getJobCount(Set.of(SPEC_JOB_CONFIG.getConfigType()),
-          CONNECTION_ID.toString());
+      final Long actualJobCount = jobPersistence.getJobCount(Set.of(SPEC_JOB_CONFIG.getConfigType()), CONNECTION_ID.toString());
 
       assertEquals(0, actualJobCount);
     }
@@ -1396,8 +1350,7 @@ class DefaultJobPersistenceTest {
       final int pagesize = 10;
       final int offset = 3;
 
-      final List<Job> actualList = jobPersistence.listJobs(SPEC_JOB_CONFIG.getConfigType(), CONNECTION_ID.toString(),
-          pagesize, offset);
+      final List<Job> actualList = jobPersistence.listJobs(SPEC_JOB_CONFIG.getConfigType(), CONNECTION_ID.toString(), pagesize, offset);
       assertEquals(pagesize, actualList.size());
       assertEquals(ids.get(ids.size() - 1 - offset), actualList.get(0).getId());
     }
@@ -1414,11 +1367,9 @@ class DefaultJobPersistenceTest {
       }
       final int pagesize = 200;
       final int offset = 0;
-      final List<Job> actualList = jobPersistence.listJobs(SPEC_JOB_CONFIG.getConfigType(), CONNECTION_ID.toString(),
-          pagesize, offset);
+      final List<Job> actualList = jobPersistence.listJobs(SPEC_JOB_CONFIG.getConfigType(), CONNECTION_ID.toString(), pagesize, offset);
       for (int i = 0; i < 100; i++) {
-        assertEquals(ids.get(ids.size() - (i + 1)), actualList.get(i).getId(),
-            "Job ids should have been in order but weren't.");
+        assertEquals(ids.get(ids.size() - (i + 1)), actualList.get(i).getId(), "Job ids should have been in order but weren't.");
       }
     }
 
@@ -1427,12 +1378,10 @@ class DefaultJobPersistenceTest {
     void testListJobs() throws IOException {
       final long jobId = jobPersistence.enqueueJob(SCOPE, SPEC_JOB_CONFIG).orElseThrow();
 
-      final List<Job> actualList = jobPersistence.listJobs(SPEC_JOB_CONFIG.getConfigType(), CONNECTION_ID.toString(),
-          9999, 0);
+      final List<Job> actualList = jobPersistence.listJobs(SPEC_JOB_CONFIG.getConfigType(), CONNECTION_ID.toString(), 9999, 0);
 
       final Job actual = actualList.get(0);
-      final Job expected = createJob(jobId, SPEC_JOB_CONFIG, JobStatus.PENDING, Collections.emptyList(),
-          NOW.getEpochSecond());
+      final Job expected = createJob(jobId, SPEC_JOB_CONFIG, JobStatus.PENDING, Collections.emptyList(), NOW.getEpochSecond());
 
       assertEquals(1, actualList.size());
       assertEquals(expected, actual);
@@ -1448,12 +1397,10 @@ class DefaultJobPersistenceTest {
       jobPersistence.enqueueJob(SCOPE, SYNC_JOB_CONFIG).orElseThrow();
 
       final List<Job> actualList =
-          jobPersistence.listJobs(Set.of(SPEC_JOB_CONFIG.getConfigType(), CHECK_JOB_CONFIG.getConfigType()),
-              CONNECTION_ID.toString(), 9999, 0);
+          jobPersistence.listJobs(Set.of(SPEC_JOB_CONFIG.getConfigType(), CHECK_JOB_CONFIG.getConfigType()), CONNECTION_ID.toString(), 9999, 0);
 
       final List<Job> expectedList =
-          List.of(
-              createJob(checkJobId, CHECK_JOB_CONFIG, JobStatus.PENDING, Collections.emptyList(), NOW.getEpochSecond()),
+          List.of(createJob(checkJobId, CHECK_JOB_CONFIG, JobStatus.PENDING, Collections.emptyList(), NOW.getEpochSecond()),
               createJob(specJobId, SPEC_JOB_CONFIG, JobStatus.PENDING, Collections.emptyList(), NOW.getEpochSecond()));
 
       assertEquals(expectedList, actualList);
@@ -1472,8 +1419,7 @@ class DefaultJobPersistenceTest {
 
       jobPersistence.succeedAttempt(jobId, attemptNumber1);
 
-      final List<Job> actualList = jobPersistence.listJobs(SPEC_JOB_CONFIG.getConfigType(), CONNECTION_ID.toString(),
-          9999, 0);
+      final List<Job> actualList = jobPersistence.listJobs(SPEC_JOB_CONFIG.getConfigType(), CONNECTION_ID.toString(), 9999, 0);
 
       final Job actual = actualList.get(0);
       final Job expected = createJob(
@@ -1508,8 +1454,7 @@ class DefaultJobPersistenceTest {
       final var job2Attempt1 = jobPersistence.createAttempt(jobId2, job2Attempt1LogPath);
       jobPersistence.succeedAttempt(jobId2, job2Attempt1);
 
-      final List<Job> actualList = jobPersistence.listJobs(SPEC_JOB_CONFIG.getConfigType(), CONNECTION_ID.toString(),
-          9999, 0);
+      final List<Job> actualList = jobPersistence.listJobs(SPEC_JOB_CONFIG.getConfigType(), CONNECTION_ID.toString(), 9999, 0);
 
       assertEquals(2, actualList.size());
       assertEquals(jobId2, actualList.get(0).getId());
@@ -1533,8 +1478,7 @@ class DefaultJobPersistenceTest {
 
       final int includingIdIndex = 90;
       final int pageSize = 25;
-      final List<Job> actualList = jobPersistence.listJobsIncludingId(
-          Set.of(SPEC_JOB_CONFIG.getConfigType(), CHECK_JOB_CONFIG.getConfigType()),
+      final List<Job> actualList = jobPersistence.listJobsIncludingId(Set.of(SPEC_JOB_CONFIG.getConfigType(), CHECK_JOB_CONFIG.getConfigType()),
           CONNECTION_ID.toString(), ids.get(includingIdIndex), pageSize);
       final List<Long> expectedJobIds = Lists.reverse(ids.subList(ids.size() - pageSize, ids.size()));
       assertEquals(expectedJobIds, actualList.stream().map(Job::getId).toList());
@@ -1559,8 +1503,7 @@ class DefaultJobPersistenceTest {
       // including id is on the second page, so response should contain two pages of jobs
       final int includingIdIndex = 60;
       final int pageSize = 25;
-      final List<Job> actualList = jobPersistence.listJobsIncludingId(
-          Set.of(SPEC_JOB_CONFIG.getConfigType(), CHECK_JOB_CONFIG.getConfigType()),
+      final List<Job> actualList = jobPersistence.listJobsIncludingId(Set.of(SPEC_JOB_CONFIG.getConfigType(), CHECK_JOB_CONFIG.getConfigType()),
           CONNECTION_ID.toString(), ids.get(includingIdIndex), pageSize);
       final List<Long> expectedJobIds = Lists.reverse(ids.subList(ids.size() - (pageSize * 2), ids.size()));
       assertEquals(expectedJobIds, actualList.stream().map(Job::getId).toList());
@@ -1573,12 +1516,10 @@ class DefaultJobPersistenceTest {
         jobPersistence.enqueueJob(CONNECTION_ID.toString(), SPEC_JOB_CONFIG);
       }
 
-      final long otherConnectionJobId = jobPersistence.enqueueJob(UUID.randomUUID().toString(), SPEC_JOB_CONFIG)
-          .orElseThrow();
+      final long otherConnectionJobId = jobPersistence.enqueueJob(UUID.randomUUID().toString(), SPEC_JOB_CONFIG).orElseThrow();
 
       final List<Job> actualList =
-          jobPersistence.listJobsIncludingId(Set.of(SPEC_JOB_CONFIG.getConfigType()), CONNECTION_ID.toString(),
-              otherConnectionJobId, 25);
+          jobPersistence.listJobsIncludingId(Set.of(SPEC_JOB_CONFIG.getConfigType()), CONNECTION_ID.toString(), otherConnectionJobId, 25);
       assertEquals(List.of(), actualList);
     }
 
@@ -1629,20 +1570,15 @@ class DefaultJobPersistenceTest {
       final List<Job> allPendingJobs = jobPersistence.listJobsWithStatus(JobStatus.PENDING);
 
       final Job expectedPendingSpecJob =
-          createJob(pendingSpecJobId, SPEC_JOB_CONFIG, JobStatus.PENDING, Lists.newArrayList(), NOW.getEpochSecond(),
-              SPEC_SCOPE);
+          createJob(pendingSpecJobId, SPEC_JOB_CONFIG, JobStatus.PENDING, Lists.newArrayList(), NOW.getEpochSecond(), SPEC_SCOPE);
       final Job expectedPendingCheckJob =
-          createJob(pendingCheckJobId, CHECK_JOB_CONFIG, JobStatus.PENDING, Lists.newArrayList(), NOW.getEpochSecond(),
-              CHECK_SCOPE);
+          createJob(pendingCheckJobId, CHECK_JOB_CONFIG, JobStatus.PENDING, Lists.newArrayList(), NOW.getEpochSecond(), CHECK_SCOPE);
       final Job expectedPendingSyncJob =
-          createJob(pendingSyncJobId, SYNC_JOB_CONFIG, JobStatus.PENDING, Lists.newArrayList(), NOW.getEpochSecond(),
-              SYNC_SCOPE);
+          createJob(pendingSyncJobId, SYNC_JOB_CONFIG, JobStatus.PENDING, Lists.newArrayList(), NOW.getEpochSecond(), SYNC_SCOPE);
 
-      final List<Job> allPendingSyncAndSpecJobs = jobPersistence.listJobsWithStatus(
-          Set.of(ConfigType.GET_SPEC, ConfigType.SYNC), JobStatus.PENDING);
+      final List<Job> allPendingSyncAndSpecJobs = jobPersistence.listJobsWithStatus(Set.of(ConfigType.GET_SPEC, ConfigType.SYNC), JobStatus.PENDING);
 
-      final List<Job> incompleteJobs = jobPersistence.listJobsWithStatus(SPEC_JOB_CONFIG.getConfigType(),
-          JobStatus.INCOMPLETE);
+      final List<Job> incompleteJobs = jobPersistence.listJobsWithStatus(SPEC_JOB_CONFIG.getConfigType(), JobStatus.INCOMPLETE);
       final Job actualIncompleteJob = incompleteJobs.get(0);
       final Job expectedIncompleteJob = createJob(
           failedSpecJobId,
@@ -1653,10 +1589,8 @@ class DefaultJobPersistenceTest {
           NOW.getEpochSecond(),
           SPEC_SCOPE);
 
-      assertEquals(Sets.newHashSet(expectedPendingCheckJob, expectedPendingSpecJob, expectedPendingSyncJob),
-          Sets.newHashSet(allPendingJobs));
-      assertEquals(Sets.newHashSet(expectedPendingSpecJob, expectedPendingSyncJob),
-          Sets.newHashSet(allPendingSyncAndSpecJobs));
+      assertEquals(Sets.newHashSet(expectedPendingCheckJob, expectedPendingSpecJob, expectedPendingSyncJob), Sets.newHashSet(allPendingJobs));
+      assertEquals(Sets.newHashSet(expectedPendingSpecJob, expectedPendingSyncJob), Sets.newHashSet(allPendingSyncAndSpecJobs));
 
       assertEquals(1, incompleteJobs.size());
       assertEquals(expectedIncompleteJob, actualIncompleteJob);
@@ -1669,45 +1603,36 @@ class DefaultJobPersistenceTest {
       final UUID otherConnectionId = UUID.randomUUID();
 
       // desired connection, statuses, and config types
-      final long desiredJobId1 = jobPersistence.enqueueJob(desiredConnectionId.toString(), SYNC_JOB_CONFIG)
-          .orElseThrow();
+      final long desiredJobId1 = jobPersistence.enqueueJob(desiredConnectionId.toString(), SYNC_JOB_CONFIG).orElseThrow();
       jobPersistence.succeedAttempt(desiredJobId1, jobPersistence.createAttempt(desiredJobId1, LOG_PATH));
-      final long desiredJobId2 = jobPersistence.enqueueJob(desiredConnectionId.toString(), SYNC_JOB_CONFIG)
-          .orElseThrow();
-      final long desiredJobId3 = jobPersistence.enqueueJob(desiredConnectionId.toString(), CHECK_JOB_CONFIG)
-          .orElseThrow();
+      final long desiredJobId2 = jobPersistence.enqueueJob(desiredConnectionId.toString(), SYNC_JOB_CONFIG).orElseThrow();
+      final long desiredJobId3 = jobPersistence.enqueueJob(desiredConnectionId.toString(), CHECK_JOB_CONFIG).orElseThrow();
       jobPersistence.succeedAttempt(desiredJobId3, jobPersistence.createAttempt(desiredJobId3, LOG_PATH));
-      final long desiredJobId4 = jobPersistence.enqueueJob(desiredConnectionId.toString(), CHECK_JOB_CONFIG)
-          .orElseThrow();
+      final long desiredJobId4 = jobPersistence.enqueueJob(desiredConnectionId.toString(), CHECK_JOB_CONFIG).orElseThrow();
 
       // right connection id and status, wrong config type
       jobPersistence.enqueueJob(desiredConnectionId.toString(), SPEC_JOB_CONFIG).orElseThrow();
       // right config type and status, wrong connection id
       jobPersistence.enqueueJob(otherConnectionId.toString(), SYNC_JOB_CONFIG).orElseThrow();
       // right connection id and config type, wrong status
-      final long otherJobId3 = jobPersistence.enqueueJob(desiredConnectionId.toString(), CHECK_JOB_CONFIG)
-          .orElseThrow();
+      final long otherJobId3 = jobPersistence.enqueueJob(desiredConnectionId.toString(), CHECK_JOB_CONFIG).orElseThrow();
       jobPersistence.failAttempt(otherJobId3, jobPersistence.createAttempt(otherJobId3, LOG_PATH));
 
       final List<Job> actualJobs = jobPersistence.listJobsForConnectionWithStatuses(desiredConnectionId,
-          Set.of(ConfigType.SYNC, ConfigType.CHECK_CONNECTION_DESTINATION),
-          Set.of(JobStatus.PENDING, JobStatus.SUCCEEDED));
+          Set.of(ConfigType.SYNC, ConfigType.CHECK_CONNECTION_DESTINATION), Set.of(JobStatus.PENDING, JobStatus.SUCCEEDED));
 
       final Job expectedDesiredJob1 = createJob(desiredJobId1, SYNC_JOB_CONFIG, JobStatus.SUCCEEDED,
           Lists.newArrayList(createAttempt(0L, desiredJobId1, AttemptStatus.SUCCEEDED, LOG_PATH)),
           NOW.getEpochSecond(), desiredConnectionId.toString());
       final Job expectedDesiredJob2 =
-          createJob(desiredJobId2, SYNC_JOB_CONFIG, JobStatus.PENDING, Lists.newArrayList(), NOW.getEpochSecond(),
-              desiredConnectionId.toString());
+          createJob(desiredJobId2, SYNC_JOB_CONFIG, JobStatus.PENDING, Lists.newArrayList(), NOW.getEpochSecond(), desiredConnectionId.toString());
       final Job expectedDesiredJob3 = createJob(desiredJobId3, CHECK_JOB_CONFIG, JobStatus.SUCCEEDED,
           Lists.newArrayList(createAttempt(0L, desiredJobId3, AttemptStatus.SUCCEEDED, LOG_PATH)),
           NOW.getEpochSecond(), desiredConnectionId.toString());
       final Job expectedDesiredJob4 =
-          createJob(desiredJobId4, CHECK_JOB_CONFIG, JobStatus.PENDING, Lists.newArrayList(), NOW.getEpochSecond(),
-              desiredConnectionId.toString());
+          createJob(desiredJobId4, CHECK_JOB_CONFIG, JobStatus.PENDING, Lists.newArrayList(), NOW.getEpochSecond(), desiredConnectionId.toString());
 
-      assertEquals(Sets.newHashSet(expectedDesiredJob1, expectedDesiredJob2, expectedDesiredJob3, expectedDesiredJob4),
-          Sets.newHashSet(actualJobs));
+      assertEquals(Sets.newHashSet(expectedDesiredJob1, expectedDesiredJob2, expectedDesiredJob3, expectedDesiredJob4), Sets.newHashSet(actualJobs));
     }
 
   }
@@ -1750,10 +1675,7 @@ class DefaultJobPersistenceTest {
   @DisplayName("When purging job history")
   class PurgeJobHistory {
 
-    private Job persistJobForJobHistoryTesting(final String scope,
-                                               final JobConfig jobConfig,
-                                               final JobStatus status,
-                                               final LocalDateTime runDate)
+    private Job persistJobForJobHistoryTesting(final String scope, final JobConfig jobConfig, final JobStatus status, final LocalDateTime runDate)
         throws IOException, SQLException {
       final Optional<Long> id = jobDatabase.query(
           ctx -> ctx.fetch(
@@ -1772,10 +1694,7 @@ class DefaultJobPersistenceTest {
       return jobPersistence.getJob(id.get());
     }
 
-    private void persistAttemptForJobHistoryTesting(final Job job,
-                                                    final String logPath,
-                                                    final LocalDateTime runDate,
-                                                    final boolean shouldHaveState)
+    private void persistAttemptForJobHistoryTesting(final Job job, final String logPath, final LocalDateTime runDate, final boolean shouldHaveState)
         throws IOException, SQLException {
       final String attemptOutputWithState = "{\n"
           + "  \"sync\": {\n"
@@ -1808,11 +1727,11 @@ class DefaultJobPersistenceTest {
      * controlling deletion logic. Thus, the test case injects overrides for those constants, testing a
      * comprehensive set of combinations to make sure that the logic is robust to reasonable
      * configurations. Extreme configurations such as zero-day retention period are not covered.
-     * <p>
+     *
      * Business rules for deletions. 1. Job must be older than X days or its conn has excessive number
      * of jobs 2. Job cannot be one of the last N jobs on that conn (last N jobs are always kept). 3.
      * Job cannot be holding the most recent saved state (most recent saved state is always kept).
-     * <p>
+     *
      * Testing Goal: Set up jobs according to the parameters passed in. Then delete according to the
      * rules, and make sure the right number of jobs are left. Against one connection/scope,
      * <ol>
@@ -1841,6 +1760,7 @@ class DefaultJobPersistenceTest {
      *        parameters. This was calculated by a human based on understanding the requirements.
      * @param goalOfTestScenario Description of the purpose of that test scenario, so it's easier to
      *        maintain and understand failures.
+     *
      */
     @DisplayName("Should purge older job history but maintain certain more recent ones")
     @ParameterizedTest
@@ -1883,10 +1803,8 @@ class DefaultJobPersistenceTest {
       final List<Job> allJobs = new ArrayList<>();
       final List<Job> decoyJobs = new ArrayList<>();
       for (int i = 0; i < numJobs; i++) {
-        allJobs.add(
-            persistJobForJobHistoryTesting(CURRENT_SCOPE, SYNC_JOB_CONFIG, JobStatus.FAILED, fakeNow.minusDays(i)));
-        decoyJobs.add(
-            persistJobForJobHistoryTesting(DECOY_SCOPE, SYNC_JOB_CONFIG, JobStatus.FAILED, fakeNow.minusDays(i)));
+        allJobs.add(persistJobForJobHistoryTesting(CURRENT_SCOPE, SYNC_JOB_CONFIG, JobStatus.FAILED, fakeNow.minusDays(i)));
+        decoyJobs.add(persistJobForJobHistoryTesting(DECOY_SCOPE, SYNC_JOB_CONFIG, JobStatus.FAILED, fakeNow.minusDays(i)));
       }
 
       // At least one job should have state. Find the desired job and add state to it.
@@ -1906,18 +1824,15 @@ class DefaultJobPersistenceTest {
       final List<Job> afterPurge = jobPersistence.listJobs(ConfigType.SYNC, CURRENT_SCOPE, 9999, 0);
 
       // Test - contains expected number of jobs and no more than that
-      assertEquals(expectedAfterPurge, afterPurge.size(),
-          goalOfTestScenario + " - Incorrect number of jobs remain after deletion.");
+      assertEquals(expectedAfterPurge, afterPurge.size(), goalOfTestScenario + " - Incorrect number of jobs remain after deletion.");
 
       // Test - most-recent are actually the most recent by date (see above, reverse order)
       for (int i = 0; i < Math.min(ageCutoff, recencyCutoff); i++) {
-        assertEquals(allJobs.get(i).getId(), afterPurge.get(i).getId(),
-            goalOfTestScenario + " - Incorrect sort order after deletion.");
+        assertEquals(allJobs.get(i).getId(), afterPurge.get(i).getId(), goalOfTestScenario + " - Incorrect sort order after deletion.");
       }
 
       // Test - job with latest state is always kept despite being older than some cutoffs
-      assertTrue(afterPurge.contains(lastJobWithState),
-          goalOfTestScenario + " - Missing last job with saved state after deletion.");
+      assertTrue(afterPurge.contains(lastJobWithState), goalOfTestScenario + " - Missing last job with saved state after deletion.");
     }
 
     private Job addStateToJob(final Job job) throws IOException, SQLException {
@@ -1935,19 +1850,15 @@ class DefaultJobPersistenceTest {
     @Test
     @DisplayName("Should list only job statuses and timestamps of specified connection id")
     void testConnectionIdFiltering() throws IOException {
-      jobPersistence = new DefaultJobPersistence(jobDatabase, timeSupplier, DEFAULT_MINIMUM_AGE_IN_DAYS,
-          DEFAULT_EXCESSIVE_NUMBER_OF_JOBS,
+      jobPersistence = new DefaultJobPersistence(jobDatabase, timeSupplier, DEFAULT_MINIMUM_AGE_IN_DAYS, DEFAULT_EXCESSIVE_NUMBER_OF_JOBS,
           DEFAULT_MINIMUM_RECENCY_COUNT);
 
       // create a connection with a non-relevant connection id that should be ignored for the duration of
       // the test
-      final long wrongConnectionSyncJobId = jobPersistence.enqueueJob(UUID.randomUUID().toString(), SYNC_JOB_CONFIG)
-          .orElseThrow();
+      final long wrongConnectionSyncJobId = jobPersistence.enqueueJob(UUID.randomUUID().toString(), SYNC_JOB_CONFIG).orElseThrow();
       final int wrongSyncJobAttemptNumber0 = jobPersistence.createAttempt(wrongConnectionSyncJobId, LOG_PATH);
       jobPersistence.failAttempt(wrongConnectionSyncJobId, wrongSyncJobAttemptNumber0);
-      assertEquals(0,
-          jobPersistence.listJobStatusAndTimestampWithConnection(CONNECTION_ID, Sets.newHashSet(ConfigType.SYNC),
-              Instant.EPOCH).size());
+      assertEquals(0, jobPersistence.listJobStatusAndTimestampWithConnection(CONNECTION_ID, Sets.newHashSet(ConfigType.SYNC), Instant.EPOCH).size());
 
       // create a connection with relevant connection id
       final long syncJobId = jobPersistence.enqueueJob(SCOPE, SYNC_JOB_CONFIG).orElseThrow();
@@ -1956,8 +1867,7 @@ class DefaultJobPersistenceTest {
 
       // check to see current status of only relevantly scoped job
       final List<JobWithStatusAndTimestamp> jobs =
-          jobPersistence.listJobStatusAndTimestampWithConnection(CONNECTION_ID, Sets.newHashSet(ConfigType.SYNC),
-              Instant.EPOCH);
+          jobPersistence.listJobStatusAndTimestampWithConnection(CONNECTION_ID, Sets.newHashSet(ConfigType.SYNC), Instant.EPOCH);
       assertEquals(jobs.size(), 1);
       assertEquals(JobStatus.INCOMPLETE, jobs.get(0).getStatus());
     }
@@ -1965,8 +1875,7 @@ class DefaultJobPersistenceTest {
     @Test
     @DisplayName("Should list jobs statuses filtered by different timestamps")
     void testTimestampFiltering() throws IOException {
-      jobPersistence = new DefaultJobPersistence(jobDatabase, timeSupplier, DEFAULT_MINIMUM_AGE_IN_DAYS,
-          DEFAULT_EXCESSIVE_NUMBER_OF_JOBS,
+      jobPersistence = new DefaultJobPersistence(jobDatabase, timeSupplier, DEFAULT_MINIMUM_AGE_IN_DAYS, DEFAULT_EXCESSIVE_NUMBER_OF_JOBS,
           DEFAULT_MINIMUM_RECENCY_COUNT);
 
       // Create and fail initial job
@@ -1977,8 +1886,7 @@ class DefaultJobPersistenceTest {
 
       // Check to see current status of all jobs from beginning of time, expecting only 1 job
       final List<JobWithStatusAndTimestamp> initialJobs =
-          jobPersistence.listJobStatusAndTimestampWithConnection(CONNECTION_ID, Sets.newHashSet(ConfigType.SYNC),
-              Instant.EPOCH);
+          jobPersistence.listJobStatusAndTimestampWithConnection(CONNECTION_ID, Sets.newHashSet(ConfigType.SYNC), Instant.EPOCH);
       assertEquals(initialJobs.size(), 1);
       assertEquals(JobStatus.FAILED, initialJobs.get(0).getStatus());
 
@@ -1994,16 +1902,14 @@ class DefaultJobPersistenceTest {
       // Check to see current status of all jobs from beginning of time, expecting both jobs in createAt
       // descending order (most recent first)
       final List<JobWithStatusAndTimestamp> allQueryJobs =
-          jobPersistence.listJobStatusAndTimestampWithConnection(CONNECTION_ID, Sets.newHashSet(ConfigType.SYNC),
-              Instant.EPOCH);
+          jobPersistence.listJobStatusAndTimestampWithConnection(CONNECTION_ID, Sets.newHashSet(ConfigType.SYNC), Instant.EPOCH);
       assertEquals(2, allQueryJobs.size());
       assertEquals(JobStatus.SUCCEEDED, allQueryJobs.get(0).getStatus());
       assertEquals(JobStatus.FAILED, allQueryJobs.get(1).getStatus());
 
       // Look up jobs with a timestamp after the first job. Expecting only the second job status
       final List<JobWithStatusAndTimestamp> timestampFilteredJobs =
-          jobPersistence.listJobStatusAndTimestampWithConnection(CONNECTION_ID, Sets.newHashSet(ConfigType.SYNC),
-              timeAfterFirstJob);
+          jobPersistence.listJobStatusAndTimestampWithConnection(CONNECTION_ID, Sets.newHashSet(ConfigType.SYNC), timeAfterFirstJob);
       assertEquals(1, timestampFilteredJobs.size());
       assertEquals(JobStatus.SUCCEEDED, timestampFilteredJobs.get(0).getStatus());
       // TODO: issues will be fixed in scope of https://github.com/airbytehq/airbyte/issues/13192
@@ -2016,16 +1922,14 @@ class DefaultJobPersistenceTest {
       // second job. Expecting no job status output
       final Instant timeAfterSecondJob = timeAfterFirstJob.plusSeconds(60);
       assertEquals(0,
-          jobPersistence.listJobStatusAndTimestampWithConnection(CONNECTION_ID, Sets.newHashSet(ConfigType.SYNC),
-              timeAfterSecondJob).size());
+          jobPersistence.listJobStatusAndTimestampWithConnection(CONNECTION_ID, Sets.newHashSet(ConfigType.SYNC), timeAfterSecondJob).size());
     }
 
     @Test
     @DisplayName("Should list jobs statuses of differing status types")
     void testMultipleJobStatusTypes() throws IOException {
       final Supplier<Instant> timeSupplier = incrementingSecondSupplier(NOW);
-      jobPersistence = new DefaultJobPersistence(jobDatabase, timeSupplier, DEFAULT_MINIMUM_AGE_IN_DAYS,
-          DEFAULT_EXCESSIVE_NUMBER_OF_JOBS,
+      jobPersistence = new DefaultJobPersistence(jobDatabase, timeSupplier, DEFAULT_MINIMUM_AGE_IN_DAYS, DEFAULT_EXCESSIVE_NUMBER_OF_JOBS,
           DEFAULT_MINIMUM_RECENCY_COUNT);
 
       // Create and fail initial job
@@ -2047,8 +1951,7 @@ class DefaultJobPersistenceTest {
       // Check to see current status of all jobs from beginning of time, expecting all jobs in createAt
       // descending order (most recent first)
       final List<JobWithStatusAndTimestamp> allJobs =
-          jobPersistence.listJobStatusAndTimestampWithConnection(CONNECTION_ID, Sets.newHashSet(ConfigType.SYNC),
-              Instant.EPOCH);
+          jobPersistence.listJobStatusAndTimestampWithConnection(CONNECTION_ID, Sets.newHashSet(ConfigType.SYNC), Instant.EPOCH);
       assertEquals(3, allJobs.size());
       assertEquals(JobStatus.CANCELLED, allJobs.get(0).getStatus());
       assertEquals(JobStatus.SUCCEEDED, allJobs.get(1).getStatus());
@@ -2060,8 +1963,7 @@ class DefaultJobPersistenceTest {
     void testMultipleConfigTypes() throws IOException {
       final Set<ConfigType> configTypes = Sets.newHashSet(ConfigType.GET_SPEC, ConfigType.CHECK_CONNECTION_DESTINATION);
       final Supplier<Instant> timeSupplier = incrementingSecondSupplier(NOW);
-      jobPersistence = new DefaultJobPersistence(jobDatabase, timeSupplier, DEFAULT_MINIMUM_AGE_IN_DAYS,
-          DEFAULT_EXCESSIVE_NUMBER_OF_JOBS,
+      jobPersistence = new DefaultJobPersistence(jobDatabase, timeSupplier, DEFAULT_MINIMUM_AGE_IN_DAYS, DEFAULT_EXCESSIVE_NUMBER_OF_JOBS,
           DEFAULT_MINIMUM_RECENCY_COUNT);
 
       // pending status

--- a/airbyte-persistence/job-persistence/src/test/java/io/airbyte/persistence/job/DefaultJobPersistenceTest.java
+++ b/airbyte-persistence/job-persistence/src/test/java/io/airbyte/persistence/job/DefaultJobPersistenceTest.java
@@ -136,7 +136,10 @@ class DefaultJobPersistenceTest {
     container.close();
   }
 
-  private static Attempt createAttempt(final long id, final long jobId, final AttemptStatus status, final Path logPath) {
+  private static Attempt createAttempt(final long id,
+                                       final long jobId,
+                                       final AttemptStatus status,
+                                       final Path logPath) {
     return new Attempt(
         id,
         jobId,
@@ -149,7 +152,10 @@ class DefaultJobPersistenceTest {
         NOW.getEpochSecond());
   }
 
-  private static Attempt createUnfinishedAttempt(final long id, final long jobId, final AttemptStatus status, final Path logPath) {
+  private static Attempt createUnfinishedAttempt(final long id,
+                                                 final long jobId,
+                                                 final AttemptStatus status,
+                                                 final Path logPath) {
     return new Attempt(
         id,
         jobId,
@@ -162,7 +168,11 @@ class DefaultJobPersistenceTest {
         null);
   }
 
-  private static Job createJob(final long id, final JobConfig jobConfig, final JobStatus status, final List<Attempt> attempts, final long time) {
+  private static Job createJob(final long id,
+                               final JobConfig jobConfig,
+                               final JobStatus status,
+                               final List<Attempt> attempts,
+                               final long time) {
     return createJob(id, jobConfig, status, attempts, time, SCOPE);
   }
 
@@ -197,7 +207,8 @@ class DefaultJobPersistenceTest {
     timeSupplier = mock(Supplier.class);
     when(timeSupplier.get()).thenReturn(NOW);
 
-    jobPersistence = new DefaultJobPersistence(jobDatabase, timeSupplier, DEFAULT_MINIMUM_AGE_IN_DAYS, DEFAULT_EXCESSIVE_NUMBER_OF_JOBS,
+    jobPersistence = new DefaultJobPersistence(jobDatabase, timeSupplier, DEFAULT_MINIMUM_AGE_IN_DAYS,
+        DEFAULT_EXCESSIVE_NUMBER_OF_JOBS,
         DEFAULT_MINIMUM_RECENCY_COUNT);
   }
 
@@ -216,7 +227,8 @@ class DefaultJobPersistenceTest {
   }
 
   private Result<Record> getJobRecord(final long jobId) throws SQLException {
-    return jobDatabase.query(ctx -> ctx.fetch(DefaultJobPersistence.BASE_JOB_SELECT_AND_JOIN + "WHERE jobs.id = ?", jobId));
+    return jobDatabase.query(
+        ctx -> ctx.fetch(DefaultJobPersistence.BASE_JOB_SELECT_AND_JOIN + "WHERE jobs.id = ?", jobId));
   }
 
   @Test
@@ -262,20 +274,27 @@ class DefaultJobPersistenceTest {
     final int attemptNumber = jobPersistence.createAttempt(jobId, LOG_PATH);
     final Job created = jobPersistence.getJob(jobId);
     final SyncStats syncStats =
-        new SyncStats().withBytesEmitted(100L).withRecordsEmitted(9L).withRecordsCommitted(10L).withDestinationStateMessagesEmitted(1L)
-            .withSourceStateMessagesEmitted(4L).withMaxSecondsBeforeSourceStateMessageEmitted(5L).withMeanSecondsBeforeSourceStateMessageEmitted(2L)
-            .withMaxSecondsBetweenStateMessageEmittedandCommitted(10L).withMeanSecondsBetweenStateMessageEmittedandCommitted(3L);
-    final FailureReason failureReason1 = new FailureReason().withFailureOrigin(FailureOrigin.DESTINATION).withFailureType(FailureType.SYSTEM_ERROR)
+        new SyncStats().withBytesEmitted(100L).withRecordsEmitted(9L).withRecordsCommitted(10L)
+            .withDestinationStateMessagesEmitted(1L)
+            .withSourceStateMessagesEmitted(4L).withMaxSecondsBeforeSourceStateMessageEmitted(5L)
+            .withMeanSecondsBeforeSourceStateMessageEmitted(2L)
+            .withMaxSecondsBetweenStateMessageEmittedandCommitted(10L)
+            .withMeanSecondsBetweenStateMessageEmittedandCommitted(3L);
+    final FailureReason failureReason1 = new FailureReason().withFailureOrigin(FailureOrigin.DESTINATION)
+        .withFailureType(FailureType.SYSTEM_ERROR)
         .withExternalMessage("There was a normalization error");
-    final FailureReason failureReason2 = new FailureReason().withFailureOrigin(FailureOrigin.SOURCE).withFailureType(FailureType.CONFIG_ERROR)
+    final FailureReason failureReason2 = new FailureReason().withFailureOrigin(FailureOrigin.SOURCE)
+        .withFailureType(FailureType.CONFIG_ERROR)
         .withExternalMessage("There was another normalization error");
 
     final NormalizationSummary normalizationSummary =
-        new NormalizationSummary().withStartTime(10L).withEndTime(500L).withFailures(List.of(failureReason1, failureReason2));
+        new NormalizationSummary().withStartTime(10L).withEndTime(500L)
+            .withFailures(List.of(failureReason1, failureReason2));
     final StandardSyncOutput standardSyncOutput =
         new StandardSyncOutput().withStandardSyncSummary(new StandardSyncSummary().withTotalStats(syncStats))
             .withNormalizationSummary(normalizationSummary);
-    final JobOutput jobOutput = new JobOutput().withOutputType(JobOutput.OutputType.DISCOVER_CATALOG).withSync(standardSyncOutput);
+    final JobOutput jobOutput = new JobOutput().withOutputType(JobOutput.OutputType.DISCOVER_CATALOG)
+        .withSync(standardSyncOutput);
 
     when(timeSupplier.get()).thenReturn(Instant.ofEpochMilli(4242));
     jobPersistence.writeOutput(jobId, attemptNumber, jobOutput,
@@ -284,7 +303,8 @@ class DefaultJobPersistenceTest {
     final Job updated = jobPersistence.getJob(jobId);
 
     assertEquals(Optional.of(jobOutput), updated.getAttempts().get(0).getOutput());
-    assertNotEquals(created.getAttempts().get(0).getUpdatedAtInSecond(), updated.getAttempts().get(0).getUpdatedAtInSecond());
+    assertNotEquals(created.getAttempts().get(0).getUpdatedAtInSecond(),
+        updated.getAttempts().get(0).getUpdatedAtInSecond());
 
     final Optional<Record> record =
         jobDatabase.query(ctx -> ctx.fetch("SELECT id from attempts where job_id = ? AND attempt_number = ?", jobId,
@@ -303,7 +323,8 @@ class DefaultJobPersistenceTest {
     assertEquals(10L, storedSyncStats.getMaxSecondsBetweenStateMessageEmittedandCommitted());
     assertEquals(3L, storedSyncStats.getMeanSecondsBetweenStateMessageEmittedandCommitted());
 
-    final NormalizationSummary storedNormalizationSummary = jobPersistence.getNormalizationSummary(attemptId).stream().findFirst().get();
+    final NormalizationSummary storedNormalizationSummary = jobPersistence.getNormalizationSummary(attemptId).stream()
+        .findFirst().get();
     assertEquals(10L, storedNormalizationSummary.getStartTime());
     assertEquals(500L, storedNormalizationSummary.getEndTime());
     assertEquals(List.of(failureReason1, failureReason2), storedNormalizationSummary.getFailures());
@@ -323,7 +344,8 @@ class DefaultJobPersistenceTest {
 
     final Job updated = jobPersistence.getJob(jobId);
     assertEquals(Optional.of(failureSummary), updated.getAttempts().get(0).getFailureSummary());
-    assertNotEquals(created.getAttempts().get(0).getUpdatedAtInSecond(), updated.getAttempts().get(0).getUpdatedAtInSecond());
+    assertNotEquals(created.getAttempts().get(0).getUpdatedAtInSecond(),
+        updated.getAttempts().get(0).getUpdatedAtInSecond());
   }
 
   @Test
@@ -354,7 +376,8 @@ class DefaultJobPersistenceTest {
 
     final Optional<Job> actual = DefaultJobPersistence.getJobFromResult(getJobRecord(jobId));
 
-    final Job expected = createJob(jobId, SPEC_JOB_CONFIG, JobStatus.PENDING, Collections.emptyList(), NOW.getEpochSecond());
+    final Job expected = createJob(jobId, SPEC_JOB_CONFIG, JobStatus.PENDING, Collections.emptyList(),
+        NOW.getEpochSecond());
     assertEquals(Optional.of(expected), actual);
   }
 
@@ -382,7 +405,8 @@ class DefaultJobPersistenceTest {
 
     jobPersistence.importDatabase("test", outputStreams);
 
-    final List<Job> actualList = jobPersistence.listJobs(SPEC_JOB_CONFIG.getConfigType(), CONNECTION_ID.toString(), 9999, 0);
+    final List<Job> actualList = jobPersistence.listJobs(SPEC_JOB_CONFIG.getConfigType(), CONNECTION_ID.toString(),
+        9999, 0);
 
     final Job actual = actualList.get(0);
     final Job expected = createJob(
@@ -406,7 +430,8 @@ class DefaultJobPersistenceTest {
     final Instant now = Instant.parse("2021-01-01T00:00:00Z");
     final Supplier<Instant> timeSupplier = incrementingSecondSupplier(now);
 
-    jobPersistence = new DefaultJobPersistence(jobDatabase, timeSupplier, DEFAULT_MINIMUM_AGE_IN_DAYS, DEFAULT_EXCESSIVE_NUMBER_OF_JOBS,
+    jobPersistence = new DefaultJobPersistence(jobDatabase, timeSupplier, DEFAULT_MINIMUM_AGE_IN_DAYS,
+        DEFAULT_EXCESSIVE_NUMBER_OF_JOBS,
         DEFAULT_MINIMUM_RECENCY_COUNT);
     final long syncJobId = jobPersistence.enqueueJob(SCOPE, SYNC_JOB_CONFIG).orElseThrow();
     final int syncJobAttemptNumber0 = jobPersistence.createAttempt(syncJobId, LOG_PATH);
@@ -441,9 +466,11 @@ class DefaultJobPersistenceTest {
     jobPersistence.succeedAttempt(newSyncJobId, newSyncJobAttemptNumber1);
 
     final Long maxEndedAtTimestamp =
-        jobs.get(0).getAttempts().stream().map(c -> c.getEndedAtInSecond().orElseThrow()).max(Long::compareTo).orElseThrow();
+        jobs.get(0).getAttempts().stream().map(c -> c.getEndedAtInSecond().orElseThrow()).max(Long::compareTo)
+            .orElseThrow();
 
-    final List<Job> secondQueryJobs = jobPersistence.listJobs(ConfigType.SYNC, Instant.ofEpochSecond(maxEndedAtTimestamp));
+    final List<Job> secondQueryJobs = jobPersistence.listJobs(ConfigType.SYNC,
+        Instant.ofEpochSecond(maxEndedAtTimestamp));
     assertEquals(secondQueryJobs.size(), 2);
     assertEquals(secondQueryJobs.get(0).getId(), syncJobId);
     assertEquals(secondQueryJobs.get(0).getAttempts().size(), 1);
@@ -457,14 +484,16 @@ class DefaultJobPersistenceTest {
     Long maxEndedAtTimestampAfterSecondQuery = -1L;
     for (final Job c : secondQueryJobs) {
       final List<Attempt> attempts = c.getAttempts();
-      final Long maxEndedAtTimestampForJob = attempts.stream().map(attempt -> attempt.getEndedAtInSecond().orElseThrow())
+      final Long maxEndedAtTimestampForJob = attempts.stream()
+          .map(attempt -> attempt.getEndedAtInSecond().orElseThrow())
           .max(Long::compareTo).orElseThrow();
       if (maxEndedAtTimestampForJob > maxEndedAtTimestampAfterSecondQuery) {
         maxEndedAtTimestampAfterSecondQuery = maxEndedAtTimestampForJob;
       }
     }
 
-    assertEquals(0, jobPersistence.listJobs(ConfigType.SYNC, Instant.ofEpochSecond(maxEndedAtTimestampAfterSecondQuery)).size());
+    assertEquals(0,
+        jobPersistence.listJobs(ConfigType.SYNC, Instant.ofEpochSecond(maxEndedAtTimestampAfterSecondQuery)).size());
   }
 
   @Test
@@ -472,7 +501,8 @@ class DefaultJobPersistenceTest {
   void testListAttemptsWithJobInfo() throws IOException {
     final Instant now = Instant.parse("2021-01-01T00:00:00Z");
     final Supplier<Instant> timeSupplier = incrementingSecondSupplier(now);
-    jobPersistence = new DefaultJobPersistence(jobDatabase, timeSupplier, DEFAULT_MINIMUM_AGE_IN_DAYS, DEFAULT_EXCESSIVE_NUMBER_OF_JOBS,
+    jobPersistence = new DefaultJobPersistence(jobDatabase, timeSupplier, DEFAULT_MINIMUM_AGE_IN_DAYS,
+        DEFAULT_EXCESSIVE_NUMBER_OF_JOBS,
         DEFAULT_MINIMUM_RECENCY_COUNT);
 
     final long job1 = jobPersistence.enqueueJob(SCOPE + "-1", SYNC_JOB_CONFIG).orElseThrow();
@@ -493,7 +523,8 @@ class DefaultJobPersistenceTest {
     jobPersistence.succeedAttempt(job1, job1Attempt3);
     jobPersistence.succeedAttempt(job2, job2Attempt3);
 
-    final List<AttemptWithJobInfo> allAttempts = jobPersistence.listAttemptsWithJobInfo(ConfigType.SYNC, Instant.ofEpochSecond(0));
+    final List<AttemptWithJobInfo> allAttempts = jobPersistence.listAttemptsWithJobInfo(ConfigType.SYNC,
+        Instant.ofEpochSecond(0));
     assertEquals(6, allAttempts.size());
 
     assertEquals(job1, allAttempts.get(0).getJobInfo().getId());
@@ -628,7 +659,8 @@ class DefaultJobPersistenceTest {
       assertTrue(defaultWorkflowId.isEmpty());
 
       jobDatabase.query(ctx -> ctx.execute(
-          "UPDATE attempts SET temporal_workflow_id = '56a81f3a-006c-42d7-bce2-29d675d08ea4' WHERE job_id = ? AND attempt_number =?", jobId,
+          "UPDATE attempts SET temporal_workflow_id = '56a81f3a-006c-42d7-bce2-29d675d08ea4' WHERE job_id = ? AND attempt_number =?",
+          jobId,
           attemptNumber));
       final var workflowId = jobPersistence.getAttemptTemporalWorkflowId(jobId, attemptNumber).get();
       assertEquals(workflowId, "56a81f3a-006c-42d7-bce2-29d675d08ea4");
@@ -762,7 +794,8 @@ class DefaultJobPersistenceTest {
       final int attemptNumber2 = jobPersistence.createAttempt(jobId, LOG_PATH);
       final Job jobAfterTwoAttempts = jobPersistence.getJob(jobId);
       assertEquals(1, attemptNumber2);
-      assertEquals(Sets.newHashSet(0L, 1L), jobAfterTwoAttempts.getAttempts().stream().map(Attempt::getId).collect(Collectors.toSet()));
+      assertEquals(Sets.newHashSet(0L, 1L),
+          jobAfterTwoAttempts.getAttempts().stream().map(Attempt::getId).collect(Collectors.toSet()));
     }
 
     @Test
@@ -814,7 +847,8 @@ class DefaultJobPersistenceTest {
       final long jobId = jobPersistence.enqueueJob(SCOPE, SPEC_JOB_CONFIG).orElseThrow();
 
       final Job actual = jobPersistence.getJob(jobId);
-      final Job expected = createJob(jobId, SPEC_JOB_CONFIG, JobStatus.PENDING, Collections.emptyList(), NOW.getEpochSecond());
+      final Job expected = createJob(jobId, SPEC_JOB_CONFIG, JobStatus.PENDING, Collections.emptyList(),
+          NOW.getEpochSecond());
       assertEquals(expected, actual);
     }
 
@@ -828,7 +862,8 @@ class DefaultJobPersistenceTest {
       assertTrue(jobId2.isEmpty());
 
       final Job actual = jobPersistence.getJob(jobId1.get());
-      final Job expected = createJob(jobId1.get(), SYNC_JOB_CONFIG, JobStatus.PENDING, Collections.emptyList(), NOW.getEpochSecond());
+      final Job expected = createJob(jobId1.get(), SYNC_JOB_CONFIG, JobStatus.PENDING, Collections.emptyList(),
+          NOW.getEpochSecond());
       assertEquals(expected, actual);
     }
 
@@ -843,7 +878,8 @@ class DefaultJobPersistenceTest {
       assertTrue(jobId2.isPresent());
 
       final Job actual = jobPersistence.getJob(jobId2.get());
-      final Job expected = createJob(jobId2.get(), SYNC_JOB_CONFIG, JobStatus.PENDING, Collections.emptyList(), NOW.getEpochSecond());
+      final Job expected = createJob(jobId2.get(), SYNC_JOB_CONFIG, JobStatus.PENDING, Collections.emptyList(),
+          NOW.getEpochSecond());
       assertEquals(expected, actual);
     }
 
@@ -905,7 +941,8 @@ class DefaultJobPersistenceTest {
       final long jobId2 = jobPersistence.enqueueJob(SCOPE, SYNC_JOB_CONFIG).orElseThrow();
 
       final Optional<Job> actual = jobPersistence.getLastReplicationJob(CONNECTION_ID);
-      final Job expected = createJob(jobId2, SYNC_JOB_CONFIG, JobStatus.PENDING, Collections.emptyList(), afterNow.getEpochSecond());
+      final Job expected = createJob(jobId2, SYNC_JOB_CONFIG, JobStatus.PENDING, Collections.emptyList(),
+          afterNow.getEpochSecond());
 
       assertEquals(Optional.of(expected), actual);
     }
@@ -921,7 +958,8 @@ class DefaultJobPersistenceTest {
       final long jobId2 = jobPersistence.enqueueJob(SCOPE, RESET_JOB_CONFIG).orElseThrow();
 
       final Optional<Job> actual = jobPersistence.getLastReplicationJob(CONNECTION_ID);
-      final Job expected = createJob(jobId2, RESET_JOB_CONFIG, JobStatus.PENDING, Collections.emptyList(), afterNow.getEpochSecond());
+      final Job expected = createJob(jobId2, RESET_JOB_CONFIG, JobStatus.PENDING, Collections.emptyList(),
+          afterNow.getEpochSecond());
 
       assertEquals(Optional.of(expected), actual);
     }
@@ -957,7 +995,8 @@ class DefaultJobPersistenceTest {
       jobPersistence.failJob(jobId2);
 
       final Optional<Job> actual = jobPersistence.getLastSyncJob(CONNECTION_ID);
-      final Job expected = createJob(jobId2, SYNC_JOB_CONFIG, JobStatus.FAILED, List.of(attempt), afterNow.getEpochSecond());
+      final Job expected = createJob(jobId2, SYNC_JOB_CONFIG, JobStatus.FAILED, List.of(attempt),
+          afterNow.getEpochSecond());
 
       assertEquals(Optional.of(expected), actual);
     }
@@ -972,6 +1011,155 @@ class DefaultJobPersistenceTest {
       when(timeSupplier.get()).thenReturn(afterNow);
 
       final Optional<Job> actual = jobPersistence.getLastSyncJob(CONNECTION_ID);
+
+      assertTrue(actual.isEmpty());
+    }
+
+  }
+
+  @Nested
+  @DisplayName("When getting the last sync job for multiple connections")
+  class GetLastSyncJobsForConnections {
+
+    private static final UUID CONNECTION_ID_1 = UUID.randomUUID();
+    private static final UUID CONNECTION_ID_2 = UUID.randomUUID();
+    private static final UUID CONNECTION_ID_3 = UUID.randomUUID();
+    private static final String SCOPE_1 = CONNECTION_ID_1.toString();
+    private static final String SCOPE_2 = CONNECTION_ID_2.toString();
+    private static final String SCOPE_3 = CONNECTION_ID_3.toString();
+    private static final List<UUID> CONNECTION_IDS = List.of(CONNECTION_ID_1, CONNECTION_ID_2, CONNECTION_ID_3);
+
+    @Test
+    @DisplayName("Should return nothing if no sync job exists")
+    void testGetLastSyncJobsForConnectionsEmpty() throws IOException {
+      final List<Optional<Job>> actual = jobPersistence.getLastSyncJobsForConnections(CONNECTION_IDS);
+
+      assertTrue(actual.isEmpty());
+    }
+
+    @Test
+    @DisplayName("Should return the last enqueued sync job for each connection")
+    void testGetLastSyncJobsForConnections() throws IOException {
+      final long scope1Job1 = jobPersistence.enqueueJob(SCOPE_1, SYNC_JOB_CONFIG).orElseThrow();
+      jobPersistence.succeedAttempt(scope1Job1, jobPersistence.createAttempt(scope1Job1, LOG_PATH));
+
+      final long scope2Job1 = jobPersistence.enqueueJob(SCOPE_2, SYNC_JOB_CONFIG).orElseThrow();
+      jobPersistence.succeedAttempt(scope2Job1, jobPersistence.createAttempt(scope2Job1, LOG_PATH));
+
+      final long scope3Job1 = jobPersistence.enqueueJob(SCOPE_3, SYNC_JOB_CONFIG).orElseThrow();
+
+      final Instant afterNow = NOW.plusSeconds(1000);
+      when(timeSupplier.get()).thenReturn(afterNow);
+
+      final long scope1Job2 = jobPersistence.enqueueJob(SCOPE_1, SYNC_JOB_CONFIG).orElseThrow();
+      final int scope1Job2AttemptNumber = jobPersistence.createAttempt(scope1Job2, LOG_PATH);
+
+      // should return the latest sync job even if failed
+      jobPersistence.failAttempt(scope1Job2, scope1Job2AttemptNumber);
+      final Attempt scope1Job2attempt = jobPersistence.getJob(scope1Job2).getAttempts().stream().findFirst()
+          .orElseThrow();
+      jobPersistence.failJob(scope1Job2);
+
+      // will leave this job running
+      final long scope2Job2 = jobPersistence.enqueueJob(SCOPE_2, SYNC_JOB_CONFIG).orElseThrow();
+      jobPersistence.createAttempt(scope2Job2, LOG_PATH);
+      final Attempt scope2Job2attempt = jobPersistence.getJob(scope2Job2).getAttempts().stream().findFirst()
+          .orElseThrow();
+
+      final List<Optional<Job>> actual = jobPersistence.getLastSyncJobsForConnections(CONNECTION_IDS);
+      final List<Optional<Job>> expected = new ArrayList<>();
+      expected.add(Optional.of(createJob(scope1Job2, SYNC_JOB_CONFIG, JobStatus.FAILED, List.of(scope1Job2attempt),
+          afterNow.getEpochSecond(), SCOPE_1)));
+      expected.add(Optional.of(createJob(scope2Job2, SYNC_JOB_CONFIG, JobStatus.RUNNING, List.of(scope2Job2attempt),
+          afterNow.getEpochSecond(), SCOPE_2)));
+      expected.add(Optional.of(
+          createJob(scope3Job1, SYNC_JOB_CONFIG, JobStatus.PENDING, Collections.emptyList(), NOW.getEpochSecond(),
+              SCOPE_3)));
+
+      assertTrue(expected.size() == actual.size() && expected.containsAll(actual) && actual.containsAll(expected));
+    }
+
+    @Test
+    @DisplayName("Should return nothing if only reset job exists")
+    void testGetLastSyncJobsForConnectionsEmptyBecauseOnlyReset() throws IOException {
+      final long jobId = jobPersistence.enqueueJob(SCOPE_1, RESET_JOB_CONFIG).orElseThrow();
+      jobPersistence.succeedAttempt(jobId, jobPersistence.createAttempt(jobId, LOG_PATH));
+
+      final Instant afterNow = NOW.plusSeconds(1000);
+      when(timeSupplier.get()).thenReturn(afterNow);
+
+      final List<Optional<Job>> actual = jobPersistence.getLastSyncJobsForConnections(CONNECTION_IDS);
+
+      assertTrue(actual.isEmpty());
+    }
+
+  }
+
+  @Nested
+  @DisplayName("When getting the last running sync job for multiple connections")
+  class GetRunningSyncJobsForConnections {
+
+    private static final UUID CONNECTION_ID_1 = UUID.randomUUID();
+    private static final UUID CONNECTION_ID_2 = UUID.randomUUID();
+    private static final UUID CONNECTION_ID_3 = UUID.randomUUID();
+    private static final String SCOPE_1 = CONNECTION_ID_1.toString();
+    private static final String SCOPE_2 = CONNECTION_ID_2.toString();
+    private static final String SCOPE_3 = CONNECTION_ID_3.toString();
+    private static final List<UUID> CONNECTION_IDS = List.of(CONNECTION_ID_1, CONNECTION_ID_2, CONNECTION_ID_3);
+
+    @Test
+    @DisplayName("Should return nothing if no sync job exists")
+    void testGetRunningSyncJobsForConnectionsEmpty() throws IOException {
+      final List<Optional<Job>> actual = jobPersistence.getRunningSyncJobForConnections(CONNECTION_IDS);
+
+      assertTrue(actual.isEmpty());
+    }
+
+    @Test
+    @DisplayName("Should return the last running sync job for each connection")
+    void testGetRunningSyncJobsForConnections() throws IOException {
+      // succeeded jobs should not be present in the result
+      final long scope1Job1 = jobPersistence.enqueueJob(SCOPE_1, SYNC_JOB_CONFIG).orElseThrow();
+      jobPersistence.succeedAttempt(scope1Job1, jobPersistence.createAttempt(scope1Job1, LOG_PATH));
+
+      // fail scope2's first job, but later start a running job that should show up in the result
+      final long scope2Job1 = jobPersistence.enqueueJob(SCOPE_2, SYNC_JOB_CONFIG).orElseThrow();
+      final int scope2Job1AttemptNumber = jobPersistence.createAttempt(scope2Job1, LOG_PATH);
+      jobPersistence.failAttempt(scope2Job1, scope2Job1AttemptNumber);
+      jobPersistence.failJob(scope2Job1);
+
+      // pending jobs should be present in the result
+      final long scope3Job1 = jobPersistence.enqueueJob(SCOPE_3, SYNC_JOB_CONFIG).orElseThrow();
+
+      final Instant afterNow = NOW.plusSeconds(1000);
+      when(timeSupplier.get()).thenReturn(afterNow);
+
+      // create a running job/attempt for scope2
+      final long scope2Job2 = jobPersistence.enqueueJob(SCOPE_2, SYNC_JOB_CONFIG).orElseThrow();
+      jobPersistence.createAttempt(scope2Job2, LOG_PATH);
+      final Attempt scope2Job2attempt = jobPersistence.getJob(scope2Job2).getAttempts().stream().findFirst()
+          .orElseThrow();
+
+      final List<Optional<Job>> expected = new ArrayList<>();
+      expected.add(Optional.of(createJob(scope2Job2, SYNC_JOB_CONFIG, JobStatus.RUNNING, List.of(scope2Job2attempt),
+          afterNow.getEpochSecond(), SCOPE_2)));
+      expected.add(Optional.of(createJob(scope3Job1, SYNC_JOB_CONFIG, JobStatus.PENDING, Collections.emptyList(),
+          NOW.getEpochSecond(), SCOPE_3)));
+
+      final List<Optional<Job>> actual = jobPersistence.getRunningSyncJobForConnections(CONNECTION_IDS);
+      assertTrue(expected.size() == actual.size() && expected.containsAll(actual) && actual.containsAll(expected));
+    }
+
+    @Test
+    @DisplayName("Should return nothing if only a running reset job exists")
+    void testGetRunningSyncJobsForConnectionsEmptyBecauseOnlyReset() throws IOException {
+      final long jobId = jobPersistence.enqueueJob(SCOPE_1, RESET_JOB_CONFIG).orElseThrow();
+      jobPersistence.createAttempt(jobId, LOG_PATH);
+
+      final Instant afterNow = NOW.plusSeconds(1000);
+      when(timeSupplier.get()).thenReturn(afterNow);
+
+      final List<Optional<Job>> actual = jobPersistence.getRunningSyncJobForConnections(CONNECTION_IDS);
 
       assertTrue(actual.isEmpty());
     }
@@ -995,7 +1183,8 @@ class DefaultJobPersistenceTest {
     void testGetFirstSyncJobForConnectionId() throws IOException {
       final long jobId1 = jobPersistence.enqueueJob(SCOPE, SYNC_JOB_CONFIG).orElseThrow();
       jobPersistence.succeedAttempt(jobId1, jobPersistence.createAttempt(jobId1, LOG_PATH));
-      final List<AttemptWithJobInfo> attemptsWithJobInfo = jobPersistence.listAttemptsWithJobInfo(SYNC_JOB_CONFIG.getConfigType(), Instant.EPOCH);
+      final List<AttemptWithJobInfo> attemptsWithJobInfo = jobPersistence.listAttemptsWithJobInfo(
+          SYNC_JOB_CONFIG.getConfigType(), Instant.EPOCH);
       final List<Attempt> attempts = Collections.singletonList(attemptsWithJobInfo.get(0).getAttempt());
 
       final Instant afterNow = NOW.plusSeconds(1000);
@@ -1022,7 +1211,8 @@ class DefaultJobPersistenceTest {
 
       final Optional<Job> actual = jobPersistence.getNextJob();
 
-      final Job expected = createJob(jobId, SPEC_JOB_CONFIG, JobStatus.PENDING, Collections.emptyList(), NOW.getEpochSecond());
+      final Job expected = createJob(jobId, SPEC_JOB_CONFIG, JobStatus.PENDING, Collections.emptyList(),
+          NOW.getEpochSecond());
       assertEquals(Optional.of(expected), actual);
     }
 
@@ -1072,7 +1262,8 @@ class DefaultJobPersistenceTest {
 
       final Optional<Job> actual = jobPersistence.getNextJob();
 
-      final Job expected = createJob(jobId2, SPEC_JOB_CONFIG, JobStatus.PENDING, Collections.emptyList(), NOW.getEpochSecond());
+      final Job expected = createJob(jobId2, SPEC_JOB_CONFIG, JobStatus.PENDING, Collections.emptyList(),
+          NOW.getEpochSecond());
       assertEquals(Optional.of(expected), actual);
     }
 
@@ -1088,7 +1279,8 @@ class DefaultJobPersistenceTest {
 
       final Optional<Job> actual = jobPersistence.getNextJob();
 
-      final Job expected = createJob(jobId2, SPEC_JOB_CONFIG, JobStatus.PENDING, Collections.emptyList(), NOW.getEpochSecond());
+      final Job expected = createJob(jobId2, SPEC_JOB_CONFIG, JobStatus.PENDING, Collections.emptyList(),
+          NOW.getEpochSecond());
       assertEquals(Optional.of(expected), actual);
     }
 
@@ -1105,7 +1297,8 @@ class DefaultJobPersistenceTest {
 
       final Optional<Job> actual = jobPersistence.getNextJob();
 
-      final Job expected = createJob(jobId2, SPEC_JOB_CONFIG, JobStatus.PENDING, Collections.emptyList(), NOW.getEpochSecond());
+      final Job expected = createJob(jobId2, SPEC_JOB_CONFIG, JobStatus.PENDING, Collections.emptyList(),
+          NOW.getEpochSecond());
       assertEquals(Optional.of(expected), actual);
     }
 
@@ -1156,7 +1349,8 @@ class DefaultJobPersistenceTest {
         jobPersistence.enqueueJob(CONNECTION_ID.toString(), SPEC_JOB_CONFIG);
       }
 
-      final Long actualJobCount = jobPersistence.getJobCount(Set.of(SPEC_JOB_CONFIG.getConfigType()), CONNECTION_ID.toString());
+      final Long actualJobCount = jobPersistence.getJobCount(Set.of(SPEC_JOB_CONFIG.getConfigType()),
+          CONNECTION_ID.toString());
 
       assertEquals(numJobsToCreate, actualJobCount);
     }
@@ -1170,7 +1364,8 @@ class DefaultJobPersistenceTest {
       jobPersistence.enqueueJob(otherConnectionId1.toString(), SPEC_JOB_CONFIG);
       jobPersistence.enqueueJob(otherConnectionId2.toString(), SPEC_JOB_CONFIG);
 
-      final Long actualJobCount = jobPersistence.getJobCount(Set.of(SPEC_JOB_CONFIG.getConfigType()), CONNECTION_ID.toString());
+      final Long actualJobCount = jobPersistence.getJobCount(Set.of(SPEC_JOB_CONFIG.getConfigType()),
+          CONNECTION_ID.toString());
 
       assertEquals(0, actualJobCount);
     }
@@ -1201,7 +1396,8 @@ class DefaultJobPersistenceTest {
       final int pagesize = 10;
       final int offset = 3;
 
-      final List<Job> actualList = jobPersistence.listJobs(SPEC_JOB_CONFIG.getConfigType(), CONNECTION_ID.toString(), pagesize, offset);
+      final List<Job> actualList = jobPersistence.listJobs(SPEC_JOB_CONFIG.getConfigType(), CONNECTION_ID.toString(),
+          pagesize, offset);
       assertEquals(pagesize, actualList.size());
       assertEquals(ids.get(ids.size() - 1 - offset), actualList.get(0).getId());
     }
@@ -1218,9 +1414,11 @@ class DefaultJobPersistenceTest {
       }
       final int pagesize = 200;
       final int offset = 0;
-      final List<Job> actualList = jobPersistence.listJobs(SPEC_JOB_CONFIG.getConfigType(), CONNECTION_ID.toString(), pagesize, offset);
+      final List<Job> actualList = jobPersistence.listJobs(SPEC_JOB_CONFIG.getConfigType(), CONNECTION_ID.toString(),
+          pagesize, offset);
       for (int i = 0; i < 100; i++) {
-        assertEquals(ids.get(ids.size() - (i + 1)), actualList.get(i).getId(), "Job ids should have been in order but weren't.");
+        assertEquals(ids.get(ids.size() - (i + 1)), actualList.get(i).getId(),
+            "Job ids should have been in order but weren't.");
       }
     }
 
@@ -1229,10 +1427,12 @@ class DefaultJobPersistenceTest {
     void testListJobs() throws IOException {
       final long jobId = jobPersistence.enqueueJob(SCOPE, SPEC_JOB_CONFIG).orElseThrow();
 
-      final List<Job> actualList = jobPersistence.listJobs(SPEC_JOB_CONFIG.getConfigType(), CONNECTION_ID.toString(), 9999, 0);
+      final List<Job> actualList = jobPersistence.listJobs(SPEC_JOB_CONFIG.getConfigType(), CONNECTION_ID.toString(),
+          9999, 0);
 
       final Job actual = actualList.get(0);
-      final Job expected = createJob(jobId, SPEC_JOB_CONFIG, JobStatus.PENDING, Collections.emptyList(), NOW.getEpochSecond());
+      final Job expected = createJob(jobId, SPEC_JOB_CONFIG, JobStatus.PENDING, Collections.emptyList(),
+          NOW.getEpochSecond());
 
       assertEquals(1, actualList.size());
       assertEquals(expected, actual);
@@ -1248,10 +1448,12 @@ class DefaultJobPersistenceTest {
       jobPersistence.enqueueJob(SCOPE, SYNC_JOB_CONFIG).orElseThrow();
 
       final List<Job> actualList =
-          jobPersistence.listJobs(Set.of(SPEC_JOB_CONFIG.getConfigType(), CHECK_JOB_CONFIG.getConfigType()), CONNECTION_ID.toString(), 9999, 0);
+          jobPersistence.listJobs(Set.of(SPEC_JOB_CONFIG.getConfigType(), CHECK_JOB_CONFIG.getConfigType()),
+              CONNECTION_ID.toString(), 9999, 0);
 
       final List<Job> expectedList =
-          List.of(createJob(checkJobId, CHECK_JOB_CONFIG, JobStatus.PENDING, Collections.emptyList(), NOW.getEpochSecond()),
+          List.of(
+              createJob(checkJobId, CHECK_JOB_CONFIG, JobStatus.PENDING, Collections.emptyList(), NOW.getEpochSecond()),
               createJob(specJobId, SPEC_JOB_CONFIG, JobStatus.PENDING, Collections.emptyList(), NOW.getEpochSecond()));
 
       assertEquals(expectedList, actualList);
@@ -1270,7 +1472,8 @@ class DefaultJobPersistenceTest {
 
       jobPersistence.succeedAttempt(jobId, attemptNumber1);
 
-      final List<Job> actualList = jobPersistence.listJobs(SPEC_JOB_CONFIG.getConfigType(), CONNECTION_ID.toString(), 9999, 0);
+      final List<Job> actualList = jobPersistence.listJobs(SPEC_JOB_CONFIG.getConfigType(), CONNECTION_ID.toString(),
+          9999, 0);
 
       final Job actual = actualList.get(0);
       final Job expected = createJob(
@@ -1305,7 +1508,8 @@ class DefaultJobPersistenceTest {
       final var job2Attempt1 = jobPersistence.createAttempt(jobId2, job2Attempt1LogPath);
       jobPersistence.succeedAttempt(jobId2, job2Attempt1);
 
-      final List<Job> actualList = jobPersistence.listJobs(SPEC_JOB_CONFIG.getConfigType(), CONNECTION_ID.toString(), 9999, 0);
+      final List<Job> actualList = jobPersistence.listJobs(SPEC_JOB_CONFIG.getConfigType(), CONNECTION_ID.toString(),
+          9999, 0);
 
       assertEquals(2, actualList.size());
       assertEquals(jobId2, actualList.get(0).getId());
@@ -1329,7 +1533,8 @@ class DefaultJobPersistenceTest {
 
       final int includingIdIndex = 90;
       final int pageSize = 25;
-      final List<Job> actualList = jobPersistence.listJobsIncludingId(Set.of(SPEC_JOB_CONFIG.getConfigType(), CHECK_JOB_CONFIG.getConfigType()),
+      final List<Job> actualList = jobPersistence.listJobsIncludingId(
+          Set.of(SPEC_JOB_CONFIG.getConfigType(), CHECK_JOB_CONFIG.getConfigType()),
           CONNECTION_ID.toString(), ids.get(includingIdIndex), pageSize);
       final List<Long> expectedJobIds = Lists.reverse(ids.subList(ids.size() - pageSize, ids.size()));
       assertEquals(expectedJobIds, actualList.stream().map(Job::getId).toList());
@@ -1354,7 +1559,8 @@ class DefaultJobPersistenceTest {
       // including id is on the second page, so response should contain two pages of jobs
       final int includingIdIndex = 60;
       final int pageSize = 25;
-      final List<Job> actualList = jobPersistence.listJobsIncludingId(Set.of(SPEC_JOB_CONFIG.getConfigType(), CHECK_JOB_CONFIG.getConfigType()),
+      final List<Job> actualList = jobPersistence.listJobsIncludingId(
+          Set.of(SPEC_JOB_CONFIG.getConfigType(), CHECK_JOB_CONFIG.getConfigType()),
           CONNECTION_ID.toString(), ids.get(includingIdIndex), pageSize);
       final List<Long> expectedJobIds = Lists.reverse(ids.subList(ids.size() - (pageSize * 2), ids.size()));
       assertEquals(expectedJobIds, actualList.stream().map(Job::getId).toList());
@@ -1367,10 +1573,12 @@ class DefaultJobPersistenceTest {
         jobPersistence.enqueueJob(CONNECTION_ID.toString(), SPEC_JOB_CONFIG);
       }
 
-      final long otherConnectionJobId = jobPersistence.enqueueJob(UUID.randomUUID().toString(), SPEC_JOB_CONFIG).orElseThrow();
+      final long otherConnectionJobId = jobPersistence.enqueueJob(UUID.randomUUID().toString(), SPEC_JOB_CONFIG)
+          .orElseThrow();
 
       final List<Job> actualList =
-          jobPersistence.listJobsIncludingId(Set.of(SPEC_JOB_CONFIG.getConfigType()), CONNECTION_ID.toString(), otherConnectionJobId, 25);
+          jobPersistence.listJobsIncludingId(Set.of(SPEC_JOB_CONFIG.getConfigType()), CONNECTION_ID.toString(),
+              otherConnectionJobId, 25);
       assertEquals(List.of(), actualList);
     }
 
@@ -1421,15 +1629,20 @@ class DefaultJobPersistenceTest {
       final List<Job> allPendingJobs = jobPersistence.listJobsWithStatus(JobStatus.PENDING);
 
       final Job expectedPendingSpecJob =
-          createJob(pendingSpecJobId, SPEC_JOB_CONFIG, JobStatus.PENDING, Lists.newArrayList(), NOW.getEpochSecond(), SPEC_SCOPE);
+          createJob(pendingSpecJobId, SPEC_JOB_CONFIG, JobStatus.PENDING, Lists.newArrayList(), NOW.getEpochSecond(),
+              SPEC_SCOPE);
       final Job expectedPendingCheckJob =
-          createJob(pendingCheckJobId, CHECK_JOB_CONFIG, JobStatus.PENDING, Lists.newArrayList(), NOW.getEpochSecond(), CHECK_SCOPE);
+          createJob(pendingCheckJobId, CHECK_JOB_CONFIG, JobStatus.PENDING, Lists.newArrayList(), NOW.getEpochSecond(),
+              CHECK_SCOPE);
       final Job expectedPendingSyncJob =
-          createJob(pendingSyncJobId, SYNC_JOB_CONFIG, JobStatus.PENDING, Lists.newArrayList(), NOW.getEpochSecond(), SYNC_SCOPE);
+          createJob(pendingSyncJobId, SYNC_JOB_CONFIG, JobStatus.PENDING, Lists.newArrayList(), NOW.getEpochSecond(),
+              SYNC_SCOPE);
 
-      final List<Job> allPendingSyncAndSpecJobs = jobPersistence.listJobsWithStatus(Set.of(ConfigType.GET_SPEC, ConfigType.SYNC), JobStatus.PENDING);
+      final List<Job> allPendingSyncAndSpecJobs = jobPersistence.listJobsWithStatus(
+          Set.of(ConfigType.GET_SPEC, ConfigType.SYNC), JobStatus.PENDING);
 
-      final List<Job> incompleteJobs = jobPersistence.listJobsWithStatus(SPEC_JOB_CONFIG.getConfigType(), JobStatus.INCOMPLETE);
+      final List<Job> incompleteJobs = jobPersistence.listJobsWithStatus(SPEC_JOB_CONFIG.getConfigType(),
+          JobStatus.INCOMPLETE);
       final Job actualIncompleteJob = incompleteJobs.get(0);
       final Job expectedIncompleteJob = createJob(
           failedSpecJobId,
@@ -1440,8 +1653,10 @@ class DefaultJobPersistenceTest {
           NOW.getEpochSecond(),
           SPEC_SCOPE);
 
-      assertEquals(Sets.newHashSet(expectedPendingCheckJob, expectedPendingSpecJob, expectedPendingSyncJob), Sets.newHashSet(allPendingJobs));
-      assertEquals(Sets.newHashSet(expectedPendingSpecJob, expectedPendingSyncJob), Sets.newHashSet(allPendingSyncAndSpecJobs));
+      assertEquals(Sets.newHashSet(expectedPendingCheckJob, expectedPendingSpecJob, expectedPendingSyncJob),
+          Sets.newHashSet(allPendingJobs));
+      assertEquals(Sets.newHashSet(expectedPendingSpecJob, expectedPendingSyncJob),
+          Sets.newHashSet(allPendingSyncAndSpecJobs));
 
       assertEquals(1, incompleteJobs.size());
       assertEquals(expectedIncompleteJob, actualIncompleteJob);
@@ -1454,36 +1669,45 @@ class DefaultJobPersistenceTest {
       final UUID otherConnectionId = UUID.randomUUID();
 
       // desired connection, statuses, and config types
-      final long desiredJobId1 = jobPersistence.enqueueJob(desiredConnectionId.toString(), SYNC_JOB_CONFIG).orElseThrow();
+      final long desiredJobId1 = jobPersistence.enqueueJob(desiredConnectionId.toString(), SYNC_JOB_CONFIG)
+          .orElseThrow();
       jobPersistence.succeedAttempt(desiredJobId1, jobPersistence.createAttempt(desiredJobId1, LOG_PATH));
-      final long desiredJobId2 = jobPersistence.enqueueJob(desiredConnectionId.toString(), SYNC_JOB_CONFIG).orElseThrow();
-      final long desiredJobId3 = jobPersistence.enqueueJob(desiredConnectionId.toString(), CHECK_JOB_CONFIG).orElseThrow();
+      final long desiredJobId2 = jobPersistence.enqueueJob(desiredConnectionId.toString(), SYNC_JOB_CONFIG)
+          .orElseThrow();
+      final long desiredJobId3 = jobPersistence.enqueueJob(desiredConnectionId.toString(), CHECK_JOB_CONFIG)
+          .orElseThrow();
       jobPersistence.succeedAttempt(desiredJobId3, jobPersistence.createAttempt(desiredJobId3, LOG_PATH));
-      final long desiredJobId4 = jobPersistence.enqueueJob(desiredConnectionId.toString(), CHECK_JOB_CONFIG).orElseThrow();
+      final long desiredJobId4 = jobPersistence.enqueueJob(desiredConnectionId.toString(), CHECK_JOB_CONFIG)
+          .orElseThrow();
 
       // right connection id and status, wrong config type
       jobPersistence.enqueueJob(desiredConnectionId.toString(), SPEC_JOB_CONFIG).orElseThrow();
       // right config type and status, wrong connection id
       jobPersistence.enqueueJob(otherConnectionId.toString(), SYNC_JOB_CONFIG).orElseThrow();
       // right connection id and config type, wrong status
-      final long otherJobId3 = jobPersistence.enqueueJob(desiredConnectionId.toString(), CHECK_JOB_CONFIG).orElseThrow();
+      final long otherJobId3 = jobPersistence.enqueueJob(desiredConnectionId.toString(), CHECK_JOB_CONFIG)
+          .orElseThrow();
       jobPersistence.failAttempt(otherJobId3, jobPersistence.createAttempt(otherJobId3, LOG_PATH));
 
       final List<Job> actualJobs = jobPersistence.listJobsForConnectionWithStatuses(desiredConnectionId,
-          Set.of(ConfigType.SYNC, ConfigType.CHECK_CONNECTION_DESTINATION), Set.of(JobStatus.PENDING, JobStatus.SUCCEEDED));
+          Set.of(ConfigType.SYNC, ConfigType.CHECK_CONNECTION_DESTINATION),
+          Set.of(JobStatus.PENDING, JobStatus.SUCCEEDED));
 
       final Job expectedDesiredJob1 = createJob(desiredJobId1, SYNC_JOB_CONFIG, JobStatus.SUCCEEDED,
           Lists.newArrayList(createAttempt(0L, desiredJobId1, AttemptStatus.SUCCEEDED, LOG_PATH)),
           NOW.getEpochSecond(), desiredConnectionId.toString());
       final Job expectedDesiredJob2 =
-          createJob(desiredJobId2, SYNC_JOB_CONFIG, JobStatus.PENDING, Lists.newArrayList(), NOW.getEpochSecond(), desiredConnectionId.toString());
+          createJob(desiredJobId2, SYNC_JOB_CONFIG, JobStatus.PENDING, Lists.newArrayList(), NOW.getEpochSecond(),
+              desiredConnectionId.toString());
       final Job expectedDesiredJob3 = createJob(desiredJobId3, CHECK_JOB_CONFIG, JobStatus.SUCCEEDED,
           Lists.newArrayList(createAttempt(0L, desiredJobId3, AttemptStatus.SUCCEEDED, LOG_PATH)),
           NOW.getEpochSecond(), desiredConnectionId.toString());
       final Job expectedDesiredJob4 =
-          createJob(desiredJobId4, CHECK_JOB_CONFIG, JobStatus.PENDING, Lists.newArrayList(), NOW.getEpochSecond(), desiredConnectionId.toString());
+          createJob(desiredJobId4, CHECK_JOB_CONFIG, JobStatus.PENDING, Lists.newArrayList(), NOW.getEpochSecond(),
+              desiredConnectionId.toString());
 
-      assertEquals(Sets.newHashSet(expectedDesiredJob1, expectedDesiredJob2, expectedDesiredJob3, expectedDesiredJob4), Sets.newHashSet(actualJobs));
+      assertEquals(Sets.newHashSet(expectedDesiredJob1, expectedDesiredJob2, expectedDesiredJob3, expectedDesiredJob4),
+          Sets.newHashSet(actualJobs));
     }
 
   }
@@ -1526,7 +1750,10 @@ class DefaultJobPersistenceTest {
   @DisplayName("When purging job history")
   class PurgeJobHistory {
 
-    private Job persistJobForJobHistoryTesting(final String scope, final JobConfig jobConfig, final JobStatus status, final LocalDateTime runDate)
+    private Job persistJobForJobHistoryTesting(final String scope,
+                                               final JobConfig jobConfig,
+                                               final JobStatus status,
+                                               final LocalDateTime runDate)
         throws IOException, SQLException {
       final Optional<Long> id = jobDatabase.query(
           ctx -> ctx.fetch(
@@ -1545,7 +1772,10 @@ class DefaultJobPersistenceTest {
       return jobPersistence.getJob(id.get());
     }
 
-    private void persistAttemptForJobHistoryTesting(final Job job, final String logPath, final LocalDateTime runDate, final boolean shouldHaveState)
+    private void persistAttemptForJobHistoryTesting(final Job job,
+                                                    final String logPath,
+                                                    final LocalDateTime runDate,
+                                                    final boolean shouldHaveState)
         throws IOException, SQLException {
       final String attemptOutputWithState = "{\n"
           + "  \"sync\": {\n"
@@ -1578,11 +1808,11 @@ class DefaultJobPersistenceTest {
      * controlling deletion logic. Thus, the test case injects overrides for those constants, testing a
      * comprehensive set of combinations to make sure that the logic is robust to reasonable
      * configurations. Extreme configurations such as zero-day retention period are not covered.
-     *
+     * <p>
      * Business rules for deletions. 1. Job must be older than X days or its conn has excessive number
      * of jobs 2. Job cannot be one of the last N jobs on that conn (last N jobs are always kept). 3.
      * Job cannot be holding the most recent saved state (most recent saved state is always kept).
-     *
+     * <p>
      * Testing Goal: Set up jobs according to the parameters passed in. Then delete according to the
      * rules, and make sure the right number of jobs are left. Against one connection/scope,
      * <ol>
@@ -1611,7 +1841,6 @@ class DefaultJobPersistenceTest {
      *        parameters. This was calculated by a human based on understanding the requirements.
      * @param goalOfTestScenario Description of the purpose of that test scenario, so it's easier to
      *        maintain and understand failures.
-     *
      */
     @DisplayName("Should purge older job history but maintain certain more recent ones")
     @ParameterizedTest
@@ -1654,8 +1883,10 @@ class DefaultJobPersistenceTest {
       final List<Job> allJobs = new ArrayList<>();
       final List<Job> decoyJobs = new ArrayList<>();
       for (int i = 0; i < numJobs; i++) {
-        allJobs.add(persistJobForJobHistoryTesting(CURRENT_SCOPE, SYNC_JOB_CONFIG, JobStatus.FAILED, fakeNow.minusDays(i)));
-        decoyJobs.add(persistJobForJobHistoryTesting(DECOY_SCOPE, SYNC_JOB_CONFIG, JobStatus.FAILED, fakeNow.minusDays(i)));
+        allJobs.add(
+            persistJobForJobHistoryTesting(CURRENT_SCOPE, SYNC_JOB_CONFIG, JobStatus.FAILED, fakeNow.minusDays(i)));
+        decoyJobs.add(
+            persistJobForJobHistoryTesting(DECOY_SCOPE, SYNC_JOB_CONFIG, JobStatus.FAILED, fakeNow.minusDays(i)));
       }
 
       // At least one job should have state. Find the desired job and add state to it.
@@ -1675,15 +1906,18 @@ class DefaultJobPersistenceTest {
       final List<Job> afterPurge = jobPersistence.listJobs(ConfigType.SYNC, CURRENT_SCOPE, 9999, 0);
 
       // Test - contains expected number of jobs and no more than that
-      assertEquals(expectedAfterPurge, afterPurge.size(), goalOfTestScenario + " - Incorrect number of jobs remain after deletion.");
+      assertEquals(expectedAfterPurge, afterPurge.size(),
+          goalOfTestScenario + " - Incorrect number of jobs remain after deletion.");
 
       // Test - most-recent are actually the most recent by date (see above, reverse order)
       for (int i = 0; i < Math.min(ageCutoff, recencyCutoff); i++) {
-        assertEquals(allJobs.get(i).getId(), afterPurge.get(i).getId(), goalOfTestScenario + " - Incorrect sort order after deletion.");
+        assertEquals(allJobs.get(i).getId(), afterPurge.get(i).getId(),
+            goalOfTestScenario + " - Incorrect sort order after deletion.");
       }
 
       // Test - job with latest state is always kept despite being older than some cutoffs
-      assertTrue(afterPurge.contains(lastJobWithState), goalOfTestScenario + " - Missing last job with saved state after deletion.");
+      assertTrue(afterPurge.contains(lastJobWithState),
+          goalOfTestScenario + " - Missing last job with saved state after deletion.");
     }
 
     private Job addStateToJob(final Job job) throws IOException, SQLException {
@@ -1701,15 +1935,19 @@ class DefaultJobPersistenceTest {
     @Test
     @DisplayName("Should list only job statuses and timestamps of specified connection id")
     void testConnectionIdFiltering() throws IOException {
-      jobPersistence = new DefaultJobPersistence(jobDatabase, timeSupplier, DEFAULT_MINIMUM_AGE_IN_DAYS, DEFAULT_EXCESSIVE_NUMBER_OF_JOBS,
+      jobPersistence = new DefaultJobPersistence(jobDatabase, timeSupplier, DEFAULT_MINIMUM_AGE_IN_DAYS,
+          DEFAULT_EXCESSIVE_NUMBER_OF_JOBS,
           DEFAULT_MINIMUM_RECENCY_COUNT);
 
       // create a connection with a non-relevant connection id that should be ignored for the duration of
       // the test
-      final long wrongConnectionSyncJobId = jobPersistence.enqueueJob(UUID.randomUUID().toString(), SYNC_JOB_CONFIG).orElseThrow();
+      final long wrongConnectionSyncJobId = jobPersistence.enqueueJob(UUID.randomUUID().toString(), SYNC_JOB_CONFIG)
+          .orElseThrow();
       final int wrongSyncJobAttemptNumber0 = jobPersistence.createAttempt(wrongConnectionSyncJobId, LOG_PATH);
       jobPersistence.failAttempt(wrongConnectionSyncJobId, wrongSyncJobAttemptNumber0);
-      assertEquals(0, jobPersistence.listJobStatusAndTimestampWithConnection(CONNECTION_ID, Sets.newHashSet(ConfigType.SYNC), Instant.EPOCH).size());
+      assertEquals(0,
+          jobPersistence.listJobStatusAndTimestampWithConnection(CONNECTION_ID, Sets.newHashSet(ConfigType.SYNC),
+              Instant.EPOCH).size());
 
       // create a connection with relevant connection id
       final long syncJobId = jobPersistence.enqueueJob(SCOPE, SYNC_JOB_CONFIG).orElseThrow();
@@ -1718,7 +1956,8 @@ class DefaultJobPersistenceTest {
 
       // check to see current status of only relevantly scoped job
       final List<JobWithStatusAndTimestamp> jobs =
-          jobPersistence.listJobStatusAndTimestampWithConnection(CONNECTION_ID, Sets.newHashSet(ConfigType.SYNC), Instant.EPOCH);
+          jobPersistence.listJobStatusAndTimestampWithConnection(CONNECTION_ID, Sets.newHashSet(ConfigType.SYNC),
+              Instant.EPOCH);
       assertEquals(jobs.size(), 1);
       assertEquals(JobStatus.INCOMPLETE, jobs.get(0).getStatus());
     }
@@ -1726,7 +1965,8 @@ class DefaultJobPersistenceTest {
     @Test
     @DisplayName("Should list jobs statuses filtered by different timestamps")
     void testTimestampFiltering() throws IOException {
-      jobPersistence = new DefaultJobPersistence(jobDatabase, timeSupplier, DEFAULT_MINIMUM_AGE_IN_DAYS, DEFAULT_EXCESSIVE_NUMBER_OF_JOBS,
+      jobPersistence = new DefaultJobPersistence(jobDatabase, timeSupplier, DEFAULT_MINIMUM_AGE_IN_DAYS,
+          DEFAULT_EXCESSIVE_NUMBER_OF_JOBS,
           DEFAULT_MINIMUM_RECENCY_COUNT);
 
       // Create and fail initial job
@@ -1737,7 +1977,8 @@ class DefaultJobPersistenceTest {
 
       // Check to see current status of all jobs from beginning of time, expecting only 1 job
       final List<JobWithStatusAndTimestamp> initialJobs =
-          jobPersistence.listJobStatusAndTimestampWithConnection(CONNECTION_ID, Sets.newHashSet(ConfigType.SYNC), Instant.EPOCH);
+          jobPersistence.listJobStatusAndTimestampWithConnection(CONNECTION_ID, Sets.newHashSet(ConfigType.SYNC),
+              Instant.EPOCH);
       assertEquals(initialJobs.size(), 1);
       assertEquals(JobStatus.FAILED, initialJobs.get(0).getStatus());
 
@@ -1753,14 +1994,16 @@ class DefaultJobPersistenceTest {
       // Check to see current status of all jobs from beginning of time, expecting both jobs in createAt
       // descending order (most recent first)
       final List<JobWithStatusAndTimestamp> allQueryJobs =
-          jobPersistence.listJobStatusAndTimestampWithConnection(CONNECTION_ID, Sets.newHashSet(ConfigType.SYNC), Instant.EPOCH);
+          jobPersistence.listJobStatusAndTimestampWithConnection(CONNECTION_ID, Sets.newHashSet(ConfigType.SYNC),
+              Instant.EPOCH);
       assertEquals(2, allQueryJobs.size());
       assertEquals(JobStatus.SUCCEEDED, allQueryJobs.get(0).getStatus());
       assertEquals(JobStatus.FAILED, allQueryJobs.get(1).getStatus());
 
       // Look up jobs with a timestamp after the first job. Expecting only the second job status
       final List<JobWithStatusAndTimestamp> timestampFilteredJobs =
-          jobPersistence.listJobStatusAndTimestampWithConnection(CONNECTION_ID, Sets.newHashSet(ConfigType.SYNC), timeAfterFirstJob);
+          jobPersistence.listJobStatusAndTimestampWithConnection(CONNECTION_ID, Sets.newHashSet(ConfigType.SYNC),
+              timeAfterFirstJob);
       assertEquals(1, timestampFilteredJobs.size());
       assertEquals(JobStatus.SUCCEEDED, timestampFilteredJobs.get(0).getStatus());
       // TODO: issues will be fixed in scope of https://github.com/airbytehq/airbyte/issues/13192
@@ -1773,14 +2016,16 @@ class DefaultJobPersistenceTest {
       // second job. Expecting no job status output
       final Instant timeAfterSecondJob = timeAfterFirstJob.plusSeconds(60);
       assertEquals(0,
-          jobPersistence.listJobStatusAndTimestampWithConnection(CONNECTION_ID, Sets.newHashSet(ConfigType.SYNC), timeAfterSecondJob).size());
+          jobPersistence.listJobStatusAndTimestampWithConnection(CONNECTION_ID, Sets.newHashSet(ConfigType.SYNC),
+              timeAfterSecondJob).size());
     }
 
     @Test
     @DisplayName("Should list jobs statuses of differing status types")
     void testMultipleJobStatusTypes() throws IOException {
       final Supplier<Instant> timeSupplier = incrementingSecondSupplier(NOW);
-      jobPersistence = new DefaultJobPersistence(jobDatabase, timeSupplier, DEFAULT_MINIMUM_AGE_IN_DAYS, DEFAULT_EXCESSIVE_NUMBER_OF_JOBS,
+      jobPersistence = new DefaultJobPersistence(jobDatabase, timeSupplier, DEFAULT_MINIMUM_AGE_IN_DAYS,
+          DEFAULT_EXCESSIVE_NUMBER_OF_JOBS,
           DEFAULT_MINIMUM_RECENCY_COUNT);
 
       // Create and fail initial job
@@ -1802,7 +2047,8 @@ class DefaultJobPersistenceTest {
       // Check to see current status of all jobs from beginning of time, expecting all jobs in createAt
       // descending order (most recent first)
       final List<JobWithStatusAndTimestamp> allJobs =
-          jobPersistence.listJobStatusAndTimestampWithConnection(CONNECTION_ID, Sets.newHashSet(ConfigType.SYNC), Instant.EPOCH);
+          jobPersistence.listJobStatusAndTimestampWithConnection(CONNECTION_ID, Sets.newHashSet(ConfigType.SYNC),
+              Instant.EPOCH);
       assertEquals(3, allJobs.size());
       assertEquals(JobStatus.CANCELLED, allJobs.get(0).getStatus());
       assertEquals(JobStatus.SUCCEEDED, allJobs.get(1).getStatus());
@@ -1814,7 +2060,8 @@ class DefaultJobPersistenceTest {
     void testMultipleConfigTypes() throws IOException {
       final Set<ConfigType> configTypes = Sets.newHashSet(ConfigType.GET_SPEC, ConfigType.CHECK_CONNECTION_DESTINATION);
       final Supplier<Instant> timeSupplier = incrementingSecondSupplier(NOW);
-      jobPersistence = new DefaultJobPersistence(jobDatabase, timeSupplier, DEFAULT_MINIMUM_AGE_IN_DAYS, DEFAULT_EXCESSIVE_NUMBER_OF_JOBS,
+      jobPersistence = new DefaultJobPersistence(jobDatabase, timeSupplier, DEFAULT_MINIMUM_AGE_IN_DAYS,
+          DEFAULT_EXCESSIVE_NUMBER_OF_JOBS,
           DEFAULT_MINIMUM_RECENCY_COUNT);
 
       // pending status

--- a/airbyte-server/src/main/java/io/airbyte/server/handlers/JobHistoryHandler.java
+++ b/airbyte-server/src/main/java/io/airbyte/server/handlers/JobHistoryHandler.java
@@ -140,6 +140,18 @@ public class JobHistoryHandler {
     return jobPersistence.getLastSyncJob(connectionId).map(JobConverter::getJobRead);
   }
 
+  public List<Optional<JobRead>> getLatestSyncJobsForConnections(final List<UUID> connectionIds) throws IOException {
+    return jobPersistence.getLastSyncJobsForConnections(connectionIds).stream()
+        .map(j -> j.map(JobConverter::getJobRead))
+        .collect(Collectors.toList());
+  }
+
+  public List<Optional<JobRead>> getRunningSyncJobForConnections(final List<UUID> connectionIds) throws IOException {
+    return jobPersistence.getRunningSyncJobForConnections(connectionIds).stream()
+        .map(j -> j.map(JobConverter::getJobRead))
+        .collect(Collectors.toList());
+  }
+
   private SourceRead getSourceRead(final ConnectionRead connectionRead) throws JsonValidationException, IOException, ConfigNotFoundException {
     final SourceIdRequestBody sourceIdRequestBody = new SourceIdRequestBody().sourceId(connectionRead.getSourceId());
     return sourceHandler.getSource(sourceIdRequestBody);

--- a/airbyte-server/src/main/java/io/airbyte/server/handlers/JobHistoryHandler.java
+++ b/airbyte-server/src/main/java/io/airbyte/server/handlers/JobHistoryHandler.java
@@ -140,15 +140,15 @@ public class JobHistoryHandler {
     return jobPersistence.getLastSyncJob(connectionId).map(JobConverter::getJobRead);
   }
 
-  public List<Optional<JobRead>> getLatestSyncJobsForConnections(final List<UUID> connectionIds) throws IOException {
-    return jobPersistence.getLastSyncJobsForConnections(connectionIds).stream()
-        .map(j -> j.map(JobConverter::getJobRead))
+  public List<JobRead> getLatestSyncJobsForConnections(final List<UUID> connectionIds) throws IOException {
+    return jobPersistence.getLastSyncJobForConnections(connectionIds).stream()
+        .map(JobConverter::getJobRead)
         .collect(Collectors.toList());
   }
 
-  public List<Optional<JobRead>> getRunningSyncJobForConnections(final List<UUID> connectionIds) throws IOException {
+  public List<JobRead> getRunningSyncJobForConnections(final List<UUID> connectionIds) throws IOException {
     return jobPersistence.getRunningSyncJobForConnections(connectionIds).stream()
-        .map(j -> j.map(JobConverter::getJobRead))
+        .map(JobConverter::getJobRead)
         .collect(Collectors.toList());
   }
 

--- a/airbyte-server/src/main/java/io/airbyte/server/handlers/WebBackendConnectionsHandler.java
+++ b/airbyte-server/src/main/java/io/airbyte/server/handlers/WebBackendConnectionsHandler.java
@@ -130,18 +130,12 @@ public class WebBackendConnectionsHandler {
 
   private Map<UUID, JobRead> getLatestJobByConnectionId(final List<UUID> connectionIds) throws IOException {
     return jobHistoryHandler.getLatestSyncJobsForConnections(connectionIds).stream()
-        .filter(Optional::isPresent)
-        .collect(Collectors.toMap(
-            j -> UUID.fromString(j.get().getConfigId()),
-            Optional::get));
+        .collect(Collectors.toMap(j -> UUID.fromString(j.getConfigId()), Function.identity()));
   }
 
   private Map<UUID, JobRead> getRunningJobByConnectionId(final List<UUID> connectionIds) throws IOException {
     return jobHistoryHandler.getRunningSyncJobForConnections(connectionIds).stream()
-        .filter(Optional::isPresent)
-        .collect(Collectors.toMap(
-            j -> UUID.fromString(j.get().getConfigId()),
-            Optional::get));
+        .collect(Collectors.toMap(j -> UUID.fromString(j.getConfigId()), Function.identity()));
   }
 
   private Map<UUID, SourceRead> getSourceReadById(final List<UUID> sourceIds) throws IOException {

--- a/airbyte-server/src/main/java/io/airbyte/server/handlers/WebBackendConnectionsHandler.java
+++ b/airbyte-server/src/main/java/io/airbyte/server/handlers/WebBackendConnectionsHandler.java
@@ -43,6 +43,8 @@ import io.airbyte.api.model.generated.WorkspaceIdRequestBody;
 import io.airbyte.commons.enums.Enums;
 import io.airbyte.commons.json.Jsons;
 import io.airbyte.commons.lang.MoreBooleans;
+import io.airbyte.config.StandardDestinationDefinition;
+import io.airbyte.config.StandardSourceDefinition;
 import io.airbyte.config.StandardSync;
 import io.airbyte.config.persistence.ConfigNotFoundException;
 import io.airbyte.config.persistence.ConfigRepository;
@@ -61,6 +63,8 @@ import java.util.Map;
 import java.util.Optional;
 import java.util.Set;
 import java.util.UUID;
+import java.util.function.Function;
+import java.util.stream.Collectors;
 import lombok.AllArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 
@@ -98,14 +102,73 @@ public class WebBackendConnectionsHandler {
   public WebBackendConnectionReadList webBackendListConnectionsForWorkspace(final WorkspaceIdRequestBody workspaceIdRequestBody)
       throws ConfigNotFoundException, IOException, JsonValidationException {
 
+    // passing 'false' so that deleted connections are not included
+    final List<StandardSync> standardSyncs =
+        configRepository.listWorkspaceStandardSyncs(workspaceIdRequestBody.getWorkspaceId(), false);
+    final Map<UUID, SourceRead> sourceReadById =
+        getSourceReadById(standardSyncs.stream().map(StandardSync::getSourceId).toList());
+    final Map<UUID, DestinationRead> destinationReadById =
+        getDestinationReadById(standardSyncs.stream().map(StandardSync::getDestinationId).toList());
+    final Map<UUID, JobRead> latestJobByConnectionId =
+        getLatestJobByConnectionId(standardSyncs.stream().map(StandardSync::getConnectionId).toList());
+    final Map<UUID, JobRead> runningJobByConnectionId =
+        getRunningJobByConnectionId(standardSyncs.stream().map(StandardSync::getConnectionId).toList());
+
     final List<WebBackendConnectionListItem> connectionItems = Lists.newArrayList();
 
-    // passing 'false' so that deleted connections are not included
-    for (final StandardSync standardSync : configRepository.listWorkspaceStandardSyncs(workspaceIdRequestBody.getWorkspaceId(), false)) {
-      connectionItems.add(buildWebBackendConnectionListItem(standardSync));
+    for (final StandardSync standardSync : standardSyncs) {
+      connectionItems.add(
+          buildWebBackendConnectionListItem(standardSync, sourceReadById, destinationReadById, latestJobByConnectionId,
+              runningJobByConnectionId));
     }
 
     return new WebBackendConnectionReadList().connections(connectionItems);
+  }
+
+  private Map<UUID, JobRead> getLatestJobByConnectionId(final List<UUID> connectionIds) throws IOException {
+    return jobHistoryHandler.getLatestSyncJobsForConnections(connectionIds).stream()
+        .filter(Optional::isPresent)
+        .collect(Collectors.toMap(
+            j -> UUID.fromString(j.get().getConfigId()),
+            Optional::get));
+  }
+
+  private Map<UUID, JobRead> getRunningJobByConnectionId(final List<UUID> connectionIds) throws IOException {
+    return jobHistoryHandler.getRunningSyncJobForConnections(connectionIds).stream()
+        .filter(Optional::isPresent)
+        .collect(Collectors.toMap(
+            j -> UUID.fromString(j.get().getConfigId()),
+            Optional::get));
+  }
+
+  private Map<UUID, SourceRead> getSourceReadById(final List<UUID> sourceIds) throws IOException {
+    final Map<UUID, StandardSourceDefinition> sourceDefinitionsById = configRepository
+        .getSourceDefinitionsFromSourceIds(sourceIds)
+        .stream()
+        .collect(Collectors.toMap(StandardSourceDefinition::getSourceDefinitionId, Function.identity()));
+
+    final List<SourceRead> sourceReads = configRepository.getSourceConnections(sourceIds).stream()
+        .map(sourceConnection -> SourceHandler.toSourceRead(
+            sourceConnection,
+            sourceDefinitionsById.get(sourceConnection.getSourceDefinitionId())))
+        .toList();
+
+    return sourceReads.stream().collect(Collectors.toMap(SourceRead::getSourceId, Function.identity()));
+  }
+
+  private Map<UUID, DestinationRead> getDestinationReadById(final List<UUID> destinationIds) throws IOException {
+    final Map<UUID, StandardDestinationDefinition> destinationDefinitionsById = configRepository
+        .getDestinationDefinitionsFromDestinationIds(destinationIds)
+        .stream()
+        .collect(Collectors.toMap(StandardDestinationDefinition::getDestinationDefinitionId, Function.identity()));
+
+    final List<DestinationRead> destinationReads = configRepository.getDestinationConnections(destinationIds).stream()
+        .map(destinationConnection -> DestinationHandler.toDestinationRead(
+            destinationConnection,
+            destinationDefinitionsById.get(destinationConnection.getDestinationDefinitionId())))
+        .toList();
+
+    return destinationReads.stream().collect(Collectors.toMap(DestinationRead::getDestinationId, Function.identity()));
   }
 
   private WebBackendConnectionRead buildWebBackendConnectionRead(final ConnectionRead connectionRead)
@@ -129,12 +192,17 @@ public class WebBackendConnectionsHandler {
     return webBackendConnectionRead;
   }
 
-  private WebBackendConnectionListItem buildWebBackendConnectionListItem(final StandardSync standardSync)
-      throws JsonValidationException, ConfigNotFoundException, IOException {
-    final SourceRead source = getSourceRead(standardSync.getSourceId());
-    final DestinationRead destination = getDestinationRead(standardSync.getDestinationId());
-    final Optional<JobRead> latestSyncJob = jobHistoryHandler.getLatestSyncJob(standardSync.getConnectionId());
-    final Optional<JobRead> latestRunningSyncJob = jobHistoryHandler.getLatestRunningSyncJob(standardSync.getConnectionId());
+  private WebBackendConnectionListItem buildWebBackendConnectionListItem(
+                                                                         final StandardSync standardSync,
+                                                                         final Map<UUID, SourceRead> sourceReadById,
+                                                                         final Map<UUID, DestinationRead> destinationReadById,
+                                                                         final Map<UUID, JobRead> latestJobByConnectionId,
+                                                                         final Map<UUID, JobRead> runningJobByConnectionId) {
+
+    final SourceRead source = sourceReadById.get(standardSync.getSourceId());
+    final DestinationRead destination = destinationReadById.get(standardSync.getDestinationId());
+    final Optional<JobRead> latestSyncJob = Optional.ofNullable(latestJobByConnectionId.get(standardSync.getConnectionId()));
+    final Optional<JobRead> latestRunningSyncJob = Optional.ofNullable(runningJobByConnectionId.get(standardSync.getConnectionId()));
 
     final WebBackendConnectionListItem listItem = new WebBackendConnectionListItem()
         .connectionId(standardSync.getConnectionId())

--- a/airbyte-server/src/main/java/io/airbyte/server/handlers/WebBackendConnectionsHandler.java
+++ b/airbyte-server/src/main/java/io/airbyte/server/handlers/WebBackendConnectionsHandler.java
@@ -148,8 +148,8 @@ public class WebBackendConnectionsHandler {
   private Map<UUID, DestinationRead> getDestinationReadById(final List<UUID> destinationIds) throws IOException {
     final List<DestinationRead> destinationReads = configRepository.getDestinationAndDefinitionsFromDestinationIds(destinationIds)
         .stream()
-        .map(destinationAndDefinition ->
-            DestinationHandler.toDestinationRead(destinationAndDefinition.destination(), destinationAndDefinition.definition()))
+        .map(destinationAndDefinition -> DestinationHandler.toDestinationRead(destinationAndDefinition.destination(),
+            destinationAndDefinition.definition()))
         .toList();
 
     return destinationReads.stream().collect(Collectors.toMap(DestinationRead::getDestinationId, Function.identity()));

--- a/airbyte-server/src/main/java/io/airbyte/server/handlers/WebBackendConnectionsHandler.java
+++ b/airbyte-server/src/main/java/io/airbyte/server/handlers/WebBackendConnectionsHandler.java
@@ -99,8 +99,7 @@ public class WebBackendConnectionsHandler {
     return Enums.convertTo(stateHandler.getState(connectionIdRequestBody).getStateType(), ConnectionStateType.class);
   }
 
-  public WebBackendConnectionReadList webBackendListConnectionsForWorkspace(final WorkspaceIdRequestBody workspaceIdRequestBody)
-      throws ConfigNotFoundException, IOException, JsonValidationException {
+  public WebBackendConnectionReadList webBackendListConnectionsForWorkspace(final WorkspaceIdRequestBody workspaceIdRequestBody) throws IOException {
 
     // passing 'false' so that deleted connections are not included
     final List<StandardSync> standardSyncs =
@@ -118,7 +117,11 @@ public class WebBackendConnectionsHandler {
 
     for (final StandardSync standardSync : standardSyncs) {
       connectionItems.add(
-          buildWebBackendConnectionListItem(standardSync, sourceReadById, destinationReadById, latestJobByConnectionId,
+          buildWebBackendConnectionListItem(
+              standardSync,
+              sourceReadById,
+              destinationReadById,
+              latestJobByConnectionId,
               runningJobByConnectionId));
     }
 

--- a/airbyte-server/src/test/java/io/airbyte/server/handlers/WebBackendConnectionsHandlerTest.java
+++ b/airbyte-server/src/test/java/io/airbyte/server/handlers/WebBackendConnectionsHandlerTest.java
@@ -205,7 +205,7 @@ class WebBackendConnectionsHandlerTest {
     when(jobHistoryHandler.getLatestSyncJob(connectionRead.getConnectionId())).thenReturn(Optional.of(jobRead.getJob()));
 
     when(jobHistoryHandler.getLatestSyncJobsForConnections(Collections.singletonList(connectionRead.getConnectionId())))
-        .thenReturn(Collections.singletonList(Optional.of(jobRead.getJob())));
+        .thenReturn(Collections.singletonList(jobRead.getJob()));
 
     expectedListItem = ConnectionHelpers.generateExpectedWebBackendConnectionListItem(
         standardSync,

--- a/airbyte-server/src/test/java/io/airbyte/server/handlers/WebBackendConnectionsHandlerTest.java
+++ b/airbyte-server/src/test/java/io/airbyte/server/handlers/WebBackendConnectionsHandlerTest.java
@@ -72,6 +72,8 @@ import io.airbyte.config.StandardSourceDefinition;
 import io.airbyte.config.StandardSync;
 import io.airbyte.config.persistence.ConfigNotFoundException;
 import io.airbyte.config.persistence.ConfigRepository;
+import io.airbyte.config.persistence.ConfigRepository.DestinationAndDefinition;
+import io.airbyte.config.persistence.ConfigRepository.SourceAndDefinition;
 import io.airbyte.protocol.models.CatalogHelpers;
 import io.airbyte.protocol.models.Field;
 import io.airbyte.protocol.models.JsonSchemaType;
@@ -148,10 +150,10 @@ class WebBackendConnectionsHandlerTest {
         eventRunner,
         configRepository);
 
-    final StandardSourceDefinition standardSourceDefinition = SourceDefinitionHelpers.generateSourceDefinition();
-    standardSourceDefinition.setIcon(SOURCE_ICON);
-    final SourceConnection source = SourceHelpers.generateSource(standardSourceDefinition.getSourceDefinitionId());
-    sourceRead = SourceHelpers.getSourceRead(source, standardSourceDefinition);
+    final StandardSourceDefinition sourceDefinition = SourceDefinitionHelpers.generateSourceDefinition();
+    sourceDefinition.setIcon(SOURCE_ICON);
+    final SourceConnection source = SourceHelpers.generateSource(sourceDefinition.getSourceDefinitionId());
+    sourceRead = SourceHelpers.getSourceRead(source, sourceDefinition);
 
     final StandardDestinationDefinition destinationDefinition = DestinationDefinitionHelpers.generateDestination();
     destinationDefinition.setIcon(DESTINATION_ICON);
@@ -161,14 +163,10 @@ class WebBackendConnectionsHandlerTest {
     final StandardSync standardSync = ConnectionHelpers.generateSyncWithSourceAndDestinationId(source.getSourceId(), destination.getDestinationId());
     when(configRepository.listWorkspaceStandardSyncs(sourceRead.getWorkspaceId(), false))
         .thenReturn(Collections.singletonList(standardSync));
-    when(configRepository.getSourceConnections(Collections.singletonList(source.getSourceId())))
-        .thenReturn(Collections.singletonList(source));
-    when(configRepository.getDestinationConnections(Collections.singletonList(destination.getDestinationId())))
-        .thenReturn(Collections.singletonList(destination));
-    when(configRepository.getSourceDefinitionsFromSourceIds(Collections.singletonList(source.getSourceId())))
-        .thenReturn(Collections.singletonList(standardSourceDefinition));
-    when(configRepository.getDestinationDefinitionsFromDestinationIds(Collections.singletonList(destination.getDestinationId())))
-        .thenReturn(Collections.singletonList(destinationDefinition));
+    when(configRepository.getSourceAndDefinitionsFromSourceIds(Collections.singletonList(source.getSourceId())))
+        .thenReturn(Collections.singletonList(new SourceAndDefinition(source, sourceDefinition)));
+    when(configRepository.getDestinationAndDefinitionsFromDestinationIds(Collections.singletonList(destination.getDestinationId())))
+        .thenReturn(Collections.singletonList(new DestinationAndDefinition(destination, destinationDefinition)));
 
     connectionRead = ConnectionHelpers.generateExpectedConnectionRead(standardSync);
     operationReadList = new OperationReadList()

--- a/airbyte-server/src/test/java/io/airbyte/server/handlers/WebBackendConnectionsHandlerTest.java
+++ b/airbyte-server/src/test/java/io/airbyte/server/handlers/WebBackendConnectionsHandlerTest.java
@@ -150,17 +150,26 @@ class WebBackendConnectionsHandlerTest {
 
     final StandardSourceDefinition standardSourceDefinition = SourceDefinitionHelpers.generateSourceDefinition();
     standardSourceDefinition.setIcon(SOURCE_ICON);
-    final SourceConnection source = SourceHelpers.generateSource(UUID.randomUUID());
+    final SourceConnection source = SourceHelpers.generateSource(standardSourceDefinition.getSourceDefinitionId());
     sourceRead = SourceHelpers.getSourceRead(source, standardSourceDefinition);
 
     final StandardDestinationDefinition destinationDefinition = DestinationDefinitionHelpers.generateDestination();
     destinationDefinition.setIcon(DESTINATION_ICON);
-    final DestinationConnection destination = DestinationHelpers.generateDestination(UUID.randomUUID());
+    final DestinationConnection destination = DestinationHelpers.generateDestination(destinationDefinition.getDestinationDefinitionId());
     final DestinationRead destinationRead = DestinationHelpers.getDestinationRead(destination, destinationDefinition);
 
-    final StandardSync standardSync = ConnectionHelpers.generateSyncWithSourceId(source.getSourceId());
+    final StandardSync standardSync = ConnectionHelpers.generateSyncWithSourceAndDestinationId(source.getSourceId(), destination.getDestinationId());
     when(configRepository.listWorkspaceStandardSyncs(sourceRead.getWorkspaceId(), false))
         .thenReturn(Collections.singletonList(standardSync));
+    when(configRepository.getSourceConnections(Collections.singletonList(source.getSourceId())))
+        .thenReturn(Collections.singletonList(source));
+    when(configRepository.getDestinationConnections(Collections.singletonList(destination.getDestinationId())))
+        .thenReturn(Collections.singletonList(destination));
+    when(configRepository.getSourceDefinitionsFromSourceIds(Collections.singletonList(source.getSourceId())))
+        .thenReturn(Collections.singletonList(standardSourceDefinition));
+    when(configRepository.getDestinationDefinitionsFromDestinationIds(Collections.singletonList(destination.getDestinationId())))
+        .thenReturn(Collections.singletonList(destinationDefinition));
+
     connectionRead = ConnectionHelpers.generateExpectedConnectionRead(standardSync);
     operationReadList = new OperationReadList()
         .operations(List.of(new OperationRead()
@@ -194,6 +203,9 @@ class WebBackendConnectionsHandlerTest {
             .endedAt(now.getEpochSecond())));
 
     when(jobHistoryHandler.getLatestSyncJob(connectionRead.getConnectionId())).thenReturn(Optional.of(jobRead.getJob()));
+
+    when(jobHistoryHandler.getLatestSyncJobsForConnections(Collections.singletonList(connectionRead.getConnectionId())))
+        .thenReturn(Collections.singletonList(Optional.of(jobRead.getJob())));
 
     expectedListItem = ConnectionHelpers.generateExpectedWebBackendConnectionListItem(
         standardSync,
@@ -300,8 +312,7 @@ class WebBackendConnectionsHandlerTest {
   }
 
   @Test
-  void testWebBackendListConnectionsForWorkspace() throws ConfigNotFoundException, IOException,
-      JsonValidationException {
+  void testWebBackendListConnectionsForWorkspace() throws IOException {
     final WorkspaceIdRequestBody workspaceIdRequestBody = new WorkspaceIdRequestBody();
     workspaceIdRequestBody.setWorkspaceId(sourceRead.getWorkspaceId());
 

--- a/airbyte-server/src/test/java/io/airbyte/server/helpers/ConnectionHelpers.java
+++ b/airbyte-server/src/test/java/io/airbyte/server/helpers/ConnectionHelpers.java
@@ -101,6 +101,23 @@ public class ConnectionHelpers {
         .withManual(true);
   }
 
+  public static StandardSync generateSyncWithSourceAndDestinationId(final UUID sourceId, final UUID destinationId) {
+    final UUID connectionId = UUID.randomUUID();
+
+    return new StandardSync()
+        .withConnectionId(connectionId)
+        .withName("presto to hudi")
+        .withNamespaceDefinition(NamespaceDefinitionType.SOURCE)
+        .withNamespaceFormat(null)
+        .withPrefix("presto_to_hudi")
+        .withStatus(StandardSync.Status.ACTIVE)
+        .withCatalog(generateBasicConfiguredAirbyteCatalog())
+        .withSourceId(sourceId)
+        .withDestinationId(destinationId)
+        .withOperationIds(List.of(UUID.randomUUID()))
+        .withManual(true);
+  }
+
   public static ConnectionSchedule generateBasicConnectionSchedule() {
     return new ConnectionSchedule()
         .timeUnit(ConnectionSchedule.TimeUnitEnum.fromValue(BASIC_SCHEDULE_TIME_UNIT))

--- a/airbyte-server/src/test/java/io/airbyte/server/helpers/ConnectionHelpers.java
+++ b/airbyte-server/src/test/java/io/airbyte/server/helpers/ConnectionHelpers.java
@@ -54,6 +54,8 @@ public class ConnectionHelpers {
   private static final String BASIC_SCHEDULE_DATA_TIME_UNITS = "days";
   private static final long BASIC_SCHEDULE_DATA_UNITS = 1L;
   private static final String ONE_HUNDRED_G = "100g";
+  private static final String STANDARD_SYNC_NAME = "presto to hudi";
+  private static final String STANDARD_SYNC_PREFIX = "presto_to_hudi";
 
   public static final StreamDescriptor STREAM_DESCRIPTOR = new StreamDescriptor().withName(STREAM_NAME);
 
@@ -70,10 +72,10 @@ public class ConnectionHelpers {
 
     return new StandardSync()
         .withConnectionId(connectionId)
-        .withName("presto to hudi")
+        .withName(STANDARD_SYNC_NAME)
         .withNamespaceDefinition(NamespaceDefinitionType.SOURCE)
         .withNamespaceFormat(null)
-        .withPrefix("presto_to_hudi")
+        .withPrefix(STANDARD_SYNC_PREFIX)
         .withStatus(StandardSync.Status.ACTIVE)
         .withCatalog(generateBasicConfiguredAirbyteCatalog())
         .withSourceId(sourceId)
@@ -89,10 +91,10 @@ public class ConnectionHelpers {
 
     return new StandardSync()
         .withConnectionId(connectionId)
-        .withName("presto to hudi")
+        .withName(STANDARD_SYNC_NAME)
         .withNamespaceDefinition(NamespaceDefinitionType.SOURCE)
         .withNamespaceFormat(null)
-        .withPrefix("presto_to_hudi")
+        .withPrefix(STANDARD_SYNC_PREFIX)
         .withStatus(StandardSync.Status.ACTIVE)
         .withCatalog(generateBasicConfiguredAirbyteCatalog())
         .withSourceId(UUID.randomUUID())
@@ -106,10 +108,10 @@ public class ConnectionHelpers {
 
     return new StandardSync()
         .withConnectionId(connectionId)
-        .withName("presto to hudi")
+        .withName(STANDARD_SYNC_NAME)
         .withNamespaceDefinition(NamespaceDefinitionType.SOURCE)
         .withNamespaceFormat(null)
-        .withPrefix("presto_to_hudi")
+        .withPrefix(STANDARD_SYNC_PREFIX)
         .withStatus(StandardSync.Status.ACTIVE)
         .withCatalog(generateBasicConfiguredAirbyteCatalog())
         .withSourceId(sourceId)


### PR DESCRIPTION
## What
The web_backend connections list handler finds all connections within a workspace, and loops over each one, calling other handlers to build source reads, destination reads, and fetching the latest job info. Doing this once per connection is very slow and can require hundreds of queries for workspaces with many connections.

Instead, this PR performs all necessary queries up front and stores the information in maps that can then be referenced when building the response model for each connection. This should drastically reduce the number of database queries.

## How
- Write new repository methods that fetch information given lists of connections/sources/etc.
- Write helpers that convert lists to maps for easy lookups
- Pass these maps into the methods that construct response items to eliminate queries inside the connection loop

## Performance Testing
I did some comparison in `dev` between master and this branch for a [workspace](https://dev-cloud.airbyte.io/workspaces/f3665eb9-1d5f-40cb-b915-1c030c6d72bf/connections) with ~250 active connections

- The code in master generates ~3.3k individual queries, and takes ~15-20 seconds. Here's an example [span](https://app.datadoghq.com/apm/trace/8033575840259006171?colorBy=service&env=dev&graphType=span_list&shouldShowLegend=true&sort=time&spanID=63795192923569091&spanViewType=metadata&timeHint=1664842386153.053)
- The code in this branch generates 11 queries, and this number is constant no matter how many connections are in the workspace. Here's an example [span](https://app.datadoghq.com/apm/trace/5247356970545716095?colorBy=service&env=dev&graphType=span_list&shouldShowLegend=true&sort=time&spanID=3458347133960319071&spanViewType=metadata&timeHint=1664914433853.138). The workspace loads in ~1-3 seconds instead of ~15-20 seconds, which is obviously a massive improvement.

Tagging @malikdiarra and @davinchia for review as they both have context on our repository layer and experience with making similar optimizations. Definitely looking for thoughts and feedback on the new queries and in-memory grouping code.