### PR TITLE
mark alloydb source as GA

### DIFF
--- a/airbyte-config/init/src/main/resources/seed/source_definitions.yaml
+++ b/airbyte-config/init/src/main/resources/seed/source_definitions.yaml
@@ -21,7 +21,7 @@
   documentationUrl: https://docs.airbyte.io/integrations/sources/alloydb
   icon: alloydb.svg
   sourceType: database
-  releaseStage: alpha
+  releaseStage: generally_available
 - name: AWS CloudTrail
   sourceDefinitionId: 6ff047c0-f5d5-4ce5-8c81-204a830fa7e1
   dockerRepository: airbyte/source-aws-cloudtrail


### PR DESCRIPTION
## What
Add GA label to AlloyDB Source connector. This connector is a wrapper around Postgres Source branded as AlloyDB