### PR TITLE
🐞 CDK: fix error when logging warning for types that could not be transformed

### DIFF
--- a/airbyte-cdk/python/CHANGELOG.md
+++ b/airbyte-cdk/python/CHANGELOG.md
@@ -1,5 +1,8 @@
 # Changelog
 
+## 0.1.90
+- Fix error when TypeTransformer tries to warn about invalid transformations in arrays
+
 ## 0.1.89
 - Fix: properly emit state when a stream has empty slices, provided by an iterator
 

--- a/airbyte-cdk/python/airbyte_cdk/sources/utils/transform.py
+++ b/airbyte-cdk/python/airbyte_cdk/sources/utils/transform.py
@@ -190,7 +190,7 @@ class TypeTransformer:
 
     def get_error_message(self, e: ValidationError) -> str:
         instance_json_type = python_to_json[type(e.instance)]
-        key_path = "." + ".".join(e.path)
+        key_path = "." + ".".join(map(str, e.path))
         return (
             f"Failed to transform value {repr(e.instance)} of type '{instance_json_type}' to '{e.validator_value}', key path: '{key_path}'"
         )

--- a/airbyte-cdk/python/setup.py
+++ b/airbyte-cdk/python/setup.py
@@ -15,7 +15,7 @@ README = (HERE / "README.md").read_text()
 
 setup(
     name="airbyte-cdk",
-    version="0.1.89",
+    version="0.1.90",
     description="A framework for writing Airbyte Connectors.",
     long_description=README,
     long_description_content_type="text/markdown",

--- a/airbyte-cdk/python/unit_tests/sources/utils/test_transform.py
+++ b/airbyte-cdk/python/unit_tests/sources/utils/test_transform.py
@@ -197,6 +197,12 @@ VERY_NESTED_SCHEMA = {
             {"value1": "value2"},
             "Failed to transform value 'value2' of type 'string' to 'object', key path: '.value1'",
         ),
+        (
+            {"type": "object", "properties": {"value": {"type": "array", "items": {"type": "object"}}}},
+            {"value": ["one", "two"]},
+            {"value": ["one", "two"]},
+            "Failed to transform value 'one' of type 'string' to 'object', key path: '.value.0'",
+        ),
     ],
 )
 def test_transform(schema, actual, expected, expected_warns, caplog):


### PR DESCRIPTION
## What

The warnings recently introduced to the TypeTransformer in https://github.com/airbytehq/airbyte/pull/16695 were causing an error to be thrown when the mismatched type was inside an array

```
Traceback (most recent call last):
  File "/airbyte/integration_code/main.py", line 13, in <module>
    launch(source, sys.argv[1:])
  File "/usr/local/lib/python3.9/site-packages/airbyte_cdk/entrypoint.py", line 123, in launch
    for message in source_entrypoint.run(parsed_args):
  File "/usr/local/lib/python3.9/site-packages/airbyte_cdk/entrypoint.py", line 114, in run
    for message in generator:
  File "/usr/local/lib/python3.9/site-packages/airbyte_cdk/sources/abstract_source.py", line 127, in read
    raise e
  File "/usr/local/lib/python3.9/site-packages/airbyte_cdk/sources/abstract_source.py", line 113, in read
    yield from self._read_stream(
  File "/usr/local/lib/python3.9/site-packages/airbyte_cdk/sources/abstract_source.py", line 182, in _read_stream
    for record in record_iterator:
  File "/usr/local/lib/python3.9/site-packages/airbyte_cdk/sources/abstract_source.py", line 246, in _read_incremental
    yield self._as_airbyte_record(stream_name, record_data)
  File "/usr/local/lib/python3.9/site-packages/airbyte_cdk/sources/abstract_source.py", line 316, in _as_airbyte_record
    transformer.transform(data, schema)  # type: ignore
  File "/usr/local/lib/python3.9/site-packages/airbyte_cdk/sources/utils/transform.py", line 189, in transform
    logger.warning(self.get_error_message(e))
  File "/usr/local/lib/python3.9/site-packages/airbyte_cdk/sources/utils/transform.py", line 193, in get_error_message
    key_path = "." + ".".join(e.path)
TypeError: sequence item 2: expected str instance, int found
```

This is beacuse `e.path` in this case was `['event_properties', 'items', 0]`.

## How

Fix the issue by mapping all path parts to string
