### PR TITLE
🐛 Source YouTube Analytics: fix `check_connection` 403 error

### DIFF
--- a/airbyte-config/init/src/main/resources/seed/source_definitions.yaml
+++ b/airbyte-config/init/src/main/resources/seed/source_definitions.yaml
@@ -1107,7 +1107,7 @@
 - sourceDefinitionId: afa734e4-3571-11ec-991a-1e0031268139
   name: YouTube Analytics
   dockerRepository: airbyte/source-youtube-analytics
-  dockerImageTag: 0.1.1
+  dockerImageTag: 0.1.2
   documentationUrl: https://docs.airbyte.io/integrations/sources/youtube-analytics
   icon: youtube.svg
   sourceType: api

--- a/airbyte-config/init/src/main/resources/seed/source_specs.yaml
+++ b/airbyte-config/init/src/main/resources/seed/source_specs.yaml
@@ -11523,7 +11523,7 @@
     supportsNormalization: false
     supportsDBT: false
     supported_destination_sync_modes: []
-- dockerImage: "airbyte/source-youtube-analytics:0.1.1"
+- dockerImage: "airbyte/source-youtube-analytics:0.1.2"
   spec:
     documentationUrl: "https://docs.airbyte.io/integrations/sources/youtube-analytics"
     connectionSpecification:

--- a/airbyte-integrations/connectors/source-youtube-analytics/Dockerfile
+++ b/airbyte-integrations/connectors/source-youtube-analytics/Dockerfile
@@ -34,5 +34,5 @@ COPY source_youtube_analytics ./source_youtube_analytics
 ENV AIRBYTE_ENTRYPOINT "python /airbyte/integration_code/main.py"
 ENTRYPOINT ["python", "/airbyte/integration_code/main.py"]
 
-LABEL io.airbyte.version=0.1.1
+LABEL io.airbyte.version=0.1.2
 LABEL io.airbyte.name=airbyte/source-youtube-analytics

--- a/airbyte-integrations/connectors/source-youtube-analytics/source_youtube_analytics/source.py
+++ b/airbyte-integrations/connectors/source-youtube-analytics/source_youtube_analytics/source.py
@@ -183,8 +183,10 @@ class SourceYoutubeAnalytics(AbstractSource):
         if result:
             return True, None
         else:
-            return False, "The Youtube account is not valid. Please make sure you're trying to use the active Youtube Account connected to your Google Account."
-        
+            return (
+                False,
+                "The Youtube account is not valid. Please make sure you're trying to use the active Youtube Account connected to your Google Account.",
+            )
 
     def streams(self, config: Mapping[str, Any]) -> List[Stream]:
         authenticator = self.get_authenticator(config)

--- a/airbyte-integrations/connectors/source-youtube-analytics/unit_tests/test_source.py
+++ b/airbyte-integrations/connectors/source-youtube-analytics/unit_tests/test_source.py
@@ -14,7 +14,7 @@ def test_check_connection(requests_mock):
     access_token = "token"
     mock_oauth_call = requests_mock.post("https://oauth2.googleapis.com/token", json={"access_token": access_token, "expires_in": 0})
 
-    mock_jobs_call = requests_mock.get("https://youtubereporting.googleapis.com/v1/jobs", json={})
+    mock_jobs_call = requests_mock.get("https://youtubereporting.googleapis.com/v1/jobs", json={"jobs": [1,2,3]})
 
     source = SourceYoutubeAnalytics()
     logger_mock, config_mock = MagicMock(), MagicMock()

--- a/airbyte-integrations/connectors/source-youtube-analytics/unit_tests/test_source.py
+++ b/airbyte-integrations/connectors/source-youtube-analytics/unit_tests/test_source.py
@@ -14,7 +14,7 @@ def test_check_connection(requests_mock):
     access_token = "token"
     mock_oauth_call = requests_mock.post("https://oauth2.googleapis.com/token", json={"access_token": access_token, "expires_in": 0})
 
-    mock_jobs_call = requests_mock.get("https://youtubereporting.googleapis.com/v1/jobs", json={"jobs": [1,2,3]})
+    mock_jobs_call = requests_mock.get("https://youtubereporting.googleapis.com/v1/jobs", json={"jobs": [1, 2, 3]})
 
     source = SourceYoutubeAnalytics()
     logger_mock, config_mock = MagicMock(), MagicMock()

--- a/docs/integrations/sources/youtube-analytics.md
+++ b/docs/integrations/sources/youtube-analytics.md
@@ -82,5 +82,6 @@ Quota usage is not an issue because data is retrieved once and then filtered, so
 
 | Version | Date | Pull Request | Subject |
 | :--- | :--- | :--- | :--- |
+| 0.1.2 | 2022-09-29 | [17399](https://github.com/airbytehq/airbyte/pull/17399) | Fixed `403` error while `check connection` |
 | 0.1.1 | 2022-08-18 | [15744](https://github.com/airbytehq/airbyte/pull/15744) | Fix `channel_basic_a2` schema fields data type |
 | 0.1.0 | 2021-11-01 | [7407](https://github.com/airbytehq/airbyte/pull/7407) | Initial Release |


### PR DESCRIPTION
## What
Resolving: https://github.com/airbytehq/alpha-beta-issues/issues/306

## How
- enabled `Youtube analytics API` for `prod-cloud` project to fix 403
- added handling of `401: UNAUTHORIZED`, when using a non-connected youtube account
- fixed related unit_test

Now the check should look like this, once failed:
<img width="636" alt="Screenshot 2022-09-29 at 19 54 46" src="https://user-images.githubusercontent.com/22987674/193092250-06356835-ba5e-489e-b824-39ef219ddd24.png">


## 🚨 User Impact 🚨
No impact is expected.

## Pre-merge Checklist
Expand the relevant checklist and delete the others.


<details><summary><strong>Updating a connector</strong></summary>

### Community member or Airbyter

- [X] Unit & integration tests added and passing. Community members, please provide proof of success locally e.g: screenshot or copy-paste unit, integration, and acceptance test output. To run acceptance tests for a Python connector, follow instructions in the README. For java connectors run `./gradlew :airbyte-integrations:connectors:<name>:integrationTest`.
- [ ] Code reviews completed
- [X] Documentation updated
    - [X] Changelog updated in `docs/integrations/<source or destination>/<name>.md` including changelog. See changelog [example](https://docs.airbyte.io/integrations/sources/stripe#changelog)
- [X] PR name follows [PR naming conventions](https://docs.airbyte.com/contributing-to-airbyte/issues-and-pull-requests)

### Airbyter

If this is a community PR, the Airbyte engineer reviewing this PR is responsible for the below items.

- [ ] Create a non-forked branch based on this PR and test the below items on it
- [ ] Build is successful
- [ ] If new credentials are required for use in CI, add them to GSM. [Instructions](https://docs.airbyte.io/connector-development#using-credentials-in-ci).
- [ ] [`/test connector=connectors/<name>` command](https://docs.airbyte.io/connector-development#updating-an-existing-connector) is passing
- [ ] New Connector version released on Dockerhub and connector version bumped by running the `/publish` command described [here](https://docs.airbyte.io/connector-development#updating-an-existing-connector)

</details>
