### PR TITLE
Low Code CDK: add statement for abstractmethod and unit test for multiple transformations

### DIFF
--- a/airbyte-cdk/python/airbyte_cdk/sources/declarative/declarative_source.py
+++ b/airbyte-cdk/python/airbyte_cdk/sources/declarative/declarative_source.py
@@ -18,6 +18,7 @@ class DeclarativeSource(AbstractSource):
     @abstractmethod
     def connection_checker(self) -> ConnectionChecker:
         """Returns the ConnectioChecker to use for the `check` operation"""
+        pass
 
     def check_connection(self, logger, config) -> Tuple[bool, any]:
         """

--- a/airbyte-cdk/python/airbyte_cdk/sources/declarative/declarative_stream.py
+++ b/airbyte-cdk/python/airbyte_cdk/sources/declarative/declarative_stream.py
@@ -114,9 +114,9 @@ class DeclarativeStream(Stream, JsonSchemaMixin):
             yield self._apply_transformations(record, self.config, stream_slice)
 
     def _apply_transformations(self, record: Mapping[str, Any], config: Config, stream_slice: StreamSlice):
-        output_record = deepcopy(record)
+        output_record = record
         for transformation in self.transformations:
-            output_record = transformation.transform(output_record, config=config, stream_state=self.state, stream_slice=stream_slice)
+            output_record = transformation.transform(record, config=config, stream_state=self.state, stream_slice=stream_slice)
 
         return output_record
 

--- a/airbyte-cdk/python/airbyte_cdk/sources/declarative/declarative_stream.py
+++ b/airbyte-cdk/python/airbyte_cdk/sources/declarative/declarative_stream.py
@@ -3,6 +3,7 @@
 #
 
 from dataclasses import InitVar, dataclass, field
+from copy import deepcopy
 from typing import Any, Iterable, List, Mapping, MutableMapping, Optional, Union
 
 from airbyte_cdk.models import SyncMode
@@ -113,9 +114,9 @@ class DeclarativeStream(Stream, JsonSchemaMixin):
             yield self._apply_transformations(record, self.config, stream_slice)
 
     def _apply_transformations(self, record: Mapping[str, Any], config: Config, stream_slice: StreamSlice):
-        output_record = record
+        output_record = deepcopy(record)
         for transformation in self.transformations:
-            output_record = transformation.transform(record, config=config, stream_state=self.state, stream_slice=stream_slice)
+            output_record = transformation.transform(output_record, config=config, stream_state=self.state, stream_slice=stream_slice)
 
         return output_record
 

--- a/airbyte-cdk/python/airbyte_cdk/sources/declarative/declarative_stream.py
+++ b/airbyte-cdk/python/airbyte_cdk/sources/declarative/declarative_stream.py
@@ -3,7 +3,6 @@
 #
 
 from dataclasses import InitVar, dataclass, field
-from copy import deepcopy
 from typing import Any, Iterable, List, Mapping, MutableMapping, Optional, Union
 
 from airbyte_cdk.models import SyncMode

--- a/airbyte-cdk/python/airbyte_cdk/sources/declarative/parsers/config_parser.py
+++ b/airbyte-cdk/python/airbyte_cdk/sources/declarative/parsers/config_parser.py
@@ -15,3 +15,4 @@ class ConnectionDefinitionParser(ABC):
     @abstractmethod
     def parse(self, config_str: str) -> ConnectionDefinition:
         """Parses the config_str to a ConnectionDefinition"""
+        pass

--- a/airbyte-cdk/python/airbyte_cdk/sources/declarative/requesters/error_handlers/backoff_strategy.py
+++ b/airbyte-cdk/python/airbyte_cdk/sources/declarative/requesters/error_handlers/backoff_strategy.py
@@ -24,3 +24,4 @@ class BackoffStrategy(JsonSchemaMixin):
         :param attempt_count: number of attempts to submit the request
         :return: time to wait in seconds
         """
+        pass

--- a/airbyte-cdk/python/airbyte_cdk/sources/declarative/requesters/paginators/paginator.py
+++ b/airbyte-cdk/python/airbyte_cdk/sources/declarative/requesters/paginators/paginator.py
@@ -25,6 +25,7 @@ class Paginator(RequestOptionsProvider, JsonSchemaMixin):
         """
         Reset the pagination's inner state
         """
+        pass
 
     @abstractmethod
     def next_page_token(self, response: requests.Response, last_records: List[Mapping[str, Any]]) -> Optional[Mapping[str, Any]]:

--- a/airbyte-cdk/python/airbyte_cdk/sources/declarative/requesters/paginators/strategies/pagination_strategy.py
+++ b/airbyte-cdk/python/airbyte_cdk/sources/declarative/requesters/paginators/strategies/pagination_strategy.py
@@ -30,3 +30,4 @@ class PaginationStrategy(JsonSchemaMixin):
         """
         Reset the pagination's inner state
         """
+        pass

--- a/airbyte-cdk/python/airbyte_cdk/sources/declarative/requesters/request_options/request_options_provider.py
+++ b/airbyte-cdk/python/airbyte_cdk/sources/declarative/requesters/request_options/request_options_provider.py
@@ -46,6 +46,7 @@ class RequestOptionsProvider(JsonSchemaMixin):
         next_page_token: Optional[Mapping[str, Any]] = None,
     ) -> Mapping[str, Any]:
         """Return any non-auth headers. Authentication headers will overwrite any overlapping headers returned from this method."""
+        pass
 
     @abstractmethod
     def get_request_body_data(
@@ -64,6 +65,7 @@ class RequestOptionsProvider(JsonSchemaMixin):
 
         At the same time only one of the 'request_body_data' and 'request_body_json' functions can be overridden.
         """
+        pass
 
     @abstractmethod
     def get_request_body_json(
@@ -78,3 +80,4 @@ class RequestOptionsProvider(JsonSchemaMixin):
 
         At the same time only one of the 'request_body_data' and 'request_body_json' functions can be overridden.
         """
+        pass

--- a/airbyte-cdk/python/airbyte_cdk/sources/declarative/requesters/requester.py
+++ b/airbyte-cdk/python/airbyte_cdk/sources/declarative/requesters/requester.py
@@ -36,6 +36,7 @@ class Requester(RequestOptionsProvider, JsonSchemaMixin):
         """
         :return: URL base for the  API endpoint e.g: if you wanted to hit https://myapi.com/v1/some_entity then this should return "https://myapi.com/v1/"
         """
+        pass
 
     @abstractmethod
     def get_path(
@@ -48,12 +49,14 @@ class Requester(RequestOptionsProvider, JsonSchemaMixin):
         """
         Returns the URL path for the API endpoint e.g: if you wanted to hit https://myapi.com/v1/some_entity then this should return "some_entity"
         """
+        pass
 
     @abstractmethod
     def get_method(self) -> HttpMethod:
         """
         Specifies the HTTP method to use
         """
+        pass
 
     @abstractmethod
     def get_request_params(
@@ -68,6 +71,7 @@ class Requester(RequestOptionsProvider, JsonSchemaMixin):
 
         E.g: you might want to define query parameters for paging if next_page_token is not None.
         """
+        pass
 
     @abstractmethod
     def should_retry(self, response: requests.Response) -> ResponseStatus:
@@ -80,6 +84,7 @@ class Requester(RequestOptionsProvider, JsonSchemaMixin):
 
         Unexpected but transient exceptions (connection timeout, DNS resolution failed, etc..) are retried by default.
         """
+        pass
 
     @abstractmethod
     def get_request_headers(
@@ -92,6 +97,7 @@ class Requester(RequestOptionsProvider, JsonSchemaMixin):
         """
         Return any non-auth headers. Authentication headers will overwrite any overlapping headers returned from this method.
         """
+        pass
 
     @abstractmethod
     def get_request_body_data(
@@ -110,6 +116,7 @@ class Requester(RequestOptionsProvider, JsonSchemaMixin):
 
         At the same time only one of the 'request_body_data' and 'request_body_json' functions can be overridden.
         """
+        pass
 
     @abstractmethod
     def get_request_body_json(
@@ -124,6 +131,7 @@ class Requester(RequestOptionsProvider, JsonSchemaMixin):
 
         At the same time only one of the 'request_body_data' and 'request_body_json' functions can be overridden.
         """
+        pass
 
     @abstractmethod
     def request_kwargs(
@@ -138,6 +146,7 @@ class Requester(RequestOptionsProvider, JsonSchemaMixin):
         Any option listed in https://docs.python-requests.org/en/latest/api/#requests.adapters.BaseAdapter.send for can be returned from
         this method. Note that these options do not conflict with request-level options such as headers, request params, etc..
         """
+        pass
 
     @property
     @abstractmethod
@@ -145,6 +154,7 @@ class Requester(RequestOptionsProvider, JsonSchemaMixin):
         """
         Return the name of cache file
         """
+        pass
 
     @property
     @abstractmethod
@@ -152,3 +162,4 @@ class Requester(RequestOptionsProvider, JsonSchemaMixin):
         """
         If True, all records will be cached.
         """
+        pass

--- a/airbyte-cdk/python/airbyte_cdk/sources/declarative/retrievers/retriever.py
+++ b/airbyte-cdk/python/airbyte_cdk/sources/declarative/retrievers/retriever.py
@@ -34,10 +34,12 @@ class Retriever(JsonSchemaMixin):
         :param stream_state: The initial stream state
         :return: The records read from the API source
         """
+        pass
 
     @abstractmethod
     def stream_slices(self, *, sync_mode: SyncMode, stream_state: Optional[StreamState] = None) -> Iterable[Optional[StreamSlice]]:
         """Returns the stream slices"""
+        pass
 
     @property
     @abstractmethod
@@ -53,8 +55,10 @@ class Retriever(JsonSchemaMixin):
          State should try to be as small as possible but at the same time descriptive enough to restore
          syncing process from the point where it stopped.
         """
+        pass
 
     @state.setter
     @abstractmethod
     def state(self, value: StreamState):
         """State setter, accept state serialized by state getter."""
+        pass

--- a/airbyte-cdk/python/airbyte_cdk/sources/declarative/stream_slicers/stream_slicer.py
+++ b/airbyte-cdk/python/airbyte_cdk/sources/declarative/stream_slicers/stream_slicer.py
@@ -32,6 +32,7 @@ class StreamSlicer(RequestOptionsProvider, JsonSchemaMixin):
         :param stream_state: The current stream state
         :return: List of stream slices
         """
+        pass
 
     @abstractmethod
     def update_cursor(self, stream_slice: StreamSlice, last_record: Optional[Record] = None):
@@ -41,7 +42,9 @@ class StreamSlicer(RequestOptionsProvider, JsonSchemaMixin):
         :param stream_slice: Current stream_slice
         :param last_record: Last record read from the source
         """
+        pass
 
     @abstractmethod
     def get_stream_state(self) -> StreamState:
         """Returns the current stream state"""
+        pass

--- a/airbyte-cdk/python/airbyte_cdk/sources/declarative/transformations/transformation.py
+++ b/airbyte-cdk/python/airbyte_cdk/sources/declarative/transformations/transformation.py
@@ -33,6 +33,7 @@ class RecordTransformation(JsonSchemaMixin):
         :param stream_slice: The stream slice
         :return: The transformed record
         """
+        pass
 
     def __eq__(self, other):
         return other.__dict__ == self.__dict__


### PR DESCRIPTION
## What

Python doesn't support functions without anything in it. So I added the pass argument to all abstractmethods in Declarative CDK; I prefer to have a raise NotImplemented() but saw a few abstractmethods are using pass.

The unit test I added only to confirm the `_apply_transformation` was running correctly for 2 or more transformations:
https://github.com/airbytehq/airbyte/blob/da5df45afe546f2a9d894989b4b041c019fa2e18/airbyte-cdk/python/airbyte_cdk/sources/declarative/declarative_stream.py#L115-L120
Not sure if doing a `deepcopy(record)` to `output_record` would be better.

## How
*Describe the solution*

## Recommended reading order
1. `x.java`
2. `y.python`

## 🚨 User Impact 🚨
Are there any breaking changes? What is the end result perceived by the user? If yes, please merge this PR with the 🚨🚨 emoji so changelog authors can further highlight this if needed.

## Pre-merge Checklist
Expand the relevant checklist and delete the others.

<details><summary><strong>New Connector</strong></summary>

### Community member or Airbyter

- [ ] **Community member?** Grant edit access to maintainers ([instructions](https://docs.github.com/en/github/collaborating-with-pull-requests/working-with-forks/allowing-changes-to-a-pull-request-branch-created-from-a-fork#enabling-repository-maintainer-permissions-on-existing-pull-requests))
- [ ] Secrets in the connector's spec are annotated with `airbyte_secret`
- [ ] Unit & integration tests added and passing. Community members, please provide proof of success locally e.g: screenshot or copy-paste unit, integration, and acceptance test output. To run acceptance tests for a Python connector, follow instructions in the README. For java connectors run `./gradlew :airbyte-integrations:connectors:<name>:integrationTest`.
- [ ] Code reviews completed
- [ ] Documentation updated
    - [ ] Connector's `README.md`
    - [ ] Connector's `bootstrap.md`. See [description and examples](https://docs.google.com/document/d/1ypdgmwmEHWv-TrO4_YOQ7pAJGVrMp5BOkEVh831N260/edit?usp=sharing)
    - [ ] `docs/integrations/<source or destination>/<name>.md` including changelog. See changelog [example](https://docs.airbyte.io/integrations/sources/stripe#changelog)
    - [ ] `docs/integrations/README.md`
    - [ ] `airbyte-integrations/builds.md`
- [ ] PR name follows [PR naming conventions](https://docs.airbyte.com/contributing-to-airbyte/issues-and-pull-requests)

### Airbyter

If this is a community PR, the Airbyte engineer reviewing this PR is responsible for the below items.

- [ ] Create a non-forked branch based on this PR and test the below items on it
- [ ] Build is successful
- [ ] If new credentials are required for use in CI, add them to GSM. [Instructions](https://docs.airbyte.io/connector-development#using-credentials-in-ci).
- [ ] [`/test connector=connectors/<name>` command](https://docs.airbyte.io/connector-development#updating-an-existing-connector) is passing
- [ ] New Connector version released on Dockerhub by running the `/publish` command described [here](https://docs.airbyte.io/connector-development#updating-an-existing-connector)
- [ ] After the connector is published, connector added to connector index as described [here](https://docs.airbyte.io/connector-development#publishing-a-connector)
- [ ] Seed specs have been re-generated by building the platform and committing the changes to the seed spec files, as described [here](https://docs.airbyte.io/connector-development#publishing-a-connector)

</details>

<details><summary><strong>Updating a connector</strong></summary>

### Community member or Airbyter

- [ ] Grant edit access to maintainers ([instructions](https://docs.github.com/en/github/collaborating-with-pull-requests/working-with-forks/allowing-changes-to-a-pull-request-branch-created-from-a-fork#enabling-repository-maintainer-permissions-on-existing-pull-requests))
- [ ] Secrets in the connector's spec are annotated with `airbyte_secret`
- [ ] Unit & integration tests added and passing. Community members, please provide proof of success locally e.g: screenshot or copy-paste unit, integration, and acceptance test output. To run acceptance tests for a Python connector, follow instructions in the README. For java connectors run `./gradlew :airbyte-integrations:connectors:<name>:integrationTest`.
- [ ] Code reviews completed
- [ ] Documentation updated
    - [ ] Connector's `README.md`
    - [ ] Connector's `bootstrap.md`. See [description and examples](https://docs.google.com/document/d/1ypdgmwmEHWv-TrO4_YOQ7pAJGVrMp5BOkEVh831N260/edit?usp=sharing)
    - [ ] Changelog updated in `docs/integrations/<source or destination>/<name>.md` including changelog. See changelog [example](https://docs.airbyte.io/integrations/sources/stripe#changelog)
- [ ] PR name follows [PR naming conventions](https://docs.airbyte.com/contributing-to-airbyte/issues-and-pull-requests)

### Airbyter

If this is a community PR, the Airbyte engineer reviewing this PR is responsible for the below items.

- [ ] Create a non-forked branch based on this PR and test the below items on it
- [ ] Build is successful
- [ ] If new credentials are required for use in CI, add them to GSM. [Instructions](https://docs.airbyte.io/connector-development#using-credentials-in-ci).
- [ ] [`/test connector=connectors/<name>` command](https://docs.airbyte.io/connector-development#updating-an-existing-connector) is passing
- [ ] New Connector version released on Dockerhub and connector version bumped by running the `/publish` command described [here](https://docs.airbyte.io/connector-development#updating-an-existing-connector)

</details>

<details><summary><strong>Connector Generator</strong></summary>

- [ ] Issue acceptance criteria met
- [ ] PR name follows [PR naming conventions](https://docs.airbyte.com/contributing-to-airbyte/issues-and-pull-requests)
- [ ] If adding a new generator, add it to the [list of scaffold modules being tested](https://github.com/airbytehq/airbyte/blob/master/airbyte-integrations/connector-templates/generator/build.gradle#L41)
- [ ] The generator test modules (all connectors with `-scaffold` in their name) have been updated with the latest scaffold by running `./gradlew :airbyte-integrations:connector-templates:generator:testScaffoldTemplates` then checking in your changes
- [ ] Documentation which references the generator is updated as needed

</details>

## Tests

<details><summary><strong>Unit</strong></summary>

*Put your unit tests output here.*

</details>

<details><summary><strong>Integration</strong></summary>

*Put your integration tests output here.*

</details>

<details><summary><strong>Acceptance</strong></summary>

*Put your acceptance tests output here.*

</details>
