### PR TITLE
add distribution gradle plugin

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -29,6 +29,7 @@ plugins {
     id 'com.diffplug.spotless' version '6.7.1'
     id 'com.github.hierynomus.license' version '0.16.1'
     id 'com.github.spotbugs' version '5.0.6'
+    id 'distribution'
     id 'version-catalog'
     id 'maven-publish'
 }

--- a/build.gradle
+++ b/build.gradle
@@ -29,6 +29,9 @@ plugins {
     id 'com.diffplug.spotless' version '6.7.1'
     id 'com.github.hierynomus.license' version '0.16.1'
     id 'com.github.spotbugs' version '5.0.6'
+    // The distribution plugin has been added to address the an issue with the copyGeneratedTar
+    // task depending on "distTar". When that dependency has been refactored away, this plugin
+    // can be removed.
     id 'distribution'
     id 'version-catalog'
     id 'maven-publish'
@@ -98,29 +101,29 @@ def createJavaLicenseWith = { license ->
 // monorepo setup and it doesn't actually exclude directories reliably. This code makes the behavior predictable.
 def createSpotlessTarget = { pattern ->
     def excludes = [
-        '.gradle',
-        'node_modules',
-        '.eggs',
-        '.mypy_cache',
-        '.venv',
-        '*.egg-info',
-        'build',
-        'dbt-project-template',
-        'dbt-project-template-mssql',
-        'dbt-project-template-mysql',
-        'dbt-project-template-oracle',
-        'dbt-project-template-clickhouse',
-        'dbt-project-template-snowflake',
-        'dbt-project-template-tidb',
-        'dbt_test_config',
-        'normalization_test_output',
-        'tools',
-        'secrets',
-        'charts', // Helm charts often have injected template strings that will fail general linting. Helm linting is done separately.
-        'resources/seed/*_specs.yaml', // Do not remove - this is necessary to prevent diffs in our github workflows, as the file diff check runs between the Format step and the Build step, the latter of which generates the file.
-        'airbyte-integrations/connectors/source-amplitude/unit_tests/api_data/zipped.json', // Zipped file presents as non-UTF-8 making spotless sad
-        'airbyte-webapp', // The webapp module uses its own auto-formatter, so spotless is not necessary here
-        'airbyte-webapp-e2e-tests', // This module also uses its own auto-formatter
+            '.gradle',
+            'node_modules',
+            '.eggs',
+            '.mypy_cache',
+            '.venv',
+            '*.egg-info',
+            'build',
+            'dbt-project-template',
+            'dbt-project-template-mssql',
+            'dbt-project-template-mysql',
+            'dbt-project-template-oracle',
+            'dbt-project-template-clickhouse',
+            'dbt-project-template-snowflake',
+            'dbt-project-template-tidb',
+            'dbt_test_config',
+            'normalization_test_output',
+            'tools',
+            'secrets',
+            'charts', // Helm charts often have injected template strings that will fail general linting. Helm linting is done separately.
+            'resources/seed/*_specs.yaml', // Do not remove - this is necessary to prevent diffs in our github workflows, as the file diff check runs between the Format step and the Build step, the latter of which generates the file.
+            'airbyte-integrations/connectors/source-amplitude/unit_tests/api_data/zipped.json', // Zipped file presents as non-UTF-8 making spotless sad
+            'airbyte-webapp', // The webapp module uses its own auto-formatter, so spotless is not necessary here
+            'airbyte-webapp-e2e-tests', // This module also uses its own auto-formatter
     ]
 
     if (System.getenv().containsKey("SUB_BUILD")) {
@@ -161,7 +164,7 @@ check.dependsOn 'spotlessApply'
 @SuppressWarnings('GroovyAssignabilityCheck')
 def Task getPublishArtifactsTask(String buildVersion, Project subproject) {
     // generate a unique task name based on the directory name.
-    return task ("publishArtifact-$subproject.name" {
+    return task("publishArtifact-$subproject.name" {
         apply plugin: 'maven-publish'
         publishing {
             repositories {


### PR DESCRIPTION
## What
- fix gradle failing due to not being able to find `distTar`
   > Could not create task ':airbyte-cli:copyGeneratedTar'.
   >
   > Could not get unknown property 'distTar' for task ':airbyte-cli:copyGeneratedTar' of type org.gradle.api.tasks.Copy.

## How
- add the `distribution` plugin to the main `build.gradle` file