### PR TITLE
🪟🧪 [Experiment] Incentivize speedy first connection (aka activation)

### DIFF
--- a/airbyte-webapp/src/components/experiments/SpeedyConnection/CountDownTimer/CountDownTimer.module.scss
+++ b/airbyte-webapp/src/components/experiments/SpeedyConnection/CountDownTimer/CountDownTimer.module.scss
@@ -1,0 +1,10 @@
+@use "../../../../scss/variables";
+
+.flex {
+  display: flex;
+  gap: variables.$spacing-xl;
+}
+
+.countdownItem {
+  text-align: center;
+}

--- a/airbyte-webapp/src/components/experiments/SpeedyConnection/CountDownTimer/CountDownTimer.tsx
+++ b/airbyte-webapp/src/components/experiments/SpeedyConnection/CountDownTimer/CountDownTimer.tsx
@@ -1,0 +1,23 @@
+import { Text } from "components/ui/Text";
+
+import styles from "./CountDownTimer.module.scss";
+import { useCountdown } from "./use-countdown";
+export const CountDownTimer: React.FC<{ expiredOfferDate: string }> = ({ expiredOfferDate }) => {
+  const [hours, minutes, seconds] = useCountdown(expiredOfferDate);
+
+  return (
+    <div className={styles.flex}>
+      {" "}
+      <div className={styles.countdownItem}>
+        <Text bold>{hours.toString().padStart(2, "0")}</Text> <Text>hours </Text>
+      </div>
+      <div className={styles.countdownItem}>
+        <Text bold>{minutes.toString().padStart(2, "0")} </Text>
+        <Text> minutes </Text>
+      </div>
+      <div className={styles.countdownItem}>
+        <Text bold>{seconds.toString().padStart(2, "0")} </Text> <Text>seconds </Text>
+      </div>
+    </div>
+  );
+};

--- a/airbyte-webapp/src/components/experiments/SpeedyConnection/CountDownTimer/index.ts
+++ b/airbyte-webapp/src/components/experiments/SpeedyConnection/CountDownTimer/index.ts
@@ -1,0 +1,1 @@
+export * from "./CountDownTimer";

--- a/airbyte-webapp/src/components/experiments/SpeedyConnection/CountDownTimer/use-countdown.ts
+++ b/airbyte-webapp/src/components/experiments/SpeedyConnection/CountDownTimer/use-countdown.ts
@@ -1,0 +1,26 @@
+import { useEffect, useState } from "react";
+
+export const useCountdown = (targetDate: string) => {
+  const countDownDate = new Date(targetDate).getTime();
+
+  const [countDown, setCountDown] = useState(countDownDate - new Date().getTime());
+
+  useEffect(() => {
+    const interval = setInterval(() => {
+      setCountDown(countDownDate - new Date().getTime());
+    }, 1000);
+
+    return () => clearInterval(interval);
+  }, [countDownDate]);
+
+  return getReturnValues(countDown);
+};
+
+const getReturnValues = (countDown: number): number[] => {
+  // calculate time left
+  const hours = Math.floor((countDown % (1000 * 60 * 60 * 24)) / (1000 * 60 * 60));
+  const minutes = Math.floor((countDown % (1000 * 60 * 60)) / (1000 * 60));
+  const seconds = Math.floor((countDown % (1000 * 60)) / 1000);
+
+  return [hours, minutes, seconds];
+};

--- a/airbyte-webapp/src/components/experiments/SpeedyConnection/SpeedyConnectionBanner/SpeedyConnectionBanner.module.scss
+++ b/airbyte-webapp/src/components/experiments/SpeedyConnection/SpeedyConnectionBanner/SpeedyConnectionBanner.module.scss
@@ -1,0 +1,46 @@
+@use "../../../../scss/colors";
+@use "../../../../scss/variables";
+
+.container {
+  height: 100px;
+  width: 100%;
+  position: fixed;
+  top: 0;
+  z-index: 3;
+  font-size: 12px;
+  line-height: 30px;
+  color: colors.$black;
+  padding: variables.$spacing-md;
+  display: flex;
+  align-items: center;
+  background-color: colors.$dark-blue-50;
+
+  @media (min-width: 1280px) {
+    height: 50px;
+  }
+}
+
+.innerContainer {
+  display: flex;
+  flex-direction: column;
+  gap: 20px;
+  justify-content: center;
+  align-items: center;
+  width: 100%;
+  @media (min-width: 1280px) {
+    width: 80%;
+    flex-direction: row;
+    gap: 0;
+  }
+
+  margin: auto;
+}
+
+.firstColumn {
+  display: flex;
+  align-items: center;
+  justify-self: flex-start;
+  gap: variables.$spacing-xl;
+  margin-left: 40px;
+  margin-right: 40px;
+}

--- a/airbyte-webapp/src/components/experiments/SpeedyConnection/SpeedyConnectionBanner/SpeedyConnectionBanner.tsx
+++ b/airbyte-webapp/src/components/experiments/SpeedyConnection/SpeedyConnectionBanner/SpeedyConnectionBanner.tsx
@@ -1,0 +1,51 @@
+import classnames from "classnames";
+import { FormattedMessage } from "react-intl";
+import { useNavigate } from "react-router-dom";
+
+import { CountDownTimer } from "components/experiments/SpeedyConnection/CountDownTimer";
+import { Button } from "components/ui";
+import { Text } from "components/ui/Text";
+
+import { Action, Namespace } from "core/analytics";
+import { useAnalyticsService } from "hooks/services/Analytics";
+import { StepType } from "pages/OnboardingPage/types";
+import { RoutePaths } from "pages/routePaths";
+
+import { useExperimentSpeedyConnection } from "../hooks/use-experiment-speedy-connection-experiment";
+import styles from "./SpeedyConnectionBanner.module.scss";
+export const SpeedyConnectionBanner = () => {
+  const { expiredOfferDate } = useExperimentSpeedyConnection();
+  const analyticsService = useAnalyticsService();
+  const navigate = useNavigate();
+  const handleClick = () => {
+    // Send track event with experiment info
+    analyticsService.track(Namespace.ONBOARDING, Action.START, {
+      actionDescription: "Start Onboarding",
+      posthog_experiment: "exp-speedy-connection",
+    });
+    navigate(RoutePaths.Onboarding, {
+      state: {
+        step: StepType.CREATE_SOURCE,
+      },
+    });
+  };
+  return (
+    <div className={classnames(styles.container)}>
+      <div className={classnames(styles.innerContainer)}>
+        <div className={classnames(styles.firstColumn)}>
+          <Text> Set up your first connection in the next</Text>
+          <CountDownTimer {...{ expiredOfferDate }} />
+          <Text>
+            {" "}
+            and get <strong>100 </strong> additonal credits for your trial
+          </Text>
+        </div>
+        <div className={classnames(styles.secondColumn)}>
+          <Button onClick={handleClick}>
+            <FormattedMessage id="onboarding.firstConnection" />
+          </Button>
+        </div>
+      </div>
+    </div>
+  );
+};

--- a/airbyte-webapp/src/components/experiments/SpeedyConnection/SpeedyConnectionBanner/index.ts
+++ b/airbyte-webapp/src/components/experiments/SpeedyConnection/SpeedyConnectionBanner/index.ts
@@ -1,0 +1,1 @@
+export * from "./SpeedyConnectionBanner";

--- a/airbyte-webapp/src/components/experiments/SpeedyConnection/SpeedyConnectionMessage/SpeedyConnectionMessage.module.scss
+++ b/airbyte-webapp/src/components/experiments/SpeedyConnection/SpeedyConnectionMessage/SpeedyConnectionMessage.module.scss
@@ -1,0 +1,11 @@
+@use "../../../../scss/colors";
+@use "../../../../scss/variables";
+
+.message {
+  display: flex;
+  justify-content: center;
+  align-items: center;
+  flex-direction: column;
+  margin-bottom: 32px;
+  gap: 8px;
+}

--- a/airbyte-webapp/src/components/experiments/SpeedyConnection/SpeedyConnectionMessage/SpeedyConnectionMessage.tsx
+++ b/airbyte-webapp/src/components/experiments/SpeedyConnection/SpeedyConnectionMessage/SpeedyConnectionMessage.tsx
@@ -1,0 +1,39 @@
+import { FormattedMessage } from "react-intl";
+
+import { CountDownTimer } from "components/experiments/SpeedyConnection/CountDownTimer";
+import { Button } from "components/ui";
+import { Text } from "components/ui/Text";
+
+import { Action, Namespace } from "core/analytics";
+import { useAnalyticsService } from "hooks/services/Analytics";
+
+import { useExperimentSpeedyConnection } from "../hooks/use-experiment-speedy-connection-experiment";
+import styles from "./SpeedyConnectionMessage.module.scss";
+
+export const SpeedyConnectionMessage = ({ onClick }: { onClick: () => void }) => {
+  const analyticsService = useAnalyticsService();
+  const { expiredOfferDate } = useExperimentSpeedyConnection();
+  const handleClick = () => {
+    analyticsService.track(Namespace.ONBOARDING, Action.START, {
+      actionDescription: "Start Onboarding",
+      posthog_experiment: "exp-speedy-connection",
+    });
+    onClick();
+  };
+  return (
+    <>
+      <div className={styles.message}>
+        <Text> Set up your first connection in the next</Text>
+        <CountDownTimer {...{ expiredOfferDate }} />
+        <Text>
+          {" "}
+          and get <strong>100 </strong> additonal credits for your trial
+        </Text>
+      </div>
+
+      <Button size="lg" onClick={handleClick}>
+        <FormattedMessage id="onboarding.firstConnection" />
+      </Button>
+    </>
+  );
+};

--- a/airbyte-webapp/src/components/experiments/SpeedyConnection/SpeedyConnectionMessage/index.ts
+++ b/airbyte-webapp/src/components/experiments/SpeedyConnection/SpeedyConnectionMessage/index.ts
@@ -1,0 +1,1 @@
+export * from "./SpeedyConnectionMessage";

--- a/airbyte-webapp/src/components/experiments/SpeedyConnection/hooks/use-experiment-speedy-connection-experiment.ts
+++ b/airbyte-webapp/src/components/experiments/SpeedyConnection/hooks/use-experiment-speedy-connection-experiment.ts
@@ -1,0 +1,19 @@
+import { useMemo } from "react";
+
+import { usePostHog } from "hooks/services/PostHogExperiment/PostHogExperimentService";
+import { useGetCloudWorkspace } from "packages/cloud/services/workspaces/CloudWorkspacesService";
+import { useCurrentWorkspace } from "services/workspaces/WorkspacesService";
+
+export const useExperimentSpeedyConnection = () => {
+  const workspace = useCurrentWorkspace();
+  const cloudWorkspace = useGetCloudWorkspace(workspace.workspaceId);
+
+  const isTrial = Boolean(cloudWorkspace.trialExpiryTimestamp);
+  const expiredOfferDate = JSON.parse(localStorage.getItem("exp-speedy-connection-timestamp") ?? "");
+
+  const { posthog } = usePostHog();
+  const isVariantEnabled = useMemo(() => posthog.getFeatureFlag("exp-speedy-connection") === "test", [posthog]);
+  const now = new Date();
+  const isExperimentVariant = isTrial && expiredOfferDate && new Date(expiredOfferDate) >= now && isVariantEnabled;
+  return { isExperimentVariant, expiredOfferDate };
+};

--- a/airbyte-webapp/src/core/analytics/types.ts
+++ b/airbyte-webapp/src/core/analytics/types.ts
@@ -27,6 +27,7 @@ export const enum Action {
   SELECTION_OPENED = "SelectionOpened",
   CHECKOUT_START = "CheckoutStart",
   LOAD_MORE_JOBS = "LoadMoreJobs",
+  START = "Start",
 }
 
 export type EventParams = Record<string, unknown>;

--- a/airbyte-webapp/src/packages/cloud/cloudRoutes.tsx
+++ b/airbyte-webapp/src/packages/cloud/cloudRoutes.tsx
@@ -3,6 +3,7 @@ import { Navigate, Route, Routes, useLocation } from "react-router-dom";
 import { useEffectOnce } from "react-use";
 
 import ApiErrorBoundary from "components/ApiErrorBoundary";
+import { useExperimentSpeedyConnection } from "components/experiments/SpeedyConnection/hooks/use-experiment-speedy-connection-experiment";
 import LoadingPage from "components/LoadingPage";
 
 import { useAnalyticsIdentifyUser, useAnalyticsRegisterValues } from "hooks/services/Analytics/useAnalyticsService";
@@ -83,6 +84,8 @@ const MainRoutes: React.FC = () => {
 
   const mainNavigate = workspace.displaySetupWizard ? RoutePaths.Onboarding : RoutePaths.Connections;
 
+  // exp-speedy-connection
+  const { isExperimentVariant } = useExperimentSpeedyConnection();
   return (
     <ApiErrorBoundary>
       <Routes>
@@ -92,7 +95,7 @@ const MainRoutes: React.FC = () => {
         <Route path={`${RoutePaths.Settings}/*`} element={<CloudSettingsPage />} />
         <Route path={CloudRoutes.Credits} element={<CreditsPage />} />
 
-        {workspace.displaySetupWizard && (
+        {(workspace.displaySetupWizard || isExperimentVariant) && (
           <Route
             path={RoutePaths.Onboarding}
             element={

--- a/airbyte-webapp/src/packages/cloud/services/auth/AuthService.tsx
+++ b/airbyte-webapp/src/packages/cloud/services/auth/AuthService.tsx
@@ -258,7 +258,10 @@ export const AuthenticationProvider: React.FC<React.PropsWithChildren<unknown>> 
       }): Promise<void> {
         // Create a user account in firebase
         const { user: firebaseUser } = await authService.signUp(form.email, form.password);
-
+        localStorage.setItem(
+          "exp-speedy-connection-timestamp",
+          JSON.stringify(new Date(new Date().getTime() + 2 * 60 * 60 * 1000))
+        );
         // Create a user in our database for that firebase user
         await createAirbyteUser(firebaseUser, { name: form.name, companyName: form.companyName, news: form.news });
 

--- a/airbyte-webapp/src/packages/cloud/views/layout/MainView/MainView.tsx
+++ b/airbyte-webapp/src/packages/cloud/views/layout/MainView/MainView.tsx
@@ -1,16 +1,18 @@
 import classNames from "classnames";
 import React, { useMemo } from "react";
 import { FormattedMessage, useIntl } from "react-intl";
-import { Link, Outlet } from "react-router-dom";
+import { Link, Outlet, useLocation } from "react-router-dom";
 
 import { LoadingPage } from "components";
+import { useExperimentSpeedyConnection } from "components/experiments/SpeedyConnection/hooks/use-experiment-speedy-connection-experiment";
+import { SpeedyConnectionBanner } from "components/experiments/SpeedyConnection/SpeedyConnectionBanner";
 import { AlertBanner } from "components/ui/Banner/AlertBanner";
 
 import { CloudRoutes } from "packages/cloud/cloudRoutes";
 import { CreditStatus } from "packages/cloud/lib/domain/cloudWorkspaces/types";
 import { useGetCloudWorkspace } from "packages/cloud/services/workspaces/CloudWorkspacesService";
 import SideBar from "packages/cloud/views/layout/SideBar";
-import { useCurrentWorkspace } from "services/workspaces/WorkspacesService";
+import { useCurrentWorkspace, useCurrentWorkspaceState } from "services/workspaces/WorkspacesService";
 import { ResourceNotFoundErrorBoundary } from "views/common/ResorceNotFoundErrorBoundary";
 import { StartOverErrorView } from "views/common/StartOverErrorView";
 
@@ -21,7 +23,6 @@ const MainView: React.FC<React.PropsWithChildren<unknown>> = (props) => {
   const { formatMessage } = useIntl();
   const workspace = useCurrentWorkspace();
   const cloudWorkspace = useGetCloudWorkspace(workspace.workspaceId);
-
   const showCreditsBanner =
     cloudWorkspace.creditStatus &&
     [
@@ -29,9 +30,23 @@ const MainView: React.FC<React.PropsWithChildren<unknown>> = (props) => {
       CreditStatus.NEGATIVE_MAX_THRESHOLD,
       CreditStatus.NEGATIVE_WITHIN_GRACE_PERIOD,
     ].includes(cloudWorkspace.creditStatus) &&
-    !cloudWorkspace.trialExpiryTimestamp;
+    !Boolean(cloudWorkspace.trialExpiryTimestamp);
 
-  const alertToShow = showCreditsBanner ? "credits" : cloudWorkspace.trialExpiryTimestamp ? "trial" : undefined;
+  const alertToShow = showCreditsBanner
+    ? "credits"
+    : Boolean(cloudWorkspace.trialExpiryTimestamp)
+    ? "trial"
+    : undefined;
+
+  // exp-speedy-connection
+  const { isExperimentVariant } = useExperimentSpeedyConnection();
+  const location = useLocation();
+  const { hasConnections } = useCurrentWorkspaceState();
+  const showExperimentBanner =
+    isExperimentVariant &&
+    !location.pathname.includes("onboarding") &&
+    !location.pathname.includes("new") &&
+    !hasConnections;
 
   const alertMessage = useMemo(() => {
     if (alertToShow === "credits") {
@@ -63,7 +78,7 @@ const MainView: React.FC<React.PropsWithChildren<unknown>> = (props) => {
       <InsufficientPermissionsErrorBoundary errorComponent={<StartOverErrorView />}>
         <SideBar />
         <div className={classNames(styles.content, { [styles.alertBanner]: !!alertToShow })}>
-          {alertToShow && <AlertBanner message={alertMessage} />}
+          {showExperimentBanner ? <SpeedyConnectionBanner /> : alertToShow && <AlertBanner message={alertMessage} />}
           <div className={styles.dataBlock}>
             <ResourceNotFoundErrorBoundary errorComponent={<StartOverErrorView />}>
               <React.Suspense fallback={<LoadingPage />}>{props.children ?? <Outlet />}</React.Suspense>

--- a/airbyte-webapp/src/pages/OnboardingPage/OnboardingPage.tsx
+++ b/airbyte-webapp/src/pages/OnboardingPage/OnboardingPage.tsx
@@ -1,7 +1,6 @@
 import React, { Suspense, useState } from "react";
 import { FormattedMessage } from "react-intl";
 import { useNavigate } from "react-router-dom";
-import { useEffectOnce } from "react-use";
 import styled from "styled-components";
 
 import { Button } from "components";
@@ -9,7 +8,7 @@ import ApiErrorBoundary from "components/ApiErrorBoundary";
 import HeadTitle from "components/HeadTitle";
 import LoadingPage from "components/LoadingPage";
 
-import { useAnalyticsService, useTrackPage, PageTrackingCodes } from "hooks/services/Analytics";
+import { useTrackPage, PageTrackingCodes } from "hooks/services/Analytics";
 import useWorkspace from "hooks/services/useWorkspace";
 import { useCurrentWorkspaceState } from "services/workspaces/WorkspacesService";
 import { ConnectorDocumentationWrapper } from "views/Connector/ConnectorDocumentationLayout";
@@ -60,14 +59,9 @@ const TITLE_BY_STEP: Partial<Record<StepType, string>> = {
 };
 
 const OnboardingPage: React.FC = () => {
-  const analyticsService = useAnalyticsService();
   useTrackPage(PageTrackingCodes.ONBOARDING);
 
   const navigate = useNavigate();
-
-  useEffectOnce(() => {
-    analyticsService.page("Onboarding Page");
-  });
 
   const { finishOnboarding } = useWorkspace();
   const { hasConnections, hasDestinations, hasSources } = useCurrentWorkspaceState();

--- a/airbyte-webapp/src/pages/OnboardingPage/components/WelcomeStep.tsx
+++ b/airbyte-webapp/src/pages/OnboardingPage/components/WelcomeStep.tsx
@@ -3,6 +3,8 @@ import { FormattedMessage } from "react-intl";
 import styled from "styled-components";
 
 import { Button } from "components";
+import { useExperimentSpeedyConnection } from "components/experiments/SpeedyConnection/hooks/use-experiment-speedy-connection-experiment";
+import { SpeedyConnectionMessage } from "components/experiments/SpeedyConnection/SpeedyConnectionMessage";
 
 import { useConfig } from "config";
 
@@ -27,6 +29,7 @@ const Videos = styled.div`
 
 const WelcomeStep: React.FC<WelcomeStepProps> = ({ userName, onNextStep }) => {
   const config = useConfig();
+  const { isExperimentVariant } = useExperimentSpeedyConnection();
 
   return (
     <>
@@ -68,9 +71,13 @@ const WelcomeStep: React.FC<WelcomeStepProps> = ({ userName, onNextStep }) => {
           link={config.links.demoLink}
         />
       </Videos>
-      <Button size="lg" onClick={onNextStep}>
-        <FormattedMessage id="onboarding.firstConnection" />
-      </Button>
+      {isExperimentVariant ? (
+        <SpeedyConnectionMessage onClick={onNextStep} />
+      ) : (
+        <Button size="lg" onClick={onNextStep}>
+          <FormattedMessage id="onboarding.firstConnection" />
+        </Button>
+      )}
     </>
   );
 };


### PR DESCRIPTION
**Control group** [Demo](https://www.loom.com/share/447fd8a8ddca4f70b634b23b86d81bb7) 
 - [x]  Banner shouldn’t be displayed 
 - [x]  Timer on onboarding shouldn’t be displayed

**Test group**  [Demo](https://www.loom.com/share/63a4a52a81d5414bb0d13a66890922a3)
 - [x] Timer is set on localStorage 
 - [x]  Timer on onboarding is displayed `SpeedyConnectionMessage` 
 - [x] Banner is displayed when the user is not on an onboarding page and hasn’t set up any connections yet `SpeedyConnectionBanner` 
 - [x] We track the following events
      - [x]  `Airbyte.Ui.Onboarding.Start` : new track event, includes `posthog_experiments`
      - [x]  `Airbyte.UI.Connection.Create`: includes `posthog_experiments`
