### PR TITLE
example pokeapi with new protocol

### DIFF
--- a/airbyte-config/config-models/src/main/resources/types/WellKnownTypes.yaml
+++ b/airbyte-config/config-models/src/main/resources/types/WellKnownTypes.yaml
@@ -1,0 +1,51 @@
+# Regexes are purely illustrative and need to be workshopped: BC dates shouldn't require 4-digit years; years may have >=5 digits; etc
+definitions:
+  String:
+    type: string
+    description: Arbitrary text
+  BinaryData:
+    type: string
+    description: >
+      Arbitrary binary data. Represented as base64-encoded strings in the JSON transport.
+      In the future, if we support other transports, may be encoded differently.
+    # All credit to https://stackoverflow.com/a/475217 for this pattern
+    pattern: (?:[A-Za-z0-9+/]{4})*(?:[A-Za-z0-9+/]{2}==|[A-Za-z0-9+/]{3}=)?
+  Date:
+    type: string
+    # format: date is a superset of what we want, so we cannot use it here (e.g. it accepts 2-digit years)
+    pattern: \d{4}-\d{2}-\d{2}( BC)?
+  TimestampWithTimezone:
+    type: string
+    # format: date-time is a superset of what we want, so we cannot use it here (e.g. it accepts 2-digit years)
+    pattern: \d{4}-\d{2}-\d{2}[T ]\d{2}:\d{2}:\d{2}(\.\d+)?(Z|[+-]\d{1,2}(:\d{2})?)( BC)?
+    description: An instant in time. Frequently simply referred to as just a timestamp, or timestamptz.
+  TimestampWithoutTimezone:
+    type: string
+    pattern: \d{4}-\d{2}-\d{2}[T ]\d{2}:\d{2}:\d{2}(\.\d+)?( BC)?
+    description: Also known as a localdatetime, or just datetime.
+  TimeWithTimezone:
+    type: string
+    pattern: \d{2}:\d{2}:\d{2}(\.\d+)?(Z|[+-]\d{1,2}(:\d{2})?)
+  TimeWithoutTimezone:
+    type: string
+    pattern: \d{2}:\d{2}:\d{2}(\.\d+)?
+  Number:
+    type: string
+    # Note the mix of regex validation for normal numbers, and enum validation for special values
+    oneOf:
+      - pattern: -?(0|[0-9]\d*)(\.\d+)?
+      - enum:
+          - Infinity
+          - -Infinity
+          - NaN
+  Integer:
+    type: string
+    oneOf:
+      - pattern: -?(0|[0-9]\d*)
+      - enum:
+          - Infinity
+          - -Infinity
+          - NaN
+  Boolean:
+    # Note the direct usage of a primitive boolean rather than string. Unlike Numbers and Integers, we don't expect unusual values  here.
+    type: boolean

--- a/airbyte-integrations/connectors/source-pokeapi/acceptance-test-config.yml
+++ b/airbyte-integrations/connectors/source-pokeapi/acceptance-test-config.yml
@@ -7,6 +7,9 @@ tests:
       status: "succeed"
   discovery:
     - config_path: "integration_tests/config.json"
+      backward_compatibility_tests_config:
+        # this change is technically breaking because it removes the `null` types.
+        disable_for_version: "0.1.5"
   basic_read:
     - config_path: "integration_tests/config.json"
       configured_catalog_path: "integration_tests/configured_catalog.json"

--- a/airbyte-integrations/connectors/source-pokeapi/source_pokeapi/schemas/pokemon.json
+++ b/airbyte-integrations/connectors/source-pokeapi/source_pokeapi/schemas/pokemon.json
@@ -3,7 +3,13 @@
   "type": "object",
   "properties": {
     "id": {
-      "$ref": "WellKnownTypes.json#definitions/Integer"
+      "$ref": "WellKnownTypes.json#definitions/Integer",
+      "airbyte_attributes": {
+        "precision": {
+          "type": "bit_width",
+          "bit_width": 32
+        }
+      }
     },
     "name": {
       "$ref": "WellKnownTypes.json#definitions/String"

--- a/airbyte-integrations/connectors/source-pokeapi/source_pokeapi/schemas/pokemon.json
+++ b/airbyte-integrations/connectors/source-pokeapi/source_pokeapi/schemas/pokemon.json
@@ -3,25 +3,25 @@
   "type": "object",
   "properties": {
     "id": {
-      "type": ["null", "integer"]
+      "$ref": "WellKnownTypes.json#definitions/Integer"
     },
     "name": {
-      "type": ["null", "string"]
+      "$ref": "WellKnownTypes.json#definitions/String"
     },
     "base_experience": {
-      "type": ["null", "integer"]
+      "$ref": "WellKnownTypes.json#definitions/Integer"
     },
     "height": {
-      "type": ["null", "integer"]
+      "$ref": "WellKnownTypes.json#definitions/Integer"
     },
     "is_default ": {
-      "type": ["null", "boolean"]
+      "$ref": "WellKnownTypes.json#definitions/Boolean"
     },
     "order": {
-      "type": ["null", "integer"]
+      "$ref": "WellKnownTypes.json#definitions/Integer"
     },
     "weight": {
-      "type": ["null", "integer"]
+      "$ref": "WellKnownTypes.json#definitions/Integer"
     },
     "abilities": {
       "type": ["null", "array"],
@@ -29,19 +29,19 @@
         "type": ["null", "object"],
         "properties": {
           "is_hidden": {
-            "type": ["null", "boolean"]
+            "$ref": "WellKnownTypes.json#definitions/Boolean"
           },
           "slot": {
-            "type": ["null", "integer"]
+            "$ref": "WellKnownTypes.json#definitions/Integer"
           },
           "ability": {
             "type": ["null", "object"],
             "properties": {
               "name": {
-                "type": ["null", "string"]
+                "$ref": "WellKnownTypes.json#definitions/String"
               },
               "url": {
-                "type": ["null", "string"]
+                "$ref": "WellKnownTypes.json#definitions/String"
               }
             }
           }
@@ -54,10 +54,10 @@
         "type": ["null", "object"],
         "properties": {
           "name": {
-            "type": ["null", "string"]
+            "$ref": "WellKnownTypes.json#definitions/String"
           },
           "url": {
-            "type": ["null", "string"]
+            "$ref": "WellKnownTypes.json#definitions/String"
           }
         }
       }
@@ -68,16 +68,16 @@
         "type": ["null", "object"],
         "properties": {
           "game_index": {
-            "type": ["null", "integer"]
+            "$ref": "WellKnownTypes.json#definitions/Integer"
           },
           "version": {
             "type": ["null", "object"],
             "properties": {
               "name": {
-                "type": ["null", "string"]
+                "$ref": "WellKnownTypes.json#definitions/String"
               },
               "url": {
-                "type": ["null", "string"]
+                "$ref": "WellKnownTypes.json#definitions/String"
               }
             }
           }
@@ -93,10 +93,10 @@
             "type": ["null", "object"],
             "properties": {
               "name": {
-                "type": ["null", "string"]
+                "$ref": "WellKnownTypes.json#definitions/String"
               },
               "url": {
-                "type": ["null", "string"]
+                "$ref": "WellKnownTypes.json#definitions/String"
               }
             }
           },
@@ -109,15 +109,15 @@
                   "type": ["null", "object"],
                   "properties": {
                     "name": {
-                      "type": ["null", "string"]
+                      "$ref": "WellKnownTypes.json#definitions/String"
                     },
                     "url": {
-                      "type": ["null", "string"]
+                      "$ref": "WellKnownTypes.json#definitions/String"
                     }
                   }
                 },
                 "rarity": {
-                  "type": ["null", "integer"]
+                  "$ref": "WellKnownTypes.json#definitions/Integer"
                 }
               }
             }
@@ -126,7 +126,7 @@
       }
     },
     "location_area_encounters": {
-      "type": ["null", "string"]
+      "$ref": "WellKnownTypes.json#definitions/String"
     },
     "moves": {
       "type": ["null", "array"],
@@ -137,10 +137,10 @@
             "type": ["null", "object"],
             "properties": {
               "name": {
-                "type": ["null", "string"]
+                "$ref": "WellKnownTypes.json#definitions/String"
               },
               "url": {
-                "type": ["null", "string"]
+                "$ref": "WellKnownTypes.json#definitions/String"
               }
             }
           },
@@ -153,10 +153,10 @@
                   "type": ["null", "object"],
                   "properties": {
                     "name": {
-                      "type": ["null", "string"]
+                      "$ref": "WellKnownTypes.json#definitions/String"
                     },
                     "url": {
-                      "type": ["null", "string"]
+                      "$ref": "WellKnownTypes.json#definitions/String"
                     }
                   }
                 },
@@ -164,15 +164,15 @@
                   "type": ["null", "object"],
                   "properties": {
                     "name": {
-                      "type": ["null", "string"]
+                      "$ref": "WellKnownTypes.json#definitions/String"
                     },
                     "url": {
-                      "type": ["null", "string"]
+                      "$ref": "WellKnownTypes.json#definitions/String"
                     }
                   }
                 },
                 "level_learned_at": {
-                  "type": ["null", "integer"]
+                  "$ref": "WellKnownTypes.json#definitions/Integer"
                 }
               }
             }
@@ -184,28 +184,28 @@
       "type": ["null", "object"],
       "properties": {
         "front_default": {
-          "type": ["null", "string"]
+          "$ref": "WellKnownTypes.json#definitions/String"
         },
         "front_shiny": {
-          "type": ["null", "string"]
+          "$ref": "WellKnownTypes.json#definitions/String"
         },
         "front_female": {
-          "type": ["null", "string"]
+          "$ref": "WellKnownTypes.json#definitions/String"
         },
         "front_shiny_female": {
-          "type": ["null", "string"]
+          "$ref": "WellKnownTypes.json#definitions/String"
         },
         "back_default": {
-          "type": ["null", "string"]
+          "$ref": "WellKnownTypes.json#definitions/String"
         },
         "back_shiny": {
-          "type": ["null", "string"]
+          "$ref": "WellKnownTypes.json#definitions/String"
         },
         "back_female": {
-          "type": ["null", "string"]
+          "$ref": "WellKnownTypes.json#definitions/String"
         },
         "back_shiny_female": {
-          "type": ["null", "string"]
+          "$ref": "WellKnownTypes.json#definitions/String"
         }
       }
     },
@@ -213,10 +213,10 @@
       "type": ["null", "object"],
       "properties": {
         "name": {
-          "type": ["null", "string"]
+          "$ref": "WellKnownTypes.json#definitions/String"
         },
         "url": {
-          "type": ["null", "string"]
+          "$ref": "WellKnownTypes.json#definitions/String"
         }
       }
     },
@@ -229,18 +229,18 @@
             "type": ["null", "object"],
             "properties": {
               "name": {
-                "type": ["null", "string"]
+                "$ref": "WellKnownTypes.json#definitions/String"
               },
               "url": {
-                "type": ["null", "string"]
+                "$ref": "WellKnownTypes.json#definitions/String"
               }
             }
           },
           "effort": {
-            "type": ["null", "integer"]
+            "$ref": "WellKnownTypes.json#definitions/Integer"
           },
           "base_stat": {
-            "type": ["null", "integer"]
+            "$ref": "WellKnownTypes.json#definitions/Integer"
           }
         }
       }
@@ -251,16 +251,16 @@
         "type": ["null", "object"],
         "properties": {
           "slot": {
-            "type": ["null", "integer"]
+            "$ref": "WellKnownTypes.json#definitions/Integer"
           },
           "type": {
             "type": ["null", "object"],
             "properties": {
               "name": {
-                "type": ["null", "string"]
+                "$ref": "WellKnownTypes.json#definitions/String"
               },
               "url": {
-                "type": ["null", "string"]
+                "$ref": "WellKnownTypes.json#definitions/String"
               }
             }
           }

--- a/airbyte-integrations/connectors/source-pokeapi/source_pokeapi/schemas/shared/WellKnownTypes.json
+++ b/airbyte-integrations/connectors/source-pokeapi/source_pokeapi/schemas/shared/WellKnownTypes.json
@@ -1,0 +1,60 @@
+{
+  "definitions": {
+    "String": {
+      "type": "string",
+      "description": "Arbitrary text"
+    },
+    "BinaryData": {
+      "type": "string",
+      "description": "Arbitrary binary data. Represented as base64-encoded strings in the JSON transport. In the future, if we support other transports, may be encoded differently.\n",
+      "pattern": "(?:[A-Za-z0-9+/]{4})*(?:[A-Za-z0-9+/]{2}==|[A-Za-z0-9+/]{3}=)?"
+    },
+    "Date": {
+      "type": "string",
+      "pattern": "\\d{4}-\\d{2}-\\d{2}( BC)?"
+    },
+    "TimestampWithTimezone": {
+      "type": "string",
+      "pattern": "\\d{4}-\\d{2}-\\d{2}[T ]\\d{2}:\\d{2}:\\d{2}(\\.\\d+)?(Z|[+-]\\d{1,2}(:\\d{2})?)( BC)?",
+      "description": "An instant in time. Frequently simply referred to as just a timestamp, or timestamptz."
+    },
+    "TimestampWithoutTimezone": {
+      "type": "string",
+      "pattern": "\\d{4}-\\d{2}-\\d{2}[T ]\\d{2}:\\d{2}:\\d{2}(\\.\\d+)?( BC)?",
+      "description": "Also known as a localdatetime, or just datetime."
+    },
+    "TimeWithTimezone": {
+      "type": "string",
+      "pattern": "\\d{2}:\\d{2}:\\d{2}(\\.\\d+)?(Z|[+-]\\d{1,2}(:\\d{2})?)"
+    },
+    "TimeWithoutTimezone": {
+      "type": "string",
+      "pattern": "\\d{2}:\\d{2}:\\d{2}(\\.\\d+)?"
+    },
+    "Number": {
+      "type": "string",
+      "oneOf": [
+        {
+          "pattern": "-?(0|[0-9]\\d*)(\\.\\d+)?"
+        },
+        {
+          "enum": ["Infinity", "-Infinity", "NaN"]
+        }
+      ]
+    },
+    "Integer": {
+      "type": "string",
+      "oneOf": [
+        {
+          "pattern": "-?(0|[0-9]\\d*)"
+        },
+        {
+          "enum": ["Infinity", "-Infinity", "NaN"]
+        }
+      ]
+    },
+    "Boolean": {
+      "type": "boolean"
+    }
+  }
+}

--- a/airbyte-integrations/connectors/source-pokeapi/source_pokeapi/source.py
+++ b/airbyte-integrations/connectors/source-pokeapi/source_pokeapi/source.py
@@ -9,6 +9,7 @@ import requests
 from airbyte_cdk.sources import AbstractSource
 from airbyte_cdk.sources.streams import Stream
 from airbyte_cdk.sources.streams.http import HttpStream
+from airbyte_cdk.sources.utils.transform import TransformConfig, TypeTransformer
 
 from . import pokemon_list
 
@@ -49,6 +50,8 @@ class PokeapiStream(HttpStream):
 class Pokemon(PokeapiStream):
     # Set this as a noop.
     primary_key = None
+
+    transformer: TypeTransformer = TypeTransformer(TransformConfig.DefaultSchemaNormalization)
 
     def path(self, **kwargs) -> str:
         pokemon_name = self.pokemon_name


### PR DESCRIPTION
An example port of source-pokeapi to the updated protocol version described in https://github.com/airbytehq/airbyte/pull/17486. Specifically:
* the schema is updated to reference well-known types
* `source.py` uses the default type transformer to wrap numeric values into strings

This PR also demonstrates `airbyte_attributes`.

See comments below for further details - https://github.com/airbytehq/airbyte/pull/17489#pullrequestreview-1129004870