### PR TITLE
🪟 🔧 Add Orb service to be able to add free credits

### DIFF
--- a/airbyte-webapp/src/packages/cloud/lib/domain/orb/OrbService.tsx
+++ b/airbyte-webapp/src/packages/cloud/lib/domain/orb/OrbService.tsx
@@ -1,0 +1,47 @@
+import { AddTrialCreditsResponse, OrbCreditLedgerEntry, OrbCustomer } from "./types";
+
+export type AddTrialCreditsRequest = Pick<OrbCreditLedgerEntry, "amount" | "expiry_date"> & { customerId: string };
+
+// TODO: this can be improved to have one different IDEMPOTENCY_KEY per experiment
+const EXP_ADD_TRIAL_CREDITS_IDEMPOTENCY_KEY = "exp-speedy-connection-";
+
+export class OrbService {
+  get baseUrl(): string {
+    return "https://api.billwithorb.com/v1";
+  }
+
+  async addTrialCredits({ customerId, amount, expiry_date }: AddTrialCreditsRequest): Promise<AddTrialCreditsResponse> {
+    const path = `${this.baseUrl}/customers/${customerId}/credits/ledger_entry`;
+
+    const requestOptions: RequestInit = {
+      method: "POST",
+      body: JSON.stringify({
+        entry_type: "increment",
+        amount,
+        expiry_date,
+        per_unit_cost_basis: "0",
+        description: `Added ${amount} free trial credits`,
+      }),
+      headers: {
+        Authorization: `Bearer ${process.env.REACT_APP_ORB_KEY}`,
+        "Content-Type": "application/json",
+        "Idempotency-Key": EXP_ADD_TRIAL_CREDITS_IDEMPOTENCY_KEY + customerId,
+      },
+    };
+    const response = await fetch(path, requestOptions);
+    return await response.json();
+  }
+
+  async getCustomerIdByExternalId(external_customer_id: string): Promise<OrbCustomer> {
+    const path = `${this.baseUrl}/customers/external_customer_id/${external_customer_id}`;
+    const requestOptions: RequestInit = {
+      method: "GET",
+      headers: {
+        Authorization: `Bearer ${process.env.REACT_APP_ORB_KEY}`,
+        "Content-Type": "application/json",
+      },
+    };
+    const response = await fetch(path, requestOptions);
+    return await response.json();
+  }
+}

--- a/airbyte-webapp/src/packages/cloud/lib/domain/orb/types.tsx
+++ b/airbyte-webapp/src/packages/cloud/lib/domain/orb/types.tsx
@@ -1,0 +1,43 @@
+export interface OrbCreditLedgerEntry {
+  entry_type: "increment" | "decrement" | "expiration_change";
+  amount: number;
+  expiry_date?: string;
+  description: string;
+  per_unit_cost_basis: string;
+}
+
+export interface AddTrialCreditsResponse {
+  amount: number;
+  created_at: string;
+  credit_block: {
+    expiry_date: string;
+    id: string;
+    per_unit_cost_basis: string | null;
+  };
+  customer: {
+    external_customer_id: string;
+    id: string;
+  };
+  description: string;
+  ending_balance: number;
+  entry_type: "increment" | "decrement" | "expiration_change";
+  id: string;
+  starting_balance: number;
+  entry_status: "commited" | "pending";
+  ledger_sequence_number: number;
+}
+
+export interface OrbCustomer {
+  balance: string;
+  billing_address: string | null;
+  created_at: string;
+  currency: string;
+  email: string;
+  external_customer_id: string;
+  id: string;
+  name: string;
+  payment_provider: string | null;
+  payment_provider_id: string | null;
+  shipping_address: string | null;
+  timezone: string;
+}

--- a/airbyte-webapp/src/packages/cloud/services/orb/OrbService.tsx
+++ b/airbyte-webapp/src/packages/cloud/services/orb/OrbService.tsx
@@ -1,0 +1,28 @@
+import { useMemo } from "react";
+import { useMutation, useQuery } from "react-query";
+
+import { AddTrialCreditsRequest, OrbService } from "packages/cloud/lib/domain/orb/OrbService";
+import { useCurrentWorkspace } from "services/workspaces/WorkspacesService";
+
+import { useGetCloudWorkspace } from "../workspaces/CloudWorkspacesService";
+
+export const useAddTrialCreditsMutation = () => {
+  const service = useMemo(() => new OrbService(), []);
+  const workspace = useCurrentWorkspace();
+  const { trialExpiryTimestamp } = useGetCloudWorkspace(workspace.workspaceId);
+  const expiry_date = trialExpiryTimestamp ? new Date(trialExpiryTimestamp).toISOString().slice(0, 10) : undefined;
+
+  const customerIdQuery = useQuery("orb-customer-id", () => service.getCustomerIdByExternalId(workspace.workspaceId), {
+    select: (data) => ({ customerId: data.id }),
+  });
+
+  const customerId = customerIdQuery.data?.customerId ?? "";
+
+  return useMutation(({ amount }: Pick<AddTrialCreditsRequest, "amount">) =>
+    service.addTrialCredits({
+      amount,
+      customerId,
+      expiry_date,
+    })
+  );
+};


### PR DESCRIPTION
## What
Usually we handle everything related to Orb in `airbyte-cloud` but we need the ability to add some free trial credits from the FE for an experiment that we are building #17469.

Context: https://airbytehq-team.slack.com/archives/C03A8CSANPQ/p1664270118103639

## How
- Create OrbService and needed queries/mutations for adding free trial credits.

TODO 
- add orb api key as env variable
