### PR TITLE
Publish file-secure

### DIFF
--- a/airbyte-integrations/connectors/source-file-secure/Dockerfile
+++ b/airbyte-integrations/connectors/source-file-secure/Dockerfile
@@ -1,4 +1,4 @@
-FROM airbyte/source-file:0.2.22
+FROM airbyte/source-file:0.2.24
 
 WORKDIR /airbyte/integration_code
 COPY source_file_secure ./source_file_secure
@@ -9,5 +9,5 @@ RUN pip install .
 ENV AIRBYTE_ENTRYPOINT "python /airbyte/integration_code/main.py"
 ENTRYPOINT ["python", "/airbyte/integration_code/main.py"]
 
-LABEL io.airbyte.version=0.2.23
+LABEL io.airbyte.version=0.2.24
 LABEL io.airbyte.name=airbyte/source-file-secure

--- a/airbyte-integrations/connectors/source-file/README.md
+++ b/airbyte-integrations/connectors/source-file/README.md
@@ -138,7 +138,8 @@ All of your dependencies should go in `setup.py`, NOT `requirements.txt`. The re
 ### Publishing a new version of the connector
 You've checked out the repo, implemented a million dollar feature, and you're ready to share your changes with the world. Now what?
 1. Make sure your changes are passing unit and integration tests
-1. Bump the connector version in `Dockerfile` -- just increment the value of the `LABEL io.airbyte.version` appropriately (we use SemVer).
-1. Create a Pull Request
-1. Pat yourself on the back for being an awesome contributor
-1. Someone from Airbyte will take a look at your PR and iterate with you to merge it into master
+2. Bump the connector version in `Dockerfile` -- just increment the value of the `LABEL io.airbyte.version` appropriately (we use SemVer).
+3. In addition to bumping the connector version of `source-file`, you must also increment the version of `source-file-secure` which depends on this source. The versions of these connectors should always remain in sync. Depending on the changes to `source-file`, you may also need to make changes to `source-file-secure` to retain compatibility.
+4. Create a Pull Request
+5. Pat yourself on the back for being an awesome contributor
+6. Someone from Airbyte will take a look at your PR and iterate with you to merge it into master


### PR DESCRIPTION
## What
We forgot to publish `source-file-secure` with the latest publish of `source-file`. This should get the latest image up to Dockerhub

## How
*Describe the solution*