### PR TITLE
Base Normalization: improve error msg if `cursor_field` missed in schema

### DIFF
--- a/airbyte-integrations/bases/base-normalization/Dockerfile
+++ b/airbyte-integrations/bases/base-normalization/Dockerfile
@@ -28,5 +28,5 @@ WORKDIR /airbyte
 ENV AIRBYTE_ENTRYPOINT "/airbyte/entrypoint.sh"
 ENTRYPOINT ["/airbyte/entrypoint.sh"]
 
-LABEL io.airbyte.version=0.2.22
+LABEL io.airbyte.version=0.2.23
 LABEL io.airbyte.name=airbyte/normalization

--- a/airbyte-integrations/bases/base-normalization/normalization/transform_catalog/stream_processor.py
+++ b/airbyte-integrations/bases/base-normalization/normalization/transform_catalog/stream_processor.py
@@ -1019,11 +1019,14 @@ from dedup_data where {{ airbyte_row_num }} = 1
         if not self.cursor_field:
             cursor = self.name_transformer.normalize_column_name(self.get_cursor_field_property_name(column_names), in_jinja)
         elif len(self.cursor_field) == 1:
-            if not is_airbyte_column(self.cursor_field[0]):
-                cursor = column_names[self.cursor_field[0]][0]
+            cursor_field = self.cursor_field[0]
+            if not is_airbyte_column(cursor_field):
+                if cursor_field not in column_names:
+                    raise ValueError(f"cursor field: '{cursor_field}' missed in schema for stream '{self.stream_name}'")
+                cursor = column_names[cursor_field][0]
             else:
                 # using an airbyte generated column
-                cursor = self.cursor_field[0]
+                cursor = cursor_field
         else:
             raise ValueError(f"Unsupported nested cursor field {'.'.join(self.cursor_field)} for stream {self.stream_name}")
         return cursor

--- a/airbyte-workers/src/main/java/io/airbyte/workers/normalization/NormalizationRunnerFactory.java
+++ b/airbyte-workers/src/main/java/io/airbyte/workers/normalization/NormalizationRunnerFactory.java
@@ -14,7 +14,7 @@ import org.apache.commons.lang3.tuple.ImmutablePair;
 public class NormalizationRunnerFactory {
 
   public static final String BASE_NORMALIZATION_IMAGE_NAME = "airbyte/normalization";
-  public static final String NORMALIZATION_VERSION = "0.2.22";
+  public static final String NORMALIZATION_VERSION = "0.2.23";
 
   static final Map<String, ImmutablePair<String, DefaultNormalizationRunner.DestinationType>> NORMALIZATION_MAPPING =
       ImmutableMap.<String, ImmutablePair<String, DefaultNormalizationRunner.DestinationType>>builder()

--- a/docs/understanding-airbyte/basic-normalization.md
+++ b/docs/understanding-airbyte/basic-normalization.md
@@ -353,6 +353,7 @@ Therefore, in order to "upgrade" to the desired normalization version, you need 
 
 | Airbyte Version | Normalization Version | Date       | Pull Request                                                | Subject                                                                                                              |
 |:----------------|:----------------------|:-----------|:------------------------------------------------------------|:---------------------------------------------------------------------------------------------------------------------|
+|                 | 0.2.23                | 2022-10-04 | [\#17549](https://github.com/airbytehq/airbyte/pull/17549)  | Improve error msg if `cursor_field` missed in schema                                                                 |
 |                 | 0.2.22                | 2022-09-05 | [\#16339](https://github.com/airbytehq/airbyte/pull/16339)  | Update Clickhouse DBT to 1.1.8                                                                                       |
 |                 | 0.2.21                | 2022-09-09 | [\#15833](https://github.com/airbytehq/airbyte/pull/15833/) | SSH Tunnel: allow using OPENSSH key format (published in [\#16545](https://github.com/airbytehq/airbyte/pull/16545)) |
 |                 | 0.2.20                | 2022-08-30 | [\#15592](https://github.com/airbytehq/airbyte/pull/15592)  | Add TiDB support                                                                                                     |


### PR DESCRIPTION
Signed-off-by: Sergey Chvalyuk <grubberr@gmail.com>

## What
Related to this oncall https://github.com/airbytehq/oncall/issues/573

if in "configured_catalog" `cursor_field` missed in schema fields, we get hard to understand exception

```
Traceback (most recent call last):
...
  File "/home/user/airbyte/airbyte-integrations/bases/base-normalization/normalization/transform_catalog/stream_processor.py", line 1023, in get_cursor_field
    cursor = column_names[self.cursor_field[0]][0]
KeyError: 'date_start'
```

## How
```
Traceback (most recent call last):
...
  File "/home/user/airbyte/airbyte-integrations/bases/base-normalization/normalization/transform_catalog/stream_processor.py", line 1025, in get_cursor_field
    raise ValueError(f"cursor field: '{cursor_field}' missed in schema for stream '{self.stream_name}'")
ValueError: cursor field: 'date_start' missed in schema for stream 'custom_campaign__insights_by_dma'
```