### PR TITLE
ci: build and publish cron with other oss images

### DIFF
--- a/docker-compose-cloud.buildx.yaml
+++ b/docker-compose-cloud.buildx.yaml
@@ -84,3 +84,19 @@ services:
         platforms:
           - linux/amd64
           - linux/arm64
+  cron:
+    image: airbyte/cron:${VERSION}
+    build:
+      dockerfile: Dockerfile
+      context: airbyte-cron/build/docker
+      labels:
+        io.airbyte.git-revision: ${GIT_REVISION}
+      args:
+        VERSION: ${VERSION}
+      x-bake:
+        tags:
+          - airbyte/cron:${VERSION}
+          - airbyte/cron:${ALT_TAG:-${VERSION}}
+        platforms:
+          - linux/amd64
+          - linux/arm64


### PR DESCRIPTION
This is needed for cron to be consumed downstream with the correct tag in cloud

## What
Publish cron alongside other oss images with the correct tag

## How
Adds cron to buildx setup
