### PR TITLE
Disable normalization skip when no new data

### DIFF
--- a/airbyte-workers/src/main/java/io/airbyte/workers/temporal/sync/SyncWorkflowImpl.java
+++ b/airbyte-workers/src/main/java/io/airbyte/workers/temporal/sync/SyncWorkflowImpl.java
@@ -74,8 +74,10 @@ public class SyncWorkflowImpl implements SyncWorkflow {
               shouldRun = true;
             }
             if (!shouldRun) {
-              LOGGER.info("Skipping normalization because there are no records to normalize.");
-              continue;
+              LOGGER.info("No records to normalize detected");
+              // Normalization skip has been disabled: issue #5417
+              // LOGGER.info("Skipping normalization because there are no records to normalize.");
+              // continue;
             }
           }
 

--- a/airbyte-workers/src/test/java/io/airbyte/workers/temporal/sync/SyncWorkflowTest.java
+++ b/airbyte-workers/src/test/java/io/airbyte/workers/temporal/sync/SyncWorkflowTest.java
@@ -50,6 +50,7 @@ import java.util.List;
 import org.apache.commons.lang3.tuple.ImmutablePair;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Test;
 
 @SuppressWarnings({"PMD.UnusedPrivateField", "PMD.UnusedPrivateMethod"})
@@ -312,6 +313,7 @@ class SyncWorkflowTest {
   }
 
   @Test
+  @Disabled("This behavior has been disabled temporarily (OC Issue #741)")
   void testSkipNormalization() throws IOException {
     final SyncStats syncStats = new SyncStats().withRecordsCommitted(0L);
     final StandardSyncSummary standardSyncSummary = new StandardSyncSummary().withTotalStats(syncStats);


### PR DESCRIPTION
## What

Resets require normalization to run, disable the new behavior introduced by #9672 while we figure out the missing requirements.

## How

Ignore the result from the normalization summary check.

