### PR TITLE
Add breakingChange to catalogDiff

### DIFF
--- a/airbyte-api/src/main/openapi/config.yaml
+++ b/airbyte-api/src/main/openapi/config.yaml
@@ -4204,7 +4204,7 @@ components:
       required:
         - transformType
         - fieldName
-        - isBreaking
+        - breaking
       properties:
         transformType:
           type: string
@@ -4214,7 +4214,7 @@ components:
             - update_field_schema
         fieldName:
           $ref: "#/components/schemas/FieldName"
-        isBreaking:
+        breaking:
           type: boolean
         addField:
           $ref: "#/components/schemas/FieldAdd"

--- a/airbyte-api/src/main/openapi/config.yaml
+++ b/airbyte-api/src/main/openapi/config.yaml
@@ -4204,6 +4204,7 @@ components:
       required:
         - transformType
         - fieldName
+        - isBreaking
       properties:
         transformType:
           type: string
@@ -4213,6 +4214,8 @@ components:
             - update_field_schema
         fieldName:
           $ref: "#/components/schemas/FieldName"
+        isBreaking:
+          type: boolean
         addField:
           $ref: "#/components/schemas/FieldAdd"
         removeField:

--- a/airbyte-protocol/protocol-models/src/main/java/io/airbyte/protocol/models/CatalogHelpers.java
+++ b/airbyte-protocol/protocol-models/src/main/java/io/airbyte/protocol/models/CatalogHelpers.java
@@ -23,6 +23,7 @@ import java.util.HashMap;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
+import java.util.Objects;
 import java.util.Optional;
 import java.util.Set;
 import java.util.stream.Collectors;
@@ -308,7 +309,9 @@ public class CatalogHelpers {
    * @param newCatalog - new catalog
    * @return difference between old and new catalogs
    */
-  public static Set<StreamTransform> getCatalogDiff(final AirbyteCatalog oldCatalog, final AirbyteCatalog newCatalog) {
+  public static Set<StreamTransform> getCatalogDiff(final AirbyteCatalog oldCatalog,
+                                                    final AirbyteCatalog newCatalog,
+                                                    final ConfiguredAirbyteCatalog configuredCatalog) {
     final Set<StreamTransform> streamTransforms = new HashSet<>();
 
     final Map<StreamDescriptor, AirbyteStream> descriptorToStreamOld = streamDescriptorToMap(oldCatalog);
@@ -322,8 +325,16 @@ public class CatalogHelpers {
         .forEach(descriptor -> {
           final AirbyteStream streamOld = descriptorToStreamOld.get(descriptor);
           final AirbyteStream streamNew = descriptorToStreamNew.get(descriptor);
+
+          final List<ConfiguredAirbyteStream> streamList = configuredCatalog.getStreams().stream()
+              .filter(s -> Objects.equals(s.getStream().getNamespace(), descriptor.getNamespace())
+                  && s.getStream().getName().equals(descriptor.getName()))
+              .toList();
+
+          final ConfiguredAirbyteStream stream = streamList.get(0);
+
           if (!streamOld.equals(streamNew)) {
-            streamTransforms.add(StreamTransform.createUpdateStreamTransform(descriptor, getStreamDiff(streamOld, streamNew)));
+            streamTransforms.add(StreamTransform.createUpdateStreamTransform(descriptor, getStreamDiff(streamOld, streamNew, stream)));
           }
         });
 
@@ -331,7 +342,8 @@ public class CatalogHelpers {
   }
 
   private static UpdateStreamTransform getStreamDiff(final AirbyteStream streamOld,
-                                                     final AirbyteStream streamNew) {
+                                                     final AirbyteStream streamNew,
+                                                     final ConfiguredAirbyteStream configuredStream) {
     final Set<FieldTransform> fieldTransforms = new HashSet<>();
     final Map<List<String>, JsonNode> fieldNameToTypeOld = getFullyQualifiedFieldNamesWithTypes(streamOld.getJsonSchema())
         .stream()
@@ -347,9 +359,17 @@ public class CatalogHelpers {
             CatalogHelpers::combineAccumulator);
 
     Sets.difference(fieldNameToTypeOld.keySet(), fieldNameToTypeNew.keySet())
-        .forEach(fieldName -> fieldTransforms.add(FieldTransform.createRemoveFieldTransform(fieldName, fieldNameToTypeOld.get(fieldName))));
+        .forEach(fieldName -> {
+          if (transformBreaksConnection(configuredStream, fieldName)) {
+            fieldTransforms.add(FieldTransform.createRemoveFieldTransform(fieldName, fieldNameToTypeOld.get(fieldName), true));
+          } else {
+            fieldTransforms.add(FieldTransform.createRemoveFieldTransform(fieldName, fieldNameToTypeOld.get(fieldName), false));
+          }
+        });
     Sets.difference(fieldNameToTypeNew.keySet(), fieldNameToTypeOld.keySet())
-        .forEach(fieldName -> fieldTransforms.add(FieldTransform.createAddFieldTransform(fieldName, fieldNameToTypeNew.get(fieldName))));
+        .forEach(fieldName -> {
+          fieldTransforms.add(FieldTransform.createAddFieldTransform(fieldName, fieldNameToTypeNew.get(fieldName)));
+        });
     Sets.intersection(fieldNameToTypeOld.keySet(), fieldNameToTypeNew.keySet()).forEach(fieldName -> {
       final JsonNode oldType = fieldNameToTypeOld.get(fieldName);
       final JsonNode newType = fieldNameToTypeNew.get(fieldName);
@@ -358,6 +378,7 @@ public class CatalogHelpers {
         fieldTransforms.add(FieldTransform.createUpdateFieldTransform(fieldName, new UpdateFieldSchemaTransform(oldType, newType)));
       }
     });
+
     return new UpdateStreamTransform(fieldTransforms);
   }
 
@@ -382,6 +403,19 @@ public class CatalogHelpers {
         accumulatorLeft.put(key, value);
       }
     });
+  }
+
+  static Boolean transformBreaksConnection(final ConfiguredAirbyteStream configuredStream, final List<String> fieldName) {
+    final SyncMode syncMode = configuredStream.getSyncMode();
+    if (SyncMode.INCREMENTAL == syncMode && configuredStream.getCursorField().equals(fieldName)) {
+      return true;
+    }
+
+    final DestinationSyncMode destinationSyncMode = configuredStream.getDestinationSyncMode();
+    if (DestinationSyncMode.APPEND_DEDUP == destinationSyncMode && configuredStream.getPrimaryKey().contains(fieldName)) {
+      return true;
+    }
+    return false;
   }
 
 }

--- a/airbyte-protocol/protocol-models/src/main/java/io/airbyte/protocol/models/CatalogHelpers.java
+++ b/airbyte-protocol/protocol-models/src/main/java/io/airbyte/protocol/models/CatalogHelpers.java
@@ -358,7 +358,8 @@ public class CatalogHelpers {
 
     Sets.difference(fieldNameToTypeOld.keySet(), fieldNameToTypeNew.keySet())
         .forEach(fieldName -> {
-          fieldTransforms.add(FieldTransform.createRemoveFieldTransform(fieldName, fieldNameToTypeOld.get(fieldName), transformBreaksConnection(configuredStream, fieldName)));
+          fieldTransforms.add(FieldTransform.createRemoveFieldTransform(fieldName, fieldNameToTypeOld.get(fieldName),
+              transformBreaksConnection(configuredStream, fieldName)));
         });
     Sets.difference(fieldNameToTypeNew.keySet(), fieldNameToTypeOld.keySet())
         .forEach(fieldName -> fieldTransforms.add(FieldTransform.createAddFieldTransform(fieldName, fieldNameToTypeNew.get(fieldName))));

--- a/airbyte-protocol/protocol-models/src/main/java/io/airbyte/protocol/models/transform_models/FieldTransform.java
+++ b/airbyte-protocol/protocol-models/src/main/java/io/airbyte/protocol/models/transform_models/FieldTransform.java
@@ -23,25 +23,28 @@ public final class FieldTransform {
   private final AddFieldTransform addFieldTransform;
   private final RemoveFieldTransform removeFieldTransform;
   private final UpdateFieldSchemaTransform updateFieldTransform;
+  private final Boolean isBreaking;
 
   public static FieldTransform createAddFieldTransform(final List<String> fieldName, final JsonNode schema) {
     return createAddFieldTransform(fieldName, new AddFieldTransform(schema));
   }
 
   public static FieldTransform createAddFieldTransform(final List<String> fieldName, final AddFieldTransform addFieldTransform) {
-    return new FieldTransform(FieldTransformType.ADD_FIELD, fieldName, addFieldTransform, null, null);
+    return new FieldTransform(FieldTransformType.ADD_FIELD, fieldName, addFieldTransform, null, null, false);
   }
 
-  public static FieldTransform createRemoveFieldTransform(final List<String> fieldName, final JsonNode schema) {
-    return createRemoveFieldTransform(fieldName, new RemoveFieldTransform(fieldName, schema));
+  public static FieldTransform createRemoveFieldTransform(final List<String> fieldName, final JsonNode schema, final Boolean isBreaking) {
+    return createRemoveFieldTransform(fieldName, new RemoveFieldTransform(fieldName, schema), isBreaking);
   }
 
-  public static FieldTransform createRemoveFieldTransform(final List<String> fieldName, final RemoveFieldTransform removeFieldTransform) {
-    return new FieldTransform(FieldTransformType.REMOVE_FIELD, fieldName, null, removeFieldTransform, null);
+  public static FieldTransform createRemoveFieldTransform(final List<String> fieldName,
+                                                          final RemoveFieldTransform removeFieldTransform,
+                                                          final Boolean isBreaking) {
+    return new FieldTransform(FieldTransformType.REMOVE_FIELD, fieldName, null, removeFieldTransform, null, isBreaking);
   }
 
   public static FieldTransform createUpdateFieldTransform(final List<String> fieldName, final UpdateFieldSchemaTransform updateFieldTransform) {
-    return new FieldTransform(FieldTransformType.UPDATE_FIELD_SCHEMA, fieldName, null, null, updateFieldTransform);
+    return new FieldTransform(FieldTransformType.UPDATE_FIELD_SCHEMA, fieldName, null, null, updateFieldTransform, false);
   }
 
   public FieldTransformType getTransformType() {
@@ -62,6 +65,10 @@ public final class FieldTransform {
 
   public UpdateFieldSchemaTransform getUpdateFieldTransform() {
     return updateFieldTransform;
+  }
+
+  public Boolean getIsBreaking() {
+    return isBreaking;
   }
 
 }

--- a/airbyte-protocol/protocol-models/src/main/java/io/airbyte/protocol/models/transform_models/FieldTransform.java
+++ b/airbyte-protocol/protocol-models/src/main/java/io/airbyte/protocol/models/transform_models/FieldTransform.java
@@ -23,7 +23,7 @@ public final class FieldTransform {
   private final AddFieldTransform addFieldTransform;
   private final RemoveFieldTransform removeFieldTransform;
   private final UpdateFieldSchemaTransform updateFieldTransform;
-  private final Boolean isBreaking;
+  private final boolean breaking;
 
   public static FieldTransform createAddFieldTransform(final List<String> fieldName, final JsonNode schema) {
     return createAddFieldTransform(fieldName, new AddFieldTransform(schema));
@@ -33,14 +33,14 @@ public final class FieldTransform {
     return new FieldTransform(FieldTransformType.ADD_FIELD, fieldName, addFieldTransform, null, null, false);
   }
 
-  public static FieldTransform createRemoveFieldTransform(final List<String> fieldName, final JsonNode schema, final Boolean isBreaking) {
-    return createRemoveFieldTransform(fieldName, new RemoveFieldTransform(fieldName, schema), isBreaking);
+  public static FieldTransform createRemoveFieldTransform(final List<String> fieldName, final JsonNode schema, final Boolean breaking) {
+    return createRemoveFieldTransform(fieldName, new RemoveFieldTransform(fieldName, schema), breaking);
   }
 
   public static FieldTransform createRemoveFieldTransform(final List<String> fieldName,
                                                           final RemoveFieldTransform removeFieldTransform,
-                                                          final Boolean isBreaking) {
-    return new FieldTransform(FieldTransformType.REMOVE_FIELD, fieldName, null, removeFieldTransform, null, isBreaking);
+                                                          final Boolean breaking) {
+    return new FieldTransform(FieldTransformType.REMOVE_FIELD, fieldName, null, removeFieldTransform, null, breaking);
   }
 
   public static FieldTransform createUpdateFieldTransform(final List<String> fieldName, final UpdateFieldSchemaTransform updateFieldTransform) {
@@ -67,8 +67,8 @@ public final class FieldTransform {
     return updateFieldTransform;
   }
 
-  public Boolean getIsBreaking() {
-    return isBreaking;
+  public boolean breaking() {
+    return breaking;
   }
 
 }

--- a/airbyte-protocol/protocol-models/src/test/java/io/airbyte/protocol/models/CatalogHelpersTest.java
+++ b/airbyte-protocol/protocol-models/src/test/java/io/airbyte/protocol/models/CatalogHelpersTest.java
@@ -232,4 +232,27 @@ class CatalogHelpersTest {
     Assertions.assertThat(actualDiff).hasSize(0);
   }
 
+  @Test
+  void testCatalogDiffWithBreakingChanges() throws IOException {
+    final JsonNode schema1 = Jsons.deserialize(MoreResources.readResource("valid_schema.json"));
+    final JsonNode breakingSchema = Jsons.deserialize(MoreResources.readResource("breaking_change_schema.json"));
+    final AirbyteCatalog catalog1 = new AirbyteCatalog().withStreams(List.of(
+        new AirbyteStream().withName(USERS).withJsonSchema(schema1)));
+    final AirbyteCatalog catalog2 = new AirbyteCatalog().withStreams(List.of(
+        new AirbyteStream().withName(USERS).withJsonSchema(breakingSchema)));
+
+    final ConfiguredAirbyteCatalog configuredAirbyteCatalog = new ConfiguredAirbyteCatalog().withStreams(List.of(
+        new ConfiguredAirbyteStream().withStream(new AirbyteStream().withName(USERS).withJsonSchema(schema1)).withSyncMode(SyncMode.INCREMENTAL).withCursorField(List.of("date")).withDestinationSyncMode(DestinationSyncMode.APPEND_DEDUP).withPrimaryKey(List.of(List.of("id")))));
+
+    final Set<StreamTransform> diff = CatalogHelpers.getCatalogDiff(catalog1, catalog2, configuredAirbyteCatalog);
+
+    final List<StreamTransform> expectedDiff = Stream.of(
+            StreamTransform.createUpdateStreamTransform(new StreamDescriptor().withName(USERS), new UpdateStreamTransform(Set.of(
+                FieldTransform.createRemoveFieldTransform(List.of("date"), schema1.get(PROPERTIES).get("date"), true),
+                FieldTransform.createRemoveFieldTransform(List.of("id"), schema1.get(PROPERTIES).get("id"), true)))))
+        .toList();
+
+    Assertions.assertThat(diff).containsAll(expectedDiff);
+  }
+
 }

--- a/airbyte-protocol/protocol-models/src/test/java/io/airbyte/protocol/models/CatalogHelpersTest.java
+++ b/airbyte-protocol/protocol-models/src/test/java/io/airbyte/protocol/models/CatalogHelpersTest.java
@@ -38,6 +38,8 @@ class CatalogHelpersTest {
   private static final String SOME_ARRAY = "someArray";
   private static final String PROPERTIES = "properties";
   private static final String USERS = "users";
+  private static final String DATE = "date";
+  private static final String SALES = "sales";
   private static final String COMPANIES_VALID = "companies_schema.json";
   private static final String COMPANIES_INVALID = "companies_schema_invalid.json";
 
@@ -96,7 +98,7 @@ class CatalogHelpersTest {
     final JsonNode node = Jsons.deserialize(MoreResources.readResource("valid_schema.json"));
     final Set<String> actualFieldNames = CatalogHelpers.getAllFieldNames(node);
     final List<String> expectedFieldNames =
-        List.of(CAD, "DKK", "HKD", "HUF", "ISK", "PHP", "date", "nestedkey", "somekey", "something", "something2", "文", SOME_ARRAY, ITEMS,
+        List.of("id", CAD, "DKK", "HKD", "HUF", "ISK", "PHP", DATE, "nestedkey", "somekey", "something", "something2", "文", SOME_ARRAY, ITEMS,
             "oldName");
 
     // sort so that the diff is easier to read.
@@ -112,16 +114,16 @@ class CatalogHelpersTest {
         new AirbyteStream().withName("accounts").withJsonSchema(Jsons.emptyObject())));
     final AirbyteCatalog catalog2 = new AirbyteCatalog().withStreams(List.of(
         new AirbyteStream().withName(USERS).withJsonSchema(schema2),
-        new AirbyteStream().withName("sales").withJsonSchema(Jsons.emptyObject())));
+        new AirbyteStream().withName(SALES).withJsonSchema(Jsons.emptyObject())));
 
     final ConfiguredAirbyteCatalog configuredAirbyteCatalog = new ConfiguredAirbyteCatalog().withStreams(List.of(
         new ConfiguredAirbyteStream().withStream(new AirbyteStream().withName(USERS).withJsonSchema(schema2)).withSyncMode(SyncMode.FULL_REFRESH),
-        new ConfiguredAirbyteStream().withStream(new AirbyteStream().withName("sales").withJsonSchema(Jsons.emptyObject()))
+        new ConfiguredAirbyteStream().withStream(new AirbyteStream().withName(SALES).withJsonSchema(Jsons.emptyObject()))
             .withSyncMode(SyncMode.FULL_REFRESH)));
 
     final Set<StreamTransform> actualDiff = CatalogHelpers.getCatalogDiff(catalog1, catalog2, configuredAirbyteCatalog);
     final List<StreamTransform> expectedDiff = Stream.of(
-        StreamTransform.createAddStreamTransform(new StreamDescriptor().withName("sales")),
+        StreamTransform.createAddStreamTransform(new StreamDescriptor().withName(SALES)),
         StreamTransform.createRemoveStreamTransform(new StreamDescriptor().withName("accounts")),
         StreamTransform.createUpdateStreamTransform(new StreamDescriptor().withName(USERS), new UpdateStreamTransform(Set.of(
             FieldTransform.createAddFieldTransform(List.of("COD"), schema2.get(PROPERTIES).get("COD")),
@@ -202,7 +204,7 @@ class CatalogHelpersTest {
 
     final ConfiguredAirbyteCatalog configuredAirbyteCatalog = new ConfiguredAirbyteCatalog().withStreams(List.of(
         new ConfiguredAirbyteStream().withStream(new AirbyteStream().withName(USERS).withJsonSchema(schema2)).withSyncMode(SyncMode.FULL_REFRESH),
-        new ConfiguredAirbyteStream().withStream(new AirbyteStream().withName("sales").withJsonSchema(Jsons.emptyObject()))
+        new ConfiguredAirbyteStream().withStream(new AirbyteStream().withName(SALES).withJsonSchema(Jsons.emptyObject()))
             .withSyncMode(SyncMode.FULL_REFRESH)));
 
     final Set<StreamTransform> actualDiff = CatalogHelpers.getCatalogDiff(catalog1, catalog2, configuredAirbyteCatalog);
@@ -224,7 +226,7 @@ class CatalogHelpersTest {
 
     final ConfiguredAirbyteCatalog configuredAirbyteCatalog = new ConfiguredAirbyteCatalog().withStreams(List.of(
         new ConfiguredAirbyteStream().withStream(new AirbyteStream().withName(USERS).withJsonSchema(schema2)).withSyncMode(SyncMode.FULL_REFRESH),
-        new ConfiguredAirbyteStream().withStream(new AirbyteStream().withName("sales").withJsonSchema(Jsons.emptyObject()))
+        new ConfiguredAirbyteStream().withStream(new AirbyteStream().withName(SALES).withJsonSchema(Jsons.emptyObject()))
             .withSyncMode(SyncMode.FULL_REFRESH)));
 
     final Set<StreamTransform> actualDiff = CatalogHelpers.getCatalogDiff(catalog1, catalog2, configuredAirbyteCatalog);
@@ -243,13 +245,13 @@ class CatalogHelpersTest {
 
     final ConfiguredAirbyteCatalog configuredAirbyteCatalog = new ConfiguredAirbyteCatalog().withStreams(List.of(
         new ConfiguredAirbyteStream().withStream(new AirbyteStream().withName(USERS).withJsonSchema(schema1)).withSyncMode(SyncMode.INCREMENTAL)
-            .withCursorField(List.of("date")).withDestinationSyncMode(DestinationSyncMode.APPEND_DEDUP).withPrimaryKey(List.of(List.of("id")))));
+            .withCursorField(List.of(DATE)).withDestinationSyncMode(DestinationSyncMode.APPEND_DEDUP).withPrimaryKey(List.of(List.of("id")))));
 
     final Set<StreamTransform> diff = CatalogHelpers.getCatalogDiff(catalog1, catalog2, configuredAirbyteCatalog);
 
     final List<StreamTransform> expectedDiff = Stream.of(
         StreamTransform.createUpdateStreamTransform(new StreamDescriptor().withName(USERS), new UpdateStreamTransform(Set.of(
-            FieldTransform.createRemoveFieldTransform(List.of("date"), schema1.get(PROPERTIES).get("date"), true),
+            FieldTransform.createRemoveFieldTransform(List.of(DATE), schema1.get(PROPERTIES).get(DATE), true),
             FieldTransform.createRemoveFieldTransform(List.of("id"), schema1.get(PROPERTIES).get("id"), true)))))
         .toList();
 

--- a/airbyte-protocol/protocol-models/src/test/java/io/airbyte/protocol/models/CatalogHelpersTest.java
+++ b/airbyte-protocol/protocol-models/src/test/java/io/airbyte/protocol/models/CatalogHelpersTest.java
@@ -242,14 +242,15 @@ class CatalogHelpersTest {
         new AirbyteStream().withName(USERS).withJsonSchema(breakingSchema)));
 
     final ConfiguredAirbyteCatalog configuredAirbyteCatalog = new ConfiguredAirbyteCatalog().withStreams(List.of(
-        new ConfiguredAirbyteStream().withStream(new AirbyteStream().withName(USERS).withJsonSchema(schema1)).withSyncMode(SyncMode.INCREMENTAL).withCursorField(List.of("date")).withDestinationSyncMode(DestinationSyncMode.APPEND_DEDUP).withPrimaryKey(List.of(List.of("id")))));
+        new ConfiguredAirbyteStream().withStream(new AirbyteStream().withName(USERS).withJsonSchema(schema1)).withSyncMode(SyncMode.INCREMENTAL)
+            .withCursorField(List.of("date")).withDestinationSyncMode(DestinationSyncMode.APPEND_DEDUP).withPrimaryKey(List.of(List.of("id")))));
 
     final Set<StreamTransform> diff = CatalogHelpers.getCatalogDiff(catalog1, catalog2, configuredAirbyteCatalog);
 
     final List<StreamTransform> expectedDiff = Stream.of(
-            StreamTransform.createUpdateStreamTransform(new StreamDescriptor().withName(USERS), new UpdateStreamTransform(Set.of(
-                FieldTransform.createRemoveFieldTransform(List.of("date"), schema1.get(PROPERTIES).get("date"), true),
-                FieldTransform.createRemoveFieldTransform(List.of("id"), schema1.get(PROPERTIES).get("id"), true)))))
+        StreamTransform.createUpdateStreamTransform(new StreamDescriptor().withName(USERS), new UpdateStreamTransform(Set.of(
+            FieldTransform.createRemoveFieldTransform(List.of("date"), schema1.get(PROPERTIES).get("date"), true),
+            FieldTransform.createRemoveFieldTransform(List.of("id"), schema1.get(PROPERTIES).get("id"), true)))))
         .toList();
 
     Assertions.assertThat(diff).containsAll(expectedDiff);

--- a/airbyte-protocol/protocol-models/src/test/java/io/airbyte/protocol/models/CatalogHelpersTest.java
+++ b/airbyte-protocol/protocol-models/src/test/java/io/airbyte/protocol/models/CatalogHelpersTest.java
@@ -114,14 +114,19 @@ class CatalogHelpersTest {
         new AirbyteStream().withName(USERS).withJsonSchema(schema2),
         new AirbyteStream().withName("sales").withJsonSchema(Jsons.emptyObject())));
 
-    final Set<StreamTransform> actualDiff = CatalogHelpers.getCatalogDiff(catalog1, catalog2);
+    final ConfiguredAirbyteCatalog configuredAirbyteCatalog = new ConfiguredAirbyteCatalog().withStreams(List.of(
+        new ConfiguredAirbyteStream().withStream(new AirbyteStream().withName(USERS).withJsonSchema(schema2)).withSyncMode(SyncMode.FULL_REFRESH),
+        new ConfiguredAirbyteStream().withStream(new AirbyteStream().withName("sales").withJsonSchema(Jsons.emptyObject()))
+            .withSyncMode(SyncMode.FULL_REFRESH)));
+
+    final Set<StreamTransform> actualDiff = CatalogHelpers.getCatalogDiff(catalog1, catalog2, configuredAirbyteCatalog);
     final List<StreamTransform> expectedDiff = Stream.of(
         StreamTransform.createAddStreamTransform(new StreamDescriptor().withName("sales")),
         StreamTransform.createRemoveStreamTransform(new StreamDescriptor().withName("accounts")),
         StreamTransform.createUpdateStreamTransform(new StreamDescriptor().withName(USERS), new UpdateStreamTransform(Set.of(
             FieldTransform.createAddFieldTransform(List.of("COD"), schema2.get(PROPERTIES).get("COD")),
-            FieldTransform.createRemoveFieldTransform(List.of("something2"), schema1.get(PROPERTIES).get("something2")),
-            FieldTransform.createRemoveFieldTransform(List.of("HKD"), schema1.get(PROPERTIES).get("HKD")),
+            FieldTransform.createRemoveFieldTransform(List.of("something2"), schema1.get(PROPERTIES).get("something2"), false),
+            FieldTransform.createRemoveFieldTransform(List.of("HKD"), schema1.get(PROPERTIES).get("HKD"), false),
             FieldTransform.createUpdateFieldTransform(List.of(CAD), new UpdateFieldSchemaTransform(
                 schema1.get(PROPERTIES).get(CAD),
                 schema2.get(PROPERTIES).get(CAD))),
@@ -132,7 +137,7 @@ class CatalogHelpersTest {
                 schema1.get(PROPERTIES).get(SOME_ARRAY).get(ITEMS),
                 schema2.get(PROPERTIES).get(SOME_ARRAY).get(ITEMS))),
             FieldTransform.createRemoveFieldTransform(List.of(SOME_ARRAY, ITEMS, "oldName"),
-                schema1.get(PROPERTIES).get(SOME_ARRAY).get(ITEMS).get(PROPERTIES).get("oldName")),
+                schema1.get(PROPERTIES).get(SOME_ARRAY).get(ITEMS).get(PROPERTIES).get("oldName"), false),
             FieldTransform.createAddFieldTransform(List.of(SOME_ARRAY, ITEMS, "newName"),
                 schema2.get(PROPERTIES).get(SOME_ARRAY).get(ITEMS).get(PROPERTIES).get("newName"))))))
         .sorted(STREAM_TRANSFORM_COMPARATOR)
@@ -195,7 +200,12 @@ class CatalogHelpersTest {
     final AirbyteCatalog catalog2 = new AirbyteCatalog().withStreams(List.of(
         new AirbyteStream().withName(USERS).withJsonSchema(schema2)));
 
-    final Set<StreamTransform> actualDiff = CatalogHelpers.getCatalogDiff(catalog1, catalog2);
+    final ConfiguredAirbyteCatalog configuredAirbyteCatalog = new ConfiguredAirbyteCatalog().withStreams(List.of(
+        new ConfiguredAirbyteStream().withStream(new AirbyteStream().withName(USERS).withJsonSchema(schema2)).withSyncMode(SyncMode.FULL_REFRESH),
+        new ConfiguredAirbyteStream().withStream(new AirbyteStream().withName("sales").withJsonSchema(Jsons.emptyObject()))
+            .withSyncMode(SyncMode.FULL_REFRESH)));
+
+    final Set<StreamTransform> actualDiff = CatalogHelpers.getCatalogDiff(catalog1, catalog2, configuredAirbyteCatalog);
 
     Assertions.assertThat(actualDiff).hasSize(1);
     Assertions.assertThat(actualDiff).first()
@@ -212,7 +222,12 @@ class CatalogHelpersTest {
     final AirbyteCatalog catalog2 = new AirbyteCatalog().withStreams(List.of(
         new AirbyteStream().withName(USERS).withJsonSchema(schema2)));
 
-    final Set<StreamTransform> actualDiff = CatalogHelpers.getCatalogDiff(catalog1, catalog2);
+    final ConfiguredAirbyteCatalog configuredAirbyteCatalog = new ConfiguredAirbyteCatalog().withStreams(List.of(
+        new ConfiguredAirbyteStream().withStream(new AirbyteStream().withName(USERS).withJsonSchema(schema2)).withSyncMode(SyncMode.FULL_REFRESH),
+        new ConfiguredAirbyteStream().withStream(new AirbyteStream().withName("sales").withJsonSchema(Jsons.emptyObject()))
+            .withSyncMode(SyncMode.FULL_REFRESH)));
+
+    final Set<StreamTransform> actualDiff = CatalogHelpers.getCatalogDiff(catalog1, catalog2, configuredAirbyteCatalog);
 
     Assertions.assertThat(actualDiff).hasSize(0);
   }

--- a/airbyte-protocol/protocol-models/src/test/java/io/airbyte/protocol/models/CatalogHelpersTest.java
+++ b/airbyte-protocol/protocol-models/src/test/java/io/airbyte/protocol/models/CatalogHelpersTest.java
@@ -258,4 +258,27 @@ class CatalogHelpersTest {
     Assertions.assertThat(diff).containsAll(expectedDiff);
   }
 
+  @Test
+  void testCatalogDiffWithoutStreamConfig() throws IOException {
+    final JsonNode schema1 = Jsons.deserialize(MoreResources.readResource("valid_schema.json"));
+    final JsonNode breakingSchema = Jsons.deserialize(MoreResources.readResource("breaking_change_schema.json"));
+    final AirbyteCatalog catalog1 = new AirbyteCatalog().withStreams(List.of(
+        new AirbyteStream().withName(USERS).withJsonSchema(schema1)));
+    final AirbyteCatalog catalog2 = new AirbyteCatalog().withStreams(List.of(
+        new AirbyteStream().withName(USERS).withJsonSchema(breakingSchema)));
+
+    final ConfiguredAirbyteCatalog configuredAirbyteCatalog = new ConfiguredAirbyteCatalog().withStreams(List.of(
+        new ConfiguredAirbyteStream().withStream(new AirbyteStream().withName(SALES).withJsonSchema(schema1)).withSyncMode(SyncMode.INCREMENTAL)
+            .withCursorField(List.of(DATE)).withDestinationSyncMode(DestinationSyncMode.APPEND_DEDUP).withPrimaryKey(List.of(List.of("id")))));
+
+    final Set<StreamTransform> diff = CatalogHelpers.getCatalogDiff(catalog1, catalog2, configuredAirbyteCatalog);
+
+    final List<StreamTransform> expectedDiff = Stream.of(
+            StreamTransform.createUpdateStreamTransform(new StreamDescriptor().withName(USERS), new UpdateStreamTransform(Set.of(
+                FieldTransform.createRemoveFieldTransform(List.of(DATE), schema1.get(PROPERTIES).get(DATE), false),
+                FieldTransform.createRemoveFieldTransform(List.of("id"), schema1.get(PROPERTIES).get("id"), false)))))
+        .toList();
+
+    Assertions.assertThat(diff).containsAll(expectedDiff);
+  }
 }

--- a/airbyte-protocol/protocol-models/src/test/java/io/airbyte/protocol/models/CatalogHelpersTest.java
+++ b/airbyte-protocol/protocol-models/src/test/java/io/airbyte/protocol/models/CatalogHelpersTest.java
@@ -42,6 +42,7 @@ class CatalogHelpersTest {
   private static final String SALES = "sales";
   private static final String COMPANIES_VALID = "companies_schema.json";
   private static final String COMPANIES_INVALID = "companies_schema_invalid.json";
+  private static final String VALID_SCHEMA_JSON = "valid_schema.json";
 
   @Test
   void testFieldToJsonSchema() {
@@ -95,7 +96,7 @@ class CatalogHelpersTest {
 
   @Test
   void testGetFieldNames() throws IOException {
-    final JsonNode node = Jsons.deserialize(MoreResources.readResource("valid_schema.json"));
+    final JsonNode node = Jsons.deserialize(MoreResources.readResource(VALID_SCHEMA_JSON));
     final Set<String> actualFieldNames = CatalogHelpers.getAllFieldNames(node);
     final List<String> expectedFieldNames =
         List.of("id", CAD, "DKK", "HKD", "HUF", "ISK", "PHP", DATE, "nestedkey", "somekey", "something", "something2", "文", SOME_ARRAY, ITEMS,
@@ -107,7 +108,7 @@ class CatalogHelpersTest {
 
   @Test
   void testGetCatalogDiff() throws IOException {
-    final JsonNode schema1 = Jsons.deserialize(MoreResources.readResource("valid_schema.json"));
+    final JsonNode schema1 = Jsons.deserialize(MoreResources.readResource(VALID_SCHEMA_JSON));
     final JsonNode schema2 = Jsons.deserialize(MoreResources.readResource("valid_schema2.json"));
     final AirbyteCatalog catalog1 = new AirbyteCatalog().withStreams(List.of(
         new AirbyteStream().withName(USERS).withJsonSchema(schema1),
@@ -236,7 +237,7 @@ class CatalogHelpersTest {
 
   @Test
   void testCatalogDiffWithBreakingChanges() throws IOException {
-    final JsonNode schema1 = Jsons.deserialize(MoreResources.readResource("valid_schema.json"));
+    final JsonNode schema1 = Jsons.deserialize(MoreResources.readResource(VALID_SCHEMA_JSON));
     final JsonNode breakingSchema = Jsons.deserialize(MoreResources.readResource("breaking_change_schema.json"));
     final AirbyteCatalog catalog1 = new AirbyteCatalog().withStreams(List.of(
         new AirbyteStream().withName(USERS).withJsonSchema(schema1)));
@@ -260,7 +261,7 @@ class CatalogHelpersTest {
 
   @Test
   void testCatalogDiffWithoutStreamConfig() throws IOException {
-    final JsonNode schema1 = Jsons.deserialize(MoreResources.readResource("valid_schema.json"));
+    final JsonNode schema1 = Jsons.deserialize(MoreResources.readResource(VALID_SCHEMA_JSON));
     final JsonNode breakingSchema = Jsons.deserialize(MoreResources.readResource("breaking_change_schema.json"));
     final AirbyteCatalog catalog1 = new AirbyteCatalog().withStreams(List.of(
         new AirbyteStream().withName(USERS).withJsonSchema(schema1)));
@@ -274,11 +275,12 @@ class CatalogHelpersTest {
     final Set<StreamTransform> diff = CatalogHelpers.getCatalogDiff(catalog1, catalog2, configuredAirbyteCatalog);
 
     final List<StreamTransform> expectedDiff = Stream.of(
-            StreamTransform.createUpdateStreamTransform(new StreamDescriptor().withName(USERS), new UpdateStreamTransform(Set.of(
-                FieldTransform.createRemoveFieldTransform(List.of(DATE), schema1.get(PROPERTIES).get(DATE), false),
-                FieldTransform.createRemoveFieldTransform(List.of("id"), schema1.get(PROPERTIES).get("id"), false)))))
+        StreamTransform.createUpdateStreamTransform(new StreamDescriptor().withName(USERS), new UpdateStreamTransform(Set.of(
+            FieldTransform.createRemoveFieldTransform(List.of(DATE), schema1.get(PROPERTIES).get(DATE), false),
+            FieldTransform.createRemoveFieldTransform(List.of("id"), schema1.get(PROPERTIES).get("id"), false)))))
         .toList();
 
     Assertions.assertThat(diff).containsAll(expectedDiff);
   }
+
 }

--- a/airbyte-protocol/protocol-models/src/test/resources/breaking_change_schema.json
+++ b/airbyte-protocol/protocol-models/src/test/resources/breaking_change_schema.json
@@ -1,8 +1,6 @@
 {
   "type": "object",
   "properties": {
-    "id": { "type":  "number" },
-    "date": { "type": "string", "format": "date-time" },
     "CAD": { "type": ["null", "number"] },
     "HKD": { "type": ["null", "number"] },
     "ISK": { "type": ["null", "number"] },

--- a/airbyte-protocol/protocol-models/src/test/resources/valid_schema.json
+++ b/airbyte-protocol/protocol-models/src/test/resources/valid_schema.json
@@ -1,7 +1,7 @@
 {
   "type": "object",
   "properties": {
-    "id": { "type":  "number" },
+    "id": { "type": "number" },
     "date": { "type": "string", "format": "date-time" },
     "CAD": { "type": ["null", "number"] },
     "HKD": { "type": ["null", "number"] },

--- a/airbyte-protocol/protocol-models/src/test/resources/valid_schema2.json
+++ b/airbyte-protocol/protocol-models/src/test/resources/valid_schema2.json
@@ -1,6 +1,7 @@
 {
   "type": "object",
   "properties": {
+    "id": { "type": "number" },
     "date": { "type": "string", "format": "date-time" },
     "CAD": { "type": ["null", "string"] },
     "COD": { "type": ["null", "string"] },

--- a/airbyte-server/src/main/java/io/airbyte/server/converters/CatalogDiffConverters.java
+++ b/airbyte-server/src/main/java/io/airbyte/server/converters/CatalogDiffConverters.java
@@ -44,6 +44,7 @@ public class CatalogDiffConverters {
     return new FieldTransform()
         .transformType(Enums.convertTo(transform.getTransformType(), FieldTransform.TransformTypeEnum.class))
         .fieldName(transform.getFieldName())
+        .isBreaking(transform.getIsBreaking())
         .addField(addFieldToApi(transform).orElse(null))
         .removeField(removeFieldToApi(transform).orElse(null))
         .updateFieldSchema(updateFieldToApi(transform).orElse(null));

--- a/airbyte-server/src/main/java/io/airbyte/server/converters/CatalogDiffConverters.java
+++ b/airbyte-server/src/main/java/io/airbyte/server/converters/CatalogDiffConverters.java
@@ -44,7 +44,7 @@ public class CatalogDiffConverters {
     return new FieldTransform()
         .transformType(Enums.convertTo(transform.getTransformType(), FieldTransform.TransformTypeEnum.class))
         .fieldName(transform.getFieldName())
-        .isBreaking(transform.getIsBreaking())
+        .breaking(transform.breaking())
         .addField(addFieldToApi(transform).orElse(null))
         .removeField(removeFieldToApi(transform).orElse(null))
         .updateFieldSchema(updateFieldToApi(transform).orElse(null));

--- a/airbyte-server/src/main/java/io/airbyte/server/handlers/ConnectionsHandler.java
+++ b/airbyte-server/src/main/java/io/airbyte/server/handlers/ConnectionsHandler.java
@@ -416,10 +416,10 @@ public class ConnectionsHandler {
     return buildConnectionRead(connectionId);
   }
 
-  public CatalogDiff getDiff(final AirbyteCatalog oldCatalog, final AirbyteCatalog newCatalog) {
+  public CatalogDiff getDiff(final AirbyteCatalog oldCatalog, final AirbyteCatalog newCatalog, final ConfiguredAirbyteCatalog configuredCatalog) {
     return new CatalogDiff().transforms(CatalogHelpers.getCatalogDiff(
         CatalogHelpers.configuredCatalogToCatalog(CatalogConverter.toProtocolKeepAllStreams(oldCatalog)),
-        CatalogHelpers.configuredCatalogToCatalog(CatalogConverter.toProtocolKeepAllStreams(newCatalog)))
+        CatalogHelpers.configuredCatalogToCatalog(CatalogConverter.toProtocolKeepAllStreams(newCatalog)), configuredCatalog)
         .stream()
         .map(CatalogDiffConverters::streamTransformToApi)
         .toList());

--- a/airbyte-server/src/main/java/io/airbyte/server/handlers/WebBackendConnectionsHandler.java
+++ b/airbyte-server/src/main/java/io/airbyte/server/handlers/WebBackendConnectionsHandler.java
@@ -298,7 +298,8 @@ public class WebBackendConnectionsHandler {
        * but was present at time of configuration will appear in the diff as an added stream which is
        * confusing. We need to figure out why source_catalog_id is not always populated in the db.
        */
-      diff = connectionsHandler.getDiff(catalogUsedToMakeConfiguredCatalog.orElse(configuredCatalog), refreshedCatalog.get().getCatalog());
+      diff = connectionsHandler.getDiff(catalogUsedToMakeConfiguredCatalog.orElse(configuredCatalog), refreshedCatalog.get().getCatalog(),
+          CatalogConverter.toProtocol(configuredCatalog));
     } else if (catalogUsedToMakeConfiguredCatalog.isPresent()) {
       // reconstructs a full picture of the full schema at the time the catalog was configured.
       syncCatalog = updateSchemaWithDiscovery(configuredCatalog, catalogUsedToMakeConfiguredCatalog.get());
@@ -457,7 +458,8 @@ public class WebBackendConnectionsHandler {
     if (!skipReset) {
       final AirbyteCatalog apiExistingCatalog = CatalogConverter.toApi(oldConfiguredCatalog);
       final AirbyteCatalog upToDateAirbyteCatalog = updatedConnectionRead.getSyncCatalog();
-      final CatalogDiff catalogDiff = connectionsHandler.getDiff(apiExistingCatalog, upToDateAirbyteCatalog);
+      final CatalogDiff catalogDiff =
+          connectionsHandler.getDiff(apiExistingCatalog, upToDateAirbyteCatalog, CatalogConverter.toProtocol(upToDateAirbyteCatalog));
       final List<StreamDescriptor> apiStreamsToReset = getStreamsToReset(catalogDiff);
       final Set<StreamDescriptor> changedConfigStreamDescriptors =
           connectionsHandler.getConfigurationDiff(apiExistingCatalog, upToDateAirbyteCatalog);

--- a/airbyte-server/src/test/java/io/airbyte/server/handlers/WebBackendConnectionsHandlerTest.java
+++ b/airbyte-server/src/test/java/io/airbyte/server/handlers/WebBackendConnectionsHandlerTest.java
@@ -76,8 +76,10 @@ import io.airbyte.config.persistence.ConfigRepository;
 import io.airbyte.config.persistence.ConfigRepository.DestinationAndDefinition;
 import io.airbyte.config.persistence.ConfigRepository.SourceAndDefinition;
 import io.airbyte.protocol.models.CatalogHelpers;
+import io.airbyte.protocol.models.ConfiguredAirbyteCatalog;
 import io.airbyte.protocol.models.Field;
 import io.airbyte.protocol.models.JsonSchemaType;
+import io.airbyte.server.handlers.helpers.CatalogConverter;
 import io.airbyte.server.helpers.ConnectionHelpers;
 import io.airbyte.server.helpers.DestinationDefinitionHelpers;
 import io.airbyte.server.helpers.DestinationHelpers;
@@ -757,9 +759,10 @@ class WebBackendConnectionsHandlerTest {
 
     // state is per-stream
     final ConnectionIdRequestBody connectionIdRequestBody = new ConnectionIdRequestBody().connectionId(expected.getConnectionId());
+    final ConfiguredAirbyteCatalog configuredAirbyteCatalog = ConnectionHelpers.generateBasicConfiguredAirbyteCatalog();
     when(stateHandler.getState(connectionIdRequestBody)).thenReturn(new ConnectionState().stateType(ConnectionStateType.STREAM));
     when(configRepository.getConfiguredCatalogForConnection(expected.getConnectionId()))
-        .thenReturn(ConnectionHelpers.generateBasicConfiguredAirbyteCatalog());
+        .thenReturn(configuredAirbyteCatalog);
 
     final CatalogDiff catalogDiff = new CatalogDiff().transforms(List.of());
     when(connectionsHandler.getDiff(any(), any(), any())).thenReturn(catalogDiff);
@@ -786,7 +789,9 @@ class WebBackendConnectionsHandlerTest {
     assertEquals(expectedWithNewSchema.getSyncCatalog(), result.getSyncCatalog());
 
     final ConnectionIdRequestBody connectionId = new ConnectionIdRequestBody().connectionId(result.getConnectionId());
-    verify(connectionsHandler).getDiff(expected.getSyncCatalog(), expectedWithNewSchema.getSyncCatalog());
+
+    verify(connectionsHandler).getDiff(expected.getSyncCatalog(), expectedWithNewSchema.getSyncCatalog(),
+        CatalogConverter.toProtocol(result.getSyncCatalog()));
     verify(connectionsHandler).getConfigurationDiff(expected.getSyncCatalog(), expectedWithNewSchema.getSyncCatalog());
     verify(schedulerHandler, times(0)).resetConnection(connectionId);
     verify(schedulerHandler, times(0)).syncConnection(connectionId);

--- a/airbyte-server/src/test/java/io/airbyte/server/handlers/WebBackendConnectionsHandlerTest.java
+++ b/airbyte-server/src/test/java/io/airbyte/server/handlers/WebBackendConnectionsHandlerTest.java
@@ -365,7 +365,7 @@ class WebBackendConnectionsHandlerTest {
 
   @Test
   void testWebBackendGetConnectionWithDiscovery() throws ConfigNotFoundException, IOException, JsonValidationException {
-    when(connectionsHandler.getDiff(any(), any())).thenReturn(expectedWithNewSchema.getCatalogDiff());
+    when(connectionsHandler.getDiff(any(), any(), any())).thenReturn(expectedWithNewSchema.getCatalogDiff());
     final WebBackendConnectionRead result = testWebBackendGetConnection(true);
     verify(schedulerHandler).discoverSchemaForSourceFromSourceId(any());
     assertEquals(expectedWithNewSchema, result);
@@ -530,7 +530,7 @@ class WebBackendConnectionsHandlerTest {
         .thenReturn(ConnectionHelpers.generateBasicConfiguredAirbyteCatalog());
 
     final CatalogDiff catalogDiff = new CatalogDiff().transforms(List.of());
-    when(connectionsHandler.getDiff(any(), any())).thenReturn(catalogDiff);
+    when(connectionsHandler.getDiff(any(), any(), any())).thenReturn(catalogDiff);
     final ConnectionIdRequestBody connectionIdRequestBody = new ConnectionIdRequestBody().connectionId(expected.getConnectionId());
     when(stateHandler.getState(connectionIdRequestBody)).thenReturn(new ConnectionState().stateType(ConnectionStateType.LEGACY));
 
@@ -584,7 +584,7 @@ class WebBackendConnectionsHandlerTest {
         .thenReturn(ConnectionHelpers.generateBasicConfiguredAirbyteCatalog());
 
     final CatalogDiff catalogDiff = new CatalogDiff().transforms(List.of());
-    when(connectionsHandler.getDiff(any(), any())).thenReturn(catalogDiff);
+    when(connectionsHandler.getDiff(any(), any(), any())).thenReturn(catalogDiff);
     final ConnectionIdRequestBody connectionIdRequestBody = new ConnectionIdRequestBody().connectionId(expected.getConnectionId());
     when(stateHandler.getState(connectionIdRequestBody)).thenReturn(new ConnectionState().stateType(ConnectionStateType.LEGACY));
 
@@ -636,7 +636,7 @@ class WebBackendConnectionsHandlerTest {
         new StreamTransform().streamDescriptor(streamDescriptorAdd).transformType(TransformTypeEnum.ADD_STREAM);
 
     final CatalogDiff catalogDiff = new CatalogDiff().transforms(List.of(streamTransformAdd));
-    when(connectionsHandler.getDiff(any(), any())).thenReturn(catalogDiff);
+    when(connectionsHandler.getDiff(any(), any(), any())).thenReturn(catalogDiff);
 
     when(operationsHandler.listOperationsForConnection(any())).thenReturn(operationReadList);
     when(connectionsHandler.getConnection(expected.getConnectionId())).thenReturn(
@@ -703,7 +703,7 @@ class WebBackendConnectionsHandlerTest {
         new StreamTransform().streamDescriptor(streamDescriptorUpdate).transformType(TransformTypeEnum.UPDATE_STREAM);
 
     final CatalogDiff catalogDiff = new CatalogDiff().transforms(List.of(streamTransformAdd, streamTransformRemove, streamTransformUpdate));
-    when(connectionsHandler.getDiff(any(), any())).thenReturn(catalogDiff);
+    when(connectionsHandler.getDiff(any(), any(), any())).thenReturn(catalogDiff);
     when(connectionsHandler.getConfigurationDiff(any(), any())).thenReturn(Set.of(new StreamDescriptor().name("configUpdateStream")));
 
     when(operationsHandler.listOperationsForConnection(any())).thenReturn(operationReadList);
@@ -762,7 +762,7 @@ class WebBackendConnectionsHandlerTest {
         .thenReturn(ConnectionHelpers.generateBasicConfiguredAirbyteCatalog());
 
     final CatalogDiff catalogDiff = new CatalogDiff().transforms(List.of());
-    when(connectionsHandler.getDiff(any(), any())).thenReturn(catalogDiff);
+    when(connectionsHandler.getDiff(any(), any(), any())).thenReturn(catalogDiff);
 
     when(operationsHandler.listOperationsForConnection(any())).thenReturn(operationReadList);
     when(connectionsHandler.getConnection(expected.getConnectionId())).thenReturn(
@@ -833,7 +833,7 @@ class WebBackendConnectionsHandlerTest {
     final ConnectionIdRequestBody connectionId = new ConnectionIdRequestBody().connectionId(result.getConnectionId());
     verify(schedulerHandler, times(0)).resetConnection(connectionId);
     verify(schedulerHandler, times(0)).syncConnection(connectionId);
-    verify(connectionsHandler, times(0)).getDiff(any(), any());
+    verify(connectionsHandler, times(0)).getDiff(any(), any(), any());
     verify(connectionsHandler, times(1)).updateConnection(any());
     verify(eventRunner, times(0)).resetConnection(any(), any(), eq(true));
   }

--- a/airbyte-webapp/src/views/Connection/CatalogDiffModal/CatalogDiffModal.test.tsx
+++ b/airbyte-webapp/src/views/Connection/CatalogDiffModal/CatalogDiffModal.test.tsx
@@ -53,14 +53,14 @@ const updatedItems: StreamTransform[] = [
     transformType: "update_stream",
     streamDescriptor: { namespace: "apple", name: "harissa_paste" },
     updateStream: [
-      { transformType: "add_field", fieldName: ["users", "phone"], isBreaking: false },
-      { transformType: "add_field", fieldName: ["users", "email"], isBreaking: false },
-      { transformType: "remove_field", fieldName: ["users", "lastName"], isBreaking: false },
+      { transformType: "add_field", fieldName: ["users", "phone"], breaking: false },
+      { transformType: "add_field", fieldName: ["users", "email"], breaking: false },
+      { transformType: "remove_field", fieldName: ["users", "lastName"], breaking: false },
 
       {
         transformType: "update_field_schema",
         fieldName: ["users", "address"],
-        isBreaking: false,
+        breaking: false,
         updateFieldSchema: { oldSchema: { type: "number" }, newSchema: { type: "string" } },
       },
     ],

--- a/airbyte-webapp/src/views/Connection/CatalogDiffModal/CatalogDiffModal.test.tsx
+++ b/airbyte-webapp/src/views/Connection/CatalogDiffModal/CatalogDiffModal.test.tsx
@@ -53,13 +53,14 @@ const updatedItems: StreamTransform[] = [
     transformType: "update_stream",
     streamDescriptor: { namespace: "apple", name: "harissa_paste" },
     updateStream: [
-      { transformType: "add_field", fieldName: ["users", "phone"] },
-      { transformType: "add_field", fieldName: ["users", "email"] },
-      { transformType: "remove_field", fieldName: ["users", "lastName"] },
+      { transformType: "add_field", fieldName: ["users", "phone"], isBreaking: false },
+      { transformType: "add_field", fieldName: ["users", "email"], isBreaking: false },
+      { transformType: "remove_field", fieldName: ["users", "lastName"], isBreaking: false },
 
       {
         transformType: "update_field_schema",
         fieldName: ["users", "address"],
+        isBreaking: false,
         updateFieldSchema: { oldSchema: { type: "number" }, newSchema: { type: "string" } },
       },
     ],

--- a/airbyte-webapp/src/views/Connection/CatalogDiffModal/index.stories.tsx
+++ b/airbyte-webapp/src/views/Connection/CatalogDiffModal/index.stories.tsx
@@ -33,12 +33,13 @@ Primary.args = {
         transformType: "update_stream",
         streamDescriptor: { namespace: "apple", name: "harissa_paste" },
         updateStream: [
-          { transformType: "add_field", fieldName: ["users", "phone"] },
-          { transformType: "add_field", fieldName: ["users", "email"] },
-          { transformType: "remove_field", fieldName: ["users", "lastName"] },
+          { transformType: "add_field", fieldName: ["users", "phone"], isBreaking: false },
+          { transformType: "add_field", fieldName: ["users", "email"], isBreaking: false },
+          { transformType: "remove_field", fieldName: ["users", "lastName"], isBreaking: false },
 
           {
             transformType: "update_field_schema",
+            isBreaking: false,
             fieldName: ["users", "address"],
             updateFieldSchema: { oldSchema: { type: "number" }, newSchema: { type: "string" } },
           },

--- a/airbyte-webapp/src/views/Connection/CatalogDiffModal/index.stories.tsx
+++ b/airbyte-webapp/src/views/Connection/CatalogDiffModal/index.stories.tsx
@@ -33,13 +33,13 @@ Primary.args = {
         transformType: "update_stream",
         streamDescriptor: { namespace: "apple", name: "harissa_paste" },
         updateStream: [
-          { transformType: "add_field", fieldName: ["users", "phone"], isBreaking: false },
-          { transformType: "add_field", fieldName: ["users", "email"], isBreaking: false },
-          { transformType: "remove_field", fieldName: ["users", "lastName"], isBreaking: false },
+          { transformType: "add_field", fieldName: ["users", "phone"], breaking: false },
+          { transformType: "add_field", fieldName: ["users", "email"], breaking: false },
+          { transformType: "remove_field", fieldName: ["users", "lastName"], breaking: false },
 
           {
             transformType: "update_field_schema",
-            isBreaking: false,
+            breaking: false,
             fieldName: ["users", "address"],
             updateFieldSchema: { oldSchema: { type: "number" }, newSchema: { type: "string" } },
           },

--- a/docs/reference/api/generated-api-html/index.html
+++ b/docs/reference/api/generated-api-html/index.html
@@ -8287,14 +8287,14 @@ containing the updated stream needs to be sent.</div>
         "addField" : { },
         "transformType" : "add_field",
         "removeField" : { },
-        "isBreaking" : true
+        "breaking" : true
       }, {
         "updateFieldSchema" : { },
         "fieldName" : [ "fieldName", "fieldName" ],
         "addField" : { },
         "transformType" : "add_field",
         "removeField" : { },
-        "isBreaking" : true
+        "breaking" : true
       } ]
     }, {
       "streamDescriptor" : {
@@ -8308,14 +8308,14 @@ containing the updated stream needs to be sent.</div>
         "addField" : { },
         "transformType" : "add_field",
         "removeField" : { },
-        "isBreaking" : true
+        "breaking" : true
       }, {
         "updateFieldSchema" : { },
         "fieldName" : [ "fieldName", "fieldName" ],
         "addField" : { },
         "transformType" : "add_field",
         "removeField" : { },
-        "isBreaking" : true
+        "breaking" : true
       } ]
     } ]
   },
@@ -8502,14 +8502,14 @@ containing the updated stream needs to be sent.</div>
         "addField" : { },
         "transformType" : "add_field",
         "removeField" : { },
-        "isBreaking" : true
+        "breaking" : true
       }, {
         "updateFieldSchema" : { },
         "fieldName" : [ "fieldName", "fieldName" ],
         "addField" : { },
         "transformType" : "add_field",
         "removeField" : { },
-        "isBreaking" : true
+        "breaking" : true
       } ]
     }, {
       "streamDescriptor" : {
@@ -8523,14 +8523,14 @@ containing the updated stream needs to be sent.</div>
         "addField" : { },
         "transformType" : "add_field",
         "removeField" : { },
-        "isBreaking" : true
+        "breaking" : true
       }, {
         "updateFieldSchema" : { },
         "fieldName" : [ "fieldName", "fieldName" ],
         "addField" : { },
         "transformType" : "add_field",
         "removeField" : { },
-        "isBreaking" : true
+        "breaking" : true
       } ]
     } ]
   },
@@ -8965,14 +8965,14 @@ containing the updated stream needs to be sent.</div>
         "addField" : { },
         "transformType" : "add_field",
         "removeField" : { },
-        "isBreaking" : true
+        "breaking" : true
       }, {
         "updateFieldSchema" : { },
         "fieldName" : [ "fieldName", "fieldName" ],
         "addField" : { },
         "transformType" : "add_field",
         "removeField" : { },
-        "isBreaking" : true
+        "breaking" : true
       } ]
     }, {
       "streamDescriptor" : {
@@ -8986,14 +8986,14 @@ containing the updated stream needs to be sent.</div>
         "addField" : { },
         "transformType" : "add_field",
         "removeField" : { },
-        "isBreaking" : true
+        "breaking" : true
       }, {
         "updateFieldSchema" : { },
         "fieldName" : [ "fieldName", "fieldName" ],
         "addField" : { },
         "transformType" : "add_field",
         "removeField" : { },
-        "isBreaking" : true
+        "breaking" : true
       } ]
     } ]
   },
@@ -10536,7 +10536,7 @@ containing the updated stream needs to be sent.</div>
         <div class="param-enum-header">Enum:</div>
         <div class="param-enum">add_field</div><div class="param-enum">remove_field</div><div class="param-enum">update_field_schema</div>
 <div class="param">fieldName </div><div class="param-desc"><span class="param-type"><a href="#string">array[String]</a></span> A field name is a list of strings that form the path to the field. </div>
-<div class="param">isBreaking </div><div class="param-desc"><span class="param-type"><a href="#boolean">Boolean</a></span>  </div>
+<div class="param">breaking </div><div class="param-desc"><span class="param-type"><a href="#boolean">Boolean</a></span>  </div>
 <div class="param">addField (optional)</div><div class="param-desc"><span class="param-type"><a href="#FieldAdd">FieldAdd</a></span>  </div>
 <div class="param">removeField (optional)</div><div class="param-desc"><span class="param-type"><a href="#FieldRemove">FieldRemove</a></span>  </div>
 <div class="param">updateFieldSchema (optional)</div><div class="param-desc"><span class="param-type"><a href="#FieldSchemaUpdate">FieldSchemaUpdate</a></span>  </div>

--- a/docs/reference/api/generated-api-html/index.html
+++ b/docs/reference/api/generated-api-html/index.html
@@ -8286,13 +8286,15 @@ containing the updated stream needs to be sent.</div>
         "fieldName" : [ "fieldName", "fieldName" ],
         "addField" : { },
         "transformType" : "add_field",
-        "removeField" : { }
+        "removeField" : { },
+        "isBreaking" : true
       }, {
         "updateFieldSchema" : { },
         "fieldName" : [ "fieldName", "fieldName" ],
         "addField" : { },
         "transformType" : "add_field",
-        "removeField" : { }
+        "removeField" : { },
+        "isBreaking" : true
       } ]
     }, {
       "streamDescriptor" : {
@@ -8305,13 +8307,15 @@ containing the updated stream needs to be sent.</div>
         "fieldName" : [ "fieldName", "fieldName" ],
         "addField" : { },
         "transformType" : "add_field",
-        "removeField" : { }
+        "removeField" : { },
+        "isBreaking" : true
       }, {
         "updateFieldSchema" : { },
         "fieldName" : [ "fieldName", "fieldName" ],
         "addField" : { },
         "transformType" : "add_field",
-        "removeField" : { }
+        "removeField" : { },
+        "isBreaking" : true
       } ]
     } ]
   },
@@ -8497,13 +8501,15 @@ containing the updated stream needs to be sent.</div>
         "fieldName" : [ "fieldName", "fieldName" ],
         "addField" : { },
         "transformType" : "add_field",
-        "removeField" : { }
+        "removeField" : { },
+        "isBreaking" : true
       }, {
         "updateFieldSchema" : { },
         "fieldName" : [ "fieldName", "fieldName" ],
         "addField" : { },
         "transformType" : "add_field",
-        "removeField" : { }
+        "removeField" : { },
+        "isBreaking" : true
       } ]
     }, {
       "streamDescriptor" : {
@@ -8516,13 +8522,15 @@ containing the updated stream needs to be sent.</div>
         "fieldName" : [ "fieldName", "fieldName" ],
         "addField" : { },
         "transformType" : "add_field",
-        "removeField" : { }
+        "removeField" : { },
+        "isBreaking" : true
       }, {
         "updateFieldSchema" : { },
         "fieldName" : [ "fieldName", "fieldName" ],
         "addField" : { },
         "transformType" : "add_field",
-        "removeField" : { }
+        "removeField" : { },
+        "isBreaking" : true
       } ]
     } ]
   },
@@ -8956,13 +8964,15 @@ containing the updated stream needs to be sent.</div>
         "fieldName" : [ "fieldName", "fieldName" ],
         "addField" : { },
         "transformType" : "add_field",
-        "removeField" : { }
+        "removeField" : { },
+        "isBreaking" : true
       }, {
         "updateFieldSchema" : { },
         "fieldName" : [ "fieldName", "fieldName" ],
         "addField" : { },
         "transformType" : "add_field",
-        "removeField" : { }
+        "removeField" : { },
+        "isBreaking" : true
       } ]
     }, {
       "streamDescriptor" : {
@@ -8975,13 +8985,15 @@ containing the updated stream needs to be sent.</div>
         "fieldName" : [ "fieldName", "fieldName" ],
         "addField" : { },
         "transformType" : "add_field",
-        "removeField" : { }
+        "removeField" : { },
+        "isBreaking" : true
       }, {
         "updateFieldSchema" : { },
         "fieldName" : [ "fieldName", "fieldName" ],
         "addField" : { },
         "transformType" : "add_field",
-        "removeField" : { }
+        "removeField" : { },
+        "isBreaking" : true
       } ]
     } ]
   },
@@ -10524,6 +10536,7 @@ containing the updated stream needs to be sent.</div>
         <div class="param-enum-header">Enum:</div>
         <div class="param-enum">add_field</div><div class="param-enum">remove_field</div><div class="param-enum">update_field_schema</div>
 <div class="param">fieldName </div><div class="param-desc"><span class="param-type"><a href="#string">array[String]</a></span> A field name is a list of strings that form the path to the field. </div>
+<div class="param">isBreaking </div><div class="param-desc"><span class="param-type"><a href="#boolean">Boolean</a></span>  </div>
 <div class="param">addField (optional)</div><div class="param-desc"><span class="param-type"><a href="#FieldAdd">FieldAdd</a></span>  </div>
 <div class="param">removeField (optional)</div><div class="param-desc"><span class="param-type"><a href="#FieldRemove">FieldRemove</a></span>  </div>
 <div class="param">updateFieldSchema (optional)</div><div class="param-desc"><span class="param-type"><a href="#FieldSchemaUpdate">FieldSchemaUpdate</a></span>  </div>


### PR DESCRIPTION
isBreaking is a new field on the FieldTransform object within the CatalogDiff object. When we calculate catalog diffs, we will now pass in the connection's configuredCatalog since that has data about the sync modes & primary and cursor fields for a connection.

A FieldTransform is considered 'breaking' if:
1. the connection is INCREMENTAL and the cursor field was removed OR
2. the connection is DEDUP and the primary key was removed

This PR does the following:
1. Update the FieldTransform object to add this new field
2. Populate the isBreaking field correctly within the getDiff calculation
3. Update the API to require the isBreaking field with the CatalogDiff response
4. Return the isBreaking field with API responses that include CatalogDiffs