### PR TITLE
🪟🧪 [Experiment] add hideOnboarding experiment

### DIFF
--- a/airbyte-webapp/src/hooks/services/Experiment/experiments.ts
+++ b/airbyte-webapp/src/hooks/services/Experiment/experiments.ts
@@ -4,6 +4,7 @@
  */
 
 export interface Experiments {
+  "onboarding.hideOnboarding": boolean;
   "connector.orderOverwrite": Record<string, number>;
   "connector.frequentlyUsedDestinationIds": string[];
   "connector.startWithDestinationId": string;

--- a/airbyte-webapp/src/packages/cloud/cloudRoutes.tsx
+++ b/airbyte-webapp/src/packages/cloud/cloudRoutes.tsx
@@ -6,6 +6,7 @@ import ApiErrorBoundary from "components/ApiErrorBoundary";
 import LoadingPage from "components/LoadingPage";
 
 import { useAnalyticsIdentifyUser, useAnalyticsRegisterValues } from "hooks/services/Analytics/useAnalyticsService";
+import { useExperiment } from "hooks/services/Experiment";
 import { FeatureItem, FeatureSet, useFeatureService } from "hooks/services/Feature";
 import { useApiHealthPoll } from "hooks/services/Health";
 import { OnboardingServiceProvider } from "hooks/services/Onboarding";
@@ -57,6 +58,7 @@ const MainRoutes: React.FC = () => {
   const { setWorkspaceFeatures } = useFeatureService();
   const workspace = useCurrentWorkspace();
   const cloudWorkspace = useGetCloudWorkspace(workspace.workspaceId);
+  const hideOnboardingExperiment = useExperiment("onboarding.hideOnboarding", false);
 
   useEffect(() => {
     const outOfCredits =
@@ -81,7 +83,8 @@ const MainRoutes: React.FC = () => {
   );
   useAnalyticsRegisterValues(analyticsContext);
 
-  const mainNavigate = workspace.displaySetupWizard ? RoutePaths.Onboarding : RoutePaths.Connections;
+  const mainNavigate =
+    workspace.displaySetupWizard && !hideOnboardingExperiment ? RoutePaths.Onboarding : RoutePaths.Connections;
 
   return (
     <ApiErrorBoundary>
@@ -92,7 +95,7 @@ const MainRoutes: React.FC = () => {
         <Route path={`${RoutePaths.Settings}/*`} element={<CloudSettingsPage />} />
         <Route path={CloudRoutes.Credits} element={<CreditsPage />} />
 
-        {workspace.displaySetupWizard && (
+        {workspace.displaySetupWizard && !hideOnboardingExperiment && (
           <Route
             path={RoutePaths.Onboarding}
             element={

--- a/airbyte-webapp/src/packages/cloud/views/layout/SideBar/SideBar.tsx
+++ b/airbyte-webapp/src/packages/cloud/views/layout/SideBar/SideBar.tsx
@@ -11,6 +11,7 @@ import { CreditsIcon } from "components/icons/CreditsIcon";
 import { Text } from "components/ui/Text";
 
 import { useConfig } from "config";
+import { useExperiment } from "hooks/services/Experiment";
 import { FeatureItem, IfFeatureEnabled } from "hooks/services/Feature";
 import { useCurrentWorkspace } from "hooks/services/useWorkspace";
 import { CloudRoutes } from "packages/cloud/cloudRoutes";
@@ -40,11 +41,16 @@ const SideBar: React.FC = () => {
   const config = useConfig();
   const { show } = useIntercom();
   const handleChatUs = () => show();
+  const hideOnboardingExperiment = useExperiment("onboarding.hideOnboarding", false);
 
   return (
     <nav className={styles.nav}>
       <div>
-        <Link to={workspace.displaySetupWizard ? RoutePaths.Onboarding : RoutePaths.Connections}>
+        <Link
+          to={
+            workspace.displaySetupWizard && !hideOnboardingExperiment ? RoutePaths.Onboarding : RoutePaths.Connections
+          }
+        >
           <img src="/simpleLogo.svg" alt="logo" height={33} width={33} />
         </Link>
         <WorkspacePopout>
@@ -55,7 +61,7 @@ const SideBar: React.FC = () => {
           )}
         </WorkspacePopout>
         <ul className={styles.menu}>
-          {workspace.displaySetupWizard ? (
+          {workspace.displaySetupWizard && !hideOnboardingExperiment ? (
             <li>
               <NavLink className={navLinkClassName} to={RoutePaths.Onboarding}>
                 <OnboardingIcon />


### PR DESCRIPTION
## What
Closes #17416, enabling an experiment to hide onboarding.

## How

- Adds a `onboarding.hideOnboarding` feature flag to LaunchDarkly
- This boolean flag toggles whether the onboarding route is accessible for cloud users. 
- When disabled, users are redirected to `/connections` after login.

Note: As far as I understand, feature flags are not used on OSS, so `src/pages/routes.tsx` remains unchanged (onboarding remains visible).

Before (or with feature flag disabled):
<img width="1454" alt="image" src="https://user-images.githubusercontent.com/7550957/194053627-bb334145-4794-4269-a068-2b75db85301c.png">

After (with feature flag enabled):
<img width="1452" alt="image" src="https://user-images.githubusercontent.com/7550957/194053822-5d25cb79-bcf4-4fa9-8908-bba1691d6105.png">
