### PR TITLE
Source Recharge: skip stream if 403 received

### DIFF
--- a/airbyte-config/init/src/main/resources/seed/source_definitions.yaml
+++ b/airbyte-config/init/src/main/resources/seed/source_definitions.yaml
@@ -876,7 +876,7 @@
 - name: Recharge
   sourceDefinitionId: 45d2e135-2ede-49e1-939f-3e3ec357a65e
   dockerRepository: airbyte/source-recharge
-  dockerImageTag: 0.2.2
+  dockerImageTag: 0.2.3
   documentationUrl: https://docs.airbyte.io/integrations/sources/recharge
   icon: recharge.svg
   sourceType: api

--- a/airbyte-config/init/src/main/resources/seed/source_specs.yaml
+++ b/airbyte-config/init/src/main/resources/seed/source_specs.yaml
@@ -9168,7 +9168,7 @@
     supportsNormalization: false
     supportsDBT: false
     supported_destination_sync_modes: []
-- dockerImage: "airbyte/source-recharge:0.2.2"
+- dockerImage: "airbyte/source-recharge:0.2.3"
   spec:
     documentationUrl: "https://docs.airbyte.com/integrations/sources/recharge"
     connectionSpecification:

--- a/airbyte-integrations/connectors/source-recharge/Dockerfile
+++ b/airbyte-integrations/connectors/source-recharge/Dockerfile
@@ -12,5 +12,5 @@ RUN pip install .
 ENV AIRBYTE_ENTRYPOINT "python /airbyte/integration_code/main.py"
 ENTRYPOINT ["python", "/airbyte/integration_code/main.py"]
 
-LABEL io.airbyte.version=0.2.2
+LABEL io.airbyte.version=0.2.3
 LABEL io.airbyte.name=airbyte/source-recharge

--- a/airbyte-integrations/connectors/source-recharge/source_recharge/api.py
+++ b/airbyte-integrations/connectors/source-recharge/source_recharge/api.py
@@ -70,6 +70,7 @@ class RechargeStream(HttpStream, ABC):
             return True
         elif forbidden_error:
             setattr(self, "raise_on_http_errors", False)
+            self.logger.error(f"Skiping stream {self.name} because of a 403 error.")
             return False
 
         return super().should_retry(response)

--- a/airbyte-integrations/connectors/source-recharge/source_recharge/api.py
+++ b/airbyte-integrations/connectors/source-recharge/source_recharge/api.py
@@ -76,7 +76,6 @@ class RechargeStream(HttpStream, ABC):
         return super().should_retry(response)
 
 
-
 class IncrementalRechargeStream(RechargeStream, ABC):
 
     cursor_field = "updated_at"

--- a/airbyte-integrations/connectors/source-recharge/source_recharge/api.py
+++ b/airbyte-integrations/connectors/source-recharge/source_recharge/api.py
@@ -19,6 +19,7 @@ class RechargeStream(HttpStream, ABC):
 
     limit = 250
     page_num = 1
+    raise_on_http_errors = True
 
     # regestring the default schema transformation
     transformer: TypeTransformer = TypeTransformer(TransformConfig.DefaultSchemaNormalization)
@@ -62,6 +63,10 @@ class RechargeStream(HttpStream, ABC):
 
     def should_retry(self, response: requests.Response) -> bool:
         res = super().should_retry(response)
+        if isinstance(response.json(), dict):
+            if response.status_code == requests.codes.FORBIDDEN:
+                setattr(self, "raise_on_http_errors", False)
+                return False
         if res:
             return res
 

--- a/docs/integrations/sources/recharge.md
+++ b/docs/integrations/sources/recharge.md
@@ -67,6 +67,7 @@ The Recharge connector should gracefully handle Recharge API limitations under n
 
 | Version | Date | Pull Request | Subject |
 | :--- | :--- | :--- | :--- |
+| 0.2.2 | 2022-10-05 | [00000](https://github.com/airbytehq/airbyte/pull/00000) | Skip stream if we receive 403 error
 | 0.2.2 | 2022-09-28 | [17304](https://github.com/airbytehq/airbyte/pull/17304) | Migrate to per-stream state.
 | 0.2.1 | 2022-09-23 | [17080](https://github.com/airbytehq/airbyte/pull/17080) | Fix `total_weight` value to be `int` instead of `float`
 | 0.2.0 | 2022-09-21 | [16959](https://github.com/airbytehq/airbyte/pull/16959) | Use TypeTransformer to reliably convert to schema declared data types

--- a/docs/integrations/sources/recharge.md
+++ b/docs/integrations/sources/recharge.md
@@ -67,7 +67,7 @@ The Recharge connector should gracefully handle Recharge API limitations under n
 
 | Version | Date | Pull Request | Subject |
 | :--- | :--- | :--- | :--- |
-| 0.2.2 | 2022-10-05 | [00000](https://github.com/airbytehq/airbyte/pull/00000) | Skip stream if we receive 403 error
+| 0.2.2 | 2022-10-05 | [17608](https://github.com/airbytehq/airbyte/pull/17608) | Skip stream if we receive 403 error
 | 0.2.2 | 2022-09-28 | [17304](https://github.com/airbytehq/airbyte/pull/17304) | Migrate to per-stream state.
 | 0.2.1 | 2022-09-23 | [17080](https://github.com/airbytehq/airbyte/pull/17080) | Fix `total_weight` value to be `int` instead of `float`
 | 0.2.0 | 2022-09-21 | [16959](https://github.com/airbytehq/airbyte/pull/16959) | Use TypeTransformer to reliably convert to schema declared data types


### PR DESCRIPTION
## What
Resolving:
https://github.com/airbytehq/alpha-beta-issues/issues/289

## How
Problem in the issue is caused by lack of permissions to retrieve a specific resource, so in order to handle this issue gracefully I have added a condition which will skip the problematic stream and continue the sync itself.


## Pre-merge Checklist

<details><summary><strong>Updating a connector</strong></summary>

### Community member or Airbyter

- [ ] Grant edit access to maintainers ([instructions](https://docs.github.com/en/github/collaborating-with-pull-requests/working-with-forks/allowing-changes-to-a-pull-request-branch-created-from-a-fork#enabling-repository-maintainer-permissions-on-existing-pull-requests))
- [ ] Secrets in the connector's spec are annotated with `airbyte_secret`
- [ ] Unit & integration tests added and passing. Community members, please provide proof of success locally e.g: screenshot or copy-paste unit, integration, and acceptance test output. To run acceptance tests for a Python connector, follow instructions in the README. For java connectors run `./gradlew :airbyte-integrations:connectors:<name>:integrationTest`.
- [ ] Code reviews completed
- [ ] Documentation updated
    - [ ] Connector's `README.md`
    - [ ] Connector's `bootstrap.md`. See [description and examples](https://docs.google.com/document/d/1ypdgmwmEHWv-TrO4_YOQ7pAJGVrMp5BOkEVh831N260/edit?usp=sharing)
    - [ ] Changelog updated in `docs/integrations/<source or destination>/<name>.md` including changelog. See changelog [example](https://docs.airbyte.io/integrations/sources/stripe#changelog)
- [ ] PR name follows [PR naming conventions](https://docs.airbyte.com/contributing-to-airbyte/issues-and-pull-requests)

### Airbyter

If this is a community PR, the Airbyte engineer reviewing this PR is responsible for the below items.

- [ ] Create a non-forked branch based on this PR and test the below items on it
- [ ] Build is successful
- [ ] If new credentials are required for use in CI, add them to GSM. [Instructions](https://docs.airbyte.io/connector-development#using-credentials-in-ci).
- [ ] [`/test connector=connectors/<name>` command](https://docs.airbyte.io/connector-development#updating-an-existing-connector) is passing
- [ ] New Connector version released on Dockerhub and connector version bumped by running the `/publish` command described [here](https://docs.airbyte.io/connector-development#updating-an-existing-connector)

</details>
