### PR TITLE
:window: :bug: Fixes connector checks not properly ending their loading state

### DIFF
--- a/airbyte-webapp/src/pages/SourcesPage/pages/SourceItemPage/components/SourceSettings.tsx
+++ b/airbyte-webapp/src/pages/SourcesPage/pages/SourceItemPage/components/SourceSettings.tsx
@@ -42,11 +42,12 @@ const SourceSettings: React.FC<SourceSettingsProps> = ({ currentSource, connecti
     name: string;
     serviceType: string;
     connectionConfiguration?: ConnectionConfiguration;
-  }) =>
+  }) => {
     await updateSource({
       values,
       sourceId: currentSource.sourceId,
     });
+  };
 
   const onDelete = async () => {
     clearFormChange(formId);

--- a/airbyte-webapp/src/views/Connector/ServiceForm/ServiceForm.test.tsx
+++ b/airbyte-webapp/src/views/Connector/ServiceForm/ServiceForm.test.tsx
@@ -244,7 +244,9 @@ describe("Service Form", () => {
         <ServiceForm
           formType="source"
           formValues={{ name: "test-name", serviceType: "test-service-type" }}
-          onSubmit={(values) => (result = values)}
+          onSubmit={(values) => {
+            result = values;
+          }}
           selectedConnectorDefinitionSpecification={
             // @ts-expect-error Partial objects for testing
             {

--- a/airbyte-webapp/src/views/Connector/ServiceForm/ServiceForm.tsx
+++ b/airbyte-webapp/src/views/Connector/ServiceForm/ServiceForm.tsx
@@ -303,9 +303,11 @@ const ServiceForm: React.FC<ServiceFormProps> = (props) => {
   );
 
   const onFormSubmit = useCallback(
-    (values: ServiceFormValues) => {
+    async (values: ServiceFormValues) => {
       const valuesToSend = getValues(values);
-      onSubmit(valuesToSend);
+      // This is currently wrongly typed but we'll need the await to not break code
+      // eslint-disable-next-line @typescript-eslint/await-thenable
+      await onSubmit(valuesToSend);
 
       clearFormChange(formId);
     },

--- a/airbyte-webapp/src/views/Connector/ServiceForm/ServiceForm.tsx
+++ b/airbyte-webapp/src/views/Connector/ServiceForm/ServiceForm.tsx
@@ -125,7 +125,7 @@ export interface ServiceFormProps {
     id: string,
     trackParams?: { actionDescription: string; connector_destination_suggested: boolean }
   ) => void;
-  onSubmit: (values: ServiceFormValues) => void;
+  onSubmit: (values: ServiceFormValues) => Promise<void> | void;
   isLoading?: boolean;
   isEditMode?: boolean;
   formValues?: Partial<ServiceFormValues>;
@@ -305,8 +305,6 @@ const ServiceForm: React.FC<ServiceFormProps> = (props) => {
   const onFormSubmit = useCallback(
     async (values: ServiceFormValues) => {
       const valuesToSend = getValues(values);
-      // This is currently wrongly typed but we'll need the await to not break code
-      // eslint-disable-next-line @typescript-eslint/await-thenable
       await onSubmit(valuesToSend);
 
       clearFormChange(formId);


### PR DESCRIPTION
## What

Fixes https://github.com/airbytehq/oncall/issues/747

Our types around this method were broken in a way, that causes those functions to actually be `async` and require the `await` here despite TypeScript thinking it shouldn't be async methods.

To test: Please make sure that setting up connectors with wrong data properly shows the error in the UI and isn't stuck in an infinite loading bar.