### PR TITLE
Moving TrackingClientSingleton.initialize into the bean itself

### DIFF
--- a/airbyte-workers/src/main/java/io/airbyte/workers/ApplicationInitializer.java
+++ b/airbyte-workers/src/main/java/io/airbyte/workers/ApplicationInitializer.java
@@ -4,25 +4,19 @@
 
 package io.airbyte.workers;
 
-import io.airbyte.analytics.Deployment;
-import io.airbyte.analytics.TrackingClientSingleton;
 import io.airbyte.commons.temporal.TemporalInitializationUtils;
 import io.airbyte.commons.temporal.TemporalJobType;
 import io.airbyte.commons.temporal.TemporalUtils;
 import io.airbyte.commons.version.AirbyteVersion;
-import io.airbyte.config.Configs.DeploymentMode;
-import io.airbyte.config.Configs.TrackingStrategy;
 import io.airbyte.config.Configs.WorkerEnvironment;
 import io.airbyte.config.MaxWorkersConfig;
 import io.airbyte.config.helpers.LogClientSingleton;
 import io.airbyte.config.helpers.LogConfigs;
-import io.airbyte.config.persistence.ConfigRepository;
 import io.airbyte.db.check.DatabaseCheckException;
 import io.airbyte.db.check.DatabaseMigrationCheck;
 import io.airbyte.db.check.impl.JobsDatabaseAvailabilityCheck;
 import io.airbyte.metrics.lib.MetricClientFactory;
 import io.airbyte.metrics.lib.MetricEmittingApps;
-import io.airbyte.persistence.job.JobPersistence;
 import io.airbyte.workers.config.WorkerMode;
 import io.airbyte.workers.process.KubePortManagerSingleton;
 import io.airbyte.workers.temporal.check.connection.CheckConnectionWorkflowImpl;
@@ -68,8 +62,6 @@ import lombok.extern.slf4j.Slf4j;
 @Slf4j
 public class ApplicationInitializer implements ApplicationEventListener<ServiceReadyEvent> {
 
-  @Value("${airbyte.role}")
-  private String airbyteRole;
   @Inject
   private AirbyteVersion airbyteVersion;
   @Inject
@@ -79,12 +71,8 @@ public class ApplicationInitializer implements ApplicationEventListener<ServiceR
   @Named("configsDatabaseMigrationCheck")
   private Optional<DatabaseMigrationCheck> configsDatabaseMigrationCheck;
   @Inject
-  private Optional<ConfigRepository> configRepository;
-  @Inject
   @Named("connectionManagerActivities")
   private Optional<List<Object>> connectionManagerActivities;
-  @Inject
-  private DeploymentMode deploymentMode;
   @Inject
   @Named("discoverActivities")
   private Optional<List<Object>> discoverActivities;
@@ -97,8 +85,7 @@ public class ApplicationInitializer implements ApplicationEventListener<ServiceR
   @Inject
   @Named("jobsDatabaseAvailabilityCheck")
   private Optional<JobsDatabaseAvailabilityCheck> jobsDatabaseAvailabilityCheck;
-  @Inject
-  private Optional<JobPersistence> jobPersistence;
+
   @Inject
   private Optional<LogConfigs> logConfigs;
   @Value("${airbyte.worker.check.max-workers}")
@@ -135,8 +122,6 @@ public class ApplicationInitializer implements ApplicationEventListener<ServiceR
   private TemporalUtils temporalUtils;
   @Value("${airbyte.temporal.worker.ports}")
   private Set<Integer> temporalWorkerPorts;
-  @Inject
-  private Optional<TrackingStrategy> trackingStrategy;
   @Inject
   private WorkerEnvironment workerEnvironment;
   @Inject
@@ -200,14 +185,6 @@ public class ApplicationInitializer implements ApplicationEventListener<ServiceR
     // Ensure that the Jobs database is available
     log.info("Checking jobs database availability...");
     jobsDatabaseAvailabilityCheck.orElseThrow().check();
-
-    TrackingClientSingleton.initialize(
-        trackingStrategy.orElseThrow(),
-        new Deployment(deploymentMode, jobPersistence.orElseThrow().getDeployment().orElseThrow(),
-            workerEnvironment),
-        airbyteRole,
-        airbyteVersion,
-        configRepository.orElseThrow());
   }
 
   private void registerWorkerFactory(final WorkerFactory workerFactory, final MaxWorkersConfig maxWorkersConfiguration) {

--- a/airbyte-workers/src/main/java/io/airbyte/workers/ApplicationInitializer.java
+++ b/airbyte-workers/src/main/java/io/airbyte/workers/ApplicationInitializer.java
@@ -7,7 +7,6 @@ package io.airbyte.workers;
 import io.airbyte.commons.temporal.TemporalInitializationUtils;
 import io.airbyte.commons.temporal.TemporalJobType;
 import io.airbyte.commons.temporal.TemporalUtils;
-import io.airbyte.commons.version.AirbyteVersion;
 import io.airbyte.config.Configs.WorkerEnvironment;
 import io.airbyte.config.MaxWorkersConfig;
 import io.airbyte.config.helpers.LogClientSingleton;
@@ -62,8 +61,6 @@ import lombok.extern.slf4j.Slf4j;
 @Slf4j
 public class ApplicationInitializer implements ApplicationEventListener<ServiceReadyEvent> {
 
-  @Inject
-  private AirbyteVersion airbyteVersion;
   @Inject
   @Named("checkConnectionActivities")
   private Optional<List<Object>> checkConnectionActivities;

--- a/airbyte-workers/src/main/java/io/airbyte/workers/config/TemporalBeanFactory.java
+++ b/airbyte-workers/src/main/java/io/airbyte/workers/config/TemporalBeanFactory.java
@@ -4,12 +4,18 @@
 
 package io.airbyte.workers.config;
 
+import io.airbyte.analytics.Deployment;
 import io.airbyte.analytics.TrackingClient;
 import io.airbyte.analytics.TrackingClientSingleton;
 import io.airbyte.commons.features.FeatureFlags;
 import io.airbyte.commons.temporal.TemporalUtils;
+import io.airbyte.commons.version.AirbyteVersion;
+import io.airbyte.config.Configs.DeploymentMode;
+import io.airbyte.config.Configs.TrackingStrategy;
+import io.airbyte.config.Configs.WorkerEnvironment;
 import io.airbyte.config.persistence.ConfigRepository;
 import io.airbyte.persistence.job.DefaultJobCreator;
+import io.airbyte.persistence.job.JobPersistence;
 import io.airbyte.persistence.job.factory.DefaultSyncJobFactory;
 import io.airbyte.persistence.job.factory.OAuthConfigSupplier;
 import io.airbyte.persistence.job.factory.SyncJobFactory;
@@ -23,7 +29,9 @@ import io.temporal.client.WorkflowClient;
 import io.temporal.serviceclient.WorkflowServiceStubs;
 import io.temporal.worker.WorkerFactory;
 import jakarta.inject.Singleton;
+import java.io.IOException;
 import java.nio.file.Path;
+import java.util.Optional;
 
 /**
  * Micronaut bean factory for Temporal-related singletons.
@@ -33,7 +41,23 @@ public class TemporalBeanFactory {
 
   @Singleton
   @Requires(env = WorkerMode.CONTROL_PLANE)
-  public TrackingClient trackingClient() {
+  public TrackingClient trackingClient(final Optional<TrackingStrategy> trackingStrategy,
+                                       final DeploymentMode deploymentMode,
+                                       Optional<JobPersistence> jobPersistence,
+                                       WorkerEnvironment workerEnvironment,
+                                       @Value("${airbyte.role}") String airbyteRole,
+                                       AirbyteVersion airbyteVersion,
+                                       Optional<ConfigRepository> configRepository)
+      throws IOException {
+
+    TrackingClientSingleton.initialize(
+        trackingStrategy.orElseThrow(),
+        new Deployment(deploymentMode, jobPersistence.orElseThrow().getDeployment().orElseThrow(),
+            workerEnvironment),
+        airbyteRole,
+        airbyteVersion,
+        configRepository.orElseThrow());
+
     return TrackingClientSingleton.get();
   }
 

--- a/airbyte-workers/src/main/resources/application.yml
+++ b/airbyte-workers/src/main/resources/application.yml
@@ -198,6 +198,7 @@ docker:
 endpoints:
   all:
     enabled: true
+    sensitive: false
 
 google:
   application:
@@ -218,4 +219,4 @@ logger:
   levels:
     io.airbyte.bootloader: DEBUG
 # Uncomment to help resolve issues with conditional beans
-#    io.micronaut.context.condition: DEBUG
+    io.micronaut.context.condition: DEBUG

--- a/airbyte-workers/src/main/resources/application.yml
+++ b/airbyte-workers/src/main/resources/application.yml
@@ -198,7 +198,6 @@ docker:
 endpoints:
   all:
     enabled: true
-    sensitive: false
 
 google:
   application:
@@ -219,4 +218,4 @@ logger:
   levels:
     io.airbyte.bootloader: DEBUG
 # Uncomment to help resolve issues with conditional beans
-    io.micronaut.context.condition: DEBUG
+#    io.micronaut.context.condition: DEBUG


### PR DESCRIPTION
https://github.com/airbytehq/oncall/issues/753

Moving TrackingClientSingleton.initialize into the bean

Noticed this bean was initialized before ApplicationInitializer; thus all trackingClient referred (especially in ApplicationBeanFactory.java) were using default logging client despite in the configuration we specified to use segment.

This shouldn't affect anything because within airbyte-worker no place is referring Singleton to generate a trackingClient except for this bean factory, and even if the bean was lazy initialized the only creation will still be from the bean defined in `TemporalBeanFactory` so we guarantee it will NOT be the default tracking client.
 
