### PR TITLE
Handle null workspace IDs in tracking/reporting methods gracefully

### DIFF
--- a/airbyte-analytics/src/main/java/io/airbyte/analytics/LoggingTrackingClient.java
+++ b/airbyte-analytics/src/main/java/io/airbyte/analytics/LoggingTrackingClient.java
@@ -10,6 +10,7 @@ import java.util.Map;
 import java.util.Optional;
 import java.util.UUID;
 import java.util.function.Function;
+import javax.annotation.Nullable;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -34,15 +35,21 @@ public class LoggingTrackingClient implements TrackingClient {
   }
 
   @Override
-  public void track(final UUID workspaceId, final String action) {
+  public void track(@Nullable final UUID workspaceId, final String action) {
     track(workspaceId, action, Collections.emptyMap());
   }
 
   @Override
-  public void track(final UUID workspaceId, final String action, final Map<String, Object> metadata) {
+  public void track(@Nullable final UUID workspaceId, final String action, final Map<String, Object> metadata) {
+    String version = null;
+    UUID userId = null;
+    if (workspaceId != null) {
+      version = Optional.ofNullable(identityFetcher.apply(workspaceId).getAirbyteVersion()).map(AirbyteVersion::serialize).orElse(null);
+      userId = identityFetcher.apply(workspaceId).getCustomerId();
+    }
     LOGGER.info("track. version: {}, userId: {}, action: {}, metadata: {}",
-        Optional.ofNullable(identityFetcher.apply(workspaceId).getAirbyteVersion()).map(AirbyteVersion::serialize).orElse(null),
-        identityFetcher.apply(workspaceId).getCustomerId(),
+        version,
+        userId,
         action,
         metadata);
   }

--- a/airbyte-analytics/src/main/java/io/airbyte/analytics/SegmentTrackingClient.java
+++ b/airbyte-analytics/src/main/java/io/airbyte/analytics/SegmentTrackingClient.java
@@ -17,6 +17,9 @@ import java.util.HashMap;
 import java.util.Map;
 import java.util.UUID;
 import java.util.function.Function;
+import javax.annotation.Nullable;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 /**
  * This class is a wrapper around the Segment backend Java SDK.
@@ -39,6 +42,8 @@ import java.util.function.Function;
  * https://docs.google.com/spreadsheets/d/1lGLmLIhiSPt_-oaEf3CpK-IxXnCO0NRHurvmWldoA2w/edit#gid=1567609168
  */
 public class SegmentTrackingClient implements TrackingClient {
+
+  private static final Logger LOGGER = LoggerFactory.getLogger(SegmentTrackingClient.class);
 
   public static final String CUSTOMER_ID_KEY = "user_id";
   private static final String SEGMENT_WRITE_KEY = "7UDdp5K55CyiGgsauOr2pNNujGvmhaeu";
@@ -106,12 +111,16 @@ public class SegmentTrackingClient implements TrackingClient {
   }
 
   @Override
-  public void track(final UUID workspaceId, final String action) {
+  public void track(@Nullable final UUID workspaceId, final String action) {
     track(workspaceId, action, Collections.emptyMap());
   }
 
   @Override
-  public void track(final UUID workspaceId, final String action, final Map<String, Object> metadata) {
+  public void track(@Nullable final UUID workspaceId, final String action, final Map<String, Object> metadata) {
+    if (workspaceId == null) {
+      LOGGER.error("Could not track action {} due to null workspaceId", action);
+      return;
+    }
     final Map<String, Object> mapCopy = new HashMap<>(metadata);
     final TrackingIdentity trackingIdentity = identityFetcher.apply(workspaceId);
 

--- a/airbyte-analytics/src/main/java/io/airbyte/analytics/TrackingClient.java
+++ b/airbyte-analytics/src/main/java/io/airbyte/analytics/TrackingClient.java
@@ -6,6 +6,7 @@ package io.airbyte.analytics;
 
 import java.util.Map;
 import java.util.UUID;
+import javax.annotation.Nullable;
 
 /**
  * General interface for user level Airbyte usage reporting. We use Segment for behavioural
@@ -28,8 +29,8 @@ public interface TrackingClient {
 
   void alias(UUID workspaceId, String previousCustomerId);
 
-  void track(UUID workspaceId, String action);
+  void track(@Nullable UUID workspaceId, String action);
 
-  void track(UUID workspaceId, String action, Map<String, Object> metadata);
+  void track(@Nullable UUID workspaceId, String action, Map<String, Object> metadata);
 
 }

--- a/airbyte-analytics/src/test/java/io/airbyte/analytics/SegmentTrackingClientTest.java
+++ b/airbyte-analytics/src/test/java/io/airbyte/analytics/SegmentTrackingClientTest.java
@@ -6,7 +6,9 @@ package io.airbyte.analytics;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
@@ -133,6 +135,13 @@ class SegmentTrackingClientTest {
     assertEquals(JUMP, actual.event());
     assertEquals(IDENTITY.getCustomerId().toString(), actual.userId());
     assertEquals(metadata, filterTrackedAtProperty(Objects.requireNonNull(actual.properties())));
+  }
+
+  @Test
+  void testTrackNullWorkspace() {
+    segmentTrackingClient.track(null, JUMP);
+
+    verify(analytics, never()).enqueue(any());
   }
 
   private static ImmutableMap<String, Object> filterTrackedAtProperty(final Map<String, ?> properties) {

--- a/airbyte-persistence/job-persistence/src/main/java/io/airbyte/persistence/job/errorreporter/JobErrorReporter.java
+++ b/airbyte-persistence/job-persistence/src/main/java/io/airbyte/persistence/job/errorreporter/JobErrorReporter.java
@@ -133,11 +133,11 @@ public class JobErrorReporter {
    * @param jobContext - connector job reporting context
    */
   public void reportSourceCheckJobFailure(final UUID sourceDefinitionId,
-                                          final UUID workspaceId,
+                                          @Nullable final UUID workspaceId,
                                           final FailureReason failureReason,
                                           final ConnectorJobReportingContext jobContext)
       throws JsonValidationException, ConfigNotFoundException, IOException {
-    final StandardWorkspace workspace = configRepository.getStandardWorkspace(workspaceId, true);
+    final StandardWorkspace workspace = workspaceId != null ? configRepository.getStandardWorkspace(workspaceId, true) : null;
     final StandardSourceDefinition sourceDefinition = configRepository.getStandardSourceDefinition(sourceDefinitionId);
     final Map<String, String> metadata = MoreMaps.merge(
         getSourceMetadata(sourceDefinition),
@@ -154,11 +154,11 @@ public class JobErrorReporter {
    * @param jobContext - connector job reporting context
    */
   public void reportDestinationCheckJobFailure(final UUID destinationDefinitionId,
-                                               final UUID workspaceId,
+                                               @Nullable final UUID workspaceId,
                                                final FailureReason failureReason,
                                                final ConnectorJobReportingContext jobContext)
       throws JsonValidationException, ConfigNotFoundException, IOException {
-    final StandardWorkspace workspace = configRepository.getStandardWorkspace(workspaceId, true);
+    final StandardWorkspace workspace = workspaceId != null ? configRepository.getStandardWorkspace(workspaceId, true) : null;
     final StandardDestinationDefinition destinationDefinition = configRepository.getStandardDestinationDefinition(destinationDefinitionId);
     final Map<String, String> metadata = MoreMaps.merge(
         getDestinationMetadata(destinationDefinition),
@@ -174,11 +174,11 @@ public class JobErrorReporter {
    * @param jobContext - connector job reporting context
    */
   public void reportDiscoverJobFailure(final UUID sourceDefinitionId,
-                                       final UUID workspaceId,
+                                       @Nullable final UUID workspaceId,
                                        final FailureReason failureReason,
                                        final ConnectorJobReportingContext jobContext)
       throws JsonValidationException, ConfigNotFoundException, IOException {
-    final StandardWorkspace workspace = configRepository.getStandardWorkspace(workspaceId, true);
+    final StandardWorkspace workspace = workspaceId != null ? configRepository.getStandardWorkspace(workspaceId, true) : null;
     final StandardSourceDefinition sourceDefinition = configRepository.getStandardSourceDefinition(sourceDefinitionId);
     final Map<String, String> metadata = MoreMaps.merge(
         getSourceMetadata(sourceDefinition),

--- a/airbyte-persistence/job-persistence/src/test/java/io/airbyte/persistence/job/errorreporter/JobErrorReporterTest.java
+++ b/airbyte-persistence/job-persistence/src/test/java/io/airbyte/persistence/job/errorreporter/JobErrorReporterTest.java
@@ -68,6 +68,11 @@ class JobErrorReporterTest {
   private static final String CONNECTOR_RELEASE_STAGE_KEY = "connector_release_stage";
   private static final String CONNECTOR_COMMAND_KEY = "connector_command";
   private static final String NORMALIZATION_REPOSITORY_KEY = "normalization_repository";
+  private static final String CHECK_COMMAND = "check";
+  private static final String DISCOVER_COMMAND = "discover";
+  private static final String SPEC_COMMAND = "spec";
+  private static final String READ_COMMAND = "read";
+  private static final String WRITE_COMMAND = "write";
 
   private ConfigRepository configRepository;
   private JobErrorReportingClient jobErrorReportingClient;
@@ -93,14 +98,14 @@ class JobErrorReporterTest {
     final FailureReason sourceFailureReason = new FailureReason()
         .withMetadata(new Metadata()
             .withAdditionalProperty(FROM_TRACE_MESSAGE, true)
-            .withAdditionalProperty(CONNECTOR_COMMAND_KEY, "read"))
+            .withAdditionalProperty(CONNECTOR_COMMAND_KEY, READ_COMMAND))
         .withFailureOrigin(FailureOrigin.SOURCE)
         .withFailureType(FailureType.SYSTEM_ERROR);
 
     final FailureReason destinationFailureReason = new FailureReason()
         .withMetadata(new Metadata()
             .withAdditionalProperty(FROM_TRACE_MESSAGE, true)
-            .withAdditionalProperty(CONNECTOR_COMMAND_KEY, "write"))
+            .withAdditionalProperty(CONNECTOR_COMMAND_KEY, WRITE_COMMAND))
         .withFailureOrigin(FailureOrigin.DESTINATION)
         .withFailureType(FailureType.SYSTEM_ERROR);
 
@@ -151,7 +156,7 @@ class JobErrorReporterTest {
         Map.entry(AIRBYTE_VERSION_KEY, AIRBYTE_VERSION),
         Map.entry(FAILURE_ORIGIN_KEY, SOURCE),
         Map.entry(FAILURE_TYPE_KEY, SYSTEM_ERROR),
-        Map.entry(CONNECTOR_COMMAND_KEY, "read"),
+        Map.entry(CONNECTOR_COMMAND_KEY, READ_COMMAND),
         Map.entry(CONNECTOR_DEFINITION_ID_KEY, SOURCE_DEFINITION_ID.toString()),
         Map.entry(CONNECTOR_REPOSITORY_KEY, SOURCE_DOCKER_REPOSITORY),
         Map.entry(CONNECTOR_NAME_KEY, SOURCE_DEFINITION_NAME),
@@ -167,7 +172,7 @@ class JobErrorReporterTest {
         Map.entry(AIRBYTE_VERSION_KEY, AIRBYTE_VERSION),
         Map.entry(FAILURE_ORIGIN_KEY, "destination"),
         Map.entry(FAILURE_TYPE_KEY, SYSTEM_ERROR),
-        Map.entry(CONNECTOR_COMMAND_KEY, "write"),
+        Map.entry(CONNECTOR_COMMAND_KEY, WRITE_COMMAND),
         Map.entry(CONNECTOR_DEFINITION_ID_KEY, DESTINATION_DEFINITION_ID.toString()),
         Map.entry(CONNECTOR_REPOSITORY_KEY, DESTINATION_DOCKER_REPOSITORY),
         Map.entry(CONNECTOR_NAME_KEY, DESTINATION_DEFINITION_NAME),
@@ -236,11 +241,10 @@ class JobErrorReporterTest {
 
   @Test
   void testReportSourceCheckJobFailure() throws JsonValidationException, ConfigNotFoundException, IOException {
-    final String connectorCommand = "check";
     final FailureReason failureReason = new FailureReason()
         .withMetadata(new Metadata()
             .withAdditionalProperty(FROM_TRACE_MESSAGE, true)
-            .withAdditionalProperty(CONNECTOR_COMMAND_KEY, connectorCommand))
+            .withAdditionalProperty(CONNECTOR_COMMAND_KEY, CHECK_COMMAND))
         .withFailureOrigin(FailureOrigin.SOURCE)
         .withFailureType(FailureType.SYSTEM_ERROR);
 
@@ -271,7 +275,7 @@ class JobErrorReporterTest {
         Map.entry(CONNECTOR_REPOSITORY_KEY, SOURCE_DOCKER_REPOSITORY),
         Map.entry(CONNECTOR_NAME_KEY, SOURCE_DEFINITION_NAME),
         Map.entry(CONNECTOR_RELEASE_STAGE_KEY, SOURCE_RELEASE_STAGE.toString()),
-        Map.entry(CONNECTOR_COMMAND_KEY, connectorCommand));
+        Map.entry(CONNECTOR_COMMAND_KEY, CHECK_COMMAND));
 
     Mockito.verify(jobErrorReportingClient).reportJobFailureReason(mWorkspace, failureReason, SOURCE_DOCKER_IMAGE, expectedMetadata);
     Mockito.verifyNoMoreInteractions(jobErrorReportingClient);
@@ -279,11 +283,10 @@ class JobErrorReporterTest {
 
   @Test
   void testReportSourceCheckJobFailureNullWorkspaceId() throws JsonValidationException, ConfigNotFoundException, IOException {
-    final String connectorCommand = "check";
     final FailureReason failureReason = new FailureReason()
         .withMetadata(new Metadata()
             .withAdditionalProperty(FROM_TRACE_MESSAGE, true)
-            .withAdditionalProperty(CONNECTOR_COMMAND_KEY, connectorCommand))
+            .withAdditionalProperty(CONNECTOR_COMMAND_KEY, CHECK_COMMAND))
         .withFailureOrigin(FailureOrigin.SOURCE)
         .withFailureType(FailureType.SYSTEM_ERROR);
 
@@ -308,7 +311,7 @@ class JobErrorReporterTest {
         Map.entry(CONNECTOR_REPOSITORY_KEY, SOURCE_DOCKER_REPOSITORY),
         Map.entry(CONNECTOR_NAME_KEY, SOURCE_DEFINITION_NAME),
         Map.entry(CONNECTOR_RELEASE_STAGE_KEY, SOURCE_RELEASE_STAGE.toString()),
-        Map.entry(CONNECTOR_COMMAND_KEY, connectorCommand));
+        Map.entry(CONNECTOR_COMMAND_KEY, CHECK_COMMAND));
 
     Mockito.verify(jobErrorReportingClient).reportJobFailureReason(null, failureReason, SOURCE_DOCKER_IMAGE, expectedMetadata);
     Mockito.verifyNoMoreInteractions(jobErrorReportingClient);
@@ -316,11 +319,10 @@ class JobErrorReporterTest {
 
   @Test
   void testReportDestinationCheckJobFailure() throws JsonValidationException, ConfigNotFoundException, IOException {
-    final String connectorCommand = "check";
     final FailureReason failureReason = new FailureReason()
         .withMetadata(new Metadata()
             .withAdditionalProperty(FROM_TRACE_MESSAGE, true)
-            .withAdditionalProperty(CONNECTOR_COMMAND_KEY, connectorCommand))
+            .withAdditionalProperty(CONNECTOR_COMMAND_KEY, CHECK_COMMAND))
         .withFailureOrigin(FailureOrigin.DESTINATION)
         .withFailureType(FailureType.SYSTEM_ERROR);
 
@@ -351,7 +353,7 @@ class JobErrorReporterTest {
         Map.entry(CONNECTOR_REPOSITORY_KEY, DESTINATION_DOCKER_REPOSITORY),
         Map.entry(CONNECTOR_NAME_KEY, DESTINATION_DEFINITION_NAME),
         Map.entry(CONNECTOR_RELEASE_STAGE_KEY, DESTINATION_RELEASE_STAGE.toString()),
-        Map.entry(CONNECTOR_COMMAND_KEY, connectorCommand));
+        Map.entry(CONNECTOR_COMMAND_KEY, CHECK_COMMAND));
 
     Mockito.verify(jobErrorReportingClient).reportJobFailureReason(mWorkspace, failureReason, DESTINATION_DOCKER_IMAGE, expectedMetadata);
     Mockito.verifyNoMoreInteractions(jobErrorReportingClient);
@@ -359,11 +361,10 @@ class JobErrorReporterTest {
 
   @Test
   void testReportDestinationCheckJobFailureNullWorkspaceId() throws JsonValidationException, ConfigNotFoundException, IOException {
-    final String connectorCommand = "check";
     final FailureReason failureReason = new FailureReason()
         .withMetadata(new Metadata()
             .withAdditionalProperty(FROM_TRACE_MESSAGE, true)
-            .withAdditionalProperty(CONNECTOR_COMMAND_KEY, connectorCommand))
+            .withAdditionalProperty(CONNECTOR_COMMAND_KEY, CHECK_COMMAND))
         .withFailureOrigin(FailureOrigin.DESTINATION)
         .withFailureType(FailureType.SYSTEM_ERROR);
 
@@ -388,7 +389,7 @@ class JobErrorReporterTest {
         Map.entry(CONNECTOR_REPOSITORY_KEY, DESTINATION_DOCKER_REPOSITORY),
         Map.entry(CONNECTOR_NAME_KEY, DESTINATION_DEFINITION_NAME),
         Map.entry(CONNECTOR_RELEASE_STAGE_KEY, DESTINATION_RELEASE_STAGE.toString()),
-        Map.entry(CONNECTOR_COMMAND_KEY, connectorCommand));
+        Map.entry(CONNECTOR_COMMAND_KEY, CHECK_COMMAND));
 
     Mockito.verify(jobErrorReportingClient).reportJobFailureReason(null, failureReason, DESTINATION_DOCKER_IMAGE, expectedMetadata);
     Mockito.verifyNoMoreInteractions(jobErrorReportingClient);
@@ -399,7 +400,7 @@ class JobErrorReporterTest {
     final FailureReason failureReason = new FailureReason()
         .withMetadata(new Metadata()
             .withAdditionalProperty(FROM_TRACE_MESSAGE, true)
-            .withAdditionalProperty(CONNECTOR_COMMAND_KEY, "discover"))
+            .withAdditionalProperty(CONNECTOR_COMMAND_KEY, DISCOVER_COMMAND))
         .withFailureOrigin(FailureOrigin.SOURCE)
         .withFailureType(FailureType.SYSTEM_ERROR);
 
@@ -430,7 +431,7 @@ class JobErrorReporterTest {
         Map.entry(CONNECTOR_REPOSITORY_KEY, SOURCE_DOCKER_REPOSITORY),
         Map.entry(CONNECTOR_NAME_KEY, SOURCE_DEFINITION_NAME),
         Map.entry(CONNECTOR_RELEASE_STAGE_KEY, SOURCE_RELEASE_STAGE.toString()),
-        Map.entry(CONNECTOR_COMMAND_KEY, "discover"));
+        Map.entry(CONNECTOR_COMMAND_KEY, DISCOVER_COMMAND));
 
     Mockito.verify(jobErrorReportingClient).reportJobFailureReason(mWorkspace, failureReason, SOURCE_DOCKER_IMAGE, expectedMetadata);
     Mockito.verifyNoMoreInteractions(jobErrorReportingClient);
@@ -441,7 +442,7 @@ class JobErrorReporterTest {
     final FailureReason failureReason = new FailureReason()
         .withMetadata(new Metadata()
             .withAdditionalProperty(FROM_TRACE_MESSAGE, true)
-            .withAdditionalProperty(CONNECTOR_COMMAND_KEY, "discover"))
+            .withAdditionalProperty(CONNECTOR_COMMAND_KEY, DISCOVER_COMMAND))
         .withFailureOrigin(FailureOrigin.SOURCE)
         .withFailureType(FailureType.SYSTEM_ERROR);
 
@@ -466,7 +467,7 @@ class JobErrorReporterTest {
         Map.entry(CONNECTOR_REPOSITORY_KEY, SOURCE_DOCKER_REPOSITORY),
         Map.entry(CONNECTOR_NAME_KEY, SOURCE_DEFINITION_NAME),
         Map.entry(CONNECTOR_RELEASE_STAGE_KEY, SOURCE_RELEASE_STAGE.toString()),
-        Map.entry(CONNECTOR_COMMAND_KEY, "discover"));
+        Map.entry(CONNECTOR_COMMAND_KEY, DISCOVER_COMMAND));
 
     Mockito.verify(jobErrorReportingClient).reportJobFailureReason(null, failureReason, SOURCE_DOCKER_IMAGE, expectedMetadata);
     Mockito.verifyNoMoreInteractions(jobErrorReportingClient);
@@ -477,7 +478,7 @@ class JobErrorReporterTest {
     final FailureReason failureReason = new FailureReason()
         .withMetadata(new Metadata()
             .withAdditionalProperty(FROM_TRACE_MESSAGE, true)
-            .withAdditionalProperty(CONNECTOR_COMMAND_KEY, "spec"))
+            .withAdditionalProperty(CONNECTOR_COMMAND_KEY, SPEC_COMMAND))
         .withFailureOrigin(FailureOrigin.SOURCE)
         .withFailureType(FailureType.SYSTEM_ERROR);
 
@@ -492,7 +493,7 @@ class JobErrorReporterTest {
         Map.entry(FAILURE_ORIGIN_KEY, SOURCE),
         Map.entry(FAILURE_TYPE_KEY, SYSTEM_ERROR),
         Map.entry(CONNECTOR_REPOSITORY_KEY, SOURCE_DOCKER_REPOSITORY),
-        Map.entry(CONNECTOR_COMMAND_KEY, "spec"));
+        Map.entry(CONNECTOR_COMMAND_KEY, SPEC_COMMAND));
 
     Mockito.verify(jobErrorReportingClient).reportJobFailureReason(null, failureReason, SOURCE_DOCKER_IMAGE, expectedMetadata);
     Mockito.verifyNoMoreInteractions(jobErrorReportingClient);

--- a/airbyte-persistence/job-persistence/src/test/java/io/airbyte/persistence/job/errorreporter/JobErrorReporterTest.java
+++ b/airbyte-persistence/job-persistence/src/test/java/io/airbyte/persistence/job/errorreporter/JobErrorReporterTest.java
@@ -278,6 +278,43 @@ class JobErrorReporterTest {
   }
 
   @Test
+  void testReportSourceCheckJobFailureNullWorkspaceId() throws JsonValidationException, ConfigNotFoundException, IOException {
+    final String connectorCommand = "check";
+    final FailureReason failureReason = new FailureReason()
+        .withMetadata(new Metadata()
+            .withAdditionalProperty(FROM_TRACE_MESSAGE, true)
+            .withAdditionalProperty(CONNECTOR_COMMAND_KEY, connectorCommand))
+        .withFailureOrigin(FailureOrigin.SOURCE)
+        .withFailureType(FailureType.SYSTEM_ERROR);
+
+    final ConnectorJobReportingContext jobContext = new ConnectorJobReportingContext(JOB_ID, SOURCE_DOCKER_IMAGE);
+
+    Mockito.when(configRepository.getStandardSourceDefinition(SOURCE_DEFINITION_ID))
+        .thenReturn(new StandardSourceDefinition()
+            .withDockerRepository(SOURCE_DOCKER_REPOSITORY)
+            .withReleaseStage(SOURCE_RELEASE_STAGE)
+            .withSourceDefinitionId(SOURCE_DEFINITION_ID)
+            .withName(SOURCE_DEFINITION_NAME));
+
+    jobErrorReporter.reportSourceCheckJobFailure(SOURCE_DEFINITION_ID, null, failureReason, jobContext);
+
+    final Map<String, String> expectedMetadata = Map.ofEntries(
+        Map.entry(JOB_ID_KEY, JOB_ID.toString()),
+        Map.entry(DEPLOYMENT_MODE_KEY, DEPLOYMENT_MODE.name()),
+        Map.entry(AIRBYTE_VERSION_KEY, AIRBYTE_VERSION),
+        Map.entry(FAILURE_ORIGIN_KEY, SOURCE),
+        Map.entry(FAILURE_TYPE_KEY, SYSTEM_ERROR),
+        Map.entry(CONNECTOR_DEFINITION_ID_KEY, SOURCE_DEFINITION_ID.toString()),
+        Map.entry(CONNECTOR_REPOSITORY_KEY, SOURCE_DOCKER_REPOSITORY),
+        Map.entry(CONNECTOR_NAME_KEY, SOURCE_DEFINITION_NAME),
+        Map.entry(CONNECTOR_RELEASE_STAGE_KEY, SOURCE_RELEASE_STAGE.toString()),
+        Map.entry(CONNECTOR_COMMAND_KEY, connectorCommand));
+
+    Mockito.verify(jobErrorReportingClient).reportJobFailureReason(null, failureReason, SOURCE_DOCKER_IMAGE, expectedMetadata);
+    Mockito.verifyNoMoreInteractions(jobErrorReportingClient);
+  }
+
+  @Test
   void testReportDestinationCheckJobFailure() throws JsonValidationException, ConfigNotFoundException, IOException {
     final String connectorCommand = "check";
     final FailureReason failureReason = new FailureReason()
@@ -321,6 +358,43 @@ class JobErrorReporterTest {
   }
 
   @Test
+  void testReportDestinationCheckJobFailureNullWorkspaceId() throws JsonValidationException, ConfigNotFoundException, IOException {
+    final String connectorCommand = "check";
+    final FailureReason failureReason = new FailureReason()
+        .withMetadata(new Metadata()
+            .withAdditionalProperty(FROM_TRACE_MESSAGE, true)
+            .withAdditionalProperty(CONNECTOR_COMMAND_KEY, connectorCommand))
+        .withFailureOrigin(FailureOrigin.DESTINATION)
+        .withFailureType(FailureType.SYSTEM_ERROR);
+
+    final ConnectorJobReportingContext jobContext = new ConnectorJobReportingContext(JOB_ID, DESTINATION_DOCKER_IMAGE);
+
+    Mockito.when(configRepository.getStandardDestinationDefinition(DESTINATION_DEFINITION_ID))
+        .thenReturn(new StandardDestinationDefinition()
+            .withDockerRepository(DESTINATION_DOCKER_REPOSITORY)
+            .withReleaseStage(DESTINATION_RELEASE_STAGE)
+            .withDestinationDefinitionId(DESTINATION_DEFINITION_ID)
+            .withName(DESTINATION_DEFINITION_NAME));
+
+    jobErrorReporter.reportDestinationCheckJobFailure(DESTINATION_DEFINITION_ID, null, failureReason, jobContext);
+
+    final Map<String, String> expectedMetadata = Map.ofEntries(
+        Map.entry(JOB_ID_KEY, JOB_ID.toString()),
+        Map.entry(DEPLOYMENT_MODE_KEY, DEPLOYMENT_MODE.name()),
+        Map.entry(AIRBYTE_VERSION_KEY, AIRBYTE_VERSION),
+        Map.entry(FAILURE_ORIGIN_KEY, "destination"),
+        Map.entry(FAILURE_TYPE_KEY, SYSTEM_ERROR),
+        Map.entry(CONNECTOR_DEFINITION_ID_KEY, DESTINATION_DEFINITION_ID.toString()),
+        Map.entry(CONNECTOR_REPOSITORY_KEY, DESTINATION_DOCKER_REPOSITORY),
+        Map.entry(CONNECTOR_NAME_KEY, DESTINATION_DEFINITION_NAME),
+        Map.entry(CONNECTOR_RELEASE_STAGE_KEY, DESTINATION_RELEASE_STAGE.toString()),
+        Map.entry(CONNECTOR_COMMAND_KEY, connectorCommand));
+
+    Mockito.verify(jobErrorReportingClient).reportJobFailureReason(null, failureReason, DESTINATION_DOCKER_IMAGE, expectedMetadata);
+    Mockito.verifyNoMoreInteractions(jobErrorReportingClient);
+  }
+
+  @Test
   void testReportDiscoverJobFailure() throws JsonValidationException, ConfigNotFoundException, IOException {
     final FailureReason failureReason = new FailureReason()
         .withMetadata(new Metadata()
@@ -359,6 +433,42 @@ class JobErrorReporterTest {
         Map.entry(CONNECTOR_COMMAND_KEY, "discover"));
 
     Mockito.verify(jobErrorReportingClient).reportJobFailureReason(mWorkspace, failureReason, SOURCE_DOCKER_IMAGE, expectedMetadata);
+    Mockito.verifyNoMoreInteractions(jobErrorReportingClient);
+  }
+
+  @Test
+  void testReportDiscoverJobFailureNullWorkspaceId() throws JsonValidationException, ConfigNotFoundException, IOException {
+    final FailureReason failureReason = new FailureReason()
+        .withMetadata(new Metadata()
+            .withAdditionalProperty(FROM_TRACE_MESSAGE, true)
+            .withAdditionalProperty(CONNECTOR_COMMAND_KEY, "discover"))
+        .withFailureOrigin(FailureOrigin.SOURCE)
+        .withFailureType(FailureType.SYSTEM_ERROR);
+
+    final ConnectorJobReportingContext jobContext = new ConnectorJobReportingContext(JOB_ID, SOURCE_DOCKER_IMAGE);
+
+    Mockito.when(configRepository.getStandardSourceDefinition(SOURCE_DEFINITION_ID))
+        .thenReturn(new StandardSourceDefinition()
+            .withDockerRepository(SOURCE_DOCKER_REPOSITORY)
+            .withReleaseStage(SOURCE_RELEASE_STAGE)
+            .withSourceDefinitionId(SOURCE_DEFINITION_ID)
+            .withName(SOURCE_DEFINITION_NAME));
+
+    jobErrorReporter.reportDiscoverJobFailure(SOURCE_DEFINITION_ID, null, failureReason, jobContext);
+
+    final Map<String, String> expectedMetadata = Map.ofEntries(
+        Map.entry(JOB_ID_KEY, JOB_ID.toString()),
+        Map.entry(DEPLOYMENT_MODE_KEY, DEPLOYMENT_MODE.name()),
+        Map.entry(AIRBYTE_VERSION_KEY, AIRBYTE_VERSION),
+        Map.entry(FAILURE_ORIGIN_KEY, SOURCE),
+        Map.entry(FAILURE_TYPE_KEY, SYSTEM_ERROR),
+        Map.entry(CONNECTOR_DEFINITION_ID_KEY, SOURCE_DEFINITION_ID.toString()),
+        Map.entry(CONNECTOR_REPOSITORY_KEY, SOURCE_DOCKER_REPOSITORY),
+        Map.entry(CONNECTOR_NAME_KEY, SOURCE_DEFINITION_NAME),
+        Map.entry(CONNECTOR_RELEASE_STAGE_KEY, SOURCE_RELEASE_STAGE.toString()),
+        Map.entry(CONNECTOR_COMMAND_KEY, "discover"));
+
+    Mockito.verify(jobErrorReportingClient).reportJobFailureReason(null, failureReason, SOURCE_DOCKER_IMAGE, expectedMetadata);
     Mockito.verifyNoMoreInteractions(jobErrorReportingClient);
   }
 


### PR DESCRIPTION
## What
One offshoot of this issue (https://github.com/airbytehq/oncall/issues/747) that Tim noted was that the entire connection check job was failing when Oauth had not been configured in the Facebook Marketing source connector, rather than the connection check job finishing and reporting the actual issue with the configuration.

To look into this issue, I inspected the airbyte-server logs when trying to set up a Facebook Marketing connector that I had not yet authenticated, and I saw these NPE stacktraces appearing in the logs when I did this:
```
airbyte-server-5d497bc9bc-26mxw server java.lang.NullPointerException: Cannot invoke "java.util.UUID.toString()" because "workspaceId" is null
airbyte-server-5d497bc9bc-26mxw server 	at io.airbyte.config.persistence.ConfigRepository.getStandardWorkspace(ConfigRepository.java:113) ~[config-persistence-dev-a17c832.jar:?]
airbyte-server-5d497bc9bc-26mxw server 	at io.airbyte.analytics.TrackingClientSingleton.getTrackingIdentity(TrackingClientSingleton.java:64) ~[airbyte-analytics-dev-a17c832.jar:?]
airbyte-server-5d497bc9bc-26mxw server 	at io.airbyte.analytics.TrackingClientSingleton.lambda$initialize$0(TrackingClientSingleton.java:53) ~[airbyte-analytics-dev-a17c832.jar:?]
airbyte-server-5d497bc9bc-26mxw server 	at io.airbyte.analytics.SegmentTrackingClient.track(SegmentTrackingClient.java:116) ~[airbyte-analytics-dev-a17c832.jar:?]
airbyte-server-5d497bc9bc-26mxw server 	at io.airbyte.persistence.job.factory.OAuthConfigSupplier.lambda$injectSourceOAuthParameters$0(OAuthConfigSupplier.java:59) ~[job-persistence-dev-a17c832.jar:?]
airbyte-server-5d497bc9bc-26mxw server 	at io.airbyte.commons.lang.Exceptions.swallow(Exceptions.java:64) ~[airbyte-commons-dev-a17c832.jar:?]
airbyte-server-5d497bc9bc-26mxw server 	at io.airbyte.persistence.job.factory.OAuthConfigSupplier.lambda$injectSourceOAuthParameters$1(OAuthConfigSupplier.java:59) ~[job-persistence-dev-a17c832.jar:?]
airbyte-server-5d497bc9bc-26mxw server 	at java.util.Optional.ifPresent(Optional.java:178) ~[?:?]
airbyte-server-5d497bc9bc-26mxw server 	at io.airbyte.persistence.job.factory.OAuthConfigSupplier.injectSourceOAuthParameters(OAuthConfigSupplier.java:55) ~[job-persistence-dev-a17c832.jar:?]
airbyte-server-5d497bc9bc-26mxw server 	at io.airbyte.server.scheduler.DefaultSynchronousSchedulerClient.createSourceCheckConnectionJob(DefaultSynchronousSchedulerClient.java:59) ~[airbyte-server-dev-a17c832.jar:?]
airbyte-server-5d497bc9bc-26mxw server 	at io.airbyte.server.handlers.SchedulerHandler.checkSourceConnectionFromSourceCreate(SchedulerHandler.java:152) ~[airbyte-server-dev-a17c832.jar:?]
airbyte-server-5d497bc9bc-26mxw server 	at io.airbyte.server.wrapped.connection_spec_handler.SpecMutatingHandler.checkSourceConnectionFromSourceCreate(SpecMutatingHandler.java:238) ~[io.airbyte-cloud-airbyte-server-wrapped-dev-a17c832-f9fcead.jar:?]
airbyte-server-5d497bc9bc-26mxw server 	at io.airbyte.server.wrapped.ConfigurationApiWrapped.lambda$executeSourceCheckConnection$93(ConfigurationApiWrapped.java:982) ~[io.airbyte-cloud-airbyte-server-wrapped-dev-a17c832-f9fcead.jar:?]
airbyte-server-5d497bc9bc-26mxw server 	at io.airbyte.cloud.auth.AuthHelper.execute(AuthHelper.java:223) ~[io.airbyte-cloud-cloud-auth-dev-a17c832-f9fcead.jar:?]
airbyte-server-5d497bc9bc-26mxw server 	at io.airbyte.cloud.auth.AuthHelper.authForInstance(AuthHelper.java:147) ~[io.airbyte-cloud-cloud-auth-dev-a17c832-f9fcead.jar:?]
airbyte-server-5d497bc9bc-26mxw server 	at io.airbyte.server.wrapped.ConfigurationApiWrapped.executeSourceCheckConnection(ConfigurationApiWrapped.java:980) ~[io.airbyte-cloud-airbyte-server-wrapped-dev-a17c832-f9fcead.jar:?]
```
and
```
airbyte-server-5d497bc9bc-26mxw server java.lang.NullPointerException: Cannot invoke "java.util.UUID.toString()" because "workspaceId" is null
airbyte-server-5d497bc9bc-26mxw server 	at io.airbyte.config.persistence.ConfigRepository.getStandardWorkspace(ConfigRepository.java:113) ~[config-persistence-dev-a17c832.jar:?]
airbyte-server-5d497bc9bc-26mxw server 	at io.airbyte.persistence.job.errorreporter.JobErrorReporter.reportSourceCheckJobFailure(JobErrorReporter.java:140) ~[job-persistence-dev-a17c832.jar:?]
airbyte-server-5d497bc9bc-26mxw server 	at io.airbyte.server.scheduler.DefaultSynchronousSchedulerClient.lambda$reportError$4(DefaultSynchronousSchedulerClient.java:218) ~[airbyte-server-dev-a17c832.jar:?]
airbyte-server-5d497bc9bc-26mxw server 	at io.airbyte.commons.lang.Exceptions.swallow(Exceptions.java:64) ~[airbyte-commons-dev-a17c832.jar:?]
airbyte-server-5d497bc9bc-26mxw server 	at io.airbyte.server.scheduler.DefaultSynchronousSchedulerClient.reportError(DefaultSynchronousSchedulerClient.java:216) ~[airbyte-server-dev-a17c832.jar:?]
airbyte-server-5d497bc9bc-26mxw server 	at io.airbyte.server.scheduler.DefaultSynchronousSchedulerClient.execute(DefaultSynchronousSchedulerClient.java:161) ~[airbyte-server-dev-a17c832.jar:?]
airbyte-server-5d497bc9bc-26mxw server 	at io.airbyte.server.scheduler.DefaultSynchronousSchedulerClient.createSourceCheckConnectionJob(DefaultSynchronousSchedulerClient.java:70) ~[airbyte-server-dev-a17c832.jar:?]
airbyte-server-5d497bc9bc-26mxw server 	at io.airbyte.server.handlers.SchedulerHandler.checkSourceConnectionFromSourceCreate(SchedulerHandler.java:152) ~[airbyte-server-dev-a17c832.jar:?]
airbyte-server-5d497bc9bc-26mxw server 	at io.airbyte.server.wrapped.connection_spec_handler.SpecMutatingHandler.checkSourceConnectionFromSourceCreate(SpecMutatingHandler.java:238) ~[io.airbyte-cloud-airbyte-server-wrapped-dev-a17c832-f9fcead.jar:?]
airbyte-server-5d497bc9bc-26mxw server 	at io.airbyte.server.wrapped.ConfigurationApiWrapped.lambda$executeSourceCheckConnection$93(ConfigurationApiWrapped.java:982) ~[io.airbyte-cloud-airbyte-server-wrapped-dev-a17c832-f9fcead.jar:?]
airbyte-server-5d497bc9bc-26mxw server 	at io.airbyte.cloud.auth.AuthHelper.execute(AuthHelper.java:223) ~[io.airbyte-cloud-cloud-auth-dev-a17c832-f9fcead.jar:?]
airbyte-server-5d497bc9bc-26mxw server 	at io.airbyte.cloud.auth.AuthHelper.authForInstance(AuthHelper.java:147) ~[io.airbyte-cloud-cloud-auth-dev-a17c832-f9fcead.jar:?]
airbyte-server-5d497bc9bc-26mxw server 	at io.airbyte.server.wrapped.ConfigurationApiWrapped.executeSourceCheckConnection(ConfigurationApiWrapped.java:980) 
```

The reason the workspace ID is null in this case is because the API call for checking the connection of a source/destination that is actively being created does not include the workspace ID, so the server doesn't have any way to determine what the workspace ID is. See https://github.com/airbytehq/airbyte/blob/77084beecd43e8675148f13c2f549d99de500418/airbyte-server/src/main/java/io/airbyte/server/apis/ConfigurationApi.java#L736

## How
This PR fixes those NPEs by gracefully handling the case where the workspace ID is null (either by avoiding querying the workspace at all or not tracking the event).

An alternative fix here could be to pass in the workspace ID for these endpoints so that the tracking logic works properly for them. I opted to fix the null workspaceID case first though, just in case there are other API endpoints with the same issue.
