### PR TITLE
Add Workspace and Connection Geography Support to API

### DIFF
--- a/airbyte-analytics/src/test/java/io/airbyte/analytics/TrackingClientSingletonTest.java
+++ b/airbyte-analytics/src/test/java/io/airbyte/analytics/TrackingClientSingletonTest.java
@@ -12,6 +12,7 @@ import static org.mockito.Mockito.when;
 import io.airbyte.commons.version.AirbyteVersion;
 import io.airbyte.config.Configs;
 import io.airbyte.config.Configs.WorkerEnvironment;
+import io.airbyte.config.Geography;
 import io.airbyte.config.StandardWorkspace;
 import io.airbyte.config.persistence.ConfigNotFoundException;
 import io.airbyte.config.persistence.ConfigRepository;
@@ -111,7 +112,8 @@ class TrackingClientSingletonTest {
         .withEmail(EMAIL)
         .withAnonymousDataCollection(false)
         .withNews(true)
-        .withSecurityUpdates(true);
+        .withSecurityUpdates(true)
+        .withDefaultGeography(Geography.AUTO);
 
     when(configRepository.getStandardWorkspace(WORKSPACE_ID, true)).thenReturn(workspace);
 
@@ -129,7 +131,8 @@ class TrackingClientSingletonTest {
         .withEmail("a@airbyte.io")
         .withAnonymousDataCollection(true)
         .withNews(true)
-        .withSecurityUpdates(true);
+        .withSecurityUpdates(true)
+        .withDefaultGeography(Geography.AUTO);
 
     when(configRepository.getStandardWorkspace(WORKSPACE_ID, true)).thenReturn(workspace);
 

--- a/airbyte-api/src/main/openapi/config.yaml
+++ b/airbyte-api/src/main/openapi/config.yaml
@@ -3295,6 +3295,8 @@ components:
         sourceCatalogId:
           type: string
           format: uuid
+        geography:
+          $ref: "#/components/schemas/Geography"
     WebBackendConnectionUpdate:
       type: object
       description: Used to apply a patch-style update to a connection, which means that null properties remain unchanged

--- a/airbyte-api/src/main/openapi/config.yaml
+++ b/airbyte-api/src/main/openapi/config.yaml
@@ -2036,6 +2036,19 @@ paths:
           $ref: "#/components/responses/NotFoundResponse"
         "422":
           $ref: "#/components/responses/InvalidInputResponse"
+  /v1/web_backend/geographies/list:
+    post:
+      tags:
+        - web_backend
+      summary: Returns two-letter country codes that can be selected for running data syncs in a particular geography.
+      operationId: webBackendListGeographies
+      responses:
+        "200":
+          description: Successful operation
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/WebBackendGeographiesListResult"
   /v1/jobs/list:
     post:
       tags:
@@ -2260,6 +2273,8 @@ components:
             $ref: "#/components/schemas/Notification"
         displaySetupWizard:
           type: boolean
+        defaultGeography:
+          $ref: "#/components/schemas/Geography"
     Notification:
       type: object
       required:
@@ -2362,6 +2377,8 @@ components:
           type: boolean
         feedbackDone:
           type: boolean
+        defaultGeography:
+          $ref: "#/components/schemas/Geography"
     WorkspaceUpdateName:
       type: object
       required:
@@ -2397,6 +2414,8 @@ components:
           type: array
           items:
             $ref: "#/components/schemas/Notification"
+        defaultGeography:
+          $ref: "#/components/schemas/Geography"
     WorkspaceGiveFeedback:
       type: object
       required:
@@ -2424,6 +2443,15 @@ components:
           type: boolean
         hasDestinations:
           type: boolean
+    WebBackendGeographiesListResult:
+      type: object
+      required:
+        - geographies
+      properties:
+        geographies:
+          type: array
+          items:
+            $ref: "#/components/schemas/Geography"
     # SLUG
     SlugRequestBody:
       type: object
@@ -2432,6 +2460,13 @@ components:
       properties:
         slug:
           type: string
+    # Geography
+    Geography:
+      type: string
+      enum:
+        - auto
+        - us
+        - eu
     # SourceDefinition
     SourceDefinitionId:
       type: string
@@ -3206,6 +3241,8 @@ components:
         sourceCatalogId:
           type: string
           format: uuid
+        geography:
+          $ref: "#/components/schemas/Geography"
     ConnectionStateCreateOrUpdate:
       type: object
       required:
@@ -3298,6 +3335,8 @@ components:
         sourceCatalogId:
           type: string
           format: uuid
+        geography:
+          $ref: "#/components/schemas/Geography"
     ConnectionRead:
       type: object
       required:
@@ -3345,6 +3384,8 @@ components:
         sourceCatalogId:
           type: string
           format: uuid
+        geography:
+          $ref: "#/components/schemas/Geography"
     ConnectionSearch:
       type: object
       properties:
@@ -4619,6 +4660,8 @@ components:
           format: uuid
         catalogDiff:
           $ref: "#/components/schemas/CatalogDiff"
+        geography:
+          $ref: "#/components/schemas/Geography"
     WebBackendConnectionReadList:
       type: object
       required:

--- a/airbyte-api/src/main/openapi/config.yaml
+++ b/airbyte-api/src/main/openapi/config.yaml
@@ -3194,6 +3194,8 @@ components:
         sourceCatalogId:
           type: string
           format: uuid
+        geography:
+          $ref: "#/components/schemas/Geography"
     WebBackendConnectionCreate:
       type: object
       required:

--- a/airbyte-api/src/main/openapi/config.yaml
+++ b/airbyte-api/src/main/openapi/config.yaml
@@ -2040,7 +2040,13 @@ paths:
     post:
       tags:
         - web_backend
-      summary: Returns two-letter country codes that can be selected for running data syncs in a particular geography.
+      description:
+        Returns all available geographies in which a data sync can run.
+      summary: |
+        Returns available geographies can be selected to run data syncs in a particular geography. 
+        The 'auto' entry indicates that the sync will be automatically assigned to a geography according 
+        to the platform default behavior. Entries other than 'auto' are two-letter country codes that 
+        follow the ISO 3166-1 alpha-2 standard.
       operationId: webBackendListGeographies
       responses:
         "200":

--- a/airbyte-api/src/main/openapi/config.yaml
+++ b/airbyte-api/src/main/openapi/config.yaml
@@ -2040,8 +2040,7 @@ paths:
     post:
       tags:
         - web_backend
-      description:
-        Returns all available geographies in which a data sync can run.
+      description: Returns all available geographies in which a data sync can run.
       summary: |
         Returns available geographies can be selected to run data syncs in a particular geography. 
         The 'auto' entry indicates that the sync will be automatically assigned to a geography according 

--- a/airbyte-bootloader/src/main/java/io/airbyte/bootloader/BootloaderApp.java
+++ b/airbyte-bootloader/src/main/java/io/airbyte/bootloader/BootloaderApp.java
@@ -12,6 +12,7 @@ import io.airbyte.commons.version.AirbyteVersion;
 import io.airbyte.commons.version.Version;
 import io.airbyte.config.Configs;
 import io.airbyte.config.EnvConfigs;
+import io.airbyte.config.Geography;
 import io.airbyte.config.StandardWorkspace;
 import io.airbyte.config.init.ApplyDefinitionsHelper;
 import io.airbyte.config.init.DefinitionsProvider;
@@ -286,7 +287,8 @@ public class BootloaderApp {
         .withSlug(workspaceId.toString())
         .withInitialSetupComplete(false)
         .withDisplaySetupWizard(true)
-        .withTombstone(false);
+        .withTombstone(false)
+        .withDefaultGeography(Geography.AUTO);
     configRepository.writeStandardWorkspace(workspace);
   }
 

--- a/airbyte-bootloader/src/test/java/io/airbyte/bootloader/BootloaderAppTest.java
+++ b/airbyte-bootloader/src/test/java/io/airbyte/bootloader/BootloaderAppTest.java
@@ -21,6 +21,7 @@ import io.airbyte.commons.features.FeatureFlags;
 import io.airbyte.commons.version.AirbyteVersion;
 import io.airbyte.commons.version.Version;
 import io.airbyte.config.Configs;
+import io.airbyte.config.Geography;
 import io.airbyte.config.SourceConnection;
 import io.airbyte.config.StandardWorkspace;
 import io.airbyte.config.init.YamlSeedConfigPersistence;
@@ -222,7 +223,8 @@ class BootloaderAppTest {
           .withSlug("wSlug")
           .withEmail("email@mail.com")
           .withTombstone(false)
-          .withInitialSetupComplete(false));
+          .withInitialSetupComplete(false)
+          .withDefaultGeography(Geography.AUTO));
       final UUID sourceId = UUID.randomUUID();
       configRepository.writeSourceConnectionNoSecrets(new SourceConnection()
           .withSourceDefinitionId(UUID.fromString("e7778cfc-e97c-4458-9ecb-b4f2bba8946c")) // Facebook Marketing

--- a/airbyte-config/config-models/src/main/resources/types/Geography.yaml
+++ b/airbyte-config/config-models/src/main/resources/types/Geography.yaml
@@ -1,0 +1,10 @@
+---
+"$schema": http://json-schema.org/draft-07/schema#
+"$id": https://github.com/airbytehq/airbyte/blob/master/airbyte-config/models/src/main/resources/types/Geography.yaml
+title: Geography
+description: Geography Setting
+type: string
+enum:
+  - auto
+  - us
+  - eu

--- a/airbyte-config/config-models/src/main/resources/types/StandardSync.yaml
+++ b/airbyte-config/config-models/src/main/resources/types/StandardSync.yaml
@@ -11,6 +11,7 @@ required:
   - catalog
   - manual
   - namespaceDefinition
+  - geography
 additionalProperties: false
 properties:
   namespaceDefinition:

--- a/airbyte-config/config-models/src/main/resources/types/StandardSync.yaml
+++ b/airbyte-config/config-models/src/main/resources/types/StandardSync.yaml
@@ -114,3 +114,5 @@ properties:
     format: uuid
   resourceRequirements:
     "$ref": ResourceRequirements.yaml
+  geography:
+    "$ref": Geography.yaml

--- a/airbyte-config/config-models/src/main/resources/types/StandardWorkspace.yaml
+++ b/airbyte-config/config-models/src/main/resources/types/StandardWorkspace.yaml
@@ -47,3 +47,5 @@ properties:
     type: boolean
   feedbackDone:
     type: boolean
+  defaultGeography:
+    "$ref": Geography.yaml

--- a/airbyte-config/config-models/src/main/resources/types/StandardWorkspace.yaml
+++ b/airbyte-config/config-models/src/main/resources/types/StandardWorkspace.yaml
@@ -9,6 +9,7 @@ required:
   - name
   - slug
   - initialSetupComplete
+  - defaultGeography
 additionalProperties: false
 properties:
   workspaceId:

--- a/airbyte-config/config-persistence/src/main/java/io/airbyte/config/persistence/DatabaseConfigPersistence.java
+++ b/airbyte-config/config-persistence/src/main/java/io/airbyte/config/persistence/DatabaseConfigPersistence.java
@@ -1113,6 +1113,7 @@ public class DatabaseConfigPersistence implements ConfigPersistence {
             .set(CONNECTION.RESOURCE_REQUIREMENTS, JSONB.valueOf(Jsons.serialize(standardSync.getResourceRequirements())))
             .set(CONNECTION.UPDATED_AT, timestamp)
             .set(CONNECTION.SOURCE_CATALOG_ID, standardSync.getSourceCatalogId())
+            .set(CONNECTION.GEOGRAPHY, standardSync.getGeography())
             .where(CONNECTION.ID.eq(standardSync.getConnectionId()))
             .execute();
 
@@ -1151,6 +1152,7 @@ public class DatabaseConfigPersistence implements ConfigPersistence {
             .set(CONNECTION.SCHEDULE_DATA, JSONB.valueOf(Jsons.serialize(standardSync.getScheduleData())))
             .set(CONNECTION.RESOURCE_REQUIREMENTS, JSONB.valueOf(Jsons.serialize(standardSync.getResourceRequirements())))
             .set(CONNECTION.SOURCE_CATALOG_ID, standardSync.getSourceCatalogId())
+            .set(CONNECTION.GEOGRAPHY, standardSync.getGeography())
             .set(CONNECTION.CREATED_AT, timestamp)
             .set(CONNECTION.UPDATED_AT, timestamp)
             .execute();

--- a/airbyte-config/config-persistence/src/main/java/io/airbyte/config/persistence/DatabaseConfigPersistence.java
+++ b/airbyte-config/config-persistence/src/main/java/io/airbyte/config/persistence/DatabaseConfigPersistence.java
@@ -1107,13 +1107,16 @@ public class DatabaseConfigPersistence implements ConfigPersistence {
             .set(CONNECTION.MANUAL, standardSync.getManual())
             .set(CONNECTION.SCHEDULE_TYPE,
                 standardSync.getScheduleType() == null ? null
-                    : Enums.toEnum(standardSync.getScheduleType().value(), io.airbyte.db.instance.configs.jooq.generated.enums.ScheduleType.class)
+                    : Enums.toEnum(standardSync.getScheduleType().value(),
+                        io.airbyte.db.instance.configs.jooq.generated.enums.ScheduleType.class)
                         .orElseThrow())
             .set(CONNECTION.SCHEDULE_DATA, JSONB.valueOf(Jsons.serialize(standardSync.getScheduleData())))
-            .set(CONNECTION.RESOURCE_REQUIREMENTS, JSONB.valueOf(Jsons.serialize(standardSync.getResourceRequirements())))
+            .set(CONNECTION.RESOURCE_REQUIREMENTS,
+                JSONB.valueOf(Jsons.serialize(standardSync.getResourceRequirements())))
             .set(CONNECTION.UPDATED_AT, timestamp)
             .set(CONNECTION.SOURCE_CATALOG_ID, standardSync.getSourceCatalogId())
-            .set(CONNECTION.GEOGRAPHY, standardSync.getGeography())
+            .set(CONNECTION.GEOGRAPHY, Enums.toEnum(standardSync.getGeography().value(),
+                io.airbyte.db.instance.configs.jooq.generated.enums.GeographyType.class).orElseThrow())
             .where(CONNECTION.ID.eq(standardSync.getConnectionId()))
             .execute();
 
@@ -1147,12 +1150,15 @@ public class DatabaseConfigPersistence implements ConfigPersistence {
             .set(CONNECTION.MANUAL, standardSync.getManual())
             .set(CONNECTION.SCHEDULE_TYPE,
                 standardSync.getScheduleType() == null ? null
-                    : Enums.toEnum(standardSync.getScheduleType().value(), io.airbyte.db.instance.configs.jooq.generated.enums.ScheduleType.class)
+                    : Enums.toEnum(standardSync.getScheduleType().value(),
+                        io.airbyte.db.instance.configs.jooq.generated.enums.ScheduleType.class)
                         .orElseThrow())
             .set(CONNECTION.SCHEDULE_DATA, JSONB.valueOf(Jsons.serialize(standardSync.getScheduleData())))
-            .set(CONNECTION.RESOURCE_REQUIREMENTS, JSONB.valueOf(Jsons.serialize(standardSync.getResourceRequirements())))
+            .set(CONNECTION.RESOURCE_REQUIREMENTS,
+                JSONB.valueOf(Jsons.serialize(standardSync.getResourceRequirements())))
             .set(CONNECTION.SOURCE_CATALOG_ID, standardSync.getSourceCatalogId())
-            .set(CONNECTION.GEOGRAPHY, standardSync.getGeography())
+            .set(CONNECTION.GEOGRAPHY, Enums.toEnum(standardSync.getGeography().value(),
+                io.airbyte.db.instance.configs.jooq.generated.enums.GeographyType.class).orElseThrow())
             .set(CONNECTION.CREATED_AT, timestamp)
             .set(CONNECTION.UPDATED_AT, timestamp)
             .execute();

--- a/airbyte-config/config-persistence/src/main/java/io/airbyte/config/persistence/DbConverter.java
+++ b/airbyte-config/config-persistence/src/main/java/io/airbyte/config/persistence/DbConverter.java
@@ -16,6 +16,7 @@ import io.airbyte.commons.json.Jsons;
 import io.airbyte.config.ActorCatalog;
 import io.airbyte.config.ActorDefinitionResourceRequirements;
 import io.airbyte.config.DestinationOAuthParameter;
+import io.airbyte.config.Geography;
 import io.airbyte.config.JobSyncConfig.NamespaceDefinitionType;
 import io.airbyte.config.Notification;
 import io.airbyte.config.ResourceRequirements;
@@ -86,7 +87,9 @@ public class DbConverter {
         .withTombstone(record.get(WORKSPACE.TOMBSTONE))
         .withNotifications(notificationList)
         .withFirstCompletedSync(record.get(WORKSPACE.FIRST_SYNC_COMPLETE))
-        .withFeedbackDone(record.get(WORKSPACE.FEEDBACK_COMPLETE));
+        .withFeedbackDone(record.get(WORKSPACE.FEEDBACK_COMPLETE))
+        .withDefaultGeography(
+            Enums.toEnum(record.get(WORKSPACE.GEOGRAPHY, String.class), Geography.class).orElseThrow());
   }
 
   public static StandardSourceDefinition buildStandardSourceDefinition(final Record record) {

--- a/airbyte-config/config-persistence/src/main/java/io/airbyte/config/persistence/DbConverter.java
+++ b/airbyte-config/config-persistence/src/main/java/io/airbyte/config/persistence/DbConverter.java
@@ -55,16 +55,20 @@ public class DbConverter {
         .withCatalog(
             Jsons.deserialize(record.get(CONNECTION.CATALOG).data(), ConfiguredAirbyteCatalog.class))
         .withStatus(
-            record.get(CONNECTION.STATUS) == null ? null : Enums.toEnum(record.get(CONNECTION.STATUS, String.class), Status.class).orElseThrow())
+            record.get(CONNECTION.STATUS) == null ? null
+                : Enums.toEnum(record.get(CONNECTION.STATUS, String.class), Status.class).orElseThrow())
         .withSchedule(Jsons.deserialize(record.get(CONNECTION.SCHEDULE).data(), Schedule.class))
         .withManual(record.get(CONNECTION.MANUAL))
         .withScheduleType(record.get(CONNECTION.SCHEDULE_TYPE) == null ? null
             : Enums.toEnum(record.get(CONNECTION.SCHEDULE_TYPE, String.class), ScheduleType.class).orElseThrow())
         .withScheduleData(
-            record.get(CONNECTION.SCHEDULE_DATA) == null ? null : Jsons.deserialize(record.get(CONNECTION.SCHEDULE_DATA).data(), ScheduleData.class))
+            record.get(CONNECTION.SCHEDULE_DATA) == null ? null
+                : Jsons.deserialize(record.get(CONNECTION.SCHEDULE_DATA).data(), ScheduleData.class))
         .withOperationIds(connectionOperationId)
-        .withResourceRequirements(Jsons.deserialize(record.get(CONNECTION.RESOURCE_REQUIREMENTS).data(), ResourceRequirements.class))
-        .withSourceCatalogId(record.get(CONNECTION.SOURCE_CATALOG_ID));
+        .withResourceRequirements(
+            Jsons.deserialize(record.get(CONNECTION.RESOURCE_REQUIREMENTS).data(), ResourceRequirements.class))
+        .withSourceCatalogId(record.get(CONNECTION.SOURCE_CATALOG_ID))
+        .withGeography(Enums.toEnum(record.get(CONNECTION.GEOGRAPHY, String.class), Geography.class).orElseThrow());
   }
 
   public static StandardWorkspace buildStandardWorkspace(final Record record) {

--- a/airbyte-config/config-persistence/src/test/java/io/airbyte/config/persistence/BaseDatabaseConfigPersistenceTest.java
+++ b/airbyte-config/config-persistence/src/test/java/io/airbyte/config/persistence/BaseDatabaseConfigPersistenceTest.java
@@ -12,6 +12,7 @@ import static org.mockito.Mockito.mock;
 import com.fasterxml.jackson.databind.JsonNode;
 import io.airbyte.config.ConfigSchema;
 import io.airbyte.config.DestinationConnection;
+import io.airbyte.config.Geography;
 import io.airbyte.config.SourceConnection;
 import io.airbyte.config.StandardDestinationDefinition;
 import io.airbyte.config.StandardSourceDefinition;
@@ -146,7 +147,8 @@ class BaseDatabaseConfigPersistenceTest {
         .withWorkspaceId(workspaceId)
         .withName(CANNOT_BE_NULL)
         .withSlug(CANNOT_BE_NULL)
-        .withInitialSetupComplete(true);
+        .withInitialSetupComplete(true)
+        .withDefaultGeography(Geography.AUTO);
     configPersistence.writeConfig(ConfigSchema.STANDARD_WORKSPACE, workspaceId.toString(), workspace);
 
     final SourceConnection sourceConnection = new SourceConnection()
@@ -172,7 +174,8 @@ class BaseDatabaseConfigPersistenceTest {
         .withWorkspaceId(workspaceId)
         .withName(CANNOT_BE_NULL)
         .withSlug(CANNOT_BE_NULL)
-        .withInitialSetupComplete(true);
+        .withInitialSetupComplete(true)
+        .withDefaultGeography(Geography.AUTO);
     configPersistence.writeConfig(ConfigSchema.STANDARD_WORKSPACE, workspaceId.toString(), workspace);
 
     final DestinationConnection destinationConnection = new DestinationConnection()

--- a/airbyte-config/config-persistence/src/test/java/io/airbyte/config/persistence/DatabaseConfigPersistenceLoadDataTest.java
+++ b/airbyte-config/config-persistence/src/test/java/io/airbyte/config/persistence/DatabaseConfigPersistenceLoadDataTest.java
@@ -17,6 +17,7 @@ import com.google.common.collect.Lists;
 import io.airbyte.commons.json.Jsons;
 import io.airbyte.config.ConfigSchema;
 import io.airbyte.config.DestinationConnection;
+import io.airbyte.config.Geography;
 import io.airbyte.config.SourceConnection;
 import io.airbyte.config.StandardDestinationDefinition;
 import io.airbyte.config.StandardSourceDefinition;
@@ -119,7 +120,8 @@ class DatabaseConfigPersistenceLoadDataTest extends BaseDatabaseConfigPersistenc
         .withWorkspaceId(s3Connection.getWorkspaceId())
         .withName("workspace")
         .withSlug("slug")
-        .withInitialSetupComplete(true);
+        .withInitialSetupComplete(true)
+        .withDefaultGeography(Geography.AUTO);
     configPersistence.writeConfig(ConfigSchema.STANDARD_WORKSPACE, standardWorkspace.getWorkspaceId().toString(), standardWorkspace);
     configPersistence.writeConfig(ConfigSchema.DESTINATION_CONNECTION, s3Connection.getDestinationId().toString(), s3Connection);
     final SourceConnection githubConnection = new SourceConnection()

--- a/airbyte-config/config-persistence/src/test/java/io/airbyte/config/persistence/MockData.java
+++ b/airbyte-config/config-persistence/src/test/java/io/airbyte/config/persistence/MockData.java
@@ -12,6 +12,7 @@ import io.airbyte.config.ActorCatalogFetchEvent;
 import io.airbyte.config.ActorDefinitionResourceRequirements;
 import io.airbyte.config.DestinationConnection;
 import io.airbyte.config.DestinationOAuthParameter;
+import io.airbyte.config.Geography;
 import io.airbyte.config.JobSyncConfig.NamespaceDefinitionType;
 import io.airbyte.config.Notification;
 import io.airbyte.config.Notification.NotificationType;
@@ -149,21 +150,24 @@ public class MockData {
         .withTombstone(false)
         .withNotifications(Collections.singletonList(notification))
         .withFirstCompletedSync(true)
-        .withFeedbackDone(true);
+        .withFeedbackDone(true)
+        .withDefaultGeography(Geography.AUTO);
 
     final StandardWorkspace workspace2 = new StandardWorkspace()
         .withWorkspaceId(WORKSPACE_ID_2)
         .withName("Another Workspace")
         .withSlug("another-workspace")
         .withInitialSetupComplete(true)
-        .withTombstone(false);
+        .withTombstone(false)
+        .withDefaultGeography(Geography.AUTO);
 
     final StandardWorkspace workspace3 = new StandardWorkspace()
         .withWorkspaceId(WORKSPACE_ID_3)
         .withName("Tombstoned")
         .withSlug("tombstoned")
         .withInitialSetupComplete(true)
-        .withTombstone(true);
+        .withTombstone(true)
+        .withDefaultGeography(Geography.AUTO);
 
     return Arrays.asList(workspace1, workspace2, workspace3);
   }
@@ -448,7 +452,8 @@ public class MockData {
         .withPrefix("")
         .withResourceRequirements(resourceRequirements)
         .withStatus(Status.ACTIVE)
-        .withSchedule(schedule);
+        .withSchedule(schedule)
+        .withGeography(Geography.AUTO);
 
     final StandardSync standardSync2 = new StandardSync()
         .withOperationIds(Arrays.asList(OPERATION_ID_1, OPERATION_ID_2))
@@ -463,7 +468,8 @@ public class MockData {
         .withPrefix("")
         .withResourceRequirements(resourceRequirements)
         .withStatus(Status.ACTIVE)
-        .withSchedule(schedule);
+        .withSchedule(schedule)
+        .withGeography(Geography.AUTO);
 
     final StandardSync standardSync3 = new StandardSync()
         .withOperationIds(Arrays.asList(OPERATION_ID_1, OPERATION_ID_2))
@@ -478,7 +484,8 @@ public class MockData {
         .withPrefix("")
         .withResourceRequirements(resourceRequirements)
         .withStatus(Status.ACTIVE)
-        .withSchedule(schedule);
+        .withSchedule(schedule)
+        .withGeography(Geography.AUTO);
 
     final StandardSync standardSync4 = new StandardSync()
         .withOperationIds(Arrays.asList(OPERATION_ID_1, OPERATION_ID_2))
@@ -493,7 +500,8 @@ public class MockData {
         .withPrefix("")
         .withResourceRequirements(resourceRequirements)
         .withStatus(Status.DEPRECATED)
-        .withSchedule(schedule);
+        .withSchedule(schedule)
+        .withGeography(Geography.AUTO);
 
     final StandardSync standardSync5 = new StandardSync()
         .withOperationIds(Arrays.asList(OPERATION_ID_3))
@@ -508,7 +516,8 @@ public class MockData {
         .withPrefix("")
         .withResourceRequirements(resourceRequirements)
         .withStatus(Status.ACTIVE)
-        .withSchedule(schedule);
+        .withSchedule(schedule)
+        .withGeography(Geography.AUTO);
 
     final StandardSync standardSync6 = new StandardSync()
         .withOperationIds(Arrays.asList())
@@ -523,7 +532,8 @@ public class MockData {
         .withPrefix("")
         .withResourceRequirements(resourceRequirements)
         .withStatus(Status.DEPRECATED)
-        .withSchedule(schedule);
+        .withSchedule(schedule)
+        .withGeography(Geography.AUTO);
 
     return Arrays.asList(standardSync1, standardSync2, standardSync3, standardSync4, standardSync5, standardSync6);
   }

--- a/airbyte-server/src/main/java/io/airbyte/server/apis/ConfigurationApi.java
+++ b/airbyte-server/src/main/java/io/airbyte/server/apis/ConfigurationApi.java
@@ -802,7 +802,7 @@ public class ConfigurationApi implements io.airbyte.api.generated.V1Api {
 
   @Override
   public WebBackendGeographiesListResult webBackendListGeographies() {
-    return execute(() -> webBackendGeographiesHandler.listGeographies());
+    return execute(webBackendGeographiesHandler::listGeographiesOSS);
   }
 
   @Override

--- a/airbyte-server/src/main/java/io/airbyte/server/apis/ConfigurationApi.java
+++ b/airbyte-server/src/main/java/io/airbyte/server/apis/ConfigurationApi.java
@@ -90,6 +90,7 @@ import io.airbyte.api.model.generated.WebBackendConnectionRead;
 import io.airbyte.api.model.generated.WebBackendConnectionReadList;
 import io.airbyte.api.model.generated.WebBackendConnectionRequestBody;
 import io.airbyte.api.model.generated.WebBackendConnectionUpdate;
+import io.airbyte.api.model.generated.WebBackendGeographiesListResult;
 import io.airbyte.api.model.generated.WebBackendWorkspaceState;
 import io.airbyte.api.model.generated.WebBackendWorkspaceStateResult;
 import io.airbyte.api.model.generated.WorkspaceCreate;
@@ -128,6 +129,7 @@ import io.airbyte.server.handlers.SourceDefinitionsHandler;
 import io.airbyte.server.handlers.SourceHandler;
 import io.airbyte.server.handlers.StateHandler;
 import io.airbyte.server.handlers.WebBackendConnectionsHandler;
+import io.airbyte.server.handlers.WebBackendGeographiesHandler;
 import io.airbyte.server.handlers.WorkspacesHandler;
 import io.airbyte.server.scheduler.EventRunner;
 import io.airbyte.server.scheduler.SynchronousSchedulerClient;
@@ -156,6 +158,7 @@ public class ConfigurationApi implements io.airbyte.api.generated.V1Api {
   private final StateHandler stateHandler;
   private final JobHistoryHandler jobHistoryHandler;
   private final WebBackendConnectionsHandler webBackendConnectionsHandler;
+  private final WebBackendGeographiesHandler webBackendGeographiesHandler;
   private final HealthCheckHandler healthCheckHandler;
   private final LogsHandler logsHandler;
   private final OpenApiConfigHandler openApiConfigHandler;
@@ -236,6 +239,7 @@ public class ConfigurationApi implements io.airbyte.api.generated.V1Api {
         operationsHandler,
         eventRunner,
         configRepository);
+    webBackendGeographiesHandler = new WebBackendGeographiesHandler();
     healthCheckHandler = new HealthCheckHandler(configRepository);
     logsHandler = new LogsHandler();
     openApiConfigHandler = new OpenApiConfigHandler();
@@ -794,6 +798,11 @@ public class ConfigurationApi implements io.airbyte.api.generated.V1Api {
   @Override
   public WebBackendConnectionReadList webBackendListConnectionsForWorkspace(final WorkspaceIdRequestBody workspaceIdRequestBody) {
     return execute(() -> webBackendConnectionsHandler.webBackendListConnectionsForWorkspace(workspaceIdRequestBody));
+  }
+
+  @Override
+  public WebBackendGeographiesListResult webBackendListGeographies() {
+    return execute(() -> webBackendGeographiesHandler.listGeographies());
   }
 
   @Override

--- a/airbyte-server/src/main/java/io/airbyte/server/converters/ApiPojoConverters.java
+++ b/airbyte-server/src/main/java/io/airbyte/server/converters/ApiPojoConverters.java
@@ -11,6 +11,7 @@ import io.airbyte.api.model.generated.ConnectionScheduleData;
 import io.airbyte.api.model.generated.ConnectionScheduleDataBasicSchedule;
 import io.airbyte.api.model.generated.ConnectionScheduleDataCron;
 import io.airbyte.api.model.generated.ConnectionStatus;
+import io.airbyte.api.model.generated.Geography;
 import io.airbyte.api.model.generated.JobType;
 import io.airbyte.api.model.generated.JobTypeResourceLimit;
 import io.airbyte.api.model.generated.ResourceRequirements;
@@ -91,7 +92,8 @@ public class ApiPojoConverters {
         .namespaceFormat(standardSync.getNamespaceFormat())
         .prefix(standardSync.getPrefix())
         .syncCatalog(CatalogConverter.toApi(standardSync.getCatalog()))
-        .sourceCatalogId(standardSync.getSourceCatalogId());
+        .sourceCatalogId(standardSync.getSourceCatalogId())
+        .geography(Enums.convertTo(standardSync.getGeography(), Geography.class));
 
     if (standardSync.getResourceRequirements() != null) {
       connectionRead.resourceRequirements(resourceRequirementsToApi(standardSync.getResourceRequirements()));
@@ -125,6 +127,14 @@ public class ApiPojoConverters {
 
   public static StandardSync.Status toPersistenceStatus(final ConnectionStatus apiStatus) {
     return Enums.convertTo(apiStatus, StandardSync.Status.class);
+  }
+
+  public static Geography toApiGeography(final io.airbyte.config.Geography geography) {
+    return Enums.convertTo(geography, Geography.class);
+  }
+
+  public static io.airbyte.config.Geography toPersistenceGeography(final Geography apiGeography) {
+    return Enums.convertTo(apiGeography, io.airbyte.config.Geography.class);
   }
 
   public static Schedule.TimeUnit toPersistenceTimeUnit(final ConnectionSchedule.TimeUnitEnum apiTimeUnit) {

--- a/airbyte-server/src/main/java/io/airbyte/server/handlers/WebBackendConnectionsHandler.java
+++ b/airbyte-server/src/main/java/io/airbyte/server/handlers/WebBackendConnectionsHandler.java
@@ -517,6 +517,7 @@ public class WebBackendConnectionsHandler {
     connectionCreate.status(webBackendConnectionCreate.getStatus());
     connectionCreate.resourceRequirements(webBackendConnectionCreate.getResourceRequirements());
     connectionCreate.sourceCatalogId(webBackendConnectionCreate.getSourceCatalogId());
+    connectionCreate.geography(webBackendConnectionCreate.getGeography());
 
     return connectionCreate;
   }
@@ -546,6 +547,7 @@ public class WebBackendConnectionsHandler {
     connectionPatch.status(webBackendConnectionPatch.getStatus());
     connectionPatch.resourceRequirements(webBackendConnectionPatch.getResourceRequirements());
     connectionPatch.sourceCatalogId(webBackendConnectionPatch.getSourceCatalogId());
+    connectionPatch.geography(webBackendConnectionPatch.getGeography());
 
     connectionPatch.operationIds(finalOperationIds);
 

--- a/airbyte-server/src/main/java/io/airbyte/server/handlers/WebBackendConnectionsHandler.java
+++ b/airbyte-server/src/main/java/io/airbyte/server/handlers/WebBackendConnectionsHandler.java
@@ -195,7 +195,8 @@ public class WebBackendConnectionsHandler {
         .source(source)
         .destination(destination)
         .operations(operations.getOperations())
-        .resourceRequirements(connectionRead.getResourceRequirements());
+        .resourceRequirements(connectionRead.getResourceRequirements())
+        .geography(connectionRead.getGeography());
   }
 
   // todo (cgardens) - This logic is a headache to follow it stems from the internal data model not

--- a/airbyte-server/src/main/java/io/airbyte/server/handlers/WebBackendGeographiesHandler.java
+++ b/airbyte-server/src/main/java/io/airbyte/server/handlers/WebBackendGeographiesHandler.java
@@ -7,6 +7,7 @@ package io.airbyte.server.handlers;
 import io.airbyte.api.model.generated.Geography;
 import io.airbyte.api.model.generated.WebBackendGeographiesListResult;
 import java.util.Arrays;
+import java.util.Collections;
 import lombok.AllArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 
@@ -14,14 +15,17 @@ import lombok.extern.slf4j.Slf4j;
 @Slf4j
 public class WebBackendGeographiesHandler {
 
-  /**
-   * Returns all available Geography settings that can be set on a Workspace or Connection.
-   *
-   * @return result containing list of geographies
-   */
-  public WebBackendGeographiesListResult listGeographies() {
+  public WebBackendGeographiesListResult listGeographiesOSS() {
+    // for now, OSS only supports AUTO. This can evolve to account for complex OSS use cases
     return new WebBackendGeographiesListResult().geographies(
-        Arrays.stream(Geography.values()).toList());
+        Collections.singletonList(Geography.AUTO));
+  }
+
+  /**
+   * Only called by the wrapped Cloud API to enable multi-cloud
+   */
+  public WebBackendGeographiesListResult listGeographiesCloud() {
+    return new WebBackendGeographiesListResult().geographies(Arrays.asList(Geography.values()));
   }
 
 }

--- a/airbyte-server/src/main/java/io/airbyte/server/handlers/WebBackendGeographiesHandler.java
+++ b/airbyte-server/src/main/java/io/airbyte/server/handlers/WebBackendGeographiesHandler.java
@@ -1,0 +1,27 @@
+/*
+ * Copyright (c) 2022 Airbyte, Inc., all rights reserved.
+ */
+
+package io.airbyte.server.handlers;
+
+import io.airbyte.api.model.generated.Geography;
+import io.airbyte.api.model.generated.WebBackendGeographiesListResult;
+import java.util.Arrays;
+import lombok.AllArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+
+@AllArgsConstructor
+@Slf4j
+public class WebBackendGeographiesHandler {
+
+  /**
+   * Returns all available Geography settings that can be set on a Workspace or Connection.
+   *
+   * @return result containing list of geographies
+   */
+  public WebBackendGeographiesListResult listGeographies() {
+    return new WebBackendGeographiesListResult().geographies(
+        Arrays.stream(Geography.values()).toList());
+  }
+
+}

--- a/airbyte-server/src/main/java/io/airbyte/server/handlers/WebBackendGeographiesHandler.java
+++ b/airbyte-server/src/main/java/io/airbyte/server/handlers/WebBackendGeographiesHandler.java
@@ -16,7 +16,8 @@ import lombok.extern.slf4j.Slf4j;
 public class WebBackendGeographiesHandler {
 
   public WebBackendGeographiesListResult listGeographiesOSS() {
-    // for now, OSS only supports AUTO. This can evolve to account for complex OSS use cases
+    // for now, OSS only supports AUTO. This can evolve to account for complex OSS use cases, but for now
+    // we expect OSS deployments to use a single default Task Queue for scheduling syncs in a vast majority of cases.
     return new WebBackendGeographiesListResult().geographies(
         Collections.singletonList(Geography.AUTO));
   }

--- a/airbyte-server/src/main/java/io/airbyte/server/handlers/WebBackendGeographiesHandler.java
+++ b/airbyte-server/src/main/java/io/airbyte/server/handlers/WebBackendGeographiesHandler.java
@@ -16,8 +16,9 @@ import lombok.extern.slf4j.Slf4j;
 public class WebBackendGeographiesHandler {
 
   public WebBackendGeographiesListResult listGeographiesOSS() {
-    // for now, OSS only supports AUTO. This can evolve to account for complex OSS use cases, but for now
-    // we expect OSS deployments to use a single default Task Queue for scheduling syncs in a vast majority of cases.
+    // for now, OSS only supports AUTO. This can evolve to account for complex OSS use cases, but for
+    // now we expect OSS deployments to use a single default Task Queue for scheduling syncs in a vast
+    // majority of cases.
     return new WebBackendGeographiesListResult().geographies(
         Collections.singletonList(Geography.AUTO));
   }

--- a/airbyte-server/src/main/java/io/airbyte/server/handlers/helpers/ConnectionMatcher.java
+++ b/airbyte-server/src/main/java/io/airbyte/server/handlers/helpers/ConnectionMatcher.java
@@ -43,6 +43,7 @@ public class ConnectionMatcher implements Matchable<ConnectionRead> {
     fromSearch.syncCatalog(query.getSyncCatalog());
     fromSearch.operationIds(query.getOperationIds());
     fromSearch.sourceCatalogId(query.getSourceCatalogId());
+    fromSearch.geography(query.getGeography());
 
     return fromSearch;
   }

--- a/airbyte-server/src/test/java/io/airbyte/server/handlers/ConnectionsHandlerTest.java
+++ b/airbyte-server/src/test/java/io/airbyte/server/handlers/ConnectionsHandlerTest.java
@@ -45,6 +45,7 @@ import io.airbyte.config.ConfigSchema;
 import io.airbyte.config.Cron;
 import io.airbyte.config.DataType;
 import io.airbyte.config.DestinationConnection;
+import io.airbyte.config.Geography;
 import io.airbyte.config.JobSyncConfig;
 import io.airbyte.config.Schedule;
 import io.airbyte.config.Schedule.TimeUnit;
@@ -55,6 +56,7 @@ import io.airbyte.config.StandardSourceDefinition;
 import io.airbyte.config.StandardSync;
 import io.airbyte.config.StandardSync.ScheduleType;
 import io.airbyte.config.StandardSync.Status;
+import io.airbyte.config.StandardWorkspace;
 import io.airbyte.config.persistence.ConfigNotFoundException;
 import io.airbyte.config.persistence.ConfigRepository;
 import io.airbyte.persistence.job.WorkspaceHelper;
@@ -147,7 +149,8 @@ class ConnectionsHandlerTest {
         .withScheduleType(ScheduleType.BASIC_SCHEDULE)
         .withScheduleData(ConnectionHelpers.generateBasicScheduleData())
         .withResourceRequirements(ConnectionHelpers.TESTING_RESOURCE_REQUIREMENTS)
-        .withSourceCatalogId(UUID.randomUUID());
+        .withSourceCatalogId(UUID.randomUUID())
+        .withGeography(Geography.AUTO);
     standardSyncDeleted = new StandardSync()
         .withConnectionId(connectionId)
         .withName("presto to hudi2")
@@ -161,7 +164,8 @@ class ConnectionsHandlerTest {
         .withOperationIds(List.of(operationId))
         .withManual(false)
         .withSchedule(ConnectionHelpers.generateBasicSchedule())
-        .withResourceRequirements(ConnectionHelpers.TESTING_RESOURCE_REQUIREMENTS);
+        .withResourceRequirements(ConnectionHelpers.TESTING_RESOURCE_REQUIREMENTS)
+        .withGeography(Geography.US);
 
     configRepository = mock(ConfigRepository.class);
     uuidGenerator = mock(Supplier.class);
@@ -210,6 +214,75 @@ class ConnectionsHandlerTest {
 
         final AirbyteCatalog catalog = ConnectionHelpers.generateBasicApiCatalog();
 
+        // set a defaultGeography on the workspace as EU, but expect connection to be
+        // created AUTO because the ConnectionCreate geography takes precedence over the workspace defaultGeography.
+        final StandardWorkspace workspace = new StandardWorkspace()
+            .withWorkspaceId(workspaceId)
+            .withDefaultGeography(Geography.EU);
+        when(configRepository.getStandardWorkspace(workspaceId, true)).thenReturn(workspace);
+
+        final ConnectionCreate connectionCreate = new ConnectionCreate()
+            .sourceId(standardSync.getSourceId())
+            .destinationId(standardSync.getDestinationId())
+            .operationIds(standardSync.getOperationIds())
+            .name(PRESTO_TO_HUDI)
+            .namespaceDefinition(NamespaceDefinitionType.SOURCE)
+            .namespaceFormat(null)
+            .prefix(PRESTO_TO_HUDI_PREFIX)
+            .status(ConnectionStatus.ACTIVE)
+            .schedule(ConnectionHelpers.generateBasicConnectionSchedule())
+            .syncCatalog(catalog)
+            .resourceRequirements(new io.airbyte.api.model.generated.ResourceRequirements()
+                .cpuRequest(standardSync.getResourceRequirements().getCpuRequest())
+                .cpuLimit(standardSync.getResourceRequirements().getCpuLimit())
+                .memoryRequest(standardSync.getResourceRequirements().getMemoryRequest())
+                .memoryLimit(standardSync.getResourceRequirements().getMemoryLimit()))
+            .sourceCatalogId(standardSync.getSourceCatalogId())
+            .geography(ApiPojoConverters.toApiGeography(standardSync.getGeography()));
+
+        final ConnectionRead actualConnectionRead = connectionsHandler.createConnection(connectionCreate);
+
+        final ConnectionRead expectedConnectionRead = ConnectionHelpers.generateExpectedConnectionRead(standardSync);
+
+        assertEquals(expectedConnectionRead, actualConnectionRead);
+
+        verify(configRepository).writeStandardSync(standardSync);
+
+        // Use new schedule schema, verify that we get the same results.
+        connectionCreate
+            .schedule(null)
+            .scheduleType(ConnectionScheduleType.BASIC)
+            .scheduleData(ConnectionHelpers.generateBasicConnectionScheduleData());
+        assertEquals(expectedConnectionRead, connectionsHandler.createConnection(connectionCreate));
+      }
+
+      @Test
+      void testCreateConnectionUsesDefaultGeographyFromWorkspace() throws JsonValidationException, ConfigNotFoundException, IOException {
+        when(uuidGenerator.get()).thenReturn(standardSync.getConnectionId());
+        final StandardSourceDefinition sourceDefinition = new StandardSourceDefinition()
+            .withName(SOURCE_TEST)
+            .withSourceDefinitionId(UUID.randomUUID());
+        final StandardDestinationDefinition destinationDefinition = new StandardDestinationDefinition()
+            .withName(DESTINATION_TEST)
+            .withDestinationDefinitionId(UUID.randomUUID());
+        when(configRepository.getStandardSync(standardSync.getConnectionId())).thenReturn(standardSync);
+        when(configRepository.getSourceDefinitionFromConnection(standardSync.getConnectionId())).thenReturn(sourceDefinition);
+        when(configRepository.getDestinationDefinitionFromConnection(standardSync.getConnectionId())).thenReturn(destinationDefinition);
+        when(configRepository.getSourceConnection(source.getSourceId()))
+            .thenReturn(source);
+        when(configRepository.getDestinationConnection(destination.getDestinationId()))
+            .thenReturn(destination);
+        when(workspaceHelper.getWorkspaceForSourceId(source.getSourceId())).thenReturn(workspaceId);
+
+        // Expect the created connection's geography to be inherited from the workspace, because
+        // the ConnectionCreate geography is unset
+        final StandardWorkspace workspace = new StandardWorkspace()
+            .withWorkspaceId(workspaceId)
+            .withDefaultGeography(Geography.EU);
+        when(configRepository.getStandardWorkspace(workspaceId, true)).thenReturn(workspace);
+
+        final AirbyteCatalog catalog = ConnectionHelpers.generateBasicApiCatalog();
+
         final ConnectionCreate connectionCreate = new ConnectionCreate()
             .sourceId(standardSync.getSourceId())
             .destinationId(standardSync.getDestinationId())
@@ -230,11 +303,14 @@ class ConnectionsHandlerTest {
 
         final ConnectionRead actualConnectionRead = connectionsHandler.createConnection(connectionCreate);
 
-        final ConnectionRead expectedConnectionRead = ConnectionHelpers.generateExpectedConnectionRead(standardSync);
+        final StandardSync expectedStandardSync = Jsons.clone(standardSync);
+        expectedStandardSync.setGeography(Geography.EU);
+
+        final ConnectionRead expectedConnectionRead = ConnectionHelpers.generateExpectedConnectionRead(expectedStandardSync);
 
         assertEquals(expectedConnectionRead, actualConnectionRead);
 
-        verify(configRepository).writeStandardSync(standardSync);
+        verify(configRepository).writeStandardSync(expectedStandardSync);
 
         // Use new schedule schema, verify that we get the same results.
         connectionCreate
@@ -345,7 +421,8 @@ class ConnectionsHandlerTest {
             standardSync.getSourceId(),
             standardSync.getDestinationId(),
             standardSync.getOperationIds(),
-            standardSync.getSourceCatalogId())
+            standardSync.getSourceCatalogId(),
+            ApiPojoConverters.toApiGeography(standardSync.getGeography()))
             .name("newName");
         final StandardSync expectedPersistedSync = Jsons.clone(standardSync).withName("newName");
 
@@ -369,7 +446,8 @@ class ConnectionsHandlerTest {
             standardSync.getSourceId(),
             standardSync.getDestinationId(),
             standardSync.getOperationIds(),
-            standardSync.getSourceCatalogId())
+            standardSync.getSourceCatalogId(),
+            ApiPojoConverters.toApiGeography(standardSync.getGeography()))
             .schedule(null)
             .scheduleType(ConnectionScheduleType.MANUAL)
             .scheduleData(null);
@@ -405,7 +483,8 @@ class ConnectionsHandlerTest {
             standardSync.getSourceId(),
             standardSync.getDestinationId(),
             standardSync.getOperationIds(),
-            standardSync.getSourceCatalogId())
+            standardSync.getSourceCatalogId(),
+            ApiPojoConverters.toApiGeography(standardSync.getGeography()))
             .schedule(null)
             .scheduleType(ConnectionScheduleType.CRON)
             .scheduleData(cronScheduleData);
@@ -441,7 +520,8 @@ class ConnectionsHandlerTest {
             standardSync.getSourceId(),
             standardSync.getDestinationId(),
             standardSync.getOperationIds(),
-            standardSync.getSourceCatalogId())
+            standardSync.getSourceCatalogId(),
+            ApiPojoConverters.toApiGeography(standardSync.getGeography()))
             .schedule(new ConnectionSchedule().timeUnit(ConnectionSchedule.TimeUnitEnum.DAYS).units(10L)) // still dual-writing to legacy field
             .scheduleType(ConnectionScheduleType.BASIC)
             .scheduleData(newScheduleData);
@@ -490,7 +570,8 @@ class ConnectionsHandlerTest {
             standardSync.getSourceId(),
             standardSync.getDestinationId(),
             standardSync.getOperationIds(),
-            standardSync.getSourceCatalogId())
+            standardSync.getSourceCatalogId(),
+            ApiPojoConverters.toApiGeography(standardSync.getGeography()))
             .syncCatalog(catalogForUpdate);
 
         final StandardSync expectedPersistedSync = Jsons.clone(standardSync)
@@ -532,7 +613,8 @@ class ConnectionsHandlerTest {
             standardSync.getSourceId(),
             standardSync.getDestinationId(),
             standardSync.getOperationIds(),
-            standardSync.getSourceCatalogId())
+            standardSync.getSourceCatalogId(),
+            ApiPojoConverters.toApiGeography(standardSync.getGeography()))
             .syncCatalog(catalogForUpdate);
 
         final StandardSync expectedPersistedSync = Jsons.clone(standardSync)
@@ -602,7 +684,8 @@ class ConnectionsHandlerTest {
             standardSync.getSourceId(),
             standardSync.getDestinationId(),
             standardSync.getOperationIds(),
-            newSourceCatalogId)
+            newSourceCatalogId,
+            ApiPojoConverters.toApiGeography(standardSync.getGeography()))
             .status(ConnectionStatus.INACTIVE)
             .scheduleType(ConnectionScheduleType.MANUAL)
             .scheduleData(null)
@@ -695,7 +778,8 @@ class ConnectionsHandlerTest {
           .withDestinationId(destinationId)
           .withOperationIds(List.of(operationId))
           .withManual(true)
-          .withResourceRequirements(ConnectionHelpers.TESTING_RESOURCE_REQUIREMENTS);
+          .withResourceRequirements(ConnectionHelpers.TESTING_RESOURCE_REQUIREMENTS)
+          .withGeography(Geography.US);
       final ConnectionRead connectionRead2 = ConnectionHelpers.connectionReadFromStandardSync(standardSync2);
       final StandardSourceDefinition sourceDefinition = new StandardSourceDefinition()
           .withName(SOURCE_TEST)

--- a/airbyte-server/src/test/java/io/airbyte/server/handlers/WebBackendConnectionsHandlerTest.java
+++ b/airbyte-server/src/test/java/io/airbyte/server/handlers/WebBackendConnectionsHandlerTest.java
@@ -36,6 +36,7 @@ import io.airbyte.api.model.generated.ConnectionUpdate;
 import io.airbyte.api.model.generated.DestinationIdRequestBody;
 import io.airbyte.api.model.generated.DestinationRead;
 import io.airbyte.api.model.generated.DestinationSyncMode;
+import io.airbyte.api.model.generated.Geography;
 import io.airbyte.api.model.generated.JobConfigType;
 import io.airbyte.api.model.generated.JobInfoRead;
 import io.airbyte.api.model.generated.JobRead;
@@ -394,7 +395,8 @@ class WebBackendConnectionsHandlerTest {
         .status(ConnectionStatus.INACTIVE)
         .schedule(schedule)
         .syncCatalog(catalog)
-        .sourceCatalogId(sourceCatalogId);
+        .sourceCatalogId(sourceCatalogId)
+        .geography(Geography.US);
 
     final List<UUID> operationIds = List.of(newOperationId);
 
@@ -409,7 +411,8 @@ class WebBackendConnectionsHandlerTest {
         .status(ConnectionStatus.INACTIVE)
         .schedule(schedule)
         .syncCatalog(catalog)
-        .sourceCatalogId(sourceCatalogId);
+        .sourceCatalogId(sourceCatalogId)
+        .geography(Geography.US);
 
     final ConnectionCreate actual = WebBackendConnectionsHandler.toConnectionCreate(input, operationIds);
 
@@ -417,7 +420,7 @@ class WebBackendConnectionsHandlerTest {
   }
 
   @Test
-  void testToConnectionUpdate() throws IOException {
+  void testToConnectionPatch() throws IOException {
     final SourceConnection source = SourceHelpers.generateSource(UUID.randomUUID());
     final StandardSync standardSync = ConnectionHelpers.generateSyncWithSourceId(source.getSourceId());
 
@@ -436,7 +439,8 @@ class WebBackendConnectionsHandlerTest {
         .status(ConnectionStatus.INACTIVE)
         .schedule(schedule)
         .name(standardSync.getName())
-        .syncCatalog(catalog);
+        .syncCatalog(catalog)
+        .geography(Geography.US);
 
     final List<UUID> operationIds = List.of(newOperationId);
 
@@ -449,7 +453,8 @@ class WebBackendConnectionsHandlerTest {
         .status(ConnectionStatus.INACTIVE)
         .schedule(schedule)
         .name(standardSync.getName())
-        .syncCatalog(catalog);
+        .syncCatalog(catalog)
+        .geography(Geography.US);
 
     final ConnectionUpdate actual = WebBackendConnectionsHandler.toConnectionPatch(input, operationIds);
 
@@ -459,8 +464,9 @@ class WebBackendConnectionsHandlerTest {
   @Test
   void testForConnectionCreateCompleteness() {
     final Set<String> handledMethods =
-        Set.of("name", "namespaceDefinition", "namespaceFormat", "prefix", "sourceId", "destinationId", "operationIds", "addOperationIdsItem",
-            "removeOperationIdsItem", "syncCatalog", "schedule", "scheduleType", "scheduleData", "status", "resourceRequirements", "sourceCatalogId");
+        Set.of("name", "namespaceDefinition", "namespaceFormat", "prefix", "sourceId", "destinationId", "operationIds",
+            "addOperationIdsItem", "removeOperationIdsItem", "syncCatalog", "schedule", "scheduleType", "scheduleData",
+            "status", "resourceRequirements", "sourceCatalogId", "geography");
 
     final Set<String> methods = Arrays.stream(ConnectionCreate.class.getMethods())
         .filter(method -> method.getReturnType() == ConnectionCreate.class)
@@ -478,10 +484,11 @@ class WebBackendConnectionsHandlerTest {
   }
 
   @Test
-  void testForConnectionUpdateCompleteness() {
+  void testForConnectionPatchCompleteness() {
     final Set<String> handledMethods =
-        Set.of("schedule", "connectionId", "syncCatalog", "namespaceDefinition", "namespaceFormat", "prefix", "status", "operationIds",
-            "addOperationIdsItem", "removeOperationIdsItem", "resourceRequirements", "name", "sourceCatalogId", "scheduleType", "scheduleData");
+        Set.of("schedule", "connectionId", "syncCatalog", "namespaceDefinition", "namespaceFormat", "prefix", "status",
+            "operationIds", "addOperationIdsItem", "removeOperationIdsItem", "resourceRequirements", "name",
+            "sourceCatalogId", "scheduleType", "scheduleData", "geography");
 
     final Set<String> methods = Arrays.stream(ConnectionUpdate.class.getMethods())
         .filter(method -> method.getReturnType() == ConnectionUpdate.class)
@@ -492,8 +499,8 @@ class WebBackendConnectionsHandlerTest {
         """
         If this test is failing, it means you added a field to ConnectionUpdate!
         Congratulations, but you're not done yet..
-        \tYou should update WebBackendConnectionsHandler::toConnectionUpdate
-        \tand ensure that the field is tested in WebBackendConnectionsHandlerTest::testToConnectionUpdate
+        \tYou should update WebBackendConnectionsHandler::toConnectionPatch
+        \tand ensure that the field is tested in WebBackendConnectionsHandlerTest::testToConnectionPatch
         Then you can add the field name here to make this test pass. Cheers!""";
     assertEquals(handledMethods, methods, message);
   }

--- a/airbyte-server/src/test/java/io/airbyte/server/handlers/WebBackendGeographiesHandlerTest.java
+++ b/airbyte-server/src/test/java/io/airbyte/server/handlers/WebBackendGeographiesHandlerTest.java
@@ -1,0 +1,43 @@
+/*
+ * Copyright (c) 2022 Airbyte, Inc., all rights reserved.
+ */
+
+package io.airbyte.server.handlers;
+
+import io.airbyte.api.model.generated.Geography;
+import io.airbyte.api.model.generated.WebBackendGeographiesListResult;
+import java.util.List;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+public class WebBackendGeographiesHandlerTest {
+
+  private WebBackendGeographiesHandler webBackendGeographiesHandler;
+
+  @BeforeEach
+  void setUp() {
+    webBackendGeographiesHandler = new WebBackendGeographiesHandler();
+  }
+
+  @Test
+  void testListGeographiesOSS() {
+    final WebBackendGeographiesListResult expected = new WebBackendGeographiesListResult().geographies(
+        List.of(Geography.AUTO));
+
+    final WebBackendGeographiesListResult actual = webBackendGeographiesHandler.listGeographiesOSS();
+
+    Assertions.assertEquals(expected, actual);
+  }
+
+  @Test
+  void testListGeographiesCloud() {
+    final WebBackendGeographiesListResult expected = new WebBackendGeographiesListResult().geographies(
+        List.of(Geography.AUTO, Geography.US, Geography.EU));
+
+    final WebBackendGeographiesListResult actual = webBackendGeographiesHandler.listGeographiesCloud();
+
+    Assertions.assertEquals(expected, actual);
+  }
+
+}

--- a/airbyte-server/src/test/java/io/airbyte/server/handlers/WebBackendGeographiesHandlerTest.java
+++ b/airbyte-server/src/test/java/io/airbyte/server/handlers/WebBackendGeographiesHandlerTest.java
@@ -11,7 +11,7 @@ import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
-public class WebBackendGeographiesHandlerTest {
+class WebBackendGeographiesHandlerTest {
 
   private WebBackendGeographiesHandler webBackendGeographiesHandler;
 

--- a/airbyte-server/src/test/java/io/airbyte/server/handlers/WorkspacesHandlerTest.java
+++ b/airbyte-server/src/test/java/io/airbyte/server/handlers/WorkspacesHandlerTest.java
@@ -30,6 +30,7 @@ import io.airbyte.api.model.generated.WorkspaceReadList;
 import io.airbyte.api.model.generated.WorkspaceUpdate;
 import io.airbyte.api.model.generated.WorkspaceUpdateName;
 import io.airbyte.commons.json.Jsons;
+import io.airbyte.config.Geography;
 import io.airbyte.config.Notification;
 import io.airbyte.config.Notification.NotificationType;
 import io.airbyte.config.SlackNotificationConfiguration;
@@ -64,6 +65,11 @@ class WorkspacesHandlerTest {
   private static final String TEST_WORKSPACE_NAME = "test workspace";
   private static final String TEST_WORKSPACE_SLUG = "test-workspace";
 
+  private static final io.airbyte.api.model.generated.Geography GEOGRAPHY_AUTO =
+      io.airbyte.api.model.generated.Geography.AUTO;
+  private static final io.airbyte.api.model.generated.Geography GEOGRAPHY_US =
+      io.airbyte.api.model.generated.Geography.US;
+
   @SuppressWarnings("unchecked")
   @BeforeEach
   void setUp() {
@@ -89,7 +95,8 @@ class WorkspacesHandlerTest {
         .withAnonymousDataCollection(false)
         .withSecurityUpdates(false)
         .withTombstone(false)
-        .withNotifications(List.of(generateNotification()));
+        .withNotifications(List.of(generateNotification()))
+        .withDefaultGeography(Geography.AUTO);
   }
 
   private Notification generateNotification() {
@@ -121,7 +128,8 @@ class WorkspacesHandlerTest {
         .news(false)
         .anonymousDataCollection(false)
         .securityUpdates(false)
-        .notifications(List.of(generateApiNotification()));
+        .notifications(List.of(generateApiNotification()))
+        .defaultGeography(GEOGRAPHY_US);
 
     final WorkspaceRead actualRead = workspacesHandler.createWorkspace(workspaceCreate);
     final WorkspaceRead expectedRead = new WorkspaceRead()
@@ -135,7 +143,8 @@ class WorkspacesHandlerTest {
         .news(false)
         .anonymousDataCollection(false)
         .securityUpdates(false)
-        .notifications(List.of(generateApiNotification()));
+        .notifications(List.of(generateApiNotification()))
+        .defaultGeography(GEOGRAPHY_US);
 
     assertEquals(expectedRead, actualRead);
   }
@@ -172,7 +181,8 @@ class WorkspacesHandlerTest {
         .news(false)
         .anonymousDataCollection(false)
         .securityUpdates(false)
-        .notifications(Collections.emptyList());
+        .notifications(Collections.emptyList())
+        .defaultGeography(GEOGRAPHY_AUTO);
 
     assertTrue(actualRead.getSlug().startsWith(workspace.getSlug()));
     assertNotEquals(workspace.getSlug(), actualRead.getSlug());
@@ -231,7 +241,8 @@ class WorkspacesHandlerTest {
         .news(workspace.getNews())
         .anonymousDataCollection(workspace.getAnonymousDataCollection())
         .securityUpdates(workspace.getSecurityUpdates())
-        .notifications(List.of(generateApiNotification()));
+        .notifications(List.of(generateApiNotification()))
+        .defaultGeography(GEOGRAPHY_AUTO);
 
     final WorkspaceRead expectedWorkspaceRead2 = new WorkspaceRead()
         .workspaceId(workspace2.getWorkspaceId())
@@ -244,7 +255,8 @@ class WorkspacesHandlerTest {
         .news(workspace2.getNews())
         .anonymousDataCollection(workspace2.getAnonymousDataCollection())
         .securityUpdates(workspace2.getSecurityUpdates())
-        .notifications(List.of(generateApiNotification()));
+        .notifications(List.of(generateApiNotification()))
+        .defaultGeography(GEOGRAPHY_AUTO);
 
     final WorkspaceReadList actualWorkspaceReadList = workspacesHandler.listWorkspaces();
 
@@ -269,7 +281,8 @@ class WorkspacesHandlerTest {
         .news(false)
         .anonymousDataCollection(false)
         .securityUpdates(false)
-        .notifications(List.of(generateApiNotification()));
+        .notifications(List.of(generateApiNotification()))
+        .defaultGeography(GEOGRAPHY_AUTO);
 
     assertEquals(workspaceRead, workspacesHandler.getWorkspace(workspaceIdRequestBody));
   }
@@ -290,7 +303,8 @@ class WorkspacesHandlerTest {
         .news(workspace.getNews())
         .anonymousDataCollection(workspace.getAnonymousDataCollection())
         .securityUpdates(workspace.getSecurityUpdates())
-        .notifications(NotificationConverter.toApiList(workspace.getNotifications()));
+        .notifications(NotificationConverter.toApiList(workspace.getNotifications()))
+        .defaultGeography(GEOGRAPHY_AUTO);
 
     assertEquals(workspaceRead, workspacesHandler.getWorkspaceBySlug(slugRequestBody));
   }
@@ -306,7 +320,8 @@ class WorkspacesHandlerTest {
         .news(false)
         .initialSetupComplete(true)
         .displaySetupWizard(false)
-        .notifications(List.of(apiNotification));
+        .notifications(List.of(apiNotification))
+        .defaultGeography(GEOGRAPHY_US);
 
     final Notification expectedNotification = generateNotification();
     expectedNotification.getSlackConfiguration().withWebhook("updated");
@@ -322,7 +337,8 @@ class WorkspacesHandlerTest {
         .withInitialSetupComplete(true)
         .withDisplaySetupWizard(false)
         .withTombstone(false)
-        .withNotifications(List.of(expectedNotification));
+        .withNotifications(List.of(expectedNotification))
+        .withDefaultGeography(Geography.US);
 
     when(configRepository.getStandardWorkspace(workspace.getWorkspaceId(), false))
         .thenReturn(workspace)
@@ -343,7 +359,8 @@ class WorkspacesHandlerTest {
         .news(false)
         .anonymousDataCollection(true)
         .securityUpdates(false)
-        .notifications(List.of(expectedNotificationRead));
+        .notifications(List.of(expectedNotificationRead))
+        .defaultGeography(GEOGRAPHY_US);
 
     verify(configRepository).writeStandardWorkspace(expectedWorkspace);
 
@@ -369,7 +386,8 @@ class WorkspacesHandlerTest {
         .withInitialSetupComplete(workspace.getInitialSetupComplete())
         .withDisplaySetupWizard(workspace.getDisplaySetupWizard())
         .withTombstone(false)
-        .withNotifications(workspace.getNotifications());
+        .withNotifications(workspace.getNotifications())
+        .withDefaultGeography(Geography.AUTO);
 
     when(configRepository.getStandardWorkspace(workspace.getWorkspaceId(), false))
         .thenReturn(workspace)
@@ -388,7 +406,8 @@ class WorkspacesHandlerTest {
         .news(workspace.getNews())
         .anonymousDataCollection(workspace.getAnonymousDataCollection())
         .securityUpdates(workspace.getSecurityUpdates())
-        .notifications(List.of(generateApiNotification()));
+        .notifications(List.of(generateApiNotification()))
+        .defaultGeography(GEOGRAPHY_AUTO);
 
     verify(configRepository).writeStandardWorkspace(expectedWorkspace);
 
@@ -420,7 +439,8 @@ class WorkspacesHandlerTest {
         .news(workspace.getNews())
         .anonymousDataCollection(true)
         .securityUpdates(workspace.getSecurityUpdates())
-        .notifications(NotificationConverter.toApiList(workspace.getNotifications()));
+        .notifications(NotificationConverter.toApiList(workspace.getNotifications()))
+        .defaultGeography(GEOGRAPHY_AUTO);
 
     final WorkspaceRead actualWorkspaceRead = workspacesHandler.updateWorkspace(workspaceUpdate);
     verify(configRepository).writeStandardWorkspace(expectedWorkspace);

--- a/airbyte-server/src/test/java/io/airbyte/server/helpers/ConnectionHelpers.java
+++ b/airbyte-server/src/test/java/io/airbyte/server/helpers/ConnectionHelpers.java
@@ -18,11 +18,13 @@ import io.airbyte.api.model.generated.ConnectionScheduleDataBasicSchedule;
 import io.airbyte.api.model.generated.ConnectionScheduleType;
 import io.airbyte.api.model.generated.ConnectionStatus;
 import io.airbyte.api.model.generated.DestinationRead;
+import io.airbyte.api.model.generated.Geography;
 import io.airbyte.api.model.generated.JobStatus;
 import io.airbyte.api.model.generated.ResourceRequirements;
 import io.airbyte.api.model.generated.SourceRead;
 import io.airbyte.api.model.generated.SyncMode;
 import io.airbyte.api.model.generated.WebBackendConnectionListItem;
+import io.airbyte.commons.enums.Enums;
 import io.airbyte.commons.text.Names;
 import io.airbyte.config.BasicSchedule;
 import io.airbyte.config.JobSyncConfig.NamespaceDefinitionType;
@@ -128,7 +130,8 @@ public class ConnectionHelpers {
                                                               final UUID sourceId,
                                                               final UUID destinationId,
                                                               final List<UUID> operationIds,
-                                                              final UUID sourceCatalogId) {
+                                                              final UUID sourceCatalogId,
+                                                              final Geography geography) {
 
     return new ConnectionRead()
         .connectionId(connectionId)
@@ -149,7 +152,8 @@ public class ConnectionHelpers {
             .cpuLimit(TESTING_RESOURCE_REQUIREMENTS.getCpuLimit())
             .memoryRequest(TESTING_RESOURCE_REQUIREMENTS.getMemoryRequest())
             .memoryLimit(TESTING_RESOURCE_REQUIREMENTS.getMemoryLimit()))
-        .sourceCatalogId(sourceCatalogId);
+        .sourceCatalogId(sourceCatalogId)
+        .geography(geography);
   }
 
   public static ConnectionRead generateExpectedConnectionRead(final StandardSync standardSync) {
@@ -158,7 +162,8 @@ public class ConnectionHelpers {
         standardSync.getSourceId(),
         standardSync.getDestinationId(),
         standardSync.getOperationIds(),
-        standardSync.getSourceCatalogId());
+        standardSync.getSourceCatalogId(),
+        Enums.convertTo(standardSync.getGeography(), Geography.class));
 
     if (standardSync.getSchedule() == null) {
       connectionRead.schedule(null);
@@ -181,7 +186,8 @@ public class ConnectionHelpers {
         .name(standardSync.getName())
         .namespaceFormat(standardSync.getNamespaceFormat())
         .prefix(standardSync.getPrefix())
-        .sourceCatalogId(standardSync.getSourceCatalogId());
+        .sourceCatalogId(standardSync.getSourceCatalogId())
+        .geography(ApiPojoConverters.toApiGeography(standardSync.getGeography()));
 
     if (standardSync.getNamespaceDefinition() != null) {
       connectionRead

--- a/docs/reference/api/generated-api-html/index.html
+++ b/docs/reference/api/generated-api-html/index.html
@@ -10088,6 +10088,7 @@ containing the updated stream needs to be sent.</div>
 <div class="param">status </div><div class="param-desc"><span class="param-type"><a href="#ConnectionStatus">ConnectionStatus</a></span>  </div>
 <div class="param">resourceRequirements (optional)</div><div class="param-desc"><span class="param-type"><a href="#ResourceRequirements">ResourceRequirements</a></span>  </div>
 <div class="param">sourceCatalogId (optional)</div><div class="param-desc"><span class="param-type"><a href="#UUID">UUID</a></span>  format: uuid</div>
+<div class="param">geography (optional)</div><div class="param-desc"><span class="param-type"><a href="#Geography">Geography</a></span>  </div>
     </div>  <!-- field-items -->
   </div>
   <div class="model">

--- a/docs/reference/api/generated-api-html/index.html
+++ b/docs/reference/api/generated-api-html/index.html
@@ -10236,6 +10236,7 @@ containing the updated stream needs to be sent.</div>
 <div class="param">status (optional)</div><div class="param-desc"><span class="param-type"><a href="#ConnectionStatus">ConnectionStatus</a></span>  </div>
 <div class="param">resourceRequirements (optional)</div><div class="param-desc"><span class="param-type"><a href="#ResourceRequirements">ResourceRequirements</a></span>  </div>
 <div class="param">sourceCatalogId (optional)</div><div class="param-desc"><span class="param-type"><a href="#UUID">UUID</a></span>  format: uuid</div>
+<div class="param">geography (optional)</div><div class="param-desc"><span class="param-type"><a href="#Geography">Geography</a></span>  </div>
     </div>  <!-- field-items -->
   </div>
   <div class="model">

--- a/docs/reference/api/generated-api-html/index.html
+++ b/docs/reference/api/generated-api-html/index.html
@@ -369,6 +369,7 @@ font-style: italic;
   <li><a href="#webBackendGetConnection"><code><span class="http-method">post</span> /v1/web_backend/connections/get</code></a></li>
   <li><a href="#webBackendGetWorkspaceState"><code><span class="http-method">post</span> /v1/web_backend/workspace/state</code></a></li>
   <li><a href="#webBackendListConnectionsForWorkspace"><code><span class="http-method">post</span> /v1/web_backend/connections/list</code></a></li>
+  <li><a href="#webBackendListGeographies"><code><span class="http-method">post</span> /v1/web_backend/geographies/list</code></a></li>
   <li><a href="#webBackendUpdateConnection"><code><span class="http-method">post</span> /v1/web_backend/connections/update</code></a></li>
   </ul>
   <h4><a href="#Workspace">Workspace</a></h4>
@@ -8831,6 +8832,46 @@ containing the updated stream needs to be sent.</div>
         <a href="#InvalidInputExceptionInfo">InvalidInputExceptionInfo</a>
   </div> <!-- method -->
   <hr/>
+  <div class="method"><a name="webBackendListGeographies"/>
+    <div class="method-path">
+    <a class="up" href="#__Methods">Up</a>
+    <pre class="post"><code class="huge"><span class="http-method">post</span> /v1/web_backend/geographies/list</code></pre></div>
+    <div class="method-summary">Returns two-letter country codes that can be selected for running data syncs in a particular geography. (<span class="nickname">webBackendListGeographies</span>)</div>
+    <div class="method-notes"></div>
+
+
+
+
+
+
+
+    <h3 class="field-label">Return type</h3>
+    <div class="return-type">
+      <a href="#WebBackendGeographiesListResult">WebBackendGeographiesListResult</a>
+      
+    </div>
+
+    <!--Todo: process Response Object and its headers, schema, examples -->
+
+    <h3 class="field-label">Example data</h3>
+    <div class="example-data-content-type">Content-Type: application/json</div>
+    <pre class="example"><code>{
+  "geographies" : [ null, null ]
+}</code></pre>
+
+    <h3 class="field-label">Produces</h3>
+    This API call produces the following media types according to the <span class="header">Accept</span> request header;
+    the media type will be conveyed by the <span class="header">Content-Type</span> response header.
+    <ul>
+      <li><code>application/json</code></li>
+    </ul>
+
+    <h3 class="field-label">Responses</h3>
+    <h4 class="field-label">200</h4>
+    Successful operation
+        <a href="#WebBackendGeographiesListResult">WebBackendGeographiesListResult</a>
+  </div> <!-- method -->
+  <hr/>
   <div class="method"><a name="webBackendUpdateConnection"/>
     <div class="method-path">
     <a class="up" href="#__Methods">Up</a>
@@ -9729,6 +9770,7 @@ containing the updated stream needs to be sent.</div>
     <li><a href="#FieldRemove"><code>FieldRemove</code> - </a></li>
     <li><a href="#FieldSchemaUpdate"><code>FieldSchemaUpdate</code> - </a></li>
     <li><a href="#FieldTransform"><code>FieldTransform</code> - </a></li>
+    <li><a href="#Geography"><code>Geography</code> - </a></li>
     <li><a href="#GlobalState"><code>GlobalState</code> - </a></li>
     <li><a href="#HealthCheckRead"><code>HealthCheckRead</code> - </a></li>
     <li><a href="#ImportRead"><code>ImportRead</code> - </a></li>
@@ -9814,6 +9856,7 @@ containing the updated stream needs to be sent.</div>
     <li><a href="#WebBackendConnectionReadList"><code>WebBackendConnectionReadList</code> - </a></li>
     <li><a href="#WebBackendConnectionRequestBody"><code>WebBackendConnectionRequestBody</code> - </a></li>
     <li><a href="#WebBackendConnectionUpdate"><code>WebBackendConnectionUpdate</code> - </a></li>
+    <li><a href="#WebBackendGeographiesListResult"><code>WebBackendGeographiesListResult</code> - </a></li>
     <li><a href="#WebBackendOperationCreateOrUpdate"><code>WebBackendOperationCreateOrUpdate</code> - </a></li>
     <li><a href="#WebBackendWorkspaceState"><code>WebBackendWorkspaceState</code> - </a></li>
     <li><a href="#WebBackendWorkspaceStateResult"><code>WebBackendWorkspaceStateResult</code> - </a></li>
@@ -10073,6 +10116,7 @@ containing the updated stream needs to be sent.</div>
 <div class="param">status </div><div class="param-desc"><span class="param-type"><a href="#ConnectionStatus">ConnectionStatus</a></span>  </div>
 <div class="param">resourceRequirements (optional)</div><div class="param-desc"><span class="param-type"><a href="#ResourceRequirements">ResourceRequirements</a></span>  </div>
 <div class="param">sourceCatalogId (optional)</div><div class="param-desc"><span class="param-type"><a href="#UUID">UUID</a></span>  format: uuid</div>
+<div class="param">geography (optional)</div><div class="param-desc"><span class="param-type"><a href="#Geography">Geography</a></span>  </div>
     </div>  <!-- field-items -->
   </div>
   <div class="model">
@@ -10479,6 +10523,12 @@ containing the updated stream needs to be sent.</div>
 <div class="param">removeField (optional)</div><div class="param-desc"><span class="param-type"><a href="#FieldRemove">FieldRemove</a></span>  </div>
 <div class="param">updateFieldSchema (optional)</div><div class="param-desc"><span class="param-type"><a href="#FieldSchemaUpdate">FieldSchemaUpdate</a></span>  </div>
     </div>  <!-- field-items -->
+  </div>
+  <div class="model">
+    <h3><a name="Geography"><code>Geography</code> - </a> <a class="up" href="#__Models">Up</a></h3>
+    <div class='model-description'></div>
+    <div class="field-items">
+          </div>  <!-- field-items -->
   </div>
   <div class="model">
     <h3><a name="GlobalState"><code>GlobalState</code> - </a> <a class="up" href="#__Models">Up</a></h3>
@@ -11185,6 +11235,7 @@ if oauth parameters were contained inside the top level, rootObject=[] If they w
 <div class="param">resourceRequirements (optional)</div><div class="param-desc"><span class="param-type"><a href="#ResourceRequirements">ResourceRequirements</a></span>  </div>
 <div class="param">operations (optional)</div><div class="param-desc"><span class="param-type"><a href="#OperationCreate">array[OperationCreate]</a></span>  </div>
 <div class="param">sourceCatalogId (optional)</div><div class="param-desc"><span class="param-type"><a href="#UUID">UUID</a></span>  format: uuid</div>
+<div class="param">geography (optional)</div><div class="param-desc"><span class="param-type"><a href="#Geography">Geography</a></span>  </div>
     </div>  <!-- field-items -->
   </div>
   <div class="model">
@@ -11231,6 +11282,7 @@ if oauth parameters were contained inside the top level, rootObject=[] If they w
 <div class="param">resourceRequirements (optional)</div><div class="param-desc"><span class="param-type"><a href="#ResourceRequirements">ResourceRequirements</a></span>  </div>
 <div class="param">catalogId (optional)</div><div class="param-desc"><span class="param-type"><a href="#UUID">UUID</a></span>  format: uuid</div>
 <div class="param">catalogDiff (optional)</div><div class="param-desc"><span class="param-type"><a href="#CatalogDiff">CatalogDiff</a></span>  </div>
+<div class="param">geography (optional)</div><div class="param-desc"><span class="param-type"><a href="#Geography">Geography</a></span>  </div>
     </div>  <!-- field-items -->
   </div>
   <div class="model">
@@ -11266,6 +11318,14 @@ if oauth parameters were contained inside the top level, rootObject=[] If they w
 <div class="param">skipReset (optional)</div><div class="param-desc"><span class="param-type"><a href="#boolean">Boolean</a></span>  </div>
 <div class="param">operations (optional)</div><div class="param-desc"><span class="param-type"><a href="#WebBackendOperationCreateOrUpdate">array[WebBackendOperationCreateOrUpdate]</a></span>  </div>
 <div class="param">sourceCatalogId (optional)</div><div class="param-desc"><span class="param-type"><a href="#UUID">UUID</a></span>  format: uuid</div>
+<div class="param">geography (optional)</div><div class="param-desc"><span class="param-type"><a href="#Geography">Geography</a></span>  </div>
+    </div>  <!-- field-items -->
+  </div>
+  <div class="model">
+    <h3><a name="WebBackendGeographiesListResult"><code>WebBackendGeographiesListResult</code> - </a> <a class="up" href="#__Models">Up</a></h3>
+    <div class='model-description'></div>
+    <div class="field-items">
+      <div class="param">geographies </div><div class="param-desc"><span class="param-type"><a href="#Geography">array[Geography]</a></span>  </div>
     </div>  <!-- field-items -->
   </div>
   <div class="model">
@@ -11305,6 +11365,7 @@ if oauth parameters were contained inside the top level, rootObject=[] If they w
 <div class="param">securityUpdates (optional)</div><div class="param-desc"><span class="param-type"><a href="#boolean">Boolean</a></span>  </div>
 <div class="param">notifications (optional)</div><div class="param-desc"><span class="param-type"><a href="#Notification">array[Notification]</a></span>  </div>
 <div class="param">displaySetupWizard (optional)</div><div class="param-desc"><span class="param-type"><a href="#boolean">Boolean</a></span>  </div>
+<div class="param">defaultGeography (optional)</div><div class="param-desc"><span class="param-type"><a href="#Geography">Geography</a></span>  </div>
     </div>  <!-- field-items -->
   </div>
   <div class="model">
@@ -11338,6 +11399,7 @@ if oauth parameters were contained inside the top level, rootObject=[] If they w
 <div class="param">notifications (optional)</div><div class="param-desc"><span class="param-type"><a href="#Notification">array[Notification]</a></span>  </div>
 <div class="param">firstCompletedSync (optional)</div><div class="param-desc"><span class="param-type"><a href="#boolean">Boolean</a></span>  </div>
 <div class="param">feedbackDone (optional)</div><div class="param-desc"><span class="param-type"><a href="#boolean">Boolean</a></span>  </div>
+<div class="param">defaultGeography (optional)</div><div class="param-desc"><span class="param-type"><a href="#Geography">Geography</a></span>  </div>
     </div>  <!-- field-items -->
   </div>
   <div class="model">
@@ -11359,6 +11421,7 @@ if oauth parameters were contained inside the top level, rootObject=[] If they w
 <div class="param">news (optional)</div><div class="param-desc"><span class="param-type"><a href="#boolean">Boolean</a></span>  </div>
 <div class="param">securityUpdates (optional)</div><div class="param-desc"><span class="param-type"><a href="#boolean">Boolean</a></span>  </div>
 <div class="param">notifications (optional)</div><div class="param-desc"><span class="param-type"><a href="#Notification">array[Notification]</a></span>  </div>
+<div class="param">defaultGeography (optional)</div><div class="param-desc"><span class="param-type"><a href="#Geography">Geography</a></span>  </div>
     </div>  <!-- field-items -->
   </div>
   <div class="model">

--- a/docs/reference/api/generated-api-html/index.html
+++ b/docs/reference/api/generated-api-html/index.html
@@ -8836,8 +8836,11 @@ containing the updated stream needs to be sent.</div>
     <div class="method-path">
     <a class="up" href="#__Methods">Up</a>
     <pre class="post"><code class="huge"><span class="http-method">post</span> /v1/web_backend/geographies/list</code></pre></div>
-    <div class="method-summary">Returns two-letter country codes that can be selected for running data syncs in a particular geography. (<span class="nickname">webBackendListGeographies</span>)</div>
-    <div class="method-notes"></div>
+    <div class="method-summary">Returns available geographies can be selected to run data syncs in a particular geography.
+The 'auto' entry indicates that the sync will be automatically assigned to a geography according
+to the platform default behavior. Entries other than 'auto' are two-letter country codes that
+follow the ISO 3166-1 alpha-2 standard. (<span class="nickname">webBackendListGeographies</span>)</div>
+    <div class="method-notes">Returns all available geographies in which a data sync can run.</div>
 
 
 


### PR DESCRIPTION
## What
Addresses https://github.com/airbytehq/airbyte-cloud/issues/2278

## How
- Adds new endpoint `v1/web_backend/geographies/list` which returns available Geographies
  - Will be just `['auto']` in OSS, and `['auto', 'us', 'eu']` in Cloud
- Modifies `/v1/workspaces/update` to support a new property called `defaultGeography`
  - This endpoint is already PATCH-style, which means:
    - If this property is present on the update request, will set the workspace's `defaultGeography` column to the value
    - If this property is not present on the update request, will leave the workspace's current `defaultGeography` unmodified
- Modifies the `/v1/connections/create` and `/v1/web_backend/connections/create` endpoint to support a new optional property called `geography`
  - If present on the create request, will set the Connection's geography column to the value
  - If not present, the Connection will use whatever is set on its workspace's `defaultGeography`.
- Modifies the `/v1/connections/update` and `/v1/web_backend/connections/update` endpoint to support a new optional property called `geography`
  - This endpoint is already PATCH-style, which means:
     - If this property is present, will set the Connection's 'geography' column to the value
     - If not present, will leave the Connection's 'geography' unmodified
  

## Recommended reading order
1. Start with the various `.yaml` files that define the Geography type and various schema updates
2. WebBackendGeographiesHandler.java
3. ConnectionsHandler.java
4. WorkspacesHandler.java
5. Other non-test changes, all relatively minor
6. Tests