### PR TITLE
supply a source id for schema discovery in connector integration tests

### DIFF
--- a/airbyte-integrations/bases/standard-source-test/src/main/java/io/airbyte/integrations/standardtest/source/AbstractSourceConnectorTest.java
+++ b/airbyte-integrations/bases/standard-source-test/src/main/java/io/airbyte/integrations/standardtest/source/AbstractSourceConnectorTest.java
@@ -164,8 +164,8 @@ public abstract class AbstractSourceConnectorTest {
     final UUID toReturn = new DefaultDiscoverCatalogWorker(
         mConfigRepository,
         new AirbyteIntegrationLauncher(JOB_ID, JOB_ATTEMPT, getImageName(), processFactory, workerConfigs.getResourceRequirements()))
-        .run(new StandardDiscoverCatalogInput().withSourceId(SOURCE_ID.toString()).withConnectionConfiguration(getConfig()), jobRoot)
-        .getDiscoverCatalogId();
+            .run(new StandardDiscoverCatalogInput().withSourceId(SOURCE_ID.toString()).withConnectionConfiguration(getConfig()), jobRoot)
+            .getDiscoverCatalogId();
     verify(mConfigRepository).writeActorCatalogFetchEvent(lastPersistedCatalog.capture(), any(), any(), any());
     return toReturn;
   }

--- a/airbyte-integrations/bases/standard-source-test/src/main/java/io/airbyte/integrations/standardtest/source/AbstractSourceConnectorTest.java
+++ b/airbyte-integrations/bases/standard-source-test/src/main/java/io/airbyte/integrations/standardtest/source/AbstractSourceConnectorTest.java
@@ -66,6 +66,8 @@ public abstract class AbstractSourceConnectorTest {
   private static final String JOB_ID = String.valueOf(0L);
   private static final int JOB_ATTEMPT = 0;
 
+  private static final UUID SOURCE_ID = UUID.randomUUID();
+
   private static final String CPU_REQUEST_FIELD_NAME = "cpuRequest";
   private static final String CPU_LIMIT_FIELD_NAME = "cpuLimit";
   private static final String MEMORY_REQUEST_FIELD_NAME = "memoryRequest";
@@ -162,7 +164,8 @@ public abstract class AbstractSourceConnectorTest {
     final UUID toReturn = new DefaultDiscoverCatalogWorker(
         mConfigRepository,
         new AirbyteIntegrationLauncher(JOB_ID, JOB_ATTEMPT, getImageName(), processFactory, workerConfigs.getResourceRequirements()))
-            .run(new StandardDiscoverCatalogInput().withConnectionConfiguration(getConfig()), jobRoot).getDiscoverCatalogId();
+        .run(new StandardDiscoverCatalogInput().withSourceId(SOURCE_ID.toString()).withConnectionConfiguration(getConfig()), jobRoot)
+        .getDiscoverCatalogId();
     verify(mConfigRepository).writeActorCatalogFetchEvent(lastPersistedCatalog.capture(), any(), any(), any());
     return toReturn;
   }

--- a/airbyte-workers/src/main/java/io/airbyte/workers/general/DefaultDiscoverCatalogWorker.java
+++ b/airbyte-workers/src/main/java/io/airbyte/workers/general/DefaultDiscoverCatalogWorker.java
@@ -88,7 +88,8 @@ public class DefaultDiscoverCatalogWorker implements DiscoverCatalogWorker {
 
         final UUID catalogId =
             configRepository.writeActorCatalogFetchEvent(catalog.get(),
-                // NOTE: sourceId is marked required in the OpenAPI config but the code generator doesn't enforce it, so we check again here.
+                // NOTE: sourceId is marked required in the OpenAPI config but the code generator doesn't enforce
+                // it, so we check again here.
                 discoverSchemaInput.getSourceId() == null ? null : UUID.fromString(discoverSchemaInput.getSourceId()),
                 discoverSchemaInput.getConnectorVersion(),
                 discoverSchemaInput.getConfigHash());

--- a/airbyte-workers/src/main/java/io/airbyte/workers/general/DefaultDiscoverCatalogWorker.java
+++ b/airbyte-workers/src/main/java/io/airbyte/workers/general/DefaultDiscoverCatalogWorker.java
@@ -87,7 +87,9 @@ public class DefaultDiscoverCatalogWorker implements DiscoverCatalogWorker {
         }
 
         final UUID catalogId =
-            configRepository.writeActorCatalogFetchEvent(catalog.get(), UUID.fromString(discoverSchemaInput.getSourceId()),
+            configRepository.writeActorCatalogFetchEvent(catalog.get(),
+                // NOTE: sourceId is marked required in the OpenAPI config but the code generator doesn't enforce it, so we check again here.
+                discoverSchemaInput.getSourceId() == null ? null : UUID.fromString(discoverSchemaInput.getSourceId()),
                 discoverSchemaInput.getConnectorVersion(),
                 discoverSchemaInput.getConfigHash());
         return new ConnectorJobOutput().withOutputType(OutputType.DISCOVER_CATALOG_ID).withDiscoverCatalogId(catalogId);


### PR DESCRIPTION
## What
Fixes the failing connector integration tests.

## How
The schema discovery workflow expects a source id. This change supplies one.
