### PR TITLE
🪟 ☁️ 🔧 Add Datadog support to cloud app

### DIFF
--- a/airbyte-webapp/package-lock.json
+++ b/airbyte-webapp/package-lock.json
@@ -8,6 +8,7 @@
       "name": "airbyte-webapp",
       "version": "0.40.12",
       "dependencies": {
+        "@datadog/browser-rum": "^4.21.2",
         "@floating-ui/react-dom": "^1.0.0",
         "@fortawesome/fontawesome-svg-core": "^6.1.1",
         "@fortawesome/free-brands-svg-icons": "^6.1.1",
@@ -2497,6 +2498,36 @@
       "resolved": "https://registry.npmjs.org/@csstools/normalize.css/-/normalize.css-12.0.0.tgz",
       "integrity": "sha512-M0qqxAcwCsIVfpFQSlGN5XjXWu8l5JDZN+fPt1LeW5SZexQTgnaEvgXAY+CeygRw0EeppWHi12JxESWiWrB0Sg==",
       "dev": true
+    },
+    "node_modules/@datadog/browser-core": {
+      "version": "4.21.2",
+      "resolved": "https://registry.npmjs.org/@datadog/browser-core/-/browser-core-4.21.2.tgz",
+      "integrity": "sha512-o3UvCPBF0OdCInCbiC9j79K0F7/wThARZFq8+wnAOitZu64VT5XNpHFQqFP+9c+zzcxmwlTIINHmWLdkpKEECg=="
+    },
+    "node_modules/@datadog/browser-rum": {
+      "version": "4.21.2",
+      "resolved": "https://registry.npmjs.org/@datadog/browser-rum/-/browser-rum-4.21.2.tgz",
+      "integrity": "sha512-qvC7sRrZ5yy7siCHeGPnBsM6sKoU+jc1YGy/5WgRSs24WUt9trgBoRcVR1KwU/aK8xn6hUOKRdEIxkrss5JaiA==",
+      "dependencies": {
+        "@datadog/browser-core": "4.21.2",
+        "@datadog/browser-rum-core": "4.21.2"
+      },
+      "peerDependencies": {
+        "@datadog/browser-logs": "4.21.2"
+      },
+      "peerDependenciesMeta": {
+        "@datadog/browser-logs": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@datadog/browser-rum-core": {
+      "version": "4.21.2",
+      "resolved": "https://registry.npmjs.org/@datadog/browser-rum-core/-/browser-rum-core-4.21.2.tgz",
+      "integrity": "sha512-8hNiNygHY8Jt2APtm4nvciGyRKIEniaupe7Uj5Bq6OFZIFNgf6qj88bRXwOdPsP9ksBNNK18Hol1oI4EdxdkkQ==",
+      "dependencies": {
+        "@datadog/browser-core": "4.21.2"
+      }
     },
     "node_modules/@discoveryjs/json-ext": {
       "version": "0.5.7",
@@ -49343,6 +49374,28 @@
       "resolved": "https://registry.npmjs.org/@csstools/normalize.css/-/normalize.css-12.0.0.tgz",
       "integrity": "sha512-M0qqxAcwCsIVfpFQSlGN5XjXWu8l5JDZN+fPt1LeW5SZexQTgnaEvgXAY+CeygRw0EeppWHi12JxESWiWrB0Sg==",
       "dev": true
+    },
+    "@datadog/browser-core": {
+      "version": "4.21.2",
+      "resolved": "https://registry.npmjs.org/@datadog/browser-core/-/browser-core-4.21.2.tgz",
+      "integrity": "sha512-o3UvCPBF0OdCInCbiC9j79K0F7/wThARZFq8+wnAOitZu64VT5XNpHFQqFP+9c+zzcxmwlTIINHmWLdkpKEECg=="
+    },
+    "@datadog/browser-rum": {
+      "version": "4.21.2",
+      "resolved": "https://registry.npmjs.org/@datadog/browser-rum/-/browser-rum-4.21.2.tgz",
+      "integrity": "sha512-qvC7sRrZ5yy7siCHeGPnBsM6sKoU+jc1YGy/5WgRSs24WUt9trgBoRcVR1KwU/aK8xn6hUOKRdEIxkrss5JaiA==",
+      "requires": {
+        "@datadog/browser-core": "4.21.2",
+        "@datadog/browser-rum-core": "4.21.2"
+      }
+    },
+    "@datadog/browser-rum-core": {
+      "version": "4.21.2",
+      "resolved": "https://registry.npmjs.org/@datadog/browser-rum-core/-/browser-rum-core-4.21.2.tgz",
+      "integrity": "sha512-8hNiNygHY8Jt2APtm4nvciGyRKIEniaupe7Uj5Bq6OFZIFNgf6qj88bRXwOdPsP9ksBNNK18Hol1oI4EdxdkkQ==",
+      "requires": {
+        "@datadog/browser-core": "4.21.2"
+      }
     },
     "@discoveryjs/json-ext": {
       "version": "0.5.7",

--- a/airbyte-webapp/package.json
+++ b/airbyte-webapp/package.json
@@ -24,6 +24,7 @@
     "validate-links": "ts-node --skip-project ./scripts/validate-links.ts"
   },
   "dependencies": {
+    "@datadog/browser-rum": "^4.21.2",
     "@floating-ui/react-dom": "^1.0.0",
     "@fortawesome/fontawesome-svg-core": "^6.1.1",
     "@fortawesome/free-brands-svg-icons": "^6.1.1",

--- a/airbyte-webapp/src/config/types.ts
+++ b/airbyte-webapp/src/config/types.ts
@@ -6,6 +6,10 @@ declare global {
     AIRBYTE_VERSION?: string;
     API_URL?: string;
     CLOUD?: string;
+    DATADOG_APPLICATION_ID: string;
+    DATADOG_CLIENT_TOKEN: string;
+    DATADOG_SITE: string;
+    DATADOG_SERVICE: string;
     REACT_APP_SENTRY_DSN?: string;
     REACT_APP_WEBAPP_TAG?: string;
     REACT_APP_INTERCOM_APP_ID?: string;

--- a/airbyte-webapp/src/packages/cloud/cloudRoutes.tsx
+++ b/airbyte-webapp/src/packages/cloud/cloudRoutes.tsx
@@ -28,6 +28,7 @@ import { CompleteOauthRequest } from "views/CompleteOauthRequest";
 
 import { RoutePaths } from "../../pages/routePaths";
 import { CreditStatus } from "./lib/domain/cloudWorkspaces/types";
+import { useDatadog } from "./services/thirdParty/datadog/useDatadog";
 import { LDExperimentServiceProvider } from "./services/thirdParty/launchdarkly";
 import { useGetCloudWorkspace } from "./services/workspaces/CloudWorkspacesService";
 import { DefaultView } from "./views/DefaultView";
@@ -138,8 +139,9 @@ const MainViewRoutes = () => {
 
 export const Routing: React.FC = () => {
   const { user, inited, providers } = useAuthService();
-
   const { search } = useLocation();
+
+  useDatadog();
 
   useEffectOnce(() => {
     storeUtmFromQuery(search);

--- a/airbyte-webapp/src/packages/cloud/services/config/configProviders.ts
+++ b/airbyte-webapp/src/packages/cloud/services/config/configProviders.ts
@@ -26,6 +26,12 @@ const cloudWindowConfigProvider: ConfigProvider<CloudConfig> = async () => {
     intercom: {
       appId: window.REACT_APP_INTERCOM_APP_ID,
     },
+    datadog: {
+      applicationId: window.DATADOG_APPLICATION_ID,
+      clientToken: window.DATADOG_CLIENT_TOKEN,
+      site: window.DATADOG_SITE,
+      service: window.DATADOG_SERVICE,
+    },
     firebase: {
       apiKey: window.FIREBASE_API_KEY,
       authDomain: window.FIREBASE_AUTH_DOMAIN,
@@ -39,6 +45,12 @@ const cloudWindowConfigProvider: ConfigProvider<CloudConfig> = async () => {
 const cloudEnvConfigProvider: ConfigProvider<CloudConfig> = async () => {
   return {
     cloudApiUrl: process.env.REACT_APP_CLOUD_API_URL,
+    datadog: {
+      applicationId: process.env.REACT_APP_DATADOG_APPLICATION_ID,
+      clientToken: process.env.REACT_APP_DATADOG_CLIENT_TOKEN,
+      site: process.env.REACT_APP_DATADOG_SITE,
+      service: process.env.REACT_APP_DATADOG_SERVICE,
+    },
     firebase: {
       apiKey: process.env.REACT_APP_FIREBASE_API_KEY,
       authDomain: process.env.REACT_APP_FIREBASE_AUTH_DOMAIN,

--- a/airbyte-webapp/src/packages/cloud/services/config/index.ts
+++ b/airbyte-webapp/src/packages/cloud/services/config/index.ts
@@ -8,6 +8,12 @@ export function useConfig(): CloudConfig {
 
 const cloudConfigExtensionDefault: CloudConfigExtension = {
   cloudApiUrl: "",
+  datadog: {
+    applicationId: "",
+    clientToken: "",
+    site: "",
+    service: "",
+  },
   firebase: {
     apiKey: "",
     authDomain: "",

--- a/airbyte-webapp/src/packages/cloud/services/config/types.ts
+++ b/airbyte-webapp/src/packages/cloud/services/config/types.ts
@@ -12,6 +12,12 @@ declare global {
 
 export interface CloudConfigExtension {
   cloudApiUrl: string;
+  datadog: {
+    applicationId: string;
+    clientToken: string;
+    site: string;
+    service: string;
+  };
   firebase: {
     apiKey: string;
     authDomain: string;

--- a/airbyte-webapp/src/packages/cloud/services/thirdParty/datadog/useDatadog.ts
+++ b/airbyte-webapp/src/packages/cloud/services/thirdParty/datadog/useDatadog.ts
@@ -1,0 +1,43 @@
+import { datadogRum } from "@datadog/browser-rum";
+import { useEffect, useMemo } from "react";
+import { createGlobalState } from "react-use";
+
+import { useConfig } from "config";
+
+import { useConfig as useCloudConfig } from "../../config";
+
+const useDatadogInited = createGlobalState(false);
+
+export const useDatadog = (): void => {
+  const { version } = useConfig();
+  const { datadog: datadogConfig } = useCloudConfig();
+
+  const [inited, setInited] = useDatadogInited();
+  const enabled = useMemo(
+    () => !Object.values(datadogConfig).some((value) => !value || value.trim().length === 0),
+    [datadogConfig]
+  );
+
+  useEffect(() => {
+    if (inited || !enabled) {
+      return;
+    }
+
+    datadogRum.init({
+      applicationId: datadogConfig.applicationId,
+      clientToken: datadogConfig.clientToken,
+      site: datadogConfig.site,
+      service: datadogConfig.service,
+      version,
+      sampleRate: 100,
+      sessionReplaySampleRate: 20,
+      trackInteractions: true,
+      trackResources: true,
+      trackLongTasks: true,
+      defaultPrivacyLevel: "mask-user-input",
+    });
+
+    datadogRum.startSessionReplayRecording();
+    setInited(true);
+  }, [datadogConfig, enabled, inited, setInited, version]);
+};


### PR DESCRIPTION
## What
Related to:  https://github.com/airbytehq/airbyte-cloud/issues/2996

Add Datadog Real User Monitoring (RUM) support to cloud app.

WIP. Still need to get feedback and add support to deploy the app with the env vars.

## How
Follow similar patterns to how other third-party tools like Intercom and (previously) Fullstory are setup. Environment variables must be defined first to enable Datadog.

Docs: https://docs.datadoghq.com/real_user_monitoring/browser/

## Recommended reading order
1. `useDatadog.ts`
2. Rest of code
