### PR TITLE
Add APM trace dependencies to catalog

### DIFF
--- a/deps.toml
+++ b/deps.toml
@@ -1,4 +1,5 @@
 [versions]
+datadog-version = "0.110.0"
 fasterxml_version = "2.13.3"
 flyway = "7.14.0"
 glassfish_version = "2.31"
@@ -90,7 +91,8 @@ otel-semconv = {module = "io.opentelemetry:opentelemetry-semconv", version = "1.
 otel-sdk = {module = "io.opentelemetry:opentelemetry-sdk-metrics", version = "1.14.0"}
 otel-sdk-testing = {module = "io.opentelemetry:opentelemetry-sdk-metrics-testing", version = "1.13.0-alpha"}
 micrometer-statsd = {module = "io.micrometer:micrometer-registry-statsd", version = "1.9.3"}
-
+datadog-trace-api = { module = "com.datadoghq:dd-trace-api", version.ref = "datadog-version" }
+datadog-trace-ot = { module = "com.datadoghq:dd-trace-ot", version.ref = "datadog-version" }
 quartz-scheduler = {module="org.quartz-scheduler:quartz", version = "2.3.2"}
 
 # Micronaut-related dependencies
@@ -119,6 +121,7 @@ micronaut-validation = { module = "io.micronaut:micronaut-validation" }
 [bundles]
 jackson = ["jackson-databind", "jackson-annotations", "jackson-dataformat", "jackson-datatype"]
 apache = ["apache-commons", "apache-commons-lang"]
+datadog = ["datadog-trace-api", "datadog-trace-ot"]
 log4j = ["log4j-api", "log4j-core", "log4j-impl", "log4j-web"]
 slf4j = ["jul-to-slf4j", "jcl-over-slf4j", "log4j-over-slf4j"]
 junit = ["junit-jupiter-api", "junit-jupiter-params", "mockito-junit-jupiter"]


### PR DESCRIPTION
## What
* Provide dependencies necessary for custom APM tracing

## How
* Add the DataDog tracing API dependencies to the dependency catalog

## Recommended reading order
1. `deps.toml`