### PR TITLE
Add dependency required by airbyte-workers

### DIFF
--- a/settings.gradle
+++ b/settings.gradle
@@ -65,6 +65,7 @@ include ':airbyte-api'
 include ':airbyte-commons-cli'
 include ':airbyte-commons-docker'
 include ':airbyte-commons-protocol'
+include ':airbyte-config:init'
 include ':airbyte-config:config-models' // reused by acceptance tests in connector base.
 include ':airbyte-db:db-lib' // reused by acceptance tests in connector base.
 include ':airbyte-json-validation'
@@ -87,7 +88,6 @@ include ':airbyte-notification' // transitively used by airbyte-workers.
 if (!System.getenv().containsKey("SUB_BUILD") || System.getenv().get("SUB_BUILD") == "PLATFORM") {
     include ':airbyte-bootloader'
     include ':airbyte-cli'
-    include ':airbyte-config:init'
     include ':airbyte-config:specs'
     include ':airbyte-container-orchestrator'
     include ':airbyte-cron'


### PR DESCRIPTION
## What
* Ensure all dependencies are present to build both platform and connectors

## How
* Move `:airbyte-config:init` to common section

## Recommended reading order
1. `settings.gradle`