### PR TITLE
source-google-analytics-v4: use hits metric for check

### DIFF
--- a/airbyte-config/init/src/main/resources/seed/source_definitions.yaml
+++ b/airbyte-config/init/src/main/resources/seed/source_definitions.yaml
@@ -386,7 +386,7 @@
 - name: Google Analytics (Universal Analytics)
   sourceDefinitionId: eff3616a-f9c3-11eb-9a03-0242ac130003
   dockerRepository: airbyte/source-google-analytics-v4
-  dockerImageTag: 0.1.26
+  dockerImageTag: 0.1.27
   documentationUrl: https://docs.airbyte.com/integrations/sources/google-analytics-universal-analytics
   icon: google-analytics.svg
   sourceType: api

--- a/airbyte-config/init/src/main/resources/seed/source_specs.yaml
+++ b/airbyte-config/init/src/main/resources/seed/source_specs.yaml
@@ -3866,7 +3866,7 @@
         oauthFlowOutputParameters:
         - - "access_token"
         - - "refresh_token"
-- dockerImage: "airbyte/source-google-analytics-v4:0.1.26"
+- dockerImage: "airbyte/source-google-analytics-v4:0.1.27"
   spec:
     documentationUrl: "https://docs.airbyte.com/integrations/sources/google-analytics-universal-analytics"
     connectionSpecification:

--- a/airbyte-integrations/connectors/source-google-analytics-v4/Dockerfile
+++ b/airbyte-integrations/connectors/source-google-analytics-v4/Dockerfile
@@ -12,5 +12,5 @@ COPY main.py ./
 ENV AIRBYTE_ENTRYPOINT "python /airbyte/integration_code/main.py"
 ENTRYPOINT ["python", "/airbyte/integration_code/main.py"]
 
-LABEL io.airbyte.version=0.1.26
+LABEL io.airbyte.version=0.1.27
 LABEL io.airbyte.name=airbyte/source-google-analytics-v4

--- a/airbyte-integrations/connectors/source-google-analytics-v4/source_google_analytics_v4/source.py
+++ b/airbyte-integrations/connectors/source-google-analytics-v4/source_google_analytics_v4/source.py
@@ -556,7 +556,7 @@ class SourceGoogleAnalyticsV4(AbstractSource):
         # declare additional variables
         authenticator = self.get_authenticator(config)
         config["authenticator"] = authenticator
-        config["metrics"] = ["ga:14dayUsers"]
+        config["metrics"] = ["ga:hits"]
         config["dimensions"] = ["ga:date"]
 
         try:

--- a/docs/integrations/sources/google-analytics-universal-analytics.md
+++ b/docs/integrations/sources/google-analytics-universal-analytics.md
@@ -155,6 +155,7 @@ Incremental sync is supported only if you add `ga:date` dimension to your custom
 
 | Version | Date       | Pull Request                                             | Subject                                                                                      |
 | :------ | :--------- | :------------------------------------------------------- | :------------------------------------------------------------------------------------------- |
+| 0.1.27  | 2022-10-07 | [17717](https://github.com/airbytehq/airbyte/pull/17717) | Improve CHECK by using `ga:hits` metric.                                                                |
 | 0.1.26  | 2022-09-28 | [17326](https://github.com/airbytehq/airbyte/pull/15087) | Migrate to per-stream states.                                                                |
 | 0.1.25  | 2022-07-27 | [15087](https://github.com/airbytehq/airbyte/pull/15087) | Fix documentationUrl                                                                         |
 | 0.1.24  | 2022-07-26 | [15042](https://github.com/airbytehq/airbyte/pull/15042) | Update `additionalProperties` field to true from schemas                                     |


### PR DESCRIPTION
## What
To check connection the Google Analytics connectors queries a simple report with the `ga:14dayUsers` metric.
This metric is not appropriate because account with low traffic does not have data for this metrics, which cause the `CHECK` to fail.
[OC issue](https://github.com/airbytehq/oncall/issues/758)

## How
Use `ga:hits` metric

