### PR TITLE
:window: :art: Fix design of log view

### DIFF
--- a/airbyte-webapp/src/components/JobItem/components/AttemptDetails.module.scss
+++ b/airbyte-webapp/src/components/JobItem/components/AttemptDetails.module.scss
@@ -7,7 +7,7 @@
   color: colors.$grey;
 }
 
-.details > *:not(:last-child)::after {
+.details > *:not(:last-child, .lastAttempt)::after {
   content: "|";
   padding: 0 variables.$spacing-sm;
 }
@@ -17,4 +17,12 @@
   white-space: nowrap;
   overflow: hidden;
   text-overflow: ellipsis;
+}
+
+.lastAttempt {
+  margin-right: variables.$spacing-sm;
+
+  &.failed {
+    color: colors.$red;
+  }
 }

--- a/airbyte-webapp/src/components/JobItem/components/AttemptDetails.tsx
+++ b/airbyte-webapp/src/components/JobItem/components/AttemptDetails.tsx
@@ -5,20 +5,20 @@ import { FormattedMessage, useIntl } from "react-intl";
 
 import Status from "core/statuses";
 
-import { AttemptRead, JobConfigType } from "../../../core/request/AirbyteClient";
+import { AttemptRead } from "../../../core/request/AirbyteClient";
 import styles from "./AttemptDetails.module.scss";
 
-interface IProps {
+interface AttemptDetailsProps {
   className?: string;
   attempt: AttemptRead;
-  configType?: JobConfigType;
+  hasMultipleAttempts?: boolean;
 }
 
 const getFailureFromAttempt = (attempt: AttemptRead) => {
   return attempt.failureSummary && attempt.failureSummary.failures[0];
 };
 
-const AttemptDetails: React.FC<IProps> = ({ attempt, className }) => {
+const AttemptDetails: React.FC<AttemptDetailsProps> = ({ attempt, className, hasMultipleAttempts }) => {
   const { formatMessage } = useIntl();
 
   if (attempt.status !== Status.SUCCEEDED && attempt.status !== Status.FAILED) {
@@ -67,6 +67,11 @@ const AttemptDetails: React.FC<IProps> = ({ attempt, className }) => {
   return (
     <div className={classNames(styles.container, className)}>
       <div className={styles.details}>
+        {hasMultipleAttempts && (
+          <strong className={classNames(styles.lastAttempt, { [styles.failed]: isFailed })}>
+            <FormattedMessage id="sources.lastAttempt" />
+          </strong>
+        )}
         <span>{formatBytes(attempt?.totalStats?.bytesEmitted)}</span>
         <span>
           <FormattedMessage

--- a/airbyte-webapp/src/components/JobItem/components/MainInfo.module.scss
+++ b/airbyte-webapp/src/components/JobItem/components/MainInfo.module.scss
@@ -25,12 +25,6 @@
       }
     }
 
-    .lastAttempt {
-      font-size: 12px;
-      font-weight: bold;
-      color: colors.$grey;
-    }
-
     .justification {
       width: 80%;
       display: flex;
@@ -38,19 +32,6 @@
       flex-direction: column;
       justify-content: center;
       min-width: 0;
-    }
-  }
-
-  &.open {
-    .arrow {
-      transform: rotate(-0deg);
-    }
-  }
-
-  &.failed {
-    .arrow,
-    .lastAttempt {
-      color: colors.$red;
     }
   }
 
@@ -64,21 +45,6 @@
       line-height: 15px;
       color: colors.$red;
     }
-
-    .arrow {
-      transform: rotate(-90deg);
-      transition: variables.$transition;
-      opacity: 0;
-      color: colors.$dark-blue-50;
-      font-size: 22px;
-      margin: 0 30px 0 50px;
-
-      div:hover > &,
-      div:hover > div > &,
-      div:hover > div > div > & {
-        opacity: 1;
-      }
-    }
   }
 
   &.open:not(.failed) {
@@ -87,5 +53,28 @@
 
   &.open.failed {
     border-bottom: variables.$border-thin solid colors.$red-50;
+  }
+}
+
+.arrow {
+  transform: rotate(-90deg);
+  transition: variables.$transition;
+  opacity: 0;
+  color: colors.$dark-blue-50;
+  font-size: 22px;
+  margin: 0 30px 0 50px;
+
+  .open & {
+    transform: rotate(-0deg);
+  }
+
+  .failed & {
+    color: colors.$red;
+  }
+
+  div:hover > &,
+  div:hover > div > &,
+  div:hover > div > div > & {
+    opacity: 1;
   }
 }

--- a/airbyte-webapp/src/components/JobItem/components/MainInfo.tsx
+++ b/airbyte-webapp/src/components/JobItem/components/MainInfo.tsx
@@ -89,15 +89,10 @@ const MainInfo: React.FC<MainInfoProps> = ({ job, attempts = [], isOpen, onExpan
           {label}
           {attempts.length > 0 && (
             <>
-              {attempts.length > 1 && (
-                <div className={styles.lastAttempt}>
-                  <FormattedMessage id="sources.lastAttempt" />
-                </div>
-              )}
               {jobConfigType === "reset_connection" ? (
                 <ResetStreamsDetails isOpen={isOpen} names={streamsToReset?.map((stream) => stream.name)} />
               ) : (
-                <AttemptDetails attempt={attempts[attempts.length - 1]} configType={getJobConfig(job)} />
+                <AttemptDetails attempt={attempts[attempts.length - 1]} hasMultipleAttempts={attempts.length > 1} />
               )}
             </>
           )}


### PR DESCRIPTION
## What

This fixes a couple of issues and design improvements on the MainInfo and AttemptDetails:

* I noticed the arrow behind at the end of the collapse isn't rotating when opening. This was caused by the further nested rule having had more specificity and thus always applied. I pulled out the CSS for the arrow and restructured the file a bit to solve that. Also this solved the problem that hovering over any item the arrow will become visible on ALL other items as well.
* I moved the "Last Attempt: " into the same row as the actual data, so it's looking a bit less crowded for failed logs (see below screenshot). Therefore I moved that line into the `AttemptDetails` component controlled by a new property whether there are multiple attempts. This also makes this code a bit cleaner, since so far that "Last Attempt" was also checked for reset jobs where it could not happen. and the component we rendered below it wasn't meant to be rendered behind a "Last Attempt" in case it would ever have shown.

![screenshot-20221008-175449](https://user-images.githubusercontent.com/877229/194716665-4a808f50-29b5-44db-9e9d-22cd3b561358.png)
