### PR TITLE
Add SSH tunneling to Elastic Search Destination

### DIFF
--- a/airbyte-config/init/src/main/resources/seed/destination_definitions.yaml
+++ b/airbyte-config/init/src/main/resources/seed/destination_definitions.yaml
@@ -100,7 +100,7 @@
 - destinationDefinitionId: 68f351a7-2745-4bef-ad7f-996b8e51bb8c
   name: ElasticSearch
   dockerRepository: airbyte/destination-elasticsearch
-  dockerImageTag: 0.1.3
+  dockerImageTag: 0.1.4
   documentationUrl: https://docs.airbyte.com/integrations/destinations/elasticsearch
   icon: elasticsearch.svg
   releaseStage: alpha

--- a/airbyte-config/init/src/main/resources/seed/destination_specs.yaml
+++ b/airbyte-config/init/src/main/resources/seed/destination_specs.yaml
@@ -1654,7 +1654,7 @@
     supported_destination_sync_modes:
     - "overwrite"
     - "append"
-- dockerImage: "airbyte/destination-elasticsearch:0.1.3"
+- dockerImage: "airbyte/destination-elasticsearch:0.1.4"
   spec:
     documentationUrl: "https://docs.airbyte.com/integrations/destinations/elasticsearch"
     connectionSpecification:
@@ -1733,6 +1733,107 @@
                   \ server"
                 type: "string"
                 airbyte_secret: true
+        tunnel_method:
+          type: "object"
+          title: "SSH Tunnel Method"
+          description: "Whether to initiate an SSH tunnel before connecting to the\
+            \ database, and if so, which kind of authentication to use."
+          oneOf:
+          - title: "No Tunnel"
+            required:
+            - "tunnel_method"
+            properties:
+              tunnel_method:
+                description: "No ssh tunnel needed to connect to database"
+                type: "string"
+                const: "NO_TUNNEL"
+                order: 0
+          - title: "SSH Key Authentication"
+            required:
+            - "tunnel_method"
+            - "tunnel_host"
+            - "tunnel_port"
+            - "tunnel_user"
+            - "ssh_key"
+            properties:
+              tunnel_method:
+                description: "Connect through a jump server tunnel host using username\
+                  \ and ssh key"
+                type: "string"
+                const: "SSH_KEY_AUTH"
+                order: 0
+              tunnel_host:
+                title: "SSH Tunnel Jump Server Host"
+                description: "Hostname of the jump server host that allows inbound\
+                  \ ssh tunnel."
+                type: "string"
+                order: 1
+              tunnel_port:
+                title: "SSH Connection Port"
+                description: "Port on the proxy/jump server that accepts inbound ssh\
+                  \ connections."
+                type: "integer"
+                minimum: 0
+                maximum: 65536
+                default: 22
+                examples:
+                - "22"
+                order: 2
+              tunnel_user:
+                title: "SSH Login Username"
+                description: "OS-level username for logging into the jump server host."
+                type: "string"
+                order: 3
+              ssh_key:
+                title: "SSH Private Key"
+                description: "OS-level user account ssh key credentials in RSA PEM\
+                  \ format ( created with ssh-keygen -t rsa -m PEM -f myuser_rsa )"
+                type: "string"
+                airbyte_secret: true
+                multiline: true
+                order: 4
+          - title: "Password Authentication"
+            required:
+            - "tunnel_method"
+            - "tunnel_host"
+            - "tunnel_port"
+            - "tunnel_user"
+            - "tunnel_user_password"
+            properties:
+              tunnel_method:
+                description: "Connect through a jump server tunnel host using username\
+                  \ and password authentication"
+                type: "string"
+                const: "SSH_PASSWORD_AUTH"
+                order: 0
+              tunnel_host:
+                title: "SSH Tunnel Jump Server Host"
+                description: "Hostname of the jump server host that allows inbound\
+                  \ ssh tunnel."
+                type: "string"
+                order: 1
+              tunnel_port:
+                title: "SSH Connection Port"
+                description: "Port on the proxy/jump server that accepts inbound ssh\
+                  \ connections."
+                type: "integer"
+                minimum: 0
+                maximum: 65536
+                default: 22
+                examples:
+                - "22"
+                order: 2
+              tunnel_user:
+                title: "SSH Login Username"
+                description: "OS-level username for logging into the jump server host"
+                type: "string"
+                order: 3
+              tunnel_user_password:
+                title: "Password"
+                description: "OS-level password for logging into the jump server host"
+                type: "string"
+                airbyte_secret: true
+                order: 4
     supportsIncremental: true
     supportsNormalization: false
     supportsDBT: false

--- a/airbyte-integrations/bases/base-java/src/main/java/io/airbyte/integrations/base/ssh/SshTunnel.java
+++ b/airbyte-integrations/bases/base-java/src/main/java/io/airbyte/integrations/base/ssh/SshTunnel.java
@@ -76,8 +76,8 @@ public class SshTunnel implements AutoCloseable {
    *        the config remoteDatabasePort is found.
    * @param endPointKey - key that points to the endpoint URL (this is commonly used for REST-based
    *        services such as Elastic and MongoDB)
-   * @param remoteServiceUrl - URL of the remote endpoint (this is commonly used for REST-based
-   *    *        services such as Elastic and MongoDB)
+   * @param remoteServiceUrl - URL of the remote endpoint (this is commonly used for REST-based *
+   *        services such as Elastic and MongoDB)
    * @param tunnelMethod - the type of ssh method that should be used (includes not using SSH at all).
    * @param tunnelHost - host name of the machine to which we will establish an ssh connection (e.g.
    *        hostname of the bastion).
@@ -133,10 +133,10 @@ public class SshTunnel implements AutoCloseable {
       if (tunnelMethod.equals(TunnelMethod.SSH_PASSWORD_AUTH)) {
         Preconditions.checkNotNull(tunnelUserPassword);
       }
-      //must provide either host/port or endpoint
+      // must provide either host/port or endpoint
       Preconditions.checkArgument((hostKey != null && portKey != null) || endPointKey != null);
       Preconditions.checkArgument((remoteServiceHost != null && remoteServicePort > 0) || remoteServiceUrl != null);
-      if(remoteServiceUrl != null) {
+      if (remoteServiceUrl != null) {
         this.remoteServiceHost = remoteServiceUrl.getHost();
         this.remoteServicePort = remoteServiceUrl.getPort();
         this.remoteServiceProtocol = remoteServiceUrl.getProtocol();

--- a/airbyte-integrations/bases/base-java/src/main/java/io/airbyte/integrations/base/ssh/SshTunnel.java
+++ b/airbyte-integrations/bases/base-java/src/main/java/io/airbyte/integrations/base/ssh/SshTunnel.java
@@ -143,7 +143,8 @@ public class SshTunnel implements AutoCloseable {
         try {
           urlObject = new URL(remoteServiceUrl);
         } catch (MalformedURLException e) {
-          AirbyteTraceMessageUtility.emitConfigErrorTrace(e, String.format("Provided value for remote service URL is not valid: %s", remoteServiceUrl));
+          AirbyteTraceMessageUtility.emitConfigErrorTrace(e,
+              String.format("Provided value for remote service URL is not valid: %s", remoteServiceUrl));
         }
         Preconditions.checkNotNull(urlObject, "Failed to parse URL of remote service");
         this.remoteServiceHost = urlObject.getHost();

--- a/airbyte-integrations/bases/base-java/src/main/java/io/airbyte/integrations/base/ssh/SshTunnel.java
+++ b/airbyte-integrations/bases/base-java/src/main/java/io/airbyte/integrations/base/ssh/SshTunnel.java
@@ -10,6 +10,7 @@ import io.airbyte.commons.functional.CheckedConsumer;
 import io.airbyte.commons.functional.CheckedFunction;
 import io.airbyte.commons.json.Jsons;
 import io.airbyte.commons.string.Strings;
+import io.airbyte.integrations.base.AirbyteTraceMessageUtility;
 import java.io.IOException;
 import java.io.StringReader;
 import java.net.InetSocketAddress;
@@ -142,9 +143,9 @@ public class SshTunnel implements AutoCloseable {
         try {
           urlObject = new URL(remoteServiceUrl);
         } catch (MalformedURLException e) {
-          e.printStackTrace();
+          AirbyteTraceMessageUtility.emitConfigErrorTrace(e, String.format("Provided value for remote service URL is not valid: %s", remoteServiceUrl));
         }
-        Preconditions.checkNotNull(urlObject);
+        Preconditions.checkNotNull(urlObject, "Failed to parse URL of remote service");
         this.remoteServiceHost = urlObject.getHost();
         this.remoteServicePort = urlObject.getPort();
         this.remoteServiceProtocol = urlObject.getProtocol();

--- a/airbyte-integrations/bases/base-java/src/main/java/io/airbyte/integrations/base/ssh/SshWrappedDestination.java
+++ b/airbyte-integrations/bases/base-java/src/main/java/io/airbyte/integrations/base/ssh/SshWrappedDestination.java
@@ -30,6 +30,7 @@ public class SshWrappedDestination implements Destination {
   private final Destination delegate;
   private final List<String> hostKey;
   private final List<String> portKey;
+  private final String endPointKey;
 
   public SshWrappedDestination(final Destination delegate,
                                final List<String> hostKey,
@@ -37,6 +38,15 @@ public class SshWrappedDestination implements Destination {
     this.delegate = delegate;
     this.hostKey = hostKey;
     this.portKey = portKey;
+    this.endPointKey = null;
+  }
+
+  public SshWrappedDestination(final Destination delegate,
+                               String endPointKey) {
+    this.delegate = delegate;
+    this.endPointKey = endPointKey;
+    this.portKey = null;
+    this.hostKey = null;
   }
 
   @Override
@@ -58,7 +68,8 @@ public class SshWrappedDestination implements Destination {
                                             final ConfiguredAirbyteCatalog catalog,
                                             final Consumer<AirbyteMessage> outputRecordCollector)
       throws Exception {
-    final SshTunnel tunnel = SshTunnel.getInstance(config, hostKey, portKey);
+    final SshTunnel tunnel = (endPointKey != null) ? SshTunnel.getInstance(config, endPointKey) : SshTunnel.getInstance(config, hostKey, portKey);
+
     final AirbyteMessageConsumer delegateConsumer;
     try {
       delegateConsumer = delegate.getConsumer(tunnel.getConfigInTunnel(), catalog, outputRecordCollector);

--- a/airbyte-integrations/bases/base-java/src/main/java/io/airbyte/integrations/base/ssh/SshWrappedDestination.java
+++ b/airbyte-integrations/bases/base-java/src/main/java/io/airbyte/integrations/base/ssh/SshWrappedDestination.java
@@ -60,7 +60,8 @@ public class SshWrappedDestination implements Destination {
 
   @Override
   public AirbyteConnectionStatus check(final JsonNode config) throws Exception {
-    return (endPointKey != null) ? SshTunnel.sshWrap(config, endPointKey, delegate::check) : SshTunnel.sshWrap(config, hostKey, portKey, delegate::check);
+    return (endPointKey != null) ? SshTunnel.sshWrap(config, endPointKey, delegate::check)
+        : SshTunnel.sshWrap(config, hostKey, portKey, delegate::check);
   }
 
   @Override

--- a/airbyte-integrations/bases/base-java/src/main/java/io/airbyte/integrations/base/ssh/SshWrappedDestination.java
+++ b/airbyte-integrations/bases/base-java/src/main/java/io/airbyte/integrations/base/ssh/SshWrappedDestination.java
@@ -60,7 +60,7 @@ public class SshWrappedDestination implements Destination {
 
   @Override
   public AirbyteConnectionStatus check(final JsonNode config) throws Exception {
-    return SshTunnel.sshWrap(config, hostKey, portKey, delegate::check);
+    return (endPointKey != null) ? SshTunnel.sshWrap(config, endPointKey, delegate::check) : SshTunnel.sshWrap(config, hostKey, portKey, delegate::check);
   }
 
   @Override

--- a/airbyte-integrations/bases/base-java/src/test/java/io/airbyte/integrations/base/ssh/SshTunnelTest.java
+++ b/airbyte-integrations/bases/base-java/src/test/java/io/airbyte/integrations/base/ssh/SshTunnelTest.java
@@ -90,8 +90,9 @@ class SshTunnelTest {
           + "\",\"tunnel_host\":\"faketunnel.com\",\"tunnel_port\":22,\"tunnel_user\":\"ec2-user\",\"tunnel_method\":\"SSH_KEY_AUTH\"}}";
 
   /**
-   * This test verifies that OpenSsh correctly replaces values in connector configuration
-   * in a spec with host/port config and in a spec with endpoint URL config
+   * This test verifies that OpenSsh correctly replaces values in connector configuration in a spec
+   * with host/port config and in a spec with endpoint URL config
+   *
    * @param configString
    * @throws Exception
    */
@@ -114,15 +115,17 @@ class SshTunnelTest {
         "tunnelUserPassword",
         endPointURL == null ? "fakeHost.com" : null,
         endPointURL == null ? 5432 : 0) {
+
       @Override
       ClientSession openTunnel(final SshClient client) {
         tunnelLocalPort = 8080;
         return null; // Prevent tunnel from attempting to connect
       }
+
     };
 
     final JsonNode configInTunnel = sshTunnel.getConfigInTunnel();
-    if(endPointURL == null) {
+    if (endPointURL == null) {
       assertTrue(configInTunnel.has("port"));
       assertTrue(configInTunnel.has("host"));
       assertFalse(configInTunnel.has("endpoint"));
@@ -137,8 +140,9 @@ class SshTunnelTest {
   }
 
   /**
-   * This test verifies that SshTunnel correctly extracts private key pairs from
-   * keys formatted as EdDSA and OpenSSH
+   * This test verifies that SshTunnel correctly extracts private key pairs from keys formatted as
+   * EdDSA and OpenSSH
+   *
    * @param privateKey
    * @throws Exception
    */
@@ -160,10 +164,12 @@ class SshTunnelTest {
         "tunnelUserPassword",
         "fakeHost.com",
         5432) {
-            @Override
-            ClientSession openTunnel(final SshClient client) {
-              return null; // Prevent tunnel from attempting to connect
-            }
+
+      @Override
+      ClientSession openTunnel(final SshClient client) {
+        return null; // Prevent tunnel from attempting to connect
+      }
+
     };
 
     final KeyPair authKeyPair = sshTunnel.getPrivateKeyPair();

--- a/airbyte-integrations/bases/base-java/src/test/java/io/airbyte/integrations/base/ssh/SshTunnelTest.java
+++ b/airbyte-integrations/bases/base-java/src/test/java/io/airbyte/integrations/base/ssh/SshTunnelTest.java
@@ -4,12 +4,16 @@
 
 package io.airbyte.integrations.base.ssh;
 
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;
+import io.airbyte.commons.json.Jsons;
 import io.airbyte.integrations.base.ssh.SshTunnel.TunnelMethod;
+import java.net.URL;
 import java.nio.charset.StandardCharsets;
 import java.security.KeyPair;
 import java.security.PrivateKey;
@@ -70,19 +74,84 @@ class SshTunnelTest {
       + "5WlcOxfV1wZuaM0fOd+PBmIlFEE7Uf6AY/UahBAxaFV2+twgK9GCDcu1t4Ye9wZ9kZ4Nal\\n"
       + "0fkKD4uN4DRO8hAAAAFm10dWhhaUBrYnAxLWxocC1hMTQ1MzMBAgME\\n"
       + "-----END OPENSSH PRIVATE KEY-----";
-  private static final String CONFIG =
+  private static final String HOST_PORT_CONFIG =
       "{\"ssl\":true,\"host\":\"fakehost.com\",\"port\":5432,\"schema\":\"public\",\"database\":\"postgres\",\"password\":\"<dummyPassword>\",\"username\":\"postgres\",\"tunnel_method\":{\"ssh_key\":\""
           + "%s"
           + "\",\"tunnel_host\":\"faketunnel.com\",\"tunnel_port\":22,\"tunnel_user\":\"ec2-user\",\"tunnel_method\":\"SSH_KEY_AUTH\"}}";
 
+  private static final String URL_CONFIG_WITH_PORT =
+      "{\"ssl\":true,\"endpoint\":\"http://fakehost.com:9090/service\",\"password\":\"<dummyPassword>\",\"username\":\"restuser\",\"tunnel_method\":{\"ssh_key\":\""
+          + "%s"
+          + "\",\"tunnel_host\":\"faketunnel.com\",\"tunnel_port\":22,\"tunnel_user\":\"ec2-user\",\"tunnel_method\":\"SSH_KEY_AUTH\"}}";
+
+  private static final String URL_CONFIG_NO_PORT =
+      "{\"ssl\":true,\"endpoint\":\"http://fakehost.com/service\",\"password\":\"<dummyPassword>\",\"username\":\"restuser\",\"tunnel_method\":{\"ssh_key\":\""
+          + "%s"
+          + "\",\"tunnel_host\":\"faketunnel.com\",\"tunnel_port\":22,\"tunnel_user\":\"ec2-user\",\"tunnel_method\":\"SSH_KEY_AUTH\"}}";
+
+  /**
+   * This test verifies that OpenSsh correctly replaces values in connector configuration
+   * in a spec with host/port config and in a spec with endpoint URL config
+   * @param configString
+   * @throws Exception
+   */
+  @ParameterizedTest
+  @ValueSource(strings = {HOST_PORT_CONFIG, URL_CONFIG_WITH_PORT, URL_CONFIG_NO_PORT})
+  public void testConfigInTunnel(final String configString) throws Exception {
+    final JsonNode config = (new ObjectMapper()).readTree(String.format(configString, SSH_RSA_PRIVATE_KEY));
+    String endPointURL = Jsons.getStringOrNull(config, "endpoint");
+    final SshTunnel sshTunnel = new SshTunnel(
+        config,
+        endPointURL == null ? Arrays.asList(new String[] {"host"}) : null,
+        endPointURL == null ? Arrays.asList(new String[] {"port"}) : null,
+        endPointURL == null ? null : "endpoint",
+        endPointURL == null ? null : new URL(endPointURL),
+        TunnelMethod.SSH_KEY_AUTH,
+        "faketunnel.com",
+        22,
+        "tunnelUser",
+        SSH_RSA_PRIVATE_KEY,
+        "tunnelUserPassword",
+        endPointURL == null ? "fakeHost.com" : null,
+        endPointURL == null ? 5432 : 0) {
+      @Override
+      ClientSession openTunnel(final SshClient client) {
+        tunnelLocalPort = 8080;
+        return null; // Prevent tunnel from attempting to connect
+      }
+    };
+
+    final JsonNode configInTunnel = sshTunnel.getConfigInTunnel();
+    if(endPointURL == null) {
+      assertTrue(configInTunnel.has("port"));
+      assertTrue(configInTunnel.has("host"));
+      assertFalse(configInTunnel.has("endpoint"));
+      assertEquals(8080, configInTunnel.get("port").asInt());
+      assertEquals("127.0.0.1", configInTunnel.get("host").asText());
+    } else {
+      assertFalse(configInTunnel.has("port"));
+      assertFalse(configInTunnel.has("host"));
+      assertTrue(configInTunnel.has("endpoint"));
+      assertEquals("http://127.0.0.1:8080/service", configInTunnel.get("endpoint").asText());
+    }
+  }
+
+  /**
+   * This test verifies that SshTunnel correctly extracts private key pairs from
+   * keys formatted as EdDSA and OpenSSH
+   * @param privateKey
+   * @throws Exception
+   */
   @ParameterizedTest
   @ValueSource(strings = {SSH_ED25519_PRIVATE_KEY, SSH_RSA_PRIVATE_KEY})
   public void getKeyPair(final String privateKey) throws Exception {
-    final JsonNode config = (new ObjectMapper()).readTree(String.format(CONFIG, privateKey));
+    final JsonNode config = (new ObjectMapper()).readTree(String.format(HOST_PORT_CONFIG, privateKey));
     final SshTunnel sshTunnel = new SshTunnel(
         config,
         Arrays.asList(new String[] {"host"}),
         Arrays.asList(new String[] {"port"}),
+        null,
+        null,
         TunnelMethod.SSH_KEY_AUTH,
         "faketunnel.com",
         22,
@@ -91,12 +160,10 @@ class SshTunnelTest {
         "tunnelUserPassword",
         "fakeHost.com",
         5432) {
-
-      @Override
-      ClientSession openTunnel(final SshClient client) {
-        return null; // Prevent tunnel from attempting to connect
-      }
-
+            @Override
+            ClientSession openTunnel(final SshClient client) {
+              return null; // Prevent tunnel from attempting to connect
+            }
     };
 
     final KeyPair authKeyPair = sshTunnel.getPrivateKeyPair();

--- a/airbyte-integrations/bases/base-java/src/test/java/io/airbyte/integrations/base/ssh/SshTunnelTest.java
+++ b/airbyte-integrations/bases/base-java/src/test/java/io/airbyte/integrations/base/ssh/SshTunnelTest.java
@@ -105,7 +105,7 @@ class SshTunnelTest {
         endPointURL == null ? Arrays.asList(new String[] {"host"}) : null,
         endPointURL == null ? Arrays.asList(new String[] {"port"}) : null,
         endPointURL == null ? null : "endpoint",
-        endPointURL == null ? null : endPointURL,
+        endPointURL,
         TunnelMethod.SSH_KEY_AUTH,
         "faketunnel.com",
         22,

--- a/airbyte-integrations/bases/base-java/src/test/java/io/airbyte/integrations/base/ssh/SshTunnelTest.java
+++ b/airbyte-integrations/bases/base-java/src/test/java/io/airbyte/integrations/base/ssh/SshTunnelTest.java
@@ -13,7 +13,6 @@ import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import io.airbyte.commons.json.Jsons;
 import io.airbyte.integrations.base.ssh.SshTunnel.TunnelMethod;
-import java.net.URL;
 import java.nio.charset.StandardCharsets;
 import java.security.KeyPair;
 import java.security.PrivateKey;
@@ -106,7 +105,7 @@ class SshTunnelTest {
         endPointURL == null ? Arrays.asList(new String[] {"host"}) : null,
         endPointURL == null ? Arrays.asList(new String[] {"port"}) : null,
         endPointURL == null ? null : "endpoint",
-        endPointURL == null ? null : new URL(endPointURL),
+        endPointURL == null ? null : endPointURL,
         TunnelMethod.SSH_KEY_AUTH,
         "faketunnel.com",
         22,

--- a/airbyte-integrations/connectors/destination-elasticsearch-strict-encrypt/Dockerfile
+++ b/airbyte-integrations/connectors/destination-elasticsearch-strict-encrypt/Dockerfile
@@ -16,5 +16,5 @@ ENV APPLICATION destination-elasticsearch-strict-encrypt
 
 COPY --from=build /airbyte /airbyte
 
-LABEL io.airbyte.version=0.1.3
+LABEL io.airbyte.version=0.1.4
 LABEL io.airbyte.name=airbyte/destination-elasticsearch-strict-encrypt

--- a/airbyte-integrations/connectors/destination-elasticsearch/Dockerfile
+++ b/airbyte-integrations/connectors/destination-elasticsearch/Dockerfile
@@ -16,5 +16,5 @@ ENV APPLICATION destination-elasticsearch
 
 COPY --from=build /airbyte /airbyte
 
-LABEL io.airbyte.version=0.1.3
+LABEL io.airbyte.version=0.1.4
 LABEL io.airbyte.name=airbyte/destination-elasticsearch

--- a/airbyte-integrations/connectors/destination-elasticsearch/src/main/java/io/airbyte/integrations/destination/elasticsearch/ElasticsearchDestination.java
+++ b/airbyte-integrations/connectors/destination-elasticsearch/src/main/java/io/airbyte/integrations/destination/elasticsearch/ElasticsearchDestination.java
@@ -10,6 +10,7 @@ import io.airbyte.integrations.BaseConnector;
 import io.airbyte.integrations.base.AirbyteMessageConsumer;
 import io.airbyte.integrations.base.Destination;
 import io.airbyte.integrations.base.IntegrationRunner;
+import io.airbyte.integrations.base.ssh.SshWrappedDestination;
 import io.airbyte.protocol.models.*;
 import java.io.IOException;
 import java.util.ArrayList;
@@ -25,10 +26,14 @@ public class ElasticsearchDestination extends BaseConnector implements Destinati
   private final ObjectMapper mapper = new ObjectMapper();
 
   public static void main(String[] args) throws Exception {
-    final var destination = new ElasticsearchDestination();
+    final var destination = sshWrappedDestination();
     LOGGER.info("starting destination: {}", ElasticsearchDestination.class);
     new IntegrationRunner(destination).run(args);
     LOGGER.info("completed destination: {}", ElasticsearchDestination.class);
+  }
+
+  public static Destination sshWrappedDestination() {
+    return new SshWrappedDestination(new ElasticsearchDestination(), "endpoint");
   }
 
   @Override

--- a/airbyte-integrations/connectors/destination-elasticsearch/src/test-integration/java/io/airbyte/integrations/destination/elasticsearch/ElasticsearchDestinationAcceptanceTest.java
+++ b/airbyte-integrations/connectors/destination-elasticsearch/src/test-integration/java/io/airbyte/integrations/destination/elasticsearch/ElasticsearchDestinationAcceptanceTest.java
@@ -96,7 +96,9 @@ public class ElasticsearchDestinationAcceptanceTest extends DestinationAcceptanc
   @Override
   protected JsonNode getFailCheckConfig() {
     // should result in a failed connection check
-    return mapper.createObjectNode();
+    var configJson = mapper.createObjectNode();
+    configJson.put("endpoint", String.format("htp::/%s:-%s", container.getHost(), container.getMappedPort(9200)));
+    return configJson;
   }
 
   @Override

--- a/airbyte-integrations/connectors/destination-elasticsearch/src/test-integration/java/io/airbyte/integrations/destination/elasticsearch/ElasticsearchDestinationAcceptanceTest.java
+++ b/airbyte-integrations/connectors/destination-elasticsearch/src/test-integration/java/io/airbyte/integrations/destination/elasticsearch/ElasticsearchDestinationAcceptanceTest.java
@@ -9,18 +9,13 @@ import com.fasterxml.jackson.databind.ObjectMapper;
 import io.airbyte.integrations.standardtest.destination.DestinationAcceptanceTest;
 import io.airbyte.integrations.standardtest.destination.comparator.AdvancedTestDataComparator;
 import io.airbyte.integrations.standardtest.destination.comparator.TestDataComparator;
-import java.io.IOException;
 import java.time.Duration;
 import java.util.List;
 import org.junit.jupiter.api.AfterAll;
 import org.junit.jupiter.api.BeforeAll;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 import org.testcontainers.elasticsearch.ElasticsearchContainer;
 
 public class ElasticsearchDestinationAcceptanceTest extends DestinationAcceptanceTest {
-
-  private static final Logger LOGGER = LoggerFactory.getLogger(ElasticsearchDestinationAcceptanceTest.class);
 
   private ObjectMapper mapper = new ObjectMapper();
   private static ElasticsearchContainer container;
@@ -87,14 +82,14 @@ public class ElasticsearchDestinationAcceptanceTest extends DestinationAcceptanc
   }
 
   @Override
-  protected JsonNode getConfig() {
+  protected JsonNode getConfig() throws Exception {
     var configJson = mapper.createObjectNode();
     configJson.put("endpoint", String.format("http://%s:%s", container.getHost(), container.getMappedPort(9200)));
     return configJson;
   }
 
   @Override
-  protected JsonNode getFailCheckConfig() {
+  protected JsonNode getFailCheckConfig() throws Exception {
     // should result in a failed connection check
     var configJson = mapper.createObjectNode();
     configJson.put("endpoint", String.format("htp::/%s:-%s", container.getHost(), container.getMappedPort(9200)));
@@ -106,7 +101,7 @@ public class ElasticsearchDestinationAcceptanceTest extends DestinationAcceptanc
                                            String streamName,
                                            String namespace,
                                            JsonNode streamSchema)
-      throws IOException {
+      throws Exception {
     // Records returned from this method will be compared against records provided to the connector
     // to verify they were written correctly
     final String indexName = new ElasticsearchWriteConfig()
@@ -119,12 +114,13 @@ public class ElasticsearchDestinationAcceptanceTest extends DestinationAcceptanc
   }
 
   @Override
-  protected void setup(TestDestinationEnv testEnv) {}
+  protected void setup(TestDestinationEnv testEnv) throws Exception {}
 
   @Override
-  protected void tearDown(TestDestinationEnv testEnv) {
+  protected void tearDown(TestDestinationEnv testEnv) throws Exception {
     ElasticsearchConnection connection = new ElasticsearchConnection(mapper.convertValue(getConfig(), ConnectorConfiguration.class));
     connection.allIndices().forEach(connection::deleteIndexIfPresent);
+    connection.close();
   }
 
 }

--- a/airbyte-integrations/connectors/destination-elasticsearch/src/test-integration/java/io/airbyte/integrations/destination/elasticsearch/SshElasticsearchDestinationAcceptanceTest.java
+++ b/airbyte-integrations/connectors/destination-elasticsearch/src/test-integration/java/io/airbyte/integrations/destination/elasticsearch/SshElasticsearchDestinationAcceptanceTest.java
@@ -1,0 +1,129 @@
+package io.airbyte.integrations.destination.elasticsearch;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.google.common.collect.ImmutableMap;
+import io.airbyte.commons.json.Jsons;
+import io.airbyte.integrations.base.ssh.SshBastionContainer;
+import io.airbyte.integrations.base.ssh.SshTunnel;
+import io.airbyte.integrations.standardtest.destination.DestinationAcceptanceTest;
+import io.airbyte.integrations.standardtest.destination.comparator.AdvancedTestDataComparator;
+import io.airbyte.integrations.standardtest.destination.comparator.TestDataComparator;
+import java.util.List;
+import org.testcontainers.containers.Network;
+import org.testcontainers.elasticsearch.ElasticsearchContainer;
+
+public abstract class SshElasticsearchDestinationAcceptanceTest  extends DestinationAcceptanceTest {
+  private static final Network network = Network.newNetwork();
+  private final SshBastionContainer bastion = new SshBastionContainer();
+  private static ElasticsearchContainer container;
+  private ObjectMapper mapper = new ObjectMapper();
+  public static String ELASTIC_PASSWORD = "MagicWord";
+
+  public abstract SshTunnel.TunnelMethod getTunnelMethod();
+
+  @Override
+  protected String getImageName() {
+    return "airbyte/destination-elasticsearch:dev";
+  }
+
+  @Override
+  protected int getMaxRecordValueLimit() {
+    return 2000000;
+  }
+
+  @Override
+  protected boolean implementsNamespaces() {
+    return true;
+  }
+
+  @Override
+  protected boolean supportsNormalization() {
+    return false;
+  }
+
+  @Override
+  protected boolean supportBasicDataTypeTest() {
+    return true;
+  }
+
+  @Override
+  protected boolean supportArrayDataTypeTest() {
+    // TODO: Enable supportArrayDataTypeTest after ticket 14568 will be done
+    return false;
+  }
+
+  @Override
+  protected boolean supportObjectDataTypeTest() {
+    return true;
+  }
+
+  @Override
+  protected TestDataComparator getTestDataComparator() {
+    return new AdvancedTestDataComparator();
+  }
+
+  private String getEndPoint() {
+    return String.format("http://%s:%d",
+        container.getContainerInfo().getNetworkSettings()
+            .getNetworks()
+            .entrySet().stream().findFirst().get().getValue().getIpAddress(),
+        container.getExposedPorts().get(0));
+  }
+
+  @Override
+  protected JsonNode getConfig() throws Exception {
+    return bastion.getTunnelConfig(getTunnelMethod(), ImmutableMap.builder().put("endpoint", getEndPoint())
+        .put("upsert", false)
+        .put("authenticationMethod", Jsons.jsonNode(ImmutableMap.builder().put("method", "basic")
+            .put("username", "elastic")
+            .put("password", ELASTIC_PASSWORD).build())));
+  }
+
+  @Override
+  protected JsonNode getFailCheckConfig() throws Exception {
+    // should result in a failed connection check
+    return bastion.getTunnelConfig(getTunnelMethod(), ImmutableMap.builder().put("endpoint", getEndPoint())
+        .put("upsert", true)
+        .put("authenticationMethod", Jsons.jsonNode(ImmutableMap.builder().put("method", "basic")
+            .put("username", "elastic")
+            .put("password", "wrongpassword").build())));
+  }
+
+  @Override
+  protected List<JsonNode> retrieveRecords(TestDestinationEnv testEnv,
+      String streamName,
+      String namespace,
+      JsonNode streamSchema)
+      throws Exception {
+    // Records returned from this method will be compared against records provided to the connector
+    // to verify they were written correctly
+    final String indexName = new ElasticsearchWriteConfig()
+        .setNamespace(namespace)
+        .setStreamName(streamName)
+        .getIndexName();
+
+    ElasticsearchConnection connection = new ElasticsearchConnection(mapper.convertValue(getConfig(), ConnectorConfiguration.class));
+    return connection.getRecords(indexName);
+  }
+
+  @Override
+  protected void setup(final TestDestinationEnv testEnv) throws Exception {
+    bastion.initAndStartBastion(network);
+    container = new ElasticsearchContainer("docker.elastic.co/elasticsearch/elasticsearch:7.15.1")
+        .withNetwork(network)
+        .withPassword(ELASTIC_PASSWORD);
+    container.start();
+  }
+
+  @Override
+  protected void tearDown(final TestDestinationEnv testEnv) throws Exception {
+    ElasticsearchConnection connection = new ElasticsearchConnection(mapper.convertValue(getConfig(), ConnectorConfiguration.class));
+    connection.allIndices().forEach(connection::deleteIndexIfPresent);
+    connection.close();
+    container.stop();
+    container.close();
+    bastion.getContainer().stop();
+    bastion.getContainer().close();
+  }
+}

--- a/airbyte-integrations/connectors/destination-elasticsearch/src/test-integration/java/io/airbyte/integrations/destination/elasticsearch/SshElasticsearchDestinationAcceptanceTest.java
+++ b/airbyte-integrations/connectors/destination-elasticsearch/src/test-integration/java/io/airbyte/integrations/destination/elasticsearch/SshElasticsearchDestinationAcceptanceTest.java
@@ -121,9 +121,7 @@ public abstract class SshElasticsearchDestinationAcceptanceTest  extends Destina
     ElasticsearchConnection connection = new ElasticsearchConnection(mapper.convertValue(getConfig(), ConnectorConfiguration.class));
     connection.allIndices().forEach(connection::deleteIndexIfPresent);
     connection.close();
-    container.stop();
     container.close();
-    bastion.getContainer().stop();
     bastion.getContainer().close();
   }
 }

--- a/airbyte-integrations/connectors/destination-elasticsearch/src/test-integration/java/io/airbyte/integrations/destination/elasticsearch/SshKeyElasticsearchDestinationAcceptanceTest.java
+++ b/airbyte-integrations/connectors/destination-elasticsearch/src/test-integration/java/io/airbyte/integrations/destination/elasticsearch/SshKeyElasticsearchDestinationAcceptanceTest.java
@@ -1,0 +1,10 @@
+package io.airbyte.integrations.destination.elasticsearch;
+
+import io.airbyte.integrations.base.ssh.SshTunnel;
+
+public class SshKeyElasticsearchDestinationAcceptanceTest extends SshElasticsearchDestinationAcceptanceTest {
+
+  public SshTunnel.TunnelMethod getTunnelMethod() {
+    return SshTunnel.TunnelMethod.SSH_KEY_AUTH;
+  }
+}

--- a/airbyte-integrations/connectors/destination-elasticsearch/src/test-integration/java/io/airbyte/integrations/destination/elasticsearch/SshPasswordElasticsearchDestinationAcceptanceTest.java
+++ b/airbyte-integrations/connectors/destination-elasticsearch/src/test-integration/java/io/airbyte/integrations/destination/elasticsearch/SshPasswordElasticsearchDestinationAcceptanceTest.java
@@ -1,0 +1,11 @@
+package io.airbyte.integrations.destination.elasticsearch;
+
+import io.airbyte.integrations.base.ssh.SshTunnel;
+
+public class SshPasswordElasticsearchDestinationAcceptanceTest  extends SshElasticsearchDestinationAcceptanceTest {
+  @Override
+  public SshTunnel.TunnelMethod getTunnelMethod() {
+    return SshTunnel.TunnelMethod.SSH_PASSWORD_AUTH;
+  }
+
+}

--- a/docs/integrations/destinations/elasticsearch.md
+++ b/docs/integrations/destinations/elasticsearch.md
@@ -36,12 +36,12 @@ This section should contain a table mapping each of the connector's data types t
 This section should contain a table with the following format:
 
 | Feature | Supported?(Yes/No) | Notes |
-| :--- | :--- | :--- |
-| Full Refresh Sync | yes |  |
-| Incremental Sync | yes |  |
-| Replicate Incremental Deletes | no |  |
-| SSL connection | yes |  |
-| SSH Tunnel Support | ?? |  |
+| :--- |:-------------------| :--- |
+| Full Refresh Sync | yes                |  |
+| Incremental Sync | yes                |  |
+| Replicate Incremental Deletes | no                 |  |
+| SSL connection | yes                |  |
+| SSH Tunnel Support | yes                |  |
 
 ### Performance considerations
 
@@ -63,12 +63,33 @@ The connector should be enhanced to support variable batch sizes.
 
 
 ### Setup guide
+Enter the endpoint URL, select authentication method, and whether to use 'upsert' method when indexing new documents. 
 
-Enter the hostname and/or other configuration information ... 
+### Connection via SSH Tunnel
+
+Airbyte has the ability to connect to an Elastic instance via an SSH Tunnel.
+The reason you might want to do this because it is not possible \(or against security policy\) to connect to your Elastic instance directly \(e.g. it does not have a public IP address\).
+
+When using an SSH tunnel, you are configuring Airbyte to connect to an intermediate server \(a.k.a. a bastion sever\) that _does_ have direct access to the Elastic instance.
+Airbyte connects to the bastion and then asks the bastion to connect directly to the server.
+
+Using this feature requires additional configuration, when creating the source. We will talk through what each piece of configuration means.
+
+1. Configure all fields for the source as you normally would, except `SSH Tunnel Method`.
+2. `SSH Tunnel Method` defaults to `No Tunnel` \(meaning a direct connection\). If you want to use an SSH Tunnel choose `SSH Key Authentication` or `Password Authentication`.
+    1. Choose `Key Authentication` if you will be using an RSA private key as your secret for establishing the SSH Tunnel \(see below for more information on generating this key\).
+    2. Choose `Password Authentication` if you will be using a password as your secret for establishing the SSH Tunnel.
+3. `SSH Tunnel Jump Server Host` refers to the intermediate \(bastion\) server that Airbyte will connect to. This should be a hostname or an IP Address.
+4. `SSH Connection Port` is the port on the bastion server with which to make the SSH connection. The default port for SSH connections is `22`, so unless you have explicitly changed something, go with the default.
+5. `SSH Login Username` is the username that Airbyte should use when connection to the bastion server. This is NOT the TiDB username.
+6. If you are using `Password Authentication`, then `SSH Login Username` should be set to the password of the User from the previous step. If you are using `SSH Key Authentication` TiDB password, but the password for the OS-user that Airbyte is using to perform commands on the bastion.
+7. If you are using `SSH Key Authentication`, then `SSH Private Key` should be set to the RSA Private Key that you are using to create the SSH connection. This should be the full contents of the key file starting with `-----BEGIN RSA PRIVATE KEY-----` and ending with `-----END RSA PRIVATE KEY-----`.
+
 ## CHANGELOG
 
 | Version | Date | Pull Request | Subject |
 | :--- | :--- | :--- | :--- |
+| 0.1.4 | 2022-10-14 | [17805](https://github.com/airbytehq/airbyte/pull/17805) | add SSH Tunneling |
 | 0.1.3 | 2022-05-30 | [14640](https://github.com/airbytehq/airbyte/pull/14640) | Include lifecycle management |
 | 0.1.2 | 2022-04-19 | [11752](https://github.com/airbytehq/airbyte/pull/11752) | Reduce batch size to 32Mb |
 | 0.1.1 | 2022-02-10 | [10256](https://github.com/airbytehq/airbyte/pull/1256) | Add ExitOnOutOfMemoryError connectors |


### PR DESCRIPTION
## What
Add support for accessing Elastic Search destination via an SSH tunnel

## How
- Add SSH tunneling support for destinations that are configured with a URL instead of a host/port pair
- Add SSH wrapped integration tests to `destination-elasticsearch`
- Modify `ElasticsearchDestination` class to return an instance of `SshWrappedDestination`

## Recommended reading order
1. SshTunnel.java
2. SshTunnelTest.java
3. SshWrappedDestination.java
4. ElasticsearchDestination.java
5. SshElasticsearchDestinationAcceptanceTest.java
6. SshKeyElasticsearchDestinationAcceptanceTest.java
7. SshPasswordElasticsearchDestinationAcceptanceTest.java

## 🚨 User Impact 🚨
Users can now use SSH tunnel with Elastic Search destination

## Pre-merge Checklist
