### PR TITLE
🪟 🧹 Remove connection and mode prop drilling on connection view/edit pages

### DIFF
--- a/airbyte-webapp/src/components/CreateConnection/CreateConnectionForm.tsx
+++ b/airbyte-webapp/src/components/CreateConnection/CreateConnectionForm.tsx
@@ -103,6 +103,8 @@ const CreateConnectionFormInner: React.FC<CreateConnectionPropsInner> = ({ schem
           initialValues={initialValues}
           validationSchema={connectionValidationSchema(mode)}
           onSubmit={onFormSubmit}
+          validateOnBlur={false}
+          validateOnChange={false}
         >
           {({ values, isSubmitting, isValid, dirty }) => (
             <Form>

--- a/airbyte-webapp/src/components/CreateConnection/CreateConnectionForm.tsx
+++ b/airbyte-webapp/src/components/CreateConnection/CreateConnectionForm.tsx
@@ -103,7 +103,6 @@ const CreateConnectionFormInner: React.FC<CreateConnectionPropsInner> = ({ schem
           initialValues={initialValues}
           validationSchema={connectionValidationSchema(mode)}
           onSubmit={onFormSubmit}
-          validateOnBlur={false}
           validateOnChange={false}
         >
           {({ values, isSubmitting, isValid, dirty }) => (

--- a/airbyte-webapp/src/components/CreateConnection/__snapshots__/CreateConnectionForm.test.tsx.snap
+++ b/airbyte-webapp/src/components/CreateConnection/__snapshots__/CreateConnectionForm.test.tsx.snap
@@ -1,184 +1,61 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
 exports[`CreateConnectionForm should render 1`] = `
-<div>
-  <div
-    class="connectionFormContainer"
-  >
-    <form
-      action="#"
+<body>
+  <div>
+    <div
+      class="<removed-for-snapshot-test>"
     >
-      <div
-        class="container"
+      <form
+        action="#"
       >
         <div
-          class="section"
+          class="<removed-for-snapshot-test>"
         >
           <div
-            class="flexRow"
+            class="<removed-for-snapshot-test>"
           >
             <div
-              class="leftFieldCol"
+              class="<removed-for-snapshot-test>"
             >
               <div
-                class="controlContainer connectionLabel"
-              >
-                <label
-                  class="sc-eCYdqJ cgRkWU"
-                >
-                  <h5
-                    class="heading md labelHeading"
-                  >
-                    Connection name*
-                  </h5>
-                  <span>
-                    <br />
-                    <span
-                      class="sc-jSMfEi dkwDTm"
-                    >
-                      Pick a name to help you identify this connection
-                    </span>
-                  </span>
-                </label>
-              </div>
-            </div>
-            <div
-              class="rightFieldCol"
-            >
-              <div
-                class="container"
-                data-testid="input-container"
-              >
-                <input
-                  class="input"
-                  data-testid="connectionName"
-                  name="name"
-                  placeholder="Name"
-                  value="Scrafty <> Heroku Postgres"
-                />
-              </div>
-            </div>
-          </div>
-        </div>
-      </div>
-      <div
-        class="formContainer"
-      >
-        <div
-          class="container"
-        >
-          <div
-            class="section"
-          >
-            <h5
-              class="heading sm"
-            >
-              Transfer
-            </h5>
-            <div
-              class="flexRow"
-            >
-              <div
-                class="leftFieldCol"
+                class="<removed-for-snapshot-test>"
               >
                 <div
-                  class="controlContainer connectorLabel"
+                  class="<removed-for-snapshot-test>"
                 >
                   <label
-                    class="sc-eCYdqJ cgRkWU"
+                    class="<removed-for-snapshot-test>"
                   >
-                    Replication frequency*
+                    <h5
+                      class="<removed-for-snapshot-test>"
+                    >
+                      Connection name*
+                    </h5>
                     <span>
                       <br />
                       <span
-                        class="sc-jSMfEi dkwDTm"
+                        class="<removed-for-snapshot-test>"
                       >
-                        Set how often data should sync to the destination
+                        Pick a name to help you identify this connection
                       </span>
                     </span>
                   </label>
                 </div>
               </div>
               <div
-                class="rightFieldCol"
-                style="pointer-events: auto;"
+                class="<removed-for-snapshot-test>"
               >
                 <div
-                  class="sc-cOFTSb bBiOrV react-select-container css-b62m3t-container"
-                  data-testid="scheduleData"
-                  role="combobox"
+                  class="<removed-for-snapshot-test>"
+                  data-testid="input-container"
                 >
-                  <span
-                    class="css-1f43avz-a11yText-A11yText"
-                    id="react-select-2-live-region"
-                  />
-                  <span
-                    aria-atomic="false"
-                    aria-live="polite"
-                    aria-relevant="additions text"
-                    class="css-1f43avz-a11yText-A11yText"
-                  />
-                  <div
-                    class="react-select__control css-1s2u09g-control"
-                  >
-                    <div
-                      class="react-select__value-container react-select__value-container--has-value css-dlobye-Component"
-                    >
-                      <div
-                        class="sc-cTQhss haoKjh"
-                      >
-                        <div
-                          class="sc-iAvgwm fQiUpU"
-                        >
-                          <div
-                            class="react-select__single-value css-qc6sy-singleValue"
-                          >
-                            Every 24 hours
-                          </div>
-                        </div>
-                      </div>
-                      <input
-                        aria-autocomplete="list"
-                        aria-expanded="false"
-                        aria-haspopup="true"
-                        aria-readonly="true"
-                        class="css-mohuvp-dummyInput-DummyInput"
-                        id="react-select-2-input"
-                        inputmode="none"
-                        role="combobox"
-                        tabindex="0"
-                        value=""
-                      />
-                    </div>
-                    <div
-                      class="react-select__indicators css-ny0e4k-Component"
-                    >
-                      <div
-                        aria-hidden="true"
-                        class="react-select__indicator react-select__dropdown-indicator css-tlfecz-indicatorContainer"
-                      >
-                        <svg
-                          aria-hidden="true"
-                          class="svg-inline--fa fa-sort-down sc-dPyBCJ eGVczJ"
-                          data-icon="sort-down"
-                          data-prefix="fas"
-                          focusable="false"
-                          role="img"
-                          viewBox="0 0 320 512"
-                          xmlns="http://www.w3.org/2000/svg"
-                        >
-                          <path
-                            d="M311.9 335.1l-132.4 136.8C174.1 477.3 167.1 480 160 480c-7.055 0-14.12-2.702-19.47-8.109l-132.4-136.8C-9.229 317.8 3.055 288 27.66 288h264.7C316.9 288 329.2 317.8 311.9 335.1z"
-                            fill="currentColor"
-                          />
-                        </svg>
-                      </div>
-                    </div>
-                  </div>
                   <input
-                    name="scheduleData"
-                    type="hidden"
-                    value="[object Object]"
+                    class="<removed-for-snapshot-test>"
+                    data-testid="connectionName"
+                    name="name"
+                    placeholder="Name"
+                    value="Scrafty <> Heroku Postgres"
                   />
                 </div>
               </div>
@@ -186,77 +63,78 @@ exports[`CreateConnectionForm should render 1`] = `
           </div>
         </div>
         <div
-          class="container"
+          class="<removed-for-snapshot-test>"
         >
           <div
-            class="section"
+            class="<removed-for-snapshot-test>"
           >
-            <h5
-              class="heading md"
+            <div
+              class="<removed-for-snapshot-test>"
             >
-              Streams
-            </h5>
-            <span
-              class=""
-            >
+              <h5
+                class="<removed-for-snapshot-test>"
+              >
+                Transfer
+              </h5>
               <div
-                class="flexRow"
+                class="<removed-for-snapshot-test>"
               >
                 <div
-                  class="leftFieldCol"
+                  class="<removed-for-snapshot-test>"
                 >
                   <div
-                    class="controlContainer"
+                    class="<removed-for-snapshot-test>"
                   >
                     <label
-                      class="sc-eCYdqJ iCvyIv"
+                      class="<removed-for-snapshot-test>"
                     >
-                      Destination Namespace*
+                      Replication frequency*
                       <span>
                         <br />
                         <span
-                          class="sc-jSMfEi dkwDTm"
+                          class="<removed-for-snapshot-test>"
                         >
-                          Define the location where the data will be stored in the destination
+                          Set how often data should sync to the destination
                         </span>
                       </span>
                     </label>
                   </div>
                 </div>
                 <div
-                  class="rightFieldCol"
+                  class="<removed-for-snapshot-test>"
+                  style="pointer-events: auto;"
                 >
                   <div
-                    class="sc-cOFTSb bBiOrV react-select-container css-b62m3t-container"
-                    data-testid="namespaceDefinition"
+                    class="<removed-for-snapshot-test>"
+                    data-testid="scheduleData"
                     role="combobox"
                   >
                     <span
-                      class="css-1f43avz-a11yText-A11yText"
-                      id="react-select-3-live-region"
+                      class="<removed-for-snapshot-test>"
+                      id="react-select-2-live-region"
                     />
                     <span
                       aria-atomic="false"
                       aria-live="polite"
                       aria-relevant="additions text"
-                      class="css-1f43avz-a11yText-A11yText"
+                      class="<removed-for-snapshot-test>"
                     />
                     <div
-                      class="react-select__control css-1s2u09g-control"
+                      class="<removed-for-snapshot-test>"
                     >
                       <div
-                        class="react-select__value-container react-select__value-container--has-value css-dlobye-Component"
+                        class="<removed-for-snapshot-test>"
                       >
                         <div
-                          class="sc-cTQhss haoKjh"
+                          class="<removed-for-snapshot-test>"
                         >
                           <div
-                            class="sc-iAvgwm fQiUpU"
+                            class="<removed-for-snapshot-test>"
                           >
                             <div
-                              class="react-select__single-value css-qc6sy-singleValue"
+                              class="<removed-for-snapshot-test>"
                             >
-                              Mirror source structure
+                              Every 24 hours
                             </div>
                           </div>
                         </div>
@@ -265,8 +143,8 @@ exports[`CreateConnectionForm should render 1`] = `
                           aria-expanded="false"
                           aria-haspopup="true"
                           aria-readonly="true"
-                          class="css-mohuvp-dummyInput-DummyInput"
-                          id="react-select-3-input"
+                          class="<removed-for-snapshot-test>"
+                          id="react-select-2-input"
                           inputmode="none"
                           role="combobox"
                           tabindex="0"
@@ -274,15 +152,15 @@ exports[`CreateConnectionForm should render 1`] = `
                         />
                       </div>
                       <div
-                        class="react-select__indicators css-ny0e4k-Component"
+                        class="<removed-for-snapshot-test>"
                       >
                         <div
                           aria-hidden="true"
-                          class="react-select__indicator react-select__dropdown-indicator css-tlfecz-indicatorContainer"
+                          class="<removed-for-snapshot-test>"
                         >
                           <svg
                             aria-hidden="true"
-                            class="svg-inline--fa fa-sort-down sc-dPyBCJ eGVczJ"
+                            class="svg-inline--fa fa-sort-down sc-jOrMOR jXccHI"
                             data-icon="sort-down"
                             data-prefix="fas"
                             focusable="false"
@@ -299,637 +177,761 @@ exports[`CreateConnectionForm should render 1`] = `
                       </div>
                     </div>
                     <input
-                      name="namespaceDefinition"
+                      name="scheduleData"
                       type="hidden"
-                      value="source"
+                      value="[object Object]"
                     />
                   </div>
                 </div>
               </div>
-            </span>
+            </div>
+          </div>
+          <div
+            class="<removed-for-snapshot-test>"
+          >
             <div
-              class="flexRow"
+              class="<removed-for-snapshot-test>"
             >
-              <div
-                class="leftFieldCol"
+              <h5
+                class="<removed-for-snapshot-test>"
+              >
+                Streams
+              </h5>
+              <span
+                class=""
               >
                 <div
-                  class="controlContainer"
+                  class="<removed-for-snapshot-test>"
+                >
+                  <div
+                    class="<removed-for-snapshot-test>"
+                  >
+                    <div
+                      class="<removed-for-snapshot-test>"
+                    >
+                      <label
+                        class="<removed-for-snapshot-test>"
+                      >
+                        Destination Namespace*
+                        <span>
+                          <br />
+                          <span
+                            class="<removed-for-snapshot-test>"
+                          >
+                            Define the location where the data will be stored in the destination
+                          </span>
+                        </span>
+                      </label>
+                    </div>
+                  </div>
+                  <div
+                    class="<removed-for-snapshot-test>"
+                  >
+                    <div
+                      class="<removed-for-snapshot-test>"
+                      data-testid="namespaceDefinition"
+                      role="combobox"
+                    >
+                      <span
+                        class="<removed-for-snapshot-test>"
+                        id="react-select-3-live-region"
+                      />
+                      <span
+                        aria-atomic="false"
+                        aria-live="polite"
+                        aria-relevant="additions text"
+                        class="<removed-for-snapshot-test>"
+                      />
+                      <div
+                        class="<removed-for-snapshot-test>"
+                      >
+                        <div
+                          class="<removed-for-snapshot-test>"
+                        >
+                          <div
+                            class="<removed-for-snapshot-test>"
+                          >
+                            <div
+                              class="<removed-for-snapshot-test>"
+                            >
+                              <div
+                                class="<removed-for-snapshot-test>"
+                              >
+                                Mirror source structure
+                              </div>
+                            </div>
+                          </div>
+                          <input
+                            aria-autocomplete="list"
+                            aria-expanded="false"
+                            aria-haspopup="true"
+                            aria-readonly="true"
+                            class="<removed-for-snapshot-test>"
+                            id="react-select-3-input"
+                            inputmode="none"
+                            role="combobox"
+                            tabindex="0"
+                            value=""
+                          />
+                        </div>
+                        <div
+                          class="<removed-for-snapshot-test>"
+                        >
+                          <div
+                            aria-hidden="true"
+                            class="<removed-for-snapshot-test>"
+                          >
+                            <svg
+                              aria-hidden="true"
+                              class="svg-inline--fa fa-sort-down sc-jOrMOR jXccHI"
+                              data-icon="sort-down"
+                              data-prefix="fas"
+                              focusable="false"
+                              role="img"
+                              viewBox="0 0 320 512"
+                              xmlns="http://www.w3.org/2000/svg"
+                            >
+                              <path
+                                d="M311.9 335.1l-132.4 136.8C174.1 477.3 167.1 480 160 480c-7.055 0-14.12-2.702-19.47-8.109l-132.4-136.8C-9.229 317.8 3.055 288 27.66 288h264.7C316.9 288 329.2 317.8 311.9 335.1z"
+                                fill="currentColor"
+                              />
+                            </svg>
+                          </div>
+                        </div>
+                      </div>
+                      <input
+                        name="namespaceDefinition"
+                        type="hidden"
+                        value="source"
+                      />
+                    </div>
+                  </div>
+                </div>
+              </span>
+              <div
+                class="<removed-for-snapshot-test>"
+              >
+                <div
+                  class="<removed-for-snapshot-test>"
+                >
+                  <div
+                    class="<removed-for-snapshot-test>"
+                  >
+                    <label
+                      class="<removed-for-snapshot-test>"
+                    >
+                      Destination Stream Prefix (Optional)
+                      <span>
+                        <br />
+                        <span
+                          class="<removed-for-snapshot-test>"
+                        >
+                          Add a prefix to stream names (ex. “airbyte_” causes “projects” =&gt; “airbyte_projects”)
+                        </span>
+                      </span>
+                    </label>
+                  </div>
+                </div>
+                <div
+                  class="<removed-for-snapshot-test>"
+                >
+                  <div
+                    class="<removed-for-snapshot-test>"
+                    data-testid="input-container"
+                  >
+                    <input
+                      class="<removed-for-snapshot-test>"
+                      data-testid="prefixInput"
+                      name="prefix"
+                      placeholder="prefix"
+                      style="pointer-events: auto;"
+                      type="text"
+                      value=""
+                    />
+                  </div>
+                </div>
+              </div>
+            </div>
+          </div>
+          <div
+            class="<removed-for-snapshot-test>"
+          >
+            <div
+              class="<removed-for-snapshot-test>"
+            >
+              <div
+                class="<removed-for-snapshot-test>"
+              >
+                <div
+                  class="<removed-for-snapshot-test>"
+                >
+                  <h5
+                    class="<removed-for-snapshot-test>"
+                  >
+                    Activate the streams you want to sync
+                  </h5>
+                  <button
+                    class="<removed-for-snapshot-test>"
+                    type="button"
+                  >
+                    <div
+                      class="<removed-for-snapshot-test>"
+                    >
+                      <svg
+                        aria-hidden="true"
+                        class="svg-inline--fa fa-rotate tryArrow"
+                        data-icon="rotate"
+                        data-prefix="fas"
+                        focusable="false"
+                        role="img"
+                        viewBox="0 0 512 512"
+                        xmlns="http://www.w3.org/2000/svg"
+                      >
+                        <path
+                          d="M449.9 39.96l-48.5 48.53C362.5 53.19 311.4 32 256 32C161.5 32 78.59 92.34 49.58 182.2c-5.438 16.81 3.797 34.88 20.61 40.28c16.97 5.5 34.86-3.812 40.3-20.59C130.9 138.5 189.4 96 256 96c37.96 0 73 14.18 100.2 37.8L311.1 178C295.1 194.8 306.8 223.4 330.4 224h146.9C487.7 223.7 496 215.3 496 204.9V59.04C496 34.99 466.9 22.95 449.9 39.96zM441.8 289.6c-16.94-5.438-34.88 3.812-40.3 20.59C381.1 373.5 322.6 416 256 416c-37.96 0-73-14.18-100.2-37.8L200 334C216.9 317.2 205.2 288.6 181.6 288H34.66C24.32 288.3 16 296.7 16 307.1v145.9c0 24.04 29.07 36.08 46.07 19.07l48.5-48.53C149.5 458.8 200.6 480 255.1 480c94.45 0 177.4-60.34 206.4-150.2C467.9 313 458.6 294.1 441.8 289.6z"
+                          fill="currentColor"
+                        />
+                      </svg>
+                      Refresh source schema
+                    </div>
+                  </button>
+                </div>
+                <div
+                  class="<removed-for-snapshot-test>"
+                >
+                  <div
+                    class="<removed-for-snapshot-test>"
+                    data-testid="input-container"
+                  >
+                    <input
+                      class="<removed-for-snapshot-test>"
+                      data-testid="input"
+                      placeholder="Search stream name"
+                    />
+                  </div>
+                </div>
+                <div
+                  class="<removed-for-snapshot-test>"
+                >
+                  <div
+                    class="<removed-for-snapshot-test>"
+                  >
+                    <label
+                      class="<removed-for-snapshot-test>"
+                    >
+                      <input
+                        class="<removed-for-snapshot-test>"
+                        type="checkbox"
+                      />
+                    </label>
+                  </div>
+                  <div
+                    class="<removed-for-snapshot-test>"
+                  />
+                  <div
+                    class="<removed-for-snapshot-test>"
+                  >
+                    Sync
+                  </div>
+                  <div
+                    class="<removed-for-snapshot-test>"
+                  >
+                    Source
+                    <div
+                      class="<removed-for-snapshot-test>"
+                    >
+                      <div
+                        class="<removed-for-snapshot-test>"
+                      >
+                        <div
+                          class="<removed-for-snapshot-test>"
+                        >
+                          <svg
+                            fill="none"
+                            height="14"
+                            viewBox="0 0 14 14"
+                            width="14"
+                          >
+                            <path
+                              d="M7.00016 13.6663C3.31816 13.6663 0.333496 10.6817 0.333496 6.99967C0.333496 3.31767 3.31816 0.333008 7.00016 0.333008C10.6822 0.333008 13.6668 3.31767 13.6668 6.99967C13.6668 10.6817 10.6822 13.6663 7.00016 13.6663ZM7.00016 12.333C8.41465 12.333 9.77121 11.7711 10.7714 10.7709C11.7716 9.77072 12.3335 8.41416 12.3335 6.99967C12.3335 5.58519 11.7716 4.22863 10.7714 3.22844C9.77121 2.22824 8.41465 1.66634 7.00016 1.66634C5.58567 1.66634 4.22912 2.22824 3.22893 3.22844C2.22873 4.22863 1.66683 5.58519 1.66683 6.99967C1.66683 8.41416 2.22873 9.77072 3.22893 10.7709C4.22912 11.7711 5.58567 12.333 7.00016 12.333ZM6.3335 3.66634H7.66683V4.99967H6.3335V3.66634ZM6.3335 6.33301H7.66683V10.333H6.3335V6.33301Z"
+                              fill="currentColor"
+                            />
+                          </svg>
+                        </div>
+                      </div>
+                    </div>
+                  </div>
+                  <div
+                    class="<removed-for-snapshot-test>"
+                  />
+                  <div
+                    class="<removed-for-snapshot-test>"
+                  >
+                    Sync mode
+                    <div
+                      class="<removed-for-snapshot-test>"
+                    >
+                      <div
+                        class="<removed-for-snapshot-test>"
+                      >
+                        <div
+                          class="<removed-for-snapshot-test>"
+                        >
+                          <svg
+                            fill="none"
+                            height="14"
+                            viewBox="0 0 14 14"
+                            width="14"
+                          >
+                            <path
+                              d="M7.00016 13.6663C3.31816 13.6663 0.333496 10.6817 0.333496 6.99967C0.333496 3.31767 3.31816 0.333008 7.00016 0.333008C10.6822 0.333008 13.6668 3.31767 13.6668 6.99967C13.6668 10.6817 10.6822 13.6663 7.00016 13.6663ZM7.00016 12.333C8.41465 12.333 9.77121 11.7711 10.7714 10.7709C11.7716 9.77072 12.3335 8.41416 12.3335 6.99967C12.3335 5.58519 11.7716 4.22863 10.7714 3.22844C9.77121 2.22824 8.41465 1.66634 7.00016 1.66634C5.58567 1.66634 4.22912 2.22824 3.22893 3.22844C2.22873 4.22863 1.66683 5.58519 1.66683 6.99967C1.66683 8.41416 2.22873 9.77072 3.22893 10.7709C4.22912 11.7711 5.58567 12.333 7.00016 12.333ZM6.3335 3.66634H7.66683V4.99967H6.3335V3.66634ZM6.3335 6.33301H7.66683V10.333H6.3335V6.33301Z"
+                              fill="currentColor"
+                            />
+                          </svg>
+                        </div>
+                      </div>
+                    </div>
+                  </div>
+                  <div
+                    class="<removed-for-snapshot-test>"
+                  >
+                    Cursor field
+                    <div
+                      class="<removed-for-snapshot-test>"
+                    >
+                      <div
+                        class="<removed-for-snapshot-test>"
+                      >
+                        <div
+                          class="<removed-for-snapshot-test>"
+                        >
+                          <svg
+                            fill="none"
+                            height="14"
+                            viewBox="0 0 14 14"
+                            width="14"
+                          >
+                            <path
+                              d="M7.00016 13.6663C3.31816 13.6663 0.333496 10.6817 0.333496 6.99967C0.333496 3.31767 3.31816 0.333008 7.00016 0.333008C10.6822 0.333008 13.6668 3.31767 13.6668 6.99967C13.6668 10.6817 10.6822 13.6663 7.00016 13.6663ZM7.00016 12.333C8.41465 12.333 9.77121 11.7711 10.7714 10.7709C11.7716 9.77072 12.3335 8.41416 12.3335 6.99967C12.3335 5.58519 11.7716 4.22863 10.7714 3.22844C9.77121 2.22824 8.41465 1.66634 7.00016 1.66634C5.58567 1.66634 4.22912 2.22824 3.22893 3.22844C2.22873 4.22863 1.66683 5.58519 1.66683 6.99967C1.66683 8.41416 2.22873 9.77072 3.22893 10.7709C4.22912 11.7711 5.58567 12.333 7.00016 12.333ZM6.3335 3.66634H7.66683V4.99967H6.3335V3.66634ZM6.3335 6.33301H7.66683V10.333H6.3335V6.33301Z"
+                              fill="currentColor"
+                            />
+                          </svg>
+                        </div>
+                      </div>
+                    </div>
+                  </div>
+                  <div
+                    class="<removed-for-snapshot-test>"
+                  >
+                    Primary key
+                    <div
+                      class="<removed-for-snapshot-test>"
+                    >
+                      <div
+                        class="<removed-for-snapshot-test>"
+                      >
+                        <div
+                          class="<removed-for-snapshot-test>"
+                        >
+                          <svg
+                            fill="none"
+                            height="14"
+                            viewBox="0 0 14 14"
+                            width="14"
+                          >
+                            <path
+                              d="M7.00016 13.6663C3.31816 13.6663 0.333496 10.6817 0.333496 6.99967C0.333496 3.31767 3.31816 0.333008 7.00016 0.333008C10.6822 0.333008 13.6668 3.31767 13.6668 6.99967C13.6668 10.6817 10.6822 13.6663 7.00016 13.6663ZM7.00016 12.333C8.41465 12.333 9.77121 11.7711 10.7714 10.7709C11.7716 9.77072 12.3335 8.41416 12.3335 6.99967C12.3335 5.58519 11.7716 4.22863 10.7714 3.22844C9.77121 2.22824 8.41465 1.66634 7.00016 1.66634C5.58567 1.66634 4.22912 2.22824 3.22893 3.22844C2.22873 4.22863 1.66683 5.58519 1.66683 6.99967C1.66683 8.41416 2.22873 9.77072 3.22893 10.7709C4.22912 11.7711 5.58567 12.333 7.00016 12.333ZM6.3335 3.66634H7.66683V4.99967H6.3335V3.66634ZM6.3335 6.33301H7.66683V10.333H6.3335V6.33301Z"
+                              fill="currentColor"
+                            />
+                          </svg>
+                        </div>
+                      </div>
+                    </div>
+                  </div>
+                  <div
+                    class="<removed-for-snapshot-test>"
+                  >
+                    Destination
+                    <div
+                      class="<removed-for-snapshot-test>"
+                    >
+                      <div
+                        class="<removed-for-snapshot-test>"
+                      >
+                        <div
+                          class="<removed-for-snapshot-test>"
+                        >
+                          <svg
+                            fill="none"
+                            height="14"
+                            viewBox="0 0 14 14"
+                            width="14"
+                          >
+                            <path
+                              d="M7.00016 13.6663C3.31816 13.6663 0.333496 10.6817 0.333496 6.99967C0.333496 3.31767 3.31816 0.333008 7.00016 0.333008C10.6822 0.333008 13.6668 3.31767 13.6668 6.99967C13.6668 10.6817 10.6822 13.6663 7.00016 13.6663ZM7.00016 12.333C8.41465 12.333 9.77121 11.7711 10.7714 10.7709C11.7716 9.77072 12.3335 8.41416 12.3335 6.99967C12.3335 5.58519 11.7716 4.22863 10.7714 3.22844C9.77121 2.22824 8.41465 1.66634 7.00016 1.66634C5.58567 1.66634 4.22912 2.22824 3.22893 3.22844C2.22873 4.22863 1.66683 5.58519 1.66683 6.99967C1.66683 8.41416 2.22873 9.77072 3.22893 10.7709C4.22912 11.7711 5.58567 12.333 7.00016 12.333ZM6.3335 3.66634H7.66683V4.99967H6.3335V3.66634ZM6.3335 6.33301H7.66683V10.333H6.3335V6.33301Z"
+                              fill="currentColor"
+                            />
+                          </svg>
+                        </div>
+                      </div>
+                    </div>
+                  </div>
+                  <div
+                    class="<removed-for-snapshot-test>"
+                  />
+                </div>
+                <div
+                  class="<removed-for-snapshot-test>"
+                >
+                  <div
+                    class="<removed-for-snapshot-test>"
+                  >
+                    Namespace
+                  </div>
+                  <div
+                    class="<removed-for-snapshot-test>"
+                  >
+                    Stream name
+                  </div>
+                  <div
+                    class="<removed-for-snapshot-test>"
+                  >
+                    Source | Destination
+                  </div>
+                  <div
+                    class="<removed-for-snapshot-test>"
+                  />
+                  <div
+                    class="<removed-for-snapshot-test>"
+                  />
+                  <div
+                    class="<removed-for-snapshot-test>"
+                  >
+                    Namespace
+                  </div>
+                  <div
+                    class="<removed-for-snapshot-test>"
+                  >
+                    Stream name
+                  </div>
+                </div>
+                <div
+                  class="<removed-for-snapshot-test>"
+                >
+                  <div
+                    class="<removed-for-snapshot-test>"
+                  >
+                    <div
+                      class="<removed-for-snapshot-test>"
+                    >
+                      <div
+                        class="<removed-for-snapshot-test>"
+                      >
+                        <label
+                          class="<removed-for-snapshot-test>"
+                        >
+                          <input
+                            class="<removed-for-snapshot-test>"
+                            type="checkbox"
+                          />
+                        </label>
+                      </div>
+                      <div
+                        class="<removed-for-snapshot-test>"
+                      >
+                        <span
+                          class="<removed-for-snapshot-test>"
+                        >
+                          <svg
+                            aria-hidden="true"
+                            class="svg-inline--fa fa-chevron-right sc-hiMGwR bbPiZr"
+                            data-icon="chevron-right"
+                            data-prefix="fas"
+                            focusable="false"
+                            role="img"
+                            viewBox="0 0 320 512"
+                            xmlns="http://www.w3.org/2000/svg"
+                          >
+                            <path
+                              d="M96 480c-8.188 0-16.38-3.125-22.62-9.375c-12.5-12.5-12.5-32.75 0-45.25L242.8 256L73.38 86.63c-12.5-12.5-12.5-32.75 0-45.25s32.75-12.5 45.25 0l192 192c12.5 12.5 12.5 32.75 0 45.25l-192 192C112.4 476.9 104.2 480 96 480z"
+                              fill="currentColor"
+                            />
+                          </svg>
+                        </span>
+                      </div>
+                      <div
+                        class="<removed-for-snapshot-test>"
+                      >
+                        <div
+                          class="<removed-for-snapshot-test>"
+                        >
+                          <label
+                            class="<removed-for-snapshot-test>"
+                          >
+                            <input
+                              checked=""
+                              class="<removed-for-snapshot-test>"
+                              type="checkbox"
+                              value=""
+                            />
+                            <span
+                              class="<removed-for-snapshot-test>"
+                            />
+                          </label>
+                        </div>
+                        <div
+                          class="<removed-for-snapshot-test>"
+                          title=""
+                        >
+                          <span
+                            class="<removed-for-snapshot-test>"
+                          >
+                            No namespace
+                          </span>
+                        </div>
+                        <div
+                          class="<removed-for-snapshot-test>"
+                          title="pokemon"
+                        >
+                          pokemon
+                        </div>
+                        <div
+                          class="<removed-for-snapshot-test>"
+                        >
+                          <div
+                            class="<removed-for-snapshot-test>"
+                            data-testid="syncSettingsDropdown"
+                            role="combobox"
+                          >
+                            <span
+                              class="<removed-for-snapshot-test>"
+                              id="react-select-4-live-region"
+                            />
+                            <span
+                              aria-atomic="false"
+                              aria-live="polite"
+                              aria-relevant="additions text"
+                              class="<removed-for-snapshot-test>"
+                            />
+                            <div
+                              class="<removed-for-snapshot-test>"
+                            >
+                              <div
+                                class="<removed-for-snapshot-test>"
+                              >
+                                <div
+                                  class="<removed-for-snapshot-test>"
+                                >
+                                  <div
+                                    class="<removed-for-snapshot-test>"
+                                  >
+                                    <div>
+                                      Full refresh
+                                    </div>
+                                    <div
+                                      class="<removed-for-snapshot-test>"
+                                    >
+                                      |
+                                    </div>
+                                    <div>
+                                      Overwrite
+                                    </div>
+                                  </div>
+                                </div>
+                                <input
+                                  aria-autocomplete="list"
+                                  aria-expanded="false"
+                                  aria-haspopup="true"
+                                  aria-readonly="true"
+                                  class="<removed-for-snapshot-test>"
+                                  id="react-select-4-input"
+                                  inputmode="none"
+                                  role="combobox"
+                                  tabindex="0"
+                                  value=""
+                                />
+                              </div>
+                              <div
+                                class="<removed-for-snapshot-test>"
+                              >
+                                <div
+                                  aria-hidden="true"
+                                  class="<removed-for-snapshot-test>"
+                                >
+                                  <svg
+                                    aria-hidden="true"
+                                    class="svg-inline--fa fa-sort-down sc-jOrMOR jXccHI"
+                                    data-icon="sort-down"
+                                    data-prefix="fas"
+                                    focusable="false"
+                                    role="img"
+                                    viewBox="0 0 320 512"
+                                    xmlns="http://www.w3.org/2000/svg"
+                                  >
+                                    <path
+                                      d="M311.9 335.1l-132.4 136.8C174.1 477.3 167.1 480 160 480c-7.055 0-14.12-2.702-19.47-8.109l-132.4-136.8C-9.229 317.8 3.055 288 27.66 288h264.7C316.9 288 329.2 317.8 311.9 335.1z"
+                                      fill="currentColor"
+                                    />
+                                  </svg>
+                                </div>
+                              </div>
+                            </div>
+                          </div>
+                        </div>
+                        <div
+                          class="<removed-for-snapshot-test>"
+                        />
+                        <div
+                          class="<removed-for-snapshot-test>"
+                        />
+                        <div
+                          class="<removed-for-snapshot-test>"
+                          title="'<source schema>"
+                        >
+                          '&lt;source schema&gt;
+                        </div>
+                        <div
+                          class="<removed-for-snapshot-test>"
+                          title="pokemon"
+                        >
+                          pokemon
+                        </div>
+                      </div>
+                    </div>
+                  </div>
+                </div>
+              </div>
+            </div>
+          </div>
+        </div>
+        <div
+          class="<removed-for-snapshot-test>"
+        >
+          <div
+            class="<removed-for-snapshot-test>"
+          >
+            <div
+              class="<removed-for-snapshot-test>"
+            >
+              <h5
+                class="<removed-for-snapshot-test>"
+              >
+                Normalization & Transformation
+              </h5>
+              <div
+                class="<removed-for-snapshot-test>"
+              >
+                <div
+                  class="<removed-for-snapshot-test>"
                 >
                   <label
-                    class="sc-eCYdqJ cgRkWU"
+                    class="<removed-for-snapshot-test>"
                   >
-                    Destination Stream Prefix (Optional)
-                    <span>
-                      <br />
-                      <span
-                        class="sc-jSMfEi dkwDTm"
+                    <div
+                      class="<removed-for-snapshot-test>"
+                    />
+                    <input
+                      class="<removed-for-snapshot-test>"
+                      id="radiobutton-normalization.raw"
+                      label="[object Object]"
+                      name="normalization"
+                      type="radio"
+                      value="raw"
+                    />
+                  </label>
+                  <label
+                    class="<removed-for-snapshot-test>"
+                    for="radiobutton-normalization.raw"
+                  >
+                    Raw data (JSON)
+                    <span
+                      class="<removed-for-snapshot-test>"
+                    />
+                  </label>
+                </div>
+                <div
+                  class="<removed-for-snapshot-test>"
+                >
+                  <label
+                    class="<removed-for-snapshot-test>"
+                  >
+                    <div
+                      class="<removed-for-snapshot-test>"
+                    />
+                    <input
+                      checked=""
+                      class="<removed-for-snapshot-test>"
+                      id="radiobutton-normalization.basic"
+                      label="[object Object]"
+                      name="normalization"
+                      type="radio"
+                      value="basic"
+                    />
+                  </label>
+                  <label
+                    class="<removed-for-snapshot-test>"
+                    for="radiobutton-normalization.basic"
+                  >
+                    Normalized tabular data
+                    <span
+                      class="<removed-for-snapshot-test>"
+                    >
+                      Map the JSON object to the types and format native to the destination. 
+                      <a
+                        class="<removed-for-snapshot-test>"
+                        href="https://docs.airbyte.com/understanding-airbyte/connections#airbyte-basic-normalization"
+                        target="_blank"
                       >
-                        Add a prefix to stream names (ex. “airbyte_” causes “projects” =&gt; “airbyte_projects”)
-                      </span>
+                        Learn more
+                      </a>
                     </span>
                   </label>
                 </div>
               </div>
               <div
-                class="rightFieldCol"
+                class="<removed-for-snapshot-test>"
               >
                 <div
-                  class="container"
-                  data-testid="input-container"
+                  class="<removed-for-snapshot-test>"
                 >
-                  <input
-                    class="input"
-                    data-testid="prefixInput"
-                    name="prefix"
-                    placeholder="prefix"
-                    style="pointer-events: auto;"
-                    type="text"
-                    value=""
-                  />
+                  No custom transformation
+                  <button
+                    class="<removed-for-snapshot-test>"
+                    data-testid="addItemButton"
+                    type="button"
+                  >
+                    <div
+                      class="<removed-for-snapshot-test>"
+                    >
+                      + Add transformation
+                    </div>
+                  </button>
                 </div>
               </div>
             </div>
           </div>
         </div>
         <div
-          class="container"
+          class="<removed-for-snapshot-test>"
         >
-          <div
-            class="section"
-          >
-            <div
-              class="loadingBackdropContainer"
+          <div />
+          <div>
+            <button
+              class="<removed-for-snapshot-test>"
+              type="submit"
             >
               <div
-                class="sc-bUbCnL keYsWp"
+                class="<removed-for-snapshot-test>"
               >
-                <h5
-                  class="sc-bczRLJ sc-dkzDqf UeZWt ebWyjL"
-                >
-                  Activate the streams you want to sync
-                </h5>
-                <button
-                  class="button sizeXS typeSecondary"
-                  type="button"
-                >
-                  <div
-                    class="childrenContainer"
-                  >
-                    <svg
-                      aria-hidden="true"
-                      class="svg-inline--fa fa-rotate tryArrow"
-                      data-icon="rotate"
-                      data-prefix="fas"
-                      focusable="false"
-                      role="img"
-                      viewBox="0 0 512 512"
-                      xmlns="http://www.w3.org/2000/svg"
-                    >
-                      <path
-                        d="M449.9 39.96l-48.5 48.53C362.5 53.19 311.4 32 256 32C161.5 32 78.59 92.34 49.58 182.2c-5.438 16.81 3.797 34.88 20.61 40.28c16.97 5.5 34.86-3.812 40.3-20.59C130.9 138.5 189.4 96 256 96c37.96 0 73 14.18 100.2 37.8L311.1 178C295.1 194.8 306.8 223.4 330.4 224h146.9C487.7 223.7 496 215.3 496 204.9V59.04C496 34.99 466.9 22.95 449.9 39.96zM441.8 289.6c-16.94-5.438-34.88 3.812-40.3 20.59C381.1 373.5 322.6 416 256 416c-37.96 0-73-14.18-100.2-37.8L200 334C216.9 317.2 205.2 288.6 181.6 288H34.66C24.32 288.3 16 296.7 16 307.1v145.9c0 24.04 29.07 36.08 46.07 19.07l48.5-48.53C149.5 458.8 200.6 480 255.1 480c94.45 0 177.4-60.34 206.4-150.2C467.9 313 458.6 294.1 441.8 289.6z"
-                        fill="currentColor"
-                      />
-                    </svg>
-                    Refresh source schema
-                  </div>
-                </button>
+                Set up connection
               </div>
-              <div
-                class="sc-ZyCDH gpzrdJ"
-              >
-                <div
-                  class="container"
-                  data-testid="input-container"
-                >
-                  <input
-                    class="input sc-jIAOiI bxGgcg"
-                    data-testid="input"
-                    placeholder="Search stream name"
-                  />
-                </div>
-              </div>
-              <div
-                class="sc-ksZaOG sc-hAZoDl fmKtaK jIJKIB catalogHeader"
-              >
-                <div
-                  class="sc-fnykZs imOUQR checkboxCell"
-                >
-                  <label
-                    class="sc-crXcEl iWbiAC"
-                  >
-                    <input
-                      class="sc-iqcoie djcshM"
-                      type="checkbox"
-                    />
-                  </label>
-                </div>
-                <div
-                  class="sc-fnykZs jUKmJs"
-                />
-                <div
-                  class="sc-fnykZs bOivtp"
-                >
-                  Sync
-                </div>
-                <div
-                  class="sc-fnykZs VApCG"
-                >
-                  Source
-                  <div
-                    class="container"
-                  >
-                    <div
-                      class="container"
-                    >
-                      <div
-                        class="icon"
-                      >
-                        <svg
-                          fill="none"
-                          height="14"
-                          viewBox="0 0 14 14"
-                          width="14"
-                        >
-                          <path
-                            d="M7.00016 13.6663C3.31816 13.6663 0.333496 10.6817 0.333496 6.99967C0.333496 3.31767 3.31816 0.333008 7.00016 0.333008C10.6822 0.333008 13.6668 3.31767 13.6668 6.99967C13.6668 10.6817 10.6822 13.6663 7.00016 13.6663ZM7.00016 12.333C8.41465 12.333 9.77121 11.7711 10.7714 10.7709C11.7716 9.77072 12.3335 8.41416 12.3335 6.99967C12.3335 5.58519 11.7716 4.22863 10.7714 3.22844C9.77121 2.22824 8.41465 1.66634 7.00016 1.66634C5.58567 1.66634 4.22912 2.22824 3.22893 3.22844C2.22873 4.22863 1.66683 5.58519 1.66683 6.99967C1.66683 8.41416 2.22873 9.77072 3.22893 10.7709C4.22912 11.7711 5.58567 12.333 7.00016 12.333ZM6.3335 3.66634H7.66683V4.99967H6.3335V3.66634ZM6.3335 6.33301H7.66683V10.333H6.3335V6.33301Z"
-                            fill="currentColor"
-                          />
-                        </svg>
-                      </div>
-                    </div>
-                  </div>
-                </div>
-                <div
-                  class="sc-fnykZs imOUQR"
-                />
-                <div
-                  class="sc-fnykZs ciVNhF"
-                >
-                  Sync mode
-                  <div
-                    class="container"
-                  >
-                    <div
-                      class="container"
-                    >
-                      <div
-                        class="icon"
-                      >
-                        <svg
-                          fill="none"
-                          height="14"
-                          viewBox="0 0 14 14"
-                          width="14"
-                        >
-                          <path
-                            d="M7.00016 13.6663C3.31816 13.6663 0.333496 10.6817 0.333496 6.99967C0.333496 3.31767 3.31816 0.333008 7.00016 0.333008C10.6822 0.333008 13.6668 3.31767 13.6668 6.99967C13.6668 10.6817 10.6822 13.6663 7.00016 13.6663ZM7.00016 12.333C8.41465 12.333 9.77121 11.7711 10.7714 10.7709C11.7716 9.77072 12.3335 8.41416 12.3335 6.99967C12.3335 5.58519 11.7716 4.22863 10.7714 3.22844C9.77121 2.22824 8.41465 1.66634 7.00016 1.66634C5.58567 1.66634 4.22912 2.22824 3.22893 3.22844C2.22873 4.22863 1.66683 5.58519 1.66683 6.99967C1.66683 8.41416 2.22873 9.77072 3.22893 10.7709C4.22912 11.7711 5.58567 12.333 7.00016 12.333ZM6.3335 3.66634H7.66683V4.99967H6.3335V3.66634ZM6.3335 6.33301H7.66683V10.333H6.3335V6.33301Z"
-                            fill="currentColor"
-                          />
-                        </svg>
-                      </div>
-                    </div>
-                  </div>
-                </div>
-                <div
-                  class="sc-fnykZs VApCG"
-                >
-                  Cursor field
-                  <div
-                    class="container"
-                  >
-                    <div
-                      class="container"
-                    >
-                      <div
-                        class="icon"
-                      >
-                        <svg
-                          fill="none"
-                          height="14"
-                          viewBox="0 0 14 14"
-                          width="14"
-                        >
-                          <path
-                            d="M7.00016 13.6663C3.31816 13.6663 0.333496 10.6817 0.333496 6.99967C0.333496 3.31767 3.31816 0.333008 7.00016 0.333008C10.6822 0.333008 13.6668 3.31767 13.6668 6.99967C13.6668 10.6817 10.6822 13.6663 7.00016 13.6663ZM7.00016 12.333C8.41465 12.333 9.77121 11.7711 10.7714 10.7709C11.7716 9.77072 12.3335 8.41416 12.3335 6.99967C12.3335 5.58519 11.7716 4.22863 10.7714 3.22844C9.77121 2.22824 8.41465 1.66634 7.00016 1.66634C5.58567 1.66634 4.22912 2.22824 3.22893 3.22844C2.22873 4.22863 1.66683 5.58519 1.66683 6.99967C1.66683 8.41416 2.22873 9.77072 3.22893 10.7709C4.22912 11.7711 5.58567 12.333 7.00016 12.333ZM6.3335 3.66634H7.66683V4.99967H6.3335V3.66634ZM6.3335 6.33301H7.66683V10.333H6.3335V6.33301Z"
-                            fill="currentColor"
-                          />
-                        </svg>
-                      </div>
-                    </div>
-                  </div>
-                </div>
-                <div
-                  class="sc-fnykZs VApCG"
-                >
-                  Primary key
-                  <div
-                    class="container"
-                  >
-                    <div
-                      class="container"
-                    >
-                      <div
-                        class="icon"
-                      >
-                        <svg
-                          fill="none"
-                          height="14"
-                          viewBox="0 0 14 14"
-                          width="14"
-                        >
-                          <path
-                            d="M7.00016 13.6663C3.31816 13.6663 0.333496 10.6817 0.333496 6.99967C0.333496 3.31767 3.31816 0.333008 7.00016 0.333008C10.6822 0.333008 13.6668 3.31767 13.6668 6.99967C13.6668 10.6817 10.6822 13.6663 7.00016 13.6663ZM7.00016 12.333C8.41465 12.333 9.77121 11.7711 10.7714 10.7709C11.7716 9.77072 12.3335 8.41416 12.3335 6.99967C12.3335 5.58519 11.7716 4.22863 10.7714 3.22844C9.77121 2.22824 8.41465 1.66634 7.00016 1.66634C5.58567 1.66634 4.22912 2.22824 3.22893 3.22844C2.22873 4.22863 1.66683 5.58519 1.66683 6.99967C1.66683 8.41416 2.22873 9.77072 3.22893 10.7709C4.22912 11.7711 5.58567 12.333 7.00016 12.333ZM6.3335 3.66634H7.66683V4.99967H6.3335V3.66634ZM6.3335 6.33301H7.66683V10.333H6.3335V6.33301Z"
-                            fill="currentColor"
-                          />
-                        </svg>
-                      </div>
-                    </div>
-                  </div>
-                </div>
-                <div
-                  class="sc-fnykZs VApCG"
-                >
-                  Destination
-                  <div
-                    class="container"
-                  >
-                    <div
-                      class="container"
-                    >
-                      <div
-                        class="icon"
-                      >
-                        <svg
-                          fill="none"
-                          height="14"
-                          viewBox="0 0 14 14"
-                          width="14"
-                        >
-                          <path
-                            d="M7.00016 13.6663C3.31816 13.6663 0.333496 10.6817 0.333496 6.99967C0.333496 3.31767 3.31816 0.333008 7.00016 0.333008C10.6822 0.333008 13.6668 3.31767 13.6668 6.99967C13.6668 10.6817 10.6822 13.6663 7.00016 13.6663ZM7.00016 12.333C8.41465 12.333 9.77121 11.7711 10.7714 10.7709C11.7716 9.77072 12.3335 8.41416 12.3335 6.99967C12.3335 5.58519 11.7716 4.22863 10.7714 3.22844C9.77121 2.22824 8.41465 1.66634 7.00016 1.66634C5.58567 1.66634 4.22912 2.22824 3.22893 3.22844C2.22873 4.22863 1.66683 5.58519 1.66683 6.99967C1.66683 8.41416 2.22873 9.77072 3.22893 10.7709C4.22912 11.7711 5.58567 12.333 7.00016 12.333ZM6.3335 3.66634H7.66683V4.99967H6.3335V3.66634ZM6.3335 6.33301H7.66683V10.333H6.3335V6.33301Z"
-                            fill="currentColor"
-                          />
-                        </svg>
-                      </div>
-                    </div>
-                  </div>
-                </div>
-                <div
-                  class="sc-fnykZs imOUQR"
-                />
-              </div>
-              <div
-                class="sc-ksZaOG sc-hAZoDl fmKtaK jIJKIB catalogSubheader"
-              >
-                <div
-                  class="sc-fnykZs sc-hlnMnd VApCG ezaSgM"
-                >
-                  Namespace
-                </div>
-                <div
-                  class="sc-fnykZs sc-hlnMnd VApCG ezaSgM"
-                >
-                  Stream name
-                </div>
-                <div
-                  class="sc-fnykZs sc-hlnMnd ciVNhF ezaSgM"
-                >
-                  Source | Destination
-                </div>
-                <div
-                  class="sc-fnykZs sc-hlnMnd sc-eKBdFk VApCG ezaSgM iBiQnB"
-                />
-                <div
-                  class="sc-fnykZs sc-hlnMnd sc-eKBdFk VApCG ezaSgM iBiQnB"
-                />
-                <div
-                  class="sc-fnykZs sc-hlnMnd VApCG ezaSgM"
-                >
-                  Namespace
-                </div>
-                <div
-                  class="sc-fnykZs sc-hlnMnd VApCG ezaSgM"
-                >
-                  Stream name
-                </div>
-              </div>
-              <div
-                class="sc-jOhDuK iHjNjo"
-              >
-                <div
-                  class="catalogSection"
-                >
-                  <div
-                    class="sc-ksZaOG fmKtaK catalogSectionRow"
-                  >
-                    <div
-                      class="checkboxCell streamRowCheckboxCell"
-                    >
-                      <label
-                        class="sc-crXcEl iWbiAC"
-                      >
-                        <input
-                          class="sc-iqcoie djcshM"
-                          type="checkbox"
-                        />
-                      </label>
-                    </div>
-                    <div
-                      class="sc-fnykZs sc-jgbSNz sc-lbxAil imOUQR dkANJX bHBjjw"
-                    >
-                      <span
-                        class="sc-hiMGwR kmDbQS"
-                      >
-                        <svg
-                          aria-hidden="true"
-                          class="svg-inline--fa fa-chevron-right sc-ehmTmK eOIlNv"
-                          data-icon="chevron-right"
-                          data-prefix="fas"
-                          focusable="false"
-                          role="img"
-                          viewBox="0 0 320 512"
-                          xmlns="http://www.w3.org/2000/svg"
-                        >
-                          <path
-                            d="M96 480c-8.188 0-16.38-3.125-22.62-9.375c-12.5-12.5-12.5-32.75 0-45.25L242.8 256L73.38 86.63c-12.5-12.5-12.5-32.75 0-45.25s32.75-12.5 45.25 0l192 192c12.5 12.5 12.5 32.75 0 45.25l-192 192C112.4 476.9 104.2 480 96 480z"
-                            fill="currentColor"
-                          />
-                        </svg>
-                      </span>
-                    </div>
-                    <div
-                      class="streamHeaderContent"
-                    >
-                      <div
-                        class="sc-fnykZs sc-jgbSNz hgpwyO dkANJX"
-                      >
-                        <label
-                          class="switch small"
-                        >
-                          <input
-                            checked=""
-                            class="switchInput"
-                            type="checkbox"
-                            value=""
-                          />
-                          <span
-                            class="slider small"
-                          />
-                        </label>
-                      </div>
-                      <div
-                        class="sc-fnykZs sc-jgbSNz kjjuyS dkANJX"
-                        title=""
-                      >
-                        <span
-                          class="sc-fXynhf sAcSt"
-                        >
-                          No namespace
-                        </span>
-                      </div>
-                      <div
-                        class="sc-fnykZs sc-jgbSNz kjjuyS dkANJX"
-                        title="pokemon"
-                      >
-                        pokemon
-                      </div>
-                      <div
-                        class="sc-fnykZs bKHgDK"
-                      >
-                        <div
-                          class="sc-cOFTSb jqsVWu react-select-container css-b62m3t-container"
-                          data-testid="syncSettingsDropdown"
-                          role="combobox"
-                        >
-                          <span
-                            class="css-1f43avz-a11yText-A11yText"
-                            id="react-select-4-live-region"
-                          />
-                          <span
-                            aria-atomic="false"
-                            aria-live="polite"
-                            aria-relevant="additions text"
-                            class="css-1f43avz-a11yText-A11yText"
-                          />
-                          <div
-                            class="sc-GVOUr ldWtuj react-select__control css-1s2u09g-control"
-                          >
-                            <div
-                              class="react-select__value-container react-select__value-container--has-value css-dlobye-Component"
-                            >
-                              <div
-                                class="sc-iAvgwm fQiUpU"
-                              >
-                                <div
-                                  class="sc-lbOyJj cHLvYg react-select__single-value css-qc6sy-singleValue"
-                                >
-                                  <div>
-                                    Full refresh
-                                  </div>
-                                  <div
-                                    class="sc-gFGZVQ ijSWZb"
-                                  >
-                                    |
-                                  </div>
-                                  <div>
-                                    Overwrite
-                                  </div>
-                                </div>
-                              </div>
-                              <input
-                                aria-autocomplete="list"
-                                aria-expanded="false"
-                                aria-haspopup="true"
-                                aria-readonly="true"
-                                class="css-mohuvp-dummyInput-DummyInput"
-                                id="react-select-4-input"
-                                inputmode="none"
-                                role="combobox"
-                                tabindex="0"
-                                value=""
-                              />
-                            </div>
-                            <div
-                              class="react-select__indicators css-ny0e4k-Component"
-                            >
-                              <div
-                                aria-hidden="true"
-                                class="react-select__indicator react-select__dropdown-indicator css-tlfecz-indicatorContainer"
-                              >
-                                <svg
-                                  aria-hidden="true"
-                                  class="svg-inline--fa fa-sort-down sc-dPyBCJ eGVczJ"
-                                  data-icon="sort-down"
-                                  data-prefix="fas"
-                                  focusable="false"
-                                  role="img"
-                                  viewBox="0 0 320 512"
-                                  xmlns="http://www.w3.org/2000/svg"
-                                >
-                                  <path
-                                    d="M311.9 335.1l-132.4 136.8C174.1 477.3 167.1 480 160 480c-7.055 0-14.12-2.702-19.47-8.109l-132.4-136.8C-9.229 317.8 3.055 288 27.66 288h264.7C316.9 288 329.2 317.8 311.9 335.1z"
-                                    fill="currentColor"
-                                  />
-                                </svg>
-                              </div>
-                            </div>
-                          </div>
-                        </div>
-                      </div>
-                      <div
-                        class="sc-fnykZs sc-jgbSNz imOUQR dkANJX"
-                      />
-                      <div
-                        class="sc-fnykZs sc-jgbSNz kjjuyS dkANJX"
-                      />
-                      <div
-                        class="sc-fnykZs sc-jgbSNz kjjuyS dkANJX"
-                        title="'<source schema>"
-                      >
-                        '&lt;source schema&gt;
-                      </div>
-                      <div
-                        class="sc-fnykZs sc-jgbSNz kjjuyS dkANJX"
-                        title="pokemon"
-                      >
-                        pokemon
-                      </div>
-                    </div>
-                  </div>
-                </div>
-              </div>
-            </div>
+            </button>
           </div>
         </div>
-      </div>
-      <div
-        class="container"
-      >
-        <div
-          class="container"
-        >
-          <div
-            class="section"
-          >
-            <h5
-              class="heading md"
-            >
-              Normalization & Transformation
-            </h5>
-            <div
-              class="sc-iTONeN jVBGIe"
-            >
-              <div
-                class="sc-papXJ jBZEjH"
-              >
-                <label
-                  class="sc-ftvSup eAaJEM"
-                >
-                  <div
-                    class="sc-iBkjds btSpQj"
-                  />
-                  <input
-                    class="sc-gKXOVf iqfEmu"
-                    id="radiobutton-normalization.raw"
-                    label="[object Object]"
-                    name="normalization"
-                    type="radio"
-                    value="raw"
-                  />
-                </label>
-                <label
-                  class="sc-jqUVSM jYhteM"
-                  for="radiobutton-normalization.raw"
-                >
-                  Raw data (JSON)
-                  <span
-                    class="sc-kDDrLX iVZNpR"
-                  />
-                </label>
-              </div>
-              <div
-                class="sc-papXJ jBZEjH"
-              >
-                <label
-                  class="sc-ftvSup eAaJEM"
-                >
-                  <div
-                    class="sc-iBkjds btSpQj"
-                  />
-                  <input
-                    checked=""
-                    class="sc-gKXOVf iqfEmu"
-                    id="radiobutton-normalization.basic"
-                    label="[object Object]"
-                    name="normalization"
-                    type="radio"
-                    value="basic"
-                  />
-                </label>
-                <label
-                  class="sc-jqUVSM jYhteM"
-                  for="radiobutton-normalization.basic"
-                >
-                  Normalized tabular data
-                  <span
-                    class="sc-kDDrLX iVZNpR"
-                  >
-                    Map the JSON object to the types and format native to the destination. 
-                    <a
-                      class="sc-evZas hBbGvM"
-                      href="https://docs.airbyte.com/understanding-airbyte/connections#airbyte-basic-normalization"
-                      target="_blank"
-                    >
-                      Learn more
-                    </a>
-                  </span>
-                </label>
-              </div>
-            </div>
-            <div
-              class="container"
-            >
-              <div
-                class="sc-hKMtZM bXwcwi"
-              >
-                No custom transformation
-                <button
-                  class="button sizeXS typeSecondary"
-                  data-testid="addItemButton"
-                  type="button"
-                >
-                  <div
-                    class="childrenContainer"
-                  >
-                    + Add transformation
-                  </div>
-                </button>
-              </div>
-            </div>
-          </div>
-        </div>
-      </div>
-      <div
-        class="sc-jIZahH gCZAUv"
-      >
-        <div />
-        <div>
-          <button
-            class="button sizeXS typePrimary"
-            type="submit"
-          >
-            <div
-              class="childrenContainer"
-            >
-              Set up connection
-            </div>
-          </button>
-        </div>
-      </div>
-    </form>
+      </form>
+    </div>
   </div>
-</div>
+</body>
 `;
 
 exports[`CreateConnectionForm should render when loading 1`] = `

--- a/airbyte-webapp/src/components/CreateConnection/__snapshots__/CreateConnectionForm.test.tsx.snap
+++ b/airbyte-webapp/src/components/CreateConnection/__snapshots__/CreateConnectionForm.test.tsx.snap
@@ -1,61 +1,184 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
 exports[`CreateConnectionForm should render 1`] = `
-<body>
-  <div>
-    <div
-      class="<removed-for-snapshot-test>"
+<div>
+  <div
+    class="connectionFormContainer"
+  >
+    <form
+      action="#"
     >
-      <form
-        action="#"
+      <div
+        class="container"
       >
         <div
-          class="<removed-for-snapshot-test>"
+          class="section"
         >
           <div
-            class="<removed-for-snapshot-test>"
+            class="flexRow"
           >
             <div
-              class="<removed-for-snapshot-test>"
+              class="leftFieldCol"
             >
               <div
-                class="<removed-for-snapshot-test>"
+                class="controlContainer connectionLabel"
+              >
+                <label
+                  class="sc-eCYdqJ cgRkWU"
+                >
+                  <h5
+                    class="heading md labelHeading"
+                  >
+                    Connection name*
+                  </h5>
+                  <span>
+                    <br />
+                    <span
+                      class="sc-jSMfEi dkwDTm"
+                    >
+                      Pick a name to help you identify this connection
+                    </span>
+                  </span>
+                </label>
+              </div>
+            </div>
+            <div
+              class="rightFieldCol"
+            >
+              <div
+                class="container"
+                data-testid="input-container"
+              >
+                <input
+                  class="input"
+                  data-testid="connectionName"
+                  name="name"
+                  placeholder="Name"
+                  value="Scrafty <> Heroku Postgres"
+                />
+              </div>
+            </div>
+          </div>
+        </div>
+      </div>
+      <div
+        class="formContainer"
+      >
+        <div
+          class="container"
+        >
+          <div
+            class="section"
+          >
+            <h5
+              class="heading sm"
+            >
+              Transfer
+            </h5>
+            <div
+              class="flexRow"
+            >
+              <div
+                class="leftFieldCol"
               >
                 <div
-                  class="<removed-for-snapshot-test>"
+                  class="controlContainer connectorLabel"
                 >
                   <label
-                    class="<removed-for-snapshot-test>"
+                    class="sc-eCYdqJ cgRkWU"
                   >
-                    <h5
-                      class="<removed-for-snapshot-test>"
-                    >
-                      Connection name*
-                    </h5>
+                    Replication frequency*
                     <span>
                       <br />
                       <span
-                        class="<removed-for-snapshot-test>"
+                        class="sc-jSMfEi dkwDTm"
                       >
-                        Pick a name to help you identify this connection
+                        Set how often data should sync to the destination
                       </span>
                     </span>
                   </label>
                 </div>
               </div>
               <div
-                class="<removed-for-snapshot-test>"
+                class="rightFieldCol"
+                style="pointer-events: auto;"
               >
                 <div
-                  class="<removed-for-snapshot-test>"
-                  data-testid="input-container"
+                  class="sc-cOFTSb bBiOrV react-select-container css-b62m3t-container"
+                  data-testid="scheduleData"
+                  role="combobox"
                 >
+                  <span
+                    class="css-1f43avz-a11yText-A11yText"
+                    id="react-select-2-live-region"
+                  />
+                  <span
+                    aria-atomic="false"
+                    aria-live="polite"
+                    aria-relevant="additions text"
+                    class="css-1f43avz-a11yText-A11yText"
+                  />
+                  <div
+                    class="react-select__control css-1s2u09g-control"
+                  >
+                    <div
+                      class="react-select__value-container react-select__value-container--has-value css-dlobye-Component"
+                    >
+                      <div
+                        class="sc-cTQhss haoKjh"
+                      >
+                        <div
+                          class="sc-iAvgwm fQiUpU"
+                        >
+                          <div
+                            class="react-select__single-value css-qc6sy-singleValue"
+                          >
+                            Every 24 hours
+                          </div>
+                        </div>
+                      </div>
+                      <input
+                        aria-autocomplete="list"
+                        aria-expanded="false"
+                        aria-haspopup="true"
+                        aria-readonly="true"
+                        class="css-mohuvp-dummyInput-DummyInput"
+                        id="react-select-2-input"
+                        inputmode="none"
+                        role="combobox"
+                        tabindex="0"
+                        value=""
+                      />
+                    </div>
+                    <div
+                      class="react-select__indicators css-ny0e4k-Component"
+                    >
+                      <div
+                        aria-hidden="true"
+                        class="react-select__indicator react-select__dropdown-indicator css-tlfecz-indicatorContainer"
+                      >
+                        <svg
+                          aria-hidden="true"
+                          class="svg-inline--fa fa-sort-down sc-dPyBCJ eGVczJ"
+                          data-icon="sort-down"
+                          data-prefix="fas"
+                          focusable="false"
+                          role="img"
+                          viewBox="0 0 320 512"
+                          xmlns="http://www.w3.org/2000/svg"
+                        >
+                          <path
+                            d="M311.9 335.1l-132.4 136.8C174.1 477.3 167.1 480 160 480c-7.055 0-14.12-2.702-19.47-8.109l-132.4-136.8C-9.229 317.8 3.055 288 27.66 288h264.7C316.9 288 329.2 317.8 311.9 335.1z"
+                            fill="currentColor"
+                          />
+                        </svg>
+                      </div>
+                    </div>
+                  </div>
                   <input
-                    class="<removed-for-snapshot-test>"
-                    data-testid="connectionName"
-                    name="name"
-                    placeholder="Name"
-                    value="Scrafty <> Heroku Postgres"
+                    name="scheduleData"
+                    type="hidden"
+                    value="[object Object]"
                   />
                 </div>
               </div>
@@ -63,78 +186,77 @@ exports[`CreateConnectionForm should render 1`] = `
           </div>
         </div>
         <div
-          class="<removed-for-snapshot-test>"
+          class="container"
         >
           <div
-            class="<removed-for-snapshot-test>"
+            class="section"
           >
-            <div
-              class="<removed-for-snapshot-test>"
+            <h5
+              class="heading md"
             >
-              <h5
-                class="<removed-for-snapshot-test>"
-              >
-                Transfer
-              </h5>
+              Streams
+            </h5>
+            <span
+              class=""
+            >
               <div
-                class="<removed-for-snapshot-test>"
+                class="flexRow"
               >
                 <div
-                  class="<removed-for-snapshot-test>"
+                  class="leftFieldCol"
                 >
                   <div
-                    class="<removed-for-snapshot-test>"
+                    class="controlContainer"
                   >
                     <label
-                      class="<removed-for-snapshot-test>"
+                      class="sc-eCYdqJ iCvyIv"
                     >
-                      Replication frequency*
+                      Destination Namespace*
                       <span>
                         <br />
                         <span
-                          class="<removed-for-snapshot-test>"
+                          class="sc-jSMfEi dkwDTm"
                         >
-                          Set how often data should sync to the destination
+                          Define the location where the data will be stored in the destination
                         </span>
                       </span>
                     </label>
                   </div>
                 </div>
                 <div
-                  class="<removed-for-snapshot-test>"
-                  style="pointer-events: auto;"
+                  class="rightFieldCol"
                 >
                   <div
-                    class="<removed-for-snapshot-test>"
-                    data-testid="scheduleData"
+                    class="sc-cOFTSb bBiOrV react-select-container css-b62m3t-container"
+                    data-testid="namespaceDefinition"
                     role="combobox"
                   >
                     <span
-                      class="<removed-for-snapshot-test>"
-                      id="react-select-2-live-region"
+                      class="css-1f43avz-a11yText-A11yText"
+                      id="react-select-3-live-region"
                     />
                     <span
                       aria-atomic="false"
                       aria-live="polite"
                       aria-relevant="additions text"
-                      class="<removed-for-snapshot-test>"
+                      class="css-1f43avz-a11yText-A11yText"
                     />
                     <div
-                      class="<removed-for-snapshot-test>"
+                      class="react-select__control css-1s2u09g-control"
                     >
                       <div
-                        class="<removed-for-snapshot-test>"
+                        class="react-select__value-container react-select__value-container--has-value css-dlobye-Component"
                       >
                         <div
-                          class="<removed-for-snapshot-test>"
+                          class="sc-cTQhss haoKjh"
                         >
                           <div
-                            class="<removed-for-snapshot-test>"
+                            class="sc-iAvgwm fQiUpU"
                           >
                             <div
-                              class="<removed-for-snapshot-test>"
+                              class="react-select__single-value css-qc6sy-singleValue"
                             >
-                              Every 24 hours
+                              Mirror source structure
                             </div>
                           </div>
                         </div>
@@ -143,8 +265,8 @@ exports[`CreateConnectionForm should render 1`] = `
                           aria-expanded="false"
                           aria-haspopup="true"
                           aria-readonly="true"
-                          class="<removed-for-snapshot-test>"
-                          id="react-select-2-input"
+                          class="css-mohuvp-dummyInput-DummyInput"
+                          id="react-select-3-input"
                           inputmode="none"
                           role="combobox"
                           tabindex="0"
@@ -152,15 +274,15 @@ exports[`CreateConnectionForm should render 1`] = `
                         />
                       </div>
                       <div
-                        class="<removed-for-snapshot-test>"
+                        class="react-select__indicators css-ny0e4k-Component"
                       >
                         <div
                           aria-hidden="true"
-                          class="<removed-for-snapshot-test>"
+                          class="react-select__indicator react-select__dropdown-indicator css-tlfecz-indicatorContainer"
                         >
                           <svg
                             aria-hidden="true"
-                            class="<removed-for-snapshot-test>"
+                            class="svg-inline--fa fa-sort-down sc-dPyBCJ eGVczJ"
                             data-icon="sort-down"
                             data-prefix="fas"
                             focusable="false"
@@ -177,761 +299,637 @@ exports[`CreateConnectionForm should render 1`] = `
                       </div>
                     </div>
                     <input
-                      name="scheduleData"
+                      name="namespaceDefinition"
                       type="hidden"
-                      value="[object Object]"
+                      value="source"
                     />
                   </div>
                 </div>
               </div>
-            </div>
-          </div>
-          <div
-            class="<removed-for-snapshot-test>"
-          >
+            </span>
             <div
-              class="<removed-for-snapshot-test>"
+              class="flexRow"
             >
-              <h5
-                class="<removed-for-snapshot-test>"
-              >
-                Streams
-              </h5>
-              <span
-                class=""
-              >
-                <div
-                  class="<removed-for-snapshot-test>"
-                >
-                  <div
-                    class="<removed-for-snapshot-test>"
-                  >
-                    <div
-                      class="<removed-for-snapshot-test>"
-                    >
-                      <label
-                        class="<removed-for-snapshot-test>"
-                      >
-                        Destination Namespace*
-                        <span>
-                          <br />
-                          <span
-                            class="<removed-for-snapshot-test>"
-                          >
-                            Define the location where the data will be stored in the destination
-                          </span>
-                        </span>
-                      </label>
-                    </div>
-                  </div>
-                  <div
-                    class="<removed-for-snapshot-test>"
-                  >
-                    <div
-                      class="<removed-for-snapshot-test>"
-                      data-testid="namespaceDefinition"
-                      role="combobox"
-                    >
-                      <span
-                        class="<removed-for-snapshot-test>"
-                        id="react-select-3-live-region"
-                      />
-                      <span
-                        aria-atomic="false"
-                        aria-live="polite"
-                        aria-relevant="additions text"
-                        class="<removed-for-snapshot-test>"
-                      />
-                      <div
-                        class="<removed-for-snapshot-test>"
-                      >
-                        <div
-                          class="<removed-for-snapshot-test>"
-                        >
-                          <div
-                            class="<removed-for-snapshot-test>"
-                          >
-                            <div
-                              class="<removed-for-snapshot-test>"
-                            >
-                              <div
-                                class="<removed-for-snapshot-test>"
-                              >
-                                Mirror source structure
-                              </div>
-                            </div>
-                          </div>
-                          <input
-                            aria-autocomplete="list"
-                            aria-expanded="false"
-                            aria-haspopup="true"
-                            aria-readonly="true"
-                            class="<removed-for-snapshot-test>"
-                            id="react-select-3-input"
-                            inputmode="none"
-                            role="combobox"
-                            tabindex="0"
-                            value=""
-                          />
-                        </div>
-                        <div
-                          class="<removed-for-snapshot-test>"
-                        >
-                          <div
-                            aria-hidden="true"
-                            class="<removed-for-snapshot-test>"
-                          >
-                            <svg
-                              aria-hidden="true"
-                              class="<removed-for-snapshot-test>"
-                              data-icon="sort-down"
-                              data-prefix="fas"
-                              focusable="false"
-                              role="img"
-                              viewBox="0 0 320 512"
-                              xmlns="http://www.w3.org/2000/svg"
-                            >
-                              <path
-                                d="M311.9 335.1l-132.4 136.8C174.1 477.3 167.1 480 160 480c-7.055 0-14.12-2.702-19.47-8.109l-132.4-136.8C-9.229 317.8 3.055 288 27.66 288h264.7C316.9 288 329.2 317.8 311.9 335.1z"
-                                fill="currentColor"
-                              />
-                            </svg>
-                          </div>
-                        </div>
-                      </div>
-                      <input
-                        name="namespaceDefinition"
-                        type="hidden"
-                        value="source"
-                      />
-                    </div>
-                  </div>
-                </div>
-              </span>
               <div
-                class="<removed-for-snapshot-test>"
+                class="leftFieldCol"
               >
                 <div
-                  class="<removed-for-snapshot-test>"
+                  class="controlContainer"
                 >
-                  <div
-                    class="<removed-for-snapshot-test>"
+                  <label
+                    class="sc-eCYdqJ cgRkWU"
                   >
-                    <label
-                      class="<removed-for-snapshot-test>"
-                    >
-                      Destination Stream Prefix (Optional)
-                      <span>
-                        <br />
-                        <span
-                          class="<removed-for-snapshot-test>"
-                        >
-                          Add a prefix to stream names (ex. “airbyte_” causes “projects” =&gt; “airbyte_projects”)
-                        </span>
+                    Destination Stream Prefix (Optional)
+                    <span>
+                      <br />
+                      <span
+                        class="sc-jSMfEi dkwDTm"
+                      >
+                        Add a prefix to stream names (ex. “airbyte_” causes “projects” =&gt; “airbyte_projects”)
                       </span>
-                    </label>
-                  </div>
-                </div>
-                <div
-                  class="<removed-for-snapshot-test>"
-                >
-                  <div
-                    class="<removed-for-snapshot-test>"
-                    data-testid="input-container"
-                  >
-                    <input
-                      class="<removed-for-snapshot-test>"
-                      data-testid="prefixInput"
-                      name="prefix"
-                      placeholder="prefix"
-                      style="pointer-events: auto;"
-                      type="text"
-                      value=""
-                    />
-                  </div>
-                </div>
-              </div>
-            </div>
-          </div>
-          <div
-            class="<removed-for-snapshot-test>"
-          >
-            <div
-              class="<removed-for-snapshot-test>"
-            >
-              <div
-                class="<removed-for-snapshot-test>"
-              >
-                <div
-                  class="<removed-for-snapshot-test>"
-                >
-                  <h5
-                    class="<removed-for-snapshot-test>"
-                  >
-                    Activate the streams you want to sync
-                  </h5>
-                  <button
-                    class="<removed-for-snapshot-test>"
-                    type="button"
-                  >
-                    <div
-                      class="<removed-for-snapshot-test>"
-                    >
-                      <svg
-                        aria-hidden="true"
-                        class="<removed-for-snapshot-test>"
-                        data-icon="rotate"
-                        data-prefix="fas"
-                        focusable="false"
-                        role="img"
-                        viewBox="0 0 512 512"
-                        xmlns="http://www.w3.org/2000/svg"
-                      >
-                        <path
-                          d="M449.9 39.96l-48.5 48.53C362.5 53.19 311.4 32 256 32C161.5 32 78.59 92.34 49.58 182.2c-5.438 16.81 3.797 34.88 20.61 40.28c16.97 5.5 34.86-3.812 40.3-20.59C130.9 138.5 189.4 96 256 96c37.96 0 73 14.18 100.2 37.8L311.1 178C295.1 194.8 306.8 223.4 330.4 224h146.9C487.7 223.7 496 215.3 496 204.9V59.04C496 34.99 466.9 22.95 449.9 39.96zM441.8 289.6c-16.94-5.438-34.88 3.812-40.3 20.59C381.1 373.5 322.6 416 256 416c-37.96 0-73-14.18-100.2-37.8L200 334C216.9 317.2 205.2 288.6 181.6 288H34.66C24.32 288.3 16 296.7 16 307.1v145.9c0 24.04 29.07 36.08 46.07 19.07l48.5-48.53C149.5 458.8 200.6 480 255.1 480c94.45 0 177.4-60.34 206.4-150.2C467.9 313 458.6 294.1 441.8 289.6z"
-                          fill="currentColor"
-                        />
-                      </svg>
-                      Refresh source schema
-                    </div>
-                  </button>
-                </div>
-                <div
-                  class="<removed-for-snapshot-test>"
-                >
-                  <div
-                    class="<removed-for-snapshot-test>"
-                    data-testid="input-container"
-                  >
-                    <input
-                      class="<removed-for-snapshot-test>"
-                      data-testid="input"
-                      placeholder="Search stream name"
-                    />
-                  </div>
-                </div>
-                <div
-                  class="<removed-for-snapshot-test>"
-                >
-                  <div
-                    class="<removed-for-snapshot-test>"
-                  >
-                    <label
-                      class="<removed-for-snapshot-test>"
-                    >
-                      <input
-                        class="<removed-for-snapshot-test>"
-                        type="checkbox"
-                      />
-                    </label>
-                  </div>
-                  <div
-                    class="<removed-for-snapshot-test>"
-                  />
-                  <div
-                    class="<removed-for-snapshot-test>"
-                  >
-                    Sync
-                  </div>
-                  <div
-                    class="<removed-for-snapshot-test>"
-                  >
-                    Source
-                    <div
-                      class="<removed-for-snapshot-test>"
-                    >
-                      <div
-                        class="<removed-for-snapshot-test>"
-                      >
-                        <div
-                          class="<removed-for-snapshot-test>"
-                        >
-                          <svg
-                            fill="none"
-                            height="14"
-                            viewBox="0 0 14 14"
-                            width="14"
-                          >
-                            <path
-                              d="M7.00016 13.6663C3.31816 13.6663 0.333496 10.6817 0.333496 6.99967C0.333496 3.31767 3.31816 0.333008 7.00016 0.333008C10.6822 0.333008 13.6668 3.31767 13.6668 6.99967C13.6668 10.6817 10.6822 13.6663 7.00016 13.6663ZM7.00016 12.333C8.41465 12.333 9.77121 11.7711 10.7714 10.7709C11.7716 9.77072 12.3335 8.41416 12.3335 6.99967C12.3335 5.58519 11.7716 4.22863 10.7714 3.22844C9.77121 2.22824 8.41465 1.66634 7.00016 1.66634C5.58567 1.66634 4.22912 2.22824 3.22893 3.22844C2.22873 4.22863 1.66683 5.58519 1.66683 6.99967C1.66683 8.41416 2.22873 9.77072 3.22893 10.7709C4.22912 11.7711 5.58567 12.333 7.00016 12.333ZM6.3335 3.66634H7.66683V4.99967H6.3335V3.66634ZM6.3335 6.33301H7.66683V10.333H6.3335V6.33301Z"
-                              fill="currentColor"
-                            />
-                          </svg>
-                        </div>
-                      </div>
-                    </div>
-                  </div>
-                  <div
-                    class="<removed-for-snapshot-test>"
-                  />
-                  <div
-                    class="<removed-for-snapshot-test>"
-                  >
-                    Sync mode
-                    <div
-                      class="<removed-for-snapshot-test>"
-                    >
-                      <div
-                        class="<removed-for-snapshot-test>"
-                      >
-                        <div
-                          class="<removed-for-snapshot-test>"
-                        >
-                          <svg
-                            fill="none"
-                            height="14"
-                            viewBox="0 0 14 14"
-                            width="14"
-                          >
-                            <path
-                              d="M7.00016 13.6663C3.31816 13.6663 0.333496 10.6817 0.333496 6.99967C0.333496 3.31767 3.31816 0.333008 7.00016 0.333008C10.6822 0.333008 13.6668 3.31767 13.6668 6.99967C13.6668 10.6817 10.6822 13.6663 7.00016 13.6663ZM7.00016 12.333C8.41465 12.333 9.77121 11.7711 10.7714 10.7709C11.7716 9.77072 12.3335 8.41416 12.3335 6.99967C12.3335 5.58519 11.7716 4.22863 10.7714 3.22844C9.77121 2.22824 8.41465 1.66634 7.00016 1.66634C5.58567 1.66634 4.22912 2.22824 3.22893 3.22844C2.22873 4.22863 1.66683 5.58519 1.66683 6.99967C1.66683 8.41416 2.22873 9.77072 3.22893 10.7709C4.22912 11.7711 5.58567 12.333 7.00016 12.333ZM6.3335 3.66634H7.66683V4.99967H6.3335V3.66634ZM6.3335 6.33301H7.66683V10.333H6.3335V6.33301Z"
-                              fill="currentColor"
-                            />
-                          </svg>
-                        </div>
-                      </div>
-                    </div>
-                  </div>
-                  <div
-                    class="<removed-for-snapshot-test>"
-                  >
-                    Cursor field
-                    <div
-                      class="<removed-for-snapshot-test>"
-                    >
-                      <div
-                        class="<removed-for-snapshot-test>"
-                      >
-                        <div
-                          class="<removed-for-snapshot-test>"
-                        >
-                          <svg
-                            fill="none"
-                            height="14"
-                            viewBox="0 0 14 14"
-                            width="14"
-                          >
-                            <path
-                              d="M7.00016 13.6663C3.31816 13.6663 0.333496 10.6817 0.333496 6.99967C0.333496 3.31767 3.31816 0.333008 7.00016 0.333008C10.6822 0.333008 13.6668 3.31767 13.6668 6.99967C13.6668 10.6817 10.6822 13.6663 7.00016 13.6663ZM7.00016 12.333C8.41465 12.333 9.77121 11.7711 10.7714 10.7709C11.7716 9.77072 12.3335 8.41416 12.3335 6.99967C12.3335 5.58519 11.7716 4.22863 10.7714 3.22844C9.77121 2.22824 8.41465 1.66634 7.00016 1.66634C5.58567 1.66634 4.22912 2.22824 3.22893 3.22844C2.22873 4.22863 1.66683 5.58519 1.66683 6.99967C1.66683 8.41416 2.22873 9.77072 3.22893 10.7709C4.22912 11.7711 5.58567 12.333 7.00016 12.333ZM6.3335 3.66634H7.66683V4.99967H6.3335V3.66634ZM6.3335 6.33301H7.66683V10.333H6.3335V6.33301Z"
-                              fill="currentColor"
-                            />
-                          </svg>
-                        </div>
-                      </div>
-                    </div>
-                  </div>
-                  <div
-                    class="<removed-for-snapshot-test>"
-                  >
-                    Primary key
-                    <div
-                      class="<removed-for-snapshot-test>"
-                    >
-                      <div
-                        class="<removed-for-snapshot-test>"
-                      >
-                        <div
-                          class="<removed-for-snapshot-test>"
-                        >
-                          <svg
-                            fill="none"
-                            height="14"
-                            viewBox="0 0 14 14"
-                            width="14"
-                          >
-                            <path
-                              d="M7.00016 13.6663C3.31816 13.6663 0.333496 10.6817 0.333496 6.99967C0.333496 3.31767 3.31816 0.333008 7.00016 0.333008C10.6822 0.333008 13.6668 3.31767 13.6668 6.99967C13.6668 10.6817 10.6822 13.6663 7.00016 13.6663ZM7.00016 12.333C8.41465 12.333 9.77121 11.7711 10.7714 10.7709C11.7716 9.77072 12.3335 8.41416 12.3335 6.99967C12.3335 5.58519 11.7716 4.22863 10.7714 3.22844C9.77121 2.22824 8.41465 1.66634 7.00016 1.66634C5.58567 1.66634 4.22912 2.22824 3.22893 3.22844C2.22873 4.22863 1.66683 5.58519 1.66683 6.99967C1.66683 8.41416 2.22873 9.77072 3.22893 10.7709C4.22912 11.7711 5.58567 12.333 7.00016 12.333ZM6.3335 3.66634H7.66683V4.99967H6.3335V3.66634ZM6.3335 6.33301H7.66683V10.333H6.3335V6.33301Z"
-                              fill="currentColor"
-                            />
-                          </svg>
-                        </div>
-                      </div>
-                    </div>
-                  </div>
-                  <div
-                    class="<removed-for-snapshot-test>"
-                  >
-                    Destination
-                    <div
-                      class="<removed-for-snapshot-test>"
-                    >
-                      <div
-                        class="<removed-for-snapshot-test>"
-                      >
-                        <div
-                          class="<removed-for-snapshot-test>"
-                        >
-                          <svg
-                            fill="none"
-                            height="14"
-                            viewBox="0 0 14 14"
-                            width="14"
-                          >
-                            <path
-                              d="M7.00016 13.6663C3.31816 13.6663 0.333496 10.6817 0.333496 6.99967C0.333496 3.31767 3.31816 0.333008 7.00016 0.333008C10.6822 0.333008 13.6668 3.31767 13.6668 6.99967C13.6668 10.6817 10.6822 13.6663 7.00016 13.6663ZM7.00016 12.333C8.41465 12.333 9.77121 11.7711 10.7714 10.7709C11.7716 9.77072 12.3335 8.41416 12.3335 6.99967C12.3335 5.58519 11.7716 4.22863 10.7714 3.22844C9.77121 2.22824 8.41465 1.66634 7.00016 1.66634C5.58567 1.66634 4.22912 2.22824 3.22893 3.22844C2.22873 4.22863 1.66683 5.58519 1.66683 6.99967C1.66683 8.41416 2.22873 9.77072 3.22893 10.7709C4.22912 11.7711 5.58567 12.333 7.00016 12.333ZM6.3335 3.66634H7.66683V4.99967H6.3335V3.66634ZM6.3335 6.33301H7.66683V10.333H6.3335V6.33301Z"
-                              fill="currentColor"
-                            />
-                          </svg>
-                        </div>
-                      </div>
-                    </div>
-                  </div>
-                  <div
-                    class="<removed-for-snapshot-test>"
-                  />
-                </div>
-                <div
-                  class="<removed-for-snapshot-test>"
-                >
-                  <div
-                    class="<removed-for-snapshot-test>"
-                  >
-                    Namespace
-                  </div>
-                  <div
-                    class="<removed-for-snapshot-test>"
-                  >
-                    Stream name
-                  </div>
-                  <div
-                    class="<removed-for-snapshot-test>"
-                  >
-                    Source | Destination
-                  </div>
-                  <div
-                    class="<removed-for-snapshot-test>"
-                  />
-                  <div
-                    class="<removed-for-snapshot-test>"
-                  />
-                  <div
-                    class="<removed-for-snapshot-test>"
-                  >
-                    Namespace
-                  </div>
-                  <div
-                    class="<removed-for-snapshot-test>"
-                  >
-                    Stream name
-                  </div>
-                </div>
-                <div
-                  class="<removed-for-snapshot-test>"
-                >
-                  <div
-                    class="<removed-for-snapshot-test>"
-                  >
-                    <div
-                      class="<removed-for-snapshot-test>"
-                    >
-                      <div
-                        class="<removed-for-snapshot-test>"
-                      >
-                        <label
-                          class="<removed-for-snapshot-test>"
-                        >
-                          <input
-                            class="<removed-for-snapshot-test>"
-                            type="checkbox"
-                          />
-                        </label>
-                      </div>
-                      <div
-                        class="<removed-for-snapshot-test>"
-                      >
-                        <span
-                          class="<removed-for-snapshot-test>"
-                        >
-                          <svg
-                            aria-hidden="true"
-                            class="<removed-for-snapshot-test>"
-                            data-icon="chevron-right"
-                            data-prefix="fas"
-                            focusable="false"
-                            role="img"
-                            viewBox="0 0 320 512"
-                            xmlns="http://www.w3.org/2000/svg"
-                          >
-                            <path
-                              d="M96 480c-8.188 0-16.38-3.125-22.62-9.375c-12.5-12.5-12.5-32.75 0-45.25L242.8 256L73.38 86.63c-12.5-12.5-12.5-32.75 0-45.25s32.75-12.5 45.25 0l192 192c12.5 12.5 12.5 32.75 0 45.25l-192 192C112.4 476.9 104.2 480 96 480z"
-                              fill="currentColor"
-                            />
-                          </svg>
-                        </span>
-                      </div>
-                      <div
-                        class="<removed-for-snapshot-test>"
-                      >
-                        <div
-                          class="<removed-for-snapshot-test>"
-                        >
-                          <label
-                            class="<removed-for-snapshot-test>"
-                          >
-                            <input
-                              checked=""
-                              class="<removed-for-snapshot-test>"
-                              type="checkbox"
-                              value=""
-                            />
-                            <span
-                              class="<removed-for-snapshot-test>"
-                            />
-                          </label>
-                        </div>
-                        <div
-                          class="<removed-for-snapshot-test>"
-                          title=""
-                        >
-                          <span
-                            class="<removed-for-snapshot-test>"
-                          >
-                            No namespace
-                          </span>
-                        </div>
-                        <div
-                          class="<removed-for-snapshot-test>"
-                          title="pokemon"
-                        >
-                          pokemon
-                        </div>
-                        <div
-                          class="<removed-for-snapshot-test>"
-                        >
-                          <div
-                            class="<removed-for-snapshot-test>"
-                            data-testid="syncSettingsDropdown"
-                            role="combobox"
-                          >
-                            <span
-                              class="<removed-for-snapshot-test>"
-                              id="react-select-4-live-region"
-                            />
-                            <span
-                              aria-atomic="false"
-                              aria-live="polite"
-                              aria-relevant="additions text"
-                              class="<removed-for-snapshot-test>"
-                            />
-                            <div
-                              class="<removed-for-snapshot-test>"
-                            >
-                              <div
-                                class="<removed-for-snapshot-test>"
-                              >
-                                <div
-                                  class="<removed-for-snapshot-test>"
-                                >
-                                  <div
-                                    class="<removed-for-snapshot-test>"
-                                  >
-                                    <div>
-                                      Full refresh
-                                    </div>
-                                    <div
-                                      class="<removed-for-snapshot-test>"
-                                    >
-                                      |
-                                    </div>
-                                    <div>
-                                      Overwrite
-                                    </div>
-                                  </div>
-                                </div>
-                                <input
-                                  aria-autocomplete="list"
-                                  aria-expanded="false"
-                                  aria-haspopup="true"
-                                  aria-readonly="true"
-                                  class="<removed-for-snapshot-test>"
-                                  id="react-select-4-input"
-                                  inputmode="none"
-                                  role="combobox"
-                                  tabindex="0"
-                                  value=""
-                                />
-                              </div>
-                              <div
-                                class="<removed-for-snapshot-test>"
-                              >
-                                <div
-                                  aria-hidden="true"
-                                  class="<removed-for-snapshot-test>"
-                                >
-                                  <svg
-                                    aria-hidden="true"
-                                    class="<removed-for-snapshot-test>"
-                                    data-icon="sort-down"
-                                    data-prefix="fas"
-                                    focusable="false"
-                                    role="img"
-                                    viewBox="0 0 320 512"
-                                    xmlns="http://www.w3.org/2000/svg"
-                                  >
-                                    <path
-                                      d="M311.9 335.1l-132.4 136.8C174.1 477.3 167.1 480 160 480c-7.055 0-14.12-2.702-19.47-8.109l-132.4-136.8C-9.229 317.8 3.055 288 27.66 288h264.7C316.9 288 329.2 317.8 311.9 335.1z"
-                                      fill="currentColor"
-                                    />
-                                  </svg>
-                                </div>
-                              </div>
-                            </div>
-                          </div>
-                        </div>
-                        <div
-                          class="<removed-for-snapshot-test>"
-                        />
-                        <div
-                          class="<removed-for-snapshot-test>"
-                        />
-                        <div
-                          class="<removed-for-snapshot-test>"
-                          title="'<source schema>"
-                        >
-                          '&lt;source schema&gt;
-                        </div>
-                        <div
-                          class="<removed-for-snapshot-test>"
-                          title="pokemon"
-                        >
-                          pokemon
-                        </div>
-                      </div>
-                    </div>
-                  </div>
-                </div>
-              </div>
-            </div>
-          </div>
-        </div>
-        <div
-          class="<removed-for-snapshot-test>"
-        >
-          <div
-            class="<removed-for-snapshot-test>"
-          >
-            <div
-              class="<removed-for-snapshot-test>"
-            >
-              <h5
-                class="<removed-for-snapshot-test>"
-              >
-                Normalization & Transformation
-              </h5>
-              <div
-                class="<removed-for-snapshot-test>"
-              >
-                <div
-                  class="<removed-for-snapshot-test>"
-                >
-                  <label
-                    class="<removed-for-snapshot-test>"
-                  >
-                    <div
-                      class="<removed-for-snapshot-test>"
-                    />
-                    <input
-                      class="<removed-for-snapshot-test>"
-                      id="radiobutton-normalization.raw"
-                      label="[object Object]"
-                      name="normalization"
-                      type="radio"
-                      value="raw"
-                    />
-                  </label>
-                  <label
-                    class="<removed-for-snapshot-test>"
-                    for="radiobutton-normalization.raw"
-                  >
-                    Raw data (JSON)
-                    <span
-                      class="<removed-for-snapshot-test>"
-                    />
-                  </label>
-                </div>
-                <div
-                  class="<removed-for-snapshot-test>"
-                >
-                  <label
-                    class="<removed-for-snapshot-test>"
-                  >
-                    <div
-                      class="<removed-for-snapshot-test>"
-                    />
-                    <input
-                      checked=""
-                      class="<removed-for-snapshot-test>"
-                      id="radiobutton-normalization.basic"
-                      label="[object Object]"
-                      name="normalization"
-                      type="radio"
-                      value="basic"
-                    />
-                  </label>
-                  <label
-                    class="<removed-for-snapshot-test>"
-                    for="radiobutton-normalization.basic"
-                  >
-                    Normalized tabular data
-                    <span
-                      class="<removed-for-snapshot-test>"
-                    >
-                      Map the JSON object to the types and format native to the destination. 
-                      <a
-                        class="<removed-for-snapshot-test>"
-                        href="https://docs.airbyte.com/understanding-airbyte/connections#airbyte-basic-normalization"
-                        target="_blank"
-                      >
-                        Learn more
-                      </a>
                     </span>
                   </label>
                 </div>
               </div>
               <div
-                class="<removed-for-snapshot-test>"
+                class="rightFieldCol"
               >
                 <div
-                  class="<removed-for-snapshot-test>"
+                  class="container"
+                  data-testid="input-container"
                 >
-                  No custom transformation
-                  <button
-                    class="<removed-for-snapshot-test>"
-                    data-testid="addItemButton"
-                    type="button"
-                  >
-                    <div
-                      class="<removed-for-snapshot-test>"
-                    >
-                      + Add transformation
-                    </div>
-                  </button>
+                  <input
+                    class="input"
+                    data-testid="prefixInput"
+                    name="prefix"
+                    placeholder="prefix"
+                    style="pointer-events: auto;"
+                    type="text"
+                    value=""
+                  />
                 </div>
               </div>
             </div>
           </div>
         </div>
         <div
-          class="<removed-for-snapshot-test>"
+          class="container"
         >
-          <div />
-          <div>
-            <button
-              class="<removed-for-snapshot-test>"
-              type="submit"
+          <div
+            class="section"
+          >
+            <div
+              class="loadingBackdropContainer"
             >
               <div
-                class="<removed-for-snapshot-test>"
+                class="sc-bUbCnL keYsWp"
               >
-                Set up connection
+                <h5
+                  class="sc-bczRLJ sc-dkzDqf UeZWt ebWyjL"
+                >
+                  Activate the streams you want to sync
+                </h5>
+                <button
+                  class="button sizeXS typeSecondary"
+                  type="button"
+                >
+                  <div
+                    class="childrenContainer"
+                  >
+                    <svg
+                      aria-hidden="true"
+                      class="svg-inline--fa fa-rotate tryArrow"
+                      data-icon="rotate"
+                      data-prefix="fas"
+                      focusable="false"
+                      role="img"
+                      viewBox="0 0 512 512"
+                      xmlns="http://www.w3.org/2000/svg"
+                    >
+                      <path
+                        d="M449.9 39.96l-48.5 48.53C362.5 53.19 311.4 32 256 32C161.5 32 78.59 92.34 49.58 182.2c-5.438 16.81 3.797 34.88 20.61 40.28c16.97 5.5 34.86-3.812 40.3-20.59C130.9 138.5 189.4 96 256 96c37.96 0 73 14.18 100.2 37.8L311.1 178C295.1 194.8 306.8 223.4 330.4 224h146.9C487.7 223.7 496 215.3 496 204.9V59.04C496 34.99 466.9 22.95 449.9 39.96zM441.8 289.6c-16.94-5.438-34.88 3.812-40.3 20.59C381.1 373.5 322.6 416 256 416c-37.96 0-73-14.18-100.2-37.8L200 334C216.9 317.2 205.2 288.6 181.6 288H34.66C24.32 288.3 16 296.7 16 307.1v145.9c0 24.04 29.07 36.08 46.07 19.07l48.5-48.53C149.5 458.8 200.6 480 255.1 480c94.45 0 177.4-60.34 206.4-150.2C467.9 313 458.6 294.1 441.8 289.6z"
+                        fill="currentColor"
+                      />
+                    </svg>
+                    Refresh source schema
+                  </div>
+                </button>
               </div>
-            </button>
+              <div
+                class="sc-ZyCDH gpzrdJ"
+              >
+                <div
+                  class="container"
+                  data-testid="input-container"
+                >
+                  <input
+                    class="input sc-jIAOiI bxGgcg"
+                    data-testid="input"
+                    placeholder="Search stream name"
+                  />
+                </div>
+              </div>
+              <div
+                class="sc-ksZaOG sc-hAZoDl fmKtaK jIJKIB catalogHeader"
+              >
+                <div
+                  class="sc-fnykZs imOUQR checkboxCell"
+                >
+                  <label
+                    class="sc-crXcEl iWbiAC"
+                  >
+                    <input
+                      class="sc-iqcoie djcshM"
+                      type="checkbox"
+                    />
+                  </label>
+                </div>
+                <div
+                  class="sc-fnykZs jUKmJs"
+                />
+                <div
+                  class="sc-fnykZs bOivtp"
+                >
+                  Sync
+                </div>
+                <div
+                  class="sc-fnykZs VApCG"
+                >
+                  Source
+                  <div
+                    class="container"
+                  >
+                    <div
+                      class="container"
+                    >
+                      <div
+                        class="icon"
+                      >
+                        <svg
+                          fill="none"
+                          height="14"
+                          viewBox="0 0 14 14"
+                          width="14"
+                        >
+                          <path
+                            d="M7.00016 13.6663C3.31816 13.6663 0.333496 10.6817 0.333496 6.99967C0.333496 3.31767 3.31816 0.333008 7.00016 0.333008C10.6822 0.333008 13.6668 3.31767 13.6668 6.99967C13.6668 10.6817 10.6822 13.6663 7.00016 13.6663ZM7.00016 12.333C8.41465 12.333 9.77121 11.7711 10.7714 10.7709C11.7716 9.77072 12.3335 8.41416 12.3335 6.99967C12.3335 5.58519 11.7716 4.22863 10.7714 3.22844C9.77121 2.22824 8.41465 1.66634 7.00016 1.66634C5.58567 1.66634 4.22912 2.22824 3.22893 3.22844C2.22873 4.22863 1.66683 5.58519 1.66683 6.99967C1.66683 8.41416 2.22873 9.77072 3.22893 10.7709C4.22912 11.7711 5.58567 12.333 7.00016 12.333ZM6.3335 3.66634H7.66683V4.99967H6.3335V3.66634ZM6.3335 6.33301H7.66683V10.333H6.3335V6.33301Z"
+                            fill="currentColor"
+                          />
+                        </svg>
+                      </div>
+                    </div>
+                  </div>
+                </div>
+                <div
+                  class="sc-fnykZs imOUQR"
+                />
+                <div
+                  class="sc-fnykZs ciVNhF"
+                >
+                  Sync mode
+                  <div
+                    class="container"
+                  >
+                    <div
+                      class="container"
+                    >
+                      <div
+                        class="icon"
+                      >
+                        <svg
+                          fill="none"
+                          height="14"
+                          viewBox="0 0 14 14"
+                          width="14"
+                        >
+                          <path
+                            d="M7.00016 13.6663C3.31816 13.6663 0.333496 10.6817 0.333496 6.99967C0.333496 3.31767 3.31816 0.333008 7.00016 0.333008C10.6822 0.333008 13.6668 3.31767 13.6668 6.99967C13.6668 10.6817 10.6822 13.6663 7.00016 13.6663ZM7.00016 12.333C8.41465 12.333 9.77121 11.7711 10.7714 10.7709C11.7716 9.77072 12.3335 8.41416 12.3335 6.99967C12.3335 5.58519 11.7716 4.22863 10.7714 3.22844C9.77121 2.22824 8.41465 1.66634 7.00016 1.66634C5.58567 1.66634 4.22912 2.22824 3.22893 3.22844C2.22873 4.22863 1.66683 5.58519 1.66683 6.99967C1.66683 8.41416 2.22873 9.77072 3.22893 10.7709C4.22912 11.7711 5.58567 12.333 7.00016 12.333ZM6.3335 3.66634H7.66683V4.99967H6.3335V3.66634ZM6.3335 6.33301H7.66683V10.333H6.3335V6.33301Z"
+                            fill="currentColor"
+                          />
+                        </svg>
+                      </div>
+                    </div>
+                  </div>
+                </div>
+                <div
+                  class="sc-fnykZs VApCG"
+                >
+                  Cursor field
+                  <div
+                    class="container"
+                  >
+                    <div
+                      class="container"
+                    >
+                      <div
+                        class="icon"
+                      >
+                        <svg
+                          fill="none"
+                          height="14"
+                          viewBox="0 0 14 14"
+                          width="14"
+                        >
+                          <path
+                            d="M7.00016 13.6663C3.31816 13.6663 0.333496 10.6817 0.333496 6.99967C0.333496 3.31767 3.31816 0.333008 7.00016 0.333008C10.6822 0.333008 13.6668 3.31767 13.6668 6.99967C13.6668 10.6817 10.6822 13.6663 7.00016 13.6663ZM7.00016 12.333C8.41465 12.333 9.77121 11.7711 10.7714 10.7709C11.7716 9.77072 12.3335 8.41416 12.3335 6.99967C12.3335 5.58519 11.7716 4.22863 10.7714 3.22844C9.77121 2.22824 8.41465 1.66634 7.00016 1.66634C5.58567 1.66634 4.22912 2.22824 3.22893 3.22844C2.22873 4.22863 1.66683 5.58519 1.66683 6.99967C1.66683 8.41416 2.22873 9.77072 3.22893 10.7709C4.22912 11.7711 5.58567 12.333 7.00016 12.333ZM6.3335 3.66634H7.66683V4.99967H6.3335V3.66634ZM6.3335 6.33301H7.66683V10.333H6.3335V6.33301Z"
+                            fill="currentColor"
+                          />
+                        </svg>
+                      </div>
+                    </div>
+                  </div>
+                </div>
+                <div
+                  class="sc-fnykZs VApCG"
+                >
+                  Primary key
+                  <div
+                    class="container"
+                  >
+                    <div
+                      class="container"
+                    >
+                      <div
+                        class="icon"
+                      >
+                        <svg
+                          fill="none"
+                          height="14"
+                          viewBox="0 0 14 14"
+                          width="14"
+                        >
+                          <path
+                            d="M7.00016 13.6663C3.31816 13.6663 0.333496 10.6817 0.333496 6.99967C0.333496 3.31767 3.31816 0.333008 7.00016 0.333008C10.6822 0.333008 13.6668 3.31767 13.6668 6.99967C13.6668 10.6817 10.6822 13.6663 7.00016 13.6663ZM7.00016 12.333C8.41465 12.333 9.77121 11.7711 10.7714 10.7709C11.7716 9.77072 12.3335 8.41416 12.3335 6.99967C12.3335 5.58519 11.7716 4.22863 10.7714 3.22844C9.77121 2.22824 8.41465 1.66634 7.00016 1.66634C5.58567 1.66634 4.22912 2.22824 3.22893 3.22844C2.22873 4.22863 1.66683 5.58519 1.66683 6.99967C1.66683 8.41416 2.22873 9.77072 3.22893 10.7709C4.22912 11.7711 5.58567 12.333 7.00016 12.333ZM6.3335 3.66634H7.66683V4.99967H6.3335V3.66634ZM6.3335 6.33301H7.66683V10.333H6.3335V6.33301Z"
+                            fill="currentColor"
+                          />
+                        </svg>
+                      </div>
+                    </div>
+                  </div>
+                </div>
+                <div
+                  class="sc-fnykZs VApCG"
+                >
+                  Destination
+                  <div
+                    class="container"
+                  >
+                    <div
+                      class="container"
+                    >
+                      <div
+                        class="icon"
+                      >
+                        <svg
+                          fill="none"
+                          height="14"
+                          viewBox="0 0 14 14"
+                          width="14"
+                        >
+                          <path
+                            d="M7.00016 13.6663C3.31816 13.6663 0.333496 10.6817 0.333496 6.99967C0.333496 3.31767 3.31816 0.333008 7.00016 0.333008C10.6822 0.333008 13.6668 3.31767 13.6668 6.99967C13.6668 10.6817 10.6822 13.6663 7.00016 13.6663ZM7.00016 12.333C8.41465 12.333 9.77121 11.7711 10.7714 10.7709C11.7716 9.77072 12.3335 8.41416 12.3335 6.99967C12.3335 5.58519 11.7716 4.22863 10.7714 3.22844C9.77121 2.22824 8.41465 1.66634 7.00016 1.66634C5.58567 1.66634 4.22912 2.22824 3.22893 3.22844C2.22873 4.22863 1.66683 5.58519 1.66683 6.99967C1.66683 8.41416 2.22873 9.77072 3.22893 10.7709C4.22912 11.7711 5.58567 12.333 7.00016 12.333ZM6.3335 3.66634H7.66683V4.99967H6.3335V3.66634ZM6.3335 6.33301H7.66683V10.333H6.3335V6.33301Z"
+                            fill="currentColor"
+                          />
+                        </svg>
+                      </div>
+                    </div>
+                  </div>
+                </div>
+                <div
+                  class="sc-fnykZs imOUQR"
+                />
+              </div>
+              <div
+                class="sc-ksZaOG sc-hAZoDl fmKtaK jIJKIB catalogSubheader"
+              >
+                <div
+                  class="sc-fnykZs sc-hlnMnd VApCG ezaSgM"
+                >
+                  Namespace
+                </div>
+                <div
+                  class="sc-fnykZs sc-hlnMnd VApCG ezaSgM"
+                >
+                  Stream name
+                </div>
+                <div
+                  class="sc-fnykZs sc-hlnMnd ciVNhF ezaSgM"
+                >
+                  Source | Destination
+                </div>
+                <div
+                  class="sc-fnykZs sc-hlnMnd sc-eKBdFk VApCG ezaSgM iBiQnB"
+                />
+                <div
+                  class="sc-fnykZs sc-hlnMnd sc-eKBdFk VApCG ezaSgM iBiQnB"
+                />
+                <div
+                  class="sc-fnykZs sc-hlnMnd VApCG ezaSgM"
+                >
+                  Namespace
+                </div>
+                <div
+                  class="sc-fnykZs sc-hlnMnd VApCG ezaSgM"
+                >
+                  Stream name
+                </div>
+              </div>
+              <div
+                class="sc-jOhDuK iHjNjo"
+              >
+                <div
+                  class="catalogSection"
+                >
+                  <div
+                    class="sc-ksZaOG fmKtaK catalogSectionRow"
+                  >
+                    <div
+                      class="checkboxCell streamRowCheckboxCell"
+                    >
+                      <label
+                        class="sc-crXcEl iWbiAC"
+                      >
+                        <input
+                          class="sc-iqcoie djcshM"
+                          type="checkbox"
+                        />
+                      </label>
+                    </div>
+                    <div
+                      class="sc-fnykZs sc-jgbSNz sc-lbxAil imOUQR dkANJX bHBjjw"
+                    >
+                      <span
+                        class="sc-hiMGwR kmDbQS"
+                      >
+                        <svg
+                          aria-hidden="true"
+                          class="svg-inline--fa fa-chevron-right sc-ehmTmK eOIlNv"
+                          data-icon="chevron-right"
+                          data-prefix="fas"
+                          focusable="false"
+                          role="img"
+                          viewBox="0 0 320 512"
+                          xmlns="http://www.w3.org/2000/svg"
+                        >
+                          <path
+                            d="M96 480c-8.188 0-16.38-3.125-22.62-9.375c-12.5-12.5-12.5-32.75 0-45.25L242.8 256L73.38 86.63c-12.5-12.5-12.5-32.75 0-45.25s32.75-12.5 45.25 0l192 192c12.5 12.5 12.5 32.75 0 45.25l-192 192C112.4 476.9 104.2 480 96 480z"
+                            fill="currentColor"
+                          />
+                        </svg>
+                      </span>
+                    </div>
+                    <div
+                      class="streamHeaderContent"
+                    >
+                      <div
+                        class="sc-fnykZs sc-jgbSNz hgpwyO dkANJX"
+                      >
+                        <label
+                          class="switch small"
+                        >
+                          <input
+                            checked=""
+                            class="switchInput"
+                            type="checkbox"
+                            value=""
+                          />
+                          <span
+                            class="slider small"
+                          />
+                        </label>
+                      </div>
+                      <div
+                        class="sc-fnykZs sc-jgbSNz kjjuyS dkANJX"
+                        title=""
+                      >
+                        <span
+                          class="sc-fXynhf sAcSt"
+                        >
+                          No namespace
+                        </span>
+                      </div>
+                      <div
+                        class="sc-fnykZs sc-jgbSNz kjjuyS dkANJX"
+                        title="pokemon"
+                      >
+                        pokemon
+                      </div>
+                      <div
+                        class="sc-fnykZs bKHgDK"
+                      >
+                        <div
+                          class="sc-cOFTSb jqsVWu react-select-container css-b62m3t-container"
+                          data-testid="syncSettingsDropdown"
+                          role="combobox"
+                        >
+                          <span
+                            class="css-1f43avz-a11yText-A11yText"
+                            id="react-select-4-live-region"
+                          />
+                          <span
+                            aria-atomic="false"
+                            aria-live="polite"
+                            aria-relevant="additions text"
+                            class="css-1f43avz-a11yText-A11yText"
+                          />
+                          <div
+                            class="sc-GVOUr ldWtuj react-select__control css-1s2u09g-control"
+                          >
+                            <div
+                              class="react-select__value-container react-select__value-container--has-value css-dlobye-Component"
+                            >
+                              <div
+                                class="sc-iAvgwm fQiUpU"
+                              >
+                                <div
+                                  class="sc-lbOyJj cHLvYg react-select__single-value css-qc6sy-singleValue"
+                                >
+                                  <div>
+                                    Full refresh
+                                  </div>
+                                  <div
+                                    class="sc-gFGZVQ ijSWZb"
+                                  >
+                                    |
+                                  </div>
+                                  <div>
+                                    Overwrite
+                                  </div>
+                                </div>
+                              </div>
+                              <input
+                                aria-autocomplete="list"
+                                aria-expanded="false"
+                                aria-haspopup="true"
+                                aria-readonly="true"
+                                class="css-mohuvp-dummyInput-DummyInput"
+                                id="react-select-4-input"
+                                inputmode="none"
+                                role="combobox"
+                                tabindex="0"
+                                value=""
+                              />
+                            </div>
+                            <div
+                              class="react-select__indicators css-ny0e4k-Component"
+                            >
+                              <div
+                                aria-hidden="true"
+                                class="react-select__indicator react-select__dropdown-indicator css-tlfecz-indicatorContainer"
+                              >
+                                <svg
+                                  aria-hidden="true"
+                                  class="svg-inline--fa fa-sort-down sc-dPyBCJ eGVczJ"
+                                  data-icon="sort-down"
+                                  data-prefix="fas"
+                                  focusable="false"
+                                  role="img"
+                                  viewBox="0 0 320 512"
+                                  xmlns="http://www.w3.org/2000/svg"
+                                >
+                                  <path
+                                    d="M311.9 335.1l-132.4 136.8C174.1 477.3 167.1 480 160 480c-7.055 0-14.12-2.702-19.47-8.109l-132.4-136.8C-9.229 317.8 3.055 288 27.66 288h264.7C316.9 288 329.2 317.8 311.9 335.1z"
+                                    fill="currentColor"
+                                  />
+                                </svg>
+                              </div>
+                            </div>
+                          </div>
+                        </div>
+                      </div>
+                      <div
+                        class="sc-fnykZs sc-jgbSNz imOUQR dkANJX"
+                      />
+                      <div
+                        class="sc-fnykZs sc-jgbSNz kjjuyS dkANJX"
+                      />
+                      <div
+                        class="sc-fnykZs sc-jgbSNz kjjuyS dkANJX"
+                        title="'<source schema>"
+                      >
+                        '&lt;source schema&gt;
+                      </div>
+                      <div
+                        class="sc-fnykZs sc-jgbSNz kjjuyS dkANJX"
+                        title="pokemon"
+                      >
+                        pokemon
+                      </div>
+                    </div>
+                  </div>
+                </div>
+              </div>
+            </div>
           </div>
         </div>
-      </form>
-    </div>
+      </div>
+      <div
+        class="container"
+      >
+        <div
+          class="container"
+        >
+          <div
+            class="section"
+          >
+            <h5
+              class="heading md"
+            >
+              Normalization & Transformation
+            </h5>
+            <div
+              class="sc-iTONeN jVBGIe"
+            >
+              <div
+                class="sc-papXJ jBZEjH"
+              >
+                <label
+                  class="sc-ftvSup eAaJEM"
+                >
+                  <div
+                    class="sc-iBkjds btSpQj"
+                  />
+                  <input
+                    class="sc-gKXOVf iqfEmu"
+                    id="radiobutton-normalization.raw"
+                    label="[object Object]"
+                    name="normalization"
+                    type="radio"
+                    value="raw"
+                  />
+                </label>
+                <label
+                  class="sc-jqUVSM jYhteM"
+                  for="radiobutton-normalization.raw"
+                >
+                  Raw data (JSON)
+                  <span
+                    class="sc-kDDrLX iVZNpR"
+                  />
+                </label>
+              </div>
+              <div
+                class="sc-papXJ jBZEjH"
+              >
+                <label
+                  class="sc-ftvSup eAaJEM"
+                >
+                  <div
+                    class="sc-iBkjds btSpQj"
+                  />
+                  <input
+                    checked=""
+                    class="sc-gKXOVf iqfEmu"
+                    id="radiobutton-normalization.basic"
+                    label="[object Object]"
+                    name="normalization"
+                    type="radio"
+                    value="basic"
+                  />
+                </label>
+                <label
+                  class="sc-jqUVSM jYhteM"
+                  for="radiobutton-normalization.basic"
+                >
+                  Normalized tabular data
+                  <span
+                    class="sc-kDDrLX iVZNpR"
+                  >
+                    Map the JSON object to the types and format native to the destination. 
+                    <a
+                      class="sc-evZas hBbGvM"
+                      href="https://docs.airbyte.com/understanding-airbyte/connections#airbyte-basic-normalization"
+                      target="_blank"
+                    >
+                      Learn more
+                    </a>
+                  </span>
+                </label>
+              </div>
+            </div>
+            <div
+              class="container"
+            >
+              <div
+                class="sc-hKMtZM bXwcwi"
+              >
+                No custom transformation
+                <button
+                  class="button sizeXS typeSecondary"
+                  data-testid="addItemButton"
+                  type="button"
+                >
+                  <div
+                    class="childrenContainer"
+                  >
+                    + Add transformation
+                  </div>
+                </button>
+              </div>
+            </div>
+          </div>
+        </div>
+      </div>
+      <div
+        class="sc-jIZahH gCZAUv"
+      >
+        <div />
+        <div>
+          <button
+            class="button sizeXS typePrimary"
+            type="submit"
+          >
+            <div
+              class="childrenContainer"
+            >
+              Set up connection
+            </div>
+          </button>
+        </div>
+      </div>
+    </form>
   </div>
-</body>
+</div>
 `;
 
 exports[`CreateConnectionForm should render when loading 1`] = `

--- a/airbyte-webapp/src/components/CreateConnection/__snapshots__/CreateConnectionForm.test.tsx.snap
+++ b/airbyte-webapp/src/components/CreateConnection/__snapshots__/CreateConnectionForm.test.tsx.snap
@@ -160,7 +160,7 @@ exports[`CreateConnectionForm should render 1`] = `
                         >
                           <svg
                             aria-hidden="true"
-                            class="svg-inline--fa fa-sort-down sc-jOrMOR jXccHI"
+                            class="<removed-for-snapshot-test>"
                             data-icon="sort-down"
                             data-prefix="fas"
                             focusable="false"
@@ -283,7 +283,7 @@ exports[`CreateConnectionForm should render 1`] = `
                           >
                             <svg
                               aria-hidden="true"
-                              class="svg-inline--fa fa-sort-down sc-jOrMOR jXccHI"
+                              class="<removed-for-snapshot-test>"
                               data-icon="sort-down"
                               data-prefix="fas"
                               focusable="false"
@@ -379,7 +379,7 @@ exports[`CreateConnectionForm should render 1`] = `
                     >
                       <svg
                         aria-hidden="true"
-                        class="svg-inline--fa fa-rotate tryArrow"
+                        class="<removed-for-snapshot-test>"
                         data-icon="rotate"
                         data-prefix="fas"
                         focusable="false"
@@ -644,7 +644,7 @@ exports[`CreateConnectionForm should render 1`] = `
                         >
                           <svg
                             aria-hidden="true"
-                            class="svg-inline--fa fa-chevron-right sc-hiMGwR bbPiZr"
+                            class="<removed-for-snapshot-test>"
                             data-icon="chevron-right"
                             data-prefix="fas"
                             focusable="false"
@@ -760,7 +760,7 @@ exports[`CreateConnectionForm should render 1`] = `
                                 >
                                   <svg
                                     aria-hidden="true"
-                                    class="svg-inline--fa fa-sort-down sc-jOrMOR jXccHI"
+                                    class="<removed-for-snapshot-test>"
                                     data-icon="sort-down"
                                     data-prefix="fas"
                                     focusable="false"

--- a/airbyte-webapp/src/pages/ConnectionPage/pages/ConnectionItemPage/ConnectionItemPage.tsx
+++ b/airbyte-webapp/src/pages/ConnectionPage/pages/ConnectionItemPage/ConnectionItemPage.tsx
@@ -45,17 +45,12 @@ export const ConnectionItemPageInner: React.FC = () => {
     >
       <Suspense fallback={<LoadingPage />}>
         <Routes>
-          <Route path={ConnectionSettingsRoutes.STATUS} element={<ConnectionStatusTab connection={connection} />} />
+          <Route path={ConnectionSettingsRoutes.STATUS} element={<ConnectionStatusTab />} />
           <Route path={ConnectionSettingsRoutes.REPLICATION} element={<ConnectionReplicationTab />} />
-          <Route
-            path={ConnectionSettingsRoutes.TRANSFORMATION}
-            element={<ConnectionTransformationTab connection={connection} />}
-          />
+          <Route path={ConnectionSettingsRoutes.TRANSFORMATION} element={<ConnectionTransformationTab />} />
           <Route
             path={ConnectionSettingsRoutes.SETTINGS}
-            element={
-              isConnectionDeleted ? <Navigate replace to=".." /> : <ConnectionSettingsTab connection={connection} />
-            }
+            element={isConnectionDeleted ? <Navigate replace to=".." /> : <ConnectionSettingsTab />}
           />
           <Route index element={<Navigate to={ConnectionSettingsRoutes.STATUS} replace />} />
         </Routes>

--- a/airbyte-webapp/src/pages/ConnectionPage/pages/ConnectionItemPage/ConnectionReplicationTab.tsx
+++ b/airbyte-webapp/src/pages/ConnectionPage/pages/ConnectionItemPage/ConnectionReplicationTab.tsx
@@ -150,6 +150,8 @@ export const ConnectionReplicationTab: React.FC = () => {
           validationSchema={connectionValidationSchema(mode)}
           onSubmit={onFormSubmit}
           enableReinitialize
+          validateOnBlur={false}
+          validateOnChange={false}
         >
           {({ values, isSubmitting, isValid, dirty, resetForm }) => (
             <Form>

--- a/airbyte-webapp/src/pages/ConnectionPage/pages/ConnectionItemPage/ConnectionReplicationTab.tsx
+++ b/airbyte-webapp/src/pages/ConnectionPage/pages/ConnectionItemPage/ConnectionReplicationTab.tsx
@@ -150,7 +150,6 @@ export const ConnectionReplicationTab: React.FC = () => {
           validationSchema={connectionValidationSchema(mode)}
           onSubmit={onFormSubmit}
           enableReinitialize
-          validateOnBlur={false}
           validateOnChange={false}
         >
           {({ values, isSubmitting, isValid, dirty, resetForm }) => (

--- a/airbyte-webapp/src/pages/ConnectionPage/pages/ConnectionItemPage/ConnectionSettingsTab.test.tsx
+++ b/airbyte-webapp/src/pages/ConnectionPage/pages/ConnectionItemPage/ConnectionSettingsTab.test.tsx
@@ -1,4 +1,4 @@
-import { render, mockConnection } from "test-utils/testutils";
+import { render } from "test-utils/testutils";
 
 import { ConnectionSettingsTab } from "./ConnectionSettingsTab";
 
@@ -40,11 +40,11 @@ describe("<SettingsView />", () => {
     let container: HTMLElement;
 
     setMockIsAdvancedMode(false);
-    ({ container } = await render(<ConnectionSettingsTab connection={mockConnection} />));
+    ({ container } = await render(<ConnectionSettingsTab />));
     expect(container.textContent).not.toContain("Connection State");
 
     setMockIsAdvancedMode(true);
-    ({ container } = await render(<ConnectionSettingsTab connection={mockConnection} />));
+    ({ container } = await render(<ConnectionSettingsTab />));
     expect(container.textContent).toContain("Connection State");
   });
 });

--- a/airbyte-webapp/src/pages/ConnectionPage/pages/ConnectionItemPage/ConnectionSettingsTab.test.tsx
+++ b/airbyte-webapp/src/pages/ConnectionPage/pages/ConnectionItemPage/ConnectionSettingsTab.test.tsx
@@ -1,4 +1,4 @@
-import { render } from "test-utils/testutils";
+import { mockConnection, render } from "test-utils/testutils";
 
 import { ConnectionSettingsTab } from "./ConnectionSettingsTab";
 
@@ -23,13 +23,10 @@ jest.mock("hooks/services/Analytics/useAnalyticsService", () => {
   return analyticsService;
 });
 
-// Mocking the DeleteBlock component is a bit ugly, but it's simpler and less
-// brittle than mocking the providers it depends on; at least it's a direct,
-// visible dependency of the component under test here.
-//
-// This mock is intentionally trivial; if anything to do with this component is
-// to be tested, we'll have to bite the bullet and render it properly, within
-// the necessary providers.
+jest.mock("hooks/services/ConnectionEdit/ConnectionEditService", () => ({
+  useConnectionEditService: () => ({ connection: mockConnection }),
+}));
+
 jest.mock("components/DeleteBlock", () => () => {
   const MockDeleteBlock = () => <div>Does not actually delete anything</div>;
   return <MockDeleteBlock />;

--- a/airbyte-webapp/src/pages/ConnectionPage/pages/ConnectionItemPage/ConnectionSettingsTab.tsx
+++ b/airbyte-webapp/src/pages/ConnectionPage/pages/ConnectionItemPage/ConnectionSettingsTab.tsx
@@ -2,19 +2,16 @@ import React from "react";
 
 import DeleteBlock from "components/DeleteBlock";
 
-import { WebBackendConnectionRead } from "core/request/AirbyteClient";
 import { PageTrackingCodes, useTrackPage } from "hooks/services/Analytics";
+import { useConnectionEditService } from "hooks/services/ConnectionEdit/ConnectionEditService";
 import { useAdvancedModeSetting } from "hooks/services/useAdvancedModeSetting";
 import { useDeleteConnection } from "hooks/services/useConnectionHook";
 
 import styles from "./ConnectionSettingsTab.module.scss";
 import { StateBlock } from "./StateBlock";
 
-interface ConnectionSettingsTabProps {
-  connection: WebBackendConnectionRead;
-}
-
-export const ConnectionSettingsTab: React.FC<ConnectionSettingsTabProps> = ({ connection }) => {
+export const ConnectionSettingsTab: React.FC = () => {
+  const { connection } = useConnectionEditService();
   const { mutateAsync: deleteConnection } = useDeleteConnection();
 
   const [isAdvancedMode] = useAdvancedModeSetting();

--- a/airbyte-webapp/src/pages/ConnectionPage/pages/ConnectionItemPage/ConnectionStatusTab.tsx
+++ b/airbyte-webapp/src/pages/ConnectionPage/pages/ConnectionItemPage/ConnectionStatusTab.tsx
@@ -13,10 +13,11 @@ import { Tooltip } from "components/ui/Tooltip";
 
 import { Action, Namespace } from "core/analytics";
 import { getFrequencyFromScheduleData } from "core/analytics/utils";
-import { ConnectionStatus, JobWithAttemptsRead, WebBackendConnectionRead } from "core/request/AirbyteClient";
+import { ConnectionStatus, JobWithAttemptsRead } from "core/request/AirbyteClient";
 import Status from "core/statuses";
 import { useTrackPage, PageTrackingCodes, useAnalyticsService } from "hooks/services/Analytics";
 import { useConfirmationModalService } from "hooks/services/ConfirmationModal";
+import { useConnectionEditService } from "hooks/services/ConnectionEdit/ConnectionEditService";
 import { FeatureItem, useFeature } from "hooks/services/Feature";
 import { useResetConnection, useSyncConnection } from "hooks/services/useConnectionHook";
 import { useCancelJob, useListJobs } from "services/job/JobService";
@@ -37,10 +38,6 @@ interface ActiveJob {
   isCanceling: boolean;
 }
 
-interface ConnectionStatusTabProps {
-  connection: WebBackendConnectionRead;
-}
-
 const getJobRunningOrPending = (jobs: JobWithAttemptsRead[]) => {
   return jobs.find((jobWithAttempts) => {
     const jobStatus = jobWithAttempts?.job?.status;
@@ -48,7 +45,8 @@ const getJobRunningOrPending = (jobs: JobWithAttemptsRead[]) => {
   });
 };
 
-export const ConnectionStatusTab: React.FC<ConnectionStatusTabProps> = ({ connection }) => {
+export const ConnectionStatusTab: React.FC = () => {
+  const { connection } = useConnectionEditService();
   useTrackPage(PageTrackingCodes.CONNECTIONS_ITEM_STATUS);
   const [activeJob, setActiveJob] = useState<ActiveJob>();
   const [jobPageSize, setJobPageSize] = useState(JOB_PAGE_SIZE_INCREMENT);

--- a/airbyte-webapp/src/pages/ConnectionPage/pages/ConnectionItemPage/ConnectionTransformationTab.module.scss
+++ b/airbyte-webapp/src/pages/ConnectionPage/pages/ConnectionItemPage/ConnectionTransformationTab.module.scss
@@ -1,0 +1,14 @@
+.content {
+  max-width: 1073px;
+  margin: 0 auto;
+  padding-bottom: 10px;
+}
+
+.customCard {
+  max-width: 500px;
+  margin: 0 auto;
+  min-height: 100px;
+  display: flex;
+  justify-content: center;
+  align-items: center;
+}

--- a/airbyte-webapp/src/pages/ConnectionPage/pages/ConnectionItemPage/ConnectionTransformationTab.tsx
+++ b/airbyte-webapp/src/pages/ConnectionPage/pages/ConnectionItemPage/ConnectionTransformationTab.tsx
@@ -7,18 +7,12 @@ import styled from "styled-components";
 import { Card } from "components/ui/Card";
 import { Text } from "components/ui/Text";
 
-import { buildConnectionUpdate, NormalizationType } from "core/domain/connection";
-import {
-  ConnectionStatus,
-  OperationCreate,
-  OperationRead,
-  OperatorType,
-  WebBackendConnectionRead,
-} from "core/request/AirbyteClient";
+import { NormalizationType } from "core/domain/connection";
+import { OperationCreate, OperationRead, OperatorType } from "core/request/AirbyteClient";
 import { useTrackPage, PageTrackingCodes } from "hooks/services/Analytics";
-import { ConnectionFormMode } from "hooks/services/ConnectionForm/ConnectionFormService";
+import { useConnectionEditService } from "hooks/services/ConnectionEdit/ConnectionEditService";
+import { useConnectionFormService } from "hooks/services/ConnectionForm/ConnectionFormService";
 import { FeatureItem, useFeature } from "hooks/services/Feature";
-import { useUpdateConnection } from "hooks/services/useConnectionHook";
 import { useCurrentWorkspace } from "hooks/services/useWorkspace";
 import { useGetDestinationDefinitionSpecification } from "services/connector/DestinationDefinitionSpecificationService";
 import { FormikOnSubmit } from "types/formik";
@@ -30,10 +24,6 @@ import {
   mapFormPropsToOperation,
 } from "views/Connection/ConnectionForm/formConfig";
 import { FormCard } from "views/Connection/FormCard";
-
-interface ConnectionTransformationTabProps {
-  connection: WebBackendConnectionRead;
-}
 
 const Content = styled.div`
   max-width: 1073px;
@@ -53,10 +43,9 @@ const NoSupportedTransformationCard = styled(Card)`
 const CustomTransformationsCard: React.FC<{
   operations?: OperationCreate[];
   onSubmit: FormikOnSubmit<{ transformations?: OperationRead[] }>;
-  mode: ConnectionFormMode;
-}> = ({ operations, onSubmit, mode }) => {
+}> = ({ operations, onSubmit }) => {
   const [editingTransformation, toggleEditingTransformation] = useToggle(false);
-
+  const { mode } = useConnectionFormService();
   const initialValues = useMemo(
     () => ({
       transformations: getInitialTransformations(operations || []),
@@ -75,7 +64,6 @@ const CustomTransformationsCard: React.FC<{
         onSubmit,
       }}
       submitDisabled={editingTransformation}
-      mode={mode}
     >
       <FieldArray name="transformations">
         {(formProps) => (
@@ -94,8 +82,8 @@ const CustomTransformationsCard: React.FC<{
 const NormalizationCard: React.FC<{
   operations?: OperationRead[];
   onSubmit: FormikOnSubmit<{ normalization?: NormalizationType }>;
-  mode: ConnectionFormMode;
-}> = ({ operations, onSubmit, mode }) => {
+}> = ({ operations, onSubmit }) => {
+  const { mode } = useConnectionFormService();
   const initialValues = useMemo(
     () => ({
       normalization: getInitialNormalization(operations, true),
@@ -111,23 +99,22 @@ const NormalizationCard: React.FC<{
       }}
       title={<FormattedMessage id="connection.normalization" />}
       collapsible
-      mode={mode}
     >
+      {/* todo: can we avoid passing mode through? */}
       <Field name="normalization" component={NormalizationField} mode={mode} />
     </FormCard>
   );
 };
 
-export const ConnectionTransformationTab: React.FC<ConnectionTransformationTabProps> = ({ connection }) => {
+export const ConnectionTransformationTab: React.FC = () => {
+  const { connection, updateConnection } = useConnectionEditService();
+  const { mode } = useConnectionFormService();
   const definition = useGetDestinationDefinitionSpecification(connection.destination.destinationDefinitionId);
-  const { mutateAsync: updateConnection } = useUpdateConnection();
   const workspace = useCurrentWorkspace();
 
   useTrackPage(PageTrackingCodes.CONNECTIONS_ITEM_TRANSFORMATION);
   const { supportsNormalization } = definition;
   const supportsDbt = useFeature(FeatureItem.AllowCustomDBT) && definition.supportsDbt;
-
-  const mode = connection.status === ConnectionStatus.deprecated ? "readonly" : "edit";
 
   const onSubmit: FormikOnSubmit<{ transformations?: OperationRead[]; normalization?: NormalizationType }> = async (
     values,
@@ -143,11 +130,8 @@ export const ConnectionTransformationTab: React.FC<ConnectionTransformationTabPr
           (connection.operations ?? [])?.filter((op) => op.operatorConfiguration.operatorType === OperatorType.dbt)
         );
 
-    await updateConnection(
-      buildConnectionUpdate(connection, {
-        operations,
-      })
-    );
+    // todo:  this
+    await updateConnection({ connectionId: connection.connectionId, operations });
 
     const nextFormValues: typeof values = {};
     if (values.transformations) {
@@ -164,12 +148,8 @@ export const ConnectionTransformationTab: React.FC<ConnectionTransformationTabPr
         disabled={mode === "readonly"}
         style={{ border: "0", pointerEvents: `${mode === "readonly" ? "none" : "auto"}` }}
       >
-        {supportsNormalization && (
-          <NormalizationCard operations={connection.operations} onSubmit={onSubmit} mode={mode} />
-        )}
-        {supportsDbt && (
-          <CustomTransformationsCard operations={connection.operations} onSubmit={onSubmit} mode={mode} />
-        )}
+        {supportsNormalization && <NormalizationCard operations={connection.operations} onSubmit={onSubmit} />}
+        {supportsDbt && <CustomTransformationsCard operations={connection.operations} onSubmit={onSubmit} />}
         {!supportsNormalization && !supportsDbt && (
           <NoSupportedTransformationCard>
             <Text as="p" size="lg" centered>

--- a/airbyte-webapp/src/pages/ConnectionPage/pages/ConnectionItemPage/ConnectionTransformationTab.tsx
+++ b/airbyte-webapp/src/pages/ConnectionPage/pages/ConnectionItemPage/ConnectionTransformationTab.tsx
@@ -2,7 +2,6 @@ import { Field, FieldArray } from "formik";
 import React, { useMemo } from "react";
 import { FormattedMessage } from "react-intl";
 import { useToggle } from "react-use";
-import styled from "styled-components";
 
 import { Card } from "components/ui/Card";
 import { Text } from "components/ui/Text";
@@ -25,20 +24,7 @@ import {
 } from "views/Connection/ConnectionForm/formConfig";
 import { FormCard } from "views/Connection/FormCard";
 
-const Content = styled.div`
-  max-width: 1073px;
-  margin: 0 auto;
-  padding-bottom: 10px;
-`;
-
-const NoSupportedTransformationCard = styled(Card)`
-  max-width: 500px;
-  margin: 0 auto;
-  min-height: 100px;
-  display: flex;
-  justify-content: center;
-  align-items: center;
-`;
+import styles from "./ConnectionTransformationTab.module.scss";
 
 const CustomTransformationsCard: React.FC<{
   operations?: OperationCreate[];
@@ -100,7 +86,6 @@ const NormalizationCard: React.FC<{
       title={<FormattedMessage id="connection.normalization" />}
       collapsible
     >
-      {/* todo: can we avoid passing mode through? */}
       <Field name="normalization" component={NormalizationField} mode={mode} />
     </FormCard>
   );
@@ -130,7 +115,6 @@ export const ConnectionTransformationTab: React.FC = () => {
           (connection.operations ?? [])?.filter((op) => op.operatorConfiguration.operatorType === OperatorType.dbt)
         );
 
-    // todo:  this
     await updateConnection({ connectionId: connection.connectionId, operations });
 
     const nextFormValues: typeof values = {};
@@ -143,7 +127,7 @@ export const ConnectionTransformationTab: React.FC = () => {
   };
 
   return (
-    <Content>
+    <div className={styles.content}>
       <fieldset
         disabled={mode === "readonly"}
         style={{ border: "0", pointerEvents: `${mode === "readonly" ? "none" : "auto"}` }}
@@ -151,13 +135,13 @@ export const ConnectionTransformationTab: React.FC = () => {
         {supportsNormalization && <NormalizationCard operations={connection.operations} onSubmit={onSubmit} />}
         {supportsDbt && <CustomTransformationsCard operations={connection.operations} onSubmit={onSubmit} />}
         {!supportsNormalization && !supportsDbt && (
-          <NoSupportedTransformationCard>
+          <Card className={styles.customCard}>
             <Text as="p" size="lg" centered>
               <FormattedMessage id="connectionForm.operations.notSupported" />
             </Text>
-          </NoSupportedTransformationCard>
+          </Card>
         )}
       </fieldset>
-    </Content>
+    </div>
   );
 };

--- a/airbyte-webapp/src/views/Connection/ConnectionForm/components/NormalizationField.module.scss
+++ b/airbyte-webapp/src/views/Connection/ConnectionForm/components/NormalizationField.module.scss
@@ -1,0 +1,5 @@
+@use "../../../../scss/variables";
+
+.normalizationField {
+  margin: variables.$spacing-lg 0;
+}

--- a/airbyte-webapp/src/views/Connection/ConnectionForm/components/NormalizationField.tsx
+++ b/airbyte-webapp/src/views/Connection/ConnectionForm/components/NormalizationField.tsx
@@ -1,25 +1,22 @@
 import { FieldProps } from "formik";
 import React from "react";
 import { FormattedMessage } from "react-intl";
-import styled from "styled-components";
 
 import { LabeledRadioButton, Link } from "components";
 
 import { NormalizationType } from "core/domain/connection/operation";
-import { ConnectionFormMode } from "hooks/services/ConnectionForm/ConnectionFormService";
+import { useConnectionFormService } from "hooks/services/ConnectionForm/ConnectionFormService";
 import { links } from "utils/links";
 
-const Normalization = styled.div`
-  margin: 16px 0;
-`;
+import styles from "./NormalizationField.module.css";
 
-type NormalizationBlockProps = FieldProps<string> & {
-  mode: ConnectionFormMode;
-};
+type NormalizationBlockProps = FieldProps<string>;
 
-const NormalizationField: React.FC<NormalizationBlockProps> = ({ form, field, mode }) => {
+export const NormalizationField: React.FC<NormalizationBlockProps> = ({ form, field }) => {
+  const { mode } = useConnectionFormService();
+
   return (
-    <Normalization>
+    <div className={styles.normalizationField}>
       <LabeledRadioButton
         {...form.getFieldProps(field.name)}
         id="normalization.raw"
@@ -50,8 +47,6 @@ const NormalizationField: React.FC<NormalizationBlockProps> = ({ form, field, mo
           )
         }
       />
-    </Normalization>
+    </div>
   );
 };
-
-export { NormalizationField };

--- a/airbyte-webapp/src/views/Connection/ConnectionForm/components/NormalizationField.tsx
+++ b/airbyte-webapp/src/views/Connection/ConnectionForm/components/NormalizationField.tsx
@@ -8,7 +8,7 @@ import { NormalizationType } from "core/domain/connection/operation";
 import { useConnectionFormService } from "hooks/services/ConnectionForm/ConnectionFormService";
 import { links } from "utils/links";
 
-import styles from "./NormalizationField.module.css";
+import styles from "./NormalizationField.module.scss";
 
 type NormalizationBlockProps = FieldProps<string>;
 

--- a/airbyte-webapp/src/views/Connection/FormCard.module.scss
+++ b/airbyte-webapp/src/views/Connection/FormCard.module.scss
@@ -1,0 +1,5 @@
+@use "../../scss/variables";
+
+.formCard {
+  padding: 22px 27px variables.$spacing-xl 24px;
+}

--- a/airbyte-webapp/src/views/Connection/FormCard.tsx
+++ b/airbyte-webapp/src/views/Connection/FormCard.tsx
@@ -6,19 +6,16 @@ import styled from "styled-components";
 
 import { FormChangeTracker } from "components/FormChangeTracker";
 
-import { ConnectionFormMode } from "hooks/services/ConnectionForm/ConnectionFormService";
+import { useConnectionFormService } from "hooks/services/ConnectionForm/ConnectionFormService";
 import { generateMessageFromError } from "utils/errorStatusMessage";
 import { CollapsibleCardProps, CollapsibleCard } from "views/Connection/CollapsibleCard";
 import EditControls from "views/Connection/ConnectionForm/components/EditControls";
 
-const FormContainer = styled(Form)`
-  padding: 22px 27px 15px 24px;
-`;
+const FormContainer = styled(Form)``;
 
 interface FormCardProps<T> extends CollapsibleCardProps {
   bottomSeparator?: boolean;
   form: FormikConfig<T>;
-  mode?: ConnectionFormMode;
   submitDisabled?: boolean;
 }
 
@@ -26,11 +23,11 @@ export const FormCard = <T extends object>({
   children,
   form,
   bottomSeparator = true,
-  mode,
   submitDisabled,
   ...props
 }: React.PropsWithChildren<FormCardProps<T>>) => {
   const { formatMessage } = useIntl();
+  const { mode } = useConnectionFormService();
 
   const { mutateAsync, error, reset, isSuccess } = useMutation<
     void,

--- a/airbyte-webapp/src/views/Connection/FormCard.tsx
+++ b/airbyte-webapp/src/views/Connection/FormCard.tsx
@@ -2,7 +2,6 @@ import { Form, Formik, FormikConfig, FormikHelpers } from "formik";
 import React from "react";
 import { useIntl } from "react-intl";
 import { useMutation } from "react-query";
-import styled from "styled-components";
 
 import { FormChangeTracker } from "components/FormChangeTracker";
 
@@ -11,7 +10,7 @@ import { generateMessageFromError } from "utils/errorStatusMessage";
 import { CollapsibleCardProps, CollapsibleCard } from "views/Connection/CollapsibleCard";
 import EditControls from "views/Connection/ConnectionForm/components/EditControls";
 
-const FormContainer = styled(Form)``;
+import styles from "./FormCard.module.scss";
 
 interface FormCardProps<T> extends CollapsibleCardProps {
   bottomSeparator?: boolean;
@@ -43,7 +42,7 @@ export const FormCard = <T extends object>({
     <Formik {...form} onSubmit={(values, formikHelpers) => mutateAsync({ values, formikHelpers })}>
       {({ resetForm, isSubmitting, dirty, isValid }) => (
         <CollapsibleCard {...props}>
-          <FormContainer>
+          <Form className={styles.formCard}>
             <FormChangeTracker changed={dirty} />
             {children}
             <div>
@@ -64,7 +63,7 @@ export const FormCard = <T extends object>({
                 />
               )}
             </div>
-          </FormContainer>
+          </Form>
         </CollapsibleCard>
       )}
     </Formik>


### PR DESCRIPTION
## What
closes #17341
closes #15609

- Migrates additional pages and components within the Connection workflows to utilize the Service(s)
- Fixes a bug where connection creation/edit forms were validating on blur and on change

## Recommended reading order
1. `*Tab.tsx`
2. `ConnectionItemPage.tsx`
3. other
