### PR TITLE
Add workspace ID to connector check calls to fix segment tracking

### DIFF
--- a/airbyte-api/src/main/openapi/config.yaml
+++ b/airbyte-api/src/main/openapi/config.yaml
@@ -2738,7 +2738,7 @@ components:
         connectionConfiguration:
           $ref: "#/components/schemas/SourceConfiguration"
         workspaceId:
-          $ref: '#/components/schemas/WorkspaceId'
+          $ref: "#/components/schemas/WorkspaceId"
     SourceCreate:
       type: object
       required:
@@ -3031,7 +3031,7 @@ components:
         connectionConfiguration:
           $ref: "#/components/schemas/DestinationConfiguration"
         workspaceId:
-          $ref: '#/components/schemas/WorkspaceId'
+          $ref: "#/components/schemas/WorkspaceId"
     DestinationCreate:
       type: object
       required:

--- a/airbyte-api/src/main/openapi/config.yaml
+++ b/airbyte-api/src/main/openapi/config.yaml
@@ -2731,11 +2731,14 @@ components:
       required:
         - sourceDefinitionId
         - connectionConfiguration
+        - workspaceId
       properties:
         sourceDefinitionId:
           $ref: "#/components/schemas/SourceDefinitionId"
         connectionConfiguration:
           $ref: "#/components/schemas/SourceConfiguration"
+        workspaceId:
+          $ref: '#/components/schemas/WorkspaceId'
     SourceCreate:
       type: object
       required:
@@ -3027,6 +3030,8 @@ components:
           $ref: "#/components/schemas/DestinationDefinitionId"
         connectionConfiguration:
           $ref: "#/components/schemas/DestinationConfiguration"
+        workspaceId:
+          $ref: '#/components/schemas/WorkspaceId'
     DestinationCreate:
       type: object
       required:

--- a/airbyte-server/src/main/java/io/airbyte/server/handlers/SchedulerHandler.java
+++ b/airbyte-server/src/main/java/io/airbyte/server/handlers/SchedulerHandler.java
@@ -146,7 +146,8 @@ public class SchedulerHandler {
     // technically declared as required.
     final SourceConnection source = new SourceConnection()
         .withSourceDefinitionId(sourceConfig.getSourceDefinitionId())
-        .withConfiguration(partialConfig);
+        .withConfiguration(partialConfig)
+        .withWorkspaceId(sourceConfig.getWorkspaceId());
 
     final String imageName = DockerUtils.getTaggedImageName(sourceDef.getDockerRepository(), sourceDef.getDockerImageTag());
     return reportConnectionStatus(synchronousSchedulerClient.createSourceCheckConnectionJob(source, imageName));
@@ -186,7 +187,8 @@ public class SchedulerHandler {
     // technically declared as required.
     final DestinationConnection destination = new DestinationConnection()
         .withDestinationDefinitionId(destinationConfig.getDestinationDefinitionId())
-        .withConfiguration(partialConfig);
+        .withConfiguration(partialConfig)
+        .withWorkspaceId(destinationConfig.getWorkspaceId());
 
     final String imageName = DockerUtils.getTaggedImageName(destDef.getDockerRepository(), destDef.getDockerImageTag());
     return reportConnectionStatus(synchronousSchedulerClient.createDestinationCheckConnectionJob(destination, imageName));
@@ -250,7 +252,8 @@ public class SchedulerHandler {
     // technically declared as required.
     final SourceConnection source = new SourceConnection()
         .withSourceDefinitionId(sourceCreate.getSourceDefinitionId())
-        .withConfiguration(partialConfig);
+        .withConfiguration(partialConfig)
+        .withWorkspaceId(sourceCreate.getWorkspaceId());
     final SynchronousResponse<UUID> response = synchronousSchedulerClient.createDiscoverSchemaJob(source, imageName, sourceDef.getDockerImageTag());
     return retrieveDiscoveredSchema(response);
   }

--- a/airbyte-server/src/test/java/io/airbyte/server/handlers/SchedulerHandlerTest.java
+++ b/airbyte-server/src/test/java/io/airbyte/server/handlers/SchedulerHandlerTest.java
@@ -189,7 +189,8 @@ class SchedulerHandlerTest {
 
     final SourceCoreConfig sourceCoreConfig = new SourceCoreConfig()
         .sourceDefinitionId(source.getSourceDefinitionId())
-        .connectionConfiguration(source.getConfiguration());
+        .connectionConfiguration(source.getConfiguration())
+        .workspaceId(source.getWorkspaceId());
 
     when(configRepository.getStandardSourceDefinition(source.getSourceDefinitionId()))
         .thenReturn(new StandardSourceDefinition()
@@ -505,7 +506,8 @@ class SchedulerHandlerTest {
 
     final SourceCoreConfig sourceCoreConfig = new SourceCoreConfig()
         .sourceDefinitionId(source.getSourceDefinitionId())
-        .connectionConfiguration(source.getConfiguration());
+        .connectionConfiguration(source.getConfiguration())
+        .workspaceId(source.getWorkspaceId());
     final ActorCatalog actorCatalog = new ActorCatalog()
         .withCatalog(Jsons.jsonNode(airbyteCatalog))
         .withCatalogHash("")
@@ -538,7 +540,8 @@ class SchedulerHandlerTest {
 
     final SourceCoreConfig sourceCoreConfig = new SourceCoreConfig()
         .sourceDefinitionId(source.getSourceDefinitionId())
-        .connectionConfiguration(source.getConfiguration());
+        .connectionConfiguration(source.getConfiguration())
+        .workspaceId(source.getWorkspaceId());
 
     when(configRepository.getStandardSourceDefinition(source.getSourceDefinitionId()))
         .thenReturn(new StandardSourceDefinition()

--- a/airbyte-webapp/src/core/domain/connector/SourceService.ts
+++ b/airbyte-webapp/src/core/domain/connector/SourceService.ts
@@ -25,6 +25,7 @@ export class SourceService extends AirbyteRequestService {
     params: {
       sourceId?: string;
       connectionConfiguration?: ConnectionConfiguration;
+      workspaceId?: string;
     },
     requestParams?: RequestInit
   ) {

--- a/airbyte-webapp/src/hooks/services/useConnector.tsx
+++ b/airbyte-webapp/src/hooks/services/useConnector.tsx
@@ -101,6 +101,7 @@ export type CheckConnectorParams = { signal: AbortSignal } & (
   | {
       selectedConnectorDefinitionId: string;
       connectionConfiguration: ConnectionConfiguration;
+      workspaceId: string;
     }
 );
 
@@ -139,6 +140,10 @@ export const useCheckConnector = (formType: "source" | "destination") => {
 
     if ("selectedConnectorDefinitionId" in params) {
       payload.sourceDefinitionId = params.selectedConnectorDefinitionId;
+    }
+
+    if ("workspaceId" in params) {
+      payload.workspaceId = params.workspaceId;
     }
 
     return await sourceService.check_connection(payload, {

--- a/airbyte-webapp/src/hooks/services/useConnector.tsx
+++ b/airbyte-webapp/src/hooks/services/useConnector.tsx
@@ -120,6 +120,10 @@ export const useCheckConnector = (formType: "source" | "destination") => {
       payload.name = params.name;
     }
 
+    if ("workspaceId" in params) {
+      payload.workspaceId = params.workspaceId;
+    }
+
     if (formType === "destination") {
       if ("selectedConnectorId" in params) {
         payload.destinationId = params.selectedConnectorId;
@@ -140,10 +144,6 @@ export const useCheckConnector = (formType: "source" | "destination") => {
 
     if ("selectedConnectorDefinitionId" in params) {
       payload.sourceDefinitionId = params.selectedConnectorDefinitionId;
-    }
-
-    if ("workspaceId" in params) {
-      payload.workspaceId = params.workspaceId;
     }
 
     return await sourceService.check_connection(payload, {

--- a/airbyte-webapp/src/views/Connector/ConnectorCard/useTestConnector.tsx
+++ b/airbyte-webapp/src/views/Connector/ConnectorCard/useTestConnector.tsx
@@ -3,6 +3,7 @@ import { useRef } from "react";
 import { ConnectorHelper } from "core/domain/connector";
 import { ConnectorT } from "core/domain/connector/types";
 import { CheckConnectorParams, useCheckConnector } from "hooks/services/useConnector";
+import { useCurrentWorkspace } from "services/workspaces/WorkspacesService";
 import { ServiceFormValues } from "views/Connector/ServiceForm";
 
 import { CheckConnectionRead } from "../../../core/request/AirbyteClient";
@@ -25,6 +26,7 @@ export const useTestConnector = (
   reset: () => void;
 } => {
   const { mutateAsync, isLoading, error, isSuccess, reset } = useCheckConnector(props.formType);
+  const workspace = useCurrentWorkspace();
 
   const abortControllerRef = useRef<AbortController | null>(null);
 
@@ -66,6 +68,7 @@ export const useTestConnector = (
           connectionConfiguration: values.connectionConfiguration,
           signal: controller.signal,
           selectedConnectorDefinitionId: values.serviceType,
+          workspaceId: workspace.workspaceId,
         };
       }
 

--- a/docs/reference/api/generated-api-html/index.html
+++ b/docs/reference/api/generated-api-html/index.html
@@ -10344,6 +10344,7 @@ containing the updated stream needs to be sent.</div>
     <div class="field-items">
       <div class="param">destinationDefinitionId </div><div class="param-desc"><span class="param-type"><a href="#UUID">UUID</a></span>  format: uuid</div>
 <div class="param">connectionConfiguration </div><div class="param-desc"><span class="param-type"><a href="#DestinationConfiguration">DestinationConfiguration</a></span>  </div>
+<div class="param">workspaceId </div><div class="param-desc"><span class="param-type"><a href="#UUID">UUID</a></span>  format: uuid</div>
     </div>  <!-- field-items -->
   </div>
   <div class="model">
@@ -11004,6 +11005,7 @@ if oauth parameters were contained inside the top level, rootObject=[] If they w
     <div class="field-items">
       <div class="param">sourceDefinitionId </div><div class="param-desc"><span class="param-type"><a href="#UUID">UUID</a></span>  format: uuid</div>
 <div class="param">connectionConfiguration </div><div class="param-desc"><span class="param-type"><a href="#SourceConfiguration">SourceConfiguration</a></span>  </div>
+<div class="param">workspaceId </div><div class="param-desc"><span class="param-type"><a href="#UUID">UUID</a></span>  format: uuid</div>
     </div>  <!-- field-items -->
   </div>
   <div class="model">


### PR DESCRIPTION
## What
Resolves https://github.com/airbytehq/airbyte/issues/17652

See slack thread for context on why this is being fixed now: https://airbytehq-team.slack.com/archives/C02U46QK5C3/p1665157191791549

## How
Adds workspaceId to the source/dest check connection and discover schema calls, to fix the segment tracking behavior for failures in these operations.

## Recommended reading order
1. `airbyte-api/src/main/openapi/config.yaml` for the API spec change
2. `airbyte-server/src/main/java/io/airbyte/server/handlers/SchedulerHandler.java` for the backend change to use the new field
3. `airbyte-webapp/*` for the changes to pass in the workspace ID to that endpoint
