### PR TITLE
🪟 🔧 Add Datadog support to webapp, cleanup sentry init

### DIFF
--- a/airbyte-webapp/package-lock.json
+++ b/airbyte-webapp/package-lock.json
@@ -8,6 +8,7 @@
       "name": "airbyte-webapp",
       "version": "0.40.14",
       "dependencies": {
+        "@datadog/browser-rum": "^4.21.2",
         "@floating-ui/react-dom": "^1.0.0",
         "@fortawesome/fontawesome-svg-core": "^6.1.1",
         "@fortawesome/free-brands-svg-icons": "^6.1.1",
@@ -2497,6 +2498,36 @@
       "resolved": "https://registry.npmjs.org/@csstools/normalize.css/-/normalize.css-12.0.0.tgz",
       "integrity": "sha512-M0qqxAcwCsIVfpFQSlGN5XjXWu8l5JDZN+fPt1LeW5SZexQTgnaEvgXAY+CeygRw0EeppWHi12JxESWiWrB0Sg==",
       "dev": true
+    },
+    "node_modules/@datadog/browser-core": {
+      "version": "4.21.2",
+      "resolved": "https://registry.npmjs.org/@datadog/browser-core/-/browser-core-4.21.2.tgz",
+      "integrity": "sha512-o3UvCPBF0OdCInCbiC9j79K0F7/wThARZFq8+wnAOitZu64VT5XNpHFQqFP+9c+zzcxmwlTIINHmWLdkpKEECg=="
+    },
+    "node_modules/@datadog/browser-rum": {
+      "version": "4.21.2",
+      "resolved": "https://registry.npmjs.org/@datadog/browser-rum/-/browser-rum-4.21.2.tgz",
+      "integrity": "sha512-qvC7sRrZ5yy7siCHeGPnBsM6sKoU+jc1YGy/5WgRSs24WUt9trgBoRcVR1KwU/aK8xn6hUOKRdEIxkrss5JaiA==",
+      "dependencies": {
+        "@datadog/browser-core": "4.21.2",
+        "@datadog/browser-rum-core": "4.21.2"
+      },
+      "peerDependencies": {
+        "@datadog/browser-logs": "4.21.2"
+      },
+      "peerDependenciesMeta": {
+        "@datadog/browser-logs": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@datadog/browser-rum-core": {
+      "version": "4.21.2",
+      "resolved": "https://registry.npmjs.org/@datadog/browser-rum-core/-/browser-rum-core-4.21.2.tgz",
+      "integrity": "sha512-8hNiNygHY8Jt2APtm4nvciGyRKIEniaupe7Uj5Bq6OFZIFNgf6qj88bRXwOdPsP9ksBNNK18Hol1oI4EdxdkkQ==",
+      "dependencies": {
+        "@datadog/browser-core": "4.21.2"
+      }
     },
     "node_modules/@discoveryjs/json-ext": {
       "version": "0.5.7",
@@ -49337,6 +49368,28 @@
       "resolved": "https://registry.npmjs.org/@csstools/normalize.css/-/normalize.css-12.0.0.tgz",
       "integrity": "sha512-M0qqxAcwCsIVfpFQSlGN5XjXWu8l5JDZN+fPt1LeW5SZexQTgnaEvgXAY+CeygRw0EeppWHi12JxESWiWrB0Sg==",
       "dev": true
+    },
+    "@datadog/browser-core": {
+      "version": "4.21.2",
+      "resolved": "https://registry.npmjs.org/@datadog/browser-core/-/browser-core-4.21.2.tgz",
+      "integrity": "sha512-o3UvCPBF0OdCInCbiC9j79K0F7/wThARZFq8+wnAOitZu64VT5XNpHFQqFP+9c+zzcxmwlTIINHmWLdkpKEECg=="
+    },
+    "@datadog/browser-rum": {
+      "version": "4.21.2",
+      "resolved": "https://registry.npmjs.org/@datadog/browser-rum/-/browser-rum-4.21.2.tgz",
+      "integrity": "sha512-qvC7sRrZ5yy7siCHeGPnBsM6sKoU+jc1YGy/5WgRSs24WUt9trgBoRcVR1KwU/aK8xn6hUOKRdEIxkrss5JaiA==",
+      "requires": {
+        "@datadog/browser-core": "4.21.2",
+        "@datadog/browser-rum-core": "4.21.2"
+      }
+    },
+    "@datadog/browser-rum-core": {
+      "version": "4.21.2",
+      "resolved": "https://registry.npmjs.org/@datadog/browser-rum-core/-/browser-rum-core-4.21.2.tgz",
+      "integrity": "sha512-8hNiNygHY8Jt2APtm4nvciGyRKIEniaupe7Uj5Bq6OFZIFNgf6qj88bRXwOdPsP9ksBNNK18Hol1oI4EdxdkkQ==",
+      "requires": {
+        "@datadog/browser-core": "4.21.2"
+      }
     },
     "@discoveryjs/json-ext": {
       "version": "0.5.7",

--- a/airbyte-webapp/package.json
+++ b/airbyte-webapp/package.json
@@ -24,6 +24,7 @@
     "validate-links": "ts-node --skip-project ./scripts/validate-links.ts"
   },
   "dependencies": {
+    "@datadog/browser-rum": "^4.21.2",
     "@floating-ui/react-dom": "^1.0.0",
     "@fortawesome/fontawesome-svg-core": "^6.1.1",
     "@fortawesome/free-brands-svg-icons": "^6.1.1",
@@ -162,7 +163,9 @@
   },
   "jest": {
     "transformIgnorePatterns": [],
-    "snapshotSerializers": ["./scripts/classname-serializer.js"],
+    "snapshotSerializers": [
+      "./scripts/classname-serializer.js"
+    ],
     "coveragePathIgnorePatterns": [
       ".stories.tsx"
     ]

--- a/airbyte-webapp/src/config/types.ts
+++ b/airbyte-webapp/src/config/types.ts
@@ -6,6 +6,10 @@ declare global {
     AIRBYTE_VERSION?: string;
     API_URL?: string;
     CLOUD?: string;
+    REACT_APP_DATADOG_APPLICATION_ID: string;
+    REACT_APP_DATADOG_CLIENT_TOKEN: string;
+    REACT_APP_DATADOG_SITE: string;
+    REACT_APP_DATADOG_SERVICE: string;
     REACT_APP_SENTRY_DSN?: string;
     REACT_APP_WEBAPP_TAG?: string;
     REACT_APP_INTERCOM_APP_ID?: string;

--- a/airbyte-webapp/src/index.tsx
+++ b/airbyte-webapp/src/index.tsx
@@ -9,6 +9,7 @@ import { initSentry } from "utils/sentry";
 
 import "./globals";
 
+// We do not follow default config approach since we want to init sentry/datadog asap
 initSentry();
 initDatadogRum();
 

--- a/airbyte-webapp/src/index.tsx
+++ b/airbyte-webapp/src/index.tsx
@@ -1,5 +1,3 @@
-import * as Sentry from "@sentry/react";
-import { Integrations } from "@sentry/tracing";
 import { lazy, Suspense } from "react";
 import ReactDOM from "react-dom";
 
@@ -7,17 +5,11 @@ import "react-reflex/styles.css";
 import { isCloudApp } from "utils/app";
 import { loadDatadogRum } from "utils/datadog";
 import { loadOsano } from "utils/dataPrivacy";
+import { initSentry } from "utils/sentry";
 
 import "./globals";
 
-// We do not follow default config approach since we want to init sentry asap
-Sentry.init({
-  dsn: process.env.REACT_APP_SENTRY_DSN || window.REACT_APP_SENTRY_DSN,
-  release: process.env.REACT_APP_WEBAPP_TAG || window.REACT_APP_WEBAPP_TAG || "dev",
-  integrations: [new Integrations.BrowserTracing()],
-  tracesSampleRate: 1.0, // may need to adjust this in the future
-});
-
+initSentry();
 loadDatadogRum();
 
 // In Cloud load the Osano script (GDPR consent tool before anything else)

--- a/airbyte-webapp/src/index.tsx
+++ b/airbyte-webapp/src/index.tsx
@@ -3,15 +3,15 @@ import ReactDOM from "react-dom";
 
 import "react-reflex/styles.css";
 import { isCloudApp } from "utils/app";
-import { initDatadogRum } from "utils/datadog";
+import { loadDatadog } from "utils/datadog";
 import { loadOsano } from "utils/dataPrivacy";
-import { initSentry } from "utils/sentry";
+import { loadSentry } from "utils/sentry";
 
 import "./globals";
 
 // We do not follow default config approach since we want to init sentry/datadog asap
-initSentry();
-initDatadogRum();
+loadSentry();
+loadDatadog();
 
 // In Cloud load the Osano script (GDPR consent tool before anything else)
 if (isCloudApp()) {

--- a/airbyte-webapp/src/index.tsx
+++ b/airbyte-webapp/src/index.tsx
@@ -5,6 +5,7 @@ import ReactDOM from "react-dom";
 
 import "react-reflex/styles.css";
 import { isCloudApp } from "utils/app";
+import { loadDatadogRum } from "utils/datadog";
 import { loadOsano } from "utils/dataPrivacy";
 
 import "./globals";
@@ -16,6 +17,8 @@ Sentry.init({
   integrations: [new Integrations.BrowserTracing()],
   tracesSampleRate: 1.0, // may need to adjust this in the future
 });
+
+loadDatadogRum();
 
 // In Cloud load the Osano script (GDPR consent tool before anything else)
 if (isCloudApp()) {

--- a/airbyte-webapp/src/index.tsx
+++ b/airbyte-webapp/src/index.tsx
@@ -3,14 +3,14 @@ import ReactDOM from "react-dom";
 
 import "react-reflex/styles.css";
 import { isCloudApp } from "utils/app";
-import { loadDatadogRum } from "utils/datadog";
+import { initDatadogRum } from "utils/datadog";
 import { loadOsano } from "utils/dataPrivacy";
 import { initSentry } from "utils/sentry";
 
 import "./globals";
 
 initSentry();
-loadDatadogRum();
+initDatadogRum();
 
 // In Cloud load the Osano script (GDPR consent tool before anything else)
 if (isCloudApp()) {

--- a/airbyte-webapp/src/utils/datadog.ts
+++ b/airbyte-webapp/src/utils/datadog.ts
@@ -1,6 +1,6 @@
 import { datadogRum } from "@datadog/browser-rum";
 
-export const loadDatadogRum = () => {
+export const initDatadogRum = () => {
   const applicationId = process.env.REACT_APP_DATADOG_APPLICATION_ID ?? window.REACT_APP_DATADOG_APPLICATION_ID;
   if (!applicationId) {
     return;

--- a/airbyte-webapp/src/utils/datadog.ts
+++ b/airbyte-webapp/src/utils/datadog.ts
@@ -9,7 +9,7 @@ export const loadDatadog = async (): Promise<void> => {
   const clientToken = process.env.REACT_APP_DATADOG_CLIENT_TOKEN ?? window.REACT_APP_DATADOG_CLIENT_TOKEN;
   const site = process.env.REACT_APP_DATADOG_SITE ?? window.REACT_APP_DATADOG_SITE;
   const service = process.env.REACT_APP_DATADOG_SERVICE ?? window.REACT_APP_DATADOG_SERVICE;
-  const version = window.AIRBYTE_VERSION;
+  const version = process.env.REACT_APP_WEBAPP_TAG ?? window.REACT_APP_WEBAPP_TAG ?? "dev";
 
   datadogRum.init({
     applicationId,

--- a/airbyte-webapp/src/utils/datadog.ts
+++ b/airbyte-webapp/src/utils/datadog.ts
@@ -1,0 +1,29 @@
+import { datadogRum } from "@datadog/browser-rum";
+
+export const loadDatadogRum = () => {
+  const applicationId = process.env.REACT_APP_DATADOG_APPLICATION_ID ?? window.REACT_APP_DATADOG_APPLICATION_ID;
+  if (!applicationId) {
+    return;
+  }
+
+  const clientToken = process.env.REACT_APP_DATADOG_CLIENT_TOKEN ?? window.REACT_APP_DATADOG_CLIENT_TOKEN;
+  const site = process.env.REACT_APP_DATADOG_SITE ?? window.REACT_APP_DATADOG_SITE;
+  const service = process.env.REACT_APP_DATADOG_SERVICE ?? window.REACT_APP_DATADOG_SERVICE;
+  const version = window.AIRBYTE_VERSION;
+
+  datadogRum.init({
+    applicationId,
+    clientToken,
+    site,
+    service,
+    version,
+    sampleRate: 100,
+    sessionReplaySampleRate: 0,
+    trackInteractions: false,
+    trackResources: true,
+    trackLongTasks: true,
+    defaultPrivacyLevel: "mask-user-input",
+  });
+
+  datadogRum.startSessionReplayRecording();
+};

--- a/airbyte-webapp/src/utils/datadog.ts
+++ b/airbyte-webapp/src/utils/datadog.ts
@@ -1,10 +1,10 @@
-import { datadogRum } from "@datadog/browser-rum";
-
-export const initDatadogRum = () => {
+export const loadDatadog = async (): Promise<void> => {
   const applicationId = process.env.REACT_APP_DATADOG_APPLICATION_ID ?? window.REACT_APP_DATADOG_APPLICATION_ID;
   if (!applicationId) {
     return;
   }
+
+  const { datadogRum } = await import("@datadog/browser-rum");
 
   const clientToken = process.env.REACT_APP_DATADOG_CLIENT_TOKEN ?? window.REACT_APP_DATADOG_CLIENT_TOKEN;
   const site = process.env.REACT_APP_DATADOG_SITE ?? window.REACT_APP_DATADOG_SITE;

--- a/airbyte-webapp/src/utils/datadog.ts
+++ b/airbyte-webapp/src/utils/datadog.ts
@@ -1,10 +1,9 @@
-export const loadDatadog = async (): Promise<void> => {
+import { datadogRum } from "@datadog/browser-rum";
+export const loadDatadog = (): void => {
   const applicationId = window.REACT_APP_DATADOG_APPLICATION_ID ?? process.env.REACT_APP_DATADOG_APPLICATION_ID;
   if (!applicationId) {
     return;
   }
-
-  const { datadogRum } = await import("@datadog/browser-rum");
 
   const clientToken = window.REACT_APP_DATADOG_CLIENT_TOKEN ?? process.env.REACT_APP_DATADOG_CLIENT_TOKEN;
   const site = window.REACT_APP_DATADOG_SITE ?? process.env.REACT_APP_DATADOG_SITE;

--- a/airbyte-webapp/src/utils/datadog.ts
+++ b/airbyte-webapp/src/utils/datadog.ts
@@ -1,15 +1,15 @@
 export const loadDatadog = async (): Promise<void> => {
-  const applicationId = process.env.REACT_APP_DATADOG_APPLICATION_ID ?? window.REACT_APP_DATADOG_APPLICATION_ID;
+  const applicationId = window.REACT_APP_DATADOG_APPLICATION_ID ?? process.env.REACT_APP_DATADOG_APPLICATION_ID;
   if (!applicationId) {
     return;
   }
 
   const { datadogRum } = await import("@datadog/browser-rum");
 
-  const clientToken = process.env.REACT_APP_DATADOG_CLIENT_TOKEN ?? window.REACT_APP_DATADOG_CLIENT_TOKEN;
-  const site = process.env.REACT_APP_DATADOG_SITE ?? window.REACT_APP_DATADOG_SITE;
-  const service = process.env.REACT_APP_DATADOG_SERVICE ?? window.REACT_APP_DATADOG_SERVICE;
-  const version = process.env.REACT_APP_WEBAPP_TAG ?? window.REACT_APP_WEBAPP_TAG ?? "dev";
+  const clientToken = window.REACT_APP_DATADOG_CLIENT_TOKEN ?? process.env.REACT_APP_DATADOG_CLIENT_TOKEN;
+  const site = window.REACT_APP_DATADOG_SITE ?? process.env.REACT_APP_DATADOG_SITE;
+  const service = window.REACT_APP_DATADOG_SERVICE ?? process.env.REACT_APP_DATADOG_SERVICE;
+  const version = window.REACT_APP_WEBAPP_TAG ?? process.env.REACT_APP_WEBAPP_TAG ?? "dev";
 
   datadogRum.init({
     applicationId,

--- a/airbyte-webapp/src/utils/sentry.ts
+++ b/airbyte-webapp/src/utils/sentry.ts
@@ -1,10 +1,11 @@
-export const loadSentry = async (): Promise<void> => {
+import * as Sentry from "@sentry/react";
+import { Integrations } from "@sentry/tracing";
+
+export const loadSentry = (): void => {
   const dsn = window.REACT_APP_SENTRY_DSN ?? process.env.REACT_APP_SENTRY_DSN;
   if (!dsn) {
     return;
   }
-
-  const [Sentry, { Integrations }] = await Promise.all([import("@sentry/react"), import("@sentry/tracing")]);
 
   const release = window.REACT_APP_WEBAPP_TAG ?? process.env.REACT_APP_WEBAPP_TAG ?? "dev";
   const integrations = [new Integrations.BrowserTracing()];

--- a/airbyte-webapp/src/utils/sentry.ts
+++ b/airbyte-webapp/src/utils/sentry.ts
@@ -1,0 +1,18 @@
+export const loadSentry = async (): Promise<void> => {
+  const dsn = process.env.REACT_APP_SENTRY_DSN ?? window.REACT_APP_SENTRY_DSN;
+  if (!dsn) {
+    return;
+  }
+
+  const [Sentry, { Integrations }] = await Promise.all([import("@sentry/react"), import("@sentry/tracing")]);
+
+  const release = process.env.REACT_APP_WEBAPP_TAG ?? window.REACT_APP_WEBAPP_TAG ?? "dev";
+  const integrations = [new Integrations.BrowserTracing()];
+
+  Sentry.init({
+    dsn,
+    release,
+    integrations,
+    tracesSampleRate: 1.0,
+  });
+};

--- a/airbyte-webapp/src/utils/sentry.ts
+++ b/airbyte-webapp/src/utils/sentry.ts
@@ -1,12 +1,12 @@
 export const loadSentry = async (): Promise<void> => {
-  const dsn = process.env.REACT_APP_SENTRY_DSN ?? window.REACT_APP_SENTRY_DSN;
+  const dsn = window.REACT_APP_SENTRY_DSN ?? process.env.REACT_APP_SENTRY_DSN;
   if (!dsn) {
     return;
   }
 
   const [Sentry, { Integrations }] = await Promise.all([import("@sentry/react"), import("@sentry/tracing")]);
 
-  const release = process.env.REACT_APP_WEBAPP_TAG ?? window.REACT_APP_WEBAPP_TAG ?? "dev";
+  const release = window.REACT_APP_WEBAPP_TAG ?? process.env.REACT_APP_WEBAPP_TAG ?? "dev";
   const integrations = [new Integrations.BrowserTracing()];
 
   Sentry.init({


### PR DESCRIPTION
## What
Related to: https://github.com/airbytehq/airbyte-cloud/issues/2996

Add Datadog Real User Monitoring (RUM) support to app. Update Sentry to lazy import if configuration is available.

https://docs.datadoghq.com/real_user_monitoring/browser/

## How
* Add Datadog utility file and support window variables
* Try loading Datadog on app startup
* Move sentry loading to its own file for tidyness

## Recommended reading order
`airbyte-webapp/src/index.tsx`
`airbyte-webapp/src/utils/datadog.ts`
`airbyte-webapp/src/utils/sentry.ts`
