### PR TITLE
remove worker tag

### DIFF
--- a/charts/airbyte/values.yaml
+++ b/charts/airbyte/values.yaml
@@ -689,7 +689,6 @@ worker:
   image:
     repository: airbyte/worker
     pullPolicy: IfNotPresent
-    tag: 0.40.14
 
   ##  worker.podAnnotations [object] Add extra annotations to the worker pod(s)
   ##


### PR DESCRIPTION
## What
*Describe what the change is solving*
there is no need to maintain default value of worker tag, because it should get it from version of chart or defined explicitly
https://github.com/airbytehq/airbyte/blob/master/charts/airbyte-worker/templates/_helpers.tpl#L68

## How
*Describe the solution*
the logic of this image should be same as it's exist airbyte-server, so it's easy to predict behaviour.
