### PR TITLE
Add base Java image

### DIFF
--- a/airbyte-base-java-image/Dockerfile
+++ b/airbyte-base-java-image/Dockerfile
@@ -1,0 +1,13 @@
+FROM amazoncorretto:19
+
+ARG DOCKER_BUILD_ARCH=amd64
+
+WORKDIR /app
+
+RUN yum install -y tar
+
+# Add the DataDaog Java APM agent
+ADD https://dtdg.co/latest-java-tracer dd-java-agent.jar
+
+# Add the OpenTelemetry Java APM agent
+ADD https://github.com/open-telemetry/opentelemetry-java-instrumentation/releases/latest/download/opentelemetry-javaagent.jar opentelemetry-javaagent.jar

--- a/airbyte-base-java-image/README.md
+++ b/airbyte-base-java-image/README.md
@@ -15,7 +15,7 @@ To release a new version of this base image, use the following steps:
      --tag airbyte/airbyte-base-java-image:<new_version> \
      --platform linux/amd64,linux/arm64 .
    ```
-   To see existing versions, [view the image on Dockerhub](https://hub.docker.com/r/airbyte/java-datadog-tracer-base).
+   To see existing versions, [view the image on Dockerhub](https://hub.docker.com/r/airbyte/airbyte-base-java-image).
 4. Update base Docker image tag to the new version in all Dockerfiles that depend on the base image:
    ```bash
    FROM airbyte/java-datadog-tracer-base:<NEW VERSION>

--- a/airbyte-base-java-image/README.md
+++ b/airbyte-base-java-image/README.md
@@ -1,0 +1,24 @@
+# Base Docker Image for Java
+
+This Docker image provides the base for any Java-based Airbyte module.  It is currently based on the [Amazon Corretto](https://aws.amazon.com/corretto/?filtered-posts.sort-by=item.additionalFields.createdDate&filtered-posts.sort-order=desc)
+distribution of [OpenJDK](https://openjdk.org/).
+
+# Releasing
+
+To release a new version of this base image, use the following steps:
+
+1. Log in to [Dockerhub](https://hub.docker.com/) via the Docker CLI (`docker login`).
+2. Run `docker buildx create --use` to enable Docker `buildx` if you have not used it previously.
+3. Run the following to build and push a new version of this image (replace `<new_version>` with a new version!) :
+   ```
+   docker buildx build --push \
+     --tag airbyte/airbyte-base-java-image:<new_version> \
+     --platform linux/amd64,linux/arm64 .
+   ```
+   To see existing versions, [view the image on Dockerhub](https://hub.docker.com/r/airbyte/java-datadog-tracer-base).
+4. Update base Docker image tag to the new version in all Dockerfiles that depend on the base image:
+   ```bash
+   FROM airbyte/java-datadog-tracer-base:<NEW VERSION>
+   ```
+
+[dockerhub]: https://hub.docker.com/repository/registry-1.docker.io/airbyte/airbyte-base-java-image/general


### PR DESCRIPTION
## What
* Common Docker image for Java-based services

## How
* Add base image that installs the required JDK and any additional/optional tools

## Recommended reading order
1. `Dockerfile`
2. `README.md`

**N.B.**:  I will build and release the image (version 1.0) once we have agreed to this PR.