### PR TITLE
Use locally-installed qemu rather than docker-installed version

### DIFF
--- a/airbyte-config/init/src/main/resources/seed/source_definitions.yaml
+++ b/airbyte-config/init/src/main/resources/seed/source_definitions.yaml
@@ -295,7 +295,7 @@
 - name: Faker
   sourceDefinitionId: dfd88b22-b603-4c3d-aad7-3701784586b1
   dockerRepository: airbyte/source-faker
-  dockerImageTag: 0.1.6
+  dockerImageTag: 0.1.7
   documentationUrl: https://docs.airbyte.com/integrations/sources/faker
   sourceType: api
   releaseStage: alpha

--- a/airbyte-config/init/src/main/resources/seed/source_specs.yaml
+++ b/airbyte-config/init/src/main/resources/seed/source_specs.yaml
@@ -2949,7 +2949,7 @@
         oauthFlowInitParameters: []
         oauthFlowOutputParameters:
         - - "access_token"
-- dockerImage: "airbyte/source-faker:0.1.6"
+- dockerImage: "airbyte/source-faker:0.1.7"
   spec:
     documentationUrl: "https://docs.airbyte.com/integrations/sources/faker"
     connectionSpecification:

--- a/airbyte-integrations/connectors/source-faker/Dockerfile
+++ b/airbyte-integrations/connectors/source-faker/Dockerfile
@@ -34,5 +34,5 @@ COPY source_faker ./source_faker
 ENV AIRBYTE_ENTRYPOINT "python /airbyte/integration_code/main.py"
 ENTRYPOINT ["python", "/airbyte/integration_code/main.py"]
 
-LABEL io.airbyte.version=0.1.6
+LABEL io.airbyte.version=0.1.7
 LABEL io.airbyte.name=airbyte/source-faker

--- a/docs/integrations/sources/faker.md
+++ b/docs/integrations/sources/faker.md
@@ -40,7 +40,8 @@ N/A
 ## Changelog
 
 | Version | Date       | Pull Request                                             | Subject                                                   |
-|:--------| :--------- | :------------------------------------------------------- | :-------------------------------------------------------- |
+| :------ | :--------- | :------------------------------------------------------- | :-------------------------------------------------------- |
+| 0.1.6   | 2022-09-07 | [17848](https://github.com/airbytehq/airbyte/pull/17848) | Bump to test publish command                              |
 | 0.1.6   | 2022-09-07 | [16418](https://github.com/airbytehq/airbyte/pull/16418) | Log start of each stream                                  |
 | 0.1.5   | 2022-06-10 | [13695](https://github.com/airbytehq/airbyte/pull/13695) | Emit timestamps in the proper ISO format                  |
 | 0.1.4   | 2022-05-27 | [13298](https://github.com/airbytehq/airbyte/pull/13298) | Test publication flow                                     |

--- a/docs/integrations/sources/faker.md
+++ b/docs/integrations/sources/faker.md
@@ -41,7 +41,7 @@ N/A
 
 | Version | Date       | Pull Request                                             | Subject                                                   |
 | :------ | :--------- | :------------------------------------------------------- | :-------------------------------------------------------- |
-| 0.1.6   | 2022-09-07 | [17848](https://github.com/airbytehq/airbyte/pull/17848) | Bump to test publish command                              |
+| 0.1.7   | 2022-10-11 | [17848](https://github.com/airbytehq/airbyte/pull/17848) | Bump to test publish command                              |
 | 0.1.6   | 2022-09-07 | [16418](https://github.com/airbytehq/airbyte/pull/16418) | Log start of each stream                                  |
 | 0.1.5   | 2022-06-10 | [13695](https://github.com/airbytehq/airbyte/pull/13695) | Emit timestamps in the proper ISO format                  |
 | 0.1.4   | 2022-05-27 | [13298](https://github.com/airbytehq/airbyte/pull/13298) | Test publication flow                                     |

--- a/tools/integrations/manage.sh
+++ b/tools/integrations/manage.sh
@@ -220,7 +220,7 @@ cmd_publish() {
 
   # Install docker emulators
   # TODO: Don't run this command on M1 macs locally (it won't work and isn't needed)
-  docker run --rm --privileged multiarch/qemu-user-static --reset -p yes
+  apt-get install -y qemu-user-static
 
   # log into docker
   if test -z "${DOCKER_HUB_USERNAME}"; then


### PR DESCRIPTION
Closes https://github.com/airbytehq/airbyte-cloud/issues/3075.

qemu - process emulation - is needed to build docker images for other chips, like Arm/MacOS M1.

> First clue was a recent PR with java connectors base container image change https://github.com/airbytehq/airbyte/pull/17820. Reverting it helped for java but python build still fails in the same way - https://github.com/airbytehq/airbyte/actions/runs/3225745475/jobs/5278467317#step:14:4189

> Our code line that fails - https://github.com/airbytehq/airbyte/blob/master/tools/integrations/manage.sh#L288

> Related moby issue https://github.com/moby/moby/issues/42963#issuecomment-951579182