### PR TITLE
Clean up temporal client and change the acceptance test harness to ca…

### DIFF
--- a/docker-compose.acceptance-test.yaml
+++ b/docker-compose.acceptance-test.yaml
@@ -1,0 +1,13 @@
+# Adds ports to the db and access to the temporal UI for debugging purposes.
+# Expected to be used like this:
+# VERSION=dev docker-compose -f docker-compose.yaml -f docker-compose.debug.yaml up
+version: "3.7"
+x-logging: &default-logging
+  options:
+    max-size: "100m"
+    max-file: "5"
+  driver: json-file
+services:
+  airbyte-temporal:
+    ports:
+      - 7233:7233

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -165,8 +165,6 @@ services:
     logging: *default-logging
     container_name: airbyte-temporal
     restart: unless-stopped
-    ports:
-      - 7233:7233
     environment:
       - DB=postgresql
       - DB_PORT=${DATABASE_PORT}

--- a/tools/bin/acceptance_test.sh
+++ b/tools/bin/acceptance_test.sh
@@ -21,7 +21,7 @@ check_success() {
 echo "Starting app..."
 
 # Detach so we can run subsequent commands
-VERSION=dev TRACKING_STRATEGY=logging USE_STREAM_CAPABLE_STATE=true docker-compose up -d
+VERSION=dev TRACKING_STRATEGY=logging USE_STREAM_CAPABLE_STATE=true docker-compose -f docker-compose.yaml -f docker-compose.acceptance-test.yaml up -d
 
 # Sometimes source/dest containers using airbyte volumes survive shutdown, which need to be killed in order to shut down properly.
 shutdown_cmd="docker-compose down -v || docker kill \$(docker ps -a -f volume=airbyte_workspace -f volume=airbyte_data -f volume=airbyte_db -q) && docker-compose down -v"


### PR DESCRIPTION
…ll the right method

## What
Extract the port forward of the airbyte temporal instance to a docker-compose file outside of the main docker-compose. 

This allow avoiding exposing it in all the docker instances and potentially to the open internet.
