### PR TITLE
Source Amazon Ads - bump dockerfile to 1.23

### DIFF
--- a/airbyte-config/init/src/main/resources/seed/source_definitions.yaml
+++ b/airbyte-config/init/src/main/resources/seed/source_definitions.yaml
@@ -33,7 +33,7 @@
 - name: Amazon Ads
   sourceDefinitionId: c6b0a29e-1da9-4512-9002-7bfd0cba2246
   dockerRepository: airbyte/source-amazon-ads
-  dockerImageTag: 0.1.22
+  dockerImageTag: 0.1.23
   documentationUrl: https://docs.airbyte.com/integrations/sources/amazon-ads
   icon: amazonads.svg
   sourceType: api

--- a/airbyte-config/init/src/main/resources/seed/source_specs.yaml
+++ b/airbyte-config/init/src/main/resources/seed/source_specs.yaml
@@ -647,7 +647,7 @@
     supportsNormalization: false
     supportsDBT: false
     supported_destination_sync_modes: []
-- dockerImage: "airbyte/source-amazon-ads:0.1.22"
+- dockerImage: "airbyte/source-amazon-ads:0.1.23"
   spec:
     documentationUrl: "https://docs.airbyte.com/integrations/sources/amazon-ads"
     connectionSpecification:

--- a/airbyte-integrations/bases/source-acceptance-test/source_acceptance_test/tests/test_incremental.py
+++ b/airbyte-integrations/bases/source-acceptance-test/source_acceptance_test/tests/test_incremental.py
@@ -218,9 +218,7 @@ class TestIncremental(BaseTest):
         stream_name_to_per_stream_state = dict()
         for idx, state_message in enumerate(checkpoint_messages):
             assert state_message.type == Type.STATE
-            state_input, complete_state = self.get_next_state_input(
-                state_message, stream_name_to_per_stream_state, is_per_stream
-            )
+            state_input, complete_state = self.get_next_state_input(state_message, stream_name_to_per_stream_state, is_per_stream)
 
             if len(checkpoint_messages) >= min_batches_to_test and idx % sample_rate != 0:
                 continue

--- a/airbyte-integrations/connectors/source-amazon-ads/Dockerfile
+++ b/airbyte-integrations/connectors/source-amazon-ads/Dockerfile
@@ -12,5 +12,5 @@ RUN pip install .
 ENV AIRBYTE_ENTRYPOINT "python /airbyte/integration_code/main.py"
 ENTRYPOINT ["python", "/airbyte/integration_code/main.py"]
 
-LABEL io.airbyte.version=0.1.22
+LABEL io.airbyte.version=0.1.23
 LABEL io.airbyte.name=airbyte/source-amazon-ads


### PR DESCRIPTION
Bumps dockerfile to version 1.23 

Publishing this PR and properly merging fixes #17870 