### PR TITLE
Fix Docker image existence check (normalization)

### DIFF
--- a/tools/bin/check_images_exist.sh
+++ b/tools/bin/check_images_exist.sh
@@ -29,7 +29,10 @@ checkPlatformImages() {
 checkNormalizationImages() {
   # the only way to know what version of normalization the platform is using is looking in NormalizationRunnerFactory.
   local image_version;
-  image_version=$(cat airbyte-commons-worker/src/main/java/io/airbyte/workers/normalization/NormalizationRunnerFactory.java | grep 'NORMALIZATION_VERSION =' | cut -d"=" -f2 | sed 's:;::' | sed -e 's:"::g' | sed -e 's:[[:space:]]::g')
+  factory_path=airbyte-commons-worker/src/main/java/io/airbyte/workers/normalization/NormalizationRunnerFactory.java
+  # This check should fail if the file doesn't exist, so just try to ls the file
+  ls $factory_path > /dev/null
+  image_version=$(cat $factory_path | grep 'NORMALIZATION_VERSION =' | cut -d"=" -f2 | sed 's:;::' | sed -e 's:"::g' | sed -e 's:[[:space:]]::g')
   echo "Checking normalization images with version $image_version exist..."
   VERSION=$image_version docker-compose -f airbyte-integrations/bases/base-normalization/docker-compose.yaml pull || exit 1
   echo "Success! All normalization images exist!"

--- a/tools/bin/check_images_exist.sh
+++ b/tools/bin/check_images_exist.sh
@@ -29,7 +29,7 @@ checkPlatformImages() {
 checkNormalizationImages() {
   # the only way to know what version of normalization the platform is using is looking in NormalizationRunnerFactory.
   local image_version;
-  image_version=$(cat airbyte-workers/src/main/java/io/airbyte/workers/normalization/NormalizationRunnerFactory.java | grep 'NORMALIZATION_VERSION =' | cut -d"=" -f2 | sed 's:;::' | sed -e 's:"::g' | sed -e 's:[[:space:]]::g')
+  image_version=$(cat airbyte-commons-worker/src/main/java/io/airbyte/workers/normalization/NormalizationRunnerFactory.java | grep 'NORMALIZATION_VERSION =' | cut -d"=" -f2 | sed 's:;::' | sed -e 's:"::g' | sed -e 's:[[:space:]]::g')
   echo "Checking normalization images with version $image_version exist..."
   VERSION=$image_version docker-compose -f airbyte-integrations/bases/base-normalization/docker-compose.yaml pull || exit 1
   echo "Success! All normalization images exist!"


### PR DESCRIPTION
NormalizationRunnerFactory got moved at some point. Update its path. Currently this check always passes for normalization images.