### PR TITLE
Remove typo line from incremental reads docs

### DIFF
--- a/docs/connector-development/config-based/tutorial/5-incremental-reads.md
+++ b/docs/connector-development/config-based/tutorial/5-incremental-reads.md
@@ -125,7 +125,6 @@ streams:
 ```
 
 We'll also update the retriever to user the stream slicer:
-> > > > > > > master
 
 ```yaml
 definitions:


### PR DESCRIPTION
## What

There's a random line "> > > master" in the [Low-code SDK Incremental Reads page](https://docs.airbyte.com/connector-development/config-based/tutorial/incremental-reads):

<img width="906" alt="Screenshot 2022-10-13 at 00 28 52" src="https://user-images.githubusercontent.com/4767109/195459715-8d6b7081-fb61-46e1-9213-d165daec96ef.png">

## How

Remove line.

## Recommended reading order
1. `docs/connector-development/config-based/tutorial/5-incremental-reads.md`

## 🚨 User Impact 🚨

None.

## Pre-merge Checklist
Expand the relevant checklist and delete the others.

