### PR TITLE
docs: update authentication.md

### DIFF
--- a/docs/connector-development/config-based/understanding-the-yaml-file/authentication.md
+++ b/docs/connector-development/config-based/understanding-the-yaml-file/authentication.md
@@ -46,7 +46,7 @@ Example:
 authenticator:
   type: "ApiKeyAuthenticator"
   header: "Authorization"
-  token: "Bearer hello"
+  api_token: "Bearer hello"
 ```
 
 ### BearerAuthenticator
@@ -74,7 +74,7 @@ Example:
 ```yaml
 authenticator:
   type: "BearerAuthenticator"
-  token: "hello"
+  api_token: "hello"
 ```
 
 More information on bearer authentication can be found [here](https://swagger.io/docs/specification/authentication/bearer-authentication/).


### PR DESCRIPTION
## What
The following PR fixes the docs in `authentication.md`. In `ApiKeyAuthenticator` and `BearerAuthenticator` examples, we're using `token` field instead of `api_token`.

## Motivation
During yesterday's office hours, we faced a similar bug because of this typo. 😥

