### PR TITLE
:window: :broom: Add React.PropsWithChildren where needed

### DIFF
--- a/airbyte-webapp/src/components/CreateConnection/CreateConnectionForm.test.tsx
+++ b/airbyte-webapp/src/components/CreateConnection/CreateConnectionForm.test.tsx
@@ -1,5 +1,6 @@
 /* eslint-disable @typescript-eslint/no-non-null-assertion */
 import { act, render as tlr } from "@testing-library/react";
+import React from "react";
 import mockConnection from "test-utils/mock-data/mockConnection.json";
 import mockDest from "test-utils/mock-data/mockDestinationDefinition.json";
 import { TestWrapper } from "test-utils/testutils";
@@ -19,7 +20,7 @@ jest.mock("services/workspaces/WorkspacesService", () => ({
 }));
 
 describe("CreateConnectionForm", () => {
-  const Wrapper: React.FC = ({ children }) => <TestWrapper>{children}</TestWrapper>;
+  const Wrapper: React.FC<React.PropsWithChildren<unknown>> = ({ children }) => <TestWrapper>{children}</TestWrapper>;
   const render = async () => {
     let renderResult: ReturnType<typeof tlr>;
 

--- a/airbyte-webapp/src/components/ui/TextInputContainer/TextInputContainer.tsx
+++ b/airbyte-webapp/src/components/ui/TextInputContainer/TextInputContainer.tsx
@@ -11,7 +11,7 @@ export interface TextInputContainerProps {
   onBlur?: React.FocusEventHandler<HTMLDivElement>;
 }
 
-export const TextInputContainer: React.FC<TextInputContainerProps> = ({
+export const TextInputContainer: React.FC<React.PropsWithChildren<TextInputContainerProps>> = ({
   disabled,
   light,
   error,

--- a/airbyte-webapp/src/hooks/services/ConnectionEdit/ConnectionEditService.tsx
+++ b/airbyte-webapp/src/hooks/services/ConnectionEdit/ConnectionEditService.tsx
@@ -48,7 +48,10 @@ const ConnectionEditContext = createContext<Omit<
   "refreshSchema" | "schemaError"
 > | null>(null);
 
-export const ConnectionEditServiceProvider: React.FC<ConnectionEditProps> = ({ children, ...props }) => {
+export const ConnectionEditServiceProvider: React.FC<React.PropsWithChildren<ConnectionEditProps>> = ({
+  children,
+  ...props
+}) => {
   const { refreshSchema, schemaError, ...data } = useConnectionEdit(props);
   return (
     <ConnectionEditContext.Provider value={data}>

--- a/airbyte-webapp/src/hooks/services/ConnectionForm/ConnectionFormService.tsx
+++ b/airbyte-webapp/src/hooks/services/ConnectionForm/ConnectionFormService.tsx
@@ -82,7 +82,10 @@ const useConnectionForm = ({ connection, mode, schemaError, refreshSchema }: Con
 
 const ConnectionFormContext = createContext<ReturnType<typeof useConnectionForm> | null>(null);
 
-export const ConnectionFormServiceProvider: React.FC<ConnectionServiceProps> = ({ children, ...props }) => {
+export const ConnectionFormServiceProvider: React.FC<React.PropsWithChildren<ConnectionServiceProps>> = ({
+  children,
+  ...props
+}) => {
   const data = useConnectionForm(props);
   return <ConnectionFormContext.Provider value={data}>{children}</ConnectionFormContext.Provider>;
 };

--- a/airbyte-webapp/src/packages/cloud/services/users/InviteUsersModalService.tsx
+++ b/airbyte-webapp/src/packages/cloud/services/users/InviteUsersModalService.tsx
@@ -1,4 +1,4 @@
-import { createContext, useContext, useMemo } from "react";
+import React, { createContext, useContext, useMemo } from "react";
 import { useToggle } from "react-use";
 
 import { InviteUsersModal } from "packages/cloud/views/users/InviteUsersModal";
@@ -19,7 +19,7 @@ export const useInviteUsersModalService = () => {
   return ctx;
 };
 
-export const InviteUsersModalServiceProvider: React.FC = ({ children }) => {
+export const InviteUsersModalServiceProvider: React.FC<React.PropsWithChildren<unknown>> = ({ children }) => {
   const [isOpen, toggleIsOpen] = useToggle(false);
 
   const contextValue = useMemo<InviteUsersModalServiceContext>(

--- a/airbyte-webapp/src/pages/ConnectionPage/pages/ConnectionItemPage/ConnectionReplicationTab.test.tsx
+++ b/airbyte-webapp/src/pages/ConnectionPage/pages/ConnectionItemPage/ConnectionReplicationTab.test.tsx
@@ -2,7 +2,7 @@
 /* eslint-disable @typescript-eslint/no-non-null-assertion */
 
 import { render as tlr, act } from "@testing-library/react";
-import { Suspense } from "react";
+import React, { Suspense } from "react";
 import mockConnection from "test-utils/mock-data/mockConnection.json";
 import mockDest from "test-utils/mock-data/mockDestinationDefinition.json";
 import { TestWrapper } from "test-utils/testutils";
@@ -18,7 +18,7 @@ jest.mock("services/connector/DestinationDefinitionSpecificationService", () => 
 }));
 
 describe("ConnectionReplicationTab", () => {
-  const Wrapper: React.FC = ({ children }) => (
+  const Wrapper: React.FC<React.PropsWithChildren<unknown>> = ({ children }) => (
     <Suspense fallback={<div>I should not show up in a snapshot</div>}>
       <TestWrapper>
         <ConnectionEditServiceProvider connectionId={mockConnection.connectionId}>


### PR DESCRIPTION
## What

Adds `React.PropsWithChildren` to all component that were lacking it so far, to ease the React 18 migration later.