### PR TITLE
ci: upload test results to github for analysis

### DIFF
--- a/.github/workflows/gradle.yml
+++ b/.github/workflows/gradle.yml
@@ -539,6 +539,13 @@ jobs:
           path: '/actions-runner/_work/airbyte/airbyte/*'
           key: ${{ secrets.BUILDPULSE_ACCESS_KEY_ID }}
           secret: ${{ secrets.BUILDPULSE_SECRET_ACCESS_KEY }}
+          
+      - name: Upload test results to Github for analysis 
+        if: '!cancelled()' # Run this step even when the tests fail. Skip if the workflow is cancelled.
+        uses: actions/upload-artifact@v2
+        with:
+          path: '/actions-runner/_work/airbyte/airbyte/*'
+          name: Test Results
 
   # In case of self-hosted EC2 errors, remove this block.
   stop-platform-build-runner:
@@ -688,6 +695,13 @@ jobs:
           path: '/actions-runner/_work/airbyte/airbyte/*'
           key: ${{ secrets.BUILDPULSE_ACCESS_KEY_ID }}
           secret: ${{ secrets.BUILDPULSE_SECRET_ACCESS_KEY }}
+          
+      - name: Upload test results to Github for analysis 
+        if: '!cancelled()' # Run this step even when the tests fail. Skip if the workflow is cancelled.
+        uses: actions/upload-artifact@v2
+        with:
+          path: '/actions-runner/_work/airbyte/airbyte/*'
+          name: Test Results
 
       - uses: actions/upload-artifact@v2
         if: failure()

--- a/.github/workflows/gradle.yml
+++ b/.github/workflows/gradle.yml
@@ -542,10 +542,12 @@ jobs:
           
       - name: Upload test results to Github for analysis 
         if: '!cancelled()' # Run this step even when the tests fail. Skip if the workflow is cancelled.
-        uses: actions/upload-artifact@v2
+        uses: actions/upload-artifact@v3
         with:
-          path: '/actions-runner/_work/airbyte/airbyte/*'
-          name: Test Results
+          path: |
+            /actions-runner/_work/airbyte/airbyte/*/build/test-results/*/*.xml
+            /actions-runner/_work/airbyte/airbyte/*/*/build/test-results/*/*.xml
+          name: test-results-build
 
   # In case of self-hosted EC2 errors, remove this block.
   stop-platform-build-runner:
@@ -698,10 +700,12 @@ jobs:
           
       - name: Upload test results to Github for analysis 
         if: '!cancelled()' # Run this step even when the tests fail. Skip if the workflow is cancelled.
-        uses: actions/upload-artifact@v2
+        uses: actions/upload-artifact@v3
         with:
-          path: '/actions-runner/_work/airbyte/airbyte/*'
-          name: Test Results
+          path: |
+            /actions-runner/_work/airbyte/airbyte/*/build/test-results/*/*.xml
+            /actions-runner/_work/airbyte/airbyte/*/*/build/test-results/*/*.xml
+          name: test-results-kube
 
       - uses: actions/upload-artifact@v2
         if: failure()


### PR DESCRIPTION
## What
Currently we upload test results to buildpulse for analysis but we don't have an easy way to export them for data analysis. This change also uploads to github.

## How
Upload test results to github as well
