### PR TITLE
Remove the bump in the value.yml

### DIFF
--- a/.bumpversion.cfg
+++ b/.bumpversion.cfg
@@ -38,8 +38,6 @@ serialize =
 
 [bumpversion:file:charts/airbyte-bootloader/Chart.yaml]
 
-[bumpversion:file:charts/airbyte/values.yaml]
-
 [bumpversion:file:charts/airbyte/README.md]
 
 [bumpversion:file:docs/operator-guides/upgrading-airbyte.md]


### PR DESCRIPTION
## What
remove the version bump in `charts/airbyte/values.yml` because it has been removed in #17834