### PR TITLE
add source s3 back to catalog

### DIFF
--- a/airbyte-webapp/src/core/domain/connector/constants.ts
+++ b/airbyte-webapp/src/core/domain/connector/constants.ts
@@ -29,7 +29,6 @@ export const getExcludedConnectorIds = (workspaceId: string) =>
         "2340cbba-358e-11ec-8d3d-0242ac130203", // hide Pular Destination https://github.com/airbytehq/airbyte-cloud/issues/2614
         "d4d3fef9-e319-45c2-881a-bd02ce44cc9f", // hide Redis Destination https://github.com/airbytehq/airbyte-cloud/issues/2593
         "2c9d93a7-9a17-4789-9de9-f46f0097eb70", // hide Rockset Destination https://github.com/airbytehq/airbyte-cloud/issues/2615
-        "69589781-7828-43c5-9f63-8925b1c1ccc2", // hide S3 Source https://github.com/airbytehq/airbyte-cloud/issues/2618
         "2470e835-feaf-4db6-96f3-70fd645acc77", // Salesforce Singer
         "3dc6f384-cd6b-4be3-ad16-a41450899bf0", // hide Scylla Destination https://github.com/airbytehq/airbyte-cloud/issues/2617
         "af7c921e-5892-4ff2-b6c1-4a5ab258fb7e", // hide MeiliSearch Destination https://github.com/airbytehq/airbyte/issues/16313


### PR DESCRIPTION
A few weeks back we hid S3 from the catalog in [17472](https://github.com/airbytehq/airbyte/pull/17472) while a longer term security fix for the connector was addressed.

Since the issue where S3 could be configured w/o TLS on certain endpoints was addressed in https://github.com/airbytehq/airbyte/issues/17481 , we can now go ahead with restoring it to the catalog for customers again. After rolling this out to OSS it will then need to be release to cloud as well in a similar fashion to what we did originally.

More context in the slack thread: https://airbytehq-team.slack.com/archives/C02UF50V9HA/p1665682359276099?thread_ts=1665171759.043279&cid=C02UF50V9HA