### PR TITLE
remove documentationurl as required from api

### DIFF
--- a/airbyte-api/src/main/openapi/config.yaml
+++ b/airbyte-api/src/main/openapi/config.yaml
@@ -2522,7 +2522,6 @@ components:
         - name
         - dockerRepository
         - dockerImageTag
-        - documentationUrl
       properties:
         name:
           type: string
@@ -2890,7 +2889,6 @@ components:
         - name
         - dockerRepository
         - dockerImageTag
-        - documentationUrl
       properties:
         name:
           type: string
@@ -2924,7 +2922,6 @@ components:
         - name
         - dockerRepository
         - dockerImageTag
-        - documentationUrl
       properties:
         destinationDefinitionId:
           $ref: "#/components/schemas/DestinationDefinitionId"

--- a/airbyte-commons/src/main/java/io/airbyte/commons/net/Uris.java
+++ b/airbyte-commons/src/main/java/io/airbyte/commons/net/Uris.java
@@ -1,0 +1,29 @@
+/*
+ * Copyright (c) 2022 Airbyte, Inc., all rights reserved.
+ */
+
+package io.airbyte.commons.net;
+
+import java.net.URI;
+import java.net.URISyntaxException;
+import java.util.Optional;
+import javax.annotation.Nullable;
+
+public class Uris {
+
+  /**
+   * Helper to handle nulls when creating a URI from a string. If null, then empty optional.
+   * Otherwise, URI of the string.
+   *
+   * @param stringOrNull - string to convert into a URI. can be null.
+   * @return optional URI of the string or empty optional if input is null.
+   */
+  public static Optional<URI> fromStringOrNull(@Nullable final String stringOrNull) throws URISyntaxException {
+    if (stringOrNull == null) {
+      return Optional.empty();
+    } else {
+      return Optional.of(new URI(stringOrNull));
+    }
+  }
+
+}

--- a/airbyte-commons/src/test/java/io/airbyte/commons/net/UrisTest.java
+++ b/airbyte-commons/src/test/java/io/airbyte/commons/net/UrisTest.java
@@ -1,0 +1,22 @@
+/*
+ * Copyright (c) 2022 Airbyte, Inc., all rights reserved.
+ */
+
+package io.airbyte.commons.net;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+import java.net.URI;
+import java.net.URISyntaxException;
+import java.util.Optional;
+import org.junit.jupiter.api.Test;
+
+class UrisTest {
+
+  @Test
+  void testFromStringOrNull() throws URISyntaxException {
+    assertEquals(Optional.empty(), Uris.fromStringOrNull(null));
+    assertEquals(Optional.of(new URI("hello.com")), Uris.fromStringOrNull("hello.com"));
+  }
+
+}

--- a/airbyte-server/src/main/java/io/airbyte/server/handlers/DestinationDefinitionsHandler.java
+++ b/airbyte-server/src/main/java/io/airbyte/server/handlers/DestinationDefinitionsHandler.java
@@ -21,6 +21,7 @@ import io.airbyte.api.model.generated.PrivateDestinationDefinitionReadList;
 import io.airbyte.api.model.generated.ReleaseStage;
 import io.airbyte.api.model.generated.WorkspaceIdRequestBody;
 import io.airbyte.commons.docker.DockerUtils;
+import io.airbyte.commons.net.Uris;
 import io.airbyte.commons.resources.MoreResources;
 import io.airbyte.commons.util.MoreLists;
 import io.airbyte.commons.version.AirbyteProtocolVersion;
@@ -39,7 +40,6 @@ import io.airbyte.server.scheduler.SynchronousSchedulerClient;
 import io.airbyte.server.services.AirbyteGithubStore;
 import io.airbyte.validation.json.JsonValidationException;
 import java.io.IOException;
-import java.net.URI;
 import java.net.URISyntaxException;
 import java.time.LocalDate;
 import java.util.List;
@@ -84,7 +84,7 @@ public class DestinationDefinitionsHandler {
           .name(standardDestinationDefinition.getName())
           .dockerRepository(standardDestinationDefinition.getDockerRepository())
           .dockerImageTag(standardDestinationDefinition.getDockerImageTag())
-          .documentationUrl(new URI(standardDestinationDefinition.getDocumentationUrl()))
+          .documentationUrl(Uris.fromStringOrNull(standardDestinationDefinition.getDocumentationUrl()).orElse(null))
           .icon(loadIcon(standardDestinationDefinition.getIcon()))
           .protocolVersion(standardDestinationDefinition.getProtocolVersion())
           .releaseStage(getReleaseStage(standardDestinationDefinition))
@@ -203,11 +203,11 @@ public class DestinationDefinitionsHandler {
     final Version airbyteProtocolVersion = AirbyteProtocolVersion.getWithDefault(spec.getProtocolVersion());
 
     final UUID id = uuidSupplier.get();
-    final StandardDestinationDefinition destinationDefinition = new StandardDestinationDefinition()
+    return new StandardDestinationDefinition()
         .withDestinationDefinitionId(id)
         .withDockerRepository(destinationDefCreate.getDockerRepository())
         .withDockerImageTag(destinationDefCreate.getDockerImageTag())
-        .withDocumentationUrl(destinationDefCreate.getDocumentationUrl().toString())
+        .withDocumentationUrl(destinationDefCreate.getDocumentationUrl() == null ? null : destinationDefCreate.getDocumentationUrl().toString())
         .withName(destinationDefCreate.getName())
         .withIcon(destinationDefCreate.getIcon())
         .withSpec(spec)
@@ -215,7 +215,6 @@ public class DestinationDefinitionsHandler {
         .withTombstone(false)
         .withReleaseStage(StandardDestinationDefinition.ReleaseStage.CUSTOM)
         .withResourceRequirements(ApiPojoConverters.actorDefResourceReqsToInternal(destinationDefCreate.getResourceRequirements()));
-    return destinationDefinition;
   }
 
   public DestinationDefinitionRead updateDestinationDefinition(final DestinationDefinitionUpdate destinationDefinitionUpdate)

--- a/airbyte-server/src/main/java/io/airbyte/server/handlers/SourceDefinitionsHandler.java
+++ b/airbyte-server/src/main/java/io/airbyte/server/handlers/SourceDefinitionsHandler.java
@@ -22,6 +22,7 @@ import io.airbyte.api.model.generated.SourceDefinitionUpdate;
 import io.airbyte.api.model.generated.SourceRead;
 import io.airbyte.api.model.generated.WorkspaceIdRequestBody;
 import io.airbyte.commons.docker.DockerUtils;
+import io.airbyte.commons.net.Uris;
 import io.airbyte.commons.resources.MoreResources;
 import io.airbyte.commons.util.MoreLists;
 import io.airbyte.commons.version.AirbyteProtocolVersion;
@@ -40,7 +41,6 @@ import io.airbyte.server.scheduler.SynchronousSchedulerClient;
 import io.airbyte.server.services.AirbyteGithubStore;
 import io.airbyte.validation.json.JsonValidationException;
 import java.io.IOException;
-import java.net.URI;
 import java.net.URISyntaxException;
 import java.time.LocalDate;
 import java.util.List;
@@ -85,7 +85,7 @@ public class SourceDefinitionsHandler {
           .sourceType(getSourceType(standardSourceDefinition))
           .dockerRepository(standardSourceDefinition.getDockerRepository())
           .dockerImageTag(standardSourceDefinition.getDockerImageTag())
-          .documentationUrl(new URI(standardSourceDefinition.getDocumentationUrl()))
+          .documentationUrl(Uris.fromStringOrNull(standardSourceDefinition.getDocumentationUrl()).orElse(null))
           .icon(loadIcon(standardSourceDefinition.getIcon()))
           .protocolVersion(standardSourceDefinition.getProtocolVersion())
           .releaseStage(getReleaseStage(standardSourceDefinition))
@@ -211,7 +211,7 @@ public class SourceDefinitionsHandler {
         .withSourceDefinitionId(id)
         .withDockerRepository(sourceDefinitionCreate.getDockerRepository())
         .withDockerImageTag(sourceDefinitionCreate.getDockerImageTag())
-        .withDocumentationUrl(sourceDefinitionCreate.getDocumentationUrl().toString())
+        .withDocumentationUrl(sourceDefinitionCreate.getDocumentationUrl() == null ? null : sourceDefinitionCreate.getDocumentationUrl().toString())
         .withName(sourceDefinitionCreate.getName())
         .withIcon(sourceDefinitionCreate.getIcon())
         .withSpec(spec)

--- a/airbyte-server/src/test/java/io/airbyte/server/handlers/DestinationDefinitionsHandlerTest.java
+++ b/airbyte-server/src/test/java/io/airbyte/server/handlers/DestinationDefinitionsHandlerTest.java
@@ -30,6 +30,7 @@ import io.airbyte.api.model.generated.ReleaseStage;
 import io.airbyte.api.model.generated.WorkspaceIdRequestBody;
 import io.airbyte.commons.docker.DockerUtils;
 import io.airbyte.commons.json.Jsons;
+import io.airbyte.commons.net.Uris;
 import io.airbyte.config.ActorDefinitionResourceRequirements;
 import io.airbyte.config.JobConfig.ConfigType;
 import io.airbyte.config.ResourceRequirements;
@@ -44,7 +45,6 @@ import io.airbyte.server.scheduler.SynchronousSchedulerClient;
 import io.airbyte.server.services.AirbyteGithubStore;
 import io.airbyte.validation.json.JsonValidationException;
 import java.io.IOException;
-import java.net.URI;
 import java.net.URISyntaxException;
 import java.time.LocalDate;
 import java.util.Collections;
@@ -98,7 +98,6 @@ class DestinationDefinitionsHandlerTest {
         .withName("presto")
         .withDockerImageTag("12.3")
         .withDockerRepository("repo")
-        .withDocumentationUrl("https://hulu.com")
         .withIcon("http.svg")
         .withSpec(spec)
         .withProtocolVersion("0.2.2")
@@ -120,7 +119,7 @@ class DestinationDefinitionsHandlerTest {
         .name(destinationDefinition.getName())
         .dockerRepository(destinationDefinition.getDockerRepository())
         .dockerImageTag(destinationDefinition.getDockerImageTag())
-        .documentationUrl(new URI(destinationDefinition.getDocumentationUrl()))
+        .documentationUrl(Uris.fromStringOrNull(destinationDefinition.getDocumentationUrl()).orElse(null))
         .icon(DestinationDefinitionsHandler.loadIcon(destinationDefinition.getIcon()))
         .protocolVersion(destinationDefinition.getProtocolVersion())
         .releaseStage(ReleaseStage.fromValue(destinationDefinition.getReleaseStage().value()))
@@ -135,7 +134,7 @@ class DestinationDefinitionsHandlerTest {
         .name(destination2.getName())
         .dockerRepository(destination2.getDockerRepository())
         .dockerImageTag(destination2.getDockerImageTag())
-        .documentationUrl(new URI(destination2.getDocumentationUrl()))
+        .documentationUrl(Uris.fromStringOrNull(destination2.getDocumentationUrl()).orElse(null))
         .icon(DestinationDefinitionsHandler.loadIcon(destination2.getIcon()))
         .protocolVersion(destinationDefinition.getProtocolVersion())
         .releaseStage(ReleaseStage.fromValue(destinationDefinition.getReleaseStage().value()))
@@ -165,7 +164,7 @@ class DestinationDefinitionsHandlerTest {
         .name(destinationDefinition.getName())
         .dockerRepository(destinationDefinition.getDockerRepository())
         .dockerImageTag(destinationDefinition.getDockerImageTag())
-        .documentationUrl(new URI(destinationDefinition.getDocumentationUrl()))
+        .documentationUrl(Uris.fromStringOrNull(destinationDefinition.getDocumentationUrl()).orElse(null))
         .icon(DestinationDefinitionsHandler.loadIcon(destinationDefinition.getIcon()))
         .protocolVersion(destinationDefinition.getProtocolVersion())
         .releaseStage(ReleaseStage.fromValue(destinationDefinition.getReleaseStage().value()))
@@ -180,7 +179,7 @@ class DestinationDefinitionsHandlerTest {
         .name(destination2.getName())
         .dockerRepository(destination2.getDockerRepository())
         .dockerImageTag(destination2.getDockerImageTag())
-        .documentationUrl(new URI(destination2.getDocumentationUrl()))
+        .documentationUrl(Uris.fromStringOrNull(destination2.getDocumentationUrl()).orElse(null))
         .icon(DestinationDefinitionsHandler.loadIcon(destination2.getIcon()))
         .protocolVersion(destinationDefinition.getProtocolVersion())
         .releaseStage(ReleaseStage.fromValue(destinationDefinition.getReleaseStage().value()))
@@ -213,7 +212,7 @@ class DestinationDefinitionsHandlerTest {
         .name(destinationDefinition.getName())
         .dockerRepository(destinationDefinition.getDockerRepository())
         .dockerImageTag(destinationDefinition.getDockerImageTag())
-        .documentationUrl(new URI(destinationDefinition.getDocumentationUrl()))
+        .documentationUrl(Uris.fromStringOrNull(destinationDefinition.getDocumentationUrl()).orElse(null))
         .icon(DestinationDefinitionsHandler.loadIcon(destinationDefinition.getIcon()))
         .protocolVersion(destinationDefinition.getProtocolVersion())
         .releaseStage(ReleaseStage.fromValue(destinationDefinition.getReleaseStage().value()))
@@ -228,7 +227,7 @@ class DestinationDefinitionsHandlerTest {
         .name(destinationDefinition2.getName())
         .dockerRepository(destinationDefinition.getDockerRepository())
         .dockerImageTag(destinationDefinition.getDockerImageTag())
-        .documentationUrl(new URI(destinationDefinition.getDocumentationUrl()))
+        .documentationUrl(Uris.fromStringOrNull(destinationDefinition.getDocumentationUrl()).orElse(null))
         .icon(DestinationDefinitionsHandler.loadIcon(destinationDefinition.getIcon()))
         .protocolVersion(destinationDefinition.getProtocolVersion())
         .releaseStage(ReleaseStage.fromValue(destinationDefinition.getReleaseStage().value()))
@@ -264,7 +263,7 @@ class DestinationDefinitionsHandlerTest {
         .name(destinationDefinition.getName())
         .dockerRepository(destinationDefinition.getDockerRepository())
         .dockerImageTag(destinationDefinition.getDockerImageTag())
-        .documentationUrl(new URI(destinationDefinition.getDocumentationUrl()))
+        .documentationUrl(Uris.fromStringOrNull(destinationDefinition.getDocumentationUrl()).orElse(null))
         .icon(DestinationDefinitionsHandler.loadIcon(destinationDefinition.getIcon()))
         .protocolVersion(destinationDefinition.getProtocolVersion())
         .releaseStage(ReleaseStage.fromValue(destinationDefinition.getReleaseStage().value()))
@@ -310,7 +309,7 @@ class DestinationDefinitionsHandlerTest {
         .name(destinationDefinition.getName())
         .dockerRepository(destinationDefinition.getDockerRepository())
         .dockerImageTag(destinationDefinition.getDockerImageTag())
-        .documentationUrl(new URI(destinationDefinition.getDocumentationUrl()))
+        .documentationUrl(Uris.fromStringOrNull(destinationDefinition.getDocumentationUrl()).orElse(null))
         .icon(DestinationDefinitionsHandler.loadIcon(destinationDefinition.getIcon()))
         .protocolVersion(destinationDefinition.getProtocolVersion())
         .releaseStage(ReleaseStage.fromValue(destinationDefinition.getReleaseStage().value()))
@@ -345,7 +344,7 @@ class DestinationDefinitionsHandlerTest {
         .name(destination.getName())
         .dockerRepository(destination.getDockerRepository())
         .dockerImageTag(destination.getDockerImageTag())
-        .documentationUrl(new URI(destination.getDocumentationUrl()))
+        .documentationUrl(Uris.fromStringOrNull(destination.getDocumentationUrl()).orElse(null))
         .icon(destination.getIcon())
         .resourceRequirements(new io.airbyte.api.model.generated.ActorDefinitionResourceRequirements()
             ._default(new io.airbyte.api.model.generated.ResourceRequirements()
@@ -356,7 +355,7 @@ class DestinationDefinitionsHandlerTest {
         .name(destination.getName())
         .dockerRepository(destination.getDockerRepository())
         .dockerImageTag(destination.getDockerImageTag())
-        .documentationUrl(new URI(destination.getDocumentationUrl()))
+        .documentationUrl(Uris.fromStringOrNull(destination.getDocumentationUrl()).orElse(null))
         .destinationDefinitionId(destination.getDestinationDefinitionId())
         .icon(DestinationDefinitionsHandler.loadIcon(destination.getIcon()))
         .protocolVersion(DEFAULT_PROTOCOL_VERSION)
@@ -378,7 +377,7 @@ class DestinationDefinitionsHandlerTest {
 
   @Test
   @DisplayName("createCustomDestinationDefinition should correctly create a destinationDefinition")
-  void testCreateCustomDestinationDefinition() throws URISyntaxException, IOException, JsonValidationException {
+  void testCreateCustomDestinationDefinition() throws URISyntaxException, IOException {
     final StandardDestinationDefinition destination = generateDestinationDefinition();
     final String imageName = DockerUtils.getTaggedImageName(destination.getDockerRepository(), destination.getDockerImageTag());
 
@@ -391,7 +390,7 @@ class DestinationDefinitionsHandlerTest {
         .name(destination.getName())
         .dockerRepository(destination.getDockerRepository())
         .dockerImageTag(destination.getDockerImageTag())
-        .documentationUrl(new URI(destination.getDocumentationUrl()))
+        .documentationUrl(Uris.fromStringOrNull(destination.getDocumentationUrl()).orElse(null))
         .icon(destination.getIcon())
         .resourceRequirements(new io.airbyte.api.model.generated.ActorDefinitionResourceRequirements()
             ._default(new io.airbyte.api.model.generated.ResourceRequirements()
@@ -406,7 +405,7 @@ class DestinationDefinitionsHandlerTest {
         .name(destination.getName())
         .dockerRepository(destination.getDockerRepository())
         .dockerImageTag(destination.getDockerImageTag())
-        .documentationUrl(new URI(destination.getDocumentationUrl()))
+        .documentationUrl(Uris.fromStringOrNull(destination.getDocumentationUrl()).orElse(null))
         .destinationDefinitionId(destination.getDestinationDefinitionId())
         .icon(DestinationDefinitionsHandler.loadIcon(destination.getIcon()))
         .protocolVersion(DEFAULT_PROTOCOL_VERSION)
@@ -454,7 +453,7 @@ class DestinationDefinitionsHandlerTest {
         Jsons.clone(destinationDefinition).withDockerImageTag(newDockerImageTag).withSpec(newSpec).withProtocolVersion(newProtocolVersion);
 
     final DestinationDefinitionRead destinationRead = destinationDefinitionsHandler.updateDestinationDefinition(
-        new DestinationDefinitionUpdate().destinationDefinitionId(this.destinationDefinition.getDestinationDefinitionId())
+        new DestinationDefinitionUpdate().destinationDefinitionId(destinationDefinition.getDestinationDefinitionId())
             .dockerImageTag(newDockerImageTag));
 
     assertEquals(newDockerImageTag, destinationRead.getDockerImageTag());
@@ -467,7 +466,7 @@ class DestinationDefinitionsHandlerTest {
   void testDeleteDestinationDefinition() throws ConfigNotFoundException, IOException, JsonValidationException {
     final DestinationDefinitionIdRequestBody destinationDefinitionIdRequestBody =
         new DestinationDefinitionIdRequestBody().destinationDefinitionId(destinationDefinition.getDestinationDefinitionId());
-    final StandardDestinationDefinition updatedDestinationDefinition = Jsons.clone(this.destinationDefinition).withTombstone(true);
+    final StandardDestinationDefinition updatedDestinationDefinition = Jsons.clone(destinationDefinition).withTombstone(true);
     final DestinationRead destination = new DestinationRead();
 
     when(configRepository.getStandardDestinationDefinition(destinationDefinition.getDestinationDefinitionId()))
@@ -494,7 +493,7 @@ class DestinationDefinitionsHandlerTest {
         .name(destinationDefinition.getName())
         .dockerRepository(destinationDefinition.getDockerRepository())
         .dockerImageTag(destinationDefinition.getDockerImageTag())
-        .documentationUrl(new URI(destinationDefinition.getDocumentationUrl()))
+        .documentationUrl(Uris.fromStringOrNull(destinationDefinition.getDocumentationUrl()).orElse(null))
         .icon(DestinationDefinitionsHandler.loadIcon(destinationDefinition.getIcon()))
         .protocolVersion(destinationDefinition.getProtocolVersion())
         .releaseStage(ReleaseStage.fromValue(destinationDefinition.getReleaseStage().value()))

--- a/airbyte-server/src/test/java/io/airbyte/server/handlers/SourceDefinitionsHandlerTest.java
+++ b/airbyte-server/src/test/java/io/airbyte/server/handlers/SourceDefinitionsHandlerTest.java
@@ -31,6 +31,7 @@ import io.airbyte.api.model.generated.SourceReadList;
 import io.airbyte.api.model.generated.WorkspaceIdRequestBody;
 import io.airbyte.commons.docker.DockerUtils;
 import io.airbyte.commons.json.Jsons;
+import io.airbyte.commons.net.Uris;
 import io.airbyte.config.ActorDefinitionResourceRequirements;
 import io.airbyte.config.JobConfig.ConfigType;
 import io.airbyte.config.ResourceRequirements;
@@ -45,7 +46,6 @@ import io.airbyte.server.scheduler.SynchronousSchedulerClient;
 import io.airbyte.server.services.AirbyteGithubStore;
 import io.airbyte.validation.json.JsonValidationException;
 import java.io.IOException;
-import java.net.URI;
 import java.net.URISyntaxException;
 import java.time.LocalDate;
 import java.util.Collections;
@@ -94,7 +94,6 @@ class SourceDefinitionsHandlerTest {
     return new StandardSourceDefinition()
         .withSourceDefinitionId(sourceDefinitionId)
         .withName("presto")
-        .withDocumentationUrl("https://netflix.com")
         .withDockerRepository("dockerstuff")
         .withDockerImageTag("12.3")
         .withIcon("http.svg")
@@ -118,7 +117,7 @@ class SourceDefinitionsHandlerTest {
         .name(sourceDefinition.getName())
         .dockerRepository(sourceDefinition.getDockerRepository())
         .dockerImageTag(sourceDefinition.getDockerImageTag())
-        .documentationUrl(new URI(sourceDefinition.getDocumentationUrl()))
+        .documentationUrl(Uris.fromStringOrNull(sourceDefinition.getDocumentationUrl()).orElse(null))
         .icon(SourceDefinitionsHandler.loadIcon(sourceDefinition.getIcon()))
         .releaseStage(ReleaseStage.fromValue(sourceDefinition.getReleaseStage().value()))
         .releaseDate(LocalDate.parse(sourceDefinition.getReleaseDate()))
@@ -132,7 +131,7 @@ class SourceDefinitionsHandlerTest {
         .name(sourceDefinition2.getName())
         .dockerRepository(sourceDefinition.getDockerRepository())
         .dockerImageTag(sourceDefinition.getDockerImageTag())
-        .documentationUrl(new URI(sourceDefinition.getDocumentationUrl()))
+        .documentationUrl(Uris.fromStringOrNull(sourceDefinition.getDocumentationUrl()).orElse(null))
         .icon(SourceDefinitionsHandler.loadIcon(sourceDefinition.getIcon()))
         .releaseStage(ReleaseStage.fromValue(sourceDefinition.getReleaseStage().value()))
         .releaseDate(LocalDate.parse(sourceDefinition.getReleaseDate()))
@@ -161,7 +160,7 @@ class SourceDefinitionsHandlerTest {
         .name(sourceDefinition.getName())
         .dockerRepository(sourceDefinition.getDockerRepository())
         .dockerImageTag(sourceDefinition.getDockerImageTag())
-        .documentationUrl(new URI(sourceDefinition.getDocumentationUrl()))
+        .documentationUrl(Uris.fromStringOrNull(sourceDefinition.getDocumentationUrl()).orElse(null))
         .icon(SourceDefinitionsHandler.loadIcon(sourceDefinition.getIcon()))
         .releaseStage(ReleaseStage.fromValue(sourceDefinition.getReleaseStage().value()))
         .releaseDate(LocalDate.parse(sourceDefinition.getReleaseDate()))
@@ -175,7 +174,7 @@ class SourceDefinitionsHandlerTest {
         .name(sourceDefinition2.getName())
         .dockerRepository(sourceDefinition.getDockerRepository())
         .dockerImageTag(sourceDefinition.getDockerImageTag())
-        .documentationUrl(new URI(sourceDefinition.getDocumentationUrl()))
+        .documentationUrl(Uris.fromStringOrNull(sourceDefinition.getDocumentationUrl()).orElse(null))
         .icon(SourceDefinitionsHandler.loadIcon(sourceDefinition.getIcon()))
         .releaseStage(ReleaseStage.fromValue(sourceDefinition.getReleaseStage().value()))
         .releaseDate(LocalDate.parse(sourceDefinition.getReleaseDate()))
@@ -207,7 +206,7 @@ class SourceDefinitionsHandlerTest {
         .name(sourceDefinition.getName())
         .dockerRepository(sourceDefinition.getDockerRepository())
         .dockerImageTag(sourceDefinition.getDockerImageTag())
-        .documentationUrl(new URI(sourceDefinition.getDocumentationUrl()))
+        .documentationUrl(Uris.fromStringOrNull(sourceDefinition.getDocumentationUrl()).orElse(null))
         .icon(SourceDefinitionsHandler.loadIcon(sourceDefinition.getIcon()))
         .releaseStage(ReleaseStage.fromValue(sourceDefinition.getReleaseStage().value()))
         .releaseDate(LocalDate.parse(sourceDefinition.getReleaseDate()))
@@ -221,7 +220,7 @@ class SourceDefinitionsHandlerTest {
         .name(sourceDefinition2.getName())
         .dockerRepository(sourceDefinition.getDockerRepository())
         .dockerImageTag(sourceDefinition.getDockerImageTag())
-        .documentationUrl(new URI(sourceDefinition.getDocumentationUrl()))
+        .documentationUrl(Uris.fromStringOrNull(sourceDefinition.getDocumentationUrl()).orElse(null))
         .icon(SourceDefinitionsHandler.loadIcon(sourceDefinition.getIcon()))
         .releaseStage(ReleaseStage.fromValue(sourceDefinition.getReleaseStage().value()))
         .releaseDate(LocalDate.parse(sourceDefinition.getReleaseDate()))
@@ -255,7 +254,7 @@ class SourceDefinitionsHandlerTest {
         .name(sourceDefinition.getName())
         .dockerRepository(sourceDefinition.getDockerRepository())
         .dockerImageTag(sourceDefinition.getDockerImageTag())
-        .documentationUrl(new URI(sourceDefinition.getDocumentationUrl()))
+        .documentationUrl(Uris.fromStringOrNull(sourceDefinition.getDocumentationUrl()).orElse(null))
         .icon(SourceDefinitionsHandler.loadIcon(sourceDefinition.getIcon()))
         .releaseStage(ReleaseStage.fromValue(sourceDefinition.getReleaseStage().value()))
         .releaseDate(LocalDate.parse(sourceDefinition.getReleaseDate()))
@@ -298,7 +297,7 @@ class SourceDefinitionsHandlerTest {
         .name(sourceDefinition.getName())
         .dockerRepository(sourceDefinition.getDockerRepository())
         .dockerImageTag(sourceDefinition.getDockerImageTag())
-        .documentationUrl(new URI(sourceDefinition.getDocumentationUrl()))
+        .documentationUrl(Uris.fromStringOrNull(sourceDefinition.getDocumentationUrl()).orElse(null))
         .icon(SourceDefinitionsHandler.loadIcon(sourceDefinition.getIcon()))
         .releaseStage(ReleaseStage.fromValue(sourceDefinition.getReleaseStage().value()))
         .releaseDate(LocalDate.parse(sourceDefinition.getReleaseDate()))
@@ -332,7 +331,7 @@ class SourceDefinitionsHandlerTest {
         .name(sourceDefinition.getName())
         .dockerRepository(sourceDefinition.getDockerRepository())
         .dockerImageTag(sourceDefinition.getDockerImageTag())
-        .documentationUrl(new URI(sourceDefinition.getDocumentationUrl()))
+        .documentationUrl(Uris.fromStringOrNull(sourceDefinition.getDocumentationUrl()).orElse(null))
         .icon(sourceDefinition.getIcon())
         .resourceRequirements(new io.airbyte.api.model.generated.ActorDefinitionResourceRequirements()
             ._default(new io.airbyte.api.model.generated.ResourceRequirements()
@@ -343,7 +342,7 @@ class SourceDefinitionsHandlerTest {
         .name(sourceDefinition.getName())
         .dockerRepository(sourceDefinition.getDockerRepository())
         .dockerImageTag(sourceDefinition.getDockerImageTag())
-        .documentationUrl(new URI(sourceDefinition.getDocumentationUrl()))
+        .documentationUrl(Uris.fromStringOrNull(sourceDefinition.getDocumentationUrl()).orElse(null))
         .sourceDefinitionId(sourceDefinition.getSourceDefinitionId())
         .icon(SourceDefinitionsHandler.loadIcon(sourceDefinition.getIcon()))
         .protocolVersion(DEFAULT_PROTOCOL_VERSION)
@@ -367,7 +366,7 @@ class SourceDefinitionsHandlerTest {
 
   @Test
   @DisplayName("createCustomSourceDefinition should correctly create a sourceDefinition")
-  void testCreateCustomSourceDefinition() throws URISyntaxException, IOException, JsonValidationException {
+  void testCreateCustomSourceDefinition() throws URISyntaxException, IOException {
     final StandardSourceDefinition sourceDefinition = generateSourceDefinition();
     final String imageName = DockerUtils.getTaggedImageName(sourceDefinition.getDockerRepository(), sourceDefinition.getDockerImageTag());
 
@@ -380,7 +379,7 @@ class SourceDefinitionsHandlerTest {
         .name(sourceDefinition.getName())
         .dockerRepository(sourceDefinition.getDockerRepository())
         .dockerImageTag(sourceDefinition.getDockerImageTag())
-        .documentationUrl(new URI(sourceDefinition.getDocumentationUrl()))
+        .documentationUrl(Uris.fromStringOrNull(sourceDefinition.getDocumentationUrl()).orElse(null))
         .icon(sourceDefinition.getIcon())
         .resourceRequirements(new io.airbyte.api.model.generated.ActorDefinitionResourceRequirements()
             ._default(new io.airbyte.api.model.generated.ResourceRequirements()
@@ -395,7 +394,7 @@ class SourceDefinitionsHandlerTest {
         .name(sourceDefinition.getName())
         .dockerRepository(sourceDefinition.getDockerRepository())
         .dockerImageTag(sourceDefinition.getDockerImageTag())
-        .documentationUrl(new URI(sourceDefinition.getDocumentationUrl()))
+        .documentationUrl(Uris.fromStringOrNull(sourceDefinition.getDocumentationUrl()).orElse(null))
         .sourceDefinitionId(sourceDefinition.getSourceDefinitionId())
         .icon(SourceDefinitionsHandler.loadIcon(sourceDefinition.getIcon()))
         .protocolVersion(DEFAULT_PROTOCOL_VERSION)
@@ -420,7 +419,7 @@ class SourceDefinitionsHandlerTest {
 
   @Test
   @DisplayName("updateSourceDefinition should correctly update a sourceDefinition")
-  void testUpdateSourceDefinition() throws ConfigNotFoundException, IOException, JsonValidationException, URISyntaxException {
+  void testUpdateSourceDefinition() throws ConfigNotFoundException, IOException, JsonValidationException {
     when(configRepository.getStandardSourceDefinition(sourceDefinition.getSourceDefinitionId())).thenReturn(sourceDefinition);
     final String newDockerImageTag = "averydifferenttag";
     final String newProtocolVersion = "0.2.1";
@@ -454,7 +453,7 @@ class SourceDefinitionsHandlerTest {
   void testDeleteSourceDefinition() throws ConfigNotFoundException, IOException, JsonValidationException {
     final SourceDefinitionIdRequestBody sourceDefinitionIdRequestBody =
         new SourceDefinitionIdRequestBody().sourceDefinitionId(sourceDefinition.getSourceDefinitionId());
-    final StandardSourceDefinition updatedSourceDefinition = Jsons.clone(this.sourceDefinition).withTombstone(true);
+    final StandardSourceDefinition updatedSourceDefinition = Jsons.clone(sourceDefinition).withTombstone(true);
     final SourceRead source = new SourceRead();
 
     when(configRepository.getStandardSourceDefinition(sourceDefinition.getSourceDefinitionId()))
@@ -481,7 +480,7 @@ class SourceDefinitionsHandlerTest {
         .name(sourceDefinition.getName())
         .dockerRepository(sourceDefinition.getDockerRepository())
         .dockerImageTag(sourceDefinition.getDockerImageTag())
-        .documentationUrl(new URI(sourceDefinition.getDocumentationUrl()))
+        .documentationUrl(Uris.fromStringOrNull(sourceDefinition.getDocumentationUrl()).orElse(null))
         .icon(SourceDefinitionsHandler.loadIcon(sourceDefinition.getIcon()))
         .releaseStage(ReleaseStage.fromValue(sourceDefinition.getReleaseStage().value()))
         .releaseDate(LocalDate.parse(sourceDefinition.getReleaseDate()))
@@ -522,7 +521,7 @@ class SourceDefinitionsHandlerTest {
 
     @Test
     @DisplayName("should return the latest list")
-    void testCorrect() throws IOException, InterruptedException {
+    void testCorrect() throws InterruptedException {
       final StandardSourceDefinition sourceDefinition = generateSourceDefinition();
       when(githubStore.getLatestSources()).thenReturn(Collections.singletonList(sourceDefinition));
 

--- a/docs/reference/api/generated-api-html/index.html
+++ b/docs/reference/api/generated-api-html/index.html
@@ -10427,7 +10427,7 @@ containing the updated stream needs to be sent.</div>
       <div class="param">name </div><div class="param-desc"><span class="param-type"><a href="#string">String</a></span>  </div>
 <div class="param">dockerRepository </div><div class="param-desc"><span class="param-type"><a href="#string">String</a></span>  </div>
 <div class="param">dockerImageTag </div><div class="param-desc"><span class="param-type"><a href="#string">String</a></span>  </div>
-<div class="param">documentationUrl </div><div class="param-desc"><span class="param-type"><a href="#URI">URI</a></span>  format: uri</div>
+<div class="param">documentationUrl (optional)</div><div class="param-desc"><span class="param-type"><a href="#URI">URI</a></span>  format: uri</div>
 <div class="param">icon (optional)</div><div class="param-desc"><span class="param-type"><a href="#string">String</a></span>  </div>
 <div class="param">resourceRequirements (optional)</div><div class="param-desc"><span class="param-type"><a href="#ActorDefinitionResourceRequirements">ActorDefinitionResourceRequirements</a></span>  </div>
     </div>  <!-- field-items -->
@@ -10455,7 +10455,7 @@ containing the updated stream needs to be sent.</div>
 <div class="param">name </div><div class="param-desc"><span class="param-type"><a href="#string">String</a></span>  </div>
 <div class="param">dockerRepository </div><div class="param-desc"><span class="param-type"><a href="#string">String</a></span>  </div>
 <div class="param">dockerImageTag </div><div class="param-desc"><span class="param-type"><a href="#string">String</a></span>  </div>
-<div class="param">documentationUrl </div><div class="param-desc"><span class="param-type"><a href="#URI">URI</a></span>  format: uri</div>
+<div class="param">documentationUrl (optional)</div><div class="param-desc"><span class="param-type"><a href="#URI">URI</a></span>  format: uri</div>
 <div class="param">icon (optional)</div><div class="param-desc"><span class="param-type"><a href="#string">String</a></span>  </div>
 <div class="param">protocolVersion (optional)</div><div class="param-desc"><span class="param-type"><a href="#string">String</a></span> The Airbyte Protocol version supported by the connector </div>
 <div class="param">releaseStage (optional)</div><div class="param-desc"><span class="param-type"><a href="#ReleaseStage">ReleaseStage</a></span>  </div>
@@ -11089,7 +11089,7 @@ if oauth parameters were contained inside the top level, rootObject=[] If they w
       <div class="param">name </div><div class="param-desc"><span class="param-type"><a href="#string">String</a></span>  </div>
 <div class="param">dockerRepository </div><div class="param-desc"><span class="param-type"><a href="#string">String</a></span>  </div>
 <div class="param">dockerImageTag </div><div class="param-desc"><span class="param-type"><a href="#string">String</a></span>  </div>
-<div class="param">documentationUrl </div><div class="param-desc"><span class="param-type"><a href="#URI">URI</a></span>  format: uri</div>
+<div class="param">documentationUrl (optional)</div><div class="param-desc"><span class="param-type"><a href="#URI">URI</a></span>  format: uri</div>
 <div class="param">icon (optional)</div><div class="param-desc"><span class="param-type"><a href="#string">String</a></span>  </div>
 <div class="param">resourceRequirements (optional)</div><div class="param-desc"><span class="param-type"><a href="#ActorDefinitionResourceRequirements">ActorDefinitionResourceRequirements</a></span>  </div>
     </div>  <!-- field-items -->


### PR DESCRIPTION
relates to https://github.com/airbytehq/airbyte/issues/3382
## What
* Part 1 of this issue https://github.com/airbytehq/airbyte/issues/3382. Stops `documentationUrl` from being required in the API. 
* Part 2 will be removing it as required in the FE.