### PR TITLE
ensure workspace webhook configs can be persisted correctly

### DIFF
--- a/airbyte-api/src/main/openapi/config.yaml
+++ b/airbyte-api/src/main/openapi/config.yaml
@@ -2454,6 +2454,10 @@ components:
             $ref: "#/components/schemas/Notification"
         defaultGeography:
           $ref: "#/components/schemas/Geography"
+        webhookConfigs:
+          type: array
+          items:
+            $ref: "#/components/schemas/WebhookConfigWrite"
     WorkspaceGiveFeedback:
       type: object
       required:

--- a/airbyte-config/config-persistence/src/main/java/io/airbyte/config/persistence/DbConverter.java
+++ b/airbyte-config/config-persistence/src/main/java/io/airbyte/config/persistence/DbConverter.java
@@ -99,7 +99,9 @@ public class DbConverter {
         .withFirstCompletedSync(record.get(WORKSPACE.FIRST_SYNC_COMPLETE))
         .withFeedbackDone(record.get(WORKSPACE.FEEDBACK_COMPLETE))
         .withDefaultGeography(
-            Enums.toEnum(record.get(WORKSPACE.GEOGRAPHY, String.class), Geography.class).orElseThrow());
+            Enums.toEnum(record.get(WORKSPACE.GEOGRAPHY, String.class), Geography.class).orElseThrow())
+        .withWebhookOperationConfigs(record.get(WORKSPACE.WEBHOOK_OPERATION_CONFIGS) == null ? null
+            : Jsons.deserialize(record.get(WORKSPACE.WEBHOOK_OPERATION_CONFIGS).data()));
   }
 
   public static SourceConnection buildSourceConnection(final Record record) {

--- a/airbyte-config/config-persistence/src/test/java/io/airbyte/config/persistence/MockData.java
+++ b/airbyte-config/config-persistence/src/test/java/io/airbyte/config/persistence/MockData.java
@@ -36,6 +36,8 @@ import io.airbyte.config.StandardSyncOperation.OperatorType;
 import io.airbyte.config.StandardSyncState;
 import io.airbyte.config.StandardWorkspace;
 import io.airbyte.config.State;
+import io.airbyte.config.WebhookConfig;
+import io.airbyte.config.WebhookOperationConfigs;
 import io.airbyte.config.WorkspaceServiceAccount;
 import io.airbyte.protocol.models.AirbyteCatalog;
 import io.airbyte.protocol.models.AuthSpecification;
@@ -156,7 +158,9 @@ public class MockData {
         .withNotifications(Collections.singletonList(notification))
         .withFirstCompletedSync(true)
         .withFeedbackDone(true)
-        .withDefaultGeography(Geography.AUTO);
+        .withDefaultGeography(Geography.AUTO)
+        .withWebhookOperationConfigs(Jsons.jsonNode(
+            new WebhookOperationConfigs().withWebhookConfigs(List.of(new WebhookConfig().withId(WEBHOOK_CONFIG_ID).withName("name")))));
 
     final StandardWorkspace workspace2 = new StandardWorkspace()
         .withWorkspaceId(WORKSPACE_ID_2)

--- a/airbyte-server/src/main/java/io/airbyte/server/converters/WorkspaceWebhookConfigsConverter.java
+++ b/airbyte-server/src/main/java/io/airbyte/server/converters/WorkspaceWebhookConfigsConverter.java
@@ -15,6 +15,7 @@ import java.util.Collections;
 import java.util.Iterator;
 import java.util.List;
 import java.util.UUID;
+import java.util.function.Supplier;
 import java.util.stream.Collectors;
 
 // NOTE: we suppress this warning because PMD thinks it can be a foreach loop in toApiReads but the
@@ -22,13 +23,13 @@ import java.util.stream.Collectors;
 @SuppressWarnings("PMD.ForLoopCanBeForeach")
 public class WorkspaceWebhookConfigsConverter {
 
-  public static JsonNode toPersistenceWrite(List<WebhookConfigWrite> apiWebhookConfigs) {
+  public static JsonNode toPersistenceWrite(List<WebhookConfigWrite> apiWebhookConfigs, Supplier<UUID> uuidSupplier) {
     if (apiWebhookConfigs == null) {
       return Jsons.emptyObject();
     }
 
     final WebhookOperationConfigs configs = new WebhookOperationConfigs()
-        .withWebhookConfigs(apiWebhookConfigs.stream().map(WorkspaceWebhookConfigsConverter::toPersistenceConfig).collect(Collectors.toList()));
+        .withWebhookConfigs(apiWebhookConfigs.stream().map((item) -> toPersistenceConfig(uuidSupplier, item)).collect(Collectors.toList()));
 
     return Jsons.jsonNode(configs);
   }
@@ -50,9 +51,9 @@ public class WorkspaceWebhookConfigsConverter {
     return configReads;
   }
 
-  private static WebhookConfig toPersistenceConfig(final WebhookConfigWrite input) {
+  private static WebhookConfig toPersistenceConfig(final Supplier<UUID> uuidSupplier, final WebhookConfigWrite input) {
     return new WebhookConfig()
-        .withId(UUID.randomUUID())
+        .withId(uuidSupplier.get())
         .withName(input.getName())
         .withAuthToken(input.getAuthToken());
   }

--- a/airbyte-server/src/main/java/io/airbyte/server/handlers/WorkspacesHandler.java
+++ b/airbyte-server/src/main/java/io/airbyte/server/handlers/WorkspacesHandler.java
@@ -105,7 +105,7 @@ public class WorkspacesHandler {
         .withTombstone(false)
         .withNotifications(NotificationConverter.toConfigList(workspaceCreate.getNotifications()))
         .withDefaultGeography(defaultGeography)
-        .withWebhookOperationConfigs(WorkspaceWebhookConfigsConverter.toPersistenceWrite(workspaceCreate.getWebhookConfigs()));
+        .withWebhookOperationConfigs(WorkspaceWebhookConfigsConverter.toPersistenceWrite(workspaceCreate.getWebhookConfigs(), uuidSupplier));
 
     if (!Strings.isNullOrEmpty(email)) {
       workspace.withEmail(email);
@@ -303,7 +303,7 @@ public class WorkspacesHandler {
           Enums.convertTo(workspacePatch.getDefaultGeography(), io.airbyte.config.Geography.class));
     }
     if (workspacePatch.getWebhookConfigs() != null) {
-      workspace.setWebhookOperationConfigs(WorkspaceWebhookConfigsConverter.toPersistenceWrite(workspacePatch.getWebhookConfigs()));
+      workspace.setWebhookOperationConfigs(WorkspaceWebhookConfigsConverter.toPersistenceWrite(workspacePatch.getWebhookConfigs(), uuidSupplier));
     }
   }
 

--- a/airbyte-server/src/main/java/io/airbyte/server/handlers/WorkspacesHandler.java
+++ b/airbyte-server/src/main/java/io/airbyte/server/handlers/WorkspacesHandler.java
@@ -24,9 +24,7 @@ import io.airbyte.api.model.generated.WorkspaceReadList;
 import io.airbyte.api.model.generated.WorkspaceUpdate;
 import io.airbyte.api.model.generated.WorkspaceUpdateName;
 import io.airbyte.commons.enums.Enums;
-import io.airbyte.commons.json.Jsons;
 import io.airbyte.config.StandardWorkspace;
-import io.airbyte.config.WebhookOperationConfigs;
 import io.airbyte.config.persistence.ConfigNotFoundException;
 import io.airbyte.config.persistence.ConfigRepository;
 import io.airbyte.config.persistence.SecretsRepositoryWriter;
@@ -39,7 +37,6 @@ import io.airbyte.server.errors.ValueConflictKnownException;
 import io.airbyte.validation.json.JsonValidationException;
 import java.io.IOException;
 import java.util.List;
-import java.util.Optional;
 import java.util.UUID;
 import java.util.function.Supplier;
 import java.util.stream.Collectors;
@@ -269,12 +266,9 @@ public class WorkspacesHandler {
         .notifications(NotificationConverter.toApiList(workspace.getNotifications()))
         .defaultGeography(Enums.convertTo(workspace.getDefaultGeography(), Geography.class));
     // Add read-only webhook configs.
-    final Optional<WebhookOperationConfigs> persistedConfigs = Jsons.tryObject(
-        workspace.getWebhookOperationConfigs(),
-        WebhookOperationConfigs.class);
-    if (persistedConfigs.isPresent()) {
-      result.setWebhookConfigs(WorkspaceWebhookConfigsConverter.toApiReads(
-          persistedConfigs.get().getWebhookConfigs()));
+    if (workspace.getWebhookOperationConfigs() != null) {
+      LOGGER.info("webhook configs: {}", workspace.getWebhookOperationConfigs());
+      result.setWebhookConfigs(WorkspaceWebhookConfigsConverter.toApiReads(workspace.getWebhookOperationConfigs()));
     }
     return result;
   }
@@ -308,6 +302,9 @@ public class WorkspacesHandler {
     if (workspacePatch.getDefaultGeography() != null) {
       workspace.setDefaultGeography(
           Enums.convertTo(workspacePatch.getDefaultGeography(), io.airbyte.config.Geography.class));
+    }
+    if (workspacePatch.getWebhookConfigs() != null) {
+      workspace.setWebhookOperationConfigs(WorkspaceWebhookConfigsConverter.toPersistenceWrite(workspacePatch.getWebhookConfigs()));
     }
   }
 

--- a/airbyte-server/src/main/java/io/airbyte/server/handlers/WorkspacesHandler.java
+++ b/airbyte-server/src/main/java/io/airbyte/server/handlers/WorkspacesHandler.java
@@ -267,7 +267,6 @@ public class WorkspacesHandler {
         .defaultGeography(Enums.convertTo(workspace.getDefaultGeography(), Geography.class));
     // Add read-only webhook configs.
     if (workspace.getWebhookOperationConfigs() != null) {
-      LOGGER.info("webhook configs: {}", workspace.getWebhookOperationConfigs());
       result.setWebhookConfigs(WorkspaceWebhookConfigsConverter.toApiReads(workspace.getWebhookOperationConfigs()));
     }
     return result;

--- a/airbyte-server/src/main/java/io/airbyte/server/handlers/WorkspacesHandler.java
+++ b/airbyte-server/src/main/java/io/airbyte/server/handlers/WorkspacesHandler.java
@@ -5,6 +5,7 @@
 package io.airbyte.server.handlers;
 
 import com.github.slugify.Slugify;
+import com.google.common.annotations.VisibleForTesting;
 import com.google.common.base.Preconditions;
 import com.google.common.base.Strings;
 import io.airbyte.analytics.TrackingClientSingleton;
@@ -63,12 +64,13 @@ public class WorkspacesHandler {
     this(configRepository, secretsRepositoryWriter, connectionsHandler, destinationHandler, sourceHandler, UUID::randomUUID);
   }
 
-  public WorkspacesHandler(final ConfigRepository configRepository,
-                           final SecretsRepositoryWriter secretsRepositoryWriter,
-                           final ConnectionsHandler connectionsHandler,
-                           final DestinationHandler destinationHandler,
-                           final SourceHandler sourceHandler,
-                           final Supplier<UUID> uuidSupplier) {
+  @VisibleForTesting
+  WorkspacesHandler(final ConfigRepository configRepository,
+                    final SecretsRepositoryWriter secretsRepositoryWriter,
+                    final ConnectionsHandler connectionsHandler,
+                    final DestinationHandler destinationHandler,
+                    final SourceHandler sourceHandler,
+                    final Supplier<UUID> uuidSupplier) {
     this.configRepository = configRepository;
     this.secretsRepositoryWriter = secretsRepositoryWriter;
     this.connectionsHandler = connectionsHandler;

--- a/airbyte-server/src/test/java/io/airbyte/server/handlers/WorkspacesHandlerTest.java
+++ b/airbyte-server/src/test/java/io/airbyte/server/handlers/WorkspacesHandlerTest.java
@@ -22,6 +22,8 @@ import io.airbyte.api.model.generated.DestinationReadList;
 import io.airbyte.api.model.generated.SlugRequestBody;
 import io.airbyte.api.model.generated.SourceRead;
 import io.airbyte.api.model.generated.SourceReadList;
+import io.airbyte.api.model.generated.WebhookConfigRead;
+import io.airbyte.api.model.generated.WebhookConfigWrite;
 import io.airbyte.api.model.generated.WorkspaceCreate;
 import io.airbyte.api.model.generated.WorkspaceGiveFeedback;
 import io.airbyte.api.model.generated.WorkspaceIdRequestBody;
@@ -38,6 +40,7 @@ import io.airbyte.config.StandardWorkspace;
 import io.airbyte.config.persistence.ConfigNotFoundException;
 import io.airbyte.config.persistence.ConfigRepository;
 import io.airbyte.config.persistence.SecretsRepositoryWriter;
+import io.airbyte.config.persistence.split_secrets.SecretPersistence;
 import io.airbyte.server.converters.NotificationConverter;
 import io.airbyte.validation.json.JsonValidationException;
 import java.io.IOException;
@@ -55,6 +58,8 @@ class WorkspacesHandlerTest {
 
   public static final String FAILURE_NOTIFICATION_WEBHOOK = "http://airbyte.notifications/failure";
   public static final String NEW_WORKSPACE = "new workspace";
+  public static final String TEST_NAME = "test-name";
+  private static final UUID WEBHOOK_CONFIG_ID = UUID.randomUUID();
   private ConfigRepository configRepository;
   private SecretsRepositoryWriter secretsRepositoryWriter;
   private ConnectionsHandler connectionsHandler;
@@ -72,12 +77,14 @@ class WorkspacesHandlerTest {
       io.airbyte.api.model.generated.Geography.AUTO;
   private static final io.airbyte.api.model.generated.Geography GEOGRAPHY_US =
       io.airbyte.api.model.generated.Geography.US;
+  private SecretPersistence secretPersistence;
 
   @SuppressWarnings("unchecked")
   @BeforeEach
   void setUp() {
     configRepository = mock(ConfigRepository.class);
-    secretsRepositoryWriter = new SecretsRepositoryWriter(configRepository, Optional.empty(), Optional.empty());
+    secretPersistence = mock(SecretPersistence.class);
+    secretsRepositoryWriter = new SecretsRepositoryWriter(configRepository, Optional.of(secretPersistence), Optional.empty());
     connectionsHandler = mock(ConnectionsHandler.class);
     destinationHandler = mock(DestinationHandler.class);
     sourceHandler = mock(SourceHandler.class);
@@ -330,7 +337,8 @@ class WorkspacesHandlerTest {
         .initialSetupComplete(true)
         .displaySetupWizard(false)
         .notifications(List.of(apiNotification))
-        .defaultGeography(GEOGRAPHY_US);
+        .defaultGeography(GEOGRAPHY_US)
+        .webhookConfigs(List.of(new WebhookConfigWrite().name(TEST_NAME).authToken("test-auth-token")));
 
     final Notification expectedNotification = generateNotification();
     expectedNotification.getSlackConfiguration().withWebhook("updated");
@@ -347,7 +355,12 @@ class WorkspacesHandlerTest {
         .withDisplaySetupWizard(false)
         .withTombstone(false)
         .withNotifications(List.of(expectedNotification))
-        .withDefaultGeography(Geography.US);
+        .withDefaultGeography(Geography.US)
+        .withWebhookOperationConfigs(Jsons.deserialize(
+            String.format("{\"webhookConfigs\": [{\"id\": \"%s\", \"name\": \"%s\", \"authToken\": {\"_secret\": \"a-secret_v1\"}}]}",
+                WEBHOOK_CONFIG_ID.toString(), TEST_NAME)));
+
+    when(uuidSupplier.get()).thenReturn(WEBHOOK_CONFIG_ID);
 
     when(configRepository.getStandardWorkspaceNoSecrets(workspace.getWorkspaceId(), false))
         .thenReturn(workspace)
@@ -369,7 +382,8 @@ class WorkspacesHandlerTest {
         .anonymousDataCollection(true)
         .securityUpdates(false)
         .notifications(List.of(expectedNotificationRead))
-        .defaultGeography(GEOGRAPHY_US);
+        .defaultGeography(GEOGRAPHY_US)
+        .webhookConfigs(List.of(new WebhookConfigRead().name(TEST_NAME).id(WEBHOOK_CONFIG_ID)));
 
     verify(configRepository).writeStandardWorkspaceNoSecrets(expectedWorkspace);
 

--- a/docs/reference/api/generated-api-html/index.html
+++ b/docs/reference/api/generated-api-html/index.html
@@ -11578,6 +11578,7 @@ if oauth parameters were contained inside the top level, rootObject=[] If they w
 <div class="param">securityUpdates (optional)</div><div class="param-desc"><span class="param-type"><a href="#boolean">Boolean</a></span>  </div>
 <div class="param">notifications (optional)</div><div class="param-desc"><span class="param-type"><a href="#Notification">array[Notification]</a></span>  </div>
 <div class="param">defaultGeography (optional)</div><div class="param-desc"><span class="param-type"><a href="#Geography">Geography</a></span>  </div>
+<div class="param">webhookConfigs (optional)</div><div class="param-desc"><span class="param-type"><a href="#WebhookConfigWrite">array[WebhookConfigWrite]</a></span>  </div>
     </div>  <!-- field-items -->
   </div>
   <div class="model">


### PR DESCRIPTION
## What
Makes sure that the workspace-level webhook operation configs are passed correctly between API and persistence.

## How
- Include webhook configs in the `workspace/update` route.
- Make sure that the database layer properly handles them.
- Write some custom JSON handling to read the webhook configs. This is necessary because the only way -- currently -- to get the stored JSON blob to properly deserialise is to first hydrate the secrets (since the secrets were split out before writing the JSON blob), and _then_ deserialise. In other words, the JSON that's in the database doesn't conform to the schema because of the secrets. Doing this custom handling lets us get the readonly bits of the config without having to unnecessarily hydrate the secrets (including a round trip to the secrets manager, and increasing some exposure risk).

## Recommended reading order
1. `airbyte-api/src/main/openapi/config.yaml`
2. `airbyte-server/src/main/java/io/airbyte/server/handlers/WorkspacesHandler.java`
3. `airbyte-server/src/main/java/io/airbyte/server/converters/WorkspaceWebhookConfigsConverter.java`

## Testing
Validated e2e that webhook configs can be written, updated, and read. Added some unit test coverage.