### PR TITLE
Update helm release workflow

### DIFF
--- a/.github/workflows/publish-helm-charts.yml
+++ b/.github/workflows/publish-helm-charts.yml
@@ -106,6 +106,14 @@ jobs:
           cwd: './airbyte-oss/'
       
 
+      - name: "Generate changelog"
+        shell: bash
+        id: changelog
+        run: |
+          cd ./airbyte/
+          echo "::set-output name=changelog::$(PAGER=cat git log $(git describe --tags --match "*-helm" $(git rev-list --tags --max-count=1))..HEAD --oneline --decorate=no)"
+
+
       - name: Create Pull Request
         uses: peter-evans/create-pull-request@v4
         with:
@@ -116,23 +124,14 @@ jobs:
           body: |
             ## What
             Bump version reference in all Chart.yaml files to ${{ needs.generate-semantic-version.outputs.next-version }}
+            CHANGELOG:
+            ${{ steps.changelog.outputs.changelog }}
           commit-message: Bump helm chart version reference to ${{ needs.generate-semantic-version.outputs.next-version }}
           delete-branch: true
 
-      - name: "Generate changelog"
+      - name: Create tag
         shell: bash
-        id: changelog
         run: |
-          echo "::set-output name=changelog::$(PAGER=cat git log $(git describe --tags --match "*-helm" $(git rev-list --tags --max-count=1))..HEAD --oneline --decorate=no)"
-
-      - name: Create Release
-        id: create_release
-        uses: ncipollo/release-action@v1
-        with:
-          body: |
-            ## What
-            Bump version reference in all Chart.yaml files to ${{ needs.generate-semantic-version.outputs.next-version }}
-            CHANGELOG:
-            ${{ steps.changelog.outputs.changelog }}
-          token: ${{ secrets.GITHUB_TOKEN }}
-          tag: ${{ needs.generate-semantic-version.outputs.tag }}
+          cd ./airbyte/
+          git tag ${{ needs.generate-semantic-version.outputs.tag }}
+          git push origin ${{ needs.generate-semantic-version.outputs.tag }}

--- a/.github/workflows/publish-helm-charts.yml
+++ b/.github/workflows/publish-helm-charts.yml
@@ -105,21 +105,34 @@ jobs:
           add: '.'
           cwd: './airbyte-oss/'
       
-      - name: Commit and push changes
-        uses: EndBug/add-and-commit@v9
-        with:
-          message: 'Bump release to ${{ needs.generate-semantic-version.outputs.tag }}'
-          add: '.'
-          tag: ${{ needs.generate-semantic-version.outputs.tag }}
-          new_branch: update-helm-chart-version-ref
-      
+
       - name: Create Pull Request
         uses: peter-evans/create-pull-request@v4
         with:
           path: ./airbyte/
           branch: update-helm-chart-version-ref
+          branch-suffix: random
           title: Bump helm chart version reference to ${{ needs.generate-semantic-version.outputs.next-version }}
           body: |
             ## What
             Bump version reference in all Chart.yaml files to ${{ needs.generate-semantic-version.outputs.next-version }}
           commit-message: Bump helm chart version reference to ${{ needs.generate-semantic-version.outputs.next-version }}
+          delete-branch: true
+
+      - name: "Generate changelog"
+        shell: bash
+        id: changelog
+        run: |
+          echo "::set-output name=changelog::$(PAGER=cat git log $(git describe --tags --match "*-helm" $(git rev-list --tags --max-count=1))..HEAD --oneline --decorate=no)"
+
+      - name: Create Release
+        id: create_release
+        uses: ncipollo/release-action@v1
+        with:
+          body: |
+            ## What
+            Bump version reference in all Chart.yaml files to ${{ needs.generate-semantic-version.outputs.next-version }}
+            CHANGELOG:
+            ${{ steps.changelog.outputs.changelog }}
+          token: ${{ secrets.GITHUB_TOKEN }}
+          tag: ${{ needs.generate-semantic-version.outputs.tag }}

--- a/.github/workflows/publish-helm-charts.yml
+++ b/.github/workflows/publish-helm-charts.yml
@@ -8,6 +8,8 @@ on:
       - 'master'
     paths:
       - 'charts/**'
+      - '!charts/**/Chart.yaml'
+      - '!charts/**/Chart.lock'
   workflow_dispatch:
 
 jobs:

--- a/.github/workflows/publish-helm-charts.yml
+++ b/.github/workflows/publish-helm-charts.yml
@@ -15,7 +15,8 @@ jobs:
     name: Generate semantic version
     runs-on: ubuntu-22.04
     outputs:
-      next-version: ${{ steps.sem-ver.outputs.version }}
+      next-version: ${{ steps.ver.outputs.fragment }}
+      tag: ${{ steps.sem-ver.outputs.version_tag }}
     steps:
       - uses: actions/checkout@v2
         with:
@@ -30,11 +31,21 @@ jobs:
           format: "${major}.${minor}.${patch}"
           change_path: "./charts"
           bump_each_commit: true
+          namespace: helm
+
+      - name: "Remove -helm from ver number"
+        shell: bash
+        env:
+          VERSION: ${{ steps.sem-ver.outputs.version }}
+        id: ver
+        run: echo "::set-output name=fragment::${VERSION%%-*}"
+
 
   release-chart:
     name: Chart release
     runs-on: ubuntu-22.04
     needs: ["generate-semantic-version"]
+    permissions: write-all
     steps:
       - uses: actions/checkout@v3
         with:
@@ -51,7 +62,9 @@ jobs:
         shell: bash
         working-directory: ./airbyte/charts
         run: |
-          sed -i "s/    version: placeholder/    version: ${{ needs.generate-semantic-version.outputs.next-version }}/g" airbyte/Chart.yaml
+          sed -i -E "s/    version: [[:digit:]].[[:digit:]].[[:digit:]]/    version: ${{ needs.generate-semantic-version.outputs.next-version }}/g" airbyte/Chart.yaml
+          sed -i -E 's/version: [0-9]+\.[0-9]+\.[0-9]+/version: ${{ needs.generate-semantic-version.outputs.next-version }}/' airbyte/Chart.yaml
+
 
       - name: "Helm package"
         shell: bash
@@ -59,6 +72,7 @@ jobs:
           declare -a StringArray=("airbyte-bootloader" "airbyte-server" "airbyte-temporal" "airbyte-webapp" "airbyte-pod-sweeper" "airbyte-worker" "airbyte-metrics")
           for val in ${StringArray[@]}; do
             cd ./airbyte/charts/${val} && helm dep update && cd $GITHUB_WORKSPACE
+            sed -i -E  's/version: \"[0-9]+\.[0-9]+\.[0-9]+\"/version: \"${{ needs.generate-semantic-version.outputs.next-version }}\"/' ./airbyte/charts/${val}/Chart.yaml
             helm package ./airbyte/charts/${val} -d airbyte-oss  --version ${{ needs.generate-semantic-version.outputs.next-version }}
           done
           helm repo index airbyte-oss/
@@ -89,3 +103,21 @@ jobs:
           add: '.'
           cwd: './airbyte-oss/'
       
+      - name: Commit and push changes
+        uses: EndBug/add-and-commit@v9
+        with:
+          message: 'Bump release to ${{ needs.generate-semantic-version.outputs.tag }}'
+          add: '.'
+          tag: ${{ needs.generate-semantic-version.outputs.tag }}
+          new_branch: update-helm-chart-version-ref
+      
+      - name: Create Pull Request
+        uses: peter-evans/create-pull-request@v4
+        with:
+          path: ./airbyte/
+          branch: update-helm-chart-version-ref
+          title: Bump helm chart version reference to ${{ needs.generate-semantic-version.outputs.next-version }}
+          body: |
+            ## What
+            Bump version reference in all Chart.yaml files to ${{ needs.generate-semantic-version.outputs.next-version }}
+          commit-message: Bump helm chart version reference to ${{ needs.generate-semantic-version.outputs.next-version }}


### PR DESCRIPTION
## What
* Update helm release workflow so it'll follow its own versioning properly using tags
* Fix issue with incorrect version pattern
## How
* Instead of using airbyte oss tags, use own instead(it'll look like `v${{ major }}.${{ minor }}.${{ patch }}-helm` this tag will be pushed on each helm chart release + a release on gh pages will be created
* After this a PR will be created containing updated Chart.yaml files(`version` field will be updated for beautiful README.md and readme on artifacthub)
* This will allow us to keep chart in this repo and also keep own helm versioning