### PR TITLE
fix check for streams that do not use a stream slicer

### DIFF
--- a/airbyte-cdk/python/CHANGELOG.md
+++ b/airbyte-cdk/python/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## 0.1.102
+
+- Low-code: Fix check for streams that do not define a stream slicer
+
 ## 0.1.101
 
 - Low-code: $options do not overwrite parameters that are already set

--- a/airbyte-cdk/python/airbyte_cdk/sources/declarative/stream_slicers/single_slice.py
+++ b/airbyte-cdk/python/airbyte_cdk/sources/declarative/stream_slicers/single_slice.py
@@ -56,4 +56,4 @@ class SingleSlice(StreamSlicer, JsonSchemaMixin):
         return {}
 
     def stream_slices(self, sync_mode: SyncMode, stream_state: Mapping[str, Any]) -> Iterable[StreamSlice]:
-        return [dict()]
+        yield dict()

--- a/airbyte-cdk/python/setup.py
+++ b/airbyte-cdk/python/setup.py
@@ -15,7 +15,7 @@ README = (HERE / "README.md").read_text()
 
 setup(
     name="airbyte-cdk",
-    version="0.1.101",
+    version="0.1.102",
     description="A framework for writing Airbyte Connectors.",
     long_description=README,
     long_description_content_type="text/markdown",

--- a/airbyte-cdk/python/unit_tests/sources/declarative/iterators/test_only_once.py
+++ b/airbyte-cdk/python/unit_tests/sources/declarative/iterators/test_only_once.py
@@ -10,4 +10,5 @@ def test():
     iterator = SingleSlice(options={})
 
     stream_slices = iterator.stream_slices(SyncMode.incremental, None)
-    assert stream_slices == [dict()]
+    next_slice = next(stream_slices)
+    assert next_slice == dict()


### PR DESCRIPTION
## What
We had a small bug where streams that did not use a stream slicer would error out while running `check`. This should fix that issue

## How
In `single_slice.py` we were accidentally emitting a list which is not iterable which would cause check to fail. Instead this should be yielding the empty `dict()` which will in turn return an iterable.

## Recommended reading order
1. `single_slice.py`