### PR TITLE
DO NOT MERGE: source-e2e-test legacy: set supported sync mode to full refresh

### DIFF
--- a/airbyte-integrations/connectors/source-e2e-test/Dockerfile
+++ b/airbyte-integrations/connectors/source-e2e-test/Dockerfile
@@ -8,5 +8,5 @@ COPY build/distributions/${APPLICATION}*.tar ${APPLICATION}.tar
 
 RUN tar xf ${APPLICATION}.tar --strip-components=1
 
-LABEL io.airbyte.version=0.1.1
+LABEL io.airbyte.version=0.1.2
 LABEL io.airbyte.name=airbyte/source-e2e-test

--- a/airbyte-protocol/models/src/main/java/io/airbyte/protocol/models/CatalogHelpers.java
+++ b/airbyte-protocol/models/src/main/java/io/airbyte/protocol/models/CatalogHelpers.java
@@ -17,7 +17,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.Set;
 import java.util.stream.Collectors;
-
+import io.airbyte.protocol.models.SyncMode;
 /**
  * Helper class for Catalog and Stream related operations. Generally only used in tests.
  */
@@ -37,7 +37,7 @@ public class CatalogHelpers {
   }
 
   public static AirbyteStream createAirbyteStream(final String streamName, final String namespace, final List<Field> fields) {
-    return new AirbyteStream().withName(streamName).withNamespace(namespace).withJsonSchema(fieldsToJsonSchema(fields));
+    return new AirbyteStream().withName(streamName).withNamespace(namespace).withJsonSchema(fieldsToJsonSchema(fields)).withSupportedSyncModes(Lists.newArrayList(SyncMode.FULL_REFRESH));
   }
 
   public static ConfiguredAirbyteCatalog createConfiguredAirbyteCatalog(final String streamName, final String namespace, final Field... fields) {


### PR DESCRIPTION
## What
I'd like to patch an old version of `source-e2e-test` (0.1.1) still used in our acceptance tests. The latest version of `source-e2e-test` is `>= 2.0.0`.
My [protocol change PR](https://github.com/airbytehq/airbyte/pull/15591) make the `supported_sync_modes` field required on all AirbyteStream. 


## How
I want to update `0.1.1` catalog to have `supported_sync_modes`.

I want to publish this change in `0.1.2` but not merge this PR because this is a legacy patch. 

⚠️ **THIS PR SHOULD NOT BE MERGED BUT ONLY CLOSED AFTER SUCCESSFUL PUBLISH OF 0.1.2**

