### PR TITLE
DO NOT MERGE: source-e2e-test legacy: set supported sync mode to full refresh

### DIFF
--- a/airbyte-integrations/connectors/source-e2e-test/Dockerfile
+++ b/airbyte-integrations/connectors/source-e2e-test/Dockerfile
@@ -1,4 +1,4 @@
-FROM airbyte/integration-base-java:dev AS build
+FROM airbyte/integration-base-java:dev
 
 WORKDIR /airbyte
 
@@ -6,16 +6,7 @@ ENV APPLICATION source-e2e-test
 
 COPY build/distributions/${APPLICATION}*.tar ${APPLICATION}.tar
 
-RUN tar xf ${APPLICATION}.tar --strip-components=1 && rm -rf ${APPLICATION}.tar
+RUN tar xf ${APPLICATION}.tar --strip-components=1
 
-FROM airbyte/integration-base-java:dev
-
-WORKDIR /airbyte
-
-ENV APPLICATION source-e2e-test
-ENV ENABLE_SENTRY true
-
-COPY --from=build /airbyte /airbyte
-
-LABEL io.airbyte.version=2.1.2
+LABEL io.airbyte.version=0.1.2
 LABEL io.airbyte.name=airbyte/source-e2e-test

--- a/airbyte-integrations/connectors/source-e2e-test/build.gradle
+++ b/airbyte-integrations/connectors/source-e2e-test/build.gradle
@@ -9,25 +9,23 @@ application {
 }
 
 dependencies {
-    implementation project(':airbyte-db:lib')
     implementation project(':airbyte-integrations:bases:base-java')
-    implementation project(':airbyte-protocol:models')
-    implementation project(':airbyte-integrations:connectors:source-jdbc')
-
+    implementation project(':airbyte-protocol:protocol-models')
+    implementation project(':airbyte-json-validation')
     implementation 'org.apache.commons:commons-lang3:3.11'
-    implementation "org.postgresql:postgresql:42.2.18"
-    implementation 'io.debezium:debezium-embedded:1.4.2.Final'
-    implementation 'io.debezium:debezium-api:1.4.2.Final'
-    implementation 'io.debezium:debezium-connector-postgres:1.4.2.Final'
+    implementation 'com.networknt:json-schema-validator:1.0.72'
+    implementation files(project(':airbyte-integrations:bases:base-java').airbyteDocker.outputs)
 
-    testImplementation testFixtures(project(':airbyte-integrations:connectors:source-jdbc'))
+    // random Json object generation from Json schema
+    // https://github.com/airbytehq/jsongenerator
+    implementation 'net.jimblackler.jsonschemafriend:core:0.11.2'
+    implementation 'org.mozilla:rhino-engine:1.7.14'
+    implementation group: 'com.github.airbytehq', name: 'jsongenerator', version: '1.0.1'
+
     testImplementation project(":airbyte-json-validation")
     testImplementation project(':airbyte-test-utils')
 
-    testImplementation 'org.testcontainers:postgresql:1.15.3'
-
     integrationTestJavaImplementation project(':airbyte-integrations:bases:standard-source-test')
-
-    implementation files(project(':airbyte-integrations:bases:base-java').airbyteDocker.outputs)
+    integrationTestJavaImplementation project(':airbyte-integrations:connectors:source-e2e-test')
     integrationTestJavaImplementation files(project(':airbyte-integrations:bases:base-java').airbyteDocker.outputs)
 }

--- a/airbyte-integrations/connectors/source-e2e-test/build.gradle
+++ b/airbyte-integrations/connectors/source-e2e-test/build.gradle
@@ -9,23 +9,25 @@ application {
 }
 
 dependencies {
+    implementation project(':airbyte-db:lib')
     implementation project(':airbyte-integrations:bases:base-java')
-    implementation project(':airbyte-protocol:protocol-models')
-    implementation project(':airbyte-json-validation')
+    implementation project(':airbyte-protocol:models')
+    implementation project(':airbyte-integrations:connectors:source-jdbc')
+
     implementation 'org.apache.commons:commons-lang3:3.11'
-    implementation 'com.networknt:json-schema-validator:1.0.72'
-    implementation files(project(':airbyte-integrations:bases:base-java').airbyteDocker.outputs)
+    implementation "org.postgresql:postgresql:42.2.18"
+    implementation 'io.debezium:debezium-embedded:1.4.2.Final'
+    implementation 'io.debezium:debezium-api:1.4.2.Final'
+    implementation 'io.debezium:debezium-connector-postgres:1.4.2.Final'
 
-    // random Json object generation from Json schema
-    // https://github.com/airbytehq/jsongenerator
-    implementation 'net.jimblackler.jsonschemafriend:core:0.11.2'
-    implementation 'org.mozilla:rhino-engine:1.7.14'
-    implementation group: 'com.github.airbytehq', name: 'jsongenerator', version: '1.0.1'
-
+    testImplementation testFixtures(project(':airbyte-integrations:connectors:source-jdbc'))
     testImplementation project(":airbyte-json-validation")
     testImplementation project(':airbyte-test-utils')
 
+    testImplementation 'org.testcontainers:postgresql:1.15.3'
+
     integrationTestJavaImplementation project(':airbyte-integrations:bases:standard-source-test')
-    integrationTestJavaImplementation project(':airbyte-integrations:connectors:source-e2e-test')
+
+    implementation files(project(':airbyte-integrations:bases:base-java').airbyteDocker.outputs)
     integrationTestJavaImplementation files(project(':airbyte-integrations:bases:base-java').airbyteDocker.outputs)
 }

--- a/airbyte-integrations/connectors/source-e2e-test/src/main/java/io/airbyte/integrations/source/e2e_test/ExceptionAfterNSource.java
+++ b/airbyte-integrations/connectors/source-e2e-test/src/main/java/io/airbyte/integrations/source/e2e_test/ExceptionAfterNSource.java
@@ -1,0 +1,111 @@
+/*
+ * Copyright (c) 2021 Airbyte, Inc., all rights reserved.
+ */
+
+package io.airbyte.integrations.source.e2e_test;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import com.google.common.collect.AbstractIterator;
+import com.google.common.collect.ImmutableMap;
+import io.airbyte.commons.json.Jsons;
+import io.airbyte.commons.util.AutoCloseableIterator;
+import io.airbyte.commons.util.AutoCloseableIterators;
+import io.airbyte.integrations.BaseConnector;
+import io.airbyte.integrations.base.Source;
+import io.airbyte.protocol.models.AirbyteCatalog;
+import io.airbyte.protocol.models.AirbyteConnectionStatus;
+import io.airbyte.protocol.models.AirbyteConnectionStatus.Status;
+import io.airbyte.protocol.models.AirbyteMessage;
+import io.airbyte.protocol.models.AirbyteMessage.Type;
+import io.airbyte.protocol.models.AirbyteRecordMessage;
+import io.airbyte.protocol.models.AirbyteStateMessage;
+import io.airbyte.protocol.models.CatalogHelpers;
+import io.airbyte.protocol.models.ConfiguredAirbyteCatalog;
+import io.airbyte.protocol.models.Field;
+import io.airbyte.protocol.models.JsonSchemaPrimitive;
+import io.airbyte.protocol.models.SyncMode;
+import java.time.Instant;
+import java.util.List;
+import java.util.concurrent.atomic.AtomicBoolean;
+import java.util.concurrent.atomic.AtomicLong;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+/**
+ * Throws an exception after it emits N record messages where N == throw_after_n_records. Ever 5th
+ * message emitted is a state message. State messages do NOT count against N.
+ */
+public class ExceptionAfterNSource extends BaseConnector implements Source {
+
+  private static final Logger LOGGER = LoggerFactory.getLogger(ExceptionAfterNSource.class);
+
+  private static final String STREAM_NAME = "data";
+  private static final String COLUMN_NAME = "column1";
+  static final AirbyteCatalog CATALOG = CatalogHelpers.createAirbyteCatalog(
+      STREAM_NAME,
+      Field.of(COLUMN_NAME, JsonSchemaPrimitive.STRING));
+  static {
+    CATALOG.getStreams().get(0).setSupportedSyncModes(List.of(SyncMode.FULL_REFRESH, SyncMode.INCREMENTAL));
+    CATALOG.getStreams().get(0).setSourceDefinedCursor(true);
+  }
+
+  @Override
+  public AirbyteConnectionStatus check(final JsonNode config) {
+    return new AirbyteConnectionStatus().withStatus(Status.SUCCEEDED);
+  }
+
+  @Override
+  public AirbyteCatalog discover(final JsonNode config) {
+    return Jsons.clone(CATALOG);
+  }
+
+  @Override
+  public AutoCloseableIterator<AirbyteMessage> read(final JsonNode config, final ConfiguredAirbyteCatalog catalog, final JsonNode state) {
+    final long throwAfterNRecords = config.get("throw_after_n_records").asLong();
+
+    final AtomicLong recordsEmitted = new AtomicLong();
+    final AtomicLong recordValue;
+    if (state != null && state.has(COLUMN_NAME)) {
+      LOGGER.info("Found state: {}", state);
+      recordValue = new AtomicLong(state.get(COLUMN_NAME).asLong());
+    } else {
+      LOGGER.info("No state found.");
+      recordValue = new AtomicLong();
+    }
+
+    final AtomicBoolean hasEmittedStateAtCount = new AtomicBoolean();
+    return AutoCloseableIterators.fromIterator(new AbstractIterator<>() {
+
+      @Override
+      protected AirbyteMessage computeNext() {
+        if (recordsEmitted.get() % 5 == 0 && !hasEmittedStateAtCount.get()) {
+
+          LOGGER.info("{}: emitting state record with value {}", ExceptionAfterNSource.class, recordValue.get());
+
+          hasEmittedStateAtCount.set(true);
+          return new AirbyteMessage()
+              .withType(Type.STATE)
+              .withState(new AirbyteStateMessage().withData(Jsons.jsonNode(ImmutableMap.of(COLUMN_NAME, recordValue.get()))));
+        } else if (throwAfterNRecords > recordsEmitted.get()) {
+          recordsEmitted.incrementAndGet();
+          recordValue.incrementAndGet();
+          hasEmittedStateAtCount.set(false);
+
+          LOGGER.info("{} ExceptionAfterNSource: emitting record with value {}. record {} in sync.",
+              ExceptionAfterNSource.class, recordValue.get(), recordsEmitted.get());
+
+          return new AirbyteMessage()
+              .withType(Type.RECORD)
+              .withRecord(new AirbyteRecordMessage()
+                  .withStream(STREAM_NAME)
+                  .withEmittedAt(Instant.now().toEpochMilli())
+                  .withData(Jsons.jsonNode(ImmutableMap.of(COLUMN_NAME, recordValue.get()))));
+        } else {
+          throw new IllegalStateException("Scheduled exceptional event.");
+        }
+      }
+
+    });
+  }
+
+}

--- a/airbyte-integrations/connectors/source-e2e-test/src/main/java/io/airbyte/integrations/source/e2e_test/ExceptionAfterNSource.java
+++ b/airbyte-integrations/connectors/source-e2e-test/src/main/java/io/airbyte/integrations/source/e2e_test/ExceptionAfterNSource.java
@@ -23,6 +23,7 @@ import io.airbyte.protocol.models.CatalogHelpers;
 import io.airbyte.protocol.models.ConfiguredAirbyteCatalog;
 import io.airbyte.protocol.models.Field;
 import io.airbyte.protocol.models.JsonSchemaPrimitive;
+import io.airbyte.protocol.models.JsonSchemaType;
 import io.airbyte.protocol.models.SyncMode;
 import java.time.Instant;
 import java.util.List;
@@ -43,7 +44,7 @@ public class ExceptionAfterNSource extends BaseConnector implements Source {
   private static final String COLUMN_NAME = "column1";
   static final AirbyteCatalog CATALOG = CatalogHelpers.createAirbyteCatalog(
       STREAM_NAME,
-      Field.of(COLUMN_NAME, JsonSchemaPrimitive.STRING));
+      Field.of(COLUMN_NAME, JsonSchemaType.STRING));
   static {
     CATALOG.getStreams().get(0).setSupportedSyncModes(List.of(SyncMode.FULL_REFRESH, SyncMode.INCREMENTAL));
     CATALOG.getStreams().get(0).setSourceDefinedCursor(true);

--- a/airbyte-integrations/connectors/source-e2e-test/src/main/java/io/airbyte/integrations/source/e2e_test/InfiniteFeedSource.java
+++ b/airbyte-integrations/connectors/source-e2e-test/src/main/java/io/airbyte/integrations/source/e2e_test/InfiniteFeedSource.java
@@ -1,0 +1,95 @@
+/*
+ * Copyright (c) 2021 Airbyte, Inc., all rights reserved.
+ */
+
+package io.airbyte.integrations.source.e2e_test;
+
+import static java.lang.Thread.sleep;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import com.google.common.collect.AbstractIterator;
+import com.google.common.collect.ImmutableMap;
+import com.google.common.collect.Lists;
+import io.airbyte.commons.json.Jsons;
+import io.airbyte.commons.util.AutoCloseableIterator;
+import io.airbyte.commons.util.AutoCloseableIterators;
+import io.airbyte.integrations.BaseConnector;
+import io.airbyte.integrations.base.Source;
+import io.airbyte.protocol.models.AirbyteCatalog;
+import io.airbyte.protocol.models.AirbyteConnectionStatus;
+import io.airbyte.protocol.models.AirbyteConnectionStatus.Status;
+import io.airbyte.protocol.models.AirbyteMessage;
+import io.airbyte.protocol.models.AirbyteMessage.Type;
+import io.airbyte.protocol.models.AirbyteRecordMessage;
+import io.airbyte.protocol.models.CatalogHelpers;
+import io.airbyte.protocol.models.ConfiguredAirbyteCatalog;
+import io.airbyte.protocol.models.Field;
+import io.airbyte.protocol.models.JsonSchemaPrimitive;
+import io.airbyte.protocol.models.JsonSchemaType;
+import io.airbyte.protocol.models.SyncMode;
+import java.time.Instant;
+import java.util.Optional;
+import java.util.concurrent.atomic.AtomicLong;
+import java.util.function.Predicate;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+public class InfiniteFeedSource extends BaseConnector implements Source {
+
+  private static final Logger LOGGER = LoggerFactory.getLogger(InfiniteFeedSource.class);
+
+  public static final AirbyteCatalog CATALOG = CatalogHelpers.createAirbyteCatalog(
+      "data",
+      Field.of("column1", JsonSchemaType.STRING));
+
+  @Override
+  public AirbyteConnectionStatus check(final JsonNode config) {
+    return new AirbyteConnectionStatus().withStatus(Status.SUCCEEDED);
+  }
+
+  @Override
+  public AirbyteCatalog discover(final JsonNode config) {
+    return Jsons.clone(CATALOG);
+  }
+
+  @Override
+  public AutoCloseableIterator<AirbyteMessage> read(final JsonNode config, final ConfiguredAirbyteCatalog catalog, final JsonNode state) {
+    final Predicate<Long> anotherRecordPredicate =
+        config.has("max_records") ? recordNumber -> recordNumber < config.get("max_records").asLong() : recordNumber -> true;
+
+    final Optional<Long> sleepTime = Optional.ofNullable(config.get("message_interval")).map(JsonNode::asLong);
+
+    final AtomicLong i = new AtomicLong();
+
+    return AutoCloseableIterators.fromIterator(new AbstractIterator<>() {
+
+      @Override
+      protected AirbyteMessage computeNext() {
+        if (anotherRecordPredicate.test(i.get())) {
+          if (i.get() != 0) {
+            if (sleepTime.isPresent()) {
+              try {
+                LOGGER.info("sleeping for {} ms", sleepTime.get());
+                sleep(sleepTime.get());
+              } catch (final InterruptedException e) {
+                throw new RuntimeException(e);
+              }
+            }
+          }
+          i.incrementAndGet();
+          LOGGER.info("source emitting record {}:", i.get());
+          return new AirbyteMessage()
+              .withType(Type.RECORD)
+              .withRecord(new AirbyteRecordMessage()
+                  .withStream("data")
+                  .withEmittedAt(Instant.now().toEpochMilli())
+                  .withData(Jsons.jsonNode(ImmutableMap.of("column1", i))));
+        } else {
+          return endOfData();
+        }
+      }
+
+    });
+  }
+
+}

--- a/airbyte-integrations/connectors/source-e2e-test/src/main/java/io/airbyte/integrations/source/e2e_test/TestingSources.java
+++ b/airbyte-integrations/connectors/source-e2e-test/src/main/java/io/airbyte/integrations/source/e2e_test/TestingSources.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2022 Airbyte, Inc., all rights reserved.
+ * Copyright (c) 2021 Airbyte, Inc., all rights reserved.
  */
 
 package io.airbyte.integrations.source.e2e_test;
@@ -15,32 +15,36 @@ import io.airbyte.protocol.models.AirbyteConnectionStatus;
 import io.airbyte.protocol.models.AirbyteMessage;
 import io.airbyte.protocol.models.ConfiguredAirbyteCatalog;
 import java.util.Map;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
+/**
+ * This source is designed to be a switch statement for our suite of highly-specific test sourcess.
+ */
 public class TestingSources extends BaseConnector implements Source {
 
-  private final Map<TestingSourceType, Source> sourceMap;
+  private static final Logger LOGGER = LoggerFactory.getLogger(TestingSources.class);
 
-  public enum TestingSourceType {
-    CONTINUOUS_FEED,
-    // the following are legacy types
-    EXCEPTION_AFTER_N,
-    INFINITE_FEED
+  private final Map<TestDestinationType, Source> sourceMap;
+
+  public enum TestDestinationType {
+    INFINITE_FEED,
+    EXCEPTION_AFTER_N
   }
 
   public TestingSources() {
-    this(ImmutableMap.<TestingSourceType, Source>builder()
-        .put(TestingSourceType.CONTINUOUS_FEED, new ContinuousFeedSource())
-        .put(TestingSourceType.EXCEPTION_AFTER_N, new LegacyExceptionAfterNSource())
-        .put(TestingSourceType.INFINITE_FEED, new LegacyInfiniteFeedSource())
+    this(ImmutableMap.<TestDestinationType, Source>builder()
+        .put(TestDestinationType.INFINITE_FEED, new InfiniteFeedSource())
+        .put(TestDestinationType.EXCEPTION_AFTER_N, new ExceptionAfterNSource())
         .build());
   }
 
-  public TestingSources(final Map<TestingSourceType, Source> sourceMap) {
+  public TestingSources(final Map<TestDestinationType, Source> sourceMap) {
     this.sourceMap = sourceMap;
   }
 
   private Source selectSource(final JsonNode config) {
-    return sourceMap.get(TestingSourceType.valueOf(config.get("type").asText()));
+    return sourceMap.get(TestDestinationType.valueOf(config.get("type").asText()));
   }
 
   @Override
@@ -63,7 +67,9 @@ public class TestingSources extends BaseConnector implements Source {
 
   public static void main(final String[] args) throws Exception {
     final Source source = new TestingSources();
+    LOGGER.info("starting source: {}", TestingSources.class);
     new IntegrationRunner(source).run(args);
+    LOGGER.info("completed source: {}", TestingSources.class);
   }
 
 }

--- a/airbyte-integrations/connectors/source-e2e-test/src/main/resources/spec.json
+++ b/airbyte-integrations/connectors/source-e2e-test/src/main/resources/spec.json
@@ -1,104 +1,49 @@
 {
-  "documentationUrl": "https://docs.airbyte.com/integrations/sources/e2e-test",
-  "protocol_version": "0.2.1",
+  "documentationUrl": "https://example.com",
   "connectionSpecification": {
     "$schema": "http://json-schema.org/draft-07/schema#",
     "title": "E2E Test Source Spec",
     "type": "object",
-    "required": ["max_messages", "mock_catalog"],
-    "additionalProperties": false,
-    "properties": {
-      "type": {
-        "type": "string",
-        "const": "CONTINUOUS_FEED",
-        "default": "CONTINUOUS_FEED",
-        "order": 10
-      },
-      "max_messages": {
-        "title": "Max Records",
-        "description": "Number of records to emit per stream. Min 1. Max 100 billion.",
-        "type": "integer",
-        "default": 100,
-        "min": 1,
-        "max": 100000000000,
-        "order": 20
-      },
-      "seed": {
-        "title": "Random Seed",
-        "description": "When the seed is unspecified, the current time millis will be used as the seed. Range: [0, 1000000].",
-        "type": "integer",
-        "default": 0,
-        "examples": [42],
-        "min": 0,
-        "max": 1000000,
-        "order": 30
-      },
-      "message_interval_ms": {
-        "title": "Message Interval (ms)",
-        "description": "Interval between messages in ms. Min 0 ms. Max 60000 ms (1 minute).",
-        "type": "integer",
-        "min": 0,
-        "max": 60000,
-        "default": 0,
-        "order": 40
-      },
-      "mock_catalog": {
-        "title": "Mock Catalog",
-        "type": "object",
-        "order": 50,
-        "oneOf": [
-          {
-            "title": "Single Schema",
-            "description": "A catalog with one or multiple streams that share the same schema.",
-            "required": ["type", "stream_name", "stream_schema"],
-            "properties": {
-              "type": {
-                "type": "string",
-                "const": "SINGLE_STREAM",
-                "default": "SINGLE_STREAM"
-              },
-              "stream_name": {
-                "title": "Stream Name",
-                "description": "Name of the data stream.",
-                "type": "string",
-                "default": "data_stream"
-              },
-              "stream_schema": {
-                "title": "Stream Schema",
-                "description": "A Json schema for the stream. The schema should be compatible with <a href=\"https://json-schema.org/draft-07/json-schema-release-notes.html\">draft-07</a>. See <a href=\"https://cswr.github.io/JsonSchema/spec/introduction/\">this doc</a> for examples.",
-                "type": "string",
-                "default": "{ \"type\": \"object\", \"properties\": { \"column1\": { \"type\": \"string\" } } }"
-              },
-              "stream_duplication": {
-                "title": "Duplicate the stream N times",
-                "description": "Duplicate the stream for easy load testing. Each stream name will have a number suffix. For example, if the stream name is \"ds\", the duplicated streams will be \"ds_0\", \"ds_1\", etc.",
-                "type": "integer",
-                "default": 1,
-                "min": 1,
-                "max": 10000
-              }
-            }
+    "oneOf": [
+      {
+        "title": "Exception After N",
+        "required": ["type", "throw_after_n_records"],
+        "additionalProperties": false,
+        "properties": {
+          "type": {
+            "type": "string",
+            "const": "EXCEPTION_AFTER_N",
+            "default": "EXCEPTION_AFTER_N"
           },
-          {
-            "title": "Multi Schema",
-            "description": "A catalog with multiple data streams, each with a different schema.",
-            "required": ["type", "stream_schemas"],
-            "properties": {
-              "type": {
-                "type": "string",
-                "const": "MULTI_STREAM",
-                "default": "MULTI_STREAM"
-              },
-              "stream_schemas": {
-                "title": "Streams and Schemas",
-                "description": "A Json object specifying multiple data streams and their schemas. Each key in this object is one stream name. Each value is the schema for that stream. The schema should be compatible with <a href=\"https://json-schema.org/draft-07/json-schema-release-notes.html\">draft-07</a>. See <a href=\"https://cswr.github.io/JsonSchema/spec/introduction/\">this doc</a> for examples.",
-                "type": "string",
-                "default": "{ \"stream1\": { \"type\": \"object\", \"properties\": { \"field1\": { \"type\": \"string\" } } }, \"stream2\": { \"type\": \"object\", \"properties\": { \"field1\": { \"type\": \"boolean\" } } } }"
-              }
-            }
+          "throw_after_n_records": {
+            "title": "Throw After N Records",
+            "description": "Number of records to emit before throwing an exception.",
+            "type": "integer"
           }
-        ]
+        }
+      },
+      {
+        "title": "Infinite Feed",
+        "required": ["type", "max_records"],
+        "additionalProperties": true,
+        "properties": {
+          "type": {
+            "type": "string",
+            "const": "INFINITE_FEED",
+            "default": "INFINITE_FEED"
+          },
+          "max_records": {
+            "title": "Max Records",
+            "description": "Number of records to emit. If not set, defaults to infinity.",
+            "type": "integer"
+          },
+          "message_interval": {
+            "title": "Message Interval",
+            "description": "Interval between messages in ms.",
+            "type": "integer"
+          }
+        }
       }
-    }
+    ]
   }
 }

--- a/airbyte-integrations/connectors/source-e2e-test/src/test-integration/java/io/airbyte/integrations/source/e2e_test/ContinuousFeedSourceAcceptanceTest.java
+++ b/airbyte-integrations/connectors/source-e2e-test/src/test-integration/java/io/airbyte/integrations/source/e2e_test/ContinuousFeedSourceAcceptanceTest.java
@@ -12,7 +12,6 @@ import com.google.common.collect.ImmutableMap;
 import io.airbyte.commons.json.Jsons;
 import io.airbyte.commons.resources.MoreResources;
 import io.airbyte.integrations.source.e2e_test.ContinuousFeedConfig.MockCatalogType;
-import io.airbyte.integrations.source.e2e_test.TestingSources.TestingSourceType;
 import io.airbyte.integrations.standardtest.source.SourceAcceptanceTest;
 import io.airbyte.integrations.standardtest.source.TestDestinationEnv;
 import io.airbyte.protocol.models.AirbyteMessage;
@@ -81,7 +80,7 @@ public class ContinuousFeedSourceAcceptanceTest extends SourceAcceptanceTest {
             Jsons.serialize(SCHEMA_2)))
         .build());
     this.config = Jsons.jsonNode(ImmutableMap.builder()
-        .put("type", TestingSourceType.CONTINUOUS_FEED)
+        .put("type", "CONTINUOUS_FEED")
         .put("seed", 1024)
         .put("message_interval_ms", 0)
         .put("max_messages", MAX_MESSAGES)

--- a/airbyte-integrations/connectors/source-e2e-test/src/test/java/io/airbyte/integrations/source/e2e_test/ExceptionAfterNSourceTest.java
+++ b/airbyte-integrations/connectors/source-e2e-test/src/test/java/io/airbyte/integrations/source/e2e_test/ExceptionAfterNSourceTest.java
@@ -1,0 +1,65 @@
+/*
+ * Copyright (c) 2021 Airbyte, Inc., all rights reserved.
+ */
+
+package io.airbyte.integrations.source.e2e_test;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import com.google.common.collect.ImmutableMap;
+import io.airbyte.commons.json.Jsons;
+import io.airbyte.commons.util.AutoCloseableIterator;
+import io.airbyte.protocol.models.AirbyteMessage;
+import io.airbyte.protocol.models.AirbyteMessage.Type;
+import io.airbyte.protocol.models.AirbyteRecordMessage;
+import io.airbyte.protocol.models.AirbyteStateMessage;
+import io.airbyte.protocol.models.CatalogHelpers;
+import io.airbyte.protocol.models.ConfiguredAirbyteCatalog;
+import io.airbyte.protocol.models.SyncMode;
+import java.time.Instant;
+import org.junit.jupiter.api.Test;
+
+class ExceptionAfterNSourceTest {
+
+  @SuppressWarnings("Convert2MethodRef")
+  @Test
+  void test() {
+    final ConfiguredAirbyteCatalog configuredCatalog = CatalogHelpers.toDefaultConfiguredCatalog(ExceptionAfterNSource.CATALOG);
+    configuredCatalog.getStreams().get(0).setSyncMode(SyncMode.INCREMENTAL);
+
+    final JsonNode config = Jsons.jsonNode(ImmutableMap.of("throw_after_n_records", 10));
+    final AutoCloseableIterator<AirbyteMessage> read = new ExceptionAfterNSource().read(config, configuredCatalog, null);
+    assertEquals(getStateMessage(0L).getState().getData(), read.next().getState().getData());
+    assertEquals(getRecordMessage(1L).getRecord().getData(), read.next().getRecord().getData());
+    assertEquals(getRecordMessage(2L).getRecord().getData(), read.next().getRecord().getData());
+    assertEquals(getRecordMessage(3L).getRecord().getData(), read.next().getRecord().getData());
+    assertEquals(getRecordMessage(4L).getRecord().getData(), read.next().getRecord().getData());
+    assertEquals(getRecordMessage(5L).getRecord().getData(), read.next().getRecord().getData());
+    assertEquals(getStateMessage(5L).getState().getData(), read.next().getState().getData());
+    assertEquals(getRecordMessage(6L).getRecord().getData(), read.next().getRecord().getData());
+    assertEquals(getRecordMessage(7L).getRecord().getData(), read.next().getRecord().getData());
+    assertEquals(getRecordMessage(8L).getRecord().getData(), read.next().getRecord().getData());
+    assertEquals(getRecordMessage(9L).getRecord().getData(), read.next().getRecord().getData());
+    assertEquals(getRecordMessage(10L).getRecord().getData(), read.next().getRecord().getData());
+    assertEquals(getStateMessage(10L).getState().getData(), read.next().getState().getData());
+    assertThrows(IllegalStateException.class, read::next);
+  }
+
+  private static AirbyteMessage getRecordMessage(final long i) {
+    return new AirbyteMessage()
+        .withType(Type.RECORD)
+        .withRecord(new AirbyteRecordMessage()
+            .withStream("data")
+            .withEmittedAt(Instant.now().toEpochMilli())
+            .withData(Jsons.jsonNode(ImmutableMap.of("column1", i))));
+  }
+
+  private static AirbyteMessage getStateMessage(final long i) {
+    return new AirbyteMessage()
+        .withType(Type.STATE)
+        .withState(new AirbyteStateMessage().withData(Jsons.jsonNode(ImmutableMap.of("column1", i))));
+  }
+
+}

--- a/airbyte-protocol/protocol-models/src/main/java/io/airbyte/protocol/models/CatalogHelpers.java
+++ b/airbyte-protocol/protocol-models/src/main/java/io/airbyte/protocol/models/CatalogHelpers.java
@@ -50,7 +50,7 @@ public class CatalogHelpers {
   }
 
   public static AirbyteStream createAirbyteStream(final String streamName, final String namespace, final List<Field> fields) {
-    return new AirbyteStream().withName(streamName).withNamespace(namespace).withJsonSchema(fieldsToJsonSchema(fields));
+    return new AirbyteStream().withName(streamName).withNamespace(namespace).withJsonSchema(fieldsToJsonSchema(fields)).withSupportedSyncModes(Lists.newArrayList(SyncMode.FULL_REFRESH));
   }
 
   public static ConfiguredAirbyteCatalog createConfiguredAirbyteCatalog(final String streamName, final String namespace, final Field... fields) {


### PR DESCRIPTION
## What
I'd like to patch an old version of `source-e2e-test` (0.1.1) still used in our acceptance tests. The latest version of `source-e2e-test` is `>= 2.0.0`.
My [protocol change PR](https://github.com/airbytehq/airbyte/pull/15591) make the `supported_sync_modes` field required on all AirbyteStream. 


## How
I want to update `0.1.1` catalog to have `supported_sync_modes`:
* `git checkout 464c485 -- airbyte-integrations/connectors/source-e2e-test/`
* Change CatalogHelper to create a catalog with streams with supported sync modes set to full refresh

I want to publish this change in `0.1.2` but not merge this PR because this is a legacy patch. 

⚠️ **THIS PR SHOULD NOT BE MERGED BUT ONLY CLOSED AFTER SUCCESSFUL PUBLISH OF 0.1.2**

