### PR TITLE
publish: increase delay to delete temp arch tags

### DIFF
--- a/tools/integrations/manage.sh
+++ b/tools/integrations/manage.sh
@@ -300,7 +300,7 @@ cmd_publish() {
     docker manifest rm $versioned_image
 
     # delete the temporary image tags made with arch_versioned_image
-    sleep 5
+    sleep 10
     for arch in $(echo $build_arch | sed "s/,/ /g")
     do
       local arch_versioned_tag=`echo $arch | sed "s/\//-/g"`-$image_version


### PR DESCRIPTION
## What

When publishing, we create some temporary tags for each architecture and then delete them. It seems like docker's API can be slow to update sometimes and gives a 404 error when deleting the tags.

An example of this occurred in https://github.com/airbytehq/airbyte/actions/runs/3269479084/jobs/5377051515

## How

Increase the sleep time to from 5 to 10 seconds. 
