### PR TITLE
Docs: Replace NoPaginator in the docs with NoPagination

### DIFF
--- a/docs/connector-development/config-based/source_schema.yaml
+++ b/docs/connector-development/config-based/source_schema.yaml
@@ -226,7 +226,7 @@ definitions:
     type: object
     anyOf:
       - "$ref": "#/definitions/DefaultPaginator"
-      - "$ref": "#/definitions/NoPaginator"
+      - "$ref": "#/definitions/NoPagination"
   DefaultPaginator:
     type: object
     additionalProperties: true
@@ -247,7 +247,7 @@ definitions:
         "$ref": "#/definitions/PaginationStrategy"
       url_base:
         type: string
-  NoPaginator:
+  NoPagination:
     type: object
     additionalProperties: true
   RequestOption:

--- a/docs/connector-development/config-based/understanding-the-yaml-file/pagination.md
+++ b/docs/connector-development/config-based/understanding-the-yaml-file/pagination.md
@@ -13,8 +13,8 @@ Schema:
     type: object
     anyOf:
       - "$ref": "#/definitions/DefaultPaginator"
-      - "$ref": "#/definitions/NoPaginator"
-  NoPaginator:
+      - "$ref": "#/definitions/NoPagination"
+  NoPagination:
     type: object
     additionalProperties: true
 ```


### PR DESCRIPTION
## What

The [low-code SDK pagination docs](https://docs.airbyte.com/connector-development/config-based/understanding-the-yaml-file/pagination) mention a `NoPaginator` paginator, but from the source it looks like it should be `NoPagination`.
