### PR TITLE
Update deployment.yaml

### DIFF
--- a/charts/airbyte-webapp/templates/deployment.yaml
+++ b/charts/airbyte-webapp/templates/deployment.yaml
@@ -19,6 +19,7 @@ spec:
         {{- include "common.tplvalues.render" (dict "value" .Values.podAnnotations "context" $) | nindent 8 }}
       {{- end }}
     spec:
+      serviceAccountName: {{ .Values.global.serviceAccountName }}
       {{- if .Values.nodeSelector }}
       nodeSelector: {{- include "common.tplvalues.render" (dict "value" .Values.nodeSelector "context" $) | nindent 8 }}
       {{- end }}


### PR DESCRIPTION
Do not ignore service account is webpp

## What
Web App deployment in helm charts ignore `global.serviceAccountName` property.

## How
Did the same thing as in: https://github.com/airbytehq/airbyte/blob/master/charts/airbyte-server/templates/deployment.yaml#L24

## 🚨 User Impact 🚨
Should be minimal afaik.
