### PR TITLE
Fix a typo in linkedin-ads.md

### DIFF
--- a/docs/integrations/sources/linkedin-ads.md
+++ b/docs/integrations/sources/linkedin-ads.md
@@ -13,9 +13,9 @@ The LinkedIn Ads source connector is based on a [Airbyte CDK](https://docs.airby
    * OAuth2.0:
       * `Client ID` from your `Developer Application`
       * `Client Secret` from your `Developer Application`
-      * `Refresh Token` obtained from successfull authorization with `Client ID` + `Client Secret`
+      * `Refresh Token` obtained from successful authorization with `Client ID` + `Client Secret`
    * Access Token:
-      * `Access Token` obtained from successfull authorization with `Client ID` + `Client Secret`
+      * `Access Token` obtained from successful authorization with `Client ID` + `Client Secret`
 
 ## Step 1: Set up LinkedIn Ads
 


### PR DESCRIPTION
## What
I'm fixing two minor typos in the LinkedIn Ads Open Source section:
<img width="492" alt="Snag_63e28289" src="https://user-images.githubusercontent.com/33040934/196766373-2e082164-c827-4d8b-933a-d43a2eba0837.png">
