### PR TITLE
add a span interceptor to treat expected errors as non-errors

### DIFF
--- a/airbyte-workers/src/main/java/io/airbyte/workers/ApplicationInitializer.java
+++ b/airbyte-workers/src/main/java/io/airbyte/workers/ApplicationInitializer.java
@@ -133,6 +133,7 @@ public class ApplicationInitializer implements ApplicationEventListener<ServiceR
   @Override
   public void onApplicationEvent(final ServiceReadyEvent event) {
     try {
+      datadog.trace.api.GlobalTracer.get().addTraceInterceptor(new StorageObjectGetInterceptor());
       initializeCommonDependencies();
 
       if (environment.getActiveNames().contains(WorkerMode.CONTROL_PLANE)) {
@@ -141,7 +142,9 @@ public class ApplicationInitializer implements ApplicationEventListener<ServiceR
         log.info("Skipping Control Plane dependency initialization.");
       }
 
-      registerWorkerFactory(workerFactory, new MaxWorkersConfig(maxCheckWorkers, maxDiscoverWorkers, maxSpecWorkers, maxSyncWorkers));
+      registerWorkerFactory(workerFactory,
+          new MaxWorkersConfig(maxCheckWorkers, maxDiscoverWorkers, maxSpecWorkers,
+              maxSyncWorkers));
 
       log.info("Starting worker factory...");
       workerFactory.start();
@@ -153,7 +156,8 @@ public class ApplicationInitializer implements ApplicationEventListener<ServiceR
     }
   }
 
-  private void initializeCommonDependencies() throws ExecutionException, InterruptedException, TimeoutException {
+  private void initializeCommonDependencies()
+      throws ExecutionException, InterruptedException, TimeoutException {
     log.info("Initializing common worker dependencies.");
 
     // Initialize the metric client
@@ -184,7 +188,8 @@ public class ApplicationInitializer implements ApplicationEventListener<ServiceR
     jobsDatabaseAvailabilityCheck.orElseThrow().check();
   }
 
-  private void registerWorkerFactory(final WorkerFactory workerFactory, final MaxWorkersConfig maxWorkersConfiguration) {
+  private void registerWorkerFactory(final WorkerFactory workerFactory,
+                                     final MaxWorkersConfig maxWorkersConfiguration) {
     log.info("Registering worker factories....");
     if (shouldRunGetSpecWorkflows) {
       registerGetSpec(workerFactory, maxWorkersConfiguration);
@@ -207,45 +212,61 @@ public class ApplicationInitializer implements ApplicationEventListener<ServiceR
     }
   }
 
-  private void registerCheckConnection(final WorkerFactory factory, final MaxWorkersConfig maxWorkersConfig) {
+  private void registerCheckConnection(final WorkerFactory factory,
+                                       final MaxWorkersConfig maxWorkersConfig) {
     final Worker checkConnectionWorker =
-        factory.newWorker(TemporalJobType.CHECK_CONNECTION.name(), getWorkerOptions(maxWorkersConfig.getMaxCheckWorkers()));
+        factory.newWorker(TemporalJobType.CHECK_CONNECTION.name(),
+            getWorkerOptions(maxWorkersConfig.getMaxCheckWorkers()));
     final WorkflowImplementationOptions options = WorkflowImplementationOptions.newBuilder()
         .setFailWorkflowExceptionTypes(NonDeterministicException.class).build();
     checkConnectionWorker
-        .registerWorkflowImplementationTypes(options, temporalProxyHelper.proxyWorkflowClass(CheckConnectionWorkflowImpl.class));
-    checkConnectionWorker.registerActivitiesImplementations(checkConnectionActivities.orElseThrow().toArray(new Object[] {}));
+        .registerWorkflowImplementationTypes(options,
+            temporalProxyHelper.proxyWorkflowClass(CheckConnectionWorkflowImpl.class));
+    checkConnectionWorker.registerActivitiesImplementations(
+        checkConnectionActivities.orElseThrow().toArray(new Object[] {}));
     log.info("Check Connection Workflow registered.");
   }
 
-  private void registerConnectionManager(final WorkerFactory factory, final MaxWorkersConfig maxWorkersConfig) {
+  private void registerConnectionManager(final WorkerFactory factory,
+                                         final MaxWorkersConfig maxWorkersConfig) {
     final Worker connectionUpdaterWorker =
-        factory.newWorker(TemporalJobType.CONNECTION_UPDATER.toString(), getWorkerOptions(maxWorkersConfig.getMaxSyncWorkers()));
+        factory.newWorker(TemporalJobType.CONNECTION_UPDATER.toString(),
+            getWorkerOptions(maxWorkersConfig.getMaxSyncWorkers()));
     final WorkflowImplementationOptions options = WorkflowImplementationOptions.newBuilder()
         .setFailWorkflowExceptionTypes(NonDeterministicException.class).build();
     connectionUpdaterWorker
-        .registerWorkflowImplementationTypes(options, temporalProxyHelper.proxyWorkflowClass(ConnectionManagerWorkflowImpl.class));
-    connectionUpdaterWorker.registerActivitiesImplementations(connectionManagerActivities.orElseThrow().toArray(new Object[] {}));
+        .registerWorkflowImplementationTypes(options,
+            temporalProxyHelper.proxyWorkflowClass(ConnectionManagerWorkflowImpl.class));
+    connectionUpdaterWorker.registerActivitiesImplementations(
+        connectionManagerActivities.orElseThrow().toArray(new Object[] {}));
     log.info("Connection Manager Workflow registered.");
   }
 
-  private void registerDiscover(final WorkerFactory factory, final MaxWorkersConfig maxWorkersConfig) {
+  private void registerDiscover(final WorkerFactory factory,
+                                final MaxWorkersConfig maxWorkersConfig) {
     final Worker discoverWorker =
-        factory.newWorker(TemporalJobType.DISCOVER_SCHEMA.name(), getWorkerOptions(maxWorkersConfig.getMaxDiscoverWorkers()));
+        factory.newWorker(TemporalJobType.DISCOVER_SCHEMA.name(),
+            getWorkerOptions(maxWorkersConfig.getMaxDiscoverWorkers()));
     final WorkflowImplementationOptions options = WorkflowImplementationOptions.newBuilder()
         .setFailWorkflowExceptionTypes(NonDeterministicException.class).build();
     discoverWorker
-        .registerWorkflowImplementationTypes(options, temporalProxyHelper.proxyWorkflowClass(DiscoverCatalogWorkflowImpl.class));
-    discoverWorker.registerActivitiesImplementations(discoverActivities.orElseThrow().toArray(new Object[] {}));
+        .registerWorkflowImplementationTypes(options,
+            temporalProxyHelper.proxyWorkflowClass(DiscoverCatalogWorkflowImpl.class));
+    discoverWorker.registerActivitiesImplementations(
+        discoverActivities.orElseThrow().toArray(new Object[] {}));
     log.info("Discover Workflow registered.");
   }
 
-  private void registerGetSpec(final WorkerFactory factory, final MaxWorkersConfig maxWorkersConfig) {
-    final Worker specWorker = factory.newWorker(TemporalJobType.GET_SPEC.name(), getWorkerOptions(maxWorkersConfig.getMaxSpecWorkers()));
+  private void registerGetSpec(final WorkerFactory factory,
+                               final MaxWorkersConfig maxWorkersConfig) {
+    final Worker specWorker = factory.newWorker(TemporalJobType.GET_SPEC.name(),
+        getWorkerOptions(maxWorkersConfig.getMaxSpecWorkers()));
     final WorkflowImplementationOptions options = WorkflowImplementationOptions.newBuilder()
         .setFailWorkflowExceptionTypes(NonDeterministicException.class).build();
-    specWorker.registerWorkflowImplementationTypes(options, temporalProxyHelper.proxyWorkflowClass(SpecWorkflowImpl.class));
-    specWorker.registerActivitiesImplementations(specActivities.orElseThrow().toArray(new Object[] {}));
+    specWorker.registerWorkflowImplementationTypes(options,
+        temporalProxyHelper.proxyWorkflowClass(SpecWorkflowImpl.class));
+    specWorker.registerActivitiesImplementations(
+        specActivities.orElseThrow().toArray(new Object[] {}));
     log.info("Get Spec Workflow registered.");
   }
 
@@ -260,11 +281,14 @@ public class ApplicationInitializer implements ApplicationEventListener<ServiceR
 
     for (final String taskQueue : taskQueues) {
       log.info("Registering sync workflow for task queue '{}'...", taskQueue);
-      final Worker syncWorker = factory.newWorker(taskQueue, getWorkerOptions(maxWorkersConfig.getMaxSyncWorkers()));
+      final Worker syncWorker = factory.newWorker(taskQueue,
+          getWorkerOptions(maxWorkersConfig.getMaxSyncWorkers()));
       final WorkflowImplementationOptions options = WorkflowImplementationOptions.newBuilder()
           .setFailWorkflowExceptionTypes(NonDeterministicException.class).build();
-      syncWorker.registerWorkflowImplementationTypes(options, temporalProxyHelper.proxyWorkflowClass(SyncWorkflowImpl.class));
-      syncWorker.registerActivitiesImplementations(syncActivities.orElseThrow().toArray(new Object[] {}));
+      syncWorker.registerWorkflowImplementationTypes(options,
+          temporalProxyHelper.proxyWorkflowClass(SyncWorkflowImpl.class));
+      syncWorker.registerActivitiesImplementations(
+          syncActivities.orElseThrow().toArray(new Object[] {}));
     }
     log.info("Sync Workflow registered.");
   }
@@ -284,7 +308,8 @@ public class ApplicationInitializer implements ApplicationEventListener<ServiceR
    * @throws InterruptedException if unable to perform the additional configuration.
    * @throws TimeoutException if unable to perform the additional configuration.
    */
-  private void configureTemporal(final TemporalUtils temporalUtils, final WorkflowServiceStubs temporalService)
+  private void configureTemporal(final TemporalUtils temporalUtils,
+                                 final WorkflowServiceStubs temporalService)
       throws ExecutionException, InterruptedException, TimeoutException {
     log.info("Configuring Temporal....");
     // Create the default Temporal namespace
@@ -292,7 +317,8 @@ public class ApplicationInitializer implements ApplicationEventListener<ServiceR
 
     // Ensure that the Temporal namespace exists before continuing.
     // If it does not exist after 30 seconds, fail the startup.
-    executorService.submit(temporalInitializationUtils::waitForTemporalNamespace).get(30, TimeUnit.SECONDS);
+    executorService.submit(temporalInitializationUtils::waitForTemporalNamespace)
+        .get(30, TimeUnit.SECONDS);
   }
 
   /**

--- a/airbyte-workers/src/main/java/io/airbyte/workers/StorageObjectGetInterceptor.java
+++ b/airbyte-workers/src/main/java/io/airbyte/workers/StorageObjectGetInterceptor.java
@@ -1,0 +1,46 @@
+/*
+ * Copyright (c) 2022 Airbyte, Inc., all rights reserved.
+ */
+
+package io.airbyte.workers;
+
+import datadog.trace.api.interceptor.MutableSpan;
+import datadog.trace.api.interceptor.TraceInterceptor;
+import java.util.ArrayList;
+import java.util.Collection;
+
+@SuppressWarnings("PMD")
+public class StorageObjectGetInterceptor implements TraceInterceptor {
+
+  @Override
+  public Collection<? extends MutableSpan> onTraceComplete(
+                                                           final Collection<? extends MutableSpan> trace) {
+    final var filtered = new ArrayList<MutableSpan>();
+    trace.forEach(s -> {
+      System.out.printf("span name: %s; tags: %s; isError: %s%n", s.getResourceName(), s.getTags(),
+          s.isError());
+      final var tags = s.getTags();
+      // if no tags, then keep the span and move on to the next one
+      if (tags == null) {
+        filtered.add(s);
+        return;
+      }
+
+      if (tags.getOrDefault("component", "").equals("google-http-client") &&
+          tags.getOrDefault("error.message", "").toString().startsWith("404 Not Found")) {
+        s.setError(false);
+      }
+      System.out.printf("span name: %s; tags: %s; isError: %s%n", s.getResourceName(), s.getTags(),
+          s.isError());
+      filtered.add(s);
+    });
+
+    return filtered;
+  }
+
+  @Override
+  public int priority() {
+    return 404;
+  }
+
+}

--- a/airbyte-workers/src/main/java/io/airbyte/workers/StorageObjectGetInterceptor.java
+++ b/airbyte-workers/src/main/java/io/airbyte/workers/StorageObjectGetInterceptor.java
@@ -27,8 +27,12 @@ public class StorageObjectGetInterceptor implements TraceInterceptor {
         return;
       }
       if (s.isError()) {
-        System.out.println(tags.get("http.status_code").getClass().getName());
-        System.out.println(tags.get("peer.hostname").getClass().getName());
+        try {
+          System.out.println(tags.get("http.status_code").getClass().getName());
+          System.out.println(tags.get("peer.hostname").getClass().getName());
+        } catch (final Exception e) {
+          // NOOP
+        }
       }
       if (s.isError() &&
           tags.getOrDefault("peer.hostname", "").equals("storage.googleapis.com") &&

--- a/airbyte-workers/src/main/java/io/airbyte/workers/StorageObjectGetInterceptor.java
+++ b/airbyte-workers/src/main/java/io/airbyte/workers/StorageObjectGetInterceptor.java
@@ -19,7 +19,7 @@ public class StorageObjectGetInterceptor implements TraceInterceptor {
     trace.forEach(s -> {
       System.out.printf("span name: %s (%s); isError: %s; tags: %s%n",
           s.getResourceName(),
-          s.isError(), s.getOperationName(), s.getTags());
+          s.getOperationName(), s.isError(), s.getTags());
       final var tags = s.getTags();
       // if no tags, then keep the span and move on to the next one
       if (tags == null) {
@@ -36,13 +36,15 @@ public class StorageObjectGetInterceptor implements TraceInterceptor {
       }
       if (s.isError() &&
           tags.getOrDefault("peer.hostname", "").equals("storage.googleapis.com") &&
-          tags.getOrDefault("http.status_code", "").equals(404)) {
+          (tags.getOrDefault("http.status_code", "").equals(404)) ||
+          ((String) tags.getOrDefault("err.msg", "")).startsWith("404 Not Found")) {
         System.out.printf("setting error to false: span name: %s (%s)%n", s.getResourceName(),
             s.getOperationName());
         s.setError(false);
       }
-      System.out.printf("span name: %s; tags: %s; isError: %s%n", s.getResourceName(), s.getTags(),
-          s.isError());
+      System.out.printf("span name: %s (%s); isError: %s; tags: %s%n",
+          s.getResourceName(),
+          s.getOperationName(), s.isError(), s.getTags());
       filtered.add(s);
     });
 

--- a/airbyte-workers/src/main/java/io/airbyte/workers/StorageObjectGetInterceptor.java
+++ b/airbyte-workers/src/main/java/io/airbyte/workers/StorageObjectGetInterceptor.java
@@ -26,10 +26,13 @@ public class StorageObjectGetInterceptor implements TraceInterceptor {
         filtered.add(s);
         return;
       }
-
+      if (s.isError()) {
+        System.out.println(tags.get("http.status_code").getClass().getName());
+        System.out.println(tags.get("peer.hostname").getClass().getName());
+      }
       if (s.isError() &&
           tags.getOrDefault("peer.hostname", "").equals("storage.googleapis.com") &&
-          tags.getOrDefault("http.status_code", "").equals("404")) {
+          tags.getOrDefault("http.status_code", "").equals(404)) {
         System.out.printf("setting error to false: span name: %s (%s)%n", s.getResourceName(),
             s.getOperationName());
         s.setError(false);

--- a/airbyte-workers/src/main/java/io/airbyte/workers/StorageObjectGetInterceptor.java
+++ b/airbyte-workers/src/main/java/io/airbyte/workers/StorageObjectGetInterceptor.java
@@ -26,8 +26,9 @@ public class StorageObjectGetInterceptor implements TraceInterceptor {
         return;
       }
 
-      if (tags.getOrDefault("component", "").equals("google-http-client") &&
-          tags.getOrDefault("error.message", "").toString().startsWith("404 Not Found")) {
+      if (s.isError() &&
+          tags.getOrDefault("peer.hostname", "").equals("storage.googleapis.com") &&
+          tags.getOrDefault("http.status_code", "").equals("404")) {
         s.setError(false);
       }
       System.out.printf("span name: %s; tags: %s; isError: %s%n", s.getResourceName(), s.getTags(),

--- a/airbyte-workers/src/main/java/io/airbyte/workers/StorageObjectGetInterceptor.java
+++ b/airbyte-workers/src/main/java/io/airbyte/workers/StorageObjectGetInterceptor.java
@@ -12,6 +12,7 @@ import java.util.Collection;
 public class StorageObjectGetInterceptor implements TraceInterceptor {
 
   @Override
+  @SuppressWarnings("PMD.AvoidLiteralsInIfCondition")
   public Collection<? extends MutableSpan> onTraceComplete(
                                                            final Collection<? extends MutableSpan> trace) {
     final var filtered = new ArrayList<MutableSpan>();
@@ -29,7 +30,7 @@ public class StorageObjectGetInterceptor implements TraceInterceptor {
       // that begins with "404 Not Found"
       final var is404 = tags.getOrDefault("http.status_code", "").equals(404) ||
           ((String) tags.getOrDefault("error.msg", "")).startsWith("404 Not Found");
-      if (s.isError() && tags.getOrDefault("peer.hostname", "").equals("storage.googleapis.com")
+      if (s.isError() && "storage.googleapis.com".equals(tags.getOrDefault("peer.hostname", ""))
           && is404) {
         // Mark these spans as non-errors as this is expected behavior based on our
         // current google storage usage.

--- a/airbyte-workers/src/main/java/io/airbyte/workers/StorageObjectGetInterceptor.java
+++ b/airbyte-workers/src/main/java/io/airbyte/workers/StorageObjectGetInterceptor.java
@@ -9,7 +9,6 @@ import datadog.trace.api.interceptor.TraceInterceptor;
 import java.util.ArrayList;
 import java.util.Collection;
 
-@SuppressWarnings("PMD")
 public class StorageObjectGetInterceptor implements TraceInterceptor {
 
   @Override
@@ -17,29 +16,26 @@ public class StorageObjectGetInterceptor implements TraceInterceptor {
                                                            final Collection<? extends MutableSpan> trace) {
     final var filtered = new ArrayList<MutableSpan>();
     trace.forEach(s -> {
-      System.out.printf("span name: %s (%s); isError: %s; tags: %s%n",
-          s.getResourceName(),
-          s.getOperationName(), s.isError(), s.getTags());
       final var tags = s.getTags();
       // if no tags, then keep the span and move on to the next one
-      if (tags == null) {
+      if (tags == null || tags.isEmpty()) {
         filtered.add(s);
         return;
       }
 
       // There are two different errors spans that we want to ignore, both of which are specific to
-      // "storage.googleapis.com". One returns an http status code of 404 and the other has an error
+      // "storage.googleapis.com". One returns a http status code of 404 and the other has an error
       // message
       // that begins with "404 Not Found"
       final var is404 = tags.getOrDefault("http.status_code", "").equals(404) ||
           ((String) tags.getOrDefault("error.msg", "")).startsWith("404 Not Found");
       if (s.isError() && tags.getOrDefault("peer.hostname", "").equals("storage.googleapis.com")
           && is404) {
+        // Mark these spans as non-errors as this is expected behavior based on our
+        // current google storage usage.
         s.setError(false);
       }
-      System.out.printf("span name: %s (%s); isError: %s; tags: %s%n",
-          s.getResourceName(),
-          s.getOperationName(), s.isError(), s.getTags());
+
       filtered.add(s);
     });
 

--- a/airbyte-workers/src/main/java/io/airbyte/workers/StorageObjectGetInterceptor.java
+++ b/airbyte-workers/src/main/java/io/airbyte/workers/StorageObjectGetInterceptor.java
@@ -17,8 +17,9 @@ public class StorageObjectGetInterceptor implements TraceInterceptor {
                                                            final Collection<? extends MutableSpan> trace) {
     final var filtered = new ArrayList<MutableSpan>();
     trace.forEach(s -> {
-      System.out.printf("span name: %s; tags: %s; isError: %s%n", s.getResourceName(), s.getTags(),
-          s.isError());
+      System.out.printf("span name: %s (%s); isError: %s; tags: %s%n",
+          s.getResourceName(),
+          s.isError(), s.getOperationName(), s.getTags());
       final var tags = s.getTags();
       // if no tags, then keep the span and move on to the next one
       if (tags == null) {
@@ -29,6 +30,8 @@ public class StorageObjectGetInterceptor implements TraceInterceptor {
       if (s.isError() &&
           tags.getOrDefault("peer.hostname", "").equals("storage.googleapis.com") &&
           tags.getOrDefault("http.status_code", "").equals("404")) {
+        System.out.printf("setting error to false: span name: %s (%s)%n", s.getResourceName(),
+            s.getOperationName());
         s.setError(false);
       }
       System.out.printf("span name: %s; tags: %s; isError: %s%n", s.getResourceName(), s.getTags(),

--- a/airbyte-workers/src/test/java/io/airbyte/workers/StorageObjectGetInterceptorTest.java
+++ b/airbyte-workers/src/test/java/io/airbyte/workers/StorageObjectGetInterceptorTest.java
@@ -1,0 +1,176 @@
+/*
+ * Copyright (c) 2022 Airbyte, Inc., all rights reserved.
+ */
+
+package io.airbyte.workers;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import datadog.trace.api.interceptor.MutableSpan;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import org.junit.jupiter.api.Test;
+
+class StorageObjectGetInterceptorTest {
+
+  private static class DummySpan implements MutableSpan {
+
+    @SuppressWarnings("PMD")
+    private final Map<String, Object> tags = new HashMap<>();
+    private boolean error = false;
+
+    @Override
+    public long getStartTime() {
+      return 0;
+    }
+
+    @Override
+    public long getDurationNano() {
+      return 0;
+    }
+
+    @Override
+    public CharSequence getOperationName() {
+      return null;
+    }
+
+    @Override
+    public MutableSpan setOperationName(final CharSequence serviceName) {
+      return null;
+    }
+
+    @Override
+    public String getServiceName() {
+      return null;
+    }
+
+    @Override
+    public MutableSpan setServiceName(final String serviceName) {
+      return null;
+    }
+
+    @Override
+    public CharSequence getResourceName() {
+      return null;
+    }
+
+    @Override
+    public MutableSpan setResourceName(final CharSequence resourceName) {
+      return null;
+    }
+
+    @Override
+    public Integer getSamplingPriority() {
+      return null;
+    }
+
+    @Override
+    public MutableSpan setSamplingPriority(final int newPriority) {
+      return null;
+    }
+
+    @Override
+    public String getSpanType() {
+      return null;
+    }
+
+    @Override
+    public MutableSpan setSpanType(final CharSequence type) {
+      return null;
+    }
+
+    @Override
+    public Map<String, Object> getTags() {
+      return tags;
+    }
+
+    @Override
+    public MutableSpan setTag(final String tag, final String value) {
+      tags.put(tag, value);
+      return this;
+    }
+
+    @Override
+    public MutableSpan setTag(final String tag, final boolean value) {
+      tags.put(tag, value);
+      return this;
+    }
+
+    @Override
+    public MutableSpan setTag(final String tag, final Number value) {
+      tags.put(tag, value);
+      return this;
+    }
+
+    @Override
+    public MutableSpan setMetric(final CharSequence metric, final int value) {
+      return null;
+    }
+
+    @Override
+    public MutableSpan setMetric(final CharSequence metric, final long value) {
+      return null;
+    }
+
+    @Override
+    public MutableSpan setMetric(final CharSequence metric, final double value) {
+      return null;
+    }
+
+    @Override
+    public boolean isError() {
+      return error;
+    }
+
+    @Override
+    public MutableSpan setError(final boolean value) {
+      error = value;
+      return this;
+    }
+
+    @Override
+    public MutableSpan getRootSpan() {
+      return null;
+    }
+
+    @Override
+    public MutableSpan getLocalRootSpan() {
+      return null;
+    }
+
+  }
+
+  @Test
+  void testOnTraceComplete() {
+    final var simple = new DummySpan();
+
+    final var unmodifiedError = new DummySpan();
+    unmodifiedError.setError(true);
+    unmodifiedError.setTag("unmodified", true);
+
+    final var statusCodeError = new DummySpan();
+    statusCodeError.setError(true);
+    statusCodeError.setTag("peer.hostname", "storage.googleapis.com");
+    statusCodeError.setTag("http.status_code", 404);
+
+    final var errorMsgError = new DummySpan();
+    errorMsgError.setError(true);
+    errorMsgError.setTag("peer.hostname", "storage.googleapis.com");
+    errorMsgError.setTag("error.msg", "404 Not Found and is still missing!");
+
+    final var spans = List.of(
+        simple, unmodifiedError, statusCodeError, errorMsgError);
+
+    final var interceptor = new StorageObjectGetInterceptor();
+    final var actual = interceptor.onTraceComplete(spans);
+
+    assertEquals(spans, actual);
+    assertTrue(unmodifiedError.isError());
+    assertFalse(statusCodeError.isError());
+    assertFalse(errorMsgError.isError());
+  }
+
+}


### PR DESCRIPTION
## What
- treat expected 404 messages from google storage as non-errors

## How
Create an interceptor that looks for specific error spans and marks them as non-errors.  This is necessary as the google storage client _automatically_ marks any 404 response from their api as an error on the span they create.  As we don't have any ability to directly influence how they create their span or what they consider to be an error, we have to do this afterwards via this interceptor.