### PR TITLE
JDBC sources: Improve source column type logs

### DIFF
--- a/airbyte-integrations/connectors/source-jdbc/src/main/java/io/airbyte/integrations/source/jdbc/AbstractJdbcSource.java
+++ b/airbyte-integrations/connectors/source-jdbc/src/main/java/io/airbyte/integrations/source/jdbc/AbstractJdbcSource.java
@@ -193,7 +193,7 @@ public abstract class AbstractJdbcSource<Datatype> extends AbstractRelationalDbS
                 .map(f -> {
                   final Datatype datatype = getFieldType(f);
                   final JsonSchemaType jsonType = getType(datatype);
-                  LOGGER.info("Table {} column {} (type {}[{}]) -> {}",
+                  LOGGER.info("Table {} column {} (type {}[{}], nullable {}) -> {}",
                       fields.get(0).get(INTERNAL_TABLE_NAME).asText(),
                       f.get(INTERNAL_COLUMN_NAME).asText(),
                       f.get(INTERNAL_COLUMN_TYPE_NAME).asText(),


### PR DESCRIPTION
These logs currently look like ` Table THE_TABLE_NAME column THE_COLUMN_NAME (type VARCHAR[16777216]) -> false`. That `false` represents nullability, and we're not logging the json schema at all.

Fix the log template so that it actually logs all the parameters, and puts them in the right place.