### PR TITLE
Add back destination-databricks

### DIFF
--- a/airbyte-webapp/src/core/domain/connector/constants.ts
+++ b/airbyte-webapp/src/core/domain/connector/constants.ts
@@ -19,7 +19,6 @@ export const getExcludedConnectorIds = (workspaceId: string) =>
   isCloudApp()
     ? [
         "707456df-6f4f-4ced-b5c6-03f73bcad1c5", // hide Cassandra Destination https://github.com/airbytehq/airbyte-cloud/issues/2606
-        "072d5540-f236-4294-ba7c-ade8fd918496", // hide Databricks Destination https://github.com/airbytehq/airbyte-cloud/issues/2607
         "8ccd8909-4e99-4141-b48d-4984b70b2d89", // hide DynamoDB Destination https://github.com/airbytehq/airbyte-cloud/issues/2608
         "68f351a7-2745-4bef-ad7f-996b8e51bb8c", // hide ElasticSearch Destination https://github.com/airbytehq/airbyte-cloud/issues/2594
         "9f760101-60ae-462f-9ee6-b7a9dafd454d", // hide Kafka Destination https://github.com/airbytehq/airbyte-cloud/issues/2610


### PR DESCRIPTION
## What
destination-databricks now enforces secure connections and can be added back to airbyte cloud