### PR TITLE
🪟🐛  [DRAFT] Only show stream validation error if it has been touched

### DIFF
--- a/airbyte-webapp/src/components/CreateConnection/CreateConnectionForm.tsx
+++ b/airbyte-webapp/src/components/CreateConnection/CreateConnectionForm.tsx
@@ -103,7 +103,6 @@ const CreateConnectionFormInner: React.FC<CreateConnectionPropsInner> = ({ schem
           initialValues={initialValues}
           validationSchema={connectionValidationSchema(mode)}
           onSubmit={onFormSubmit}
-          validateOnChange={false}
         >
           {({ values, isSubmitting, isValid, dirty }) => (
             <Form>

--- a/airbyte-webapp/src/pages/ConnectionPage/pages/ConnectionItemPage/ConnectionReplicationTab.tsx
+++ b/airbyte-webapp/src/pages/ConnectionPage/pages/ConnectionItemPage/ConnectionReplicationTab.tsx
@@ -150,7 +150,6 @@ export const ConnectionReplicationTab: React.FC = () => {
           validationSchema={connectionValidationSchema(mode)}
           onSubmit={onFormSubmit}
           enableReinitialize
-          validateOnChange={false}
         >
           {({ values, isSubmitting, isValid, dirty, resetForm }) => (
             <Form>

--- a/airbyte-webapp/src/views/Connection/CatalogTree/CatalogSection.tsx
+++ b/airbyte-webapp/src/views/Connection/CatalogTree/CatalogSection.tsx
@@ -1,4 +1,4 @@
-import { FormikErrors, getIn } from "formik";
+import { FormikErrors, getIn, useFormikContext } from "formik";
 import React, { memo, useCallback, useMemo } from "react";
 import { useToggle } from "react-use";
 
@@ -45,6 +45,7 @@ const CatalogSectionInner: React.FC<CatalogSectionInnerProps> = ({
     destDefinition: { supportedDestinationSyncModes },
   } = useConnectionFormService();
   const { mode } = useConnectionFormService();
+  const { touched } = useFormikContext();
 
   const [isRowExpanded, onExpand] = useToggle(false);
   const { stream, config } = streamNode;
@@ -128,8 +129,9 @@ const CatalogSectionInner: React.FC<CatalogSectionInnerProps> = ({
   );
 
   const destName = prefix + (streamNode.stream?.name ?? "");
-  const configErrors = getIn(errors, `schema.streams[${streamNode.id}].config`);
-  const hasError = configErrors && Object.keys(configErrors).length > 0;
+  const configErrors = getIn(errors, `syncCatalog.streams[${streamNode.id}].config`);
+  const streamIsTouched = getIn(touched, `syncCatalog.streams[${streamNode.id}]`);
+  const hasError = configErrors && streamIsTouched;
   const pkType = getPathType(pkRequired, shouldDefinePk);
   const cursorType = getPathType(cursorRequired, shouldDefineCursor);
   const hasFields = fields?.length > 0;

--- a/airbyte-webapp/src/views/Connection/CatalogTree/CatalogTreeBody.tsx
+++ b/airbyte-webapp/src/views/Connection/CatalogTree/CatalogTreeBody.tsx
@@ -16,6 +16,7 @@ interface CatalogTreeBodyProps {
 
 export const CatalogTreeBody: React.FC<CatalogTreeBodyProps> = ({ streams, onStreamChanged }) => {
   const { mode } = useConnectionFormService();
+  const { setFieldTouched } = useFormikContext();
 
   const onUpdateStream = useCallback(
     (id: string | undefined, newConfig: Partial<AirbyteStreamConfiguration>) => {
@@ -23,11 +24,11 @@ export const CatalogTreeBody: React.FC<CatalogTreeBodyProps> = ({ streams, onStr
 
       if (streamNode) {
         const newStreamNode = setIn(streamNode, "config", { ...streamNode.config, ...newConfig });
-
+        setFieldTouched(`syncCatalog.streams[${id}]`, true);
         onStreamChanged(newStreamNode);
       }
     },
-    [streams, onStreamChanged]
+    [streams, onStreamChanged, setFieldTouched]
   );
 
   const { initialValues } = useFormikContext<ConnectionFormValues>();

--- a/airbyte-webapp/src/views/Connection/ConnectionForm/formConfig.tsx
+++ b/airbyte-webapp/src/views/Connection/ConnectionForm/formConfig.tsx
@@ -154,7 +154,7 @@ export const connectionValidationSchema = (mode: ConnectionFormMode) =>
                     if (value.primaryKey?.length === 0) {
                       return this.createError({
                         message: "connectionForm.primaryKey.required",
-                        path: `schema.streams[${this.parent.id}].config.primaryKey`,
+                        path: `syncCatalog.streams[${this.parent.id}].config.primaryKey`,
                       });
                     }
                   }
@@ -168,7 +168,7 @@ export const connectionValidationSchema = (mode: ConnectionFormMode) =>
                     ) {
                       return this.createError({
                         message: "connectionForm.cursorField.required",
-                        path: `schema.streams[${this.parent.id}].config.cursorField`,
+                        path: `syncCatalog.streams[${this.parent.id}].config.cursorField`,
                       });
                     }
                   }


### PR DESCRIPTION
## What
Closes https://github.com/airbytehq/airbyte-internal-issues/issues/1063

Note: still results in weird UX, so these changes alone should probably not be merged.

## How
- Adds a manual `setFieldTouched()` call when updating a stream in formik
- Check to make sure the stream field has been `touched` before displaying an error indicator (red border)

## Recommended reading order
top to bottom

