### PR TITLE
Improve secret replacement matching reg ex

### DIFF
--- a/airbyte-commons/src/main/java/io/airbyte/commons/logging/MaskedDataInterceptor.java
+++ b/airbyte-commons/src/main/java/io/airbyte/commons/logging/MaskedDataInterceptor.java
@@ -127,7 +127,7 @@ public class MaskedDataInterceptor implements RewritePolicy {
     builder.append("(?i)"); // case insensitive
     builder.append("\"(");
     builder.append(properties.stream().collect(Collectors.joining("|")));
-    builder.append(")\"\\s*:\\s*\"?((\\\\\"|[^\",}])*)\"?");
+    builder.append(")\"\\s*:\\s*(\"(?:[^\"\\\\]|\\\\.)*\"|\\[[^]\\[]*]|\\d+)");
     return builder.toString();
   }
 

--- a/airbyte-commons/src/test/java/io/airbyte/commons/logging/MaskedDataInterceptorTest.java
+++ b/airbyte-commons/src/test/java/io/airbyte/commons/logging/MaskedDataInterceptorTest.java
@@ -55,6 +55,8 @@ class MaskedDataInterceptorTest {
     when(message.getFormattedMessage()).thenReturn(JSON_WITH_STRING_WITH_QUOTE_SECRETS);
     when(logEvent.getMessage()).thenReturn(message);
 
+    System.out.println(JSON_WITH_STRING_WITH_QUOTE_SECRETS);
+
     final MaskedDataInterceptor interceptor = MaskedDataInterceptor.createPolicy(TEST_SPEC_SECRET_MASK_YAML);
     final LogEvent result = interceptor.rewrite(logEvent);
 

--- a/airbyte-commons/src/test/java/io/airbyte/commons/logging/MaskedDataInterceptorTest.java
+++ b/airbyte-commons/src/test/java/io/airbyte/commons/logging/MaskedDataInterceptorTest.java
@@ -55,8 +55,6 @@ class MaskedDataInterceptorTest {
     when(message.getFormattedMessage()).thenReturn(JSON_WITH_STRING_WITH_QUOTE_SECRETS);
     when(logEvent.getMessage()).thenReturn(message);
 
-    System.out.println(JSON_WITH_STRING_WITH_QUOTE_SECRETS);
-
     final MaskedDataInterceptor interceptor = MaskedDataInterceptor.createPolicy(TEST_SPEC_SECRET_MASK_YAML);
     final LogEvent result = interceptor.rewrite(logEvent);
 


### PR DESCRIPTION
## What
* Improve the masking of secrets so that the replaced version is valid JSON

## How
* Improve the regular expression used to find and replace secret values to better handle values with double quotes and commas in their value.

## Recommended reading order
1. `MaskedDataInterceptor.java`

## Tests

* All unit tests pass
* Tested regular expression manually against a variety of strings, some which included double quotes and commas in the value to verify the replacement works.