### PR TITLE
Remove `airbyte-cli` from build scrips

### DIFF
--- a/tools/bin/publish_docker.sh
+++ b/tools/bin/publish_docker.sh
@@ -4,7 +4,6 @@ set -e
 # List of directories without "airbyte-" prefix.
 projectDir=(
   "bootloader"
-  "cli"
   "config/init"
   "container-orchestrator"
   "cron"


### PR DESCRIPTION
This was forgotten in https://github.com/airbytehq/airbyte/pull/18009.
Publishing OSS is blocked (e.g. [here](https://github.com/airbytehq/airbyte/actions/runs/3290776654/jobs/5424099841))