### PR TITLE
Update Python Source connectors to use the latest airbyte-cdk minor version

### DIFF
--- a/airbyte-integrations/bases/source-acceptance-test/setup.py
+++ b/airbyte-integrations/bases/source-acceptance-test/setup.py
@@ -6,7 +6,7 @@
 import setuptools
 
 MAIN_REQUIREMENTS = [
-    "airbyte-cdk~=0.2.0",
+    "airbyte-cdk~=0.2",
     "docker~=5.0.3",
     "PyYAML~=5.4",
     "icdiff~=1.9",

--- a/airbyte-integrations/connector-templates/source-python-http-api/setup.py.hbs
+++ b/airbyte-integrations/connector-templates/source-python-http-api/setup.py.hbs
@@ -6,7 +6,7 @@
 from setuptools import find_packages, setup
 
 MAIN_REQUIREMENTS = [
-    "airbyte-cdk~=0.1.56",
+    "airbyte-cdk~=0.2",
 ]
 
 TEST_REQUIREMENTS = [

--- a/airbyte-integrations/connector-templates/source-python/setup.py.hbs
+++ b/airbyte-integrations/connector-templates/source-python/setup.py.hbs
@@ -6,7 +6,7 @@
 from setuptools import find_packages, setup
 
 MAIN_REQUIREMENTS = [
-    "airbyte-cdk~=0.1.56",
+    "airbyte-cdk~=0.2",
 ]
 
 TEST_REQUIREMENTS = [

--- a/airbyte-integrations/connectors/source-adjust/setup.py
+++ b/airbyte-integrations/connectors/source-adjust/setup.py
@@ -6,7 +6,7 @@
 from setuptools import find_packages, setup
 
 MAIN_REQUIREMENTS = [
-    "airbyte-cdk~=0.1.56",
+    "airbyte-cdk~=0.1",
 ]
 
 TEST_REQUIREMENTS = [

--- a/airbyte-integrations/connectors/source-amazon-ads/setup.py
+++ b/airbyte-integrations/connectors/source-amazon-ads/setup.py
@@ -5,7 +5,7 @@
 
 from setuptools import find_packages, setup
 
-MAIN_REQUIREMENTS = ["airbyte-cdk~=0.2.0", "requests_oauthlib~=1.3.1", "pendulum~=2.1.2"]
+MAIN_REQUIREMENTS = ["airbyte-cdk~=0.2", "requests_oauthlib~=1.3.1", "pendulum~=2.1.2"]
 
 TEST_REQUIREMENTS = [
     "pytest~=6.1",

--- a/airbyte-integrations/connectors/source-appfollow/setup.py
+++ b/airbyte-integrations/connectors/source-appfollow/setup.py
@@ -6,7 +6,7 @@
 from setuptools import find_packages, setup
 
 MAIN_REQUIREMENTS = [
-    "airbyte-cdk~=0.1.56",
+    "airbyte-cdk~=0.1",
 ]
 
 TEST_REQUIREMENTS = ["pytest~=6.1", "pytest-mock~=3.6.1", "source-acceptance-test", "requests_mock~=1.9"]

--- a/airbyte-integrations/connectors/source-appsflyer/setup.py
+++ b/airbyte-integrations/connectors/source-appsflyer/setup.py
@@ -5,7 +5,7 @@
 
 from setuptools import find_packages, setup
 
-MAIN_REQUIREMENTS = ["airbyte-cdk~=0.1.25", "pendulum~=2.1.2"]
+MAIN_REQUIREMENTS = ["airbyte-cdk~=0.1", "pendulum~=2.1.2"]
 
 TEST_REQUIREMENTS = [
     "pytest~=6.1",

--- a/airbyte-integrations/connectors/source-cart/setup.py
+++ b/airbyte-integrations/connectors/source-cart/setup.py
@@ -6,7 +6,7 @@
 from setuptools import find_packages, setup
 
 MAIN_REQUIREMENTS = [
-    "airbyte-cdk~=0.1.7",
+    "airbyte-cdk~=0.1",
 ]
 
 TEST_REQUIREMENTS = [

--- a/airbyte-integrations/connectors/source-courier/setup.py
+++ b/airbyte-integrations/connectors/source-courier/setup.py
@@ -6,7 +6,7 @@
 from setuptools import find_packages, setup
 
 MAIN_REQUIREMENTS = [
-    "airbyte-cdk~=0.1.99",
+    "airbyte-cdk~=0.1",
 ]
 
 TEST_REQUIREMENTS = [

--- a/airbyte-integrations/connectors/source-facebook-marketing/setup.py
+++ b/airbyte-integrations/connectors/source-facebook-marketing/setup.py
@@ -6,7 +6,7 @@
 from setuptools import find_packages, setup
 
 MAIN_REQUIREMENTS = [
-    "airbyte-cdk~=0.1.56",
+    "airbyte-cdk~=0.1",
     "cached_property==1.5.2",
     "facebook_business==14.0.0",
     "pendulum>=2,<3",

--- a/airbyte-integrations/connectors/source-fauna/setup.py
+++ b/airbyte-integrations/connectors/source-fauna/setup.py
@@ -6,7 +6,7 @@
 from setuptools import find_packages, setup
 
 MAIN_REQUIREMENTS = [
-    "airbyte-cdk~=0.1.56",
+    "airbyte-cdk~=0.1",
     "faunadb~=4.2",
 ]
 

--- a/airbyte-integrations/connectors/source-file/setup.py
+++ b/airbyte-integrations/connectors/source-file/setup.py
@@ -6,7 +6,7 @@
 from setuptools import find_packages, setup
 
 MAIN_REQUIREMENTS = [
-    "airbyte-cdk~=0.2.0",
+    "airbyte-cdk~=0.2",
     "gcsfs==2022.7.1",
     "genson==1.2.2",
     "google-cloud-storage==2.5.0",

--- a/airbyte-integrations/connectors/source-freshservice/setup.py
+++ b/airbyte-integrations/connectors/source-freshservice/setup.py
@@ -6,7 +6,7 @@
 from setuptools import find_packages, setup
 
 MAIN_REQUIREMENTS = [
-    "airbyte-cdk~=0.1.25",
+    "airbyte-cdk~=0.1",
 ]
 
 TEST_REQUIREMENTS = [

--- a/airbyte-integrations/connectors/source-github/setup.py
+++ b/airbyte-integrations/connectors/source-github/setup.py
@@ -5,7 +5,7 @@
 
 from setuptools import find_packages, setup
 
-MAIN_REQUIREMENTS = ["airbyte-cdk~=0.2.0", "pendulum~=2.1.2", "sgqlc"]
+MAIN_REQUIREMENTS = ["airbyte-cdk~=0.2", "pendulum~=2.1.2", "sgqlc"]
 
 TEST_REQUIREMENTS = ["pytest~=6.1", "source-acceptance-test", "responses~=0.19.0"]
 

--- a/airbyte-integrations/connectors/source-glassfrog/setup.py
+++ b/airbyte-integrations/connectors/source-glassfrog/setup.py
@@ -6,7 +6,7 @@
 from setuptools import find_packages, setup
 
 MAIN_REQUIREMENTS = [
-    "airbyte-cdk~=0.1.56",
+    "airbyte-cdk~=0.1",
 ]
 
 TEST_REQUIREMENTS = [

--- a/airbyte-integrations/connectors/source-google-sheets/setup.py
+++ b/airbyte-integrations/connectors/source-google-sheets/setup.py
@@ -6,7 +6,7 @@
 from setuptools import find_packages, setup
 
 MAIN_REQUIREMENTS = [
-    "airbyte-cdk~=0.1.56",
+    "airbyte-cdk~=0.1",
     "backoff",
     "requests",
     "google-auth-httplib2",

--- a/airbyte-integrations/connectors/source-greenhouse/setup.py
+++ b/airbyte-integrations/connectors/source-greenhouse/setup.py
@@ -16,7 +16,7 @@ setup(
     author="Airbyte",
     author_email="contact@airbyte.io",
     packages=find_packages(),
-    install_requires=["airbyte-cdk>=0.1.91", "dataclasses-jsonschema==2.15.1"],
+    install_requires=["airbyte-cdk~=0.1", "dataclasses-jsonschema==2.15.1"],
     package_data={"": ["*.json", "*.yaml", "schemas/*.json"]},
     extras_require={
         "tests": TEST_REQUIREMENTS,

--- a/airbyte-integrations/connectors/source-hubspot/setup.py
+++ b/airbyte-integrations/connectors/source-hubspot/setup.py
@@ -6,7 +6,7 @@
 from setuptools import find_packages, setup
 
 MAIN_REQUIREMENTS = [
-    "airbyte-cdk~=0.1.55",
+    "airbyte-cdk~=0.1",
     "backoff==1.11.1",
     "pendulum==2.1.2",
     "requests==2.26.0",

--- a/airbyte-integrations/connectors/source-instagram/setup.py
+++ b/airbyte-integrations/connectors/source-instagram/setup.py
@@ -6,7 +6,7 @@
 from setuptools import find_packages, setup
 
 MAIN_REQUIREMENTS = [
-    "airbyte-cdk~=0.1.81",
+    "airbyte-cdk~=0.1",
     "cached_property~=1.5",
     "facebook_business~=11.0",
     "pendulum>=2,<3",

--- a/airbyte-integrations/connectors/source-mailchimp/setup.py
+++ b/airbyte-integrations/connectors/source-mailchimp/setup.py
@@ -15,7 +15,7 @@ setup(
     author_email="contact@airbyte.io",
     packages=find_packages(),
     install_requires=[
-        "airbyte-cdk~=0.1.35",
+        "airbyte-cdk~=0.1",
         "pytest~=6.1",
     ],
     package_data={"": ["*.json", "schemas/*.json", "schemas/shared/*.json"]},

--- a/airbyte-integrations/connectors/source-netsuite/setup.py
+++ b/airbyte-integrations/connectors/source-netsuite/setup.py
@@ -6,7 +6,7 @@
 from setuptools import find_packages, setup
 
 MAIN_REQUIREMENTS = [
-    "airbyte-cdk~=0.1.56",
+    "airbyte-cdk~=0.1",
     "requests-oauthlib~=1.3",
 ]
 

--- a/airbyte-integrations/connectors/source-orbit/setup.py
+++ b/airbyte-integrations/connectors/source-orbit/setup.py
@@ -6,7 +6,7 @@
 from setuptools import find_packages, setup
 
 MAIN_REQUIREMENTS = [
-    "airbyte-cdk~=0.1.56",
+    "airbyte-cdk~=0.1",
 ]
 
 TEST_REQUIREMENTS = [

--- a/airbyte-integrations/connectors/source-primetric/setup.py
+++ b/airbyte-integrations/connectors/source-primetric/setup.py
@@ -6,7 +6,7 @@
 from setuptools import find_packages, setup
 
 MAIN_REQUIREMENTS = [
-    "airbyte-cdk~=0.1.56",
+    "airbyte-cdk~=0.1",
 ]
 
 TEST_REQUIREMENTS = [

--- a/airbyte-integrations/connectors/source-salesforce/setup.py
+++ b/airbyte-integrations/connectors/source-salesforce/setup.py
@@ -5,7 +5,7 @@
 
 from setuptools import find_packages, setup
 
-MAIN_REQUIREMENTS = ["airbyte-cdk~=0.1.56", "vcrpy==4.1.1", "pandas"]
+MAIN_REQUIREMENTS = ["airbyte-cdk~=0.1", "vcrpy==4.1.1", "pandas"]
 
 TEST_REQUIREMENTS = ["pytest~=6.1", "pytest-mock~=3.6", "requests_mock", "source-acceptance-test", "pytest-timeout"]
 

--- a/airbyte-integrations/connectors/source-salesloft/setup.py
+++ b/airbyte-integrations/connectors/source-salesloft/setup.py
@@ -6,7 +6,7 @@
 from setuptools import find_packages, setup
 
 MAIN_REQUIREMENTS = [
-    "airbyte-cdk~=0.1.22",
+    "airbyte-cdk~=0.1",
 ]
 
 TEST_REQUIREMENTS = [

--- a/airbyte-integrations/connectors/source-scaffold-source-http/setup.py
+++ b/airbyte-integrations/connectors/source-scaffold-source-http/setup.py
@@ -6,7 +6,7 @@
 from setuptools import find_packages, setup
 
 MAIN_REQUIREMENTS = [
-    "airbyte-cdk~=0.1.56",
+    "airbyte-cdk~=0.1",
 ]
 
 TEST_REQUIREMENTS = [

--- a/airbyte-integrations/connectors/source-scaffold-source-http/setup.py
+++ b/airbyte-integrations/connectors/source-scaffold-source-http/setup.py
@@ -6,7 +6,7 @@
 from setuptools import find_packages, setup
 
 MAIN_REQUIREMENTS = [
-    "airbyte-cdk~=0.1",
+    "airbyte-cdk~=0.2",
 ]
 
 TEST_REQUIREMENTS = [

--- a/airbyte-integrations/connectors/source-scaffold-source-python/setup.py
+++ b/airbyte-integrations/connectors/source-scaffold-source-python/setup.py
@@ -6,7 +6,7 @@
 from setuptools import find_packages, setup
 
 MAIN_REQUIREMENTS = [
-    "airbyte-cdk~=0.1.56",
+    "airbyte-cdk~=0.1",
 ]
 
 TEST_REQUIREMENTS = [

--- a/airbyte-integrations/connectors/source-scaffold-source-python/setup.py
+++ b/airbyte-integrations/connectors/source-scaffold-source-python/setup.py
@@ -6,7 +6,7 @@
 from setuptools import find_packages, setup
 
 MAIN_REQUIREMENTS = [
-    "airbyte-cdk~=0.1",
+    "airbyte-cdk~=0.2",
 ]
 
 TEST_REQUIREMENTS = [

--- a/airbyte-integrations/connectors/source-shortio/setup.py
+++ b/airbyte-integrations/connectors/source-shortio/setup.py
@@ -5,7 +5,7 @@
 
 from setuptools import find_packages, setup
 
-MAIN_REQUIREMENTS = ["airbyte-cdk~=0.1.56"]
+MAIN_REQUIREMENTS = ["airbyte-cdk~=0.1"]
 
 TEST_REQUIREMENTS = [
     "pytest~=6.2.5",

--- a/airbyte-integrations/connectors/source-wrike/setup.py
+++ b/airbyte-integrations/connectors/source-wrike/setup.py
@@ -6,7 +6,7 @@
 from setuptools import find_packages, setup
 
 MAIN_REQUIREMENTS = [
-    "airbyte-cdk~=0.1.56",
+    "airbyte-cdk~=0.1",
 ]
 
 TEST_REQUIREMENTS = [

--- a/airbyte-integrations/connectors/source-yandex-metrica/setup.py
+++ b/airbyte-integrations/connectors/source-yandex-metrica/setup.py
@@ -6,7 +6,7 @@
 from setuptools import find_packages, setup
 
 MAIN_REQUIREMENTS = [
-    "airbyte-cdk~=0.1.56",
+    "airbyte-cdk~=0.1",
     "pytest~=6.1",
 ]
 

--- a/airbyte-integrations/connectors/source-zendesk-support/setup.py
+++ b/airbyte-integrations/connectors/source-zendesk-support/setup.py
@@ -5,7 +5,7 @@
 
 from setuptools import find_packages, setup
 
-MAIN_REQUIREMENTS = ["airbyte-cdk~=0.1.60", "pytz", "requests-futures~=1.0.0", "pendulum~=2.1.2"]
+MAIN_REQUIREMENTS = ["airbyte-cdk~=0.1", "pytz", "requests-futures~=1.0.0", "pendulum~=2.1.2"]
 
 TEST_REQUIREMENTS = ["pytest~=6.1", "pytest-mock~=3.6", "source-acceptance-test", "requests-mock==1.9.3"]
 


### PR DESCRIPTION
## What
Now that we're going to more strictly adhere to semantic versioning of the `airbyte-cdk` any connectors adhering to the `~=0.1.56` etc pattern will not get minor bumps.

## How
Update the relevant `setup.py` files as well as the source API generator so new connectors follow the same format.

Note: I won't be publishing these connectors, just fixing the setup file so that CI checks are fixed. These can be rolled next time a connector gets updated.
