### PR TITLE
Disable basic auth for Octavia integration tests

### DIFF
--- a/tools/bin/integration_tests_octavia.sh
+++ b/tools/bin/integration_tests_octavia.sh
@@ -9,7 +9,7 @@ assert_root
 echo "Starting app..."
 
 # Detach so we can run subsequent commands
-VERSION=dev TRACKING_STRATEGY=logging docker-compose up -d
+VERSION=dev TRACKING_STRATEGY=logging BASIC_AUTH_USERNAME="" BASIC_AUTH_PASSWORD="" docker-compose up -d
 
 # Sometimes source/dest containers using airbyte volumes survive shutdown, which need to be killed in order to shut down properly.
 shutdown_cmd="docker-compose down -v || docker kill \$(docker ps -a -f volume=airbyte_workspace -f volume=airbyte_data -f volume=airbyte_db -q) && docker-compose down -v"


### PR DESCRIPTION
Just like https://github.com/airbytehq/airbyte/pull/18255 and https://github.com/airbytehq/airbyte/issues/18245