### PR TITLE
Add basic auth to load_test script

### DIFF
--- a/tools/bin/load_test/cleanup_load_test.sh
+++ b/tools/bin/load_test/cleanup_load_test.sh
@@ -7,6 +7,9 @@ This script cleans up an earlier load test. It reads from cleanup files that the
 in order to determine which IDs to delete.
 comment
 
+echo "Sourcing environment variables from .env"
+source .env
+
 cd "$(dirname "$0")"
 source load_test_utils.sh
 

--- a/tools/bin/load_test/load_test_airbyte.sh
+++ b/tools/bin/load_test/load_test_airbyte.sh
@@ -9,6 +9,9 @@ that requires port-forwarding. It stores connector and connection IDs that it cr
 which means the script will delete every connector and connection ID that it created and stored in that file.
 comment
 
+echo "Sourcing environment variables from .env"
+source .env
+
 cd "$(dirname "$0")"
 source load_test_utils.sh
 

--- a/tools/bin/load_test/load_test_utils.sh
+++ b/tools/bin/load_test/load_test_utils.sh
@@ -22,6 +22,7 @@ function callApi {
    --show-error \
    --header 'Content-Type: application/json' \
    --header "X-Endpoint-API-UserInfo: ${x_endpoint_header}" \
+   --user "${BASIC_AUTH_USERNAME}:${BASIC_AUTH_PASSWORD}" \
    --data "${payload}" \
     "${hostname}:${api_port}/api/v1/${endpoint}"
 }


### PR DESCRIPTION
## What
Now that OSS deployments of Airbyte use basic auth, update the load_test script to source `.env` and use the `BASIC_AUTH_USERNAME`/`BASIC_AUTH_PASSWORD` values when `curl`ing the API

