### PR TITLE
Fix broken link to config in .env comment

### DIFF
--- a/.env
+++ b/.env
@@ -3,7 +3,7 @@
 # Variables with defaults have been omitted to avoid duplication of defaults.
 # The only exception to the non-default rule are env vars related to scaling.
 #
-# See https://github.com/airbytehq/airbyte/blob/master/airbyte-config/models/src/main/java/io/airbyte/config/Configs.java
+# See https://github.com/airbytehq/airbyte/blob/master/airbyte-config/config-models/src/main/java/io/airbyte/config/Configs.java
 # for the latest environment variables.
 #
 # # Contributors - please organise this env file according to the above linked file.


### PR DESCRIPTION
## What
Fixes a broken link to config variables in a comment in `.env`