### PR TITLE
Update docs for local webapp development and basic auth

### DIFF
--- a/docs/contributing-to-airbyte/developing-locally.md
+++ b/docs/contributing-to-airbyte/developing-locally.md
@@ -166,11 +166,12 @@ Note: If you are contributing a Python file without imports or function definiti
 ### Develop on `airbyte-webapp`
 
 - Spin up Airbyte locally so the UI can make requests against the local API.
-- Stop the `webapp`.
 
 ```bash
-docker-compose stop webapp
+BASIC_AUTH_USERNAME="" BASIC_AUTH_PASSWORD="" docker-compose up
 ```
+
+Note: [basic auth](https://docs.airbyte.com/operator-guides/security#network-security) must be disabled by setting `BASIC_AUTH_USERNAME` and `BASIC_AUTH_PASSWORD` to empty values, otherwise requests from the development server will fail against the local API.
 
 - Start up the react app.
 


### PR DESCRIPTION
## What
Requests from the local webapp development server (running on `localhost:3000`) to the local API (running in docker) will fail due to the new [basic auth](https://github.com/airbytehq/airbyte/edit/master/docs/contributing-to-airbyte/developing-locally.md). 

## How
This PR updates the docs around local webapp development, instructing developers to disable basic auth.