### PR TITLE
use api to do jobpersistence query

### DIFF
--- a/airbyte-api/src/main/openapi/config.yaml
+++ b/airbyte-api/src/main/openapi/config.yaml
@@ -2187,7 +2187,7 @@ paths:
           content:
             application/json:
               schema:
-                $ref: "#/components/schemas/AttemptNormalizationStatuses"
+                $ref: "#/components/schemas/AttemptNormalizationStatusReadList"
 
   /v1/health:
     get:
@@ -4844,10 +4844,10 @@ components:
       properties:
         succeeded:
           type: boolean
-    AttemptNormalizationStatuses:
+    AttemptNormalizationStatusReadList:
       type: object
       properties:
-        attemptNormalizationStatus:
+        attemptNormalizationStatuses:
           type: array
           items:
             $ref: "#/components/schemas/AttemptNormalizationStatusRead"

--- a/airbyte-api/src/main/openapi/config.yaml
+++ b/airbyte-api/src/main/openapi/config.yaml
@@ -2169,6 +2169,26 @@ paths:
           $ref: "#/components/responses/NotFoundResponse"
         "422":
           $ref: "#/components/responses/InvalidInputResponse"
+  /v1/jobs/get_normalization_status:
+    post:
+      tags:
+        - jobs
+        - internal
+      summary: Get normalization status to determine if we can bypass normalization phase
+      operationId: getAttemptNormalizationStatusesForJob
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: "#/components/schemas/JobIdRequestBody"
+      responses:
+        "200":
+          description: Successful operation
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/AttemptNormalizationStatuses"
+
   /v1/health:
     get:
       tags:
@@ -2242,6 +2262,7 @@ paths:
             application/json:
               schema:
                 $ref: "#/components/schemas/InternalOperationResult"
+
 components:
   securitySchemes:
     bearerAuth:
@@ -4823,6 +4844,26 @@ components:
       properties:
         succeeded:
           type: boolean
+    AttemptNormalizationStatuses:
+      type: object
+      properties:
+        attemptNormalizationStatus:
+          type: array
+          items:
+            $ref: "#/components/schemas/AttemptNormalizationStatusRead"
+    AttemptNormalizationStatusRead:
+      type: object
+      properties:
+        attemptNumber:
+          $ref: "#/components/schemas/AttemptNumber"
+        hasRecordsCommitted:
+          type: boolean
+        recordsCommitted:
+          type: integer
+          format: int64
+        hasNormalizationFailed:
+          type: boolean
+
     InvalidInputProperty:
       type: object
       required:

--- a/airbyte-persistence/job-persistence/src/main/java/io/airbyte/persistence/job/models/AttemptNormalizationStatus.java
+++ b/airbyte-persistence/job-persistence/src/main/java/io/airbyte/persistence/job/models/AttemptNormalizationStatus.java
@@ -6,4 +6,4 @@ package io.airbyte.persistence.job.models;
 
 import java.util.Optional;
 
-public record AttemptNormalizationStatus(long attemptNumber, Optional<Long> recordsCommitted, boolean normalizationFailed) {}
+public record AttemptNormalizationStatus(int attemptNumber, Optional<Long> recordsCommitted, boolean normalizationFailed) {}

--- a/airbyte-server/src/main/java/io/airbyte/server/apis/ConfigurationApi.java
+++ b/airbyte-server/src/main/java/io/airbyte/server/apis/ConfigurationApi.java
@@ -5,7 +5,7 @@
 package io.airbyte.server.apis;
 
 import io.airbyte.analytics.TrackingClient;
-import io.airbyte.api.model.generated.AttemptNormalizationStatuses;
+import io.airbyte.api.model.generated.AttemptNormalizationStatusReadList;
 import io.airbyte.api.model.generated.CheckConnectionRead;
 import io.airbyte.api.model.generated.CheckOperationRead;
 import io.airbyte.api.model.generated.CompleteDestinationOAuthRequest;
@@ -784,7 +784,7 @@ public class ConfigurationApi implements io.airbyte.api.generated.V1Api {
   }
 
   @Override
-  public AttemptNormalizationStatuses getAttemptNormalizationStatusesForJob(final JobIdRequestBody jobIdRequestBody) {
+  public AttemptNormalizationStatusReadList getAttemptNormalizationStatusesForJob(final JobIdRequestBody jobIdRequestBody) {
     return execute(() -> jobHistoryHandler.getAttemptNormalizationStatuses(jobIdRequestBody));
   }
 

--- a/airbyte-server/src/main/java/io/airbyte/server/apis/ConfigurationApi.java
+++ b/airbyte-server/src/main/java/io/airbyte/server/apis/ConfigurationApi.java
@@ -5,6 +5,7 @@
 package io.airbyte.server.apis;
 
 import io.airbyte.analytics.TrackingClient;
+import io.airbyte.api.model.generated.AttemptNormalizationStatuses;
 import io.airbyte.api.model.generated.CheckConnectionRead;
 import io.airbyte.api.model.generated.CheckOperationRead;
 import io.airbyte.api.model.generated.CompleteDestinationOAuthRequest;
@@ -780,6 +781,11 @@ public class ConfigurationApi implements io.airbyte.api.generated.V1Api {
   @Override
   public JobDebugInfoRead getJobDebugInfo(final JobIdRequestBody jobIdRequestBody) {
     return execute(() -> jobHistoryHandler.getJobDebugInfo(jobIdRequestBody));
+  }
+
+  @Override
+  public AttemptNormalizationStatuses getAttemptNormalizationStatusesForJob(final JobIdRequestBody jobIdRequestBody) {
+    return execute(() -> jobHistoryHandler.getAttemptNormalizationStatuses(jobIdRequestBody));
   }
 
   @Override

--- a/airbyte-server/src/main/java/io/airbyte/server/converters/JobConverter.java
+++ b/airbyte-server/src/main/java/io/airbyte/server/converters/JobConverter.java
@@ -9,6 +9,7 @@ import io.airbyte.api.model.generated.AttemptFailureReason;
 import io.airbyte.api.model.generated.AttemptFailureSummary;
 import io.airbyte.api.model.generated.AttemptFailureType;
 import io.airbyte.api.model.generated.AttemptInfoRead;
+import io.airbyte.api.model.generated.AttemptNormalizationStatusRead;
 import io.airbyte.api.model.generated.AttemptRead;
 import io.airbyte.api.model.generated.AttemptStats;
 import io.airbyte.api.model.generated.AttemptStatus;
@@ -38,6 +39,7 @@ import io.airbyte.config.SyncStats;
 import io.airbyte.config.helpers.LogClientSingleton;
 import io.airbyte.config.helpers.LogConfigs;
 import io.airbyte.persistence.job.models.Attempt;
+import io.airbyte.persistence.job.models.AttemptNormalizationStatus;
 import io.airbyte.persistence.job.models.Job;
 import io.airbyte.server.scheduler.SynchronousJobMetadata;
 import io.airbyte.server.scheduler.SynchronousResponse;
@@ -238,6 +240,13 @@ public class JobConverter {
         .endedAt(metadata.getEndedAt())
         .succeeded(metadata.isSucceeded())
         .logs(getLogRead(metadata.getLogPath()));
+  }
+
+  public static AttemptNormalizationStatusRead convertAttemptNormalizationStatus(
+                                                                                 AttemptNormalizationStatus databaseStatus) {
+    return new AttemptNormalizationStatusRead().attemptNumber(databaseStatus.attemptNumber())
+        .hasRecordsCommitted(!databaseStatus.recordsCommitted().isEmpty())
+        .recordsCommitted(databaseStatus.recordsCommitted().orElse(0L)).hasNormalizationFailed(databaseStatus.normalizationFailed());
   }
 
 }

--- a/airbyte-server/src/main/java/io/airbyte/server/converters/JobConverter.java
+++ b/airbyte-server/src/main/java/io/airbyte/server/converters/JobConverter.java
@@ -244,9 +244,11 @@ public class JobConverter {
 
   public static AttemptNormalizationStatusRead convertAttemptNormalizationStatus(
                                                                                  AttemptNormalizationStatus databaseStatus) {
-    return new AttemptNormalizationStatusRead().attemptNumber(databaseStatus.attemptNumber())
+    return new AttemptNormalizationStatusRead()
+        .attemptNumber(databaseStatus.attemptNumber())
         .hasRecordsCommitted(!databaseStatus.recordsCommitted().isEmpty())
-        .recordsCommitted(databaseStatus.recordsCommitted().orElse(0L)).hasNormalizationFailed(databaseStatus.normalizationFailed());
+        .recordsCommitted(databaseStatus.recordsCommitted().orElse(0L))
+        .hasNormalizationFailed(databaseStatus.normalizationFailed());
   }
 
 }

--- a/airbyte-server/src/main/java/io/airbyte/server/handlers/JobHistoryHandler.java
+++ b/airbyte-server/src/main/java/io/airbyte/server/handlers/JobHistoryHandler.java
@@ -5,7 +5,7 @@
 package io.airbyte.server.handlers;
 
 import com.google.common.base.Preconditions;
-import io.airbyte.api.model.generated.AttemptNormalizationStatuses;
+import io.airbyte.api.model.generated.AttemptNormalizationStatusReadList;
 import io.airbyte.api.model.generated.ConnectionRead;
 import io.airbyte.api.model.generated.DestinationDefinitionIdRequestBody;
 import io.airbyte.api.model.generated.DestinationDefinitionRead;
@@ -147,9 +147,9 @@ public class JobHistoryHandler {
         .collect(Collectors.toList());
   }
 
-  public AttemptNormalizationStatuses getAttemptNormalizationStatuses(final JobIdRequestBody jobIdRequestBody) throws IOException {
-    return new AttemptNormalizationStatuses()
-        .attemptNormalizationStatus(jobPersistence.getAttemptNormalizationStatusesForJob(jobIdRequestBody.getId()).stream()
+  public AttemptNormalizationStatusReadList getAttemptNormalizationStatuses(final JobIdRequestBody jobIdRequestBody) throws IOException {
+    return new AttemptNormalizationStatusReadList()
+        .attemptNormalizationStatuses(jobPersistence.getAttemptNormalizationStatusesForJob(jobIdRequestBody.getId()).stream()
             .map(JobConverter::convertAttemptNormalizationStatus).collect(Collectors.toList()));
   }
 

--- a/airbyte-server/src/main/java/io/airbyte/server/handlers/JobHistoryHandler.java
+++ b/airbyte-server/src/main/java/io/airbyte/server/handlers/JobHistoryHandler.java
@@ -5,6 +5,7 @@
 package io.airbyte.server.handlers;
 
 import com.google.common.base.Preconditions;
+import io.airbyte.api.model.generated.AttemptNormalizationStatuses;
 import io.airbyte.api.model.generated.ConnectionRead;
 import io.airbyte.api.model.generated.DestinationDefinitionIdRequestBody;
 import io.airbyte.api.model.generated.DestinationDefinitionRead;
@@ -144,6 +145,12 @@ public class JobHistoryHandler {
     return jobPersistence.getLastSyncJobForConnections(connectionIds).stream()
         .map(JobConverter::getJobRead)
         .collect(Collectors.toList());
+  }
+
+  public AttemptNormalizationStatuses getAttemptNormalizationStatuses(final JobIdRequestBody jobIdRequestBody) throws IOException {
+    return new AttemptNormalizationStatuses()
+        .attemptNormalizationStatus(jobPersistence.getAttemptNormalizationStatusesForJob(jobIdRequestBody.getId()).stream()
+            .map(JobConverter::convertAttemptNormalizationStatus).collect(Collectors.toList()));
   }
 
   public List<JobRead> getRunningSyncJobForConnections(final List<UUID> connectionIds) throws IOException {

--- a/airbyte-server/src/test/java/io/airbyte/server/handlers/JobHistoryHandlerTest.java
+++ b/airbyte-server/src/test/java/io/airbyte/server/handlers/JobHistoryHandlerTest.java
@@ -385,7 +385,7 @@ class JobHistoryHandlerTest {
 
     when(jobPersistence.getAttemptNormalizationStatusesForJob(JOB_ID)).thenReturn(List.of(databaseReadResult));
 
-    AttemptNormalizationStatuses expectedStatus = new AttemptNormalizationStatuses().attemptNormalizationStatus(
+    AttemptNormalizationStatusReadList expectedStatus = new AttemptNormalizationStatusReadList().attemptNormalizationStatuses(
         List.of(new AttemptNormalizationStatusRead().attemptNumber(1).hasRecordsCommitted(true).hasNormalizationFailed(false).recordsCommitted(10L)));
 
     assertEquals(expectedStatus, jobHistoryHandler.getAttemptNormalizationStatuses(new JobIdRequestBody().id(JOB_ID)));

--- a/airbyte-server/src/test/java/io/airbyte/server/handlers/JobHistoryHandlerTest.java
+++ b/airbyte-server/src/test/java/io/airbyte/server/handlers/JobHistoryHandlerTest.java
@@ -20,6 +20,7 @@ import io.airbyte.config.helpers.LogConfigs;
 import io.airbyte.config.persistence.ConfigNotFoundException;
 import io.airbyte.persistence.job.JobPersistence;
 import io.airbyte.persistence.job.models.Attempt;
+import io.airbyte.persistence.job.models.AttemptNormalizationStatus;
 import io.airbyte.persistence.job.models.AttemptStatus;
 import io.airbyte.persistence.job.models.Job;
 import io.airbyte.persistence.job.models.JobStatus;
@@ -374,6 +375,21 @@ class JobHistoryHandlerTest {
   @DisplayName("Should have compatible config enums")
   void testEnumConversion() {
     assertTrue(Enums.isCompatible(JobConfig.ConfigType.class, JobConfigType.class));
+  }
+
+  @Test
+  @DisplayName("Should return attempt normalization info for the job")
+  void testGetAttemptNormalizationStatuses() throws IOException {
+
+    AttemptNormalizationStatus databaseReadResult = new AttemptNormalizationStatus(1, Optional.of(10L), /* hasNormalizationFailed= */ false);
+
+    when(jobPersistence.getAttemptNormalizationStatusesForJob(JOB_ID)).thenReturn(List.of(databaseReadResult));
+
+    AttemptNormalizationStatuses expectedStatus = new AttemptNormalizationStatuses().attemptNormalizationStatus(
+        List.of(new AttemptNormalizationStatusRead().attemptNumber(1).hasRecordsCommitted(true).hasNormalizationFailed(false).recordsCommitted(10L)));
+
+    assertEquals(expectedStatus, jobHistoryHandler.getAttemptNormalizationStatuses(new JobIdRequestBody().id(JOB_ID)));
+
   }
 
 }

--- a/airbyte-workers/src/main/java/io/airbyte/workers/temporal/sync/NormalizationSummaryCheckActivity.java
+++ b/airbyte-workers/src/main/java/io/airbyte/workers/temporal/sync/NormalizationSummaryCheckActivity.java
@@ -6,13 +6,12 @@ package io.airbyte.workers.temporal.sync;
 
 import io.temporal.activity.ActivityInterface;
 import io.temporal.activity.ActivityMethod;
-import java.io.IOException;
 import java.util.Optional;
 
 @ActivityInterface
 public interface NormalizationSummaryCheckActivity {
 
   @ActivityMethod
-  boolean shouldRunNormalization(Long jobId, Long attemptId, Optional<Long> numCommittedRecords) throws IOException;
+  boolean shouldRunNormalization(Long jobId, Long attemptId, Optional<Long> numCommittedRecords);
 
 }

--- a/airbyte-workers/src/main/java/io/airbyte/workers/temporal/sync/NormalizationSummaryCheckActivityImpl.java
+++ b/airbyte-workers/src/main/java/io/airbyte/workers/temporal/sync/NormalizationSummaryCheckActivityImpl.java
@@ -8,13 +8,15 @@ import static io.airbyte.workers.temporal.trace.TemporalTraceConstants.ACTIVITY_
 import static io.airbyte.workers.temporal.trace.TemporalTraceConstants.Tags.JOB_ID_KEY;
 
 import datadog.trace.api.Trace;
+import io.airbyte.api.client.AirbyteApiClient;
+import io.airbyte.api.client.invoker.generated.ApiException;
+import io.airbyte.api.client.model.generated.AttemptNormalizationStatusRead;
+import io.airbyte.api.client.model.generated.AttemptNormalizationStatuses;
+import io.airbyte.api.client.model.generated.JobIdRequestBody;
 import io.airbyte.metrics.lib.ApmTraceUtils;
-import io.airbyte.persistence.job.JobPersistence;
-import io.airbyte.persistence.job.models.AttemptNormalizationStatus;
+import io.temporal.activity.Activity;
 import jakarta.inject.Singleton;
-import java.io.IOException;
 import java.util.Comparator;
-import java.util.List;
 import java.util.Map;
 import java.util.Optional;
 import java.util.concurrent.atomic.AtomicBoolean;
@@ -25,22 +27,17 @@ import lombok.extern.slf4j.Slf4j;
 @Singleton
 public class NormalizationSummaryCheckActivityImpl implements NormalizationSummaryCheckActivity {
 
-  private final Optional<JobPersistence> jobPersistence;
+  private final AirbyteApiClient airbyteApiClient;
 
-  public NormalizationSummaryCheckActivityImpl(final Optional<JobPersistence> jobPersistence) {
-    this.jobPersistence = jobPersistence;
+  public NormalizationSummaryCheckActivityImpl(AirbyteApiClient airbyteApiClient) {
+    this.airbyteApiClient = airbyteApiClient;
   }
 
   @Trace(operationName = ACTIVITY_TRACE_OPERATION_NAME)
   @Override
   @SuppressWarnings("PMD.AvoidLiteralsInIfCondition")
-  public boolean shouldRunNormalization(final Long jobId, final Long attemptNumber, final Optional<Long> numCommittedRecords) throws IOException {
+  public boolean shouldRunNormalization(final Long jobId, final Long attemptNumber, final Optional<Long> numCommittedRecords) {
     ApmTraceUtils.addTagsToTrace(Map.of(JOB_ID_KEY, jobId));
-
-    // if job persistence is unavailable, default to running normalization
-    if (jobPersistence.isEmpty()) {
-      return true;
-    }
 
     // if the count of committed records for this attempt is > 0 OR if it is null,
     // then we should run normalization
@@ -48,19 +45,26 @@ public class NormalizationSummaryCheckActivityImpl implements NormalizationSumma
       return true;
     }
 
-    final List<AttemptNormalizationStatus> attemptNormalizationStatuses = jobPersistence.get().getAttemptNormalizationStatusesForJob(jobId);
+    final AttemptNormalizationStatuses attemptNormalizationStatuses;
+    try {
+      attemptNormalizationStatuses = airbyteApiClient.getJobsApi().getAttemptNormalizationStatusesForJob(new JobIdRequestBody().id(jobId));
+    } catch (ApiException e) {
+      throw Activity.wrap(e);
+    }
     final AtomicLong totalRecordsCommitted = new AtomicLong(0L);
     final AtomicBoolean shouldReturnTrue = new AtomicBoolean(false);
 
-    attemptNormalizationStatuses.stream().sorted(Comparator.comparing(AttemptNormalizationStatus::attemptNumber).reversed()).toList()
+    attemptNormalizationStatuses.getAttemptNormalizationStatus().stream().sorted(Comparator.comparing(
+        AttemptNormalizationStatusRead::getAttemptNumber).reversed()).toList()
         .forEach(n -> {
-          if (n.attemptNumber() == attemptNumber) {
+          // Have to cast it because attemptNumber is read from JobRunConfig.
+          if (n.getAttemptNumber().intValue() == attemptNumber) {
             return;
           }
 
           // if normalization succeeded from a previous attempt succeeded,
           // we can stop looking for previous attempts
-          if (!n.normalizationFailed()) {
+          if (!n.getHasNormalizationFailed()) {
             return;
           }
 
@@ -68,11 +72,11 @@ public class NormalizationSummaryCheckActivityImpl implements NormalizationSumma
           // committed number
           // if there is no data recorded for the number of committed records, we should assume that there
           // were committed records and run normalization
-          if (n.recordsCommitted().isEmpty()) {
+          if (!n.getHasRecordsCommitted()) {
             shouldReturnTrue.set(true);
             return;
-          } else if (n.recordsCommitted().get() != 0L) {
-            totalRecordsCommitted.addAndGet(n.recordsCommitted().get());
+          } else if (n.getRecordsCommitted().longValue() != 0L) {
+            totalRecordsCommitted.addAndGet(n.getRecordsCommitted());
           }
         });
 

--- a/airbyte-workers/src/main/java/io/airbyte/workers/temporal/sync/NormalizationSummaryCheckActivityImpl.java
+++ b/airbyte-workers/src/main/java/io/airbyte/workers/temporal/sync/NormalizationSummaryCheckActivityImpl.java
@@ -11,7 +11,7 @@ import datadog.trace.api.Trace;
 import io.airbyte.api.client.AirbyteApiClient;
 import io.airbyte.api.client.invoker.generated.ApiException;
 import io.airbyte.api.client.model.generated.AttemptNormalizationStatusRead;
-import io.airbyte.api.client.model.generated.AttemptNormalizationStatuses;
+import io.airbyte.api.client.model.generated.AttemptNormalizationStatusReadList;
 import io.airbyte.api.client.model.generated.JobIdRequestBody;
 import io.airbyte.metrics.lib.ApmTraceUtils;
 import io.temporal.activity.Activity;
@@ -45,16 +45,16 @@ public class NormalizationSummaryCheckActivityImpl implements NormalizationSumma
       return true;
     }
 
-    final AttemptNormalizationStatuses attemptNormalizationStatuses;
+    final AttemptNormalizationStatusReadList AttemptNormalizationStatusReadList;
     try {
-      attemptNormalizationStatuses = airbyteApiClient.getJobsApi().getAttemptNormalizationStatusesForJob(new JobIdRequestBody().id(jobId));
+      AttemptNormalizationStatusReadList = airbyteApiClient.getJobsApi().getAttemptNormalizationStatusesForJob(new JobIdRequestBody().id(jobId));
     } catch (ApiException e) {
       throw Activity.wrap(e);
     }
     final AtomicLong totalRecordsCommitted = new AtomicLong(0L);
     final AtomicBoolean shouldReturnTrue = new AtomicBoolean(false);
 
-    attemptNormalizationStatuses.getAttemptNormalizationStatus().stream().sorted(Comparator.comparing(
+    AttemptNormalizationStatusReadList.getAttemptNormalizationStatuses().stream().sorted(Comparator.comparing(
         AttemptNormalizationStatusRead::getAttemptNumber).reversed()).toList()
         .forEach(n -> {
           // Have to cast it because attemptNumber is read from JobRunConfig.

--- a/airbyte-workers/src/main/java/io/airbyte/workers/temporal/sync/SyncWorkflowImpl.java
+++ b/airbyte-workers/src/main/java/io/airbyte/workers/temporal/sync/SyncWorkflowImpl.java
@@ -27,7 +27,6 @@ import io.airbyte.persistence.job.models.JobRunConfig;
 import io.airbyte.protocol.models.ConfiguredAirbyteCatalog;
 import io.airbyte.workers.temporal.annotations.TemporalActivityStub;
 import io.temporal.workflow.Workflow;
-import java.io.IOException;
 import java.util.Map;
 import java.util.Optional;
 import java.util.UUID;
@@ -92,7 +91,7 @@ public class SyncWorkflowImpl implements SyncWorkflow {
             try {
               shouldRun = normalizationSummaryCheckActivity.shouldRunNormalization(Long.valueOf(jobRunConfig.getJobId()), jobRunConfig.getAttemptId(),
                   Optional.ofNullable(syncOutput.getStandardSyncSummary().getTotalStats().getRecordsCommitted()));
-            } catch (final IOException e) {
+            } catch (final Exception e) {
               shouldRun = true;
             }
             if (!shouldRun) {

--- a/airbyte-workers/src/test/java/io/airbyte/workers/temporal/scheduling/activities/NormalizationSummaryCheckActivityTest.java
+++ b/airbyte-workers/src/test/java/io/airbyte/workers/temporal/scheduling/activities/NormalizationSummaryCheckActivityTest.java
@@ -11,7 +11,7 @@ import io.airbyte.api.client.AirbyteApiClient;
 import io.airbyte.api.client.generated.JobsApi;
 import io.airbyte.api.client.invoker.generated.ApiException;
 import io.airbyte.api.client.model.generated.AttemptNormalizationStatusRead;
-import io.airbyte.api.client.model.generated.AttemptNormalizationStatuses;
+import io.airbyte.api.client.model.generated.AttemptNormalizationStatusReadList;
 import io.airbyte.api.client.model.generated.JobIdRequestBody;
 import io.airbyte.workers.temporal.sync.NormalizationSummaryCheckActivityImpl;
 import java.util.List;
@@ -50,7 +50,7 @@ class NormalizationSummaryCheckActivityTest {
         new AttemptNormalizationStatusRead().attemptNumber(2).hasRecordsCommitted(true).recordsCommitted(0L).hasNormalizationFailed(true);
 
     when(jobsApi.getAttemptNormalizationStatusesForJob(new JobIdRequestBody().id(JOB_ID)))
-        .thenReturn(new AttemptNormalizationStatuses().attemptNormalizationStatus(List.of(attempt1, attempt2)));
+        .thenReturn(new AttemptNormalizationStatusReadList().AttemptNormalizationStatuses(List.of(attempt1, attempt2)));
 
     Assertions.assertThat(true).isEqualTo(normalizationSummaryCheckActivity.shouldRunNormalization(JOB_ID, 3L, Optional.of(0L)));
   }
@@ -70,7 +70,7 @@ class NormalizationSummaryCheckActivityTest {
         new AttemptNormalizationStatusRead().attemptNumber(2).hasRecordsCommitted(true).recordsCommitted(0L).hasNormalizationFailed(true);
 
     when(jobsApi.getAttemptNormalizationStatusesForJob(new JobIdRequestBody().id(JOB_ID)))
-        .thenReturn(new AttemptNormalizationStatuses().attemptNormalizationStatus(List.of(attempt1, attempt2)));
+        .thenReturn(new AttemptNormalizationStatusReadList().AttemptNormalizationStatuses(List.of(attempt1, attempt2)));
     Assertions.assertThat(false).isEqualTo(normalizationSummaryCheckActivity.shouldRunNormalization(JOB_ID, 3L, Optional.of(0L)));
   }
 
@@ -84,7 +84,7 @@ class NormalizationSummaryCheckActivityTest {
         new AttemptNormalizationStatusRead().attemptNumber(2).hasRecordsCommitted(true).recordsCommitted(20L).hasNormalizationFailed(false);
 
     when(jobsApi.getAttemptNormalizationStatusesForJob(new JobIdRequestBody().id(JOB_ID)))
-        .thenReturn(new AttemptNormalizationStatuses().attemptNormalizationStatus(List.of(attempt1, attempt2)));
+        .thenReturn(new AttemptNormalizationStatusReadList().AttemptNormalizationStatuses(List.of(attempt1, attempt2)));
     Assertions.assertThat(false).isEqualTo(normalizationSummaryCheckActivity.shouldRunNormalization(JOB_ID, 3L, Optional.of(0L)));
   }
 

--- a/airbyte-workers/src/test/java/io/airbyte/workers/temporal/scheduling/activities/NormalizationSummaryCheckActivityTest.java
+++ b/airbyte-workers/src/test/java/io/airbyte/workers/temporal/scheduling/activities/NormalizationSummaryCheckActivityTest.java
@@ -50,7 +50,7 @@ class NormalizationSummaryCheckActivityTest {
         new AttemptNormalizationStatusRead().attemptNumber(2).hasRecordsCommitted(true).recordsCommitted(0L).hasNormalizationFailed(true);
 
     when(jobsApi.getAttemptNormalizationStatusesForJob(new JobIdRequestBody().id(JOB_ID)))
-        .thenReturn(new AttemptNormalizationStatusReadList().AttemptNormalizationStatuses(List.of(attempt1, attempt2)));
+        .thenReturn(new AttemptNormalizationStatusReadList().attemptNormalizationStatuses(List.of(attempt1, attempt2)));
 
     Assertions.assertThat(true).isEqualTo(normalizationSummaryCheckActivity.shouldRunNormalization(JOB_ID, 3L, Optional.of(0L)));
   }
@@ -70,7 +70,7 @@ class NormalizationSummaryCheckActivityTest {
         new AttemptNormalizationStatusRead().attemptNumber(2).hasRecordsCommitted(true).recordsCommitted(0L).hasNormalizationFailed(true);
 
     when(jobsApi.getAttemptNormalizationStatusesForJob(new JobIdRequestBody().id(JOB_ID)))
-        .thenReturn(new AttemptNormalizationStatusReadList().AttemptNormalizationStatuses(List.of(attempt1, attempt2)));
+        .thenReturn(new AttemptNormalizationStatusReadList().attemptNormalizationStatuses(List.of(attempt1, attempt2)));
     Assertions.assertThat(false).isEqualTo(normalizationSummaryCheckActivity.shouldRunNormalization(JOB_ID, 3L, Optional.of(0L)));
   }
 
@@ -84,7 +84,7 @@ class NormalizationSummaryCheckActivityTest {
         new AttemptNormalizationStatusRead().attemptNumber(2).hasRecordsCommitted(true).recordsCommitted(20L).hasNormalizationFailed(false);
 
     when(jobsApi.getAttemptNormalizationStatusesForJob(new JobIdRequestBody().id(JOB_ID)))
-        .thenReturn(new AttemptNormalizationStatusReadList().AttemptNormalizationStatuses(List.of(attempt1, attempt2)));
+        .thenReturn(new AttemptNormalizationStatusReadList().attemptNormalizationStatuses(List.of(attempt1, attempt2)));
     Assertions.assertThat(false).isEqualTo(normalizationSummaryCheckActivity.shouldRunNormalization(JOB_ID, 3L, Optional.of(0L)));
   }
 

--- a/airbyte-workers/src/test/java/io/airbyte/workers/temporal/scheduling/activities/NormalizationSummaryCheckActivityTest.java
+++ b/airbyte-workers/src/test/java/io/airbyte/workers/temporal/scheduling/activities/NormalizationSummaryCheckActivityTest.java
@@ -5,11 +5,15 @@
 package io.airbyte.workers.temporal.scheduling.activities;
 
 import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
 
-import io.airbyte.persistence.job.JobPersistence;
-import io.airbyte.persistence.job.models.AttemptNormalizationStatus;
+import io.airbyte.api.client.AirbyteApiClient;
+import io.airbyte.api.client.generated.JobsApi;
+import io.airbyte.api.client.invoker.generated.ApiException;
+import io.airbyte.api.client.model.generated.AttemptNormalizationStatusRead;
+import io.airbyte.api.client.model.generated.AttemptNormalizationStatuses;
+import io.airbyte.api.client.model.generated.JobIdRequestBody;
 import io.airbyte.workers.temporal.sync.NormalizationSummaryCheckActivityImpl;
-import java.io.IOException;
 import java.util.List;
 import java.util.Optional;
 import lombok.extern.slf4j.Slf4j;
@@ -17,7 +21,6 @@ import org.assertj.core.api.Assertions;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
-import org.mockito.Mockito;
 import org.mockito.junit.jupiter.MockitoExtension;
 
 @Slf4j
@@ -26,47 +29,62 @@ class NormalizationSummaryCheckActivityTest {
 
   private static final Long JOB_ID = 10L;
   static private NormalizationSummaryCheckActivityImpl normalizationSummaryCheckActivity;
-  static private JobPersistence mJobPersistence;
+  static private AirbyteApiClient airbyteApiClient;
+  static private JobsApi jobsApi;
 
   @BeforeAll
   static void setUp() {
-    mJobPersistence = mock(JobPersistence.class);
-    normalizationSummaryCheckActivity = new NormalizationSummaryCheckActivityImpl(Optional.of(mJobPersistence));
+    airbyteApiClient = mock(AirbyteApiClient.class);
+    jobsApi = mock(JobsApi.class);
+    when(airbyteApiClient.getJobsApi()).thenReturn(jobsApi);
+    normalizationSummaryCheckActivity = new NormalizationSummaryCheckActivityImpl(airbyteApiClient);
   }
 
   @Test
-  void testShouldRunNormalizationRecordsCommittedOnFirstAttemptButNotCurrentAttempt() throws IOException {
+  void testShouldRunNormalizationRecordsCommittedOnFirstAttemptButNotCurrentAttempt() throws ApiException {
     // Attempt 1 committed records, but normalization failed
     // Attempt 2 did not commit records, normalization failed (or did not run)
-    final AttemptNormalizationStatus attempt1 = new AttemptNormalizationStatus(1, Optional.of(10L), true);
-    final AttemptNormalizationStatus attempt2 = new AttemptNormalizationStatus(2, Optional.of(0L), true);
-    Mockito.when(mJobPersistence.getAttemptNormalizationStatusesForJob(JOB_ID)).thenReturn(List.of(attempt1, attempt2));
+    final AttemptNormalizationStatusRead attempt1 =
+        new AttemptNormalizationStatusRead().attemptNumber(1).hasRecordsCommitted(true).recordsCommitted(10L).hasNormalizationFailed(true);
+    final AttemptNormalizationStatusRead attempt2 =
+        new AttemptNormalizationStatusRead().attemptNumber(2).hasRecordsCommitted(true).recordsCommitted(0L).hasNormalizationFailed(true);
+
+    when(jobsApi.getAttemptNormalizationStatusesForJob(new JobIdRequestBody().id(JOB_ID)))
+        .thenReturn(new AttemptNormalizationStatuses().attemptNormalizationStatus(List.of(attempt1, attempt2)));
 
     Assertions.assertThat(true).isEqualTo(normalizationSummaryCheckActivity.shouldRunNormalization(JOB_ID, 3L, Optional.of(0L)));
   }
 
   @Test
-  void testShouldRunNormalizationRecordsCommittedOnCurrentAttempt() throws IOException {
+  void testShouldRunNormalizationRecordsCommittedOnCurrentAttempt() throws ApiException {
     Assertions.assertThat(true).isEqualTo(normalizationSummaryCheckActivity.shouldRunNormalization(JOB_ID, 3L, Optional.of(30L)));
   }
 
   @Test
-  void testShouldRunNormalizationNoRecordsCommittedOnCurrentAttemptOrPreviousAttempts() throws IOException {
+  void testShouldRunNormalizationNoRecordsCommittedOnCurrentAttemptOrPreviousAttempts() throws ApiException {
     // No attempts committed any records
     // Normalization did not run on any attempts
-    final AttemptNormalizationStatus attempt1 = new AttemptNormalizationStatus(1, Optional.of(0L), true);
-    final AttemptNormalizationStatus attempt2 = new AttemptNormalizationStatus(2, Optional.of(0L), true);
-    Mockito.when(mJobPersistence.getAttemptNormalizationStatusesForJob(JOB_ID)).thenReturn(List.of(attempt1, attempt2));
+    final AttemptNormalizationStatusRead attempt1 =
+        new AttemptNormalizationStatusRead().attemptNumber(1).hasRecordsCommitted(true).recordsCommitted(0L).hasNormalizationFailed(true);
+    final AttemptNormalizationStatusRead attempt2 =
+        new AttemptNormalizationStatusRead().attemptNumber(2).hasRecordsCommitted(true).recordsCommitted(0L).hasNormalizationFailed(true);
+
+    when(jobsApi.getAttemptNormalizationStatusesForJob(new JobIdRequestBody().id(JOB_ID)))
+        .thenReturn(new AttemptNormalizationStatuses().attemptNormalizationStatus(List.of(attempt1, attempt2)));
     Assertions.assertThat(false).isEqualTo(normalizationSummaryCheckActivity.shouldRunNormalization(JOB_ID, 3L, Optional.of(0L)));
   }
 
   @Test
-  void testShouldRunNormalizationNoRecordsCommittedOnCurrentAttemptPreviousAttemptsSucceeded() throws IOException {
+  void testShouldRunNormalizationNoRecordsCommittedOnCurrentAttemptPreviousAttemptsSucceeded() throws ApiException {
     // Records committed on first two attempts and normalization succeeded
     // No records committed on current attempt and normalization has not yet run
-    final AttemptNormalizationStatus attempt1 = new AttemptNormalizationStatus(1, Optional.of(10L), false);
-    final AttemptNormalizationStatus attempt2 = new AttemptNormalizationStatus(2, Optional.of(20L), false);
-    Mockito.when(mJobPersistence.getAttemptNormalizationStatusesForJob(JOB_ID)).thenReturn(List.of(attempt1, attempt2));
+    final AttemptNormalizationStatusRead attempt1 =
+        new AttemptNormalizationStatusRead().attemptNumber(1).hasRecordsCommitted(true).recordsCommitted(10L).hasNormalizationFailed(false);
+    final AttemptNormalizationStatusRead attempt2 =
+        new AttemptNormalizationStatusRead().attemptNumber(2).hasRecordsCommitted(true).recordsCommitted(20L).hasNormalizationFailed(false);
+
+    when(jobsApi.getAttemptNormalizationStatusesForJob(new JobIdRequestBody().id(JOB_ID)))
+        .thenReturn(new AttemptNormalizationStatuses().attemptNormalizationStatus(List.of(attempt1, attempt2)));
     Assertions.assertThat(false).isEqualTo(normalizationSummaryCheckActivity.shouldRunNormalization(JOB_ID, 3L, Optional.of(0L)));
   }
 

--- a/docs/reference/api/generated-api-html/index.html
+++ b/docs/reference/api/generated-api-html/index.html
@@ -283,11 +283,13 @@ font-style: italic;
   <h4><a href="#Internal">Internal</a></h4>
   <ul>
   <li><a href="#createOrUpdateState"><code><span class="http-method">post</span> /v1/state/create_or_update</code></a></li>
+  <li><a href="#getAttemptNormalizationStatusesForJob"><code><span class="http-method">post</span> /v1/jobs/get_normalization_status</code></a></li>
   <li><a href="#setWorkflowInAttempt"><code><span class="http-method">post</span> /v1/attempt/set_workflow_in_attempt</code></a></li>
   </ul>
   <h4><a href="#Jobs">Jobs</a></h4>
   <ul>
   <li><a href="#cancelJob"><code><span class="http-method">post</span> /v1/jobs/cancel</code></a></li>
+  <li><a href="#getAttemptNormalizationStatusesForJob"><code><span class="http-method">post</span> /v1/jobs/get_normalization_status</code></a></li>
   <li><a href="#getJobDebugInfo"><code><span class="http-method">post</span> /v1/jobs/get_debug_info</code></a></li>
   <li><a href="#getJobInfo"><code><span class="http-method">post</span> /v1/jobs/get</code></a></li>
   <li><a href="#getJobInfoLight"><code><span class="http-method">post</span> /v1/jobs/get_light</code></a></li>
@@ -4115,6 +4117,68 @@ containing the updated stream needs to be sent.</div>
         <a href="#InvalidInputExceptionInfo">InvalidInputExceptionInfo</a>
   </div> <!-- method -->
   <hr/>
+  <div class="method"><a name="getAttemptNormalizationStatusesForJob"/>
+    <div class="method-path">
+    <a class="up" href="#__Methods">Up</a>
+    <pre class="post"><code class="huge"><span class="http-method">post</span> /v1/jobs/get_normalization_status</code></pre></div>
+    <div class="method-summary">Get normalization status to determine if we can bypass normalization phase (<span class="nickname">getAttemptNormalizationStatusesForJob</span>)</div>
+    <div class="method-notes"></div>
+
+
+    <h3 class="field-label">Consumes</h3>
+    This API call consumes the following media types via the <span class="header">Content-Type</span> request header:
+    <ul>
+      <li><code>application/json</code></li>
+    </ul>
+
+    <h3 class="field-label">Request body</h3>
+    <div class="field-items">
+      <div class="param">JobIdRequestBody <a href="#JobIdRequestBody">JobIdRequestBody</a> (optional)</div>
+
+      <div class="param-desc"><span class="param-type">Body Parameter</span> &mdash;  </div>
+
+    </div>  <!-- field-items -->
+
+
+
+
+    <h3 class="field-label">Return type</h3>
+    <div class="return-type">
+      <a href="#AttemptNormalizationStatuses">AttemptNormalizationStatuses</a>
+      
+    </div>
+
+    <!--Todo: process Response Object and its headers, schema, examples -->
+
+    <h3 class="field-label">Example data</h3>
+    <div class="example-data-content-type">Content-Type: application/json</div>
+    <pre class="example"><code>{
+  "attemptNormalizationStatus" : [ {
+    "attemptNumber" : 0,
+    "recordsCommitted" : 6,
+    "hasRecordsCommitted" : true,
+    "hasNormalizationFailed" : true
+  }, {
+    "attemptNumber" : 0,
+    "recordsCommitted" : 6,
+    "hasRecordsCommitted" : true,
+    "hasNormalizationFailed" : true
+  } ]
+}</code></pre>
+
+    <h3 class="field-label">Produces</h3>
+    This API call produces the following media types according to the <span class="header">Accept</span> request header;
+    the media type will be conveyed by the <span class="header">Content-Type</span> response header.
+    <ul>
+      <li><code>application/json</code></li>
+    </ul>
+
+    <h3 class="field-label">Responses</h3>
+    <h4 class="field-label">200</h4>
+    Successful operation
+        <a href="#AttemptNormalizationStatuses">AttemptNormalizationStatuses</a>
+  </div> <!-- method -->
+  <hr/>
   <div class="method"><a name="setWorkflowInAttempt"/>
     <div class="method-path">
     <a class="up" href="#__Methods">Up</a>
@@ -4341,6 +4405,68 @@ containing the updated stream needs to be sent.</div>
     <h4 class="field-label">422</h4>
     Input failed validation
         <a href="#InvalidInputExceptionInfo">InvalidInputExceptionInfo</a>
+  </div> <!-- method -->
+  <hr/>
+  <div class="method"><a name="getAttemptNormalizationStatusesForJob"/>
+    <div class="method-path">
+    <a class="up" href="#__Methods">Up</a>
+    <pre class="post"><code class="huge"><span class="http-method">post</span> /v1/jobs/get_normalization_status</code></pre></div>
+    <div class="method-summary">Get normalization status to determine if we can bypass normalization phase (<span class="nickname">getAttemptNormalizationStatusesForJob</span>)</div>
+    <div class="method-notes"></div>
+
+
+    <h3 class="field-label">Consumes</h3>
+    This API call consumes the following media types via the <span class="header">Content-Type</span> request header:
+    <ul>
+      <li><code>application/json</code></li>
+    </ul>
+
+    <h3 class="field-label">Request body</h3>
+    <div class="field-items">
+      <div class="param">JobIdRequestBody <a href="#JobIdRequestBody">JobIdRequestBody</a> (optional)</div>
+
+      <div class="param-desc"><span class="param-type">Body Parameter</span> &mdash;  </div>
+
+    </div>  <!-- field-items -->
+
+
+
+
+    <h3 class="field-label">Return type</h3>
+    <div class="return-type">
+      <a href="#AttemptNormalizationStatuses">AttemptNormalizationStatuses</a>
+      
+    </div>
+
+    <!--Todo: process Response Object and its headers, schema, examples -->
+
+    <h3 class="field-label">Example data</h3>
+    <div class="example-data-content-type">Content-Type: application/json</div>
+    <pre class="example"><code>{
+  "attemptNormalizationStatus" : [ {
+    "attemptNumber" : 0,
+    "recordsCommitted" : 6,
+    "hasRecordsCommitted" : true,
+    "hasNormalizationFailed" : true
+  }, {
+    "attemptNumber" : 0,
+    "recordsCommitted" : 6,
+    "hasRecordsCommitted" : true,
+    "hasNormalizationFailed" : true
+  } ]
+}</code></pre>
+
+    <h3 class="field-label">Produces</h3>
+    This API call produces the following media types according to the <span class="header">Accept</span> request header;
+    the media type will be conveyed by the <span class="header">Content-Type</span> response header.
+    <ul>
+      <li><code>application/json</code></li>
+    </ul>
+
+    <h3 class="field-label">Responses</h3>
+    <h4 class="field-label">200</h4>
+    Successful operation
+        <a href="#AttemptNormalizationStatuses">AttemptNormalizationStatuses</a>
   </div> <!-- method -->
   <hr/>
   <div class="method"><a name="getJobDebugInfo"/>
@@ -9832,6 +9958,8 @@ containing the updated stream needs to be sent.</div>
     <li><a href="#AttemptFailureSummary"><code>AttemptFailureSummary</code> - </a></li>
     <li><a href="#AttemptFailureType"><code>AttemptFailureType</code> - </a></li>
     <li><a href="#AttemptInfoRead"><code>AttemptInfoRead</code> - </a></li>
+    <li><a href="#AttemptNormalizationStatusRead"><code>AttemptNormalizationStatusRead</code> - </a></li>
+    <li><a href="#AttemptNormalizationStatuses"><code>AttemptNormalizationStatuses</code> - </a></li>
     <li><a href="#AttemptRead"><code>AttemptRead</code> - </a></li>
     <li><a href="#AttemptStats"><code>AttemptStats</code> - </a></li>
     <li><a href="#AttemptStatus"><code>AttemptStatus</code> - </a></li>
@@ -10090,6 +10218,23 @@ containing the updated stream needs to be sent.</div>
     <div class="field-items">
       <div class="param">attempt </div><div class="param-desc"><span class="param-type"><a href="#AttemptRead">AttemptRead</a></span>  </div>
 <div class="param">logs </div><div class="param-desc"><span class="param-type"><a href="#LogRead">LogRead</a></span>  </div>
+    </div>  <!-- field-items -->
+  </div>
+  <div class="model">
+    <h3><a name="AttemptNormalizationStatusRead"><code>AttemptNormalizationStatusRead</code> - </a> <a class="up" href="#__Models">Up</a></h3>
+    <div class='model-description'></div>
+    <div class="field-items">
+      <div class="param">attemptNumber (optional)</div><div class="param-desc"><span class="param-type"><a href="#integer">Integer</a></span>  format: int32</div>
+<div class="param">hasRecordsCommitted (optional)</div><div class="param-desc"><span class="param-type"><a href="#boolean">Boolean</a></span>  </div>
+<div class="param">recordsCommitted (optional)</div><div class="param-desc"><span class="param-type"><a href="#long">Long</a></span>  format: int64</div>
+<div class="param">hasNormalizationFailed (optional)</div><div class="param-desc"><span class="param-type"><a href="#boolean">Boolean</a></span>  </div>
+    </div>  <!-- field-items -->
+  </div>
+  <div class="model">
+    <h3><a name="AttemptNormalizationStatuses"><code>AttemptNormalizationStatuses</code> - </a> <a class="up" href="#__Models">Up</a></h3>
+    <div class='model-description'></div>
+    <div class="field-items">
+      <div class="param">attemptNormalizationStatus (optional)</div><div class="param-desc"><span class="param-type"><a href="#AttemptNormalizationStatusRead">array[AttemptNormalizationStatusRead]</a></span>  </div>
     </div>  <!-- field-items -->
   </div>
   <div class="model">

--- a/docs/reference/api/generated-api-html/index.html
+++ b/docs/reference/api/generated-api-html/index.html
@@ -4144,7 +4144,7 @@ containing the updated stream needs to be sent.</div>
 
     <h3 class="field-label">Return type</h3>
     <div class="return-type">
-      <a href="#AttemptNormalizationStatuses">AttemptNormalizationStatuses</a>
+      <a href="#AttemptNormalizationStatusReadList">AttemptNormalizationStatusReadList</a>
       
     </div>
 
@@ -4153,7 +4153,7 @@ containing the updated stream needs to be sent.</div>
     <h3 class="field-label">Example data</h3>
     <div class="example-data-content-type">Content-Type: application/json</div>
     <pre class="example"><code>{
-  "attemptNormalizationStatus" : [ {
+  "attemptNormalizationStatuses" : [ {
     "attemptNumber" : 0,
     "recordsCommitted" : 6,
     "hasRecordsCommitted" : true,
@@ -4176,7 +4176,7 @@ containing the updated stream needs to be sent.</div>
     <h3 class="field-label">Responses</h3>
     <h4 class="field-label">200</h4>
     Successful operation
-        <a href="#AttemptNormalizationStatuses">AttemptNormalizationStatuses</a>
+        <a href="#AttemptNormalizationStatusReadList">AttemptNormalizationStatusReadList</a>
   </div> <!-- method -->
   <hr/>
   <div class="method"><a name="setWorkflowInAttempt"/>
@@ -4434,7 +4434,7 @@ containing the updated stream needs to be sent.</div>
 
     <h3 class="field-label">Return type</h3>
     <div class="return-type">
-      <a href="#AttemptNormalizationStatuses">AttemptNormalizationStatuses</a>
+      <a href="#AttemptNormalizationStatusReadList">AttemptNormalizationStatusReadList</a>
       
     </div>
 
@@ -4443,7 +4443,7 @@ containing the updated stream needs to be sent.</div>
     <h3 class="field-label">Example data</h3>
     <div class="example-data-content-type">Content-Type: application/json</div>
     <pre class="example"><code>{
-  "attemptNormalizationStatus" : [ {
+  "attemptNormalizationStatuses" : [ {
     "attemptNumber" : 0,
     "recordsCommitted" : 6,
     "hasRecordsCommitted" : true,
@@ -4466,7 +4466,7 @@ containing the updated stream needs to be sent.</div>
     <h3 class="field-label">Responses</h3>
     <h4 class="field-label">200</h4>
     Successful operation
-        <a href="#AttemptNormalizationStatuses">AttemptNormalizationStatuses</a>
+        <a href="#AttemptNormalizationStatusReadList">AttemptNormalizationStatusReadList</a>
   </div> <!-- method -->
   <hr/>
   <div class="method"><a name="getJobDebugInfo"/>
@@ -9959,7 +9959,7 @@ containing the updated stream needs to be sent.</div>
     <li><a href="#AttemptFailureType"><code>AttemptFailureType</code> - </a></li>
     <li><a href="#AttemptInfoRead"><code>AttemptInfoRead</code> - </a></li>
     <li><a href="#AttemptNormalizationStatusRead"><code>AttemptNormalizationStatusRead</code> - </a></li>
-    <li><a href="#AttemptNormalizationStatuses"><code>AttemptNormalizationStatuses</code> - </a></li>
+    <li><a href="#AttemptNormalizationStatusReadList"><code>AttemptNormalizationStatusReadList</code> - </a></li>
     <li><a href="#AttemptRead"><code>AttemptRead</code> - </a></li>
     <li><a href="#AttemptStats"><code>AttemptStats</code> - </a></li>
     <li><a href="#AttemptStatus"><code>AttemptStatus</code> - </a></li>
@@ -10231,10 +10231,10 @@ containing the updated stream needs to be sent.</div>
     </div>  <!-- field-items -->
   </div>
   <div class="model">
-    <h3><a name="AttemptNormalizationStatuses"><code>AttemptNormalizationStatuses</code> - </a> <a class="up" href="#__Models">Up</a></h3>
+    <h3><a name="AttemptNormalizationStatusReadList"><code>AttemptNormalizationStatusReadList</code> - </a> <a class="up" href="#__Models">Up</a></h3>
     <div class='model-description'></div>
     <div class="field-items">
-      <div class="param">attemptNormalizationStatus (optional)</div><div class="param-desc"><span class="param-type"><a href="#AttemptNormalizationStatusRead">array[AttemptNormalizationStatusRead]</a></span>  </div>
+      <div class="param">attemptNormalizationStatuses (optional)</div><div class="param-desc"><span class="param-type"><a href="#AttemptNormalizationStatusRead">array[AttemptNormalizationStatusRead]</a></span>  </div>
     </div>  <!-- field-items -->
   </div>
   <div class="model">


### PR DESCRIPTION
## What
Convert JobPeristence dependency to airbyteApiCilent dependency; because normalization summary check is on sync workflow so they will also be executed by multicloud.

Converted Optional.of(recordsCommited) into two fields (hasRecordsCommited, recordsCommited).

I tried to fit everything back in all existing logic but would like a second.