### PR TITLE
🪟 🐛  Load global CSS in storybook

### DIFF
--- a/airbyte-webapp/.storybook/preview.ts
+++ b/airbyte-webapp/.storybook/preview.ts
@@ -2,6 +2,8 @@ import { addDecorator } from "@storybook/react";
 
 import { withProviders } from "./withProvider";
 
+import "!style-loader!css-loader!sass-loader!../public/index.css";
+
 addDecorator(withProviders);
 
 export const parameters = {};


### PR DESCRIPTION
@edmundito [noticed](https://airbytehq-team.slack.com/archives/C039SG3DQ8K/p1666380579789069) that we are not loading the correct font (Inter) in storybook. This PR adds our global `public/index.css` file to storybook, which in turn loads fonts via `@font-face`.