### PR TITLE
Change port for acceptance test destination db

### DIFF
--- a/airbyte-test-utils/src/main/java/io/airbyte/test/utils/GKEPostgresConfig.java
+++ b/airbyte-test-utils/src/main/java/io/airbyte/test/utils/GKEPostgresConfig.java
@@ -52,7 +52,7 @@ public class GKEPostgresConfig {
 
   public static Database getDestinationDatabase() {
     return new Database(DSLContextFactory.create(USERNAME, PASSWORD, DatabaseDriver.POSTGRESQL.getDriverClassName(),
-        "jdbc:postgresql://localhost:3000/postgresdb", SQLDialect.POSTGRES));
+        "jdbc:postgresql://localhost:4000/postgresdb", SQLDialect.POSTGRES));
   }
 
 }

--- a/tools/bin/gke-kube-acceptance-test/acceptance_test_kube_gke.sh
+++ b/tools/bin/gke-kube-acceptance-test/acceptance_test_kube_gke.sh
@@ -64,7 +64,7 @@ kubectl port-forward svc/airbyte-server-svc 8001:8001 --namespace=$NAMESPACE &
 
 kubectl port-forward svc/postgres-source-svc 2000:5432 --namespace=$NAMESPACE &
 
-kubectl port-forward svc/postgres-destination-svc 3000:5432 --namespace=$NAMESPACE &
+kubectl port-forward svc/postgres-destination-svc 4000:5432 --namespace=$NAMESPACE &
 
 sleep 10s
 

--- a/tools/bin/gke-kube-helm-acceptance-test/acceptance_test_kube_gke.sh
+++ b/tools/bin/gke-kube-helm-acceptance-test/acceptance_test_kube_gke.sh
@@ -66,7 +66,7 @@ kubectl port-forward svc/airbyte-server-svc 8001:8001 --namespace=$NAMESPACE &
 
 kubectl port-forward svc/postgres-source-svc 2000:5432 --namespace=$NAMESPACE &
 
-kubectl port-forward svc/postgres-destination-svc 3000:5432 --namespace=$NAMESPACE &
+kubectl port-forward svc/postgres-destination-svc 4000:5432 --namespace=$NAMESPACE &
 
 sleep 10s
 


### PR DESCRIPTION
## What
Change the postgres destination db's port number. This db is only initialized and used for acceptance tests on a gke environment.

Ultimately the only reason for this change is to make testing easier on cloud. See related comment here: https://github.com/airbytehq/airbyte-cloud/pull/1943#discussion_r1003631056