### PR TITLE
:window: :bug: Fix error highlight of select boxes

### DIFF
--- a/airbyte-webapp/src/components/ui/DropDown/CustomSelect.tsx
+++ b/airbyte-webapp/src/components/ui/DropDown/CustomSelect.tsx
@@ -13,7 +13,7 @@ export const CustomSelect = styled(Select)<
     box-shadow: none;
     border: 1px solid
       ${({ theme, $withBorder, $error }) =>
-        $error ? theme.dangerColor : $withBorder ? theme.greyColor30 : theme.greyColor0};
+        $error ? theme.red100 : $withBorder ? theme.greyColor30 : theme.greyColor0};
     background: ${({ theme }) => theme.greyColor0};
     border-radius: 4px;
     font-size: 14px;
@@ -21,8 +21,12 @@ export const CustomSelect = styled(Select)<
     min-height: 36px;
     flex-wrap: nowrap;
 
+    &:not(:focus-within, :disabled):hover {
+      border-color: ${({ theme, $error }) => ($error ? theme.red : undefined)};
+    }
+
     &:hover {
-      border-color: ${({ theme, $error }) => ($error ? theme.dangerColor : theme.greyColor10)};
+      border-color: ${({ theme }) => theme.greyColor10};
     }
 
     &.react-select__control--menu-is-open,

--- a/airbyte-webapp/src/views/Connector/ServiceForm/components/Property/Control.tsx
+++ b/airbyte-webapp/src/views/Connector/ServiceForm/components/Property/Control.tsx
@@ -78,6 +78,7 @@ export const Control: React.FC<ControlProps> = ({
         onChange={(selectedItem) => selectedItem && helpers.setValue(selectedItem.value)}
         value={value}
         isDisabled={disabled}
+        error={error}
       />
     );
   } else if (property.multiline && !property.isSecret) {


### PR DESCRIPTION
## What
Improves the error state of dropdowns:

* Makes sure in the ServiceForm that a select box that's in error state is actually now highlighted as such (`error` wasn't set previously on the `DropDown` component).
* Makes the `DropDown` have the same error border styles as the input fields (light red when not hovered, darker red when hovered).

![screenshot-20221024-125522](https://user-images.githubusercontent.com/877229/197617200-4e1877a4-287f-42cc-b363-37403a1613ae.png)
