### PR TITLE
Additional worker APM tracing

### DIFF
--- a/airbyte-commons-worker/src/main/java/io/airbyte/workers/internal/AirbyteMessageTracker.java
+++ b/airbyte-commons-worker/src/main/java/io/airbyte/workers/internal/AirbyteMessageTracker.java
@@ -4,12 +4,15 @@
 
 package io.airbyte.workers.internal;
 
+import static io.airbyte.metrics.lib.ApmTraceConstants.WORKER_OPERATION_NAME;
+
 import com.google.common.annotations.VisibleForTesting;
 import com.google.common.base.Charsets;
 import com.google.common.collect.BiMap;
 import com.google.common.collect.HashBiMap;
 import com.google.common.hash.HashFunction;
 import com.google.common.hash.Hashing;
+import datadog.trace.api.Trace;
 import io.airbyte.commons.features.EnvVariableFeatureFlags;
 import io.airbyte.commons.json.Jsons;
 import io.airbyte.config.FailureReason;
@@ -98,6 +101,7 @@ public class AirbyteMessageTracker implements MessageTracker {
     this.stateAggregator = stateAggregator;
   }
 
+  @Trace(operationName = WORKER_OPERATION_NAME)
   @Override
   public void acceptFromSource(final AirbyteMessage message) {
     logMessageAsJSON("source", message);
@@ -110,6 +114,7 @@ public class AirbyteMessageTracker implements MessageTracker {
     }
   }
 
+  @Trace(operationName = WORKER_OPERATION_NAME)
   @Override
   public void acceptFromDestination(final AirbyteMessage message) {
     logMessageAsJSON("destination", message);

--- a/airbyte-commons-worker/src/main/java/io/airbyte/workers/internal/AirbyteProtocolPredicate.java
+++ b/airbyte-commons-worker/src/main/java/io/airbyte/workers/internal/AirbyteProtocolPredicate.java
@@ -4,7 +4,10 @@
 
 package io.airbyte.workers.internal;
 
+import static io.airbyte.metrics.lib.ApmTraceConstants.WORKER_OPERATION_NAME;
+
 import com.fasterxml.jackson.databind.JsonNode;
+import datadog.trace.api.Trace;
 import io.airbyte.protocol.models.AirbyteProtocolSchema;
 import io.airbyte.validation.json.JsonSchemaValidator;
 import java.util.function.Predicate;
@@ -23,6 +26,7 @@ public class AirbyteProtocolPredicate implements Predicate<JsonNode> {
     schema = JsonSchemaValidator.getSchema(AirbyteProtocolSchema.PROTOCOL.getFile(), "AirbyteMessage");
   }
 
+  @Trace(operationName = WORKER_OPERATION_NAME)
   @Override
   public boolean test(final JsonNode s) {
     return jsonSchemaValidator.test(schema, s);

--- a/airbyte-commons-worker/src/main/java/io/airbyte/workers/internal/DefaultAirbyteDestination.java
+++ b/airbyte-commons-worker/src/main/java/io/airbyte/workers/internal/DefaultAirbyteDestination.java
@@ -4,8 +4,11 @@
 
 package io.airbyte.workers.internal;
 
+import static io.airbyte.metrics.lib.ApmTraceConstants.WORKER_OPERATION_NAME;
+
 import com.google.common.base.Charsets;
 import com.google.common.base.Preconditions;
+import datadog.trace.api.Trace;
 import io.airbyte.commons.io.IOs;
 import io.airbyte.commons.io.LineGobbler;
 import io.airbyte.commons.json.Jsons;
@@ -58,6 +61,7 @@ public class DefaultAirbyteDestination implements AirbyteDestination {
     this.streamFactory = streamFactory;
   }
 
+  @Trace(operationName = WORKER_OPERATION_NAME)
   @Override
   public void start(final WorkerDestinationConfig destinationConfig, final Path jobRoot) throws IOException, WorkerException {
     Preconditions.checkState(destinationProcess == null);
@@ -79,6 +83,7 @@ public class DefaultAirbyteDestination implements AirbyteDestination {
         .iterator();
   }
 
+  @Trace(operationName = WORKER_OPERATION_NAME)
   @Override
   public void accept(final AirbyteMessage message) throws IOException {
     Preconditions.checkState(destinationProcess != null && !inputHasEnded.get());
@@ -87,6 +92,7 @@ public class DefaultAirbyteDestination implements AirbyteDestination {
     writer.newLine();
   }
 
+  @Trace(operationName = WORKER_OPERATION_NAME)
   @Override
   public void notifyEndOfInput() throws IOException {
     Preconditions.checkState(destinationProcess != null && !inputHasEnded.get());
@@ -96,6 +102,7 @@ public class DefaultAirbyteDestination implements AirbyteDestination {
     inputHasEnded.set(true);
   }
 
+  @Trace(operationName = WORKER_OPERATION_NAME)
   @Override
   public void close() throws Exception {
     if (destinationProcess == null) {
@@ -116,6 +123,7 @@ public class DefaultAirbyteDestination implements AirbyteDestination {
     }
   }
 
+  @Trace(operationName = WORKER_OPERATION_NAME)
   @Override
   public void cancel() throws Exception {
     LOGGER.info("Attempting to cancel destination process...");
@@ -129,6 +137,7 @@ public class DefaultAirbyteDestination implements AirbyteDestination {
     }
   }
 
+  @Trace(operationName = WORKER_OPERATION_NAME)
   @Override
   public boolean isFinished() {
     Preconditions.checkState(destinationProcess != null);
@@ -139,6 +148,7 @@ public class DefaultAirbyteDestination implements AirbyteDestination {
     return !messageIterator.hasNext() && !destinationProcess.isAlive();
   }
 
+  @Trace(operationName = WORKER_OPERATION_NAME)
   @Override
   public int getExitValue() {
     Preconditions.checkState(destinationProcess != null, "Destination process is null, cannot retrieve exit value.");
@@ -151,6 +161,7 @@ public class DefaultAirbyteDestination implements AirbyteDestination {
     return exitValue;
   }
 
+  @Trace(operationName = WORKER_OPERATION_NAME)
   @Override
   public Optional<AirbyteMessage> attemptRead() {
     Preconditions.checkState(destinationProcess != null);

--- a/airbyte-commons-worker/src/main/java/io/airbyte/workers/internal/DefaultAirbyteSource.java
+++ b/airbyte-commons-worker/src/main/java/io/airbyte/workers/internal/DefaultAirbyteSource.java
@@ -4,8 +4,11 @@
 
 package io.airbyte.workers.internal;
 
+import static io.airbyte.metrics.lib.ApmTraceConstants.WORKER_OPERATION_NAME;
+
 import com.google.common.annotations.VisibleForTesting;
 import com.google.common.base.Preconditions;
+import datadog.trace.api.Trace;
 import io.airbyte.commons.features.EnvVariableFeatureFlags;
 import io.airbyte.commons.io.IOs;
 import io.airbyte.commons.io.LineGobbler;
@@ -63,6 +66,7 @@ public class DefaultAirbyteSource implements AirbyteSource {
     this.heartbeatMonitor = heartbeatMonitor;
   }
 
+  @Trace(operationName = WORKER_OPERATION_NAME)
   @Override
   public void start(final WorkerSourceConfig sourceConfig, final Path jobRoot) throws Exception {
     Preconditions.checkState(sourceProcess == null);
@@ -85,6 +89,7 @@ public class DefaultAirbyteSource implements AirbyteSource {
         .iterator();
   }
 
+  @Trace(operationName = WORKER_OPERATION_NAME)
   @Override
   public boolean isFinished() {
     Preconditions.checkState(sourceProcess != null);
@@ -96,6 +101,7 @@ public class DefaultAirbyteSource implements AirbyteSource {
     return !messageIterator.hasNext() && !sourceProcess.isAlive();
   }
 
+  @Trace(operationName = WORKER_OPERATION_NAME)
   @Override
   public int getExitValue() throws IllegalStateException {
     Preconditions.checkState(sourceProcess != null, "Source process is null, cannot retrieve exit value.");
@@ -108,6 +114,7 @@ public class DefaultAirbyteSource implements AirbyteSource {
     return exitValue;
   }
 
+  @Trace(operationName = WORKER_OPERATION_NAME)
   @Override
   public Optional<AirbyteMessage> attemptRead() {
     Preconditions.checkState(sourceProcess != null);
@@ -115,6 +122,7 @@ public class DefaultAirbyteSource implements AirbyteSource {
     return Optional.ofNullable(messageIterator.hasNext() ? messageIterator.next() : null);
   }
 
+  @Trace(operationName = WORKER_OPERATION_NAME)
   @Override
   public void close() throws Exception {
     if (sourceProcess == null) {
@@ -134,6 +142,7 @@ public class DefaultAirbyteSource implements AirbyteSource {
     }
   }
 
+  @Trace(operationName = WORKER_OPERATION_NAME)
   @Override
   public void cancel() throws Exception {
     LOGGER.info("Attempting to cancel source process...");

--- a/airbyte-commons-worker/src/main/java/io/airbyte/workers/internal/DefaultAirbyteStreamFactory.java
+++ b/airbyte-commons-worker/src/main/java/io/airbyte/workers/internal/DefaultAirbyteStreamFactory.java
@@ -4,7 +4,10 @@
 
 package io.airbyte.workers.internal;
 
+import static io.airbyte.metrics.lib.ApmTraceConstants.WORKER_OPERATION_NAME;
+
 import com.fasterxml.jackson.databind.JsonNode;
+import datadog.trace.api.Trace;
 import io.airbyte.commons.json.Jsons;
 import io.airbyte.commons.logging.MdcScope;
 import io.airbyte.metrics.lib.MetricClientFactory;
@@ -52,6 +55,7 @@ public class DefaultAirbyteStreamFactory implements AirbyteStreamFactory {
     this.containerLogMdcBuilder = containerLogMdcBuilder;
   }
 
+  @Trace(operationName = WORKER_OPERATION_NAME)
   @Override
   public Stream<AirbyteMessage> create(final BufferedReader bufferedReader) {
     final var metricClient = MetricClientFactory.getMetricClient();

--- a/airbyte-commons-worker/src/main/java/io/airbyte/workers/internal/EmptyAirbyteSource.java
+++ b/airbyte-commons-worker/src/main/java/io/airbyte/workers/internal/EmptyAirbyteSource.java
@@ -4,6 +4,9 @@
 
 package io.airbyte.workers.internal;
 
+import static io.airbyte.metrics.lib.ApmTraceConstants.WORKER_OPERATION_NAME;
+
+import datadog.trace.api.Trace;
 import io.airbyte.commons.json.Jsons;
 import io.airbyte.config.ResetSourceConfiguration;
 import io.airbyte.config.StateType;
@@ -50,6 +53,7 @@ public class EmptyAirbyteSource implements AirbyteSource {
     this.useStreamCapableState = useStreamCapableState;
   }
 
+  @Trace(operationName = WORKER_OPERATION_NAME)
   @Override
   public void start(final WorkerSourceConfig workerSourceConfig, final Path jobRoot) throws Exception {
 
@@ -105,16 +109,19 @@ public class EmptyAirbyteSource implements AirbyteSource {
   }
 
   // always finished. it has no data to send.
+  @Trace(operationName = WORKER_OPERATION_NAME)
   @Override
   public boolean isFinished() {
     return hasEmittedState.get();
   }
 
+  @Trace(operationName = WORKER_OPERATION_NAME)
   @Override
   public int getExitValue() {
     return 0;
   }
 
+  @Trace(operationName = WORKER_OPERATION_NAME)
   @Override
   public Optional<AirbyteMessage> attemptRead() {
     if (!isStarted) {
@@ -134,11 +141,13 @@ public class EmptyAirbyteSource implements AirbyteSource {
     }
   }
 
+  @Trace(operationName = WORKER_OPERATION_NAME)
   @Override
   public void close() throws Exception {
     // no op.
   }
 
+  @Trace(operationName = WORKER_OPERATION_NAME)
   @Override
   public void cancel() throws Exception {
     // no op.

--- a/airbyte-commons-worker/src/main/java/io/airbyte/workers/internal/StateDeltaTracker.java
+++ b/airbyte-commons-worker/src/main/java/io/airbyte/workers/internal/StateDeltaTracker.java
@@ -4,7 +4,10 @@
 
 package io.airbyte.workers.internal;
 
+import static io.airbyte.metrics.lib.ApmTraceConstants.WORKER_OPERATION_NAME;
+
 import com.google.common.annotations.VisibleForTesting;
+import datadog.trace.api.Trace;
 import java.nio.ByteBuffer;
 import java.util.ArrayList;
 import java.util.HashMap;
@@ -72,6 +75,7 @@ public class StateDeltaTracker {
    * @throws StateDeltaTrackerException thrown when the memory footprint of stateDeltas exceeds
    *         available capacity.
    */
+  @Trace(operationName = WORKER_OPERATION_NAME)
   public void addState(final int stateHash, final Map<Short, Long> streamIndexToRecordCount) throws StateDeltaTrackerException {
     synchronized (this) {
       final int size = STATE_HASH_BYTES + (streamIndexToRecordCount.size() * BYTES_PER_STREAM);
@@ -104,6 +108,7 @@ public class StateDeltaTracker {
    * @throws StateDeltaTrackerException thrown when committed counts can no longer be reliably
    *         computed.
    */
+  @Trace(operationName = WORKER_OPERATION_NAME)
   public void commitStateHash(final int stateHash) throws StateDeltaTrackerException {
     synchronized (this) {
       if (capacityExceeded) {
@@ -139,6 +144,7 @@ public class StateDeltaTracker {
     }
   }
 
+  @Trace(operationName = WORKER_OPERATION_NAME)
   public Map<Short, Long> getStreamToCommittedRecords() {
     return streamToCommittedRecords;
   }

--- a/airbyte-commons-worker/src/main/java/io/airbyte/workers/internal/state_aggregator/SingleStateAggregator.java
+++ b/airbyte-commons-worker/src/main/java/io/airbyte/workers/internal/state_aggregator/SingleStateAggregator.java
@@ -4,6 +4,9 @@
 
 package io.airbyte.workers.internal.state_aggregator;
 
+import static io.airbyte.metrics.lib.ApmTraceConstants.WORKER_OPERATION_NAME;
+
+import datadog.trace.api.Trace;
 import io.airbyte.commons.json.Jsons;
 import io.airbyte.config.State;
 import io.airbyte.protocol.models.AirbyteStateMessage;
@@ -14,11 +17,13 @@ class SingleStateAggregator implements StateAggregator {
 
   AirbyteStateMessage state;
 
+  @Trace(operationName = WORKER_OPERATION_NAME)
   @Override
   public void ingest(final AirbyteStateMessage stateMessage) {
     state = stateMessage;
   }
 
+  @Trace(operationName = WORKER_OPERATION_NAME)
   @Override
   public State getAggregated() {
     if (state.getType() == null || state.getType() == AirbyteStateType.LEGACY) {

--- a/airbyte-commons-worker/src/main/java/io/airbyte/workers/internal/state_aggregator/StreamStateAggregator.java
+++ b/airbyte-commons-worker/src/main/java/io/airbyte/workers/internal/state_aggregator/StreamStateAggregator.java
@@ -4,6 +4,9 @@
 
 package io.airbyte.workers.internal.state_aggregator;
 
+import static io.airbyte.metrics.lib.ApmTraceConstants.WORKER_OPERATION_NAME;
+
+import datadog.trace.api.Trace;
 import io.airbyte.commons.json.Jsons;
 import io.airbyte.config.State;
 import io.airbyte.protocol.models.AirbyteStateMessage;
@@ -15,6 +18,7 @@ class StreamStateAggregator implements StateAggregator {
 
   Map<StreamDescriptor, AirbyteStateMessage> aggregatedState = new HashMap<>();
 
+  @Trace(operationName = WORKER_OPERATION_NAME)
   @Override
   public void ingest(final AirbyteStateMessage stateMessage) {
     /**
@@ -27,6 +31,7 @@ class StreamStateAggregator implements StateAggregator {
     aggregatedState.put(stateMessage.getStream().getStreamDescriptor(), stateMessage);
   }
 
+  @Trace(operationName = WORKER_OPERATION_NAME)
   @Override
   public State getAggregated() {
 

--- a/airbyte-commons-worker/src/main/java/io/airbyte/workers/process/AirbyteIntegrationLauncher.java
+++ b/airbyte-commons-worker/src/main/java/io/airbyte/workers/process/AirbyteIntegrationLauncher.java
@@ -4,13 +4,20 @@
 
 package io.airbyte.workers.process;
 
+import static io.airbyte.metrics.lib.ApmTraceConstants.Tags.DOCKER_IMAGE_KEY;
+import static io.airbyte.metrics.lib.ApmTraceConstants.Tags.JOB_ID_KEY;
+import static io.airbyte.metrics.lib.ApmTraceConstants.Tags.JOB_ROOT_KEY;
+import static io.airbyte.metrics.lib.ApmTraceConstants.WORKER_OPERATION_NAME;
+
 import com.google.common.base.Preconditions;
 import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.Lists;
+import datadog.trace.api.Trace;
 import io.airbyte.commons.features.EnvVariableFeatureFlags;
 import io.airbyte.commons.features.FeatureFlags;
 import io.airbyte.config.ResourceRequirements;
 import io.airbyte.config.WorkerEnvConstants;
+import io.airbyte.metrics.lib.ApmTraceUtils;
 import io.airbyte.workers.exception.WorkerException;
 import java.nio.file.Path;
 import java.util.Collections;
@@ -63,8 +70,10 @@ public class AirbyteIntegrationLauncher implements IntegrationLauncher {
     this.featureFlags = new EnvVariableFeatureFlags();
   }
 
+  @Trace(operationName = WORKER_OPERATION_NAME)
   @Override
   public Process spec(final Path jobRoot) throws WorkerException {
+    ApmTraceUtils.addTagsToTrace(Map.of(JOB_ID_KEY, jobId, JOB_ROOT_KEY, jobRoot, DOCKER_IMAGE_KEY, imageName));
     return processFactory.create(
         SPEC_JOB,
         jobId,
@@ -81,8 +90,10 @@ public class AirbyteIntegrationLauncher implements IntegrationLauncher {
         "spec");
   }
 
+  @Trace(operationName = WORKER_OPERATION_NAME)
   @Override
   public Process check(final Path jobRoot, final String configFilename, final String configContents) throws WorkerException {
+    ApmTraceUtils.addTagsToTrace(Map.of(JOB_ID_KEY, jobId, JOB_ROOT_KEY, jobRoot, DOCKER_IMAGE_KEY, imageName));
     return processFactory.create(
         CHECK_JOB,
         jobId,
@@ -100,8 +111,10 @@ public class AirbyteIntegrationLauncher implements IntegrationLauncher {
         CONFIG, configFilename);
   }
 
+  @Trace(operationName = WORKER_OPERATION_NAME)
   @Override
   public Process discover(final Path jobRoot, final String configFilename, final String configContents) throws WorkerException {
+    ApmTraceUtils.addTagsToTrace(Map.of(JOB_ID_KEY, jobId, JOB_ROOT_KEY, jobRoot, DOCKER_IMAGE_KEY, imageName));
     return processFactory.create(
         DISCOVER_JOB,
         jobId,
@@ -119,6 +132,7 @@ public class AirbyteIntegrationLauncher implements IntegrationLauncher {
         CONFIG, configFilename);
   }
 
+  @Trace(operationName = WORKER_OPERATION_NAME)
   @Override
   public Process read(final Path jobRoot,
                       final String configFilename,
@@ -128,6 +142,7 @@ public class AirbyteIntegrationLauncher implements IntegrationLauncher {
                       final String stateFilename,
                       final String stateContents)
       throws WorkerException {
+    ApmTraceUtils.addTagsToTrace(Map.of(JOB_ID_KEY, jobId, JOB_ROOT_KEY, jobRoot, DOCKER_IMAGE_KEY, imageName));
     final List<String> arguments = Lists.newArrayList(
         "read",
         CONFIG, configFilename,
@@ -161,6 +176,7 @@ public class AirbyteIntegrationLauncher implements IntegrationLauncher {
         arguments.toArray(new String[arguments.size()]));
   }
 
+  @Trace(operationName = WORKER_OPERATION_NAME)
   @Override
   public Process write(final Path jobRoot,
                        final String configFilename,
@@ -168,6 +184,7 @@ public class AirbyteIntegrationLauncher implements IntegrationLauncher {
                        final String catalogFilename,
                        final String catalogContents)
       throws WorkerException {
+    ApmTraceUtils.addTagsToTrace(Map.of(JOB_ID_KEY, jobId, JOB_ROOT_KEY, jobRoot, DOCKER_IMAGE_KEY, imageName));
     final Map<String, String> files = ImmutableMap.of(
         configFilename, configContents,
         catalogFilename, catalogContents);


### PR DESCRIPTION
## What
* Provide more detailed tracing of source/destination workers

## How
* Add `@Trace` annotations to public methods of classes used during the execution of a source/destination connector
* Ensure all of these new traces use the same operation name for grouping.

## Recommended reading order

No recommended reading order, as the PR consists of adding `@Trace` to all public functions in the various classes used during the execution of a source/destination connector.

## Tests

* All tests pass
* Project builds locally

**N.B.** An airbyte-cloud PR will be created using the merge commit SHA.