### PR TITLE
Refactor SourceHandler:buildSourceRead function

### DIFF
--- a/airbyte-server/src/main/java/io/airbyte/server/handlers/SourceHandler.java
+++ b/airbyte-server/src/main/java/io/airbyte/server/handlers/SourceHandler.java
@@ -100,16 +100,17 @@ public class SourceHandler {
         spec);
 
     // read configuration from db
-    return buildSourceRead(sourceId, spec);
+    return buildSourceRead(configRepository.getSourceConnection(sourceId), spec);
   }
 
   public SourceRead updateSource(final SourceUpdate sourceUpdate)
       throws ConfigNotFoundException, IOException, JsonValidationException {
 
+    final UUID sourceId = sourceUpdate.getSourceId();
     final SourceConnection updatedSource = configurationUpdate
-        .source(sourceUpdate.getSourceId(), sourceUpdate.getName(),
+        .source(sourceId, sourceUpdate.getName(),
             sourceUpdate.getConnectionConfiguration());
-    final ConnectorSpecification spec = getSpecFromSourceId(updatedSource.getSourceId());
+    final ConnectorSpecification spec = getSpecFromSourceId(sourceId);
     validateSource(spec, sourceUpdate.getConnectionConfiguration());
 
     // persist
@@ -123,7 +124,7 @@ public class SourceHandler {
         spec);
 
     // read configuration from db
-    return buildSourceRead(sourceUpdate.getSourceId(), spec);
+    return buildSourceRead(configRepository.getSourceConnection(sourceId), spec);
   }
 
   public SourceRead getSource(final SourceIdRequestBody sourceIdRequestBody)
@@ -244,13 +245,12 @@ public class SourceHandler {
     // read configuration from db
     final StandardSourceDefinition sourceDef = configRepository.getSourceDefinitionFromSource(sourceId);
     final ConnectorSpecification spec = sourceDef.getSpec();
-    return buildSourceRead(sourceId, spec);
+    return buildSourceRead(configRepository.getSourceConnection(sourceId), spec);
   }
 
-  private SourceRead buildSourceRead(final UUID sourceId, final ConnectorSpecification spec)
+  private SourceRead buildSourceRead(final SourceConnection sourceConnection, final ConnectorSpecification spec)
       throws ConfigNotFoundException, IOException, JsonValidationException {
     // read configuration from db
-    final SourceConnection sourceConnection = configRepository.getSourceConnection(sourceId);
     final StandardSourceDefinition standardSourceDefinition = configRepository
         .getStandardSourceDefinition(sourceConnection.getSourceDefinitionId());
     final JsonNode sanitizedConfig = secretsProcessor.prepareSecretsForOutput(sourceConnection.getConfiguration(), spec.getConnectionSpecification());

--- a/airbyte-server/src/main/java/io/airbyte/server/handlers/SourceHandler.java
+++ b/airbyte-server/src/main/java/io/airbyte/server/handlers/SourceHandler.java
@@ -243,9 +243,15 @@ public class SourceHandler {
   private SourceRead buildSourceRead(final UUID sourceId)
       throws ConfigNotFoundException, IOException, JsonValidationException {
     // read configuration from db
-    final StandardSourceDefinition sourceDef = configRepository.getSourceDefinitionFromSource(sourceId);
+    final SourceConnection sourceConnection = configRepository.getSourceConnection(sourceId);
+    return buildSourceRead(sourceConnection);
+  }
+
+  private SourceRead buildSourceRead(final SourceConnection sourceConnection)
+      throws ConfigNotFoundException, IOException, JsonValidationException {
+    final StandardSourceDefinition sourceDef = configRepository.getSourceDefinitionFromSource(sourceConnection.getSourceId());
     final ConnectorSpecification spec = sourceDef.getSpec();
-    return buildSourceRead(configRepository.getSourceConnection(sourceId), spec);
+    return buildSourceRead(sourceConnection, spec);
   }
 
   private SourceRead buildSourceRead(final SourceConnection sourceConnection, final ConnectorSpecification spec)

--- a/airbyte-server/src/main/java/io/airbyte/server/handlers/SourceHandler.java
+++ b/airbyte-server/src/main/java/io/airbyte/server/handlers/SourceHandler.java
@@ -167,7 +167,7 @@ public class SourceHandler {
 
     final List<SourceRead> reads = Lists.newArrayList();
     for (final SourceConnection sc : sourceConnections) {
-      reads.add(buildSourceRead(sc.getSourceId()));
+      reads.add(buildSourceRead(sc));
     }
 
     return new SourceReadList().sources(reads);
@@ -184,7 +184,7 @@ public class SourceHandler {
 
     final List<SourceRead> reads = Lists.newArrayList();
     for (final SourceConnection sourceConnection : sourceConnections) {
-      reads.add(buildSourceRead(sourceConnection.getSourceId()));
+      reads.add(buildSourceRead(sourceConnection));
     }
 
     return new SourceReadList().sources(reads);
@@ -196,7 +196,7 @@ public class SourceHandler {
 
     for (final SourceConnection sci : configRepository.listSourceConnection()) {
       if (!sci.getTombstone()) {
-        final SourceRead sourceRead = buildSourceRead(sci.getSourceId());
+        final SourceRead sourceRead = buildSourceRead(sci);
         if (connectionsHandler.matchSearch(sourceSearch, sourceRead)) {
           reads.add(sourceRead);
         }


### PR DESCRIPTION
## What
Improve the performance of multiple sources API calls.

## How
The `buildSourceRead` function is the main way to build an API response message for any calls that return detailed information about a source.
That function only takes as input a `sourceId` and perform a db query to retrieve the information it needs to create the object; this is fine for APIs that returns a single source (getSource, updateSource,...) but most listing operations have to retrieve a collection of source objects and then convert those in an API message.
Before this commit, most of those do so by iterating over the collection and calling buildSourceRead(sourceId), this leads to unnecessary db queries.

This change adds a new overload to buildSourceRead that can be called with a `source` object and uses that method in existing call sites that already have a source object.

