### PR TITLE
:window: :art: Make YouTube login button Google styled

### DIFF
--- a/airbyte-webapp/src/views/Connector/ServiceForm/components/Sections/auth/AuthButton.tsx
+++ b/airbyte-webapp/src/views/Connector/ServiceForm/components/Sections/auth/AuthButton.tsx
@@ -22,6 +22,7 @@ function isGoogleConnector(connectorDefinitionId: string): boolean {
     "71607ba1-c0ac-4799-8049-7f4b90dd50f7", // google sheets source
     "a4cbd2d1-8dbe-4818-b8bc-b90ad782d12a", // google sheets destination
     "ed9dfefa-1bbc-419d-8c5e-4d78f0ef6734", // google workspace admin reports
+    "afa734e4-3571-11ec-991a-1e0031268139", // YouTube analytics
   ].includes(connectorDefinitionId);
 }
 


### PR DESCRIPTION
## What

Makes sure the YouTube Analytics source will render it's Auth button in the Google login style same as the other Google Auth sources. This was flagged by the Google team when auditing.