### PR TITLE
:window: :tada: Use Google business mails by default for login

### DIFF
--- a/airbyte-webapp/src/packages/cloud/lib/auth/GoogleAuthService.ts
+++ b/airbyte-webapp/src/packages/cloud/lib/auth/GoogleAuthService.ts
@@ -38,7 +38,11 @@ export class GoogleAuthService {
   }
 
   async loginWithOAuth(provider: OAuthProviders) {
-    await signInWithPopup(this.auth, provider === "github" ? new GithubAuthProvider() : new GoogleAuthProvider());
+    // Instantiate the appropriate auth provider. For Google we're specifying the `hd` parameter, to only show
+    // Google accounts in the selector that are linked to a business (GSuite) account.
+    const authProvider =
+      provider === "github" ? new GithubAuthProvider() : new GoogleAuthProvider().setCustomParameters({ hd: "*" });
+    await signInWithPopup(this.auth, authProvider);
   }
 
   async login(email: string, password: string): Promise<UserCredential> {


### PR DESCRIPTION
## What

Focus login/signup users to their business email instead of a private one.

## How

This PR adds the `hd` parameters (https://developers.google.com/identity/openid-connect/openid-connect#authenticationuriparameters) which hints the google sign in modal to only show accounts that are linked to business accounts.

Users could still use a private google account to login, but will require to type their login again in the dialog, since it won't be shown by default. This will also be the way users who already signed up with their private email via Google OAuth will be able to relogin into their account.