### PR TITLE
Fix broken table in Fauna docs

### DIFF
--- a/docs/integrations/sources/fauna.md
+++ b/docs/integrations/sources/fauna.md
@@ -194,6 +194,7 @@ inferred that the document ID refers to a document within the synced collection.
 
 Every ref is serialized as a JSON object with 2 or 3 fields, as listed above. The `type` field must be
 one of these strings:
+
 |                                    Reference Type                                       |    `type` string    |
 | --------------------------------------------------------------------------------------- | ------------------- |
 | Document                                                                                | `"document"`        |


### PR DESCRIPTION
## What
Fixes broken table in the Fauna Source docs. The current docs show a broken table here: https://docs.airbyte.com/integrations/sources/fauna/#ref-types

## How
Add a newline before said table.

I don't know if this will actually fix it, but I can't find any other differences between the broken and working table in the Fauna Docs. Could a reviewer verify that this will fix the table?

## 🚨 User Impact 🚨
None
