### PR TITLE
Make script both Unix/Linux and OSX compatible

### DIFF
--- a/tools/bin/acceptance_test_kube.sh
+++ b/tools/bin/acceptance_test_kube.sh
@@ -32,7 +32,7 @@ echo "Listing nodes scheduled for pods..."
 kubectl describe pods | grep "Name\|Node"
 
 # allocates a lot of time to start kube. takes a while for postgres+temporal to work things out
-sleep 120s
+sleep 120
 
 if [ -n "$CI" ]; then
   server_logs () { kubectl logs deployment.apps/airbyte-server > /tmp/kubernetes_logs/server.txt; }


### PR DESCRIPTION
## What
* Ensure that tests can be executed in all environments

## How
* Remove incompatible OSX syntax from script

## Recommended reading order
1. `acceptance_test_kube.sh`

## Tests

* Script runs without issue when invoked in OSX