### PR TITLE
update file-secure to 0.2.27

### DIFF
--- a/airbyte-integrations/connectors/source-file-secure/Dockerfile
+++ b/airbyte-integrations/connectors/source-file-secure/Dockerfile
@@ -1,4 +1,4 @@
-FROM airbyte/source-file:0.2.27
+FROM airbyte/source-file:0.2.26
 
 WORKDIR /airbyte/integration_code
 COPY source_file_secure ./source_file_secure

--- a/airbyte-integrations/connectors/source-file-secure/Dockerfile
+++ b/airbyte-integrations/connectors/source-file-secure/Dockerfile
@@ -1,4 +1,4 @@
-FROM airbyte/source-file:0.2.26
+FROM airbyte/source-file:0.2.27
 
 WORKDIR /airbyte/integration_code
 COPY source_file_secure ./source_file_secure
@@ -9,5 +9,5 @@ RUN pip install .
 ENV AIRBYTE_ENTRYPOINT "python /airbyte/integration_code/main.py"
 ENTRYPOINT ["python", "/airbyte/integration_code/main.py"]
 
-LABEL io.airbyte.version=0.2.26
+LABEL io.airbyte.version=0.2.27
 LABEL io.airbyte.name=airbyte/source-file-secure

--- a/airbyte-integrations/connectors/source-file-secure/acceptance-test-config.yml
+++ b/airbyte-integrations/connectors/source-file-secure/acceptance-test-config.yml
@@ -13,9 +13,6 @@ tests:
     # for https
     - config_path: "integration_tests/config.json"
       status: "succeed"
-    # for local should be failed
-    - config_path: "integration_tests/local_config.json"
-      status: "exception"
 
   discovery:
     # for https

--- a/airbyte-integrations/connectors/source-file-secure/acceptance-test-config.yml
+++ b/airbyte-integrations/connectors/source-file-secure/acceptance-test-config.yml
@@ -13,6 +13,9 @@ tests:
     # for https
     - config_path: "integration_tests/config.json"
       status: "succeed"
+    # for local should be failed
+    - config_path: "integration_tests/local_config.json"
+      status: "exception"
 
   discovery:
     # for https


### PR DESCRIPTION
`source-file` was bumped to 0.2.27 in https://github.com/airbytehq/airbyte/pull/18481 but we forgot to also bump `source-file-secure` which will break cloud publish since the connector image will be missing. This fixed that