### PR TITLE
add authentication info to local development guide

### DIFF
--- a/docs/contributing-to-airbyte/developing-locally.md
+++ b/docs/contributing-to-airbyte/developing-locally.md
@@ -103,6 +103,7 @@ The above connector image is tagged with `dev`. You can change this to use anoth
 :::
 
 - In your browser, visit [http://localhost:8000/](http://localhost:8000/)
+- Log in with the default user `airbyte` with password `password`
 - Go to `Settings` (gear icon in lower left corner) 
 - Go to `Sources` or `Destinations` (depending on which connector you are testing)
 - Update the version number to use your docker image tag (default is `dev`)

--- a/docs/contributing-to-airbyte/developing-locally.md
+++ b/docs/contributing-to-airbyte/developing-locally.md
@@ -103,7 +103,7 @@ The above connector image is tagged with `dev`. You can change this to use anoth
 :::
 
 - In your browser, visit [http://localhost:8000/](http://localhost:8000/)
-- Log in with the default user `airbyte` with password `password`
+- Log in with the default user `airbyte` and default password `password`
 - Go to `Settings` (gear icon in lower left corner) 
 - Go to `Sources` or `Destinations` (depending on which connector you are testing)
 - Update the version number to use your docker image tag (default is `dev`)


### PR DESCRIPTION
## What
When following the docs for [local development](https://docs.airbyte.com/contributing-to-airbyte/developing-locally/#add-a-connector-under-development-to-airbyte), I got stuck due to recently added authentication (not sure if the auth is new or just needing auth by default)

## How
Let users know what the default user and password are :)