### PR TITLE
query to include data plane attributes

### DIFF
--- a/airbyte-metrics/metrics-lib/src/main/java/io/airbyte/metrics/lib/MetricTags.java
+++ b/airbyte-metrics/metrics-lib/src/main/java/io/airbyte/metrics/lib/MetricTags.java
@@ -20,6 +20,8 @@ public class MetricTags {
   public static final String RELEASE_STAGE = "release_stage";
   public static final String RESET_WORKFLOW_FAILURE_CAUSE = "failure_cause";
   public static final String WORKFLOW_TYPE = "workflow_type";
+  public static final String ATTEMPT_QUEUE = "attempt_queue";
+  public static final String GEOGRAPHY = "geography";
 
   public static String getReleaseStage(final ReleaseStage stage) {
     return stage.getLiteral();

--- a/airbyte-metrics/reporter/src/main/java/io/airbyte/metrics/reporter/Emitter.java
+++ b/airbyte-metrics/reporter/src/main/java/io/airbyte/metrics/reporter/Emitter.java
@@ -36,7 +36,7 @@ final class NumRunningJobs extends Emitter {
 
   public NumRunningJobs(final MetricClient client, final MetricRepository db) {
     super(client, () -> {
-      db.numberOfRunningJobs().forEach((attemptQueue, count) -> client.gauge(
+      db.numberOfRunningJobsByTaskQueue().forEach((attemptQueue, count) -> client.gauge(
           OssMetricsRegistry.NUM_RUNNING_JOBS,
           count,
           new MetricAttribute(MetricTags.ATTEMPT_QUEUE, attemptQueue)));

--- a/airbyte-metrics/reporter/src/main/java/io/airbyte/metrics/reporter/Emitter.java
+++ b/airbyte-metrics/reporter/src/main/java/io/airbyte/metrics/reporter/Emitter.java
@@ -20,7 +20,7 @@ final class NumPendingJobs extends Emitter {
 
   public NumPendingJobs(final MetricClient client, final MetricRepository db) {
     super(client, () -> {
-      db.numberOfPendingJobs().forEach((geography, count) -> client.gauge(
+      db.numberOfPendingJobsByGeography().forEach((geography, count) -> client.gauge(
           OssMetricsRegistry.NUM_PENDING_JOBS,
           count,
           new MetricAttribute(MetricTags.GEOGRAPHY, geography)));
@@ -64,7 +64,7 @@ final class OldestRunningJob extends Emitter {
 
   OldestRunningJob(final MetricClient client, final MetricRepository db) {
     super(client, () -> {
-      db.oldestRunningJobAgeSecs().forEach((attemptQueue, count) -> client.gauge(
+      db.oldestRunningJobAgeSecsByTaskQueue().forEach((attemptQueue, count) -> client.gauge(
           OssMetricsRegistry.OLDEST_RUNNING_JOB_AGE_SECS,
           count,
           new MetricAttribute(MetricTags.ATTEMPT_QUEUE, attemptQueue)));
@@ -79,7 +79,7 @@ final class OldestPendingJob extends Emitter {
 
   OldestPendingJob(final MetricClient client, final MetricRepository db) {
     super(client, () -> {
-      db.oldestPendingJobAgeSecs().forEach((geographyType, count) -> client.gauge(
+      db.oldestPendingJobAgeSecsByGeography().forEach((geographyType, count) -> client.gauge(
           OssMetricsRegistry.OLDEST_PENDING_JOB_AGE_SECS,
           count,
           new MetricAttribute(MetricTags.GEOGRAPHY, geographyType.getLiteral())));

--- a/airbyte-metrics/reporter/src/main/java/io/airbyte/metrics/reporter/Emitter.java
+++ b/airbyte-metrics/reporter/src/main/java/io/airbyte/metrics/reporter/Emitter.java
@@ -20,8 +20,11 @@ final class NumPendingJobs extends Emitter {
 
   public NumPendingJobs(final MetricClient client, final MetricRepository db) {
     super(client, () -> {
-      final var pending = db.numberOfPendingJobs();
-      client.gauge(OssMetricsRegistry.NUM_PENDING_JOBS, pending);
+      db.numberOfPendingJobs().forEach((geography, count) -> client.gauge(
+          OssMetricsRegistry.NUM_PENDING_JOBS,
+          count,
+          new MetricAttribute(MetricTags.GEOGRAPHY, geography)));
+
       return null;
     });
   }
@@ -33,8 +36,10 @@ final class NumRunningJobs extends Emitter {
 
   public NumRunningJobs(final MetricClient client, final MetricRepository db) {
     super(client, () -> {
-      final var running = db.numberOfRunningJobs();
-      client.gauge(OssMetricsRegistry.NUM_RUNNING_JOBS, running);
+      db.numberOfRunningJobs().forEach((attemptQueue, count) -> client.gauge(
+          OssMetricsRegistry.NUM_RUNNING_JOBS,
+          count,
+          new MetricAttribute(MetricTags.ATTEMPT_QUEUE, attemptQueue)));
       return null;
     });
   }
@@ -59,8 +64,10 @@ final class OldestRunningJob extends Emitter {
 
   OldestRunningJob(final MetricClient client, final MetricRepository db) {
     super(client, () -> {
-      final var age = db.oldestRunningJobAgeSecs();
-      client.gauge(OssMetricsRegistry.OLDEST_RUNNING_JOB_AGE_SECS, age);
+      db.oldestRunningJobAgeSecs().forEach((attemptQueue, count) -> client.gauge(
+          OssMetricsRegistry.OLDEST_RUNNING_JOB_AGE_SECS,
+          count,
+          new MetricAttribute(MetricTags.ATTEMPT_QUEUE, attemptQueue)));
       return null;
     });
   }
@@ -72,8 +79,10 @@ final class OldestPendingJob extends Emitter {
 
   OldestPendingJob(final MetricClient client, final MetricRepository db) {
     super(client, () -> {
-      final var age = db.oldestPendingJobAgeSecs();
-      client.gauge(OssMetricsRegistry.OLDEST_PENDING_JOB_AGE_SECS, age);
+      db.oldestPendingJobAgeSecs().forEach((geographyType, count) -> client.gauge(
+          OssMetricsRegistry.OLDEST_PENDING_JOB_AGE_SECS,
+          count,
+          new MetricAttribute(MetricTags.GEOGRAPHY, geographyType.getLiteral())));
       return null;
     });
   }

--- a/airbyte-metrics/reporter/src/main/java/io/airbyte/metrics/reporter/MetricRepository.java
+++ b/airbyte-metrics/reporter/src/main/java/io/airbyte/metrics/reporter/MetricRepository.java
@@ -30,7 +30,7 @@ class MetricRepository {
     this.ctx = ctx;
   }
 
-  Map<String, Integer> numberOfPendingJobs() {
+  Map<String, Integer> numberOfPendingJobsByGeography() {
     var result = ctx.select(CONNECTION.GEOGRAPHY.cast(String.class), count(asterisk()).as("count"))
         .from(JOBS)
         .join(CONNECTION)
@@ -40,7 +40,7 @@ class MetricRepository {
     return (Map<String, Integer>) result.fetchMap(0, 1);
   }
 
-  Map<String, Integer> numberOfRunningJobs() {
+  Map<String, Integer> numberOfRunningJobsByTaskQueue() {
     var result = ctx.select(ATTEMPTS.PROCESSING_TASK_QUEUE, count(asterisk()).as("count"))
         .from(JOBS)
         .join(CONNECTION)
@@ -65,7 +65,7 @@ class MetricRepository {
         .fetchOne(0, int.class);
   }
 
-  Map<GeographyType, Double> oldestPendingJobAgeSecs() {
+  Map<GeographyType, Double> oldestPendingJobAgeSecsByGeography() {
     final var query =
         """
         SELECT cast(connection.geography as varchar) AS geography, MAX(EXTRACT(EPOCH FROM (current_timestamp - jobs.created_at))) AS run_duration_seconds
@@ -79,7 +79,7 @@ class MetricRepository {
     return (Map<GeographyType, Double>) result.intoMap(0, 1);
   }
 
-  Map<String, Double> oldestRunningJobAgeSecs() {
+  Map<String, Double> oldestRunningJobAgeSecsByTaskQueue() {
     final var query =
         """
         SELECT attempts.processing_task_queue AS task_queue, MAX(EXTRACT(EPOCH FROM (current_timestamp - jobs.created_at))) AS run_duration_seconds

--- a/airbyte-metrics/reporter/src/main/java/io/airbyte/metrics/reporter/MetricRepository.java
+++ b/airbyte-metrics/reporter/src/main/java/io/airbyte/metrics/reporter/MetricRepository.java
@@ -5,10 +5,15 @@
 package io.airbyte.metrics.reporter;
 
 import static io.airbyte.db.instance.configs.jooq.generated.Tables.CONNECTION;
+import static io.airbyte.db.instance.jobs.jooq.generated.Tables.ATTEMPTS;
 import static io.airbyte.db.instance.jobs.jooq.generated.Tables.JOBS;
+import static org.jooq.impl.DSL.asterisk;
+import static org.jooq.impl.DSL.count;
 import static org.jooq.impl.SQLDataType.VARCHAR;
 
+import io.airbyte.db.instance.configs.jooq.generated.enums.GeographyType;
 import io.airbyte.db.instance.configs.jooq.generated.enums.StatusType;
+import io.airbyte.db.instance.jobs.jooq.generated.enums.AttemptStatus;
 import io.airbyte.db.instance.jobs.jooq.generated.enums.JobStatus;
 import jakarta.inject.Singleton;
 import java.util.HashMap;
@@ -25,22 +30,32 @@ class MetricRepository {
     this.ctx = ctx;
   }
 
-  int numberOfPendingJobs() {
-    return ctx.selectCount()
-        .from(JOBS)
-        .where(JOBS.STATUS.eq(JobStatus.pending))
-        .fetchOne(0, int.class);
-  }
-
-  int numberOfRunningJobs() {
-    return ctx.selectCount()
+  Map<String, Integer> numberOfPendingJobs() {
+    var result = ctx.select(CONNECTION.GEOGRAPHY.cast(String.class), count(asterisk()).as("count"))
         .from(JOBS)
         .join(CONNECTION)
         .on(CONNECTION.ID.cast(VARCHAR(255)).eq(JOBS.SCOPE))
-        .where(JOBS.STATUS.eq(JobStatus.running).and(CONNECTION.STATUS.eq(StatusType.active)))
-        .fetchOne(0, int.class);
+        .where(JOBS.STATUS.eq(JobStatus.pending))
+        .groupBy(CONNECTION.GEOGRAPHY);
+    return (Map<String, Integer>) result.fetchMap(0, 1);
   }
 
+  Map<String, Integer> numberOfRunningJobs() {
+    var result = ctx.select(ATTEMPTS.PROCESSING_TASK_QUEUE, count(asterisk()).as("count"))
+        .from(JOBS)
+        .join(CONNECTION)
+        .on(CONNECTION.ID.cast(VARCHAR(255)).eq(JOBS.SCOPE))
+        .join(ATTEMPTS)
+        .on(ATTEMPTS.JOB_ID.eq(JOBS.ID))
+        .where(JOBS.STATUS.eq(JobStatus.running).and(CONNECTION.STATUS.eq(StatusType.active)))
+        .and(ATTEMPTS.STATUS.eq(AttemptStatus.running))
+        .groupBy(ATTEMPTS.PROCESSING_TASK_QUEUE);
+    return (Map<String, Integer>) result.fetchMap(0, 1);
+
+  }
+
+  // This is a rare case and not likely to be related to data planes; So we will monitor them as a
+  // whole.
   int numberOfOrphanRunningJobs() {
     return ctx.selectCount()
         .from(JOBS)
@@ -50,12 +65,32 @@ class MetricRepository {
         .fetchOne(0, int.class);
   }
 
-  long oldestPendingJobAgeSecs() {
-    return oldestJobAgeSecs(JobStatus.pending);
+  Map<GeographyType, Double> oldestPendingJobAgeSecs() {
+    final var query =
+        """
+        SELECT cast(connection.geography as varchar) AS geography, MAX(EXTRACT(EPOCH FROM (current_timestamp - jobs.created_at))) AS run_duration_seconds
+        FROM jobs
+        JOIN connection
+        ON jobs.scope::uuid = connection.id
+        WHERE jobs.status = 'pending'
+        GROUP BY geography;
+        """;
+    final var result = ctx.fetch(query);
+    return (Map<GeographyType, Double>) result.intoMap(0, 1);
   }
 
-  long oldestRunningJobAgeSecs() {
-    return oldestJobAgeSecs(JobStatus.running);
+  Map<String, Double> oldestRunningJobAgeSecs() {
+    final var query =
+        """
+        SELECT attempts.processing_task_queue AS task_queue, MAX(EXTRACT(EPOCH FROM (current_timestamp - jobs.created_at))) AS run_duration_seconds
+        FROM jobs
+        JOIN attempts
+        ON jobs.id = attempts.job_id
+        WHERE jobs.status = 'running' AND attempts.status = 'running'
+        GROUP BY task_queue;
+        """;
+    final var result = ctx.fetch(query);
+    return (Map<String, Double>) result.intoMap(0, 1);
   }
 
   List<Long> numberOfActiveConnPerWorkspace() {
@@ -216,20 +251,6 @@ class MetricRepository {
     }
 
     return results;
-  }
-
-  private long oldestJobAgeSecs(final JobStatus status) {
-    final var query = """
-                      SELECT id, EXTRACT(EPOCH FROM (current_timestamp - created_at)) AS run_duration_seconds
-                      FROM jobs WHERE status = ?::job_status
-                      ORDER BY created_at ASC limit 1;
-                      """;
-    final var result = ctx.fetchOne(query, status.getLiteral());
-    if (result == null) {
-      return 0L;
-    }
-    // as double can have rounding errors, round down to remove noise.
-    return result.getValue("run_duration_seconds", Double.class).longValue();
   }
 
 }

--- a/airbyte-metrics/reporter/src/test/java/io/airbyte/metrics/reporter/EmitterTest.java
+++ b/airbyte-metrics/reporter/src/test/java/io/airbyte/metrics/reporter/EmitterTest.java
@@ -41,13 +41,13 @@ class EmitterTest {
   @Test
   void TestNumPendingJobs() {
     final var value = Map.of("AUTO", 101, "EU", 20);
-    when(repo.numberOfPendingJobs()).thenReturn(value);
+    when(repo.numberOfPendingJobsByGeography()).thenReturn(value);
 
     final var emitter = new NumPendingJobs(client, repo);
     emitter.Emit();
 
     assertEquals(Duration.ofSeconds(15), emitter.getDuration());
-    verify(repo).numberOfPendingJobs();
+    verify(repo).numberOfPendingJobsByGeography();
     verify(client).gauge(OssMetricsRegistry.NUM_PENDING_JOBS, 101,
         new MetricAttribute(MetricTags.GEOGRAPHY, "AUTO"));
     verify(client).gauge(OssMetricsRegistry.NUM_PENDING_JOBS, 20,
@@ -89,13 +89,13 @@ class EmitterTest {
   @Test
   void TestOldestRunningJob() {
     final var value = Map.of(SYNC_QUEUE, 101.0, AWS_QUEUE, 20.0);
-    when(repo.oldestRunningJobAgeSecs()).thenReturn(value);
+    when(repo.oldestRunningJobAgeSecsByTaskQueue()).thenReturn(value);
 
     final var emitter = new OldestRunningJob(client, repo);
     emitter.Emit();
 
     assertEquals(Duration.ofSeconds(15), emitter.getDuration());
-    verify(repo).oldestRunningJobAgeSecs();
+    verify(repo).oldestRunningJobAgeSecsByTaskQueue();
     verify(client).gauge(OssMetricsRegistry.OLDEST_RUNNING_JOB_AGE_SECS, 101,
         new MetricAttribute(MetricTags.ATTEMPT_QUEUE, SYNC_QUEUE));
     verify(client).gauge(OssMetricsRegistry.OLDEST_RUNNING_JOB_AGE_SECS, 20,
@@ -106,13 +106,13 @@ class EmitterTest {
   @Test
   void TestOldestPendingJob() {
     final var value = Map.of(GeographyType.AUTO, 101.0, GeographyType.EU, 20.0);
-    when(repo.oldestPendingJobAgeSecs()).thenReturn(value);
+    when(repo.oldestPendingJobAgeSecsByGeography()).thenReturn(value);
 
     final var emitter = new OldestPendingJob(client, repo);
     emitter.Emit();
 
     assertEquals(Duration.ofSeconds(15), emitter.getDuration());
-    verify(repo).oldestPendingJobAgeSecs();
+    verify(repo).oldestPendingJobAgeSecsByGeography();
     verify(client).gauge(OssMetricsRegistry.OLDEST_PENDING_JOB_AGE_SECS, 101,
         new MetricAttribute(MetricTags.GEOGRAPHY, AUTO_REGION));
     verify(client).gauge(OssMetricsRegistry.OLDEST_PENDING_JOB_AGE_SECS, 20,

--- a/airbyte-metrics/reporter/src/test/java/io/airbyte/metrics/reporter/EmitterTest.java
+++ b/airbyte-metrics/reporter/src/test/java/io/airbyte/metrics/reporter/EmitterTest.java
@@ -58,13 +58,13 @@ class EmitterTest {
   @Test
   void TestNumRunningJobs() {
     final var value = Map.of(SYNC_QUEUE, 101, AWS_QUEUE, 20);
-    when(repo.numberOfRunningJobs()).thenReturn(value);
+    when(repo.numberOfRunningJobsByTaskQueue()).thenReturn(value);
 
     final var emitter = new NumRunningJobs(client, repo);
     emitter.Emit();
 
     assertEquals(Duration.ofSeconds(15), emitter.getDuration());
-    verify(repo).numberOfRunningJobs();
+    verify(repo).numberOfRunningJobsByTaskQueue();
     verify(client).gauge(OssMetricsRegistry.NUM_RUNNING_JOBS, 101,
         new MetricAttribute(MetricTags.ATTEMPT_QUEUE, SYNC_QUEUE));
     verify(client).gauge(OssMetricsRegistry.NUM_RUNNING_JOBS, 20,

--- a/airbyte-metrics/reporter/src/test/java/io/airbyte/metrics/reporter/MetricRepositoryTest.java
+++ b/airbyte-metrics/reporter/src/test/java/io/airbyte/metrics/reporter/MetricRepositoryTest.java
@@ -171,7 +171,7 @@ class MetricRepositoryTest {
           .values(4L, connectionUuid.toString(), JobStatus.running)
           .execute();
 
-      final var res = db.numberOfPendingJobs();
+      final var res = db.numberOfPendingJobsByGeography();
       assertEquals(2, res.get(EU_REGION));
     }
 
@@ -192,7 +192,7 @@ class MetricRepositoryTest {
           .values(2L, connectionUuid.toString(), JobStatus.failed)
           .execute();
 
-      final var res = db.numberOfPendingJobs();
+      final var res = db.numberOfPendingJobsByGeography();
       assertTrue(res.isEmpty());
     }
 
@@ -227,7 +227,7 @@ class MetricRepositoryTest {
           .values(4L, connectionUuid.toString(), JobStatus.failed)
           .execute();
 
-      Double result = db.oldestPendingJobAgeSecs().get(EU_REGION);
+      Double result = db.oldestPendingJobAgeSecsByGeography().get(EU_REGION);
       // expected age is 1000 seconds, but allow for +/- 1 second to account for timing/rounding errors
       assertTrue(999 < result && result < 1001);
     }
@@ -248,7 +248,7 @@ class MetricRepositoryTest {
           .values(2L, connectionUuid.toString(), JobStatus.running)
           .values(3L, connectionUuid.toString(), JobStatus.failed).execute();
 
-      final var res = db.oldestPendingJobAgeSecs();
+      final var res = db.oldestPendingJobAgeSecsByGeography();
       assertTrue(res.isEmpty());
     }
 
@@ -277,7 +277,7 @@ class MetricRepositoryTest {
           .values(4L, "", JobStatus.failed)
           .execute();
 
-      final var result = Iterators.getOnlyElement(db.oldestRunningJobAgeSecs().entrySet().iterator());
+      final var result = Iterators.getOnlyElement(db.oldestRunningJobAgeSecsByTaskQueue().entrySet().iterator());
       assertEquals(SYNC_QUEUE, result.getKey());
       // expected age is 1000 seconds, but allow for +/- 1 second to account for timing/rounding errors
       assertTrue(9999 < result.getValue() && result.getValue() < 10001L);
@@ -293,7 +293,7 @@ class MetricRepositoryTest {
           .values(3L, "", JobStatus.failed)
           .execute();
 
-      final var res = db.oldestRunningJobAgeSecs();
+      final var res = db.oldestRunningJobAgeSecsByTaskQueue();
       assertTrue(res.isEmpty());
     }
 

--- a/airbyte-metrics/reporter/src/test/java/io/airbyte/metrics/reporter/MetricRepositoryTest.java
+++ b/airbyte-metrics/reporter/src/test/java/io/airbyte/metrics/reporter/MetricRepositoryTest.java
@@ -138,7 +138,7 @@ class MetricRepositoryTest {
           .values(5L, inactiveConnectionId.toString(), JobStatus.running)
           .execute();
 
-      assertEquals(2, db.numberOfRunningJobs().get(SYNC_QUEUE));
+      assertEquals(2, db.numberOfRunningJobsByTaskQueue().get(SYNC_QUEUE));
       assertEquals(1, db.numberOfOrphanRunningJobs());
     }
 
@@ -148,7 +148,7 @@ class MetricRepositoryTest {
       ctx.insertInto(JOBS, JOBS.ID, JOBS.SCOPE, JOBS.STATUS).values(1L, "", JobStatus.pending).execute();
       ctx.insertInto(JOBS, JOBS.ID, JOBS.SCOPE, JOBS.STATUS).values(2L, "", JobStatus.failed).execute();
 
-      final var res = db.numberOfRunningJobs();
+      final var res = db.numberOfRunningJobsByTaskQueue();
       assertTrue(res.isEmpty());
     }
 

--- a/airbyte-metrics/reporter/src/test/java/io/airbyte/metrics/reporter/MetricRepositoryTest.java
+++ b/airbyte-metrics/reporter/src/test/java/io/airbyte/metrics/reporter/MetricRepositoryTest.java
@@ -18,9 +18,11 @@ import static io.airbyte.db.instance.jobs.jooq.generated.Tables.JOBS;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
+import com.google.common.collect.Iterators;
 import io.airbyte.db.factory.DSLContextFactory;
 import io.airbyte.db.init.DatabaseInitializationException;
 import io.airbyte.db.instance.configs.jooq.generated.enums.ActorType;
+import io.airbyte.db.instance.configs.jooq.generated.enums.GeographyType;
 import io.airbyte.db.instance.configs.jooq.generated.enums.NamespaceDefinitionType;
 import io.airbyte.db.instance.configs.jooq.generated.enums.ReleaseStage;
 import io.airbyte.db.instance.configs.jooq.generated.enums.StatusType;
@@ -33,7 +35,6 @@ import java.io.IOException;
 import java.sql.SQLException;
 import java.time.OffsetDateTime;
 import java.time.temporal.ChronoUnit;
-import java.util.List;
 import java.util.Map;
 import java.util.UUID;
 import org.jooq.DSLContext;
@@ -52,6 +53,9 @@ class MetricRepositoryTest {
   private static final String SRC = "src";
   private static final String DEST = "dst";
   private static final String CONN = "conn";
+  private static final String SYNC_QUEUE = "SYNC";
+  private static final String EU_REGION = "EU";
+
   private static final UUID SRC_DEF_ID = UUID.randomUUID();
   private static final UUID DST_DEF_ID = UUID.randomUUID();
   private static MetricRepository db;
@@ -108,14 +112,13 @@ class MetricRepositoryTest {
 
     @Test
     void shouldReturnReleaseStages() {
+      ctx.insertInto(ATTEMPTS, ATTEMPTS.ID, ATTEMPTS.JOB_ID, ATTEMPTS.STATUS, ATTEMPTS.PROCESSING_TASK_QUEUE)
+          .values(10L, 1L, AttemptStatus.running, SYNC_QUEUE).values(20L, 2L, AttemptStatus.running, SYNC_QUEUE)
+          .values(30L, 3L, AttemptStatus.running, SYNC_QUEUE).values(40L, 4L, AttemptStatus.running, SYNC_QUEUE)
+          .values(50L, 5L, AttemptStatus.running, SYNC_QUEUE)
+          .execute();
       final var srcId = UUID.randomUUID();
       final var dstId = UUID.randomUUID();
-
-      ctx.insertInto(ACTOR, ACTOR.ID, ACTOR.WORKSPACE_ID, ACTOR.ACTOR_DEFINITION_ID, ACTOR.NAME, ACTOR.CONFIGURATION, ACTOR.ACTOR_TYPE)
-          .values(srcId, UUID.randomUUID(), SRC_DEF_ID, SRC, JSONB.valueOf("{}"), ActorType.source)
-          .values(dstId, UUID.randomUUID(), DST_DEF_ID, DEST, JSONB.valueOf("{}"), ActorType.destination)
-          .execute();
-
       final var activeConnectionId = UUID.randomUUID();
       final var inactiveConnectionId = UUID.randomUUID();
       ctx.insertInto(CONNECTION, CONNECTION.ID, CONNECTION.STATUS, CONNECTION.NAMESPACE_DEFINITION, CONNECTION.SOURCE_ID,
@@ -135,7 +138,7 @@ class MetricRepositoryTest {
           .values(5L, inactiveConnectionId.toString(), JobStatus.running)
           .execute();
 
-      assertEquals(2, db.numberOfRunningJobs());
+      assertEquals(2, db.numberOfRunningJobs().get(SYNC_QUEUE));
       assertEquals(1, db.numberOfOrphanRunningJobs());
     }
 
@@ -146,33 +149,51 @@ class MetricRepositoryTest {
       ctx.insertInto(JOBS, JOBS.ID, JOBS.SCOPE, JOBS.STATUS).values(2L, "", JobStatus.failed).execute();
 
       final var res = db.numberOfRunningJobs();
-      assertEquals(0, res);
+      assertTrue(res.isEmpty());
     }
 
     @Test
     void pendingJobsShouldReturnCorrectCount() throws SQLException {
       // non-pending jobs
+      final var connectionUuid = UUID.randomUUID();
+      final var srcId = UUID.randomUUID();
+      final var dstId = UUID.randomUUID();
+      ctx.insertInto(CONNECTION, CONNECTION.ID, CONNECTION.NAMESPACE_DEFINITION, CONNECTION.SOURCE_ID, CONNECTION.DESTINATION_ID,
+          CONNECTION.NAME, CONNECTION.CATALOG, CONNECTION.MANUAL, CONNECTION.STATUS, CONNECTION.GEOGRAPHY)
+          .values(connectionUuid, NamespaceDefinitionType.source, srcId, dstId, CONN, JSONB.valueOf("{}"), true, StatusType.active,
+              GeographyType.valueOf(EU_REGION))
+          .execute();
+
       ctx.insertInto(JOBS, JOBS.ID, JOBS.SCOPE, JOBS.STATUS)
-          .values(1L, "", JobStatus.pending)
-          .values(2L, "", JobStatus.failed)
-          .values(3L, "", JobStatus.pending)
-          .values(4L, "", JobStatus.running)
+          .values(1L, connectionUuid.toString(), JobStatus.pending)
+          .values(2L, connectionUuid.toString(), JobStatus.failed)
+          .values(3L, connectionUuid.toString(), JobStatus.pending)
+          .values(4L, connectionUuid.toString(), JobStatus.running)
           .execute();
 
       final var res = db.numberOfPendingJobs();
-      assertEquals(2, res);
+      assertEquals(2, res.get(EU_REGION));
     }
 
     @Test
     void pendingJobsShouldReturnZero() throws SQLException {
+      final var connectionUuid = UUID.randomUUID();
+      final var srcId = UUID.randomUUID();
+      final var dstId = UUID.randomUUID();
+      ctx.insertInto(CONNECTION, CONNECTION.ID, CONNECTION.NAMESPACE_DEFINITION, CONNECTION.SOURCE_ID, CONNECTION.DESTINATION_ID,
+          CONNECTION.NAME, CONNECTION.CATALOG, CONNECTION.MANUAL, CONNECTION.STATUS, CONNECTION.GEOGRAPHY)
+          .values(connectionUuid, NamespaceDefinitionType.source, srcId, dstId, CONN, JSONB.valueOf("{}"), true, StatusType.active,
+              GeographyType.valueOf(EU_REGION))
+          .execute();
+
       // non-pending jobs
       ctx.insertInto(JOBS, JOBS.ID, JOBS.SCOPE, JOBS.STATUS)
-          .values(1L, "", JobStatus.running)
-          .values(2L, "", JobStatus.failed)
+          .values(1L, connectionUuid.toString(), JobStatus.running)
+          .values(2L, connectionUuid.toString(), JobStatus.failed)
           .execute();
 
       final var res = db.numberOfPendingJobs();
-      assertEquals(0, res);
+      assertTrue(res.isEmpty());
     }
 
   }
@@ -184,33 +205,51 @@ class MetricRepositoryTest {
     void shouldReturnOnlyPendingSeconds() throws SQLException {
       final var expAgeSecs = 1000;
       final var oldestCreateAt = OffsetDateTime.now().minus(expAgeSecs, ChronoUnit.SECONDS);
+      final var connectionUuid = UUID.randomUUID();
+      final var srcId = UUID.randomUUID();
+      final var dstId = UUID.randomUUID();
+
+      ctx.insertInto(CONNECTION, CONNECTION.ID, CONNECTION.NAMESPACE_DEFINITION, CONNECTION.SOURCE_ID, CONNECTION.DESTINATION_ID,
+          CONNECTION.NAME, CONNECTION.CATALOG, CONNECTION.MANUAL, CONNECTION.STATUS, CONNECTION.GEOGRAPHY)
+          .values(connectionUuid, NamespaceDefinitionType.source, srcId, dstId, CONN, JSONB.valueOf("{}"), true, StatusType.active,
+              GeographyType.valueOf(EU_REGION))
+          .execute();
 
       ctx.insertInto(JOBS, JOBS.ID, JOBS.SCOPE, JOBS.STATUS, JOBS.CREATED_AT)
           // oldest pending job
-          .values(1L, "", JobStatus.pending, oldestCreateAt)
+          .values(1L, connectionUuid.toString(), JobStatus.pending, oldestCreateAt)
           // second-oldest pending job
-          .values(2L, "", JobStatus.pending, OffsetDateTime.now())
+          .values(2L, connectionUuid.toString(), JobStatus.pending, OffsetDateTime.now())
           .execute();
       // non-pending jobs
       ctx.insertInto(JOBS, JOBS.ID, JOBS.SCOPE, JOBS.STATUS)
-          .values(3L, "", JobStatus.running)
-          .values(4L, "", JobStatus.failed)
+          .values(3L, connectionUuid.toString(), JobStatus.running)
+          .values(4L, connectionUuid.toString(), JobStatus.failed)
           .execute();
 
-      final var res = db.oldestPendingJobAgeSecs();
+      Double result = db.oldestPendingJobAgeSecs().get(EU_REGION);
       // expected age is 1000 seconds, but allow for +/- 1 second to account for timing/rounding errors
-      assertTrue(List.of(999L, 1000L, 1001L).contains(res));
+      assertTrue(999 < result && result < 1001);
     }
 
     @Test
     void shouldReturnNothingIfNotApplicable() {
+      final var connectionUuid = UUID.randomUUID();
+      final var srcId = UUID.randomUUID();
+      final var dstId = UUID.randomUUID();
+
+      ctx.insertInto(CONNECTION, CONNECTION.ID, CONNECTION.NAMESPACE_DEFINITION, CONNECTION.SOURCE_ID, CONNECTION.DESTINATION_ID,
+          CONNECTION.NAME, CONNECTION.CATALOG, CONNECTION.MANUAL, CONNECTION.STATUS, CONNECTION.GEOGRAPHY)
+          .values(connectionUuid, NamespaceDefinitionType.source, srcId, dstId, CONN, JSONB.valueOf("{}"), true, StatusType.active, GeographyType.EU)
+          .execute();
+
       ctx.insertInto(JOBS, JOBS.ID, JOBS.SCOPE, JOBS.STATUS)
-          .values(1L, "", JobStatus.succeeded)
-          .values(2L, "", JobStatus.running)
-          .values(3L, "", JobStatus.failed).execute();
+          .values(1L, connectionUuid.toString(), JobStatus.succeeded)
+          .values(2L, connectionUuid.toString(), JobStatus.running)
+          .values(3L, connectionUuid.toString(), JobStatus.failed).execute();
 
       final var res = db.oldestPendingJobAgeSecs();
-      assertEquals(0L, res);
+      assertTrue(res.isEmpty());
     }
 
   }
@@ -222,7 +261,9 @@ class MetricRepositoryTest {
     void shouldReturnOnlyRunningSeconds() {
       final var expAgeSecs = 10000;
       final var oldestCreateAt = OffsetDateTime.now().minus(expAgeSecs, ChronoUnit.SECONDS);
-
+      ctx.insertInto(ATTEMPTS, ATTEMPTS.ID, ATTEMPTS.JOB_ID, ATTEMPTS.STATUS, ATTEMPTS.PROCESSING_TASK_QUEUE)
+          .values(10L, 1L, AttemptStatus.running, SYNC_QUEUE).values(20L, 2L, AttemptStatus.running, SYNC_QUEUE)
+          .execute();
       ctx.insertInto(JOBS, JOBS.ID, JOBS.SCOPE, JOBS.STATUS, JOBS.CREATED_AT)
           // oldest pending job
           .values(1L, "", JobStatus.running, oldestCreateAt)
@@ -236,13 +277,16 @@ class MetricRepositoryTest {
           .values(4L, "", JobStatus.failed)
           .execute();
 
-      final var res = db.oldestRunningJobAgeSecs();
-      // expected age is 10000 seconds, but allow for +/- 1 second to account for timing/rounding errors
-      assertTrue(List.of(9999L, 10000L, 10001L).contains(res));
+      final var result = Iterators.getOnlyElement(db.oldestRunningJobAgeSecs().entrySet().iterator());
+      assertEquals(SYNC_QUEUE, result.getKey());
+      // expected age is 1000 seconds, but allow for +/- 1 second to account for timing/rounding errors
+      assertTrue(9999 < result.getValue() && result.getValue() < 10001L);
     }
 
     @Test
     void shouldReturnNothingIfNotApplicable() {
+      ctx.insertInto(ATTEMPTS, ATTEMPTS.ID, ATTEMPTS.JOB_ID, ATTEMPTS.PROCESSING_TASK_QUEUE).values(10L, 1L, SYNC_QUEUE).values(20L, 2L, SYNC_QUEUE)
+          .values(30L, 3L, SYNC_QUEUE).execute();
       ctx.insertInto(JOBS, JOBS.ID, JOBS.SCOPE, JOBS.STATUS)
           .values(1L, "", JobStatus.succeeded)
           .values(2L, "", JobStatus.pending)
@@ -250,7 +294,7 @@ class MetricRepositoryTest {
           .execute();
 
       final var res = db.oldestRunningJobAgeSecs();
-      assertEquals(0L, res);
+      assertTrue(res.isEmpty());
     }
 
   }


### PR DESCRIPTION
## What

https://github.com/airbytehq/airbyte/issues/15898

Include processing_task_queue or connection geography into metric report query.
