### PR TITLE
🪟 🐛 Fix UI issues in connection streams table

### DIFF
--- a/airbyte-webapp/src/components/connection/CatalogTree/PathPopout.tsx
+++ b/airbyte-webapp/src/components/connection/CatalogTree/PathPopout.tsx
@@ -41,7 +41,11 @@ export const PathPopout: React.FC<PathPopoutProps> = (props) => {
       const text = props.isMulti ? props.path.map(pathDisplayName).join(", ") : pathDisplayName(props.path);
 
       return (
-        <Tooltip placement="bottom-start" control={<div className={styles.text}>{text}</div>}>
+        <Tooltip
+          placement="bottom-start"
+          control={<div className={styles.text}>{text}</div>}
+          disabled={!props.isMulti || props.path.length <= 1}
+        >
           {text}
         </Tooltip>
       );

--- a/airbyte-webapp/src/components/connection/CatalogTree/PathPopout.tsx
+++ b/airbyte-webapp/src/components/connection/CatalogTree/PathPopout.tsx
@@ -41,11 +41,7 @@ export const PathPopout: React.FC<PathPopoutProps> = (props) => {
       const text = props.isMulti ? props.path.map(pathDisplayName).join(", ") : pathDisplayName(props.path);
 
       return (
-        <Tooltip
-          placement="bottom-start"
-          control={<div className={styles.text}>{text}</div>}
-          disabled={!props.isMulti || props.path.length <= 1}
-        >
+        <Tooltip placement="bottom-start" control={<div className={styles.text}>{text}</div>}>
           {text}
         </Tooltip>
       );

--- a/airbyte-webapp/src/components/connection/CatalogTree/PathPopoutButton.module.scss
+++ b/airbyte-webapp/src/components/connection/CatalogTree/PathPopoutButton.module.scss
@@ -12,6 +12,7 @@
   flex-direction: row;
   justify-content: space-between;
   gap: variables.$spacing-sm;
+  max-width: 100%;
   padding: 8px;
   border-radius: variables.$border-radius-xs;
   background-color: colors.$grey-100;

--- a/airbyte-webapp/src/components/connection/CatalogTree/PathPopoutButton.tsx
+++ b/airbyte-webapp/src/components/connection/CatalogTree/PathPopoutButton.tsx
@@ -27,7 +27,7 @@ export const PathPopoutButton: React.FC<React.PropsWithChildren<PathPopoutButton
       </button>
     }
     placement="bottom-start"
-    disabled={items.length <= 1}
+    disabled={items.length === 0}
   >
     {items.map((value, key) => (
       <div key={`tooltip-item-${key}`}>

--- a/airbyte-webapp/src/components/connection/CatalogTree/PathPopoutButton.tsx
+++ b/airbyte-webapp/src/components/connection/CatalogTree/PathPopoutButton.tsx
@@ -1,4 +1,4 @@
-import { faSortDown } from "@fortawesome/free-solid-svg-icons";
+import { faCaretDown } from "@fortawesome/free-solid-svg-icons";
 import { FontAwesomeIcon } from "@fortawesome/react-fontawesome";
 import React from "react";
 
@@ -23,11 +23,11 @@ export const PathPopoutButton: React.FC<React.PropsWithChildren<PathPopoutButton
         <Text size="sm" className={styles.text}>
           {children}
         </Text>
-        <FontAwesomeIcon className={styles.arrow} icon={faSortDown} />
+        <FontAwesomeIcon className={styles.arrow} icon={faCaretDown} />
       </button>
     }
     placement="bottom-start"
-    disabled={items.length === 0}
+    disabled={items.length <= 1}
   >
     {items.map((value, key) => (
       <div key={`tooltip-item-${key}`}>

--- a/airbyte-webapp/src/components/connection/CatalogTree/StreamHeader.module.scss
+++ b/airbyte-webapp/src/components/connection/CatalogTree/StreamHeader.module.scss
@@ -1,6 +1,6 @@
 @use "scss/colors";
 @use "scss/variables";
-@forward "./CatalogTreeBody.module.scss";
+@forward "./CatalogTreeHeader.module.scss";
 
 .icon {
   margin-right: 7px;

--- a/airbyte-webapp/src/components/connection/CatalogTree/SyncSettingsDropdown.tsx
+++ b/airbyte-webapp/src/components/connection/CatalogTree/SyncSettingsDropdown.tsx
@@ -53,7 +53,8 @@ const Title = styled.span`
 
 const OptionContent = styled(OptionView)`
   justify-content: left;
-  font-size: 12px;
+  font-size: 11px;
+  padding: 10px;
 `;
 
 const DropdownControl = styled(components.Control)<ControlProps<DropDownOptionDataItem, false>>`
@@ -74,7 +75,7 @@ const Mode: React.FC<{
 }> = (props) => {
   return (
     <>
-      <Title> {props.title}:</Title>
+      <Title>{props.title}:</Title>
       <div>{props.label}</div>
       {props.separator ? <Separator>{props.separator}</Separator> : null}
     </>


### PR DESCRIPTION
## What
Resolves #16976

Fixes a few UI styling issues related to the streams table:

* Fixes the overflow on the primary key/cursor dropdowns
* Fixes overflow in sync mode menu from cutting off "Deduped + History"
* Fixes issues where `+` `-` states were shifted to the right

![Screen Shot 2022-10-27 at 09 39 08](https://user-images.githubusercontent.com/168664/198300553-116d869f-1c7a-4616-a1d8-9ac86e5c49bd.png)

## How
Styling changes
Logic changes to when to enable/disable the tooltip for `PathPopout`

## Testing
* Connection with Mailchimp source
* Connection with Postgres source
