### PR TITLE
Ensure that restart delay is set before any other activity is executed

### DIFF
--- a/airbyte-workers/src/main/java/io/airbyte/workers/temporal/scheduling/ConnectionManagerWorkflowImpl.java
+++ b/airbyte-workers/src/main/java/io/airbyte/workers/temporal/scheduling/ConnectionManagerWorkflowImpl.java
@@ -161,8 +161,8 @@ public class ConnectionManagerWorkflowImpl implements ConnectionManagerWorkflow 
   public void run(final ConnectionUpdaterInput connectionUpdaterInput) throws RetryableException {
     try {
       ApmTraceUtils.addTagsToTrace(Map.of(CONNECTION_ID_KEY, connectionUpdaterInput.getConnectionId()));
-      recordMetric(new RecordMetricInput(connectionUpdaterInput, Optional.empty(), OssMetricsRegistry.TEMPORAL_WORKFLOW_ATTEMPT, null));
       workflowDelay = getWorkflowRestartDelaySeconds();
+      recordMetric(new RecordMetricInput(connectionUpdaterInput, Optional.empty(), OssMetricsRegistry.TEMPORAL_WORKFLOW_ATTEMPT, null));
 
       try {
         cancellableSyncWorkflow = generateSyncWorkflowRunnable(connectionUpdaterInput);

--- a/airbyte-workers/src/main/java/io/airbyte/workers/temporal/scheduling/ConnectionManagerWorkflowImpl.java
+++ b/airbyte-workers/src/main/java/io/airbyte/workers/temporal/scheduling/ConnectionManagerWorkflowImpl.java
@@ -163,7 +163,8 @@ public class ConnectionManagerWorkflowImpl implements ConnectionManagerWorkflow 
   public void run(final ConnectionUpdaterInput connectionUpdaterInput) throws RetryableException {
     try {
       ApmTraceUtils.addTagsToTrace(Map.of(CONNECTION_ID_KEY, connectionUpdaterInput.getConnectionId()));
-      if(Workflow.getVersion(WORKFLOW_DELAY_TAG, Workflow.DEFAULT_VERSION, WORKFLOW_DELAY_TAG_CURRENT_VERSION) < WORKFLOW_DELAY_TAG_CURRENT_VERSION) {
+      if (Workflow.getVersion(WORKFLOW_DELAY_TAG, Workflow.DEFAULT_VERSION,
+          WORKFLOW_DELAY_TAG_CURRENT_VERSION) < WORKFLOW_DELAY_TAG_CURRENT_VERSION) {
         recordMetric(new RecordMetricInput(connectionUpdaterInput, Optional.empty(), OssMetricsRegistry.TEMPORAL_WORKFLOW_ATTEMPT, null));
         workflowDelay = getWorkflowRestartDelaySeconds();
       } else {

--- a/airbyte-workers/src/main/java/io/airbyte/workers/temporal/scheduling/ConnectionManagerWorkflowImpl.java
+++ b/airbyte-workers/src/main/java/io/airbyte/workers/temporal/scheduling/ConnectionManagerWorkflowImpl.java
@@ -121,6 +121,8 @@ public class ConnectionManagerWorkflowImpl implements ConnectionManagerWorkflow 
   private static final int RECORD_METRIC_CURRENT_VERSION = 1;
   private static final String WORKFLOW_CONFIG_TAG = "workflow_config";
   private static final int WORKFLOW_CONFIG_CURRENT_VERSION = 1;
+  private static final String WORKFLOW_DELAY_TAG = "get_workflow_delay";
+  private static final int WORKFLOW_DELAY_TAG_CURRENT_VERSION = 1;
 
   private static final String ROUTE_ACTIVITY_TAG = "route_activity";
   private static final int ROUTE_ACTIVITY_CURRENT_VERSION = 1;
@@ -161,8 +163,13 @@ public class ConnectionManagerWorkflowImpl implements ConnectionManagerWorkflow 
   public void run(final ConnectionUpdaterInput connectionUpdaterInput) throws RetryableException {
     try {
       ApmTraceUtils.addTagsToTrace(Map.of(CONNECTION_ID_KEY, connectionUpdaterInput.getConnectionId()));
-      workflowDelay = getWorkflowRestartDelaySeconds();
-      recordMetric(new RecordMetricInput(connectionUpdaterInput, Optional.empty(), OssMetricsRegistry.TEMPORAL_WORKFLOW_ATTEMPT, null));
+      if(Workflow.getVersion(WORKFLOW_DELAY_TAG, Workflow.DEFAULT_VERSION, WORKFLOW_DELAY_TAG_CURRENT_VERSION) < WORKFLOW_DELAY_TAG_CURRENT_VERSION) {
+        recordMetric(new RecordMetricInput(connectionUpdaterInput, Optional.empty(), OssMetricsRegistry.TEMPORAL_WORKFLOW_ATTEMPT, null));
+        workflowDelay = getWorkflowRestartDelaySeconds();
+      } else {
+        workflowDelay = getWorkflowRestartDelaySeconds();
+        recordMetric(new RecordMetricInput(connectionUpdaterInput, Optional.empty(), OssMetricsRegistry.TEMPORAL_WORKFLOW_ATTEMPT, null));
+      }
 
       try {
         cancellableSyncWorkflow = generateSyncWorkflowRunnable(connectionUpdaterInput);


### PR DESCRIPTION
## What
* Address possible NPE that occurs when an activity fails before the retry duration is retrieved

```
airbyte-cloud-workers-5f8f6489b-95s5w cloud-workers 2022-10-27 13:50:34 ERROR i.a.w.t.s.ConnectionManagerWorkflowImpl(runMandatoryActivityWithOutput):614 - [ACTIVITY-FAILURE] Connection null failed to run an activity.(RecordMetricInput).  Connection manager workflow will be restarted after a delay of null.
airbyte-cloud-workers-5f8f6489b-95s5w cloud-workers io.temporal.failure.ActivityFailure: scheduledEventId=6, startedEventId=7, activityType='RecordWorkflowCountMetric', activityId='e155db69-093a-316b-a0ae-13700d9e612b', identity='1@airbyte-worker-5574d5978b-xszzt', retryState=RETRY_STATE_MAXIMUM_ATTEMPTS_REACHED
airbyte-cloud-workers-5f8f6489b-95s5w cloud-workers 	at java.lang.Thread.getStackTrace(Thread.java:2550) ~[?:?]
airbyte-cloud-workers-5f8f6489b-95s5w cloud-workers 	at io.temporal.internal.sync.ActivityStubBase.execute(ActivityStubBase.java:48) ~[temporal-sdk-1.8.1.jar:?]
airbyte-cloud-workers-5f8f6489b-95s5w cloud-workers 	at io.temporal.internal.sync.ActivityInvocationHandler.lambda$getActivityFunc$0(ActivityInvocationHandler.java:77) ~[temporal-sdk-1.8.1.jar:?]
airbyte-cloud-workers-5f8f6489b-95s5w cloud-workers 	at io.temporal.internal.sync.ActivityInvocationHandlerBase.invoke(ActivityInvocationHandlerBase.java:70) ~[temporal-sdk-1.8.1.jar:?]
airbyte-cloud-workers-5f8f6489b-95s5w cloud-workers 	at jdk.proxy3.$Proxy130.recordWorkflowCountMetric(Unknown Source) ~[?:?]
airbyte-cloud-workers-5f8f6489b-95s5w cloud-workers 	at io.airbyte.workers.temporal.scheduling.ConnectionManagerWorkflowImpl.lambda$runMandatoryActivity$3(ConnectionManagerWorkflowImpl.java:650) ~[io.airbyte-airbyte-workers-dev-d6ce20f.jar:?]
airbyte-cloud-workers-5f8f6489b-95s5w cloud-workers 	at io.airbyte.workers.temporal.scheduling.ConnectionManagerWorkflowImpl.runMandatoryActivityWithOutput(ConnectionManagerWorkflowImpl.java:612) ~[io.airbyte-airbyte-workers-dev-d6ce20f.jar:?]
airbyte-cloud-workers-5f8f6489b-95s5w cloud-workers 	at io.airbyte.workers.temporal.scheduling.ConnectionManagerWorkflowImpl.runMandatoryActivity(ConnectionManagerWorkflowImpl.java:649) ~[io.airbyte-airbyte-workers-dev-d6ce20f.jar:?]
airbyte-cloud-workers-5f8f6489b-95s5w cloud-workers 	at io.airbyte.workers.temporal.scheduling.ConnectionManagerWorkflowImpl.recordMetric(ConnectionManagerWorkflowImpl.java:699) ~[io.airbyte-airbyte-workers-dev-d6ce20f.jar:?]
airbyte-cloud-workers-5f8f6489b-95s5w cloud-workers 	at io.airbyte.workers.temporal.scheduling.ConnectionManagerWorkflowImpl.run(ConnectionManagerWorkflowImpl.java:164) ~[io.airbyte-airbyte-workers-dev-d6ce20f.jar:?]
airbyte-cloud-workers-5f8f6489b-95s5w cloud-workers 	at ConnectionManagerWorkflowImplProxy.run$accessor$SVGM76cA(Unknown Source) ~[?:?]
airbyte-cloud-workers-5f8f6489b-95s5w cloud-workers 	at ConnectionManagerWorkflowImplProxy$auxiliary$ZlIJToVY.call(Unknown Source) ~[?:?]
airbyte-cloud-workers-5f8f6489b-95s5w cloud-workers 	at io.airbyte.workers.temporal.support.TemporalActivityStubInterceptor.execute(TemporalActivityStubInterceptor.java:79) ~[io.airbyte-airbyte-workers-dev-d6ce20f.jar:?]
airbyte-cloud-workers-5f8f6489b-95s5w cloud-workers 	at ConnectionManagerWorkflowImplProxy.run(Unknown Source) ~[?:?]
airbyte-cloud-workers-5f8f6489b-95s5w cloud-workers 	at jdk.internal.reflect.DirectMethodHandleAccessor.invoke(DirectMethodHandleAccessor.java:104) ~[?:?]
airbyte-cloud-workers-5f8f6489b-95s5w cloud-workers 	at java.lang.reflect.Method.invoke(Method.java:578) ~[?:?]
airbyte-cloud-workers-5f8f6489b-95s5w cloud-workers 	at io.temporal.internal.sync.POJOWorkflowImplementationFactory$POJOWorkflowImplementation$RootWorkflowInboundCallsInterceptor.execute(POJOWorkflowImplementationFactory.java:317) ~[temporal-sdk-1.8.1.jar:?]
airbyte-cloud-workers-5f8f6489b-95s5w cloud-workers 	at io.temporal.internal.sync.POJOWorkflowImplementationFactory$POJOWorkflowImplementation.execute(POJOWorkflowImplementationFactory.java:292) ~[temporal-sdk-1.8.1.jar:?]
airbyte-cloud-workers-5f8f6489b-95s5w cloud-workers 	at io.temporal.internal.sync.WorkflowExecuteRunnable.run(WorkflowExecuteRunnable.java:72) ~[temporal-sdk-1.8.1.jar:?]
airbyte-cloud-workers-5f8f6489b-95s5w cloud-workers 	at io.temporal.internal.sync.SyncWorkflow.lambda$start$0(SyncWorkflow.java:137) ~[temporal-sdk-1.8.1.jar:?]
airbyte-cloud-workers-5f8f6489b-95s5w cloud-workers 	at io.temporal.internal.sync.CancellationScopeImpl.run(CancellationScopeImpl.java:101) ~[temporal-sdk-1.8.1.jar:?]
airbyte-cloud-workers-5f8f6489b-95s5w cloud-workers 	at io.temporal.internal.sync.WorkflowThreadImpl$RunnableWrapper.run(WorkflowThreadImpl.java:111) ~[temporal-sdk-1.8.1.jar:?]
airbyte-cloud-workers-5f8f6489b-95s5w cloud-workers 	at java.util.concurrent.Executors$RunnableAdapter.call(Executors.java:577) ~[?:?]
airbyte-cloud-workers-5f8f6489b-95s5w cloud-workers 	at java.util.concurrent.FutureTask.run(FutureTask.java:317) ~[?:?]
airbyte-cloud-workers-5f8f6489b-95s5w cloud-workers 	at java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1144) ~[?:?]
airbyte-cloud-workers-5f8f6489b-95s5w cloud-workers 	at java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:642) ~[?:?]
airbyte-cloud-workers-5f8f6489b-95s5w cloud-workers 	at java.lang.Thread.run(Thread.java:1589) ~[?:?]
airbyte-cloud-workers-5f8f6489b-95s5w cloud-workers Caused by: io.temporal.failure.ApplicationFailure: type='java.lang.NullPointerException', nonRetryable=false
airbyte-cloud-workers-5f8f6489b-95s5w cloud-workers 	at java.base/java.util.Objects.requireNonNull(Objects.java:233) ~[?:?]
airbyte-cloud-workers-5f8f6489b-95s5w cloud-workers 	at java.base/java.util.ImmutableCollections$MapN.<init>(ImmutableCollections.java:1186) ~[?:?]
airbyte-cloud-workers-5f8f6489b-95s5w cloud-workers 	at java.base/java.util.Map.of(Map.java:1371) ~[?:?]
airbyte-cloud-workers-5f8f6489b-95s5w cloud-workers 	at io.airbyte.workers.temporal.scheduling.activities.RecordMetricActivityImpl.recordWorkflowCountMetric(RecordMetricActivityImpl.java:48) ~[io.airbyte-airbyte-workers-dev-d6ce20f.jar:?]
airbyte-cloud-workers-5f8f6489b-95s5w cloud-workers 	at java.base/jdk.internal.reflect.DirectMethodHandleAccessor.invoke(DirectMethodHandleAccessor.java:104) ~[?:?]
airbyte-cloud-workers-5f8f6489b-95s5w cloud-workers 	at java.base/java.lang.reflect.Method.invoke(Method.java:578) ~[?:?]
airbyte-cloud-workers-5f8f6489b-95s5w cloud-workers 	at io.temporal.internal.activity.POJOActivityTaskHandler$POJOActivityInboundCallsInterceptor.execute(POJOActivityTaskHandler.java:214) ~[temporal-sdk-1.8.1.jar:?]
airbyte-cloud-workers-5f8f6489b-95s5w cloud-workers 	at io.temporal.internal.activity.POJOActivityTaskHandler$POJOActivityImplementation.execute(POJOActivityTaskHandler.java:180) ~[temporal-sdk-1.8.1.jar:?]
airbyte-cloud-workers-5f8f6489b-95s5w cloud-workers 	at io.temporal.internal.activity.POJOActivityTaskHandler.handle(POJOActivityTaskHandler.java:120) ~[temporal-sdk-1.8.1.jar:?]
airbyte-cloud-workers-5f8f6489b-95s5w cloud-workers 	at io.temporal.internal.worker.ActivityWorker$TaskHandlerImpl.handle(ActivityWorker.java:204) ~[temporal-sdk-1.8.1.jar:?]
airbyte-cloud-workers-5f8f6489b-95s5w cloud-workers 	at io.temporal.internal.worker.ActivityWorker$TaskHandlerImpl.handle(ActivityWorker.java:164) ~[temporal-sdk-1.8.1.jar:?]
airbyte-cloud-workers-5f8f6489b-95s5w cloud-workers 	at io.temporal.internal.worker.PollTaskExecutor.lambda$process$0(PollTaskExecutor.java:93) ~[temporal-sdk-1.8.1.jar:?]
airbyte-cloud-workers-5f8f6489b-95s5w cloud-workers 	at java.base/java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1144) ~[?:?]
airbyte-cloud-workers-5f8f6489b-95s5w cloud-workers 	at java.base/java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:642) ~[?:?]
airbyte-cloud-workers-5f8f6489b-95s5w cloud-workers 	at java.base/java.lang.Thread.run(Thread.java:1589) ~[?:?]
airbyte-cloud-workers-5f8f6489b-95s5w cloud-workers 2022-10-27 13:50:34 INFO i.a.w.t.s.ConnectionManagerWorkflowImpl(runMandatoryActivityWithOutput):623 - Waiting null before restarting the workflow for connection null, to prevent spamming temporal with restarts.
airbyte-cloud-workers-5f8f6489b-95s5w cloud-workers 2022-10-27 13:50:34 ERROR i.a.w.t.s.ConnectionManagerWorkflowImpl(run):199 - The connection update workflow has failed, will create a new attempt.
airbyte-cloud-workers-5f8f6489b-95s5w cloud-workers java.lang.NullPointerException: Cannot invoke "java.time.Duration.compareTo(java.time.Duration)" because "delay" is null
airbyte-cloud-workers-5f8f6489b-95s5w cloud-workers 	at io.temporal.internal.replay.ReplayWorkflowContextImpl.newTimer(ReplayWorkflowContextImpl.java:266) ~[temporal-sdk-1.8.1.jar:?]
airbyte-cloud-workers-5f8f6489b-95s5w cloud-workers 	at io.temporal.internal.sync.SyncWorkflowContext.newTimer(SyncWorkflowContext.java:571) ~[temporal-sdk-1.8.1.jar:?]
airbyte-cloud-workers-5f8f6489b-95s5w cloud-workers 	at io.temporal.internal.sync.SyncWorkflowContext.await(SyncWorkflowContext.java:766) ~[temporal-sdk-1.8.1.jar:?]
airbyte-cloud-workers-5f8f6489b-95s5w cloud-workers 	at io.temporal.internal.sync.WorkflowInternal.await(WorkflowInternal.java:401) ~[temporal-sdk-1.8.1.jar:?]
airbyte-cloud-workers-5f8f6489b-95s5w cloud-workers 	at io.temporal.workflow.Workflow.await(Workflow.java:567) ~[temporal-sdk-1.8.1.jar:?]
airbyte-cloud-workers-5f8f6489b-95s5w cloud-workers 	at io.airbyte.workers.temporal.scheduling.ConnectionManagerWorkflowImpl.runMandatoryActivityWithOutput(ConnectionManagerWorkflowImpl.java:625) ~[io.airbyte-airbyte-workers-dev-d6ce20f.jar:?]
airbyte-cloud-workers-5f8f6489b-95s5w cloud-workers 	at io.airbyte.workers.temporal.scheduling.ConnectionManagerWorkflowImpl.runMandatoryActivity(ConnectionManagerWorkflowImpl.java:649) ~[io.airbyte-airbyte-workers-dev-d6ce20f.jar:?]
airbyte-cloud-workers-5f8f6489b-95s5w cloud-workers 	at io.airbyte.workers.temporal.scheduling.ConnectionManagerWorkflowImpl.recordMetric(ConnectionManagerWorkflowImpl.java:699) ~[io.airbyte-airbyte-workers-dev-d6ce20f.jar:?]
airbyte-cloud-workers-5f8f6489b-95s5w cloud-workers 	at io.airbyte.workers.temporal.scheduling.ConnectionManagerWorkflowImpl.run(ConnectionManagerWorkflowImpl.java:164) ~[io.airbyte-airbyte-workers-dev-d6ce20f.jar:?]
airbyte-cloud-workers-5f8f6489b-95s5w cloud-workers 	at ConnectionManagerWorkflowImplProxy.run$accessor$SVGM76cA(Unknown Source) ~[?:?]
airbyte-cloud-workers-5f8f6489b-95s5w cloud-workers 	at ConnectionManagerWorkflowImplProxy$auxiliary$ZlIJToVY.call(Unknown Source) ~[?:?]
airbyte-cloud-workers-5f8f6489b-95s5w cloud-workers 	at io.airbyte.workers.temporal.support.TemporalActivityStubInterceptor.execute(TemporalActivityStubInterceptor.java:79) ~[io.airbyte-airbyte-workers-dev-d6ce20f.jar:?]
airbyte-cloud-workers-5f8f6489b-95s5w cloud-workers 	at ConnectionManagerWorkflowImplProxy.run(Unknown Source) ~[?:?]
airbyte-cloud-workers-5f8f6489b-95s5w cloud-workers 	at jdk.internal.reflect.DirectMethodHandleAccessor.invoke(DirectMethodHandleAccessor.java:104) ~[?:?]
airbyte-cloud-workers-5f8f6489b-95s5w cloud-workers 	at java.lang.reflect.Method.invoke(Method.java:578) ~[?:?]
airbyte-cloud-workers-5f8f6489b-95s5w cloud-workers 	at io.temporal.internal.sync.POJOWorkflowImplementationFactory$POJOWorkflowImplementation$RootWorkflowInboundCallsInterceptor.execute(POJOWorkflowImplementationFactory.java:317) ~[temporal-sdk-1.8.1.jar:?]
airbyte-cloud-workers-5f8f6489b-95s5w cloud-workers 	at io.temporal.internal.sync.POJOWorkflowImplementationFactory$POJOWorkflowImplementation.execute(POJOWorkflowImplementationFactory.java:292) ~[temporal-sdk-1.8.1.jar:?]
airbyte-cloud-workers-5f8f6489b-95s5w cloud-workers 	at io.temporal.internal.sync.WorkflowExecuteRunnable.run(WorkflowExecuteRunnable.java:72) ~[temporal-sdk-1.8.1.jar:?]
airbyte-cloud-workers-5f8f6489b-95s5w cloud-workers 	at io.temporal.internal.sync.SyncWorkflow.lambda$start$0(SyncWorkflow.java:137) ~[temporal-sdk-1.8.1.jar:?]
airbyte-cloud-workers-5f8f6489b-95s5w cloud-workers 	at io.temporal.internal.sync.CancellationScopeImpl.run(CancellationScopeImpl.java:101) ~[temporal-sdk-1.8.1.jar:?]
airbyte-cloud-workers-5f8f6489b-95s5w cloud-workers 	at io.temporal.internal.sync.WorkflowThreadImpl$RunnableWrapper.run(WorkflowThreadImpl.java:111) ~[temporal-sdk-1.8.1.jar:?]
airbyte-cloud-workers-5f8f6489b-95s5w cloud-workers 	at java.util.concurrent.Executors$RunnableAdapter.call(Executors.java:577) ~[?:?]
airbyte-cloud-workers-5f8f6489b-95s5w cloud-workers 	at java.util.concurrent.FutureTask.run(FutureTask.java:317) ~[?:?]
airbyte-cloud-workers-5f8f6489b-95s5w cloud-workers 	at java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1144) ~[?:?]
airbyte-cloud-workers-5f8f6489b-95s5w cloud-workers 	at java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:642) ~[?:?]
airbyte-cloud-workers-5f8f6489b-95s5w cloud-workers 	at java.lang.Thread.run(Thread.java:1589) ~[?:?]
```

## How
* Move retrieval of the retry duration before any other activity execution

## Recommended reading order
1. `ConnectionManagerWorkflowImpl.java`

## Tests

* Project builds locally
* All tests pass
* Kube acceptance tests pass locally