### PR TITLE
Add endpoint to retrieve manifest template

### DIFF
--- a/connector-builder-server/src/main/openapi/openapi.yaml
+++ b/connector-builder-server/src/main/openapi/openapi.yaml
@@ -57,6 +57,20 @@ paths:
           $ref: "#/components/responses/ExceptionResponse"
         "422":
           $ref: "#/components/responses/InvalidInputResponse"
+  /v1/manifest_template:
+    get:
+      summary: Return a connector manifest template to use as the default value for the yaml editor
+      operationId: template
+      responses:
+        "200":
+          description: Successful operation
+          content:
+            application/json:
+              schema:
+                type: string
+                description: Connector manifest template string
+        "400":
+          $ref: "#/components/responses/ExceptionResponse"
 
 components:
   schemas:
@@ -87,8 +101,6 @@ components:
                   type: object
                   required:
                     - records
-                    - request
-                    - response
                   properties:
                     records:
                       type: array

--- a/connector-builder-server/src/main/openapi/openapi.yaml
+++ b/connector-builder-server/src/main/openapi/openapi.yaml
@@ -69,8 +69,6 @@ paths:
               schema:
                 type: string
                 description: Connector manifest template string
-        "400":
-          $ref: "#/components/responses/ExceptionResponse"
 
 components:
   schemas:


### PR DESCRIPTION
## What
Because the webapp cannot pull in an external file to use as the default value for the yaml editor, this template yaml needs to be retrieved from the connector builder server.

## How
Add a `/v1/manifest_template` endpoint to the connector builder server api spec

Also makes the `request` and `response` properties on the StreamRead optional, since we may not be able to provide those in the first iteration of the connector builder server.
