### PR TITLE
Hide Reject all button in consent dialog

### DIFF
--- a/airbyte-webapp/src/utils/dataPrivacy.ts
+++ b/airbyte-webapp/src/utils/dataPrivacy.ts
@@ -59,6 +59,12 @@ export const loadOsano = (): void => {
   // Create style element to hide osano widget
   const style = document.createElement("style");
   style.appendChild(document.createTextNode(".osano-cm-widget { display: none; }"));
+  style.appendChild(document.createTextNode(".osano-cm-button--type_denyAll { display: none; }"));
+  style.appendChild(
+    document.createTextNode(
+      `.osano-cm-button--type_manage { background-color: inherit; border: 1px inherit; font-weight: 200; }`
+    )
+  );
   document.head.appendChild(style);
 
   // Create and append the script tag to  load osano

--- a/airbyte-webapp/src/utils/dataPrivacy.ts
+++ b/airbyte-webapp/src/utils/dataPrivacy.ts
@@ -58,12 +58,11 @@ export const loadOsano = (): void => {
 
   // Create style element to hide osano widget
   const style = document.createElement("style");
-  style.appendChild(document.createTextNode(".osano-cm-widget { display: none; }"));
-  style.appendChild(document.createTextNode(".osano-cm-button--type_denyAll { display: none; }"));
   style.appendChild(
-    document.createTextNode(
-      `.osano-cm-button--type_manage { background-color: inherit; border: 1px inherit; font-weight: 200; }`
-    )
+    document.createTextNode(`
+    .osano-cm-widget { display: none; }
+    .osano-cm-button--type_denyAll { display: none; }
+    .osano-cm-button--type_manage { background-color: inherit; border: 1px inherit; font-weight: 200; }`)
   );
   document.head.appendChild(style);
 


### PR DESCRIPTION
## What

We are experimenting with the consent manager dialog (green light from Patsy). 
changes: 
- Hide `Reject all `cookies button
- Change UI for `Manage preferences` cookies button

Same changes have been already applied at `airbyte.com` and `cost.airbyte.io`

## How
Adding styles specific to Osano items.

<img width="1251" alt="Screen Shot 2022-10-28 at 10 36 10 AM" src="https://user-images.githubusercontent.com/45267095/198543972-c1d1ff0f-e4b9-4ca2-9622-6d002aba04b8.png">
