### PR TITLE
Fix ConfiguredCatalog for Resets

### DIFF
--- a/airbyte-persistence/job-persistence/src/test/java/io/airbyte/persistence/job/DefaultJobCreatorTest.java
+++ b/airbyte-persistence/job-persistence/src/test/java/io/airbyte/persistence/job/DefaultJobCreatorTest.java
@@ -114,11 +114,17 @@ class DefaultJobCreatorTest {
     final UUID operationId = UUID.randomUUID();
 
     final ConfiguredAirbyteStream stream1 = new ConfiguredAirbyteStream()
-        .withStream(CatalogHelpers.createAirbyteStream(STREAM1_NAME, Field.of(FIELD_NAME, JsonSchemaType.STRING)));
+        .withStream(CatalogHelpers.createAirbyteStream(STREAM1_NAME, Field.of(FIELD_NAME, JsonSchemaType.STRING)))
+        .withSyncMode(SyncMode.FULL_REFRESH)
+        .withDestinationSyncMode(DestinationSyncMode.APPEND);
     final ConfiguredAirbyteStream stream2 = new ConfiguredAirbyteStream()
-        .withStream(CatalogHelpers.createAirbyteStream(STREAM2_NAME, NAMESPACE, Field.of(FIELD_NAME, JsonSchemaType.STRING)));
+        .withStream(CatalogHelpers.createAirbyteStream(STREAM2_NAME, NAMESPACE, Field.of(FIELD_NAME, JsonSchemaType.STRING)))
+        .withSyncMode(SyncMode.INCREMENTAL)
+        .withDestinationSyncMode(DestinationSyncMode.APPEND);
     final ConfiguredAirbyteStream stream3 = new ConfiguredAirbyteStream()
-        .withStream(CatalogHelpers.createAirbyteStream(STREAM3_NAME, NAMESPACE, Field.of(FIELD_NAME, JsonSchemaType.STRING)));
+        .withStream(CatalogHelpers.createAirbyteStream(STREAM3_NAME, NAMESPACE, Field.of(FIELD_NAME, JsonSchemaType.STRING)))
+        .withSyncMode(SyncMode.FULL_REFRESH)
+        .withDestinationSyncMode(DestinationSyncMode.OVERWRITE);
     final ConfiguredAirbyteCatalog catalog = new ConfiguredAirbyteCatalog().withStreams(List.of(stream1, stream2, stream3));
 
     STANDARD_SYNC = new StandardSync()


### PR DESCRIPTION
## What
We are overriding configs for streams that should not be reset which can cause weird issue in some cases.

## How
We should only force (FULL_REFRESH,OVERWRITE) for the streams to reset. For the other streams, we only want to replace OVERWRITE with APPEND to avoid having destination clear the stream. The other cases should be left as is.
