### PR TITLE
add action for deploying oss connector catalog to GCS

### DIFF
--- a/.github/workflows/deploy-oss-catalog.yml
+++ b/.github/workflows/deploy-oss-catalog.yml
@@ -1,0 +1,33 @@
+name: Deploy OSS Connector Catalog to GCS
+
+on:
+  push:
+    branches:
+      - master
+    paths: 
+      - airbyte-config/init/src/main/resources/seed
+
+  workflow_dispatch:
+
+jobs:
+  deploy-catalog:
+    name: "Deploy Catalog"
+    if: github.ref == 'refs/heads/master'
+    runs-on: ubuntu-latest
+    concurrency: deploy-oss-connector-catalog
+    steps:
+      - name: Checkout Airbyte
+        uses: actions/checkout@v2
+      - name: Setup Cloud SDK
+        uses: google-github-actions/setup-gcloud@v0
+        with:
+          service_account_key: ${{ secrets.SOME_SECRET_WITH_KEY }} # TODO
+          export_default_credentials: true
+      - name: Generate catalog
+        run: SUB_BUILD=PLATFORM ./gradlew :airbyte-config:init:processResources
+      - name: Upload catalog to GCS
+        shell: bash
+        run: |
+          gcs_bucket_name="prod-airbyte-cloud-connector-metadata-service"
+          catalog_path="airbyte-config/init/src/main/resources/seed/oss_catalog.json"
+          gsutil -h "Cache-Control:public, max-age=10" cp "$catalog_path" "gs://$gcs_bucket_name/oss_catalog.json"

--- a/.github/workflows/deploy-oss-catalog.yml
+++ b/.github/workflows/deploy-oss-catalog.yml
@@ -21,7 +21,7 @@ jobs:
       - name: Setup Cloud SDK
         uses: google-github-actions/setup-gcloud@v0
         with:
-          service_account_key: ${{ secrets.SOME_SECRET_WITH_KEY }} # TODO
+          service_account_key: ${{ secrets.PROD_SPEC_CACHE_SA_KEY }}
           export_default_credentials: true
       - name: Generate catalog
         run: SUB_BUILD=PLATFORM ./gradlew :airbyte-config:init:processResources


### PR DESCRIPTION
## What

To be able to use the remote OSS catalog as a base, we need to upload it to GCS.

to merge after #18562 

close https://github.com/airbytehq/airbyte-cloud/issues/3164

## How

Create an action that will be auto triggered when a catalog change is merged to master. This action will generate the new oss_catalog.json and upload it to the GCS bucket.


