### PR TITLE
Corrected SSH to ssh in on-gcp-compute-engine.md

### DIFF
--- a/docs/deploying-airbyte/on-gcp-compute-engine.md
+++ b/docs/deploying-airbyte/on-gcp-compute-engine.md
@@ -44,7 +44,7 @@ gcloud --project $PROJECT_ID compute instances list
 5. Connect to your instance in your local terminal:
 
 ```bash
-gcloud --project=$PROJECT_ID beta compute SSH $INSTANCE_NAME
+gcloud --project=$PROJECT_ID beta compute ssh $INSTANCE_NAME
 ```
 
 6. Install Docker on your VM instance by following the below commands in your VM terminal:
@@ -81,7 +81,7 @@ To install and launch Airbyte:
 1. In your local terminal, connect to your Google Cloud instance:
 
 ```bash
-gcloud --project=$PROJECT_ID beta compute SSH $INSTANCE_NAME
+gcloud --project=$PROJECT_ID beta compute ssh $INSTANCE_NAME
 ```
 
 2. In your VM terminal, install Airbyte:
@@ -101,7 +101,7 @@ Warning: For security reasons, we strongly recommended not exposing Airbyte publ
 1. In your local terminal, create an SSH tunnel to connect the GCP instance to Airbyte:
 
 ```bash
-gcloud --project=$PROJECT_ID beta compute SSH $INSTANCE_NAME -- -L 8000:localhost:8000 -N -f
+gcloud --project=$PROJECT_ID beta compute ssh $INSTANCE_NAME -- -L 8000:localhost:8000 -N -f
 ```
 
 2. Verify the connection by visiting [http://localhost:8000](http://localhost:8000) in your browser.


### PR DESCRIPTION
All caps SSH throws an error from gcloud now. Changed to lowercase ssh.

## What

In glcoud examples, SSH is all-caps. This throws an error. Changing it to lowercase ssh works.

## How

Changed all occurrences of SSH within a gcloud call to ssh

## Recommended reading order

N/A

## 🚨 User Impact 🚨

None

## Pre-merge Checklist

N/A

### Community member or Airbyter

- [x] **Community member?** Grant edit access to maintainers ([instructions](https://docs.github.com/en/github/collaborating-with-pull-requests/working-with-forks/allowing-changes-to-a-pull-request-branch-created-from-a-fork#enabling-repository-maintainer-permissions-on-existing-pull-requests))

- [x] Documentation updated
 
- [x] PR name follows [PR naming conventions](https://docs.airbyte.com/contributing-to-airbyte/issues-and-pull-requests)

### Community member or Airbyter

- [x] Grant edit access to maintainers ([instructions](https://docs.github.com/en/github/collaborating-with-pull-requests/working-with-forks/allowing-changes-to-a-pull-request-branch-created-from-a-fork#enabling-repository-maintainer-permissions-on-existing-pull-requests))
- [ ] Secrets in the connector's spec are annotated with `airbyte_secret`
- [ ] Unit & integration tests added and passing. Community members, please provide proof of success locally e.g: screenshot or copy-paste unit, integration, and acceptance test output. To run acceptance tests for a Python connector, follow instructions in the README. For java connectors run `./gradlew :airbyte-integrations:connectors:<name>:integrationTest`.
- [ ] Code reviews completed
- [ ] Documentation updated
    - [ ] Connector's `README.md`
    - [ ] Connector's `bootstrap.md`. See [description and examples](https://docs.google.com/document/d/1ypdgmwmEHWv-TrO4_YOQ7pAJGVrMp5BOkEVh831N260/edit?usp=sharing)
    - [ ] Changelog updated in `docs/integrations/<source or destination>/<name>.md` including changelog. See changelog [example](https://docs.airbyte.io/integrations/sources/stripe#changelog)
- [ ] PR name follows [PR naming conventions](https://docs.airbyte.com/contributing-to-airbyte/issues-and-pull-requests)

### Airbyter

If this is a community PR, the Airbyte engineer reviewing this PR is responsible for the below items.

- [ ] Create a non-forked branch based on this PR and test the below items on it
- [ ] Build is successful
- [ ] If new credentials are required for use in CI, add them to GSM. [Instructions](https://docs.airbyte.io/connector-development#using-credentials-in-ci).
- [ ] [`/test connector=connectors/<name>` command](https://docs.airbyte.io/connector-development#updating-an-existing-connector) is passing
- [ ] New Connector version released on Dockerhub and connector version bumped by running the `/publish` command described [here](https://docs.airbyte.io/connector-development#updating-an-existing-connector)

</details>

<details><summary><strong>Connector Generator</strong></summary>

- [ ] Issue acceptance criteria met
- [ ] PR name follows [PR naming conventions](https://docs.airbyte.com/contributing-to-airbyte/issues-and-pull-requests)
- [ ] If adding a new generator, add it to the [list of scaffold modules being tested](https://github.com/airbytehq/airbyte/blob/master/airbyte-integrations/connector-templates/generator/build.gradle#L41)
- [ ] The generator test modules (all connectors with `-scaffold` in their name) have been updated with the latest scaffold by running `./gradlew :airbyte-integrations:connector-templates:generator:testScaffoldTemplates` then checking in your changes
- [ ] Documentation which references the generator is updated as needed

</details>

## Tests

<details><summary><strong>Unit</strong></summary>

*Put your unit tests output here.*

</details>

<details><summary><strong>Integration</strong></summary>

*Put your integration tests output here.*

</details>

<details><summary><strong>Acceptance</strong></summary>

*Put your acceptance tests output here.*

</details>
