### PR TITLE
Update AMI: ami-0d648081937c75a73 -> ami-06cf12549e3d9c522

### DIFF
--- a/.github/workflows/publish-connector-command.yml
+++ b/.github/workflows/publish-connector-command.yml
@@ -67,7 +67,7 @@ jobs:
 #          aws-secret-access-key: ${{ secrets.SELF_RUNNER_AWS_SECRET_ACCESS_KEY }}
 #          github-token: ${{ needs.find_valid_pat.outputs.pat }}
 #          # 80 gb disk
-#          ec2-image-id: ami-0d648081937c75a73
+#          ec2-image-id: ami-06cf12549e3d9c522
 #  bump-build-test-connector:
 #    needs: start-bump-build-test-connector-runner
 #    runs-on: ${{ needs.start-bump-build-test-connector-runner.outputs.label }}

--- a/.github/workflows/test-command.yml
+++ b/.github/workflows/test-command.yml
@@ -62,7 +62,7 @@ jobs:
           aws-secret-access-key: ${{ secrets.SELF_RUNNER_AWS_SECRET_ACCESS_KEY }}
           github-token: ${{ needs.find_valid_pat.outputs.pat }}
           # 80 gb disk
-          ec2-image-id: ami-0d648081937c75a73
+          ec2-image-id: ami-06cf12549e3d9c522
   integration-test:
     timeout-minutes: 240
     needs: start-test-runner

--- a/.github/workflows/test-performance-command.yml
+++ b/.github/workflows/test-performance-command.yml
@@ -65,7 +65,7 @@ jobs:
           aws-secret-access-key: ${{ secrets.SELF_RUNNER_AWS_SECRET_ACCESS_KEY }}
           github-token: ${{ needs.find_valid_pat.outputs.pat }}
           # 80 gb disk
-          ec2-image-id: ami-0d648081937c75a73
+          ec2-image-id: ami-06cf12549e3d9c522
   performance-test:
     timeout-minutes: 240
     needs: start-test-runner


### PR DESCRIPTION
Signed-off-by: Sergey Chvalyuk <grubberr@gmail.com>

## What
UPDATE AMI ami-0d648081937c75a73 -> ami-06cf12549e3d9c522

```
apt-get update
apt-get -y upgrade
apt-get clean
```

The main reason of this change is to update `docker.io` package:
`20.10.2-0ubuntu1~20.04.2 -> 20.10.12-0ubuntu2~20.04.1`

I have experienced problems with running`docker.io/library/mariadb:latest` container on old docker daemon

```
# docker run -t docker.io/library/mariadb:latest
2022-10-30 15:38:12+00:00 [Note] [Entrypoint]: Entrypoint script for MariaDB Server 1:10.9.3+maria~ubu2204 started.
2022-10-30 15:38:12+00:00 [ERROR] [Entrypoint]: mariadbd failed while attempting to check config
        command was: mariadbd --verbose --help --log-bin-index=/tmp/tmp.zvXK4QMLfA
        Can't initialize timers
```

**ERROR: Can't initialize timers**


After package upgrade:

```
# docker run -t docker.io/library/mariadb:latest                                          
2022-10-30 15:41:39+00:00 [Note] [Entrypoint]: Entrypoint script for MariaDB Server 1:10.9.3+maria~ubu2204 started.
2022-10-30 15:41:40+00:00 [Note] [Entrypoint]: Switching to dedicated user 'mysql'
2022-10-30 15:41:40+00:00 [Note] [Entrypoint]: Entrypoint script for MariaDB Server 1:10.9.3+maria~ubu2204 started.
2022-10-30 15:41:40+00:00 [ERROR] [Entrypoint]: Database is uninitialized and password option is not specified
        You need to specify one of MARIADB_ROOT_PASSWORD, MARIADB_ROOT_PASSWORD_HASH, MARIADB_ALLOW_EMPTY_ROOT_PASSWORD and MARIADB_RANDOM_ROOT_PASSWORD
```