### PR TITLE
Added a note about chained dbt transformations

### DIFF
--- a/docs/operator-guides/transformation-and-normalization/transformations-with-airbyte.md
+++ b/docs/operator-guides/transformation-and-normalization/transformations-with-airbyte.md
@@ -60,6 +60,19 @@ In Airbyte, I can use the git url as: `https://airbyteuser:ghp_***********ShLrG2
 
 ## How-to use custom dbt tips
 
+### Allows "chained" dbt transformations
+
+Since every transformation leave in his own Docker container, at this moment I can't rely on packages installed using `dbt deps` for the next transformations.
+According to the dbt documentation, I can configure the [packages folder](https://docs.getdbt.com/reference/project-configs/packages-install-path) outside of the container:
+
+```yaml
+# dbt_project.yml
+packages-install-path: '../dbt_packages'
+```
+
+> If I want to chain **dbt deps** and **dbt run**, I may use **[dbt build](https://docs.getdbt.com/reference/commands/build)** instead, which is not equivalent to the two previous commands, but will remove the need to alter the configuration of dbt.
+
+
 ### Refresh models partially
 
 Since I am using a mono-repo from my organization, other team members or departments may also contribute their dbt models to this centralized location. This will give us many dbt models and sources to build our complete data warehouse...


### PR DESCRIPTION
## What

We can't chain 2 dbt transformations, as every transformation is executed inside his own container.
Main issue with that: if you have packages and expect **dbt deps** + **dbt run** to works as 2 custom transformations.

## How

dbt allows configuring the path to packages, but the best you can do is probably to use **dbt build** instead.


## 🚨 User Impact 🚨

Fewer tears.

## Pre-merge Checklist

Nothing, it's documentation

### Community member or Airbyter

- [X] **Community member?** Grant edit access to maintainers ([instructions](https://docs.github.com/en/github/collaborating-with-pull-requests/working-with-forks/allowing-changes-to-a-pull-request-branch-created-from-a-fork#enabling-repository-maintainer-permissions-on-existing-pull-requests))
    - [X] `docs/operator-guides/transformation-and-normalization/transformations-with-airbyte.md`
- [X] PR name follows [PR naming conventions](https://docs.airbyte.com/contributing-to-airbyte/issues-and-pull-requests)

