### PR TITLE
🐛 Source Amplitude: fix empty `series` for `AverageSessionLength` stream

### DIFF
--- a/airbyte-config/init/src/main/resources/seed/source_definitions.yaml
+++ b/airbyte-config/init/src/main/resources/seed/source_definitions.yaml
@@ -63,7 +63,7 @@
 - name: Amplitude
   sourceDefinitionId: fa9f58c6-2d03-4237-aaa4-07d75e0c1396
   dockerRepository: airbyte/source-amplitude
-  dockerImageTag: 0.1.16
+  dockerImageTag: 0.1.17
   documentationUrl: https://docs.airbyte.com/integrations/sources/amplitude
   icon: amplitude.svg
   sourceType: api

--- a/airbyte-config/init/src/main/resources/seed/source_specs.yaml
+++ b/airbyte-config/init/src/main/resources/seed/source_specs.yaml
@@ -1140,7 +1140,7 @@
     supportsNormalization: false
     supportsDBT: false
     supported_destination_sync_modes: []
-- dockerImage: "airbyte/source-amplitude:0.1.16"
+- dockerImage: "airbyte/source-amplitude:0.1.17"
   spec:
     documentationUrl: "https://docs.airbyte.com/integrations/sources/amplitude"
     connectionSpecification:

--- a/airbyte-integrations/connectors/source-amplitude/Dockerfile
+++ b/airbyte-integrations/connectors/source-amplitude/Dockerfile
@@ -12,5 +12,5 @@ RUN pip install .
 ENV AIRBYTE_ENTRYPOINT "python /airbyte/integration_code/main.py"
 ENTRYPOINT ["python", "/airbyte/integration_code/main.py"]
 
-LABEL io.airbyte.version=0.1.16
+LABEL io.airbyte.version=0.1.17
 LABEL io.airbyte.name=airbyte/source-amplitude

--- a/airbyte-integrations/connectors/source-amplitude/README.md
+++ b/airbyte-integrations/connectors/source-amplitude/README.md
@@ -79,7 +79,7 @@ docker run --rm -v $(pwd)/secrets:/secrets -v $(pwd)/integration_tests:/integrat
 Make sure to familiarize yourself with [pytest test discovery](https://docs.pytest.org/en/latest/goodpractices.html#test-discovery) to know how your test files and methods should be named.
 First install test dependencies into your virtual environment:
 ```
-pip install .[tests]
+pip install '.[tests]'
 ```
 ### Unit Tests
 To run unit tests locally, from the connector directory run:

--- a/airbyte-integrations/connectors/source-amplitude/source_amplitude/api.py
+++ b/airbyte-integrations/connectors/source-amplitude/source_amplitude/api.py
@@ -252,9 +252,11 @@ class AverageSessionLength(IncrementalAmplitudeStream):
             # From the Amplitude documentation it follows that "series" is an array with one element which is itself
             # an array that contains the average session length for each day.
             # https://developers.amplitude.com/docs/dashboard-rest-api#returns-2
-            series = response_data["series"][0]
-            for i, date in enumerate(response_data["xValues"]):
-                yield {"date": date, "length": series[i]}
+            series = response_data.get("series", [])
+            if len(series) > 0:
+                series = series[0] # get the nested list
+                for i, date in enumerate(response_data["xValues"]):
+                    yield {"date": date, "length": series[i]}
 
     def path(self, **kwargs) -> str:
         return f"{self.api_version}/sessions/average"

--- a/airbyte-integrations/connectors/source-amplitude/source_amplitude/api.py
+++ b/airbyte-integrations/connectors/source-amplitude/source_amplitude/api.py
@@ -254,7 +254,7 @@ class AverageSessionLength(IncrementalAmplitudeStream):
             # https://developers.amplitude.com/docs/dashboard-rest-api#returns-2
             series = response_data.get("series", [])
             if len(series) > 0:
-                series = series[0] # get the nested list
+                series = series[0]  # get the nested list
                 for i, date in enumerate(response_data["xValues"]):
                     yield {"date": date, "length": series[i]}
 

--- a/airbyte-integrations/connectors/source-amplitude/unit_tests/test_api.py
+++ b/airbyte-integrations/connectors/source-amplitude/unit_tests/test_api.py
@@ -96,8 +96,19 @@ class TestIncrementalStreams:
                 },
                 [{"date": "2019-05-23", "length": 2}, {"date": "2019-05-24", "length": 6}],
             ),
+            (
+                AverageSessionLength,
+                {
+                    "xValues": ["2019-05-23", "2019-05-24"],
+                    "series": [],
+                    "seriesCollapsed": [[0]],
+                    "seriesLabels": [0],
+                    "seriesMeta": [{"segmentIndex": 0}],
+                },
+                [],
+            ),
         ],
-        ids=["ActiveUsers", "EmptyActiveUsers", "AverageSessionLength"],
+        ids=["ActiveUsers", "EmptyActiveUsers", "AverageSessionLength", "EmptyAverageSessionLength"],
     )
     def test_parse_response(self, requests_mock, stream_cls, data, expected):
         stream = stream_cls("2021-01-01T00:00:00Z")

--- a/docs/integrations/sources/amplitude.md
+++ b/docs/integrations/sources/amplitude.md
@@ -43,7 +43,8 @@ The Amplitude connector ideally should gracefully handle Amplitude API limitatio
 
 | Version | Date       | Pull Request                                             | Subject                                                                                         |
 |:--------|:-----------|:---------------------------------------------------------|:------------------------------------------------------------------------------------------------|
-| 0.1.16  | 2022-10-11 | [17854](https://github.com/airbytehq/airbyte/pull/17854) | Add empty `series` validation                                                                   |
+| 0.1.17  | 2022-10-31 | [18684](https://github.com/airbytehq/airbyte/pull/18684) | Add empty `series` validation for `AverageSessionLength` stream                               |
+| 0.1.16  | 2022-10-11 | [17854](https://github.com/airbytehq/airbyte/pull/17854) | Add empty `series` validation for `ActtiveUsers` steam                                        |
 | 0.1.15  | 2022-10-03 | [17320](https://github.com/airbytehq/airbyte/pull/17320) | Add validation `start_date` filed if it's in the future                                         |
 | 0.1.14  | 2022-09-28 | [17326](https://github.com/airbytehq/airbyte/pull/17326) | Migrate to per-stream states.                                                                   |
 | 0.1.13  | 2022-08-31 | [16185](https://github.com/airbytehq/airbyte/pull/16185) | Re-release on new `airbyte_cdk==0.1.81`                                                         |


### PR DESCRIPTION
## What
Resolving: https://github.com/airbytehq/oncall/issues/937

## How
- added additional length check for incoming `series` object from response
- added unit test to cover the case

## 🚨 User Impact 🚨
No impact is expected

## Pre-merge Checklist
Expand the relevant checklist and delete the others.

<details><summary><strong>Updating a connector</strong></summary>

### Community member or Airbyter

- [X] Unit & integration tests added and passing. Community members, please provide proof of success locally e.g: screenshot or copy-paste unit, integration, and acceptance test output. To run acceptance tests for a Python connector, follow instructions in the README. For java connectors run `./gradlew :airbyte-integrations:connectors:<name>:integrationTest`.
- [X] Code reviews completed
- [X] Documentation updated
    - [X] Connector's `README.md`
    - [X] Changelog updated in `docs/integrations/<source or destination>/<name>.md` including changelog. See changelog [example](https://docs.airbyte.io/integrations/sources/stripe#changelog)
- [X] PR name follows [PR naming conventions](https://docs.airbyte.com/contributing-to-airbyte/issues-and-pull-requests)

### Airbyter

If this is a community PR, the Airbyte engineer reviewing this PR is responsible for the below items.

- [ ] Create a non-forked branch based on this PR and test the below items on it
- [ ] Build is successful
- [ ] If new credentials are required for use in CI, add them to GSM. [Instructions](https://docs.airbyte.io/connector-development#using-credentials-in-ci).
- [ ] [`/test connector=connectors/<name>` command](https://docs.airbyte.io/connector-development#updating-an-existing-connector) is passing
- [ ] New Connector version released on Dockerhub and connector version bumped by running the `/publish` command described [here](https://docs.airbyte.io/connector-development#updating-an-existing-connector)

</details>