### PR TITLE
Improvements to master build fail/success alerts

### DIFF
--- a/.github/workflows/gradle.yml
+++ b/.github/workflows/gradle.yml
@@ -942,7 +942,7 @@ jobs:
       - kube-acceptance-test
       # Todo: Kyryl turn this on.
       # - helm-acceptance-test
-    if: success()
+    if: ${{ failure() && github.ref == 'refs/heads/master' }}
     steps:
       - name: Get Previous Workflow Status
         uses: Mercymeilya/last-workflow-status@v0.3


### PR DESCRIPTION
- Success should only run on master builds (see false positive [here](https://airbytehq-team.slack.com/archives/C03BEADRPNY/p1667239050989719))
- TODO: I believe `if: ${{ steps.last_status.outputs.last_status == 'failure' }}` would have to specifically get the last master build to check this correctly, not sure if it does
  - We might be able to separate this into a mini workflow that only runs on merge to master? E.g. by using fountainhead/action-wait-for-check to report the status

## What
*Describe what the change is solving*
*It helps to add screenshots if it affects the frontend.*

## How
*Describe the solution*
