### PR TITLE
add audit logging to the config db

### DIFF
--- a/airbyte-db/db-lib/src/main/java/io/airbyte/db/instance/configs/migrations/V0_40_17_001__AddAuditLog.java
+++ b/airbyte-db/db-lib/src/main/java/io/airbyte/db/instance/configs/migrations/V0_40_17_001__AddAuditLog.java
@@ -4,31 +4,24 @@
 
 package io.airbyte.db.instance.configs.migrations;
 
-import static org.jooq.impl.DSL.currentOffsetDateTime;
-import static org.jooq.impl.DSL.primaryKey;
-
 import io.airbyte.commons.resources.MoreResources;
 import java.io.IOException;
-import java.time.OffsetDateTime;
 import java.util.Set;
 import java.util.UUID;
 import org.flywaydb.core.api.migration.BaseJavaMigration;
 import org.flywaydb.core.api.migration.Context;
-import org.jooq.Catalog;
 import org.jooq.DSLContext;
-import org.jooq.EnumType;
 import org.jooq.Field;
-import org.jooq.JSONB;
-import org.jooq.Schema;
 import org.jooq.impl.DSL;
 import org.jooq.impl.SQLDataType;
-import org.jooq.impl.SchemaImpl;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 public class V0_40_17_001__AddAuditLog extends BaseJavaMigration {
+
   private static final UUID PLACEHOLDER_CREATED_BY = UUID.fromString("00000000-0000-0000-0000-000000000000");
-  private static final Field<UUID> DEFAULT_CREATED_BY_COLUMN = DSL.field("created_by", SQLDataType.UUID.nullable(false).defaultValue(PLACEHOLDER_CREATED_BY));
+  private static final Field<UUID> DEFAULT_CREATED_BY_COLUMN =
+      DSL.field("updated_by", SQLDataType.UUID.nullable(false).defaultValue(PLACEHOLDER_CREATED_BY));
 
   private static final Set<String> TABLE_TO_TRACK = Set.of(
       "actor_definition",
@@ -40,7 +33,7 @@ public class V0_40_17_001__AddAuditLog extends BaseJavaMigration {
       "stream_reset",
       "workspace",
       "workspace_service_account"
-//      "state" todo (cgardens) should we do this one too?
+  // "state" todo (cgardens) should we do this one too?
   );
 
   private static final Logger LOGGER = LoggerFactory.getLogger(V0_40_17_001__AddAuditLog.class);
@@ -58,7 +51,7 @@ public class V0_40_17_001__AddAuditLog extends BaseJavaMigration {
     createConfigEventTableAndFunctions(ctx);
 
     // add created_by to tables
-    for(final String tableName : TABLE_TO_TRACK) {
+    for (final String tableName : TABLE_TO_TRACK) {
       addCreatedByToTable(ctx, tableName);
       trackUpdatesToTable(ctx, tableName);
     }
@@ -70,12 +63,13 @@ public class V0_40_17_001__AddAuditLog extends BaseJavaMigration {
   }
 
   private static void addCreatedByToTable(final DSLContext ctx, final String tableName) {
-    ctx.alterTable(tableName).addColumn(DEFAULT_CREATED_BY_COLUMN);
-    LOGGER.info(String.format("created created_by column for %s table.", tableName));
+    ctx.alterTable(tableName).addColumn(DEFAULT_CREATED_BY_COLUMN).execute();
+    LOGGER.info(String.format("created updated_by column for %s table.", tableName));
   }
 
   private static void trackUpdatesToTable(final DSLContext ctx, final String tableName) {
-     ctx.execute(String.format("SELECT create_config_event_trigger('%s');", tableName));
+    ctx.execute(String.format("SELECT create_config_event_trigger('%s');", tableName));
     LOGGER.info(String.format("added event trigger for %s table.", tableName));
   }
+
 }

--- a/airbyte-db/db-lib/src/main/java/io/airbyte/db/instance/configs/migrations/V0_40_17_001__AddAuditLog.java
+++ b/airbyte-db/db-lib/src/main/java/io/airbyte/db/instance/configs/migrations/V0_40_17_001__AddAuditLog.java
@@ -1,0 +1,81 @@
+/*
+ * Copyright (c) 2022 Airbyte, Inc., all rights reserved.
+ */
+
+package io.airbyte.db.instance.configs.migrations;
+
+import static org.jooq.impl.DSL.currentOffsetDateTime;
+import static org.jooq.impl.DSL.primaryKey;
+
+import io.airbyte.commons.resources.MoreResources;
+import java.io.IOException;
+import java.time.OffsetDateTime;
+import java.util.Set;
+import java.util.UUID;
+import org.flywaydb.core.api.migration.BaseJavaMigration;
+import org.flywaydb.core.api.migration.Context;
+import org.jooq.Catalog;
+import org.jooq.DSLContext;
+import org.jooq.EnumType;
+import org.jooq.Field;
+import org.jooq.JSONB;
+import org.jooq.Schema;
+import org.jooq.impl.DSL;
+import org.jooq.impl.SQLDataType;
+import org.jooq.impl.SchemaImpl;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+public class V0_40_17_001__AddAuditLog extends BaseJavaMigration {
+  private static final UUID PLACEHOLDER_CREATED_BY = UUID.fromString("00000000-0000-0000-0000-000000000000");
+  private static final Field<UUID> DEFAULT_CREATED_BY_COLUMN = DSL.field("created_by", SQLDataType.UUID.nullable(false).defaultValue(PLACEHOLDER_CREATED_BY));
+
+  private static final Set<String> TABLE_TO_TRACK = Set.of(
+      "actor_definition",
+      "actor",
+      "actor_oauth_parameter",
+      "connection",
+      "connection_operation",
+      "operation",
+      "stream_reset",
+      "workspace",
+      "workspace_service_account"
+//      "state" todo (cgardens) should we do this one too?
+  );
+
+  private static final Logger LOGGER = LoggerFactory.getLogger(V0_40_17_001__AddAuditLog.class);
+
+  @Override
+  public void migrate(final Context context) throws Exception {
+    LOGGER.info("Running migration: {}", getClass().getSimpleName());
+
+    // Warning: please do not use any jOOQ generated code to write a migration.
+    // As database schema changes, the generated jOOQ code can be deprecated. So
+    // old migration may not compile if there is any generated code.
+    final DSLContext ctx = DSL.using(context.getConnection());
+
+    // set up functions
+    createConfigEventTableAndFunctions(ctx);
+
+    // add created_by to tables
+    for(final String tableName : TABLE_TO_TRACK) {
+      addCreatedByToTable(ctx, tableName);
+      trackUpdatesToTable(ctx, tableName);
+    }
+  }
+
+  private static void createConfigEventTableAndFunctions(final DSLContext ctx) throws IOException {
+    ctx.execute(MoreResources.readResource("sql_functions_and_triggers/config_events.sql"));
+    LOGGER.info("created config_event table and config event functions and triggers");
+  }
+
+  private static void addCreatedByToTable(final DSLContext ctx, final String tableName) {
+    ctx.alterTable(tableName).addColumn(DEFAULT_CREATED_BY_COLUMN);
+    LOGGER.info(String.format("created created_by column for %s table.", tableName));
+  }
+
+  private static void trackUpdatesToTable(final DSLContext ctx, final String tableName) {
+     ctx.execute(String.format("SELECT create_config_event_trigger('%s');", tableName));
+    LOGGER.info(String.format("added event trigger for %s table.", tableName));
+  }
+}

--- a/airbyte-db/db-lib/src/main/resources/configs_database/schema_dump.txt
+++ b/airbyte-db/db-lib/src/main/resources/configs_database/schema_dump.txt
@@ -86,6 +86,17 @@ create table "public"."airbyte_configs_migrations"(
   constraint "airbyte_configs_migrations_pk"
     primary key ("installed_rank")
 );
+create table "public"."config_event"(
+  "id" uuid not null default null,
+  "operation_type" any null,
+  "config_type" varchar(256) not null,
+  "config_id" uuid not null,
+  "result" jsonb null,
+  "created_at" timestamptz(35) not null default null,
+  "created_by" uuid null,
+  constraint "config_event_pkey"
+    primary key ("id")
+);
 create table "public"."connection"(
   "id" uuid not null,
   "namespace_definition" namespace_definition_type not null,
@@ -273,6 +284,12 @@ create index "actor_oauth_parameter_workspace_definition_idx" on "public"."actor
 );
 create unique index "airbyte_configs_migrations_pk" on "public"."airbyte_configs_migrations"("installed_rank" asc);
 create index "airbyte_configs_migrations_s_idx" on "public"."airbyte_configs_migrations"("success" asc);
+create unique index "config_event_pkey" on "public"."config_event"("id" asc);
+create index "config_id_idx" on "public"."config_event"("config_id" asc);
+create index "config_type_and_id_idx" on "public"."config_event"(
+  "config_type" asc,
+  "config_id" asc
+);
 create index "connection_destination_id_idx" on "public"."connection"("destination_id" asc);
 create unique index "connection_pkey" on "public"."connection"("id" asc);
 create index "connection_source_id_idx" on "public"."connection"("source_id" asc);

--- a/airbyte-db/db-lib/src/main/resources/sql_functions_and_triggers/config_events.sql
+++ b/airbyte-db/db-lib/src/main/resources/sql_functions_and_triggers/config_events.sql
@@ -12,16 +12,21 @@ usage: to add this tracking ability to a table:
 -- #1 - create config_event table
 CREATE EXTENSION IF NOT EXISTS "uuid-ossp";
 
+CREATE TYPE operation_type AS ENUM ('insert', 'update', 'delete');
+
 CREATE TABLE IF NOT EXISTS config_event
 (
     "id"             uuid PRIMARY KEY         DEFAULT uuid_generate_v4(),
     "operation_type" operation_type  NOT NULL,
-    "config_type"    config_type     NOT NULL,
+    "config_type"    varchar(256)    NOT NULL,
     "config_id"      uuid            NOT NULL,
     "result"         jsonb           NULL,
-    "created_at"     timestamptz(35) NOT NULL DEFAULT NULL,
+    "created_at"     timestamptz(35) NOT NULL DEFAULT CURRENT_TIMESTAMP,
     "created_by"     uuid            NULL
 );
+
+CREATE INDEX config_id_idx ON config_event (config_id);
+CREATE INDEX config_type_and_id_idx ON config_event (config_type, config_id);
 
 -- #2 - declare function that saves copy of the record after it is modified.
 -- WARNING: target table must define the following 2 columns: id (uuid, non-nullable) and updated_by (uuid, nullable)
@@ -29,7 +34,7 @@ CREATE OR REPLACE FUNCTION process_config_event() RETURNS TRIGGER AS
 $$
 DECLARE
     -- functions used in triggers cannot take arguments in the traditional way. they can be passed in via TG_ARGS though.
-    configtype config_type;
+    configtype varchar(256);
 BEGIN
     configtype := TG_ARGV[0];
     /*
@@ -38,15 +43,15 @@ BEGIN
     IF (TG_OP = 'DELETE') THEN
         -- note: for deletes, we cannot track how did the delete.
         INSERT INTO config_event (operation_type, config_type, config_id, result, created_at, created_by)
-        VALUES ('delete', configtype, OLD.id, null, now(), null);
+        VALUES ('delete', configtype, OLD.id, NULL, NOW(), NULL);
         RETURN OLD;
     ELSIF (TG_OP = 'UPDATE') THEN
         INSERT INTO config_event (operation_type, config_type, config_id, result, created_at, created_by)
-        VALUES ('update', configtype, NEW.id, to_jsonb(NEW), now(), NEW.updated_by);
+        VALUES ('update', configtype, NEW.id, to_jsonb(NEW), NOW(), NEW.updated_by);
         RETURN NEW;
     ELSIF (TG_OP = 'INSERT') THEN
         INSERT INTO config_event (operation_type, config_type, config_id, result, created_at, created_by)
-        VALUES ('insert', configtype, NEW.id, to_jsonb(NEW), now(), NEW.updated_by);
+        VALUES ('insert', configtype, NEW.id, to_jsonb(NEW), NOW(), NEW.updated_by);
         RETURN NEW;
     END IF;
     RETURN NULL; -- result is ignored since this is an AFTER trigger

--- a/airbyte-db/db-lib/src/main/resources/sql_functions_and_triggers/config_events.sql
+++ b/airbyte-db/db-lib/src/main/resources/sql_functions_and_triggers/config_events.sql
@@ -1,0 +1,61 @@
+-- the goal of this script is to be able to track each change event for a target table. it achieves this by doing a few things:
+-- 1. created a config_event table, where all of the tracked events are stored.
+-- 2. defines a generic psql function that saves a copy of the record AFTER the event is completed. This function can be called on any table that has the following 2 columns: id (uuid, non-nullable) and updated_by (uuid, nullable)
+-- 3. defines a psql function that takes in a table name as an argument and creates a trigger on that table that calls the function defined #2 on insert, updated, or delete.
+
+-- usage: to add this tracking ability to a table:
+-- SELECT create_event_trigger('<table name>');
+-- SELECT create_event_trigger('actor');
+
+-- #1 - create config_event table
+CREATE EXTENSION IF NOT EXISTS "uuid-ossp";
+
+CREATE TABLE IF NOT EXISTS config_event(
+    "id" uuid PRIMARY KEY DEFAULT uuid_generate_v4(),
+    "operation_type" operation_type NOT NULL,
+    "config_type" config_type NOT NULL,
+    "config_id" uuid NOT NULL,
+    "result" jsonb NULL,
+    "created_at" timestamptz(35) NOT NULL DEFAULT NULL,
+    "created_by" uuid NULL
+);
+
+-- #2 - declare function that saves copy of the record after it is modified.
+-- WARNING: target table must define the following 2 columns: id (uuid, non-nullable) and updated_by (uuid, nullable)
+CREATE OR REPLACE FUNCTION process_config_event() RETURNS TRIGGER AS $$
+DECLARE
+    configtype config_type;
+BEGIN
+    configtype := TG_ARGV[0];
+    --
+    -- Create a row in emp_audit to reflect the operation performed on emp,
+    -- make use of the special variable TG_OP to work out the operation.
+    --
+    IF (TG_OP = 'DELETE') THEN
+        -- note: for deletes, we cannot track how did the delete.
+        INSERT INTO config_event (operation_type, config_type, config_id, result, created_at, created_by) VALUES ('delete', configtype, OLD.id, null, now(), null);
+        RETURN OLD;
+    ELSIF (TG_OP = 'UPDATE') THEN
+        INSERT INTO config_event (operation_type, config_type, config_id, result, created_at, created_by) VALUES ('update', configtype, NEW.id, to_jsonb(NEW), now(), NEW.updated_by);
+        RETURN NEW;
+    ELSIF (TG_OP = 'INSERT') THEN
+        INSERT INTO config_event (operation_type, config_type, config_id, result, created_at, created_by) VALUES ('insert', configtype, NEW.id, to_jsonb(NEW), now(), NEW.updated_by);
+        RETURN NEW;
+    END IF;
+    RETURN NULL; -- result is ignored since this is an AFTER trigger
+END;
+$$ LANGUAGE plpgsql;
+
+-- #3 -- declare function that creates a config event trigger for a given table. takes table name as an argument.
+CREATE OR REPLACE FUNCTION create_config_event_trigger(text)
+    RETURNS void AS $$
+BEGIN
+-- psql does not allow interpolation in trigger creation, so need to trick it by creating the desired string with
+-- interpolation and then calling EXECUTE. See in comment below the command transcribed in vanilla SQL.
+    EXECUTE(FORMAT('CREATE TRIGGER config_event_trigger AFTER INSERT OR UPDATE OR DELETE ON %s FOR EACH ROW EXECUTE PROCEDURE process_config_event(%s);', $1, $1));
+--     CREATE TRIGGER set_updated_at
+--     BEFORE UPDATE ON <tablename>
+--     FOR EACH ROW
+--     EXECUTE PROCEDURE updated_at_timestamp_trigger_function();
+END;
+$$ LANGUAGE plpgsql;

--- a/airbyte-db/db-lib/src/main/resources/sql_functions_and_triggers/config_events.sql
+++ b/airbyte-db/db-lib/src/main/resources/sql_functions_and_triggers/config_events.sql
@@ -1,45 +1,52 @@
--- the goal of this script is to be able to track each change event for a target table. it achieves this by doing a few things:
--- 1. created a config_event table, where all of the tracked events are stored.
--- 2. defines a generic psql function that saves a copy of the record AFTER the event is completed. This function can be called on any table that has the following 2 columns: id (uuid, non-nullable) and updated_by (uuid, nullable)
--- 3. defines a psql function that takes in a table name as an argument and creates a trigger on that table that calls the function defined #2 on insert, updated, or delete.
+/*
+the goal of this script is to be able to track each change event for a target table. it achieves this by doing a few things:
+1. created a config_event table, where all of the tracked events are stored.
+2. defines a generic psql function that saves a copy of the record AFTER the event is completed. This function can be called on any table that has the following 2 columns: id (uuid, non-nullable) and updated_by (uuid, nullable)
+3. defines a psql function that takes in a table name as an argument and creates a trigger on that table that calls the function defined #2 on insert, updated, or delete.
 
--- usage: to add this tracking ability to a table:
--- SELECT create_event_trigger('<table name>');
--- SELECT create_event_trigger('actor');
+usage: to add this tracking ability to a table:
+`SELECT create_event_trigger('<table name>');`
+`SELECT create_event_trigger('actor');`
+*/
 
 -- #1 - create config_event table
 CREATE EXTENSION IF NOT EXISTS "uuid-ossp";
 
-CREATE TABLE IF NOT EXISTS config_event(
-    "id" uuid PRIMARY KEY DEFAULT uuid_generate_v4(),
-    "operation_type" operation_type NOT NULL,
-    "config_type" config_type NOT NULL,
-    "config_id" uuid NOT NULL,
-    "result" jsonb NULL,
-    "created_at" timestamptz(35) NOT NULL DEFAULT NULL,
-    "created_by" uuid NULL
+CREATE TABLE IF NOT EXISTS config_event
+(
+    "id"             uuid PRIMARY KEY         DEFAULT uuid_generate_v4(),
+    "operation_type" operation_type  NOT NULL,
+    "config_type"    config_type     NOT NULL,
+    "config_id"      uuid            NOT NULL,
+    "result"         jsonb           NULL,
+    "created_at"     timestamptz(35) NOT NULL DEFAULT NULL,
+    "created_by"     uuid            NULL
 );
 
 -- #2 - declare function that saves copy of the record after it is modified.
 -- WARNING: target table must define the following 2 columns: id (uuid, non-nullable) and updated_by (uuid, nullable)
-CREATE OR REPLACE FUNCTION process_config_event() RETURNS TRIGGER AS $$
+CREATE OR REPLACE FUNCTION process_config_event() RETURNS TRIGGER AS
+$$
 DECLARE
+    -- functions used in triggers cannot take arguments in the traditional way. they can be passed in via TG_ARGS though.
     configtype config_type;
 BEGIN
     configtype := TG_ARGV[0];
-    --
-    -- Create a row in emp_audit to reflect the operation performed on emp,
-    -- make use of the special variable TG_OP to work out the operation.
-    --
+    /*
+    Create a row in config_event to reflect the operation performed on the target table. Make use of the special variable TG_OP to work out the operation.
+    */
     IF (TG_OP = 'DELETE') THEN
         -- note: for deletes, we cannot track how did the delete.
-        INSERT INTO config_event (operation_type, config_type, config_id, result, created_at, created_by) VALUES ('delete', configtype, OLD.id, null, now(), null);
+        INSERT INTO config_event (operation_type, config_type, config_id, result, created_at, created_by)
+        VALUES ('delete', configtype, OLD.id, null, now(), null);
         RETURN OLD;
     ELSIF (TG_OP = 'UPDATE') THEN
-        INSERT INTO config_event (operation_type, config_type, config_id, result, created_at, created_by) VALUES ('update', configtype, NEW.id, to_jsonb(NEW), now(), NEW.updated_by);
+        INSERT INTO config_event (operation_type, config_type, config_id, result, created_at, created_by)
+        VALUES ('update', configtype, NEW.id, to_jsonb(NEW), now(), NEW.updated_by);
         RETURN NEW;
     ELSIF (TG_OP = 'INSERT') THEN
-        INSERT INTO config_event (operation_type, config_type, config_id, result, created_at, created_by) VALUES ('insert', configtype, NEW.id, to_jsonb(NEW), now(), NEW.updated_by);
+        INSERT INTO config_event (operation_type, config_type, config_id, result, created_at, created_by)
+        VALUES ('insert', configtype, NEW.id, to_jsonb(NEW), now(), NEW.updated_by);
         RETURN NEW;
     END IF;
     RETURN NULL; -- result is ignored since this is an AFTER trigger
@@ -48,14 +55,20 @@ $$ LANGUAGE plpgsql;
 
 -- #3 -- declare function that creates a config event trigger for a given table. takes table name as an argument.
 CREATE OR REPLACE FUNCTION create_config_event_trigger(text)
-    RETURNS void AS $$
+    RETURNS void AS
+$$
 BEGIN
--- psql does not allow interpolation in trigger creation, so need to trick it by creating the desired string with
--- interpolation and then calling EXECUTE. See in comment below the command transcribed in vanilla SQL.
-    EXECUTE(FORMAT('CREATE TRIGGER config_event_trigger AFTER INSERT OR UPDATE OR DELETE ON %s FOR EACH ROW EXECUTE PROCEDURE process_config_event(%s);', $1, $1));
---     CREATE TRIGGER set_updated_at
---     BEFORE UPDATE ON <tablename>
---     FOR EACH ROW
---     EXECUTE PROCEDURE updated_at_timestamp_trigger_function();
+    /*
+    psql does not allow interpolation in trigger creation, so need to trick it by creating the desired string with interpolation and then calling EXECUTE. See in comment below the command transcribed in vanilla SQL. The statement below is the equivalent of
+
+    CREATE TRIGGER set_updated_at
+    BEFORE UPDATE ON <tablename>
+    FOR EACH ROW
+    EXECUTE PROCEDURE updated_at_timestamp_trigger_function();
+    */
+    EXECUTE (FORMAT(
+            'CREATE TRIGGER config_event_trigger AFTER INSERT OR UPDATE OR DELETE ON %s FOR EACH ROW EXECUTE PROCEDURE process_config_event(%s);',
+            $1,
+            $1));
 END;
 $$ LANGUAGE plpgsql;

--- a/build.gradle
+++ b/build.gradle
@@ -124,6 +124,7 @@ def createSpotlessTarget = { pattern ->
             'airbyte-integrations/connectors/source-amplitude/unit_tests/api_data/zipped.json', // Zipped file presents as non-UTF-8 making spotless sad
             'airbyte-webapp', // The webapp module uses its own auto-formatter, so spotless is not necessary here
             'airbyte-webapp-e2e-tests', // This module also uses its own auto-formatter
+            'config_events.sql', // The SQL formatter makes this file unreadable.
     ]
 
     if (System.getenv().containsKey("SUB_BUILD")) {


### PR DESCRIPTION
Closes https://github.com/airbytehq/airbyte-internal-issues/issues/1098
Related to epic: https://github.com/airbytehq/airbyte/issues/8120

## What
* Track changes to configuration tables. We want to WHAT & WHEN each change was and WHO did it.
* Thought this would be fun for hack dayz... nothing better than writing complex SQL functions. 😂 

## How
* Use SQL triggers
* Specifically create a "generic" psql function that can be reused for any config table we want to track changes on (as lon gas it meets the prescribed pattern).
* Adding a new table to be tracked should be as easy as: `SELECT create_config_event_trigger(<table name>)` (as long as it already has the following columns:id - uuid and updated_by - uuid ).
* Add relevant existing tables to use it

## Recommended reading order
1. `config.events.sql`
2. `V0_40_17_001__AddAuditLog.java`
3. the rest...