### PR TITLE
Remove ConfigPersistence usage from SecretsMigrator

### DIFF
--- a/airbyte-bootloader/src/main/java/io/airbyte/bootloader/BootloaderApp.java
+++ b/airbyte-bootloader/src/main/java/io/airbyte/bootloader/BootloaderApp.java
@@ -17,11 +17,15 @@ import io.airbyte.config.StandardWorkspace;
 import io.airbyte.config.init.ApplyDefinitionsHelper;
 import io.airbyte.config.init.DefinitionsProvider;
 import io.airbyte.config.init.LocalDefinitionsProvider;
+import io.airbyte.config.persistence.ConfigNotFoundException;
 import io.airbyte.config.persistence.ConfigPersistence;
 import io.airbyte.config.persistence.ConfigRepository;
 import io.airbyte.config.persistence.DatabaseConfigPersistence;
+import io.airbyte.config.persistence.SecretsRepositoryReader;
+import io.airbyte.config.persistence.SecretsRepositoryWriter;
 import io.airbyte.config.persistence.split_secrets.JsonSecretsProcessor;
 import io.airbyte.config.persistence.split_secrets.SecretPersistence;
+import io.airbyte.config.persistence.split_secrets.SecretsHydrator;
 import io.airbyte.db.Database;
 import io.airbyte.db.factory.DSLContextFactory;
 import io.airbyte.db.factory.DataSourceFactory;
@@ -68,7 +72,7 @@ public class BootloaderApp {
   private final Runnable postLoadExecution;
   private final FeatureFlags featureFlags;
   private final SecretMigrator secretMigrator;
-  private ConfigPersistence configPersistence;
+  private ConfigRepository configRepository;
   private DefinitionsProvider localDefinitionsProvider;
   private Database configDatabase;
   private Database jobDatabase;
@@ -128,9 +132,6 @@ public class BootloaderApp {
 
     postLoadExecution = () -> {
       try {
-        final ConfigRepository configRepository =
-            new ConfigRepository(configPersistence, configDatabase);
-
         final ApplyDefinitionsHelper applyDefinitionsHelper = new ApplyDefinitionsHelper(configRepository, localDefinitionsProvider);
         applyDefinitionsHelper.apply();
 
@@ -141,7 +142,7 @@ public class BootloaderApp {
           }
         }
         LOGGER.info("Loaded seed data..");
-      } catch (final IOException | JsonValidationException e) {
+      } catch (final IOException | JsonValidationException | ConfigNotFoundException e) {
         throw new RuntimeException(e);
       }
     };
@@ -172,9 +173,6 @@ public class BootloaderApp {
 
     runFlywayMigration(configs, configDbMigrator, jobDbMigrator);
     LOGGER.info("Ran Flyway migrations.");
-
-    final ConfigRepository configRepository =
-        new ConfigRepository(configPersistence, configDatabase);
 
     createWorkspaceIfNoneExists(configRepository);
     LOGGER.info("Default workspace created.");
@@ -219,7 +217,7 @@ public class BootloaderApp {
   private void initPersistences(final DSLContext configsDslContext, final DSLContext jobsDslContext) {
     try {
       configDatabase = getConfigDatabase(configsDslContext);
-      configPersistence = getConfigPersistence(configDatabase);
+      configRepository = new ConfigRepository(getConfigPersistence(configDatabase), configDatabase);
       localDefinitionsProvider = getLocalDefinitionsProvider();
       jobDatabase = getJobDatabase(jobsDslContext);
       jobPersistence = getJobPersistence(jobDatabase);
@@ -244,10 +242,17 @@ public class BootloaderApp {
       // TODO Will be converted to an injected singleton during DI migration
       final Database configDatabase = getConfigDatabase(configsDslContext);
       final ConfigPersistence configPersistence = getConfigPersistence(configDatabase);
+      final ConfigRepository configRepository = new ConfigRepository(configPersistence, configDatabase);
       final Database jobDatabase = getJobDatabase(jobsDslContext);
       final JobPersistence jobPersistence = getJobPersistence(jobDatabase);
+
+      final SecretsHydrator secretsHydrator = SecretPersistence.getSecretsHydrator(configsDslContext, configs);
+      final Optional<SecretPersistence> secretPersistence = SecretPersistence.getLongLived(configsDslContext, configs);
+      final SecretsRepositoryReader secretsRepositoryReader = new SecretsRepositoryReader(configRepository, secretsHydrator);
+      final SecretsRepositoryWriter secretsRepositoryWriter = new SecretsRepositoryWriter(configRepository, secretPersistence, Optional.empty());
+
       final SecretMigrator secretMigrator =
-          new SecretMigrator(configPersistence, jobPersistence, SecretPersistence.getLongLived(configsDslContext, configs));
+          new SecretMigrator(secretsRepositoryReader, secretsRepositoryWriter, configRepository, jobPersistence, secretPersistence);
       final Flyway configsFlyway = FlywayFactory.create(configsDataSource, BootloaderApp.class.getSimpleName(), ConfigsDatabaseMigrator.DB_IDENTIFIER,
           ConfigsDatabaseMigrator.MIGRATION_FILE_LOCATION);
       final Flyway jobsFlyway = FlywayFactory.create(jobsDataSource, BootloaderApp.class.getSimpleName(), JobsDatabaseMigrator.DB_IDENTIFIER,

--- a/airbyte-bootloader/src/main/java/io/airbyte/bootloader/SecretMigrator.java
+++ b/airbyte-bootloader/src/main/java/io/airbyte/bootloader/SecretMigrator.java
@@ -4,30 +4,27 @@
 
 package io.airbyte.bootloader;
 
-import static io.airbyte.config.persistence.split_secrets.SecretsHelpers.COORDINATE_FIELD;
-
 import com.fasterxml.jackson.databind.JsonNode;
 import com.google.common.annotations.VisibleForTesting;
-import io.airbyte.commons.json.JsonPaths;
 import io.airbyte.commons.json.Jsons;
-import io.airbyte.config.ConfigSchema;
 import io.airbyte.config.DestinationConnection;
 import io.airbyte.config.SourceConnection;
 import io.airbyte.config.StandardDestinationDefinition;
 import io.airbyte.config.StandardSourceDefinition;
-import io.airbyte.config.persistence.ConfigPersistence;
-import io.airbyte.config.persistence.split_secrets.SecretCoordinate;
+import io.airbyte.config.persistence.ConfigNotFoundException;
+import io.airbyte.config.persistence.ConfigRepository;
+import io.airbyte.config.persistence.SecretsRepositoryReader;
+import io.airbyte.config.persistence.SecretsRepositoryWriter;
 import io.airbyte.config.persistence.split_secrets.SecretPersistence;
-import io.airbyte.config.persistence.split_secrets.SecretsHelpers;
 import io.airbyte.persistence.job.JobPersistence;
+import io.airbyte.protocol.models.ConnectorSpecification;
 import io.airbyte.validation.json.JsonValidationException;
 import java.io.IOException;
+import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
 import java.util.UUID;
-import java.util.concurrent.atomic.AtomicReference;
-import java.util.function.Supplier;
 import java.util.stream.Collectors;
 import lombok.AllArgsConstructor;
 import lombok.Value;
@@ -37,7 +34,9 @@ import lombok.extern.slf4j.Slf4j;
 @Slf4j
 public class SecretMigrator {
 
-  private final ConfigPersistence configPersistence;
+  private final SecretsRepositoryReader secretsReader;
+  private final SecretsRepositoryWriter secretsWriter;
+  private final ConfigRepository configRepository;
   private final JobPersistence jobPersistence;
   private final Optional<SecretPersistence> secretPersistence;
 
@@ -55,34 +54,39 @@ public class SecretMigrator {
    * Then for all the secret that are stored in a plain text format, it will save the plain text in
    * the secret manager and store the coordinate in the config DB.
    */
-  public void migrateSecrets() throws JsonValidationException, IOException {
+  public void migrateSecrets() throws JsonValidationException, IOException, ConfigNotFoundException {
     if (secretPersistence.isEmpty()) {
       log.info("No secret persistence is provided, the migration won't be run ");
 
       return;
     }
-    final List<StandardSourceDefinition> standardSourceDefinitions =
-        configPersistence.listConfigs(ConfigSchema.STANDARD_SOURCE_DEFINITION, StandardSourceDefinition.class);
+    final List<StandardSourceDefinition> standardSourceDefinitions = configRepository.listStandardSourceDefinitions(true);
 
-    final Map<UUID, JsonNode> definitionIdToSourceSpecs = standardSourceDefinitions
-        .stream().collect(Collectors.toMap(StandardSourceDefinition::getSourceDefinitionId,
-            def -> def.getSpec().getConnectionSpecification()));
+    final Map<UUID, ConnectorSpecification> definitionIdToSourceSpecs = standardSourceDefinitions
+        .stream().collect(Collectors.toMap(StandardSourceDefinition::getSourceDefinitionId, StandardSourceDefinition::getSpec));
 
-    final List<SourceConnection> sources = configPersistence.listConfigs(ConfigSchema.SOURCE_CONNECTION, SourceConnection.class);
+    final List<SourceConnection> sourcesWithoutSecrets = configRepository.listSourceConnection();
+    final List<SourceConnection> sourcesWithSecrets = new ArrayList<>();
+    for (final SourceConnection source : sourcesWithoutSecrets) {
+      final SourceConnection sourceWithSecrets = secretsReader.getSourceConnectionWithSecrets(source.getSourceId());
+      sourcesWithSecrets.add(sourceWithSecrets);
+    }
 
-    migrateSources(sources, definitionIdToSourceSpecs);
+    migrateSources(sourcesWithSecrets, definitionIdToSourceSpecs);
 
-    final List<StandardDestinationDefinition> standardDestinationDefinitions =
-        configPersistence.listConfigs(ConfigSchema.STANDARD_DESTINATION_DEFINITION,
-            StandardDestinationDefinition.class);
+    final List<StandardDestinationDefinition> standardDestinationDefinitions = configRepository.listStandardDestinationDefinitions(true);
 
-    final Map<UUID, JsonNode> definitionIdToDestinationSpecs = standardDestinationDefinitions.stream()
-        .collect(Collectors.toMap(StandardDestinationDefinition::getDestinationDefinitionId,
-            def -> def.getSpec().getConnectionSpecification()));
+    final Map<UUID, ConnectorSpecification> definitionIdToDestinationSpecs = standardDestinationDefinitions.stream()
+        .collect(Collectors.toMap(StandardDestinationDefinition::getDestinationDefinitionId, StandardDestinationDefinition::getSpec));
 
-    final List<DestinationConnection> destinations = configPersistence.listConfigs(ConfigSchema.DESTINATION_CONNECTION, DestinationConnection.class);
+    final List<DestinationConnection> destinationsWithoutSecrets = configRepository.listDestinationConnection();
+    final List<DestinationConnection> destinationsWithSecrets = new ArrayList<>();
+    for (final DestinationConnection destination : destinationsWithoutSecrets) {
+      final DestinationConnection destinationWithoutSecrets = secretsReader.getDestinationConnectionWithSecrets(destination.getDestinationId());
+      destinationsWithSecrets.add(destinationWithoutSecrets);
+    }
 
-    migrateDestinations(destinations, definitionIdToDestinationSpecs);
+    migrateDestinations(destinationsWithSecrets, definitionIdToDestinationSpecs);
 
     jobPersistence.setSecretMigrationDone();
   }
@@ -91,23 +95,21 @@ public class SecretMigrator {
    * This is migrating the secrets for the source actors
    */
   @VisibleForTesting
-  void migrateSources(final List<SourceConnection> sources, final Map<UUID, JsonNode> definitionIdToSourceSpecs)
+  void migrateSources(final List<SourceConnection> sources, final Map<UUID, ConnectorSpecification> definitionIdToSourceSpecs)
       throws JsonValidationException, IOException {
     log.info("Migrating Sources");
-    final List<SourceConnection> sourceConnections = sources.stream()
-        .map(source -> {
-          final JsonNode migratedConfig = migrateConfiguration(new ConnectorConfiguration(
-              source.getWorkspaceId(),
-              source.getConfiguration(),
-              definitionIdToSourceSpecs.get(source.getSourceDefinitionId())),
-              () -> UUID.randomUUID());
-          source.setConfiguration(migratedConfig);
-          return source;
-        })
-        .toList();
+    for (final SourceConnection source : sources) {
+      final Optional<ConnectorSpecification> specOptional = Optional.ofNullable(definitionIdToSourceSpecs.get(source.getSourceDefinitionId()));
 
-    for (final SourceConnection source : sourceConnections) {
-      configPersistence.writeConfig(ConfigSchema.SOURCE_CONNECTION, source.getSourceId().toString(), source);
+      if (specOptional.isPresent()) {
+        secretsWriter.writeSourceConnection(source, specOptional.get());
+      } else {
+        // if the spec can't be found, don't risk writing secrets to db. wipe out the configuration for the
+        // connector.
+        final SourceConnection sourceWithConfigRemoved = Jsons.clone(source);
+        sourceWithConfigRemoved.setConfiguration(Jsons.emptyObject());
+        secretsWriter.writeSourceConnection(sourceWithConfigRemoved, new ConnectorSpecification().withConnectionSpecification(Jsons.emptyObject()));
+      }
     }
   }
 
@@ -115,96 +117,24 @@ public class SecretMigrator {
    * This is migrating the secrets for the destination actors
    */
   @VisibleForTesting
-  void migrateDestinations(final List<DestinationConnection> destinations, final Map<UUID, JsonNode> definitionIdToDestinationSpecs)
+  void migrateDestinations(final List<DestinationConnection> destinations, final Map<UUID, ConnectorSpecification> definitionIdToDestinationSpecs)
       throws JsonValidationException, IOException {
     log.info("Migration Destinations");
+    for (final DestinationConnection destination : destinations) {
+      final Optional<ConnectorSpecification> specOptional =
+          Optional.ofNullable(definitionIdToDestinationSpecs.get(destination.getDestinationDefinitionId()));
 
-    final List<DestinationConnection> destinationConnections = destinations.stream().map(destination -> {
-      final JsonNode migratedConfig = migrateConfiguration(new ConnectorConfiguration(
-          destination.getWorkspaceId(),
-          destination.getConfiguration(),
-          definitionIdToDestinationSpecs.get(destination.getDestinationDefinitionId())),
-          () -> UUID.randomUUID());
-      destination.setConfiguration(migratedConfig);
-      return destination;
-    })
-        .toList();
-    for (final DestinationConnection destination : destinationConnections) {
-      configPersistence.writeConfig(ConfigSchema.DESTINATION_CONNECTION, destination.getDestinationId().toString(), destination);
-    }
-  }
-
-  /**
-   * This is a generic method to migrate an actor configuration It will extract the secret path form
-   * the provided spec and then replace them by coordinates in the actor configuration
-   */
-  @VisibleForTesting
-  JsonNode migrateConfiguration(final ConnectorConfiguration connectorConfiguration, final Supplier<UUID> uuidProvider) {
-    if (connectorConfiguration.getSpec() == null) {
-      throw new IllegalStateException("No connector definition to match the connector");
-    }
-
-    final AtomicReference<JsonNode> connectorConfigurationJson = new AtomicReference<>(connectorConfiguration.getConfiguration());
-    final List<String> uniqSecretPaths = getSecretPath(connectorConfiguration.getSpec())
-        .stream()
-        .flatMap(secretPath -> getAllExplodedPath(connectorConfigurationJson.get(), secretPath).stream())
-        .toList();
-
-    final UUID workspaceId = connectorConfiguration.getWorkspace();
-    uniqSecretPaths.forEach(secretPath -> {
-      final Optional<JsonNode> secretValue = getValueForPath(connectorConfigurationJson.get(), secretPath);
-      if (secretValue.isEmpty()) {
-        throw new IllegalStateException("Missing secret for the path: " + secretPath);
-      }
-
-      // Only migrate plain text.
-      if (secretValue.get().isTextual()) {
-        final JsonNode stringSecretValue = secretValue.get();
-
-        final SecretCoordinate coordinate =
-            new SecretCoordinate(SecretsHelpers.getCoordinatorBase("airbyte_workspace_", workspaceId, uuidProvider), 1);
-        secretPersistence.get().write(coordinate, stringSecretValue.textValue());
-        connectorConfigurationJson.set(replaceAtJsonNode(connectorConfigurationJson.get(), secretPath,
-            Jsons.jsonNode(Map.of(COORDINATE_FIELD, coordinate.getFullCoordinate()))));
+      if (specOptional.isPresent()) {
+        secretsWriter.writeDestinationConnection(destination, specOptional.get());
       } else {
-        log.error("Not migrating already migrated secrets");
+        // if the spec can't be found, don't risk writing secrets to db. wipe out the configuration for the
+        // connector.
+        final DestinationConnection destinationWithConfigRemoved = Jsons.clone(destination);
+        destinationWithConfigRemoved.setConfiguration(Jsons.emptyObject());
+        secretsWriter.writeDestinationConnection(destinationWithConfigRemoved,
+            new ConnectorSpecification().withConnectionSpecification(Jsons.emptyObject()));
       }
-
-    });
-
-    return connectorConfigurationJson.get();
-  }
-
-  /**
-   * Wrapper to help to mock static methods
-   */
-  @VisibleForTesting
-  JsonNode replaceAtJsonNode(final JsonNode connectorConfigurationJson, final String secretPath, final JsonNode replacement) {
-    return JsonPaths.replaceAtJsonNode(connectorConfigurationJson, secretPath, replacement);
-  }
-
-  /**
-   * Wrapper to help to mock static methods
-   */
-  @VisibleForTesting
-  List<String> getSecretPath(final JsonNode specs) {
-    return SecretsHelpers.getSortedSecretPaths(specs);
-  }
-
-  /**
-   * Wrapper to help to mock static methods
-   */
-  @VisibleForTesting
-  List<String> getAllExplodedPath(final JsonNode node, final String path) {
-    return JsonPaths.getPaths(node, path);
-  }
-
-  /**
-   * Wrapper to help to mock static methods
-   */
-  @VisibleForTesting
-  Optional<JsonNode> getValueForPath(final JsonNode node, final String path) {
-    return JsonPaths.getSingleValue(node, path);
+    }
   }
 
 }

--- a/airbyte-bootloader/src/test/java/io/airbyte/bootloader/BootloaderAppTest.java
+++ b/airbyte-bootloader/src/test/java/io/airbyte/bootloader/BootloaderAppTest.java
@@ -33,7 +33,8 @@ import io.airbyte.config.persistence.DatabaseConfigPersistence;
 import io.airbyte.config.persistence.SecretsRepositoryReader;
 import io.airbyte.config.persistence.SecretsRepositoryWriter;
 import io.airbyte.config.persistence.split_secrets.JsonSecretsProcessor;
-import io.airbyte.config.persistence.split_secrets.NoOpSecretsHydrator;
+import io.airbyte.config.persistence.split_secrets.LocalTestingSecretPersistence;
+import io.airbyte.config.persistence.split_secrets.RealSecretsHydrator;
 import io.airbyte.config.persistence.split_secrets.SecretPersistence;
 import io.airbyte.db.factory.DSLContextFactory;
 import io.airbyte.db.factory.DataSourceFactory;
@@ -192,7 +193,9 @@ class BootloaderAppTest {
       val jobsPersistence = new DefaultJobPersistence(jobDatabase);
 
       val secretsPersistence = SecretPersistence.getLongLived(configsDslContext, mockedConfigs);
-      val secretsReader = new SecretsRepositoryReader(configRepository, new NoOpSecretsHydrator());
+      final LocalTestingSecretPersistence localTestingSecretPersistence = new LocalTestingSecretPersistence(configDatabase);
+
+      val secretsReader = new SecretsRepositoryReader(configRepository, new RealSecretsHydrator(localTestingSecretPersistence));
       val secretsWriter = new SecretsRepositoryWriter(configRepository, secretsPersistence, Optional.empty());
 
       val spiedSecretMigrator =

--- a/airbyte-bootloader/src/test/java/io/airbyte/bootloader/SecretMigratorTest.java
+++ b/airbyte-bootloader/src/test/java/io/airbyte/bootloader/SecretMigratorTest.java
@@ -4,17 +4,20 @@
 
 package io.airbyte.bootloader;
 
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.when;
+
 import com.fasterxml.jackson.databind.JsonNode;
 import com.google.common.collect.Lists;
-import io.airbyte.bootloader.SecretMigrator.ConnectorConfiguration;
 import io.airbyte.commons.json.Jsons;
-import io.airbyte.config.ConfigSchema;
 import io.airbyte.config.DestinationConnection;
 import io.airbyte.config.SourceConnection;
 import io.airbyte.config.StandardDestinationDefinition;
 import io.airbyte.config.StandardSourceDefinition;
-import io.airbyte.config.persistence.ConfigPersistence;
-import io.airbyte.config.persistence.split_secrets.SecretCoordinate;
+import io.airbyte.config.persistence.ConfigNotFoundException;
+import io.airbyte.config.persistence.ConfigRepository;
+import io.airbyte.config.persistence.SecretsRepositoryReader;
+import io.airbyte.config.persistence.SecretsRepositoryWriter;
 import io.airbyte.config.persistence.split_secrets.SecretPersistence;
 import io.airbyte.persistence.job.JobPersistence;
 import io.airbyte.protocol.models.ConnectorSpecification;
@@ -25,7 +28,6 @@ import java.util.List;
 import java.util.Map;
 import java.util.Optional;
 import java.util.UUID;
-import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
@@ -39,7 +41,13 @@ class SecretMigratorTest {
   private final UUID workspaceId = UUID.randomUUID();
 
   @Mock
-  private ConfigPersistence configPersistence;
+  private ConfigRepository configRepository;
+
+  @Mock
+  private SecretsRepositoryReader secretsReader;
+
+  @Mock
+  private SecretsRepositoryWriter secretsWriter;
 
   @Mock
   private SecretPersistence secretPersistence;
@@ -51,11 +59,11 @@ class SecretMigratorTest {
 
   @BeforeEach
   void setup() {
-    secretMigrator = Mockito.spy(new SecretMigrator(configPersistence, jobPersistence, Optional.of(secretPersistence)));
+    secretMigrator = Mockito.spy(new SecretMigrator(secretsReader, secretsWriter, configRepository, jobPersistence, Optional.of(secretPersistence)));
   }
 
   @Test
-  void testMigrateSecret() throws JsonValidationException, IOException {
+  void testMigrateSecret() throws JsonValidationException, IOException, ConfigNotFoundException {
     final JsonNode sourceSpec = Jsons.jsonNode("sourceSpec");
     final UUID sourceDefinitionId = UUID.randomUUID();
     final StandardSourceDefinition standardSourceDefinition = new StandardSourceDefinition()
@@ -63,9 +71,9 @@ class SecretMigratorTest {
         .withSpec(
             new ConnectorSpecification()
                 .withConnectionSpecification(sourceSpec));
-    final Map<UUID, JsonNode> standardSourceDefinitions = new HashMap<>();
-    standardSourceDefinitions.put(sourceDefinitionId, standardSourceDefinition.getSpec().getConnectionSpecification());
-    Mockito.when(configPersistence.listConfigs(ConfigSchema.STANDARD_SOURCE_DEFINITION, StandardSourceDefinition.class))
+    final Map<UUID, ConnectorSpecification> standardSourceDefinitions = new HashMap<>();
+    standardSourceDefinitions.put(sourceDefinitionId, standardSourceDefinition.getSpec());
+    when(configRepository.listStandardSourceDefinitions(true))
         .thenReturn(Lists.newArrayList(standardSourceDefinition));
 
     final JsonNode sourceConfiguration = Jsons.jsonNode("sourceConfiguration");
@@ -75,7 +83,7 @@ class SecretMigratorTest {
         .withConfiguration(sourceConfiguration)
         .withWorkspaceId(workspaceId);
     final List<SourceConnection> sourceConnections = Lists.newArrayList(sourceConnection);
-    Mockito.when(configPersistence.listConfigs(ConfigSchema.SOURCE_CONNECTION, SourceConnection.class))
+    when(configRepository.listSourceConnection())
         .thenReturn(sourceConnections);
 
     final JsonNode destinationSpec = Jsons.jsonNode("destinationSpec");
@@ -85,9 +93,9 @@ class SecretMigratorTest {
         .withSpec(
             new ConnectorSpecification()
                 .withConnectionSpecification(destinationSpec));
-    final Map<UUID, JsonNode> standardDestinationDefinitions = new HashMap<>();
-    standardDestinationDefinitions.put(destinationDefinitionId, standardDestinationDefinition.getSpec().getConnectionSpecification());
-    Mockito.when(configPersistence.listConfigs(ConfigSchema.STANDARD_DESTINATION_DEFINITION, StandardDestinationDefinition.class))
+    final Map<UUID, ConnectorSpecification> standardDestinationDefinitions = new HashMap<>();
+    standardDestinationDefinitions.put(destinationDefinitionId, standardDestinationDefinition.getSpec());
+    when(configRepository.listStandardDestinationDefinitions(true))
         .thenReturn(Lists.newArrayList(standardDestinationDefinition));
 
     final JsonNode destinationConfiguration = Jsons.jsonNode("destinationConfiguration");
@@ -97,29 +105,19 @@ class SecretMigratorTest {
         .withConfiguration(destinationConfiguration)
         .withWorkspaceId(workspaceId);
     final List<DestinationConnection> destinationConnections = Lists.newArrayList(destinationConnection);
-    Mockito.when(configPersistence.listConfigs(ConfigSchema.DESTINATION_CONNECTION, DestinationConnection.class))
+    when(configRepository.listDestinationConnection())
         .thenReturn(destinationConnections);
 
-    // Mockito.doNothing().when(secretMigrator).migrateDestinations(Mockito.any(), Mockito.any());
+    when(secretsReader.getSourceConnectionWithSecrets(sourceConnection.getSourceId())).thenReturn(sourceConnection);
+    when(secretsReader.getDestinationConnectionWithSecrets(destinationConnection.getDestinationId())).thenReturn(destinationConnection);
 
-    final String path = "Mocked static call source";
-    Mockito.doReturn(Lists.newArrayList(path)).when(secretMigrator).getSecretPath(sourceSpec);
-    Mockito.doReturn(Lists.newArrayList(path)).when(secretMigrator).getAllExplodedPath(sourceConfiguration, path);
-    final String sourceSecret = "sourceSecret";
-    Mockito.doReturn(Optional.of(Jsons.jsonNode(sourceSecret))).when(secretMigrator).getValueForPath(sourceConfiguration, path);
-    Mockito.doReturn(Lists.newArrayList(path)).when(secretMigrator).getSecretPath(destinationSpec);
-    Mockito.doReturn(Lists.newArrayList(path)).when(secretMigrator).getAllExplodedPath(destinationConfiguration, path);
-    final String destinationSecret = "destinationSecret";
-    Mockito.doReturn(Optional.of(Jsons.jsonNode(destinationSecret))).when(secretMigrator).getValueForPath(destinationConfiguration, path);
-
-    Mockito.doReturn(Jsons.jsonNode("sanitized")).when(secretMigrator).replaceAtJsonNode(Mockito.any(), Mockito.any(), Mockito.any());
     secretMigrator.migrateSecrets();
 
     Mockito.verify(secretMigrator).migrateSources(sourceConnections, standardSourceDefinitions);
-    Mockito.verify(secretPersistence).write(Mockito.any(), Mockito.eq(sourceSecret));
-    secretPersistence.write(Mockito.any(), Mockito.any());
+    Mockito.verify(secretsWriter).writeSourceConnection(sourceConnection, standardSourceDefinition.getSpec());
+    secretPersistence.write(any(), any());
     Mockito.verify(secretMigrator).migrateDestinations(destinationConnections, standardDestinationDefinitions);
-    Mockito.verify(secretPersistence).write(Mockito.any(), Mockito.eq(destinationSecret));
+    Mockito.verify(secretsWriter).writeDestinationConnection(destinationConnection, standardDestinationDefinition.getSpec());
 
     Mockito.verify(jobPersistence).setSecretMigrationDone();
   }
@@ -132,8 +130,8 @@ class SecretMigratorTest {
     final UUID sourceId2 = UUID.randomUUID();
     final JsonNode sourceConfiguration1 = Jsons.jsonNode("conf1");
     final JsonNode sourceConfiguration2 = Jsons.jsonNode("conf2");
-    final JsonNode sourceDefinition1 = Jsons.jsonNode("def1");
-    final JsonNode sourceDefinition2 = Jsons.jsonNode("def2");
+    final ConnectorSpecification sourceDefinition1 = new ConnectorSpecification().withConnectionSpecification(Jsons.jsonNode("def1"));
+    final ConnectorSpecification sourceDefinition2 = new ConnectorSpecification().withConnectionSpecification(Jsons.jsonNode("def2"));
     final SourceConnection sourceConnection1 = new SourceConnection()
         .withSourceId(sourceId1)
         .withSourceDefinitionId(definitionId1)
@@ -144,18 +142,14 @@ class SecretMigratorTest {
         .withConfiguration(sourceConfiguration2);
 
     final List<SourceConnection> sources = Lists.newArrayList(sourceConnection1, sourceConnection2);
-    final Map<UUID, JsonNode> definitionIdToDestinationSpecs = new HashMap<>();
+    final Map<UUID, ConnectorSpecification> definitionIdToDestinationSpecs = new HashMap<>();
     definitionIdToDestinationSpecs.put(definitionId1, sourceDefinition1);
     definitionIdToDestinationSpecs.put(definitionId2, sourceDefinition2);
 
-    Mockito.doReturn(Jsons.emptyObject()).when(secretMigrator).migrateConfiguration(
-        Mockito.any(),
-        Mockito.any());
-
     secretMigrator.migrateSources(sources, definitionIdToDestinationSpecs);
 
-    Mockito.verify(configPersistence).writeConfig(ConfigSchema.SOURCE_CONNECTION, sourceId1.toString(), sourceConnection1);
-    Mockito.verify(configPersistence).writeConfig(ConfigSchema.SOURCE_CONNECTION, sourceId2.toString(), sourceConnection2);
+    Mockito.verify(secretsWriter).writeSourceConnection(sourceConnection1, sourceDefinition1);
+    Mockito.verify(secretsWriter).writeSourceConnection(sourceConnection2, sourceDefinition2);
   }
 
   @Test
@@ -166,8 +160,8 @@ class SecretMigratorTest {
     final UUID destinationId2 = UUID.randomUUID();
     final JsonNode destinationConfiguration1 = Jsons.jsonNode("conf1");
     final JsonNode destinationConfiguration2 = Jsons.jsonNode("conf2");
-    final JsonNode destinationDefinition1 = Jsons.jsonNode("def1");
-    final JsonNode destinationDefinition2 = Jsons.jsonNode("def2");
+    final ConnectorSpecification destinationDefinition1 = new ConnectorSpecification().withConnectionSpecification(Jsons.jsonNode("def1"));
+    final ConnectorSpecification destinationDefinition2 = new ConnectorSpecification().withConnectionSpecification(Jsons.jsonNode("def2"));
     final DestinationConnection destinationConnection1 = new DestinationConnection()
         .withDestinationId(destinationId1)
         .withDestinationDefinitionId(definitionId1)
@@ -178,69 +172,14 @@ class SecretMigratorTest {
         .withConfiguration(destinationConfiguration2);
 
     final List<DestinationConnection> destinations = Lists.newArrayList(destinationConnection1, destinationConnection2);
-    final Map<UUID, JsonNode> definitionIdToDestinationSpecs = new HashMap<>();
+    final Map<UUID, ConnectorSpecification> definitionIdToDestinationSpecs = new HashMap<>();
     definitionIdToDestinationSpecs.put(definitionId1, destinationDefinition1);
     definitionIdToDestinationSpecs.put(definitionId2, destinationDefinition2);
 
-    Mockito.doReturn(Jsons.emptyObject()).when(secretMigrator).migrateConfiguration(
-        Mockito.any(),
-        Mockito.any());
-
     secretMigrator.migrateDestinations(destinations, definitionIdToDestinationSpecs);
 
-    Mockito.verify(configPersistence).writeConfig(ConfigSchema.DESTINATION_CONNECTION, destinationId1.toString(), destinationConnection1);
-    Mockito.verify(configPersistence).writeConfig(ConfigSchema.DESTINATION_CONNECTION, destinationId2.toString(), destinationConnection2);
-  }
-
-  @Test
-  void testMigrateConfigurationWithoutSpecs() {
-    final ConnectorConfiguration connectorConfiguration = new ConnectorConfiguration(null, null, null);
-
-    Assertions.assertThrows(IllegalStateException.class, () -> secretMigrator.migrateConfiguration(connectorConfiguration, null));
-  }
-
-  @Test
-  void testMissingSecret() {
-    final List<String> secretPathList = Lists.newArrayList("secretPath");
-
-    Mockito.doReturn(secretPathList).when(secretMigrator).getSecretPath(Mockito.any());
-    Mockito.doReturn(secretPathList).when(secretMigrator).getAllExplodedPath(Mockito.any(), Mockito.eq(secretPathList.get(0)));
-    Mockito.doReturn(Optional.empty()).when(secretMigrator).getValueForPath(Mockito.any(), Mockito.eq(secretPathList.get(0)));
-
-    final ConnectorConfiguration connectorConfiguration = new ConnectorConfiguration(UUID.randomUUID(), Jsons.emptyObject(), Jsons.emptyObject());
-    Assertions.assertThrows(IllegalStateException.class, () -> secretMigrator.migrateConfiguration(connectorConfiguration, () -> UUID.randomUUID()));
-  }
-
-  @Test
-  void testMigrateConfiguration() {
-    final List<String> secretPathList = Lists.newArrayList("$.secretPath");
-
-    Mockito.doReturn(secretPathList).when(secretMigrator).getSecretPath(Mockito.any());
-    Mockito.doReturn(secretPathList).when(secretMigrator).getAllExplodedPath(Mockito.any(), Mockito.eq(secretPathList.get(0)));
-    Mockito.doReturn(Optional.of(Jsons.jsonNode(secretPathList.get(0)))).when(secretMigrator).getValueForPath(Mockito.any(),
-        Mockito.eq(secretPathList.get(0)));
-
-    final ConnectorConfiguration connectorConfiguration = new ConnectorConfiguration(UUID.randomUUID(), Jsons.emptyObject(), Jsons.emptyObject());
-
-    secretMigrator.migrateConfiguration(connectorConfiguration, () -> UUID.randomUUID());
-    Mockito.verify(secretPersistence).write(Mockito.any(), Mockito.any());
-  }
-
-  @Test
-  void testMigrateConfigurationAlreadyInSecretManager() {
-    final List<String> secretPathList = Lists.newArrayList("$.secretPath");
-
-    Mockito.doReturn(secretPathList).when(secretMigrator).getSecretPath(Mockito.any());
-    Mockito.doReturn(secretPathList).when(secretMigrator).getAllExplodedPath(Mockito.any(), Mockito.eq(secretPathList.get(0)));
-
-    final SecretCoordinate fakeCoordinate = new SecretCoordinate("fake", 1);
-    Mockito.doReturn(Optional.of(Jsons.jsonNode(fakeCoordinate))).when(secretMigrator).getValueForPath(Mockito.any(),
-        Mockito.eq(secretPathList.get(0)));
-
-    final ConnectorConfiguration connectorConfiguration = new ConnectorConfiguration(UUID.randomUUID(), Jsons.emptyObject(), Jsons.emptyObject());
-
-    secretMigrator.migrateConfiguration(connectorConfiguration, () -> UUID.randomUUID());
-    Mockito.verify(secretPersistence, Mockito.times(0)).write(Mockito.any(), Mockito.any());
+    Mockito.verify(secretsWriter).writeDestinationConnection(destinationConnection1, destinationDefinition1);
+    Mockito.verify(secretsWriter).writeDestinationConnection(destinationConnection2, destinationDefinition2);
   }
 
 }

--- a/airbyte-config/config-persistence/src/main/java/io/airbyte/config/persistence/ConfigPersistence.java
+++ b/airbyte-config/config-persistence/src/main/java/io/airbyte/config/persistence/ConfigPersistence.java
@@ -13,6 +13,10 @@ import java.util.List;
 import java.util.Map;
 import java.util.stream.Stream;
 
+/**
+ * We are moving migrating away from this interface entirely. Use ConfigRepository instead.
+ */
+@Deprecated
 public interface ConfigPersistence {
 
   <T> T getConfig(AirbyteConfig configType, String configId, Class<T> clazz) throws ConfigNotFoundException, JsonValidationException, IOException;


### PR DESCRIPTION
## What
* We want to remove the `ConfigPersistence` entirely
* One of the few places it was still "meaningfully" used was the `SecretsMigrator`... until now.

## How
* Replace usages of `ConfigPersistence` with the `ConfigRepository`.