### PR TITLE
Destination DynamoDB: SSH

### DIFF
--- a/airbyte-integrations/connectors/destination-dynamodb/build.gradle
+++ b/airbyte-integrations/connectors/destination-dynamodb/build.gradle
@@ -21,4 +21,5 @@ dependencies {
 
     integrationTestJavaImplementation project(':airbyte-integrations:bases:standard-destination-test')
     integrationTestJavaImplementation project(':airbyte-integrations:connectors:destination-dynamodb')
+    integrationTestJavaImplementation libs.connectors.testcontainers.dynamodb
 }

--- a/airbyte-integrations/connectors/destination-dynamodb/src/main/java/io/airbyte/integrations/destination/dynamodb/DynamodbChecker.java
+++ b/airbyte-integrations/connectors/destination-dynamodb/src/main/java/io/airbyte/integrations/destination/dynamodb/DynamodbChecker.java
@@ -7,7 +7,8 @@ package io.airbyte.integrations.destination.dynamodb;
 import com.amazonaws.ClientConfiguration;
 import com.amazonaws.auth.AWSStaticCredentialsProvider;
 import com.amazonaws.auth.BasicAWSCredentials;
-import com.amazonaws.client.builder.AwsClientBuilder;
+import com.amazonaws.client.builder.AwsClientBuilder.EndpointConfiguration;
+import com.amazonaws.retry.PredefinedRetryPolicies;
 import com.amazonaws.services.dynamodbv2.AmazonDynamoDB;
 import com.amazonaws.services.dynamodbv2.AmazonDynamoDBClientBuilder;
 import com.amazonaws.services.dynamodbv2.document.*;
@@ -65,12 +66,19 @@ public class DynamodbChecker {
           .build();
 
     } else {
-      final ClientConfiguration clientConfiguration = new ClientConfiguration();
-      clientConfiguration.setSignerOverride("AWSDynamodbSignerType");
+      ClientConfiguration clientConfiguration = new ClientConfiguration()
+          .withConnectionTimeout(3000)
+          .withClientExecutionTimeout(3000)
+          .withRequestTimeout(3000)
+          .withSocketTimeout(3000)
+          .withRetryPolicy(PredefinedRetryPolicies
+                  .getDynamoDBDefaultRetryPolicyWithCustomMaxRetries(
+                      1));
+
 
       return AmazonDynamoDBClientBuilder
           .standard()
-          .withEndpointConfiguration(new AwsClientBuilder.EndpointConfiguration(endpoint, region))
+          .withEndpointConfiguration(new EndpointConfiguration(endpoint, region))
           .withClientConfiguration(clientConfiguration)
           .withCredentials(new AWSStaticCredentialsProvider(awsCreds))
           .build();

--- a/airbyte-integrations/connectors/destination-dynamodb/src/main/java/io/airbyte/integrations/destination/dynamodb/DynamodbDestination.java
+++ b/airbyte-integrations/connectors/destination-dynamodb/src/main/java/io/airbyte/integrations/destination/dynamodb/DynamodbDestination.java
@@ -21,7 +21,14 @@ public class DynamodbDestination extends BaseConnector implements Destination {
   private static final Logger LOGGER = LoggerFactory.getLogger(DynamodbDestination.class);
 
   public static void main(final String[] args) throws Exception {
-    new IntegrationRunner(new DynamodbDestination()).run(args);
+    LOGGER.info("starting destination: {}", DynamodbDestination.class);
+    final Destination destination = DynamodbDestination.sshWrappedDestination();
+    new IntegrationRunner(destination).run(args);
+    LOGGER.info("completed destination: {}", DynamodbDestination.class);
+  }
+
+  public static Destination sshWrappedDestination() {
+    return new DynamodbSshWrapper(new DynamodbDestination(), "dynamodb_endpoint");
   }
 
   @Override

--- a/airbyte-integrations/connectors/destination-dynamodb/src/main/java/io/airbyte/integrations/destination/dynamodb/DynamodbDestinationConfig.java
+++ b/airbyte-integrations/connectors/destination-dynamodb/src/main/java/io/airbyte/integrations/destination/dynamodb/DynamodbDestinationConfig.java
@@ -8,6 +8,7 @@ import com.fasterxml.jackson.databind.JsonNode;
 
 public class DynamodbDestinationConfig {
 
+  private final static String DYNAMODB_DEFAULT_URL = "https://dynamodb.amazonaws.com:443";
   private final String endpoint;
   private final String tableNamePrefix;
   private final String accessKeyId;
@@ -29,7 +30,8 @@ public class DynamodbDestinationConfig {
 
   public static DynamodbDestinationConfig getDynamodbDestinationConfig(final JsonNode config) {
     return new DynamodbDestinationConfig(
-        config.get("dynamodb_endpoint") == null ? "" : config.get("dynamodb_endpoint").asText(),
+        config.get("dynamodb_endpoint") == null || config.get("dynamodb_endpoint").asText().isEmpty() ? DYNAMODB_DEFAULT_URL
+            : config.get("dynamodb_endpoint").asText(),
         config.get("dynamodb_table_name_prefix").asText(),
         config.get("dynamodb_region").asText(),
         config.get("access_key_id").asText(),

--- a/airbyte-integrations/connectors/destination-dynamodb/src/main/java/io/airbyte/integrations/destination/dynamodb/DynamodbSshWrapper.java
+++ b/airbyte-integrations/connectors/destination-dynamodb/src/main/java/io/airbyte/integrations/destination/dynamodb/DynamodbSshWrapper.java
@@ -1,0 +1,66 @@
+package io.airbyte.integrations.destination.dynamodb;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.node.ObjectNode;
+import io.airbyte.commons.exceptions.ConnectionErrorException;
+import io.airbyte.integrations.base.AirbyteMessageConsumer;
+import io.airbyte.integrations.base.AirbyteTraceMessageUtility;
+import io.airbyte.integrations.base.Destination;
+import io.airbyte.integrations.base.ssh.SshTunnel;
+import io.airbyte.integrations.base.ssh.SshWrappedDestination;
+import io.airbyte.protocol.models.AirbyteConnectionStatus;
+import io.airbyte.protocol.models.AirbyteConnectionStatus.Status;
+import io.airbyte.protocol.models.AirbyteMessage;
+import io.airbyte.protocol.models.ConfiguredAirbyteCatalog;
+import java.util.function.Consumer;
+
+public class DynamodbSshWrapper extends SshWrappedDestination {
+
+  private String endPointKey;
+  private final Destination delegate;
+
+
+  public DynamodbSshWrapper(Destination delegate, String endPointKey) {
+    super(delegate, endPointKey);
+    this.delegate = delegate;
+    this.endPointKey = endPointKey;
+  }
+
+  @Override
+  public AirbyteConnectionStatus check(final JsonNode config) throws Exception {
+    try {
+      DynamodbDestinationConfig dynamodbDestinationConfig = DynamodbDestinationConfig.getDynamodbDestinationConfig(config);
+      String endpoint = dynamodbDestinationConfig.getEndpoint();
+      ((ObjectNode)config).put(endPointKey, endpoint);
+      return  SshTunnel.sshWrap(config, endPointKey, delegate::check);
+    } catch (final ConnectionErrorException e) {
+      final String sshErrorMessage = "Could not connect with provided SSH configuration. Error: " + e.getMessage();
+      AirbyteTraceMessageUtility.emitConfigErrorTrace(e, sshErrorMessage);
+      return new AirbyteConnectionStatus()
+          .withStatus(Status.FAILED)
+          .withMessage(sshErrorMessage);
+    }
+  }
+
+  @Override
+  public AirbyteMessageConsumer getConsumer(final JsonNode config,
+      final ConfiguredAirbyteCatalog catalog,
+      final Consumer<AirbyteMessage> outputRecordCollector)
+      throws Exception {
+
+    DynamodbDestinationConfig dynamodbDestinationConfig = DynamodbDestinationConfig.getDynamodbDestinationConfig(config);
+
+    final SshTunnel tunnel = SshTunnel.getInstance(config, dynamodbDestinationConfig.getEndpoint());
+
+    final AirbyteMessageConsumer delegateConsumer;
+    try {
+      delegateConsumer = delegate.getConsumer(tunnel.getConfigInTunnel(), catalog, outputRecordCollector);
+    } catch (final Exception e) {
+//      LOGGER.error("Exception occurred while getting the delegate consumer, closing SSH tunnel", e);
+      tunnel.close();
+      throw e;
+    }
+    return AirbyteMessageConsumer.appendOnClose(delegateConsumer, tunnel::close);
+  }
+
+}

--- a/airbyte-integrations/connectors/destination-dynamodb/src/test-integration/java/io/airbyte/integrations/destination/dynamodb/DynamoDBContainer.java
+++ b/airbyte-integrations/connectors/destination-dynamodb/src/test-integration/java/io/airbyte/integrations/destination/dynamodb/DynamoDBContainer.java
@@ -1,0 +1,67 @@
+package io.airbyte.integrations.destination.dynamodb;
+
+import com.amazonaws.auth.AWSCredentialsProvider;
+import com.amazonaws.auth.AWSStaticCredentialsProvider;
+import com.amazonaws.auth.BasicAWSCredentials;
+import com.amazonaws.client.builder.AwsClientBuilder;
+import com.amazonaws.services.dynamodbv2.AmazonDynamoDB;
+import com.amazonaws.services.dynamodbv2.AmazonDynamoDBClientBuilder;
+import org.testcontainers.containers.GenericContainer;
+import org.testcontainers.utility.DockerImageName;
+
+public class DynamoDBContainer extends GenericContainer<DynamoDBContainer> {
+
+  private static final DockerImageName DEFAULT_IMAGE_NAME = DockerImageName.parse("amazon/dynamodb-local");
+
+  private static final String DEFAULT_TAG = "1.20.0";
+
+  private static final int MAPPED_PORT = 8000;
+
+
+  public DynamoDBContainer() {
+    this(DEFAULT_IMAGE_NAME.withTag(DEFAULT_TAG));
+  }
+
+
+  public DynamoDBContainer(final DockerImageName dockerImageName) {
+    super(dockerImageName);
+    withExposedPorts(MAPPED_PORT);
+  }
+
+  /**
+   * Gets a preconfigured {@link AmazonDynamoDB} client object for connecting to this
+   * container.
+   *
+   * @return preconfigured client
+   */
+  public AmazonDynamoDB getClient() {
+    return AmazonDynamoDBClientBuilder
+        .standard()
+        .withEndpointConfiguration(getEndpointConfiguration())
+        .withCredentials(getCredentials())
+        .build();
+  }
+
+  /**
+   * Gets {@link AwsClientBuilder.EndpointConfiguration}
+   * that may be used to connect to this container.
+   *
+   * @return endpoint configuration
+   */
+  public AwsClientBuilder.EndpointConfiguration getEndpointConfiguration() {
+    return new AwsClientBuilder.EndpointConfiguration(
+        "http://" + this.getHost() + ":" + this.getMappedPort(MAPPED_PORT),
+        null
+    );
+  }
+
+  /**
+   * Gets an {@link AWSCredentialsProvider} that may be used to connect to this container.
+   *
+   * @return dummy AWS credentials
+   */
+  public AWSCredentialsProvider getCredentials() {
+    return new AWSStaticCredentialsProvider(new BasicAWSCredentials("dummy", "dummy"));
+  }
+
+}

--- a/airbyte-integrations/connectors/destination-dynamodb/src/test-integration/java/io/airbyte/integrations/destination/dynamodb/SshDynamodbDestinationAcceptanceTest.java
+++ b/airbyte-integrations/connectors/destination-dynamodb/src/test-integration/java/io/airbyte/integrations/destination/dynamodb/SshDynamodbDestinationAcceptanceTest.java
@@ -1,0 +1,145 @@
+/*
+ * Copyright (c) 2022 Airbyte, Inc., all rights reserved.
+ */
+
+package io.airbyte.integrations.destination.dynamodb;
+
+import com.amazonaws.auth.AWSCredentials;
+import com.amazonaws.client.builder.AwsClientBuilder.EndpointConfiguration;
+import com.amazonaws.services.dynamodbv2.AmazonDynamoDB;
+import com.amazonaws.services.dynamodbv2.document.DynamoDB;
+import com.amazonaws.services.dynamodbv2.document.Item;
+import com.amazonaws.services.dynamodbv2.document.ItemCollection;
+import com.amazonaws.services.dynamodbv2.document.ScanOutcome;
+import com.amazonaws.services.dynamodbv2.document.spec.ScanSpec;
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.node.ObjectNode;
+import com.google.common.collect.ImmutableMap;
+import io.airbyte.commons.json.Jsons;
+import io.airbyte.integrations.base.JavaBaseConstants;
+import io.airbyte.integrations.base.ssh.SshBastionContainer;
+import io.airbyte.integrations.base.ssh.SshTunnel;
+import io.airbyte.integrations.standardtest.destination.DestinationAcceptanceTest;
+import io.airbyte.integrations.util.HostPortResolver;
+import java.io.IOException;
+import java.math.BigDecimal;
+import java.util.ArrayList;
+import java.util.Comparator;
+import java.util.Iterator;
+import java.util.LinkedList;
+import java.util.List;
+import org.testcontainers.containers.Network;
+
+public abstract class SshDynamodbDestinationAcceptanceTest extends DestinationAcceptanceTest {
+
+  private static final SshBastionContainer bastion = new SshBastionContainer();
+  private static final Network network = Network.newNetwork();
+  private static final DynamoDBContainer dynamoDBContainer = new DynamoDBContainer();
+  protected AmazonDynamoDB client;
+  private JsonNode configJson;
+  private AWSCredentials credentials;
+  private EndpointConfiguration endpointConfiguration;
+
+
+  private String getEndPoint() {
+    return String.format("http://%s:%d",
+        HostPortResolver.resolveIpAddress(dynamoDBContainer),
+        dynamoDBContainer.getExposedPorts().get(0));
+  }
+
+
+  @Override
+  protected void setup(final TestDestinationEnv testEnv) throws Exception {
+    dynamoDBContainer
+        .withNetwork(network);
+    dynamoDBContainer.start();
+    bastion.initAndStartBastion(network);
+
+    final var endpointUrl = getEndPoint();
+    client = dynamoDBContainer.getClient();
+    credentials = dynamoDBContainer.getCredentials().getCredentials();
+
+    configJson = bastion.getTunnelConfig(getTunnelMethod(), ImmutableMap.builder()
+        .put("dynamodb_endpoint", endpointUrl)
+        .put("dynamodb_region", "us-east-2")
+        .put("dynamodb_table_name_prefix", "test")
+        .put("access_key_id", credentials.getAWSAccessKeyId())
+        .put("secret_access_key", credentials.getAWSSecretKey()));
+
+  }
+
+
+  public abstract SshTunnel.TunnelMethod getTunnelMethod();
+
+
+  @Override
+  protected void tearDown(TestDestinationEnv testEnv) {
+    dynamoDBContainer.stop();
+    dynamoDBContainer.close();
+    bastion.getContainer().stop();
+    bastion.getContainer().close();
+  }
+
+  @Override
+  protected String getImageName() {
+    return "airbyte/destination-dynamodb:dev";
+  }
+
+  @Override
+  protected JsonNode getConfig() throws Exception {
+    return configJson;
+  }
+
+  @Override
+  protected JsonNode getFailCheckConfig() {
+    final JsonNode failCheckJson = Jsons.clone(configJson);
+    // invalid credential
+    ((ObjectNode) failCheckJson).put("dynamodb_endpoint", "fake-endpoint");
+    return failCheckJson;
+  }
+
+  @Override
+  protected List<JsonNode> retrieveRecords(final TestDestinationEnv testEnv,
+      final String streamName,
+      final String namespace,
+      final JsonNode streamSchema)
+      throws IOException {
+    final List<Item> items = getAllSyncedObjects(streamName, namespace);
+    final List<JsonNode> jsonRecords = new LinkedList<>();
+
+    for (final var item : items) {
+      final var itemJson = item.toJSON();
+      jsonRecords.add(Jsons.deserialize(itemJson).get(JavaBaseConstants.COLUMN_NAME_DATA));
+    }
+
+    return jsonRecords;
+  }
+
+  protected List<Item> getAllSyncedObjects(final String streamName, final String namespace) {
+    final var dynamodb = new DynamoDB(client);
+    final var tableName = DynamodbOutputTableHelper.getOutputTableName("test", streamName, namespace);
+    final var table = dynamodb.getTable(tableName);
+    final List<Item> items = new ArrayList<Item>();
+    Long maxSyncTime = 0L;
+
+    try {
+      final ItemCollection<ScanOutcome> scanItems = table.scan(new ScanSpec());
+
+      final Iterator<Item> iter = scanItems.iterator();
+      while (iter.hasNext()) {
+
+        final Item item = iter.next();
+        items.add(item);
+        maxSyncTime = Math.max(maxSyncTime, ((BigDecimal) item.get("sync_time")).longValue());
+      }
+    } catch (final Exception e) {
+//      LOGGER.error(e.getMessage(), e);
+    }
+
+    items.sort(Comparator.comparingLong(o -> ((BigDecimal) o.get(JavaBaseConstants.COLUMN_NAME_EMITTED_AT)).longValue()));
+
+    return items;
+  }
+
+
+}

--- a/airbyte-integrations/connectors/destination-dynamodb/src/test-integration/java/io/airbyte/integrations/destination/dynamodb/SshKeyDynamodbDestinationAcceptanceTest.java
+++ b/airbyte-integrations/connectors/destination-dynamodb/src/test-integration/java/io/airbyte/integrations/destination/dynamodb/SshKeyDynamodbDestinationAcceptanceTest.java
@@ -1,0 +1,16 @@
+/*
+ * Copyright (c) 2022 Airbyte, Inc., all rights reserved.
+ */
+
+package io.airbyte.integrations.destination.dynamodb;
+
+import io.airbyte.integrations.base.ssh.SshTunnel;
+
+public class SshKeyDynamodbDestinationAcceptanceTest extends SshDynamodbDestinationAcceptanceTest {
+
+  @Override
+  public SshTunnel.TunnelMethod getTunnelMethod() {
+    return SshTunnel.TunnelMethod.SSH_KEY_AUTH;
+  }
+
+}

--- a/airbyte-integrations/connectors/destination-dynamodb/src/test-integration/java/io/airbyte/integrations/destination/dynamodb/SshPasswordDynamodbDestinationAcceptanceTest.java
+++ b/airbyte-integrations/connectors/destination-dynamodb/src/test-integration/java/io/airbyte/integrations/destination/dynamodb/SshPasswordDynamodbDestinationAcceptanceTest.java
@@ -1,0 +1,16 @@
+/*
+ * Copyright (c) 2022 Airbyte, Inc., all rights reserved.
+ */
+
+package io.airbyte.integrations.destination.dynamodb;
+
+import io.airbyte.integrations.base.ssh.SshTunnel;
+
+public class SshPasswordDynamodbDestinationAcceptanceTest extends SshDynamodbDestinationAcceptanceTest {
+
+  @Override
+  public SshTunnel.TunnelMethod getTunnelMethod() {
+    return SshTunnel.TunnelMethod.SSH_PASSWORD_AUTH;
+  }
+
+}

--- a/deps.toml
+++ b/deps.toml
@@ -22,6 +22,7 @@ connectors-testcontainers-tidb = "1.16.3"
 connectors-destination-testcontainers-clickhouse = "1.17.3"
 connectors-destination-testcontainers-oracle-xe = "1.17.3"
 connectors-destination-testcontainers-elasticsearch = "1.17.3"
+connectors-destination-testcontainers-dynamodb = "1.17.5"
 connectors-source-testcontainers-clickhouse = "1.17.3"
 platform-testcontainers = "1.17.3"
 
@@ -56,6 +57,7 @@ connectors-testcontainers-cassandra = { module = "org.testcontainers:cassandra",
 connectors-testcontainers-cockroachdb = { module = "org.testcontainers:cockroachdb", version.ref = "connectors-testcontainers" }
 connectors-testcontainers-db2 = { module = "org.testcontainers:db2", version.ref = "connectors-testcontainers" }
 connectors-testcontainers-elasticsearch = { module = "org.testcontainers:elasticsearch", version.ref = "connectors-destination-testcontainers-elasticsearch" }
+connectors-testcontainers-dynamodb = { module = "org.testcontainers:dynalite", version.ref = "connectors-destination-testcontainers-dynamodb" }
 connectors-testcontainers-jdbc = { module = "org.testcontainers:jdbc", version.ref = "connectors-testcontainers" }
 connectors-testcontainers-kafka = { module = "org.testcontainers:kafka", version.ref = "connectors-testcontainers" }
 connectors-testcontainers-mariadb = { module = "org.testcontainers:mariadb", version.ref = "connectors-testcontainers-mariadb" }


### PR DESCRIPTION
## What
Draft SSH DynamoDB support. 

_NOTE: Since DynamoDB is mostly used in Amazon infrastructure we can ignore SSH support for now. Leaving this PR for potential need_  

