### PR TITLE
fix cron resources spec

### DIFF
--- a/charts/airbyte-cron/templates/deployment.yaml
+++ b/charts/airbyte-cron/templates/deployment.yaml
@@ -141,5 +141,5 @@ spec:
           {{- end }}
 
           {{- if .Values.resources }}
-          resources: {{- toYaml .Values.resources | nindent 10 }}
+          resources: {{- toYaml .Values.resources | nindent 12 }}
           {{- end }}


### PR DESCRIPTION
## What
* Fix resources spec in `airbyte-cron` chart so it won't break on unknown field error