### PR TITLE
hide config persistence

### DIFF
--- a/airbyte-bootloader/src/main/java/io/airbyte/bootloader/BootloaderApp.java
+++ b/airbyte-bootloader/src/main/java/io/airbyte/bootloader/BootloaderApp.java
@@ -18,9 +18,7 @@ import io.airbyte.config.init.ApplyDefinitionsHelper;
 import io.airbyte.config.init.DefinitionsProvider;
 import io.airbyte.config.init.LocalDefinitionsProvider;
 import io.airbyte.config.persistence.ConfigNotFoundException;
-import io.airbyte.config.persistence.ConfigPersistence;
 import io.airbyte.config.persistence.ConfigRepository;
-import io.airbyte.config.persistence.DatabaseConfigPersistence;
 import io.airbyte.config.persistence.SecretsRepositoryReader;
 import io.airbyte.config.persistence.SecretsRepositoryWriter;
 import io.airbyte.config.persistence.split_secrets.SecretPersistence;
@@ -193,10 +191,6 @@ public class BootloaderApp {
     return new Database(dslContext);
   }
 
-  private static ConfigPersistence getConfigPersistence(final Database configDatabase) throws IOException {
-    return DatabaseConfigPersistence.createWithValidation(configDatabase);
-  }
-
   private static DefinitionsProvider getLocalDefinitionsProvider() throws IOException {
     return new LocalDefinitionsProvider(LocalDefinitionsProvider.DEFAULT_SEED_DEFINITION_RESOURCE_CLASS);
   }
@@ -212,7 +206,7 @@ public class BootloaderApp {
   private void initPersistences(final DSLContext configsDslContext, final DSLContext jobsDslContext) {
     try {
       configDatabase = getConfigDatabase(configsDslContext);
-      configRepository = new ConfigRepository(getConfigPersistence(configDatabase), configDatabase);
+      configRepository = new ConfigRepository(configDatabase);
       localDefinitionsProvider = getLocalDefinitionsProvider();
       jobDatabase = getJobDatabase(jobsDslContext);
       jobPersistence = getJobPersistence(jobDatabase);
@@ -236,8 +230,7 @@ public class BootloaderApp {
 
       // TODO Will be converted to an injected singleton during DI migration
       final Database configDatabase = getConfigDatabase(configsDslContext);
-      final ConfigPersistence configPersistence = getConfigPersistence(configDatabase);
-      final ConfigRepository configRepository = new ConfigRepository(configPersistence, configDatabase);
+      final ConfigRepository configRepository = new ConfigRepository(configDatabase);
       final Database jobDatabase = getJobDatabase(jobsDslContext);
       final JobPersistence jobPersistence = getJobPersistence(jobDatabase);
 

--- a/airbyte-bootloader/src/test/java/io/airbyte/bootloader/BootloaderAppTest.java
+++ b/airbyte-bootloader/src/test/java/io/airbyte/bootloader/BootloaderAppTest.java
@@ -27,7 +27,6 @@ import io.airbyte.config.StandardWorkspace;
 import io.airbyte.config.init.DefinitionsProvider;
 import io.airbyte.config.init.LocalDefinitionsProvider;
 import io.airbyte.config.persistence.ConfigRepository;
-import io.airbyte.config.persistence.DatabaseConfigPersistence;
 import io.airbyte.config.persistence.SecretsRepositoryReader;
 import io.airbyte.config.persistence.SecretsRepositoryWriter;
 import io.airbyte.config.persistence.split_secrets.LocalTestingSecretPersistence;
@@ -181,8 +180,7 @@ class BootloaderAppTest {
       val configDatabase = new ConfigsDatabaseTestProvider(configsDslContext, configsFlyway).create(false);
       val jobDatabase = new JobsDatabaseTestProvider(jobsDslContext, jobsFlyway).create(false);
 
-      val configPersistence = new DatabaseConfigPersistence(configDatabase);
-      val configRepository = new ConfigRepository(configPersistence, configDatabase);
+      val configRepository = new ConfigRepository(configDatabase);
       val jobsPersistence = new DefaultJobPersistence(jobDatabase);
 
       val secretsPersistence = SecretPersistence.getLongLived(configsDslContext, mockedConfigs);

--- a/airbyte-bootloader/src/test/java/io/airbyte/bootloader/BootloaderAppTest.java
+++ b/airbyte-bootloader/src/test/java/io/airbyte/bootloader/BootloaderAppTest.java
@@ -234,6 +234,7 @@ class BootloaderAppTest {
           .withSourceId(sourceId)
           .withName("test source")
           .withWorkspaceId(workspaceId)
+          .withTombstone(false)
           .withConfiguration(mapper.readTree(sourceSpecs)));
 
       when(mockedFeatureFlags.forceSecretMigration()).thenReturn(false);

--- a/airbyte-config/config-persistence/src/main/java/io/airbyte/config/persistence/ConfigPersistence.java
+++ b/airbyte-config/config-persistence/src/main/java/io/airbyte/config/persistence/ConfigPersistence.java
@@ -14,7 +14,7 @@ import java.util.Map;
 /**
  * We are moving migrating away from this interface entirely. Use ConfigRepository instead.
  */
-@Deprecated
+@Deprecated(forRemoval = true)
 public interface ConfigPersistence {
 
   <T> T getConfig(AirbyteConfig configType, String configId, Class<T> clazz) throws ConfigNotFoundException, JsonValidationException, IOException;

--- a/airbyte-config/config-persistence/src/main/java/io/airbyte/config/persistence/ConfigRepository.java
+++ b/airbyte-config/config-persistence/src/main/java/io/airbyte/config/persistence/ConfigRepository.java
@@ -93,8 +93,8 @@ public class ConfigRepository {
   private final ExceptionWrappingDatabase database;
   private final ActorDefinitionMigrator actorDefinitionMigrator;
 
-  public ConfigRepository(final ConfigPersistence persistence, final Database database) {
-    this(persistence, database, new ActorDefinitionMigrator(new ExceptionWrappingDatabase(database)));
+  public ConfigRepository(final Database database) {
+    this(DatabaseConfigPersistence.createWithValidation(database), database, new ActorDefinitionMigrator(new ExceptionWrappingDatabase(database)));
   }
 
   @VisibleForTesting

--- a/airbyte-config/config-persistence/src/main/java/io/airbyte/config/persistence/ConfigRepository.java
+++ b/airbyte-config/config-persistence/src/main/java/io/airbyte/config/persistence/ConfigRepository.java
@@ -579,6 +579,16 @@ public class ConfigRepository {
     persistence.writeConfig(ConfigSchema.SOURCE_CONNECTION, partialSource.getSourceId().toString(), partialSource);
   }
 
+  public boolean deleteSource(final UUID sourceId) throws JsonValidationException, ConfigNotFoundException, IOException {
+    try {
+      getSourceConnection(sourceId);
+      persistence.deleteConfig(ConfigSchema.SOURCE_CONNECTION, sourceId.toString());
+      return true;
+    } catch (final ConfigNotFoundException e) {
+      return false;
+    }
+  }
+
   /**
    * Returns all sources in the database. Does not contain secrets. To hydrate with secrets see
    * { @link SecretsRepositoryReader#listSourceConnectionWithSecrets() }.
@@ -636,6 +646,16 @@ public class ConfigRepository {
    */
   public void writeDestinationConnectionNoSecrets(final DestinationConnection partialDestination) throws JsonValidationException, IOException {
     persistence.writeConfig(ConfigSchema.DESTINATION_CONNECTION, partialDestination.getDestinationId().toString(), partialDestination);
+  }
+
+  public boolean deleteDestination(final UUID destId) throws JsonValidationException, ConfigNotFoundException, IOException {
+    try {
+      getDestinationConnection(destId);
+      persistence.deleteConfig(ConfigSchema.DESTINATION_CONNECTION, destId.toString());
+      return true;
+    } catch (final ConfigNotFoundException e) {
+      return false;
+    }
   }
 
   /**

--- a/airbyte-config/config-persistence/src/main/java/io/airbyte/config/persistence/DatabaseConfigPersistence.java
+++ b/airbyte-config/config-persistence/src/main/java/io/airbyte/config/persistence/DatabaseConfigPersistence.java
@@ -79,6 +79,7 @@ import org.jooq.impl.TableImpl;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+@Deprecated(forRemoval = true)
 @SuppressWarnings({"PMD.CyclomaticComplexity", "PMD.CognitiveComplexity", "PMD.NPathComplexity", "PMD.ExcessiveMethodLength",
   "PMD.AvoidThrowingRawExceptionTypes", "PMD.ShortVariable", "PMD.LongVariable", "PMD.ExcessiveClassLength", "PMD.AvoidLiteralsInIfCondition"})
 public class DatabaseConfigPersistence implements ConfigPersistence {

--- a/airbyte-config/config-persistence/src/main/java/io/airbyte/config/persistence/ValidatingConfigPersistence.java
+++ b/airbyte-config/config-persistence/src/main/java/io/airbyte/config/persistence/ValidatingConfigPersistence.java
@@ -19,6 +19,7 @@ import java.util.Map;
  * Validates that json input and outputs for the ConfigPersistence against their schemas.
  */
 @SuppressWarnings("PMD.AvoidThrowingRawExceptionTypes")
+@Deprecated(forRemoval = true)
 public class ValidatingConfigPersistence implements ConfigPersistence {
 
   private final JsonSchemaValidator schemaValidator;

--- a/airbyte-config/config-persistence/src/test/java/io/airbyte/config/persistence/ConfigRepositoryE2EReadWriteTest.java
+++ b/airbyte-config/config-persistence/src/test/java/io/airbyte/config/persistence/ConfigRepositoryE2EReadWriteTest.java
@@ -32,6 +32,7 @@ import io.airbyte.config.StandardWorkspace;
 import io.airbyte.config.persistence.ConfigRepository.DestinationAndDefinition;
 import io.airbyte.config.persistence.ConfigRepository.SourceAndDefinition;
 import io.airbyte.db.Database;
+import io.airbyte.db.ExceptionWrappingDatabase;
 import io.airbyte.db.factory.DSLContextFactory;
 import io.airbyte.db.factory.FlywayFactory;
 import io.airbyte.db.init.DatabaseInitializationException;
@@ -97,7 +98,7 @@ class ConfigRepositoryE2EReadWriteTest {
         ConfigsDatabaseMigrator.MIGRATION_FILE_LOCATION);
     database = new ConfigsDatabaseTestProvider(dslContext, flyway).create(false);
     configPersistence = spy(new DatabaseConfigPersistence(database));
-    configRepository = spy(new ConfigRepository(configPersistence, database));
+    configRepository = spy(new ConfigRepository(configPersistence, database, new ActorDefinitionMigrator(new ExceptionWrappingDatabase(database))));
     final ConfigsDatabaseMigrator configsDatabaseMigrator =
         new ConfigsDatabaseMigrator(database, flyway);
     final DevDatabaseMigrator devDatabaseMigrator = new DevDatabaseMigrator(configsDatabaseMigrator);

--- a/airbyte-config/config-persistence/src/test/java/io/airbyte/config/persistence/ConfigRepositoryTest.java
+++ b/airbyte-config/config-persistence/src/test/java/io/airbyte/config/persistence/ConfigRepositoryTest.java
@@ -29,6 +29,7 @@ import io.airbyte.config.StandardSyncState;
 import io.airbyte.config.StandardWorkspace;
 import io.airbyte.config.State;
 import io.airbyte.db.Database;
+import io.airbyte.db.ExceptionWrappingDatabase;
 import io.airbyte.protocol.models.AirbyteStream;
 import io.airbyte.protocol.models.ConfiguredAirbyteCatalog;
 import io.airbyte.protocol.models.ConfiguredAirbyteStream;
@@ -62,7 +63,7 @@ class ConfigRepositoryTest {
   void setup() {
     configPersistence = mock(ConfigPersistence.class);
     database = mock(Database.class);
-    configRepository = spy(new ConfigRepository(configPersistence, database));
+    configRepository = spy(new ConfigRepository(configPersistence, database, new ActorDefinitionMigrator(new ExceptionWrappingDatabase(database))));
   }
 
   @AfterEach

--- a/airbyte-config/config-persistence/src/test/java/io/airbyte/config/persistence/StatePersistenceTest.java
+++ b/airbyte-config/config-persistence/src/test/java/io/airbyte/config/persistence/StatePersistenceTest.java
@@ -16,6 +16,7 @@ import io.airbyte.config.StandardWorkspace;
 import io.airbyte.config.State;
 import io.airbyte.config.StateType;
 import io.airbyte.config.StateWrapper;
+import io.airbyte.db.ExceptionWrappingDatabase;
 import io.airbyte.db.factory.DSLContextFactory;
 import io.airbyte.db.factory.FlywayFactory;
 import io.airbyte.db.init.DatabaseInitializationException;
@@ -544,7 +545,10 @@ class StatePersistenceTest extends BaseDatabaseConfigPersistenceTest {
   }
 
   private void setupTestData() throws JsonValidationException, IOException {
-    configRepository = new ConfigRepository(new DatabaseConfigPersistence(database), database);
+    configRepository = new ConfigRepository(
+        new DatabaseConfigPersistence(database),
+        database,
+        new ActorDefinitionMigrator(new ExceptionWrappingDatabase(database)));
 
     final StandardWorkspace workspace = MockData.standardWorkspaces().get(0);
     final StandardSourceDefinition sourceDefinition = MockData.publicSourceDefinition();

--- a/airbyte-cron/src/main/java/io/airbyte/cron/config/DatabaseBeanFactory.java
+++ b/airbyte-cron/src/main/java/io/airbyte/cron/config/DatabaseBeanFactory.java
@@ -5,11 +5,8 @@
 package io.airbyte.cron.config;
 
 import io.airbyte.commons.temporal.config.WorkerMode;
-import io.airbyte.config.persistence.ConfigPersistence;
 import io.airbyte.config.persistence.ConfigRepository;
-import io.airbyte.config.persistence.DatabaseConfigPersistence;
 import io.airbyte.config.persistence.StreamResetPersistence;
-import io.airbyte.config.persistence.split_secrets.JsonSecretsProcessor;
 import io.airbyte.db.Database;
 import io.airbyte.db.check.DatabaseMigrationCheck;
 import io.airbyte.db.factory.DatabaseCheckFactory;
@@ -68,15 +65,8 @@ public class DatabaseBeanFactory {
   }
 
   @Singleton
-  public ConfigPersistence configPersistence(@Named("configDatabase") final Database configDatabase,
-                                             final JsonSecretsProcessor jsonSecretsProcessor) {
-    return DatabaseConfigPersistence.createWithValidation(configDatabase);
-  }
-
-  @Singleton
-  public ConfigRepository configRepository(@Named("configPersistence") final ConfigPersistence configPersistence,
-                                           @Named("configDatabase") final Database configDatabase) {
-    return new ConfigRepository(configPersistence, configDatabase);
+  public ConfigRepository configRepository(@Named("configDatabase") final Database configDatabase) {
+    return new ConfigRepository(configDatabase);
   }
 
   @Singleton

--- a/airbyte-server/src/main/java/io/airbyte/server/ServerApp.java
+++ b/airbyte-server/src/main/java/io/airbyte/server/ServerApp.java
@@ -22,9 +22,7 @@ import io.airbyte.config.StandardSync;
 import io.airbyte.config.StandardSync.Status;
 import io.airbyte.config.helpers.LogClientSingleton;
 import io.airbyte.config.persistence.ConfigNotFoundException;
-import io.airbyte.config.persistence.ConfigPersistence;
 import io.airbyte.config.persistence.ConfigRepository;
-import io.airbyte.config.persistence.DatabaseConfigPersistence;
 import io.airbyte.config.persistence.SecretsRepositoryReader;
 import io.airbyte.config.persistence.SecretsRepositoryWriter;
 import io.airbyte.config.persistence.StreamResetPersistence;
@@ -189,11 +187,10 @@ public class ServerApp implements ServerRunnable {
 
     LOGGER.info("Creating config repository...");
     final Database configsDatabase = new Database(configsDslContext);
-    final ConfigPersistence configPersistence = DatabaseConfigPersistence.createWithValidation(configsDatabase);
     final SecretsHydrator secretsHydrator = SecretPersistence.getSecretsHydrator(configsDslContext, configs);
     final Optional<SecretPersistence> secretPersistence = SecretPersistence.getLongLived(configsDslContext, configs);
     final Optional<SecretPersistence> ephemeralSecretPersistence = SecretPersistence.getEphemeral(configsDslContext, configs);
-    final ConfigRepository configRepository = new ConfigRepository(configPersistence, configsDatabase);
+    final ConfigRepository configRepository = new ConfigRepository(configsDatabase);
     final SecretsRepositoryReader secretsRepositoryReader = new SecretsRepositoryReader(configRepository, secretsHydrator);
     final SecretsRepositoryWriter secretsRepositoryWriter =
         new SecretsRepositoryWriter(configRepository, secretPersistence, ephemeralSecretPersistence);

--- a/airbyte-workers/src/main/java/io/airbyte/workers/config/DatabaseBeanFactory.java
+++ b/airbyte-workers/src/main/java/io/airbyte/workers/config/DatabaseBeanFactory.java
@@ -5,12 +5,9 @@
 package io.airbyte.workers.config;
 
 import io.airbyte.commons.temporal.config.WorkerMode;
-import io.airbyte.config.persistence.ConfigPersistence;
 import io.airbyte.config.persistence.ConfigRepository;
-import io.airbyte.config.persistence.DatabaseConfigPersistence;
 import io.airbyte.config.persistence.StatePersistence;
 import io.airbyte.config.persistence.StreamResetPersistence;
-import io.airbyte.config.persistence.split_secrets.JsonSecretsProcessor;
 import io.airbyte.db.Database;
 import io.airbyte.db.check.DatabaseMigrationCheck;
 import io.airbyte.db.check.impl.JobsDatabaseAvailabilityCheck;
@@ -90,16 +87,8 @@ public class DatabaseBeanFactory {
 
   @Singleton
   @Requires(env = WorkerMode.CONTROL_PLANE)
-  public ConfigPersistence configPersistence(@Named("configDatabase") final Database configDatabase,
-                                             final JsonSecretsProcessor jsonSecretsProcessor) {
-    return DatabaseConfigPersistence.createWithValidation(configDatabase);
-  }
-
-  @Singleton
-  @Requires(env = WorkerMode.CONTROL_PLANE)
-  public ConfigRepository configRepository(@Named("configPersistence") final ConfigPersistence configPersistence,
-                                           @Named("configDatabase") final Database configDatabase) {
-    return new ConfigRepository(configPersistence, configDatabase);
+  public ConfigRepository configRepository(@Named("configDatabase") final Database configDatabase) {
+    return new ConfigRepository(configDatabase);
   }
 
   @Singleton


### PR DESCRIPTION
## What
* Goal: Remove `ConfigPersistence` entirely
* This PR fully hides `ConfigPersistence` inside of `ConfigRepository` as an implementation detail. 
* Next steps are to replace usages inside of `ConfigRepository` with jooq queries (or whatever micronaut stuff we replace it with). Until then, we want to avoid new usages of `ConfigPersistence` appearing, so we hide it, so no one is tempted to use it.

Reviewers: I am not very familiar with micronaut, so please lmk if I've done anything obviously dumb with the bean factories.