### PR TITLE
🐛 Destination Typesense: fix default batch size

### DIFF
--- a/airbyte-integrations/connectors/destination-typesense/destination_typesense/destination.py
+++ b/airbyte-integrations/connectors/destination-typesense/destination_typesense/destination.py
@@ -18,7 +18,7 @@ def get_client(config: Mapping[str, Any]) -> Client:
     port = config.get("port") or "8108"
     protocol = config.get("protocol") or "https"
 
-    client = Client({"api_key": api_key, "nodes": [{"host": host, "port": port, "protocol": protocol}], "connection_timeout_seconds": 2})
+    client = Client({"api_key": api_key, "nodes": [{"host": host, "port": port, "protocol": protocol}], "connection_timeout_seconds": 3600})
 
     return client
 

--- a/airbyte-integrations/connectors/destination-typesense/destination_typesense/spec.json
+++ b/airbyte-integrations/connectors/destination-typesense/destination_typesense/spec.json
@@ -37,7 +37,7 @@
       },
       "batch_size": {
         "title": "Batch size",
-        "type": "string",
+        "type": "integer",
         "description": "How many documents should be imported together. Default 1000",
         "order": 4
       }

--- a/airbyte-integrations/connectors/destination-typesense/destination_typesense/writer.py
+++ b/airbyte-integrations/connectors/destination-typesense/destination_typesense/writer.py
@@ -14,10 +14,10 @@ logger = getLogger("airbyte")
 class TypesenseWriter:
     write_buffer = []
 
-    def __init__(self, client: Client, steam_name: str, batch_size: int = 1000):
+    def __init__(self, client: Client, steam_name: str, batch_size: int = None):
         self.client = client
         self.steam_name = steam_name
-        self.batch_size = batch_size
+        self.batch_size = batch_size or 1000
 
     def queue_write_operation(self, data: Mapping):
         random_key = str(uuid4())

--- a/airbyte-integrations/connectors/destination-typesense/destination_typesense/writer.py
+++ b/airbyte-integrations/connectors/destination-typesense/destination_typesense/writer.py
@@ -17,7 +17,7 @@ class TypesenseWriter:
     def __init__(self, client: Client, steam_name: str, batch_size: int = None):
         self.client = client
         self.steam_name = steam_name
-        self.batch_size = batch_size or 1000
+        self.batch_size = batch_size or 10000
 
     def queue_write_operation(self, data: Mapping):
         random_key = str(uuid4())

--- a/airbyte-integrations/connectors/destination-typesense/unit_tests/unit_test.py
+++ b/airbyte-integrations/connectors/destination-typesense/unit_tests/unit_test.py
@@ -8,6 +8,24 @@ from destination_typesense.writer import TypesenseWriter
 
 
 @patch("typesense.Client")
+def test_default_batch_size(client):
+    writer = TypesenseWriter(client, "steam_name")
+    assert writer.batch_size == 1000
+
+
+@patch("typesense.Client")
+def test_empty_batch_size(client):
+    writer = TypesenseWriter(client, "steam_name", "")
+    assert writer.batch_size == 1000
+
+
+@patch("typesense.Client")
+def test_custom_batch_size(client):
+    writer = TypesenseWriter(client, "steam_name", 9000)
+    assert writer.batch_size == 9000
+
+
+@patch("typesense.Client")
 def test_queue_write_operation(client):
     writer = TypesenseWriter(client, "steam_name")
     writer.queue_write_operation({"a": "a"})

--- a/airbyte-integrations/connectors/destination-typesense/unit_tests/unit_test.py
+++ b/airbyte-integrations/connectors/destination-typesense/unit_tests/unit_test.py
@@ -10,13 +10,13 @@ from destination_typesense.writer import TypesenseWriter
 @patch("typesense.Client")
 def test_default_batch_size(client):
     writer = TypesenseWriter(client, "steam_name")
-    assert writer.batch_size == 1000
+    assert writer.batch_size == 10000
 
 
 @patch("typesense.Client")
 def test_empty_batch_size(client):
     writer = TypesenseWriter(client, "steam_name", "")
-    assert writer.batch_size == 1000
+    assert writer.batch_size == 10000
 
 
 @patch("typesense.Client")


### PR DESCRIPTION
## What
The batch size isn't working. The destination is syncing the whole source stream leading to high memory allocation for large dataset

## How
Change Batch Size to integer on spec.json
If batch_size is None or "" we should use the default batch_size value

## Recommended reading order
1. writer.py
2. spec.json

## 🚨 User Impact 🚨
No

## Pre-merge Checklist
Expand the relevant checklist and delete the others.

<details><summary><strong>Updating a connector</strong></summary>

### Community member or Airbyter

- [ ] Grant edit access to maintainers ([instructions](https://docs.github.com/en/github/collaborating-with-pull-requests/working-with-forks/allowing-changes-to-a-pull-request-branch-created-from-a-fork#enabling-repository-maintainer-permissions-on-existing-pull-requests))
- [ ] Secrets in the connector's spec are annotated with `airbyte_secret`
- [ ] Unit & integration tests added and passing. Community members, please provide proof of success locally e.g: screenshot or copy-paste unit, integration, and acceptance test output. To run acceptance tests for a Python connector, follow instructions in the README. For java connectors run `./gradlew :airbyte-integrations:connectors:<name>:integrationTest`.
- [ ] Code reviews completed
- [ ] Documentation updated
    - [ ] Connector's `README.md`
    - [ ] Connector's `bootstrap.md`. See [description and examples](https://docs.google.com/document/d/1ypdgmwmEHWv-TrO4_YOQ7pAJGVrMp5BOkEVh831N260/edit?usp=sharing)
    - [ ] Changelog updated in `docs/integrations/<source or destination>/<name>.md` including changelog. See changelog [example](https://docs.airbyte.io/integrations/sources/stripe#changelog)
- [ ] PR name follows [PR naming conventions](https://docs.airbyte.com/contributing-to-airbyte/issues-and-pull-requests)

### Airbyter

If this is a community PR, the Airbyte engineer reviewing this PR is responsible for the below items.

- [ ] Create a non-forked branch based on this PR and test the below items on it
- [ ] Build is successful
- [ ] If new credentials are required for use in CI, add them to GSM. [Instructions](https://docs.airbyte.io/connector-development#using-credentials-in-ci).
- [ ] [`/test connector=connectors/<name>` command](https://docs.airbyte.io/connector-development#updating-an-existing-connector) is passing
- [ ] New Connector version released on Dockerhub and connector version bumped by running the `/publish` command described [here](https://docs.airbyte.io/connector-development#updating-an-existing-connector)

</details>

## Tests

<details><summary><strong>Unit</strong></summary>

```
❯ python -m pytest -s -vv unit_tests
==================================================================================================== test session starts =====================================================================================================

unit_tests/unit_test.py::test_default_batch_size PASSED
unit_tests/unit_test.py::test_empty_batch_size PASSED
unit_tests/unit_test.py::test_custom_batch_size PASSED
unit_tests/unit_test.py::test_queue_write_operation PASSED
unit_tests/unit_test.py::test_flush {"type": "LOG", "log": {"level": "INFO", "message": "flushing 2 records"}}
PASSED

===================================================================================================== 5 passed in 0.37s ======================================================================================================
```

</details>

