### PR TITLE
increase test timeout for some webapp tests to prevent flakes

### DIFF
--- a/airbyte-webapp/src/pages/ConnectionPage/pages/ConnectionItemPage/ConnectionReplicationTab.test.tsx
+++ b/airbyte-webapp/src/pages/ConnectionPage/pages/ConnectionItemPage/ConnectionReplicationTab.test.tsx
@@ -19,6 +19,7 @@ import { ConnectionReplicationTab } from "./ConnectionReplicationTab";
 jest.mock("services/connector/DestinationDefinitionSpecificationService", () => ({
   useGetDestinationDefinitionSpecification: () => mockDest,
 }));
+jest.setTimeout(10000);
 
 describe("ConnectionReplicationTab", () => {
   const Wrapper: React.FC<React.PropsWithChildren<unknown>> = ({ children }) => (


### PR DESCRIPTION
## What
Add a 10s timeout for some webapp tests which frequently time out and flake when I do a local platform build.
