### PR TITLE
ci: replace GITHUB_OUTPUT with GITHUB_ENV on multiline variables

### DIFF
--- a/.github/workflows/publish-helm-charts.yml
+++ b/.github/workflows/publish-helm-charts.yml
@@ -109,7 +109,10 @@ jobs:
         id: changelog
         run: |
           cd ./airbyte/
-          echo "::set-output name=changelog::$(PAGER=cat git log $(git describe --tags --match "*-helm" $(git rev-list --tags --max-count=1))..HEAD --oneline --decorate=no)"
+          changelog=$(PAGER=cat git log $(git describe --tags --match "*-helm" $(git rev-list --tags --max-count=1))..HEAD --oneline --decorate=no)
+          echo "changelog<<EOF" >> $GITHUB_ENV
+          echo "$changelog" >> $GITHUB_ENV
+          echo "EOF" >> $GITHUB_ENV
 
       - name: Create Pull Request
         uses: peter-evans/create-pull-request@v4
@@ -122,7 +125,7 @@ jobs:
             ## What
             Bump version reference in all Chart.yaml files to ${{ needs.generate-semantic-version.outputs.next-version }}
             CHANGELOG:
-            ${{ steps.changelog.outputs.changelog }}
+            ${{ env.changelog }}
           commit-message: Bump helm chart version reference to ${{ needs.generate-semantic-version.outputs.next-version }}
           delete-branch: true
 

--- a/.github/workflows/release-airbyte-os.yml
+++ b/.github/workflows/release-airbyte-os.yml
@@ -135,8 +135,9 @@ jobs:
         run: |
           chmod +x tools/bin/pr_body.sh
           body=$(./tools/bin/pr_body.sh)
-          body="${body//$'\n'/'%0A'}"
-          echo PR_BODY=$body >> $GITHUB_OUTPUT
+          echo "PR_BODY<<EOF" >> $GITHUB_ENV
+          echo "$body" >> $GITHUB_ENV
+          echo "EOF" >> $GITHUB_ENV
       - name: Create Pull Request
         id: cpr
         uses: peter-evans/create-pull-request@v3
@@ -146,7 +147,7 @@ jobs:
           branch-suffix: random
           delete-branch: true
           title: Bump Airbyte version from ${{ steps.bump_version.outputs.PREV_VERSION }} to ${{ steps.bump_version.outputs.NEW_VERSION }}
-          body: ${{ steps.pr_body.outputs.PR_BODY }}
+          body: ${{ env.PR_BODY }}
           commit-message: Bump Airbyte version from ${{ steps.bump_version.outputs.PREV_VERSION }} to ${{ steps.bump_version.outputs.NEW_VERSION }}
       - name: PR Details
         run: |

--- a/tools/bin/bump_version.sh
+++ b/tools/bin/bump_version.sh
@@ -20,6 +20,6 @@ export VERSION=$NEW_VERSION # for safety, since lib.sh exports a VERSION that is
 
 set +o xtrace
 echo "Bumped version from ${PREV_VERSION} to ${NEW_VERSION}"
-echo ::set-output name=PREV_VERSION::${PREV_VERSION}
-echo ::set-output name=NEW_VERSION::${NEW_VERSION}
-echo ::set-output name=GIT_REVISION::${GIT_REVISION}
+echo "PREV_VERSION=${PREV_VERSION}" >> $GITHUB_OUTPUT
+echo "NEW_VERSION=${NEW_VERSION}" >> $GITHUB_OUTPUT
+echo "GIT_REVISION=${GIT_REVISION}" >> $GITHUB_OUTPUT

--- a/tools/bin/find_non_rate_limited_PAT
+++ b/tools/bin/find_non_rate_limited_PAT
@@ -40,8 +40,8 @@ for personal_access_token in $@
       # github actions will NOT pass a string that looks like a secret
       base64_valid_pat=$(echo "$personal_access_token" | base64)
       echo -e "$blue_text""Found a good PAT!!""$default_text"
-      # ::set-output name is a github action magic string for output
-      echo "::set-output name=pat::$base64_valid_pat"
+      # $GITHUB_OUTPUT is a github action magic env variable for output
+      echo "pat=$base64_valid_pat" >> $GITHUB_OUTPUT
       echo "PAT=$personal_access_token" >> $GITHUB_ENV
       exit 0
     else


### PR DESCRIPTION
## What
[$GITHUB_OUTPUT](https://docs.github.com/en/actions/using-workflows/workflow-commands-for-github-actions#setting-an-output-parameter) in GitHub Actions doesn't work correctly with multiline variables.

## How
Replace [$GITHUB_OUTPUT](https://docs.github.com/en/actions/using-workflows/workflow-commands-for-github-actions#setting-an-output-parameter) with [$GITHUB_ENV](https://docs.github.com/en/actions/using-workflows/workflow-commands-for-github-actions#multiline-strings) on multiline strings.

