### PR TITLE
:window: :tada: Allow environment specific sections in docs

### DIFF
--- a/airbyte-webapp/src/components/common/DocumentationPanel/DocumentationPanel.test.ts
+++ b/airbyte-webapp/src/components/common/DocumentationPanel/DocumentationPanel.test.ts
@@ -2,27 +2,27 @@ import { prepareMarkdown } from "./DocumentationPanel";
 
 const testMarkdown = `## Some documentation
 
-<!-- ENV:CLOUD -->
+<!-- env:cloud -->
 ### Only relevant for Cloud
 
 some specific documentation that only applies for cloud.
-<!-- /ENV:CLOUD -->
+<!-- /env:cloud -->
 
-<!-- ENV:OSS -->
+<!-- env:oss -->
 ### Only relevant for OSS users
 
 some specific documentation that only applies for OSS users
-<!-- /ENV:OSS -->`;
+<!-- /env:oss -->`;
 
 describe("prepareMarkdown", () => {
   it("should prepare markdown for cloud", () => {
     expect(prepareMarkdown(testMarkdown, "cloud")).toBe(`## Some documentation
 
-<!-- ENV:CLOUD -->
+<!-- env:cloud -->
 ### Only relevant for Cloud
 
 some specific documentation that only applies for cloud.
-<!-- /ENV:CLOUD -->
+<!-- /env:cloud -->
 
 `);
   });
@@ -31,10 +31,10 @@ some specific documentation that only applies for cloud.
 
 
 
-<!-- ENV:OSS -->
+<!-- env:oss -->
 ### Only relevant for OSS users
 
 some specific documentation that only applies for OSS users
-<!-- /ENV:OSS -->`);
+<!-- /env:oss -->`);
   });
 });

--- a/airbyte-webapp/src/components/common/DocumentationPanel/DocumentationPanel.test.ts
+++ b/airbyte-webapp/src/components/common/DocumentationPanel/DocumentationPanel.test.ts
@@ -1,0 +1,40 @@
+import { prepareMarkdown } from "./DocumentationPanel";
+
+const testMarkdown = `## Some documentation
+
+<!-- ENV:CLOUD -->
+### Only relevant for Cloud
+
+some specific documentation that only applies for cloud.
+<!-- /ENV:CLOUD -->
+
+<!-- ENV:OSS -->
+### Only relevant for OSS users
+
+some specific documentation that only applies for OSS users
+<!-- /ENV:OSS -->`;
+
+describe("prepareMarkdown", () => {
+  it("should prepare markdown for cloud", () => {
+    expect(prepareMarkdown(testMarkdown, "cloud")).toBe(`## Some documentation
+
+<!-- ENV:CLOUD -->
+### Only relevant for Cloud
+
+some specific documentation that only applies for cloud.
+<!-- /ENV:CLOUD -->
+
+`);
+  });
+  it("should prepare markdown for oss", () => {
+    expect(prepareMarkdown(testMarkdown, "oss")).toBe(`## Some documentation
+
+
+
+<!-- ENV:OSS -->
+### Only relevant for OSS users
+
+some specific documentation that only applies for OSS users
+<!-- /ENV:OSS -->`);
+  });
+});

--- a/airbyte-webapp/src/components/common/DocumentationPanel/DocumentationPanel.tsx
+++ b/airbyte-webapp/src/components/common/DocumentationPanel/DocumentationPanel.tsx
@@ -14,10 +14,18 @@ import { PageHeader } from "components/ui/PageHeader";
 
 import { useConfig } from "config";
 import { useDocumentation } from "hooks/services/useDocumentation";
+import { isCloudApp } from "utils/app";
 import { links } from "utils/links";
 import { useDocumentationPanelContext } from "views/Connector/ConnectorDocumentationLayout/DocumentationPanelContext";
 
 import styles from "./DocumentationPanel.module.scss";
+
+const OSS_ENV_MARKERS = /<!-- ENV:OSS -->([\s\S]*?)<!-- \/ENV:OSS -->/gm;
+const CLOUD_ENV_MARKERS = /<!-- ENV:CLOUD -->([\s\S]*?)<!-- \/ENV:CLOUD -->/gm;
+
+export const prepareMarkdown = (markdown: string, env: "oss" | "cloud"): string => {
+  return env === "oss" ? markdown.replaceAll(CLOUD_ENV_MARKERS, "") : markdown.replaceAll(OSS_ENV_MARKERS, "");
+};
 
 export const DocumentationPanel: React.FC = () => {
   const { formatMessage } = useIntl();
@@ -57,7 +65,11 @@ export const DocumentationPanel: React.FC = () => {
       <PageHeader withLine title={<FormattedMessage id="connector.setupGuide" />} />
       <Markdown
         className={styles.content}
-        content={docs && !error ? docs : formatMessage({ id: "connector.setupGuide.notFound" })}
+        content={
+          docs && !error
+            ? prepareMarkdown(docs, isCloudApp() ? "cloud" : "oss")
+            : formatMessage({ id: "connector.setupGuide.notFound" })
+        }
         rehypePlugins={urlReplacerPlugin}
       />
     </div>

--- a/airbyte-webapp/src/components/common/DocumentationPanel/DocumentationPanel.tsx
+++ b/airbyte-webapp/src/components/common/DocumentationPanel/DocumentationPanel.tsx
@@ -20,8 +20,8 @@ import { useDocumentationPanelContext } from "views/Connector/ConnectorDocumenta
 
 import styles from "./DocumentationPanel.module.scss";
 
-const OSS_ENV_MARKERS = /<!-- ENV:OSS -->([\s\S]*?)<!-- \/ENV:OSS -->/gm;
-const CLOUD_ENV_MARKERS = /<!-- ENV:CLOUD -->([\s\S]*?)<!-- \/ENV:CLOUD -->/gm;
+const OSS_ENV_MARKERS = /<!-- env:oss -->([\s\S]*?)<!-- \/env:oss -->/gm;
+const CLOUD_ENV_MARKERS = /<!-- env:cloud -->([\s\S]*?)<!-- \/env:cloud -->/gm;
 
 export const prepareMarkdown = (markdown: string, env: "oss" | "cloud"): string => {
   return env === "oss" ? markdown.replaceAll(CLOUD_ENV_MARKERS, "") : markdown.replaceAll(OSS_ENV_MARKERS, "");

--- a/docs/integrations/sources/facebook-marketing.md
+++ b/docs/integrations/sources/facebook-marketing.md
@@ -11,13 +11,13 @@ This page guides you through the process of setting up the Facebook Marketing so
 ## Prerequisites
 
 * A [Facebook Ad Account ID](https://www.facebook.com/business/help/1492627900875762)
-<!-- ENV:OSS -->
+<!-- env:oss -->
 * (For Open Source) A [Facebook App](https://developers.facebook.com/apps/) with the Marketing API enabled
-<!-- /ENV:OSS -->
+<!-- /env:oss -->
 
 ## Set up Facebook Marketing as a source in Airbyte 
 
-<!-- ENV:CLOUD -->
+<!-- env:cloud -->
 ### For Airbyte Cloud
 
 To set up Facebook Marketing as a source in Airbyte Cloud:
@@ -63,9 +63,9 @@ To set up Facebook Marketing as a source in Airbyte Cloud:
 12. For **Page Size of Requests**, fill in the size of the page in case pagintion kicks in. Feel free to ignore it, the default value should work in most cases.
 13. For **Insights Lookback Window**, fill in the appropriate value. See [more](#facebook-marketing-attribution-reporting) on this parameter.
 14. Click **Set up source**.
-<!-- /ENV:CLOUD -->
+<!-- /env:cloud -->
 
-<!-- ENV:OSS -->
+<!-- env:oss -->
 ### For Airbyte Open Source
 
 To set up Facebook Marketing as a source in Airbyte Open Source:
@@ -81,7 +81,7 @@ To set up Facebook Marketing as a source in Airbyte Open Source:
 
     See the Facebook [documentation on Authorization](https://developers.facebook.com/docs/marketing-api/overview/authorization/#access-levels) to request Advanced Access to the relevant permissions.
 5. Navigate to the Airbyte Open Source Dashboard. Add the access token when prompted to do so and follow the same instructions as for [setting up the Facebook Connector on Airbyte Cloud](#for-airbyte-cloud).
-<!-- /ENV:OSS -->
+<!-- /env:oss -->
 
 ## Supported sync modes
 

--- a/docs/integrations/sources/facebook-marketing.md
+++ b/docs/integrations/sources/facebook-marketing.md
@@ -11,10 +11,13 @@ This page guides you through the process of setting up the Facebook Marketing so
 ## Prerequisites
 
 * A [Facebook Ad Account ID](https://www.facebook.com/business/help/1492627900875762)
+<!-- ENV:OSS -->
 * (For Open Source) A [Facebook App](https://developers.facebook.com/apps/) with the Marketing API enabled
+<!-- /ENV:OSS -->
 
 ## Set up Facebook Marketing as a source in Airbyte 
 
+<!-- ENV:CLOUD -->
 ### For Airbyte Cloud
 
 To set up Facebook Marketing as a source in Airbyte Cloud:
@@ -60,7 +63,9 @@ To set up Facebook Marketing as a source in Airbyte Cloud:
 12. For **Page Size of Requests**, fill in the size of the page in case pagintion kicks in. Feel free to ignore it, the default value should work in most cases.
 13. For **Insights Lookback Window**, fill in the appropriate value. See [more](#facebook-marketing-attribution-reporting) on this parameter.
 14. Click **Set up source**.
+<!-- /ENV:CLOUD -->
 
+<!-- ENV:OSS -->
 ### For Airbyte Open Source
 
 To set up Facebook Marketing as a source in Airbyte Open Source:
@@ -76,6 +81,7 @@ To set up Facebook Marketing as a source in Airbyte Open Source:
 
     See the Facebook [documentation on Authorization](https://developers.facebook.com/docs/marketing-api/overview/authorization/#access-levels) to request Advanced Access to the relevant permissions.
 5. Navigate to the Airbyte Open Source Dashboard. Add the access token when prompted to do so and follow the same instructions as for [setting up the Facebook Connector on Airbyte Cloud](#for-airbyte-cloud).
+<!-- /ENV:OSS -->
 
 ## Supported sync modes
 


### PR DESCRIPTION
## What

This allows any connector doc to mark sections that are specific to Cloud or OSS and they'll be only showing in the Documentation sidebar only in that specific environment.

The syntax is as follows:

```md
<!-- env:oss -->
Some text that is only relevant for OSS users.
<!-- /env:oss -->

<!-- env:cloud -->
Some text that is only relevant for Cloud users.
<!-- /env:cloud -->
```

This also leverages those tags on the Facebook Marketing connector as an example.

Since those tags are regular HTML comments, they will not show up when rendering the documentation on our docs page and both sections will be rendered (with hidden HTML comments around it).