### PR TITLE
ci: add job and run id to test reports

### DIFF
--- a/.github/workflows/gradle.yml
+++ b/.github/workflows/gradle.yml
@@ -259,7 +259,7 @@ jobs:
       - name: Prep Test Results For GCS
         if: always()
         run: |
-          python tools/bin/prep_test_results_for_gcs.py --json connectors_base_results.json
+          python tools/bin/prep_test_results_for_gcs.py --json connectors_base_results.json  --jobid $GITHUB_JOB --runid $GITHUB_RUN_ID
         
       - name: Upload Test Results to GCS
         if: always()
@@ -582,7 +582,7 @@ jobs:
       - name: Prep Test Results For GCS
         if: always()
         run: |
-          python tools/bin/prep_test_results_for_gcs.py --json platform_results.json
+          python tools/bin/prep_test_results_for_gcs.py --json platform_results.json  --jobid $GITHUB_JOB --runid $GITHUB_RUN_ID
         
       - name: Upload Test Results to GCS
         if: always()
@@ -768,7 +768,7 @@ jobs:
       - name: Prep Test Results For GCS
         if: always()
         run: |
-          python tools/bin/prep_test_results_for_gcs.py --json kube_results.json
+          python tools/bin/prep_test_results_for_gcs.py --json kube_results.json  --jobid $GITHUB_JOB --runid $GITHUB_RUN_ID
         
       - name: Upload Test Results to GCS
         if: always()

--- a/tools/bin/prep_test_results_for_gcs.py
+++ b/tools/bin/prep_test_results_for_gcs.py
@@ -17,6 +17,8 @@ parser = argparse.ArgumentParser()
 
 # Add long and short argument
 parser.add_argument("--json", "-j", help="Path to the result json output by https://github.com/EnricoMi/publish-unit-test-result-action")
+parser.add_argument("--runid", "-r", help="Run id of the action") # this can be derived from checks api, but it's easier to derive it here
+parser.add_argument("--jobid", "-c", help="Job id of the action") # this can be derived from checks api, but it's easier to derive it here
 
 def main():
     # Read arguments from the command line
@@ -40,6 +42,8 @@ def main():
                     "time": elem['states'][conclusion][i]['time'],
                     "state": conclusion,
                     "check_run_id": check_run_id,
+                    "workflow_run_id": args.runid,
+                    "job_id": args.jobid,
                     "repo": "airbytehq/airbyte"
                 }
                 out.append(output)


### PR DESCRIPTION
## What
This info can be derived from the checks api, but since we don't currently export that and need to extend our github airbyte connector to do so we want a quicker and easier solution to access this info in test case results. Ideally in the longer term we have our github connector also export this information and walk the tables in bigquery to derive it.

## How
Use github environment variables to derive and pass into the python script that builds the case JSON
