### PR TITLE
Add notes about EU OAUth

### DIFF
--- a/docs/integrations/sources/surveymonkey.md
+++ b/docs/integrations/sources/surveymonkey.md
@@ -2,6 +2,12 @@
 
 This page guides you through the process of setting up the SurveyMonkey source connector.
 
+:::note
+
+OAuth for Survey Monkey is officially supported only for the US. We are testing how to enable it in the EU at the moment. If you run into any issues, please [reach out to us](mailto:product@airbyte.io) so we can promptly assist you.
+
+:::
+
 ## Prerequisites 
 
  ### For Airbyte Open Source:


### PR DESCRIPTION
EU OAuth is not fully tested so adding a note to account for that. This is discussed in more details [here](https://github.com/airbytehq/oncall/issues/757).