### PR TITLE
🪟🐛 Fix: visual regression in ConnectorIcon

### DIFF
--- a/airbyte-webapp/src/components/common/ConnectorIcon/ConnectorIcon.tsx
+++ b/airbyte-webapp/src/components/common/ConnectorIcon/ConnectorIcon.tsx
@@ -1,17 +1,18 @@
+import classNames from "classnames";
 import React from "react";
 
 import { getIcon } from "utils/imageUtils";
 
 import styles from "./ConnectorIcon.module.scss";
 
-interface Props {
+interface ConnectorIconProps {
   icon?: string;
   className?: string;
   small?: boolean;
 }
 
-export const ConnectorIcon: React.FC<Props> = ({ icon }) => (
-  <div className={styles.content} aria-hidden="true">
+export const ConnectorIcon: React.FC<ConnectorIconProps> = ({ className, icon }) => (
+  <div className={classNames(styles.content, className)} aria-hidden="true">
     {getIcon(icon)}
   </div>
 );

--- a/airbyte-webapp/src/components/common/ConnectorIcon/ConnectorIcon.tsx
+++ b/airbyte-webapp/src/components/common/ConnectorIcon/ConnectorIcon.tsx
@@ -8,7 +8,6 @@ import styles from "./ConnectorIcon.module.scss";
 interface ConnectorIconProps {
   icon?: string;
   className?: string;
-  small?: boolean;
 }
 
 export const ConnectorIcon: React.FC<ConnectorIconProps> = ({ className, icon }) => (


### PR DESCRIPTION
## What
Fixes a small visual regression introduced in #18766, this fix passes additional `classNames` through.

Before
![image](https://user-images.githubusercontent.com/7550957/199490829-552ab00e-8604-482b-929b-28feb4b0cbba.png)

After
![image](https://user-images.githubusercontent.com/7550957/199490894-aed5c068-5e6e-4388-b70a-96492d8b394e.png)
