### PR TITLE
Filter exit errors by operation name

### DIFF
--- a/airbyte-workers/src/main/java/io/airbyte/workers/tracing/TemporalSdkInterceptor.java
+++ b/airbyte-workers/src/main/java/io/airbyte/workers/tracing/TemporalSdkInterceptor.java
@@ -4,6 +4,8 @@
 
 package io.airbyte.workers.tracing;
 
+import static io.airbyte.metrics.lib.ApmTraceConstants.WORKFLOW_TRACE_OPERATION_NAME;
+
 import com.google.common.annotations.VisibleForTesting;
 import datadog.trace.api.interceptor.MutableSpan;
 import datadog.trace.api.interceptor.TraceInterceptor;
@@ -18,11 +20,6 @@ import lombok.extern.slf4j.Slf4j;
  */
 @Slf4j
 public class TemporalSdkInterceptor implements TraceInterceptor {
-
-  /**
-   * Trace resource name used to scope the filtering performed by this interceptor.
-   */
-  static final String CONNECTION_MANAGER_WORKFLOW_IMPL_RESOURCE_NAME = "ConnectionManagerWorkflowImpl.run";
 
   /**
    * Error message tag key name that contains the Temporal exit error message.
@@ -76,7 +73,7 @@ public class TemporalSdkInterceptor implements TraceInterceptor {
 
     return trace.isError() &&
         EXIT_ERROR_MESSAGE.equalsIgnoreCase(trace.getTags().getOrDefault(ERROR_MESSAGE_TAG_KEY, "").toString()) &&
-        CONNECTION_MANAGER_WORKFLOW_IMPL_RESOURCE_NAME.equalsIgnoreCase(trace.getResourceName().toString());
+        WORKFLOW_TRACE_OPERATION_NAME.equalsIgnoreCase(trace.getOperationName().toString());
   }
 
 }

--- a/airbyte-workers/src/test/java/io/airbyte/workers/tracing/DummySpan.java
+++ b/airbyte-workers/src/test/java/io/airbyte/workers/tracing/DummySpan.java
@@ -12,7 +12,7 @@ class DummySpan implements MutableSpan {
 
   private final Map<String, Object> tags = new HashMap<>();
   private boolean error = false;
-
+  private String operationName = null;
   private String resourceName = null;
 
   @Override
@@ -27,12 +27,13 @@ class DummySpan implements MutableSpan {
 
   @Override
   public CharSequence getOperationName() {
-    return null;
+    return operationName;
   }
 
   @Override
-  public MutableSpan setOperationName(final CharSequence serviceName) {
-    return null;
+  public MutableSpan setOperationName(final CharSequence operationName) {
+    this.operationName = operationName != null ? operationName.toString() : null;
+    return this;
   }
 
   @Override
@@ -52,7 +53,7 @@ class DummySpan implements MutableSpan {
 
   @Override
   public MutableSpan setResourceName(final CharSequence resourceName) {
-    this.resourceName = resourceName.toString();
+    this.resourceName = resourceName != null ? resourceName.toString() : null;
     return this;
   }
 

--- a/airbyte-workers/src/test/java/io/airbyte/workers/tracing/TemporalSdkInterceptorTest.java
+++ b/airbyte-workers/src/test/java/io/airbyte/workers/tracing/TemporalSdkInterceptorTest.java
@@ -4,7 +4,7 @@
 
 package io.airbyte.workers.tracing;
 
-import static io.airbyte.workers.tracing.TemporalSdkInterceptor.CONNECTION_MANAGER_WORKFLOW_IMPL_RESOURCE_NAME;
+import static io.airbyte.metrics.lib.ApmTraceConstants.WORKFLOW_TRACE_OPERATION_NAME;
 import static io.airbyte.workers.tracing.TemporalSdkInterceptor.ERROR_MESSAGE_TAG_KEY;
 import static io.airbyte.workers.tracing.TemporalSdkInterceptor.EXIT_ERROR_MESSAGE;
 import static org.junit.jupiter.api.Assertions.assertEquals;
@@ -25,23 +25,23 @@ class TemporalSdkInterceptorTest {
 
     final var noError = new DummySpan();
     noError.setError(false);
-    noError.setResourceName(CONNECTION_MANAGER_WORKFLOW_IMPL_RESOURCE_NAME);
+    noError.setOperationName(WORKFLOW_TRACE_OPERATION_NAME);
     noError.setTag("tag", "value");
 
     final var otherError = new DummySpan();
     otherError.setError(true);
-    otherError.setResourceName(CONNECTION_MANAGER_WORKFLOW_IMPL_RESOURCE_NAME);
+    otherError.setOperationName(WORKFLOW_TRACE_OPERATION_NAME);
     otherError.setTag("error.message", "some other error");
 
     final var temporalExitMsgError = new DummySpan();
     temporalExitMsgError.setError(true);
+    temporalExitMsgError.setOperationName(WORKFLOW_TRACE_OPERATION_NAME);
     temporalExitMsgError.setTag(ERROR_MESSAGE_TAG_KEY, EXIT_ERROR_MESSAGE);
-    temporalExitMsgError.setResourceName(CONNECTION_MANAGER_WORKFLOW_IMPL_RESOURCE_NAME);
 
     final var temporalExitMsgOtherResourceError = new DummySpan();
     temporalExitMsgOtherResourceError.setError(true);
+    temporalExitMsgOtherResourceError.setOperationName("OtherOperation");
     temporalExitMsgOtherResourceError.setTag(ERROR_MESSAGE_TAG_KEY, EXIT_ERROR_MESSAGE);
-    temporalExitMsgOtherResourceError.setResourceName("OtherResource.run");
 
     final var spans = List.of(
         simple, noError, otherError, temporalExitMsgError, temporalExitMsgOtherResourceError);
@@ -65,24 +65,24 @@ class TemporalSdkInterceptorTest {
     assertEquals(false, interceptor.isExitTrace(new DummySpan()));
 
     final var temporalTrace = new DummySpan();
-    temporalTrace.setResourceName(CONNECTION_MANAGER_WORKFLOW_IMPL_RESOURCE_NAME);
+    temporalTrace.setOperationName(WORKFLOW_TRACE_OPERATION_NAME);
     assertEquals(false, interceptor.isExitTrace(temporalTrace));
 
     final var temporalTraceWithError = new DummySpan();
     temporalTraceWithError.setError(true);
-    temporalTraceWithError.setResourceName(CONNECTION_MANAGER_WORKFLOW_IMPL_RESOURCE_NAME);
+    temporalTraceWithError.setOperationName(WORKFLOW_TRACE_OPERATION_NAME);
     assertEquals(false, interceptor.isExitTrace(temporalTraceWithError));
 
     final var temporalTraceWithExitError = new DummySpan();
     temporalTraceWithExitError.setError(true);
+    temporalTraceWithExitError.setOperationName(WORKFLOW_TRACE_OPERATION_NAME);
     temporalTraceWithExitError.setTag(ERROR_MESSAGE_TAG_KEY, EXIT_ERROR_MESSAGE);
-    temporalTraceWithExitError.setResourceName(CONNECTION_MANAGER_WORKFLOW_IMPL_RESOURCE_NAME);
     assertEquals(true, interceptor.isExitTrace(temporalTraceWithExitError));
 
     final var otherTemporalTraceWithExitError = new DummySpan();
     otherTemporalTraceWithExitError.setError(true);
+    otherTemporalTraceWithExitError.setOperationName("OtherOperation");
     otherTemporalTraceWithExitError.setTag(ERROR_MESSAGE_TAG_KEY, EXIT_ERROR_MESSAGE);
-    otherTemporalTraceWithExitError.setResourceName("OtherResource");
     assertEquals(false, interceptor.isExitTrace(otherTemporalTraceWithExitError));
   }
 


### PR DESCRIPTION
## What
* Correctly filter `DestroyWorkflowThreadError` exceptions from APM traces

## How
* Use the operation name, not the resource name, to identify and filter out the unwanted errors

## Recommended reading order
1. `TermporalSdkInterceptor.java`

## Tests

* Project builds successfully
* Tests pass after updates to use operation name in place of resource name