### PR TITLE
ci: replace GITHUB_OUTPUT with GITHUB_ENV for multiline variables

### DIFF
--- a/.github/workflows/create-release.yml
+++ b/.github/workflows/create-release.yml
@@ -32,13 +32,15 @@ jobs:
           # The sed removes carriage returns so that the body is easier to parse later, and
           #   escapes backticks so that they are not executed as commands.
           PR_BODY=$(printf '%s' "$PR" | jq '.[0].body' | sed 's/\\r//g' | sed 's/`/\\`/g')
-          echo pr_body=${PR_BODY} >> $GITHUB_OUTPUT
+          echo "pr_body<<EOF" >> $GITHUB_ENV
+          echo "$PR_BODY" >> $GITHUB_ENV
+          echo "EOF" >> $GITHUB_ENV
       - name: Extract Changelog
         id: extract_changelog
         shell: bash
         run: |-
           set -x
-          PR_BODY=${{ steps.fetch_pr_body.outputs.pr_body}}
+          PR_BODY=${{ env.pr_body}}
           if [[ $PR_BODY = "null" ]]; then
             echo "No PR body exists for this commit, so a release cannot be generated."
             exit 1


### PR DESCRIPTION
## What
[$GITHUB_OUTPUT](https://docs.github.com/en/actions/using-workflows/workflow-commands-for-github-actions#setting-an-output-parameter) in GitHub Actions doesn't work correctly with multiline variables.

## How
Replace [$GITHUB_OUTPUT](https://docs.github.com/en/actions/using-workflows/workflow-commands-for-github-actions#setting-an-output-parameter) with [$GITHUB_ENV](https://docs.github.com/en/actions/using-workflows/workflow-commands-for-github-actions#multiline-strings) on multiline strings.
