### PR TITLE
🪟 🔧 Add connector failure count in local storage

### DIFF
--- a/airbyte-webapp/src/views/Connector/ConnectorCard/ConnectorCard.tsx
+++ b/airbyte-webapp/src/views/Connector/ConnectorCard/ConnectorCard.tsx
@@ -68,6 +68,8 @@ export const ConnectorCard: React.FC<ConnectorCardCreateProps | ConnectorCardEdi
 
     const testConnectorWithTracking = async () => {
       trackTestConnectorStarted(connector);
+      const connectorFailureCount = Number(localStorage.getItem("connector_failure_count"));
+      localStorage.setItem("connector_failure_count", (connectorFailureCount + 1).toString());
       try {
         await testConnector(values);
         trackTestConnectorSuccess(connector);

--- a/airbyte-webapp/src/views/Connector/ConnectorCard/ConnectorCard.tsx
+++ b/airbyte-webapp/src/views/Connector/ConnectorCard/ConnectorCard.tsx
@@ -68,13 +68,13 @@ export const ConnectorCard: React.FC<ConnectorCardCreateProps | ConnectorCardEdi
 
     const testConnectorWithTracking = async () => {
       trackTestConnectorStarted(connector);
-      const connectorFailureCount = Number(localStorage.getItem("connector_failure_count"));
-      localStorage.setItem("connector_failure_count", (connectorFailureCount + 1).toString());
       try {
         await testConnector(values);
         trackTestConnectorSuccess(connector);
       } catch (e) {
         trackTestConnectorFailure(connector);
+        const connectorFailureCount = Number(localStorage.getItem("connector_failure_count"));
+        localStorage.setItem("connector_failure_count", (connectorFailureCount + 1).toString());
         throw e;
       }
     };


### PR DESCRIPTION
## What
We need to count the number of times the user has a connector setup failure to trigger a Calendly support modal when it's 3 times

Related experiment: https://airtable.com/appIuY0uKPVnk8TWT/tbl2SxXnUwf6fVCWS/viwtQpgNYwBvoHllF/recLICAN532e5BIoC?blocks=hide

## How
Store the count value in local storage