### PR TITLE
🪟 🔧  Add Segment event to invite users modal

### DIFF
--- a/.github/teams.yml
+++ b/.github/teams.yml
@@ -1,0 +1,3 @@
+team/growth:
+  - "@letiescanciano"
+  - "@arnaudjnn"

--- a/.github/workflows/label-pr-by-team.yml
+++ b/.github/workflows/label-pr-by-team.yml
@@ -1,0 +1,9 @@
+name: "Add labels to github PRs based on team"
+on: pull_request
+jobs:
+  team-labeler:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: JulienKode/team-labeler-action@v0.1.1
+        with:
+          repo-token: "${{ secrets.GITHUB_TOKEN }}"

--- a/airbyte-webapp/src/core/analytics/types.ts
+++ b/airbyte-webapp/src/core/analytics/types.ts
@@ -27,6 +27,7 @@ export const enum Action {
   SELECTION_OPENED = "SelectionOpened",
   CHECKOUT_START = "CheckoutStart",
   LOAD_MORE_JOBS = "LoadMoreJobs",
+  INVITE = "Invite",
 }
 
 export type EventParams = Record<string, unknown>;

--- a/airbyte-webapp/src/packages/cloud/services/users/InviteUsersModalService.tsx
+++ b/airbyte-webapp/src/packages/cloud/services/users/InviteUsersModalService.tsx
@@ -19,7 +19,9 @@ export const useInviteUsersModalService = () => {
   return ctx;
 };
 
-export const InviteUsersModalServiceProvider: React.FC<React.PropsWithChildren<unknown>> = ({ children }) => {
+export const InviteUsersModalServiceProvider: React.FC<
+  React.PropsWithChildren<unknown> & { invitedFrom: "source" | "destination" | "user.settings" }
+> = ({ children, invitedFrom }) => {
   const [isOpen, toggleIsOpen] = useToggle(false);
 
   const contextValue = useMemo<InviteUsersModalServiceContext>(
@@ -33,7 +35,7 @@ export const InviteUsersModalServiceProvider: React.FC<React.PropsWithChildren<u
   return (
     <Provider value={contextValue}>
       {children}
-      {isOpen && <InviteUsersModal onClose={toggleIsOpen} />}
+      {isOpen && <InviteUsersModal onClose={toggleIsOpen} invitedFrom={invitedFrom} />}
     </Provider>
   );
 };

--- a/airbyte-webapp/src/packages/cloud/services/users/InviteUsersModalService.tsx
+++ b/airbyte-webapp/src/packages/cloud/services/users/InviteUsersModalService.tsx
@@ -19,8 +19,11 @@ export const useInviteUsersModalService = () => {
   return ctx;
 };
 
+interface InviteUsersModalServiceProviderProps {
+  invitedFrom: "source" | "destination" | "user.settings";
+}
 export const InviteUsersModalServiceProvider: React.FC<
-  React.PropsWithChildren<unknown> & { invitedFrom: "source" | "destination" | "user.settings" }
+  React.PropsWithChildren<InviteUsersModalServiceProviderProps>
 > = ({ children, invitedFrom }) => {
   const [isOpen, toggleIsOpen] = useToggle(false);
 

--- a/airbyte-webapp/src/packages/cloud/views/users/InviteUsersHint/InviteUsersHint.tsx
+++ b/airbyte-webapp/src/packages/cloud/views/users/InviteUsersHint/InviteUsersHint.tsx
@@ -60,7 +60,7 @@ export const InviteUsersHint: React.VFC<InviteUsersHintProps> = (props) => {
   const isVisible = useExperiment("connector.inviteUsersHint.visible", false);
 
   return isVisible ? (
-    <InviteUsersModalServiceProvider>
+    <InviteUsersModalServiceProvider invitedFrom={props.connectorType}>
       <InviteUsersHintContent {...props} />
     </InviteUsersModalServiceProvider>
   ) : null;

--- a/airbyte-webapp/src/packages/cloud/views/users/InviteUsersModal/InviteUsersModal.tsx
+++ b/airbyte-webapp/src/packages/cloud/views/users/InviteUsersModal/InviteUsersModal.tsx
@@ -13,6 +13,8 @@ import { DropDown } from "components/ui/DropDown";
 import { Input } from "components/ui/Input";
 import { Modal } from "components/ui/Modal";
 
+import { Action, Namespace } from "core/analytics";
+import { useAnalyticsService } from "hooks/services/Analytics";
 import { useNotificationService } from "hooks/services/Notification";
 import { useCurrentWorkspace } from "hooks/services/useWorkspace";
 import { useUserHook } from "packages/cloud/services/users/UseUserHook";
@@ -56,6 +58,7 @@ const ROLE_OPTIONS = [
 
 export const InviteUsersModal: React.FC<{
   onClose: () => void;
+  invitedFrom: "source" | "destination" | "user.settings";
 }> = (props) => {
   const { formatMessage } = useIntl();
   const { workspaceId } = useCurrentWorkspace();
@@ -64,7 +67,7 @@ export const InviteUsersModal: React.FC<{
   const { mutateAsync: invite } = inviteUserLogic;
 
   const isRoleVisible = false; // Temporarily hiding roles because there's only 'Admin' in cloud.
-
+  const analyticsService = useAnalyticsService();
   return (
     <Modal title={<FormattedMessage id="modals.addUser.title" />} onClose={props.onClose}>
       <Formik
@@ -92,6 +95,9 @@ export const InviteUsersModal: React.FC<{
               },
             }
           );
+          analyticsService.track(Namespace.USER, Action.INVITE, {
+            invited_from: props.invitedFrom,
+          });
         }}
       >
         {({ values, isValid, isSubmitting, dirty, setFieldValue }) => {

--- a/airbyte-webapp/src/packages/cloud/views/users/UsersSettingsView/UsersSettingsView.tsx
+++ b/airbyte-webapp/src/packages/cloud/views/users/UsersSettingsView/UsersSettingsView.tsx
@@ -120,7 +120,7 @@ export const UsersSettingsView: React.VFC = () => {
   useTrackPage(PageTrackingCodes.SETTINGS_ACCESS_MANAGEMENT);
 
   return (
-    <InviteUsersModalServiceProvider>
+    <InviteUsersModalServiceProvider invitedFrom="user.settings">
       <Header />
       <UsersTable />
     </InviteUsersModalServiceProvider>


### PR DESCRIPTION
Demo: https://www.loom.com/share/1e899c9678124321a62dc71d23bfe52e
## What
Adding a new `Airbyte.UI.User.Invite` Segment event to be able to track user invites across sources, destinations and access management pages.

## How
Add new event
Add tracking on invite
