### PR TITLE
Multi-cloud documentation

### DIFF
--- a/docs/cloud/getting-started-with-airbyte-cloud.md
+++ b/docs/cloud/getting-started-with-airbyte-cloud.md
@@ -191,7 +191,7 @@ Depending on your data residency location, you may need to allowlist the followi
 * 34.106.196.165
 * 34.106.60.246
 
-### Europe
+### European Union
 * 34.106.109.131
 * 34.106.196.165
 * 34.106.60.246

--- a/docs/cloud/getting-started-with-airbyte-cloud.md
+++ b/docs/cloud/getting-started-with-airbyte-cloud.md
@@ -63,7 +63,7 @@ Setting up a connection involves configuring the following parameters:
 | Parameter                              | Description                                                                                                                                                                                                                                                           |
 |----------------------------------------|-----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
 | Replication frequency                  | How often should the data sync?                                                                                                                                                                                                                                       |
-| Data residency                         | Where is the data processing location for this connection? To choose the preferred data processing location for all of your connections, set your default [data residency](https://docs.airbyte.com/cloud/managing-airbyte-cloud#choose-your-default-data-residency). |
+| Data residency                         | Where should the data be processed? To choose the preferred data processing location for all of your connections, set your default [data residency](https://docs.airbyte.com/cloud/managing-airbyte-cloud#choose-your-default-data-residency). |
 | Destination Namespace and stream names | Where should the replicated data be written?                                                                                                                                                                                                                          |
 | Catalog selection                      | Which streams and fields should be replicated from the source to the destination?                                                                                                                                                                                     |
 | Sync mode                              | How should the streams be replicated (read and written)?                                                                                                                                                                                                              |
@@ -187,11 +187,13 @@ Verify the sync by checking the logs:
 Depending on your data residency location, you may need to allowlist the following IP addresses to enable access to Airbyte:
 
 ### United States and Airbyte Default
+#### GCP region: us-west2
 * 34.106.109.131
 * 34.106.196.165
 * 34.106.60.246
 
 ### European Union
+#### AWS region: eu-west-3
 * 34.106.109.131
 * 34.106.196.165
 * 34.106.60.246

--- a/docs/cloud/getting-started-with-airbyte-cloud.md
+++ b/docs/cloud/getting-started-with-airbyte-cloud.md
@@ -60,44 +60,14 @@ A connection is an automated data pipeline that replicates data from a source to
 
 Setting up a connection involves configuring the following parameters:
 
-<table>
-  <tr>
-   <td><strong>Parameter</strong>
-   </td>
-   <td><strong>Description</strong>
-   </td>
-  </tr>
-  <tr>
-   <td>Replication frequency
-   </td>
-   <td>How often should the data sync?
-   </td>
-  </tr>
-  <tr>
-   <td>Destination Namespace and stream names
-   </td>
-   <td>Where should the replicated data be written?
-   </td>
-  </tr>
-  <tr>
-   <td>Catalog selection
-   </td>
-   <td>Which streams and fields should be replicated from the source to the destination?
-   </td>
-  </tr>
-  <tr>
-   <td>Sync mode
-   </td>
-   <td>How should the streams be replicated (read and written)?
-   </td>
-  </tr>
-  <tr>
-   <td>Optional transformations
-   </td>
-   <td>How should Airbyte protocol messages (raw JSON blob) data be converted into other data representations?
-   </td>
-  </tr>
-</table>
+| Parameter                              | Description                                                                                                                                                                                                                                                           |
+|----------------------------------------|-----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
+| Replication frequency                  | How often should the data sync?                                                                                                                                                                                                                                       |
+| Data residency                         | Where is the data processing location for this connection? To choose the preferred data processing location for all of your connections, set your default [data residency](https://docs.airbyte.com/cloud/managing-airbyte-cloud#choose-your-default-data-residency). |
+| Destination Namespace and stream names | Where should the replicated data be written?                                                                                                                                                                                                                          |
+| Catalog selection                      | Which streams and fields should be replicated from the source to the destination?                                                                                                                                                                                     |
+| Sync mode                              | How should the streams be replicated (read and written)?                                                                                                                                                                                                              |
+| Optional transformations               | How should Airbyte protocol messages (raw JSON blob) data be converted into other data representations?                                                                                                                                                               |
 
 For more information, see [Connections and Sync Modes](../understanding-airbyte/connections/README.md) and [Namespaces](../understanding-airbyte/namespaces.md)
 
@@ -214,7 +184,17 @@ Verify the sync by checking the logs:
 
 ## Allowlist IP address
 
-You may need to allowlist one of our IP addresses to enable access to Airbyte:
-- 34.106.109.131
-- 34.106.196.165
-- 34.106.60.246
+Depending on your data residency location, you may need to allowlist the following IP addresses to enable access to Airbyte:
+
+### United States and Airbyte Default
+* 34.106.109.131
+* 34.106.196.165
+* 34.106.60.246
+
+### Europe
+* 34.106.109.131
+* 34.106.196.165
+* 34.106.60.246
+* 13.37.4.46
+* 13.37.142.60
+* 35.181.124.238

--- a/docs/cloud/managing-airbyte-cloud.md
+++ b/docs/cloud/managing-airbyte-cloud.md
@@ -85,13 +85,9 @@ To switch between workspaces:
 3. Click the name of the workspace you want to switch to.
 
 ### Choose your default data residency
-You can choose the preferred data processing location for all of your connections in a workspace. 
+Default data residency allows you to choose where your data is processed. When you set the default data residency, it applies that data residency to all new connections, but it will not affect existing connections. 
 
-:::note 
-    
-Your data will not leave the default data residency unless you choose a different data residency for a connection. You can choose a different data residency when creating a [new connection](https://docs.airbyte.com/cloud/getting-started-with-airbyte-cloud#set-up-a-connection) or in the [connection settings](#choose-the-data-residency-for-a-connection).
-
-:::
+For individual connections, you can choose a data residency that is different from the default. You can do this in the [connection settings](#choose-the-data-residency-for-a-connection) or when you create a [new connection](https://docs.airbyte.com/cloud/getting-started-with-airbyte-cloud#set-up-a-connection). Your data will not leave the chosen data residency for your connection.
 
 To choose your default data residency:
 
@@ -100,7 +96,7 @@ To choose your default data residency:
 2. In the Workspace settings sidebar, click **Default Data Residency**.
 
 3. Click the dropdown and choose the location for your default data residency.
- 
+
 4. Click **Save changes**. 
 
 :::info 

--- a/docs/cloud/managing-airbyte-cloud.md
+++ b/docs/cloud/managing-airbyte-cloud.md
@@ -38,16 +38,6 @@ To remove a user from your workspace:
 
 4. The **Remove user** dialog displays. Click **Remove**.
 
-### Switch between multiple workspaces
-
-To switch between workspaces:
-
-1. On the [Airbyte Cloud](http://cloud.airbyte.io) dashboard, click the current workspace name under the Airbyte logo in the navigation bar.
-
-2. Click **View all workspaces**.
-
-3. Click the name of the workspace you want to switch to.
-
 ### Rename a workspace
 
 To rename a workspace:
@@ -83,6 +73,41 @@ You can use one or multiple workspaces with Airbyte Cloud.
 |----------------------|-------------------------------------------------------------------------------|---------------------------------------------------------------------------------------------------------------------------------------------|
 | Single               | You can use the same payment method for all purchases.                        | Credits pay for the use of resources in a workspace when you run a sync. Resource usage cannot be divided and paid for separately (for example, you cannot bill different departments in your organization for the usage of some credits in one workspace).                                     |
 | Multiple             | Workspaces are independent of each other, so you can use a different payment method card for each workspace (for example,  different credit cards per department in your organization). | You can use the same payment method for different workspaces, but each workspace is billed separately. Managing billing for each workspace can become complicated if you have many workspaces. |
+
+### Switch between multiple workspaces
+
+To switch between workspaces:
+
+1. On the [Airbyte Cloud](http://cloud.airbyte.io) dashboard, click the current workspace name under the Airbyte logo in the navigation bar.
+
+2. Click **View all workspaces**.
+
+3. Click the name of the workspace you want to switch to.
+
+### Choose your default data residency
+You can choose the preferred data processing location for all of your connections in a workspace. 
+
+:::note 
+    
+Your data will not leave the default data residency unless you choose a different data residency for a connection. You can choose a different data residency when creating a [new connection](https://docs.airbyte.com/cloud/getting-started-with-airbyte-cloud#set-up-a-connection) or in the [connection settings](#choose-the-data-residency-for-a-connection).
+
+:::
+
+To choose your default data residency:
+
+1. On the [Airbyte Cloud](http://cloud.airbyte.io) dashboard, click **Settings** in the navigation bar.
+
+2. In the Workspace settings sidebar, click **Default Data Residency**.
+
+3. Click the dropdown and choose the location for your default data residency.
+ 
+4. Click **Save changes**. 
+
+:::info 
+
+Depending on your network configuration, you may need to add [IP addresses](https://docs.airbyte.com/cloud/getting-started-with-airbyte-cloud#allowlist-ip-address) to your allowlist.   
+
+:::
 
 ## Manage Airbyte Cloud notifications
 
@@ -258,6 +283,23 @@ To display **Connection State**:
 5. Click the **Settings** tab on the Connection page.
 
     The **Connection State** displays. 
+
+## Choose the data residency for a connection
+To choose the data residency for an existing connection: 
+
+1. On the [Airbyte Cloud](http://cloud.airbyte.io) dashboard, click **Connections** in the navigation bar and then click the connection that you want to change. 
+
+    The Connection page displays. 
+
+2. Click the **Settings** tab. 
+
+3. Click the **Data residency** dropdown and choose the location for your default data residency.
+
+:::note 
+    
+You can also choose data residency when creating a [new connection](https://docs.airbyte.com/cloud/getting-started-with-airbyte-cloud#set-up-a-connection), or you can set the [default data residency](#choose-your-default-data-residency) for all of your connections. 
+
+:::
 
 ## Buy credits
 

--- a/docs/cloud/managing-airbyte-cloud.md
+++ b/docs/cloud/managing-airbyte-cloud.md
@@ -85,9 +85,16 @@ To switch between workspaces:
 3. Click the name of the workspace you want to switch to.
 
 ### Choose your default data residency
-Default data residency allows you to choose where your data is processed. When you set the default data residency, it applies that data residency to all new connections, but it will not affect existing connections. 
+Default data residency allows you to choose where your data is processed. When you set the default data residency, it is applied to all new connections, but it does not affect existing connections. 
 
-For individual connections, you can choose a data residency that is different from the default. You can do this in the [connection settings](#choose-the-data-residency-for-a-connection) or when you create a [new connection](https://docs.airbyte.com/cloud/getting-started-with-airbyte-cloud#set-up-a-connection). Your data will not leave the chosen data residency for your connection.
+For individual connections, you can choose a data residency that is different from the default. You can do this in the [connection settings](#choose-the-data-residency-for-a-connection) or when you create a [new connection](https://docs.airbyte.com/cloud/getting-started-with-airbyte-cloud#set-up-a-connection).
+
+:::note 
+
+Your data is processed in the chosen residency, but some data is still stored in the US.
+
+:::
+
 
 To choose your default data residency:
 


### PR DESCRIPTION
Users are able to:
* Choose a default data residency (settings).
* Choose data residency when creating a new connection. 
* Choose data residency in connection settings. 
* See IP addresses for EU, US, and Airbyte Default.

The documentation in this PR includes:
* Set up a connection (Getting Started with Airbyte Cloud)
* Allowlist IP addresses (Getting Started with Airbyte Cloud)
* Choose your default data residency (Managing Airbyte Cloud)
* Choose data residency for a connection (Managing Airbyte Cloud)