### PR TITLE
Add unsupported_protocol_version column to Connection

### DIFF
--- a/airbyte-bootloader/src/test/java/io/airbyte/bootloader/BootloaderAppTest.java
+++ b/airbyte-bootloader/src/test/java/io/airbyte/bootloader/BootloaderAppTest.java
@@ -141,7 +141,7 @@ class BootloaderAppTest {
       val configsMigrator = new ConfigsDatabaseMigrator(configDatabase, configsFlyway);
       // this line should change with every new migration
       // to show that you meant to make a new migration to the prod database
-      assertEquals("0.40.12.001", configsMigrator.getLatestMigration().getVersion().getVersion());
+      assertEquals("0.40.18.001", configsMigrator.getLatestMigration().getVersion().getVersion());
 
       val jobsPersistence = new DefaultJobPersistence(jobDatabase);
       assertEquals(VERSION_0330_ALPHA, jobsPersistence.getVersion().get());

--- a/airbyte-db/db-lib/src/main/java/io/airbyte/db/instance/configs/migrations/V0_40_18_001__AddInvalidProtocolFlagToConnections.java
+++ b/airbyte-db/db-lib/src/main/java/io/airbyte/db/instance/configs/migrations/V0_40_18_001__AddInvalidProtocolFlagToConnections.java
@@ -1,0 +1,36 @@
+/*
+ * Copyright (c) 2022 Airbyte, Inc., all rights reserved.
+ */
+
+package io.airbyte.db.instance.configs.migrations;
+
+import org.flywaydb.core.api.migration.BaseJavaMigration;
+import org.flywaydb.core.api.migration.Context;
+import org.jooq.DSLContext;
+import org.jooq.impl.DSL;
+import org.jooq.impl.SQLDataType;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+public class V0_40_18_001__AddInvalidProtocolFlagToConnections extends BaseJavaMigration {
+
+  private static final Logger LOGGER = LoggerFactory.getLogger(V0_40_18_001__AddInvalidProtocolFlagToConnections.class);
+
+  @Override
+  public void migrate(final Context context) throws Exception {
+    LOGGER.info("Running migration: {}", this.getClass().getSimpleName());
+
+    // Warning: please do not use any jOOQ generated code to write a migration.
+    // As database schema changes, the generated jOOQ code can be deprecated. So
+    // old migration may not compile if there is any generated code.
+    final DSLContext ctx = DSL.using(context.getConnection());
+    addInvalidProtocolFlagToConnections(ctx);
+  }
+
+  private void addInvalidProtocolFlagToConnections(final DSLContext ctx) {
+    ctx.alterTable("connection")
+        .addColumn(DSL.field("unsupported_protocol_version", SQLDataType.BOOLEAN.nullable(false).defaultValue(false)))
+        .execute();
+  }
+
+}

--- a/airbyte-db/db-lib/src/main/resources/configs_database/schema_dump.txt
+++ b/airbyte-db/db-lib/src/main/resources/configs_database/schema_dump.txt
@@ -108,6 +108,7 @@ create table "public"."connection"(
   "notify_schema_changes" bool not null default true,
   "non_breaking_change_preference" varchar(7) not null default '''ignore''::character varying',
   "breaking_change" bool not null default false,
+  "unsupported_protocol_version" bool not null default false,
   constraint "connection_pkey"
     primary key ("id")
 );


### PR DESCRIPTION
## What
Add a `unsupported_protocol_version` column to the `connection` table to track connections that should be disabled due to an unsupported protocol version in one of the connectors.

Closes #16037 
