### PR TITLE
Extract open API

### DIFF
--- a/airbyte-server/src/main/java/io/airbyte/server/ServerApp.java
+++ b/airbyte-server/src/main/java/io/airbyte/server/ServerApp.java
@@ -60,6 +60,7 @@ import io.airbyte.server.handlers.HealthCheckHandler;
 import io.airbyte.server.handlers.JobHistoryHandler;
 import io.airbyte.server.handlers.LogsHandler;
 import io.airbyte.server.handlers.OAuthHandler;
+import io.airbyte.server.handlers.OpenApiConfigHandler;
 import io.airbyte.server.handlers.OperationsHandler;
 import io.airbyte.server.handlers.SchedulerHandler;
 import io.airbyte.server.handlers.SourceDefinitionsHandler;
@@ -333,6 +334,8 @@ public class ServerApp implements ServerRunnable {
         destinationHandler,
         sourceHandler);
 
+    final OpenApiConfigHandler openApiConfigHandler = new OpenApiConfigHandler();
+
     LOGGER.info("Starting server...");
 
     return apiFactory.create(
@@ -361,6 +364,7 @@ public class ServerApp implements ServerRunnable {
         jobHistoryHandler,
         logsHandler,
         oAuthHandler,
+        openApiConfigHandler,
         operationsHandler,
         schedulerHandler,
         workspacesHandler);

--- a/airbyte-server/src/main/java/io/airbyte/server/ServerFactory.java
+++ b/airbyte-server/src/main/java/io/airbyte/server/ServerFactory.java
@@ -26,6 +26,7 @@ import io.airbyte.server.apis.HealthApiController;
 import io.airbyte.server.apis.JobsApiController;
 import io.airbyte.server.apis.LogsApiController;
 import io.airbyte.server.apis.NotificationsApiController;
+import io.airbyte.server.apis.OpenapiApiController;
 import io.airbyte.server.apis.binders.AttemptApiBinder;
 import io.airbyte.server.apis.binders.ConnectionApiBinder;
 import io.airbyte.server.apis.binders.DbMigrationBinder;
@@ -37,6 +38,7 @@ import io.airbyte.server.apis.binders.HealthApiBinder;
 import io.airbyte.server.apis.binders.JobsApiBinder;
 import io.airbyte.server.apis.binders.LogsApiBinder;
 import io.airbyte.server.apis.binders.NotificationApiBinder;
+import io.airbyte.server.apis.binders.OpenapiApiBinder;
 import io.airbyte.server.apis.binders.SourceOauthApiBinder;
 import io.airbyte.server.apis.factories.AttemptApiFactory;
 import io.airbyte.server.apis.factories.ConnectionApiFactory;
@@ -49,6 +51,7 @@ import io.airbyte.server.apis.factories.HealthApiFactory;
 import io.airbyte.server.apis.factories.JobsApiFactory;
 import io.airbyte.server.apis.factories.LogsApiFactory;
 import io.airbyte.server.apis.factories.NotificationsApiFactory;
+import io.airbyte.server.apis.factories.OpenapiApiFactory;
 import io.airbyte.server.apis.factories.SourceOauthApiFactory;
 import io.airbyte.server.handlers.AttemptHandler;
 import io.airbyte.server.handlers.ConnectionsHandler;
@@ -59,6 +62,7 @@ import io.airbyte.server.handlers.HealthCheckHandler;
 import io.airbyte.server.handlers.JobHistoryHandler;
 import io.airbyte.server.handlers.LogsHandler;
 import io.airbyte.server.handlers.OAuthHandler;
+import io.airbyte.server.handlers.OpenApiConfigHandler;
 import io.airbyte.server.handlers.OperationsHandler;
 import io.airbyte.server.handlers.SchedulerHandler;
 import io.airbyte.server.handlers.WorkspacesHandler;
@@ -98,6 +102,7 @@ public interface ServerFactory {
                         final JobHistoryHandler jobHistoryHandler,
                         final LogsHandler logsHandler,
                         final OAuthHandler oAuthHandler,
+                        final OpenApiConfigHandler openApiConfigHandler,
                         final OperationsHandler operationsHandler,
                         final SchedulerHandler schedulerHandler,
                         final WorkspacesHandler workspacesHandler);
@@ -130,6 +135,7 @@ public interface ServerFactory {
                                  final JobHistoryHandler jobHistoryHandler,
                                  final LogsHandler logsHandler,
                                  final OAuthHandler oAuthHandler,
+                                 final OpenApiConfigHandler openApiConfigHandler,
                                  final OperationsHandler operationsHandler,
                                  final SchedulerHandler schedulerHandler,
                                  final WorkspacesHandler workspacesHandler) {
@@ -184,6 +190,8 @@ public interface ServerFactory {
 
       NotificationsApiFactory.setValues(workspacesHandler);
 
+      OpenapiApiFactory.setValues(openApiConfigHandler);
+
       // server configurations
       final Set<Class<?>> componentClasses = Set.of(
           ConfigurationApi.class,
@@ -198,6 +206,7 @@ public interface ServerFactory {
           JobsApiController.class,
           LogsApiController.class,
           NotificationsApiController.class,
+          OpenapiApiController.class,
           SourceOauthApiFactory.class);
 
       final Set<Object> components = Set.of(
@@ -214,6 +223,7 @@ public interface ServerFactory {
           new JobsApiBinder(),
           new LogsApiBinder(),
           new NotificationApiBinder(),
+          new OpenapiApiBinder(),
           new SourceOauthApiBinder());
 
       // construct server

--- a/airbyte-server/src/main/java/io/airbyte/server/apis/ConfigurationApi.java
+++ b/airbyte-server/src/main/java/io/airbyte/server/apis/ConfigurationApi.java
@@ -962,9 +962,13 @@ public class ConfigurationApi implements io.airbyte.api.generated.V1Api {
     throw new NotImplementedException();
   }
 
+  /**
+   * This implementation has been moved to {@link HealthApiController}. Since the path of
+   * {@link HealthApiController} is more granular, it will override this implementation
+   */
   @Override
   public File getOpenApiSpec() {
-    return execute(openApiConfigHandler::getFile);
+    throw new NotImplementedException();
   }
 
   // HEALTH

--- a/airbyte-server/src/main/java/io/airbyte/server/apis/ConfigurationApi.java
+++ b/airbyte-server/src/main/java/io/airbyte/server/apis/ConfigurationApi.java
@@ -117,7 +117,6 @@ import io.airbyte.server.handlers.ConnectionsHandler;
 import io.airbyte.server.handlers.DestinationDefinitionsHandler;
 import io.airbyte.server.handlers.DestinationHandler;
 import io.airbyte.server.handlers.JobHistoryHandler;
-import io.airbyte.server.handlers.OpenApiConfigHandler;
 import io.airbyte.server.handlers.OperationsHandler;
 import io.airbyte.server.handlers.SchedulerHandler;
 import io.airbyte.server.handlers.SourceDefinitionsHandler;
@@ -152,7 +151,6 @@ public class ConfigurationApi implements io.airbyte.api.generated.V1Api {
   private final JobHistoryHandler jobHistoryHandler;
   private final WebBackendConnectionsHandler webBackendConnectionsHandler;
   private final WebBackendGeographiesHandler webBackendGeographiesHandler;
-  private final OpenApiConfigHandler openApiConfigHandler;
 
   public ConfigurationApi(final ConfigRepository configRepository,
                           final JobPersistence jobPersistence,
@@ -222,7 +220,6 @@ public class ConfigurationApi implements io.airbyte.api.generated.V1Api {
         eventRunner,
         configRepository);
     webBackendGeographiesHandler = new WebBackendGeographiesHandler();
-    openApiConfigHandler = new OpenApiConfigHandler();
   }
 
   // WORKSPACE

--- a/airbyte-server/src/main/java/io/airbyte/server/apis/OpenapiApiController.java
+++ b/airbyte-server/src/main/java/io/airbyte/server/apis/OpenapiApiController.java
@@ -1,3 +1,7 @@
+/*
+ * Copyright (c) 2022 Airbyte, Inc., all rights reserved.
+ */
+
 package io.airbyte.server.apis;
 
 import io.airbyte.api.generated.OpenapiApi;
@@ -12,7 +16,9 @@ public class OpenapiApiController implements OpenapiApi {
 
   private final OpenApiConfigHandler openApiConfigHandler;
 
-  @Override public File getOpenApiSpec() {
+  @Override
+  public File getOpenApiSpec() {
     return ConfigurationApi.execute(openApiConfigHandler::getFile);
   }
+
 }

--- a/airbyte-server/src/main/java/io/airbyte/server/apis/OpenapiApiController.java
+++ b/airbyte-server/src/main/java/io/airbyte/server/apis/OpenapiApiController.java
@@ -1,0 +1,18 @@
+package io.airbyte.server.apis;
+
+import io.airbyte.api.generated.OpenapiApi;
+import io.airbyte.server.handlers.OpenApiConfigHandler;
+import java.io.File;
+import javax.ws.rs.Path;
+import lombok.AllArgsConstructor;
+
+@Path("/v1/openapi")
+@AllArgsConstructor
+public class OpenapiApiController implements OpenapiApi {
+
+  private final OpenApiConfigHandler openApiConfigHandler;
+
+  @Override public File getOpenApiSpec() {
+    return ConfigurationApi.execute(openApiConfigHandler::getFile);
+  }
+}

--- a/airbyte-server/src/main/java/io/airbyte/server/apis/binders/OpenapiApiBinder.java
+++ b/airbyte-server/src/main/java/io/airbyte/server/apis/binders/OpenapiApiBinder.java
@@ -1,3 +1,7 @@
+/*
+ * Copyright (c) 2022 Airbyte, Inc., all rights reserved.
+ */
+
 package io.airbyte.server.apis.binders;
 
 import io.airbyte.server.apis.OpenapiApiController;
@@ -13,4 +17,5 @@ public class OpenapiApiBinder extends AbstractBinder {
         .to(OpenapiApiController.class)
         .in(RequestScoped.class);
   }
+
 }

--- a/airbyte-server/src/main/java/io/airbyte/server/apis/binders/OpenapiApiBinder.java
+++ b/airbyte-server/src/main/java/io/airbyte/server/apis/binders/OpenapiApiBinder.java
@@ -1,0 +1,16 @@
+package io.airbyte.server.apis.binders;
+
+import io.airbyte.server.apis.OpenapiApiController;
+import io.airbyte.server.apis.factories.OpenapiApiFactory;
+import org.glassfish.hk2.utilities.binding.AbstractBinder;
+import org.glassfish.jersey.process.internal.RequestScoped;
+
+public class OpenapiApiBinder extends AbstractBinder {
+
+  @Override
+  protected void configure() {
+    bindFactory(OpenapiApiFactory.class)
+        .to(OpenapiApiController.class)
+        .in(RequestScoped.class);
+  }
+}

--- a/airbyte-server/src/main/java/io/airbyte/server/apis/factories/OpenapiApiFactory.java
+++ b/airbyte-server/src/main/java/io/airbyte/server/apis/factories/OpenapiApiFactory.java
@@ -1,0 +1,22 @@
+package io.airbyte.server.apis.factories;
+
+import io.airbyte.server.apis.OpenapiApiController;
+import io.airbyte.server.handlers.OpenApiConfigHandler;
+import org.glassfish.hk2.api.Factory;
+
+public class OpenapiApiFactory implements Factory<OpenapiApiController> {
+
+  private static OpenApiConfigHandler openApiConfigHandler;
+
+  public static void setValues(final OpenApiConfigHandler openApiConfigHandler) {
+    OpenapiApiFactory.openApiConfigHandler = openApiConfigHandler;
+  }
+
+  @Override public OpenapiApiController provide() {
+    return new OpenapiApiController(openApiConfigHandler);
+  }
+
+  @Override public void dispose(final OpenapiApiController instance) {
+    /* no op */
+  }
+}

--- a/airbyte-server/src/main/java/io/airbyte/server/apis/factories/OpenapiApiFactory.java
+++ b/airbyte-server/src/main/java/io/airbyte/server/apis/factories/OpenapiApiFactory.java
@@ -1,3 +1,7 @@
+/*
+ * Copyright (c) 2022 Airbyte, Inc., all rights reserved.
+ */
+
 package io.airbyte.server.apis.factories;
 
 import io.airbyte.server.apis.OpenapiApiController;
@@ -12,11 +16,14 @@ public class OpenapiApiFactory implements Factory<OpenapiApiController> {
     OpenapiApiFactory.openApiConfigHandler = openApiConfigHandler;
   }
 
-  @Override public OpenapiApiController provide() {
+  @Override
+  public OpenapiApiController provide() {
     return new OpenapiApiController(openApiConfigHandler);
   }
 
-  @Override public void dispose(final OpenapiApiController instance) {
+  @Override
+  public void dispose(final OpenapiApiController instance) {
     /* no op */
   }
+
 }


### PR DESCRIPTION
## What
In order to be prepared for a smoother migration to Micronaut for the server, an effort must be made to break the ConfigurationApi into multiple classes. This PR is the first one of a series of PR to come.

## How
Extract the OpenapiApi into its own class

## Recommended reading order
No specific order