### PR TITLE
Remove cyclic dead code in ConfigPersistence

### DIFF
--- a/airbyte-config/config-persistence/src/main/java/io/airbyte/config/persistence/ConfigPersistence.java
+++ b/airbyte-config/config-persistence/src/main/java/io/airbyte/config/persistence/ConfigPersistence.java
@@ -5,7 +5,6 @@
 package io.airbyte.config.persistence;
 
 import io.airbyte.config.AirbyteConfig;
-import io.airbyte.config.ConfigWithMetadata;
 import io.airbyte.validation.json.JsonValidationException;
 import java.io.IOException;
 import java.util.List;
@@ -20,11 +19,6 @@ public interface ConfigPersistence {
   <T> T getConfig(AirbyteConfig configType, String configId, Class<T> clazz) throws ConfigNotFoundException, JsonValidationException, IOException;
 
   <T> List<T> listConfigs(AirbyteConfig configType, Class<T> clazz) throws JsonValidationException, IOException;
-
-  <T> ConfigWithMetadata<T> getConfigWithMetadata(AirbyteConfig configType, String configId, Class<T> clazz)
-      throws ConfigNotFoundException, JsonValidationException, IOException;
-
-  <T> List<ConfigWithMetadata<T>> listConfigsWithMetadata(AirbyteConfig configType, Class<T> clazz) throws JsonValidationException, IOException;
 
   <T> void writeConfig(AirbyteConfig configType, String configId, T config) throws JsonValidationException, IOException;
 

--- a/airbyte-config/config-persistence/src/main/java/io/airbyte/config/persistence/DatabaseConfigPersistence.java
+++ b/airbyte-config/config-persistence/src/main/java/io/airbyte/config/persistence/DatabaseConfigPersistence.java
@@ -240,14 +240,6 @@ public class DatabaseConfigPersistence implements ConfigPersistence {
     }
   }
 
-  private <T> ConfigWithMetadata<T> validateAndReturn(final String configId,
-                                                      final List<ConfigWithMetadata<T>> result,
-                                                      final AirbyteConfig airbyteConfig)
-      throws ConfigNotFoundException {
-    validate(configId, result, airbyteConfig);
-    return result.get(0);
-  }
-
   @Override
   public <T> List<T> listConfigs(final AirbyteConfig configType, final Class<T> clazz) throws JsonValidationException, IOException {
     final List<T> config = new ArrayList<>();
@@ -255,42 +247,9 @@ public class DatabaseConfigPersistence implements ConfigPersistence {
     return config;
   }
 
-  @Override
-  public <T> ConfigWithMetadata<T> getConfigWithMetadata(final AirbyteConfig configType, final String configId, final Class<T> clazz)
-      throws ConfigNotFoundException, JsonValidationException, IOException {
-    final Optional<UUID> configIdOpt = Optional.of(UUID.fromString(configId));
-    if (configType == ConfigSchema.STANDARD_WORKSPACE) {
-      return (ConfigWithMetadata<T>) validateAndReturn(configId, listStandardWorkspaceWithMetadata(configIdOpt), configType);
-    } else if (configType == ConfigSchema.STANDARD_SOURCE_DEFINITION) {
-      return (ConfigWithMetadata<T>) validateAndReturn(configId, listStandardSourceDefinitionWithMetadata(configIdOpt), configType);
-    } else if (configType == ConfigSchema.STANDARD_DESTINATION_DEFINITION) {
-      return (ConfigWithMetadata<T>) validateAndReturn(configId, listStandardDestinationDefinitionWithMetadata(configIdOpt), configType);
-    } else if (configType == ConfigSchema.SOURCE_CONNECTION) {
-      return (ConfigWithMetadata<T>) validateAndReturn(configId, listSourceConnectionWithMetadata(configIdOpt), configType);
-    } else if (configType == ConfigSchema.DESTINATION_CONNECTION) {
-      return (ConfigWithMetadata<T>) validateAndReturn(configId, listDestinationConnectionWithMetadata(configIdOpt), configType);
-    } else if (configType == ConfigSchema.SOURCE_OAUTH_PARAM) {
-      return (ConfigWithMetadata<T>) validateAndReturn(configId, listSourceOauthParamWithMetadata(configIdOpt), configType);
-    } else if (configType == ConfigSchema.DESTINATION_OAUTH_PARAM) {
-      return (ConfigWithMetadata<T>) validateAndReturn(configId, listDestinationOauthParamWithMetadata(configIdOpt), configType);
-    } else if (configType == ConfigSchema.STANDARD_SYNC_OPERATION) {
-      return (ConfigWithMetadata<T>) validateAndReturn(configId, listStandardSyncOperationWithMetadata(configIdOpt), configType);
-    } else if (configType == ConfigSchema.STANDARD_SYNC) {
-      return (ConfigWithMetadata<T>) validateAndReturn(configId, listStandardSyncWithMetadata(configIdOpt), configType);
-    } else if (configType == ConfigSchema.STANDARD_SYNC_STATE) {
-      return (ConfigWithMetadata<T>) validateAndReturn(configId, listStandardSyncStateWithMetadata(configIdOpt), configType);
-    } else if (configType == ConfigSchema.ACTOR_CATALOG) {
-      return (ConfigWithMetadata<T>) validateAndReturn(configId, listActorCatalogWithMetadata(configIdOpt), configType);
-    } else if (configType == ConfigSchema.ACTOR_CATALOG_FETCH_EVENT) {
-      return (ConfigWithMetadata<T>) validateAndReturn(configId, listActorCatalogFetchEventWithMetadata(configIdOpt), configType);
-    } else if (configType == ConfigSchema.WORKSPACE_SERVICE_ACCOUNT) {
-      return (ConfigWithMetadata<T>) validateAndReturn(configId, listWorkspaceServiceAccountWithMetadata(configIdOpt), configType);
-    } else {
-      throw new IllegalArgumentException(UNKNOWN_CONFIG_TYPE + configType);
-    }
-  }
-
-  @Override
+  // listConfigWithMetadata seems to be unused at this point.
+  // It is only called by listConfigs and it only reads the config. The "metadata" part seems to be
+  // unused.
   public <T> List<ConfigWithMetadata<T>> listConfigsWithMetadata(final AirbyteConfig configType, final Class<T> clazz) throws IOException {
     final List<ConfigWithMetadata<T>> configWithMetadata = new ArrayList<>();
     if (configType == ConfigSchema.STANDARD_WORKSPACE) {

--- a/airbyte-config/config-persistence/src/main/java/io/airbyte/config/persistence/ValidatingConfigPersistence.java
+++ b/airbyte-config/config-persistence/src/main/java/io/airbyte/config/persistence/ValidatingConfigPersistence.java
@@ -7,7 +7,6 @@ package io.airbyte.config.persistence;
 import com.fasterxml.jackson.databind.JsonNode;
 import io.airbyte.commons.json.Jsons;
 import io.airbyte.config.AirbyteConfig;
-import io.airbyte.config.ConfigWithMetadata;
 import io.airbyte.validation.json.JsonSchemaValidator;
 import io.airbyte.validation.json.JsonValidationException;
 import java.io.IOException;
@@ -47,24 +46,6 @@ public class ValidatingConfigPersistence implements ConfigPersistence {
     final List<T> configs = decoratedPersistence.listConfigs(configType, clazz);
     for (final T config : configs) {
       validateJson(config, configType);
-    }
-    return configs;
-  }
-
-  @Override
-  public <T> ConfigWithMetadata<T> getConfigWithMetadata(final AirbyteConfig configType, final String configId, final Class<T> clazz)
-      throws ConfigNotFoundException, JsonValidationException, IOException {
-    final ConfigWithMetadata<T> config = decoratedPersistence.getConfigWithMetadata(configType, configId, clazz);
-    validateJson(config.getConfig(), configType);
-    return config;
-  }
-
-  @Override
-  public <T> List<ConfigWithMetadata<T>> listConfigsWithMetadata(final AirbyteConfig configType, final Class<T> clazz)
-      throws JsonValidationException, IOException {
-    final List<ConfigWithMetadata<T>> configs = decoratedPersistence.listConfigsWithMetadata(configType, clazz);
-    for (final ConfigWithMetadata<T> config : configs) {
-      validateJson(config.getConfig(), configType);
     }
     return configs;
   }

--- a/airbyte-config/config-persistence/src/test/java/io/airbyte/config/persistence/DatabaseConfigPersistenceTest.java
+++ b/airbyte-config/config-persistence/src/test/java/io/airbyte/config/persistence/DatabaseConfigPersistenceTest.java
@@ -97,21 +97,6 @@ class DatabaseConfigPersistenceTest extends BaseDatabaseConfigPersistenceTest {
   }
 
   @Test
-  void testGetConfigWithMetadata() throws Exception {
-    final Instant now = Instant.now().minus(Duration.ofSeconds(1));
-    writeDestination(configPersistence, DESTINATION_S3);
-    final ConfigWithMetadata<StandardDestinationDefinition> configWithMetadata = configPersistence.getConfigWithMetadata(
-        STANDARD_DESTINATION_DEFINITION,
-        DESTINATION_S3.getDestinationDefinitionId().toString(),
-        StandardDestinationDefinition.class);
-    assertEquals("STANDARD_DESTINATION_DEFINITION", configWithMetadata.getConfigType());
-    assertTrue(configWithMetadata.getCreatedAt().isAfter(now));
-    assertTrue(configWithMetadata.getUpdatedAt().isAfter(now));
-    assertEquals(DESTINATION_S3.getDestinationDefinitionId().toString(), configWithMetadata.getConfigId());
-    assertEquals(DESTINATION_S3, configWithMetadata.getConfig());
-  }
-
-  @Test
   void testListConfigWithMetadata() throws Exception {
     final Instant now = Instant.now().minus(Duration.ofSeconds(1));
     writeDestination(configPersistence, DESTINATION_S3);

--- a/airbyte-config/config-persistence/src/test/java/io/airbyte/config/persistence/ValidatingConfigPersistenceTest.java
+++ b/airbyte-config/config-persistence/src/test/java/io/airbyte/config/persistence/ValidatingConfigPersistenceTest.java
@@ -15,7 +15,6 @@ import static org.mockito.Mockito.when;
 
 import com.google.common.collect.Sets;
 import io.airbyte.config.ConfigSchema;
-import io.airbyte.config.ConfigWithMetadata;
 import io.airbyte.config.StandardSourceDefinition;
 import io.airbyte.validation.json.JsonSchemaValidator;
 import io.airbyte.validation.json.JsonValidationException;
@@ -48,14 +47,14 @@ class ValidatingConfigPersistenceTest {
   private JsonSchemaValidator schemaValidator;
 
   private ValidatingConfigPersistence configPersistence;
-  private ConfigPersistence decoratedConfigPersistence;
+  private DatabaseConfigPersistence decoratedConfigPersistence;
   private static final String ERROR_MESSAGE = "error";
 
   @BeforeEach
   void setUp() {
     schemaValidator = mock(JsonSchemaValidator.class);
 
-    decoratedConfigPersistence = mock(ConfigPersistence.class);
+    decoratedConfigPersistence = mock(DatabaseConfigPersistence.class);
     configPersistence = new ValidatingConfigPersistence(decoratedConfigPersistence, schemaValidator);
   }
 
@@ -142,59 +141,6 @@ class ValidatingConfigPersistenceTest {
 
     assertThrows(JsonValidationException.class, () -> configPersistence
         .listConfigs(ConfigSchema.STANDARD_SOURCE_DEFINITION, StandardSourceDefinition.class));
-  }
-
-  @Test
-  void testGetConfigWithMetadataSuccess() throws IOException, JsonValidationException, ConfigNotFoundException {
-    when(decoratedConfigPersistence.getConfigWithMetadata(ConfigSchema.STANDARD_SOURCE_DEFINITION, UUID_1.toString(), StandardSourceDefinition.class))
-        .thenReturn(withMetadata(SOURCE_1));
-    final ConfigWithMetadata<StandardSourceDefinition> actualConfig = configPersistence
-        .getConfigWithMetadata(ConfigSchema.STANDARD_SOURCE_DEFINITION, UUID_1.toString(), StandardSourceDefinition.class);
-
-    assertEquals(withMetadata(SOURCE_1), actualConfig);
-  }
-
-  @Test
-  void testGetConfigWithMetadataFailure() throws IOException, JsonValidationException, ConfigNotFoundException {
-    doThrow(new JsonValidationException(ERROR_MESSAGE)).when(schemaValidator).ensure(any(), any());
-    when(decoratedConfigPersistence.getConfigWithMetadata(ConfigSchema.STANDARD_SOURCE_DEFINITION, UUID_1.toString(), StandardSourceDefinition.class))
-        .thenReturn(withMetadata(SOURCE_1));
-
-    assertThrows(
-        JsonValidationException.class,
-        () -> configPersistence.getConfigWithMetadata(ConfigSchema.STANDARD_SOURCE_DEFINITION, UUID_1.toString(), StandardSourceDefinition.class));
-  }
-
-  @Test
-  void testListConfigsWithMetadataSuccess() throws JsonValidationException, IOException {
-    when(decoratedConfigPersistence.listConfigsWithMetadata(ConfigSchema.STANDARD_SOURCE_DEFINITION, StandardSourceDefinition.class))
-        .thenReturn(List.of(withMetadata(SOURCE_1), withMetadata(SOURCE_2)));
-
-    final List<ConfigWithMetadata<StandardSourceDefinition>> actualConfigs = configPersistence
-        .listConfigsWithMetadata(ConfigSchema.STANDARD_SOURCE_DEFINITION, StandardSourceDefinition.class);
-
-    // noinspection unchecked
-    assertEquals(
-        Sets.newHashSet(withMetadata(SOURCE_1), withMetadata(SOURCE_2)),
-        Sets.newHashSet(actualConfigs));
-  }
-
-  @Test
-  void testListConfigsWithMetadataFailure() throws JsonValidationException, IOException {
-    doThrow(new JsonValidationException(ERROR_MESSAGE)).when(schemaValidator).ensure(any(), any());
-    when(decoratedConfigPersistence.listConfigsWithMetadata(ConfigSchema.STANDARD_SOURCE_DEFINITION, StandardSourceDefinition.class))
-        .thenReturn(List.of(withMetadata(SOURCE_1), withMetadata(SOURCE_2)));
-
-    assertThrows(JsonValidationException.class, () -> configPersistence
-        .listConfigsWithMetadata(ConfigSchema.STANDARD_SOURCE_DEFINITION, StandardSourceDefinition.class));
-  }
-
-  private static ConfigWithMetadata<StandardSourceDefinition> withMetadata(final StandardSourceDefinition sourceDef) {
-    return new ConfigWithMetadata<>(sourceDef.getSourceDefinitionId().toString(),
-        ConfigSchema.STANDARD_SOURCE_DEFINITION.name(),
-        INSTANT,
-        INSTANT,
-        sourceDef);
   }
 
 }


### PR DESCRIPTION
## What

`getConfigWithMetadata` and `listConfigWithMetadata` seems to be unused. Removing them simplifies code tracking because it cuts off cyclic a dependency between `DatabaseConfigPersistence` and `ValidatingConfigPersistence` that is no longer used.

This should help when actually breaking out the the different parts of `DatabaseConfigPersistence`.

## How

Remove dead code.
