### PR TITLE
fix: install java in oss catalog deploy action

### DIFF
--- a/.github/workflows/deploy-oss-catalog.yml
+++ b/.github/workflows/deploy-oss-catalog.yml
@@ -12,7 +12,7 @@ on:
 jobs:
   deploy-catalog:
     name: "Deploy Catalog"
-    # if: github.ref == 'refs/heads/master'
+    if: github.ref == 'refs/heads/master'
     runs-on: ubuntu-latest
     concurrency: deploy-oss-connector-catalog
     steps:

--- a/.github/workflows/deploy-oss-catalog.yml
+++ b/.github/workflows/deploy-oss-catalog.yml
@@ -23,6 +23,10 @@ jobs:
         with:
           service_account_key: ${{ secrets.PROD_SPEC_CACHE_SA_KEY }}
           export_default_credentials: true
+      - name: Install Java
+        uses: actions/setup-java@v1
+        with:
+          java-version: "17"
       - name: Generate catalog
         run: SUB_BUILD=PLATFORM ./gradlew :airbyte-config:init:processResources
       - name: Upload catalog to GCS

--- a/.github/workflows/deploy-oss-catalog.yml
+++ b/.github/workflows/deploy-oss-catalog.yml
@@ -12,7 +12,7 @@ on:
 jobs:
   deploy-catalog:
     name: "Deploy Catalog"
-    if: github.ref == 'refs/heads/master'
+    # if: github.ref == 'refs/heads/master'
     runs-on: ubuntu-latest
     concurrency: deploy-oss-connector-catalog
     steps:


### PR DESCRIPTION
## What

When running the new deploy action introduced in #18633 we were seeing it fail with the following error:

```
Execution failed for task ':airbyte-commons:compileJava'.
> error: invalid source release: 17
```

https://github.com/airbytehq/airbyte/actions/runs/3382086888/jobs/5617052601

## How

Fix it by installing java as a pre-step to running the gradle command

Successful run from this branch: https://github.com/airbytehq/airbyte/actions/runs/3382535879
