### PR TITLE
Remove deprecated connector dependency report

### DIFF
--- a/.github/comment_templates/connector_dependency_template.md
+++ b/.github/comment_templates/connector_dependency_template.md
@@ -17,6 +17,8 @@ NOTE ⚠️ Changes in this PR affect the following connectors. Make sure to do 
 | --- | :---: | :---: | :---: |
 {source_rows}
 
+* See "Actionable Items" below for how to resolves warnings and errors.
+
 </details>
 
 <details {destination_open}>
@@ -30,6 +32,8 @@ NOTE ⚠️ Changes in this PR affect the following connectors. Make sure to do 
 | --- | :---: | :---: | :---: |
 {destination_rows}
 
+* See "Actionable Items" below for how to resolves warnings and errors.
+
 </details>
 
 {others}
@@ -38,7 +42,9 @@ NOTE ⚠️ Changes in this PR affect the following connectors. Make sure to do 
 
 <summary>
 
-### Notes
+### Actionable Items
+
+(click to expand)
 
 </summary>
 

--- a/.github/comment_templates/connector_dependency_template.md
+++ b/.github/comment_templates/connector_dependency_template.md
@@ -19,7 +19,7 @@ NOTE ⚠️ Changes in this PR affect the following connectors. Make sure to do 
 | --- | :---: | :---: | :---: |
 {source_rows}
 
-* See "Actionable Items" below for how to resolves warnings and errors.
+* See "Actionable Items" below for how to resolve warnings and errors.
 
 </details>
 
@@ -34,7 +34,7 @@ NOTE ⚠️ Changes in this PR affect the following connectors. Make sure to do 
 | --- | :---: | :---: | :---: |
 {destination_rows}
 
-* See "Actionable Items" below for how to resolves warnings and errors.
+* See "Actionable Items" below for how to resolve warnings and errors.
 
 </details>
 

--- a/.github/comment_templates/connector_dependency_template.md
+++ b/.github/comment_templates/connector_dependency_template.md
@@ -1,5 +1,7 @@
 <!--- this comment is for `report-connectors-dependency.yml` identification, do not remove -->
 
+## Affected Connector Report
+
 NOTE ⚠️ Changes in this PR affect the following connectors. Make sure to do the following as needed:
 - Run integration tests
 - Bump connector version

--- a/.github/workflows/report-connectors-dependency.yml
+++ b/.github/workflows/report-connectors-dependency.yml
@@ -25,6 +25,8 @@ jobs:
             echo "comment=true" >> $GITHUB_OUTPUT
           fi
       - name: Find existing comment for connector dependencies
+        # Always run this step because the action may need to
+        # remove a comment created from a previous comment.
         uses: peter-evans/find-comment@v2
         id: find_comment
         with:
@@ -39,7 +41,7 @@ jobs:
           comment-id: ${{ steps.find_comment.outputs.comment-id }}
           edit-mode: "replace"
           body-file: "comment_body.md"
-      - name: Delete deprecated comment in PR
+      - name: Remove deprecated report in PR
         if: steps.dependency_report.outputs.comment != 'true' && steps.find_comment.outputs.comment-id != ''
         uses: peter-evans/create-or-update-comment@v2
         with:

--- a/.github/workflows/report-connectors-dependency.yml
+++ b/.github/workflows/report-connectors-dependency.yml
@@ -49,5 +49,6 @@ jobs:
           comment-id: ${{ steps.find_comment.outputs.comment-id }}
           edit-mode: "replace"
           body: |
+            <!--- this comment is for `report-connectors-dependency.yml` identification, do not remove -->
             ## Affected Connector Report
             The latest commit has removed all connector-related changes. There is no more dependent connector for this PR.

--- a/.github/workflows/report-connectors-dependency.yml
+++ b/.github/workflows/report-connectors-dependency.yml
@@ -23,6 +23,8 @@ jobs:
           python ./tools/bin/ci_check_dependency.py ./changed_files.txt
           if [[ -f comment_body.md ]]; then
             echo "comment=true" >> $GITHUB_OUTPUT
+          else
+            echo "comment=false" >> $GITHUB_OUTPUT
           fi
       - name: Find existing comment for connector dependencies
         if: steps.dependency_report.outputs.comment == 'true'

--- a/.github/workflows/report-connectors-dependency.yml
+++ b/.github/workflows/report-connectors-dependency.yml
@@ -26,7 +26,7 @@ jobs:
           fi
       - name: Find existing comment for connector dependencies
         # Always run this step because the action may need to
-        # remove a comment created from a previous comment.
+        # remove a comment created from a previous commit.
         uses: peter-evans/find-comment@v2
         id: find_comment
         with:
@@ -51,4 +51,4 @@ jobs:
           body: |
             <!--- this comment is for `report-connectors-dependency.yml` identification, do not remove -->
             ## Affected Connector Report
-            The latest commit has removed all connector-related changes. There is no more dependent connector for this PR.
+            The latest commit has removed all connector-related changes. There are no more dependent connectors for this PR.

--- a/.github/workflows/report-connectors-dependency.yml
+++ b/.github/workflows/report-connectors-dependency.yml
@@ -48,4 +48,6 @@ jobs:
           issue-number: ${{ github.event.pull_request.number }}
           comment-id: ${{ steps.find_comment.outputs.comment-id }}
           edit-mode: "replace"
-          body: "The latest commit has removed all connector-related changes. There is no more dependent connector for this PR."
+          body: |
+            ## Affected Connector Report
+            The latest commit has removed all connector-related changes. There is no more dependent connector for this PR.

--- a/.github/workflows/report-connectors-dependency.yml
+++ b/.github/workflows/report-connectors-dependency.yml
@@ -23,11 +23,8 @@ jobs:
           python ./tools/bin/ci_check_dependency.py ./changed_files.txt
           if [[ -f comment_body.md ]]; then
             echo "comment=true" >> $GITHUB_OUTPUT
-          else
-            echo "comment=false" >> $GITHUB_OUTPUT
           fi
       - name: Find existing comment for connector dependencies
-        if: steps.dependency_report.outputs.comment == 'true'
         uses: peter-evans/find-comment@v2
         id: find_comment
         with:

--- a/.github/workflows/report-connectors-dependency.yml
+++ b/.github/workflows/report-connectors-dependency.yml
@@ -40,3 +40,11 @@ jobs:
           comment-id: ${{ steps.find_comment.outputs.comment-id }}
           edit-mode: "replace"
           body-file: "comment_body.md"
+      - name: Delete deprecated comment in PR
+        if: steps.dependency_report.outputs.comment != 'true' && steps.find_comment.outputs.comment-id != ''
+        uses: peter-evans/create-or-update-comment@v2
+        with:
+          issue-number: ${{ github.event.pull_request.number }}
+          comment-id: ${{ steps.find_comment.outputs.comment-id }}
+          edit-mode: "replace"
+          body: "The latest commit has removed all connector-related changes. There is no more dependent connector for this PR."

--- a/airbyte-integrations/connectors/source-postgres/Dockerfile
+++ b/airbyte-integrations/connectors/source-postgres/Dockerfile
@@ -16,5 +16,5 @@ ENV APPLICATION source-postgres
 
 COPY --from=build /airbyte /airbyte
 
-LABEL io.airbyte.version=1.0.23
+LABEL io.airbyte.version=1.0.22
 LABEL io.airbyte.name=airbyte/source-postgres

--- a/airbyte-integrations/connectors/source-postgres/Dockerfile
+++ b/airbyte-integrations/connectors/source-postgres/Dockerfile
@@ -16,5 +16,5 @@ ENV APPLICATION source-postgres
 
 COPY --from=build /airbyte /airbyte
 
-LABEL io.airbyte.version=1.0.22
+LABEL io.airbyte.version=1.0.23
 LABEL io.airbyte.name=airbyte/source-postgres


### PR DESCRIPTION
## What
- Follow up for #18845.
- If a commit removes all changes related to connectors, the connector dependency report should be removed.
- This PR adds a new action to replace the report comment with a static message.
