### PR TITLE
`ci_integration_test.sh`: cut GITHUB_STEP_SUMMARY

### DIFF
--- a/tools/bin/ci_integration_test.sh
+++ b/tools/bin/ci_integration_test.sh
@@ -135,6 +135,9 @@ write_logs() {
 echo "# $connector" >> $GITHUB_STEP_SUMMARY
 echo "" >> $GITHUB_STEP_SUMMARY
 
+# Cut the $GITHUB_STEP_SUMMARY with head if its larger than 1MB
+echo "$GITHUB_STEP_SUMMARY" | head -c 1048576 >> $GITHUB_STEP_SUMMARY
+
 # Copy command output to extract gradle scan link.
 run | tee build.out
 # return status of "run" command, not "tee"


### PR DESCRIPTION
## What
Closes https://github.com/airbytehq/airbyte/issues/18868
Currently /test jobs are failing ([1](https://github.com/airbytehq/airbyte/actions/runs/3377029052),[2](https://github.com/airbytehq/airbyte/actions/runs/3377023024)) because the GITHUB_STEP_SUMMARY ([docs](https://docs.github.com/en/actions/using-workflows/workflow-commands-for-github-actions#adding-a-job-summary)) is larger than the allowed 1MB.

## How
Cut the GITHUB_STEP_SUMMARY with `head -c 1048576`  so that it never exceeds 1MB.