### PR TITLE
:window: :wrench: Improve pre-commit hook

### DIFF
--- a/airbyte-webapp/.husky/pre-commit
+++ b/airbyte-webapp/.husky/pre-commit
@@ -1,1 +1,10 @@
-cd airbyte-webapp && npx --no lint-staged
+# Only run this pre-commit hook when npx is actually in the path.
+# Since CI will fail on misformated frontend code we consider this hook optional
+# and don't want to fail if the system doesn't have the requirements to run it.
+if command -v npx &> /dev/null; then
+  # Only run if `npx` is at least version 8, since earlier versions didn't support the --no flag
+  npxMajorVersion=$(npx --version | cut -d. -f1)
+  if [ "$npxMajorVersion" -ge "8" ]; then
+    cd airbyte-webapp && npx --no lint-staged
+  fi
+fi


### PR DESCRIPTION
## What

Improve the pre-commit hook from the airbyte-webapp. Since our CI checks on proper formatting the hook is just a convenience to fail early, but not required to execute. So we should not fail committing if the devs system does not fulfill the requirements to execute it (e.g. we've have seen some backend engineers having older `node` versions installed, which cause the hook to fail on their systems).

## How

The script now checks if `npx` is installed at all (might not e.g. if you commit form an IDE, and don't have it in the PATH there), and if the major version of it is at least 8, since before that `--no` wasn't supported.

## Testing

I would appreciate, if this could be reviewed by someone with OS X, since I only tested it on Linux. To test, please check this out, be in the repository root and execute `airbyte-webapp/.husky/pre-commit` from a shell and see if you get the "No staged files found" output. 