### PR TITLE
ci: bring old set-output to build branch and artifact tags

### DIFF
--- a/.github/actions/build-branch/action.yml
+++ b/.github/actions/build-branch/action.yml
@@ -19,6 +19,12 @@ runs:
         #
         [[ "${{ inputs.branch_version_tag }}" != '' ]] && echo "branch_version_tag=${{ inputs.branch_version_tag }}" >> $GITHUB_OUTPUT \
           || { short_hash=$(git rev-parse --short HEAD); echo "branch_version_tag=dev-$short_hash" >> $GITHUB_OUTPUT ; }
+        cat $GITHUB_OUTPUT || true  # for the sake of investigation
+
+        # if the *branch_version_tag* input param is not specified, then generate it as 'dev-<commit_hash>`
+        #
+        [[ "${{ inputs.branch_version_tag }}" != '' ]] && echo "::set-output name=branch_version_tag::${{ inputs.branch_version_tag }}" \
+          || { short_hash=$(git rev-parse --short HEAD); echo "::set-output name=branch_version_tag::dev-$short_hash"; }
 
     - uses: actions/setup-java@v1
       with:

--- a/.github/workflows/publish-oss-for-cloud.yml
+++ b/.github/workflows/publish-oss-for-cloud.yml
@@ -72,6 +72,15 @@ jobs:
           if $(git merge-base --is-ancestor "${commit_sha}" master); then
             echo "master_tag=${commit_sha}" >> $GITHUB_OUTPUT
           fi
+          cat $GITHUB_OUTPUT || true # for the sake of investigation
+
+          # set dev_tag
+          # AirbyteVersion.java allows versions that have a prefix of 'dev'
+          echo "::set-output name=dev_tag::dev-${commit_sha}"
+
+          if $(git merge-base --is-ancestor "${commit_sha}" master); then
+            echo "::set-output name=master_tag::${commit_sha}"
+          fi
 
   oss-branch-build:
     name: "Gradle Build and Publish"


### PR DESCRIPTION
## What
We have broken `dev-{short_sha}` tagging. Trying to fix it.

## How
Bring old `set-output` GitHub Actions syntax