### PR TITLE
Extract StandardSyncPersistence from DatabaseConfigPersistence

### DIFF
--- a/airbyte-config/config-persistence/src/main/java/io/airbyte/config/persistence/DatabaseConfigPersistence.java
+++ b/airbyte-config/config-persistence/src/main/java/io/airbyte/config/persistence/DatabaseConfigPersistence.java
@@ -9,8 +9,6 @@ import static io.airbyte.db.instance.configs.jooq.generated.Tables.ACTOR_CATALOG
 import static io.airbyte.db.instance.configs.jooq.generated.Tables.ACTOR_CATALOG_FETCH_EVENT;
 import static io.airbyte.db.instance.configs.jooq.generated.Tables.ACTOR_DEFINITION;
 import static io.airbyte.db.instance.configs.jooq.generated.Tables.ACTOR_OAUTH_PARAMETER;
-import static io.airbyte.db.instance.configs.jooq.generated.Tables.CONNECTION;
-import static io.airbyte.db.instance.configs.jooq.generated.Tables.CONNECTION_OPERATION;
 import static io.airbyte.db.instance.configs.jooq.generated.Tables.OPERATION;
 import static io.airbyte.db.instance.configs.jooq.generated.Tables.STATE;
 import static io.airbyte.db.instance.configs.jooq.generated.Tables.WORKSPACE;
@@ -42,14 +40,12 @@ import io.airbyte.config.SourceOAuthParameter;
 import io.airbyte.config.StandardDestinationDefinition;
 import io.airbyte.config.StandardSourceDefinition;
 import io.airbyte.config.StandardSourceDefinition.SourceType;
-import io.airbyte.config.StandardSync;
 import io.airbyte.config.StandardSyncOperation;
 import io.airbyte.config.StandardSyncOperation.OperatorType;
 import io.airbyte.config.StandardSyncState;
 import io.airbyte.config.StandardWorkspace;
 import io.airbyte.config.State;
 import io.airbyte.config.WorkspaceServiceAccount;
-import io.airbyte.config.helpers.ScheduleHelpers;
 import io.airbyte.db.Database;
 import io.airbyte.db.ExceptionWrappingDatabase;
 import io.airbyte.db.instance.configs.jooq.generated.enums.ActorType;
@@ -68,6 +64,7 @@ import java.util.Set;
 import java.util.UUID;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
+import org.apache.commons.lang3.NotImplementedException;
 import org.jooq.DSLContext;
 import org.jooq.JSONB;
 import org.jooq.Record;
@@ -123,7 +120,7 @@ public class DatabaseConfigPersistence implements ConfigPersistence {
     } else if (configType == ConfigSchema.STANDARD_SYNC_OPERATION) {
       return (T) getStandardSyncOperation(configId);
     } else if (configType == ConfigSchema.STANDARD_SYNC) {
-      return (T) getStandardSync(configId);
+      throw buildUseStandardSyncPersistenceException();
     } else if (configType == ConfigSchema.STANDARD_SYNC_STATE) {
       return (T) getStandardSyncState(configId);
     } else if (configType == ConfigSchema.ACTOR_CATALOG) {
@@ -135,6 +132,10 @@ public class DatabaseConfigPersistence implements ConfigPersistence {
     } else {
       throw new IllegalArgumentException(UNKNOWN_CONFIG_TYPE + configType);
     }
+  }
+
+  private NotImplementedException buildUseStandardSyncPersistenceException() {
+    return new NotImplementedException("Use StandardSyncPersistence instead");
   }
 
   private StandardWorkspace getStandardWorkspace(final String configId) throws IOException, ConfigNotFoundException {
@@ -193,12 +194,6 @@ public class DatabaseConfigPersistence implements ConfigPersistence {
     return result.get(0).getConfig();
   }
 
-  private StandardSync getStandardSync(final String configId) throws IOException, ConfigNotFoundException {
-    final List<ConfigWithMetadata<StandardSync>> result = listStandardSyncWithMetadata(Optional.of(UUID.fromString(configId)));
-    validate(configId, result, ConfigSchema.STANDARD_SYNC);
-    return result.get(0).getConfig();
-  }
-
   private StandardSyncState getStandardSyncState(final String configId) throws IOException, ConfigNotFoundException {
     final List<ConfigWithMetadata<StandardSyncState>> result = listStandardSyncStateWithMetadata(Optional.of(UUID.fromString(configId)));
     validate(configId, result, ConfigSchema.STANDARD_SYNC_STATE);
@@ -215,20 +210,6 @@ public class DatabaseConfigPersistence implements ConfigPersistence {
     final List<ConfigWithMetadata<ActorCatalogFetchEvent>> result = listActorCatalogFetchEventWithMetadata(Optional.of(UUID.fromString(configId)));
     validate(configId, result, ConfigSchema.ACTOR_CATALOG_FETCH_EVENT);
     return result.get(0).getConfig();
-  }
-
-  private List<UUID> connectionOperationIds(final UUID connectionId) throws IOException {
-    final Result<Record> result = database.query(ctx -> ctx.select(asterisk())
-        .from(CONNECTION_OPERATION)
-        .where(CONNECTION_OPERATION.CONNECTION_ID.eq(connectionId))
-        .fetch());
-
-    final List<UUID> ids = new ArrayList<>();
-    for (final Record record : result) {
-      ids.add(record.get(CONNECTION_OPERATION.OPERATION_ID));
-    }
-
-    return ids;
   }
 
   private <T> void validate(final String configId, final List<ConfigWithMetadata<T>> result, final AirbyteConfig airbyteConfig)
@@ -269,7 +250,7 @@ public class DatabaseConfigPersistence implements ConfigPersistence {
     } else if (configType == ConfigSchema.STANDARD_SYNC_OPERATION) {
       listStandardSyncOperationWithMetadata().forEach(c -> configWithMetadata.add((ConfigWithMetadata<T>) c));
     } else if (configType == ConfigSchema.STANDARD_SYNC) {
-      listStandardSyncWithMetadata().forEach(c -> configWithMetadata.add((ConfigWithMetadata<T>) c));
+      throw buildUseStandardSyncPersistenceException();
     } else if (configType == ConfigSchema.STANDARD_SYNC_STATE) {
       listStandardSyncStateWithMetadata().forEach(c -> configWithMetadata.add((ConfigWithMetadata<T>) c));
     } else if (configType == ConfigSchema.ACTOR_CATALOG) {
@@ -538,35 +519,6 @@ public class DatabaseConfigPersistence implements ConfigPersistence {
         .withTombstone(record.get(OPERATION.TOMBSTONE));
   }
 
-  private List<ConfigWithMetadata<StandardSync>> listStandardSyncWithMetadata() throws IOException {
-    return listStandardSyncWithMetadata(Optional.empty());
-  }
-
-  private List<ConfigWithMetadata<StandardSync>> listStandardSyncWithMetadata(final Optional<UUID> configId) throws IOException {
-    final Result<Record> result = database.query(ctx -> {
-      final SelectJoinStep<Record> query = ctx.select(asterisk()).from(CONNECTION);
-      if (configId.isPresent()) {
-        return query.where(CONNECTION.ID.eq(configId.get())).fetch();
-      }
-      return query.fetch();
-    });
-
-    final List<ConfigWithMetadata<StandardSync>> standardSyncs = new ArrayList<>();
-    for (final Record record : result) {
-      final StandardSync standardSync = DbConverter.buildStandardSync(record, connectionOperationIds(record.get(CONNECTION.ID)));
-      if (ScheduleHelpers.isScheduleTypeMismatch(standardSync)) {
-        throw new RuntimeException("unexpected schedule type mismatch");
-      }
-      standardSyncs.add(new ConfigWithMetadata<>(
-          record.get(CONNECTION.ID).toString(),
-          ConfigSchema.STANDARD_SYNC.name(),
-          record.get(CONNECTION.CREATED_AT).toInstant(),
-          record.get(CONNECTION.UPDATED_AT).toInstant(),
-          standardSync));
-    }
-    return standardSyncs;
-  }
-
   private List<ConfigWithMetadata<StandardSyncState>> listStandardSyncStateWithMetadata() throws IOException {
     return listStandardSyncStateWithMetadata(Optional.empty());
   }
@@ -676,7 +628,7 @@ public class DatabaseConfigPersistence implements ConfigPersistence {
     } else if (configType == ConfigSchema.STANDARD_SYNC_OPERATION) {
       writeStandardSyncOperation(Collections.singletonList((StandardSyncOperation) config));
     } else if (configType == ConfigSchema.STANDARD_SYNC) {
-      writeStandardSync(Collections.singletonList((StandardSync) config));
+      throw buildUseStandardSyncPersistenceException();
     } else if (configType == ConfigSchema.STANDARD_SYNC_STATE) {
       writeStandardSyncState(Collections.singletonList((StandardSyncState) config));
     } else if (configType == ConfigSchema.ACTOR_CATALOG) {
@@ -1018,112 +970,6 @@ public class DatabaseConfigPersistence implements ConfigPersistence {
     });
   }
 
-  private void writeStandardSync(final List<StandardSync> configs) throws IOException {
-    database.transaction(ctx -> {
-      writeStandardSync(configs, ctx);
-      return null;
-    });
-  }
-
-  private void writeStandardSync(final List<StandardSync> configs, final DSLContext ctx) {
-    final OffsetDateTime timestamp = OffsetDateTime.now();
-    configs.forEach((standardSync) -> {
-      final boolean isExistingConfig = ctx.fetchExists(select()
-          .from(CONNECTION)
-          .where(CONNECTION.ID.eq(standardSync.getConnectionId())));
-
-      if (ScheduleHelpers.isScheduleTypeMismatch(standardSync)) {
-        throw new RuntimeException("unexpected schedule type mismatch");
-      }
-
-      if (isExistingConfig) {
-        ctx.update(CONNECTION)
-            .set(CONNECTION.ID, standardSync.getConnectionId())
-            .set(CONNECTION.NAMESPACE_DEFINITION, Enums.toEnum(standardSync.getNamespaceDefinition().value(),
-                io.airbyte.db.instance.configs.jooq.generated.enums.NamespaceDefinitionType.class).orElseThrow())
-            .set(CONNECTION.NAMESPACE_FORMAT, standardSync.getNamespaceFormat())
-            .set(CONNECTION.PREFIX, standardSync.getPrefix())
-            .set(CONNECTION.SOURCE_ID, standardSync.getSourceId())
-            .set(CONNECTION.DESTINATION_ID, standardSync.getDestinationId())
-            .set(CONNECTION.NAME, standardSync.getName())
-            .set(CONNECTION.CATALOG, JSONB.valueOf(Jsons.serialize(standardSync.getCatalog())))
-            .set(CONNECTION.STATUS, standardSync.getStatus() == null ? null
-                : Enums.toEnum(standardSync.getStatus().value(),
-                    io.airbyte.db.instance.configs.jooq.generated.enums.StatusType.class).orElseThrow())
-            .set(CONNECTION.SCHEDULE, JSONB.valueOf(Jsons.serialize(standardSync.getSchedule())))
-            .set(CONNECTION.MANUAL, standardSync.getManual())
-            .set(CONNECTION.SCHEDULE_TYPE,
-                standardSync.getScheduleType() == null ? null
-                    : Enums.toEnum(standardSync.getScheduleType().value(),
-                        io.airbyte.db.instance.configs.jooq.generated.enums.ScheduleType.class)
-                        .orElseThrow())
-            .set(CONNECTION.SCHEDULE_DATA, JSONB.valueOf(Jsons.serialize(standardSync.getScheduleData())))
-            .set(CONNECTION.RESOURCE_REQUIREMENTS,
-                JSONB.valueOf(Jsons.serialize(standardSync.getResourceRequirements())))
-            .set(CONNECTION.UPDATED_AT, timestamp)
-            .set(CONNECTION.SOURCE_CATALOG_ID, standardSync.getSourceCatalogId())
-            .set(CONNECTION.BREAKING_CHANGE, standardSync.getBreakingChange())
-            .set(CONNECTION.GEOGRAPHY, Enums.toEnum(standardSync.getGeography().value(),
-                io.airbyte.db.instance.configs.jooq.generated.enums.GeographyType.class).orElseThrow())
-            .where(CONNECTION.ID.eq(standardSync.getConnectionId()))
-            .execute();
-
-        ctx.deleteFrom(CONNECTION_OPERATION)
-            .where(CONNECTION_OPERATION.CONNECTION_ID.eq(standardSync.getConnectionId()))
-            .execute();
-        for (final UUID operationIdFromStandardSync : standardSync.getOperationIds()) {
-          ctx.insertInto(CONNECTION_OPERATION)
-              .set(CONNECTION_OPERATION.ID, UUID.randomUUID())
-              .set(CONNECTION_OPERATION.CONNECTION_ID, standardSync.getConnectionId())
-              .set(CONNECTION_OPERATION.OPERATION_ID, operationIdFromStandardSync)
-              .set(CONNECTION_OPERATION.CREATED_AT, timestamp)
-              .set(CONNECTION_OPERATION.UPDATED_AT, timestamp)
-              .execute();
-        }
-      } else {
-        ctx.insertInto(CONNECTION)
-            .set(CONNECTION.ID, standardSync.getConnectionId())
-            .set(CONNECTION.NAMESPACE_DEFINITION, Enums.toEnum(standardSync.getNamespaceDefinition().value(),
-                io.airbyte.db.instance.configs.jooq.generated.enums.NamespaceDefinitionType.class).orElseThrow())
-            .set(CONNECTION.NAMESPACE_FORMAT, standardSync.getNamespaceFormat())
-            .set(CONNECTION.PREFIX, standardSync.getPrefix())
-            .set(CONNECTION.SOURCE_ID, standardSync.getSourceId())
-            .set(CONNECTION.DESTINATION_ID, standardSync.getDestinationId())
-            .set(CONNECTION.NAME, standardSync.getName())
-            .set(CONNECTION.CATALOG, JSONB.valueOf(Jsons.serialize(standardSync.getCatalog())))
-            .set(CONNECTION.STATUS, standardSync.getStatus() == null ? null
-                : Enums.toEnum(standardSync.getStatus().value(),
-                    io.airbyte.db.instance.configs.jooq.generated.enums.StatusType.class).orElseThrow())
-            .set(CONNECTION.SCHEDULE, JSONB.valueOf(Jsons.serialize(standardSync.getSchedule())))
-            .set(CONNECTION.MANUAL, standardSync.getManual())
-            .set(CONNECTION.SCHEDULE_TYPE,
-                standardSync.getScheduleType() == null ? null
-                    : Enums.toEnum(standardSync.getScheduleType().value(),
-                        io.airbyte.db.instance.configs.jooq.generated.enums.ScheduleType.class)
-                        .orElseThrow())
-            .set(CONNECTION.SCHEDULE_DATA, JSONB.valueOf(Jsons.serialize(standardSync.getScheduleData())))
-            .set(CONNECTION.RESOURCE_REQUIREMENTS,
-                JSONB.valueOf(Jsons.serialize(standardSync.getResourceRequirements())))
-            .set(CONNECTION.SOURCE_CATALOG_ID, standardSync.getSourceCatalogId())
-            .set(CONNECTION.GEOGRAPHY, Enums.toEnum(standardSync.getGeography().value(),
-                io.airbyte.db.instance.configs.jooq.generated.enums.GeographyType.class).orElseThrow())
-            .set(CONNECTION.BREAKING_CHANGE, standardSync.getBreakingChange())
-            .set(CONNECTION.CREATED_AT, timestamp)
-            .set(CONNECTION.UPDATED_AT, timestamp)
-            .execute();
-        for (final UUID operationIdFromStandardSync : standardSync.getOperationIds()) {
-          ctx.insertInto(CONNECTION_OPERATION)
-              .set(CONNECTION_OPERATION.ID, UUID.randomUUID())
-              .set(CONNECTION_OPERATION.CONNECTION_ID, standardSync.getConnectionId())
-              .set(CONNECTION_OPERATION.OPERATION_ID, operationIdFromStandardSync)
-              .set(CONNECTION_OPERATION.CREATED_AT, timestamp)
-              .set(CONNECTION_OPERATION.UPDATED_AT, timestamp)
-              .execute();
-        }
-      }
-    });
-  }
-
   private void writeStandardSyncState(final List<StandardSyncState> configs) throws IOException {
     database.transaction(ctx -> {
       writeStandardSyncState(configs, ctx);
@@ -1246,7 +1092,7 @@ public class DatabaseConfigPersistence implements ConfigPersistence {
     } else if (configType == ConfigSchema.STANDARD_SYNC_OPERATION) {
       writeStandardSyncOperation(configs.values().stream().map(c -> (StandardSyncOperation) c).collect(Collectors.toList()));
     } else if (configType == ConfigSchema.STANDARD_SYNC) {
-      writeStandardSync(configs.values().stream().map(c -> (StandardSync) c).collect(Collectors.toList()));
+      throw buildUseStandardSyncPersistenceException();
     } else if (configType == ConfigSchema.STANDARD_SYNC_STATE) {
       writeStandardSyncState(configs.values().stream().map(c -> (StandardSyncState) c).collect(Collectors.toList()));
     } else if (configType == ConfigSchema.ACTOR_CATALOG) {
@@ -1279,7 +1125,7 @@ public class DatabaseConfigPersistence implements ConfigPersistence {
     } else if (configType == ConfigSchema.STANDARD_SYNC_OPERATION) {
       deleteConfig(OPERATION, OPERATION.ID, UUID.fromString(configId));
     } else if (configType == ConfigSchema.STANDARD_SYNC) {
-      deleteStandardSync(configId);
+      throw buildUseStandardSyncPersistenceException();
     } else if (configType == ConfigSchema.STANDARD_SYNC_STATE) {
       deleteConfig(STATE, STATE.CONNECTION_ID, UUID.fromString(configId));
     } else if (configType == ConfigSchema.ACTOR_CATALOG) {
@@ -1296,32 +1142,7 @@ public class DatabaseConfigPersistence implements ConfigPersistence {
   private <T extends Record> void deleteConfig(final TableImpl<T> table, final TableField<T, UUID> keyColumn, final UUID configId)
       throws IOException {
     database.transaction(ctx -> {
-      deleteConfig(table, keyColumn, configId, ctx);
-      return null;
-    });
-  }
-
-  private <T extends Record> void deleteConfig(final TableImpl<T> table,
-                                               final TableField<T, UUID> keyColumn,
-                                               final UUID configId,
-                                               final DSLContext ctx) {
-    final boolean isExistingConfig = ctx.fetchExists(select()
-        .from(table)
-        .where(keyColumn.eq(configId)));
-
-    if (isExistingConfig) {
-      ctx.deleteFrom(table)
-          .where(keyColumn.eq(configId))
-          .execute();
-    }
-  }
-
-  private void deleteStandardSync(final String configId) throws IOException {
-    database.transaction(ctx -> {
-      final UUID connectionId = UUID.fromString(configId);
-      deleteConfig(CONNECTION_OPERATION, CONNECTION_OPERATION.CONNECTION_ID, connectionId, ctx);
-      deleteConfig(STATE, STATE.CONNECTION_ID, connectionId, ctx);
-      deleteConfig(CONNECTION, CONNECTION.ID, connectionId, ctx);
+      PersistenceHelpers.deleteConfig(table, keyColumn, configId, ctx);
       return null;
     });
   }

--- a/airbyte-config/config-persistence/src/main/java/io/airbyte/config/persistence/PersistenceHelpers.java
+++ b/airbyte-config/config-persistence/src/main/java/io/airbyte/config/persistence/PersistenceHelpers.java
@@ -4,8 +4,15 @@
 
 package io.airbyte.config.persistence;
 
+import static org.jooq.impl.DSL.select;
+
+import java.util.UUID;
 import org.jooq.Condition;
+import org.jooq.DSLContext;
 import org.jooq.Field;
+import org.jooq.Record;
+import org.jooq.TableField;
+import org.jooq.impl.TableImpl;
 
 public class PersistenceHelpers {
 
@@ -20,6 +27,29 @@ public class PersistenceHelpers {
    */
   public static Condition isNullOrEquals(final Field<String> field, final String value) {
     return value != null ? field.eq(value) : field.isNull();
+  }
+
+  /**
+   * Helper to delete records from the database
+   *
+   * @param table the table to delete from
+   * @param keyColumn the column to use as a key
+   * @param configId the id of the object to delete, must be from the keyColumn
+   * @param ctx the db context to use
+   */
+  public static <T extends Record> void deleteConfig(final TableImpl<T> table,
+                                                     final TableField<T, UUID> keyColumn,
+                                                     final UUID configId,
+                                                     final DSLContext ctx) {
+    final boolean isExistingConfig = ctx.fetchExists(select()
+        .from(table)
+        .where(keyColumn.eq(configId)));
+
+    if (isExistingConfig) {
+      ctx.deleteFrom(table)
+          .where(keyColumn.eq(configId))
+          .execute();
+    }
   }
 
 }

--- a/airbyte-config/config-persistence/src/main/java/io/airbyte/config/persistence/StandardSyncPersistence.java
+++ b/airbyte-config/config-persistence/src/main/java/io/airbyte/config/persistence/StandardSyncPersistence.java
@@ -1,0 +1,209 @@
+/*
+ * Copyright (c) 2022 Airbyte, Inc., all rights reserved.
+ */
+
+package io.airbyte.config.persistence;
+
+import static io.airbyte.db.instance.configs.jooq.generated.Tables.CONNECTION;
+import static io.airbyte.db.instance.configs.jooq.generated.Tables.CONNECTION_OPERATION;
+import static io.airbyte.db.instance.configs.jooq.generated.Tables.STATE;
+import static org.jooq.impl.DSL.asterisk;
+import static org.jooq.impl.DSL.select;
+
+import io.airbyte.commons.enums.Enums;
+import io.airbyte.commons.json.Jsons;
+import io.airbyte.config.ConfigSchema;
+import io.airbyte.config.ConfigWithMetadata;
+import io.airbyte.config.StandardSync;
+import io.airbyte.config.helpers.ScheduleHelpers;
+import io.airbyte.db.Database;
+import io.airbyte.db.ExceptionWrappingDatabase;
+import java.io.IOException;
+import java.time.OffsetDateTime;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Optional;
+import java.util.UUID;
+import org.jooq.DSLContext;
+import org.jooq.JSONB;
+import org.jooq.Record;
+import org.jooq.Result;
+import org.jooq.SelectJoinStep;
+
+public class StandardSyncPersistence {
+
+  private final ExceptionWrappingDatabase database;
+
+  public StandardSyncPersistence(final Database database) {
+    this.database = new ExceptionWrappingDatabase(database);
+  }
+
+  public StandardSync getStandardSync(final UUID connectionId) throws IOException, ConfigNotFoundException {
+    final List<ConfigWithMetadata<StandardSync>> result = listStandardSyncWithMetadata(Optional.of(connectionId));
+
+    final boolean foundMoreThanOneConfig = result.size() > 1;
+    if (result.isEmpty()) {
+      throw new ConfigNotFoundException(ConfigSchema.STANDARD_SYNC, connectionId.toString());
+    } else if (foundMoreThanOneConfig) {
+      throw new IllegalStateException(String.format("Multiple %s configs found for ID %s: %s", ConfigSchema.STANDARD_SYNC, connectionId, result));
+    }
+    return result.get(0).getConfig();
+  }
+
+  public List<StandardSync> listStandardSync() throws IOException {
+    return listStandardSyncWithMetadata(Optional.empty()).stream().map(ConfigWithMetadata::getConfig).toList();
+  }
+
+  public void writeStandardSync(final StandardSync standardSync) throws IOException {
+    database.transaction(ctx -> {
+      writeStandardSync(standardSync, ctx);
+      return null;
+    });
+  }
+
+  public void deleteStandardSync(final UUID standardSyncId) throws IOException {
+    database.transaction(ctx -> {
+      PersistenceHelpers.deleteConfig(CONNECTION_OPERATION, CONNECTION_OPERATION.CONNECTION_ID, standardSyncId, ctx);
+      PersistenceHelpers.deleteConfig(STATE, STATE.CONNECTION_ID, standardSyncId, ctx);
+      PersistenceHelpers.deleteConfig(CONNECTION, CONNECTION.ID, standardSyncId, ctx);
+      return null;
+    });
+  }
+
+  private List<ConfigWithMetadata<StandardSync>> listStandardSyncWithMetadata(final Optional<UUID> configId) throws IOException {
+    final Result<Record> result = database.query(ctx -> {
+      final SelectJoinStep<Record> query = ctx.select(asterisk()).from(CONNECTION);
+      if (configId.isPresent()) {
+        return query.where(CONNECTION.ID.eq(configId.get())).fetch();
+      }
+      return query.fetch();
+    });
+
+    final List<ConfigWithMetadata<StandardSync>> standardSyncs = new ArrayList<>();
+    for (final Record record : result) {
+      final StandardSync standardSync = DbConverter.buildStandardSync(record, connectionOperationIds(record.get(CONNECTION.ID)));
+      if (ScheduleHelpers.isScheduleTypeMismatch(standardSync)) {
+        throw new RuntimeException("unexpected schedule type mismatch");
+      }
+      standardSyncs.add(new ConfigWithMetadata<>(
+          record.get(CONNECTION.ID).toString(),
+          ConfigSchema.STANDARD_SYNC.name(),
+          record.get(CONNECTION.CREATED_AT).toInstant(),
+          record.get(CONNECTION.UPDATED_AT).toInstant(),
+          standardSync));
+    }
+    return standardSyncs;
+  }
+
+  private List<UUID> connectionOperationIds(final UUID connectionId) throws IOException {
+    final Result<Record> result = database.query(ctx -> ctx.select(asterisk())
+        .from(CONNECTION_OPERATION)
+        .where(CONNECTION_OPERATION.CONNECTION_ID.eq(connectionId))
+        .fetch());
+
+    final List<UUID> ids = new ArrayList<>();
+    for (final Record record : result) {
+      ids.add(record.get(CONNECTION_OPERATION.OPERATION_ID));
+    }
+
+    return ids;
+  }
+
+  private void writeStandardSync(final StandardSync standardSync, final DSLContext ctx) {
+    final OffsetDateTime timestamp = OffsetDateTime.now();
+    final boolean isExistingConfig = ctx.fetchExists(select()
+        .from(CONNECTION)
+        .where(CONNECTION.ID.eq(standardSync.getConnectionId())));
+
+    if (ScheduleHelpers.isScheduleTypeMismatch(standardSync)) {
+      throw new RuntimeException("unexpected schedule type mismatch");
+    }
+
+    if (isExistingConfig) {
+      ctx.update(CONNECTION)
+          .set(CONNECTION.ID, standardSync.getConnectionId())
+          .set(CONNECTION.NAMESPACE_DEFINITION, Enums.toEnum(standardSync.getNamespaceDefinition().value(),
+              io.airbyte.db.instance.configs.jooq.generated.enums.NamespaceDefinitionType.class).orElseThrow())
+          .set(CONNECTION.NAMESPACE_FORMAT, standardSync.getNamespaceFormat())
+          .set(CONNECTION.PREFIX, standardSync.getPrefix())
+          .set(CONNECTION.SOURCE_ID, standardSync.getSourceId())
+          .set(CONNECTION.DESTINATION_ID, standardSync.getDestinationId())
+          .set(CONNECTION.NAME, standardSync.getName())
+          .set(CONNECTION.CATALOG, JSONB.valueOf(Jsons.serialize(standardSync.getCatalog())))
+          .set(CONNECTION.STATUS, standardSync.getStatus() == null ? null
+              : Enums.toEnum(standardSync.getStatus().value(),
+                  io.airbyte.db.instance.configs.jooq.generated.enums.StatusType.class).orElseThrow())
+          .set(CONNECTION.SCHEDULE, JSONB.valueOf(Jsons.serialize(standardSync.getSchedule())))
+          .set(CONNECTION.MANUAL, standardSync.getManual())
+          .set(CONNECTION.SCHEDULE_TYPE,
+              standardSync.getScheduleType() == null ? null
+                  : Enums.toEnum(standardSync.getScheduleType().value(),
+                      io.airbyte.db.instance.configs.jooq.generated.enums.ScheduleType.class)
+                      .orElseThrow())
+          .set(CONNECTION.SCHEDULE_DATA, JSONB.valueOf(Jsons.serialize(standardSync.getScheduleData())))
+          .set(CONNECTION.RESOURCE_REQUIREMENTS,
+              JSONB.valueOf(Jsons.serialize(standardSync.getResourceRequirements())))
+          .set(CONNECTION.UPDATED_AT, timestamp)
+          .set(CONNECTION.SOURCE_CATALOG_ID, standardSync.getSourceCatalogId())
+          .set(CONNECTION.BREAKING_CHANGE, standardSync.getBreakingChange())
+          .set(CONNECTION.GEOGRAPHY, Enums.toEnum(standardSync.getGeography().value(),
+              io.airbyte.db.instance.configs.jooq.generated.enums.GeographyType.class).orElseThrow())
+          .where(CONNECTION.ID.eq(standardSync.getConnectionId()))
+          .execute();
+
+      ctx.deleteFrom(CONNECTION_OPERATION)
+          .where(CONNECTION_OPERATION.CONNECTION_ID.eq(standardSync.getConnectionId()))
+          .execute();
+      for (final UUID operationIdFromStandardSync : standardSync.getOperationIds()) {
+        ctx.insertInto(CONNECTION_OPERATION)
+            .set(CONNECTION_OPERATION.ID, UUID.randomUUID())
+            .set(CONNECTION_OPERATION.CONNECTION_ID, standardSync.getConnectionId())
+            .set(CONNECTION_OPERATION.OPERATION_ID, operationIdFromStandardSync)
+            .set(CONNECTION_OPERATION.CREATED_AT, timestamp)
+            .set(CONNECTION_OPERATION.UPDATED_AT, timestamp)
+            .execute();
+      }
+    } else {
+      ctx.insertInto(CONNECTION)
+          .set(CONNECTION.ID, standardSync.getConnectionId())
+          .set(CONNECTION.NAMESPACE_DEFINITION, Enums.toEnum(standardSync.getNamespaceDefinition().value(),
+              io.airbyte.db.instance.configs.jooq.generated.enums.NamespaceDefinitionType.class).orElseThrow())
+          .set(CONNECTION.NAMESPACE_FORMAT, standardSync.getNamespaceFormat())
+          .set(CONNECTION.PREFIX, standardSync.getPrefix())
+          .set(CONNECTION.SOURCE_ID, standardSync.getSourceId())
+          .set(CONNECTION.DESTINATION_ID, standardSync.getDestinationId())
+          .set(CONNECTION.NAME, standardSync.getName())
+          .set(CONNECTION.CATALOG, JSONB.valueOf(Jsons.serialize(standardSync.getCatalog())))
+          .set(CONNECTION.STATUS, standardSync.getStatus() == null ? null
+              : Enums.toEnum(standardSync.getStatus().value(),
+                  io.airbyte.db.instance.configs.jooq.generated.enums.StatusType.class).orElseThrow())
+          .set(CONNECTION.SCHEDULE, JSONB.valueOf(Jsons.serialize(standardSync.getSchedule())))
+          .set(CONNECTION.MANUAL, standardSync.getManual())
+          .set(CONNECTION.SCHEDULE_TYPE,
+              standardSync.getScheduleType() == null ? null
+                  : Enums.toEnum(standardSync.getScheduleType().value(),
+                      io.airbyte.db.instance.configs.jooq.generated.enums.ScheduleType.class)
+                      .orElseThrow())
+          .set(CONNECTION.SCHEDULE_DATA, JSONB.valueOf(Jsons.serialize(standardSync.getScheduleData())))
+          .set(CONNECTION.RESOURCE_REQUIREMENTS,
+              JSONB.valueOf(Jsons.serialize(standardSync.getResourceRequirements())))
+          .set(CONNECTION.SOURCE_CATALOG_ID, standardSync.getSourceCatalogId())
+          .set(CONNECTION.GEOGRAPHY, Enums.toEnum(standardSync.getGeography().value(),
+              io.airbyte.db.instance.configs.jooq.generated.enums.GeographyType.class).orElseThrow())
+          .set(CONNECTION.BREAKING_CHANGE, standardSync.getBreakingChange())
+          .set(CONNECTION.CREATED_AT, timestamp)
+          .set(CONNECTION.UPDATED_AT, timestamp)
+          .execute();
+      for (final UUID operationIdFromStandardSync : standardSync.getOperationIds()) {
+        ctx.insertInto(CONNECTION_OPERATION)
+            .set(CONNECTION_OPERATION.ID, UUID.randomUUID())
+            .set(CONNECTION_OPERATION.CONNECTION_ID, standardSync.getConnectionId())
+            .set(CONNECTION_OPERATION.OPERATION_ID, operationIdFromStandardSync)
+            .set(CONNECTION_OPERATION.CREATED_AT, timestamp)
+            .set(CONNECTION_OPERATION.UPDATED_AT, timestamp)
+            .execute();
+      }
+    }
+  }
+
+}

--- a/airbyte-config/config-persistence/src/test/java/io/airbyte/config/persistence/BaseDatabaseConfigPersistenceTest.java
+++ b/airbyte-config/config-persistence/src/test/java/io/airbyte/config/persistence/BaseDatabaseConfigPersistenceTest.java
@@ -49,6 +49,7 @@ class BaseDatabaseConfigPersistenceTest {
   static PostgreSQLContainer<?> container;
   static Database database;
   static DatabaseConfigPersistence configPersistence;
+  static StandardSyncPersistence standardSyncPersistence;
   static JsonSecretsProcessor jsonSecretsProcessor;
   static DataSource dataSource;
   static DSLContext dslContext;

--- a/airbyte-config/config-persistence/src/test/java/io/airbyte/config/persistence/ConfigRepositoryE2EReadWriteTest.java
+++ b/airbyte-config/config-persistence/src/test/java/io/airbyte/config/persistence/ConfigRepositoryE2EReadWriteTest.java
@@ -98,7 +98,8 @@ class ConfigRepositoryE2EReadWriteTest {
         ConfigsDatabaseMigrator.MIGRATION_FILE_LOCATION);
     database = new ConfigsDatabaseTestProvider(dslContext, flyway).create(false);
     configPersistence = spy(new DatabaseConfigPersistence(database));
-    configRepository = spy(new ConfigRepository(configPersistence, database, new ActorDefinitionMigrator(new ExceptionWrappingDatabase(database))));
+    configRepository = spy(new ConfigRepository(configPersistence, database, new ActorDefinitionMigrator(new ExceptionWrappingDatabase(database)),
+        new StandardSyncPersistence(database)));
     final ConfigsDatabaseMigrator configsDatabaseMigrator =
         new ConfigsDatabaseMigrator(database, flyway);
     final DevDatabaseMigrator devDatabaseMigrator = new DevDatabaseMigrator(configsDatabaseMigrator);

--- a/airbyte-config/config-persistence/src/test/java/io/airbyte/config/persistence/ConfigRepositoryTest.java
+++ b/airbyte-config/config-persistence/src/test/java/io/airbyte/config/persistence/ConfigRepositoryTest.java
@@ -56,14 +56,17 @@ class ConfigRepositoryTest {
   private static final UUID DESTINATION_DEFINITION_ID = UUID.randomUUID();
 
   private ConfigPersistence configPersistence;
+  private StandardSyncPersistence standardSyncPersistence;
   private ConfigRepository configRepository;
   private Database database;
 
   @BeforeEach
   void setup() {
     configPersistence = mock(ConfigPersistence.class);
+    standardSyncPersistence = mock(StandardSyncPersistence.class);
     database = mock(Database.class);
-    configRepository = spy(new ConfigRepository(configPersistence, database, new ActorDefinitionMigrator(new ExceptionWrappingDatabase(database))));
+    configRepository = spy(new ConfigRepository(configPersistence, database, new ActorDefinitionMigrator(new ExceptionWrappingDatabase(database)),
+        standardSyncPersistence));
   }
 
   @AfterEach
@@ -287,7 +290,7 @@ class ConfigRepositoryTest {
     final StandardSync syncToStay = new StandardSync().withConnectionId(UUID.randomUUID()).withSourceId(sourceConnectionToStay.getSourceId())
         .withDestinationId(UUID.randomUUID());
 
-    when(configPersistence.listConfigs(ConfigSchema.STANDARD_SYNC, StandardSync.class)).thenReturn(List.of(syncToDelete, syncToStay));
+    when(standardSyncPersistence.listStandardSync()).thenReturn(List.of(syncToDelete, syncToStay));
 
     configRepository.deleteSourceDefinitionAndAssociations(sourceDefToDelete.getSourceDefinitionId());
 
@@ -421,7 +424,7 @@ class ConfigRepositoryTest {
     final StandardSync syncToStay = new StandardSync().withConnectionId(UUID.randomUUID()).withDestinationId(destConnectionToStay.getDestinationId())
         .withSourceId(UUID.randomUUID());
 
-    when(configPersistence.listConfigs(ConfigSchema.STANDARD_SYNC, StandardSync.class)).thenReturn(List.of(syncToDelete, syncToStay));
+    when(standardSyncPersistence.listStandardSync()).thenReturn(List.of(syncToDelete, syncToStay));
 
     configRepository.deleteDestinationDefinitionAndAssociations(destDefToDelete.getDestinationDefinitionId());
 
@@ -445,7 +448,7 @@ class ConfigRepositoryTest {
     final UUID connectionId = UUID.randomUUID();
     configRepository.deleteStandardSyncDefinition(connectionId);
 
-    verify(configPersistence).deleteConfig(ConfigSchema.STANDARD_SYNC, connectionId.toString());
+    verify(standardSyncPersistence).deleteStandardSync(connectionId);
   }
 
   @Test

--- a/airbyte-config/config-persistence/src/test/java/io/airbyte/config/persistence/DatabaseConfigPersistenceE2EReadWriteTest.java
+++ b/airbyte-config/config-persistence/src/test/java/io/airbyte/config/persistence/DatabaseConfigPersistenceE2EReadWriteTest.java
@@ -7,6 +7,7 @@ package io.airbyte.config.persistence;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.Mockito.spy;
 
@@ -35,6 +36,8 @@ import io.airbyte.test.utils.DatabaseConnectionHelper;
 import io.airbyte.validation.json.JsonValidationException;
 import java.io.IOException;
 import java.util.List;
+import java.util.Map;
+import org.apache.commons.lang3.NotImplementedException;
 import org.jooq.SQLDialect;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
@@ -51,6 +54,7 @@ class DatabaseConfigPersistenceE2EReadWriteTest extends BaseDatabaseConfigPersis
         ConfigsDatabaseMigrator.MIGRATION_FILE_LOCATION);
     database = new ConfigsDatabaseTestProvider(dslContext, flyway).create(false);
     configPersistence = spy(new DatabaseConfigPersistence(database));
+    standardSyncPersistence = new StandardSyncPersistence(database);
     final ConfigsDatabaseMigrator configsDatabaseMigrator =
         new ConfigsDatabaseMigrator(database, flyway);
     final DevDatabaseMigrator devDatabaseMigrator = new DevDatabaseMigrator(configsDatabaseMigrator);
@@ -79,6 +83,22 @@ class DatabaseConfigPersistenceE2EReadWriteTest extends BaseDatabaseConfigPersis
     standardActorCatalog();
     workspaceServiceAccounts();
     deletion();
+
+    checkSafeguards();
+  }
+
+  private void checkSafeguards() {
+    final String anyString = "";
+
+    // Making sure that the objects that have been migrated out of config persistence are protected with
+    // an explicit error.
+    assertThrows(NotImplementedException.class, () -> configPersistence.getConfig(ConfigSchema.STANDARD_SYNC, anyString, StandardSync.class));
+    assertThrows(NotImplementedException.class, () -> configPersistence.listConfigs(ConfigSchema.STANDARD_SYNC, StandardSync.class));
+    assertThrows(NotImplementedException.class,
+        () -> configPersistence.writeConfig(ConfigSchema.STANDARD_SYNC, anyString, MockData.standardSyncs().get(0)));
+    assertThrows(NotImplementedException.class,
+        () -> configPersistence.writeConfigs(ConfigSchema.STANDARD_SYNC, Map.of(anyString, MockData.standardSyncs().get(0))));
+    assertThrows(NotImplementedException.class, () -> configPersistence.deleteConfig(ConfigSchema.STANDARD_SYNC, anyString));
   }
 
   private void deletion() throws ConfigNotFoundException, IOException, JsonValidationException {
@@ -87,7 +107,7 @@ class DatabaseConfigPersistenceE2EReadWriteTest extends BaseDatabaseConfigPersis
       configPersistence.deleteConfig(ConfigSchema.STANDARD_WORKSPACE, standardWorkspace.getWorkspaceId().toString());
     }
     assertTrue(configPersistence.listConfigs(ConfigSchema.STANDARD_SYNC_STATE, StandardSyncState.class).isEmpty());
-    assertTrue(configPersistence.listConfigs(ConfigSchema.STANDARD_SYNC, StandardSync.class).isEmpty());
+    assertTrue(standardSyncPersistence.listStandardSync().isEmpty());
     assertTrue(configPersistence.listConfigs(ConfigSchema.STANDARD_SYNC_OPERATION, StandardSyncOperation.class).isEmpty());
     assertTrue(configPersistence.listConfigs(ConfigSchema.DESTINATION_CONNECTION, SourceConnection.class).isEmpty());
     assertTrue(configPersistence.listConfigs(ConfigSchema.STANDARD_WORKSPACE, StandardWorkspace.class).isEmpty());
@@ -146,16 +166,11 @@ class DatabaseConfigPersistenceE2EReadWriteTest extends BaseDatabaseConfigPersis
 
   private void standardSync() throws JsonValidationException, IOException, ConfigNotFoundException {
     for (final StandardSync standardSync : MockData.standardSyncs()) {
-      configPersistence.writeConfig(ConfigSchema.STANDARD_SYNC,
-          standardSync.getConnectionId().toString(),
-          standardSync);
-      final StandardSync standardSyncFromDB = configPersistence.getConfig(ConfigSchema.STANDARD_SYNC,
-          standardSync.getConnectionId().toString(),
-          StandardSync.class);
+      standardSyncPersistence.writeStandardSync(standardSync);
+      final StandardSync standardSyncFromDB = standardSyncPersistence.getStandardSync(standardSync.getConnectionId());
       assertEquals(standardSync, standardSyncFromDB);
     }
-    final List<StandardSync> standardSyncs = configPersistence
-        .listConfigs(ConfigSchema.STANDARD_SYNC, StandardSync.class);
+    final List<StandardSync> standardSyncs = standardSyncPersistence.listStandardSync();
     assertEquals(MockData.standardSyncs().size(), standardSyncs.size());
     assertThat(MockData.standardSyncs()).hasSameElementsAs(standardSyncs);
   }

--- a/airbyte-config/config-persistence/src/test/java/io/airbyte/config/persistence/StatePersistenceTest.java
+++ b/airbyte-config/config-persistence/src/test/java/io/airbyte/config/persistence/StatePersistenceTest.java
@@ -548,7 +548,8 @@ class StatePersistenceTest extends BaseDatabaseConfigPersistenceTest {
     configRepository = new ConfigRepository(
         new DatabaseConfigPersistence(database),
         database,
-        new ActorDefinitionMigrator(new ExceptionWrappingDatabase(database)));
+        new ActorDefinitionMigrator(new ExceptionWrappingDatabase(database)),
+        new StandardSyncPersistence(database));
 
     final StandardWorkspace workspace = MockData.standardWorkspaces().get(0);
     final StandardSourceDefinition sourceDefinition = MockData.publicSourceDefinition();


### PR DESCRIPTION
## What
`ConfigRepository` is getting too big, breaking it out into more specific classes would help separation of concerns and more specific dependency injection.
`ConfigPersistence` and its implementation are convoluted with some form of fan in/out dispatch on its operation. We want to move away from those objects.

## How
Extract `StandardSync` related operations into a `StandardSyncPersistence` as a first step.
It is still used under the hood by `ConfigRepository`, to minimize the span of this change.

Medium term next step would be to have clients use the `StandardSyncPersistence` directly, but this step should become more straightforward once the APIs are broken up and we are using micronaut in the `airbyte-server`.

## Recommended reading order
`StandardSyncPersistence` contains the code that has been extracted from `DatabaseConfigPersistence`. Logic change should be minimal, mostly moving code around.
