### PR TITLE
🪟 🐛 Fix validation when setting the connection stream cursor or primary key

### DIFF
--- a/airbyte-webapp/src/components/connection/CatalogTree/CatalogTree.tsx
+++ b/airbyte-webapp/src/components/connection/CatalogTree/CatalogTree.tsx
@@ -28,7 +28,7 @@ const CatalogTreeComponent: React.FC<React.PropsWithChildren<CatalogTreeProps>> 
   isLoading,
 }) => {
   const isNewStreamsTableEnabled = process.env.REACT_APP_NEW_STREAMS_TABLE ?? false;
-  const { mode } = useConnectionFormService();
+  const { initialValues, mode } = useConnectionFormService();
 
   const [searchString, setSearchString] = useState("");
 
@@ -38,7 +38,7 @@ const CatalogTreeComponent: React.FC<React.PropsWithChildren<CatalogTreeProps>> 
   );
 
   const sortedSchema = useMemo(
-    () => streams.sort(naturalComparatorBy((syncStream) => syncStream.stream?.name ?? "")),
+    () => [...streams].sort(naturalComparatorBy((syncStream) => syncStream.stream?.name ?? "")),
     [streams]
   );
 
@@ -52,6 +52,14 @@ const CatalogTreeComponent: React.FC<React.PropsWithChildren<CatalogTreeProps>> 
 
     return sortedSchema.filter((stream) => filters.every((f) => f(stream)));
   }, [searchString, sortedSchema]);
+
+  const changedStreams = useMemo(
+    () =>
+      streams.filter((stream, idx) => {
+        return stream.config?.selected !== initialValues.syncCatalog.streams[idx].config?.selected;
+      }),
+    [initialValues.syncCatalog.streams, streams]
+  );
 
   return (
     <BulkEditServiceProvider nodes={streams} update={onStreamsChanged}>
@@ -69,7 +77,11 @@ const CatalogTreeComponent: React.FC<React.PropsWithChildren<CatalogTreeProps>> 
             <BulkHeader />
           </>
         )}
-        <CatalogTreeBody streams={filteredStreams} onStreamChanged={onSingleStreamChanged} />
+        <CatalogTreeBody
+          streams={filteredStreams}
+          changedStreams={changedStreams}
+          onStreamChanged={onSingleStreamChanged}
+        />
       </LoadingBackdrop>
       {isNewStreamsTableEnabled && <BulkEditPanel />}
     </BulkEditServiceProvider>

--- a/airbyte-webapp/src/components/connection/CatalogTree/CatalogTreeBody.tsx
+++ b/airbyte-webapp/src/components/connection/CatalogTree/CatalogTreeBody.tsx
@@ -1,20 +1,21 @@
-import { Field, FieldProps, setIn, useFormikContext } from "formik";
+import { Field, FieldProps, setIn } from "formik";
 import React, { useCallback } from "react";
 
 import { SyncSchemaStream } from "core/domain/catalog";
 import { AirbyteStreamConfiguration } from "core/request/AirbyteClient";
 import { useConnectionFormService } from "hooks/services/ConnectionForm/ConnectionFormService";
-import { ConnectionFormValues, FormikConnectionFormValues } from "views/Connection/ConnectionForm/formConfig";
+import { FormikConnectionFormValues } from "views/Connection/ConnectionForm/formConfig";
 
 import { CatalogSection } from "./CatalogSection";
 import styles from "./CatalogTreeBody.module.scss";
 
 interface CatalogTreeBodyProps {
   streams: SyncSchemaStream[];
+  changedStreams: SyncSchemaStream[];
   onStreamChanged: (stream: SyncSchemaStream) => void;
 }
 
-export const CatalogTreeBody: React.FC<CatalogTreeBodyProps> = ({ streams, onStreamChanged }) => {
+export const CatalogTreeBody: React.FC<CatalogTreeBodyProps> = ({ streams, changedStreams, onStreamChanged }) => {
   const { mode } = useConnectionFormService();
 
   const onUpdateStream = useCallback(
@@ -29,12 +30,6 @@ export const CatalogTreeBody: React.FC<CatalogTreeBodyProps> = ({ streams, onStr
     },
     [streams, onStreamChanged]
   );
-
-  const { initialValues } = useFormikContext<ConnectionFormValues>();
-
-  const changedStreams = streams.filter((stream, idx) => {
-    return stream.config?.selected !== initialValues.syncCatalog.streams[idx].config?.selected;
-  });
 
   return (
     <div className={styles.container}>

--- a/airbyte-webapp/src/pages/ConnectionPage/pages/ConnectionItemPage/ConnectionReplicationTab.tsx
+++ b/airbyte-webapp/src/pages/ConnectionPage/pages/ConnectionItemPage/ConnectionReplicationTab.tsx
@@ -18,7 +18,7 @@ import { FeatureItem, useFeature } from "hooks/services/Feature";
 import { useModalService } from "hooks/services/Modal";
 import { useConnectionService, ValuesProps } from "hooks/services/useConnectionHook";
 import { useCurrentWorkspaceId } from "services/workspaces/WorkspacesService";
-import { equal, naturalComparatorBy } from "utils/objects";
+import { equal } from "utils/objects";
 import { useConfirmCatalogDiff } from "views/Connection/CatalogDiffModal/useConfirmCatalogDiff";
 import EditControls from "views/Connection/ConnectionForm/components/EditControls";
 import { ConnectionFormFields } from "views/Connection/ConnectionForm/ConnectionFormFields";
@@ -90,12 +90,8 @@ export const ConnectionReplicationTab: React.FC = () => {
       // This could be due to user changes (e.g. in the sync mode) or due to new/removed
       // streams due to a "refreshed source schema".
       const catalogHasChanged = !equal(
-        formValues.syncCatalog.streams
-          .filter((s) => s.config?.selected)
-          .sort(naturalComparatorBy((syncStream) => syncStream.stream?.name ?? "")),
-        connection.syncCatalog.streams
-          .filter((s) => s.config?.selected)
-          .sort(naturalComparatorBy((syncStream) => syncStream.stream?.name ?? ""))
+        formValues.syncCatalog.streams.filter((s) => s.config?.selected),
+        connection.syncCatalog.streams.filter((s) => s.config?.selected)
       );
 
       setSubmitError(null);


### PR DESCRIPTION
## What
Related to https://github.com/airbytehq/oncall/issues/948

This fixes an issue related to validation not running when the connection stream primary key or cursor field is not set.

## How
The validation was happening in the wrong order because the form initial values streams were being sorted when the CatalogTree component rendered. Instead, now it makes a copy of the array before sorting since sorting is one of those weird [functions that is done in place](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Array/sort).
