### PR TITLE
ci: return 7 symbols short git hash on branch build

### DIFF
--- a/.github/actions/build-branch/action.yml
+++ b/.github/actions/build-branch/action.yml
@@ -18,13 +18,7 @@ runs:
         # if the *branch_version_tag* input param is not specified, then generate it as 'dev-<commit_hash>`
         #
         [[ "${{ inputs.branch_version_tag }}" != '' ]] && echo "branch_version_tag=${{ inputs.branch_version_tag }}" >> $GITHUB_OUTPUT \
-          || { short_hash=$(git rev-parse --short HEAD); echo "branch_version_tag=dev-$short_hash" >> $GITHUB_OUTPUT ; }
-        cat $GITHUB_OUTPUT || true  # for the sake of investigation
-
-        # if the *branch_version_tag* input param is not specified, then generate it as 'dev-<commit_hash>`
-        #
-        [[ "${{ inputs.branch_version_tag }}" != '' ]] && echo "::set-output name=branch_version_tag::${{ inputs.branch_version_tag }}" \
-          || { short_hash=$(git rev-parse --short HEAD); echo "::set-output name=branch_version_tag::dev-$short_hash"; }
+          || { short_hash=$(git rev-parse --short=7 HEAD); echo "branch_version_tag=dev-$short_hash" >> $GITHUB_OUTPUT ; }
 
     - uses: actions/setup-java@v1
       with:

--- a/.github/workflows/publish-oss-for-cloud.yml
+++ b/.github/workflows/publish-oss-for-cloud.yml
@@ -62,7 +62,7 @@ jobs:
         run: |-
           set -x
 
-          commit_sha=$(git rev-parse --short HEAD)
+          commit_sha=$(git rev-parse --short=7 HEAD)
 
           # set dev_tag
           # AirbyteVersion.java allows versions that have a prefix of 'dev'
@@ -73,14 +73,6 @@ jobs:
             echo "master_tag=${commit_sha}" >> $GITHUB_OUTPUT
           fi
           cat $GITHUB_OUTPUT || true # for the sake of investigation
-
-          # set dev_tag
-          # AirbyteVersion.java allows versions that have a prefix of 'dev'
-          echo "::set-output name=dev_tag::dev-${commit_sha}"
-
-          if $(git merge-base --is-ancestor "${commit_sha}" master); then
-            echo "::set-output name=master_tag::${commit_sha}"
-          fi
 
   oss-branch-build:
     name: "Gradle Build and Publish"


### PR DESCRIPTION
## What
For some reason `git rev-parse --short HEAD` started to return 8 symbols hash. It breaks updating OSS revision on cloud.

## How
Return 7 symbols with `git rev-parse --short=7 HEAD`