### PR TITLE
add project automation

### DIFF
--- a/.github/workflows/platform-workflow-labels.yml
+++ b/.github/workflows/platform-workflow-labels.yml
@@ -11,19 +11,31 @@ jobs:
     permissions:
       issues: write
     steps:
-      - name: Label Platform Workflow Issue
+      - name: Label Issue
         uses: andymckay/labeler@1.0.4
         with:
           add-labels: "platform-workflow/requires-grooming"
           repo-token: ${{ secrets.GITHUB_TOKEN }}
+      - name: Add Issue To Project
+        uses: action/add-to-project@v0.3.0
+        with:
+          project-url: https://github.com/orgs/airbytehq/projects/25
+          github-token: ${{ secrets.PLATFORM_WORKFLOW_PROJECT_AUTOMATION }}
   unlabel_issues:
     if: ${{ github.event.action == 'unlabeled' && github.event.label.name == 'team/platform-workflow' }}
     runs-on: ubuntu-latest
     permissions:
       issues: write
     steps:
-      - name: Unlabel Platform Workflow Issue
+      - name: Unlabel Issue
         uses: andymckay/labeler@1.0.4
         with:
           remove-labels: "platform-workflow/requires-grooming"
           repo-token: ${{ secrets.GITHUB_TOKEN }}
+      - name: Remove Issue From Project
+        uses: monry/actions-delete-issue-from-project@v2.0.1
+        with:
+          github-token: ${{ secrets.PLATFORM_WORKFLOW_PROJECT_AUTOMATION }}
+          project-owner: airbytehq
+          project-number: 25
+          issue-id: ${{ github.event.issue.node_id }}


### PR DESCRIPTION
## What
- add action that adds any issues with the label `team/platform-workflow` added to it to the platform workflow project
- add action that removes any issues with the label `team/platform-workflow` removes to it from the platform workflow project

## How
- created a `PLATFORM_WORKFLOW_PROJECT_AUTOMATION` personal-access-token with `repo` and `project` scopes
- add `action/add-to-project@v0.3.0` to execute when an issue is labeled `team/platform-workflow`
- add `monry/actions-delete-issue-from-project@v2.0.1` to execute when an issue is un-labeled `team/platform-workflow`


