### PR TITLE
fix paths specification for oss catalog deploy action

### DIFF
--- a/.github/workflows/deploy-oss-catalog.yml
+++ b/.github/workflows/deploy-oss-catalog.yml
@@ -5,7 +5,7 @@ on:
     branches:
       - master
     paths: 
-      - airbyte-config/init/src/main/resources/seed
+      - airbyte-config/init/src/main/resources/seed/**
 
   workflow_dispatch:
 


### PR DESCRIPTION
## What

The action was not auto-triggering for changes to the seed definitions. 

## How

Fix it by following[ docs](https://docs.github.com/en/actions/using-workflows/workflow-syntax-for-github-actions#example-including-and-excluding-paths) (add `**`)
