### PR TITLE
Ensure that only 6-character hex values are passed to monaco editor

### DIFF
--- a/airbyte-webapp/src/components/ui/CodeEditor/CodeEditor.tsx
+++ b/airbyte-webapp/src/components/ui/CodeEditor/CodeEditor.tsx
@@ -16,10 +16,9 @@ interface CodeEditorProps {
 // Converts 3-character hex values into 6-character ones.
 // Required for custom monaco theme, because it fails when receiving 3-character hex values.
 function expandHexValue(input: string) {
-  // matches strings of the form #aaa
-  const match = /^#([0-9a-f])\1{2}$/.exec(input);
+  const match = /^#([0-9a-fA-F])([0-9a-fA-F])([0-9a-fA-F])$/.exec(input);
   if (match) {
-    return input + match[1].repeat(3);
+    return `#${match[1].repeat(2)}${match[2].repeat(2)}${match[3].repeat(2)}`;
   }
   return input;
 }

--- a/airbyte-webapp/src/components/ui/CodeEditor/CodeEditor.tsx
+++ b/airbyte-webapp/src/components/ui/CodeEditor/CodeEditor.tsx
@@ -13,6 +13,17 @@ interface CodeEditorProps {
   lineNumberCharacterWidth?: number;
 }
 
+// Converts 3-character hex values into 6-character ones.
+// Required for custom monaco theme, because it fails when receiving 3-character hex values.
+function expandHexValue(input: string) {
+  // matches strings of the form #aaa
+  const match = /^#([0-9a-f])\1{2}$/.exec(input);
+  if (match) {
+    return input + match[1].repeat(3);
+  }
+  return input;
+}
+
 export const CodeEditor: React.FC<CodeEditorProps> = ({
   value,
   language,
@@ -27,11 +38,11 @@ export const CodeEditor: React.FC<CodeEditorProps> = ({
       base: "vs-dark",
       inherit: true,
       rules: [
-        { token: "string", foreground: styles.tokenString },
-        { token: "type", foreground: styles.tokenType },
-        { token: "number", foreground: styles.tokenNumber },
-        { token: "delimiter", foreground: styles.tokenDelimiter },
-        { token: "keyword", foreground: styles.tokenKeyword },
+        { token: "string", foreground: expandHexValue(styles.tokenString) },
+        { token: "type", foreground: expandHexValue(styles.tokenType) },
+        { token: "number", foreground: expandHexValue(styles.tokenNumber) },
+        { token: "delimiter", foreground: expandHexValue(styles.tokenDelimiter) },
+        { token: "keyword", foreground: expandHexValue(styles.tokenKeyword) },
       ],
       colors: {
         "editor.background": "#00000000", // transparent, so that parent background is shown instead


### PR DESCRIPTION
## What
Without this change, trying to access `localhost:8000/connector-builder` would case this error to be thrown:
<img width="519" alt="Screen Shot 2022-11-03 at 2 58 37 PM" src="https://user-images.githubusercontent.com/22731524/199842629-4f66052e-d2d8-4c85-a75b-3ce0e267bc44.png">

This is thrown even though the original definition of that hex value uses 6 characters: https://github.com/airbytehq/airbyte/blob/0109f5de8562acde3499f10e3259d9dde1b33851/airbyte-webapp/src/scss/_colors.scss#L82
So there is likely some minifying going on that converts that 6-character value into a 3-character one.

## How
This PR solves the problem by adding a JS function to convert 3-character hex values to 6-character ones, and using this function on the strings being passed into the custom monaco theme definition.

