### PR TITLE
pod affinity experiment

### DIFF
--- a/airbyte-commons-worker/src/main/java/io/airbyte/workers/process/KubeProcessFactory.java
+++ b/airbyte-commons-worker/src/main/java/io/airbyte/workers/process/KubeProcessFactory.java
@@ -97,6 +97,7 @@ public class KubeProcessFactory implements ProcessFactory {
     try {
       // used to differentiate source and destination processes with the same id and attempt
       final String podName = ProcessFactory.createProcessName(imageName, jobType, jobId, attempt, KUBE_NAME_LEN_LIMIT);
+      final String jobIdentifier = String.format("%s-%s-%s", jobType, jobId, attempt);
       LOGGER.info("Attempting to start pod = {} for {} with resources {}", podName, imageName, resourceRequirements);
 
       final int stdoutLocalPort = KubePortManagerSingleton.getInstance().take();
@@ -106,6 +107,7 @@ public class KubeProcessFactory implements ProcessFactory {
       LOGGER.info("{} stderrLocalPort = {}", podName, stderrLocalPort);
 
       final var allLabels = getLabels(jobId, attempt, customLabels);
+      allLabels.put("job_identifier", jobIdentifier);
 
       return new KubePodProcess(
           isOrchestrator,


### PR DESCRIPTION
## What
* PR to experiment with whether adding a pod affinity so that all the pods in a sync prefer to run on the same K8s node.
* If this ends up having an impact then we should also look at what turning source / destination into sidecars of the orchestrator. It's slightly more java code to change, but not too much more invasive.