### PR TITLE
Progress Bar API Changes.

### DIFF
--- a/airbyte-api/src/main/openapi/config.yaml
+++ b/airbyte-api/src/main/openapi/config.yaml
@@ -2271,7 +2271,7 @@ paths:
       tags:
         - attempt
         - internal
-      summary: For worker to set running attempt stats.
+      summary: For worker to set sync stats of a running attempt.
       operationId: saveStats
       requestBody:
         content:

--- a/airbyte-api/src/main/openapi/config.yaml
+++ b/airbyte-api/src/main/openapi/config.yaml
@@ -2266,6 +2266,26 @@ paths:
             application/json:
               schema:
                 $ref: "#/components/schemas/InternalOperationResult"
+  /v1/attempt/save_stats:
+    post:
+      tags:
+        - attempt
+        - internal
+      summary: For worker to set running attempt stats.
+      operationId: saveStats
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: "#/components/schemas/SaveStatsRequestBody"
+        required: true
+      responses:
+        "200":
+          description: Successful Operation
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/InternalOperationResult"
 
 components:
   securitySchemes:
@@ -4049,6 +4069,12 @@ components:
         recordsCommitted:
           type: integer
           format: int64
+        estimatedRecords:
+          type: integer
+          format: int64
+        estimatedBytes:
+          type: integer
+          format: int64
     AttemptStreamStats:
       type: object
       required:
@@ -4892,6 +4918,23 @@ components:
         processingTaskQueue:
           type: string
           default: ""
+    SaveStatsRequestBody:
+      type: object
+      required:
+        - jobId
+        - attemptNumber
+        - stats
+      properties:
+        jobId:
+          $ref: "#/components/schemas/JobId"
+        attemptNumber:
+          $ref: "#/components/schemas/AttemptNumber"
+        stats:
+          $ref: "#/components/schemas/AttemptStats"
+        streamStats:
+          type: array
+          items:
+            $ref: "#/components/schemas/AttemptStreamStats"
     InternalOperationResult:
       type: object
       required:

--- a/airbyte-server/src/main/java/io/airbyte/server/apis/AttemptApiController.java
+++ b/airbyte-server/src/main/java/io/airbyte/server/apis/AttemptApiController.java
@@ -6,17 +6,23 @@ package io.airbyte.server.apis;
 
 import io.airbyte.api.generated.AttemptApi;
 import io.airbyte.api.model.generated.InternalOperationResult;
+import io.airbyte.api.model.generated.SaveStatsRequestBody;
 import io.airbyte.api.model.generated.SetWorkflowInAttemptRequestBody;
 import io.airbyte.server.handlers.AttemptHandler;
 import javax.ws.rs.Path;
 
-@Path("/v1/attempt/set_workflow_in_attempt")
+@Path("/v1/attempt/")
 public class AttemptApiController implements AttemptApi {
 
   private final AttemptHandler attemptHandler;
 
   public AttemptApiController(final AttemptHandler attemptHandler) {
     this.attemptHandler = attemptHandler;
+  }
+
+  @Override
+  public InternalOperationResult saveStats(final SaveStatsRequestBody saveStatsRequestBody) {
+    throw new UnsupportedOperationException();
   }
 
   @Override

--- a/airbyte-server/src/main/java/io/airbyte/server/apis/ConfigurationApi.java
+++ b/airbyte-server/src/main/java/io/airbyte/server/apis/ConfigurationApi.java
@@ -64,6 +64,7 @@ import io.airbyte.api.model.generated.PrivateDestinationDefinitionRead;
 import io.airbyte.api.model.generated.PrivateDestinationDefinitionReadList;
 import io.airbyte.api.model.generated.PrivateSourceDefinitionRead;
 import io.airbyte.api.model.generated.PrivateSourceDefinitionReadList;
+import io.airbyte.api.model.generated.SaveStatsRequestBody;
 import io.airbyte.api.model.generated.SetInstancewideDestinationOauthParamsRequestBody;
 import io.airbyte.api.model.generated.SetInstancewideSourceOauthParamsRequestBody;
 import io.airbyte.api.model.generated.SetWorkflowInAttemptRequestBody;
@@ -360,6 +361,11 @@ public class ConfigurationApi implements io.airbyte.api.generated.V1Api {
       sourceDefinitionsHandler.revokeSourceDefinitionFromWorkspace(sourceDefinitionIdWithWorkspaceId);
       return null;
     });
+  }
+
+  @Override
+  public InternalOperationResult saveStats(SaveStatsRequestBody saveStatsRequestBody) {
+    throw new UnsupportedOperationException();
   }
 
   // SOURCE SPECIFICATION

--- a/docs/reference/api/generated-api-html/index.html
+++ b/docs/reference/api/generated-api-html/index.html
@@ -221,6 +221,7 @@ font-style: italic;
   <div class="method-summary"></div>
   <h4><a href="#Attempt">Attempt</a></h4>
   <ul>
+  <li><a href="#saveStats"><code><span class="http-method">post</span> /v1/attempt/save_stats</code></a></li>
   <li><a href="#setWorkflowInAttempt"><code><span class="http-method">post</span> /v1/attempt/set_workflow_in_attempt</code></a></li>
   </ul>
   <h4><a href="#Connection">Connection</a></h4>
@@ -287,6 +288,7 @@ font-style: italic;
   <ul>
   <li><a href="#createOrUpdateState"><code><span class="http-method">post</span> /v1/state/create_or_update</code></a></li>
   <li><a href="#getAttemptNormalizationStatusesForJob"><code><span class="http-method">post</span> /v1/jobs/get_normalization_status</code></a></li>
+  <li><a href="#saveStats"><code><span class="http-method">post</span> /v1/attempt/save_stats</code></a></li>
   <li><a href="#setWorkflowInAttempt"><code><span class="http-method">post</span> /v1/attempt/set_workflow_in_attempt</code></a></li>
   </ul>
   <h4><a href="#Jobs">Jobs</a></h4>
@@ -393,6 +395,58 @@ font-style: italic;
   </ul>
 
   <h1><a name="Attempt">Attempt</a></h1>
+  <div class="method"><a name="saveStats"/>
+    <div class="method-path">
+    <a class="up" href="#__Methods">Up</a>
+    <pre class="post"><code class="huge"><span class="http-method">post</span> /v1/attempt/save_stats</code></pre></div>
+    <div class="method-summary">For worker to set running attempt stats. (<span class="nickname">saveStats</span>)</div>
+    <div class="method-notes"></div>
+
+
+    <h3 class="field-label">Consumes</h3>
+    This API call consumes the following media types via the <span class="header">Content-Type</span> request header:
+    <ul>
+      <li><code>application/json</code></li>
+    </ul>
+
+    <h3 class="field-label">Request body</h3>
+    <div class="field-items">
+      <div class="param">SaveStatsRequestBody <a href="#SaveStatsRequestBody">SaveStatsRequestBody</a> (required)</div>
+
+      <div class="param-desc"><span class="param-type">Body Parameter</span> &mdash;  </div>
+
+    </div>  <!-- field-items -->
+
+
+
+
+    <h3 class="field-label">Return type</h3>
+    <div class="return-type">
+      <a href="#InternalOperationResult">InternalOperationResult</a>
+      
+    </div>
+
+    <!--Todo: process Response Object and its headers, schema, examples -->
+
+    <h3 class="field-label">Example data</h3>
+    <div class="example-data-content-type">Content-Type: application/json</div>
+    <pre class="example"><code>{
+  "succeeded" : true
+}</code></pre>
+
+    <h3 class="field-label">Produces</h3>
+    This API call produces the following media types according to the <span class="header">Accept</span> request header;
+    the media type will be conveyed by the <span class="header">Content-Type</span> response header.
+    <ul>
+      <li><code>application/json</code></li>
+    </ul>
+
+    <h3 class="field-label">Responses</h3>
+    <h4 class="field-label">200</h4>
+    Successful Operation
+        <a href="#InternalOperationResult">InternalOperationResult</a>
+  </div> <!-- method -->
+  <hr/>
   <div class="method"><a name="setWorkflowInAttempt"/>
     <div class="method-path">
     <a class="up" href="#__Methods">Up</a>
@@ -1160,6 +1214,8 @@ font-style: italic;
         "stateMessagesEmitted" : 7,
         "recordsCommitted" : 1,
         "bytesEmitted" : 4,
+        "estimatedBytes" : 1,
+        "estimatedRecords" : 1,
         "recordsEmitted" : 2
       },
       "failureSummary" : {
@@ -1168,13 +1224,13 @@ font-style: italic;
           "stacktrace" : "stacktrace",
           "internalMessage" : "internalMessage",
           "externalMessage" : "externalMessage",
-          "timestamp" : 1
+          "timestamp" : 6
         }, {
           "retryable" : true,
           "stacktrace" : "stacktrace",
           "internalMessage" : "internalMessage",
           "externalMessage" : "externalMessage",
-          "timestamp" : 1
+          "timestamp" : 6
         } ],
         "partialSuccess" : true
       },
@@ -1186,6 +1242,8 @@ font-style: italic;
           "stateMessagesEmitted" : 7,
           "recordsCommitted" : 1,
           "bytesEmitted" : 4,
+          "estimatedBytes" : 1,
+          "estimatedRecords" : 1,
           "recordsEmitted" : 2
         },
         "streamName" : "streamName"
@@ -1194,6 +1252,8 @@ font-style: italic;
           "stateMessagesEmitted" : 7,
           "recordsCommitted" : 1,
           "bytesEmitted" : 4,
+          "estimatedBytes" : 1,
+          "estimatedRecords" : 1,
           "recordsEmitted" : 2
         },
         "streamName" : "streamName"
@@ -1211,6 +1271,8 @@ font-style: italic;
         "stateMessagesEmitted" : 7,
         "recordsCommitted" : 1,
         "bytesEmitted" : 4,
+        "estimatedBytes" : 1,
+        "estimatedRecords" : 1,
         "recordsEmitted" : 2
       },
       "failureSummary" : {
@@ -1219,13 +1281,13 @@ font-style: italic;
           "stacktrace" : "stacktrace",
           "internalMessage" : "internalMessage",
           "externalMessage" : "externalMessage",
-          "timestamp" : 1
+          "timestamp" : 6
         }, {
           "retryable" : true,
           "stacktrace" : "stacktrace",
           "internalMessage" : "internalMessage",
           "externalMessage" : "externalMessage",
-          "timestamp" : 1
+          "timestamp" : 6
         } ],
         "partialSuccess" : true
       },
@@ -1237,6 +1299,8 @@ font-style: italic;
           "stateMessagesEmitted" : 7,
           "recordsCommitted" : 1,
           "bytesEmitted" : 4,
+          "estimatedBytes" : 1,
+          "estimatedRecords" : 1,
           "recordsEmitted" : 2
         },
         "streamName" : "streamName"
@@ -1245,6 +1309,8 @@ font-style: italic;
           "stateMessagesEmitted" : 7,
           "recordsCommitted" : 1,
           "bytesEmitted" : 4,
+          "estimatedBytes" : 1,
+          "estimatedRecords" : 1,
           "recordsEmitted" : 2
         },
         "streamName" : "streamName"
@@ -1518,6 +1584,8 @@ font-style: italic;
         "stateMessagesEmitted" : 7,
         "recordsCommitted" : 1,
         "bytesEmitted" : 4,
+        "estimatedBytes" : 1,
+        "estimatedRecords" : 1,
         "recordsEmitted" : 2
       },
       "failureSummary" : {
@@ -1526,13 +1594,13 @@ font-style: italic;
           "stacktrace" : "stacktrace",
           "internalMessage" : "internalMessage",
           "externalMessage" : "externalMessage",
-          "timestamp" : 1
+          "timestamp" : 6
         }, {
           "retryable" : true,
           "stacktrace" : "stacktrace",
           "internalMessage" : "internalMessage",
           "externalMessage" : "externalMessage",
-          "timestamp" : 1
+          "timestamp" : 6
         } ],
         "partialSuccess" : true
       },
@@ -1544,6 +1612,8 @@ font-style: italic;
           "stateMessagesEmitted" : 7,
           "recordsCommitted" : 1,
           "bytesEmitted" : 4,
+          "estimatedBytes" : 1,
+          "estimatedRecords" : 1,
           "recordsEmitted" : 2
         },
         "streamName" : "streamName"
@@ -1552,6 +1622,8 @@ font-style: italic;
           "stateMessagesEmitted" : 7,
           "recordsCommitted" : 1,
           "bytesEmitted" : 4,
+          "estimatedBytes" : 1,
+          "estimatedRecords" : 1,
           "recordsEmitted" : 2
         },
         "streamName" : "streamName"
@@ -1569,6 +1641,8 @@ font-style: italic;
         "stateMessagesEmitted" : 7,
         "recordsCommitted" : 1,
         "bytesEmitted" : 4,
+        "estimatedBytes" : 1,
+        "estimatedRecords" : 1,
         "recordsEmitted" : 2
       },
       "failureSummary" : {
@@ -1577,13 +1651,13 @@ font-style: italic;
           "stacktrace" : "stacktrace",
           "internalMessage" : "internalMessage",
           "externalMessage" : "externalMessage",
-          "timestamp" : 1
+          "timestamp" : 6
         }, {
           "retryable" : true,
           "stacktrace" : "stacktrace",
           "internalMessage" : "internalMessage",
           "externalMessage" : "externalMessage",
-          "timestamp" : 1
+          "timestamp" : 6
         } ],
         "partialSuccess" : true
       },
@@ -1595,6 +1669,8 @@ font-style: italic;
           "stateMessagesEmitted" : 7,
           "recordsCommitted" : 1,
           "bytesEmitted" : 4,
+          "estimatedBytes" : 1,
+          "estimatedRecords" : 1,
           "recordsEmitted" : 2
         },
         "streamName" : "streamName"
@@ -1603,6 +1679,8 @@ font-style: italic;
           "stateMessagesEmitted" : 7,
           "recordsCommitted" : 1,
           "bytesEmitted" : 4,
+          "estimatedBytes" : 1,
+          "estimatedRecords" : 1,
           "recordsEmitted" : 2
         },
         "streamName" : "streamName"
@@ -4143,6 +4221,58 @@ containing the updated stream needs to be sent.</div>
         <a href="#AttemptNormalizationStatusReadList">AttemptNormalizationStatusReadList</a>
   </div> <!-- method -->
   <hr/>
+  <div class="method"><a name="saveStats"/>
+    <div class="method-path">
+    <a class="up" href="#__Methods">Up</a>
+    <pre class="post"><code class="huge"><span class="http-method">post</span> /v1/attempt/save_stats</code></pre></div>
+    <div class="method-summary">For worker to set running attempt stats. (<span class="nickname">saveStats</span>)</div>
+    <div class="method-notes"></div>
+
+
+    <h3 class="field-label">Consumes</h3>
+    This API call consumes the following media types via the <span class="header">Content-Type</span> request header:
+    <ul>
+      <li><code>application/json</code></li>
+    </ul>
+
+    <h3 class="field-label">Request body</h3>
+    <div class="field-items">
+      <div class="param">SaveStatsRequestBody <a href="#SaveStatsRequestBody">SaveStatsRequestBody</a> (required)</div>
+
+      <div class="param-desc"><span class="param-type">Body Parameter</span> &mdash;  </div>
+
+    </div>  <!-- field-items -->
+
+
+
+
+    <h3 class="field-label">Return type</h3>
+    <div class="return-type">
+      <a href="#InternalOperationResult">InternalOperationResult</a>
+      
+    </div>
+
+    <!--Todo: process Response Object and its headers, schema, examples -->
+
+    <h3 class="field-label">Example data</h3>
+    <div class="example-data-content-type">Content-Type: application/json</div>
+    <pre class="example"><code>{
+  "succeeded" : true
+}</code></pre>
+
+    <h3 class="field-label">Produces</h3>
+    This API call produces the following media types according to the <span class="header">Accept</span> request header;
+    the media type will be conveyed by the <span class="header">Content-Type</span> response header.
+    <ul>
+      <li><code>application/json</code></li>
+    </ul>
+
+    <h3 class="field-label">Responses</h3>
+    <h4 class="field-label">200</h4>
+    Successful Operation
+        <a href="#InternalOperationResult">InternalOperationResult</a>
+  </div> <!-- method -->
+  <hr/>
   <div class="method"><a name="setWorkflowInAttempt"/>
     <div class="method-path">
     <a class="up" href="#__Methods">Up</a>
@@ -4253,6 +4383,8 @@ containing the updated stream needs to be sent.</div>
         "stateMessagesEmitted" : 7,
         "recordsCommitted" : 1,
         "bytesEmitted" : 4,
+        "estimatedBytes" : 1,
+        "estimatedRecords" : 1,
         "recordsEmitted" : 2
       },
       "failureSummary" : {
@@ -4261,13 +4393,13 @@ containing the updated stream needs to be sent.</div>
           "stacktrace" : "stacktrace",
           "internalMessage" : "internalMessage",
           "externalMessage" : "externalMessage",
-          "timestamp" : 1
+          "timestamp" : 6
         }, {
           "retryable" : true,
           "stacktrace" : "stacktrace",
           "internalMessage" : "internalMessage",
           "externalMessage" : "externalMessage",
-          "timestamp" : 1
+          "timestamp" : 6
         } ],
         "partialSuccess" : true
       },
@@ -4279,6 +4411,8 @@ containing the updated stream needs to be sent.</div>
           "stateMessagesEmitted" : 7,
           "recordsCommitted" : 1,
           "bytesEmitted" : 4,
+          "estimatedBytes" : 1,
+          "estimatedRecords" : 1,
           "recordsEmitted" : 2
         },
         "streamName" : "streamName"
@@ -4287,6 +4421,8 @@ containing the updated stream needs to be sent.</div>
           "stateMessagesEmitted" : 7,
           "recordsCommitted" : 1,
           "bytesEmitted" : 4,
+          "estimatedBytes" : 1,
+          "estimatedRecords" : 1,
           "recordsEmitted" : 2
         },
         "streamName" : "streamName"
@@ -4304,6 +4440,8 @@ containing the updated stream needs to be sent.</div>
         "stateMessagesEmitted" : 7,
         "recordsCommitted" : 1,
         "bytesEmitted" : 4,
+        "estimatedBytes" : 1,
+        "estimatedRecords" : 1,
         "recordsEmitted" : 2
       },
       "failureSummary" : {
@@ -4312,13 +4450,13 @@ containing the updated stream needs to be sent.</div>
           "stacktrace" : "stacktrace",
           "internalMessage" : "internalMessage",
           "externalMessage" : "externalMessage",
-          "timestamp" : 1
+          "timestamp" : 6
         }, {
           "retryable" : true,
           "stacktrace" : "stacktrace",
           "internalMessage" : "internalMessage",
           "externalMessage" : "externalMessage",
-          "timestamp" : 1
+          "timestamp" : 6
         } ],
         "partialSuccess" : true
       },
@@ -4330,6 +4468,8 @@ containing the updated stream needs to be sent.</div>
           "stateMessagesEmitted" : 7,
           "recordsCommitted" : 1,
           "bytesEmitted" : 4,
+          "estimatedBytes" : 1,
+          "estimatedRecords" : 1,
           "recordsEmitted" : 2
         },
         "streamName" : "streamName"
@@ -4338,6 +4478,8 @@ containing the updated stream needs to be sent.</div>
           "stateMessagesEmitted" : 7,
           "recordsCommitted" : 1,
           "bytesEmitted" : 4,
+          "estimatedBytes" : 1,
+          "estimatedRecords" : 1,
           "recordsEmitted" : 2
         },
         "streamName" : "streamName"
@@ -4547,6 +4689,8 @@ containing the updated stream needs to be sent.</div>
         "stateMessagesEmitted" : 7,
         "recordsCommitted" : 1,
         "bytesEmitted" : 4,
+        "estimatedBytes" : 1,
+        "estimatedRecords" : 1,
         "recordsEmitted" : 2
       },
       "failureSummary" : {
@@ -4555,13 +4699,13 @@ containing the updated stream needs to be sent.</div>
           "stacktrace" : "stacktrace",
           "internalMessage" : "internalMessage",
           "externalMessage" : "externalMessage",
-          "timestamp" : 1
+          "timestamp" : 6
         }, {
           "retryable" : true,
           "stacktrace" : "stacktrace",
           "internalMessage" : "internalMessage",
           "externalMessage" : "externalMessage",
-          "timestamp" : 1
+          "timestamp" : 6
         } ],
         "partialSuccess" : true
       },
@@ -4573,6 +4717,8 @@ containing the updated stream needs to be sent.</div>
           "stateMessagesEmitted" : 7,
           "recordsCommitted" : 1,
           "bytesEmitted" : 4,
+          "estimatedBytes" : 1,
+          "estimatedRecords" : 1,
           "recordsEmitted" : 2
         },
         "streamName" : "streamName"
@@ -4581,6 +4727,8 @@ containing the updated stream needs to be sent.</div>
           "stateMessagesEmitted" : 7,
           "recordsCommitted" : 1,
           "bytesEmitted" : 4,
+          "estimatedBytes" : 1,
+          "estimatedRecords" : 1,
           "recordsEmitted" : 2
         },
         "streamName" : "streamName"
@@ -4598,6 +4746,8 @@ containing the updated stream needs to be sent.</div>
         "stateMessagesEmitted" : 7,
         "recordsCommitted" : 1,
         "bytesEmitted" : 4,
+        "estimatedBytes" : 1,
+        "estimatedRecords" : 1,
         "recordsEmitted" : 2
       },
       "failureSummary" : {
@@ -4606,13 +4756,13 @@ containing the updated stream needs to be sent.</div>
           "stacktrace" : "stacktrace",
           "internalMessage" : "internalMessage",
           "externalMessage" : "externalMessage",
-          "timestamp" : 1
+          "timestamp" : 6
         }, {
           "retryable" : true,
           "stacktrace" : "stacktrace",
           "internalMessage" : "internalMessage",
           "externalMessage" : "externalMessage",
-          "timestamp" : 1
+          "timestamp" : 6
         } ],
         "partialSuccess" : true
       },
@@ -4624,6 +4774,8 @@ containing the updated stream needs to be sent.</div>
           "stateMessagesEmitted" : 7,
           "recordsCommitted" : 1,
           "bytesEmitted" : 4,
+          "estimatedBytes" : 1,
+          "estimatedRecords" : 1,
           "recordsEmitted" : 2
         },
         "streamName" : "streamName"
@@ -4632,6 +4784,8 @@ containing the updated stream needs to be sent.</div>
           "stateMessagesEmitted" : 7,
           "recordsCommitted" : 1,
           "bytesEmitted" : 4,
+          "estimatedBytes" : 1,
+          "estimatedRecords" : 1,
           "recordsEmitted" : 2
         },
         "streamName" : "streamName"
@@ -4722,6 +4876,8 @@ containing the updated stream needs to be sent.</div>
         "stateMessagesEmitted" : 7,
         "recordsCommitted" : 1,
         "bytesEmitted" : 4,
+        "estimatedBytes" : 1,
+        "estimatedRecords" : 1,
         "recordsEmitted" : 2
       },
       "failureSummary" : {
@@ -4730,13 +4886,13 @@ containing the updated stream needs to be sent.</div>
           "stacktrace" : "stacktrace",
           "internalMessage" : "internalMessage",
           "externalMessage" : "externalMessage",
-          "timestamp" : 1
+          "timestamp" : 6
         }, {
           "retryable" : true,
           "stacktrace" : "stacktrace",
           "internalMessage" : "internalMessage",
           "externalMessage" : "externalMessage",
-          "timestamp" : 1
+          "timestamp" : 6
         } ],
         "partialSuccess" : true
       },
@@ -4748,6 +4904,8 @@ containing the updated stream needs to be sent.</div>
           "stateMessagesEmitted" : 7,
           "recordsCommitted" : 1,
           "bytesEmitted" : 4,
+          "estimatedBytes" : 1,
+          "estimatedRecords" : 1,
           "recordsEmitted" : 2
         },
         "streamName" : "streamName"
@@ -4756,6 +4914,8 @@ containing the updated stream needs to be sent.</div>
           "stateMessagesEmitted" : 7,
           "recordsCommitted" : 1,
           "bytesEmitted" : 4,
+          "estimatedBytes" : 1,
+          "estimatedRecords" : 1,
           "recordsEmitted" : 2
         },
         "streamName" : "streamName"
@@ -4773,6 +4933,8 @@ containing the updated stream needs to be sent.</div>
         "stateMessagesEmitted" : 7,
         "recordsCommitted" : 1,
         "bytesEmitted" : 4,
+        "estimatedBytes" : 1,
+        "estimatedRecords" : 1,
         "recordsEmitted" : 2
       },
       "failureSummary" : {
@@ -4781,13 +4943,13 @@ containing the updated stream needs to be sent.</div>
           "stacktrace" : "stacktrace",
           "internalMessage" : "internalMessage",
           "externalMessage" : "externalMessage",
-          "timestamp" : 1
+          "timestamp" : 6
         }, {
           "retryable" : true,
           "stacktrace" : "stacktrace",
           "internalMessage" : "internalMessage",
           "externalMessage" : "externalMessage",
-          "timestamp" : 1
+          "timestamp" : 6
         } ],
         "partialSuccess" : true
       },
@@ -4799,6 +4961,8 @@ containing the updated stream needs to be sent.</div>
           "stateMessagesEmitted" : 7,
           "recordsCommitted" : 1,
           "bytesEmitted" : 4,
+          "estimatedBytes" : 1,
+          "estimatedRecords" : 1,
           "recordsEmitted" : 2
         },
         "streamName" : "streamName"
@@ -4807,6 +4971,8 @@ containing the updated stream needs to be sent.</div>
           "stateMessagesEmitted" : 7,
           "recordsCommitted" : 1,
           "bytesEmitted" : 4,
+          "estimatedBytes" : 1,
+          "estimatedRecords" : 1,
           "recordsEmitted" : 2
         },
         "streamName" : "streamName"
@@ -4970,6 +5136,8 @@ containing the updated stream needs to be sent.</div>
         "stateMessagesEmitted" : 7,
         "recordsCommitted" : 1,
         "bytesEmitted" : 4,
+        "estimatedBytes" : 1,
+        "estimatedRecords" : 1,
         "recordsEmitted" : 2
       },
       "failureSummary" : {
@@ -4978,13 +5146,13 @@ containing the updated stream needs to be sent.</div>
           "stacktrace" : "stacktrace",
           "internalMessage" : "internalMessage",
           "externalMessage" : "externalMessage",
-          "timestamp" : 1
+          "timestamp" : 6
         }, {
           "retryable" : true,
           "stacktrace" : "stacktrace",
           "internalMessage" : "internalMessage",
           "externalMessage" : "externalMessage",
-          "timestamp" : 1
+          "timestamp" : 6
         } ],
         "partialSuccess" : true
       },
@@ -4996,6 +5164,8 @@ containing the updated stream needs to be sent.</div>
           "stateMessagesEmitted" : 7,
           "recordsCommitted" : 1,
           "bytesEmitted" : 4,
+          "estimatedBytes" : 1,
+          "estimatedRecords" : 1,
           "recordsEmitted" : 2
         },
         "streamName" : "streamName"
@@ -5004,6 +5174,8 @@ containing the updated stream needs to be sent.</div>
           "stateMessagesEmitted" : 7,
           "recordsCommitted" : 1,
           "bytesEmitted" : 4,
+          "estimatedBytes" : 1,
+          "estimatedRecords" : 1,
           "recordsEmitted" : 2
         },
         "streamName" : "streamName"
@@ -5016,6 +5188,8 @@ containing the updated stream needs to be sent.</div>
         "stateMessagesEmitted" : 7,
         "recordsCommitted" : 1,
         "bytesEmitted" : 4,
+        "estimatedBytes" : 1,
+        "estimatedRecords" : 1,
         "recordsEmitted" : 2
       },
       "failureSummary" : {
@@ -5024,13 +5198,13 @@ containing the updated stream needs to be sent.</div>
           "stacktrace" : "stacktrace",
           "internalMessage" : "internalMessage",
           "externalMessage" : "externalMessage",
-          "timestamp" : 1
+          "timestamp" : 6
         }, {
           "retryable" : true,
           "stacktrace" : "stacktrace",
           "internalMessage" : "internalMessage",
           "externalMessage" : "externalMessage",
-          "timestamp" : 1
+          "timestamp" : 6
         } ],
         "partialSuccess" : true
       },
@@ -5042,6 +5216,8 @@ containing the updated stream needs to be sent.</div>
           "stateMessagesEmitted" : 7,
           "recordsCommitted" : 1,
           "bytesEmitted" : 4,
+          "estimatedBytes" : 1,
+          "estimatedRecords" : 1,
           "recordsEmitted" : 2
         },
         "streamName" : "streamName"
@@ -5050,6 +5226,8 @@ containing the updated stream needs to be sent.</div>
           "stateMessagesEmitted" : 7,
           "recordsCommitted" : 1,
           "bytesEmitted" : 4,
+          "estimatedBytes" : 1,
+          "estimatedRecords" : 1,
           "recordsEmitted" : 2
         },
         "streamName" : "streamName"
@@ -5079,6 +5257,8 @@ containing the updated stream needs to be sent.</div>
         "stateMessagesEmitted" : 7,
         "recordsCommitted" : 1,
         "bytesEmitted" : 4,
+        "estimatedBytes" : 1,
+        "estimatedRecords" : 1,
         "recordsEmitted" : 2
       },
       "failureSummary" : {
@@ -5087,13 +5267,13 @@ containing the updated stream needs to be sent.</div>
           "stacktrace" : "stacktrace",
           "internalMessage" : "internalMessage",
           "externalMessage" : "externalMessage",
-          "timestamp" : 1
+          "timestamp" : 6
         }, {
           "retryable" : true,
           "stacktrace" : "stacktrace",
           "internalMessage" : "internalMessage",
           "externalMessage" : "externalMessage",
-          "timestamp" : 1
+          "timestamp" : 6
         } ],
         "partialSuccess" : true
       },
@@ -5105,6 +5285,8 @@ containing the updated stream needs to be sent.</div>
           "stateMessagesEmitted" : 7,
           "recordsCommitted" : 1,
           "bytesEmitted" : 4,
+          "estimatedBytes" : 1,
+          "estimatedRecords" : 1,
           "recordsEmitted" : 2
         },
         "streamName" : "streamName"
@@ -5113,6 +5295,8 @@ containing the updated stream needs to be sent.</div>
           "stateMessagesEmitted" : 7,
           "recordsCommitted" : 1,
           "bytesEmitted" : 4,
+          "estimatedBytes" : 1,
+          "estimatedRecords" : 1,
           "recordsEmitted" : 2
         },
         "streamName" : "streamName"
@@ -5125,6 +5309,8 @@ containing the updated stream needs to be sent.</div>
         "stateMessagesEmitted" : 7,
         "recordsCommitted" : 1,
         "bytesEmitted" : 4,
+        "estimatedBytes" : 1,
+        "estimatedRecords" : 1,
         "recordsEmitted" : 2
       },
       "failureSummary" : {
@@ -5133,13 +5319,13 @@ containing the updated stream needs to be sent.</div>
           "stacktrace" : "stacktrace",
           "internalMessage" : "internalMessage",
           "externalMessage" : "externalMessage",
-          "timestamp" : 1
+          "timestamp" : 6
         }, {
           "retryable" : true,
           "stacktrace" : "stacktrace",
           "internalMessage" : "internalMessage",
           "externalMessage" : "externalMessage",
-          "timestamp" : 1
+          "timestamp" : 6
         } ],
         "partialSuccess" : true
       },
@@ -5151,6 +5337,8 @@ containing the updated stream needs to be sent.</div>
           "stateMessagesEmitted" : 7,
           "recordsCommitted" : 1,
           "bytesEmitted" : 4,
+          "estimatedBytes" : 1,
+          "estimatedRecords" : 1,
           "recordsEmitted" : 2
         },
         "streamName" : "streamName"
@@ -5159,6 +5347,8 @@ containing the updated stream needs to be sent.</div>
           "stateMessagesEmitted" : 7,
           "recordsCommitted" : 1,
           "bytesEmitted" : 4,
+          "estimatedBytes" : 1,
+          "estimatedRecords" : 1,
           "recordsEmitted" : 2
         },
         "streamName" : "streamName"
@@ -10190,6 +10380,7 @@ containing the updated stream needs to be sent.</div>
     <li><a href="#ReleaseStage"><code>ReleaseStage</code> - </a></li>
     <li><a href="#ResetConfig"><code>ResetConfig</code> - </a></li>
     <li><a href="#ResourceRequirements"><code>ResourceRequirements</code> - </a></li>
+    <li><a href="#SaveStatsRequestBody"><code>SaveStatsRequestBody</code> - </a></li>
     <li><a href="#SchemaChange"><code>SchemaChange</code> - </a></li>
     <li><a href="#SetInstancewideDestinationOauthParamsRequestBody"><code>SetInstancewideDestinationOauthParamsRequestBody</code> - </a></li>
     <li><a href="#SetInstancewideSourceOauthParamsRequestBody"><code>SetInstancewideSourceOauthParamsRequestBody</code> - </a></li>
@@ -10384,6 +10575,8 @@ containing the updated stream needs to be sent.</div>
 <div class="param">bytesEmitted (optional)</div><div class="param-desc"><span class="param-type"><a href="#long">Long</a></span>  format: int64</div>
 <div class="param">stateMessagesEmitted (optional)</div><div class="param-desc"><span class="param-type"><a href="#long">Long</a></span>  format: int64</div>
 <div class="param">recordsCommitted (optional)</div><div class="param-desc"><span class="param-type"><a href="#long">Long</a></span>  format: int64</div>
+<div class="param">estimatedRecords (optional)</div><div class="param-desc"><span class="param-type"><a href="#long">Long</a></span>  format: int64</div>
+<div class="param">estimatedBytes (optional)</div><div class="param-desc"><span class="param-type"><a href="#long">Long</a></span>  format: int64</div>
     </div>  <!-- field-items -->
   </div>
   <div class="model">
@@ -11354,6 +11547,16 @@ if oauth parameters were contained inside the top level, rootObject=[] If they w
 <div class="param">cpu_limit (optional)</div><div class="param-desc"><span class="param-type"><a href="#string">String</a></span>  </div>
 <div class="param">memory_request (optional)</div><div class="param-desc"><span class="param-type"><a href="#string">String</a></span>  </div>
 <div class="param">memory_limit (optional)</div><div class="param-desc"><span class="param-type"><a href="#string">String</a></span>  </div>
+    </div>  <!-- field-items -->
+  </div>
+  <div class="model">
+    <h3><a name="SaveStatsRequestBody"><code>SaveStatsRequestBody</code> - </a> <a class="up" href="#__Models">Up</a></h3>
+    <div class='model-description'></div>
+    <div class="field-items">
+      <div class="param">jobId </div><div class="param-desc"><span class="param-type"><a href="#long">Long</a></span>  format: int64</div>
+<div class="param">attemptNumber </div><div class="param-desc"><span class="param-type"><a href="#integer">Integer</a></span>  format: int32</div>
+<div class="param">stats </div><div class="param-desc"><span class="param-type"><a href="#AttemptStats">AttemptStats</a></span>  </div>
+<div class="param">streamStats (optional)</div><div class="param-desc"><span class="param-type"><a href="#AttemptStreamStats">array[AttemptStreamStats]</a></span>  </div>
     </div>  <!-- field-items -->
   </div>
   <div class="model">

--- a/docs/reference/api/generated-api-html/index.html
+++ b/docs/reference/api/generated-api-html/index.html
@@ -399,7 +399,7 @@ font-style: italic;
     <div class="method-path">
     <a class="up" href="#__Methods">Up</a>
     <pre class="post"><code class="huge"><span class="http-method">post</span> /v1/attempt/save_stats</code></pre></div>
-    <div class="method-summary">For worker to set running attempt stats. (<span class="nickname">saveStats</span>)</div>
+    <div class="method-summary">For worker to set sync stats of a running attempt. (<span class="nickname">saveStats</span>)</div>
     <div class="method-notes"></div>
 
 
@@ -4225,7 +4225,7 @@ containing the updated stream needs to be sent.</div>
     <div class="method-path">
     <a class="up" href="#__Methods">Up</a>
     <pre class="post"><code class="huge"><span class="http-method">post</span> /v1/attempt/save_stats</code></pre></div>
-    <div class="method-summary">For worker to set running attempt stats. (<span class="nickname">saveStats</span>)</div>
+    <div class="method-summary">For worker to set sync stats of a running attempt. (<span class="nickname">saveStats</span>)</div>
     <div class="method-notes"></div>
 
 


### PR DESCRIPTION
## What
API changes to support the progress bar.

1) The eventual idea is for the save_stats route to be called by the workers during replication. Workers will save stats for a job id and attempt number.
2) Make modifications to the /jobs/list and the /jobs/get_debug_info routes to also return estimated bytes/records.

We need both estimated metadata, as well as running states to calculate progress bar and throughput.

## How
- add the `save_stats` route. This is the route that will be called by workers. I've done my best to reuse existing openapi bodies to reduce duplication.
- add the `estimatedRecords` and `estimatedBytes` fields to the `AttemptStats` body. This is part of the `AttemptRead` and the `AttemptStreamStats` objects. This eventually filters up to the `jobs/list` and `jobs/get_debug_info` objects. This also adds these to all the endpoints that were previously returning stats information. I think the duplicated data is a small issue and don't think it's worth splitting out a new api objects, though I will gladly do so if folks feel strongly. 
- minor changes to the AttemptApiController to support the new route.
- I've stubbed out the handlers for now since the backend is not yet implemented.

## Recommended reading order
1. `config.yaml` for the main changes.
2. `AttemptApiController.java` for the override changes.

## 🚨 User Impact 🚨
Are there any breaking changes? What is the end result perceived by the user? If yes, please merge this PR with the 🚨🚨 emoji so changelog authors can further highlight this if needed.

## Pre-merge Checklist
Expand the relevant checklist and delete the others.

<details><summary><strong>New Connector</strong></summary>

### Community member or Airbyter

- [ ] **Community member?** Grant edit access to maintainers ([instructions](https://docs.github.com/en/github/collaborating-with-pull-requests/working-with-forks/allowing-changes-to-a-pull-request-branch-created-from-a-fork#enabling-repository-maintainer-permissions-on-existing-pull-requests))
- [ ] Secrets in the connector's spec are annotated with `airbyte_secret`
- [ ] Unit & integration tests added and passing. Community members, please provide proof of success locally e.g: screenshot or copy-paste unit, integration, and acceptance test output. To run acceptance tests for a Python connector, follow instructions in the README. For java connectors run `./gradlew :airbyte-integrations:connectors:<name>:integrationTest`.
- [ ] Code reviews completed
- [ ] Documentation updated
    - [ ] Connector's `README.md`
    - [ ] Connector's `bootstrap.md`. See [description and examples](https://docs.google.com/document/d/1ypdgmwmEHWv-TrO4_YOQ7pAJGVrMp5BOkEVh831N260/edit?usp=sharing)
    - [ ] `docs/integrations/<source or destination>/<name>.md` including changelog. See changelog [example](https://docs.airbyte.io/integrations/sources/stripe#changelog)
    - [ ] `docs/integrations/README.md`
    - [ ] `airbyte-integrations/builds.md`
- [ ] PR name follows [PR naming conventions](https://docs.airbyte.com/contributing-to-airbyte/issues-and-pull-requests)

### Airbyter

If this is a community PR, the Airbyte engineer reviewing this PR is responsible for the below items.

- [ ] Create a non-forked branch based on this PR and test the below items on it
- [ ] Build is successful
- [ ] If new credentials are required for use in CI, add them to GSM. [Instructions](https://docs.airbyte.io/connector-development#using-credentials-in-ci).
- [ ] [`/test connector=connectors/<name>` command](https://docs.airbyte.io/connector-development#updating-an-existing-connector) is passing
- [ ] New Connector version released on Dockerhub by running the `/publish` command described [here](https://docs.airbyte.io/connector-development#updating-an-existing-connector)
- [ ] After the connector is published, connector added to connector index as described [here](https://docs.airbyte.io/connector-development#publishing-a-connector)
- [ ] Seed specs have been re-generated by building the platform and committing the changes to the seed spec files, as described [here](https://docs.airbyte.io/connector-development#publishing-a-connector)

</details>

<details><summary><strong>Updating a connector</strong></summary>

### Community member or Airbyter

- [ ] Grant edit access to maintainers ([instructions](https://docs.github.com/en/github/collaborating-with-pull-requests/working-with-forks/allowing-changes-to-a-pull-request-branch-created-from-a-fork#enabling-repository-maintainer-permissions-on-existing-pull-requests))
- [ ] Secrets in the connector's spec are annotated with `airbyte_secret`
- [ ] Unit & integration tests added and passing. Community members, please provide proof of success locally e.g: screenshot or copy-paste unit, integration, and acceptance test output. To run acceptance tests for a Python connector, follow instructions in the README. For java connectors run `./gradlew :airbyte-integrations:connectors:<name>:integrationTest`.
- [ ] Code reviews completed
- [ ] Documentation updated
    - [ ] Connector's `README.md`
    - [ ] Connector's `bootstrap.md`. See [description and examples](https://docs.google.com/document/d/1ypdgmwmEHWv-TrO4_YOQ7pAJGVrMp5BOkEVh831N260/edit?usp=sharing)
    - [ ] Changelog updated in `docs/integrations/<source or destination>/<name>.md` including changelog. See changelog [example](https://docs.airbyte.io/integrations/sources/stripe#changelog)
- [ ] PR name follows [PR naming conventions](https://docs.airbyte.com/contributing-to-airbyte/issues-and-pull-requests)

### Airbyter

If this is a community PR, the Airbyte engineer reviewing this PR is responsible for the below items.

- [ ] Create a non-forked branch based on this PR and test the below items on it
- [ ] Build is successful
- [ ] If new credentials are required for use in CI, add them to GSM. [Instructions](https://docs.airbyte.io/connector-development#using-credentials-in-ci).
- [ ] [`/test connector=connectors/<name>` command](https://docs.airbyte.io/connector-development#updating-an-existing-connector) is passing
- [ ] New Connector version released on Dockerhub and connector version bumped by running the `/publish` command described [here](https://docs.airbyte.io/connector-development#updating-an-existing-connector)

</details>

<details><summary><strong>Connector Generator</strong></summary>

- [ ] Issue acceptance criteria met
- [ ] PR name follows [PR naming conventions](https://docs.airbyte.com/contributing-to-airbyte/issues-and-pull-requests)
- [ ] If adding a new generator, add it to the [list of scaffold modules being tested](https://github.com/airbytehq/airbyte/blob/master/airbyte-integrations/connector-templates/generator/build.gradle#L41)
- [ ] The generator test modules (all connectors with `-scaffold` in their name) have been updated with the latest scaffold by running `./gradlew :airbyte-integrations:connector-templates:generator:testScaffoldTemplates` then checking in your changes
- [ ] Documentation which references the generator is updated as needed

</details>

## Tests

<details><summary><strong>Unit</strong></summary>

*Put your unit tests output here.*

</details>

<details><summary><strong>Integration</strong></summary>

*Put your integration tests output here.*

</details>

<details><summary><strong>Acceptance</strong></summary>

*Put your acceptance tests output here.*

</details>
