### PR TITLE
Handle potential NPE

### DIFF
--- a/airbyte-metrics/metrics-lib/src/main/java/io/airbyte/metrics/lib/MetricTags.java
+++ b/airbyte-metrics/metrics-lib/src/main/java/io/airbyte/metrics/lib/MetricTags.java
@@ -22,17 +22,18 @@ public class MetricTags {
   public static final String WORKFLOW_TYPE = "workflow_type";
   public static final String ATTEMPT_QUEUE = "attempt_queue";
   public static final String GEOGRAPHY = "geography";
+  public static final String UNKNOWN = "unknown";
 
   public static String getReleaseStage(final ReleaseStage stage) {
-    return stage.getLiteral();
+    return stage != null ? stage.getLiteral() : UNKNOWN;
   }
 
   public static String getFailureOrigin(final FailureOrigin origin) {
-    return origin.value();
+    return origin != null ? origin.value() : UNKNOWN;
   }
 
   public static String getJobStatus(final JobStatus status) {
-    return status.getLiteral();
+    return status != null ? status.getLiteral() : UNKNOWN;
   }
 
 }


### PR DESCRIPTION
## What
* Reduce runtime errors that can impact workflows

## How
* Ensure that a default value is used for metric attribute values with source object is null.  

Addresses this error:

```
java.lang.NullPointerException: Cannot invoke "io.airbyte.config.FailureReason$FailureOrigin.value()" because "origin" is null
	at io.airbyte.metrics.lib.MetricTags.getFailureOrigin(MetricTags.java:31)
	at io.airbyte.workers.temporal.scheduling.activities.JobCreationAndStatusUpdateActivityImpl.attemptFailure(JobCreationAndStatusUpdateActivityImpl.java:304)
	at io.airbyte.workers.temporal.scheduling.activities.JobCreationAndStatusUpdateActivityImpl.attemptFailureWithAttemptNumber(JobCreationAndStatusUpdateActivityImpl.java:316)
	at java.base/jdk.internal.reflect.DirectMethodHandleAccessor.invoke(DirectMethodHandleAccessor.java:104)
	at java.base/java.lang.reflect.Method.invoke(Method.java:578)
	at io.temporal.internal.activity.RootActivityInboundCallsInterceptor$POJOActivityInboundCallsInterceptor.executeActivity(RootActivityInboundCallsInterceptor.java:64)
	at io.temporal.internal.activity.RootActivityInboundCallsInterceptor.execute(RootActivityInboundCallsInterceptor.java:43)
	at io.temporal.internal.activity.ActivityTaskExecutors$BaseActivityTaskExecutor.execute(ActivityTaskExecutors.java:95)
	at io.temporal.internal.activity.ActivityTaskHandlerImpl.handle(ActivityTaskHandlerImpl.java:92)
	at io.temporal.internal.worker.ActivityWorker$TaskHandlerImpl.handleActivity(ActivityWorker.java:241)
	at io.temporal.internal.worker.ActivityWorker$TaskHandlerImpl.handle(ActivityWorker.java:206)
	at io.temporal.internal.worker.ActivityWorker$TaskHandlerImpl.handle(ActivityWorker.java:179)
	at io.temporal.internal.worker.PollTaskExecutor.lambda$process$0(PollTaskExecutor.java:93)
	at java.base/java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1144)
	at java.base/java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:642)
	at java.base/java.lang.Thread.run(Thread.java:1589)
```

## Recommended reading order
1. `MetricTags.java`

## Tests

* All tests pass
* Project builds successfully
