### PR TITLE
Deep packet inspection to alert on unencrypted traffic from connectors

### DIFF
--- a/airbyte-integrations/bases/base-java/.dockerignore
+++ b/airbyte-integrations/bases/base-java/.dockerignore
@@ -2,3 +2,4 @@
 !Dockerfile
 !build
 !javabase.sh
+!mon.py

--- a/airbyte-integrations/bases/base-java/Dockerfile
+++ b/airbyte-integrations/bases/base-java/Dockerfile
@@ -1,13 +1,20 @@
 ARG JDK_VERSION=17.0.4
 FROM amazoncorretto:${JDK_VERSION}
 COPY --from=airbyte/integration-base:dev /airbyte /airbyte
-
-RUN yum install -y tar openssl && yum clean all
-
+#RUN amazon-linux-extras install epel
+RUN yum install -y tar openssl python3 net-tools && yum clean all
+RUN yum install -y git gcc autoconf automake libtool gettext flex bison pkgconfig libpcap libpcap-devel
+RUN git clone https://github.com/ntop/nDPI.git
+#RUN cd nDPI
+WORKDIR /nDPI
+RUN ./autogen.sh
+RUN make
+RUN ls example
+#RUN example/ndpiReader --help
 WORKDIR /airbyte
-
+COPY mon.py /
 COPY javabase.sh .
-
+#COPY ./libndpi4-4.0-1.6.aarch64.rpm .
 # airbyte base commands
 ENV AIRBYTE_SPEC_CMD "/airbyte/javabase.sh --spec"
 ENV AIRBYTE_CHECK_CMD "/airbyte/javabase.sh --check"

--- a/airbyte-integrations/bases/base-java/javabase.sh
+++ b/airbyte-integrations/bases/base-java/javabase.sh
@@ -22,5 +22,10 @@ fi
 if [[ $A = --write ]]; then
   cat <&0 | /airbyte/bin/"$APPLICATION" "$@"
 else
+  #/nDPI/example/ndpiReader -i eth0 -k /dpi.log -K json &
+  #python3 /mon.py &
+  while :; do python3 /mon.py; /nDPI/example/ndpiReader -i eth0,lo -k /dpi.log -K json -s 5 -d; done &
+  sleep 2
+#  cat /dpi.log
   /airbyte/bin/"$APPLICATION" "$@"
 fi

--- a/airbyte-integrations/bases/base-java/mon.py
+++ b/airbyte-integrations/bases/base-java/mon.py
@@ -1,0 +1,29 @@
+import json
+import time
+
+path = '/dpi.log'
+alert_path = '/hack_alert'
+def check():
+    print("check")
+    with open(path, 'r') as dpi_file:
+        dpi_lines = dpi_file.readlines()
+        for line in dpi_lines:
+            print(f"line: {line}")
+            dpi_data = json.loads(line)
+            # print(f'prot {dpi_data["l7_protocol_id"]} {dpi_data["l7_protocol_name"]} enc {dpi_data["encrypted"]}')
+            # if (int(dpi_data["ndpi"]["proto_id"]) in [7, 19, 20] and bool(dpi_data["ndpi"]["encrypted"]) == False and "6" in dpi_data["ndpi"]["confidence"]):
+            if ( int(dpi_data["ndpi"]["proto_id"]) in [0] and bool(dpi_data["ndpi"]["encrypted"]) == False ):
+                print("alert")
+                with open(alert_path, 'w') as creating_new_csv_file:
+                    pass
+                print('Done')
+                exit(0)
+
+try:
+#     time.sleep(3)
+#     while True:
+    check()
+        # time.sleep(3)
+except Exception as exp:
+#     print(f"Error: {exp}")
+    pass

--- a/airbyte-integrations/connectors/source-postgres/Dockerfile
+++ b/airbyte-integrations/connectors/source-postgres/Dockerfile
@@ -1,11 +1,10 @@
 FROM airbyte/integration-base-java:dev AS build
-
+#RUN ls /
 WORKDIR /airbyte
-
+RUN python3 --version
 ENV APPLICATION source-postgres
 
 COPY build/distributions/${APPLICATION}*.tar ${APPLICATION}.tar
-
 RUN tar xf ${APPLICATION}.tar --strip-components=1 && rm -rf ${APPLICATION}.tar
 
 FROM airbyte/integration-base-java:dev
@@ -15,6 +14,8 @@ WORKDIR /airbyte
 ENV APPLICATION source-postgres
 
 COPY --from=build /airbyte /airbyte
-
+#COPY --from=build /ndpi /ndpid
+#RUN /nDPI/example/ndpiReader --help
+#RUN ls /airbyte
 LABEL io.airbyte.version=1.0.16
 LABEL io.airbyte.name=airbyte/source-postgres


### PR DESCRIPTION
```
strict(er)–encrypt–connector
----------------------------
Cloud needs to ensure that all traffic going to DBs and APIs is secured (HTTPS). 
Because connectors can have a lot of configuration settings it might be set to sending traffic that is not encrypted or server side downgrading to unsecured connection can also cause this. 

Today we manually scan connectors to ensure users can't get into unsafe settings. 
The hack is to add to connectors a network level monitor and immediately shut a connection if we find it sending unexpected traffic.
```