### PR TITLE
:window: :wrench: Hash filenames of extracted CSS

### DIFF
--- a/airbyte-webapp/craco.config.js
+++ b/airbyte-webapp/craco.config.js
@@ -15,6 +15,8 @@ module.exports = {
           }),
           new MiniCssExtractPlugin({
             ignoreOrder: true,
+            filename: "static/css/[name].[contenthash:8].css",
+            chunkFilename: "static/css/[name].[contenthash:8].chunk.css",
           }),
         ],
       };


### PR DESCRIPTION
## What

Hash filenames of CSS that is extracted during build properly. This is the default behvaior Create React App (see https://github.com/facebook/create-react-app/blob/main/packages/react-scripts/config/webpack.config.js#L666-L671) would do, but we lost this since we overwrote the `MiniCssExtractPlugin` config with our own (to prevent another bug we were seeing).

I've tested that this works when running `npm run build` and gives us now hashed file names (and also made sure that build output is still running when being served), and that `npm start` still works as expected.