### PR TITLE
Fix migration dev center schema dump by run db-specific initialization script

### DIFF
--- a/airbyte-bootloader/src/main/java/io/airbyte/bootloader/BootloaderApp.java
+++ b/airbyte-bootloader/src/main/java/io/airbyte/bootloader/BootloaderApp.java
@@ -148,10 +148,10 @@ public class BootloaderApp {
   public void load() throws Exception {
     LOGGER.info("Initializing databases...");
     DatabaseCheckFactory.createConfigsDatabaseInitializer(configsDslContext,
-        configs.getConfigsDatabaseInitializationTimeoutMs(), MoreResources.readResource(DatabaseConstants.CONFIGS_SCHEMA_PATH)).initialize();
+        configs.getConfigsDatabaseInitializationTimeoutMs(), MoreResources.readResource(DatabaseConstants.CONFIGS_INITIAL_SCHEMA_PATH)).initialize();
 
     DatabaseCheckFactory.createJobsDatabaseInitializer(jobsDslContext,
-        configs.getJobsDatabaseInitializationTimeoutMs(), MoreResources.readResource(DatabaseConstants.JOBS_SCHEMA_PATH)).initialize();
+        configs.getJobsDatabaseInitializationTimeoutMs(), MoreResources.readResource(DatabaseConstants.JOBS_INITIAL_SCHEMA_PATH)).initialize();
     LOGGER.info("Databases initialized.");
 
     LOGGER.info("Setting up config database and default workspace...");

--- a/airbyte-db/db-lib/src/main/java/io/airbyte/db/instance/DatabaseConstants.java
+++ b/airbyte-db/db-lib/src/main/java/io/airbyte/db/instance/DatabaseConstants.java
@@ -26,7 +26,9 @@ public final class DatabaseConstants {
   /**
    * Path to the script that contains the initial schema definition for the Configurations database.
    */
-  public static final String CONFIGS_SCHEMA_PATH = "configs_database/schema.sql";
+  public static final String CONFIGS_INITIAL_SCHEMA_PATH = "configs_database/schema.sql";
+
+  public static final String CONFIGS_SCHEMA_DUMP_PATH = "src/main/resources/configs_database/schema_dump.txt";
 
   /**
    * Logical name of the Jobs database.
@@ -41,7 +43,9 @@ public final class DatabaseConstants {
   /**
    * Path to the script that contains the initial schema definition for the Jobs database.
    */
-  public static final String JOBS_SCHEMA_PATH = "jobs_database/schema.sql";
+  public static final String JOBS_INITIAL_SCHEMA_PATH = "jobs_database/schema.sql";
+
+  public static final String JOBS_SCHEMA_DUMP_PATH = "src/main/resources/jobs_database/schema_dump.txt";
 
   /**
    * Default database connection timeout in milliseconds.

--- a/airbyte-db/db-lib/src/main/java/io/airbyte/db/instance/configs/ConfigsDatabaseMigrationDevCenter.java
+++ b/airbyte-db/db-lib/src/main/java/io/airbyte/db/instance/configs/ConfigsDatabaseMigrationDevCenter.java
@@ -10,9 +10,6 @@ import io.airbyte.db.instance.FlywayDatabaseMigrator;
 import io.airbyte.db.instance.development.MigrationDevCenter;
 import javax.sql.DataSource;
 import org.flywaydb.core.Flyway;
-import org.testcontainers.containers.PostgreSQLContainer;
-import org.testcontainers.ext.ScriptUtils;
-import org.testcontainers.jdbc.JdbcDatabaseDelegate;
 
 /**
  * Helper class for migration development. See README for details.
@@ -20,18 +17,12 @@ import org.testcontainers.jdbc.JdbcDatabaseDelegate;
 public class ConfigsDatabaseMigrationDevCenter extends MigrationDevCenter {
 
   public ConfigsDatabaseMigrationDevCenter() {
-    super("configs", "src/main/resources/configs_database/schema_dump.txt");
+    super("configs", "src/main/resources/configs_database/schema_dump.txt", "configs_database/schema.sql");
   }
 
   @Override
   protected FlywayDatabaseMigrator getMigrator(final Database database, final Flyway flyway) {
     return new ConfigsDatabaseMigrator(database, flyway);
-  }
-
-  @Override
-  protected void initializeDatabase(final PostgreSQLContainer<?> container) {
-    final var containerDelegate = new JdbcDatabaseDelegate(container, "");
-    ScriptUtils.runInitScript(containerDelegate, "configs_database/schema.sql");
   }
 
   @Override

--- a/airbyte-db/db-lib/src/main/java/io/airbyte/db/instance/configs/ConfigsDatabaseMigrationDevCenter.java
+++ b/airbyte-db/db-lib/src/main/java/io/airbyte/db/instance/configs/ConfigsDatabaseMigrationDevCenter.java
@@ -8,10 +8,11 @@ import io.airbyte.db.Database;
 import io.airbyte.db.factory.FlywayFactory;
 import io.airbyte.db.instance.FlywayDatabaseMigrator;
 import io.airbyte.db.instance.development.MigrationDevCenter;
-import java.io.IOException;
 import javax.sql.DataSource;
 import org.flywaydb.core.Flyway;
-import org.jooq.DSLContext;
+import org.testcontainers.containers.PostgreSQLContainer;
+import org.testcontainers.ext.ScriptUtils;
+import org.testcontainers.jdbc.JdbcDatabaseDelegate;
 
 /**
  * Helper class for migration development. See README for details.
@@ -28,8 +29,9 @@ public class ConfigsDatabaseMigrationDevCenter extends MigrationDevCenter {
   }
 
   @Override
-  protected Database getDatabase(final DSLContext dslContext) throws IOException {
-    return new Database(dslContext);
+  protected void initializeDatabase(final PostgreSQLContainer<?> container) {
+    final var containerDelegate = new JdbcDatabaseDelegate(container, "");
+    ScriptUtils.runInitScript(containerDelegate, "configs_database/schema.sql");
   }
 
   @Override

--- a/airbyte-db/db-lib/src/main/java/io/airbyte/db/instance/configs/ConfigsDatabaseMigrationDevCenter.java
+++ b/airbyte-db/db-lib/src/main/java/io/airbyte/db/instance/configs/ConfigsDatabaseMigrationDevCenter.java
@@ -18,7 +18,7 @@ import org.flywaydb.core.Flyway;
 public class ConfigsDatabaseMigrationDevCenter extends MigrationDevCenter {
 
   public ConfigsDatabaseMigrationDevCenter() {
-    super("configs", "src/main/resources/configs_database/schema_dump.txt", DatabaseConstants.CONFIGS_SCHEMA_PATH);
+    super("configs", DatabaseConstants.CONFIGS_SCHEMA_DUMP_PATH, DatabaseConstants.CONFIGS_INITIAL_SCHEMA_PATH);
   }
 
   @Override

--- a/airbyte-db/db-lib/src/main/java/io/airbyte/db/instance/configs/ConfigsDatabaseMigrationDevCenter.java
+++ b/airbyte-db/db-lib/src/main/java/io/airbyte/db/instance/configs/ConfigsDatabaseMigrationDevCenter.java
@@ -6,6 +6,7 @@ package io.airbyte.db.instance.configs;
 
 import io.airbyte.db.Database;
 import io.airbyte.db.factory.FlywayFactory;
+import io.airbyte.db.instance.DatabaseConstants;
 import io.airbyte.db.instance.FlywayDatabaseMigrator;
 import io.airbyte.db.instance.development.MigrationDevCenter;
 import javax.sql.DataSource;
@@ -17,7 +18,7 @@ import org.flywaydb.core.Flyway;
 public class ConfigsDatabaseMigrationDevCenter extends MigrationDevCenter {
 
   public ConfigsDatabaseMigrationDevCenter() {
-    super("configs", "src/main/resources/configs_database/schema_dump.txt", "configs_database/schema.sql");
+    super("configs", "src/main/resources/configs_database/schema_dump.txt", DatabaseConstants.CONFIGS_SCHEMA_PATH);
   }
 
   @Override

--- a/airbyte-db/db-lib/src/main/java/io/airbyte/db/instance/configs/ConfigsDatabaseTestProvider.java
+++ b/airbyte-db/db-lib/src/main/java/io/airbyte/db/instance/configs/ConfigsDatabaseTestProvider.java
@@ -35,7 +35,7 @@ public class ConfigsDatabaseTestProvider implements TestDatabaseProvider {
 
   @Override
   public Database create(final boolean runMigration) throws IOException, DatabaseInitializationException {
-    final String initalSchema = MoreResources.readResource(DatabaseConstants.CONFIGS_SCHEMA_PATH);
+    final String initalSchema = MoreResources.readResource(DatabaseConstants.CONFIGS_INITIAL_SCHEMA_PATH);
     DatabaseCheckFactory.createConfigsDatabaseInitializer(dslContext, DatabaseConstants.DEFAULT_CONNECTION_TIMEOUT_MS, initalSchema).initialize();
 
     final Database database = new Database(dslContext);

--- a/airbyte-db/db-lib/src/main/java/io/airbyte/db/instance/configs/ConfigsFlywayMigrationDatabase.java
+++ b/airbyte-db/db-lib/src/main/java/io/airbyte/db/instance/configs/ConfigsFlywayMigrationDatabase.java
@@ -47,7 +47,7 @@ public class ConfigsFlywayMigrationDatabase extends FlywayMigrationDatabase {
 
   @Override
   protected void initializeDatabase(final DSLContext dslContext) throws DatabaseInitializationException, IOException {
-    final String initialSchema = MoreResources.readResource(DatabaseConstants.CONFIGS_SCHEMA_PATH);
+    final String initialSchema = MoreResources.readResource(DatabaseConstants.CONFIGS_INITIAL_SCHEMA_PATH);
     DatabaseCheckFactory.createConfigsDatabaseInitializer(dslContext, DatabaseConstants.DEFAULT_CONNECTION_TIMEOUT_MS, initialSchema).initialize();
   }
 

--- a/airbyte-db/db-lib/src/main/java/io/airbyte/db/instance/development/MigrationDevCenter.java
+++ b/airbyte-db/db-lib/src/main/java/io/airbyte/db/instance/development/MigrationDevCenter.java
@@ -37,10 +37,12 @@ public abstract class MigrationDevCenter {
 
   private final String dbIdentifier;
   private final String schemaDumpFile;
+  private final String initialScript;
 
-  protected MigrationDevCenter(final String dbIdentifier, final String schemaDumpFile) {
+  protected MigrationDevCenter(final String dbIdentifier, final String schemaDumpFile, final String initialScript) {
     this.dbIdentifier = dbIdentifier;
     this.schemaDumpFile = schemaDumpFile;
+    this.initialScript = initialScript;
   }
 
   private PostgreSQLContainer<?> createContainer() {
@@ -49,14 +51,9 @@ public abstract class MigrationDevCenter {
         .withUsername("docker")
         .withPassword("docker");
     container.start();
-    initializeDatabase(container);
-    return container;
-  }
-
-  protected void initializeDatabase(final PostgreSQLContainer<?> container) {
     final var containerDelegate = new JdbcDatabaseDelegate(container, "");
-    ScriptUtils.runInitScript(containerDelegate, "configs_database/schema.sql");
-    ScriptUtils.runInitScript(containerDelegate, "jobs_database/schema.sql");
+    ScriptUtils.runInitScript(containerDelegate, initialScript);
+    return container;
   }
 
   protected abstract FlywayDatabaseMigrator getMigrator(Database database, Flyway flyway);

--- a/airbyte-db/db-lib/src/main/java/io/airbyte/db/instance/jobs/JobsDatabaseMigrationDevCenter.java
+++ b/airbyte-db/db-lib/src/main/java/io/airbyte/db/instance/jobs/JobsDatabaseMigrationDevCenter.java
@@ -6,6 +6,7 @@ package io.airbyte.db.instance.jobs;
 
 import io.airbyte.db.Database;
 import io.airbyte.db.factory.FlywayFactory;
+import io.airbyte.db.instance.DatabaseConstants;
 import io.airbyte.db.instance.FlywayDatabaseMigrator;
 import io.airbyte.db.instance.development.MigrationDevCenter;
 import javax.sql.DataSource;
@@ -17,7 +18,7 @@ import org.flywaydb.core.Flyway;
 public class JobsDatabaseMigrationDevCenter extends MigrationDevCenter {
 
   public JobsDatabaseMigrationDevCenter() {
-    super("jobs", "src/main/resources/jobs_database/schema_dump.txt", "jobs_database/schema.sql");
+    super("jobs", "src/main/resources/jobs_database/schema_dump.txt", DatabaseConstants.JOBS_SCHEMA_PATH);
   }
 
   @Override

--- a/airbyte-db/db-lib/src/main/java/io/airbyte/db/instance/jobs/JobsDatabaseMigrationDevCenter.java
+++ b/airbyte-db/db-lib/src/main/java/io/airbyte/db/instance/jobs/JobsDatabaseMigrationDevCenter.java
@@ -8,10 +8,11 @@ import io.airbyte.db.Database;
 import io.airbyte.db.factory.FlywayFactory;
 import io.airbyte.db.instance.FlywayDatabaseMigrator;
 import io.airbyte.db.instance.development.MigrationDevCenter;
-import java.io.IOException;
 import javax.sql.DataSource;
 import org.flywaydb.core.Flyway;
-import org.jooq.DSLContext;
+import org.testcontainers.containers.PostgreSQLContainer;
+import org.testcontainers.ext.ScriptUtils;
+import org.testcontainers.jdbc.JdbcDatabaseDelegate;
 
 /**
  * Helper class for migration development. See README for details.
@@ -28,8 +29,9 @@ public class JobsDatabaseMigrationDevCenter extends MigrationDevCenter {
   }
 
   @Override
-  protected Database getDatabase(final DSLContext dslContext) throws IOException {
-    return new Database(dslContext);
+  protected void initializeDatabase(final PostgreSQLContainer<?> container) {
+    final var containerDelegate = new JdbcDatabaseDelegate(container, "");
+    ScriptUtils.runInitScript(containerDelegate, "jobs_database/schema.sql");
   }
 
   @Override

--- a/airbyte-db/db-lib/src/main/java/io/airbyte/db/instance/jobs/JobsDatabaseMigrationDevCenter.java
+++ b/airbyte-db/db-lib/src/main/java/io/airbyte/db/instance/jobs/JobsDatabaseMigrationDevCenter.java
@@ -10,9 +10,6 @@ import io.airbyte.db.instance.FlywayDatabaseMigrator;
 import io.airbyte.db.instance.development.MigrationDevCenter;
 import javax.sql.DataSource;
 import org.flywaydb.core.Flyway;
-import org.testcontainers.containers.PostgreSQLContainer;
-import org.testcontainers.ext.ScriptUtils;
-import org.testcontainers.jdbc.JdbcDatabaseDelegate;
 
 /**
  * Helper class for migration development. See README for details.
@@ -20,18 +17,12 @@ import org.testcontainers.jdbc.JdbcDatabaseDelegate;
 public class JobsDatabaseMigrationDevCenter extends MigrationDevCenter {
 
   public JobsDatabaseMigrationDevCenter() {
-    super("jobs", "src/main/resources/jobs_database/schema_dump.txt");
+    super("jobs", "src/main/resources/jobs_database/schema_dump.txt", "jobs_database/schema.sql");
   }
 
   @Override
   protected FlywayDatabaseMigrator getMigrator(final Database database, final Flyway flyway) {
     return new JobsDatabaseMigrator(database, flyway);
-  }
-
-  @Override
-  protected void initializeDatabase(final PostgreSQLContainer<?> container) {
-    final var containerDelegate = new JdbcDatabaseDelegate(container, "");
-    ScriptUtils.runInitScript(containerDelegate, "jobs_database/schema.sql");
   }
 
   @Override

--- a/airbyte-db/db-lib/src/main/java/io/airbyte/db/instance/jobs/JobsDatabaseMigrationDevCenter.java
+++ b/airbyte-db/db-lib/src/main/java/io/airbyte/db/instance/jobs/JobsDatabaseMigrationDevCenter.java
@@ -18,7 +18,7 @@ import org.flywaydb.core.Flyway;
 public class JobsDatabaseMigrationDevCenter extends MigrationDevCenter {
 
   public JobsDatabaseMigrationDevCenter() {
-    super("jobs", "src/main/resources/jobs_database/schema_dump.txt", DatabaseConstants.JOBS_SCHEMA_PATH);
+    super("jobs", DatabaseConstants.JOBS_SCHEMA_DUMP_PATH, DatabaseConstants.JOBS_INITIAL_SCHEMA_PATH);
   }
 
   @Override

--- a/airbyte-db/db-lib/src/main/java/io/airbyte/db/instance/jobs/JobsDatabaseTestProvider.java
+++ b/airbyte-db/db-lib/src/main/java/io/airbyte/db/instance/jobs/JobsDatabaseTestProvider.java
@@ -27,7 +27,7 @@ public class JobsDatabaseTestProvider implements TestDatabaseProvider {
 
   @Override
   public Database create(final boolean runMigration) throws IOException, DatabaseInitializationException {
-    final String initialSchema = MoreResources.readResource(DatabaseConstants.JOBS_SCHEMA_PATH);
+    final String initialSchema = MoreResources.readResource(DatabaseConstants.JOBS_INITIAL_SCHEMA_PATH);
     DatabaseCheckFactory.createJobsDatabaseInitializer(dslContext, DatabaseConstants.DEFAULT_CONNECTION_TIMEOUT_MS, initialSchema).initialize();
 
     final Database jobsDatabase = new Database(dslContext);

--- a/airbyte-db/db-lib/src/main/java/io/airbyte/db/instance/jobs/JobsFlywayMigrationDatabase.java
+++ b/airbyte-db/db-lib/src/main/java/io/airbyte/db/instance/jobs/JobsFlywayMigrationDatabase.java
@@ -47,7 +47,7 @@ public class JobsFlywayMigrationDatabase extends FlywayMigrationDatabase {
 
   @Override
   protected void initializeDatabase(final DSLContext dslContext) throws DatabaseInitializationException, IOException {
-    final String initialSchema = MoreResources.readResource(DatabaseConstants.JOBS_SCHEMA_PATH);
+    final String initialSchema = MoreResources.readResource(DatabaseConstants.JOBS_INITIAL_SCHEMA_PATH);
     DatabaseCheckFactory.createJobsDatabaseInitializer(dslContext, DatabaseConstants.DEFAULT_CONNECTION_TIMEOUT_MS, initialSchema).initialize();
   }
 

--- a/airbyte-db/db-lib/src/test/java/io/airbyte/db/init/impl/ConfigsDatabaseInitializerTest.java
+++ b/airbyte-db/db-lib/src/test/java/io/airbyte/db/init/impl/ConfigsDatabaseInitializerTest.java
@@ -25,7 +25,7 @@ class ConfigsDatabaseInitializerTest extends CommonDatabaseInitializerTest {
   @Test
   void testInitializingSchema() throws IOException {
     final var databaseAvailabilityCheck = mock(ConfigsDatabaseAvailabilityCheck.class);
-    final var initialSchema = MoreResources.readResource(DatabaseConstants.CONFIGS_SCHEMA_PATH);
+    final var initialSchema = MoreResources.readResource(DatabaseConstants.CONFIGS_INITIAL_SCHEMA_PATH);
     final var initializer = new ConfigsDatabaseInitializer(databaseAvailabilityCheck, dslContext, initialSchema);
 
     Assertions.assertDoesNotThrow(() -> initializer.initialize());
@@ -35,7 +35,7 @@ class ConfigsDatabaseInitializerTest extends CommonDatabaseInitializerTest {
   @Test
   void testInitializingSchemaAlreadyExists() throws IOException {
     final var databaseAvailabilityCheck = mock(ConfigsDatabaseAvailabilityCheck.class);
-    final var initialSchema = MoreResources.readResource(DatabaseConstants.CONFIGS_SCHEMA_PATH);
+    final var initialSchema = MoreResources.readResource(DatabaseConstants.CONFIGS_INITIAL_SCHEMA_PATH);
     dslContext.execute(initialSchema);
     final var initializer = new ConfigsDatabaseInitializer(databaseAvailabilityCheck, dslContext, initialSchema);
 
@@ -46,7 +46,7 @@ class ConfigsDatabaseInitializerTest extends CommonDatabaseInitializerTest {
   @Test
   void testInitializationException() throws IOException, DatabaseCheckException {
     final var databaseAvailabilityCheck = mock(ConfigsDatabaseAvailabilityCheck.class);
-    final var initialSchema = MoreResources.readResource(DatabaseConstants.CONFIGS_SCHEMA_PATH);
+    final var initialSchema = MoreResources.readResource(DatabaseConstants.CONFIGS_INITIAL_SCHEMA_PATH);
 
     doThrow(new DatabaseCheckException("test")).when(databaseAvailabilityCheck).check();
 

--- a/airbyte-db/db-lib/src/test/java/io/airbyte/db/init/impl/JobsDatabaseInitializerTest.java
+++ b/airbyte-db/db-lib/src/test/java/io/airbyte/db/init/impl/JobsDatabaseInitializerTest.java
@@ -25,7 +25,7 @@ class JobsDatabaseInitializerTest extends CommonDatabaseInitializerTest {
   @Test
   void testInitializingSchema() throws IOException {
     final var databaseAvailabilityCheck = mock(JobsDatabaseAvailabilityCheck.class);
-    final var initialSchema = MoreResources.readResource(DatabaseConstants.JOBS_SCHEMA_PATH);
+    final var initialSchema = MoreResources.readResource(DatabaseConstants.JOBS_INITIAL_SCHEMA_PATH);
     final var initializer = new JobsDatabaseInitializer(databaseAvailabilityCheck, dslContext, initialSchema);
 
     Assertions.assertDoesNotThrow(() -> initializer.initialize());
@@ -35,7 +35,7 @@ class JobsDatabaseInitializerTest extends CommonDatabaseInitializerTest {
   @Test
   void testInitializingSchemaAlreadyExists() throws IOException {
     final var databaseAvailabilityCheck = mock(JobsDatabaseAvailabilityCheck.class);
-    final var initialSchema = MoreResources.readResource(DatabaseConstants.JOBS_SCHEMA_PATH);
+    final var initialSchema = MoreResources.readResource(DatabaseConstants.JOBS_INITIAL_SCHEMA_PATH);
     dslContext.execute(initialSchema);
     final var initializer = new JobsDatabaseInitializer(databaseAvailabilityCheck, dslContext, initialSchema);
 
@@ -46,7 +46,7 @@ class JobsDatabaseInitializerTest extends CommonDatabaseInitializerTest {
   @Test
   void testInitializationException() throws IOException, DatabaseCheckException {
     final var databaseAvailabilityCheck = mock(JobsDatabaseAvailabilityCheck.class);
-    final var initialSchema = MoreResources.readResource(DatabaseConstants.JOBS_SCHEMA_PATH);
+    final var initialSchema = MoreResources.readResource(DatabaseConstants.JOBS_INITIAL_SCHEMA_PATH);
 
     doThrow(new DatabaseCheckException("test")).when(databaseAvailabilityCheck).check();
 
@@ -56,7 +56,7 @@ class JobsDatabaseInitializerTest extends CommonDatabaseInitializerTest {
 
   @Test
   void testInitializationNullAvailabilityCheck() throws IOException {
-    final var initialSchema = MoreResources.readResource(DatabaseConstants.JOBS_SCHEMA_PATH);
+    final var initialSchema = MoreResources.readResource(DatabaseConstants.JOBS_INITIAL_SCHEMA_PATH);
     final var initializer = new JobsDatabaseInitializer(null, dslContext, initialSchema);
     Assertions.assertThrows(DatabaseInitializationException.class, () -> initializer.initialize());
   }
@@ -64,7 +64,7 @@ class JobsDatabaseInitializerTest extends CommonDatabaseInitializerTest {
   @Test
   void testInitializationNullDslContext() throws IOException {
     final var databaseAvailabilityCheck = mock(JobsDatabaseAvailabilityCheck.class);
-    final var initialSchema = MoreResources.readResource(DatabaseConstants.JOBS_SCHEMA_PATH);
+    final var initialSchema = MoreResources.readResource(DatabaseConstants.JOBS_INITIAL_SCHEMA_PATH);
     final var initializer = new JobsDatabaseInitializer(databaseAvailabilityCheck, null, initialSchema);
     Assertions.assertThrows(DatabaseInitializationException.class, () -> initializer.initialize());
   }

--- a/airbyte-db/db-lib/src/test/java/io/airbyte/db/instance/configs/ConfigsDatabaseMigrationDevCenterTest.java
+++ b/airbyte-db/db-lib/src/test/java/io/airbyte/db/instance/configs/ConfigsDatabaseMigrationDevCenterTest.java
@@ -1,0 +1,29 @@
+/*
+ * Copyright (c) 2022 Airbyte, Inc., all rights reserved.
+ */
+
+package io.airbyte.db.instance.configs;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+import io.airbyte.commons.io.IOs;
+import io.airbyte.db.instance.DatabaseConstants;
+import io.airbyte.db.instance.development.MigrationDevCenter;
+import java.nio.file.Path;
+import org.junit.jupiter.api.Test;
+
+class ConfigsDatabaseMigrationDevCenterTest {
+
+  /**
+   * This test ensures that the dev center is working correctly end-to-end. If it fails, it means
+   * either the migration is not run properly, or the database initialization is incorrect in the dev
+   * center implementation.
+   */
+  @Test
+  void testSchemaDump() {
+    final MigrationDevCenter devCenter = new ConfigsDatabaseMigrationDevCenter();
+    final String schemaDump = IOs.readFile(Path.of(DatabaseConstants.CONFIGS_SCHEMA_DUMP_PATH));
+    assertEquals(schemaDump.trim(), devCenter.dumpSchema(false));
+  }
+
+}

--- a/airbyte-db/db-lib/src/test/java/io/airbyte/db/instance/configs/ConfigsDatabaseMigratorTest.java
+++ b/airbyte-db/db-lib/src/test/java/io/airbyte/db/instance/configs/ConfigsDatabaseMigratorTest.java
@@ -5,6 +5,7 @@
 package io.airbyte.db.instance.configs;
 
 import io.airbyte.db.factory.FlywayFactory;
+import io.airbyte.db.instance.DatabaseConstants;
 import io.airbyte.db.instance.DatabaseMigrator;
 import io.airbyte.db.instance.development.MigrationDevHelper;
 import java.io.IOException;
@@ -14,8 +15,6 @@ import org.junit.jupiter.api.Test;
 @SuppressWarnings("PMD.JUnitTestsShouldIncludeAssert")
 class ConfigsDatabaseMigratorTest extends AbstractConfigsDatabaseTest {
 
-  private static final String SCHEMA_DUMP_FILE = "src/main/resources/configs_database/schema_dump.txt";
-
   @Test
   void dumpSchema() throws IOException {
     final Flyway flyway = FlywayFactory.create(getDataSource(), getClass().getSimpleName(), ConfigsDatabaseMigrator.DB_IDENTIFIER,
@@ -23,7 +22,7 @@ class ConfigsDatabaseMigratorTest extends AbstractConfigsDatabaseTest {
     final DatabaseMigrator migrator = new ConfigsDatabaseMigrator(database, flyway);
     migrator.migrate();
     final String schema = migrator.dumpSchema();
-    MigrationDevHelper.dumpSchema(schema, SCHEMA_DUMP_FILE, false);
+    MigrationDevHelper.dumpSchema(schema, DatabaseConstants.CONFIGS_SCHEMA_DUMP_PATH, false);
   }
 
 }

--- a/airbyte-db/db-lib/src/test/java/io/airbyte/db/instance/jobs/JobsDatabaseMigrationDevCenterTest.java
+++ b/airbyte-db/db-lib/src/test/java/io/airbyte/db/instance/jobs/JobsDatabaseMigrationDevCenterTest.java
@@ -1,0 +1,28 @@
+/*
+ * Copyright (c) 2022 Airbyte, Inc., all rights reserved.
+ */
+
+package io.airbyte.db.instance.jobs;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+import io.airbyte.commons.io.IOs;
+import io.airbyte.db.instance.DatabaseConstants;
+import io.airbyte.db.instance.development.MigrationDevCenter;
+import java.nio.file.Path;
+import org.junit.jupiter.api.Test;
+
+class JobsDatabaseMigrationDevCenterTest {
+
+  /**
+   * This test ensures that the dev center is working correctly end-to-end. If it fails, it means
+   * either the migration is not run properly, or the database initialization is incorrect.
+   */
+  @Test
+  void testSchemaDump() {
+    final MigrationDevCenter devCenter = new JobsDatabaseMigrationDevCenter();
+    final String schemaDump = IOs.readFile(Path.of(DatabaseConstants.JOBS_SCHEMA_DUMP_PATH));
+    assertEquals(schemaDump.trim(), devCenter.dumpSchema(false));
+  }
+
+}

--- a/airbyte-db/db-lib/src/test/java/io/airbyte/db/instance/jobs/JobsDatabaseMigratorTest.java
+++ b/airbyte-db/db-lib/src/test/java/io/airbyte/db/instance/jobs/JobsDatabaseMigratorTest.java
@@ -5,6 +5,7 @@
 package io.airbyte.db.instance.jobs;
 
 import io.airbyte.db.factory.FlywayFactory;
+import io.airbyte.db.instance.DatabaseConstants;
 import io.airbyte.db.instance.DatabaseMigrator;
 import io.airbyte.db.instance.development.MigrationDevHelper;
 import java.io.IOException;
@@ -14,8 +15,6 @@ import org.junit.jupiter.api.Test;
 @SuppressWarnings("PMD.JUnitTestsShouldIncludeAssert")
 class JobsDatabaseMigratorTest extends AbstractJobsDatabaseTest {
 
-  private static final String SCHEMA_DUMP_FILE = "src/main/resources/jobs_database/schema_dump.txt";
-
   @Test
   void dumpSchema() throws IOException {
     final Flyway flyway = FlywayFactory.create(getDataSource(), getClass().getSimpleName(), JobsDatabaseMigrator.DB_IDENTIFIER,
@@ -23,7 +22,7 @@ class JobsDatabaseMigratorTest extends AbstractJobsDatabaseTest {
     final DatabaseMigrator migrator = new JobsDatabaseMigrator(database, flyway);
     migrator.migrate();
     final String schema = migrator.dumpSchema();
-    MigrationDevHelper.dumpSchema(schema, SCHEMA_DUMP_FILE, false);
+    MigrationDevHelper.dumpSchema(schema, DatabaseConstants.JOBS_SCHEMA_DUMP_PATH, false);
   }
 
 }


### PR DESCRIPTION
## What
- Follow up for #17697.
- The migration dev center should not run initialization scripts for both databases. This will pollute the configs schema dump with tables from the jobs database, and vice versa.
- The fix is to only run the initialization script for the specific db.
- Add unit tests to ensure that this won't happen in the future.
