### PR TITLE
:window: :tada: Load credits consumption separate

### DIFF
--- a/airbyte-webapp/src/packages/cloud/locales/en.json
+++ b/airbyte-webapp/src/packages/cloud/locales/en.json
@@ -130,6 +130,7 @@
   "credits.date": "Date",
   "credits.amount": "Credits",
 
+  "credits.loadingCreditsUsage": "Loading credits usage …",
   "credits.usagePerConnection": "Usage per connection",
   "credits.connection": "Connection",
   "credits.usage": "Usage",

--- a/airbyte-webapp/src/packages/cloud/views/credits/CreditsPage/CreditsPage.module.scss
+++ b/airbyte-webapp/src/packages/cloud/views/credits/CreditsPage/CreditsPage.module.scss
@@ -10,6 +10,7 @@
 
 .creditUsageLoading {
   display: flex;
+  flex-direction: column;
   gap: variables.$spacing-md;
   justify-content: center;
   align-items: center;

--- a/airbyte-webapp/src/packages/cloud/views/credits/CreditsPage/CreditsPage.module.scss
+++ b/airbyte-webapp/src/packages/cloud/views/credits/CreditsPage/CreditsPage.module.scss
@@ -7,3 +7,11 @@
 .emailVerificationHint {
   margin-bottom: variables.$spacing-md;
 }
+
+.creditUsageLoading {
+  display: flex;
+  gap: variables.$spacing-md;
+  justify-content: center;
+  align-items: center;
+  margin: variables.$spacing-2xl auto;
+}

--- a/airbyte-webapp/src/packages/cloud/views/credits/CreditsPage/CreditsPage.tsx
+++ b/airbyte-webapp/src/packages/cloud/views/credits/CreditsPage/CreditsPage.tsx
@@ -4,6 +4,8 @@ import { FormattedMessage } from "react-intl";
 import { HeadTitle } from "components/common/HeadTitle";
 import { MainPageWithScroll } from "components/common/MainPageWithScroll";
 import { PageHeader } from "components/ui/PageHeader";
+import { Spinner } from "components/ui/Spinner";
+import { Text } from "components/ui/Text";
 
 import { PageTrackingCodes, useTrackPage } from "hooks/services/Analytics";
 import { useAuthService } from "packages/cloud/services/auth/AuthService";
@@ -24,7 +26,18 @@ const CreditsPage: React.FC = () => {
       <div className={styles.content}>
         {!emailVerified && <EmailVerificationHint className={styles.emailVerificationHint} />}
         <RemainingCredits selfServiceCheckoutEnabled={emailVerified} />
-        <CreditsUsage />
+        <React.Suspense
+          fallback={
+            <div className={styles.creditUsageLoading}>
+              <Spinner small />
+              <Text>
+                <FormattedMessage id="credits.loadingCreditsUsage" />
+              </Text>
+            </div>
+          }
+        >
+          <CreditsUsage />
+        </React.Suspense>
       </div>
     </MainPageWithScroll>
   );


### PR DESCRIPTION
## What

The credits page currently loads really slow, because of the consumption queries and connector definition queries we need to execute for the chart and table on the bottom. We should though not block the upper part of the page allowing the user to see their remaining credits and buy new ones, on the slow part on the bottom. 

This PR wraps the bottom part in it's own React.Suspense, so its queries won't block the upper part:

![screenshot-20221104-212901](https://user-images.githubusercontent.com/877229/200069598-2c0fa1d8-ac3e-45c5-b25c-0d9d0654c709.png)
