### PR TITLE
🐛 Fix incorrect messages reversing in DestinationAcceptanceTest

### DIFF
--- a/airbyte-integrations/bases/standard-destination-test/src/main/java/io/airbyte/integrations/standardtest/destination/DestinationAcceptanceTest.java
+++ b/airbyte-integrations/bases/standard-destination-test/src/main/java/io/airbyte/integrations/standardtest/destination/DestinationAcceptanceTest.java
@@ -1217,8 +1217,9 @@ public abstract class DestinationAcceptanceTest {
     final List<AirbyteMessage> destinationOutput = runSync(config, messages, catalog,
         runNormalization);
 
-    Collections.reverse(messages);
-    final AirbyteMessage expectedStateMessage = messages
+    List<AirbyteMessage> copiedMessages = new ArrayList<>(messages);
+    Collections.reverse(copiedMessages);
+    final AirbyteMessage expectedStateMessage = copiedMessages
         .stream()
         .filter(m -> m.getType() == Type.STATE)
         .findFirst()


### PR DESCRIPTION
fix: messages List is reversed in runSyncAndVerifyStateOutput() method, causing some integration tests' failure

## What

in #18788, `MoreLists.reversed()` is removed, and `DestinationAcceptanceTest.runSyncAndVerifyStateOutput()` reverses message list by `Collections.reverse()`. It will change the order of origin message list, and causes some integration tests' failure.

For example, `DestinationAcceptanceTest.testSync()` reads test `messages`, and call `runSyncAndVerifyStateOutput()` to run sync:

```java
  @ParameterizedTest
  @ArgumentsSource(DataArgumentsProvider.class)
  public void testSync(final String messagesFilename, final String catalogFilename)
      throws Exception {
    /*......*/
    runSyncAndVerifyStateOutput(config, messages, configuredCatalog, false);
    retrieveRawRecordsAndAssertSameMessages(catalog, messages, defaultSchema);
  }
```
 
`messages`  is reversed in `runSyncAndVerifyStateOutput()`: 

```java
protected void runSyncAndVerifyStateOutput(final List<AirbyteMessage> messages, /*.....*/)
      throws Exception {
    /*......*/
    Collections.reverse(messages);
    /*......*/
}
```

and then `testSync()` call `retrieveRawRecordsAndAssertSameMessages()` with the reversed `messages`.


## How

in `runSyncAndVerifyStateOutput()`, clone `messages` and then reverse the cloned one, avoiding change the order of origin `messages`.

## Recommended reading order

1. `DestinationAcceptanceTest.java`

## 🚨 User Impact 🚨
no breaking changes.

## Pre-merge Checklist

this PR is not about connector, only small bug fix.

## Tests

<details><summary><strong>Unit</strong></summary>

*Put your unit tests output here.*

</details>

<details><summary><strong>Integration</strong></summary>

*Put your integration tests output here.*

</details>

<details><summary><strong>Acceptance</strong></summary>

*Put your acceptance tests output here.*

</details>
