### PR TITLE
🪟 🎉  Enable frontend validation for <1hr syncs (cloud)

### DIFF
--- a/airbyte-webapp/src/packages/cloud/App.tsx
+++ b/airbyte-webapp/src/packages/cloud/App.tsx
@@ -37,13 +37,7 @@ const Services: React.FC<React.PropsWithChildren<unknown>> = ({ children }) => (
         <ConfirmationModalService>
           <ModalServiceProvider>
             <FormChangeTrackerService>
-              <FeatureService
-                features={[
-                  FeatureItem.AllowOAuthConnector,
-                  FeatureItem.AllowSync,
-                  FeatureItem.AllowSyncSubOneHourCronExpressions,
-                ]}
-              >
+              <FeatureService features={[FeatureItem.AllowOAuthConnector, FeatureItem.AllowSync]}>
                 <AppServicesProvider>
                   <AuthenticationProvider>
                     <HelmetProvider>


### PR DESCRIPTION
## What
Disables sub 1hr syncs for cloud users

## How
This validation logic was already merged, but toggled off via the `FeatureItem.AllowSyncSubOneHourCronExpressions` flag. This PR removes this flag in production, except for a segment of cloud customers who need to sync more frequently than 1hr:

![image](https://user-images.githubusercontent.com/7550957/200315753-c1862981-e386-4ac2-ab64-4e0f7c066297.png)