### PR TITLE
ci: bump marketplace actions due to deprecations

### DIFF
--- a/.github/actions/build-and-push-branch/action.yml
+++ b/.github/actions/build-and-push-branch/action.yml
@@ -20,7 +20,7 @@ runs:
         branch_version_tag: ${{ inputs.branch_version_tag }}
 
     - name: Login to Docker (on Master)
-      uses: docker/login-action@v1
+      uses: docker/login-action@v2
       with:
         username: ${{ inputs.dockerhub_username }}
         password: ${{ inputs.dockerhub_token }}

--- a/.github/actions/build-branch/action.yml
+++ b/.github/actions/build-branch/action.yml
@@ -20,15 +20,16 @@ runs:
         [[ "${{ inputs.branch_version_tag }}" != '' ]] && echo "branch_version_tag=${{ inputs.branch_version_tag }}" >> $GITHUB_OUTPUT \
           || { short_hash=$(git rev-parse --short=10 HEAD); echo "branch_version_tag=dev-$short_hash" >> $GITHUB_OUTPUT ; }
 
-    - uses: actions/setup-java@v1
+    - uses: actions/setup-java@v3
       with:
+        distribution: "zulu"
         java-version: "17"
 
-    - uses: actions/setup-node@v2
+    - uses: actions/setup-node@v3
       with:
         node-version: "lts/gallium"
 
-    - uses: actions/setup-python@v2
+    - uses: actions/setup-python@v4
       with:
         python-version: "3.9"
 

--- a/.github/actions/cache-build-artifacts/action.yml
+++ b/.github/actions/cache-build-artifacts/action.yml
@@ -14,7 +14,7 @@ runs:
   steps:
     - name: Pip Caching
       if: ${{ inputs.cache_python }} == 'true'
-      uses: actions/cache@v2
+      uses: actions/cache@v3
       with:
         path: |
           ~/.cache/pip
@@ -23,7 +23,7 @@ runs:
           ${{ inputs.cache-key }}-pip-${{ runner.os }}-
 
     - name: Npm Caching
-      uses: actions/cache@v2
+      uses: actions/cache@v3
       with:
         path: |
           ~/.npm
@@ -33,7 +33,7 @@ runs:
 
     # this intentionally does not use restore-keys so we don't mess with gradle caching
     - name: Gradle and Python Caching
-      uses: actions/cache@v2
+      uses: actions/cache@v3
       with:
         path: |
           ~/.gradle/caches

--- a/.github/actions/ci-tests-runner/action.yml
+++ b/.github/actions/ci-tests-runner/action.yml
@@ -27,13 +27,14 @@ runs:
   using: "composite"
   steps:
     - name: Set up Python
-      uses: actions/setup-python@v2
+      uses: actions/setup-python@v4
       with:
         python-version: 3.9
 
     - name: Install Java
-      uses: actions/setup-java@v1
+      uses: actions/setup-java@v3
       with:
+        distribution: "zulu"
         java-version: "17"
 
     - name: Tests of CI

--- a/.github/workflows/build-report.yml
+++ b/.github/workflows/build-report.yml
@@ -18,7 +18,7 @@ jobs:
     environment: more-secrets
     steps:
       - name: Checkout Airbyte
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
       - name: Install dependencies
         run: |
           python -m pip install --upgrade pip

--- a/.github/workflows/commands-for-testing-tool.yml
+++ b/.github/workflows/commands-for-testing-tool.yml
@@ -14,7 +14,7 @@ jobs:
       command: ${{ steps.regex.outputs.first_match }}
     steps:
       - name: Checkout Airbyte
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
       - name: Check PAT rate limits
         run: |
           ./tools/bin/find_non_rate_limited_PAT \
@@ -97,7 +97,7 @@ jobs:
           comment-id: ${{ needs.set-params.outputs.comment-id }}
           reactions: eyes, rocket
       - name: Checkout Airbyte
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
         with:
           repository: ${{  needs.set-params.outputs.repo }}
           ref: ${{  needs.set-params.outputs.ref }}

--- a/.github/workflows/connector_integration_tests.yml
+++ b/.github/workflows/connector_integration_tests.yml
@@ -6,7 +6,7 @@ on:
   workflow_dispatch:
   schedule:
     # 11am UTC is 4am PDT.
-    - cron: '0 11 * * *'
+    - cron: "0 11 * * *"
 
 jobs:
   launch_integration_tests:
@@ -15,11 +15,12 @@ jobs:
     if: github.ref == 'refs/heads/master'
     steps:
       - name: Checkout Airbyte
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
       - name: Install Java
-        uses: actions/setup-java@v1
+        uses: actions/setup-java@v3
         with:
-          java-version: '17'
+          distribution: "zulu"
+          java-version: "17"
       - name: Install dependencies
         run: |
           python -m pip install --upgrade pip

--- a/.github/workflows/create-release.yml
+++ b/.github/workflows/create-release.yml
@@ -57,7 +57,7 @@ jobs:
           echo -e "$CHANGELOG" >> $GITHUB_ENV
           echo "EOF" >> $GITHUB_ENV
       - name: Checkout Airbyte
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
       - name: Get Version
         id: get_version
         shell: bash

--- a/.github/workflows/deploy-docs-site.yml
+++ b/.github/workflows/deploy-docs-site.yml
@@ -5,7 +5,7 @@ on:
     branches:
       - master
     paths:
-      - 'docs/**'
+      - "docs/**"
 
   # Allows you to run this workflow manually from the Actions tab
   workflow_dispatch:
@@ -23,10 +23,10 @@ jobs:
 
       # Node.js is needed for Yarn
       - name: Setup Yarn
-        uses: actions/setup-node@v2
+        uses: actions/setup-node@v3
         with:
-          node-version: '16.14.0'
-          cache: 'yarn'
+          node-version: "16.14.0"
+          cache: "yarn"
           cache-dependency-path: docusaurus
 
       - name: Run Docusaurus

--- a/.github/workflows/deploy-oss-catalog.yml
+++ b/.github/workflows/deploy-oss-catalog.yml
@@ -4,7 +4,7 @@ on:
   push:
     branches:
       - master
-    paths: 
+    paths:
       - airbyte-config/init/src/main/resources/seed/**
 
   workflow_dispatch:
@@ -17,15 +17,16 @@ jobs:
     concurrency: deploy-oss-connector-catalog
     steps:
       - name: Checkout Airbyte
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
       - name: Setup Cloud SDK
         uses: google-github-actions/setup-gcloud@v0
         with:
           service_account_key: ${{ secrets.PROD_SPEC_CACHE_SA_KEY }}
           export_default_credentials: true
       - name: Install Java
-        uses: actions/setup-java@v1
+        uses: actions/setup-java@v3
         with:
+          disribution: "zulu"
           java-version: "17"
       - name: Generate catalog
         run: SUB_BUILD=PLATFORM ./gradlew :airbyte-config:init:processResources

--- a/.github/workflows/fe-validate-links.yml
+++ b/.github/workflows/fe-validate-links.yml
@@ -3,7 +3,7 @@ name: Check for broken links in FE
 on:
   workflow_dispatch:
   schedule:
-    - cron:  '0 14 * * *'
+    - cron: "0 14 * * *"
 
 jobs:
   validate-frontend-links:
@@ -12,13 +12,14 @@ jobs:
     timeout-minutes: 15
     steps:
       - name: Checkout Airbyte
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
 
-      - uses: actions/setup-java@v1
+      - uses: actions/setup-java@v3
         with:
+          distribution: "zulu"
           java-version: "17"
 
-      - uses: actions/setup-node@v2
+      - uses: actions/setup-node@v3
         with:
           node-version: "lts/gallium"
 

--- a/.github/workflows/gke-kube-test-command.yml
+++ b/.github/workflows/gke-kube-test-command.yml
@@ -1,7 +1,7 @@
 name: GKE Kube Acceptance Test
 on:
   schedule:
-    - cron: '0 0 * * 0' # runs at midnight UTC every Sunday
+    - cron: "0 0 * * 0" # runs at midnight UTC every Sunday
   workflow_dispatch:
     inputs:
       repo:
@@ -25,7 +25,7 @@ jobs:
       pat: ${{ steps.variables.outputs.pat }}
     steps:
       - name: Checkout Airbyte
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
       - name: Check PAT rate limits
         id: variables
         run: |
@@ -44,7 +44,7 @@ jobs:
       ec2-instance-id: ${{ steps.start-ec2-runner.outputs.ec2-instance-id }}
     steps:
       - name: Checkout Airbyte
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
         with:
           repository: ${{ github.event.inputs.repo }}
           ref: ${{ github.event.inputs.gitref }}
@@ -71,16 +71,17 @@ jobs:
             > :clock2: https://github.com/${{github.repository}}/actions/runs/${{github.run_id}}
 
       - name: Checkout Airbyte
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
         with:
           repository: ${{ github.event.inputs.repo || "airbytehq/airbyte" }}
           ref: ${{ github.event.inputs.gitref || "master" }}
 
-      - uses: actions/setup-java@v1
+      - uses: actions/setup-java@v3
         with:
+          distribution: "zulu"
           java-version: "17"
 
-      - uses: actions/setup-node@v2
+      - uses: actions/setup-node@v3
         with:
           node-version: "lts/gallium"
 

--- a/.github/workflows/gradle.yml
+++ b/.github/workflows/gradle.yml
@@ -17,7 +17,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout Airbyte
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
 
       - name: Check images exist
         run: ./tools/bin/check_images_exist.sh all
@@ -39,7 +39,7 @@ jobs:
       frontend: ${{ steps.filter.outputs.frontend }}
     steps:
       - name: Checkout Airbyte
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
       - uses: dorny/paths-filter@v2
         id: filter
         with:
@@ -76,7 +76,7 @@ jobs:
       pat: ${{ steps.variables.outputs.pat }}
     steps:
       - name: Checkout Airbyte
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
       - name: Check PAT rate limits
         id: variables
         run: |
@@ -92,7 +92,7 @@ jobs:
   #    needs: changes
   #    runs-on: ubuntu-latest
   #    steps:
-  #      - uses: actions/checkout@v2
+  #      - uses: actions/checkout@v3
   #      - run: |
   #          echo '${{ toJSON(needs) }}'
 
@@ -106,7 +106,7 @@ jobs:
     timeout-minutes: 90
     steps:
       - name: Checkout Airbyte
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
 
       - name: Cache Build Artifacts
         uses: ./.github/actions/cache-build-artifacts
@@ -114,11 +114,12 @@ jobs:
           cache-key: ${{ secrets.CACHE_VERSION }}
           cache-python: "false"
 
-      - uses: actions/setup-java@v1
+      - uses: actions/setup-java@v3
         with:
+          distribution: "zulu"
           java-version: "17"
 
-      - uses: actions/setup-python@v2
+      - uses: actions/setup-python@v4
         with:
           python-version: "3.9"
 
@@ -169,7 +170,7 @@ jobs:
       ec2-instance-id: ${{ steps.start-ec2-runner.outputs.ec2-instance-id }}
     steps:
       - name: Checkout Airbyte
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
       - name: Start AWS Runner
         id: start-ec2-runner
         uses: ./.github/actions/start-aws-runner
@@ -186,22 +187,23 @@ jobs:
     timeout-minutes: 90
     steps:
       - name: Checkout Airbyte
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
 
       - name: Cache Build Artifacts
         uses: ./.github/actions/cache-build-artifacts
         with:
           cache-key: ${{ secrets.CACHE_VERSION }}
 
-      - uses: actions/setup-java@v1
+      - uses: actions/setup-java@v3
         with:
+          distribution: "zulu"
           java-version: "17"
 
-      - uses: actions/setup-node@v2
+      - uses: actions/setup-node@v3
         with:
           node-version: "lts/gallium"
 
-      - uses: actions/setup-python@v2
+      - uses: actions/setup-python@v4
         with:
           python-version: "3.9"
 
@@ -322,7 +324,7 @@ jobs:
       ec2-instance-id: ${{ steps.start-ec2-runner.outputs.ec2-instance-id }}
     steps:
       - name: Checkout Airbyte
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
       - name: Start AWS Runner
         id: start-ec2-runner
         uses: ./.github/actions/start-aws-runner
@@ -338,7 +340,7 @@ jobs:
     runs-on: ${{ needs.start-frontend-runner.outputs.label }}
     steps:
       - name: Checkout Airbyte
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
         with:
           fetch-depth: 0
 
@@ -348,15 +350,16 @@ jobs:
           cache-key: ${{ secrets.CACHE_VERSION }}
           cache-python: "false"
 
-      - uses: actions/setup-java@v1
+      - uses: actions/setup-java@v3
         with:
+          distribution: "zulu"
           java-version: "17"
 
-      - uses: actions/setup-node@v2
+      - uses: actions/setup-node@v3
         with:
           node-version: "lts/gallium"
 
-      - uses: actions/setup-python@v2
+      - uses: actions/setup-python@v4
         with:
           python-version: "3.9"
 
@@ -394,7 +397,7 @@ jobs:
     timeout-minutes: 120
     steps:
       - name: Checkout Airbyte
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
 
       - name: Cache Build Artifacts
         uses: ./.github/actions/cache-build-artifacts
@@ -402,15 +405,16 @@ jobs:
           cache-key: ${{ secrets.CACHE_VERSION }}
           cache-python: "false"
 
-      - uses: actions/setup-java@v1
+      - uses: actions/setup-java@v3
         with:
+          distribution: "zulu"
           java-version: "17"
 
-      - uses: actions/setup-node@v2
+      - uses: actions/setup-node@v3
         with:
           node-version: "lts/gallium"
 
-      - uses: actions/setup-python@v2
+      - uses: actions/setup-python@v4
         with:
           python-version: "3.9"
 
@@ -480,7 +484,7 @@ jobs:
       ec2-instance-id: ${{ steps.start-ec2-runner.outputs.ec2-instance-id }}
     steps:
       - name: Checkout Airbyte
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
       - name: Start AWS Runner
         id: start-ec2-runner
         uses: ./.github/actions/start-aws-runner
@@ -496,7 +500,7 @@ jobs:
     timeout-minutes: 90
     steps:
       - name: Checkout Airbyte
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
 
       - name: Cache Build Artifacts
         uses: ./.github/actions/cache-build-artifacts
@@ -504,15 +508,16 @@ jobs:
           cache-key: ${{ secrets.CACHE_VERSION }}
           cache-python: "false"
 
-      - uses: actions/setup-java@v1
+      - uses: actions/setup-java@v3
         with:
+          distribution: "zulu"
           java-version: "17"
 
-      - uses: actions/setup-python@v2
+      - uses: actions/setup-python@v4
         with:
           python-version: "3.9"
 
-      - uses: actions/setup-node@v2
+      - uses: actions/setup-node@v3
         with:
           node-version: "lts/gallium"
 
@@ -566,7 +571,7 @@ jobs:
       - name: Automatic Migration Acceptance Test
         run: SUB_BUILD=PLATFORM ./gradlew :airbyte-tests:automaticMigrationAcceptanceTest --scan -i
 
-      - uses: actions/setup-python@v2
+      - uses: actions/setup-python@v4
         if: always()
         with:
           python-version: "3.9"
@@ -620,6 +625,7 @@ jobs:
           path: "/actions-runner/_work/airbyte/airbyte/*"
           key: ${{ secrets.BUILDPULSE_ACCESS_KEY_ID }}
           secret: ${{ secrets.BUILDPULSE_SECRET_ACCESS_KEY }}
+
   # In case of self-hosted EC2 errors, remove this block.
   stop-platform-build-runner:
     name: "Platform: Stop Build EC2 Runner"
@@ -664,7 +670,7 @@ jobs:
       ec2-instance-id: ${{ steps.start-ec2-runner.outputs.ec2-instance-id }}
     steps:
       - name: Checkout Airbyte
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
       - name: Start AWS Runner
         id: start-ec2-runner
         uses: ./.github/actions/start-aws-runner
@@ -683,7 +689,7 @@ jobs:
     timeout-minutes: 40
     steps:
       - name: Checkout Airbyte
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
 
       - name: Cache Build Artifacts
         uses: ./.github/actions/cache-build-artifacts
@@ -691,15 +697,16 @@ jobs:
           cache-key: ${{ secrets.CACHE_VERSION }}
           cache-python: "false"
 
-      - uses: actions/setup-java@v1
+      - uses: actions/setup-java@v3
         with:
+          distribution: "zulu"
           java-version: "17"
 
-      - uses: actions/setup-node@v2
+      - uses: actions/setup-node@v3
         with:
           node-version: "lts/gallium"
 
-      - uses: actions/setup-python@v2
+      - uses: actions/setup-python@v4
         with:
           python-version: "3.9"
 
@@ -755,7 +762,7 @@ jobs:
         run: |
           CI=true IS_MINIKUBE=true ./tools/bin/acceptance_test_kube.sh
 
-      - uses: actions/setup-python@v2
+      - uses: actions/setup-python@v4
         if: always()
         with:
           python-version: "3.9"
@@ -808,7 +815,8 @@ jobs:
           path: "/actions-runner/_work/airbyte/airbyte/*"
           key: ${{ secrets.BUILDPULSE_ACCESS_KEY_ID }}
           secret: ${{ secrets.BUILDPULSE_SECRET_ACCESS_KEY }}
-      - uses: actions/upload-artifact@v2
+
+      - uses: actions/upload-artifact@v3
         if: failure()
         with:
           name: Kubernetes Logs
@@ -860,7 +868,7 @@ jobs:
   #     ec2-instance-id: ${{ steps.start-ec2-runner.outputs.ec2-instance-id }}
   #   steps:
   #     - name: Checkout Airbyte
-  #       uses: actions/checkout@v2
+  #       uses: actions/checkout@v3
   #     - name: Start AWS Runner
   #       id: start-ec2-runner
   #       uses: ./.github/actions/start-aws-runner
@@ -881,7 +889,7 @@ jobs:
   #    timeout-minutes: 90
   #    steps:
   #      - name: Checkout Airbyte
-  #        uses: actions/checkout@v2
+  #        uses: actions/checkout@v3
   #
   #      - name: Cache Build Artifacts
   #        uses: ./.github/actions/cache-build-artifacts
@@ -889,11 +897,12 @@ jobs:
   #          cache-key: ${{ secrets.CACHE_VERSION }}
   #          cache-python: "false"
   #
-  #      - uses: actions/setup-java@v1
+  #      - uses: actions/setup-java@v3
   #        with:
+  #          distribution: "zulu"
   #          java-version: "17"
   #
-  #      - uses: actions/setup-node@v2
+  #      - uses: actions/setup-node@v3
   #        with:
   #          node-version: "lts/gallium"
   #
@@ -959,7 +968,7 @@ jobs:
   #        run: |
   #          CI=true IS_MINIKUBE=true ./tools/bin/acceptance_test_kube_helm.sh
   #
-  #      - uses: actions/upload-artifact@v2
+  #      - uses: actions/upload-artifact@v3
   #        if: failure()
   #        with:
   #          name: Kubernetes Logs

--- a/.github/workflows/label-github-issues-by-context.yml
+++ b/.github/workflows/label-github-issues-by-context.yml
@@ -9,7 +9,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout Airbyte Repo for PAT command
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
       - name: Check PAT rate limits
         # Cannot share PAT outside of JOB context
         run: |

--- a/.github/workflows/label-prs-by-context.yml
+++ b/.github/workflows/label-prs-by-context.yml
@@ -11,7 +11,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout Airbyte Repo for PAT command
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
       - name: Check PAT rate limits
         # Cannot share PAT outside of JOB context
         run: |

--- a/.github/workflows/notify-on-label.yml
+++ b/.github/workflows/notify-on-label.yml
@@ -4,7 +4,7 @@ name: Notify FE team for FE label on issues
 
 on:
   issues:
-      types: [labeled]
+    types: [labeled]
 
 jobs:
   notify:
@@ -12,7 +12,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout Airbyte Repo for PAT command
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
       - name: Check PAT rate limits
         # Cannot share PAT outside of JOB context
         run: |
@@ -24,7 +24,7 @@ jobs:
         uses: jenschelkopf/issue-label-notification-action@1.3
         with:
           token: "${{ env.PAT }}"
-          message: 'cc {recipients}'
+          message: "cc {recipients}"
           # Specify a map of label -> team/user to notify
           recipients: |
             team/frontend=@airbytehq/frontend

--- a/.github/workflows/notify-on-push-to-master.yml
+++ b/.github/workflows/notify-on-push-to-master.yml
@@ -4,14 +4,14 @@ on:
     branches:
       - master
   workflow_dispatch:
-      
+
 jobs:
   repo-sync:
     name: "Fire a Repo Dispatch event to airbyte-cloud"
     runs-on: ubuntu-latest
     steps:
       - name: Checkout Airbyte Repo for PAT command
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
       - name: Check PAT rate limits
         # Cannot share PAT outside of JOB context
         run: |

--- a/.github/workflows/publish-cdk-command.yml
+++ b/.github/workflows/publish-cdk-command.yml
@@ -24,14 +24,15 @@ jobs:
       matrix:
         python-version: ["3.9"]
     steps:
-      - uses: actions/setup-python@v2
+      - uses: actions/setup-python@v4
         with:
           python-version: ${{ matrix.python-version }}
-      - uses: actions/setup-java@v1
+      - uses: actions/setup-java@v3
         with:
+          distribution: "zulu"
           java-version: "17"
       - name: Checkout Airbyte
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
         with:
           repository: ${{ github.event.inputs.repo }}
           ref: ${{ github.event.inputs.gitref }}
@@ -64,7 +65,7 @@ jobs:
           echo ${{ github.event.inputs.dry-run }}
           echo "pypi_url=https://test.pypi.org/legacy/" >> $GITHUB_ENV
       - name: Checkout Airbyte
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
         with:
           repository: ${{ github.event.inputs.repo }}
           ref: ${{ github.event.inputs.gitref }}

--- a/.github/workflows/publish-command.yml
+++ b/.github/workflows/publish-command.yml
@@ -38,7 +38,7 @@ jobs:
       pat: ${{ steps.variables.outputs.pat }}
     steps:
       - name: Checkout Airbyte
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
       - name: Check PAT rate limits
         id: variables
         run: |
@@ -58,7 +58,7 @@ jobs:
       ec2-instance-id: ${{ steps.start-ec2-runner.outputs.ec2-instance-id }}
     steps:
       - name: Checkout Airbyte
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
         with:
           repository: ${{ github.event.inputs.repo }}
           ref: ${{ github.event.inputs.gitref }}
@@ -80,7 +80,7 @@ jobs:
       ec2-instance-id: ${{ steps.start-ec2-runner.outputs.ec2-instance-id }}
     steps:
       - name: Checkout Airbyte
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
         with:
           repository: ${{ github.event.inputs.repo }}
           ref: ${{ github.event.inputs.gitref }}
@@ -102,7 +102,7 @@ jobs:
       ec2-instance-id: ${{ steps.start-ec2-runner.outputs.ec2-instance-id }}
     steps:
       - name: Checkout Airbyte
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
         with:
           repository: ${{ github.event.inputs.repo }}
           ref: ${{ github.event.inputs.gitref }}
@@ -124,7 +124,7 @@ jobs:
       ec2-instance-id: ${{ steps.start-ec2-runner.outputs.ec2-instance-id }}
     steps:
       - name: Checkout Airbyte
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
         with:
           repository: ${{ github.event.inputs.repo }}
           ref: ${{ github.event.inputs.gitref }}
@@ -146,7 +146,7 @@ jobs:
       ec2-instance-id: ${{ steps.start-ec2-runner.outputs.ec2-instance-id }}
     steps:
       - name: Checkout Airbyte
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
         with:
           repository: ${{ github.event.inputs.repo }}
           ref: ${{ github.event.inputs.gitref }}
@@ -233,17 +233,18 @@ jobs:
         if: steps.regex.outputs.first_match != matrix.connector
         run: echo "The connector provided has an invalid format!" && exit 1
       - name: Checkout Airbyte
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
         with:
           repository: ${{ github.event.inputs.repo }}
           ref: ${{ github.event.inputs.gitref }}
           token: ${{ secrets.OCTAVIA_PAT }}
       - name: Install Java
-        uses: actions/setup-java@v1
+        uses: actions/setup-java@v3
         with:
+          distribution: "zulu"
           java-version: "17"
       - name: Install Python
-        uses: actions/setup-python@v2
+        uses: actions/setup-python@v4
         with:
           python-version: "3.9"
       - name: Install Pyenv and Tox

--- a/.github/workflows/publish-connector-command.yml
+++ b/.github/workflows/publish-connector-command.yml
@@ -34,7 +34,7 @@ jobs:
       pat: ${{ steps.variables.outputs.pat }}
     steps:
       - name: Checkout Airbyte
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
       - name: Check PAT rate limits
         id: variables
         run: |
@@ -55,7 +55,7 @@ jobs:
 #      ec2-instance-id: ${{ steps.start-ec2-runner.outputs.ec2-instance-id }}
 #    steps:
 #      - name: Checkout Airbyte
-#        uses: actions/checkout@v2
+#        uses: actions/checkout@v3
 #        with:
 #          repository: ${{ github.event.inputs.repo }}
 #          ref: ${{ github.event.inputs.gitref }}
@@ -99,17 +99,18 @@ jobs:
 #          body: |
 #            > :clock2: ${{github.event.inputs.connector}} https://github.com/${{github.repository}}/actions/runs/${{github.run_id}}
 #      - name: Checkout Airbyte
-#        uses: actions/checkout@v2
+#        uses: actions/checkout@v3
 #        with:
 #          repository: ${{ github.event.inputs.repo }}
 #          ref: ${{ github.event.inputs.gitref }}
 #          token: ${{ secrets.OCTAVIA_PAT }}
 #      - name: Install Java
-#        uses: actions/setup-java@v1
+#        uses: actions/setup-java@v3
 #        with:
+#          distribution: "zulu"
 #          java-version: "17"
 #      - name: Install Python
-#        uses: actions/setup-python@v2
+#        uses: actions/setup-python@v4
 #        with:
 #          python-version: "3.9"
 #      - name: Install Pyenv and Tox

--- a/.github/workflows/publish-helm-charts.yml
+++ b/.github/workflows/publish-helm-charts.yml
@@ -21,7 +21,7 @@ jobs:
       next-version: ${{ steps.ver.outputs.fragment }}
       tag: ${{ steps.sem-ver.outputs.version_tag }}
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
         with:
           fetch-depth: 0
 

--- a/.github/workflows/publish-oss-for-cloud.yml
+++ b/.github/workflows/publish-oss-for-cloud.yml
@@ -17,7 +17,7 @@ jobs:
       pat: ${{ steps.variables.outputs.pat }}
     steps:
       - name: Checkout Airbyte
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
       - name: Check PAT rate limits
         id: variables
         run: |
@@ -36,7 +36,7 @@ jobs:
       ec2-instance-id: ${{ steps.start-ec2-runner.outputs.ec2-instance-id }}
     steps:
       - name: Checkout Airbyte
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
       - name: Start AWS Runner
         id: start-ec2-runner
         uses: ./.github/actions/start-aws-runner
@@ -53,7 +53,7 @@ jobs:
       master_tag: ${{ steps.set-outputs.outputs.master_tag }}
     steps:
       - name: Checkout Airbyte
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
         with:
           ref: ${{ github.event.inputs.oss_ref || github.ref }}
       - name: Generate Outputs
@@ -83,7 +83,7 @@ jobs:
     environment: more-secrets
     steps:
       - name: Checkout Airbyte
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
         with:
           ref: ${{ github.event.inputs.oss_ref || github.ref }}
 
@@ -116,7 +116,7 @@ jobs:
     runs-on: ${{ needs.start-runner.outputs.label }}
     steps:
       - name: Login to Docker (on Master)
-        uses: docker/login-action@v1
+        uses: docker/login-action@v2
         with:
           username: ${{ secrets.DOCKER_HUB_USERNAME }}
           password: ${{ secrets.DOCKER_HUB_PASSWORD }}

--- a/.github/workflows/release-airbyte-os.yml
+++ b/.github/workflows/release-airbyte-os.yml
@@ -17,7 +17,7 @@ jobs:
       pat: ${{ steps.variables.outputs.pat }}
     steps:
       - name: Checkout Airbyte
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
       - name: Check PAT rate limits
         id: variables
         run: |
@@ -37,7 +37,7 @@ jobs:
       ec2-instance-id: ${{ steps.start-ec2-runner.outputs.ec2-instance-id }}
     steps:
       - name: Checkout Airbyte
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
       - name: Start AWS Runner
         id: start-ec2-runner
         uses: ./.github/actions/start-aws-runner
@@ -53,18 +53,19 @@ jobs:
     environment: more-secrets
     steps:
       - name: Checkout
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
         with:
           fetch-depth: 0
-      - uses: actions/setup-java@v1
+      - uses: actions/setup-java@v3
         with:
+          distribution: "zulu"
           java-version: "17"
 
-      - uses: actions/setup-node@v2
+      - uses: actions/setup-node@v3
         with:
           node-version: "lts/gallium"
       # necessary to install pip
-      - uses: actions/setup-python@v2
+      - uses: actions/setup-python@v4
         with:
           python-version: "3.9"
       - name: Release Airbyte
@@ -85,17 +86,18 @@ jobs:
     environment: more-secrets
     steps:
       - name: Checkout
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
         with:
           fetch-depth: 0
-      - uses: actions/setup-java@v1
+      - uses: actions/setup-java@v3
         with:
+          distribution: "zulu"
           java-version: "17"
 
-      - uses: actions/setup-node@v2
+      - uses: actions/setup-node@v3
         with:
           node-version: "lts/gallium"
-      - uses: actions/setup-python@v2
+      - uses: actions/setup-python@v4
         with:
           python-version: "3.9"
       - name: Release Octavia
@@ -114,11 +116,11 @@ jobs:
     environment: more-secrets
     steps:
       - name: Checkout
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
         with:
           fetch-depth: 0
       # necessary to install pip
-      - uses: actions/setup-python@v2
+      - uses: actions/setup-python@v4
         with:
           python-version: "3.9"
       - name: Bump version

--- a/.github/workflows/run-performance-test.yml
+++ b/.github/workflows/run-performance-test.yml
@@ -22,13 +22,13 @@ jobs:
     environment: more-secrets
     steps:
       - name: Checkout Airbyte
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
         with:
           repository: ${{ github.event.inputs.repo }}
           ref: ${{ github.event.inputs.gitref }}
 
       - name: Npm Caching
-        uses: actions/cache@v2
+        uses: actions/cache@v3
         with:
           path: |
             ~/.npm
@@ -38,7 +38,7 @@ jobs:
 
       # this intentionally does not use restore-keys so we don't mess with gradle caching
       - name: Gradle Caching
-        uses: actions/cache@v2
+        uses: actions/cache@v3
         with:
           path: |
             ~/.gradle/caches
@@ -46,13 +46,14 @@ jobs:
             **/.venv
           key: ${{ secrets.CACHE_VERSION }}-${{ runner.os }}-${{ hashFiles('**/*.gradle*') }}-${{ hashFiles('**/package-lock.json') }}
 
-      - uses: actions/setup-java@v1
+      - uses: actions/setup-java@v3
         with:
-          java-version: '14'
+          distribution: "zulu"
+          java-version: "14"
 
-      - uses: actions/setup-node@v2
+      - uses: actions/setup-node@v3
         with:
-          node-version: 'lts/gallium'
+          node-version: "lts/gallium"
 
       - name: Build
         id: run-specific-test

--- a/.github/workflows/slash-commands.yml
+++ b/.github/workflows/slash-commands.yml
@@ -9,7 +9,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout Airbyte
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
 
       - name: Check PAT rate limits
         run: |

--- a/.github/workflows/terminate-zombie-build-instances.yml
+++ b/.github/workflows/terminate-zombie-build-instances.yml
@@ -41,7 +41,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout Airbyte
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
       - name: List and Terminate GH actions in status 'offline'
         env:
           GITHUB_PAT: ${{ secrets.OCTAVIA_PAT }}

--- a/.github/workflows/test-command.yml
+++ b/.github/workflows/test-command.yml
@@ -31,7 +31,7 @@ jobs:
       - name: UUID ${{ github.event.inputs.uuid }}
         run: true
       - name: Checkout Airbyte
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
       - name: Check PAT rate limits
         id: variables
         run: |
@@ -50,7 +50,7 @@ jobs:
       ec2-instance-id: ${{ steps.start-ec2-runner.outputs.ec2-instance-id }}
     steps:
       - name: Checkout Airbyte
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
         with:
           repository: ${{ github.event.inputs.repo }}
           ref: ${{ github.event.inputs.gitref }}
@@ -87,16 +87,17 @@ jobs:
         if: steps.regex.outputs.first_match != github.event.inputs.connector
         run: echo "The connector provided has an invalid format!" && exit 1
       - name: Checkout Airbyte
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
         with:
           repository: ${{ github.event.inputs.repo }}
           ref: ${{ github.event.inputs.gitref }}
       - name: Install Java
-        uses: actions/setup-java@v1
+        uses: actions/setup-java@v3
         with:
+          distribution: "zulu"
           java-version: "17"
       - name: Install Python
-        uses: actions/setup-python@v2
+        uses: actions/setup-python@v4
         with:
           python-version: "3.9"
       - name: Install Pyenv and Tox
@@ -134,7 +135,7 @@ jobs:
           TZ: UTC
       - name: Archive test reports artifacts
         if: github.event.inputs.comment-id && failure()
-        uses: actions/upload-artifact@v2
+        uses: actions/upload-artifact@v3
         with:
           name: test-reports
           path: |
@@ -148,7 +149,7 @@ jobs:
 
       - name: Test coverage reports artifacts
         if: github.event.inputs.comment-id && success()
-        uses: actions/upload-artifact@v2
+        uses: actions/upload-artifact@v3
         with:
           name: test-reports
           path: |

--- a/.github/workflows/test-performance-command.yml
+++ b/.github/workflows/test-performance-command.yml
@@ -34,7 +34,7 @@ jobs:
       pat: ${{ steps.variables.outputs.pat }}
     steps:
       - name: Checkout Airbyte
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
       - name: Check PAT rate limits
         id: variables
         run: |
@@ -53,7 +53,7 @@ jobs:
       ec2-instance-id: ${{ steps.start-ec2-runner.outputs.ec2-instance-id }}
     steps:
       - name: Checkout Airbyte
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
         with:
           repository: ${{ github.event.inputs.repo }}
           ref: ${{ github.event.inputs.gitref }}
@@ -90,16 +90,17 @@ jobs:
           body: |
             > :clock2: ${{github.event.inputs.connector}} https://github.com/${{github.repository}}/actions/runs/${{github.run_id}}
       - name: Checkout Airbyte
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
         with:
           repository: ${{ github.event.inputs.repo }}
           ref: ${{ github.event.inputs.gitref }}
       - name: Install Java
-        uses: actions/setup-java@v1
+        uses: actions/setup-java@v3
         with:
+          distribution: "zulu"
           java-version: "17"
       - name: Install Python
-        uses: actions/setup-python@v2
+        uses: actions/setup-python@v4
         with:
           python-version: "3.9"
       - name: Install Pyenv and Tox
@@ -136,7 +137,7 @@ jobs:
           TZ: UTC
       - name: Archive test reports artifacts
         if: github.event.inputs.comment-id && failure()
-        uses: actions/upload-artifact@v2
+        uses: actions/upload-artifact@v3
         with:
           name: test-reports
           path: |
@@ -150,7 +151,7 @@ jobs:
 
       - name: Test coverage reports artifacts
         if: github.event.inputs.comment-id && success()
-        uses: actions/upload-artifact@v2
+        uses: actions/upload-artifact@v3
         with:
           name: test-reports
           path: |

--- a/.github/workflows/workflow-cleanup.yml
+++ b/.github/workflows/workflow-cleanup.yml
@@ -1,34 +1,33 @@
 name: Cleanup old GH workflow runs
 
-on: 
+on:
   schedule:
-    - cron: '0 12 * * *' # runs at 12:00 UTC everyday
+    - cron: "0 12 * * *" # runs at 12:00 UTC everyday
 
 jobs:
   build:
     runs-on: ubuntu-latest
     steps:
-
       - name: checkout repo content
-        uses: actions/checkout@v2 # checkout the repository content to github runner
+        uses: actions/checkout@v3 # checkout the repository content to github runner
 
       - name: setup python
-        uses: actions/setup-python@v2
+        uses: actions/setup-python@v4
         with:
-          python-version: '3.9.13' # install the python version needed
-          
+          python-version: "3.9.13" # install the python version needed
+
       - name: install python packages
         run: |
           python -m pip install --upgrade pip
           pip install PyGithub slack_sdk
-          
-      - name: execute cleanup workflow py script 
-        env: 
+
+      - name: execute cleanup workflow py script
+        env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: python tools/bin/cleanup-workflow-runs.py --delete
-      
-      - name: execute dormant workflow py script 
-        env: 
+
+      - name: execute dormant workflow py script
+        env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           SLACK_TOKEN: ${{ secrets.SLACK_BOT_TOKEN_AIRBYTE_TEAM }}
 


### PR DESCRIPTION
## What
`set-output` GitHub Actions directive is deprecated and will be fully disabled on 31st May 2023.
https://github.blog/changelog/2022-10-11-github-actions-deprecating-save-state-and-set-output-commands/
`node12` is deprecated as well and should be switched to `node16`

## How
Update `actions/cache`, `actions/checkout`, `actions/setup-java`, `actions/setup-node`, `actions/setup-python` and `docker/login-action` to the latest versions.
