### PR TITLE
🪟 🐛 Update refresh schema logic to handle confirmation modal and other edge cases

### DIFF
--- a/airbyte-webapp/src/hooks/services/ConnectionForm/ConnectionFormService.tsx
+++ b/airbyte-webapp/src/hooks/services/ConnectionForm/ConnectionFormService.tsx
@@ -1,7 +1,12 @@
 import React, { createContext, useCallback, useContext, useState } from "react";
 import { useIntl } from "react-intl";
 
-import { ConnectionScheduleType, OperationRead, WebBackendConnectionRead } from "core/request/AirbyteClient";
+import {
+  ConnectionScheduleType,
+  DestinationDefinitionSpecificationRead,
+  OperationRead,
+  WebBackendConnectionRead,
+} from "core/request/AirbyteClient";
 import { useGetDestinationDefinitionSpecification } from "services/connector/DestinationDefinitionSpecificationService";
 import { FormError, generateMessageFromError } from "utils/errorStatusMessage";
 import {
@@ -54,7 +59,24 @@ export const tidyConnectionFormValues = (
   return formValues;
 };
 
-const useConnectionForm = ({ connection, mode, schemaError, refreshSchema }: ConnectionServiceProps) => {
+interface ConnectionFormHook {
+  connection: ConnectionOrPartialConnection;
+  mode: ConnectionFormMode;
+  destDefinition: DestinationDefinitionSpecificationRead;
+  initialValues: FormikConnectionFormValues;
+  schemaError?: SchemaError;
+  formId: string;
+  setSubmitError: (submitError: FormError | null) => void;
+  getErrorMessage: (formValid: boolean, connectionDirty: boolean) => string | JSX.Element | null;
+  refreshSchema: () => Promise<void>;
+}
+
+const useConnectionForm = ({
+  connection,
+  mode,
+  schemaError,
+  refreshSchema,
+}: ConnectionServiceProps): ConnectionFormHook => {
   const destDefinition = useGetDestinationDefinitionSpecification(connection.destination.destinationDefinitionId);
   const initialValues = useInitialValues(connection, destDefinition, mode !== "create");
   const { formatMessage } = useIntl();
@@ -84,7 +106,7 @@ const useConnectionForm = ({ connection, mode, schemaError, refreshSchema }: Con
   };
 };
 
-const ConnectionFormContext = createContext<ReturnType<typeof useConnectionForm> | null>(null);
+const ConnectionFormContext = createContext<ConnectionFormHook | null>(null);
 
 export const ConnectionFormServiceProvider: React.FC<React.PropsWithChildren<ConnectionServiceProps>> = ({
   children,

--- a/airbyte-webapp/src/pages/ConnectionPage/pages/ConnectionItemPage/ConnectionReplicationTab.tsx
+++ b/airbyte-webapp/src/pages/ConnectionPage/pages/ConnectionItemPage/ConnectionReplicationTab.tsx
@@ -41,13 +41,8 @@ export const ConnectionReplicationTab: React.FC = () => {
 
   const [saved, setSaved] = useState(false);
 
-  const {
-    connection,
-    schemaRefreshing,
-    schemaHasBeenRefreshed,
-    updateConnection,
-    discardRefreshedSchema: clearRefreshedSchema,
-  } = useConnectionEditService();
+  const { connection, schemaRefreshing, schemaHasBeenRefreshed, updateConnection, discardRefreshedSchema } =
+    useConnectionEditService();
   const { initialValues, mode, schemaError, getErrorMessage, setSubmitError } = useConnectionFormService();
   const allowSubOneHourCronExpressions = useFeature(FeatureItem.AllowSyncSubOneHourCronExpressions);
 
@@ -164,7 +159,7 @@ export const ConnectionReplicationTab: React.FC = () => {
   useConfirmCatalogDiff();
 
   useUnmount(() => {
-    clearRefreshedSchema();
+    discardRefreshedSchema();
   });
 
   return (
@@ -191,7 +186,7 @@ export const ConnectionReplicationTab: React.FC = () => {
                 dirty={dirty}
                 resetForm={async () => {
                   resetForm();
-                  clearRefreshedSchema();
+                  discardRefreshedSchema();
                 }}
                 successMessage={saved && !dirty && <FormattedMessage id="form.changesSaved" />}
                 errorMessage={getErrorMessage(isValid, dirty)}

--- a/airbyte-webapp/src/pages/ConnectionPage/pages/ConnectionItemPage/ConnectionReplicationTab.tsx
+++ b/airbyte-webapp/src/pages/ConnectionPage/pages/ConnectionItemPage/ConnectionReplicationTab.tsx
@@ -1,6 +1,7 @@
 import { Form, Formik, FormikHelpers } from "formik";
 import React, { useCallback, useState } from "react";
 import { FormattedMessage, useIntl } from "react-intl";
+import { useUnmount } from "react-use";
 
 import { SchemaError } from "components/CreateConnection/SchemaError";
 import LoadingSchema from "components/LoadingSchema";
@@ -40,7 +41,7 @@ export const ConnectionReplicationTab: React.FC = () => {
 
   const [saved, setSaved] = useState(false);
 
-  const { connection, schemaRefreshing, schemaHasBeenRefreshed, updateConnection, setSchemaHasBeenRefreshed } =
+  const { connection, schemaRefreshing, schemaHasBeenRefreshed, updateConnection, clearRefreshedSchema } =
     useConnectionEditService();
   const { initialValues, mode, schemaError, getErrorMessage, setSubmitError } = useConnectionFormService();
   const allowSubOneHourCronExpressions = useFeature(FeatureItem.AllowSyncSubOneHourCronExpressions);
@@ -134,7 +135,7 @@ export const ConnectionReplicationTab: React.FC = () => {
         }
 
         setSaved(true);
-        setSchemaHasBeenRefreshed(false);
+        clearRefreshedSchema();
       } catch (e) {
         setSubmitError(e);
       }
@@ -150,7 +151,7 @@ export const ConnectionReplicationTab: React.FC = () => {
       mode,
       openModal,
       saveConnection,
-      setSchemaHasBeenRefreshed,
+      clearRefreshedSchema,
       setSubmitError,
       workspaceId,
       allowSubOneHourCronExpressions,
@@ -158,6 +159,10 @@ export const ConnectionReplicationTab: React.FC = () => {
   );
 
   useConfirmCatalogDiff();
+
+  useUnmount(() => {
+    clearRefreshedSchema();
+  });
 
   return (
     <div className={styles.content}>
@@ -172,14 +177,18 @@ export const ConnectionReplicationTab: React.FC = () => {
         >
           {({ values, isSubmitting, isValid, dirty, resetForm }) => (
             <Form>
-              <ConnectionFormFields values={values} isSubmitting={isSubmitting} dirty={dirty} />
+              <ConnectionFormFields
+                values={values}
+                isSubmitting={isSubmitting}
+                dirty={dirty || schemaHasBeenRefreshed}
+              />
               <EditControls
                 isSubmitting={isSubmitting}
                 submitDisabled={!isValid}
                 dirty={dirty}
                 resetForm={async () => {
                   resetForm();
-                  setSchemaHasBeenRefreshed(false);
+                  clearRefreshedSchema();
                 }}
                 successMessage={saved && !dirty && <FormattedMessage id="form.changesSaved" />}
                 errorMessage={getErrorMessage(isValid, dirty)}

--- a/airbyte-webapp/src/pages/ConnectionPage/pages/ConnectionItemPage/ConnectionReplicationTab.tsx
+++ b/airbyte-webapp/src/pages/ConnectionPage/pages/ConnectionItemPage/ConnectionReplicationTab.tsx
@@ -41,8 +41,13 @@ export const ConnectionReplicationTab: React.FC = () => {
 
   const [saved, setSaved] = useState(false);
 
-  const { connection, schemaRefreshing, schemaHasBeenRefreshed, updateConnection, clearRefreshedSchema } =
-    useConnectionEditService();
+  const {
+    connection,
+    schemaRefreshing,
+    schemaHasBeenRefreshed,
+    updateConnection,
+    discardRefreshedSchema: clearRefreshedSchema,
+  } = useConnectionEditService();
   const { initialValues, mode, schemaError, getErrorMessage, setSubmitError } = useConnectionFormService();
   const allowSubOneHourCronExpressions = useFeature(FeatureItem.AllowSyncSubOneHourCronExpressions);
 
@@ -135,7 +140,6 @@ export const ConnectionReplicationTab: React.FC = () => {
         }
 
         setSaved(true);
-        clearRefreshedSchema();
       } catch (e) {
         setSubmitError(e);
       }
@@ -151,7 +155,6 @@ export const ConnectionReplicationTab: React.FC = () => {
       mode,
       openModal,
       saveConnection,
-      clearRefreshedSchema,
       setSubmitError,
       workspaceId,
       allowSubOneHourCronExpressions,

--- a/airbyte-webapp/src/test-utils/mock-data/mockCatalogDiff.ts
+++ b/airbyte-webapp/src/test-utils/mock-data/mockCatalogDiff.ts
@@ -1,0 +1,46 @@
+import { CatalogDiff } from "core/request/AirbyteClient";
+
+export const mockCatalogDiff: CatalogDiff = {
+  transforms: [
+    {
+      transformType: "update_stream",
+      streamDescriptor: { namespace: "apple", name: "harissa_paste" },
+      updateStream: [
+        { transformType: "add_field", fieldName: ["users", "phone"], breaking: false },
+        { transformType: "add_field", fieldName: ["users", "email"], breaking: false },
+        { transformType: "remove_field", fieldName: ["users", "lastName"], breaking: false },
+
+        {
+          transformType: "update_field_schema",
+          breaking: false,
+          fieldName: ["users", "address"],
+          updateFieldSchema: { oldSchema: { type: "number" }, newSchema: { type: "string" } },
+        },
+      ],
+    },
+    {
+      transformType: "add_stream",
+      streamDescriptor: { namespace: "apple", name: "banana" },
+    },
+    {
+      transformType: "add_stream",
+      streamDescriptor: { namespace: "apple", name: "carrot" },
+    },
+    {
+      transformType: "remove_stream",
+      streamDescriptor: { namespace: "apple", name: "dragonfruit" },
+    },
+    {
+      transformType: "remove_stream",
+      streamDescriptor: { namespace: "apple", name: "eclair" },
+    },
+    {
+      transformType: "remove_stream",
+      streamDescriptor: { namespace: "apple", name: "fishcake" },
+    },
+    {
+      transformType: "remove_stream",
+      streamDescriptor: { namespace: "apple", name: "gelatin_mold" },
+    },
+  ],
+};

--- a/airbyte-webapp/src/views/Connection/CatalogDiffModal/useConfirmCatalogDiff.tsx
+++ b/airbyte-webapp/src/views/Connection/CatalogDiffModal/useConfirmCatalogDiff.tsx
@@ -10,10 +10,10 @@ export const useConfirmCatalogDiff = () => {
   const { formatMessage } = useIntl();
   const { openModal } = useModalService();
   const { connection } = useConnectionEditService();
+  const { catalogDiff, syncCatalog } = connection;
 
   useEffect(() => {
     // If we have a catalogDiff we always want to show the modal
-    const { catalogDiff, syncCatalog } = connection;
     if (catalogDiff?.transforms && catalogDiff.transforms?.length > 0) {
       openModal<void>({
         title: formatMessage({ id: "connection.updateSchema.completed" }),
@@ -25,5 +25,5 @@ export const useConfirmCatalogDiff = () => {
         ),
       });
     }
-  }, [connection, formatMessage, openModal]);
+  }, [catalogDiff, syncCatalog, formatMessage, openModal]);
 };


### PR DESCRIPTION
## What
This change ensures that:

* The "discard changes" confirmation modal appears after the schema has been refreshed.
* The updated schema and `catalogId` are discarded when the user cancels or navigates away from the page
* The catalog diff modal appears only if the connection diff has changed
* The connection is now patched only with the changes that were sent

Some of this functionality was lost during the refactor in airbytehq/airbyte#15603

## How
The connection sync catalog and the schema are stored when the hook is initialized so that they can be reset if the user cancels or navigates away from the tab. These are only updated when the syncCatalog is updated.

Additionally, I updated the tests to check for diffs and added additional interfaces to track references of hook usage better.

## Recommended reading order
`airbyte-webapp/src/hooks/services/ConnectionEdit/ConnectionEditService.tsx`
`airbyte-webapp/src/hooks/services/ConnectionEdit/ConnectionEditService.test.tsx`
Rest of code