### PR TITLE
Source AlloyDB for PostgreSQL: enable `high` test strictness level in SAT

### DIFF
--- a/airbyte-integrations/connectors/source-alloydb/acceptance-test-config.yml
+++ b/airbyte-integrations/connectors/source-alloydb/acceptance-test-config.yml
@@ -1,6 +1,6 @@
-# See [Source Acceptance Tests](https://docs.airbyte.com/connector-development/testing-connectors/source-acceptance-tests-reference)
-# for more information about how to configure these tests
-connector_image: airbyte/source-alloydb:dev
-tests:
+acceptance_tests:
   spec:
-    - spec_path: "src/test/resources/expected_spec.json"
+    tests:
+      - spec_path: src/test/resources/expected_spec.json
+connector_image: airbyte/source-alloydb:dev
+test_strictness_level: high


### PR DESCRIPTION
## What
A `test_strictness_level` field was introduced to Source Acceptance Tests (SAT).
AlloyDB for PostgreSQL is a generally_available connector, we want it to have a `high` test strictness level.

**This will help**:
- maximize the SAT coverage on this connector.
- document its potential weaknesses in term of test coverage.

## How
1. Migrate the existing `acceptance-test-config.yml` file to the latest configuration format. (See instructions [here](https://github.com/airbytehq/airbyte/blob/master/airbyte-integrations/bases/source-acceptance-test/README.md#L61))
2. Enable `high` test strictness level in `acceptance-test-config.yml`. (See instructions [here](https://github.com/airbytehq/airbyte/blob/master/docs/connector-development/testing-connectors/source-acceptance-tests-reference.md#L240))

**If tests are failing please fix the failing test by changing the `acceptance-test-config.yml` file or use `bypass_reason` fields to explain why a specific test can't be run.**
Please open a new PR ff the new enabled tests help discover a new bug. 
Once this bug fix is merged please rebase this branch and run `/test` again.

You can find more details about the rules enforced by `high` test strictness level [here](https://docs.airbyte.com/connector-development/testing-connectors/source-acceptance-tests-reference/).