### PR TITLE
Source Amazon Ads: enable `high` test strictness level in SAT

### DIFF
--- a/airbyte-integrations/connectors/source-amazon-ads/acceptance-test-config.yml
+++ b/airbyte-integrations/connectors/source-amazon-ads/acceptance-test-config.yml
@@ -1,50 +1,55 @@
-# See [Source Acceptance Tests](https://docs.airbyte.com/connector-development/testing-connectors/source-acceptance-tests-reference)
-# for more information about how to configure these tests
-connector_image: airbyte/source-amazon-ads:dev
-tests:
-  spec:
-    - spec_path: "integration_tests/spec.json"
-  connection:
-    - config_path: "secrets/config.json"
-      status: "succeed"
-    - config_path: "integration_tests/invalid_config.json"
-      status: "failed"
-  discovery:
-    - config_path: "secrets/config.json"
+acceptance_tests:
   basic_read:
-    - config_path: "secrets/config.json"
-      configured_catalog_path: "integration_tests/configured_catalog.json"
-      expect_records:
-        path: "integration_tests/expected_records.txt"
-        extra_fields: no
-        exact_order: no
-        extra_records: no
-      empty_streams:
-        [
-          "profiles",
-          "sponsored_brands_ad_groups",
-          "sponsored_brands_campaigns",
-          "sponsored_brands_keywords",
-          "attribution_report_performance_creative",
-          "attribution_report_performance_adgroup",
-          "attribution_report_products",
-          "attribution_report_performance_campaign",
-        ]
-    - config_path: "secrets/config_report.json"
-      configured_catalog_path: "integration_tests/configured_catalog_report.json"
-      timeout_seconds: 2400
-  incremental:
-    - config_path: "secrets/config_report.json"
-      configured_catalog_path: "integration_tests/configured_catalog_report.json"
-      future_state_path: "integration_tests/abnormal_state.json"
-      cursor_paths:
-        sponsored_products_report_stream: ["1861552880916640", "reportDate"]
-      timeout_seconds: 2400
+    tests:
+      - config_path: secrets/config.json
+        empty_streams:
+          - name: profiles
+          - name: sponsored_brands_ad_groups
+          - name: sponsored_brands_campaigns
+          - name: sponsored_brands_keywords
+          - name: attribution_report_performance_creative
+          - name: attribution_report_performance_adgroup
+          - name: attribution_report_products
+          - name: attribution_report_performance_campaign
+        expect_records:
+          exact_order: false
+          extra_fields: false
+          extra_records: false
+          path: integration_tests/expected_records.txt
+      - config_path: secrets/config_report.json
+        timeout_seconds: 2400
+  connection:
+    tests:
+      - config_path: secrets/config.json
+        status: succeed
+      - config_path: integration_tests/invalid_config.json
+        status: failed
+  discovery:
+    tests:
+      - config_path: secrets/config.json
   full_refresh:
-    - config_path: "secrets/config.json"
-      configured_catalog_path: "integration_tests/configured_catalog.json"
-    - config_path: "secrets/config_report.json"
-      configured_catalog_path: "integration_tests/configured_catalog_report.json"
-      ignored_fields:
-        "sponsored_products_report_stream": ["updatedAt"]
-      timeout_seconds: 3600
+    tests:
+      - config_path: secrets/config.json
+        configured_catalog_path: integration_tests/configured_catalog.json
+      - config_path: secrets/config_report.json
+        configured_catalog_path: integration_tests/configured_catalog_report.json
+        ignored_fields:
+          sponsored_products_report_stream:
+            - updatedAt
+        timeout_seconds: 3600
+  incremental:
+    tests:
+      - config_path: secrets/config_report.json
+        configured_catalog_path: integration_tests/configured_catalog_report.json
+        cursor_paths:
+          sponsored_products_report_stream:
+            - "1861552880916640"
+            - reportDate
+        future_state:
+          future_state_path: integration_tests/abnormal_state.json
+        timeout_seconds: 2400
+  spec:
+    tests:
+      - spec_path: integration_tests/spec.json
+connector_image: airbyte/source-amazon-ads:dev
+test_strictness_level: high


### PR DESCRIPTION
## What
A `test_strictness_level` field was introduced to Source Acceptance Tests (SAT).
Amazon Ads is a generally_available connector, we want it to have a `high` test strictness level.

**This will help**:
- maximize the SAT coverage on this connector.
- document its potential weaknesses in term of test coverage.

## How
1. Migrate the existing `acceptance-test-config.yml` file to the latest configuration format. (See instructions [here](https://github.com/airbytehq/airbyte/blob/master/airbyte-integrations/bases/source-acceptance-test/README.md#L61))
2. Enable `high` test strictness level in `acceptance-test-config.yml`. (See instructions [here](https://github.com/airbytehq/airbyte/blob/master/docs/connector-development/testing-connectors/source-acceptance-tests-reference.md#L240))

⚠️ ⚠️ ⚠️ 
**If tests are failing please fix the failing test by changing the `acceptance-test-config.yml` file or use `bypass_reason` fields to explain why a specific test can't be run.**

Please open a new PR if the new enabled tests help discover a new bug. 
Once this bug fix is merged please rebase this branch and run `/test` again.

You can find more details about the rules enforced by `high` test strictness level [here](https://docs.airbyte.com/connector-development/testing-connectors/source-acceptance-tests-reference/).

## Review process
Please ask the `connector-operations` teams for review.