### PR TITLE
Source Chargebee: enable `high` test strictness level in SAT

### DIFF
--- a/airbyte-integrations/connectors/source-chargebee/acceptance-test-config.yml
+++ b/airbyte-integrations/connectors/source-chargebee/acceptance-test-config.yml
@@ -1,31 +1,36 @@
-# See [Source Acceptance Tests](https://docs.airbyte.com/connector-development/testing-connectors/source-acceptance-tests-reference)
-# for more information about how to configure these tests
-connector_image: airbyte/source-chargebee:dev
-tests:
-  spec:
-    - spec_path: "source_chargebee/spec.json"
-  connection:
-    - config_path: "secrets/config.json"
-      status: "succeed"
-    - config_path: "integration_tests/invalid_config.json"
-      status: "failed"
-  discovery:
-    - config_path: "secrets/config.json"
-      backward_compatibility_tests_config:
-        disable_for_version: "0.1.12"
+acceptance_tests:
   basic_read:
-    - config_path: "secrets/config.json"
-      configured_catalog_path: "integration_tests/product_catalog_v2_configured_catalog.json"
-      # I was unable to create orders using API and I didn’t find a way to create orders
-      # through UI, so that’s why `order` stream is empty.
-      empty_streams:
-        - order
-  incremental:
-    - config_path: "secrets/config.json"
-      configured_catalog_path: "integration_tests/product_catalog_v2_configured_catalog.json"
-      future_state_path: "integration_tests/future_state.json"
-      cursor_paths:
-        attached_item: [ "cbdemo_standard", "updated_at" ]
+    tests:
+      - config_path: secrets/config.json
+        empty_streams:
+          - name: order
+  connection:
+    tests:
+      - config_path: secrets/config.json
+        status: succeed
+      - config_path: integration_tests/invalid_config.json
+        status: failed
+  discovery:
+    tests:
+      - backward_compatibility_tests_config:
+          disable_for_version: 0.1.12
+        config_path: secrets/config.json
   full_refresh:
-    - config_path: "secrets/config.json"
-      configured_catalog_path: "integration_tests/product_catalog_v2_configured_catalog.json"
+    tests:
+      - config_path: secrets/config.json
+        configured_catalog_path: integration_tests/product_catalog_v2_configured_catalog.json
+  incremental:
+    tests:
+      - config_path: secrets/config.json
+        configured_catalog_path: integration_tests/product_catalog_v2_configured_catalog.json
+        cursor_paths:
+          attached_item:
+            - cbdemo_standard
+            - updated_at
+        future_state:
+          future_state_path: integration_tests/future_state.json
+  spec:
+    tests:
+      - spec_path: source_chargebee/spec.json
+connector_image: airbyte/source-chargebee:dev
+test_strictness_level: high


### PR DESCRIPTION
## What
A `test_strictness_level` field was introduced to Source Acceptance Tests (SAT).
Chargebee is a generally_available connector, we want it to have a `high` test strictness level.

**This will help**:
- maximize the SAT coverage on this connector.
- document its potential weaknesses in term of test coverage.

## How
1. Migrate the existing `acceptance-test-config.yml` file to the latest configuration format. (See instructions [here](https://github.com/airbytehq/airbyte/blob/master/airbyte-integrations/bases/source-acceptance-test/README.md#L61))
2. Enable `high` test strictness level in `acceptance-test-config.yml`. (See instructions [here](https://github.com/airbytehq/airbyte/blob/master/docs/connector-development/testing-connectors/source-acceptance-tests-reference.md#L240))

⚠️ ⚠️ ⚠️ 
**If tests are failing please fix the failing test by changing the `acceptance-test-config.yml` file or use `bypass_reason` fields to explain why a specific test can't be run.**

Please open a new PR if the new enabled tests help discover a new bug. 
Once this bug fix is merged please rebase this branch and run `/test` again.

You can find more details about the rules enforced by `high` test strictness level [here](https://docs.airbyte.com/connector-development/testing-connectors/source-acceptance-tests-reference/).

## Review process
Please ask the `connector-operations` teams for review.