### PR TITLE
Source GitHub: enable `high` test strictness level in SAT

### DIFF
--- a/airbyte-integrations/connectors/source-github/acceptance-test-config.yml
+++ b/airbyte-integrations/connectors/source-github/acceptance-test-config.yml
@@ -1,55 +1,115 @@
-connector_image: airbyte/source-github:dev
-tests:
-  spec:
-    - spec_path: "source_github/spec.json"
-  connection:
-    - config_path: "secrets/config.json"
-      status: "succeed"
-    - config_path: "secrets/config_oauth.json"
-      status: "succeed"
-    - config_path: "integration_tests/invalid_config.json"
-      status: "failed"
-  discovery:
-    - config_path: "secrets/config.json"
-    - config_path: "secrets/config_oauth.json"
+acceptance_tests:
   basic_read:
-    - config_path: "secrets/config.json"
-      configured_catalog_path: "integration_tests/configured_catalog.json"
-  incremental:
-    - config_path: "secrets/config.json"
-      configured_catalog_path: "integration_tests/configured_catalog.json"
-      future_state_path: "integration_tests/abnormal_state.json"
-      cursor_paths:
-        comments: ["airbytehq/integration-test", "updated_at"]
-        commit_comment_reactions:
-          ["airbytehq/integration-test", "55538825", "created_at"]
-        commit_comments: ["airbytehq/integration-test", "updated_at"]
-        commits: ["airbytehq/integration-test", "master", "created_at"]
-        deployments: ["airbytehq/integration-test", "updated_at"]
-        events: ["airbytehq/integration-test", "created_at"]
-        issue_comment_reactions:
-          ["airbytehq/integration-test", "907296275", "created_at"]
-        issue_events: ["airbytehq/integration-test", "created_at"]
-        issue_milestones: ["airbytehq/integration-test", "updated_at"]
-        issue_reactions: ["airbytehq/integration-test", "11", "created_at"]
-        issues: ["airbytehq/integration-test", "updated_at"]
-        project_cards:
-          ["airbytehq/integration-test", "13167124", "17807006", "updated_at"]
-        project_columns:
-          ["airbytehq/integration-test", "13167124", "updated_at"]
-        projects: ["airbytehq/integration-test", "updated_at"]
-        pull_request_comment_reactions:
-          ["airbytehq/integration-test", "699253726", "created_at"]
-        pull_request_stats: ["airbytehq/integration-test", "updated_at"]
-        pull_requests: ["airbytehq/integration-test", "updated_at"]
-        releases: ["airbytehq/integration-test", "created_at"]
-        repositories: ["airbytehq", "updated_at"]
-        review_comments: ["airbytehq/integration-test", "updated_at"]
-        reviews: ["airbytehq/integration-test", "updated_at"]
-        stargazers: ["airbytehq/integration-test", "starred_at"]
-        workflow_runs: ["airbytehq/integration-test", "updated_at"]
-        workflows: ["airbytehq/integration-test", "updated_at"]
-        workflow_jobs: ["airbytehq/integration-test", "completed_at"]
+    tests:
+      - config_path: secrets/config.json
+  connection:
+    tests:
+      - config_path: secrets/config.json
+        status: succeed
+      - config_path: secrets/config_oauth.json
+        status: succeed
+      - config_path: integration_tests/invalid_config.json
+        status: failed
+  discovery:
+    tests:
+      - config_path: secrets/config.json
+      - config_path: secrets/config_oauth.json
   full_refresh:
-    - config_path: "secrets/config.json"
-      configured_catalog_path: "integration_tests/configured_catalog.json"
+    tests:
+      - config_path: secrets/config.json
+        configured_catalog_path: integration_tests/configured_catalog.json
+  incremental:
+    tests:
+      - config_path: secrets/config.json
+        configured_catalog_path: integration_tests/configured_catalog.json
+        cursor_paths:
+          comments:
+            - airbytehq/integration-test
+            - updated_at
+          commit_comment_reactions:
+            - airbytehq/integration-test
+            - "55538825"
+            - created_at
+          commit_comments:
+            - airbytehq/integration-test
+            - updated_at
+          commits:
+            - airbytehq/integration-test
+            - master
+            - created_at
+          deployments:
+            - airbytehq/integration-test
+            - updated_at
+          events:
+            - airbytehq/integration-test
+            - created_at
+          issue_comment_reactions:
+            - airbytehq/integration-test
+            - "907296275"
+            - created_at
+          issue_events:
+            - airbytehq/integration-test
+            - created_at
+          issue_milestones:
+            - airbytehq/integration-test
+            - updated_at
+          issue_reactions:
+            - airbytehq/integration-test
+            - "11"
+            - created_at
+          issues:
+            - airbytehq/integration-test
+            - updated_at
+          project_cards:
+            - airbytehq/integration-test
+            - "13167124"
+            - "17807006"
+            - updated_at
+          project_columns:
+            - airbytehq/integration-test
+            - "13167124"
+            - updated_at
+          projects:
+            - airbytehq/integration-test
+            - updated_at
+          pull_request_comment_reactions:
+            - airbytehq/integration-test
+            - "699253726"
+            - created_at
+          pull_request_stats:
+            - airbytehq/integration-test
+            - updated_at
+          pull_requests:
+            - airbytehq/integration-test
+            - updated_at
+          releases:
+            - airbytehq/integration-test
+            - created_at
+          repositories:
+            - airbytehq
+            - updated_at
+          review_comments:
+            - airbytehq/integration-test
+            - updated_at
+          reviews:
+            - airbytehq/integration-test
+            - updated_at
+          stargazers:
+            - airbytehq/integration-test
+            - starred_at
+          workflow_jobs:
+            - airbytehq/integration-test
+            - completed_at
+          workflow_runs:
+            - airbytehq/integration-test
+            - updated_at
+          workflows:
+            - airbytehq/integration-test
+            - updated_at
+        future_state:
+          future_state_path: integration_tests/abnormal_state.json
+  spec:
+    tests:
+      - spec_path: source_github/spec.json
+connector_image: airbyte/source-github:dev
+test_strictness_level: high


### PR DESCRIPTION
## What
A `test_strictness_level` field was introduced to Source Acceptance Tests (SAT).
GitHub is a generally_available connector, we want it to have a `high` test strictness level.

**This will help**:
- maximize the SAT coverage on this connector.
- document its potential weaknesses in term of test coverage.

## How
1. Migrate the existing `acceptance-test-config.yml` file to the latest configuration format. (See instructions [here](https://github.com/airbytehq/airbyte/blob/master/airbyte-integrations/bases/source-acceptance-test/README.md#L61))
2. Enable `high` test strictness level in `acceptance-test-config.yml`. (See instructions [here](https://github.com/airbytehq/airbyte/blob/master/docs/connector-development/testing-connectors/source-acceptance-tests-reference.md#L240))

⚠️ ⚠️ ⚠️ 
**If tests are failing please fix the failing test by changing the `acceptance-test-config.yml` file or use `bypass_reason` fields to explain why a specific test can't be run.**

Please open a new PR if the new enabled tests help discover a new bug. 
Once this bug fix is merged please rebase this branch and run `/test` again.

You can find more details about the rules enforced by `high` test strictness level [here](https://docs.airbyte.com/connector-development/testing-connectors/source-acceptance-tests-reference/).

## Review process
Please ask the `connector-operations` teams for review.