### PR TITLE
Source Google Ads: enable `high` test strictness level in SAT

### DIFF
--- a/airbyte-integrations/connectors/source-google-ads/acceptance-test-config.yml
+++ b/airbyte-integrations/connectors/source-google-ads/acceptance-test-config.yml
@@ -1,34 +1,34 @@
-# See [Source Acceptance Tests](https://docs.airbyte.com/connector-development/testing-connectors/source-acceptance-tests-reference)
-# for more information about how to configure these tests
-connector_image: airbyte/source-google-ads:dev
-tests:
-  spec:
-    - spec_path: "source_google_ads/spec.json"
-      backward_compatibility_tests_config:
-        disable_for_version: "0.1.45"
-  connection:
-    - config_path: "secrets/config.json"
-      status: "succeed"
-    - config_path: "integration_tests/invalid_config.json"
-      status: "failed"
-  discovery:
-    - config_path: "secrets/config.json"
+acceptance_tests:
   basic_read:
-    - config_path: "secrets/config.json"
-      configured_catalog_path: "integration_tests/configured_catalog.json"
-      empty_streams:
-        [
-          "geographic_report",
-          "keyword_report",
-          "display_keyword_performance_report",
-          "display_topics_performance_report",
-          "shopping_performance_report",
-          "unhappytable",
-          "click_view",
-        ]
-      timeout_seconds: 600
-    - config_path: "secrets/config.json"
-      configured_catalog_path: "integration_tests/configured_catalog_protobuf_msg.json"
+    tests:
+      - config_path: secrets/config.json
+        empty_streams:
+          - name: geographic_report
+          - name: keyword_report
+          - name: display_keyword_performance_report
+          - name: display_topics_performance_report
+          - name: shopping_performance_report
+          - name: unhappytable
+          - name: click_view
+        timeout_seconds: 600
+      - config_path: secrets/config.json
+  connection:
+    tests:
+      - config_path: secrets/config.json
+        status: succeed
+      - config_path: integration_tests/invalid_config.json
+        status: failed
+  discovery:
+    tests:
+      - config_path: secrets/config.json
   full_refresh:
-    - config_path: "secrets/config.json"
-      configured_catalog_path: "integration_tests/configured_catalog.json"
+    tests:
+      - config_path: secrets/config.json
+        configured_catalog_path: integration_tests/configured_catalog.json
+  spec:
+    tests:
+      - backward_compatibility_tests_config:
+          disable_for_version: 0.1.45
+        spec_path: source_google_ads/spec.json
+connector_image: airbyte/source-google-ads:dev
+test_strictness_level: high


### PR DESCRIPTION
## What
A `test_strictness_level` field was introduced to Source Acceptance Tests (SAT).
Google Ads is a generally_available connector, we want it to have a `high` test strictness level.

**This will help**:
- maximize the SAT coverage on this connector.
- document its potential weaknesses in term of test coverage.

## How
1. Migrate the existing `acceptance-test-config.yml` file to the latest configuration format. (See instructions [here](https://github.com/airbytehq/airbyte/blob/master/airbyte-integrations/bases/source-acceptance-test/README.md#L61))
2. Enable `high` test strictness level in `acceptance-test-config.yml`. (See instructions [here](https://github.com/airbytehq/airbyte/blob/master/docs/connector-development/testing-connectors/source-acceptance-tests-reference.md#L240))

⚠️ ⚠️ ⚠️ 
**If tests are failing please fix the failing test by changing the `acceptance-test-config.yml` file or use `bypass_reason` fields to explain why a specific test can't be run.**

Please open a new PR if the new enabled tests help discover a new bug. 
Once this bug fix is merged please rebase this branch and run `/test` again.

You can find more details about the rules enforced by `high` test strictness level [here](https://docs.airbyte.com/connector-development/testing-connectors/source-acceptance-tests-reference/).

## Review process
Please ask the `connector-operations` teams for review.