### PR TITLE
Source Greenhouse: enable `high` test strictness level in SAT

### DIFF
--- a/airbyte-integrations/connectors/source-greenhouse/acceptance-test-config.yml
+++ b/airbyte-integrations/connectors/source-greenhouse/acceptance-test-config.yml
@@ -1,38 +1,60 @@
-# See [Source Acceptance Tests](https://docs.airbyte.com/connector-development/testing-connectors/source-acceptance-tests-reference)
-# for more information about how to configure these tests
-connector_image: airbyte/source-greenhouse:dev
-tests:
-  spec:
-    - spec_path: "source_greenhouse/spec.json"
-  connection:
-    - config_path: "secrets/config.json"
-      status: "succeed"
-    - config_path: "integration_tests/config_invalid.json"
-      status: "failed"
-  discovery:
-    - config_path: "secrets/config.json"
-    - config_path: "secrets/config_users_only.json"
+acceptance_tests:
   basic_read:
-    - config_path: "secrets/config.json"
-      configured_catalog_path: "integration_tests/configured_catalog.json"
-      expect_records:
-        path: "integration_tests/expected_records.txt"
-    - config_path: "secrets/config_users_only.json"
-      # test we do not fail when encounter 403 error
-      configured_catalog_path: "integration_tests/configured_catalog.json"
-      empty_streams: [
-        "applications", "applications_demographics_answers", "applications_interviews", "candidates", "close_reasons",
-        "custom_fields", "degrees", "demographics_answers", "demographics_answer_options", "questions",
-        "demographics_answers_answer_options", "demographics_question_sets", "demographics_question_sets_questions",
-        "departments", "jobs", "jobs_openings", "interviews", "job_posts", "job_stages", "jobs_stages", "offers",
-        "rejection_reasons", "scorecards", "sources", "demographics_questions"
-      ]
+    tests:
+      - config_path: secrets/config.json
+        expect_records:
+          path: integration_tests/expected_records.txt
+      - config_path: secrets/config_users_only.json
+        empty_streams:
+          - name: applications
+          - name: applications_demographics_answers
+          - name: applications_interviews
+          - name: candidates
+          - name: close_reasons
+          - name: custom_fields
+          - name: degrees
+          - name: demographics_answers
+          - name: demographics_answer_options
+          - name: questions
+          - name: demographics_answers_answer_options
+          - name: demographics_question_sets
+          - name: demographics_question_sets_questions
+          - name: departments
+          - name: jobs
+          - name: jobs_openings
+          - name: interviews
+          - name: job_posts
+          - name: job_stages
+          - name: jobs_stages
+          - name: offers
+          - name: rejection_reasons
+          - name: scorecards
+          - name: sources
+          - name: demographics_questions
+  connection:
+    tests:
+      - config_path: secrets/config.json
+        status: succeed
+      - config_path: integration_tests/config_invalid.json
+        status: failed
+  discovery:
+    tests:
+      - config_path: secrets/config.json
+      - config_path: secrets/config_users_only.json
   full_refresh:
-    - config_path: "secrets/config.json"
-      configured_catalog_path: "integration_tests/configured_catalog.json"
-    - config_path: "secrets/config_users_only.json"
-      configured_catalog_path: "integration_tests/configured_catalog_users_only.json"
+    tests:
+      - config_path: secrets/config.json
+        configured_catalog_path: integration_tests/configured_catalog.json
+      - config_path: secrets/config_users_only.json
+        configured_catalog_path: integration_tests/configured_catalog_users_only.json
   incremental:
-    - config_path: "secrets/config.json"
-      configured_catalog_path: "integration_tests/incremental_configured_catalog.json"
-      future_state_path: "integration_tests/abnormal_state.json"
+    tests:
+      - config_path: secrets/config.json
+        configured_catalog_path: integration_tests/incremental_configured_catalog.json
+        future_state:
+          future_state_path: integration_tests/abnormal_state.json
+  spec:
+    tests:
+      - spec_path: source_greenhouse/spec.json
+connector_image: airbyte/source-greenhouse:dev
+test_strictness_level: high


### PR DESCRIPTION
## What
A `test_strictness_level` field was introduced to Source Acceptance Tests (SAT).
Greenhouse is a generally_available connector, we want it to have a `high` test strictness level.

**This will help**:
- maximize the SAT coverage on this connector.
- document its potential weaknesses in term of test coverage.

## How
1. Migrate the existing `acceptance-test-config.yml` file to the latest configuration format. (See instructions [here](https://github.com/airbytehq/airbyte/blob/master/airbyte-integrations/bases/source-acceptance-test/README.md#L61))
2. Enable `high` test strictness level in `acceptance-test-config.yml`. (See instructions [here](https://github.com/airbytehq/airbyte/blob/master/docs/connector-development/testing-connectors/source-acceptance-tests-reference.md#L240))

⚠️ ⚠️ ⚠️ 
**If tests are failing please fix the failing test by changing the `acceptance-test-config.yml` file or use `bypass_reason` fields to explain why a specific test can't be run.**

Please open a new PR if the new enabled tests help discover a new bug. 
Once this bug fix is merged please rebase this branch and run `/test` again.

You can find more details about the rules enforced by `high` test strictness level [here](https://docs.airbyte.com/connector-development/testing-connectors/source-acceptance-tests-reference/).

## Review process
Please ask the `connector-operations` teams for review.