### PR TITLE
Source HubSpot: enable `high` test strictness level in SAT

### DIFF
--- a/airbyte-integrations/connectors/source-hubspot/acceptance-test-config.yml
+++ b/airbyte-integrations/connectors/source-hubspot/acceptance-test-config.yml
@@ -1,107 +1,89 @@
-connector_image: airbyte/source-hubspot:dev
-tests:
-  spec:
-    - spec_path: "source_hubspot/spec.yaml"
-  connection:
-    - config_path: "secrets/config.json"
-      status: "succeed"
-    - config_path: "secrets/config_oauth.json"
-      status: "succeed"
-    - config_path: "integration_tests/invalid_config.json"
-      status: "failed"
-    - config_path: "integration_tests/invalid_config_oauth.json"
-      status: "failed"
-    - config_path: "integration_tests/invalid_config_wrong_title.json"
-      status: "failed"
-  discovery:
-    - config_path: "secrets/config.json"
-      backward_compatibility_tests_config:
-        disable_for_version: "0.1.83"
+acceptance_tests:
   basic_read:
-    - config_path: "secrets/config.json"
-      timeout_seconds: 600
-      configured_catalog_path: "sample_files/basic_read_catalog.json"
-      empty_streams: ["form_submissions", "ticket_pipelines", "engagements_meetings", "engagements_emails", "engagements", "engagements_calls", "quotes"]
-      # This test commented out, since it produces errors during active testing
-      # expect_records:
-      #   path: "integration_tests/expected_records.txt"
-    - config_path: "secrets/config_oauth.json"
-      timeout_seconds: 600
-      configured_catalog_path: "sample_files/basic_read_oauth_catalog.json"
-      empty_streams: ["form_submissions", "ticket_pipelines", "engagements_meetings", "engagements_emails", "engagements", "engagements_calls", "quotes"]
-      # This test commented out, since it produces errors during active testing
-      # expect_records:
-      #   path: "integration_tests/expected_records.txt"
-  incremental:
-    - config_path: "secrets/config.json"
-      configured_catalog_path: "sample_files/incremental_catalog.json"
-      future_state_path: "integration_tests/abnormal_state.json"
+    tests:
+      - config_path: secrets/config.json
+        empty_streams:
+          - name: form_submissions
+          - name: ticket_pipelines
+          - name: engagements_meetings
+          - name: engagements_emails
+          - name: engagements
+          - name: engagements_calls
+          - name: quotes
+        timeout_seconds: 600
+      - config_path: secrets/config_oauth.json
+        empty_streams:
+          - name: form_submissions
+          - name: ticket_pipelines
+          - name: engagements_meetings
+          - name: engagements_emails
+          - name: engagements
+          - name: engagements_calls
+          - name: quotes
+        timeout_seconds: 600
+  connection:
+    tests:
+      - config_path: secrets/config.json
+        status: succeed
+      - config_path: secrets/config_oauth.json
+        status: succeed
+      - config_path: integration_tests/invalid_config.json
+        status: failed
+      - config_path: integration_tests/invalid_config_oauth.json
+        status: failed
+      - config_path: integration_tests/invalid_config_wrong_title.json
+        status: failed
+  discovery:
+    tests:
+      - backward_compatibility_tests_config:
+          disable_for_version: 0.1.83
+        config_path: secrets/config.json
   full_refresh:
-    - config_path: "secrets/config.json"
-      configured_catalog_path: "sample_files/full_refresh_catalog.json"
-      ignored_fields:
-        "contact_lists": [ "properties", "ilsFilterBranch" ]
-        "companies": [ "properties", "hs_time_in_customer" ]
-        "companies": [ "properties", "hs_time_in_evangelist" ]
-        "companies": [ "properties", "hs_time_in_lead" ]
-        "companies": [ "properties", "hs_time_in_marketingqualifiedlead" ]
-        "companies": [ "properties", "hs_time_in_opportunity" ]
-        "companies": [ "properties", "hs_time_in_other" ]
-        "companies": [ "properties", "hs_time_in_salesqualifiedlead" ]
-        "companies": [ "properties", "hs_time_in_subscriber" ]
-        "contacts": [ "properties", "hs_time_in_customer" ]
-        "contacts": [ "properties", "hs_time_in_evangelist" ]
-        "contacts": [ "properties", "hs_time_in_lead" ]
-        "contacts": [ "properties", "hs_time_in_marketingqualifiedlead" ]
-        "contacts": [ "properties", "hs_time_in_opportunity" ]
-        "contacts": [ "properties", "hs_time_in_other" ]
-        "contacts": [ "properties", "hs_time_in_salesqualifiedlead" ]
-        "contacts": [ "properties", "hs_time_in_subscriber" ]
-        "deals": [ "properties", "hs_time_in_9567448" ]
-        "deals": [ "properties", "hs_time_in_9567449" ]
-        "deals": [ "properties", "hs_time_in_appointmentscheduled" ]
-        "deals": [ "properties", "hs_time_in_closedlost" ]
-        "deals": [ "properties", "hs_time_in_closedwon" ]
-        "deals": [ "properties", "hs_time_in_contractsent" ]
-        "deals": [ "properties", "hs_time_in_customclosedwonstage" ]
-        "deals": [ "properties", "hs_time_in_decisionmakerboughtin" ]
-        "deals": [ "properties", "hs_time_in_presentationscheduled" ]
-        "deals": [ "properties", "hs_time_in_qualifiedtobuy" ]
-        "tickets": [ "properties", "hs_time_in_1" ]
-        "tickets": [ "properties", "hs_time_in_2" ]
-        "tickets": [ "properties", "hs_time_in_3" ]
-        "tickets": [ "properties", "hs_time_in_4" ]
-    - config_path: "secrets/config_oauth.json"
-      configured_catalog_path: "sample_files/full_refresh_oauth_catalog.json"
-      ignored_fields:
-        "contact_lists": [ "properties", "ilsFilterBranch" ]
-        "companies": [ "properties", "hs_time_in_customer" ]
-        "companies": [ "properties", "hs_time_in_evangelist" ]
-        "companies": [ "properties", "hs_time_in_lead" ]
-        "companies": [ "properties", "hs_time_in_marketingqualifiedlead" ]
-        "companies": [ "properties", "hs_time_in_opportunity" ]
-        "companies": [ "properties", "hs_time_in_other" ]
-        "companies": [ "properties", "hs_time_in_salesqualifiedlead" ]
-        "companies": [ "properties", "hs_time_in_subscriber" ]
-        "contacts": [ "properties", "hs_time_in_customer" ]
-        "contacts": [ "properties", "hs_time_in_evangelist" ]
-        "contacts": [ "properties", "hs_time_in_lead" ]
-        "contacts": [ "properties", "hs_time_in_marketingqualifiedlead" ]
-        "contacts": [ "properties", "hs_time_in_opportunity" ]
-        "contacts": [ "properties", "hs_time_in_other" ]
-        "contacts": [ "properties", "hs_time_in_salesqualifiedlead" ]
-        "contacts": [ "properties", "hs_time_in_subscriber" ]
-        "deals": [ "properties", "hs_time_in_9567448" ]
-        "deals": [ "properties", "hs_time_in_9567449" ]
-        "deals": [ "properties", "hs_time_in_appointmentscheduled" ]
-        "deals": [ "properties", "hs_time_in_closedlost" ]
-        "deals": [ "properties", "hs_time_in_closedwon" ]
-        "deals": [ "properties", "hs_time_in_contractsent" ]
-        "deals": [ "properties", "hs_time_in_customclosedwonstage" ]
-        "deals": [ "properties", "hs_time_in_decisionmakerboughtin" ]
-        "deals": [ "properties", "hs_time_in_presentationscheduled" ]
-        "deals": [ "properties", "hs_time_in_qualifiedtobuy" ]
-        "tickets": [ "properties", "hs_time_in_1" ]
-        "tickets": [ "properties", "hs_time_in_2" ]
-        "tickets": [ "properties", "hs_time_in_3" ]
-        "tickets": [ "properties", "hs_time_in_4" ]
+    tests:
+      - config_path: secrets/config.json
+        configured_catalog_path: sample_files/full_refresh_catalog.json
+        ignored_fields:
+          companies:
+            - properties
+            - hs_time_in_subscriber
+          contact_lists:
+            - properties
+            - ilsFilterBranch
+          contacts:
+            - properties
+            - hs_time_in_subscriber
+          deals:
+            - properties
+            - hs_time_in_qualifiedtobuy
+          tickets:
+            - properties
+            - hs_time_in_4
+      - config_path: secrets/config_oauth.json
+        configured_catalog_path: sample_files/full_refresh_oauth_catalog.json
+        ignored_fields:
+          companies:
+            - properties
+            - hs_time_in_subscriber
+          contact_lists:
+            - properties
+            - ilsFilterBranch
+          contacts:
+            - properties
+            - hs_time_in_subscriber
+          deals:
+            - properties
+            - hs_time_in_qualifiedtobuy
+          tickets:
+            - properties
+            - hs_time_in_4
+  incremental:
+    tests:
+      - config_path: secrets/config.json
+        configured_catalog_path: sample_files/incremental_catalog.json
+        future_state:
+          future_state_path: integration_tests/abnormal_state.json
+  spec:
+    tests:
+      - spec_path: source_hubspot/spec.yaml
+connector_image: airbyte/source-hubspot:dev
+test_strictness_level: high


### PR DESCRIPTION
## What
A `test_strictness_level` field was introduced to Source Acceptance Tests (SAT).
HubSpot is a generally_available connector, we want it to have a `high` test strictness level.

**This will help**:
- maximize the SAT coverage on this connector.
- document its potential weaknesses in term of test coverage.

## How
1. Migrate the existing `acceptance-test-config.yml` file to the latest configuration format. (See instructions [here](https://github.com/airbytehq/airbyte/blob/master/airbyte-integrations/bases/source-acceptance-test/README.md#L61))
2. Enable `high` test strictness level in `acceptance-test-config.yml`. (See instructions [here](https://github.com/airbytehq/airbyte/blob/master/docs/connector-development/testing-connectors/source-acceptance-tests-reference.md#L240))

⚠️ ⚠️ ⚠️ 
**If tests are failing please fix the failing test by changing the `acceptance-test-config.yml` file or use `bypass_reason` fields to explain why a specific test can't be run.**

Please open a new PR if the new enabled tests help discover a new bug. 
Once this bug fix is merged please rebase this branch and run `/test` again.

You can find more details about the rules enforced by `high` test strictness level [here](https://docs.airbyte.com/connector-development/testing-connectors/source-acceptance-tests-reference/).

## Review process
Please ask the `connector-operations` teams for review.