### PR TITLE
Source Instagram: enable `high` test strictness level in SAT

### DIFF
--- a/airbyte-integrations/connectors/source-instagram/acceptance-test-config.yml
+++ b/airbyte-integrations/connectors/source-instagram/acceptance-test-config.yml
@@ -1,40 +1,38 @@
-# See [Source Acceptance Tests](https://docs.airbyte.com/connector-development/testing-connectors/source-acceptance-tests-reference)
-# for more information about how to configure these tests
-connector_image: airbyte/source-instagram:dev
-tests:
-  spec:
-    - spec_path: "integration_tests/spec.json"
-  connection:
-    - config_path: "secrets/config.json"
-      status: "succeed"
-    - config_path: "integration_tests/invalid_config.json"
-      status: "failed"
-  discovery:
-    - config_path: "secrets/config.json"
+acceptance_tests:
   basic_read:
-    - config_path: "secrets/config.json"
-      configured_catalog_path: "integration_tests/configured_catalog_without_stories.json"
-# disabled because the only incremental stream is user_insights and its state is nested
-#  incremental:
-#    - config_path: "secrets/config.json"
-#      configured_catalog_path: "integration_tests/configured_catalog.json"
-#      future_state_path: "integration_tests/abnormal_state.json"
+    tests:
+      - config_path: secrets/config.json
+  connection:
+    tests:
+      - config_path: secrets/config.json
+        status: succeed
+      - config_path: integration_tests/invalid_config.json
+        status: failed
+  discovery:
+    tests:
+      - config_path: secrets/config.json
   full_refresh:
-    - config_path: "secrets/config.json"
-      configured_catalog_path: "integration_tests/configured_catalog.json"
-      ignored_fields:
-        "user_insights":
-          - email_contacts
-          - follower_count
-          - get_directions_clicks
-          - impressions
-          - phone_call_clicks
-          - profile_views
-          - reach
-          - text_message_clicks
-          - website_clicks
-          - impressions_week
-          - reach_week
-          - impressions_days_28
-          - reach_days_28
-          - online_followers
+    tests:
+      - config_path: secrets/config.json
+        configured_catalog_path: integration_tests/configured_catalog.json
+        ignored_fields:
+          user_insights:
+            - email_contacts
+            - follower_count
+            - get_directions_clicks
+            - impressions
+            - phone_call_clicks
+            - profile_views
+            - reach
+            - text_message_clicks
+            - website_clicks
+            - impressions_week
+            - reach_week
+            - impressions_days_28
+            - reach_days_28
+            - online_followers
+  spec:
+    tests:
+      - spec_path: integration_tests/spec.json
+connector_image: airbyte/source-instagram:dev
+test_strictness_level: high


### PR DESCRIPTION
## What
A `test_strictness_level` field was introduced to Source Acceptance Tests (SAT).
Instagram is a generally_available connector, we want it to have a `high` test strictness level.

**This will help**:
- maximize the SAT coverage on this connector.
- document its potential weaknesses in term of test coverage.

## How
1. Migrate the existing `acceptance-test-config.yml` file to the latest configuration format. (See instructions [here](https://github.com/airbytehq/airbyte/blob/master/airbyte-integrations/bases/source-acceptance-test/README.md#L61))
2. Enable `high` test strictness level in `acceptance-test-config.yml`. (See instructions [here](https://github.com/airbytehq/airbyte/blob/master/docs/connector-development/testing-connectors/source-acceptance-tests-reference.md#L240))

⚠️ ⚠️ ⚠️ 
**If tests are failing please fix the failing test by changing the `acceptance-test-config.yml` file or use `bypass_reason` fields to explain why a specific test can't be run.**

Please open a new PR if the new enabled tests help discover a new bug. 
Once this bug fix is merged please rebase this branch and run `/test` again.

You can find more details about the rules enforced by `high` test strictness level [here](https://docs.airbyte.com/connector-development/testing-connectors/source-acceptance-tests-reference/).

## Review process
Please ask the `connector-operations` teams for review.