### PR TITLE
Source Mailchimp: enable `high` test strictness level in SAT

### DIFF
--- a/airbyte-integrations/connectors/source-mailchimp/acceptance-test-config.yml
+++ b/airbyte-integrations/connectors/source-mailchimp/acceptance-test-config.yml
@@ -1,66 +1,46 @@
-connector_image: airbyte/source-mailchimp:dev
-tests:
-  spec:
-    - spec_path: "source_mailchimp/spec.json"
-      timeout_seconds: 60
-  connection:
-    # for old spec config (without oneOf)
-    - config_path: "secrets/config.json"
-      status: "succeed"
-      timeout_seconds: 180
-    # for auth with API token
-    - config_path: "secrets/config_apikey.json"
-      status: "succeed"
-      timeout_seconds: 180
-    # for auth with oauth2 token
-    - config_path: "secrets/config_oauth.json"
-      status: "succeed"
-      timeout_seconds: 180
-    - config_path: "integration_tests/invalid_config.json"
-      status: "failed"
-      timeout_seconds: 180
-    - config_path: "integration_tests/invalid_config_apikey.json"
-      status: "failed"
-      timeout_seconds: 180
-    - config_path: "integration_tests/invalid_config_oauth.json"
-      status: "failed"
-      timeout_seconds: 180
-  discovery:
-    # for old spec config (without oneOf)
-    - config_path: "secrets/config.json"
-    # for auth with API token
-    - config_path: "secrets/config_apikey.json"
-    # for auth with oauth2 token
-    - config_path: "secrets/config_oauth.json"
+acceptance_tests:
   basic_read:
-    - config_path: "secrets/config.json"
-      configured_catalog_path: "integration_tests/configured_catalog.json"
-      timeout_seconds: 1800
-    - config_path: "secrets/config_oauth.json"
-      configured_catalog_path: "integration_tests/configured_catalog.json"
-      timeout_seconds: 1800
-#  THIS TEST IS COMMENTED OUT. Tests are supposed to accept
-#  `state = {cursor_field: value}`. When we have dependent endpoint path
-#  `path_begin/{some_id}/path_end` we need a complex state like below:
-#  `{"id1": {cursor_field: value}, "id2": {cursor_field: value}...}`
-#  The test currently is not supposed to accept this desired construction,
-#  so it is commented out
-
-#  incremental:
-#    - config_path: "secrets/config.json"
-#      configured_catalog_path: "integration_tests/configured_catalog.json"
-#      future_state_path: "integration_tests/state.json"
-#      cursor_paths:
-#        lists: [ "date_created" ]
-#        campaigns: [ "create_time" ]
-#        Email_activity: [ "timestamp" ]
-
-  # Email activities stream has working campaigns with email newsletters.
-  # Due to this sequential_reads test could be failed.
+    tests:
+      - config_path: secrets/config.json
+        timeout_seconds: 1800
+      - config_path: secrets/config_oauth.json
+        timeout_seconds: 1800
+  connection:
+    tests:
+      - config_path: secrets/config.json
+        status: succeed
+        timeout_seconds: 180
+      - config_path: secrets/config_apikey.json
+        status: succeed
+        timeout_seconds: 180
+      - config_path: secrets/config_oauth.json
+        status: succeed
+        timeout_seconds: 180
+      - config_path: integration_tests/invalid_config.json
+        status: failed
+        timeout_seconds: 180
+      - config_path: integration_tests/invalid_config_apikey.json
+        status: failed
+        timeout_seconds: 180
+      - config_path: integration_tests/invalid_config_oauth.json
+        status: failed
+        timeout_seconds: 180
+  discovery:
+    tests:
+      - config_path: secrets/config.json
+      - config_path: secrets/config_apikey.json
+      - config_path: secrets/config_oauth.json
   full_refresh:
-    - config_path: "secrets/config.json"
-      configured_catalog_path: "integration_tests/configured_catalog_without_email_activities.json"
-      timeout_seconds: 1800
-    - config_path: "secrets/config_oauth.json"
-      configured_catalog_path: "integration_tests/configured_catalog_without_email_activities.json"
-      timeout_seconds: 1800
+    tests:
+      - config_path: secrets/config.json
+        configured_catalog_path: integration_tests/configured_catalog_without_email_activities.json
+        timeout_seconds: 1800
+      - config_path: secrets/config_oauth.json
+        configured_catalog_path: integration_tests/configured_catalog_without_email_activities.json
+        timeout_seconds: 1800
+  spec:
+    tests:
+      - spec_path: source_mailchimp/spec.json
+        timeout_seconds: 60
+connector_image: airbyte/source-mailchimp:dev
+test_strictness_level: high


### PR DESCRIPTION
## What
A `test_strictness_level` field was introduced to Source Acceptance Tests (SAT).
Mailchimp is a generally_available connector, we want it to have a `high` test strictness level.

**This will help**:
- maximize the SAT coverage on this connector.
- document its potential weaknesses in term of test coverage.

## How
1. Migrate the existing `acceptance-test-config.yml` file to the latest configuration format. (See instructions [here](https://github.com/airbytehq/airbyte/blob/master/airbyte-integrations/bases/source-acceptance-test/README.md#L61))
2. Enable `high` test strictness level in `acceptance-test-config.yml`. (See instructions [here](https://github.com/airbytehq/airbyte/blob/master/docs/connector-development/testing-connectors/source-acceptance-tests-reference.md#L240))

⚠️ ⚠️ ⚠️ 
**If tests are failing please fix the failing test by changing the `acceptance-test-config.yml` file or use `bypass_reason` fields to explain why a specific test can't be run.**

Please open a new PR if the new enabled tests help discover a new bug. 
Once this bug fix is merged please rebase this branch and run `/test` again.

You can find more details about the rules enforced by `high` test strictness level [here](https://docs.airbyte.com/connector-development/testing-connectors/source-acceptance-tests-reference/).

## Review process
Please ask the `connector-operations` teams for review.