### PR TITLE
Source Paypal Transaction: enable `high` test strictness level in SAT

### DIFF
--- a/airbyte-integrations/connectors/source-paypal-transaction/acceptance-test-config.yml
+++ b/airbyte-integrations/connectors/source-paypal-transaction/acceptance-test-config.yml
@@ -1,36 +1,24 @@
-# See [Source Acceptance Tests](https://docs.airbyte.com/connector-development/testing-connectors/source-acceptance-tests-reference)
-# for more information about how to configure these tests
-connector_image: airbyte/source-paypal-transaction:dev
-tests:
-  spec:
-    - spec_path: "source_paypal_transaction/spec.json"
-  connection:
-    - config_path: "secrets/config.json"
-      status: "succeed"
-    - config_path: "integration_tests/invalid_config.json"
-      status: "failed"
-    - config_path: "secrets/config_oauth.json"
-      status: "succeed"
-    - config_path: "integration_tests/invalid_config_oauth.json"
-      status: "failed"
-  discovery:
-    - config_path: "secrets/config.json"
+acceptance_tests:
   basic_read:
-    # Sometimes test could fail (on weekends) because transactions could temporary disappear from Paypal Sandbox account
-    - config_path: "secrets/config.json"
-      configured_catalog_path: "integration_tests/configured_catalog.json"
-      empty_streams: ["transactions"]
-    # Two-sequence read is failing because of "last_refresh_time" property inside of response,
-    # It is enough to have basic_read test for all the records to check.
-  # full_refresh:
-  #  - config_path: "secrets/config.json"
-  #    configured_catalog_path: "integration_tests/configured_catalog.json"
-  # incremental:
-    # Only "Transactions" stream is tested here because "Balances" stream always return
-    # at least one message (and causes test failure)
-  #  - config_path: "secrets/config.json"
-  #    configured_catalog_path: "integration_tests/configured_catalog_transactions.json"
-  #    future_state_path: "integration_tests/abnormal_state.json"
-  #    cursor_paths:
-  #      transactions: ["date"]
-
+    tests:
+      - config_path: secrets/config.json
+        empty_streams:
+          - name: transactions
+  connection:
+    tests:
+      - config_path: secrets/config.json
+        status: succeed
+      - config_path: integration_tests/invalid_config.json
+        status: failed
+      - config_path: secrets/config_oauth.json
+        status: succeed
+      - config_path: integration_tests/invalid_config_oauth.json
+        status: failed
+  discovery:
+    tests:
+      - config_path: secrets/config.json
+  spec:
+    tests:
+      - spec_path: source_paypal_transaction/spec.json
+connector_image: airbyte/source-paypal-transaction:dev
+test_strictness_level: high


### PR DESCRIPTION
## What
A `test_strictness_level` field was introduced to Source Acceptance Tests (SAT).
Paypal Transaction is a generally_available connector, we want it to have a `high` test strictness level.

**This will help**:
- maximize the SAT coverage on this connector.
- document its potential weaknesses in term of test coverage.

## How
1. Migrate the existing `acceptance-test-config.yml` file to the latest configuration format. (See instructions [here](https://github.com/airbytehq/airbyte/blob/master/airbyte-integrations/bases/source-acceptance-test/README.md#L61))
2. Enable `high` test strictness level in `acceptance-test-config.yml`. (See instructions [here](https://github.com/airbytehq/airbyte/blob/master/docs/connector-development/testing-connectors/source-acceptance-tests-reference.md#L240))

⚠️ ⚠️ ⚠️ 
**If tests are failing please fix the failing test by changing the `acceptance-test-config.yml` file or use `bypass_reason` fields to explain why a specific test can't be run.**

Please open a new PR if the new enabled tests help discover a new bug. 
Once this bug fix is merged please rebase this branch and run `/test` again.

You can find more details about the rules enforced by `high` test strictness level [here](https://docs.airbyte.com/connector-development/testing-connectors/source-acceptance-tests-reference/).

## Review process
Please ask the `connector-operations` teams for review.