### PR TITLE
Source Pinterest: enable `high` test strictness level in SAT

### DIFF
--- a/airbyte-integrations/connectors/source-pinterest/acceptance-test-config.yml
+++ b/airbyte-integrations/connectors/source-pinterest/acceptance-test-config.yml
@@ -1,56 +1,41 @@
-# See [Source Acceptance Tests](https://docs.airbyte.com/connector-development/testing-connectors/source-acceptance-tests-reference)
-# for more information about how to configure these tests
-connector_image: airbyte/source-pinterest:dev
-tests:
-  spec:
-      # TODO: remove backward compatibility checks once updated to version `>0.1.3`
-      # because for OAuth2.0 implementation the specs are different
-    - spec_path: "source_pinterest/spec.json"
-      backward_compatibility_tests_config:
-        disable_for_version: "0.1.2"
-  connection:
-    - config_path: "secrets/config.json"
-      status: "succeed"
-    - config_path: "integration_tests/invalid_config.json"
-      status: "failed"
-    - config_path: "secrets/config_oauth.json"
-      status: "succeed"
-  discovery:
-      # TODO: remove backward compatibility checks once updated to version `>0.1.3`
-    - config_path: "secrets/config.json"
-      backward_compatibility_tests_config:
-        disable_for_version: "0.1.2"
-    - config_path: "secrets/config_oauth.json"
-      backward_compatibility_tests_config:
-        disable_for_version: "0.1.2"
+acceptance_tests:
   basic_read:
-    - config_path: "secrets/config.json"
-      configured_catalog_path: "integration_tests/configured_catalog.json"
-      # empty streams could be produced because of very low rate limits
-      empty_streams: [
-        "ad_account_analytics",
-        "ad_accounts",
-        "ad_analytics",
-        "ad_group_analytics",
-        "ad_groups",
-        "ads",
-        "board_pins",
-        "board_section_pins",
-        "board_sections",
-        "boards",
-        "campaign_analytics",
-        "campaigns",
-        "user_account_analytics",
-      ]
-  
-  # INFO: `incremental` and `full_refresh` tests are commented out because of very small Rate Limits for Pinterest API
-  # They simply not going to pass with Trial Account, having 300 api calls in total.
-  # The basic_read test is totaly enough to verify key things of this connector.
-  # Once upgraded to Standard Plan - they could be uncomment back.
-
-  # incremental:
-  #   - config_path: "secrets/config.json"
-  #     configured_catalog_path: "integration_tests/configured_catalog.json"
-  # full_refresh:
-  #   - config_path: "secrets/config.json"
-  #     configured_catalog_path: "integration_tests/configured_catalog.json"
+    tests:
+      - config_path: secrets/config.json
+        empty_streams:
+          - name: ad_account_analytics
+          - name: ad_accounts
+          - name: ad_analytics
+          - name: ad_group_analytics
+          - name: ad_groups
+          - name: ads
+          - name: board_pins
+          - name: board_section_pins
+          - name: board_sections
+          - name: boards
+          - name: campaign_analytics
+          - name: campaigns
+          - name: user_account_analytics
+  connection:
+    tests:
+      - config_path: secrets/config.json
+        status: succeed
+      - config_path: integration_tests/invalid_config.json
+        status: failed
+      - config_path: secrets/config_oauth.json
+        status: succeed
+  discovery:
+    tests:
+      - backward_compatibility_tests_config:
+          disable_for_version: 0.1.2
+        config_path: secrets/config.json
+      - backward_compatibility_tests_config:
+          disable_for_version: 0.1.2
+        config_path: secrets/config_oauth.json
+  spec:
+    tests:
+      - backward_compatibility_tests_config:
+          disable_for_version: 0.1.2
+        spec_path: source_pinterest/spec.json
+connector_image: airbyte/source-pinterest:dev
+test_strictness_level: high


### PR DESCRIPTION
## What
A `test_strictness_level` field was introduced to Source Acceptance Tests (SAT).
Pinterest is a generally_available connector, we want it to have a `high` test strictness level.

**This will help**:
- maximize the SAT coverage on this connector.
- document its potential weaknesses in term of test coverage.

## How
1. Migrate the existing `acceptance-test-config.yml` file to the latest configuration format. (See instructions [here](https://github.com/airbytehq/airbyte/blob/master/airbyte-integrations/bases/source-acceptance-test/README.md#L61))
2. Enable `high` test strictness level in `acceptance-test-config.yml`. (See instructions [here](https://github.com/airbytehq/airbyte/blob/master/docs/connector-development/testing-connectors/source-acceptance-tests-reference.md#L240))

⚠️ ⚠️ ⚠️ 
**If tests are failing please fix the failing test by changing the `acceptance-test-config.yml` file or use `bypass_reason` fields to explain why a specific test can't be run.**

Please open a new PR if the new enabled tests help discover a new bug. 
Once this bug fix is merged please rebase this branch and run `/test` again.

You can find more details about the rules enforced by `high` test strictness level [here](https://docs.airbyte.com/connector-development/testing-connectors/source-acceptance-tests-reference/).

## Review process
Please ask the `connector-operations` teams for review.