### PR TITLE
Source S3: enable `high` test strictness level in SAT

### DIFF
--- a/airbyte-integrations/connectors/source-s3/acceptance-test-config.yml
+++ b/airbyte-integrations/connectors/source-s3/acceptance-test-config.yml
@@ -1,146 +1,124 @@
-# See [Source Acceptance Tests](https://docs.airbyte.com/connector-development/testing-connectors/source-acceptance-tests-reference)
-# for more information about how to configure these tests
-connector_image: airbyte/source-s3:dev
-tests:
-  spec:
-    - spec_path: "integration_tests/spec.json"
-  connection:
-    # for CSV format
-    - config_path: "secrets/config.json"
-      status: "succeed"
-    # for Parquet format
-    - config_path: "secrets/parquet_config.json"
-      status: "succeed"
-    # # for Avro format
-    - config_path: "secrets/avro_config.json"
-      status:
-        "succeed"
-        # for JSON format
-    - config_path: "secrets/jsonl_config.json"
-      status: "succeed"
-    - config_path: "secrets/jsonl_newlines_config.json"
-      status: "succeed"
-    # for custom server
-    - config_path: "integration_tests/config_minio.json"
-      status: "succeed"
-    - config_path: "integration_tests/invalid_config.json"
-      status: "failed"
-  discovery:
-    # for CSV format
-    - config_path: "secrets/config.json"
-    # for Parquet format
-    - config_path: "secrets/parquet_config.json"
-    # for Avro format
-    - config_path: "secrets/avro_config.json"
-    # for JSON format
-    - config_path: "secrets/jsonl_config.json"
-    - config_path: "secrets/jsonl_newlines_config.json"
-    # for custom server
-    - config_path: "integration_tests/config_minio.json"
+acceptance_tests:
   basic_read:
-    # for CSV format
-    - config_path: "secrets/config.json"
-      timeout_seconds: 1800
-      configured_catalog_path: "integration_tests/configured_catalogs/csv.json"
-      expect_records:
-        path: "integration_tests/expected_records/csv.txt"
-    # for Parquet format
-    - config_path: "secrets/parquet_config.json"
-      timeout_seconds: 1800
-      configured_catalog_path: "integration_tests/configured_catalogs/parquet.json"
-      expect_records:
-        path: "integration_tests/expected_records/parquet.txt"
-      # for Avro format
-    - config_path: "secrets/avro_config.json"
-      timeout_seconds: 1800
-      configured_catalog_path: "integration_tests/configured_catalogs/avro.json"
-      expect_records:
-        path: "integration_tests/expected_records/avro.txt"
-    # for JSONL format
-    - config_path: "secrets/jsonl_config.json"
-      timeout_seconds: 1800
-      configured_catalog_path: "integration_tests/configured_catalogs/jsonl.json"
-      expect_records:
-        path: "integration_tests/expected_records/jsonl.txt"
-    - config_path: "secrets/jsonl_newlines_config.json"
-      timeout_seconds: 1800
-      configured_catalog_path: "integration_tests/configured_catalogs/jsonl.json"
-      expect_records:
-        path: "integration_tests/expected_records/jsonl_newlines.txt"
-    # for custom server
-    - config_path: "integration_tests/config_minio.json"
-      timeout_seconds: 1800
-      configured_catalog_path: "integration_tests/configured_catalogs/csv.json"
-      # expected records contains _ab_source_file_last_modified property which
-      # is modified all the time s3 file changed and for custom server it is
-      # file creating date and it always new. Uncomment this line when SAT
-      # would have ability to ignore specific fields from expected records.
-      # expect_records:
-      #  path: "integration_tests/expected_records/custom_server.txt"
-  incremental:
-    # for CSV format
-    - config_path: "secrets/config.json"
-      timeout_seconds: 1800
-      configured_catalog_path: "integration_tests/configured_catalogs/csv.json"
-      cursor_paths:
-        test: ["_ab_source_file_last_modified"]
-      future_state_path: "integration_tests/abnormal_state.json"
-    # for Parquet format
-    - config_path: "secrets/parquet_config.json"
-      timeout_seconds: 1800
-      configured_catalog_path: "integration_tests/configured_catalogs/parquet.json"
-      cursor_paths:
-        test: ["_ab_source_file_last_modified"]
-      future_state_path: "integration_tests/abnormal_state.json"
-    # for Avro format
-    - config_path: "secrets/avro_config.json"
-      timeout_seconds: 1800
-      configured_catalog_path: "integration_tests/configured_catalogs/avro.json"
-      cursor_paths:
-        test: ["_ab_source_file_last_modified"]
-      future_state_path: "integration_tests/abnormal_state.json"
-    # for JSON format
-    - config_path: "secrets/jsonl_config.json"
-      timeout_seconds: 1800
-      configured_catalog_path: "integration_tests/configured_catalogs/jsonl.json"
-      cursor_paths:
-        test: ["_ab_source_file_last_modified"]
-      future_state_path: "integration_tests/abnormal_state.json"
-    - config_path: "secrets/jsonl_newlines_config.json"
-      timeout_seconds: 1800
-      configured_catalog_path: "integration_tests/configured_catalogs/jsonl.json"
-      cursor_paths:
-        test: ["_ab_source_file_last_modified"]
-      future_state_path: "integration_tests/abnormal_state.json"
-    # for custom server
-    - config_path: "integration_tests/config_minio.json"
-      timeout_seconds: 1800
-      configured_catalog_path: "integration_tests/configured_catalogs/csv.json"
-      cursor_paths:
-        test: ["_ab_source_file_last_modified"]
-      future_state_path: "integration_tests/abnormal_state.json"
-
+    tests:
+      - config_path: secrets/config.json
+        expect_records:
+          path: integration_tests/expected_records/csv.txt
+        timeout_seconds: 1800
+      - config_path: secrets/parquet_config.json
+        expect_records:
+          path: integration_tests/expected_records/parquet.txt
+        timeout_seconds: 1800
+      - config_path: secrets/avro_config.json
+        expect_records:
+          path: integration_tests/expected_records/avro.txt
+        timeout_seconds: 1800
+      - config_path: secrets/jsonl_config.json
+        expect_records:
+          path: integration_tests/expected_records/jsonl.txt
+        timeout_seconds: 1800
+      - config_path: secrets/jsonl_newlines_config.json
+        expect_records:
+          path: integration_tests/expected_records/jsonl_newlines.txt
+        timeout_seconds: 1800
+      - config_path: integration_tests/config_minio.json
+        timeout_seconds: 1800
+  connection:
+    tests:
+      - config_path: secrets/config.json
+        status: succeed
+      - config_path: secrets/parquet_config.json
+        status: succeed
+      - config_path: secrets/avro_config.json
+        status: succeed
+      - config_path: secrets/jsonl_config.json
+        status: succeed
+      - config_path: secrets/jsonl_newlines_config.json
+        status: succeed
+      - config_path: integration_tests/config_minio.json
+        status: succeed
+      - config_path: integration_tests/invalid_config.json
+        status: failed
+  discovery:
+    tests:
+      - config_path: secrets/config.json
+      - config_path: secrets/parquet_config.json
+      - config_path: secrets/avro_config.json
+      - config_path: secrets/jsonl_config.json
+      - config_path: secrets/jsonl_newlines_config.json
+      - config_path: integration_tests/config_minio.json
   full_refresh:
-    # for CSV format
-    - config_path: "secrets/config.json"
-      timeout_seconds: 1800
-      configured_catalog_path: "integration_tests/configured_catalogs/csv.json"
-    # for Parquet format
-    - config_path: "secrets/parquet_config.json"
-      timeout_seconds: 1800
-      configured_catalog_path: "integration_tests/configured_catalogs/parquet.json"
-    # for Avro format
-    - config_path: "secrets/avro_config.json"
-      timeout_seconds: 1800
-      configured_catalog_path: "integration_tests/configured_catalogs/avro.json"
-    # for JSON format
-    - config_path: "secrets/jsonl_config.json"
-      timeout_seconds: 1800
-      configured_catalog_path: "integration_tests/configured_catalogs/jsonl.json"
-    - config_path: "secrets/jsonl_newlines_config.json"
-      timeout_seconds: 1800
-      configured_catalog_path: "integration_tests/configured_catalogs/jsonl.json"
-    # for custom server
-    - config_path: "integration_tests/config_minio.json"
-      timeout_seconds: 1800
-      configured_catalog_path: "integration_tests/configured_catalogs/csv.json"
+    tests:
+      - config_path: secrets/config.json
+        configured_catalog_path: integration_tests/configured_catalogs/csv.json
+        timeout_seconds: 1800
+      - config_path: secrets/parquet_config.json
+        configured_catalog_path: integration_tests/configured_catalogs/parquet.json
+        timeout_seconds: 1800
+      - config_path: secrets/avro_config.json
+        configured_catalog_path: integration_tests/configured_catalogs/avro.json
+        timeout_seconds: 1800
+      - config_path: secrets/jsonl_config.json
+        configured_catalog_path: integration_tests/configured_catalogs/jsonl.json
+        timeout_seconds: 1800
+      - config_path: secrets/jsonl_newlines_config.json
+        configured_catalog_path: integration_tests/configured_catalogs/jsonl.json
+        timeout_seconds: 1800
+      - config_path: integration_tests/config_minio.json
+        configured_catalog_path: integration_tests/configured_catalogs/csv.json
+        timeout_seconds: 1800
+  incremental:
+    tests:
+      - config_path: secrets/config.json
+        configured_catalog_path: integration_tests/configured_catalogs/csv.json
+        cursor_paths:
+          test:
+            - _ab_source_file_last_modified
+        future_state:
+          future_state_path: integration_tests/abnormal_state.json
+        timeout_seconds: 1800
+      - config_path: secrets/parquet_config.json
+        configured_catalog_path: integration_tests/configured_catalogs/parquet.json
+        cursor_paths:
+          test:
+            - _ab_source_file_last_modified
+        future_state:
+          future_state_path: integration_tests/abnormal_state.json
+        timeout_seconds: 1800
+      - config_path: secrets/avro_config.json
+        configured_catalog_path: integration_tests/configured_catalogs/avro.json
+        cursor_paths:
+          test:
+            - _ab_source_file_last_modified
+        future_state:
+          future_state_path: integration_tests/abnormal_state.json
+        timeout_seconds: 1800
+      - config_path: secrets/jsonl_config.json
+        configured_catalog_path: integration_tests/configured_catalogs/jsonl.json
+        cursor_paths:
+          test:
+            - _ab_source_file_last_modified
+        future_state:
+          future_state_path: integration_tests/abnormal_state.json
+        timeout_seconds: 1800
+      - config_path: secrets/jsonl_newlines_config.json
+        configured_catalog_path: integration_tests/configured_catalogs/jsonl.json
+        cursor_paths:
+          test:
+            - _ab_source_file_last_modified
+        future_state:
+          future_state_path: integration_tests/abnormal_state.json
+        timeout_seconds: 1800
+      - config_path: integration_tests/config_minio.json
+        configured_catalog_path: integration_tests/configured_catalogs/csv.json
+        cursor_paths:
+          test:
+            - _ab_source_file_last_modified
+        future_state:
+          future_state_path: integration_tests/abnormal_state.json
+        timeout_seconds: 1800
+  spec:
+    tests:
+      - spec_path: integration_tests/spec.json
+connector_image: airbyte/source-s3:dev
+test_strictness_level: high


### PR DESCRIPTION
## What
A `test_strictness_level` field was introduced to Source Acceptance Tests (SAT).
S3 is a generally_available connector, we want it to have a `high` test strictness level.

**This will help**:
- maximize the SAT coverage on this connector.
- document its potential weaknesses in term of test coverage.

## How
1. Migrate the existing `acceptance-test-config.yml` file to the latest configuration format. (See instructions [here](https://github.com/airbytehq/airbyte/blob/master/airbyte-integrations/bases/source-acceptance-test/README.md#L61))
2. Enable `high` test strictness level in `acceptance-test-config.yml`. (See instructions [here](https://github.com/airbytehq/airbyte/blob/master/docs/connector-development/testing-connectors/source-acceptance-tests-reference.md#L240))

⚠️ ⚠️ ⚠️ 
**If tests are failing please fix the failing test by changing the `acceptance-test-config.yml` file or use `bypass_reason` fields to explain why a specific test can't be run.**

Please open a new PR if the new enabled tests help discover a new bug. 
Once this bug fix is merged please rebase this branch and run `/test` again.

You can find more details about the rules enforced by `high` test strictness level [here](https://docs.airbyte.com/connector-development/testing-connectors/source-acceptance-tests-reference/).

## Review process
Please ask the `connector-operations` teams for review.