### PR TITLE
Source Stripe: enable `high` test strictness level in SAT

### DIFF
--- a/airbyte-integrations/connectors/source-stripe/acceptance-test-config.yml
+++ b/airbyte-integrations/connectors/source-stripe/acceptance-test-config.yml
@@ -1,49 +1,54 @@
-connector_image: airbyte/source-stripe:dev
-tests:
-  spec:
-    - spec_path: "source_stripe/spec.yaml"
-  connection:
-    - config_path: "secrets/config.json"
-      status: "succeed"
-    - config_path: "secrets/connected_account_config.json"
-      status: "succeed"
-    - config_path: "integration_tests/invalid_config.json"
-      status: "failed"
-  discovery:
-    - config_path: "secrets/config.json"
-      backward_compatibility_tests_config:
-        disable_for_version: "0.1.37"
-    - config_path: "secrets/connected_account_config.json"
-      backward_compatibility_tests_config:
-        disable_for_version: "0.1.37"
+acceptance_tests:
   basic_read:
-    - config_path: "secrets/config.json"
-      configured_catalog_path: "integration_tests/full_refresh_configured_catalog.json"
-      empty_streams: ["external_account_bank_accounts"]
-    # TEST 1 - Reading catalog without invoice_line_items
-    - config_path: "secrets/config.json"
-      configured_catalog_path: "integration_tests/non_invoice_line_items_catalog.json"
-      timeout_seconds: 3600
-    # TEST 2 - Reading data from account that has no records for stream Disputes
-    - config_path: "secrets/connected_account_config.json"
-      configured_catalog_path: "integration_tests/connected_account_configured_catalog.json"
-      timeout_seconds: 3600
-  incremental:
-    - config_path: "secrets/config.json"
-      configured_catalog_path: "integration_tests/non_invoice_line_items_catalog.json"
-      future_state_path: "integration_tests/abnormal_state.json"
-    - config_path: "secrets/connected_account_config.json"
-      configured_catalog_path: "integration_tests/connected_account_configured_catalog.json"
-      future_state_path: "integration_tests/abnormal_state.json"
+    tests:
+      - config_path: secrets/config.json
+        empty_streams:
+          - name: external_account_bank_accounts
+      - config_path: secrets/config.json
+        timeout_seconds: 3600
+      - config_path: secrets/connected_account_config.json
+        timeout_seconds: 3600
+  connection:
+    tests:
+      - config_path: secrets/config.json
+        status: succeed
+      - config_path: secrets/connected_account_config.json
+        status: succeed
+      - config_path: integration_tests/invalid_config.json
+        status: failed
+  discovery:
+    tests:
+      - backward_compatibility_tests_config:
+          disable_for_version: 0.1.37
+        config_path: secrets/config.json
+      - backward_compatibility_tests_config:
+          disable_for_version: 0.1.37
+        config_path: secrets/connected_account_config.json
   full_refresh:
-    - config_path: "secrets/config.json"
-      configured_catalog_path: "integration_tests/non_invoice_line_items_catalog.json"
-      timeout_seconds: 3600
-    - config_path: "secrets/config.json"
-      configured_catalog_path: "integration_tests/full_refresh_configured_catalog.json"
-    - config_path: "secrets/connected_account_config.json"
-      configured_catalog_path: "integration_tests/connected_account_configured_catalog.json"
-      ignored_fields:
-        "invoices":
-          - invoice_pdf
-          - hosted_invoice_url
+    tests:
+      - config_path: secrets/config.json
+        configured_catalog_path: integration_tests/non_invoice_line_items_catalog.json
+        timeout_seconds: 3600
+      - config_path: secrets/config.json
+        configured_catalog_path: integration_tests/full_refresh_configured_catalog.json
+      - config_path: secrets/connected_account_config.json
+        configured_catalog_path: integration_tests/connected_account_configured_catalog.json
+        ignored_fields:
+          invoices:
+            - invoice_pdf
+            - hosted_invoice_url
+  incremental:
+    tests:
+      - config_path: secrets/config.json
+        configured_catalog_path: integration_tests/non_invoice_line_items_catalog.json
+        future_state:
+          future_state_path: integration_tests/abnormal_state.json
+      - config_path: secrets/connected_account_config.json
+        configured_catalog_path: integration_tests/connected_account_configured_catalog.json
+        future_state:
+          future_state_path: integration_tests/abnormal_state.json
+  spec:
+    tests:
+      - spec_path: source_stripe/spec.yaml
+connector_image: airbyte/source-stripe:dev
+test_strictness_level: high


### PR DESCRIPTION
## What
A `test_strictness_level` field was introduced to Source Acceptance Tests (SAT).
Stripe is a generally_available connector, we want it to have a `high` test strictness level.

**This will help**:
- maximize the SAT coverage on this connector.
- document its potential weaknesses in term of test coverage.

## How
1. Migrate the existing `acceptance-test-config.yml` file to the latest configuration format. (See instructions [here](https://github.com/airbytehq/airbyte/blob/master/airbyte-integrations/bases/source-acceptance-test/README.md#L61))
2. Enable `high` test strictness level in `acceptance-test-config.yml`. (See instructions [here](https://github.com/airbytehq/airbyte/blob/master/docs/connector-development/testing-connectors/source-acceptance-tests-reference.md#L240))

⚠️ ⚠️ ⚠️ 
**If tests are failing please fix the failing test by changing the `acceptance-test-config.yml` file or use `bypass_reason` fields to explain why a specific test can't be run.**

Please open a new PR if the new enabled tests help discover a new bug. 
Once this bug fix is merged please rebase this branch and run `/test` again.

You can find more details about the rules enforced by `high` test strictness level [here](https://docs.airbyte.com/connector-development/testing-connectors/source-acceptance-tests-reference/).

## Review process
Please ask the `connector-operations` teams for review.