### PR TITLE
Source TikTok Marketing: enable `high` test strictness level in SAT

### DIFF
--- a/airbyte-integrations/connectors/source-tiktok-marketing/acceptance-test-config.yml
+++ b/airbyte-integrations/connectors/source-tiktok-marketing/acceptance-test-config.yml
@@ -1,90 +1,87 @@
-# See [Source Acceptance Tests](https://docs.airbyte.com/connector-development/testing-connectors/source-acceptance-tests-reference)
-# for more information about how to configure these tests
-
-connector_image: airbyte/source-tiktok-marketing:dev
-tests:
-  spec:
-    - spec_path: "integration_tests/spec.json"
-
-  connection:
-    - config_path: "secrets/prod_config.json"
-      status: "succeed"
-    - config_path: "secrets/prod_config_with_day_granularity.json"
-      status: "succeed"
-    - config_path: "secrets/prod_config_with_lifetime_granularity.json"
-      status: "succeed"
-    - config_path: "secrets/new_config_prod.json"
-      status: "succeed"
-    - config_path: "secrets/config_oauth.json"
-      status: "succeed"
-    - config_path: "integration_tests/invalid_config.json"
-      status: "failed"
-    - config_path: "integration_tests/invalid_config_access_token.json"
-      status: "failed"
-    - config_path: "integration_tests/invalid_config_oauth.json"
-      status: "failed"
-
-  discovery:
-    - config_path: "secrets/prod_config.json"
-      backward_compatibility_tests_config:
-        disable_for_version: "0.1.14"
-    - config_path: "secrets/prod_config_with_day_granularity.json"
-      backward_compatibility_tests_config:
-        disable_for_version: "0.1.14"
-    - config_path: "secrets/prod_config_with_lifetime_granularity.json"
-      backward_compatibility_tests_config:
-        disable_for_version: "0.1.14"
-    - config_path: "secrets/config.json"
-      backward_compatibility_tests_config:
-        disable_for_version: "0.1.14"
-    - config_path: "secrets/new_config_prod.json"
-      backward_compatibility_tests_config:
-        disable_for_version: "0.1.14"
-    - config_path: "secrets/config_oauth.json"
-      backward_compatibility_tests_config:
-        disable_for_version: "0.1.14"
-
+acceptance_tests:
   basic_read:
-    # New style streams (for >= 0.1.13):
-    - config_path: "secrets/prod_config.json"
-      configured_catalog_path: "integration_tests/streams_basic.json"
-      timeout_seconds: 1200
-    - config_path: "secrets/prod_config.json"
-      configured_catalog_path: "integration_tests/streams_reports_daily.json"
-      timeout_seconds: 1200
-    - config_path: "secrets/prod_config.json"
-      configured_catalog_path: "integration_tests/streams_reports_lifetime.json"
-      timeout_seconds: 1200
-    # Old style streams with granularity config (for < 0.1.13)
-    # Note: not needed to be tested separately in full and incremental tests, because code of
-    # these streams is called directly in new style streams
-    - config_path: "secrets/prod_config_with_day_granularity.json"
-      configured_catalog_path: "integration_tests/streams_with_day_granularity.json"
-      timeout_seconds: 1200
-    - config_path: "secrets/prod_config_with_lifetime_granularity.json"
-      configured_catalog_path: "integration_tests/streams_with_lifetime_granularity.json"
-      timeout_seconds: 1200
-
-  incremental:
-    - config_path: "secrets/prod_config.json"
-      configured_catalog_path: "integration_tests/streams_basic.json"
-      timeout_seconds: 7200
-      future_state_path: "integration_tests/abnormal_state.json"
-    - config_path: "secrets/prod_config.json"
-      configured_catalog_path: "integration_tests/streams_reports_daily.json"
-      timeout_seconds: 7200
-      future_state_path: "integration_tests/abnormal_state.json"
-    # LIFETIME granularity: does not support incremental sync
-
+    tests:
+      - config_path: secrets/prod_config.json
+        timeout_seconds: 1200
+      - config_path: secrets/prod_config.json
+        timeout_seconds: 1200
+      - config_path: secrets/prod_config.json
+        timeout_seconds: 1200
+      - config_path: secrets/prod_config_with_day_granularity.json
+        timeout_seconds: 1200
+      - config_path: secrets/prod_config_with_lifetime_granularity.json
+        timeout_seconds: 1200
+  connection:
+    tests:
+      - config_path: secrets/prod_config.json
+        status: succeed
+      - config_path: secrets/prod_config_with_day_granularity.json
+        status: succeed
+      - config_path: secrets/prod_config_with_lifetime_granularity.json
+        status: succeed
+      - config_path: secrets/new_config_prod.json
+        status: succeed
+      - config_path: secrets/config_oauth.json
+        status: succeed
+      - config_path: integration_tests/invalid_config.json
+        status: failed
+      - config_path: integration_tests/invalid_config_access_token.json
+        status: failed
+      - config_path: integration_tests/invalid_config_oauth.json
+        status: failed
+  discovery:
+    tests:
+      - backward_compatibility_tests_config:
+          disable_for_version: 0.1.14
+        config_path: secrets/prod_config.json
+      - backward_compatibility_tests_config:
+          disable_for_version: 0.1.14
+        config_path: secrets/prod_config_with_day_granularity.json
+      - backward_compatibility_tests_config:
+          disable_for_version: 0.1.14
+        config_path: secrets/prod_config_with_lifetime_granularity.json
+      - backward_compatibility_tests_config:
+          disable_for_version: 0.1.14
+        config_path: secrets/config.json
+      - backward_compatibility_tests_config:
+          disable_for_version: 0.1.14
+        config_path: secrets/new_config_prod.json
+      - backward_compatibility_tests_config:
+          disable_for_version: 0.1.14
+        config_path: secrets/config_oauth.json
   full_refresh:
-    - config_path: "secrets/prod_config.json"
-      configured_catalog_path: "integration_tests/streams_basic.json"
-      timeout_seconds: 7200
-      ignored_fields:  # Important: sometimes some streams does not return the same records in subsequent syncs
-        "ad_groups": ["dayparting", "enable_search_result", "display_mode", "schedule_infos", "feed_type", "status" ]
-    - config_path: "secrets/prod_config.json"
-      configured_catalog_path: "integration_tests/streams_reports_daily.json"
-      timeout_seconds: 7200
-    - config_path: "secrets/prod_config.json"
-      configured_catalog_path: "integration_tests/streams_reports_lifetime.json"
-      timeout_seconds: 7200
+    tests:
+      - config_path: secrets/prod_config.json
+        configured_catalog_path: integration_tests/streams_basic.json
+        ignored_fields:
+          ad_groups:
+            - dayparting
+            - enable_search_result
+            - display_mode
+            - schedule_infos
+            - feed_type
+            - status
+        timeout_seconds: 7200
+      - config_path: secrets/prod_config.json
+        configured_catalog_path: integration_tests/streams_reports_daily.json
+        timeout_seconds: 7200
+      - config_path: secrets/prod_config.json
+        configured_catalog_path: integration_tests/streams_reports_lifetime.json
+        timeout_seconds: 7200
+  incremental:
+    tests:
+      - config_path: secrets/prod_config.json
+        configured_catalog_path: integration_tests/streams_basic.json
+        future_state:
+          future_state_path: integration_tests/abnormal_state.json
+        timeout_seconds: 7200
+      - config_path: secrets/prod_config.json
+        configured_catalog_path: integration_tests/streams_reports_daily.json
+        future_state:
+          future_state_path: integration_tests/abnormal_state.json
+        timeout_seconds: 7200
+  spec:
+    tests:
+      - spec_path: integration_tests/spec.json
+connector_image: airbyte/source-tiktok-marketing:dev
+test_strictness_level: high


### PR DESCRIPTION
## What
A `test_strictness_level` field was introduced to Source Acceptance Tests (SAT).
TikTok Marketing is a generally_available connector, we want it to have a `high` test strictness level.

**This will help**:
- maximize the SAT coverage on this connector.
- document its potential weaknesses in term of test coverage.

## How
1. Migrate the existing `acceptance-test-config.yml` file to the latest configuration format. (See instructions [here](https://github.com/airbytehq/airbyte/blob/master/airbyte-integrations/bases/source-acceptance-test/README.md#L61))
2. Enable `high` test strictness level in `acceptance-test-config.yml`. (See instructions [here](https://github.com/airbytehq/airbyte/blob/master/docs/connector-development/testing-connectors/source-acceptance-tests-reference.md#L240))

⚠️ ⚠️ ⚠️ 
**If tests are failing please fix the failing test by changing the `acceptance-test-config.yml` file or use `bypass_reason` fields to explain why a specific test can't be run.**

Please open a new PR if the new enabled tests help discover a new bug. 
Once this bug fix is merged please rebase this branch and run `/test` again.

You can find more details about the rules enforced by `high` test strictness level [here](https://docs.airbyte.com/connector-development/testing-connectors/source-acceptance-tests-reference/).

## Review process
Please ask the `connector-operations` teams for review.