### PR TITLE
Source Zendesk Chat: enable `high` test strictness level in SAT

### DIFF
--- a/airbyte-integrations/connectors/source-zendesk-chat/acceptance-test-config.yml
+++ b/airbyte-integrations/connectors/source-zendesk-chat/acceptance-test-config.yml
@@ -1,35 +1,42 @@
-connector_image: airbyte/source-zendesk-chat:dev
-tests:
-  spec:
-    - spec_path: "source_zendesk_chat/spec.json"
-  connection:
-    - config_path: "secrets/config_old.json"
-      status: "succeed"
-    - config_path: "secrets/config.json"
-      status: "succeed"
-    - config_path: "secrets/config_oauth.json"
-      status: "succeed"
-    - config_path: "integration_tests/invalid_config.json"
-      status: "failed"
-  discovery:
-    - config_path: "secrets/config_old.json"
-    - config_path: "secrets/config.json"
-    - config_path: "secrets/config_oauth.json"
+acceptance_tests:
   basic_read:
-    - config_path: "secrets/config.json"
-      configured_catalog_path: "integration_tests/configured_catalog.json"
-    - config_path: "secrets/config_oauth.json"
-      configured_catalog_path: "integration_tests/configured_catalog.json"
-  incremental:
-    - config_path: "secrets/config.json"
-      configured_catalog_path: "integration_tests/configured_catalog.json"
-      # Unable to use 'future_state_path' because Zendesk Chat API returns an error when specifying a date in the future.
-      # future_state_path: "integration_tests/abnormal_state.json"
-      cursor_paths:
-        agents: [ "id" ]
-        bans: [ "id" ]
-        agent_timeline: [ "start_time" ]
-        chats: [ "update_timestamp" ]
+    tests:
+      - config_path: secrets/config.json
+      - config_path: secrets/config_oauth.json
+  connection:
+    tests:
+      - config_path: secrets/config_old.json
+        status: succeed
+      - config_path: secrets/config.json
+        status: succeed
+      - config_path: secrets/config_oauth.json
+        status: succeed
+      - config_path: integration_tests/invalid_config.json
+        status: failed
+  discovery:
+    tests:
+      - config_path: secrets/config_old.json
+      - config_path: secrets/config.json
+      - config_path: secrets/config_oauth.json
   full_refresh:
-    - config_path: "secrets/config.json"
-      configured_catalog_path: "integration_tests/configured_catalog.json"
+    tests:
+      - config_path: secrets/config.json
+        configured_catalog_path: integration_tests/configured_catalog.json
+  incremental:
+    tests:
+      - config_path: secrets/config.json
+        configured_catalog_path: integration_tests/configured_catalog.json
+        cursor_paths:
+          agent_timeline:
+            - start_time
+          agents:
+            - id
+          bans:
+            - id
+          chats:
+            - update_timestamp
+  spec:
+    tests:
+      - spec_path: source_zendesk_chat/spec.json
+connector_image: airbyte/source-zendesk-chat:dev
+test_strictness_level: high


### PR DESCRIPTION
## What
A `test_strictness_level` field was introduced to Source Acceptance Tests (SAT).
Zendesk Chat is a generally_available connector, we want it to have a `high` test strictness level.

**This will help**:
- maximize the SAT coverage on this connector.
- document its potential weaknesses in term of test coverage.

## How
1. Migrate the existing `acceptance-test-config.yml` file to the latest configuration format. (See instructions [here](https://github.com/airbytehq/airbyte/blob/master/airbyte-integrations/bases/source-acceptance-test/README.md#L61))
2. Enable `high` test strictness level in `acceptance-test-config.yml`. (See instructions [here](https://github.com/airbytehq/airbyte/blob/master/docs/connector-development/testing-connectors/source-acceptance-tests-reference.md#L240))

⚠️ ⚠️ ⚠️ 
**If tests are failing please fix the failing test by changing the `acceptance-test-config.yml` file or use `bypass_reason` fields to explain why a specific test can't be run.**

Please open a new PR if the new enabled tests help discover a new bug. 
Once this bug fix is merged please rebase this branch and run `/test` again.

You can find more details about the rules enforced by `high` test strictness level [here](https://docs.airbyte.com/connector-development/testing-connectors/source-acceptance-tests-reference/).

## Review process
Please ask the `connector-operations` teams for review.