### PR TITLE
use longer short shas

### DIFF
--- a/.github/actions/build-branch/action.yml
+++ b/.github/actions/build-branch/action.yml
@@ -18,7 +18,7 @@ runs:
         # if the *branch_version_tag* input param is not specified, then generate it as 'dev-<commit_hash>`
         #
         [[ "${{ inputs.branch_version_tag }}" != '' ]] && echo "branch_version_tag=${{ inputs.branch_version_tag }}" >> $GITHUB_OUTPUT \
-          || { short_hash=$(git rev-parse --short=7 HEAD); echo "branch_version_tag=dev-$short_hash" >> $GITHUB_OUTPUT ; }
+          || { short_hash=$(git rev-parse --short=10 HEAD); echo "branch_version_tag=dev-$short_hash" >> $GITHUB_OUTPUT ; }
 
     - uses: actions/setup-java@v1
       with:

--- a/.github/workflows/publish-oss-for-cloud.yml
+++ b/.github/workflows/publish-oss-for-cloud.yml
@@ -62,7 +62,7 @@ jobs:
         run: |-
           set -x
 
-          commit_sha=$(git rev-parse --short=7 HEAD)
+          commit_sha=$(git rev-parse --short=10 HEAD)
 
           # set dev_tag
           # AirbyteVersion.java allows versions that have a prefix of 'dev'


### PR DESCRIPTION
it seems github APIs want us to use longer shas in some cases where a 7 character short sha is still entirely valid

So just set the minimum short sha length to 10
