### PR TITLE
:window: :wrench: Increase LaunchDarkly initialization timeout

### DIFF
--- a/airbyte-webapp/src/packages/cloud/services/thirdParty/launchdarkly/LDExperimentService.tsx
+++ b/airbyte-webapp/src/packages/cloud/services/thirdParty/launchdarkly/LDExperimentService.tsx
@@ -20,7 +20,7 @@ import { rejectAfter } from "utils/promises";
  * The maximum time in milliseconds we'll wait for LaunchDarkly to finish initialization,
  * before running disabling it.
  */
-const INITIALIZATION_TIMEOUT = 1500;
+const INITIALIZATION_TIMEOUT = 5000;
 
 const FEATURE_FLAG_EXPERIMENT = "featureService.overwrites";
 


### PR DESCRIPTION
## What

Increase the LaunchDarkly timeout which we'll wait for initialization. This is mostly a security mechanism to prevent failing (or slowing down completely) the app in case LD doesn't work. 1.5s was rather low and we saw it already on slower internet connections not initializing, thus increasing to 5s.