### PR TITLE
Add SAT test for no duplicates in `enum` properties

### DIFF
--- a/airbyte-integrations/bases/source-acceptance-test/pytest.ini
+++ b/airbyte-integrations/bases/source-acceptance-test/pytest.ini
@@ -7,3 +7,4 @@ testpaths =
 markers =
     default_timeout
     slow: marks tests as slow (deselect with '-m "not slow"')
+    backward_compatibility

--- a/airbyte-integrations/bases/source-acceptance-test/source_acceptance_test/tests/test_core.py
+++ b/airbyte-integrations/bases/source-acceptance-test/source_acceptance_test/tests/test_core.py
@@ -81,6 +81,16 @@ class TestSpec(BaseTest):
             docker_runner.entry_point
         ), "env should be equal to space-joined entrypoint"
 
+    def test_enum_usage(self, actual_connector_spec: ConnectorSpecification):
+        """Check that enum lists in specs contain distinct values."""
+
+        schema_helper = JsonSchemaHelper(actual_connector_spec.connectionSpecification)
+        enum_paths = schema_helper.find_nodes(keys=["enum"])
+
+        for path in enum_paths:
+            enum_list = schema_helper.get_node(path)
+            assert len(set(enum_list)) == len(enum_list), f"Enum lists should not contain duplicate values. Misconfigured enum array: {enum_list}."
+
     def test_oneof_usage(self, actual_connector_spec: ConnectorSpecification):
         """Check that if spec contains oneOf it follows the rules according to reference
         https://docs.airbyte.io/connector-development/connector-specification-reference

--- a/airbyte-integrations/bases/source-acceptance-test/source_acceptance_test/tests/test_core.py
+++ b/airbyte-integrations/bases/source-acceptance-test/source_acceptance_test/tests/test_core.py
@@ -83,13 +83,15 @@ class TestSpec(BaseTest):
 
     def test_enum_usage(self, actual_connector_spec: ConnectorSpecification):
         """Check that enum lists in specs contain distinct values."""
+        docs_url = "https://docs.airbyte.io/connector-development/connector-specification-reference"
+        docs_msg = f"See specification reference at {docs_url}."
 
         schema_helper = JsonSchemaHelper(actual_connector_spec.connectionSpecification)
         enum_paths = schema_helper.find_nodes(keys=["enum"])
 
         for path in enum_paths:
             enum_list = schema_helper.get_node(path)
-            assert len(set(enum_list)) == len(enum_list), f"Enum lists should not contain duplicate values. Misconfigured enum array: {enum_list}."
+            assert len(set(enum_list)) == len(enum_list), f"Enum lists should not contain duplicate values. Misconfigured enum array: {enum_list}. {docs_msg}"
 
     def test_oneof_usage(self, actual_connector_spec: ConnectorSpecification):
         """Check that if spec contains oneOf it follows the rules according to reference

--- a/airbyte-integrations/bases/source-acceptance-test/unit_tests/test_spec.py
+++ b/airbyte-integrations/bases/source-acceptance-test/unit_tests/test_spec.py
@@ -350,6 +350,49 @@ def test_oneof_usage(connector_spec, should_fail):
     else:
         t.test_oneof_usage(actual_connector_spec=ConnectorSpecification(connectionSpecification=connector_spec))
 
+@parametrize_test_case(
+    {
+        "test_id": "successful",
+        "connector_spec": {
+            "type": "object",
+            "properties": {
+                "property_with_options": {
+                    "title": "Property with options",
+                    "description": "A property in the form of an enumerated list",
+                    "type": "string",
+                    "default": "Option 1",
+                    "enum": ["Option 1", "Option 2", "Option 3"],
+                }
+            },
+        },
+        "should_fail": False,
+    },
+    {
+        "test_id": "duplicate_values",
+        "connector_spec": {
+            "type": "object",
+            "properties": {
+                "property_with_options": {
+                    "title": "Property with options",
+                    "description": "A property in the form of an enumerated list",
+                    "type": "string",
+                    "default": "Option 1",
+                    "enum": ["Option 1", "Option 2", "Option 3", "Option 2"],
+                }
+            },
+        },
+        "should_fail": True,
+    },
+)
+def test_enum_usage(connector_spec, should_fail):
+    t = _TestSpec()
+    if should_fail is True:
+        with pytest.raises(AssertionError):
+            t.test_enum_usage(actual_connector_spec=ConnectorSpecification(connectionSpecification=connector_spec))
+    else:
+        t.test_enum_usage(actual_connector_spec=ConnectorSpecification(connectionSpecification=connector_spec))
+
+
 
 @pytest.mark.parametrize(
     "connector_spec, expected_error",

--- a/docs/connector-development/connector-specification-reference.md
+++ b/docs/connector-development/connector-specification-reference.md
@@ -96,12 +96,14 @@ In this case, use the `"airbyte_hidden": true` keyword to hide that field from t
 }
 ```
 
+Results in the following form:
+
 ![hidden fields](../.gitbook/assets/spec_reference_hidden_field_screenshot.png)
 
-Results in the following form: 
 
+## Airbyte Modifications to `jsonschema`
 
-### Using `oneOf`s
+### Using `oneOf`
 
 In some cases, a connector needs to accept one out of many options. For example, a connector might need to know the compression codec of the file it will read, which will render in the Airbyte UI as a list of the available codecs. In JSONSchema, this can be expressed using the [oneOf](https://json-schema.org/understanding-json-schema/reference/combining.html#oneof) keyword.
 
@@ -178,3 +180,28 @@ In each item in the `oneOf` array, the `option_title` string field exists with t
 }
 ```
 
+### Using `enum`
+
+In regular `jsonschema`, some drafts enforce that `enum` lists must contain distinct values, while others do not. For consistency, Airbyte enforces this restriction.
+
+For example, this spec is invalid, since `a_format` is listed twice under the enumerated property `format`:
+
+```javascript
+{
+  "connection_specification": {
+    "$schema": "http://json-schema.org/draft-07/schema#",
+    "title": "File Source Spec",
+    "type": "object",
+    "required": ["format"],
+    "properties": {
+      "dataset_name": {
+        ...
+      },
+      "format": {
+        type: "string",
+        enum: ["a_format", "another_format", "a_format"]
+      },
+    }
+  }
+}
+```


### PR DESCRIPTION
## What
- Stop users from writing `enum` lists that contain duplicate values, since we don't want duplicates values in the UI list. 
- Close #18740 

## How
* Decide to enforce this, although some jsonschema drafts, in particular draft7 doesn't canonically (see [thread](https://airbytehq-team.slack.com/archives/C03VDJ4FMJB/p1667940125196249) for the rabbit hole that lead to this conclusion)
* Add SAT test that checks correct usage of `enum` by Airbyte's standards 

## 🚨 User Impact 🚨
- Users with custom connectors that contain specsc with duplicate `enum` values will no longer pass SAT. This shouldn't affect anything in production, but will stop connectors from being published until they pass the new test.

## Pre-merge Checklist
- [x] Run `/test` on a few connectors as sanity checks
  * connector without `enum`: `source-airtable`
  * source with `enum`: `source-amazon-ads`