### PR TITLE
[low-code] publish the cdk

### DIFF
--- a/airbyte-cdk/python/CHANGELOG.md
+++ b/airbyte-cdk/python/CHANGELOG.md
@@ -1,5 +1,8 @@
 # Changelog
 
+## 0.8.0
+Low-code: Allow for request and response to be emitted as log messages
+
 ## 0.7.1
 Low-code: Decouple yaml manifest parsing from the declarative source implementation
 

--- a/airbyte-cdk/python/setup.py
+++ b/airbyte-cdk/python/setup.py
@@ -15,7 +15,7 @@ README = (HERE / "README.md").read_text()
 
 setup(
     name="airbyte-cdk",
-    version="0.7.1",
+    version="0.8.0",
     description="A framework for writing Airbyte Connectors.",
     long_description=README,
     long_description_content_type="text/markdown",


### PR DESCRIPTION
Publishes a new version of the CDK for the PR: https://github.com/airbytehq/airbyte/pull/18644 . Needs a new version so that it can be used by the connector builder server