### PR TITLE
don't update cursor for log messages and and default schema path coming from connector builder

### DIFF
--- a/airbyte-cdk/python/CHANGELOG.md
+++ b/airbyte-cdk/python/CHANGELOG.md
@@ -1,5 +1,8 @@
 # Changelog
 
+## 0.8.1
+Low-code: Don't update cursor for non-record messages and fix default loader for connector builder manifests
+
 ## 0.8.0
 Low-code: Allow for request and response to be emitted as log messages
 

--- a/airbyte-cdk/python/airbyte_cdk/sources/declarative/retrievers/simple_retriever.py
+++ b/airbyte-cdk/python/airbyte_cdk/sources/declarative/retrievers/simple_retriever.py
@@ -371,11 +371,14 @@ class SimpleRetriever(Retriever, HttpStream, JsonSchemaMixin):
             stream_state,
         )
         for record in records_generator:
-            self.stream_slicer.update_cursor(stream_slice, last_record=record)
+            # Only record messages should be parsed to update the cursor which is indicated by the Mapping type
+            if isinstance(record, Mapping):
+                self.stream_slicer.update_cursor(stream_slice, last_record=record)
             yield record
         else:
             last_record = self._last_records[-1] if self._last_records else None
-            self.stream_slicer.update_cursor(stream_slice, last_record=last_record)
+            if last_record and isinstance(last_record, Mapping):
+                self.stream_slicer.update_cursor(stream_slice, last_record=last_record)
             yield from []
 
     def stream_slices(

--- a/airbyte-cdk/python/airbyte_cdk/sources/declarative/schema/default_schema_loader.py
+++ b/airbyte-cdk/python/airbyte_cdk/sources/declarative/schema/default_schema_loader.py
@@ -38,7 +38,7 @@ class DefaultSchemaLoader(SchemaLoader, JsonSchemaMixin):
 
         try:
             return self.default_loader.get_json_schema()
-        except FileNotFoundError:
+        except OSError:
             # A slight hack since we don't directly have the stream name. However, when building the default filepath we assume the
             # runtime options stores stream name 'name' so we'll do the same here
             stream_name = self._options.get("name", "")

--- a/airbyte-cdk/python/airbyte_cdk/sources/declarative/schema/json_file_schema_loader.py
+++ b/airbyte-cdk/python/airbyte_cdk/sources/declarative/schema/json_file_schema_loader.py
@@ -15,11 +15,16 @@ from dataclasses_jsonschema import JsonSchemaMixin
 
 
 def _default_file_path() -> str:
-    # schema files are always in "source_<connector_name>/schemas/<stream_name>.json
-    # the connector's module name can be inferred by looking at the modules loaded and look for the one starting with source_
+    # Schema files are always in "source_<connector_name>/schemas/<stream_name>.json
+    # The connector's module name can be inferred by looking at the modules loaded and look for the one starting with source_
+    # One exception to this rule are reads invoked from the connector builder server which is prefixed by connector_builder
     source_modules = [
-        k for k, v in sys.modules.items() if "source_" in k  # example: ['source_exchange_rates', 'source_exchange_rates.source']
+        k
+        for k, v in sys.modules.items()
+        if "source_" in k or "connector_builder" in k  # example: ['source_exchange_rates', 'source_exchange_rates.source']
     ]
+    if not source_modules:
+        raise RuntimeError("Expected at least one module starting with 'source_' or 'connector_builder'")
     if not source_modules:
         raise RuntimeError("Expected at least one module starting with 'source_'")
     module = source_modules[0].split(".")[0]

--- a/airbyte-cdk/python/airbyte_cdk/sources/declarative/schema/json_file_schema_loader.py
+++ b/airbyte-cdk/python/airbyte_cdk/sources/declarative/schema/json_file_schema_loader.py
@@ -17,18 +17,16 @@ from dataclasses_jsonschema import JsonSchemaMixin
 def _default_file_path() -> str:
     # Schema files are always in "source_<connector_name>/schemas/<stream_name>.json
     # The connector's module name can be inferred by looking at the modules loaded and look for the one starting with source_
-    # One exception to this rule are reads invoked from the connector builder server which is prefixed by connector_builder
     source_modules = [
-        k
-        for k, v in sys.modules.items()
-        if "source_" in k or "connector_builder" in k  # example: ['source_exchange_rates', 'source_exchange_rates.source']
-    ]
-    if not source_modules:
-        raise RuntimeError("Expected at least one module starting with 'source_' or 'connector_builder'")
-    if not source_modules:
-        raise RuntimeError("Expected at least one module starting with 'source_'")
-    module = source_modules[0].split(".")[0]
-    return f"./{module}/schemas/{{{{options['name']}}}}.json"
+        k for k, v in sys.modules.items() if "source_" in k
+    ]  # example: ['source_exchange_rates', 'source_exchange_rates.source']
+    if source_modules:
+        module = source_modules[0].split(".")[0]
+        return f"./{module}/schemas/{{{{options['name']}}}}.json"
+
+    # If we are not in a source_ module, the most likely scenario is we're processing a manifest from the connector builder
+    # server which does not require a json schema to be defined.
+    return "./{{options['name']}}.json"
 
 
 @dataclass

--- a/airbyte-cdk/python/setup.py
+++ b/airbyte-cdk/python/setup.py
@@ -15,7 +15,7 @@ README = (HERE / "README.md").read_text()
 
 setup(
     name="airbyte-cdk",
-    version="0.8.0",
+    version="0.8.1",
     description="A framework for writing Airbyte Connectors.",
     long_description=README,
     long_description_content_type="text/markdown",


### PR DESCRIPTION
## What
While connecting the wires for the connector builder server I found a few small issues when trying to make requests coming from the connector builder server that aren't present for real low code connectors.

## How
The two fixes required are:

- When we invoke `read()` from the connector builder, we don't have any modules prefixed by `source_` which makes sense because the builder server module is called `connector_builder`. Simplest path forward is to allow that caveat in the default logic.
- When performing `read_records` we should only attempt to update the cursor on record messages and not `AirbyteLogMessage` or `AirbyteTraceMessage` which are now valid messages from the generator. They don't have any relevant fields to update state so we should just skip over these.