### PR TITLE
:window: :art: Use StepIndicator for connection setup steps

### DIFF
--- a/airbyte-webapp/src/components/ui/StepsIndicator/StepsIndicator.module.scss
+++ b/airbyte-webapp/src/components/ui/StepsIndicator/StepsIndicator.module.scss
@@ -1,0 +1,31 @@
+@use "scss/colors";
+@use "scss/variables";
+
+.steps {
+  display: flex;
+  align-items: center;
+  gap: variables.$spacing-md;
+}
+
+.tooltip {
+  display: flex;
+}
+
+.step {
+  display: inline-block;
+  width: 35px;
+  height: 4px;
+  border-radius: 3px;
+  background-color: colors.$grey-300;
+
+  // Give the element a bit larger hover area for the tooltip to show
+  margin: 8px 0;
+
+  &.completed {
+    background-color: colors.$blue-200;
+  }
+
+  &.current {
+    background-color: colors.$blue;
+  }
+}

--- a/airbyte-webapp/src/components/ui/StepsIndicator/StepsIndicator.tsx
+++ b/airbyte-webapp/src/components/ui/StepsIndicator/StepsIndicator.tsx
@@ -1,0 +1,51 @@
+import classNames from "classnames";
+import { FormattedMessage } from "react-intl";
+
+import { Tooltip } from "components/ui/Tooltip";
+
+import styles from "./StepsIndicator.module.scss";
+
+interface Step {
+  id: string;
+  name: string;
+}
+
+interface StepIndicatorProps {
+  step: Step;
+  isCurrent: boolean;
+  isCompleted: boolean;
+}
+
+interface StepsIndicatorProps {
+  steps: Step[];
+  activeStep: string;
+  className?: string;
+}
+
+const StepIndicator: React.FC<StepIndicatorProps> = ({ step, isCurrent, isCompleted }) => {
+  return (
+    <Tooltip
+      containerClassName={styles.tooltip}
+      control={
+        <span
+          aria-label={step.name}
+          aria-current={isCurrent ? "step" : undefined}
+          className={classNames(styles.step, { [styles.current]: isCurrent, [styles.completed]: isCompleted })}
+        />
+      }
+    >
+      {step.name} {isCurrent && <FormattedMessage id="ui.stepIndicator.currentStep" />}
+    </Tooltip>
+  );
+};
+
+export const StepsIndicator: React.FC<StepsIndicatorProps> = ({ className, steps, activeStep }) => {
+  const activeIndex = steps.findIndex((step) => step.id === activeStep);
+  return (
+    <div className={classNames(className, styles.steps)}>
+      {steps.map((step, index) => (
+        <StepIndicator step={step} isCurrent={activeStep === step.id} isCompleted={index < activeIndex} />
+      ))}
+    </div>
+  );
+};

--- a/airbyte-webapp/src/components/ui/StepsIndicator/index.stories.tsx
+++ b/airbyte-webapp/src/components/ui/StepsIndicator/index.stories.tsx
@@ -1,0 +1,30 @@
+import { ComponentMeta, ComponentStory } from "@storybook/react";
+
+import { StepsIndicator } from "./StepsIndicator";
+
+export default {
+  title: "UI/StepsIndicator",
+  component: StepsIndicator,
+  argTypes: {},
+} as ComponentMeta<typeof StepsIndicator>;
+
+const Template: ComponentStory<typeof StepsIndicator> = (args) => <StepsIndicator {...args} />;
+
+export const Primary = Template.bind({});
+Primary.args = {
+  steps: [
+    {
+      id: "source",
+      name: "Create source",
+    },
+    {
+      id: "destination",
+      name: "Create destination",
+    },
+    {
+      id: "connection",
+      name: "Create connection",
+    },
+  ],
+  activeStep: "destination",
+};

--- a/airbyte-webapp/src/components/ui/StepsIndicator/index.ts
+++ b/airbyte-webapp/src/components/ui/StepsIndicator/index.ts
@@ -1,0 +1,1 @@
+export { StepsIndicator } from "./StepsIndicator";

--- a/airbyte-webapp/src/components/ui/Tooltip/Tooltip.tsx
+++ b/airbyte-webapp/src/components/ui/Tooltip/Tooltip.tsx
@@ -20,7 +20,16 @@ const FLOATING_OPTIONS: UseFloatingProps = {
 };
 
 export const Tooltip: React.FC<React.PropsWithChildren<TooltipProps>> = (props) => {
-  const { children, control, className, disabled, cursor, theme = "dark", placement = "bottom" } = props;
+  const {
+    children,
+    control,
+    className,
+    containerClassName,
+    disabled,
+    cursor,
+    theme = "dark",
+    placement = "bottom",
+  } = props;
 
   const [isMouseOver, setIsMouseOver] = useState(false);
   const [isVisible, setIsVisible] = useState(false);
@@ -59,7 +68,7 @@ export const Tooltip: React.FC<React.PropsWithChildren<TooltipProps>> = (props) 
     <>
       <div
         ref={reference}
-        className={styles.container}
+        className={classNames(styles.container, containerClassName)}
         style={disabled ? undefined : { cursor }}
         onMouseOver={onMouseOver}
         onMouseOut={onMouseOut}

--- a/airbyte-webapp/src/components/ui/Tooltip/types.ts
+++ b/airbyte-webapp/src/components/ui/Tooltip/types.ts
@@ -6,6 +6,7 @@ export type TooltipTheme = "dark" | "light";
 export interface TooltipProps {
   control: React.ReactNode;
   className?: string;
+  containerClassName?: string;
   disabled?: boolean;
   cursor?: TooltipCursor;
   theme?: TooltipTheme;

--- a/airbyte-webapp/src/locales/en.json
+++ b/airbyte-webapp/src/locales/en.json
@@ -580,6 +580,7 @@
   "ui.keyValuePairV3": "{key}, {value}",
   "ui.learnMore": "Learn more",
   "ui.secretTextArea.hidden": "Contents hidden. Click to show.",
+  "ui.stepIndicator.currentStep": "(current step)",
 
   "airbyte.datatype.string": "String",
   "airbyte.datatype.date": "Date",

--- a/airbyte-webapp/src/pages/ConnectionPage/pages/CreationFormPage/CreationFormPage.tsx
+++ b/airbyte-webapp/src/pages/ConnectionPage/pages/CreationFormPage/CreationFormPage.tsx
@@ -1,5 +1,5 @@
 import React, { useState } from "react";
-import { FormattedMessage } from "react-intl";
+import { FormattedMessage, useIntl } from "react-intl";
 import { useLocation, useNavigate } from "react-router-dom";
 
 import { LoadingPage } from "components";
@@ -9,7 +9,7 @@ import ConnectionBlock from "components/ConnectionBlock";
 import { FormPageContent } from "components/ConnectorBlocks";
 import { CreateConnectionForm } from "components/CreateConnection/CreateConnectionForm";
 import { PageHeader } from "components/ui/PageHeader";
-import { StepsMenu } from "components/ui/StepsMenu";
+import { StepsIndicator } from "components/ui/StepsIndicator";
 
 import {
   DestinationDefinitionRead,
@@ -75,6 +75,7 @@ function usePreloadData(): {
 export const CreationFormPage: React.FC = () => {
   useTrackPage(PageTrackingCodes.CONNECTIONS_NEW);
   const location = useLocation();
+  const { formatMessage } = useIntl();
 
   // exp-signup-selected-source-definition
   const state = useLocationState<{ sourceDefinitionId?: string }>();
@@ -185,30 +186,28 @@ export const CreationFormPage: React.FC = () => {
       ? [
           {
             id: StepsTypes.CREATE_ENTITY,
-            name: <FormattedMessage id="onboarding.createSource" />,
+            name: formatMessage({ id: "onboarding.createSource" }),
           },
           {
             id: StepsTypes.CREATE_CONNECTOR,
-            name: <FormattedMessage id="onboarding.createDestination" />,
+            name: formatMessage({ id: "onboarding.createDestination" }),
           },
           {
             id: StepsTypes.CREATE_CONNECTION,
-            name: <FormattedMessage id="onboarding.setUpConnection" />,
+            name: formatMessage({ id: "onboarding.setUpConnection" }),
           },
         ]
       : [
           {
             id: StepsTypes.CREATE_ENTITY,
             name:
-              type === "destination" ? (
-                <FormattedMessage id="onboarding.createDestination" />
-              ) : (
-                <FormattedMessage id="onboarding.createSource" />
-              ),
+              type === "destination"
+                ? formatMessage({ id: "onboarding.createDestination" })
+                : formatMessage({ id: "onboarding.createSource" }),
           },
           {
             id: StepsTypes.CREATE_CONNECTION,
-            name: <FormattedMessage id="onboarding.setUpConnection" />,
+            name: formatMessage({ id: "onboarding.setUpConnection" }),
           },
         ];
 
@@ -226,7 +225,7 @@ export const CreationFormPage: React.FC = () => {
       <ConnectorDocumentationWrapper>
         <PageHeader
           title={<FormattedMessage id={titleId} />}
-          middleComponent={<StepsMenu lightMode data={steps} activeStep={currentStep} />}
+          middleComponent={<StepsIndicator steps={steps} activeStep={currentStep} />}
         />
         <FormPageContent big={currentStep === StepsTypes.CREATE_CONNECTION}>
           {currentStep !== StepsTypes.CREATE_CONNECTION && (!!source || !!destination) && (


### PR DESCRIPTION
## What

Introduces a new `StepIndicator`, which is a leightweight way of presenting which step is current active. This replaces the currently used `StepMenu` in the Connection Creation flow.

![screenshot-20221110-141038](https://user-images.githubusercontent.com/877229/201109733-5e60dcf7-2750-41a4-aeca-561ec65eac7f.png)

The step title will be shown in a tooltip on hover:

![screenshot-20221110-144011](https://user-images.githubusercontent.com/877229/201109792-1c7c59ac-02d4-4b6d-b5fa-00b77cfbc8f5.png)

**Why?**

For a couple of reasons:

* We see in FullStory regularily that people think they could navigate through those steps by clicking the which they can't given it's only an indicator.
* The old indicator was specifically once the documentation panel was extended looking quiet squished because it wrote out all the titles in way too less space. Given that our primary focus is to show the user their progress and how (little) steps they have, we don't need all the indidivual step names present all the time.
* This helps us stripping down the `StepMenu` into a now proper interactive `Tab` component, since it doesn't fulfill the weird double function as a step indicator anymore.
