### PR TITLE
Add docker/helm/kube to the backend filters

### DIFF
--- a/.github/workflows/gradle.yml
+++ b/.github/workflows/gradle.yml
@@ -49,6 +49,8 @@ jobs:
               - 'airbyte-!(cdk|integrations|webapp|webapp-e2e-tests)/**'
               - 'airbyte-integrations/connectors/(destination-jdbc|destination-postgres|source-jdbc|source-postgres)/**'
               - 'airbyte-config/init/src/main/resources/seed/(source|destination)_definitions.yaml'
+              - 'docker-compose*.yaml'
+              - '(charts|kube)/**'
             build:
               - '.github/**'
               - 'buildSrc/**'


### PR DESCRIPTION
## What
Currently, when modifying docker/helm/kube configs, we do not test against the platform code, as a result, it makes it easier to break the platform.
Modifying the docker/helm/kube config should run platform tests.

## How
Update the filters to add some infra config to the backend build filter.
