### PR TITLE
:window: :wrench: Pass connector id to consent request when in edit mode

### DIFF
--- a/airbyte-webapp/src/hooks/services/useConnectorAuth.tsx
+++ b/airbyte-webapp/src/hooks/services/useConnectorAuth.tsx
@@ -7,6 +7,7 @@ import { DestinationAuthService } from "core/domain/connector/DestinationAuthSer
 import { isSourceDefinitionSpecification } from "core/domain/connector/source";
 import { SourceAuthService } from "core/domain/connector/SourceAuthService";
 import { DestinationOauthConsentRequest, SourceOauthConsentRequest } from "core/request/AirbyteClient";
+import { useConnectorForm } from "views/Connector/ConnectorForm/connectorFormContext";
 
 import { useDefaultRequestMiddlewares } from "../../services/useDefaultRequestMiddlewares";
 import { useQuery } from "../useQuery";
@@ -47,6 +48,7 @@ export function useConnectorAuth(): {
 } {
   const { workspaceId } = useCurrentWorkspace();
   const { apiUrl, oauthRedirectUrl } = useConfig();
+  const { actorId } = useConnectorForm();
 
   // TODO: move to separate initFacade and use refs instead
   const requestAuthMiddleware = useDefaultRequestMiddlewares();
@@ -74,6 +76,7 @@ export function useConnectorAuth(): {
           sourceDefinitionId: ConnectorSpecification.id(connector),
           redirectUrl: `${oauthRedirectUrl}/auth_flow`,
           oAuthInputConfiguration,
+          sourceId: actorId,
         };
         const response = await sourceAuthService.getConsentUrl(payload);
 
@@ -84,6 +87,7 @@ export function useConnectorAuth(): {
         destinationDefinitionId: ConnectorSpecification.id(connector),
         redirectUrl: `${oauthRedirectUrl}/auth_flow`,
         oAuthInputConfiguration,
+        destinationId: actorId,
       };
       const response = await destinationAuthService.getConsentUrl(payload);
 

--- a/airbyte-webapp/src/hooks/services/useConnectorAuth.tsx
+++ b/airbyte-webapp/src/hooks/services/useConnectorAuth.tsx
@@ -48,7 +48,7 @@ export function useConnectorAuth(): {
 } {
   const { workspaceId } = useCurrentWorkspace();
   const { apiUrl, oauthRedirectUrl } = useConfig();
-  const { actorId } = useConnectorForm();
+  const { connectorId } = useConnectorForm();
 
   // TODO: move to separate initFacade and use refs instead
   const requestAuthMiddleware = useDefaultRequestMiddlewares();
@@ -71,23 +71,23 @@ export function useConnectorAuth(): {
       consentUrl: string;
     }> => {
       if (isSourceDefinitionSpecification(connector)) {
-        const payload = {
+        const payload: SourceOauthConsentRequest = {
           workspaceId,
           sourceDefinitionId: ConnectorSpecification.id(connector),
           redirectUrl: `${oauthRedirectUrl}/auth_flow`,
           oAuthInputConfiguration,
-          sourceId: actorId,
+          sourceId: connectorId,
         };
         const response = await sourceAuthService.getConsentUrl(payload);
 
         return { consentUrl: response.consentUrl, payload };
       }
-      const payload = {
+      const payload: DestinationOauthConsentRequest = {
         workspaceId,
         destinationDefinitionId: ConnectorSpecification.id(connector),
         redirectUrl: `${oauthRedirectUrl}/auth_flow`,
         oAuthInputConfiguration,
-        destinationId: actorId,
+        destinationId: connectorId,
       };
       const response = await destinationAuthService.getConsentUrl(payload);
 

--- a/airbyte-webapp/src/views/Connector/ConnectorCard/ConnectorCard.tsx
+++ b/airbyte-webapp/src/views/Connector/ConnectorCard/ConnectorCard.tsx
@@ -180,6 +180,13 @@ export const ConnectorCard: React.FC<ConnectorCardCreateProps | ConnectorCardEdi
             successMessage={
               props.successMessage || (saved && props.isEditMode && <FormattedMessage id="form.changesSaved" />)
             }
+            actorId={
+              isEditMode
+                ? "sourceId" in props.connector
+                  ? props.connector.sourceId
+                  : props.connector.destinationId
+                : undefined
+            }
           />
           {/* Show the job log only if advanced mode is turned on or the actual job failed (not the check inside the job) */}
           {job && (advancedMode || !job.succeeded) && <JobItem job={job} />}

--- a/airbyte-webapp/src/views/Connector/ConnectorCard/ConnectorCard.tsx
+++ b/airbyte-webapp/src/views/Connector/ConnectorCard/ConnectorCard.tsx
@@ -11,7 +11,7 @@ import {
   ConnectorSpecification,
   ConnectorT,
 } from "core/domain/connector";
-import { SynchronousJobRead } from "core/request/AirbyteClient";
+import { DestinationRead, SourceRead, SynchronousJobRead } from "core/request/AirbyteClient";
 import { LogsRequestError } from "core/request/LogsRequestError";
 import { useAdvancedModeSetting } from "hooks/services/useAdvancedModeSetting";
 import { generateMessageFromError } from "utils/errorStatusMessage";
@@ -57,6 +57,10 @@ interface ConnectorCardEditProps extends ConnectorCardBaseProps {
   isEditMode: true;
   connector: ConnectorT;
 }
+
+const getConnectorId = (connectorRead: DestinationRead | SourceRead) => {
+  return "sourceId" in connectorRead ? connectorRead.sourceId : connectorRead.destinationId;
+};
 
 export const ConnectorCard: React.FC<ConnectorCardCreateProps | ConnectorCardEditProps> = ({
   title,
@@ -180,13 +184,7 @@ export const ConnectorCard: React.FC<ConnectorCardCreateProps | ConnectorCardEdi
             successMessage={
               props.successMessage || (saved && props.isEditMode && <FormattedMessage id="form.changesSaved" />)
             }
-            actorId={
-              isEditMode
-                ? "sourceId" in props.connector
-                  ? props.connector.sourceId
-                  : props.connector.destinationId
-                : undefined
-            }
+            connectorId={isEditMode ? getConnectorId(props.connector) : undefined}
           />
           {/* Show the job log only if advanced mode is turned on or the actual job failed (not the check inside the job) */}
           {job && (advancedMode || !job.succeeded) && <JobItem job={job} />}

--- a/airbyte-webapp/src/views/Connector/ConnectorForm/ConnectorForm.tsx
+++ b/airbyte-webapp/src/views/Connector/ConnectorForm/ConnectorForm.tsx
@@ -97,6 +97,7 @@ export interface ConnectorFormProps {
   fetchingConnectorError?: Error | null;
   errorMessage?: React.ReactNode;
   successMessage?: React.ReactNode;
+  actorId?: string;
 
   isTestConnectionInProgress?: boolean;
   onStopTesting?: () => void;
@@ -119,6 +120,7 @@ export const ConnectorForm: React.FC<ConnectorFormProps> = (props) => {
     selectedConnectorDefinition,
     selectedConnectorDefinitionSpecification,
     errorMessage,
+    actorId,
   } = props;
 
   const specifications = useBuildInitialSchema(selectedConnectorDefinitionSpecification);
@@ -199,6 +201,7 @@ export const ConnectorForm: React.FC<ConnectorFormProps> = (props) => {
           isEditMode={isEditMode}
           isLoadingSchema={isLoading}
           validationSchema={validationSchema}
+          actorId={actorId}
         >
           <RevalidateOnValidationSchemaChange validationSchema={validationSchema} />
           <FormikPatch />

--- a/airbyte-webapp/src/views/Connector/ConnectorForm/ConnectorForm.tsx
+++ b/airbyte-webapp/src/views/Connector/ConnectorForm/ConnectorForm.tsx
@@ -97,7 +97,7 @@ export interface ConnectorFormProps {
   fetchingConnectorError?: Error | null;
   errorMessage?: React.ReactNode;
   successMessage?: React.ReactNode;
-  actorId?: string;
+  connectorId?: string;
 
   isTestConnectionInProgress?: boolean;
   onStopTesting?: () => void;
@@ -120,7 +120,7 @@ export const ConnectorForm: React.FC<ConnectorFormProps> = (props) => {
     selectedConnectorDefinition,
     selectedConnectorDefinitionSpecification,
     errorMessage,
-    actorId,
+    connectorId,
   } = props;
 
   const specifications = useBuildInitialSchema(selectedConnectorDefinitionSpecification);
@@ -201,7 +201,7 @@ export const ConnectorForm: React.FC<ConnectorFormProps> = (props) => {
           isEditMode={isEditMode}
           isLoadingSchema={isLoading}
           validationSchema={validationSchema}
-          actorId={actorId}
+          connectorId={connectorId}
         >
           <RevalidateOnValidationSchemaChange validationSchema={validationSchema} />
           <FormikPatch />

--- a/airbyte-webapp/src/views/Connector/ConnectorForm/connectorFormContext.tsx
+++ b/airbyte-webapp/src/views/Connector/ConnectorForm/connectorFormContext.tsx
@@ -21,7 +21,7 @@ interface ConnectorFormContext {
   isLoadingSchema?: boolean;
   isEditMode?: boolean;
   validationSchema: AnySchema;
-  actorId?: string;
+  connectorId?: string;
 }
 
 const connectorFormContext = React.createContext<ConnectorFormContext | null>(null);
@@ -45,7 +45,7 @@ interface ConnectorFormContextProviderProps {
   getValues: <T = unknown>(values: ConnectorFormValues<T>) => ConnectorFormValues<T>;
   selectedConnectorDefinitionSpecification?: ConnectorDefinitionSpecification;
   validationSchema: AnySchema;
-  actorId?: string;
+  connectorId?: string;
 }
 
 export const ConnectorFormContextProvider: React.FC<React.PropsWithChildren<ConnectorFormContextProviderProps>> = ({
@@ -60,7 +60,7 @@ export const ConnectorFormContextProvider: React.FC<React.PropsWithChildren<Conn
   isLoadingSchema,
   validationSchema,
   isEditMode,
-  actorId,
+  connectorId,
 }) => {
   const { resetForm } = useFormikContext<ConnectorFormValues>();
 
@@ -76,7 +76,7 @@ export const ConnectorFormContextProvider: React.FC<React.PropsWithChildren<Conn
       isLoadingSchema,
       validationSchema,
       isEditMode,
-      actorId,
+      connectorId,
       unfinishedFlows,
       addUnfinishedFlow: (path, info) =>
         setUiWidgetsInfo("_common.unfinishedFlows", {
@@ -104,7 +104,7 @@ export const ConnectorFormContextProvider: React.FC<React.PropsWithChildren<Conn
     isLoadingSchema,
     validationSchema,
     isEditMode,
-    actorId,
+    connectorId,
     resetForm,
     resetUiWidgetsInfo,
   ]);

--- a/airbyte-webapp/src/views/Connector/ConnectorForm/connectorFormContext.tsx
+++ b/airbyte-webapp/src/views/Connector/ConnectorForm/connectorFormContext.tsx
@@ -21,6 +21,7 @@ interface ConnectorFormContext {
   isLoadingSchema?: boolean;
   isEditMode?: boolean;
   validationSchema: AnySchema;
+  actorId?: string;
 }
 
 const connectorFormContext = React.createContext<ConnectorFormContext | null>(null);
@@ -44,6 +45,7 @@ interface ConnectorFormContextProviderProps {
   getValues: <T = unknown>(values: ConnectorFormValues<T>) => ConnectorFormValues<T>;
   selectedConnectorDefinitionSpecification?: ConnectorDefinitionSpecification;
   validationSchema: AnySchema;
+  actorId?: string;
 }
 
 export const ConnectorFormContextProvider: React.FC<React.PropsWithChildren<ConnectorFormContextProviderProps>> = ({
@@ -58,6 +60,7 @@ export const ConnectorFormContextProvider: React.FC<React.PropsWithChildren<Conn
   isLoadingSchema,
   validationSchema,
   isEditMode,
+  actorId,
 }) => {
   const { resetForm } = useFormikContext<ConnectorFormValues>();
 
@@ -73,6 +76,7 @@ export const ConnectorFormContextProvider: React.FC<React.PropsWithChildren<Conn
       isLoadingSchema,
       validationSchema,
       isEditMode,
+      actorId,
       unfinishedFlows,
       addUnfinishedFlow: (path, info) =>
         setUiWidgetsInfo("_common.unfinishedFlows", {
@@ -100,6 +104,7 @@ export const ConnectorFormContextProvider: React.FC<React.PropsWithChildren<Conn
     isLoadingSchema,
     validationSchema,
     isEditMode,
+    actorId,
     resetForm,
     resetUiWidgetsInfo,
   ]);


### PR DESCRIPTION
## What
Fixes https://github.com/airbytehq/airbyte/issues/19316
Relates to https://github.com/airbytehq/oncall/issues/999

This PR contains the FE changes required to resolve the above OC issue, by making sure that the source or destination ID is passed to the `getConsentUrl` request when it is requested for an already-existing connector.

## How
- Adds `actorId` to the ConnectorForm as a prop
- Sets that `actorId` prop by pulling either the source or destination ID out of the `connector` prop in ConnectorCard when in edit mode
- Adds `actorId` to the ConnectorFormContext, and sets this in ConnectorForm
- Pulls the `actorId` out of the ConnectorFormContext in the `useConnectorAuth` hook just before calling `getConsentUrl`, and passes it into that request

I tested this locally on frontend-dev by clicking the OAuth button on a new source & destination setup page, and verified that the new field was not set. I then created those connectors and reauthenticated in the settings page and verified that the new field was set in the consent URL requests for both the source and dest.