### PR TITLE
:window: :bug:  Fix showing reset dialog after refresh source

### DIFF
--- a/airbyte-webapp/src/pages/ConnectionPage/pages/ConnectionItemPage/ConnectionReplicationTab.tsx
+++ b/airbyte-webapp/src/pages/ConnectionPage/pages/ConnectionItemPage/ConnectionReplicationTab.tsx
@@ -86,13 +86,23 @@ export const ConnectionReplicationTab: React.FC = () => {
         connection.operations
       );
 
-      // Detect whether the catalog has any differences in its enabled streams compared to the original one.
-      // This could be due to user changes (e.g. in the sync mode) or due to new/removed
-      // streams due to a "refreshed source schema".
-      const catalogHasChanged = !equal(
+      // Check if the user refreshed the catalog and there was any change in a currently enabled stream
+      const hasDiffInEnabledStream = connection.catalogDiff?.transforms.some(({ streamDescriptor }) => {
+        // Find the stream for this transform in our form's syncCatalog
+        const stream = formValues.syncCatalog.streams.find(
+          ({ stream }) => streamDescriptor.name === stream?.name && streamDescriptor.namespace === stream.namespace
+        );
+        return stream?.config?.selected;
+      });
+
+      // Check if the user made any modifications to enabled streams compared to the ones in the latest connection
+      // e.g. changed the sync mode of an enabled stream
+      const hasUserChangesInEnabledStreams = !equal(
         formValues.syncCatalog.streams.filter((s) => s.config?.selected),
         connection.syncCatalog.streams.filter((s) => s.config?.selected)
       );
+
+      const catalogHasChanged = hasDiffInEnabledStream || hasUserChangesInEnabledStreams;
 
       setSubmitError(null);
 
@@ -131,6 +141,7 @@ export const ConnectionReplicationTab: React.FC = () => {
     },
     [
       connection.connectionId,
+      connection.catalogDiff,
       connection.operations,
       connection.status,
       connection.syncCatalog.streams,


### PR DESCRIPTION
## What

Fixes a problem with the reset modal not showing after a user refreshed their source schema.

## How

Since https://github.com/airbytehq/airbyte/pull/16748 we updated the `connection` in `ConnectionEditService`, which is later when submitting used to compare against the form values to detect if there's a change in the catalog. Since it now always contained the updated (refreshed) connection, it would no longer diff from the form values just because of a refreshed catalog and thus the reset modal wouldn't show.

Sicne we now have the `catalogDiff` on that connection after refreshing I added logic to check if any of the transforms in this affects an enabled stream and if so show the reset modal again.