### PR TITLE
Add the /manifest_template endpoint to return a string representation of the manifest template

### DIFF
--- a/airbyte-connector-builder-server/connector_builder/impl/default_api.py
+++ b/airbyte-connector-builder-server/connector_builder/impl/default_api.py
@@ -52,7 +52,7 @@ class DefaultApiImpl(DefaultApi):
         spec:
           documentation_url: https://docsurl.com
           connection_specification:
-            title: Source Name Spec
+            title: Source Name Spec # 'TODO: Replace this with the name of your source.'
             type: object
             required:
               - api_key

--- a/airbyte-connector-builder-server/connector_builder/impl/default_api.py
+++ b/airbyte-connector-builder-server/connector_builder/impl/default_api.py
@@ -13,7 +13,56 @@ from fastapi import Body
 
 class DefaultApiImpl(DefaultApi):
     async def get_manifest_template(self) -> str:
-        return "Hello World"
+        return """version: "0.1.0"
+
+        definitions:
+          selector:
+            extractor:
+              field_pointer: []
+          requester:
+            url_base: "https://example.com"
+            http_method: "GET"
+            authenticator:
+              type: BearerAuthenticator
+              api_token: "{{ config['api_key'] }}"
+          retriever:
+            record_selector:
+              $ref: "*ref(definitions.selector)"
+            paginator:
+              type: NoPagination
+            requester:
+              $ref: "*ref(definitions.requester)"
+          base_stream:
+            retriever:
+              $ref: "*ref(definitions.retriever)"
+          customers_stream:
+            $ref: "*ref(definitions.base_stream)"
+            $options:
+              name: "customers"
+              primary_key: "id"
+              path: "/example"
+
+        streams:
+          - "*ref(definitions.customers_stream)"
+
+        check:
+          stream_names:
+            - "customers"
+
+        spec:
+          documentation_url: https://docsurl.com
+          connection_specification:
+            title: {{capitalCase name}} Spec
+            type: object
+            required:
+              - api_key
+            additionalProperties: true
+            properties:
+              # 'TODO: This schema defines the configuration required for the source. This usually involves metadata such as database and/or authentication information.':
+              api_key:
+                type: string
+                description: API Key
+"""
 
     async def list_streams(self, streams_list_request_body: StreamsListRequestBody = Body(None, description="")) -> StreamsListRead:
         raise Exception("not yet implemented")

--- a/airbyte-connector-builder-server/connector_builder/impl/default_api.py
+++ b/airbyte-connector-builder-server/connector_builder/impl/default_api.py
@@ -52,7 +52,7 @@ class DefaultApiImpl(DefaultApi):
         spec:
           documentation_url: https://docsurl.com
           connection_specification:
-            title: {{capitalCase name}} Spec
+            title: Source Name Spec
             type: object
             required:
               - api_key


### PR DESCRIPTION
## What
The UI needs to display the default manifest template the first time a developer enters the connector builder UI. This is just a flat string which will then be rendered by the UI. It includes indentation spaces and `\n` characters.

## How
Just returns a flat string. It is a little bit annoying that we have the template _mostly_ duplicated in the generator and in the connector builder server, but there are a few slight changes between the files. One example is we need to escape the interpolation block in the generator version. But in the connector server one, we don't need to.

## Recommended reading order
1. `default_api.py`