### PR TITLE
🎉 Source Shopify: remove unused `read_checkouts` scope from OAuth Flow

### DIFF
--- a/airbyte-oauth/src/main/java/io/airbyte/oauth/flows/ShopifyOAuthFlow.java
+++ b/airbyte-oauth/src/main/java/io/airbyte/oauth/flows/ShopifyOAuthFlow.java
@@ -27,7 +27,6 @@ public class ShopifyOAuthFlow extends BaseOAuth2Flow {
       "read_orders",
       "read_all_orders",
       "read_assigned_fulfillment_orders",
-      "read_checkouts",
       "read_content",
       "read_customers",
       "read_discounts",


### PR DESCRIPTION
## What
Resolving: https://github.com/airbytehq/airbyte/issues/18680

## How
Removed `read_checkouts` from scopes list for java oauth flow (server side)

## Recommended reading order
1. `x.java`