### PR TITLE
ci-connector-ops: Check test strictness level on GA source connectors

### DIFF
--- a/.github/workflows/connector_ops_ci.yml
+++ b/.github/workflows/connector_ops_ci.yml
@@ -1,0 +1,23 @@
+name: Connector Ops CI
+
+on:
+  pull_request:
+    paths:
+      - "airbyte-integrations/connectors/source-**"
+jobs:
+  test-strictness-level:
+    name: "Check test strictness level"
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout Airbyte
+        uses: actions/checkout@v3
+        with:
+          fetch-depth: 0
+      - name: Install Python
+        uses: actions/setup-python@v4
+        with:
+          python-version: "3.9"
+      - name: Install ci-connector-ops package
+        run: pip install --quiet -e ./tools/ci_connector_ops
+      - name: Check test strictness level
+        run: check-test-strictness-level

--- a/airbyte-integrations/connectors/source-facebook-marketing/acceptance-test-config.yml
+++ b/airbyte-integrations/connectors/source-facebook-marketing/acceptance-test-config.yml
@@ -22,4 +22,3 @@ tests:
       skip_comprehensive_incremental_tests: true
   full_refresh:
     - config_path: "secrets/config.json"
-# TODO remove this change

--- a/airbyte-integrations/connectors/source-facebook-marketing/acceptance-test-config.yml
+++ b/airbyte-integrations/connectors/source-facebook-marketing/acceptance-test-config.yml
@@ -22,3 +22,4 @@ tests:
       skip_comprehensive_incremental_tests: true
   full_refresh:
     - config_path: "secrets/config.json"
+# TODO remove this change

--- a/tools/ci_connector_ops/ci_connector_ops/__init__.py
+++ b/tools/ci_connector_ops/ci_connector_ops/__init__.py
@@ -1,0 +1,3 @@
+#
+# Copyright (c) 2022 Airbyte, Inc., all rights reserved.
+#

--- a/tools/ci_connector_ops/ci_connector_ops/check_test_strictness_level.py
+++ b/tools/ci_connector_ops/ci_connector_ops/check_test_strictness_level.py
@@ -41,7 +41,9 @@ def find_connectors_with_bad_strictness_level() -> List[str]:
 def main():
     connectors_with_bad_strictness_level = find_connectors_with_bad_strictness_level()
     if connectors_with_bad_strictness_level:
-        logging.error(f"The following GA connectors must enable high test strictness level: {connectors_with_bad_strictness_level}")
+        logging.error(
+            f"The following GA connectors must enable high test strictness level: {connectors_with_bad_strictness_level}. Please check this documentation for details: https://docs.airbyte.com/connector-development/testing-connectors/source-acceptance-tests-reference/#strictness-level"
+        )
         sys.exit(1)
     else:
         sys.exit(0)

--- a/tools/ci_connector_ops/ci_connector_ops/check_test_strictness_level.py
+++ b/tools/ci_connector_ops/ci_connector_ops/check_test_strictness_level.py
@@ -1,0 +1,51 @@
+#
+# Copyright (c) 2022 Airbyte, Inc., all rights reserved.
+#
+
+import logging
+import sys
+from typing import List
+
+from ci_connector_ops import utils
+
+RELEASE_STAGE_TO_STRICTNESS_LEVEL_MAPPING = {"generally_available": "high"}
+
+
+def find_connectors_with_bad_strictness_level() -> List[str]:
+    """Check if changed connectors have the expected SAT test strictness level according to their release stage.
+    1. Identifies changed connectors
+    2. Retrieve their release stage from the catalog
+    3. Parse their acceptance test config file
+    4. Check if the test strictness level matches the strictness level expected for their release stage.
+
+    Returns:
+        List[str]: List of changed connector names that are not matching test strictness level expectations.
+    """
+    connectors_with_bad_strictness_level = []
+    changed_connector_names = utils.get_changed_connector_names()
+    for connector_name in changed_connector_names:
+        connector_release_stage = utils.get_connector_release_stage(connector_name)
+        expected_test_strictness_level = RELEASE_STAGE_TO_STRICTNESS_LEVEL_MAPPING.get(connector_release_stage)
+        _, acceptance_test_config = utils.get_acceptance_test_config(connector_name)
+        can_check_strictness_level = all(
+            [item is not None for item in [connector_release_stage, expected_test_strictness_level, acceptance_test_config]]
+        )
+        if can_check_strictness_level:
+            try:
+                assert acceptance_test_config.get("test_strictness_level") == expected_test_strictness_level
+            except AssertionError:
+                connectors_with_bad_strictness_level.append(connector_name)
+    return connectors_with_bad_strictness_level
+
+
+def main():
+    connectors_with_bad_strictness_level = find_connectors_with_bad_strictness_level()
+    if connectors_with_bad_strictness_level:
+        logging.error(f"The following GA connectors must enable high test strictness level: {connectors_with_bad_strictness_level}")
+        sys.exit(1)
+    else:
+        sys.exit(0)
+
+
+if __name__ == "__main__":
+    main()

--- a/tools/ci_connector_ops/ci_connector_ops/check_test_strictness_level.py
+++ b/tools/ci_connector_ops/ci_connector_ops/check_test_strictness_level.py
@@ -13,7 +13,7 @@ RELEASE_STAGE_TO_STRICTNESS_LEVEL_MAPPING = {"generally_available": "high"}
 
 def find_connectors_with_bad_strictness_level() -> List[str]:
     """Check if changed connectors have the expected SAT test strictness level according to their release stage.
-    1. Identifies changed connectors
+    1. Identify changed connectors
     2. Retrieve their release stage from the catalog
     3. Parse their acceptance test config file
     4. Check if the test strictness level matches the strictness level expected for their release stage.

--- a/tools/ci_connector_ops/ci_connector_ops/utils.py
+++ b/tools/ci_connector_ops/ci_connector_ops/utils.py
@@ -1,0 +1,96 @@
+#
+# Copyright (c) 2022 Airbyte, Inc., all rights reserved.
+#
+import logging
+from typing import Dict, List, Optional, Tuple
+
+import git
+import requests
+import yaml
+
+AIRBYTE_REPO = git.Repo(".")
+OSS_CATALOG_URL = "https://storage.googleapis.com/prod-airbyte-cloud-connector-metadata-service/oss_catalog.json"
+CONNECTOR_PATH_PREFIX = "airbyte-integrations/connectors"
+SOURCE_CONNECTOR_PATH_PREFIX = CONNECTOR_PATH_PREFIX + "/source-"
+ACCEPTANCE_TEST_CONFIG_FILE_NAME = "acceptance-test-config.yml"
+AIRBYTE_DOCKER_REPO = "airbyte"
+
+
+def download_catalog(catalog_url):
+    response = requests.get(catalog_url)
+    return response.json()
+
+
+OSS_CATALOG = download_catalog(OSS_CATALOG_URL)
+
+
+def get_changed_connector_names() -> List[str]:
+    """Retrieve a list of connector names that were changed in the current branch (compared to master).
+
+    Returns:
+        List[str]: List of connector names e.g ["source-pokeapi"]
+    """
+    head_commit = AIRBYTE_REPO.head.commit
+    master_diffs = head_commit.diff(AIRBYTE_REPO.remotes.origin.refs.master)
+    changed_source_connector_files = [diff.b_path for diff in master_diffs if diff.b_path.startswith(SOURCE_CONNECTOR_PATH_PREFIX)]
+
+    def get_connector_name_from_path(path):
+        return path.split("/")[2]
+
+    return [get_connector_name_from_path(changed_file) for changed_file in changed_source_connector_files]
+
+
+def get_connector_definition(connector_name: str, catalog: Dict = OSS_CATALOG) -> Optional[Dict]:
+    """Find a connector definition from the catalog.
+
+    Args:
+        connector_name (str): The connector name. E.G. 'source-pokeapi'
+        catalog (Dict, optional): The connector catalog. Defaults to OSS_CATALOG.
+
+    Raises:
+        Exception: Raised if the definition type (source/destination) could not be determined from connector name.
+
+    Returns:
+        Optional[Dict]: The definition if the connector was found in the catalo. Returns None otherwise.
+    """
+    try:
+        definition_type = connector_name.split("-")[0]
+        assert definition_type in ["source", "destination"]
+    except AssertionError:
+        raise Exception(f"Could not determine the definition type for {connector_name}.")
+    for definition in catalog[definition_type + "s"]:
+        if definition["dockerRepository"].replace(f"{AIRBYTE_DOCKER_REPO}/", "") == connector_name:
+            return definition
+
+
+def get_connector_release_stage(connector_name: str, catalog: Dict = OSS_CATALOG) -> Optional[str]:
+    """Retrieve the connector release stage (E.G. alpha/beta/generally_available).
+
+    Args:
+        connector_name (str): The connector name. E.G. 'source-pokeapi'
+        catalog (Dict, optional): The connector catalog. Defaults to OSS_CATALOG.
+
+    Returns:
+        Optional[str]: The connector release stage if it was defined. Returns None otherwise.
+    """
+    definition = get_connector_definition(connector_name, catalog)
+    return definition.get("releaseStage")
+
+
+def get_acceptance_test_config(connector_name: str) -> Tuple[str, Dict]:
+    """Retrieve the acceptance test config file path and its content as dict.
+
+    Args:
+        connector_name (str): The connector name. E.G. 'source-pokeapi'
+
+
+    Returns:
+        Tuple(str, Dict): The acceptance test config file path and its content as dict.
+    """
+    acceptance_test_config_path = f"{CONNECTOR_PATH_PREFIX}/{connector_name}/{ACCEPTANCE_TEST_CONFIG_FILE_NAME}"
+    try:
+        with open(acceptance_test_config_path) as acceptance_test_config_file:
+            return acceptance_test_config_path, yaml.safe_load(acceptance_test_config_file)
+    except FileNotFoundError:
+        logging.warning(f"No {ACCEPTANCE_TEST_CONFIG_FILE_NAME} file found for {connector_name}")
+        return None, None

--- a/tools/ci_connector_ops/setup.py
+++ b/tools/ci_connector_ops/setup.py
@@ -1,0 +1,25 @@
+#
+# Copyright (c) 2022 Airbyte, Inc., all rights reserved.
+#
+
+
+from setuptools import find_packages, setup
+
+MAIN_REQUIREMENTS = ["requests", "PyYAML~=6.0", "GitPython~=3.1.29"]
+
+
+setup(
+    version="0.1.0",
+    name="ci_connector_ops",
+    description="Packaged maintained by the connector operations team to perform CI for connectors",
+    author="Airbyte",
+    author_email="contact@airbyte.io",
+    packages=find_packages(),
+    install_requires=MAIN_REQUIREMENTS,
+    python_requires=">=3.9",
+    entry_points={
+        "console_scripts": [
+            "check-test-strictness-level = ci_connector_ops.check_test_strictness_level:main",
+        ],
+    },
+)


### PR DESCRIPTION
## What
Closes #19378 
Now the `test_strictness_level` option is available on SAT's `acceptance-test-config.yml` we want to enforce the usage of `high`  `test_strictness_level` on GA connectors.

## How
* Create a new python package call `ci-connector-ops`. It can be used in the future for addition of othe CI checks our connector ops team might implement.
* Add a script with a bunch of utils to check if the modified connectors are GA and have `test_strictness_level == high` in their `acceptance-test-config.yml`.
* Create a new GitHub action workflow (`connector_ops_ci.yml`)with a `Check test strictness level` job,  (again, this can evolve in the future with additional jobs such as running SAT 🥁 ). This job is triggered on PRs when a connector path is modified.

## Recommended reading order
1. https://github.com/airbytehq/airbyte/blob/0455882135c0c7c833a3340f5bbf197a605ea811/.github/workflows/connector_ops_ci.yml#L1
2. https://github.com/airbytehq/airbyte/blob/0455882135c0c7c833a3340f5bbf197a605ea811/tools/ci_connector_ops/ci_connector_ops/check_test_strictness_level.py#L14
3. https://github.com/airbytehq/airbyte/blob/0455882135c0c7c833a3340f5bbf197a605ea811/tools/ci_connector_ops/ci_connector_ops/utils.py#L11

## 🚨 User Impact 🚨
This check will fail in all existing PR modifying GA connectors. It's made to encourage connectors maintainers to set `high` `test_strictness_level`.
