### PR TITLE
Change AWS runner instance type from "c5.2xlarge" to "c6a.4xlarge"

### DIFF
--- a/.github/actions/start-aws-runner/action.yml
+++ b/.github/actions/start-aws-runner/action.yml
@@ -12,7 +12,7 @@ inputs:
     default: "ami-005924fb76f7477ce"
     required: true
   ec2-instance-type:
-    default: "c5.2xlarge"
+    default: "c6a.4xlarge"
     required: true
   subnet-id:
     default: "subnet-0469a9e68a379c1d3"


### PR DESCRIPTION
Changing instance type of AWS self-hosted runner from `c5.2xlarge` to `c6a.4xlarge`.

It will result in:

CPU: 8 -> 16
Sustained clock speed (GHz): 3.4 -> 3.6
RAM: 16 -> 32
cost: 0.34 USD/hr -> 0.612 USD/hr

Details are in https://github.com/airbytehq/airbyte-cloud/issues/2737