### PR TITLE
Fixed url in Microsoft Dataverse doc

### DIFF
--- a/docs/integrations/sources/microsoft-dataverse.md
+++ b/docs/integrations/sources/microsoft-dataverse.md
@@ -9,7 +9,7 @@ This connector currently uses version v9.2 of the API
 ### Output schema
 
 This source will automatically discover the schema of the Entities of your Dataverse instance using the API
-https://<url>/api/data/v9.2/EntityDefinitions?$expand=Attributes
+`https://<url>/api/data/v9.2/EntityDefinitions?$expand=Attributes`
 
 ### Data type mapping
 


### PR DESCRIPTION
The url in the Microsoft Dataverse doc wasn't allowing me to build a docusaurus preview of our docs, so I used code backticks on the url. 