### PR TITLE
:window: :wrench: Move 'Example values' into intl

### DIFF
--- a/airbyte-webapp/src/locales/en.json
+++ b/airbyte-webapp/src/locales/en.json
@@ -550,6 +550,7 @@
   "connector.connectorsInDevelopment.docLink": "See our <lnk>documentation</lnk> for more details.",
   "connector.setupGuide": "Setup Guide",
   "connector.setupGuide.notFound": "No Setup Guide found for this connector.",
+  "connector.exampleValues": "Example {count, plural, one {value} other {values}}",
 
   "credits.credits": "Credits",
   "credits.whatAreCredits": "What are credits?",

--- a/airbyte-webapp/src/views/Connector/ConnectorForm/components/Property/LabelInfo.tsx
+++ b/airbyte-webapp/src/views/Connector/ConnectorForm/components/Property/LabelInfo.tsx
@@ -1,5 +1,6 @@
 import { JSONSchema7Type } from "json-schema";
 import React from "react";
+import { FormattedMessage } from "react-intl";
 
 import { TextWithHTML } from "components/ui/TextWithHTML";
 
@@ -35,7 +36,9 @@ const Examples: React.FC<Pick<LabelInfoProps, "examples">> = ({ examples }) => {
   return (
     <div>
       {/* don't use <Text as=h4> here, because we want the default parent styling for this header */}
-      <h4 className={styles.exampleHeader}>{`Example value${examplesArray.length > 1 ? "s" : ""}`}</h4>
+      <h4 className={styles.exampleHeader}>
+        <FormattedMessage id="connector.exampleValues" values={{ count: examplesArray.length }} />
+      </h4>
       <div className={styles.exampleContainer}>
         {examplesArray.map((example) => (
           <span className={styles.exampleItem}>{example}</span>


### PR DESCRIPTION
## What
The "Example values" header in the label info tooltip was originally not implemented in an intl-friendly way. This PR corrects that.

There should be no user-visible changes from this PR.