### PR TITLE
Revert Github runner size changes because we need to open a ticket for more

### DIFF
--- a/.github/actions/start-aws-runner/action.yml
+++ b/.github/actions/start-aws-runner/action.yml
@@ -12,7 +12,7 @@ inputs:
     default: "ami-005924fb76f7477ce"
     required: true
   ec2-instance-type:
-    default: "c6a.4xlarge"
+    default: "c5.2xlarge"
     required: true
   subnet-id:
     default: "subnet-0469a9e68a379c1d3"


### PR DESCRIPTION
This reverts commit 78fb528a9a1499c32b1a496f20628a4588c4caef.

https://airbytehq-team.slack.com/archives/C046KQF5GBT/p1668531356052829