### PR TITLE
Make sure that long running activity are not retried

### DIFF
--- a/airbyte-workers/src/main/java/io/airbyte/workers/config/ActivityBeanFactory.java
+++ b/airbyte-workers/src/main/java/io/airbyte/workers/config/ActivityBeanFactory.java
@@ -170,6 +170,7 @@ public class ActivityBeanFactory {
   public RetryOptions containerOrchestratorRetryOptions() {
     return RetryOptions.newBuilder()
         .setDoNotRetry(RuntimeException.class.getName(), WorkerException.class.getName())
+        .setMaximumAttempts(1)
         .build();
   }
 


### PR DESCRIPTION
## What

Make sure https://github.com/airbytehq/oncall/issues/350 don't happen again. Currrently if a timeout error is happening, the replication activity will be retry in loop and makes the connection to be stuck. This PR ensure that we don't retry it. 