### PR TITLE
Fix flaky tests

### DIFF
--- a/airbyte-api/src/main/openapi/config.yaml
+++ b/airbyte-api/src/main/openapi/config.yaml
@@ -4019,6 +4019,11 @@ components:
           $ref: "#/components/schemas/SourceDefinitionRead"
         destinationDefinition:
           $ref: "#/components/schemas/DestinationDefinitionRead"
+    WorkflowStateRead:
+      type: object
+      properties:
+        running:
+          type: boolean
     JobWithAttemptsRead:
       type: object
       properties:
@@ -4210,6 +4215,8 @@ components:
           type: array
           items:
             $ref: "#/components/schemas/AttemptInfoRead"
+        workflowState:
+          $ref: "#/components/schemas/WorkflowStateRead"
     AttemptInfoRead:
       type: object
       required:

--- a/airbyte-api/src/main/openapi/config.yaml
+++ b/airbyte-api/src/main/openapi/config.yaml
@@ -4021,6 +4021,8 @@ components:
           $ref: "#/components/schemas/DestinationDefinitionRead"
     WorkflowStateRead:
       type: object
+      required:
+        - running
       properties:
         running:
           type: boolean

--- a/airbyte-commons-temporal/src/main/java/io/airbyte/commons/temporal/ConnectionManagerUtils.java
+++ b/airbyte-commons-temporal/src/main/java/io/airbyte/commons/temporal/ConnectionManagerUtils.java
@@ -213,14 +213,19 @@ public class ConnectionManagerUtils {
     return connectionManagerWorkflow;
   }
 
-  boolean isWorkflowStateRunning(final WorkflowClient client, final UUID connectionId) {
+  Optional<WorkflowState> getWorkflowState(final WorkflowClient client, final UUID connectionId) {
     try {
       final ConnectionManagerWorkflow connectionManagerWorkflow = client.newWorkflowStub(ConnectionManagerWorkflow.class,
           getConnectionManagerName(connectionId));
-      return connectionManagerWorkflow.getState().isRunning();
+      return Optional.of(connectionManagerWorkflow.getState());
     } catch (final Exception e) {
-      return false;
+      log.error("Exception thrown while checking workflow state for connection id {}", connectionId, e);
+      return Optional.empty();
     }
+  }
+
+  boolean isWorkflowStateRunning(final WorkflowClient client, final UUID connectionId) {
+    return getWorkflowState(client, connectionId).map(WorkflowState::isRunning).orElse(false);
   }
 
   public WorkflowExecutionStatus getConnectionManagerWorkflowStatus(final WorkflowClient workflowClient, final UUID connectionId) {

--- a/airbyte-commons-temporal/src/main/java/io/airbyte/commons/temporal/TemporalClient.java
+++ b/airbyte-commons-temporal/src/main/java/io/airbyte/commons/temporal/TemporalClient.java
@@ -16,6 +16,7 @@ import io.airbyte.commons.temporal.scheduling.ConnectionManagerWorkflow;
 import io.airbyte.commons.temporal.scheduling.DiscoverCatalogWorkflow;
 import io.airbyte.commons.temporal.scheduling.SpecWorkflow;
 import io.airbyte.commons.temporal.scheduling.SyncWorkflow;
+import io.airbyte.commons.temporal.scheduling.state.WorkflowState;
 import io.airbyte.config.ConnectorJobOutput;
 import io.airbyte.config.JobCheckConnectionConfig;
 import io.airbyte.config.JobDiscoverCatalogConfig;
@@ -189,6 +190,10 @@ public class TemporalClient {
     final Optional<Long> jobId;
     final Optional<ErrorCode> errorCode;
 
+  }
+
+  public Optional<WorkflowState> getWorkflowState(final UUID connectionId) {
+    return connectionManagerUtils.getWorkflowState(client, connectionId);
   }
 
   public ManualOperationResult startNewManualSync(final UUID connectionId) {

--- a/airbyte-server/src/main/java/io/airbyte/server/ServerApp.java
+++ b/airbyte-server/src/main/java/io/airbyte/server/ServerApp.java
@@ -315,7 +315,8 @@ public class ServerApp implements ServerRunnable {
         sourceDefinitionsHandler,
         destinationHandler,
         destinationDefinitionsHandler,
-        configs.getAirbyteVersion());
+        configs.getAirbyteVersion(),
+        temporalClient);
 
     final LogsHandler logsHandler = new LogsHandler(configs);
 

--- a/airbyte-server/src/main/java/io/airbyte/server/converters/WorkflowStateConverter.java
+++ b/airbyte-server/src/main/java/io/airbyte/server/converters/WorkflowStateConverter.java
@@ -1,0 +1,16 @@
+/*
+ * Copyright (c) 2022 Airbyte, Inc., all rights reserved.
+ */
+
+package io.airbyte.server.converters;
+
+import io.airbyte.api.model.generated.WorkflowStateRead;
+import io.airbyte.commons.temporal.scheduling.state.WorkflowState;
+
+public class WorkflowStateConverter {
+
+  public WorkflowStateRead getWorkflowStateRead(final WorkflowState workflowState) {
+    return new WorkflowStateRead().running(workflowState.isRunning());
+  }
+
+}

--- a/airbyte-tests/src/acceptanceTests/java/io/airbyte/test/acceptance/BasicAcceptanceTests.java
+++ b/airbyte-tests/src/acceptanceTests/java/io/airbyte/test/acceptance/BasicAcceptanceTests.java
@@ -13,6 +13,7 @@ import static io.airbyte.test.utils.AirbyteAcceptanceTestHarness.STAGING_SCHEMA_
 import static io.airbyte.test.utils.AirbyteAcceptanceTestHarness.STREAM_NAME;
 import static io.airbyte.test.utils.AirbyteAcceptanceTestHarness.waitForSuccessfulJob;
 import static io.airbyte.test.utils.AirbyteAcceptanceTestHarness.waitWhileJobHasStatus;
+import static io.airbyte.test.utils.AirbyteAcceptanceTestHarness.waitWhileJobIsRunning;
 import static java.lang.Thread.sleep;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
@@ -641,6 +642,11 @@ class BasicAcceptanceTests {
     final JobInfoRead jobInfoRead = apiClient.getConnectionApi().resetConnection(new ConnectionIdRequestBody().connectionId(connectionId));
     waitWhileJobHasStatus(apiClient.getJobsApi(), jobInfoRead.getJob(),
         Sets.newHashSet(JobStatus.PENDING, JobStatus.RUNNING, JobStatus.INCOMPLETE, JobStatus.FAILED));
+    // This is a band-aid to prevent some race conditions where the job status was updated but we may
+    // still be cleaning up some data in the reset table. This would be an argument for reworking the
+    // source of truth of the replication workflow state to be in DB rather than in Memory and
+    // serialized automagically by temporal
+    waitWhileJobIsRunning(apiClient.getJobsApi(), jobInfoRead.getJob(), Duration.ofMinutes(1));
 
     LOGGER.info("state after reset: {}", apiClient.getStateApi().getState(new ConnectionIdRequestBody().connectionId(connectionId)));
 

--- a/airbyte-tests/src/acceptanceTests/java/io/airbyte/test/acceptance/BasicAcceptanceTests.java
+++ b/airbyte-tests/src/acceptanceTests/java/io/airbyte/test/acceptance/BasicAcceptanceTests.java
@@ -945,6 +945,11 @@ class BasicAcceptanceTests {
     final JobInfoRead jobInfoRead = apiClient.getConnectionApi().resetConnection(new ConnectionIdRequestBody().connectionId(connectionId));
     waitWhileJobHasStatus(apiClient.getJobsApi(), jobInfoRead.getJob(),
         Sets.newHashSet(JobStatus.PENDING, JobStatus.RUNNING, JobStatus.INCOMPLETE, JobStatus.FAILED));
+    // This is a band-aid to prevent some race conditions where the job status was updated but we may
+    // still be cleaning up some data in the reset table. This would be an argument for reworking the
+    // source of truth of the replication workflow state to be in DB rather than in Memory and
+    // serialized automagically by temporal
+    waitWhileJobIsRunning(apiClient.getJobsApi(), jobInfoRead.getJob(), Duration.ofMinutes(1));
 
     LOGGER.info("state after reset: {}", apiClient.getStateApi().getState(new ConnectionIdRequestBody().connectionId(connectionId)));
 
@@ -1250,6 +1255,11 @@ class BasicAcceptanceTests {
     final JobInfoRead jobInfoRead = apiClient.getConnectionApi().resetConnection(new ConnectionIdRequestBody().connectionId(connectionId));
     waitWhileJobHasStatus(apiClient.getJobsApi(), jobInfoRead.getJob(),
         Sets.newHashSet(JobStatus.PENDING, JobStatus.RUNNING, JobStatus.INCOMPLETE, JobStatus.FAILED));
+    // This is a band-aid to prevent some race conditions where the job status was updated but we may
+    // still be cleaning up some data in the reset table. This would be an argument for reworking the
+    // source of truth of the replication workflow state to be in DB rather than in Memory and
+    // serialized automagically by temporal
+    waitWhileJobIsRunning(apiClient.getJobsApi(), jobInfoRead.getJob(), Duration.ofMinutes(1));
 
     LOGGER.info("state after reset: {}", apiClient.getStateApi().getState(new ConnectionIdRequestBody().connectionId(connectionId)));
 

--- a/docs/reference/api/generated-api-html/index.html
+++ b/docs/reference/api/generated-api-html/index.html
@@ -4612,6 +4612,9 @@ containing the updated stream needs to be sent.</div>
     <h3 class="field-label">Example data</h3>
     <div class="example-data-content-type">Content-Type: application/json</div>
     <pre class="example"><code>{
+  "workflowState" : {
+    "running" : true
+  },
   "job" : {
     "configId" : "configId",
     "sourceDefinition" : {
@@ -10516,6 +10519,7 @@ containing the updated stream needs to be sent.</div>
     <li><a href="#WebBackendWorkspaceStateResult"><code>WebBackendWorkspaceStateResult</code> - </a></li>
     <li><a href="#WebhookConfigRead"><code>WebhookConfigRead</code> - </a></li>
     <li><a href="#WebhookConfigWrite"><code>WebhookConfigWrite</code> - </a></li>
+    <li><a href="#WorkflowStateRead"><code>WorkflowStateRead</code> - </a></li>
     <li><a href="#WorkspaceCreate"><code>WorkspaceCreate</code> - </a></li>
     <li><a href="#WorkspaceGiveFeedback"><code>WorkspaceGiveFeedback</code> - </a></li>
     <li><a href="#WorkspaceIdRequestBody"><code>WorkspaceIdRequestBody</code> - </a></li>
@@ -11289,6 +11293,7 @@ containing the updated stream needs to be sent.</div>
     <div class="field-items">
       <div class="param">job </div><div class="param-desc"><span class="param-type"><a href="#JobDebugRead">JobDebugRead</a></span>  </div>
 <div class="param">attempts </div><div class="param-desc"><span class="param-type"><a href="#AttemptInfoRead">array[AttemptInfoRead]</a></span>  </div>
+<div class="param">workflowState (optional)</div><div class="param-desc"><span class="param-type"><a href="#WorkflowStateRead">WorkflowStateRead</a></span>  </div>
     </div>  <!-- field-items -->
   </div>
   <div class="model">
@@ -12101,6 +12106,13 @@ if oauth parameters were contained inside the top level, rootObject=[] If they w
       <div class="param">name (optional)</div><div class="param-desc"><span class="param-type"><a href="#string">String</a></span> human readable name for this webhook e.g. for UI display. </div>
 <div class="param">authToken (optional)</div><div class="param-desc"><span class="param-type"><a href="#string">String</a></span> an auth token, to be passed as the value for an HTTP Authorization header. </div>
 <div class="param">validationUrl (optional)</div><div class="param-desc"><span class="param-type"><a href="#string">String</a></span> if supplied, the webhook config will be validated by checking that this URL returns a 2xx response. </div>
+    </div>  <!-- field-items -->
+  </div>
+  <div class="model">
+    <h3><a name="WorkflowStateRead"><code>WorkflowStateRead</code> - </a> <a class="up" href="#__Models">Up</a></h3>
+    <div class='model-description'></div>
+    <div class="field-items">
+      <div class="param">running (optional)</div><div class="param-desc"><span class="param-type"><a href="#boolean">Boolean</a></span>  </div>
     </div>  <!-- field-items -->
   </div>
   <div class="model">

--- a/docs/reference/api/generated-api-html/index.html
+++ b/docs/reference/api/generated-api-html/index.html
@@ -12112,7 +12112,7 @@ if oauth parameters were contained inside the top level, rootObject=[] If they w
     <h3><a name="WorkflowStateRead"><code>WorkflowStateRead</code> - </a> <a class="up" href="#__Models">Up</a></h3>
     <div class='model-description'></div>
     <div class="field-items">
-      <div class="param">running (optional)</div><div class="param-desc"><span class="param-type"><a href="#boolean">Boolean</a></span>  </div>
+      <div class="param">running </div><div class="param-desc"><span class="param-type"><a href="#boolean">Boolean</a></span>  </div>
     </div>  <!-- field-items -->
   </div>
   <div class="model">


### PR DESCRIPTION
## What

Tests involving resets can be flaky. It is due to the fact that we currently track job state in two different ways, one is in the jobs table, the other one is WorkflowState from the connection manager. Following a reset, we update part of the WorkflowState state, update the jobs db, clear resets from the reset table, then update the state.

One option could be to rewrite the state logic to have workers have the main source of truth in the DB rather than split. This is an issue that is likely to happen in the tests, however, due to scheduling and timing less likely to happen under real conditions.

This PR introduce a workaround to be able to wait on both states. The other solution should be discussed/prioritized later.

Closes airbytehq/airbyte#19398 

## How
* Expose `WorkflowState.running` in the `JobsDebugInfo` API.
* Add a condition on the tests involving a reset to wait for the `WorkflowState.running` flag to flip as well as the jobs status.
