### PR TITLE
multi cloud gauge metric fix

### DIFF
--- a/airbyte-metrics/reporter/src/main/java/io/airbyte/metrics/reporter/MetricRepository.java
+++ b/airbyte-metrics/reporter/src/main/java/io/airbyte/metrics/reporter/MetricRepository.java
@@ -30,6 +30,8 @@ class MetricRepository {
 
   // We have to report gauge metric with value 0 if they are not showing up in the DB,
   // otherwise datadog will use previous reported value.
+  // Another option we didn't use here is to build this into SQL query - it will lead SQL much less
+  // readable while not decreasing any complexity.
   private final static List<String> REGISTERED_ATTEMPT_QUEUE = List.of("SYNC", "AWS_PARIS_SYNC", "null");
   private final static List<String> REGISTERED_GEOGRAPHY = List.of("US", "AUTO", "EU");
 


### PR DESCRIPTION
## What
In multi cloud context we tag some gauge metrics with their geography or their attempt queue. This could cause some problem in this scenario:

Say at 13:00 we send `num_running_jobs[gcp] = 2` and `num_running_jobs[aws] = 2`; 
at 14:00 we don't query any aws running jobs so we send `num_running_jobs[gcp] = 3` only

At datadog dashboard - since these metrics are gauge metric; not sending aws data at 14:00 will NOT overwrite previous data - so on dashboard we are still seeing 2 running jobs at aws.

That's the gist of the fix. Also due to previous bug where attempt_queue got overwritten by null value, we have some gauge data with tag null. This PR attempts to fix that by instilling attempt_queue:null = 0 into datadog to get it reset.

(Also, as a separate fix for total number of running jobs not equal to aws + gcp, that's because the aggregate was using 'max' but in this case it should be sum because it adds metrics with all tags together. that has been done)