### PR TITLE
Upgrade minimatch to at least 3.0.5

### DIFF
--- a/airbyte-webapp/package-lock.json
+++ b/airbyte-webapp/package-lock.json
@@ -21593,18 +21593,6 @@
       "integrity": "sha512-L18DaJsXSUk2+42pv8mLs5jJT2hqFkFE4j21wOmgbUqsZ2hL72NsUU785g9RXgo3s0ZNgVl42TiHp3ZtOv/Vyg==",
       "dev": true
     },
-    "node_modules/eslint-plugin-jsx-a11y/node_modules/minimatch": {
-      "version": "3.1.2",
-      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.2.tgz",
-      "integrity": "sha512-J7p63hRiAjw1NDEww1W7i37+ByIrOWO5XQQAzZ3VOcL0PNybwpfmV/N05zFAzwQ9USyEcX6t3UO+K5aqBQOIHw==",
-      "dev": true,
-      "dependencies": {
-        "brace-expansion": "^1.1.7"
-      },
-      "engines": {
-        "node": "*"
-      }
-    },
     "node_modules/eslint-plugin-prettier": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/eslint-plugin-prettier/-/eslint-plugin-prettier-4.0.0.tgz",
@@ -32811,9 +32799,9 @@
       "dev": true
     },
     "node_modules/minimatch": {
-      "version": "3.0.4",
-      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.0.4.tgz",
-      "integrity": "sha512-yJHVQEhyqPLUTgt9B83PXu6W3rx4MvvHvSUvToogpwoGDOUQ+yDrR0HRot+yOCdCO7u4hX3pWft6kWBBcqh0UA==",
+      "version": "3.1.2",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.2.tgz",
+      "integrity": "sha512-J7p63hRiAjw1NDEww1W7i37+ByIrOWO5XQQAzZ3VOcL0PNybwpfmV/N05zFAzwQ9USyEcX6t3UO+K5aqBQOIHw==",
       "dependencies": {
         "brace-expansion": "^1.1.7"
       },
@@ -49435,7 +49423,7 @@
         "ignore": "^4.0.6",
         "import-fresh": "^3.2.1",
         "js-yaml": "^4.1.0",
-        "minimatch": "^3.0.4",
+        "minimatch": "^3.0.5",
         "strip-json-comments": "^3.1.1"
       },
       "dependencies": {
@@ -50310,7 +50298,7 @@
       "requires": {
         "@humanwhocodes/object-schema": "^1.2.1",
         "debug": "^4.1.1",
-        "minimatch": "^3.0.4"
+        "minimatch": "^3.0.5"
       }
     },
     "@humanwhocodes/object-schema": {
@@ -52393,7 +52381,7 @@
         "jsonpath-plus": "6.0.1",
         "lodash": "~4.17.21",
         "lodash.topath": "^4.5.2",
-        "minimatch": "3.0.4",
+        "minimatch": "^3.0.5",
         "nimma": "0.1.7",
         "simple-eval": "1.0.0",
         "tslib": "^2.3.0"
@@ -53408,7 +53396,7 @@
             "@babel/code-frame": "^7.5.5",
             "chalk": "^2.4.1",
             "micromatch": "^3.1.10",
-            "minimatch": "^3.0.4",
+            "minimatch": "^3.0.5",
             "semver": "^5.6.0",
             "tapable": "^1.0.0",
             "worker-rpc": "^0.1.0"
@@ -63904,7 +63892,7 @@
         "json-stable-stringify-without-jsonify": "^1.0.1",
         "levn": "^0.4.1",
         "lodash.merge": "^4.6.2",
-        "minimatch": "^3.0.4",
+        "minimatch": "^3.0.5",
         "natural-compare": "^1.4.0",
         "optionator": "^0.9.1",
         "regexpp": "^3.2.0",
@@ -64194,7 +64182,7 @@
         "has": "^1.0.3",
         "is-core-module": "^2.8.0",
         "is-glob": "^4.0.3",
-        "minimatch": "^3.0.4",
+        "minimatch": "^3.0.5",
         "object.values": "^1.1.5",
         "resolve": "^1.20.0",
         "tsconfig-paths": "^3.12.0"
@@ -64263,7 +64251,7 @@
         "has": "^1.0.3",
         "jsx-ast-utils": "^3.3.2",
         "language-tags": "^1.0.5",
-        "minimatch": "^3.1.2",
+        "minimatch": "^3.0.5",
         "semver": "^6.3.0"
       },
       "dependencies": {
@@ -64272,15 +64260,6 @@
           "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-9.2.2.tgz",
           "integrity": "sha512-L18DaJsXSUk2+42pv8mLs5jJT2hqFkFE4j21wOmgbUqsZ2hL72NsUU785g9RXgo3s0ZNgVl42TiHp3ZtOv/Vyg==",
           "dev": true
-        },
-        "minimatch": {
-          "version": "3.1.2",
-          "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.2.tgz",
-          "integrity": "sha512-J7p63hRiAjw1NDEww1W7i37+ByIrOWO5XQQAzZ3VOcL0PNybwpfmV/N05zFAzwQ9USyEcX6t3UO+K5aqBQOIHw==",
-          "dev": true,
-          "requires": {
-            "brace-expansion": "^1.1.7"
-          }
         }
       }
     },
@@ -64304,7 +64283,7 @@
         "doctrine": "^2.1.0",
         "estraverse": "^5.3.0",
         "jsx-ast-utils": "^2.4.1 || ^3.0.0",
-        "minimatch": "^3.0.4",
+        "minimatch": "^3.0.5",
         "object.entries": "^1.1.5",
         "object.fromentries": "^2.0.5",
         "object.hasown": "^1.1.0",
@@ -65123,7 +65102,7 @@
       "integrity": "sha512-LwjCsruLWQULGYKy7TX0OPtrL9kLpojOFKc5VCTxdFTV7w5zbsgqVKfnkKG7Qgjtq50gKfO56hJv88OfcGb70Q==",
       "dev": true,
       "requires": {
-        "minimatch": "^5.0.1"
+        "minimatch": "^3.0.5"
       },
       "dependencies": {
         "brace-expansion": {
@@ -65136,8 +65115,7 @@
           }
         },
         "minimatch": {
-          "version": "5.0.1",
-          "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-5.0.1.tgz",
+          "version": "https://registry.npmjs.org/minimatch/-/minimatch-5.0.1.tgz",
           "integrity": "sha512-nLDxIFRyhDblz3qMuq+SoRZED4+miJ/G+tdDrjkkkRnjAsBexeGpgjLEQ0blJy7rHhR2b93rhQY4SvyWu9v03g==",
           "dev": true,
           "requires": {
@@ -65351,7 +65329,7 @@
         "fs-extra": "^9.0.0",
         "glob": "^7.1.6",
         "memfs": "^3.1.2",
-        "minimatch": "^3.0.4",
+        "minimatch": "^3.0.5",
         "schema-utils": "2.7.0",
         "semver": "^7.3.2",
         "tapable": "^1.0.0"
@@ -65855,7 +65833,7 @@
         "fs.realpath": "^1.0.0",
         "inflight": "^1.0.4",
         "inherits": "2",
-        "minimatch": "^3.0.4",
+        "minimatch": "^3.0.5",
         "once": "^1.3.0",
         "path-is-absolute": "^1.0.0"
       }
@@ -67662,7 +67640,7 @@
         "async": "^3.2.3",
         "chalk": "^4.0.2",
         "filelist": "^1.0.1",
-        "minimatch": "^3.0.4"
+        "minimatch": "^3.0.5"
       },
       "dependencies": {
         "ansi-styles": {
@@ -72641,9 +72619,9 @@
       "dev": true
     },
     "minimatch": {
-      "version": "3.0.4",
-      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.0.4.tgz",
-      "integrity": "sha512-yJHVQEhyqPLUTgt9B83PXu6W3rx4MvvHvSUvToogpwoGDOUQ+yDrR0HRot+yOCdCO7u4hX3pWft6kWBBcqh0UA==",
+      "version": "3.1.2",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.2.tgz",
+      "integrity": "sha512-J7p63hRiAjw1NDEww1W7i37+ByIrOWO5XQQAzZ3VOcL0PNybwpfmV/N05zFAzwQ9USyEcX6t3UO+K5aqBQOIHw==",
       "requires": {
         "brace-expansion": "^1.1.7"
       }
@@ -73000,7 +72978,7 @@
       "integrity": "sha1-X1Zl2TNRM1yqvvjxxVRRbPXx5OU=",
       "dev": true,
       "requires": {
-        "minimatch": "^3.0.2"
+        "minimatch": "^3.0.5"
       }
     },
     "node-fetch": {
@@ -77636,7 +77614,7 @@
       "integrity": "sha512-nRCcW9Sj7NuZwa2XvH9co8NPeXUBhZP7CRKJtU+cS6PW9FpCIFoI5ib0NT1ZrbNuPoRy0ylyCaUL8Gih4LSyFg==",
       "dev": true,
       "requires": {
-        "minimatch": "3.0.4"
+        "minimatch": "^3.0.5"
       }
     },
     "redent": {
@@ -81278,7 +81256,7 @@
       "requires": {
         "@istanbuljs/schema": "^0.1.2",
         "glob": "^7.1.4",
-        "minimatch": "^3.0.4"
+        "minimatch": "^3.0.5"
       }
     },
     "text-encoding-utf-8": {

--- a/airbyte-webapp/package.json
+++ b/airbyte-webapp/package.json
@@ -141,6 +141,9 @@
     "ts-node": "^10.8.1",
     "typescript": "^4.7.3"
   },
+  "overrides": {
+    "minimatch": "^3.0.5"
+  },
   "lint-staged": {
     "src/**/*.{js,jsx,ts,tsx}": [
       "eslint --fix"


### PR DESCRIPTION
## What

Fixes https://github.com/airbytehq/airbyte-cloud/issues/3227

Upgrades minimatch to at least 3.0.5 to prevent a potential ReDoS vulnerability.