### PR TITLE
SAT: do not treat spec fields with const values as the ones that can hold secrets

### DIFF
--- a/airbyte-integrations/bases/source-acceptance-test/CHANGELOG.md
+++ b/airbyte-integrations/bases/source-acceptance-test/CHANGELOG.md
@@ -1,6 +1,9 @@
 # Changelog
 
 
+## 0.2.19
+Test for exposed secrets: const values can not hold secrets. [#00000](https://github.com/airbytehq/airbyte/pull/00000).
+
 ## 0.2.18
 Test connector specification against exposed secret fields. [#19124](https://github.com/airbytehq/airbyte/pull/19124).
 

--- a/airbyte-integrations/bases/source-acceptance-test/CHANGELOG.md
+++ b/airbyte-integrations/bases/source-acceptance-test/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 
 ## 0.2.19
-Test for exposed secrets: const values can not hold secrets. [#00000](https://github.com/airbytehq/airbyte/pull/00000).
+Test for exposed secrets: const values can not hold secrets. [#19465](https://github.com/airbytehq/airbyte/pull/19465).
 
 ## 0.2.18
 Test connector specification against exposed secret fields. [#19124](https://github.com/airbytehq/airbyte/pull/19124).

--- a/airbyte-integrations/bases/source-acceptance-test/Dockerfile
+++ b/airbyte-integrations/bases/source-acceptance-test/Dockerfile
@@ -33,7 +33,7 @@ COPY pytest.ini setup.py ./
 COPY source_acceptance_test ./source_acceptance_test
 RUN pip install .
 
-LABEL io.airbyte.version=0.2.18
+LABEL io.airbyte.version=0.2.19
 LABEL io.airbyte.name=airbyte/source-acceptance-test
 
 ENTRYPOINT ["python", "-m", "pytest", "-p", "source_acceptance_test.plugin", "-r", "fEsx"]

--- a/airbyte-integrations/bases/source-acceptance-test/unit_tests/test_spec.py
+++ b/airbyte-integrations/bases/source-acceptance-test/unit_tests/test_spec.py
@@ -723,6 +723,13 @@ def test_additional_properties_is_true(connector_spec, expectation):
             },
             False,
             False
+        ),
+        (
+            {
+                 "connectionSpecification": {"type": "object", "properties": {"credentials": {"oneOf": [{"type": "string", "const": "OAuth2.0"}]}}}
+            },
+            False,
+            False
         )
     ),
 )
@@ -773,7 +780,8 @@ def test_is_spec_property_name_secret(path, expected_name, expected_result):
         ({"type": "object", "properties": {"api_key": {}}}, False),
         ({"type": "array"}, True),
         # same as object
-        ({"type": "array", "items": {"type": "string"}}, False)
+        ({"type": "array", "items": {"type": "string"}}, False),
+        ({"type": "string", "const": "OAuth2.0"}, False)
     )
 )
 def test_property_can_store_secret(property_def, can_store_secret):


### PR DESCRIPTION
## What
SAT: when looking for specification properties that potentially can hold a secret value, we count constants as well

## How
Do not treat these fields as the ones that can hold a secret