### PR TITLE
Source Notion: title text can be an array of object

### DIFF
--- a/airbyte-integrations/connectors/source-notion/Dockerfile
+++ b/airbyte-integrations/connectors/source-notion/Dockerfile
@@ -34,5 +34,5 @@ COPY source_notion ./source_notion
 ENV AIRBYTE_ENTRYPOINT "python /airbyte/integration_code/main.py"
 ENTRYPOINT ["python", "/airbyte/integration_code/main.py"]
 
-LABEL io.airbyte.version=1.0.0
+LABEL io.airbyte.version=1.0.1
 LABEL io.airbyte.name=airbyte/source-notion

--- a/airbyte-integrations/connectors/source-notion/source_notion/schemas/shared/title.json
+++ b/airbyte-integrations/connectors/source-notion/source_notion/schemas/shared/title.json
@@ -8,54 +8,14 @@
         "type": ["null", "string"]
       },
       "text": {
-        "type": ["null", "object"],
-        "properties": {
-          "content": {
-            "type": ["null", "string"]
-          },
-          "link": {
-            "type": ["null", "object"],
-            "additionalProperties": true,
-            "properties": {
-              "type": {
-                "enum": ["url"]
-              },
-              "url": {
-                "type": ["null", "string"]
-              }
-            }
+        "oneOf": [{
+          "$ref": "title_text.json"
+        }, {
+          "type": ["null", "array"],
+          "items": {
+            "$ref": "title_text.json"
           }
-        }
-      },
-      "annotations": {
-        "type": ["null", "object"],
-        "additionalProperties": true,
-        "properties": {
-          "bold": {
-            "type": ["null", "boolean"]
-          },
-          "italic": {
-            "type": ["null", "boolean"]
-          },
-          "strikethrough": {
-            "type": ["null", "boolean"]
-          },
-          "underline": {
-            "type": ["null", "boolean"]
-          },
-          "code": {
-            "type": ["null", "boolean"]
-          },
-          "color": {
-            "type": ["null", "string"]
-          }
-        }
-      },
-      "plain_text": {
-        "type": ["null", "string"]
-      },
-      "href": {
-        "type": ["null", "string"]
+        }]
       }
     }
   }

--- a/airbyte-integrations/connectors/source-notion/source_notion/schemas/shared/title_text.json
+++ b/airbyte-integrations/connectors/source-notion/source_notion/schemas/shared/title_text.json
@@ -1,0 +1,59 @@
+{
+  "type": ["null", "object"],
+  "additionalProperties": true,
+  "properties": {
+    "type": {
+      "type": ["null", "string"]
+    },
+    "text": {
+      "type": ["null", "object"],
+      "properties": {
+        "content": {
+          "type": ["null", "string"]
+        },
+        "link": {
+          "type": ["null", "object"],
+          "additionalProperties": true,
+          "properties": {
+            "type": {
+              "enum": ["url"]
+            },
+            "url": {
+              "type": ["null", "string"]
+            }
+          }
+        }
+      }
+    },
+    "annotations": {
+      "type": ["null", "object"],
+      "additionalProperties": true,
+      "properties": {
+        "bold": {
+          "type": ["null", "boolean"]
+        },
+        "italic": {
+          "type": ["null", "boolean"]
+        },
+        "strikethrough": {
+          "type": ["null", "boolean"]
+        },
+        "underline": {
+          "type": ["null", "boolean"]
+        },
+        "code": {
+          "type": ["null", "boolean"]
+        },
+        "color": {
+          "type": ["null", "string"]
+        }
+      }
+    },
+    "plain_text": {
+      "type": ["null", "string"]
+    },
+    "href": {
+      "type": ["null", "string"]
+    }
+  }
+}

--- a/docs/integrations/sources/notion.md
+++ b/docs/integrations/sources/notion.md
@@ -83,16 +83,17 @@ The connector is restricted by Notion [request limits](https://developers.notion
 ## Changelog
 
 | Version | Date       | Pull Request                                             | Subject                                                         |
-|:--------|:-----------|:---------------------------------------------------------|:----------------------------------------------------------------|
-| 1.0.0   | 2022-12-19 | [20639](https://github.com/airbytehq/airbyte/pull/20639) | Fix `Pages` stream schema                                       |
-| 0.1.10  | 2022-09-28 | [17298](https://github.com/airbytehq/airbyte/pull/17298) | Use "Retry-After" header for backoff                            |
-| 0.1.9   | 2022-09-16 | [16799](https://github.com/airbytehq/airbyte/pull/16799) | Migrate to per-stream state                                     |
-| 0.1.8   | 2022-09-05 | [16272](https://github.com/airbytehq/airbyte/pull/16272) | Update spec description to include working timestamp example    |
-| 0.1.7   | 2022-07-26 | [15042](https://github.com/airbytehq/airbyte/pull/15042) | Update `additionalProperties` field to true from shared schemas |
-| 0.1.6   | 2022-07-21 | [14924](https://github.com/airbytehq/airbyte/pull/14924) | Remove `additionalProperties` field from schemas and spec       |
-| 0.1.5   | 2022-07-14 | [14706](https://github.com/airbytehq/airbyte/pull/14706) | Added OAuth2.0 authentication                                   |
-| 0.1.4   | 2022-07-07 | [14505](https://github.com/airbytehq/airbyte/pull/14505) | Fixed bug when normalization didn't run through                 |
-| 0.1.3   | 2022-04-22 | [11452](https://github.com/airbytehq/airbyte/pull/11452) | Use pagination for User stream                                  |
-| 0.1.2   | 2022-01-11 | [9084](https://github.com/airbytehq/airbyte/pull/9084)   | Fix documentation URL                                           |
-| 0.1.1   | 2021-12-30 | [9207](https://github.com/airbytehq/airbyte/pull/9207)   | Update connector fields title/description                       |
-| 0.1.0   | 2021-10-17 | [7092](https://github.com/airbytehq/airbyte/pull/7092)   | Initial Release                                                 |
+|--------|------------|----------------------------------------------------------|-----------------------------------------------------------------|
+| 1.0.1  | 2023-01-12 | [19478](https://github.com/airbytehq/airbyte/pull/19478) | Fix title.text schema to allow single text objects              |
+| 1.0.0  | 2022-12-19 | [20639](https://github.com/airbytehq/airbyte/pull/20639) | Fix `Pages` stream schema                                       |
+| 0.1.10 | 2022-09-28 | [17298](https://github.com/airbytehq/airbyte/pull/17298) | Use "Retry-After" header for backoff                            |
+| 0.1.9  | 2022-09-16 | [16799](https://github.com/airbytehq/airbyte/pull/16799) | Migrate to per-stream state                                     |
+| 0.1.8  | 2022-09-05 | [16272](https://github.com/airbytehq/airbyte/pull/16272) | Update spec description to include working timestamp example    |
+| 0.1.7  | 2022-07-26 | [15042](https://github.com/airbytehq/airbyte/pull/15042) | Update `additionalProperties` field to true from shared schemas |
+| 0.1.6  | 2022-07-21 | [14924](https://github.com/airbytehq/airbyte/pull/14924) | Remove `additionalProperties` field from schemas and spec       |
+| 0.1.5  | 2022-07-14 | [14706](https://github.com/airbytehq/airbyte/pull/14706) | Added OAuth2.0 authentication                                   |
+| 0.1.4  | 2022-07-07 | [14505](https://github.com/airbytehq/airbyte/pull/14505) | Fixed bug when normalization didn't run through                 |
+| 0.1.3  | 2022-04-22 | [11452](https://github.com/airbytehq/airbyte/pull/11452) | Use pagination for User stream                                  |
+| 0.1.2  | 2022-01-11 | [9084](https://github.com/airbytehq/airbyte/pull/9084)   | Fix documentation URL                                           |
+| 0.1.1  | 2021-12-30 | [9207](https://github.com/airbytehq/airbyte/pull/9207)   | Update connector fields title/description                       |
+| 0.1.0  | 2021-10-17 | [7092](https://github.com/airbytehq/airbyte/pull/7092)   | Initial Release                                                 |


### PR DESCRIPTION
## What
- Source Notion's schema currently specifies title text as an array, but it can also be an object. Here is an example document I observed:
```
{
  "id": "b649a924-70fa-43c3-812e-262b4043ae27",
  "properties": [
    {
      "name": "Name",
      "value": {
        "id": "title",
        "title": [
          {
            "annotations": {
              "bold": false,
              "code": false,
              "color": "default",
              "italic": false,
              "strikethrough": false,
              "underline": false
            },
            "href": null,
            "plain_text": "Europe Trip",
            "text": {
              "content": "Europe Trip",
              "link": null
            },
            "type": "text"
          }
        ],
        "type": "title"
      }
    }
  ]
}
```

## How
- Accept both an array of objects, or a single object as `title.text`

## Recommended reading order
1. `airbyte-integrations/connectors/source-notion/source_notion/schemas/shared/title.json`
2. `airbyte-integrations/connectors/source-notion/source_notion/schemas/shared/title_text.json`

## 🚨 User Impact 🚨
Are there any breaking changes? What is the end result perceived by the user? If yes, please merge this PR with the 🚨🚨 emoji so changelog authors can further highlight this if needed.

Not a breaking change.

## Pre-merge Checklist

<strong>Updating a connector</strong>

### Community member or Airbyter

- [x] Grant edit access to maintainers ([instructions](https://docs.github.com/en/github/collaborating-with-pull-requests/working-with-forks/allowing-changes-to-a-pull-request-branch-created-from-a-fork#enabling-repository-maintainer-permissions-on-existing-pull-requests))
- [ ] Secrets in the connector's spec are annotated with `airbyte_secret`
- [x] Unit & integration tests added and passing. Community members, please provide proof of success locally e.g: screenshot or copy-paste unit, integration, and acceptance test output. To run acceptance tests for a Python connector, follow instructions in the README. For java connectors run `./gradlew :airbyte-integrations:connectors:<name>:integrationTest`.
- [ ] Code reviews completed
- [x] Documentation updated
    - [ ] Connector's `README.md`
    - [ ] Connector's `bootstrap.md`. See [description and examples](https://docs.google.com/document/d/1ypdgmwmEHWv-TrO4_YOQ7pAJGVrMp5BOkEVh831N260/edit?usp=sharing)
    - [x] Changelog updated in `docs/integrations/<source or destination>/<name>.md` including changelog. See changelog [example](https://docs.airbyte.io/integrations/sources/stripe#changelog)
- [x] PR name follows [PR naming conventions](https://docs.airbyte.com/contributing-to-airbyte/issues-and-pull-requests)

### Airbyter

If this is a community PR, the Airbyte engineer reviewing this PR is responsible for the below items.

- [ ] Create a non-forked branch based on this PR and test the below items on it
- [ ] Build is successful
- [ ] If new credentials are required for use in CI, add them to GSM. [Instructions](https://docs.airbyte.io/connector-development#using-credentials-in-ci).
- [ ] [`/test connector=connectors/<name>` command](https://docs.airbyte.io/connector-development#updating-an-existing-connector) is passing
- [ ] New Connector version released on Dockerhub and connector version bumped by running the `/publish` command described [here](https://docs.airbyte.io/connector-development#updating-an-existing-connector)

## Tests

<details><summary><strong>Unit</strong></summary>

<img width="707" alt="image" src="https://user-images.githubusercontent.com/2807772/202200963-322d0541-82ff-44f5-ae29-66805f38c876.png">

</details>

<details><summary><strong>Integration</strong></summary>

*Put your integration tests output here.*

</details>

<details><summary><strong>Acceptance</strong></summary>

*Put your acceptance tests output here.*

</details>
