### PR TITLE
Update availability of SALES_AND_TRAFFIC_REPORT SLA to 2 days

### DIFF
--- a/airbyte-integrations/connectors/source-amazon-seller-partner/source_amazon_seller_partner/streams.py
+++ b/airbyte-integrations/connectors/source-amazon-seller-partner/source_amazon_seller_partner/streams.py
@@ -997,6 +997,7 @@ class SellerAnalyticsSalesAndTrafficReports(IncrementalAnalyticsStream):
     result_key = "salesAndTrafficByAsin"
     cursor_field = "queryEndDate"
     fixed_period_in_days = 1
+    availability_sla_days = 2
 
 
 class VendorSalesReports(IncrementalAnalyticsStream):


### PR DESCRIPTION
## What
Data is not available in Amazon Seller API next day, so only fetch data now - 2 days (instead of now - 1 day)

## How
Adjusted the SLA parameter

## 🚨 User Impact 🚨
No breaking changes.

