### PR TITLE
add null check when reading resource_requirements from the db

### DIFF
--- a/airbyte-config/config-persistence/src/main/java/io/airbyte/config/persistence/DbConverter.java
+++ b/airbyte-config/config-persistence/src/main/java/io/airbyte/config/persistence/DbConverter.java
@@ -77,7 +77,8 @@ public class DbConverter {
                 : Jsons.deserialize(record.get(CONNECTION.SCHEDULE_DATA).data(), ScheduleData.class))
         .withOperationIds(connectionOperationId)
         .withResourceRequirements(
-            Jsons.deserialize(record.get(CONNECTION.RESOURCE_REQUIREMENTS).data(), ResourceRequirements.class))
+            record.get(CONNECTION.RESOURCE_REQUIREMENTS) == null ? null
+                : Jsons.deserialize(record.get(CONNECTION.RESOURCE_REQUIREMENTS).data(), ResourceRequirements.class))
         .withSourceCatalogId(record.get(CONNECTION.SOURCE_CATALOG_ID))
         .withBreakingChange(record.get(CONNECTION.BREAKING_CHANGE))
         .withGeography(Enums.toEnum(record.get(CONNECTION.GEOGRAPHY, String.class), Geography.class).orElseThrow())


### PR DESCRIPTION
## What
* @colesnodgrass and I were talking about the new APM dashboard that @jdpgrailsdev built and noticed this very frequent NPE ([link](https://app.datadoghq.com/apm/trace/2177460164262014560?colorBy=service&env=dev&graphType=flamegraph&shouldShowLegend=true&sort=time&spanID=5729246165658222820&spanViewType=errors&timeHint=1668633434233.255))
* Looks like we are assuming a field is non-null in the db when actually it can be null.
* Adds a null check. @gosusnp any idea of this is a regression? Does this break all connections where we don't explicitly set a resource requirement? This seems like it might be stopping the show, but I might be missing some handling.