### PR TITLE
Publish version 0.1.0 for Fauna source

### DIFF
--- a/airbyte-config/init/src/main/resources/seed/source_definitions.yaml
+++ b/airbyte-config/init/src/main/resources/seed/source_definitions.yaml
@@ -445,7 +445,7 @@
 - name: Fauna
   sourceDefinitionId: 3825db3e-c94b-42ac-bd53-b5a9507ace2b
   dockerRepository: airbyte/source-fauna
-  dockerImageTag: 0.1.0
+  dockerImageTag: dev
   documentationUrl: https://docs.airbyte.com/integrations/sources/fauna
   icon: fauna.svg
   sourceType: database
@@ -1165,6 +1165,13 @@
   dockerImageTag: 0.1.5
   documentationUrl: https://docs.airbyte.com/integrations/sources/pokeapi
   icon: pokeapi.svg
+  sourceType: api
+  releaseStage: alpha
+- name: Polygon Stock API
+  sourceDefinitionId: 5807d72f-0abc-49f9-8fa5-ae820007032b
+  dockerRepository: airbyte/source-polygon-stock-api
+  dockerImageTag: 0.1.0
+  documentationUrl: https://docs.airbyte.com/integrations/sources/polygon-stock-api
   sourceType: api
   releaseStage: alpha
 - name: PostHog

--- a/airbyte-config/init/src/main/resources/seed/source_definitions.yaml
+++ b/airbyte-config/init/src/main/resources/seed/source_definitions.yaml
@@ -445,7 +445,7 @@
 - name: Fauna
   sourceDefinitionId: 3825db3e-c94b-42ac-bd53-b5a9507ace2b
   dockerRepository: airbyte/source-fauna
-  dockerImageTag: dev
+  dockerImageTag: 0.1.0
   documentationUrl: https://docs.airbyte.com/integrations/sources/fauna
   icon: fauna.svg
   sourceType: database

--- a/airbyte-integrations/connectors/source-fauna/Dockerfile
+++ b/airbyte-integrations/connectors/source-fauna/Dockerfile
@@ -34,5 +34,5 @@ COPY source_fauna ./source_fauna
 ENV AIRBYTE_ENTRYPOINT "python /airbyte/integration_code/main.py"
 ENTRYPOINT ["python", "/airbyte/integration_code/main.py"]
 
-LABEL io.airbyte.version=dev
+LABEL io.airbyte.version=0.1.0
 LABEL io.airbyte.name=airbyte/source-fauna

--- a/docs/integrations/sources/fauna.md
+++ b/docs/integrations/sources/fauna.md
@@ -223,5 +223,5 @@ FQL [`Select`](https://docs.fauna.com/fauna/current/api/fql/functions/select) is
 ## Changelog
 
 | Version | Date       | Pull Request                                             | Subject          |
-| ------- | ---------- | -------------------------------------------------------- | ---------------- |
-| 0.1.0   | 2022-08-03 | [15274](https://github.com/airbytehq/airbyte/pull/15274) | Add Fauna Source |
+| ------- |------------| -------------------------------------------------------- | ---------------- |
+| 0.1.0   | 2022-11-16 | [15274](https://github.com/airbytehq/airbyte/pull/15274) | Add Fauna Source |


### PR DESCRIPTION
## What
Fauna source was added in https://github.com/airbytehq/airbyte/pull/15274, however only a `dev` version was published. If we would like this to be included in the Cloud catalog, we'll need to publish the actual 0.1.0 version of this. 
