### PR TITLE
:window: :bug: Remount connector form on type switch

### DIFF
--- a/airbyte-webapp/src/views/Connector/ConnectorCard/ConnectorCard.tsx
+++ b/airbyte-webapp/src/views/Connector/ConnectorCard/ConnectorCard.tsx
@@ -172,6 +172,10 @@ export const ConnectorCard: React.FC<ConnectorCardCreateProps | ConnectorCardEdi
         {additionalSelectorComponent}
         <div>
           <ConnectorForm
+            // Causes the whole ConnectorForm to be unmounted and a new instance mounted whenever the connector type changes.
+            // That way we carry less state around inside it, preventing any state from one connector type from affecting another
+            // connector type's form in any way.
+            key={selectedConnectorDefinition && Connector.id(selectedConnectorDefinition)}
             {...props}
             selectedConnectorDefinition={selectedConnectorDefinition}
             selectedConnectorDefinitionSpecification={selectedConnectorDefinitionSpecification}

--- a/airbyte-webapp/src/views/Connector/ConnectorForm/components/Property/LabelInfo.tsx
+++ b/airbyte-webapp/src/views/Connector/ConnectorForm/components/Property/LabelInfo.tsx
@@ -41,7 +41,7 @@ const Examples: React.FC<Pick<LabelInfoProps, "examples">> = ({ examples }) => {
       </h4>
       <div className={styles.exampleContainer}>
         {examplesArray.map((example) => (
-          <span className={styles.exampleItem}>{example}</span>
+          <span className={styles.exampleItem}>{String(example)}</span>
         ))}
       </div>
     </div>


### PR DESCRIPTION
## What

This fixes an issue that (timing based) the OAuth button sometims would not render and instead it would render out the raw fields. This time (yeah I know we "fixed" this already two weeks ago) it happened way less reliable.

## How

Thanks to the refactorings we've done to the ConnectorForm, we no longer track the actual connector type as part of Formik. The `ConnectorForm` component itself though would still stay the same whenever you switch the connector type (because that's how React works), and just Formik inside that component would reinitialize.

This still kept a lot of state inside the `ConnectorForm` component around while changing the connector type. None of that state should actually be kept around when changing connector types. So we added a `key` to the `ConnectorForm` where we render it, that depends on the connector type, which causes React to fully unmount that component and mount a new instance of that component whenever the connector type changes. That way we can be sure no state is kept when switching connector types.

With that change we could no longer get into the state where OAuth fields where rendered out raw... and we REALLY tried.

## Bonus

Also makes sure the examples in the connector form are always strings, since atm if a connector has an example of `false` it would just not render out, because React doesn't render `false`. Making sure this will now be `"false"`.