### PR TITLE
Note to call-out API restriction for event

### DIFF
--- a/docs/integrations/sources/stripe.md
+++ b/docs/integrations/sources/stripe.md
@@ -1,3 +1,7 @@
+:::caution
+Stripe API Restriction: Access to events endpoint is [guaranteed only for the last 30 days](https://stripe.com/docs/api/events). Using the full-refresh sync from Airbyte will overwrite data prior to 30 days in your destination.
+:::
+
 # Stripe
 
 This page guides you through the process of setting up the Stripe source connector.

--- a/docs/integrations/sources/stripe.md
+++ b/docs/integrations/sources/stripe.md
@@ -1,5 +1,5 @@
-:::caution
-Stripe API Restriction: Access to events endpoint is [guaranteed only for the last 30 days](https://stripe.com/docs/api/events). Using the full-refresh sync from Airbyte will overwrite data prior to 30 days in your destination.
+:::warning
+Stripe API Restriction: Access to events endpoint is [guaranteed only for the last 30 days](https://stripe.com/docs/api/events). Using the full-refresh-overwrite sync from Airbyte will delete data older than 30 days from your target destination.
 :::
 
 # Stripe


### PR DESCRIPTION
As per this [thread](https://airbytehq-team.slack.com/archives/C03GD9SV36E/p1668619305507619), adding a caution warning to the docs.