### PR TITLE
Fix indentation of manifest template

### DIFF
--- a/airbyte-connector-builder-server/connector_builder/impl/default_api.py
+++ b/airbyte-connector-builder-server/connector_builder/impl/default_api.py
@@ -30,53 +30,53 @@ class DefaultApiImpl(DefaultApi):
     async def get_manifest_template(self) -> str:
         return """version: "0.1.0"
 
-        definitions:
-          selector:
-            extractor:
-              field_pointer: []
-          requester:
-            url_base: "https://example.com"
-            http_method: "GET"
-            authenticator:
-              type: BearerAuthenticator
-              api_token: "{{ config['api_key'] }}"
-          retriever:
-            record_selector:
-              $ref: "*ref(definitions.selector)"
-            paginator:
-              type: NoPagination
-            requester:
-              $ref: "*ref(definitions.requester)"
-          base_stream:
-            retriever:
-              $ref: "*ref(definitions.retriever)"
-          customers_stream:
-            $ref: "*ref(definitions.base_stream)"
-            $options:
-              name: "customers"
-              primary_key: "id"
-              path: "/example"
+definitions:
+  selector:
+    extractor:
+      field_pointer: []
+  requester:
+    url_base: "https://example.com"
+    http_method: "GET"
+    authenticator:
+      type: BearerAuthenticator
+      api_token: "{{ config['api_key'] }}"
+  retriever:
+    record_selector:
+      $ref: "*ref(definitions.selector)"
+    paginator:
+      type: NoPagination
+    requester:
+      $ref: "*ref(definitions.requester)"
+  base_stream:
+    retriever:
+      $ref: "*ref(definitions.retriever)"
+  customers_stream:
+    $ref: "*ref(definitions.base_stream)"
+    $options:
+      name: "customers"
+      primary_key: "id"
+      path: "/example"
 
-        streams:
-          - "*ref(definitions.customers_stream)"
+streams:
+  - "*ref(definitions.customers_stream)"
 
-        check:
-          stream_names:
-            - "customers"
+check:
+  stream_names:
+    - "customers"
 
-        spec:
-          documentation_url: https://docsurl.com
-          connection_specification:
-            title: Source Name Spec # 'TODO: Replace this with the name of your source.'
-            type: object
-            required:
-              - api_key
-            additionalProperties: true
-            properties:
-              # 'TODO: This schema defines the configuration required for the source. This usually involves metadata such as database and/or authentication information.':
-              api_key:
-                type: string
-                description: API Key
+spec:
+  documentation_url: https://docsurl.com
+  connection_specification:
+    title: Source Name Spec # 'TODO: Replace this with the name of your source.'
+    type: object
+    required:
+      - api_key
+    additionalProperties: true
+    properties:
+      # 'TODO: This schema defines the configuration required for the source. This usually involves metadata such as database and/or authentication information.':
+      api_key:
+        type: string
+        description: API Key
 """
 
     async def list_streams(self, streams_list_request_body: StreamsListRequestBody = Body(None, description="")) -> StreamsListRead:


### PR DESCRIPTION
## What
Something I noticed while testing the connector builder was that if starting from a fresh state (i.e. no local browser storage for the yaml editor contents, which I tested using an incognito window), the app fetches the manifest template from the connector builder server, and the template had incorrect indentation, as shown in this screenshot:
<img width="1000" alt="Screen Shot 2022-11-16 at 4 41 48 PM" src="https://user-images.githubusercontent.com/22731524/202325925-a4088cd9-30c7-4138-854d-6fb9bcc686ff.png">

## How
To fix this, I removed the indents from the multiline string in the manifest_template endpoint.
