### PR TITLE
Remove namespace value from gcs secret

### DIFF
--- a/kube/resources/secret-gcs-log-creds.yaml
+++ b/kube/resources/secret-gcs-log-creds.yaml
@@ -2,6 +2,5 @@ apiVersion: v1
 kind: Secret
 metadata:
   name: gcs-log-creds
-  namespace: default
 data:
   gcp.json: ""


### PR DESCRIPTION
## What
The `gcs-log-creds` Secret is always created in the `default` namespace, regardless of where the rest of the resources are deployed. This causes some pods to fail to be created.

## How
Removing the hard-coded `namespace:` metadata from the `gcs-log-creds` secret, so that `kubectl` (or whatever us used to deploy the k8s manifests) uses the same namespace for all resources.
