### PR TITLE
Fix typo in BigQuery source documentation

### DIFF
--- a/docs/integrations/sources/bigquery.md
+++ b/docs/integrations/sources/bigquery.md
@@ -18,7 +18,7 @@ The BigQuery source does not alter the schema present in your database. Dependin
 
 The BigQuery data types mapping:
 
-| CockroachDb Type | Resulting Type | Notes |
+| BigQuery Type | Resulting Type | Notes |
 | :--- | :--- | :--- |
 | `BOOL` | Boolean |  |
 | `INT64` | Number |  |


### PR DESCRIPTION
Data type mapping table referred to "CockroachDb Type" instead of "BigQuery Type".