### PR TITLE
🪟🔧 Add isCorporate flag to analytics identify

### DIFF
--- a/airbyte-webapp/src/packages/cloud/cloudRoutes.tsx
+++ b/airbyte-webapp/src/packages/cloud/cloudRoutes.tsx
@@ -128,7 +128,7 @@ const MainViewRoutes = () => {
 };
 
 export const Routing: React.FC = () => {
-  const { user, inited, providers } = useAuthService();
+  const { user, inited, providers, hasCorporateEmail } = useAuthService();
 
   const { search } = useLocation();
 
@@ -146,9 +146,15 @@ export const Routing: React.FC = () => {
         : null,
     [user]
   );
+
+  const userTraits = useMemo(
+    () => (user ? { providers, email: user.email, isCorporate: hasCorporateEmail() } : {}),
+    [hasCorporateEmail, providers, user]
+  );
+
   useGetSegmentAnonymousId();
   useAnalyticsRegisterValues(analyticsContext);
-  useAnalyticsIdentifyUser(user?.userId, { providers, email: user?.email });
+  useAnalyticsIdentifyUser(user?.userId, userTraits);
 
   if (!inited) {
     return <LoadingPage />;


### PR DESCRIPTION
## What

Adds a new `isCorporate` flag to the user traits we send to analytics, so it's easier to filter on that in different analytic systems.