### PR TITLE
feat: remove limit to amount of gradle workers and enable pytest parallelism

### DIFF
--- a/.github/actions/build-branch/action.yml
+++ b/.github/actions/build-branch/action.yml
@@ -42,7 +42,6 @@ runs:
           --add-exports jdk.compiler/com.sun.tools.javac.parser=ALL-UNNAMED \
           --add-exports jdk.compiler/com.sun.tools.javac.tree=ALL-UNNAMED \
           --add-exports jdk.compiler/com.sun.tools.javac.util=ALL-UNNAMED
-        org.gradle.workers.max=8
         org.gradle.vfs.watch=false
         EOF
       shell: bash

--- a/.github/actions/build-branch/action.yml
+++ b/.github/actions/build-branch/action.yml
@@ -42,7 +42,7 @@ runs:
           --add-exports jdk.compiler/com.sun.tools.javac.parser=ALL-UNNAMED \
           --add-exports jdk.compiler/com.sun.tools.javac.tree=ALL-UNNAMED \
           --add-exports jdk.compiler/com.sun.tools.javac.util=ALL-UNNAMED
-        org.gradle.workers.max=8
+        org.gradle.workers.max=16
         org.gradle.vfs.watch=false
         EOF
       shell: bash

--- a/.github/actions/build-branch/action.yml
+++ b/.github/actions/build-branch/action.yml
@@ -42,6 +42,7 @@ runs:
           --add-exports jdk.compiler/com.sun.tools.javac.parser=ALL-UNNAMED \
           --add-exports jdk.compiler/com.sun.tools.javac.tree=ALL-UNNAMED \
           --add-exports jdk.compiler/com.sun.tools.javac.util=ALL-UNNAMED
+        org.gradle.workers.max=8
         org.gradle.vfs.watch=false
         EOF
       shell: bash

--- a/.github/actions/start-aws-runner/action.yml
+++ b/.github/actions/start-aws-runner/action.yml
@@ -12,7 +12,7 @@ inputs:
     default: "ami-005924fb76f7477ce"
     required: true
   ec2-instance-type:
-    default: "c6a.4xlarge"
+    default: "c5.2xlarge"
     required: true
   subnet-id:
     default: "subnet-0469a9e68a379c1d3"

--- a/.github/actions/start-aws-runner/action.yml
+++ b/.github/actions/start-aws-runner/action.yml
@@ -12,7 +12,7 @@ inputs:
     default: "ami-005924fb76f7477ce"
     required: true
   ec2-instance-type:
-    default: "c5.2xlarge"
+    default: "c6a.4xlarge"
     required: true
   subnet-id:
     default: "subnet-0469a9e68a379c1d3"

--- a/.github/workflows/fe-validate-links.yml
+++ b/.github/workflows/fe-validate-links.yml
@@ -32,6 +32,7 @@ jobs:
             --add-exports jdk.compiler/com.sun.tools.javac.parser=ALL-UNNAMED \
             --add-exports jdk.compiler/com.sun.tools.javac.tree=ALL-UNNAMED \
             --add-exports jdk.compiler/com.sun.tools.javac.util=ALL-UNNAMED
+          org.gradle.workers.max=8
           org.gradle.vfs.watch=false
           EOF
 

--- a/.github/workflows/fe-validate-links.yml
+++ b/.github/workflows/fe-validate-links.yml
@@ -32,7 +32,7 @@ jobs:
             --add-exports jdk.compiler/com.sun.tools.javac.parser=ALL-UNNAMED \
             --add-exports jdk.compiler/com.sun.tools.javac.tree=ALL-UNNAMED \
             --add-exports jdk.compiler/com.sun.tools.javac.util=ALL-UNNAMED
-          org.gradle.workers.max=8
+          org.gradle.workers.max=16
           org.gradle.vfs.watch=false
           EOF
 

--- a/.github/workflows/fe-validate-links.yml
+++ b/.github/workflows/fe-validate-links.yml
@@ -32,7 +32,6 @@ jobs:
             --add-exports jdk.compiler/com.sun.tools.javac.parser=ALL-UNNAMED \
             --add-exports jdk.compiler/com.sun.tools.javac.tree=ALL-UNNAMED \
             --add-exports jdk.compiler/com.sun.tools.javac.util=ALL-UNNAMED
-          org.gradle.workers.max=8
           org.gradle.vfs.watch=false
           EOF
 

--- a/.github/workflows/gradle.yml
+++ b/.github/workflows/gradle.yml
@@ -139,7 +139,6 @@ jobs:
             --add-exports jdk.compiler/com.sun.tools.javac.parser=ALL-UNNAMED \
             --add-exports jdk.compiler/com.sun.tools.javac.tree=ALL-UNNAMED \
             --add-exports jdk.compiler/com.sun.tools.javac.util=ALL-UNNAMED
-          org.gradle.workers.max=8
           org.gradle.vfs.watch=false
           EOF
 
@@ -229,7 +228,6 @@ jobs:
             --add-exports jdk.compiler/com.sun.tools.javac.parser=ALL-UNNAMED \
             --add-exports jdk.compiler/com.sun.tools.javac.tree=ALL-UNNAMED \
             --add-exports jdk.compiler/com.sun.tools.javac.util=ALL-UNNAMED
-          org.gradle.workers.max=8
           org.gradle.vfs.watch=false
           EOF
 
@@ -378,7 +376,6 @@ jobs:
             --add-exports jdk.compiler/com.sun.tools.javac.parser=ALL-UNNAMED \
             --add-exports jdk.compiler/com.sun.tools.javac.tree=ALL-UNNAMED \
             --add-exports jdk.compiler/com.sun.tools.javac.util=ALL-UNNAMED
-          org.gradle.workers.max=8
           org.gradle.vfs.watch=false
           EOF
 
@@ -433,7 +430,6 @@ jobs:
             --add-exports jdk.compiler/com.sun.tools.javac.parser=ALL-UNNAMED \
             --add-exports jdk.compiler/com.sun.tools.javac.tree=ALL-UNNAMED \
             --add-exports jdk.compiler/com.sun.tools.javac.util=ALL-UNNAMED
-          org.gradle.workers.max=8
           org.gradle.vfs.watch=false
           EOF
 
@@ -537,7 +533,6 @@ jobs:
             --add-exports jdk.compiler/com.sun.tools.javac.parser=ALL-UNNAMED \
             --add-exports jdk.compiler/com.sun.tools.javac.tree=ALL-UNNAMED \
             --add-exports jdk.compiler/com.sun.tools.javac.util=ALL-UNNAMED
-          org.gradle.workers.max=8
           org.gradle.vfs.watch=false
           EOF
 
@@ -729,7 +724,6 @@ jobs:
             --add-exports jdk.compiler/com.sun.tools.javac.parser=ALL-UNNAMED \
             --add-exports jdk.compiler/com.sun.tools.javac.tree=ALL-UNNAMED \
             --add-exports jdk.compiler/com.sun.tools.javac.util=ALL-UNNAMED
-          org.gradle.workers.max=8
           org.gradle.vfs.watch=false
           EOF
 

--- a/.github/workflows/gradle.yml
+++ b/.github/workflows/gradle.yml
@@ -139,7 +139,7 @@ jobs:
             --add-exports jdk.compiler/com.sun.tools.javac.parser=ALL-UNNAMED \
             --add-exports jdk.compiler/com.sun.tools.javac.tree=ALL-UNNAMED \
             --add-exports jdk.compiler/com.sun.tools.javac.util=ALL-UNNAMED
-          org.gradle.workers.max=8
+          org.gradle.workers.max=16
           org.gradle.vfs.watch=false
           EOF
 
@@ -229,7 +229,7 @@ jobs:
             --add-exports jdk.compiler/com.sun.tools.javac.parser=ALL-UNNAMED \
             --add-exports jdk.compiler/com.sun.tools.javac.tree=ALL-UNNAMED \
             --add-exports jdk.compiler/com.sun.tools.javac.util=ALL-UNNAMED
-          org.gradle.workers.max=8
+          org.gradle.workers.max=16
           org.gradle.vfs.watch=false
           EOF
 
@@ -378,7 +378,7 @@ jobs:
             --add-exports jdk.compiler/com.sun.tools.javac.parser=ALL-UNNAMED \
             --add-exports jdk.compiler/com.sun.tools.javac.tree=ALL-UNNAMED \
             --add-exports jdk.compiler/com.sun.tools.javac.util=ALL-UNNAMED
-          org.gradle.workers.max=8
+          org.gradle.workers.max=16
           org.gradle.vfs.watch=false
           EOF
 
@@ -433,7 +433,7 @@ jobs:
             --add-exports jdk.compiler/com.sun.tools.javac.parser=ALL-UNNAMED \
             --add-exports jdk.compiler/com.sun.tools.javac.tree=ALL-UNNAMED \
             --add-exports jdk.compiler/com.sun.tools.javac.util=ALL-UNNAMED
-          org.gradle.workers.max=8
+          org.gradle.workers.max=16
           org.gradle.vfs.watch=false
           EOF
 
@@ -537,7 +537,7 @@ jobs:
             --add-exports jdk.compiler/com.sun.tools.javac.parser=ALL-UNNAMED \
             --add-exports jdk.compiler/com.sun.tools.javac.tree=ALL-UNNAMED \
             --add-exports jdk.compiler/com.sun.tools.javac.util=ALL-UNNAMED
-          org.gradle.workers.max=8
+          org.gradle.workers.max=16
           org.gradle.vfs.watch=false
           EOF
 
@@ -729,7 +729,7 @@ jobs:
             --add-exports jdk.compiler/com.sun.tools.javac.parser=ALL-UNNAMED \
             --add-exports jdk.compiler/com.sun.tools.javac.tree=ALL-UNNAMED \
             --add-exports jdk.compiler/com.sun.tools.javac.util=ALL-UNNAMED
-          org.gradle.workers.max=8
+          org.gradle.workers.max=16
           org.gradle.vfs.watch=false
           EOF
 
@@ -935,7 +935,7 @@ jobs:
   #            --add-exports jdk.compiler/com.sun.tools.javac.parser=ALL-UNNAMED \
   #            --add-exports jdk.compiler/com.sun.tools.javac.tree=ALL-UNNAMED \
   #            --add-exports jdk.compiler/com.sun.tools.javac.util=ALL-UNNAMED
-  #          org.gradle.workers.max=8
+  #          org.gradle.workers.max=16
   #          org.gradle.vfs.watch=false
   #          EOF
   #

--- a/.github/workflows/gradle.yml
+++ b/.github/workflows/gradle.yml
@@ -139,6 +139,7 @@ jobs:
             --add-exports jdk.compiler/com.sun.tools.javac.parser=ALL-UNNAMED \
             --add-exports jdk.compiler/com.sun.tools.javac.tree=ALL-UNNAMED \
             --add-exports jdk.compiler/com.sun.tools.javac.util=ALL-UNNAMED
+          org.gradle.workers.max=8
           org.gradle.vfs.watch=false
           EOF
 
@@ -228,6 +229,7 @@ jobs:
             --add-exports jdk.compiler/com.sun.tools.javac.parser=ALL-UNNAMED \
             --add-exports jdk.compiler/com.sun.tools.javac.tree=ALL-UNNAMED \
             --add-exports jdk.compiler/com.sun.tools.javac.util=ALL-UNNAMED
+          org.gradle.workers.max=8
           org.gradle.vfs.watch=false
           EOF
 
@@ -376,6 +378,7 @@ jobs:
             --add-exports jdk.compiler/com.sun.tools.javac.parser=ALL-UNNAMED \
             --add-exports jdk.compiler/com.sun.tools.javac.tree=ALL-UNNAMED \
             --add-exports jdk.compiler/com.sun.tools.javac.util=ALL-UNNAMED
+          org.gradle.workers.max=8
           org.gradle.vfs.watch=false
           EOF
 
@@ -430,6 +433,7 @@ jobs:
             --add-exports jdk.compiler/com.sun.tools.javac.parser=ALL-UNNAMED \
             --add-exports jdk.compiler/com.sun.tools.javac.tree=ALL-UNNAMED \
             --add-exports jdk.compiler/com.sun.tools.javac.util=ALL-UNNAMED
+          org.gradle.workers.max=8
           org.gradle.vfs.watch=false
           EOF
 
@@ -533,6 +537,7 @@ jobs:
             --add-exports jdk.compiler/com.sun.tools.javac.parser=ALL-UNNAMED \
             --add-exports jdk.compiler/com.sun.tools.javac.tree=ALL-UNNAMED \
             --add-exports jdk.compiler/com.sun.tools.javac.util=ALL-UNNAMED
+          org.gradle.workers.max=8
           org.gradle.vfs.watch=false
           EOF
 
@@ -724,6 +729,7 @@ jobs:
             --add-exports jdk.compiler/com.sun.tools.javac.parser=ALL-UNNAMED \
             --add-exports jdk.compiler/com.sun.tools.javac.tree=ALL-UNNAMED \
             --add-exports jdk.compiler/com.sun.tools.javac.util=ALL-UNNAMED
+          org.gradle.workers.max=8
           org.gradle.vfs.watch=false
           EOF
 

--- a/.github/workflows/gradle.yml
+++ b/.github/workflows/gradle.yml
@@ -139,7 +139,6 @@ jobs:
             --add-exports jdk.compiler/com.sun.tools.javac.parser=ALL-UNNAMED \
             --add-exports jdk.compiler/com.sun.tools.javac.tree=ALL-UNNAMED \
             --add-exports jdk.compiler/com.sun.tools.javac.util=ALL-UNNAMED
-          org.gradle.workers.max=16
           org.gradle.vfs.watch=false
           EOF
 
@@ -229,7 +228,6 @@ jobs:
             --add-exports jdk.compiler/com.sun.tools.javac.parser=ALL-UNNAMED \
             --add-exports jdk.compiler/com.sun.tools.javac.tree=ALL-UNNAMED \
             --add-exports jdk.compiler/com.sun.tools.javac.util=ALL-UNNAMED
-          org.gradle.workers.max=16
           org.gradle.vfs.watch=false
           EOF
 
@@ -378,7 +376,6 @@ jobs:
             --add-exports jdk.compiler/com.sun.tools.javac.parser=ALL-UNNAMED \
             --add-exports jdk.compiler/com.sun.tools.javac.tree=ALL-UNNAMED \
             --add-exports jdk.compiler/com.sun.tools.javac.util=ALL-UNNAMED
-          org.gradle.workers.max=16
           org.gradle.vfs.watch=false
           EOF
 
@@ -433,7 +430,6 @@ jobs:
             --add-exports jdk.compiler/com.sun.tools.javac.parser=ALL-UNNAMED \
             --add-exports jdk.compiler/com.sun.tools.javac.tree=ALL-UNNAMED \
             --add-exports jdk.compiler/com.sun.tools.javac.util=ALL-UNNAMED
-          org.gradle.workers.max=16
           org.gradle.vfs.watch=false
           EOF
 
@@ -537,7 +533,6 @@ jobs:
             --add-exports jdk.compiler/com.sun.tools.javac.parser=ALL-UNNAMED \
             --add-exports jdk.compiler/com.sun.tools.javac.tree=ALL-UNNAMED \
             --add-exports jdk.compiler/com.sun.tools.javac.util=ALL-UNNAMED
-          org.gradle.workers.max=16
           org.gradle.vfs.watch=false
           EOF
 
@@ -729,7 +724,6 @@ jobs:
             --add-exports jdk.compiler/com.sun.tools.javac.parser=ALL-UNNAMED \
             --add-exports jdk.compiler/com.sun.tools.javac.tree=ALL-UNNAMED \
             --add-exports jdk.compiler/com.sun.tools.javac.util=ALL-UNNAMED
-          org.gradle.workers.max=16
           org.gradle.vfs.watch=false
           EOF
 

--- a/airbyte-cdk/python/setup.py
+++ b/airbyte-cdk/python/setup.py
@@ -66,6 +66,7 @@ setup(
             "pytest",
             "pytest-cov",
             "pytest-mock",
+            "pytest-xdist",
             "requests-mock",
             "pytest-httpserver",
         ],

--- a/airbyte-cdk/python/type_check_and_test.sh
+++ b/airbyte-cdk/python/type_check_and_test.sh
@@ -12,4 +12,4 @@ printf "\n"
 # Test with Coverage Report
 echo "Running tests.."
 # The -s flag instructs PyTest to capture stdout logging; simplifying debugging.
-pytest -s -vv --cov=airbyte_cdk unit_tests/
+pytest -s -vv --cov=airbyte_cdk unit_tests/ -n auto

--- a/airbyte-cdk/python/type_check_and_test.sh
+++ b/airbyte-cdk/python/type_check_and_test.sh
@@ -12,4 +12,4 @@ printf "\n"
 # Test with Coverage Report
 echo "Running tests.."
 # The -s flag instructs PyTest to capture stdout logging; simplifying debugging.
-pytest -s -vv --cov=airbyte_cdk unit_tests/ -n auto
+pytest -s -vv --cov=airbyte_cdk unit_tests/ -n auto --dist loadgroup

--- a/airbyte-cdk/python/unit_tests/sources/streams/http/test_http.py
+++ b/airbyte-cdk/python/unit_tests/sources/streams/http/test_http.py
@@ -21,7 +21,7 @@ from airbyte_cdk.sources.streams.http.requests_native_auth import TokenAuthentic
 class StubBasicReadHttpStream(HttpStream):
     url_base = "https://test_base_url.com"
     primary_key = ""
-    
+
     def __init__(self, **kwargs):
         super().__init__(**kwargs)
         self.resp_counter = 1

--- a/airbyte-cdk/python/unit_tests/sources/utils/test_schema_helpers.py
+++ b/airbyte-cdk/python/unit_tests/sources/utils/test_schema_helpers.py
@@ -84,6 +84,7 @@ def test_should_not_fail_validation_for_valid_config(spec_object):
 class TestResourceSchemaLoader:
     # Test that a simple schema is loaded correctly
     @staticmethod
+    @pytest.mark.xdist_group(name="test_schema_helpers")
     def test_inline_schema_resolves():
         expected_schema = {
             "type": ["null", "object"],

--- a/airbyte-cdk/python/unit_tests/sources/utils/test_schema_helpers.py
+++ b/airbyte-cdk/python/unit_tests/sources/utils/test_schema_helpers.py
@@ -12,6 +12,7 @@ from collections.abc import Mapping
 from pathlib import Path
 
 import jsonref
+import pytest
 from airbyte_cdk.logger import AirbyteLogger
 from airbyte_cdk.models.airbyte_protocol import ConnectorSpecification, FailureType
 from airbyte_cdk.sources.utils.schema_helpers import ResourceSchemaLoader, check_config_against_spec_or_exit
@@ -28,6 +29,7 @@ SCHEMAS_ROOT = "/".join(os.path.abspath(MODULE.__file__).split("/")[:-1]) / Path
 
 
 @fixture(autouse=True, scope="session")
+@pytest.mark.xdist_group(name="test_schema_helpers")
 def create_and_teardown_schemas_dir():
     os.mkdir(SCHEMAS_ROOT)
     os.mkdir(SCHEMAS_ROOT / "shared")
@@ -35,12 +37,14 @@ def create_and_teardown_schemas_dir():
     shutil.rmtree(SCHEMAS_ROOT)
 
 
+@pytest.mark.xdist_group(name="test_schema_helpers")
 def create_schema(name: str, content: Mapping):
     with open(SCHEMAS_ROOT / f"{name}.json", "w") as f:
         f.write(json.dumps(content))
 
 
 @fixture
+@pytest.mark.xdist_group(name="test_schema_helpers")
 def spec_object():
     spec = {
         "connectionSpecification": {
@@ -56,6 +60,7 @@ def spec_object():
     yield ConnectorSpecification.parse_obj(spec)
 
 
+@pytest.mark.xdist_group(name="test_schema_helpers")
 def test_check_config_against_spec_or_exit_does_not_print_schema(capsys, spec_object):
     config = {"super_secret_token": "really_a_secret"}
 
@@ -69,6 +74,7 @@ def test_check_config_against_spec_or_exit_does_not_print_schema(capsys, spec_ob
     assert exc.failure_type == FailureType.config_error, "failure_type should be config_error"
 
 
+@pytest.mark.xdist_group(name="test_schema_helpers")
 def test_should_not_fail_validation_for_valid_config(spec_object):
     config = {"api_token": "something"}
     check_config_against_spec_or_exit(config, spec_object)
@@ -97,6 +103,7 @@ class TestResourceSchemaLoader:
         assert actual_schema == expected_schema
 
     @staticmethod
+    @pytest.mark.xdist_group(name="test_schema_helpers")
     def test_shared_schemas_resolves():
         expected_schema = {
             "type": ["null", "object"],
@@ -133,6 +140,7 @@ class TestResourceSchemaLoader:
         assert actual_schema == expected_schema
 
     @staticmethod
+    @pytest.mark.xdist_group(name="test_schema_helpers")
     def test_shared_schemas_resolves_nested():
         expected_schema = {
             "type": ["null", "object"],

--- a/airbyte-cdk/python/unit_tests/test_connector.py
+++ b/airbyte-cdk/python/unit_tests/test_connector.py
@@ -34,6 +34,7 @@ class TestAirbyteSpec:
         },
     }
 
+    @pytest.mark.xdist_group(name="test_spec")
     def test_from_file(self):
         expected = self.VALID_SPEC
         with tempfile.NamedTemporaryFile("w") as f:
@@ -42,6 +43,7 @@ class TestAirbyteSpec:
             actual = AirbyteSpec.from_file(f.name)
             assert expected == json.loads(actual.spec_string)
 
+    @pytest.mark.xdist_group(name="test_spec")
     def test_from_file_nonexistent(self):
         with pytest.raises(OSError):
             AirbyteSpec.from_file("/tmp/i do not exist")
@@ -52,11 +54,13 @@ class MockConnector(Connector):
         pass
 
 
+@pytest.mark.xdist_group(name="test_spec")
 @pytest.fixture()
 def mock_config():
     return {"bogus": "file"}
 
 
+@pytest.mark.xdist_group(name="test_spec")
 @pytest.fixture
 def nonempty_file(mock_config):
     with tempfile.NamedTemporaryFile("w") as file:
@@ -65,16 +69,19 @@ def nonempty_file(mock_config):
         yield file
 
 
+@pytest.mark.xdist_group(name="test_spec")
 @pytest.fixture
 def integration():
     return MockConnector()
 
 
+@pytest.mark.xdist_group(name="test_spec")
 def test_read_config(nonempty_file, integration: Connector, mock_config):
     actual = integration.read_config(nonempty_file.name)
     assert mock_config == actual
 
 
+@pytest.mark.xdist_group(name="test_spec")
 def test_write_config(integration, mock_config):
     config_path = Path(tempfile.gettempdir()) / "config.json"
     integration.write_config(mock_config, str(config_path))
@@ -90,6 +97,7 @@ class TestConnectorSpec:
         "properties": {"api_token": {"type": "string"}},
     }
 
+    @pytest.mark.xdist_group(name="test_spec")
     @pytest.fixture
     def use_json_spec(self):
         spec = {
@@ -103,6 +111,7 @@ class TestConnectorSpec:
         yield
         os.remove(json_path)
 
+    @pytest.mark.xdist_group(name="test_spec")
     @pytest.fixture
     def use_yaml_spec(self):
         spec = {"documentationUrl": "https://airbyte.com/#yaml", "connectionSpecification": self.CONNECTION_SPECIFICATION}
@@ -113,20 +122,24 @@ class TestConnectorSpec:
         yield
         os.remove(yaml_path)
 
+    @pytest.mark.xdist_group(name="test_spec")
     def test_spec_from_json_file(self, integration, use_json_spec):
         connector_spec = integration.spec(logger)
         assert connector_spec.documentationUrl == "https://airbyte.com/#json"
         assert connector_spec.connectionSpecification == self.CONNECTION_SPECIFICATION
 
+    @pytest.mark.xdist_group(name="test_spec")
     def test_spec_from_yaml_file(self, integration, use_yaml_spec):
         connector_spec = integration.spec(logger)
         assert connector_spec.documentationUrl == "https://airbyte.com/#yaml"
         assert connector_spec.connectionSpecification == self.CONNECTION_SPECIFICATION
 
+    @pytest.mark.xdist_group(name="test_spec")
     def test_multiple_spec_files_raises_exception(self, integration, use_yaml_spec, use_json_spec):
         with pytest.raises(RuntimeError, match="spec.yaml or spec.json"):
             integration.spec(logger)
 
+    @pytest.mark.xdist_group(name="test_spec")
     def test_no_spec_file_raises_exception(self, integration):
         with pytest.raises(FileNotFoundError, match="Unable to find spec."):
             integration.spec(logger)

--- a/airbyte-connector-builder-server/run_tests.sh
+++ b/airbyte-connector-builder-server/run_tests.sh
@@ -6,5 +6,5 @@ pip install -e '.[main]'
 pip install -e '.[tests]'
 
 # Run the tests
-python -m coverage run -m pytest unit_tests -c pytest.ini -n auto
-python -m coverage run -m pytest integration_tests -c pytest.ini -n auto
+python -m coverage run -m pytest unit_tests -c pytest.ini
+python -m coverage run -m pytest integration_tests -c pytest.ini

--- a/airbyte-connector-builder-server/run_tests.sh
+++ b/airbyte-connector-builder-server/run_tests.sh
@@ -6,5 +6,5 @@ pip install -e '.[main]'
 pip install -e '.[tests]'
 
 # Run the tests
-python -m coverage run -m pytest unit_tests -c pytest.ini
-python -m coverage run -m pytest integration_tests -c pytest.ini
+python -m coverage run -m pytest unit_tests -c pytest.ini -n auto
+python -m coverage run -m pytest integration_tests -c pytest.ini -n auto

--- a/airbyte-connector-builder-server/setup.py
+++ b/airbyte-connector-builder-server/setup.py
@@ -47,6 +47,7 @@ setup(
         "tests": [
             "MyPy~=0.812",
             "pytest~=6.2.5",
+            "pytest-xdist",
             "pytest-cov",
             "pytest-mock",
             "pytest-recording",

--- a/airbyte-integrations/bases/base-normalization/build.gradle
+++ b/airbyte-integrations/bases/base-normalization/build.gradle
@@ -94,7 +94,7 @@ airbyteDocker.dependsOn(airbyteDockerTiDB)
 
 task("customIntegrationTestPython", type: PythonTask, dependsOn: installTestReqs) {
     module = "pytest"
-    command = "-s integration_tests"
+    command = "-s integration_tests -n auto"
 
     dependsOn ':airbyte-integrations:bases:base-normalization:airbyteDocker'
     dependsOn ':airbyte-integrations:connectors:destination-bigquery:airbyteDocker'

--- a/airbyte-integrations/bases/base-normalization/build.gradle
+++ b/airbyte-integrations/bases/base-normalization/build.gradle
@@ -94,7 +94,7 @@ airbyteDocker.dependsOn(airbyteDockerTiDB)
 
 task("customIntegrationTestPython", type: PythonTask, dependsOn: installTestReqs) {
     module = "pytest"
-    command = "-s integration_tests -n auto"
+    command = "-s integration_tests -n auto --dist loadgroup"
 
     dependsOn ':airbyte-integrations:bases:base-normalization:airbyteDocker'
     dependsOn ':airbyte-integrations:connectors:destination-bigquery:airbyteDocker'

--- a/airbyte-integrations/bases/base-normalization/setup.py
+++ b/airbyte-integrations/bases/base-normalization/setup.py
@@ -22,6 +22,6 @@ setuptools.setup(
         ],
     },
     extras_require={
-        "tests": ["airbyte-cdk", "pytest", "mypy", "types-PyYAML"],
+        "tests": ["airbyte-cdk", "pytest", "mypy", "types-PyYAML", "pytest-xdist"],
     },
 )

--- a/airbyte-integrations/bases/source-acceptance-test/Dockerfile
+++ b/airbyte-integrations/bases/source-acceptance-test/Dockerfile
@@ -36,4 +36,4 @@ RUN pip install .
 LABEL io.airbyte.version=0.2.19
 LABEL io.airbyte.name=airbyte/source-acceptance-test
 
-ENTRYPOINT ["python", "-m", "pytest", "-p", "source_acceptance_test.plugin", "-r", "fEsx"]
+ENTRYPOINT ["python", "-m", "pytest", "-n", "auto", "-p", "source_acceptance_test.plugin", "-r", "fEsx"]

--- a/airbyte-integrations/bases/source-acceptance-test/setup.py
+++ b/airbyte-integrations/bases/source-acceptance-test/setup.py
@@ -24,6 +24,7 @@ MAIN_REQUIREMENTS = [
     "requests-mock~=1.9.3",
     "pytest-mock~=3.6.1",
     "pytest-cov~=3.0.0",
+    "pytest-xdist~=3.0.2"
     "hypothesis~=6.54.1",
     "hypothesis-jsonschema~=0.20.1",  # TODO alafanechere upgrade to latest when jsonschema lib is upgraded to >= 4.0.0 in airbyte-cdk and SAT
 ]

--- a/airbyte-integrations/bases/source-acceptance-test/setup.py
+++ b/airbyte-integrations/bases/source-acceptance-test/setup.py
@@ -24,7 +24,7 @@ MAIN_REQUIREMENTS = [
     "requests-mock~=1.9.3",
     "pytest-mock~=3.6.1",
     "pytest-cov~=3.0.0",
-    "pytest-xdist~=3.0.2"
+    "pytest-xdist~=3.0.2",
     "hypothesis~=6.54.1",
     "hypothesis-jsonschema~=0.20.1",  # TODO alafanechere upgrade to latest when jsonschema lib is upgraded to >= 4.0.0 in airbyte-cdk and SAT
 ]

--- a/airbyte-integrations/bases/source-acceptance-test/setup.py
+++ b/airbyte-integrations/bases/source-acceptance-test/setup.py
@@ -25,7 +25,6 @@ MAIN_REQUIREMENTS = [
     "requests-mock~=1.9.3",
     "pytest-mock~=3.6.1",
     "pytest-cov~=3.0.0",
-    "pytest-xdist~=3.0.2",
     "hypothesis~=6.54.1",
     "hypothesis-jsonschema~=0.20.1",  # TODO alafanechere upgrade to latest when jsonschema lib is upgraded to >= 4.0.0 in airbyte-cdk and SAT
 ]

--- a/airbyte-integrations/bases/source-acceptance-test/setup.py
+++ b/airbyte-integrations/bases/source-acceptance-test/setup.py
@@ -14,6 +14,7 @@ MAIN_REQUIREMENTS = [
     "pdbpp~=0.10",
     "pydantic~=1.6",
     "pytest~=6.1",
+    "pytest-xdist~=3.0.2",
     "pytest-sugar~=0.9",
     "pytest-timeout~=1.4",
     "pprintpp~=0.4",

--- a/airbyte-integrations/bases/source-acceptance-test/tools/strictness_level_migration/requirements.txt
+++ b/airbyte-integrations/bases/source-acceptance-test/tools/strictness_level_migration/requirements.txt
@@ -43,7 +43,7 @@ pytest-cov==3.0.0
 pytest-mock==3.6.1
 pytest-sugar==0.9.6
 pytest-timeout==1.4.2
-pytest-xdist===3.0.2
+pytest-xdist==3.0.2
 python-dateutil==2.8.2
 pytzdata==2020.1
 PyYAML==5.4.1

--- a/airbyte-integrations/bases/source-acceptance-test/tools/strictness_level_migration/requirements.txt
+++ b/airbyte-integrations/bases/source-acceptance-test/tools/strictness_level_migration/requirements.txt
@@ -43,6 +43,7 @@ pytest-cov==3.0.0
 pytest-mock==3.6.1
 pytest-sugar==0.9.6
 pytest-timeout==1.4.2
+pytest-xdist===3.0.2
 python-dateutil==2.8.2
 pytzdata==2020.1
 PyYAML==5.4.1

--- a/airbyte-integrations/bases/source-acceptance-test/unit_tests/test_backward_compatibility.py
+++ b/airbyte-integrations/bases/source-acceptance-test/unit_tests/test_backward_compatibility.py
@@ -968,7 +968,7 @@ assert all([not transition.should_fail for transition in VALID_SPEC_TRANSITIONS]
 
 ALL_SPEC_TRANSITIONS_PARAMS = [transition.as_pytest_param() for transition in FAILING_SPEC_TRANSITIONS + VALID_SPEC_TRANSITIONS]
 
-
+@pytest.mark.xdist_group(name="backward_compatibility")
 @pytest.mark.parametrize("previous_connector_spec, actual_connector_spec, should_fail", ALL_SPEC_TRANSITIONS_PARAMS)
 def test_spec_backward_compatibility(previous_connector_spec, actual_connector_spec, should_fail):
     t = _TestSpec()
@@ -983,6 +983,7 @@ VALID_JSON_SCHEMA_TRANSITIONS_PARAMS = [
 
 
 @pytest.mark.slow
+@pytest.mark.xdist_group(name="backward_compatibility")
 @pytest.mark.parametrize("previous_connector_spec, actual_connector_spec, should_fail", VALID_JSON_SCHEMA_TRANSITIONS_PARAMS)
 def test_validate_previous_configs(previous_connector_spec, actual_connector_spec, should_fail):
     expectation = pytest.raises(NonBackwardCompatibleError) if should_fail else does_not_raise()
@@ -1328,7 +1329,7 @@ assert all([not transition.should_fail for transition in VALID_CATALOG_TRANSITIO
 
 ALL_CATALOG_TRANSITIONS_PARAMS = [transition.as_pytest_param() for transition in FAILING_CATALOG_TRANSITIONS + VALID_CATALOG_TRANSITIONS]
 
-
+@pytest.mark.xdist_group(name="backward_compatibility")
 @pytest.mark.parametrize("previous_discovered_catalog, discovered_catalog, should_fail", ALL_CATALOG_TRANSITIONS_PARAMS)
 def test_catalog_backward_compatibility(previous_discovered_catalog, discovered_catalog, should_fail):
     t = _TestDiscovery()

--- a/airbyte-integrations/bases/source-acceptance-test/unit_tests/test_backward_compatibility.py
+++ b/airbyte-integrations/bases/source-acceptance-test/unit_tests/test_backward_compatibility.py
@@ -968,8 +968,9 @@ assert all([not transition.should_fail for transition in VALID_SPEC_TRANSITIONS]
 
 ALL_SPEC_TRANSITIONS_PARAMS = [transition.as_pytest_param() for transition in FAILING_SPEC_TRANSITIONS + VALID_SPEC_TRANSITIONS]
 
-@pytest.mark.xdist_group(name="backward_compatibility")
+
 @pytest.mark.parametrize("previous_connector_spec, actual_connector_spec, should_fail", ALL_SPEC_TRANSITIONS_PARAMS)
+@pytest.mark.xdist_group(name="backward_compatibility")
 def test_spec_backward_compatibility(previous_connector_spec, actual_connector_spec, should_fail):
     t = _TestSpec()
     expectation = pytest.raises(NonBackwardCompatibleError) if should_fail else does_not_raise()
@@ -983,8 +984,8 @@ VALID_JSON_SCHEMA_TRANSITIONS_PARAMS = [
 
 
 @pytest.mark.slow
-@pytest.mark.xdist_group(name="backward_compatibility")
 @pytest.mark.parametrize("previous_connector_spec, actual_connector_spec, should_fail", VALID_JSON_SCHEMA_TRANSITIONS_PARAMS)
+@pytest.mark.xdist_group(name="backward_compatibility")
 def test_validate_previous_configs(previous_connector_spec, actual_connector_spec, should_fail):
     expectation = pytest.raises(NonBackwardCompatibleError) if should_fail else does_not_raise()
     with expectation:
@@ -1328,6 +1329,7 @@ assert all([transition.should_fail for transition in FAILING_CATALOG_TRANSITIONS
 assert all([not transition.should_fail for transition in VALID_CATALOG_TRANSITIONS])
 
 ALL_CATALOG_TRANSITIONS_PARAMS = [transition.as_pytest_param() for transition in FAILING_CATALOG_TRANSITIONS + VALID_CATALOG_TRANSITIONS]
+
 
 @pytest.mark.xdist_group(name="backward_compatibility")
 @pytest.mark.parametrize("previous_discovered_catalog, discovered_catalog, should_fail", ALL_CATALOG_TRANSITIONS_PARAMS)

--- a/airbyte-integrations/connector-templates/source-configuration-based/setup.py.hbs
+++ b/airbyte-integrations/connector-templates/source-configuration-based/setup.py.hbs
@@ -12,6 +12,7 @@ MAIN_REQUIREMENTS = [
 TEST_REQUIREMENTS = [
     "pytest~=6.1",
     "pytest-mock~=3.6.1",
+    "pytest-xdist~=3.0.2",
     "source-acceptance-test",
 ]
 

--- a/airbyte-integrations/connector-templates/source-configuration-based/setup.py.hbs
+++ b/airbyte-integrations/connector-templates/source-configuration-based/setup.py.hbs
@@ -12,7 +12,7 @@ MAIN_REQUIREMENTS = [
 TEST_REQUIREMENTS = [
     "pytest~=6.1",
     "pytest-mock~=3.6.1",
-    "pytest-xdist~=3.0.2",
+    "pytest-xdist",
     "source-acceptance-test",
 ]
 

--- a/airbyte-integrations/connectors/source-google-analytics-data-api/Makefile
+++ b/airbyte-integrations/connectors/source-google-analytics-data-api/Makefile
@@ -16,4 +16,4 @@ read:
 	@docker run --rm -v $(PWD)/secrets:/secrets -v $(PWD)/integration_tests:/integration_tests $(docker_image) read --config /secrets/config.json --catalog /integration_tests/configured_catalog.json | jq
 
 unittest-local:
-	@python -m pytest unit_tests -n auto
+	@python -m pytest unit_tests -n auto --dist loadgroup

--- a/airbyte-integrations/connectors/source-google-analytics-data-api/Makefile
+++ b/airbyte-integrations/connectors/source-google-analytics-data-api/Makefile
@@ -16,4 +16,4 @@ read:
 	@docker run --rm -v $(PWD)/secrets:/secrets -v $(PWD)/integration_tests:/integration_tests $(docker_image) read --config /secrets/config.json --catalog /integration_tests/configured_catalog.json | jq
 
 unittest-local:
-	@python -m pytest unit_tests
+	@python -m pytest unit_tests -n auto

--- a/airbyte-integrations/connectors/tasks.py
+++ b/airbyte-integrations/connectors/tasks.py
@@ -63,7 +63,7 @@ TASK_COMMANDS: Dict[str, List[str]] = {
         "pip install .",
         "pip install .[tests]",
         "pip install pytest-cov",
-        "pytest -v --cov={source_path} --cov-report xml unit_tests",
+        "pytest -n auto -v --cov={source_path} --cov-report xml unit_tests",
     ],
 }
 

--- a/airbyte-integrations/connectors/tasks.py
+++ b/airbyte-integrations/connectors/tasks.py
@@ -63,7 +63,7 @@ TASK_COMMANDS: Dict[str, List[str]] = {
         "pip install .",
         "pip install .[tests]",
         "pip install pytest-cov",
-        "pytest -n auto -v --cov={source_path} --cov-report xml unit_tests",
+        "pytest -n auto --dist loadgroup -v --cov={source_path} --cov-report xml unit_tests",
     ],
 }
 

--- a/buildSrc/src/main/groovy/airbyte-python.gradle
+++ b/buildSrc/src/main/groovy/airbyte-python.gradle
@@ -37,7 +37,7 @@ class Helpers {
             project.projectDir.toPath().resolve(testFilesDirectory).traverse(type: FileType.FILES, nameFilter: ~/(^test_.*|.*_test)\.py$/) { file ->
                 project.task("_${taskName}Coverage", type: PythonTask, dependsOn: taskDependencies) {
                     module = "coverage"
-                    command = "run --data-file=${testFilesDirectory}/.coverage.${taskName} --rcfile=${project.rootProject.file('pyproject.toml').absolutePath} -m pytest -s ${testFilesDirectory} -c ${testConfig} -n auto"
+                    command = "run --data-file=${testFilesDirectory}/.coverage.${taskName} --rcfile=${project.rootProject.file('pyproject.toml').absolutePath} -m pytest -s ${testFilesDirectory} -c ${testConfig} -n auto --dist loadgroup"
                 }
                 // generation of coverage report is optional and we should skip it if tests are empty
 

--- a/buildSrc/src/main/groovy/airbyte-python.gradle
+++ b/buildSrc/src/main/groovy/airbyte-python.gradle
@@ -37,7 +37,7 @@ class Helpers {
             project.projectDir.toPath().resolve(testFilesDirectory).traverse(type: FileType.FILES, nameFilter: ~/(^test_.*|.*_test)\.py$/) { file ->
                 project.task("_${taskName}Coverage", type: PythonTask, dependsOn: taskDependencies) {
                     module = "coverage"
-                    command = "run --data-file=${testFilesDirectory}/.coverage.${taskName} --rcfile=${project.rootProject.file('pyproject.toml').absolutePath} -m pytest -s ${testFilesDirectory} -c ${testConfig}"
+                    command = "run --data-file=${testFilesDirectory}/.coverage.${taskName} --rcfile=${project.rootProject.file('pyproject.toml').absolutePath} -m pytest -s ${testFilesDirectory} -c ${testConfig} -n auto"
                 }
                 // generation of coverage report is optional and we should skip it if tests are empty
 

--- a/buildSrc/src/main/groovy/airbyte-python.gradle
+++ b/buildSrc/src/main/groovy/airbyte-python.gradle
@@ -93,6 +93,7 @@ class AirbytePythonPlugin implements Plugin<Project> {
             pip 'mypy:0.930'
             pip 'isort:5.6.4'
             pip 'pytest:6.1.2'
+            pip 'pytest-xdist:3.0.2'
             pip 'coverage[toml]:6.3.1'
         }
 

--- a/octavia-cli/integration_tests/test_apply/test_resources.py
+++ b/octavia-cli/integration_tests/test_apply/test_resources.py
@@ -8,6 +8,7 @@ import pytest
 pytestmark = pytest.mark.integration
 
 
+@pytest.mark.xdist_group(name="test_connection_lifecycle")
 def test_source_lifecycle(source, workspace_id):
     assert not source.was_created
     source.create()
@@ -22,6 +23,7 @@ def test_source_lifecycle(source, workspace_id):
     assert source.catalog["streams"][0]["config"]["alias_name"] == "pokemon"
 
 
+@pytest.mark.xdist_group(name="test_connection_lifecycle")
 def test_destination_lifecycle(destination, workspace_id):
     assert not destination.was_created
     destination.create()
@@ -35,6 +37,7 @@ def test_destination_lifecycle(destination, workspace_id):
     assert not destination.get_diff_with_remote_resource()
 
 
+@pytest.mark.xdist_group(name="test_connection_lifecycle")
 def test_connection_lifecycle(source, destination, connection, workspace_id):
     assert source.was_created
     assert destination.was_created
@@ -48,6 +51,7 @@ def test_connection_lifecycle(source, destination, connection, workspace_id):
     connection.update()
 
 
+@pytest.mark.xdist_group(name="test_connection_lifecycle")
 def test_connection_lifecycle_with_normalization(source, destination, connection_with_normalization, workspace_id):
     assert source.was_created
     assert destination.was_created

--- a/octavia-cli/integration_tests/test_list/test_listings.py
+++ b/octavia-cli/integration_tests/test_list/test_listings.py
@@ -9,6 +9,7 @@ from octavia_cli.list.listings import Connections, DestinationConnectorsDefiniti
 pytestmark = pytest.mark.integration
 
 
+@pytest.mark.xdist_group(name="test_list_workspace_resource")
 @pytest.mark.parametrize("ConnectorsDefinitionListing", [SourceConnectorsDefinitions, DestinationConnectorsDefinitions])
 def test_list_connectors(api_client, ConnectorsDefinitionListing):
     connector_definitions = ConnectorsDefinitionListing(api_client)
@@ -18,6 +19,7 @@ def test_list_connectors(api_client, ConnectorsDefinitionListing):
     assert str(listing)
 
 
+@pytest.mark.xdist_group(name="test_list_workspace_resource")
 @pytest.mark.parametrize("WorkspaceListing", [Sources, Destinations, Connections])
 def test_list_workspace_resource(api_client, source, destination, connection, workspace_id, WorkspaceListing):
     assert source.was_created

--- a/octavia-cli/setup.py
+++ b/octavia-cli/setup.py
@@ -53,7 +53,16 @@ setup(
     ],
     python_requires=">=3.9.11",
     extras_require={
-        "tests": ["MyPy~=0.812", "pytest~=6.2.5", "pytest-cov", "pytest-mock", "pytest-recording", "pytest-xdist~=3.0.2", "requests-mock", "pre-commit"],
+        "tests": [
+            "MyPy~=0.812",
+            "pytest~=6.2.5",
+            "pytest-cov",
+            "pytest-mock",
+            "pytest-recording",
+            "pytest-xdist~=3.0.2",
+            "requests-mock",
+            "pre-commit",
+        ],
         "sphinx-docs": [
             "Sphinx~=4.2",
             "sphinx-rtd-theme~=1.0",

--- a/octavia-cli/setup.py
+++ b/octavia-cli/setup.py
@@ -53,7 +53,7 @@ setup(
     ],
     python_requires=">=3.9.11",
     extras_require={
-        "tests": ["MyPy~=0.812", "pytest~=6.2.5", "pytest-cov", "pytest-mock", "pytest-recording", "requests-mock", "pre-commit"],
+        "tests": ["MyPy~=0.812", "pytest~=6.2.5", "pytest-cov", "pytest-mock", "pytest-recording", "pytest-xdist~=3.0.2", "requests-mock", "pre-commit"],
         "sphinx-docs": [
             "Sphinx~=4.2",
             "sphinx-rtd-theme~=1.0",

--- a/octavia-cli/unit_tests/test_get/test_resources.py
+++ b/octavia-cli/unit_tests/test_get/test_resources.py
@@ -12,6 +12,7 @@ from octavia_cli.get.resources import BaseResource, Connection, Destination, Dup
 
 class TestBaseResource:
     @pytest.fixture
+    @pytest.mark.xdist_group(name="test_resources")
     def patch_base_class(self, mocker):
         # Mock abstract methods to enable instantiating abstract class
         mocker.patch.object(BaseResource, "__abstractmethods__", set())
@@ -21,6 +22,7 @@ class TestBaseResource:
         mocker.patch.object(BaseResource, "list_for_workspace_function_name", "list_for_workspace_function_name")
         mocker.patch.object(BaseResource, "name", "fake_resource")
 
+    @pytest.mark.xdist_group(name="test_resources")
     @pytest.mark.parametrize(
         "resource_id, resource_name, expected_error, expected_error_message",
         [
@@ -30,6 +32,8 @@ class TestBaseResource:
             ("my_resource_id", "my_resource_name", ValueError, "resource_id and resource_name keyword arguments can't be both set."),
         ],
     )
+
+    @pytest.mark.xdist_group(name="test_resources")
     def test_init(self, patch_base_class, mock_api_client, resource_id, resource_name, expected_error, expected_error_message):
         if expected_error:
             with pytest.raises(expected_error, match=expected_error_message):
@@ -44,6 +48,7 @@ class TestBaseResource:
             assert base_resource.resource_id == resource_id
             assert base_resource.resource_name == resource_name
 
+    @pytest.mark.xdist_group(name="test_resources")
     @pytest.mark.parametrize(
         "resource_name, api_response_resources_names, expected_error, expected_error_message",
         [
@@ -57,6 +62,7 @@ class TestBaseResource:
             ),
         ],
     )
+    @pytest.mark.xdist_group(name="test_resources")
     def test__find_by_resource_name(
         self, mocker, patch_base_class, mock_api_client, resource_name, api_response_resources_names, expected_error, expected_error_message
     ):
@@ -76,13 +82,15 @@ class TestBaseResource:
         if expected_error:
             with pytest.raises(expected_error, match=expected_error_message):
                 base_resource._find_by_resource_name()
-
+    
+    @pytest.mark.xdist_group(name="test_resources")
     def test__find_by_id(self, mocker, patch_base_class, mock_api_client):
         mocker.patch.object(BaseResource, "_get_fn")
         base_resource = BaseResource(mock_api_client, "workspace_id", resource_id="my_resource_id")
         base_resource._find_by_resource_id()
         base_resource._get_fn.assert_called_with(base_resource.api_instance, base_resource.get_payload)
 
+    @pytest.mark.xdist_group(name="test_resources")
     @pytest.mark.parametrize("resource_id, resource_name", [("my_resource_id", None), (None, "my_resource_name")])
     def test_get_remote_resource(self, mocker, patch_base_class, mock_api_client, resource_id, resource_name):
         mocker.patch.object(BaseResource, "_find_by_resource_id")
@@ -98,6 +106,7 @@ class TestBaseResource:
             base_resource._find_by_resource_name.assert_called_once()
             assert remote_resource == base_resource._find_by_resource_name.return_value
 
+    @pytest.mark.xdist_group(name="test_resources")
     def test_to_json(self, mocker, patch_base_class, mock_api_client):
         mocker.patch.object(
             BaseResource, "get_remote_resource", mocker.Mock(return_value=mocker.Mock(to_dict=mocker.Mock(return_value={"foo": "bar"})))
@@ -108,6 +117,7 @@ class TestBaseResource:
 
 
 class TestSource:
+    @pytest.mark.xdist_group(name="test_resources")
     def test_init(self, mock_api_client):
         assert Source.__base__ == BaseResource
         source = Source(mock_api_client, "workspace_id", "resource_id")
@@ -118,6 +128,7 @@ class TestSource:
 
 
 class TestDestination:
+    @pytest.mark.xdist_group(name="test_resources")
     def test_init(self, mock_api_client):
         assert Destination.__base__ == BaseResource
         destination = Destination(mock_api_client, "workspace_id", "resource_id")
@@ -128,6 +139,7 @@ class TestDestination:
 
 
 class TestConnection:
+    @pytest.mark.xdist_group(name="test_resources")
     def test_init(self, mock_api_client):
         assert Connection.__base__ == BaseResource
         connection = Connection(mock_api_client, "workspace_id", "resource_id")

--- a/octavia-cli/unit_tests/test_get/test_resources.py
+++ b/octavia-cli/unit_tests/test_get/test_resources.py
@@ -32,7 +32,6 @@ class TestBaseResource:
             ("my_resource_id", "my_resource_name", ValueError, "resource_id and resource_name keyword arguments can't be both set."),
         ],
     )
-
     @pytest.mark.xdist_group(name="test_resources")
     def test_init(self, patch_base_class, mock_api_client, resource_id, resource_name, expected_error, expected_error_message):
         if expected_error:
@@ -82,7 +81,7 @@ class TestBaseResource:
         if expected_error:
             with pytest.raises(expected_error, match=expected_error_message):
                 base_resource._find_by_resource_name()
-    
+
     @pytest.mark.xdist_group(name="test_resources")
     def test__find_by_id(self, mocker, patch_base_class, mock_api_client):
         mocker.patch.object(BaseResource, "_get_fn")

--- a/octavia-cli/unit_tests/test_list/test_listings.py
+++ b/octavia-cli/unit_tests/test_list/test_listings.py
@@ -18,12 +18,14 @@ from octavia_cli.list.listings import (
 
 class TestBaseListing:
     @pytest.fixture
+    @pytest.mark.xdist_group(name="test_listings")
     def patch_base_class(self, mocker):
         # Mock abstract methods to enable instantiating abstract class
         mocker.patch.object(BaseListing, "__abstractmethods__", set())
         mocker.patch.object(BaseListing, "list_function_name", "my_list_function_name")
         mocker.patch.object(BaseListing, "api", mocker.Mock(my_list_function_name=mocker.Mock()))
 
+    @pytest.mark.xdist_group(name="test_listings")
     def test_init(self, patch_base_class, mock_api_client):
         base_listing = BaseListing(mock_api_client)
         assert base_listing._list_fn == BaseListing.api.my_list_function_name
@@ -32,11 +34,13 @@ class TestBaseListing:
         base_listing.api.assert_called_with(mock_api_client)
         assert base_listing.COMMON_LIST_FUNCTION_KWARGS == {"_check_return_type": False}
 
+    @pytest.mark.xdist_group(name="test_listings")
     def test_abstract_methods(self, mock_api_client):
         assert BaseListing.__abstractmethods__ == {"api", "fields_to_display", "list_field_in_response", "list_function_name"}
         with pytest.raises(TypeError):
             BaseListing(mock_api_client)
 
+    @pytest.mark.xdist_group(name="test_listings")
     def test_parse_response(self, patch_base_class, mocker, mock_api_client):
         mocker.patch.object(BaseListing, "fields_to_display", ["fieldA", "fieldB"])
         base_listing = BaseListing(mock_api_client)
@@ -51,6 +55,7 @@ class TestBaseListing:
             assert parsed_listing[i] == [f"{field}_value_{i}" for field in base_listing.fields_to_display]
             assert "discarded_value" not in parsed_listing[i]
 
+    @pytest.mark.xdist_group(name="test_listings")
     def test_gest_listing(self, patch_base_class, mocker, mock_api_client):
         mocker.patch.object(BaseListing, "_parse_response")
         mocker.patch.object(BaseListing, "_list_fn")
@@ -62,6 +67,7 @@ class TestBaseListing:
         base_listing._parse_response.assert_called_with(base_listing._list_fn.return_value)
         assert listing == base_listing._parse_response.return_value
 
+    @pytest.mark.xdist_group(name="test_listings")
     def test_repr(self, patch_base_class, mocker, mock_api_client):
         headers = ["fieldA", "fieldB", "fieldC"]
         api_response_listing = [["a", "b", "c"]]
@@ -77,6 +83,7 @@ class TestBaseListing:
 
 
 class TestSourceConnectorsDefinitions:
+    @pytest.mark.xdist_group(name="test_listings")
     def test_init(self, mock_api_client):
         assert SourceConnectorsDefinitions.__base__ == BaseListing
         source_connectors_definition = SourceConnectorsDefinitions(mock_api_client)
@@ -87,6 +94,7 @@ class TestSourceConnectorsDefinitions:
 
 
 class TestDestinationConnectorsDefinitions:
+    @pytest.mark.xdist_group(name="test_listings")
     def test_init(self, mock_api_client):
         assert DestinationConnectorsDefinitions.__base__ == BaseListing
         destination_connectors_definition = DestinationConnectorsDefinitions(mock_api_client)
@@ -102,12 +110,14 @@ class TestDestinationConnectorsDefinitions:
 
 
 class TestWorkspaceListing:
+    @pytest.mark.xdist_group(name="test_listings")
     @pytest.fixture
     def patch_base_class(self, mocker):
         # Mock abstract methods to enable instantiating abstract class
         mocker.patch.object(WorkspaceListing, "__abstractmethods__", set())
         mocker.patch.object(WorkspaceListing, "api", mocker.Mock())
 
+    @pytest.mark.xdist_group(name="test_listings")
     def test_init(self, patch_base_class, mocker, mock_api_client):
         mocker.patch.object(listings, "WorkspaceIdRequestBody")
         mocker.patch.object(BaseListing, "__init__")
@@ -119,12 +129,14 @@ class TestWorkspaceListing:
         listings.WorkspaceIdRequestBody.assert_called_with(workspace_id="my_workspace_id")
         BaseListing.__init__.assert_called_with(mock_api_client)
 
+    @pytest.mark.xdist_group(name="test_listings")
     def test_abstract(self, mock_api_client):
         with pytest.raises(TypeError):
             WorkspaceListing(mock_api_client)
 
 
 class TestSources:
+    @pytest.mark.xdist_group(name="test_listings")
     def test_init(self, mock_api_client):
         assert Sources.__base__ == WorkspaceListing
         sources = Sources(mock_api_client, "my_workspace_id")
@@ -135,6 +147,7 @@ class TestSources:
 
 
 class TestDestinations:
+    @pytest.mark.xdist_group(name="test_listings")
     def test_init(self, mock_api_client):
         assert Destinations.__base__ == WorkspaceListing
         destinations = Destinations(mock_api_client, "my_workspace_id")
@@ -145,6 +158,7 @@ class TestDestinations:
 
 
 class TestConnections:
+    @pytest.mark.xdist_group(name="test_listings")
     def test_init(self, mock_api_client):
         assert Connections.__base__ == WorkspaceListing
         connections = Connections(mock_api_client, "my_workspace_id")

--- a/tools/bin/setup_connector_venv.sh
+++ b/tools/bin/setup_connector_venv.sh
@@ -12,3 +12,4 @@ source .venv/bin/activate
 pip install -r requirements.txt
 pip install '.[tests]'
 pip install pytest-cov
+pip install pytest-xdist

--- a/tools/tox_ci.ini
+++ b/tools/tox_ci.ini
@@ -13,6 +13,7 @@ envlist =
 deps =
      -e{toxinidir}/{envname}[tests]
      pytest~=6.2.5
+     pytest-xdist~=3.0.2
      flake8==4.0.1
      pyproject-flake8
 


### PR DESCRIPTION
## What
Removes the limit to amount of threads that gradle can spawn in order to get better cpu utilization, possibly with larger machines. Also add pytest parallelism

## How
Remove the gradle.properties setting and add pytest-xdist, which parallelizes pytest unit tests
