### PR TITLE
Go back to concise connector builder server error messages

### DIFF
--- a/airbyte-connector-builder-server/connector_builder/impl/default_api.py
+++ b/airbyte-connector-builder-server/connector_builder/impl/default_api.py
@@ -97,7 +97,7 @@ spec:
                     )
                 )
         except Exception as error:
-            raise HTTPException(status_code=400, detail=f"Could not list streams with with error: {str(error)}")
+            raise HTTPException(status_code=400, detail=f"Could not list streams with with error: {error.args[0]}")
         return StreamsListRead(streams=stream_list_read)
 
     async def read_stream(self, stream_read_request_body: StreamReadRequestBody = Body(None, description="")) -> StreamRead:
@@ -121,7 +121,7 @@ spec:
                     single_slice.pages.append(message_group)
         except Exception as error:
             # TODO: We're temporarily using FastAPI's default exception model. Ideally we should use exceptions defined in the OpenAPI spec
-            raise HTTPException(status_code=400, detail=f"Could not perform read with with error: {str(error)}")
+            raise HTTPException(status_code=400, detail=f"Could not perform read with with error: {error.args[0]}")
 
         return StreamRead(logs=log_messages, slices=[single_slice])
 
@@ -199,6 +199,6 @@ spec:
     def _create_low_code_adapter(manifest: Dict[str, Any]) -> LowCodeSourceAdapter:
         try:
             return LowCodeSourceAdapter(manifest=manifest)
-        except Exception as error:
+        except ValidationError as error:
             # TODO: We're temporarily using FastAPI's default exception model. Ideally we should use exceptions defined in the OpenAPI spec
-            raise HTTPException(status_code=400, detail=f"Invalid connector manifest with error: {str(error)}")
+            raise HTTPException(status_code=400, detail=f"Invalid connector manifest with error: {error.message}")


### PR DESCRIPTION
## What
[A PR](https://github.com/airbytehq/airbyte/commit/86eb221cab4bdf1285a79b3d91573dd4e70bea55#diff-9d15ecb8c45b75149182f5a9ec28f04425f591e7709f94195aff524a0f53d7afR99) added a change which made the error messages returned by the connector builder server very verbose, causing ugly looking error messages like this in the UI:
<img width="1000" alt="Screen Shot 2022-11-18 at 9 36 22 AM" src="https://user-images.githubusercontent.com/22731524/202772429-b2c90143-10de-480b-8304-cb119a224107.png">

## How
This PR undoes that error message change, to bring us back to more concise error messages:
<img width="1000" alt="Screen Shot 2022-11-18 at 10 00 53 AM" src="https://user-images.githubusercontent.com/22731524/202772502-eceb933b-2d44-4c69-be1d-bbcc1b1774ad.png">


