### PR TITLE
:window: :wrench: Show success message and clear form on successful dbt cloud token submisison

### DIFF
--- a/airbyte-webapp/src/packages/cloud/locales/en.json
+++ b/airbyte-webapp/src/packages/cloud/locales/en.json
@@ -104,6 +104,7 @@
   "settings.integrationSettings.dbtCloudSettings.form.singleTenantUrl": "Single-tenant URL",
   "settings.integrationSettings.dbtCloudSettings.form.testConnection": "Test connection",
   "settings.integrationSettings.dbtCloudSettings.form.submit": "Save changes",
+  "settings.integrationSettings.dbtCloudSettings.form.success": "Service Token saved successfully",
   "settings.generalSettings": "General Settings",
   "settings.generalSettings.changeWorkspace": "Change Workspace",
   "settings.generalSettings.form.name.label": "Workspace name",

--- a/airbyte-webapp/src/packages/cloud/services/dbtCloud.ts
+++ b/airbyte-webapp/src/packages/cloud/services/dbtCloud.ts
@@ -64,6 +64,8 @@ export const isSameJob = (remoteJob: DbtCloudJobInfo, savedJob: DbtCloudJob): bo
 
 type ServiceToken = string;
 
+type ServiceToken = string;
+
 export const useSubmitDbtCloudIntegrationConfig = () => {
   const { workspaceId } = useCurrentWorkspace();
   const { mutateAsync: updateWorkspace } = useUpdateWorkspace();

--- a/airbyte-webapp/src/packages/cloud/services/dbtCloud.ts
+++ b/airbyte-webapp/src/packages/cloud/services/dbtCloud.ts
@@ -64,8 +64,6 @@ export const isSameJob = (remoteJob: DbtCloudJobInfo, savedJob: DbtCloudJob): bo
 
 type ServiceToken = string;
 
-type ServiceToken = string;
-
 export const useSubmitDbtCloudIntegrationConfig = () => {
   const { workspaceId } = useCurrentWorkspace();
   const { mutateAsync: updateWorkspace } = useUpdateWorkspace();

--- a/airbyte-webapp/src/packages/cloud/views/settings/integrations/DbtCloudSettingsView.tsx
+++ b/airbyte-webapp/src/packages/cloud/views/settings/integrations/DbtCloudSettingsView.tsx
@@ -1,6 +1,6 @@
 import { Field, FieldProps, Form, Formik } from "formik";
 import React, { useState } from "react";
-import { FormattedMessage } from "react-intl";
+import { FormattedMessage, useIntl } from "react-intl";
 
 import { LabeledInput } from "components/LabeledInput";
 import { Button } from "components/ui/Button";
@@ -11,6 +11,7 @@ import { Content, SettingsCard } from "pages/SettingsPage/pages/SettingsComponen
 import styles from "./DbtCloudSettingsView.module.scss";
 
 export const DbtCloudSettingsView: React.FC = () => {
+  const { formatMessage } = useIntl();
   const { mutate: submitDbtCloudIntegrationConfig, isLoading } = useSubmitDbtCloudIntegrationConfig();
   const [hasValidationError, setHasValidationError] = useState(false);
   const [validationMessage, setValidationMessage] = useState("");
@@ -21,7 +22,7 @@ export const DbtCloudSettingsView: React.FC = () => {
           initialValues={{
             serviceToken: "",
           }}
-          onSubmit={({ serviceToken }) => {
+          onSubmit={({ serviceToken }, { resetForm }) => {
             setHasValidationError(false);
             return submitDbtCloudIntegrationConfig(serviceToken, {
               onError: (e) => {
@@ -29,7 +30,12 @@ export const DbtCloudSettingsView: React.FC = () => {
 
                 setValidationMessage(e.message.replace("Internal Server Error: ", ""));
               },
-              onSuccess: () => setValidationMessage(""),
+              onSuccess: () => {
+                setValidationMessage(
+                  formatMessage({ id: "settings.integrationSettings.dbtCloudSettings.form.success" })
+                );
+                resetForm();
+              },
             });
           }}
         >

--- a/airbyte-webapp/src/packages/cloud/views/settings/integrations/DbtCloudSettingsView.tsx
+++ b/airbyte-webapp/src/packages/cloud/views/settings/integrations/DbtCloudSettingsView.tsx
@@ -24,6 +24,7 @@ export const DbtCloudSettingsView: React.FC = () => {
           }}
           onSubmit={({ serviceToken }, { resetForm }) => {
             setHasValidationError(false);
+            setValidationMessage("");
             return submitDbtCloudIntegrationConfig(serviceToken, {
               onError: (e) => {
                 setHasValidationError(true);


### PR DESCRIPTION
![2022-11-18-10:34:49-screenshot](https://user-images.githubusercontent.com/7516653/202778045-6d509d1e-090d-4c2a-941f-d6754c2cc678.png)

Wrote this quickly; I'm guessing that `components/ui/Toast` would be the conventional way to show the success message, rather than a `message` prop on the input, is that correct?