### PR TITLE
Revert "Trace Failure Origins"

### DIFF
--- a/airbyte-metrics/metrics-lib/src/main/java/io/airbyte/metrics/lib/ApmTraceConstants.java
+++ b/airbyte-metrics/metrics-lib/src/main/java/io/airbyte/metrics/lib/ApmTraceConstants.java
@@ -64,11 +64,6 @@ public final class ApmTraceConstants {
     public static final String DOCKER_IMAGE_KEY = "docker_image";
 
     /**
-     * Name of the APM trace tag that holds the failure origin(s) associated with the trace.
-     */
-    public static final String FAILURE_ORIGINS_KEY = "failure_origins";
-
-    /**
      * Name of the APM trace tag that holds the job ID value associated with the trace.
      */
     public static final String JOB_ID_KEY = "job_id";

--- a/docker-compose.datadog.yaml
+++ b/docker-compose.datadog.yaml
@@ -2,7 +2,7 @@
 # This exists _only_ for testing datadog integrations!
 #
 # Usage:
-# 1. Create an organization API Key in DataDog (Organization Settings > API Keys)
+# 1. create an API Key in datadog
 # 2. wget -O dd-java-agent.jar 'https://dtdg.co/latest-java-tracer'
 # 3. DD_API_KEY=[datadog api key] VERSION=dev docker-compose -f docker-compose.yaml -f docker-compose.datadog.yaml up -d
 version: "3.7"


### PR DESCRIPTION
Reverts airbytehq/airbyte#19550

This is causing NPE when trying to resolve https://github.com/airbytehq/oncall/issues/1077

For example: https://web.prod.ebc2e.tmprl.cloud/namespaces/prod.ebc2e/workflows/connection_manager_89b764f2-c3cd-4a16-a711-da02be8a1f74/54364fdb-3a81-4eae-a1e9-56660b5ff260/history/compact?sort=descending
