### PR TITLE
No longer forces custom source/destination definition always

### DIFF
--- a/airbyte-webapp/src/core/domain/connector/DestinationDefinitionService.ts
+++ b/airbyte-webapp/src/core/domain/connector/DestinationDefinitionService.ts
@@ -1,14 +1,14 @@
 import { AirbyteRequestService } from "core/request/AirbyteRequestService";
 
 import {
-  createCustomDestinationDefinition,
-  CustomDestinationDefinitionCreate,
-  CustomDestinationDefinitionUpdate,
+  createDestinationDefinition,
+  DestinationDefinitionCreate,
   DestinationDefinitionIdWithWorkspaceId,
+  DestinationDefinitionUpdate,
   getDestinationDefinitionForWorkspace,
   listDestinationDefinitionsForWorkspace,
   listLatestDestinationDefinitions,
-  updateCustomDestinationDefinition,
+  updateDestinationDefinition,
 } from "../../request/AirbyteClient";
 
 export class DestinationDefinitionService extends AirbyteRequestService {
@@ -24,11 +24,11 @@ export class DestinationDefinitionService extends AirbyteRequestService {
     return listLatestDestinationDefinitions(this.requestOptions);
   }
 
-  public update(body: CustomDestinationDefinitionUpdate) {
-    return updateCustomDestinationDefinition(body, this.requestOptions);
+  public update(body: DestinationDefinitionUpdate) {
+    return updateDestinationDefinition(body, this.requestOptions);
   }
 
-  public create(body: CustomDestinationDefinitionCreate) {
-    return createCustomDestinationDefinition(body, this.requestOptions);
+  public create(body: DestinationDefinitionCreate) {
+    return createDestinationDefinition(body, this.requestOptions);
   }
 }

--- a/airbyte-webapp/src/core/domain/connector/SourceDefinitionService.ts
+++ b/airbyte-webapp/src/core/domain/connector/SourceDefinitionService.ts
@@ -1,14 +1,14 @@
 import { AirbyteRequestService } from "core/request/AirbyteRequestService";
 
 import {
-  createCustomSourceDefinition,
-  CustomSourceDefinitionCreate,
   getSourceDefinitionForWorkspace,
   listLatestSourceDefinitions,
   listSourceDefinitionsForWorkspace,
-  CustomSourceDefinitionUpdate,
-  updateCustomSourceDefinition,
   SourceDefinitionIdWithWorkspaceId,
+  updateSourceDefinition,
+  SourceDefinitionUpdate,
+  createSourceDefinition,
+  SourceDefinitionCreate,
 } from "../../request/AirbyteClient";
 
 export class SourceDefinitionService extends AirbyteRequestService {
@@ -24,11 +24,11 @@ export class SourceDefinitionService extends AirbyteRequestService {
     return listLatestSourceDefinitions(this.requestOptions);
   }
 
-  public update(body: CustomSourceDefinitionUpdate) {
-    return updateCustomSourceDefinition(body, this.requestOptions);
+  public update(body: SourceDefinitionUpdate) {
+    return updateSourceDefinition(body, this.requestOptions);
   }
 
-  public create(body: CustomSourceDefinitionCreate) {
-    return createCustomSourceDefinition(body, this.requestOptions);
+  public create(body: SourceDefinitionCreate) {
+    return createSourceDefinition(body, this.requestOptions);
   }
 }

--- a/airbyte-webapp/src/services/connector/DestinationDefinitionService.ts
+++ b/airbyte-webapp/src/services/connector/DestinationDefinitionService.ts
@@ -76,10 +76,9 @@ const useDestinationDefinition = <T extends string | undefined>(
 const useCreateDestinationDefinition = () => {
   const service = useGetDestinationDefinitionService();
   const queryClient = useQueryClient();
-  const workspaceId = useCurrentWorkspaceId();
 
   return useMutation<DestinationDefinitionRead, Error, DestinationDefinitionCreate>(
-    (destinationDefinition) => service.create({ workspaceId, destinationDefinition }),
+    (destinationDefinition) => service.create(destinationDefinition),
     {
       onSuccess: (data) => {
         queryClient.setQueryData(
@@ -96,7 +95,6 @@ const useCreateDestinationDefinition = () => {
 const useUpdateDestinationDefinition = () => {
   const service = useGetDestinationDefinitionService();
   const queryClient = useQueryClient();
-  const workspaceId = useCurrentWorkspaceId();
 
   return useMutation<
     DestinationDefinitionRead,
@@ -105,7 +103,7 @@ const useUpdateDestinationDefinition = () => {
       destinationDefinitionId: string;
       dockerImageTag: string;
     }
-  >((destinationDefinition) => service.update({ workspaceId, destinationDefinition }), {
+  >((destinationDefinition) => service.update(destinationDefinition), {
     onSuccess: (data) => {
       queryClient.setQueryData(destinationDefinitionKeys.detail(data.destinationDefinitionId), data);
 

--- a/airbyte-webapp/src/services/connector/SourceDefinitionService.ts
+++ b/airbyte-webapp/src/services/connector/SourceDefinitionService.ts
@@ -74,10 +74,9 @@ const useSourceDefinition = <T extends string | undefined>(
 const useCreateSourceDefinition = () => {
   const service = useGetSourceDefinitionService();
   const queryClient = useQueryClient();
-  const workspaceId = useCurrentWorkspaceId();
 
   return useMutation<SourceDefinitionRead, Error, SourceDefinitionCreate>(
-    (sourceDefinition) => service.create({ workspaceId, sourceDefinition }),
+    (sourceDefinition) => service.create(sourceDefinition),
     {
       onSuccess: (data) => {
         queryClient.setQueryData(
@@ -94,7 +93,6 @@ const useCreateSourceDefinition = () => {
 const useUpdateSourceDefinition = () => {
   const service = useGetSourceDefinitionService();
   const queryClient = useQueryClient();
-  const workspaceId = useCurrentWorkspaceId();
 
   return useMutation<
     SourceDefinitionRead,
@@ -103,7 +101,7 @@ const useUpdateSourceDefinition = () => {
       sourceDefinitionId: string;
       dockerImageTag: string;
     }
-  >((sourceDefinition) => service.update({ workspaceId, sourceDefinition }), {
+  >((sourceDefinition) => service.update(sourceDefinition), {
     onSuccess: (data) => {
       queryClient.setQueryData(sourceDefinitionKeys.detail(data.sourceDefinitionId), data);
 


### PR DESCRIPTION
## What
This [PR](https://github.com/airbytehq/airbyte/pull/19221) introduced a bug that made all source and destination definitions create or update a custom.
Rather than a full revert, this PR simply returns the old functionality.