### PR TITLE
airbyte-cdk offset pagination strategy: page_size to be interpolated …

### DIFF
--- a/airbyte-cdk/python/airbyte_cdk/sources/declarative/requesters/paginators/strategies/offset_increment.py
+++ b/airbyte-cdk/python/airbyte_cdk/sources/declarative/requesters/paginators/strategies/offset_increment.py
@@ -3,10 +3,12 @@
 #
 
 from dataclasses import InitVar, dataclass
-from typing import Any, List, Mapping, Optional
+from typing import Any, List, Mapping, Optional, Union
 
 import requests
 from airbyte_cdk.sources.declarative.requesters.paginators.strategies.pagination_strategy import PaginationStrategy
+from airbyte_cdk.sources.declarative.interpolation import InterpolatedString
+from airbyte_cdk.sources.declarative.types import Config
 from dataclasses_jsonschema import JsonSchemaMixin
 
 
@@ -16,14 +18,17 @@ class OffsetIncrement(PaginationStrategy, JsonSchemaMixin):
     Pagination strategy that returns the number of records reads so far and returns it as the next page token
 
     Attributes:
-        page_size (int): the number of records to request
+        page_size (InterpolatedString): the number of records to request
     """
 
-    page_size: int
+    config: Config
+    page_size: Union[InterpolatedString, str, int]
     options: InitVar[Mapping[str, Any]]
 
     def __post_init__(self, options: Mapping[str, Any]):
         self._offset = 0
+        self.page_size.string = str(self.page_size.string)
+        self.page_size = self.page_size.eval(self.config)
 
     def next_page_token(self, response: requests.Response, last_records: List[Mapping[str, Any]]) -> Optional[Any]:
         if len(last_records) < self.page_size:

--- a/airbyte-cdk/python/airbyte_cdk/sources/declarative/requesters/paginators/strategies/offset_increment.py
+++ b/airbyte-cdk/python/airbyte_cdk/sources/declarative/requesters/paginators/strategies/offset_increment.py
@@ -16,6 +16,21 @@ from dataclasses_jsonschema import JsonSchemaMixin
 class OffsetIncrement(PaginationStrategy, JsonSchemaMixin):
     """
     Pagination strategy that returns the number of records reads so far and returns it as the next page token
+    Examples:
+        # page_size to be a constant integer value
+        pagination_strategy:
+          type: OffsetIncrement
+          page_size: 2
+
+        # page_size to be a constant string value
+        pagination_strategy:
+          type: OffsetIncrement
+          page_size: "2"
+
+        # page_size to be an interpolated string value
+        pagination_strategy:
+          type: OffsetIncrement
+          page_size: "{{ options['items_per_page'] }}"
 
     Attributes:
         page_size (InterpolatedString): the number of records to request
@@ -27,6 +42,8 @@ class OffsetIncrement(PaginationStrategy, JsonSchemaMixin):
 
     def __post_init__(self, options: Mapping[str, Any]):
         self._offset = 0
+        # InterpolatedString page_size may contain one int/str types,
+        # so we need to ensure that its `.string` attribute is of *string* type
         self.page_size.string = str(self.page_size.string)
         self.page_size = self.page_size.eval(self.config)
 

--- a/airbyte-cdk/python/airbyte_cdk/sources/declarative/requesters/paginators/strategies/offset_increment.py
+++ b/airbyte-cdk/python/airbyte_cdk/sources/declarative/requesters/paginators/strategies/offset_increment.py
@@ -42,7 +42,7 @@ class OffsetIncrement(PaginationStrategy, JsonSchemaMixin):
 
     def __post_init__(self, options: Mapping[str, Any]):
         self._offset = 0
-        # InterpolatedString page_size may contain one int/str types,
+        # InterpolatedString page_size may contain one of int/str types,
         # so we need to ensure that its `.string` attribute is of *string* type
         self.page_size.string = str(self.page_size.string)
         self.page_size = self.page_size.eval(self.config)

--- a/airbyte-cdk/python/airbyte_cdk/sources/declarative/requesters/paginators/strategies/offset_increment.py
+++ b/airbyte-cdk/python/airbyte_cdk/sources/declarative/requesters/paginators/strategies/offset_increment.py
@@ -45,10 +45,9 @@ class OffsetIncrement(PaginationStrategy, JsonSchemaMixin):
         # InterpolatedString page_size may contain one of int/str types,
         # so we need to ensure that its `.string` attribute is of *string* type
         self.page_size.string = str(self.page_size.string)
-        self.page_size = self.page_size.eval(self.config)
 
     def next_page_token(self, response: requests.Response, last_records: List[Mapping[str, Any]]) -> Optional[Any]:
-        if len(last_records) < self.page_size:
+        if len(last_records) < self.page_size.eval(self.config):
             return None
         else:
             self._offset += len(last_records)
@@ -58,4 +57,7 @@ class OffsetIncrement(PaginationStrategy, JsonSchemaMixin):
         self._offset = 0
 
     def get_page_size(self) -> Optional[int]:
-        return self.page_size
+        page_size = self.page_size.eval(self.config)
+        if not isinstance(page_size, int):
+            raise Exception(f"{page_size} is of type {type(page_size)}. Expected {int}")
+        return page_size

--- a/airbyte-cdk/python/setup.py
+++ b/airbyte-cdk/python/setup.py
@@ -15,7 +15,7 @@ README = (HERE / "README.md").read_text()
 
 setup(
     name="airbyte-cdk",
-    version="0.11.3",
+    version="0.11.4",
     description="A framework for writing Airbyte Connectors.",
     long_description=README,
     long_description_content_type="text/markdown",

--- a/airbyte-cdk/python/unit_tests/sources/declarative/requesters/paginators/test_offset_increment.py
+++ b/airbyte-cdk/python/unit_tests/sources/declarative/requesters/paginators/test_offset_increment.py
@@ -6,18 +6,21 @@ import json
 
 import pytest
 import requests
+
+from airbyte_cdk.sources.declarative.interpolation import InterpolatedString
 from airbyte_cdk.sources.declarative.requesters.paginators.strategies.offset_increment import OffsetIncrement
 
 
 @pytest.mark.parametrize(
     "test_name, page_size, expected_next_page_token, expected_offset",
     [
-        ("test_same_page_size", 2, 2, 2),
-        ("test_larger_page_size", 3, None, 0),
+        ("test_same_page_size", InterpolatedString(string="2", options={}), 2, 2),
+        ("test_same_page_size", InterpolatedString(string=2, options={}), 2, 2),
+        ("test_larger_page_size", InterpolatedString(string="{{ options['page_size'] }}", options={"page_size": 3}), None, 0),
     ],
 )
 def test_offset_increment_paginator_strategy(test_name, page_size, expected_next_page_token, expected_offset):
-    paginator_strategy = OffsetIncrement(page_size, options={})
+    paginator_strategy = OffsetIncrement(page_size=page_size, options={}, config={})
     assert paginator_strategy._offset == 0
 
     response = requests.Response()

--- a/airbyte-cdk/python/unit_tests/sources/declarative/requesters/paginators/test_offset_increment.py
+++ b/airbyte-cdk/python/unit_tests/sources/declarative/requesters/paginators/test_offset_increment.py
@@ -36,3 +36,14 @@ def test_offset_increment_paginator_strategy(test_name, page_size, expected_next
 
     paginator_strategy.reset()
     assert 0 == paginator_strategy._offset
+
+
+def test_offset_increment_paginator_strategy_rises():
+    paginator_strategy = OffsetIncrement(
+        page_size=InterpolatedString(string="{{ options['page_size'] }}", options={"page_size": "invalid value"}),
+        options={},
+        config={}
+    )
+    with pytest.raises(Exception) as exc:
+        paginator_strategy.get_page_size()
+    assert str(exc.value) == 'invalid value is of type <class \'str\'>. Expected <class \'int\'>'


### PR DESCRIPTION
It is often happen that `page_size` need to be specified per stream. With current changes we can set the `page_size` in stream options while define it only once:
```
page_size: "{{ options['items_per_page'] }}"