### PR TITLE
🎉 New implementation for AWS Secret Manager for issue

### DIFF
--- a/airbyte-config/config-models/src/main/java/io/airbyte/config/Configs.java
+++ b/airbyte-config/config-models/src/main/java/io/airbyte/config/Configs.java
@@ -148,6 +148,16 @@ public interface Configs {
    */
   String getVaultToken();
 
+  /**
+   * Defines thw aws_access_key configuration to use AWSSecretManager.
+   */
+  String getAwsAccessKey();
+
+  /**
+   * Defines aws_secret_access_key to use for AWSSecretManager.
+   */
+  String getAwsSecretAccessKey();
+
   // Database
 
   /**
@@ -748,7 +758,8 @@ public interface Configs {
     NONE,
     TESTING_CONFIG_DB_TABLE,
     GOOGLE_SECRET_MANAGER,
-    VAULT
+    VAULT,
+    AWS_SECRET_MANAGER
   }
 
 }

--- a/airbyte-config/config-models/src/main/java/io/airbyte/config/EnvConfigs.java
+++ b/airbyte-config/config-models/src/main/java/io/airbyte/config/EnvConfigs.java
@@ -203,6 +203,8 @@ public class EnvConfigs implements Configs {
   private static final String DEFAULT_JOB_KUBE_SIDECAR_CONTAINER_IMAGE_PULL_POLICY = "IfNotPresent";
   private static final String SECRET_STORE_GCP_PROJECT_ID = "SECRET_STORE_GCP_PROJECT_ID";
   private static final String SECRET_STORE_GCP_CREDENTIALS = "SECRET_STORE_GCP_CREDENTIALS";
+  private static final String AWS_ACCESS_KEY = "AWS_ACCESS_KEY";
+  private static final String AWS_SECRET_ACCESS_KEY = "AWS_SECRET_ACCESS_KEY";
   private static final String DEFAULT_JOB_KUBE_SOCAT_IMAGE = "alpine/socat:1.7.4.3-r0";
   private static final String DEFAULT_JOB_KUBE_BUSYBOX_IMAGE = "busybox:1.28";
   private static final String DEFAULT_JOB_KUBE_CURL_IMAGE = "curlimages/curl:7.83.1";
@@ -417,6 +419,16 @@ public class EnvConfigs implements Configs {
   @Override
   public String getVaultToken() {
     return getEnv(VAULT_AUTH_TOKEN);
+  }
+
+  @Override
+  public String getAwsAccessKey() {
+    return getEnv(AWS_ACCESS_KEY);
+  }
+
+  @Override
+  public String getAwsSecretAccessKey() {
+    return getEnv(AWS_SECRET_ACCESS_KEY);
   }
 
   // Database

--- a/airbyte-config/config-persistence/build.gradle
+++ b/airbyte-config/config-persistence/build.gradle
@@ -20,7 +20,9 @@ dependencies {
     implementation 'commons-io:commons-io:2.7'
     implementation 'com.google.cloud:google-cloud-secretmanager:2.0.5'
     implementation 'com.bettercloud:vault-java-driver:5.1.0'
-    implementation 'com.amazonaws.secretsmanager:aws-secretsmanager-caching-java:1.0.2'
+    implementation ('com.amazonaws.secretsmanager:aws-secretsmanager-caching-java:1.0.2') {
+        exclude group: 'com.fasterxml.jackson.core', module: 'jackson-databind'
+    }
 
     testImplementation 'org.hamcrest:hamcrest-all:1.3'
     testImplementation libs.platform.testcontainers.postgresql

--- a/airbyte-config/config-persistence/build.gradle
+++ b/airbyte-config/config-persistence/build.gradle
@@ -20,7 +20,7 @@ dependencies {
     implementation 'commons-io:commons-io:2.7'
     implementation 'com.google.cloud:google-cloud-secretmanager:2.0.5'
     implementation 'com.bettercloud:vault-java-driver:5.1.0'
-    implementation 'com.amazonaws.secretsmanager:aws-secretsmanager-caching-java:1.0.1'
+    implementation 'com.amazonaws.secretsmanager:aws-secretsmanager-caching-java:1.0.2'
 
     testImplementation 'org.hamcrest:hamcrest-all:1.3'
     testImplementation libs.platform.testcontainers.postgresql

--- a/airbyte-config/config-persistence/build.gradle
+++ b/airbyte-config/config-persistence/build.gradle
@@ -20,6 +20,7 @@ dependencies {
     implementation 'commons-io:commons-io:2.7'
     implementation 'com.google.cloud:google-cloud-secretmanager:2.0.5'
     implementation 'com.bettercloud:vault-java-driver:5.1.0'
+    implementation 'com.amazonaws.secretsmanager:aws-secretsmanager-caching-java:1.0.1'
 
     testImplementation 'org.hamcrest:hamcrest-all:1.3'
     testImplementation libs.platform.testcontainers.postgresql

--- a/airbyte-config/config-persistence/build.gradle
+++ b/airbyte-config/config-persistence/build.gradle
@@ -20,9 +20,7 @@ dependencies {
     implementation 'commons-io:commons-io:2.7'
     implementation 'com.google.cloud:google-cloud-secretmanager:2.0.5'
     implementation 'com.bettercloud:vault-java-driver:5.1.0'
-    implementation ('com.amazonaws.secretsmanager:aws-secretsmanager-caching-java:1.0.2') {
-        exclude group: 'com.fasterxml.jackson.core', module: 'jackson-databind'
-    }
+    implementation 'com.amazonaws.secretsmanager:aws-secretsmanager-caching-java:1.0.2'
 
     testImplementation 'org.hamcrest:hamcrest-all:1.3'
     testImplementation libs.platform.testcontainers.postgresql

--- a/airbyte-config/config-persistence/src/main/java/io/airbyte/config/persistence/split_secrets/AWSSecretManagerPersistence.java
+++ b/airbyte-config/config-persistence/src/main/java/io/airbyte/config/persistence/split_secrets/AWSSecretManagerPersistence.java
@@ -1,0 +1,105 @@
+/*
+ * Copyright (c) 2022 Airbyte, Inc., all rights reserved.
+ */
+
+package io.airbyte.config.persistence.split_secrets;
+
+import com.amazonaws.secretsmanager.caching.SecretCache;
+import com.amazonaws.services.secretsmanager.AWSSecretsManager;
+import com.amazonaws.services.secretsmanager.AWSSecretsManagerClientBuilder;
+import com.amazonaws.services.secretsmanager.model.CreateSecretRequest;
+import com.amazonaws.services.secretsmanager.model.DeleteSecretRequest;
+import com.amazonaws.services.secretsmanager.model.ResourceNotFoundException;
+import com.amazonaws.services.secretsmanager.model.UpdateSecretRequest;
+import com.google.common.annotations.VisibleForTesting;
+import java.util.Optional;
+import lombok.extern.slf4j.Slf4j;
+
+/**
+ * SecretPersistence implementation for AWS Secret Manager using <a href=
+ * "https://sdk.amazonaws.com/java/api/latest/software/amazon/awssdk/services/secretsmanager/package-summary.html">Java
+ * SDK</a> The current implementation doesn't make use of `SecretCoordinate#getVersion` as this
+ * version is non-compatible with how AWS secret manager deals with versions. In AWS versions is an
+ * internal idiom that can is accessible, but it's a UUID + a tag <a href=
+ * "https://sdk.amazonaws.com/java/api/latest/software/amazon/awssdk/services/secretsmanager/SecretsManagerClient.html#listSecretVersionIds--">more
+ * details.</a>
+ */
+@Slf4j
+public class AWSSecretManagerPersistence implements SecretPersistence {
+
+  private final AWSSecretsManager client;
+
+  @VisibleForTesting
+  protected final SecretCache cache;
+
+  /**
+   * Creates a AWSSecretManagerPersistence using the defaults client and region from the current AWS
+   * credentials. This implementation makes use of SecretCache as optimization to access secrets
+   *
+   * @see SecretCache
+   */
+  public AWSSecretManagerPersistence() {
+    this.client = AWSSecretsManagerClientBuilder.defaultClient();
+    this.cache = new SecretCache(this.client);
+  }
+
+  /**
+   * Creates a AWSSecretManagerPersistence overriding the current region. This implementation makes
+   * use of SecretCache as optimization to access secrets
+   *
+   * @param region AWS region to use
+   * @see SecretCache
+   */
+  public AWSSecretManagerPersistence(final String region) {
+    this.client = AWSSecretsManagerClientBuilder
+        .standard()
+        .withRegion(region)
+        .build();
+    this.cache = new SecretCache(this.client);
+  }
+
+  @Override
+  public Optional<String> read(final SecretCoordinate coordinate) {
+    String secretString = null;
+    try {
+      log.debug("Reading secret {}", coordinate.getCoordinateBase());
+      secretString = cache.getSecretString(coordinate.getCoordinateBase());
+    } catch (ResourceNotFoundException e) {
+      log.warn("Secret {} not found", coordinate.getCoordinateBase());
+    }
+    return Optional.ofNullable(secretString);
+  }
+
+  @Override
+  public void write(final SecretCoordinate coordinate, final String payload) {
+    if (read(coordinate).isPresent()) {
+      log.debug("Secret {} found updating payload.", coordinate.getCoordinateBase());
+      final UpdateSecretRequest request = new UpdateSecretRequest()
+          .withSecretId(coordinate.getCoordinateBase())
+          .withSecretString(payload)
+          .withDescription("Airbyte secret.");
+      client.updateSecret(request);
+    } else {
+      log.debug("Secret {} not found, creating a new one.", coordinate.getCoordinateBase());
+      final CreateSecretRequest secretRequest = new CreateSecretRequest()
+          .withName(coordinate.getCoordinateBase())
+          .withSecretString(payload)
+          .withDescription("Airbyte secret.");
+      client.createSecret(secretRequest);
+    }
+
+  }
+
+  /**
+   * Utility to clean up after integration tests.
+   *
+   * @param coordinate SecretCoordinate to delete.
+   */
+  @VisibleForTesting
+  protected void deleteSecret(final SecretCoordinate coordinate) {
+    client.deleteSecret(new DeleteSecretRequest()
+        .withSecretId(coordinate.getCoordinateBase())
+        .withForceDeleteWithoutRecovery(true));
+  }
+
+}

--- a/airbyte-config/config-persistence/src/main/java/io/airbyte/config/persistence/split_secrets/AWSSecretManagerPersistence.java
+++ b/airbyte-config/config-persistence/src/main/java/io/airbyte/config/persistence/split_secrets/AWSSecretManagerPersistence.java
@@ -66,7 +66,8 @@ public class AWSSecretManagerPersistence implements SecretPersistence {
   @Override
   public Optional<String> read(final SecretCoordinate coordinate) {
     // fail fast, return an empty
-    if (coordinate == null) return Optional.empty();
+    if (coordinate == null)
+      return Optional.empty();
 
     String secretString = null;
     try {

--- a/airbyte-config/config-persistence/src/main/java/io/airbyte/config/persistence/split_secrets/AWSSecretManagerPersistence.java
+++ b/airbyte-config/config-persistence/src/main/java/io/airbyte/config/persistence/split_secrets/AWSSecretManagerPersistence.java
@@ -4,6 +4,9 @@
 
 package io.airbyte.config.persistence.split_secrets;
 
+import static com.google.common.base.Preconditions.checkArgument;
+import static com.google.common.base.Preconditions.checkNotNull;
+
 import com.amazonaws.secretsmanager.caching.SecretCache;
 import com.amazonaws.services.secretsmanager.AWSSecretsManager;
 import com.amazonaws.services.secretsmanager.AWSSecretsManagerClientBuilder;
@@ -51,6 +54,8 @@ public class AWSSecretManagerPersistence implements SecretPersistence {
    * @see SecretCache
    */
   public AWSSecretManagerPersistence(final String region) {
+    checkNotNull(region, "Region cannot be null, to use a default region call AWSSecretManagerPersistence.AWSSecretManagerPersistence()");
+    checkArgument(!region.isEmpty(), "Region can't be empty, to use a default region call AWSSecretManagerPersistence.AWSSecretManagerPersistence()");
     this.client = AWSSecretsManagerClientBuilder
         .standard()
         .withRegion(region)
@@ -60,6 +65,9 @@ public class AWSSecretManagerPersistence implements SecretPersistence {
 
   @Override
   public Optional<String> read(final SecretCoordinate coordinate) {
+    // fail fast, return an empty
+    if (coordinate == null) return Optional.empty();
+
     String secretString = null;
     try {
       log.debug("Reading secret {}", coordinate.getCoordinateBase());
@@ -72,6 +80,10 @@ public class AWSSecretManagerPersistence implements SecretPersistence {
 
   @Override
   public void write(final SecretCoordinate coordinate, final String payload) {
+    checkNotNull(coordinate, "SecretCoordinate cannot be null");
+    checkNotNull(payload, "Payload cannot be null");
+    checkArgument(!payload.isEmpty(), "Payload shouldn't be empty");
+
     if (read(coordinate).isPresent()) {
       log.debug("Secret {} found updating payload.", coordinate.getCoordinateBase());
       final UpdateSecretRequest request = new UpdateSecretRequest()

--- a/airbyte-config/config-persistence/src/main/java/io/airbyte/config/persistence/split_secrets/AWSSecretManagerPersistence.java
+++ b/airbyte-config/config-persistence/src/main/java/io/airbyte/config/persistence/split_secrets/AWSSecretManagerPersistence.java
@@ -39,7 +39,8 @@ public class AWSSecretManagerPersistence implements SecretPersistence {
 
   /**
    * Creates a AWSSecretManagerPersistence using the default client and region from the current AWS
-   * credentials. Recommended way based on <a href="https://docs.aws.amazon.com/sdk-for-java/v1/developer-guide/credentials.html">this</a>
+   * credentials. Recommended way based on
+   * <a href="https://docs.aws.amazon.com/sdk-for-java/v1/developer-guide/credentials.html">this</a>
    * This implementation makes use of SecretCache as optimization to access secrets.
    *
    * @see SecretCache
@@ -68,14 +69,18 @@ public class AWSSecretManagerPersistence implements SecretPersistence {
 
   /**
    * Creates a new AWSSecretManagerPersistence using the provided explicitly passed credentials.
+   *
    * @param awsAccessKey The AWS access key.
    * @param awsSecretAccessKey The AWS secret access key.
    */
   public AWSSecretManagerPersistence(final String awsAccessKey, final String awsSecretAccessKey) {
     checkNotNull(awsAccessKey, "awsAccessKey cannot be null, to use a default region call AWSSecretManagerPersistence.AWSSecretManagerPersistence()");
-    checkNotNull(awsSecretAccessKey, "awsSecretAccessKey cannot be null, to use a default region call AWSSecretManagerPersistence.AWSSecretManagerPersistence()");
-    checkArgument(!awsAccessKey.isEmpty(), "awsAccessKey cannot be empty, to use a default region call AWSSecretManagerPersistence.AWSSecretManagerPersistence()");
-    checkArgument(!awsSecretAccessKey.isEmpty(), "awsSecretAccessKey cannot be empty, to use a default region call AWSSecretManagerPersistence.AWSSecretManagerPersistence()");
+    checkNotNull(awsSecretAccessKey,
+        "awsSecretAccessKey cannot be null, to use a default region call AWSSecretManagerPersistence.AWSSecretManagerPersistence()");
+    checkArgument(!awsAccessKey.isEmpty(),
+        "awsAccessKey cannot be empty, to use a default region call AWSSecretManagerPersistence.AWSSecretManagerPersistence()");
+    checkArgument(!awsSecretAccessKey.isEmpty(),
+        "awsSecretAccessKey cannot be empty, to use a default region call AWSSecretManagerPersistence.AWSSecretManagerPersistence()");
     BasicAWSCredentials credentials = new BasicAWSCredentials(awsAccessKey, awsSecretAccessKey);
     this.client = AWSSecretsManagerClientBuilder
         .standard()

--- a/airbyte-config/config-persistence/src/main/java/io/airbyte/config/persistence/split_secrets/SecretPersistence.java
+++ b/airbyte-config/config-persistence/src/main/java/io/airbyte/config/persistence/split_secrets/SecretPersistence.java
@@ -34,6 +34,9 @@ public interface SecretPersistence extends ReadOnlySecretPersistence {
       case VAULT -> {
         return Optional.of(new VaultSecretPersistence(configs.getVaultAddress(), configs.getVaultPrefix(), configs.getVaultToken()));
       }
+      case AWS_SECRET_MANAGER -> {
+        return Optional.of(new AWSSecretManagerPersistence(configs.getAwsAccessKey(), configs.getAwsSecretAccessKey()));
+      }
       default -> {
         return Optional.empty();
       }
@@ -61,6 +64,9 @@ public interface SecretPersistence extends ReadOnlySecretPersistence {
       }
       case VAULT -> {
         return Optional.of(new VaultSecretPersistence(configs.getVaultAddress(), configs.getVaultPrefix(), configs.getVaultToken()));
+      }
+      case AWS_SECRET_MANAGER -> {
+        return Optional.of(new AWSSecretManagerPersistence(configs.getAwsAccessKey(), configs.getAwsSecretAccessKey()));
       }
       default -> {
         return Optional.empty();

--- a/airbyte-config/config-persistence/src/test-integration/java/io/airbyte/config/persistence/split_secrets/AWSSecretManagerPersistenceIntegrationTest.java
+++ b/airbyte-config/config-persistence/src/test-integration/java/io/airbyte/config/persistence/split_secrets/AWSSecretManagerPersistenceIntegrationTest.java
@@ -1,0 +1,58 @@
+/*
+ * Copyright (c) 2022 Airbyte, Inc., all rights reserved.
+ */
+
+package io.airbyte.config.persistence.split_secrets;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.util.Optional;
+import org.apache.commons.lang3.RandomUtils;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+public class AWSSecretManagerPersistenceIntegrationTest {
+
+  public String coordinate_base;
+  private AWSSecretManagerPersistence persistence;
+
+  @BeforeEach
+  void setup() {
+    persistence = new AWSSecretManagerPersistence();
+    coordinate_base = "aws/airbyte/secret/integration/" + RandomUtils.nextInt() % 20000;
+  }
+
+  @Test
+  void testReadWriteUpdate() throws InterruptedException {
+    SecretCoordinate secretCoordinate = new SecretCoordinate(coordinate_base, 1);
+
+    // try reading a non-existent secret
+    Optional<String> firstRead = persistence.read(secretCoordinate);
+    assertTrue(firstRead.isEmpty());
+
+    // write it
+    String payload = "foo-secret";
+    persistence.write(secretCoordinate, payload);
+    persistence.cache.refreshNow(secretCoordinate.getCoordinateBase());
+    Optional<String> read2 = persistence.read(secretCoordinate);
+    assertTrue(read2.isPresent());
+    assertEquals(payload, read2.get());
+
+    // update it
+    final var secondPayload = "bar-secret";
+    final var coordinate2 = new SecretCoordinate(coordinate_base, 2);
+    persistence.write(coordinate2, secondPayload);
+    persistence.cache.refreshNow(secretCoordinate.getCoordinateBase());
+    final var thirdRead = persistence.read(coordinate2);
+    assertTrue(thirdRead.isPresent());
+    assertEquals(secondPayload, thirdRead.get());
+  }
+
+  @AfterEach
+  void tearDown() {
+    persistence.deleteSecret(new SecretCoordinate(coordinate_base, 1));
+  }
+
+}

--- a/airbyte-config/config-persistence/src/test-integration/java/io/airbyte/config/persistence/split_secrets/AWSSecretManagerPersistenceIntegrationTest.java
+++ b/airbyte-config/config-persistence/src/test-integration/java/io/airbyte/config/persistence/split_secrets/AWSSecretManagerPersistenceIntegrationTest.java
@@ -21,7 +21,6 @@ public class AWSSecretManagerPersistenceIntegrationTest {
   private AWSSecretManagerPersistence persistence;
   private final Configs configs = new EnvConfigs();
 
-
   @BeforeEach
   void setup() {
     persistence = new AWSSecretManagerPersistence(configs.getAwsAccessKey(), configs.getAwsSecretAccessKey());

--- a/airbyte-config/config-persistence/src/test-integration/java/io/airbyte/config/persistence/split_secrets/AWSSecretManagerPersistenceIntegrationTest.java
+++ b/airbyte-config/config-persistence/src/test-integration/java/io/airbyte/config/persistence/split_secrets/AWSSecretManagerPersistenceIntegrationTest.java
@@ -7,6 +7,8 @@ package io.airbyte.config.persistence.split_secrets;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
+import io.airbyte.config.Configs;
+import io.airbyte.config.EnvConfigs;
 import java.util.Optional;
 import org.apache.commons.lang3.RandomUtils;
 import org.junit.jupiter.api.AfterEach;
@@ -17,10 +19,12 @@ public class AWSSecretManagerPersistenceIntegrationTest {
 
   public String coordinate_base;
   private AWSSecretManagerPersistence persistence;
+  private final Configs configs = new EnvConfigs();
+
 
   @BeforeEach
   void setup() {
-    persistence = new AWSSecretManagerPersistence();
+    persistence = new AWSSecretManagerPersistence(configs.getAwsAccessKey(), configs.getAwsSecretAccessKey());
     coordinate_base = "aws/airbyte/secret/integration/" + RandomUtils.nextInt() % 20000;
   }
 

--- a/deps.toml
+++ b/deps.toml
@@ -77,9 +77,9 @@ platform-testcontainers-jdbc = { module = "org.testcontainers:jdbc", version.ref
 platform-testcontainers-postgresql = { module = "org.testcontainers:postgresql", version.ref = "platform-testcontainers" }
 log4j-over-slf4j = { module = "org.slf4j:log4j-over-slf4j", version.ref = "slf4j" }
 appender-log4j2 = { module = "com.therealvan:appender-log4j2", version = "3.6.0" }
-aws-java-sdk-s3 = { module = "com.amazonaws:aws-java-sdk-s3", version = "1.12.6" }
+aws-java-sdk-s3 = { module = "com.amazonaws:aws-java-sdk-s3", version = "1.12.353" }
 google-cloud-storage = { module = "com.google.cloud:google-cloud-storage", version = "2.2.2" }
-s3 = { module = "software.amazon.awssdk:s3", version = "2.16.84" }
+s3 = { module = "software.amazon.awssdk:s3", version = "2.18.28" }
 lombok = { module = "org.projectlombok:lombok", version.ref = "lombok" }
 junit-jupiter-engine = { module = "org.junit.jupiter:junit-jupiter-engine", version.ref = "junit-jupiter" }
 junit-jupiter-api = { module = "org.junit.jupiter:junit-jupiter-api", version.ref = "junit-jupiter" }

--- a/deps.toml
+++ b/deps.toml
@@ -77,9 +77,9 @@ platform-testcontainers-jdbc = { module = "org.testcontainers:jdbc", version.ref
 platform-testcontainers-postgresql = { module = "org.testcontainers:postgresql", version.ref = "platform-testcontainers" }
 log4j-over-slf4j = { module = "org.slf4j:log4j-over-slf4j", version.ref = "slf4j" }
 appender-log4j2 = { module = "com.therealvan:appender-log4j2", version = "3.6.0" }
-aws-java-sdk-s3 = { module = "com.amazonaws:aws-java-sdk-s3", version = "1.12.353" }
+aws-java-sdk-s3 = { module = "com.amazonaws:aws-java-sdk-s3", version = "1.12.6" }
 google-cloud-storage = { module = "com.google.cloud:google-cloud-storage", version = "2.2.2" }
-s3 = { module = "software.amazon.awssdk:s3", version = "2.18.28" }
+s3 = { module = "software.amazon.awssdk:s3", version = "2.16.84" }
 lombok = { module = "org.projectlombok:lombok", version.ref = "lombok" }
 junit-jupiter-engine = { module = "org.junit.jupiter:junit-jupiter-engine", version.ref = "junit-jupiter" }
 junit-jupiter-api = { module = "org.junit.jupiter:junit-jupiter-api", version.ref = "junit-jupiter" }

--- a/docs/operator-guides/configuring-airbyte.md
+++ b/docs/operator-guides/configuring-airbyte.md
@@ -61,6 +61,8 @@ Set to empty values, e.g. "" to disable basic auth. **Be sure to change these va
 5. `VAULT_AUTH_TOKEN` - The token used for vault authentication. Alpha Support.
 6. `VAULT_AUTH_METHOD` - How vault will preform authentication. Currently, only supports Token auth. Defaults to token. Alpha Support.
 7. `SECRET_PERSISTENCE` - Defines the Secret Persistence type. Defaults to NONE. Set to GOOGLE_SECRET_MANAGER to use Google Secret Manager. Set to TESTING_CONFIG_DB_TABLE to use the database as a test. Set to VAULT to use Hashicorp Vault, currently only the token based authentication is supported. Alpha support. Undefined behavior will result if this is turned on and then off.
+8. `AWS_ACCESS_KEY` - Defines the aws_access_key_id from the AWS credentials to use for AWS Secret Manager.
+9. `AWS_SECRET_ACCESS_KEY`- Defines aws_secret_access_key to use for the AWS Secret Manager.
 
 #### Database
 


### PR DESCRIPTION
## What
Initial implementation for AWS Secret Manager for [issue](https://github.com/airbytehq/airbyte/issues/10518)
https://github.com/airbytehq/airbyte/issues/10518

Added new implementation `AWSSecretManagerPersistence` and integration tests `AWSSecretManagerPersistenceIntegrationTest`

## How
A new implementation of `SecretPersistence` to support AWS Secret Manager `AWSSecretManagerPersistence` 
New Integration tests as suggested on the open Issue, similar to GCP secret manager

![image](https://user-images.githubusercontent.com/558874/203184092-d96d7ac3-92e0-4310-8ac8-1f96122dccd2.png)


## 🚨 User Impact 🚨
No breaking changes, you need a new set of AWS credentials and AWS cli installed in order to run integration test.

Also note that the credentials need the following
- "secretsmanager:GetResourcePolicy",
- "secretsmanager:GetSecretValue",
- "secretsmanager:DescribeSecret",
- "secretsmanager:ListSecretVersionIds"
- "secretsmanager:DeleteSecret"

## Pre-merge Checklist
Expand the relevant checklist and delete the others.

<details><summary><strong>New Feature Implemenation</strong></summary>

### Community member or Airbyter

- [x] **Community member?** Grant edit access to maintainers ([instructions](https://docs.github.com/en/github/collaborating-with-pull-requests/working-with-forks/allowing-changes-to-a-pull-request-branch-created-from-a-fork#enabling-repository-maintainer-permissions-on-existing-pull-requests))
- [x] Unit & integration tests added and passing. Community members, please provide proof of success locally e.g: screenshot or copy-paste unit, integration, and acceptance test output. To run acceptance tests for a Python connector, follow instructions in the README. For java connectors run `./gradlew :airbyte-integrations:connectors:<name>:integrationTest`.
- [ ] Code reviews completed
- [ ] Documentation updated
- [ ] PR name follows [PR naming conventions](https://docs.airbyte.com/contributing-to-airbyte/issues-and-pull-requests)



## Tests

<details><summary><strong>Unit</strong></summary>

*Building Airbyte Sub Build: PLATFORM
Type-safe dependency accessors is an incubating feature.

> Configure project :
configuring docker task for airbyte-bootloader
configuring docker task for airbyte-connector-builder-server
configuring docker task for airbyte-container-orchestrator
configuring docker task for airbyte-cron
configuring docker task for airbyte-proxy
configuring docker task for airbyte-server
configuring docker task for airbyte-temporal
configuring docker task for airbyte-webapp
configuring docker task for airbyte-workers
configuring docker task for init
configuring docker task for db-lib
configuring docker task for reporter

Deprecated Gradle features were used in this build, making it incompatible with Gradle 8.0.

You can use '--warning-mode all' to show the individual deprecation warnings and determine if they come from your own scripts or plugins.

See https://docs.gradle.org/7.4/userguide/command_line_interface.html#sec:command_line_warnings

BUILD SUCCESSFUL in 1s
13 actionable tasks: 13 up-to-date
*

</details>

<details><summary><strong>Integration</strong></summary>


*Gist with results [here](https://gist.github.com/mauricioalarcon/5af2b4be7959697db52728bb8bc30b92)*

</details>

<details><summary><strong>Acceptance</strong></summary>

*Gist with results [here](https://gist.github.com/mauricioalarcon/50424bf3acffcacf2c9a811742a42fc9)*

</details>
