### PR TITLE
test new AMI

### DIFF
--- a/.github/actions/start-aws-runner/action.yml
+++ b/.github/actions/start-aws-runner/action.yml
@@ -8,7 +8,7 @@ inputs:
   github-token:
     required: true
   ec2-image-id:
-    # github-self-hosted-runner-ubuntu-20-100g-disk-with-cypress-deps
+    # https://internal-docs.airbyte.io/Things-To-Know/Build-Runner-Images#ami-05b3422b3649a6911
     default: "ami-05b3422b3649a6911"
     required: true
   ec2-instance-type:

--- a/.github/actions/start-aws-runner/action.yml
+++ b/.github/actions/start-aws-runner/action.yml
@@ -9,7 +9,7 @@ inputs:
     required: true
   ec2-image-id:
     # github-self-hosted-runner-ubuntu-20-100g-disk-with-cypress-deps
-    default: "ami-005924fb76f7477ce"
+    default: "ami-05b3422b3649a6911"
     required: true
   ec2-instance-type:
     default: "c5.2xlarge"

--- a/.github/workflows/test-command.yml
+++ b/.github/workflows/test-command.yml
@@ -61,8 +61,6 @@ jobs:
           aws-access-key-id: ${{ secrets.SELF_RUNNER_AWS_ACCESS_KEY_ID }}
           aws-secret-access-key: ${{ secrets.SELF_RUNNER_AWS_SECRET_ACCESS_KEY }}
           github-token: ${{ needs.find_valid_pat.outputs.pat }}
-          # 80 gb disk
-          ec2-image-id: ami-06cf12549e3d9c522
   integration-test:
     timeout-minutes: 240
     needs: start-test-runner


### PR DESCRIPTION
Use new github runner AMI that is fully documented here: https://github.com/airbytehq/airbyte-cloud/pull/3445

closes https://github.com/airbytehq/airbyte/issues/16265