### PR TITLE
fix: add extraEnv block

### DIFF
--- a/charts/airbyte-cron/templates/deployment.yaml
+++ b/charts/airbyte-cron/templates/deployment.yaml
@@ -116,6 +116,11 @@ spec:
           {{- end }}
           {{- end }}
 
+          # Values from extraEnv for more compability(if you want to use external secret source or other stuff)
+          {{- if .Values.extraEnv }}
+          {{- toYaml .Values.extraEnv | nindent 8 }}
+          {{- end }}
+
           {{- if .Values.containerSecurityContext }}
           securityContext: {{- toYaml .Values.containerSecurityContext | nindent 12 }}
           {{- end }}

--- a/charts/airbyte-cron/templates/deployment.yaml
+++ b/charts/airbyte-cron/templates/deployment.yaml
@@ -118,7 +118,7 @@ spec:
 
           # Values from extraEnv for more compability(if you want to use external secret source or other stuff)
           {{- if .Values.extraEnv }}
-          {{- toYaml .Values.extraEnv | nindent 8 }}
+          {{- toYaml .Values.extraEnv | nindent 10 }}
           {{- end }}
 
           {{- if .Values.containerSecurityContext }}


### PR DESCRIPTION
## What
* Add extraEnv block back to the chart so users can specify custom env variables in full definition notation