### PR TITLE
Update date-time format instructions in docs

### DIFF
--- a/docs/integrations/sources/chargebee.md
+++ b/docs/integrations/sources/chargebee.md
@@ -13,7 +13,7 @@ To set up the Chargebee source connector, you'll need the [Chargebee API key](ht
 3. On the Set up the source page, select **Chargebee** from the Source type dropdown.
 4. Enter the name for the Chargebee connector.
 5. For **Site**, enter the site prefix for your Chargebee instance.
-6. For **Start Date**, enter the date in YYYY-MM-DD format. The data added on and after this date will be replicated.
+6. For **Start Date**, enter the date in YYYY-MM-DDTHH:mm:ssZ format. The data added on and after this date will be replicated.
 7. For **API Key**, enter the [Chargebee API key](https://apidocs.chargebee.com/docs/api?prod_cat_ver=2#api_authentication).
 8. For **Product Catalog**, enter the Chargebee [Product Catalog version](https://apidocs.chargebee.com/docs/api?prod_cat_ver=2).
 9. Click **Set up source**.

--- a/docs/integrations/sources/facebook-marketing.md
+++ b/docs/integrations/sources/facebook-marketing.md
@@ -21,13 +21,13 @@ To set up Facebook Marketing as a source in Airbyte Cloud:
 3. On the Set up the source page, select **Facebook Marketing** from the **Source type** dropdown.
 4. For Name, enter a name for the Facebook Marketing connector.
 5. Click **Authenticate your account** to authorize your [Meta for Developers](https://developers.facebook.com/) account. Airbyte will authenticate the account you are already logged in to. Make sure you are logged into the right account.
-6. For **Start Date**, enter the date in the YYYY-MM-DDTHR:MIN:S format. The data added on and after this date will be replicated. If this field is blank, Airbyte will replicate all data.
+6. For **Start Date**, enter the date in the `YYYY-MM-DDTHH:mm:ssZ` format. The data added on and after this date will be replicated. If this field is blank, Airbyte will replicate all data.
 
     :::warning
     Insight tables are only able to pull data from 37 months. If you are syncing insight tables and your start date is older than 37 months, your sync will fail.
     :::
 
-7. For **End Date**, enter the date in the YYYY-MM-DDTHR:MIN:S format. The data added on and before this date will be replicated. If this field is blank, Airbyte will replicate the latest data.
+7. For **End Date**, enter the date in the `YYYY-MM-DDTHH:mm:ssZ` format. The data added on and before this date will be replicated. If this field is blank, Airbyte will replicate the latest data.
 8. For Account ID, enter your [Facebook Ad Account ID Number](https://www.facebook.com/business/help/1492627900875762).
 9. (Optional) Toggle the **Include Deleted** button to include data from deleted Campaigns, Ads, and AdSets.
 
@@ -45,9 +45,9 @@ To set up Facebook Marketing as a source in Airbyte Cloud:
 
     1. For **Name**, enter a name for the insight. This will be used as the Airbyte stream name
     2. For **Fields**, enter a list of the fields you want to pull from the Facebook Marketing API.
-    3. For **End Date**, enter the date in the YYYY-MM-DDTHR:MIN:S format. The data added on and before this date will be replicated. If this field is blank, Airbyte will replicate the latest data.
+    3. For **End Date**, enter the date in the `YYYY-MM-DDTHH:mm:ssZ` format. The data added on and before this date will be replicated. If this field is blank, Airbyte will replicate the latest data.
     4. For **Breakdowns**, enter a list of the breakdowns you want to configure.
-    5. For **Start Date**, enter the date in the YYYY-MM-DDTHR:MIN:S format. The data added on and after this date will be replicated. If this field is blank, Airbyte will replicate all data.
+    5. For **Start Date**, enter the date in the `YYYY-MM-DDTHH:mm:ssZ` format. The data added on and after this date will be replicated. If this field is blank, Airbyte will replicate all data.
     6. For **Time Increment**, enter the number of days over which you want to aggregate statistics.
 
             For example, if you set this value to 7, Airbyte will report statistics as 7-day aggregates starting from the Start Date. Suppose the start and end dates are October 1st and October 30th, then the connector will output 5 records: 01 - 06, 07 - 13, 14 - 20, 21 - 27, and 28 - 30 (3 days only).  

--- a/docs/integrations/sources/freshdesk.md
+++ b/docs/integrations/sources/freshdesk.md
@@ -14,7 +14,7 @@ To set up the Freshdesk source connector, you'll need the Freshdesk [domain URL]
 4. Enter the name for the Freshdesk connector.
 5. For **Domain**, enter your [Freshdesk domain URL](https://support.freshdesk.com/en/support/solutions/articles/50000004704-customizing-your-helpdesk-url).
 6. For **API Key**, enter your [Freshdesk API key](https://support.freshdesk.com/support/solutions/articles/215517).
-7. For **Start Date**, enter the date in YYYY-MM-DD format. The data added on and after this date will be replicated.
+7. For **Start Date**, enter the date in YYYY-MM-DDTHH:mm:ssZ format. The data added on and after this date will be replicated.
 8. For **Requests per minute**, enter the number of requests per minute that this source allowed to use. The Freshdesk rate limit is 50 requests per minute per app per account.
 9. Click **Set up source**.
 

--- a/docs/integrations/sources/harvest.md
+++ b/docs/integrations/sources/harvest.md
@@ -16,7 +16,7 @@ To set up the Harvest source connector, you'll need the [Harvest Account ID and 
 3. On the Set up the source page, select **Harvest** from the Source type dropdown.
 4. Enter the name for the Harvest connector.
 5. Enter your [Harvest Account ID](https://help.getharvest.com/api-v2/authentication-api/authentication/authentication/).
-6. For **Start Date**, enter the date in YYYY-MM-DD format. The data added on and after this date will be replicated.
+6. For **Start Date**, enter the date in YYYY-MM-DDTHH:mm:ssZ format. The data added on and after this date will be replicated.
 7. For Authentication mechanism, select **Authenticate via Harvest (OAuth)** from the dropdown and click **Authenticate your Harvest account**. Log in and authorize your Harvest account.
 8. Click **Set up source**.
 <!-- /env:cloud -->
@@ -29,7 +29,7 @@ To set up the Harvest source connector, you'll need the [Harvest Account ID and 
 3. On the Set up the source page, select **Harvest** from the Source type dropdown.
 4. Enter the name for the Harvest connector.
 5. Enter your [Harvest Account ID](https://help.getharvest.com/api-v2/authentication-api/authentication/authentication/).
-6. For **Start Date**, enter the date in YYYY-MM-DD format. The data added on and after this date will be replicated.
+6. For **Start Date**, enter the date in YYYY-MM-DDTHH:mm:ssZ format. The data added on and after this date will be replicated.
 7. For **Authentication mechanism**, select **Authenticate with Personal Access Token** from the dropdown. Enter your [Personal Access Token](https://help.getharvest.com/api-v2/authentication-api/authentication/authentication/#personal-access-tokens).
 8. Click **Set up source**.
 <!-- /env:oss -->

--- a/docs/integrations/sources/instagram.md
+++ b/docs/integrations/sources/instagram.md
@@ -31,7 +31,7 @@ Generate access tokens with the following permissions:
 4. Enter a name for your source.
 5. Click **Authenticate your Instagram account**.
 6. Log in and authorize the Instagram account.
-7. Enter the **Start Date** in YYYY-MM-DDT00:00:00Z format. All data generated after this date will be replicated. If this field is blank, Airbyte will replicate all data.
+7. Enter the **Start Date** in YYYY-MM-DDTHH:mm:ssZ format. All data generated after this date will be replicated. If this field is blank, Airbyte will replicate all data.
 8. Click **Set up source**.
 <!-- /env:cloud -->
 
@@ -44,7 +44,7 @@ Generate access tokens with the following permissions:
 4. Enter a name for your source.
 5. Click **Authenticate your Instagram account**.
 6. Log in and authorize the Instagram account.
-7. Enter the **Start Date** in YYYY-MM-DDT00:00:00Z format. All data generated after this date will be replicated. If this field is blank, Airbyte will replicate all data.
+7. Enter the **Start Date** in YYYY-MM-DDTHH:mm:ssZ format. All data generated after this date will be replicated. If this field is blank, Airbyte will replicate all data.
 8. Paste the access tokens from [Step 1](#step-1-set-up-instagram​).
 9. Click **Set up source**.
 <!-- /env:oss -->

--- a/docs/integrations/sources/iterable.md
+++ b/docs/integrations/sources/iterable.md
@@ -13,7 +13,7 @@ To set up the Iterable source connector, you'll need the Iterable [`Server-side`
 3. On the Set up the source page, select **Iterable** from the Source type dropdown.
 4. Enter the name for the Iterable connector.
 5. For **API Key**, enter the [Iterable API key](https://support.iterable.com/hc/en-us/articles/360043464871-API-Keys-).
-6. For **Start Date**, enter the date in YYYY-MM-DD format. The data added on and after this date will be replicated.
+6. For **Start Date**, enter the date in YYYY-MM-DDTHH:mm:ssZ format. The data added on and after this date will be replicated.
 7. Click **Set up source**.
 
 ## Supported sync modes

--- a/docs/integrations/sources/notion.md
+++ b/docs/integrations/sources/notion.md
@@ -35,7 +35,7 @@ You must be the owner of a Notion workspace to create a new integration.
       * If you select **Access Token**, paste the access token from [Step 8](#step-1-set-up-notion​).
       * If you select **OAuth2.0** authorization, click **Authenticate your Notion account**.
           * Log in and Authorize the Notion account. Select the permissions you want to allow Airbyte.
-6. Enter the **Start Date** in YYYY-MM-DDT00:00:00Z format. All data generated after this date will be replicated. If this field is blank, Airbyte will replicate all data.
+6. Enter the **Start Date** in YYYY-MM-DDTHH:mm:ssZ format. All data generated after this date will be replicated. If this field is blank, Airbyte will replicate all data.
 7. Click **Set up source**.
 <!-- /env:cloud -->
 
@@ -49,7 +49,7 @@ You must be the owner of a Notion workspace to create a new integration.
 5. Choose the method of authentication:
       * If you select **Access Token**, paste the access token from [Step 8](#step-1-set-up-notion​).
       * If you select **OAuth2.0** authorization, paste the client ID, access token, and client secret from [Step 8](#step-1-set-up-notion​).
-6. Enter the **Start Date** in YYYY-MM-DDT00:00:00Z format. All data generated after this date will be replicated. If this field is blank, Airbyte will replicate all data.
+6. Enter the **Start Date** in YYYY-MM-DDTHH:mm:ssZ format. All data generated after this date will be replicated. If this field is blank, Airbyte will replicate all data.
 7. Click **Set up source**.
 <!-- /env:oss -->
 

--- a/docs/integrations/sources/stripe.md
+++ b/docs/integrations/sources/stripe.md
@@ -22,7 +22,7 @@ This page guides you through the process of setting up the Stripe source connect
 
    We recommend creating a secret key specifically for Airbyte to control which resources Airbyte can access. For ease of use, we recommend granting read permission to all resources and configuring which resource to replicate in the Airbyte UI. You can also use the API keys for the [test mode](https://stripe.com/docs/keys#obtain-api-keys) to try out the Stripe integration with Airbyte.
 
-7. For **Replication start date**, enter the date in YYYY-MM-DDTHH:mm:ssZ format. The data added on and after this date will be replicated. If this field is blank, Airbyte will replicate all data.
+7. For **Replication start date**, enter the date in `YYYY-MM-DDTHH:mm:ssZ` format. The data added on and after this date will be replicated. If this field is blank, Airbyte will replicate all data.
 8. For **Lookback Window in days (Optional)**, select the number of days the value in days prior to the start date that you to sync your data with. If your data is updated after setting up this connector, you can use the this option to reload data from the past N days. Example: If the Replication start date is set to `2021-01-01T00:00:00Z`, then:
    - If you leave the Lookback Window in days parameter to its the default value of 0, Airbyte will sync data from the Replication start date `2021-01-01T00:00:00Z`
    - If the Lookback Window in days value is set to 1, Airbyte will consider the Replication start date to be `2020-12-31T00:00:00Z`

--- a/docs/integrations/sources/wrike.md
+++ b/docs/integrations/sources/wrike.md
@@ -17,7 +17,7 @@ This page guides you through the process of setting up the Wrike source connecto
     Permissions granted to the permanent token are equal to the permissions of the user who generates the token.
 
 6. For **Wrike Instance (hostname)**, add the hostname of the Wrike instance you are currently using. This could be `www.wrike.com`, `app-us2.wrike.com`, or anything similar.
-7. For **Start date for comments**, enter the date in YYYY-MM-DDTHH:mm:ssZ format. The comments added on and after this date will be replicated. If this field is blank, Airbyte will replicate comments from the last seven days.
+7. For **Start date for comments**, enter the date in `YYYY-MM-DDTHH:mm:ssZ` format. The comments added on and after this date will be replicated. If this field is blank, Airbyte will replicate comments from the last seven days.
 8. Click **Set up source**.
 
 ## Supported sync modes

--- a/docs/integrations/sources/xero.md
+++ b/docs/integrations/sources/xero.md
@@ -45,7 +45,7 @@ As Xero uses .NET, some date fields in records could be in [.NET JSON date forma
 6. For **Tenant ID** field, enter your Xero Organisation's [Tenant ID](https://developer.xero.com/documentation/guides/oauth2/auth-flow/#xero-tenants)
 7. For **Scopes** field enter scopes you used for user's authorization on "Configuration" screen of your Xero App
 8. Choose **Custom Connections Authentication** as **Authentication** option
-9. For **Start date** enter UTC date and time in the format YYYY-MM-DDTHH:mm:ssZ as the start date and time of ingestion.
+9. For **Start date** enter UTC date and time in the format `YYYY-MM-DDTHH:mm:ssZ` as the start date and time of ingestion.
 10. Click **Set up source**.
 
 ## Supported sync modes

--- a/docs/integrations/sources/zendesk-chat.md
+++ b/docs/integrations/sources/zendesk-chat.md
@@ -19,7 +19,7 @@ This page contains the setup guide and reference information for the Zendesk Cha
 3. On the Set up the source page, select **Zendesk Chat** from the Source type dropdown.
 4. Enter the name for the Zendesk Chat connector.
 5. If you access Zendesk Chat from a [Zendesk subdomain](https://support.zendesk.com/hc/en-us/articles/4409381383578-Where-can-I-find-my-Zendesk-subdomain-), enter the **Subdomain**.
-6. For **Start Date**, enter the date in YYYY-MM-DD format. The data added on and after this date will be replicated.
+6. For **Start Date**, enter the date in `YYYY-MM-DDTHH:mm:ssZ` format. The data added on and after this date will be replicated.
 7. Click **Authenticate your Zendesk Chat account**. Log in and authorize your Zendesk Chat account.
 8. Click **Set up source**.
 <!-- /env:cloud -->
@@ -32,7 +32,7 @@ This page contains the setup guide and reference information for the Zendesk Cha
 3. On the Set up the source page, select **Zendesk Chat** from the Source type dropdown.
 4. Enter the name for the Zendesk Chat connector.
 5. If you access Zendesk Chat from a [Zendesk subdomain](https://support.zendesk.com/hc/en-us/articles/4409381383578-Where-can-I-find-my-Zendesk-subdomain-), enter the **Subdomain**.
-6. For **Start Date**, enter the date in YYYY-MM-DD format. The data added on and after this date will be replicated.
+6. For **Start Date**, enter the date in `YYYY-MM-DDTHH:mm:ssZ` format. The data added on and after this date will be replicated.
 7. For Authorization Method, select **Access Token** from the dropdown and enter your Zendesk [access token](https://developer.zendesk.com/rest_api/docs/chat/auth).
 8. Click **Set up source**.
 <!-- /env:oss -->

--- a/docs/integrations/sources/zendesk-support.md
+++ b/docs/integrations/sources/zendesk-support.md
@@ -14,7 +14,7 @@ This page guides you through setting up the Zendesk Support source connector.
 3. On the Set up the source page, select **Zendesk Support** from the Source type dropdown.
 4. Enter a name for your source.
 5. For **Subdomain**, enter your [Zendesk subdomain](#prerequisites).
-6. For **Start date**, enter the date in YYYY-MM-DDTHH:mm:ssZ format. The data added on and after this date will be replicated. If this field is blank, Airbyte will replicate all data.
+6. For **Start date**, enter the date in `YYYY-MM-DDTHH:mm:ssZ` format. The data added on and after this date will be replicated. If this field is blank, Airbyte will replicate all data.
 7. You can use OAuth or an API key to authenticate your Zendesk Support account. We recommend using OAuth for Airbyte Cloud and an API key for Airbyte Open Source.
     - To authenticate using OAuth for Airbyte Cloud, click **Authenticate your Zendesk Support account** to sign in with Zendesk Support and authorize your account. 
     - To authenticate using an API key for Airbyte Open Source, select **API key** from the Authentication dropdown and enter your [API key](#prerequisites). Enter the **Email** associated with your Zendesk Support account.   


### PR DESCRIPTION
## What
While working on the datepicker component, I noticed several setup guides instruct users to input `YYYY-MM-DD`, but the actual connector form requires a full UTC datetime (`YYYY-MM-DDTHH:mm:ssZ`).

Example screenshots to illustrate:

<details>
<summary>source-freshdesk</summary>

![Screenshot 2022-11-22 at 12 50 12 PM](https://user-images.githubusercontent.com/7550957/203307013-e55486c6-69b2-4a4c-964e-fc88630bf1e7.png)

</details>

<details>
<summary>source-chargebee</summary>

![Screenshot 2022-11-22 at 2 26 12 PM](https://user-images.githubusercontent.com/7550957/203325507-a4755919-b401-4cda-a268-d3abfd17dc66.png)

</details>

<details>
<summary>source-harvest</summary>

![Screenshot 2022-11-22 at 2 36 52 PM](https://user-images.githubusercontent.com/7550957/203329280-67da066c-78f6-47df-9024-f7a6b457936a.png)


</details>

<details>
<summary>source-iterable</summary>

![Screenshot 2022-11-22 at 2 42 22 PM](https://user-images.githubusercontent.com/7550957/203329187-06e62d57-6646-4c4f-85c9-28daed8ac9f8.png)

</details>

<details>
<summary>source-klaviyo</summary>

![Screenshot 2022-11-22 at 2 45 23 PM](https://user-images.githubusercontent.com/7550957/203329626-aaf498b8-8e0d-4684-aafd-d6727580b223.png)

</details>

I also noticed that, for some reason, when "YYYY-MM-DDTHH:mm:ssZ" is written in a markdown ordered or unordered list, the end (":ssZ") is cut off. It seems to get interpreted as a line break:

![image](https://user-images.githubusercontent.com/7550957/203330722-4480a8a1-78e5-4f47-8085-d5c6b1d56eb1.png)

Adding backticks around the expression fixes that:

![image](https://user-images.githubusercontent.com/7550957/203330907-80b132a8-f50a-49d4-80e7-63dd866456b1.png)

