### PR TITLE
deprecate config repository use in web backend

### DIFF
--- a/airbyte-server/src/main/java/io/airbyte/server/handlers/WebBackendConnectionsHandler.java
+++ b/airbyte-server/src/main/java/io/airbyte/server/handlers/WebBackendConnectionsHandler.java
@@ -68,6 +68,11 @@ import java.util.stream.Collectors;
 import lombok.AllArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 
+/**
+ * The web backend is an abstraction that allows the frontend to structure data in such a way that
+ * it is easier for a react frontend to consume. It should NOT have direct access to the database.
+ * It should operate exclusively by calling other endpoints that are exposed in the API.
+ */
 @AllArgsConstructor
 @Slf4j
 public class WebBackendConnectionsHandler {


### PR DESCRIPTION
## What
* it was a mistake that `ConfigRepository` was ever added to the web backend. 
* it is now now not easy to remove, but we need to more clearly signal to people that they should not use it for new cases (which keeps happening).
* add java doc explaining the purpose of the webbackend.

## How
* rename the field to make it clear that it shouldn't be used.
* deprecate the field