### PR TITLE
Typo Fix: Use value for `notify` workflow instead of `sync` workflow to determine if notify workflow should run

### DIFF
--- a/airbyte-workers/src/main/java/io/airbyte/workers/ApplicationInitializer.java
+++ b/airbyte-workers/src/main/java/io/airbyte/workers/ApplicationInitializer.java
@@ -115,7 +115,7 @@ public class ApplicationInitializer implements ApplicationEventListener<ServiceR
   private boolean shouldRunGetSpecWorkflows;
   @Value("${airbyte.worker.sync.enabled}")
   private boolean shouldRunSyncWorkflows;
-  @Value("${airbyte.worker.sync.enabled}")
+  @Value("${airbyte.worker.notify.enabled}")
   private boolean shouldRunNotifyWorkflows;
 
   @Inject


### PR DESCRIPTION
## What
Confirmed with Anne that this was just a typo, easy fix!
