### PR TITLE
Add schemaChange attrs to patch handler

### DIFF
--- a/airbyte-config/config-persistence/src/main/java/io/airbyte/config/persistence/StandardSyncPersistence.java
+++ b/airbyte-config/config-persistence/src/main/java/io/airbyte/config/persistence/StandardSyncPersistence.java
@@ -195,6 +195,7 @@ public class StandardSyncPersistence {
           .set(CONNECTION.BREAKING_CHANGE, standardSync.getBreakingChange())
           .set(CONNECTION.GEOGRAPHY, Enums.toEnum(standardSync.getGeography().value(),
               io.airbyte.db.instance.configs.jooq.generated.enums.GeographyType.class).orElseThrow())
+          .set(CONNECTION.NON_BREAKING_CHANGE_PREFERENCE, standardSync.getNonBreakingChangesPreference().value())
           .where(CONNECTION.ID.eq(standardSync.getConnectionId()))
           .execute();
 

--- a/airbyte-config/config-persistence/src/main/java/io/airbyte/config/persistence/StandardSyncPersistence.java
+++ b/airbyte-config/config-persistence/src/main/java/io/airbyte/config/persistence/StandardSyncPersistence.java
@@ -196,6 +196,7 @@ public class StandardSyncPersistence {
           .set(CONNECTION.GEOGRAPHY, Enums.toEnum(standardSync.getGeography().value(),
               io.airbyte.db.instance.configs.jooq.generated.enums.GeographyType.class).orElseThrow())
           .set(CONNECTION.NON_BREAKING_CHANGE_PREFERENCE, standardSync.getNonBreakingChangesPreference().value())
+          .set(CONNECTION.NOTIFY_SCHEMA_CHANGES, standardSync.getNotifySchemaChanges())
           .where(CONNECTION.ID.eq(standardSync.getConnectionId()))
           .execute();
 

--- a/airbyte-server/src/main/java/io/airbyte/server/converters/ApiPojoConverters.java
+++ b/airbyte-server/src/main/java/io/airbyte/server/converters/ApiPojoConverters.java
@@ -133,6 +133,10 @@ public class ApiPojoConverters {
     return Enums.convertTo(apiStatus, StandardSync.Status.class);
   }
 
+  public static StandardSync.NonBreakingChangesPreference toPersistenceNonBreakingChangesPreference(final NonBreakingChangesPreference preference) {
+    return Enums.convertTo(preference, StandardSync.NonBreakingChangesPreference.class);
+  }
+
   public static Geography toApiGeography(final io.airbyte.config.Geography geography) {
     return Enums.convertTo(geography, Geography.class);
   }

--- a/airbyte-server/src/main/java/io/airbyte/server/handlers/ConnectionsHandler.java
+++ b/airbyte-server/src/main/java/io/airbyte/server/handlers/ConnectionsHandler.java
@@ -352,6 +352,14 @@ public class ConnectionsHandler {
     if (patch.getBreakingChange() != null) {
       sync.setBreakingChange(patch.getBreakingChange());
     }
+
+    if(patch.getNotifySchemaChanges() != null) {
+      sync.setNotifySchemaChanges(patch.getNotifySchemaChanges());
+    }
+
+    if(patch.getNonBreakingChangesPreference() != null) {
+      sync.setNonBreakingChangesPreference(ApiPojoConverters.toPersistenceNonBreakingChangesPreference(patch.getNonBreakingChangesPreference()));
+    }
   }
 
   private void validateConnectionPatch(final WorkspaceHelper workspaceHelper, final StandardSync persistedSync, final ConnectionUpdate patch) {

--- a/airbyte-server/src/main/java/io/airbyte/server/handlers/ConnectionsHandler.java
+++ b/airbyte-server/src/main/java/io/airbyte/server/handlers/ConnectionsHandler.java
@@ -353,11 +353,11 @@ public class ConnectionsHandler {
       sync.setBreakingChange(patch.getBreakingChange());
     }
 
-    if(patch.getNotifySchemaChanges() != null) {
+    if (patch.getNotifySchemaChanges() != null) {
       sync.setNotifySchemaChanges(patch.getNotifySchemaChanges());
     }
 
-    if(patch.getNonBreakingChangesPreference() != null) {
+    if (patch.getNonBreakingChangesPreference() != null) {
       sync.setNonBreakingChangesPreference(ApiPojoConverters.toPersistenceNonBreakingChangesPreference(patch.getNonBreakingChangesPreference()));
     }
   }

--- a/airbyte-server/src/test/java/io/airbyte/server/handlers/WebBackendConnectionsHandlerTest.java
+++ b/airbyte-server/src/test/java/io/airbyte/server/handlers/WebBackendConnectionsHandlerTest.java
@@ -43,6 +43,7 @@ import io.airbyte.api.model.generated.JobRead;
 import io.airbyte.api.model.generated.JobStatus;
 import io.airbyte.api.model.generated.JobWithAttemptsRead;
 import io.airbyte.api.model.generated.NamespaceDefinitionType;
+import io.airbyte.api.model.generated.NonBreakingChangesPreference;
 import io.airbyte.api.model.generated.OperationRead;
 import io.airbyte.api.model.generated.OperationReadList;
 import io.airbyte.api.model.generated.OperationUpdate;
@@ -539,7 +540,9 @@ class WebBackendConnectionsHandlerTest {
         .schedule(schedule)
         .name(standardSync.getName())
         .syncCatalog(catalog)
-        .geography(Geography.US);
+        .geography(Geography.US)
+        .nonBreakingChangesPreference(NonBreakingChangesPreference.DISABLE)
+        .notifySchemaChanges(false);
 
     final List<UUID> operationIds = List.of(newOperationId);
 
@@ -553,7 +556,9 @@ class WebBackendConnectionsHandlerTest {
         .schedule(schedule)
         .name(standardSync.getName())
         .syncCatalog(catalog)
-        .geography(Geography.US);
+        .geography(Geography.US)
+        .nonBreakingChangesPreference(NonBreakingChangesPreference.DISABLE)
+        .notifySchemaChanges(false);
 
     final ConnectionUpdate actual = WebBackendConnectionsHandler.toConnectionPatch(input, operationIds);
 


### PR DESCRIPTION
nonBreakingSchemaChangePreference and notifySchemaChanges need to be added to the patch handler in WebBackendConnectionHandler so they are properly added to the StandardSync object