### PR TITLE
:window: :wrench: Handle LD feature flags besides `featureService.overwrites`

### DIFF
--- a/airbyte-webapp/src/packages/cloud/services/thirdParty/launchdarkly/LDExperimentService.tsx
+++ b/airbyte-webapp/src/packages/cloud/services/thirdParty/launchdarkly/LDExperimentService.tsx
@@ -33,14 +33,14 @@ import { rejectAfter } from "utils/promises";
  * states LaunchDarkly can provide for a user/feature pair:
  * |--------------------------+-----------------------------------------------|
  * | `{}`                     | use the application's default feature setting |
- * | `{ "overwrite": true }`  | enable the feature                            |
- * | `{ "overwrite": false }` | disable the feature                           |
+ * | `{ "enabled": true }`    | enable the feature                            |
+ * | `{ "enabled": false }`   | disable the feature                           |
  * |--------------------------+-----------------------------------------------|
  */
 const FEATURE_FLAG_PREFIX = "featureService";
 type LDFeatureName = `${typeof FEATURE_FLAG_PREFIX}.${FeatureItem}`;
 interface LDFeatureToggle {
-  overwrite?: boolean;
+  enabled?: boolean;
 }
 type LDFeatureFlagResponse = Record<LDFeatureName, LDFeatureToggle>;
 type LDInitState = "initializing" | "failed" | "initialized";
@@ -93,18 +93,18 @@ const LDInitializationWrapper: React.FC<React.PropsWithChildren<{ apiKey: string
 
   /**
    * Update the feature overwrites based on the LaunchDarkly value.
-   * The feature flag variants which do not include a JSON `overwrite` field are filtered
-   * out; then, each feature corresponding to one of the remaining overwrite flags is
-   * either enabled or disabled for the current user based on the boolean value of the
-   * overwrite field.
+   * The feature flag variants which do not include a JSON `enabled` field are filtered
+   * out; then, each feature corresponding to one of the remaining feature flag overwrites
+   * is either enabled or disabled for the current user based on the boolean value of its
+   * overwrite's `enabled` field.
    */
   const updateFeatureOverwrites = () => {
     const allFlags = (ldClient.current?.allFlags() ?? {}) as LDFeatureFlagResponse;
     const featureSet: FeatureSet = Object.fromEntries(
       Object.entries(allFlags)
         .filter(([flagName]) => flagName.startsWith(FEATURE_FLAG_PREFIX))
-        .map(([flagName, { overwrite }]) => [flagName.replace(`${FEATURE_FLAG_PREFIX}.`, ""), overwrite])
-        .filter(([_, overwrite]) => typeof overwrite !== "undefined")
+        .map(([flagName, { enabled }]) => [flagName.replace(`${FEATURE_FLAG_PREFIX}.`, ""), enabled])
+        .filter(([_, enabled]) => typeof enabled !== "undefined")
     );
 
     setFeatureOverwrites(featureSet);

--- a/airbyte-webapp/src/packages/cloud/services/thirdParty/launchdarkly/LDExperimentService.tsx
+++ b/airbyte-webapp/src/packages/cloud/services/thirdParty/launchdarkly/LDExperimentService.tsx
@@ -102,11 +102,14 @@ const LDInitializationWrapper: React.FC<React.PropsWithChildren<{ apiKey: string
         };
       }, {} as FeatureSet);
 
+    // by convention, feature flags return one of three payloads, each with its own meaning:
+    // 1) `{ "overwrite": true }` :: enable the feature
+    // 2) `{ "overwrite": false }` :: disable the feature
+    // 3) `{}` :: `overwrite` is `undefined`, i.e. continue to use the application's default feature state
     const independentFeaturesSet = Object.fromEntries(
-      Object.entries(independentFeatureOverwritesRaw).map(([flag, value]) => [
-        flag.replace(`${FEATURE_FLAG_PREFIX}.`, ""),
-        value,
-      ])
+      Object.entries(independentFeatureOverwritesRaw)
+        .map(([flag, { overwrite }]) => [flag.replace(`${FEATURE_FLAG_PREFIX}.`, ""), overwrite])
+        .filter(([_, value]) => (typeof value === "undefined" ? false : true))
     );
 
     const featureSet: FeatureSet = { ...sharedFeaturesSet, ...independentFeaturesSet };


### PR DESCRIPTION
## Background
Feature flags in LaunchDarkly serve multiple uses in airbyte cloud at various points in the lifecycle of a feature release. Sometimes they are used to opt specific people into the feature for testing; sometimes they are used to "soft launch" a feature in a way that can be rolled out and rolled back without the lag of a code update and deployment; sometimes they are used to grandfather certain users into the ability to continue using otherwise deprecated code.

The original implementation of our LaunchDarkly frontend integration put all feature toggles into a single LD "feature flag", with various experiences defined as variants on that single flag. Because all of a given flag's variants are mutually exclusive to a given user, this means we could not independently toggle different features for the whole userbase without auditing and possibly editing every other more targeted rule and worrying about rule precedence in LD. This added complexity and hassle scales up exponentially with the number of distinct feature toggles in use at a given moment.

## External context
A chunk of the work for this feature happened in LaunchDarkly itself: for each feature toogle that has been managed to date with the shared `featureService.overwrites` feature flag needed to be ported to a new feature flag using an `{ enabled?: boolean }` payload, along with all targeting rules used to apply that variant. More on this below.

## What this changes
This adds logic to the LaunchDarkly integration that populates the FeatureService's overwrites to accept single-toggle feature flags. It hardcodes the assumption that all such flags will use a key that begins with the same `featureService.` prefix as the shared feature flag: this (otherwise arbitrary) criterion lets us quickly and reliably filter the list of feature flags in LD to the set that is specifically relevant to the frontend codebase for visibility and auditing. Closes https://github.com/airbytehq/airbyte/issues/19726.

Here's a recording of a manual test of the new code, toggling the presence of two different sub-nav link via new, independent feature flags. At the time of recording this screencap, https://github.com/airbytehq/airbyte/pull/20105 had not yet been merged into the feature branch, which is kind of ideal for demonstration purposes: explicitly using the "enable feature" and "disable feature" variants work identically for each feature, while using the "use application default" variants enables the "Data residency" link and disables the "dbt Cloud integration" one, using the cloud build's default features [as of commit `7b19f59`](https://github.com/airbytehq/airbyte/blob/7b19f59f7c1d07f1daf8c972078b97444b531819/airbyte-webapp/src/packages/cloud/App.tsx#L42-L48):
![independent-feature-flags](https://user-images.githubusercontent.com/7516653/206265674-98102cb3-ad0e-4a34-82b3-a9282a8f6b45.gif)


## 🚨 User Impact 🚨
Existing feature flags are handled exactly as before, so there should be zero user impact. There is one cohort of users who have been grandfathered into continued use of sub-one-hour sync scheduling, so some care should be taken to ensure that deploying this change causes no interruption to that targeting logic.

## Manual testing
Unfortunately, there's not a great way to add automated tests for this feature: writing jest tests would require lots of time consuming effort to mock out large swaths of the application context before any assertions can be written; cypress tests would be ideal, but we only use `LDExperimentService` in cloud, and we don't yet have a test suite for that. So manual testing it is.

Tests done:
- [X] *In the feature branch*, each existing feature can be toggled on, off, or to the application default in isolation via the new feature flags (tested via the LD development environment and a local frontend)
- [X] *In the feature branch*, toggling a feature via the shared `featureService.overwrites` feature flag does not affect the UI (same testing setup)
- [X] *In the existing prod app*, creating and toggling the new feature flags does not affect the UI (tested via [a targeting rule matching my personal email](https://app.launchdarkly.com/default/production/features/featureService.ALLOW_DBT_CLOUD_INTEGRATION/targeting) in the LD production environment and cloud.airbyte.io)

## Documentation
This seems worth documenting for the Airbyte team! That is not, strictly speaking, a concern for this PR, since it happens outside of the codebase; just calling it out to keep myself honest.