### PR TITLE
fix: add BuildPulse report for helm ac tests

### DIFF
--- a/.github/workflows/gradle.yml
+++ b/.github/workflows/gradle.yml
@@ -1074,6 +1074,16 @@ jobs:
         with:
           name: Kubernetes Logs
           path: /tmp/kubernetes_logs/*
+      
+      - name: Upload test results to BuildPulse for flaky test detection
+        if: "!cancelled()" # Run this step even when the tests fail. Skip if the workflow is cancelled.
+        uses: Workshop64/buildpulse-action@main
+        with:
+          account: 59758427
+          repository: 283046497
+          path: "/actions-runner/_work/airbyte/airbyte/*"
+          key: ${{ secrets.BUILDPULSE_ACCESS_KEY_ID }}
+          secret: ${{ secrets.BUILDPULSE_SECRET_ACCESS_KEY }}
     
 
   # # In case of self-hosted EC2 errors, remove this block.


### PR DESCRIPTION
## What
* Add BuildPulse report step for helm AC tests for flaky test detection