### PR TITLE
Exclude pyc files when building connector-builder-server

### DIFF
--- a/airbyte-connector-builder-server/build.gradle
+++ b/airbyte-connector-builder-server/build.gradle
@@ -50,7 +50,7 @@ task prepareBuild(type: Copy) {
     from layout.projectDirectory.file(".")
     exclude '.*'
     exclude 'build'
-
+    exclude '**/*.pyc'
 
     into layout.buildDirectory.dir("docker")
 }


### PR DESCRIPTION
## What
The platform build fails if the compiled python files are created as root.
We don't need the compiled files so we can exclude them from the copy step.

## How
`exclude '**/*.pyc'`