### PR TITLE
Fix markdown typo in airbyte-protocol-docker.md

### DIFF
--- a/docs/understanding-airbyte/airbyte-protocol-docker.md
+++ b/docs/understanding-airbyte/airbyte-protocol-docker.md
@@ -43,7 +43,7 @@ cat <&0 | docker run --rm -i <destination-image-name> write --config <config-fil
 
 The `write` command will consume `AirbyteMessage`s from STDIN.
 
-##I/O:
+## I/O:
 * Connectors receive arguments on the command line via JSON files. `e.g. --catalog catalog.json`
 * They read `AirbyteMessage`s from STDIN. The destination `write` action is the only command that consumes `AirbyteMessage`s.
 * They emit `AirbyteMessage`s on STDOUT.


### PR DESCRIPTION
## What
I noticed the `I/O` heading was not displaying properly due to a missing space. 
![16FAF8E0-04F1-4CEF-896E-3CC543F0B36F](https://user-images.githubusercontent.com/1325608/204357990-b213d914-472d-4d6d-af8f-f933bb03b76a.jpeg)


## How
This fixes that by adding the space. 


## 🚨 User Impact 🚨
Users will finally get that well formatted heading they’ve all been asking for. 

## Pre-merge Checklist
Expand the relevant checklist and delete the others.

<details><summary><strong>New Connector</strong></summary>

### Community member or Airbyter

- [x] **Community member?** Grant edit access to maintainers ([instructions](https://docs.github.com/en/github/collaborating-with-pull-requests/working-with-forks/allowing-changes-to-a-pull-request-branch-created-from-a-fork#enabling-repository-maintainer-permissions-on-existing-pull-requests))

