### PR TITLE
fix: add action that remove unattended-upgrades from the os [#3608]

### DIFF
--- a/.github/actions/remove-unattended-upgrade/action.yml
+++ b/.github/actions/remove-unattended-upgrade/action.yml
@@ -1,0 +1,11 @@
+name: "Remove Unattended upgrade"
+description: "Removes unattended upgrade package so no updates will be performed in backrground"
+
+runs:
+  using: "composite"
+  steps:
+    - name: "Remove unattended upgrade package"
+      shell: bash
+      run: |
+        sudo apt -y remove --purge unattended-upgrades
+        sudo apt -y install ubuntu-release-updater-core

--- a/.github/workflows/gradle.yml
+++ b/.github/workflows/gradle.yml
@@ -960,6 +960,9 @@ jobs:
         with:
           fetch-depth: 0
 
+      - name: Remove unattended-upgrades
+        uses: ./.github/actions/remove-unattended-upgrade
+
       - name: Delete default old docker and replace it with a new one
         shell: bash
         run: |

--- a/.github/workflows/gradle.yml
+++ b/.github/workflows/gradle.yml
@@ -191,6 +191,9 @@ jobs:
       - name: Checkout Airbyte
         uses: actions/checkout@v3
 
+      - name: Remove unattended-upgrades
+        uses: ./.github/actions/remove-unattended-upgrade
+
       - name: Cache Build Artifacts
         uses: ./.github/actions/cache-build-artifacts
         with:
@@ -358,6 +361,9 @@ jobs:
         uses: actions/checkout@v3
         with:
           fetch-depth: 0
+
+      - name: Remove unattended-upgrades
+        uses: ./.github/actions/remove-unattended-upgrade
 
       - name: Cache Build Artifacts
         uses: ./.github/actions/cache-build-artifacts
@@ -530,6 +536,9 @@ jobs:
     steps:
       - name: Checkout Airbyte
         uses: actions/checkout@v3
+
+      - name: Remove unattended-upgrades
+        uses: ./.github/actions/remove-unattended-upgrade
 
       - name: Cache Build Artifacts
         uses: ./.github/actions/cache-build-artifacts
@@ -733,6 +742,9 @@ jobs:
     steps:
       - name: Checkout Airbyte
         uses: actions/checkout@v3
+
+      - name: Remove unattended-upgrades
+        uses: ./.github/actions/remove-unattended-upgrade
 
       - name: Cache Build Artifacts
         uses: ./.github/actions/cache-build-artifacts


### PR DESCRIPTION
## What
* Remove unattended-upgrades package from ubuntu so it won't lock apt frontend during workflow execution
* Fixes https://github.com/airbytehq/airbyte-cloud/issues/3608