### PR TITLE
Allow overriding cloud env in start:cloud script

### DIFF
--- a/airbyte-webapp/package.json
+++ b/airbyte-webapp/package.json
@@ -10,7 +10,7 @@
     "prestart": "npm run generate-client",
     "start": "craco start",
     "prestart:cloud": "npm run generate-client",
-    "start:cloud": "AB_ENV=frontend-dev node -r ./scripts/environment.js ./node_modules/.bin/craco start",
+    "start:cloud": "AB_ENV=${AB_ENV-frontend-dev} node -r ./scripts/environment.js ./node_modules/.bin/craco start",
     "prebuild": "npm run generate-client",
     "build": "BUILD_PATH='./build/app' craco build",
     "pretest": "npm run generate-client",


### PR DESCRIPTION
Uses basic bash variable substitution syntax to define `frontend-dev` as the default value for `$AB_ENV` when running `npm run start:cloud` instead of unconditionally hardcoding it; this allows devs to override which staging instance their frontend dev server will attempt to find configuration for. Manually tested and confirmed to work in bash, zsh, and fish shells. In hindsight, since npm opens a `bin/sh` subshell on POSIX-compliant OSes, this testing was unnecessary, but it was confirmation nonetheless. 

No users should be affected, since the established usage still works as before (barring the fairly unrealistic case where an Airbyte employee has an unrelated `$AB_ENV` defined in their development shell env). Existing script definitions use POSIX variable syntax, so while this variable substitution syntax is incompatible with non-WSL windows (on which npm executes scripts with `cmd.exe`), that's not actually a breaking change.

To specify different environments:
```sh
# `$AB_ENV` is the default value, `"frontend-dev"`
npm rum start:cloud

# `$AB_ENV` is the user-supplied value, `"dev-2"`; expects a corresponding `.env.dev-2` file to exist
AB_ENV=dev-2 npm run start:cloud
```

This PR lays the prerequisite groundwork for developing the airbyte frontend against other staging instances for the `airbyte` repo; there will need to be corresponding changes in `airbyte-cloud` to define the required `.env.${ENVIRONMENT}` files for each additional staging instance.