### PR TITLE
Allow resets for disabled connections

### DIFF
--- a/airbyte-webapp/src/pages/ConnectionPage/pages/ConnectionItemPage/ConnectionReplicationTab.tsx
+++ b/airbyte-webapp/src/pages/ConnectionPage/pages/ConnectionItemPage/ConnectionReplicationTab.tsx
@@ -119,9 +119,8 @@ export const ConnectionReplicationTab: React.FC = () => {
           });
           if (result.type !== "canceled") {
             // Save the connection taking into account the correct skipReset value from the dialog choice.
-            // We also want to skip the reset sync if the connection is not in an "active" status
             await saveConnection(formValues, {
-              skipReset: !result.reason || connection.status !== "active",
+              skipReset: !result.reason,
               catalogHasChanged,
             });
           } else {

--- a/airbyte-webapp/src/pages/ConnectionPage/pages/ConnectionItemPage/ConnectionReplicationTab.tsx
+++ b/airbyte-webapp/src/pages/ConnectionPage/pages/ConnectionItemPage/ConnectionReplicationTab.tsx
@@ -142,7 +142,6 @@ export const ConnectionReplicationTab: React.FC = () => {
       connection.connectionId,
       connection.catalogDiff,
       connection.operations,
-      connection.status,
       connection.syncCatalog.streams,
       connectionService,
       formatMessage,


### PR DESCRIPTION
Resolves #19861 

This is fixing a bug that was introduced during the connection form refactor. skipReset should be set to false if there is any change to the configured catalog, regardless of whether the connection is disabled.