### PR TITLE
source-surveymonkey: fix `getBaseURLByOrigin`

### DIFF
--- a/airbyte-config/init/src/main/resources/seed/source_definitions.yaml
+++ b/airbyte-config/init/src/main/resources/seed/source_definitions.yaml
@@ -1553,7 +1553,7 @@
 - name: SurveyMonkey
   sourceDefinitionId: badc5925-0485-42be-8caa-b34096cb71b5
   dockerRepository: airbyte/source-surveymonkey
-  dockerImageTag: 0.1.12
+  dockerImageTag: 0.1.13
   documentationUrl: https://docs.airbyte.com/integrations/sources/surveymonkey
   icon: surveymonkey.svg
   sourceType: api

--- a/airbyte-config/init/src/main/resources/seed/source_specs.yaml
+++ b/airbyte-config/init/src/main/resources/seed/source_specs.yaml
@@ -14045,7 +14045,7 @@
     supportsNormalization: false
     supportsDBT: false
     supported_destination_sync_modes: []
-- dockerImage: "airbyte/source-surveymonkey:0.1.12"
+- dockerImage: "airbyte/source-surveymonkey:0.1.13"
   spec:
     documentationUrl: "https://docs.airbyte.com/integrations/sources/surveymonkey"
     connectionSpecification:

--- a/airbyte-integrations/connectors/source-surveymonkey/Dockerfile
+++ b/airbyte-integrations/connectors/source-surveymonkey/Dockerfile
@@ -12,5 +12,5 @@ RUN pip install .
 ENV AIRBYTE_ENTRYPOINT "python /airbyte/integration_code/main.py"
 ENTRYPOINT ["python", "/airbyte/integration_code/main.py"]
 
-LABEL io.airbyte.version=0.1.12
+LABEL io.airbyte.version=0.1.13
 LABEL io.airbyte.name=airbyte/source-surveymonkey

--- a/airbyte-integrations/connectors/source-surveymonkey/acceptance-test-config.yml
+++ b/airbyte-integrations/connectors/source-surveymonkey/acceptance-test-config.yml
@@ -2,26 +2,27 @@ connector_image: airbyte/source-surveymonkey:dev
 acceptance_tests:
   spec:
     tests:
-    - spec_path: "source_surveymonkey/spec.json"
+      - spec_path: "source_surveymonkey/spec.json"
   connection:
     tests:
-    - config_path: "secrets/config.json"
-      status: "succeed"
-    - config_path: "integration_tests/invalid_config.json"
-      status: "failed"
+      - config_path: "secrets/config.json"
+        status: "succeed"
+      - config_path: "integration_tests/invalid_config.json"
+        status: "failed"
   discovery:
     tests:
-    - config_path: "secrets/config.json"
+      - config_path: "secrets/config.json"
   basic_read:
     tests:
-    - config_path: "secrets/config.json"
-      configured_catalog_path: "integration_tests/configured_catalog.json"
+      - config_path: "secrets/config.json"
+        configured_catalog_path: "integration_tests/configured_catalog.json"
   incremental:
     tests:
-    - config_path: "secrets/config.json"
-      configured_catalog_path: "integration_tests/configured_catalog.json"
-      future_state_path: "integration_tests/abnormal_state.json"
+      - config_path: "secrets/config.json"
+        configured_catalog_path: "integration_tests/configured_catalog.json"
+        future_state:
+          future_state_path: "integration_tests/abnormal_state.json"
   full_refresh:
     tests:
-    - config_path: "secrets/config.json"
-      configured_catalog_path: "integration_tests/configured_catalog.json"
+      - config_path: "secrets/config.json"
+        configured_catalog_path: "integration_tests/configured_catalog.json"

--- a/airbyte-oauth/src/main/java/io/airbyte/oauth/flows/SurveymonkeyOAuthFlow.java
+++ b/airbyte-oauth/src/main/java/io/airbyte/oauth/flows/SurveymonkeyOAuthFlow.java
@@ -50,11 +50,11 @@ public class SurveymonkeyOAuthFlow extends BaseOAuth2Flow {
   protected String getBaseURLByOrigin(final JsonNode inputOAuthConfiguration) throws Error {
     final String origin = getConfigValueUnsafe(inputOAuthConfiguration, "origin");
     if (EUROPE.equals(origin)) {
-      return API_ACCESS_URL_EU + AUTHORIZE_URL;
+      return API_ACCESS_URL_EU;
     } else if (CANADA.equals(origin)) {
-      return API_ACCESS_URL_CA + AUTHORIZE_URL;
+      return API_ACCESS_URL_CA;
     } else if (USA.equals(origin)) {
-      return API_ACCESS_URL_USA + AUTHORIZE_URL;
+      return API_ACCESS_URL_USA;
     } else {
       throw new Error("Unknown Origin: " + origin);
     }

--- a/airbyte-oauth/src/test/java/io/airbyte/oauth/flows/SurveymonkeyOAuthFlowTest.java
+++ b/airbyte-oauth/src/test/java/io/airbyte/oauth/flows/SurveymonkeyOAuthFlowTest.java
@@ -4,6 +4,8 @@
 
 package io.airbyte.oauth.flows;
 
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
 import com.fasterxml.jackson.databind.JsonNode;
 import com.google.common.collect.ImmutableMap;
 import io.airbyte.commons.json.Jsons;
@@ -12,7 +14,6 @@ import io.airbyte.oauth.MoreOAuthParameters;
 import java.util.List;
 import java.util.Map;
 import org.junit.jupiter.api.Test;
-import static org.junit.jupiter.api.Assertions.assertEquals;
 
 @SuppressWarnings("PMD.JUnitTestsShouldIncludeAssert")
 class SurveymonkeyOAuthFlowTest extends BaseOAuthFlowTest {

--- a/airbyte-oauth/src/test/java/io/airbyte/oauth/flows/SurveymonkeyOAuthFlowTest.java
+++ b/airbyte-oauth/src/test/java/io/airbyte/oauth/flows/SurveymonkeyOAuthFlowTest.java
@@ -12,6 +12,7 @@ import io.airbyte.oauth.MoreOAuthParameters;
 import java.util.List;
 import java.util.Map;
 import org.junit.jupiter.api.Test;
+import static org.junit.jupiter.api.Assertions.assertEquals;
 
 @SuppressWarnings("PMD.JUnitTestsShouldIncludeAssert")
 class SurveymonkeyOAuthFlowTest extends BaseOAuthFlowTest {
@@ -64,6 +65,15 @@ class SurveymonkeyOAuthFlowTest extends BaseOAuthFlowTest {
     return Map.of(
         "access_token", "access_token_response",
         "client_id", MoreOAuthParameters.SECRET_MASK);
+  }
+
+  @Test
+  void testGetAccessTokenUrl() {
+    final SurveymonkeyOAuthFlow oauthFlow = (SurveymonkeyOAuthFlow) getOAuthFlow();
+    final String expectedAccessTokenUrl = "https://api.surveymonkey.com/oauth/token";
+
+    final String accessTokenUrl = oauthFlow.getAccessTokenUrl(getInputOAuthConfiguration());
+    assertEquals(accessTokenUrl, expectedAccessTokenUrl);
   }
 
   @Test

--- a/docs/integrations/sources/surveymonkey.md
+++ b/docs/integrations/sources/surveymonkey.md
@@ -64,8 +64,9 @@ To cover more data from this source we use caching.
 ## Changelog
 
 | Version | Date       | Pull Request                                             | Subject                                                                |
-|:--------|:-----------|:---------------------------------------------------------|:-----------------------------------------------------------------------|
-| 0.1.12  | 2022-10-13 | [17964](https://github.com/airbytehq/airbyte/pull/17964)                                                     | Add OAuth for Eu and Ca                                                |
+| :------ | :--------- | :------------------------------------------------------- | :--------------------------------------------------------------------- |
+| 0.1.13  | 2022-11-29 | [TBD](https://github.com/airbytehq/airbyte/pull/TBD)     | Fix OAuth flow urls                                                    |
+| 0.1.12  | 2022-10-13 | [17964](https://github.com/airbytehq/airbyte/pull/17964) | Add OAuth for Eu and Ca                                                |
 | 0.1.11  | 2022-09-28 | [17326](https://github.com/airbytehq/airbyte/pull/17326) | Migrate to per-stream states.                                          |
 | 0.1.10  | 2022-09-14 | [16706](https://github.com/airbytehq/airbyte/pull/16706) | Fix 404 error when handling nonexistent surveys                        |
 | 0.1.9   | 2022-07-28 | [13046](https://github.com/airbytehq/airbyte/pull/14998) | Fix state for response stream, fixed backoff behaviour, added unittest |

--- a/docs/integrations/sources/surveymonkey.md
+++ b/docs/integrations/sources/surveymonkey.md
@@ -65,7 +65,7 @@ To cover more data from this source we use caching.
 
 | Version | Date       | Pull Request                                             | Subject                                                                |
 | :------ | :--------- | :------------------------------------------------------- | :--------------------------------------------------------------------- |
-| 0.1.13  | 2022-11-29 | [TBD](https://github.com/airbytehq/airbyte/pull/TBD)     | Fix OAuth flow urls                                                    |
+| 0.1.13  | 2022-11-29 | [19868](https://github.com/airbytehq/airbyte/pull/19868) | Fix OAuth flow urls                                                    |
 | 0.1.12  | 2022-10-13 | [17964](https://github.com/airbytehq/airbyte/pull/17964) | Add OAuth for Eu and Ca                                                |
 | 0.1.11  | 2022-09-28 | [17326](https://github.com/airbytehq/airbyte/pull/17326) | Migrate to per-stream states.                                          |
 | 0.1.10  | 2022-09-14 | [16706](https://github.com/airbytehq/airbyte/pull/16706) | Fix 404 error when handling nonexistent surveys                        |


### PR DESCRIPTION
## What
The URL built to complete oauth flow seem wrong and return 404.
I suspect this URL to be badly formatted after this [PR](https://github.com/airbytehq/airbyte/pull/17964).
I think the `ACCESS_TOKEN_URL` is appended to `AUTHORIZE_URL`, creating wrong URLs like `https://api.surveymonkey.com/oauth/authorize/oauth/token`


## How
Remove the append of `AUTHORIZE_URL` in `getBaseURLByOrigin` 

