### PR TITLE
🪟 🎨 Update text describing connection geography

### DIFF
--- a/airbyte-webapp/src/components/CreateConnection/DataResidency.tsx
+++ b/airbyte-webapp/src/components/CreateConnection/DataResidency.tsx
@@ -1,4 +1,5 @@
 import { Field, FieldProps, useFormikContext } from "formik";
+import React from "react";
 import { FormattedMessage, useIntl } from "react-intl";
 
 import { DataGeographyDropdown } from "components/common/DataGeographyDropdown";
@@ -33,8 +34,13 @@ export const DataResidency: React.FC<DataResidencyProps> = ({ name = "geography"
                   <FormattedMessage
                     id="connection.geographyDescription"
                     values={{
-                      lnk: (node: React.ReactNode) => (
+                      lnk1: (node: React.ReactNode) => (
                         <a href={links.cloudAllowlistIPsLink} target="_blank" rel="noreferrer">
+                          {node}
+                        </a>
+                      ),
+                      lnk2: (node: React.ReactNode) => (
+                        <a href={links.connectionDataResidency} target="_blank" rel="noreferrer">
                           {node}
                         </a>
                       ),

--- a/airbyte-webapp/src/components/CreateConnection/DataResidency.tsx
+++ b/airbyte-webapp/src/components/CreateConnection/DataResidency.tsx
@@ -34,12 +34,12 @@ export const DataResidency: React.FC<DataResidencyProps> = ({ name = "geography"
                   <FormattedMessage
                     id="connection.geographyDescription"
                     values={{
-                      lnk1: (node: React.ReactNode) => (
+                      ipLink: (node: React.ReactNode) => (
                         <a href={links.cloudAllowlistIPsLink} target="_blank" rel="noreferrer">
                           {node}
                         </a>
                       ),
-                      lnk2: (node: React.ReactNode) => (
+                      docLink: (node: React.ReactNode) => (
                         <a href={links.connectionDataResidency} target="_blank" rel="noreferrer">
                           {node}
                         </a>

--- a/airbyte-webapp/src/components/connection/UpdateConnectionDataResidency/UpdateConnectionDataResidency.tsx
+++ b/airbyte-webapp/src/components/connection/UpdateConnectionDataResidency/UpdateConnectionDataResidency.tsx
@@ -50,8 +50,13 @@ export const UpdateConnectionDataResidency: React.FC = () => {
               <FormattedMessage
                 id="connection.geographyDescription"
                 values={{
-                  lnk: (node: React.ReactNode) => (
+                  lnk1: (node: React.ReactNode) => (
                     <a href={links.cloudAllowlistIPsLink} target="_blank" rel="noreferrer">
+                      {node}
+                    </a>
+                  ),
+                  lnk2: (node: React.ReactNode) => (
+                    <a href={links.connectionDataResidency} target="_blank" rel="noreferrer">
                       {node}
                     </a>
                   ),

--- a/airbyte-webapp/src/components/connection/UpdateConnectionDataResidency/UpdateConnectionDataResidency.tsx
+++ b/airbyte-webapp/src/components/connection/UpdateConnectionDataResidency/UpdateConnectionDataResidency.tsx
@@ -50,12 +50,12 @@ export const UpdateConnectionDataResidency: React.FC = () => {
               <FormattedMessage
                 id="connection.geographyDescription"
                 values={{
-                  lnk1: (node: React.ReactNode) => (
+                  ipLink: (node: React.ReactNode) => (
                     <a href={links.cloudAllowlistIPsLink} target="_blank" rel="noreferrer">
                       {node}
                     </a>
                   ),
-                  lnk2: (node: React.ReactNode) => (
+                  docLink: (node: React.ReactNode) => (
                     <a href={links.connectionDataResidency} target="_blank" rel="noreferrer">
                       {node}
                     </a>

--- a/airbyte-webapp/src/locales/en.json
+++ b/airbyte-webapp/src/locales/en.json
@@ -344,7 +344,7 @@
 
   "connection.geographyTitle": "Data residency",
   "connection.requestNewGeography": "Request a new geography",
-  "connection.geographyDescription": "Choose where the data for this connection will be processed. Depending on your network configuration, you may need to <lnk1>add IP addresses</lnk1> to your allowlist. <lnk2>Learn more</lnk2>.",
+  "connection.geographyDescription": "Choose where the data for this connection will be processed. Depending on your network configuration, you may need to <ipLink>add IP addresses</ipLink> to your allowlist. <docLink>Learn more</docLink>.",
   "connection.geography.auto": "Airbyte Default",
   "connection.geography.us": "United States",
   "connection.geography.eu": "European Union",

--- a/airbyte-webapp/src/locales/en.json
+++ b/airbyte-webapp/src/locales/en.json
@@ -344,7 +344,7 @@
 
   "connection.geographyTitle": "Data residency",
   "connection.requestNewGeography": "Request a new geography",
-  "connection.geographyDescription": "Depending on your network configuration, you may need to <lnk>add IP addresses</lnk> to your allowlist.",
+  "connection.geographyDescription": "Choose where the data for this connection will be processed. Depending on your network configuration, you may need to <lnk1>add IP addresses</lnk1> to your allowlist. <lnk2>Learn more</lnk2>.",
   "connection.geography.auto": "Airbyte Default",
   "connection.geography.us": "United States",
   "connection.geography.eu": "European Union",
@@ -494,6 +494,7 @@
   "settings.cookiePreferences": "Cookie Preferences",
   "settings.dataResidency": "Data Residency",
   "settings.defaultDataResidency": "Default Data Residency",
+  "settings.geographyDescription": "Depending on your network configuration, you may need to <lnk>add IP addresses</lnk> to your allowlist.",
   "settings.defaultGeography": "Geography",
   "settings.defaultDataResidencyDescription": "Choose the default preferred data processing location for all of your connections. The default data residency setting only affects new connections. Existing connections will retain their data residency setting. <lnk>Learn more</lnk>.",
   "settings.defaultDataResidencyUpdateError": "There was an error updating the default data residency for this workspace.",

--- a/airbyte-webapp/src/packages/cloud/views/workspaces/DataResidencyView/DataResidencyView.tsx
+++ b/airbyte-webapp/src/packages/cloud/views/workspaces/DataResidencyView/DataResidencyView.tsx
@@ -80,7 +80,7 @@ export const DataResidencyView: React.FC = () => {
                       label={<FormattedMessage id="settings.defaultGeography" />}
                       message={
                         <FormattedMessage
-                          id="connection.geographyDescription"
+                          id="settings.geographyDescription"
                           values={{
                             lnk: (node: React.ReactNode) => (
                               <a href={links.cloudAllowlistIPsLink} target="_blank" rel="noreferrer">

--- a/airbyte-webapp/src/utils/links.ts
+++ b/airbyte-webapp/src/utils/links.ts
@@ -29,8 +29,10 @@ export const links = {
   webhookVideoGuideLink: "https://www.youtube.com/watch?v=NjYm8F-KiFc",
   webhookGuideLink: `${BASE_DOCS_LINK}/operator-guides/configuring-sync-notifications/`,
   cronReferenceLink: "http://www.quartz-scheduler.org/documentation/quartz-2.3.0/tutorials/crontrigger.html",
-  cloudAllowlistIPsLink: `${BASE_DOCS_LINK}/cloud/getting-started-with-airbyte-cloud/#allowlist-ip-address`,
+  cloudAllowlistIPsLink: `${BASE_DOCS_LINK}/cloud/getting-started-with-airbyte-cloud/#allowlist-ip-addresses`,
   dataResidencySurvey: "https://forms.gle/Dr7MPTdt9k3xTinL8",
+  connectionDataResidency:
+    "https://docs.airbyte.com/cloud/managing-airbyte-cloud/#choose-the-data-residency-for-a-connection",
   lowCodeYamlDescription: `${BASE_DOCS_LINK}/connector-development/config-based/understanding-the-yaml-file/yaml-overview`,
 } as const;
 


### PR DESCRIPTION
## What
Updates the text describing what a connection's geography setting means. This was a [suggestion](https://airbytehq-team.slack.com/archives/C03NRC12XD1/p1669127616667489) from @alex-gron that @andyjih approved ✅ 

Before:
> Depending on your network configuration, you may need to [add IP addresses](https://docs.airbyte.com/cloud/getting-started-with-airbyte-cloud/#allowlist-ip-address) to your allowlist.

After:
> Choose where the data for this connection will be processed. Depending on your network configuration, you may need to [add IP addresses](https://docs.airbyte.com/cloud/getting-started-with-airbyte-cloud/#allowlist-ip-address) to your allowlist. [Learn more](https://docs.airbyte.com/cloud/managing-airbyte-cloud/#choose-the-data-residency-for-a-connection).

This appears on both the connection creation page and on the settings tab of existing connections:
<img width="1159" alt="image" src="https://user-images.githubusercontent.com/7550957/204577971-ced78d8e-01ff-4291-8416-4f562a9dddf3.png">
<img width="502" alt="image" src="https://user-images.githubusercontent.com/7550957/204576765-038983b5-886d-4643-a95c-fd669f4d8b31.png">