### PR TITLE
Change canonical url to docs for SEO purposes

### DIFF
--- a/docusaurus/docusaurus.config.js
+++ b/docusaurus/docusaurus.config.js
@@ -9,7 +9,7 @@ const config = {
     title: 'Airbyte Documentation',
     tagline:
         'Airbyte is an open-source data integration platform to build ELT pipelines. Consolidate your data in your data warehouses, lakes and databases.',
-    url: 'https://airbytehq.github.io',
+    url: 'https://docs.airbyte.com',
     // Assumed relative path.  If you are using airbytehq.github.io use /
     // anything else should match the repo name
     baseUrl: '/',


### PR DESCRIPTION
## What
Currently our docs point to our github pages as the canonical url. The canonical url should point to docs.airbyte.com

<img width="825" alt="Screenshot 2022-11-29 at 8 12 00 AM" src="https://user-images.githubusercontent.com/633226/204584761-1f8d3848-272c-41eb-bb7c-097c7e9982c3.png">