### PR TITLE
Data types update: Implement protocol message downgrade path

### DIFF
--- a/airbyte-commons-protocol/build.gradle
+++ b/airbyte-commons-protocol/build.gradle
@@ -6,6 +6,7 @@ dependencies {
     testImplementation libs.bundles.micronaut.test
 
     implementation project(':airbyte-protocol:protocol-models')
+    implementation project(':airbyte-json-validation')
 }
 
 Task publishArtifactsTask = getPublishArtifactsTask("$rootProject.ext.version", project)

--- a/airbyte-commons-protocol/src/main/java/io/airbyte/commons/protocol/migrations/AirbyteMessageMigrationV1.java
+++ b/airbyte-commons-protocol/src/main/java/io/airbyte/commons/protocol/migrations/AirbyteMessageMigrationV1.java
@@ -34,7 +34,6 @@ public class AirbyteMessageMigrationV1 implements AirbyteMessageMigration<io.air
 
   @Override
   public io.airbyte.protocol.models.v0.AirbyteMessage downgrade(AirbyteMessage oldMessage) {
-    // TODO implement downgrade
     io.airbyte.protocol.models.v0.AirbyteMessage newMessage = Jsons.object(
         Jsons.jsonNode(oldMessage),
         io.airbyte.protocol.models.v0.AirbyteMessage.class);
@@ -239,7 +238,8 @@ public class AirbyteMessageMigrationV1 implements AirbyteMessageMigration<io.air
             replacement.setAll(subschema);
           }
         } else {
-          // TODO maybe if this oneOf has boolean entries, then it's doing something funky, and we shouldn't attempt to combine it into a single type entry
+          // TODO maybe if this oneOf has boolean entries, then it's doing something funky, and we shouldn't
+          // attempt to combine it into a single type entry
         }
       }
 

--- a/airbyte-commons-protocol/src/main/java/io/airbyte/commons/protocol/migrations/AirbyteMessageMigrationV1.java
+++ b/airbyte-commons-protocol/src/main/java/io/airbyte/commons/protocol/migrations/AirbyteMessageMigrationV1.java
@@ -203,7 +203,13 @@ public class AirbyteMessageMigrationV1 implements AirbyteMessageMigration<io.air
   }
 
   private void downgradeTypeDeclaration(JsonNode schema) {
-    // TODO
+    if (schema.hasNonNull("$ref")) {
+      String referenceType = schema.get("$ref").asText();
+      ((ObjectNode) schema).removeAll();
+      ((ObjectNode) schema).setAll(JsonSchemaReferenceTypes.REFERENCE_TYPE_TO_OLD_TYPE.get(referenceType));
+    } else {
+      // TODO handle oneOf
+    }
   }
 
   private static void copyKey(ObjectNode source, ObjectNode target, String key) {

--- a/airbyte-commons-protocol/src/main/java/io/airbyte/commons/protocol/migrations/AirbyteMessageMigrationV1.java
+++ b/airbyte-commons-protocol/src/main/java/io/airbyte/commons/protocol/migrations/AirbyteMessageMigrationV1.java
@@ -638,7 +638,7 @@ public class AirbyteMessageMigrationV1 implements AirbyteMessageMigration<io.air
             if (itemsNode.size() > i) {
               // If we have a schema for this element, then try downgrading the element
               DowngradedNode downgradedElement = downgradeNode(element, itemsNode.get(i));
-              if (downgradedElement.matchedSchema()) {
+              if (!downgradedElement.matchedSchema()) {
                 allSchemasMatched = false;
               }
               downgradedItems.add(downgradedElement.node());

--- a/airbyte-commons-protocol/src/main/java/io/airbyte/commons/protocol/migrations/AirbyteMessageMigrationV1.java
+++ b/airbyte-commons-protocol/src/main/java/io/airbyte/commons/protocol/migrations/AirbyteMessageMigrationV1.java
@@ -107,8 +107,8 @@ public class AirbyteMessageMigrationV1 implements AirbyteMessageMigration<io.air
   }
 
   /**
-   * Detects any schema that looks like a reference type declaration, e.g.: { "$ref": "WellKnownTypes.json...." } or
-   * { "oneOf": [{"$ref": "..."}, {"type": "object"}] }
+   * Detects any schema that looks like a reference type declaration, e.g.: { "$ref":
+   * "WellKnownTypes.json...." } or { "oneOf": [{"$ref": "..."}, {"type": "object"}] }
    */
   private boolean isPrimitiveReferenceTypeDeclaration(JsonNode schema) {
     if (!schema.isObject()) {

--- a/airbyte-commons-protocol/src/main/java/io/airbyte/commons/protocol/migrations/AirbyteMessageMigrationV1.java
+++ b/airbyte-commons-protocol/src/main/java/io/airbyte/commons/protocol/migrations/AirbyteMessageMigrationV1.java
@@ -498,182 +498,253 @@ public class AirbyteMessageMigrationV1 implements AirbyteMessageMigration<io.air
     }
   }
 
+  /**
+   * Quick and dirty tuple. Used internally by {@link #downgradeNode(JsonNode, JsonNode)};
+   * callers probably only actually need the node.
+   *
+   * matchedSchema is useful for downgrading using a oneOf schema, where we need
+   * to recognize the correct subschema.
+   *
+   * @param node Our attempt at downgrading the node, under the given schema
+   * @param matchedSchema Whether the original node actually matched the schema
+   */
+  private record DowngradedNode(JsonNode node, boolean matchedSchema) {}
+
+  /**
+   * We need the schema to recognize which fields are integers, since it would
+   * be wrong to just assume any numerical string should be parsed out.
+   *
+   * Works on a best-effort basis. If the schema doesn't match the data, we'll
+   * do our best to downgrade anything that we can definitively say is a number.
+   * Should _not_ throw an exception if bad things happen (e.g. we try to parse
+   * a non-numerical string as a number).
+   */
   private DowngradedNode downgradeNode(JsonNode data, JsonNode schema) {
+    // If this is a oneOf node that looks like an upgraded v0 message, then we need to handle each oneOf case.
     if (!schema.hasNonNull(REF_KEY) && !schema.hasNonNull("type") && schema.hasNonNull("oneOf")) {
-      // If this is a oneOf node that looks like an upgraded v0 message, then we need to handle each oneOf case.
-      JsonNode schemaOptions = schema.get("oneOf");
-      if (schemaOptions.size() == 0) {
-        // If the oneOf has no options, then don't do anything interesting.
-        return new DowngradedNode(data, validator.validate(schema, data).isEmpty());
-      }
-
-      // Attempt to downgrade the node against each oneOf schema.
-      // Return the first schema that matches the data, or the first schema if none matched successfully.
-      DowngradedNode downgradedNode = null;
-      for (JsonNode maybeSchema : schemaOptions) {
-        DowngradedNode maybeDowngradedNode = downgradeNode(data, maybeSchema);
-        if (downgradedNode == null) {
-          downgradedNode = maybeDowngradedNode;
-        } else if (!downgradedNode.matchedSchema() && maybeDowngradedNode.matchedSchema()) {
-          downgradedNode = maybeDowngradedNode;
-          break;
-        }
-      }
-      return downgradedNode;
+      return downgradeOneofNode(data, schema);
     }
+    // Otherwise, we need to do something specific to whatever the data is.
     if (data.isTextual()) {
-      JsonNode refNode = schema.get(REF_KEY);
-      if (refNode != null) {
-        String refType = refNode.asText();
-        if (JsonSchemaReferenceTypes.NUMBER_REFERENCE.equals(refType)
-            || JsonSchemaReferenceTypes.INTEGER_REFERENCE.equals(refType)) {
-          // We could do this as a try-catch, but this migration will run on every RecordMessage
-          // so it does need to be reasonably performant.
-          // Instead, we use a regex to check for numeric literals.
-          // Note that this does _not_ allow infinity/nan, even though protocol v1 _does_ allow them.
-          // This is because JSON numeric literals don't allow those values.
-          if (data.asText().matches("-?\\d+(\\.\\d+)?")) {
-            // If this string is a numeric literal, convert it to a numeric node.
-            return new DowngradedNode(Jsons.deserialize(data.asText()), true);
-          } else {
-            // Otherwise, just leave the node unchanged.
-            return new DowngradedNode(data, false);
-          }
-        } else {
-          return new DowngradedNode(data, validator.validate(schema, data).isEmpty());
-        }
-      } else {
-        return new DowngradedNode(data, validator.validate(schema, data).isEmpty());
-      }
+      return downgradeTextualNode(data, schema);
     } else if (data.isObject()) {
-      boolean isObjectSchema;
-      if (schema.hasNonNull(REF_KEY)) {
-        // If the schema uses a reference type, then it's not an object schema.
-        isObjectSchema = false;
-      } else if (schema.hasNonNull("type")) {
-        // If the schema declares {type: object} or {type: [..., object, ...]}
-        // Then this is an object schema
-        JsonNode typeNode = schema.get("type");
-        if (typeNode.isArray()) {
-          isObjectSchema = false;
-          for (JsonNode typeItem : typeNode) {
-            if ("object".equals(typeItem.asText())) {
-              isObjectSchema = true;
-            }
-          }
-        } else {
-          isObjectSchema = "object".equals(typeNode.asText());
-        }
-      } else {
-        // If the schema doesn't declare a type at all (which is bad practice, but let's handle it anyway)
-        // Then check for a properties entry, and assume that this is an object if it's present
-        isObjectSchema = schema.hasNonNull("properties");
-      }
-      if (!isObjectSchema) {
-        return new DowngradedNode(data, false);
-      } else {
-        ObjectNode downgradedData = (ObjectNode) Jsons.emptyObject();
-        JsonNode propertiesNode = schema.get("properties");
-
-        Iterator<Entry<String, JsonNode>> dataFields = data.fields();
-        boolean matchedSchema = true;
-        while (dataFields.hasNext()) {
-          Entry<String, JsonNode> field = dataFields.next();
-          String key = field.getKey();
-          JsonNode value = field.getValue();
-          if (propertiesNode != null && propertiesNode.hasNonNull(key)) {
-            // If we have a schema for this property, do the downgrade
-            JsonNode subschema = propertiesNode.get(key);
-            DowngradedNode downgradedNode = downgradeNode(value, subschema);
-            downgradedData.set(key, downgradedNode.node);
-            if (!downgradedNode.matchedSchema) {
-              matchedSchema = false;
-            }
-          } else {
-            // Else it's an additional property - we _could_ check additionalProperties,
-            // but that's annoying and we don't actually respect that in destinations/normalization anyway.
-            downgradedData.set(key, value);
-          }
-        }
-
-        return new DowngradedNode(downgradedData, matchedSchema);
-      }
+      return downgradeObjectNode(data, schema);
     } else if (data.isArray()) {
-      boolean isArraySchema;
-      if (schema.hasNonNull(REF_KEY)) {
-        // If the schema uses a reference type, then it's not an array schema.
-        isArraySchema = false;
-      } else if (schema.hasNonNull("type")) {
-        // If the schema declares {type: array} or {type: [..., array, ...]}
-        // Then this is an array schema
-        JsonNode typeNode = schema.get("type");
-        if (typeNode.isArray()) {
-          isArraySchema = false;
-          for (JsonNode typeItem : typeNode) {
-            if ("array".equals(typeItem.asText())) {
-              isArraySchema = true;
-            }
-          }
-        } else {
-          isArraySchema = "array".equals(typeNode.asText());
-        }
-      } else {
-        // If the schema doesn't declare a type at all (which is bad practice, but let's handle it anyway)
-        // Then check for an items entry, and assume that this is an array if it's present
-        isArraySchema = schema.hasNonNull("items");
-      }
-      if (!isArraySchema) {
-        return new DowngradedNode(data, false);
-      } else {
-        ArrayNode downgradedItems = Jsons.arrayNode();
-        JsonNode itemsNode = schema.get("items");
-        if (itemsNode == null) {
-          // We _could_ check additionalItems, but much like the additionalProperties comment above:
-          // it's a lot of work for no payoff
-          return new DowngradedNode(data, true);
-        } else if (itemsNode.isArray()) {
-          boolean allSchemasMatched = true;
-          for (int i = 0; i < data.size(); i++) {
-            JsonNode element = data.get(i);
-            if (itemsNode.size() > i) {
-              // If we have a schema for this element, then try downgrading the element
-              DowngradedNode downgradedElement = downgradeNode(element, itemsNode.get(i));
-              if (!downgradedElement.matchedSchema()) {
-                allSchemasMatched = false;
-              }
-              downgradedItems.add(downgradedElement.node());
-            }
-          }
-          // If there were more elements in `data` than there were schemas in `itemsNode`,
-          // then just blindly add the rest of those elements.
-          for (int i = itemsNode.size(); i < data.size(); i++) {
-            downgradedItems.add(data.get(i));
-          }
-          return new DowngradedNode(downgradedItems, allSchemasMatched);
-        } else {
-          boolean matchedSchema = true;
-          for (JsonNode item : data) {
-            DowngradedNode downgradedNode = downgradeNode(item, itemsNode);
-            downgradedItems.add(downgradedNode.node);
-            if (!downgradedNode.matchedSchema) {
-              matchedSchema = false;
-            }
-          }
-          return new DowngradedNode(downgradedItems, matchedSchema);
-        }
-      }
+      return downgradeArrayNode(data, schema);
     } else {
+      // A primitive, non-text node never needs to be modified:
+      // Protocol v1 didn't change how booleans work
+      // And protocol v0 expects raw numbers anyway
+      // So we just check whether the schema is correct and return the node as-is.
       return new DowngradedNode(data, validator.validate(schema, data).isEmpty());
     }
   }
 
   /**
-   * Quick and dirty tuple. Used internally by {@link #downgradeNode(JsonNode, JsonNode)};
-   * callers probably only actually need the node.
-   * @param node Our attempt at downgrading the node, under the given schema
-   * @param matchedSchema Whether the original node actually matched the schema
+   * Attempt to downgrade using each oneOf option in sequence. Returns the
+   * result from downgrading using the first subschema that matches the data, or
+   * if none match, then the result of using the first subschema.
    */
-  private record DowngradedNode(JsonNode node, boolean matchedSchema) {}
+  private DowngradedNode downgradeOneofNode(JsonNode data, JsonNode schema) {
+    JsonNode schemaOptions = schema.get("oneOf");
+    if (schemaOptions.size() == 0) {
+      // If the oneOf has no options, then don't do anything interesting.
+      return new DowngradedNode(data, validator.validate(schema, data).isEmpty());
+    }
+
+    // Attempt to downgrade the node against each oneOf schema.
+    // Return the first schema that matches the data, or the first schema if none matched successfully.
+    DowngradedNode downgradedNode = null;
+    for (JsonNode maybeSchema : schemaOptions) {
+      DowngradedNode maybeDowngradedNode = downgradeNode(data, maybeSchema);
+      if (downgradedNode == null) {
+        // If this is the first subschema, then just take it
+        downgradedNode = maybeDowngradedNode;
+      } else if (!downgradedNode.matchedSchema() && maybeDowngradedNode.matchedSchema()) {
+        // Otherwise - if we've found a matching schema, then return immediately
+        downgradedNode = maybeDowngradedNode;
+        break;
+      }
+    }
+    // None of the schemas matched, so just return whatever we found first
+    return downgradedNode;
+  }
+
+  /**
+   * Downgrade a textual node. This could either be a string/date/timestamp/etc,
+   * in which case we need to do nothing. Or it could be a number/integer, in
+   * which case we should convert it to a JSON numerical node.
+   *
+   * If the data doesn't match the schema, then just return it without
+   * modification.
+   */
+  private DowngradedNode downgradeTextualNode(JsonNode data, JsonNode schema) {
+    JsonNode refNode = schema.get(REF_KEY);
+    if (refNode != null) {
+      // If this is a valid v1 schema, then we _must_ have a $ref schema.
+      String refType = refNode.asText();
+      if (JsonSchemaReferenceTypes.NUMBER_REFERENCE.equals(refType)
+          || JsonSchemaReferenceTypes.INTEGER_REFERENCE.equals(refType)) {
+        // We could do this as a try-catch, but this migration will run on every RecordMessage
+        // so it does need to be reasonably performant.
+        // Instead, we use a regex to check for numeric literals.
+        // Note that this does _not_ allow infinity/nan, even though protocol v1 _does_ allow them.
+        // This is because JSON numeric literals don't allow those values.
+        if (data.asText().matches("-?\\d+(\\.\\d+)?")) {
+          // If this string is a numeric literal, convert it to a numeric node.
+          return new DowngradedNode(Jsons.deserialize(data.asText()), true);
+        } else {
+          // Otherwise, just leave the node unchanged.
+          return new DowngradedNode(data, false);
+        }
+      } else {
+        // This is a non-numeric string (so could be a date/timestamp/etc)
+        // Run it through the validator, but don't modify the data.
+        return new DowngradedNode(data, validator.validate(schema, data).isEmpty());
+      }
+    } else {
+      // Otherwise - the schema is invalid.
+      return new DowngradedNode(data, false);
+    }
+  }
+
+  /**
+   * If data is an object, then we need to recursively downgrade all of its fields.
+   */
+  private DowngradedNode downgradeObjectNode(JsonNode data, JsonNode schema) {
+    boolean isObjectSchema;
+    // First, check whether the schema is supposed to be an object at all.
+    if (schema.hasNonNull(REF_KEY)) {
+      // If the schema uses a reference type, then it's not an object schema.
+      isObjectSchema = false;
+    } else if (schema.hasNonNull("type")) {
+      // If the schema declares {type: object} or {type: [..., object, ...]}
+      // Then this is an object schema
+      JsonNode typeNode = schema.get("type");
+      if (typeNode.isArray()) {
+        isObjectSchema = false;
+        for (JsonNode typeItem : typeNode) {
+          if ("object".equals(typeItem.asText())) {
+            isObjectSchema = true;
+          }
+        }
+      } else {
+        isObjectSchema = "object".equals(typeNode.asText());
+      }
+    } else {
+      // If the schema doesn't declare a type at all (which is bad practice, but let's handle it anyway)
+      // Then check for a properties entry, and assume that this is an object if it's present
+      isObjectSchema = schema.hasNonNull("properties");
+    }
+
+    if (!isObjectSchema) {
+      // If it's not supposed to be an object, then we can't do anything here.
+      // Return the data without modification.
+      return new DowngradedNode(data, false);
+    } else {
+      // If the schema _is_ for an object, then recurse into each field
+      ObjectNode downgradedData = (ObjectNode) Jsons.emptyObject();
+      JsonNode propertiesNode = schema.get("properties");
+
+      Iterator<Entry<String, JsonNode>> dataFields = data.fields();
+      boolean matchedSchema = true;
+      while (dataFields.hasNext()) {
+        Entry<String, JsonNode> field = dataFields.next();
+        String key = field.getKey();
+        JsonNode value = field.getValue();
+        if (propertiesNode != null && propertiesNode.hasNonNull(key)) {
+          // If we have a schema for this property, downgrade the value
+          JsonNode subschema = propertiesNode.get(key);
+          DowngradedNode downgradedNode = downgradeNode(value, subschema);
+          downgradedData.set(key, downgradedNode.node);
+          if (!downgradedNode.matchedSchema) {
+            matchedSchema = false;
+          }
+        } else {
+          // Else it's an additional property - we _could_ check additionalProperties,
+          // but that's annoying. We don't actually respect that in destinations/normalization anyway.
+          downgradedData.set(key, value);
+        }
+      }
+
+      return new DowngradedNode(downgradedData, matchedSchema);
+    }
+  }
+
+  /**
+   * Much like objects, arrays must be recursively downgraded.
+   */
+  private DowngradedNode downgradeArrayNode(JsonNode data, JsonNode schema) {
+    // Similar to objects, we first check whether this is even supposed to be an array.
+    boolean isArraySchema;
+    if (schema.hasNonNull(REF_KEY)) {
+      // If the schema uses a reference type, then it's not an array schema.
+      isArraySchema = false;
+    } else if (schema.hasNonNull("type")) {
+      // If the schema declares {type: array} or {type: [..., array, ...]}
+      // Then this is an array schema
+      JsonNode typeNode = schema.get("type");
+      if (typeNode.isArray()) {
+        isArraySchema = false;
+        for (JsonNode typeItem : typeNode) {
+          if ("array".equals(typeItem.asText())) {
+            isArraySchema = true;
+          }
+        }
+      } else {
+        isArraySchema = "array".equals(typeNode.asText());
+      }
+    } else {
+      // If the schema doesn't declare a type at all (which is bad practice, but let's handle it anyway)
+      // Then check for an items entry, and assume that this is an array if it's present
+      isArraySchema = schema.hasNonNull("items");
+    }
+
+    if (!isArraySchema) {
+      return new DowngradedNode(data, false);
+    } else {
+      ArrayNode downgradedItems = Jsons.arrayNode();
+      JsonNode itemsNode = schema.get("items");
+      if (itemsNode == null) {
+        // We _could_ check additionalItems, but much like the additionalProperties comment for objects:
+        // it's a lot of work for no payoff
+        return new DowngradedNode(data, true);
+      } else if (itemsNode.isArray()) {
+        // In the case of {items: [schema1, schema2, ...]}
+        // We need to check schema1 against the first element of the array,
+        // schema2 against the second element, etc.
+        boolean allSchemasMatched = true;
+        for (int i = 0; i < data.size(); i++) {
+          JsonNode element = data.get(i);
+          if (itemsNode.size() > i) {
+            // If we have a schema for this element, then try downgrading the element
+            DowngradedNode downgradedElement = downgradeNode(element, itemsNode.get(i));
+            if (!downgradedElement.matchedSchema()) {
+              allSchemasMatched = false;
+            }
+            downgradedItems.add(downgradedElement.node());
+          }
+        }
+        // If there were more elements in `data` than there were schemas in `itemsNode`,
+        // then just blindly add the rest of those elements.
+        for (int i = itemsNode.size(); i < data.size(); i++) {
+          downgradedItems.add(data.get(i));
+        }
+        return new DowngradedNode(downgradedItems, allSchemasMatched);
+      } else {
+        // IN the case of {items: schema}, we just check every array element against that schema.
+        boolean matchedSchema = true;
+        for (JsonNode item : data) {
+          DowngradedNode downgradedNode = downgradeNode(item, itemsNode);
+          downgradedItems.add(downgradedNode.node);
+          if (!downgradedNode.matchedSchema) {
+            matchedSchema = false;
+          }
+        }
+        return new DowngradedNode(downgradedItems, matchedSchema);
+      }
+    }
+  }
 
   @Override
   public Version getPreviousVersion() {

--- a/airbyte-commons-protocol/src/main/java/io/airbyte/commons/protocol/migrations/AirbyteMessageMigrationV1.java
+++ b/airbyte-commons-protocol/src/main/java/io/airbyte/commons/protocol/migrations/AirbyteMessageMigrationV1.java
@@ -543,11 +543,6 @@ public class AirbyteMessageMigrationV1 implements AirbyteMessageMigration<io.air
           return new DowngradedNode(data, validator.validate(schema, data).isEmpty());
         }
       } else {
-        JsonNode typeNode = schema.get("type");
-        boolean matchesSchema = true;
-        if (typeNode != null) {
-          // TODO check whether textual node is of the correct type
-        }
         return new DowngradedNode(data, validator.validate(schema, data).isEmpty());
       }
     } else if (data.isObject()) {
@@ -668,7 +663,6 @@ public class AirbyteMessageMigrationV1 implements AirbyteMessageMigration<io.air
         }
       }
     } else {
-      // TODO check whether non-textual node (i.e. number/boolean?) is of the correct type
       return new DowngradedNode(data, validator.validate(schema, data).isEmpty());
     }
   }

--- a/airbyte-commons-protocol/src/main/java/io/airbyte/commons/protocol/migrations/AirbyteMessageMigrationV1.java
+++ b/airbyte-commons-protocol/src/main/java/io/airbyte/commons/protocol/migrations/AirbyteMessageMigrationV1.java
@@ -6,7 +6,6 @@ package io.airbyte.commons.protocol.migrations;
 
 import static io.airbyte.protocol.models.JsonSchemaReferenceTypes.REF_KEY;
 
-import com.amazonaws.util.NumberUtils;
 import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.node.ArrayNode;
 import com.fasterxml.jackson.databind.node.ObjectNode;
@@ -31,7 +30,6 @@ import java.util.Optional;
 import java.util.function.Consumer;
 import java.util.function.Function;
 import java.util.stream.StreamSupport;
-import org.apache.logging.log4j.util.Strings;
 
 public class AirbyteMessageMigrationV1 implements AirbyteMessageMigration<io.airbyte.protocol.models.v0.AirbyteMessage, AirbyteMessage> {
 
@@ -499,11 +497,11 @@ public class AirbyteMessageMigrationV1 implements AirbyteMessageMigration<io.air
   }
 
   /**
-   * Quick and dirty tuple. Used internally by {@link #downgradeNode(JsonNode, JsonNode)};
-   * callers probably only actually need the node.
+   * Quick and dirty tuple. Used internally by {@link #downgradeNode(JsonNode, JsonNode)}; callers
+   * probably only actually need the node.
    *
-   * matchedSchema is useful for downgrading using a oneOf schema, where we need
-   * to recognize the correct subschema.
+   * matchedSchema is useful for downgrading using a oneOf schema, where we need to recognize the
+   * correct subschema.
    *
    * @param node Our attempt at downgrading the node, under the given schema
    * @param matchedSchema Whether the original node actually matched the schema
@@ -511,16 +509,16 @@ public class AirbyteMessageMigrationV1 implements AirbyteMessageMigration<io.air
   private record DowngradedNode(JsonNode node, boolean matchedSchema) {}
 
   /**
-   * We need the schema to recognize which fields are integers, since it would
-   * be wrong to just assume any numerical string should be parsed out.
+   * We need the schema to recognize which fields are integers, since it would be wrong to just assume
+   * any numerical string should be parsed out.
    *
-   * Works on a best-effort basis. If the schema doesn't match the data, we'll
-   * do our best to downgrade anything that we can definitively say is a number.
-   * Should _not_ throw an exception if bad things happen (e.g. we try to parse
-   * a non-numerical string as a number).
+   * Works on a best-effort basis. If the schema doesn't match the data, we'll do our best to
+   * downgrade anything that we can definitively say is a number. Should _not_ throw an exception if
+   * bad things happen (e.g. we try to parse a non-numerical string as a number).
    */
   private DowngradedNode downgradeNode(JsonNode data, JsonNode schema) {
-    // If this is a oneOf node that looks like an upgraded v0 message, then we need to handle each oneOf case.
+    // If this is a oneOf node that looks like an upgraded v0 message, then we need to handle each oneOf
+    // case.
     if (!schema.hasNonNull(REF_KEY) && !schema.hasNonNull("type") && schema.hasNonNull("oneOf")) {
       return downgradeOneofNode(data, schema);
     }
@@ -541,9 +539,9 @@ public class AirbyteMessageMigrationV1 implements AirbyteMessageMigration<io.air
   }
 
   /**
-   * Attempt to downgrade using each oneOf option in sequence. Returns the
-   * result from downgrading using the first subschema that matches the data, or
-   * if none match, then the result of using the first subschema.
+   * Attempt to downgrade using each oneOf option in sequence. Returns the result from downgrading
+   * using the first subschema that matches the data, or if none match, then the result of using the
+   * first subschema.
    */
   private DowngradedNode downgradeOneofNode(JsonNode data, JsonNode schema) {
     JsonNode schemaOptions = schema.get("oneOf");
@@ -571,12 +569,11 @@ public class AirbyteMessageMigrationV1 implements AirbyteMessageMigration<io.air
   }
 
   /**
-   * Downgrade a textual node. This could either be a string/date/timestamp/etc,
-   * in which case we need to do nothing. Or it could be a number/integer, in
-   * which case we should convert it to a JSON numerical node.
+   * Downgrade a textual node. This could either be a string/date/timestamp/etc, in which case we need
+   * to do nothing. Or it could be a number/integer, in which case we should convert it to a JSON
+   * numerical node.
    *
-   * If the data doesn't match the schema, then just return it without
-   * modification.
+   * If the data doesn't match the schema, then just return it without modification.
    */
   private DowngradedNode downgradeTextualNode(JsonNode data, JsonNode schema) {
     JsonNode refNode = schema.get(REF_KEY);

--- a/airbyte-commons-protocol/src/main/java/io/airbyte/commons/protocol/migrations/AirbyteMessageMigrationV1.java
+++ b/airbyte-commons-protocol/src/main/java/io/airbyte/commons/protocol/migrations/AirbyteMessageMigrationV1.java
@@ -19,7 +19,6 @@ import io.airbyte.protocol.models.JsonSchemaReferenceTypes;
 import io.airbyte.protocol.models.AirbyteMessage;
 import io.airbyte.protocol.models.AirbyteMessage.Type;
 import io.airbyte.protocol.models.AirbyteStream;
-import io.airbyte.protocol.models.v0.AirbyteRecordMessage;
 import io.airbyte.validation.json.JsonSchemaValidator;
 import java.util.ArrayList;
 import java.util.Iterator;
@@ -52,7 +51,7 @@ public class AirbyteMessageMigrationV1 implements AirbyteMessageMigration<io.air
         downgradeSchema(schema);
       }
     } else if (oldMessage.getType() == Type.RECORD) {
-      AirbyteRecordMessage record = newMessage.getRecord();
+      io.airbyte.protocol.models.v0.AirbyteRecordMessage record = newMessage.getRecord();
       Optional<ConfiguredAirbyteStream> maybeStream = catalog.getStreams().stream()
           .filter(stream -> Objects.equals(stream.getStream().getName(), record.getStream())
               && Objects.equals(stream.getStream().getNamespace(), record.getNamespace()))

--- a/airbyte-commons-protocol/src/main/java/io/airbyte/commons/protocol/migrations/AirbyteMessageMigrationV1.java
+++ b/airbyte-commons-protocol/src/main/java/io/airbyte/commons/protocol/migrations/AirbyteMessageMigrationV1.java
@@ -11,6 +11,7 @@ import com.fasterxml.jackson.databind.node.TextNode;
 import io.airbyte.commons.json.Jsons;
 import io.airbyte.commons.version.AirbyteProtocolVersion;
 import io.airbyte.commons.version.Version;
+import io.airbyte.protocol.models.ConfiguredAirbyteCatalog;
 import io.airbyte.protocol.models.JsonSchemaReferenceTypes;
 import io.airbyte.protocol.models.AirbyteMessage;
 import io.airbyte.protocol.models.AirbyteStream;
@@ -23,6 +24,12 @@ import java.util.function.Function;
 import java.util.stream.StreamSupport;
 
 public class AirbyteMessageMigrationV1 implements AirbyteMessageMigration<io.airbyte.protocol.models.v0.AirbyteMessage, AirbyteMessage> {
+
+  private ConfiguredAirbyteCatalog catalog;
+
+  public AirbyteMessageMigrationV1(ConfiguredAirbyteCatalog catalog) {
+    this.catalog = catalog;
+  }
 
   @Override
   public io.airbyte.protocol.models.v0.AirbyteMessage downgrade(AirbyteMessage oldMessage) {

--- a/airbyte-commons-protocol/src/test/java/io/airbyte/commons/protocol/migrations/V0ToV1MigrationTest.java
+++ b/airbyte-commons-protocol/src/test/java/io/airbyte/commons/protocol/migrations/V0ToV1MigrationTest.java
@@ -20,7 +20,8 @@ public class V0ToV1MigrationTest {
 
   @BeforeEach
   public void setup() {
-    migration = new AirbyteMessageMigrationV1();
+    // TODO write catalog
+    migration = new AirbyteMessageMigrationV1(null);
   }
 
   @Test

--- a/airbyte-commons-protocol/src/test/java/io/airbyte/commons/protocol/migrations/V0ToV1MigrationTest.java
+++ b/airbyte-commons-protocol/src/test/java/io/airbyte/commons/protocol/migrations/V0ToV1MigrationTest.java
@@ -1334,6 +1334,9 @@ public class V0ToV1MigrationTest {
                       "id": {"$ref": "WellKnownTypes.json#/definitions/Integer"},
                       "name": {"$ref": "WellKnownTypes.json#/definitions/String"}
                     }
+                  },
+                  "empty_oneof": {
+                    "oneOf": []
                   }
                 }
               }
@@ -1350,7 +1353,8 @@ public class V0ToV1MigrationTest {
             },
             "typeless_array": ["42"],
             "arr_obj_union1": [{"id": "42", "name": "arst"}, {"id": "43", "name": "qwfp"}],
-            "arr_obj_union2": {"id": "42", "name": "arst"}
+            "arr_obj_union2": {"id": "42", "name": "arst"},
+            "empty_oneof": "42"
           }
           """);
 
@@ -1373,7 +1377,8 @@ public class V0ToV1MigrationTest {
                 },
                 "typeless_array": [42],
                 "arr_obj_union1": [{"id": 42, "name": "arst"}, {"id": 43, "name": "qwfp"}],
-                "arr_obj_union2": {"id": 42, "name": "arst"}
+                "arr_obj_union2": {"id": 42, "name": "arst"},
+                "empty_oneof": "42"
               }
             }
           }

--- a/airbyte-commons-protocol/src/test/java/io/airbyte/commons/protocol/migrations/V0ToV1MigrationTest.java
+++ b/airbyte-commons-protocol/src/test/java/io/airbyte/commons/protocol/migrations/V0ToV1MigrationTest.java
@@ -1022,28 +1022,30 @@ public class V0ToV1MigrationTest {
                   }
                 ]
               },
-              "nullable_multityped_field": {
-                "oneOf": [
-                  {"$ref": "WellKnownTypes.json#/definitions/String"},
-                  {
-                    "type": "array",
-                    "items": [
-                      {"$ref": "WellKnownTypes.json#/definitions/String"},
-                      {"$ref": "WellKnownTypes.json#/definitions/Integer"}
-                    ]
-                  },
-                  {
-                    "type": "object",
-                    "properties": {
-                      "id": {"$ref": "WellKnownTypes.json#/definitions/Integer"}
-                    }
-                  }
-                ]
-              },
               "multityped_date_field": {
                 "oneOf": [
                   {"$ref": "WellKnownTypes.json#/definitions/Date"},
                   {"$ref": "WellKnownTypes.json#/definitions/Integer"}
+                ]
+              },
+              "boolean_field": {
+                "oneOf": [
+                  true,
+                  {"$ref": "WellKnownTypes.json#/definitions/String"},
+                  false
+                ]
+              },
+              "conflicting_field": {
+                "oneOf": [
+                  {"type": "object", "properties": {"id": {"$ref": "WellKnownTypes.json#/definitions/String"}}},
+                  {"type": "object", "properties": {"name": {"$ref": "WellKnownTypes.json#/definitions/String"}}},
+                  {"$ref": "WellKnownTypes.json#/definitions/String"}
+                ]
+              },
+              "conflicting_primitives": {
+                "oneOf": [
+                  {"$ref": "WellKnownTypes.json#/definitions/TimestampWithoutTimezone"},
+                  {"$ref": "WellKnownTypes.json#/definitions/TimestampWithTimezone"}
                 ]
               }
             }
@@ -1070,16 +1072,29 @@ public class V0ToV1MigrationTest {
                 "additionalItems": {"type": "string"},
                 "contains": {"type": "string"}
               },
-              "nullable_multityped_field": {
-                "type": ["string", "array", "object"],
-                "items": [{"type": "string"}, {"type": "integer"}],
-                "properties": {
-                  "id": {"type": "integer"}
-                }
-              },
               "multityped_date_field": {
                 "type": ["string", "integer"],
                 "format": "date"
+              },
+              "boolean_field": {
+                "oneOf": [
+                  true,
+                  {"type": "string"},
+                  false
+                ]
+              },
+              "conflicting_field": {
+                "oneOf": [
+                  {"type": "object", "properties": {"id": {"type": "string"}}},
+                  {"type": "object", "properties": {"name": {"type": "string"}}},
+                  {"type": "string"}
+                ]
+              },
+              "conflicting_primitives": {
+                "oneOf": [
+                  {"type": "string", "format": "date-time", "airbyte_type": "timestamp_without_timezone"},
+                  {"type": "string", "format": "date-time", "airbyte_type": "timestamp_with_timezone"}
+                ]
               }
             }
           }
@@ -1087,27 +1102,16 @@ public class V0ToV1MigrationTest {
       assertEquals(expectedSchema, downgradedMessage.getCatalog().getStreams().get(0).getJsonSchema());
     }
 
-    // TODO better method name + field names
     @Test
-    public void testSomething() {
+    public void testDowngradeWeirdSchemas() {
+      // old_style_schema isn't actually valid (i.e. v1 schemas should always be using $ref)
+      // but we should check that it behaves well anyway
       JsonNode oldSchema = Jsons.deserialize(
           """
           {
             "type": "object",
             "properties": {
-              "a": {
-                "type": ["object", "array"],
-                "properties": {
-                  "a": {"$ref": "WellKnownTypes.json#/definitions/String"}
-                },
-                "items": [{"$ref": "WellKnownTypes.json#/definitions/String"}]
-              },
-              "b": {
-                "oneOf": [
-                  true,
-                  {"$ref": "WellKnownTypes.json#/definitions/String"}
-                ]
-              }
+              "old_style_schema": {"type": "string"}
             }
           }
           """);
@@ -1119,19 +1123,7 @@ public class V0ToV1MigrationTest {
           {
             "type": "object",
             "properties": {
-              "a": {
-                "type": ["object", "array"],
-                "properties": {
-                  "a": {"type": "string"}
-                },
-                "items": [{"type": "string"}]
-              },
-              "b": {
-                "oneOf": [
-                  true,
-                  {"type": "string"}
-                ]
-              }
+              "old_style_schema": {"type": "string"}
             }
           }
           """);

--- a/airbyte-commons-protocol/src/test/java/io/airbyte/commons/protocol/migrations/V0ToV1MigrationTest.java
+++ b/airbyte-commons-protocol/src/test/java/io/airbyte/commons/protocol/migrations/V0ToV1MigrationTest.java
@@ -713,7 +713,7 @@ public class V0ToV1MigrationTest {
     }
 
     @Test
-    public void testUpgradeAllPrimitives() {
+    public void testDowngradeAllPrimitives() {
       doTest(
           """
           {

--- a/airbyte-commons-protocol/src/test/java/io/airbyte/commons/protocol/migrations/V0ToV1MigrationTest.java
+++ b/airbyte-commons-protocol/src/test/java/io/airbyte/commons/protocol/migrations/V0ToV1MigrationTest.java
@@ -1204,12 +1204,20 @@ public class V0ToV1MigrationTest {
                   "object": {
                     "type": "object",
                     "properties": {
-                      "int": {"$ref": "WellKnownTypes.json#/definitions/Integer"}
+                      "int": {"$ref": "WellKnownTypes.json#/definitions/Integer"},
+                      "arr": {
+                        "type": "array",
+                        "items": {"$ref": "WellKnownTypes.json#/definitions/Integer"}
+                      }
                     }
                   },
                   "array": {
                     "type": "array",
                     "items": {"$ref": "WellKnownTypes.json#/definitions/Integer"}
+                  },
+                  "array_multitype": {
+                    "type": "array",
+                    "items": [{"$ref": "WellKnownTypes.json#/definitions/Integer"}, {"$ref": "WellKnownTypes.json#/definitions/String"}]
                   }
                 }
               }
@@ -1226,6 +1234,7 @@ public class V0ToV1MigrationTest {
               "int": "42"
             },
             "array": ["42"],
+            "array_multitype": ["42", "42"],
             "additionalProperty": "42"
           }
           """);
@@ -1249,6 +1258,7 @@ public class V0ToV1MigrationTest {
                   "int": 42
                 },
                 "array": [42],
+                "array_multitype": [42, "42"],
                 "additionalProperty": "42"
               }
             }
@@ -1276,6 +1286,34 @@ public class V0ToV1MigrationTest {
                     "properties": {
                       "foo": {"$ref": "WellKnownTypes.json#/definitions/Integer"}
                     }
+                  },
+                  "arr_obj_union1": {
+                    "type": ["array", "object"],
+                    "items": {
+                      "type": "object",
+                      "properties": {
+                        "id": {"$ref": "WellKnownTypes.json#/definitions/Integer"},
+                        "name": {"$ref": "WellKnownTypes.json#/definitions/String"}
+                      }
+                    },
+                    "properties": {
+                      "id": {"$ref": "WellKnownTypes.json#/definitions/Integer"},
+                      "name": {"$ref": "WellKnownTypes.json#/definitions/String"}
+                    }
+                  },
+                  "arr_obj_union2": {
+                    "type": ["array", "object"],
+                    "items": {
+                      "type": "object",
+                      "properties": {
+                        "id": {"$ref": "WellKnownTypes.json#/definitions/Integer"},
+                        "name": {"$ref": "WellKnownTypes.json#/definitions/String"}
+                      }
+                    },
+                    "properties": {
+                      "id": {"$ref": "WellKnownTypes.json#/definitions/Integer"},
+                      "name": {"$ref": "WellKnownTypes.json#/definitions/String"}
+                    }
                   }
                 }
               }
@@ -1289,7 +1327,9 @@ public class V0ToV1MigrationTest {
             "bad_int": "foo",
             "typeless_object": {
               "foo": "42"
-            }
+            },
+            "arr_obj_union1": [{"id": "42", "name": "arst"}, {"id": "43", "name": "qwfp"}],
+            "arr_obj_union2": {"id": "42", "name": "arst"}
           }
           """);
 
@@ -1309,7 +1349,9 @@ public class V0ToV1MigrationTest {
                 "bad_int": "foo",
                 "typeless_object": {
                   "foo": 42
-                }
+                },
+                "arr_obj_union1": [{"id": 42, "name": "arst"}, {"id": 43, "name": "qwfp"}],
+                "arr_obj_union2": {"id": 42, "name": "arst"}
               }
             }
           }

--- a/airbyte-commons-protocol/src/test/java/io/airbyte/commons/protocol/migrations/V0ToV1MigrationTest.java
+++ b/airbyte-commons-protocol/src/test/java/io/airbyte/commons/protocol/migrations/V0ToV1MigrationTest.java
@@ -1199,7 +1199,7 @@ public class V0ToV1MigrationTest {
                  "properties": {
                   "int": {"$ref": "WellKnownTypes.json#/definitions/Integer"},
                   "num": {"$ref": "WellKnownTypes.json#/definitions/Number"},
-                  "string": {"$ref": "WellKnownTypes.json#/definitions/String"},
+                  "binary": {"$ref": "WellKnownTypes.json#/definitions/BinaryData"},
                   "bool": {"$ref": "WellKnownTypes.json#/definitions/Boolean"},
                   "object": {
                     "type": "object",

--- a/airbyte-commons-protocol/src/test/java/io/airbyte/commons/protocol/migrations/V0ToV1MigrationTest.java
+++ b/airbyte-commons-protocol/src/test/java/io/airbyte/commons/protocol/migrations/V0ToV1MigrationTest.java
@@ -648,7 +648,7 @@ public class V0ToV1MigrationTest {
       // but this test case is mostly about preserving the message structure, so it's not super relevant
       JsonNode newSchema = Jsons.deserialize("""
                                              {
-                                               "type": "string"
+                                               "$ref": "WellKnownTypes.json#/definitions/String"
                                              }
                                              """);
 
@@ -661,7 +661,7 @@ public class V0ToV1MigrationTest {
                                                              "streams": [
                                                                {
                                                                  "json_schema": {
-                                                                   "$ref": "WellKnownTypes.json#/definitions/String"
+                                                                   "type": "string"
                                                                  }
                                                                }
                                                              ]

--- a/airbyte-commons-protocol/src/test/java/io/airbyte/commons/protocol/migrations/V0ToV1MigrationTest.java
+++ b/airbyte-commons-protocol/src/test/java/io/airbyte/commons/protocol/migrations/V0ToV1MigrationTest.java
@@ -1,4 +1,4 @@
-  /*
+/*
  * Copyright (c) 2022 Airbyte, Inc., all rights reserved.
  */
 
@@ -1045,8 +1045,7 @@ public class V0ToV1MigrationTest {
                   {"$ref": "WellKnownTypes.json#/definitions/Date"},
                   {"$ref": "WellKnownTypes.json#/definitions/Integer"}
                 ]
-              },
-              "sneaky_singletype_field": {"$ref": "WellKnownTypes.json#/definitions/TimestampWithTimezone"}
+              }
             }
           }
           """);
@@ -1072,7 +1071,7 @@ public class V0ToV1MigrationTest {
                 "contains": {"type": "string"}
               },
               "nullable_multityped_field": {
-                "type": ["null", "string", "array", "object"],
+                "type": ["string", "array", "object"],
                 "items": [{"type": "string"}, {"type": "integer"}],
                 "properties": {
                   "id": {"type": "integer"}
@@ -1081,10 +1080,6 @@ public class V0ToV1MigrationTest {
               "multityped_date_field": {
                 "type": ["string", "integer"],
                 "format": "date"
-              },
-              "sneaky_singletype_field": {
-                "type": ["string", "null"],
-                "format": "date-time"
               }
             }
           }

--- a/airbyte-commons-protocol/src/test/java/io/airbyte/commons/protocol/migrations/V0ToV1MigrationTest.java
+++ b/airbyte-commons-protocol/src/test/java/io/airbyte/commons/protocol/migrations/V0ToV1MigrationTest.java
@@ -745,6 +745,9 @@ public class V0ToV1MigrationTest {
               },
               "example_date": {
                 "$ref": "WellKnownTypes.json#/definitions/Date"
+              },
+              "example_binary": {
+                "$ref": "WellKnownTypes.json#/definitions/BinaryData"
               }
             }
           }
@@ -788,6 +791,10 @@ public class V0ToV1MigrationTest {
               "example_date": {
                 "type": "string",
                 "format": "date"
+              },
+              "example_binary": {
+                "type": "string",
+                "contentEncoding": "base64"
               }
             }
           }

--- a/airbyte-commons-protocol/src/test/java/io/airbyte/commons/protocol/migrations/V0ToV1MigrationTest.java
+++ b/airbyte-commons-protocol/src/test/java/io/airbyte/commons/protocol/migrations/V0ToV1MigrationTest.java
@@ -1,4 +1,4 @@
-/*
+  /*
  * Copyright (c) 2022 Airbyte, Inc., all rights reserved.
  */
 
@@ -39,252 +39,258 @@ public class V0ToV1MigrationTest {
     public void testBasicUpgrade() {
       // This isn't actually a valid stream schema (since it's not an object)
       // but this test case is mostly about preserving the message structure, so it's not super relevant
-      JsonNode oldSchema = Jsons.deserialize("""
-                                             {
-                                               "type": "string"
-                                             }
-                                             """);
+      JsonNode oldSchema = Jsons.deserialize(
+          """
+          {
+            "type": "string"
+          }
+          """);
 
       AirbyteMessage upgradedMessage = migration.upgrade(createCatalogMessage(oldSchema));
 
-      AirbyteMessage expectedMessage = Jsons.deserialize("""
-                                                         {
-                                                           "type": "CATALOG",
-                                                           "catalog": {
-                                                             "streams": [
-                                                               {
-                                                                 "json_schema": {
-                                                                   "$ref": "WellKnownTypes.json#/definitions/String"
-                                                                 }
-                                                               }
-                                                             ]
-                                                           }
-                                                         }
-                                                         """,
+      AirbyteMessage expectedMessage = Jsons.deserialize(
+          """
+          {
+            "type": "CATALOG",
+            "catalog": {
+              "streams": [
+                {
+                  "json_schema": {
+                    "$ref": "WellKnownTypes.json#/definitions/String"
+                  }
+                }
+              ]
+            }
+          }
+          """,
           AirbyteMessage.class);
       assertEquals(expectedMessage, upgradedMessage);
     }
 
     @Test
     public void testUpgradeAllPrimitives() {
-      JsonNode oldSchema = Jsons.deserialize("""
-                                             {
-                                               "type": "object",
-                                               "properties": {
-                                                 "example_string": {
-                                                   "type": "string"
-                                                 },
-                                                 "example_number": {
-                                                   "type": "number"
-                                                 },
-                                                 "example_integer": {
-                                                   "type": "integer"
-                                                 },
-                                                 "example_airbyte_integer": {
-                                                   "type": "number",
-                                                   "airbyte_type": "integer"
-                                                 },
-                                                 "example_boolean": {
-                                                   "type": "boolean"
-                                                 },
-                                                 "example_timestamptz": {
-                                                   "type": "string",
-                                                   "format": "date-time",
-                                                   "airbyte_type": "timestamp_with_timezone"
-                                                 },
-                                                 "example_timestamptz_implicit": {
-                                                   "type": "string",
-                                                   "format": "date-time"
-                                                 },
-                                                 "example_timestamp_without_tz": {
-                                                   "type": "string",
-                                                   "format": "date-time",
-                                                   "airbyte_type": "timestamp_without_timezone"
-                                                 },
-                                                 "example_timez": {
-                                                   "type": "string",
-                                                   "format": "time",
-                                                   "airbyte_type": "time_with_timezone"
-                                                 },
-                                                 "example_timetz_implicit": {
-                                                   "type": "string",
-                                                   "format": "time"
-                                                 },
-                                                 "example_time_without_tz": {
-                                                   "type": "string",
-                                                   "format": "time",
-                                                   "airbyte_type": "time_without_timezone"
-                                                 },
-                                                 "example_date": {
-                                                   "type": "string",
-                                                   "format": "date"
-                                                 },
-                                                 "example_binary": {
-                                                   "type": "string",
-                                                   "contentEncoding": "base64"
-                                                 }
-                                               }
-                                             }
-                                             """);
+      JsonNode oldSchema = Jsons.deserialize(
+          """
+          {
+            "type": "object",
+            "properties": {
+              "example_string": {
+                "type": "string"
+              },
+              "example_number": {
+                "type": "number"
+              },
+              "example_integer": {
+                "type": "integer"
+              },
+              "example_airbyte_integer": {
+                "type": "number",
+                "airbyte_type": "integer"
+              },
+              "example_boolean": {
+                "type": "boolean"
+              },
+              "example_timestamptz": {
+                "type": "string",
+                "format": "date-time",
+                "airbyte_type": "timestamp_with_timezone"
+              },
+              "example_timestamptz_implicit": {
+                "type": "string",
+                "format": "date-time"
+              },
+              "example_timestamp_without_tz": {
+                "type": "string",
+                "format": "date-time",
+                "airbyte_type": "timestamp_without_timezone"
+              },
+              "example_timez": {
+                "type": "string",
+                "format": "time",
+                "airbyte_type": "time_with_timezone"
+              },
+              "example_timetz_implicit": {
+                "type": "string",
+                "format": "time"
+              },
+              "example_time_without_tz": {
+                "type": "string",
+                "format": "time",
+                "airbyte_type": "time_without_timezone"
+              },
+              "example_date": {
+                "type": "string",
+                "format": "date"
+              },
+             "example_binary": {
+               "type": "string",
+               "contentEncoding": "base64"
+             }
+            }
+          }
+          """);
 
       AirbyteMessage upgradedMessage = migration.upgrade(createCatalogMessage(oldSchema));
 
-      JsonNode expectedSchema = Jsons.deserialize("""
-                                                  {
-                                                    "type": "object",
-                                                    "properties": {
-                                                      "example_string": {
-                                                        "$ref": "WellKnownTypes.json#/definitions/String"
-                                                      },
-                                                      "example_number": {
-                                                        "$ref": "WellKnownTypes.json#/definitions/Number"
-                                                      },
-                                                      "example_integer": {
-                                                        "$ref": "WellKnownTypes.json#/definitions/Integer"
-                                                      },
-                                                      "example_airbyte_integer": {
-                                                        "$ref": "WellKnownTypes.json#/definitions/Integer"
-                                                      },
-                                                      "example_boolean": {
-                                                        "$ref": "WellKnownTypes.json#/definitions/Boolean"
-                                                      },
-                                                      "example_timestamptz": {
-                                                        "$ref": "WellKnownTypes.json#/definitions/TimestampWithTimezone"
-                                                      },
-                                                      "example_timestamptz_implicit": {
-                                                        "$ref": "WellKnownTypes.json#/definitions/TimestampWithTimezone"
-                                                      },
-                                                      "example_timestamp_without_tz": {
-                                                        "$ref": "WellKnownTypes.json#/definitions/TimestampWithoutTimezone"
-                                                      },
-                                                      "example_timez": {
-                                                        "$ref": "WellKnownTypes.json#/definitions/TimeWithTimezone"
-                                                      },
-                                                      "example_timetz_implicit": {
-                                                        "$ref": "WellKnownTypes.json#/definitions/TimeWithTimezone"
-                                                      },
-                                                      "example_time_without_tz": {
-                                                        "$ref": "WellKnownTypes.json#/definitions/TimeWithoutTimezone"
-                                                      },
-                                                      "example_date": {
-                                                        "$ref": "WellKnownTypes.json#/definitions/Date"
-                                                      },
-                                                      "example_binary": {
-                                                        "$ref": "WellKnownTypes.json#/definitions/BinaryData"
-                                                      }
-                                                    }
-                                                  }
-                                                  """);
+      JsonNode expectedSchema = Jsons.deserialize(
+          """
+          {
+            "type": "object",
+            "properties": {
+              "example_string": {
+                "$ref": "WellKnownTypes.json#/definitions/String"
+              },
+              "example_number": {
+                "$ref": "WellKnownTypes.json#/definitions/Number"
+              },
+              "example_integer": {
+                "$ref": "WellKnownTypes.json#/definitions/Integer"
+              },
+              "example_airbyte_integer": {
+                "$ref": "WellKnownTypes.json#/definitions/Integer"
+              },
+              "example_boolean": {
+                "$ref": "WellKnownTypes.json#/definitions/Boolean"
+              },
+              "example_timestamptz": {
+                "$ref": "WellKnownTypes.json#/definitions/TimestampWithTimezone"
+              },
+              "example_timestamptz_implicit": {
+                "$ref": "WellKnownTypes.json#/definitions/TimestampWithTimezone"
+              },
+              "example_timestamp_without_tz": {
+                "$ref": "WellKnownTypes.json#/definitions/TimestampWithoutTimezone"
+              },
+              "example_timez": {
+                "$ref": "WellKnownTypes.json#/definitions/TimeWithTimezone"
+              },
+              "example_timetz_implicit": {
+                "$ref": "WellKnownTypes.json#/definitions/TimeWithTimezone"
+              },
+              "example_time_without_tz": {
+                "$ref": "WellKnownTypes.json#/definitions/TimeWithoutTimezone"
+              },
+              "example_date": {
+                "$ref": "WellKnownTypes.json#/definitions/Date"
+              },
+              "example_binary": {
+                "$ref": "WellKnownTypes.json#/definitions/BinaryData"
+              }
+            }
+          }
+          """);
       assertEquals(expectedSchema, upgradedMessage.getCatalog().getStreams().get(0).getJsonSchema());
     }
 
     @Test
     public void testUpgradeNestedFields() {
-      JsonNode oldSchema = Jsons.deserialize("""
-                                             {
-                                               "type": "object",
-                                               "properties": {
-                                                 "basic_array": {
-                                                   "items": {"type": "string"}
-                                                 },
-                                                 "tuple_array": {
-                                                   "items": [
-                                                     {"type": "string"},
-                                                     {"type": "integer"}
-                                                   ],
-                                                   "additionalItems": {"type": "string"},
-                                                   "contains": {"type": "integer"}
-                                                 },
-                                                 "nested_object": {
-                                                   "properties": {
-                                                     "id": {"type": "integer"},
-                                                     "nested_oneof": {
-                                                       "oneOf": [
-                                                         {"type": "string"},
-                                                         {"type": "integer"}
-                                                       ]
-                                                     },
-                                                     "nested_anyof": {
-                                                       "anyOf": [
-                                                         {"type": "string"},
-                                                         {"type": "integer"}
-                                                       ]
-                                                     },
-                                                     "nested_allof": {
-                                                       "allOf": [
-                                                         {"type": "string"},
-                                                         {"type": "integer"}
-                                                       ]
-                                                     },
-                                                     "nested_not": {
-                                                       "not": [
-                                                         {"type": "string"},
-                                                         {"type": "integer"}
-                                                       ]
-                                                     }
-                                                   },
-                                                   "patternProperties": {
-                                                     "integer_.*": {"type": "integer"}
-                                                   },
-                                                   "additionalProperties": {"type": "string"}
-                                                 }
-                                               }
-                                             }
-                                             """);
+      JsonNode oldSchema = Jsons.deserialize(
+          """
+          {
+            "type": "object",
+            "properties": {
+              "basic_array": {
+                "items": {"type": "string"}
+              },
+              "tuple_array": {
+                "items": [
+                  {"type": "string"},
+                  {"type": "integer"}
+                ],
+                "additionalItems": {"type": "string"},
+                "contains": {"type": "integer"}
+              },
+              "nested_object": {
+                "properties": {
+                  "id": {"type": "integer"},
+                  "nested_oneof": {
+                    "oneOf": [
+                      {"type": "string"},
+                      {"type": "integer"}
+                    ]
+                  },
+                  "nested_anyof": {
+                    "anyOf": [
+                      {"type": "string"},
+                      {"type": "integer"}
+                    ]
+                  },
+                  "nested_allof": {
+                    "allOf": [
+                      {"type": "string"},
+                      {"type": "integer"}
+                    ]
+                  },
+                  "nested_not": {
+                    "not": [
+                      {"type": "string"},
+                      {"type": "integer"}
+                    ]
+                  }
+                },
+                "patternProperties": {
+                  "integer_.*": {"type": "integer"}
+                },
+                "additionalProperties": {"type": "string"}
+              }
+            }
+          }
+          """);
 
       AirbyteMessage upgradedMessage = migration.upgrade(createCatalogMessage(oldSchema));
 
-      JsonNode expectedSchema = Jsons.deserialize("""
-                                                  {
-                                                    "type": "object",
-                                                    "properties": {
-                                                      "basic_array": {
-                                                        "items": {"$ref": "WellKnownTypes.json#/definitions/String"}
-                                                      },
-                                                      "tuple_array": {
-                                                        "items": [
-                                                          {"$ref": "WellKnownTypes.json#/definitions/String"},
-                                                          {"$ref": "WellKnownTypes.json#/definitions/Integer"}
-                                                        ],
-                                                        "additionalItems": {"$ref": "WellKnownTypes.json#/definitions/String"},
-                                                        "contains": {"$ref": "WellKnownTypes.json#/definitions/Integer"}
-                                                      },
-                                                      "nested_object": {
-                                                        "properties": {
-                                                          "id": {"$ref": "WellKnownTypes.json#/definitions/Integer"},
-                                                          "nested_oneof": {
-                                                            "oneOf": [
-                                                              {"$ref": "WellKnownTypes.json#/definitions/String"},
-                                                              {"$ref": "WellKnownTypes.json#/definitions/Integer"}
-                                                            ]
-                                                          },
-                                                          "nested_anyof": {
-                                                            "anyOf": [
-                                                              {"$ref": "WellKnownTypes.json#/definitions/String"},
-                                                              {"$ref": "WellKnownTypes.json#/definitions/Integer"}
-                                                            ]
-                                                          },
-                                                          "nested_allof": {
-                                                            "allOf": [
-                                                              {"$ref": "WellKnownTypes.json#/definitions/String"},
-                                                              {"$ref": "WellKnownTypes.json#/definitions/Integer"}
-                                                            ]
-                                                          },
-                                                          "nested_not": {
-                                                            "not": [
-                                                              {"$ref": "WellKnownTypes.json#/definitions/String"},
-                                                              {"$ref": "WellKnownTypes.json#/definitions/Integer"}
-                                                            ]
-                                                          }
-                                                        },
-                                                        "patternProperties": {
-                                                          "integer_.*": {"$ref": "WellKnownTypes.json#/definitions/Integer"}
-                                                        },
-                                                        "additionalProperties": {"$ref": "WellKnownTypes.json#/definitions/String"}
-                                                      }
-                                                    }
-                                                  }
-                                                  """);
+      JsonNode expectedSchema = Jsons.deserialize(
+          """
+          {
+            "type": "object",
+            "properties": {
+              "basic_array": {
+                "items": {"$ref": "WellKnownTypes.json#/definitions/String"}
+              },
+              "tuple_array": {
+                "items": [
+                  {"$ref": "WellKnownTypes.json#/definitions/String"},
+                  {"$ref": "WellKnownTypes.json#/definitions/Integer"}
+                ],
+                "additionalItems": {"$ref": "WellKnownTypes.json#/definitions/String"},
+                "contains": {"$ref": "WellKnownTypes.json#/definitions/Integer"}
+              },
+              "nested_object": {
+                "properties": {
+                  "id": {"$ref": "WellKnownTypes.json#/definitions/Integer"},
+                  "nested_oneof": {
+                    "oneOf": [
+                      {"$ref": "WellKnownTypes.json#/definitions/String"},
+                      {"$ref": "WellKnownTypes.json#/definitions/Integer"}
+                    ]
+                  },
+                  "nested_anyof": {
+                    "anyOf": [
+                      {"$ref": "WellKnownTypes.json#/definitions/String"},
+                      {"$ref": "WellKnownTypes.json#/definitions/Integer"}
+                    ]
+                  },
+                  "nested_allof": {
+                    "allOf": [
+                      {"$ref": "WellKnownTypes.json#/definitions/String"},
+                      {"$ref": "WellKnownTypes.json#/definitions/Integer"}
+                    ]
+                  },
+                  "nested_not": {
+                    "not": [
+                      {"$ref": "WellKnownTypes.json#/definitions/String"},
+                      {"$ref": "WellKnownTypes.json#/definitions/Integer"}
+                    ]
+                  }
+                },
+                "patternProperties": {
+                  "integer_.*": {"$ref": "WellKnownTypes.json#/definitions/Integer"}
+                },
+                "additionalProperties": {"$ref": "WellKnownTypes.json#/definitions/String"}
+              }
+            }
+          }
+          """);
       assertEquals(expectedSchema, upgradedMessage.getCatalog().getStreams().get(0).getJsonSchema());
     }
 
@@ -400,131 +406,135 @@ public class V0ToV1MigrationTest {
       // i.e. it will disregard the option for a boolean.
       // Generating this sort of schema is just wrong; sources shouldn't do this to begin with. But let's
       // verify that we behave mostly correctly here.
-      JsonNode oldSchema = Jsons.deserialize("""
-                                             {
-                                               "type": "object",
-                                               "properties": {
-                                                 "bad_timestamptz": {
-                                                   "type": ["boolean", "string"],
-                                                   "format": "date-time",
-                                                   "airbyte_type": "timestamp_with_timezone"
-                                                 },
-                                                 "bad_integer": {
-                                                   "type": "string",
-                                                   "format": "date-time",
-                                                   "airbyte_type": "integer"
-                                                 }
-                                               }
-                                             }
-                                             """);
+      JsonNode oldSchema = Jsons.deserialize(
+          """
+          {
+            "type": "object",
+            "properties": {
+              "bad_timestamptz": {
+                "type": ["boolean", "string"],
+                "format": "date-time",
+                "airbyte_type": "timestamp_with_timezone"
+              },
+              "bad_integer": {
+                "type": "string",
+                "format": "date-time",
+                "airbyte_type": "integer"
+              }
+            }
+          }
+          """);
 
       AirbyteMessage upgradedMessage = migration.upgrade(createCatalogMessage(oldSchema));
 
-      JsonNode expectedSchema = Jsons.deserialize("""
-                                                  {
-                                                    "type": "object",
-                                                    "properties": {
-                                                      "bad_timestamptz": {"$ref": "WellKnownTypes.json#/definitions/TimestampWithTimezone"},
-                                                      "bad_integer": {"$ref": "WellKnownTypes.json#/definitions/Integer"}
-                                                    }
-                                                  }
-                                                  """);
+      JsonNode expectedSchema = Jsons.deserialize(
+          """
+          {
+            "type": "object",
+            "properties": {
+              "bad_timestamptz": {"$ref": "WellKnownTypes.json#/definitions/TimestampWithTimezone"},
+              "bad_integer": {"$ref": "WellKnownTypes.json#/definitions/Integer"}
+            }
+          }
+          """);
       assertEquals(expectedSchema, upgradedMessage.getCatalog().getStreams().get(0).getJsonSchema());
     }
 
     @Test
     public void testUpgradeMultiTypeFields() {
-      JsonNode oldSchema = Jsons.deserialize("""
-                                             {
-                                               "type": "object",
-                                               "properties": {
-                                                 "multityped_field": {
-                                                   "type": ["string", "object", "array"],
-                                                   "properties": {
-                                                     "id": {"type": "string"}
-                                                   },
-                                                   "patternProperties": {
-                                                     "integer_.*": {"type": "integer"}
-                                                   },
-                                                   "additionalProperties": {"type": "string"},
-                                                   "items": {"type": "string"},
-                                                   "additionalItems": {"type": "string"},
-                                                   "contains": {"type": "string"}
-                                                 },
-                                                 "nullable_multityped_field": {
-                                                   "type": ["null", "string", "array", "object"],
-                                                   "items": [{"type": "string"}, {"type": "integer"}],
-                                                   "properties": {
-                                                     "id": {"type": "integer"}
-                                                   }
-                                                 },
-                                                 "multityped_date_field": {
-                                                   "type": ["string", "integer"],
-                                                   "format": "date"
-                                                 },
-                                                 "sneaky_singletype_field": {
-                                                   "type": ["string", "null"],
-                                                   "format": "date-time"
-                                                 }
-                                               }
-                                             }
-                                             """);
+      JsonNode oldSchema = Jsons.deserialize(
+          """
+          {
+            "type": "object",
+            "properties": {
+              "multityped_field": {
+                "type": ["string", "object", "array"],
+                "properties": {
+                  "id": {"type": "string"}
+                },
+                "patternProperties": {
+                  "integer_.*": {"type": "integer"}
+                },
+                "additionalProperties": {"type": "string"},
+                "items": {"type": "string"},
+                "additionalItems": {"type": "string"},
+                "contains": {"type": "string"}
+              },
+              "nullable_multityped_field": {
+                "type": ["null", "string", "array", "object"],
+                "items": [{"type": "string"}, {"type": "integer"}],
+                "properties": {
+                  "id": {"type": "integer"}
+                }
+              },
+              "multityped_date_field": {
+                "type": ["string", "integer"],
+                "format": "date"
+              },
+              "sneaky_singletype_field": {
+                "type": ["string", "null"],
+                "format": "date-time"
+              }
+            }
+          }
+          """);
 
       AirbyteMessage upgradedMessage = migration.upgrade(createCatalogMessage(oldSchema));
 
-      JsonNode expectedSchema = Jsons.deserialize("""
-                                                  {
-                                                    "type": "object",
-                                                    "properties": {
-                                                      "multityped_field": {
-                                                        "oneOf": [
-                                                          {"$ref": "WellKnownTypes.json#/definitions/String"},
-                                                          {
-                                                            "type": "object",
-                                                            "properties": {
-                                                              "id": {"$ref": "WellKnownTypes.json#/definitions/String"}
-                                                            },
-                                                            "patternProperties": {
-                                                              "integer_.*": {"$ref": "WellKnownTypes.json#/definitions/Integer"}
-                                                            },
-                                                            "additionalProperties": {"$ref": "WellKnownTypes.json#/definitions/String"}
-                                                          },
-                                                          {
-                                                            "type": "array",
-                                                            "items": {"$ref": "WellKnownTypes.json#/definitions/String"},
-                                                            "additionalItems": {"$ref": "WellKnownTypes.json#/definitions/String"},
-                                                            "contains": {"$ref": "WellKnownTypes.json#/definitions/String"}
-                                                          }
-                                                        ]
-                                                      },
-                                                      "nullable_multityped_field": {
-                                                        "oneOf": [
-                                                          {"$ref": "WellKnownTypes.json#/definitions/String"},
-                                                          {
-                                                            "type": "array",
-                                                            "items": [
-                                                              {"$ref": "WellKnownTypes.json#/definitions/String"},
-                                                              {"$ref": "WellKnownTypes.json#/definitions/Integer"}
-                                                            ]
-                                                          },
-                                                          {
-                                                            "type": "object",
-                                                            "properties": {
-                                                              "id": {"$ref": "WellKnownTypes.json#/definitions/Integer"}
-                                                            }
-                                                          }
-                                                        ]
-                                                      },
-                                                      "multityped_date_field": {
-                                                        "oneOf": [
-                                                          {"$ref": "WellKnownTypes.json#/definitions/Date"},
-                                                          {"$ref": "WellKnownTypes.json#/definitions/Integer"}
-                                                        ]
-                                                      },
-                                                      "sneaky_singletype_field": {"$ref": "WellKnownTypes.json#/definitions/TimestampWithTimezone"}
-                                                    }
-                                                  }
-                                                  """);
+      JsonNode expectedSchema = Jsons.deserialize(
+          """
+          {
+            "type": "object",
+            "properties": {
+              "multityped_field": {
+                "oneOf": [
+                  {"$ref": "WellKnownTypes.json#/definitions/String"},
+                  {
+                    "type": "object",
+                    "properties": {
+                      "id": {"$ref": "WellKnownTypes.json#/definitions/String"}
+                    },
+                    "patternProperties": {
+                      "integer_.*": {"$ref": "WellKnownTypes.json#/definitions/Integer"}
+                    },
+                    "additionalProperties": {"$ref": "WellKnownTypes.json#/definitions/String"}
+                  },
+                  {
+                    "type": "array",
+                    "items": {"$ref": "WellKnownTypes.json#/definitions/String"},
+                    "additionalItems": {"$ref": "WellKnownTypes.json#/definitions/String"},
+                    "contains": {"$ref": "WellKnownTypes.json#/definitions/String"}
+                  }
+                ]
+              },
+              "nullable_multityped_field": {
+                "oneOf": [
+                  {"$ref": "WellKnownTypes.json#/definitions/String"},
+                  {
+                    "type": "array",
+                    "items": [
+                      {"$ref": "WellKnownTypes.json#/definitions/String"},
+                      {"$ref": "WellKnownTypes.json#/definitions/Integer"}
+                    ]
+                  },
+                  {
+                    "type": "object",
+                    "properties": {
+                      "id": {"$ref": "WellKnownTypes.json#/definitions/Integer"}
+                    }
+                  }
+                ]
+              },
+              "multityped_date_field": {
+                "oneOf": [
+                  {"$ref": "WellKnownTypes.json#/definitions/Date"},
+                  {"$ref": "WellKnownTypes.json#/definitions/Integer"}
+                ]
+              },
+              "sneaky_singletype_field": {"$ref": "WellKnownTypes.json#/definitions/TimestampWithTimezone"}
+            }
+          }
+          """);
       assertEquals(expectedSchema, upgradedMessage.getCatalog().getStreams().get(0).getJsonSchema());
     }
 
@@ -551,89 +561,95 @@ public class V0ToV1MigrationTest {
 
     @Test
     public void testBasicUpgrade() {
-      JsonNode oldData = Jsons.deserialize("""
-                                           {
-                                             "id": 42
-                                           }
-                                           """);
+      JsonNode oldData = Jsons.deserialize(
+          """
+          {
+            "id": 42
+          }
+          """);
 
       AirbyteMessage upgradedMessage = migration.upgrade(createRecordMessage(oldData));
 
-      AirbyteMessage expectedMessage = Jsons.deserialize("""
-                                                         {
-                                                           "type": "RECORD",
-                                                           "record": {
-                                                             "data": {
-                                                               "id": "42"
-                                                             }
-                                                           }
-                                                         }
-                                                         """,
+      AirbyteMessage expectedMessage = Jsons.deserialize(
+          """
+          {
+            "type": "RECORD",
+            "record": {
+              "data": {
+                "id": "42"
+              }
+            }
+          }
+          """,
           AirbyteMessage.class);
       assertEquals(expectedMessage, upgradedMessage);
     }
 
     @Test
     public void testNestedUpgrade() {
-      JsonNode oldData = Jsons.deserialize("""
-                                           {
-                                             "int": 42,
-                                             "float": 42.0,
-                                             "float2": 42.2,
-                                             "sub_object": {
-                                               "sub_int": 42,
-                                               "sub_float": 42.0,
-                                               "sub_float2": 42.2
-                                             },
-                                             "sub_array": [42, 42.0, 42.2]
-                                           }
-                                           """);
+      JsonNode oldData = Jsons.deserialize(
+          """
+          {
+            "int": 42,
+            "float": 42.0,
+            "float2": 42.2,
+            "sub_object": {
+              "sub_int": 42,
+              "sub_float": 42.0,
+              "sub_float2": 42.2
+            },
+            "sub_array": [42, 42.0, 42.2]
+          }
+          """);
 
       AirbyteMessage upgradedMessage = migration.upgrade(createRecordMessage(oldData));
 
-      JsonNode expectedData = Jsons.deserialize("""
-                                                {
-                                                  "int": "42",
-                                                  "float": "42.0",
-                                                  "float2": "42.2",
-                                                  "sub_object": {
-                                                    "sub_int": "42",
-                                                    "sub_float": "42.0",
-                                                    "sub_float2": "42.2"
-                                                  },
-                                                  "sub_array": ["42", "42.0", "42.2"]
-                                                }
-                                                """);
+      JsonNode expectedData = Jsons.deserialize(
+          """
+          {
+            "int": "42",
+            "float": "42.0",
+            "float2": "42.2",
+            "sub_object": {
+              "sub_int": "42",
+              "sub_float": "42.0",
+              "sub_float2": "42.2"
+            },
+            "sub_array": ["42", "42.0", "42.2"]
+          }
+          """);
       assertEquals(expectedData, upgradedMessage.getRecord().getData());
     }
 
     @Test
     public void testNonUpgradableValues() {
-      JsonNode oldData = Jsons.deserialize("""
-                                           {
-                                             "boolean": true,
-                                             "string": "arst",
-                                             "sub_object": {
-                                               "boolean": true,
-                                               "string": "arst"
-                                             },
-                                             "sub_array": [true, "arst"]
-                                           }
-                                           """);
+      JsonNode oldData = Jsons.deserialize(
+          """
+          {
+            "boolean": true,
+            "string": "arst",
+            "sub_object": {
+              "boolean": true,
+              "string": "arst"
+            },
+            "sub_array": [true, "arst"]
+          }
+          """);
 
       AirbyteMessage upgradedMessage = migration.upgrade(createRecordMessage(oldData));
 
-      JsonNode expectedData = Jsons.deserialize("""
-                                                {
-                                                  "boolean": true,
-                                                  "string": "arst",
-                                                  "sub_object": {
-                                                    "boolean": true,
-                                                    "string": "arst"
-                                                  },
-                                                  "sub_array": [true, "arst"]
-                                                }
-                                                """);
+      JsonNode expectedData = Jsons.deserialize(
+          """
+          {
+            "boolean": true,
+            "string": "arst",
+            "sub_object": {
+              "boolean": true,
+              "string": "arst"
+            },
+            "sub_array": [true, "arst"]
+          }
+          """);
       assertEquals(expectedData, upgradedMessage.getRecord().getData());
     }
 
@@ -646,224 +662,230 @@ public class V0ToV1MigrationTest {
     public void testBasicDowngrade() {
       // This isn't actually a valid stream schema (since it's not an object)
       // but this test case is mostly about preserving the message structure, so it's not super relevant
-      JsonNode newSchema = Jsons.deserialize("""
-                                             {
-                                               "$ref": "WellKnownTypes.json#/definitions/String"
-                                             }
-                                             """);
+      JsonNode newSchema = Jsons.deserialize(
+          """
+          {
+            "$ref": "WellKnownTypes.json#/definitions/String"
+          }
+          """);
 
       io.airbyte.protocol.models.v0.AirbyteMessage downgradedMessage = migration.downgrade(createCatalogMessage(newSchema));
 
-      io.airbyte.protocol.models.v0.AirbyteMessage expectedMessage = Jsons.deserialize("""
-                                                                                       {
-                                                                                         "type": "CATALOG",
-                                                                                         "catalog": {
-                                                                                           "streams": [
-                                                                                             {
-                                                                                               "json_schema": {
-                                                                                                 "type": "string"
-                                                                                               }
-                                                                                             }
-                                                                                           ]
-                                                                                         }
-                                                                                       }
-                                                                                       """,
+      io.airbyte.protocol.models.v0.AirbyteMessage expectedMessage = Jsons.deserialize(
+          """
+          {
+            "type": "CATALOG",
+            "catalog": {
+              "streams": [
+                {
+                  "json_schema": {
+                    "type": "string"
+                  }
+                }
+              ]
+            }
+          }
+          """,
           io.airbyte.protocol.models.v0.AirbyteMessage.class);
       assertEquals(expectedMessage, downgradedMessage);
     }
 
     @Test
     public void testUpgradeAllPrimitives() {
-      JsonNode oldSchema = Jsons.deserialize("""
-                                             {
-                                               "type": "object",
-                                               "properties": {
-                                                 "example_string": {
-                                                   "$ref": "WellKnownTypes.json#/definitions/String"
-                                                 },
-                                                 "example_number": {
-                                                   "$ref": "WellKnownTypes.json#/definitions/Number"
-                                                 },
-                                                 "example_integer": {
-                                                   "$ref": "WellKnownTypes.json#/definitions/Integer"
-                                                 },
-                                                 "example_boolean": {
-                                                   "$ref": "WellKnownTypes.json#/definitions/Boolean"
-                                                 },
-                                                 "example_timestamptz": {
-                                                   "$ref": "WellKnownTypes.json#/definitions/TimestampWithTimezone"
-                                                 },
-                                                 "example_timestamp_without_tz": {
-                                                   "$ref": "WellKnownTypes.json#/definitions/TimestampWithoutTimezone"
-                                                 },
-                                                 "example_timez": {
-                                                   "$ref": "WellKnownTypes.json#/definitions/TimeWithTimezone"
-                                                 },
-                                                 "example_time_without_tz": {
-                                                   "$ref": "WellKnownTypes.json#/definitions/TimeWithoutTimezone"
-                                                 },
-                                                 "example_date": {
-                                                   "$ref": "WellKnownTypes.json#/definitions/Date"
-                                                 }
-                                               }
-                                             }
-                                             """);
+      JsonNode oldSchema = Jsons.deserialize(
+          """
+          {
+            "type": "object",
+            "properties": {
+              "example_string": {
+                "$ref": "WellKnownTypes.json#/definitions/String"
+              },
+              "example_number": {
+                "$ref": "WellKnownTypes.json#/definitions/Number"
+              },
+              "example_integer": {
+                "$ref": "WellKnownTypes.json#/definitions/Integer"
+              },
+              "example_boolean": {
+                "$ref": "WellKnownTypes.json#/definitions/Boolean"
+              },
+              "example_timestamptz": {
+                "$ref": "WellKnownTypes.json#/definitions/TimestampWithTimezone"
+              },
+              "example_timestamp_without_tz": {
+                "$ref": "WellKnownTypes.json#/definitions/TimestampWithoutTimezone"
+              },
+              "example_timez": {
+                "$ref": "WellKnownTypes.json#/definitions/TimeWithTimezone"
+              },
+              "example_time_without_tz": {
+                "$ref": "WellKnownTypes.json#/definitions/TimeWithoutTimezone"
+              },
+              "example_date": {
+                "$ref": "WellKnownTypes.json#/definitions/Date"
+              }
+            }
+          }
+          """);
 
       io.airbyte.protocol.models.v0.AirbyteMessage downgradedMessage = migration.downgrade(createCatalogMessage(oldSchema));
 
-      JsonNode expectedSchema = Jsons.deserialize("""
-                                                  {
-                                                    "type": "object",
-                                                    "properties": {
-                                                      "example_string": {
-                                                        "type": "string"
-                                                      },
-                                                      "example_number": {
-                                                        "type": "number"
-                                                      },
-                                                      "example_integer": {
-                                                        "type": "integer"
-                                                      },
-                                                      "example_boolean": {
-                                                        "type": "boolean"
-                                                      },
-                                                      "example_timestamptz": {
-                                                        "type": "string",
-                                                        "airbyte_type": "timestamp_with_timezone",
-                                                        "format": "date-time"
-                                                      },
-                                                      "example_timestamp_without_tz": {
-                                                        "type": "string",
-                                                        "airbyte_type": "timestamp_without_timezone",
-                                                        "format": "date-time"
-                                                      },
-                                                      "example_timez": {
-                                                        "type": "string",
-                                                        "airbyte_type": "time_with_timezone",
-                                                        "format": "time"
-                                                      },
-                                                      "example_time_without_tz": {
-                                                        "type": "string",
-                                                        "airbyte_type": "time_without_timezone",
-                                                        "format": "time"
-                                                      },
-                                                      "example_date": {
-                                                        "type": "string",
-                                                        "format": "date"
-                                                      }
-                                                    }
-                                                  }
-                                                  """);
+      JsonNode expectedSchema = Jsons.deserialize(
+          """
+          {
+            "type": "object",
+            "properties": {
+              "example_string": {
+                "type": "string"
+              },
+              "example_number": {
+                "type": "number"
+              },
+              "example_integer": {
+                "type": "integer"
+              },
+              "example_boolean": {
+                "type": "boolean"
+              },
+              "example_timestamptz": {
+                "type": "string",
+                "airbyte_type": "timestamp_with_timezone",
+                "format": "date-time"
+              },
+              "example_timestamp_without_tz": {
+                "type": "string",
+                "airbyte_type": "timestamp_without_timezone",
+                "format": "date-time"
+              },
+              "example_timez": {
+                "type": "string",
+                "airbyte_type": "time_with_timezone",
+                "format": "time"
+              },
+              "example_time_without_tz": {
+                "type": "string",
+                "airbyte_type": "time_without_timezone",
+                "format": "time"
+              },
+              "example_date": {
+                "type": "string",
+                "format": "date"
+              }
+            }
+          }
+          """);
       assertEquals(expectedSchema, downgradedMessage.getCatalog().getStreams().get(0).getJsonSchema());
     }
 
     @Test
     public void testDowngradeNestedFields() {
-      JsonNode oldSchema = Jsons.deserialize("""
-                                                  {
-                                                    "type": "object",
-                                                    "properties": {
-                                                      "basic_array": {
-                                                        "items": {"$ref": "WellKnownTypes.json#/definitions/String"}
-                                                      },
-                                                      "tuple_array": {
-                                                        "items": [
-                                                          {"$ref": "WellKnownTypes.json#/definitions/String"},
-                                                          {"$ref": "WellKnownTypes.json#/definitions/Integer"}
-                                                        ],
-                                                        "additionalItems": {"$ref": "WellKnownTypes.json#/definitions/String"},
-                                                        "contains": {"$ref": "WellKnownTypes.json#/definitions/Integer"}
-                                                      },
-                                                      "nested_object": {
-                                                        "properties": {
-                                                          "id": {"$ref": "WellKnownTypes.json#/definitions/Integer"},
-                                                          "nested_oneof": {
-                                                            "oneOf": [
-                                                              {"$ref": "WellKnownTypes.json#/definitions/String"},
-                                                              {"$ref": "WellKnownTypes.json#/definitions/TimestampWithTimezone"}
-                                                            ]
-                                                          },
-                                                          "nested_anyof": {
-                                                            "anyOf": [
-                                                              {"$ref": "WellKnownTypes.json#/definitions/String"},
-                                                              {"$ref": "WellKnownTypes.json#/definitions/Integer"}
-                                                            ]
-                                                          },
-                                                          "nested_allof": {
-                                                            "allOf": [
-                                                              {"$ref": "WellKnownTypes.json#/definitions/String"},
-                                                              {"$ref": "WellKnownTypes.json#/definitions/Integer"}
-                                                            ]
-                                                          },
-                                                          "nested_not": {
-                                                            "not": [
-                                                              {"$ref": "WellKnownTypes.json#/definitions/String"},
-                                                              {"$ref": "WellKnownTypes.json#/definitions/Integer"}
-                                                            ]
-                                                          }
-                                                        },
-                                                        "patternProperties": {
-                                                          "integer_.*": {"$ref": "WellKnownTypes.json#/definitions/Integer"}
-                                                        },
-                                                        "additionalProperties": {"$ref": "WellKnownTypes.json#/definitions/String"}
-                                                      }
-                                                    }
-                                                  }
-                                                  """);
+      JsonNode oldSchema = Jsons.deserialize(
+          """
+          {
+            "type": "object",
+            "properties": {
+              "basic_array": {
+                "items": {"$ref": "WellKnownTypes.json#/definitions/String"}
+              },
+              "tuple_array": {
+                "items": [
+                  {"$ref": "WellKnownTypes.json#/definitions/String"},
+                  {"$ref": "WellKnownTypes.json#/definitions/Integer"}
+                ],
+                "additionalItems": {"$ref": "WellKnownTypes.json#/definitions/String"},
+                "contains": {"$ref": "WellKnownTypes.json#/definitions/Integer"}
+              },
+              "nested_object": {
+                "properties": {
+                  "id": {"$ref": "WellKnownTypes.json#/definitions/Integer"},
+                  "nested_oneof": {
+                    "oneOf": [
+                      {"$ref": "WellKnownTypes.json#/definitions/String"},
+                      {"$ref": "WellKnownTypes.json#/definitions/TimestampWithTimezone"}
+                    ]
+                  },
+                  "nested_anyof": {
+                    "anyOf": [
+                      {"$ref": "WellKnownTypes.json#/definitions/String"},
+                      {"$ref": "WellKnownTypes.json#/definitions/Integer"}
+                    ]
+                  },
+                  "nested_allof": {
+                    "allOf": [
+                      {"$ref": "WellKnownTypes.json#/definitions/String"},
+                      {"$ref": "WellKnownTypes.json#/definitions/Integer"}
+                    ]
+                  },
+                  "nested_not": {
+                    "not": [
+                      {"$ref": "WellKnownTypes.json#/definitions/String"},
+                      {"$ref": "WellKnownTypes.json#/definitions/Integer"}
+                    ]
+                  }
+                },
+                "patternProperties": {
+                  "integer_.*": {"$ref": "WellKnownTypes.json#/definitions/Integer"}
+                },
+                "additionalProperties": {"$ref": "WellKnownTypes.json#/definitions/String"}
+              }
+            }
+          }
+          """);
 
       io.airbyte.protocol.models.v0.AirbyteMessage downgradedMessage = migration.downgrade(createCatalogMessage(oldSchema));
 
-      JsonNode expectedSchema = Jsons.deserialize("""
-                                             {
-                                               "type": "object",
-                                               "properties": {
-                                                 "basic_array": {
-                                                   "items": {"type": "string"}
-                                                 },
-                                                 "tuple_array": {
-                                                   "items": [
-                                                     {"type": "string"},
-                                                     {"type": "integer"}
-                                                   ],
-                                                   "additionalItems": {"type": "string"},
-                                                   "contains": {"type": "integer"}
-                                                 },
-                                                 "nested_object": {
-                                                   "properties": {
-                                                     "id": {"type": "integer"},
-                                                     "nested_oneof": {
-                                                       "oneOf": [
-                                                         {"type": "string"},
-                                                         {"type": "string", "format": "date-time", "airbyte_type": "timestamp_with_timezone"}
-                                                       ]
-                                                     },
-                                                     "nested_anyof": {
-                                                       "anyOf": [
-                                                         {"type": "string"},
-                                                         {"type": "integer"}
-                                                       ]
-                                                     },
-                                                     "nested_allof": {
-                                                       "allOf": [
-                                                         {"type": "string"},
-                                                         {"type": "integer"}
-                                                       ]
-                                                     },
-                                                     "nested_not": {
-                                                       "not": [
-                                                         {"type": "string"},
-                                                         {"type": "integer"}
-                                                       ]
-                                                     }
-                                                   },
-                                                   "patternProperties": {
-                                                     "integer_.*": {"type": "integer"}
-                                                   },
-                                                   "additionalProperties": {"type": "string"}
-                                                 }
-                                               }
-                                             }
-                                             """);
+      JsonNode expectedSchema = Jsons.deserialize(
+          """
+          {
+            "type": "object",
+            "properties": {
+              "basic_array": {
+                "items": {"type": "string"}
+              },
+              "tuple_array": {
+                "items": [
+                  {"type": "string"},
+                  {"type": "integer"}
+                ],
+                "additionalItems": {"type": "string"},
+                "contains": {"type": "integer"}
+              },
+              "nested_object": {
+                "properties": {
+                  "id": {"type": "integer"},
+                  "nested_oneof": {
+                    "oneOf": [
+                      {"type": "string"},
+                      {"type": "string", "format": "date-time", "airbyte_type": "timestamp_with_timezone"}
+                    ]
+                  },
+                  "nested_anyof": {
+                    "anyOf": [
+                      {"type": "string"},
+                      {"type": "integer"}
+                    ]
+                  },
+                  "nested_allof": {
+                    "allOf": [
+                      {"type": "string"},
+                      {"type": "integer"}
+                    ]
+                  },
+                  "nested_not": {
+                    "not": [
+                      {"type": "string"},
+                      {"type": "integer"}
+                    ]
+                  }
+                },
+                "patternProperties": {
+                  "integer_.*": {"type": "integer"}
+                },
+                "additionalProperties": {"type": "string"}
+              }
+            }
+          }
+          """);
       assertEquals(expectedSchema, downgradedMessage.getCatalog().getStreams().get(0).getJsonSchema());
     }
 
@@ -974,146 +996,150 @@ public class V0ToV1MigrationTest {
 
     @Test
     public void testDowngradeMultiTypeFields() {
-      JsonNode oldSchema = Jsons.deserialize("""
-                                                  {
-                                                    "type": "object",
-                                                    "properties": {
-                                                      "multityped_field": {
-                                                        "oneOf": [
-                                                          {"$ref": "WellKnownTypes.json#/definitions/String"},
-                                                          {
-                                                            "type": "object",
-                                                            "properties": {
-                                                              "id": {"$ref": "WellKnownTypes.json#/definitions/String"}
-                                                            },
-                                                            "patternProperties": {
-                                                              "integer_.*": {"$ref": "WellKnownTypes.json#/definitions/Integer"}
-                                                            },
-                                                            "additionalProperties": {"$ref": "WellKnownTypes.json#/definitions/String"}
-                                                          },
-                                                          {
-                                                            "type": "array",
-                                                            "items": {"$ref": "WellKnownTypes.json#/definitions/String"},
-                                                            "additionalItems": {"$ref": "WellKnownTypes.json#/definitions/String"},
-                                                            "contains": {"$ref": "WellKnownTypes.json#/definitions/String"}
-                                                          }
-                                                        ]
-                                                      },
-                                                      "nullable_multityped_field": {
-                                                        "oneOf": [
-                                                          {"$ref": "WellKnownTypes.json#/definitions/String"},
-                                                          {
-                                                            "type": "array",
-                                                            "items": [
-                                                              {"$ref": "WellKnownTypes.json#/definitions/String"},
-                                                              {"$ref": "WellKnownTypes.json#/definitions/Integer"}
-                                                            ]
-                                                          },
-                                                          {
-                                                            "type": "object",
-                                                            "properties": {
-                                                              "id": {"$ref": "WellKnownTypes.json#/definitions/Integer"}
-                                                            }
-                                                          }
-                                                        ]
-                                                      },
-                                                      "multityped_date_field": {
-                                                        "oneOf": [
-                                                          {"$ref": "WellKnownTypes.json#/definitions/Date"},
-                                                          {"$ref": "WellKnownTypes.json#/definitions/Integer"}
-                                                        ]
-                                                      },
-                                                      "sneaky_singletype_field": {"$ref": "WellKnownTypes.json#/definitions/TimestampWithTimezone"}
-                                                    }
-                                                  }
-                                                  """);
+      JsonNode oldSchema = Jsons.deserialize(
+          """
+          {
+            "type": "object",
+            "properties": {
+              "multityped_field": {
+                "oneOf": [
+                  {"$ref": "WellKnownTypes.json#/definitions/String"},
+                  {
+                    "type": "object",
+                    "properties": {
+                      "id": {"$ref": "WellKnownTypes.json#/definitions/String"}
+                    },
+                    "patternProperties": {
+                      "integer_.*": {"$ref": "WellKnownTypes.json#/definitions/Integer"}
+                    },
+                    "additionalProperties": {"$ref": "WellKnownTypes.json#/definitions/String"}
+                  },
+                  {
+                    "type": "array",
+                    "items": {"$ref": "WellKnownTypes.json#/definitions/String"},
+                    "additionalItems": {"$ref": "WellKnownTypes.json#/definitions/String"},
+                    "contains": {"$ref": "WellKnownTypes.json#/definitions/String"}
+                  }
+                ]
+              },
+              "nullable_multityped_field": {
+                "oneOf": [
+                  {"$ref": "WellKnownTypes.json#/definitions/String"},
+                  {
+                    "type": "array",
+                    "items": [
+                      {"$ref": "WellKnownTypes.json#/definitions/String"},
+                      {"$ref": "WellKnownTypes.json#/definitions/Integer"}
+                    ]
+                  },
+                  {
+                    "type": "object",
+                    "properties": {
+                      "id": {"$ref": "WellKnownTypes.json#/definitions/Integer"}
+                    }
+                  }
+                ]
+              },
+              "multityped_date_field": {
+                "oneOf": [
+                  {"$ref": "WellKnownTypes.json#/definitions/Date"},
+                  {"$ref": "WellKnownTypes.json#/definitions/Integer"}
+                ]
+              },
+              "sneaky_singletype_field": {"$ref": "WellKnownTypes.json#/definitions/TimestampWithTimezone"}
+            }
+          }
+          """);
 
       io.airbyte.protocol.models.v0.AirbyteMessage downgradedMessage = migration.downgrade(createCatalogMessage(oldSchema));
 
-      JsonNode expectedSchema = Jsons.deserialize("""
-                                             {
-                                               "type": "object",
-                                               "properties": {
-                                                 "multityped_field": {
-                                                   "type": ["string", "object", "array"],
-                                                   "properties": {
-                                                     "id": {"type": "string"}
-                                                   },
-                                                   "patternProperties": {
-                                                     "integer_.*": {"type": "integer"}
-                                                   },
-                                                   "additionalProperties": {"type": "string"},
-                                                   "items": {"type": "string"},
-                                                   "additionalItems": {"type": "string"},
-                                                   "contains": {"type": "string"}
-                                                 },
-                                                 "nullable_multityped_field": {
-                                                   "type": ["null", "string", "array", "object"],
-                                                   "items": [{"type": "string"}, {"type": "integer"}],
-                                                   "properties": {
-                                                     "id": {"type": "integer"}
-                                                   }
-                                                 },
-                                                 "multityped_date_field": {
-                                                   "type": ["string", "integer"],
-                                                   "format": "date"
-                                                 },
-                                                 "sneaky_singletype_field": {
-                                                   "type": ["string", "null"],
-                                                   "format": "date-time"
-                                                 }
-                                               }
-                                             }
-                                             """);
+      JsonNode expectedSchema = Jsons.deserialize(
+          """
+          {
+            "type": "object",
+            "properties": {
+              "multityped_field": {
+                "type": ["string", "object", "array"],
+                "properties": {
+                  "id": {"type": "string"}
+                },
+                "patternProperties": {
+                  "integer_.*": {"type": "integer"}
+                },
+                "additionalProperties": {"type": "string"},
+                "items": {"type": "string"},
+                "additionalItems": {"type": "string"},
+                "contains": {"type": "string"}
+              },
+              "nullable_multityped_field": {
+                "type": ["null", "string", "array", "object"],
+                "items": [{"type": "string"}, {"type": "integer"}],
+                "properties": {
+                  "id": {"type": "integer"}
+                }
+              },
+              "multityped_date_field": {
+                "type": ["string", "integer"],
+                "format": "date"
+              },
+              "sneaky_singletype_field": {
+                "type": ["string", "null"],
+                "format": "date-time"
+              }
+            }
+          }
+          """);
       assertEquals(expectedSchema, downgradedMessage.getCatalog().getStreams().get(0).getJsonSchema());
     }
 
     // TODO better method name + field names
     @Test
     public void testSomething() {
-      JsonNode oldSchema = Jsons.deserialize("""
-                                                  {
-                                                    "type": "object",
-                                                    "properties": {
-                                                      "a": {
-                                                        "type": ["object", "array"],
-                                                        "properties": {
-                                                          "a": {"$ref": "WellKnownTypes.json#/definitions/String"}
-                                                        },
-                                                        "items": [{"$ref": "WellKnownTypes.json#/definitions/String"}]
-                                                      },
-                                                      "b": {
-                                                        "oneOf": [
-                                                          true,
-                                                          {"$ref": "WellKnownTypes.json#/definitions/String"}
-                                                        ]
-                                                      }
-                                                    }
-                                                  }
-                                                  """);
+      JsonNode oldSchema = Jsons.deserialize(
+          """
+          {
+            "type": "object",
+            "properties": {
+              "a": {
+                "type": ["object", "array"],
+                "properties": {
+                  "a": {"$ref": "WellKnownTypes.json#/definitions/String"}
+                },
+                "items": [{"$ref": "WellKnownTypes.json#/definitions/String"}]
+              },
+              "b": {
+                "oneOf": [
+                  true,
+                  {"$ref": "WellKnownTypes.json#/definitions/String"}
+                ]
+              }
+            }
+          }
+          """);
 
       io.airbyte.protocol.models.v0.AirbyteMessage downgradedMessage = migration.downgrade(createCatalogMessage(oldSchema));
 
-      JsonNode expectedSchema = Jsons.deserialize("""
-                                             {
-                                               "type": "object",
-                                               "properties": {
-                                                 "a": {
-                                                   "type": ["object", "array"],
-                                                   "properties": {
-                                                     "a": {"type": "string"}
-                                                   },
-                                                   "items": [{"type": "string"}]
-                                                 },
-                                                 "b": {
-                                                   "oneOf": [
-                                                     true,
-                                                     {"type": "string"}
-                                                   ]
-                                                 }
-                                               }
-                                             }
-                                             """);
+      JsonNode expectedSchema = Jsons.deserialize(
+          """
+          {
+            "type": "object",
+            "properties": {
+              "a": {
+                "type": ["object", "array"],
+                "properties": {
+                  "a": {"type": "string"}
+                },
+                "items": [{"type": "string"}]
+              },
+              "b": {
+                "oneOf": [
+                  true,
+                  {"type": "string"}
+                ]
+              }
+            }
+          }
+          """);
       assertEquals(expectedSchema, downgradedMessage.getCatalog().getStreams().get(0).getJsonSchema());
     }
 

--- a/airbyte-commons-protocol/src/test/java/io/airbyte/commons/protocol/migrations/V0ToV1MigrationTest.java
+++ b/airbyte-commons-protocol/src/test/java/io/airbyte/commons/protocol/migrations/V0ToV1MigrationTest.java
@@ -780,7 +780,7 @@ public class V0ToV1MigrationTest {
                                                           "nested_oneof": {
                                                             "oneOf": [
                                                               {"$ref": "WellKnownTypes.json#/definitions/String"},
-                                                              {"$ref": "WellKnownTypes.json#/definitions/Integer"}
+                                                              {"$ref": "WellKnownTypes.json#/definitions/TimestampWithTimezone"}
                                                             ]
                                                           },
                                                           "nested_anyof": {
@@ -834,7 +834,7 @@ public class V0ToV1MigrationTest {
                                                      "nested_oneof": {
                                                        "oneOf": [
                                                          {"type": "string"},
-                                                         {"type": "integer"}
+                                                         {"type": "string", "format": "date-time", "airbyte_type": "timestamp_with_timezone"}
                                                        ]
                                                      },
                                                      "nested_anyof": {
@@ -1061,6 +1061,55 @@ public class V0ToV1MigrationTest {
                                                  "sneaky_singletype_field": {
                                                    "type": ["string", "null"],
                                                    "format": "date-time"
+                                                 }
+                                               }
+                                             }
+                                             """);
+      assertEquals(expectedSchema, downgradedMessage.getCatalog().getStreams().get(0).getJsonSchema());
+    }
+
+    // TODO better method name + field names
+    @Test
+    public void testSomething() {
+      JsonNode oldSchema = Jsons.deserialize("""
+                                                  {
+                                                    "type": "object",
+                                                    "properties": {
+                                                      "a": {
+                                                        "type": ["object", "array"],
+                                                        "properties": {
+                                                          "a": {"$ref": "WellKnownTypes.json#/definitions/String"}
+                                                        },
+                                                        "items": [{"$ref": "WellKnownTypes.json#/definitions/String"}]
+                                                      },
+                                                      "b": {
+                                                        "oneOf": [
+                                                          true,
+                                                          {"$ref": "WellKnownTypes.json#/definitions/String"}
+                                                        ]
+                                                      }
+                                                    }
+                                                  }
+                                                  """);
+
+      io.airbyte.protocol.models.v0.AirbyteMessage downgradedMessage = migration.downgrade(createCatalogMessage(oldSchema));
+
+      JsonNode expectedSchema = Jsons.deserialize("""
+                                             {
+                                               "type": "object",
+                                               "properties": {
+                                                 "a": {
+                                                   "type": ["object", "array"],
+                                                   "properties": {
+                                                     "a": {"type": "string"}
+                                                   },
+                                                   "items": [{"type": "string"}]
+                                                 },
+                                                 "b": {
+                                                   "oneOf": [
+                                                     true,
+                                                     {"type": "string"}
+                                                   ]
                                                  }
                                                }
                                              }

--- a/airbyte-commons-protocol/src/test/java/io/airbyte/commons/protocol/migrations/V0ToV1MigrationTest.java
+++ b/airbyte-commons-protocol/src/test/java/io/airbyte/commons/protocol/migrations/V0ToV1MigrationTest.java
@@ -734,7 +734,8 @@ public class V0ToV1MigrationTest {
                                                       },
                                                       "example_timestamp_without_tz": {
                                                         "type": "string",
-                                                        "airbyte_type": "timestamp_without_timezone"
+                                                        "airbyte_type": "timestamp_without_timezone",
+                                                        "format": "date-time"
                                                       },
                                                       "example_timez": {
                                                         "type": "string",
@@ -743,7 +744,8 @@ public class V0ToV1MigrationTest {
                                                       },
                                                       "example_time_without_tz": {
                                                         "type": "string",
-                                                        "airbyte_type": "time_without_timezone"
+                                                        "airbyte_type": "time_without_timezone",
+                                                        "format": "time"
                                                       },
                                                       "example_date": {
                                                         "type": "string",

--- a/airbyte-commons-protocol/src/test/java/io/airbyte/commons/protocol/migrations/V0ToV1MigrationTest.java
+++ b/airbyte-commons-protocol/src/test/java/io/airbyte/commons/protocol/migrations/V0ToV1MigrationTest.java
@@ -78,9 +78,24 @@ public class V0ToV1MigrationTest {
       assertEquals(expectedMessage, upgradedMessage);
     }
 
+    /**
+     * Utility method to upgrade the oldSchema, and assert that the result is equal to expectedSchema
+     *
+     * @param oldSchemaString The schema to be upgraded
+     * @param expectedSchemaString The expected schema after upgrading
+     */
+    private void doTest(String oldSchemaString, String expectedSchemaString) {
+      JsonNode oldSchema = Jsons.deserialize(oldSchemaString);
+
+      AirbyteMessage upgradedMessage = migration.upgrade(createCatalogMessage(oldSchema));
+
+      JsonNode expectedSchema = Jsons.deserialize(expectedSchemaString);
+      assertEquals(expectedSchema, upgradedMessage.getCatalog().getStreams().get(0).getJsonSchema());
+    }
+
     @Test
     public void testUpgradeAllPrimitives() {
-      JsonNode oldSchema = Jsons.deserialize(
+      doTest(
           """
           {
             "type": "object",
@@ -139,11 +154,7 @@ public class V0ToV1MigrationTest {
              }
             }
           }
-          """);
-
-      AirbyteMessage upgradedMessage = migration.upgrade(createCatalogMessage(oldSchema));
-
-      JsonNode expectedSchema = Jsons.deserialize(
+          """,
           """
           {
             "type": "object",
@@ -190,12 +201,11 @@ public class V0ToV1MigrationTest {
             }
           }
           """);
-      assertEquals(expectedSchema, upgradedMessage.getCatalog().getStreams().get(0).getJsonSchema());
     }
 
     @Test
     public void testUpgradeNestedFields() {
-      JsonNode oldSchema = Jsons.deserialize(
+      doTest(
           """
           {
             "type": "object",
@@ -246,11 +256,7 @@ public class V0ToV1MigrationTest {
               }
             }
           }
-          """);
-
-      AirbyteMessage upgradedMessage = migration.upgrade(createCatalogMessage(oldSchema));
-
-      JsonNode expectedSchema = Jsons.deserialize(
+          """,
           """
           {
             "type": "object",
@@ -302,7 +308,6 @@ public class V0ToV1MigrationTest {
             }
           }
           """);
-      assertEquals(expectedSchema, upgradedMessage.getCatalog().getStreams().get(0).getJsonSchema());
     }
 
     @Test
@@ -345,7 +350,7 @@ public class V0ToV1MigrationTest {
                               }
                             }
                             """;
-      assertUpgradeIsNoop(schemaString);
+      doTest(schemaString, schemaString);
     }
 
     @Test
@@ -388,7 +393,7 @@ public class V0ToV1MigrationTest {
                               }
                             }
                             """;
-      assertUpgradeIsNoop(schemaString);
+      doTest(schemaString, schemaString);
     }
 
     @Test
@@ -407,7 +412,7 @@ public class V0ToV1MigrationTest {
                               }
                             }
                             """;
-      assertUpgradeIsNoop(schemaString);
+      doTest(schemaString, schemaString);
     }
 
     @Test
@@ -417,7 +422,7 @@ public class V0ToV1MigrationTest {
       // i.e. it will disregard the option for a boolean.
       // Generating this sort of schema is just wrong; sources shouldn't do this to begin with. But let's
       // verify that we behave mostly correctly here.
-      JsonNode oldSchema = Jsons.deserialize(
+      doTest(
           """
           {
             "type": "object",
@@ -434,11 +439,7 @@ public class V0ToV1MigrationTest {
               }
             }
           }
-          """);
-
-      AirbyteMessage upgradedMessage = migration.upgrade(createCatalogMessage(oldSchema));
-
-      JsonNode expectedSchema = Jsons.deserialize(
+          """,
           """
           {
             "type": "object",
@@ -448,12 +449,11 @@ public class V0ToV1MigrationTest {
             }
           }
           """);
-      assertEquals(expectedSchema, upgradedMessage.getCatalog().getStreams().get(0).getJsonSchema());
     }
 
     @Test
     public void testUpgradeMultiTypeFields() {
-      JsonNode oldSchema = Jsons.deserialize(
+      doTest(
           """
           {
             "type": "object",
@@ -488,11 +488,7 @@ public class V0ToV1MigrationTest {
               }
             }
           }
-          """);
-
-      AirbyteMessage upgradedMessage = migration.upgrade(createCatalogMessage(oldSchema));
-
-      JsonNode expectedSchema = Jsons.deserialize(
+          """,
           """
           {
             "type": "object",
@@ -546,7 +542,6 @@ public class V0ToV1MigrationTest {
             }
           }
           """);
-      assertEquals(expectedSchema, upgradedMessage.getCatalog().getStreams().get(0).getJsonSchema());
     }
 
     private io.airbyte.protocol.models.v0.AirbyteMessage createCatalogMessage(JsonNode schema) {
@@ -554,15 +549,6 @@ public class V0ToV1MigrationTest {
           .withCatalog(
               new io.airbyte.protocol.models.v0.AirbyteCatalog().withStreams(List.of(new io.airbyte.protocol.models.v0.AirbyteStream().withJsonSchema(
                   schema))));
-    }
-
-    private void assertUpgradeIsNoop(String schemaString) {
-      JsonNode oldSchema = Jsons.deserialize(schemaString);
-
-      AirbyteMessage upgradedMessage = migration.upgrade(createCatalogMessage(oldSchema));
-
-      JsonNode expectedSchema = Jsons.deserialize(schemaString);
-      assertEquals(expectedSchema, upgradedMessage.getCatalog().getStreams().get(0).getJsonSchema());
     }
 
   }
@@ -596,9 +582,24 @@ public class V0ToV1MigrationTest {
       assertEquals(expectedMessage, upgradedMessage);
     }
 
+    /**
+     * Utility method to upgrade the oldData, and assert that the result is equal to expectedData
+     *
+     * @param oldDataString The data of the record to be upgraded
+     * @param expectedDataString The expected data after upgrading
+     */
+    private void doTest(String oldDataString, String expectedDataString) {
+      JsonNode oldData = Jsons.deserialize(oldDataString);
+
+      AirbyteMessage upgradedMessage = migration.upgrade(createRecordMessage(oldData));
+
+      JsonNode expectedData = Jsons.deserialize(expectedDataString);
+      assertEquals(expectedData, upgradedMessage.getRecord().getData());
+    }
+
     @Test
     public void testNestedUpgrade() {
-      JsonNode oldData = Jsons.deserialize(
+      doTest(
           """
           {
             "int": 42,
@@ -611,11 +612,7 @@ public class V0ToV1MigrationTest {
             },
             "sub_array": [42, 42.0, 42.2]
           }
-          """);
-
-      AirbyteMessage upgradedMessage = migration.upgrade(createRecordMessage(oldData));
-
-      JsonNode expectedData = Jsons.deserialize(
+          """,
           """
           {
             "int": "42",
@@ -629,12 +626,22 @@ public class V0ToV1MigrationTest {
             "sub_array": ["42", "42.0", "42.2"]
           }
           """);
-      assertEquals(expectedData, upgradedMessage.getRecord().getData());
     }
 
     @Test
     public void testNonUpgradableValues() {
-      JsonNode oldData = Jsons.deserialize(
+      doTest(
+          """
+          {
+            "boolean": true,
+            "string": "arst",
+            "sub_object": {
+              "boolean": true,
+              "string": "arst"
+            },
+            "sub_array": [true, "arst"]
+          }
+          """,
           """
           {
             "boolean": true,
@@ -646,22 +653,6 @@ public class V0ToV1MigrationTest {
             "sub_array": [true, "arst"]
           }
           """);
-
-      AirbyteMessage upgradedMessage = migration.upgrade(createRecordMessage(oldData));
-
-      JsonNode expectedData = Jsons.deserialize(
-          """
-          {
-            "boolean": true,
-            "string": "arst",
-            "sub_object": {
-              "boolean": true,
-              "string": "arst"
-            },
-            "sub_array": [true, "arst"]
-          }
-          """);
-      assertEquals(expectedData, upgradedMessage.getRecord().getData());
     }
 
     private io.airbyte.protocol.models.v0.AirbyteMessage createRecordMessage(JsonNode data) {
@@ -706,9 +697,24 @@ public class V0ToV1MigrationTest {
       assertEquals(expectedMessage, downgradedMessage);
     }
 
+    /**
+     * Utility method to downgrade the oldSchema, and assert that the result is equal to expectedSchema
+     *
+     * @param oldSchemaString The schema to be downgraded
+     * @param expectedSchemaString The expected schema after downgrading
+     */
+    private void doTest(String oldSchemaString, String expectedSchemaString) {
+      JsonNode oldSchema = Jsons.deserialize(oldSchemaString);
+
+      io.airbyte.protocol.models.v0.AirbyteMessage downgradedMessage = migration.downgrade(createCatalogMessage(oldSchema));
+
+      JsonNode expectedSchema = Jsons.deserialize(expectedSchemaString);
+      assertEquals(expectedSchema, downgradedMessage.getCatalog().getStreams().get(0).getJsonSchema());
+    }
+
     @Test
     public void testUpgradeAllPrimitives() {
-      JsonNode oldSchema = Jsons.deserialize(
+      doTest(
           """
           {
             "type": "object",
@@ -742,11 +748,7 @@ public class V0ToV1MigrationTest {
               }
             }
           }
-          """);
-
-      io.airbyte.protocol.models.v0.AirbyteMessage downgradedMessage = migration.downgrade(createCatalogMessage(oldSchema));
-
-      JsonNode expectedSchema = Jsons.deserialize(
+          """,
           """
           {
             "type": "object",
@@ -790,12 +792,11 @@ public class V0ToV1MigrationTest {
             }
           }
           """);
-      assertEquals(expectedSchema, downgradedMessage.getCatalog().getStreams().get(0).getJsonSchema());
     }
 
     @Test
     public void testDowngradeNestedFields() {
-      JsonNode oldSchema = Jsons.deserialize(
+      doTest(
           """
           {
             "type": "object",
@@ -846,11 +847,7 @@ public class V0ToV1MigrationTest {
               }
             }
           }
-          """);
-
-      io.airbyte.protocol.models.v0.AirbyteMessage downgradedMessage = migration.downgrade(createCatalogMessage(oldSchema));
-
-      JsonNode expectedSchema = Jsons.deserialize(
+          """,
           """
           {
             "type": "object",
@@ -902,7 +899,6 @@ public class V0ToV1MigrationTest {
             }
           }
           """);
-      assertEquals(expectedSchema, downgradedMessage.getCatalog().getStreams().get(0).getJsonSchema());
     }
 
     @Test
@@ -945,7 +941,7 @@ public class V0ToV1MigrationTest {
                               }
                             }
                             """;
-      assertDowngradeIsNoop(schemaString);
+      doTest(schemaString, schemaString);
     }
 
     @Test
@@ -988,7 +984,7 @@ public class V0ToV1MigrationTest {
                               }
                             }
                             """;
-      assertDowngradeIsNoop(schemaString);
+      doTest(schemaString, schemaString);
     }
 
     @Test
@@ -1007,12 +1003,12 @@ public class V0ToV1MigrationTest {
                               }
                             }
                             """;
-      assertDowngradeIsNoop(schemaString);
+      doTest(schemaString, schemaString);
     }
 
     @Test
     public void testDowngradeMultiTypeFields() {
-      JsonNode oldSchema = Jsons.deserialize(
+      doTest(
           """
           {
             "type": "object",
@@ -1066,11 +1062,7 @@ public class V0ToV1MigrationTest {
               }
             }
           }
-          """);
-
-      io.airbyte.protocol.models.v0.AirbyteMessage downgradedMessage = migration.downgrade(createCatalogMessage(oldSchema));
-
-      JsonNode expectedSchema = Jsons.deserialize(
+          """,
           """
           {
             "type": "object",
@@ -1115,14 +1107,21 @@ public class V0ToV1MigrationTest {
             }
           }
           """);
-      assertEquals(expectedSchema, downgradedMessage.getCatalog().getStreams().get(0).getJsonSchema());
     }
 
     @Test
     public void testDowngradeWeirdSchemas() {
       // old_style_schema isn't actually valid (i.e. v1 schemas should always be using $ref)
       // but we should check that it behaves well anyway
-      JsonNode oldSchema = Jsons.deserialize(
+      doTest(
+          """
+          {
+            "type": "object",
+            "properties": {
+              "old_style_schema": {"type": "string"}
+            }
+          }
+          """,
           """
           {
             "type": "object",
@@ -1131,19 +1130,6 @@ public class V0ToV1MigrationTest {
             }
           }
           """);
-
-      io.airbyte.protocol.models.v0.AirbyteMessage downgradedMessage = migration.downgrade(createCatalogMessage(oldSchema));
-
-      JsonNode expectedSchema = Jsons.deserialize(
-          """
-          {
-            "type": "object",
-            "properties": {
-              "old_style_schema": {"type": "string"}
-            }
-          }
-          """);
-      assertEquals(expectedSchema, downgradedMessage.getCatalog().getStreams().get(0).getJsonSchema());
     }
 
     private AirbyteMessage createCatalogMessage(JsonNode schema) {
@@ -1151,15 +1137,6 @@ public class V0ToV1MigrationTest {
           .withCatalog(
               new AirbyteCatalog().withStreams(List.of(new AirbyteStream().withJsonSchema(
                   schema))));
-    }
-
-    private void assertDowngradeIsNoop(String schemaString) {
-      JsonNode oldSchema = Jsons.deserialize(schemaString);
-
-      io.airbyte.protocol.models.v0.AirbyteMessage downgradedMessage = migration.downgrade(createCatalogMessage(oldSchema));
-
-      JsonNode expectedSchema = Jsons.deserialize(schemaString);
-      assertEquals(expectedSchema, downgradedMessage.getCatalog().getStreams().get(0).getJsonSchema());
     }
 
   }
@@ -1200,8 +1177,8 @@ public class V0ToV1MigrationTest {
     }
 
     /**
-     * Utility method to use the given catalog to downgrade the oldData, and assert that the result
-     * is equal to expectedDataString
+     * Utility method to use the given catalog to downgrade the oldData, and assert that the result is
+     * equal to expectedDataString
      *
      * @param schemaString The JSON schema of the record
      * @param oldDataString The data of the record to be downgraded

--- a/airbyte-commons-protocol/src/test/resources/WellKnownTypes.json
+++ b/airbyte-commons-protocol/src/test/resources/WellKnownTypes.json
@@ -1,0 +1,73 @@
+{
+  "definitions": {
+    "String": {
+      "type": "string",
+      "description": "Arbitrary text"
+    },
+    "BinaryData": {
+      "type": "string",
+      "description": "Arbitrary binary data. Represented as base64-encoded strings in the JSON transport. In the future, if we support other transports, may be encoded differently.\n",
+      "pattern": "^(?:[A-Za-z0-9+/]{4})*(?:[A-Za-z0-9+/]{2}==|[A-Za-z0-9+/]{3}=)?$"
+    },
+    "Date": {
+      "type": "string",
+      "pattern": "^\\d{4}-\\d{2}-\\d{2}( BC)?$",
+      "description": "RFC 3339\u00a75.6's full-date format, extended with BC era support"
+    },
+    "TimestampWithTimezone": {
+      "type": "string",
+      "pattern": "^\\d{4}-\\d{2}-\\d{2}T\\d{2}:\\d{2}:\\d{2}(\\.\\d+)?(Z|[+\\-]\\d{1,2}:\\d{2})( BC)?$",
+      "description": "An instant in time. Frequently simply referred to as just a timestamp, or timestamptz. Uses RFC 3339\u00a75.6's date-time format, requiring a \"T\" separator, and extended with BC era support. Note that we do _not_ accept Unix epochs here.\n"
+    },
+    "TimestampWithoutTimezone": {
+      "type": "string",
+      "pattern": "^\\d{4}-\\d{2}-\\d{2}T\\d{2}:\\d{2}:\\d{2}(\\.\\d+)?( BC)?$",
+      "description": "Also known as a localdatetime, or just datetime. Under RFC 3339\u00a75.6, this would be represented as `full-date \"T\" partial-time`, extended with BC era support.\n"
+    },
+    "TimeWithTimezone": {
+      "type": "string",
+      "pattern": "^\\d{2}:\\d{2}:\\d{2}(\\.\\d+)?(Z|[+\\-]\\d{1,2}:\\d{2})$",
+      "description": "An RFC 3339\u00a75.6 full-time"
+    },
+    "TimeWithoutTimezone": {
+      "type": "string",
+      "pattern": "^\\d{2}:\\d{2}:\\d{2}(\\.\\d+)?$",
+      "description": "An RFC 3339\u00a75.6 partial-time"
+    },
+    "Number": {
+      "type": "string",
+      "oneOf": [
+        {
+          "pattern": "-?(0|[0-9]\\d*)(\\.\\d+)?"
+        },
+        {
+          "enum": [
+            "Infinity",
+            "-Infinity",
+            "NaN"
+          ]
+        }
+      ],
+      "description": "Note the mix of regex validation for normal numbers, and enum validation for special values."
+    },
+    "Integer": {
+      "type": "string",
+      "oneOf": [
+        {
+          "pattern": "-?(0|[0-9]\\d*)"
+        },
+        {
+          "enum": [
+            "Infinity",
+            "-Infinity",
+            "NaN"
+          ]
+        }
+      ]
+    },
+    "Boolean": {
+      "type": "boolean",
+      "description": "Note the direct usage of a primitive boolean rather than string. Unlike Numbers and Integers, we don't expect unusual values  here."
+    }
+  }
+}

--- a/airbyte-commons-protocol/src/test/resources/WellKnownTypes.json
+++ b/airbyte-commons-protocol/src/test/resources/WellKnownTypes.json
@@ -41,11 +41,7 @@
           "pattern": "-?(0|[0-9]\\d*)(\\.\\d+)?"
         },
         {
-          "enum": [
-            "Infinity",
-            "-Infinity",
-            "NaN"
-          ]
+          "enum": ["Infinity", "-Infinity", "NaN"]
         }
       ],
       "description": "Note the mix of regex validation for normal numbers, and enum validation for special values."
@@ -57,11 +53,7 @@
           "pattern": "-?(0|[0-9]\\d*)"
         },
         {
-          "enum": [
-            "Infinity",
-            "-Infinity",
-            "NaN"
-          ]
+          "enum": ["Infinity", "-Infinity", "NaN"]
         }
       ]
     },

--- a/airbyte-json-validation/src/main/java/io/airbyte/validation/json/JsonSchemaValidator.java
+++ b/airbyte-json-validation/src/main/java/io/airbyte/validation/json/JsonSchemaValidator.java
@@ -58,7 +58,7 @@ public class JsonSchemaValidator {
    * @param baseUri The base URI for schema resolution
    */
   @VisibleForTesting
-  protected JsonSchemaValidator(URI baseUri) {
+  public JsonSchemaValidator(URI baseUri) {
     this.jsonSchemaFactory = JsonSchemaFactory.getInstance(SpecVersion.VersionFlag.V7);
     this.baseUri = baseUri;
   }

--- a/airbyte-protocol/protocol-models/src/main/java/io/airbyte/protocol/models/JsonSchemaReferenceTypes.java
+++ b/airbyte-protocol/protocol-models/src/main/java/io/airbyte/protocol/models/JsonSchemaReferenceTypes.java
@@ -55,7 +55,7 @@ public class JsonSchemaReferenceTypes {
           """),
       TIMESTAMP_WITHOUT_TIMEZONE_REFERENCE, (ObjectNode) Jsons.deserialize(
           """
-          {"type": "string", "airbyte_type": "timestamp_without_timezone"}
+          {"type": "string", "airbyte_type": "timestamp_without_timezone", "format": "date-time"}
           """),
       TIME_WITH_TIMEZONE_REFERENCE, (ObjectNode) Jsons.deserialize(
           """
@@ -63,7 +63,7 @@ public class JsonSchemaReferenceTypes {
           """),
       TIME_WITHOUT_TIMEZONE_REFERENCE, (ObjectNode) Jsons.deserialize(
           """
-          {"type": "string", "airbyte_type": "time_without_timezone"}
+          {"type": "string", "airbyte_type": "time_without_timezone", "format": "time"}
           """),
       DATE_REFERENCE, (ObjectNode) Jsons.deserialize(
           """

--- a/airbyte-protocol/protocol-models/src/main/java/io/airbyte/protocol/models/JsonSchemaReferenceTypes.java
+++ b/airbyte-protocol/protocol-models/src/main/java/io/airbyte/protocol/models/JsonSchemaReferenceTypes.java
@@ -17,16 +17,17 @@ public class JsonSchemaReferenceTypes {
       "integer",
       "boolean");
 
-  public static final String STRING_REFERENCE = "WellKnownTypes.json#/definitions/String";
-  public static final String BINARY_DATA_REFERENCE = "WellKnownTypes.json#/definitions/BinaryData";
-  public static final String NUMBER_REFERENCE = "WellKnownTypes.json#/definitions/Number";
-  public static final String INTEGER_REFERENCE = "WellKnownTypes.json#/definitions/Integer";
-  public static final String BOOLEAN_REFERENCE = "WellKnownTypes.json#/definitions/Boolean";
-  public static final String DATE_REFERENCE = "WellKnownTypes.json#/definitions/Date";
-  public static final String TIMESTAMP_WITH_TIMEZONE_REFERENCE = "WellKnownTypes.json#/definitions/TimestampWithTimezone";
-  public static final String TIMESTAMP_WITHOUT_TIMEZONE_REFERENCE = "WellKnownTypes.json#/definitions/TimestampWithoutTimezone";
-  public static final String TIME_WITH_TIMEZONE_REFERENCE = "WellKnownTypes.json#/definitions/TimeWithTimezone";
-  public static final String TIME_WITHOUT_TIMEZONE_REFERENCE = "WellKnownTypes.json#/definitions/TimeWithoutTimezone";
+  public static final String WELL_KNOWN_TYPES_FILENAME = "WellKnownTypes.json";
+  public static final String STRING_REFERENCE = WELL_KNOWN_TYPES_FILENAME + "#/definitions/String";
+  public static final String BINARY_DATA_REFERENCE = WELL_KNOWN_TYPES_FILENAME + "#/definitions/BinaryData";
+  public static final String NUMBER_REFERENCE = WELL_KNOWN_TYPES_FILENAME + "#/definitions/Number";
+  public static final String INTEGER_REFERENCE = WELL_KNOWN_TYPES_FILENAME + "#/definitions/Integer";
+  public static final String BOOLEAN_REFERENCE = WELL_KNOWN_TYPES_FILENAME + "#/definitions/Boolean";
+  public static final String DATE_REFERENCE = WELL_KNOWN_TYPES_FILENAME + "#/definitions/Date";
+  public static final String TIMESTAMP_WITH_TIMEZONE_REFERENCE = WELL_KNOWN_TYPES_FILENAME + "#/definitions/TimestampWithTimezone";
+  public static final String TIMESTAMP_WITHOUT_TIMEZONE_REFERENCE = WELL_KNOWN_TYPES_FILENAME + "#/definitions/TimestampWithoutTimezone";
+  public static final String TIME_WITH_TIMEZONE_REFERENCE = WELL_KNOWN_TYPES_FILENAME + "#/definitions/TimeWithTimezone";
+  public static final String TIME_WITHOUT_TIMEZONE_REFERENCE = WELL_KNOWN_TYPES_FILENAME + "#/definitions/TimeWithoutTimezone";
 
   /**
    * This is primarily useful for migrating from protocol v0 to v1. It provides a mapping from the old

--- a/airbyte-protocol/protocol-models/src/main/java/io/airbyte/protocol/models/JsonSchemaReferenceTypes.java
+++ b/airbyte-protocol/protocol-models/src/main/java/io/airbyte/protocol/models/JsonSchemaReferenceTypes.java
@@ -4,7 +4,6 @@
 
 package io.airbyte.protocol.models;
 
-import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.node.ObjectNode;
 import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.ImmutableSet;
@@ -49,34 +48,45 @@ public class JsonSchemaReferenceTypes {
       "date", DATE_REFERENCE);
 
   public static final Map<String, ObjectNode> REFERENCE_TYPE_TO_OLD_TYPE = ImmutableMap.of(
-      TIMESTAMP_WITH_TIMEZONE_REFERENCE, (ObjectNode) Jsons.deserialize("""
-          {"type": "string", "airbyte_type": "timestamp_with_timezone"}
+      TIMESTAMP_WITH_TIMEZONE_REFERENCE,
+      (ObjectNode) Jsons.deserialize(
+          """
+          {"type": "string", "airbyte_type": "timestamp_with_timezone", "format": "date-time"}
           """),
-      TIMESTAMP_WITHOUT_TIMEZONE_REFERENCE, (ObjectNode) Jsons.deserialize("""
+      TIMESTAMP_WITHOUT_TIMEZONE_REFERENCE, (ObjectNode) Jsons.deserialize(
+          """
           {"type": "string", "airbyte_type": "timestamp_without_timezone"}
           """),
-      TIME_WITH_TIMEZONE_REFERENCE, (ObjectNode) Jsons.deserialize("""
-          {"type": "string", "airbyte_type": "time_with_timezone"}
+      TIME_WITH_TIMEZONE_REFERENCE, (ObjectNode) Jsons.deserialize(
+          """
+          {"type": "string", "airbyte_type": "time_with_timezone", "format": "time"}
           """),
-      TIME_WITHOUT_TIMEZONE_REFERENCE, (ObjectNode) Jsons.deserialize("""
+      TIME_WITHOUT_TIMEZONE_REFERENCE, (ObjectNode) Jsons.deserialize(
+          """
           {"type": "string", "airbyte_type": "time_without_timezone"}
           """),
-      INTEGER_REFERENCE, (ObjectNode) Jsons.deserialize("""
-          {"type": "integer", "airbyte_type": "integer"}
+      DATE_REFERENCE, (ObjectNode) Jsons.deserialize(
+          """
+          {"type": "string", "format": "date"}
           """),
-      STRING_REFERENCE, (ObjectNode) Jsons.deserialize("""
-          {"type": "string"}
+      INTEGER_REFERENCE, (ObjectNode) Jsons.deserialize(
+          """
+          {"type": "integer"}
           """),
-      NUMBER_REFERENCE, (ObjectNode) Jsons.deserialize("""
+      NUMBER_REFERENCE, (ObjectNode) Jsons.deserialize(
+          """
           {"type": "number"}
           """),
-      BOOLEAN_REFERENCE, (ObjectNode) Jsons.deserialize("""
+      BOOLEAN_REFERENCE, (ObjectNode) Jsons.deserialize(
+          """
           {"type": "boolean"}
           """),
-      DATE_REFERENCE, (ObjectNode) Jsons.deserialize("""
-          {"type": "string", "airbyte_type": "date"}
+      STRING_REFERENCE, (ObjectNode) Jsons.deserialize(
+          """
+          {"type": "string"}
           """),
-      BINARY_DATA_REFERENCE, (ObjectNode) Jsons.deserialize("""
+      BINARY_DATA_REFERENCE, (ObjectNode) Jsons.deserialize(
+          """
           {"type": "string"}
           """));
 

--- a/airbyte-protocol/protocol-models/src/main/java/io/airbyte/protocol/models/JsonSchemaReferenceTypes.java
+++ b/airbyte-protocol/protocol-models/src/main/java/io/airbyte/protocol/models/JsonSchemaReferenceTypes.java
@@ -19,6 +19,8 @@ public class JsonSchemaReferenceTypes {
       "integer",
       "boolean");
 
+  public static final String REF_KEY = "$ref";
+
   public static final String WELL_KNOWN_TYPES_FILENAME = "WellKnownTypes.json";
   public static final String STRING_REFERENCE = WELL_KNOWN_TYPES_FILENAME + "#/definitions/String";
   public static final String BINARY_DATA_REFERENCE = WELL_KNOWN_TYPES_FILENAME + "#/definitions/BinaryData";

--- a/airbyte-protocol/protocol-models/src/main/java/io/airbyte/protocol/models/JsonSchemaReferenceTypes.java
+++ b/airbyte-protocol/protocol-models/src/main/java/io/airbyte/protocol/models/JsonSchemaReferenceTypes.java
@@ -4,8 +4,11 @@
 
 package io.airbyte.protocol.models;
 
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.node.ObjectNode;
 import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.ImmutableSet;
+import io.airbyte.commons.json.Jsons;
 import java.util.Map;
 import java.util.Set;
 
@@ -44,5 +47,37 @@ public class JsonSchemaReferenceTypes {
       "number", NUMBER_REFERENCE,
       "boolean", BOOLEAN_REFERENCE,
       "date", DATE_REFERENCE);
+
+  public static final Map<String, ObjectNode> REFERENCE_TYPE_TO_OLD_TYPE = ImmutableMap.of(
+      TIMESTAMP_WITH_TIMEZONE_REFERENCE, (ObjectNode) Jsons.deserialize("""
+          {"type": "string", "airbyte_type": "timestamp_with_timezone"}
+          """),
+      TIMESTAMP_WITHOUT_TIMEZONE_REFERENCE, (ObjectNode) Jsons.deserialize("""
+          {"type": "string", "airbyte_type": "timestamp_without_timezone"}
+          """),
+      TIME_WITH_TIMEZONE_REFERENCE, (ObjectNode) Jsons.deserialize("""
+          {"type": "string", "airbyte_type": "time_with_timezone"}
+          """),
+      TIME_WITHOUT_TIMEZONE_REFERENCE, (ObjectNode) Jsons.deserialize("""
+          {"type": "string", "airbyte_type": "time_without_timezone"}
+          """),
+      INTEGER_REFERENCE, (ObjectNode) Jsons.deserialize("""
+          {"type": "integer", "airbyte_type": "integer"}
+          """),
+      STRING_REFERENCE, (ObjectNode) Jsons.deserialize("""
+          {"type": "string"}
+          """),
+      NUMBER_REFERENCE, (ObjectNode) Jsons.deserialize("""
+          {"type": "number"}
+          """),
+      BOOLEAN_REFERENCE, (ObjectNode) Jsons.deserialize("""
+          {"type": "boolean"}
+          """),
+      DATE_REFERENCE, (ObjectNode) Jsons.deserialize("""
+          {"type": "string", "airbyte_type": "date"}
+          """),
+      BINARY_DATA_REFERENCE, (ObjectNode) Jsons.deserialize("""
+          {"type": "string"}
+          """));
 
 }

--- a/airbyte-protocol/protocol-models/src/main/java/io/airbyte/protocol/models/JsonSchemaReferenceTypes.java
+++ b/airbyte-protocol/protocol-models/src/main/java/io/airbyte/protocol/models/JsonSchemaReferenceTypes.java
@@ -89,7 +89,7 @@ public class JsonSchemaReferenceTypes {
           """),
       BINARY_DATA_REFERENCE, (ObjectNode) Jsons.deserialize(
           """
-          {"type": "string"}
+          {"type": "string", "contentEncoding": "base64"}
           """));
 
 }


### PR DESCRIPTION
closes https://github.com/airbytehq/airbyte/issues/18254

based on https://github.com/airbytehq/airbyte/pull/19240

for reviewers:
* definitely hide whitespace changes ;)
* take a quick look at: (misc changes)
    * build.gradle
    * JsonSchemaValidator.java
    * JsonSchemaReferenceTypes.java
* WellKnownTypes.json (this is just needed for the sake of testing; it's equivalent to the YAML file. I'll generate this as part of the build later, but for now just wanted to get the tests running)
* MigrationV1
    * downgrade is the top-level method, which just invokes everything else
    * downgradeSchema + isPrimitiveReferenceTypeDeclaration + getSubschemas + downgradeTypeDeclaration are for downgrading catalog messages
    * downgradeNode is for downgrading record messages; it calls into the various `downgradeXyzNode` methods
* V1MigrationTest
    * couple minor formatting/refactoring changes in the upgrade tests, but no actual behavior changes
    * scroll down to `CatalogDowngradeTest` for the actual downgrade stuff