### PR TITLE
🪟 🔧 Optimize lodash imports

### DIFF
--- a/airbyte-webapp/.eslintrc.js
+++ b/airbyte-webapp/.eslintrc.js
@@ -88,6 +88,18 @@ module.exports = {
     "react/jsx-fragments": "warn",
     "react/jsx-no-useless-fragment": ["warn", { allowExpressions: true }],
     "react/self-closing-comp": "warn",
+    "no-restricted-imports": [
+      "error",
+      {
+        paths: [
+          {
+            name: "lodash",
+            message: 'Please use `import [function] from "lodash/[function]";` instead.',
+          },
+        ],
+        patterns: ["!lodash/*"],
+      },
+    ],
   },
   parser: "@typescript-eslint/parser",
   overrides: [

--- a/airbyte-webapp/src/components/JobItem/components/JobLogs.tsx
+++ b/airbyte-webapp/src/components/JobItem/components/JobLogs.tsx
@@ -1,4 +1,4 @@
-import { clamp } from "lodash";
+import clamp from "lodash/clamp";
 import React, { useState } from "react";
 import { FormattedMessage } from "react-intl";
 import { useLocation } from "react-router-dom";

--- a/airbyte-webapp/src/components/StreamTestingPanel/StreamSelector.tsx
+++ b/airbyte-webapp/src/components/StreamTestingPanel/StreamSelector.tsx
@@ -1,7 +1,7 @@
 import { faSortDown } from "@fortawesome/free-solid-svg-icons";
 import { FontAwesomeIcon } from "@fortawesome/react-fontawesome";
 import classNames from "classnames";
-import { capitalize } from "lodash";
+import capitalize from "lodash/capitalize";
 
 import { Heading } from "components/ui/Heading";
 import { ListBox, ListBoxControlButtonProps } from "components/ui/ListBox";

--- a/airbyte-webapp/src/components/ui/TagInput/TagInput.tsx
+++ b/airbyte-webapp/src/components/ui/TagInput/TagInput.tsx
@@ -1,4 +1,4 @@
-import { uniqueId } from "lodash";
+import uniqueId from "lodash/uniqueId";
 import { KeyboardEventHandler, useMemo, useState } from "react";
 import { ActionMeta, MultiValue, OnChangeValue } from "react-select";
 import CreatableSelect from "react-select/creatable";

--- a/airbyte-webapp/src/hooks/services/ConnectionEdit/ConnectionEditService.tsx
+++ b/airbyte-webapp/src/hooks/services/ConnectionEdit/ConnectionEditService.tsx
@@ -1,4 +1,4 @@
-import { pick } from "lodash";
+import pick from "lodash/pick";
 import { useContext, useState, createContext, useCallback } from "react";
 import { useAsyncFn } from "react-use";
 

--- a/airbyte-webapp/src/hooks/services/FormChangeTracker/hooks.ts
+++ b/airbyte-webapp/src/hooks/services/FormChangeTracker/hooks.ts
@@ -1,4 +1,4 @@
-import { uniqueId } from "lodash";
+import uniqueId from "lodash/uniqueId";
 import { useCallback, useMemo } from "react";
 import { createGlobalState } from "react-use";
 

--- a/airbyte-webapp/src/views/Connection/TransformationForm/utils.test.ts
+++ b/airbyte-webapp/src/views/Connection/TransformationForm/utils.test.ts
@@ -1,4 +1,4 @@
-import { merge } from "lodash";
+import merge from "lodash/merge";
 import { InferType, ValidationError } from "yup";
 
 import { validationSchema } from "./utils";

--- a/airbyte-webapp/src/views/Connector/ConnectorForm/components/Controls/ConnectorServiceTypeControl/useAnalyticsTrackFunctions.tsx
+++ b/airbyte-webapp/src/views/Connector/ConnectorForm/components/Controls/ConnectorServiceTypeControl/useAnalyticsTrackFunctions.tsx
@@ -1,4 +1,4 @@
-import { capitalize } from "lodash";
+import capitalize from "lodash/capitalize";
 import { useCallback } from "react";
 
 import { Action, Namespace } from "core/analytics";


### PR DESCRIPTION
## What

This changes all named imports from lodash e.g. `import { isEqual } from 'lodash';` to imports from the submodule directly i.e. `import isEqual from 'lodash/isEqual';`.

This allows our build system to only need to include the corresponding lodash submodules we really use. This stripped off ~500kB (21kB gziped) of our bundle size.

Also this adds a linting rule that will prevent those types of imports in the future.