### PR TITLE
🚨🚨 [ISSUE #19733] Executing a source with an invalid JSON file should display a clear error

### DIFF
--- a/airbyte-cdk/python/CHANGELOG.md
+++ b/airbyte-cdk/python/CHANGELOG.md
@@ -1,5 +1,8 @@
 # Changelog
 
+## 0.12.0
+Improve error readability when error while reading JSON config files
+
 ## 0.11.1
 Low-code: Fix the component manifest schema to and validate check instead of checker
 

--- a/airbyte-cdk/python/airbyte_cdk/connector.py
+++ b/airbyte-cdk/python/airbyte_cdk/connector.py
@@ -47,10 +47,14 @@ class BaseConnector(ABC, Generic[TConfig]):
         """
 
     @staticmethod
-    def read_config(config_path: str) -> TConfig:
+    def read_json_file(config_path: str) -> TConfig:
         with open(config_path, "r") as file:
             contents = file.read()
-        return json.loads(contents)
+
+        try:
+            return json.loads(contents)
+        except json.JSONDecodeError as error:
+            raise ValueError(f"Could not read json file {config_path}: `{error}`")
 
     @staticmethod
     def write_config(config: TConfig, config_path: str):

--- a/airbyte-cdk/python/airbyte_cdk/connector.py
+++ b/airbyte-cdk/python/airbyte_cdk/connector.py
@@ -54,7 +54,7 @@ class BaseConnector(ABC, Generic[TConfig]):
         try:
             return json.loads(contents)
         except json.JSONDecodeError as error:
-            raise ValueError(f"Could not read json file {config_path}: `{error}`")
+            raise ValueError(f"Could not read json file {config_path}: {error}. Please ensure that it is a valid JSON.")
 
     @staticmethod
     def write_config(config: TConfig, config_path: str):
@@ -78,7 +78,10 @@ class BaseConnector(ABC, Generic[TConfig]):
         if yaml_spec:
             spec_obj = yaml.load(yaml_spec, Loader=yaml.SafeLoader)
         elif json_spec:
-            spec_obj = json.loads(json_spec)
+            try:
+                spec_obj = json.loads(json_spec)
+            except json.JSONDecodeError as error:
+                raise ValueError(f"Could not read json spec file: {error}. Please ensure that it is a valid JSON.")
         else:
             raise FileNotFoundError("Unable to find spec.yaml or spec.json in the package.")
 

--- a/airbyte-cdk/python/airbyte_cdk/destinations/destination.py
+++ b/airbyte-cdk/python/airbyte_cdk/destinations/destination.py
@@ -94,7 +94,7 @@ class Destination(Connector, ABC):
         if cmd == "spec":
             yield AirbyteMessage(type=Type.SPEC, spec=spec)
             return
-        config = self.read_config(config_path=parsed_args.config)
+        config = self.read_json_file(config_path=parsed_args.config)
         if self.check_config_against_spec or cmd == "check":
             try:
                 check_config_against_spec_or_exit(config, spec)

--- a/airbyte-cdk/python/airbyte_cdk/entrypoint.py
+++ b/airbyte-cdk/python/airbyte_cdk/entrypoint.py
@@ -82,7 +82,7 @@ class AirbyteEntrypoint(object):
                 message = AirbyteMessage(type=Type.SPEC, spec=source_spec)
                 yield message.json(exclude_unset=True)
             else:
-                raw_config = self.source.read_config(parsed_args.config)
+                raw_config = self.source.read_json_file(parsed_args.config)
                 config = self.source.configure(raw_config, temp_dir)
 
                 # Now that we have the config, we can use it to get a list of ai airbyte_secrets

--- a/airbyte-cdk/python/airbyte_cdk/sources/singer/source.py
+++ b/airbyte-cdk/python/airbyte_cdk/sources/singer/source.py
@@ -98,7 +98,7 @@ class SingerSource(BaseSource[ConfigContainer, str, str]):
         Implements the parent class read method.
         """
         catalogs = self._discover_internal(logger, config.config_path)
-        masked_airbyte_catalog = ConfiguredAirbyteCatalog.parse_obj(self.read_config(catalog_path))
+        masked_airbyte_catalog = ConfiguredAirbyteCatalog.parse_obj(self.read_json_file(catalog_path))
         selected_singer_catalog_path = SingerHelper.create_singer_catalog_with_selection(masked_airbyte_catalog, catalogs.singer_catalog)
 
         read_cmd = self.read_cmd(logger, config.config_path, selected_singer_catalog_path, state_path)

--- a/airbyte-cdk/python/airbyte_cdk/sources/source.py
+++ b/airbyte-cdk/python/airbyte_cdk/sources/source.py
@@ -54,7 +54,7 @@ class Source(
         :return: The complete stream state based on the connector's previous sync
         """
         if state_path:
-            state_obj = json.loads(open(state_path, "r").read())
+            state_obj = self.read_json_file(state_path)
             if not state_obj:
                 return self._emit_legacy_state_format({})
             is_per_stream_state = isinstance(state_obj, List)
@@ -87,4 +87,4 @@ class Source(
 
     # can be overridden to change an input catalog
     def read_catalog(self, catalog_path: str) -> ConfiguredAirbyteCatalog:
-        return ConfiguredAirbyteCatalog.parse_obj(self.read_config(catalog_path))
+        return ConfiguredAirbyteCatalog.parse_obj(self.read_json_file(catalog_path))

--- a/airbyte-cdk/python/setup.py
+++ b/airbyte-cdk/python/setup.py
@@ -15,7 +15,7 @@ README = (HERE / "README.md").read_text()
 
 setup(
     name="airbyte-cdk",
-    version="0.11.1",
+    version="0.12.0",
     description="A framework for writing Airbyte Connectors.",
     long_description=README,
     long_description_content_type="text/markdown",

--- a/airbyte-cdk/python/unit_tests/test_connector.py
+++ b/airbyte-cdk/python/unit_tests/test_connector.py
@@ -66,13 +66,26 @@ def nonempty_file(mock_config):
 
 
 @pytest.fixture
+def nonjson_file(mock_config):
+    with tempfile.NamedTemporaryFile("w") as file:
+        file.write("the content of this file is not JSON")
+        file.flush()
+        yield file
+
+
+@pytest.fixture
 def integration():
     return MockConnector()
 
 
-def test_read_config(nonempty_file, integration: Connector, mock_config):
-    actual = integration.read_config(nonempty_file.name)
+def test_read_json_file(nonempty_file, integration: Connector, mock_config):
+    actual = integration.read_json_file(nonempty_file.name)
     assert mock_config == actual
+
+
+def test_read_non_json_file(nonjson_file, integration: Connector):
+    with pytest.raises(ValueError, match="Could not read json file"):
+        integration.read_json_file(nonjson_file.name)
 
 
 def test_write_config(integration, mock_config):

--- a/airbyte-cdk/python/unit_tests/test_connector.py
+++ b/airbyte-cdk/python/unit_tests/test_connector.py
@@ -117,6 +117,14 @@ class TestConnectorSpec:
         os.remove(json_path)
 
     @pytest.fixture
+    def use_invalid_json_spec(self):
+        json_path = os.path.join(SPEC_ROOT, "spec.json")
+        with open(json_path, "w") as f:
+            f.write("the content of this file is not JSON")
+        yield
+        os.remove(json_path)
+
+    @pytest.fixture
     def use_yaml_spec(self):
         spec = {"documentationUrl": "https://airbyte.com/#yaml", "connectionSpecification": self.CONNECTION_SPECIFICATION}
 
@@ -130,6 +138,10 @@ class TestConnectorSpec:
         connector_spec = integration.spec(logger)
         assert connector_spec.documentationUrl == "https://airbyte.com/#json"
         assert connector_spec.connectionSpecification == self.CONNECTION_SPECIFICATION
+
+    def test_spec_from_improperly_formatted_json_file(self, integration, use_invalid_json_spec):
+        with pytest.raises(ValueError, match="Could not read json spec file"):
+            integration.spec(logger)
 
     def test_spec_from_yaml_file(self, integration, use_yaml_spec):
         connector_spec = integration.spec(logger)

--- a/airbyte-cdk/python/unit_tests/test_entrypoint.py
+++ b/airbyte-cdk/python/unit_tests/test_entrypoint.py
@@ -130,7 +130,7 @@ def test_run_spec(entrypoint: AirbyteEntrypoint, mocker):
 @pytest.fixture
 def config_mock(mocker, request):
     config = request.param if hasattr(request, "param") else {"username": "fake"}
-    mocker.patch.object(MockSource, "read_config", return_value=config)
+    mocker.patch.object(MockSource, "read_json_file", return_value=config)
     mocker.patch.object(MockSource, "configure", return_value=config)
     return config
 

--- a/airbyte-cdk/python/unit_tests/test_secure_logger.py
+++ b/airbyte-cdk/python/unit_tests/test_secure_logger.py
@@ -134,7 +134,7 @@ def test_airbyte_secret_is_masked_on_logger_output(source_spec, mocker, config, 
         return_value=ConnectorSpecification(connectionSpecification=source_spec),
     )
     mocker.patch.object(MockSource, "configure", return_value=config)
-    mocker.patch.object(MockSource, "read_config", return_value=None)
+    mocker.patch.object(MockSource, "read_json_file", return_value=None)
     mocker.patch.object(MockSource, "read_state", return_value={})
     mocker.patch.object(MockSource, "read_catalog", return_value={})
     list(entrypoint.run(parsed_args))
@@ -180,7 +180,7 @@ def test_airbyte_secrets_are_masked_on_uncaught_exceptions(mocker, caplog, capsy
         return_value=ConnectorSpecification(connectionSpecification=source_spec),
     )
     mocker.patch.object(MockSource, "configure", return_value=simple_config)
-    mocker.patch.object(MockSource, "read_config", return_value=None)
+    mocker.patch.object(MockSource, "read_json_file", return_value=None)
     mocker.patch.object(MockSource, "read_state", return_value={})
     mocker.patch.object(MockSource, "read_catalog", return_value={})
 
@@ -227,7 +227,7 @@ def test_non_airbyte_secrets_are_not_masked_on_uncaught_exceptions(mocker, caplo
         return_value=ConnectorSpecification(connectionSpecification=source_spec),
     )
     mocker.patch.object(MockSource, "configure", return_value=simple_config)
-    mocker.patch.object(MockSource, "read_config", return_value=None)
+    mocker.patch.object(MockSource, "read_json_file", return_value=None)
     mocker.patch.object(MockSource, "read_state", return_value={})
     mocker.patch.object(MockSource, "read_catalog", return_value={})
     mocker.patch.object(MockSource, "read", side_effect=Exception("Exception:" + NOT_A_SECRET_VALUE))

--- a/airbyte-integrations/connectors/source-s3/source_s3/source.py
+++ b/airbyte-integrations/connectors/source-s3/source_s3/source.py
@@ -57,8 +57,8 @@ class SourceS3(SourceFilesAbstract):
     spec_class = SourceS3Spec
     documentation_url = "https://docs.airbyte.com/integrations/sources/s3"
 
-    def read_config(self, config_path: str) -> Mapping[str, Any]:
-        config: Mapping[str, Any] = super().read_config(config_path)
+    def read_json_file(self, config_path: str) -> Mapping[str, Any]:
+        config: Mapping[str, Any] = super().read_json_file(config_path)
         if config.get("format", {}).get("delimiter") == r"\t":
             config["format"]["delimiter"] = "\t"
         return config

--- a/airbyte-integrations/connectors/source-s3/unit_tests/conftest.py
+++ b/airbyte-integrations/connectors/source-s3/unit_tests/conftest.py
@@ -49,7 +49,7 @@ def config_fixture(tmp_path):
             fp,
         )
     source = SourceS3()
-    config = source.read_config(config_file)
+    config = source.read_json_file(config_file)
     return config
 
 

--- a/airbyte-integrations/connectors/source-s3/unit_tests/test_source.py
+++ b/airbyte-integrations/connectors/source-s3/unit_tests/test_source.py
@@ -19,7 +19,7 @@ def test_transform_backslash_t_to_tab(tmp_path):
     with open(config_file, "w") as fp:
         json.dump({"format": {"delimiter": "\\t"}}, fp)
     source = SourceS3()
-    config = source.read_config(config_file)
+    config = source.read_json_file(config_file)
     assert config["format"]["delimiter"] == "\t"
 
 


### PR DESCRIPTION
## What
This change address https://github.com/airbytehq/airbyte/issues/19733 which would cause the error message from reading config files to be unclear.

## How
As https://github.com/airbytehq/airbyte/issues/19733 states, `We should rename BaseConnector.read_config() to read_json_file() to accurately reflect what it is doing. The existing usages of read_config() should be updated.` and `The Source.read_state() method should start using this newly renamed read_json_file() to read the state JSON file instead of duplicating all the same file reading logic.`

## 🚨 User Impact 🚨
Previous error message: _Expecting value: line 1 column 1 (char 0)_
New error message: _Could not read json file secrets/config.json: `Expecting value: line 1 column 1 (char 0)`_

The solution proposed in https://github.com/airbytehq/airbyte/issues/19733 is a breaking change since the public method `read_config` is changed to `read_json_file`.

## Pre-merge Checklist

### Community member or Airbyter
- [X] Unit & integration tests added and passing
- [ ] Code reviews completed
- [X] PR name follows [PR naming conventions](https://docs.airbyte.com/contributing-to-airbyte/issues-and-pull-requests)

## Tests

<details><summary><strong>Unit</strong></summary>

*Put your unit tests output here.*

</details>

<details><summary><strong>Integration</strong></summary>

*Put your integration tests output here.*

</details>

<details><summary><strong>Acceptance</strong></summary>

*Put your acceptance tests output here.*

</details>

## Other Notes
Running `mypy airbyte_cdk` (as mentioned in the README.md) before creating changes to the repository gave me the following output `Found 134 errors in 60 files (checked 140 source files)`. Is this expected?