### PR TITLE
Fix margin and padding issues with CatalogTree table

### DIFF
--- a/airbyte-webapp/src/components/CreateConnection/__snapshots__/CreateConnectionForm.test.tsx.snap
+++ b/airbyte-webapp/src/components/CreateConnection/__snapshots__/CreateConnectionForm.test.tsx.snap
@@ -417,252 +417,217 @@ exports[`CreateConnectionForm should render 1`] = `
                   <div
                     class="<removed-for-snapshot-test>"
                   >
-                    <label
-                      class="<removed-for-snapshot-test>"
-                    >
-                      <input
-                        class="<removed-for-snapshot-test>"
-                        type="checkbox"
-                      />
-                    </label>
-                  </div>
-                  <div
-                    class="<removed-for-snapshot-test>"
-                  />
-                  <div
-                    class="<removed-for-snapshot-test>"
-                  >
-                    Sync
-                  </div>
-                  <div
-                    class="<removed-for-snapshot-test>"
-                  >
-                    Source
                     <div
                       class="<removed-for-snapshot-test>"
                     >
+                      <label
+                        class="<removed-for-snapshot-test>"
+                      >
+                        <input
+                          class="<removed-for-snapshot-test>"
+                          type="checkbox"
+                        />
+                      </label>
+                    </div>
+                    <div
+                      class="<removed-for-snapshot-test>"
+                    />
+                    <div
+                      class="<removed-for-snapshot-test>"
+                    >
+                      Sync
+                    </div>
+                    <div
+                      class="<removed-for-snapshot-test>"
+                    >
+                      Source
                       <div
                         class="<removed-for-snapshot-test>"
                       >
                         <div
                           class="<removed-for-snapshot-test>"
                         >
-                          <svg
-                            fill="none"
-                            height="14"
-                            viewBox="0 0 14 14"
-                            width="14"
-                          >
-                            <path
-                              d="M7.00016 13.6663C3.31816 13.6663 0.333496 10.6817 0.333496 6.99967C0.333496 3.31767 3.31816 0.333008 7.00016 0.333008C10.6822 0.333008 13.6668 3.31767 13.6668 6.99967C13.6668 10.6817 10.6822 13.6663 7.00016 13.6663ZM7.00016 12.333C8.41465 12.333 9.77121 11.7711 10.7714 10.7709C11.7716 9.77072 12.3335 8.41416 12.3335 6.99967C12.3335 5.58519 11.7716 4.22863 10.7714 3.22844C9.77121 2.22824 8.41465 1.66634 7.00016 1.66634C5.58567 1.66634 4.22912 2.22824 3.22893 3.22844C2.22873 4.22863 1.66683 5.58519 1.66683 6.99967C1.66683 8.41416 2.22873 9.77072 3.22893 10.7709C4.22912 11.7711 5.58567 12.333 7.00016 12.333ZM6.3335 3.66634H7.66683V4.99967H6.3335V3.66634ZM6.3335 6.33301H7.66683V10.333H6.3335V6.33301Z"
-                              fill="currentColor"
-                            />
-                          </svg>
-                        </div>
-                      </div>
-                    </div>
-                  </div>
-                  <div
-                    class="<removed-for-snapshot-test>"
-                  />
-                  <div
-                    class="<removed-for-snapshot-test>"
-                  >
-                    Sync mode
-                    <div
-                      class="<removed-for-snapshot-test>"
-                    >
-                      <div
-                        class="<removed-for-snapshot-test>"
-                      >
-                        <div
-                          class="<removed-for-snapshot-test>"
-                        >
-                          <svg
-                            fill="none"
-                            height="14"
-                            viewBox="0 0 14 14"
-                            width="14"
-                          >
-                            <path
-                              d="M7.00016 13.6663C3.31816 13.6663 0.333496 10.6817 0.333496 6.99967C0.333496 3.31767 3.31816 0.333008 7.00016 0.333008C10.6822 0.333008 13.6668 3.31767 13.6668 6.99967C13.6668 10.6817 10.6822 13.6663 7.00016 13.6663ZM7.00016 12.333C8.41465 12.333 9.77121 11.7711 10.7714 10.7709C11.7716 9.77072 12.3335 8.41416 12.3335 6.99967C12.3335 5.58519 11.7716 4.22863 10.7714 3.22844C9.77121 2.22824 8.41465 1.66634 7.00016 1.66634C5.58567 1.66634 4.22912 2.22824 3.22893 3.22844C2.22873 4.22863 1.66683 5.58519 1.66683 6.99967C1.66683 8.41416 2.22873 9.77072 3.22893 10.7709C4.22912 11.7711 5.58567 12.333 7.00016 12.333ZM6.3335 3.66634H7.66683V4.99967H6.3335V3.66634ZM6.3335 6.33301H7.66683V10.333H6.3335V6.33301Z"
-                              fill="currentColor"
-                            />
-                          </svg>
-                        </div>
-                      </div>
-                    </div>
-                  </div>
-                  <div
-                    class="<removed-for-snapshot-test>"
-                  >
-                    Cursor field
-                    <div
-                      class="<removed-for-snapshot-test>"
-                    >
-                      <div
-                        class="<removed-for-snapshot-test>"
-                      >
-                        <div
-                          class="<removed-for-snapshot-test>"
-                        >
-                          <svg
-                            fill="none"
-                            height="14"
-                            viewBox="0 0 14 14"
-                            width="14"
-                          >
-                            <path
-                              d="M7.00016 13.6663C3.31816 13.6663 0.333496 10.6817 0.333496 6.99967C0.333496 3.31767 3.31816 0.333008 7.00016 0.333008C10.6822 0.333008 13.6668 3.31767 13.6668 6.99967C13.6668 10.6817 10.6822 13.6663 7.00016 13.6663ZM7.00016 12.333C8.41465 12.333 9.77121 11.7711 10.7714 10.7709C11.7716 9.77072 12.3335 8.41416 12.3335 6.99967C12.3335 5.58519 11.7716 4.22863 10.7714 3.22844C9.77121 2.22824 8.41465 1.66634 7.00016 1.66634C5.58567 1.66634 4.22912 2.22824 3.22893 3.22844C2.22873 4.22863 1.66683 5.58519 1.66683 6.99967C1.66683 8.41416 2.22873 9.77072 3.22893 10.7709C4.22912 11.7711 5.58567 12.333 7.00016 12.333ZM6.3335 3.66634H7.66683V4.99967H6.3335V3.66634ZM6.3335 6.33301H7.66683V10.333H6.3335V6.33301Z"
-                              fill="currentColor"
-                            />
-                          </svg>
-                        </div>
-                      </div>
-                    </div>
-                  </div>
-                  <div
-                    class="<removed-for-snapshot-test>"
-                  >
-                    Primary key
-                    <div
-                      class="<removed-for-snapshot-test>"
-                    >
-                      <div
-                        class="<removed-for-snapshot-test>"
-                      >
-                        <div
-                          class="<removed-for-snapshot-test>"
-                        >
-                          <svg
-                            fill="none"
-                            height="14"
-                            viewBox="0 0 14 14"
-                            width="14"
-                          >
-                            <path
-                              d="M7.00016 13.6663C3.31816 13.6663 0.333496 10.6817 0.333496 6.99967C0.333496 3.31767 3.31816 0.333008 7.00016 0.333008C10.6822 0.333008 13.6668 3.31767 13.6668 6.99967C13.6668 10.6817 10.6822 13.6663 7.00016 13.6663ZM7.00016 12.333C8.41465 12.333 9.77121 11.7711 10.7714 10.7709C11.7716 9.77072 12.3335 8.41416 12.3335 6.99967C12.3335 5.58519 11.7716 4.22863 10.7714 3.22844C9.77121 2.22824 8.41465 1.66634 7.00016 1.66634C5.58567 1.66634 4.22912 2.22824 3.22893 3.22844C2.22873 4.22863 1.66683 5.58519 1.66683 6.99967C1.66683 8.41416 2.22873 9.77072 3.22893 10.7709C4.22912 11.7711 5.58567 12.333 7.00016 12.333ZM6.3335 3.66634H7.66683V4.99967H6.3335V3.66634ZM6.3335 6.33301H7.66683V10.333H6.3335V6.33301Z"
-                              fill="currentColor"
-                            />
-                          </svg>
-                        </div>
-                      </div>
-                    </div>
-                  </div>
-                  <div
-                    class="<removed-for-snapshot-test>"
-                  >
-                    Destination
-                    <div
-                      class="<removed-for-snapshot-test>"
-                    >
-                      <div
-                        class="<removed-for-snapshot-test>"
-                      >
-                        <div
-                          class="<removed-for-snapshot-test>"
-                        >
-                          <svg
-                            fill="none"
-                            height="14"
-                            viewBox="0 0 14 14"
-                            width="14"
-                          >
-                            <path
-                              d="M7.00016 13.6663C3.31816 13.6663 0.333496 10.6817 0.333496 6.99967C0.333496 3.31767 3.31816 0.333008 7.00016 0.333008C10.6822 0.333008 13.6668 3.31767 13.6668 6.99967C13.6668 10.6817 10.6822 13.6663 7.00016 13.6663ZM7.00016 12.333C8.41465 12.333 9.77121 11.7711 10.7714 10.7709C11.7716 9.77072 12.3335 8.41416 12.3335 6.99967C12.3335 5.58519 11.7716 4.22863 10.7714 3.22844C9.77121 2.22824 8.41465 1.66634 7.00016 1.66634C5.58567 1.66634 4.22912 2.22824 3.22893 3.22844C2.22873 4.22863 1.66683 5.58519 1.66683 6.99967C1.66683 8.41416 2.22873 9.77072 3.22893 10.7709C4.22912 11.7711 5.58567 12.333 7.00016 12.333ZM6.3335 3.66634H7.66683V4.99967H6.3335V3.66634ZM6.3335 6.33301H7.66683V10.333H6.3335V6.33301Z"
-                              fill="currentColor"
-                            />
-                          </svg>
-                        </div>
-                      </div>
-                    </div>
-                  </div>
-                  <div
-                    class="<removed-for-snapshot-test>"
-                  />
-                </div>
-                <div
-                  class="<removed-for-snapshot-test>"
-                >
-                  <div
-                    class="<removed-for-snapshot-test>"
-                  />
-                  <div
-                    class="<removed-for-snapshot-test>"
-                  >
-                    Namespace
-                  </div>
-                  <div
-                    class="<removed-for-snapshot-test>"
-                  >
-                    Stream name
-                  </div>
-                  <div
-                    class="<removed-for-snapshot-test>"
-                  >
-                    Source | Destination
-                  </div>
-                  <div
-                    class="<removed-for-snapshot-test>"
-                  />
-                  <div
-                    class="<removed-for-snapshot-test>"
-                  />
-                  <div
-                    class="<removed-for-snapshot-test>"
-                  >
-                    Namespace
-                  </div>
-                  <div
-                    class="<removed-for-snapshot-test>"
-                  >
-                    Stream name
-                  </div>
-                </div>
-                <div
-                  class="<removed-for-snapshot-test>"
-                >
-                  <div
-                    class="<removed-for-snapshot-test>"
-                  >
-                    <div
-                      class="<removed-for-snapshot-test>"
-                    >
-                      <div
-                        class="<removed-for-snapshot-test>"
-                      >
-                        <label
-                          class="<removed-for-snapshot-test>"
-                        >
-                          <input
+                          <div
                             class="<removed-for-snapshot-test>"
-                            type="checkbox"
-                          />
-                        </label>
+                          >
+                            <svg
+                              fill="none"
+                              height="14"
+                              viewBox="0 0 14 14"
+                              width="14"
+                            >
+                              <path
+                                d="M7.00016 13.6663C3.31816 13.6663 0.333496 10.6817 0.333496 6.99967C0.333496 3.31767 3.31816 0.333008 7.00016 0.333008C10.6822 0.333008 13.6668 3.31767 13.6668 6.99967C13.6668 10.6817 10.6822 13.6663 7.00016 13.6663ZM7.00016 12.333C8.41465 12.333 9.77121 11.7711 10.7714 10.7709C11.7716 9.77072 12.3335 8.41416 12.3335 6.99967C12.3335 5.58519 11.7716 4.22863 10.7714 3.22844C9.77121 2.22824 8.41465 1.66634 7.00016 1.66634C5.58567 1.66634 4.22912 2.22824 3.22893 3.22844C2.22873 4.22863 1.66683 5.58519 1.66683 6.99967C1.66683 8.41416 2.22873 9.77072 3.22893 10.7709C4.22912 11.7711 5.58567 12.333 7.00016 12.333ZM6.3335 3.66634H7.66683V4.99967H6.3335V3.66634ZM6.3335 6.33301H7.66683V10.333H6.3335V6.33301Z"
+                                fill="currentColor"
+                              />
+                            </svg>
+                          </div>
+                        </div>
                       </div>
+                    </div>
+                    <div
+                      class="<removed-for-snapshot-test>"
+                    />
+                    <div
+                      class="<removed-for-snapshot-test>"
+                    >
+                      Sync mode
                       <div
                         class="<removed-for-snapshot-test>"
                       >
-                        <span
+                        <div
                           class="<removed-for-snapshot-test>"
                         >
-                          <svg
-                            aria-hidden="true"
+                          <div
                             class="<removed-for-snapshot-test>"
-                            data-icon="chevron-right"
-                            data-prefix="fas"
-                            focusable="false"
-                            role="img"
-                            viewBox="0 0 320 512"
-                            xmlns="http://www.w3.org/2000/svg"
                           >
-                            <path
-                              d="M96 480c-8.188 0-16.38-3.125-22.62-9.375c-12.5-12.5-12.5-32.75 0-45.25L242.8 256L73.38 86.63c-12.5-12.5-12.5-32.75 0-45.25s32.75-12.5 45.25 0l192 192c12.5 12.5 12.5 32.75 0 45.25l-192 192C112.4 476.9 104.2 480 96 480z"
-                              fill="currentColor"
-                            />
-                          </svg>
-                        </span>
+                            <svg
+                              fill="none"
+                              height="14"
+                              viewBox="0 0 14 14"
+                              width="14"
+                            >
+                              <path
+                                d="M7.00016 13.6663C3.31816 13.6663 0.333496 10.6817 0.333496 6.99967C0.333496 3.31767 3.31816 0.333008 7.00016 0.333008C10.6822 0.333008 13.6668 3.31767 13.6668 6.99967C13.6668 10.6817 10.6822 13.6663 7.00016 13.6663ZM7.00016 12.333C8.41465 12.333 9.77121 11.7711 10.7714 10.7709C11.7716 9.77072 12.3335 8.41416 12.3335 6.99967C12.3335 5.58519 11.7716 4.22863 10.7714 3.22844C9.77121 2.22824 8.41465 1.66634 7.00016 1.66634C5.58567 1.66634 4.22912 2.22824 3.22893 3.22844C2.22873 4.22863 1.66683 5.58519 1.66683 6.99967C1.66683 8.41416 2.22873 9.77072 3.22893 10.7709C4.22912 11.7711 5.58567 12.333 7.00016 12.333ZM6.3335 3.66634H7.66683V4.99967H6.3335V3.66634ZM6.3335 6.33301H7.66683V10.333H6.3335V6.33301Z"
+                                fill="currentColor"
+                              />
+                            </svg>
+                          </div>
+                        </div>
                       </div>
+                    </div>
+                    <div
+                      class="<removed-for-snapshot-test>"
+                    >
+                      Cursor field
+                      <div
+                        class="<removed-for-snapshot-test>"
+                      >
+                        <div
+                          class="<removed-for-snapshot-test>"
+                        >
+                          <div
+                            class="<removed-for-snapshot-test>"
+                          >
+                            <svg
+                              fill="none"
+                              height="14"
+                              viewBox="0 0 14 14"
+                              width="14"
+                            >
+                              <path
+                                d="M7.00016 13.6663C3.31816 13.6663 0.333496 10.6817 0.333496 6.99967C0.333496 3.31767 3.31816 0.333008 7.00016 0.333008C10.6822 0.333008 13.6668 3.31767 13.6668 6.99967C13.6668 10.6817 10.6822 13.6663 7.00016 13.6663ZM7.00016 12.333C8.41465 12.333 9.77121 11.7711 10.7714 10.7709C11.7716 9.77072 12.3335 8.41416 12.3335 6.99967C12.3335 5.58519 11.7716 4.22863 10.7714 3.22844C9.77121 2.22824 8.41465 1.66634 7.00016 1.66634C5.58567 1.66634 4.22912 2.22824 3.22893 3.22844C2.22873 4.22863 1.66683 5.58519 1.66683 6.99967C1.66683 8.41416 2.22873 9.77072 3.22893 10.7709C4.22912 11.7711 5.58567 12.333 7.00016 12.333ZM6.3335 3.66634H7.66683V4.99967H6.3335V3.66634ZM6.3335 6.33301H7.66683V10.333H6.3335V6.33301Z"
+                                fill="currentColor"
+                              />
+                            </svg>
+                          </div>
+                        </div>
+                      </div>
+                    </div>
+                    <div
+                      class="<removed-for-snapshot-test>"
+                    >
+                      Primary key
+                      <div
+                        class="<removed-for-snapshot-test>"
+                      >
+                        <div
+                          class="<removed-for-snapshot-test>"
+                        >
+                          <div
+                            class="<removed-for-snapshot-test>"
+                          >
+                            <svg
+                              fill="none"
+                              height="14"
+                              viewBox="0 0 14 14"
+                              width="14"
+                            >
+                              <path
+                                d="M7.00016 13.6663C3.31816 13.6663 0.333496 10.6817 0.333496 6.99967C0.333496 3.31767 3.31816 0.333008 7.00016 0.333008C10.6822 0.333008 13.6668 3.31767 13.6668 6.99967C13.6668 10.6817 10.6822 13.6663 7.00016 13.6663ZM7.00016 12.333C8.41465 12.333 9.77121 11.7711 10.7714 10.7709C11.7716 9.77072 12.3335 8.41416 12.3335 6.99967C12.3335 5.58519 11.7716 4.22863 10.7714 3.22844C9.77121 2.22824 8.41465 1.66634 7.00016 1.66634C5.58567 1.66634 4.22912 2.22824 3.22893 3.22844C2.22873 4.22863 1.66683 5.58519 1.66683 6.99967C1.66683 8.41416 2.22873 9.77072 3.22893 10.7709C4.22912 11.7711 5.58567 12.333 7.00016 12.333ZM6.3335 3.66634H7.66683V4.99967H6.3335V3.66634ZM6.3335 6.33301H7.66683V10.333H6.3335V6.33301Z"
+                                fill="currentColor"
+                              />
+                            </svg>
+                          </div>
+                        </div>
+                      </div>
+                    </div>
+                    <div
+                      class="<removed-for-snapshot-test>"
+                    >
+                      Destination
+                      <div
+                        class="<removed-for-snapshot-test>"
+                      >
+                        <div
+                          class="<removed-for-snapshot-test>"
+                        >
+                          <div
+                            class="<removed-for-snapshot-test>"
+                          >
+                            <svg
+                              fill="none"
+                              height="14"
+                              viewBox="0 0 14 14"
+                              width="14"
+                            >
+                              <path
+                                d="M7.00016 13.6663C3.31816 13.6663 0.333496 10.6817 0.333496 6.99967C0.333496 3.31767 3.31816 0.333008 7.00016 0.333008C10.6822 0.333008 13.6668 3.31767 13.6668 6.99967C13.6668 10.6817 10.6822 13.6663 7.00016 13.6663ZM7.00016 12.333C8.41465 12.333 9.77121 11.7711 10.7714 10.7709C11.7716 9.77072 12.3335 8.41416 12.3335 6.99967C12.3335 5.58519 11.7716 4.22863 10.7714 3.22844C9.77121 2.22824 8.41465 1.66634 7.00016 1.66634C5.58567 1.66634 4.22912 2.22824 3.22893 3.22844C2.22873 4.22863 1.66683 5.58519 1.66683 6.99967C1.66683 8.41416 2.22873 9.77072 3.22893 10.7709C4.22912 11.7711 5.58567 12.333 7.00016 12.333ZM6.3335 3.66634H7.66683V4.99967H6.3335V3.66634ZM6.3335 6.33301H7.66683V10.333H6.3335V6.33301Z"
+                                fill="currentColor"
+                              />
+                            </svg>
+                          </div>
+                        </div>
+                      </div>
+                    </div>
+                    <div
+                      class="<removed-for-snapshot-test>"
+                    />
+                  </div>
+                  <div
+                    class="<removed-for-snapshot-test>"
+                  >
+                    <div
+                      class="<removed-for-snapshot-test>"
+                    />
+                    <div
+                      class="<removed-for-snapshot-test>"
+                    >
+                      Namespace
+                    </div>
+                    <div
+                      class="<removed-for-snapshot-test>"
+                    >
+                      Stream name
+                    </div>
+                    <div
+                      class="<removed-for-snapshot-test>"
+                    >
+                      Source | Destination
+                    </div>
+                    <div
+                      class="<removed-for-snapshot-test>"
+                    />
+                    <div
+                      class="<removed-for-snapshot-test>"
+                    />
+                    <div
+                      class="<removed-for-snapshot-test>"
+                    >
+                      Namespace
+                    </div>
+                    <div
+                      class="<removed-for-snapshot-test>"
+                    >
+                      Stream name
+                    </div>
+                  </div>
+                  <div
+                    class="<removed-for-snapshot-test>"
+                  >
+                    <div
+                      class="<removed-for-snapshot-test>"
+                    >
                       <div
                         class="<removed-for-snapshot-test>"
                       >
@@ -673,54 +638,89 @@ exports[`CreateConnectionForm should render 1`] = `
                             class="<removed-for-snapshot-test>"
                           >
                             <input
-                              checked=""
                               class="<removed-for-snapshot-test>"
-                              data-testid="pokemon-stream-sync-switch"
                               type="checkbox"
-                              value=""
-                            />
-                            <span
-                              class="<removed-for-snapshot-test>"
                             />
                           </label>
                         </div>
                         <div
                           class="<removed-for-snapshot-test>"
-                          title=""
                         >
                           <span
                             class="<removed-for-snapshot-test>"
                           >
-                            No namespace
+                            <svg
+                              aria-hidden="true"
+                              class="<removed-for-snapshot-test>"
+                              data-icon="chevron-right"
+                              data-prefix="fas"
+                              focusable="false"
+                              role="img"
+                              viewBox="0 0 320 512"
+                              xmlns="http://www.w3.org/2000/svg"
+                            >
+                              <path
+                                d="M96 480c-8.188 0-16.38-3.125-22.62-9.375c-12.5-12.5-12.5-32.75 0-45.25L242.8 256L73.38 86.63c-12.5-12.5-12.5-32.75 0-45.25s32.75-12.5 45.25 0l192 192c12.5 12.5 12.5 32.75 0 45.25l-192 192C112.4 476.9 104.2 480 96 480z"
+                                fill="currentColor"
+                              />
+                            </svg>
                           </span>
-                        </div>
-                        <div
-                          class="<removed-for-snapshot-test>"
-                          title="pokemon"
-                        >
-                          pokemon
                         </div>
                         <div
                           class="<removed-for-snapshot-test>"
                         >
                           <div
                             class="<removed-for-snapshot-test>"
-                            data-testid="syncSettingsDropdown"
-                            role="combobox"
+                          >
+                            <label
+                              class="<removed-for-snapshot-test>"
+                            >
+                              <input
+                                checked=""
+                                class="<removed-for-snapshot-test>"
+                                data-testid="pokemon-stream-sync-switch"
+                                type="checkbox"
+                                value=""
+                              />
+                              <span
+                                class="<removed-for-snapshot-test>"
+                              />
+                            </label>
+                          </div>
+                          <div
+                            class="<removed-for-snapshot-test>"
+                            title=""
                           >
                             <span
                               class="<removed-for-snapshot-test>"
-                              id="react-select-4-live-region"
-                            />
-                            <span
-                              aria-atomic="false"
-                              aria-live="polite"
-                              aria-relevant="additions text"
-                              class="<removed-for-snapshot-test>"
-                            />
+                            >
+                              No namespace
+                            </span>
+                          </div>
+                          <div
+                            class="<removed-for-snapshot-test>"
+                            title="pokemon"
+                          >
+                            pokemon
+                          </div>
+                          <div
+                            class="<removed-for-snapshot-test>"
+                          >
                             <div
                               class="<removed-for-snapshot-test>"
+                              data-testid="syncSettingsDropdown"
+                              role="combobox"
                             >
+                              <span
+                                class="<removed-for-snapshot-test>"
+                                id="react-select-4-live-region"
+                              />
+                              <span
+                                aria-atomic="false"
+                                aria-live="polite"
+                                aria-relevant="additions text"
+                                class="<removed-for-snapshot-test>"
+                              />
                               <div
                                 class="<removed-for-snapshot-test>"
                               >
@@ -730,76 +730,80 @@ exports[`CreateConnectionForm should render 1`] = `
                                   <div
                                     class="<removed-for-snapshot-test>"
                                   >
-                                    <div>
-                                      Full refresh
-                                    </div>
                                     <div
                                       class="<removed-for-snapshot-test>"
                                     >
-                                      |
-                                    </div>
-                                    <div>
-                                      Overwrite
+                                      <div>
+                                        Full refresh
+                                      </div>
+                                      <div
+                                        class="<removed-for-snapshot-test>"
+                                      >
+                                        |
+                                      </div>
+                                      <div>
+                                        Overwrite
+                                      </div>
                                     </div>
                                   </div>
+                                  <input
+                                    aria-autocomplete="list"
+                                    aria-expanded="false"
+                                    aria-haspopup="true"
+                                    aria-readonly="true"
+                                    class="<removed-for-snapshot-test>"
+                                    id="react-select-4-input"
+                                    inputmode="none"
+                                    role="combobox"
+                                    tabindex="0"
+                                    value=""
+                                  />
                                 </div>
-                                <input
-                                  aria-autocomplete="list"
-                                  aria-expanded="false"
-                                  aria-haspopup="true"
-                                  aria-readonly="true"
-                                  class="<removed-for-snapshot-test>"
-                                  id="react-select-4-input"
-                                  inputmode="none"
-                                  role="combobox"
-                                  tabindex="0"
-                                  value=""
-                                />
-                              </div>
-                              <div
-                                class="<removed-for-snapshot-test>"
-                              >
                                 <div
-                                  aria-hidden="true"
                                   class="<removed-for-snapshot-test>"
                                 >
-                                  <svg
+                                  <div
                                     aria-hidden="true"
                                     class="<removed-for-snapshot-test>"
-                                    data-icon="sort-down"
-                                    data-prefix="fas"
-                                    focusable="false"
-                                    role="img"
-                                    viewBox="0 0 320 512"
-                                    xmlns="http://www.w3.org/2000/svg"
                                   >
-                                    <path
-                                      d="M311.9 335.1l-132.4 136.8C174.1 477.3 167.1 480 160 480c-7.055 0-14.12-2.702-19.47-8.109l-132.4-136.8C-9.229 317.8 3.055 288 27.66 288h264.7C316.9 288 329.2 317.8 311.9 335.1z"
-                                      fill="currentColor"
-                                    />
-                                  </svg>
+                                    <svg
+                                      aria-hidden="true"
+                                      class="<removed-for-snapshot-test>"
+                                      data-icon="sort-down"
+                                      data-prefix="fas"
+                                      focusable="false"
+                                      role="img"
+                                      viewBox="0 0 320 512"
+                                      xmlns="http://www.w3.org/2000/svg"
+                                    >
+                                      <path
+                                        d="M311.9 335.1l-132.4 136.8C174.1 477.3 167.1 480 160 480c-7.055 0-14.12-2.702-19.47-8.109l-132.4-136.8C-9.229 317.8 3.055 288 27.66 288h264.7C316.9 288 329.2 317.8 311.9 335.1z"
+                                        fill="currentColor"
+                                      />
+                                    </svg>
+                                  </div>
                                 </div>
                               </div>
                             </div>
                           </div>
-                        </div>
-                        <div
-                          class="<removed-for-snapshot-test>"
-                        />
-                        <div
-                          class="<removed-for-snapshot-test>"
-                        />
-                        <div
-                          class="<removed-for-snapshot-test>"
-                          title="'<source schema>"
-                        >
-                          '&lt;source schema&gt;
-                        </div>
-                        <div
-                          class="<removed-for-snapshot-test>"
-                          title="pokemon"
-                        >
-                          pokemon
+                          <div
+                            class="<removed-for-snapshot-test>"
+                          />
+                          <div
+                            class="<removed-for-snapshot-test>"
+                          />
+                          <div
+                            class="<removed-for-snapshot-test>"
+                            title="'<source schema>"
+                          >
+                            '&lt;source schema&gt;
+                          </div>
+                          <div
+                            class="<removed-for-snapshot-test>"
+                            title="pokemon"
+                          >
+                            pokemon
+                          </div>
                         </div>
                       </div>
                     </div>

--- a/airbyte-webapp/src/components/connection/CatalogTree/CatalogSection.module.scss
+++ b/airbyte-webapp/src/components/connection/CatalogTree/CatalogSection.module.scss
@@ -2,7 +2,7 @@
 @use "scss/variables";
 
 .streamFieldTableContainer {
-  margin-left: 85px;
+  margin-left: 83px;
   background: colors.$grey-50;
 }
 

--- a/airbyte-webapp/src/components/connection/CatalogTree/CatalogTree.module.scss
+++ b/airbyte-webapp/src/components/connection/CatalogTree/CatalogTree.module.scss
@@ -1,0 +1,5 @@
+@use "scss/variables";
+
+.catalogTreeTable {
+  padding: variables.$spacing-lg variables.$spacing-xl 0;
+}

--- a/airbyte-webapp/src/components/connection/CatalogTree/CatalogTree.tsx
+++ b/airbyte-webapp/src/components/connection/CatalogTree/CatalogTree.tsx
@@ -8,6 +8,7 @@ import { useConnectionFormService } from "hooks/services/ConnectionForm/Connecti
 import { naturalComparatorBy } from "utils/objects";
 
 import { BulkHeader } from "./BulkHeader";
+import styles from "./CatalogTree.module.scss";
 import { CatalogTreeBody } from "./CatalogTreeBody";
 import { CatalogTreeHeader } from "./CatalogTreeHeader";
 import { CatalogTreeSearch } from "./CatalogTreeSearch";
@@ -65,23 +66,25 @@ const CatalogTreeComponent: React.FC<React.PropsWithChildren<CatalogTreeProps>> 
     <BulkEditServiceProvider nodes={streams} update={onStreamsChanged}>
       <LoadingBackdrop loading={isLoading}>
         {mode !== "readonly" && <CatalogTreeSearch onSearch={setSearchString} />}
-        {isNewStreamsTableEnabled ? (
-          <>
-            <StreamConnectionHeader />
-            <CatalogTreeTableHeader />
-          </>
-        ) : (
-          <>
-            <CatalogTreeHeader />
-            <CatalogTreeSubheader />
-            <BulkHeader />
-          </>
-        )}
-        <CatalogTreeBody
-          streams={filteredStreams}
-          changedStreams={changedStreams}
-          onStreamChanged={onSingleStreamChanged}
-        />
+        <div className={isNewStreamsTableEnabled ? undefined : styles.catalogTreeTable}>
+          {isNewStreamsTableEnabled ? (
+            <>
+              <StreamConnectionHeader />
+              <CatalogTreeTableHeader />
+            </>
+          ) : (
+            <>
+              <CatalogTreeHeader />
+              <CatalogTreeSubheader />
+              <BulkHeader />
+            </>
+          )}
+          <CatalogTreeBody
+            streams={filteredStreams}
+            changedStreams={changedStreams}
+            onStreamChanged={onSingleStreamChanged}
+          />
+        </div>
       </LoadingBackdrop>
       {isNewStreamsTableEnabled && <BulkEditPanel />}
     </BulkEditServiceProvider>

--- a/airbyte-webapp/src/components/connection/CatalogTree/CatalogTreeSearch.module.scss
+++ b/airbyte-webapp/src/components/connection/CatalogTree/CatalogTreeSearch.module.scss
@@ -7,16 +7,6 @@
 .searchContent {
   position: relative;
   width: 100%;
-  padding-left: variables.$spacing-xl;
-
-  &::before {
-    content: attr(data-content);
-  }
-}
-
-.searchContentNew {
-  position: relative;
-  width: 100%;
   padding: 0 variables.$spacing-xl;
 
   &::before {

--- a/airbyte-webapp/src/components/connection/CatalogTree/CatalogTreeSearch.tsx
+++ b/airbyte-webapp/src/components/connection/CatalogTree/CatalogTreeSearch.tsx
@@ -1,4 +1,3 @@
-import classnames from "classnames";
 import React from "react";
 import { useIntl } from "react-intl";
 
@@ -11,17 +10,10 @@ interface CatalogTreeSearchProps {
 }
 
 export const CatalogTreeSearch: React.FC<CatalogTreeSearchProps> = ({ onSearch }) => {
-  const isNewStreamsTableEnabled = process.env.REACT_APP_NEW_STREAMS_TABLE ?? false;
-
   const { formatMessage } = useIntl();
 
-  const searchStyles = classnames({
-    [styles.searchContentNew]: isNewStreamsTableEnabled,
-    [styles.searchContent]: !isNewStreamsTableEnabled,
-  });
-
   return (
-    <div className={searchStyles}>
+    <div className={styles.searchContent}>
       <Input
         className={styles.searchInput}
         placeholder={formatMessage({

--- a/airbyte-webapp/src/components/connection/CatalogTree/StreamFieldTable.module.scss
+++ b/airbyte-webapp/src/components/connection/CatalogTree/StreamFieldTable.module.scss
@@ -1,8 +1,15 @@
 @use "scss/colors";
 @use "scss/variables";
 
+.container {
+  padding-bottom: variables.$spacing-md;
+
+  // HACK: Hot-fixes an issue in StreamHeader SCSS where the .catalogSectionRow margin-top is creating a spacing between rows
+  margin-bottom: -9px;
+}
+
 .rowsContainer {
   background: colors.$white;
   border-radius: variables.$border-radius-md;
-  margin: 0 10px 5px;
+  margin: 0 variables.$spacing-md;
 }

--- a/airbyte-webapp/src/components/connection/CatalogTree/StreamFieldTable.tsx
+++ b/airbyte-webapp/src/components/connection/CatalogTree/StreamFieldTable.tsx
@@ -20,7 +20,7 @@ interface StreamFieldTableProps {
 
 export const StreamFieldTable: React.FC<StreamFieldTableProps> = (props) => {
   return (
-    <>
+    <div className={styles.container}>
       <TreeRowWrapper noBorder>
         <FieldHeader />
       </TreeRowWrapper>
@@ -38,6 +38,6 @@ export const StreamFieldTable: React.FC<StreamFieldTableProps> = (props) => {
           </TreeRowWrapper>
         ))}
       </div>
-    </>
+    </div>
   );
 };

--- a/airbyte-webapp/src/pages/ConnectionPage/pages/ConnectionItemPage/__snapshots__/ConnectionReplicationTab.test.tsx.snap
+++ b/airbyte-webapp/src/pages/ConnectionPage/pages/ConnectionItemPage/__snapshots__/ConnectionReplicationTab.test.tsx.snap
@@ -364,252 +364,217 @@ exports[`ConnectionReplicationTab should render 1`] = `
                   <div
                     class="<removed-for-snapshot-test>"
                   >
-                    <label
-                      class="<removed-for-snapshot-test>"
-                    >
-                      <input
-                        class="<removed-for-snapshot-test>"
-                        type="checkbox"
-                      />
-                    </label>
-                  </div>
-                  <div
-                    class="<removed-for-snapshot-test>"
-                  />
-                  <div
-                    class="<removed-for-snapshot-test>"
-                  >
-                    Sync
-                  </div>
-                  <div
-                    class="<removed-for-snapshot-test>"
-                  >
-                    Source
                     <div
                       class="<removed-for-snapshot-test>"
                     >
+                      <label
+                        class="<removed-for-snapshot-test>"
+                      >
+                        <input
+                          class="<removed-for-snapshot-test>"
+                          type="checkbox"
+                        />
+                      </label>
+                    </div>
+                    <div
+                      class="<removed-for-snapshot-test>"
+                    />
+                    <div
+                      class="<removed-for-snapshot-test>"
+                    >
+                      Sync
+                    </div>
+                    <div
+                      class="<removed-for-snapshot-test>"
+                    >
+                      Source
                       <div
                         class="<removed-for-snapshot-test>"
                       >
                         <div
                           class="<removed-for-snapshot-test>"
                         >
-                          <svg
-                            fill="none"
-                            height="14"
-                            viewBox="0 0 14 14"
-                            width="14"
-                          >
-                            <path
-                              d="M7.00016 13.6663C3.31816 13.6663 0.333496 10.6817 0.333496 6.99967C0.333496 3.31767 3.31816 0.333008 7.00016 0.333008C10.6822 0.333008 13.6668 3.31767 13.6668 6.99967C13.6668 10.6817 10.6822 13.6663 7.00016 13.6663ZM7.00016 12.333C8.41465 12.333 9.77121 11.7711 10.7714 10.7709C11.7716 9.77072 12.3335 8.41416 12.3335 6.99967C12.3335 5.58519 11.7716 4.22863 10.7714 3.22844C9.77121 2.22824 8.41465 1.66634 7.00016 1.66634C5.58567 1.66634 4.22912 2.22824 3.22893 3.22844C2.22873 4.22863 1.66683 5.58519 1.66683 6.99967C1.66683 8.41416 2.22873 9.77072 3.22893 10.7709C4.22912 11.7711 5.58567 12.333 7.00016 12.333ZM6.3335 3.66634H7.66683V4.99967H6.3335V3.66634ZM6.3335 6.33301H7.66683V10.333H6.3335V6.33301Z"
-                              fill="currentColor"
-                            />
-                          </svg>
-                        </div>
-                      </div>
-                    </div>
-                  </div>
-                  <div
-                    class="<removed-for-snapshot-test>"
-                  />
-                  <div
-                    class="<removed-for-snapshot-test>"
-                  >
-                    Sync mode
-                    <div
-                      class="<removed-for-snapshot-test>"
-                    >
-                      <div
-                        class="<removed-for-snapshot-test>"
-                      >
-                        <div
-                          class="<removed-for-snapshot-test>"
-                        >
-                          <svg
-                            fill="none"
-                            height="14"
-                            viewBox="0 0 14 14"
-                            width="14"
-                          >
-                            <path
-                              d="M7.00016 13.6663C3.31816 13.6663 0.333496 10.6817 0.333496 6.99967C0.333496 3.31767 3.31816 0.333008 7.00016 0.333008C10.6822 0.333008 13.6668 3.31767 13.6668 6.99967C13.6668 10.6817 10.6822 13.6663 7.00016 13.6663ZM7.00016 12.333C8.41465 12.333 9.77121 11.7711 10.7714 10.7709C11.7716 9.77072 12.3335 8.41416 12.3335 6.99967C12.3335 5.58519 11.7716 4.22863 10.7714 3.22844C9.77121 2.22824 8.41465 1.66634 7.00016 1.66634C5.58567 1.66634 4.22912 2.22824 3.22893 3.22844C2.22873 4.22863 1.66683 5.58519 1.66683 6.99967C1.66683 8.41416 2.22873 9.77072 3.22893 10.7709C4.22912 11.7711 5.58567 12.333 7.00016 12.333ZM6.3335 3.66634H7.66683V4.99967H6.3335V3.66634ZM6.3335 6.33301H7.66683V10.333H6.3335V6.33301Z"
-                              fill="currentColor"
-                            />
-                          </svg>
-                        </div>
-                      </div>
-                    </div>
-                  </div>
-                  <div
-                    class="<removed-for-snapshot-test>"
-                  >
-                    Cursor field
-                    <div
-                      class="<removed-for-snapshot-test>"
-                    >
-                      <div
-                        class="<removed-for-snapshot-test>"
-                      >
-                        <div
-                          class="<removed-for-snapshot-test>"
-                        >
-                          <svg
-                            fill="none"
-                            height="14"
-                            viewBox="0 0 14 14"
-                            width="14"
-                          >
-                            <path
-                              d="M7.00016 13.6663C3.31816 13.6663 0.333496 10.6817 0.333496 6.99967C0.333496 3.31767 3.31816 0.333008 7.00016 0.333008C10.6822 0.333008 13.6668 3.31767 13.6668 6.99967C13.6668 10.6817 10.6822 13.6663 7.00016 13.6663ZM7.00016 12.333C8.41465 12.333 9.77121 11.7711 10.7714 10.7709C11.7716 9.77072 12.3335 8.41416 12.3335 6.99967C12.3335 5.58519 11.7716 4.22863 10.7714 3.22844C9.77121 2.22824 8.41465 1.66634 7.00016 1.66634C5.58567 1.66634 4.22912 2.22824 3.22893 3.22844C2.22873 4.22863 1.66683 5.58519 1.66683 6.99967C1.66683 8.41416 2.22873 9.77072 3.22893 10.7709C4.22912 11.7711 5.58567 12.333 7.00016 12.333ZM6.3335 3.66634H7.66683V4.99967H6.3335V3.66634ZM6.3335 6.33301H7.66683V10.333H6.3335V6.33301Z"
-                              fill="currentColor"
-                            />
-                          </svg>
-                        </div>
-                      </div>
-                    </div>
-                  </div>
-                  <div
-                    class="<removed-for-snapshot-test>"
-                  >
-                    Primary key
-                    <div
-                      class="<removed-for-snapshot-test>"
-                    >
-                      <div
-                        class="<removed-for-snapshot-test>"
-                      >
-                        <div
-                          class="<removed-for-snapshot-test>"
-                        >
-                          <svg
-                            fill="none"
-                            height="14"
-                            viewBox="0 0 14 14"
-                            width="14"
-                          >
-                            <path
-                              d="M7.00016 13.6663C3.31816 13.6663 0.333496 10.6817 0.333496 6.99967C0.333496 3.31767 3.31816 0.333008 7.00016 0.333008C10.6822 0.333008 13.6668 3.31767 13.6668 6.99967C13.6668 10.6817 10.6822 13.6663 7.00016 13.6663ZM7.00016 12.333C8.41465 12.333 9.77121 11.7711 10.7714 10.7709C11.7716 9.77072 12.3335 8.41416 12.3335 6.99967C12.3335 5.58519 11.7716 4.22863 10.7714 3.22844C9.77121 2.22824 8.41465 1.66634 7.00016 1.66634C5.58567 1.66634 4.22912 2.22824 3.22893 3.22844C2.22873 4.22863 1.66683 5.58519 1.66683 6.99967C1.66683 8.41416 2.22873 9.77072 3.22893 10.7709C4.22912 11.7711 5.58567 12.333 7.00016 12.333ZM6.3335 3.66634H7.66683V4.99967H6.3335V3.66634ZM6.3335 6.33301H7.66683V10.333H6.3335V6.33301Z"
-                              fill="currentColor"
-                            />
-                          </svg>
-                        </div>
-                      </div>
-                    </div>
-                  </div>
-                  <div
-                    class="<removed-for-snapshot-test>"
-                  >
-                    Destination
-                    <div
-                      class="<removed-for-snapshot-test>"
-                    >
-                      <div
-                        class="<removed-for-snapshot-test>"
-                      >
-                        <div
-                          class="<removed-for-snapshot-test>"
-                        >
-                          <svg
-                            fill="none"
-                            height="14"
-                            viewBox="0 0 14 14"
-                            width="14"
-                          >
-                            <path
-                              d="M7.00016 13.6663C3.31816 13.6663 0.333496 10.6817 0.333496 6.99967C0.333496 3.31767 3.31816 0.333008 7.00016 0.333008C10.6822 0.333008 13.6668 3.31767 13.6668 6.99967C13.6668 10.6817 10.6822 13.6663 7.00016 13.6663ZM7.00016 12.333C8.41465 12.333 9.77121 11.7711 10.7714 10.7709C11.7716 9.77072 12.3335 8.41416 12.3335 6.99967C12.3335 5.58519 11.7716 4.22863 10.7714 3.22844C9.77121 2.22824 8.41465 1.66634 7.00016 1.66634C5.58567 1.66634 4.22912 2.22824 3.22893 3.22844C2.22873 4.22863 1.66683 5.58519 1.66683 6.99967C1.66683 8.41416 2.22873 9.77072 3.22893 10.7709C4.22912 11.7711 5.58567 12.333 7.00016 12.333ZM6.3335 3.66634H7.66683V4.99967H6.3335V3.66634ZM6.3335 6.33301H7.66683V10.333H6.3335V6.33301Z"
-                              fill="currentColor"
-                            />
-                          </svg>
-                        </div>
-                      </div>
-                    </div>
-                  </div>
-                  <div
-                    class="<removed-for-snapshot-test>"
-                  />
-                </div>
-                <div
-                  class="<removed-for-snapshot-test>"
-                >
-                  <div
-                    class="<removed-for-snapshot-test>"
-                  />
-                  <div
-                    class="<removed-for-snapshot-test>"
-                  >
-                    Namespace
-                  </div>
-                  <div
-                    class="<removed-for-snapshot-test>"
-                  >
-                    Stream name
-                  </div>
-                  <div
-                    class="<removed-for-snapshot-test>"
-                  >
-                    Source | Destination
-                  </div>
-                  <div
-                    class="<removed-for-snapshot-test>"
-                  />
-                  <div
-                    class="<removed-for-snapshot-test>"
-                  />
-                  <div
-                    class="<removed-for-snapshot-test>"
-                  >
-                    Namespace
-                  </div>
-                  <div
-                    class="<removed-for-snapshot-test>"
-                  >
-                    Stream name
-                  </div>
-                </div>
-                <div
-                  class="<removed-for-snapshot-test>"
-                >
-                  <div
-                    class="<removed-for-snapshot-test>"
-                  >
-                    <div
-                      class="<removed-for-snapshot-test>"
-                    >
-                      <div
-                        class="<removed-for-snapshot-test>"
-                      >
-                        <label
-                          class="<removed-for-snapshot-test>"
-                        >
-                          <input
+                          <div
                             class="<removed-for-snapshot-test>"
-                            type="checkbox"
-                          />
-                        </label>
+                          >
+                            <svg
+                              fill="none"
+                              height="14"
+                              viewBox="0 0 14 14"
+                              width="14"
+                            >
+                              <path
+                                d="M7.00016 13.6663C3.31816 13.6663 0.333496 10.6817 0.333496 6.99967C0.333496 3.31767 3.31816 0.333008 7.00016 0.333008C10.6822 0.333008 13.6668 3.31767 13.6668 6.99967C13.6668 10.6817 10.6822 13.6663 7.00016 13.6663ZM7.00016 12.333C8.41465 12.333 9.77121 11.7711 10.7714 10.7709C11.7716 9.77072 12.3335 8.41416 12.3335 6.99967C12.3335 5.58519 11.7716 4.22863 10.7714 3.22844C9.77121 2.22824 8.41465 1.66634 7.00016 1.66634C5.58567 1.66634 4.22912 2.22824 3.22893 3.22844C2.22873 4.22863 1.66683 5.58519 1.66683 6.99967C1.66683 8.41416 2.22873 9.77072 3.22893 10.7709C4.22912 11.7711 5.58567 12.333 7.00016 12.333ZM6.3335 3.66634H7.66683V4.99967H6.3335V3.66634ZM6.3335 6.33301H7.66683V10.333H6.3335V6.33301Z"
+                                fill="currentColor"
+                              />
+                            </svg>
+                          </div>
+                        </div>
                       </div>
+                    </div>
+                    <div
+                      class="<removed-for-snapshot-test>"
+                    />
+                    <div
+                      class="<removed-for-snapshot-test>"
+                    >
+                      Sync mode
                       <div
                         class="<removed-for-snapshot-test>"
                       >
-                        <span
+                        <div
                           class="<removed-for-snapshot-test>"
                         >
-                          <svg
-                            aria-hidden="true"
+                          <div
                             class="<removed-for-snapshot-test>"
-                            data-icon="chevron-right"
-                            data-prefix="fas"
-                            focusable="false"
-                            role="img"
-                            viewBox="0 0 320 512"
-                            xmlns="http://www.w3.org/2000/svg"
                           >
-                            <path
-                              d="M96 480c-8.188 0-16.38-3.125-22.62-9.375c-12.5-12.5-12.5-32.75 0-45.25L242.8 256L73.38 86.63c-12.5-12.5-12.5-32.75 0-45.25s32.75-12.5 45.25 0l192 192c12.5 12.5 12.5 32.75 0 45.25l-192 192C112.4 476.9 104.2 480 96 480z"
-                              fill="currentColor"
-                            />
-                          </svg>
-                        </span>
+                            <svg
+                              fill="none"
+                              height="14"
+                              viewBox="0 0 14 14"
+                              width="14"
+                            >
+                              <path
+                                d="M7.00016 13.6663C3.31816 13.6663 0.333496 10.6817 0.333496 6.99967C0.333496 3.31767 3.31816 0.333008 7.00016 0.333008C10.6822 0.333008 13.6668 3.31767 13.6668 6.99967C13.6668 10.6817 10.6822 13.6663 7.00016 13.6663ZM7.00016 12.333C8.41465 12.333 9.77121 11.7711 10.7714 10.7709C11.7716 9.77072 12.3335 8.41416 12.3335 6.99967C12.3335 5.58519 11.7716 4.22863 10.7714 3.22844C9.77121 2.22824 8.41465 1.66634 7.00016 1.66634C5.58567 1.66634 4.22912 2.22824 3.22893 3.22844C2.22873 4.22863 1.66683 5.58519 1.66683 6.99967C1.66683 8.41416 2.22873 9.77072 3.22893 10.7709C4.22912 11.7711 5.58567 12.333 7.00016 12.333ZM6.3335 3.66634H7.66683V4.99967H6.3335V3.66634ZM6.3335 6.33301H7.66683V10.333H6.3335V6.33301Z"
+                                fill="currentColor"
+                              />
+                            </svg>
+                          </div>
+                        </div>
                       </div>
+                    </div>
+                    <div
+                      class="<removed-for-snapshot-test>"
+                    >
+                      Cursor field
+                      <div
+                        class="<removed-for-snapshot-test>"
+                      >
+                        <div
+                          class="<removed-for-snapshot-test>"
+                        >
+                          <div
+                            class="<removed-for-snapshot-test>"
+                          >
+                            <svg
+                              fill="none"
+                              height="14"
+                              viewBox="0 0 14 14"
+                              width="14"
+                            >
+                              <path
+                                d="M7.00016 13.6663C3.31816 13.6663 0.333496 10.6817 0.333496 6.99967C0.333496 3.31767 3.31816 0.333008 7.00016 0.333008C10.6822 0.333008 13.6668 3.31767 13.6668 6.99967C13.6668 10.6817 10.6822 13.6663 7.00016 13.6663ZM7.00016 12.333C8.41465 12.333 9.77121 11.7711 10.7714 10.7709C11.7716 9.77072 12.3335 8.41416 12.3335 6.99967C12.3335 5.58519 11.7716 4.22863 10.7714 3.22844C9.77121 2.22824 8.41465 1.66634 7.00016 1.66634C5.58567 1.66634 4.22912 2.22824 3.22893 3.22844C2.22873 4.22863 1.66683 5.58519 1.66683 6.99967C1.66683 8.41416 2.22873 9.77072 3.22893 10.7709C4.22912 11.7711 5.58567 12.333 7.00016 12.333ZM6.3335 3.66634H7.66683V4.99967H6.3335V3.66634ZM6.3335 6.33301H7.66683V10.333H6.3335V6.33301Z"
+                                fill="currentColor"
+                              />
+                            </svg>
+                          </div>
+                        </div>
+                      </div>
+                    </div>
+                    <div
+                      class="<removed-for-snapshot-test>"
+                    >
+                      Primary key
+                      <div
+                        class="<removed-for-snapshot-test>"
+                      >
+                        <div
+                          class="<removed-for-snapshot-test>"
+                        >
+                          <div
+                            class="<removed-for-snapshot-test>"
+                          >
+                            <svg
+                              fill="none"
+                              height="14"
+                              viewBox="0 0 14 14"
+                              width="14"
+                            >
+                              <path
+                                d="M7.00016 13.6663C3.31816 13.6663 0.333496 10.6817 0.333496 6.99967C0.333496 3.31767 3.31816 0.333008 7.00016 0.333008C10.6822 0.333008 13.6668 3.31767 13.6668 6.99967C13.6668 10.6817 10.6822 13.6663 7.00016 13.6663ZM7.00016 12.333C8.41465 12.333 9.77121 11.7711 10.7714 10.7709C11.7716 9.77072 12.3335 8.41416 12.3335 6.99967C12.3335 5.58519 11.7716 4.22863 10.7714 3.22844C9.77121 2.22824 8.41465 1.66634 7.00016 1.66634C5.58567 1.66634 4.22912 2.22824 3.22893 3.22844C2.22873 4.22863 1.66683 5.58519 1.66683 6.99967C1.66683 8.41416 2.22873 9.77072 3.22893 10.7709C4.22912 11.7711 5.58567 12.333 7.00016 12.333ZM6.3335 3.66634H7.66683V4.99967H6.3335V3.66634ZM6.3335 6.33301H7.66683V10.333H6.3335V6.33301Z"
+                                fill="currentColor"
+                              />
+                            </svg>
+                          </div>
+                        </div>
+                      </div>
+                    </div>
+                    <div
+                      class="<removed-for-snapshot-test>"
+                    >
+                      Destination
+                      <div
+                        class="<removed-for-snapshot-test>"
+                      >
+                        <div
+                          class="<removed-for-snapshot-test>"
+                        >
+                          <div
+                            class="<removed-for-snapshot-test>"
+                          >
+                            <svg
+                              fill="none"
+                              height="14"
+                              viewBox="0 0 14 14"
+                              width="14"
+                            >
+                              <path
+                                d="M7.00016 13.6663C3.31816 13.6663 0.333496 10.6817 0.333496 6.99967C0.333496 3.31767 3.31816 0.333008 7.00016 0.333008C10.6822 0.333008 13.6668 3.31767 13.6668 6.99967C13.6668 10.6817 10.6822 13.6663 7.00016 13.6663ZM7.00016 12.333C8.41465 12.333 9.77121 11.7711 10.7714 10.7709C11.7716 9.77072 12.3335 8.41416 12.3335 6.99967C12.3335 5.58519 11.7716 4.22863 10.7714 3.22844C9.77121 2.22824 8.41465 1.66634 7.00016 1.66634C5.58567 1.66634 4.22912 2.22824 3.22893 3.22844C2.22873 4.22863 1.66683 5.58519 1.66683 6.99967C1.66683 8.41416 2.22873 9.77072 3.22893 10.7709C4.22912 11.7711 5.58567 12.333 7.00016 12.333ZM6.3335 3.66634H7.66683V4.99967H6.3335V3.66634ZM6.3335 6.33301H7.66683V10.333H6.3335V6.33301Z"
+                                fill="currentColor"
+                              />
+                            </svg>
+                          </div>
+                        </div>
+                      </div>
+                    </div>
+                    <div
+                      class="<removed-for-snapshot-test>"
+                    />
+                  </div>
+                  <div
+                    class="<removed-for-snapshot-test>"
+                  >
+                    <div
+                      class="<removed-for-snapshot-test>"
+                    />
+                    <div
+                      class="<removed-for-snapshot-test>"
+                    >
+                      Namespace
+                    </div>
+                    <div
+                      class="<removed-for-snapshot-test>"
+                    >
+                      Stream name
+                    </div>
+                    <div
+                      class="<removed-for-snapshot-test>"
+                    >
+                      Source | Destination
+                    </div>
+                    <div
+                      class="<removed-for-snapshot-test>"
+                    />
+                    <div
+                      class="<removed-for-snapshot-test>"
+                    />
+                    <div
+                      class="<removed-for-snapshot-test>"
+                    >
+                      Namespace
+                    </div>
+                    <div
+                      class="<removed-for-snapshot-test>"
+                    >
+                      Stream name
+                    </div>
+                  </div>
+                  <div
+                    class="<removed-for-snapshot-test>"
+                  >
+                    <div
+                      class="<removed-for-snapshot-test>"
+                    >
                       <div
                         class="<removed-for-snapshot-test>"
                       >
@@ -620,54 +585,89 @@ exports[`ConnectionReplicationTab should render 1`] = `
                             class="<removed-for-snapshot-test>"
                           >
                             <input
-                              checked=""
                               class="<removed-for-snapshot-test>"
-                              data-testid="pokemon-stream-sync-switch"
                               type="checkbox"
-                              value=""
-                            />
-                            <span
-                              class="<removed-for-snapshot-test>"
                             />
                           </label>
                         </div>
                         <div
                           class="<removed-for-snapshot-test>"
-                          title=""
                         >
                           <span
                             class="<removed-for-snapshot-test>"
                           >
-                            No namespace
+                            <svg
+                              aria-hidden="true"
+                              class="<removed-for-snapshot-test>"
+                              data-icon="chevron-right"
+                              data-prefix="fas"
+                              focusable="false"
+                              role="img"
+                              viewBox="0 0 320 512"
+                              xmlns="http://www.w3.org/2000/svg"
+                            >
+                              <path
+                                d="M96 480c-8.188 0-16.38-3.125-22.62-9.375c-12.5-12.5-12.5-32.75 0-45.25L242.8 256L73.38 86.63c-12.5-12.5-12.5-32.75 0-45.25s32.75-12.5 45.25 0l192 192c12.5 12.5 12.5 32.75 0 45.25l-192 192C112.4 476.9 104.2 480 96 480z"
+                                fill="currentColor"
+                              />
+                            </svg>
                           </span>
-                        </div>
-                        <div
-                          class="<removed-for-snapshot-test>"
-                          title="pokemon"
-                        >
-                          pokemon
                         </div>
                         <div
                           class="<removed-for-snapshot-test>"
                         >
                           <div
                             class="<removed-for-snapshot-test>"
-                            data-testid="syncSettingsDropdown"
-                            role="combobox"
+                          >
+                            <label
+                              class="<removed-for-snapshot-test>"
+                            >
+                              <input
+                                checked=""
+                                class="<removed-for-snapshot-test>"
+                                data-testid="pokemon-stream-sync-switch"
+                                type="checkbox"
+                                value=""
+                              />
+                              <span
+                                class="<removed-for-snapshot-test>"
+                              />
+                            </label>
+                          </div>
+                          <div
+                            class="<removed-for-snapshot-test>"
+                            title=""
                           >
                             <span
                               class="<removed-for-snapshot-test>"
-                              id="react-select-4-live-region"
-                            />
-                            <span
-                              aria-atomic="false"
-                              aria-live="polite"
-                              aria-relevant="additions text"
-                              class="<removed-for-snapshot-test>"
-                            />
+                            >
+                              No namespace
+                            </span>
+                          </div>
+                          <div
+                            class="<removed-for-snapshot-test>"
+                            title="pokemon"
+                          >
+                            pokemon
+                          </div>
+                          <div
+                            class="<removed-for-snapshot-test>"
+                          >
                             <div
                               class="<removed-for-snapshot-test>"
+                              data-testid="syncSettingsDropdown"
+                              role="combobox"
                             >
+                              <span
+                                class="<removed-for-snapshot-test>"
+                                id="react-select-4-live-region"
+                              />
+                              <span
+                                aria-atomic="false"
+                                aria-live="polite"
+                                aria-relevant="additions text"
+                                class="<removed-for-snapshot-test>"
+                              />
                               <div
                                 class="<removed-for-snapshot-test>"
                               >
@@ -677,76 +677,80 @@ exports[`ConnectionReplicationTab should render 1`] = `
                                   <div
                                     class="<removed-for-snapshot-test>"
                                   >
-                                    <div>
-                                      Full refresh
-                                    </div>
                                     <div
                                       class="<removed-for-snapshot-test>"
                                     >
-                                      |
-                                    </div>
-                                    <div>
-                                      Append
+                                      <div>
+                                        Full refresh
+                                      </div>
+                                      <div
+                                        class="<removed-for-snapshot-test>"
+                                      >
+                                        |
+                                      </div>
+                                      <div>
+                                        Append
+                                      </div>
                                     </div>
                                   </div>
+                                  <input
+                                    aria-autocomplete="list"
+                                    aria-expanded="false"
+                                    aria-haspopup="true"
+                                    aria-readonly="true"
+                                    class="<removed-for-snapshot-test>"
+                                    id="react-select-4-input"
+                                    inputmode="none"
+                                    role="combobox"
+                                    tabindex="0"
+                                    value=""
+                                  />
                                 </div>
-                                <input
-                                  aria-autocomplete="list"
-                                  aria-expanded="false"
-                                  aria-haspopup="true"
-                                  aria-readonly="true"
-                                  class="<removed-for-snapshot-test>"
-                                  id="react-select-4-input"
-                                  inputmode="none"
-                                  role="combobox"
-                                  tabindex="0"
-                                  value=""
-                                />
-                              </div>
-                              <div
-                                class="<removed-for-snapshot-test>"
-                              >
                                 <div
-                                  aria-hidden="true"
                                   class="<removed-for-snapshot-test>"
                                 >
-                                  <svg
+                                  <div
                                     aria-hidden="true"
                                     class="<removed-for-snapshot-test>"
-                                    data-icon="sort-down"
-                                    data-prefix="fas"
-                                    focusable="false"
-                                    role="img"
-                                    viewBox="0 0 320 512"
-                                    xmlns="http://www.w3.org/2000/svg"
                                   >
-                                    <path
-                                      d="M311.9 335.1l-132.4 136.8C174.1 477.3 167.1 480 160 480c-7.055 0-14.12-2.702-19.47-8.109l-132.4-136.8C-9.229 317.8 3.055 288 27.66 288h264.7C316.9 288 329.2 317.8 311.9 335.1z"
-                                      fill="currentColor"
-                                    />
-                                  </svg>
+                                    <svg
+                                      aria-hidden="true"
+                                      class="<removed-for-snapshot-test>"
+                                      data-icon="sort-down"
+                                      data-prefix="fas"
+                                      focusable="false"
+                                      role="img"
+                                      viewBox="0 0 320 512"
+                                      xmlns="http://www.w3.org/2000/svg"
+                                    >
+                                      <path
+                                        d="M311.9 335.1l-132.4 136.8C174.1 477.3 167.1 480 160 480c-7.055 0-14.12-2.702-19.47-8.109l-132.4-136.8C-9.229 317.8 3.055 288 27.66 288h264.7C316.9 288 329.2 317.8 311.9 335.1z"
+                                        fill="currentColor"
+                                      />
+                                    </svg>
+                                  </div>
                                 </div>
                               </div>
                             </div>
                           </div>
-                        </div>
-                        <div
-                          class="<removed-for-snapshot-test>"
-                        />
-                        <div
-                          class="<removed-for-snapshot-test>"
-                        />
-                        <div
-                          class="<removed-for-snapshot-test>"
-                          title="'<source schema>"
-                        >
-                          '&lt;source schema&gt;
-                        </div>
-                        <div
-                          class="<removed-for-snapshot-test>"
-                          title="pokemon"
-                        >
-                          pokemon
+                          <div
+                            class="<removed-for-snapshot-test>"
+                          />
+                          <div
+                            class="<removed-for-snapshot-test>"
+                          />
+                          <div
+                            class="<removed-for-snapshot-test>"
+                            title="'<source schema>"
+                          >
+                            '&lt;source schema&gt;
+                          </div>
+                          <div
+                            class="<removed-for-snapshot-test>"
+                            title="pokemon"
+                          >
+                            pokemon
+                          </div>
                         </div>
                       </div>
                     </div>

--- a/airbyte-webapp/src/views/Connection/ConnectionForm/ConnectionFormFields.tsx
+++ b/airbyte-webapp/src/views/Connection/ConnectionForm/ConnectionFormFields.tsx
@@ -46,8 +46,6 @@ export const ConnectionFormFields: React.FC<ConnectionFormFieldsProps> = ({ valu
     clearFormChange(formId);
   });
 
-  const isNewStreamsTableEnabled = process.env.REACT_APP_NEW_STREAMS_TABLE ?? false;
-
   return (
     <>
       {/* FormChangeTracker is here as it has access to everything it needs without being repeated */}
@@ -118,7 +116,7 @@ export const ConnectionFormFields: React.FC<ConnectionFormFieldsProps> = ({ valu
             )}
           </Field>
         </Section>
-        <Section className={isNewStreamsTableEnabled ? styles.flush : undefined}>
+        <Section className={styles.flush}>
           <Field
             name="syncCatalog.streams"
             component={SyncCatalogField}


### PR DESCRIPTION
## What
Resolves #19874
Closes #19924

Fixes many issues with the margin and padding in the CatalogTree table:

* Fixes the field table left margin not quite aligning with the row
* Fixes the bottom margin of the field table
* Fixes padding issues around the table and simplifies check between old table and new table

Before:
![image](https://user-images.githubusercontent.com/168664/204917286-be5b2945-093b-4002-b17c-ac156fcf78b5.png)

Problem areas:
![fixes](https://user-images.githubusercontent.com/168664/204917628-f03f85dd-9a7f-4064-963d-e05a50daf473.png)


After:

![image](https://user-images.githubusercontent.com/168664/204916727-7ee918a3-a37f-40f7-951d-0c8901b602c6.png)


## How
This approach favors the parent pushing the content inward with padding over the content making margin for themselves.
There is a hotfix for specific situation that was too convoluted to fix. Noted in comments.
