### PR TITLE
Added dark variant to Button

### DIFF
--- a/airbyte-webapp/src/components/ui/Button/Button.module.scss
+++ b/airbyte-webapp/src/components/ui/Button/Button.module.scss
@@ -213,6 +213,21 @@
     }
   }
 
+  &.typeDark {
+    background-color: colors.$dark-blue;
+    color: colors.$white;
+
+    &:hover {
+      background-color: colors.$dark-blue-800;
+      color: colors.$white;
+    }
+
+    &:active {
+      background-color: colors.$dark-blue-1000;
+      color: colors.$white;
+    }
+  }
+
   &.isLoading {
     position: relative;
     align-content: center;

--- a/airbyte-webapp/src/components/ui/Button/Button.tsx
+++ b/airbyte-webapp/src/components/ui/Button/Button.tsx
@@ -32,6 +32,7 @@ export const Button = React.forwardRef<HTMLButtonElement, ButtonProps>((props, r
     [styles.typeLight]: variant === "light",
     [styles.typePrimary]: variant === "primary",
     [styles.typeSecondary]: variant === "secondary",
+    [styles.typeDark]: variant === "dark",
   };
   const widthStyle: { width?: string } = {};
   if (width) {

--- a/airbyte-webapp/src/components/ui/Button/index.stories.tsx
+++ b/airbyte-webapp/src/components/ui/Button/index.stories.tsx
@@ -75,3 +75,9 @@ Clear.args = {
   variant: "clear",
   children: "No Stroke",
 };
+
+export const Dark = Template.bind({});
+Dark.args = {
+  variant: "dark",
+  children: "Dark",
+};

--- a/airbyte-webapp/src/components/ui/Button/types.tsx
+++ b/airbyte-webapp/src/components/ui/Button/types.tsx
@@ -1,7 +1,7 @@
 import React from "react";
 
 type ButtonSize = "xs" | "sm" | "lg";
-type ButtonVariant = "primary" | "secondary" | "danger" | "light" | "clear";
+type ButtonVariant = "primary" | "secondary" | "danger" | "light" | "clear" | "dark";
 
 export interface ButtonProps extends React.ButtonHTMLAttributes<HTMLButtonElement> {
   clickable?: boolean;


### PR DESCRIPTION
## What
Closes [#19445](https://github.com/airbytehq/airbyte/issues/19445)

## How
Added dark variant to Button component

[Figma prototype](https://www.figma.com/file/gMNRYVJav25pdsoxAyW7Qp/00_01_WEB-APP-LIBRARIES?node-id=58%3A126&t=I233yUM96VlbIiC1-0)

## Test result

State: default, active, disabled, icon + focus, loading

![image](https://user-images.githubusercontent.com/66960359/204934889-e9695e25-513a-40b4-b7ce-4cd1fbdc4dcb.png)
