### PR TITLE
Include http method in `SimpleRetriever` log message for requests

### DIFF
--- a/airbyte-cdk/python/CHANGELOG.md
+++ b/airbyte-cdk/python/CHANGELOG.md
@@ -1,5 +1,8 @@
 # Changelog
 
+## 0.11.2
+Low-code: Include the HTTP method used by the request in logging output of the `airbyte-cdk`
+
 ## 0.11.1
 Low-code: Fix the component manifest schema to and validate check instead of checker
 

--- a/airbyte-cdk/python/airbyte_cdk/sources/declarative/retrievers/simple_retriever.py
+++ b/airbyte-cdk/python/airbyte_cdk/sources/declarative/retrievers/simple_retriever.py
@@ -413,7 +413,7 @@ class SimpleRetriever(Retriever, HttpStream, JsonSchemaMixin):
 
     def _create_trace_message_from_request(self, request: requests.PreparedRequest):
         # FIXME: this should return some sort of trace message
-        request_dict = {"url": request.url, "headers": dict(request.headers), "body": request.body}
+        request_dict = {"url": request.url, "http_method": request.method, "headers": dict(request.headers), "body": request.body}
         log_message = filter_secrets(f"request:{json.dumps(request_dict)}")
         return AirbyteMessage(type=MessageType.LOG, log=AirbyteLogMessage(level=Level.INFO, message=log_message))
 

--- a/airbyte-cdk/python/setup.py
+++ b/airbyte-cdk/python/setup.py
@@ -15,7 +15,7 @@ README = (HERE / "README.md").read_text()
 
 setup(
     name="airbyte-cdk",
-    version="0.11.1",
+    version="0.11.2",
     description="A framework for writing Airbyte Connectors.",
     long_description=README,
     long_description_content_type="text/markdown",


### PR DESCRIPTION
## What
Adds the HTTP method used by the request to logging output of the `airbyte-cdk`, per https://github.com/airbytehq/airbyte/issues/19735.

## How
Adds a `"http_method": <request.method>` key to `AirbyteLogMessage`'s `message` dictionary.

## Recommended reading order
1. `airbyte-cdk/python/airbyte_cdk/sources/declarative/retrievers/simple_retriever.py`

## 🚨 User Impact 🚨
Are there any breaking changes? What is the end result perceived by the user? If yes, please merge this PR with the 🚨🚨 emoji so changelog authors can further highlight this if needed.

## Pre-merge Checklist
Expand the relevant checklist and delete the others.

- [x] Unit & integration tests passing. 
- [x] Code reviews completed
- [X] PR name follows [PR naming conventions](https://docs.airbyte.com/contributing-to-airbyte/issues-and-pull-requests)
- [x] Issue acceptance criteria met*

## Tests

<details><summary><strong>Unit</strong></summary>

*Put your unit tests output here.*

</details>

<details><summary><strong>Integration</strong></summary>

*Put your integration tests output here.*

</details>

<details><summary><strong>Acceptance</strong></summary>

*Put your acceptance tests output here.*

</details>
