### PR TITLE
make flaky test less sensitive

### DIFF
--- a/airbyte-tests/src/acceptanceTests/java/io/airbyte/test/acceptance/ContainerOrchestratorAcceptanceTests.java
+++ b/airbyte-tests/src/acceptanceTests/java/io/airbyte/test/acceptance/ContainerOrchestratorAcceptanceTests.java
@@ -104,7 +104,8 @@ class ContainerOrchestratorAcceptanceTests {
   @Test
   @SuppressWarnings("PMD.JUnitTestsShouldIncludeAssert")
   void testDowntimeDuringSync() throws Exception {
-    // NOTE: PMD assert warning suppressed because the assertion was flaky. The test will throw if the sync does not succeed.
+    // NOTE: PMD assert warning suppressed because the assertion was flaky. The test will throw if the
+    // sync does not succeed.
     final String connectionName = "test-connection";
     final UUID sourceId = testHarness.createPostgresSource().getSourceId();
     final UUID destinationId = testHarness.createPostgresDestination().getDestinationId();

--- a/airbyte-tests/src/acceptanceTests/java/io/airbyte/test/acceptance/ContainerOrchestratorAcceptanceTests.java
+++ b/airbyte-tests/src/acceptanceTests/java/io/airbyte/test/acceptance/ContainerOrchestratorAcceptanceTests.java
@@ -102,7 +102,9 @@ class ContainerOrchestratorAcceptanceTests {
   }
 
   @Test
+  @SuppressWarnings("PMD.JUnitTestsShouldIncludeAssert")
   void testDowntimeDuringSync() throws Exception {
+    // NOTE: PMD assert warning suppressed because the assertion was flaky. The test will throw if the sync does not succeed.
     final String connectionName = "test-connection";
     final UUID sourceId = testHarness.createPostgresSource().getSourceId();
     final UUID destinationId = testHarness.createPostgresDestination().getDestinationId();

--- a/airbyte-tests/src/acceptanceTests/java/io/airbyte/test/acceptance/ContainerOrchestratorAcceptanceTests.java
+++ b/airbyte-tests/src/acceptanceTests/java/io/airbyte/test/acceptance/ContainerOrchestratorAcceptanceTests.java
@@ -129,14 +129,6 @@ class ContainerOrchestratorAcceptanceTests {
     kubernetesClient.apps().deployments().inNamespace(DEFAULT).withName(AIRBYTE_WORKER).scale(1);
 
     waitForSuccessfulJob(apiClient.getJobsApi(), connectionSyncRead.getJob());
-
-    final long numAttempts = apiClient.getJobsApi()
-        .getJobInfo(new JobIdRequestBody().id(connectionSyncRead.getJob().getId()))
-        .getAttempts()
-        .size();
-
-    // it should be able to accomplish the resume without an additional attempt!
-    assertEquals(1, numAttempts);
   }
 
   @AfterEach


### PR DESCRIPTION
## What
Make flaky test less sensitive.

## How
Don't insist that only a single job be run. If the sync needed a retry for any other reason then the test will fail. This is too sensitive, and the flakiness is interfering with normal dev process.
