### PR TITLE
Remove use of unimplemented pid() method

### DIFF
--- a/airbyte-commons-worker/src/main/java/io/airbyte/workers/normalization/DefaultNormalizationRunner.java
+++ b/airbyte-commons-worker/src/main/java/io/airbyte/workers/normalization/DefaultNormalizationRunner.java
@@ -201,7 +201,7 @@ public class DefaultNormalizationRunner implements NormalizationRunner {
       return;
     }
 
-    LOGGER.info("Terminating normalization process {}...", process.pid());
+    LOGGER.info("Terminating normalization process...");
     WorkerUtils.gentleClose(process, 1, TimeUnit.MINUTES);
 
     /*
@@ -210,11 +210,11 @@ public class DefaultNormalizationRunner implements NormalizationRunner {
      * Did the process actually terminate? If "yes", did it do so nominally?
      */
     if (process.isAlive()) {
-      throw new WorkerException("Normalization process " + process.pid() + " did not terminate after 1 minute.");
+      throw new WorkerException("Normalization process did not terminate after 1 minute.");
     } else if (process.exitValue() != 0) {
-      throw new WorkerException("Normalization process " + process.pid() + " did not terminate normally (exit code: " + process.exitValue() + ")");
+      throw new WorkerException("Normalization process did not terminate normally (exit code: " + process.exitValue() + ")");
     } else {
-      LOGGER.info("Normalization process {} successfully terminated.", process.pid());
+      LOGGER.info("Normalization process successfully terminated.");
     }
   }
 


### PR DESCRIPTION
## What
*Fix failures due to an unsupported operation during process close

## How
* Remove references to unimplemented `pid()` method

## Recommended reading order
1. `DefaultNormalizationRunner.java`