### PR TITLE
Fail on internal errors

### DIFF
--- a/airbyte-workers/src/main/java/io/airbyte/workers/ApplicationInitializer.java
+++ b/airbyte-workers/src/main/java/io/airbyte/workers/ApplicationInitializer.java
@@ -317,7 +317,7 @@ public class ApplicationInitializer implements ApplicationEventListener<ServiceR
       final Worker syncWorker = factory.newWorker(taskQueue,
           getWorkerOptions(maxWorkersConfig.getMaxSyncWorkers()));
       final WorkflowImplementationOptions options = WorkflowImplementationOptions.newBuilder()
-          .setFailWorkflowExceptionTypes(NonDeterministicException.class).build();
+          .setFailWorkflowExceptionTypes(NonDeterministicException.class, RuntimeException.class).build();
       syncWorker.registerWorkflowImplementationTypes(options,
           temporalProxyHelper.proxyWorkflowClass(SyncWorkflowImpl.class));
       syncWorker.registerActivitiesImplementations(


### PR DESCRIPTION
## What
If a runtime exception happens in an activity launched by the sync workflow, we should fail the workflow instead of making it stuck.