### PR TITLE
Fix: Tutorial config-based invalid keywords #20071

### DIFF
--- a/CONTRIBUTORS.md
+++ b/CONTRIBUTORS.md
@@ -61,6 +61,7 @@
 * [jonathan-duval](https://github.com/jonathan-duval)
 * [jonstacks](https://github.com/jonstacks)
 * [jrhizor](https://github.com/jrhizor)
+* [juweins](https://github.com/juweins)
 * [keu](https://github.com/keu)
 * [lazebnyi](https://github.com/lazebnyi)
 * [lizdeika](https://github.com/lizdeika)

--- a/docs/connector-development/config-based/tutorial/3-connecting-to-the-API-source.md
+++ b/docs/connector-development/config-based/tutorial/3-connecting-to-the-API-source.md
@@ -22,8 +22,8 @@ Let's populate the specification (`spec`) and the configuration (`secrets/config
 
 ```yaml
 spec: 
-  documentationUrl: https://docs.airbyte.io/integrations/sources/exchangeratesapi
-  connectionSpecification:
+  documentation_url: https://docs.airbyte.io/integrations/sources/exchangeratesapi
+  connection_specification:
     $schema: http://json-schema.org/draft-07/schema#
     title: exchangeratesapi.io Source Spec
     type: object
@@ -170,8 +170,8 @@ check:
   stream_names:
     - "rates"
 spec: 
-  documentationUrl: https://docs.airbyte.io/integrations/sources/exchangeratesapi
-  connectionSpecification:
+  documentation_url: https://docs.airbyte.io/integrations/sources/exchangeratesapi
+  connection_specification:
     $schema: http://json-schema.org/draft-07/schema#
     title: exchangeratesapi.io Source Spec
     type: object

--- a/docs/connector-development/config-based/tutorial/5-incremental-reads.md
+++ b/docs/connector-development/config-based/tutorial/5-incremental-reads.md
@@ -181,7 +181,7 @@ definitions:
       datetime_format: "%Y-%m-%d"
     end_datetime:
       datetime: "{{ now_utc() }}"
-      datetime_format: "%Y-%m-%d %H:%M:%S.%f"
+      datetime_format: "%Y-%m-%d %H:%M:%S.%f+00:00"
     step: "1d"
     datetime_format: "%Y-%m-%d"
     cursor_field: "{{ options['stream_cursor_field'] }}"

--- a/docs/connector-development/config-based/tutorial/5-incremental-reads.md
+++ b/docs/connector-development/config-based/tutorial/5-incremental-reads.md
@@ -103,7 +103,7 @@ definitions:
       datetime_format: "%Y-%m-%d"
     end_datetime:
       datetime: "{{ now_utc() }}"
-      datetime_format: "%Y-%m-%d %H:%M:%S.%f"
+      datetime_format: "%Y-%m-%d %H:%M:%S.%f+00:00"
     step: "1d"
     datetime_format: "%Y-%m-%d"
     cursor_field: "{{ options['stream_cursor_field'] }}"

--- a/docs/connector-development/config-based/tutorial/5-incremental-reads.md
+++ b/docs/connector-development/config-based/tutorial/5-incremental-reads.md
@@ -11,8 +11,8 @@ First we'll update the spec block in `source_exchange_rates_tutorial/exchange_ra
 
 ```yaml
 spec: 
-  documentationUrl: https://docs.airbyte.io/integrations/sources/exchangeratesapi
-  connectionSpecification:
+  documentation_url: https://docs.airbyte.io/integrations/sources/exchangeratesapi
+  connection_specification:
     $schema: http://json-schema.org/draft-07/schema#
     title: exchangeratesapi.io Source Spec
     type: object
@@ -210,8 +210,8 @@ check:
   stream_names:
     - "rates"
 spec: 
-  documentationUrl: https://docs.airbyte.io/integrations/sources/exchangeratesapi
-  connectionSpecification:
+  documentation_url: https://docs.airbyte.io/integrations/sources/exchangeratesapi
+  connection_specification:
     $schema: http://json-schema.org/draft-07/schema#
     title: exchangeratesapi.io Source Spec
     type: object


### PR DESCRIPTION
## What
The yaml reference files in the tutorial for config-based connectors provided wrong keywords. Therefore, a user could not follow the example properly.

## How
Adjusted the error-leading keywords on all occurences in this tutorial:

```yaml
spec: 
  documentationUrl: https://docs.airbyte.io/integrations/sources/exchangeratesapi
  connectionSpecification:
```

This PR also includes the related Issue #20047 , which also gets resolved. 

The PR will also resolve #18663. (Duplicate)

## 🚨 User Impact 🚨
Minor.

## Pre-merge Checklist
Expand the relevant checklist and delete the others.

<details><summary><strong>Updating a connector</strong></summary>
### Community member or Airbyter

- [ ] Grant edit access to maintainers ([instructions](https://docs.github.com/en/github/collaborating-with-pull-requests/working-with-forks/allowing-changes-to-a-pull-request-branch-created-from-a-fork#enabling-repository-maintainer-permissions-on-existing-pull-requests))
- [x] Documentation updated
    - [x] Connector's `README.md`
- [x] PR name follows [PR naming conventions](https://docs.airbyte.com/contributing-to-airbyte/issues-and-pull-requests)

### Airbyter

If this is a community PR, the Airbyte engineer reviewing this PR is responsible for the below items.

- [ ] Create a non-forked branch based on this PR and test the below items on it
- [ ] Build is successful
- [ ] If new credentials are required for use in CI, add them to GSM. [Instructions](https://docs.airbyte.io/connector-development#using-credentials-in-ci).
- [ ] [`/test connector=connectors/<name>` command](https://docs.airbyte.io/connector-development#updating-an-existing-connector) is passing
- [ ] New Connector version released on Dockerhub and connector version bumped by running the `/publish` command described [here](https://docs.airbyte.io/connector-development#updating-an-existing-connector)

</details>

<details><summary><strong>Connector Generator</strong></summary>

- [ ] Issue acceptance criteria met
- [x] PR name follows [PR naming conventions](https://docs.airbyte.com/contributing-to-airbyte/issues-and-pull-requests)
- [x] Documentation which references the generator is updated as needed

</details>

## Tests

Manually worked through the tutorial to ensure correctness.

## Comment from Contributor
I am not able to rename commit 0f35da5d2cf7e48dd61ce14171eb797f65de97cc to reference #20047 instead of misleading issue number. Maybe you can fix this.