### PR TITLE
[ISSUE #20086] fix precommit pyproject-flake8 dependency issue

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -38,7 +38,7 @@ repos:
           ).?$
 
   - repo: https://github.com/csachs/pyproject-flake8
-    rev: v0.0.1a2.post1
+    rev: v6.0.0
     hooks:
       - id: pyproject-flake8
         args: ["--config", "pyproject.toml"]


### PR DESCRIPTION
## What
This addresses issue airbytehq/airbyte-internal-issues#1165 where an old version of pyproject-flake8 would call a recent version of flake8 that had a breaking change.

## How
Update pyproject-flake8 to the most recent

## 🚨 User Impact 🚨
None since pre-commit will see the new version of pyproject-flake8 in the config file and on the next `git commit` will run the following:
```
maxime@Maxime-MacBookPro-RM609Q3XML airbyte % git commit -m "test"
[INFO] Initializing environment for https://github.com/csachs/pyproject-flake8.
[INFO] Initializing environment for https://github.com/csachs/pyproject-flake8:mccabe.
[INFO] Installing environment for https://github.com/csachs/pyproject-flake8.
[INFO] Once installed this environment will be reused.
[INFO] This may take a few minutes...
<logs for the "normal" pre-commit hook will follow>
 ```
