### PR TITLE
octavia-cli: undue skip_reset flag revert and update integration tests 

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -38,7 +38,7 @@ repos:
           ).?$
 
   - repo: https://github.com/csachs/pyproject-flake8
-    rev: v0.0.1a2.post1
+    rev: v6.0.0
     hooks:
       - id: pyproject-flake8
         args: ["--config", "pyproject.toml"]

--- a/octavia-cli/integration_tests/configurations/connections/poke_to_pg/configuration.yaml
+++ b/octavia-cli/integration_tests/configurations/connections/poke_to_pg/configuration.yaml
@@ -7,6 +7,7 @@ destination_configuration_path: TO_UPDATE_FROM_TEST
 # EDIT THE CONFIGURATION BELOW!
 configuration:
   status: active # REQUIRED | string | Allowed values: active, inactive, deprecated
+  skip_reset: false # REQUIRED | boolean | Flag to check if the connection should be reseted after a connection update
   namespace_definition: source # OPTIONAL | string | Allowed values: source, destination, customformat
   namespace_format: "${SOURCE_NAMESPACE}" # OPTIONAL | string | Used when namespaceDefinition is 'customformat'. If blank then behaves like namespaceDefinition = 'destination'. If "${SOURCE_NAMESPACE}" then behaves like namespaceDefinition = 'source'.
   prefix: "" # REQUIRED | Prefix that will be prepended to the name of each stream when it is written to the destination

--- a/octavia-cli/integration_tests/configurations/connections/poke_to_pg/configuration.yaml
+++ b/octavia-cli/integration_tests/configurations/connections/poke_to_pg/configuration.yaml
@@ -7,7 +7,7 @@ destination_configuration_path: TO_UPDATE_FROM_TEST
 # EDIT THE CONFIGURATION BELOW!
 configuration:
   status: active # REQUIRED | string | Allowed values: active, inactive, deprecated
-  skip_reset: false # REQUIRED | boolean | Flag to check if the connection should be reseted after a connection update
+  skip_reset: false # OPTIONAL | boolean | Flag to check if the connection should be reset after a connection update
   namespace_definition: source # OPTIONAL | string | Allowed values: source, destination, customformat
   namespace_format: "${SOURCE_NAMESPACE}" # OPTIONAL | string | Used when namespaceDefinition is 'customformat'. If blank then behaves like namespaceDefinition = 'destination'. If "${SOURCE_NAMESPACE}" then behaves like namespaceDefinition = 'source'.
   prefix: "" # REQUIRED | Prefix that will be prepended to the name of each stream when it is written to the destination

--- a/octavia-cli/integration_tests/test_generate/expected_rendered_yaml/connection/expected_with_normalization.yaml
+++ b/octavia-cli/integration_tests/test_generate/expected_rendered_yaml/connection/expected_with_normalization.yaml
@@ -7,6 +7,7 @@ destination_configuration_path: destination_configuration_path
 # EDIT THE CONFIGURATION BELOW!
 configuration:
   status: active # REQUIRED | string | Allowed values: active, inactive, deprecated
+  skip_reset: false # OPTIONAL | boolean | Flag to check if the connection should be reset after a connection update
   namespace_definition: source # OPTIONAL | string | Allowed values: source, destination, customformat
   namespace_format: "${SOURCE_NAMESPACE}" # OPTIONAL | string | Used when namespaceDefinition is 'customformat'. If blank then behaves like namespaceDefinition = 'destination'. If "${SOURCE_NAMESPACE}" then behaves like namespaceDefinition = 'source'.
   prefix: "" # REQUIRED | Prefix that will be prepended to the name of each stream when it is written to the destination

--- a/octavia-cli/integration_tests/test_generate/expected_rendered_yaml/connection/expected_without_normalization.yaml
+++ b/octavia-cli/integration_tests/test_generate/expected_rendered_yaml/connection/expected_without_normalization.yaml
@@ -7,6 +7,7 @@ destination_configuration_path: destination_configuration_path
 # EDIT THE CONFIGURATION BELOW!
 configuration:
   status: active # REQUIRED | string | Allowed values: active, inactive, deprecated
+  skip_reset: false # OPTIONAL | boolean | Flag to check if the connection should be reset after a connection update
   namespace_definition: source # OPTIONAL | string | Allowed values: source, destination, customformat
   namespace_format: "${SOURCE_NAMESPACE}" # OPTIONAL | string | Used when namespaceDefinition is 'customformat'. If blank then behaves like namespaceDefinition = 'destination'. If "${SOURCE_NAMESPACE}" then behaves like namespaceDefinition = 'source'.
   prefix: "" # REQUIRED | Prefix that will be prepended to the name of each stream when it is written to the destination

--- a/octavia-cli/octavia_cli/apply/resources.py
+++ b/octavia-cli/octavia_cli/apply/resources.py
@@ -569,13 +569,9 @@ class Connection(BaseResource):
 
     resource_type = "connection"
 
-    local_root_level_keys_to_remove_during_create = [
-        "skip_reset"
-    ]  # Remove these keys when sending a create request
+    local_root_level_keys_to_remove_during_create = ["skip_reset"]  # Remove these keys when sending a create request
 
-    local_root_level_keys_to_filter_out_for_comparison = [
-        "skip_reset"
-    ]  # Remote do not have these keys
+    local_root_level_keys_to_filter_out_for_comparison = ["skip_reset"]  # Remote do not have these keys
 
     remote_root_level_keys_to_filter_out_for_comparison = [
         "name",
@@ -806,7 +802,9 @@ class Connection(BaseResource):
 
     def _get_local_comparable_configuration(self) -> dict:
         comparable = {
-            k: v for k, v in self.raw_configuration["configuration"].items() if k not in self.local_root_level_keys_to_filter_out_for_comparison
+            k: v
+            for k, v in self.raw_configuration["configuration"].items()
+            if k not in self.local_root_level_keys_to_filter_out_for_comparison
         }
         return comparable
 

--- a/octavia-cli/octavia_cli/apply/resources.py
+++ b/octavia-cli/octavia_cli/apply/resources.py
@@ -569,6 +569,14 @@ class Connection(BaseResource):
 
     resource_type = "connection"
 
+    local_root_level_keys_to_remove_during_create = [
+        "skip_reset"
+    ]  # Remove these keys when sending a create request
+
+    local_root_level_keys_to_filter_out_for_comparison = [
+        "skip_reset"
+    ]  # Remote do not have these keys
+
     remote_root_level_keys_to_filter_out_for_comparison = [
         "name",
         "source",
@@ -667,6 +675,8 @@ class Connection(BaseResource):
             self.configuration["operations"] = self._deserialize_operations(
                 self.raw_configuration["configuration"]["operations"], OperationCreate
             )
+        for k in self.local_root_level_keys_to_remove_during_create:
+            self.configuration.pop(k, None)
         return WebBackendConnectionCreate(
             name=self.resource_name, source_id=self.source_id, destination_id=self.destination_id, **self.configuration
         )
@@ -793,6 +803,12 @@ class Connection(BaseResource):
             {"source_id", "destination_id"},
             "These keys changed to source_configuration_path and destination_configuration_path in version > 0.39.18, please update your connection configuration to give path to source and destination configuration files or regenerate the connection",
         )
+
+    def _get_local_comparable_configuration(self) -> dict:
+        comparable = {
+            k: v for k, v in self.raw_configuration["configuration"].items() if k not in self.local_root_level_keys_to_filter_out_for_comparison
+        }
+        return comparable
 
     def _get_remote_comparable_configuration(self) -> dict:
 

--- a/octavia-cli/octavia_cli/generate/templates/connection.yaml.j2
+++ b/octavia-cli/octavia_cli/generate/templates/connection.yaml.j2
@@ -7,6 +7,7 @@ destination_configuration_path: {{ destination_configuration_path }}
 # EDIT THE CONFIGURATION BELOW!
 configuration:
   status: active # REQUIRED | string | Allowed values: active, inactive, deprecated
+  skip_reset: false # REQUIRED | boolean | Flag to check if the connection should be reseted after a connection update
   namespace_definition: source # OPTIONAL | string | Allowed values: source, destination, customformat
   namespace_format: "${SOURCE_NAMESPACE}" # OPTIONAL | string | Used when namespaceDefinition is 'customformat'. If blank then behaves like namespaceDefinition = 'destination'. If "${SOURCE_NAMESPACE}" then behaves like namespaceDefinition = 'source'.
   prefix: "" # REQUIRED | Prefix that will be prepended to the name of each stream when it is written to the destination

--- a/octavia-cli/octavia_cli/generate/templates/connection.yaml.j2
+++ b/octavia-cli/octavia_cli/generate/templates/connection.yaml.j2
@@ -7,7 +7,7 @@ destination_configuration_path: {{ destination_configuration_path }}
 # EDIT THE CONFIGURATION BELOW!
 configuration:
   status: active # REQUIRED | string | Allowed values: active, inactive, deprecated
-  skip_reset: false # REQUIRED | boolean | Flag to check if the connection should be reseted after a connection update
+  skip_reset: false # OPTIONAL | boolean | Flag to check if the connection should be reset after a connection update
   namespace_definition: source # OPTIONAL | string | Allowed values: source, destination, customformat
   namespace_format: "${SOURCE_NAMESPACE}" # OPTIONAL | string | Used when namespaceDefinition is 'customformat'. If blank then behaves like namespaceDefinition = 'destination'. If "${SOURCE_NAMESPACE}" then behaves like namespaceDefinition = 'source'.
   prefix: "" # REQUIRED | Prefix that will be prepended to the name of each stream when it is written to the destination


### PR DESCRIPTION
## What
Undoes the revert here: https://github.com/airbytehq/airbyte/commit/da0d9a7984807c619a8242b304e6493bd71168ea

Reinstating the original PR here: https://github.com/airbytehq/airbyte/pull/18337

This PR also:
- fixes failing integration test by adding the new field
- fixes formatting of the code