### PR TITLE
Add missing "unknown" reason

### DIFF
--- a/airbyte-api/src/main/openapi/config.yaml
+++ b/airbyte-api/src/main/openapi/config.yaml
@@ -4038,6 +4038,7 @@ components:
         - normalization
         - dbt
         - airbyte_platform
+        - unknown
     AttemptFailureType:
       description: Categorizes well known errors into types for programmatic handling. If not set, the type of error is not well known.
       type: string


### PR DESCRIPTION
## What
* Ensure that all `FailureReason` values can be mapped to `AttemptFailureOrigin`

## How
* Add the missing value to `AttemptFailureOrigin`

## Recommended reading order
1. `config.yaml`

Relates to https://github.com/airbytehq/airbyte/pull/19665.