### PR TITLE
Add dbt cloud integration to default cloud features

### DIFF
--- a/airbyte-webapp/src/packages/cloud/App.tsx
+++ b/airbyte-webapp/src/packages/cloud/App.tsx
@@ -44,6 +44,7 @@ const Services: React.FC<React.PropsWithChildren<unknown>> = ({ children }) => (
                     FeatureItem.AllowOAuthConnector,
                     FeatureItem.AllowSync,
                     FeatureItem.AllowChangeDataGeographies,
+                    FeatureItem.AllowDBTCloudIntegration,
                   ]}
                 >
                   <AppServicesProvider>


### PR DESCRIPTION
For the initial rollout, we chose to enable dbt Cloud integration via a feature override in LaunchDarkly so we could roll back immediately if something went awry. This enables the feature in the cloud build by default, so a LaunchDarkly outage would no longer prevent people from managing synced dbt jobs.