### PR TITLE
Destination doc and warning updates

### DIFF
--- a/airbyte-integrations/connectors/source-faker/main.py
+++ b/airbyte-integrations/connectors/source-faker/main.py
@@ -1,6 +1,7 @@
 #
 # Copyright (c) 2022 Airbyte, Inc., all rights reserved.
 #
+#
 
 
 import sys

--- a/docs/integrations/destinations/bigquery-denormalized.md
+++ b/docs/integrations/destinations/bigquery-denormalized.md
@@ -1,0 +1,3 @@
+# Bigquery Denormalized
+
+See [destinations/bigquery](/integrations/destinations/bigquery)

--- a/docs/integrations/destinations/cassandra.md
+++ b/docs/integrations/destinations/cassandra.md
@@ -1,8 +1,8 @@
 # Cassandra
 
 ## Prerequisites
-- For Airbyte Open Source users using the [Postgres](https://docs.airbyte.com/integrations/sources/postgres) source connector, [upgrade](https://docs.airbyte.com/operator-guides/upgrading-airbyte/) your Airbyte platform to version `v0.40.0-alpha` or newer and upgrade your Cassandra connector to version `0.1.3` or newer
 
+- For Airbyte Open Source users using the [Postgres](https://docs.airbyte.com/integrations/sources/postgres) source connector, [upgrade](https://docs.airbyte.com/operator-guides/upgrading-airbyte/) your Airbyte platform to version `v0.40.0-alpha` or newer and upgrade your Cassandra connector to version `0.1.3` or newer
 
 ## Sync overview
 
@@ -10,23 +10,21 @@
 
 The incoming airbyte data is structured in keyspaces and tables and is partitioned and replicated across different nodes
 in the cluster. This connector maps an incoming `stream` to a Cassandra `table` and a `namespace` to a
-Cassandra`keyspace`. Fields in the airbyte message become different columns in the Cassandra tables. Each table will 
+Cassandra`keyspace`. Fields in the airbyte message become different columns in the Cassandra tables. Each table will
 contain the following columns.
 
-* `_airbyte_ab_id`: A random uuid generator to be used as a partition key.
-* `_airbyte_emitted_at`: a timestamp representing when the event was received from the data source.
-* `_airbyte_data`: a json text representing the extracted data.
+- `_airbyte_ab_id`: A random uuid generator to be used as a partition key.
+- `_airbyte_emitted_at`: a timestamp representing when the event was received from the data source.
+- `_airbyte_data`: a json text representing the extracted data.
 
 ### Features
 
-| Feature | Support | Notes |
-| :--- | :---: | :--- |
-| Full Refresh Sync | ✅ | Warning: this mode deletes all previously synced data in the configured DynamoDB table. |
-| Incremental - Append Sync | ✅ |  |
-| Incremental - Deduped History | ❌ | As this connector does not support dbt, we don't support this sync mode on this destination. |
-| Namespaces | ✅ | Namespace will be used as part of the table name. |
-
-
+| Feature                       | Support | Notes                                                                                        |
+| :---------------------------- | :-----: | :------------------------------------------------------------------------------------------- |
+| Full Refresh Sync             |   ✅    | Warning: this mode deletes all previously synced data in the configured DynamoDB table.      |
+| Incremental - Append Sync     |   ✅    |                                                                                              |
+| Incremental - Deduped History |   ❌    | As this connector does not support dbt, we don't support this sync mode on this destination. |
+| Namespaces                    |   ✅    | Namespace will be used as part of the table name.                                            |
 
 ### Performance considerations
 
@@ -38,16 +36,18 @@ data from the connector.
 
 ### Requirements
 
-* The driver is compatible with _Cassandra >= 2.1_
-* Configuration
-    * Keyspace [default keyspace to use when writing data]
-    * Username [authentication username]
-    * Password [authentication password]
-    * Address [cluster address]
-    * Port [default: 9042]
-    * Datacenter [optional] [default: datacenter1]
-    * Replication [optional] [default: 1]
-    
-### Setup guide
+- The driver is compatible with _Cassandra >= 2.1_
+- Configuration
+  - Keyspace [default keyspace to use when writing data]
+  - Username [authentication username]
+  - Password [authentication password]
+  - Address [cluster address]
+  - Port [default: 9042]
+  - Datacenter [optional] [default: datacenter1]
+  - Replication [optional] [default: 1]
 
-######TODO: more info, screenshots?, etc...
+## Changelog
+
+| Version | Date       | Pull Request                                             | Subject                                |
+| :------ | :--------- | :------------------------------------------------------- | :------------------------------------- |
+| 0.1.4   | 2022-08-23 | [15894](https://github.com/airbytehq/airbyte/pull/15894) | Replace batch insert with async method |

--- a/docs/integrations/destinations/csv.md
+++ b/docs/integrations/destinations/csv.md
@@ -1,4 +1,4 @@
-# Azure Blob Storage
+# CSV Destination
 
 The Airbyte Destination for CSV files.
 

--- a/docs/integrations/destinations/csv.md
+++ b/docs/integrations/destinations/csv.md
@@ -1,0 +1,9 @@
+# Azure Blob Storage
+
+The Airbyte Destination for CSV files.
+
+## Changelog
+
+| Version | Date       | Pull Request                                             | Subject      |
+| :------ | :--------- | :------------------------------------------------------- | :----------- |
+| 0.2.10  | 2022-08-08 | [13932](https://github.com/airbytehq/airbyte/pull/13932) | Bump version |

--- a/docs/integrations/destinations/destination-azure-blob-storage.md
+++ b/docs/integrations/destinations/destination-azure-blob-storage.md
@@ -1,0 +1,9 @@
+# Azure Blob Storage
+
+The Airbyte Destination for [Microsoft Azure Blob Storage](https://azure.microsoft.com/en-us/products/storage/blobs/)
+
+## Changelog
+
+| Version | Date       | Pull Request                                             | Subject      |
+| :------ | :--------- | :------------------------------------------------------- | :----------- |
+| 0.1.6   | 2022-08-08 | [15412](https://github.com/airbytehq/airbyte/pull/15412) | Bump version |

--- a/docs/integrations/destinations/dev-null.md
+++ b/docs/integrations/destinations/dev-null.md
@@ -1,0 +1,9 @@
+# Azure Blob Storage
+
+The Airbyte `dev-null` Destination. This destination is for testing and debugging only.
+
+## Changelog
+
+| Version | Date       | Pull Request                                             | Subject      |
+| :------ | :--------- | :------------------------------------------------------- | :----------- |
+| 0.2.7   | 2022-08-08 | [13932](https://github.com/airbytehq/airbyte/pull/13932) | Bump version |

--- a/docs/integrations/destinations/dev-null.md
+++ b/docs/integrations/destinations/dev-null.md
@@ -1,4 +1,4 @@
-# Azure Blob Storage
+# Dev Null Destination
 
 The Airbyte `dev-null` Destination. This destination is for testing and debugging only.
 

--- a/docs/integrations/destinations/doris.md
+++ b/docs/integrations/destinations/doris.md
@@ -1,6 +1,6 @@
 # Doris
 
-destination-doris is a destination implemented based on [Doris stream load](https://doris.apache.org/docs/dev/data-operate/import/import-way/stream-load-manual), supports batch rollback, and uses http/https put request
+destination-doris is a destination implemented based on [Apache Doris stream load](https://doris.apache.org/docs/dev/data-operate/import/import-way/stream-load-manual), supports batch rollback, and uses http/https put request
 
 ## Sync overview
 
@@ -8,24 +8,24 @@ destination-doris is a destination implemented based on [Doris stream load](http
 
 Each stream will be output into its own table in Doris. Each table will contain 3 columns:
 
-* `_airbyte_ab_id`: an uuid assigned by Airbyte to each event that is processed. The column type in Doris is `VARCHAR(40)`.
-* `_airbyte_emitted_at`: a timestamp representing when the event was pulled from the data source. The column type in Doris is `BIGINT`.
-* `_airbyte_data`: a json blob representing with the event data. The column type in Doris is `String`.
+- `_airbyte_ab_id`: an uuid assigned by Airbyte to each event that is processed. The column type in Doris is `VARCHAR(40)`.
+- `_airbyte_emitted_at`: a timestamp representing when the event was pulled from the data source. The column type in Doris is `BIGINT`.
+- `_airbyte_data`: a json blob representing with the event data. The column type in Doris is `String`.
 
 ### Features
 
 This section should contain a table with the following format:
 
-| Feature | Supported?(Yes/No) | Notes |
-| :--- |:-------------------| :--- |
-| Full Refresh Sync | Yes                |  |
-| Incremental - Append Sync | Yes                |  |
-| Incremental - Deduped History | No                 | it will soon be realized |
-| For databases, WAL/Logical replication | Yes                |  |
+| Feature                                | Supported?(Yes/No) | Notes                    |
+| :------------------------------------- | :----------------- | :----------------------- |
+| Full Refresh Sync                      | Yes                |                          |
+| Incremental - Append Sync              | Yes                |                          |
+| Incremental - Deduped History          | No                 | it will soon be realized |
+| For databases, WAL/Logical replication | Yes                |                          |
 
 ### Performance considerations
 
-Batch writes are performed. mini records may impact performance.  
+Batch writes are performed. mini records may impact performance.
 Importing multiple tables will generate multiple [Doris stream load](https://doris.apache.org/docs/dev/data-operate/import/import-way/stream-load-manual) transactions, which should be split as much as possible.
 
 ## Getting started
@@ -33,19 +33,28 @@ Importing multiple tables will generate multiple [Doris stream load](https://dor
 ### Requirements
 
 To use the Doris destination, you'll need:
-* A Doris server version 0.14 or above
-* Make sure your Doris fe http port can be accessed by Airbyte.
-* Make sure your Doris database host can be accessed by Airbyte.
-* Make sure your Doris user with read/write permissions on certain tables.
+
+- A Doris server version 0.14 or above
+- Make sure your Doris fe http port can be accessed by Airbyte.
+- Make sure your Doris database host can be accessed by Airbyte.
+- Make sure your Doris user with read/write permissions on certain tables.
 
 ### Target Database and tables
+
 You will need to choose a database that will be used to store synced data from Airbyte.
 You need to prepare tables that will be used to store synced data from Airbyte, and ensure the order and matching of the column names in the table as much as possible.
 
 ### Setup the access parameters
-* **Host**
-* **HttpPort**
-* **QueryPort**
-* **Username**
-* **Password**
-* **Database**
+
+- **Host**
+- **HttpPort**
+- **QueryPort**
+- **Username**
+- **Password**
+- **Database**
+
+## Changelog
+
+| Version | Date       | Pull Request                                             | Subject        |
+| :------ | :--------- | :------------------------------------------------------- | :------------- |
+| 0.1.0   | 2022-11-14 | [17884](https://github.com/airbytehq/airbyte/pull/17884) | Initial Commit |

--- a/docs/integrations/destinations/iceberg.md
+++ b/docs/integrations/destinations/iceberg.md
@@ -11,30 +11,30 @@ in the cluster. This connector maps an incoming `stream` to an Iceberg `table` a
 Iceberg `database`. Fields in the airbyte message become different columns in the Iceberg tables. Each table will
 contain the following columns.
 
-* `_airbyte_ab_id`: A random generated uuid.
-* `_airbyte_emitted_at`: a timestamp representing when the event was received from the data source.
-* `_airbyte_data`: a json text representing the extracted data.
+- `_airbyte_ab_id`: A random generated uuid.
+- `_airbyte_emitted_at`: a timestamp representing when the event was received from the data source.
+- `_airbyte_data`: a json text representing the extracted data.
 
 ### Features
 
 This section should contain a table with the following format:
 
-| Feature | Supported?(Yes/No) | Notes |
-| :--- | :--- | :--- |
-| Full Refresh Sync | ✅ |  |
-| Incremental Sync | ✅ |  |
-| Replicate Incremental Deletes | ❌ |  |
-| SSH Tunnel Support | ❌ |  |
+| Feature                       | Supported?(Yes/No) | Notes |
+| :---------------------------- | :----------------- | :---- |
+| Full Refresh Sync             | ✅                 |       |
+| Incremental Sync              | ✅                 |       |
+| Replicate Incremental Deletes | ❌                 |       |
+| SSH Tunnel Support            | ❌                 |       |
 
 ### Performance considerations
 
 Every ten thousand pieces of incoming airbyte data in a stream ————we call it a batch, would produce one data file(
 Parquet/Avro) in an Iceberg table. This batch size can be configurabled by `Data file flushing batch size`
-property.  
+property.
 As the quantity of Iceberg data files grows, it causes an unnecessary amount of metadata and less efficient queries from
-file open costs.  
+file open costs.
 Iceberg provides data file compaction action to improve this case, you can read more about
-compaction [HERE](https://iceberg.apache.org/docs/latest/maintenance/#compact-data-files).  
+compaction [HERE](https://iceberg.apache.org/docs/latest/maintenance/#compact-data-files).
 This connector also provides auto compact action when stream closes, by `Auto compact data files` property. Any you can
 specify the target size of compacted Iceberg data file.
 
@@ -42,17 +42,19 @@ specify the target size of compacted Iceberg data file.
 
 ### Requirements
 
-* **Iceberg catalog** : Iceberg uses `catalog` to manage tables. this connector already supports:
-    * [HiveCatalog](https://iceberg.apache.org/docs/latest/hive/#global-hive-catalog)  connects to a **Hive metastore**
-      to keep track of Iceberg tables.
-    * [HadoopCatalog](https://iceberg.apache.org/docs/latest/java-api-quickstart/#using-a-hadoop-catalog) doesn’t need
-      to connect to a Hive MetaStore, but can only be used with **HDFS or similar file systems** that support atomic
-      rename. For `HadoopCatalog`, this connector use **Storage Config** (S3 or HDFS) to manage Iceberg tables.
-    * [JdbcCatalog](https://iceberg.apache.org/docs/latest/jdbc/) uses a table in a relational database to manage
-      Iceberg tables through JDBC. So far, this connector supports **PostgreSQL** only.
-* **Storage medium** means where Iceberg data files storages in. So far, this connector supports **S3/S3N/S3N**
+- **Iceberg catalog** : Iceberg uses `catalog` to manage tables. this connector already supports:
+  - [HiveCatalog](https://iceberg.apache.org/docs/latest/hive/#global-hive-catalog) connects to a **Hive metastore**
+    to keep track of Iceberg tables.
+  - [HadoopCatalog](https://iceberg.apache.org/docs/latest/java-api-quickstart/#using-a-hadoop-catalog) doesn’t need
+    to connect to a Hive MetaStore, but can only be used with **HDFS or similar file systems** that support atomic
+    rename. For `HadoopCatalog`, this connector use **Storage Config** (S3 or HDFS) to manage Iceberg tables.
+  - [JdbcCatalog](https://iceberg.apache.org/docs/latest/jdbc/) uses a table in a relational database to manage
+    Iceberg tables through JDBC. So far, this connector supports **PostgreSQL** only.
+- **Storage medium** means where Iceberg data files storages in. So far, this connector supports **S3/S3N/S3N**
   object-storage only.
 
-### Setup guide
+## Changelog
 
-######TODO: more info
+| Version | Date       | Pull Request                                             | Subject        |
+| :------ | :--------- | :------------------------------------------------------- | :------------- |
+| 0.1.0   | 2022-11-01 | [18836](https://github.com/airbytehq/airbyte/pull/18836) | Initial Commit |

--- a/docs/integrations/destinations/kafka.md
+++ b/docs/integrations/destinations/kafka.md
@@ -5,8 +5,8 @@
 The Airbyte Kafka destination allows you to sync data to Kafka. Each stream is written to the corresponding Kafka topic.
 
 ## Prerequisites
-- For Airbyte Open Source users using the [Postgres](https://docs.airbyte.com/integrations/sources/postgres) source connector, [upgrade](https://docs.airbyte.com/operator-guides/upgrading-airbyte/) your Airbyte platform to version `v0.40.0-alpha` or newer and upgrade your Kafka connector to version `0.1.10` or newer
 
+- For Airbyte Open Source users using the [Postgres](https://docs.airbyte.com/integrations/sources/postgres) source connector, [upgrade](https://docs.airbyte.com/operator-guides/upgrading-airbyte/) your Airbyte platform to version `v0.40.0-alpha` or newer and upgrade your Kafka connector to version `0.1.10` or newer
 
 ### Sync overview
 
@@ -18,19 +18,19 @@ Currently, this connector only writes data with JSON format. More formats \(e.g.
 
 Each record will contain in its key the uuid assigned by Airbyte, and in the value these 3 fields:
 
-* `_airbyte_ab_id`: a uuid assigned by Airbyte to each event that is processed.
-* `_airbyte_emitted_at`:  a timestamp representing when the event was pulled from the data source.
-* `_airbyte_data`: a json blob representing with the event data.
-* `_airbyte_stream`: the name of each record's stream.
+- `_airbyte_ab_id`: a uuid assigned by Airbyte to each event that is processed.
+- `_airbyte_emitted_at`: a timestamp representing when the event was pulled from the data source.
+- `_airbyte_data`: a json blob representing with the event data.
+- `_airbyte_stream`: the name of each record's stream.
 
 #### Features
 
-| Feature | Supported?\(Yes/No\) | Notes |
-| :--- | :--- | :--- |
-| Full Refresh Sync | No |  |
-| Incremental - Append Sync | Yes |  |
-| Incremental - Deduped History | No | As this connector does not support dbt, we don't support this sync mode on this destination. |
-| Namespaces | Yes |  |
+| Feature                       | Supported?\(Yes/No\) | Notes                                                                                        |
+| :---------------------------- | :------------------- | :------------------------------------------------------------------------------------------- |
+| Full Refresh Sync             | No                   |                                                                                              |
+| Incremental - Append Sync     | Yes                  |                                                                                              |
+| Incremental - Deduped History | No                   | As this connector does not support dbt, we don't support this sync mode on this destination. |
+| Namespaces                    | Yes                  |                                                                                              |
 
 ## Getting started
 
@@ -38,7 +38,7 @@ Each record will contain in its key the uuid assigned by Airbyte, and in the val
 
 To use the Kafka destination, you'll need:
 
-* A Kafka cluster 1.0 or above.
+- A Kafka cluster 1.0 or above.
 
 ### Setup guide
 
@@ -68,31 +68,31 @@ If you define output topic dynamically, you might want to enable `auto.create.to
 
 You should now have all the requirements needed to configure Kafka as a destination in the UI. You can configure the following parameters on the Kafka destination \(though many of these are optional or have default values\):
 
-* **Bootstrap servers**
-* **Topic pattern**
-* **Test topic**
-* **Sync producer**
-* **Security protocol**
-* **SASL JAAS config**
-* **SASL mechanism**
-* **Client ID**
-* **ACKs**
-* **Enable idempotence**
-* **Compression type**
-* **Batch size**
-* **Linger ms**
-* **Max in flight requests per connection**
-* **Client DNS lookup**
-* **Buffer memory**
-* **Max request size**
-* **Retries**
-* **Socket connection setup timeout**
-* **Socket connection setup max timeout**
-* **Max block ms**
-* **Request timeout**
-* **Delivery timeout**
-* **Send buffer bytes**
-* **Receive buffer bytes**
+- **Bootstrap servers**
+- **Topic pattern**
+- **Test topic**
+- **Sync producer**
+- **Security protocol**
+- **SASL JAAS config**
+- **SASL mechanism**
+- **Client ID**
+- **ACKs**
+- **Enable idempotence**
+- **Compression type**
+- **Batch size**
+- **Linger ms**
+- **Max in flight requests per connection**
+- **Client DNS lookup**
+- **Buffer memory**
+- **Max request size**
+- **Retries**
+- **Socket connection setup timeout**
+- **Socket connection setup max timeout**
+- **Max block ms**
+- **Request timeout**
+- **Delivery timeout**
+- **Send buffer bytes**
+- **Receive buffer bytes**
 
 More info about this can be found in the [Kafka producer configs documentation site](https://kafka.apache.org/documentation/#producerconfigs).
 
@@ -100,15 +100,15 @@ _NOTE_: Some configurations for SSL are not available yet.
 
 ## Changelog
 
-| Version | Date | Pull Request | Subject |
-| :--- | :--- | :--- | :--- |
-| 0.1.9 | 2022-06-17 | [13864](https://github.com/airbytehq/airbyte/pull/13864) | Updated stacktrace format for any trace message errors |
-| 0.1.7 | 2022-04-19 | [12134](https://github.com/airbytehq/airbyte/pull/12134) | Add PLAIN Auth |
-| 0.1.6 | 2022-02-15 | [10186](https://github.com/airbytehq/airbyte/pull/10186) | Add SCRAM-SHA-512 Auth |
-| 0.1.5 | 2022-02-14 | [10256](https://github.com/airbytehq/airbyte/pull/10256) | Add `-XX:+ExitOnOutOfMemoryError` JVM option |
-| 0.1.4 | 2022-01-31 | [\#9905](https://github.com/airbytehq/airbyte/pull/9905) |  Fix SASL config read issue |
-| 0.1.3 | 2021-12-30 | [\#8809](https://github.com/airbytehq/airbyte/pull/8809) | Update connector fields title/description |
-| 0.1.2 | 2021-09-14 | [\#6040](https://github.com/airbytehq/airbyte/pull/6040) | Change spec.json and config parser |
-| 0.1.1 | 2021-07-30 | [\#5125](https://github.com/airbytehq/airbyte/pull/5125) | Enable `additionalPropertities` in spec.json |
-| 0.1.0 | 2021-07-21 | [\#3746](https://github.com/airbytehq/airbyte/pull/3746) | Initial Release |
-
+| Version | Date       | Pull Request                                             | Subject                                                                       |
+| :------ | :--------- | :------------------------------------------------------- | :---------------------------------------------------------------------------- |
+| 0.1.10  | 2022-08-04 | [15287](https://github.com/airbytehq/airbyte/pull/15287) | Update Kafka destination to use outputRecordCollector to properly store state |
+| 0.1.9   | 2022-06-17 | [13864](https://github.com/airbytehq/airbyte/pull/13864) | Updated stacktrace format for any trace message errors                        |
+| 0.1.7   | 2022-04-19 | [12134](https://github.com/airbytehq/airbyte/pull/12134) | Add PLAIN Auth                                                                |
+| 0.1.6   | 2022-02-15 | [10186](https://github.com/airbytehq/airbyte/pull/10186) | Add SCRAM-SHA-512 Auth                                                        |
+| 0.1.5   | 2022-02-14 | [10256](https://github.com/airbytehq/airbyte/pull/10256) | Add `-XX:+ExitOnOutOfMemoryError` JVM option                                  |
+| 0.1.4   | 2022-01-31 | [9905](https://github.com/airbytehq/airbyte/pull/9905)   | Fix SASL config read issue                                                    |
+| 0.1.3   | 2021-12-30 | [8809](https://github.com/airbytehq/airbyte/pull/8809)   | Update connector fields title/description                                     |
+| 0.1.2   | 2021-09-14 | [6040](https://github.com/airbytehq/airbyte/pull/6040)   | Change spec.json and config parser                                            |
+| 0.1.1   | 2021-07-30 | [5125](https://github.com/airbytehq/airbyte/pull/5125)   | Enable `additionalPropertities` in spec.json                                  |
+| 0.1.0   | 2021-07-21 | [3746](https://github.com/airbytehq/airbyte/pull/3746)   | Initial Release                                                               |

--- a/docs/integrations/destinations/keen.md
+++ b/docs/integrations/destinations/keen.md
@@ -10,8 +10,8 @@ description: >-
 The Airbyte Keen destination allows you to stream data from any Airbyte Source into [Keen](https://keen.io?utm_campaign=Airbyte%20Destination%20Connector&utm_source=Airbyte%20Hosted%20Docs&utm_medium=Airbyte%20Hosted%20Docs&utm_term=Airbyte%20Hosted%20Docs&utm_content=Airbyte%20Hosted%20Docs) for storage, analysis, and visualization. Keen is a flexible, fully managed event streaming and analytics platform that empowers anyone to ship custom, embeddable dashboards in minutes, not months.
 
 ## Prerequisites
-- For Airbyte Open Source users using the [Postgres](https://docs.airbyte.com/integrations/sources/postgres) source connector, [upgrade](https://docs.airbyte.com/operator-guides/upgrading-airbyte/) your Airbyte platform to version `v0.40.0-alpha` or newer and upgrade your Keen connector to version `0.2.4` or newer
 
+- For Airbyte Open Source users using the [Postgres](https://docs.airbyte.com/integrations/sources/postgres) source connector, [upgrade](https://docs.airbyte.com/operator-guides/upgrading-airbyte/) your Airbyte platform to version `v0.40.0-alpha` or newer and upgrade your Keen connector to version `0.2.4` or newer
 
 ### Sync overview
 
@@ -21,12 +21,12 @@ Each replicated stream from Airbyte will output data into a corresponding event 
 
 #### Features
 
-| Feature | Supported?\(Yes/No\) | Notes |
-| :--- | :--- | :--- |
-| Full Refresh Sync | Yes |  |
-| Incremental - Append Sync | Yes |  |
-| Incremental - Deduped History | No | As this connector does not support dbt, we don't support this sync mode on this destination. |
-| Namespaces | No |  |
+| Feature                       | Supported?\(Yes/No\) | Notes                                                                                        |
+| :---------------------------- | :------------------- | :------------------------------------------------------------------------------------------- |
+| Full Refresh Sync             | Yes                  |                                                                                              |
+| Incremental - Append Sync     | Yes                  |                                                                                              |
+| Incremental - Deduped History | No                   | As this connector does not support dbt, we don't support this sync mode on this destination. |
+| Namespaces                    | No                   |                                                                                              |
 
 ## Getting started
 
@@ -36,8 +36,8 @@ To use the Keen destination, you'll first need to create a [Keen account](https:
 
 Once you have a Keen account, you can use the following credentials to set up the connector
 
-* A Keen Project ID
-* A Keen Master API key associated with the project
+- A Keen Project ID
+- A Keen Master API key associated with the project
 
 See the setup guide for more information about how to get started.
 
@@ -59,7 +59,7 @@ Head to the ‘Access’ tab and grab your Project ID and Master API Key
 
 #### API Key and Project ID
 
-The Keen Connector uses the [Keen Kafka Inbound Cluster](https://keen.io/docs/streams/kafka-streaming/kafka-inbound-cluster/?utm_campaign=Airbyte%20Destination%20Connector&utm_source=Airbyte%20Hosted%20Docs&utm_medium=Airbyte%20Hosted%20Docs&utm_term=Airbyte%20Hosted%20Docs&utm_content=Airbyte%20Hosted%20Docs) to stream  data. It requires your `Project ID` and `Master Key` for  authentication. To get them, navigate to the `Access` tab from the left-hand, side panel and check the `Project Details` section.
+The Keen Connector uses the [Keen Kafka Inbound Cluster](https://keen.io/docs/streams/kafka-streaming/kafka-inbound-cluster/?utm_campaign=Airbyte%20Destination%20Connector&utm_source=Airbyte%20Hosted%20Docs&utm_medium=Airbyte%20Hosted%20Docs&utm_term=Airbyte%20Hosted%20Docs&utm_content=Airbyte%20Hosted%20Docs) to stream data. It requires your `Project ID` and `Master Key` for authentication. To get them, navigate to the `Access` tab from the left-hand, side panel and check the `Project Details` section.
 **Important**: This destination requires the Project's **Master** Key.
 
 #### Timestamp Inference
@@ -70,9 +70,9 @@ The `Infer Timestamp` field lets you specify if you want the connector to infer 
 
 Now, you should have all the parameters needed to configure Keen destination.
 
-* **Project ID**
-* **Master API Key**
-* **Infer Timestamp**
+- **Project ID**
+- **Master API Key**
+- **Infer Timestamp**
 
 Connect your first source and then head to the Keen application. You can seamlessly run [custom analysis](https://keen.io/docs/compute/data-explorer-guide/?utm_campaign=Airbyte%20Destination%20Connector&utm_source=Airbyte%20Hosted%20Docs&utm_medium=Airbyte%20Hosted%20Docs&utm_term=Airbyte%20Hosted%20Docs&utm_content=Airbyte%20Hosted%20Docs) on your data and [build interactive dashboards](https://keen.io/docs/visualize/dashboard-creator/dashboard-edition/?utm_campaign=Airbyte%20Destination%20Connector&utm_source=Airbyte%20Hosted%20Docs&utm_medium=Airbyte%20Hosted%20Docs&utm_term=Airbyte%20Hosted%20Docs&utm_content=Airbyte%20Hosted%20Docs) for key stakeholders.
 
@@ -80,10 +80,10 @@ If you have any questions, please reach out to us at team@keen.io and we’ll be
 
 ## CHANGELOG
 
-| Version | Date | Pull Request | Subject |
-| :--- | :--- | :--- | :--- |
-| 0.2.3 | 2022-06-17 | [13864](https://github.com/airbytehq/airbyte/pull/13864) | Updated stacktrace format for any trace message errors |
-| 0.2.1 | 2021-12-30 | [\#8809](https://github.com/airbytehq/airbyte/pull/8809) | Update connector fields title/description |
-| 0.2.0 | 2021-09-10 | [\#5973](https://github.com/airbytehq/airbyte/pull/5973) | Fix timestamp inference for complex schemas |
-| 0.1.0 | 2021-08-18 | [\#5339](https://github.com/airbytehq/airbyte/pull/5339) | Keen Destination Release! |
-
+| Version | Date       | Pull Request                                             | Subject                                                                      |
+| :------ | :--------- | :------------------------------------------------------- | :--------------------------------------------------------------------------- |
+| 0.2.4   | 2022-08-04 | [15291](https://github.com/airbytehq/airbyte/pull/15291) | Update Keen destination to use outputRecordCollector to properly store state |
+| 0.2.3   | 2022-06-17 | [13864](https://github.com/airbytehq/airbyte/pull/13864) | Updated stacktrace format for any trace message errors                       |
+| 0.2.1   | 2021-12-30 | [8809](https://github.com/airbytehq/airbyte/pull/8809)   | Update connector fields title/description                                    |
+| 0.2.0   | 2021-09-10 | [5973](https://github.com/airbytehq/airbyte/pull/5973)   | Fix timestamp inference for complex schemas                                  |
+| 0.1.0   | 2021-08-18 | [5339](https://github.com/airbytehq/airbyte/pull/5339)   | Keen Destination Release!                                                    |

--- a/docs/integrations/destinations/kinesis.md
+++ b/docs/integrations/destinations/kinesis.md
@@ -1,28 +1,28 @@
 # Kinesis
 
 ## Prerequisites
+
 - For Airbyte Open Source users using the [Postgres](https://docs.airbyte.com/integrations/sources/postgres) source connector, [upgrade](https://docs.airbyte.com/operator-guides/upgrading-airbyte/) your Airbyte platform to version `v0.40.0-alpha` or newer and upgrade your Kinesis connector to version `0.1.4` or newer
 
 ## Sync overview
 
-
 ### Output schema
 
-The incoming Airbyte data is structured in a Json format and is sent across diferent stream shards determined by the partition key. 
+The incoming Airbyte data is structured in a Json format and is sent across diferent stream shards determined by the partition key.
 This connector maps an incoming data from a namespace and stream to a unique Kinesis stream. The Kinesis record which is sent to the stream is consisted of the following Json fields
 
-* `_airbyte_ab_id`: Random UUID generated to be used as a partition key for sending data to different shards.
-* `_airbyte_emitted_at`: a timestamp representing when the event was received from the data source.
-* `_airbyte_data`: a json text/object representing the data that was received from the data source.
+- `_airbyte_ab_id`: Random UUID generated to be used as a partition key for sending data to different shards.
+- `_airbyte_emitted_at`: a timestamp representing when the event was received from the data source.
+- `_airbyte_data`: a json text/object representing the data that was received from the data source.
 
 ### Features
 
-| Feature                       | Support| Notes                                                                             |
-| :-----------------------------| :-----:| :---------------------------------------------------------------------------------|
-| Full Refresh Sync             | ❌     |                                                                                   |
-| Incremental - Append Sync     | ✅     |  Incoming messages are streamed/appended to a Kinesis stream as they are received.|
-| Incremental - Deduped History | ❌     |                                                                                   |
-| Namespaces                    | ✅     | Namespaces will be used to determine the Kinesis stream name.                     |
+| Feature                       | Support | Notes                                                                             |
+| :---------------------------- | :-----: | :-------------------------------------------------------------------------------- |
+| Full Refresh Sync             |   ❌    |                                                                                   |
+| Incremental - Append Sync     |   ✅    | Incoming messages are streamed/appended to a Kinesis stream as they are received. |
+| Incremental - Deduped History |   ❌    |                                                                                   |
+| Namespaces                    |   ✅    | Namespaces will be used to determine the Kinesis stream name.                     |
 
 ### Performance considerations
 
@@ -33,15 +33,19 @@ The connector buffer size should also be tweaked according to your data size and
 
 ### Requirements
 
-* The connector is compatible with the latest Kinesis service version at the time of this writing. 
-* Configuration
-    * **_Endpoint_**: Aws Kinesis endpoint to connect to. Default endpoint if not provided   
-    * **_Region_**: Aws Kinesis region to connect to. Default region if not provided.  
-    * **_shardCount_**: The number of shards with which the stream should be created. The amount of shards affects the throughput of your stream. 
-    * **_accessKey_**: Access key credential for authenticating with the service.  
-    * **_privateKey_**: Private key credential for authenticating with the service.
-    * **_bufferSize_**: Buffer size used to increase throughput by sending data in a single request.
+- The connector is compatible with the latest Kinesis service version at the time of this writing.
+- Configuration
+  - **_Endpoint_**: Aws Kinesis endpoint to connect to. Default endpoint if not provided
+  - **_Region_**: Aws Kinesis region to connect to. Default region if not provided.
+  - **_shardCount_**: The number of shards with which the stream should be created. The amount of shards affects the throughput of your stream.
+  - **_accessKey_**: Access key credential for authenticating with the service.
+  - **_privateKey_**: Private key credential for authenticating with the service.
+  - **_bufferSize_**: Buffer size used to increase throughput by sending data in a single request.
 
 ### Setup guide
 
-######TODO: more info, screenshots?, etc...
+## CHANGELOG
+
+| Version | Date       | Pull Request                                             | Subject                    |
+| :------ | :--------- | :------------------------------------------------------- | :------------------------- |
+| 0.1.5   | 2022-09-22 | [16952](https://github.com/airbytehq/airbyte/pull/16952) | Add required config fields |

--- a/docs/integrations/destinations/pulsar.md
+++ b/docs/integrations/destinations/pulsar.md
@@ -5,6 +5,7 @@
 The Airbyte Pulsar destination allows you to sync data to Pulsar. Each stream is written to the corresponding Pulsar topic.
 
 ## Prerequisites
+
 - For Airbyte Open Source users using the [Postgres](https://docs.airbyte.com/integrations/sources/postgres) source connector, [upgrade](https://docs.airbyte.com/operator-guides/upgrading-airbyte/) your Airbyte platform to version `v0.40.0-alpha` or newer and upgrade your Pulsar connector to version `0.1.3` or newer
 
 ### Sync overview
@@ -17,19 +18,19 @@ Currently, this connector only writes data with JSON format. More formats \(e.g.
 
 Each record will contain in its key the uuid assigned by Airbyte, and in the value these 3 fields:
 
-* `_airbyte_ab_id`: a uuid assigned by Airbyte to each event that is processed.
-* `_airbyte_emitted_at`:  a timestamp representing when the event was pulled from the data source.
-* `_airbyte_data`: a json blob representing with the event data encoded in base64 .
-* `_airbyte_stream`: the name of each record's stream.
+- `_airbyte_ab_id`: a uuid assigned by Airbyte to each event that is processed.
+- `_airbyte_emitted_at`: a timestamp representing when the event was pulled from the data source.
+- `_airbyte_data`: a json blob representing with the event data encoded in base64 .
+- `_airbyte_stream`: the name of each record's stream.
 
 #### Features
 
-| Feature | Supported?\(Yes/No\) | Notes |
-| :--- | :--- | :--- |
-| Full Refresh Sync | No |  |
-| Incremental - Append Sync | Yes |  |
-| Incremental - Deduped History | No | As this connector does not support dbt, we don't support this sync mode on this destination. |
-| Namespaces | Yes |  |
+| Feature                       | Supported?\(Yes/No\) | Notes                                                                                        |
+| :---------------------------- | :------------------- | :------------------------------------------------------------------------------------------- |
+| Full Refresh Sync             | No                   |                                                                                              |
+| Incremental - Append Sync     | Yes                  |                                                                                              |
+| Incremental - Deduped History | No                   | As this connector does not support dbt, we don't support this sync mode on this destination. |
+| Namespaces                    | Yes                  |                                                                                              |
 
 ## Getting started
 
@@ -37,7 +38,7 @@ Each record will contain in its key the uuid assigned by Airbyte, and in the val
 
 To use the Pulsar destination, you'll need:
 
-* A Pulsar cluster 2.8 or above.
+- A Pulsar cluster 2.8 or above.
 
 ### Setup guide
 
@@ -69,22 +70,28 @@ If you define output topic dynamically, you might want to enable `allowAutoTopic
 
 You should now have all the requirements needed to configure Pulsar as a destination in the UI. You can configure the following parameters on the Pulsar destination \(though many of these are optional or have default values\):
 
-* **Pulsar brokers**
-* **Use TLS**
-* **Topic type**
-* **Topic tenant**
-* **Topic namespace**
-* **Topic pattern**
-* **Test topic**
-* **Producer name**
-* **Sync producer**
-* **Compression type**
-* **Message send timeout**
-* **Max pending messages**
-* **Max pending messages across partitions**
-* **Enable batching**
-* **Batching max messages**
-* **Batching max publish delay**
-* **Block if queue is full**
+- **Pulsar brokers**
+- **Use TLS**
+- **Topic type**
+- **Topic tenant**
+- **Topic namespace**
+- **Topic pattern**
+- **Test topic**
+- **Producer name**
+- **Sync producer**
+- **Compression type**
+- **Message send timeout**
+- **Max pending messages**
+- **Max pending messages across partitions**
+- **Enable batching**
+- **Batching max messages**
+- **Batching max publish delay**
+- **Block if queue is full**
 
 More info about this can be found in the [Pulsar producer configs documentation site](https://pulsar.apache.org/docs/en/client-libraries-java/#producer).
+
+## CHANGELOG
+
+| Version | Date       | Pull Request                                             | Subject                                                                        |
+| :------ | :--------- | :------------------------------------------------------- | :----------------------------------------------------------------------------- |
+| 0.1.3   | 2022-08-05 | [15349](https://github.com/airbytehq/airbyte/pull/15349) | Update Pulsar destination to use outputRecordCollector to properly store state |

--- a/docs/integrations/destinations/redpanda.md
+++ b/docs/integrations/destinations/redpanda.md
@@ -2,7 +2,6 @@
 
 The Airbyte Redpanda destination connector allows you to sync data to [Redpada](https://redpanda.com/). Each stream is written to the corresponding Redpanda topic.
 
-
 ## Sync overview
 
 ### Output schema
@@ -15,28 +14,25 @@ Currently, this connector only writes data with JSON format. More formats \(e.g.
 
 Each record will contain in its key the uuid assigned by Airbyte, and in the value these 3 fields:
 
-* `_airbyte_ab_id`: a uuid assigned by Airbyte to each event that is processed.
-* `_airbyte_emitted_at`:  a timestamp representing when the event was pulled from the data source.
-* `_airbyte_data`: a json blob representing with the event data.
+- `_airbyte_ab_id`: a uuid assigned by Airbyte to each event that is processed.
+- `_airbyte_emitted_at`: a timestamp representing when the event was pulled from the data source.
+- `_airbyte_data`: a json blob representing with the event data.
 
 ### Data type mapping
 
 | Integration Type | Airbyte Type | Notes |
-| :--- | :--- | :--- |
-
+| :--------------- | :----------- | :---- |
 
 ### Features
 
 This section should contain a table with the following format:
 
-
-| Feature | Supported?\(Yes/No\) | Notes |
-| :--- | :--- | :--- |
-| Full Refresh Sync | No |  |
-| Incremental - Append Sync | Yes |  |
-| Incremental - Deduped History | No | As this connector does not support dbt, we don't support this sync mode on this destination. |
-| Namespaces | Yes |  |
-
+| Feature                       | Supported?\(Yes/No\) | Notes                                                                                        |
+| :---------------------------- | :------------------- | :------------------------------------------------------------------------------------------- |
+| Full Refresh Sync             | No                   |                                                                                              |
+| Incremental - Append Sync     | Yes                  |                                                                                              |
+| Incremental - Deduped History | No                   | As this connector does not support dbt, we don't support this sync mode on this destination. |
+| Namespaces                    | Yes                  |                                                                                              |
 
 ### Performance considerations
 
@@ -46,22 +42,22 @@ Granted you have enough Redpanda nodes/partitions the cluster should be able to 
 
 ### Requirements
 
-* The connector should be able to create topics using the [AdminClient](https://docs.confluent.io/platform/current/installation/configuration/admin-configs.html)
-* Configuration options
-  * **Bootstrap servers**
-  * **Buffer Memory**
-  * **Compression Type**
-  * **Batch Size**
-  * **Retries**
-  * **Number of topic partitions**
-  * **Topic replication factor**
-  * **Socket Connection Setup Timeout**
-  * **Socket Connection Setup Max Timeout**
+- The connector should be able to create topics using the [AdminClient](https://docs.confluent.io/platform/current/installation/configuration/admin-configs.html)
+- Configuration options
+  - **Bootstrap servers**
+  - **Buffer Memory**
+  - **Compression Type**
+  - **Batch Size**
+  - **Retries**
+  - **Number of topic partitions**
+  - **Topic replication factor**
+  - **Socket Connection Setup Timeout**
+  - **Socket Connection Setup Max Timeout**
 
 More info about this can be found in the [Redpanda producer configs documentation site](https://docs.confluent.io/platform/current/installation/configuration/producer-configs.html).
 
 _NOTE_: Configurations for SSL are not available yet.
 
-### Setup guide
-
-
+| Version | Date       | Pull Request                                             | Subject        |
+| :------ | :--------- | :------------------------------------------------------- | :------------- |
+| 0.1.0   | 2022-08-05 | [18884](https://github.com/airbytehq/airbyte/pull/18884) | Initial commit |

--- a/docs/integrations/destinations/rockset.md
+++ b/docs/integrations/destinations/rockset.md
@@ -1,27 +1,28 @@
 # Rockset
 
 ## Prerequisites
+
 - For Airbyte Open Source users using the [Postgres](https://docs.airbyte.com/integrations/sources/postgres) source connector, [upgrade](https://docs.airbyte.com/operator-guides/upgrading-airbyte/) your Airbyte platform to version `v0.40.0-alpha` or newer and upgrade your Rockset connector to version `0.1.4` or newer
+
 ## Features
 
-| Feature | Support |
-| :--- | :---: |
-| Full Refresh Sync | ✅ |
-| Incremental - Append Sync | ✅ |
-| Incremental - Deduped History | ❌ |
-| Namespaces | ❌ |
-
+| Feature                       | Support |
+| :---------------------------- | :-----: |
+| Full Refresh Sync             |   ✅    |
+| Incremental - Append Sync     |   ✅    |
+| Incremental - Deduped History |   ❌    |
+| Namespaces                    |   ❌    |
 
 ## Troubleshooting
 
-
 ## Configuration
 
-| Parameter | Type | Notes |
-| :--- | :---: | :--- |
-| api_key | string | rockset api key |
-| api_server | string | api URL to rockset, specifying http protocol  |
-| workspace | string | workspace under which rockset collections will be added/modified |
+| Parameter  |  Type  | Notes                                                            |
+| :--------- | :----: | :--------------------------------------------------------------- |
+| api_key    | string | rockset api key                                                  |
+| api_server | string | api URL to rockset, specifying http protocol                     |
+| workspace  | string | workspace under which rockset collections will be added/modified |
+
 ## Getting Started \(Airbyte Open-Source / Airbyte Cloud\)
 
 #### Requirements
@@ -30,10 +31,10 @@
 
 ## CHANGELOG
 
-| Version | Date | Pull Request | Subject |
-| :--- | :--- | :--- | :--- |
-| 0.1.3 | 2022-06-17 | [13864](https://github.com/airbytehq/airbyte/pull/13864) | Updated stacktrace format for any trace message errors |
-| 0.1.2 | 2022-05-17 | [12820](https://github.com/airbytehq/airbyte/pull/12820) | Improved 'check' operation performance |
-| 0.1.1 | 2022-02-14 | [10256](https://github.com/airbytehq/airbyte/pull/10256) | Add `-XX:+ExitOnOutOfMemoryError` JVM option |
-| 0.1.0 | 2021-11-15 | [\#8006](https://github.com/airbytehq/airbyte/pull/8006) | Initial release|
-
+| Version | Date       | Pull Request                                             | Subject                                                |
+| :------ | :--------- | :------------------------------------------------------- | :----------------------------------------------------- |
+| 0.1.4   | 2022-06-17 | [15395](https://github.com/airbytehq/airbyte/pull/15395) | Updated Destination Rockset to handle per-stream state |
+| 0.1.3   | 2022-06-17 | [13864](https://github.com/airbytehq/airbyte/pull/13864) | Updated stacktrace format for any trace message errors |
+| 0.1.2   | 2022-05-17 | [12820](https://github.com/airbytehq/airbyte/pull/12820) | Improved 'check' operation performance                 |
+| 0.1.1   | 2022-02-14 | [10256](https://github.com/airbytehq/airbyte/pull/10256) | Add `-XX:+ExitOnOutOfMemoryError` JVM option           |
+| 0.1.0   | 2021-11-15 | [8006](https://github.com/airbytehq/airbyte/pull/8006)   | Initial release                                        |

--- a/docs/integrations/destinations/s3-glue.md
+++ b/docs/integrations/destinations/s3-glue.md
@@ -5,13 +5,14 @@ This page guides you through the process of setting up the S3 destination connec
 ## Prerequisites
 
 List of required fields:
-* **Access Key ID**
-* **Secret Access Key**
-* **S3 Bucket Name**
-* **S3 Bucket Path**
-* **S3 Bucket Region**
-* **Glue database**
-* **Glue serialization library**
+
+- **Access Key ID**
+- **Secret Access Key**
+- **S3 Bucket Name**
+- **S3 Bucket Path**
+- **S3 Bucket Region**
+- **Glue database**
+- **Glue serialization library**
 
 1. Allow connections from Airbyte server to your AWS S3/ Minio S3 cluster \(if they exist in separate VPCs\).
 2. An S3 bucket with credentials or an instance profile with read/write permissions configured for the host (ec2, eks).
@@ -28,6 +29,7 @@ Prepare S3 bucket that will be used as destination, see [this](https://docs.aws.
 NOTE: If the S3 cluster is not configured to use TLS, the connection to Amazon S3 silently reverts to an unencrypted connection. Airbyte recommends all connections be configured to use TLS/SSL as support for AWS's [shared responsibility model](https://aws.amazon.com/compliance/shared-responsibility-model/)
 
 ## Step 2: Set up Glue
+
 [Sign in](https://signin.aws.amazon.com/signin) to your AWS account.
 Use an existing or create new [Access Key ID and Secret Access Key](https://docs.aws.amazon.com/general/latest/gr/aws-sec-cred-types.html#:~:text=IAM%20User%20Guide.-,Programmatic%20access,-You%20must%20provide).
 
@@ -35,34 +37,33 @@ Prepare the Glue database that will be used as destination, see [this](https://d
 
 ## Step 3: Set up the S3-Glue destination connector in Airbyte
 
-
 **For Airbyte Cloud:**
 
 1. [Log into your Airbyte Cloud](https://cloud.airbyte.io/workspaces) account.
 2. In the left navigation bar, click **Destinations**. In the top-right corner, click **+ new destination**.
 3. On the destination setup page, select **S3** from the Destination type dropdown and enter a name for this connector.
 4. Configure fields:
-    * **Access Key Id**
-        * See [this](https://docs.aws.amazon.com/general/latest/gr/aws-sec-cred-types.html#access-keys-and-secret-access-keys) on how to generate an access key.
-        * We recommend creating an Airbyte-specific user. This user will require [read and write permissions](https://docs.aws.amazon.com/IAM/latest/UserGuide/reference_policies_examples_s3_rw-bucket.html) to objects in the bucket.
-    * **Secret Access Key**
-        * Corresponding key to the above key id.
-    * **S3 Bucket Name**
-        * See [this](https://docs.aws.amazon.com/AmazonS3/latest/userguide/create-bucket-overview.html) to create an S3 bucket.
-    * **S3 Bucket Path**
-        * Subdirectory under the above bucket to sync the data into.
-    * **S3 Bucket Region**
-        * See [here](https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/using-regions-availability-zones.html#concepts-available-regions) for all region codes.
-    * **S3 Path Format**
-        *  Additional string format on how to store data under S3 Bucket Path. Default value is `${NAMESPACE}/${STREAM_NAME}/${YEAR}_${MONTH}_${DAY}_${EPOCH}_`.
-    * **S3 Endpoint**
-        * Leave empty if using AWS S3, fill in S3 URL if using Minio S3.
-    * **S3 Filename pattern**
-        * The pattern allows you to set the file-name format for the S3 staging file(s), next placeholders combinations are currently supported: {date}, {date:yyyy_MM}, {timestamp}, {timestamp:millis}, {timestamp:micros}, {part_number}, {sync_id}, {format_extension}. Please, don't use empty space and not supportable placeholders, as they won't recognized.
-    * **Glue database**
-        * The Glue database name that was previously created through the management console or the cli.
-    * **Glue serialization library**
-        * The library that your query engine will use for reading and writing data in your lake
+   - **Access Key Id**
+     - See [this](https://docs.aws.amazon.com/general/latest/gr/aws-sec-cred-types.html#access-keys-and-secret-access-keys) on how to generate an access key.
+     - We recommend creating an Airbyte-specific user. This user will require [read and write permissions](https://docs.aws.amazon.com/IAM/latest/UserGuide/reference_policies_examples_s3_rw-bucket.html) to objects in the bucket.
+   - **Secret Access Key**
+     - Corresponding key to the above key id.
+   - **S3 Bucket Name**
+     - See [this](https://docs.aws.amazon.com/AmazonS3/latest/userguide/create-bucket-overview.html) to create an S3 bucket.
+   - **S3 Bucket Path**
+     - Subdirectory under the above bucket to sync the data into.
+   - **S3 Bucket Region**
+     - See [here](https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/using-regions-availability-zones.html#concepts-available-regions) for all region codes.
+   - **S3 Path Format**
+     - Additional string format on how to store data under S3 Bucket Path. Default value is `${NAMESPACE}/${STREAM_NAME}/${YEAR}_${MONTH}_${DAY}_${EPOCH}_`.
+   - **S3 Endpoint**
+     - Leave empty if using AWS S3, fill in S3 URL if using Minio S3.
+   - **S3 Filename pattern**
+     - The pattern allows you to set the file-name format for the S3 staging file(s), next placeholders combinations are currently supported: {date}, {date:yyyy_MM}, {timestamp}, {timestamp:millis}, {timestamp:micros}, {part_number}, {sync_id}, {format_extension}. Please, don't use empty space and not supportable placeholders, as they won't recognized.
+   - **Glue database**
+     - The Glue database name that was previously created through the management console or the cli.
+   - **Glue serialization library**
+     - The library that your query engine will use for reading and writing data in your lake
 5. Click `Set up destination`.
 
 **For Airbyte Open Source:**
@@ -71,51 +72,53 @@ Prepare the Glue database that will be used as destination, see [this](https://d
 2. In the left navigation bar, click **Destinations**. In the top-right corner, click **+ new destination**.
 3. On the destination setup page, select **S3** from the Destination type dropdown and enter a name for this connector.
 4. Configure fields:
-    * **Access Key Id**
-        * See [this](https://docs.aws.amazon.com/general/latest/gr/aws-sec-cred-types.html#access-keys-and-secret-access-keys) on how to generate an access key.
-        * See [this](https://docs.aws.amazon.com/IAM/latest/UserGuide/id_roles_use_switch-role-ec2_instance-profiles.html) on how to create a instanceprofile.
-        * We recommend creating an Airbyte-specific user. This user will require [read and write permissions](https://docs.aws.amazon.com/IAM/latest/UserGuide/reference_policies_examples_s3_rw-bucket.html) to objects in the staging bucket.
-        * If the Access Key and Secret Access Key are not provided, the authentication will rely on the instanceprofile.
-    * **Secret Access Key**
-        * Corresponding key to the above key id.
-    * Make sure your S3 bucket is accessible from the machine running Airbyte.
-        * This depends on your networking setup.
-        * You can check AWS S3 documentation with a tutorial on how to properly configure your S3's access [here](https://docs.aws.amazon.com/AmazonS3/latest/userguide/access-control-overview.html).
-        * If you use instance profile authentication, make sure the role has permission to read/write on the bucket.
-        * The easiest way to verify if Airbyte is able to connect to your S3 bucket is via the check connection tool in the UI.
-    * **S3 Bucket Name**
-        * See [this](https://docs.aws.amazon.com/AmazonS3/latest/userguide/create-bucket-overview.html) to create an S3 bucket.
-    * **S3 Bucket Path**
-        * Subdirectory under the above bucket to sync the data into.
-    * **S3 Bucket Region**
-        * See [here](https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/using-regions-availability-zones.html#concepts-available-regions) for all region codes.
-    * **S3 Path Format**
-        * Additional string format on how to store data under S3 Bucket Path. Default value is `${NAMESPACE}/${STREAM_NAME}/${YEAR}_${MONTH}_${DAY}_${EPOCH}_`.
-    * **S3 Endpoint**
-        * Leave empty if using AWS S3, fill in S3 URL if using Minio S3.
-    * **S3 Filename pattern**
-        * The pattern allows you to set the file-name format for the S3 staging file(s), next placeholders combinations are currently supported: {date}, {date:yyyy_MM}, {timestamp}, {timestamp:millis}, {timestamp:micros}, {part_number}, {sync_id}, {format_extension}. Please, don't use empty space and not supportable placeholders, as they won't recognized.
-   * **Glue database**
-       * The Glue database name that was previously created through the management console or the cli.
-   * **Glue serialization library**
-       * The library that your query engine will use for reading and writing data in your lake
+
+   - **Access Key Id**
+     - See [this](https://docs.aws.amazon.com/general/latest/gr/aws-sec-cred-types.html#access-keys-and-secret-access-keys) on how to generate an access key.
+     - See [this](https://docs.aws.amazon.com/IAM/latest/UserGuide/id_roles_use_switch-role-ec2_instance-profiles.html) on how to create a instanceprofile.
+     - We recommend creating an Airbyte-specific user. This user will require [read and write permissions](https://docs.aws.amazon.com/IAM/latest/UserGuide/reference_policies_examples_s3_rw-bucket.html) to objects in the staging bucket.
+     - If the Access Key and Secret Access Key are not provided, the authentication will rely on the instanceprofile.
+   - **Secret Access Key**
+     - Corresponding key to the above key id.
+   - Make sure your S3 bucket is accessible from the machine running Airbyte.
+     - This depends on your networking setup.
+     - You can check AWS S3 documentation with a tutorial on how to properly configure your S3's access [here](https://docs.aws.amazon.com/AmazonS3/latest/userguide/access-control-overview.html).
+     - If you use instance profile authentication, make sure the role has permission to read/write on the bucket.
+     - The easiest way to verify if Airbyte is able to connect to your S3 bucket is via the check connection tool in the UI.
+   - **S3 Bucket Name**
+     - See [this](https://docs.aws.amazon.com/AmazonS3/latest/userguide/create-bucket-overview.html) to create an S3 bucket.
+   - **S3 Bucket Path**
+     - Subdirectory under the above bucket to sync the data into.
+   - **S3 Bucket Region**
+     - See [here](https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/using-regions-availability-zones.html#concepts-available-regions) for all region codes.
+   - **S3 Path Format**
+     - Additional string format on how to store data under S3 Bucket Path. Default value is `${NAMESPACE}/${STREAM_NAME}/${YEAR}_${MONTH}_${DAY}_${EPOCH}_`.
+   - **S3 Endpoint**
+     - Leave empty if using AWS S3, fill in S3 URL if using Minio S3.
+   - **S3 Filename pattern**
+     - The pattern allows you to set the file-name format for the S3 staging file(s), next placeholders combinations are currently supported: {date}, {date:yyyy_MM}, {timestamp}, {timestamp:millis}, {timestamp:micros}, {part_number}, {sync_id}, {format_extension}. Please, don't use empty space and not supportable placeholders, as they won't recognized.
+   - **Glue database**
+     - The Glue database name that was previously created through the management console or the cli.
+   - **Glue serialization library**
+     - The library that your query engine will use for reading and writing data in your lake
 
 5. Click `Set up destination`.
 
 In order for everything to work correctly, it is also necessary that the user whose "S3 Key Id" and "S3 Access Key" are used have access to both the bucket and its contents. Policies to use:
+
 ```json
 {
   "Version": "2012-10-17",
-    "Statement": [
-        {
-            "Effect": "Allow",
-            "Action": "s3:*",
-            "Resource": [
-                "arn:aws:s3:::YOUR_BUCKET_NAME/*",
-                "arn:aws:s3:::YOUR_BUCKET_NAME"
-            ]
-            }
-    ]
+  "Statement": [
+    {
+      "Effect": "Allow",
+      "Action": "s3:*",
+      "Resource": [
+        "arn:aws:s3:::YOUR_BUCKET_NAME/*",
+        "arn:aws:s3:::YOUR_BUCKET_NAME"
+      ]
+    }
+  ]
 }
 ```
 
@@ -149,6 +152,7 @@ The rationales behind this naming pattern are:
 3. The upload time composes of a date part and millis part so that it is both readable and unique.
 
 But it is possible to further customize by using the available variables to format the bucket path:
+
 - `${NAMESPACE}`: Namespace where the stream comes from or configured by the connection namespace fields.
 - `${STREAM_NAME}`: Name of the stream
 - `${YEAR}`: Year in which the sync was writing the output data in.
@@ -162,6 +166,7 @@ But it is possible to further customize by using the available variables to form
 - `${UUID}`: random uuid string
 
 Note:
+
 - Multiple `/` characters in the S3 path are collapsed into a single `/` character.
 - If the output bucket contains too many files, the part id variable is using a `UUID` instead. It uses sequential ID otherwise.
 
@@ -170,12 +175,12 @@ A data sync may create multiple files as the output files can be partitioned by 
 
 ## Supported sync modes
 
-| Feature | Support | Notes |
-| :--- | :---: | :--- |
-| Full Refresh Sync | ✅ | Warning: this mode deletes all previously synced data in the configured bucket path. |
-| Incremental - Append Sync | ✅ |  |
-| Incremental - Deduped History | ❌ | As this connector does not support dbt, we don't support this sync mode on this destination. |
-| Namespaces | ❌ | Setting a specific bucket path is equivalent to having separate namespaces. |
+| Feature                       | Support | Notes                                                                                        |
+| :---------------------------- | :-----: | :------------------------------------------------------------------------------------------- |
+| Full Refresh Sync             |   ✅    | Warning: this mode deletes all previously synced data in the configured bucket path.         |
+| Incremental - Append Sync     |   ✅    |                                                                                              |
+| Incremental - Deduped History |   ❌    | As this connector does not support dbt, we don't support this sync mode on this destination. |
+| Namespaces                    |   ❌    | Setting a specific bucket path is equivalent to having separate namespaces.                  |
 
 The Airbyte S3 destination allows you to sync data to AWS S3 or Minio S3. Each stream is written to its own directory under the bucket.
 ⚠️ Please note that under "Full Refresh Sync" mode, data in the configured bucket and path will be wiped out before each sync. We recommend you to provision a dedicated S3 resource for this sync to prevent unexpected data deletion from misconfiguration. ⚠️
@@ -184,9 +189,8 @@ The Airbyte S3 destination allows you to sync data to AWS S3 or Minio S3. Each s
 
 Each stream will be outputted to its dedicated directory according to the configuration. The complete datastore of each stream includes all the output files under that directory. You can think of the directory as equivalent of a Table in the database world.
 
-* Under Full Refresh Sync mode, old output files will be purged before new files are created.
-* Under Incremental - Append Sync mode, new output files will be added that only contain the new data.
-
+- Under Full Refresh Sync mode, old output files will be purged before new files are created.
+- Under Incremental - Append Sync mode, new output files will be added that only contain the new data.
 
 ### JSON Lines \(JSONL\)
 
@@ -231,15 +235,14 @@ The json objects can have the following formats:
 ```
 
 ```text
-{ "_airbyte_ab_id": "26d73cde-7eb1-4e1e-b7db-a4c03b4cf206", "_airbyte_emitted_at": "1622135805000", "user_id": 123, "name": { "first": "John", "last": "Doe" } } 
-{ "_airbyte_ab_id": "0a61de1b-9cdd-4455-a739-93572c9a5f20", "_airbyte_emitted_at": "1631948170000", "user_id": 456, "name": { "first": "Jane", "last": "Roe" } } 
+{ "_airbyte_ab_id": "26d73cde-7eb1-4e1e-b7db-a4c03b4cf206", "_airbyte_emitted_at": "1622135805000", "user_id": 123, "name": { "first": "John", "last": "Doe" } }
+{ "_airbyte_ab_id": "0a61de1b-9cdd-4455-a739-93572c9a5f20", "_airbyte_emitted_at": "1631948170000", "user_id": 456, "name": { "first": "Jane", "last": "Roe" } }
 ```
 
 Output files can be compressed. The default option is GZIP compression. If compression is selected, the output filename will have an extra extension (GZIP: `.jsonl.gz`).
 
 ## CHANGELOG
 
-| Version | Date | Pull Request | Subject |
-|:--------|:-----|:-------------|:--------|
-|         |      |              |         |
-
+| Version | Date       | Pull Request                                             | Subject        |
+| :------ | :--------- | :------------------------------------------------------- | :------------- |
+| 0.1.0   | 2022-11-17 | [18695](https://github.com/airbytehq/airbyte/pull/18695) | Initial Commit |

--- a/tools/bin/ci_check_dependency.py
+++ b/tools/bin/ci_check_dependency.py
@@ -2,7 +2,8 @@ import sys
 import os
 import os.path
 import yaml
-from typing import Any, Dict, Text
+import re
+from typing import Any, Dict, Text, List
 
 CONNECTORS_PATH = "./airbyte-integrations/connectors/"
 NORMALIZATION_PATH = "./airbyte-integrations/bases/base-normalization/"
@@ -16,6 +17,11 @@ IGNORE_LIST = [
     "/integration_tests/", "/unit_tests/",
     # Common
     "acceptance-test-config.yml", "acceptance-test-docker.sh", ".md", ".dockerignore", ".gitignore", "requirements.txt"]
+IGNORED_DESTINATIONS = [
+    re.compile(".*-strict-encrypt$"),
+    re.compile("^destination-dev-null$"),
+    re.compile("^destination-jdbc$")
+]
 COMMENT_TEMPLATE_PATH = ".github/comment_templates/connector_dependency_template.md"
 
 
@@ -23,6 +29,9 @@ def main():
     # Used git diff checks airbyte-integrations/ folder only
     # See .github/workflows/report-connectors-dependency.yml file
     git_diff_file_path = ' '.join(sys.argv[1:])
+
+    if git_diff_file_path == None or git_diff_file_path == "":
+        raise Exception("No changefile provided")
 
     # Get changed files
     changed_files = get_changed_files(git_diff_file_path)
@@ -117,7 +126,7 @@ def get_connector_version_status(connector, version):
         return f"❌ `{version}`<br/>(mismatch: `{base_variant_version}`)"
 
 
-def get_connector_changelog_status(connector, version):
+def get_connector_changelog_status(connector: str, version):
     type, name = connector.replace("-strict-encrypt", "").split("-", 1)
     doc_path = f"{DOC_PATH}{type}s/{name}.md"
     if not os.path.exists(doc_path):
@@ -129,7 +138,11 @@ def get_connector_changelog_status(connector, version):
                 after_changelog = True
             if after_changelog and version in line:
                 return "✅"
-    return "❌<br/>(changelog missing)"
+
+    if any(regex.match(connector) for regex in IGNORED_DESTINATIONS):
+        return "🔵<br/>(ignored)"
+    else:
+        return "❌<br/>(changelog missing)"
 
 
 def as_bulleted_markdown_list(items):
@@ -139,14 +152,16 @@ def as_bulleted_markdown_list(items):
     return text
 
 
-def as_markdown_table_rows(connectors, definitions):
+def as_markdown_table_rows(connectors: List[str], definitions):
     text = ""
     for connector in connectors:
         version = get_connector_version(connector)
         version_status = get_connector_version_status(connector, version)
         changelog_status = get_connector_changelog_status(connector, version)
         definition = next((x for x in definitions if x["dockerRepository"].endswith(connector)), None)
-        if definition is None:
+        if any(regex.match(connector) for regex in IGNORED_DESTINATIONS):
+            publish_status = "🔵<br/>(ignored)"
+        elif definition is None:
             publish_status = "⚠<br/>(not in seed)"
         elif definition["dockerImageTag"] == version:
             publish_status = "✅"
@@ -156,7 +171,7 @@ def as_markdown_table_rows(connectors, definitions):
     return text
 
 
-def get_status_summary(rows):
+def get_status_summary(rows: str):
     if "❌" in rows:
         return "❌"
     elif "⚠" in rows:

--- a/tools/bin/ci_check_dependency.py
+++ b/tools/bin/ci_check_dependency.py
@@ -126,7 +126,7 @@ def get_connector_version_status(connector, version):
         return f"❌ `{version}`<br/>(mismatch: `{base_variant_version}`)"
 
 
-def get_connector_changelog_status(connector: str, version):
+def get_connector_changelog_status(connector: str, version) -> str:
     type, name = connector.replace("-strict-encrypt", "").split("-", 1)
     doc_path = f"{DOC_PATH}{type}s/{name}.md"
     if not os.path.exists(doc_path):
@@ -152,7 +152,7 @@ def as_bulleted_markdown_list(items):
     return text
 
 
-def as_markdown_table_rows(connectors: List[str], definitions):
+def as_markdown_table_rows(connectors: List[str], definitions) -> str:
     text = ""
     for connector in connectors:
         version = get_connector_version(connector)
@@ -171,7 +171,7 @@ def as_markdown_table_rows(connectors: List[str], definitions):
     return text
 
 
-def get_status_summary(rows: str):
+def get_status_summary(rows: str) -> str:
     if "❌" in rows:
         return "❌"
     elif "⚠" in rows:


### PR DESCRIPTION
Closes https://github.com/airbytehq/airbyte/issues/20075.  

Working though the list of connector issues here https://github.com/airbytehq/airbyte/pull/19993#issuecomment-1336456298 solving missing chagelogs and missing docs pages entirely. 

After this update, a missing strict-encrypt connector or `destination-jdbc` won't trigger a failure.  We now use 🔵 for skipped connectors in this check.

<img width="668" alt="Screenshot 2022-12-05 at 5 09 06 PM" src="https://user-images.githubusercontent.com/303226/205781778-0196c923-4093-476d-8ae8-41f502134e1f.png">

---

To test the python code, add a file like this the root of your airbyte project `changed_files.txt`:

```
airbyte-integrations/connectors/source-faker/main.py
airbyte-integrations/connectors/destination-jdbc/foo.java
```
and then run `python3 ./tools/bin/ci_check_dependency.py ./changed_files.txt` to see the generated comment markdown at `comment_body.md`