### PR TITLE
source-java-jdbc: use latest acceptance-test-config.yml format

### DIFF
--- a/airbyte-integrations/connector-templates/source-java-jdbc/acceptance-test-config.yml.hbs
+++ b/airbyte-integrations/connector-templates/source-java-jdbc/acceptance-test-config.yml.hbs
@@ -1,7 +1,9 @@
 # See [Source Acceptance Tests](https://docs.airbyte.com/connector-development/testing-connectors/source-acceptance-tests-reference)
 # for more information about how to configure these tests
 connector_image: airbyte/source-{{dashCase name}}:dev
-tests:
+acceptance_tests:
   spec:
-    - spec_path: "src/test-integration/resources/expected_spec.json"
-      config_path: "src/test-integration/resources/dummy_config.json"
+    tests:
+      - spec_path: "src/test-integration/resources/expected_spec.json"
+        config_path: "src/test-integration/resources/dummy_config.json"  
+

--- a/airbyte-integrations/connectors/source-scaffold-java-jdbc/acceptance-test-config.yml
+++ b/airbyte-integrations/connectors/source-scaffold-java-jdbc/acceptance-test-config.yml
@@ -1,7 +1,8 @@
 # See [Source Acceptance Tests](https://docs.airbyte.com/connector-development/testing-connectors/source-acceptance-tests-reference)
 # for more information about how to configure these tests
 connector_image: airbyte/source-scaffold-java-jdbc:dev
-tests:
+acceptance_tests:
   spec:
-    - spec_path: "src/test-integration/resources/expected_spec.json"
-      config_path: "src/test-integration/resources/dummy_config.json"
+    tests:
+      - spec_path: "src/test-integration/resources/expected_spec.json"
+        config_path: "src/test-integration/resources/dummy_config.json"


### PR DESCRIPTION
## What
Update the source-java-jdbc generator to use the latest acceptance-test-config format.