### PR TITLE
📝 fix google analytics ua docs url in readme

### DIFF
--- a/airbyte-integrations/connectors/source-google-analytics-v4/README.md
+++ b/airbyte-integrations/connectors/source-google-analytics-v4/README.md
@@ -1,7 +1,7 @@
 # Google Analytics V4 Source
 
 This is the repository for the Google Analytics V4 source connector, written in Python.
-For information about how to use this connector within Airbyte, see [the documentation](https://docs.airbyte.io/integrations/sources/google-analytics-v4).
+For information about how to use this connector within Airbyte, see [the documentation](https://docs.airbyte.com/integrations/sources/google-analytics-universal-analytics/).
 
 ## Local development
 


### PR DESCRIPTION
## What
Following up on https://github.com/airbytehq/airbyte/pull/15087 which has the important user-facing changes

Noticed that the readme is still linking to the [Google Analytics GA4](https://docs.airbyte.com/integrations/sources/google-analytics-v4/) connector docs which is not correct. This PR changes that link to the correct doc, [Google Analytics (Universal Analytics)](https://docs.airbyte.com/integrations/sources/google-analytics-universal-analytics/)

## How
- Updated docs link in README.md to match source_definitions.yaml and the connector's spec.json