### PR TITLE
test/publish commands: always run update secrets

### DIFF
--- a/.github/workflows/publish-command.yml
+++ b/.github/workflows/publish-command.yml
@@ -321,6 +321,7 @@ jobs:
           attempt_limit: 3
           attempt_delay: 5000 in # ms
       - name: Update Integration Test Credentials after test run for ${{ github.event.inputs.connector }}
+        if: always()
         run: |
           source venv/bin/activate
           ci_credentials ${{ matrix.connector }} update-secrets

--- a/.github/workflows/test-command.yml
+++ b/.github/workflows/test-command.yml
@@ -132,6 +132,7 @@ jobs:
           attempt_limit: 3
           attempt_delay: 10000 # in ms
       - name: Update Integration Test Credentials after test run for ${{ github.event.inputs.connector }}
+        if: always()
         run: |
           source venv/bin/activate
           ci_credentials ${{ github.event.inputs.connector }} update-secrets

--- a/.github/workflows/test-performance-command.yml
+++ b/.github/workflows/test-performance-command.yml
@@ -125,6 +125,7 @@ jobs:
           # Oracle expects this variable to be set. Although usually present, this is not set by default on Github virtual runners.
           TZ: UTC
       - name: Update Integration Test Credentials after test run for ${{ github.event.inputs.connector }}
+        if: always()
         run: |
           source venv/bin/activate
           ci_credentials ${{ github.event.inputs.connector }} update-secrets


### PR DESCRIPTION
## What
Always run `Update Integration Test Credentials after test` step, even if previous step failed.