### PR TITLE
database migration to add column for field selection info

### DIFF
--- a/airbyte-bootloader/src/test/java/io/airbyte/bootloader/BootloaderAppTest.java
+++ b/airbyte-bootloader/src/test/java/io/airbyte/bootloader/BootloaderAppTest.java
@@ -142,7 +142,7 @@ class BootloaderAppTest {
       val configsMigrator = new ConfigsDatabaseMigrator(configDatabase, configsFlyway);
       // this line should change with every new migration
       // to show that you meant to make a new migration to the prod database
-      assertEquals("0.40.18.004", configsMigrator.getLatestMigration().getVersion().getVersion());
+      assertEquals("0.40.23.001", configsMigrator.getLatestMigration().getVersion().getVersion());
 
       val jobsPersistence = new DefaultJobPersistence(jobDatabase);
       assertEquals(VERSION_0330_ALPHA, jobsPersistence.getVersion().get());

--- a/airbyte-db/db-lib/src/main/java/io/airbyte/db/instance/configs/migrations/V0_40_23_001__AddFieldSelectionDataToConnections.java
+++ b/airbyte-db/db-lib/src/main/java/io/airbyte/db/instance/configs/migrations/V0_40_23_001__AddFieldSelectionDataToConnections.java
@@ -1,0 +1,36 @@
+/*
+ * Copyright (c) 2022 Airbyte, Inc., all rights reserved.
+ */
+
+package io.airbyte.db.instance.configs.migrations;
+
+import org.flywaydb.core.api.migration.BaseJavaMigration;
+import org.flywaydb.core.api.migration.Context;
+import org.jooq.DSLContext;
+import org.jooq.impl.DSL;
+import org.jooq.impl.SQLDataType;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+public class V0_40_23_001__AddFieldSelectionDataToConnections extends BaseJavaMigration {
+
+  private static final Logger LOGGER = LoggerFactory.getLogger(V0_40_23_001__AddFieldSelectionDataToConnections.class);
+
+  @Override
+  public void migrate(final Context context) throws Exception {
+    LOGGER.info("Running migration: {}", this.getClass().getSimpleName());
+
+    // Warning: please do not use any jOOQ generated code to write a migration.
+    // As database schema changes, the generated jOOQ code can be deprecated. So
+    // old migration may not compile if there is any generated code.
+    final DSLContext ctx = DSL.using(context.getConnection());
+    addFieldSelectionData(ctx);
+  }
+
+  private static void addFieldSelectionData(final DSLContext ctx) {
+    ctx.alterTable("connection")
+        .addColumnIfNotExists(DSL.field("field_selection_data", SQLDataType.JSONB.nullable(true)))
+        .execute();
+  }
+
+}

--- a/airbyte-db/db-lib/src/main/resources/configs_database/schema_dump.txt
+++ b/airbyte-db/db-lib/src/main/resources/configs_database/schema_dump.txt
@@ -112,6 +112,7 @@ create table "public"."connection"(
   "non_breaking_change_preference" varchar(7) not null default '''ignore''::character varying',
   "breaking_change" bool not null default false,
   "unsupported_protocol_version" bool not null default false,
+  "field_selection_data" jsonb null,
   constraint "connection_pkey"
     primary key ("id")
 );


### PR DESCRIPTION
## What
Config database support for field/column selection info.

## How
Adds a column in the `connection` table.

This will be a map from `StreamDescriptor` -> `true/false` indicating whether the given stream has requested column selection.

See [spec](https://docs.google.com/document/d/1mCY9pi3iwWEzx7V2_--80E7tkmeWs_ckcLfqin1k_rA).