### PR TITLE
Add notification and metrics docs to sidebar

### DIFF
--- a/docusaurus/sidebars.js
+++ b/docusaurus/sidebars.js
@@ -185,6 +185,8 @@ module.exports = {
           },
         'operator-guides/using-custom-connectors',
         'operator-guides/scaling-airbyte',
+        'operator-guides/configuring-sync-notifications',
+        'operator-guides/collecting-metrics',
       ],
     },
     {


### PR DESCRIPTION
Add these existing docs pages to the sidebar:
- https://docs.airbyte.com/operator-guides/configuring-sync-notifications/
- https://docs.airbyte.com/operator-guides/collecting-metrics/