### PR TITLE
🪟 🔧 Add storybook for `<RadioButton />` component

### DIFF
--- a/airbyte-webapp/src/components/ui/RadioButton/index.stories.tsx
+++ b/airbyte-webapp/src/components/ui/RadioButton/index.stories.tsx
@@ -1,0 +1,17 @@
+import { ComponentMeta, ComponentStory } from "@storybook/react";
+
+import { RadioButton } from "./RadioButton";
+
+export default {
+  title: "Ui/RadioButton",
+  component: RadioButton,
+  argTypes: {
+    disabled: { control: "boolean" },
+    checked: { control: "boolean" },
+  },
+} as ComponentMeta<typeof RadioButton>;
+
+const Template: ComponentStory<typeof RadioButton> = (args) => <RadioButton {...args} />;
+
+export const Default = Template.bind({});
+Default.args = {};


### PR DESCRIPTION
## What
The original issue was: https://github.com/airbytehq/airbyte/issues/20089
But turned out that we have desired state.
So the PR contains only storybook updates  

## How
Add storybook for `<RadioButton />` component

<img width="371" alt="image" src="https://user-images.githubusercontent.com/20929344/206479710-1d137879-0367-40c4-85ec-49ae952a850b.png">
