### PR TITLE
Source Jira: correct description and example for additional fields to avoid misleading users

### DIFF
--- a/airbyte-integrations/connectors/source-jira/source_jira/spec.json
+++ b/airbyte-integrations/connectors/source-jira/source_jira/spec.json
@@ -47,8 +47,8 @@
         "items": {
           "type": "string"
         },
-        "description": "List of additional fields to include in replicating issues.",
-        "examples": ["customfield_10096", "customfield_10071"]
+        "description": "List of additional fields names to include in replicating issues.",
+        "examples": ["Approvers", "Change completion date"]
       },
       "expand_issue_changelog": {
         "type": "boolean",


### PR DESCRIPTION
correct description and example for additional fields to avoid misleading users. Now it's array of fields names, not their ids