### PR TITLE
🪟 🔧 Allow overwriting features in dev by env variables

### DIFF
--- a/airbyte-webapp/src/hooks/services/Feature/FeatureService.test.tsx
+++ b/airbyte-webapp/src/hooks/services/Feature/FeatureService.test.tsx
@@ -181,6 +181,13 @@ describe("Feature Service", () => {
         expect(getFeature(FeatureItem.AllowSync)).toBe(false);
         expect(getFeature(FeatureItem.AllowChangeDataGeographies)).toBe(true);
       });
+
+      it("should not overwrite in a non dev environment", () => {
+        (process.env.NODE_ENV as string) = "productions";
+        const getFeature = (feature: FeatureItem) => renderHook(() => useFeature(feature), { wrapper }).result.current;
+        expect(getFeature(FeatureItem.AllowSync)).toBe(true);
+        expect(getFeature(FeatureItem.AllowChangeDataGeographies)).toBe(false);
+      });
     });
   });
 

--- a/airbyte-webapp/src/hooks/services/Feature/FeatureService.test.tsx
+++ b/airbyte-webapp/src/hooks/services/Feature/FeatureService.test.tsx
@@ -162,6 +162,26 @@ describe("Feature Service", () => {
       rerender({ overwrite: undefined });
       expect(result.current.sort()).toEqual([FeatureItem.AllowDBTCloudIntegration, FeatureItem.AllowSync]);
     });
+
+    describe("env variable overwrites", () => {
+      beforeEach(() => {
+        process.env.REACT_APP_FEATURE_ALLOW_SYNC = "false";
+        process.env.REACT_APP_FEATURE_ALLOW_CHANGE_DATA_GEOGRAPHIES = "true";
+      });
+
+      afterEach(() => {
+        (process.env.NODE_ENV as string) = "test";
+        process.env.REACT_APP_FEATURE_ALLOW_SYNC = undefined;
+        process.env.REACT_APP_FEATURE_ALLOW_CHANGE_DATA_GEOGRAPHIES = undefined;
+      });
+
+      it("should allow overwriting it in dev", () => {
+        (process.env.NODE_ENV as string) = "development";
+        const getFeature = (feature: FeatureItem) => renderHook(() => useFeature(feature), { wrapper }).result.current;
+        expect(getFeature(FeatureItem.AllowSync)).toBe(false);
+        expect(getFeature(FeatureItem.AllowChangeDataGeographies)).toBe(true);
+      });
+    });
   });
 
   describe("IfFeatureEnabled", () => {

--- a/airbyte-webapp/src/hooks/services/Feature/FeatureService.test.tsx
+++ b/airbyte-webapp/src/hooks/services/Feature/FeatureService.test.tsx
@@ -183,7 +183,7 @@ describe("Feature Service", () => {
       });
 
       it("should not overwrite in a non dev environment", () => {
-        (process.env.NODE_ENV as string) = "productions";
+        (process.env.NODE_ENV as string) = "production";
         const getFeature = (feature: FeatureItem) => renderHook(() => useFeature(feature), { wrapper }).result.current;
         expect(getFeature(FeatureItem.AllowSync)).toBe(true);
         expect(getFeature(FeatureItem.AllowChangeDataGeographies)).toBe(false);

--- a/airbyte-webapp/src/hooks/services/Feature/FeatureService.tsx
+++ b/airbyte-webapp/src/hooks/services/Feature/FeatureService.tsx
@@ -40,6 +40,10 @@ export const FeatureService: React.FC<React.PropsWithChildren<FeatureServiceProp
   const [overwrittenFeatures, setOverwrittenFeaturesState] = useState<FeatureSet>();
 
   const envOverwrites = useMemo(() => {
+    // Allow env feature overwrites only during development
+    if (process.env.NODE_ENV !== "development") {
+      return {};
+    }
     const featureSet: FeatureSet = {};
     for (const item of Object.values(FeatureItem)) {
       const envFeature = process.env[`REACT_APP_FEATURE_${item}`];
@@ -57,8 +61,7 @@ export const FeatureService: React.FC<React.PropsWithChildren<FeatureServiceProp
       ...workspaceFeatures,
       ...userFeatures,
       ...overwrittenFeatures,
-      // Any REACT_APP_FEATURE_FEATURE_ID env can overwrite feature states during development
-      ...(process.env.NODE_ENV === "development" ? envOverwrites : {}),
+      ...envOverwrites,
     };
 
     return Object.entries(combined)

--- a/airbyte-webapp/src/hooks/services/Feature/FeatureService.tsx
+++ b/airbyte-webapp/src/hooks/services/Feature/FeatureService.tsx
@@ -47,7 +47,7 @@ export const FeatureService: React.FC<React.PropsWithChildren<FeatureServiceProp
     const featureSet: FeatureSet = {};
     for (const item of Object.values(FeatureItem)) {
       const envFeature = process.env[`REACT_APP_FEATURE_${item}`];
-      // If a REACT_APP_FEATURE_{id} env variable is set it can overwrite that fetaure state
+      // If a REACT_APP_FEATURE_{id} env variable is set it can overwrite that feature state
       if (envFeature) {
         featureSet[item] = envFeature === "true";
       }

--- a/airbyte-webapp/src/hooks/services/Feature/FeatureService.tsx
+++ b/airbyte-webapp/src/hooks/services/Feature/FeatureService.tsx
@@ -39,12 +39,26 @@ export const FeatureService: React.FC<React.PropsWithChildren<FeatureServiceProp
   const [userFeatures, setUserFeaturesState] = useState<FeatureSet>();
   const [overwrittenFeatures, setOverwrittenFeaturesState] = useState<FeatureSet>();
 
+  const envOverwrites = useMemo(() => {
+    const featureSet: FeatureSet = {};
+    for (const item of Object.values(FeatureItem)) {
+      const envFeature = process.env[`REACT_APP_FEATURE_${item}`];
+      // If a REACT_APP_FEATURE_{id} env variable is set it can overwrite that fetaure state
+      if (envFeature) {
+        featureSet[item] = envFeature === "true";
+      }
+    }
+    return featureSet;
+  }, []);
+
   const combinedFeatures = useMemo(() => {
     const combined: FeatureSet = {
       ...featureSetFromList(defaultFeatures),
       ...workspaceFeatures,
       ...userFeatures,
       ...overwrittenFeatures,
+      // Any REACT_APP_FEATURE_FEATURE_ID env can overwrite feature states during development
+      ...(process.env.NODE_ENV === "development" ? envOverwrites : {}),
     };
 
     return Object.entries(combined)

--- a/airbyte-webapp/src/hooks/services/Feature/types.tsx
+++ b/airbyte-webapp/src/hooks/services/Feature/types.tsx
@@ -14,4 +14,4 @@ export enum FeatureItem {
   AllowSyncSubOneHourCronExpressions = "ALLOW_SYNC_SUB_ONE_HOUR_CRON_EXPRESSIONS",
 }
 
-export type FeatureSet = Record<FeatureItem, boolean>;
+export type FeatureSet = Partial<Record<FeatureItem, boolean>>;


### PR DESCRIPTION
## What

Allows any `FeatureItem` to be overwritten in development by a env variable with the name `REACT_APP_FEATURE_{ID}`, e.g. one can have the following in the `.env.development` file:

```
REACT_APP_FEATURE_ALLOW_SYNC=false
REACT_APP_FEATURE_ALLOW_CHANGE_DATA_GEOGRAPHIES=true
```

To disable syncs and allow geography changes.

This is only enabled during development, since this isn't meant to be misused accidentally in environments instead of the regular feature chain (default features, workspace, users).