### PR TITLE
Break inheritance dependency on java.lang.Process

### DIFF
--- a/airbyte-commons-worker/src/main/java/io/airbyte/workers/process/KubePod.java
+++ b/airbyte-commons-worker/src/main/java/io/airbyte/workers/process/KubePod.java
@@ -4,18 +4,16 @@
 
 package io.airbyte.workers.process;
 
-import java.util.concurrent.TimeUnit;
-
 public interface KubePod {
 
   int exitValue();
 
   void destroy();
 
-  boolean waitFor(final long timeout, final TimeUnit unit) throws InterruptedException;
-
   int waitFor() throws InterruptedException;
 
   KubePodInfo getInfo();
+
+  Process toProcess();
 
 }

--- a/airbyte-commons-worker/src/main/java/io/airbyte/workers/process/KubeProcessFactory.java
+++ b/airbyte-commons-worker/src/main/java/io/airbyte/workers/process/KubeProcessFactory.java
@@ -140,7 +140,7 @@ public class KubeProcessFactory implements ProcessFactory {
           workerConfigs.getJobCurlImage(),
           MoreMaps.merge(jobMetadata, workerConfigs.getEnvMap()),
           internalToExternalPorts,
-          args);
+          args).toProcess();
     } catch (final Exception e) {
       throw new WorkerException(e.getMessage(), e);
     }

--- a/airbyte-webapp/package-lock.json
+++ b/airbyte-webapp/package-lock.json
@@ -48774,7 +48774,7 @@
         "ignore": "^4.0.6",
         "import-fresh": "^3.2.1",
         "js-yaml": "^4.1.0",
-        "minimatch": "^3.0.4",
+        "minimatch": "^3.0.5",
         "strip-json-comments": "^3.1.1"
       },
       "dependencies": {
@@ -49649,7 +49649,7 @@
       "requires": {
         "@humanwhocodes/object-schema": "^1.2.1",
         "debug": "^4.1.1",
-        "minimatch": "^3.0.4"
+        "minimatch": "^3.0.5"
       }
     },
     "@humanwhocodes/object-schema": {
@@ -51848,7 +51848,7 @@
         "jsonpath-plus": "7.1.0",
         "lodash": "~4.17.21",
         "lodash.topath": "^4.5.2",
-        "minimatch": "3.1.2",
+        "minimatch": "^3.0.5",
         "nimma": "0.2.2",
         "pony-cause": "^1.0.0",
         "simple-eval": "1.0.0",
@@ -52826,7 +52826,7 @@
             "@babel/code-frame": "^7.5.5",
             "chalk": "^2.4.1",
             "micromatch": "^3.1.10",
-            "minimatch": "^3.0.4",
+            "minimatch": "^3.0.5",
             "semver": "^5.6.0",
             "tapable": "^1.0.0",
             "worker-rpc": "^0.1.0"
@@ -64414,7 +64414,7 @@
       "integrity": "sha512-LwjCsruLWQULGYKy7TX0OPtrL9kLpojOFKc5VCTxdFTV7w5zbsgqVKfnkKG7Qgjtq50gKfO56hJv88OfcGb70Q==",
       "dev": true,
       "requires": {
-        "minimatch": "^5.0.1"
+        "minimatch": "^3.0.5"
       },
       "dependencies": {
         "brace-expansion": {
@@ -66812,7 +66812,7 @@
         "async": "^3.2.3",
         "chalk": "^4.0.2",
         "filelist": "^1.0.1",
-        "minimatch": "^3.0.4"
+        "minimatch": "^3.0.5"
       },
       "dependencies": {
         "ansi-styles": {
@@ -72054,7 +72054,7 @@
       "integrity": "sha1-X1Zl2TNRM1yqvvjxxVRRbPXx5OU=",
       "dev": true,
       "requires": {
-        "minimatch": "^3.0.2"
+        "minimatch": "^3.0.5"
       }
     },
     "node-fetch": {
@@ -76548,7 +76548,7 @@
       "integrity": "sha512-nRCcW9Sj7NuZwa2XvH9co8NPeXUBhZP7CRKJtU+cS6PW9FpCIFoI5ib0NT1ZrbNuPoRy0ylyCaUL8Gih4LSyFg==",
       "dev": true,
       "requires": {
-        "minimatch": "3.0.4"
+        "minimatch": "^3.0.5"
       }
     },
     "redent": {
@@ -80183,7 +80183,7 @@
       "requires": {
         "@istanbuljs/schema": "^0.1.2",
         "glob": "^7.1.4",
-        "minimatch": "^3.0.4"
+        "minimatch": "^3.0.5"
       }
     },
     "text-encoding-utf-8": {

--- a/docs/reference/api/generated-api-html/index.html
+++ b/docs/reference/api/generated-api-html/index.html
@@ -190,17 +190,9 @@ font-style: italic;
 <li>The naming convention for endpoints is: localhost:8000/{VERSION}/{METHOD_FAMILY}/{METHOD_NAME} e.g. <code>localhost:8000/v1/connections/create</code>.</li>
 <li>For all <code>update</code> methods, the whole object must be passed in, even the fields that did not change.</li>
 </ul>
-<p>Change Management:</p>
+<p>Authentication (OSS):</p>
 <ul>
-<li>The major version of the API endpoint can be determined / specified in the URL <code>localhost:8080/v1/connections/create</code></li>
-<li>Minor version bumps will be invisible to the end user. The user cannot specify minor versions in requests.</li>
-<li>All backwards incompatible changes will happen in major version bumps. We will not make backwards incompatible changes in minor version bumps. Examples of non-breaking changes (includes but not limited to...):
-<ul>
-<li>Adding fields to request or response bodies.</li>
-<li>Adding new HTTP endpoints.</li>
-</ul>
-</li>
-<li>All <code>web_backend</code> APIs are not considered public APIs and are not guaranteeing backwards compatibility.</li>
+<li>When authenticating to the Configuration API, you must use Basic Authentication by setting the Authentication Header to Basic and base64 encoding the username and password (which are <code>airbyte</code> and <code>password</code> by default - so base64 encoding <code>airbyte:password</code> results in <code>YWlyYnl0ZTpwYXNzd29yZA==</code>). So the full header reads <code>'Authorization': &quot;Basic YWlyYnl0ZTpwYXNzd29yZA==&quot;</code></li>
 </ul>
 </div>
     <div class="app-desc">More information: <a href="https://openapi-generator.tech">https://openapi-generator.tech</a></div>


### PR DESCRIPTION
## What
* Remove the direct inheritance dependency on `java.lang.Process` to avoid issues caused by partial implementation

## How
* Remove extension from `java.lang.Process`
* Add ability to create a `java.lang.Process` implementation from existing "process" objects

This PR is inspired by a discussion [following an incident](https://github.com/airbytehq/airbyte/pull/20028) where the use of `.pid()` in `KubePodProcess` lead to failures, as the parent class (`java.lang.Process`) throws exceptions for certain non-abstract, public methods that are not implemented by the child class.  More broadly speaking, the classes that we have identified as "processes" are not really processes in the Java sense (e.g. they are not native processes provided by an operating system).  This change will break that dependency so that changes made to these classes will not be exposed to the problem outlined above (e.g. calling a method on the parent class that is not and cannot really be implemented by the child class due to the fact that it is not a true native process).  This is analogous to extending `java.lang.Thread` instead of implementing `Runnable` or `Callable`.

## Recommended reading order
1. `KubePod.java`
2. `KubePodProcess.java`
3. `AsyncOrchestratorPodProcess.java`
4. `KubeProcessFactory.java`

## Tests

* All unit tests pass
* All Kube acceptance tests pass locally
* Project builds locally