### PR TITLE
Create documentation for Destination namespace example settings

### DIFF
--- a/airbyte-webapp/src/components/connection/DestinationNamespaceModal/DestinationNamespaceModal.tsx
+++ b/airbyte-webapp/src/components/connection/DestinationNamespaceModal/DestinationNamespaceModal.tsx
@@ -10,6 +10,7 @@ import { ModalBody, ModalFooter } from "components/ui/Modal";
 import { Text } from "components/ui/Text";
 
 import { NamespaceDefinitionType } from "core/request/AirbyteClient";
+import { links } from "utils/links";
 import { FormikConnectionFormValues } from "views/Connection/ConnectionForm/formConfig";
 
 import styles from "./DestinationNamespaceModal.module.scss";
@@ -143,6 +144,11 @@ export const DestinationNamespaceModal: React.FC<DestinationNamespaceModalProps>
                 <FormattedMessage id="connectionForm.modal.destinationNamespace.description" />
               </Text>
               <ExampleSettingsTable namespaceDefinitionType={values.namespaceDefinition} />
+              <a className={styles.namespaceLink} href={links.namespaceLink} target="_blank" rel="noreferrer">
+                <Text className={styles.text} size="xs">
+                  <FormattedMessage id="connectionForm.modal.destinationNamespace.learnMore.link" />
+                </Text>
+              </a>
             </div>
           </ModalBody>
           <ModalFooter>

--- a/airbyte-webapp/src/locales/en.json
+++ b/airbyte-webapp/src/locales/en.json
@@ -171,6 +171,7 @@
   "connectionForm.modal.destinationNamespace.table.data.exampleSourceNamespace": "\"$<symbol>SOURCE_NAMESPACE</symbol>\"",
   "connectionForm.modal.destinationNamespace.table.data.exampleMySourceNamespace": "\"my_$<symbol>SOURCE_NAMESPACE</symbol>_schema\"",
   "connectionForm.modal.destinationNamespace.table.data.custom": "<symbol>custom</symbol>",
+  "connectionForm.modal.destinationNamespace.learnMore.link": "Learn more",
 
   "connectionForm.modal.destinationStreamNames.title": "Destination stream names",
   "connectionForm.modal.destinationStreamNames.radioButton.mirror": "Mirror source name",


### PR DESCRIPTION
## What
Closes [#20137](https://github.com/airbytehq/airbyte/issues/20137)

## How
Added "Learn more" link to documentation namespace

_For test purposes, use the variable:_ **REACT_APP_NEW_STREAMS_TABLE=true**

## Result 
![image](https://user-images.githubusercontent.com/66960359/206537686-9bc81a38-a96a-4946-98b5-9e6781a9d39c.png)
