### PR TITLE
Source Amazon Seller Partner: Hide on cloud

### DIFF
--- a/airbyte-webapp/src/core/domain/connector/constants.ts
+++ b/airbyte-webapp/src/core/domain/connector/constants.ts
@@ -30,6 +30,7 @@ export const getExcludedConnectorIds = (workspaceId?: string): string[] =>
         ConnectorIds.Destinations.MeiliSearch, // hide MeiliSearch Destination https://github.com/airbytehq/airbyte/issues/16313
         ConnectorIds.Destinations.RabbitMq, // hide RabbitMQ Destination https://github.com/airbytehq/airbyte/issues/16315
         ConnectorIds.Destinations.AmazonSqs, // hide Amazon SQS Destination https://github.com/airbytehq/airbyte/issues/16316
+        ConnectorIds.Sources.AmazonSellerPartner, // hide Amazon Seller Partner Source https://github.com/airbytehq/airbyte/issues/14734
         ...(workspaceId !== "54135667-ce73-4820-a93c-29fe1510d348" // Shopify workspace for review
           ? [ConnectorIds.Sources.Shopify] // Shopify
           : []),


### PR DESCRIPTION
## What
Completely non-functional connector - [#14734 Amazon Seller Partner (Cloud Only) Connection Error](https://github.com/airbytehq/airbyte/issues/14734)

slack conversation - https://airbytehq.slack.com/archives/C02URF5LA5P/p1669753568694279

## How
Source Amazon Seller Partner connector from the cloud is hidden until the problem is solved.