### PR TITLE
remove the requirement on the activity

### DIFF
--- a/airbyte-workers/src/main/java/io/airbyte/workers/temporal/scheduling/activities/ConfigFetchActivityImpl.java
+++ b/airbyte-workers/src/main/java/io/airbyte/workers/temporal/scheduling/activities/ConfigFetchActivityImpl.java
@@ -41,7 +41,6 @@ import org.quartz.CronExpression;
 
 @Slf4j
 @Singleton
-@Requires(env = WorkerMode.CONTROL_PLANE)
 public class ConfigFetchActivityImpl implements ConfigFetchActivity {
 
   private final static long MS_PER_SECOND = 1000L;
@@ -177,22 +176,22 @@ public class ConfigFetchActivityImpl implements ConfigFetchActivity {
   }
 
   @Override
-  public Optional<UUID> getSourceId(UUID connectionId) {
+  public Optional<UUID> getSourceId(final UUID connectionId) {
     try {
       final StandardSync standardSync = getStandardSync(connectionId);
       return Optional.ofNullable(standardSync.getSourceId());
-    } catch (JsonValidationException | ConfigNotFoundException | IOException e) {
+    } catch (final JsonValidationException | ConfigNotFoundException | IOException e) {
       log.info("Encountered an error fetching the connection's Source ID: ", e);
       return Optional.empty();
     }
   }
 
   @Override
-  public Optional<Status> getStatus(UUID connectionId) {
+  public Optional<Status> getStatus(final UUID connectionId) {
     try {
       final StandardSync standardSync = getStandardSync(connectionId);
       return Optional.ofNullable(standardSync.getStatus());
-    } catch (JsonValidationException | ConfigNotFoundException | IOException e) {
+    } catch (final JsonValidationException | ConfigNotFoundException | IOException e) {
       log.info("Encountered an error fetching the connection's status: ", e);
       return Optional.empty();
     }

--- a/airbyte-workers/src/main/java/io/airbyte/workers/temporal/scheduling/activities/ConfigFetchActivityImpl.java
+++ b/airbyte-workers/src/main/java/io/airbyte/workers/temporal/scheduling/activities/ConfigFetchActivityImpl.java
@@ -8,7 +8,6 @@ import static io.airbyte.metrics.lib.ApmTraceConstants.ACTIVITY_TRACE_OPERATION_
 import static io.airbyte.metrics.lib.ApmTraceConstants.Tags.CONNECTION_ID_KEY;
 
 import datadog.trace.api.Trace;
-import io.airbyte.commons.temporal.config.WorkerMode;
 import io.airbyte.commons.temporal.exception.RetryableException;
 import io.airbyte.config.Cron;
 import io.airbyte.config.StandardSync;
@@ -21,7 +20,6 @@ import io.airbyte.metrics.lib.ApmTraceUtils;
 import io.airbyte.persistence.job.JobPersistence;
 import io.airbyte.persistence.job.models.Job;
 import io.airbyte.validation.json.JsonValidationException;
-import io.micronaut.context.annotation.Requires;
 import io.micronaut.context.annotation.Value;
 import jakarta.inject.Named;
 import jakarta.inject.Singleton;


### PR DESCRIPTION
## What
For the auto detect schema change, we need to check the status of a connection after the refresh schema call because it can be disabled by the refresh schema. This means that the activity need to be accessed in the DataPlane. This PR remove the limitation on the activity bean.