### PR TITLE
Set breaking change to false when connection is fixed

### DIFF
--- a/airbyte-config/config-persistence/src/main/java/io/airbyte/config/persistence/ConfigRepository.java
+++ b/airbyte-config/config-persistence/src/main/java/io/airbyte/config/persistence/ConfigRepository.java
@@ -1304,6 +1304,16 @@ public class ConfigRepository {
 
     return records.stream().findFirst().map(DbConverter::buildActorCatalog);
   }
+  
+  public Optional<ActorCatalog> getMostRecentActorCatalogForSource(final UUID sourceId) throws IOException {
+    final Result<Record> records = database.query(ctx -> ctx.select(ACTOR_CATALOG.asterisk())
+        .from(ACTOR_CATALOG)
+        .join(ACTOR_CATALOG_FETCH_EVENT)
+        .on(ACTOR_CATALOG_FETCH_EVENT.ACTOR_CATALOG_ID.eq(ACTOR_CATALOG.ID))
+        .where(ACTOR_CATALOG_FETCH_EVENT.ACTOR_ID.eq(sourceId))
+        .orderBy(ACTOR_CATALOG_FETCH_EVENT.CREATED_AT.desc()).limit(1).fetch());
+    return records.stream().findFirst().map(DbConverter::buildActorCatalog);
+  }
 
   public Optional<ActorCatalog> getMostRecentActorCatalogForSource(final UUID sourceId) throws IOException {
     final Result<Record> records = database.query(ctx -> ctx.select(ACTOR_CATALOG.asterisk())
@@ -1316,6 +1326,7 @@ public class ConfigRepository {
   }
 
   public Optional<ActorCatalogFetchEvent> getMostRecentActorCatalogFetchEventForSource(final UUID sourceId) throws IOException {
+
 
     final Result<Record> records = database.query(ctx -> ctx.select(ACTOR_CATALOG_FETCH_EVENT.asterisk())
         .from(ACTOR_CATALOG_FETCH_EVENT)

--- a/airbyte-config/config-persistence/src/main/java/io/airbyte/config/persistence/ConfigRepository.java
+++ b/airbyte-config/config-persistence/src/main/java/io/airbyte/config/persistence/ConfigRepository.java
@@ -1304,14 +1304,24 @@ public class ConfigRepository {
 
     return records.stream().findFirst().map(DbConverter::buildActorCatalog);
   }
+  
+  public Optional<ActorCatalog> getMostRecentActorCatalogForSource(final UUID sourceId) throws IOException {
+    final Result<Record> records = database.query(ctx -> ctx.select(ACTOR_CATALOG.asterisk())
+        .from(ACTOR_CATALOG)
+        .join(ACTOR_CATALOG_FETCH_EVENT)
+        .on(ACTOR_CATALOG_FETCH_EVENT.ACTOR_CATALOG_ID.eq(ACTOR_CATALOG.ID))
+        .where(ACTOR_CATALOG_FETCH_EVENT.ACTOR_ID.eq(sourceId))
+        .orderBy(ACTOR_CATALOG_FETCH_EVENT.CREATED_AT.desc()).limit(1).fetch());
+    return records.stream().findFirst().map(DbConverter::buildActorCatalog);
+  }
 
   public Optional<ActorCatalogFetchEvent> getMostRecentActorCatalogFetchEventForSource(final UUID sourceId) throws IOException {
+
 
     final Result<Record> records = database.query(ctx -> ctx.select(ACTOR_CATALOG_FETCH_EVENT.asterisk())
         .from(ACTOR_CATALOG_FETCH_EVENT)
         .where(ACTOR_CATALOG_FETCH_EVENT.ACTOR_ID.eq(sourceId))
         .orderBy(ACTOR_CATALOG_FETCH_EVENT.CREATED_AT.desc()).limit(1).fetch());
-
     return records.stream().findFirst().map(DbConverter::buildActorCatalogFetchEvent);
   }
 

--- a/airbyte-config/config-persistence/src/main/java/io/airbyte/config/persistence/ConfigRepository.java
+++ b/airbyte-config/config-persistence/src/main/java/io/airbyte/config/persistence/ConfigRepository.java
@@ -1304,16 +1304,6 @@ public class ConfigRepository {
 
     return records.stream().findFirst().map(DbConverter::buildActorCatalog);
   }
-  
-  public Optional<ActorCatalog> getMostRecentActorCatalogForSource(final UUID sourceId) throws IOException {
-    final Result<Record> records = database.query(ctx -> ctx.select(ACTOR_CATALOG.asterisk())
-        .from(ACTOR_CATALOG)
-        .join(ACTOR_CATALOG_FETCH_EVENT)
-        .on(ACTOR_CATALOG_FETCH_EVENT.ACTOR_CATALOG_ID.eq(ACTOR_CATALOG.ID))
-        .where(ACTOR_CATALOG_FETCH_EVENT.ACTOR_ID.eq(sourceId))
-        .orderBy(ACTOR_CATALOG_FETCH_EVENT.CREATED_AT.desc()).limit(1).fetch());
-    return records.stream().findFirst().map(DbConverter::buildActorCatalog);
-  }
 
   public Optional<ActorCatalog> getMostRecentActorCatalogForSource(final UUID sourceId) throws IOException {
     final Result<Record> records = database.query(ctx -> ctx.select(ACTOR_CATALOG.asterisk())
@@ -1326,7 +1316,6 @@ public class ConfigRepository {
   }
 
   public Optional<ActorCatalogFetchEvent> getMostRecentActorCatalogFetchEventForSource(final UUID sourceId) throws IOException {
-
 
     final Result<Record> records = database.query(ctx -> ctx.select(ACTOR_CATALOG_FETCH_EVENT.asterisk())
         .from(ACTOR_CATALOG_FETCH_EVENT)

--- a/airbyte-config/config-persistence/src/main/java/io/airbyte/config/persistence/ConfigRepository.java
+++ b/airbyte-config/config-persistence/src/main/java/io/airbyte/config/persistence/ConfigRepository.java
@@ -1304,7 +1304,7 @@ public class ConfigRepository {
 
     return records.stream().findFirst().map(DbConverter::buildActorCatalog);
   }
-  
+
   public Optional<ActorCatalog> getMostRecentActorCatalogForSource(final UUID sourceId) throws IOException {
     final Result<Record> records = database.query(ctx -> ctx.select(ACTOR_CATALOG.asterisk())
         .from(ACTOR_CATALOG)
@@ -1316,7 +1316,6 @@ public class ConfigRepository {
   }
 
   public Optional<ActorCatalogFetchEvent> getMostRecentActorCatalogFetchEventForSource(final UUID sourceId) throws IOException {
-
 
     final Result<Record> records = database.query(ctx -> ctx.select(ACTOR_CATALOG_FETCH_EVENT.asterisk())
         .from(ACTOR_CATALOG_FETCH_EVENT)

--- a/airbyte-server/src/main/java/io/airbyte/server/handlers/WebBackendConnectionsHandler.java
+++ b/airbyte-server/src/main/java/io/airbyte/server/handlers/WebBackendConnectionsHandler.java
@@ -489,13 +489,13 @@ public class WebBackendConnectionsHandler {
       // Get the most recent actor catalog fetched for this connection's source and the newly updated sync
       // catalog
       Optional<ActorCatalog> mostRecentActorCatalog = configRepository.getMostRecentActorCatalogForSource(originalConnectionRead.getSourceId());
-      AirbyteCatalog newActorCatalog = webBackendConnectionPatch.getSyncCatalog();
+      AirbyteCatalog newAirbyteCatalog = webBackendConnectionPatch.getSyncCatalog();
       // Get the diff between these two catalogs to check for breaking changes
       if (!mostRecentActorCatalog.isEmpty()) {
         final io.airbyte.api.model.generated.AirbyteCatalog mostRecentAirbyteCatalog =
             Jsons.object(mostRecentActorCatalog.get().getCatalog(), io.airbyte.api.model.generated.AirbyteCatalog.class);
         final CatalogDiff catalogDiff =
-            connectionsHandler.getDiff(mostRecentAirbyteCatalog, newActorCatalog, CatalogConverter.toProtocol(newActorCatalog));
+            connectionsHandler.getDiff(mostRecentAirbyteCatalog, newAirbyteCatalog, CatalogConverter.toProtocol(newAirbyteCatalog));
         if (containsBreakingChange(catalogDiff)) {
           breakingChange = true;
         } else {

--- a/airbyte-server/src/main/java/io/airbyte/server/handlers/WebBackendConnectionsHandler.java
+++ b/airbyte-server/src/main/java/io/airbyte/server/handlers/WebBackendConnectionsHandler.java
@@ -654,7 +654,7 @@ public class WebBackendConnectionsHandler {
                                                       final List<UUID> finalOperationIds) {
     final ConnectionUpdate connectionPatch = new ConnectionUpdate();
 
-    if(webBackendConnectionPatch.getSyncCatalog() != null) {
+    if (webBackendConnectionPatch.getSyncCatalog() != null) {
       // the user has updated their sync catalog, so there is no breaking change
       connectionPatch.breakingChange(false);
     }

--- a/airbyte-server/src/main/java/io/airbyte/server/handlers/WebBackendConnectionsHandler.java
+++ b/airbyte-server/src/main/java/io/airbyte/server/handlers/WebBackendConnectionsHandler.java
@@ -495,7 +495,7 @@ public class WebBackendConnectionsHandler {
         final io.airbyte.protocol.models.AirbyteCatalog mostRecentAirbyteCatalog =
             Jsons.object(mostRecentActorCatalog.get().getCatalog(), io.airbyte.protocol.models.AirbyteCatalog.class);
         final CatalogDiff catalogDiff =
-            connectionsHandler.getDiff(CatalogConverter.toApi(mostRecentAirbyteCatalog), newAirbyteCatalog,
+            connectionsHandler.getDiff(newAirbyteCatalog, CatalogConverter.toApi(mostRecentAirbyteCatalog),
                 CatalogConverter.toProtocol(newAirbyteCatalog));
         breakingChange = containsBreakingChange(catalogDiff);
       }

--- a/airbyte-server/src/main/java/io/airbyte/server/handlers/WebBackendConnectionsHandler.java
+++ b/airbyte-server/src/main/java/io/airbyte/server/handlers/WebBackendConnectionsHandler.java
@@ -481,7 +481,7 @@ public class WebBackendConnectionsHandler {
 
     final UUID connectionId = webBackendConnectionPatch.getConnectionId();
     final ConnectionRead originalConnectionRead = connectionsHandler.getConnection(connectionId);
-    boolean breakingChange = originalConnectionRead.getBreakingChange();
+    boolean breakingChange = originalConnectionRead.getBreakingChange() != null && originalConnectionRead.getBreakingChange();
 
     // If there have been changes to the sync catalog, check whether these changes result in or fix a
     // broken connection

--- a/airbyte-server/src/main/java/io/airbyte/server/handlers/WebBackendConnectionsHandler.java
+++ b/airbyte-server/src/main/java/io/airbyte/server/handlers/WebBackendConnectionsHandler.java
@@ -491,16 +491,13 @@ public class WebBackendConnectionsHandler {
       Optional<ActorCatalog> mostRecentActorCatalog = configRepository.getMostRecentActorCatalogForSource(originalConnectionRead.getSourceId());
       AirbyteCatalog newAirbyteCatalog = webBackendConnectionPatch.getSyncCatalog();
       // Get the diff between these two catalogs to check for breaking changes
-      if (!mostRecentActorCatalog.isEmpty()) {
-        final io.airbyte.api.model.generated.AirbyteCatalog mostRecentAirbyteCatalog =
-            Jsons.object(mostRecentActorCatalog.get().getCatalog(), io.airbyte.api.model.generated.AirbyteCatalog.class);
+      if (mostRecentActorCatalog.isPresent()) {
+        final io.airbyte.protocol.models.AirbyteCatalog mostRecentAirbyteCatalog =
+            Jsons.object(mostRecentActorCatalog.get().getCatalog(), io.airbyte.protocol.models.AirbyteCatalog.class);
         final CatalogDiff catalogDiff =
-            connectionsHandler.getDiff(mostRecentAirbyteCatalog, newAirbyteCatalog, CatalogConverter.toProtocol(newAirbyteCatalog));
-        if (containsBreakingChange(catalogDiff)) {
-          breakingChange = true;
-        } else {
-          breakingChange = false;
-        }
+            connectionsHandler.getDiff(CatalogConverter.toApi(mostRecentAirbyteCatalog), newAirbyteCatalog,
+                CatalogConverter.toProtocol(newAirbyteCatalog));
+        breakingChange = containsBreakingChange(catalogDiff);
       }
     }
 

--- a/airbyte-server/src/main/java/io/airbyte/server/handlers/WebBackendConnectionsHandler.java
+++ b/airbyte-server/src/main/java/io/airbyte/server/handlers/WebBackendConnectionsHandler.java
@@ -20,6 +20,7 @@ import io.airbyte.api.model.generated.ConnectionStateType;
 import io.airbyte.api.model.generated.ConnectionUpdate;
 import io.airbyte.api.model.generated.DestinationIdRequestBody;
 import io.airbyte.api.model.generated.DestinationRead;
+import io.airbyte.api.model.generated.FieldTransform;
 import io.airbyte.api.model.generated.JobRead;
 import io.airbyte.api.model.generated.OperationCreate;
 import io.airbyte.api.model.generated.OperationReadList;
@@ -32,6 +33,7 @@ import io.airbyte.api.model.generated.SourceIdRequestBody;
 import io.airbyte.api.model.generated.SourceRead;
 import io.airbyte.api.model.generated.StreamDescriptor;
 import io.airbyte.api.model.generated.StreamTransform;
+import io.airbyte.api.model.generated.StreamTransform.TransformTypeEnum;
 import io.airbyte.api.model.generated.WebBackendConnectionCreate;
 import io.airbyte.api.model.generated.WebBackendConnectionListItem;
 import io.airbyte.api.model.generated.WebBackendConnectionRead;
@@ -45,6 +47,7 @@ import io.airbyte.api.model.generated.WorkspaceIdRequestBody;
 import io.airbyte.commons.enums.Enums;
 import io.airbyte.commons.json.Jsons;
 import io.airbyte.commons.lang.MoreBooleans;
+import io.airbyte.config.ActorCatalog;
 import io.airbyte.config.ActorCatalogFetchEvent;
 import io.airbyte.config.StandardSync;
 import io.airbyte.config.persistence.ConfigNotFoundException;
@@ -478,6 +481,28 @@ public class WebBackendConnectionsHandler {
 
     final UUID connectionId = webBackendConnectionPatch.getConnectionId();
     final ConnectionRead originalConnectionRead = connectionsHandler.getConnection(connectionId);
+    boolean breakingChange = originalConnectionRead.getBreakingChange();
+
+    // If there have been changes to the sync catalog, check whether these changes result in or fix a
+    // broken connection
+    if (webBackendConnectionPatch.getSyncCatalog() != null) {
+      // Get the most recent actor catalog fetched for this connection's source and the newly updated sync
+      // catalog
+      Optional<ActorCatalog> mostRecentActorCatalog = configRepository.getMostRecentActorCatalogForSource(originalConnectionRead.getSourceId());
+      AirbyteCatalog newActorCatalog = webBackendConnectionPatch.getSyncCatalog();
+      // Get the diff between these two catalogs to check for breaking changes
+      if (!mostRecentActorCatalog.isEmpty()) {
+        final io.airbyte.api.model.generated.AirbyteCatalog mostRecentAirbyteCatalog =
+            Jsons.object(mostRecentActorCatalog.get().getCatalog(), io.airbyte.api.model.generated.AirbyteCatalog.class);
+        final CatalogDiff catalogDiff =
+            connectionsHandler.getDiff(mostRecentAirbyteCatalog, newActorCatalog, CatalogConverter.toProtocol(newActorCatalog));
+        if (containsBreakingChange(catalogDiff)) {
+          breakingChange = true;
+        } else {
+          breakingChange = false;
+        }
+      }
+    }
 
     // before doing any updates, fetch the existing catalog so that it can be diffed
     // with the final catalog to determine which streams might need to be reset.
@@ -488,7 +513,7 @@ public class WebBackendConnectionsHandler {
 
     // pass in operationIds because the patch object doesn't include operationIds that were just created
     // above.
-    final ConnectionUpdate connectionPatch = toConnectionPatch(webBackendConnectionPatch, newAndExistingOperationIds);
+    final ConnectionUpdate connectionPatch = toConnectionPatch(webBackendConnectionPatch, newAndExistingOperationIds, breakingChange);
 
     // persist the update and set the connectionRead to the updated form.
     final ConnectionRead updatedConnectionRead = connectionsHandler.updateConnection(connectionPatch);
@@ -651,7 +676,8 @@ public class WebBackendConnectionsHandler {
    */
   @VisibleForTesting
   protected static ConnectionUpdate toConnectionPatch(final WebBackendConnectionUpdate webBackendConnectionPatch,
-                                                      final List<UUID> finalOperationIds) {
+                                                      final List<UUID> finalOperationIds,
+                                                      boolean breakingChange) {
     final ConnectionUpdate connectionPatch = new ConnectionUpdate();
 
     connectionPatch.connectionId(webBackendConnectionPatch.getConnectionId());
@@ -669,6 +695,7 @@ public class WebBackendConnectionsHandler {
     connectionPatch.geography(webBackendConnectionPatch.getGeography());
     connectionPatch.notifySchemaChanges(webBackendConnectionPatch.getNotifySchemaChanges());
     connectionPatch.nonBreakingChangesPreference(webBackendConnectionPatch.getNonBreakingChangesPreference());
+    connectionPatch.breakingChange(breakingChange);
 
     connectionPatch.operationIds(finalOperationIds);
 
@@ -687,6 +714,21 @@ public class WebBackendConnectionsHandler {
    */
   private record Stream(String name, String namespace) {
 
+  }
+
+  private boolean containsBreakingChange(final CatalogDiff diff) {
+    for (final StreamTransform streamTransform : diff.getTransforms()) {
+      if (streamTransform.getTransformType() != TransformTypeEnum.UPDATE_STREAM) {
+        continue;
+      }
+
+      final boolean anyBreakingFieldTransforms = streamTransform.getUpdateStream().stream().anyMatch(FieldTransform::getBreaking);
+      if (anyBreakingFieldTransforms) {
+        return true;
+      }
+    }
+
+    return false;
   }
 
 }

--- a/airbyte-server/src/main/java/io/airbyte/server/handlers/WebBackendConnectionsHandler.java
+++ b/airbyte-server/src/main/java/io/airbyte/server/handlers/WebBackendConnectionsHandler.java
@@ -355,16 +355,18 @@ public class WebBackendConnectionsHandler {
       diff = refreshedCatalog.get().getCatalogDiff();
       connection.setBreakingChange(refreshedCatalog.get().getBreakingChange());
       connection.setStatus(refreshedCatalog.get().getConnectionStatus());
-    } else if (catalogUsedToMakeConfiguredCatalog.isPresent()) {
-      // reconstructs a full picture of the full schema at the time the catalog was configured.
-      syncCatalog = updateSchemaWithDiscovery(configuredCatalog, catalogUsedToMakeConfiguredCatalog.get());
-      // diff not relevant if there was no refresh.
-      diff = null;
     } else {
-      // fallback. over time this should be rarely used because source_catalog_id should always be set.
-      syncCatalog = configuredCatalog;
+      // Since there was no schema refresh before this update, there is no breaking change
+      connection.setBreakingChange(false);
       // diff not relevant if there was no refresh.
       diff = null;
+      if (catalogUsedToMakeConfiguredCatalog.isPresent()) {
+        // reconstructs a full picture of the full schema at the time the catalog was configured.
+        syncCatalog = updateSchemaWithDiscovery(configuredCatalog, catalogUsedToMakeConfiguredCatalog.get());
+      } else {
+        // fallback. over time this should be rarely used because source_catalog_id should always be set.
+        syncCatalog = configuredCatalog;
+      }
     }
 
     connection.setSyncCatalog(syncCatalog);

--- a/airbyte-server/src/main/java/io/airbyte/server/handlers/WebBackendConnectionsHandler.java
+++ b/airbyte-server/src/main/java/io/airbyte/server/handlers/WebBackendConnectionsHandler.java
@@ -654,11 +654,6 @@ public class WebBackendConnectionsHandler {
                                                       final List<UUID> finalOperationIds) {
     final ConnectionUpdate connectionPatch = new ConnectionUpdate();
 
-    if (webBackendConnectionPatch.getSyncCatalog() != null) {
-      // the user has updated their sync catalog, so there is no breaking change
-      connectionPatch.breakingChange(false);
-    }
-
     connectionPatch.connectionId(webBackendConnectionPatch.getConnectionId());
     connectionPatch.namespaceDefinition(webBackendConnectionPatch.getNamespaceDefinition());
     connectionPatch.namespaceFormat(webBackendConnectionPatch.getNamespaceFormat());

--- a/airbyte-server/src/test/java/io/airbyte/server/handlers/WebBackendConnectionsHandlerTest.java
+++ b/airbyte-server/src/test/java/io/airbyte/server/handlers/WebBackendConnectionsHandlerTest.java
@@ -68,6 +68,7 @@ import io.airbyte.api.model.generated.WebBackendOperationCreateOrUpdate;
 import io.airbyte.api.model.generated.WebBackendWorkspaceState;
 import io.airbyte.api.model.generated.WorkspaceIdRequestBody;
 import io.airbyte.commons.enums.Enums;
+import io.airbyte.commons.json.Jsons;
 import io.airbyte.commons.temporal.TemporalClient.ManualOperationResult;
 import io.airbyte.config.ActorCatalog;
 import io.airbyte.config.ActorCatalogFetchEvent;
@@ -105,6 +106,7 @@ import java.util.UUID;
 import java.util.stream.Collectors;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
+import org.mockito.ArgumentCaptor;
 import org.mockito.InOrder;
 
 class WebBackendConnectionsHandlerTest {
@@ -942,6 +944,66 @@ class WebBackendConnectionsHandlerTest {
     verify(connectionsHandler, times(0)).getDiff(any(), any(), any());
     verify(connectionsHandler, times(1)).updateConnection(any());
     verify(eventRunner, times(0)).resetConnection(any(), any(), eq(true));
+  }
+
+  @Test
+  void testUpdateConnectionFixingBreakingSchemaChange() throws JsonValidationException, ConfigNotFoundException, IOException {
+    final WebBackendConnectionUpdate updateBody = new WebBackendConnectionUpdate()
+        .namespaceDefinition(expected.getNamespaceDefinition())
+        .namespaceFormat(expected.getNamespaceFormat())
+        .prefix(expected.getPrefix())
+        .connectionId(expected.getConnectionId())
+        .schedule(expected.getSchedule())
+        .status(expected.getStatus())
+        .syncCatalog(expectedWithNewSchema.getSyncCatalog())
+        .skipReset(false)
+        .connectionId(expected.getConnectionId());
+
+    final UUID sourceId = UUID.randomUUID();
+
+    // existing connection has a breaking change
+    when(connectionsHandler.getConnection(expected.getConnectionId())).thenReturn(
+        new ConnectionRead().connectionId(expected.getConnectionId()).breakingChange(true).sourceId(sourceId));
+
+    final CatalogDiff catalogDiff = new CatalogDiff().transforms(List.of());
+    when(configRepository.getMostRecentActorCatalogForSource(sourceId)).thenReturn(Optional.of(new ActorCatalog().withCatalog(Jsons.deserialize(
+        "{\"streams\": [{\"name\": \"cat_names\", \"namespace\": \"public\", \"json_schema\": {\"type\": \"object\", \"properties\": {\"id\": {\"type\": \"number\", \"airbyte_type\": \"integer\"}}}}]}"))));
+    when(connectionsHandler.getDiff(any(), any(), any())).thenReturn(catalogDiff, catalogDiff);
+
+    when(configRepository.getConfiguredCatalogForConnection(expected.getConnectionId()))
+        .thenReturn(ConnectionHelpers.generateBasicConfiguredAirbyteCatalog());
+    when(operationsHandler.listOperationsForConnection(any())).thenReturn(operationReadList);
+
+    final ConnectionRead connectionRead = new ConnectionRead()
+        .connectionId(expected.getConnectionId())
+        .sourceId(expected.getSourceId())
+        .destinationId(expected.getDestinationId())
+        .name(expected.getName())
+        .namespaceDefinition(expected.getNamespaceDefinition())
+        .namespaceFormat(expected.getNamespaceFormat())
+        .prefix(expected.getPrefix())
+        .syncCatalog(expectedWithNewSchema.getSyncCatalog())
+        .status(expected.getStatus())
+        .schedule(expected.getSchedule())
+        .breakingChange(false);
+
+    when(connectionsHandler.updateConnection(any())).thenReturn(connectionRead);
+
+    final WebBackendConnectionRead result = wbHandler.webBackendUpdateConnection(updateBody);
+
+    assertEquals(expectedWithNewSchema.getSyncCatalog(), result.getSyncCatalog());
+
+    final ConnectionIdRequestBody connectionId = new ConnectionIdRequestBody().connectionId(result.getConnectionId());
+    ArgumentCaptor<ConnectionUpdate> expectedArgumentCaptor = ArgumentCaptor.forClass(ConnectionUpdate.class);
+    verify(connectionsHandler, times(1)).updateConnection(expectedArgumentCaptor.capture());
+    List<ConnectionUpdate> connectionUpdateValues = expectedArgumentCaptor.getAllValues();
+    // Expect the ConnectionUpdate object to have breakingChange: false
+    assertEquals(false, connectionUpdateValues.get(0).getBreakingChange());
+
+    verify(schedulerHandler, times(0)).resetConnection(connectionId);
+    verify(schedulerHandler, times(0)).syncConnection(connectionId);
+    verify(connectionsHandler, times(2)).getDiff(any(), any(), any());
+    verify(connectionsHandler, times(1)).updateConnection(any());
   }
 
   @Test

--- a/airbyte-server/src/test/java/io/airbyte/server/handlers/WebBackendConnectionsHandlerTest.java
+++ b/airbyte-server/src/test/java/io/airbyte/server/handlers/WebBackendConnectionsHandlerTest.java
@@ -562,29 +562,9 @@ class WebBackendConnectionsHandlerTest {
         .syncCatalog(catalog)
         .geography(Geography.US)
         .nonBreakingChangesPreference(NonBreakingChangesPreference.DISABLE)
-        .notifySchemaChanges(false)
-        .breakingChange(false);
+        .notifySchemaChanges(false);
 
     final ConnectionUpdate actual = WebBackendConnectionsHandler.toConnectionPatch(input, operationIds);
-
-    assertEquals(expected, actual);
-  }
-
-  @Test
-  void testToConnectionPatchNoSyncCatalogChange() {
-    final UUID connectionId = UUID.randomUUID();
-    final String connectionName = "New Connection Name";
-
-    final WebBackendConnectionUpdate input = new WebBackendConnectionUpdate()
-        .connectionId(connectionId)
-        .name(connectionName);
-
-    final ConnectionUpdate expected = new ConnectionUpdate()
-        .connectionId(connectionId)
-        .name(connectionName)
-        .operationIds(List.of());
-
-    final ConnectionUpdate actual = WebBackendConnectionsHandler.toConnectionPatch(input, List.of());
 
     assertEquals(expected, actual);
   }

--- a/airbyte-server/src/test/java/io/airbyte/server/handlers/WebBackendConnectionsHandlerTest.java
+++ b/airbyte-server/src/test/java/io/airbyte/server/handlers/WebBackendConnectionsHandlerTest.java
@@ -562,9 +562,29 @@ class WebBackendConnectionsHandlerTest {
         .syncCatalog(catalog)
         .geography(Geography.US)
         .nonBreakingChangesPreference(NonBreakingChangesPreference.DISABLE)
-        .notifySchemaChanges(false);
+        .notifySchemaChanges(false)
+        .breakingChange(false);
 
     final ConnectionUpdate actual = WebBackendConnectionsHandler.toConnectionPatch(input, operationIds);
+
+    assertEquals(expected, actual);
+  }
+
+  @Test
+  void testToConnectionPatchNoSyncCatalogChange() {
+    final UUID connectionId = UUID.randomUUID();
+    final String connectionName = "New Connection Name";
+
+    final WebBackendConnectionUpdate input = new WebBackendConnectionUpdate()
+        .connectionId(connectionId)
+        .name(connectionName);
+
+    final ConnectionUpdate expected = new ConnectionUpdate()
+        .connectionId(connectionId)
+        .name(connectionName)
+        .operationIds(List.of());
+
+    final ConnectionUpdate actual = WebBackendConnectionsHandler.toConnectionPatch(input, List.of());
 
     assertEquals(expected, actual);
   }

--- a/airbyte-server/src/test/java/io/airbyte/server/handlers/WebBackendConnectionsHandlerTest.java
+++ b/airbyte-server/src/test/java/io/airbyte/server/handlers/WebBackendConnectionsHandlerTest.java
@@ -562,9 +562,10 @@ class WebBackendConnectionsHandlerTest {
         .syncCatalog(catalog)
         .geography(Geography.US)
         .nonBreakingChangesPreference(NonBreakingChangesPreference.DISABLE)
-        .notifySchemaChanges(false);
+        .notifySchemaChanges(false)
+        .breakingChange(false);
 
-    final ConnectionUpdate actual = WebBackendConnectionsHandler.toConnectionPatch(input, operationIds);
+    final ConnectionUpdate actual = WebBackendConnectionsHandler.toConnectionPatch(input, operationIds, false);
 
     assertEquals(expected, actual);
   }


### PR DESCRIPTION
When users update their connection's sync catalog after there is a breaking schema change, the breaking_change field should be set to false