### PR TITLE
:window: :bug: add object-fit: contain to fix connector image stretching

### DIFF
--- a/airbyte-webapp/src/utils/imageUtils.tsx
+++ b/airbyte-webapp/src/utils/imageUtils.tsx
@@ -6,6 +6,7 @@ import { DefaultLogoCatalog } from "components/common/DefaultLogoCatalog";
 const IconContainer = styled.img`
   height: 100%;
   width: 100%;
+  object-fit: contain;
 `;
 
 const IconDefaultContainer = styled.div`


### PR DESCRIPTION
## What
Add [object-fit](https://developer.mozilla.org/en-US/docs/Web/CSS/object-fit): contain to the IconContainer component to fix the image stretching bug that was identified in master.

See slack thread for context: https://airbytehq-team.slack.com/archives/C02U9R3AF37/p1670529386817179

## How
As described in the [docs](https://developer.mozilla.org/en-US/docs/Web/CSS/object-fit), `object-fit: contain` means "The replaced content is scaled to maintain its aspect ratio while fitting within the element's content box.", which is exactly what we want here: we want the images to scale up to fit their containers, but we want their aspect ratio maintained so they aren't stretched.

Before:
<img width="366" alt="Screen Shot 2022-12-09 at 10 58 42 AM" src="https://user-images.githubusercontent.com/22731524/206775827-ff96108c-09ec-486b-9124-0a129e251b82.png">

After:
<img width="288" alt="Screen Shot 2022-12-09 at 10 58 59 AM" src="https://user-images.githubusercontent.com/22731524/206775864-f962736a-15d3-43a4-8fe9-836a428e41ce.png">

## 🚨 User Impact 🚨
Fixes visual bug causing connector icons to be stretched.
