### PR TITLE
Update web backend get connection to properly handle field selection and schema refresh

### DIFF
--- a/airbyte-server/src/main/java/io/airbyte/server/handlers/WebBackendConnectionsHandler.java
+++ b/airbyte-server/src/main/java/io/airbyte/server/handlers/WebBackendConnectionsHandler.java
@@ -460,9 +460,6 @@ public class WebBackendConnectionsHandler {
           originalDiscoveredStream.getStream().getJsonSchema().findPath("properties").fieldNames()
               .forEachRemaining((name) -> originallyDiscovered.add(name));
           stream.getJsonSchema().findPath("properties").fieldNames().forEachRemaining((name) -> refreshDiscovered.add(name));
-          LOGGER.info("originallySelected: {}", String.join(", ", originallySelected));
-          LOGGER.info("originallyDiscovered: {}", String.join(", ", originallyDiscovered));
-          LOGGER.info("refreshDiscovered: {}", String.join(", ", refreshDiscovered));
           // We include a selected field if it:
           // (is in the newly discovered schema) AND (it was either originally selected OR not in the
           // originally discovered schema at all)

--- a/airbyte-server/src/main/java/io/airbyte/server/handlers/WebBackendConnectionsHandler.java
+++ b/airbyte-server/src/main/java/io/airbyte/server/handlers/WebBackendConnectionsHandler.java
@@ -68,11 +68,14 @@ import java.util.function.Function;
 import java.util.stream.Collectors;
 import lombok.AllArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 @AllArgsConstructor
 @Slf4j
 public class WebBackendConnectionsHandler {
 
+  private static final Logger LOGGER = LoggerFactory.getLogger(WebBackendConnectionsHandler.class);
   private final ConnectionsHandler connectionsHandler;
   private final StateHandler stateHandler;
   private final SourceHandler sourceHandler;
@@ -343,7 +346,7 @@ public class WebBackendConnectionsHandler {
        * constructs a full picture of all existing configured + all new / updated streams in the newest
        * catalog.
        */
-      syncCatalog = updateSchemaWithDiscovery(configuredCatalog, refreshedCatalog.get().getCatalog());
+      syncCatalog = updateSchemaWithDiscovery(configuredCatalog, catalogUsedToMakeConfiguredCatalog.get(), refreshedCatalog.get().getCatalog());
       /*
        * Diffing the catalog used to make the configured catalog gives us the clearest diff between the
        * schema when the configured catalog was made and now. In the case where we do not have the
@@ -357,7 +360,7 @@ public class WebBackendConnectionsHandler {
       connection.setStatus(refreshedCatalog.get().getConnectionStatus());
     } else if (catalogUsedToMakeConfiguredCatalog.isPresent()) {
       // reconstructs a full picture of the full schema at the time the catalog was configured.
-      syncCatalog = updateSchemaWithDiscovery(configuredCatalog, catalogUsedToMakeConfiguredCatalog.get());
+      syncCatalog = updateSchemaWithDiscovery(configuredCatalog, catalogUsedToMakeConfiguredCatalog.get(), catalogUsedToMakeConfiguredCatalog.get());
       // diff not relevant if there was no refresh.
       diff = null;
     } else {
@@ -386,18 +389,25 @@ public class WebBackendConnectionsHandler {
    * is in the old and new catalog, any configuration that was previously set for users, we add to the
    * new catalog.
    *
-   * @param original fully configured, original catalog
+   * @param originalConfigured fully configured, original catalog
+   * @param originalDiscovered the original discovered catalog used to make the original configured
+   *        catalog
    * @param discovered newly discovered catalog, no configurations set
    * @return merged catalog, most up-to-date schema with most up-to-date configurations from old
    *         catalog
    */
   @VisibleForTesting
-  protected static AirbyteCatalog updateSchemaWithDiscovery(final AirbyteCatalog original, final AirbyteCatalog discovered) {
+  protected static AirbyteCatalog updateSchemaWithDiscovery(final AirbyteCatalog originalConfigured,
+                                                            AirbyteCatalog originalDiscovered,
+                                                            final AirbyteCatalog discovered) {
     /*
      * We can't directly use s.getStream() as the key, because it contains a bunch of other fields, so
      * we just define a quick-and-dirty record class.
      */
-    final Map<Stream, AirbyteStreamAndConfiguration> streamDescriptorToOriginalStream = original.getStreams()
+    final Map<Stream, AirbyteStreamAndConfiguration> streamDescriptorToOriginalStream = originalConfigured.getStreams()
+        .stream()
+        .collect(toMap(s -> new Stream(s.getStream().getName(), s.getStream().getNamespace()), s -> s));
+    final Map<Stream, AirbyteStreamAndConfiguration> streamDescriptorToOriginalDiscoveredStream = originalDiscovered.getStreams()
         .stream()
         .collect(toMap(s -> new Stream(s.getStream().getName(), s.getStream().getNamespace()), s -> s));
 
@@ -405,11 +415,14 @@ public class WebBackendConnectionsHandler {
 
     for (final AirbyteStreamAndConfiguration discoveredStream : discovered.getStreams()) {
       final AirbyteStream stream = discoveredStream.getStream();
-      final AirbyteStreamAndConfiguration originalStream = streamDescriptorToOriginalStream.get(new Stream(stream.getName(), stream.getNamespace()));
+      final AirbyteStreamAndConfiguration originalConfiguredStream = streamDescriptorToOriginalStream.get(
+          new Stream(stream.getName(), stream.getNamespace()));
+      final AirbyteStreamAndConfiguration originalDiscoveredStream = streamDescriptorToOriginalDiscoveredStream.get(
+          new Stream(stream.getName(), stream.getNamespace()));
       final AirbyteStreamConfiguration outputStreamConfig;
 
-      if (originalStream != null) {
-        final AirbyteStreamConfiguration originalStreamConfig = originalStream.getConfig();
+      if (originalConfiguredStream != null) {
+        final AirbyteStreamConfiguration originalStreamConfig = originalConfiguredStream.getConfig();
         final AirbyteStreamConfiguration discoveredStreamConfig = discoveredStream.getConfig();
         outputStreamConfig = new AirbyteStreamConfiguration();
 
@@ -433,16 +446,32 @@ public class WebBackendConnectionsHandler {
         }
 
         outputStreamConfig.setAliasName(originalStreamConfig.getAliasName());
-        outputStreamConfig.setSelected(originalStream.getConfig().getSelected());
+        outputStreamConfig.setSelected(originalConfiguredStream.getConfig().getSelected());
 
         outputStreamConfig.setFieldSelectionEnabled(originalStreamConfig.getFieldSelectionEnabled());
         if (outputStreamConfig.getFieldSelectionEnabled()) {
           // TODO(mfsiega-airbyte): support nested fields.
-          // If field selection is enabled, populate the selected columns.
-          final List<String> selectedFields = new ArrayList<>();
-          originalStream.getStream().getJsonSchema().findValue("properties").fieldNames().forEachRemaining((name) -> selectedFields.add(name));
-          outputStreamConfig.setSelectedFields(
-              selectedFields.stream().map((fieldName) -> new SelectedFieldInfo().addFieldPathItem(fieldName)).collect(Collectors.toList()));
+          // If field selection is enabled, populate the selected fields.
+          final Set<String> originallyDiscovered = new HashSet<>();
+          final Set<String> refreshDiscovered = new HashSet<>();
+          // NOTE: by only taking the first element of the path, we're restricting to top-level fields.
+          final Set<String> originallySelected = new HashSet<>(
+              originalConfiguredStream.getConfig().getSelectedFields().stream().map((field) -> field.getFieldPath().get(0)).toList());
+          originalDiscoveredStream.getStream().getJsonSchema().findPath("properties").fieldNames()
+              .forEachRemaining((name) -> originallyDiscovered.add(name));
+          stream.getJsonSchema().findPath("properties").fieldNames().forEachRemaining((name) -> refreshDiscovered.add(name));
+          LOGGER.info("originallySelected: {}", String.join(", ", originallySelected));
+          LOGGER.info("originallyDiscovered: {}", String.join(", ", originallyDiscovered));
+          LOGGER.info("refreshDiscovered: {}", String.join(", ", refreshDiscovered));
+          // We include a selected field if it:
+          // (is in the newly discovered schema) AND (it was either originally selected OR not in the
+          // originally discovered schema at all)
+          // NOTE: this implies that the default behaviour for newly-discovered columns is to add them.
+          for (final String discoveredField : refreshDiscovered) {
+            if (originallySelected.contains(discoveredField) || !originallyDiscovered.contains(discoveredField)) {
+              outputStreamConfig.addSelectedFieldsItem(new SelectedFieldInfo().addFieldPathItem(discoveredField));
+            }
+          }
         }
 
       } else {
@@ -503,7 +532,8 @@ public class WebBackendConnectionsHandler {
         .getConnectionAirbyteCatalog(connectionId);
     if (catalogUsedToMakeConfiguredCatalog.isPresent()) {
       // Update the Catalog returned to include all streams, including disabled ones
-      final AirbyteCatalog syncCatalog = updateSchemaWithDiscovery(updatedConnectionRead.getSyncCatalog(), catalogUsedToMakeConfiguredCatalog.get());
+      final AirbyteCatalog syncCatalog = updateSchemaWithDiscovery(updatedConnectionRead.getSyncCatalog(), catalogUsedToMakeConfiguredCatalog.get(),
+          catalogUsedToMakeConfiguredCatalog.get());
       updatedConnectionRead.setSyncCatalog(syncCatalog);
     }
 

--- a/airbyte-server/src/test/java/io/airbyte/server/handlers/WebBackendConnectionsHandlerTest.java
+++ b/airbyte-server/src/test/java/io/airbyte/server/handlers/WebBackendConnectionsHandlerTest.java
@@ -759,7 +759,8 @@ class WebBackendConnectionsHandlerTest {
     when(connectionsHandler.getConnectionAirbyteCatalog(connectionRead.getConnectionId())).thenReturn(Optional.ofNullable(fullAirbyteCatalog));
 
     final AirbyteCatalog expectedCatalogReturned =
-        WebBackendConnectionsHandler.updateSchemaWithDiscovery(expected.getSyncCatalog(), expected.getSyncCatalog(), fullAirbyteCatalog);
+        WebBackendConnectionsHandler.updateSchemaWithRefreshedDiscoveredCatalog(expected.getSyncCatalog(), expected.getSyncCatalog(),
+            fullAirbyteCatalog);
     final WebBackendConnectionRead connectionRead = wbHandler.webBackendUpdateConnection(updateBody);
 
     assertEquals(expectedCatalogReturned, connectionRead.getSyncCatalog());
@@ -1076,7 +1077,7 @@ class WebBackendConnectionsHandlerTest {
         .aliasName(STREAM1)
         .setSelected(false);
 
-    final AirbyteCatalog actual = WebBackendConnectionsHandler.updateSchemaWithDiscovery(original, original, discovered);
+    final AirbyteCatalog actual = WebBackendConnectionsHandler.updateSchemaWithRefreshedDiscoveredCatalog(original, original, discovered);
 
     assertEquals(expected, actual);
   }
@@ -1126,7 +1127,7 @@ class WebBackendConnectionsHandlerTest {
         .aliasName(STREAM1)
         .setSelected(false);
 
-    final AirbyteCatalog actual = WebBackendConnectionsHandler.updateSchemaWithDiscovery(original, original, discovered);
+    final AirbyteCatalog actual = WebBackendConnectionsHandler.updateSchemaWithRefreshedDiscoveredCatalog(original, original, discovered);
 
     assertEquals(expected, actual);
   }
@@ -1203,7 +1204,7 @@ class WebBackendConnectionsHandlerTest {
         .setSelected(false);
     expected.getStreams().add(expectedNewStream);
 
-    final AirbyteCatalog actual = WebBackendConnectionsHandler.updateSchemaWithDiscovery(original, original, discovered);
+    final AirbyteCatalog actual = WebBackendConnectionsHandler.updateSchemaWithRefreshedDiscoveredCatalog(original, original, discovered);
 
     assertEquals(expected, actual);
   }
@@ -1251,7 +1252,7 @@ class WebBackendConnectionsHandlerTest {
         .aliasName(STREAM1)
         .setSelected(false);
 
-    final AirbyteCatalog actual = WebBackendConnectionsHandler.updateSchemaWithDiscovery(original, original, discovered);
+    final AirbyteCatalog actual = WebBackendConnectionsHandler.updateSchemaWithRefreshedDiscoveredCatalog(original, original, discovered);
 
     assertEquals(expected, actual);
   }


### PR DESCRIPTION
## What
Make the web backend handler properly handle field selection when there is a schema refresh.

## How
Only include a selected field if:

`is in the newly discovered schema` AND `it was either originally selected OR not in the originally discovered schema at all`.

TODO before merging: add another unit test for the case where a field is removed in the newly-discovered schema.

## Recommended reading order
Reading the new unit test might make the intended logic clearer, and therefore easier to review the actual code change.
