### PR TITLE
🪟 🎉 Re-validate connection edit form after schema refresh to highlight any missing keys or cursors

### DIFF
--- a/airbyte-webapp/src/pages/ConnectionPage/pages/ConnectionItemPage/ConnectionReplicationTab.tsx
+++ b/airbyte-webapp/src/pages/ConnectionPage/pages/ConnectionItemPage/ConnectionReplicationTab.tsx
@@ -38,7 +38,7 @@ const ValidateFormOnSchemaRefresh: React.FC = () => {
 
   useEffect(() => {
     if (schemaHasBeenRefreshed) {
-      setTouched(true, true);
+      setTouched({ syncCatalog: true }, true);
     }
   }, [setTouched, schemaHasBeenRefreshed]);
 

--- a/airbyte-webapp/src/pages/ConnectionPage/pages/ConnectionItemPage/ConnectionReplicationTab.tsx
+++ b/airbyte-webapp/src/pages/ConnectionPage/pages/ConnectionItemPage/ConnectionReplicationTab.tsx
@@ -1,5 +1,5 @@
-import { Form, Formik, FormikHelpers } from "formik";
-import React, { useCallback, useState } from "react";
+import { Form, Formik, FormikHelpers, useFormikContext } from "formik";
+import React, { useCallback, useEffect, useState } from "react";
 import { FormattedMessage, useIntl } from "react-intl";
 import { useUnmount } from "react-use";
 
@@ -31,6 +31,19 @@ import {
 
 import styles from "./ConnectionReplicationTab.module.scss";
 import { ResetWarningModal } from "./ResetWarningModal";
+
+const ValidateFormOnSchemaRefresh: React.FC = () => {
+  const { schemaHasBeenRefreshed } = useConnectionEditService();
+  const { setTouched } = useFormikContext();
+
+  useEffect(() => {
+    if (schemaHasBeenRefreshed) {
+      setTouched(true, true);
+    }
+  }, [setTouched, schemaHasBeenRefreshed]);
+
+  return null;
+};
 
 export const ConnectionReplicationTab: React.FC = () => {
   const isAutoDetectSchemaChangesEnabled = useIsAutoDetectSchemaChangesEnabled();
@@ -182,6 +195,7 @@ export const ConnectionReplicationTab: React.FC = () => {
         >
           {({ values, isSubmitting, isValid, dirty, resetForm, status }) => (
             <Form>
+              <ValidateFormOnSchemaRefresh />
               <ConnectionFormFields
                 values={values}
                 isSubmitting={isSubmitting}


### PR DESCRIPTION
## What
This change ensures that the form highlights any areas that may have gone missing after the schema was refreshed. For example, the primary key and the cursor.

![image](https://user-images.githubusercontent.com/168664/206788715-9b8ba7a6-ffe6-47e5-8b44-4523c16a3efd.png)

## How
This uses a hook component that sets the form as touch and revalidates after the schema has been refreshed. Sets the catalog to touched so that the changes are immediately cancelable.
