### PR TITLE
emit failure type in attempt_failure_by_origin

### DIFF
--- a/airbyte-metrics/metrics-lib/src/main/java/io/airbyte/metrics/lib/ApmTraceConstants.java
+++ b/airbyte-metrics/metrics-lib/src/main/java/io/airbyte/metrics/lib/ApmTraceConstants.java
@@ -75,6 +75,11 @@ public final class ApmTraceConstants {
     public static final String FAILURE_ORIGINS_KEY = "failure_origins";
 
     /**
+     * Name of the APM trace tag that holds the failure origin(s) associated with the trace.
+     */
+    public static final String FAILURE_TYPES_KEY = "failure_types";
+
+    /**
      * Name of the APM trace tag that holds the job ID value associated with the trace.
      */
     public static final String JOB_ID_KEY = "job_id";

--- a/airbyte-metrics/metrics-lib/src/main/java/io/airbyte/metrics/lib/ApmTraceConstants.java
+++ b/airbyte-metrics/metrics-lib/src/main/java/io/airbyte/metrics/lib/ApmTraceConstants.java
@@ -75,7 +75,7 @@ public final class ApmTraceConstants {
     public static final String FAILURE_ORIGINS_KEY = "failure_origins";
 
     /**
-     * Name of the APM trace tag that holds the failure origin(s) associated with the trace.
+     * Name of the APM trace tag that holds the failure type(s) associated with the trace.
      */
     public static final String FAILURE_TYPES_KEY = "failure_types";
 

--- a/airbyte-metrics/metrics-lib/src/main/java/io/airbyte/metrics/lib/MetricTags.java
+++ b/airbyte-metrics/metrics-lib/src/main/java/io/airbyte/metrics/lib/MetricTags.java
@@ -5,6 +5,7 @@
 package io.airbyte.metrics.lib;
 
 import io.airbyte.config.FailureReason.FailureOrigin;
+import io.airbyte.config.FailureReason.FailureType;
 import io.airbyte.db.instance.configs.jooq.generated.enums.ReleaseStage;
 import io.airbyte.db.instance.jobs.jooq.generated.enums.JobStatus;
 
@@ -15,6 +16,7 @@ public class MetricTags {
 
   public static final String CONNECTION_ID = "connection_id";
   public static final String FAILURE_ORIGIN = "failure_origin";
+  public static final String FAILURE_TYPE = "failure_type";
   public static final String JOB_ID = "job_id";
   public static final String JOB_STATUS = "job_status";
   public static final String RELEASE_STAGE = "release_stage";
@@ -30,6 +32,10 @@ public class MetricTags {
 
   public static String getFailureOrigin(final FailureOrigin origin) {
     return origin != null ? origin.value() : FailureOrigin.UNKNOWN.value();
+  }
+
+  public static String getFailureType(final FailureType origin) {
+    return origin != null ? origin.value() : UNKNOWN;
   }
 
   public static String getJobStatus(final JobStatus status) {

--- a/airbyte-metrics/metrics-lib/src/main/java/io/airbyte/metrics/lib/OssMetricsRegistry.java
+++ b/airbyte-metrics/metrics-lib/src/main/java/io/airbyte/metrics/lib/OssMetricsRegistry.java
@@ -42,7 +42,7 @@ public enum OssMetricsRegistry implements MetricsRegistry {
   ATTEMPT_FAILED_BY_FAILURE_ORIGIN(
       MetricEmittingApps.WORKER,
       "attempt_failed_by_failure_origin",
-      "increments for every failure origin a failed attempt has. since a failure can have multiple origins, a single failure can be counted more than once. tagged by failure origin."),
+      "increments for every failure origin a failed attempt has. since a failure can have multiple origins, a single failure can be counted more than once. tagged by failure origin and failure type."),
   ATTEMPT_SUCCEEDED_BY_RELEASE_STAGE(
       MetricEmittingApps.WORKER,
       "attempt_succeeded_by_release_stage",

--- a/airbyte-workers/src/main/java/io/airbyte/workers/temporal/scheduling/activities/JobCreationAndStatusUpdateActivityImpl.java
+++ b/airbyte-workers/src/main/java/io/airbyte/workers/temporal/scheduling/activities/JobCreationAndStatusUpdateActivityImpl.java
@@ -521,11 +521,13 @@ public class JobCreationAndStatusUpdateActivityImpl implements JobCreationAndSta
     if (failureSummary != null) {
       for (final FailureReason reason : failureSummary.getFailures()) {
         MetricClientFactory.getMetricClient().count(OssMetricsRegistry.ATTEMPT_FAILED_BY_FAILURE_ORIGIN, 1,
-            new MetricAttribute(MetricTags.FAILURE_ORIGIN, MetricTags.getFailureOrigin(reason.getFailureOrigin())));
+            new MetricAttribute(MetricTags.FAILURE_ORIGIN, MetricTags.getFailureOrigin(reason.getFailureOrigin())),
+            new MetricAttribute(MetricTags.FAILURE_TYPE, MetricTags.getFailureType(reason.getFailureType())));
       }
     } else {
       MetricClientFactory.getMetricClient().count(OssMetricsRegistry.ATTEMPT_FAILED_BY_FAILURE_ORIGIN, 1,
-          new MetricAttribute(MetricTags.FAILURE_ORIGIN, FailureOrigin.UNKNOWN.value()));
+          new MetricAttribute(MetricTags.FAILURE_ORIGIN, FailureOrigin.UNKNOWN.value()),
+          new MetricAttribute(MetricTags.FAILURE_TYPE, MetricTags.getFailureType(null)));
     }
   }
 

--- a/airbyte-workers/src/main/java/io/airbyte/workers/temporal/scheduling/activities/JobCreationAndStatusUpdateActivityImpl.java
+++ b/airbyte-workers/src/main/java/io/airbyte/workers/temporal/scheduling/activities/JobCreationAndStatusUpdateActivityImpl.java
@@ -504,11 +504,24 @@ public class JobCreationAndStatusUpdateActivityImpl implements JobCreationAndSta
   private void traceFailures(final AttemptFailureSummary failureSummary) {
     if (failureSummary != null) {
       if (CollectionUtils.isNotEmpty(failureSummary.getFailures())) {
-        ApmTraceUtils.addTagsToTrace(Map.of(FAILURE_ORIGINS_KEY, failureSummary.getFailures().stream().map(FailureReason::getFailureOrigin).map(
-            FailureOrigin::name).collect(Collectors.joining(","))));
+        ApmTraceUtils.addTagsToTrace(Map.of(
+            MetricTags.FAILURE_TYPE,
+            failureSummary.getFailures()
+                .stream()
+                .map(FailureReason::getFailureType)
+                .map(MetricTags::getFailureType)
+                .collect(Collectors.joining(",")),
+            FAILURE_ORIGINS_KEY,
+            failureSummary.getFailures()
+                .stream()
+                .map(FailureReason::getFailureOrigin)
+                .map(FailureOrigin::name)
+                .collect(Collectors.joining(","))));
       }
     } else {
-      ApmTraceUtils.addTagsToTrace(Map.of(FAILURE_ORIGINS_KEY, FailureOrigin.UNKNOWN.value()));
+      ApmTraceUtils.addTagsToTrace(Map.of(
+          MetricTags.FAILURE_TYPE, MetricTags.getFailureType(null),
+          FAILURE_ORIGINS_KEY, FailureOrigin.UNKNOWN.value()));
     }
   }
 

--- a/airbyte-workers/src/main/java/io/airbyte/workers/temporal/scheduling/activities/JobCreationAndStatusUpdateActivityImpl.java
+++ b/airbyte-workers/src/main/java/io/airbyte/workers/temporal/scheduling/activities/JobCreationAndStatusUpdateActivityImpl.java
@@ -9,6 +9,7 @@ import static io.airbyte.metrics.lib.ApmTraceConstants.ACTIVITY_TRACE_OPERATION_
 import static io.airbyte.metrics.lib.ApmTraceConstants.Tags.ATTEMPT_NUMBER_KEY;
 import static io.airbyte.metrics.lib.ApmTraceConstants.Tags.CONNECTION_ID_KEY;
 import static io.airbyte.metrics.lib.ApmTraceConstants.Tags.FAILURE_ORIGINS_KEY;
+import static io.airbyte.metrics.lib.ApmTraceConstants.Tags.FAILURE_TYPES_KEY;
 import static io.airbyte.metrics.lib.ApmTraceConstants.Tags.JOB_ID_KEY;
 import static io.airbyte.persistence.job.models.AttemptStatus.FAILED;
 
@@ -505,7 +506,7 @@ public class JobCreationAndStatusUpdateActivityImpl implements JobCreationAndSta
     if (failureSummary != null) {
       if (CollectionUtils.isNotEmpty(failureSummary.getFailures())) {
         ApmTraceUtils.addTagsToTrace(Map.of(
-            MetricTags.FAILURE_TYPE,
+            FAILURE_TYPES_KEY,
             failureSummary.getFailures()
                 .stream()
                 .map(FailureReason::getFailureType)
@@ -520,7 +521,7 @@ public class JobCreationAndStatusUpdateActivityImpl implements JobCreationAndSta
       }
     } else {
       ApmTraceUtils.addTagsToTrace(Map.of(
-          MetricTags.FAILURE_TYPE, MetricTags.getFailureType(null),
+          FAILURE_TYPES_KEY, MetricTags.getFailureType(null),
           FAILURE_ORIGINS_KEY, FailureOrigin.UNKNOWN.value()));
     }
   }


### PR DESCRIPTION
## What
* We emit attempt failure by origin (e.g. where in the system it was caused), but we do not include failure type. This PR adds it.
* Adding it because I want to be able to see it in our DD dashboards and be able to cut by failure type.