### PR TITLE
ci-credentials: fix typo when no secret found

### DIFF
--- a/tools/ci_credentials/ci_credentials/secrets_manager.py
+++ b/tools/ci_credentials/ci_credentials/secrets_manager.py
@@ -181,8 +181,6 @@ class SecretsManager:
             List[Path]: List of paths were the secrets were written
         """
         written_files = []
-        if not secrets:
-            return 0
         for secret in secrets:
             secrets_dir = self.base_folder / secret.directory
             secrets_dir.mkdir(parents=True, exist_ok=True)

--- a/tools/ci_credentials/setup.py
+++ b/tools/ci_credentials/setup.py
@@ -10,7 +10,7 @@ MAIN_REQUIREMENTS = ["requests", "ci_common_utils", "click~=8.1.3"]
 TEST_REQUIREMENTS = ["requests-mock", "pytest"]
 
 setup(
-    version="1.0.0",
+    version="1.0.1",
     name="ci_credentials",
     description="CLI tooling to read and manage GSM secrets",
     author="Airbyte",

--- a/tools/ci_credentials/tests/test_secrets_manager.py
+++ b/tools/ci_credentials/tests/test_secrets_manager.py
@@ -121,6 +121,11 @@ def test_read(matchers, connector_name, gsm_secrets, expected_secrets):
                 "airbyte-integrations/bases/base-normalization/secrets/auth.json",
             ],
         ),
+        (
+            "source-no-secret",
+            [],
+            [],
+        ),
     ),
 )
 def test_write(tmp_path, connector_name, secrets, expected_files):


### PR DESCRIPTION
## What
A typo was existing in the code:
In the situation of no secret found on GSM, an int was returned but an empty list was expected.
Leading to the following error `TypeError: object of type 'int' has no len()` when running `write-to-storage` command.