### PR TITLE
Document IntelliJ exclusion manual workaround

### DIFF
--- a/docs/contributing-to-airbyte/monorepo-python-development.md
+++ b/docs/contributing-to-airbyte/monorepo-python-development.md
@@ -101,3 +101,10 @@ By default, the find function in IntelliJ is not scoped and will include all fil
 5. Press OK to confirm your options.
 
 ![](../.gitbook/assets/monorepo-exclude-files.png)
+
+#### Manual Workaround
+
+We have seen the above solution not being applied by IntelliJ. The exact reason is not clear to us but as a workaround, you can:
+1. Open `.gitignore` in your IntelliJ
+2. There will be a banner saying `Some of the ignored directories are not excluded from indexing and search`. Click on `View Directories`
+3. A tree with all the git ignored files should be displayed. You can exclude them from IntelliJ by clicking `Exclude`


### PR DESCRIPTION
## What
The steps for excluding files sometimes does not work in IntelliJ. The reason is not clear but @erohmensing found a manual workaround that users can leverage to alleviate the issue.

## How
Improving documentation to share the information on https://docs.airbyte.com/contributing-to-airbyte/monorepo-python-development/#excluding-files-from-venv
