### PR TITLE
fix: remove retry attempt from "publish connector image" step

### DIFF
--- a/.github/workflows/publish-command.yml
+++ b/.github/workflows/publish-command.yml
@@ -307,19 +307,15 @@ jobs:
           attempt_delay: 5000 # in ms
           command: curl -sL https://sentry.io/get-cli/ | bash || echo "sentry cli already installed"
       - name: Publish ${{ matrix.connector }}
+        run: |
+          echo "$SPEC_CACHE_SERVICE_ACCOUNT_KEY" > spec_cache_key_file.json && docker login -u ${DOCKER_HUB_USERNAME} -p ${DOCKER_HUB_PASSWORD}
+          ./tools/integrations/manage.sh publish airbyte-integrations/${{ matrix.connector }} ${{ github.event.inputs.run-tests }} --publish_spec_to_cache
         id: publish
         env:
           DOCKER_HUB_USERNAME: ${{ secrets.DOCKER_HUB_USERNAME }}
           DOCKER_HUB_PASSWORD: ${{ secrets.DOCKER_HUB_PASSWORD }}
           # Oracle expects this variable to be set. Although usually present, this is not set by default on Github virtual runners.
           TZ: UTC
-        uses: Wandalen/wretry.action@master
-        with:
-          command: |
-            echo "$SPEC_CACHE_SERVICE_ACCOUNT_KEY" > spec_cache_key_file.json && docker login -u ${DOCKER_HUB_USERNAME} -p ${DOCKER_HUB_PASSWORD}
-            ./tools/integrations/manage.sh publish airbyte-integrations/${{ matrix.connector }} ${{ github.event.inputs.run-tests }} --publish_spec_to_cache
-          attempt_limit: 3
-          attempt_delay: 5000 in # ms
       - name: Update Integration Test Credentials after test run for ${{ github.event.inputs.connector }}
         if: always()
         run: |


### PR DESCRIPTION
This PR removes retry attempts for "Publish connector" step in [Publish connector image workflow](https://github.com/airbytehq/airbyte/blob/master/.github/workflows/publish-command.yml) due to confrontation with [fail-fast = false](https://github.com/airbytehq/airbyte/blob/21e7290eb6cd0a328e4f11b26bb5e29c6168080d/.github/workflows/publish-command.yml#L227) github actions logic.

Example - https://github.com/airbytehq/airbyte/pull/19610#issuecomment-1343269603