### PR TITLE
🐛  airbyte-proxy: Fix 413 Request Entity Too Large nginx/1.23.2 for Airbyte > 0.40.15

### DIFF
--- a/airbyte-proxy/nginx-auth.conf.template
+++ b/airbyte-proxy/nginx-auth.conf.template
@@ -9,6 +9,8 @@ http {
       proxy_set_header X-Real-IP $remote_addr;
       proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
 
+      client_max_body_size 200M;
+
       auth_basic "Welcome to Airbyte";
       auth_basic_user_file /etc/nginx/.htpasswd;
 
@@ -35,6 +37,8 @@ http {
       proxy_set_header X-Real-IP $remote_addr;
       proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
 
+      client_max_body_size 200M;
+
       auth_basic "Welcome to Airbyte";
       auth_basic_user_file /etc/nginx/.htpasswd;
 
@@ -60,6 +64,8 @@ http {
       proxy_set_header Host $host;
       proxy_set_header X-Real-IP $remote_addr;
       proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+
+      client_max_body_size 200M;
 
       auth_basic "Welcome to Airbyte";
       auth_basic_user_file /etc/nginx/.htpasswd;

--- a/airbyte-proxy/nginx-no-auth.conf.template
+++ b/airbyte-proxy/nginx-no-auth.conf.template
@@ -9,6 +9,8 @@ http {
       proxy_set_header X-Real-IP $remote_addr;
       proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
 
+      client_max_body_size 200M;
+
       proxy_pass "${PROXY_PASS_WEB}";
 
       proxy_connect_timeout       ${BASIC_AUTH_PROXY_TIMEOUT};
@@ -26,6 +28,8 @@ http {
       proxy_set_header X-Real-IP $remote_addr;
       proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
 
+      client_max_body_size 200M;
+
       proxy_pass "${PROXY_PASS_API}";
 
       proxy_connect_timeout       ${BASIC_AUTH_PROXY_TIMEOUT};
@@ -42,6 +46,8 @@ http {
       proxy_set_header Host $host;
       proxy_set_header X-Real-IP $remote_addr;
       proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+
+      client_max_body_size 200M;
 
       proxy_pass "${CONNECTOR_BUILDER_SERVER_API}";
     }


### PR DESCRIPTION
## What

From issue #18822

For long schemas creating the connection fails due to the request payload being over `1M`. This issue was introduced with the new airbyte-proxy service as `client_max_body_size` clause is not set on nginx template and defaults to `1M` limit.

## How

adding `client_max_body_size` clause to replicate the one set on `airbyte-server` nginx.

## 🚨 User Impact 🚨

No breaking changes

## Pre-merge Checklist
Expand the relevant checklist and delete the others.

<details><summary><strong>BugFix of service</strong></summary>

### Community member or Airbyter

- [x] **Community member?** Grant edit access to maintainers ([instructions](https://docs.github.com/en/github/collaborating-with-pull-requests/working-with-forks/allowing-changes-to-a-pull-request-branch-created-from-a-fork#enabling-repository-maintainer-permissions-on-existing-pull-requests))
- [ ] Code reviews completed
- [x] PR name follows [PR naming conventions](https://docs.airbyte.com/contributing-to-airbyte/issues-and-pull-requests)

</details>

