### PR TITLE
🪟 🧹 Match sync catalog items by name and namespace, not their index

### DIFF
--- a/airbyte-webapp/src/components/connection/CatalogTree/CatalogTree.tsx
+++ b/airbyte-webapp/src/components/connection/CatalogTree/CatalogTree.tsx
@@ -57,19 +57,12 @@ const CatalogTreeComponent: React.FC<React.PropsWithChildren<CatalogTreeProps>> 
   const changedStreams = useMemo(
     () =>
       streams.filter((stream) => {
-        if (!stream.config) {
-          return false;
-        }
-        const matchingInitialValue = initialValues.syncCatalog.streams.filter(
+        const matchingInitialValue = initialValues.syncCatalog.streams.find(
           (initialStream) =>
             initialStream.stream?.name === stream.stream?.name &&
             initialStream.stream?.namespace === stream.stream?.namespace
-        )[0];
-        if (!matchingInitialValue) {
-          return false;
-        }
-
-        return stream.config?.selected !== matchingInitialValue.config?.selected;
+        );
+        return stream.config?.selected !== matchingInitialValue?.config?.selected;
       }),
     [initialValues.syncCatalog.streams, streams]
   );

--- a/airbyte-webapp/src/components/connection/CatalogTree/CatalogTree.tsx
+++ b/airbyte-webapp/src/components/connection/CatalogTree/CatalogTree.tsx
@@ -56,8 +56,20 @@ const CatalogTreeComponent: React.FC<React.PropsWithChildren<CatalogTreeProps>> 
 
   const changedStreams = useMemo(
     () =>
-      streams.filter((stream, idx) => {
-        return stream.config?.selected !== initialValues.syncCatalog.streams[idx].config?.selected;
+      streams.filter((stream) => {
+        if (!stream.config) {
+          return false;
+        }
+        const matchingInitialValue = initialValues.syncCatalog.streams.filter(
+          (initialStream) =>
+            initialStream.stream?.name === stream.stream?.name &&
+            initialStream.stream?.namespace === stream.stream?.namespace
+        )[0];
+        if (!matchingInitialValue) {
+          return false;
+        }
+
+        return stream.config?.selected !== matchingInitialValue.config?.selected;
       }),
     [initialValues.syncCatalog.streams, streams]
   );


### PR DESCRIPTION
## What
Match by stream name and namespace instead of by syncCatalog index.

Fixes a bug when editing a connection where adding or removing a stream from the source, refreshing the source schema, then canceling the changes in the form would throw an error in `<CatalogTree/>`

## How
Name and namespace are more stable matchers than index.  The array may change based on refreshes, making it not a stable reference. 