### PR TITLE
:window: :art: Make TextInputContainer styles match other input styles

### DIFF
--- a/airbyte-webapp/src/components/ui/TextInputContainer/TextInputContainer.module.scss
+++ b/airbyte-webapp/src/components/ui/TextInputContainer/TextInputContainer.module.scss
@@ -13,12 +13,10 @@
   }
 
   &.error {
-    background-color: colors.$grey-100;
-    border-color: colors.$red;
+    border-color: colors.$red-100;
   }
 
   &:not(.disabled, .focused):hover {
-    background-color: colors.$grey-100;
     border-color: colors.$grey-100;
 
     &.light {
@@ -31,7 +29,6 @@
   }
 
   &.focused {
-    background-color: colors.$primaryColor12;
     border-color: colors.$blue;
 
     &.light {


### PR DESCRIPTION
## What
Resolves https://github.com/airbytehq/airbyte/issues/20394

The TextInputContainer styles were not in sync with the styles of our other input components. This PR brings them in line.

E.g. before:
<img width="735" alt="Screen Shot 2022-12-12 at 2 20 45 PM" src="https://user-images.githubusercontent.com/22731524/207167652-29fddaca-cd83-485a-9f28-041ca3f84518.png">

after:
<img width="738" alt="Screen Shot 2022-12-12 at 2 20 51 PM" src="https://user-images.githubusercontent.com/22731524/207167685-8c1adb76-7f62-464a-9932-57f57cc2ea86.png">

## Recommended reading order
1. `x.java`
2. `y.python`

## 🚨 User Impact 🚨
Consistent input styles
