### PR TITLE
Source Close.com: fix release stage to beta

### DIFF
--- a/airbyte-config/init/src/main/resources/seed/source_definitions.yaml
+++ b/airbyte-config/init/src/main/resources/seed/source_definitions.yaml
@@ -259,7 +259,7 @@
   documentationUrl: https://docs.airbyte.com/integrations/sources/close-com
   icon: close.svg
   sourceType: api
-  releaseStage: alpha
+  releaseStage: beta
 - name: CoinGecko Coins
   sourceDefinitionId: 9cdd4183-d0ba-40c3-aad3-6f46d4103974
   dockerRepository: airbyte/source-coingecko-coins
@@ -267,7 +267,7 @@
   documentationUrl: https://docs.airbyte.com/integrations/sources/coingecko-coins
   icon: coingeckocoins.svg
   sourceType: api
-  releaseStage: beta
+  releaseStage: alpha
 - name: Cockroachdb
   sourceDefinitionId: 9fa5862c-da7c-11eb-8d19-0242ac130003
   dockerRepository: airbyte/source-cockroachdb


### PR DESCRIPTION
## What
*release stage was accidentally updated not for Close.com connector but for CoinGecko Coins*
