### PR TITLE
SAT:  skip backward compatibility tests on spec/catalog if previous and actual spec/catalog are identical

### DIFF
--- a/airbyte-integrations/bases/source-acceptance-test/CHANGELOG.md
+++ b/airbyte-integrations/bases/source-acceptance-test/CHANGELOG.md
@@ -1,5 +1,8 @@
 # Changelog
 
+## 0.2.23
+Skip backward compatibility tests on specifications if actual and previous spec are identical.
+
 ## 0.2.22
 Capture control messages to store and use updated configurations. [#19979](https://github.com/airbytehq/airbyte/pull/19979).
 

--- a/airbyte-integrations/bases/source-acceptance-test/CHANGELOG.md
+++ b/airbyte-integrations/bases/source-acceptance-test/CHANGELOG.md
@@ -1,7 +1,7 @@
 # Changelog
 
 ## 0.2.23
-Skip backward compatibility tests on specifications if actual and previous spec are identical.
+Skip backward compatibility tests on specifications if actual and previous specifications and discovered catalogs are identical.[#20435](https://github.com/airbytehq/airbyte/pull/20435)
 
 ## 0.2.22
 Capture control messages to store and use updated configurations. [#19979](https://github.com/airbytehq/airbyte/pull/19979).

--- a/airbyte-integrations/bases/source-acceptance-test/Dockerfile
+++ b/airbyte-integrations/bases/source-acceptance-test/Dockerfile
@@ -33,7 +33,7 @@ COPY pytest.ini setup.py ./
 COPY source_acceptance_test ./source_acceptance_test
 RUN pip install .
 
-LABEL io.airbyte.version=0.2.22
+LABEL io.airbyte.version=0.2.23
 LABEL io.airbyte.name=airbyte/source-acceptance-test
 
 ENTRYPOINT ["python", "-m", "pytest", "-p", "source_acceptance_test.plugin", "-r", "fEsx"]

--- a/airbyte-integrations/bases/source-acceptance-test/source_acceptance_test/tests/test_core.py
+++ b/airbyte-integrations/bases/source-acceptance-test/source_acceptance_test/tests/test_core.py
@@ -83,7 +83,13 @@ class TestSpec(BaseTest):
     previous_spec_cache: ConnectorSpecification = None
 
     @pytest.fixture(name="skip_backward_compatibility_tests")
-    def skip_backward_compatibility_tests_fixture(self, inputs: SpecTestConfig, previous_connector_docker_runner: ConnectorRunner,  previous_connector_spec: ConnectorSpecification, actual_connector_spec: ConnectorSpecification) -> bool:
+    def skip_backward_compatibility_tests_fixture(
+        self,
+        inputs: SpecTestConfig,
+        previous_connector_docker_runner: ConnectorRunner,
+        previous_connector_spec: ConnectorSpecification,
+        actual_connector_spec: ConnectorSpecification,
+    ) -> bool:
         if actual_connector_spec == previous_connector_spec:
             pytest.skip("The previous and actual specifications are identical.")
 
@@ -361,7 +367,11 @@ class TestConnection(BaseTest):
 class TestDiscovery(BaseTest):
     @pytest.fixture(name="skip_backward_compatibility_tests")
     def skip_backward_compatibility_tests_fixture(
-        self, inputs: DiscoveryTestConfig, previous_connector_docker_runner: ConnectorRunner, discovered_catalog: MutableMapping[str, AirbyteStream], previous_discovered_catalog: MutableMapping[str, AirbyteStream], 
+        self,
+        inputs: DiscoveryTestConfig,
+        previous_connector_docker_runner: ConnectorRunner,
+        discovered_catalog: MutableMapping[str, AirbyteStream],
+        previous_discovered_catalog: MutableMapping[str, AirbyteStream],
     ) -> bool:
         if discovered_catalog == previous_discovered_catalog:
             pytest.skip("The previous and actual discovered catalogs are identical.")

--- a/airbyte-integrations/bases/source-acceptance-test/source_acceptance_test/tests/test_core.py
+++ b/airbyte-integrations/bases/source-acceptance-test/source_acceptance_test/tests/test_core.py
@@ -361,8 +361,11 @@ class TestConnection(BaseTest):
 class TestDiscovery(BaseTest):
     @pytest.fixture(name="skip_backward_compatibility_tests")
     def skip_backward_compatibility_tests_fixture(
-        self, inputs: DiscoveryTestConfig, previous_connector_docker_runner: ConnectorRunner
+        self, inputs: DiscoveryTestConfig, previous_connector_docker_runner: ConnectorRunner, discovered_catalog: MutableMapping[str, AirbyteStream], previous_discovered_catalog: MutableMapping[str, AirbyteStream], 
     ) -> bool:
+        if discovered_catalog == previous_discovered_catalog:
+            pytest.skip("The previous and actual discovered catalogs are identical.")
+
         if previous_connector_docker_runner is None:
             pytest.skip("The previous connector image could not be retrieved.")
 

--- a/airbyte-integrations/bases/source-acceptance-test/source_acceptance_test/tests/test_core.py
+++ b/airbyte-integrations/bases/source-acceptance-test/source_acceptance_test/tests/test_core.py
@@ -83,7 +83,10 @@ class TestSpec(BaseTest):
     previous_spec_cache: ConnectorSpecification = None
 
     @pytest.fixture(name="skip_backward_compatibility_tests")
-    def skip_backward_compatibility_tests_fixture(self, inputs: SpecTestConfig, previous_connector_docker_runner: ConnectorRunner) -> bool:
+    def skip_backward_compatibility_tests_fixture(self, inputs: SpecTestConfig, previous_connector_docker_runner: ConnectorRunner,  previous_connector_spec: ConnectorSpecification, actual_connector_spec: ConnectorSpecification) -> bool:
+        if actual_connector_spec == previous_connector_spec:
+            pytest.skip("The previous and actual specifications are identical.")
+
         if previous_connector_docker_runner is None:
             pytest.skip("The previous connector image could not be retrieved.")
 


### PR DESCRIPTION
## What
We don't need to run backward compatibility tests - that can be long-running - if the current and previous connector spec /catalog are identical.

Unblocking https://github.com/airbytehq/airbyte/pull/20237#discussion_r1047276082
## How
Skip spec backward compatibility tests if the current and previous connector spec are identical.