### PR TITLE
Update `source-gnews` acceptance test config

### DIFF
--- a/airbyte-integrations/connectors/source-gnews/acceptance-test-config.yml
+++ b/airbyte-integrations/connectors/source-gnews/acceptance-test-config.yml
@@ -1,30 +1,23 @@
 # See [Source Acceptance Tests](https://docs.airbyte.com/connector-development/testing-connectors/source-acceptance-tests-reference)
 # for more information about how to configure these tests
 connector_image: airbyte/source-gnews:dev
-acceptance_tests:
+tests:
   spec:
-    tests:
-      - spec_path: "source_gnews/spec.yaml"
+    - spec_path: "source_gnews/spec.yaml"
   connection:
-    tests:
-      - config_path: "secrets/config.json"
-        status: "succeed"
-      - config_path: "integration_tests/invalid_config.json"
-        status: "failed"
+    - config_path: "secrets/config.json"
+      status: "succeed"
+    - config_path: "integration_tests/invalid_config.json"
+      status: "failed"
   discovery:
-    tests:
-      - config_path: "secrets/config.json"
+    - config_path: "secrets/config.json"
   basic_read:
-    tests:
-      - config_path: "secrets/config.json"
-        configured_catalog_path: "integration_tests/configured_catalog.json"
-        empty_streams: []
-  incremental: 
-    tests:
-      - config_path: "secrets/config.json"
-        configured_catalog_path: "integration_tests/configured_catalog.json"
-        future_state_path: "integration_tests/abnormal_state.json"
+    - config_path: "secrets/config.json"
+      configured_catalog_path: "integration_tests/configured_catalog.json"
+  incremental:
+    - config_path: "secrets/config.json"
+      configured_catalog_path: "integration_tests/configured_catalog.json"
+      future_state_path: "integration_tests/abnormal_state.json"
   full_refresh:
-    tests:
-      - config_path: "secrets/config.json"
-        configured_catalog_path: "integration_tests/configured_catalog.json"
+    - config_path: "secrets/config.json"
+      configured_catalog_path: "integration_tests/configured_catalog.json"

--- a/docs/integrations/sources/gnews.md
+++ b/docs/integrations/sources/gnews.md
@@ -35,6 +35,7 @@ Rate Limiting is based on the API Key tier subscription, get more info [here](ht
 
 ## Changelog
 
-| Version | Date       | Pull Request                                             | Subject                                         |
-|:--------|:-----------|:---------------------------------------------------------|:------------------------------------------------|
-| 0.1.0   | 2022-11-01 | [18808](https://github.com/airbytehq/airbyte/pull/18808) | 🎉 New Source: GNews                            |
+| Version | Date       | Pull Request                                             | Subject                              |
+|:--------|:-----------|:---------------------------------------------------------|:-------------------------------------|
+| 0.1.1   | 2022-12-13 | [20460](https://github.com/airbytehq/airbyte/pull/20460) | Update source acceptance test config |
+| 0.1.0   | 2022-11-01 | [18808](https://github.com/airbytehq/airbyte/pull/18808) | 🎉 New Source: GNews                 |


### PR DESCRIPTION
## What
Updates the acceptance test config for `source-gnews`, which was using the legacy version.

## How
Update airbyte-integrations/connectors/source-gnews/acceptance-test-config.yml.

## Recommended reading order
1. `airbyte-integrations/connectors/source-gnews/acceptance-test-config.yml`

## 🚨 User Impact 🚨
No user impact.

## Pre-merge Checklist
- [x] Integration tests passing.
- [x] Code reviews completed
- [x] Documentation updated
    - [x] `docs/integrations/<source or destination>/<name>.md` including changelog. See changelog [example](https://docs.airbyte.io/integrations/sources/stripe#changelog)
- [x] PR name follows [PR naming conventions](https://docs.airbyte.com/contributing-to-airbyte/issues-and-pull-requests)
- [x] [`/test connector=connectors/<name>` command](https://docs.airbyte.io/connector-development#updating-an-existing-connector) is passing
- [x] New Connector version released on Dockerhub by running the `/publish` command described [here](https://docs.airbyte.io/connector-development#updating-an-existing-connector)

## Tests

<details><summary><strong>Unit</strong></summary>

*Put your unit tests output here.*

</details>

<details><summary><strong>Integration</strong></summary>

*Put your integration tests output here.*

</details>

<details><summary><strong>Acceptance</strong></summary>

*Put your acceptance tests output here.*

</details>
