### PR TITLE
:window: :bug: [Connector Builder] correctly ignore individually touched fields in useBuilderErrors

### DIFF
--- a/airbyte-webapp/src/components/connectorBuilder/useBuilderErrors.ts
+++ b/airbyte-webapp/src/components/connectorBuilder/useBuilderErrors.ts
@@ -1,6 +1,7 @@
 import { flatten } from "flat";
 import { FormikErrors, useFormikContext } from "formik";
 import intersection from "lodash/intersection";
+import { useCallback } from "react";
 
 import { BuilderView, useConnectorBuilderState } from "services/connectorBuilder/ConnectorBuilderStateService";
 
@@ -10,86 +11,91 @@ export const useBuilderErrors = () => {
   const { touched, errors, validateForm, setFieldTouched } = useFormikContext<BuilderFormValues>();
   const { setSelectedView, setTestStreamIndex } = useConnectorBuilderState();
 
-  const invalidViews = (
-    ignoreUntouched: boolean,
-    limitToViews?: BuilderView[],
-    inputErrors?: FormikErrors<BuilderFormValues>
-  ) => {
-    const errorsToCheck = inputErrors !== undefined ? inputErrors : errors;
-    const errorKeys = Object.keys(errorsToCheck);
+  const invalidViews = useCallback(
+    (ignoreUntouched: boolean, limitToViews?: BuilderView[], inputErrors?: FormikErrors<BuilderFormValues>) => {
+      const errorsToCheck = inputErrors !== undefined ? inputErrors : errors;
+      const errorKeys = Object.keys(errorsToCheck);
 
-    const invalidViews: BuilderView[] = [];
+      const invalidViews: BuilderView[] = [];
 
-    if (errorKeys.includes("global")) {
-      if (ignoreUntouched) {
-        if (errorsToCheck.global && touched.global) {
-          const globalErrorKeys = Object.keys(flatten(errorsToCheck.global));
-          const globalTouchedKeys = Object.keys(flatten(touched.global));
-          if (intersection(globalErrorKeys, globalTouchedKeys).length > 0) {
-            invalidViews.push("global");
+      if (errorKeys.includes("global")) {
+        if (ignoreUntouched) {
+          if (errorsToCheck.global && touched.global) {
+            const globalErrorKeys = Object.keys(flatten(errorsToCheck.global));
+            const globalTouchedKeys = Object.keys(flatten(touched.global));
+            if (intersection(globalErrorKeys, globalTouchedKeys).length > 0) {
+              invalidViews.push("global");
+            }
           }
+        } else {
+          invalidViews.push("global");
         }
-      } else {
-        invalidViews.push("global");
       }
-    }
 
-    if (errorKeys.includes("streams")) {
-      const errorStreamNums = Object.keys(errorsToCheck.streams ?? {});
+      if (errorKeys.includes("streams")) {
+        const errorStreamNums = Object.keys(errorsToCheck.streams ?? {});
 
-      if (ignoreUntouched) {
-        if (errorsToCheck.streams && touched.streams) {
-          // loop over each stream and find ones with fields that are both touched and erroring
-          for (const streamNumString of errorStreamNums) {
-            const streamNum = Number(streamNumString);
-            const streamErrors = errorsToCheck.streams[streamNum];
-            const streamTouched = touched.streams[streamNum];
-            if (streamErrors && streamTouched) {
-              const streamErrorKeys = Object.keys(flatten(streamErrors));
-              const streamTouchedKeys = Object.keys(flatten(streamTouched));
-              if (intersection(streamErrorKeys, streamTouchedKeys).length > 0) {
-                invalidViews.push(streamNum);
+        if (ignoreUntouched) {
+          if (errorsToCheck.streams && touched.streams) {
+            // loop over each stream and find ones with fields that are both touched and erroring
+            for (const streamNumString of errorStreamNums) {
+              const streamNum = Number(streamNumString);
+              const streamErrors = errorsToCheck.streams[streamNum];
+              const streamTouched = touched.streams[streamNum];
+              if (streamErrors && streamTouched) {
+                const streamErrorKeys = Object.keys(flatten(streamErrors));
+                const streamTouchedKeys = Object.keys(flatten(streamTouched));
+                if (intersection(streamErrorKeys, streamTouchedKeys).length > 0) {
+                  invalidViews.push(streamNum);
+                }
               }
             }
           }
+        } else {
+          invalidViews.push(...errorStreamNums.map((numString) => Number(numString)));
         }
-      } else {
-        invalidViews.push(...errorStreamNums.map((numString) => Number(numString)));
       }
-    }
 
-    return limitToViews === undefined ? invalidViews : intersection(invalidViews, limitToViews);
-  };
+      return limitToViews === undefined ? invalidViews : intersection(invalidViews, limitToViews);
+    },
+    [errors, touched]
+  );
 
   // Returns true if the global config fields or any stream config fields have errors in the provided formik errors, and false otherwise.
   // If limitToViews is provided, the error check is limited to only those views.
-  const hasErrors = (ignoreUntouched: boolean, limitToViews?: BuilderView[]) => {
-    return invalidViews(ignoreUntouched, limitToViews).length > 0;
-  };
+  const hasErrors = useCallback(
+    (ignoreUntouched: boolean, limitToViews?: BuilderView[]) => {
+      return invalidViews(ignoreUntouched, limitToViews).length > 0;
+    },
+    [invalidViews]
+  );
 
-  const validateAndTouch = (callback: () => void, limitToViews?: BuilderView[]) => {
-    validateForm().then((errors) => {
-      for (const path of Object.keys(flatten(errors))) {
-        setFieldTouched(path);
-      }
-
-      // If there are relevant errors, select the erroring view, prioritizing global
-      // Otherwise, execute the callback.
-
-      const invalidBuilderViews = invalidViews(false, limitToViews, errors);
-
-      if (invalidBuilderViews.length > 0) {
-        if (invalidBuilderViews.includes("global")) {
-          setSelectedView("global");
-        } else {
-          setSelectedView(invalidBuilderViews[0]);
-          setTestStreamIndex(invalidBuilderViews[0] as number);
+  const validateAndTouch = useCallback(
+    (callback: () => void, limitToViews?: BuilderView[]) => {
+      validateForm().then((errors) => {
+        for (const path of Object.keys(flatten(errors))) {
+          setFieldTouched(path);
         }
-      } else {
-        callback();
-      }
-    });
-  };
+
+        // If there are relevant errors, select the erroring view, prioritizing global
+        // Otherwise, execute the callback.
+
+        const invalidBuilderViews = invalidViews(false, limitToViews, errors);
+
+        if (invalidBuilderViews.length > 0) {
+          if (invalidBuilderViews.includes("global")) {
+            setSelectedView("global");
+          } else {
+            setSelectedView(invalidBuilderViews[0]);
+            setTestStreamIndex(invalidBuilderViews[0] as number);
+          }
+        } else {
+          callback();
+        }
+      });
+    },
+    [invalidViews, setFieldTouched, setSelectedView, setTestStreamIndex, validateForm]
+  );
 
   return { hasErrors, validateAndTouch };
 };

--- a/airbyte-webapp/src/components/connectorBuilder/useBuilderErrors.ts
+++ b/airbyte-webapp/src/components/connectorBuilder/useBuilderErrors.ts
@@ -16,17 +16,20 @@ export const useBuilderErrors = () => {
     inputErrors?: FormikErrors<BuilderFormValues>
   ) => {
     const errorsToCheck = inputErrors !== undefined ? inputErrors : errors;
-    console.log("errorsToCheck", errorsToCheck);
-
-    const errorKeys = ignoreUntouched
-      ? intersection(Object.keys(errorsToCheck), Object.keys(touched))
-      : Object.keys(errorsToCheck);
-    console.log("errorKeys", errorKeys);
+    const errorKeys = Object.keys(errorsToCheck);
 
     const invalidViews: BuilderView[] = [];
 
     if (errorKeys.includes("global")) {
-      invalidViews.push("global");
+      if (ignoreUntouched) {
+        const globalErrorKeys = Object.keys(flatten(errorsToCheck.global));
+        const globalTouchedKeys = Object.keys(flatten(touched.global));
+        if (intersection(globalErrorKeys, globalTouchedKeys).length > 0) {
+          invalidViews.push("global");
+        }
+      } else {
+        invalidViews.push("global");
+      }
     }
 
     if (errorKeys.includes("streams")) {

--- a/airbyte-webapp/src/components/connectorBuilder/useBuilderErrors.ts
+++ b/airbyte-webapp/src/components/connectorBuilder/useBuilderErrors.ts
@@ -1,10 +1,10 @@
 import { flatten } from "flat";
-import { FormikErrors, FormikTouched, useFormikContext } from "formik";
+import { FormikErrors, useFormikContext } from "formik";
 import intersection from "lodash/intersection";
 
 import { BuilderView, useConnectorBuilderState } from "services/connectorBuilder/ConnectorBuilderStateService";
 
-import { BuilderFormValues, BuilderStream } from "./types";
+import { BuilderFormValues } from "./types";
 
 export const useBuilderErrors = () => {
   const { touched, errors, validateForm, setFieldTouched } = useFormikContext<BuilderFormValues>();
@@ -22,10 +22,12 @@ export const useBuilderErrors = () => {
 
     if (errorKeys.includes("global")) {
       if (ignoreUntouched) {
-        const globalErrorKeys = Object.keys(flatten(errorsToCheck.global));
-        const globalTouchedKeys = Object.keys(flatten(touched.global));
-        if (intersection(globalErrorKeys, globalTouchedKeys).length > 0) {
-          invalidViews.push("global");
+        if (errorsToCheck.global && touched.global) {
+          const globalErrorKeys = Object.keys(flatten(errorsToCheck.global));
+          const globalTouchedKeys = Object.keys(flatten(touched.global));
+          if (intersection(globalErrorKeys, globalTouchedKeys).length > 0) {
+            invalidViews.push("global");
+          }
         }
       } else {
         invalidViews.push("global");
@@ -36,18 +38,19 @@ export const useBuilderErrors = () => {
       const errorStreamNums = Object.keys(errorsToCheck.streams ?? {});
 
       if (ignoreUntouched) {
-        // have to cast to allow us to index into the formik errors objects
-        const streamsErrors = errorsToCheck.streams as Array<FormikErrors<BuilderStream>>;
-        const streamsTouched = touched.streams as Array<FormikTouched<BuilderStream>>;
-        // loop over each stream and find ones with fields that are both touched and erroring
-        for (const streamNumString of errorStreamNums) {
-          const streamNum = Number(streamNumString);
-          const streamErrors = streamsErrors[streamNum];
-          const streamTouched = streamsTouched[streamNum];
-          const streamErrorKeys = Object.keys(flatten(streamErrors));
-          const streamTouchedKeys = Object.keys(flatten(streamTouched));
-          if (intersection(streamErrorKeys, streamTouchedKeys).length > 0) {
-            invalidViews.push(streamNum);
+        if (errorsToCheck.streams && touched.streams) {
+          // loop over each stream and find ones with fields that are both touched and erroring
+          for (const streamNumString of errorStreamNums) {
+            const streamNum = Number(streamNumString);
+            const streamErrors = errorsToCheck.streams[streamNum];
+            const streamTouched = touched.streams[streamNum];
+            if (streamErrors && streamTouched) {
+              const streamErrorKeys = Object.keys(flatten(streamErrors));
+              const streamTouchedKeys = Object.keys(flatten(streamTouched));
+              if (intersection(streamErrorKeys, streamTouchedKeys).length > 0) {
+                invalidViews.push(streamNum);
+              }
+            }
           }
         }
       } else {


### PR DESCRIPTION
## What
I found a bug in which if you touched a field in some view of the connector builder which did not have an error, and a different field had an error but was _untouched_, then the error indicator would still show for that view even though it should only be showing if there is a _touched_ field with an error in the view.

## How
This issue was caused by the useBuilderErrors object just checking if the entire view had been touched and had some errors, rather than checking individual fields in the view.

This PR fixes the issue by looking into the touched and error objects for each view and finding if there are any individual fields that are both touched _and_ have an error, which makes the error indicator correctly only show when there are touched and erroring fields in the corresponding view.

## 🚨 User Impact 🚨
Connector builder view error indicators are shown correctly.
