### PR TITLE
[source-asana] Update CDK dependency to ~0.13

### DIFF
--- a/airbyte-integrations/connectors/source-asana/Dockerfile
+++ b/airbyte-integrations/connectors/source-asana/Dockerfile
@@ -12,5 +12,5 @@ RUN pip install .
 ENV AIRBYTE_ENTRYPOINT "python /airbyte/integration_code/main.py"
 ENTRYPOINT ["python", "/airbyte/integration_code/main.py"]
 
-LABEL io.airbyte.version=0.1.5
+LABEL io.airbyte.version=0.1.6
 LABEL io.airbyte.name=airbyte/source-asana

--- a/airbyte-integrations/connectors/source-asana/setup.py
+++ b/airbyte-integrations/connectors/source-asana/setup.py
@@ -6,7 +6,7 @@
 from setuptools import find_packages, setup
 
 MAIN_REQUIREMENTS = [
-    "airbyte-cdk~=0.2",
+    "airbyte-cdk~=0.13",
 ]
 
 TEST_REQUIREMENTS = ["pytest~=6.1", "requests-mock~=1.9.3", "source-acceptance-test"]

--- a/docs/integrations/sources/asana.md
+++ b/docs/integrations/sources/asana.md
@@ -65,8 +65,9 @@ The connector is restricted by normal Asana [requests limitation](https://develo
 ## Changelog
 
 | Version | Date       | Pull Request                                             | Subject                                                     |
-| :------ | :--------- | :------------------------------------------------------- | :---------------------------------------------------------- |
-| 0.1.5   | 2022-11-16 | [19561](https://github.com/airbytehq/airbyte/pull/19561) | Added errors handling, updated SAT with new format
+|:--------|:-----------|:---------------------------------------------------------|:------------------------------------------------------------|
+| 0.1.6   | 2022-12-14 | [20477](https://github.com/airbytehq/airbyte/pull/20477) | Upgraded CDK dependency                                     |
+| 0.1.5   | 2022-11-16 | [19561](https://github.com/airbytehq/airbyte/pull/19561) | Added errors handling, updated SAT with new format          |
 | 0.1.4   | 2022-08-18 | [15749](https://github.com/airbytehq/airbyte/pull/15749) | Add cache to project stream                                 |
 | 0.1.3   | 2021-10-06 | [6832](https://github.com/airbytehq/airbyte/pull/6832)   | Add oauth init flow parameters support                      |
 | 0.1.2   | 2021-09-24 | [6402](https://github.com/airbytehq/airbyte/pull/6402)   | Fix SAT tests: update schemas and invalid\_config.json file |


### PR DESCRIPTION
Update the CDK dependency and re-publish to ensure that the default AvailabilityStrategy for HttpStreams is in place for the Asana source. This is a beta connector we are upgrading as a trial run to bulk-updating the dependency for all GA connectors that use HttpStreams. For more context see #20401 :) 