### PR TITLE
prevent the cursor or primary key fields from being deselected

### DIFF
--- a/airbyte-server/src/test/java/io/airbyte/server/handlers/ConnectionsHandlerTest.java
+++ b/airbyte-server/src/test/java/io/airbyte/server/handlers/ConnectionsHandlerTest.java
@@ -5,6 +5,7 @@
 package io.airbyte.server.handlers;
 
 import static io.airbyte.server.helpers.ConnectionHelpers.FIELD_NAME;
+import static io.airbyte.server.helpers.ConnectionHelpers.SECOND_FIELD_NAME;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertThrows;
@@ -351,6 +352,46 @@ class ConnectionsHandlerTest {
         standardSync.withFieldSelectionData(new FieldSelectionData().withAdditionalProperty("null/users-data0", true));
 
         verify(configRepository).writeStandardSync(standardSync);
+      }
+
+      @Test
+      void testFieldSelectionRemoveCursorFails() throws JsonValidationException, ConfigNotFoundException, IOException {
+        // Test that if we try to de-select a field that's being used for the cursor, the request will fail.
+        // The connection initially has a catalog with one stream, and two fields in that stream.
+        standardSync.setCatalog(ConnectionHelpers.generateAirbyteCatalogWithTwoFields());
+
+        // Send an update that sets a cursor but de-selects that field.
+        final AirbyteCatalog catalogForUpdate = ConnectionHelpers.generateApiCatalogWithTwoFields();
+        catalogForUpdate.getStreams().get(0).getConfig()
+            .fieldSelectionEnabled(true)
+            .selectedFields(List.of(new SelectedFieldInfo().addFieldPathItem(FIELD_NAME)))
+            .cursorField(List.of(SECOND_FIELD_NAME));
+
+        final ConnectionUpdate connectionUpdate = new ConnectionUpdate()
+            .connectionId(standardSync.getConnectionId())
+            .syncCatalog(catalogForUpdate);
+
+        assertThrows(JsonValidationException.class, () -> connectionsHandler.updateConnection(connectionUpdate));
+      }
+
+      @Test
+      void testFieldSelectionRemovePrimaryKeyFails() throws JsonValidationException, ConfigNotFoundException, IOException {
+        // Test that if we try to de-select a field that's being used for the primary key, the request will fail.
+        // The connection initially has a catalog with one stream, and two fields in that stream.
+        standardSync.setCatalog(ConnectionHelpers.generateAirbyteCatalogWithTwoFields());
+
+        // Send an update that sets a primary key but deselects that field.
+        final AirbyteCatalog catalogForUpdate = ConnectionHelpers.generateApiCatalogWithTwoFields();
+        catalogForUpdate.getStreams().get(0).getConfig()
+            .fieldSelectionEnabled(true)
+            .selectedFields(List.of(new SelectedFieldInfo().addFieldPathItem(FIELD_NAME)))
+            .primaryKey(List.of(List.of(SECOND_FIELD_NAME)));
+
+        final ConnectionUpdate connectionUpdate = new ConnectionUpdate()
+            .connectionId(standardSync.getConnectionId())
+            .syncCatalog(catalogForUpdate);
+
+        assertThrows(JsonValidationException.class, () -> connectionsHandler.updateConnection(connectionUpdate));
       }
 
       @Test

--- a/airbyte-server/src/test/java/io/airbyte/server/handlers/ConnectionsHandlerTest.java
+++ b/airbyte-server/src/test/java/io/airbyte/server/handlers/ConnectionsHandlerTest.java
@@ -376,7 +376,8 @@ class ConnectionsHandlerTest {
 
       @Test
       void testFieldSelectionRemovePrimaryKeyFails() throws JsonValidationException, ConfigNotFoundException, IOException {
-        // Test that if we try to de-select a field that's being used for the primary key, the request will fail.
+        // Test that if we try to de-select a field that's being used for the primary key, the request will
+        // fail.
         // The connection initially has a catalog with one stream, and two fields in that stream.
         standardSync.setCatalog(ConnectionHelpers.generateAirbyteCatalogWithTwoFields());
 

--- a/airbyte-server/src/test/java/io/airbyte/server/helpers/ConnectionHelpers.java
+++ b/airbyte-server/src/test/java/io/airbyte/server/helpers/ConnectionHelpers.java
@@ -54,6 +54,8 @@ public class ConnectionHelpers {
   private static final String STREAM_NAME_BASE = "users-data";
   private static final String STREAM_NAME = STREAM_NAME_BASE + "0";
   public static final String FIELD_NAME = "id";
+
+  public static final String SECOND_FIELD_NAME = "id2";
   private static final String BASIC_SCHEDULE_TIME_UNIT = "days";
   private static final long BASIC_SCHEDULE_UNITS = 1L;
   private static final String BASIC_SCHEDULE_DATA_TIME_UNITS = "days";
@@ -284,7 +286,7 @@ public class ConnectionHelpers {
   public static JsonNode generateJsonSchemaWithTwoFields() {
     return CatalogHelpers.fieldsToJsonSchema(
         Field.of(FIELD_NAME, JsonSchemaType.STRING),
-        Field.of(FIELD_NAME + "2", JsonSchemaType.STRING));
+        Field.of(SECOND_FIELD_NAME, JsonSchemaType.STRING));
   }
 
   public static ConfiguredAirbyteCatalog generateBasicConfiguredAirbyteCatalog() {


### PR DESCRIPTION
## What
Ensure that the cursor and primary key fields can't be deselected.

We might want to allow this in some cases, but for simplicity we disallow it entirely per the PRD.

## How
If but `cursor`/`primary key` and `selectedFields` are provided, check that the key field is included in the list of selected fields.