### PR TITLE
add ReplicationWorkerFactory to dry creation logic

### DIFF
--- a/airbyte-commons-worker/src/main/java/io/airbyte/workers/general/DefaultReplicationWorkerFactory.java
+++ b/airbyte-commons-worker/src/main/java/io/airbyte/workers/general/DefaultReplicationWorkerFactory.java
@@ -1,0 +1,117 @@
+/*
+ * Copyright (c) 2022 Airbyte, Inc., all rights reserved.
+ */
+
+package io.airbyte.workers.general;
+
+import io.airbyte.commons.features.FeatureFlags;
+import io.airbyte.commons.logging.MdcScope;
+import io.airbyte.commons.protocol.AirbyteMessageSerDeProvider;
+import io.airbyte.commons.protocol.AirbyteMessageVersionedMigratorFactory;
+import io.airbyte.commons.version.Version;
+import io.airbyte.config.StandardSyncInput;
+import io.airbyte.metrics.lib.MetricClientFactory;
+import io.airbyte.metrics.lib.MetricEmittingApps;
+import io.airbyte.workers.RecordSchemaValidator;
+import io.airbyte.workers.WorkerConstants;
+import io.airbyte.workers.WorkerMetricReporter;
+import io.airbyte.workers.WorkerUtils;
+import io.airbyte.workers.internal.AirbyteSource;
+import io.airbyte.workers.internal.AirbyteStreamFactory;
+import io.airbyte.workers.internal.DefaultAirbyteDestination;
+import io.airbyte.workers.internal.DefaultAirbyteSource;
+import io.airbyte.workers.internal.DefaultAirbyteStreamFactory;
+import io.airbyte.workers.internal.EmptyAirbyteSource;
+import io.airbyte.workers.internal.NamespacingMapper;
+import io.airbyte.workers.internal.VersionedAirbyteMessageBufferedWriterFactory;
+import io.airbyte.workers.internal.VersionedAirbyteStreamFactory;
+import io.airbyte.workers.internal.book_keeping.AirbyteMessageTracker;
+import io.airbyte.workers.process.AirbyteIntegrationLauncher;
+import io.airbyte.workers.process.IntegrationLauncher;
+import io.airbyte.workers.process.ProcessFactory;
+import java.lang.invoke.MethodHandles;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+public class DefaultReplicationWorkerFactory {
+
+  private static final Logger log = LoggerFactory.getLogger(MethodHandles.lookup().lookupClass());
+
+  public static DefaultReplicationWorker create(final String jobId,
+                                                final int attemptId,
+                                                final ProcessFactory processFactory,
+                                                final String srcDockerImage,
+                                                final String destDockerImage,
+                                                final boolean srcIsCustomConnector,
+                                                final boolean destIsCustomConnector,
+                                                final Version srcProtocolVersion,
+                                                final Version destProtocolVersion,
+                                                final StandardSyncInput syncInput,
+                                                final AirbyteMessageSerDeProvider serdeProvider,
+                                                final AirbyteMessageVersionedMigratorFactory migratorFactory,
+                                                final FeatureFlags featureFlags,
+                                                final boolean fieldSelectionEnabled
+
+  ) {
+    log.info("Setting up source launcher...");
+    final IntegrationLauncher sourceLauncher = new AirbyteIntegrationLauncher(
+        jobId,
+        attemptId,
+        srcDockerImage,
+        processFactory,
+        syncInput.getSourceResourceRequirements(),
+        srcIsCustomConnector);
+
+    log.info("Setting up destination launcher...");
+    final IntegrationLauncher destinationLauncher = new AirbyteIntegrationLauncher(
+        jobId,
+        attemptId,
+        destDockerImage,
+        processFactory,
+        syncInput.getDestinationResourceRequirements(),
+        destIsCustomConnector);
+
+    MetricClientFactory.initialize(MetricEmittingApps.WORKER);
+    final var metricClient = MetricClientFactory.getMetricClient();
+    final var metricReporter = new WorkerMetricReporter(metricClient, srcDockerImage);
+
+    log.info("Setting up source...");
+    // reset jobs use an empty source to induce resetting all data in destination.
+    final AirbyteSource airbyteSource;
+    if (WorkerConstants.RESET_JOB_SOURCE_DOCKER_IMAGE_STUB.equals(srcDockerImage)) {
+      airbyteSource = new EmptyAirbyteSource(featureFlags.useStreamCapableState());
+    } else {
+      airbyteSource = new DefaultAirbyteSource(
+          sourceLauncher,
+          getStreamFactory(srcProtocolVersion, DefaultAirbyteSource.CONTAINER_LOG_MDC_BUILDER, serdeProvider, migratorFactory));
+    }
+
+    log.info("Setting up destination...");
+    final var airbyteDestination = new DefaultAirbyteDestination(
+        destinationLauncher,
+        getStreamFactory(destProtocolVersion, DefaultAirbyteDestination.CONTAINER_LOG_MDC_BUILDER, serdeProvider, migratorFactory),
+        new VersionedAirbyteMessageBufferedWriterFactory(serdeProvider, migratorFactory, destProtocolVersion));
+
+    log.info("Setting up replication worker...");
+    return new DefaultReplicationWorker(
+        jobId,
+        attemptId,
+        airbyteSource,
+        new NamespacingMapper(syncInput.getNamespaceDefinition(), syncInput.getNamespaceFormat(), syncInput.getPrefix()),
+        airbyteDestination,
+        new AirbyteMessageTracker(),
+        new RecordSchemaValidator(WorkerUtils.mapStreamNamesToSchemas(syncInput)),
+        metricReporter,
+        fieldSelectionEnabled);
+  }
+
+  private static AirbyteStreamFactory getStreamFactory(final Version protocolVersion,
+                                                       final MdcScope.Builder mdcScope,
+                                                       final AirbyteMessageSerDeProvider serdeProvider,
+                                                       final AirbyteMessageVersionedMigratorFactory migratorFactory) {
+    return protocolVersion != null
+        ? new VersionedAirbyteStreamFactory(serdeProvider, migratorFactory, protocolVersion, mdcScope)
+        : new DefaultAirbyteStreamFactory(mdcScope);
+  }
+
+}

--- a/airbyte-commons-worker/src/test/java/io/airbyte/workers/WorkerUtilsTest.java
+++ b/airbyte-commons-worker/src/test/java/io/airbyte/workers/WorkerUtilsTest.java
@@ -5,125 +5,18 @@
 package io.airbyte.workers;
 
 import static org.junit.jupiter.api.Assertions.assertNotNull;
-import static org.mockito.Mockito.doAnswer;
-import static org.mockito.Mockito.mock;
-import static org.mockito.Mockito.verify;
-import static org.mockito.Mockito.verifyNoInteractions;
-import static org.mockito.Mockito.when;
 
 import com.fasterxml.jackson.databind.JsonNode;
-import io.airbyte.config.Configs;
-import io.airbyte.config.EnvConfigs;
 import io.airbyte.config.StandardSync;
 import io.airbyte.config.StandardSyncInput;
 import io.airbyte.protocol.models.AirbyteStreamNameNamespacePair;
-import io.airbyte.workers.internal.HeartbeatMonitor;
 import io.airbyte.workers.test_utils.TestConfigHelpers;
-import java.time.Duration;
-import java.time.temporal.ChronoUnit;
 import java.util.Map;
-import java.util.concurrent.TimeUnit;
-import java.util.concurrent.atomic.AtomicInteger;
-import java.util.function.BiConsumer;
 import org.apache.commons.lang3.tuple.ImmutablePair;
-import org.junit.jupiter.api.BeforeEach;
-import org.junit.jupiter.api.DisplayName;
-import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 
 @SuppressWarnings("PMD.JUnitTestsShouldIncludeAssert")
 class WorkerUtilsTest {
-
-  private static final Logger LOGGER = LoggerFactory.getLogger(GentleCloseWithHeartbeat.class);
-
-  @Nested
-  class GentleCloseWithHeartbeat {
-
-    private final Duration CHECK_HEARTBEAT_DURATION = Duration.of(10, ChronoUnit.MILLIS);
-
-    private final Duration SHUTDOWN_TIME_DURATION = Duration.of(100, ChronoUnit.MILLIS);
-
-    private Process process;
-    private HeartbeatMonitor heartbeatMonitor;
-    private BiConsumer<Process, Duration> forceShutdown;
-
-    @SuppressWarnings("unchecked")
-    @BeforeEach
-    void setup() {
-      process = mock(Process.class);
-      heartbeatMonitor = mock(HeartbeatMonitor.class);
-      forceShutdown = mock(BiConsumer.class);
-    }
-
-    private void runShutdown() {
-      gentleCloseWithHeartbeat(
-          new WorkerConfigs(new EnvConfigs()),
-          process,
-          heartbeatMonitor,
-          SHUTDOWN_TIME_DURATION,
-          CHECK_HEARTBEAT_DURATION,
-          SHUTDOWN_TIME_DURATION,
-          forceShutdown);
-    }
-
-    @SuppressWarnings("BusyWait")
-    @DisplayName("Verify that shutdown waits indefinitely when heartbeat and process are healthy.")
-    @Test
-    void testStartsWait() throws InterruptedException {
-      when(process.isAlive()).thenReturn(true);
-      final AtomicInteger recordedBeats = new AtomicInteger(0);
-      doAnswer((ignored) -> {
-        recordedBeats.incrementAndGet();
-        return true;
-      }).when(heartbeatMonitor).isBeating();
-
-      final Thread thread = new Thread(this::runShutdown);
-
-      thread.start();
-
-      // block until the loop is running.
-      while (recordedBeats.get() < 3) {
-        Thread.sleep(10);
-      }
-
-      thread.stop();
-    }
-
-    @Test
-    @DisplayName("Test heartbeat ends and graceful shutdown.")
-    void testGracefulShutdown() {
-      when(heartbeatMonitor.isBeating()).thenReturn(false);
-      when(process.isAlive()).thenReturn(false);
-
-      runShutdown();
-
-      verifyNoInteractions(forceShutdown);
-    }
-
-    @Test
-    @DisplayName("Test heartbeat ends and shutdown is forced.")
-    void testForcedShutdown() {
-      when(heartbeatMonitor.isBeating()).thenReturn(false);
-      when(process.isAlive()).thenReturn(true);
-
-      runShutdown();
-
-      verify(forceShutdown).accept(process, SHUTDOWN_TIME_DURATION);
-    }
-
-    @Test
-    @DisplayName("Test process dies.")
-    void testProcessDies() {
-      when(heartbeatMonitor.isBeating()).thenReturn(true);
-      when(process.isAlive()).thenReturn(false);
-      runShutdown();
-
-      verifyNoInteractions(forceShutdown);
-    }
-
-  }
 
   @Test
   void testMapStreamNamesToSchemasWithNullNamespace() {
@@ -140,63 +33,6 @@ class WorkerUtilsTest {
     final Map<AirbyteStreamNameNamespacePair, JsonNode> mapOutput = WorkerUtils.mapStreamNamesToSchemas(syncInput);
     assertNotNull(mapOutput.get(new AirbyteStreamNameNamespacePair("user_preferences", "namespace")));
     assertNotNull(mapOutput.get(new AirbyteStreamNameNamespacePair("user_preferences", "namespace2")));
-  }
-
-  /**
-   * As long as the the heartbeatMonitor detects a heartbeat, the process will be allowed to continue.
-   * This method checks the heartbeat once every minute. Once there is no heartbeat detected, if the
-   * process has ended, then the method returns. If the process is still running it is given a grace
-   * period of the timeout arguments passed into the method. Once those expire the process is killed
-   * forcibly. If the process cannot be killed, this method will log that this is the case, but then
-   * returns.
-   *
-   * @param process - process to monitor.
-   * @param heartbeatMonitor - tracks if the heart is still beating for the given process.
-   * @param gracefulShutdownDuration - grace period to give the process to die after its heart stops
-   *        beating.
-   * @param checkHeartbeatDuration - frequency with which the heartbeat of the process is checked.
-   * @param forcedShutdownDuration - amount of time to wait if a process needs to be destroyed
-   *        forcibly.
-   */
-  static void gentleCloseWithHeartbeat(final WorkerConfigs workerConfigs,
-                                       final Process process,
-                                       final HeartbeatMonitor heartbeatMonitor,
-                                       final Duration gracefulShutdownDuration,
-                                       final Duration checkHeartbeatDuration,
-                                       final Duration forcedShutdownDuration,
-                                       final BiConsumer<Process, Duration> forceShutdown) {
-    while (process.isAlive() && heartbeatMonitor.isBeating()) {
-      try {
-        if (workerConfigs.getWorkerEnvironment().equals(Configs.WorkerEnvironment.KUBERNETES)) {
-          LOGGER.debug("Gently closing process {} with heartbeat..", process.info().commandLine().get());
-        }
-
-        process.waitFor(checkHeartbeatDuration.toMillis(), TimeUnit.MILLISECONDS);
-      } catch (final InterruptedException e) {
-        LOGGER.error("Exception while waiting for process to finish", e);
-      }
-    }
-
-    if (process.isAlive()) {
-      try {
-        if (workerConfigs.getWorkerEnvironment().equals(Configs.WorkerEnvironment.KUBERNETES)) {
-          LOGGER.debug("Gently closing process {} without heartbeat..", process.info().commandLine().get());
-        }
-
-        process.waitFor(gracefulShutdownDuration.toMillis(), TimeUnit.MILLISECONDS);
-      } catch (final InterruptedException e) {
-        LOGGER.error("Exception during grace period for process to finish. This can happen when cancelling jobs.");
-      }
-    }
-
-    // if we were unable to exist gracefully, force shutdown...
-    if (process.isAlive()) {
-      if (workerConfigs.getWorkerEnvironment().equals(Configs.WorkerEnvironment.KUBERNETES)) {
-        LOGGER.debug("Force shutdown process {}..", process.info().commandLine().get());
-      }
-
-      forceShutdown.accept(process, forcedShutdownDuration);
-    }
   }
 
 }


### PR DESCRIPTION
## What
* We duplicate most of the logic for creating a DefaultReplicationWorker in the orchestrator and not orchestrator versions of the platform. This PR creates a factory to de-duplicate that logic.
* Is it helpful? We can close it if it doesn't feel like an improvement.