### PR TITLE
🪟 🐛 Fix JobService for jobs without attempts

### DIFF
--- a/airbyte-webapp/src/components/JobItem/components/JobLogs.module.scss
+++ b/airbyte-webapp/src/components/JobItem/components/JobLogs.module.scss
@@ -1,0 +1,5 @@
+@use "scss/variables";
+
+.jobStartFailure {
+  padding: variables.$spacing-lg;
+}

--- a/airbyte-webapp/src/components/JobItem/components/JobLogs.tsx
+++ b/airbyte-webapp/src/components/JobItem/components/JobLogs.tsx
@@ -5,12 +5,14 @@ import { useLocation } from "react-router-dom";
 
 import { StatusIcon } from "components/ui/StatusIcon";
 import { StatusIconStatus } from "components/ui/StatusIcon/StatusIcon";
+import { Text } from "components/ui/Text";
 
 import { JobsWithJobs } from "pages/ConnectionPage/pages/ConnectionItemPage/JobsList";
 import { useGetDebugInfoJob } from "services/job/JobService";
 
 import { AttemptRead, AttemptStatus, SynchronousJobRead } from "../../../core/request/AirbyteClient";
 import { parseAttemptLink } from "../attemptLinkUtils";
+import styles from "./JobLogs.module.scss";
 import Logs from "./Logs";
 import { LogsDetails } from "./LogsDetails";
 import Tabs, { TabsData } from "./Tabs";
@@ -83,22 +85,28 @@ const JobLogs: React.FC<JobLogsProps> = ({ jobIsFailed, job }) => {
 
   return (
     <>
-      {attempts > 1 ? (
+      {attempts > 1 && (
         <Tabs
           activeStep={attemptNumber.toString()}
           onSelect={(at) => setAttemptNumber(parseInt(at))}
           data={attemptsTabs}
           isFailed={jobIsFailed}
         />
-      ) : null}
-      <LogsDetails
-        id={job.job.id}
-        path={path}
-        currentAttempt={currentAttempt}
-        jobDebugInfo={debugInfo}
-        showAttemptStats={attempts > 1}
-        logs={debugInfo?.attempts[attemptNumber]?.logs.logLines}
-      />
+      )}
+      {attempts ? (
+        <LogsDetails
+          id={job.job.id}
+          path={path}
+          currentAttempt={currentAttempt}
+          jobDebugInfo={debugInfo}
+          showAttemptStats={attempts > 1}
+          logs={debugInfo?.attempts[attemptNumber]?.logs.logLines}
+        />
+      ) : (
+        <Text size="md" className={styles.jobStartFailure}>
+          <FormattedMessage id="jobs.noAttemptsFailure" />
+        </Text>
+      )}
     </>
   );
 };

--- a/airbyte-webapp/src/locales/en.json
+++ b/airbyte-webapp/src/locales/en.json
@@ -663,5 +663,7 @@
   "connectorBuilder.resetAll": "Reset all",
   "connectorBuilder.emptyName": "(empty)",
 
+  "jobs.noAttemptsFailure": "Failed to start job.",
+
   "cloudApi.loginCallbackUrlError": "There was an error connecting to the developer portal. Please try again."
 }

--- a/airbyte-webapp/src/services/job/JobService.tsx
+++ b/airbyte-webapp/src/services/job/JobService.tsx
@@ -69,7 +69,8 @@ export const useGetDebugInfoJob = (
           // If refetchWhileRunning was true, we keep refetching debug info (including logs), while the job is still
           // running or hasn't ended too long ago. We need some time after the last attempt has stopped, since logs
           // keep incoming for some time after the job has already been marked as finished.
-          const lastAttemptEndTimestamp = data?.attempts[data.attempts.length - 1].attempt.endedAt;
+          const lastAttemptEndTimestamp =
+            data?.attempts.length && data.attempts[data.attempts.length - 1].attempt.endedAt;
           // While no attempt ended timestamp exists yet (i.e. the job is still running) or it hasn't ended
           // more than 2 minutes (2 * 60 * 1000ms) ago, keep refetching
           return lastAttemptEndTimestamp && Date.now() - lastAttemptEndTimestamp * 1000 > 2 * 60 * 1000 ? false : 2500;


### PR DESCRIPTION
## What

There are sometimes jobs that don't have any attempts (yet). When we load them this code broke, since we tried to access `attempt.endedAt` on `undefined` now. Fixed this to make sure we have any attempts actually before trying to get the last one.

Since we can't fetch any logs in this case, we're actually just showing now a simple error message when the job is expanded:

![screenshot-20221215-202147](https://user-images.githubusercontent.com/877229/207948754-09d1d59a-5534-47fa-bbae-efa04f7c6180.png)


The code below that line already handled the case when `lastAttemptEndTimestamp` is undefined.