### PR TITLE
airbyte-workers copyGeneratedTar depends on generateWellKnownTypes

### DIFF
--- a/airbyte-workers/build.gradle
+++ b/airbyte-workers/build.gradle
@@ -133,6 +133,12 @@ task generateWellKnownTypes() {
 
 tasks.named("buildDockerImage") {
     dependsOn copyGeneratedTar
+}
+
+// Ideally, we would have buildDockerImage depend on generateWellKnownTypes
+// but some of our actions use copyGeneratedTar as the "set up the docker build context" task
+// so we'll just add it here.
+tasks.named("copyGeneratedTar") {
     dependsOn generateWellKnownTypes
 }
 


### PR DESCRIPTION
fix for https://github.com/airbytehq/airbyte/actions/runs/3705267099/jobs/6279243380#step:7:366

specifically https://github.com/airbytehq/airbyte/actions/runs/3705267099/workflow#L147 - this is where we invoke copyGenerateTar, as preparation for a `docker buildx bake`

in my continued adventures to add a single file to a docker image 😓 