### PR TITLE
bump CDK dependency of snapchat-marketing

### DIFF
--- a/airbyte-config/init/src/main/resources/seed/source_definitions.yaml
+++ b/airbyte-config/init/src/main/resources/seed/source_definitions.yaml
@@ -1530,7 +1530,7 @@
 - name: Snapchat Marketing
   sourceDefinitionId: 200330b2-ea62-4d11-ac6d-cfe3e3f8ab2b
   dockerRepository: airbyte/source-snapchat-marketing
-  dockerImageTag: 0.1.9
+  dockerImageTag: 0.1.10
   documentationUrl: https://docs.airbyte.com/integrations/sources/snapchat-marketing
   icon: snapchat.svg
   sourceType: api

--- a/airbyte-config/init/src/main/resources/seed/source_specs.yaml
+++ b/airbyte-config/init/src/main/resources/seed/source_specs.yaml
@@ -13589,7 +13589,7 @@
     supportsNormalization: false
     supportsDBT: false
     supported_destination_sync_modes: []
-- dockerImage: "airbyte/source-snapchat-marketing:0.1.9"
+- dockerImage: "airbyte/source-snapchat-marketing:0.1.10"
   spec:
     documentationUrl: "https://docs.airbyte.com/integrations/sources/snapchat-marketing"
     connectionSpecification:

--- a/airbyte-integrations/connectors/source-snapchat-marketing/Dockerfile
+++ b/airbyte-integrations/connectors/source-snapchat-marketing/Dockerfile
@@ -25,5 +25,5 @@ COPY source_snapchat_marketing ./source_snapchat_marketing
 ENV AIRBYTE_ENTRYPOINT "python /airbyte/integration_code/main.py"
 ENTRYPOINT ["python", "/airbyte/integration_code/main.py"]
 
-LABEL io.airbyte.version=0.1.9
+LABEL io.airbyte.version=0.1.10
 LABEL io.airbyte.name=airbyte/source-snapchat-marketing

--- a/docs/integrations/sources/snapchat-marketing.md
+++ b/docs/integrations/sources/snapchat-marketing.md
@@ -113,7 +113,8 @@ Snapchat Marketing API has limitations to 1000 items per page.
 
 | Version | Date       | Pull Request                                             | Subject                                               |
 |:--------|:-----------|:---------------------------------------------------------|:------------------------------------------------------|
-| 0.1.9   | 2022-12-14 | [20498](https://github.com/airbytehq/airbyte/pull/20498)      | Fix output state when no records are read             |
+| 0.1.10  | 2022-12-15 | [20530](https://github.com/airbytehq/airbyte/pull/20530) | Run on CDK 0.15.0                                     |
+| 0.1.9   | 2022-12-14 | [20498](https://github.com/airbytehq/airbyte/pull/20498) | Fix output state when no records are read             |
 | 0.1.8   | 2022-10-05 | [17596](https://github.com/airbytehq/airbyte/pull/17596) | Retry 429 and 5xx errors when refreshing access token |
 | 0.1.6   | 2022-07-21 | [14924](https://github.com/airbytehq/airbyte/pull/14924) | Remove `additionalProperties` field from specs        |
 | 0.1.5   | 2022-07-13 | [14577](https://github.com/airbytehq/airbyte/pull/14577) | Added stats streams hourly, daily, lifetime           |

--- a/docs/integrations/sources/snapchat-marketing.md
+++ b/docs/integrations/sources/snapchat-marketing.md
@@ -113,7 +113,7 @@ Snapchat Marketing API has limitations to 1000 items per page.
 
 | Version | Date       | Pull Request                                             | Subject                                               |
 |:--------|:-----------|:---------------------------------------------------------|:------------------------------------------------------|
-| 0.1.10  | 2022-12-15 | [20536](https://github.com/airbytehq/airbyte/pull/20536) | Run on CDK 0.15.0                                     |
+| 0.1.10  | 2022-12-15 | [20537](https://github.com/airbytehq/airbyte/pull/20537) | Run on CDK 0.15.0                                     |
 | 0.1.9   | 2022-12-14 | [20498](https://github.com/airbytehq/airbyte/pull/20498) | Fix output state when no records are read             |
 | 0.1.8   | 2022-10-05 | [17596](https://github.com/airbytehq/airbyte/pull/17596) | Retry 429 and 5xx errors when refreshing access token |
 | 0.1.6   | 2022-07-21 | [14924](https://github.com/airbytehq/airbyte/pull/14924) | Remove `additionalProperties` field from specs        |

--- a/docs/integrations/sources/snapchat-marketing.md
+++ b/docs/integrations/sources/snapchat-marketing.md
@@ -113,7 +113,7 @@ Snapchat Marketing API has limitations to 1000 items per page.
 
 | Version | Date       | Pull Request                                             | Subject                                               |
 |:--------|:-----------|:---------------------------------------------------------|:------------------------------------------------------|
-| 0.1.10  | 2022-12-15 | [20530](https://github.com/airbytehq/airbyte/pull/20530) | Run on CDK 0.15.0                                     |
+| 0.1.10  | 2022-12-15 | [20536](https://github.com/airbytehq/airbyte/pull/20536) | Run on CDK 0.15.0                                     |
 | 0.1.9   | 2022-12-14 | [20498](https://github.com/airbytehq/airbyte/pull/20498) | Fix output state when no records are read             |
 | 0.1.8   | 2022-10-05 | [17596](https://github.com/airbytehq/airbyte/pull/17596) | Retry 429 and 5xx errors when refreshing access token |
 | 0.1.6   | 2022-07-21 | [14924](https://github.com/airbytehq/airbyte/pull/14924) | Remove `additionalProperties` field from specs        |


### PR DESCRIPTION
Separated out, see passing tests [here](https://github.com/airbytehq/airbyte/pull/20530#issuecomment-1353509756)