### PR TITLE
Octavia Segment MTU fix

### DIFF
--- a/octavia-cli/octavia_cli/telemetry.py
+++ b/octavia-cli/octavia_cli/telemetry.py
@@ -3,7 +3,6 @@
 #
 
 import os
-import uuid
 from typing import Optional
 
 import analytics

--- a/octavia-cli/octavia_cli/telemetry.py
+++ b/octavia-cli/octavia_cli/telemetry.py
@@ -75,7 +75,8 @@ class TelemetryClient:
             error (Optional[Exception], optional): The error that was raised. Defaults to None.
             extra_info_name (Optional[str], optional): Extra info name if the context was not built yet. Defaults to None.
         """
-        user_id = ctx.obj.get("WORKSPACE_ID") if ctx.obj.get("ANONYMOUS_DATA_COLLECTION", True) is False else "anonymous"
+        user_id = ctx.obj.get("WORKSPACE_ID") if ctx.obj.get("ANONYMOUS_DATA_COLLECTION", True) is False else None
+        anonymous_user_id = "anonymous" if not user_id else None
         segment_context = {"app": {"name": "octavia-cli", "version": ctx.obj.get("OCTAVIA_VERSION")}}
         segment_properties = {
             "success": error is None,
@@ -86,5 +87,5 @@ class TelemetryClient:
         }
         command_name = self._create_command_name(ctx, extra_info_name=extra_info_name)
         self.segment_client.track(
-            user_id=user_id, anonymous_id=None, event=command_name, properties=segment_properties, context=segment_context
+            user_id=user_id, anonymous_id=anonymous_user_id, event=command_name, properties=segment_properties, context=segment_context
         )

--- a/octavia-cli/octavia_cli/telemetry.py
+++ b/octavia-cli/octavia_cli/telemetry.py
@@ -76,7 +76,7 @@ class TelemetryClient:
             extra_info_name (Optional[str], optional): Extra info name if the context was not built yet. Defaults to None.
         """
         user_id = ctx.obj.get("WORKSPACE_ID") if ctx.obj.get("ANONYMOUS_DATA_COLLECTION", True) is False else None
-        anonymous_user_id = "anonymous" if not user_id else None
+        anonymous_user_id = None if user_id else "anonymous"
         segment_context = {"app": {"name": "octavia-cli", "version": ctx.obj.get("OCTAVIA_VERSION")}}
         segment_properties = {
             "success": error is None,

--- a/octavia-cli/octavia_cli/telemetry.py
+++ b/octavia-cli/octavia_cli/telemetry.py
@@ -76,8 +76,7 @@ class TelemetryClient:
             error (Optional[Exception], optional): The error that was raised. Defaults to None.
             extra_info_name (Optional[str], optional): Extra info name if the context was not built yet. Defaults to None.
         """
-        user_id = ctx.obj.get("WORKSPACE_ID") if ctx.obj.get("ANONYMOUS_DATA_COLLECTION", True) is False else None
-        anonymous_id = None if user_id else str(uuid.uuid1())
+        user_id = ctx.obj.get("WORKSPACE_ID") if ctx.obj.get("ANONYMOUS_DATA_COLLECTION", True) is False else "anonymous"
         segment_context = {"app": {"name": "octavia-cli", "version": ctx.obj.get("OCTAVIA_VERSION")}}
         segment_properties = {
             "success": error is None,
@@ -88,5 +87,5 @@ class TelemetryClient:
         }
         command_name = self._create_command_name(ctx, extra_info_name=extra_info_name)
         self.segment_client.track(
-            user_id=user_id, anonymous_id=anonymous_id, event=command_name, properties=segment_properties, context=segment_context
+            user_id=user_id, anonymous_id=None, event=command_name, properties=segment_properties, context=segment_context
         )

--- a/octavia-cli/octavia_cli/telemetry.py
+++ b/octavia-cli/octavia_cli/telemetry.py
@@ -76,7 +76,7 @@ class TelemetryClient:
             extra_info_name (Optional[str], optional): Extra info name if the context was not built yet. Defaults to None.
         """
         user_id = ctx.obj.get("WORKSPACE_ID") if ctx.obj.get("ANONYMOUS_DATA_COLLECTION", True) is False else None
-        anonymous_user_id = None if user_id else "anonymous"
+        anonymous_id = None if user_id else "anonymous"
         segment_context = {"app": {"name": "octavia-cli", "version": ctx.obj.get("OCTAVIA_VERSION")}}
         segment_properties = {
             "success": error is None,
@@ -87,5 +87,5 @@ class TelemetryClient:
         }
         command_name = self._create_command_name(ctx, extra_info_name=extra_info_name)
         self.segment_client.track(
-            user_id=user_id, anonymous_id=anonymous_user_id, event=command_name, properties=segment_properties, context=segment_context
+            user_id=user_id, anonymous_id=anonymous_id, event=command_name, properties=segment_properties, context=segment_context
         )

--- a/octavia-cli/unit_tests/test_telemetry.py
+++ b/octavia-cli/unit_tests/test_telemetry.py
@@ -92,7 +92,8 @@ class TestTelemetryClient:
     ):
         extra_info_name = "foo"
         mocker.patch.object(telemetry.os, "getenv", mocker.Mock(return_value=airbyte_role))
-        expected_user_id = workspace_id if workspace_id is not None and anonymous_data_collection is False else "anonymous"
+        expected_user_id = workspace_id if workspace_id is not None and anonymous_data_collection is False else None
+        expected_anonymous_id = "anonymous" if expected_user_id is None else None
         mock_ctx = mocker.Mock(
             obj={
                 "OCTAVIA_VERSION": octavia_version,
@@ -116,7 +117,7 @@ class TestTelemetryClient:
         telemetry_client._create_command_name.assert_called_with(mock_ctx, extra_info_name=extra_info_name)
         telemetry_client.segment_client.track.assert_called_with(
             user_id=expected_user_id,
-            anonymous_id=None,
+            anonymous_id=expected_anonymous_id,
             event="my_command",
             properties=expected_properties,
             context=expected_segment_context,

--- a/octavia-cli/unit_tests/test_telemetry.py
+++ b/octavia-cli/unit_tests/test_telemetry.py
@@ -92,9 +92,7 @@ class TestTelemetryClient:
     ):
         extra_info_name = "foo"
         mocker.patch.object(telemetry.os, "getenv", mocker.Mock(return_value=airbyte_role))
-        mocker.patch.object(telemetry.uuid, "uuid1", mocker.Mock(return_value="MY_UUID"))
-        expected_user_id = workspace_id if workspace_id is not None and anonymous_data_collection is False else None
-        expected_anonymous_id = "MY_UUID" if expected_user_id is None else None
+        expected_user_id = workspace_id if workspace_id is not None and anonymous_data_collection is False else "anonymous"
         mock_ctx = mocker.Mock(
             obj={
                 "OCTAVIA_VERSION": octavia_version,
@@ -118,7 +116,7 @@ class TestTelemetryClient:
         telemetry_client._create_command_name.assert_called_with(mock_ctx, extra_info_name=extra_info_name)
         telemetry_client.segment_client.track.assert_called_with(
             user_id=expected_user_id,
-            anonymous_id=expected_anonymous_id,
+            anonymous_id=None,
             event="my_command",
             properties=expected_properties,
             context=expected_segment_context,


### PR DESCRIPTION
## What
*Describe what the change is solving*
Preventing 1 new MTU per anonymous CLI usage
## How
*Describe the solution*
Instead of generating a random UUID for each user, we will instead just set their user ID to "anonymous".
We lose nothing since we're already unable to break down anonymous requests by user.

## 🚨 User Impact 🚨
None

## Pre-merge Checklist
Expand the relevant checklist and delete the others.

<details><summary><strong>New Connector</strong></summary>

### Airbyter

If this is a community PR, the Airbyte engineer reviewing this PR is responsible for the below items.

- [ ] Create a non-forked branch based on this PR and test the below items on it
- [ ] Build is successful
- [ ] If new credentials are required for use in CI, add them to GSM. [Instructions](https://docs.airbyte.io/connector-development#using-credentials-in-ci).
- [ ] [`/test connector=connectors/<name>` command](https://docs.airbyte.io/connector-development#updating-an-existing-connector) is passing
- [ ] New Connector version released on Dockerhub by running the `/publish` command described [here](https://docs.airbyte.io/connector-development#updating-an-existing-connector)
- [ ] After the connector is published, connector added to connector index as described [here](https://docs.airbyte.io/connector-development#publishing-a-connector)
- [ ] Seed specs have been re-generated by building the platform and committing the changes to the seed spec files, as described [here](https://docs.airbyte.io/connector-development#publishing-a-connector)

</details>

<details><summary><strong>Updating a connector</strong></summary>

### Community member or Airbyter

- [ ] Grant edit access to maintainers ([instructions](https://docs.github.com/en/github/collaborating-with-pull-requests/working-with-forks/allowing-changes-to-a-pull-request-branch-created-from-a-fork#enabling-repository-maintainer-permissions-on-existing-pull-requests))
- [ ] Secrets in the connector's spec are annotated with `airbyte_secret`
- [ ] Unit & integration tests added and passing. Community members, please provide proof of success locally e.g: screenshot or copy-paste unit, integration, and acceptance test output. To run acceptance tests for a Python connector, follow instructions in the README. For java connectors run `./gradlew :airbyte-integrations:connectors:<name>:integrationTest`.
- [ ] Code reviews completed
- [ ] Documentation updated
    - [ ] Connector's `README.md`
    - [ ] Connector's `bootstrap.md`. See [description and examples](https://docs.google.com/document/d/1ypdgmwmEHWv-TrO4_YOQ7pAJGVrMp5BOkEVh831N260/edit?usp=sharing)
    - [ ] Changelog updated in `docs/integrations/<source or destination>/<name>.md` including changelog. See changelog [example](https://docs.airbyte.io/integrations/sources/stripe#changelog)
- [ ] PR name follows [PR naming conventions](https://docs.airbyte.com/contributing-to-airbyte/issues-and-pull-requests)

### Airbyter

If this is a community PR, the Airbyte engineer reviewing this PR is responsible for the below items.

- [ ] Create a non-forked branch based on this PR and test the below items on it
- [ ] Build is successful
- [ ] If new credentials are required for use in CI, add them to GSM. [Instructions](https://docs.airbyte.io/connector-development#using-credentials-in-ci).
- [ ] [`/test connector=connectors/<name>` command](https://docs.airbyte.io/connector-development#updating-an-existing-connector) is passing
- [ ] New Connector version released on Dockerhub and connector version bumped by running the `/publish` command described [here](https://docs.airbyte.io/connector-development#updating-an-existing-connector)

</details>

<details><summary><strong>Connector Generator</strong></summary>

- [ ] Issue acceptance criteria met
- [ ] PR name follows [PR naming conventions](https://docs.airbyte.com/contributing-to-airbyte/issues-and-pull-requests)
- [ ] If adding a new generator, add it to the [list of scaffold modules being tested](https://github.com/airbytehq/airbyte/blob/master/airbyte-integrations/connector-templates/generator/build.gradle#L41)
- [ ] The generator test modules (all connectors with `-scaffold` in their name) have been updated with the latest scaffold by running `./gradlew :airbyte-integrations:connector-templates:generator:testScaffoldTemplates` then checking in your changes
- [ ] Documentation which references the generator is updated as needed

</details>

## Tests

<details><summary><strong>Unit</strong></summary>

> Task :octavia-cli:_unitTestCoverage
[python] .venv/bin/python -m coverage run --data-file=unit_tests/.coverage.unitTest --rcfile=/Users/jon/Documents/code/airbyte/pyproject.toml -m pytest -s unit_tests -c pytest.ini
         ============================= test session starts ==============================
         platform darwin -- Python 3.9.11, pytest-6.2.5, py-1.11.0, pluggy-1.0.0
         rootdir: /Users/jon/Documents/code/airbyte/octavia-cli/unit_tests, configfile: ../pytest.ini
         plugins: mock-3.10.0, recording-0.12.1, requests-mock-1.10.0, cov-4.0.0
         collected 332 items

         unit_tests/test_api_http_headers.py::TestApiHttpHeader::test_init[foo-bar-None-foo-bar] PASSED
         unit_tests/test_api_http_headers.py::TestApiHttpHeader::test_init[ foo - bar -None-foo-bar] PASSED
         unit_tests/test_api_http_headers.py::TestApiHttpHeader::test_init[-bar-AttributeError-None-None] PASSED
         unit_tests/test_api_http_headers.py::TestApiHttpHeader::test_init[foo--AttributeError-None-None] PASSED
         unit_tests/test_api_http_headers.py::test_deserialize_file_based_headers[\n    headers:\n      Content-Type: ${API_HTTP_HEADER_IN_ENV_VAR}\n    -expected_api_http_headers0-None] PASSED
         unit_tests/test_api_http_headers.py::test_deserialize_file_based_headers[\n    headers:\n      Content-Type: application/json\n    -expected_api_http_headers1-None] PASSED
         unit_tests/test_api_http_headers.py::test_deserialize_file_based_headers[\n    headers:\n      Content-Type: application/csv\n      Content-Type: application/json\n    -expected_api_http_headers2-None] PASSED
         unit_tests/test_api_http_headers.py::test_deserialize_file_based_headers[\n    headers:\n      Content-Type: application/json\n      Authorization: Bearer XXX\n    -expected_api_http_headers3-None] PASSED
         unit_tests/test_api_http_headers.py::test_deserialize_file_based_headers[no_headers: foo-None-InvalidApiHttpHeadersFileError] PASSED
         unit_tests/test_api_http_headers.py::test_deserialize_file_based_headers[-None-InvalidApiHttpHeadersFileError] PASSED
         unit_tests/test_api_http_headers.py::test_deserialize_file_based_headers[some random words\n     - some dashes:\n      - and_next-None-InvalidApiHttpHeadersFileError] PASSED
         unit_tests/test_api_http_headers.py::test_deserialize_option_based_headers[option_based_headers0-expected_option_based_headers0] PASSED
         unit_tests/test_api_http_headers.py::test_deserialize_option_based_headers[option_based_headers1-expected_option_based_headers1] PASSED
         unit_tests/test_api_http_headers.py::test_deserialize_option_based_headers[option_based_headers2-expected_option_based_headers2] PASSED
         unit_tests/test_api_http_headers.py::test_deserialize_option_based_headers[option_based_headers3-expected_option_based_headers3] PASSED
         unit_tests/test_api_http_headers.py::test_merge_api_headers[\n    headers:\n      Content-Type: application/csv\n    -option_based_raw_headers0-expected_merged_headers0] PASSED
         unit_tests/test_api_http_headers.py::test_merge_api_headers[None-option_based_raw_headers1-expected_merged_headers1] PASSED
         unit_tests/test_api_http_headers.py::test_merge_api_headers[\n    headers:\n      Content-Type: application/json\n    -option_based_raw_headers2-expected_merged_headers2] PASSED
         unit_tests/test_api_http_headers.py::test_merge_api_headers[\n    headers:\n      Content-Type: application/json\n    -None-expected_merged_headers3] PASSED
         unit_tests/test_api_http_headers.py::test_merge_api_headers[\n    headers:\n      Content-Type: application/json\n    -option_based_raw_headers4-expected_merged_headers4] PASSED
         unit_tests/test_api_http_headers.py::test_merge_api_headers[\n    headers:\n      Content-Type: application/json\n      Foo: Bar\n    -option_based_raw_headers5-expected_merged_headers5] PASSED
         unit_tests/test_api_http_headers.py::test_set_api_headers_on_api_client PASSED
         unit_tests/test_base_commands.py::TestOctaviaCommand::test_make_context PASSED
         unit_tests/test_base_commands.py::TestOctaviaCommand::test_make_context_error[error0] PASSED
         unit_tests/test_base_commands.py::TestOctaviaCommand::test_make_context_error[error1] PASSED
         unit_tests/test_base_commands.py::TestOctaviaCommand::test_make_context_error[error2] PASSED
         unit_tests/test_base_commands.py::TestOctaviaCommand::test_invoke PASSED
         unit_tests/test_base_commands.py::TestOctaviaCommand::test_invoke_error PASSED
         unit_tests/test_check_context.py::test_api_check_health_available PASSED
         unit_tests/test_check_context.py::test_api_check_health_unavailable PASSED
         unit_tests/test_check_context.py::test_api_check_health_unreachable_api_exception PASSED
         unit_tests/test_check_context.py::test_api_check_health_unreachable_max_retry_error PASSED
         unit_tests/test_check_context.py::test_check_workspace_exists PASSED
         unit_tests/test_check_context.py::test_check_workspace_exists_error PASSED
         unit_tests/test_check_context.py::test_check_is_initialized PASSED
         unit_tests/test_check_context.py::test_check_not_initialized PASSED
         unit_tests/test_entrypoint.py::test_set_context_object[option_based_api_http_headers0-api_http_headers_file_path] PASSED
         unit_tests/test_entrypoint.py::test_set_context_object[option_based_api_http_headers1-None] PASSED
         unit_tests/test_entrypoint.py::test_set_context_object[None-None] PASSED
         unit_tests/test_entrypoint.py::test_set_context_object_error PASSED
         unit_tests/test_entrypoint.py::test_octavia[options0-0] PASSED
         unit_tests/test_entrypoint.py::test_octavia[options1-0] PASSED
         unit_tests/test_entrypoint.py::test_octavia[options2-2] PASSED
         unit_tests/test_entrypoint.py::test_octavia[options3-0] PASSED
         unit_tests/test_entrypoint.py::test_octavia[options4-2] PASSED
         unit_tests/test_entrypoint.py::test_octavia[options5-0] PASSED
         unit_tests/test_entrypoint.py::test_octavia[options6-0] PASSED
         unit_tests/test_entrypoint.py::test_octavia[options7-0] PASSED
         unit_tests/test_entrypoint.py::test_octavia[options8-2] PASSED
         unit_tests/test_entrypoint.py::test_octavia_not_initialized PASSED
         unit_tests/test_entrypoint.py::test_get_api_client[None] PASSED
         unit_tests/test_entrypoint.py::test_get_api_client[api_http_headers1] PASSED
         unit_tests/test_entrypoint.py::test_get_api_client[api_http_headers2] PASSED
         unit_tests/test_entrypoint.py::test_get_api_client[api_http_headers3] PASSED
         unit_tests/test_entrypoint.py::test_get_workspace_id_user_defined PASSED
         unit_tests/test_entrypoint.py::test_get_workspace_id_api_defined PASSED
         unit_tests/test_entrypoint.py::test_get_anonymous_data_collection PASSED
         unit_tests/test_entrypoint.py::test_commands_in_octavia_group PASSED
         unit_tests/test_entrypoint.py::test_not_implemented_commands[command0] PASSED
         unit_tests/test_entrypoint.py::test_available_commands PASSED
         unit_tests/test_telemetry.py::test_build_user_agent PASSED
         unit_tests/test_telemetry.py::TestTelemetryClient::test_init[True] PASSED
         unit_tests/test_telemetry.py::TestTelemetryClient::test_init[False] PASSED
         unit_tests/test_telemetry.py::TestTelemetryClient::test_write_key[my_custom_write_key] PASSED
         unit_tests/test_telemetry.py::TestTelemetryClient::test_write_key[None] PASSED
         unit_tests/test_telemetry.py::TestTelemetryClient::test__create_command_name_multi_contexts[foo] PASSED
         unit_tests/test_telemetry.py::TestTelemetryClient::test__create_command_name_multi_contexts[None] PASSED
         unit_tests/test_telemetry.py::TestTelemetryClient::test__create_command_name_single_context[foo] PASSED
         unit_tests/test_telemetry.py::TestTelemetryClient::test__create_command_name_single_context[None] PASSED
         unit_tests/test_telemetry.py::TestTelemetryClient::test_send_command_telemetry[None-None-None-None-None-None-True-None-False] PASSED
         unit_tests/test_telemetry.py::TestTelemetryClient::test_send_command_telemetry[None-None-None-None-None-error1-False-Exception-False] PASSED
         unit_tests/test_telemetry.py::TestTelemetryClient::test_send_command_telemetry[None-None-None-None-None-error2-False-AttributeError-False] PASSED
         unit_tests/test_telemetry.py::TestTelemetryClient::test_send_command_telemetry[None-True-None-None-None-None-True-None-False] PASSED
         unit_tests/test_telemetry.py::TestTelemetryClient::test_send_command_telemetry[None-True-None-None-None-error4-False-Exception-False] PASSED
         unit_tests/test_telemetry.py::TestTelemetryClient::test_send_command_telemetry[None-True-None-None-None-error5-False-AttributeError-False] PASSED
         unit_tests/test_telemetry.py::TestTelemetryClient::test_send_command_telemetry[my_workspace_id-False-None-None-None-None-True-None-False] PASSED
         unit_tests/test_telemetry.py::TestTelemetryClient::test_send_command_telemetry[my_workspace_id-False-None-None-None-error7-False-Exception-False] PASSED
         unit_tests/test_telemetry.py::TestTelemetryClient::test_send_command_telemetry[my_workspace_id-True-None-None-None-None-True-None-False] PASSED
         unit_tests/test_telemetry.py::TestTelemetryClient::test_send_command_telemetry[my_workspace_id-True-None-None-None-error9-False-Exception-False] PASSED
         unit_tests/test_telemetry.py::TestTelemetryClient::test_send_command_telemetry[my_workspace_id-True-airbyter-None-None-None-True-None-False] PASSED
         unit_tests/test_telemetry.py::TestTelemetryClient::test_send_command_telemetry[my_workspace_id-True-non_airbyter-None-None-error11-False-Exception-False] PASSED
         unit_tests/test_telemetry.py::TestTelemetryClient::test_send_command_telemetry[my_workspace_id-True-airbyter-True-None-None-True-None-False0] PASSED
         unit_tests/test_telemetry.py::TestTelemetryClient::test_send_command_telemetry[my_workspace_id-True-non_airbyter-False-None-error13-False-Exception-False] PASSED
         unit_tests/test_telemetry.py::TestTelemetryClient::test_send_command_telemetry[my_workspace_id-True-airbyter-True-None-None-True-None-False1] PASSED
         unit_tests/test_telemetry.py::TestTelemetryClient::test_send_command_telemetry[my_workspace_id-True-non_airbyter-False-0.1.0-error15-False-Exception-False] PASSED
         unit_tests/test_telemetry.py::TestTelemetryClient::test_send_command_telemetry[my_workspace_id-True-non_airbyter-False-0.1.0-None-True-None-False] PASSED
         unit_tests/test_telemetry.py::TestTelemetryClient::test_send_command_telemetry[my_workspace_id-True-non_airbyter-False-0.1.0-None-True-None-True] PASSED
         unit_tests/test__import/test_commands.py::test_build_help_message PASSED
         unit_tests/test__import/test_commands.py::test_import_source_or_destination[Source] PASSED
         unit_tests/test__import/test_commands.py::test_import_source_or_destination[Destination] PASSED
         unit_tests/test__import/test_commands.py::test_import_connection[True-True-True-True] PASSED
         unit_tests/test__import/test_commands.py::test_import_connection[False-False-False-False] PASSED
         unit_tests/test__import/test_commands.py::test_import_connection[True-False-True-False] PASSED
         unit_tests/test__import/test_commands.py::test_import_connection[True-True-False-False] PASSED
         unit_tests/test__import/test_commands.py::test_import_connection[True-True-True-False] PASSED
         unit_tests/test__import/test_commands.py::test_import_not_initialized[command0] PASSED
         unit_tests/test__import/test_commands.py::test_import_not_initialized[command1] PASSED
         unit_tests/test__import/test_commands.py::test_import_not_initialized[command2] PASSED
         unit_tests/test__import/test_commands.py::test_import_not_initialized[command3] PASSED
         unit_tests/test__import/test_commands.py::test_import_commands[command0-Source-import_source_or_destination] PASSED
         unit_tests/test__import/test_commands.py::test_import_commands[command1-Destination-import_source_or_destination] PASSED
         unit_tests/test__import/test_commands.py::test_import_commands[command2-None-import_connection] PASSED
         unit_tests/test__import/test_commands.py::test_import_all PASSED
         unit_tests/test_apply/test_commands.py::test_apply_not_initialized PASSED
         unit_tests/test_apply/test_commands.py::test_apply_without_custom_configuration_file PASSED
         unit_tests/test_apply/test_commands.py::test_apply_with_custom_configuration_file PASSED
         unit_tests/test_apply/test_commands.py::test_apply_with_custom_configuration_file_force PASSED
         unit_tests/test_apply/test_commands.py::test_get_resource_to_apply PASSED
         unit_tests/test_apply/test_commands.py::test_apply_single_resource[True] PASSED
         unit_tests/test_apply/test_commands.py::test_apply_single_resource[False] PASSED
         unit_tests/test_apply/test_commands.py::test_should_update_resource[1 - Check if force has the top priority.] PASSED
         unit_tests/test_apply/test_commands.py::test_should_update_resource[2 - Check if force has the top priority.] PASSED
         unit_tests/test_apply/test_commands.py::test_should_update_resource[3 - Check if force has the top priority.] PASSED
         unit_tests/test_apply/test_commands.py::test_should_update_resource[4 - Check if force has the top priority.] PASSED
         unit_tests/test_apply/test_commands.py::test_should_update_resource[Check if user validation has priority over local file change.0] PASSED
         unit_tests/test_apply/test_commands.py::test_should_update_resource[Check if user validation has priority over local file change.1] PASSED
         unit_tests/test_apply/test_commands.py::test_should_update_resource[Check if local_file_changed runs even if user validation is None.] PASSED
         unit_tests/test_apply/test_commands.py::test_should_update_resource[Check no update if no local change and user validation is None.] PASSED
         unit_tests/test_apply/test_commands.py::test_prompt_for_diff_validation[-0] PASSED
         unit_tests/test_apply/test_commands.py::test_prompt_for_diff_validation[First diff line-1] PASSED
         unit_tests/test_apply/test_commands.py::test_prompt_for_diff_validation[First diff line\nSecond diff line-2] PASSED
         unit_tests/test_apply/test_commands.py::test_prompt_for_diff_validation[First diff line\nSecond diff line\nThird diff line-3] PASSED
         unit_tests/test_apply/test_commands.py::test_create_resource PASSED
         unit_tests/test_apply/test_commands.py::test_update_resource[Force, diff, local file change -> no prompt, no validation, expect update.] PASSED
         unit_tests/test_apply/test_commands.py::test_update_resource[Force, diff, no local file change -> no prompt, no validation, expect update.] PASSED
         unit_tests/test_apply/test_commands.py::test_update_resource[Force, no diff, no local file change -> no prompt, no validation, expect update.] PASSED
         unit_tests/test_apply/test_commands.py::test_update_resource[Force, no diff, local file change -> no prompt, no validation, expect update.] PASSED
         unit_tests/test_apply/test_commands.py::test_update_resource[No force, diff, local file change -> expect prompt, validation, expect update.] PASSED
         unit_tests/test_apply/test_commands.py::test_update_resource[No force, diff, local file change -> expect prompt, no validation, no update.] PASSED
         unit_tests/test_apply/test_commands.py::test_update_resource[No force, diff, no local file change -> expect prompt, validation, expect update.] PASSED
         unit_tests/test_apply/test_commands.py::test_update_resource[No force, diff, no local file change -> expect prompt, no validation, no update.] PASSED
         unit_tests/test_apply/test_commands.py::test_update_resource[No force, no diff, local file change -> no prompt, no validation, expect update.] PASSED
         unit_tests/test_apply/test_commands.py::test_update_resource[No force, no diff, no local file change -> no prompt, no validation, no update.] PASSED
         unit_tests/test_apply/test_commands.py::test_find_local_configuration_files PASSED
         unit_tests/test_apply/test_commands.py::test_find_local_configuration_files_no_file_found PASSED
         unit_tests/test_apply/test_diff_helpers.py::test_hash_config PASSED
         unit_tests/test_apply/test_diff_helpers.py::test_exclude_secrets_from_diff[**********-True] PASSED
         unit_tests/test_apply/test_diff_helpers.py::test_exclude_secrets_from_diff[not secret-False] PASSED
         unit_tests/test_apply/test_diff_helpers.py::test_exclude_secrets_from_diff[obj2-False] PASSED
         unit_tests/test_apply/test_diff_helpers.py::test_compute_diff PASSED
         unit_tests/test_apply/test_diff_helpers.py::test_display_diff_line[resource changed from-E - resource changed from-yellow] PASSED
         unit_tests/test_apply/test_diff_helpers.py::test_display_diff_line[resource added-+ - resource added-green] PASSED
         unit_tests/test_apply/test_diff_helpers.py::test_display_diff_line[resource removed-- - resource removed-red] PASSED
         unit_tests/test_apply/test_diff_helpers.py::test_display_diff_line[whatever- - whatever-None] PASSED
         unit_tests/test_apply/test_resources.py::TestResourceState::test_init PASSED
         unit_tests/test_apply/test_resources.py::TestResourceState::test_as_dict PASSED
         unit_tests/test_apply/test_resources.py::TestResourceState::test_save PASSED
         unit_tests/test_apply/test_resources.py::TestResourceState::test_create PASSED
         unit_tests/test_apply/test_resources.py::TestResourceState::test_delete PASSED
         unit_tests/test_apply/test_resources.py::TestResourceState::test_from_file PASSED
         unit_tests/test_apply/test_resources.py::TestResourceState::test__get_path_from_configuration_and_workspace_id PASSED
         unit_tests/test_apply/test_resources.py::TestResourceState::test_from_configuration_path_and_workspace PASSED
         unit_tests/test_apply/test_resources.py::TestResourceState::test_migrate PASSED
         unit_tests/test_apply/test_resources.py::TestBaseResource::test_init_no_remote_resource PASSED
         unit_tests/test_apply/test_resources.py::TestBaseResource::test_init_with_remote_resource_not_changed PASSED
         unit_tests/test_apply/test_resources.py::TestBaseResource::test_init_with_remote_resource_changed PASSED
         unit_tests/test_apply/test_resources.py::TestBaseResource::test_get_remote_resource PASSED
         unit_tests/test_apply/test_resources.py::TestBaseResource::test_get_state_from_file[True-False-False] PASSED
         unit_tests/test_apply/test_resources.py::TestBaseResource::test_get_state_from_file[False-True-True] PASSED
         unit_tests/test_apply/test_resources.py::TestBaseResource::test_get_state_from_file[False-True-False] PASSED
         unit_tests/test_apply/test_resources.py::TestBaseResource::test_get_state_from_file[False-False-False] PASSED
         unit_tests/test_apply/test_resources.py::TestBaseResource::test_get_diff_with_remote_resource[True] PASSED
         unit_tests/test_apply/test_resources.py::TestBaseResource::test_get_diff_with_remote_resource[False] PASSED
         unit_tests/test_apply/test_resources.py::TestBaseResource::test_create_or_update PASSED
         unit_tests/test_apply/test_resources.py::TestBaseResource::test_create_or_update_error[404-ApiException] PASSED
         unit_tests/test_apply/test_resources.py::TestBaseResource::test_create_or_update_error[422-InvalidConfigurationError] PASSED
         unit_tests/test_apply/test_resources.py::TestBaseResource::test_create PASSED
         unit_tests/test_apply/test_resources.py::TestBaseResource::test_update PASSED
         unit_tests/test_apply/test_resources.py::TestBaseResource::test_manage PASSED
         unit_tests/test_apply/test_resources.py::TestBaseResource::test__check_for_invalid_configuration_keys[configuration0-invalid_keys0-True] PASSED
         unit_tests/test_apply/test_resources.py::TestBaseResource::test__check_for_invalid_configuration_keys[configuration1-invalid_keys1-True] PASSED
         unit_tests/test_apply/test_resources.py::TestBaseResource::test__check_for_invalid_configuration_keys[configuration2-invalid_keys2-False] PASSED
         unit_tests/test_apply/test_resources.py::TestSourceAndDestination::test_init PASSED
         unit_tests/test_apply/test_resources.py::TestSourceAndDestination::test_get_remote_comparable_configuration PASSED
         unit_tests/test_apply/test_resources.py::TestSource::test_init[None] PASSED
         unit_tests/test_apply/test_resources.py::TestSource::test_init[state1] PASSED
         unit_tests/test_apply/test_resources.py::TestSource::test_source_discover_schema_request_body[None] PASSED
         unit_tests/test_apply/test_resources.py::TestSource::test_source_discover_schema_request_body[foo] PASSED
         unit_tests/test_apply/test_resources.py::TestSource::test_catalog PASSED
         unit_tests/test_apply/test_resources.py::TestSource::test_definition PASSED
         unit_tests/test_apply/test_resources.py::TestDestination::test_init[None] PASSED
         unit_tests/test_apply/test_resources.py::TestDestination::test_init[state1] PASSED
         unit_tests/test_apply/test_resources.py::TestDestination::test_definition PASSED
         unit_tests/test_apply/test_resources.py::TestConnection::test_init[None] PASSED
         unit_tests/test_apply/test_resources.py::TestConnection::test_init[state1] PASSED
         unit_tests/test_apply/test_resources.py::TestConnection::test_source_id[False] PASSED
         unit_tests/test_apply/test_resources.py::TestConnection::test_source_id[True] PASSED
         unit_tests/test_apply/test_resources.py::TestConnection::test_destination_id[False] PASSED
         unit_tests/test_apply/test_resources.py::TestConnection::test_destination_id[True] PASSED
         unit_tests/test_apply/test_resources.py::TestConnection::test_create_payload_no_normalization PASSED
         unit_tests/test_apply/test_resources.py::TestConnection::test_create_payload_with_normalization PASSED
         unit_tests/test_apply/test_resources.py::TestConnection::test_update_payload_no_normalization PASSED
         unit_tests/test_apply/test_resources.py::TestConnection::test_update_payload_with_normalization PASSED
         unit_tests/test_apply/test_resources.py::TestConnection::test_get_remote_comparable_configuration[remote_resource0] PASSED
         unit_tests/test_apply/test_resources.py::TestConnection::test_get_remote_comparable_configuration[remote_resource1] PASSED
         unit_tests/test_apply/test_resources.py::TestConnection::test_get_remote_comparable_configuration[remote_resource2] PASSED
         unit_tests/test_apply/test_resources.py::TestConnection::test_get_remote_comparable_configuration[remote_resource3] PASSED
         unit_tests/test_apply/test_resources.py::TestConnection::test_create PASSED
         unit_tests/test_apply/test_resources.py::TestConnection::test_update PASSED
         unit_tests/test_apply/test_resources.py::TestConnection::test__deserialize_raw_configuration PASSED
         unit_tests/test_apply/test_resources.py::TestConnection::test__deserialize_operations PASSED
         unit_tests/test_apply/test_resources.py::TestConnection::test__create_configured_catalog PASSED
         unit_tests/test_apply/test_resources.py::TestConnection::test__check_for_legacy_connection_configuration_keys PASSED
         unit_tests/test_apply/test_resources.py::test_factory[local_configuration0-Source-None] PASSED
         unit_tests/test_apply/test_resources.py::test_factory[local_configuration1-Destination-None] PASSED
         unit_tests/test_apply/test_resources.py::test_factory[local_configuration2-Connection-None] PASSED
         unit_tests/test_apply/test_resources.py::test_factory[local_configuration3-None-NotImplementedError] PASSED
         unit_tests/test_apply/test_yaml_loaders.py::test_env_var_replacer PASSED
         unit_tests/test_apply/test_yaml_loaders.py::test_env_var_loader PASSED
         unit_tests/test_generate/test_commands.py::test_generate_initialized PASSED
         unit_tests/test_generate/test_commands.py::test_generate_not_initialized PASSED
         unit_tests/test_generate/test_commands.py::test_invalid_definition_type PASSED
         unit_tests/test_generate/test_commands.py::test_generate_source_or_destination[command0-my_source-source] PASSED
         unit_tests/test_generate/test_commands.py::test_generate_source_or_destination[command1-my_destination-destination] PASSED
         unit_tests/test_generate/test_commands.py::test_generate_connection[True-True] PASSED
         unit_tests/test_generate/test_commands.py::test_generate_connection[False-True] PASSED
         unit_tests/test_generate/test_commands.py::test_generate_connection[True-False] PASSED
         unit_tests/test_generate/test_commands.py::test_generate_connection[False-False] PASSED
         unit_tests/test_generate/test_definitions.py::TestBaseDefinition::test_init PASSED
         unit_tests/test_generate/test_definitions.py::TestBaseDefinition::test_get_attr PASSED
         unit_tests/test_generate/test_definitions.py::TestBaseDefinition::test_read_success PASSED
         unit_tests/test_generate/test_definitions.py::TestBaseDefinition::test_read_error_not_found[404] PASSED
         unit_tests/test_generate/test_definitions.py::TestBaseDefinition::test_read_error_not_found[422] PASSED
         unit_tests/test_generate/test_definitions.py::TestBaseDefinition::test_read_error_other PASSED
         unit_tests/test_generate/test_definitions.py::TestSourceDefinition::test_init PASSED
         unit_tests/test_generate/test_definitions.py::TestDestinationDefinition::test_init PASSED
         unit_tests/test_generate/test_definitions.py::TestSourceDefinitionSpecification::test_init PASSED
         unit_tests/test_generate/test_definitions.py::TestDestinationDefinitionSpecification::test_init PASSED
         unit_tests/test_generate/test_definitions.py::test_factory PASSED
         unit_tests/test_generate/test_renderers.py::TestFieldToRender::test_init PASSED
         unit_tests/test_generate/test_renderers.py::TestFieldToRender::test_get_attr PASSED
         unit_tests/test_generate/test_renderers.py::TestFieldToRender::test_is_array_of_objects PASSED
         unit_tests/test_generate/test_renderers.py::TestFieldToRender::test__get_one_of_values PASSED
         unit_tests/test_generate/test_renderers.py::TestFieldToRender::test__get_array_items PASSED
         unit_tests/test_generate/test_renderers.py::TestFieldToRender::test__get_required_comment PASSED
         unit_tests/test_generate/test_renderers.py::TestFieldToRender::test__get_type_comment[string-string] PASSED
         unit_tests/test_generate/test_renderers.py::TestFieldToRender::test__get_type_comment[_type1-string, null] PASSED
         unit_tests/test_generate/test_renderers.py::TestFieldToRender::test__get_type_comment[None-None] PASSED
         unit_tests/test_generate/test_renderers.py::TestFieldToRender::test__get_secret_comment PASSED
         unit_tests/test_generate/test_renderers.py::TestFieldToRender::test__get_description_comment PASSED
         unit_tests/test_generate/test_renderers.py::TestFieldToRender::test__get_example_comment[examples_value0-Examples: foo, bar] PASSED
         unit_tests/test_generate/test_renderers.py::TestFieldToRender::test__get_example_comment[examples_value1-Example: foo] PASSED
         unit_tests/test_generate/test_renderers.py::TestFieldToRender::test__get_example_comment[foo-Example: foo] PASSED
         unit_tests/test_generate/test_renderers.py::TestFieldToRender::test__get_example_comment[examples_value3-Example: 5432] PASSED
         unit_tests/test_generate/test_renderers.py::TestFieldToRender::test__get_example_comment[None-None] PASSED
         unit_tests/test_generate/test_renderers.py::TestFieldToRender::test__get_default[field_metadata0-foo] PASSED
         unit_tests/test_generate/test_renderers.py::TestFieldToRender::test__get_default[field_metadata1-bar] PASSED
         unit_tests/test_generate/test_renderers.py::TestFieldToRender::test__get_default[field_metadata2-${FIELD_NAME}] PASSED
         unit_tests/test_generate/test_renderers.py::TestFieldToRender::test__get_default[field_metadata3-None] PASSED
         unit_tests/test_generate/test_renderers.py::TestFieldToRender::test__build_comment PASSED
         unit_tests/test_generate/test_renderers.py::test_parse_fields PASSED
         unit_tests/test_generate/test_renderers.py::test_get_object_fields PASSED
         unit_tests/test_generate/test_renderers.py::TestBaseRenderer::test_init PASSED
         unit_tests/test_generate/test_renderers.py::TestBaseRenderer::test_get_output_path PASSED
         unit_tests/test_generate/test_renderers.py::TestBaseRenderer::test__confirm_overwrite[True-True] PASSED
         unit_tests/test_generate/test_renderers.py::TestBaseRenderer::test__confirm_overwrite[False-None] PASSED
         unit_tests/test_generate/test_renderers.py::TestBaseRenderer::test__confirm_overwrite[True-False] PASSED
         unit_tests/test_generate/test_renderers.py::TestBaseRenderer::test_import_configuration[True] PASSED
         unit_tests/test_generate/test_renderers.py::TestBaseRenderer::test_import_configuration[False] PASSED
         unit_tests/test_generate/test_renderers.py::TestConnectorSpecificationRenderer::test_init PASSED
         unit_tests/test_generate/test_renderers.py::TestConnectorSpecificationRenderer::test__parse_connection_specification PASSED
         unit_tests/test_generate/test_renderers.py::TestConnectorSpecificationRenderer::test__parse_connection_specification_one_of PASSED
         unit_tests/test_generate/test_renderers.py::TestConnectorSpecificationRenderer::test_write_yaml[True] PASSED
         unit_tests/test_generate/test_renderers.py::TestConnectorSpecificationRenderer::test_write_yaml[False] PASSED
         unit_tests/test_generate/test_renderers.py::TestConnectorSpecificationRenderer::test__render PASSED
         unit_tests/test_generate/test_renderers.py::TestConnectionRenderer::test_init PASSED
         unit_tests/test_generate/test_renderers.py::TestConnectionRenderer::test_catalog_to_yaml PASSED
         unit_tests/test_generate/test_renderers.py::TestConnectionRenderer::test_write_yaml[True] PASSED
         unit_tests/test_generate/test_renderers.py::TestConnectionRenderer::test_write_yaml[False] PASSED
         unit_tests/test_generate/test_renderers.py::TestConnectionRenderer::test__render PASSED
         unit_tests/test_generate/test_renderers.py::TestConnectionRenderer::test_import_configuration[True-operations0] PASSED
         unit_tests/test_generate/test_renderers.py::TestConnectionRenderer::test_import_configuration[False-operations1] PASSED
         unit_tests/test_generate/test_renderers.py::TestConnectionRenderer::test_import_configuration[True-operations2] PASSED
         unit_tests/test_generate/test_renderers.py::TestConnectionRenderer::test_import_configuration[False-operations3] PASSED
         unit_tests/test_get/test_commands.py::test_commands_in_get_group PASSED
         unit_tests/test_get/test_commands.py::test_available_commands PASSED
         unit_tests/test_get/test_commands.py::test_build_help_message PASSED
         unit_tests/test_get/test_commands.py::test_get_resource_id_or_name PASSED
         unit_tests/test_get/test_commands.py::test_get_json_representation PASSED
         unit_tests/test_get/test_commands.py::test_commands[command0-Source-my_resource_id] PASSED
         unit_tests/test_get/test_commands.py::test_commands[command1-Destination-my_resource_id] PASSED
         unit_tests/test_get/test_commands.py::test_commands[command2-Connection-my_resource_id] PASSED
         unit_tests/test_get/test_resources.py::TestBaseResource::test_init[my_resource_id-None-None-None] PASSED
         unit_tests/test_get/test_resources.py::TestBaseResource::test_init[None-my_resource_name-None-None] PASSED
         unit_tests/test_get/test_resources.py::TestBaseResource::test_init[None-None-ValueError-resource_id and resource_name keyword arguments can't be both None.] PASSED
         unit_tests/test_get/test_resources.py::TestBaseResource::test_init[my_resource_id-my_resource_name-ValueError-resource_id and resource_name keyword arguments can't be both set.] PASSED
         unit_tests/test_get/test_resources.py::TestBaseResource::test__find_by_resource_name[foo-api_response_resources_names0-None-None] PASSED
         unit_tests/test_get/test_resources.py::TestBaseResource::test__find_by_resource_name[foo-api_response_resources_names1-ResourceNotFoundError-The fake_resource foo was not found in your current Airbyte workspace.] PASSED
         unit_tests/test_get/test_resources.py::TestBaseResource::test__find_by_resource_name[foo-api_response_resources_names2-DuplicateResourceError-2 fake_resources with the name foo were found in your current Airbyte workspace.] PASSED
         unit_tests/test_get/test_resources.py::TestBaseResource::test__find_by_id PASSED
         unit_tests/test_get/test_resources.py::TestBaseResource::test_get_remote_resource[my_resource_id-None] PASSED
         unit_tests/test_get/test_resources.py::TestBaseResource::test_get_remote_resource[None-my_resource_name] PASSED
         unit_tests/test_get/test_resources.py::TestBaseResource::test_to_json PASSED
         unit_tests/test_get/test_resources.py::TestSource::test_init PASSED
         unit_tests/test_get/test_resources.py::TestDestination::test_init PASSED
         unit_tests/test_get/test_resources.py::TestConnection::test_init PASSED
         unit_tests/test_init/test_commands.py::test_directories_to_create PASSED
         unit_tests/test_init/test_commands.py::test_create_directories[directories_to_create0-None-expected_created_directories0-expected_not_created_directories0] PASSED
         unit_tests/test_init/test_commands.py::test_create_directories[directories_to_create1-mkdir_side_effects1-expected_created_directories1-expected_not_created_directories1] PASSED
         unit_tests/test_init/test_commands.py::test_create_directories[directories_to_create2-mkdir_side_effects2-expected_created_directories2-expected_not_created_directories2] PASSED
         unit_tests/test_init/test_commands.py::test_init PASSED
         unit_tests/test_init/test_commands.py::test_init_some_existing_directories PASSED
         unit_tests/test_init/test_commands.py::test_init_all_existing_directories PASSED
         unit_tests/test_init/test_commands.py::test_init_when_api_headers_configuration_file_exists PASSED
         unit_tests/test_init/test_commands.py::test_create_init_configuration[False] PASSED
         unit_tests/test_init/test_commands.py::test_create_init_configuration[True] PASSED
         unit_tests/test_list/test_commands.py::test_available_commands PASSED
         unit_tests/test_list/test_commands.py::test_commands_in_list_group PASSED
         unit_tests/test_list/test_commands.py::test_connectors_sources PASSED
         unit_tests/test_list/test_commands.py::test_connectors_destinations PASSED
         unit_tests/test_list/test_commands.py::test_sources PASSED
         unit_tests/test_list/test_commands.py::test_destinations PASSED
         unit_tests/test_list/test_commands.py::test_connections PASSED
         unit_tests/test_list/test_formatting.py::test_compute_columns_width[test_data0-expected_columns_width0] PASSED
         unit_tests/test_list/test_formatting.py::test_compute_columns_width[test_data1-expected_columns_width1] PASSED
         unit_tests/test_list/test_formatting.py::test_compute_columns_width[test_data2-expected_columns_width2] PASSED
         unit_tests/test_list/test_formatting.py::test_camelcased_to_uppercased_spaced[camelCased-CAMEL CASED] PASSED
         unit_tests/test_list/test_formatting.py::test_camelcased_to_uppercased_spaced[notcamelcased-NOTCAMELCASED] PASSED
         unit_tests/test_list/test_formatting.py::test_display_as_table[test_data0-columns_width0-a  ___10chars   \ne  ____11chars  ] PASSED
         unit_tests/test_list/test_formatting.py::test_format_column_names PASSED
         unit_tests/test_list/test_listings.py::TestBaseListing::test_init PASSED
         unit_tests/test_list/test_listings.py::TestBaseListing::test_abstract_methods PASSED
         unit_tests/test_list/test_listings.py::TestBaseListing::test_parse_response PASSED
         unit_tests/test_list/test_listings.py::TestBaseListing::test_gest_listing PASSED
         unit_tests/test_list/test_listings.py::TestBaseListing::test_repr PASSED
         unit_tests/test_list/test_listings.py::TestSourceConnectorsDefinitions::test_init PASSED
         unit_tests/test_list/test_listings.py::TestDestinationConnectorsDefinitions::test_init PASSED
         unit_tests/test_list/test_listings.py::TestWorkspaceListing::test_init PASSED
         unit_tests/test_list/test_listings.py::TestWorkspaceListing::test_abstract PASSED
         unit_tests/test_list/test_listings.py::TestSources::test_init PASSED
         unit_tests/test_list/test_listings.py::TestDestinations::test_init PASSED
         unit_tests/test_list/test_listings.py::TestConnections::test_init PASSED

         ============================= 332 passed in 1.52s ==============================

</details>

<details><summary><strong>Integration</strong></summary>

*Put your integration tests output here.*

</details>

<details><summary><strong>Acceptance</strong></summary>

*Put your acceptance tests output here.*

</details>
