### PR TITLE
🪟 🔧 Update auto-detect schema feature name

### DIFF
--- a/airbyte-webapp/src/components/CreateConnection/CreateConnectionForm.tsx
+++ b/airbyte-webapp/src/components/CreateConnection/CreateConnectionForm.tsx
@@ -42,7 +42,7 @@ const CreateConnectionFormInner: React.FC<CreateConnectionPropsInner> = ({ schem
   const navigate = useNavigate();
   const canEditDataGeographies = useFeature(FeatureItem.AllowChangeDataGeographies);
   const { mutateAsync: createConnection } = useCreateConnection();
-  const allowAutoDetectSchema = useFeature(FeatureItem.AutoDetectSchema);
+  const allowAutoDetectSchema = useFeature(FeatureItem.AllowAutoDetectSchema);
   const { clearFormChange } = useFormChangeTrackerService();
 
   const workspaceId = useCurrentWorkspaceId();

--- a/airbyte-webapp/src/components/CreateConnection/CreateConnectionForm.tsx
+++ b/airbyte-webapp/src/components/CreateConnection/CreateConnectionForm.tsx
@@ -42,7 +42,7 @@ const CreateConnectionFormInner: React.FC<CreateConnectionPropsInner> = ({ schem
   const navigate = useNavigate();
   const canEditDataGeographies = useFeature(FeatureItem.AllowChangeDataGeographies);
   const { mutateAsync: createConnection } = useCreateConnection();
-  const allowAutoDetectSchemaChanges = useFeature(FeatureItem.AllowAutoDetectSchemaChanges);
+  const allowAutoDetectSchema = useFeature(FeatureItem.AutoDetectSchema);
   const { clearFormChange } = useFormChangeTrackerService();
 
   const workspaceId = useCurrentWorkspaceId();
@@ -58,7 +58,7 @@ const CreateConnectionFormInner: React.FC<CreateConnectionPropsInner> = ({ schem
         workspaceId,
         mode,
         allowSubOneHourCronExpressions,
-        allowAutoDetectSchemaChanges
+        allowAutoDetectSchema
       );
 
       try {
@@ -93,7 +93,7 @@ const CreateConnectionFormInner: React.FC<CreateConnectionPropsInner> = ({ schem
       workspaceId,
       mode,
       allowSubOneHourCronExpressions,
-      allowAutoDetectSchemaChanges,
+      allowAutoDetectSchema,
       createConnection,
       connection.source,
       connection.destination,
@@ -118,7 +118,7 @@ const CreateConnectionFormInner: React.FC<CreateConnectionPropsInner> = ({ schem
           validationSchema={createConnectionValidationSchema({
             mode,
             allowSubOneHourCronExpressions,
-            allowAutoDetectSchemaChanges,
+            allowAutoDetectSchema,
           })}
           onSubmit={onFormSubmit}
         >

--- a/airbyte-webapp/src/components/EntityTable/ConnectionTable.tsx
+++ b/airbyte-webapp/src/components/EntityTable/ConnectionTable.tsx
@@ -28,7 +28,7 @@ interface IProps {
 const ConnectionTable: React.FC<IProps> = ({ data, entity, onClickRow, onSync }) => {
   const navigate = useNavigate();
   const query = useQuery<{ sortBy?: string; order?: SortOrderEnum }>();
-  const allowAutoDetectSchemaChanges = useFeature(FeatureItem.AllowAutoDetectSchemaChanges);
+  const allowAutoDetectSchema = useFeature(FeatureItem.AutoDetectSchema);
   const allowSync = useFeature(FeatureItem.AllowSync);
 
   const sortBy = query.sortBy || "entityName";
@@ -163,7 +163,7 @@ const ConnectionTable: React.FC<IProps> = ({ data, entity, onClickRow, onSync })
             isSyncing={row.original.isSyncing}
             isManual={row.original.scheduleType === ConnectionScheduleType.manual}
             onSync={onSync}
-            hasBreakingChange={allowAutoDetectSchemaChanges && row.original.schemaChange === SchemaChange.breaking}
+            hasBreakingChange={allowAutoDetectSchema && row.original.schemaChange === SchemaChange.breaking}
             allowSync={allowSync}
           />
         ),
@@ -175,7 +175,7 @@ const ConnectionTable: React.FC<IProps> = ({ data, entity, onClickRow, onSync })
         Cell: ({ cell }: CellProps<ITableDataItem>) => <ConnectionSettingsCell id={cell.value} />,
       },
     ],
-    [sortBy, sortOrder, entity, onSortClick, onSync, allowSync, allowAutoDetectSchemaChanges]
+    [sortBy, sortOrder, entity, onSortClick, onSync, allowSync, allowAutoDetectSchema]
   );
 
   return <Table columns={columns} data={sortingData} onClickRow={onClickRow} erroredRows />;

--- a/airbyte-webapp/src/components/EntityTable/ConnectionTable.tsx
+++ b/airbyte-webapp/src/components/EntityTable/ConnectionTable.tsx
@@ -28,7 +28,7 @@ interface IProps {
 const ConnectionTable: React.FC<IProps> = ({ data, entity, onClickRow, onSync }) => {
   const navigate = useNavigate();
   const query = useQuery<{ sortBy?: string; order?: SortOrderEnum }>();
-  const allowAutoDetectSchema = useFeature(FeatureItem.AutoDetectSchema);
+  const allowAutoDetectSchema = useFeature(FeatureItem.AllowAutoDetectSchema);
   const allowSync = useFeature(FeatureItem.AllowSync);
 
   const sortBy = query.sortBy || "entityName";

--- a/airbyte-webapp/src/components/EntityTable/components/StatusCell.tsx
+++ b/airbyte-webapp/src/components/EntityTable/components/StatusCell.tsx
@@ -28,7 +28,7 @@ export const StatusCell: React.FC<StatusCellProps> = ({
   schemaChange,
   hasBreakingChange,
 }) => {
-  const allowAutoDetectSchema = useFeature(FeatureItem.AutoDetectSchema);
+  const allowAutoDetectSchema = useFeature(FeatureItem.AllowAutoDetectSchema);
 
   return (
     <div className={styles.container}>

--- a/airbyte-webapp/src/components/EntityTable/components/StatusCell.tsx
+++ b/airbyte-webapp/src/components/EntityTable/components/StatusCell.tsx
@@ -28,7 +28,7 @@ export const StatusCell: React.FC<StatusCellProps> = ({
   schemaChange,
   hasBreakingChange,
 }) => {
-  const allowAutoDetectSchemaChanges = useFeature(FeatureItem.AllowAutoDetectSchemaChanges);
+  const allowAutoDetectSchema = useFeature(FeatureItem.AutoDetectSchema);
 
   return (
     <div className={styles.container}>
@@ -41,7 +41,7 @@ export const StatusCell: React.FC<StatusCellProps> = ({
         hasBreakingChange={hasBreakingChange}
         allowSync={allowSync}
       />
-      {allowAutoDetectSchemaChanges && <ChangesStatusIcon schemaChange={schemaChange} />}
+      {allowAutoDetectSchema && <ChangesStatusIcon schemaChange={schemaChange} />}
     </div>
   );
 };

--- a/airbyte-webapp/src/hooks/connection/useSchemaChanges.ts
+++ b/airbyte-webapp/src/hooks/connection/useSchemaChanges.ts
@@ -4,7 +4,7 @@ import { SchemaChange } from "core/request/AirbyteClient";
 import { FeatureItem, useFeature } from "hooks/services/Feature";
 
 export const useSchemaChanges = (schemaChange: SchemaChange) => {
-  const allowAutoDetectSchema = useFeature(FeatureItem.AutoDetectSchema);
+  const allowAutoDetectSchema = useFeature(FeatureItem.AllowAutoDetectSchema);
 
   return useMemo(() => {
     const hasSchemaChanges = allowAutoDetectSchema && schemaChange !== SchemaChange.no_change;

--- a/airbyte-webapp/src/hooks/connection/useSchemaChanges.ts
+++ b/airbyte-webapp/src/hooks/connection/useSchemaChanges.ts
@@ -4,10 +4,10 @@ import { SchemaChange } from "core/request/AirbyteClient";
 import { FeatureItem, useFeature } from "hooks/services/Feature";
 
 export const useSchemaChanges = (schemaChange: SchemaChange) => {
-  const allowAutoDetectSchemaChanges = useFeature(FeatureItem.AllowAutoDetectSchemaChanges);
+  const allowAutoDetectSchema = useFeature(FeatureItem.AutoDetectSchema);
 
   return useMemo(() => {
-    const hasSchemaChanges = allowAutoDetectSchemaChanges && schemaChange !== SchemaChange.no_change;
+    const hasSchemaChanges = allowAutoDetectSchema && schemaChange !== SchemaChange.no_change;
     const hasBreakingSchemaChange = hasSchemaChanges && schemaChange === SchemaChange.breaking;
     const hasNonBreakingSchemaChange = hasSchemaChanges && schemaChange === SchemaChange.non_breaking;
 
@@ -17,5 +17,5 @@ export const useSchemaChanges = (schemaChange: SchemaChange) => {
       hasBreakingSchemaChange,
       hasNonBreakingSchemaChange,
     };
-  }, [allowAutoDetectSchemaChanges, schemaChange]);
+  }, [allowAutoDetectSchema, schemaChange]);
 };

--- a/airbyte-webapp/src/hooks/services/ConnectionForm/ConnectionFormService.tsx
+++ b/airbyte-webapp/src/hooks/services/ConnectionForm/ConnectionFormService.tsx
@@ -39,14 +39,14 @@ export const tidyConnectionFormValues = (
   workspaceId: string,
   mode: ConnectionFormMode,
   allowSubOneHourCronExpressions: boolean,
-  allowAutoDetectSchemaChanges: boolean,
+  allowAutoDetectSchema: boolean,
   operations?: OperationRead[]
 ): ValuesProps => {
   // TODO (https://github.com/airbytehq/airbyte/issues/17279): We should try to fix the types so we don't need the casting.
   const formValues: ConnectionFormValues = createConnectionValidationSchema({
     mode,
     allowSubOneHourCronExpressions,
-    allowAutoDetectSchemaChanges,
+    allowAutoDetectSchema,
   }).cast(values, {
     context: { isRequest: true },
   }) as unknown as ConnectionFormValues;

--- a/airbyte-webapp/src/hooks/services/Feature/types.tsx
+++ b/airbyte-webapp/src/hooks/services/Feature/types.tsx
@@ -4,7 +4,7 @@
  */
 
 export enum FeatureItem {
-  AllowAutoDetectSchemaChanges = "ALLOW_AUTO_DETECT_SCHEMA_CHANGES",
+  AutoDetectSchema = "ALLOW_AUTO_DETECT_SCHEMA",
   AllowUploadCustomImage = "ALLOW_UPLOAD_CUSTOM_IMAGE",
   AllowCustomDBT = "ALLOW_CUSTOM_DBT",
   AllowDBTCloudIntegration = "ALLOW_DBT_CLOUD_INTEGRATION",

--- a/airbyte-webapp/src/hooks/services/Feature/types.tsx
+++ b/airbyte-webapp/src/hooks/services/Feature/types.tsx
@@ -4,7 +4,7 @@
  */
 
 export enum FeatureItem {
-  AutoDetectSchema = "ALLOW_AUTO_DETECT_SCHEMA",
+  AllowAutoDetectSchema = "ALLOW_AUTO_DETECT_SCHEMA",
   AllowUploadCustomImage = "ALLOW_UPLOAD_CUSTOM_IMAGE",
   AllowCustomDBT = "ALLOW_CUSTOM_DBT",
   AllowDBTCloudIntegration = "ALLOW_DBT_CLOUD_INTEGRATION",

--- a/airbyte-webapp/src/pages/ConnectionPage/pages/ConnectionItemPage/ConnectionReplicationTab.tsx
+++ b/airbyte-webapp/src/pages/ConnectionPage/pages/ConnectionItemPage/ConnectionReplicationTab.tsx
@@ -46,7 +46,7 @@ const ValidateFormOnSchemaRefresh: React.FC = () => {
 };
 
 export const ConnectionReplicationTab: React.FC = () => {
-  const allowAutoDetectSchemaChanges = useFeature(FeatureItem.AllowAutoDetectSchemaChanges);
+  const allowAutoDetectSchema = useFeature(FeatureItem.AutoDetectSchema);
   const analyticsService = useAnalyticsService();
   const connectionService = useConnectionService();
   const workspaceId = useCurrentWorkspaceId();
@@ -99,7 +99,7 @@ export const ConnectionReplicationTab: React.FC = () => {
         workspaceId,
         mode,
         allowSubOneHourCronExpressions,
-        allowAutoDetectSchemaChanges,
+        allowAutoDetectSchema,
         connection.operations
       );
 
@@ -158,7 +158,7 @@ export const ConnectionReplicationTab: React.FC = () => {
       workspaceId,
       mode,
       allowSubOneHourCronExpressions,
-      allowAutoDetectSchemaChanges,
+      allowAutoDetectSchema,
       connection.operations,
       connection.catalogDiff?.transforms,
       connection.syncCatalog.streams,
@@ -188,7 +188,7 @@ export const ConnectionReplicationTab: React.FC = () => {
           validationSchema={createConnectionValidationSchema({
             mode,
             allowSubOneHourCronExpressions,
-            allowAutoDetectSchemaChanges,
+            allowAutoDetectSchema,
           })}
           onSubmit={onFormSubmit}
           enableReinitialize

--- a/airbyte-webapp/src/pages/ConnectionPage/pages/ConnectionItemPage/ConnectionReplicationTab.tsx
+++ b/airbyte-webapp/src/pages/ConnectionPage/pages/ConnectionItemPage/ConnectionReplicationTab.tsx
@@ -46,7 +46,7 @@ const ValidateFormOnSchemaRefresh: React.FC = () => {
 };
 
 export const ConnectionReplicationTab: React.FC = () => {
-  const allowAutoDetectSchema = useFeature(FeatureItem.AutoDetectSchema);
+  const allowAutoDetectSchema = useFeature(FeatureItem.AllowAutoDetectSchema);
   const analyticsService = useAnalyticsService();
   const connectionService = useConnectionService();
   const workspaceId = useCurrentWorkspaceId();

--- a/airbyte-webapp/src/pages/ConnectionPage/pages/ConnectionItemPage/SchemaChangesDetected.test.tsx
+++ b/airbyte-webapp/src/pages/ConnectionPage/pages/ConnectionItemPage/SchemaChangesDetected.test.tsx
@@ -22,7 +22,7 @@ jest.doMock("views/Connection/ConnectionForm/components/refreshSourceSchemaWithC
 }));
 
 const TestWrapperWithAutoDetectSchema: React.FC<React.PropsWithChildren<Record<string, unknown>>> = ({ children }) => (
-  <TestWrapper features={[FeatureItem.AllowAutoDetectSchemaChanges]}>{children}</TestWrapper>
+  <TestWrapper features={[FeatureItem.AutoDetectSchema]}>{children}</TestWrapper>
 );
 
 const renderComponent = () => render(<SchemaChangesDetected />, { wrapper: TestWrapperWithAutoDetectSchema });

--- a/airbyte-webapp/src/pages/ConnectionPage/pages/ConnectionItemPage/SchemaChangesDetected.test.tsx
+++ b/airbyte-webapp/src/pages/ConnectionPage/pages/ConnectionItemPage/SchemaChangesDetected.test.tsx
@@ -22,7 +22,7 @@ jest.doMock("views/Connection/ConnectionForm/components/refreshSourceSchemaWithC
 }));
 
 const TestWrapperWithAutoDetectSchema: React.FC<React.PropsWithChildren<Record<string, unknown>>> = ({ children }) => (
-  <TestWrapper features={[FeatureItem.AutoDetectSchema]}>{children}</TestWrapper>
+  <TestWrapper features={[FeatureItem.AllowAutoDetectSchema]}>{children}</TestWrapper>
 );
 
 const renderComponent = () => render(<SchemaChangesDetected />, { wrapper: TestWrapperWithAutoDetectSchema });

--- a/airbyte-webapp/src/pages/ConnectionPage/pages/ConnectionItemPage/StatusMainInfo.test.tsx
+++ b/airbyte-webapp/src/pages/ConnectionPage/pages/ConnectionItemPage/StatusMainInfo.test.tsx
@@ -28,7 +28,7 @@ jest.doMock("views/Connection/ConnectionForm/components/refreshSourceSchemaWithC
 }));
 
 const TestWrapperWithAutoDetectSchema: React.FC<React.PropsWithChildren<Record<string, unknown>>> = ({ children }) => (
-  <TestWrapper features={[...defaultOssFeatures, FeatureItem.AutoDetectSchema]}>{children}</TestWrapper>
+  <TestWrapper features={[...defaultOssFeatures, FeatureItem.AllowAutoDetectSchema]}>{children}</TestWrapper>
 );
 
 // eslint-disable-next-line @typescript-eslint/no-var-requires

--- a/airbyte-webapp/src/pages/ConnectionPage/pages/ConnectionItemPage/StatusMainInfo.test.tsx
+++ b/airbyte-webapp/src/pages/ConnectionPage/pages/ConnectionItemPage/StatusMainInfo.test.tsx
@@ -28,7 +28,7 @@ jest.doMock("views/Connection/ConnectionForm/components/refreshSourceSchemaWithC
 }));
 
 const TestWrapperWithAutoDetectSchema: React.FC<React.PropsWithChildren<Record<string, unknown>>> = ({ children }) => (
-  <TestWrapper features={[...defaultOssFeatures, FeatureItem.AllowAutoDetectSchemaChanges]}>{children}</TestWrapper>
+  <TestWrapper features={[...defaultOssFeatures, FeatureItem.AutoDetectSchema]}>{children}</TestWrapper>
 );
 
 // eslint-disable-next-line @typescript-eslint/no-var-requires

--- a/airbyte-webapp/src/views/Connection/ConnectionForm/ConnectionFormFields.tsx
+++ b/airbyte-webapp/src/views/Connection/ConnectionForm/ConnectionFormFields.tsx
@@ -34,7 +34,7 @@ interface ConnectionFormFieldsProps {
 }
 
 export const ConnectionFormFields: React.FC<ConnectionFormFieldsProps> = ({ values, isSubmitting, dirty }) => {
-  const allowAutoDetectSchemaChanges = useFeature(FeatureItem.AllowAutoDetectSchemaChanges);
+  const allowAutoDetectSchema = useFeature(FeatureItem.AutoDetectSchema);
 
   const { mode, formId } = useConnectionFormService();
   const { formatMessage } = useIntl();
@@ -59,7 +59,7 @@ export const ConnectionFormFields: React.FC<ConnectionFormFieldsProps> = ({ valu
       <div className={styles.formContainer}>
         <Section title={<FormattedMessage id="connection.transfer" />}>
           <ScheduleField />
-          {allowAutoDetectSchemaChanges && (
+          {allowAutoDetectSchema && (
             <Field name="nonBreakingChangesPreference" component={NonBreakingChangesPreferenceField} />
           )}
         </Section>

--- a/airbyte-webapp/src/views/Connection/ConnectionForm/ConnectionFormFields.tsx
+++ b/airbyte-webapp/src/views/Connection/ConnectionForm/ConnectionFormFields.tsx
@@ -34,7 +34,7 @@ interface ConnectionFormFieldsProps {
 }
 
 export const ConnectionFormFields: React.FC<ConnectionFormFieldsProps> = ({ values, isSubmitting, dirty }) => {
-  const allowAutoDetectSchema = useFeature(FeatureItem.AutoDetectSchema);
+  const allowAutoDetectSchema = useFeature(FeatureItem.AllowAutoDetectSchema);
 
   const { mode, formId } = useConnectionFormService();
   const { formatMessage } = useIntl();

--- a/airbyte-webapp/src/views/Connection/ConnectionForm/components/SchemaChangeBackdrop.tsx
+++ b/airbyte-webapp/src/views/Connection/ConnectionForm/components/SchemaChangeBackdrop.tsx
@@ -12,7 +12,7 @@ import { OctaviaYellowFlag } from "./OctaviaYellowFlag";
 import styles from "./SchemaChangeBackdrop.module.scss";
 
 export const SchemaChangeBackdrop: React.FC<React.PropsWithChildren<unknown>> = ({ children }) => {
-  const allowAutoDetectSchemaChanges = useFeature(FeatureItem.AllowAutoDetectSchemaChanges);
+  const allowAutoDetectSchema = useFeature(FeatureItem.AllowAutoDetectSchema);
 
   const {
     schemaHasBeenRefreshed,
@@ -25,11 +25,7 @@ export const SchemaChangeBackdrop: React.FC<React.PropsWithChildren<unknown>> = 
     return hasBreakingSchemaChange ? <OctaviaRedFlag /> : hasNonBreakingSchemaChange ? <OctaviaYellowFlag /> : null;
   }, [hasBreakingSchemaChange, hasNonBreakingSchemaChange]);
 
-  if (
-    !allowAutoDetectSchemaChanges ||
-    (!hasBreakingSchemaChange && !hasNonBreakingSchemaChange) ||
-    schemaHasBeenRefreshed
-  ) {
+  if (!allowAutoDetectSchema || (!hasBreakingSchemaChange && !hasNonBreakingSchemaChange) || schemaHasBeenRefreshed) {
     return <>{children}</>;
   }
 

--- a/airbyte-webapp/src/views/Connection/ConnectionForm/components/SchemaChangesBackdrop.test.tsx
+++ b/airbyte-webapp/src/views/Connection/ConnectionForm/components/SchemaChangesBackdrop.test.tsx
@@ -11,7 +11,7 @@ jest.doMock("hooks/services/ConnectionEdit/ConnectionEditService", () => ({
 }));
 
 const TestWrapperWithAutoDetectSchema: React.FC<React.PropsWithChildren<Record<string, unknown>>> = ({ children }) => (
-  <TestWrapper features={[FeatureItem.AllowAutoDetectSchemaChanges]}>{children}</TestWrapper>
+  <TestWrapper features={[FeatureItem.AllowAutoDetectSchema]}>{children}</TestWrapper>
 );
 
 const buttonSpy = jest.fn();

--- a/airbyte-webapp/src/views/Connection/ConnectionForm/formConfig.tsx
+++ b/airbyte-webapp/src/views/Connection/ConnectionForm/formConfig.tsx
@@ -83,13 +83,13 @@ export function useDefaultTransformation(): OperationCreate {
 interface CreateConnectionValidationSchemaArgs {
   allowSubOneHourCronExpressions: boolean;
   mode: ConnectionFormMode;
-  allowAutoDetectSchemaChanges: boolean;
+  allowAutoDetectSchema: boolean;
 }
 
 export const createConnectionValidationSchema = ({
   mode,
   allowSubOneHourCronExpressions,
-  allowAutoDetectSchemaChanges,
+  allowAutoDetectSchema,
 }: CreateConnectionValidationSchemaArgs) =>
   yup
     .object({
@@ -131,7 +131,7 @@ export const createConnectionValidationSchema = ({
             .defined("form.empty.error"),
         });
       }),
-      nonBreakingChangesPreference: allowAutoDetectSchemaChanges
+      nonBreakingChangesPreference: allowAutoDetectSchema
         ? yup.mixed().oneOf(Object.values(NonBreakingChangesPreference)).required("form.empty.error")
         : yup.mixed().notRequired(),
 


### PR DESCRIPTION
## What
Updates the name of the Auto-detect schema feature because it was not set up correctly in LaunchDarkly.

LaunchDarkly would not allow changing the type of the flag, so it needed to be archived and re-created with a new unique name.