### PR TITLE
fix `LOG_CONNECTOR_MESSAGES` when source has no state

### DIFF
--- a/airbyte-commons-worker/src/main/java/io/airbyte/workers/internal/DefaultAirbyteSource.java
+++ b/airbyte-commons-worker/src/main/java/io/airbyte/workers/internal/DefaultAirbyteSource.java
@@ -164,6 +164,11 @@ public class DefaultAirbyteSource implements AirbyteSource {
       return;
     }
 
+    if (sourceConfig.getState() == null) {
+      LOGGER.info("source starting state | empty");
+      return;
+    }
+
     LOGGER.info("source starting state | " + Jsons.serialize(sourceConfig.getState().getState()));
   }
 


### PR DESCRIPTION
## What

When using `LOG_CONNECTOR_MESSAGES=true` to have syncs log all the connector messages, if you're running from an empty state this would trigger a null pointer exception when trying to log the initial state.

## How

- Fix the issue by checking for null
