### PR TITLE
Test destination continues writing after source fails

### DIFF
--- a/airbyte-commons-worker/src/main/java/io/airbyte/workers/general/DefaultReplicationWorker.java
+++ b/airbyte-commons-worker/src/main/java/io/airbyte/workers/general/DefaultReplicationWorker.java
@@ -195,6 +195,7 @@ public class DefaultReplicationWorker implements ReplicationWorker {
           executors)
           .whenComplete((msg, ex) -> {
             if (ex != null) {
+              LOGGER.info("error thrown from destination runnable");
               ApmTraceUtils.addExceptionToTrace(ex);
               if (ex.getCause() instanceof DestinationException) {
                 destinationRunnableFailureRef.set(FailureHelper.destinationFailure(ex, Long.valueOf(jobId), attempt));
@@ -220,12 +221,15 @@ public class DefaultReplicationWorker implements ReplicationWorker {
           executors)
           .whenComplete((msg, ex) -> {
             if (ex != null) {
+              LOGGER.info("error thrown from read source and dest write runnable");
               ApmTraceUtils.addExceptionToTrace(ex);
               if (ex.getCause() instanceof SourceException) {
+                LOGGER.info("source exception thrown");
                 replicationRunnableFailureRef.set(FailureHelper.sourceFailure(ex, Long.valueOf(jobId), attempt));
               } else if (ex.getCause() instanceof DestinationException) {
                 replicationRunnableFailureRef.set(FailureHelper.destinationFailure(ex, Long.valueOf(jobId), attempt));
               } else {
+                LOGGER.info("worker failure thrown");
                 replicationRunnableFailureRef.set(FailureHelper.replicationFailure(ex, Long.valueOf(jobId), attempt));
               }
             }

--- a/airbyte-integrations/connectors/destination-e2e-test/src/main/java/io/airbyte/integrations/destination/e2e_test/ThrottledDestination.java
+++ b/airbyte-integrations/connectors/destination-e2e-test/src/main/java/io/airbyte/integrations/destination/e2e_test/ThrottledDestination.java
@@ -61,6 +61,7 @@ public class ThrottledDestination extends BaseConnector implements Destination {
       }
 
       if (message.getType() == Type.STATE) {
+        LOGGER.info("Emitting state: {}", message);
         outputRecordCollector.accept(message);
       }
     }

--- a/airbyte-integrations/connectors/destination-e2e-test/src/main/java/io/airbyte/integrations/destination/e2e_test/ThrottledDestination.java
+++ b/airbyte-integrations/connectors/destination-e2e-test/src/main/java/io/airbyte/integrations/destination/e2e_test/ThrottledDestination.java
@@ -56,9 +56,11 @@ public class ThrottledDestination extends BaseConnector implements Destination {
     @Override
     public void accept(final AirbyteMessage message) throws Exception {
       sleep(millisPerRecord);
+      if(message.getType() == Type.RECORD) {
+        LOGGER.info("processing record: " + message.getRecord());
+      }
 
       if (message.getType() == Type.STATE) {
-        LOGGER.info("Emitting state: {}", message);
         outputRecordCollector.accept(message);
       }
     }

--- a/airbyte-integrations/connectors/source-e2e-test/src/main/java/io/airbyte/integrations/source/e2e_test/ContinuousFeedSource.java
+++ b/airbyte-integrations/connectors/source-e2e-test/src/main/java/io/airbyte/integrations/source/e2e_test/ContinuousFeedSource.java
@@ -76,8 +76,8 @@ public class ContinuousFeedSource extends BaseConnector implements Source {
             return endOfData();
           }
 
-          if(emittedMessages.get() == 500){
-            throw new RuntimeException("SOURCE EXCEPTION HAPPENED");
+          if(emittedMessages.get() > 50L){
+            throw new IllegalStateException("SOURCE EXCEPTION HAPPENED");
           }
 
           if (messageIntervalMs.isPresent() && emittedMessages.get() != 0) {

--- a/airbyte-integrations/connectors/source-e2e-test/src/main/java/io/airbyte/integrations/source/e2e_test/ContinuousFeedSource.java
+++ b/airbyte-integrations/connectors/source-e2e-test/src/main/java/io/airbyte/integrations/source/e2e_test/ContinuousFeedSource.java
@@ -76,6 +76,10 @@ public class ContinuousFeedSource extends BaseConnector implements Source {
             return endOfData();
           }
 
+          if(emittedMessages.get() == 500){
+            throw new RuntimeException("SOURCE EXCEPTION HAPPENED");
+          }
+
           if (messageIntervalMs.isPresent() && emittedMessages.get() != 0) {
             try {
               Thread.sleep(messageIntervalMs.get());


### PR DESCRIPTION
Demo of destination continuing to process records after source fails. Changes are:

1. Update E2E test source to fail mid-sync
2. Add logging to E2E destination to show records being processed
3. Add logging to Replication worker to show progress of sync

To test:
1. Check out this branch
2. Build source e2e connector: ./gradlew :airbyte-integrations:connectors:source-e2e-test:build
3. Build destination e2e connector: ./gradlew :airbyte-integrations:connectors:destination-e2e-test:build
4. Build platform: SUB_BUILD=PLATFORM ./gradlew build -x test
5. Set up a new Connection using the E2E Source Connector and E2E destination connector. For the E2E source connector, set max_records to 100. For the E2E destination connector, select "Throttled" and set millis_per_record to 500 milliseconds.
6. From your workspace, navigate to Settings -> Sources. Set the E2E Testing version to 'dev'
7. Navigate to Settings -> Destinations. Set the E2E Testing version to 'dev'
8. Run a sync. Logging should appear.