### PR TITLE
airbyte-server: tag span of additional OAuth routes

### DIFF
--- a/airbyte-server/src/main/java/io/airbyte/server/handlers/OAuthHandler.java
+++ b/airbyte-server/src/main/java/io/airbyte/server/handlers/OAuthHandler.java
@@ -116,8 +116,10 @@ public class OAuthHandler {
 
   public OAuthConsentRead getDestinationOAuthConsent(final DestinationOauthConsentRequest destinationOauthConsentRequest)
       throws JsonValidationException, ConfigNotFoundException, IOException {
-    ApmTraceUtils.addTagsToTrace(Map.of(WORKSPACE_ID_KEY, destinationOauthConsentRequest.getWorkspaceId(), DESTINATION_DEFINITION_ID_KEY,
-        destinationOauthConsentRequest.getDestinationDefinitionId()));
+    final Map<String, Object> traceTags = Map.of(WORKSPACE_ID_KEY, destinationOauthConsentRequest.getWorkspaceId(), DESTINATION_DEFINITION_ID_KEY,
+        destinationOauthConsentRequest.getDestinationDefinitionId());
+    ApmTraceUtils.addTagsToTrace(traceTags);
+    ApmTraceUtils.addTagsToRootSpan(traceTags);
 
     final StandardDestinationDefinition destinationDefinition =
         configRepository.getStandardDestinationDefinition(destinationOauthConsentRequest.getDestinationDefinitionId());
@@ -162,8 +164,10 @@ public class OAuthHandler {
 
   public Map<String, Object> completeSourceOAuth(final CompleteSourceOauthRequest completeSourceOauthRequest)
       throws JsonValidationException, ConfigNotFoundException, IOException {
-    ApmTraceUtils.addTagsToTrace(Map.of(WORKSPACE_ID_KEY, completeSourceOauthRequest.getWorkspaceId(), SOURCE_DEFINITION_ID_KEY,
-        completeSourceOauthRequest.getSourceDefinitionId()));
+    final Map<String, Object> traceTags = Map.of(WORKSPACE_ID_KEY, completeSourceOauthRequest.getWorkspaceId(), SOURCE_DEFINITION_ID_KEY,
+        completeSourceOauthRequest.getSourceDefinitionId());
+    ApmTraceUtils.addTagsToTrace(traceTags);
+    ApmTraceUtils.addTagsToRootSpan(traceTags);
 
     final StandardSourceDefinition sourceDefinition =
         configRepository.getStandardSourceDefinition(completeSourceOauthRequest.getSourceDefinitionId());
@@ -210,8 +214,10 @@ public class OAuthHandler {
 
   public Map<String, Object> completeDestinationOAuth(final CompleteDestinationOAuthRequest completeDestinationOAuthRequest)
       throws JsonValidationException, ConfigNotFoundException, IOException {
-    ApmTraceUtils.addTagsToTrace(Map.of(WORKSPACE_ID_KEY, completeDestinationOAuthRequest.getWorkspaceId(), DESTINATION_DEFINITION_ID_KEY,
-        completeDestinationOAuthRequest.getDestinationDefinitionId()));
+    final Map<String, Object> traceTags = Map.of(WORKSPACE_ID_KEY, completeDestinationOAuthRequest.getWorkspaceId(), SOURCE_DEFINITION_ID_KEY,
+        completeDestinationOAuthRequest.getDestinationDefinitionId());
+    ApmTraceUtils.addTagsToTrace(traceTags);
+    ApmTraceUtils.addTagsToRootSpan(traceTags);
 
     final StandardDestinationDefinition destinationDefinition =
         configRepository.getStandardDestinationDefinition(completeDestinationOAuthRequest.getDestinationDefinitionId());

--- a/airbyte-server/src/main/java/io/airbyte/server/handlers/OAuthHandler.java
+++ b/airbyte-server/src/main/java/io/airbyte/server/handlers/OAuthHandler.java
@@ -214,7 +214,7 @@ public class OAuthHandler {
 
   public Map<String, Object> completeDestinationOAuth(final CompleteDestinationOAuthRequest completeDestinationOAuthRequest)
       throws JsonValidationException, ConfigNotFoundException, IOException {
-    final Map<String, Object> traceTags = Map.of(WORKSPACE_ID_KEY, completeDestinationOAuthRequest.getWorkspaceId(), SOURCE_DEFINITION_ID_KEY,
+    final Map<String, Object> traceTags = Map.of(WORKSPACE_ID_KEY, completeDestinationOAuthRequest.getWorkspaceId(), DESTINATION_DEFINITION_ID_KEY,
         completeDestinationOAuthRequest.getDestinationDefinitionId());
     ApmTraceUtils.addTagsToTrace(traceTags);
     ApmTraceUtils.addTagsToRootSpan(traceTags);


### PR DESCRIPTION
## What
I forgot to add tags from additional OAuth routes after this initial [PR](https://github.com/airbytehq/airbyte/pull/20468/files#diff-a51e8edc400f0098044b097b2548f045beef41ad99958dcbe3be3dd6d19e2ca8).

## How
Tag the root span with definition and workspace id on `complete_oauth` + `get_consent_url` for sources and destinations.
