### PR TITLE
🪟 🐛 Fix non-breaking schema changes preference issues

### DIFF
--- a/airbyte-webapp/src/locales/en.json
+++ b/airbyte-webapp/src/locales/en.json
@@ -153,6 +153,7 @@
   "connectionForm.nonBreakingChangesPreference.label": "Non-breaking schema updates detected*",
   "connectionForm.nonBreakingChangesPreference.message": "Set how Airbyte handles syncs when it detects a non-breaking schema change in the source",
   "connectionForm.nonBreakingChangesPreference.ignore": "Ignore",
+  "connectionForm.nonBreakingChangesPreference.disable": "Disable connection",
   "connectionForm.schemaChangesBackdrop.message": "Please review the schema updates before making changes to the connection",
 
   "connectionForm.modal.destinationNamespace.title": "Destination namespace",

--- a/airbyte-webapp/src/views/Connection/ConnectionForm/components/NonBreakingChangesPreferenceField.module.scss
+++ b/airbyte-webapp/src/views/Connection/ConnectionForm/components/NonBreakingChangesPreferenceField.module.scss
@@ -9,12 +9,6 @@
   gap: variables.$spacing-md;
 }
 
-.connectorLabel {
-  max-width: 328px;
-  margin-right: variables.$spacing-xl;
-  vertical-align: top;
-}
-
 .leftFieldCol {
   flex: 1;
   max-width: 640px;

--- a/airbyte-webapp/src/views/Connection/ConnectionForm/components/NonBreakingChangesPreferenceField.tsx
+++ b/airbyte-webapp/src/views/Connection/ConnectionForm/components/NonBreakingChangesPreferenceField.tsx
@@ -30,7 +30,6 @@ export const NonBreakingChangesPreferenceField: React.FC<FieldProps<string>> = (
     <div className={styles.flexRow}>
       <div className={styles.leftFieldCol}>
         <ControlLabels
-          className={styles.connectorLabel}
           nextLine
           label={formatMessage({
             id: "connectionForm.nonBreakingChangesPreference.label",

--- a/airbyte-webapp/src/views/Connection/ConnectionForm/components/NonBreakingChangesPreferenceField.tsx
+++ b/airbyte-webapp/src/views/Connection/ConnectionForm/components/NonBreakingChangesPreferenceField.tsx
@@ -11,12 +11,13 @@ import { useConnectionFormService } from "hooks/services/ConnectionForm/Connecti
 
 import styles from "./NonBreakingChangesPreferenceField.module.scss";
 
+const SUPPORTED_PREFERENCES = [NonBreakingChangesPreference.ignore, NonBreakingChangesPreference.disable];
+
 export const NonBreakingChangesPreferenceField: React.FC<FieldProps<string>> = ({ field, form }) => {
   const { formatMessage } = useIntl();
 
   const preferenceOptions = useMemo(() => {
-    const values = Object.values(NonBreakingChangesPreference);
-    return values.map((value) => ({
+    return SUPPORTED_PREFERENCES.map((value) => ({
       value,
       label: formatMessage({ id: `connectionForm.nonBreakingChangesPreference.${value}` }),
       testId: `nonBreakingChangesPreference-${value}`,


### PR DESCRIPTION
## What
Fixes three issues:

* Adds missing i18n string for when sync is disabled
* Ensures that the options rendered are the ones we can support
* Custom styling on the label that is not necessary breaks when the resizing small