### PR TITLE
reduce await time on cancellation

### DIFF
--- a/airbyte-commons-worker/src/main/java/io/airbyte/workers/general/DefaultReplicationWorker.java
+++ b/airbyte-commons-worker/src/main/java/io/airbyte/workers/general/DefaultReplicationWorker.java
@@ -622,7 +622,8 @@ public class DefaultReplicationWorker implements ReplicationWorker {
     // Resources are closed in the opposite order they are declared.
     LOGGER.info("Cancelling replication worker...");
     try {
-      executors.awaitTermination(10, TimeUnit.SECONDS);
+      final boolean wasGracefulExit = executors.awaitTermination(100, TimeUnit.MILLISECONDS);
+      LOGGER.info("Executor exited {}", wasGracefulExit ? "gracefully" : "by timeout");
     } catch (final InterruptedException e) {
       ApmTraceUtils.addExceptionToTrace(e);
       LOGGER.error("Unable to cancel due to interruption.", e);


### PR DESCRIPTION
## What
* reduces a test that takes 10 seconds down to 240ms (`DefaultReplicationWorkerTest.testCancellation`)
* unclear why we need to wait as long as we were anyway as none of these threads do anything special on interrupted execeptions