### PR TITLE
remove old (unused) usages of heartbeat monitor

### DIFF
--- a/airbyte-commons-worker/src/main/java/io/airbyte/workers/internal/DefaultAirbyteSource.java
+++ b/airbyte-commons-worker/src/main/java/io/airbyte/workers/internal/DefaultAirbyteSource.java
@@ -49,6 +49,10 @@ public class DefaultAirbyteSource implements AirbyteSource {
   private Integer exitValue = null;
   private final boolean logConnectorMessages = new EnvVariableFeatureFlags().logConnectorMessages();
 
+  public DefaultAirbyteSource(final IntegrationLauncher integrationLauncher) {
+    this(integrationLauncher, new DefaultAirbyteStreamFactory(CONTAINER_LOG_MDC_BUILDER));
+  }
+
   public DefaultAirbyteSource(final IntegrationLauncher integrationLauncher, final AirbyteStreamFactory streamFactory) {
     this.integrationLauncher = integrationLauncher;
     this.streamFactory = streamFactory;

--- a/airbyte-commons-worker/src/main/java/io/airbyte/workers/internal/DefaultAirbyteSource.java
+++ b/airbyte-commons-worker/src/main/java/io/airbyte/workers/internal/DefaultAirbyteSource.java
@@ -6,7 +6,6 @@ package io.airbyte.workers.internal;
 
 import static io.airbyte.metrics.lib.ApmTraceConstants.WORKER_OPERATION_NAME;
 
-import com.google.common.annotations.VisibleForTesting;
 import com.google.common.base.Preconditions;
 import datadog.trace.api.Trace;
 import io.airbyte.commons.features.EnvVariableFeatureFlags;
@@ -36,7 +35,6 @@ public class DefaultAirbyteSource implements AirbyteSource {
 
   private static final Logger LOGGER = LoggerFactory.getLogger(DefaultAirbyteSource.class);
 
-  private static final Duration HEARTBEAT_FRESH_DURATION = Duration.of(5, ChronoUnit.MINUTES);
   private static final Duration GRACEFUL_SHUTDOWN_DURATION = Duration.of(1, ChronoUnit.MINUTES);
 
   public static final MdcScope.Builder CONTAINER_LOG_MDC_BUILDER = new Builder()
@@ -45,28 +43,15 @@ public class DefaultAirbyteSource implements AirbyteSource {
 
   private final IntegrationLauncher integrationLauncher;
   private final AirbyteStreamFactory streamFactory;
-  private final HeartbeatMonitor heartbeatMonitor;
 
   private Process sourceProcess = null;
   private Iterator<AirbyteMessage> messageIterator = null;
   private Integer exitValue = null;
   private final boolean logConnectorMessages = new EnvVariableFeatureFlags().logConnectorMessages();
 
-  public DefaultAirbyteSource(final IntegrationLauncher integrationLauncher) {
-    this(integrationLauncher, new DefaultAirbyteStreamFactory(CONTAINER_LOG_MDC_BUILDER));
-  }
-
   public DefaultAirbyteSource(final IntegrationLauncher integrationLauncher, final AirbyteStreamFactory streamFactory) {
-    this(integrationLauncher, streamFactory, new HeartbeatMonitor(HEARTBEAT_FRESH_DURATION));
-  }
-
-  @VisibleForTesting
-  DefaultAirbyteSource(final IntegrationLauncher integrationLauncher,
-                       final AirbyteStreamFactory streamFactory,
-                       final HeartbeatMonitor heartbeatMonitor) {
     this.integrationLauncher = integrationLauncher;
     this.streamFactory = streamFactory;
-    this.heartbeatMonitor = heartbeatMonitor;
   }
 
   @Trace(operationName = WORKER_OPERATION_NAME)
@@ -87,7 +72,6 @@ public class DefaultAirbyteSource implements AirbyteSource {
     logInitialStateAsJSON(sourceConfig);
 
     messageIterator = streamFactory.create(IOs.newBufferedReader(sourceProcess.getInputStream()))
-        .peek(message -> heartbeatMonitor.beat())
         .filter(message -> message.getType() == Type.RECORD || message.getType() == Type.STATE || message.getType() == Type.TRACE)
         .iterator();
   }

--- a/airbyte-commons-worker/src/test/java/io/airbyte/workers/WorkerUtilsTest.java
+++ b/airbyte-commons-worker/src/test/java/io/airbyte/workers/WorkerUtilsTest.java
@@ -5,30 +5,14 @@
 package io.airbyte.workers;
 
 import static org.junit.jupiter.api.Assertions.assertNotNull;
-import static org.mockito.Mockito.doAnswer;
-import static org.mockito.Mockito.mock;
-import static org.mockito.Mockito.verify;
-import static org.mockito.Mockito.verifyNoInteractions;
-import static org.mockito.Mockito.when;
 
 import com.fasterxml.jackson.databind.JsonNode;
-import io.airbyte.config.Configs;
-import io.airbyte.config.EnvConfigs;
 import io.airbyte.config.StandardSync;
 import io.airbyte.config.StandardSyncInput;
 import io.airbyte.protocol.models.AirbyteStreamNameNamespacePair;
-import io.airbyte.workers.internal.HeartbeatMonitor;
 import io.airbyte.workers.test_utils.TestConfigHelpers;
-import java.time.Duration;
-import java.time.temporal.ChronoUnit;
 import java.util.Map;
-import java.util.concurrent.TimeUnit;
-import java.util.concurrent.atomic.AtomicInteger;
-import java.util.function.BiConsumer;
 import org.apache.commons.lang3.tuple.ImmutablePair;
-import org.junit.jupiter.api.BeforeEach;
-import org.junit.jupiter.api.DisplayName;
-import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -36,94 +20,7 @@ import org.slf4j.LoggerFactory;
 @SuppressWarnings("PMD.JUnitTestsShouldIncludeAssert")
 class WorkerUtilsTest {
 
-  private static final Logger LOGGER = LoggerFactory.getLogger(GentleCloseWithHeartbeat.class);
-
-  @Nested
-  class GentleCloseWithHeartbeat {
-
-    private final Duration CHECK_HEARTBEAT_DURATION = Duration.of(10, ChronoUnit.MILLIS);
-
-    private final Duration SHUTDOWN_TIME_DURATION = Duration.of(100, ChronoUnit.MILLIS);
-
-    private Process process;
-    private HeartbeatMonitor heartbeatMonitor;
-    private BiConsumer<Process, Duration> forceShutdown;
-
-    @SuppressWarnings("unchecked")
-    @BeforeEach
-    void setup() {
-      process = mock(Process.class);
-      heartbeatMonitor = mock(HeartbeatMonitor.class);
-      forceShutdown = mock(BiConsumer.class);
-    }
-
-    private void runShutdown() {
-      gentleCloseWithHeartbeat(
-          new WorkerConfigs(new EnvConfigs()),
-          process,
-          heartbeatMonitor,
-          SHUTDOWN_TIME_DURATION,
-          CHECK_HEARTBEAT_DURATION,
-          SHUTDOWN_TIME_DURATION,
-          forceShutdown);
-    }
-
-    @SuppressWarnings("BusyWait")
-    @DisplayName("Verify that shutdown waits indefinitely when heartbeat and process are healthy.")
-    @Test
-    void testStartsWait() throws InterruptedException {
-      when(process.isAlive()).thenReturn(true);
-      final AtomicInteger recordedBeats = new AtomicInteger(0);
-      doAnswer((ignored) -> {
-        recordedBeats.incrementAndGet();
-        return true;
-      }).when(heartbeatMonitor).isBeating();
-
-      final Thread thread = new Thread(this::runShutdown);
-
-      thread.start();
-
-      // block until the loop is running.
-      while (recordedBeats.get() < 3) {
-        Thread.sleep(10);
-      }
-
-      thread.stop();
-    }
-
-    @Test
-    @DisplayName("Test heartbeat ends and graceful shutdown.")
-    void testGracefulShutdown() {
-      when(heartbeatMonitor.isBeating()).thenReturn(false);
-      when(process.isAlive()).thenReturn(false);
-
-      runShutdown();
-
-      verifyNoInteractions(forceShutdown);
-    }
-
-    @Test
-    @DisplayName("Test heartbeat ends and shutdown is forced.")
-    void testForcedShutdown() {
-      when(heartbeatMonitor.isBeating()).thenReturn(false);
-      when(process.isAlive()).thenReturn(true);
-
-      runShutdown();
-
-      verify(forceShutdown).accept(process, SHUTDOWN_TIME_DURATION);
-    }
-
-    @Test
-    @DisplayName("Test process dies.")
-    void testProcessDies() {
-      when(heartbeatMonitor.isBeating()).thenReturn(true);
-      when(process.isAlive()).thenReturn(false);
-      runShutdown();
-
-      verifyNoInteractions(forceShutdown);
-    }
-
-  }
+  private static final Logger LOGGER = LoggerFactory.getLogger(WorkerUtilsTest.class);
 
   @Test
   void testMapStreamNamesToSchemasWithNullNamespace() {
@@ -140,63 +37,6 @@ class WorkerUtilsTest {
     final Map<AirbyteStreamNameNamespacePair, JsonNode> mapOutput = WorkerUtils.mapStreamNamesToSchemas(syncInput);
     assertNotNull(mapOutput.get(new AirbyteStreamNameNamespacePair("user_preferences", "namespace")));
     assertNotNull(mapOutput.get(new AirbyteStreamNameNamespacePair("user_preferences", "namespace2")));
-  }
-
-  /**
-   * As long as the the heartbeatMonitor detects a heartbeat, the process will be allowed to continue.
-   * This method checks the heartbeat once every minute. Once there is no heartbeat detected, if the
-   * process has ended, then the method returns. If the process is still running it is given a grace
-   * period of the timeout arguments passed into the method. Once those expire the process is killed
-   * forcibly. If the process cannot be killed, this method will log that this is the case, but then
-   * returns.
-   *
-   * @param process - process to monitor.
-   * @param heartbeatMonitor - tracks if the heart is still beating for the given process.
-   * @param gracefulShutdownDuration - grace period to give the process to die after its heart stops
-   *        beating.
-   * @param checkHeartbeatDuration - frequency with which the heartbeat of the process is checked.
-   * @param forcedShutdownDuration - amount of time to wait if a process needs to be destroyed
-   *        forcibly.
-   */
-  static void gentleCloseWithHeartbeat(final WorkerConfigs workerConfigs,
-                                       final Process process,
-                                       final HeartbeatMonitor heartbeatMonitor,
-                                       final Duration gracefulShutdownDuration,
-                                       final Duration checkHeartbeatDuration,
-                                       final Duration forcedShutdownDuration,
-                                       final BiConsumer<Process, Duration> forceShutdown) {
-    while (process.isAlive() && heartbeatMonitor.isBeating()) {
-      try {
-        if (workerConfigs.getWorkerEnvironment().equals(Configs.WorkerEnvironment.KUBERNETES)) {
-          LOGGER.debug("Gently closing process {} with heartbeat..", process.info().commandLine().get());
-        }
-
-        process.waitFor(checkHeartbeatDuration.toMillis(), TimeUnit.MILLISECONDS);
-      } catch (final InterruptedException e) {
-        LOGGER.error("Exception while waiting for process to finish", e);
-      }
-    }
-
-    if (process.isAlive()) {
-      try {
-        if (workerConfigs.getWorkerEnvironment().equals(Configs.WorkerEnvironment.KUBERNETES)) {
-          LOGGER.debug("Gently closing process {} without heartbeat..", process.info().commandLine().get());
-        }
-
-        process.waitFor(gracefulShutdownDuration.toMillis(), TimeUnit.MILLISECONDS);
-      } catch (final InterruptedException e) {
-        LOGGER.error("Exception during grace period for process to finish. This can happen when cancelling jobs.");
-      }
-    }
-
-    // if we were unable to exist gracefully, force shutdown...
-    if (process.isAlive()) {
-      if (workerConfigs.getWorkerEnvironment().equals(Configs.WorkerEnvironment.KUBERNETES)) {
-        LOGGER.debug("Force shutdown process {}..", process.info().commandLine().get());
-      }
-
-      forceShutdown.accept(process, forcedShutdownDuration);
-    }
   }
 
 }

--- a/airbyte-commons-worker/src/test/java/io/airbyte/workers/WorkerUtilsTest.java
+++ b/airbyte-commons-worker/src/test/java/io/airbyte/workers/WorkerUtilsTest.java
@@ -14,13 +14,9 @@ import io.airbyte.workers.test_utils.TestConfigHelpers;
 import java.util.Map;
 import org.apache.commons.lang3.tuple.ImmutablePair;
 import org.junit.jupiter.api.Test;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 
 @SuppressWarnings("PMD.JUnitTestsShouldIncludeAssert")
 class WorkerUtilsTest {
-
-  private static final Logger LOGGER = LoggerFactory.getLogger(WorkerUtilsTest.class);
 
   @Test
   void testMapStreamNamesToSchemasWithNullNamespace() {


### PR DESCRIPTION
## What
* At some point we had a working heartbeat monitor that tracked that the source was regularly sending records to the platform. 
* At some point, it got partially disconnected. In other words, it doesn't work at all, but it still exists in the code.
* This PR removes the old, unused usages.
* Next PR will plug in a new heartbeat monitor

@davinchia a sanity check here would be appreciated.