### PR TITLE
add noise to cron scheduling

### DIFF
--- a/airbyte-workers/src/main/java/io/airbyte/workers/temporal/scheduling/activities/ConfigFetchActivityImpl.java
+++ b/airbyte-workers/src/main/java/io/airbyte/workers/temporal/scheduling/activities/ConfigFetchActivityImpl.java
@@ -39,14 +39,17 @@ import java.util.function.Supplier;
 import lombok.extern.slf4j.Slf4j;
 import org.joda.time.DateTimeZone;
 import org.quartz.CronExpression;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 @Slf4j
 @Singleton
 public class ConfigFetchActivityImpl implements ConfigFetchActivity {
 
+  private static final Logger LOGGER = LoggerFactory.getLogger(ConfigFetchActivityImpl.class);
   private final static long MS_PER_SECOND = 1000L;
   private final static long MIN_CRON_INTERVAL_SECONDS = 60;
-  private static final Set<UUID> SCHEDULING_NOISE_WORKSPACE_IDS = Set.of();
+  private static final Set<UUID> SCHEDULING_NOISE_WORKSPACE_IDS = Set.of(UUID.fromString("20810d92-41a4-4cfd-85db-fb50e77cf36b"));
   private static final long SCHEDULING_NOISE_CONSTANT = 15;
 
   private final ConfigRepository configRepository;
@@ -170,7 +173,9 @@ public class ConfigFetchActivityImpl implements ConfigFetchActivity {
     }
 
     // We really do want to add some scheduling noise for this connection.
-    timeToWait.plusMinutes((long) Math.random() * SCHEDULING_NOISE_CONSTANT);
+    final long minutesToWait = (long) (Math.random() * SCHEDULING_NOISE_CONSTANT);
+    LOGGER.debug("Adding {} minutes to wait", minutesToWait);
+    timeToWait.plusMinutes(minutesToWait);
   }
 
   /**

--- a/airbyte-workers/src/test/java/io/airbyte/workers/temporal/scheduling/activities/ConfigFetchActivityTest.java
+++ b/airbyte-workers/src/test/java/io/airbyte/workers/temporal/scheduling/activities/ConfigFetchActivityTest.java
@@ -4,6 +4,9 @@
 
 package io.airbyte.workers.temporal.scheduling.activities;
 
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.when;
+
 import io.airbyte.config.BasicSchedule;
 import io.airbyte.config.Cron;
 import io.airbyte.config.Schedule;
@@ -14,6 +17,7 @@ import io.airbyte.config.StandardSync.Status;
 import io.airbyte.config.persistence.ConfigNotFoundException;
 import io.airbyte.config.persistence.ConfigRepository;
 import io.airbyte.persistence.job.JobPersistence;
+import io.airbyte.persistence.job.WorkspaceHelper;
 import io.airbyte.persistence.job.models.Job;
 import io.airbyte.validation.json.JsonValidationException;
 import io.airbyte.workers.temporal.scheduling.activities.ConfigFetchActivity.ScheduleRetrieverInput;
@@ -31,7 +35,6 @@ import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.Mock;
-import org.mockito.Mockito;
 import org.mockito.junit.jupiter.MockitoExtension;
 
 @ExtendWith(MockitoExtension.class)
@@ -44,6 +47,9 @@ class ConfigFetchActivityTest {
 
   @Mock
   private JobPersistence mJobPersistence;
+
+  @Mock
+  private WorkspaceHelper mWorkspaceHelper;
 
   @Mock
   private Job mJob;
@@ -93,7 +99,8 @@ class ConfigFetchActivityTest {
   @BeforeEach
   void setup() {
     configFetchActivity =
-        new ConfigFetchActivityImpl(mConfigRepository, mJobPersistence, SYNC_JOB_MAX_ATTEMPTS, () -> Instant.now().getEpochSecond());
+        new ConfigFetchActivityImpl(mConfigRepository, mJobPersistence, mWorkspaceHelper, SYNC_JOB_MAX_ATTEMPTS,
+            () -> Instant.now().getEpochSecond());
   }
 
   @Nested
@@ -102,10 +109,10 @@ class ConfigFetchActivityTest {
     @Test
     @DisplayName("Test that the job gets scheduled if it is not manual and if it is the first run with legacy schedule schema")
     void testFirstJobNonManual() throws IOException, JsonValidationException, ConfigNotFoundException {
-      Mockito.when(mJobPersistence.getLastReplicationJob(connectionId))
+      when(mJobPersistence.getLastReplicationJob(connectionId))
           .thenReturn(Optional.empty());
 
-      Mockito.when(mConfigRepository.getStandardSync(connectionId))
+      when(mConfigRepository.getStandardSync(connectionId))
           .thenReturn(standardSyncWithLegacySchedule);
 
       final ScheduleRetrieverInput input = new ScheduleRetrieverInput(connectionId);
@@ -119,7 +126,7 @@ class ConfigFetchActivityTest {
     @Test
     @DisplayName("Test that the job will wait for a long time if it is manual in the legacy schedule schema")
     void testManual() throws IOException, JsonValidationException, ConfigNotFoundException {
-      Mockito.when(mConfigRepository.getStandardSync(connectionId))
+      when(mConfigRepository.getStandardSync(connectionId))
           .thenReturn(standardSyncWithoutSchedule);
 
       final ScheduleRetrieverInput input = new ScheduleRetrieverInput(connectionId);
@@ -133,7 +140,7 @@ class ConfigFetchActivityTest {
     @Test
     @DisplayName("Test that the job will wait for a long time if it is disabled")
     void testDisable() throws IOException, JsonValidationException, ConfigNotFoundException {
-      Mockito.when(mConfigRepository.getStandardSync(connectionId))
+      when(mConfigRepository.getStandardSync(connectionId))
           .thenReturn(standardSyncWithScheduleDisable);
 
       final ScheduleRetrieverInput input = new ScheduleRetrieverInput(connectionId);
@@ -147,7 +154,7 @@ class ConfigFetchActivityTest {
     @Test
     @DisplayName("Test that the connection will wait for a long time if it is deleted")
     void testDeleted() throws IOException, JsonValidationException, ConfigNotFoundException {
-      Mockito.when(mConfigRepository.getStandardSync(connectionId))
+      when(mConfigRepository.getStandardSync(connectionId))
           .thenReturn(standardSyncWithScheduleDeleted);
 
       final ScheduleRetrieverInput input = new ScheduleRetrieverInput(connectionId);
@@ -163,13 +170,13 @@ class ConfigFetchActivityTest {
     void testWait() throws IOException, JsonValidationException, ConfigNotFoundException {
       configFetchActivity = new ConfigFetchActivityImpl(mConfigRepository, mJobPersistence, SYNC_JOB_MAX_ATTEMPTS, () -> 60L * 3);
 
-      Mockito.when(mJob.getStartedAtInSecond())
+      when(mJob.getStartedAtInSecond())
           .thenReturn(Optional.of(60L));
 
-      Mockito.when(mJobPersistence.getLastReplicationJob(connectionId))
+      when(mJobPersistence.getLastReplicationJob(connectionId))
           .thenReturn(Optional.of(mJob));
 
-      Mockito.when(mConfigRepository.getStandardSync(connectionId))
+      when(mConfigRepository.getStandardSync(connectionId))
           .thenReturn(standardSyncWithLegacySchedule);
 
       final ScheduleRetrieverInput input = new ScheduleRetrieverInput(connectionId);
@@ -185,13 +192,13 @@ class ConfigFetchActivityTest {
     void testNotWaitIfLate() throws IOException, JsonValidationException, ConfigNotFoundException {
       configFetchActivity = new ConfigFetchActivityImpl(mConfigRepository, mJobPersistence, SYNC_JOB_MAX_ATTEMPTS, () -> 60L * 10);
 
-      Mockito.when(mJob.getStartedAtInSecond())
+      when(mJob.getStartedAtInSecond())
           .thenReturn(Optional.of(60L));
 
-      Mockito.when(mJobPersistence.getLastReplicationJob(connectionId))
+      when(mJobPersistence.getLastReplicationJob(connectionId))
           .thenReturn(Optional.of(mJob));
 
-      Mockito.when(mConfigRepository.getStandardSync(connectionId))
+      when(mConfigRepository.getStandardSync(connectionId))
           .thenReturn(standardSyncWithLegacySchedule);
 
       final ScheduleRetrieverInput input = new ScheduleRetrieverInput(connectionId);
@@ -207,7 +214,7 @@ class ConfigFetchActivityTest {
   @Test
   @DisplayName("Test that the job will wait a long time if it is MANUAL scheduleType")
   void testManualScheduleType() throws IOException, JsonValidationException, ConfigNotFoundException {
-    Mockito.when(mConfigRepository.getStandardSync(connectionId))
+    when(mConfigRepository.getStandardSync(connectionId))
         .thenReturn(standardSyncWithManualScheduleType);
 
     final ScheduleRetrieverInput input = new ScheduleRetrieverInput(connectionId);
@@ -221,10 +228,10 @@ class ConfigFetchActivityTest {
   @Test
   @DisplayName("Test that the job will be immediately scheduled if it is a BASIC_SCHEDULE type on the first run")
   void testBasicScheduleTypeFirstRun() throws IOException, JsonValidationException, ConfigNotFoundException {
-    Mockito.when(mJobPersistence.getLastReplicationJob(connectionId))
+    when(mJobPersistence.getLastReplicationJob(connectionId))
         .thenReturn(Optional.empty());
 
-    Mockito.when(mConfigRepository.getStandardSync(connectionId))
+    when(mConfigRepository.getStandardSync(connectionId))
         .thenReturn(standardSyncWithBasicScheduleType);
 
     final ScheduleRetrieverInput input = new ScheduleRetrieverInput(connectionId);
@@ -240,13 +247,13 @@ class ConfigFetchActivityTest {
   void testBasicScheduleSubsequentRun() throws IOException, JsonValidationException, ConfigNotFoundException {
     configFetchActivity = new ConfigFetchActivityImpl(mConfigRepository, mJobPersistence, SYNC_JOB_MAX_ATTEMPTS, () -> 60L * 3);
 
-    Mockito.when(mJob.getStartedAtInSecond())
+    when(mJob.getStartedAtInSecond())
         .thenReturn(Optional.of(60L));
 
-    Mockito.when(mJobPersistence.getLastReplicationJob(connectionId))
+    when(mJobPersistence.getLastReplicationJob(connectionId))
         .thenReturn(Optional.of(mJob));
 
-    Mockito.when(mConfigRepository.getStandardSync(connectionId))
+    when(mConfigRepository.getStandardSync(connectionId))
         .thenReturn(standardSyncWithBasicScheduleType);
 
     final ScheduleRetrieverInput input = new ScheduleRetrieverInput(connectionId);
@@ -266,13 +273,16 @@ class ConfigFetchActivityTest {
     mockRightNow.set(Calendar.SECOND, 0);
     mockRightNow.set(Calendar.MILLISECOND, 0);
 
-    configFetchActivity =
-        new ConfigFetchActivityImpl(mConfigRepository, mJobPersistence, SYNC_JOB_MAX_ATTEMPTS, () -> mockRightNow.getTimeInMillis() / 1000L);
+    when(mWorkspaceHelper.getWorkspaceForConnectionId(any())).thenReturn(UUID.randomUUID());
 
-    Mockito.when(mJobPersistence.getLastReplicationJob(connectionId))
+    configFetchActivity =
+        new ConfigFetchActivityImpl(mConfigRepository, mJobPersistence, mWorkspaceHelper, SYNC_JOB_MAX_ATTEMPTS,
+            () -> mockRightNow.getTimeInMillis() / 1000L);
+
+    when(mJobPersistence.getLastReplicationJob(connectionId))
         .thenReturn(Optional.of(mJob));
 
-    Mockito.when(mConfigRepository.getStandardSync(connectionId))
+    when(mConfigRepository.getStandardSync(connectionId))
         .thenReturn(standardSyncWithCronScheduleType);
 
     final ScheduleRetrieverInput input = new ScheduleRetrieverInput(connectionId);
@@ -292,14 +302,17 @@ class ConfigFetchActivityTest {
     mockRightNow.set(Calendar.SECOND, 0);
     mockRightNow.set(Calendar.MILLISECOND, 0);
 
-    configFetchActivity =
-        new ConfigFetchActivityImpl(mConfigRepository, mJobPersistence, SYNC_JOB_MAX_ATTEMPTS, () -> mockRightNow.getTimeInMillis() / 1000L);
+    when(mWorkspaceHelper.getWorkspaceForConnectionId(any())).thenReturn(UUID.randomUUID());
 
-    Mockito.when(mJob.getStartedAtInSecond()).thenReturn(Optional.of(mockRightNow.getTimeInMillis() / 1000L));
-    Mockito.when(mJobPersistence.getLastReplicationJob(connectionId))
+    configFetchActivity =
+        new ConfigFetchActivityImpl(mConfigRepository, mJobPersistence, mWorkspaceHelper, SYNC_JOB_MAX_ATTEMPTS,
+            () -> mockRightNow.getTimeInMillis() / 1000L);
+
+    when(mJob.getStartedAtInSecond()).thenReturn(Optional.of(mockRightNow.getTimeInMillis() / 1000L));
+    when(mJobPersistence.getLastReplicationJob(connectionId))
         .thenReturn(Optional.of(mJob));
 
-    Mockito.when(mConfigRepository.getStandardSync(connectionId))
+    when(mConfigRepository.getStandardSync(connectionId))
         .thenReturn(standardSyncWithCronScheduleType);
 
     final ScheduleRetrieverInput input = new ScheduleRetrieverInput(connectionId);


### PR DESCRIPTION
## What
Adds 0-15 minutes of random noise to cron scheduling.

The time is always added, never subtracted. It's restricted to an allow-listed set of workspaces (empty in this PR).