### PR TITLE
:window: :art: Move `Add` button into the line of Connector Builder key value list fields

### DIFF
--- a/airbyte-webapp/src/components/GroupControls/GroupControls.module.scss
+++ b/airbyte-webapp/src/components/GroupControls/GroupControls.module.scss
@@ -36,11 +36,10 @@ $border-width: variables.$border-thick;
   white-space: nowrap;
 }
 
-.dropdown {
+.control {
   margin-left: auto;
   padding: 0 variables.$spacing-xs;
   background-color: colors.$white;
-  min-width: calc(50% - 100px);
 }
 
 .content {

--- a/airbyte-webapp/src/components/GroupControls/GroupControls.tsx
+++ b/airbyte-webapp/src/components/GroupControls/GroupControls.tsx
@@ -1,21 +1,29 @@
+import classNames from "classnames";
 import React from "react";
 
 import styles from "./GroupControls.module.scss";
 
 interface GroupControlsProps {
   label: React.ReactNode;
-  dropdown?: React.ReactNode;
+  control?: React.ReactNode;
+  controlClassName?: string;
   name?: string;
 }
 
-const GroupControls: React.FC<React.PropsWithChildren<GroupControlsProps>> = ({ label, dropdown, children, name }) => {
+const GroupControls: React.FC<React.PropsWithChildren<GroupControlsProps>> = ({
+  label,
+  control,
+  children,
+  name,
+  controlClassName,
+}) => {
   return (
     // This outer div is necessary for .content > :first-child padding to be properly applied in the case of nested GroupControls
     <div>
       <div className={styles.container}>
         <div className={styles.title}>
           <div className={styles.label}>{label}</div>
-          <div className={styles.dropdown}>{dropdown}</div>
+          <div className={classNames(styles.control, controlClassName)}>{control}</div>
         </div>
         <div className={styles.content} data-testid={name}>
           {children}

--- a/airbyte-webapp/src/components/GroupControls/index.stories.tsx
+++ b/airbyte-webapp/src/components/GroupControls/index.stories.tsx
@@ -1,5 +1,6 @@
 import { ComponentStory, ComponentMeta } from "@storybook/react";
 
+import { Button } from "components/ui/Button";
 import { Card } from "components/ui/Card";
 
 import { FormBlock, FormConditionItem } from "core/form/types";
@@ -64,6 +65,24 @@ Empty.args = {
 export const WithContent = Template.bind({});
 WithContent.args = {
   label,
+  children: (
+    <>
+      <SectionContainer>Content part 1</SectionContainer>
+      <SectionContainer>Content part 2</SectionContainer>
+    </>
+  ),
+};
+
+export const EmptyWithControl = Template.bind({});
+EmptyWithControl.args = {
+  label,
+  control: <Button variant="secondary">Test</Button>,
+};
+
+export const ControlAndContent = Template.bind({});
+ControlAndContent.args = {
+  label,
+  control: <Button variant="secondary">Test</Button>,
   children: (
     <>
       <SectionContainer>Content part 1</SectionContainer>

--- a/airbyte-webapp/src/components/GroupControls/index.stories.tsx
+++ b/airbyte-webapp/src/components/GroupControls/index.stories.tsx
@@ -76,13 +76,13 @@ WithContent.args = {
 export const EmptyWithControl = Template.bind({});
 EmptyWithControl.args = {
   label,
-  control: <Button variant="secondary">Test</Button>,
+  control: <Button variant="secondary">Control</Button>,
 };
 
 export const ControlAndContent = Template.bind({});
 ControlAndContent.args = {
   label,
-  control: <Button variant="secondary">Test</Button>,
+  control: <Button variant="secondary">Control</Button>,
   children: (
     <>
       <SectionContainer>Content part 1</SectionContainer>

--- a/airbyte-webapp/src/components/connectorBuilder/Builder/KeyValueListField.tsx
+++ b/airbyte-webapp/src/components/connectorBuilder/Builder/KeyValueListField.tsx
@@ -49,7 +49,14 @@ export const KeyValueListField: React.FC<KeyValueListFieldProps> = ({ path, labe
   const [{ value: keyValueList }, , { setValue: setKeyValueList }] = useField<Array<[string, string]>>(path);
 
   return (
-    <GroupControls label={<ControlLabels label={label} infoTooltipContent={tooltip} />}>
+    <GroupControls
+      label={<ControlLabels label={label} infoTooltipContent={tooltip} />}
+      control={
+        <Button variant="secondary" onClick={() => setKeyValueList([...keyValueList, ["", ""]])}>
+          <FormattedMessage id="connectorBuilder.addKeyValue" />
+        </Button>
+      }
+    >
       {keyValueList.map((keyValue, keyValueIndex) => (
         <KeyValueInput
           key={keyValueIndex}
@@ -64,11 +71,6 @@ export const KeyValueListField: React.FC<KeyValueListFieldProps> = ({ path, labe
           }}
         />
       ))}
-      <div>
-        <Button variant="secondary" onClick={() => setKeyValueList([...keyValueList, ["", ""]])}>
-          <FormattedMessage id="connectorBuilder.addKeyValue" />
-        </Button>
-      </div>
     </GroupControls>
   );
 };

--- a/airbyte-webapp/src/views/Connector/ConnectorForm/components/Sections/ConditionSection.module.scss
+++ b/airbyte-webapp/src/views/Connector/ConnectorForm/components/Sections/ConditionSection.module.scss
@@ -1,0 +1,3 @@
+.dropdown {
+  min-width: calc(50% - 100px);
+}

--- a/airbyte-webapp/src/views/Connector/ConnectorForm/components/Sections/ConditionSection.tsx
+++ b/airbyte-webapp/src/views/Connector/ConnectorForm/components/Sections/ConditionSection.tsx
@@ -9,6 +9,7 @@ import { isDefined } from "utils/common";
 
 import { useConnectorForm } from "../../connectorFormContext";
 import { ConnectorFormValues } from "../../types";
+import styles from "./ConditionSection.module.scss";
 import { FormSection } from "./FormSection";
 import { GroupLabel } from "./GroupLabel";
 import { SectionContainer } from "./SectionContainer";
@@ -67,7 +68,7 @@ export const ConditionSection: React.FC<ConditionSectionProps> = ({ formField, p
       <GroupControls
         key={`form-field-group-${formField.fieldKey}`}
         label={<GroupLabel formField={formField} />}
-        dropdown={
+        control={
           <DropDown
             options={options}
             onChange={onOptionChange}
@@ -77,6 +78,7 @@ export const ConditionSection: React.FC<ConditionSectionProps> = ({ formField, p
             error={typeof meta.error === "string" && !!meta.error}
           />
         }
+        controlClassName={styles.dropdown}
       >
         <FormSection
           blocks={formField.conditions[currentlySelectedCondition]}


### PR DESCRIPTION
## What
I felt that the request options components of the connector builder were taking up too much space when no entries had been added:
<img width="700" alt="Screen Shot 2022-12-19 at 6 35 11 PM" src="https://user-images.githubusercontent.com/22731524/208568638-c53a97be-78f3-4d40-8e6c-03370da96f3a.png">


## How
In order to address this, I wanted to try out moving the `Add` button into the top line of this component. To accomplish this, I modified the GroupControls component to take in a generic "control" rather than specifically a "dropdown", and moved the add button into there, achieving this look:
<img width="700" alt="Screen Shot 2022-12-19 at 6 35 22 PM" src="https://user-images.githubusercontent.com/22731524/208568649-a01002dc-6227-4536-bdc3-0e843eafa0a6.png">

This also has the nice benefit of keeping the Add button in the same place when clicked, rather than it jumping down below the newly added entry.
