### PR TITLE
fix a bug where the OAuthAuthenticator was misnamed

### DIFF
--- a/airbyte-cdk/python/CHANGELOG.md
+++ b/airbyte-cdk/python/CHANGELOG.md
@@ -1,5 +1,8 @@
 # Changelog
 
+## 0.16.2
+Fix the naming of OAuthAuthenticator
+
 ## 0.16.1
 Include declarative_component_schema.yaml in the publish to PyPi
 

--- a/airbyte-cdk/python/airbyte_cdk/sources/declarative/declarative_component_schema.yaml
+++ b/airbyte-cdk/python/airbyte_cdk/sources/declarative/declarative_component_schema.yaml
@@ -363,8 +363,8 @@ definitions:
       $options:
         type: object
         additionalProperties: true
-  DeclarativeOauth2Authenticator:
-    description: Authenticator for requests using Oauth authentication
+  OAuthAuthenticator:
+    description: Authenticator for requests using OAuth 2.0 authentication
     type: object
     required:
       - type
@@ -375,7 +375,7 @@ definitions:
     properties:
       type:
         type: string
-        enum: [DeclarativeOauth2Authenticator]
+        enum: [OAuthAuthenticator]
       client_id:
         type: string
       client_secret:
@@ -580,7 +580,7 @@ definitions:
           - "$ref": "#/definitions/BasicHttpAuthenticator"
           - "$ref": "#/definitions/BearerAuthenticator"
           - "$ref": "#/definitions/CustomAuthenticator"
-          - "$ref": "#/definitions/DeclarativeOauth2Authenticator"
+          - "$ref": "#/definitions/OAuthAuthenticator"
           - "$ref": "#/definitions/NoAuth"
           - "$ref": "#/definitions/SessionTokenAuthenticator"
       error_handler:

--- a/airbyte-cdk/python/airbyte_cdk/sources/declarative/parsers/class_types_registry.py
+++ b/airbyte-cdk/python/airbyte_cdk/sources/declarative/parsers/class_types_registry.py
@@ -19,6 +19,8 @@ from airbyte_cdk.sources.declarative.extractors.dpath_extractor import DpathExtr
 from airbyte_cdk.sources.declarative.extractors.record_selector import RecordSelector
 from airbyte_cdk.sources.declarative.interpolation.interpolated_boolean import InterpolatedBoolean
 from airbyte_cdk.sources.declarative.interpolation.interpolated_string import InterpolatedString
+from airbyte_cdk.sources.declarative.requesters import RequestOption
+from airbyte_cdk.sources.declarative.requesters.error_handlers import HttpResponseFilter
 from airbyte_cdk.sources.declarative.requesters.error_handlers.backoff_strategies.constant_backoff_strategy import ConstantBackoffStrategy
 from airbyte_cdk.sources.declarative.requesters.error_handlers.backoff_strategies.exponential_backoff_strategy import (
     ExponentialBackoffStrategy,
@@ -37,6 +39,7 @@ from airbyte_cdk.sources.declarative.requesters.paginators.no_pagination import 
 from airbyte_cdk.sources.declarative.requesters.paginators.strategies.cursor_pagination_strategy import CursorPaginationStrategy
 from airbyte_cdk.sources.declarative.requesters.paginators.strategies.offset_increment import OffsetIncrement
 from airbyte_cdk.sources.declarative.requesters.paginators.strategies.page_increment import PageIncrement
+from airbyte_cdk.sources.declarative.requesters.request_options import InterpolatedRequestOptionsProvider
 from airbyte_cdk.sources.declarative.retrievers.simple_retriever import SimpleRetriever
 from airbyte_cdk.sources.declarative.schema.inline_schema_loader import InlineSchemaLoader
 from airbyte_cdk.sources.declarative.schema.json_file_schema_loader import JsonFileSchemaLoader
@@ -45,7 +48,7 @@ from airbyte_cdk.sources.declarative.stream_slicers.cartesian_product_stream_sli
 from airbyte_cdk.sources.declarative.stream_slicers.datetime_stream_slicer import DatetimeStreamSlicer
 from airbyte_cdk.sources.declarative.stream_slicers.list_stream_slicer import ListStreamSlicer
 from airbyte_cdk.sources.declarative.stream_slicers.single_slice import SingleSlice
-from airbyte_cdk.sources.declarative.stream_slicers.substream_slicer import SubstreamSlicer
+from airbyte_cdk.sources.declarative.stream_slicers.substream_slicer import ParentStreamConfig, SubstreamSlicer
 from airbyte_cdk.sources.declarative.transformations import RemoveFields
 from airbyte_cdk.sources.declarative.transformations.add_fields import AddFields
 
@@ -69,8 +72,10 @@ CLASS_TYPES_REGISTRY: Mapping[str, Type] = {
     "DpathExtractor": DpathExtractor,
     "ExponentialBackoffStrategy": ExponentialBackoffStrategy,
     "HttpRequester": HttpRequester,
+    "HttpResponseFilter": HttpResponseFilter,
     "InlineSchemaLoader": InlineSchemaLoader,
     "InterpolatedBoolean": InterpolatedBoolean,
+    "InterpolatedRequestOptionsProvider": InterpolatedRequestOptionsProvider,
     "InterpolatedString": InterpolatedString,
     "JsonSchema": JsonFileSchemaLoader,  # todo remove after hacktoberfest and update connectors to use JsonFileSchemaLoader
     "JsonFileSchemaLoader": JsonFileSchemaLoader,
@@ -81,7 +86,9 @@ CLASS_TYPES_REGISTRY: Mapping[str, Type] = {
     "OAuthAuthenticator": DeclarativeOauth2Authenticator,
     "OffsetIncrement": OffsetIncrement,
     "PageIncrement": PageIncrement,
+    "ParentStreamConfig": ParentStreamConfig,
     "RecordSelector": RecordSelector,
+    "RequestOption": RequestOption,
     "RemoveFields": RemoveFields,
     "SimpleRetriever": SimpleRetriever,
     "SingleSlice": SingleSlice,

--- a/airbyte-cdk/python/airbyte_cdk/sources/declarative/parsers/manifest_component_transformer.py
+++ b/airbyte-cdk/python/airbyte_cdk/sources/declarative/parsers/manifest_component_transformer.py
@@ -26,7 +26,7 @@ DEFAULT_MODEL_TYPES: Mapping[str, str] = {
     "DeclarativeSource.streams": "DeclarativeStream",
     # DeclarativeStream
     "DeclarativeStream.retriever": "SimpleRetriever",
-    "DeclarativeStream.schema_loader": "DefaultSchemaLoader",
+    "DeclarativeStream.schema_loader": "JsonFileSchemaLoader",
     # DefaultErrorHandler
     "DefaultErrorHandler.response_filters": "HttpResponseFilter",
     # DefaultPaginator

--- a/airbyte-cdk/python/setup.py
+++ b/airbyte-cdk/python/setup.py
@@ -15,7 +15,7 @@ README = (HERE / "README.md").read_text()
 
 setup(
     name="airbyte-cdk",
-    version="0.16.1",
+    version="0.16.2",
     description="A framework for writing Airbyte Connectors.",
     long_description=README,
     long_description_content_type="text/markdown",

--- a/airbyte-cdk/python/unit_tests/sources/declarative/parsers/test_manifest_component_transformer.py
+++ b/airbyte-cdk/python/unit_tests/sources/declarative/parsers/test_manifest_component_transformer.py
@@ -17,7 +17,7 @@ from airbyte_cdk.sources.declarative.parsers.manifest_component_transformer impo
                     {
                         "type": "DeclarativeStream",
                         "retriever": {"type": "SimpleRetriever"},
-                        "schema_loader": {"type": "DefaultSchemaLoader"},
+                        "schema_loader": {"type": "JsonFileSchemaLoader"},
                     }
                 ],
             },


### PR DESCRIPTION
## What
https://github.com/airbytehq/airbyte/pull/20422#issuecomment-1358660835

Fixes a small bug where the correct component name in our existing code was `OAuthAuthenticator`, but in the handwritten schema I accidentally named it `DeclarativeOauthAuthenticator` which impacted someone developing an integration using that component.

## How
Correctly renames the component in the schema used to validate manifests:

Example of correct manifest which was tested against:
```
authenticator:
  type: "OAuthAuthenticator"
  token_refresh_endpoint: "{{ config['token_refresh_endpoint'] }}"
  client_id: "{{ config['client_id'] }}"
  client_secret: "{{ config['client_secret'] }}"
  refresh_token: ""
  refresh_request_body: 
    audience: "{{ config['graphql_endpoint'] }}"
  grant_type: "client_credentials"
```