### PR TITLE
🪟 🎨 Fixed wrong color on hover "Cancel" sync button

### DIFF
--- a/airbyte-webapp/src/pages/ConnectionPage/pages/ConnectionItemPage/ConnectionStatusTab.module.scss
+++ b/airbyte-webapp/src/pages/ConnectionPage/pages/ConnectionItemPage/ConnectionStatusTab.module.scss
@@ -12,7 +12,6 @@
   display: flex;
 
   .resetButton,
-  .cancelButton,
   .syncButton {
     display: flex;
     align-items: center;
@@ -21,16 +20,6 @@
 
   .resetButton {
     margin-right: variables.$spacing-md;
-  }
-
-  .cancelButton {
-    border-color: transparent;
-    background-color: colors.$red;
-
-    .iconXmark {
-      margin-right: 12px;
-      font-size: 18px;
-    }
   }
 
   .syncButton {

--- a/airbyte-webapp/src/pages/ConnectionPage/pages/ConnectionItemPage/ConnectionStatusTab.tsx
+++ b/airbyte-webapp/src/pages/ConnectionPage/pages/ConnectionItemPage/ConnectionStatusTab.tsx
@@ -147,10 +147,10 @@ export const ConnectionStatusTab: React.FC = () => {
 
   const cancelJobBtn = (
     <Button
-      className={styles.cancelButton}
+      variant="danger"
       disabled={!activeJob?.id || activeJob.isCanceling}
       onClick={onCancelJob}
-      icon={<FontAwesomeIcon className={styles.iconXmark} icon={faXmark} />}
+      icon={<FontAwesomeIcon icon={faXmark} />}
     >
       {label}
     </Button>


### PR DESCRIPTION
## What
Resolves https://github.com/airbytehq/airbyte/issues/20728

## How
Remove the redundant button style and use the button's "dander" variant instead.

_Thoughts:_ IMO this was caused during the transition Button component from `styled-components` to `css-modules`

![CPT2212211401-273x81](https://user-images.githubusercontent.com/20929344/208900816-1c41c158-4808-4384-8f2b-06d605e76372.gif)
