### PR TITLE
Remove "Transfer" title from card in replication settings when new table is enabled

### DIFF
--- a/airbyte-webapp/src/views/Connection/ConnectionForm/ConnectionFormFields.tsx
+++ b/airbyte-webapp/src/views/Connection/ConnectionForm/ConnectionFormFields.tsx
@@ -9,7 +9,6 @@ import { useUnmount } from "react-use";
 import { ControlLabels } from "components";
 import { FormChangeTracker } from "components/common/FormChangeTracker";
 import { Button } from "components/ui/Button";
-import { Heading } from "components/ui/Heading";
 import { Input } from "components/ui/Input";
 
 import { NamespaceDefinitionType } from "core/request/AirbyteClient";
@@ -51,23 +50,21 @@ export const ConnectionFormFields: React.FC<ConnectionFormFieldsProps> = ({ valu
   });
 
   const isNewStreamsTableEnabled = process.env.REACT_APP_NEW_STREAMS_TABLE ?? false;
+  const firstSectionTitle = isNewStreamsTableEnabled ? undefined : <FormattedMessage id="connection.transfer" />;
 
   return (
     <>
       {/* FormChangeTracker is here as it has access to everything it needs without being repeated */}
       <FormChangeTracker changed={dirty} formId={formId} />
       <div className={styles.formContainer}>
-        <Section title={<FormattedMessage id="connection.transfer" />}>
+        <Section title={firstSectionTitle}>
           <ScheduleField />
           {allowAutoDetectSchema && (
             <Field name="nonBreakingChangesPreference" component={NonBreakingChangesPreferenceField} />
           )}
         </Section>
         {!isNewStreamsTableEnabled && (
-          <Section>
-            <Heading as="h2" size="sm">
-              <FormattedMessage id="connection.streams" />
-            </Heading>
+          <Section title={<FormattedMessage id="connection.streams" />}>
             <span className={readonlyClass}>
               <Field name="namespaceDefinition" component={NamespaceDefinitionField} />
             </span>


### PR DESCRIPTION
## What
Resolves #20452 

Removes the "Transfer" Title when the new table is enabled so that it matches the design:
![image](https://user-images.githubusercontent.com/168664/208962715-cd22cd90-3ec0-41f9-bab7-c846ceb445de.png)



