### PR TITLE
Exclude Era date from common v1 dataset

### DIFF
--- a/airbyte-integrations/bases/standard-destination-test/src/main/resources/v1/data_type_basic_test_messages.txt
+++ b/airbyte-integrations/bases/standard-destination-test/src/main/resources/v1/data_type_basic_test_messages.txt
@@ -5,7 +5,6 @@
 {"type": "RECORD", "record": {"stream": "date_test_1", "emitted_at": 1602637589200, "data": { "data" : "1504-02-29" }}}
 {"type": "RECORD", "record": {"stream": "date_test_1", "emitted_at": 1602637589300, "data": { "data" : "9999-12-23" }}}
 {"type": "RECORD", "record": {"stream": "datetime_test_1", "emitted_at": 1602637589100, "data": { "data" : "2022-01-23T01:23:45Z" }}}
-{"type": "RECORD", "record": {"stream": "datetime_test_1", "emitted_at": 1602637589200, "data": { "data" : "2022-01-23T01:23:45.678-11:30 BC" }}}
 {"type": "RECORD", "record": {"stream": "datetime_test_1", "emitted_at": 1602637589300, "data": { "data" : "9999-12-23T01:23:45Z" }}}
 {"type": "RECORD", "record": {"stream": "datetime_test_2", "emitted_at": 1602637589100, "data": { "data" : "2022-11-22T01:23:45" }}}
 {"type": "RECORD", "record": {"stream": "datetime_test_2", "emitted_at": 1602637589200, "data": { "data" : "1504-02-29T01:23:45" }}}


### PR DESCRIPTION
## What
Era dates is not supported by all destinations. The era dates should be checked by connectors which supports it
## How
Exclude Era date from common dataset. Add separate tests for era date with https://github.com/airbytehq/airbyte-internal-issues/issues/1253

## Recommended reading order
1. `x.java`
2. `y.python`

## 🚨 User Impact 🚨
No Impact.
