### PR TITLE
Fix the bug introduced by this commit 350d5443a19e0c8db8aec0eae74624e2235c7d3f

### DIFF
--- a/airbyte-config/init/src/main/resources/seed/destination_definitions.yaml
+++ b/airbyte-config/init/src/main/resources/seed/destination_definitions.yaml
@@ -60,10 +60,6 @@
   dockerImageTag: 1.2.9
   documentationUrl: https://docs.airbyte.com/integrations/destinations/bigquery
   icon: bigquery.svg
-  normalizationConfig:
-    normalizationRepository: airbyte/normalization
-    normalizationTag: 0.2.25
-    normalizationIntegrationType: bigquery
   resourceRequirements:
     jobSpecific:
       - jobType: sync


### PR DESCRIPTION
Destination BigQuery denormalized does not support normalization. The change that added normalization definitions to actor definitions table (https://github.com/airbytehq/airbyte/commit/350d5443a19e0c8db8aec0eae74624e2235c7d3f) broke DATs for bigquery denormalized by erroneously adding normalization config for it. This change removes normalization config from `destination-bigquery-denormalized` in `destination_definitions.yaml`