### PR TITLE
SAT: check for nullity of docker runner in `previous_discovered_catalog`

### DIFF
--- a/airbyte-integrations/bases/source-acceptance-test/CHANGELOG.md
+++ b/airbyte-integrations/bases/source-acceptance-test/CHANGELOG.md
@@ -1,5 +1,8 @@
 # Changelog
 
+## 0.2.24
+Check for nullity of docker runner in `previous_discovered_catalog_fixture`.[#20899](https://github.com/airbytehq/airbyte/pull/20899)
+
 ## 0.2.23
 Skip backward compatibility tests on specifications if actual and previous specifications and discovered catalogs are identical.[#20435](https://github.com/airbytehq/airbyte/pull/20435)
 

--- a/airbyte-integrations/bases/source-acceptance-test/Dockerfile
+++ b/airbyte-integrations/bases/source-acceptance-test/Dockerfile
@@ -33,7 +33,7 @@ COPY pytest.ini setup.py ./
 COPY source_acceptance_test ./source_acceptance_test
 RUN pip install .
 
-LABEL io.airbyte.version=0.2.23
+LABEL io.airbyte.version=0.2.24
 LABEL io.airbyte.name=airbyte/source-acceptance-test
 
 ENTRYPOINT ["python", "-m", "pytest", "-p", "source_acceptance_test.plugin", "-r", "fEsx"]

--- a/airbyte-integrations/bases/source-acceptance-test/source_acceptance_test/conftest.py
+++ b/airbyte-integrations/bases/source-acceptance-test/source_acceptance_test/conftest.py
@@ -272,6 +272,11 @@ def previous_discovered_catalog_fixture(
     connector_config, previous_connector_docker_runner: ConnectorRunner, previous_cached_schemas
 ) -> MutableMapping[str, AirbyteStream]:
     """JSON schemas for each stream"""
+    if previous_connector_docker_runner is None:
+        logging.warning(
+            "\n We could not retrieve the previous connector spec as a connector runner for the previous connector version could not be instantiated."
+        )
+        return None
     if not previous_cached_schemas:
         output = previous_connector_docker_runner.call_discover(config=connector_config)
         catalogs = [message.catalog for message in output if message.type == Type.CATALOG]

--- a/airbyte-integrations/bases/source-acceptance-test/source_acceptance_test/conftest.py
+++ b/airbyte-integrations/bases/source-acceptance-test/source_acceptance_test/conftest.py
@@ -274,7 +274,7 @@ def previous_discovered_catalog_fixture(
     """JSON schemas for each stream"""
     if previous_connector_docker_runner is None:
         logging.warning(
-            "\n We could not retrieve the previous connector spec as a connector runner for the previous connector version could not be instantiated."
+            "\n We could not retrieve the previous discovered catalog as a connector runner for the previous connector version could not be instantiated."
         )
         return None
     if not previous_cached_schemas:


### PR DESCRIPTION
## What
When we create the `previous_discovered_catalog_fixture` we call discover on the `previous_connector_docker_runner` object. This object is `None` if we cannot find a previous connector version. 
The existing fixture code did not check for nullity of the object and the `AttributeError: 'NoneType' object has no attribute 'call_discover` can be raised.

This bug is noticeable now because of the recent change of https://github.com/airbytehq/airbyte/pull/20435 which accesses `previous_discovered_catalog` before checking the nullity of `previous_connector_docker_runner`.

## How
Make the fixture return None if the previous docker runner is None (like we do for `previous_connector_spec_fixture`)

