### PR TITLE
Add some abstraction to avoid direct generated object use

### DIFF
--- a/airbyte-commons-protocol/src/main/java/io/airbyte/commons/protocol/objects/AirbyteMessage.java
+++ b/airbyte-commons-protocol/src/main/java/io/airbyte/commons/protocol/objects/AirbyteMessage.java
@@ -1,0 +1,18 @@
+/*
+ * Copyright (c) 2022 Airbyte, Inc., all rights reserved.
+ */
+
+package io.airbyte.commons.protocol.objects;
+
+import io.airbyte.protocol.models.AirbyteTraceMessage;
+
+public interface AirbyteMessage {
+
+  AirbyteMessageType getType();
+
+  ConnectorSpecification getSpec();
+
+  // TODO should be an interface
+  AirbyteTraceMessage getTrace();
+
+}

--- a/airbyte-commons-protocol/src/main/java/io/airbyte/commons/protocol/objects/AirbyteMessageType.java
+++ b/airbyte-commons-protocol/src/main/java/io/airbyte/commons/protocol/objects/AirbyteMessageType.java
@@ -1,0 +1,16 @@
+/*
+ * Copyright (c) 2022 Airbyte, Inc., all rights reserved.
+ */
+
+package io.airbyte.commons.protocol.objects;
+
+public enum AirbyteMessageType {
+  RECORD,
+  STATE,
+  LOG,
+  CONNECTION_STATUS,
+  CATALOG,
+  TRACE,
+  SPEC,
+  CONTROL
+}

--- a/airbyte-commons-protocol/src/main/java/io/airbyte/commons/protocol/objects/AirbyteMessageType.java
+++ b/airbyte-commons-protocol/src/main/java/io/airbyte/commons/protocol/objects/AirbyteMessageType.java
@@ -13,4 +13,5 @@ public enum AirbyteMessageType {
   TRACE,
   SPEC,
   CONTROL
+
 }

--- a/airbyte-commons-protocol/src/main/java/io/airbyte/commons/protocol/objects/ConnectorSpecification.java
+++ b/airbyte-commons-protocol/src/main/java/io/airbyte/commons/protocol/objects/ConnectorSpecification.java
@@ -19,11 +19,11 @@ public interface ConnectorSpecification {
 
   JsonNode getConnectorSpecification();
 
-  boolean getSupportsIncremental();
+  Boolean isSupportingIncremental();
 
-  boolean getSupportsNormalization();
+  Boolean isSupportingNormalization();
 
-  boolean getSupportsDBT();
+  Boolean isSupportingDBT();
 
   // TODO should be a new Enum
   List<DestinationSyncMode> getSupportedDestinationSyncModes();

--- a/airbyte-commons-protocol/src/main/java/io/airbyte/commons/protocol/objects/ConnectorSpecification.java
+++ b/airbyte-commons-protocol/src/main/java/io/airbyte/commons/protocol/objects/ConnectorSpecification.java
@@ -7,7 +7,6 @@ package io.airbyte.commons.protocol.objects;
 import com.fasterxml.jackson.databind.JsonNode;
 import io.airbyte.protocol.models.AdvancedAuth;
 import io.airbyte.protocol.models.AuthSpecification;
-import io.airbyte.protocol.models.DestinationSyncMode;
 import java.net.URI;
 import java.util.List;
 
@@ -25,15 +24,16 @@ public interface ConnectorSpecification {
 
   Boolean isSupportingDBT();
 
-  // TODO should be a new Enum
   List<DestinationSyncMode> getSupportedDestinationSyncModes();
 
-  // TODO we should introduce specific interfaces
+  // TODO introduce specific interfaces
   AuthSpecification getAuthSpecification();
 
+  // TODO introduce specific interfaces
   AdvancedAuth getAdvancedAuth();
 
-  // TODO Temp hack to avoid having to migrate all the code to this interface at once
+  // Clients should use this interface rather than the underlying object
+  @Deprecated
   io.airbyte.protocol.models.ConnectorSpecification getRaw();
 
 }

--- a/airbyte-commons-protocol/src/main/java/io/airbyte/commons/protocol/objects/ConnectorSpecification.java
+++ b/airbyte-commons-protocol/src/main/java/io/airbyte/commons/protocol/objects/ConnectorSpecification.java
@@ -5,12 +5,19 @@
 package io.airbyte.commons.protocol.objects;
 
 import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
+import com.fasterxml.jackson.databind.annotation.JsonSerialize;
+import io.airbyte.commons.protocol.objects.serde.ConnectionSpecificationDeserializer;
+import io.airbyte.commons.protocol.objects.serde.ConnectionSpecificationSerializer;
+import io.airbyte.commons.protocol.objects.serde.JsonSerializable;
 import io.airbyte.protocol.models.AdvancedAuth;
 import io.airbyte.protocol.models.AuthSpecification;
 import java.net.URI;
 import java.util.List;
 
-public interface ConnectorSpecification {
+@JsonDeserialize(using = ConnectionSpecificationDeserializer.class)
+@JsonSerialize(using = ConnectionSpecificationSerializer.class)
+public interface ConnectorSpecification extends JsonSerializable {
 
   URI getDocumentationUrl();
 

--- a/airbyte-commons-protocol/src/main/java/io/airbyte/commons/protocol/objects/ConnectorSpecification.java
+++ b/airbyte-commons-protocol/src/main/java/io/airbyte/commons/protocol/objects/ConnectorSpecification.java
@@ -1,0 +1,39 @@
+/*
+ * Copyright (c) 2022 Airbyte, Inc., all rights reserved.
+ */
+
+package io.airbyte.commons.protocol.objects;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import io.airbyte.protocol.models.AdvancedAuth;
+import io.airbyte.protocol.models.AuthSpecification;
+import io.airbyte.protocol.models.DestinationSyncMode;
+import java.net.URI;
+import java.util.List;
+
+public interface ConnectorSpecification {
+
+  URI getDocumentationUrl();
+
+  URI getChangelogUrl();
+
+  JsonNode getConnectorSpecification();
+
+  boolean getSupportsIncremental();
+
+  boolean getSupportsNormalization();
+
+  boolean getSupportsDBT();
+
+  // TODO should be a new Enum
+  List<DestinationSyncMode> getSupportedDestinationSyncModes();
+
+  // TODO we should introduce specific interfaces
+  AuthSpecification getAuthSpecification();
+
+  AdvancedAuth getAdvancedAuth();
+
+  // TODO Temp hack to avoid having to migrate all the code to this interface at once
+  io.airbyte.protocol.models.ConnectorSpecification getRaw();
+
+}

--- a/airbyte-commons-protocol/src/main/java/io/airbyte/commons/protocol/objects/DestinationSyncMode.java
+++ b/airbyte-commons-protocol/src/main/java/io/airbyte/commons/protocol/objects/DestinationSyncMode.java
@@ -1,0 +1,11 @@
+/*
+ * Copyright (c) 2022 Airbyte, Inc., all rights reserved.
+ */
+
+package io.airbyte.commons.protocol.objects;
+
+public enum DestinationSyncMode {
+  APPEND,
+  OVERWRITE,
+  APPEND_DEDUP
+}

--- a/airbyte-commons-protocol/src/main/java/io/airbyte/commons/protocol/objects/impl/AirbyteMessageAdapter.java
+++ b/airbyte-commons-protocol/src/main/java/io/airbyte/commons/protocol/objects/impl/AirbyteMessageAdapter.java
@@ -10,7 +10,9 @@ import io.airbyte.commons.protocol.objects.ConnectorSpecification;
 import io.airbyte.protocol.models.AirbyteMessage.Type;
 import io.airbyte.protocol.models.AirbyteTraceMessage;
 import java.util.Map;
+import lombok.EqualsAndHashCode;
 
+@EqualsAndHashCode
 public class AirbyteMessageAdapter implements AirbyteMessage {
 
   private final io.airbyte.protocol.models.AirbyteMessage airbyteMessage;
@@ -26,7 +28,7 @@ public class AirbyteMessageAdapter implements AirbyteMessage {
 
   @Override
   public ConnectorSpecification getSpec() {
-    return null;
+    return new ConnectorSpecificationAdapter(airbyteMessage.getSpec());
   }
 
   @Override

--- a/airbyte-commons-protocol/src/main/java/io/airbyte/commons/protocol/objects/impl/AirbyteMessageAdapter.java
+++ b/airbyte-commons-protocol/src/main/java/io/airbyte/commons/protocol/objects/impl/AirbyteMessageAdapter.java
@@ -23,7 +23,7 @@ public class AirbyteMessageAdapter implements AirbyteMessage {
 
   @Override
   public AirbyteMessageType getType() {
-    return toTypes.get(airbyteMessage.getType());
+    return fromProtocolObject(airbyteMessage.getType());
   }
 
   @Override
@@ -36,7 +36,11 @@ public class AirbyteMessageAdapter implements AirbyteMessage {
     return airbyteMessage.getTrace();
   }
 
-  private final static Map<io.airbyte.protocol.models.AirbyteMessage.Type, AirbyteMessageType> toTypes = Map.of(
+  public static AirbyteMessageType fromProtocolObject(final Type type) {
+    return fromProtocolObject.get(type);
+  }
+
+  private final static Map<Type, AirbyteMessageType> fromProtocolObject = Map.of(
       Type.RECORD, AirbyteMessageType.RECORD,
       Type.STATE, AirbyteMessageType.STATE,
       Type.LOG, AirbyteMessageType.RECORD,

--- a/airbyte-commons-protocol/src/main/java/io/airbyte/commons/protocol/objects/impl/AirbyteMessageAdapter.java
+++ b/airbyte-commons-protocol/src/main/java/io/airbyte/commons/protocol/objects/impl/AirbyteMessageAdapter.java
@@ -1,0 +1,47 @@
+/*
+ * Copyright (c) 2022 Airbyte, Inc., all rights reserved.
+ */
+
+package io.airbyte.commons.protocol.objects.impl;
+
+import io.airbyte.commons.protocol.objects.AirbyteMessage;
+import io.airbyte.commons.protocol.objects.AirbyteMessageType;
+import io.airbyte.commons.protocol.objects.ConnectorSpecification;
+import io.airbyte.protocol.models.AirbyteMessage.Type;
+import io.airbyte.protocol.models.AirbyteTraceMessage;
+import java.util.Map;
+
+public class AirbyteMessageAdapter implements AirbyteMessage {
+
+  private final io.airbyte.protocol.models.AirbyteMessage airbyteMessage;
+
+  public AirbyteMessageAdapter(final io.airbyte.protocol.models.AirbyteMessage airbyteMessage) {
+    this.airbyteMessage = airbyteMessage;
+  }
+
+  @Override
+  public AirbyteMessageType getType() {
+    return toTypes.get(airbyteMessage.getType());
+  }
+
+  @Override
+  public ConnectorSpecification getSpec() {
+    return null;
+  }
+
+  @Override
+  public AirbyteTraceMessage getTrace() {
+    return airbyteMessage.getTrace();
+  }
+
+  private final static Map<io.airbyte.protocol.models.AirbyteMessage.Type, AirbyteMessageType> toTypes = Map.of(
+      Type.RECORD, AirbyteMessageType.RECORD,
+      Type.STATE, AirbyteMessageType.STATE,
+      Type.LOG, AirbyteMessageType.RECORD,
+      Type.CONNECTION_STATUS, AirbyteMessageType.CONNECTION_STATUS,
+      Type.CATALOG, AirbyteMessageType.CATALOG,
+      Type.TRACE, AirbyteMessageType.TRACE,
+      Type.SPEC, AirbyteMessageType.SPEC,
+      Type.CONTROL, AirbyteMessageType.CONTROL);
+
+}

--- a/airbyte-commons-protocol/src/main/java/io/airbyte/commons/protocol/objects/impl/ConnectorSpecificationAdapter.java
+++ b/airbyte-commons-protocol/src/main/java/io/airbyte/commons/protocol/objects/impl/ConnectorSpecificationAdapter.java
@@ -11,7 +11,9 @@ import io.airbyte.protocol.models.AuthSpecification;
 import io.airbyte.protocol.models.DestinationSyncMode;
 import java.net.URI;
 import java.util.List;
+import lombok.EqualsAndHashCode;
 
+@EqualsAndHashCode
 public class ConnectorSpecificationAdapter implements ConnectorSpecification {
 
   final io.airbyte.protocol.models.ConnectorSpecification connectorSpecification;
@@ -36,17 +38,17 @@ public class ConnectorSpecificationAdapter implements ConnectorSpecification {
   }
 
   @Override
-  public boolean getSupportsIncremental() {
+  public Boolean isSupportingIncremental() {
     return connectorSpecification.getSupportsIncremental();
   }
 
   @Override
-  public boolean getSupportsNormalization() {
+  public Boolean isSupportingNormalization() {
     return connectorSpecification.getSupportsNormalization();
   }
 
   @Override
-  public boolean getSupportsDBT() {
+  public Boolean isSupportingDBT() {
     return connectorSpecification.getSupportsDBT();
   }
 

--- a/airbyte-commons-protocol/src/main/java/io/airbyte/commons/protocol/objects/impl/ConnectorSpecificationAdapter.java
+++ b/airbyte-commons-protocol/src/main/java/io/airbyte/commons/protocol/objects/impl/ConnectorSpecificationAdapter.java
@@ -1,0 +1,73 @@
+/*
+ * Copyright (c) 2022 Airbyte, Inc., all rights reserved.
+ */
+
+package io.airbyte.commons.protocol.objects.impl;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import io.airbyte.commons.protocol.objects.ConnectorSpecification;
+import io.airbyte.protocol.models.AdvancedAuth;
+import io.airbyte.protocol.models.AuthSpecification;
+import io.airbyte.protocol.models.DestinationSyncMode;
+import java.net.URI;
+import java.util.List;
+
+public class ConnectorSpecificationAdapter implements ConnectorSpecification {
+
+  final io.airbyte.protocol.models.ConnectorSpecification connectorSpecification;
+
+  public ConnectorSpecificationAdapter(final io.airbyte.protocol.models.ConnectorSpecification connectorSpecification) {
+    this.connectorSpecification = connectorSpecification;
+  }
+
+  @Override
+  public URI getDocumentationUrl() {
+    return connectorSpecification.getDocumentationUrl();
+  }
+
+  @Override
+  public URI getChangelogUrl() {
+    return connectorSpecification.getChangelogUrl();
+  }
+
+  @Override
+  public JsonNode getConnectorSpecification() {
+    return connectorSpecification.getConnectionSpecification();
+  }
+
+  @Override
+  public boolean getSupportsIncremental() {
+    return connectorSpecification.getSupportsIncremental();
+  }
+
+  @Override
+  public boolean getSupportsNormalization() {
+    return connectorSpecification.getSupportsNormalization();
+  }
+
+  @Override
+  public boolean getSupportsDBT() {
+    return connectorSpecification.getSupportsDBT();
+  }
+
+  @Override
+  public List<DestinationSyncMode> getSupportedDestinationSyncModes() {
+    return connectorSpecification.getSupportedDestinationSyncModes();
+  }
+
+  @Override
+  public AuthSpecification getAuthSpecification() {
+    return connectorSpecification.getAuthSpecification();
+  }
+
+  @Override
+  public AdvancedAuth getAdvancedAuth() {
+    return connectorSpecification.getAdvancedAuth();
+  }
+
+  @Override
+  public io.airbyte.protocol.models.ConnectorSpecification getRaw() {
+    return connectorSpecification;
+  }
+
+}

--- a/airbyte-commons-protocol/src/main/java/io/airbyte/commons/protocol/objects/impl/ConnectorSpecificationAdapter.java
+++ b/airbyte-commons-protocol/src/main/java/io/airbyte/commons/protocol/objects/impl/ConnectorSpecificationAdapter.java
@@ -5,6 +5,7 @@
 package io.airbyte.commons.protocol.objects.impl;
 
 import com.fasterxml.jackson.databind.JsonNode;
+import io.airbyte.commons.json.Jsons;
 import io.airbyte.commons.protocol.objects.ConnectorSpecification;
 import io.airbyte.commons.protocol.objects.DestinationSyncMode;
 import io.airbyte.protocol.models.AdvancedAuth;
@@ -66,6 +67,15 @@ public class ConnectorSpecificationAdapter implements ConnectorSpecification {
   @Override
   public AdvancedAuth getAdvancedAuth() {
     return connectorSpecification.getAdvancedAuth();
+  }
+
+  @Override
+  public String toJson() {
+    return Jsons.serialize(connectorSpecification);
+  }
+
+  static public ConnectorSpecification fromJson(final String jsonString) {
+    return new ConnectorSpecificationAdapter(Jsons.deserialize(jsonString, io.airbyte.protocol.models.ConnectorSpecification.class));
   }
 
   @Override

--- a/airbyte-commons-protocol/src/main/java/io/airbyte/commons/protocol/objects/impl/ConnectorSpecificationAdapter.java
+++ b/airbyte-commons-protocol/src/main/java/io/airbyte/commons/protocol/objects/impl/ConnectorSpecificationAdapter.java
@@ -6,11 +6,12 @@ package io.airbyte.commons.protocol.objects.impl;
 
 import com.fasterxml.jackson.databind.JsonNode;
 import io.airbyte.commons.protocol.objects.ConnectorSpecification;
+import io.airbyte.commons.protocol.objects.DestinationSyncMode;
 import io.airbyte.protocol.models.AdvancedAuth;
 import io.airbyte.protocol.models.AuthSpecification;
-import io.airbyte.protocol.models.DestinationSyncMode;
 import java.net.URI;
 import java.util.List;
+import java.util.Map;
 import lombok.EqualsAndHashCode;
 
 @EqualsAndHashCode
@@ -54,7 +55,7 @@ public class ConnectorSpecificationAdapter implements ConnectorSpecification {
 
   @Override
   public List<DestinationSyncMode> getSupportedDestinationSyncModes() {
-    return connectorSpecification.getSupportedDestinationSyncModes();
+    return connectorSpecification.getSupportedDestinationSyncModes().stream().map(fromProtocolObjects::get).toList();
   }
 
   @Override
@@ -71,5 +72,10 @@ public class ConnectorSpecificationAdapter implements ConnectorSpecification {
   public io.airbyte.protocol.models.ConnectorSpecification getRaw() {
     return connectorSpecification;
   }
+
+  private final static Map<io.airbyte.protocol.models.DestinationSyncMode, DestinationSyncMode> fromProtocolObjects = Map.of(
+      io.airbyte.protocol.models.DestinationSyncMode.APPEND, DestinationSyncMode.APPEND,
+      io.airbyte.protocol.models.DestinationSyncMode.APPEND_DEDUP, DestinationSyncMode.APPEND_DEDUP,
+      io.airbyte.protocol.models.DestinationSyncMode.OVERWRITE, DestinationSyncMode.OVERWRITE);
 
 }

--- a/airbyte-commons-protocol/src/main/java/io/airbyte/commons/protocol/objects/serde/ConnectionSpecificationDeserializer.java
+++ b/airbyte-commons-protocol/src/main/java/io/airbyte/commons/protocol/objects/serde/ConnectionSpecificationDeserializer.java
@@ -1,0 +1,33 @@
+/*
+ * Copyright (c) 2022 Airbyte, Inc., all rights reserved.
+ */
+
+package io.airbyte.commons.protocol.objects.serde;
+
+import com.fasterxml.jackson.core.JacksonException;
+import com.fasterxml.jackson.core.JsonParser;
+import com.fasterxml.jackson.databind.DeserializationContext;
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.deser.std.StdDeserializer;
+import io.airbyte.commons.protocol.objects.ConnectorSpecification;
+import io.airbyte.commons.protocol.objects.impl.ConnectorSpecificationAdapter;
+import java.io.IOException;
+
+public class ConnectionSpecificationDeserializer extends StdDeserializer<ConnectorSpecification> {
+
+  public ConnectionSpecificationDeserializer() {
+    this(null);
+  }
+
+  protected ConnectionSpecificationDeserializer(Class<?> vc) {
+    super(vc);
+  }
+
+  @Override
+  public ConnectorSpecification deserialize(JsonParser p, DeserializationContext ctxt) throws IOException, JacksonException {
+    final JsonNode node = p.getCodec().readTree(p);
+    final String jsonString = node.get("object").asText();
+    return ConnectorSpecificationAdapter.fromJson(jsonString);
+  }
+
+}

--- a/airbyte-commons-protocol/src/main/java/io/airbyte/commons/protocol/objects/serde/ConnectionSpecificationSerializer.java
+++ b/airbyte-commons-protocol/src/main/java/io/airbyte/commons/protocol/objects/serde/ConnectionSpecificationSerializer.java
@@ -1,0 +1,30 @@
+/*
+ * Copyright (c) 2022 Airbyte, Inc., all rights reserved.
+ */
+
+package io.airbyte.commons.protocol.objects.serde;
+
+import com.fasterxml.jackson.core.JsonGenerator;
+import com.fasterxml.jackson.databind.SerializerProvider;
+import com.fasterxml.jackson.databind.ser.std.StdSerializer;
+import io.airbyte.commons.protocol.objects.ConnectorSpecification;
+import java.io.IOException;
+
+public class ConnectionSpecificationSerializer extends StdSerializer<ConnectorSpecification> {
+
+  public ConnectionSpecificationSerializer() {
+    this(null);
+  }
+
+  protected ConnectionSpecificationSerializer(Class<ConnectorSpecification> t) {
+    super(t);
+  }
+
+  @Override
+  public void serialize(ConnectorSpecification value, JsonGenerator gen, SerializerProvider provider) throws IOException {
+    gen.writeStartObject();
+    gen.writeStringField("object", value.toJson());
+    gen.writeEndObject();
+  }
+
+}

--- a/airbyte-commons-protocol/src/main/java/io/airbyte/commons/protocol/objects/serde/JsonSerializable.java
+++ b/airbyte-commons-protocol/src/main/java/io/airbyte/commons/protocol/objects/serde/JsonSerializable.java
@@ -1,0 +1,11 @@
+/*
+ * Copyright (c) 2022 Airbyte, Inc., all rights reserved.
+ */
+
+package io.airbyte.commons.protocol.objects.serde;
+
+public interface JsonSerializable {
+
+  String toJson();
+
+}

--- a/airbyte-commons-protocol/src/test/java/io/airbyte/commons/protocol/objects/impl/ConnectorSpecificationAdapterTest.java
+++ b/airbyte-commons-protocol/src/test/java/io/airbyte/commons/protocol/objects/impl/ConnectorSpecificationAdapterTest.java
@@ -1,0 +1,84 @@
+/*
+ * Copyright (c) 2022 Airbyte, Inc., all rights reserved.
+ */
+
+package io.airbyte.commons.protocol.objects.impl;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+import io.airbyte.commons.json.Jsons;
+import io.airbyte.commons.protocol.objects.ConnectorSpecification;
+import io.airbyte.protocol.models.DestinationSyncMode;
+import java.io.Serializable;
+import java.net.URI;
+import java.net.URISyntaxException;
+import java.util.List;
+import lombok.EqualsAndHashCode;
+import org.junit.jupiter.api.Test;
+
+@EqualsAndHashCode
+class TestWrapper implements Serializable {
+
+  @JsonProperty("connectorSpecification")
+  private ConnectorSpecification connectionSpecification;
+
+  public ConnectorSpecification getConnectionSpecification() {
+    return connectionSpecification;
+  }
+
+  public TestWrapper withConnectorSpecification(final ConnectorSpecification connectorSpecification) {
+    this.connectionSpecification = connectorSpecification;
+    return this;
+  }
+
+}
+
+class ConnectorSpecificationAdapterTest {
+
+  @Test
+  void serDeRoundTrip() throws URISyntaxException {
+    final TestWrapper init = new TestWrapper()
+        .withConnectorSpecification(
+            new ConnectorSpecificationAdapter(
+                new io.airbyte.protocol.models.ConnectorSpecification()
+                    .withDocumentationUrl(new URI("https://airbyte.io"))
+                    .withChangelogUrl(new URI("https://changelog.io"))
+                    .withConnectionSpecification(Jsons.deserialize("{\"test\": \"data\"}"))
+                    .withSupportedDestinationSyncModes(List.of(DestinationSyncMode.OVERWRITE, DestinationSyncMode.APPEND_DEDUP))
+                    .withSupportsDBT(true)
+                    .withSupportsIncremental(true)
+                    .withSupportsNormalization(false)));
+
+    final String serialized = Jsons.serialize(init);
+    final TestWrapper result = Jsons.deserialize(serialized, TestWrapper.class);
+
+    assertEquals(init, result);
+    assertEquals(new URI("https://airbyte.io"), result.getConnectionSpecification().getDocumentationUrl());
+  }
+
+  @Test
+  void testFieldMapping() throws URISyntaxException {
+    final io.airbyte.protocol.models.ConnectorSpecification rawSpec = new io.airbyte.protocol.models.ConnectorSpecification()
+        .withDocumentationUrl(new URI("https://doc.com"))
+        .withChangelogUrl(new URI("https://change.log"))
+        .withConnectionSpecification(Jsons.deserialize("{\"test\": \"data\"}"))
+        .withSupportedDestinationSyncModes(List.of(DestinationSyncMode.APPEND, DestinationSyncMode.OVERWRITE, DestinationSyncMode.APPEND_DEDUP))
+        .withSupportsDBT(false)
+        .withSupportsIncremental(true)
+        .withSupportsNormalization(false);
+
+    final ConnectorSpecification spec = new ConnectorSpecificationAdapter(rawSpec);
+    assertEquals(rawSpec.getDocumentationUrl(), spec.getDocumentationUrl());
+    assertEquals(rawSpec.getChangelogUrl(), spec.getChangelogUrl());
+    assertEquals(rawSpec.getConnectionSpecification(), spec.getConnectorSpecification());
+    assertEquals(List.of(
+        io.airbyte.commons.protocol.objects.DestinationSyncMode.APPEND,
+        io.airbyte.commons.protocol.objects.DestinationSyncMode.OVERWRITE,
+        io.airbyte.commons.protocol.objects.DestinationSyncMode.APPEND_DEDUP), spec.getSupportedDestinationSyncModes());
+    assertEquals(rawSpec.getSupportsDBT(), spec.isSupportingDBT());
+    assertEquals(rawSpec.getSupportsIncremental(), spec.isSupportingIncremental());
+    assertEquals(rawSpec.getSupportsNormalization(), spec.isSupportingNormalization());
+  }
+
+}

--- a/airbyte-commons-worker/src/main/java/io/airbyte/workers/WorkerUtils.java
+++ b/airbyte-commons-worker/src/main/java/io/airbyte/workers/WorkerUtils.java
@@ -26,6 +26,7 @@ import java.util.Map;
 import java.util.Optional;
 import java.util.concurrent.TimeUnit;
 import java.util.stream.Collectors;
+import java.util.stream.Stream;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -111,9 +112,18 @@ public class WorkerUtils {
                                                               final Map<Type, List<AirbyteMessage>> messagesByType,
                                                               final String defaultErrorMessage)
       throws WorkerException {
+    return getJobFailureOutputOrThrow(
+        outputType,
+        messagesByType.getOrDefault(Type.TRACE, new ArrayList<>()).stream().map(AirbyteMessage::getTrace),
+        defaultErrorMessage);
+  }
+
+  public static ConnectorJobOutput getJobFailureOutputOrThrow(final OutputType outputType,
+                                                              final Stream<AirbyteTraceMessage> traceMessages,
+                                                              final String defaultErrorMessage)
+      throws WorkerException {
     final Optional<AirbyteTraceMessage> traceMessage =
-        messagesByType.getOrDefault(Type.TRACE, new ArrayList<>()).stream()
-            .map(AirbyteMessage::getTrace)
+        traceMessages
             .filter(trace -> trace.getType() == AirbyteTraceMessage.Type.ERROR)
             .findFirst();
 

--- a/airbyte-commons-worker/src/main/java/io/airbyte/workers/internal/AirbyteMessageReader.java
+++ b/airbyte-commons-worker/src/main/java/io/airbyte/workers/internal/AirbyteMessageReader.java
@@ -1,0 +1,42 @@
+/*
+ * Copyright (c) 2022 Airbyte, Inc., all rights reserved.
+ */
+
+package io.airbyte.workers.internal;
+
+import io.airbyte.commons.protocol.objects.AirbyteMessage;
+import io.airbyte.commons.protocol.objects.AirbyteMessageType;
+import io.airbyte.commons.protocol.objects.ConnectorSpecification;
+import io.airbyte.commons.protocol.objects.impl.AirbyteMessageAdapter;
+import io.airbyte.protocol.models.AirbyteTraceMessage;
+import java.util.List;
+import java.util.Map;
+import java.util.function.Function;
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
+
+public class AirbyteMessageReader {
+
+  final Map<AirbyteMessageType, List<AirbyteMessage>> sortedMessages;
+
+  public AirbyteMessageReader(final Stream<io.airbyte.protocol.models.AirbyteMessage> airbyteMessageStream) {
+    sortedMessages = sortMessages(airbyteMessageStream);
+  }
+
+  public Stream<ConnectorSpecification> getSpecs() {
+    return getMessagesByType(AirbyteMessageType.SPEC, AirbyteMessage::getSpec);
+  }
+
+  public Stream<AirbyteTraceMessage> getTraces() {
+    return getMessagesByType(AirbyteMessageType.TRACE, AirbyteMessage::getTrace);
+  }
+
+  private <T> Stream<T> getMessagesByType(final AirbyteMessageType key, final Function<AirbyteMessage, T> mapper) {
+    return sortedMessages.getOrDefault(key, List.of()).stream().map(mapper);
+  }
+
+  private static Map<AirbyteMessageType, List<AirbyteMessage>> sortMessages(final Stream<io.airbyte.protocol.models.AirbyteMessage> messages) {
+    return messages.map(AirbyteMessageAdapter::new).collect(Collectors.groupingBy(AirbyteMessage::getType));
+  }
+
+}

--- a/airbyte-config/config-models/build.gradle
+++ b/airbyte-config/config-models/build.gradle
@@ -10,8 +10,10 @@ dependencies {
     api libs.bundles.micronaut.annotation
 
     implementation project(':airbyte-json-validation')
+    // TODO remove the dependency on the raw protocol objects
     implementation project(':airbyte-protocol:protocol-models')
     implementation project(':airbyte-commons')
+    implementation project(':airbyte-commons-protocol')
 }
 
 jsonSchema2Pojo {

--- a/airbyte-config/config-models/src/main/resources/types/ConnectorJobOutput.yaml
+++ b/airbyte-config/config-models/src/main/resources/types/ConnectorJobOutput.yaml
@@ -21,6 +21,6 @@ properties:
     type: string
     format: uuid
   spec:
-    existingJavaType: io.airbyte.protocol.models.ConnectorSpecification
+    existingJavaType: io.airbyte.commons.protocol.objects.ConnectorSpecification
   failureReason:
     "$ref": FailureReason.yaml

--- a/airbyte-integrations/bases/standard-destination-test/build.gradle
+++ b/airbyte-integrations/bases/standard-destination-test/build.gradle
@@ -3,6 +3,7 @@ plugins {
 }
 dependencies {
     implementation project(':airbyte-db:db-lib')
+    implementation project(':airbyte-commons-protocol')
     implementation project(':airbyte-commons-worker')
     implementation project(':airbyte-config:config-models')
     implementation project(':airbyte-config:init')

--- a/airbyte-integrations/bases/standard-source-test/build.gradle
+++ b/airbyte-integrations/bases/standard-source-test/build.gradle
@@ -13,6 +13,7 @@ import org.jsoup.Jsoup;
 
 dependencies {
     implementation project(':airbyte-db:db-lib')
+    implementation project(':airbyte-commons-protocol')
     implementation project(':airbyte-commons-worker')
     implementation project(':airbyte-config:config-models')
     implementation project(':airbyte-config:config-persistence')

--- a/airbyte-integrations/bases/standard-source-test/src/main/java/io/airbyte/integrations/standardtest/source/AbstractSourceConnectorTest.java
+++ b/airbyte-integrations/bases/standard-source-test/src/main/java/io/airbyte/integrations/standardtest/source/AbstractSourceConnectorTest.java
@@ -155,7 +155,9 @@ public abstract class AbstractSourceConnectorTest {
   protected ConnectorSpecification runSpec() throws WorkerException {
     final io.airbyte.protocol.models.ConnectorSpecification spec = new DefaultGetSpecWorker(
         new AirbyteIntegrationLauncher(JOB_ID, JOB_ATTEMPT, getImageName(), processFactory, workerConfigs.getResourceRequirements(), false))
-            .run(new JobGetSpecConfig().withDockerImage(getImageName()), jobRoot).getSpec();
+            // TODO using ConnectorSpecification interface from airbyte-commons-protocol, we would make us
+            // protocol version agnostic here.
+            .run(new JobGetSpecConfig().withDockerImage(getImageName()), jobRoot).getSpec().getRaw();
     return convertProtocolObject(spec, ConnectorSpecification.class);
   }
 

--- a/airbyte-server/build.gradle
+++ b/airbyte-server/build.gradle
@@ -11,6 +11,7 @@ dependencies {
     implementation project(':airbyte-analytics')
     implementation project(':airbyte-api')
     implementation project(':airbyte-commons-docker')
+    implementation project(':airbyte-commons-protocol')
     implementation project(':airbyte-commons-temporal')
     implementation project(':airbyte-commons-worker')
     implementation project(':airbyte-config:init')

--- a/airbyte-server/src/main/java/io/airbyte/server/scheduler/DefaultSynchronousSchedulerClient.java
+++ b/airbyte-server/src/main/java/io/airbyte/server/scheduler/DefaultSynchronousSchedulerClient.java
@@ -160,7 +160,7 @@ public class DefaultSynchronousSchedulerClient implements SynchronousSchedulerCl
         jobReportingContext,
         null,
         () -> temporalClient.submitGetSpec(jobId, 0, jobSpecConfig),
-        ConnectorJobOutput::getSpec,
+        connectorJobOutput -> connectorJobOutput.getSpec().getRaw(),
         null);
   }
 

--- a/airbyte-server/src/test/java/io/airbyte/server/scheduler/DefaultSynchronousSchedulerClientTest.java
+++ b/airbyte-server/src/test/java/io/airbyte/server/scheduler/DefaultSynchronousSchedulerClientTest.java
@@ -20,6 +20,7 @@ import static org.mockito.Mockito.when;
 import com.fasterxml.jackson.databind.JsonNode;
 import com.google.common.collect.ImmutableMap;
 import io.airbyte.commons.json.Jsons;
+import io.airbyte.commons.protocol.objects.ConnectorSpecification;
 import io.airbyte.commons.temporal.JobMetadata;
 import io.airbyte.commons.temporal.TemporalClient;
 import io.airbyte.commons.temporal.TemporalResponse;
@@ -37,7 +38,6 @@ import io.airbyte.persistence.job.errorreporter.JobErrorReporter;
 import io.airbyte.persistence.job.factory.OAuthConfigSupplier;
 import io.airbyte.persistence.job.tracker.JobTracker;
 import io.airbyte.persistence.job.tracker.JobTracker.JobState;
-import io.airbyte.protocol.models.ConnectorSpecification;
 import java.io.IOException;
 import java.nio.file.Path;
 import java.util.UUID;
@@ -251,7 +251,8 @@ class DefaultSynchronousSchedulerClientTest {
       final ConnectorJobOutput jobOutput = new ConnectorJobOutput().withSpec(mockOutput);
       when(temporalClient.submitGetSpec(any(UUID.class), eq(0), eq(jobSpecConfig)))
           .thenReturn(new TemporalResponse<>(jobOutput, createMetadata(true)));
-      final SynchronousResponse<ConnectorSpecification> response = schedulerClient.createGetSpecJob(DOCKER_IMAGE, false);
+      // TODO this should be returning the ConnectorSpecification interface
+      final SynchronousResponse<io.airbyte.protocol.models.ConnectorSpecification> response = schedulerClient.createGetSpecJob(DOCKER_IMAGE, false);
       assertEquals(mockOutput, response.getOutput());
     }
 

--- a/airbyte-server/src/test/java/io/airbyte/server/scheduler/DefaultSynchronousSchedulerClientTest.java
+++ b/airbyte-server/src/test/java/io/airbyte/server/scheduler/DefaultSynchronousSchedulerClientTest.java
@@ -20,7 +20,7 @@ import static org.mockito.Mockito.when;
 import com.fasterxml.jackson.databind.JsonNode;
 import com.google.common.collect.ImmutableMap;
 import io.airbyte.commons.json.Jsons;
-import io.airbyte.commons.protocol.objects.ConnectorSpecification;
+import io.airbyte.commons.protocol.objects.impl.ConnectorSpecificationAdapter;
 import io.airbyte.commons.temporal.JobMetadata;
 import io.airbyte.commons.temporal.TemporalClient;
 import io.airbyte.commons.temporal.TemporalResponse;
@@ -247,8 +247,9 @@ class DefaultSynchronousSchedulerClientTest {
     void testCreateGetSpecJob() throws IOException {
       final JobGetSpecConfig jobSpecConfig = new JobGetSpecConfig().withDockerImage(DOCKER_IMAGE).withIsCustomConnector(false);
 
-      final ConnectorSpecification mockOutput = mock(ConnectorSpecification.class);
-      final ConnectorJobOutput jobOutput = new ConnectorJobOutput().withSpec(mockOutput);
+      // TODO this should be mocking io.airbyte.commons.protocol.objects.ConnectorSpecification
+      final io.airbyte.protocol.models.ConnectorSpecification mockOutput = mock(io.airbyte.protocol.models.ConnectorSpecification.class);
+      final ConnectorJobOutput jobOutput = new ConnectorJobOutput().withSpec(new ConnectorSpecificationAdapter(mockOutput));
       when(temporalClient.submitGetSpec(any(UUID.class), eq(0), eq(jobSpecConfig)))
           .thenReturn(new TemporalResponse<>(jobOutput, createMetadata(true)));
       // TODO this should be returning the ConnectorSpecification interface

--- a/airbyte-workers/src/test/java/io/airbyte/workers/general/DefaultGetSpecWorkerTest.java
+++ b/airbyte-workers/src/test/java/io/airbyte/workers/general/DefaultGetSpecWorkerTest.java
@@ -17,6 +17,7 @@ import static org.mockito.Mockito.when;
 
 import com.google.common.base.Charsets;
 import io.airbyte.commons.json.Jsons;
+import io.airbyte.commons.protocol.objects.impl.ConnectorSpecificationAdapter;
 import io.airbyte.commons.resources.MoreResources;
 import io.airbyte.config.ConnectorJobOutput;
 import io.airbyte.config.ConnectorJobOutput.OutputType;
@@ -72,7 +73,7 @@ class DefaultGetSpecWorkerTest {
 
     final ConnectorJobOutput actualOutput = worker.run(config, jobRoot);
     final ConnectorJobOutput expectedOutput = new ConnectorJobOutput().withOutputType(OutputType.SPEC)
-        .withSpec(Jsons.deserialize(expectedSpecString, ConnectorSpecification.class));
+        .withSpec(new ConnectorSpecificationAdapter(Jsons.deserialize(expectedSpecString, ConnectorSpecification.class)));
 
     assertThat(actualOutput).isEqualTo(expectedOutput);
   }


### PR DESCRIPTION
## What

With the introduction of Airbyte Protocol versioning, direct use of the generated objects comes with some overhead:
* Moving to a new version means patching all the `import` statement of classes that are relying on protocol objects
* Java Connectors are sharing some classes from the platform which led to some non-straight forward dependencies. We have a disconnect since there will be a transition period during which we will have different versions of the protocol for different connectors at the same time.

## How

In order to reduce the coupling:
* we introduce interfaces that describes the different concepts used in the protocol
* we leverage adapters to map the most current version of the protocol to the interface

The key benefits:
* This layer of abstraction gives us more flexibility to decouple our internal logic from the network representation of the objects
* Bumping a version means update the adapter rather all the imports
* This removes the explicit dependencies on the protocol version for the java connectors and allows us to shift the focus towards the information read rather than the container

The tradeoff is that we need to explicitly update the interfaces/adapters to channel new information.

## Recommended reading order
1. `x.java`
2. `y.python`

## 🚨 User Impact 🚨

No behavior change expected, this is targeting dev efficiency.

