### PR TITLE
Destination Snowflake: Update to V1 protocol

### DIFF
--- a/airbyte-integrations/connectors/destination-snowflake/src/test-integration/java/io/airbyte/integrations/destination/snowflake/SnowflakeInsertDestinationAcceptanceTest.java
+++ b/airbyte-integrations/connectors/destination-snowflake/src/test-integration/java/io/airbyte/integrations/destination/snowflake/SnowflakeInsertDestinationAcceptanceTest.java
@@ -22,6 +22,7 @@ import io.airbyte.db.jdbc.JdbcDatabase;
 import io.airbyte.integrations.base.JavaBaseConstants;
 import io.airbyte.integrations.destination.NamingConventionTransformer;
 import io.airbyte.integrations.standardtest.destination.DestinationAcceptanceTest;
+import io.airbyte.integrations.standardtest.destination.ProtocolVersion;
 import io.airbyte.integrations.standardtest.destination.argproviders.DataArgumentsProvider;
 import io.airbyte.integrations.standardtest.destination.comparator.TestDataComparator;
 import io.airbyte.protocol.models.v0.AirbyteCatalog;
@@ -83,6 +84,11 @@ public class SnowflakeInsertDestinationAcceptanceTest extends DestinationAccepta
   @Override
   protected boolean supportObjectDataTypeTest() {
     return true;
+  }
+
+  @Override
+  public ProtocolVersion getProtocolVersion() {
+    return ProtocolVersion.V1;
   }
 
   public JsonNode getStaticConfig() {

--- a/airbyte-integrations/connectors/destination-snowflake/src/test-integration/java/io/airbyte/integrations/destination/snowflake/SnowflakeTestSourceOperations.java
+++ b/airbyte-integrations/connectors/destination-snowflake/src/test-integration/java/io/airbyte/integrations/destination/snowflake/SnowflakeTestSourceOperations.java
@@ -5,16 +5,23 @@
 package io.airbyte.integrations.destination.snowflake;
 
 import com.fasterxml.jackson.databind.node.ObjectNode;
+import io.airbyte.db.jdbc.DateTimeConverter;
 import io.airbyte.db.jdbc.JdbcSourceOperations;
 import io.airbyte.integrations.standardtest.destination.DestinationAcceptanceTestUtils;
 import java.sql.ResultSet;
 import java.sql.SQLException;
+import java.time.LocalTime;
 
 public class SnowflakeTestSourceOperations extends JdbcSourceOperations {
 
   @Override
   protected void putString(ObjectNode node, String columnName, ResultSet resultSet, int index) throws SQLException {
     DestinationAcceptanceTestUtils.putStringIntoJson(resultSet.getString(index), columnName, node);
+  }
+
+  @Override
+  protected void putTime(final ObjectNode node, final String columnName, final ResultSet resultSet, final int index) throws SQLException {
+    node.put(columnName, resultSet.getString(index));
   }
 
 }


### PR DESCRIPTION
## What
Destination Snowflake: Update to V1 protocol

## How
Most of the changes done in https://github.com/airbytehq/airbyte/pull/20088 and https://github.com/airbytehq/json-avro-converter/pull/17.
This PR contains integration tests V1 dataset. Since this dataset contains time have to update SnowflakeTestSourceOperations to retrieve time correctly.

Note: The test should pass after:
-  Normalization PR https://github.com/airbytehq/airbyte/pull/19721 will be merged. 
- Era dates (`2022-01-23T01:23:45.678-11:30 BC`) will be excluded from dataset. Currently normalisation failed to proceed it  
- Time with milliseconds (`01:23:45.678`) is ignored via normalization for Snowflake and BigQuery. For example this `01:23:45.678` become `01:23:45` after normalization. I expect we can investigate it but for now time with millisends can be removed from dataset. 
The tests passed locally without Era date and time with milliseconds:
<img width="870" alt="image" src="https://user-images.githubusercontent.com/5124694/209968514-1edb0830-d527-4414-b649-327db1b56f40.png">
<img width="212" alt="image" src="https://user-images.githubusercontent.com/5124694/209968755-c782d97f-8f18-4423-93f9-c76fca7aa9ac.png">


## Recommended reading order
1. `SnowflakeInsertDestinationAcceptanceTest.java`
2. `SnowflakeTestSourceOperations.java`

## 🚨 User Impact 🚨
No impact 
