### PR TITLE
CDK: `SingleUseRefreshTokenOauth2Authenticator` update config with access tokens and expiration date

### DIFF
--- a/airbyte-cdk/python/CHANGELOG.md
+++ b/airbyte-cdk/python/CHANGELOG.md
@@ -1,5 +1,8 @@
 # Changelog
 
+## 0.16.3
+Do not eagerly refresh access token in `SingleUseRefreshTokenOauth2Authenticator` [#20923](https://github.com/airbytehq/airbyte/pull/20923)
+
 ## 0.16.2
 Fix the naming of OAuthAuthenticator
 

--- a/airbyte-cdk/python/airbyte_cdk/config_observation.py
+++ b/airbyte-cdk/python/airbyte_cdk/config_observation.py
@@ -55,16 +55,7 @@ class ConfigObserver:
         self.config = config
 
     def update(self) -> None:
-        self._emit_airbyte_control_message()
-
-    def _emit_airbyte_control_message(self) -> None:
-        control_message = AirbyteControlMessage(
-            type=OrchestratorType.CONNECTOR_CONFIG,
-            emitted_at=time.time() * 1000,
-            connectorConfig=AirbyteControlConnectorConfigMessage(config=self.config),
-        )
-        airbyte_message = AirbyteMessage(type=Type.CONTROL, control=control_message)
-        print(airbyte_message.json(exclude_unset=True))
+        emit_configuration_as_airbyte_control_message(self.config)
 
 
 def observe_connector_config(non_observed_connector_config: MutableMapping[str, Any]):
@@ -74,3 +65,13 @@ def observe_connector_config(non_observed_connector_config: MutableMapping[str, 
     observed_connector_config = ObservedDict(non_observed_connector_config, connector_config_observer)
     connector_config_observer.set_config(observed_connector_config)
     return observed_connector_config
+
+
+def emit_configuration_as_airbyte_control_message(config: MutableMapping):
+    control_message = AirbyteControlMessage(
+        type=OrchestratorType.CONNECTOR_CONFIG,
+        emitted_at=time.time() * 1000,
+        connectorConfig=AirbyteControlConnectorConfigMessage(config=config),
+    )
+    airbyte_message = AirbyteMessage(type=Type.CONTROL, control=control_message)
+    print(airbyte_message.json(exclude_unset=True))

--- a/airbyte-cdk/python/airbyte_cdk/sources/streams/http/requests_native_auth/oauth.py
+++ b/airbyte-cdk/python/airbyte_cdk/sources/streams/http/requests_native_auth/oauth.py
@@ -205,7 +205,7 @@ class SingleUseRefreshTokenOauth2Authenticator(Oauth2Authenticator):
         return pendulum.parse(dpath.util.get(self._connector_config, self._token_expiry_date_config_path))
 
     def set_token_expiry_date(self, new_token_expiry_date):
-        dpath.util.set(self._connector_config, self._token_expiry_date_config_path, new_token_expiry_date)
+        dpath.util.set(self._connector_config, self._token_expiry_date_config_path, str(new_token_expiry_date))
 
     def token_has_expired(self) -> bool:
         """Returns True if the token is expired"""

--- a/airbyte-cdk/python/airbyte_cdk/sources/streams/http/requests_native_auth/oauth.py
+++ b/airbyte-cdk/python/airbyte_cdk/sources/streams/http/requests_native_auth/oauth.py
@@ -210,7 +210,7 @@ class SingleUseRefreshTokenOauth2Authenticator(Oauth2Authenticator):
 
     def token_has_expired(self) -> bool:
         """Returns True if the token is expired"""
-        return pendulum.now("UTC") > self.token_expiry_date
+        return pendulum.now("UTC") > self.get_token_expiry_date()
     
     @staticmethod
     def get_new_token_expiry_date(access_token_expires_in: int):

--- a/airbyte-cdk/python/airbyte_cdk/sources/streams/http/requests_native_auth/oauth.py
+++ b/airbyte-cdk/python/airbyte_cdk/sources/streams/http/requests_native_auth/oauth.py
@@ -150,7 +150,7 @@ class SingleUseRefreshTokenOauth2Authenticator(Oauth2Authenticator):
             access_token_name=access_token_name,
             expires_in_name=expires_in_name,
             refresh_request_body=refresh_request_body,
-            grant_type=grant_type
+            grant_type=grant_type,
         )
 
     def _validate_connector_config(self):
@@ -194,7 +194,7 @@ class SingleUseRefreshTokenOauth2Authenticator(Oauth2Authenticator):
     @access_token.setter
     def access_token(self, new_access_token: str):
         dpath.util.set(self._connector_config, self._access_token_config_path, new_access_token)
-    
+
     def get_refresh_token(self) -> str:
         return dpath.util.get(self._connector_config, self._refresh_token_config_path)
 
@@ -204,14 +204,13 @@ class SingleUseRefreshTokenOauth2Authenticator(Oauth2Authenticator):
     def get_token_expiry_date(self) -> pendulum.DateTime:
         return pendulum.parse(dpath.util.get(self._connector_config, self._token_expiry_date_config_path))
 
-    def set_token_expiry_date(self,  new_token_expiry_date):
+    def set_token_expiry_date(self, new_token_expiry_date):
         dpath.util.set(self._connector_config, self._token_expiry_date_config_path, new_token_expiry_date)
-
 
     def token_has_expired(self) -> bool:
         """Returns True if the token is expired"""
         return pendulum.now("UTC") > self.get_token_expiry_date()
-    
+
     @staticmethod
     def get_new_token_expiry_date(access_token_expires_in: int):
         return pendulum.now("UTC").add(seconds=access_token_expires_in)
@@ -241,4 +240,3 @@ class SingleUseRefreshTokenOauth2Authenticator(Oauth2Authenticator):
             )
         except Exception as e:
             raise Exception(f"Error while refreshing access token and refresh token: {e}") from e
-

--- a/airbyte-cdk/python/setup.py
+++ b/airbyte-cdk/python/setup.py
@@ -15,7 +15,7 @@ README = (HERE / "README.md").read_text()
 
 setup(
     name="airbyte-cdk",
-    version="0.16.2",
+    version="0.16.3",
     description="A framework for writing Airbyte Connectors.",
     long_description=README,
     long_description_content_type="text/markdown",

--- a/airbyte-cdk/python/unit_tests/sources/streams/http/requests_native_auth/test_requests_native_auth.py
+++ b/airbyte-cdk/python/unit_tests/sources/streams/http/requests_native_auth/test_requests_native_auth.py
@@ -9,7 +9,6 @@ import freezegun
 import pendulum
 import pytest
 import requests
-from airbyte_cdk.config_observation import ObservedDict
 from airbyte_cdk.sources.streams.http.requests_native_auth import (
     BasicHttpAuthenticator,
     MultipleTokenAuthenticator,

--- a/airbyte-cdk/python/unit_tests/sources/streams/http/requests_native_auth/test_requests_native_auth.py
+++ b/airbyte-cdk/python/unit_tests/sources/streams/http/requests_native_auth/test_requests_native_auth.py
@@ -5,6 +5,7 @@
 import json
 import logging
 
+import freezegun
 import pendulum
 import pytest
 import requests
@@ -188,6 +189,7 @@ class TestSingleUseRefreshTokenOauth2Authenticator:
                 "refresh_token": "my_refresh_token",
                 "client_id": "my_client_id",
                 "client_secret": "my_client_secret",
+                "access_token_expiration_datetime": "2022-12-31T00:00:00+00:00"
             }
         }
 
@@ -209,6 +211,7 @@ class TestSingleUseRefreshTokenOauth2Authenticator:
                 token_refresh_endpoint="foobar",
             )
 
+    @freezegun.freeze_time("2022-12-31")
     def test_get_access_token(self, capsys, mocker, connector_config):
         authenticator = SingleUseRefreshTokenOauth2Authenticator(
             connector_config,
@@ -222,7 +225,7 @@ class TestSingleUseRefreshTokenOauth2Authenticator:
         expected_new_config = connector_config.copy()
         expected_new_config["credentials"]["access_token"] = "new_access_token"
         expected_new_config["credentials"]["refresh_token"] = "new_refresh_token"
-
+        expected_new_config["credentials"]["access_token_expiration_datetime"] = "2022-12-31T00:00:42+00:00"
         assert airbyte_message["control"]["connectorConfig"]["config"] == expected_new_config
         assert authenticator.access_token == access_token == "new_access_token"
         assert authenticator.get_refresh_token() == "new_refresh_token"

--- a/airbyte-cdk/python/unit_tests/sources/streams/http/requests_native_auth/test_requests_native_auth.py
+++ b/airbyte-cdk/python/unit_tests/sources/streams/http/requests_native_auth/test_requests_native_auth.py
@@ -189,7 +189,7 @@ class TestSingleUseRefreshTokenOauth2Authenticator:
                 "refresh_token": "my_refresh_token",
                 "client_id": "my_client_id",
                 "client_secret": "my_client_secret",
-                "access_token_expiration_datetime": "2022-12-31T00:00:00+00:00"
+                "token_expiry_date": "2022-12-31T00:00:00+00:00"
             }
         }
 
@@ -198,10 +198,13 @@ class TestSingleUseRefreshTokenOauth2Authenticator:
         return {"no_credentials_key": "foo"}
 
     def test_init(self, connector_config):
-        SingleUseRefreshTokenOauth2Authenticator(
+        authenticator = SingleUseRefreshTokenOauth2Authenticator(
             connector_config,
             token_refresh_endpoint="foobar",
         )
+        assert authenticator.access_token == connector_config["credentials"]["access_token"]
+        assert authenticator.get_refresh_token() == connector_config["credentials"]["refresh_token"]
+        assert authenticator.get_token_expiry_date() == pendulum.parse(connector_config["credentials"]["token_expiry_date"])
 
     def test_init_with_invalid_config(self, invalid_connector_config):
         with pytest.raises(ValueError):
@@ -224,7 +227,7 @@ class TestSingleUseRefreshTokenOauth2Authenticator:
         expected_new_config = connector_config.copy()
         expected_new_config["credentials"]["access_token"] = "new_access_token"
         expected_new_config["credentials"]["refresh_token"] = "new_refresh_token"
-        expected_new_config["credentials"]["access_token_expiration_datetime"] = "2022-12-31T00:00:42+00:00"
+        expected_new_config["credentials"]["token_expiry_date"] = "2022-12-31T00:00:42+00:00"
         assert airbyte_message["control"]["connectorConfig"]["config"] == expected_new_config
         assert authenticator.access_token == access_token == "new_access_token"
         assert authenticator.get_refresh_token() == "new_refresh_token"

--- a/airbyte-cdk/python/unit_tests/sources/streams/http/requests_native_auth/test_requests_native_auth.py
+++ b/airbyte-cdk/python/unit_tests/sources/streams/http/requests_native_auth/test_requests_native_auth.py
@@ -198,11 +198,10 @@ class TestSingleUseRefreshTokenOauth2Authenticator:
         return {"no_credentials_key": "foo"}
 
     def test_init(self, connector_config):
-        authenticator = SingleUseRefreshTokenOauth2Authenticator(
+        SingleUseRefreshTokenOauth2Authenticator(
             connector_config,
             token_refresh_endpoint="foobar",
         )
-        assert isinstance(authenticator._connector_config, ObservedDict)
 
     def test_init_with_invalid_config(self, invalid_connector_config):
         with pytest.raises(ValueError):
@@ -221,7 +220,7 @@ class TestSingleUseRefreshTokenOauth2Authenticator:
         authenticator.token_has_expired = mocker.Mock(return_value=True)
         access_token = authenticator.get_access_token()
         captured = capsys.readouterr()
-        airbyte_message = json.loads(captured.out.split("\n")[-2])
+        airbyte_message = json.loads(captured.out)
         expected_new_config = connector_config.copy()
         expected_new_config["credentials"]["access_token"] = "new_access_token"
         expected_new_config["credentials"]["refresh_token"] = "new_refresh_token"

--- a/airbyte-cdk/python/unit_tests/sources/streams/http/requests_native_auth/test_requests_native_auth.py
+++ b/airbyte-cdk/python/unit_tests/sources/streams/http/requests_native_auth/test_requests_native_auth.py
@@ -218,9 +218,11 @@ class TestSingleUseRefreshTokenOauth2Authenticator:
         authenticator.token_has_expired = mocker.Mock(return_value=True)
         access_token = authenticator.get_access_token()
         captured = capsys.readouterr()
-        airbyte_message = json.loads(captured.out)
+        airbyte_message = json.loads(captured.out.split("\n")[-2])
         expected_new_config = connector_config.copy()
+        expected_new_config["credentials"]["access_token"] = "new_access_token"
         expected_new_config["credentials"]["refresh_token"] = "new_refresh_token"
+
         assert airbyte_message["control"]["connectorConfig"]["config"] == expected_new_config
         assert authenticator.access_token == access_token == "new_access_token"
         assert authenticator.get_refresh_token() == "new_refresh_token"


### PR DESCRIPTION
## What
Closes https://github.com/airbytehq/airbyte/issues/20914

Before this PR the `SingleUseRefreshTokenOauth2Authenticator` eagerly performed access token refresh:
- In each operation (`check`, `discover`, `read`) a new OAuth flow is started even if the previous access token is still valid.

As synchronous operation, like `check` on source creation, can't process control message, we can end up with invalid refresh token as the latest one are not persisted to the DB. (more details in https://github.com/airbytehq/airbyte-internal-issues/issues/1260)
To mitigate this problem we try to store the expiration date of the access token in the config and only perform refresh when the expiration date is met. 

## How
* Read `access_token_expiration_datetime` from connector configuration
* On access token refresh:
  * Update the `access_token_value`
  * Update the `access_token_expiration_datetime`


## Recommended reading order

https://github.com/airbytehq/airbyte/blob/833d978fe1b2cff2779397bc747eeba1f8c6954f/airbyte-cdk/python/airbyte_cdk/sources/streams/http/requests_native_auth/oauth.py#L93

https://github.com/airbytehq/airbyte/blob/833d978fe1b2cff2779397bc747eeba1f8c6954f/airbyte-cdk/python/unit_tests/sources/streams/http/requests_native_auth/test_requests_native_auth.py#L183

## 🚨 User Impact 🚨
The connector using `SingleUseRefreshTokenOauth2Authenticator` should be reworked:
https://github.com/airbytehq/airbyte/pull/7506

