### PR TITLE
Prep for Java 19: Remove Sneaky Throws.

### DIFF
--- a/airbyte-commons-protocol/src/test/java/io/airbyte/commons/protocol/migrations/DefaultToV0MigrationTest.java
+++ b/airbyte-commons-protocol/src/test/java/io/airbyte/commons/protocol/migrations/DefaultToV0MigrationTest.java
@@ -7,6 +7,7 @@ package io.airbyte.commons.protocol.migrations;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 
 import java.net.URI;
+import java.net.URISyntaxException;
 import lombok.SneakyThrows;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
@@ -27,7 +28,7 @@ class DefaultToV0MigrationTest {
   }
 
   @Test
-  void testDowngrade() {
+  void testDowngrade() throws URISyntaxException {
     final io.airbyte.protocol.models.v0.AirbyteMessage v0Message = getV0Message();
 
     final io.airbyte.protocol.models.AirbyteMessage downgradedMessage = v0migration.downgrade(v0Message);
@@ -36,7 +37,7 @@ class DefaultToV0MigrationTest {
   }
 
   @Test
-  void testUpgrade() {
+  void testUpgrade() throws URISyntaxException {
     final io.airbyte.protocol.models.AirbyteMessage unversionedMessage = getUnversionedMessage();
 
     final io.airbyte.protocol.models.v0.AirbyteMessage upgradedMessage = v0migration.upgrade(unversionedMessage);
@@ -44,8 +45,7 @@ class DefaultToV0MigrationTest {
     assertEquals(expectedMessage, upgradedMessage);
   }
 
-  @SneakyThrows
-  private io.airbyte.protocol.models.v0.AirbyteMessage getV0Message() {
+  private io.airbyte.protocol.models.v0.AirbyteMessage getV0Message() throws URISyntaxException {
     return new io.airbyte.protocol.models.v0.AirbyteMessage()
         .withType(io.airbyte.protocol.models.v0.AirbyteMessage.Type.SPEC)
         .withSpec(
@@ -54,8 +54,7 @@ class DefaultToV0MigrationTest {
                 .withDocumentationUrl(new URI("file:///tmp/doc")));
   }
 
-  @SneakyThrows
-  private io.airbyte.protocol.models.AirbyteMessage getUnversionedMessage() {
+  private io.airbyte.protocol.models.AirbyteMessage getUnversionedMessage() throws URISyntaxException {
     return new io.airbyte.protocol.models.AirbyteMessage()
         .withType(io.airbyte.protocol.models.AirbyteMessage.Type.SPEC)
         .withSpec(

--- a/airbyte-commons-worker/src/main/java/io/airbyte/workers/internal/VersionedAirbyteStreamFactory.java
+++ b/airbyte-commons-worker/src/main/java/io/airbyte/workers/internal/VersionedAirbyteStreamFactory.java
@@ -78,11 +78,15 @@ public class VersionedAirbyteStreamFactory<T> extends DefaultAirbyteStreamFactor
    * the stream rather than the one passed from the constructor.
    */
   @Trace(operationName = WORKER_OPERATION_NAME)
-  @SneakyThrows
   @Override
   public Stream<AirbyteMessage> create(final BufferedReader bufferedReader) {
     if (shouldDetectVersion) {
-      final Optional<Version> versionMaybe = detectVersion(bufferedReader);
+      final Optional<Version> versionMaybe;
+      try {
+        versionMaybe = detectVersion(bufferedReader);
+      } catch (final IOException e) {
+        throw new RuntimeException(e);
+      }
       if (versionMaybe.isPresent()) {
         logger.info("Detected Protocol Version {}", versionMaybe.get().serialize());
         initializeForProtocolVersion(versionMaybe.get());

--- a/airbyte-json-validation/src/test/java/io/airbyte/validation/json/JsonSchemaValidatorTest.java
+++ b/airbyte-json-validation/src/test/java/io/airbyte/validation/json/JsonSchemaValidatorTest.java
@@ -17,6 +17,7 @@ import io.airbyte.commons.json.Jsons;
 import java.io.File;
 import java.io.IOException;
 import java.net.URI;
+import java.net.URISyntaxException;
 import java.nio.file.Files;
 import java.util.Set;
 import lombok.SneakyThrows;
@@ -106,9 +107,8 @@ class JsonSchemaValidatorTest {
     assertNull(JsonSchemaValidator.getSchema(schemaFile, "NonExistentObject"));
   }
 
-  @SneakyThrows
   @Test
-  void testResolveReferences() throws IOException {
+  void testResolveReferences() throws IOException, URISyntaxException {
     String referencableSchemas = """
                                  {
                                    "definitions": {


### PR DESCRIPTION
## What
The Java 19 toolchain doesn't like sneaky throws. Not entirely sure why. However, I think it's better practice to not use sneaky throws as it makes it clearer what is throw and where.

Example error message when trying to compile the current codebase with Java 19:
```
error: Error during the transformation of 'io.airbyte.validation.json.JsonSchemaValidatorTest'; post-compiler 'lombok.bytecode.SneakyThrowsRemover' caused an exception: java.lang.IllegalArgumentException: Unsupported class file major version 63
        at org.objectweb.asm.ClassReader.<init>(ClassReader.java:199)
        at org.objectweb.asm.ClassReader.<init>(ClassReader.java:180)
        at org.objectweb.asm.ClassReader.<init>(ClassReader.java:166)
        at lombok.bytecode.AsmUtil.fixJSRInlining(AsmUtil.java:37)
        at lombok.bytecode.SneakyThrowsRemover.applyTransformations(SneakyThrowsRemover.java:46)
        at lombok.core.PostCompiler.applyTransformations(PostCompiler.java:44)
        at lombok.core.PostCompiler$1.close(PostCompiler.java:87)
        at jdk.compiler/com.sun.tools.javac.jvm.ClassWriter.writeClass(ClassWriter.java:1508)
        at jdk.compiler/com.sun.tools.javac.main.JavaCompiler.genCode(JavaCompiler.java:738)
```

## How
Remove sneaky throws from platform code.

## Recommended reading order
All files.

## 🚨 User Impact 🚨
Are there any breaking changes? What is the end result perceived by the user? If yes, please merge this PR with the 🚨🚨 emoji so changelog authors can further highlight this if needed.

## Pre-merge Checklist
Expand the relevant checklist and delete the others.

<details><summary><strong>New Connector</strong></summary>

### Community member or Airbyter

- [ ] **Community member?** Grant edit access to maintainers ([instructions](https://docs.github.com/en/github/collaborating-with-pull-requests/working-with-forks/allowing-changes-to-a-pull-request-branch-created-from-a-fork#enabling-repository-maintainer-permissions-on-existing-pull-requests))
- [ ] Secrets in the connector's spec are annotated with `airbyte_secret`
- [ ] Unit & integration tests added and passing. Community members, please provide proof of success locally e.g: screenshot or copy-paste unit, integration, and acceptance test output. To run acceptance tests for a Python connector, follow instructions in the README. For java connectors run `./gradlew :airbyte-integrations:connectors:<name>:integrationTest`.
- [ ] Code reviews completed
- [ ] Documentation updated
    - [ ] Connector's `README.md`
    - [ ] Connector's `bootstrap.md`. See [description and examples](https://docs.google.com/document/d/1ypdgmwmEHWv-TrO4_YOQ7pAJGVrMp5BOkEVh831N260/edit?usp=sharing)
    - [ ] `docs/integrations/<source or destination>/<name>.md` including changelog. See changelog [example](https://docs.airbyte.io/integrations/sources/stripe#changelog)
    - [ ] `docs/integrations/README.md`
    - [ ] `airbyte-integrations/builds.md`
- [ ] PR name follows [PR naming conventions](https://docs.airbyte.com/contributing-to-airbyte/issues-and-pull-requests)

### Airbyter

If this is a community PR, the Airbyte engineer reviewing this PR is responsible for the below items.

- [ ] Create a non-forked branch based on this PR and test the below items on it
- [ ] Build is successful
- [ ] If new credentials are required for use in CI, add them to GSM. [Instructions](https://docs.airbyte.io/connector-development#using-credentials-in-ci).
- [ ] [`/test connector=connectors/<name>` command](https://docs.airbyte.io/connector-development#updating-an-existing-connector) is passing
- [ ] New Connector version released on Dockerhub by running the `/publish` command described [here](https://docs.airbyte.io/connector-development#updating-an-existing-connector)
- [ ] After the connector is published, connector added to connector index as described [here](https://docs.airbyte.io/connector-development#publishing-a-connector)
- [ ] Seed specs have been re-generated by building the platform and committing the changes to the seed spec files, as described [here](https://docs.airbyte.io/connector-development#publishing-a-connector)

</details>

<details><summary><strong>Updating a connector</strong></summary>

### Community member or Airbyter

- [ ] Grant edit access to maintainers ([instructions](https://docs.github.com/en/github/collaborating-with-pull-requests/working-with-forks/allowing-changes-to-a-pull-request-branch-created-from-a-fork#enabling-repository-maintainer-permissions-on-existing-pull-requests))
- [ ] Secrets in the connector's spec are annotated with `airbyte_secret`
- [ ] Unit & integration tests added and passing. Community members, please provide proof of success locally e.g: screenshot or copy-paste unit, integration, and acceptance test output. To run acceptance tests for a Python connector, follow instructions in the README. For java connectors run `./gradlew :airbyte-integrations:connectors:<name>:integrationTest`.
- [ ] Code reviews completed
- [ ] Documentation updated
    - [ ] Connector's `README.md`
    - [ ] Connector's `bootstrap.md`. See [description and examples](https://docs.google.com/document/d/1ypdgmwmEHWv-TrO4_YOQ7pAJGVrMp5BOkEVh831N260/edit?usp=sharing)
    - [ ] Changelog updated in `docs/integrations/<source or destination>/<name>.md` including changelog. See changelog [example](https://docs.airbyte.io/integrations/sources/stripe#changelog)
- [ ] PR name follows [PR naming conventions](https://docs.airbyte.com/contributing-to-airbyte/issues-and-pull-requests)

### Airbyter

If this is a community PR, the Airbyte engineer reviewing this PR is responsible for the below items.

- [ ] Create a non-forked branch based on this PR and test the below items on it
- [ ] Build is successful
- [ ] If new credentials are required for use in CI, add them to GSM. [Instructions](https://docs.airbyte.io/connector-development#using-credentials-in-ci).
- [ ] [`/test connector=connectors/<name>` command](https://docs.airbyte.io/connector-development#updating-an-existing-connector) is passing
- [ ] New Connector version released on Dockerhub and connector version bumped by running the `/publish` command described [here](https://docs.airbyte.io/connector-development#updating-an-existing-connector)

</details>

<details><summary><strong>Connector Generator</strong></summary>

- [ ] Issue acceptance criteria met
- [ ] PR name follows [PR naming conventions](https://docs.airbyte.com/contributing-to-airbyte/issues-and-pull-requests)
- [ ] If adding a new generator, add it to the [list of scaffold modules being tested](https://github.com/airbytehq/airbyte/blob/master/airbyte-integrations/connector-templates/generator/build.gradle#L41)
- [ ] The generator test modules (all connectors with `-scaffold` in their name) have been updated with the latest scaffold by running `./gradlew :airbyte-integrations:connector-templates:generator:testScaffoldTemplates` then checking in your changes
- [ ] Documentation which references the generator is updated as needed

</details>

## Tests

<details><summary><strong>Unit</strong></summary>

*Put your unit tests output here.*

</details>

<details><summary><strong>Integration</strong></summary>

*Put your integration tests output here.*

</details>

<details><summary><strong>Acceptance</strong></summary>

*Put your acceptance tests output here.*

</details>
