### PR TITLE
fix(oauth): dont convert config values to string when building consent url

### DIFF
--- a/airbyte-server/src/main/java/io/airbyte/server/handlers/OAuthHandler.java
+++ b/airbyte-server/src/main/java/io/airbyte/server/handlers/OAuthHandler.java
@@ -327,6 +327,7 @@ public class OAuthHandler {
       final String k = entry.getKey();
       final JsonNode v = entry.getValue();
 
+      // Note: This does not currently handle replacing masked secrets within nested objects.
       if (AirbyteSecretConstants.SECRETS_MASK.equals(v.textValue())) {
         if (oAuthInputConfigurationFromDB.has(k)) {
           result.set(k, oAuthInputConfigurationFromDB.get(k));

--- a/airbyte-server/src/test/java/io/airbyte/server/handlers/OAuthHandlerTest.java
+++ b/airbyte-server/src/test/java/io/airbyte/server/handlers/OAuthHandlerTest.java
@@ -205,7 +205,8 @@ class OAuthHandlerTest {
         """
         {
           "testMask": "**********",
-          "testNotMask": "this"
+          "testNotMask": "this",
+          "testOtherType": true
         }
         """);
 
@@ -213,7 +214,8 @@ class OAuthHandlerTest {
         """
         {
           "testMask": "mask",
-          "testNotMask": "notThis"
+          "testNotMask": "notThis",
+          "testOtherType": true
         }
         """);
 
@@ -221,7 +223,8 @@ class OAuthHandlerTest {
         """
         {
           "testMask": "mask",
-          "testNotMask": "this"
+          "testNotMask": "this",
+          "testOtherType": true
         }
         """);
 


### PR DESCRIPTION
## What

Fixes OC issue https://github.com/airbytehq/oncall/issues/1250

If the configuration passed to generate the consent URL includes non-string values, they would be implicitly converted to strings when replacing masked values with secrets.

We noticed this happening specifically for Salesforce when re-authenticating the source, since it uses the `is_sandbox` field, which is a boolean. Issuing the `get_consent_url` call for an already created connector would return a 422 status code with the following error:

```
io.airbyte.validation.json.JsonValidationException: json schema validation failed when comparing the data to the json schema. 
Errors: $.is_sandbox: string found, boolean expected 
Schema: 
{
  "type" : "object",
  "properties" : {
    "is_sandbox" : {
      "type" : "boolean",
      "path_in_connector_config" : [ "is_sandbox" ]
    }
  },
  "additionalProperties" : false
}
```

## How

The `getOAuthFromDBIfNeeded` method was using a string map and calling `Jsons.deserializeToStringMap`, which basically converts all values to strings. In order to keep the original types, I reworked the implementation to use JsonNodes directly.

