### PR TITLE
fix(oauth): handle fields missing in the stored config when building consent url

### DIFF
--- a/airbyte-server/src/test/java/io/airbyte/server/handlers/OAuthHandlerTest.java
+++ b/airbyte-server/src/test/java/io/airbyte/server/handlers/OAuthHandlerTest.java
@@ -185,7 +185,8 @@ class OAuthHandlerTest {
     final Map<String, String> pathsToGet = Map.ofEntries(
         Map.entry("field1", "$.field1"),
         Map.entry("field3_1", "$.field3.field3_1"),
-        Map.entry("field3_2", "$.field3.field3_2"));
+        Map.entry("field3_2", "$.field3.field3_2"),
+        Map.entry("field4", "$.someNonexistentField"));
 
     final JsonNode expected = Jsons.deserialize(
         """


### PR DESCRIPTION
## What

Fixes OC issue https://github.com/airbytehq/oncall/issues/1251

When an input used for the oauth flow is missing from the stored configuration, a `java.util.NoSuchElementException: No value present` exception was being thrown. 

The value not being stored in the database is expected in some scenarios, like is the case for Monday. It has a field located within the oauth credentials block (credentials.subdomain) that would only be set if the connector was previously authenticated with OAuth. Having setting up the connector with an api key, this field is not part of the saved configuration. When the OAuthHandler tries to look up the value for that field, it doesn't find anything and throws the above exception. 

## How

Update the implementation to only set fields in the returned config that it are present. Fields that are not present in the stored configuration will be left out from the map.
