### PR TITLE
Destination Databricks: replicate into specified catalog using three level namespace

### DIFF
--- a/airbyte-integrations/connectors/destination-databricks/src/main/java/io/airbyte/integrations/destination/databricks/DatabricksAzureBlobStorageStreamCopier.java
+++ b/airbyte-integrations/connectors/destination-databricks/src/main/java/io/airbyte/integrations/destination/databricks/DatabricksAzureBlobStorageStreamCopier.java
@@ -150,9 +150,9 @@ public class DatabricksAzureBlobStorageStreamCopier extends DatabricksStreamCopi
 
     if (!useMetastore) {
       return String.format("CREATE TABLE %s.%s.%s (%s) USING csv LOCATION '%s' " +
-        "options (\"header\" = \"true\", \"multiLine\" = \"true\") ;",
-        catalogName, schemaName, tmpTableName, schemaString,
-        getTmpTableLocation().replace(AZURE_BLOB_ENDPOINT_DOMAIN_NAME, AZURE_DFS_ENDPOINT_DOMAIN_NAME));
+          "options (\"header\" = \"true\", \"multiLine\" = \"true\") ;",
+          catalogName, schemaName, tmpTableName, schemaString,
+          getTmpTableLocation().replace(AZURE_BLOB_ENDPOINT_DOMAIN_NAME, AZURE_DFS_ENDPOINT_DOMAIN_NAME));
     }
 
     return String.format("CREATE TABLE %s.%s (%s) USING csv LOCATION '%s' " +
@@ -188,11 +188,10 @@ public class DatabricksAzureBlobStorageStreamCopier extends DatabricksStreamCopi
       LOGGER.info("Destination OVERWRITE mode detected. Dest table: {}, schema: {}, truncated.", destTableName, schemaName);
     }
     if (!useMetastore) {
-        queries.append(sqlOperations.copyTableQuery(database, String.format("%s.%s", catalogName, schemaName), tmpTableName, destTableName));
+      queries.append(sqlOperations.insertTableQuery(database, String.format("%s.%s", catalogName, schemaName), tmpTableName, destTableName));
     } else {
-      queries.append(sqlOperations.copyTableQuery(database, schemaName, tmpTableName, destTableName));
+      queries.append(sqlOperations.insertTableQuery(database, schemaName, tmpTableName, destTableName));
     }
-    queries.append(sqlOperations.insertTableQuery(database, schemaName, tmpTableName, destTableName));
 
     return queries.toString();
   }

--- a/airbyte-integrations/connectors/destination-databricks/src/main/java/io/airbyte/integrations/destination/databricks/DatabricksAzureBlobStorageStreamCopier.java
+++ b/airbyte-integrations/connectors/destination-databricks/src/main/java/io/airbyte/integrations/destination/databricks/DatabricksAzureBlobStorageStreamCopier.java
@@ -55,6 +55,7 @@ public class DatabricksAzureBlobStorageStreamCopier extends DatabricksStreamCopi
   protected String currentFile;
 
   public DatabricksAzureBlobStorageStreamCopier(final String stagingFolder,
+                                                final String catalog,
                                                 final String schema,
                                                 final ConfiguredAirbyteStream configuredStream,
                                                 final JdbcDatabase database,
@@ -63,7 +64,7 @@ public class DatabricksAzureBlobStorageStreamCopier extends DatabricksStreamCopi
                                                 final SqlOperations sqlOperations,
                                                 final SpecializedBlobClientBuilder specializedBlobClientBuilder,
                                                 final AzureBlobStorageConfig azureConfig) {
-    super(stagingFolder, schema, configuredStream, database, databricksConfig, nameTransformer, sqlOperations);
+    super(stagingFolder, catalog, schema, configuredStream, database, databricksConfig, nameTransformer, sqlOperations);
 
     this.specializedBlobClientBuilder = specializedBlobClientBuilder;
     this.azureConfig = azureConfig;
@@ -147,6 +148,13 @@ public class DatabricksAzureBlobStorageStreamCopier extends DatabricksStreamCopi
 
     LOGGER.info("[Stream {}] tmp table schema: {}", stream.getName(), schemaString);
 
+    if (!useMetastore) {
+      return String.format("CREATE TABLE %s.%s.%s (%s) USING csv LOCATION '%s' " +
+        "options (\"header\" = \"true\", \"multiLine\" = \"true\") ;",
+        catalogName, schemaName, tmpTableName, schemaString,
+        getTmpTableLocation().replace(AZURE_BLOB_ENDPOINT_DOMAIN_NAME, AZURE_DFS_ENDPOINT_DOMAIN_NAME));
+    }
+
     return String.format("CREATE TABLE %s.%s (%s) USING csv LOCATION '%s' " +
         "options (\"header\" = \"true\", \"multiLine\" = \"true\") ;",
         schemaName, tmpTableName, schemaString,
@@ -172,8 +180,17 @@ public class DatabricksAzureBlobStorageStreamCopier extends DatabricksStreamCopi
     LOGGER.info("Preparing to merge tmp table {} to dest table: {}, schema: {}, in destination.", tmpTableName, destTableName, schemaName);
     final var queries = new StringBuilder();
     if (destinationSyncMode.equals(DestinationSyncMode.OVERWRITE)) {
-      queries.append(sqlOperations.truncateTableQuery(database, schemaName, destTableName));
+      if (!useMetastore) {
+        queries.append(sqlOperations.truncateTableQuery(database, String.format("%s.%s", catalogName, schemaName), destTableName));
+      } else {
+        queries.append(sqlOperations.truncateTableQuery(database, schemaName, destTableName));
+      }
       LOGGER.info("Destination OVERWRITE mode detected. Dest table: {}, schema: {}, truncated.", destTableName, schemaName);
+    }
+    if (!useMetastore) {
+        queries.append(sqlOperations.copyTableQuery(database, String.format("%s.%s", catalogName, schemaName), tmpTableName, destTableName));
+    } else {
+      queries.append(sqlOperations.copyTableQuery(database, schemaName, tmpTableName, destTableName));
     }
     queries.append(sqlOperations.insertTableQuery(database, schemaName, tmpTableName, destTableName));
 

--- a/airbyte-integrations/connectors/destination-databricks/src/main/java/io/airbyte/integrations/destination/databricks/DatabricksAzureBlobStorageStreamCopierFactory.java
+++ b/airbyte-integrations/connectors/destination-databricks/src/main/java/io/airbyte/integrations/destination/databricks/DatabricksAzureBlobStorageStreamCopierFactory.java
@@ -27,13 +27,14 @@ public class DatabricksAzureBlobStorageStreamCopierFactory implements Databricks
     try {
       final AirbyteStream stream = configuredStream.getStream();
       final String schema = StreamCopierFactory.getSchema(stream.getNamespace(), configuredSchema, nameTransformer);
+      final String catalog = databricksConfig.getDatabricksCatalog();
 
       final AzureBlobStorageConfig azureConfig = databricksConfig.getStorageConfig().getAzureBlobStorageConfigOrThrow();
       final SpecializedBlobClientBuilder specializedBlobClientBuilder = new SpecializedBlobClientBuilder()
           .endpoint(azureConfig.getEndpointUrl())
           .sasToken(azureConfig.getSasToken())
           .containerName(azureConfig.getContainerName());
-      return new DatabricksAzureBlobStorageStreamCopier(stagingFolder, schema, configuredStream, database,
+      return new DatabricksAzureBlobStorageStreamCopier(stagingFolder, catalog, schema, configuredStream, database,
           databricksConfig, nameTransformer, sqlOperations, specializedBlobClientBuilder, azureConfig);
     } catch (final Exception e) {
       throw new RuntimeException(e);

--- a/airbyte-integrations/connectors/destination-databricks/src/main/java/io/airbyte/integrations/destination/databricks/DatabricksDestinationConfig.java
+++ b/airbyte-integrations/connectors/destination-databricks/src/main/java/io/airbyte/integrations/destination/databricks/DatabricksDestinationConfig.java
@@ -10,30 +10,38 @@ import com.google.common.base.Preconditions;
 public class DatabricksDestinationConfig {
 
   static final String DEFAULT_DATABRICKS_PORT = "443";
+  static final String DEFAULT_DATABRICKS_CATALOG = "airbyte";
   static final String DEFAULT_DATABASE_SCHEMA = "public";
   static final boolean DEFAULT_PURGE_STAGING_DATA = true;
+  static final boolean DEFAULT_USE_METASTORE = true;
 
   private final String databricksServerHostname;
   private final String databricksHttpPath;
   private final String databricksPort;
   private final String databricksPersonalAccessToken;
+  private final String databricksCatalog;
   private final String databaseSchema;
   private final boolean purgeStagingData;
+  private final boolean useMetastore;
   private final DatabricksStorageConfig storageConfig;
 
   public DatabricksDestinationConfig(final String databricksServerHostname,
                                      final String databricksHttpPath,
                                      final String databricksPort,
                                      final String databricksPersonalAccessToken,
+                                     final String databricksCatalog,
                                      final String databaseSchema,
                                      final boolean purgeStagingData,
+                                     final boolean useMetastore,
                                      DatabricksStorageConfig storageConfig) {
     this.databricksServerHostname = databricksServerHostname;
     this.databricksHttpPath = databricksHttpPath;
     this.databricksPort = databricksPort;
     this.databricksPersonalAccessToken = databricksPersonalAccessToken;
+    this.databricksCatalog = databricksCatalog;
     this.databaseSchema = databaseSchema;
     this.purgeStagingData = purgeStagingData;
+    this.useMetastore = useMetastore;
     this.storageConfig = storageConfig;
   }
 
@@ -47,8 +55,10 @@ public class DatabricksDestinationConfig {
         config.get("databricks_http_path").asText(),
         config.has("databricks_port") ? config.get("databricks_port").asText() : DEFAULT_DATABRICKS_PORT,
         config.get("databricks_personal_access_token").asText(),
+        config.has("databricks_catalog") ? config.get("databricks_catalog").asText() : DEFAULT_DATABRICKS_CATALOG,
         config.has("database_schema") ? config.get("database_schema").asText() : DEFAULT_DATABASE_SCHEMA,
         config.has("purge_staging_data") ? config.get("purge_staging_data").asBoolean() : DEFAULT_PURGE_STAGING_DATA,
+        config.has("use_metastore") ? config.get("use_metastore").asBoolean() : DEFAULT_USE_METASTORE,
         DatabricksStorageConfig.getDatabricksStorageConfig(config.get("data_source")));
   }
 
@@ -68,12 +78,20 @@ public class DatabricksDestinationConfig {
     return databricksPersonalAccessToken;
   }
 
+  public String getDatabricksCatalog() {
+    return databricksCatalog;
+  }
+
   public String getDatabaseSchema() {
     return databaseSchema;
   }
 
   public boolean isPurgeStagingData() {
     return purgeStagingData;
+  }
+
+  public boolean isUseMetastore() {
+    return useMetastore;
   }
 
   public DatabricksStorageConfig getStorageConfig() {

--- a/airbyte-integrations/connectors/destination-databricks/src/main/java/io/airbyte/integrations/destination/databricks/DatabricksS3StreamCopier.java
+++ b/airbyte-integrations/connectors/destination-databricks/src/main/java/io/airbyte/integrations/destination/databricks/DatabricksS3StreamCopier.java
@@ -50,6 +50,7 @@ public class DatabricksS3StreamCopier extends DatabricksStreamCopier {
   private final S3ParquetWriter parquetWriter;
 
   public DatabricksS3StreamCopier(final String stagingFolder,
+                                  final String catalog,
                                   final String schema,
                                   final ConfiguredAirbyteStream configuredStream,
                                   final AmazonS3 s3Client,
@@ -60,7 +61,7 @@ public class DatabricksS3StreamCopier extends DatabricksStreamCopier {
                                   final S3WriterFactory writerFactory,
                                   final Timestamp uploadTime)
       throws Exception {
-    super(stagingFolder, schema, configuredStream, database, databricksConfig, nameTransformer, sqlOperations);
+    super(stagingFolder, catalog, schema, configuredStream, database, databricksConfig, nameTransformer, sqlOperations);
     this.s3Client = s3Client;
     this.s3Config = databricksConfig.getStorageConfig().getS3DestinationConfigOrThrow();
     final S3DestinationConfig stagingS3Config = getStagingS3DestinationConfig(s3Config, stagingFolder);
@@ -103,17 +104,24 @@ public class DatabricksS3StreamCopier extends DatabricksStreamCopier {
 
   @Override
   protected String getCreateTempTableStatement() {
+    if (!useMetastore) {
+      return String.format("CREATE TABLE %s.%s.%s USING parquet LOCATION '%s';", catalogName, schemaName, tmpTableName, getTmpTableLocation());
+    }
     return String.format("CREATE TABLE %s.%s USING parquet LOCATION '%s';", schemaName, tmpTableName, getTmpTableLocation());
   }
 
   @Override
   public String generateMergeStatement(final String destTableName) {
+    String namespace = String.format("%s.%s", schemaName, destTableName);
+    if (!useMetastore) {
+      namespace = String.format("%s.%s.%s", catalogName, schemaName, destTableName);
+    }
     final String copyData = String.format(
-        "COPY INTO %s.%s " +
+        "COPY INTO %s " +
             "FROM '%s' " +
             "FILEFORMAT = PARQUET " +
             "PATTERN = '%s'",
-        schemaName, destTableName,
+        namespace,
         getTmpTableLocation(),
         parquetWriter.getOutputFilename());
     LOGGER.info(copyData);

--- a/airbyte-integrations/connectors/destination-databricks/src/main/java/io/airbyte/integrations/destination/databricks/DatabricksS3StreamCopierFactory.java
+++ b/airbyte-integrations/connectors/destination-databricks/src/main/java/io/airbyte/integrations/destination/databricks/DatabricksS3StreamCopierFactory.java
@@ -29,12 +29,13 @@ public class DatabricksS3StreamCopierFactory implements DatabricksStreamCopierFa
     try {
       final AirbyteStream stream = configuredStream.getStream();
       final String schema = StreamCopierFactory.getSchema(stream.getNamespace(), configuredSchema, nameTransformer);
+      final String catalog = databricksConfig.getDatabricksCatalog();
 
       S3DestinationConfig s3Config = databricksConfig.getStorageConfig().getS3DestinationConfigOrThrow();
       final AmazonS3 s3Client = s3Config.getS3Client();
       final ProductionWriterFactory writerFactory = new ProductionWriterFactory();
       final Timestamp uploadTimestamp = new Timestamp(System.currentTimeMillis());
-      return new DatabricksS3StreamCopier(stagingFolder, schema, configuredStream, s3Client, database,
+      return new DatabricksS3StreamCopier(stagingFolder, catalog, schema, configuredStream, s3Client, database,
           databricksConfig, nameTransformer, sqlOperations, writerFactory, uploadTimestamp);
     } catch (final Exception e) {
       throw new RuntimeException(e);

--- a/airbyte-integrations/connectors/destination-databricks/src/main/java/io/airbyte/integrations/destination/databricks/DatabricksSqlOperations.java
+++ b/airbyte-integrations/connectors/destination-databricks/src/main/java/io/airbyte/integrations/destination/databricks/DatabricksSqlOperations.java
@@ -38,6 +38,10 @@ public class DatabricksSqlOperations extends JdbcSqlOperations {
         JavaBaseConstants.COLUMN_NAME_EMITTED_AT);
   }
 
+  public void createCatalogIfNotExists(final JdbcDatabase database, final String catalogName) throws Exception {
+    database.execute(String.format("create catalog if not exists %s;", catalogName));
+  }
+
   @Override
   public void createSchemaIfNotExists(final JdbcDatabase database, final String schemaName) throws Exception {
     database.execute(String.format("create database if not exists %s;", schemaName));

--- a/airbyte-integrations/connectors/destination-databricks/src/main/resources/spec.json
+++ b/airbyte-integrations/connectors/destination-databricks/src/main/resources/spec.json
@@ -53,13 +53,21 @@
         "airbyte_secret": true,
         "order": 5
       },
+      "databricks_catalog": {
+        "title": "Databricks Catalog",
+        "type": "string",
+        "description": "The default catalog tables are written to.",
+        "default": "airbyte",
+        "examples": ["airbyte"],
+        "order": 6
+      },
       "database_schema": {
         "title": "Database Schema",
         "type": "string",
         "description": "The default schema tables are written to if the source does not specify a namespace. Unless specifically configured, the usual value for this field is \"public\".",
         "default": "public",
         "examples": ["public"],
-        "order": 6
+        "order": 7
       },
       "data_source": {
         "title": "Data Source",
@@ -213,14 +221,21 @@
             }
           }
         ],
-        "order": 7
+        "order": 8
       },
       "purge_staging_data": {
         "title": "Purge Staging Files and Tables",
         "type": "boolean",
         "description": "Default to 'true'. Switch it to 'false' for debugging purpose.",
         "default": true,
-        "order": 8
+        "order": 9
+      },
+      "use_metastore": {
+        "title": "Use Metastore as Catalog",
+        "type": "boolean",
+        "description": "Default to 'true'. Switch it to 'false' using three level namespace and create new catalog (this needs Unity Catalog to be activated).",
+        "default": true,
+        "order": 10
       }
     }
   }


### PR DESCRIPTION
## What
The Problem and solution can be found in the corresponding Issue: [#20953](https://github.com/airbytehq/airbyte/issues/20953)

## Recommended reading order
1. `spec.json`
2. `DatabricksDestinationConfig.java` 
3. `DatabricksStreamCopier.java` 
4. `DatabricksS3StreamCopier.java`
5. `DatabricksS3StreamCopierFactory.java`
6. `DatabricksAzureBlobStorageStreamCopier.java`
7. `DatabricksAzureBlobStorageStreamCopierFactory.java`
8. `DatabricksSqlOperations.java`

## 🚨 User Impact 🚨
Are there any breaking changes? What is the end result perceived by the user? If yes, please merge this PR with the 🚨🚨 emoji so changelog authors can further highlight this if needed.

## Pre-merge Checklist
Expand the relevant checklist and delete the others.

<details><summary><strong>Updating a connector</strong></summary>

### Community member or Airbyter

- [] Grant edit access to maintainers ([instructions](https://docs.github.com/en/github/collaborating-with-pull-requests/working-with-forks/allowing-changes-to-a-pull-request-branch-created-from-a-fork#enabling-repository-maintainer-permissions-on-existing-pull-requests))
- [x] Secrets in the connector's spec are annotated with `airbyte_secret`
- [x] Unit & integration tests added and passing. Community members, please provide proof of success locally e.g: screenshot or copy-paste unit, integration, and acceptance test output. To run acceptance tests for a Python connector, follow instructions in the README. For java connectors run `./gradlew :airbyte-integrations:connectors:<name>:integrationTest`.
- [ ] Code reviews completed
- [ ] Documentation updated
    - [ ] Connector's `README.md`
    - [ ] Connector's `bootstrap.md`. See [description and examples](https://docs.google.com/document/d/1ypdgmwmEHWv-TrO4_YOQ7pAJGVrMp5BOkEVh831N260/edit?usp=sharing)
    - [ ] Changelog updated in `docs/integrations/<source or destination>/<name>.md` including changelog. See changelog [example](https://docs.airbyte.io/integrations/sources/stripe#changelog)
- [x] PR name follows [PR naming conventions](https://docs.airbyte.com/contributing-to-airbyte/issues-and-pull-requests)

### Airbyter

If this is a community PR, the Airbyte engineer reviewing this PR is responsible for the below items.

- [ ] Create a non-forked branch based on this PR and test the below items on it
- [ ] Build is successful
- [ ] If new credentials are required for use in CI, add them to GSM. [Instructions](https://docs.airbyte.io/connector-development#using-credentials-in-ci).
- [ ] [`/test connector=connectors/<name>` command](https://docs.airbyte.io/connector-development#updating-an-existing-connector) is passing
- [ ] New Connector version released on Dockerhub and connector version bumped by running the `/publish` command described [here](https://docs.airbyte.io/connector-development#updating-an-existing-connector)

</details>

## Tests

<details><summary><strong>Unit</strong></summary>

*Put your unit tests output here.*

</details>

<details><summary><strong>Integration</strong></summary>

*Put your integration tests output here.*

</details>

<details><summary><strong>Acceptance</strong></summary>

*Put your acceptance tests output here.*

</details>
