### PR TITLE
fix build: OAuthHandler missing import

### DIFF
--- a/airbyte-server/src/main/java/io/airbyte/server/handlers/OAuthHandler.java
+++ b/airbyte-server/src/main/java/io/airbyte/server/handlers/OAuthHandler.java
@@ -41,6 +41,7 @@ import io.airbyte.server.handlers.helpers.OAuthPathExtractor;
 import io.airbyte.validation.json.JsonValidationException;
 import java.io.IOException;
 import java.net.http.HttpClient;
+import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;


### PR DESCRIPTION
## What

When #20932 and #20933 went in, one removed an import that the other was using, causing a failed build on master.

## How

Fix the build by adding the import again
