### PR TITLE
Update to latest plugin

### DIFF
--- a/airbyte-api/build.gradle
+++ b/airbyte-api/build.gradle
@@ -1,9 +1,7 @@
 import org.openapitools.generator.gradle.plugin.tasks.GenerateTask
 
 plugins {
-    // 6.1.0-SNAPSHOT contains this fix: https://github.com/OpenAPITools/openapi-generator/issues/13025
-    // TODO update to v6.1.0 when it officially releases (due end of August 2022) so that we don't need to depend on a SNAPSHOT version anymore
-    id "org.openapi.generator" version "6.1.0-SNAPSHOT"
+    id "org.openapi.generator" version "6.2.1"
     id "java-library"
 }
 


### PR DESCRIPTION
## What
* Update to latest Open API generator Gradle plugin

## How
* Bump to version 6.2.1 to avoid this issue with snapshot resolution:

```
FAILURE: Build failed with an exception.

* Where:
Build file '/actions-runner/_work/airbyte/airbyte/airbyte-api/build.gradle' line: 6

* What went wrong:
Plugin [id: 'org.openapi.generator', version: '6.1.0-SNAPSHOT', artifact: 'org.openapitools:openapi-generator-gradle-plugin:6.1.0-SNAPSHOT'] was not found in any of the following sources:

- Gradle Core Plugins (plugin is not in 'org.gradle' namespace)
- Plugin Repositories (could not resolve plugin artifact 'org.openapitools:openapi-generator-gradle-plugin:6.1.0-SNAPSHOT')

  Searched in the following repositories:
    Gradle Central Plugin Repository
    maven(https://oss.sonatype.org/content/repositories/snapshots)

Deprecated Gradle features were used in this build, making it incompatible with Gradle 8.0.
```

## Recommended reading order
1. `build.gradle`