### PR TITLE
Remove definitions from getEntityTableData method

### DIFF
--- a/airbyte-webapp/src/components/EntityTable/utils.tsx
+++ b/airbyte-webapp/src/components/EntityTable/utils.tsx
@@ -1,9 +1,7 @@
 import {
   ConnectionStatus,
-  DestinationDefinitionRead,
   DestinationRead,
   JobStatus,
-  SourceDefinitionRead,
   SourceRead,
   WebBackendConnectionListItem,
 } from "core/request/AirbyteClient";
@@ -17,9 +15,8 @@ const getConnectorTypeName = (connectorSpec: DestinationRead | SourceRead) => {
 // TODO: types in next methods look a bit ugly
 export function getEntityTableData<
   S extends "source" | "destination",
-  SoD extends S extends "source" ? SourceRead : DestinationRead,
-  Def extends S extends "source" ? SourceDefinitionRead : DestinationDefinitionRead
->(entities: SoD[], connections: WebBackendConnectionListItem[], definitions: Def[], type: S): EntityTableDataItem[] {
+  SoD extends S extends "source" ? SourceRead : DestinationRead
+>(entities: SoD[], connections: WebBackendConnectionListItem[], type: S): EntityTableDataItem[] {
   const connectType = type === "source" ? "destination" : "source";
 
   const mappedEntities = entities.map((entityItem) => {
@@ -29,21 +26,13 @@ export function getEntityTableData<
       (connectionItem) => connectionItem[`${type}Id` as "sourceId" | "destinationId"] === entitySoDId
     );
 
-    const definitionId = `${type}DefinitionId` as keyof Def;
-    const entityDefinitionId = entityItem[`${type}DefinitionId` as keyof SoD];
-
-    const definition = definitions.find(
-      // @ts-expect-error ignored during react-scripts update
-      (def) => def[definitionId] === entityDefinitionId
-    );
-
     if (!entityConnections.length) {
       return {
         entityId: entitySoDId,
         entityName: entityItem.name,
         enabled: true,
         connectorName: entitySoDName,
-        connectorIcon: definition?.icon,
+        connectorIcon: entityItem.icon,
         lastSync: null,
         connectEntities: [],
       };
@@ -69,7 +58,7 @@ export function getEntityTableData<
       connectorName: entitySoDName,
       lastSync: sortBySync?.[0].latestSyncJobCreatedAt,
       connectEntities,
-      connectorIcon: definition?.icon,
+      connectorIcon: entityItem.icon,
     };
   });
 

--- a/airbyte-webapp/src/components/destination/DestinationsTable/DestinationsTable.tsx
+++ b/airbyte-webapp/src/components/destination/DestinationsTable/DestinationsTable.tsx
@@ -7,7 +7,6 @@ import { getEntityTableData } from "components/EntityTable/utils";
 
 import { DestinationRead } from "core/request/AirbyteClient";
 import { useConnectionList } from "hooks/services/useConnectionHook";
-import { useDestinationDefinitionList } from "services/connector/DestinationDefinitionService";
 
 interface DestinationsTableProps {
   destinations: DestinationRead[];
@@ -16,9 +15,8 @@ interface DestinationsTableProps {
 export const DestinationsTable: React.FC<DestinationsTableProps> = ({ destinations }) => {
   const navigate = useNavigate();
   const { connections } = useConnectionList();
-  const { destinationDefinitions } = useDestinationDefinitionList();
 
-  const data = getEntityTableData(destinations, connections, destinationDefinitions, "destination");
+  const data = getEntityTableData(destinations, connections, "destination");
 
   const clickRow = (destination: EntityTableDataItem) => navigate(`${destination.entityId}`);
 

--- a/airbyte-webapp/src/pages/SourcesPage/pages/AllSourcesPage/components/SourcesTable.tsx
+++ b/airbyte-webapp/src/pages/SourcesPage/pages/AllSourcesPage/components/SourcesTable.tsx
@@ -8,8 +8,6 @@ import { getEntityTableData } from "components/EntityTable/utils";
 import { SourceRead } from "core/request/AirbyteClient";
 import { useConnectionList } from "hooks/services/useConnectionHook";
 
-import { useSourceDefinitionList } from "../../../../../services/connector/SourceDefinitionService";
-
 interface SourcesTableProps {
   sources: SourceRead[];
 }
@@ -18,9 +16,8 @@ const SourcesTable: React.FC<SourcesTableProps> = ({ sources }) => {
   const navigate = useNavigate();
 
   const { connections } = useConnectionList();
-  const { sourceDefinitions } = useSourceDefinitionList();
 
-  const data = getEntityTableData(sources, connections, sourceDefinitions, "source");
+  const data = getEntityTableData(sources, connections, "source");
 
   const clickRow = (source: EntityTableDataItem) => navigate(`${source.entityId}`);
 


### PR DESCRIPTION
## What
Resolves #20667

## How
The `icon` property is available on the top level source or destination so there was no need to load the source or destination definition.