### PR TITLE
🪟 🐛 Show correct page header for creating connection from connector page

### DIFF
--- a/airbyte-webapp/src/pages/ConnectionPage/pages/CreationFormPage/CreationFormPage.tsx
+++ b/airbyte-webapp/src/pages/ConnectionPage/pages/CreationFormPage/CreationFormPage.tsx
@@ -222,7 +222,6 @@ export const CreationFormPage: React.FC = () => {
           } as Record<EntityStepsTypes, string>
         )[type];
 
-  console.log({ currentStep }, { type });
   return (
     <>
       <HeadTitle titles={[{ id: "connection.newConnectionTitle" }]} />

--- a/airbyte-webapp/src/pages/ConnectionPage/pages/CreationFormPage/CreationFormPage.tsx
+++ b/airbyte-webapp/src/pages/ConnectionPage/pages/CreationFormPage/CreationFormPage.tsx
@@ -211,14 +211,18 @@ export const CreationFormPage: React.FC = () => {
           },
         ];
 
-  const titleId: string = (
-    {
-      [EntityStepsTypes.CONNECTION]: "connection.newConnectionTitle",
-      [EntityStepsTypes.DESTINATION]: "destinations.newDestinationTitle",
-      [EntityStepsTypes.SOURCE]: "sources.newSourceTitle",
-    } as Record<EntityStepsTypes, string>
-  )[type];
+  const titleId: string =
+    currentStep === "createConnection"
+      ? "connection.newConnectionTitle"
+      : (
+          {
+            [EntityStepsTypes.CONNECTION]: "connection.newConnectionTitle",
+            [EntityStepsTypes.DESTINATION]: "destinations.newDestinationTitle",
+            [EntityStepsTypes.SOURCE]: "sources.newSourceTitle",
+          } as Record<EntityStepsTypes, string>
+        )[type];
 
+  console.log({ currentStep }, { type });
   return (
     <>
       <HeadTitle titles={[{ id: "connection.newConnectionTitle" }]} />


### PR DESCRIPTION
## What
closes #19796 

Previously, creating a connection from a Source or Destination page (by clicking "add a Destination" or "add a Source" respectively) would display an incorrect title in the PageHeader component when a user was configuring their Connection.

This new flow follows the same page header pattern as for the "Create Connection" workflow when initiated from the Connections page.

Before:
<img width="1090" alt="Screenshot 2023-01-03 at 1 42 50 PM" src="https://user-images.githubusercontent.com/63751206/210420986-293fe188-627c-4289-8675-11304df12fa5.png">

After:
<img width="906" alt="Screenshot 2023-01-03 at 1 36 42 PM" src="https://user-images.githubusercontent.com/63751206/210420882-5b5b5a07-5175-4fb2-b4a4-9cbe191ec1fa.png">


Note:
When creating a new Source and/or Destination during the Connection creation workflow, the "Create connection" page header always shows.  This is the same as what exists currently on master and matches the [current design](https://www.figma.com/file/wihAJg5mkp61I7lLHs0IpV/FREE-CONNECTOR-PROGRAM?node-id=1080%3A15370&t=u1eTzN0UCETkplHn-0) as well (layout is different, but header text is the same)