### PR TITLE
Re-authenticating using the modern flow correcly sets form as dirty

### DIFF
--- a/airbyte-webapp/src/views/Connector/ConnectorForm/components/Sections/auth/useOauthFlowAdapter.tsx
+++ b/airbyte-webapp/src/views/Connector/ConnectorForm/components/Sections/auth/useOauthFlowAdapter.tsx
@@ -41,7 +41,7 @@ function useFormikOauthAdapter(connector: ConnectorDefinitionSpecification): {
         values
       );
     } else {
-      newValues = merge(values, {
+      newValues = merge({}, values, {
         connectionConfiguration: completeOauthResponse,
       });
     }


### PR DESCRIPTION
## What
Resolves https://github.com/airbytehq/oncall/issues/1232

## How
Properly triggers a change to the form values object so Formik knows it's dirty by merging the values into a fresh object.