### PR TITLE
🪟 🐛 Remove unneeded scrollbar on Notification Settings page

### DIFF
--- a/airbyte-webapp/src/pages/SettingsPage/pages/NotificationPage/components/WebHookForm.module.scss
+++ b/airbyte-webapp/src/pages/SettingsPage/pages/NotificationPage/components/WebHookForm.module.scss
@@ -157,7 +157,7 @@
 }
 
 .tooltip {
-  transform: translate(0, -#{variables.$spacing-md});
+  transform: translate(-#{variables.$spacing-xs}, -#{variables.$spacing-md});
   white-space: nowrap;
 }
 


### PR DESCRIPTION
## What
closes #18906 

Previously, hovering over the "Test" button on the Notification Settings tab would cause a scrollbar at the bottom of the screen (see Loom in linked issue)

Now it does not: 
https://www.loom.com/share/7df40f10729f4499a02436bae86a20de

## How
The Tooltip was overflowing the viewport.  Now it is transformed slightly to the left.
