### PR TITLE
Switch order of namespaces and make Destination Default is the defaul…

### DIFF
--- a/airbyte-webapp/src/components/CreateConnection/__snapshots__/CreateConnectionForm.test.tsx.snap
+++ b/airbyte-webapp/src/components/CreateConnection/__snapshots__/CreateConnectionForm.test.tsx.snap
@@ -258,7 +258,7 @@ exports[`CreateConnectionForm should render 1`] = `
                               <div
                                 class="<removed-for-snapshot-test>"
                               >
-                                Mirror source structure
+                                Destination default
                               </div>
                             </div>
                           </div>
@@ -303,7 +303,7 @@ exports[`CreateConnectionForm should render 1`] = `
                       <input
                         name="namespaceDefinition"
                         type="hidden"
-                        value="source"
+                        value="destination"
                       />
                     </div>
                   </div>
@@ -796,9 +796,9 @@ exports[`CreateConnectionForm should render 1`] = `
                           />
                           <div
                             class="<removed-for-snapshot-test>"
-                            title="'<source schema>"
+                            title="'<destination schema>"
                           >
-                            '&lt;source schema&gt;
+                            '&lt;destination schema&gt;
                           </div>
                           <div
                             class="<removed-for-snapshot-test>"

--- a/airbyte-webapp/src/components/connection/DestinationNamespaceModal/DestinationNamespaceModal.tsx
+++ b/airbyte-webapp/src/components/connection/DestinationNamespaceModal/DestinationNamespaceModal.tsx
@@ -69,22 +69,6 @@ export const DestinationNamespaceModal: React.FC<DestinationNamespaceModalProps>
                   <LabeledRadioButton
                     {...field}
                     className={styles.radioButton}
-                    id="destinationNamespace.source"
-                    label={
-                      <Text as="span">
-                        <FormattedMessage id="connectionForm.modal.destinationNamespace.option.source" />
-                      </Text>
-                    }
-                    value={NamespaceDefinitionType.source}
-                    checked={field.value === NamespaceDefinitionType.source}
-                  />
-                )}
-              </Field>
-              <Field name="namespaceDefinition">
-                {({ field }: FieldProps<string>) => (
-                  <LabeledRadioButton
-                    {...field}
-                    className={styles.radioButton}
                     id="destinationNamespace.destination"
                     label={
                       <Text as="span">
@@ -93,6 +77,22 @@ export const DestinationNamespaceModal: React.FC<DestinationNamespaceModalProps>
                     }
                     value={NamespaceDefinitionType.destination}
                     checked={field.value === NamespaceDefinitionType.destination}
+                  />
+                )}
+              </Field>
+              <Field name="namespaceDefinition">
+                {({ field }: FieldProps<string>) => (
+                  <LabeledRadioButton
+                    {...field}
+                    className={styles.radioButton}
+                    id="destinationNamespace.source"
+                    label={
+                      <Text as="span">
+                        <FormattedMessage id="connectionForm.modal.destinationNamespace.option.source" />
+                      </Text>
+                    }
+                    value={NamespaceDefinitionType.source}
+                    checked={field.value === NamespaceDefinitionType.source}
                   />
                 )}
               </Field>

--- a/airbyte-webapp/src/components/connection/DestinationNamespaceModal/DestinationNamespaceModal.tsx
+++ b/airbyte-webapp/src/components/connection/DestinationNamespaceModal/DestinationNamespaceModal.tsx
@@ -19,7 +19,7 @@ import { ExampleSettingsTable } from "./ExampleSettingsTable";
 const destinationNamespaceValidationSchema = yup.object().shape({
   namespaceDefinition: yup
     .string()
-    .oneOf([NamespaceDefinitionType.source, NamespaceDefinitionType.destination, NamespaceDefinitionType.customformat])
+    .oneOf([NamespaceDefinitionType.destination, NamespaceDefinitionType.source, NamespaceDefinitionType.customformat])
     .required("form.empty.error"),
   namespaceFormat: yup.string().when("namespaceDefinition", {
     is: NamespaceDefinitionType.customformat,
@@ -48,7 +48,7 @@ export const DestinationNamespaceModal: React.FC<DestinationNamespaceModalProps>
   return (
     <Formik
       initialValues={{
-        namespaceDefinition: initialValues?.namespaceDefinition ?? NamespaceDefinitionType.source,
+        namespaceDefinition: initialValues?.namespaceDefinition ?? NamespaceDefinitionType.destination,
         namespaceFormat: initialValues.namespaceFormat,
       }}
       enableReinitialize

--- a/airbyte-webapp/src/views/Connection/ConnectionForm/components/NamespaceDefinitionField.tsx
+++ b/airbyte-webapp/src/views/Connection/ConnectionForm/components/NamespaceDefinitionField.tsx
@@ -11,14 +11,14 @@ import styles from "./NamespaceDefinitionField.module.scss";
 
 export const StreamOptions = [
   {
-    value: NamespaceDefinitionType.source,
-    label: <FormattedMessage id="connectionForm.sourceFormat" />,
-    testId: "namespaceDefinition-source",
-  },
-  {
     value: NamespaceDefinitionType.destination,
     label: <FormattedMessage id="connectionForm.destinationFormat" />,
     testId: "namespaceDefinition-destination",
+  },
+  {
+    value: NamespaceDefinitionType.source,
+    label: <FormattedMessage id="connectionForm.sourceFormat" />,
+    testId: "namespaceDefinition-source",
   },
   {
     value: NamespaceDefinitionType.customformat,

--- a/airbyte-webapp/src/views/Connection/ConnectionForm/formConfig.tsx
+++ b/airbyte-webapp/src/views/Connection/ConnectionForm/formConfig.tsx
@@ -138,8 +138,8 @@ export const createConnectionValidationSchema = ({
       namespaceDefinition: yup
         .string()
         .oneOf([
-          NamespaceDefinitionType.source,
           NamespaceDefinitionType.destination,
+          NamespaceDefinitionType.source,
           NamespaceDefinitionType.customformat,
         ])
         .required("form.empty.error"),
@@ -365,7 +365,7 @@ export const useInitialValues = (
       scheduleData: connection.connectionId ? connection.scheduleData ?? null : DEFAULT_SCHEDULE,
       nonBreakingChangesPreference: connection.nonBreakingChangesPreference ?? NonBreakingChangesPreference.ignore,
       prefix: connection.prefix || "",
-      namespaceDefinition: connection.namespaceDefinition || NamespaceDefinitionType.source,
+      namespaceDefinition: connection.namespaceDefinition || NamespaceDefinitionType.destination,
       namespaceFormat: connection.namespaceFormat ?? SOURCE_NAMESPACE_TAG,
       geography: connection.geography || workspace.defaultGeography || "auto",
     };

--- a/tools/bin/load_test/connection_spec.json
+++ b/tools/bin/load_test/connection_spec.json
@@ -32,7 +32,7 @@
     ]
   },
   "prefix": "",
-  "namespaceDefinition": "source",
+  "namespaceDefinition": "destination",
   "namespaceFormat": "${SOURCE_NAMESPACE}",
   "scheduleType": "basic",
   "scheduleData": {


### PR DESCRIPTION
Fixes https://github.com/airbytehq/airbyte/issues/21030

## What

- Change the order of options to make Destination Default the first option
- Make Destination Default the option selected by default instead of Mirror Source Structure