### PR TITLE
Remove workspace helper from fetchConfigActivity

### DIFF
--- a/airbyte-workers/src/main/java/io/airbyte/workers/config/ApiClientBeanFactory.java
+++ b/airbyte-workers/src/main/java/io/airbyte/workers/config/ApiClientBeanFactory.java
@@ -11,6 +11,7 @@ import com.google.auth.oauth2.ServiceAccountCredentials;
 import io.airbyte.api.client.AirbyteApiClient;
 import io.airbyte.api.client.generated.ConnectionApi;
 import io.airbyte.api.client.generated.SourceApi;
+import io.airbyte.api.client.generated.WorkspaceApi;
 import io.airbyte.api.client.invoker.generated.ApiClient;
 import io.airbyte.commons.temporal.config.WorkerMode;
 import io.micronaut.context.BeanProvider;
@@ -71,6 +72,11 @@ public class ApiClientBeanFactory {
   @Singleton
   public ConnectionApi connectionApi(final ApiClient apiClient) {
     return new ConnectionApi(apiClient);
+  }
+
+  @Singleton
+  public WorkspaceApi workspaceApi(final ApiClient apiClient) {
+    return new WorkspaceApi(apiClient);
   }
 
   @Singleton

--- a/airbyte-workers/src/main/java/io/airbyte/workers/temporal/scheduling/ConnectionNotificationWorkflowImpl.java
+++ b/airbyte-workers/src/main/java/io/airbyte/workers/temporal/scheduling/ConnectionNotificationWorkflowImpl.java
@@ -16,6 +16,7 @@ import io.airbyte.workers.temporal.annotations.TemporalActivityStub;
 import io.airbyte.workers.temporal.scheduling.activities.ConfigFetchActivity;
 import io.airbyte.workers.temporal.scheduling.activities.NotifySchemaChangeActivity;
 import io.airbyte.workers.temporal.scheduling.activities.SlackConfigActivity;
+import io.temporal.workflow.Workflow;
 import java.io.IOException;
 import java.util.Optional;
 import java.util.UUID;
@@ -23,6 +24,9 @@ import lombok.extern.slf4j.Slf4j;
 
 @Slf4j
 public class ConnectionNotificationWorkflowImpl implements ConnectionNotificationWorkflow {
+
+  private static final String GET_BREAKING_CHANGE_TAG = "get_breaking_change";
+  private static final int GET_BREAKING_CHANGE_VERSION = 1;
 
   @TemporalActivityStub(activityOptionsBeanName = "shortActivityOptions")
   private NotifySchemaChangeActivity notifySchemaChangeActivity;
@@ -34,14 +38,18 @@ public class ConnectionNotificationWorkflowImpl implements ConnectionNotificatio
   @Override
   public boolean sendSchemaChangeNotification(final UUID connectionId)
       throws IOException, InterruptedException, ApiException, ConfigNotFoundException, JsonValidationException {
-    final Optional<Boolean> breakingChange = configFetchActivity.getBreakingChange(connectionId);
-    final Optional<SlackNotificationConfiguration> slackConfig = slackConfigActivity.fetchSlackConfiguration(connectionId);
-    if (slackConfig.isPresent() && breakingChange.isPresent()) {
-      final Notification notification =
-          new Notification().withNotificationType(NotificationType.SLACK).withSendOnFailure(false).withSendOnSuccess(false)
-              .withSlackConfiguration(slackConfig.get());
-      final SlackNotificationClient notificationClient = new SlackNotificationClient(notification);
-      return notifySchemaChangeActivity.notifySchemaChange(notificationClient, connectionId, breakingChange.get());
+    final int getBreakingChangeVersion =
+        Workflow.getVersion(GET_BREAKING_CHANGE_TAG, Workflow.DEFAULT_VERSION, GET_BREAKING_CHANGE_VERSION);
+    if (getBreakingChangeVersion >= GET_BREAKING_CHANGE_VERSION) {
+      final Optional<Boolean> breakingChange = configFetchActivity.getBreakingChange(connectionId);
+      final Optional<SlackNotificationConfiguration> slackConfig = slackConfigActivity.fetchSlackConfiguration(connectionId);
+      if (slackConfig.isPresent() && breakingChange.isPresent()) {
+        final Notification notification =
+            new Notification().withNotificationType(NotificationType.SLACK).withSendOnFailure(false).withSendOnSuccess(false)
+                .withSlackConfiguration(slackConfig.get());
+        final SlackNotificationClient notificationClient = new SlackNotificationClient(notification);
+        return notifySchemaChangeActivity.notifySchemaChange(notificationClient, connectionId, breakingChange.get());
+      }
     } else {
       return false;
     }

--- a/airbyte-workers/src/main/java/io/airbyte/workers/temporal/scheduling/ConnectionNotificationWorkflowImpl.java
+++ b/airbyte-workers/src/main/java/io/airbyte/workers/temporal/scheduling/ConnectionNotificationWorkflowImpl.java
@@ -49,6 +49,8 @@ public class ConnectionNotificationWorkflowImpl implements ConnectionNotificatio
                 .withSlackConfiguration(slackConfig.get());
         final SlackNotificationClient notificationClient = new SlackNotificationClient(notification);
         return notifySchemaChangeActivity.notifySchemaChange(notificationClient, connectionId, breakingChange.get());
+      } else {
+        return false;
       }
     } else {
       return false;

--- a/airbyte-workers/src/main/java/io/airbyte/workers/temporal/scheduling/activities/ConfigFetchActivity.java
+++ b/airbyte-workers/src/main/java/io/airbyte/workers/temporal/scheduling/activities/ConfigFetchActivity.java
@@ -5,12 +5,8 @@
 package io.airbyte.workers.temporal.scheduling.activities;
 
 import io.airbyte.api.client.model.generated.ConnectionStatus;
-import io.airbyte.config.StandardSync;
-import io.airbyte.config.persistence.ConfigNotFoundException;
-import io.airbyte.validation.json.JsonValidationException;
 import io.temporal.activity.ActivityInterface;
 import io.temporal.activity.ActivityMethod;
-import java.io.IOException;
 import java.time.Duration;
 import java.util.Optional;
 import java.util.UUID;
@@ -26,6 +22,9 @@ public interface ConfigFetchActivity {
 
   @ActivityMethod
   Optional<ConnectionStatus> getStatus(UUID connectionId);
+
+  @ActivityMethod
+  public Optional<Boolean> getBreakingChange(final UUID connectionId);
 
   @Data
   @NoArgsConstructor
@@ -44,8 +43,6 @@ public interface ConfigFetchActivity {
     private Duration timeToWait;
 
   }
-
-  StandardSync getStandardSync(final UUID connectionId) throws JsonValidationException, ConfigNotFoundException, IOException;
 
   /**
    * Return how much time to wait before running the next sync. It will query the DB to get the last

--- a/airbyte-workers/src/test/java/io/airbyte/workers/temporal/scheduling/ConnectionNotificationWorkflowTest.java
+++ b/airbyte-workers/src/test/java/io/airbyte/workers/temporal/scheduling/ConnectionNotificationWorkflowTest.java
@@ -13,7 +13,6 @@ import static org.mockito.Mockito.when;
 import io.airbyte.api.client.invoker.generated.ApiException;
 import io.airbyte.commons.temporal.scheduling.ConnectionNotificationWorkflow;
 import io.airbyte.config.SlackNotificationConfiguration;
-import io.airbyte.config.StandardSync;
 import io.airbyte.config.persistence.ConfigNotFoundException;
 import io.airbyte.notification.SlackNotificationClient;
 import io.airbyte.validation.json.JsonValidationException;
@@ -102,7 +101,7 @@ class ConnectionNotificationWorkflowTest {
 
     final UUID connectionId = UUID.randomUUID();
 
-    when(mConfigFetchActivity.getStandardSync(connectionId)).thenReturn(new StandardSync().withBreakingChange(false));
+    when(mConfigFetchActivity.getBreakingChange(connectionId)).thenReturn(Optional.of(false));
     workflow.sendSchemaChangeNotification(connectionId);
 
     verify(mNotifySchemaChangeActivity, times(1)).notifySchemaChange(any(SlackNotificationClient.class), any(UUID.class), any(boolean.class));


### PR DESCRIPTION
- Remove WorkspaceHelper, which requires configRepository, and replace it with WorkspaceApi
- Remove getStandardSync method from fetchConfigActivity, which relies on configRepository
- Add getBreakingChange method to fetch the breaking change attr from a connection using the connectionApi