### PR TITLE
🪟🐛 Connector form: Fill in all default values on oneOf switch

### DIFF
--- a/airbyte-webapp/src/views/Connector/ConnectorForm/components/Sections/ConditionSection.tsx
+++ b/airbyte-webapp/src/views/Connector/ConnectorForm/components/Sections/ConditionSection.tsx
@@ -1,14 +1,15 @@
 import { useFormikContext, setIn, useField } from "formik";
+import clone from "lodash/clone";
 import get from "lodash/get";
 import React, { useCallback, useMemo } from "react";
 
 import GroupControls from "components/GroupControls";
 import { DropDown, DropDownOptionDataItem } from "components/ui/DropDown";
 
-import { FormBlock, FormConditionItem } from "core/form/types";
-import { isDefined } from "utils/common";
+import { FormConditionItem } from "core/form/types";
 
 import { ConnectorFormValues } from "../../types";
+import { setDefaultValues } from "../../useBuildForm";
 import styles from "./ConditionSection.module.scss";
 import { FormSection } from "./FormSection";
 import { GroupLabel } from "./GroupLabel";
@@ -39,22 +40,15 @@ export const ConditionSection: React.FC<ConditionSectionProps> = ({ formField, p
 
   const onOptionChange = useCallback(
     (selectedItem: DropDownOptionDataItem) => {
-      const newSelectedPath = formField.conditions[selectedItem.value];
+      const newSelectedFormBlock = formField.conditions[selectedItem.value];
 
-      const newValues =
-        newSelectedPath._type === "formGroup"
-          ? newSelectedPath.properties?.reduce(
-              (acc: ConnectorFormValues, property: FormBlock) =>
-                property._type === "formItem" && isDefined(property.const)
-                  ? setIn(acc, property.path, property.const)
-                  : acc,
-              values
-            )
-          : values;
+      const conditionValues = clone(get(values, path) || {});
+      conditionValues[formField.selectionKey] = formField.selectionConstValues[selectedItem.value];
+      setDefaultValues(newSelectedFormBlock, conditionValues, { respectExistingValues: true });
 
-      setValues(newValues);
+      setValues(setIn(values, path, conditionValues));
     },
-    [values, formField.conditions, setValues]
+    [formField.conditions, formField.selectionKey, formField.selectionConstValues, values, path, setValues]
   );
 
   const options = useMemo(

--- a/airbyte-webapp/src/views/Connector/ConnectorForm/useBuildForm.tsx
+++ b/airbyte-webapp/src/views/Connector/ConnectorForm/useBuildForm.tsx
@@ -22,7 +22,7 @@ export interface BuildFormHook {
   validationSchema: AnySchema;
 }
 
-function setDefaultValues(
+export function setDefaultValues(
   formGroup: FormGroupItem,
   values: Record<string, unknown>,
   options: { respectExistingValues: boolean } = { respectExistingValues: false }


### PR DESCRIPTION
Slack thread for context: https://airbytehq-team.slack.com/archives/C02TL38U5L7/p1672859912283969

This PR fixes the problem that default values of nested properties are not populated when switching between oneOf conditions.

For example:
* Go to big query destination
* Switch to GCS staging
* "Credential" should default to "HMAC", but defaults to empty

This is fixed by selectively running the existing recursive `setDefaultValues` logic when picking a new condition (respecting all properties that have been set already to preserve existing behavior).

The old logic did only update the "const" values on the highest level, ignoring all nested default values.