### PR TITLE
Move hadoop-lzo to test dependency

### DIFF
--- a/airbyte-integrations/bases/base-java-s3/build.gradle
+++ b/airbyte-integrations/bases/base-java-s3/build.gradle
@@ -13,7 +13,6 @@ dependencies {
 
     implementation ('org.apache.parquet:parquet-avro:1.12.3') { exclude group: 'org.slf4j', module: 'slf4j-log4j12'}
     implementation ('com.github.airbytehq:json-avro-converter:1.1.0') { exclude group: 'ch.qos.logback', module: 'logback-classic'}
-    implementation group: 'com.hadoop.gplcompression', name: 'hadoop-lzo', version: '0.4.20'
 
     // parquet
     implementation ('org.apache.hadoop:hadoop-common:3.3.3') {

--- a/airbyte-integrations/bases/base-java-s3/build.gradle
+++ b/airbyte-integrations/bases/base-java-s3/build.gradle
@@ -35,4 +35,5 @@ dependencies {
 
     testImplementation 'org.junit.jupiter:junit-jupiter-api:5.8.1'
     testRuntimeOnly 'org.junit.jupiter:junit-jupiter-engine:5.8.1'
+    testImplementation group: 'com.hadoop.gplcompression', name: 'hadoop-lzo', version: '0.4.20'
 }

--- a/airbyte-integrations/connectors/destination-s3/build.gradle
+++ b/airbyte-integrations/connectors/destination-s3/build.gradle
@@ -33,7 +33,7 @@ dependencies {
     }
     implementation ('org.apache.parquet:parquet-avro:1.12.3') { exclude group: 'org.slf4j', module: 'slf4j-log4j12'}
     implementation ('com.github.airbytehq:json-avro-converter:1.1.0') { exclude group: 'ch.qos.logback', module: 'logback-classic'}
-    implementation group: 'com.hadoop.gplcompression', name: 'hadoop-lzo', version: '0.4.20'
+
     testImplementation 'org.apache.commons:commons-lang3:3.11'
     testImplementation 'org.xerial.snappy:snappy-java:1.1.8.4'
     testImplementation "org.mockito:mockito-inline:4.1.0"


### PR DESCRIPTION
## What
destination-s3 does not have a direct compile dependency on hadoop-lzo library, so it can be removed