### PR TITLE
In Cloud, out of date connectors call always returns 0

### DIFF
--- a/airbyte-webapp/src/services/connector/ConnectorService.ts
+++ b/airbyte-webapp/src/services/connector/ConnectorService.ts
@@ -1,11 +1,15 @@
 import { useConfig } from "config";
-import { webBackendCheckUpdates } from "core/request/AirbyteClient";
+import { webBackendCheckUpdates, WebBackendCheckUpdatesRead } from "core/request/AirbyteClient";
 import { AirbyteRequestService } from "core/request/AirbyteRequestService";
 import { useDefaultRequestMiddlewares } from "services/useDefaultRequestMiddlewares";
 import { useInitService } from "services/useInitService";
+import { isCloudApp } from "utils/app";
 
 class ConnectorService extends AirbyteRequestService {
-  checkUpdates() {
+  checkUpdates(): Promise<WebBackendCheckUpdatesRead> {
+    if (isCloudApp()) {
+      return Promise.resolve({ sourceDefinitions: 0, destinationDefinitions: 0 });
+    }
     return webBackendCheckUpdates(this.requestOptions);
   }
 }

--- a/airbyte-webapp/src/utils/app.ts
+++ b/airbyte-webapp/src/utils/app.ts
@@ -1,1 +1,1 @@
-export const isCloudApp = () => process.env.REACT_APP_CLOUD || window.CLOUD === "true";
+export const isCloudApp = () => (process.env.REACT_APP_CLOUD || window.CLOUD) === "true";


### PR DESCRIPTION
## What
In Cloud, out of date connectors call always returns 0

## How
The app checks if it's running in Cloud mode, and if so doesn't make the call to the server to get out of date connectors; it just returns 0 out of date connectors.

Additionally, the check now properly returns a boolean.