### PR TITLE
Only checkUpdates if AllowUpdateConnectors enabled

### DIFF
--- a/airbyte-webapp/src/services/connector/ConnectorService.ts
+++ b/airbyte-webapp/src/services/connector/ConnectorService.ts
@@ -1,23 +1,46 @@
 import { useConfig } from "config";
 import { webBackendCheckUpdates, WebBackendCheckUpdatesRead } from "core/request/AirbyteClient";
 import { AirbyteRequestService } from "core/request/AirbyteRequestService";
+import { RequestMiddleware } from "core/request/RequestMiddleware";
+import { FeatureItem, useFeature } from "hooks/services/Feature";
 import { useDefaultRequestMiddlewares } from "services/useDefaultRequestMiddlewares";
 import { useInitService } from "services/useInitService";
-import { isCloudApp } from "utils/app";
+
+const NO_UPDATES: WebBackendCheckUpdatesRead = {
+  destinationDefinitions: 0,
+  sourceDefinitions: 0,
+};
+
+type EnabledFeatures = Partial<Record<FeatureItem, boolean>>;
 
 class ConnectorService extends AirbyteRequestService {
-  checkUpdates(): Promise<WebBackendCheckUpdatesRead> {
-    if (isCloudApp()) {
-      return Promise.resolve({ sourceDefinitions: 0, destinationDefinitions: 0 });
+  constructor(
+    rootUrl: string,
+    middlewares: RequestMiddleware[] = [],
+    private readonly enabledFeatures: EnabledFeatures
+  ) {
+    super(rootUrl, middlewares);
+    this.enabledFeatures = enabledFeatures;
+  }
+  checkUpdates() {
+    if (this.enabledFeatures[FeatureItem.AllowUpdateConnectors]) {
+      return webBackendCheckUpdates(this.requestOptions);
     }
-    return webBackendCheckUpdates(this.requestOptions);
+    return Promise.resolve(NO_UPDATES);
   }
 }
 
 export function useConnectorService() {
   const { apiUrl } = useConfig();
 
+  const enabledFeatures = {
+    [FeatureItem.AllowUpdateConnectors]: useFeature(FeatureItem.AllowUpdateConnectors),
+  };
+
   const requestAuthMiddleware = useDefaultRequestMiddlewares();
 
-  return useInitService(() => new ConnectorService(apiUrl, requestAuthMiddleware), [apiUrl, requestAuthMiddleware]);
+  return useInitService(
+    () => new ConnectorService(apiUrl, requestAuthMiddleware, enabledFeatures),
+    [apiUrl, requestAuthMiddleware]
+  );
 }


### PR DESCRIPTION
## What
Changes the conditional guarding whether we actually query the `webBackendCheckUpdates` endpoint. The current version checks whether the app is using a cloud build; this updates it to check whether the `AllowUpdateConnector` feature is enabled, which is the actual source of truth (i.e. if we ever start supporting this endpoint for cloud, that's what would change). Closes https://github.com/airbytehq/airbyte-cloud/issues/3972

## on the implementation
The only API we expose for querying `FeatureService` is a react hook, which can't be directly used outside of other react hooks or components--i.e., not in the `ConnectorService` class. Conveniently (in the short term, anyway), the only API we expose for using `ConnectorService` is... a react hook defined in the same file. So the job was reduced to writing an explicit constructor which can be passed the app's feature context via an additional argument. There's a few lines of diff that are just porting the right type definitions for the superclass's constructor args.

I used the `FeatureService` in a slightly roundabout way, though: for aesthetic reasons, I wanted an object which mapped `FeatureItem` member keys to boolean values, and `useFeatureService` doesn't expose anything like that. Maybe I should move the local `EnabledFeatures` into `FeatureService` instead, so it's reusable?