### PR TITLE
Clean up in destination acceptance tests

### DIFF
--- a/airbyte-integrations/bases/standard-destination-test/src/main/java/io/airbyte/integrations/standardtest/destination/DestinationAcceptanceTest.java
+++ b/airbyte-integrations/bases/standard-destination-test/src/main/java/io/airbyte/integrations/standardtest/destination/DestinationAcceptanceTest.java
@@ -88,6 +88,7 @@ import lombok.Getter;
 import org.joda.time.DateTime;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtensionContext;
 import org.junit.jupiter.params.ParameterizedTest;
@@ -660,11 +661,6 @@ public abstract class DestinationAcceptanceTest {
     final AirbyteCatalog catalog = Jsons.deserialize(
         MoreResources.readResource(DataArgumentsProvider.EXCHANGE_RATE_CONFIG.getCatalogFileVersion(ProtocolVersion.V0)),
         AirbyteCatalog.class);
-
-    if (!catalog.getStreams().get(0).getName().equals("exchange_rate")) {
-      // This test is only implemented for the exchange rate catalog.
-      return;
-    }
 
     final ConfiguredAirbyteCatalog configuredCatalog = CatalogHelpers.toDefaultConfiguredCatalog(
         catalog);
@@ -1535,6 +1531,7 @@ public abstract class DestinationAcceptanceTest {
    * your_containers_id" (ex. docker container attach 18cc929f44c8) to see the container's output
    */
   @Test
+  @Disabled
   public void testStressPerformance() throws Exception {
     final int streamsSize = 5; // number of generated streams
     final int messagesNumber = 300; // number of msg to be written to each generated stream


### PR DESCRIPTION
## What
- Re-disable testStressPerformance, it was accidentally enabled in https://github.com/airbytehq/airbyte/pull/20033.
- Small style cleanup from that PR review.
