### PR TITLE
🪟 🐛 Hide no credits banner for no billing accounts

### DIFF
--- a/airbyte-webapp/src/packages/cloud/views/credits/CreditsPage/components/LowCreditBalanceHint/LowCreditBalanceHint.tsx
+++ b/airbyte-webapp/src/packages/cloud/views/credits/CreditsPage/components/LowCreditBalanceHint/LowCreditBalanceHint.tsx
@@ -3,6 +3,7 @@ import { FormattedMessage } from "react-intl";
 
 import { InfoBox } from "components/ui/InfoBox";
 
+import { CreditStatus } from "packages/cloud/lib/domain/cloudWorkspaces/types";
 import { useGetCloudWorkspace } from "packages/cloud/services/workspaces/CloudWorkspacesService";
 import { useCurrentWorkspace } from "services/workspaces/WorkspacesService";
 
@@ -14,7 +15,9 @@ export const LowCreditBalanceHint: React.FC<React.PropsWithChildren<unknown>> = 
   const workspace = useCurrentWorkspace();
   const cloudWorkspace = useGetCloudWorkspace(workspace.workspaceId);
 
-  if (cloudWorkspace.remainingCredits > LOW_BALANCE_CREDIT_TRESHOLD) {
+  const isNoBillingAccount =
+    cloudWorkspace.remainingCredits <= 0 && cloudWorkspace.creditStatus === CreditStatus.POSITIVE;
+  if (isNoBillingAccount || cloudWorkspace.remainingCredits > LOW_BALANCE_CREDIT_TRESHOLD) {
     return null;
   }
 


### PR DESCRIPTION
## What

Hide the "We stopped all your syncs because you ran out of credits" for accounts that actually are still working (no billing accounts). They will still have creditStatus on "positive" even when ran out. There's not real way we know those accounts before they ran out of credit, so we keep showing the "Low credit warning" still, but at least hide the banner that tells we stopped their syncs (which would not happen).