### PR TITLE
🪟 🐛 Fix broken switch UI state - when checked state provided as a "value"

### DIFF
--- a/airbyte-webapp/src/components/ui/Switch/Switch.tsx
+++ b/airbyte-webapp/src/components/ui/Switch/Switch.tsx
@@ -44,7 +44,7 @@ export const Switch: React.FC<SwitchProps> = ({
     <label className={labelStyle}>
       <input
         {...props}
-        aria-checked={indeterminate ? "mixed" : checked || !!value}
+        aria-checked={(indeterminate ? "mixed" : checked) ?? !!value}
         className={styles.switchInput}
         type="checkbox"
         value={value}

--- a/airbyte-webapp/src/components/ui/Switch/Switch.tsx
+++ b/airbyte-webapp/src/components/ui/Switch/Switch.tsx
@@ -44,7 +44,7 @@ export const Switch: React.FC<SwitchProps> = ({
     <label className={labelStyle}>
       <input
         {...props}
-        aria-checked={indeterminate ? "mixed" : checked}
+        aria-checked={indeterminate ? "mixed" : checked || !!value}
         className={styles.switchInput}
         type="checkbox"
         value={value}


### PR DESCRIPTION
## What
Fixed broken `<Switch />` UI state

## How
Handle the `checked` state if it was provided as a `value`

![CPT2301102049-572x571](https://user-images.githubusercontent.com/20929344/211637003-7649481d-d09e-4e6f-a130-aa69ceeed07d.gif)
