### PR TITLE
🪟 🔧 Use experiment for new streams table design

### DIFF
--- a/airbyte-webapp/src/components/CreateConnection/CreateConnectionForm.tsx
+++ b/airbyte-webapp/src/components/CreateConnection/CreateConnectionForm.tsx
@@ -18,10 +18,7 @@ import { useCurrentWorkspaceId } from "services/workspaces/WorkspacesService";
 import CreateControls from "views/Connection/ConnectionForm/components/CreateControls";
 import { OperationsSection } from "views/Connection/ConnectionForm/components/OperationsSection";
 import { ConnectionFormFields } from "views/Connection/ConnectionForm/ConnectionFormFields";
-import {
-  createConnectionValidationSchema,
-  FormikConnectionFormValues,
-} from "views/Connection/ConnectionForm/formConfig";
+import { useConnectionValidationSchema, FormikConnectionFormValues } from "views/Connection/ConnectionForm/formConfig";
 
 import styles from "./CreateConnectionForm.module.scss";
 import { CreateConnectionNameField } from "./CreateConnectionNameField";
@@ -42,24 +39,17 @@ const CreateConnectionFormInner: React.FC<CreateConnectionPropsInner> = ({ schem
   const navigate = useNavigate();
   const canEditDataGeographies = useFeature(FeatureItem.AllowChangeDataGeographies);
   const { mutateAsync: createConnection } = useCreateConnection();
-  const allowAutoDetectSchema = useFeature(FeatureItem.AllowAutoDetectSchema);
   const { clearFormChange } = useFormChangeTrackerService();
 
   const workspaceId = useCurrentWorkspaceId();
 
   const { connection, initialValues, mode, formId, getErrorMessage, setSubmitError } = useConnectionFormService();
   const [editingTransformation, setEditingTransformation] = useState(false);
-  const allowSubOneHourCronExpressions = useFeature(FeatureItem.AllowSyncSubOneHourCronExpressions);
+  const validationSchema = useConnectionValidationSchema({ mode });
 
   const onFormSubmit = useCallback(
     async (formValues: FormikConnectionFormValues, formikHelpers: FormikHelpers<FormikConnectionFormValues>) => {
-      const values = tidyConnectionFormValues(
-        formValues,
-        workspaceId,
-        mode,
-        allowSubOneHourCronExpressions,
-        allowAutoDetectSchema
-      );
+      const values = tidyConnectionFormValues(formValues, workspaceId, validationSchema);
 
       try {
         const createdConnection = await createConnection({
@@ -91,9 +81,7 @@ const CreateConnectionFormInner: React.FC<CreateConnectionPropsInner> = ({ schem
     },
     [
       workspaceId,
-      mode,
-      allowSubOneHourCronExpressions,
-      allowAutoDetectSchema,
+      validationSchema,
       createConnection,
       connection.source,
       connection.destination,
@@ -113,15 +101,7 @@ const CreateConnectionFormInner: React.FC<CreateConnectionPropsInner> = ({ schem
   return (
     <Suspense fallback={<LoadingSchema />}>
       <div className={styles.connectionFormContainer}>
-        <Formik
-          initialValues={initialValues}
-          validationSchema={createConnectionValidationSchema({
-            mode,
-            allowSubOneHourCronExpressions,
-            allowAutoDetectSchema,
-          })}
-          onSubmit={onFormSubmit}
-        >
+        <Formik initialValues={initialValues} validationSchema={validationSchema} onSubmit={onFormSubmit}>
           {({ values, isSubmitting, isValid, dirty }) => (
             <Form>
               <CreateConnectionNameField />

--- a/airbyte-webapp/src/components/connection/CatalogTree/CatalogSection.tsx
+++ b/airbyte-webapp/src/components/connection/CatalogTree/CatalogSection.tsx
@@ -15,6 +15,7 @@ import {
   SelectedFieldInfo,
 } from "core/request/AirbyteClient";
 import { useDestinationNamespace } from "hooks/connection/useDestinationNamespace";
+import { useNewTableDesignExperiment } from "hooks/connection/useNewTableDesignExperiment";
 import { useConnectionFormService } from "hooks/services/ConnectionForm/ConnectionFormService";
 import { naturalComparatorBy } from "utils/objects";
 import { ConnectionFormValues, SUPPORTED_MODES } from "views/Connection/ConnectionForm/formConfig";
@@ -50,7 +51,7 @@ const CatalogSectionInner: React.FC<CatalogSectionInnerProps> = ({
   errors,
   changedSelected,
 }) => {
-  const isNewStreamsTableEnabled = process.env.REACT_APP_NEW_STREAMS_TABLE ?? false;
+  const isNewTableDesignEnabled = useNewTableDesignExperiment();
 
   const numberOfFieldsInStream = Object.keys(streamNode?.stream?.jsonSchema?.properties).length ?? 0;
 
@@ -187,9 +188,7 @@ const CatalogSectionInner: React.FC<CatalogSectionInnerProps> = ({
   const destName = prefix + (streamNode.stream?.name ?? "");
   const configErrors = getIn(
     errors,
-    isNewStreamsTableEnabled
-      ? `syncCatalog.streams[${streamNode.id}].config`
-      : `schema.streams[${streamNode.id}].config`
+    isNewTableDesignEnabled ? `syncCatalog.streams[${streamNode.id}].config` : `schema.streams[${streamNode.id}].config`
   );
   const hasError = configErrors && Object.keys(configErrors).length > 0;
   const pkType = getPathType(pkRequired, shouldDefinePk);
@@ -197,7 +196,7 @@ const CatalogSectionInner: React.FC<CatalogSectionInnerProps> = ({
   const hasFields = fields?.length > 0;
   const disabled = mode === "readonly";
 
-  const StreamComponent = isNewStreamsTableEnabled ? CatalogTreeTableRow : StreamHeader;
+  const StreamComponent = isNewTableDesignEnabled ? CatalogTreeTableRow : StreamHeader;
 
   return (
     <div className={styles.catalogSection}>
@@ -223,7 +222,7 @@ const CatalogSectionInner: React.FC<CatalogSectionInnerProps> = ({
       />
       {isRowExpanded &&
         hasFields &&
-        (isNewStreamsTableEnabled ? (
+        (isNewTableDesignEnabled ? (
           <StreamDetailsPanel
             config={config}
             disabled={mode === "readonly"}

--- a/airbyte-webapp/src/components/connection/CatalogTree/CatalogTree.tsx
+++ b/airbyte-webapp/src/components/connection/CatalogTree/CatalogTree.tsx
@@ -4,6 +4,7 @@ import React, { useCallback, useMemo, useState } from "react";
 import { LoadingBackdrop } from "components/ui/LoadingBackdrop";
 
 import { SyncSchemaStream } from "core/domain/catalog";
+import { useNewTableDesignExperiment } from "hooks/connection/useNewTableDesignExperiment";
 import { BulkEditServiceProvider } from "hooks/services/BulkEdit/BulkEditService";
 import { useConnectionFormService } from "hooks/services/ConnectionForm/ConnectionFormService";
 import { naturalComparatorBy } from "utils/objects";
@@ -24,7 +25,7 @@ const CatalogTreeComponent: React.FC<React.PropsWithChildren<CatalogTreeProps>> 
   onStreamsChanged,
   isLoading,
 }) => {
-  const isNewStreamsTableEnabled = process.env.REACT_APP_NEW_STREAMS_TABLE ?? false;
+  const isNewTableDesignEnabled = useNewTableDesignExperiment();
   const { initialValues, mode } = useConnectionFormService();
 
   const [searchString, setSearchString] = useState("");
@@ -72,9 +73,7 @@ const CatalogTreeComponent: React.FC<React.PropsWithChildren<CatalogTreeProps>> 
     <BulkEditServiceProvider nodes={streams} update={onStreamsChanged}>
       <LoadingBackdrop loading={isLoading}>
         {mode !== "readonly" && <CatalogTreeSearch onSearch={setSearchString} />}
-        <div
-          className={classNames(styles.catalogTreeTable, { [styles.newCatalogTreeTable]: isNewStreamsTableEnabled })}
-        >
+        <div className={classNames(styles.catalogTreeTable, { [styles.newCatalogTreeTable]: isNewTableDesignEnabled })}>
           <CatalogTreeBody
             streams={filteredStreams}
             changedStreams={changedStreams}
@@ -82,7 +81,7 @@ const CatalogTreeComponent: React.FC<React.PropsWithChildren<CatalogTreeProps>> 
           />
         </div>
       </LoadingBackdrop>
-      {isNewStreamsTableEnabled && <BulkEditPanel />}
+      {isNewTableDesignEnabled && <BulkEditPanel />}
     </BulkEditServiceProvider>
   );
 };

--- a/airbyte-webapp/src/components/connection/CatalogTree/CatalogTreeBody.tsx
+++ b/airbyte-webapp/src/components/connection/CatalogTree/CatalogTreeBody.tsx
@@ -3,6 +3,7 @@ import React, { useCallback } from "react";
 
 import { SyncSchemaStream } from "core/domain/catalog";
 import { AirbyteStreamConfiguration } from "core/request/AirbyteClient";
+import { useNewTableDesignExperiment } from "hooks/connection/useNewTableDesignExperiment";
 import { useConnectionFormService } from "hooks/services/ConnectionForm/ConnectionFormService";
 import { FormikConnectionFormValues } from "views/Connection/ConnectionForm/formConfig";
 
@@ -20,10 +21,9 @@ interface CatalogTreeBodyProps {
   onStreamChanged: (stream: SyncSchemaStream) => void;
 }
 
-const isNewStreamsTableEnabled = process.env.REACT_APP_NEW_STREAMS_TABLE ?? false;
-
 export const CatalogTreeBody: React.FC<CatalogTreeBodyProps> = ({ streams, changedStreams, onStreamChanged }) => {
   const { mode } = useConnectionFormService();
+  const isNewTableDesignEnabled = useNewTableDesignExperiment();
 
   const onUpdateStream = useCallback(
     (id: string | undefined, newConfig: Partial<AirbyteStreamConfiguration>) => {
@@ -40,7 +40,7 @@ export const CatalogTreeBody: React.FC<CatalogTreeBodyProps> = ({ streams, chang
 
   return (
     <div className={styles.container}>
-      {isNewStreamsTableEnabled ? (
+      {isNewTableDesignEnabled ? (
         <>
           <StreamConnectionHeader />
           <CatalogTreeTableHeader />

--- a/airbyte-webapp/src/components/connection/CatalogTree/next/CatalogTreeTableHeader.tsx
+++ b/airbyte-webapp/src/components/connection/CatalogTree/next/CatalogTreeTableHeader.tsx
@@ -12,6 +12,7 @@ import { Text } from "components/ui/Text";
 import { InfoTooltip, TooltipLearnMoreLink } from "components/ui/Tooltip";
 
 import { NamespaceDefinitionType } from "core/request/AirbyteClient";
+import { useNewTableDesignExperiment } from "hooks/connection/useNewTableDesignExperiment";
 import { useBulkEditService } from "hooks/services/BulkEdit/BulkEditService";
 import { useConnectionFormService } from "hooks/services/ConnectionForm/ConnectionFormService";
 import { useModalService } from "hooks/services/Modal";
@@ -43,13 +44,12 @@ const HeaderCell: React.FC<React.PropsWithChildren<Parameters<typeof CatalogTree
   );
 };
 
-const isNewStreamsTableEnabled = process.env.REACT_APP_NEW_STREAMS_TABLE ?? false;
-
 export const CatalogTreeTableHeader: React.FC = () => {
   const { mode } = useConnectionFormService();
   const { openModal, closeModal } = useModalService();
   const { onCheckAll, selectedBatchNodeIds, allChecked } = useBulkEditService();
   const formikProps = useFormikContext<FormikConnectionFormValues>();
+  const useNewConnectionTableDesign = useNewTableDesignExperiment();
 
   const destinationNamespaceChange = (value: DestinationNamespaceFormValueType) => {
     formikProps.setFieldValue("namespaceDefinition", value.namespaceDefinition);
@@ -67,7 +67,7 @@ export const CatalogTreeTableHeader: React.FC = () => {
   };
 
   return (
-    <Header className={classNames(styles.headerContainer, { [styles.newTable]: !!isNewStreamsTableEnabled })}>
+    <Header className={classNames(styles.headerContainer, { [styles.newTable]: !!useNewConnectionTableDesign })}>
       <CatalogTreeTableCell size="small" className={styles.checkboxCell}>
         {mode !== "readonly" && (
           <CheckBox

--- a/airbyte-webapp/src/components/connection/CatalogTree/next/CatalogTreeTableHeader.tsx
+++ b/airbyte-webapp/src/components/connection/CatalogTree/next/CatalogTreeTableHeader.tsx
@@ -49,7 +49,7 @@ export const CatalogTreeTableHeader: React.FC = () => {
   const { openModal, closeModal } = useModalService();
   const { onCheckAll, selectedBatchNodeIds, allChecked } = useBulkEditService();
   const formikProps = useFormikContext<FormikConnectionFormValues>();
-  const useNewConnectionTableDesign = useNewTableDesignExperiment();
+  const isNewTableDesignEnabled = useNewTableDesignExperiment();
 
   const destinationNamespaceChange = (value: DestinationNamespaceFormValueType) => {
     formikProps.setFieldValue("namespaceDefinition", value.namespaceDefinition);
@@ -67,7 +67,7 @@ export const CatalogTreeTableHeader: React.FC = () => {
   };
 
   return (
-    <Header className={classNames(styles.headerContainer, { [styles.newTable]: !!useNewConnectionTableDesign })}>
+    <Header className={classNames(styles.headerContainer, { [styles.newTable]: !!isNewTableDesignEnabled })}>
       <CatalogTreeTableCell size="small" className={styles.checkboxCell}>
         {mode !== "readonly" && (
           <CheckBox

--- a/airbyte-webapp/src/components/connection/CatalogTree/next/StreamConnectionHeader.tsx
+++ b/airbyte-webapp/src/components/connection/CatalogTree/next/StreamConnectionHeader.tsx
@@ -4,6 +4,7 @@ import { FormattedMessage } from "react-intl";
 import { ArrowRightIcon } from "components/icons/ArrowRightIcon";
 import { Heading } from "components/ui/Heading";
 
+import { useNewTableDesignExperiment } from "hooks/connection/useNewTableDesignExperiment";
 import { useConnectionFormService } from "hooks/services/ConnectionForm/ConnectionFormService";
 import { useDestinationDefinition } from "services/connector/DestinationDefinitionService";
 import { useSourceDefinition } from "services/connector/SourceDefinitionService";
@@ -12,7 +13,6 @@ import { getIcon } from "utils/imageUtils";
 import styles from "./StreamConnectionHeader.module.scss";
 
 export const renderIcon = (icon?: string): JSX.Element => <div className={styles.icon}>{getIcon(icon)}</div>;
-const isNewStreamsTableEnabled = process.env.REACT_APP_NEW_STREAMS_TABLE ?? false;
 
 export const StreamConnectionHeader: React.FC = () => {
   const {
@@ -20,11 +20,12 @@ export const StreamConnectionHeader: React.FC = () => {
   } = useConnectionFormService();
   const sourceDefinition = useSourceDefinition(source.sourceDefinitionId);
   const destinationDefinition = useDestinationDefinition(destination.destinationDefinitionId);
+  const isNewTableDesignEnabled = useNewTableDesignExperiment();
   const sourceStyles = classnames(styles.connector, styles.source);
   const destinationStyles = classnames(styles.connector, styles.destination);
 
   return (
-    <div className={classnames(styles.container, { [styles.newTableContainer]: !!isNewStreamsTableEnabled })}>
+    <div className={classnames(styles.container, { [styles.newTableContainer]: !!isNewTableDesignEnabled })}>
       <div className={sourceStyles}>
         {renderIcon(sourceDefinition.icon)}{" "}
         <Heading as="h5" size="sm">

--- a/airbyte-webapp/src/hooks/connection/useNewTableDesignExperiment.ts
+++ b/airbyte-webapp/src/hooks/connection/useNewTableDesignExperiment.ts
@@ -1,0 +1,4 @@
+import { useExperiment } from "hooks/services/Experiment";
+
+export const useNewTableDesignExperiment = () =>
+  useExperiment("connection.newTableDesign", process.env.REACT_APP_NEW_STREAMS_TABLE === "true");

--- a/airbyte-webapp/src/hooks/services/Experiment/experiments.ts
+++ b/airbyte-webapp/src/hooks/services/Experiment/experiments.ts
@@ -27,4 +27,5 @@ export interface Experiments {
   "connection.onboarding.destinations": string;
   "connection.autoDetectSchemaChanges": boolean;
   "connection.columnSelection": boolean;
+  "connection.newTableDesign": boolean;
 }

--- a/airbyte-webapp/src/views/Connection/ConnectionForm/ConnectionFormFields.tsx
+++ b/airbyte-webapp/src/views/Connection/ConnectionForm/ConnectionFormFields.tsx
@@ -13,6 +13,7 @@ import { FlexContainer } from "components/ui/Flex";
 import { Input } from "components/ui/Input";
 
 import { NamespaceDefinitionType } from "core/request/AirbyteClient";
+import { useNewTableDesignExperiment } from "hooks/connection/useNewTableDesignExperiment";
 import { useConnectionFormService } from "hooks/services/ConnectionForm/ConnectionFormService";
 import { FeatureItem, useFeature } from "hooks/services/Feature";
 import { useFormChangeTrackerService } from "hooks/services/FormChangeTracker";
@@ -50,8 +51,8 @@ export const ConnectionFormFields: React.FC<ConnectionFormFieldsProps> = ({ valu
     clearFormChange(formId);
   });
 
-  const isNewStreamsTableEnabled = process.env.REACT_APP_NEW_STREAMS_TABLE ?? false;
-  const firstSectionTitle = isNewStreamsTableEnabled ? undefined : <FormattedMessage id="connection.transfer" />;
+  const isNewTableDesignEnabled = useNewTableDesignExperiment();
+  const firstSectionTitle = isNewTableDesignEnabled ? undefined : <FormattedMessage id="connection.transfer" />;
 
   return (
     <>
@@ -64,7 +65,7 @@ export const ConnectionFormFields: React.FC<ConnectionFormFieldsProps> = ({ valu
             <Field name="nonBreakingChangesPreference" component={NonBreakingChangesPreferenceField} />
           )}
         </Section>
-        {!isNewStreamsTableEnabled && (
+        {!isNewTableDesignEnabled && (
           <Section title={<FormattedMessage id="connection.streams" />}>
             <span className={readonlyClass}>
               <Field name="namespaceDefinition" component={NamespaceDefinitionField} />


### PR DESCRIPTION
## What
Resolves #20196 

Updates flagging for new table design to use LaunchDarkly experiment.

## How
Creates a helper hook that checks for the experiment or the current env variable. While there is work to make this easier, I decided to use this custom solution to enable this in cloud sooner.

Some changes were made to how the `validationSchema` was created to use the hook. Creating the schema validation is also a hook so that the flags and experiments don't need to be passed directly.

`tidyConnectionFormValues` also now takes the generated validation schema instead of re-generating it.

## Recommended reading order
Top top bottom
