### PR TITLE
Lowcode docs: add link to YAML reference

### DIFF
--- a/docs/connector-development/config-based/understanding-the-yaml-file/reference.md
+++ b/docs/connector-development/config-based/understanding-the-yaml-file/reference.md
@@ -1,0 +1,3 @@
+# YAML Reference
+
+To see every component and each possible parameter, see the full YAML schema reference [here](https://github.com/airbytehq/airbyte/blob/master/airbyte-cdk/python/airbyte_cdk/sources/declarative/declarative_component_schema.yaml).

--- a/docusaurus/sidebars.js
+++ b/docusaurus/sidebars.js
@@ -254,6 +254,7 @@ module.exports = {
                 'connector-development/config-based/understanding-the-yaml-file/pagination',
                 'connector-development/config-based/understanding-the-yaml-file/record-selector',
                 'connector-development/config-based/understanding-the-yaml-file/stream-slicers',
+                'connector-development/config-based/understanding-the-yaml-file/reference',
               ]
             },
             'connector-development/config-based/advanced-topics',    


### PR DESCRIPTION
## What
Adds a link to the YAML reference to the docs so users can always see the full options available. 

In the future, it would be a better experience to have a CI hook which embeds this into the docs directly, using something like https://coveooss.github.io/json-schema-for-humans. 

in the interest of "shipped is better than perfect", putting this here as a stopgap.