### PR TITLE
🪟 🐛 Fix auto detect schema change backdrop color CSS

### DIFF
--- a/airbyte-webapp/src/views/Connection/ConnectionForm/components/SchemaChangeBackdrop.module.scss
+++ b/airbyte-webapp/src/views/Connection/ConnectionForm/components/SchemaChangeBackdrop.module.scss
@@ -16,7 +16,7 @@
     @extend %cover;
 
     position: absolute;
-    background: linear-gradient(180deg, rgba(colors.$grey-50, 0.5) 0%, colors.$white 92.54%);
+    background: linear-gradient(180deg, rgba(248, 248, 250, 50% /* grey-50 50% */) 0%, colors.$white 92.54%);
     z-index: z-indices.$schemaChangesBackdrop;
     border-radius: variables.$border-radius-lg;
     display: flex;


### PR DESCRIPTION
## What
Fixes a CSS rule that prevents rendering the background that covers the replication settings when schema changes have been detected.

Caused by #19344

## How
`rgba(var(--color-name), 50%)` is not supported, so the color must be extracted into the RGB values first.
