### PR TITLE
🪟 🔧 Switch CI to use npm ci

### DIFF
--- a/airbyte-webapp/build.gradle
+++ b/airbyte-webapp/build.gradle
@@ -19,6 +19,7 @@ def commonConfigs = [
 node {
     download = true
     version = nodeVersion
+    npmInstallCommand = 'ci'
 }
 
 npm_run_build {


### PR DESCRIPTION
## What

This enables our CI (i.e. when running `npm` via Gradle) to use [`npm ci`](https://docs.npmjs.com/cli/v9/commands/npm-ci) instead of `npm install` for installing dependencies. This command will install dependencies, but make sure to clean the `node_modules` beforehand. Also (the main reason to switch) it will fail if it would need to change the  `package-lock.json` file. This prevents us from running into situations where we commited a not up to date `package-lock.json` file.