### PR TITLE
Add missing info tooltips to new streams table headers

### DIFF
--- a/airbyte-webapp/src/components/connection/CatalogTree/next/CatalogTreeTableHeader.tsx
+++ b/airbyte-webapp/src/components/connection/CatalogTree/next/CatalogTreeTableHeader.tsx
@@ -86,13 +86,13 @@ export const CatalogTreeTableHeader: React.FC = () => {
       <HeaderCell>
         <FormattedMessage id="form.namespace" />
         <InfoTooltip>
-          <FormattedMessage id="connectionForm.destinationName.info" />
+          <FormattedMessage id="connectionForm.sourceNamespace.info" />
         </InfoTooltip>
       </HeaderCell>
       <HeaderCell>
         <FormattedMessage id="form.streamName" />
         <InfoTooltip>
-          <FormattedMessage id="connectionForm.destinationStream.info" />
+          <FormattedMessage id="connectionForm.sourceStreamName.info" />
         </InfoTooltip>
       </HeaderCell>
       <HeaderCell size="large">

--- a/airbyte-webapp/src/components/connection/CatalogTree/next/CatalogTreeTableHeader.tsx
+++ b/airbyte-webapp/src/components/connection/CatalogTree/next/CatalogTreeTableHeader.tsx
@@ -85,9 +85,15 @@ export const CatalogTreeTableHeader: React.FC = () => {
       </TextCell> */}
       <HeaderCell>
         <FormattedMessage id="form.namespace" />
+        <InfoTooltip>
+          <FormattedMessage id="connectionForm.destinationName.info" />
+        </InfoTooltip>
       </HeaderCell>
       <HeaderCell>
         <FormattedMessage id="form.streamName" />
+        <InfoTooltip>
+          <FormattedMessage id="connectionForm.destinationStream.info" />
+        </InfoTooltip>
       </HeaderCell>
       <HeaderCell size="large">
         <FormattedMessage id="form.syncMode" />
@@ -104,6 +110,9 @@ export const CatalogTreeTableHeader: React.FC = () => {
       </HeaderCell>
       <HeaderCell>
         <FormattedMessage id="form.primaryKey" />
+        <InfoTooltip>
+          <FormattedMessage id="connectionForm.primaryKey.info" />
+        </InfoTooltip>
       </HeaderCell>
       <CatalogTreeTableCell size="xsmall" />
       <HeaderCell>

--- a/airbyte-webapp/src/components/connection/DestinationNamespaceModal/DestinationNamespaceModal.module.scss
+++ b/airbyte-webapp/src/components/connection/DestinationNamespaceModal/DestinationNamespaceModal.module.scss
@@ -3,7 +3,7 @@
 
 .content {
   display: flex;
-  height: 340px;
+  height: 360px;
 }
 
 .actions,
@@ -41,5 +41,14 @@
   .generalInfo {
     color: colors.$grey;
     margin: variables.$spacing-lg 0;
+  }
+
+  .namespaceLink {
+    margin-top: variables.$spacing-lg;
+    color: colors.$blue;
+
+    .text {
+      color: colors.$blue;
+    }
   }
 }

--- a/airbyte-webapp/src/locales/en.json
+++ b/airbyte-webapp/src/locales/en.json
@@ -143,6 +143,8 @@
   "connectionForm.cursor.info": "Used in incremental sync mode only. It determines which records to sync.",
   "connectionForm.primaryKey.info": "Used in Deduped and History modes only. It determines the unique identifier.",
   "connectionForm.source.info": "<b>Stream name</b> is the raw table name from your source.",
+  "connectionForm.sourceStreamName.info": "<b>Stream name</b> is the raw table name from your source.",
+  "connectionForm.sourceNamespace.info": "<b>Namespace</b> is the database schema of your source tables.",
   "connectionForm.syncType.info": "How data will be replicated from source to destination.",
   "connectionForm.destinationName.info": "<b>Namespace</b> is the database schema of your destination tables.",
   "connectionForm.destinationStream.info": "<b>Stream name</b> is the final table name in destination.",

--- a/airbyte-webapp/src/pages/SettingsPage/pages/NotificationPage/components/WebHookForm.tsx
+++ b/airbyte-webapp/src/pages/SettingsPage/pages/NotificationPage/components/WebHookForm.tsx
@@ -17,10 +17,10 @@ import { Text } from "components/ui/Text";
 import { ToastType } from "components/ui/Toast";
 import { Tooltip } from "components/ui/Tooltip";
 
+import { useNotificationService } from "hooks/services/Notification";
 import useWorkspace, { WebhookPayload } from "hooks/services/useWorkspace";
 import { links } from "utils/links";
 
-import { useNotificationService } from "../../../../../hooks/services/Notification";
 import { Content, SettingsCard } from "../../SettingsComponents";
 import help from "./help.png";
 import styles from "./WebHookForm.module.scss";


### PR DESCRIPTION
## What
Closes [#20451](https://github.com/airbytehq/airbyte/issues/20451)

## How
Added info tooltips to the new streams table headers

Fixed minor issues:
- "Learn more" link (color and margin-top)
- Relative import

_For test purposes, use the environment variable: REACT_APP_NEW_STREAMS_TABLE=true_

## Loom
https://www.loom.com/share/c67fd06ed3da478a9ffbdf6be98839c3

![image](https://user-images.githubusercontent.com/66960359/211922298-4fb9577b-3a96-4b09-af93-35eb10aa870d.png)
