### PR TITLE
add attempt metrics

### DIFF
--- a/airbyte-commons/src/main/java/io/airbyte/commons/util/MoreLists.java
+++ b/airbyte-commons/src/main/java/io/airbyte/commons/util/MoreLists.java
@@ -4,6 +4,7 @@
 
 package io.airbyte.commons.util;
 
+import com.google.common.base.Preconditions;
 import java.util.List;
 import java.util.stream.Stream;
 
@@ -19,6 +20,15 @@ public class MoreLists {
   @SafeVarargs
   public static <T> List<T> concat(final List<T>... lists) {
     return Stream.of(lists).flatMap(List::stream).toList();
+  }
+
+  public static <T> T getOrNull(final List<T> list, final int index) {
+    Preconditions.checkNotNull(list);
+    if (list.size() > index) {
+      return list.get(index);
+    } else {
+      return null;
+    }
   }
 
 }

--- a/airbyte-commons/src/test/java/io/airbyte/commons/util/MoreListsTest.java
+++ b/airbyte-commons/src/test/java/io/airbyte/commons/util/MoreListsTest.java
@@ -5,6 +5,8 @@
 package io.airbyte.commons.util;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 
 import java.util.List;
 import org.junit.jupiter.api.Test;
@@ -17,6 +19,15 @@ class MoreListsTest {
     final List<Integer> expected = List.of(1, 2, 3, 4, 5, 6, 7, 8, 9);
     final List<Integer> actual = MoreLists.concat(lists.get(0), lists.get(1), lists.get(2));
     assertEquals(expected, actual);
+  }
+
+  @Test
+  void testGetOrNull() {
+    assertThrows(NullPointerException.class, MoreLists.getOrNull(null, 0));
+    assertEquals(1, MoreLists.getOrNull(List.of(1, 2, 3), 0));
+    assertEquals(2, MoreLists.getOrNull(List.of(1, 2, 3), 1));
+    assertEquals(3, MoreLists.getOrNull(List.of(1, 2, 3), 2));
+    assertNull(MoreLists.getOrNull(List.of(1, 2, 3), 3));
   }
 
 }

--- a/airbyte-commons/src/test/java/io/airbyte/commons/util/MoreListsTest.java
+++ b/airbyte-commons/src/test/java/io/airbyte/commons/util/MoreListsTest.java
@@ -23,7 +23,7 @@ class MoreListsTest {
 
   @Test
   void testGetOrNull() {
-    assertThrows(NullPointerException.class, MoreLists.getOrNull(null, 0));
+    assertThrows(NullPointerException.class, () -> MoreLists.getOrNull(null, 0));
     assertEquals(1, MoreLists.getOrNull(List.of(1, 2, 3), 0));
     assertEquals(2, MoreLists.getOrNull(List.of(1, 2, 3), 1));
     assertEquals(3, MoreLists.getOrNull(List.of(1, 2, 3), 2));

--- a/airbyte-metrics/metrics-lib/src/main/java/io/airbyte/metrics/lib/MetricTags.java
+++ b/airbyte-metrics/metrics-lib/src/main/java/io/airbyte/metrics/lib/MetricTags.java
@@ -26,17 +26,12 @@ public class MetricTags {
   public static final String GEOGRAPHY = "geography";
   public static final String UNKNOWN = "unknown";
 
-  /*
-   * for airbyte data planes: <cloud provider (gcp|aws)>-<geography>-<data plane number for tuple>
-   * e.g. gcp-us-west-1 for hybrid data planes: <human-readable identifier>-<user uuid> e.g.
-   * dataline-7ca63f9d-c0bb-4c52-a52f-599a3ff3b6c8 alternatively it can just be 3 separate fields
-   */
-  public static final String DATA_PLANE_ID = "data_plane_id";
   // the release stage of the highest release connector in the sync (GA > Beta > Alpha)
   public static final String MAX_CONNECTOR_RELEASE_STATE = "max_connector_release_stage";
   // the release stage of the lowest release stage connector in the sync (GA > Beta > Alpha)
   public static final String MIN_CONNECTOR_RELEASE_STATE = "min_connector_release_stage";
-  public static final String ATTEMPT_OUTCOME = "attempt_outcome"; // succeeded || failed
+  public static final String ATTEMPT_OUTCOME = "attempt_outcome"; // succeeded|failed
+  public static final String ATTEMPT_NUMBER = "attempt_number"; // 0|1|2|3
 
   public static String getReleaseStage(final ReleaseStage stage) {
     return stage != null ? stage.getLiteral() : UNKNOWN;

--- a/airbyte-metrics/metrics-lib/src/main/java/io/airbyte/metrics/lib/MetricTags.java
+++ b/airbyte-metrics/metrics-lib/src/main/java/io/airbyte/metrics/lib/MetricTags.java
@@ -26,6 +26,18 @@ public class MetricTags {
   public static final String GEOGRAPHY = "geography";
   public static final String UNKNOWN = "unknown";
 
+  /*
+   * for airbyte data planes: <cloud provider (gcp|aws)>-<geography>-<data plane number for tuple>
+   * e.g. gcp-us-west-1 for hybrid data planes: <human-readable identifier>-<user uuid> e.g.
+   * dataline-7ca63f9d-c0bb-4c52-a52f-599a3ff3b6c8 alternatively it can just be 3 separate fields
+   */
+  public static final String DATA_PLANE_ID = "data_plane_id";
+  // the release stage of the highest release connector in the sync (GA > Beta > Alpha)
+  public static final String MAX_CONNECTOR_RELEASE_STATE = "max_connector_release_stage";
+  // the release stage of the lowest release stage connector in the sync (GA > Beta > Alpha)
+  public static final String MIN_CONNECTOR_RELEASE_STATE = "min_connector_release_stage";
+  public static final String ATTEMPT_OUTCOME = "attempt_outcome"; // succeeded || failed
+
   public static String getReleaseStage(final ReleaseStage stage) {
     return stage != null ? stage.getLiteral() : UNKNOWN;
   }

--- a/airbyte-metrics/metrics-lib/src/main/java/io/airbyte/metrics/lib/OssMetricsRegistry.java
+++ b/airbyte-metrics/metrics-lib/src/main/java/io/airbyte/metrics/lib/OssMetricsRegistry.java
@@ -166,6 +166,8 @@ public enum OssMetricsRegistry implements MetricsRegistry {
   private final String metricName;
   private final String metricDescription;
 
+  // added this field to declare metric attributes, but we never read them.
+  @SuppressWarnings("FieldCanBeLocal")
   private final List<String> metricTags;
 
   OssMetricsRegistry(final MetricEmittingApp application,

--- a/airbyte-metrics/metrics-lib/src/main/java/io/airbyte/metrics/lib/OssMetricsRegistry.java
+++ b/airbyte-metrics/metrics-lib/src/main/java/io/airbyte/metrics/lib/OssMetricsRegistry.java
@@ -141,33 +141,26 @@ public enum OssMetricsRegistry implements MetricsRegistry {
       "reset_request",
       "number of requested resets"),
 
-  ATTEMPT_CREATED(
+  ATTEMPTS_CREATED(
       MetricEmittingApps.WORKER,
       "attempt_created",
       "increments when a new attempt is created. one is emitted per attempt",
-      MetricTags.DATA_PLANE_ID,
-      MetricTags.MIN_CONNECTOR_RELEASE_STATE, // max
-      MetricTags.MAX_CONNECTOR_RELEASE_STATE // min
-  ),
-  // ATTEMPT_PENDING (doesn't actually mean anything)
-  ATTEMPTS_RUNNING(
-      MetricEmittingApps.METRICS_REPORTER,
-      "attempts_running",
-      "number attempts in status running at a moment in time.",
-      MetricTags.DATA_PLANE_ID, // really should be data-plane id
-      MetricTags.MIN_CONNECTOR_RELEASE_STATE, // max
-      MetricTags.MAX_CONNECTOR_RELEASE_STATE // min
-  ),
-  ATTEMPT_COMPLETED(
+      MetricTags.GEOGRAPHY,
+      MetricTags.ATTEMPT_NUMBER,
+      MetricTags.MIN_CONNECTOR_RELEASE_STATE,
+      MetricTags.MAX_CONNECTOR_RELEASE_STATE),
+  ATTEMPTS_COMPLETED(
       MetricEmittingApps.WORKER,
       "attempt_completed",
       "increments when a new attempt is completed. one is emitted per attempt",
-      MetricTags.DATA_PLANE_ID,
-      MetricTags.MIN_CONNECTOR_RELEASE_STATE, // max
-      MetricTags.MAX_CONNECTOR_RELEASE_STATE, // min
+      MetricTags.GEOGRAPHY,
+      MetricTags.ATTEMPT_NUMBER,
+      MetricTags.MIN_CONNECTOR_RELEASE_STATE,
+      MetricTags.MAX_CONNECTOR_RELEASE_STATE,
+      MetricTags.ATTEMPT_QUEUE,
       MetricTags.ATTEMPT_OUTCOME,
-      MetricTags.FAILURE_ORIGIN,
-      MetricTags.FAILURE_TYPE);
+      MetricTags.FAILURE_ORIGIN, // only includes the first failure origin
+      MetricTags.FAILURE_TYPE); // only includes the first failure type
 
   private final MetricEmittingApp application;
   private final String metricName;

--- a/airbyte-metrics/metrics-lib/src/main/java/io/airbyte/metrics/lib/OssMetricsRegistry.java
+++ b/airbyte-metrics/metrics-lib/src/main/java/io/airbyte/metrics/lib/OssMetricsRegistry.java
@@ -5,6 +5,8 @@
 package io.airbyte.metrics.lib;
 
 import com.google.api.client.util.Preconditions;
+import java.util.Arrays;
+import java.util.List;
 
 /**
  * Enum source of truth of all Airbyte metrics. Each enum value represent a metric and is linked to
@@ -137,21 +139,53 @@ public enum OssMetricsRegistry implements MetricsRegistry {
       "number of records synced during replication"),
   RESET_REQUEST(MetricEmittingApps.WORKER,
       "reset_request",
-      "number of requested resets");
+      "number of requested resets"),
+
+  ATTEMPT_CREATED(
+      MetricEmittingApps.WORKER,
+      "attempt_created",
+      "increments when a new attempt is created. one is emitted per attempt",
+      MetricTags.DATA_PLANE_ID,
+      MetricTags.MIN_CONNECTOR_RELEASE_STATE, // max
+      MetricTags.MAX_CONNECTOR_RELEASE_STATE // min
+  ),
+  // ATTEMPT_PENDING (doesn't actually mean anything)
+  ATTEMPTS_RUNNING(
+      MetricEmittingApps.METRICS_REPORTER,
+      "attempts_running",
+      "number attempts in status running at a moment in time.",
+      MetricTags.DATA_PLANE_ID, // really should be data-plane id
+      MetricTags.MIN_CONNECTOR_RELEASE_STATE, // max
+      MetricTags.MAX_CONNECTOR_RELEASE_STATE // min
+  ),
+  ATTEMPT_COMPLETED(
+      MetricEmittingApps.WORKER,
+      "attempt_completed",
+      "increments when a new attempt is completed. one is emitted per attempt",
+      MetricTags.DATA_PLANE_ID,
+      MetricTags.MIN_CONNECTOR_RELEASE_STATE, // max
+      MetricTags.MAX_CONNECTOR_RELEASE_STATE, // min
+      MetricTags.ATTEMPT_OUTCOME,
+      MetricTags.FAILURE_ORIGIN,
+      MetricTags.FAILURE_TYPE);
 
   private final MetricEmittingApp application;
   private final String metricName;
   private final String metricDescription;
 
+  private final List<String> metricTags;
+
   OssMetricsRegistry(final MetricEmittingApp application,
                      final String metricName,
-                     final String metricDescription) {
+                     final String metricDescription,
+                     final String... metricTags) {
     Preconditions.checkNotNull(metricDescription);
     Preconditions.checkNotNull(application);
 
     this.application = application;
     this.metricName = metricName;
     this.metricDescription = metricDescription;
+    this.metricTags = Arrays.asList(metricTags);
   }
 
   @Override

--- a/airbyte-persistence/job-persistence/src/main/java/io/airbyte/persistence/job/DefaultJobPersistence.java
+++ b/airbyte-persistence/job-persistence/src/main/java/io/airbyte/persistence/job/DefaultJobPersistence.java
@@ -157,6 +157,7 @@ public class DefaultJobPersistence implements JobPersistence {
         + "attempts.log_path AS log_path,\n"
         + "attempts.output AS attempt_output,\n"
         + "attempts.status AS attempt_status,\n"
+        + "attempts.processing_task_queue AS processing_task_queue,\n"
         + "attempts.failure_summary AS attempt_failure_summary,\n"
         + "attempts.created_at AS attempt_created_at,\n"
         + "attempts.updated_at AS attempt_updated_at,\n"
@@ -931,6 +932,7 @@ public class DefaultJobPersistence implements JobPersistence {
         Path.of(record.get("log_path", String.class)),
         record.get("attempt_output", String.class) == null ? null : Jsons.deserialize(record.get("attempt_output", String.class), JobOutput.class),
         Enums.toEnum(record.get("attempt_status", String.class), AttemptStatus.class).orElseThrow(),
+        record.get("processing_task_queue", String.class),
         record.get("attempt_failure_summary", String.class) == null ? null
             : Jsons.deserialize(record.get("attempt_failure_summary", String.class), AttemptFailureSummary.class),
         getEpoch(record, "attempt_created_at"),

--- a/airbyte-persistence/job-persistence/src/main/java/io/airbyte/persistence/job/models/Attempt.java
+++ b/airbyte-persistence/job-persistence/src/main/java/io/airbyte/persistence/job/models/Attempt.java
@@ -17,6 +17,7 @@ public class Attempt {
   private final long jobId;
   private final JobOutput output;
   private final AttemptStatus status;
+  private final String processingTaskQueue;
   private final AttemptFailureSummary failureSummary;
   private final Path logPath;
   private final long updatedAtInSecond;
@@ -28,6 +29,7 @@ public class Attempt {
                  final Path logPath,
                  final @Nullable JobOutput output,
                  final AttemptStatus status,
+                 final String processingTaskQueue,
                  final @Nullable AttemptFailureSummary failureSummary,
                  final long createdAtInSecond,
                  final long updatedAtInSecond,
@@ -36,6 +38,7 @@ public class Attempt {
     this.jobId = jobId;
     this.output = output;
     this.status = status;
+    this.processingTaskQueue = processingTaskQueue;
     this.failureSummary = failureSummary;
     this.logPath = logPath;
     this.updatedAtInSecond = updatedAtInSecond;
@@ -57,6 +60,10 @@ public class Attempt {
 
   public AttemptStatus getStatus() {
     return status;
+  }
+
+  public String getProcessingTaskQueue() {
+    return processingTaskQueue;
   }
 
   public Optional<AttemptFailureSummary> getFailureSummary() {

--- a/airbyte-persistence/job-persistence/src/main/java/io/airbyte/persistence/job/models/Job.java
+++ b/airbyte-persistence/job-persistence/src/main/java/io/airbyte/persistence/job/models/Job.java
@@ -126,6 +126,12 @@ public class Job {
         .findFirst();
   }
 
+  public Optional<Attempt> getLastAttempt() {
+    return getAttempts()
+        .stream()
+        .max(Comparator.comparing(Attempt::getCreatedAtInSecond));
+  }
+
   public boolean hasRunningAttempt() {
     return getAttempts().stream().anyMatch(a -> !Attempt.isAttemptInTerminalState(a));
   }

--- a/airbyte-persistence/job-persistence/src/test/java/io/airbyte/persistence/job/DefaultJobPersistenceTest.java
+++ b/airbyte-persistence/job-persistence/src/test/java/io/airbyte/persistence/job/DefaultJobPersistenceTest.java
@@ -152,6 +152,7 @@ class DefaultJobPersistenceTest {
         null,
         status,
         null,
+        null,
         NOW.getEpochSecond(),
         NOW.getEpochSecond(),
         NOW.getEpochSecond());
@@ -164,6 +165,7 @@ class DefaultJobPersistenceTest {
         logPath,
         null,
         status,
+        null,
         null,
         NOW.getEpochSecond(),
         NOW.getEpochSecond(),

--- a/airbyte-persistence/job-persistence/src/test/java/io/airbyte/persistence/job/models/AttemptTest.java
+++ b/airbyte-persistence/job-persistence/src/test/java/io/airbyte/persistence/job/models/AttemptTest.java
@@ -19,7 +19,7 @@ class AttemptTest {
   }
 
   private static Attempt attemptWithStatus(final AttemptStatus attemptStatus) {
-    return new Attempt(1, 1L, null, null, attemptStatus, null, 0L, 0L, null);
+    return new Attempt(1, 1L, null, null, attemptStatus, null, null, 0L, 0L, null);
   }
 
 }

--- a/airbyte-persistence/job-persistence/src/test/java/io/airbyte/persistence/job/models/JobTest.java
+++ b/airbyte-persistence/job-persistence/src/test/java/io/airbyte/persistence/job/models/JobTest.java
@@ -72,6 +72,13 @@ class JobTest {
   }
 
   @Test
+  void testGetLastAttempt() {
+    final Job job = jobWithAttemptWithStatus(AttemptStatus.FAILED, AttemptStatus.FAILED, AttemptStatus.SUCCEEDED);
+    assertTrue(job.getLastAttempt().isPresent());
+    assertEquals(3, job.getLastAttempt().get().getAttemptNumber());
+  }
+
+  @Test
   void testValidateStatusTransitionFromPending() {
     final Job pendingJob = jobWithStatus(JobStatus.PENDING);
     assertDoesNotThrow(() -> pendingJob.validateStatusTransition(JobStatus.RUNNING));

--- a/airbyte-persistence/job-persistence/src/test/java/io/airbyte/persistence/job/models/JobTest.java
+++ b/airbyte-persistence/job-persistence/src/test/java/io/airbyte/persistence/job/models/JobTest.java
@@ -43,7 +43,7 @@ class JobTest {
 
   private static Job jobWithAttemptWithStatus(final AttemptStatus... attemptStatuses) {
     final List<Attempt> attempts = IntStream.range(0, attemptStatuses.length)
-        .mapToObj(idx -> new Attempt(idx + 1, 1L, null, null, attemptStatuses[idx], null, idx, 0L, null))
+        .mapToObj(idx -> new Attempt(idx + 1, 1L, null, null, attemptStatuses[idx], null, null, idx, 0L, null))
         .collect(Collectors.toList());
     return new Job(1L, null, null, null, attempts, null, 0L, 0L, 0L);
   }

--- a/airbyte-persistence/job-persistence/src/test/java/io/airbyte/persistence/job/tracker/TrackingMetadataTest.java
+++ b/airbyte-persistence/job-persistence/src/test/java/io/airbyte/persistence/job/tracker/TrackingMetadataTest.java
@@ -61,7 +61,7 @@ class TrackingMetadataTest {
     final StandardSyncSummary standardSyncSummary = new StandardSyncSummary().withTotalStats(syncStats);
     final StandardSyncOutput standardSyncOutput = new StandardSyncOutput().withStandardSyncSummary(standardSyncSummary);
     final JobOutput jobOutput = new JobOutput().withSync(standardSyncOutput);
-    final Attempt attempt = new Attempt(0, 10L, Path.of("test"), jobOutput, AttemptStatus.SUCCEEDED, null, 100L, 100L, 99L);
+    final Attempt attempt = new Attempt(0, 10L, Path.of("test"), jobOutput, AttemptStatus.SUCCEEDED, null, null, 100L, 100L, 99L);
     final Job job = mock(Job.class);
     when(job.getAttempts()).thenReturn(List.of(attempt));
 

--- a/airbyte-server/src/test/java/io/airbyte/server/handlers/JobHistoryHandlerTest.java
+++ b/airbyte-server/src/test/java/io/airbyte/server/handlers/JobHistoryHandlerTest.java
@@ -157,7 +157,7 @@ class JobHistoryHandlerTest {
   }
 
   private static Attempt createAttempt(final long jobId, final long timestamps, final AttemptStatus status) {
-    return new Attempt(ATTEMPT_NUMBER, jobId, LOG_PATH, null, status, null, timestamps, timestamps, timestamps);
+    return new Attempt(ATTEMPT_NUMBER, jobId, LOG_PATH, null, status, null, null, timestamps, timestamps, timestamps);
   }
 
   @BeforeEach
@@ -442,11 +442,11 @@ class JobHistoryHandlerTest {
   @DisplayName("Should return attempt normalization info for the job")
   void testGetAttemptNormalizationStatuses() throws IOException {
 
-    AttemptNormalizationStatus databaseReadResult = new AttemptNormalizationStatus(1, Optional.of(10L), /* hasNormalizationFailed= */ false);
+    final AttemptNormalizationStatus databaseReadResult = new AttemptNormalizationStatus(1, Optional.of(10L), /* hasNormalizationFailed= */ false);
 
     when(jobPersistence.getAttemptNormalizationStatusesForJob(JOB_ID)).thenReturn(List.of(databaseReadResult));
 
-    AttemptNormalizationStatusReadList expectedStatus = new AttemptNormalizationStatusReadList().attemptNormalizationStatuses(
+    final AttemptNormalizationStatusReadList expectedStatus = new AttemptNormalizationStatusReadList().attemptNormalizationStatuses(
         List.of(new AttemptNormalizationStatusRead().attemptNumber(1).hasRecordsCommitted(true).hasNormalizationFailed(false).recordsCommitted(10L)));
 
     assertEquals(expectedStatus, jobHistoryHandler.getAttemptNormalizationStatuses(new JobIdRequestBody().id(JOB_ID)));

--- a/airbyte-workers/src/main/java/io/airbyte/workers/temporal/scheduling/activities/JobCreationAndStatusUpdateActivityImpl.java
+++ b/airbyte-workers/src/main/java/io/airbyte/workers/temporal/scheduling/activities/JobCreationAndStatusUpdateActivityImpl.java
@@ -549,7 +549,8 @@ public class JobCreationAndStatusUpdateActivityImpl implements JobCreationAndSta
     final List<MetricAttribute> additionalAttributes = List.of(
         new MetricAttribute(MetricTags.ATTEMPT_OUTCOME, attempt.getStatus().toString()),
         new MetricAttribute(MetricTags.FAILURE_ORIGIN, failureOrigin.orElse(null)),
-        new MetricAttribute(MetricTags.FAILURE_TYPE, failureType.orElse(null)));
+        new MetricAttribute(MetricTags.FAILURE_TYPE, failureType.orElse(null)),
+        new MetricAttribute(MetricTags.ATTEMPT_QUEUE, attempt.getProcessingTaskQueue()));
 
     emitAttemptEvent(OssMetricsRegistry.ATTEMPTS_COMPLETED, job, attempt.getAttemptNumber(), additionalAttributes);
   }

--- a/airbyte-workers/src/main/java/io/airbyte/workers/temporal/scheduling/activities/JobCreationAndStatusUpdateActivityImpl.java
+++ b/airbyte-workers/src/main/java/io/airbyte/workers/temporal/scheduling/activities/JobCreationAndStatusUpdateActivityImpl.java
@@ -538,12 +538,14 @@ public class JobCreationAndStatusUpdateActivityImpl implements JobCreationAndSta
     final Optional<String> failureOrigin = attempt.getFailureSummary().flatMap(summary -> summary.getFailures()
         .stream()
         .map(FailureReason::getFailureOrigin)
+        .filter(Objects::nonNull)
         .map(FailureOrigin::name)
         .findFirst());
 
     final Optional<String> failureType = attempt.getFailureSummary().flatMap(summary -> summary.getFailures()
         .stream()
         .map(FailureReason::getFailureType)
+        .filter(Objects::nonNull)
         .map(MetricTags::getFailureType)
         .findFirst());
 

--- a/airbyte-workers/src/main/java/io/airbyte/workers/temporal/scheduling/activities/JobCreationAndStatusUpdateActivityImpl.java
+++ b/airbyte-workers/src/main/java/io/airbyte/workers/temporal/scheduling/activities/JobCreationAndStatusUpdateActivityImpl.java
@@ -20,6 +20,7 @@ import io.airbyte.commons.docker.DockerUtils;
 import io.airbyte.commons.enums.Enums;
 import io.airbyte.commons.temporal.config.WorkerMode;
 import io.airbyte.commons.temporal.exception.RetryableException;
+import io.airbyte.commons.util.MoreLists;
 import io.airbyte.commons.version.Version;
 import io.airbyte.config.AttemptFailureSummary;
 import io.airbyte.config.Configs.WorkerEnvironment;
@@ -65,6 +66,9 @@ import io.micronaut.core.util.CollectionUtils;
 import jakarta.inject.Singleton;
 import java.io.IOException;
 import java.nio.file.Path;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.Comparator;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
@@ -198,15 +202,16 @@ public class JobCreationAndStatusUpdateActivityImpl implements JobCreationAndSta
     try {
       final long jobId = input.getJobId();
       ApmTraceUtils.addTagsToTrace(Map.of(JOB_ID_KEY, jobId));
-      final Job createdJob = jobPersistence.getJob(jobId);
+      final Job job = jobPersistence.getJob(jobId);
 
-      final WorkerRun workerRun = temporalWorkerRunFactory.create(createdJob);
+      final WorkerRun workerRun = temporalWorkerRunFactory.create(job);
       final Path logFilePath = workerRun.getJobRoot().resolve(LogClientSingleton.LOG_FILENAME);
-      final int persistedAttemptId = jobPersistence.createAttempt(jobId, logFilePath);
+      final int persistedAttemptNumber = jobPersistence.createAttempt(jobId, logFilePath);
       emitJobIdToReleaseStagesMetric(OssMetricsRegistry.ATTEMPT_CREATED_BY_RELEASE_STAGE, jobId);
+      emitAttemptCreatedEvent(job, persistedAttemptNumber);
 
       LogClientSingleton.getInstance().setJobMdc(workerEnvironment, logConfigs, workerRun.getJobRoot());
-      return new AttemptCreationOutput(persistedAttemptId);
+      return new AttemptCreationOutput(persistedAttemptNumber);
     } catch (final IOException e) {
       throw new RetryableException(e);
     }
@@ -470,6 +475,85 @@ public class JobCreationAndStatusUpdateActivityImpl implements JobCreationAndSta
     }
   }
 
+  private static final Map<ReleaseStage, Integer> RELEASE_STAGE_ORDER = Map.of(
+      ReleaseStage.custom, 1,
+      ReleaseStage.alpha, 2,
+      ReleaseStage.beta, 3,
+      ReleaseStage.generally_available, 4);
+  private static final Comparator<ReleaseStage> RELEASE_STAGE_COMPARATOR = Comparator.comparingInt(RELEASE_STAGE_ORDER::get);
+
+  private static List<ReleaseStage> orderByReleaseStageAsc(final List<ReleaseStage> releaseStages) {
+    final List<ReleaseStage> copiedList = new ArrayList<>(releaseStages);
+    copiedList.sort(RELEASE_STAGE_COMPARATOR);
+    return copiedList;
+  }
+
+  /**
+   * Extract the attempt number from an attempt. If the number is anonymous (not 0,1,2,3) for some
+   * reason return null. We don't want to accidentally have high cardinality here because of a bug.
+   *
+   * @param attemptNumber - attemptNumber to parse
+   * @return extract attempt number or null
+   */
+  private static String parseAttemptNumberOrNull(final int attemptNumber) {
+    if (attemptNumber > 3) {
+      return null;
+    } else {
+      return Integer.toString(attemptNumber);
+    }
+  }
+
+  private void emitAttemptEvent(final OssMetricsRegistry metric, final Job job, final int attemptNumber) throws IOException {
+    emitAttemptEvent(metric, job, attemptNumber, Collections.emptyList());
+  }
+
+  private void emitAttemptEvent(final OssMetricsRegistry metric,
+                                final Job job,
+                                final int attemptNumber,
+                                final List<MetricAttribute> additionalAttributes)
+      throws IOException {
+    final List<ReleaseStage> releaseStages = configRepository.getJobIdToReleaseStages(job.getId());
+    final var releaseStagesOrdered = orderByReleaseStageAsc(releaseStages);
+    final var connectionId = job.getScope() == null ? null : UUID.fromString(job.getScope());
+    final var geography = configRepository.getGeographyForConnection(connectionId);
+
+    final List<MetricAttribute> baseMetricAttributes = List.of(
+        new MetricAttribute(MetricTags.GEOGRAPHY, geography == null ? null : geography.toString()),
+        new MetricAttribute(MetricTags.ATTEMPT_NUMBER, parseAttemptNumberOrNull(attemptNumber)),
+        new MetricAttribute(MetricTags.MIN_CONNECTOR_RELEASE_STATE, MetricTags.getReleaseStage(MoreLists.getOrNull(releaseStagesOrdered, 0))),
+        new MetricAttribute(MetricTags.MAX_CONNECTOR_RELEASE_STATE, MetricTags.getReleaseStage(MoreLists.getOrNull(releaseStagesOrdered, 1))));
+
+    final MetricAttribute[] allMetricAttributes = MoreLists
+        .concat(baseMetricAttributes, additionalAttributes)
+        .toArray(new MetricAttribute[baseMetricAttributes.size() + additionalAttributes.size()]);
+    MetricClientFactory.getMetricClient().count(metric, 1, allMetricAttributes);
+  }
+
+  private void emitAttemptCreatedEvent(final Job job, final int attemptNumber) throws IOException {
+    emitAttemptEvent(OssMetricsRegistry.ATTEMPTS_CREATED, job, attemptNumber);
+  }
+
+  private void emitAttemptCompletedEvent(final Job job, final Attempt attempt) throws IOException {
+    final Optional<String> failureOrigin = attempt.getFailureSummary().flatMap(summary -> summary.getFailures()
+        .stream()
+        .map(FailureReason::getFailureOrigin)
+        .map(FailureOrigin::name)
+        .findFirst());
+
+    final Optional<String> failureType = attempt.getFailureSummary().flatMap(summary -> summary.getFailures()
+        .stream()
+        .map(FailureReason::getFailureType)
+        .map(MetricTags::getFailureType)
+        .findFirst());
+
+    final List<MetricAttribute> additionalAttributes = List.of(
+        new MetricAttribute(MetricTags.ATTEMPT_OUTCOME, attempt.getStatus().toString()),
+        new MetricAttribute(MetricTags.FAILURE_ORIGIN, failureOrigin.orElse(null)),
+        new MetricAttribute(MetricTags.FAILURE_TYPE, failureType.orElse(null)));
+
+    emitAttemptEvent(OssMetricsRegistry.ATTEMPTS_COMPLETED, job, attempt.getAttemptNumber(), additionalAttributes);
+  }
+
   private void emitJobIdToReleaseStagesMetric(final OssMetricsRegistry metric, final long jobId) throws IOException {
     final var releaseStages = configRepository.getJobIdToReleaseStages(jobId);
     if (releaseStages == null || releaseStages.isEmpty()) {
@@ -484,8 +568,20 @@ public class JobCreationAndStatusUpdateActivityImpl implements JobCreationAndSta
     }
   }
 
-  private void trackCompletion(final Job job, final io.airbyte.workers.JobStatus status) {
+  private void trackCompletion(final Job job, final io.airbyte.workers.JobStatus status) throws IOException {
+    emitAttemptCompletedEventIfAttemptPresent(job);
     jobTracker.trackSync(job, Enums.convertTo(status, JobState.class));
+  }
+
+  private void emitAttemptCompletedEventIfAttemptPresent(final Job job) throws IOException {
+    if (job == null) {
+      return;
+    }
+
+    final Optional<Attempt> lastAttempt = job.getLastAttempt();
+    if (lastAttempt.isPresent()) {
+      emitAttemptCompletedEvent(job, lastAttempt.get());
+    }
   }
 
   private void trackCompletionForInternalFailure(final Long jobId,

--- a/airbyte-workers/src/main/java/io/airbyte/workers/temporal/scheduling/activities/JobCreationAndStatusUpdateActivityImpl.java
+++ b/airbyte-workers/src/main/java/io/airbyte/workers/temporal/scheduling/activities/JobCreationAndStatusUpdateActivityImpl.java
@@ -475,6 +475,7 @@ public class JobCreationAndStatusUpdateActivityImpl implements JobCreationAndSta
     }
   }
 
+  private static final int MAX_ATTEMPTS = 3;
   private static final Map<ReleaseStage, Integer> RELEASE_STAGE_ORDER = Map.of(
       ReleaseStage.custom, 1,
       ReleaseStage.alpha, 2,
@@ -496,7 +497,7 @@ public class JobCreationAndStatusUpdateActivityImpl implements JobCreationAndSta
    * @return extract attempt number or null
    */
   private static String parseAttemptNumberOrNull(final int attemptNumber) {
-    if (attemptNumber > 3) {
+    if (attemptNumber > MAX_ATTEMPTS) {
       return null;
     } else {
       return Integer.toString(attemptNumber);

--- a/airbyte-workers/src/test/java/io/airbyte/workers/temporal/scheduling/activities/JobCreationAndStatusUpdateActivityTest.java
+++ b/airbyte-workers/src/test/java/io/airbyte/workers/temporal/scheduling/activities/JobCreationAndStatusUpdateActivityTest.java
@@ -234,7 +234,7 @@ class JobCreationAndStatusUpdateActivityTest {
     @Test
     void isLastJobOrAttemptFailureTrueTest() throws Exception {
       final int activeAttemptNumber = 0;
-      final Attempt activeAttempt = new Attempt(activeAttemptNumber, 1, Path.of(""), null, AttemptStatus.RUNNING, null, 4L, 5L, null);
+      final Attempt activeAttempt = new Attempt(activeAttemptNumber, 1, Path.of(""), null, AttemptStatus.RUNNING, null, null, 4L, 5L, null);
 
       final Job previousJob = new Job(PREVIOUS_JOB_ID, ConfigType.SYNC, CONNECTION_ID.toString(),
           new JobConfig(), List.of(), JobStatus.SUCCEEDED, 4L, 4L, 5L);
@@ -254,7 +254,7 @@ class JobCreationAndStatusUpdateActivityTest {
     @Test
     void isLastJobOrAttemptFailureFalseTest() throws Exception {
       final int activeAttemptNumber = 0;
-      final Attempt activeAttempt = new Attempt(activeAttemptNumber, 1, Path.of(""), null, AttemptStatus.RUNNING, null, 4L, 5L, null);
+      final Attempt activeAttempt = new Attempt(activeAttemptNumber, 1, Path.of(""), null, AttemptStatus.RUNNING, null, null, 4L, 5L, null);
 
       final Job previousJob = new Job(PREVIOUS_JOB_ID, ConfigType.SYNC, CONNECTION_ID.toString(),
           new JobConfig(), List.of(), JobStatus.FAILED, 4L, 4L, 5L);
@@ -273,9 +273,9 @@ class JobCreationAndStatusUpdateActivityTest {
 
     @Test
     void isLastJobOrAttemptFailurePreviousAttemptFailureTest() throws Exception {
-      final Attempt previousAttempt = new Attempt(0, 1, Path.of(""), null, AttemptStatus.FAILED, null, 2L, 3L, 3L);
+      final Attempt previousAttempt = new Attempt(0, 1, Path.of(""), null, AttemptStatus.FAILED, null, null, 2L, 3L, 3L);
       final int activeAttemptNumber = 1;
-      final Attempt activeAttempt = new Attempt(activeAttemptNumber, 1, Path.of(""), null, AttemptStatus.RUNNING, null, 4L, 5L, null);
+      final Attempt activeAttempt = new Attempt(activeAttemptNumber, 1, Path.of(""), null, AttemptStatus.RUNNING, null, null, 4L, 5L, null);
 
       final Job previousJob = new Job(PREVIOUS_JOB_ID, ConfigType.SYNC, CONNECTION_ID.toString(), new JobConfig(), List.of(),
           JobStatus.SUCCEEDED, 4L, 4L, 5L);
@@ -505,9 +505,9 @@ class JobCreationAndStatusUpdateActivityTest {
 
     @Test
     void ensureCleanJobState() throws IOException {
-      final Attempt failedAttempt = new Attempt(0, 1, Path.of(""), null, AttemptStatus.FAILED, null, 2L, 3L, 3L);
+      final Attempt failedAttempt = new Attempt(0, 1, Path.of(""), null, AttemptStatus.FAILED, null, null, 2L, 3L, 3L);
       final int runningAttemptNumber = 1;
-      final Attempt runningAttempt = new Attempt(runningAttemptNumber, 1, Path.of(""), null, AttemptStatus.RUNNING, null, 4L, 5L, null);
+      final Attempt runningAttempt = new Attempt(runningAttemptNumber, 1, Path.of(""), null, AttemptStatus.RUNNING, null, null, 4L, 5L, null);
       final Job runningJob = new Job(1, ConfigType.SYNC, CONNECTION_ID.toString(), new JobConfig(), List.of(failedAttempt, runningAttempt),
           JobStatus.RUNNING, 2L, 2L, 3L);
 


### PR DESCRIPTION
## What
I want to be able to build this dashboard (below). I want to know what the failure rate is with connector failures removed. Ideally this is what we would use to trigger pages for the _platform_  team, instead of triggering based on failure rate with connectors included.
![Screen Shot 2023-01-11 at 5 26 29 PM](https://user-images.githubusercontent.com/9092207/211954100-71b8031e-0fc6-4d29-b69b-5f109011f192.png) ([link](https://app.datadoghq.com/dashboard/ad6-yqt-54d/charles-kpi-dashboard?fullscreen_end_ts=1673487186475&fullscreen_paused=false&fullscreen_section=overview&fullscreen_start_ts=1672882386475&fullscreen_widget=3379745404882158&from_ts=1672877320065&to_ts=1673482120065&live=true))

I can't build it because we don't emit one event per attempt or job. We emit n events based on the number of release stages and failure origins. Because of this, I can't really get numbers that reflect the reality. They get skewed by the number of stages and failure origins. I end up with a result I don't really trust.

In addition, I find dashboards like this [one](https://app.datadoghq.com/dashboard/fai-itf-f54/chriss-dashboard?fullscreen_end_ts=1673486919717&fullscreen_paused=false&fullscreen_section=edit&fullscreen_start_ts=1670808519717&fullscreen_widget=7929707339489212&from_ts=1670803915040&to_ts=1673482315040&live=true) that are wrong, because they double count jobs since for each job there could be 1 or 2 release stages.

## How
* I am proposing emitting new events for attempts. There will be 1 created and 1 completed event for each attempt.
* I get around the multiple release stage issue by having a min and max release stage field. Any graph we could build with the old one we could build using this new scheme and not have confusing cardinality issues.
* For failure origin and failure type, just emit the first one (if present).
* Suggests normalizing  the way we refer to data planes. Using just geography isn't going to cut it. We need something. Not too picky on what.
* Added a constructor in `OssMetricRepository` so that we can declare what dimensions we expect to ship with a metric. Not sure this is a good idea yet. The declaration is good, but it currently can't be enforced.
* I did it for attempts and not jobs (at least for now) because that's really what I need for the current dashboard, but we could do the same for jobs if we like it.
* Skipped doing pending since it's not really meaningful. I would love to figure out how to get a meaningful pending metric though.

## To d
* Still need to wire up the metrics to actually get emitted. Will do this if I get a :+1: on the approach.