### PR TITLE
airbyte-protocol: remove `supportsNormalization` and `supportsDbt` from `ConnectorSpecification`

### DIFF
--- a/airbyte-cdk/python/airbyte_cdk/models/airbyte_protocol.py
+++ b/airbyte-cdk/python/airbyte_cdk/models/airbyte_protocol.py
@@ -327,8 +327,6 @@ class ConnectorSpecification(BaseModel):
         None,
         description="(deprecated) If the connector supports incremental mode or not.",
     )
-    supportsNormalization: Optional[bool] = Field(False, description="If the connector supports normalization or not.")
-    supportsDBT: Optional[bool] = Field(False, description="If the connector supports DBT or not.")
     supported_destination_sync_modes: Optional[List[DestinationSyncMode]] = Field(
         None, description="List of destination sync modes supported by the connector"
     )

--- a/airbyte-config/config-persistence/src/test/java/io/airbyte/config/persistence/MockData.java
+++ b/airbyte-config/config-persistence/src/test/java/io/airbyte/config/persistence/MockData.java
@@ -263,9 +263,7 @@ public class MockData {
         .withAdvancedAuth(null)
         .withChangelogUrl(URI.create("whatever"))
         .withSupportedDestinationSyncModes(Arrays.asList(DestinationSyncMode.APPEND, DestinationSyncMode.OVERWRITE, DestinationSyncMode.APPEND_DEDUP))
-        .withSupportsDBT(true)
-        .withSupportsIncremental(true)
-        .withSupportsNormalization(true);
+        .withSupportsIncremental(true);
   }
 
   public static StandardDestinationDefinition publicDestinationDefinition() {

--- a/airbyte-db/db-lib/src/test/java/io/airbyte/db/instance/configs/migrations/SetupForNormalizedTablesTest.java
+++ b/airbyte-db/db-lib/src/test/java/io/airbyte/db/instance/configs/migrations/SetupForNormalizedTablesTest.java
@@ -208,9 +208,7 @@ public class SetupForNormalizedTablesTest {
         .withAdvancedAuth(null)
         .withChangelogUrl(URI.create("whatever"))
         .withSupportedDestinationSyncModes(Arrays.asList(DestinationSyncMode.APPEND, DestinationSyncMode.OVERWRITE, DestinationSyncMode.APPEND_DEDUP))
-        .withSupportsDBT(true)
-        .withSupportsIncremental(true)
-        .withSupportsNormalization(true);
+        .withSupportsIncremental(true);
   }
 
   public static List<StandardDestinationDefinition> standardDestinationDefinitions() {

--- a/airbyte-protocol/protocol-models/src/main/resources/airbyte_protocol/airbyte_protocol.yaml
+++ b/airbyte-protocol/protocol-models/src/main/resources/airbyte_protocol/airbyte_protocol.yaml
@@ -452,16 +452,6 @@ definitions:
       supportsIncremental:
         description: (deprecated) If the connector supports incremental mode or not.
         type: boolean
-      # Destination Connectors Properties
-      # Normalization is currently implemented using dbt, so it requires `supportsDBT` to be true for this to be true.
-      supportsNormalization:
-        description: If the connector supports normalization or not.
-        type: boolean
-        default: false
-      supportsDBT:
-        description: If the connector supports DBT or not.
-        type: boolean
-        default: false
       supported_destination_sync_modes:
         description: List of destination sync modes supported by the connector
         type: array

--- a/airbyte-server/src/test/java/io/airbyte/server/helpers/ConnectorSpecificationHelpers.java
+++ b/airbyte-server/src/test/java/io/airbyte/server/helpers/ConnectorSpecificationHelpers.java
@@ -22,9 +22,7 @@ public class ConnectorSpecificationHelpers {
     try {
       return new ConnectorSpecification()
           .withDocumentationUrl(new URI("https://airbyte.io"))
-          .withConnectionSpecification(Jsons.deserialize(Files.readString(path)))
-          .withSupportsDBT(false)
-          .withSupportsNormalization(false);
+          .withConnectionSpecification(Jsons.deserialize(Files.readString(path)));
     } catch (final URISyntaxException e) {
       throw new RuntimeException(e);
     }

--- a/docs/understanding-airbyte/airbyte-protocol.md
+++ b/docs/understanding-airbyte/airbyte-protocol.md
@@ -199,8 +199,6 @@ The specification also contains information about what features the Actor suppor
 The following are fields that still exist in the specification but are slated to be removed as they leak choices about how Airbyte implements the protocol as opposed to being strictly necessary part of the protocol.
 
 - `supportsIncremental` is deprecated and can be ignored. It is vestigial from when full refresh / incremental was specified at the Actor level.
-- `supportsNormalization` determines whether the Destination supports Basic Normalization
-- `supportsDBT` - determines whether the Destination supports Basic Normalization
 - `authSpecification` and `advanced_auth` will be removed from the protocol and as such are not documented. Information on their use can be found here.
 
 ```yaml
@@ -230,16 +228,6 @@ ConnectorSpecification:
     supportsIncremental:
       description: (deprecated) If the connector supports incremental mode or not.
       type: boolean
-    # Destination Connectors Properties
-    # Normalization is currently implemented using dbt, so it requires `supportsDBT` to be true for this to be true.
-    supportsNormalization:
-      description: If the connector supports normalization or not.
-      type: boolean
-      default: false
-    supportsDBT:
-      description: If the connector supports DBT or not.
-      type: boolean
-      default: false
     supported_destination_sync_modes:
       description: List of destination sync modes supported by the connector
       type: array


### PR DESCRIPTION
## What
Closes https://github.com/airbytehq/airbyte-internal-issues/issues/2536
We are removing the `supportsNormalization` and `supportsDbt` from the connector specification and moved these metadata to destination definitions. (https://github.com/airbytehq/airbyte/pull/21005)

## How
* Remove these two fields from the protocols `ConnectorSpecification` model in `airbyte_protocol.yaml`
* Update mocks using `withSupportsDbt` or `withSupportsNormalization`
* Update the CDK models