### PR TITLE
normalization decoupling cleanup: update destination-python generator

### DIFF
--- a/airbyte-integrations/connector-templates/destination-python/destination_{{snakeCase name}}/spec.json
+++ b/airbyte-integrations/connector-templates/destination-python/destination_{{snakeCase name}}/spec.json
@@ -4,8 +4,6 @@
     "TODO, available options are: 'overwrite', 'append', and 'append_dedup'"
   ],
   "supportsIncremental": true,
-  "supportsDBT": false,
-  "supportsNormalization": false,
   "connectionSpecification": {
     "$schema": "http://json-schema.org/draft-07/schema#",
     "title": "Destination {{capitalCase name}}",

--- a/airbyte-integrations/connectors/destination-scaffold-destination-python/destination_scaffold_destination_python/spec.json
+++ b/airbyte-integrations/connectors/destination-scaffold-destination-python/destination_scaffold_destination_python/spec.json
@@ -4,8 +4,6 @@
     "TODO, available options are: 'overwrite', 'append', and 'append_dedup'"
   ],
   "supportsIncremental": true,
-  "supportsDBT": false,
-  "supportsNormalization": false,
   "connectionSpecification": {
     "$schema": "http://json-schema.org/draft-07/schema#",
     "title": "Destination Scaffold Destination Python",


### PR DESCRIPTION
## What
Closes https://github.com/airbytehq/airbyte/issues/21301
Remove `supportsDbt` and `supportsNormalization` from generated spec file in `destination-python`.
