### PR TITLE
Source Zendesk Support: added timeout to basic_read, full_refresh and incremental tests

### DIFF
--- a/airbyte-integrations/connectors/source-zendesk-support/acceptance-test-config.yml
+++ b/airbyte-integrations/connectors/source-zendesk-support/acceptance-test-config.yml
@@ -23,6 +23,7 @@ acceptance_tests:
       - config_path: "secrets/config.json"
         expect_records:
           path: "integration_tests/expected_records.jsonl"
+        timeout_seconds: 2400
   incremental:
     tests:
       - config_path: "secrets/config.json"
@@ -31,7 +32,9 @@ acceptance_tests:
           future_state_path: "integration_tests/abnormal_state.json"
         cursor_paths:
           ticket_comments: ["created_at"]
+        timeout_seconds: 2400
   full_refresh:
     tests:
       - config_path: "secrets/config.json"
         configured_catalog_path: "integration_tests/configured_catalog.json"
+        timeout_seconds: 2400


### PR DESCRIPTION
added timeout: 2400 to basic_read, full_refresh and incremental tests