### PR TITLE
Add bootloader/server to published images for Cloud

### DIFF
--- a/docker-compose-cloud.buildx.yaml
+++ b/docker-compose-cloud.buildx.yaml
@@ -4,6 +4,38 @@
 version: "3.7"
 
 services:
+  bootloader:
+    image: airbyte/bootloader:${VERSION}
+    build:
+      dockerfile: Dockerfile
+      context: airbyte-bootloader/build/docker
+      labels:
+        io.airbyte.git-revision: ${GIT_REVISION}
+      args:
+        VERSION: ${VERSION}
+      x-bake:
+        tags:
+          - airbyte/bootloader:${VERSION}
+          - airbyte/bootloader:${ALT_TAG:-${VERSION}}
+        platforms:
+          - linux/amd64
+          - linux/arm64
+  server:
+    image: airbyte/server:${VERSION}
+    build:
+      dockerfile: Dockerfile
+      context: airbyte-server/build/docker
+      labels:
+        io.airbyte.git-revision: ${GIT_REVISION}
+      args:
+        VERSION: ${VERSION}
+      x-bake:
+        tags:
+          - airbyte/server:${VERSION}
+          - airbyte/server:${ALT_TAG:-${VERSION}}
+        platforms:
+          - linux/amd64
+          - linux/arm64          
   worker:
     image: airbyte/worker:${VERSION}
     build:


### PR DESCRIPTION
## What
* Publish all images used by cloud

## How
* Add `airbyte-bootloader` and `airbyte-server` to the published images for cloud

## Recommended reading order
1. `docker-compose-cloud.buildx.yaml`
