### PR TITLE
Ensure Local Secret Persistence is Initialized

### DIFF
--- a/airbyte-config/config-persistence/src/main/java/io/airbyte/config/persistence/split_secrets/LocalTestingSecretPersistence.java
+++ b/airbyte-config/config-persistence/src/main/java/io/airbyte/config/persistence/split_secrets/LocalTestingSecretPersistence.java
@@ -36,6 +36,7 @@ public class LocalTestingSecretPersistence implements SecretPersistence {
   @Override
   public Optional<String> read(final SecretCoordinate coordinate) {
     return Exceptions.toRuntime(() -> this.configDatabase.query(ctx -> {
+      initialize();
       final var result = ctx.fetch("SELECT payload FROM secrets WHERE coordinate = ?;", coordinate.getFullCoordinate());
       if (result.size() == 0) {
         return Optional.empty();
@@ -48,6 +49,7 @@ public class LocalTestingSecretPersistence implements SecretPersistence {
   @Override
   public void write(final SecretCoordinate coordinate, final String payload) {
     Exceptions.toRuntime(() -> this.configDatabase.query(ctx -> {
+      initialize();
       ctx.query("INSERT INTO secrets(coordinate,payload) VALUES(?, ?) ON CONFLICT (coordinate) DO UPDATE SET payload = ?;",
           coordinate.getFullCoordinate(), payload, payload, coordinate.getFullCoordinate()).execute();
       return null;

--- a/docker-compose-cloud.buildx.yaml
+++ b/docker-compose-cloud.buildx.yaml
@@ -35,7 +35,7 @@ services:
           - airbyte/server:${ALT_TAG:-${VERSION}}
         platforms:
           - linux/amd64
-          - linux/arm64          
+          - linux/arm64
   worker:
     image: airbyte/worker:${VERSION}
     build:


### PR DESCRIPTION
## What
* Ensure that local testing persistence is initialized

## How
* Call `intialize()` before read/write

## Recommended reading order
1. `LocalTestingSecretPersistence.java`