### PR TITLE
Added nginx reverse proxy example config

### DIFF
--- a/docs/operator-guides/security.md
+++ b/docs/operator-guides/security.md
@@ -37,7 +37,7 @@ Deploy Airbyte Open Source in a private network or use a firewall to filter whic
 You can secure access to Airbyte using the following methods:
 
 - Deploy Airbyte in a private network or use a firewall to filter which IP is allowed to access your host.
-- Deploy Airbyte behind a reverse proxy and handle the access control and ssl encryption on the reverse proxy side.
+- Deploy Airbyte behind a reverse proxy and handle the access control and SSL encryption on the reverse proxy side.
   ```
   # Example nginx reverse proxy config
   server {

--- a/docs/operator-guides/security.md
+++ b/docs/operator-guides/security.md
@@ -37,7 +37,23 @@ Deploy Airbyte Open Source in a private network or use a firewall to filter whic
 You can secure access to Airbyte using the following methods:
 
 - Deploy Airbyte in a private network or use a firewall to filter which IP is allowed to access your host.
-- Deploy Airbyte behind a reverse proxy and handle the access control on the reverse proxy side.
+- Deploy Airbyte behind a reverse proxy and handle the access control and ssl encryption on the reverse proxy side.
+  ```
+  # Example nginx reverse proxy config
+  server {
+    listen 443 ssl;
+    server_name airbyte.<your-domain>.com;
+    client_max_body_size 200M;  # required for Airbyte API
+    ssl_certificate <path-to-your-cert>.crt.pem; 
+    ssl_certificate_key <path-to-your-key>.key.pem;
+    
+    location / {
+      proxy_pass http://127.0.0.1:8000;
+      proxy_set_header Cookie $http_ccokie;  # if you use Airbytes basic auth
+      proxy_read_timeout 3600;  # set a number in seconds suitable for you
+    }
+  }
+  ```
 - Change the default username and password in your environment's `.env` file:
   ```
   	# Proxy Configuration


### PR DESCRIPTION
## What
I added an nginx example config for people who want to put their local installation of Airbyte behind a reverse proxy.
This may be important for people who want to use Airbyte in production with SSL encryption

## How
A new entry in the docs showing config for nginx.

