### PR TITLE
manually bump source definition version

### DIFF
--- a/airbyte-config/init/src/main/resources/seed/source_definitions.yaml
+++ b/airbyte-config/init/src/main/resources/seed/source_definitions.yaml
@@ -1614,7 +1614,7 @@
 - name: Snowflake
   sourceDefinitionId: e2d65910-8c8b-40a1-ae7d-ee2416b2bfa2
   dockerRepository: airbyte/source-snowflake
-  dockerImageTag: 0.1.27
+  dockerImageTag: 0.1.28
   documentationUrl: https://docs.airbyte.com/integrations/sources/snowflake
   icon: snowflake.svg
   sourceType: database

--- a/airbyte-config/init/src/main/resources/seed/source_specs.yaml
+++ b/airbyte-config/init/src/main/resources/seed/source_specs.yaml
@@ -13667,7 +13667,7 @@
         - - "client_secret"
         oauthFlowOutputParameters:
         - - "refresh_token"
-- dockerImage: "airbyte/source-snowflake:0.1.27"
+- dockerImage: "airbyte/source-snowflake:0.1.28"
   spec:
     documentationUrl: "https://docs.airbyte.com/integrations/sources/snowflake"
     connectionSpecification:
@@ -13679,7 +13679,6 @@
       - "role"
       - "warehouse"
       - "database"
-      - "schema"
       properties:
         credentials:
           title: "Authorization Method"
@@ -13778,7 +13777,8 @@
           title: "Database"
           order: 4
         schema:
-          description: "The source Snowflake schema tables."
+          description: "The source Snowflake schema tables. Leave empty to access\
+            \ tables from multiple schemas."
           examples:
           - "AIRBYTE_SCHEMA"
           type: "string"


### PR DESCRIPTION
## What
For some reason `/publish` of original [PR](https://github.com/airbytehq/airbyte/pull/20465) failed to bump the version.
Following instruction to manually update source definition.