### PR TITLE
Update create connection page to full width, and fix trivial UI issues

### DIFF
--- a/airbyte-webapp/src/components/ConnectorBlocks/FormPageContent.module.scss
+++ b/airbyte-webapp/src/components/ConnectorBlocks/FormPageContent.module.scss
@@ -1,0 +1,11 @@
+@use "scss/variables";
+
+.container {
+  margin: 13px auto 0;
+  padding-bottom: variables.$spacing-page-bottom;
+
+  &:not(.big) {
+    width: 80%;
+    max-width: 813px;
+  }
+}

--- a/airbyte-webapp/src/components/ConnectorBlocks/FormPageContent.tsx
+++ b/airbyte-webapp/src/components/ConnectorBlocks/FormPageContent.tsx
@@ -1,9 +1,12 @@
 import styled from "styled-components";
 
-const FormPageContent = styled.div<{ big?: boolean }>`
-  width: 80%;
-  max-width: ${({ big }) => (big ? 1279 : 813)}px;
-  margin: 13px auto;
+interface FormPageContentProps {
+  big?: boolean;
+}
+
+const FormPageContent = styled.div<FormPageContentProps>`
+  ${({ big }) => (big ? "" : "width: 80%; max-width: 813px;")}
+  margin: 13px auto 0;
 `;
 
 export default FormPageContent;

--- a/airbyte-webapp/src/components/ConnectorBlocks/FormPageContent.tsx
+++ b/airbyte-webapp/src/components/ConnectorBlocks/FormPageContent.tsx
@@ -1,12 +1,14 @@
-import styled from "styled-components";
+import classNames from "classnames";
+import { PropsWithChildren } from "react";
+
+import styles from "./FormPageContent.module.scss";
 
 interface FormPageContentProps {
   big?: boolean;
 }
 
-const FormPageContent = styled.div<FormPageContentProps>`
-  ${({ big }) => (big ? "" : "width: 80%; max-width: 813px;")}
-  margin: 13px auto 0;
-`;
+const FormPageContent: React.FC<PropsWithChildren<FormPageContentProps>> = ({ big, children }) => (
+  <div className={classNames(styles.container, { [styles.big]: big })}>{children}</div>
+);
 
 export default FormPageContent;

--- a/airbyte-webapp/src/pages/connections/ConnectionReplicationPage/ConnectionReplicationPage.module.scss
+++ b/airbyte-webapp/src/pages/connections/ConnectionReplicationPage/ConnectionReplicationPage.module.scss
@@ -1,8 +1,7 @@
 @use "scss/variables";
 
 .content {
-  max-width: calc(100% - 2 * (#{variables.$spacing-xl}));
-  margin: 0 variables.$spacing-xl;
+  max-width: 100%;
   padding-bottom: variables.$spacing-md;
 
   > form {

--- a/airbyte-webapp/src/pages/connections/ConnectionReplicationPage/ConnectionReplicationPage.module.scss
+++ b/airbyte-webapp/src/pages/connections/ConnectionReplicationPage/ConnectionReplicationPage.module.scss
@@ -1,7 +1,6 @@
 @use "scss/variables";
 
 .content {
-  max-width: 100%;
   padding-bottom: variables.$spacing-md;
 
   > form {

--- a/airbyte-webapp/src/views/Connection/ConnectionForm/components/OperationsSection.tsx
+++ b/airbyte-webapp/src/views/Connection/ConnectionForm/components/OperationsSection.tsx
@@ -38,7 +38,7 @@ export const OperationsSection: React.FC<OperationsSectionProps> = ({
     <Card>
       <Section>
         {supportsNormalization || supportsTransformations ? (
-          <Heading as="h5">
+          <Heading as="h2" size="sm">
             {[
               supportsNormalization && formatMessage({ id: "connectionForm.normalization.title" }),
               supportsTransformations && formatMessage({ id: "connectionForm.transformation.title" }),


### PR DESCRIPTION
## What
Resolves #21338 

Updates the create connection page screen full width on the create connection step (not the source or destination step). Additionally:

* Updates the Normalizations & Transformations section heading to match the rest of the headings
* Removes extra 20px padding from the Replication page
* Adds page bottom padding to the FormPageContent layout

## How
CSS changes
