### PR TITLE
Add back in Auto detect schema functionality in sync workflow

### DIFF
--- a/airbyte-commons/src/main/java/io/airbyte/commons/features/EnvVariableFeatureFlags.java
+++ b/airbyte-commons/src/main/java/io/airbyte/commons/features/EnvVariableFeatureFlags.java
@@ -39,7 +39,7 @@ public class EnvVariableFeatureFlags implements FeatureFlags {
 
   @Override
   public boolean autoDetectSchema() {
-    return getEnvOrDefault(AUTO_DETECT_SCHEMA, true, Boolean::parseBoolean);
+    return getEnvOrDefault(AUTO_DETECT_SCHEMA, false, Boolean::parseBoolean);
   }
 
   @Override

--- a/airbyte-commons/src/main/java/io/airbyte/commons/features/EnvVariableFeatureFlags.java
+++ b/airbyte-commons/src/main/java/io/airbyte/commons/features/EnvVariableFeatureFlags.java
@@ -39,7 +39,7 @@ public class EnvVariableFeatureFlags implements FeatureFlags {
 
   @Override
   public boolean autoDetectSchema() {
-    return getEnvOrDefault(AUTO_DETECT_SCHEMA, false, Boolean::parseBoolean);
+    return getEnvOrDefault(AUTO_DETECT_SCHEMA, true, Boolean::parseBoolean);
   }
 
   @Override

--- a/airbyte-workers/src/main/java/io/airbyte/workers/config/ActivityBeanFactory.java
+++ b/airbyte-workers/src/main/java/io/airbyte/workers/config/ActivityBeanFactory.java
@@ -112,12 +112,10 @@ public class ActivityBeanFactory {
                                      final PersistStateActivity persistStateActivity,
                                      final NormalizationSummaryCheckActivity normalizationSummaryCheckActivity,
                                      final WebhookOperationActivity webhookOperationActivity,
-                                     /*
-                                      * Temporarily disabled to address OC issue #1210 final ConfigFetchActivity configFetchActivity,
-                                      */
+                                     final ConfigFetchActivity configFetchActivity,
                                      final RefreshSchemaActivity refreshSchemaActivity) {
     return List.of(replicationActivity, normalizationActivity, dbtTransformationActivity, persistStateActivity, normalizationSummaryCheckActivity,
-        webhookOperationActivity, /* configFetchActivity, */ refreshSchemaActivity);
+        webhookOperationActivity, configFetchActivity, refreshSchemaActivity);
   }
 
   @Singleton

--- a/airbyte-workers/src/main/java/io/airbyte/workers/temporal/scheduling/activities/ConfigFetchActivityImpl.java
+++ b/airbyte-workers/src/main/java/io/airbyte/workers/temporal/scheduling/activities/ConfigFetchActivityImpl.java
@@ -21,12 +21,10 @@ import io.airbyte.api.client.model.generated.ConnectionScheduleDataCron;
 import io.airbyte.api.client.model.generated.ConnectionScheduleType;
 import io.airbyte.api.client.model.generated.ConnectionStatus;
 import io.airbyte.api.client.model.generated.WorkspaceRead;
-import io.airbyte.commons.temporal.config.WorkerMode;
 import io.airbyte.commons.temporal.exception.RetryableException;
 import io.airbyte.metrics.lib.ApmTraceUtils;
 import io.airbyte.persistence.job.JobPersistence;
 import io.airbyte.persistence.job.models.Job;
-import io.micronaut.context.annotation.Requires;
 import io.micronaut.context.annotation.Value;
 import jakarta.inject.Named;
 import jakarta.inject.Singleton;
@@ -50,7 +48,6 @@ import org.slf4j.LoggerFactory;
 
 @Slf4j
 @Singleton
-@Requires(env = WorkerMode.CONTROL_PLANE)
 public class ConfigFetchActivityImpl implements ConfigFetchActivity {
 
   private static final Logger LOGGER = LoggerFactory.getLogger(ConfigFetchActivityImpl.class);

--- a/airbyte-workers/src/main/java/io/airbyte/workers/temporal/sync/SyncWorkflowImpl.java
+++ b/airbyte-workers/src/main/java/io/airbyte/workers/temporal/sync/SyncWorkflowImpl.java
@@ -12,6 +12,7 @@ import static io.airbyte.metrics.lib.ApmTraceConstants.Tags.SOURCE_DOCKER_IMAGE_
 import static io.airbyte.metrics.lib.ApmTraceConstants.WORKFLOW_TRACE_OPERATION_NAME;
 
 import datadog.trace.api.Trace;
+import io.airbyte.api.client.model.generated.ConnectionStatus;
 import io.airbyte.commons.temporal.scheduling.SyncWorkflow;
 import io.airbyte.config.NormalizationInput;
 import io.airbyte.config.NormalizationSummary;
@@ -21,12 +22,16 @@ import io.airbyte.config.StandardSyncInput;
 import io.airbyte.config.StandardSyncOperation;
 import io.airbyte.config.StandardSyncOperation.OperatorType;
 import io.airbyte.config.StandardSyncOutput;
+import io.airbyte.config.StandardSyncSummary;
+import io.airbyte.config.StandardSyncSummary.ReplicationStatus;
+import io.airbyte.config.SyncStats;
 import io.airbyte.config.WebhookOperationSummary;
 import io.airbyte.metrics.lib.ApmTraceUtils;
 import io.airbyte.persistence.job.models.IntegrationLauncherConfig;
 import io.airbyte.persistence.job.models.JobRunConfig;
 import io.airbyte.protocol.models.ConfiguredAirbyteCatalog;
 import io.airbyte.workers.temporal.annotations.TemporalActivityStub;
+import io.airbyte.workers.temporal.scheduling.activities.ConfigFetchActivity;
 import io.temporal.workflow.Workflow;
 import java.util.Map;
 import java.util.Optional;
@@ -57,11 +62,10 @@ public class SyncWorkflowImpl implements SyncWorkflow {
   private NormalizationSummaryCheckActivity normalizationSummaryCheckActivity;
   @TemporalActivityStub(activityOptionsBeanName = "shortActivityOptions")
   private WebhookOperationActivity webhookOperationActivity;
-  // Temporarily disabled to address OC issue #1210
-  // @TemporalActivityStub(activityOptionsBeanName = "shortActivityOptions")
-  // private RefreshSchemaActivity refreshSchemaActivity;
-  // @TemporalActivityStub(activityOptionsBeanName = "shortActivityOptions")
-  // private ConfigFetchActivity configFetchActivity;
+  @TemporalActivityStub(activityOptionsBeanName = "shortActivityOptions")
+  private RefreshSchemaActivity refreshSchemaActivity;
+  @TemporalActivityStub(activityOptionsBeanName = "shortActivityOptions")
+  private ConfigFetchActivity configFetchActivity;
 
   @Trace(operationName = WORKFLOW_TRACE_OPERATION_NAME)
   @Override
@@ -80,30 +84,26 @@ public class SyncWorkflowImpl implements SyncWorkflow {
     final int version = Workflow.getVersion(VERSION_LABEL, Workflow.DEFAULT_VERSION, CURRENT_VERSION);
     final String taskQueue = Workflow.getInfo().getTaskQueue();
 
-    // Temporarily suppressed to address OC issue #1210
-    @SuppressWarnings("PMD.UnusedLocalVariable")
     final int autoDetectSchemaVersion =
         Workflow.getVersion(AUTO_DETECT_SCHEMA_TAG, Workflow.DEFAULT_VERSION, AUTO_DETECT_SCHEMA_VERSION);
 
-    // Temporarily disabled to address OC issue #1210
-    // if (autoDetectSchemaVersion >= AUTO_DETECT_SCHEMA_VERSION) {
-    // final Optional<UUID> sourceId = configFetchActivity.getSourceId(connectionId);
-    //
-    // if (!sourceId.isEmpty() && refreshSchemaActivity.shouldRefreshSchema(sourceId.get())) {
-    // LOGGER.info("Refreshing source schema...");
-    // refreshSchemaActivity.refreshSchema(sourceId.get(), connectionId);
-    // }
-    //
-    // final Optional<Status> status = configFetchActivity.getStatus(connectionId);
-    // if (!status.isEmpty() && Status.INACTIVE == status.get()) {
-    // LOGGER.info("Connection is disabled. Cancelling run.");
-    // final StandardSyncOutput output =
-    // new StandardSyncOutput()
-    // .withStandardSyncSummary(new
-    // StandardSyncSummary().withStatus(ReplicationStatus.CANCELLED).withTotalStats(new SyncStats()));
-    // return output;
-    // }
-    // }
+    if (autoDetectSchemaVersion >= AUTO_DETECT_SCHEMA_VERSION) {
+      final Optional<UUID> sourceId = configFetchActivity.getSourceId(connectionId);
+
+      if (!sourceId.isEmpty() && refreshSchemaActivity.shouldRefreshSchema(sourceId.get())) {
+        LOGGER.info("Refreshing source schema...");
+        refreshSchemaActivity.refreshSchema(sourceId.get(), connectionId);
+      }
+
+      final Optional<ConnectionStatus> status = configFetchActivity.getStatus(connectionId);
+      if (!status.isEmpty() && ConnectionStatus.INACTIVE == status.get()) {
+        LOGGER.info("Connection is disabled. Cancelling run.");
+        final StandardSyncOutput output =
+            new StandardSyncOutput()
+                .withStandardSyncSummary(new StandardSyncSummary().withStatus(ReplicationStatus.CANCELLED).withTotalStats(new SyncStats()));
+        return output;
+      }
+    }
 
     StandardSyncOutput syncOutput =
         replicationActivity.replicate(jobRunConfig, sourceLauncherConfig, destinationLauncherConfig, syncInput, taskQueue);

--- a/airbyte-workers/src/main/java/io/airbyte/workers/temporal/sync/SyncWorkflowImpl.java
+++ b/airbyte-workers/src/main/java/io/airbyte/workers/temporal/sync/SyncWorkflowImpl.java
@@ -48,7 +48,7 @@ public class SyncWorkflowImpl implements SyncWorkflow {
   private static final String NORMALIZATION_SUMMARY_CHECK_TAG = "normalization_summary_check";
   private static final int NORMALIZATION_SUMMARY_CHECK_CURRENT_VERSION = 1;
   private static final String AUTO_DETECT_SCHEMA_TAG = "auto_detect_schema";
-  private static final int AUTO_DETECT_SCHEMA_VERSION = 1;
+  private static final int AUTO_DETECT_SCHEMA_VERSION = 2;
 
   @TemporalActivityStub(activityOptionsBeanName = "longRunActivityOptions")
   private ReplicationActivity replicationActivity;

--- a/airbyte-workers/src/test/java/io/airbyte/workers/temporal/sync/SyncWorkflowTest.java
+++ b/airbyte-workers/src/test/java/io/airbyte/workers/temporal/sync/SyncWorkflowTest.java
@@ -229,9 +229,8 @@ class SyncWorkflowTest {
     verifyNormalize(normalizationActivity, normalizationInput);
     verifyDbtTransform(dbtTransformationActivity, syncInput.getResourceRequirements(),
         operatorDbtInput);
-    // Temporarily disabled to address OC issue #1210
-    // verifyShouldRefreshSchema(refreshSchemaActivity);
-    // verifyRefreshSchema(refreshSchemaActivity, sync);
+    verifyShouldRefreshSchema(refreshSchemaActivity);
+    verifyRefreshSchema(refreshSchemaActivity, sync);
     assertEquals(
         replicationSuccessOutput.withNormalizationSummary(normalizationSummary).getStandardSyncSummary(),
         actualOutput.getStandardSyncSummary());
@@ -247,9 +246,8 @@ class SyncWorkflowTest {
 
     assertThrows(WorkflowFailedException.class, this::execute);
 
-    // Temporarily disabled to address OC issue #1210
-    // verifyShouldRefreshSchema(refreshSchemaActivity);
-    // verifyRefreshSchema(refreshSchemaActivity, sync);
+    verifyShouldRefreshSchema(refreshSchemaActivity);
+    verifyRefreshSchema(refreshSchemaActivity, sync);
     verifyReplication(replicationActivity, syncInput);
     verifyNoInteractions(persistStateActivity);
     verifyNoInteractions(normalizationActivity);
@@ -271,9 +269,8 @@ class SyncWorkflowTest {
 
     final StandardSyncOutput actualOutput = execute();
 
-    // Temporarily disabled to address OC issue #1210
-    // verifyShouldRefreshSchema(refreshSchemaActivity);
-    // verifyRefreshSchema(refreshSchemaActivity, sync);
+    verifyShouldRefreshSchema(refreshSchemaActivity);
+    verifyRefreshSchema(refreshSchemaActivity, sync);
     verifyReplication(replicationActivity, syncInput);
     verifyPersistState(persistStateActivity, sync, replicationFailOutput, syncInput.getCatalog());
     verifyNormalize(normalizationActivity, normalizationInput);
@@ -299,9 +296,8 @@ class SyncWorkflowTest {
 
     assertThrows(WorkflowFailedException.class, this::execute);
 
-    // Temporarily disabled to address OC issue #1210
-    // verifyShouldRefreshSchema(refreshSchemaActivity);
-    // verifyRefreshSchema(refreshSchemaActivity, sync);
+    verifyShouldRefreshSchema(refreshSchemaActivity);
+    verifyRefreshSchema(refreshSchemaActivity, sync);
     verifyReplication(replicationActivity, syncInput);
     verifyPersistState(persistStateActivity, sync, replicationSuccessOutput, syncInput.getCatalog());
     verifyNormalize(normalizationActivity, normalizationInput);
@@ -321,9 +317,8 @@ class SyncWorkflowTest {
 
     assertThrows(WorkflowFailedException.class, this::execute);
 
-    // Temporarily disabled to address OC issue #1210
-    // verifyShouldRefreshSchema(refreshSchemaActivity);
-    // verifyRefreshSchema(refreshSchemaActivity, sync);
+    verifyShouldRefreshSchema(refreshSchemaActivity);
+    verifyRefreshSchema(refreshSchemaActivity, sync);
     verifyReplication(replicationActivity, syncInput);
     verifyNoInteractions(persistStateActivity);
     verifyNoInteractions(normalizationActivity);
@@ -348,9 +343,8 @@ class SyncWorkflowTest {
 
     assertThrows(WorkflowFailedException.class, this::execute);
 
-    // Temporarily disabled to address OC issue #1210
-    // verifyShouldRefreshSchema(refreshSchemaActivity);
-    // verifyRefreshSchema(refreshSchemaActivity, sync);
+    verifyShouldRefreshSchema(refreshSchemaActivity);
+    verifyRefreshSchema(refreshSchemaActivity, sync);
     verifyReplication(replicationActivity, syncInput);
     verifyPersistState(persistStateActivity, sync, replicationSuccessOutput, syncInput.getCatalog());
     verifyNormalize(normalizationActivity, normalizationInput);
@@ -403,7 +397,6 @@ class SyncWorkflowTest {
   }
 
   @Test
-  @Disabled("Temporarily disabled to address OC issue #1210")
   void testSkipReplicationAfterRefreshSchema() {
     when(configFetchActivity.getStatus(any())).thenReturn(Optional.of(ConnectionStatus.INACTIVE));
     final StandardSyncOutput output = execute();


### PR DESCRIPTION
Add back in Auto Detect Schema functionality that was removed due to OC issue #1210

ConfigFetchActivityImpl no longer relies on the ConfigRepository