### PR TITLE
Connector builder: Fix e2e tests

### DIFF
--- a/airbyte-webapp/src/components/connectorBuilder/types.ts
+++ b/airbyte-webapp/src/components/connectorBuilder/types.ts
@@ -20,6 +20,7 @@ import {
   SubstreamSlicer,
   SubstreamSlicerType,
   CartesianProductStreamSlicer,
+  DeclarativeStreamSchemaLoader,
 } from "core/request/ConnectorManifest";
 
 export interface BuilderFormInput {
@@ -506,14 +507,16 @@ function builderFormStreamSlicerToStreamSlicer(
   };
 }
 
-function parseSchemaString(schema?: string) {
+const EMPTY_SCHEMA = { type: "InlineSchemaLoader", schema: {} };
+
+function parseSchemaString(schema?: string): DeclarativeStreamSchemaLoader {
   if (!schema) {
-    return undefined;
+    return EMPTY_SCHEMA;
   }
   try {
     return { type: "InlineSchemaLoader", schema: JSON.parse(schema) };
   } catch {
-    return undefined;
+    return EMPTY_SCHEMA;
   }
 }
 


### PR DESCRIPTION
Quick fix for the connector builder e2e tests

It looks like the connector builder server is not returning records anymore if no schema is passed along. This PR applies to quick-fix to the frontend, passing an empty schema along until it's fixed on the backend.