### PR TITLE
🪟 🐛 Fix jest tests to fail build correctly

### DIFF
--- a/airbyte-webapp/build.gradle
+++ b/airbyte-webapp/build.gradle
@@ -34,7 +34,7 @@ npm_run_build {
 task test(type: NpmTask) {
     dependsOn assemble
 
-    args = ['run', 'test', '--', '--watchAll=false', '--silent']
+    args = ['run', 'test:ci']
     inputs.files commonConfigs
     inputs.dir 'src'
 }

--- a/airbyte-webapp/package.json
+++ b/airbyte-webapp/package.json
@@ -15,6 +15,7 @@
     "build": "BUILD_PATH='./build/app' craco build",
     "pretest": "npm run generate-client",
     "test": "jest --watch",
+    "test:ci": "jest --watchAll=false --silent",
     "test:coverage": "jest --coverage --watchAll=false",
     "format": "prettier --write 'src/**/*.{ts,tsx}'",
     "storybook": "start-storybook -p 9009 --quiet",

--- a/airbyte-webapp/src/components/EntityTable/components/StatusCell.test.tsx
+++ b/airbyte-webapp/src/components/EntityTable/components/StatusCell.test.tsx
@@ -37,7 +37,7 @@ describe("<StatusCell />", () => {
       wrapper: TestWrapper,
     });
 
-    expect(getByTestId("enable-connection-switch")).toBeDisabled();
+    expect(getByTestId("enable-connection-switch")).toBeEnabled();
   });
 
   it("disables manual sync button when hasBreakingChange is true", () => {

--- a/airbyte-webapp/src/components/EntityTable/components/StatusCell.test.tsx
+++ b/airbyte-webapp/src/components/EntityTable/components/StatusCell.test.tsx
@@ -37,7 +37,7 @@ describe("<StatusCell />", () => {
       wrapper: TestWrapper,
     });
 
-    expect(getByTestId("enable-connection-switch")).toBeEnabled();
+    expect(getByTestId("enable-connection-switch")).toBeDisabled();
   });
 
   it("disables manual sync button when hasBreakingChange is true", () => {


### PR DESCRIPTION
## What

Jests tests currently don't fail the `:airbyte-webapp:test` task correctly, since specifying `--watch` and `--watchAll=false` to jest will cause it to always return 0 exit codes, despite the `--watch` being overwritten otherwise in behavior by `--watchAll=false`.

## How

This creates a new `test:ci` npm task that will be called from gradle, to make sure we're not specifying both arguments.
To test you can make sure that `SUB_BUILD=PLATFORM ./gradlew :airbyte-webapp:test` will now correctly fail if there's a jest test failure.