### PR TITLE
Allow the OSS server only on OSS

### DIFF
--- a/airbyte-server/src/main/java/io/airbyte/server/apis/AttemptApiController.java
+++ b/airbyte-server/src/main/java/io/airbyte/server/apis/AttemptApiController.java
@@ -9,12 +9,15 @@ import io.airbyte.api.model.generated.InternalOperationResult;
 import io.airbyte.api.model.generated.SaveStatsRequestBody;
 import io.airbyte.api.model.generated.SetWorkflowInAttemptRequestBody;
 import io.airbyte.server.handlers.AttemptHandler;
+import io.micronaut.context.annotation.Requires;
 import io.micronaut.http.MediaType;
 import io.micronaut.http.annotation.Body;
 import io.micronaut.http.annotation.Controller;
 import io.micronaut.http.annotation.Post;
 
 @Controller("/api/v1/attempt/")
+@Requires(property = "airbyte.deployment-mode",
+          value = "OSS")
 public class AttemptApiController implements AttemptApi {
 
   private final AttemptHandler attemptHandler;

--- a/airbyte-server/src/main/java/io/airbyte/server/apis/ConnectionApiController.java
+++ b/airbyte-server/src/main/java/io/airbyte/server/apis/ConnectionApiController.java
@@ -17,12 +17,15 @@ import io.airbyte.server.handlers.ConnectionsHandler;
 import io.airbyte.server.handlers.OperationsHandler;
 import io.airbyte.server.handlers.SchedulerHandler;
 import io.micronaut.context.annotation.Context;
+import io.micronaut.context.annotation.Requires;
 import io.micronaut.http.annotation.Body;
 import io.micronaut.http.annotation.Controller;
 import io.micronaut.http.annotation.Post;
 
 @Controller("/api/v1/connections")
 @Context()
+@Requires(property = "airbyte.deployment-mode",
+          value = "OSS")
 public class ConnectionApiController implements ConnectionApi {
 
   private final ConnectionsHandler connectionsHandler;

--- a/airbyte-server/src/main/java/io/airbyte/server/apis/DestinationApiController.java
+++ b/airbyte-server/src/main/java/io/airbyte/server/apis/DestinationApiController.java
@@ -16,12 +16,15 @@ import io.airbyte.api.model.generated.DestinationUpdate;
 import io.airbyte.api.model.generated.WorkspaceIdRequestBody;
 import io.airbyte.server.handlers.DestinationHandler;
 import io.airbyte.server.handlers.SchedulerHandler;
+import io.micronaut.context.annotation.Requires;
 import io.micronaut.http.annotation.Body;
 import io.micronaut.http.annotation.Controller;
 import io.micronaut.http.annotation.Post;
 import lombok.AllArgsConstructor;
 
 @Controller("/api/v1/destinations")
+@Requires(property = "airbyte.deployment-mode",
+          value = "OSS")
 @AllArgsConstructor
 public class DestinationApiController implements DestinationApi {
 

--- a/airbyte-server/src/main/java/io/airbyte/server/apis/DestinationDefinitionApiController.java
+++ b/airbyte-server/src/main/java/io/airbyte/server/apis/DestinationDefinitionApiController.java
@@ -16,10 +16,13 @@ import io.airbyte.api.model.generated.PrivateDestinationDefinitionReadList;
 import io.airbyte.api.model.generated.WorkspaceIdRequestBody;
 import io.airbyte.server.handlers.DestinationDefinitionsHandler;
 import io.micronaut.context.annotation.Context;
+import io.micronaut.context.annotation.Requires;
 import io.micronaut.http.annotation.Controller;
 import io.micronaut.http.annotation.Post;
 
 @Controller("/api/v1/destination_definitions")
+@Requires(property = "airbyte.deployment-mode",
+          value = "OSS")
 @Context
 public class DestinationDefinitionApiController implements DestinationDefinitionApi {
 

--- a/airbyte-server/src/main/java/io/airbyte/server/apis/DestinationDefinitionSpecificationApiController.java
+++ b/airbyte-server/src/main/java/io/airbyte/server/apis/DestinationDefinitionSpecificationApiController.java
@@ -8,10 +8,13 @@ import io.airbyte.api.generated.DestinationDefinitionSpecificationApi;
 import io.airbyte.api.model.generated.DestinationDefinitionIdWithWorkspaceId;
 import io.airbyte.api.model.generated.DestinationDefinitionSpecificationRead;
 import io.airbyte.server.handlers.SchedulerHandler;
+import io.micronaut.context.annotation.Requires;
 import io.micronaut.http.annotation.Controller;
 import io.micronaut.http.annotation.Post;
 
 @Controller("/api/v1/destination_definition_specifications")
+@Requires(property = "airbyte.deployment-mode",
+          value = "OSS")
 public class DestinationDefinitionSpecificationApiController implements DestinationDefinitionSpecificationApi {
 
   private final SchedulerHandler schedulerHandler;

--- a/airbyte-server/src/main/java/io/airbyte/server/apis/DestinationOauthApiController.java
+++ b/airbyte-server/src/main/java/io/airbyte/server/apis/DestinationOauthApiController.java
@@ -11,11 +11,14 @@ import io.airbyte.api.model.generated.OAuthConsentRead;
 import io.airbyte.api.model.generated.SetInstancewideDestinationOauthParamsRequestBody;
 import io.airbyte.server.handlers.OAuthHandler;
 import io.micronaut.context.annotation.Context;
+import io.micronaut.context.annotation.Requires;
 import io.micronaut.http.annotation.Controller;
 import io.micronaut.http.annotation.Post;
 import java.util.Map;
 
 @Controller("/api/v1/destination_oauths")
+@Requires(property = "airbyte.deployment-mode",
+          value = "OSS")
 @Context
 public class DestinationOauthApiController implements DestinationOauthApi {
 

--- a/airbyte-server/src/main/java/io/airbyte/server/apis/HealthApiController.java
+++ b/airbyte-server/src/main/java/io/airbyte/server/apis/HealthApiController.java
@@ -7,11 +7,14 @@ package io.airbyte.server.apis;
 import io.airbyte.api.generated.HealthApi;
 import io.airbyte.api.model.generated.HealthCheckRead;
 import io.airbyte.server.handlers.HealthCheckHandler;
+import io.micronaut.context.annotation.Requires;
 import io.micronaut.http.MediaType;
 import io.micronaut.http.annotation.Controller;
 import io.micronaut.http.annotation.Get;
 
 @Controller("/api/v1/health")
+@Requires(property = "airbyte.deployment-mode",
+          value = "OSS")
 public class HealthApiController implements HealthApi {
 
   private final HealthCheckHandler healthCheckHandler;

--- a/airbyte-server/src/main/java/io/airbyte/server/apis/JobsApiController.java
+++ b/airbyte-server/src/main/java/io/airbyte/server/apis/JobsApiController.java
@@ -15,10 +15,13 @@ import io.airbyte.api.model.generated.JobReadList;
 import io.airbyte.server.handlers.JobHistoryHandler;
 import io.airbyte.server.handlers.SchedulerHandler;
 import io.micronaut.context.annotation.Context;
+import io.micronaut.context.annotation.Requires;
 import io.micronaut.http.annotation.Controller;
 import io.micronaut.http.annotation.Post;
 
 @Controller("/api/v1/jobs")
+@Requires(property = "airbyte.deployment-mode",
+          value = "OSS")
 @Context
 public class JobsApiController implements JobsApi {
 

--- a/airbyte-server/src/main/java/io/airbyte/server/apis/LogsApiController.java
+++ b/airbyte-server/src/main/java/io/airbyte/server/apis/LogsApiController.java
@@ -8,11 +8,14 @@ import io.airbyte.api.generated.LogsApi;
 import io.airbyte.api.model.generated.LogsRequestBody;
 import io.airbyte.server.handlers.LogsHandler;
 import io.micronaut.context.annotation.Context;
+import io.micronaut.context.annotation.Requires;
 import io.micronaut.http.annotation.Controller;
 import io.micronaut.http.annotation.Post;
 import java.io.File;
 
 @Controller("/api/v1/logs")
+@Requires(property = "airbyte.deployment-mode",
+          value = "OSS")
 @Context
 public class LogsApiController implements LogsApi {
 

--- a/airbyte-server/src/main/java/io/airbyte/server/apis/NotFoundController.java
+++ b/airbyte-server/src/main/java/io/airbyte/server/apis/NotFoundController.java
@@ -4,6 +4,7 @@
 
 package io.airbyte.server.apis;
 
+import io.micronaut.context.annotation.Requires;
 import io.micronaut.http.HttpRequest;
 import io.micronaut.http.HttpResponse;
 import io.micronaut.http.HttpStatus;
@@ -15,6 +16,8 @@ import io.micronaut.http.annotation.Error;
  * Custom controller that handles global 404 responses for unknown/unmapped paths.
  */
 @Controller("/api/notfound")
+@Requires(property = "airbyte.deployment-mode",
+          value = "OSS")
 public class NotFoundController {
 
   @Error(status = HttpStatus.NOT_FOUND,

--- a/airbyte-server/src/main/java/io/airbyte/server/apis/NotificationsApiController.java
+++ b/airbyte-server/src/main/java/io/airbyte/server/apis/NotificationsApiController.java
@@ -8,11 +8,14 @@ import io.airbyte.api.generated.NotificationsApi;
 import io.airbyte.api.model.generated.Notification;
 import io.airbyte.api.model.generated.NotificationRead;
 import io.airbyte.server.handlers.WorkspacesHandler;
+import io.micronaut.context.annotation.Requires;
 import io.micronaut.http.annotation.Body;
 import io.micronaut.http.annotation.Controller;
 import io.micronaut.http.annotation.Post;
 
 @Controller("/api/v1/notifications/try")
+@Requires(property = "airbyte.deployment-mode",
+          value = "OSS")
 public class NotificationsApiController implements NotificationsApi {
 
   private final WorkspacesHandler workspacesHandler;

--- a/airbyte-server/src/main/java/io/airbyte/server/apis/OpenapiApiController.java
+++ b/airbyte-server/src/main/java/io/airbyte/server/apis/OpenapiApiController.java
@@ -6,11 +6,14 @@ package io.airbyte.server.apis;
 
 import io.airbyte.api.generated.OpenapiApi;
 import io.airbyte.server.handlers.OpenApiConfigHandler;
+import io.micronaut.context.annotation.Requires;
 import io.micronaut.http.annotation.Controller;
 import io.micronaut.http.annotation.Get;
 import java.io.File;
 
 @Controller("/api/v1/openapi")
+@Requires(property = "airbyte.deployment-mode",
+          value = "OSS")
 public class OpenapiApiController implements OpenapiApi {
 
   private final OpenApiConfigHandler openApiConfigHandler;

--- a/airbyte-server/src/main/java/io/airbyte/server/apis/OperationApiController.java
+++ b/airbyte-server/src/main/java/io/airbyte/server/apis/OperationApiController.java
@@ -14,11 +14,14 @@ import io.airbyte.api.model.generated.OperationReadList;
 import io.airbyte.api.model.generated.OperationUpdate;
 import io.airbyte.api.model.generated.OperatorConfiguration;
 import io.airbyte.server.handlers.OperationsHandler;
+import io.micronaut.context.annotation.Requires;
 import io.micronaut.http.annotation.Body;
 import io.micronaut.http.annotation.Controller;
 import io.micronaut.http.annotation.Post;
 
 @Controller("/api/v1/operations")
+@Requires(property = "airbyte.deployment-mode",
+          value = "OSS")
 public class OperationApiController implements OperationApi {
 
   private final OperationsHandler operationsHandler;

--- a/airbyte-server/src/main/java/io/airbyte/server/apis/SchedulerApiController.java
+++ b/airbyte-server/src/main/java/io/airbyte/server/apis/SchedulerApiController.java
@@ -10,10 +10,13 @@ import io.airbyte.api.model.generated.DestinationCoreConfig;
 import io.airbyte.api.model.generated.SourceCoreConfig;
 import io.airbyte.api.model.generated.SourceDiscoverSchemaRead;
 import io.airbyte.server.handlers.SchedulerHandler;
+import io.micronaut.context.annotation.Requires;
 import io.micronaut.http.annotation.Controller;
 import io.micronaut.http.annotation.Post;
 
 @Controller("/api/v1/scheduler")
+@Requires(property = "airbyte.deployment-mode",
+          value = "OSS")
 public class SchedulerApiController implements SchedulerApi {
 
   private final SchedulerHandler schedulerHandler;

--- a/airbyte-server/src/main/java/io/airbyte/server/apis/SourceApiController.java
+++ b/airbyte-server/src/main/java/io/airbyte/server/apis/SourceApiController.java
@@ -19,10 +19,13 @@ import io.airbyte.api.model.generated.SourceUpdate;
 import io.airbyte.api.model.generated.WorkspaceIdRequestBody;
 import io.airbyte.server.handlers.SchedulerHandler;
 import io.airbyte.server.handlers.SourceHandler;
+import io.micronaut.context.annotation.Requires;
 import io.micronaut.http.annotation.Controller;
 import io.micronaut.http.annotation.Post;
 
 @Controller("/api/v1/sources")
+@Requires(property = "airbyte.deployment-mode",
+          value = "OSS")
 public class SourceApiController implements SourceApi {
 
   private final SchedulerHandler schedulerHandler;

--- a/airbyte-server/src/main/java/io/airbyte/server/apis/SourceDefinitionApiController.java
+++ b/airbyte-server/src/main/java/io/airbyte/server/apis/SourceDefinitionApiController.java
@@ -16,10 +16,13 @@ import io.airbyte.api.model.generated.SourceDefinitionUpdate;
 import io.airbyte.api.model.generated.WorkspaceIdRequestBody;
 import io.airbyte.server.handlers.SourceDefinitionsHandler;
 import io.micronaut.context.annotation.Context;
+import io.micronaut.context.annotation.Requires;
 import io.micronaut.http.annotation.Controller;
 import io.micronaut.http.annotation.Post;
 
 @Controller("/api/v1/source_definitions")
+@Requires(property = "airbyte.deployment-mode",
+          value = "OSS")
 @Context
 public class SourceDefinitionApiController implements SourceDefinitionApi {
 

--- a/airbyte-server/src/main/java/io/airbyte/server/apis/SourceDefinitionSpecificationApiController.java
+++ b/airbyte-server/src/main/java/io/airbyte/server/apis/SourceDefinitionSpecificationApiController.java
@@ -8,10 +8,13 @@ import io.airbyte.api.generated.SourceDefinitionSpecificationApi;
 import io.airbyte.api.model.generated.SourceDefinitionIdWithWorkspaceId;
 import io.airbyte.api.model.generated.SourceDefinitionSpecificationRead;
 import io.airbyte.server.handlers.SchedulerHandler;
+import io.micronaut.context.annotation.Requires;
 import io.micronaut.http.annotation.Controller;
 import io.micronaut.http.annotation.Post;
 
 @Controller("/api/v1/source_definition_specifications")
+@Requires(property = "airbyte.deployment-mode",
+          value = "OSS")
 public class SourceDefinitionSpecificationApiController implements SourceDefinitionSpecificationApi {
 
   private final SchedulerHandler schedulerHandler;

--- a/airbyte-server/src/main/java/io/airbyte/server/apis/SourceOauthApiController.java
+++ b/airbyte-server/src/main/java/io/airbyte/server/apis/SourceOauthApiController.java
@@ -10,12 +10,15 @@ import io.airbyte.api.model.generated.OAuthConsentRead;
 import io.airbyte.api.model.generated.SetInstancewideSourceOauthParamsRequestBody;
 import io.airbyte.api.model.generated.SourceOauthConsentRequest;
 import io.airbyte.server.handlers.OAuthHandler;
+import io.micronaut.context.annotation.Requires;
 import io.micronaut.http.annotation.Body;
 import io.micronaut.http.annotation.Controller;
 import io.micronaut.http.annotation.Post;
 import java.util.Map;
 
 @Controller("/api/v1/source_oauths")
+@Requires(property = "airbyte.deployment-mode",
+          value = "OSS")
 public class SourceOauthApiController implements SourceOauthApi {
 
   private final OAuthHandler oAuthHandler;

--- a/airbyte-server/src/main/java/io/airbyte/server/apis/StateApiController.java
+++ b/airbyte-server/src/main/java/io/airbyte/server/apis/StateApiController.java
@@ -9,10 +9,13 @@ import io.airbyte.api.model.generated.ConnectionIdRequestBody;
 import io.airbyte.api.model.generated.ConnectionState;
 import io.airbyte.api.model.generated.ConnectionStateCreateOrUpdate;
 import io.airbyte.server.handlers.StateHandler;
+import io.micronaut.context.annotation.Requires;
 import io.micronaut.http.annotation.Controller;
 import io.micronaut.http.annotation.Post;
 
 @Controller("/api/v1/state")
+@Requires(property = "airbyte.deployment-mode",
+          value = "OSS")
 public class StateApiController implements StateApi {
 
   private final StateHandler stateHandler;

--- a/airbyte-server/src/main/java/io/airbyte/server/apis/WebBackendApiController.java
+++ b/airbyte-server/src/main/java/io/airbyte/server/apis/WebBackendApiController.java
@@ -20,10 +20,13 @@ import io.airbyte.api.model.generated.WebBackendWorkspaceStateResult;
 import io.airbyte.server.handlers.WebBackendCheckUpdatesHandler;
 import io.airbyte.server.handlers.WebBackendConnectionsHandler;
 import io.airbyte.server.handlers.WebBackendGeographiesHandler;
+import io.micronaut.context.annotation.Requires;
 import io.micronaut.http.annotation.Controller;
 import io.micronaut.http.annotation.Post;
 
 @Controller("/api/v1/web_backend")
+@Requires(property = "airbyte.deployment-mode",
+          value = "OSS")
 public class WebBackendApiController implements WebBackendApi {
 
   private final WebBackendConnectionsHandler webBackendConnectionsHandler;

--- a/airbyte-server/src/main/java/io/airbyte/server/apis/WorkspaceApiController.java
+++ b/airbyte-server/src/main/java/io/airbyte/server/apis/WorkspaceApiController.java
@@ -15,11 +15,14 @@ import io.airbyte.api.model.generated.WorkspaceReadList;
 import io.airbyte.api.model.generated.WorkspaceUpdate;
 import io.airbyte.api.model.generated.WorkspaceUpdateName;
 import io.airbyte.server.handlers.WorkspacesHandler;
+import io.micronaut.context.annotation.Requires;
 import io.micronaut.http.annotation.Body;
 import io.micronaut.http.annotation.Controller;
 import io.micronaut.http.annotation.Post;
 
 @Controller("/api/v1/workspaces")
+@Requires(property = "airbyte.deployment-mode",
+          value = "OSS")
 public class WorkspaceApiController implements WorkspaceApi {
 
   private final WorkspacesHandler workspacesHandler;


### PR DESCRIPTION
## What
The server endpoints are being declared twice in cloud because it depends on the server.
Ideally we should extract the handler in their own module and remove the dependency from the server wrapped to the server to avoid having requirement but this is a temporary since we will have one server soon. So the "dirty" solution is acceptable.

Without that the wrapped server can't run its health check properly because of:
```
benoit@Benoits-MacBook-Pro-2 ~/w/airbuild (master|✔) [7]> k exec airbyte-server-64cb54bb9b-qb8nf -- curl http://localhost:8001/api/v1/health
  % Total    % Received % Xferd  Average Speed   Time    Time     Time  Current
                                 Dload  Upload   Total   Spent    Left  Speed
  0     0    0     0    0     0      0      0 --:--:-- --:--:-- --:--:--     0{"message":"Bad Request","_links":{"self":{"href":"/api/v1/health","templated":false}},"_embedded":{"errors":[{"message":"More than 1 100   262  100   262    0     0  36449      0 --:--:-- --:--:-- --:--:-- 43666h: GET - /api/v1/health, GET - /api/v1/health"}]}}
```
