### PR TITLE
Fix CreateConnectionForm test snapshot

### DIFF
--- a/airbyte-webapp/src/components/CreateConnection/__snapshots__/CreateConnectionForm.test.tsx.snap
+++ b/airbyte-webapp/src/components/CreateConnection/__snapshots__/CreateConnectionForm.test.tsx.snap
@@ -892,11 +892,11 @@ exports[`CreateConnectionForm should render 1`] = `
             <div
               class="<removed-for-snapshot-test>"
             >
-              <h5
+              <h2
                 class="<removed-for-snapshot-test>"
               >
                 Normalization & Transformation
-              </h5>
+              </h2>
               <div
                 class="<removed-for-snapshot-test>"
               >


### PR DESCRIPTION
## What
Fixes a broken jest snapshot that causes the webapp unit tests to fail.

Caused by #21352
Related: #21408

## How
Updates snapshot