### PR TITLE
make the pr code coverage comment update instead of adding new comments

### DIFF
--- a/.github/workflows/gradle.yml
+++ b/.github/workflows/gradle.yml
@@ -678,6 +678,8 @@ jobs:
           token: ${{ secrets.GITHUB_TOKEN }}
           min-coverage-overall: 25
           min-coverage-changed-files: 60
+          title: Airbyte Code Coverage
+          update-comment: true
           debug-mode: false
 
       - name: Integration test


### PR DESCRIPTION
## What
Update the existing comment about code coverage % instead of creating a new one.

In general, this will probably be less noisy than adding a new one each time the PR is updated.
