### PR TITLE
Fix connector builder documentation link again

### DIFF
--- a/docs/connector-development/config-based/connector-builder-ui.md
+++ b/docs/connector-development/config-based/connector-builder-ui.md
@@ -1,6 +1,6 @@
 # Connector Builder UI
 
-The connector builder UI provides an ergonomic iteration interface on top of the [low-code YAML format](./understanding-the-yaml-file/yaml-overview). We recommend using it to iterate on your low-code connectors.
+The connector builder UI provides an ergonomic iteration interface on top of the [low-code YAML format](../understanding-the-yaml-file/yaml-overview). We recommend using it to iterate on your low-code connectors.
 
 :::caution
 The connector builder UI is in alpha, which means it’s still in active development and may include backward-incompatible changes. Share feedback and requests with us on our Slack channel or email us at feedback@airbyte.io

--- a/docs/connector-development/config-based/connector-builder-ui.md
+++ b/docs/connector-development/config-based/connector-builder-ui.md
@@ -1,6 +1,6 @@
 # Connector Builder UI
 
-The connector builder UI provides an ergonomic iteration interface on top of the [low-code YAML format](../understanding-the-yaml-file/yaml-overview). We recommend using it to iterate on your low-code connectors.
+The connector builder UI provides an ergonomic iteration interface on top of the [low-code YAML format](../config-based/understanding-the-yaml-file/yaml-overview). We recommend using it to iterate on your low-code connectors.
 
 :::caution
 The connector builder UI is in alpha, which means it’s still in active development and may include backward-incompatible changes. Share feedback and requests with us on our Slack channel or email us at feedback@airbyte.io


### PR DESCRIPTION
## What
(Hopefully) fix link again.

## How
For some reason, our production `docs.airbyte.com` doesn't seem to like relative links of the form `./<path>`. This works when testing docusaurus locally, but when it is deployed to our docs page, the link behaves incorrectly.

This PR avoids the `./` path completely by walking up one level and then back down to into `/config-based` to get to the right path. This also works locally, and other links using `../` work correctly on docs.airbyte.com, so hopefully this solution will work fine.

