### PR TITLE
Fix connector builder link once more

### DIFF
--- a/docs/connector-development/config-based/connector-builder-ui.md
+++ b/docs/connector-development/config-based/connector-builder-ui.md
@@ -1,6 +1,6 @@
 # Connector Builder UI
 
-The connector builder UI provides an ergonomic iteration interface on top of the [low-code YAML format](../understanding-the-yaml-file/yaml-overview). We recommend using it to iterate on your low-code connectors.
+The connector builder UI provides an ergonomic iteration interface on top of the [low-code YAML format](understanding-the-yaml-file/yaml-overview). We recommend using it to iterate on your low-code connectors.
 
 :::caution
 The connector builder UI is in alpha, which means it’s still in active development and may include backward-incompatible changes. Share feedback and requests with us on our Slack channel or email us at feedback@airbyte.io

--- a/docs/connector-development/config-based/connector-builder-ui.md
+++ b/docs/connector-development/config-based/connector-builder-ui.md
@@ -1,6 +1,6 @@
 # Connector Builder UI
 
-The connector builder UI provides an ergonomic iteration interface on top of the [low-code YAML format](../config-based/understanding-the-yaml-file/yaml-overview). We recommend using it to iterate on your low-code connectors.
+The connector builder UI provides an ergonomic iteration interface on top of the [low-code YAML format](../understanding-the-yaml-file/yaml-overview). We recommend using it to iterate on your low-code connectors.
 
 :::caution
 The connector builder UI is in alpha, which means it’s still in active development and may include backward-incompatible changes. Share feedback and requests with us on our Slack channel or email us at feedback@airbyte.io


### PR DESCRIPTION
## What
The fix I described in https://github.com/airbytehq/airbyte/pull/21441 still did not work once actually deployed to the docs page, even though again it worked locally.

## How
`./understanding-the-yaml-file/yaml-overview` resulted in navigating to `https://docs.airbyte.com/connector-development/config-based/connector-builder-ui/understanding-the-yaml-file/yaml-overview` on docs.airbyte.com, and 
`../config-based/understanding-the-yaml-file/yaml-overview` resulted in navigating to `https://docs.airbyte.com/connector-development/config-based/config-based/understanding-the-yaml-file/yaml-overview` on docs.airbyte.com.

Both of those approaches properly navigated to the desired url of `http://localhost:3000/connector-development/config-based/understanding-the-yaml-file/yaml-overview` when testing locally 🤷 

However, the approach of omitting the `./` and/or `../` completely seems to work for other relative links pointing to similar sibling folders in this readme (e.g. [here](https://github.com/airbytehq/airbyte/blob/e092a4eeabce12b9c67df7483c66f328c98d7463/docs/connector-development/config-based/connector-builder-ui.md?plain=1#L45)), so I am trying that approach here as well. It works locally and the similar link works both locally and on docs.airbyte.com, so I feel fairly confident about this solution.