### PR TITLE
Don't return stacktrace as part of the response

### DIFF
--- a/airbyte-connector-builder-server/connector_builder/impl/default_api.py
+++ b/airbyte-connector-builder-server/connector_builder/impl/default_api.py
@@ -5,14 +5,12 @@
 import json
 import logging
 import traceback
-from airbyte_cdk.models import AirbyteLogMessage, AirbyteMessage, Type
-from airbyte_cdk.utils.schema_inferrer import SchemaInferrer
-from fastapi import Body, HTTPException
 from json import JSONDecodeError
-from jsonschema import ValidationError
 from typing import Any, Callable, Dict, Iterable, Iterator, Optional, Union
 from urllib.parse import parse_qs, urljoin, urlparse
 
+from airbyte_cdk.models import AirbyteLogMessage, AirbyteMessage, Type
+from airbyte_cdk.utils.schema_inferrer import SchemaInferrer
 from connector_builder.generated.apis.default_api_interface import DefaultApi
 from connector_builder.generated.models.http_request import HttpRequest
 from connector_builder.generated.models.http_response import HttpResponse
@@ -24,6 +22,8 @@ from connector_builder.generated.models.streams_list_read import StreamsListRead
 from connector_builder.generated.models.streams_list_read_streams import StreamsListReadStreams
 from connector_builder.generated.models.streams_list_request_body import StreamsListRequestBody
 from connector_builder.impl.adapter import CdkAdapter
+from fastapi import Body, HTTPException
+from jsonschema import ValidationError
 
 
 class DefaultApiImpl(DefaultApi):


### PR DESCRIPTION
## What
* Remove the stacktrace from the connector builder's error response

Before
<img width="1627" alt="Screen Shot 2023-01-13 at 5 27 16 PM" src="https://user-images.githubusercontent.com/1451943/212444810-26febc57-f664-4d33-bad0-fa7bd1500f52.png">

After:
![Screen Shot 2023-01-13 at 5 38 21 PM](https://user-images.githubusercontent.com/1451943/212444781-7db27d4e-e7fd-4c6b-9b0f-82ecf8a66f72.png)

