### PR TITLE
🪟 🐛 Fix duplicate createUser calls on signup

### DIFF
--- a/airbyte-webapp/src/packages/cloud/services/auth/AuthService.tsx
+++ b/airbyte-webapp/src/packages/cloud/services/auth/AuthService.tsx
@@ -1,5 +1,5 @@
 import { User as FirebaseUser } from "firebase/auth";
-import React, { useCallback, useContext, useEffect, useMemo, useRef } from "react";
+import React, { useCallback, useContext, useMemo, useRef } from "react";
 import { useQueryClient } from "react-query";
 import { useEffectOnce } from "react-use";
 import { Observable, Subject } from "rxjs";
@@ -159,23 +159,6 @@ export const AuthenticationProvider: React.FC<React.PropsWithChildren<unknown>> 
       }
     });
   });
-
-  useEffect(() => {
-    const onFocus = async () => {
-      return auth.onAuthStateChanged(async (currentUser) => {
-        if (!currentUser) {
-          loggedOut();
-        } else {
-          await onAfterAuth(currentUser);
-        }
-      });
-    };
-
-    window.addEventListener("focus", onFocus);
-    return () => {
-      window.removeEventListener("focus", onFocus);
-    };
-  }, [auth, loggedOut, onAfterAuth]);
 
   const queryClient = useQueryClient();
 

--- a/airbyte-webapp/src/packages/cloud/services/auth/AuthService.tsx
+++ b/airbyte-webapp/src/packages/cloud/services/auth/AuthService.tsx
@@ -148,10 +148,10 @@ export const AuthenticationProvider: React.FC<React.PropsWithChildren<unknown>> 
   stateRef.current = state;
 
   const onAuthStateChange = useCallback(
-    async (currentUser: FirebaseUser | null) => {
+    (currentUser: FirebaseUser | null) => {
       if (!stateRef.current.inited) {
         if (stateRef.current.currentUser === null && currentUser) {
-          await onAfterAuth(currentUser);
+          onAfterAuth(currentUser);
         } else {
           authInited();
         }
@@ -161,7 +161,7 @@ export const AuthenticationProvider: React.FC<React.PropsWithChildren<unknown>> 
   );
 
   useEffectOnce(() => {
-    return auth.onAuthStateChanged(async (currentUser) => {
+    return auth.onAuthStateChanged((currentUser) => {
       // We want to run this effect only once on initial page opening
       onAuthStateChange(currentUser);
     });

--- a/airbyte-webapp/src/packages/cloud/services/auth/AuthService.tsx
+++ b/airbyte-webapp/src/packages/cloud/services/auth/AuthService.tsx
@@ -169,8 +169,8 @@ export const AuthenticationProvider: React.FC<React.PropsWithChildren<unknown>> 
 
   // Check auth state on window focus, in case the user logged out in a different tab
   useEffect(() => {
-    const onFocus = async () => {
-      return auth.onAuthStateChanged(async (currentUser) => {
+    const onFocus = () => {
+      return auth.onAuthStateChanged((currentUser) => {
         if (!currentUser) {
           loggedOut();
         } else {

--- a/airbyte-webapp/src/packages/cloud/services/auth/AuthService.tsx
+++ b/airbyte-webapp/src/packages/cloud/services/auth/AuthService.tsx
@@ -1,5 +1,5 @@
 import { User as FirebaseUser } from "firebase/auth";
-import React, { useCallback, useContext, useMemo, useRef } from "react";
+import React, { useCallback, useContext, useEffect, useMemo, useRef } from "react";
 import { useQueryClient } from "react-query";
 import { useEffectOnce } from "react-use";
 import { Observable, Subject } from "rxjs";
@@ -147,9 +147,8 @@ export const AuthenticationProvider: React.FC<React.PropsWithChildren<unknown>> 
   const stateRef = useRef(state);
   stateRef.current = state;
 
-  useEffectOnce(() => {
-    return auth.onAuthStateChanged(async (currentUser) => {
-      // We want to run this effect only once on initial page opening
+  const onAuthStateChange = useCallback(
+    async (currentUser) => {
       if (!stateRef.current.inited) {
         if (stateRef.current.currentUser === null && currentUser) {
           await onAfterAuth(currentUser);
@@ -157,8 +156,34 @@ export const AuthenticationProvider: React.FC<React.PropsWithChildren<unknown>> 
           authInited();
         }
       }
+    },
+    [onAfterAuth, authInited]
+  );
+
+  useEffectOnce(() => {
+    return auth.onAuthStateChanged(async (currentUser) => {
+      // We want to run this effect only once on initial page opening
+      onAuthStateChange(currentUser);
     });
   });
+
+  // Check auth state on window focus, in case the user logged out in a different tab
+  useEffect(() => {
+    const onFocus = async () => {
+      return auth.onAuthStateChanged(async (currentUser) => {
+        if (!currentUser) {
+          loggedOut();
+        } else {
+          onAuthStateChange(currentUser);
+        }
+      });
+    };
+
+    window.addEventListener("focus", onFocus);
+    return () => {
+      window.removeEventListener("focus", onFocus);
+    };
+  }, [auth, loggedOut, onAfterAuth, onAuthStateChange]);
 
   const queryClient = useQueryClient();
 

--- a/airbyte-webapp/src/packages/cloud/services/auth/AuthService.tsx
+++ b/airbyte-webapp/src/packages/cloud/services/auth/AuthService.tsx
@@ -148,11 +148,11 @@ export const AuthenticationProvider: React.FC<React.PropsWithChildren<unknown>> 
   stateRef.current = state;
 
   useEffectOnce(() => {
-    return auth.onAuthStateChanged((currentUser) => {
+    return auth.onAuthStateChanged(async (currentUser) => {
       // We want to run this effect only once on initial page opening
       if (!stateRef.current.inited) {
         if (stateRef.current.currentUser === null && currentUser) {
-          onAfterAuth(currentUser);
+          await onAfterAuth(currentUser);
         } else {
           authInited();
         }

--- a/airbyte-webapp/src/packages/cloud/services/auth/AuthService.tsx
+++ b/airbyte-webapp/src/packages/cloud/services/auth/AuthService.tsx
@@ -148,7 +148,7 @@ export const AuthenticationProvider: React.FC<React.PropsWithChildren<unknown>> 
   stateRef.current = state;
 
   const onAuthStateChange = useCallback(
-    async (currentUser) => {
+    async (currentUser: FirebaseUser | null) => {
       if (!stateRef.current.inited) {
         if (stateRef.current.currentUser === null && currentUser) {
           await onAfterAuth(currentUser);


### PR DESCRIPTION
## What
`onAfterAuth()` was being called multiple times. This in turn was causing multiple calls to `web_backend/users/create` with the same user information, which caused many 409s (conflicting user names) and spamming our oncall with failed requests.

## How
Reverts the change introduced in https://github.com/airbytehq/airbyte/pull/21175

## Considerations
The auth service is missing tests, which could help avoid this. The component is complex and depends on many other modules, so testing this is out of scope for this PR.

