### PR TITLE
Source Mongodb: Fix docs highlight the requirement on user access levels

### DIFF
--- a/docs/integrations/sources/mongodb-v2.md
+++ b/docs/integrations/sources/mongodb-v2.md
@@ -52,7 +52,7 @@ use admin;
 db.createUser({user: "READ_ONLY_USER", pwd: "READ_ONLY_PASSWORD", roles: [{role: "read", db: "TARGET_DATABASE"}]})
 ```
 
-Make sure the user have appropriate access levels.
+**Make sure the user have appropriate access levels, a user with higher access levels may throw an exception.**
 
 ### Enable MongoDB authentication
 


### PR DESCRIPTION
## What

I've met some issues with the well-known `system.views` exception error. It ends up it was documented but not clear enough to me that a MongoDB user with higher access levels than `READ_ONLY` could be a problem.

## How

The one I suggest, be more explicit on the requirement.


## 🚨 User Impact 🚨

Less issues on GitHub and Slack for something already fixed.


### Community member or Airbyter

- [X] **Community member?** Grant edit access to maintainers ([instructions](https://docs.github.com/en/github/collaborating-with-pull-requests/working-with-forks/allowing-changes-to-a-pull-request-branch-created-from-a-fork#enabling-repository-maintainer-permissions-on-existing-pull-requests))
- [X] Documentation updated

