### PR TITLE
Updating start-aws-runner-action to fetch the latest AMI

### DIFF
--- a/.github/actions/start-aws-runner/action.yml
+++ b/.github/actions/start-aws-runner/action.yml
@@ -8,7 +8,7 @@ inputs:
   github-token:
     required: true
   ec2-image-id:
-    # https://internal-docs.airbyte.io/Things-To-Know/Build-Runner-Images#ami-017f6fe645968f7e0
+    # https://internal-docs.airbyte.io/Things-To-Know/Build-Runner-Images
     default: "ami-017f6fe645968f7e0"
     required: true
   ec2-instance-type:
@@ -40,13 +40,25 @@ runs:
         aws-access-key-id: ${{ inputs.aws-access-key-id }}
         aws-secret-access-key: ${{ inputs.aws-secret-access-key }}
         aws-region: us-east-2
+
+    - name: Get a latest AMI id
+      id: get-ami-id
+      shell: bash
+      run: |-
+        echo "latest_ami_id=$(aws ec2 describe-images --owners "self" \
+                                                      --region ${{ inputs.aws-region }} \
+                                                      --filters "Name=name,Values=github-runner*" \
+                                                      --filters "Name=state,Values=available" \
+                                                      --query "sort_by(Images, &CreationDate)[-1].ImageId" \
+                                                      --output text)" >> $GITHUB_OUTPUT
+
     - name: Start EC2 runner
       id: start-ec2-runner
       uses: airbytehq/ec2-github-runner@MSGv0.0.2
       with:
         mode: start
         github-token: ${{ inputs.github-token }}
-        ec2-image-id: ${{ inputs.ec2-image-id }}
+        ec2-image-id: ${{ steps.get-ami-id.outputs.latest_ami_id }}
         ec2-instance-type: ${{ inputs.ec2-instance-type }}
         subnet-id: ${{ inputs.subnet-id }}
         security-group-id: ${{ inputs.security-group-id }}

--- a/.github/actions/start-aws-runner/action.yml
+++ b/.github/actions/start-aws-runner/action.yml
@@ -46,7 +46,7 @@ runs:
       shell: bash
       run: |-
         echo "latest_ami_id=$(aws ec2 describe-images --owners "self" \
-                                                      --region ${{ inputs.aws-region }} \
+                                                      --region "us-east-2" \
                                                       --filters "Name=name,Values=github-runner*" \
                                                       --filters "Name=state,Values=available" \
                                                       --query "sort_by(Images, &CreationDate)[-1].ImageId" \


### PR DESCRIPTION
In scope of https://github.com/airbytehq/airbyte-cloud/issues/3612 a new process of AMI building was introduced.
This PR updates `start-aws-runner-action` to fetch the latest freshest AMI in AWS for gh self-hosted runners.