### PR TITLE
turn off HttpAvailabilityStrategy as default (for now)

### DIFF
--- a/airbyte-cdk/python/airbyte_cdk/sources/streams/http/http.py
+++ b/airbyte-cdk/python/airbyte_cdk/sources/streams/http/http.py
@@ -115,10 +115,6 @@ class HttpStream(Stream, ABC):
     def authenticator(self) -> HttpAuthenticator:
         return self._authenticator
 
-    @property
-    def availability_strategy(self) -> Optional[AvailabilityStrategy]:
-        return HttpAvailabilityStrategy()
-
     @abstractmethod
     def next_page_token(self, response: requests.Response) -> Optional[Mapping[str, Any]]:
         """

--- a/airbyte-cdk/python/airbyte_cdk/sources/streams/http/http.py
+++ b/airbyte-cdk/python/airbyte_cdk/sources/streams/http/http.py
@@ -13,9 +13,7 @@ from urllib.parse import urljoin
 import requests
 import requests_cache
 from airbyte_cdk.models import SyncMode
-from airbyte_cdk.sources.streams.availability_strategy import AvailabilityStrategy
 from airbyte_cdk.sources.streams.core import Stream, StreamData
-from airbyte_cdk.sources.streams.http.availability_strategy import HttpAvailabilityStrategy
 from requests.auth import AuthBase
 from requests_cache.session import CachedSession
 

--- a/airbyte-cdk/python/docs/concepts/http-streams.md
+++ b/airbyte-cdk/python/docs/concepts/http-streams.md
@@ -87,8 +87,15 @@ be returned as a keyword argument.
 The CDK defines an `AvailabilityStrategy` for a stream, which is used to perform the `check_availability` method. This method checks whether
 the stream is available before performing `read_records`.
 
-For HTTP streams, a default `HttpAvailabilityStrategy` is defined, which attempts to read the first record of the stream, and excepts
+For HTTP streams, a `HttpAvailabilityStrategy` is defined, which attempts to read the first record of the stream, and excepts
 a dictionary of known error codes and associated reasons, `reasons_for_unavailable_status_codes`. By default, this list contains only
 `requests.status_codes.FORBIDDEN` (403), with an associated error message that tells the user that they are likely missing permissions associated with that stream.
 
-You can override these known errors to except more error codes and inform the user how to resolve errors.
+You can use this `HttpAvailabilityStrategy` in your `HttpStream` by adding the following property to your stream class:
+
+```python
+    def availability_strategy(self) -> Optional[AvailabilityStrategy]:
+        return HttpAvailabilityStrategy()
+```
+
+You can also subclass `HttpAvailabilityStrategy` to override the list of known errors to except more error codes and inform the user how to resolve errors specific to your connector or stream.

--- a/airbyte-cdk/python/unit_tests/sources/declarative/checks/test_check_stream.py
+++ b/airbyte-cdk/python/unit_tests/sources/declarative/checks/test_check_stream.py
@@ -9,6 +9,7 @@ from unittest.mock import MagicMock
 import pytest
 import requests
 from airbyte_cdk.sources.declarative.checks.check_stream import CheckStream
+from airbyte_cdk.sources.streams.availability_strategy import AvailabilityStrategy
 from airbyte_cdk.sources.streams.http import HttpStream
 from airbyte_cdk.sources.streams.http.availability_strategy import HttpAvailabilityStrategy
 

--- a/airbyte-cdk/python/unit_tests/sources/declarative/checks/test_check_stream.py
+++ b/airbyte-cdk/python/unit_tests/sources/declarative/checks/test_check_stream.py
@@ -119,6 +119,11 @@ def test_check_http_stream_via_availability_strategy(mocker, test_name, response
             yield stub_resp
         pass
 
+        # TODO (Ella): Remove explicit definition when turning on default
+        @property
+        def availability_strategy(self) -> Optional["AvailabilityStrategy"]:
+            return HttpAvailabilityStrategy()
+
     http_stream = MockHttpStream()
     assert isinstance(http_stream, HttpStream)
     assert isinstance(http_stream.availability_strategy, HttpAvailabilityStrategy)

--- a/airbyte-cdk/python/unit_tests/sources/streams/http/test_availability_strategy.py
+++ b/airbyte-cdk/python/unit_tests/sources/streams/http/test_availability_strategy.py
@@ -39,6 +39,11 @@ class MockHttpStream(HttpStream):
     def retry_factor(self) -> float:
         return 0.01
 
+    # TODO (Ella): Remove explicit definition when turning on default
+    @property
+    def availability_strategy(self) -> Optional["AvailabilityStrategy"]:
+        return HttpAvailabilityStrategy()
+
 
 def test_default_http_availability_strategy(mocker):
     http_stream = MockHttpStream()

--- a/airbyte-cdk/python/unit_tests/sources/streams/http/test_availability_strategy.py
+++ b/airbyte-cdk/python/unit_tests/sources/streams/http/test_availability_strategy.py
@@ -9,6 +9,7 @@ import pytest
 import requests
 from airbyte_cdk.sources import AbstractSource
 from airbyte_cdk.sources.streams import Stream
+from airbyte_cdk.sources.streams.availability_strategy import AvailabilityStrategy
 from airbyte_cdk.sources.streams.http.availability_strategy import HttpAvailabilityStrategy
 from airbyte_cdk.sources.streams.http.http import HttpStream
 from requests import HTTPError

--- a/airbyte-cdk/python/unit_tests/sources/test_source.py
+++ b/airbyte-cdk/python/unit_tests/sources/test_source.py
@@ -23,6 +23,7 @@ from airbyte_cdk.models import (
     Type,
 )
 from airbyte_cdk.sources import AbstractSource, Source
+from airbyte_cdk.sources.streams.availability_strategy import AvailabilityStrategy
 from airbyte_cdk.sources.streams.core import Stream
 from airbyte_cdk.sources.streams.http.availability_strategy import HttpAvailabilityStrategy
 from airbyte_cdk.sources.streams.http.http import HttpStream

--- a/airbyte-cdk/python/unit_tests/sources/test_source.py
+++ b/airbyte-cdk/python/unit_tests/sources/test_source.py
@@ -491,6 +491,11 @@ def test_read_default_http_availability_strategy_stream_available(catalog, mocke
             HttpStream.__init__(self, *args, kvargs)
             self.read_records = mocker.MagicMock()
 
+        # TODO (Ella): Remove explicit definition when turning on default
+        @property
+        def availability_strategy(self) -> Optional["AvailabilityStrategy"]:
+            return HttpAvailabilityStrategy()
+
     class MockStream(mocker.MagicMock, Stream):
         page_size = None
         get_json_schema = mocker.MagicMock()
@@ -543,6 +548,11 @@ def test_read_default_http_availability_strategy_stream_unavailable(catalog, moc
             stub_response = {"data": self.resp_counter}
             self.resp_counter += 1
             yield stub_response
+
+        # TODO (Ella): Remove explicit definition when turning on default
+        @property
+        def availability_strategy(self) -> Optional["AvailabilityStrategy"]:
+            return HttpAvailabilityStrategy()
 
     class MockStream(mocker.MagicMock, Stream):
         page_size = None


### PR DESCRIPTION
As per the [rollout plan](https://github.com/airbytehq/airbyte/issues/20401#issuecomment-1382373462), we want to start by introducing the HttpAvailabiltyStrategy into the code without it being the default. 

We'll make it default (revert changes from this PR) at the same time as turning it off for GA connectors and problem connectors. 