### PR TITLE
Remove inefficient namespace clone.

### DIFF
--- a/airbyte-commons-worker/src/main/java/io/airbyte/workers/internal/NamespacingMapper.java
+++ b/airbyte-commons-worker/src/main/java/io/airbyte/workers/internal/NamespacingMapper.java
@@ -61,7 +61,6 @@ public class NamespacingMapper implements AirbyteMapper {
   @Override
   public AirbyteMessage mapMessage(final AirbyteMessage message) {
     if (message.getType() == Type.RECORD) {
-      // final AirbyteMessage message = Jsons.clone(inputMessage);
       // Default behavior if namespaceDefinition is not set is to follow SOURCE
       if (namespaceDefinition != null) {
         if (namespaceDefinition.equals(NamespaceDefinitionType.DESTINATION)) {

--- a/airbyte-commons-worker/src/main/java/io/airbyte/workers/internal/NamespacingMapper.java
+++ b/airbyte-commons-worker/src/main/java/io/airbyte/workers/internal/NamespacingMapper.java
@@ -59,9 +59,9 @@ public class NamespacingMapper implements AirbyteMapper {
   }
 
   @Override
-  public AirbyteMessage mapMessage(final AirbyteMessage inputMessage) {
-    if (inputMessage.getType() == Type.RECORD) {
-      final AirbyteMessage message = Jsons.clone(inputMessage);
+  public AirbyteMessage mapMessage(final AirbyteMessage message) {
+    if (message.getType() == Type.RECORD) {
+      // final AirbyteMessage message = Jsons.clone(inputMessage);
       // Default behavior if namespaceDefinition is not set is to follow SOURCE
       if (namespaceDefinition != null) {
         if (namespaceDefinition.equals(NamespaceDefinitionType.DESTINATION)) {
@@ -73,7 +73,7 @@ public class NamespacingMapper implements AirbyteMapper {
       message.getRecord().setStream(transformStreamName(message.getRecord().getStream(), streamPrefix));
       return message;
     }
-    return inputMessage;
+    return message;
   }
 
   private static String formatNamespace(final String sourceNamespace, final String namespaceFormat) {

--- a/airbyte-commons-worker/src/test/java/io/airbyte/workers/internal/NamespacingMapperTest.java
+++ b/airbyte-commons-worker/src/test/java/io/airbyte/workers/internal/NamespacingMapperTest.java
@@ -14,6 +14,7 @@ import io.airbyte.protocol.models.ConfiguredAirbyteCatalog;
 import io.airbyte.protocol.models.Field;
 import io.airbyte.protocol.models.JsonSchemaType;
 import io.airbyte.workers.test_utils.AirbyteMessageUtils;
+import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
 class NamespacingMapperTest {
@@ -28,12 +29,17 @@ class NamespacingMapperTest {
       STREAM_NAME,
       INPUT_NAMESPACE,
       Field.of(FIELD_NAME, JsonSchemaType.STRING));
-  private static final AirbyteMessage RECORD_MESSAGE = createRecordMessage();
+  private AirbyteMessage RECORD_MESSAGE;
 
   private static AirbyteMessage createRecordMessage() {
     final AirbyteMessage message = AirbyteMessageUtils.createRecordMessage(STREAM_NAME, FIELD_NAME, BLUE);
     message.getRecord().withNamespace(INPUT_NAMESPACE);
     return message;
+  }
+
+  @BeforeEach
+  void setUp() {
+    RECORD_MESSAGE = createRecordMessage();
   }
 
   @Test
@@ -51,11 +57,12 @@ class NamespacingMapperTest {
     assertEquals(expectedCatalog, actualCatalog);
 
     final AirbyteMessage originalMessage = Jsons.clone(RECORD_MESSAGE);
+    assertEquals(originalMessage, RECORD_MESSAGE);
+
     final AirbyteMessage expectedMessage = AirbyteMessageUtils.createRecordMessage(OUTPUT_PREFIX + STREAM_NAME, FIELD_NAME, BLUE);
     expectedMessage.getRecord().withNamespace(INPUT_NAMESPACE);
-    final AirbyteMessage actualMessage = mapper.mapMessage(RECORD_MESSAGE);
 
-    assertEquals(originalMessage, RECORD_MESSAGE);
+    final AirbyteMessage actualMessage = mapper.mapMessage(RECORD_MESSAGE);
     assertEquals(expectedMessage, actualMessage);
   }
 
@@ -100,10 +107,10 @@ class NamespacingMapperTest {
     assertEquals(expectedCatalog, actualCatalog);
 
     final AirbyteMessage originalMessage = Jsons.clone(RECORD_MESSAGE);
+    assertEquals(originalMessage, RECORD_MESSAGE);
+
     final AirbyteMessage expectedMessage = AirbyteMessageUtils.createRecordMessage(OUTPUT_PREFIX + STREAM_NAME, FIELD_NAME, BLUE);
     final AirbyteMessage actualMessage = mapper.mapMessage(RECORD_MESSAGE);
-
-    assertEquals(originalMessage, RECORD_MESSAGE);
     assertEquals(expectedMessage, actualMessage);
   }
 
@@ -122,11 +129,11 @@ class NamespacingMapperTest {
     assertEquals(expectedCatalog, actualCatalog);
 
     final AirbyteMessage originalMessage = Jsons.clone(RECORD_MESSAGE);
+    assertEquals(originalMessage, RECORD_MESSAGE);
+
     final AirbyteMessage expectedMessage = AirbyteMessageUtils.createRecordMessage(OUTPUT_PREFIX + STREAM_NAME, FIELD_NAME, BLUE);
     expectedMessage.getRecord().withNamespace(expectedNamespace);
     final AirbyteMessage actualMessage = mapper.mapMessage(RECORD_MESSAGE);
-
-    assertEquals(originalMessage, RECORD_MESSAGE);
     assertEquals(expectedMessage, actualMessage);
   }
 
@@ -145,11 +152,11 @@ class NamespacingMapperTest {
     assertEquals(expectedCatalog, actualCatalog);
 
     final AirbyteMessage originalMessage = Jsons.clone(RECORD_MESSAGE);
+    assertEquals(originalMessage, RECORD_MESSAGE);
+
     final AirbyteMessage expectedMessage = AirbyteMessageUtils.createRecordMessage(OUTPUT_PREFIX + STREAM_NAME, FIELD_NAME, BLUE);
     expectedMessage.getRecord().withNamespace(expectedNamespace);
     final AirbyteMessage actualMessage = mapper.mapMessage(RECORD_MESSAGE);
-
-    assertEquals(originalMessage, RECORD_MESSAGE);
     assertEquals(expectedMessage, actualMessage);
   }
 
@@ -194,13 +201,13 @@ class NamespacingMapperTest {
     assertEquals(expectedCatalog, actualCatalog);
 
     final AirbyteMessage originalMessage = Jsons.clone(RECORD_MESSAGE);
+    assertEquals(originalMessage, RECORD_MESSAGE);
+
     final AirbyteMessage expectedMessage = AirbyteMessageUtils.createRecordMessage(
         STREAM_NAME,
         FIELD_NAME, BLUE);
     expectedMessage.getRecord().withNamespace(INPUT_NAMESPACE);
     final AirbyteMessage actualMessage = mapper.mapMessage(RECORD_MESSAGE);
-
-    assertEquals(originalMessage, RECORD_MESSAGE);
     assertEquals(expectedMessage, actualMessage);
   }
 


### PR DESCRIPTION
## What
Testing shows this is causing ~ 5MB/s of throughput on the platform. This is not needed since we can simply modify the already present Json node instead of a cloned object.

This should help both CPU and GC pressure.

## How
- Remove the clone.
- Adjust test to accommodate the newly removed clone. The test previously had set up that relied on mapper cloning the input to pass.

## Recommended reading order
Both files.

## 🚨 User Impact 🚨
Are there any breaking changes? What is the end result perceived by the user? If yes, please merge this PR with the 🚨🚨 emoji so changelog authors can further highlight this if needed.

## Pre-merge Checklist
Expand the relevant checklist and delete the others.

<details><summary><strong>New Connector</strong></summary>

### Community member or Airbyter

- [ ] **Community member?** Grant edit access to maintainers ([instructions](https://docs.github.com/en/github/collaborating-with-pull-requests/working-with-forks/allowing-changes-to-a-pull-request-branch-created-from-a-fork#enabling-repository-maintainer-permissions-on-existing-pull-requests))
- [ ] Secrets in the connector's spec are annotated with `airbyte_secret`
- [ ] Unit & integration tests added and passing. Community members, please provide proof of success locally e.g: screenshot or copy-paste unit, integration, and acceptance test output. To run acceptance tests for a Python connector, follow instructions in the README. For java connectors run `./gradlew :airbyte-integrations:connectors:<name>:integrationTest`.
- [ ] Code reviews completed
- [ ] Documentation updated
    - [ ] Connector's `README.md`
    - [ ] Connector's `bootstrap.md`. See [description and examples](https://docs.google.com/document/d/1ypdgmwmEHWv-TrO4_YOQ7pAJGVrMp5BOkEVh831N260/edit?usp=sharing)
    - [ ] `docs/integrations/<source or destination>/<name>.md` including changelog. See changelog [example](https://docs.airbyte.io/integrations/sources/stripe#changelog)
    - [ ] `docs/integrations/README.md`
    - [ ] `airbyte-integrations/builds.md`
- [ ] PR name follows [PR naming conventions](https://docs.airbyte.com/contributing-to-airbyte/issues-and-pull-requests)

### Airbyter

If this is a community PR, the Airbyte engineer reviewing this PR is responsible for the below items.

- [ ] Create a non-forked branch based on this PR and test the below items on it
- [ ] Build is successful
- [ ] If new credentials are required for use in CI, add them to GSM. [Instructions](https://docs.airbyte.io/connector-development#using-credentials-in-ci).
- [ ] [`/test connector=connectors/<name>` command](https://docs.airbyte.io/connector-development#updating-an-existing-connector) is passing
- [ ] New Connector version released on Dockerhub by running the `/publish` command described [here](https://docs.airbyte.io/connector-development#updating-an-existing-connector)
- [ ] After the connector is published, connector added to connector index as described [here](https://docs.airbyte.io/connector-development#publishing-a-connector)
- [ ] Seed specs have been re-generated by building the platform and committing the changes to the seed spec files, as described [here](https://docs.airbyte.io/connector-development#publishing-a-connector)

</details>

<details><summary><strong>Updating a connector</strong></summary>

### Community member or Airbyter

- [ ] Grant edit access to maintainers ([instructions](https://docs.github.com/en/github/collaborating-with-pull-requests/working-with-forks/allowing-changes-to-a-pull-request-branch-created-from-a-fork#enabling-repository-maintainer-permissions-on-existing-pull-requests))
- [ ] Secrets in the connector's spec are annotated with `airbyte_secret`
- [ ] Unit & integration tests added and passing. Community members, please provide proof of success locally e.g: screenshot or copy-paste unit, integration, and acceptance test output. To run acceptance tests for a Python connector, follow instructions in the README. For java connectors run `./gradlew :airbyte-integrations:connectors:<name>:integrationTest`.
- [ ] Code reviews completed
- [ ] Documentation updated
    - [ ] Connector's `README.md`
    - [ ] Connector's `bootstrap.md`. See [description and examples](https://docs.google.com/document/d/1ypdgmwmEHWv-TrO4_YOQ7pAJGVrMp5BOkEVh831N260/edit?usp=sharing)
    - [ ] Changelog updated in `docs/integrations/<source or destination>/<name>.md` including changelog. See changelog [example](https://docs.airbyte.io/integrations/sources/stripe#changelog)
- [ ] PR name follows [PR naming conventions](https://docs.airbyte.com/contributing-to-airbyte/issues-and-pull-requests)

### Airbyter

If this is a community PR, the Airbyte engineer reviewing this PR is responsible for the below items.

- [ ] Create a non-forked branch based on this PR and test the below items on it
- [ ] Build is successful
- [ ] If new credentials are required for use in CI, add them to GSM. [Instructions](https://docs.airbyte.io/connector-development#using-credentials-in-ci).
- [ ] [`/test connector=connectors/<name>` command](https://docs.airbyte.io/connector-development#updating-an-existing-connector) is passing
- [ ] New Connector version released on Dockerhub and connector version bumped by running the `/publish` command described [here](https://docs.airbyte.io/connector-development#updating-an-existing-connector)

</details>

<details><summary><strong>Connector Generator</strong></summary>

- [ ] Issue acceptance criteria met
- [ ] PR name follows [PR naming conventions](https://docs.airbyte.com/contributing-to-airbyte/issues-and-pull-requests)
- [ ] If adding a new generator, add it to the [list of scaffold modules being tested](https://github.com/airbytehq/airbyte/blob/master/airbyte-integrations/connector-templates/generator/build.gradle#L41)
- [ ] The generator test modules (all connectors with `-scaffold` in their name) have been updated with the latest scaffold by running `./gradlew :airbyte-integrations:connector-templates:generator:testScaffoldTemplates` then checking in your changes
- [ ] Documentation which references the generator is updated as needed

</details>

## Tests

<details><summary><strong>Unit</strong></summary>

*Put your unit tests output here.*

</details>

<details><summary><strong>Integration</strong></summary>

*Put your integration tests output here.*

</details>

<details><summary><strong>Acceptance</strong></summary>

*Put your acceptance tests output here.*

</details>
