### PR TITLE
Replaced cloud.airbyte.io with cloud.airbyte.com in docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -75,7 +75,7 @@ Deployment options: [Docker](https://docs.airbyte.com/deploying-airbyte/local-de
 
 Airbyte Cloud is the fastest and most reliable way to run Airbyte. You can get started with free credits in minutes.
 
-Sign up for [Airbyte Cloud](https://cloud.airbyte.io/signup).
+Sign up for [Airbyte Cloud](https://cloud.airbyte.com/signup).
 
 ## Contributing
 

--- a/docs/cloud/core-concepts.md
+++ b/docs/cloud/core-concepts.md
@@ -153,7 +153,7 @@ After a sync is complete, Airbyte normalizes the data. When setting up a connect
 
 A workspace is a grouping of sources, destinations, connections, and other configurations. It lets you collaborate with team members and share resources across your team under a shared billing account. 
 
-When you [sign up](http://cloud.airbyte.io/signup) for Airbyte Cloud, we automatically create your first workspace where you are the only user with access. You can set up your sources and destinations to start syncing data and invite other users to join your workspace.
+When you [sign up](http://cloud.airbyte.com/signup) for Airbyte Cloud, we automatically create your first workspace where you are the only user with access. You can set up your sources and destinations to start syncing data and invite other users to join your workspace.
 
 ## Glossary of Terms
 

--- a/docs/cloud/getting-started-with-airbyte-cloud.md
+++ b/docs/cloud/getting-started-with-airbyte-cloud.md
@@ -6,7 +6,7 @@ This page guides you through setting up your Airbyte Cloud account, setting up a
 
 To use Airbyte Cloud:
 
-1. If you haven't already, [sign up for Airbyte Cloud](https://cloud.airbyte.io/signup?utm_campaign=22Q1_AirbyteCloudSignUpCampaign_Trial&utm_source=Docs&utm_content=SetupGuide) using your email address, Google login, or GitHub login.
+1. If you haven't already, [sign up for Airbyte Cloud](https://cloud.airbyte.com/signup?utm_campaign=22Q1_AirbyteCloudSignUpCampaign_Trial&utm_source=Docs&utm_content=SetupGuide) using your email address, Google login, or GitHub login.
 
    Airbyte Cloud offers a 14-day free trial. For more information, see [Pricing](https://airbyte.com/pricing).
 

--- a/docs/cloud/managing-airbyte-cloud.md
+++ b/docs/cloud/managing-airbyte-cloud.md
@@ -14,7 +14,7 @@ Airbyte [credits](https://airbyte.com/pricing) are assigned per workspace and ca
 
 To add a user to your workspace:
 
-1. On the [Airbyte Cloud](http://cloud.airbyte.io) dashboard, click **Settings**.
+1. On the [Airbyte Cloud](http://cloud.airbyte.com) dashboard, click **Settings**.
 
 2. Click **Access Management**.
 
@@ -32,7 +32,7 @@ To add a user to your workspace:
 
 To remove a user from your workspace:
 
-1. On the [Airbyte Cloud](http://cloud.airbyte.io) dashboard, click **Settings**.
+1. On the [Airbyte Cloud](http://cloud.airbyte.com) dashboard, click **Settings**.
 
 2. Click **Access Management**.
 
@@ -44,7 +44,7 @@ To remove a user from your workspace:
 
 To rename a workspace:
 
-1. On the [Airbyte Cloud](http://cloud.airbyte.io) dashboard, click **Settings**.
+1. On the [Airbyte Cloud](http://cloud.airbyte.com) dashboard, click **Settings**.
 
 2. Click **General Settings**.
 
@@ -56,7 +56,7 @@ To rename a workspace:
 
 To delete a workspace:
 
-1. On the [Airbyte Cloud](http://cloud.airbyte.io) dashboard, click **Settings**.
+1. On the [Airbyte Cloud](http://cloud.airbyte.com) dashboard, click **Settings**.
 
 2. Click **General Settings**.
 
@@ -82,7 +82,7 @@ You can use one or multiple workspaces with Airbyte Cloud.
 
 To switch between workspaces:
 
-1. On the [Airbyte Cloud](http://cloud.airbyte.io) dashboard, click the current workspace name under the Airbyte logo in the navigation bar.
+1. On the [Airbyte Cloud](http://cloud.airbyte.com) dashboard, click the current workspace name under the Airbyte logo in the navigation bar.
 
 2. Click **View all workspaces**.
 
@@ -108,7 +108,7 @@ While the data is processed in a data plane in the chosen residency, the cursor 
 
 To choose your default data residency:
 
-1. On the [Airbyte Cloud](http://cloud.airbyte.io) dashboard, click **Settings**.
+1. On the [Airbyte Cloud](http://cloud.airbyte.com) dashboard, click **Settings**.
 
 2. Click **Data Residency**.
 
@@ -126,7 +126,7 @@ Depending on your network configuration, you may need to add [IP addresses](http
 
 To set up Slack notifications:
 
-1. On the [Airbyte Cloud](http://cloud.airbyte.io) dashboard, click **Settings**.
+1. On the [Airbyte Cloud](http://cloud.airbyte.com) dashboard, click **Settings**.
 
 2. Click **Notifications**.
 
@@ -156,7 +156,7 @@ Understanding the following limitations will help you better manage Airbyte Clou
 The sync summary displays information about the data moved during a sync.
  
 To view the sync summary:
-1. On the [Airbyte Cloud](http://cloud.airbyte.io/) dashboard, click **Connections**.   
+1. On the [Airbyte Cloud](http://cloud.airbyte.com/) dashboard, click **Connections**.   
 
 2. Click a connection in the list to view its sync history.
 
@@ -186,7 +186,7 @@ In a successful sync, the number of emitted records and committed records should
 
 ## Edit stream configuration
 
-1. On the [Airbyte Cloud](http://cloud.airbyte.io) dashboard, click **Connections** and then click a connection in the list you want to change.   
+1. On the [Airbyte Cloud](http://cloud.airbyte.com) dashboard, click **Connections** and then click a connection in the list you want to change.   
 
 2. Click the **Replication** tab.
 
@@ -281,7 +281,7 @@ To refresh the source schema:
 
 To display **Connection State**:
 
-1. On the [Airbyte Cloud](http://cloud.airbyte.io) dashboard, click **Settings**.
+1. On the [Airbyte Cloud](http://cloud.airbyte.com) dashboard, click **Settings**.
 
 2. Click **General Settings**.
 
@@ -298,7 +298,7 @@ You can choose the data residency for your connection in the connection settings
 
 To choose the data residency for your connection: 
 
-1. On the [Airbyte Cloud](http://cloud.airbyte.io) dashboard, click **Connections** and then click the connection that you want to change. 
+1. On the [Airbyte Cloud](http://cloud.airbyte.com) dashboard, click **Connections** and then click the connection that you want to change. 
 
 2. Click the **Settings** tab. 
 
@@ -318,7 +318,7 @@ This section guides you through purchasing credits on Airbyte Cloud. An Airbyte 
 
  To buy credits:
 
-1. On the [Airbyte Cloud](http://cloud.airbyte.io) dashboard, click the **coin** icon in the navigation bar.
+1. On the [Airbyte Cloud](http://cloud.airbyte.com) dashboard, click the **coin** icon in the navigation bar.
 
 2. If you are unsure of how many credits you need, click **Talk to Sales** to find the right amount for your team.
 

--- a/docs/integrations/destinations/bigquery.md
+++ b/docs/integrations/destinations/bigquery.md
@@ -44,7 +44,7 @@ You can use BigQuery's [`INSERT`](https://cloud.google.com/bigquery/docs/referen
 
 ### Step 2: Set up the BigQuery connector
 
-1. Log into your [Airbyte Cloud](https://cloud.airbyte.io/workspaces) or Airbyte Open Source account.
+1. Log into your [Airbyte Cloud](https://cloud.airbyte.com/workspaces) or Airbyte Open Source account.
 2. Click **Destinations** and then click **+ New destination**.
 3. On the Set up the destination page, select **BigQuery** or **BigQuery (denormalized typed struct)** from the **Destination type** dropdown depending on whether you want to set up the connector in [BigQuery](#connector-modes) or [BigQuery (Denormalized)](#connector-modes) mode.
 4. Enter the name for the BigQuery connector.

--- a/docs/integrations/destinations/google-sheets.md
+++ b/docs/integrations/destinations/google-sheets.md
@@ -28,7 +28,7 @@ Visit the [Google Support](https://support.google.com/accounts/answer/27441?hl=e
 
 **For Airbyte Cloud:**
 
-1. [Log into your Airbyte Cloud](https://cloud.airbyte.io/workspaces) account.
+1. [Log into your Airbyte Cloud](https://cloud.airbyte.com/workspaces) account.
 2. In the left navigation bar, click **Destinations**. In the top-right corner, click **+ new destination**.
 3. On the source setup page, select **Google Sheets** from the Source type dropdown and enter a name for this connector.
 4. Select `Sign in with Google`.

--- a/docs/integrations/destinations/postgres.md
+++ b/docs/integrations/destinations/postgres.md
@@ -84,7 +84,7 @@ characters.
 
 **For Airbyte Cloud:**
 
-1. [Log into your Airbyte Cloud](https://cloud.airbyte.io/workspaces) account.
+1. [Log into your Airbyte Cloud](https://cloud.airbyte.com/workspaces) account.
 2. In the left navigation bar, click **Destinations**. In the top-right corner, click **new destination**.
 3. On the Set up the destination page, enter the name for the Postgres connector
    and select **Postgres** from the Destination type dropdown.

--- a/docs/integrations/destinations/r2.md
+++ b/docs/integrations/destinations/r2.md
@@ -26,7 +26,7 @@ to create an S3 bucket, or you can create bucket via R2 module of [dashboard](ht
 
 **For Airbyte Cloud:**
 
-1. [Log into your Airbyte Cloud](https://cloud.airbyte.io/workspaces) account.
+1. [Log into your Airbyte Cloud](https://cloud.airbyte.com/workspaces) account.
 2. In the left navigation bar, click **Destinations**. In the top-right corner, click **+ new destination**.
 3. On the destination setup page, select **R2** from the Destination type dropdown and enter a name for this connector.
 4. Configure fields:

--- a/docs/integrations/destinations/redshift.md
+++ b/docs/integrations/destinations/redshift.md
@@ -60,7 +60,7 @@ Optional parameters:
 
 **For Airbyte Cloud:**
 
-1. [Log into your Airbyte Cloud](https://cloud.airbyte.io/workspaces) account.
+1. [Log into your Airbyte Cloud](https://cloud.airbyte.com/workspaces) account.
 2. In the left navigation bar, click **Destinations**. In the top-right corner, click **+ new destination**.
 3. On the destination setup page, select **Redshift** from the Destination type dropdown and enter a name for this connector.
 4. Fill in all the required fields to use the INSERT or COPY strategy

--- a/docs/integrations/destinations/s3-glue.md
+++ b/docs/integrations/destinations/s3-glue.md
@@ -39,7 +39,7 @@ Prepare the Glue database that will be used as destination, see [this](https://d
 
 **For Airbyte Cloud:**
 
-1. [Log into your Airbyte Cloud](https://cloud.airbyte.io/workspaces) account.
+1. [Log into your Airbyte Cloud](https://cloud.airbyte.com/workspaces) account.
 2. In the left navigation bar, click **Destinations**. In the top-right corner, click **+ new destination**.
 3. On the destination setup page, select **S3** from the Destination type dropdown and enter a name for this connector.
 4. Configure fields:

--- a/docs/integrations/destinations/s3.md
+++ b/docs/integrations/destinations/s3.md
@@ -32,7 +32,7 @@ NOTE: If the S3 cluster is not configured to use TLS, the connection to Amazon S
 <!-- env:cloud -->
 **For Airbyte Cloud:**
 
-1. [Log into your Airbyte Cloud](https://cloud.airbyte.io/workspaces) account.
+1. [Log into your Airbyte Cloud](https://cloud.airbyte.com/workspaces) account.
 2. In the left navigation bar, click **Destinations**. In the top-right corner, click **+ new destination**.
 3. On the destination setup page, select **S3** from the Destination type dropdown and enter a name for this connector.
 4. Configure fields:

--- a/docs/integrations/sources/airtable.md
+++ b/docs/integrations/sources/airtable.md
@@ -13,7 +13,7 @@ This source syncs data from the [Airtable API](https://airtable.com/api).
 
 ### For Airbyte Cloud:
 
-1. [Log into your Airbyte Cloud](https://cloud.airbyte.io/workspaces) account.
+1. [Log into your Airbyte Cloud](https://cloud.airbyte.com/workspaces) account.
 2. In the left navigation bar, click **Sources**. In the top-right corner, click **+new source**.
 3. On the Set up the source page, enter the name for the Airtable connector and select **Airtable** from the Source type dropdown.
 4. Enter your `API Key` obtained by following [these steps](https://airtable.com/developers/web/guides/personal-access-tokens)

--- a/docs/integrations/sources/alloydb.md
+++ b/docs/integrations/sources/alloydb.md
@@ -86,7 +86,7 @@ This issue is tracked in [#9771](https://github.com/airbytehq/airbyte/issues/977
 
 ### Step 2: Set up the AlloyDB connector in Airbyte
 
-1. Log into your [Airbyte Cloud](https://cloud.airbyte.io/workspaces) or Airbyte Open Source account.
+1. Log into your [Airbyte Cloud](https://cloud.airbyte.com/workspaces) or Airbyte Open Source account.
 2. Click **Sources** and then click **+ New source**.
 3. On the Set up the source page, select **AlloyDB** from the Source type dropdown.
 4. Enter a name for your source.

--- a/docs/integrations/sources/amazon-ads.md
+++ b/docs/integrations/sources/amazon-ads.md
@@ -24,7 +24,7 @@ To use the [Amazon Ads API](https://advertising.amazon.com/API/docs/en-us), you 
 <!-- env:cloud -->
 **For Airbyte Cloud:**
 
-1. [Log into your Airbyte Cloud](https://cloud.airbyte.io/workspaces) account.
+1. [Log into your Airbyte Cloud](https://cloud.airbyte.com/workspaces) account.
 2. In the left navigation bar, click **Sources**. In the top-right corner, click **+ new source**.
 3. On the source setup page, select **Amazon Ads** from the Source type dropdown and enter a name for this connector.
 4. Click `Authenticate your Amazon Ads account`.

--- a/docs/integrations/sources/amazon-seller-partner.md
+++ b/docs/integrations/sources/amazon-seller-partner.md
@@ -30,7 +30,7 @@ Authenticating this Alpha connector is currently blocked. This is a known issue 
 
 **For Airbyte Cloud:**
 
-1. [Log into your Airbyte Cloud](https://cloud.airbyte.io/workspaces) account. 
+1. [Log into your Airbyte Cloud](https://cloud.airbyte.com/workspaces) account. 
 2. In the left navigation bar, click **Sources**. In the top-right corner, click **+ new source**. 
 3. On the source setup page, select **Amazon Seller Partner** from the Source type dropdown and enter a name for this connector.
 4. Click `Authenticate your account`.

--- a/docs/integrations/sources/amplitude.md
+++ b/docs/integrations/sources/amplitude.md
@@ -8,7 +8,7 @@ To set up the Amplitude source connector, you'll need your Amplitude [`API Key` 
 
 ## Set up the Amplitude source connector
 
-1. Log into your [Airbyte Cloud](https://cloud.airbyte.io/workspaces) or Airbyte Open Source account.
+1. Log into your [Airbyte Cloud](https://cloud.airbyte.com/workspaces) or Airbyte Open Source account.
 2. Click **Sources** and then click **+ New source**. 
 3. On the Set up the source page, select **Amplitude** from the Source type dropdown.
 4. Enter a name for your source.

--- a/docs/integrations/sources/appfollow.md
+++ b/docs/integrations/sources/appfollow.md
@@ -8,7 +8,7 @@ To set up the Appfollow source connector, you'll need your Appfollow `ext_id`, `
 
 ## Set up the Appfollow source connector
 
-1. Log into your [Airbyte Cloud](https://cloud.airbyte.io/workspaces) or Airbyte Open Source account.
+1. Log into your [Airbyte Cloud](https://cloud.airbyte.com/workspaces) or Airbyte Open Source account.
 2. Click **Sources** and then click **+ New source**.
 3. On the Set up the source page, select **Appfollow** from the Source type dropdown.
 4. Enter a name for your source.

--- a/docs/integrations/sources/asana.md
+++ b/docs/integrations/sources/asana.md
@@ -11,7 +11,7 @@ Please follow these [steps](https://developers.asana.com/docs/personal-access-to
 
 ### For Airbyte Cloud:
 
-1. [Log into your Airbyte Cloud](https://cloud.airbyte.io/workspaces) account.
+1. [Log into your Airbyte Cloud](https://cloud.airbyte.com/workspaces) account.
 2. In the left navigation bar, click **Sources**. In the top-right corner, click **+new source**.
 3. On the Set up the source page, enter the name for the Asana connector and select **Asana** from the Source type dropdown.
 4. Select `Authenticate your account`.

--- a/docs/integrations/sources/bamboo-hr.md
+++ b/docs/integrations/sources/bamboo-hr.md
@@ -44,7 +44,7 @@ This page contains the setup guide and reference information for the Bamboo HR s
 
 ### For Airbyte Cloud:
 
-1. [Log into your Airbyte Cloud](https://cloud.airbyte.io/workspaces) account.
+1. [Log into your Airbyte Cloud](https://cloud.airbyte.com/workspaces) account.
 2. In the left navigation bar, click **Sources**. In the top-right corner, click **+new source**.
 3. On the Set up the source page, enter the name for the Bamboo HR connector and select **Bamboo HR** from the Source type dropdown.
 3. Enter your `subdomain`

--- a/docs/integrations/sources/bing-ads.md
+++ b/docs/integrations/sources/bing-ads.md
@@ -26,7 +26,7 @@ The tenant is used in the authentication URL, for example: `https://login.micros
 
 <!-- env:cloud -->
 **For Airbyte Cloud:**
-1. Log in to your [Airbyte Cloud](https://cloud.airbyte.io/workspaces) account.
+1. Log in to your [Airbyte Cloud](https://cloud.airbyte.com/workspaces) account.
 2. Click **Sources** and then click **+ New source**.
 3. On the Set up the source page, select **Bing Ads** from the **Source type** dropdown.
 4. Enter a name for your source.

--- a/docs/integrations/sources/braze.md
+++ b/docs/integrations/sources/braze.md
@@ -12,7 +12,7 @@ It is required to have an account on Braze to provide us with `URL` and `Rest AP
 
 ### For Airbyte Cloud:
 
-1. [Log into your Airbyte Cloud](https://cloud.airbyte.io/workspaces) account.
+1. [Log into your Airbyte Cloud](https://cloud.airbyte.com/workspaces) account.
 2. In the left navigation bar, click **Sources**. In the top-right corner, click **+new source**.
 3. On the Set up the source page, enter the name for the Braze connector and select **Braze** from the Source type dropdown.
 4. Fill in your `URL`, `Rest API Key` and `Start date` and then click **Set up source**.

--- a/docs/integrations/sources/chargebee.md
+++ b/docs/integrations/sources/chargebee.md
@@ -8,7 +8,7 @@ To set up the Chargebee source connector, you'll need the [Chargebee API key](ht
 
 ## Set up the Chargebee connector in Airbyte
 
-1. [Log into your Airbyte Cloud](https://cloud.airbyte.io/workspaces) account or navigate to the Airbyte Open Source dashboard.
+1. [Log into your Airbyte Cloud](https://cloud.airbyte.com/workspaces) account or navigate to the Airbyte Open Source dashboard.
 2. Click **Sources** and then click **+ New source**.
 3. On the Set up the source page, select **Chargebee** from the Source type dropdown.
 4. Enter the name for the Chargebee connector.

--- a/docs/integrations/sources/chartmogul.md
+++ b/docs/integrations/sources/chartmogul.md
@@ -14,7 +14,7 @@ This page contains the setup guide and reference information for the Chartmogul 
 ### Step 2: Set up the Chartmogul connector in Airbyte
 **For Airbyte Cloud:**
 
-1. [Log into your Airbyte Cloud](https://cloud.airbyte.io/workspaces) account.
+1. [Log into your Airbyte Cloud](https://cloud.airbyte.com/workspaces) account.
 2. In the left navigation bar, click **Sources**. In the top-right corner, click **+ new source**.
 3. On the source setup page, select **Chartmogul** from the Source type dropdown and enter a name for this connector.
 4. Enter the **API key** that you obtained.

--- a/docs/integrations/sources/close-com.md
+++ b/docs/integrations/sources/close-com.md
@@ -12,7 +12,7 @@ We recommend creating a restricted key specifically for Airbyte access. This wil
 
 ## Setup guide
 
-1. [Log into your Airbyte Cloud](https://cloud.airbyte.io/workspaces) account.
+1. [Log into your Airbyte Cloud](https://cloud.airbyte.com/workspaces) account.
 2. In the left navigation bar, click **Sources**. In the top-right corner, click **+new source**.
 3. On the Set up the source page, enter the name for the Close.com connector and select **Close.com** from the Source type dropdown.
 4. Fill in the API Key and Start date fields and click **Set up source**.

--- a/docs/integrations/sources/coda.md
+++ b/docs/integrations/sources/coda.md
@@ -12,7 +12,7 @@ You can find or create authentication tokens within [Coda](https://coda.io/accou
 
 ### For Airbyte Cloud:
 
-1. [Log into your Airbyte Cloud](https://cloud.airbyte.io/workspaces) account.
+1. [Log into your Airbyte Cloud](https://cloud.airbyte.com/workspaces) account.
 2. In the left navigation bar, click **Sources**. In the top-right corner, click **+new source**.
 3. On the Set up the source page, enter the name for the Coda connector and select **Coda** from the Source type dropdown.
 4. Enter your `auth_token` - Coda Authentication Token with the necessary permissions \(described below\).

--- a/docs/integrations/sources/commcare.md
+++ b/docs/integrations/sources/commcare.md
@@ -10,7 +10,7 @@ This page guides you through the process of setting up the Commcare source conne
 
 ## Set up the Commcare source connector
 
-1. Log into your [Airbyte Cloud](https://cloud.airbyte.io/workspaces) or Airbyte Open Source account.
+1. Log into your [Airbyte Cloud](https://cloud.airbyte.com/workspaces) or Airbyte Open Source account.
 2. Click **Sources** and then click **+ New source**.
 3. On the Set up the source page, select **Commcare** from the Source type dropdown.
 4. Enter a name for your source.

--- a/docs/integrations/sources/courier.md
+++ b/docs/integrations/sources/courier.md
@@ -17,7 +17,7 @@ Generate an API key per the [Courier documentation](https://www.courier.com/docs
 
 ### For Airbyte Cloud:
 
-1. [Log into your Airbyte Cloud](https://cloud.airbyte.io/workspaces) account.
+1. [Log into your Airbyte Cloud](https://cloud.airbyte.com/workspaces) account.
 2. In the left navigation bar, click **Sources**. In the top-right corner, click **+new source**.
 3. On the Set up the source page, enter the name for the Courier connector and select **Courier** from the Source type dropdown.
 4. Enter your `api_key`.

--- a/docs/integrations/sources/datadog.md
+++ b/docs/integrations/sources/datadog.md
@@ -12,7 +12,7 @@ An API key is required as well as an API application key. See the [Datadog API a
 
 ### For Airbyte Cloud:
 
-1. [Log into your Airbyte Cloud](https://cloud.airbyte.io/workspaces) account.
+1. [Log into your Airbyte Cloud](https://cloud.airbyte.com/workspaces) account.
 2. In the left navigation bar, click **Sources**. In the top-right corner, click **+new source**.
 3. On the Set up the source page, enter the name for the Datadog connector and select **Datadog** from the Source type dropdown.
 4. Enter your `api_key` - Datadog API key.

--- a/docs/integrations/sources/datascope.md
+++ b/docs/integrations/sources/datascope.md
@@ -18,7 +18,7 @@ A DataScope account with access to the API. You can create a free account [here]
 
 ### For Airbyte Cloud:
 
-1. [Log into your Airbyte Cloud](https://cloud.airbyte.io/workspaces) account.
+1. [Log into your Airbyte Cloud](https://cloud.airbyte.com/workspaces) account.
 2. In the left navigation bar, click **Sources**. In the top-right corner, click **+new source**.
 3. On the Set up the source page, enter the name for the DataScope connector and select **DataScope** from the Source type dropdown.
 4. Enter your `api_key`.

--- a/docs/integrations/sources/delighted.md
+++ b/docs/integrations/sources/delighted.md
@@ -8,7 +8,7 @@ To set up the Delighted source connector, you'll need the [Delighted API key](ht
 
 ## Set up the Delighted connector in Airbyte
 
-1. [Log into your Airbyte Cloud](https://cloud.airbyte.io/workspaces) account.
+1. [Log into your Airbyte Cloud](https://cloud.airbyte.com/workspaces) account.
 2. Click **Sources** and then click **+ New source**.
 3. On the Set up the source page, enter the name for the Delighted connector and select **Delighted** from the Source type dropdown.
 4. For **Since**, enter the date in a Unix Timestamp format. The data added on and after this date will be replicated.

--- a/docs/integrations/sources/facebook-marketing.md
+++ b/docs/integrations/sources/facebook-marketing.md
@@ -16,7 +16,7 @@ This page guides you through the process of setting up the Facebook Marketing so
 
 To set up Facebook Marketing as a source in Airbyte Cloud:
 
-1. [Log into your Airbyte Cloud](https://cloud.airbyte.io/workspaces) account.
+1. [Log into your Airbyte Cloud](https://cloud.airbyte.com/workspaces) account.
 2. In the left navigation bar, click **Sources**. In the top-right corner, click **+ New source**.
 3. On the Set up the source page, select **Facebook Marketing** from the **Source type** dropdown.
 4. For Name, enter a name for the Facebook Marketing connector.

--- a/docs/integrations/sources/facebook-pages.md
+++ b/docs/integrations/sources/facebook-pages.md
@@ -30,7 +30,7 @@ After all the steps, it should look something like this
 
 ### For Airbyte Cloud:
 
-1. [Log into your Airbyte Cloud](https://cloud.airbyte.io/workspaces) account.
+1. [Log into your Airbyte Cloud](https://cloud.airbyte.com/workspaces) account.
 2. In the left navigation bar, click **Sources**. In the top-right corner, click **+ New source**.
 3. On the Set up the source page, enter the name for the Facebook Pages connector and select **Facebook Pages** from the Source type dropdown.
 4. Fill in Page Access Token with Long-Lived Page Token

--- a/docs/integrations/sources/fastbill.md
+++ b/docs/integrations/sources/fastbill.md
@@ -14,7 +14,7 @@ You can find your Project ID and find or create an API key within [Fastbill](htt
 
 ### For Airbyte Cloud:
 
-1. [Log into your Airbyte Cloud](https://cloud.airbyte.io/workspaces) account.
+1. [Log into your Airbyte Cloud](https://cloud.airbyte.com/workspaces) account.
 2. In the left navigation bar, click **Sources**. In the top-right corner, click **+new source**.
 3. On the Set up the source page, enter the name for the Fastbill connector and select **Fastbill** from the Source type dropdown.
 4. Enter your `username` - Fastbill username/email.

--- a/docs/integrations/sources/freshdesk.md
+++ b/docs/integrations/sources/freshdesk.md
@@ -8,7 +8,7 @@ To set up the Freshdesk source connector, you'll need the Freshdesk [domain URL]
 
 ## Set up the Freshdesk connector in Airbyte
 
-1. [Log into your Airbyte Cloud](https://cloud.airbyte.io/workspaces) account or navigate to the Airbyte Open Source dashboard.
+1. [Log into your Airbyte Cloud](https://cloud.airbyte.com/workspaces) account or navigate to the Airbyte Open Source dashboard.
 2. Click **Sources** and then click **+ New source**.
 3. On the Set up the source page, select **Freshdesk** from the Source type dropdown.
 4. Enter the name for the Freshdesk connector.

--- a/docs/integrations/sources/github.md
+++ b/docs/integrations/sources/github.md
@@ -39,7 +39,7 @@ Log into [GitHub](https://github.com) and then generate a [personal access token
 
 **For Airbyte Cloud:**
 
-1. [Log into your Airbyte Cloud](https://cloud.airbyte.io/workspaces) account.
+1. [Log into your Airbyte Cloud](https://cloud.airbyte.com/workspaces) account.
 2. In the left navigation bar, click **Sources**. In the top-right corner, click **+ new source**.
 3. On the source setup page, select **GitHub** from the Source type dropdown and enter a name for this connector.
 4. Click `Authenticate your GitHub account` by selecting Oauth or Personal Access Token for Authentication.

--- a/docs/integrations/sources/gitlab.md
+++ b/docs/integrations/sources/gitlab.md
@@ -39,7 +39,7 @@ Log into [GitLab](https://gitlab.com) and then generate a [personal access token
 
 **For Airbyte Cloud:**
 
-1. [Log into your Airbyte Cloud](https://cloud.airbyte.io/workspaces) account.
+1. [Log into your Airbyte Cloud](https://cloud.airbyte.com/workspaces) account.
 2. In the left navigation bar, click **Sources**. In the top-right corner, click **+ new source**.
 3. On the source setup page, select **GitLab** from the Source type dropdown and enter a name for this connector.
 4. Click `Authenticate your GitLab account` by selecting Oauth or Personal Access Token for Authentication.

--- a/docs/integrations/sources/google-ads.md
+++ b/docs/integrations/sources/google-ads.md
@@ -35,7 +35,7 @@ When you apply for a token, make sure to mention:
 
 To set up Google Ads as a source in Airbyte Cloud:
 
-1. [Log into your Airbyte Cloud](https://cloud.airbyte.io/workspaces) account.
+1. [Log into your Airbyte Cloud](https://cloud.airbyte.com/workspaces) account.
 2. Click **Sources** and then click **+ New source**.
 3. On the Set up the source page, select **Google Ads** from the Source type dropdown.
 4. Enter a **Name** for your source.

--- a/docs/integrations/sources/google-analytics-universal-analytics.md
+++ b/docs/integrations/sources/google-analytics-universal-analytics.md
@@ -11,7 +11,7 @@ This connector supports Universal Analytics properties through the [Reporting AP
 
 To set up Google Analytics as a source in Airbyte Cloud:
 
-1. [Log into your Airbyte Cloud](https://cloud.airbyte.io/workspaces) account.
+1. [Log into your Airbyte Cloud](https://cloud.airbyte.com/workspaces) account.
 2. In the left navigation bar, click **Sources**. In the top-right corner, click **+ New source**.
 3. On the Set up the source page, select **Google Analytics** from the **Source type** dropdown.
 4. For Name, enter a name for the Google Analytics connector.

--- a/docs/integrations/sources/google-analytics-v4.md
+++ b/docs/integrations/sources/google-analytics-v4.md
@@ -41,7 +41,7 @@ To determine a Google Analytics 4 [Property ID](https://developers.google.com/an
 
 **For Airbyte Cloud:**
 
-1. [Login to your Airbyte Cloud](https://cloud.airbyte.io/workspaces) account.
+1. [Login to your Airbyte Cloud](https://cloud.airbyte.com/workspaces) account.
 2. In the left navigation bar, click **Sources**. In the top-right corner, click **+ new source**.
 3. On the source setup page, select **Google Analytics 4 (GA4)** from the Source type dropdown and enter a name for this connector.
 4. Click `Authenticate your account` by selecting Oauth or Service Account for Authentication.

--- a/docs/integrations/sources/google-pagespeed-insights.md
+++ b/docs/integrations/sources/google-pagespeed-insights.md
@@ -9,7 +9,7 @@ This page guides you through the process of setting up the Google PageSpeed Insi
 
 ## Set up the Google PageSpeed Insights source connector
 
-1. Log into your [Airbyte Cloud](https://cloud.airbyte.io/workspaces) or Airbyte Open Source account.
+1. Log into your [Airbyte Cloud](https://cloud.airbyte.com/workspaces) or Airbyte Open Source account.
 2. Click **Sources** and then click **+ New source**.
 3. On the Set up the source page, select **Google PageSpeed Insights** from the Source type dropdown.
 4. Enter a name for your source.

--- a/docs/integrations/sources/google-search-console.md
+++ b/docs/integrations/sources/google-search-console.md
@@ -67,7 +67,7 @@ At the end of this process, you should have JSON credentials to this Google Serv
 <!-- env:cloud -->
 **For Airbyte Cloud:**
 
-1. [Log into your Airbyte Cloud](https://cloud.airbyte.io/workspaces) account.
+1. [Log into your Airbyte Cloud](https://cloud.airbyte.com/workspaces) account.
 2. In the left navigation bar, click **Sources**. In the top-right corner, click **+new source**.
 3. On the Set up the source page, enter the name for the google search console connector and select **google search console** from the Source type dropdown.
 4. Click Authenticate your account to sign in with Google and authorize your account.

--- a/docs/integrations/sources/google-sheets.md
+++ b/docs/integrations/sources/google-sheets.md
@@ -13,7 +13,7 @@ The Google Sheets source connector pulls data from a single Google Sheets spread
 
 To set up Google Sheets as a source in Airbyte Cloud:
 
-1. [Log into your Airbyte Cloud](https://cloud.airbyte.io/workspaces) account.
+1. [Log into your Airbyte Cloud](https://cloud.airbyte.com/workspaces) account.
 2. In the left navigation bar, click **Sources**. In the top-right corner, click **+ New source**.
 3. On the Set up the source page, select **Google Sheets** from the **Source type** dropdown.
 4. Enter a name for the Google Sheets connector.

--- a/docs/integrations/sources/google-webfonts.md
+++ b/docs/integrations/sources/google-webfonts.md
@@ -22,7 +22,7 @@ Just pass the generated API key and optional parameters for establishing the con
 
 ### For Airbyte Cloud:
 
-1. [Log into your Airbyte Cloud](https://cloud.airbyte.io/workspaces) account.
+1. [Log into your Airbyte Cloud](https://cloud.airbyte.com/workspaces) account.
 2. In the left navigation bar, click **Sources**. In the top-right corner, click **+new source**.
 3. On the Set up the source page, enter the name for the Google-webfonts connector and select **Google-webfonts** from the Source type dropdown.
 4. Enter your `api_key`.

--- a/docs/integrations/sources/greenhouse.md
+++ b/docs/integrations/sources/greenhouse.md
@@ -8,7 +8,7 @@ To set up the Greenhouse source connector, you'll need the [Harvest API key](htt
 
 ## Set up the Greenhouse connector in Airbyte
 
-1. [Log into your Airbyte Cloud](https://cloud.airbyte.io/workspaces) account or navigate to the Airbyte Open Source dashboard.
+1. [Log into your Airbyte Cloud](https://cloud.airbyte.com/workspaces) account or navigate to the Airbyte Open Source dashboard.
 2. Click **Sources** and then click **+ New source**.
 3. On the Set up the source page, select **Greenhouse** from the Source type dropdown.
 4. Enter the name for the Greenhouse connector.

--- a/docs/integrations/sources/gutendex.md
+++ b/docs/integrations/sources/gutendex.md
@@ -53,7 +53,7 @@ The source is capable of syncing the results stream.
 
 ### For Airbyte Cloud:
 
-1. [Log into your Airbyte Cloud](https://cloud.airbyte.io/workspaces) account.
+1. [Log into your Airbyte Cloud](https://cloud.airbyte.com/workspaces) account.
 2. In the left navigation bar, click **Sources**. In the top-right corner, click **+new source**.
 3. On the Set up the source page, select **Gutendex** from the Source type dropdown.
 4. Click **Set up source**.

--- a/docs/integrations/sources/harvest.md
+++ b/docs/integrations/sources/harvest.md
@@ -11,7 +11,7 @@ To set up the Harvest source connector, you'll need the [Harvest Account ID and 
 <!-- env:cloud -->
 **For Airbyte Cloud:**
 
-1. [Log into your Airbyte Cloud](https://cloud.airbyte.io/workspaces).
+1. [Log into your Airbyte Cloud](https://cloud.airbyte.com/workspaces).
 2. Click **Sources** and then click **+ New source**.
 3. On the Set up the source page, select **Harvest** from the Source type dropdown.
 4. Enter the name for the Harvest connector.

--- a/docs/integrations/sources/hubspot.md
+++ b/docs/integrations/sources/hubspot.md
@@ -31,7 +31,7 @@ You can use OAuth, API key, or Private App to authenticate your HubSpot account.
 
 ## Set up the HubSpot source connector
 
-1. Log into your [Airbyte Cloud](https://cloud.airbyte.io/workspaces) or Airbyte Open Source account.
+1. Log into your [Airbyte Cloud](https://cloud.airbyte.com/workspaces) or Airbyte Open Source account.
 2. Click **Sources** and then click **+ New source**. 
 3. On the Set up the source page, select **HubSpot** from the Source type dropdown.
 4. Enter a name for your source.

--- a/docs/integrations/sources/insightly.md
+++ b/docs/integrations/sources/insightly.md
@@ -4,7 +4,7 @@ This page guides you through the process of setting up the Insightly source conn
 
 ## Set up the Insightly connector
 
-1. Log into your [Airbyte Cloud](https://cloud.airbyte.io/workspaces) or Airbyte Open Source account.
+1. Log into your [Airbyte Cloud](https://cloud.airbyte.com/workspaces) or Airbyte Open Source account.
 2. Click **Sources** and then click **+ New source**.
 3. On the Set up the source page, select **Insightly** from the Source type dropdown.
 4. Enter a name for your source.

--- a/docs/integrations/sources/instagram.md
+++ b/docs/integrations/sources/instagram.md
@@ -25,7 +25,7 @@ Generate access tokens with the following permissions:
 <!-- env:cloud -->
 **For Airbyte Cloud:**
 
-1. Log in to your [Airbyte Cloud](https://cloud.airbyte.io/workspaces) account.
+1. Log in to your [Airbyte Cloud](https://cloud.airbyte.com/workspaces) account.
 2. Click **Sources** and then click **+ New source**.
 3. On the Set up the source page, select **Instagram** from the **Source type** dropdown.
 4. Enter a name for your source.

--- a/docs/integrations/sources/intercom.md
+++ b/docs/integrations/sources/intercom.md
@@ -4,7 +4,7 @@ This page guides you through the process of setting up the Intercom source conne
 
 ## Set up the Intercom connector 
 
-1. Log into your [Airbyte Cloud](https://cloud.airbyte.io/workspaces) or Airbyte Open Source account.
+1. Log into your [Airbyte Cloud](https://cloud.airbyte.com/workspaces) or Airbyte Open Source account.
 2. Click **Sources** and then click **+ New source**. 
 3. On the Set up the source page, select **Intercom** from the Source type dropdown.
 4. Enter a name for your source.

--- a/docs/integrations/sources/iterable.md
+++ b/docs/integrations/sources/iterable.md
@@ -8,7 +8,7 @@ To set up the Iterable source connector, you'll need the Iterable [`Server-side`
 
 ## Set up the Iterable connector in Airbyte
 
-1. [Log into your Airbyte Cloud](https://cloud.airbyte.io/workspaces) account or navigate to the Airbyte Open Source dashboard.
+1. [Log into your Airbyte Cloud](https://cloud.airbyte.com/workspaces) account or navigate to the Airbyte Open Source dashboard.
 2. Click **Sources** and then click **+ New source**.
 3. On the Set up the source page, select **Iterable** from the Source type dropdown.
 4. Enter the name for the Iterable connector.

--- a/docs/integrations/sources/jira.md
+++ b/docs/integrations/sources/jira.md
@@ -18,7 +18,7 @@ This page contains the setup guide and reference information for the Jira source
 
 **For Airbyte Cloud:**
 
-1. [Log into your Airbyte Cloud](https://cloud.airbyte.io/workspaces) account.
+1. [Log into your Airbyte Cloud](https://cloud.airbyte.com/workspaces) account.
 2. In the left navigation bar, click **Sources**. In the top-right corner, click **+ new source**.
 3. On the source setup page, select **Jira** from the Source type dropdown and enter a name for this connector.
 4. Enter the **API Token** that you have created.

--- a/docs/integrations/sources/klaviyo.md
+++ b/docs/integrations/sources/klaviyo.md
@@ -9,7 +9,7 @@ To set up the Klaviyo source connector, you'll need the [Klaviyo Private API key
 
 ## Set up the Klaviyo connector in Airbyte
 
-1. [Log into your Airbyte Cloud](https://cloud.airbyte.io/workspaces) or navigate to the Airbyte Open Source dashboard.
+1. [Log into your Airbyte Cloud](https://cloud.airbyte.com/workspaces) or navigate to the Airbyte Open Source dashboard.
 2. Click **Sources** and then click **+ New source**.
 3. On the Set up the source page, select **Klaviyo** from the Source type dropdown.
 4. Enter the name for the Klaviyo connector.

--- a/docs/integrations/sources/linkedin-ads.md
+++ b/docs/integrations/sources/linkedin-ads.md
@@ -102,7 +102,7 @@ To edit these roles, sign in to Campaign Manager and follow [these instructions]
 <!-- env:cloud -->
 **For Airbyte Cloud:**
 
-1. [Login to your Airbyte Cloud](https://cloud.airbyte.io/workspaces) account.
+1. [Login to your Airbyte Cloud](https://cloud.airbyte.com/workspaces) account.
 2. In the left navigation bar, click **Sources**. In the top-right corner, click **+ new source**.
 3. On the source setup page, select **LinkedIn Ads** from the Source type dropdown and enter a name for this connector.
 4. Add `Start Date` - the starting point for your data replication.

--- a/docs/integrations/sources/lokalise.md
+++ b/docs/integrations/sources/lokalise.md
@@ -14,7 +14,7 @@ You can find your Project ID and find or create an API key within [Lokalise](htt
 
 ### For Airbyte Cloud:
 
-1. [Log into your Airbyte Cloud](https://cloud.airbyte.io/workspaces) account.
+1. [Log into your Airbyte Cloud](https://cloud.airbyte.com/workspaces) account.
 2. In the left navigation bar, click **Sources**. In the top-right corner, click **+new source**.
 3. On the Set up the source page, enter the name for the Lokalise connector and select **Lokalise** from the Source type dropdown.
 4. Enter your `project_id` - Lokalise Project ID.

--- a/docs/integrations/sources/mailchimp.md
+++ b/docs/integrations/sources/mailchimp.md
@@ -8,7 +8,7 @@ You can use [OAuth](https://mailchimp.com/developer/marketing/guides/access-user
 
 ## Set up the Mailchimp source connector
 
-1. Log into your [Airbyte Cloud](https://cloud.airbyte.io/workspaces) or Airbyte Open Source account.
+1. Log into your [Airbyte Cloud](https://cloud.airbyte.com/workspaces) or Airbyte Open Source account.
 2. Click **Sources** and then click **+ New source**. 
 3. On the Set up the source page, select **Mailchimp** from the Source type dropdown.
 4. Enter a name for your source.

--- a/docs/integrations/sources/marketo.md
+++ b/docs/integrations/sources/marketo.md
@@ -47,7 +47,7 @@ We're almost there! Armed with your Endpoint & Identity URLs and your Client ID 
 <!-- env:cloud -->
 **For Airbyte Cloud:**
 
-1. [Log into your Airbyte Cloud](https://cloud.airbyte.io/workspaces) account.
+1. [Log into your Airbyte Cloud](https://cloud.airbyte.com/workspaces) account.
 2. In the left navigation bar, click Sources. In the top-right corner, click **+new source**.
 3. On the Set up the source page, enter the name for the Marketo connector and select **Marketo** from the Source type dropdown.
 4. Enter the start date, domain URL, client ID and secret

--- a/docs/integrations/sources/mixpanel.md
+++ b/docs/integrations/sources/mixpanel.md
@@ -8,7 +8,7 @@ To set up the Harvest source connector, you'll need a Mixpanel [Service Account]
 
 ## Set up the Mixpanel connector in Airbyte
 
-1. [Log into your Airbyte Cloud](https://cloud.airbyte.io/workspaces) or navigate to the Airbyte Open Source dashboard.
+1. [Log into your Airbyte Cloud](https://cloud.airbyte.com/workspaces) or navigate to the Airbyte Open Source dashboard.
 2. Click **Sources** and then click **+ New source**.
 3. On the Set up the source page, select **Mixpanel** from the Source type dropdown.
 4. Enter the name for the Mixpanel connector.

--- a/docs/integrations/sources/monday.md
+++ b/docs/integrations/sources/monday.md
@@ -10,7 +10,7 @@ You can get the API token for Monday by going to Profile picture (bottom left co
 
 ## Setup guide
 
-1. [Log into your Airbyte Cloud](https://cloud.airbyte.io/workspaces) account.
+1. [Log into your Airbyte Cloud](https://cloud.airbyte.com/workspaces) account.
 2. In the left navigation bar, click **Sources**. In the top-right corner, click **+new source**.
 3. On the Set up the source page, enter the name for the Monday connector and select **Monday** from the Source type dropdown.
 4. Fill in your API Key or authenticate using OAuth and then click **Set up source**.

--- a/docs/integrations/sources/netsuite.md
+++ b/docs/integrations/sources/netsuite.md
@@ -74,7 +74,7 @@ Also you have properly **Configured Account** with **Correct Permissions** and *
 ### Step 3: Set up the source connector in Airbyte
 ### For Airbyte Cloud:
 
-1. [Log into your Airbyte Cloud](https://cloud.airbyte.io/workspaces) account.
+1. [Log into your Airbyte Cloud](https://cloud.airbyte.com/workspaces) account.
 2. In the left navigation bar, click **Sources**. In the top-right corner, click **+ new source**.
 3. On the source setup page, select **NetSuite** from the Source type dropdown and enter a name for this connector.
 4. Add **Realm**

--- a/docs/integrations/sources/notion.md
+++ b/docs/integrations/sources/notion.md
@@ -27,7 +27,7 @@ You must be the owner of a Notion workspace to create a new integration.
 <!-- env:cloud -->
 **For Airbyte Cloud:**
 
-1. Log in to your [Airbyte Cloud](https://cloud.airbyte.io/workspaces) account.
+1. Log in to your [Airbyte Cloud](https://cloud.airbyte.com/workspaces) account.
 2. Click **Sources** and then click **+ New source**.
 3. On the Set up the source page, select **Notion** from the **Source type** dropdown.
 4. Enter a name for your source.

--- a/docs/integrations/sources/okta.md
+++ b/docs/integrations/sources/okta.md
@@ -28,7 +28,7 @@ Okta is the complete identity solution for all your apps and people that’s uni
 
 ### For Airbyte Cloud:
 
-1. [Log into your Airbyte Cloud](https://cloud.airbyte.io/workspaces) account.
+1. [Log into your Airbyte Cloud](https://cloud.airbyte.com/workspaces) account.
 2. In the left navigation bar, click **Sources**. In the top-right corner, click **+ new source**.
 3. On the source setup page, select **Okta** from the Source type dropdown and enter a name for this connector.
 4. Add **Name**

--- a/docs/integrations/sources/paypal-transaction.md
+++ b/docs/integrations/sources/paypal-transaction.md
@@ -22,7 +22,7 @@ Our Paypal Transactions Source Connector does not support OAuth at this time due
 <!-- env:cloud -->
 **For Airbyte Cloud:**
 
-1. [Log into your Airbyte Cloud](https://cloud.airbyte.io/workspaces) account.
+1. [Log into your Airbyte Cloud](https://cloud.airbyte.com/workspaces) account.
 2. In the left navigation bar, click **Sources**. In the top-right corner, click **+new source**.
 3. On the Set up the source page, enter the name for the Paypal Transaction connector and select **Paypal Transaction** from the Source type dropdown.
 4. Enter your client id

--- a/docs/integrations/sources/pexels-api.md
+++ b/docs/integrations/sources/pexels-api.md
@@ -24,7 +24,7 @@ Just pass the generated API key and optional parameters for establishing the con
 
 ### For Airbyte Cloud:
 
-1. [Log into your Airbyte Cloud](https://cloud.airbyte.io/workspaces) account.
+1. [Log into your Airbyte Cloud](https://cloud.airbyte.com/workspaces) account.
 2. In the left navigation bar, click **Sources**. In the top-right corner, click **+new source**.
 3. On the Set up the source page, enter the name for the Pexels-API connector and select **Pexels-API** from the Source type dropdown.
 4. Enter your `api_key`.

--- a/docs/integrations/sources/pinterest.md
+++ b/docs/integrations/sources/pinterest.md
@@ -11,7 +11,7 @@ To set up the Pinterest source connector with Airbyte Open Source, you'll need y
 <!-- env:cloud -->
 **For Airbyte Cloud:**
 
-1. [Log into your Airbyte Cloud](https://cloud.airbyte.io/workspaces) account.
+1. [Log into your Airbyte Cloud](https://cloud.airbyte.com/workspaces) account.
 2. Click **Sources** and then click **+ New source**.
 3. On the Set up the source page, select **Pinterest** from the Source type dropdown.
 4. Enter the name for the Pinterest connector.

--- a/docs/integrations/sources/postgres.md
+++ b/docs/integrations/sources/postgres.md
@@ -91,7 +91,7 @@ This issue is tracked in [#9771](https://github.com/airbytehq/airbyte/issues/977
 
 ### Step 2: Set up the Postgres connector in Airbyte
 
-1. Log into your [Airbyte Cloud](https://cloud.airbyte.io/workspaces) or Airbyte Open Source account.
+1. Log into your [Airbyte Cloud](https://cloud.airbyte.com/workspaces) or Airbyte Open Source account.
 2. Click **Sources** and then click **+ New source**.
 3. On the Set up the source page, select **Postgres** from the Source type dropdown.
 4. Enter a name for your source.

--- a/docs/integrations/sources/posthog.md
+++ b/docs/integrations/sources/posthog.md
@@ -16,7 +16,7 @@ This page contains the setup guide and reference information for the PostHog sou
 
 ### For Airbyte Cloud:
 
-1. [Log into your Airbyte Cloud](https://cloud.airbyte.io/workspaces) account.
+1. [Log into your Airbyte Cloud](https://cloud.airbyte.com/workspaces) account.
 2. In the left navigation bar, click **Sources**. In the top-right corner, click **+new source**.
 3. On the Set up the source page, enter the name for the PostHog connector and select **PostHog** from the Source type dropdown.
 4. Enter your `apikey`.

--- a/docs/integrations/sources/postmarkapp.md
+++ b/docs/integrations/sources/postmarkapp.md
@@ -30,7 +30,7 @@ Account-API
 
 ### For Airbyte Cloud:
 
-1. [Log into your Airbyte Cloud](https://cloud.airbyte.io/workspaces) account.
+1. [Log into your Airbyte Cloud](https://cloud.airbyte.com/workspaces) account.
 2. In the left navigation bar, click **Sources**. In the top-right corner, click **+new source**.
 3. On the Set up the source page, select **Postmarkapp** from the Source type dropdown.
 4. Click **Set up source**.

--- a/docs/integrations/sources/prestashop.md
+++ b/docs/integrations/sources/prestashop.md
@@ -19,7 +19,7 @@ This page contains the setup guide and reference information for the PrestaShop 
 
 **For Airbyte Cloud:**
 
-1. [Log into your Airbyte Cloud](https://cloud.airbyte.io/workspaces) account.
+1. [Log into your Airbyte Cloud](https://cloud.airbyte.com/workspaces) account.
 2. In the left navigation bar, click **Sources**. In the top-right corner, click **+ new source**.
 3. On the source setup page, select **PrestaShop** from the Source type dropdown and enter a name for this connector.
 4. Enter the **Access Key** that you obtained.

--- a/docs/integrations/sources/punk-api.md
+++ b/docs/integrations/sources/punk-api.md
@@ -17,7 +17,7 @@ Api key is not required for this connector to work,But a dummy key need to be pa
 
 ### For Airbyte Cloud:
 
-1. [Log into your Airbyte Cloud](https://cloud.airbyte.io/workspaces) account.
+1. [Log into your Airbyte Cloud](https://cloud.airbyte.com/workspaces) account.
 2. In the left navigation bar, click **Sources**. In the top-right corner, click **+new source**.
 3. On the Set up the source page, enter the name for the Punk-API connector and select **Punk-API** from the Source type dropdown.
 4. Enter your dummy `api_key`.

--- a/docs/integrations/sources/recharge.md
+++ b/docs/integrations/sources/recharge.md
@@ -20,7 +20,7 @@ Please read [How to generate your API token](https://support.rechargepayments.co
 
 **For Airbyte Cloud:**
 
-1. [Log into your Airbyte Cloud](https://cloud.airbyte.io/workspaces) account.
+1. [Log into your Airbyte Cloud](https://cloud.airbyte.com/workspaces) account.
 2. In the left navigation bar, click **Sources**. In the top-right corner, click **+ new source**.
 3. On the source setup page, select **Recharge** from the Source type dropdown and enter a name for this connector.
 4. Choose required `Start date`

--- a/docs/integrations/sources/recruitee.md
+++ b/docs/integrations/sources/recruitee.md
@@ -14,7 +14,7 @@ You can find your Company ID and find or create an API key within [Recruitee](ht
 
 ### For Airbyte Cloud:
 
-1. [Log into your Airbyte Cloud](https://cloud.airbyte.io/workspaces) account.
+1. [Log into your Airbyte Cloud](https://cloud.airbyte.com/workspaces) account.
 2. In the left navigation bar, click **Sources**. In the top-right corner, click **+new source**.
 3. On the Set up the source page, enter the name for the Recruitee connector and select **Recruitee** from the Source type dropdown.
 4. Enter your `company_id` - Recruitee Company ID.

--- a/docs/integrations/sources/s3.md
+++ b/docs/integrations/sources/s3.md
@@ -17,7 +17,7 @@ Define file pattern, see the [Path Patterns section](s3.md#path-patterns)
 <!-- env:cloud -->
 **For Airbyte Cloud:**
 
-1. [Log into your Airbyte Cloud](https://cloud.airbyte.io/workspaces) account.
+1. [Log into your Airbyte Cloud](https://cloud.airbyte.com/workspaces) account.
 2. In the left navigation bar, click **<Sources/Destinations>**. In the top-right corner, click **+new source/destination**.
 3. On the Set up the source/destination page, enter the name for the `connector name` connector and select **connector name** from the `Source/Destination` type dropdown.
 4. Set `dataset` appropriately. This will be the name of the table in the destination.

--- a/docs/integrations/sources/salesforce.md
+++ b/docs/integrations/sources/salesforce.md
@@ -43,7 +43,7 @@ To create a dedicated read only Salesforce user:
 
 To set up Salesforce as a source in Airbyte Cloud:
 
-1. [Log into your Airbyte Cloud](https://cloud.airbyte.io/workspaces) account.
+1. [Log into your Airbyte Cloud](https://cloud.airbyte.com/workspaces) account.
 2. In the left navigation bar, click **Sources**. In the top-right corner, click **+ New source**.
 3. On the Set up the source page, select **Salesforce** from the **Source type** dropdown.
 4. For Name, enter a name for the Salesforce connector.

--- a/docs/integrations/sources/sendgrid.md
+++ b/docs/integrations/sources/sendgrid.md
@@ -25,7 +25,7 @@ To consume Messages resources requires to purchase an extra on Sendgrid. You can
 
 ### For Airbyte Cloud:
 
-1. [Log into your Airbyte Cloud](https://cloud.airbyte.io/workspaces) account.
+1. [Log into your Airbyte Cloud](https://cloud.airbyte.com/workspaces) account.
 2. In the left navigation bar, click **Sources**. In the top-right corner, click **+new source**.
 3. On the Set up the source page, enter the name for the Sendgrid connector and select **Sendgrid** from the Source type dropdown.
 4. Enter your `apikey`.

--- a/docs/integrations/sources/senseforce.md
+++ b/docs/integrations/sources/senseforce.md
@@ -28,7 +28,7 @@ The Senseforce Airbyte connector allows to export custom datasets built bei Sens
 
 ## Set up the Senseforce source connector
 
-1. Log into your [Airbyte Cloud](https://cloud.airbyte.io/workspaces) or Airbyte Open Source account.
+1. Log into your [Airbyte Cloud](https://cloud.airbyte.com/workspaces) or Airbyte Open Source account.
 2. Click **Sources** and then click **+ New source**. 
 3. On the Set up the source page, select **Senseforce** from the Source type dropdown.
 4. Enter a name for your source.

--- a/docs/integrations/sources/sentry.md
+++ b/docs/integrations/sources/sentry.md
@@ -8,7 +8,7 @@ To set up the Sentry source connector, you'll need the Sentry [project name](htt
 
 ## Set up the Sentry connector in Airbyte
 
-1. [Log into your Airbyte Cloud](https://cloud.airbyte.io/workspaces) account or navigate to the Airbyte Open Source dashboard.
+1. [Log into your Airbyte Cloud](https://cloud.airbyte.com/workspaces) account or navigate to the Airbyte Open Source dashboard.
 2. Click **Sources** and then click **+ New source**.
 3. On the Set up the source page, select **Sentry** from the Source type dropdown.
 4. Enter the name for the Sentry connector.

--- a/docs/integrations/sources/sftp.md
+++ b/docs/integrations/sources/sftp.md
@@ -24,7 +24,7 @@ Server will now allow access to anyone who can prove they have the corresponding
 
 #### For Airbyte Cloud:
 
-1. [Log into your Airbyte Cloud](https://cloud.airbyte.io/workspaces) account.
+1. [Log into your Airbyte Cloud](https://cloud.airbyte.com/workspaces) account.
 2. In the left navigation bar, click **`Sources`**. In the top-right corner, click **+new source**.
 3. On the Set up the source page, enter the name for the SFTP connector and select **SFTP** from the Source type dropdown.
 4. Enter your `User Name`, `Host Address`, `Port`

--- a/docs/integrations/sources/slack.md
+++ b/docs/integrations/sources/slack.md
@@ -72,7 +72,7 @@ We recommend creating a restricted, read-only key specifically for Airbyte acces
 <!-- env:cloud -->
 **For Airbyte Cloud:**
 
-1. [Log into your Airbyte Cloud](https://cloud.airbyte.io/workspaces) account.
+1. [Log into your Airbyte Cloud](https://cloud.airbyte.com/workspaces) account.
 2. In the left navigation bar, click **Sources**. In the top-right corner, click **+new source**.
 3. On the Set up the source page, enter the name for the Slack connector and select **Slack** from the Source type dropdown.
 4. Select `Authenticate your account` and log in and Authorize to the Slack account.

--- a/docs/integrations/sources/smartsheets.md
+++ b/docs/integrations/sources/smartsheets.md
@@ -33,7 +33,7 @@ You'll also need the ID of the Spreadsheet you'd like to sync. Unlike Google She
 
 **For Airbyte Cloud:**
 
-1. [Log into your Airbyte Cloud](https://cloud.airbyte.io/workspaces) account.
+1. [Log into your Airbyte Cloud](https://cloud.airbyte.com/workspaces) account.
 2. In the left navigation bar, click Sources. In the top-right corner, click **+new source**.
 3. On the Set up the source page, enter the name for the Smartsheets connector and select **Smartsheets** from the Source type dropdown.
 4. Authenticate via OAuth2.0 using the API access token from Prerequisites

--- a/docs/integrations/sources/snapchat-marketing.md
+++ b/docs/integrations/sources/snapchat-marketing.md
@@ -57,7 +57,7 @@ The useful link to Authentication process is [here](https://marketingapi.snapcha
 <!-- env:cloud -->
 **For Airbyte Cloud:**
 
-1. [Log into your Airbyte Cloud](https://cloud.airbyte.io/workspaces) account.
+1. [Log into your Airbyte Cloud](https://cloud.airbyte.com/workspaces) account.
 2. In the left navigation bar, click **Sources**. In the top-right corner, click **+ new source**.
 3. On the source setup page, select **Snapchat Marketing** from the Source type dropdown and enter a name for this connector.
 4. lick `Authenticate your account`.

--- a/docs/integrations/sources/spacex-api.md
+++ b/docs/integrations/sources/spacex-api.md
@@ -17,7 +17,7 @@ No prerequisites, but a dummy api_key is required as it enhances security in fut
 
 ### For Airbyte Cloud:
 
-1. [Log into your Airbyte Cloud](https://cloud.airbyte.io/workspaces) account.
+1. [Log into your Airbyte Cloud](https://cloud.airbyte.com/workspaces) account.
 2. In the left navigation bar, click **Sources**. In the top-right corner, click **+new source**.
 3. On the Set up the source page, enter the name for the SpaceX-API connector and select **Spacex-API** from the Source type dropdown.
 4. Enter your `api_key`.

--- a/docs/integrations/sources/square.md
+++ b/docs/integrations/sources/square.md
@@ -17,7 +17,7 @@ To set up the Square source connector with Airbyte, you'll need to create your S
 
 ### For Airbyte Cloud:
 
-1. [Log into your Airbyte Cloud](https://cloud.airbyte.io/workspaces) account.
+1. [Log into your Airbyte Cloud](https://cloud.airbyte.com/workspaces) account.
 2. In the left navigation bar, click **Sources**. In the top-right corner, click **+ New source**.
 3. On the Set up the source page, enter the name for the Square connector and select **Square** from the Source type dropdown.
 4. Choose authentication method:

--- a/docs/integrations/sources/stripe.md
+++ b/docs/integrations/sources/stripe.md
@@ -13,7 +13,7 @@ This page guides you through the process of setting up the Stripe source connect
 
 ## Set up the Stripe source connector
 
-1. Log into your [Airbyte Cloud](https://cloud.airbyte.io/workspaces) or Airbyte Open Source account.
+1. Log into your [Airbyte Cloud](https://cloud.airbyte.com/workspaces) or Airbyte Open Source account.
 2. Click **Sources** and then click **+ New source**. 
 3. On the Set up the source page, select **Stripe** from the Source type dropdown.
 4. Enter a name for your source.

--- a/docs/integrations/sources/surveycto.md
+++ b/docs/integrations/sources/surveycto.md
@@ -17,7 +17,7 @@ This page guides you through the process of setting up the SurveyCTO source conn
 - give your user an API consumer permission to the existing role or create a user with that role and permission.
 
 ## Set up the SurveyCTO source connection
-1. Log into your [Airbyte Cloud](https://cloud.airbyte.io/workspaces) or Airbyte Open Source account.
+1. Log into your [Airbyte Cloud](https://cloud.airbyte.com/workspaces) or Airbyte Open Source account.
 2. Click **Sources** and then click **+ New source**.
 3. On the Set up the source page, select **Survey CTO** from the Source type dropdown.
 4. Enter a name for your source.

--- a/docs/integrations/sources/surveymonkey.md
+++ b/docs/integrations/sources/surveymonkey.md
@@ -25,7 +25,7 @@ Please read this [docs](https://developer.surveymonkey.com/api/v3/#getting-start
 <!-- env:cloud -->
 **For Airbyte Cloud:**
 
-1. [Log into your Airbyte Cloud](https://cloud.airbyte.io/workspaces) account.
+1. [Log into your Airbyte Cloud](https://cloud.airbyte.com/workspaces) account.
 2. In the left navigation bar, click **Sources**. In the top-right corner, click **+ new source**.
 3. On the source setup page, select **SurveyMonkey** from the Source type dropdown and enter a name for this connector.
 4. lick `Authenticate your account`.

--- a/docs/integrations/sources/tempo.md
+++ b/docs/integrations/sources/tempo.md
@@ -16,7 +16,7 @@ Go to **Tempo &gt; Settings**, scroll down to **Data Access** and select **API i
 
 ## Step 2: Set up the Tempo connector in Airbyte
 
-1. [Log into your Airbyte Cloud](https://cloud.airbyte.io/workspaces) account.
+1. [Log into your Airbyte Cloud](https://cloud.airbyte.com/workspaces) account.
 2. In the left navigation bar, click **Sources**. In the top-right corner, click **+new source**.
 3. On the Set up the source page, enter the name for the Tempo connector and select **Tempo** from the Source type dropdown.
 4. Enter your API token that you obtained from Tempo.

--- a/docs/integrations/sources/the-guardian-api.md
+++ b/docs/integrations/sources/the-guardian-api.md
@@ -79,7 +79,7 @@ The source is capable of syncing the content stream.
 
 ### For Airbyte Cloud:
 
-1. [Log into your Airbyte Cloud](https://cloud.airbyte.io/workspaces) account.
+1. [Log into your Airbyte Cloud](https://cloud.airbyte.com/workspaces) account.
 2. In the left navigation bar, click **Sources**. In the top-right corner, click **+new source**.
 3. On the Set up the source page, select **The Guardian API** from the Source type dropdown.
 4. Enter your api_key (mandatory) and any other optional parameters as per your requirements.

--- a/docs/integrations/sources/tiktok-marketing.md
+++ b/docs/integrations/sources/tiktok-marketing.md
@@ -35,7 +35,7 @@ To access the Sandbox environment:
 <!-- env:cloud -->
 **For Airbyte Cloud:**
 
-1. [Log into your Airbyte Cloud](https://cloud.airbyte.io/workspaces) account.
+1. [Log into your Airbyte Cloud](https://cloud.airbyte.com/workspaces) account.
 2. In the left navigation bar, click **Sources**. In the top-right corner, click **+ new source**.
 3. On the source setup page, select **Tiktok Marketing** from the Source type dropdown and enter a name for this connector.
 4. Select `OAuth2.0` Authorization method, then click `Authenticate your account`.

--- a/docs/integrations/sources/tmdb.md
+++ b/docs/integrations/sources/tmdb.md
@@ -18,7 +18,7 @@ Just pass the generated API key and Movie ID for establishing the connection.
 
 ### For Airbyte Cloud:
 
-1. [Log into your Airbyte Cloud](https://cloud.airbyte.io/workspaces) account.
+1. [Log into your Airbyte Cloud](https://cloud.airbyte.com/workspaces) account.
 2. In the left navigation bar, click **Sources**. In the top-right corner, click **+new source**.
 3. On the Set up the source page, enter the name for the Google-webfonts connector and select **TMDb** from the Source type dropdown.
 4. Enter your `api_key`.

--- a/docs/integrations/sources/twilio-taskrouter.md
+++ b/docs/integrations/sources/twilio-taskrouter.md
@@ -17,7 +17,7 @@ See [docs](https://www.twilio.com/docs/taskrouter/api) for more details.
 
 ### For Airbyte Cloud:
 
-1. [Log into your Airbyte Cloud](https://cloud.airbyte.io/workspaces) account.
+1. [Log into your Airbyte Cloud](https://cloud.airbyte.com/workspaces) account.
 2. In the left navigation bar, click **Sources**. In the top-right corner, click **+new source**.
 3. On the Set up the source page, enter the name for the Twilio connector and select **Twilio Taskrouter** from the <Source/Destination> type dropdown.
 4. Enter your `account_sid`.

--- a/docs/integrations/sources/twilio.md
+++ b/docs/integrations/sources/twilio.md
@@ -15,7 +15,7 @@ See [docs](https://www.twilio.com/docs/iam/api) for more details.
 <!-- env:cloud -->
 **For Airbyte Cloud:**
 
-1. [Log into your Airbyte Cloud](https://cloud.airbyte.io/workspaces) account.
+1. [Log into your Airbyte Cloud](https://cloud.airbyte.com/workspaces) account.
 2. In the left navigation bar, click **Sources**. In the top-right corner, click **+new source**.
 3. On the Set up the source page, enter the name for the Twilio connector and select **Twilio** from the <Source/Destination> type dropdown.
 4. Enter your `account_sid`.

--- a/docs/integrations/sources/tyntec-sms.md
+++ b/docs/integrations/sources/tyntec-sms.md
@@ -19,7 +19,7 @@ A Tyntec SMS API Key and SMS message request ID are required for this connector 
 
 #### For Airbyte Cloud:
 
-1. [Log into your Airbyte Cloud](https://cloud.airbyte.io/workspaces) account.
+1. [Log into your Airbyte Cloud](https://cloud.airbyte.com/workspaces) account.
 2. In the left navigation bar, click **Sources**. In the top-right corner, click **+new source**.
 3. On the Set up the source page, enter the name for the Tyntec SMS connector and select **Tyntec SMS** from the Source type dropdown.
 4. Enter your `Tyntec API Key`.

--- a/docs/integrations/sources/typeform.md
+++ b/docs/integrations/sources/typeform.md
@@ -27,7 +27,7 @@ To get the API token for your application follow this [steps](https://developer.
 <!-- env:cloud -->
 **For Airbyte Cloud:**
 
-1. [Log into your Airbyte Cloud](https://cloud.airbyte.io/workspaces) account.
+1. [Log into your Airbyte Cloud](https://cloud.airbyte.com/workspaces) account.
 2. In the left navigation bar, click **Sources**. In the top-right corner, click **+ new source**.
 3. On the source setup page, select **Typeform** from the Source type dropdown and enter a name for this connector.
 4. Fill-in 'API Token' and 'Start Date'

--- a/docs/integrations/sources/visma-economic.md
+++ b/docs/integrations/sources/visma-economic.md
@@ -17,7 +17,7 @@ In sort your options are:
 
 ## Set up the Visma e-conomic source connector
 
-1. Log into your [Airbyte Cloud](https://cloud.airbyte.io/workspaces) or Airbyte Open Source account.
+1. Log into your [Airbyte Cloud](https://cloud.airbyte.com/workspaces) or Airbyte Open Source account.
 2. Click **Sources** and then click **+ New source**.
 3. On the Set up the source page, select **Stripe** from the Source type dropdown.
 4. Enter a name for your source.

--- a/docs/integrations/sources/waiteraid.md
+++ b/docs/integrations/sources/waiteraid.md
@@ -11,7 +11,7 @@ You can find or create authentication tokens within [Waiteraid](https://app.wait
 
 ### For Airbyte Cloud:
 
-1. [Log into your Airbyte Cloud](https://cloud.airbyte.io/workspaces) account.
+1. [Log into your Airbyte Cloud](https://cloud.airbyte.com/workspaces) account.
 2. In the left navigation bar, click **Sources**. In the top-right corner, click **+new source**.
 3. On the Set up the source page, enter the name for the Waiteraid connector and select **Waiteraid** from the Source type dropdown.
 4. Enter your `auth_token` - Waiteraid Authentication Token.

--- a/docs/integrations/sources/wikipedia-pageviews.md
+++ b/docs/integrations/sources/wikipedia-pageviews.md
@@ -12,7 +12,7 @@ None
 
 ### For Airbyte Cloud:
 
-1. [Log into your Airbyte Cloud](https://cloud.airbyte.io/workspaces) account.
+1. [Log into your Airbyte Cloud](https://cloud.airbyte.com/workspaces) account.
 2. In the left navigation bar, click **Sources**. In the top-right corner, click **+new source**.
 3. On the Set up the source page, enter the name for the Courier connector and select **Wikipedia Pageviews** from the Source type dropdown.
 4. Enter your parameters.

--- a/docs/integrations/sources/woocommerce.md
+++ b/docs/integrations/sources/woocommerce.md
@@ -24,7 +24,7 @@ You will need to generate new API key with read permissions and use `Customer ke
 
 ### For Airbyte Cloud:
 
-1. [Log into your Airbyte Cloud](https://cloud.airbyte.io/workspaces) account.
+1. [Log into your Airbyte Cloud](https://cloud.airbyte.com/workspaces) account.
 2. In the left navigation bar, click **Sources**. In the top-right corner, click **+ New source**.
 3. On the Set up the source page, enter the name for the WooCommerce connector and select **WooCommerce** from the Source
    type dropdown.

--- a/docs/integrations/sources/workable.md
+++ b/docs/integrations/sources/workable.md
@@ -12,7 +12,7 @@ You can find or create a Workable access token within the [Workable Integrations
 
 ### For Airbyte Cloud:
 
-1. [Log into your Airbyte Cloud](https://cloud.airbyte.io/workspaces) account.
+1. [Log into your Airbyte Cloud](https://cloud.airbyte.com/workspaces) account.
 2. In the left navigation bar, click **Sources**. In the top-right corner, click **+new source**.
 3. On the Set up the source page, enter the name for the Workable connector and select **Workable** from the Source type dropdown.
 4. Enter your `api_token` - Workable Access Token.

--- a/docs/integrations/sources/wrike.md
+++ b/docs/integrations/sources/wrike.md
@@ -8,7 +8,7 @@ This page guides you through the process of setting up the Wrike source connecto
 
 ## Set up the Wrike source connector 
 
-1. Log into your [Airbyte Cloud](https://cloud.airbyte.io/workspaces) or Airbyte OSS account.
+1. Log into your [Airbyte Cloud](https://cloud.airbyte.com/workspaces) or Airbyte OSS account.
 2. Click **Sources** and then click **+ New source**. 
 3. On the Set up the source page, select **Wrike** from the Source type dropdown.
 4. Enter a name for your source.

--- a/docs/integrations/sources/youtube-analytics.md
+++ b/docs/integrations/sources/youtube-analytics.md
@@ -22,7 +22,7 @@ Youtube also generates historical data reports covering the 30-day period prior 
 
 ### For Airbyte Cloud:
 
-1. [Log into your Airbyte Cloud](https://cloud.airbyte.io/workspaces) account.
+1. [Log into your Airbyte Cloud](https://cloud.airbyte.com/workspaces) account.
 2. In the left navigation bar, click **Sources**. In the top-right corner, click **+new source**.
 3. On the Set up the source page, enter the name for the YouTube Analytics connector and select **YouTube Analytics** from the Source type dropdown.
 4. Select `Authenticate your account`.

--- a/docs/integrations/sources/zendesk-chat.md
+++ b/docs/integrations/sources/zendesk-chat.md
@@ -14,7 +14,7 @@ This page contains the setup guide and reference information for the Zendesk Cha
 <!-- env:cloud -->
 **For Airbyte Cloud:**
 
-1. [Log into your Airbyte Cloud](https://cloud.airbyte.io/workspaces) account.
+1. [Log into your Airbyte Cloud](https://cloud.airbyte.com/workspaces) account.
 2. Click **Sources** and then click **+ New source**.
 3. On the Set up the source page, select **Zendesk Chat** from the Source type dropdown.
 4. Enter the name for the Zendesk Chat connector.

--- a/docs/integrations/sources/zendesk-support.md
+++ b/docs/integrations/sources/zendesk-support.md
@@ -9,7 +9,7 @@ This page guides you through setting up the Zendesk Support source connector.
 
 ## Set up the Zendesk Support source connector
 
-1. Log into your [Airbyte Cloud](https://cloud.airbyte.io/workspaces) or Airbyte Open Source account.
+1. Log into your [Airbyte Cloud](https://cloud.airbyte.com/workspaces) or Airbyte Open Source account.
 2. Click **Sources** and then click **+ New source**. 
 3. On the Set up the source page, select **Zendesk Support** from the Source type dropdown.
 4. Enter a name for your source.

--- a/docs/integrations/sources/zendesk-talk.md
+++ b/docs/integrations/sources/zendesk-talk.md
@@ -21,7 +21,7 @@ Another option is to use OAuth2.0 for authentication. See [Zendesk docs](https:/
 
 **For Airbyte Cloud:**
 
-1. [Log into your Airbyte Cloud](https://cloud.airbyte.io/workspaces) account.
+1. [Log into your Airbyte Cloud](https://cloud.airbyte.com/workspaces) account.
 2. In the left navigation bar, click **Sources**. In the top-right corner, click **+new source**.
 3. On the Set up the source page, enter the name for the Zendesk Talk connector and select **Zendesk Talk** from the Source type dropdown.
 4. Fill in the rest of the fields:

--- a/docs/integrations/sources/zenloop.md
+++ b/docs/integrations/sources/zenloop.md
@@ -6,7 +6,7 @@ This page contains the setup guide and reference information for the Zenloop sou
 <!-- env:cloud -->
 **For Airbyte Cloud:**
 
-1. [Log into your Airbyte Cloud](https://cloud.airbyte.io/workspaces).
+1. [Log into your Airbyte Cloud](https://cloud.airbyte.com/workspaces).
 2. Click **Sources** and then click **+ New source**.
 3. On the Set up the source page, select **Zenloop** from the Source type dropdown.
 4. Enter the name for the Zenloop connector.

--- a/docusaurus/docusaurus.config.js
+++ b/docusaurus/docusaurus.config.js
@@ -132,7 +132,7 @@ const config = {
                         position: 'left',
                     },
                     {
-                        href: 'https://cloud.airbyte.io/signup?utm_campaign=22Q1_AirbyteCloudSignUpCampaign_Trial&utm_source=Docs&utm_content=NavBar',
+                        href: 'https://cloud.airbyte.com/signup?utm_campaign=22Q1_AirbyteCloudSignUpCampaign_Trial&utm_source=Docs&utm_content=NavBar',
                         label: 'Try Airbyte Cloud',
                         position: 'left',
                     },


### PR DESCRIPTION
Replaced cloud.airbyte.io with cloud.airbyte.com in docs.

Related to [4090](https://github.com/airbytehq/airbyte-cloud/issues/4090)