### PR TITLE
ci_credentials: disable tooling test run by tox

### DIFF
--- a/.github/workflows/publish-command.yml
+++ b/.github/workflows/publish-command.yml
@@ -260,13 +260,12 @@ jobs:
         uses: actions/setup-python@v4
         with:
           python-version: "3.9"
-      - name: Install Pyenv and Tox
+      - name: Install Pyenv
         run: |
           python3 -m pip install --quiet virtualenv==16.7.9 --user
           rm -r venv || echo "no pre-existing venv"
           python3 -m virtualenv venv
           source venv/bin/activate
-          pip install --quiet tox==3.24.4
       - name: Install yq
         if: github.event.inputs.auto-bump-version == 'true' && success()
         run: |

--- a/.github/workflows/publish-command.yml
+++ b/.github/workflows/publish-command.yml
@@ -274,7 +274,7 @@ jobs:
           sudo add-apt-repository ppa:rmescandon/yq
           sudo apt update
           sudo apt install yq -y
-      - name: Test and install CI scripts
+      - name: Install CI scripts
         # all CI python packages have the prefix "ci_"
         run: |
           source venv/bin/activate

--- a/.github/workflows/publish-command.yml
+++ b/.github/workflows/publish-command.yml
@@ -278,7 +278,6 @@ jobs:
         # all CI python packages have the prefix "ci_"
         run: |
           source venv/bin/activate
-          tox -r -c ./tools/tox_ci.ini
           pip install --quiet -e ./tools/ci_*
       - name: Write Integration Test Credentials for ${{ matrix.connector }}
         run: |

--- a/.github/workflows/publish-connector-command.yml
+++ b/.github/workflows/publish-connector-command.yml
@@ -115,7 +115,7 @@ jobs:
 #          sudo add-apt-repository ppa:rmescandon/yq
 #          sudo apt update
 #          sudo apt install yq -y
-#      - name: Test and install CI scripts
+#      - name: Install CI scripts
 #        # all CI python packages have the prefix "ci_"
 #        run: |
 #          source venv/bin/activate

--- a/.github/workflows/publish-connector-command.yml
+++ b/.github/workflows/publish-connector-command.yml
@@ -115,7 +115,7 @@ jobs:
 #          sudo add-apt-repository ppa:rmescandon/yq
 #          sudo apt update
 #          sudo apt install yq -y
-#      - name: Install CI scripts
+#      - name: Test and install CI scripts
 #        # all CI python packages have the prefix "ci_"
 #        run: |
 #          source venv/bin/activate

--- a/.github/workflows/test-command.yml
+++ b/.github/workflows/test-command.yml
@@ -105,7 +105,6 @@ jobs:
         # all CI python packages have the prefix "ci_"
         run: |
           source venv/bin/activate
-          tox -r -c ./tools/tox_ci.ini
           pip install --quiet -e ./tools/ci_*
       - name: Write Integration Test Credentials for ${{ github.event.inputs.connector }}
         run: |

--- a/.github/workflows/test-command.yml
+++ b/.github/workflows/test-command.yml
@@ -95,12 +95,11 @@ jobs:
         uses: actions/setup-python@v4
         with:
           python-version: "3.9"
-      - name: Install Pyenv and Tox
+      - name: Install Pyenv
         run: |
           python3 -m pip install --quiet virtualenv==16.7.9 --user
           python3 -m virtualenv venv
           source venv/bin/activate
-          pip install --quiet tox==3.24.4
       - name: Install CI scripts
         # all CI python packages have the prefix "ci_"
         run: |

--- a/.github/workflows/test-command.yml
+++ b/.github/workflows/test-command.yml
@@ -101,7 +101,7 @@ jobs:
           python3 -m virtualenv venv
           source venv/bin/activate
           pip install --quiet tox==3.24.4
-      - name: Test and install CI scripts
+      - name: Install CI scripts
         # all CI python packages have the prefix "ci_"
         run: |
           source venv/bin/activate

--- a/.github/workflows/test-performance-command.yml
+++ b/.github/workflows/test-performance-command.yml
@@ -102,7 +102,6 @@ jobs:
         # all CI python packages have the prefix "ci_"
         run: |
           source venv/bin/activate
-          tox -r -c ./tools/tox_ci.ini
           pip install --quiet -e ./tools/ci_*
       - name: Write Integration Test Credentials for ${{ github.event.inputs.connector }}
         run: |

--- a/.github/workflows/test-performance-command.yml
+++ b/.github/workflows/test-performance-command.yml
@@ -92,12 +92,11 @@ jobs:
         uses: actions/setup-python@v4
         with:
           python-version: "3.9"
-      - name: Install Pyenv and Tox
+      - name: Install Pyenv
         run: |
           python3 -m pip install --quiet virtualenv==16.7.9 --user
           python3 -m virtualenv venv
           source venv/bin/activate
-          pip install --quiet tox==3.24.4
       - name: Install CI scripts
         # all CI python packages have the prefix "ci_"
         run: |

--- a/.github/workflows/test-performance-command.yml
+++ b/.github/workflows/test-performance-command.yml
@@ -98,7 +98,7 @@ jobs:
           python3 -m virtualenv venv
           source venv/bin/activate
           pip install --quiet tox==3.24.4
-      - name: Test and install CI scripts
+      - name: Install CI scripts
         # all CI python packages have the prefix "ci_"
         run: |
           source venv/bin/activate


### PR DESCRIPTION
## What
Closes https://github.com/airbytehq/airbyte/issues/21578
`tox` is used in the CI to run tests on the python packages before we install them.
These python packages are installed to provide the required tooling for connector testing.
Actually testing them in this context does not look required.

`tox` was introduced by https://github.com/airbytehq/airbyte/pull/8561 but I don't have context why it was added to the tooling install step. Maybe for env consistency guarantees 🤔 

## How
Remove `tox` commands from the `/publish` and `/test` commands.

