### PR TITLE
Add missing extraContainers to airbyte-cron chart

### DIFF
--- a/charts/airbyte-cron/templates/deployment.yaml
+++ b/charts/airbyte-cron/templates/deployment.yaml
@@ -146,3 +146,9 @@ spec:
           resources: {{- toYaml .Values.resources | nindent 12 }}
           {{- end }}
 
+        {{- if .Values.extraContainers }}
+          {{ toYaml .Values.extraContainers | nindent 6 }}
+        {{- end }}
+        {{- if .Values.global.extraContainers }}
+          {{ toYaml .Values.global.extraContainers | nindent 8 }}
+        {{- end }}


### PR DESCRIPTION
Signed-off-by: Marko Milenovic <marko@mailnord.com>

## What
airbyte-cron is missing `extraContainers` from `deployment.yaml` file. The variable is in `values.yaml` but it's never used. This prevents the charts from being used in GCP with SQL proxy enabled.

## How
I've added the missing code. There is an existing PR for this issue ([#20506](https://github.com/airbytehq/airbyte/pull/20506)) but the solution in it will fail since the indentation is wrong. That PR has been inactive for a while so I'm creating a new one.
