### PR TITLE
Revert: CI  nightly build alpha sources and destinations

### DIFF
--- a/.github/workflows/connector_integration_tests.yml
+++ b/.github/workflows/connector_integration_tests.yml
@@ -26,6 +26,6 @@ jobs:
           python -m pip install --upgrade pip
           pip install PyYAML requests
       - name: Launch Integration Tests
-        run: python ./tools/bin/ci_integration_workflow_launcher.py base-normalization source-acceptance-test source:alpha source:beta source:GA destination:alpha destination:beta destination:GA
+        run: python ./tools/bin/ci_integration_workflow_launcher.py base-normalization source-acceptance-test source:beta source:GA destination:beta destination:GA
         env:
           GITHUB_TOKEN: ${{ secrets.SLASH_COMMAND_PAT }}


### PR DESCRIPTION
This reverts commit 61f88f30134df1a71466cd63e0d73757a7ad1d8d.

## What
There's a timeout in the GHA running Integration tests for connector.
All connectors's can't be built in this time window.

