### PR TITLE
Connector daily integration tests: new job for alpha connectors

### DIFF
--- a/.github/workflows/connector_integration_tests.yml
+++ b/.github/workflows/connector_integration_tests.yml
@@ -29,3 +29,22 @@ jobs:
         run: python ./tools/bin/ci_integration_workflow_launcher.py base-normalization source-acceptance-test source:alpha source:beta source:GA destination:alpha destination:beta destination:GA
         env:
           GITHUB_TOKEN: ${{ secrets.SLASH_COMMAND_PAT }}
+  launch_integration_tests_alpha_only:
+    runs-on: ubuntu-latest
+    if: github.ref == 'refs/heads/master'
+    steps:
+      - name: Checkout Airbyte
+        uses: actions/checkout@v3
+      - name: Install Java
+        uses: actions/setup-java@v3
+        with:
+          distribution: "zulu"
+          java-version: "17"
+      - name: Install dependencies
+        run: |
+          python -m pip install --upgrade pip
+          pip install PyYAML requests
+      - name: Launch Integration Tests
+        run: python ./tools/bin/ci_integration_workflow_launcher.py source:alpha destination:alpha
+        env:
+          GITHUB_TOKEN: ${{ secrets.SLASH_COMMAND_PAT }}

--- a/.github/workflows/connector_integration_tests.yml
+++ b/.github/workflows/connector_integration_tests.yml
@@ -44,7 +44,7 @@ jobs:
         run: |
           python -m pip install --upgrade pip
           pip install PyYAML requests
-      - name: Launch Integration Tests
+      - name: Launch Integration Tests (Alpha connectors)
         run: python ./tools/bin/ci_integration_workflow_launcher.py source:alpha destination:alpha
         env:
           GITHUB_TOKEN: ${{ secrets.SLASH_COMMAND_PAT }}


### PR DESCRIPTION
## What
Declare a separate job to run `alpha` connectors build only in the daily Connector Integration Tests run.
I reverted https://github.com/airbytehq/airbyte/pull/21589 because all the builds can't run in 30mn.
For orchestration and timeout reasons I prefer to declare it in a second job.
