### PR TITLE
[ISSUE #20771] adding slices to connector builder read request

### DIFF
--- a/airbyte-cdk/python/airbyte_cdk/sources/abstract_source.py
+++ b/airbyte-cdk/python/airbyte_cdk/sources/abstract_source.py
@@ -237,7 +237,6 @@ class AbstractSource(Source, ABC):
             has_slices = True
             if logger.isEnabledFor(logging.DEBUG):
                 yield AirbyteMessage(type=MessageType.LOG, log=AirbyteLogMessage(level=Level.INFO, message=f"slice:{json.dumps(_slice)}"))
-            logger.debug("Processing stream slice", extra={"slice": _slice})
             records = stream_instance.read_records(
                 sync_mode=SyncMode.incremental,
                 stream_slice=_slice,
@@ -288,7 +287,6 @@ class AbstractSource(Source, ABC):
         for _slice in slices:
             if logger.isEnabledFor(logging.DEBUG):
                 yield AirbyteMessage(type=MessageType.LOG, log=AirbyteLogMessage(level=Level.INFO, message=f"slice:{json.dumps(_slice)}"))
-            logger.debug("Processing stream slice", extra={"slice": _slice})
             record_data_or_messages = stream_instance.read_records(
                 stream_slice=_slice,
                 sync_mode=SyncMode.full_refresh,

--- a/airbyte-cdk/python/airbyte_cdk/sources/abstract_source.py
+++ b/airbyte-cdk/python/airbyte_cdk/sources/abstract_source.py
@@ -6,6 +6,7 @@ import json
 import logging
 from abc import ABC, abstractmethod
 from typing import Any, Dict, Iterator, List, Mapping, MutableMapping, Optional, Tuple, Union
+
 from airbyte_cdk.models import (
     AirbyteCatalog,
     AirbyteConnectionStatus,

--- a/airbyte-cdk/python/airbyte_cdk/sources/abstract_source.py
+++ b/airbyte-cdk/python/airbyte_cdk/sources/abstract_source.py
@@ -2,17 +2,19 @@
 # Copyright (c) 2022 Airbyte, Inc., all rights reserved.
 #
 
+import json
 import logging
 from abc import ABC, abstractmethod
 from typing import Any, Dict, Iterator, List, Mapping, MutableMapping, Optional, Tuple, Union
-
 from airbyte_cdk.models import (
     AirbyteCatalog,
     AirbyteConnectionStatus,
+    AirbyteLogMessage,
     AirbyteMessage,
     AirbyteStateMessage,
     ConfiguredAirbyteCatalog,
     ConfiguredAirbyteStream,
+    Level,
     Status,
     SyncMode,
 )
@@ -232,6 +234,8 @@ class AbstractSource(Source, ABC):
         has_slices = False
         for _slice in slices:
             has_slices = True
+            if logger.isEnabledFor(logging.DEBUG):
+                yield AirbyteMessage(type=MessageType.LOG, log=AirbyteLogMessage(level=Level.INFO, message=f"slice:{json.dumps(_slice)}"))
             logger.debug("Processing stream slice", extra={"slice": _slice})
             records = stream_instance.read_records(
                 sync_mode=SyncMode.incremental,
@@ -281,6 +285,8 @@ class AbstractSource(Source, ABC):
         )
         total_records_counter = 0
         for _slice in slices:
+            if logger.isEnabledFor(logging.DEBUG):
+                yield AirbyteMessage(type=MessageType.LOG, log=AirbyteLogMessage(level=Level.INFO, message=f"slice:{json.dumps(_slice)}"))
             logger.debug("Processing stream slice", extra={"slice": _slice})
             record_data_or_messages = stream_instance.read_records(
                 stream_slice=_slice,

--- a/airbyte-cdk/python/airbyte_cdk/sources/declarative/requesters/paginators/default_paginator.py
+++ b/airbyte-cdk/python/airbyte_cdk/sources/declarative/requesters/paginators/default_paginator.py
@@ -172,9 +172,11 @@ class PaginatorTestReadDecorator(Paginator):
     _DEFAULT_PAGINATION_LIMIT = 5
 
     def __init__(self, decorated, maximum_number_of_pages: int = None):
+        if maximum_number_of_pages and maximum_number_of_pages < 1:
+            raise ValueError(f"The maximum number of pages on a test read needs to be strictly positive. Got {maximum_number_of_pages}")
+        self._maximum_number_of_pages = maximum_number_of_pages if maximum_number_of_pages else self._DEFAULT_PAGINATION_LIMIT
         self._decorated = decorated
         self._page_count = self._PAGE_COUNT_BEFORE_FIRST_NEXT_CALL
-        self._maximum_number_of_pages = maximum_number_of_pages if maximum_number_of_pages else self._DEFAULT_PAGINATION_LIMIT
 
     def next_page_token(self, response: requests.Response, last_records: List[Mapping[str, Any]]) -> Optional[Mapping[str, Any]]:
         if self._page_count >= self._maximum_number_of_pages:

--- a/airbyte-cdk/python/airbyte_cdk/sources/declarative/retrievers/simple_retriever.py
+++ b/airbyte-cdk/python/airbyte_cdk/sources/declarative/retrievers/simple_retriever.py
@@ -417,18 +417,26 @@ class SimpleRetriever(Retriever, HttpStream, JsonSchemaMixin):
         yield from self.parse_response(response, stream_slice=stream_slice, stream_state=stream_state)
 
 
+@dataclass
 class SimpleRetrieverTestReadDecorator(SimpleRetriever):
     """
     In some cases, we want to limit the number of requests that are made to the backend source. This class allows for limiting the number of
     slices that are queried throughout a read command.
     """
 
-    _MAXIMUM_NUMBER_OF_SLICES = 5
+    maximum_number_of_slices: int = 5
+
+    def __post_init__(self, options: Mapping[str, Any]):
+        super().__post_init__(options)
+        if self.maximum_number_of_slices and self.maximum_number_of_slices < 1:
+            raise ValueError(
+                f"The maximum number of slices on a test read needs to be strictly positive. Got {self.maximum_number_of_slices}"
+            )
 
     def stream_slices(
         self, *, sync_mode: SyncMode, cursor_field: List[str] = None, stream_state: Optional[StreamState] = None
     ) -> Iterable[Optional[Mapping[str, Any]]]:
-        return islice(super().stream_slices(sync_mode=sync_mode, stream_state=stream_state), self._MAXIMUM_NUMBER_OF_SLICES)
+        return islice(super().stream_slices(sync_mode=sync_mode, stream_state=stream_state), self.maximum_number_of_slices)
 
 
 def _prepared_request_to_airbyte_message(request: requests.PreparedRequest) -> AirbyteMessage:

--- a/airbyte-cdk/python/unit_tests/sources/declarative/test_manifest_declarative_source.py
+++ b/airbyte-cdk/python/unit_tests/sources/declarative/test_manifest_declarative_source.py
@@ -12,6 +12,7 @@ import yaml
 from airbyte_cdk.sources.declarative.declarative_stream import DeclarativeStream
 from airbyte_cdk.sources.declarative.manifest_declarative_source import ManifestDeclarativeSource
 from jsonschema.exceptions import ValidationError
+from unittest.mock import patch
 
 logger = logging.getLogger("airbyte")
 
@@ -540,6 +541,95 @@ class TestManifestDeclarativeSource:
         }
         with pytest.raises(ValidationError):
             ManifestDeclarativeSource(source_config=manifest, construct_using_pydantic_models=construct_using_pydantic_models)
+
+
+    @patch("airbyte_cdk.sources.declarative.declarative_source.DeclarativeSource.read")
+    def test_given_debug_when_read_then_set_log_level(self, declarative_source_read):
+        any_valid_manifest = {
+            "version": "version",
+            "definitions": {
+                "schema_loader": {"name": "{{ options.stream_name }}", "file_path": "./source_sendgrid/schemas/{{ options.name }}.yaml"},
+                "retriever": {
+                    "paginator": {
+                        "type": "DefaultPaginator",
+                        "page_size": 10,
+                        "page_size_option": {"inject_into": "request_parameter", "field_name": "page_size"},
+                        "page_token_option": {"inject_into": "path"},
+                        "pagination_strategy": {"type": "CursorPagination", "cursor_value": "{{ response._metadata.next }}"},
+                    },
+                    "requester": {
+                        "path": "/v3/marketing/lists",
+                        "authenticator": {"type": "BearerAuthenticator", "api_token": "{{ config.apikey }}"},
+                        "request_parameters": {"page_size": 10},
+                    },
+                    "record_selector": {"extractor": {"field_pointer": ["result"]}},
+                },
+            },
+            "streams": [
+                {
+                    "type": "DeclarativeStream",
+                    "$options": {"name": "lists", "primary_key": "id", "url_base": "https://api.sendgrid.com"},
+                    "schema_loader": {
+                        "name": "{{ options.stream_name }}",
+                        "file_path": "./source_sendgrid/schemas/{{ options.name }}.yaml",
+                    },
+                    "retriever": {
+                        "paginator": {
+                            "type": "DefaultPaginator",
+                            "page_size": 10,
+                            "page_size_option": {"inject_into": "request_parameter", "field_name": "page_size"},
+                            "page_token_option": {"inject_into": "path"},
+                            "pagination_strategy": {
+                                "type": "CursorPagination",
+                                "cursor_value": "{{ response._metadata.next }}",
+                                "page_size": 10,
+                            },
+                        },
+                        "requester": {
+                            "path": "/v3/marketing/lists",
+                            "authenticator": {"type": "BearerAuthenticator", "api_token": "{{ config.apikey }}"},
+                            "request_parameters": {"page_size": 10},
+                        },
+                        "record_selector": {"extractor": {"field_pointer": ["result"]}},
+                    },
+                },
+                {
+                    "type": "DeclarativeStream",
+                    "$options": {"name": "stream_with_custom_requester", "primary_key": "id", "url_base": "https://api.sendgrid.com"},
+                    "schema_loader": {
+                        "name": "{{ options.stream_name }}",
+                        "file_path": "./source_sendgrid/schemas/{{ options.name }}.yaml",
+                    },
+                    "retriever": {
+                        "paginator": {
+                            "type": "DefaultPaginator",
+                            "page_size": 10,
+                            "page_size_option": {"inject_into": "request_parameter", "field_name": "page_size"},
+                            "page_token_option": {"inject_into": "path"},
+                            "pagination_strategy": {
+                                "type": "CursorPagination",
+                                "cursor_value": "{{ response._metadata.next }}",
+                                "page_size": 10,
+                            },
+                        },
+                        "requester": {
+                            "type": "CustomRequester",
+                            "class_name": "unit_tests.sources.declarative.external_component.SampleCustomComponent",
+                            "path": "/v3/marketing/lists",
+                            "custom_request_parameters": {"page_size": 10},
+                        },
+                        "record_selector": {"extractor": {"field_pointer": ["result"]}},
+                    },
+                },
+            ],
+            "check": {"type": "CheckStream", "stream_names": ["lists"]},
+        }
+        source = ManifestDeclarativeSource(source_config=any_valid_manifest, debug=True, construct_using_pydantic_models=True)
+
+        debug_logger = logging.getLogger("logger.debug")
+        list(source.read(debug_logger, {}, {}, {}))
+
+        assert debug_logger.isEnabledFor(logging.DEBUG)
 
 
 def test_generate_schema():

--- a/airbyte-connector-builder-server/connector_builder/entrypoint.py
+++ b/airbyte-connector-builder-server/connector_builder/entrypoint.py
@@ -4,9 +4,13 @@
 
 from connector_builder.generated.apis.default_api_interface import initialize_router
 from connector_builder.impl.default_api import DefaultApiImpl
-from connector_builder.impl.low_code_cdk_adapter import LowCodeSourceAdapter
+from connector_builder.impl.low_code_cdk_adapter import LowCodeSourceAdapterFactory
 from fastapi import FastAPI
 from fastapi.middleware.cors import CORSMiddleware
+
+_MAXIMUM_NUMBER_OF_PAGES_PER_SLICE = 5
+_MAXIMUM_NUMBER_OF_SLICES = 5
+_ADAPTER_FACTORY = LowCodeSourceAdapterFactory(_MAXIMUM_NUMBER_OF_PAGES_PER_SLICE, _MAXIMUM_NUMBER_OF_SLICES)
 
 app = FastAPI(
     title="Connector Builder Server API",
@@ -22,4 +26,4 @@ app.add_middleware(
     allow_headers=["*"],
 )
 
-app.include_router(initialize_router(DefaultApiImpl(LowCodeSourceAdapter)))
+app.include_router(initialize_router(DefaultApiImpl(_ADAPTER_FACTORY, _MAXIMUM_NUMBER_OF_PAGES_PER_SLICE, _MAXIMUM_NUMBER_OF_SLICES)))

--- a/airbyte-connector-builder-server/connector_builder/generated/models/stream_read.py
+++ b/airbyte-connector-builder-server/connector_builder/generated/models/stream_read.py
@@ -19,11 +19,13 @@ class StreamRead(BaseModel):
 
         logs: The logs of this StreamRead.
         slices: The slices of this StreamRead.
+        test_read_limit_reached: The test_read_limit_reached of this StreamRead.
         inferred_schema: The inferred_schema of this StreamRead [Optional].
     """
 
     logs: List[object]
     slices: List[StreamReadSlices]
+    test_read_limit_reached: bool
     inferred_schema: Optional[Dict[str, Any]] = None
 
 StreamRead.update_forward_refs()

--- a/airbyte-connector-builder-server/connector_builder/impl/adapter.py
+++ b/airbyte-connector-builder-server/connector_builder/impl/adapter.py
@@ -32,3 +32,11 @@ class CdkAdapter(ABC):
         :param config: The user-provided configuration as specified by the source's spec.
         :return: An iterator over `AirbyteMessage` objects.
         """
+
+
+class CdkAdapterFactory(ABC):
+
+    @abstractmethod
+    def create(self, manifest: Dict[str, Any]) -> CdkAdapter:
+        """Return an implementation of CdkAdapter"""
+        pass

--- a/airbyte-connector-builder-server/connector_builder/impl/low_code_cdk_adapter.py
+++ b/airbyte-connector-builder-server/connector_builder/impl/low_code_cdk_adapter.py
@@ -10,13 +10,17 @@ from airbyte_cdk.sources.declarative.declarative_stream import DeclarativeStream
 from airbyte_cdk.sources.declarative.parsers.model_to_component_factory import ModelToComponentFactory
 from airbyte_cdk.sources.declarative.yaml_declarative_source import ManifestDeclarativeSource
 from airbyte_cdk.sources.streams.http import HttpStream
-from connector_builder.impl.adapter import CdkAdapter
+from connector_builder.impl.adapter import CdkAdapter, CdkAdapterFactory
 
 
 class LowCodeSourceAdapter(CdkAdapter):
-    def __init__(self, manifest: Dict[str, Any]):
+    def __init__(self, manifest: Dict[str, Any], limit_page_fetched_per_slice, limit_slices_fetched):
         # Request and response messages are only emitted for a sources that have debug turned on
-        self._source = ManifestDeclarativeSource(manifest, debug=True, component_factory=ModelToComponentFactory(is_test_read=True))
+        self._source = ManifestDeclarativeSource(
+            manifest,
+            debug=True,
+            component_factory=ModelToComponentFactory(limit_page_fetched_per_slice, limit_slices_fetched)
+        )
 
     def get_http_streams(self, config: Dict[str, Any]) -> List[HttpStream]:
         http_streams = []
@@ -59,3 +63,13 @@ class LowCodeSourceAdapter(CdkAdapter):
         except Exception as e:
             yield AirbyteMessage(type=MessageType.LOG, log=AirbyteLogMessage(level=Level.ERROR, message=str(e)))
             return
+
+
+class LowCodeSourceAdapterFactory(CdkAdapterFactory):
+
+    def __init__(self, max_pages_per_slice, max_slices):
+        self._max_pages_per_slice = max_pages_per_slice
+        self._max_slices = max_slices
+
+    def create(self, manifest: Dict[str, Any]) -> CdkAdapter:
+        return LowCodeSourceAdapter(manifest, self._max_pages_per_slice, self._max_slices)

--- a/airbyte-connector-builder-server/src/main/openapi/openapi.yaml
+++ b/airbyte-connector-builder-server/src/main/openapi/openapi.yaml
@@ -77,6 +77,7 @@ components:
       required:
         - logs
         - slices
+        - test_read_limit_reached
       properties:
         logs:
           type: array
@@ -123,6 +124,9 @@ components:
                 type: object
                 description: The STATE AirbyteMessage emitted at the end of this slice. This can be omitted if a stream slicer is not configured.
                 # $ref: "#/components/schemas/AirbyteProtocol/definitions/AirbyteStateMessage"
+        test_read_limit_reached:
+          type: boolean
+          description: Whether the maximum number of request per slice or the maximum number of slices queried has been reached
         inferred_schema:
           type: object
           description: The narrowest JSON Schema against which every AirbyteRecord in the slices can validate successfully. This is inferred from reading every record in the output slices.

--- a/airbyte-connector-builder-server/unit_tests/connector_builder/impl/test_default_api.py
+++ b/airbyte-connector-builder-server/unit_tests/connector_builder/impl/test_default_api.py
@@ -18,9 +18,12 @@ from connector_builder.generated.models.streams_list_read import StreamsListRead
 from connector_builder.generated.models.streams_list_read_streams import StreamsListReadStreams
 from connector_builder.generated.models.streams_list_request_body import StreamsListRequestBody
 from connector_builder.impl.default_api import DefaultApiImpl
-from connector_builder.impl.low_code_cdk_adapter import LowCodeSourceAdapter
+from connector_builder.impl.low_code_cdk_adapter import LowCodeSourceAdapter, LowCodeSourceAdapterFactory
 from fastapi import HTTPException
 from pydantic.error_wrappers import ValidationError
+
+MAX_PAGES_PER_SLICE = 4
+MAX_SLICES = 3
 
 MANIFEST = {
     "version": "0.1.0",
@@ -103,7 +106,7 @@ def test_list_streams():
         StreamsListReadStreams(name="breathing-techniques", url="https://demonslayers.com/api/v1/breathing_techniques"),
     ]
 
-    api = DefaultApiImpl(LowCodeSourceAdapter)
+    api = DefaultApiImpl(LowCodeSourceAdapterFactory(MAX_PAGES_PER_SLICE, MAX_SLICES), MAX_PAGES_PER_SLICE, MAX_SLICES)
     streams_list_request_body = StreamsListRequestBody(manifest=MANIFEST, config=CONFIG)
     loop = asyncio.get_event_loop()
     actual_streams = loop.run_until_complete(api.list_streams(streams_list_request_body))
@@ -137,7 +140,7 @@ def test_list_streams_with_interpolated_urls():
 
     expected_streams = StreamsListRead(streams=[StreamsListReadStreams(name="demons", url="https://upper-six.muzan.com/api/v1/demons")])
 
-    api = DefaultApiImpl(LowCodeSourceAdapter)
+    api = DefaultApiImpl(LowCodeSourceAdapterFactory(MAX_PAGES_PER_SLICE, MAX_SLICES), MAX_PAGES_PER_SLICE, MAX_SLICES)
     streams_list_request_body = StreamsListRequestBody(manifest=manifest, config=CONFIG)
     loop = asyncio.get_event_loop()
     actual_streams = loop.run_until_complete(api.list_streams(streams_list_request_body))
@@ -171,7 +174,7 @@ def test_list_streams_with_unresolved_interpolation():
     # The interpolated string {{ config['not_in_config'] }} doesn't resolve to anything so it ends up blank during interpolation
     expected_streams = StreamsListRead(streams=[StreamsListReadStreams(name="demons", url="https://.muzan.com/api/v1/demons")])
 
-    api = DefaultApiImpl(LowCodeSourceAdapter)
+    api = DefaultApiImpl(LowCodeSourceAdapterFactory(MAX_PAGES_PER_SLICE, MAX_SLICES), MAX_PAGES_PER_SLICE, MAX_SLICES)
 
     streams_list_request_body = StreamsListRequestBody(manifest=manifest, config=CONFIG)
     loop = asyncio.get_event_loop()
@@ -214,7 +217,7 @@ def test_read_stream():
         ),
     ]
 
-    mock_source_adapter_cls = make_mock_adapter_cls(
+    mock_source_adapter_cls = make_mock_adapter_factory(
         iter(
             [
                 request_log_message(request),
@@ -228,7 +231,7 @@ def test_read_stream():
         )
     )
 
-    api = DefaultApiImpl(mock_source_adapter_cls)
+    api = DefaultApiImpl(mock_source_adapter_cls, MAX_PAGES_PER_SLICE, MAX_SLICES)
 
     loop = asyncio.get_event_loop()
     actual_response: StreamRead = loop.run_until_complete(
@@ -279,7 +282,7 @@ def test_read_stream_with_logs():
         {"message": "log message after the response"},
     ]
 
-    mock_source_adapter_cls = make_mock_adapter_cls(
+    mock_source_adapter_cls = make_mock_adapter_factory(
         iter(
             [
                 AirbyteMessage(type=Type.LOG, log=AirbyteLogMessage(level=Level.INFO, message="log message before the request")),
@@ -293,7 +296,7 @@ def test_read_stream_with_logs():
         )
     )
 
-    api = DefaultApiImpl(mock_source_adapter_cls)
+    api = DefaultApiImpl(mock_source_adapter_cls, MAX_PAGES_PER_SLICE, MAX_SLICES)
 
     loop = asyncio.get_event_loop()
     actual_response: StreamRead = loop.run_until_complete(
@@ -322,7 +325,7 @@ def test_read_stream_record_limit(request_record_limit, max_record_limit):
         "body": {"custom": "field"},
     }
     response = {"status_code": 200, "headers": {"field": "value"}, "body": '{"name": "field"}'}
-    mock_source_adapter_cls = make_mock_adapter_cls(
+    mock_source_adapter_cls = make_mock_adapter_factory(
         iter(
             [
                 request_log_message(request),
@@ -339,7 +342,7 @@ def test_read_stream_record_limit(request_record_limit, max_record_limit):
     n_records = 2
     record_limit = min(request_record_limit, max_record_limit)
 
-    api = DefaultApiImpl(mock_source_adapter_cls, max_record_limit=max_record_limit)
+    api = DefaultApiImpl(mock_source_adapter_cls, MAX_PAGES_PER_SLICE, MAX_SLICES, max_record_limit=max_record_limit)
     loop = asyncio.get_event_loop()
     actual_response: StreamRead = loop.run_until_complete(
         api.read_stream(StreamReadRequestBody(manifest=MANIFEST, config=CONFIG, stream="hashiras", record_limit=request_record_limit))
@@ -365,7 +368,7 @@ def test_read_stream_default_record_limit(max_record_limit):
         "body": {"custom": "field"},
     }
     response = {"status_code": 200, "headers": {"field": "value"}, "body": '{"name": "field"}'}
-    mock_source_adapter_cls = make_mock_adapter_cls(
+    mock_source_adapter_cls = make_mock_adapter_factory(
         iter(
             [
                 request_log_message(request),
@@ -381,7 +384,7 @@ def test_read_stream_default_record_limit(max_record_limit):
     )
     n_records = 2
 
-    api = DefaultApiImpl(mock_source_adapter_cls, max_record_limit=max_record_limit)
+    api = DefaultApiImpl(mock_source_adapter_cls, MAX_PAGES_PER_SLICE, MAX_SLICES, max_record_limit=max_record_limit)
     loop = asyncio.get_event_loop()
     actual_response: StreamRead = loop.run_until_complete(
         api.read_stream(StreamReadRequestBody(manifest=MANIFEST, config=CONFIG, stream="hashiras"))
@@ -400,7 +403,7 @@ def test_read_stream_limit_0():
         "body": {"custom": "field"},
     }
     response = {"status_code": 200, "headers": {"field": "value"}, "body": '{"name": "field"}'}
-    mock_source_adapter_cls = make_mock_adapter_cls(
+    mock_source_adapter_cls = make_mock_adapter_factory(
         iter(
             [
                 request_log_message(request),
@@ -414,7 +417,7 @@ def test_read_stream_limit_0():
             ]
         )
     )
-    api = DefaultApiImpl(mock_source_adapter_cls)
+    api = DefaultApiImpl(mock_source_adapter_cls, MAX_PAGES_PER_SLICE, MAX_SLICES)
     loop = asyncio.get_event_loop()
 
     with pytest.raises(ValidationError):
@@ -455,7 +458,7 @@ def test_read_stream_no_records():
         ),
     ]
 
-    mock_source_adapter_cls = make_mock_adapter_cls(
+    mock_source_adapter_cls = make_mock_adapter_factory(
         iter(
             [
                 request_log_message(request),
@@ -466,7 +469,7 @@ def test_read_stream_no_records():
         )
     )
 
-    api = DefaultApiImpl(mock_source_adapter_cls)
+    api = DefaultApiImpl(mock_source_adapter_cls, MAX_PAGES_PER_SLICE, MAX_SLICES)
 
     loop = asyncio.get_event_loop()
     actual_response: StreamRead = loop.run_until_complete(
@@ -503,7 +506,7 @@ def test_invalid_manifest():
 
     expected_status_code = 400
 
-    api = DefaultApiImpl(LowCodeSourceAdapter)
+    api = DefaultApiImpl(LowCodeSourceAdapterFactory(MAX_PAGES_PER_SLICE, MAX_SLICES), MAX_PAGES_PER_SLICE, MAX_SLICES)
     loop = asyncio.get_event_loop()
     with pytest.raises(HTTPException) as actual_exception:
         loop.run_until_complete(api.read_stream(StreamReadRequestBody(manifest=invalid_manifest, config={}, stream="hashiras")))
@@ -514,7 +517,7 @@ def test_invalid_manifest():
 def test_read_stream_invalid_group_format():
     response = {"status_code": 200, "headers": {"field": "value"}, "body": '{"name": "field"}'}
 
-    mock_source_adapter_cls = make_mock_adapter_cls(
+    mock_source_adapter_cls = make_mock_adapter_factory(
         iter(
             [
                 response_log_message(response),
@@ -524,7 +527,7 @@ def test_read_stream_invalid_group_format():
         )
     )
 
-    api = DefaultApiImpl(mock_source_adapter_cls)
+    api = DefaultApiImpl(mock_source_adapter_cls, MAX_PAGES_PER_SLICE, MAX_SLICES)
 
     loop = asyncio.get_event_loop()
     with pytest.raises(HTTPException) as actual_exception:
@@ -536,7 +539,7 @@ def test_read_stream_invalid_group_format():
 def test_read_stream_returns_error_if_stream_does_not_exist():
     expected_status_code = 400
 
-    api = DefaultApiImpl(LowCodeSourceAdapter)
+    api = DefaultApiImpl(LowCodeSourceAdapterFactory(MAX_PAGES_PER_SLICE, MAX_SLICES), MAX_PAGES_PER_SLICE, MAX_SLICES)
     loop = asyncio.get_event_loop()
     with pytest.raises(HTTPException) as actual_exception:
         loop.run_until_complete(api.read_stream(StreamReadRequestBody(manifest=MANIFEST, config={}, stream="not_in_manifest")))
@@ -586,7 +589,7 @@ def test_read_stream_returns_error_if_stream_does_not_exist():
 )
 def test_create_request_from_log_message(log_message, expected_request):
     airbyte_log_message = AirbyteLogMessage(level=Level.INFO, message=log_message)
-    api = DefaultApiImpl(LowCodeSourceAdapter)
+    api = DefaultApiImpl(LowCodeSourceAdapterFactory(MAX_PAGES_PER_SLICE, MAX_SLICES), MAX_PAGES_PER_SLICE, MAX_SLICES)
     actual_request = api._create_request_from_log_message(airbyte_log_message)
 
     assert actual_request == expected_request
@@ -621,22 +624,17 @@ def test_create_response_from_log_message(log_message, expected_response):
         response_message = f"response:{json.dumps(log_message)}"
 
     airbyte_log_message = AirbyteLogMessage(level=Level.INFO, message=response_message)
-    api = DefaultApiImpl(LowCodeSourceAdapter)
+    api = DefaultApiImpl(LowCodeSourceAdapterFactory(MAX_PAGES_PER_SLICE, MAX_SLICES), MAX_PAGES_PER_SLICE, MAX_SLICES)
     actual_response = api._create_response_from_log_message(airbyte_log_message)
 
     assert actual_response == expected_response
 
 
 def test_read_stream_with_many_slices():
-    request = {
-        "url": "https://demonslayers.com/api/v1/hashiras?era=taisho",
-        "headers": {"Content-Type": "application/json"},
-        "body": {"custom": "field"},
-        "http_method": "GET",
-    }
-    response = {"status_code": 200, "headers": {"field": "value"}, "body": '{"name": "field"}'}
+    request = {}
+    response = {"status_code": 200}
 
-    mock_source_adapter_cls = make_mock_adapter_cls(
+    mock_source_adapter_cls = make_mock_adapter_factory(
         iter(
             [
                 slice_message(),
@@ -655,13 +653,14 @@ def test_read_stream_with_many_slices():
         )
     )
 
-    api = DefaultApiImpl(mock_source_adapter_cls)
+    api = DefaultApiImpl(mock_source_adapter_cls, MAX_PAGES_PER_SLICE, MAX_SLICES)
 
     loop = asyncio.get_event_loop()
     stream_read: StreamRead = loop.run_until_complete(
         api.read_stream(StreamReadRequestBody(manifest=MANIFEST, config=CONFIG, stream="hashiras"))
     )
 
+    assert not stream_read.test_read_limit_reached
     assert 2 == len(stream_read.slices)
 
     assert 2 == len(stream_read.slices[0].pages)
@@ -672,9 +671,53 @@ def test_read_stream_with_many_slices():
     assert 1 == len(stream_read.slices[1].pages[0].records)
 
 
-def make_mock_adapter_cls(return_value: Iterator) -> MagicMock:
-    mock_source_adapter_cls = MagicMock()
+def test_read_stream_given_maximum_number_of_slices_then_test_read_limit_reached():
+    maximum_number_of_slices = 5
+    request = {}
+    response = {"status_code": 200}
+    mock_source_adapter_cls = make_mock_adapter_factory(
+        iter(
+            [
+                slice_message(),
+                request_log_message(request),
+                response_log_message(response)
+            ] * maximum_number_of_slices
+        )
+    )
+
+    api = DefaultApiImpl(mock_source_adapter_cls, MAX_PAGES_PER_SLICE, MAX_SLICES)
+
+    loop = asyncio.get_event_loop()
+    stream_read: StreamRead = loop.run_until_complete(
+        api.read_stream(StreamReadRequestBody(manifest=MANIFEST, config=CONFIG, stream="hashiras"))
+    )
+
+    assert stream_read.test_read_limit_reached
+
+
+def test_read_stream_given_maximum_number_of_pages_then_test_read_limit_reached():
+    maximum_number_of_pages_per_slice = 5
+    request = {}
+    response = {"status_code": 200}
+    mock_source_adapter_cls = make_mock_adapter_factory(
+        iter(
+            [slice_message()] + [request_log_message(request), response_log_message(response)] * maximum_number_of_pages_per_slice
+        )
+    )
+
+    api = DefaultApiImpl(mock_source_adapter_cls, MAX_PAGES_PER_SLICE, MAX_SLICES)
+
+    loop = asyncio.get_event_loop()
+    stream_read: StreamRead = loop.run_until_complete(
+        api.read_stream(StreamReadRequestBody(manifest=MANIFEST, config=CONFIG, stream="hashiras"))
+    )
+
+    assert stream_read.test_read_limit_reached
+
+
+def make_mock_adapter_factory(return_value: Iterator) -> MagicMock:
+    mock_source_adapter_factory = MagicMock()
     mock_source_adapter = MagicMock()
     mock_source_adapter.read_stream.return_value = return_value
-    mock_source_adapter_cls.return_value = mock_source_adapter
-    return mock_source_adapter_cls
+    mock_source_adapter_factory.create.return_value = mock_source_adapter
+    return mock_source_adapter_factory

--- a/airbyte-connector-builder-server/unit_tests/connector_builder/impl/test_default_api.py
+++ b/airbyte-connector-builder-server/unit_tests/connector_builder/impl/test_default_api.py
@@ -18,7 +18,7 @@ from connector_builder.generated.models.streams_list_read import StreamsListRead
 from connector_builder.generated.models.streams_list_read_streams import StreamsListReadStreams
 from connector_builder.generated.models.streams_list_request_body import StreamsListRequestBody
 from connector_builder.impl.default_api import DefaultApiImpl
-from connector_builder.impl.low_code_cdk_adapter import LowCodeSourceAdapter, LowCodeSourceAdapterFactory
+from connector_builder.impl.low_code_cdk_adapter import LowCodeSourceAdapterFactory
 from fastapi import HTTPException
 from pydantic.error_wrappers import ValidationError
 
@@ -640,6 +640,10 @@ def test_read_stream_with_many_slices():
                 slice_message(),
                 request_log_message(request),
                 response_log_message(response),
+                record_message("hashiras", {"name": "Muichiro Tokito"}),
+                slice_message(),
+                request_log_message(request),
+                response_log_message(response),
                 record_message("hashiras", {"name": "Shinobu Kocho"}),
                 record_message("hashiras", {"name": "Mitsuri Kanroji"}),
                 request_log_message(request),
@@ -647,8 +651,6 @@ def test_read_stream_with_many_slices():
                 record_message("hashiras", {"name": "Obanai Iguro"}),
                 request_log_message(request),
                 response_log_message(response),
-                slice_message(),
-                record_message("hashiras", {"name": "Muichiro Tokito"}),
             ]
         )
     )
@@ -661,14 +663,16 @@ def test_read_stream_with_many_slices():
     )
 
     assert not stream_read.test_read_limit_reached
-    assert 2 == len(stream_read.slices)
+    assert len(stream_read.slices) == 2
 
-    assert 2 == len(stream_read.slices[0].pages)
-    assert 2 == len(stream_read.slices[0].pages[0].records)
-    assert 1 == len(stream_read.slices[0].pages[1].records)
+    assert len(stream_read.slices[0].pages) == 1
+    assert len(stream_read.slices[0].pages[0].records) == 1
 
-    assert 1 == len(stream_read.slices[1].pages)
-    assert 1 == len(stream_read.slices[1].pages[0].records)
+    assert len(stream_read.slices[1].pages) == 3
+    assert len(stream_read.slices[1].pages[0].records) == 2
+    assert len(stream_read.slices[1].pages[1].records) == 1
+    assert len(stream_read.slices[1].pages[2].records) == 0
+
 
 
 def test_read_stream_given_maximum_number_of_slices_then_test_read_limit_reached():

--- a/airbyte-connector-builder-server/unit_tests/connector_builder/impl/test_low_code_cdk_adapter.py
+++ b/airbyte-connector-builder-server/unit_tests/connector_builder/impl/test_low_code_cdk_adapter.py
@@ -208,7 +208,7 @@ MANIFEST_WITH_PAGINATOR = {
 def test_get_http_streams():
     expected_urls = {"https://demonslayers.com/api/v1/breathing_techniques", "https://demonslayers.com/api/v1/hashiras"}
 
-    adapter = LowCodeSourceAdapter(MANIFEST)
+    adapter = LowCodeSourceAdapter(MANIFEST, MAXIMUM_NUMBER_OF_PAGES_PER_SLICE, MAXIMUM_NUMBER_OF_SLICES)
     actual_streams = adapter.get_http_streams(config={})
     actual_urls = {http_stream.url_base + http_stream.path() for http_stream in actual_streams}
 
@@ -216,10 +216,13 @@ def test_get_http_streams():
     assert actual_urls == expected_urls
 
 
+MAXIMUM_NUMBER_OF_PAGES_PER_SLICE = 5
+MAXIMUM_NUMBER_OF_SLICES = 5
+
 def test_get_http_manifest_with_references():
     expected_urls = {"https://demonslayers.com/api/v1/ranks"}
 
-    adapter = LowCodeSourceAdapter(MANIFEST_WITH_REFERENCES)
+    adapter = LowCodeSourceAdapter(MANIFEST_WITH_REFERENCES, MAXIMUM_NUMBER_OF_PAGES_PER_SLICE, MAXIMUM_NUMBER_OF_SLICES)
     actual_streams = adapter.get_http_streams(config={})
     actual_urls = {http_stream.url_base + http_stream.path() for http_stream in actual_streams}
 
@@ -233,7 +236,7 @@ def test_get_http_streams_non_declarative_streams():
     mock_source = MagicMock()
     mock_source.streams.return_value = [non_declarative_stream]
 
-    adapter = LowCodeSourceAdapter(MANIFEST)
+    adapter = LowCodeSourceAdapter(MANIFEST, MAXIMUM_NUMBER_OF_PAGES_PER_SLICE, MAXIMUM_NUMBER_OF_SLICES)
     adapter._source = mock_source
     with pytest.raises(TypeError):
         adapter.get_http_streams(config={})
@@ -246,7 +249,7 @@ def test_get_http_streams_non_http_stream():
     mock_source = MagicMock()
     mock_source.streams.return_value = [declarative_stream_non_http_retriever]
 
-    adapter = LowCodeSourceAdapter(MANIFEST)
+    adapter = LowCodeSourceAdapter(MANIFEST, MAXIMUM_NUMBER_OF_PAGES_PER_SLICE, MAXIMUM_NUMBER_OF_SLICES)
     adapter._source = mock_source
     with pytest.raises(TypeError):
         adapter.get_http_streams(config={})
@@ -276,7 +279,7 @@ def test_read_streams():
     mock_source = MagicMock()
     mock_source.read.return_value = expected_messages
 
-    adapter = LowCodeSourceAdapter(MANIFEST)
+    adapter = LowCodeSourceAdapter(MANIFEST, MAXIMUM_NUMBER_OF_PAGES_PER_SLICE, MAXIMUM_NUMBER_OF_SLICES)
     adapter._source = mock_source
     actual_messages = list(adapter.read_stream("hashiras", {}))
 
@@ -301,7 +304,7 @@ def test_read_streams_with_error():
 
     mock_source.read.side_effect = return_value
 
-    adapter = LowCodeSourceAdapter(MANIFEST)
+    adapter = LowCodeSourceAdapter(MANIFEST, MAXIMUM_NUMBER_OF_PAGES_PER_SLICE, MAXIMUM_NUMBER_OF_SLICES)
     adapter._source = mock_source
     actual_messages = list(adapter.read_stream("hashiras", {}))
 
@@ -338,11 +341,11 @@ def test_read_streams_invalid_reference():
     }
 
     with pytest.raises(UndefinedReferenceException):
-        LowCodeSourceAdapter(invalid_reference_manifest)
+        LowCodeSourceAdapter(invalid_reference_manifest, MAXIMUM_NUMBER_OF_PAGES_PER_SLICE, MAXIMUM_NUMBER_OF_SLICES)
 
 
 def test_stream_use_read_test_retriever_and_paginator():
-    adapter = LowCodeSourceAdapter(MANIFEST_WITH_PAGINATOR)
+    adapter = LowCodeSourceAdapter(MANIFEST_WITH_PAGINATOR, MAXIMUM_NUMBER_OF_PAGES_PER_SLICE, MAXIMUM_NUMBER_OF_SLICES)
     streams = adapter.get_http_streams(config={})
 
     assert streams


### PR DESCRIPTION
## What
In order to validate if the number of requests was limited, we want to be able to know how many pages and slices were queries. We already had the information for the pages but didn't for the slices. This PR addresses the slices part.

## How
Emit a log message when a new slice is being started and catch this log message to create the slices properly

## Recommended reading order
1. `airbyte-cdk/python/airbyte_cdk/sources/abstract_source.py`: how the slice message is logged
2. `airbyte-connector-builder-server/connector_builder/impl/default_api.py`: how we use this log message to create the slices on the connector-builder server

## 🚨 User Impact 🚨
@flash1293, will this be supported by the UI? Although not a breaking API change, there were some assumptions in the backend that there will always be only one slice.
