### PR TITLE
[ISSUE #20771] set flag when limit requests reached

### DIFF
--- a/airbyte-cdk/python/airbyte_cdk/sources/declarative/requesters/paginators/default_paginator.py
+++ b/airbyte-cdk/python/airbyte_cdk/sources/declarative/requesters/paginators/default_paginator.py
@@ -173,7 +173,7 @@ class PaginatorTestReadDecorator(Paginator):
 
     def __init__(self, decorated, maximum_number_of_pages: int = None):
         if maximum_number_of_pages and maximum_number_of_pages < 1:
-            raise ValueError("The maximum number of pages on a test read needs to be strictly positive")
+            raise ValueError(f"The maximum number of pages on a test read needs to be strictly positive. Got {maximum_number_of_pages}")
         self._maximum_number_of_pages = maximum_number_of_pages if maximum_number_of_pages else self._DEFAULT_PAGINATION_LIMIT
         self._decorated = decorated
         self._page_count = self._PAGE_COUNT_BEFORE_FIRST_NEXT_CALL

--- a/airbyte-cdk/python/airbyte_cdk/sources/declarative/requesters/paginators/default_paginator.py
+++ b/airbyte-cdk/python/airbyte_cdk/sources/declarative/requesters/paginators/default_paginator.py
@@ -172,9 +172,11 @@ class PaginatorTestReadDecorator(Paginator):
     _DEFAULT_PAGINATION_LIMIT = 5
 
     def __init__(self, decorated, maximum_number_of_pages: int = None):
+        if maximum_number_of_pages and maximum_number_of_pages < 1:
+            raise ValueError("The maximum number of pages on a test read needs to be strictly positive")
+        self._maximum_number_of_pages = maximum_number_of_pages if maximum_number_of_pages else self._DEFAULT_PAGINATION_LIMIT
         self._decorated = decorated
         self._page_count = self._PAGE_COUNT_BEFORE_FIRST_NEXT_CALL
-        self._maximum_number_of_pages = maximum_number_of_pages if maximum_number_of_pages else self._DEFAULT_PAGINATION_LIMIT
 
     def next_page_token(self, response: requests.Response, last_records: List[Mapping[str, Any]]) -> Optional[Mapping[str, Any]]:
         if self._page_count >= self._maximum_number_of_pages:

--- a/airbyte-cdk/python/airbyte_cdk/sources/declarative/retrievers/simple_retriever.py
+++ b/airbyte-cdk/python/airbyte_cdk/sources/declarative/retrievers/simple_retriever.py
@@ -429,6 +429,8 @@ class SimpleRetrieverTestReadDecorator(SimpleRetriever):
 
     def __post_init__(self, options: Mapping[str, Any]):
         super().__post_init__(options)
+        if self.maximum_number_of_slices and self.maximum_number_of_slices < 1:
+            raise ValueError("The maximum number of slices on a test read needs to be strictly positive")
         self.maximum_number_of_slices = self.maximum_number_of_slices or self._MAXIMUM_NUMBER_OF_SLICES
 
     def stream_slices(

--- a/airbyte-cdk/python/airbyte_cdk/sources/declarative/retrievers/simple_retriever.py
+++ b/airbyte-cdk/python/airbyte_cdk/sources/declarative/retrievers/simple_retriever.py
@@ -424,14 +424,14 @@ class SimpleRetrieverTestReadDecorator(SimpleRetriever):
     slices that are queried throughout a read command.
     """
 
-    _MAXIMUM_NUMBER_OF_SLICES: int = 5
-    maximum_number_of_slices: int = None
+    maximum_number_of_slices: int = 5
 
     def __post_init__(self, options: Mapping[str, Any]):
         super().__post_init__(options)
         if self.maximum_number_of_slices and self.maximum_number_of_slices < 1:
-            raise ValueError("The maximum number of slices on a test read needs to be strictly positive")
-        self.maximum_number_of_slices = self.maximum_number_of_slices or self._MAXIMUM_NUMBER_OF_SLICES
+            raise ValueError(
+                f"The maximum number of slices on a test read needs to be strictly positive. Got {self.maximum_number_of_slices}"
+            )
 
     def stream_slices(
         self, *, sync_mode: SyncMode, cursor_field: List[str] = None, stream_state: Optional[StreamState] = None

--- a/airbyte-connector-builder-server/connector_builder/entrypoint.py
+++ b/airbyte-connector-builder-server/connector_builder/entrypoint.py
@@ -4,9 +4,13 @@
 
 from connector_builder.generated.apis.default_api_interface import initialize_router
 from connector_builder.impl.default_api import DefaultApiImpl
-from connector_builder.impl.low_code_cdk_adapter import LowCodeSourceAdapter
+from connector_builder.impl.low_code_cdk_adapter import LowCodeSourceAdapterFactory
 from fastapi import FastAPI
 from fastapi.middleware.cors import CORSMiddleware
+
+_MAXIMUM_NUMBER_OF_PAGES_PER_SLICE = 5
+_MAXIMUM_NUMBER_OF_SLICES = 5
+_ADAPTER_FACTORY = LowCodeSourceAdapterFactory(_MAXIMUM_NUMBER_OF_PAGES_PER_SLICE, _MAXIMUM_NUMBER_OF_SLICES)
 
 app = FastAPI(
     title="Connector Builder Server API",
@@ -22,4 +26,4 @@ app.add_middleware(
     allow_headers=["*"],
 )
 
-app.include_router(initialize_router(DefaultApiImpl(LowCodeSourceAdapter)))
+app.include_router(initialize_router(DefaultApiImpl(_ADAPTER_FACTORY, _MAXIMUM_NUMBER_OF_PAGES_PER_SLICE, _MAXIMUM_NUMBER_OF_SLICES)))

--- a/airbyte-connector-builder-server/connector_builder/generated/models/stream_read.py
+++ b/airbyte-connector-builder-server/connector_builder/generated/models/stream_read.py
@@ -19,11 +19,13 @@ class StreamRead(BaseModel):
 
         logs: The logs of this StreamRead.
         slices: The slices of this StreamRead.
+        test_read_limit_reached: The test_read_limit_reached of this StreamRead.
         inferred_schema: The inferred_schema of this StreamRead [Optional].
     """
 
     logs: List[object]
     slices: List[StreamReadSlices]
+    test_read_limit_reached: bool
     inferred_schema: Optional[Dict[str, Any]] = None
 
 StreamRead.update_forward_refs()

--- a/airbyte-connector-builder-server/connector_builder/impl/adapter.py
+++ b/airbyte-connector-builder-server/connector_builder/impl/adapter.py
@@ -32,3 +32,11 @@ class CdkAdapter(ABC):
         :param config: The user-provided configuration as specified by the source's spec.
         :return: An iterator over `AirbyteMessage` objects.
         """
+
+
+class CdkAdapterFactory(ABC):
+
+    @abstractmethod
+    def create(self, manifest: Dict[str, Any]) -> CdkAdapter:
+        """Return an implementation of CdkAdapter"""
+        pass

--- a/airbyte-connector-builder-server/connector_builder/impl/default_api.py
+++ b/airbyte-connector-builder-server/connector_builder/impl/default_api.py
@@ -6,7 +6,7 @@ import json
 import logging
 import traceback
 from json import JSONDecodeError
-from typing import Any, Callable, Dict, Iterable, Iterator, Optional, Union
+from typing import Any, Dict, Iterable, Iterator, Optional, Union
 from urllib.parse import parse_qs, urljoin, urlparse
 
 from airbyte_cdk.models import AirbyteLogMessage, AirbyteMessage, Type
@@ -21,20 +21,21 @@ from connector_builder.generated.models.stream_read_slices import StreamReadSlic
 from connector_builder.generated.models.streams_list_read import StreamsListRead
 from connector_builder.generated.models.streams_list_read_streams import StreamsListReadStreams
 from connector_builder.generated.models.streams_list_request_body import StreamsListRequestBody
-from connector_builder.impl.adapter import CdkAdapter
+from connector_builder.impl.adapter import CdkAdapter, CdkAdapterFactory
 from fastapi import Body, HTTPException
 from jsonschema import ValidationError
 
 
 class DefaultApiImpl(DefaultApi):
-    _MAXIMUM_NUMBER_OF_PAGES_PER_SLICE = 5
-    _MAXIMUM_NUMBER_OF_SLICES = 5
 
     logger = logging.getLogger("airbyte.connector-builder")
 
-    def __init__(self, adapter_cls: Callable[[Dict[str, Any]], CdkAdapter], max_record_limit: int = 1000):
-        self.adapter_cls = adapter_cls
+    def __init__(self, adapter_factory: CdkAdapterFactory, max_pages_per_slice, max_slices, max_record_limit: int = 1000):
+        self.adapter_factory = adapter_factory
+        self._max_pages_per_slice = max_pages_per_slice
+        self._max_slices = max_slices
         self.max_record_limit = max_record_limit
+
         super().__init__()
 
     async def get_manifest_template(self) -> str:
@@ -151,11 +152,11 @@ spec:
                           inferred_schema=schema_inferrer.get_stream_schema(stream_read_request_body.stream))
 
     def _has_reached_limit(self, slices):
-        if len(slices) >= self._MAXIMUM_NUMBER_OF_SLICES:
+        if len(slices) >= self._max_slices:
             return True
 
         for slice in slices:
-            if len(slice.pages) >= self._MAXIMUM_NUMBER_OF_PAGES_PER_SLICE:
+            if len(slice.pages) >= self._max_pages_per_slice:
                 return True
         return False
 
@@ -249,7 +250,7 @@ spec:
 
     def _create_low_code_adapter(self, manifest: Dict[str, Any]) -> CdkAdapter:
         try:
-            return self.adapter_cls(manifest, self._MAXIMUM_NUMBER_OF_PAGES_PER_SLICE, self._MAXIMUM_NUMBER_OF_SLICES)
+            return self.adapter_factory.create(manifest)
         except ValidationError as error:
             # TODO: We're temporarily using FastAPI's default exception model. Ideally we should use exceptions defined in the OpenAPI spec
             self.logger.error(f"Invalid connector manifest with error: {error.message} - {DefaultApiImpl._get_stacktrace_as_string(error)}")

--- a/airbyte-connector-builder-server/connector_builder/impl/low_code_cdk_adapter.py
+++ b/airbyte-connector-builder-server/connector_builder/impl/low_code_cdk_adapter.py
@@ -14,9 +14,13 @@ from connector_builder.impl.adapter import CdkAdapter
 
 
 class LowCodeSourceAdapter(CdkAdapter):
-    def __init__(self, manifest: Dict[str, Any]):
+    def __init__(self, manifest: Dict[str, Any], limit_page_fetched_per_slice, limit_slices_fetched):
         # Request and response messages are only emitted for a sources that have debug turned on
-        self._source = ManifestDeclarativeSource(manifest, debug=True, component_factory=ModelToComponentFactory(is_test_read=True))
+        self._source = ManifestDeclarativeSource(
+            manifest,
+            debug=True,
+            component_factory=ModelToComponentFactory(limit_page_fetched_per_slice, limit_slices_fetched)
+        )
 
     def get_http_streams(self, config: Dict[str, Any]) -> List[HttpStream]:
         http_streams = []

--- a/airbyte-connector-builder-server/connector_builder/impl/low_code_cdk_adapter.py
+++ b/airbyte-connector-builder-server/connector_builder/impl/low_code_cdk_adapter.py
@@ -10,7 +10,7 @@ from airbyte_cdk.sources.declarative.declarative_stream import DeclarativeStream
 from airbyte_cdk.sources.declarative.parsers.model_to_component_factory import ModelToComponentFactory
 from airbyte_cdk.sources.declarative.yaml_declarative_source import ManifestDeclarativeSource
 from airbyte_cdk.sources.streams.http import HttpStream
-from connector_builder.impl.adapter import CdkAdapter
+from connector_builder.impl.adapter import CdkAdapter, CdkAdapterFactory
 
 
 class LowCodeSourceAdapter(CdkAdapter):
@@ -63,3 +63,13 @@ class LowCodeSourceAdapter(CdkAdapter):
         except Exception as e:
             yield AirbyteMessage(type=MessageType.LOG, log=AirbyteLogMessage(level=Level.ERROR, message=str(e)))
             return
+
+
+class LowCodeSourceAdapterFactory(CdkAdapterFactory):
+
+    def __init__(self, max_pages_per_slice, max_slices):
+        self._max_pages_per_slice = max_pages_per_slice
+        self._max_slices = max_slices
+
+    def create(self, manifest: Dict[str, Any]) -> CdkAdapter:
+        return LowCodeSourceAdapter(manifest, self._max_pages_per_slice, self._max_slices)

--- a/airbyte-connector-builder-server/src/main/openapi/openapi.yaml
+++ b/airbyte-connector-builder-server/src/main/openapi/openapi.yaml
@@ -77,6 +77,7 @@ components:
       required:
         - logs
         - slices
+        - test_read_limit_reached
       properties:
         logs:
           type: array
@@ -123,6 +124,9 @@ components:
                 type: object
                 description: The STATE AirbyteMessage emitted at the end of this slice. This can be omitted if a stream slicer is not configured.
                 # $ref: "#/components/schemas/AirbyteProtocol/definitions/AirbyteStateMessage"
+        test_read_limit_reached:
+          type: boolean
+          description: Whether the maximum number of request per slice or the maximum number of slices queried has been reached
         inferred_schema:
           type: object
           description: The narrowest JSON Schema against which every AirbyteRecord in the slices can validate successfully. This is inferred from reading every record in the output slices.

--- a/airbyte-connector-builder-server/unit_tests/connector_builder/impl/test_low_code_cdk_adapter.py
+++ b/airbyte-connector-builder-server/unit_tests/connector_builder/impl/test_low_code_cdk_adapter.py
@@ -208,7 +208,7 @@ MANIFEST_WITH_PAGINATOR = {
 def test_get_http_streams():
     expected_urls = {"https://demonslayers.com/api/v1/breathing_techniques", "https://demonslayers.com/api/v1/hashiras"}
 
-    adapter = LowCodeSourceAdapter(MANIFEST)
+    adapter = LowCodeSourceAdapter(MANIFEST, MAXIMUM_NUMBER_OF_PAGES_PER_SLICE, MAXIMUM_NUMBER_OF_SLICES)
     actual_streams = adapter.get_http_streams(config={})
     actual_urls = {http_stream.url_base + http_stream.path() for http_stream in actual_streams}
 
@@ -216,10 +216,13 @@ def test_get_http_streams():
     assert actual_urls == expected_urls
 
 
+MAXIMUM_NUMBER_OF_PAGES_PER_SLICE = 5
+MAXIMUM_NUMBER_OF_SLICES = 5
+
 def test_get_http_manifest_with_references():
     expected_urls = {"https://demonslayers.com/api/v1/ranks"}
 
-    adapter = LowCodeSourceAdapter(MANIFEST_WITH_REFERENCES)
+    adapter = LowCodeSourceAdapter(MANIFEST_WITH_REFERENCES, MAXIMUM_NUMBER_OF_PAGES_PER_SLICE, MAXIMUM_NUMBER_OF_SLICES)
     actual_streams = adapter.get_http_streams(config={})
     actual_urls = {http_stream.url_base + http_stream.path() for http_stream in actual_streams}
 
@@ -233,7 +236,7 @@ def test_get_http_streams_non_declarative_streams():
     mock_source = MagicMock()
     mock_source.streams.return_value = [non_declarative_stream]
 
-    adapter = LowCodeSourceAdapter(MANIFEST)
+    adapter = LowCodeSourceAdapter(MANIFEST, MAXIMUM_NUMBER_OF_PAGES_PER_SLICE, MAXIMUM_NUMBER_OF_SLICES)
     adapter._source = mock_source
     with pytest.raises(TypeError):
         adapter.get_http_streams(config={})
@@ -246,7 +249,7 @@ def test_get_http_streams_non_http_stream():
     mock_source = MagicMock()
     mock_source.streams.return_value = [declarative_stream_non_http_retriever]
 
-    adapter = LowCodeSourceAdapter(MANIFEST)
+    adapter = LowCodeSourceAdapter(MANIFEST, MAXIMUM_NUMBER_OF_PAGES_PER_SLICE, MAXIMUM_NUMBER_OF_SLICES)
     adapter._source = mock_source
     with pytest.raises(TypeError):
         adapter.get_http_streams(config={})
@@ -276,7 +279,7 @@ def test_read_streams():
     mock_source = MagicMock()
     mock_source.read.return_value = expected_messages
 
-    adapter = LowCodeSourceAdapter(MANIFEST)
+    adapter = LowCodeSourceAdapter(MANIFEST, MAXIMUM_NUMBER_OF_PAGES_PER_SLICE, MAXIMUM_NUMBER_OF_SLICES)
     adapter._source = mock_source
     actual_messages = list(adapter.read_stream("hashiras", {}))
 
@@ -301,7 +304,7 @@ def test_read_streams_with_error():
 
     mock_source.read.side_effect = return_value
 
-    adapter = LowCodeSourceAdapter(MANIFEST)
+    adapter = LowCodeSourceAdapter(MANIFEST, MAXIMUM_NUMBER_OF_PAGES_PER_SLICE, MAXIMUM_NUMBER_OF_SLICES)
     adapter._source = mock_source
     actual_messages = list(adapter.read_stream("hashiras", {}))
 
@@ -338,11 +341,11 @@ def test_read_streams_invalid_reference():
     }
 
     with pytest.raises(UndefinedReferenceException):
-        LowCodeSourceAdapter(invalid_reference_manifest)
+        LowCodeSourceAdapter(invalid_reference_manifest, MAXIMUM_NUMBER_OF_PAGES_PER_SLICE, MAXIMUM_NUMBER_OF_SLICES)
 
 
 def test_stream_use_read_test_retriever_and_paginator():
-    adapter = LowCodeSourceAdapter(MANIFEST_WITH_PAGINATOR)
+    adapter = LowCodeSourceAdapter(MANIFEST_WITH_PAGINATOR, MAXIMUM_NUMBER_OF_PAGES_PER_SLICE, MAXIMUM_NUMBER_OF_SLICES)
     streams = adapter.get_http_streams(config={})
 
     assert streams


### PR DESCRIPTION
## What
Now that we know how many pages and slices were queries, we can set the flag in the response so that the UI can display it.

## How
Count the number of slices and the number of pages per slices. If any of these exceeds the limit, set flag to true.

## Recommended reading order
1. `airbyte-cdk/python/airbyte_cdk/sources/abstract_source.py`: how the slice message is logged
2. `airbyte-connector-builder-server/connector_builder/impl/default_api.py`: how we use this log message to create the slices on the connector-builder server

## 🚨 User Impact 🚨
@flash1293, I wouldn't mind trying to add this to the UI but I'm not sure what you had in mind in terms of UX (where to display the warning, content of the warning message, etc...) Do you mind if we sync on this?
