### PR TITLE
:window: :handshake: Free connectors program confirmation UI

### DIFF
--- a/airbyte-webapp/src/components/ui/Toast/Toast.module.scss
+++ b/airbyte-webapp/src/components/ui/Toast/Toast.module.scss
@@ -43,6 +43,7 @@ $toast-bottom-margin: 27px;
   position: fixed;
   box-sizing: border-box;
   bottom: $toast-bottom-margin;
+  margin-left: calc(vars.$width-size-menu / 2);
   left: 50%;
   transform: translate(-50%, 0);
   z-index: z-indices.$notification;

--- a/airbyte-webapp/src/packages/cloud/components/experiments/FreeConnectorProgram/EnrollmentModal/EnrollmentModal.tsx
+++ b/airbyte-webapp/src/packages/cloud/components/experiments/FreeConnectorProgram/EnrollmentModal/EnrollmentModal.tsx
@@ -12,14 +12,13 @@ import { Text } from "components/ui/Text";
 
 import { StripeCheckoutSessionCreate, StripeCheckoutSessionRead } from "packages/cloud/lib/domain/stripe";
 
+import { STRIPE_SUCCESS_QUERY } from "../hooks/useFreeConnectorProgram";
 import { ReactComponent as CardSVG } from "./cards.svg";
 import { ReactComponent as ConnectorGridSvg } from "./connectorGrid.svg";
 import styles from "./EnrollmentModal.module.scss";
 import { ReactComponent as FreeAlphaBetaPillsSVG } from "./free-alpha-beta-pills.svg";
 import { ReactComponent as FreeSVG } from "./free.svg";
 import { ReactComponent as MailSVG } from "./mail.svg";
-
-const STRIPE_SUCCESS_QUERY = "stripeCheckoutSuccess";
 
 interface EnrollmentModalContentProps {
   closeModal: () => void;

--- a/airbyte-webapp/src/packages/cloud/components/experiments/FreeConnectorProgram/EnrollmentModal/useShowEnrollmentModal.tsx
+++ b/airbyte-webapp/src/packages/cloud/components/experiments/FreeConnectorProgram/EnrollmentModal/useShowEnrollmentModal.tsx
@@ -1,4 +1,9 @@
+import { useIntl } from "react-intl";
+
+import { ToastType } from "components/ui/Toast";
+
 import { useModalService } from "hooks/services/Modal";
+import { useNotificationService } from "hooks/services/Notification";
 import { useAuthService } from "packages/cloud/services/auth/AuthService";
 import { useStripeCheckout } from "packages/cloud/services/stripe/StripeService";
 import { useCurrentWorkspaceId } from "services/workspaces/WorkspacesService";
@@ -10,6 +15,18 @@ export const useShowEnrollmentModal = () => {
   const { mutateAsync: createCheckout } = useStripeCheckout();
   const workspaceId = useCurrentWorkspaceId();
   const { emailVerified, sendEmailVerification } = useAuthService();
+  const { formatMessage } = useIntl();
+  const { registerNotification } = useNotificationService();
+
+  const verifyEmail = () =>
+    sendEmailVerification().then(() => {
+      registerNotification({
+        id: "fcp/verify-email",
+        text: formatMessage({ id: "freeConnectorProgram.enrollmentModal.validationEmailConfirmation" }),
+        type: ToastType.INFO,
+      });
+      closeModal();
+    });
 
   return {
     showEnrollmentModal: () => {
@@ -21,7 +38,7 @@ export const useShowEnrollmentModal = () => {
             createCheckout={createCheckout}
             closeModal={closeModal}
             emailVerified={emailVerified}
-            sendEmailVerification={sendEmailVerification}
+            sendEmailVerification={verifyEmail}
           />
         ),
       });

--- a/airbyte-webapp/src/packages/cloud/components/experiments/FreeConnectorProgram/EnrollmentModal/useShowEnrollmentModal.tsx
+++ b/airbyte-webapp/src/packages/cloud/components/experiments/FreeConnectorProgram/EnrollmentModal/useShowEnrollmentModal.tsx
@@ -19,14 +19,15 @@ export const useShowEnrollmentModal = () => {
   const { registerNotification } = useNotificationService();
 
   const verifyEmail = () =>
-    sendEmailVerification().then(() => {
-      registerNotification({
-        id: "fcp/verify-email",
-        text: formatMessage({ id: "freeConnectorProgram.enrollmentModal.validationEmailConfirmation" }),
-        type: ToastType.INFO,
-      });
-      closeModal();
-    });
+    sendEmailVerification()
+      .then(() => {
+        registerNotification({
+          id: "fcp/verify-email",
+          text: formatMessage({ id: "freeConnectorProgram.enrollmentModal.validationEmailConfirmation" }),
+          type: ToastType.INFO,
+        });
+      })
+      .catch(); // don't crash the page on error
 
   return {
     showEnrollmentModal: () => {

--- a/airbyte-webapp/src/packages/cloud/components/experiments/FreeConnectorProgram/InlineEnrollmentCallout.tsx
+++ b/airbyte-webapp/src/packages/cloud/components/experiments/FreeConnectorProgram/InlineEnrollmentCallout.tsx
@@ -5,6 +5,7 @@ import { Callout } from "components/ui/Callout";
 import { Text } from "components/ui/Text";
 
 import { useShowEnrollmentModal } from "./EnrollmentModal";
+import { useFreeConnectorProgram } from "./hooks/useFreeConnectorProgram";
 import styles from "./InlineEnrollmentCallout.module.scss";
 
 export const EnrollLink: React.FC<PropsWithChildren<unknown>> = ({ children }) => {
@@ -17,7 +18,12 @@ export const EnrollLink: React.FC<PropsWithChildren<unknown>> = ({ children }) =
   );
 };
 export const InlineEnrollmentCallout: React.FC = () => {
-  return (
+  const { userDidEnroll } = useFreeConnectorProgram();
+
+  return userDidEnroll ? (
+    // eslint-disable-next-line react/jsx-no-useless-fragment
+    <></>
+  ) : (
     <Callout variant="info" className={styles.container}>
       <Text size="sm">
         <FormattedMessage

--- a/airbyte-webapp/src/packages/cloud/components/experiments/FreeConnectorProgram/InlineEnrollmentCallout.tsx
+++ b/airbyte-webapp/src/packages/cloud/components/experiments/FreeConnectorProgram/InlineEnrollmentCallout.tsx
@@ -20,10 +20,7 @@ export const EnrollLink: React.FC<PropsWithChildren<unknown>> = ({ children }) =
 export const InlineEnrollmentCallout: React.FC = () => {
   const { userDidEnroll } = useFreeConnectorProgram();
 
-  return userDidEnroll ? (
-    // eslint-disable-next-line react/jsx-no-useless-fragment
-    <></>
-  ) : (
+  return userDidEnroll ? null : (
     <Callout variant="info" className={styles.container}>
       <Text size="sm">
         <FormattedMessage

--- a/airbyte-webapp/src/packages/cloud/components/experiments/FreeConnectorProgram/LargeEnrollmentCallout.tsx
+++ b/airbyte-webapp/src/packages/cloud/components/experiments/FreeConnectorProgram/LargeEnrollmentCallout.tsx
@@ -16,10 +16,7 @@ export const LargeEnrollmentCallout: React.FC = () => {
   const { showEnrollmentModal } = useShowEnrollmentModal();
   const { userDidEnroll } = useFreeConnectorProgram();
 
-  return userDidEnroll ? (
-    // eslint-disable-next-line react/jsx-no-useless-fragment
-    <></>
-  ) : (
+  return userDidEnroll ? null : (
     <Callout variant="boldInfo" className={styles.container}>
       <FlexContainer direction="row" alignItems="center" className={styles.flexRow}>
         <FlexItem grow={false} alignSelf="center">

--- a/airbyte-webapp/src/packages/cloud/components/experiments/FreeConnectorProgram/LargeEnrollmentCallout.tsx
+++ b/airbyte-webapp/src/packages/cloud/components/experiments/FreeConnectorProgram/LargeEnrollmentCallout.tsx
@@ -9,12 +9,17 @@ import { Text } from "components/ui/Text";
 
 import { ReactComponent as ConnectorsBadges } from "./connectors-badges.svg";
 import { useShowEnrollmentModal } from "./EnrollmentModal";
+import { useFreeConnectorProgram } from "./hooks/useFreeConnectorProgram";
 import styles from "./LargeEnrollmentCallout.module.scss";
 
 export const LargeEnrollmentCallout: React.FC = () => {
   const { showEnrollmentModal } = useShowEnrollmentModal();
+  const { userDidEnroll } = useFreeConnectorProgram();
 
-  return (
+  return userDidEnroll ? (
+    // eslint-disable-next-line react/jsx-no-useless-fragment
+    <></>
+  ) : (
     <Callout variant="boldInfo" className={styles.container}>
       <FlexContainer direction="row" alignItems="center" className={styles.flexRow}>
         <FlexItem grow={false} alignSelf="center">

--- a/airbyte-webapp/src/packages/cloud/components/experiments/FreeConnectorProgram/hooks/useFreeConnectorProgram.ts
+++ b/airbyte-webapp/src/packages/cloud/components/experiments/FreeConnectorProgram/hooks/useFreeConnectorProgram.ts
@@ -1,6 +1,13 @@
+import { useState } from "react";
+import { useIntl } from "react-intl";
 import { useQuery } from "react-query";
+import { useSearchParams } from "react-router-dom";
+import { useEffectOnce } from "react-use";
+
+import { ToastType } from "components/ui/Toast";
 
 import { useExperiment } from "hooks/services/Experiment";
+import { useNotificationService } from "hooks/services/Notification";
 import { useConfig } from "packages/cloud/services/config";
 import { useDefaultRequestMiddlewares } from "services/useDefaultRequestMiddlewares";
 import { useCurrentWorkspaceId } from "services/workspaces/WorkspacesService";
@@ -16,8 +23,25 @@ export const useFreeConnectorProgram = () => {
   const middlewares = useDefaultRequestMiddlewares();
   const requestOptions = { config, middlewares };
   const freeConnectorProgramEnabled = useExperiment("workspace.freeConnectorsProgram.visible", false);
+  const [searchParams, setSearchParams] = useSearchParams();
+  const [userDidEnroll, setUserDidEnroll] = useState(false);
+  const { formatMessage } = useIntl();
+  const { registerNotification } = useNotificationService();
 
-  return useQuery(["freeConnectorProgramInfo", workspaceId], () =>
+  useEffectOnce(() => {
+    if (searchParams.has(STRIPE_SUCCESS_QUERY)) {
+      // Remove the stripe parameter from the URL
+      setSearchParams({}, { replace: true });
+      setUserDidEnroll(true);
+      registerNotification({
+        id: "fcp/enrolled",
+        text: formatMessage({ id: "freeConnectorProgram.enroll.success" }),
+        type: ToastType.SUCCESS,
+      });
+    }
+  });
+
+  const enrollmentStatusQuery = useQuery(["freeConnectorProgramInfo", workspaceId], () =>
     webBackendGetFreeConnectorProgramInfoForWorkspace({ workspaceId }, requestOptions).then(
       ({ hasEligibleConnector, hasPaymentAccountSaved }) => {
         const userIsEligibleToEnroll = !hasPaymentAccountSaved && hasEligibleConnector;
@@ -29,4 +53,9 @@ export const useFreeConnectorProgram = () => {
       }
     )
   );
+
+  return {
+    enrollmentStatusQuery,
+    userDidEnroll,
+  };
 };

--- a/airbyte-webapp/src/packages/cloud/components/experiments/FreeConnectorProgram/hooks/useFreeConnectorProgram.ts
+++ b/airbyte-webapp/src/packages/cloud/components/experiments/FreeConnectorProgram/hooks/useFreeConnectorProgram.ts
@@ -7,6 +7,8 @@ import { useCurrentWorkspaceId } from "services/workspaces/WorkspacesService";
 
 import { webBackendGetFreeConnectorProgramInfoForWorkspace } from "../lib/api";
 
+export const STRIPE_SUCCESS_QUERY = "fcpEnrollmentSuccess";
+
 export const useFreeConnectorProgram = () => {
   const workspaceId = useCurrentWorkspaceId();
   const { cloudApiUrl } = useConfig();

--- a/airbyte-webapp/src/packages/cloud/locales/en.json
+++ b/airbyte-webapp/src/packages/cloud/locales/en.json
@@ -189,6 +189,7 @@
   "freeConnectorProgram.enrollmentModal.emailNotification": "We will let you know through email before a Connector you use moves to GA",
   "freeConnectorProgram.enrollmentModal.cardOnFile": "When both Connectors are in GA, the Connection will no longer be free. You'll need to have a credit card on file to enroll so Airbyte can handle a Connection's transition to paid service.",
   "freeConnectorProgram.enrollmentModal.unvalidatedEmailWarning": "You need to <b>verify your email</b> address before you can enroll in the Free Connector Program. <resendEmail>Re-send verification email</resendEmail>.",
+  "freeConnectorProgram.enrollmentModal.validationEmailConfirmation": "Verification email sent",
   "freeConnectorProgram.enrollmentModal.cancelButtonText": "Cancel",
   "freeConnectorProgram.enrollmentModal.enrollButtonText": "Enroll now!",
   "freeConnectorProgram.enrollmentModal.unvalidatedEmailButtonText": "Resend email validation",

--- a/airbyte-webapp/src/packages/cloud/locales/en.json
+++ b/airbyte-webapp/src/packages/cloud/locales/en.json
@@ -183,6 +183,7 @@
   "freeConnectorProgram.title": "Free Connector Program",
   "freeConnectorProgram.enrollNow": "Enroll now!",
   "freeConnectorProgram.enroll.description": "Enroll in the <b>Free Connector Program</b> to use Alpha and Beta connectors for <b>free</b>.",
+  "freeConnectorProgram.enroll.success": "Successfully enrolled in the Free Connector Program",
   "freeConnectorProgram.enrollmentModal.title": "Free connector program",
   "freeConnectorProgram.enrollmentModal.free": "<p1>Alpha and Beta Connectors are free while you're in the program.</p1><p2>The whole Connection is free until both Connectors have move into General Availability (GA)</p2>",
   "freeConnectorProgram.enrollmentModal.emailNotification": "We will let you know through email before a Connector you use moves to GA",

--- a/airbyte-webapp/src/packages/cloud/services/auth/AuthService.tsx
+++ b/airbyte-webapp/src/packages/cloud/services/auth/AuthService.tsx
@@ -273,6 +273,7 @@ export const AuthenticationProvider: React.FC<React.PropsWithChildren<unknown>> 
                 type: ToastType.ERROR,
               });
           }
+          throw error;
         }
       },
       async verifyEmail(code: string): Promise<void> {

--- a/airbyte-webapp/src/packages/cloud/views/credits/CreditsPage/CreditsPage.tsx
+++ b/airbyte-webapp/src/packages/cloud/views/credits/CreditsPage/CreditsPage.tsx
@@ -20,7 +20,8 @@ import styles from "./CreditsPage.module.scss";
 const CreditsPage: React.FC = () => {
   const { emailVerified } = useAuthService();
   useTrackPage(PageTrackingCodes.CREDITS);
-  const { data: freeConnectorProgramInfo } = useFreeConnectorProgram();
+  const { enrollmentStatusQuery } = useFreeConnectorProgram();
+  const { data: freeConnectorProgramInfo } = enrollmentStatusQuery;
   const { showEnrollmentUi } = freeConnectorProgramInfo || {};
 
   return (

--- a/airbyte-webapp/src/packages/cloud/views/credits/CreditsPage/CreditsPage.tsx
+++ b/airbyte-webapp/src/packages/cloud/views/credits/CreditsPage/CreditsPage.tsx
@@ -21,8 +21,7 @@ const CreditsPage: React.FC = () => {
   const { emailVerified } = useAuthService();
   useTrackPage(PageTrackingCodes.CREDITS);
   const { enrollmentStatusQuery } = useFreeConnectorProgram();
-  const { data: freeConnectorProgramInfo } = enrollmentStatusQuery;
-  const { showEnrollmentUi } = freeConnectorProgramInfo || {};
+  const { showEnrollmentUi } = enrollmentStatusQuery.data || {};
 
   return (
     <MainPageWithScroll

--- a/airbyte-webapp/src/packages/cloud/views/credits/CreditsPage/components/EmailVerificationHint.tsx
+++ b/airbyte-webapp/src/packages/cloud/views/credits/CreditsPage/components/EmailVerificationHint.tsx
@@ -30,7 +30,8 @@ export const EmailVerificationHint: React.FC<Props> = ({ className }) => {
   const [isEmailResend, setIsEmailResend] = useState(false);
 
   const onResendVerificationMail = async () => {
-    await sendEmailVerification();
+    // the shared error handling inside `sendEmailVerification` suffices
+    await sendEmailVerification().catch();
     setIsEmailResend(true);
   };
 

--- a/airbyte-webapp/src/pages/connections/ConnectionPage/ConnectionPageTitle.tsx
+++ b/airbyte-webapp/src/pages/connections/ConnectionPage/ConnectionPageTitle.tsx
@@ -26,7 +26,8 @@ export const ConnectionPageTitle: React.FC = () => {
 
   const { connection } = useConnectionEditService();
 
-  const { data: freeConnectorProgramInfo } = useFreeConnectorProgram();
+  const { enrollmentStatusQuery } = useFreeConnectorProgram();
+  const { data: freeConnectorProgramInfo } = enrollmentStatusQuery;
   const displayEnrollmentCallout = freeConnectorProgramInfo?.showEnrollmentUi;
 
   const steps = useMemo(() => {

--- a/airbyte-webapp/src/pages/connections/ConnectionPage/ConnectionPageTitle.tsx
+++ b/airbyte-webapp/src/pages/connections/ConnectionPage/ConnectionPageTitle.tsx
@@ -27,8 +27,7 @@ export const ConnectionPageTitle: React.FC = () => {
   const { connection } = useConnectionEditService();
 
   const { enrollmentStatusQuery } = useFreeConnectorProgram();
-  const { data: freeConnectorProgramInfo } = enrollmentStatusQuery;
-  const displayEnrollmentCallout = freeConnectorProgramInfo?.showEnrollmentUi;
+  const { showEnrollmentUi } = enrollmentStatusQuery.data || {};
 
   const steps = useMemo(() => {
     const steps = [
@@ -81,7 +80,7 @@ export const ConnectionPageTitle: React.FC = () => {
       <div className={styles.statusContainer}>
         <FlexContainer direction="column" gap="none">
           <ConnectionInfoCard />
-          {displayEnrollmentCallout && <InlineEnrollmentCallout />}
+          {showEnrollmentUi && <InlineEnrollmentCallout />}
         </FlexContainer>
       </div>
       <StepsMenu lightMode data={steps} onSelect={onSelectStep} activeStep={currentStep} />

--- a/airbyte-webapp/src/scss/_z-indices.scss
+++ b/airbyte-webapp/src/scss/_z-indices.scss
@@ -1,11 +1,11 @@
-$tooltip: 9999 + 3;
+$tooltip: 9999 + 4;
+$notification: 9999 + 3;
 $datepicker: 9999 + 2;
 $modal: 9999 + 1;
 $sidebar: 9999;
-$panelSplitter: 0;
-$dropdownMenu: 2;
-$notification: 20;
-$schemaChangesBackdrop: 3;
 $schemaChangesBackdropContent: 4;
+$schemaChangesBackdrop: 3;
+$dropdownMenu: 2;
 $switchSliderBefore: 1;
 $tableScroll: 1;
+$panelSplitter: 0;


### PR DESCRIPTION
## What
Suppress enrollment banners and show confirmation `Toast` when user returns to the `successUrl` from an enrollment stripe checkout session; dismiss modal and show confirmation `Toast` when a user requests a verification email resend from the enrollment modal. Closes https://github.com/airbytehq/airbyte/issues/21616.

## screen recordings
Enrollment success. In retrospect, I should have started recording the gif before opening the modal, to make the difference more apparent when the enrollment banner is hidden. Ah well, c'est la vie. Gifs are hidden behind `<details>` tags because they are large and distracting:
<details>
![fcp-enrollment-success](https://user-images.githubusercontent.com/7516653/213574254-30a04245-9128-464e-beb3-06f3724f031e.gif)
</details>

Email validation resend requested
<details>
![fcp-email-validation-confirmation](https://user-images.githubusercontent.com/7516653/213574240-cf6c21ff-a791-4631-93aa-829fda766cfe.gif)
</details>

## How
Pretty straightforward implementation. One key but nonobvious detail: this changes the query param appended to the stripe `successUrl`, in order to distinguish between a Free Connector Program enrollment and a one-off transaction on the credits page.

## Open question about a future UX improvement
Should the email verification popup mention that the user has to refresh the page after confirming their email? Simply retriggering the modal won't reflect any changes that may have happened if the banner that triggers it hasn't rerendered, because the current modal implementation cannot directly use the required hooks (it renders outside of the necessary context provider components).

Options:
- tell users to refresh the page in the popup
- start polling email validation status from `AuthService` in the banner components as soon as the user requests email validation
- other??