### PR TITLE
[Low Code CDK] Fix missing stream name

### DIFF
--- a/airbyte-cdk/python/airbyte_cdk/sources/declarative/parsers/model_to_component_factory.py
+++ b/airbyte-cdk/python/airbyte_cdk/sources/declarative/parsers/model_to_component_factory.py
@@ -359,7 +359,10 @@ def create_declarative_stream(model: DeclarativeStreamModel, config: Config, **k
     if model.schema_loader:
         schema_loader = _create_component_from_model(model=model.schema_loader, config=config)
     else:
-        schema_loader = DefaultSchemaLoader(config=config, options=model.options)
+        options = model.options or {}
+        if "name" not in options:
+            options["name"] = model.name
+        schema_loader = DefaultSchemaLoader(config=config, options=options)
 
     transformations = []
     if model.transformations:

--- a/airbyte-cdk/python/unit_tests/sources/declarative/parsers/test_model_to_component_factory.py
+++ b/airbyte-cdk/python/unit_tests/sources/declarative/parsers/test_model_to_component_factory.py
@@ -1011,3 +1011,37 @@ class TestCreateTransformations:
             )
         ]
         assert stream.transformations == expected
+
+    def test_default_schema_loader(self):
+        component_definition = {
+            "type": "DeclarativeStream",
+            "name": "test",
+            "primary_key": [],
+            "retriever": {
+                "type": "SimpleRetriever",
+                "name": "test",
+                "primary_key": [],
+                "requester": {
+                    "type": "HttpRequester",
+                    "name": "test",
+                    "url_base": "http://localhost:6767/",
+                    "path": "items/",
+                    "request_options_provider": {
+                        "request_parameters": {},
+                        "request_headers": {},
+                        "request_body_json": {},
+                        "type": "InterpolatedRequestOptionsProvider",
+                    },
+                    "authenticator": {"type": "BearerAuthenticator", "api_token": "{{ config['api_key'] }}"},
+                },
+                "record_selector": {"type": "RecordSelector", "extractor": {"type": "DpathExtractor", "field_pointer": ["items"]}},
+                "paginator": {"type": "NoPagination"},
+            },
+        }
+        resolved_manifest = resolver.preprocess_manifest(component_definition)
+        propagated_source_config = ManifestComponentTransformer().propagate_types_and_options("", resolved_manifest, {})
+        stream = factory.create_component(
+            model_type=DeclarativeStreamModel, component_definition=propagated_source_config, config=input_config
+        )
+        schema_loader = stream.schema_loader
+        assert schema_loader.default_loader._get_json_filepath().split("/")[-1] == f"{stream.name}.json"


### PR DESCRIPTION
Closes https://github.com/airbytehq/airbyte/issues/21381

Revisit https://github.com/airbytehq/airbyte/pull/21516, which was reverted due to test failures associated with the creation of `DefaultSchemaLoader` when created as part of a subcomponent.

This solution passes `name` into `options` in the `create_declarative_stream` function. It's also more consistent with the use of component classes, which don't take arguments other than `options`.