### PR TITLE
[Low Code CDK] Update ref format from `*ref(.*)` -> `#/` in all low code source manifests

### DIFF
--- a/airbyte-integrations/connectors/source-activecampaign/source_activecampaign/activecampaign.yaml
+++ b/airbyte-integrations/connectors/source-activecampaign/source_activecampaign/activecampaign.yaml
@@ -17,12 +17,12 @@ definitions:
 
   retriever:
     record_selector:
-      $ref: "*ref(definitions.selector)"
+      $ref: "#/definitions/selector"
 
     # API Docs: https://developers.activecampaign.com/reference/pagination
     paginator:
       type: DefaultPaginator
-      url_base: "*ref(definitions.requester.url_base)"
+      url_base: "#/definitions/requester/url_base"
       page_size_option:
         inject_into: "request_parameter"
         field_name: "limit"
@@ -34,15 +34,15 @@ definitions:
         field_name: "offset"
 
     requester:
-      $ref: "*ref(definitions.requester)"
+      $ref: "#/definitions/requester"
 
   base_stream:
     retriever:
-      $ref: "*ref(definitions.retriever)"
+      $ref: "#/definitions/retriever"
 
   # API Docs: https://developers.activecampaign.com/reference/list-all-campaigns
   campaigns_stream:
-    $ref: "*ref(definitions.base_stream)"
+    $ref: "#/definitions/base_stream"
     $options:
       name: "campaigns"
       primary_key: "id"
@@ -50,7 +50,7 @@ definitions:
 
   # API Docs: https://developers.activecampaign.com/reference/list-all-contacts
   contacts_stream:
-    $ref: "*ref(definitions.base_stream)"
+    $ref: "#/definitions/base_stream"
     $options:
       name: "contacts"
       primary_key: "id"
@@ -58,7 +58,7 @@ definitions:
 
   # API Docs: https://developers.activecampaign.com/reference/list-all-deals
   deals_stream:
-    $ref: "*ref(definitions.base_stream)"
+    $ref: "#/definitions/base_stream"
     $options:
       name: "deals"
       primary_key: "id"
@@ -66,7 +66,7 @@ definitions:
 
   # API Docs: https://developers.activecampaign.com/reference/retrieve-all-lists
   lists_stream:
-    $ref: "*ref(definitions.base_stream)"
+    $ref: "#/definitions/base_stream"
     $options:
       name: "lists"
       primary_key: "id"
@@ -74,7 +74,7 @@ definitions:
 
   # API Docs: https://developers.activecampaign.com/reference/list-all-segments
   segments_stream:
-    $ref: "*ref(definitions.base_stream)"
+    $ref: "#/definitions/base_stream"
     $options:
       name: "segments"
       primary_key: "id"
@@ -82,19 +82,19 @@ definitions:
 
   # API Docs: https://developers.activecampaign.com/reference/forms-1
   forms_stream:
-    $ref: "*ref(definitions.base_stream)"
+    $ref: "#/definitions/base_stream"
     $options:
       name: "forms"
       primary_key: "id"
       path: "/forms"
 
 streams:
-  - "*ref(definitions.campaigns_stream)"
-  - "*ref(definitions.contacts_stream)"
-  - "*ref(definitions.lists_stream)"
-  - "*ref(definitions.deals_stream)"
-  - "*ref(definitions.segments_stream)"
-  - "*ref(definitions.forms_stream)"
+  - "#/definitions/campaigns_stream"
+  - "#/definitions/contacts_stream"
+  - "#/definitions/lists_stream"
+  - "#/definitions/deals_stream"
+  - "#/definitions/segments_stream"
+  - "#/definitions/forms_stream"
 
 check:
   stream_names: ["campaigns"]

--- a/airbyte-integrations/connectors/source-aha/source_aha/aha.yaml
+++ b/airbyte-integrations/connectors/source-aha/source_aha/aha.yaml
@@ -27,7 +27,7 @@ definitions:
       api_token: "{{ config['api_key'] }}"
   increment_paginator:
     type: "DefaultPaginator"
-    url_base: "*ref(definitions.requester.url_base)"
+    url_base: "#/definitions/requester/url_base"
     page_size_option:
       inject_into: "request_parameter"
       field_name: "per_page"
@@ -39,66 +39,66 @@ definitions:
       field_name: "page"
   retriever:
     record_selector:
-      $ref: "*ref(definitions.selector)"
+      $ref: "#/definitions/selector"
     requester:
-      $ref: "*ref(definitions.requester)"
+      $ref: "#/definitions/requester"
     paginator:
-      $ref: "*ref(definitions.increment_paginator)"
+      $ref: "#/definitions/increment_paginator"
   base_stream:
     retriever:
-      $ref: "*ref(definitions.retriever)"
+      $ref: "#/definitions/retriever"
   features_stream:
-    $ref: "*ref(definitions.base_stream)"
+    $ref: "#/definitions/base_stream"
     retriever:
-      $ref: "*ref(definitions.retriever)"
+      $ref: "#/definitions/retriever"
       record_selector:
-        $ref: "*ref(definitions.selector_features)"
+        $ref: "#/definitions/selector_features"
     $options:
       name: "features"
       path: "/features"
   products_stream:
-    $ref: "*ref(definitions.base_stream)"
+    $ref: "#/definitions/base_stream"
     retriever:
-      $ref: "*ref(definitions.retriever)"
+      $ref: "#/definitions/retriever"
       record_selector:
-        $ref: "*ref(definitions.selector_products)"
+        $ref: "#/definitions/selector_products"
     $options:
       name: "products"
       path: "/products"
   ideas_stream:
-    $ref: "*ref(definitions.base_stream)"
+    $ref: "#/definitions/base_stream"
     retriever:
-      $ref: "*ref(definitions.retriever)"
+      $ref: "#/definitions/retriever"
       record_selector:
-        $ref: "*ref(definitions.selector_ideas)"
+        $ref: "#/definitions/selector_ideas"
     $options:
       name: "ideas"
       path: "/ideas"
   users_stream:
-    $ref: "*ref(definitions.base_stream)"
+    $ref: "#/definitions/base_stream"
     retriever:
-      $ref: "*ref(definitions.retriever)"
+      $ref: "#/definitions/retriever"
       record_selector:
-        $ref: "*ref(definitions.selector_users)"
+        $ref: "#/definitions/selector_users"
     $options:
       name: "users"
       path: "/users"
   goals_stream:
-    $ref: "*ref(definitions.base_stream)"
+    $ref: "#/definitions/base_stream"
     retriever:
-      $ref: "*ref(definitions.retriever)"
+      $ref: "#/definitions/retriever"
       record_selector:
-        $ref: "*ref(definitions.selector_goals)"
+        $ref: "#/definitions/selector_goals"
     $options:
       name: "goals"
       path: "/goals"
 
 streams:
-  - "*ref(definitions.features_stream)"
-  - "*ref(definitions.products_stream)"
-  - "*ref(definitions.ideas_stream)"
-  - "*ref(definitions.users_stream)"
-  - "*ref(definitions.goals_stream)"
+  - "#/definitions/features_stream"
+  - "#/definitions/products_stream"
+  - "#/definitions/ideas_stream"
+  - "#/definitions/users_stream"
+  - "#/definitions/goals_stream"
 
 check:
   stream_names:

--- a/airbyte-integrations/connectors/source-alpha-vantage/source_alpha_vantage/alpha_vantage.yaml
+++ b/airbyte-integrations/connectors/source-alpha-vantage/source_alpha_vantage/alpha_vantage.yaml
@@ -26,16 +26,16 @@ definitions:
       adjusted: "{{ config['adjusted'] }}"
   retriever:
     record_selector:
-      $ref: "*ref(definitions.selector)"
+      $ref: "#/definitions/selector"
     paginator:
       type: NoPagination
     requester:
-      $ref: "*ref(definitions.requester)"
+      $ref: "#/definitions/requester"
   base_stream:
     retriever:
-      $ref: "*ref(definitions.retriever)"
+      $ref: "#/definitions/retriever"
   time_series_intraday_stream:
-    $ref: "*ref(definitions.base_stream)"
+    $ref: "#/definitions/base_stream"
     $options:
       name: "time_series_intraday"
       dpath: "Time Series ({{ config['interval'] }})"
@@ -43,7 +43,7 @@ definitions:
       path: "/query"
       key_field: "timestamp"
   time_series_daily_stream:
-    $ref: "*ref(definitions.base_stream)"
+    $ref: "#/definitions/base_stream"
     $options:
       name: "time_series_daily"
       dpath: "Time Series (Daily)"
@@ -51,7 +51,7 @@ definitions:
       path: "/query"
       key_field: "date"
   time_series_daily_adjusted_stream:
-    $ref: "*ref(definitions.base_stream)"
+    $ref: "#/definitions/base_stream"
     $options:
       name: "time_series_daily_adjusted"
       dpath: "Time Series (Daily)"
@@ -59,7 +59,7 @@ definitions:
       path: "/query"
       key_field: "date"
   time_series_weekly_stream:
-    $ref: "*ref(definitions.base_stream)"
+    $ref: "#/definitions/base_stream"
     $options:
       name: "time_series_weekly"
       dpath: "Weekly Time Series"
@@ -67,7 +67,7 @@ definitions:
       path: "/query"
       key_field: "date"
   time_series_weekly_adjusted_stream:
-    $ref: "*ref(definitions.base_stream)"
+    $ref: "#/definitions/base_stream"
     $options:
       name: "time_series_weekly_adjusted"
       dpath: "Weekly Adjusted Time Series"
@@ -75,7 +75,7 @@ definitions:
       path: "/query"
       key_field: "date"
   time_series_monthly_stream:
-    $ref: "*ref(definitions.base_stream)"
+    $ref: "#/definitions/base_stream"
     $options:
       name: "time_series_monthly"
       dpath: "Monthly Time Series"
@@ -83,7 +83,7 @@ definitions:
       path: "/query"
       key_field: "date"
   time_series_monthly_adjusted_stream:
-    $ref: "*ref(definitions.base_stream)"
+    $ref: "#/definitions/base_stream"
     $options:
       name: "time_series_monthly_adjusted"
       dpath: "Monthly Adjusted Time Series"
@@ -91,22 +91,21 @@ definitions:
       path: "/query"
       key_field: "date"
   quote_stream:
-    $ref: "*ref(definitions.base_stream)"
+    $ref: "#/definitions/base_stream"
     $options:
       name: "quote"
       function: "GLOBAL_QUOTE"
       path: "/query"
 
-
 streams:
-  - "*ref(definitions.time_series_intraday_stream)"
-  - "*ref(definitions.time_series_daily_stream)"
-  - "*ref(definitions.time_series_daily_adjusted_stream)"
-  - "*ref(definitions.time_series_weekly_stream)"
-  - "*ref(definitions.time_series_weekly_adjusted_stream)"
-  - "*ref(definitions.time_series_monthly_stream)"
-  - "*ref(definitions.time_series_monthly_adjusted_stream)"
-  - "*ref(definitions.quote_stream)"
+  - "#/definitions/time_series_intraday_stream"
+  - "#/definitions/time_series_daily_stream"
+  - "#/definitions/time_series_daily_adjusted_stream"
+  - "#/definitions/time_series_weekly_stream"
+  - "#/definitions/time_series_weekly_adjusted_stream"
+  - "#/definitions/time_series_monthly_stream"
+  - "#/definitions/time_series_monthly_adjusted_stream"
+  - "#/definitions/quote_stream"
 
 check:
   stream_names:

--- a/airbyte-integrations/connectors/source-ashby/source_ashby/ashby.yaml
+++ b/airbyte-integrations/connectors/source-ashby/source_ashby/ashby.yaml
@@ -12,7 +12,7 @@ definitions:
       username: "{{ config['api_key'] }}"
   retriever:
     record_selector:
-      $ref: "*ref(definitions.selector)"
+      $ref: "#/definitions/selector"
     paginator:
       type: DefaultPaginator
       pagination_strategy:
@@ -26,128 +26,128 @@ definitions:
         inject_into: "body_json"
         field_name: "cursor"
       url_base:
-        $ref: "*ref(definitions.requester.url_base)"
+        $ref: "#/definitions/requester/url_base"
     requester:
-      $ref: "*ref(definitions.requester)"
+      $ref: "#/definitions/requester"
 
   # base stream
   base_stream:
     retriever:
-      $ref: "*ref(definitions.retriever)"
+      $ref: "#/definitions/retriever"
 
   # stream definitions
   applications_stream:
-    $ref: "*ref(definitions.base_stream)"
+    $ref: "#/definitions/base_stream"
     $options:
       name: "applications"
       primary_key: "id"
       path: "/application.list"
     retriever:
-      $ref: "*ref(definitions.base_stream.retriever)"
+      $ref: "#/definitions/base_stream/retriever"
       requester:
-        $ref: "*ref(definitions.requester)"
+        $ref: "#/definitions/requester"
         request_body_json:
           createdAfter: "{{ timestamp(config['start_date']) * 1000 }}"
   archive_reasons_stream:
-    $ref: "*ref(definitions.base_stream)"
+    $ref: "#/definitions/base_stream"
     $options:
       name: "archive_reasons"
       primary_key: "id"
       path: "/archiveReason.list"
   candidate_tags_stream:
-    $ref: "*ref(definitions.base_stream)"
+    $ref: "#/definitions/base_stream"
     $options:
       name: "candidate_tags"
       primary_key: "id"
       path: "/candidateTag.list"
   candidates_stream:
-    $ref: "*ref(definitions.base_stream)"
+    $ref: "#/definitions/base_stream"
     $options:
       name: "candidates"
       primary_key: "id"
       path: "/candidate.list"
   custom_fields_stream:
-    $ref: "*ref(definitions.base_stream)"
+    $ref: "#/definitions/base_stream"
     $options:
       name: "custom_fields"
       primary_key: "id"
       path: "/customField.list"
   departments_stream:
-    $ref: "*ref(definitions.base_stream)"
+    $ref: "#/definitions/base_stream"
     $options:
       name: "departments"
       primary_key: "id"
       path: "/department.list"
   feedback_form_definitions_stream:
-    $ref: "*ref(definitions.base_stream)"
+    $ref: "#/definitions/base_stream"
     $options:
       name: "feedback_form_definitions"
       primary_key: "id"
       path: "/feedbackFormDefinition.list"
   interview_schedules_stream:
-    $ref: "*ref(definitions.base_stream)"
+    $ref: "#/definitions/base_stream"
     $options:
       name: "interview_schedules"
       primary_key: "id"
       path: "/interviewSchedule.list"
     retriever:
-      $ref: "*ref(definitions.base_stream.retriever)"
+      $ref: "#/definitions/base_stream/retriever"
       requester:
-        $ref: "*ref(definitions.requester)"
+        $ref: "#/definitions/requester"
         request_body_json:
           createdAfter: "{{ timestamp(config['start_date']) * 1000 }}"
   job_postings_stream:
-    $ref: "*ref(definitions.base_stream)"
+    $ref: "#/definitions/base_stream"
     $options:
       name: "job_postings"
       primary_key: "id"
       path: "/jobPosting.list"
   jobs_stream:
-    $ref: "*ref(definitions.base_stream)"
+    $ref: "#/definitions/base_stream"
     $options:
       name: "jobs"
       primary_key: "id"
       path: "/job.list"
   locations_stream:
-    $ref: "*ref(definitions.base_stream)"
+    $ref: "#/definitions/base_stream"
     $options:
       name: "locations"
       primary_key: "id"
       path: "/location.list"
   offers_stream:
-    $ref: "*ref(definitions.base_stream)"
+    $ref: "#/definitions/base_stream"
     $options:
       name: "offers"
       primary_key: "id"
       path: "/offer.list"
   sources_stream:
-    $ref: "*ref(definitions.base_stream)"
+    $ref: "#/definitions/base_stream"
     $options:
       name: "sources"
       primary_key: "id"
       path: "/source.list"
   users_stream:
-    $ref: "*ref(definitions.base_stream)"
+    $ref: "#/definitions/base_stream"
     $options:
       name: "users"
       primary_key: "id"
       path: "/user.list"
 
 streams:
-  - "*ref(definitions.applications_stream)"
-  - "*ref(definitions.archive_reasons_stream)"
-  - "*ref(definitions.candidate_tags_stream)"
-  - "*ref(definitions.candidates_stream)"
-  - "*ref(definitions.custom_fields_stream)"
-  - "*ref(definitions.departments_stream)"
-  - "*ref(definitions.feedback_form_definitions_stream)"
-  - "*ref(definitions.interview_schedules_stream)"
-  - "*ref(definitions.job_postings_stream)"
-  - "*ref(definitions.jobs_stream)"
-  - "*ref(definitions.locations_stream)"
-  - "*ref(definitions.offers_stream)"
-  - "*ref(definitions.sources_stream)"
-  - "*ref(definitions.users_stream)"
+  - "#/definitions/applications_stream"
+  - "#/definitions/archive_reasons_stream"
+  - "#/definitions/candidate_tags_stream"
+  - "#/definitions/candidates_stream"
+  - "#/definitions/custom_fields_stream"
+  - "#/definitions/departments_stream"
+  - "#/definitions/feedback_form_definitions_stream"
+  - "#/definitions/interview_schedules_stream"
+  - "#/definitions/job_postings_stream"
+  - "#/definitions/jobs_stream"
+  - "#/definitions/locations_stream"
+  - "#/definitions/offers_stream"
+  - "#/definitions/sources_stream"
+  - "#/definitions/users_stream"
 
 check:
   stream_names:

--- a/airbyte-integrations/connectors/source-braze/source_braze/braze.yaml
+++ b/airbyte-integrations/connectors/source-braze/source_braze/braze.yaml
@@ -20,7 +20,7 @@ definitions:
   # ----- Retriever -----
   list_retriever:
     record_selector:
-      $ref: "*ref(definitions.list_selector)"
+      $ref: "#/definitions/list_selector"
     paginator:
       type: DefaultPaginator
       url_base: "{{ config['url'] }}"
@@ -31,42 +31,42 @@ definitions:
         inject_into: "request_parameter"
         field_name: "page"
     requester:
-      $ref: "*ref(definitions.requester)"
+      $ref: "#/definitions/requester"
       request_parameters:
         last_edit.time[gt]: "{{ config['start_date'] }}"
 
   # ----- Stream bases -----
   list_stream:
     retriever:
-      $ref: "*ref(definitions.list_retriever)"
+      $ref: "#/definitions/list_retriever"
 
   # ----- Parent streams -----
   campaigns_stream:
-    $ref: "*ref(definitions.list_stream)"
+    $ref: "#/definitions/list_stream"
     $options:
       name: "campaigns"
       primary_key: "id"
       path: "/campaigns/list"
   canvases_stream:
-    $ref: "*ref(definitions.list_stream)"
+    $ref: "#/definitions/list_stream"
     $options:
       name: "canvases"
       primary_key: "id"
       path: "/canvas/list"
   cards_stream:
-    $ref: "*ref(definitions.list_stream)"
+    $ref: "#/definitions/list_stream"
     $options:
       name: "cards"
       primary_key: "id"
       path: "/feed/list"
   segments_stream:
-    $ref: "*ref(definitions.list_stream)"
+    $ref: "#/definitions/list_stream"
     $options:
       name: "segments"
       primary_key: "id"
       path: "/segments/list"
   custom_events_stream:
-    $ref: "*ref(definitions.list_stream)"
+    $ref: "#/definitions/list_stream"
     transformations:
       - class_name: "source_braze.TransformToRecordComponent"
         fields:
@@ -97,37 +97,37 @@ definitions:
     cursor_granularity: "P1D"
 
   datetime_14d_slicer:
-    $ref: "*ref(definitions.datetime_100d_slicer)"
+    $ref: "#/definitions/datetime_100d_slicer"
     step: "P14D"
 
   # ----- Sliced streams -----
   sliced_retriever:
     record_selector:
-      $ref: "*ref(definitions.base_selector)"
+      $ref: "#/definitions/base_selector"
     paginator:
       type: NoPagination
     requester:
-      $ref: "*ref(definitions.requester)"
+      $ref: "#/definitions/requester"
     stream_slicer:
-      $ref: "*ref(definitions.datetime_100d_slicer)"
+      $ref: "#/definitions/datetime_100d_slicer"
 
   kpi_daily_new_users_stream:
     retriever:
-      $ref: "*ref(definitions.sliced_retriever)"
+      $ref: "#/definitions/sliced_retriever"
     stream_cursor_field: "time"
     $options:
       name: "kpi_daily_new_users"
       path: "/kpi/new_users/data_series"
   kpi_daily_active_users_stream:
     retriever:
-      $ref: "*ref(definitions.sliced_retriever)"
+      $ref: "#/definitions/sliced_retriever"
     stream_cursor_field: "time"
     $options:
       name: "kpi_daily_active_users"
       path: "/kpi/dau/data_series"
   kpi_daily_app_uninstalls_stream:
     retriever:
-      $ref: "*ref(definitions.sliced_retriever)"
+      $ref: "#/definitions/sliced_retriever"
     stream_cursor_field: "time"
     $options:
       name: "kpi_daily_app_uninstalls"
@@ -136,19 +136,19 @@ definitions:
   # ----- Sliced sub-streams -----
   campaigns_analytics_substream_config:
     retriever:
-      $ref: "*ref(definitions.sliced_retriever)"
+      $ref: "#/definitions/sliced_retriever"
       stream_slicer:
         type: CartesianProductStreamSlicer
         stream_slicers:
           - type: SubstreamSlicer
             parent_stream_configs:
-              - stream: "*ref(definitions.campaigns_stream)"
+              - stream: "#/definitions/campaigns_stream"
                 parent_key: "id"
                 stream_slice_field: "campaign_id"
                 request_option:
                   field_name: "campaign_id"
                   inject_into: "request_parameter"
-          - "*ref(definitions.datetime_100d_slicer)"
+          - "#/definitions/datetime_100d_slicer"
     transformations:
       - type: AddFields
         fields:
@@ -157,7 +157,7 @@ definitions:
     stream_cursor_field: "time"
   canvases_analytics_substream_config:
     retriever:
-      $ref: "*ref(definitions.sliced_retriever)"
+      $ref: "#/definitions/sliced_retriever"
       record_selector:
         extractor:
           field_pointer: ["data", "stats"]
@@ -166,13 +166,13 @@ definitions:
         stream_slicers:
           - type: SubstreamSlicer
             parent_stream_configs:
-              - stream: "*ref(definitions.canvases_stream)"
+              - stream: "#/definitions/canvases_stream"
                 parent_key: "id"
                 stream_slice_field: "canvas_id"
                 request_option:
                   field_name: "canvas_id"
                   inject_into: "request_parameter"
-          - "*ref(definitions.datetime_14d_slicer)"
+          - "#/definitions/datetime_14d_slicer"
     transformations:
       - type: AddFields
         fields:
@@ -181,19 +181,19 @@ definitions:
     stream_cursor_field: "time"
   cards_analytics_substream_config:
     retriever:
-      $ref: "*ref(definitions.sliced_retriever)"
+      $ref: "#/definitions/sliced_retriever"
       stream_slicer:
         type: CartesianProductStreamSlicer
         stream_slicers:
           - type: SubstreamSlicer
             parent_stream_configs:
-              - stream: "*ref(definitions.cards_stream)"
+              - stream: "#/definitions/cards_stream"
                 parent_key: "id"
                 stream_slice_field: "card_id"
                 request_option:
                   field_name: "card_id"
                   inject_into: "request_parameter"
-          - "*ref(definitions.datetime_100d_slicer)"
+          - "#/definitions/datetime_100d_slicer"
     transformations:
       - type: AddFields
         fields:
@@ -202,19 +202,19 @@ definitions:
     stream_cursor_field: "time"
   segments_analytics_substream_config:
     retriever:
-      $ref: "*ref(definitions.sliced_retriever)"
+      $ref: "#/definitions/sliced_retriever"
       stream_slicer:
         type: CartesianProductStreamSlicer
         stream_slicers:
           - type: SubstreamSlicer
             parent_stream_configs:
-              - stream: "*ref(definitions.segments_stream)"
+              - stream: "#/definitions/segments_stream"
                 parent_key: "id"
                 stream_slice_field: "segment_id"
                 request_option:
                   field_name: "segment_id"
                   inject_into: "request_parameter"
-          - "*ref(definitions.datetime_100d_slicer)"
+          - "#/definitions/datetime_100d_slicer"
     transformations:
       - type: AddFields
         fields:
@@ -223,9 +223,9 @@ definitions:
     stream_cursor_field: "time"
   events_analytics_substream_config:
     retriever:
-      $ref: "*ref(definitions.sliced_retriever)"
+      $ref: "#/definitions/sliced_retriever"
       requester:
-        $ref: "*ref(definitions.sliced_retriever.requester)"
+        $ref: "#/definitions/sliced_retriever/requester"
         request_parameters:
           unit: "day"
       stream_slicer:
@@ -233,13 +233,13 @@ definitions:
         stream_slicers:
           - type: SubstreamSlicer
             parent_stream_configs:
-              - stream: "*ref(definitions.custom_events_stream)"
+              - stream: "#/definitions/custom_events_stream"
                 parent_key: "event_name"
                 stream_slice_field: "event"
                 request_option:
                   field_name: "event"
                   inject_into: "request_parameter"
-          - "*ref(definitions.datetime_100d_slicer)"
+          - "#/definitions/datetime_100d_slicer"
     transformations:
       - type: AddFields
         fields:
@@ -248,45 +248,45 @@ definitions:
     stream_cursor_field: "time"
 
   campaigns_analytics_stream:
-    $ref: "*ref(definitions.campaigns_analytics_substream_config)"
+    $ref: "#/definitions/campaigns_analytics_substream_config"
     $options:
       name: "campaigns_analytics"
       path: "/campaigns/data_series"
   canvases_analytics_stream:
-    $ref: "*ref(definitions.canvases_analytics_substream_config)"
+    $ref: "#/definitions/canvases_analytics_substream_config"
     $options:
       name: "canvases_analytics"
       path: "/canvas/data_series"
   cards_analytics_stream:
-    $ref: "*ref(definitions.cards_analytics_substream_config)"
+    $ref: "#/definitions/cards_analytics_substream_config"
     $options:
       name: "cards_analytics"
       path: "/feed/data_series"
   segments_analytics_stream:
-    $ref: "*ref(definitions.segments_analytics_substream_config)"
+    $ref: "#/definitions/segments_analytics_substream_config"
     $options:
       name: "segments_analytics"
       path: "/segments/data_series"
   events_analytics_stream:
-    $ref: "*ref(definitions.events_analytics_substream_config)"
+    $ref: "#/definitions/events_analytics_substream_config"
     $options:
       name: "events_analytics"
       path: "/events/data_series"
 
 streams:
-  - "*ref(definitions.campaigns_stream)"
-  - "*ref(definitions.campaigns_analytics_stream)"
-  - "*ref(definitions.canvases_stream)"
-  - "*ref(definitions.canvases_analytics_stream)"
-  - "*ref(definitions.custom_events_stream)"
-  - "*ref(definitions.events_analytics_stream)"
-  - "*ref(definitions.kpi_daily_new_users_stream)"
-  - "*ref(definitions.kpi_daily_active_users_stream)"
-  - "*ref(definitions.kpi_daily_app_uninstalls_stream)"
-  - "*ref(definitions.cards_stream)"
-  - "*ref(definitions.cards_analytics_stream)"
-  - "*ref(definitions.segments_stream)"
-  - "*ref(definitions.segments_analytics_stream)"
+  - "#/definitions/campaigns_stream"
+  - "#/definitions/campaigns_analytics_stream"
+  - "#/definitions/canvases_stream"
+  - "#/definitions/canvases_analytics_stream"
+  - "#/definitions/custom_events_stream"
+  - "#/definitions/events_analytics_stream"
+  - "#/definitions/kpi_daily_new_users_stream"
+  - "#/definitions/kpi_daily_active_users_stream"
+  - "#/definitions/kpi_daily_app_uninstalls_stream"
+  - "#/definitions/cards_stream"
+  - "#/definitions/cards_analytics_stream"
+  - "#/definitions/segments_stream"
+  - "#/definitions/segments_analytics_stream"
 
 check:
   stream_names:

--- a/airbyte-integrations/connectors/source-breezometer/source_breezometer/breezometer.yaml
+++ b/airbyte-integrations/connectors/source-breezometer/source_breezometer/breezometer.yaml
@@ -8,7 +8,7 @@ definitions:
   air_quality_current_stream:
     retriever:
       record_selector:
-        $ref: "*ref(definitions.selector)"
+        $ref: "#/definitions/selector"
       paginator:
         type: NoPagination
       requester:
@@ -26,7 +26,7 @@ definitions:
   air_quality_forecast_stream:
     retriever:
       record_selector:
-        $ref: "*ref(definitions.selector)"
+        $ref: "#/definitions/selector"
       paginator:
         type: NoPagination
       requester:
@@ -45,7 +45,7 @@ definitions:
   air_quality_historical_stream:
     retriever:
       record_selector:
-        $ref: "*ref(definitions.selector)"
+        $ref: "#/definitions/selector"
       paginator:
         type: NoPagination
       requester:
@@ -64,7 +64,7 @@ definitions:
   pollen_forecast_stream:
     retriever:
       record_selector:
-        $ref: "*ref(definitions.selector)"
+        $ref: "#/definitions/selector"
       paginator:
         type: NoPagination
       requester:
@@ -83,7 +83,7 @@ definitions:
   weather_current_stream:
     retriever:
       record_selector:
-        $ref: "*ref(definitions.selector)"
+        $ref: "#/definitions/selector"
       paginator:
         type: NoPagination
       requester:
@@ -101,7 +101,7 @@ definitions:
   weather_forecast_stream:
     retriever:
       record_selector:
-        $ref: "*ref(definitions.selector)"
+        $ref: "#/definitions/selector"
       paginator:
         type: NoPagination
       requester:
@@ -119,7 +119,7 @@ definitions:
   wildfire_burnt_area_stream:
     retriever:
       record_selector:
-        $ref: "*ref(definitions.selector)"
+        $ref: "#/definitions/selector"
       paginator:
         type: NoPagination
       requester:
@@ -137,7 +137,7 @@ definitions:
   wildfire_locate_stream:
     retriever:
       record_selector:
-        $ref: "*ref(definitions.selector)"
+        $ref: "#/definitions/selector"
       paginator:
         type: NoPagination
       requester:
@@ -153,14 +153,14 @@ definitions:
       path: "/fires/v1/locate-and-track"
 
 streams:
-  - "*ref(definitions.air_quality_current_stream)"
-  - "*ref(definitions.air_quality_forecast_stream)"
-  - "*ref(definitions.air_quality_historical_stream)"
-  - "*ref(definitions.pollen_forecast_stream)"
-  - "*ref(definitions.weather_current_stream)"
-  - "*ref(definitions.weather_forecast_stream)"
-  - "*ref(definitions.wildfire_burnt_area_stream)"
-  - "*ref(definitions.wildfire_locate_stream)"
+  - "#/definitions/air_quality_current_stream"
+  - "#/definitions/air_quality_forecast_stream"
+  - "#/definitions/air_quality_historical_stream"
+  - "#/definitions/pollen_forecast_stream"
+  - "#/definitions/weather_current_stream"
+  - "#/definitions/weather_forecast_stream"
+  - "#/definitions/wildfire_burnt_area_stream"
+  - "#/definitions/wildfire_locate_stream"
 
 check:
   stream_names:

--- a/airbyte-integrations/connectors/source-callrail/source_callrail/callrail.yaml
+++ b/airbyte-integrations/connectors/source-callrail/source_callrail/callrail.yaml
@@ -25,7 +25,7 @@ definitions:
     end_datetime:
       datetime: "{{ today_utc() }}"
       datetime_format: "%Y-%m-%d"
-    step: "*ref(definitions.step)"
+    step: "#/definitions/step"
     cursor_field: "{{ options.stream_cursor_field }}"
     start_time_option:
       field_name: "start_date"
@@ -56,7 +56,7 @@ definitions:
       page_token_option:
         inject_into: "path"
     stream_slicer:
-      $ref: "*ref(definitions.stream_slicer)"
+      $ref: "#/definitions/stream_slicer"
 
   calls_stream:
     $options:
@@ -64,11 +64,11 @@ definitions:
       stream_cursor_field: "start_time"
     primary_key: "id"
     schema_loader:
-      $ref: "*ref(definitions.schema_loader)"
+      $ref: "#/definitions/schema_loader"
     retriever:
-      $ref: "*ref(definitions.retriever)"
+      $ref: "#/definitions/retriever"
       requester:
-        $ref: "*ref(definitions.requester)"
+        $ref: "#/definitions/requester"
         path: "{{ config['account_id'] }}/calls.json?"
         request_parameters:
           fields: "call_type,company_id,company_name,company_time_zone,created_at,device_type,first_call,formatted_call_type,formatted_customer_location,formatted_business_phone_number,formatted_customer_name,prior_calls,formatted_customer_name_or_phone_number,formatted_customer_phone_number,formatted_duration,formatted_tracking_phone_number,formatted_tracking_source,formatted_value,good_lead_call_id,good_lead_call_time,lead_status,note,source,source_name,tags,total_calls,value,waveforms,tracker_id,speaker_percent,keywords,medium,campaign,referring_url,landing_page_url,last_requested_url,referrer_domain,utm_source,utm_medium,utm_term,utm_content,utm_campaign,utma,utmb,utmc,utmv,utmz,ga,gclid,fbclid,msclkid,milestones,timeline_url,keywords_spotted,call_highlights,agent_email,keypad_entries"
@@ -79,11 +79,11 @@ definitions:
       stream_cursor_field: "last_message_at"
     primary_key: "id"
     schema_loader:
-      $ref: "*ref(definitions.schema_loader)"
+      $ref: "#/definitions/schema_loader"
     retriever:
-      $ref: "*ref(definitions.retriever)"
+      $ref: "#/definitions/retriever"
       requester:
-        $ref: "*ref(definitions.requester)"
+        $ref: "#/definitions/requester"
         path: "{{ config['account_id'] }}/text-messages.json?"
         request_parameters:
           fields: "id,company_id,initial_tracker_id,current_tracker_id,customer_name,customer_phone_number,initial_tracking_number,current_tracking_number,last_message_at,state,company_time_zone,formatted_customer_phone_number,formatted_initial_tracking_number,formatted_current_tracking_number,formatted_customer_name,recent_messages"
@@ -94,11 +94,11 @@ definitions:
       stream_cursor_field: "created_at"
     primary_key: "id"
     schema_loader:
-      $ref: "*ref(definitions.schema_loader)"
+      $ref: "#/definitions/schema_loader"
     retriever:
-      $ref: "*ref(definitions.retriever)"
+      $ref: "#/definitions/retriever"
       requester:
-        $ref: "*ref(definitions.requester)"
+        $ref: "#/definitions/requester"
         path: "{{ config['account_id'] }}/users.json?"
 
   companies_stream:
@@ -107,18 +107,18 @@ definitions:
       stream_cursor_field: "created_at"
     primary_key: "id"
     schema_loader:
-      $ref: "*ref(definitions.schema_loader)"
+      $ref: "#/definitions/schema_loader"
     retriever:
-      $ref: "*ref(definitions.retriever)"
+      $ref: "#/definitions/retriever"
       requester:
-        $ref: "*ref(definitions.requester)"
+        $ref: "#/definitions/requester"
         path: "{{ config['account_id'] }}/companies.json?"
 
 streams:
-  - "*ref(definitions.calls_stream)"
-  - "*ref(definitions.conversations_stream)"
-  - "*ref(definitions.users_stream)"
-  - "*ref(definitions.companies_stream)"
+  - "#/definitions/calls_stream"
+  - "#/definitions/conversations_stream"
+  - "#/definitions/users_stream"
+  - "#/definitions/companies_stream"
 
 check:
   type: CheckStream

--- a/airbyte-integrations/connectors/source-chartmogul/source_chartmogul/chartmogul.yaml
+++ b/airbyte-integrations/connectors/source-chartmogul/source_chartmogul/chartmogul.yaml
@@ -12,15 +12,15 @@ definitions:
       username: "{{ config['api_key'] }}"
   retriever:
     record_selector:
-      $ref: "*ref(definitions.selector)"
+      $ref: "#/definitions/selector"
     requester:
-      $ref: "*ref(definitions.requester)"
+      $ref: "#/definitions/requester"
   customers_stream:
     retriever:
-      $ref: "*ref(definitions.retriever)"
+      $ref: "#/definitions/retriever"
       paginator:
         type: DefaultPaginator
-        url_base: "*ref(definitions.requester.url_base)"
+        url_base: "#/definitions/requester/url_base"
         pagination_strategy:
           type: "PageIncrement"
           start_from_page: 1
@@ -37,14 +37,14 @@ definitions:
       path: "/v1/customers"
   activities_stream:
     retriever:
-      $ref: "*ref(definitions.retriever)"
+      $ref: "#/definitions/retriever"
       requester:
-        $ref: "*ref(definitions.requester)"
+        $ref: "#/definitions/requester"
         request_parameters:
           start-date: "{{ config.start_date }}"
       paginator:
         type: DefaultPaginator
-        url_base: "*ref(definitions.requester.url_base)"
+        url_base: "#/definitions/requester/url_base"
         pagination_strategy:
           type: "CursorPagination"
           cursor_value: "{{ response['entries'][-1]['uuid'] }}"
@@ -62,9 +62,9 @@ definitions:
       path: "/v1/activities"
   customer_count_stream:
     retriever:
-      $ref: "*ref(definitions.retriever)"
+      $ref: "#/definitions/retriever"
       requester:
-        $ref: "*ref(definitions.requester)"
+        $ref: "#/definitions/requester"
         request_body_data:
           start-date: "{{ format_datetime(config['start_date'], '%Y-%m-%d') }}"
           end-date: "{{ now_utc().strftime('%Y-%m-%d') }}"
@@ -77,9 +77,9 @@ definitions:
       path: "/v1/metrics/customer-count"
 
 streams:
-  - "*ref(definitions.customers_stream)"
-  - "*ref(definitions.activities_stream)"
-  - "*ref(definitions.customer_count_stream)"
+  - "#/definitions/customers_stream"
+  - "#/definitions/activities_stream"
+  - "#/definitions/customer_count_stream"
 
 check:
   stream_names:

--- a/airbyte-integrations/connectors/source-clickup-api/source_clickup_api/clickup_api.yaml
+++ b/airbyte-integrations/connectors/source-clickup-api/source_clickup_api/clickup_api.yaml
@@ -36,84 +36,84 @@ streams:
     $options:
       name: "user"
     schema_loader:
-      $ref: "*ref(definitions.schema_loader)"
+      $ref: "#/definitions/schema_loader"
     retriever:
-      $ref: "*ref(definitions.retriever)"
+      $ref: "#/definitions/retriever"
       requester:
-        $ref: "*ref(definitions.requester)"
+        $ref: "#/definitions/requester"
         path: "/user"
       paginator:
-        $ref: "*ref(definitions.paginator)"
+        $ref: "#/definitions/paginator"
       record_selector:
-        $ref: "*ref(definitions.singleSelector)"
+        $ref: "#/definitions/singleSelector"
   - type: DeclarativeStream
     $options:
       name: "team"
     schema_loader:
-      $ref: "*ref(definitions.schema_loader)"
+      $ref: "#/definitions/schema_loader"
     retriever:
-      $ref: "*ref(definitions.retriever)"
+      $ref: "#/definitions/retriever"
       requester:
-        $ref: "*ref(definitions.requester)"
+        $ref: "#/definitions/requester"
         path: "/team"
       paginator:
-        $ref: "*ref(definitions.paginator)"
+        $ref: "#/definitions/paginator"
       record_selector:
-        $ref: "*ref(definitions.arraySelector)"
+        $ref: "#/definitions/arraySelector"
   - type: DeclarativeStream
     $options:
       name: "list"
     schema_loader:
-      $ref: "*ref(definitions.schema_loader)"
+      $ref: "#/definitions/schema_loader"
     retriever:
-      $ref: "*ref(definitions.retriever)"
+      $ref: "#/definitions/retriever"
       requester:
-        $ref: "*ref(definitions.requester)"
+        $ref: "#/definitions/requester"
         path: "folder/{{ config['folder_id'] }}/list"
       paginator:
-        $ref: "*ref(definitions.paginator)"
+        $ref: "#/definitions/paginator"
       record_selector:
-        $ref: "*ref(definitions.arraySelector)"
+        $ref: "#/definitions/arraySelector"
   - type: DeclarativeStream
     $options:
       name: "space"
     schema_loader:
-      $ref: "*ref(definitions.schema_loader)"
+      $ref: "#/definitions/schema_loader"
     retriever:
-      $ref: "*ref(definitions.retriever)"
+      $ref: "#/definitions/retriever"
       requester:
-        $ref: "*ref(definitions.requester)"
+        $ref: "#/definitions/requester"
         path: "team/{{ config['team_id'] }}/space"
       paginator:
-        $ref: "*ref(definitions.paginator)"
+        $ref: "#/definitions/paginator"
       record_selector:
-        $ref: "*ref(definitions.arraySelector)"
+        $ref: "#/definitions/arraySelector"
   - type: DeclarativeStream
     $options:
       name: "folder"
     schema_loader:
-      $ref: "*ref(definitions.schema_loader)"
+      $ref: "#/definitions/schema_loader"
     retriever:
-      $ref: "*ref(definitions.retriever)"
+      $ref: "#/definitions/retriever"
       requester:
-        $ref: "*ref(definitions.requester)"
+        $ref: "#/definitions/requester"
         path: "space/{{ config['space_id'] }}/folder"
       paginator:
-        $ref: "*ref(definitions.paginator)"
+        $ref: "#/definitions/paginator"
       record_selector:
-        $ref: "*ref(definitions.arraySelector)"
+        $ref: "#/definitions/arraySelector"
   - type: DeclarativeStream
     $options:
       name: "task"
     schema_loader:
-      $ref: "*ref(definitions.schema_loader)"
+      $ref: "#/definitions/schema_loader"
     retriever:
-      $ref: "*ref(definitions.retriever)"
+      $ref: "#/definitions/retriever"
       requester:
-        $ref: "*ref(definitions.requester)"
+        $ref: "#/definitions/requester"
         path: "list/{{ config['list_id'] }}/task"
       record_selector:
-        $ref: "*ref(definitions.arraySelector)"
+        $ref: "#/definitions/arraySelector"
       paginator:
         type: DefaultPaginator
         page_size_option:

--- a/airbyte-integrations/connectors/source-close-com/source_close_com/close_com.yaml
+++ b/airbyte-integrations/connectors/source-close-com/source_close_com/close_com.yaml
@@ -17,12 +17,12 @@ definitions:
       username: "{{ config['api_key'] }}"
       password: ""
   incremental_query_requester:
-    $ref: "*ref(definitions.requester)"
+    $ref: "#/definitions/requester"
     request_parameters:
       query: "sort:updated date_updated > {{ stream_slice['start_time'] }} date_updated <= {{ stream_slice['end_time'] }}"
   offset_paginator:
     type: DefaultPaginator
-    url_base: "*ref(definitions.requester.url_base)"
+    url_base: "#/definitions/requester/url_base"
     page_size_option:
       inject_into: "request_parameter"
       field_name: "_limit"
@@ -34,7 +34,7 @@ definitions:
       page_size: "{{ options['items_per_page'] }}"
   cursor_paginator:
     type: DefaultPaginator
-    url_base: "*ref(definitions.requester.url_base)"
+    url_base: "#/definitions/requester/url_base"
     page_token_option:
       inject_into: "request_parameter"
       field_name: "_cursor"
@@ -100,78 +100,78 @@ definitions:
     cursor_granularity: "PT0.000001S"
   retriever:
     record_selector:
-      $ref: "*ref(definitions.selector)"
+      $ref: "#/definitions/selector"
     requester:
-      $ref: "*ref(definitions.requester)"
+      $ref: "#/definitions/requester"
     paginator:
       type: NoPagination
 
   base_stream:
     retriever:
-      $ref: "*ref(definitions.retriever)"
+      $ref: "#/definitions/retriever"
     schema_loader:
-      $ref: "*ref(definitions.schema_loader)"
+      $ref: "#/definitions/schema_loader"
     primary_key: "id"
   full_refresh_stream:
-    $ref: "*ref(definitions.base_stream)"
+    $ref: "#/definitions/base_stream"
     retriever:
-      $ref: "*ref(definitions.retriever)"
+      $ref: "#/definitions/retriever"
       paginator:
-        $ref: "*ref(definitions.offset_paginator)"
+        $ref: "#/definitions/offset_paginator"
   full_refresh_cursor_stream:
-    $ref: "*ref(definitions.base_stream)"
+    $ref: "#/definitions/base_stream"
     retriever:
-      $ref: "*ref(definitions.retriever)"
+      $ref: "#/definitions/retriever"
       paginator:
-        $ref: "*ref(definitions.cursor_paginator)"
+        $ref: "#/definitions/cursor_paginator"
   incremental_stream:
-    $ref: "*ref(definitions.full_refresh_stream)"
+    $ref: "#/definitions/full_refresh_stream"
     retriever:
-      $ref: "*ref(definitions.full_refresh_stream.retriever)"
+      $ref: "#/definitions/full_refresh_stream/retriever"
       stream_slicer:
-        $ref: "*ref(definitions.stream_slicer__cursor_date_updated)"
+        $ref: "#/definitions/stream_slicer__cursor_date_updated"
       requester:
-        $ref: "*ref(definitions.requester)"
+        $ref: "#/definitions/requester"
     stream_cursor_field: "date_updated"
   incremental_cursor_based_stream:
-    $ref: "*ref(definitions.incremental_stream)"
+    $ref: "#/definitions/incremental_stream"
     retriever:
-      $ref: "*ref(definitions.incremental_stream.retriever)"
+      $ref: "#/definitions/incremental_stream/retriever"
       paginator:
-        $ref: "*ref(definitions.cursor_paginator)"
+        $ref: "#/definitions/cursor_paginator"
 
   activities_base_stream:
-    $ref: "*ref(definitions.incremental_stream)"
+    $ref: "#/definitions/incremental_stream"
     retriever:
-      $ref: "*ref(definitions.incremental_stream.retriever)"
+      $ref: "#/definitions/incremental_stream/retriever"
       stream_slicer:
-        $ref: "*ref(definitions.stream_slicer__cursor_date_created)"
+        $ref: "#/definitions/stream_slicer__cursor_date_created"
     stream_cursor_field: "date_created"
     $options:
       items_per_page: 100
 
   tasks_base_stream:
-    $ref: "*ref(definitions.incremental_stream)"
+    $ref: "#/definitions/incremental_stream"
     retriever:
-      $ref: "*ref(definitions.incremental_stream.retriever)"
+      $ref: "#/definitions/incremental_stream/retriever"
       requester:
-        $ref: "*ref(definitions.requester)"
+        $ref: "#/definitions/requester"
         request_parameters:
           _type: "{{ options['task_type'] }}"
           _order_by: "date_created"
       stream_slicer:
-        $ref: "*ref(definitions.stream_slicer__cursor_date_created)"
+        $ref: "#/definitions/stream_slicer__cursor_date_created"
     $options:
       path: "task"
       items_per_page: 1000
     stream_cursor_field: "date_created"
 
   connected_accounts_base_stream:
-    $ref: "*ref(definitions.full_refresh_stream)"
+    $ref: "#/definitions/full_refresh_stream"
     retriever:
-      $ref: "*ref(definitions.full_refresh_stream.retriever)"
+      $ref: "#/definitions/full_refresh_stream/retriever"
       requester:
-        $ref: "*ref(definitions.requester)"
+        $ref: "#/definitions/requester"
         request_parameters:
           _type: "{{ options['connected_accounts_type'] }}"
     $options:
@@ -179,155 +179,155 @@ definitions:
       items_per_page: 100
 
   created_activities_stream:
-    $ref: "*ref(definitions.activities_base_stream)"
+    $ref: "#/definitions/activities_base_stream"
     $options:
-      $ref: "*ref(definitions.activities_base_stream.$options)"
+      $ref: "#/definitions/activities_base_stream/$options"
       name: "created_activities"
       path: "activity/created"
   note_activities_stream:
-    $ref: "*ref(definitions.activities_base_stream)"
+    $ref: "#/definitions/activities_base_stream"
     $options:
-      $ref: "*ref(definitions.activities_base_stream.$options)"
+      $ref: "#/definitions/activities_base_stream/$options"
       name: "note_activities"
       path: "activity/note"
   email_thread_activities_stream:
-    $ref: "*ref(definitions.activities_base_stream)"
+    $ref: "#/definitions/activities_base_stream"
     $options:
-      $ref: "*ref(definitions.activities_base_stream.$options)"
+      $ref: "#/definitions/activities_base_stream/$options"
       name: "email_thread_activities"
       path: "activity/emailthread"
   email_activities_stream:
-    $ref: "*ref(definitions.activities_base_stream)"
+    $ref: "#/definitions/activities_base_stream"
     $options:
-      $ref: "*ref(definitions.activities_base_stream.$options)"
+      $ref: "#/definitions/activities_base_stream/$options"
       name: "email_activities"
       path: "activity/email"
   sms_activities_stream:
-    $ref: "*ref(definitions.activities_base_stream)"
+    $ref: "#/definitions/activities_base_stream"
     $options:
-      $ref: "*ref(definitions.activities_base_stream.$options)"
+      $ref: "#/definitions/activities_base_stream/$options"
       name: "sms_activities"
       path: "activity/sms"
   call_activities_stream:
-    $ref: "*ref(definitions.activities_base_stream)"
+    $ref: "#/definitions/activities_base_stream"
     $options:
-      $ref: "*ref(definitions.activities_base_stream.$options)"
+      $ref: "#/definitions/activities_base_stream/$options"
       name: "call_activities"
       path: "activity/call"
   meeting_activities_stream:
-    $ref: "*ref(definitions.activities_base_stream)"
+    $ref: "#/definitions/activities_base_stream"
     $options:
-      $ref: "*ref(definitions.activities_base_stream.$options)"
+      $ref: "#/definitions/activities_base_stream/$options"
       name: "meeting_activities"
       path: "activity/meeting"
   lead_status_change_activities_stream:
-    $ref: "*ref(definitions.activities_base_stream)"
+    $ref: "#/definitions/activities_base_stream"
     $options:
-      $ref: "*ref(definitions.activities_base_stream.$options)"
+      $ref: "#/definitions/activities_base_stream/$options"
       name: "lead_status_change_activities"
       path: "activity/status_change/lead"
   opportunity_status_change_activities_stream:
-    $ref: "*ref(definitions.activities_base_stream)"
+    $ref: "#/definitions/activities_base_stream"
     $options:
-      $ref: "*ref(definitions.activities_base_stream.$options)"
+      $ref: "#/definitions/activities_base_stream/$options"
       name: "opportunity_status_change_activities"
       path: "activity/status_change/opportunity"
   task_completed_activities_stream:
-    $ref: "*ref(definitions.activities_base_stream)"
+    $ref: "#/definitions/activities_base_stream"
     $options:
-      $ref: "*ref(definitions.activities_base_stream.$options)"
+      $ref: "#/definitions/activities_base_stream/$options"
       name: "task_completed_activities"
       path: "activity/task_completed"
 
   lead_custom_fields_stream:
-    $ref: "*ref(definitions.full_refresh_stream)"
+    $ref: "#/definitions/full_refresh_stream"
     $options:
       name: "lead_custom_fields"
       path: "custom_field/lead"
       items_per_page: 1000
   contact_custom_fields_stream:
-    $ref: "*ref(definitions.full_refresh_stream)"
+    $ref: "#/definitions/full_refresh_stream"
     $options:
       name: "contact_custom_fields"
       path: "custom_field/contact"
       items_per_page: 1000
   opportunity_custom_fields_stream:
-    $ref: "*ref(definitions.full_refresh_stream)"
+    $ref: "#/definitions/full_refresh_stream"
     $options:
       name: "opportunity_custom_fields"
       path: "custom_field/opportunity"
       items_per_page: 1000
   activity_custom_fields_stream:
-    $ref: "*ref(definitions.full_refresh_stream)"
+    $ref: "#/definitions/full_refresh_stream"
     $options:
       name: "activity_custom_fields"
       path: "custom_field/activity"
       items_per_page: 1000
   users_stream:
-    $ref: "*ref(definitions.full_refresh_stream)"
+    $ref: "#/definitions/full_refresh_stream"
     $options:
       name: "users"
       path: "user"
       items_per_page: 1000
   contacts_stream:
-    $ref: "*ref(definitions.full_refresh_stream)"
+    $ref: "#/definitions/full_refresh_stream"
     $options:
       name: "contacts"
       path: "contact"
       items_per_page: 100
   roles_stream:
-    $ref: "*ref(definitions.full_refresh_cursor_stream)"
+    $ref: "#/definitions/full_refresh_cursor_stream"
     $options:
       name: "roles"
       path: "role"
   lead_statuses_stream:
-    $ref: "*ref(definitions.full_refresh_stream)"
+    $ref: "#/definitions/full_refresh_stream"
     $options:
       name: "lead_statuses"
       path: "status/lead"
       items_per_page: 100
   opportunity_statuses_stream:
-    $ref: "*ref(definitions.full_refresh_stream)"
+    $ref: "#/definitions/full_refresh_stream"
     $options:
       name: "opportunity_statuses"
       path: "status/opportunity"
       items_per_page: 100
   pipelines_stream:
-    $ref: "*ref(definitions.base_stream)"
+    $ref: "#/definitions/base_stream"
     $options:
       name: "pipelines"
       path: "pipeline"
   email_templates_stream:
-    $ref: "*ref(definitions.full_refresh_stream)"
+    $ref: "#/definitions/full_refresh_stream"
     $options:
       name: "email_templates"
       path: "email_template"
       items_per_page: 100
 
   events_stream:
-    $ref: "*ref(definitions.incremental_cursor_based_stream)"
+    $ref: "#/definitions/incremental_cursor_based_stream"
     $options:
       name: "events"
       path: "event"
       items_per_page: 50
   leads_steam:
-    $ref: "*ref(definitions.incremental_stream)"
+    $ref: "#/definitions/incremental_stream"
     retriever:
-      $ref: "*ref(definitions.incremental_stream.retriever)"
+      $ref: "#/definitions/incremental_stream/retriever"
       stream_slicer:
-        $ref: "*ref(definitions.stream_query_slicer)"
+        $ref: "#/definitions/stream_query_slicer"
       requester:
-        $ref: "*ref(definitions.incremental_query_requester)"
+        $ref: "#/definitions/incremental_query_requester"
     $options:
       name: "leads"
       path: "lead"
       items_per_page: 200
   opportunities_stream:
-    $ref: "*ref(definitions.incremental_stream)"
+    $ref: "#/definitions/incremental_stream"
     retriever:
-      $ref: "*ref(definitions.incremental_stream.retriever)"
+      $ref: "#/definitions/incremental_stream/retriever"
       requester:
-        $ref: "*ref(definitions.requester)"
+        $ref: "#/definitions/requester"
         request_parameters:
           _order_by: "date_updated"
     $options:
@@ -336,178 +336,178 @@ definitions:
       items_per_page: 250
 
   lead_tasks_stream:
-    $ref: "*ref(definitions.tasks_base_stream)"
+    $ref: "#/definitions/tasks_base_stream"
     $options:
-      $ref: "*ref(definitions.tasks_base_stream.$options)"
+      $ref: "#/definitions/tasks_base_stream/$options"
       name: "lead_tasks"
       task_type: "lead"
   incoming_email_tasks_stream:
-    $ref: "*ref(definitions.tasks_base_stream)"
+    $ref: "#/definitions/tasks_base_stream"
     $options:
-      $ref: "*ref(definitions.tasks_base_stream.$options)"
+      $ref: "#/definitions/tasks_base_stream/$options"
       name: "incoming_email_tasks"
       task_type: "incoming_email"
   email_followup_tasks_stream:
-    $ref: "*ref(definitions.tasks_base_stream)"
+    $ref: "#/definitions/tasks_base_stream"
     $options:
-      $ref: "*ref(definitions.tasks_base_stream.$options)"
+      $ref: "#/definitions/tasks_base_stream/$options"
       name: "email_followup_tasks"
       task_type: "email_followup"
   missed_call_tasks_stream:
-    $ref: "*ref(definitions.tasks_base_stream)"
+    $ref: "#/definitions/tasks_base_stream"
     $options:
-      $ref: "*ref(definitions.tasks_base_stream.$options)"
+      $ref: "#/definitions/tasks_base_stream/$options"
       name: "missed_call_tasks"
       task_type: "missed_call"
   answered_detached_call_tasks_stream:
-    $ref: "*ref(definitions.tasks_base_stream)"
+    $ref: "#/definitions/tasks_base_stream"
     $options:
-      $ref: "*ref(definitions.tasks_base_stream.$options)"
+      $ref: "#/definitions/tasks_base_stream/$options"
       name: "answered_detached_call_tasks"
       task_type: "answered_detached_call"
   voicemail_tasks_stream:
-    $ref: "*ref(definitions.tasks_base_stream)"
+    $ref: "#/definitions/tasks_base_stream"
     $options:
-      $ref: "*ref(definitions.tasks_base_stream.$options)"
+      $ref: "#/definitions/tasks_base_stream/$options"
       name: "voicemail_tasks"
       task_type: "voicemail"
   opportunity_due_tasks_stream:
-    $ref: "*ref(definitions.tasks_base_stream)"
+    $ref: "#/definitions/tasks_base_stream"
     $options:
-      $ref: "*ref(definitions.tasks_base_stream.$options)"
+      $ref: "#/definitions/tasks_base_stream/$options"
       name: "opportunity_due_tasks"
       task_type: "opportunity_due"
   incoming_sms_tasks_stream:
-    $ref: "*ref(definitions.tasks_base_stream)"
+    $ref: "#/definitions/tasks_base_stream"
     $options:
-      $ref: "*ref(definitions.tasks_base_stream.$options)"
+      $ref: "#/definitions/tasks_base_stream/$options"
       name: "incoming_sms_tasks"
       task_type: "incoming_sms"
 
   google_connected_accounts_stream:
-    $ref: "*ref(definitions.connected_accounts_base_stream)"
+    $ref: "#/definitions/connected_accounts_base_stream"
     $options:
-      $ref: "*ref(definitions.connected_accounts_base_stream.$options)"
+      $ref: "#/definitions/connected_accounts_base_stream/$options"
       name: "google_connected_accounts"
       connected_accounts_type: "google"
   custom_email_connected_accounts_stream:
-    $ref: "*ref(definitions.connected_accounts_base_stream)"
+    $ref: "#/definitions/connected_accounts_base_stream"
     $options:
-      $ref: "*ref(definitions.connected_accounts_base_stream.$options)"
+      $ref: "#/definitions/connected_accounts_base_stream/$options"
       name: "custom_email_connected_accounts"
       connected_accounts_type: "custom_email"
   zoom_connected_accounts_stream:
-    $ref: "*ref(definitions.connected_accounts_base_stream)"
+    $ref: "#/definitions/connected_accounts_base_stream"
     $options:
-      $ref: "*ref(definitions.connected_accounts_base_stream.$options)"
+      $ref: "#/definitions/connected_accounts_base_stream/$options"
       name: "zoom_connected_accounts"
       connected_accounts_type: "zoom"
 
   send_as_stream:
-    $ref: "*ref(definitions.base_stream)"
+    $ref: "#/definitions/base_stream"
     $options:
       name: "send_as"
       path: "send_as"
   email_sequences_stream:
-    $ref: "*ref(definitions.full_refresh_stream)"
+    $ref: "#/definitions/full_refresh_stream"
     $options:
       name: "email_sequences"
       path: "sequence"
       items_per_page: 1000
   dialer_stream:
-    $ref: "*ref(definitions.full_refresh_stream)"
+    $ref: "#/definitions/full_refresh_stream"
     $options:
       name: "dialer"
       path: "dialer"
       items_per_page: 100
   smart_views_stream:
-    $ref: "*ref(definitions.full_refresh_cursor_stream)"
+    $ref: "#/definitions/full_refresh_cursor_stream"
     $options:
       name: "smart_views"
       path: "saved_search"
   #      items_per_page: 600
   email_bulk_actions_stream:
-    $ref: "*ref(definitions.full_refresh_stream)"
+    $ref: "#/definitions/full_refresh_stream"
     $options:
       name: "email_bulk_actions"
       path: "bulk_action/email"
       items_per_page: 100
   sequence_subscription_bulk_actions_stream:
-    $ref: "*ref(definitions.full_refresh_stream)"
+    $ref: "#/definitions/full_refresh_stream"
     $options:
       name: "sequence_subscription_bulk_actions"
       path: "bulk_action/sequence_subscription"
       items_per_page: 100
   delete_bulk_actions_stream:
-    $ref: "*ref(definitions.full_refresh_stream)"
+    $ref: "#/definitions/full_refresh_stream"
     $options:
       name: "delete_bulk_actions"
       path: "bulk_action/delete"
       items_per_page: 100
   edit_bulk_actions_stream:
-    $ref: "*ref(definitions.full_refresh_stream)"
+    $ref: "#/definitions/full_refresh_stream"
     $options:
       name: "edit_bulk_actions"
       path: "bulk_action/edit"
       items_per_page: 100
   integration_links_stream:
-    $ref: "*ref(definitions.full_refresh_stream)"
+    $ref: "#/definitions/full_refresh_stream"
     $options:
       name: "integration_links"
       path: "integration_link"
       items_per_page: 100
   custom_activities_stream:
-    $ref: "*ref(definitions.base_stream)"
+    $ref: "#/definitions/base_stream"
     $options:
       name: "custom_activities"
       path: "custom_activity"
 
 streams:
-  - "*ref(definitions.created_activities_stream)"
-  - "*ref(definitions.note_activities_stream)"
-  - "*ref(definitions.email_thread_activities_stream)"
-  - "*ref(definitions.email_activities_stream)"
-  - "*ref(definitions.sms_activities_stream)"
-  - "*ref(definitions.call_activities_stream)"
-  - "*ref(definitions.meeting_activities_stream)"
-  - "*ref(definitions.lead_status_change_activities_stream)"
-  - "*ref(definitions.opportunity_status_change_activities_stream)"
-  - "*ref(definitions.task_completed_activities_stream)"
-  - "*ref(definitions.lead_custom_fields_stream)"
-  - "*ref(definitions.contact_custom_fields_stream)"
-  - "*ref(definitions.opportunity_custom_fields_stream)"
-  - "*ref(definitions.activity_custom_fields_stream)"
-  - "*ref(definitions.users_stream)"
-  - "*ref(definitions.contacts_stream)"
-  - "*ref(definitions.roles_stream)"
-  - "*ref(definitions.lead_statuses_stream)"
-  - "*ref(definitions.opportunity_statuses_stream)"
-  - "*ref(definitions.pipelines_stream)"
-  - "*ref(definitions.email_templates_stream)"
-  - "*ref(definitions.events_stream)"
-  - "*ref(definitions.leads_steam)"
-  - "*ref(definitions.opportunities_stream)"
-  - "*ref(definitions.lead_tasks_stream)"
-  - "*ref(definitions.incoming_email_tasks_stream)"
-  - "*ref(definitions.email_followup_tasks_stream)"
-  - "*ref(definitions.missed_call_tasks_stream)"
-  - "*ref(definitions.answered_detached_call_tasks_stream)"
-  - "*ref(definitions.voicemail_tasks_stream)"
-  - "*ref(definitions.opportunity_due_tasks_stream)"
-  - "*ref(definitions.incoming_sms_tasks_stream)"
-  - "*ref(definitions.google_connected_accounts_stream)"
-  - "*ref(definitions.custom_email_connected_accounts_stream)"
-  - "*ref(definitions.zoom_connected_accounts_stream)"
-  - "*ref(definitions.send_as_stream)"
-  - "*ref(definitions.email_sequences_stream)"
-  - "*ref(definitions.dialer_stream)"
-  - "*ref(definitions.smart_views_stream)"
-  - "*ref(definitions.email_bulk_actions_stream)"
-  - "*ref(definitions.sequence_subscription_bulk_actions_stream)"
-  - "*ref(definitions.delete_bulk_actions_stream)"
-  - "*ref(definitions.edit_bulk_actions_stream)"
-  - "*ref(definitions.integration_links_stream)"
-  - "*ref(definitions.custom_activities_stream)"
+  - "#/definitions/created_activities_stream"
+  - "#/definitions/note_activities_stream"
+  - "#/definitions/email_thread_activities_stream"
+  - "#/definitions/email_activities_stream"
+  - "#/definitions/sms_activities_stream"
+  - "#/definitions/call_activities_stream"
+  - "#/definitions/meeting_activities_stream"
+  - "#/definitions/lead_status_change_activities_stream"
+  - "#/definitions/opportunity_status_change_activities_stream"
+  - "#/definitions/task_completed_activities_stream"
+  - "#/definitions/lead_custom_fields_stream"
+  - "#/definitions/contact_custom_fields_stream"
+  - "#/definitions/opportunity_custom_fields_stream"
+  - "#/definitions/activity_custom_fields_stream"
+  - "#/definitions/users_stream"
+  - "#/definitions/contacts_stream"
+  - "#/definitions/roles_stream"
+  - "#/definitions/lead_statuses_stream"
+  - "#/definitions/opportunity_statuses_stream"
+  - "#/definitions/pipelines_stream"
+  - "#/definitions/email_templates_stream"
+  - "#/definitions/events_stream"
+  - "#/definitions/leads_steam"
+  - "#/definitions/opportunities_stream"
+  - "#/definitions/lead_tasks_stream"
+  - "#/definitions/incoming_email_tasks_stream"
+  - "#/definitions/email_followup_tasks_stream"
+  - "#/definitions/missed_call_tasks_stream"
+  - "#/definitions/answered_detached_call_tasks_stream"
+  - "#/definitions/voicemail_tasks_stream"
+  - "#/definitions/opportunity_due_tasks_stream"
+  - "#/definitions/incoming_sms_tasks_stream"
+  - "#/definitions/google_connected_accounts_stream"
+  - "#/definitions/custom_email_connected_accounts_stream"
+  - "#/definitions/zoom_connected_accounts_stream"
+  - "#/definitions/send_as_stream"
+  - "#/definitions/email_sequences_stream"
+  - "#/definitions/dialer_stream"
+  - "#/definitions/smart_views_stream"
+  - "#/definitions/email_bulk_actions_stream"
+  - "#/definitions/sequence_subscription_bulk_actions_stream"
+  - "#/definitions/delete_bulk_actions_stream"
+  - "#/definitions/edit_bulk_actions_stream"
+  - "#/definitions/integration_links_stream"
+  - "#/definitions/custom_activities_stream"
 
 check:
   stream_names:

--- a/airbyte-integrations/connectors/source-coin-api/source_coin_api/coin_api.yaml
+++ b/airbyte-integrations/connectors/source-coin-api/source_coin_api/coin_api.yaml
@@ -36,38 +36,38 @@ definitions:
 
   retriever:
     record_selector:
-      $ref: "*ref(definitions.selector)"
+      $ref: "#/definitions/selector"
     paginator:
       type: NoPagination
     requester:
-      $ref: "*ref(definitions.requester)"
+      $ref: "#/definitions/requester"
   base_stream:
     retriever:
-      $ref: "*ref(definitions.retriever)"
+      $ref: "#/definitions/retriever"
   ohlcv_historical_data_stream:
-    $ref: "*ref(definitions.base_stream)"
+    $ref: "#/definitions/base_stream"
     $options:
       name: "ohlcv_historical_data"
       primary_key: "time_period_start"
       path: "/ohlcv/{{ config['symbol_id'] }}/history"
       stream_cursor_field: "time_period_start"
   trades_historical_data_stream:
-    $ref: "*ref(definitions.base_stream)"
+    $ref: "#/definitions/base_stream"
     $options:
       name: "trades_historical_data"
       primary_key: "uuid"
       path: "/trades/{{ config['symbol_id'] }}/history"
       stream_cursor_field: "time_exchange"
   quotes_historical_data_stream:
-    $ref: "*ref(definitions.base_stream)"
+    $ref: "#/definitions/base_stream"
     $options:
       name: "quotes_historical_data"
       path: "/quotes/{{ config['symbol_id'] }}/history"
 
 streams:
-  - "*ref(definitions.ohlcv_historical_data_stream)"
-  - "*ref(definitions.trades_historical_data_stream)"
-  - "*ref(definitions.quotes_historical_data_stream)"
+  - "#/definitions/ohlcv_historical_data_stream"
+  - "#/definitions/trades_historical_data_stream"
+  - "#/definitions/quotes_historical_data_stream"
 
 check:
   stream_names:

--- a/airbyte-integrations/connectors/source-coingecko-coins/source_coingecko_coins/coingecko_coins.yaml
+++ b/airbyte-integrations/connectors/source-coingecko-coins/source_coingecko_coins/coingecko_coins.yaml
@@ -28,29 +28,29 @@ definitions:
       inject_into: "request_parameter"
   retriever:
     record_selector:
-      $ref: "*ref(definitions.selector)"
+      $ref: "#/definitions/selector"
     paginator:
       type: NoPagination
     requester:
-      $ref: "*ref(definitions.requester)"
+      $ref: "#/definitions/requester"
   sliced_retriever:
-    $ref: "*ref(definitions.retriever)"
+    $ref: "#/definitions/retriever"
     stream_slicer:
-      $ref: "*ref(definitions.stream_slicer)"
+      $ref: "#/definitions/stream_slicer"
   base_stream:
     retriever:
-      $ref: "*ref(definitions.retriever)"
+      $ref: "#/definitions/retriever"
   sliced_stream:
     retriever:
-      $ref: "*ref(definitions.sliced_retriever)"
+      $ref: "#/definitions/sliced_retriever"
   market_chart_stream:
-    $ref: "*ref(definitions.base_stream)"
+    $ref: "#/definitions/base_stream"
     $options:
       name: "market_chart"
       path: "/market_chart"
       primary_key: "prices"
   history_stream:
-    $ref: "*ref(definitions.sliced_stream)"
+    $ref: "#/definitions/sliced_stream"
     $options:
       name: "history"
       path: "/history"
@@ -61,8 +61,8 @@ definitions:
             value: "{{ stream_slice['start_time'] }}"
 
 streams:
-  - "*ref(definitions.market_chart_stream)"
-  - "*ref(definitions.history_stream)"
+  - "#/definitions/market_chart_stream"
+  - "#/definitions/history_stream"
 
 check:
   stream_names:

--- a/airbyte-integrations/connectors/source-coinmarketcap/source_coinmarketcap/coinmarketcap.yaml
+++ b/airbyte-integrations/connectors/source-coinmarketcap/source_coinmarketcap/coinmarketcap.yaml
@@ -14,7 +14,7 @@ definitions:
   offset_paginator:
     type: DefaultPaginator
     $options:
-      url_base: "*ref(definitions.requester.url_base)"
+      url_base: "#/definitions/requester/url_base"
     page_size_option:
       inject_into: "request_parameter"
       field_name: "limit"
@@ -26,59 +26,59 @@ definitions:
       inject_into: "request_parameter"
   retriever:
     record_selector:
-      $ref: "*ref(definitions.selector)"
+      $ref: "#/definitions/selector"
     paginator:
-      $ref: "*ref(definitions.offset_paginator)"
+      $ref: "#/definitions/offset_paginator"
     requester:
-      $ref: "*ref(definitions.requester)"
+      $ref: "#/definitions/requester"
   base_stream:
     retriever:
-      $ref: "*ref(definitions.retriever)"
+      $ref: "#/definitions/retriever"
   categories_stream:
-    $ref: "*ref(definitions.base_stream)"
+    $ref: "#/definitions/base_stream"
     $options:
       name: "categories"
       primary_key: "id"
       path: "/v1/cryptocurrency/categories"
   listing_stream:
-    $ref: "*ref(definitions.base_stream)"
+    $ref: "#/definitions/base_stream"
     $options:
       name: "listing"
       primary_key: "id"
       path: "/v1/cryptocurrency/listings/{{ config['data_type'] or ''}}"
   quotes_stream:
-    $ref: "*ref(definitions.base_stream)"
+    $ref: "#/definitions/base_stream"
     retriever:
       record_selector:
-        $ref: "*ref(definitions.selector)"
+        $ref: "#/definitions/selector"
       paginator:
         type: NoPagination
       requester:
-        $ref: "*ref(definitions.requester)"
+        $ref: "#/definitions/requester"
         request_parameters:
           symbol: "{{ ','.join(config.get('symbols', [])) }}"
     $options:
       name: "quotes"
       path: "/v1/cryptocurrency/quotes/{{ config['data_type'] or ''}}"
   fiat_stream:
-    $ref: "*ref(definitions.base_stream)"
+    $ref: "#/definitions/base_stream"
     $options:
       name: "fiat"
       primary_key: "id"
       path: "/v1/fiat/map"
   exchange_stream:
-    $ref: "*ref(definitions.base_stream)"
+    $ref: "#/definitions/base_stream"
     $options:
       name: "exchange"
       primary_key: "id"
       path: "/v1/exchange/map"
 
 streams:
-  - "*ref(definitions.categories_stream)"
-  - "*ref(definitions.listing_stream)"
-  - "*ref(definitions.quotes_stream)"
-  - "*ref(definitions.fiat_stream)"
-  - "*ref(definitions.exchange_stream)"
+  - "#/definitions/categories_stream"
+  - "#/definitions/listing_stream"
+  - "#/definitions/quotes_stream"
+  - "#/definitions/fiat_stream"
+  - "#/definitions/exchange_stream"
 
 check:
   stream_names:

--- a/airbyte-integrations/connectors/source-configcat/source_configcat/configcat.yaml
+++ b/airbyte-integrations/connectors/source-configcat/source_configcat/configcat.yaml
@@ -13,22 +13,22 @@ definitions:
       password: "{{ config['password'] }}"
   retriever:
     record_selector:
-      $ref: "*ref(definitions.selector)"
+      $ref: "#/definitions/selector"
     paginator:
       type: NoPagination
     requester:
-      $ref: "*ref(definitions.requester)"
+      $ref: "#/definitions/requester"
   base_stream:
     retriever:
-      $ref: "*ref(definitions.retriever)"
+      $ref: "#/definitions/retriever"
   organizations_stream:
-    $ref: "*ref(definitions.base_stream)"
+    $ref: "#/definitions/base_stream"
     $options:
       name: "organizations"
       primary_key: "organizationId"
       path: "/organizations"
   products_stream:
-    $ref: "*ref(definitions.base_stream)"
+    $ref: "#/definitions/base_stream"
     $options:
       name: "products"
       primary_key: "productId"
@@ -36,64 +36,64 @@ definitions:
   product_stream_slicer:
     type: SubstreamSlicer
     parent_stream_configs:
-      - stream: "*ref(definitions.products_stream)"
+      - stream: "#/definitions/products_stream"
         parent_key: productId
         stream_slice_field: productId
   tags_stream:
-    $ref: "*ref(definitions.base_stream)"
+    $ref: "#/definitions/base_stream"
     $options:
       name: "tags"
       primary_key: "tagId"
     retriever:
-      $ref: "*ref(definitions.retriever)"
+      $ref: "#/definitions/retriever"
       requester:
-        $ref: "*ref(definitions.requester)"
+        $ref: "#/definitions/requester"
         path: "/products/{{ stream_slice.productId }}/tags"
       stream_slicer:
-        $ref: "*ref(definitions.product_stream_slicer)"
+        $ref: "#/definitions/product_stream_slicer"
       record_selector:
-        $ref: "*ref(definitions.selector)"
+        $ref: "#/definitions/selector"
   environments_stream:
-    $ref: "*ref(definitions.base_stream)"
+    $ref: "#/definitions/base_stream"
     $options:
       name: "environments"
       primary_key: "environmentId"
     retriever:
-      $ref: "*ref(definitions.retriever)"
+      $ref: "#/definitions/retriever"
       requester:
-        $ref: "*ref(definitions.requester)"
+        $ref: "#/definitions/requester"
         path: "/products/{{ stream_slice.productId }}/environments"
       stream_slicer:
-        $ref: "*ref(definitions.product_stream_slicer)"
+        $ref: "#/definitions/product_stream_slicer"
       record_selector:
-        $ref: "*ref(definitions.selector)"
+        $ref: "#/definitions/selector"
   organization_stream_slicer:
     type: SubstreamSlicer
     parent_stream_configs:
-      - stream: "*ref(definitions.organizations_stream)"
+      - stream: "#/definitions/organizations_stream"
         parent_key: organizationId
         stream_slice_field: organizationId
   organization_members_stream:
-    $ref: "*ref(definitions.base_stream)"
+    $ref: "#/definitions/base_stream"
     $options:
       name: "organization_members"
       primary_key: "userId"
     retriever:
-      $ref: "*ref(definitions.retriever)"
+      $ref: "#/definitions/retriever"
       requester:
-        $ref: "*ref(definitions.requester)"
+        $ref: "#/definitions/requester"
         path: "/organizations/{{ stream_slice.organizationId }}/members"
       stream_slicer:
-        $ref: "*ref(definitions.organization_stream_slicer)"
+        $ref: "#/definitions/organization_stream_slicer"
       record_selector:
-        $ref: "*ref(definitions.selector)"
+        $ref: "#/definitions/selector"
 
 streams:
-  - "*ref(definitions.organizations_stream)"
-  - "*ref(definitions.organization_members_stream)"
-  - "*ref(definitions.products_stream)"
-  - "*ref(definitions.tags_stream)"
-  - "*ref(definitions.environments_stream)"
+  - "#/definitions/organizations_stream"
+  - "#/definitions/organization_members_stream"
+  - "#/definitions/products_stream"
+  - "#/definitions/tags_stream"
+  - "#/definitions/environments_stream"
 
 check:
   stream_names:

--- a/airbyte-integrations/connectors/source-convertkit/source_convertkit/convertkit.yaml
+++ b/airbyte-integrations/connectors/source-convertkit/source_convertkit/convertkit.yaml
@@ -12,7 +12,7 @@ definitions:
       api_secret: "{{ config['api_secret'] }}"
   increment_paginator:
     type: DefaultPaginator
-    url_base: "*ref(definitions.requester.url_base)"
+    url_base: "#/definitions/requester/url_base"
     page_size_option:
       inject_into: "request_parameter"
       field_name: "limit"
@@ -24,26 +24,26 @@ definitions:
       field_name: "page"
   retriever:
     record_selector:
-      $ref: "*ref(definitions.selector)"
+      $ref: "#/definitions/selector"
     paginator:
       type: NoPagination
     requester:
-      $ref: "*ref(definitions.requester)"
+      $ref: "#/definitions/requester"
   base_stream:
     retriever:
-      $ref: "*ref(definitions.retriever)"
+      $ref: "#/definitions/retriever"
   # API Docs: https://developers.convertkit.com/#forms
   forms_stream:
-    $ref: "*ref(definitions.base_stream)"
+    $ref: "#/definitions/base_stream"
     $options:
       name: "forms"
       primary_key: "id"
       path: "/forms"
   # API Docs: https://developers.convertkit.com/#sequences
   sequences_stream:
-    $ref: "*ref(definitions.base_stream)"
+    $ref: "#/definitions/base_stream"
     retriever:
-      $ref: "*ref(definitions.retriever)"
+      $ref: "#/definitions/retriever"
       record_selector:
         extractor:
           field_pointer: ["courses"]
@@ -53,34 +53,34 @@ definitions:
       path: "/sequences"
   # API Docs: https://developers.convertkit.com/#tags
   tags_stream:
-    $ref: "*ref(definitions.base_stream)"
+    $ref: "#/definitions/base_stream"
     $options:
       name: "tags"
       primary_key: "id"
       path: "/tags"
     retriever:
-      $ref: "*ref(definitions.retriever)"
+      $ref: "#/definitions/retriever"
       paginator:
-        $ref: "*ref(definitions.increment_paginator)"
+        $ref: "#/definitions/increment_paginator"
   # API Docs: https://developers.convertkit.com/#subscribers
   subscribers_stream:
-    $ref: "*ref(definitions.base_stream)"
+    $ref: "#/definitions/base_stream"
     $options:
       name: "subscribers"
       primary_key: "id"
       path: "/subscribers"
   # API Docs: https://developers.convertkit.com/#broadcasts
   broadcasts_stream:
-    $ref: "*ref(definitions.base_stream)"
+    $ref: "#/definitions/base_stream"
     $options:
       name: "broadcasts"
       primary_key: "id"
       path: "/broadcasts"
 streams:
-  - "*ref(definitions.forms_stream)"
-  - "*ref(definitions.sequences_stream)"
-  - "*ref(definitions.tags_stream)"
-  - "*ref(definitions.subscribers_stream)"
-  - "*ref(definitions.broadcasts_stream)"
+  - "#/definitions/forms_stream"
+  - "#/definitions/sequences_stream"
+  - "#/definitions/tags_stream"
+  - "#/definitions/subscribers_stream"
+  - "#/definitions/broadcasts_stream"
 check:
   stream_names: ["forms"]

--- a/airbyte-integrations/connectors/source-courier/source_courier/courier.yaml
+++ b/airbyte-integrations/connectors/source-courier/source_courier/courier.yaml
@@ -29,7 +29,7 @@ definitions:
 
   cursor_paginator:
     type: DefaultPaginator
-    url_base: "*ref(definitions.requester.url_base)"
+    url_base: "#/definitions/requester/url_base"
     page_token_option:
       field_name: cursor
       inject_into: request_parameter
@@ -46,36 +46,36 @@ definitions:
     name: "{{ options['name'] }}"
     primary_key: "{{ options['primary_key'] }}"
     record_selector:
-      $ref: "*ref(definitions.results_selector)"
+      $ref: "#/definitions/results_selector"
 
   base_stream:
     type: DeclarativeStream
     primary_key: "id"
     schema_loader:
-      $ref: "*ref(definitions.schema_loader)"
+      $ref: "#/definitions/schema_loader"
     retriever:
-      $ref: "*ref(definitions.retriever)"
+      $ref: "#/definitions/retriever"
       requester:
-        $ref: "*ref(definitions.requester)"
+        $ref: "#/definitions/requester"
       record_selector:
-        $ref: "*ref(definitions.root_selector)"
+        $ref: "#/definitions/root_selector"
 
   ## MESSAGES API ##
   messages_stream:
-    $ref: "*ref(definitions.base_stream)"
+    $ref: "#/definitions/base_stream"
     primary_key: id
     $options:
       name: "messages"
       path: "/messages"
     retriever:
-      $ref: "*ref(definitions.retriever)"
+      $ref: "#/definitions/retriever"
       record_selector:
-        $ref: "*ref(definitions.results_selector)"
+        $ref: "#/definitions/results_selector"
       requester:
-        $ref: "*ref(definitions.requester)"
+        $ref: "#/definitions/requester"
         path: "/messages"
       paginator:
-        $ref: "*ref(definitions.cursor_paginator)"
+        $ref: "#/definitions/cursor_paginator"
 
   ## MESSAGE INFO / HISTORY / OUTPUT STREAMS ##
   message_id_transformer:
@@ -86,25 +86,25 @@ definitions:
   message_stream_slicer:
     type: SubstreamSlicer
     parent_stream_configs:
-      - stream: "*ref(definitions.messages_stream)"
+      - stream: "#/definitions/messages_stream"
         parent_key: id
         stream_slice_field: id
 
   message_info_stream:
-    $ref: "*ref(definitions.base_stream)"
+    $ref: "#/definitions/base_stream"
     type: DeclarativeStream
     primary_key: id
     $options:
       name: message_info
     retriever:
-      $ref: "*ref(definitions.retriever)"
+      $ref: "#/definitions/retriever"
       requester:
-        $ref: "*ref(definitions.requester)"
+        $ref: "#/definitions/requester"
         path: "/messages/{{ stream_slice.id }}"
       stream_slicer:
-        $ref: "*ref(definitions.message_stream_slicer)"
+        $ref: "#/definitions/message_stream_slicer"
       record_selector:
-        $ref: "*ref(definitions.root_selector)"
+        $ref: "#/definitions/root_selector"
 
   message_history_stream:
     type: DeclarativeStream
@@ -112,18 +112,18 @@ definitions:
       name: message_history
     primary_key: message_id
     schema_loader:
-      $ref: "*ref(definitions.schema_loader)"
+      $ref: "#/definitions/schema_loader"
     retriever:
-      $ref: "*ref(definitions.retriever)"
+      $ref: "#/definitions/retriever"
       record_selector:
-        $ref: "*ref(definitions.results_selector)"
+        $ref: "#/definitions/results_selector"
       requester:
-        $ref: "*ref(definitions.requester)"
+        $ref: "#/definitions/requester"
         path: "/messages/{{ stream_slice.id }}/history"
       stream_slicer:
-        $ref: "*ref(definitions.message_stream_slicer)"
+        $ref: "#/definitions/message_stream_slicer"
     transformations:
-      - $ref: "*ref(definitions.message_id_transformer)"
+      - $ref: "#/definitions/message_id_transformer"
 
   message_output_stream:
     type: DeclarativeStream
@@ -131,24 +131,24 @@ definitions:
       name: message_output
     primary_key: message_id
     schema_loader:
-      $ref: "*ref(definitions.schema_loader)"
+      $ref: "#/definitions/schema_loader"
     retriever:
-      $ref: "*ref(definitions.retriever)"
+      $ref: "#/definitions/retriever"
       record_selector:
-        $ref: "*ref(definitions.results_selector)"
+        $ref: "#/definitions/results_selector"
       requester:
-        $ref: "*ref(definitions.requester)"
+        $ref: "#/definitions/requester"
         path: "/messages/{{ stream_slice.id }}/output"
       stream_slicer:
-        $ref: "*ref(definitions.message_stream_slicer)"
+        $ref: "#/definitions/message_stream_slicer"
     transformations:
-      - $ref: "*ref(definitions.message_id_transformer)"
+      - $ref: "#/definitions/message_id_transformer"
 
 streams:
-  - "*ref(definitions.messages_stream)"
-  - "*ref(definitions.message_info_stream)"
-  - "*ref(definitions.message_history_stream)"
-  - "*ref(definitions.message_output_stream)"
+  - "#/definitions/messages_stream"
+  - "#/definitions/message_info_stream"
+  - "#/definitions/message_history_stream"
+  - "#/definitions/message_output_stream"
 
 check:
   type: CheckStream

--- a/airbyte-integrations/connectors/source-datascope/source_datascope/datascope.yaml
+++ b/airbyte-integrations/connectors/source-datascope/source_datascope/datascope.yaml
@@ -34,10 +34,10 @@ definitions:
 
   retriever:
     record_selector:
-      $ref: "*ref(definitions.selector)"
+      $ref: "#/definitions/selector"
     paginator:
       type: DefaultPaginator
-      url_base: "*ref(definitions.requester.url_base)"
+      url_base: "#/definitions/requester/url_base"
       page_size_option:
         inject_into: "request_parameter"
         field_name: "limit"
@@ -48,16 +48,16 @@ definitions:
         inject_into: "request_parameter"
         field_name: "offset"
     requester:
-      $ref: "*ref(definitions.requester)"
+      $ref: "#/definitions/requester"
     stream_slicer:
-      $ref: "*ref(definitions.stream_slicer)"
+      $ref: "#/definitions/stream_slicer"
 
   retriever_non_incremental:
     record_selector:
-      $ref: "*ref(definitions.selector)"
+      $ref: "#/definitions/selector"
     paginator:
       type: DefaultPaginator
-      url_base: "*ref(definitions.requester.url_base)"
+      url_base: "#/definitions/requester/url_base"
       page_size_option:
         inject_into: "request_parameter"
         field_name: "limit"
@@ -68,19 +68,19 @@ definitions:
         inject_into: "request_parameter"
         field_name: "offset"
     requester:
-      $ref: "*ref(definitions.requester)"
+      $ref: "#/definitions/requester"
   base_stream:
     retriever:
-      $ref: "*ref(definitions.retriever)"
+      $ref: "#/definitions/retriever"
   location_stream:
     retriever:
-      $ref: "*ref(definitions.retriever_non_incremental)"
+      $ref: "#/definitions/retriever_non_incremental"
     $options:
       name: "locations"
       primary_key: "id"
       path: "/locations"
   answers_stream:
-    $ref: "*ref(definitions.base_stream)"
+    $ref: "#/definitions/base_stream"
     $options:
       name: "answers"
       primary_key: "form_answer_id"
@@ -88,23 +88,23 @@ definitions:
       stream_cursor_field: "created_at"
   lists_stream:
     retriever:
-      $ref: "*ref(definitions.retriever_non_incremental)"
+      $ref: "#/definitions/retriever_non_incremental"
     $options:
       name: "lists"
       primary_key: "id"
       path: "/metadata_objects"
   notifications_stream:
-    $ref: "*ref(definitions.base_stream)"
+    $ref: "#/definitions/base_stream"
     $options:
       name: "notifications"
       primary_key: "id"
       path: "/notifications"
       stream_cursor_field: "created_at"
 streams:
-  - "*ref(definitions.location_stream)"
-  - "*ref(definitions.answers_stream)"
-  - "*ref(definitions.lists_stream)"
-  - "*ref(definitions.notifications_stream)"
+  - "#/definitions/location_stream"
+  - "#/definitions/answers_stream"
+  - "#/definitions/lists_stream"
+  - "#/definitions/notifications_stream"
 
 check:
   stream_names:

--- a/airbyte-integrations/connectors/source-delighted/source_delighted/delighted.yaml
+++ b/airbyte-integrations/connectors/source-delighted/source_delighted/delighted.yaml
@@ -41,7 +41,7 @@ definitions:
     type: SimpleRetriever
     name: "{{ options['name'] }}"
     record_selector:
-      $ref: "*ref(definitions.selector)"
+      $ref: "#/definitions/selector"
     paginator:
       type: DefaultPaginator
       pagination_strategy:
@@ -54,20 +54,20 @@ definitions:
       page_token_option:
         field_name: "page"
         inject_into: "request_parameter"
-      url_base: "*ref(definitions.requester.url_base)"
+      url_base: "#/definitions/requester/url_base"
     requester:
-      $ref: "*ref(definitions.requester)"
+      $ref: "#/definitions/requester"
     stream_slicer:
-      $ref: "*ref(definitions.stream_slicer)"
+      $ref: "#/definitions/stream_slicer"
   base_stream:
     primary_key: "id"
     retriever:
-      $ref: "*ref(definitions.retriever)"
+      $ref: "#/definitions/retriever"
   people:
-    $ref: "*ref(definitions.base_stream)"
+    $ref: "#/definitions/base_stream"
     stream_cursor_field: "created_at"
     retriever:
-      $ref: "*ref(definitions.retriever)"
+      $ref: "#/definitions/retriever"
       paginator:
         type: DefaultPaginator
         pagination_strategy:
@@ -80,13 +80,13 @@ definitions:
           inject_into: "request_parameter"
         page_token_option:
           inject_into: "path"
-        url_base: "*ref(definitions.requester.url_base)"
+        url_base: "#/definitions/requester/url_base"
     $options:
       name: "people"
       path: "people.json"
       stream_cursor_field: "created_at"
   bounces:
-    $ref: "*ref(definitions.base_stream)"
+    $ref: "#/definitions/base_stream"
     primary_key: "person_id"
     stream_cursor_field: "bounced_at"
     $options:
@@ -94,7 +94,7 @@ definitions:
       name: "bounces"
       path: "bounces.json"
   unsubscribes:
-    $ref: "*ref(definitions.base_stream)"
+    $ref: "#/definitions/base_stream"
     primary_key: "person_id"
     stream_cursor_field: "unsubscribed_at"
     $options:
@@ -102,12 +102,12 @@ definitions:
       name: "unsubscribes"
       path: "unsubscribes.json"
   survey_responses:
-    $ref: "*ref(definitions.base_stream)"
+    $ref: "#/definitions/base_stream"
     stream_cursor_field: "updated_at"
     retriever:
-      $ref: "*ref(definitions.retriever)"
+      $ref: "#/definitions/retriever"
       stream_slicer:
-        $ref: "*ref(definitions.stream_slicer)"
+        $ref: "#/definitions/stream_slicer"
         end_time_option:
           field_name: "updated_until"
           inject_into: "request_parameter"
@@ -120,10 +120,10 @@ definitions:
       path: "survey_responses.json"
 
 streams:
-  - "*ref(definitions.people)"
-  - "*ref(definitions.unsubscribes)"
-  - "*ref(definitions.bounces)"
-  - "*ref(definitions.survey_responses)"
+  - "#/definitions/people"
+  - "#/definitions/unsubscribes"
+  - "#/definitions/bounces"
+  - "#/definitions/survey_responses"
 
 check:
   type: CheckStream

--- a/airbyte-integrations/connectors/source-emailoctopus/source_emailoctopus/emailoctopus.yaml
+++ b/airbyte-integrations/connectors/source-emailoctopus/source_emailoctopus/emailoctopus.yaml
@@ -11,7 +11,7 @@ definitions:
       api_key: "{{ config['api_key'] }}"
   increment_paginator:
     type: DefaultPaginator
-    url_base: "*ref(definitions.requester.url_base)"
+    url_base: "#/definitions/requester/url_base"
     pagination_strategy:
       type: PageIncrement
       page_size: 50
@@ -23,25 +23,25 @@ definitions:
       field_name: "page"
   retriever:
     record_selector:
-      $ref: "*ref(definitions.selector)"
+      $ref: "#/definitions/selector"
     paginator:
       type: NoPagination
     requester:
-      $ref: "*ref(definitions.requester)"
+      $ref: "#/definitions/requester"
   base_stream:
     retriever:
-      $ref: "*ref(definitions.retriever)"
+      $ref: "#/definitions/retriever"
   # API Docs: https://emailoctopus.com/api-documentation/campaigns/get-all
   campaigns_stream:
-    $ref: "*ref(definitions.base_stream)"
+    $ref: "#/definitions/base_stream"
     $options:
       name: "campaigns"
       primary_key: "id"
       path: "/campaigns"
     retriever:
-      $ref: "*ref(definitions.retriever)"
+      $ref: "#/definitions/retriever"
       paginator:
-        $ref: "*ref(definitions.increment_paginator)"
+        $ref: "#/definitions/increment_paginator"
     # Fields are large and may affect performance
     transformations:
       - type: RemoveFields
@@ -50,15 +50,15 @@ definitions:
           - ["content", "plain_text"]
   # API Docs: https://emailoctopus.com/api-documentation/lists/get-all
   lists_stream:
-    $ref: "*ref(definitions.base_stream)"
+    $ref: "#/definitions/base_stream"
     $options:
       name: "lists"
       primary_key: "id"
       path: "/lists"
     retriever:
-      $ref: "*ref(definitions.retriever)"
+      $ref: "#/definitions/retriever"
       paginator:
-        $ref: "*ref(definitions.increment_paginator)"
+        $ref: "#/definitions/increment_paginator"
     # 'tags' array not yet documented (2022-10-29)
     transformations:
       - type: RemoveFields
@@ -66,8 +66,8 @@ definitions:
           - ["tags"]
 
 streams:
-  - "*ref(definitions.campaigns_stream)"
-  - "*ref(definitions.lists_stream)"
+  - "#/definitions/campaigns_stream"
+  - "#/definitions/lists_stream"
 
 check:
   stream_names:

--- a/airbyte-integrations/connectors/source-facebook-pages/source_facebook_pages/facebook_pages.yaml
+++ b/airbyte-integrations/connectors/source-facebook-pages/source_facebook_pages/facebook_pages.yaml
@@ -13,7 +13,7 @@ definitions:
     error_handler:
       type: DefaultErrorHandler
       response_filters:
-        - http_codes: [ 400 ]
+        - http_codes: [400]
           action: RETRY
     authenticator:
       type: CustomAuthenticator
@@ -33,34 +33,34 @@ definitions:
     page_token_option:
       field_name: "after"
       inject_into: "request_parameter"
-    url_base: "*ref(definitions.requester.url_base)"
+    url_base: "#/definitions/requester/url_base"
   retriever:
     record_selector:
-      $ref: "*ref(definitions.selector)"
+      $ref: "#/definitions/selector"
     paginator:
       type: NoPagination
     requester:
-      $ref: "*ref(definitions.requester)"
+      $ref: "#/definitions/requester"
 
   base_stream:
     schema_loader:
-      $ref: "*ref(definitions.schema_loader)"
+      $ref: "#/definitions/schema_loader"
     retriever:
-      $ref: "*ref(definitions.retriever)"
+      $ref: "#/definitions/retriever"
 
   page_stream:
-    $ref: "*ref(definitions.base_stream)"
+    $ref: "#/definitions/base_stream"
     $options:
       name: "page"
       primary_key: "id"
       path: "/{{ config['page_id'] }}"
     retriever:
-      $ref: "*ref(definitions.retriever)"
+      $ref: "#/definitions/retriever"
       record_selector:
         extractor:
           field_pointer: []
       requester:
-        $ref: "*ref(definitions.requester)"
+        $ref: "#/definitions/requester"
         request_parameters:
           fields: " {{ ','.join([
             'id',
@@ -206,21 +206,20 @@ definitions:
             'product_catalogs',
             'rtb_dynamic_posts',
             'video_lists',
-            'videos',
-          ]) }} "
+            'videos']) }} "
 
   post_stream:
-    $ref: "*ref(definitions.base_stream)"
+    $ref: "#/definitions/base_stream"
     $options:
       name: "post"
       primary_key: "id"
       path: "/{{ config['page_id'] }}/posts"
     retriever:
-      $ref: "*ref(definitions.retriever)"
+      $ref: "#/definitions/retriever"
       paginator:
-        $ref: "*ref(definitions.facebook_post_paginator)"
+        $ref: "#/definitions/facebook_post_paginator"
       requester:
-        $ref: "*ref(definitions.requester)"
+        $ref: "#/definitions/requester"
         request_parameters:
           fields: "{{ ','.join([
             'id',
@@ -279,26 +278,25 @@ definitions:
             'reactions',
             'sharedposts',
             'sponsor_tags',
-            'to'
-          ]) }}"
+            'to']) }}"
 
   post_insights_stream:
-    $ref: "*ref(definitions.base_stream)"
+    $ref: "#/definitions/base_stream"
     $options:
       name: "post_insights"
       primary_key: "id"
       path: "/{{ config['page_id'] }}/posts"
     retriever:
-      $ref: "*ref(definitions.retriever)"
+      $ref: "#/definitions/retriever"
       paginator:
-        $ref: "*ref(definitions.facebook_post_paginator)"
+        $ref: "#/definitions/facebook_post_paginator"
       record_selector:
         type: RecordSelector
         extractor:
           class_name: source_facebook_pages.components.NestedDpathExtractor
           field_pointer: ["data", "insights", "data"]
       requester:
-        $ref: "*ref(definitions.requester)"
+        $ref: "#/definitions/requester"
         request_parameters:
           fields: "{{ 'insights.metric(%s)' % ','.join([
             'post_impressions',
@@ -327,19 +325,18 @@ definitions:
             'post_clicks_unique',
             'post_clicks_by_type',
             'post_clicks_by_type_unique',
-            'post_reactions_by_type_total',
-          ]) }}"
+            'post_reactions_by_type_total']) }}"
 
   page_insights_stream:
-    $ref: "*ref(definitions.base_stream)"
+    $ref: "#/definitions/base_stream"
     $options:
       name: "page_insights"
       primary_key: "id"
       path: "/{{ config['page_id'] }}/insights"
     retriever:
-      $ref: "*ref(definitions.retriever)"
+      $ref: "#/definitions/retriever"
       requester:
-        $ref: "*ref(definitions.requester)"
+        $ref: "#/definitions/requester"
         request_parameters:
           metric: "{{ ','.join([
             'page_tab_views_login_top_unique',
@@ -406,15 +403,13 @@ definitions:
             'page_impressions_by_locale_unique',
             'page_impressions_by_age_gender_unique',
             'page_impressions_frequency_distribution',
-            'page_impressions_viral_frequency_distribution',
-          ]) }}"
+            'page_impressions_viral_frequency_distribution']) }}"
 streams:
-  - "*ref(definitions.page_stream)"
-  - "*ref(definitions.post_stream)"
-  - "*ref(definitions.post_insights_stream)"
-  - "*ref(definitions.page_insights_stream)"
+  - "#/definitions/page_stream"
+  - "#/definitions/post_stream"
+  - "#/definitions/post_insights_stream"
+  - "#/definitions/page_insights_stream"
 
 check:
   stream_names:
     - "page"
-

--- a/airbyte-integrations/connectors/source-getlago/source_getlago/getlago.yaml
+++ b/airbyte-integrations/connectors/source-getlago/source_getlago/getlago.yaml
@@ -12,7 +12,7 @@ definitions:
       api_token: "{{ config['api_key'] }}"
   cursor_paginator:
     type: DefaultPaginator
-    url_base: "*ref(definitions.requester.url_base)"
+    url_base: "#/definitions/requester/url_base"
     page_token_option:
       inject_into: request_parameter
       field_name: "page"
@@ -26,46 +26,46 @@ definitions:
       page_size: 100
   retriever:
     record_selector:
-      $ref: "*ref(definitions.selector)"
+      $ref: "#/definitions/selector"
     paginator:
-      $ref: "*ref(definitions.cursor_paginator)"
+      $ref: "#/definitions/cursor_paginator"
     requester:
-      $ref: "*ref(definitions.requester)"
+      $ref: "#/definitions/requester"
   base_stream:
     retriever:
-      $ref: "*ref(definitions.retriever)"
+      $ref: "#/definitions/retriever"
   billable_metrics_stream:
-    $ref: "*ref(definitions.base_stream)"
+    $ref: "#/definitions/base_stream"
     $options:
       name: "billable_metrics"
       primary_key: "lago_id"
       path: "/billable_metrics"
   plans_stream:
-    $ref: "*ref(definitions.base_stream)"
+    $ref: "#/definitions/base_stream"
     $options:
       name: "plans"
       primary_key: "lago_id"
       path: "/plans"
   coupons_stream:
-    $ref: "*ref(definitions.base_stream)"
+    $ref: "#/definitions/base_stream"
     $options:
       name: "coupons"
       primary_key: "lago_id"
       path: "/coupons"
   add_ons_stream:
-    $ref: "*ref(definitions.base_stream)"
+    $ref: "#/definitions/base_stream"
     $options:
       name: "add_ons"
       primary_key: "lago_id"
       path: "/add_ons"
   invoices_stream:
-    $ref: "*ref(definitions.base_stream)"
+    $ref: "#/definitions/base_stream"
     $options:
       name: "invoices"
       primary_key: "lago_id"
       path: "/invoices"
   customers_stream:
-    $ref: "*ref(definitions.base_stream)"
+    $ref: "#/definitions/base_stream"
     $options:
       name: "customers"
       primary_key: "lago_id"
@@ -73,32 +73,32 @@ definitions:
   customer_stream_slicer:
     type: SubstreamSlicer
     parent_stream_configs:
-      - stream: "*ref(definitions.customers_stream)"
+      - stream: "#/definitions/customers_stream"
         parent_key: external_id
         stream_slice_field: customer_external_id
   subscriptions_stream:
-    $ref: "*ref(definitions.base_stream)"
+    $ref: "#/definitions/base_stream"
     $options:
       name: "subscriptions"
       primary_key: "lago_id"
     retriever:
-      $ref: "*ref(definitions.retriever)"
+      $ref: "#/definitions/retriever"
       requester:
-        $ref: "*ref(definitions.requester)"
+        $ref: "#/definitions/requester"
         path: "/subscriptions?external_customer_id={{ stream_slice.customer_external_id }}"
       stream_slicer:
-        $ref: "*ref(definitions.customer_stream_slicer)"
+        $ref: "#/definitions/customer_stream_slicer"
       record_selector:
-        $ref: "*ref(definitions.selector)"
+        $ref: "#/definitions/selector"
 
 streams:
-  - "*ref(definitions.billable_metrics_stream)"
-  - "*ref(definitions.plans_stream)"
-  - "*ref(definitions.coupons_stream)"
-  - "*ref(definitions.add_ons_stream)"
-  - "*ref(definitions.invoices_stream)"
-  - "*ref(definitions.customers_stream)"
-  - "*ref(definitions.subscriptions_stream)"
+  - "#/definitions/billable_metrics_stream"
+  - "#/definitions/plans_stream"
+  - "#/definitions/coupons_stream"
+  - "#/definitions/add_ons_stream"
+  - "#/definitions/invoices_stream"
+  - "#/definitions/customers_stream"
+  - "#/definitions/subscriptions_stream"
 
 check:
   stream_names:

--- a/airbyte-integrations/connectors/source-gnews/source_gnews/gnews.yaml
+++ b/airbyte-integrations/connectors/source-gnews/source_gnews/gnews.yaml
@@ -125,7 +125,7 @@ definitions:
             - class_name: "source_gnews.WaitUntilMidnightBackoffStrategy"
   base_retriever:
     record_selector:
-      $ref: "*ref(definitions.selector)"
+      $ref: "#/definitions/selector"
     paginator:
       type: NoPagination
     stream_slicer:
@@ -151,43 +151,43 @@ definitions:
     type: InlineSchemaLoader
   search_stream:
     schema_loader:
-      $ref: "*ref(definitions.schema_loader)"
-      schema: "*ref(schemas.search_stream_schema)"
+      $ref: "#/definitions/schema_loader"
+      schema: "#/schemas/search_stream_schema"
     $options:
       name: "search"
       primary_key: "url"
       path: "/search"
       stream_cursor_field: "publishedAt"
     retriever:
-      $ref: "*ref(definitions.base_retriever)"
+      $ref: "#/definitions/base_retriever"
       requester:
-        $ref: "*ref(definitions.base_requester)"
+        $ref: "#/definitions/base_requester"
         request_parameters:
-          $ref: "*ref(definitions.common_parameters)"
+          $ref: "#/definitions/common_parameters"
           q: "{{ config['query'] }}"
           in: "{{ ','.join(config['in']) }}"
           sortby: "{{ config['sortby'] }}"
   top_headlines_stream:
     schema_loader:
-      $ref: "*ref(definitions.schema_loader)"
-      schema: "*ref(schemas.top_headlines_stream_schema)"
+      $ref: "#/definitions/schema_loader"
+      schema: "#/schemas/top_headlines_stream_schema"
     $options:
       name: "top_headlines"
       primary_key: "url"
       path: "/top-headlines"
       stream_cursor_field: "publishedAt"
     retriever:
-      $ref: "*ref(definitions.base_retriever)"
+      $ref: "#/definitions/base_retriever"
       requester:
-        $ref: "*ref(definitions.base_requester)"
+        $ref: "#/definitions/base_requester"
         request_parameters:
-          $ref: "*ref(definitions.common_parameters)"
+          $ref: "#/definitions/common_parameters"
           topic: "{{ config['top_headlines_topic'] }}"
           q: "{{ config['top_headlines_query'] }}"
 
 streams:
-  - "*ref(definitions.search_stream)"
-  - "*ref(definitions.top_headlines_stream)"
+  - "#/definitions/search_stream"
+  - "#/definitions/top_headlines_stream"
 
 check:
   stream_names:

--- a/airbyte-integrations/connectors/source-gocardless/source_gocardless/gocardless.yaml
+++ b/airbyte-integrations/connectors/source-gocardless/source_gocardless/gocardless.yaml
@@ -28,7 +28,7 @@ definitions:
     name: "{{ options['name'] }}"
     primary_key: "{{ options['primary_key'] }}"
     record_selector:
-      $ref: "*ref(definitions.selector)"
+      $ref: "#/definitions/selector"
     paginator:
       type: "DefaultPaginator"
       pagination_strategy:
@@ -52,11 +52,11 @@ streams:
       stream_cursor_field: "created_at"
     primary_key: "id"
     schema_loader:
-      $ref: "*ref(definitions.schema_loader)"
+      $ref: "#/definitions/schema_loader"
     retriever:
-      $ref: "*ref(definitions.retriever)"
+      $ref: "#/definitions/retriever"
       requester:
-        $ref: "*ref(definitions.requester)"
+        $ref: "#/definitions/requester"
         path: "/payments"
   - type: DeclarativeStream
     $options:
@@ -64,11 +64,11 @@ streams:
       stream_cursor_field: "created_at"
     primary_key: "id"
     schema_loader:
-      $ref: "*ref(definitions.schema_loader)"
+      $ref: "#/definitions/schema_loader"
     retriever:
-      $ref: "*ref(definitions.retriever)"
+      $ref: "#/definitions/retriever"
       requester:
-        $ref: "*ref(definitions.requester)"
+        $ref: "#/definitions/requester"
         path: "/refunds"
   - type: DeclarativeStream
     $options:
@@ -76,11 +76,11 @@ streams:
       stream_cursor_field: "created_at"
     primary_key: "id"
     schema_loader:
-      $ref: "*ref(definitions.schema_loader)"
+      $ref: "#/definitions/schema_loader"
     retriever:
-      $ref: "*ref(definitions.retriever)"
+      $ref: "#/definitions/retriever"
       requester:
-        $ref: "*ref(definitions.requester)"
+        $ref: "#/definitions/requester"
         path: "/mandates"
   - type: DeclarativeStream
     $options:
@@ -88,11 +88,11 @@ streams:
       stream_cursor_field: "created_at"
     primary_key: "id"
     schema_loader:
-      $ref: "*ref(definitions.schema_loader)"
+      $ref: "#/definitions/schema_loader"
     retriever:
-      $ref: "*ref(definitions.retriever)"
+      $ref: "#/definitions/retriever"
       requester:
-        $ref: "*ref(definitions.requester)"
+        $ref: "#/definitions/requester"
         path: "/payouts"
 check:
   type: CheckStream

--- a/airbyte-integrations/connectors/source-gong/source_gong/gong.yaml
+++ b/airbyte-integrations/connectors/source-gong/source_gong/gong.yaml
@@ -15,7 +15,7 @@ definitions:
       fromDateTime: "{{ config['start_date'] }}"
   retriever:
     record_selector:
-      $ref: "*ref(definitions.selector)"
+      $ref: "#/definitions/selector"
     paginator:
       type: DefaultPaginator
       pagination_strategy:
@@ -30,47 +30,47 @@ definitions:
         field_name: "cursor"
         inject_into: "request_parameter"
       url_base:
-        $ref: "*ref(definitions.requester.url_base)"
+        $ref: "#/definitions/requester/url_base"
     requester:
-      $ref: "*ref(definitions.requester)"
+      $ref: "#/definitions/requester"
 
   # base stream
   base_stream:
     retriever:
-      $ref: "*ref(definitions.retriever)"
+      $ref: "#/definitions/retriever"
 
   # streams
   users_stream:
-    $ref: "*ref(definitions.base_stream)"
+    $ref: "#/definitions/base_stream"
     $options:
       name: "users"
       primary_key: "id"
       path: "/users"
 
   calls_stream:
-    $ref: "*ref(definitions.base_stream)"
+    $ref: "#/definitions/base_stream"
     $options:
       name: "calls"
       primary_key: "id"
       path: "/calls"
 
   scorecards_stream:
-    $ref: "*ref(definitions.base_stream)"
+    $ref: "#/definitions/base_stream"
     $options:
       name: "scorecards"
       primary_key: "scorecardId"
       path: "/settings/scorecards"
 
   answered_scorecards_stream:
-    $ref: "*ref(definitions.base_stream)"
+    $ref: "#/definitions/base_stream"
     $options:
       name: "answeredScorecards"
       primary_key: "answeredScorecardId"
       path: "/stats/activity/scorecards"
     retriever:
-      $ref: "*ref(definitions.base_stream.retriever)"
+      $ref: "#/definitions/base_stream/retriever"
       paginator:
-        $ref: "*ref(definitions.retriever.paginator)"
+        $ref: "#/definitions/retriever/paginator"
         page_size_option:
           field_name: "limit"
           inject_into: "body_json"
@@ -78,16 +78,16 @@ definitions:
           field_name: "cursor"
           inject_into: "body_json"
       requester:
-        $ref: "*ref(definitions.requester)"
+        $ref: "#/definitions/requester"
         http_method: "POST"
         request_body_json:
           filter: '{"callFromDate": "{{ config["start_date"] }}"}'
 
 streams:
-  - "*ref(definitions.users_stream)"
-  - "*ref(definitions.calls_stream)"
-  - "*ref(definitions.scorecards_stream)"
-  - "*ref(definitions.answered_scorecards_stream)"
+  - "#/definitions/users_stream"
+  - "#/definitions/calls_stream"
+  - "#/definitions/scorecards_stream"
+  - "#/definitions/answered_scorecards_stream"
 
 check:
   stream_names:

--- a/airbyte-integrations/connectors/source-google-pagespeed-insights/source_google_pagespeed_insights/google_pagespeed_insights.yaml
+++ b/airbyte-integrations/connectors/source-google-pagespeed-insights/source_google_pagespeed_insights/google_pagespeed_insights.yaml
@@ -25,32 +25,32 @@ definitions:
       category: "{{ config['categories'] }}"
   retriever:
     record_selector:
-      $ref: "*ref(definitions.selector)"
+      $ref: "#/definitions/selector"
     paginator:
       type: NoPagination
     requester:
-      $ref: "*ref(definitions.requester)"
+      $ref: "#/definitions/requester"
     stream_slicer:
       type: CartesianProductStreamSlicer
       stream_slicers:
-        - "*ref(definitions.url_stream_slicer)"
-        - "*ref(definitions.strategy_stream_slicer)"
+        - "#/definitions/url_stream_slicer"
+        - "#/definitions/strategy_stream_slicer"
   base_stream:
     retriever:
-      $ref: "*ref(definitions.retriever)"
+      $ref: "#/definitions/retriever"
   pagespeed_stream:
     transformations:
       - type: AddFields
         fields:
           - path: ["strategy"]
             value: "{{ stream_slice.strategy }}"
-    $ref: "*ref(definitions.base_stream)"
+    $ref: "#/definitions/base_stream"
     $options:
       name: "pagespeed"
       path: "/runPagespeed"
 
 streams:
-  - "*ref(definitions.pagespeed_stream)"
+  - "#/definitions/pagespeed_stream"
 
 check:
   stream_names:

--- a/airbyte-integrations/connectors/source-google-webfonts/source_google_webfonts/google_webfonts.yaml
+++ b/airbyte-integrations/connectors/source-google-webfonts/source_google_webfonts/google_webfonts.yaml
@@ -14,24 +14,24 @@ definitions:
 
   retriever:
     record_selector:
-      $ref: "*ref(definitions.selector)"
+      $ref: "#/definitions/selector"
     paginator:
       type: NoPagination
     requester:
-      $ref: "*ref(definitions.requester)"
+      $ref: "#/definitions/requester"
 
   base_stream:
     retriever:
-      $ref: "*ref(definitions.retriever)"
+      $ref: "#/definitions/retriever"
 
   fonts_stream:
-    $ref: "*ref(definitions.base_stream)"
+    $ref: "#/definitions/base_stream"
     $options:
       name: "fonts"
       path: "/webfonts?key={{ config['api_key'] }}&sort={{ config['sort'] or 'SORT_UNDEFINED'}}&prettyPrint={{ config['prettyPrint'] or 'true'}}&alt={{ config['alt'] or 'json'}}"
 
 streams:
-  - "*ref(definitions.fonts_stream)"
+  - "#/definitions/fonts_stream"
 
 check:
   stream_names:

--- a/airbyte-integrations/connectors/source-greenhouse/source_greenhouse/greenhouse.yaml
+++ b/airbyte-integrations/connectors/source-greenhouse/source_greenhouse/greenhouse.yaml
@@ -31,7 +31,7 @@ definitions:
     name: "{{ options['name'] }}"
     primary_key: "{{ options['primary_key'] }}"
     record_selector:
-      $ref: "*ref(definitions.selector)"
+      $ref: "#/definitions/selector"
     paginator:
       type: DefaultPaginator
       pagination_strategy:
@@ -44,64 +44,64 @@ definitions:
         inject_into: "request_parameter"
       page_token_option:
         inject_into: "path"
-      url_base: "*ref(definitions.requester.url_base)"
+      url_base: "#/definitions/requester/url_base"
   base_stream:
     type: DeclarativeStream
     $options:
       name: "applications"
     primary_key: "id"
     schema_loader:
-      $ref: "*ref(definitions.schema_loader)"
+      $ref: "#/definitions/schema_loader"
     retriever:
-      $ref: "*ref(definitions.retriever)"
+      $ref: "#/definitions/retriever"
       requester:
-        $ref: "*ref(definitions.requester)"
+        $ref: "#/definitions/requester"
   base_incremental_stream:
-    $ref: "*ref(definitions.base_stream)"
+    $ref: "#/definitions/base_stream"
     stream_cursor_field: "updated_at"
     retriever:
-      $ref: "*ref(definitions.retriever)"
-      requester: "*ref(definitions.requester)"
+      $ref: "#/definitions/retriever"
+      requester: "#/definitions/requester"
       stream_slicer:
         request_cursor_field: "updated_after"
         cursor_field: "updated_at"
         class_name: source_greenhouse.components.GreenHouseSlicer
   applications_stream:
-    $ref: "*ref(definitions.base_incremental_stream)"
+    $ref: "#/definitions/base_incremental_stream"
     $options:
       name: "applications"
       path: "applications"
     stream_cursor_field: "applied_at"
     retriever:
-      $ref: "*ref(definitions.retriever)"
-      requester: "*ref(definitions.requester)"
+      $ref: "#/definitions/retriever"
+      requester: "#/definitions/requester"
       stream_slicer:
         request_cursor_field: "created_after"
         cursor_field: "applied_at"
         class_name: source_greenhouse.components.GreenHouseSlicer
   candidates_stream:
-    $ref: "*ref(definitions.base_incremental_stream)"
+    $ref: "#/definitions/base_incremental_stream"
     $options:
       name: "candidates"
       path: "candidates"
   close_reasons_stream:
-    $ref: "*ref(definitions.base_stream)"
+    $ref: "#/definitions/base_stream"
     $options:
       name: "close_reasons"
       path: "close_reasons"
     primary_key: "id"
   degrees_stream:
-    $ref: "*ref(definitions.base_stream)"
+    $ref: "#/definitions/base_stream"
     $options:
       name: "degrees"
       path: "degrees"
   departments_stream:
-    $ref: "*ref(definitions.base_stream)"
+    $ref: "#/definitions/base_stream"
     $options:
       name: "departments"
       path: "departments"
   jobs_stream:
-    $ref: "*ref(definitions.base_incremental_stream)"
+    $ref: "#/definitions/base_incremental_stream"
     $options:
       name: "jobs"
       path: "jobs"
@@ -110,59 +110,59 @@ definitions:
       name: "jobs_openings"
     primary_key: "id"
     schema_loader:
-      $ref: "*ref(definitions.schema_loader)"
+      $ref: "#/definitions/schema_loader"
     retriever:
-      $ref: "*ref(definitions.retriever)"
+      $ref: "#/definitions/retriever"
       requester:
-        $ref: "*ref(definitions.requester)"
+        $ref: "#/definitions/requester"
         path: "jobs/{{ stream_slice.parent_id }}/openings"
       stream_slicer:
         type: SubstreamSlicer
         parent_stream_configs:
-          - stream: "*ref(definitions.jobs_stream)"
+          - stream: "#/definitions/jobs_stream"
             parent_key: "id"
             stream_slice_field: "parent_id"
   applications_demographics_answers_stream:
-    $ref: "*ref(definitions.base_stream)"
+    $ref: "#/definitions/base_stream"
     $options:
       name: "applications_demographics_answers"
     stream_cursor_field: "updated_at"
     retriever:
-      $ref: "*ref(definitions.retriever)"
+      $ref: "#/definitions/retriever"
       requester:
-        $ref: "*ref(definitions.requester)"
+        $ref: "#/definitions/requester"
         path: "applications/{{ stream_slice.parent_id }}/demographics/answers"
       stream_slicer:
         class_name: source_greenhouse.components.GreenHouseSubstreamSlicer
-        parent_stream: "*ref(definitions.applications_stream)"
+        parent_stream: "#/definitions/applications_stream"
         request_cursor_field: "updated_after"
         stream_slice_field: "parent_id"
         cursor_field: "updated_at"
         parent_key: "id"
   applications_interviews_stream:
-    $ref: "*ref(definitions.base_stream)"
+    $ref: "#/definitions/base_stream"
     $options:
       name: "applications_interviews"
     stream_cursor_field: "updated_at"
     retriever:
-      $ref: "*ref(definitions.retriever)"
+      $ref: "#/definitions/retriever"
       requester:
-        $ref: "*ref(definitions.requester)"
+        $ref: "#/definitions/requester"
         path: "applications/{{ stream_slice.parent_id }}/scheduled_interviews"
       stream_slicer:
         class_name: source_greenhouse.components.GreenHouseSubstreamSlicer
-        parent_stream: "*ref(definitions.applications_stream)"
+        parent_stream: "#/definitions/applications_stream"
         request_cursor_field: "updated_after"
         stream_slice_field: "parent_id"
         cursor_field: "updated_at"
         parent_key: "id"
   custom_fields_stream:
-    $ref: "*ref(definitions.base_stream)"
+    $ref: "#/definitions/base_stream"
     $options:
       name: "custom_fields"
       path: "custom_fields"
   questions_stream:
-    $ref: "*ref(definitions.base_stream)"
+    $ref: "#/definitions/base_stream"
     $options:
       name: "demographics_questions"
       path: "demographics/questions"
@@ -171,20 +171,20 @@ definitions:
       name: "demographics_answers_answer_options"
       primary_key: "id"
       schema_loader:
-        $ref: "*ref(definitions.schema_loader)"
+        $ref: "#/definitions/schema_loader"
       retriever:
-        $ref: "*ref(definitions.retriever)"
+        $ref: "#/definitions/retriever"
         requester:
-          $ref: "*ref(definitions.requester)"
+          $ref: "#/definitions/requester"
           path: "demographics/questions/{{ stream_slice.parent_id }}/answer_options"
         stream_slicer:
           type: SubstreamSlicer
           parent_stream_configs:
-            - stream: "*ref(definitions.questions_stream)"
+            - stream: "#/definitions/questions_stream"
               parent_key: "id"
               stream_slice_field: "parent_id"
   demographics_question_sets_stream:
-    $ref: "*ref(definitions.base_stream)"
+    $ref: "#/definitions/base_stream"
     $options:
       name: "demographics_question_sets"
       path: "demographics/question_sets"
@@ -193,112 +193,112 @@ definitions:
       name: "demographics_question_sets_questions"
       primary_key: "id"
       schema_loader:
-        $ref: "*ref(definitions.schema_loader)"
+        $ref: "#/definitions/schema_loader"
       retriever:
-        $ref: "*ref(definitions.retriever)"
+        $ref: "#/definitions/retriever"
         requester:
-          $ref: "*ref(definitions.requester)"
+          $ref: "#/definitions/requester"
           path: "demographics/question_sets/{{ stream_slice.parent_id }}/questions"
         stream_slicer:
           type: SubstreamSlicer
           parent_stream_configs:
-            - stream: "*ref(definitions.demographics_question_sets_stream)"
+            - stream: "#/definitions/demographics_question_sets_stream"
               parent_key: "id"
               stream_slice_field: "parent_id"
   interviews_stream:
-    $ref: "*ref(definitions.base_incremental_stream)"
+    $ref: "#/definitions/base_incremental_stream"
     $options:
       name: "interviews"
       path: "scheduled_interviews"
   job_posts_stream:
-    $ref: "*ref(definitions.base_incremental_stream)"
+    $ref: "#/definitions/base_incremental_stream"
     $options:
       name: "job_posts"
       path: "job_posts"
   job_stages_stream:
-    $ref: "*ref(definitions.base_incremental_stream)"
+    $ref: "#/definitions/base_incremental_stream"
     $options:
       name: "job_stages"
       path: "job_stages"
   jobs_stages_stream:
-    $ref: "*ref(definitions.base_stream)"
+    $ref: "#/definitions/base_stream"
     $options:
       name: "jobs_stages"
       path: "jobs/{{ stream_slice.parent_id }}/stages"
       stream_cursor_field: "updated_at"
     retriever:
-      $ref: "*ref(definitions.retriever)"
+      $ref: "#/definitions/retriever"
       requester:
-        $ref: "*ref(definitions.requester)"
+        $ref: "#/definitions/requester"
         path: "jobs/{{ stream_slice.parent_id }}/stages"
       stream_slicer:
         class_name: source_greenhouse.components.GreenHouseSubstreamSlicer
-        parent_stream: "*ref(definitions.jobs_stream)"
+        parent_stream: "#/definitions/jobs_stream"
         request_cursor_field: "updated_after"
         stream_slice_field: "parent_id"
         cursor_field: "updated_at"
         parent_key: "id"
   offers_stream:
-    $ref: "*ref(definitions.base_incremental_stream)"
+    $ref: "#/definitions/base_incremental_stream"
     $options:
       name: "offers"
       path: "offers"
   rejection_reasons_stream:
-    $ref: "*ref(definitions.base_stream)"
+    $ref: "#/definitions/base_stream"
     $options:
       name: "rejection_reasons"
       path: "rejection_reasons"
   scorecards_stream:
-    $ref: "*ref(definitions.base_incremental_stream)"
+    $ref: "#/definitions/base_incremental_stream"
     $options:
       name: "scorecards"
       path: "scorecards"
   sources_stream:
-    $ref: "*ref(definitions.base_stream)"
+    $ref: "#/definitions/base_stream"
     $options:
       name: "sources"
       path: "sources"
   users_stream:
-    $ref: "*ref(definitions.base_incremental_stream)"
+    $ref: "#/definitions/base_incremental_stream"
     $options:
       name: "users"
       path: "users"
   demographics_answers_stream:
-    $ref: "*ref(definitions.base_incremental_stream)"
+    $ref: "#/definitions/base_incremental_stream"
     $options:
       name: "demographics_answers"
       path: "demographics/answers"
   demographics_answer_options_stream:
-    $ref: "*ref(definitions.base_stream)"
+    $ref: "#/definitions/base_stream"
     $options:
       name: "demographics_answer_options"
       path: "demographics/answer_options"
 streams:
-  - "*ref(definitions.applications_stream)"
-  - "*ref(definitions.applications_demographics_answers_stream)"
-  - "*ref(definitions.applications_interviews_stream)"
-  - "*ref(definitions.candidates_stream)"
-  - "*ref(definitions.close_reasons_stream)"
-  - "*ref(definitions.custom_fields_stream)"
-  - "*ref(definitions.degrees_stream)"
-  - "*ref(definitions.demographics_answers_stream)"
-  - "*ref(definitions.demographics_answer_options_stream)"
-  - "*ref(definitions.questions_stream)"
-  - "*ref(definitions.demographics_answers_answer_options_stream)"
-  - "*ref(definitions.demographics_question_sets_stream)"
-  - "*ref(definitions.demographics_question_sets_questions_stream)"
-  - "*ref(definitions.departments_stream)"
-  - "*ref(definitions.jobs_stream)"
-  - "*ref(definitions.jobs_openings_stream)"
-  - "*ref(definitions.interviews_stream)"
-  - "*ref(definitions.job_posts_stream)"
-  - "*ref(definitions.job_stages_stream)"
-  - "*ref(definitions.jobs_stages_stream)"
-  - "*ref(definitions.offers_stream)"
-  - "*ref(definitions.rejection_reasons_stream)"
-  - "*ref(definitions.scorecards_stream)"
-  - "*ref(definitions.sources_stream)"
-  - "*ref(definitions.users_stream)"
+  - "#/definitions/applications_stream"
+  - "#/definitions/applications_demographics_answers_stream"
+  - "#/definitions/applications_interviews_stream"
+  - "#/definitions/candidates_stream"
+  - "#/definitions/close_reasons_stream"
+  - "#/definitions/custom_fields_stream"
+  - "#/definitions/degrees_stream"
+  - "#/definitions/demographics_answers_stream"
+  - "#/definitions/demographics_answer_options_stream"
+  - "#/definitions/questions_stream"
+  - "#/definitions/demographics_answers_answer_options_stream"
+  - "#/definitions/demographics_question_sets_stream"
+  - "#/definitions/demographics_question_sets_questions_stream"
+  - "#/definitions/departments_stream"
+  - "#/definitions/jobs_stream"
+  - "#/definitions/jobs_openings_stream"
+  - "#/definitions/interviews_stream"
+  - "#/definitions/job_posts_stream"
+  - "#/definitions/job_stages_stream"
+  - "#/definitions/jobs_stages_stream"
+  - "#/definitions/offers_stream"
+  - "#/definitions/rejection_reasons_stream"
+  - "#/definitions/scorecards_stream"
+  - "#/definitions/sources_stream"
+  - "#/definitions/users_stream"
 
 check:
   type: CheckStream

--- a/airbyte-integrations/connectors/source-gutendex/source_gutendex/gutendex.yaml
+++ b/airbyte-integrations/connectors/source-gutendex/source_gutendex/gutendex.yaml
@@ -18,10 +18,10 @@ definitions:
       topic: "{{ config['topic'] }}"
   retriever:
     record_selector:
-      $ref: "*ref(definitions.selector)"
+      $ref: "#/definitions/selector"
     paginator:
       type: "DefaultPaginator"
-      url_base: "*ref(definitions.requester.url_base)"
+      url_base: "#/definitions/requester/url_base"
       pagination_strategy:
         type: "PageIncrement"
         page_size: 32
@@ -32,18 +32,18 @@ definitions:
         inject_into: "body_data"
         field_name: "page_size"
     requester:
-      $ref: "*ref(definitions.requester)"
+      $ref: "#/definitions/requester"
   base_stream:
     retriever:
-      $ref: "*ref(definitions.retriever)"
+      $ref: "#/definitions/retriever"
   books_stream:
-    $ref: "*ref(definitions.base_stream)"
+    $ref: "#/definitions/base_stream"
     $options:
       name: "books"
       path: "/books"
 
 streams:
-  - "*ref(definitions.books_stream)"
+  - "#/definitions/books_stream"
 
 check:
   stream_names:

--- a/airbyte-integrations/connectors/source-intruder/source_intruder/intruder.yaml
+++ b/airbyte-integrations/connectors/source-intruder/source_intruder/intruder.yaml
@@ -13,7 +13,7 @@ definitions:
   offset_paginator:
     type: DefaultPaginator
     $options:
-      url_base: "*ref(definitions.requester.url_base)"
+      url_base: "#/definitions/requester/url_base"
     pagination_strategy:
       type: "OffsetIncrement"
       page_size: 100
@@ -25,16 +25,16 @@ definitions:
       field_name: "limit"
   retriever:
     record_selector:
-      $ref: "*ref(definitions.selector)"
+      $ref: "#/definitions/selector"
     paginator:
-      $ref: "*ref(definitions.offset_paginator)"
+      $ref: "#/definitions/offset_paginator"
     requester:
-      $ref: "*ref(definitions.requester)"
+      $ref: "#/definitions/requester"
   base_stream:
     retriever:
-      $ref: "*ref(definitions.retriever)"
+      $ref: "#/definitions/retriever"
   issues_stream:
-    $ref: "*ref(definitions.base_stream)"
+    $ref: "#/definitions/base_stream"
     $options:
       name: "issues"
       primary_key: "id"
@@ -42,41 +42,41 @@ definitions:
   issue_stream_slicer:
     type: SubstreamSlicer
     parent_stream_configs:
-      - stream: "*ref(definitions.issues_stream)"
+      - stream: "#/definitions/issues_stream"
         parent_key: id
         stream_slice_field: id
   occurrences_issue_stream:
-    $ref: "*ref(definitions.base_stream)"
+    $ref: "#/definitions/base_stream"
     $options:
       name: "occurrences_issues"
       primary_key: "id"
     retriever:
-      $ref: "*ref(definitions.retriever)"
+      $ref: "#/definitions/retriever"
       record_selector:
-        $ref: "*ref(definitions.selector)"
+        $ref: "#/definitions/selector"
       requester:
-        $ref: "*ref(definitions.requester)"
+        $ref: "#/definitions/requester"
         path: "/issues/{{ stream_slice.id }}/occurrences"
       stream_slicer:
-        $ref: "*ref(definitions.issue_stream_slicer)"
+        $ref: "#/definitions/issue_stream_slicer"
   scans_stream:
-    $ref: "*ref(definitions.base_stream)"
+    $ref: "#/definitions/base_stream"
     $options:
       name: "scans"
       primary_key: "id"
       path: "/scans"
   targets_stream:
-    $ref: "*ref(definitions.base_stream)"
+    $ref: "#/definitions/base_stream"
     $options:
       name: "targets"
       primary_key: "id"
       path: "/targets"
 
 streams:
-  - "*ref(definitions.issues_stream)"
-  - "*ref(definitions.occurrences_issue_stream)"
-  - "*ref(definitions.scans_stream)"
-  - "*ref(definitions.targets_stream)"
+  - "#/definitions/issues_stream"
+  - "#/definitions/occurrences_issue_stream"
+  - "#/definitions/scans_stream"
+  - "#/definitions/targets_stream"
 
 check:
   stream_names:

--- a/airbyte-integrations/connectors/source-ip2whois/source_ip2whois/ip2whois.yaml
+++ b/airbyte-integrations/connectors/source-ip2whois/source_ip2whois/ip2whois.yaml
@@ -12,23 +12,23 @@ definitions:
       domain: "{{ config['domain'] }}"
   retriever:
     record_selector:
-      $ref: "*ref(definitions.selector)"
+      $ref: "#/definitions/selector"
     paginator:
       type: NoPagination
     requester:
-      $ref: "*ref(definitions.requester)"
+      $ref: "#/definitions/requester"
   base_stream:
     retriever:
-      $ref: "*ref(definitions.retriever)"
+      $ref: "#/definitions/retriever"
   whois_stream:
-    $ref: "*ref(definitions.base_stream)"
+    $ref: "#/definitions/base_stream"
     $options:
       name: "whois"
       primary_key: "domain_id"
       path: "/v2"
 
 streams:
-  - "*ref(definitions.whois_stream)"
+  - "#/definitions/whois_stream"
 check:
   stream_names:
     - "whois"

--- a/airbyte-integrations/connectors/source-k6-cloud/source_k6_cloud/k6_cloud.yaml
+++ b/airbyte-integrations/connectors/source-k6-cloud/source_k6_cloud/k6_cloud.yaml
@@ -14,7 +14,7 @@ definitions:
 
   increment_paginator:
     type: "DefaultPaginator"
-    url_base: "*ref(definitions.requester.url_base)"
+    url_base: "#/definitions/requester/url_base"
     pagination_strategy:
       type: "PageIncrement"
       page_size: 32
@@ -26,23 +26,23 @@ definitions:
       field_name: "page_size"
   retriever:
     record_selector:
-      $ref: "*ref(definitions.selector)"
+      $ref: "#/definitions/selector"
     paginator:
-      $ref: "*ref(definitions.increment_paginator)"
+      $ref: "#/definitions/increment_paginator"
     requester:
-      $ref: "*ref(definitions.requester)"
+      $ref: "#/definitions/requester"
   base_stream:
     retriever:
-      $ref: "*ref(definitions.retriever)"
+      $ref: "#/definitions/retriever"
   organizations_stream:
-    $ref: "*ref(definitions.base_stream)"
+    $ref: "#/definitions/base_stream"
     retriever:
       record_selector:
-        $ref: "*ref(definitions.selector)"
+        $ref: "#/definitions/selector"
       paginator:
         type: NoPagination
       requester:
-        $ref: "*ref(definitions.requester)"
+        $ref: "#/definitions/requester"
     $options:
       name: "organizations"
       primary_key: "id"
@@ -50,41 +50,41 @@ definitions:
   organizations_stream_slicer:
     type: SubstreamSlicer
     parent_stream_configs:
-      - stream: "*ref(definitions.organizations_stream)"
+      - stream: "#/definitions/organizations_stream"
         parent_key: id
         stream_slice_field: id
   projects_stream:
-    $ref: "*ref(definitions.base_stream)"
+    $ref: "#/definitions/base_stream"
     type: DeclarativeStream
     $options:
       name: "projects"
     retriever:
-      $ref: "*ref(definitions.retriever)"
+      $ref: "#/definitions/retriever"
       requester:
-        $ref: "*ref(definitions.requester)"
+        $ref: "#/definitions/requester"
         path: "/v3/organizations/{{ stream_slice.id }}/projects"
       stream_slicer:
-        $ref: "*ref(definitions.organizations_stream_slicer)"
+        $ref: "#/definitions/organizations_stream_slicer"
       record_selector:
-        $ref: "*ref(definitions.selector)"
+        $ref: "#/definitions/selector"
   tests_stream:
-    $ref: "*ref(definitions.base_stream)"
+    $ref: "#/definitions/base_stream"
     retriever:
       record_selector:
-        $ref: "*ref(definitions.selector)"
+        $ref: "#/definitions/selector"
       paginator:
-        $ref: "*ref(definitions.increment_paginator)"
+        $ref: "#/definitions/increment_paginator"
       requester:
-        $ref: "*ref(definitions.requester)"
+        $ref: "#/definitions/requester"
     $options:
       name: "k6-tests"
       primary_key: "id"
       path: "loadtests/v2/tests"
 
 streams:
-  - "*ref(definitions.organizations_stream)"
-  - "*ref(definitions.projects_stream)"
-  - "*ref(definitions.tests_stream)"
+  - "#/definitions/organizations_stream"
+  - "#/definitions/projects_stream"
+  - "#/definitions/tests_stream"
 
 check:
   stream_names:

--- a/airbyte-integrations/connectors/source-launchdarkly/source_launchdarkly/launchdarkly.yaml
+++ b/airbyte-integrations/connectors/source-launchdarkly/source_launchdarkly/launchdarkly.yaml
@@ -14,7 +14,7 @@ definitions:
   offset_paginator:
     type: DefaultPaginator
     $options:
-      url_base: "*ref(definitions.requester.url_base)"
+      url_base: "#/definitions/requester/url_base"
     pagination_strategy:
       type: "OffsetIncrement"
       page_size: 20
@@ -26,16 +26,16 @@ definitions:
       field_name: "limit"
   retriever:
     record_selector:
-      $ref: "*ref(definitions.selector)"
+      $ref: "#/definitions/selector"
     paginator:
-      $ref: "*ref(definitions.offset_paginator)"
+      $ref: "#/definitions/offset_paginator"
     requester:
-      $ref: "*ref(definitions.requester)"
+      $ref: "#/definitions/requester"
   base_stream:
     retriever:
-      $ref: "*ref(definitions.retriever)"
+      $ref: "#/definitions/retriever"
   projects_stream:
-    $ref: "*ref(definitions.base_stream)"
+    $ref: "#/definitions/base_stream"
     $options:
       name: "projects"
       primary_key: "_id"
@@ -43,71 +43,71 @@ definitions:
   project_stream_slicer:
     type: SubstreamSlicer
     parent_stream_configs:
-      - stream: "*ref(definitions.projects_stream)"
+      - stream: "#/definitions/projects_stream"
         parent_key: key
         stream_slice_field: project_key
   environments_stream:
-    $ref: "*ref(definitions.base_stream)"
+    $ref: "#/definitions/base_stream"
     $options:
       name: "environments"
       primary_key: "_id"
     retriever:
-      $ref: "*ref(definitions.retriever)"
+      $ref: "#/definitions/retriever"
       record_selector:
-        $ref: "*ref(definitions.selector)"
+        $ref: "#/definitions/selector"
       requester:
-        $ref: "*ref(definitions.requester)"
+        $ref: "#/definitions/requester"
         path: "/projects/{{ stream_slice.project_key }}/environments"
       stream_slicer:
-        $ref: "*ref(definitions.project_stream_slicer)"
+        $ref: "#/definitions/project_stream_slicer"
   metrics_stream:
-    $ref: "*ref(definitions.base_stream)"
+    $ref: "#/definitions/base_stream"
     $options:
       name: "metrics"
       primary_key: "_id"
     retriever:
-      $ref: "*ref(definitions.retriever)"
+      $ref: "#/definitions/retriever"
       record_selector:
-        $ref: "*ref(definitions.selector)"
+        $ref: "#/definitions/selector"
       requester:
-        $ref: "*ref(definitions.requester)"
+        $ref: "#/definitions/requester"
         path: "/metrics/{{ stream_slice.project_key }}"
       stream_slicer:
-        $ref: "*ref(definitions.project_stream_slicer)"
+        $ref: "#/definitions/project_stream_slicer"
   members_stream:
-    $ref: "*ref(definitions.base_stream)"
+    $ref: "#/definitions/base_stream"
     $options:
       name: "members"
       primary_key: "_id"
       path: "/members"
   audit_log_stream:
-    $ref: "*ref(definitions.base_stream)"
+    $ref: "#/definitions/base_stream"
     $options:
       name: "auditlog"
       primary_key: "_id"
       path: "/auditlog"
   flags_stream:
-    $ref: "*ref(definitions.base_stream)"
+    $ref: "#/definitions/base_stream"
     $options:
       name: "flags"
       primary_key: "key"
     retriever:
-      $ref: "*ref(definitions.retriever)"
+      $ref: "#/definitions/retriever"
       record_selector:
-        $ref: "*ref(definitions.selector)"
+        $ref: "#/definitions/selector"
       requester:
-        $ref: "*ref(definitions.requester)"
+        $ref: "#/definitions/requester"
         path: "/flags/{{ stream_slice.project_key }}"
       stream_slicer:
-        $ref: "*ref(definitions.project_stream_slicer)"
+        $ref: "#/definitions/project_stream_slicer"
 
 streams:
-  - "*ref(definitions.projects_stream)"
-  - "*ref(definitions.environments_stream)"
-  - "*ref(definitions.metrics_stream)"
-  - "*ref(definitions.members_stream)"
-  - "*ref(definitions.audit_log_stream)"
-  - "*ref(definitions.flags_stream)"
+  - "#/definitions/projects_stream"
+  - "#/definitions/environments_stream"
+  - "#/definitions/metrics_stream"
+  - "#/definitions/members_stream"
+  - "#/definitions/audit_log_stream"
+  - "#/definitions/flags_stream"
 
 check:
   stream_names:

--- a/airbyte-integrations/connectors/source-lokalise/source_lokalise/lokalise.yaml
+++ b/airbyte-integrations/connectors/source-lokalise/source_lokalise/lokalise.yaml
@@ -16,7 +16,7 @@ definitions:
 
   increment_paginator:
     type: "DefaultPaginator"
-    url_base: "*ref(definitions.requester.url_base)"
+    url_base: "#/definitions/requester/url_base"
     pagination_strategy:
       type: "PageIncrement"
       page_size: 1000
@@ -29,26 +29,26 @@ definitions:
 
   retriever:
     record_selector:
-      $ref: "*ref(definitions.selector)"
+      $ref: "#/definitions/selector"
     paginator:
-      $ref: "*ref(definitions.increment_paginator)"
+      $ref: "#/definitions/increment_paginator"
     requester:
-      $ref: "*ref(definitions.requester)"
+      $ref: "#/definitions/requester"
 
   base_stream:
     retriever:
-      $ref: "*ref(definitions.retriever)"
+      $ref: "#/definitions/retriever"
 
   keys_stream:
     # https://developers.lokalise.com/reference/list-all-keys
-    $ref: "*ref(definitions.base_stream)"
+    $ref: "#/definitions/base_stream"
     retriever:
       record_selector:
-        $ref: "*ref(definitions.selector)"
+        $ref: "#/definitions/selector"
       paginator:
-        $ref: "*ref(definitions.increment_paginator)"
+        $ref: "#/definitions/increment_paginator"
       requester:
-        $ref: "*ref(definitions.requester)"
+        $ref: "#/definitions/requester"
     $options:
       name: "keys"
       primary_key: "key_id"
@@ -56,14 +56,14 @@ definitions:
 
   languages_stream:
     # https://developers.lokalise.com/reference/list-all-keys
-    $ref: "*ref(definitions.base_stream)"
+    $ref: "#/definitions/base_stream"
     retriever:
       record_selector:
-        $ref: "*ref(definitions.selector)"
+        $ref: "#/definitions/selector"
       paginator:
-        $ref: "*ref(definitions.increment_paginator)"
+        $ref: "#/definitions/increment_paginator"
       requester:
-        $ref: "*ref(definitions.requester)"
+        $ref: "#/definitions/requester"
     $options:
       name: "languages"
       primary_key: "lang_id"
@@ -71,14 +71,14 @@ definitions:
 
   comments_stream:
     # https://developers.lokalise.com/reference/list-project-comments
-    $ref: "*ref(definitions.base_stream)"
+    $ref: "#/definitions/base_stream"
     retriever:
       record_selector:
-        $ref: "*ref(definitions.selector)"
+        $ref: "#/definitions/selector"
       paginator:
-        $ref: "*ref(definitions.increment_paginator)"
+        $ref: "#/definitions/increment_paginator"
       requester:
-        $ref: "*ref(definitions.requester)"
+        $ref: "#/definitions/requester"
     $options:
       name: "comments"
       primary_key: "comment_id"
@@ -86,14 +86,14 @@ definitions:
 
   contributors_stream:
     # https://developers.lokalise.com/reference/list-all-contributors
-    $ref: "*ref(definitions.base_stream)"
+    $ref: "#/definitions/base_stream"
     retriever:
       record_selector:
-        $ref: "*ref(definitions.selector)"
+        $ref: "#/definitions/selector"
       paginator:
-        $ref: "*ref(definitions.increment_paginator)"
+        $ref: "#/definitions/increment_paginator"
       requester:
-        $ref: "*ref(definitions.requester)"
+        $ref: "#/definitions/requester"
     $options:
       name: "contributors"
       primary_key: "user_id"
@@ -101,25 +101,25 @@ definitions:
 
   translations_stream:
     # https://developers.lokalise.com/reference/list-all-translations
-    $ref: "*ref(definitions.base_stream)"
+    $ref: "#/definitions/base_stream"
     retriever:
       record_selector:
-        $ref: "*ref(definitions.selector)"
+        $ref: "#/definitions/selector"
       paginator:
-        $ref: "*ref(definitions.increment_paginator)"
+        $ref: "#/definitions/increment_paginator"
       requester:
-        $ref: "*ref(definitions.requester)"
+        $ref: "#/definitions/requester"
     $options:
       name: "translations"
       primary_key: "translation_id"
       path: "/api2/projects/{{ config['project_id'] }}/translations"
 
 streams:
-  - "*ref(definitions.keys_stream)"
-  - "*ref(definitions.languages_stream)"
-  - "*ref(definitions.comments_stream)"
-  - "*ref(definitions.contributors_stream)"
-  - "*ref(definitions.translations_stream)"
+  - "#/definitions/keys_stream"
+  - "#/definitions/languages_stream"
+  - "#/definitions/comments_stream"
+  - "#/definitions/contributors_stream"
+  - "#/definitions/translations_stream"
 
 check:
   stream_names:

--- a/airbyte-integrations/connectors/source-mailerlite/source_mailerlite/mailerlite.yaml
+++ b/airbyte-integrations/connectors/source-mailerlite/source_mailerlite/mailerlite.yaml
@@ -14,7 +14,7 @@ definitions:
 
   increment_paginator:
     type: "DefaultPaginator"
-    url_base: "*ref(definitions.requester.url_base)"
+    url_base: "#/definitions/requester/url_base"
     page_size_option:
       inject_into: "request_parameter"
       field_name: "limit"
@@ -27,74 +27,74 @@ definitions:
 
   retriever:
     record_selector:
-      $ref: "*ref(definitions.selector)"
+      $ref: "#/definitions/selector"
     paginator:
       type: NoPagination
     requester:
-      $ref: "*ref(definitions.requester)"
+      $ref: "#/definitions/requester"
 
   base_stream:
     retriever:
-      $ref: "*ref(definitions.retriever)"
+      $ref: "#/definitions/retriever"
 
   # STREAMS
   # API Docs: https://developers.mailerlite.com/docs/subscribers.html
   subscribers_stream:
-    $ref: "*ref(definitions.base_stream)"
+    $ref: "#/definitions/base_stream"
     $options:
       name: "subscribers"
       primary_key: "id"
       path: "/subscribers"
     retriever:
-      $ref: "*ref(definitions.retriever)"
+      $ref: "#/definitions/retriever"
       paginator:
-        $ref: "*ref(definitions.increment_paginator)"
+        $ref: "#/definitions/increment_paginator"
 
   # API Docs: https://developers.mailerlite.com/docs/segments.html
   segments_stream:
-    $ref: "*ref(definitions.base_stream)"
+    $ref: "#/definitions/base_stream"
     $options:
       name: "segments"
       primary_key: "id"
       path: "/segments"
     retriever:
-      $ref: "*ref(definitions.retriever)"
+      $ref: "#/definitions/retriever"
       paginator:
-        $ref: "*ref(definitions.increment_paginator)"
+        $ref: "#/definitions/increment_paginator"
         pagination_strategy:
           type: "PageIncrement"
           page_size: 50
 
   # API Docs: https://developers.mailerlite.com/docs/automations.html
   automations_stream:
-    $ref: "*ref(definitions.base_stream)"
+    $ref: "#/definitions/base_stream"
     $options:
       name: "automations"
       primary_key: "id"
       path: "/automations"
     retriever:
-      $ref: "*ref(definitions.retriever)"
+      $ref: "#/definitions/retriever"
       paginator:
-        $ref: "*ref(definitions.increment_paginator)"
+        $ref: "#/definitions/increment_paginator"
         pagination_strategy:
           type: "PageIncrement"
           page_size: 10
 
   # API Docs: https://developers.mailerlite.com/docs/campaigns.html
   campaigns_stream:
-    $ref: "*ref(definitions.base_stream)"
+    $ref: "#/definitions/base_stream"
     $options:
       name: "campaigns"
       primary_key: "id"
       path: "/campaigns"
     retriever:
-      $ref: "*ref(definitions.retriever)"
+      $ref: "#/definitions/retriever"
       paginator:
-        $ref: "*ref(definitions.increment_paginator)"
+        $ref: "#/definitions/increment_paginator"
 
   # API Docs: https://developers.mailerlite.com/docs/timezones.html
   timezones_stream:
-    $ref: "*ref(definitions.base_stream)"
+    $ref: "#/definitions/base_stream"
     $options:
       name: "timezones"
       primary_key: "id"
@@ -102,49 +102,49 @@ definitions:
 
   # API Docs: https://developers.mailerlite.com/docs/forms.html
   forms_popup_stream:
-    $ref: "*ref(definitions.base_stream)"
+    $ref: "#/definitions/base_stream"
     $options:
       name: "forms_popup"
       primary_key: "id"
       path: "/forms/popup"
     retriever:
-      $ref: "*ref(definitions.retriever)"
+      $ref: "#/definitions/retriever"
       paginator:
-        $ref: "*ref(definitions.increment_paginator)"
+        $ref: "#/definitions/increment_paginator"
 
   # API Docs: https://developers.mailerlite.com/docs/forms.html
   forms_embedded_stream:
-    $ref: "*ref(definitions.base_stream)"
+    $ref: "#/definitions/base_stream"
     $options:
       name: "forms_embedded"
       primary_key: "id"
       path: "/forms/embedded"
     retriever:
-      $ref: "*ref(definitions.retriever)"
+      $ref: "#/definitions/retriever"
       paginator:
-        $ref: "*ref(definitions.increment_paginator)"
+        $ref: "#/definitions/increment_paginator"
 
   # API Docs: https://developers.mailerlite.com/docs/forms.html
   forms_promotion_stream:
-    $ref: "*ref(definitions.base_stream)"
+    $ref: "#/definitions/base_stream"
     $options:
       name: "forms_promotion"
       primary_key: "id"
       path: "/forms/promotion"
     retriever:
-      $ref: "*ref(definitions.retriever)"
+      $ref: "#/definitions/retriever"
       paginator:
-        $ref: "*ref(definitions.increment_paginator)"
+        $ref: "#/definitions/increment_paginator"
 
 streams:
-  - "*ref(definitions.subscribers_stream)"
-  - "*ref(definitions.segments_stream)"
-  - "*ref(definitions.automations_stream)"
-  - "*ref(definitions.campaigns_stream)"
-  - "*ref(definitions.timezones_stream)"
-  - "*ref(definitions.forms_popup_stream)"
-  - "*ref(definitions.forms_embedded_stream)"
-  - "*ref(definitions.forms_promotion_stream)"
+  - "#/definitions/subscribers_stream"
+  - "#/definitions/segments_stream"
+  - "#/definitions/automations_stream"
+  - "#/definitions/campaigns_stream"
+  - "#/definitions/timezones_stream"
+  - "#/definitions/forms_popup_stream"
+  - "#/definitions/forms_embedded_stream"
+  - "#/definitions/forms_promotion_stream"
 
 check:
   stream_names: ["timezones"]

--- a/airbyte-integrations/connectors/source-mailersend/source_mailersend/mailersend.yaml
+++ b/airbyte-integrations/connectors/source-mailersend/source_mailersend/mailersend.yaml
@@ -38,21 +38,21 @@ definitions:
     page_token_option:
       inject_into: "request_parameter"
       field_name: "page"
-    url_base: "*ref(definitions.requester.url_base)"
+    url_base: "#/definitions/requester/url_base"
   retriever:
     record_selector:
-      $ref: "*ref(definitions.selector)"
+      $ref: "#/definitions/selector"
     paginator:
-      $ref: "*ref(definitions.paginator)"
+      $ref: "#/definitions/paginator"
     requester:
-      $ref: "*ref(definitions.requester)"
+      $ref: "#/definitions/requester"
     stream_slicer:
-      $ref: "*ref(definitions.stream_slicer)"
+      $ref: "#/definitions/stream_slicer"
   base_stream:
     retriever:
-      $ref: "*ref(definitions.retriever)"
+      $ref: "#/definitions/retriever"
   activity_stream:
-    $ref: "*ref(definitions.base_stream)"
+    $ref: "#/definitions/base_stream"
     $options:
       name: "activity"
       primary_key: "id"
@@ -60,7 +60,7 @@ definitions:
       stream_cursor_field: "created_at"
 
 streams:
-  - "*ref(definitions.activity_stream)"
+  - "#/definitions/activity_stream"
 
 check:
   stream_names:

--- a/airbyte-integrations/connectors/source-mailjet-mail/source_mailjet_mail/mailjet_mail.yaml
+++ b/airbyte-integrations/connectors/source-mailjet-mail/source_mailjet_mail/mailjet_mail.yaml
@@ -14,7 +14,7 @@ definitions:
   offset_paginator:
     type: DefaultPaginator
     $options:
-      url_base: "*ref(definitions.requester.url_base)"
+      url_base: "#/definitions/requester/url_base"
     pagination_strategy:
       type: "OffsetIncrement"
       page_size: 100
@@ -26,72 +26,72 @@ definitions:
       field_name: "limit"
   retriever:
     record_selector:
-      $ref: "*ref(definitions.selector)"
+      $ref: "#/definitions/selector"
     paginator:
       type: NoPagination
     requester:
-      $ref: "*ref(definitions.requester)"
+      $ref: "#/definitions/requester"
   base_stream:
     retriever:
-      $ref: "*ref(definitions.retriever)"
+      $ref: "#/definitions/retriever"
   contactslist_stream:
-    $ref: "*ref(definitions.base_stream)"
+    $ref: "#/definitions/base_stream"
     retriever:
       record_selector:
-        $ref: "*ref(definitions.selector)"
+        $ref: "#/definitions/selector"
       paginator:
-        $ref: "*ref(definitions.offset_paginator)"
+        $ref: "#/definitions/offset_paginator"
       requester:
-        $ref: "*ref(definitions.requester)"
+        $ref: "#/definitions/requester"
     $options:
       name: "contactslist"
       primary_key: "ID"
       path: "/contactslist"
   contacts_stream:
-    $ref: "*ref(definitions.base_stream)"
+    $ref: "#/definitions/base_stream"
     retriever:
       record_selector:
-        $ref: "*ref(definitions.selector)"
+        $ref: "#/definitions/selector"
       paginator:
-        $ref: "*ref(definitions.offset_paginator)"
+        $ref: "#/definitions/offset_paginator"
       requester:
-        $ref: "*ref(definitions.requester)"
+        $ref: "#/definitions/requester"
     $options:
       name: "contacts"
       primary_key: "ID"
       path: "/contact"
   stats_api_lifetime_message_stream:
-    $ref: "*ref(definitions.base_stream)"
+    $ref: "#/definitions/base_stream"
     $options:
       name: "stats_api_lifetime_message"
       primary_key: "APIKeyID"
       path: "/statcounters?CounterSource=APIKey&CounterResolution=Lifetime&CounterTiming=Message"
   campaign_stream:
-    $ref: "*ref(definitions.base_stream)"
+    $ref: "#/definitions/base_stream"
     $options:
       name: "campaign"
       primary_key: "ID"
       path: "/campaign"
   message_stream:
-    $ref: "*ref(definitions.base_stream)"
+    $ref: "#/definitions/base_stream"
     retriever:
       record_selector:
-        $ref: "*ref(definitions.selector)"
+        $ref: "#/definitions/selector"
       paginator:
-        $ref: "*ref(definitions.offset_paginator)"
+        $ref: "#/definitions/offset_paginator"
       requester:
-        $ref: "*ref(definitions.requester)"
+        $ref: "#/definitions/requester"
     $options:
       name: "message"
       primary_key: "ID"
       path: "/message"
 
 streams:
-  - "*ref(definitions.contactslist_stream)"
-  - "*ref(definitions.contacts_stream)"
-  - "*ref(definitions.stats_api_lifetime_message_stream)"
-  - "*ref(definitions.campaign_stream)"
-  - "*ref(definitions.message_stream)"
+  - "#/definitions/contactslist_stream"
+  - "#/definitions/contacts_stream"
+  - "#/definitions/stats_api_lifetime_message_stream"
+  - "#/definitions/campaign_stream"
+  - "#/definitions/message_stream"
 
 check:
   stream_names:

--- a/airbyte-integrations/connectors/source-mailjet-sms/source_mailjet_sms/mailjet_sms.yaml
+++ b/airbyte-integrations/connectors/source-mailjet-sms/source_mailjet_sms/mailjet_sms.yaml
@@ -16,7 +16,7 @@ definitions:
   offset_paginator:
     type: DefaultPaginator
     $options:
-      url_base: "*ref(definitions.requester.url_base)"
+      url_base: "#/definitions/requester/url_base"
     pagination_strategy:
       type: "OffsetIncrement"
       page_size: 100
@@ -28,30 +28,30 @@ definitions:
       field_name: "Limit"
   retriever:
     record_selector:
-      $ref: "*ref(definitions.selector)"
+      $ref: "#/definitions/selector"
     paginator:
       type: NoPagination
     requester:
-      $ref: "*ref(definitions.requester)"
+      $ref: "#/definitions/requester"
   base_stream:
     retriever:
-      $ref: "*ref(definitions.retriever)"
+      $ref: "#/definitions/retriever"
   sms_stream:
-    $ref: "*ref(definitions.base_stream)"
+    $ref: "#/definitions/base_stream"
     retriever:
       record_selector:
-        $ref: "*ref(definitions.selector)"
+        $ref: "#/definitions/selector"
       paginator:
-        $ref: "*ref(definitions.offset_paginator)"
+        $ref: "#/definitions/offset_paginator"
       requester:
-        $ref: "*ref(definitions.requester)"
+        $ref: "#/definitions/requester"
     $options:
       name: "sms"
       primary_key: "ID"
       path: "/sms"
 
 streams:
-  - "*ref(definitions.sms_stream)"
+  - "#/definitions/sms_stream"
 
 check:
   stream_names:

--- a/airbyte-integrations/connectors/source-metabase/source_metabase/metabase.yaml
+++ b/airbyte-integrations/connectors/source-metabase/source_metabase/metabase.yaml
@@ -24,55 +24,55 @@ definitions:
       validate_session_url: "user/current"
   retriever:
     record_selector:
-      $ref: "*ref(definitions.selector)"
+      $ref: "#/definitions/selector"
     paginator:
       type: NoPagination
     requester:
-      $ref: "*ref(definitions.requester)"
+      $ref: "#/definitions/requester"
   data_field_retriever:
     record_selector:
-      $ref: "*ref(definitions.data_field_selector)"
+      $ref: "#/definitions/data_field_selector"
     paginator:
       type: NoPagination
     requester:
-      $ref: "*ref(definitions.requester)"
+      $ref: "#/definitions/requester"
   base_stream:
     primary_key: "id"
     retriever:
-      $ref: "*ref(definitions.retriever)"
+      $ref: "#/definitions/retriever"
   activity_stream:
-    $ref: "*ref(definitions.base_stream)"
+    $ref: "#/definitions/base_stream"
     $options:
       name: "activity"
       path: "activity"
   cards_stream:
-    $ref: "*ref(definitions.base_stream)"
+    $ref: "#/definitions/base_stream"
     $options:
       name: "cards"
       path: "card"
   collections_stream:
-    $ref: "*ref(definitions.base_stream)"
+    $ref: "#/definitions/base_stream"
     $options:
       name: "collections"
       path: "collection"
   dashboards_stream:
-    $ref: "*ref(definitions.base_stream)"
+    $ref: "#/definitions/base_stream"
     $options:
       name: "dashboards"
       path: "dashboard"
   users_stream:
     primary_key: "id"
     retriever:
-      $ref: "*ref(definitions.data_field_retriever)"
+      $ref: "#/definitions/data_field_retriever"
     $options:
       name: "users"
       path: "user"
 streams:
-  - "*ref(definitions.activity_stream)"
-  - "*ref(definitions.cards_stream)"
-  - "*ref(definitions.collections_stream)"
-  - "*ref(definitions.dashboards_stream)"
-  - "*ref(definitions.users_stream)"
+  - "#/definitions/activity_stream"
+  - "#/definitions/cards_stream"
+  - "#/definitions/collections_stream"
+  - "#/definitions/dashboards_stream"
+  - "#/definitions/users_stream"
 
 check:
   stream_names:

--- a/airbyte-integrations/connectors/source-monday/source_monday/monday.yaml
+++ b/airbyte-integrations/connectors/source-monday/source_monday/monday.yaml
@@ -37,26 +37,26 @@ definitions:
       page_size: 100
   retriever:
     record_selector:
-      $ref: "*ref(definitions.selector)"
+      $ref: "#/definitions/selector"
     requester:
-      $ref: "*ref(definitions.requester)"
+      $ref: "#/definitions/requester"
     paginator:
-      $ref: "*ref(definitions.default_paginator)"
+      $ref: "#/definitions/default_paginator"
   base_stream:
     retriever:
-      $ref: "*ref(definitions.retriever)"
+      $ref: "#/definitions/retriever"
     schema_loader:
-      $ref: "*ref(definitions.schema_loader)"
+      $ref: "#/definitions/schema_loader"
     primary_key: "id"
   base_nopagination_stream:
     retriever:
-      $ref: "*ref(definitions.retriever)"
+      $ref: "#/definitions/retriever"
       paginator:
         type: NoPagination
   items_stream:
-    $ref: "*ref(definitions.base_stream)"
+    $ref: "#/definitions/base_stream"
     retriever:
-      $ref: "*ref(definitions.retriever)"
+      $ref: "#/definitions/retriever"
       record_selector:
         type: RecordSelector
         extractor:
@@ -64,41 +64,41 @@ definitions:
           field_pointer: "/data/boards/*/items/*"
           class_name: "source_monday.DpathStringExtractor"
       paginator:
-        $ref: "*ref(definitions.default_paginator)"
+        $ref: "#/definitions/default_paginator"
         pagination_strategy:
-          $ref: "*ref(definitions.default_paginator.pagination_strategy)"
+          $ref: "#/definitions/default_paginator/pagination_strategy"
           page_size: 1
     $options:
       name: "items"
       path: ""
       items_per_page: 1
   boards_stream:
-    $ref: "*ref(definitions.base_stream)"
+    $ref: "#/definitions/base_stream"
     $options:
       name: "boards"
       path: ""
   teams_stream:
-    $ref: "*ref(definitions.base_nopagination_stream)"
+    $ref: "#/definitions/base_nopagination_stream"
     $options:
       name: "teams"
       path: ""
   updates_stream:
-    $ref: "*ref(definitions.base_stream)"
+    $ref: "#/definitions/base_stream"
     $options:
       name: "updates"
       path: ""
   users_stream:
-    $ref: "*ref(definitions.base_stream)"
+    $ref: "#/definitions/base_stream"
     $options:
       name: "users"
       path: ""
 
 streams:
-  - "*ref(definitions.items_stream)"
-  - "*ref(definitions.boards_stream)"
-  - "*ref(definitions.teams_stream)"
-  - "*ref(definitions.updates_stream)"
-  - "*ref(definitions.users_stream)"
+  - "#/definitions/items_stream"
+  - "#/definitions/boards_stream"
+  - "#/definitions/teams_stream"
+  - "#/definitions/updates_stream"
+  - "#/definitions/users_stream"
 
 check:
   stream_names:

--- a/airbyte-integrations/connectors/source-n8n/source_n8n/n8n.yaml
+++ b/airbyte-integrations/connectors/source-n8n/source_n8n/n8n.yaml
@@ -15,10 +15,10 @@ definitions:
       limit: "250"
   retriever:
     record_selector:
-      $ref: "*ref(definitions.selector)"
+      $ref: "#/definitions/selector"
     paginator:
       type: DefaultPaginator
-      url_base: "*ref(definitions.requester.url_base)"
+      url_base: "#/definitions/requester/url_base"
       page_size_option:
         inject_into: "request_parameter"
         field_name: ""
@@ -30,19 +30,19 @@ definitions:
         field_name: "cursor"
         inject_into: "request_parameter"
     requester:
-      $ref: "*ref(definitions.requester)"
+      $ref: "#/definitions/requester"
   base_stream:
     retriever:
-      $ref: "*ref(definitions.retriever)"
+      $ref: "#/definitions/retriever"
   executions_stream:
-    $ref: "*ref(definitions.base_stream)"
+    $ref: "#/definitions/base_stream"
     $options:
       name: "executions"
       primary_key: "id"
       path: "/executions"
 
 streams:
-  - "*ref(definitions.executions_stream)"
+  - "#/definitions/executions_stream"
 
 check:
   stream_names:

--- a/airbyte-integrations/connectors/source-news-api/source_news_api/news_api.yaml
+++ b/airbyte-integrations/connectors/source-news-api/source_news_api/news_api.yaml
@@ -30,10 +30,10 @@ definitions:
       category: "{{ config['category'] if options['use_category'] is defined and not config.get('sources') else None }}"
   retriever:
     record_selector:
-      $ref: "*ref(definitions.selector)"
+      $ref: "#/definitions/selector"
     paginator:
       type: DefaultPaginator
-      url_base: "*ref(definitions.requester.url_base)"
+      url_base: "#/definitions/requester/url_base"
       page_size_option:
         inject_into: "request_parameter"
         field_name: "pageSize"
@@ -44,18 +44,18 @@ definitions:
         inject_into: "request_parameter"
         field_name: "page"
     requester:
-      $ref: "*ref(definitions.requester)"
+      $ref: "#/definitions/requester"
   base_stream:
     retriever:
-      $ref: "*ref(definitions.retriever)"
+      $ref: "#/definitions/retriever"
   everything_stream:
-    $ref: "*ref(definitions.base_stream)"
+    $ref: "#/definitions/base_stream"
     $options:
       name: "everything"
       primary_key: "publishedAt"
       path: "/everything"
   top_headlines_stream:
-    $ref: "*ref(definitions.base_stream)"
+    $ref: "#/definitions/base_stream"
     $options:
       name: "top_headlines"
       primary_key: "publishedAt"
@@ -64,8 +64,8 @@ definitions:
       use_category: true
 
 streams:
-  - "*ref(definitions.everything_stream)"
-  - "*ref(definitions.top_headlines_stream)"
+  - "#/definitions/everything_stream"
+  - "#/definitions/top_headlines_stream"
 
 check:
   stream_names:

--- a/airbyte-integrations/connectors/source-newsdata/source_newsdata/newsdata.yaml
+++ b/airbyte-integrations/connectors/source-newsdata/source_newsdata/newsdata.yaml
@@ -13,12 +13,12 @@ definitions:
       api_token: "{{ config['api_key'] }}"
   base_retriever:
     record_selector:
-      $ref: "*ref(definitions.selector)"
+      $ref: "#/definitions/selector"
   base_stream:
     retriever:
-      $ref: "*ref(definitions.base_retriever)"
+      $ref: "#/definitions/base_retriever"
       requester:
-        $ref: "*ref(definitions.base_requester)"
+        $ref: "#/definitions/base_requester"
   cursor_paginator:
     type: "DefaultPaginator"
     pagination_strategy:
@@ -32,17 +32,17 @@ definitions:
     page_size_option: # This is useless, only there because it is required, but page sizes are managed automatically by API subscription type
       field_name: "X-Pagination-Page-Size"
       inject_into: "header"
-    url_base: "*ref(definitions.base_requester.url_base)"
+    url_base: "#/definitions/base_requester/url_base"
   latest_stream:
-    $ref: "*ref(definitions.base_stream)"
+    $ref: "#/definitions/base_stream"
     $options:
       name: "latest"
       primary_key: "link"
       path: "/news"
     retriever:
-      $ref: "*ref(definitions.base_retriever)"
+      $ref: "#/definitions/base_retriever"
       requester:
-        $ref: "*ref(definitions.base_requester)"
+        $ref: "#/definitions/base_requester"
         request_parameters:
           country: "{{ ','.join(config['country']) }}"
           language: "{{ ','.join(config['language']) }}"
@@ -51,25 +51,25 @@ definitions:
           qInTitle: "{{ config['query_in_title'] | urlencode }}"
           domain: "{{ ','.join(config['domain']) }}"
       paginator:
-        $ref: "*ref(definitions.cursor_paginator)"
+        $ref: "#/definitions/cursor_paginator"
   sources_stream:
-    $ref: "*ref(definitions.base_stream)"
+    $ref: "#/definitions/base_stream"
     $options:
       name: "sources"
       primary_key: "id"
       path: "/sources"
     retriever:
-      $ref: "*ref(definitions.base_retriever)"
+      $ref: "#/definitions/base_retriever"
       requester:
-        $ref: "*ref(definitions.base_requester)"
+        $ref: "#/definitions/base_requester"
         request_parameters:
           country: "{{ config['country'][0] }}"
           language: "{{ config['language'][0] }}"
           category: "{{ config['category'][0] }}"
 
 streams:
-  - "*ref(definitions.latest_stream)"
-  - "*ref(definitions.sources_stream)"
+  - "#/definitions/latest_stream"
+  - "#/definitions/sources_stream"
 
 check:
   stream_names:

--- a/airbyte-integrations/connectors/source-nytimes/source_nytimes/nytimes.yaml
+++ b/airbyte-integrations/connectors/source-nytimes/source_nytimes/nytimes.yaml
@@ -10,10 +10,10 @@ definitions:
     paginator:
       type: NoPagination
     requester:
-      $ref: "*ref(definitions.requester)"
+      $ref: "#/definitions/requester"
   archive_stream:
     retriever:
-      $ref: "*ref(definitions.retriever)"
+      $ref: "#/definitions/retriever"
       record_selector:
         extractor:
           field_pointer: ["response", "docs"]
@@ -36,7 +36,7 @@ definitions:
       stream_cursor_field: "pub_date"
   most_popular_emailed_stream:
     retriever:
-      $ref: "*ref(definitions.retriever)"
+      $ref: "#/definitions/retriever"
       record_selector:
         extractor:
           field_pointer: ["results"]
@@ -46,7 +46,7 @@ definitions:
       path: "/mostpopular/v2/emailed/{{ config['period'] }}.json"
   most_popular_shared_stream:
     retriever:
-      $ref: "*ref(definitions.retriever)"
+      $ref: "#/definitions/retriever"
       record_selector:
         extractor:
           field_pointer: ["results"]
@@ -56,7 +56,7 @@ definitions:
       path: "/mostpopular/v2/shared/{{ config['period'] }}{% if 'share_type' in config %}/{{ config['share_type'] }}{% endif %}.json"
   most_popular_viewed_stream:
     retriever:
-      $ref: "*ref(definitions.retriever)"
+      $ref: "#/definitions/retriever"
       record_selector:
         extractor:
           field_pointer: ["results"]
@@ -66,10 +66,10 @@ definitions:
       path: "/mostpopular/v2/viewed/{{ config['period'] }}.json"
 
 streams:
-  - "*ref(definitions.archive_stream)"
-  - "*ref(definitions.most_popular_emailed_stream)"
-  - "*ref(definitions.most_popular_shared_stream)"
-  - "*ref(definitions.most_popular_viewed_stream)"
+  - "#/definitions/archive_stream"
+  - "#/definitions/most_popular_emailed_stream"
+  - "#/definitions/most_popular_shared_stream"
+  - "#/definitions/most_popular_viewed_stream"
 
 check:
   stream_names:

--- a/airbyte-integrations/connectors/source-omnisend/source_omnisend/omnisend.yaml
+++ b/airbyte-integrations/connectors/source-omnisend/source_omnisend/omnisend.yaml
@@ -13,10 +13,10 @@ definitions:
       api_token: "{{ config['api_key'] }}"
   retriever:
     record_selector:
-      $ref: "*ref(definitions.selector)"
+      $ref: "#/definitions/selector"
     paginator:
       type: DefaultPaginator
-      url_base: "*ref(definitions.requester.url_base)"
+      url_base: "#/definitions/requester/url_base"
       page_size_option:
         inject_into: "request_parameter"
         field_name: "limit"
@@ -28,57 +28,57 @@ definitions:
       page_token_option:
         inject_into: "path"
     requester:
-      $ref: "*ref(definitions.requester)"
+      $ref: "#/definitions/requester"
   base_stream:
     retriever:
-      $ref: "*ref(definitions.retriever)"
+      $ref: "#/definitions/retriever"
   # API Docs: https://api-docs.omnisend.com/reference/list-contacts
   contacts_stream:
-    $ref: "*ref(definitions.base_stream)"
+    $ref: "#/definitions/base_stream"
     $options:
       name: "contacts"
       primary_key: "contactID"
       path: "/contacts"
   # API Docs: https://api-docs.omnisend.com/reference/get_campaigns
   campaigns_stream:
-    $ref: "*ref(definitions.base_stream)"
+    $ref: "#/definitions/base_stream"
     $options:
       name: "campaigns"
       primary_key: "campaignID"
       path: "/campaigns"
     retriever:
-      $ref: "*ref(definitions.retriever)"
+      $ref: "#/definitions/retriever"
       record_selector:
         extractor:
           field_pointer: ["campaign"]
   # API Docs: https://api-docs.omnisend.com/reference/get_carts
   carts_stream:
-    $ref: "*ref(definitions.base_stream)"
+    $ref: "#/definitions/base_stream"
     $options:
       name: "carts"
       primary_key: "cartID"
       path: "/carts"
   # API Docs: https://api-docs.omnisend.com/reference/get_orders
   orders_stream:
-    $ref: "*ref(definitions.base_stream)"
+    $ref: "#/definitions/base_stream"
     $options:
       name: "orders"
       primary_key: "orderID"
       path: "/orders"
   # API Docs: https://api-docs.omnisend.com/reference/get_products
   products_stream:
-    $ref: "*ref(definitions.base_stream)"
+    $ref: "#/definitions/base_stream"
     $options:
       name: "products"
       primary_key: "productID"
       path: "/products"
 
 streams:
-  - "*ref(definitions.contacts_stream)"
-  - "*ref(definitions.campaigns_stream)"
-  - "*ref(definitions.carts_stream)"
-  - "*ref(definitions.orders_stream)"
-  - "*ref(definitions.products_stream)"
+  - "#/definitions/contacts_stream"
+  - "#/definitions/campaigns_stream"
+  - "#/definitions/carts_stream"
+  - "#/definitions/orders_stream"
+  - "#/definitions/products_stream"
 
 check:
   stream_names: ["contacts"]

--- a/airbyte-integrations/connectors/source-oura/source_oura/oura.yaml
+++ b/airbyte-integrations/connectors/source-oura/source_oura/oura.yaml
@@ -11,12 +11,12 @@ definitions:
       type: BearerAuthenticator
       api_token: "{{ config['api_key'] }}"
   date_requester:
-    $ref: "*ref(definitions.base_requester)"
+    $ref: "#/definitions/base_requester"
     request_parameters:
       start_date: "{{ config['start_date'].split('T')[0] }}"
       end_date: "{{ config['end_date'].split('T')[0] }}"
   datetime_requester:
-    $ref: "*ref(definitions.base_requester)"
+    $ref: "#/definitions/base_requester"
     request_parameters:
       start_datetime: "{{ config['start_datetime'] }}"
       end_datetime: "{{ config['end_datetime'] }}"
@@ -29,87 +29,87 @@ definitions:
     page_token_option:
       field_name: "next_token"
       inject_into: "request_parameter"
-    url_base: "*ref(definitions.base_requester.url_base)"
+    url_base: "#/definitions/base_requester/url_base"
     page_size_option: # Not used, but check fails without it
       field_name: ""
       inject_into: "request_parameter"
   base_retriever:
     record_selector:
-      $ref: "*ref(definitions.selector)"
+      $ref: "#/definitions/selector"
     paginator:
-      $ref: "*ref(definitions.paginator)"
+      $ref: "#/definitions/paginator"
   date_retriever:
-    $ref: "*ref(definitions.base_retriever)"
+    $ref: "#/definitions/base_retriever"
     requester:
-      $ref: "*ref(definitions.date_requester)"
+      $ref: "#/definitions/date_requester"
   datetime_retriever:
-    $ref: "*ref(definitions.base_retriever)"
+    $ref: "#/definitions/base_retriever"
     requester:
-      $ref: "*ref(definitions.datetime_requester)"
+      $ref: "#/definitions/datetime_requester"
   date_stream:
     retriever:
-      $ref: "*ref(definitions.date_retriever)"
+      $ref: "#/definitions/date_retriever"
   datetime_stream:
     retriever:
-      $ref: "*ref(definitions.datetime_retriever)"
+      $ref: "#/definitions/datetime_retriever"
   daily_activity_stream:
-    $ref: "*ref(definitions.date_stream)"
+    $ref: "#/definitions/date_stream"
     $options:
       name: "daily_activity"
       primary_key: "timestamp"
       path: "/daily_activity"
   daily_readiness_stream:
-    $ref: "*ref(definitions.date_stream)"
+    $ref: "#/definitions/date_stream"
     $options:
       name: "daily_readiness"
       primary_key: "timestamp"
       path: "/daily_readiness"
   daily_sleep_stream:
-    $ref: "*ref(definitions.date_stream)"
+    $ref: "#/definitions/date_stream"
     $options:
       name: "daily_sleep"
       primary_key: "timestamp"
       path: "/daily_sleep"
   heart_rate_stream:
-    $ref: "*ref(definitions.datetime_stream)"
+    $ref: "#/definitions/datetime_stream"
     $options:
       name: "heart_rate"
       primary_key: "timestamp"
       path: "/heartrate"
   sessions_stream:
-    $ref: "*ref(definitions.date_stream)"
+    $ref: "#/definitions/date_stream"
     $options:
       name: "sessions"
       primary_key: "start_datetime"
       path: "/session"
   sleep_periods_stream:
-    $ref: "*ref(definitions.date_stream)"
+    $ref: "#/definitions/date_stream"
     $options:
       name: "sleep_periods"
       primary_key: "bedtime_start"
       path: "/sleep"
   tags_stream:
-    $ref: "*ref(definitions.date_stream)"
+    $ref: "#/definitions/date_stream"
     $options:
       name: "tags"
       primary_key: "timestamp"
       path: "/tag"
   workouts_stream:
-    $ref: "*ref(definitions.date_stream)"
+    $ref: "#/definitions/date_stream"
     $options:
       name: "workouts"
       primary_key: "start_datetime"
       path: "/workout"
 
 streams:
-  - "*ref(definitions.daily_activity_stream)"
-  - "*ref(definitions.daily_readiness_stream)"
-  - "*ref(definitions.daily_sleep_stream)"
-  - "*ref(definitions.heart_rate_stream)"
-  - "*ref(definitions.sessions_stream)"
-  - "*ref(definitions.sleep_periods_stream)"
-  - "*ref(definitions.tags_stream)"
-  - "*ref(definitions.workouts_stream)"
+  - "#/definitions/daily_activity_stream"
+  - "#/definitions/daily_readiness_stream"
+  - "#/definitions/daily_sleep_stream"
+  - "#/definitions/heart_rate_stream"
+  - "#/definitions/sessions_stream"
+  - "#/definitions/sleep_periods_stream"
+  - "#/definitions/tags_stream"
+  - "#/definitions/workouts_stream"
 
 check:
   stream_names:

--- a/airbyte-integrations/connectors/source-partnerstack/source_partnerstack/partnerstack.yaml
+++ b/airbyte-integrations/connectors/source-partnerstack/source_partnerstack/partnerstack.yaml
@@ -19,7 +19,7 @@ definitions:
     class_name: source_partnerstack.components.PartnerstackSlicer
   retriever:
     record_selector:
-      $ref: "*ref(definitions.selector)"
+      $ref: "#/definitions/selector"
     paginator:
       type: DefaultPaginator
       pagination_strategy:
@@ -34,70 +34,70 @@ definitions:
         field_name: "starting_after"
         inject_into: "request_parameter"
       url_base:
-        $ref: "*ref(definitions.requester.url_base)"
+        $ref: "#/definitions/requester/url_base"
     requester:
-      $ref: "*ref(definitions.requester)"
+      $ref: "#/definitions/requester"
     stream_slicer:
-      $ref: "*ref(definitions.stream_slicer)"
+      $ref: "#/definitions/stream_slicer"
 
   # base stream
   base_stream:
     retriever:
-      $ref: "*ref(definitions.retriever)"
+      $ref: "#/definitions/retriever"
 
   # stream definitions
   customers_stream:
-    $ref: "*ref(definitions.base_stream)"
+    $ref: "#/definitions/base_stream"
     $options:
       name: "customers"
       primary_key: "key"
       path: "/customers"
       stream_cursor_field: "updated_at"
   deals_stream:
-    $ref: "*ref(definitions.base_stream)"
+    $ref: "#/definitions/base_stream"
     $options:
       name: "deals"
       primary_key: "key"
       path: "/deals"
   groups_stream:
-    $ref: "*ref(definitions.base_stream)"
+    $ref: "#/definitions/base_stream"
     $options:
       name: "groups"
       primary_key: "key"
       path: "/groups"
   leads_stream:
-    $ref: "*ref(definitions.base_stream)"
+    $ref: "#/definitions/base_stream"
     $options:
       name: "leads"
       primary_key: "key"
       path: "/leads"
   partnerships_stream:
-    $ref: "*ref(definitions.base_stream)"
+    $ref: "#/definitions/base_stream"
     $options:
       name: "partnerships"
       primary_key: "key"
       path: "/partnerships"
   rewards_stream:
-    $ref: "*ref(definitions.base_stream)"
+    $ref: "#/definitions/base_stream"
     $options:
       name: "rewards"
       primary_key: "key"
       path: "/rewards"
   transactions_stream:
-    $ref: "*ref(definitions.base_stream)"
+    $ref: "#/definitions/base_stream"
     $options:
       name: "transactions"
       primary_key: "key"
       path: "/transactions"
 
 streams:
-  - "*ref(definitions.customers_stream)"
-  - "*ref(definitions.deals_stream)"
-  - "*ref(definitions.groups_stream)"
-  - "*ref(definitions.leads_stream)"
-  - "*ref(definitions.partnerships_stream)"
-  - "*ref(definitions.rewards_stream)"
-  - "*ref(definitions.transactions_stream)"
+  - "#/definitions/customers_stream"
+  - "#/definitions/deals_stream"
+  - "#/definitions/groups_stream"
+  - "#/definitions/leads_stream"
+  - "#/definitions/partnerships_stream"
+  - "#/definitions/rewards_stream"
+  - "#/definitions/transactions_stream"
 
 check:
   stream_names:

--- a/airbyte-integrations/connectors/source-pexels-api/source_pexels_api/pexels_api.yaml
+++ b/airbyte-integrations/connectors/source-pexels-api/source_pexels_api/pexels_api.yaml
@@ -42,7 +42,7 @@ definitions:
     url_base: "https://api.pexels.com"
     http_method: "GET"
     request_parameters:
-      $ref: "*ref(definitions.requester_stream.request_parameters)"
+      $ref: "#/definitions/requester_stream/request_parameters"
     authenticator:
       type: ApiKeyAuthenticator
       header: "Authorization"
@@ -57,18 +57,18 @@ definitions:
 
   retriever:
     record_selector:
-      $ref: "*ref(definitions.selector)"
+      $ref: "#/definitions/selector"
     paginator:
       type: NoPagination
     requester:
-      $ref: "*ref(definitions.requester)"
+      $ref: "#/definitions/requester"
 
   base_stream:
     schema_loader:
       type: JsonSchema
       file_path: "./source_pexels_api/schemas/{{ options['name'] }}.json"
     retriever:
-      $ref: "*ref(definitions.retriever)"
+      $ref: "#/definitions/retriever"
 
   page_stream:
     schema_loader:
@@ -76,10 +76,10 @@ definitions:
       file_path: "./source_pexels_api/schemas/{{ options['name'] }}.json"
     retriever:
       record_selector:
-        $ref: "*ref(definitions.selector)"
+        $ref: "#/definitions/selector"
       paginator:
         type: "DefaultPaginator"
-        url_base: "*ref(definitions.requester.url_base)"
+        url_base: "#/definitions/requester/url_base"
         pagination_strategy:
           type: "PageIncrement"
           page_size: 1000
@@ -90,44 +90,44 @@ definitions:
           inject_into: "request_parameter"
           field_name: "per_page"
       requester:
-        $ref: "*ref(definitions.requester)"
+        $ref: "#/definitions/requester"
 
   photos_search_stream:
-    $ref: "*ref(definitions.page_stream)"
+    $ref: "#/definitions/page_stream"
     $options:
       name: "photos_search"
       path: "/v1/search"
 
   photos_curated_stream:
-    $ref: "*ref(definitions.page_stream)"
+    $ref: "#/definitions/page_stream"
     $options:
       name: "photos_curated"
       path: "/v1/curated"
 
   videos_search_stream:
-    $ref: "*ref(definitions.page_stream)"
+    $ref: "#/definitions/page_stream"
     $options:
       name: "videos_search"
       path: "/videos/search"
 
   videos_popular_stream:
-    $ref: "*ref(definitions.page_stream)"
+    $ref: "#/definitions/page_stream"
     $options:
       name: "videos_popular"
       path: "/videos/popular"
 
   collection_featured_stream:
-    $ref: "*ref(definitions.page_stream)"
+    $ref: "#/definitions/page_stream"
     $options:
       name: "collection_featured"
       path: "/v1/collections/featured"
 
 streams:
-  - "*ref(definitions.photos_search_stream)"
-  - "*ref(definitions.photos_curated_stream)"
-  - "*ref(definitions.collection_featured_stream)"
-  - "*ref(definitions.videos_search_stream)"
-  - "*ref(definitions.videos_popular_stream)"
+  - "#/definitions/photos_search_stream"
+  - "#/definitions/photos_curated_stream"
+  - "#/definitions/collection_featured_stream"
+  - "#/definitions/videos_search_stream"
+  - "#/definitions/videos_popular_stream"
 
 check:
   stream_names:

--- a/airbyte-integrations/connectors/source-plausible/source_plausible/plausible.yaml
+++ b/airbyte-integrations/connectors/source-plausible/source_plausible/plausible.yaml
@@ -24,23 +24,23 @@ definitions:
       date: "{{ config['start_date'] or '2019-01-01' }},{{ today_utc() }}"
   retriever:
     record_selector:
-      $ref: "*ref(definitions.selector)"
+      $ref: "#/definitions/selector"
     paginator:
       type: NoPagination
     requester:
-      $ref: "*ref(definitions.requester)"
+      $ref: "#/definitions/requester"
   base_stream:
     retriever:
-      $ref: "*ref(definitions.retriever)"
+      $ref: "#/definitions/retriever"
   stats_stream:
-    $ref: "*ref(definitions.base_stream)"
+    $ref: "#/definitions/base_stream"
     $options:
       name: "stats"
       primary_key: "date"
       path: "/timeseries"
 
 streams:
-  - "*ref(definitions.stats_stream)"
+  - "#/definitions/stats_stream"
 
 check:
   stream_names:

--- a/airbyte-integrations/connectors/source-pocket/source_pocket/pocket.yaml
+++ b/airbyte-integrations/connectors/source-pocket/source_pocket/pocket.yaml
@@ -32,10 +32,10 @@ definitions:
               header: "X-Limit-User-Reset"
   retriever:
     record_selector:
-      $ref: "*ref(definitions.selector)"
+      $ref: "#/definitions/selector"
     paginator:
       type: "DefaultPaginator"
-      url_base: "*ref(definitions.requester.url_base)"
+      url_base: "#/definitions/requester/url_base"
       page_size_option:
         inject_into: "request_parameter"
         field_name: "count"
@@ -46,21 +46,21 @@ definitions:
         inject_into: "request_parameter"
         field_name: "offset"
     requester:
-      $ref: "*ref(definitions.requester)"
+      $ref: "#/definitions/requester"
   base_stream:
     retriever:
-      $ref: "*ref(definitions.retriever)"
+      $ref: "#/definitions/retriever"
     schema_loader:
       type: "JsonSchema"
   retrieve_stream:
-    $ref: "*ref(definitions.base_stream)"
+    $ref: "#/definitions/base_stream"
     $options:
       name: "retrieve"
       primary_key: "item_id"
       path: "/get"
 
 streams:
-  - "*ref(definitions.retrieve_stream)"
+  - "#/definitions/retrieve_stream"
 
 check:
   stream_names:

--- a/airbyte-integrations/connectors/source-polygon-stock-api/source_polygon_stock_api/polygon_stock_api.yaml
+++ b/airbyte-integrations/connectors/source-polygon-stock-api/source_polygon_stock_api/polygon_stock_api.yaml
@@ -13,14 +13,14 @@ definitions:
     api_token: "{{ config['access_key'] }}"
   retriever:
     record_selector:
-      $ref: "*ref(definitions.selector)"
+      $ref: "#/definitions/selector"
     paginator:
       type: NoPagination
     requester:
-      $ref: "*ref(definitions.requester)"
+      $ref: "#/definitions/requester"
   base_stream:
     retriever:
-      $ref: "*ref(definitions.retriever)"
+      $ref: "#/definitions/retriever"
 
   stream_slicer:
     start_datetime: "{{ config['start_date'] }}T00:00:00.000000+0000"
@@ -28,13 +28,13 @@ definitions:
     step: "1d"
 
   stock_api_stream:
-    $ref: "*ref(definitions.base_stream)"
+    $ref: "#/definitions/base_stream"
     $options:
       name: "stock_api"
       primary_key: "t"
       path: "/v2/aggs/ticker/{{ config['stocksTicker'] }}/range/{{ config['multiplier'] }}/{{ config['timespan'] }}/{{ config['start_date'] }}/{{ config['end_date'] }}?adjusted={{ config['adjusted'] }}&sort={{ config['sort'] }}&limit=120&apiKey={{ config['apiKey'] }}"
 streams:
-  - "*ref(definitions.stock_api_stream)"
+  - "#/definitions/stock_api_stream"
 
 check:
   stream_names:

--- a/airbyte-integrations/connectors/source-posthog/source_posthog/posthog.yaml
+++ b/airbyte-integrations/connectors/source-posthog/source_posthog/posthog.yaml
@@ -24,10 +24,10 @@ definitions:
     name: "{{ options['name'] }}"
     primary_key: "{{ options['primary_key'] }}"
     record_selector:
-      $ref: "*ref(definitions.selector)"
+      $ref: "#/definitions/selector"
     paginator:
       type: "DefaultPaginator"
-      url_base: "*ref(definitions.requester.url_base)"
+      url_base: "#/definitions/requester/url_base"
       page_size_option:
         inject_into: "request_parameter"
         field_name: "limit"
@@ -41,58 +41,58 @@ definitions:
   base_stream:
     primary_key: "id"
     schema_loader:
-      $ref: "*ref(definitions.schema_loader)"
+      $ref: "#/definitions/schema_loader"
     retriever:
-      $ref: "*ref(definitions.retriever)"
+      $ref: "#/definitions/retriever"
       requester:
-        $ref: "*ref(definitions.requester)"
+        $ref: "#/definitions/requester"
 
   projects_stream:
-    $ref: "*ref(definitions.base_stream)"
+    $ref: "#/definitions/base_stream"
     $options:
       name: "projects"
       path: "projects"
 
   base_slicing_stream:
-    $ref: "*ref(definitions.base_stream)"
+    $ref: "#/definitions/base_stream"
     retriever:
-      $ref: "*ref(definitions.retriever)"
+      $ref: "#/definitions/retriever"
       requester:
-        $ref: "*ref(definitions.requester)"
+        $ref: "#/definitions/requester"
         path: "/projects/{{ stream_slice.id }}/{{ options['name'] }}"
       stream_slicer:
         type: SubstreamSlicer
         parent_stream_configs:
-          - stream: "*ref(definitions.projects_stream)"
+          - stream: "#/definitions/projects_stream"
             parent_key: id
             stream_slice_field: id
 
   cohorts_stream:
-    $ref: "*ref(definitions.base_slicing_stream)"
+    $ref: "#/definitions/base_slicing_stream"
     $options:
       name: "cohorts"
       path: "cohorts"
 
   feature_flags_stream:
-    $ref: "*ref(definitions.base_slicing_stream)"
+    $ref: "#/definitions/base_slicing_stream"
     $options:
       name: "feature_flags"
       path: "feature_flags"
 
   persons_stream:
-    $ref: "*ref(definitions.base_slicing_stream)"
+    $ref: "#/definitions/base_slicing_stream"
     $options:
       name: "persons"
       path: "persons"
 
   annotations_stream:
-    $ref: "*ref(definitions.base_slicing_stream)"
+    $ref: "#/definitions/base_slicing_stream"
     $options:
       name: "annotations"
       path: "annotations"
 
   insights_stream:
-    $ref: "*ref(definitions.base_slicing_stream)"
+    $ref: "#/definitions/base_slicing_stream"
     $options:
       name: "insights"
       path: "insights"
@@ -104,15 +104,15 @@ definitions:
     primary_key: "id"
     stream_cursor_field: "timestamp"
     schema_loader:
-      $ref: "*ref(definitions.schema_loader)"
+      $ref: "#/definitions/schema_loader"
     retriever:
       class_name: source_posthog.components.EventsSimpleRetriever
       name: "{{ options['name'] }}"
       primary_key: "{{ options['primary_key'] }}"
       record_selector:
-        $ref: "*ref(definitions.selector)"
+        $ref: "#/definitions/selector"
       requester:
-        $ref: "*ref(definitions.requester)"
+        $ref: "#/definitions/requester"
         path: "/projects/{{ stream_slice.project_id }}/{{ options['name'] }}/"
       stream_slicer:
         type: CustomStreamSlicer
@@ -120,7 +120,7 @@ definitions:
         stream_slicers:
           - type: SubstreamSlicer
             parent_stream_configs:
-              - stream: "*ref(definitions.projects_stream)"
+              - stream: "#/definitions/projects_stream"
                 parent_key: "id"
                 stream_slice_field: "project_id"
           - type: DatetimeStreamSlicer
@@ -142,7 +142,7 @@ definitions:
               inject_into: request_parameter
       paginator:
         type: "DefaultPaginator"
-        url_base: "*ref(definitions.requester.url_base)"
+        url_base: "#/definitions/requester/url_base"
         page_size_option:
           inject_into: "request_parameter"
           field_name: "limit"
@@ -154,13 +154,13 @@ definitions:
           inject_into: "path"
 
 streams:
-  - "*ref(definitions.projects_stream)"
-  - "*ref(definitions.cohorts_stream)"
-  - "*ref(definitions.feature_flags_stream)"
-  - "*ref(definitions.persons_stream)"
-  - "*ref(definitions.events_stream)"
-  - "*ref(definitions.annotations_stream)"
-  - "*ref(definitions.insights_stream)"
+  - "#/definitions/projects_stream"
+  - "#/definitions/cohorts_stream"
+  - "#/definitions/feature_flags_stream"
+  - "#/definitions/persons_stream"
+  - "#/definitions/events_stream"
+  - "#/definitions/annotations_stream"
+  - "#/definitions/insights_stream"
 
 check:
   type: CheckStream

--- a/airbyte-integrations/connectors/source-postmarkapp/source_postmarkapp/postmarkapp.yaml
+++ b/airbyte-integrations/connectors/source-postmarkapp/source_postmarkapp/postmarkapp.yaml
@@ -43,11 +43,11 @@ definitions:
       api_token: "{{ config['X-Postmark-Account-Token'] }}"
   retriever_account:
     record_selector:
-      $ref: "*ref(definitions.selector)"
+      $ref: "#/definitions/selector"
     paginator:
       type: DefaultPaginator
       $options:
-        url_base: "*ref(definitions.requester.url_base)"
+        url_base: "#/definitions/requester/url_base"
       pagination_strategy:
         type: "OffsetIncrement"
         page_size: 500
@@ -58,14 +58,14 @@ definitions:
         inject_into: "request_parameter"
         field_name: "offset"
     requester:
-      $ref: "*ref(definitions.requester_account)"
+      $ref: "#/definitions/requester_account"
   retriever:
     record_selector:
-      $ref: "*ref(definitions.selector)"
+      $ref: "#/definitions/selector"
     paginator:
       type: DefaultPaginator
       $options:
-        url_base: "*ref(definitions.requester.url_base)"
+        url_base: "#/definitions/requester/url_base"
       pagination_strategy:
         type: "OffsetIncrement"
         page_size: 500
@@ -76,80 +76,80 @@ definitions:
         inject_into: "request_parameter"
         field_name: "offset"
     requester:
-      $ref: "*ref(definitions.requester)"
+      $ref: "#/definitions/requester"
   base_stream:
     retriever:
-      $ref: "*ref(definitions.retriever)"
+      $ref: "#/definitions/retriever"
   base_stream_account:
     retriever:
-      $ref: "*ref(definitions.retriever_account)"
+      $ref: "#/definitions/retriever_account"
   deliverystats:
     retriever:
-      $ref: "*ref(definitions.retriever)"
+      $ref: "#/definitions/retriever"
       record_selector:
-        $ref: "*ref(definitions.selector_bounces)"
+        $ref: "#/definitions/selector_bounces"
     $options:
       name: "deliverystats"
       primary_key: "Name"
       path: "/deliverystats"
   message-streams:
-    $ref: "*ref(definitions.base_stream)"
+    $ref: "#/definitions/base_stream"
     retriever:
-      $ref: "*ref(definitions.retriever)"
+      $ref: "#/definitions/retriever"
       record_selector:
-        $ref: "*ref(definitions.selector_message_streams)"
+        $ref: "#/definitions/selector_message_streams"
     $options:
       name: "message-streams"
       primary_key: "ID"
       path: "/message-streams"
   bounces:
-    $ref: "*ref(definitions.base_stream)"
+    $ref: "#/definitions/base_stream"
     retriever:
-      $ref: "*ref(definitions.retriever)"
+      $ref: "#/definitions/retriever"
       record_selector:
-        $ref: "*ref(definitions.selector_bounces)"
+        $ref: "#/definitions/selector_bounces"
     $options:
       name: "bounces"
       primary_key: "ID"
       path: "/bounces"
 
   servers:
-    $ref: "*ref(definitions.base_stream_account)"
+    $ref: "#/definitions/base_stream_account"
     retriever:
-      $ref: "*ref(definitions.retriever_account)"
+      $ref: "#/definitions/retriever_account"
       record_selector:
-        $ref: "*ref(definitions.selector_servers)"
+        $ref: "#/definitions/selector_servers"
     $options:
       name: "servers"
       primary_key: "ID"
       path: "/servers"
   messages:
-    $ref: "*ref(definitions.base_stream)"
+    $ref: "#/definitions/base_stream"
     retriever:
-      $ref: "*ref(definitions.retriever)"
+      $ref: "#/definitions/retriever"
       record_selector:
-        $ref: "*ref(definitions.selector_messages)"
+        $ref: "#/definitions/selector_messages"
     $options:
       name: "messages"
       primary_key: "MessageID"
       path: "/messages/outbound"
   domains:
-    $ref: "*ref(definitions.base_stream_account)"
+    $ref: "#/definitions/base_stream_account"
     $options:
       name: "domains"
       primary_key: "ID"
       path: "/domains"
     retriever:
-      $ref: "*ref(definitions.retriever_account)"
+      $ref: "#/definitions/retriever_account"
       record_selector:
-        $ref: "*ref(definitions.selector_domains)"
+        $ref: "#/definitions/selector_domains"
 streams:
-  - "*ref(definitions.deliverystats)"
-  - "*ref(definitions.message-streams)"
-  - "*ref(definitions.domains)"
-  - "*ref(definitions.messages)"
-  - "*ref(definitions.bounces)"
-  - "*ref(definitions.servers)"
+  - "#/definitions/deliverystats"
+  - "#/definitions/message-streams"
+  - "#/definitions/domains"
+  - "#/definitions/messages"
+  - "#/definitions/bounces"
+  - "#/definitions/servers"
 
 check:
   stream_names:

--- a/airbyte-integrations/connectors/source-prestashop/source_prestashop/prestashop.yaml
+++ b/airbyte-integrations/connectors/source-prestashop/source_prestashop/prestashop.yaml
@@ -17,24 +17,24 @@ definitions:
       limit: "'{{ next_page_token['next_page_token'] or '0' }},50'"
   retriever:
     record_selector:
-      $ref: "*ref(definitions.selector)"
+      $ref: "#/definitions/selector"
     paginator:
       type: DefaultPaginator
-      url_base: "*ref(definitions.requester.url_base)"
+      url_base: "#/definitions/requester/url_base"
       pagination_strategy:
         type: "OffsetIncrement"
         page_size: 50
     requester:
-      $ref: "*ref(definitions.requester)"
+      $ref: "#/definitions/requester"
   base_stream:
     retriever:
-      $ref: "*ref(definitions.retriever)"
+      $ref: "#/definitions/retriever"
   base_incremental_stream:
-    $ref: "*ref(definitions.base_stream)"
+    $ref: "#/definitions/base_stream"
     stream_cursor_field: "date_upd"
     checkpoint_interval: 500
     retriever:
-      $ref: "*ref(definitions.retriever)"
+      $ref: "#/definitions/retriever"
       stream_slicer:
         type: "DatetimeStreamSlicer"
         start_datetime:
@@ -47,16 +47,16 @@ definitions:
         datetime_format: "%Y-%m-%d %H:%M:%S"
         cursor_granularity: "PT1S"
       requester:
-        $ref: "*ref(definitions.requester)"
+        $ref: "#/definitions/requester"
         request_headers:
-          $ref: "*ref(definitions.requester.request_headers)"
+          $ref: "#/definitions/requester/request_headers"
         request_parameters:
-          $ref: "*ref(definitions.requester.request_parameters)"
+          $ref: "#/definitions/requester/request_parameters"
           date: "1"
           sort: "[{{ options['cursor_field'] }}_ASC,{{ options['primary_key'] }}_ASC]"
           "filter[{{ options['cursor_field'] }}]": "[{{ stream_slice['start_time'] }},{{ stream_slice['end_time'] }}]"
   addresses_stream:
-    $ref: "*ref(definitions.base_incremental_stream)"
+    $ref: "#/definitions/base_incremental_stream"
     $options:
       name: "addresses"
       path: "/addresses"
@@ -64,14 +64,14 @@ definitions:
       primary_key: "id"
       cursor_field: "date_upd"
   carriers_stream:
-    $ref: "*ref(definitions.base_stream)"
+    $ref: "#/definitions/base_stream"
     $options:
       name: "carriers"
       path: "/carriers"
       data_key: "carriers"
       primary_key: "id"
   cart_rules_stream:
-    $ref: "*ref(definitions.base_incremental_stream)"
+    $ref: "#/definitions/base_incremental_stream"
     $options:
       name: "cart_rules"
       path: "/cart_rules"
@@ -79,7 +79,7 @@ definitions:
       primary_key: "id"
       cursor_field: "date_upd"
   carts_stream:
-    $ref: "*ref(definitions.base_incremental_stream)"
+    $ref: "#/definitions/base_incremental_stream"
     $options:
       name: "carts"
       path: "/carts"
@@ -87,7 +87,7 @@ definitions:
       primary_key: "id"
       cursor_field: "date_upd"
   categories_stream:
-    $ref: "*ref(definitions.base_incremental_stream)"
+    $ref: "#/definitions/base_incremental_stream"
     $options:
       name: "categories"
       path: "/categories"
@@ -95,14 +95,14 @@ definitions:
       primary_key: "id"
       cursor_field: "date_upd"
   combinations_stream:
-    $ref: "*ref(definitions.base_stream)"
+    $ref: "#/definitions/base_stream"
     $options:
       name: "combinations"
       path: "/combinations"
       data_key: "combinations"
       primary_key: "id"
   configurations_stream:
-    $ref: "*ref(definitions.base_incremental_stream)"
+    $ref: "#/definitions/base_incremental_stream"
     $options:
       name: "configurations"
       path: "/configurations"
@@ -110,35 +110,35 @@ definitions:
       primary_key: "id"
       cursor_field: "date_upd"
   contacts_stream:
-    $ref: "*ref(definitions.base_stream)"
+    $ref: "#/definitions/base_stream"
     $options:
       name: "contacts"
       path: "/contacts"
       data_key: "contacts"
       primary_key: "id"
   content_management_system_stream:
-    $ref: "*ref(definitions.base_stream)"
+    $ref: "#/definitions/base_stream"
     $options:
       name: "content_management_system"
       path: "/content_management_system"
       data_key: "content_management_system"
       primary_key: "id"
   countries_stream:
-    $ref: "*ref(definitions.base_stream)"
+    $ref: "#/definitions/base_stream"
     $options:
       name: "countries"
       path: "/countries"
       data_key: "countries"
       primary_key: "id"
   currencies_stream:
-    $ref: "*ref(definitions.base_stream)"
+    $ref: "#/definitions/base_stream"
     $options:
       name: "currencies"
       path: "/currencies"
       data_key: "currencies"
       primary_key: "id"
   customer_messages_stream:
-    $ref: "*ref(definitions.base_incremental_stream)"
+    $ref: "#/definitions/base_incremental_stream"
     $options:
       name: "customer_messages"
       path: "/customer_messages"
@@ -146,7 +146,7 @@ definitions:
       primary_key: "id"
       cursor_field: "date_upd"
   customers_stream:
-    $ref: "*ref(definitions.base_incremental_stream)"
+    $ref: "#/definitions/base_incremental_stream"
     $options:
       name: "customers"
       path: "/customers"
@@ -154,7 +154,7 @@ definitions:
       primary_key: "id"
       cursor_field: "date_upd"
   customer_threads_stream:
-    $ref: "*ref(definitions.base_incremental_stream)"
+    $ref: "#/definitions/base_incremental_stream"
     $options:
       name: "customer_threads"
       path: "/customer_threads"
@@ -162,21 +162,21 @@ definitions:
       primary_key: "id"
       cursor_field: "date_upd"
   deliveries_stream:
-    $ref: "*ref(definitions.base_stream)"
+    $ref: "#/definitions/base_stream"
     $options:
       name: "deliveries"
       path: "/deliveries"
       data_key: "deliveries"
       primary_key: "id"
   employees_stream:
-    $ref: "*ref(definitions.base_stream)"
+    $ref: "#/definitions/base_stream"
     $options:
       name: "employees"
       path: "/employees"
       data_key: "employees"
       primary_key: "id"
   groups_stream:
-    $ref: "*ref(definitions.base_incremental_stream)"
+    $ref: "#/definitions/base_incremental_stream"
     $options:
       name: "groups"
       path: "/groups"
@@ -184,28 +184,28 @@ definitions:
       primary_key: "id"
       cursor_field: "date_upd"
   guests_stream:
-    $ref: "*ref(definitions.base_stream)"
+    $ref: "#/definitions/base_stream"
     $options:
       name: "guests"
       path: "/guests"
       data_key: "guests"
       primary_key: "id"
   image_types_stream:
-    $ref: "*ref(definitions.base_stream)"
+    $ref: "#/definitions/base_stream"
     $options:
       name: "image_types"
       path: "/image_types"
       data_key: "image_types"
       primary_key: "id"
   languages_stream:
-    $ref: "*ref(definitions.base_stream)"
+    $ref: "#/definitions/base_stream"
     $options:
       name: "languages"
       path: "/languages"
       data_key: "languages"
       primary_key: "id"
   manufacturers_stream:
-    $ref: "*ref(definitions.base_incremental_stream)"
+    $ref: "#/definitions/base_incremental_stream"
     $options:
       name: "manufacturers"
       path: "/manufacturers"
@@ -213,7 +213,7 @@ definitions:
       primary_key: "id"
       cursor_field: "date_upd"
   messages_stream:
-    $ref: "*ref(definitions.base_incremental_stream)"
+    $ref: "#/definitions/base_incremental_stream"
     stream_cursor_field: "date_add"
     $options:
       name: "messages"
@@ -222,7 +222,7 @@ definitions:
       primary_key: "id"
       cursor_field: "date_add"
   order_carriers_stream:
-    $ref: "*ref(definitions.base_incremental_stream)"
+    $ref: "#/definitions/base_incremental_stream"
     stream_cursor_field: "date_add"
     $options:
       name: "order_carriers"
@@ -231,14 +231,14 @@ definitions:
       primary_key: "id"
       cursor_field: "date_add"
   order_details_stream:
-    $ref: "*ref(definitions.base_stream)"
+    $ref: "#/definitions/base_stream"
     $options:
       name: "order_details"
       path: "/order_details"
       data_key: "order_details"
       primary_key: "id"
   order_histories_stream:
-    $ref: "*ref(definitions.base_incremental_stream)"
+    $ref: "#/definitions/base_incremental_stream"
     stream_cursor_field: "date_add"
     $options:
       name: "order_histories"
@@ -247,7 +247,7 @@ definitions:
       primary_key: "id"
       cursor_field: "date_add"
   order_invoices_stream:
-    $ref: "*ref(definitions.base_incremental_stream)"
+    $ref: "#/definitions/base_incremental_stream"
     stream_cursor_field: "date_add"
     $options:
       name: "order_invoices"
@@ -256,7 +256,7 @@ definitions:
       primary_key: "id"
       cursor_field: "date_add"
   order_payments_stream:
-    $ref: "*ref(definitions.base_incremental_stream)"
+    $ref: "#/definitions/base_incremental_stream"
     stream_cursor_field: "date_add"
     $options:
       name: "order_payments"
@@ -265,7 +265,7 @@ definitions:
       primary_key: "id"
       cursor_field: "date_add"
   orders_stream:
-    $ref: "*ref(definitions.base_incremental_stream)"
+    $ref: "#/definitions/base_incremental_stream"
     $options:
       name: "orders"
       path: "/orders"
@@ -273,7 +273,7 @@ definitions:
       primary_key: "id"
       cursor_field: "date_upd"
   order_slip_stream:
-    $ref: "*ref(definitions.base_incremental_stream)"
+    $ref: "#/definitions/base_incremental_stream"
     $options:
       name: "order_slip"
       path: "/order_slip"
@@ -281,56 +281,56 @@ definitions:
       primary_key: "id"
       cursor_field: "date_upd"
   order_states_stream:
-    $ref: "*ref(definitions.base_stream)"
+    $ref: "#/definitions/base_stream"
     $options:
       name: "order_states"
       path: "/order_states"
       data_key: "order_states"
       primary_key: "id"
   price_ranges_stream:
-    $ref: "*ref(definitions.base_stream)"
+    $ref: "#/definitions/base_stream"
     $options:
       name: "price_ranges"
       path: "/price_ranges"
       data_key: "price_ranges"
       primary_key: "id"
   product_customization_fields_stream:
-    $ref: "*ref(definitions.base_stream)"
+    $ref: "#/definitions/base_stream"
     $options:
       name: "product_customization_fields"
       path: "/product_customization_fields"
       data_key: "customization_fields"
       primary_key: "id"
   product_features_stream:
-    $ref: "*ref(definitions.base_stream)"
+    $ref: "#/definitions/base_stream"
     $options:
       name: "product_features"
       path: "/product_features"
       data_key: "product_features"
       primary_key: "id"
   product_feature_values_stream:
-    $ref: "*ref(definitions.base_stream)"
+    $ref: "#/definitions/base_stream"
     $options:
       name: "product_feature_values"
       path: "/product_feature_values"
       data_key: "product_feature_values"
       primary_key: "id"
   product_options_stream:
-    $ref: "*ref(definitions.base_stream)"
+    $ref: "#/definitions/base_stream"
     $options:
       name: "product_options"
       path: "/product_options"
       data_key: "product_options"
       primary_key: "id"
   product_option_values_stream:
-    $ref: "*ref(definitions.base_stream)"
+    $ref: "#/definitions/base_stream"
     $options:
       name: "product_option_values"
       path: "/product_option_values"
       data_key: "product_option_values"
       primary_key: "id"
   products_stream:
-    $ref: "*ref(definitions.base_incremental_stream)"
+    $ref: "#/definitions/base_incremental_stream"
     $options:
       name: "products"
       path: "/products"
@@ -338,63 +338,63 @@ definitions:
       primary_key: "id"
       cursor_field: "date_upd"
   product_suppliers_stream:
-    $ref: "*ref(definitions.base_stream)"
+    $ref: "#/definitions/base_stream"
     $options:
       name: "product_suppliers"
       path: "/product_suppliers"
       data_key: "product_suppliers"
       primary_key: "id"
   shop_groups_stream:
-    $ref: "*ref(definitions.base_stream)"
+    $ref: "#/definitions/base_stream"
     $options:
       name: "shop_groups"
       path: "/shop_groups"
       data_key: "shop_groups"
       primary_key: "id"
   shops_stream:
-    $ref: "*ref(definitions.base_stream)"
+    $ref: "#/definitions/base_stream"
     $options:
       name: "shops"
       path: "/shops"
       data_key: "shops"
       primary_key: "id"
   shop_urls_stream:
-    $ref: "*ref(definitions.base_stream)"
+    $ref: "#/definitions/base_stream"
     $options:
       name: "shop_urls"
       path: "/shop_urls"
       data_key: "shop_urls"
       primary_key: "id"
   specific_price_rules_stream:
-    $ref: "*ref(definitions.base_stream)"
+    $ref: "#/definitions/base_stream"
     $options:
       name: "specific_price_rules"
       path: "/specific_price_rules"
       data_key: "specific_price_rules"
       primary_key: "id"
   specific_prices_stream:
-    $ref: "*ref(definitions.base_stream)"
+    $ref: "#/definitions/base_stream"
     $options:
       name: "specific_prices"
       path: "/specific_prices"
       data_key: "specific_prices"
       primary_key: "id"
   states_stream:
-    $ref: "*ref(definitions.base_stream)"
+    $ref: "#/definitions/base_stream"
     $options:
       name: "states"
       path: "/states"
       data_key: "states"
       primary_key: "id"
   stock_availables_stream:
-    $ref: "*ref(definitions.base_stream)"
+    $ref: "#/definitions/base_stream"
     $options:
       name: "stock_availables"
       path: "/stock_availables"
       data_key: "stock_availables"
       primary_key: "id"
   stock_movement_reasons_stream:
-    $ref: "*ref(definitions.base_incremental_stream)"
+    $ref: "#/definitions/base_incremental_stream"
     $options:
       name: "stock_movement_reasons"
       path: "/stock_movement_reasons"
@@ -402,7 +402,7 @@ definitions:
       primary_key: "id"
       cursor_field: "date_upd"
   stock_movements_stream:
-    $ref: "*ref(definitions.base_incremental_stream)"
+    $ref: "#/definitions/base_incremental_stream"
     stream_cursor_field: "date_add"
     $options:
       name: "stock_movements"
@@ -411,7 +411,7 @@ definitions:
       primary_key: "id"
       cursor_field: "date_add"
   stores_stream:
-    $ref: "*ref(definitions.base_incremental_stream)"
+    $ref: "#/definitions/base_incremental_stream"
     $options:
       name: "stores"
       path: "/stores"
@@ -419,7 +419,7 @@ definitions:
       primary_key: "id"
       cursor_field: "date_upd"
   suppliers_stream:
-    $ref: "*ref(definitions.base_incremental_stream)"
+    $ref: "#/definitions/base_incremental_stream"
     $options:
       name: "suppliers"
       path: "/suppliers"
@@ -427,21 +427,21 @@ definitions:
       primary_key: "id"
       cursor_field: "date_upd"
   tags_stream:
-    $ref: "*ref(definitions.base_stream)"
+    $ref: "#/definitions/base_stream"
     $options:
       name: "tags"
       path: "/tags"
       data_key: "tags"
       primary_key: "id"
   taxes_stream:
-    $ref: "*ref(definitions.base_stream)"
+    $ref: "#/definitions/base_stream"
     $options:
       name: "taxes"
       path: "/taxes"
       data_key: "taxes"
       primary_key: "id"
   tax_rule_groups_stream:
-    $ref: "*ref(definitions.base_incremental_stream)"
+    $ref: "#/definitions/base_incremental_stream"
     $options:
       name: "tax_rule_groups"
       path: "/tax_rule_groups"
@@ -449,28 +449,28 @@ definitions:
       primary_key: "id"
       cursor_field: "date_upd"
   tax_rules_stream:
-    $ref: "*ref(definitions.base_stream)"
+    $ref: "#/definitions/base_stream"
     $options:
       name: "tax_rules"
       path: "/tax_rules"
       data_key: "tax_rules"
       primary_key: "id"
   translated_configurations_stream:
-    $ref: "*ref(definitions.base_stream)"
+    $ref: "#/definitions/base_stream"
     $options:
       name: "translated_configurations"
       path: "/translated_configurations"
       data_key: "translated_configurations"
       primary_key: "id"
   weight_ranges_stream:
-    $ref: "*ref(definitions.base_stream)"
+    $ref: "#/definitions/base_stream"
     $options:
       name: "weight_ranges"
       path: "/weight_ranges"
       data_key: "weight_ranges"
       primary_key: "id"
   zones_stream:
-    $ref: "*ref(definitions.base_stream)"
+    $ref: "#/definitions/base_stream"
     $options:
       name: "zones"
       path: "/zones"
@@ -478,62 +478,62 @@ definitions:
       primary_key: "id"
 
 streams:
-  - "*ref(definitions.addresses_stream)"
-  - "*ref(definitions.carriers_stream)"
-  - "*ref(definitions.cart_rules_stream)"
-  - "*ref(definitions.carts_stream)"
-  - "*ref(definitions.categories_stream)"
-  - "*ref(definitions.combinations_stream)"
-  - "*ref(definitions.configurations_stream)"
-  - "*ref(definitions.contacts_stream)"
-  - "*ref(definitions.content_management_system_stream)"
-  - "*ref(definitions.countries_stream)"
-  - "*ref(definitions.currencies_stream)"
-  - "*ref(definitions.customer_messages_stream)"
-  - "*ref(definitions.customers_stream)"
-  - "*ref(definitions.customer_threads_stream)"
-  - "*ref(definitions.deliveries_stream)"
-  - "*ref(definitions.employees_stream)"
-  - "*ref(definitions.groups_stream)"
-  - "*ref(definitions.guests_stream)"
-  - "*ref(definitions.image_types_stream)"
-  - "*ref(definitions.languages_stream)"
-  - "*ref(definitions.manufacturers_stream)"
-  - "*ref(definitions.messages_stream)"
-  - "*ref(definitions.order_carriers_stream)"
-  - "*ref(definitions.order_details_stream)"
-  - "*ref(definitions.order_histories_stream)"
-  - "*ref(definitions.order_invoices_stream)"
-  - "*ref(definitions.order_payments_stream)"
-  - "*ref(definitions.orders_stream)"
-  - "*ref(definitions.order_slip_stream)"
-  - "*ref(definitions.order_states_stream)"
-  - "*ref(definitions.price_ranges_stream)"
-  - "*ref(definitions.product_customization_fields_stream)"
-  - "*ref(definitions.product_features_stream)"
-  - "*ref(definitions.product_feature_values_stream)"
-  - "*ref(definitions.product_options_stream)"
-  - "*ref(definitions.product_option_values_stream)"
-  - "*ref(definitions.products_stream)"
-  - "*ref(definitions.product_suppliers_stream)"
-  - "*ref(definitions.shop_groups_stream)"
-  - "*ref(definitions.shops_stream)"
-  - "*ref(definitions.shop_urls_stream)"
-  - "*ref(definitions.specific_price_rules_stream)"
-  - "*ref(definitions.specific_prices_stream)"
-  - "*ref(definitions.states_stream)"
-  - "*ref(definitions.stock_availables_stream)"
-  - "*ref(definitions.stock_movement_reasons_stream)"
-  - "*ref(definitions.stock_movements_stream)"
-  - "*ref(definitions.stores_stream)"
-  - "*ref(definitions.suppliers_stream)"
-  - "*ref(definitions.tags_stream)"
-  - "*ref(definitions.taxes_stream)"
-  - "*ref(definitions.tax_rule_groups_stream)"
-  - "*ref(definitions.tax_rules_stream)"
-  - "*ref(definitions.translated_configurations_stream)"
-  - "*ref(definitions.weight_ranges_stream)"
-  - "*ref(definitions.zones_stream)"
+  - "#/definitions/addresses_stream"
+  - "#/definitions/carriers_stream"
+  - "#/definitions/cart_rules_stream"
+  - "#/definitions/carts_stream"
+  - "#/definitions/categories_stream"
+  - "#/definitions/combinations_stream"
+  - "#/definitions/configurations_stream"
+  - "#/definitions/contacts_stream"
+  - "#/definitions/content_management_system_stream"
+  - "#/definitions/countries_stream"
+  - "#/definitions/currencies_stream"
+  - "#/definitions/customer_messages_stream"
+  - "#/definitions/customers_stream"
+  - "#/definitions/customer_threads_stream"
+  - "#/definitions/deliveries_stream"
+  - "#/definitions/employees_stream"
+  - "#/definitions/groups_stream"
+  - "#/definitions/guests_stream"
+  - "#/definitions/image_types_stream"
+  - "#/definitions/languages_stream"
+  - "#/definitions/manufacturers_stream"
+  - "#/definitions/messages_stream"
+  - "#/definitions/order_carriers_stream"
+  - "#/definitions/order_details_stream"
+  - "#/definitions/order_histories_stream"
+  - "#/definitions/order_invoices_stream"
+  - "#/definitions/order_payments_stream"
+  - "#/definitions/orders_stream"
+  - "#/definitions/order_slip_stream"
+  - "#/definitions/order_states_stream"
+  - "#/definitions/price_ranges_stream"
+  - "#/definitions/product_customization_fields_stream"
+  - "#/definitions/product_features_stream"
+  - "#/definitions/product_feature_values_stream"
+  - "#/definitions/product_options_stream"
+  - "#/definitions/product_option_values_stream"
+  - "#/definitions/products_stream"
+  - "#/definitions/product_suppliers_stream"
+  - "#/definitions/shop_groups_stream"
+  - "#/definitions/shops_stream"
+  - "#/definitions/shop_urls_stream"
+  - "#/definitions/specific_price_rules_stream"
+  - "#/definitions/specific_prices_stream"
+  - "#/definitions/states_stream"
+  - "#/definitions/stock_availables_stream"
+  - "#/definitions/stock_movement_reasons_stream"
+  - "#/definitions/stock_movements_stream"
+  - "#/definitions/stores_stream"
+  - "#/definitions/suppliers_stream"
+  - "#/definitions/tags_stream"
+  - "#/definitions/taxes_stream"
+  - "#/definitions/tax_rule_groups_stream"
+  - "#/definitions/tax_rules_stream"
+  - "#/definitions/translated_configurations_stream"
+  - "#/definitions/weight_ranges_stream"
+  - "#/definitions/zones_stream"
 
 check:
   stream_names:

--- a/airbyte-integrations/connectors/source-punk-api/source_punk_api/punk_api.yaml
+++ b/airbyte-integrations/connectors/source-punk-api/source_punk_api/punk_api.yaml
@@ -36,20 +36,20 @@ definitions:
 
   retriever:
     record_selector:
-      $ref: "*ref(definitions.selector)"
+      $ref: "#/definitions/selector"
     paginator:
       type: NoPagination
     requester:
-      $ref: "*ref(definitions.requester)"
+      $ref: "#/definitions/requester"
     # stream_slicer:
-    #   $ref: "*ref(definitions.stream_slicer)"
+    #   $ref: "#/definitions/stream_slicer"
 
   base_stream:
     schema_loader:
       type: JsonSchema
       file_path: "./source_punk_api/schemas/{{ options['name'] }}.json"
     retriever:
-      $ref: "*ref(definitions.retriever)"
+      $ref: "#/definitions/retriever"
 
   page_stream:
     schema_loader:
@@ -57,10 +57,10 @@ definitions:
       file_path: "./source_punk_api/schemas/{{ options['name'] }}.json"
     retriever:
       record_selector:
-        $ref: "*ref(definitions.selector)"
+        $ref: "#/definitions/selector"
       paginator:
         type: "DefaultPaginator"
-        url_base: "*ref(definitions.requester.url_base)"
+        url_base: "#/definitions/requester/url_base"
         pagination_strategy:
           type: "PageIncrement"
           page_size: 25
@@ -71,23 +71,23 @@ definitions:
           inject_into: "request_parameter"
           field_name: "per_page"
       requester:
-        $ref: "*ref(definitions.requester)"
+        $ref: "#/definitions/requester"
 
   beers_stream:
-    $ref: "*ref(definitions.page_stream)"
+    $ref: "#/definitions/page_stream"
     $options:
       name: "beers"
       path: "/beers"
 
   beers_with_id_stream:
-    $ref: "*ref(definitions.page_stream)"
+    $ref: "#/definitions/page_stream"
     $options:
       name: "beers_with_id"
       path: "/beers?{{ config['brewed_after'] }}"
 
 streams:
-  - "*ref(definitions.beers_stream)"
-  - "*ref(definitions.beers_with_id_stream)"
+  - "#/definitions/beers_stream"
+  - "#/definitions/beers_with_id_stream"
 
 check:
   stream_names:

--- a/airbyte-integrations/connectors/source-pypi/source_pypi/pypi.yaml
+++ b/airbyte-integrations/connectors/source-pypi/source_pypi/pypi.yaml
@@ -15,39 +15,39 @@ definitions:
       Accept: "application/json"
   retriever:
     record_selector:
-      $ref: "*ref(definitions.selector)"
+      $ref: "#/definitions/selector"
     paginator:
       type: NoPagination
     requester:
-      $ref: "*ref(definitions.requester)"
+      $ref: "#/definitions/requester"
   base_stream:
     schema_loader:
-      $ref: "*ref(definitions.schema_loader)"
+      $ref: "#/definitions/schema_loader"
     retriever:
-      $ref: "*ref(definitions.retriever)"
+      $ref: "#/definitions/retriever"
 
   project_stream:
-    $ref: "*ref(definitions.base_stream)"
+    $ref: "#/definitions/base_stream"
     $options:
       name: "project"
       path: "/pypi/{{ config['project_name'] }}/json"
 
   release_stream:
-    $ref: "*ref(definitions.base_stream)"
+    $ref: "#/definitions/base_stream"
     $options:
       name: "release"
       path: "/pypi/{{ config['project_name'] }}/{{ config['version'] }}/json"
 
   stats_stream:
-    $ref: "*ref(definitions.base_stream)"
+    $ref: "#/definitions/base_stream"
     $options:
       name: "stats"
       path: "/stats"
 
 streams:
-  - "*ref(definitions.project_stream)"
-  - "*ref(definitions.release_stream)"
-  - "*ref(definitions.stats_stream)"
+  - "#/definitions/project_stream"
+  - "#/definitions/release_stream"
+  - "#/definitions/stats_stream"
 
 check:
   stream_names:

--- a/airbyte-integrations/connectors/source-recreation/source_recreation/recreation.yaml
+++ b/airbyte-integrations/connectors/source-recreation/source_recreation/recreation.yaml
@@ -20,11 +20,11 @@ definitions:
 
   retriever:
     record_selector:
-      $ref: "*ref(definitions.selector)"
+      $ref: "#/definitions/selector"
     paginator:
       type: "DefaultPaginator"
       $options:
-        url_base: "*ref(definitions.requester.url_base)"
+        url_base: "#/definitions/requester/url_base"
       page_size_option:
         inject_into: "request_parameter"
         field_name: "limit"
@@ -35,109 +35,109 @@ definitions:
         field_name: "offset"
         inject_into: "request_parameter"
     requester:
-      $ref: "*ref(definitions.requester)"
+      $ref: "#/definitions/requester"
 
   base_stream:
     retriever:
-      $ref: "*ref(definitions.retriever)"
+      $ref: "#/definitions/retriever"
 
   activity_stream:
-    $ref: "*ref(definitions.base_stream)"
+    $ref: "#/definitions/base_stream"
     $options:
       name: "activities"
       primary_key: "ActivityID"
       path: "/activities"
 
   campsites_stream:
-    $ref: "*ref(definitions.base_stream)"
+    $ref: "#/definitions/base_stream"
     $options:
       name: "campsites"
       primary_key: "CampsiteID"
       path: "/campsites"
 
   events_stream:
-    $ref: "*ref(definitions.base_stream)"
+    $ref: "#/definitions/base_stream"
     $options:
       name: "events"
       primary_key: "EventID"
       path: "/events"
 
   facilities_stream:
-    $ref: "*ref(definitions.base_stream)"
+    $ref: "#/definitions/base_stream"
     $options:
       name: "facilities"
       primary_key: "FacilityID"
       path: "/facilities"
 
   facilityaddresses_stream:
-    $ref: "*ref(definitions.base_stream)"
+    $ref: "#/definitions/base_stream"
     $options:
       name: "facilityaddresses"
       primary_key: "FacilityAddressID"
       path: "/facilityaddresses"
 
   links_stream:
-    $ref: "*ref(definitions.base_stream)"
+    $ref: "#/definitions/base_stream"
     $options:
       name: "links"
       primary_key: "EntityLinkID"
       path: "/links"
 
   media_stream:
-    $ref: "*ref(definitions.base_stream)"
+    $ref: "#/definitions/base_stream"
     $options:
       name: "media"
       primary_key: "EntityMediaID"
       path: "/media"
 
   organizations_stream:
-    $ref: "*ref(definitions.base_stream)"
+    $ref: "#/definitions/base_stream"
     $options:
       name: "organizations"
       primary_key: "OrgID"
       path: "/organizations"
 
   permits_stream:
-    $ref: "*ref(definitions.base_stream)"
+    $ref: "#/definitions/base_stream"
     $options:
       name: "permits"
       primary_key: "PermitEntranceID"
       path: "/permits"
 
   recreationareas_stream:
-    $ref: "*ref(definitions.base_stream)"
+    $ref: "#/definitions/base_stream"
     $options:
       name: "recreationareas"
       primary_key: "RecAreaID"
       path: "/recareas"
 
   recreationareaaddresses_stream:
-    $ref: "*ref(definitions.base_stream)"
+    $ref: "#/definitions/base_stream"
     $options:
       name: "recreationareaaddresses"
       primary_key: "RecAreaAddressID"
       path: "/recareaaddresses"
 
   tours_stream:
-    $ref: "*ref(definitions.base_stream)"
+    $ref: "#/definitions/base_stream"
     $options:
       name: "tours"
       primary_key: "TourID"
       path: "/tours"
 
 streams:
-  - "*ref(definitions.organizations_stream)"
-  - "*ref(definitions.media_stream)"
-  - "*ref(definitions.links_stream)"
-  - "*ref(definitions.facilityaddresses_stream)"
-  - "*ref(definitions.facilities_stream)"
-  - "*ref(definitions.events_stream)"
-  - "*ref(definitions.activity_stream)"
-  - "*ref(definitions.campsites_stream)"
-  - "*ref(definitions.permits_stream)"
-  - "*ref(definitions.recreationareaaddresses_stream)"
-  - "*ref(definitions.recreationareas_stream)"
-  - "*ref(definitions.tours_stream)"
+  - "#/definitions/organizations_stream"
+  - "#/definitions/media_stream"
+  - "#/definitions/links_stream"
+  - "#/definitions/facilityaddresses_stream"
+  - "#/definitions/facilities_stream"
+  - "#/definitions/events_stream"
+  - "#/definitions/activity_stream"
+  - "#/definitions/campsites_stream"
+  - "#/definitions/permits_stream"
+  - "#/definitions/recreationareaaddresses_stream"
+  - "#/definitions/recreationareas_stream"
+  - "#/definitions/tours_stream"
 
 check:
   stream_names:

--- a/airbyte-integrations/connectors/source-recruitee/source_recruitee/recruitee.yaml
+++ b/airbyte-integrations/connectors/source-recruitee/source_recruitee/recruitee.yaml
@@ -16,38 +16,38 @@ definitions:
       api_token: "{{ config['api_key'] }}"
   retriever:
     record_selector:
-      $ref: "*ref(definitions.selector)"
+      $ref: "#/definitions/selector"
     paginator:
       type: NoPagination
     requester:
-      $ref: "*ref(definitions.requester)"
+      $ref: "#/definitions/requester"
     primary_key: "id"
   base_stream:
     retriever:
-      $ref: "*ref(definitions.retriever)"
+      $ref: "#/definitions/retriever"
   candidates_stream:
     # Docs: https://docs.recruitee.com/reference/candidates-get
-    $ref: "*ref(definitions.base_stream)"
+    $ref: "#/definitions/base_stream"
     $options:
       name: "candidates"
       path: "/candidates"
   offers_stream:
     # Docs: https://docs.recruitee.com/reference/offers-get
-    $ref: "*ref(definitions.base_stream)"
+    $ref: "#/definitions/base_stream"
     $options:
       name: "offers"
       path: "/offers"
   departments_stream:
     # Docs: https://docs.recruitee.com/reference/departments-get
-    $ref: "*ref(definitions.base_stream)"
+    $ref: "#/definitions/base_stream"
     $options:
       name: "departments"
       path: "/departments"
 
 streams:
-  - "*ref(definitions.candidates_stream)"
-  - "*ref(definitions.offers_stream)"
-  - "*ref(definitions.departments_stream)"
+  - "#/definitions/candidates_stream"
+  - "#/definitions/offers_stream"
+  - "#/definitions/departments_stream"
 
 check:
   stream_names:

--- a/airbyte-integrations/connectors/source-reply-io/source_reply_io/reply_io.yaml
+++ b/airbyte-integrations/connectors/source-reply-io/source_reply_io/reply_io.yaml
@@ -20,18 +20,18 @@ definitions:
               backoff_time_in_seconds: 15
   retriever:
     record_selector:
-      $ref: "*ref(definitions.selector)"
+      $ref: "#/definitions/selector"
     paginator:
       type: NoPagination
     requester:
-      $ref: "*ref(definitions.requester)"
+      $ref: "#/definitions/requester"
 
   base_stream:
     retriever:
-      $ref: "*ref(definitions.retriever)"
+      $ref: "#/definitions/retriever"
   paginated_stream:
     retriever:
-      $ref: "*ref(definitions.retriever)"
+      $ref: "#/definitions/retriever"
       record_selector:
         extractor:
           field_pointer: ["{{ options.name }}"]
@@ -47,29 +47,29 @@ definitions:
           inject_into: "request_parameter"
           field_name: "page"
         url_base:
-          $ref: "*ref(definitions.requester.url_base)"
+          $ref: "#/definitions/requester/url_base"
 
   campaigns_stream:
-    $ref: "*ref(definitions.base_stream)"
+    $ref: "#/definitions/base_stream"
     $options:
       name: "campaigns"
       primary_key: "id"
       path: "/campaigns"
   email_accounts_stream:
-    $ref: "*ref(definitions.base_stream)"
+    $ref: "#/definitions/base_stream"
     $options:
       name: "email_accounts"
       primary_key: "id"
       path: "/emailAccounts"
   people_stream:
-    $ref: "*ref(definitions.paginated_stream)"
+    $ref: "#/definitions/paginated_stream"
     $options:
       name: "people"
       primary_key: "id"
       path: "/people"
   templates_stream:
     retriever:
-      $ref: "*ref(definitions.base_stream.retriever)"
+      $ref: "#/definitions/base_stream/retriever"
       record_selector:
         extractor:
           field_pointer: ["userTemplates"]
@@ -79,10 +79,10 @@ definitions:
       path: "/templates"
 
 streams:
-  - "*ref(definitions.campaigns_stream)"
-  - "*ref(definitions.email_accounts_stream)"
-  - "*ref(definitions.people_stream)"
-  - "*ref(definitions.templates_stream)"
+  - "#/definitions/campaigns_stream"
+  - "#/definitions/email_accounts_stream"
+  - "#/definitions/people_stream"
+  - "#/definitions/templates_stream"
 
 check:
   stream_names:

--- a/airbyte-integrations/connectors/source-rocket-chat/source_rocket_chat/rocket_chat.yaml
+++ b/airbyte-integrations/connectors/source-rocket-chat/source_rocket_chat/rocket_chat.yaml
@@ -21,7 +21,7 @@ definitions:
   offset_paginator:
     type: DefaultPaginator
     $options:
-      url_base: "*ref(definitions.requester.url_base)"
+      url_base: "#/definitions/requester/url_base"
       page_size: 1
     page_size_option:
       inject_into: "request_parameter"
@@ -33,76 +33,76 @@ definitions:
       type: "OffsetIncrement"
   custom_retriever:
     record_selector:
-      $ref: "*ref(definitions.update_selector)"
+      $ref: "#/definitions/update_selector"
     paginator:
       type: NoPagination
     requester:
-      $ref: "*ref(definitions.requester)"
+      $ref: "#/definitions/requester"
   retriever:
     record_selector:
-      $ref: "*ref(definitions.selector)"
+      $ref: "#/definitions/selector"
     paginator:
-      $ref: "*ref(definitions.offset_paginator)"
+      $ref: "#/definitions/offset_paginator"
     requester:
-      $ref: "*ref(definitions.requester)"
+      $ref: "#/definitions/requester"
   base_stream:
     retriever:
-      $ref: "*ref(definitions.retriever)"
+      $ref: "#/definitions/retriever"
   teams_stream:
-    $ref: "*ref(definitions.base_stream)"
+    $ref: "#/definitions/base_stream"
     $options:
       name: "teams"
       primary_key: "_id"
       path: "/teams.list"
   rooms_stream:
-    $ref: "*ref(definitions.base_stream)"
+    $ref: "#/definitions/base_stream"
     retriever:
-      $ref: "*ref(definitions.custom_retriever)"
+      $ref: "#/definitions/custom_retriever"
     $options:
       name: "rooms"
       primary_key: "_id"
       path: "/rooms.get"
   channels_stream:
-    $ref: "*ref(definitions.base_stream)"
+    $ref: "#/definitions/base_stream"
     $options:
       name: "channels"
       primary_key: "_id"
       path: "/channels.list"
   roles_stream:
-    $ref: "*ref(definitions.base_stream)"
+    $ref: "#/definitions/base_stream"
     retriever:
       record_selector:
-        $ref: "*ref(definitions.selector)"
+        $ref: "#/definitions/selector"
       paginator:
         type: NoPagination
       requester:
-        $ref: "*ref(definitions.requester)"
+        $ref: "#/definitions/requester"
     $options:
       name: "roles"
       primary_key: "_id"
       path: "/roles.list"
   subscriptions_stream:
-    $ref: "*ref(definitions.base_stream)"
+    $ref: "#/definitions/base_stream"
     retriever:
-      $ref: "*ref(definitions.custom_retriever)"
+      $ref: "#/definitions/custom_retriever"
     $options:
       name: "subscriptions"
       primary_key: "_id"
       path: "/subscriptions.get"
   users_stream:
-    $ref: "*ref(definitions.base_stream)"
+    $ref: "#/definitions/base_stream"
     $options:
       name: "users"
       primary_key: "_id"
       path: "/users.list"
 
 streams:
-  - "*ref(definitions.teams_stream)"
-  - "*ref(definitions.rooms_stream)"
-  - "*ref(definitions.channels_stream)"
-  - "*ref(definitions.roles_stream)"
-  - "*ref(definitions.subscriptions_stream)"
-  - "*ref(definitions.users_stream)"
+  - "#/definitions/teams_stream"
+  - "#/definitions/rooms_stream"
+  - "#/definitions/channels_stream"
+  - "#/definitions/roles_stream"
+  - "#/definitions/subscriptions_stream"
+  - "#/definitions/users_stream"
 
 check:
   stream_names:

--- a/airbyte-integrations/connectors/source-sap-fieldglass/source_sap_fieldglass/sap_fieldglass.yaml
+++ b/airbyte-integrations/connectors/source-sap-fieldglass/source_sap_fieldglass/sap_fieldglass.yaml
@@ -16,22 +16,22 @@ definitions:
         base: "{{ config['base'] }}"
   retriever:
     record_selector:
-      $ref: "*ref(definitions.selector)"
+      $ref: "#/definitions/selector"
     paginator:
       type: NoPagination
     requester:
-      $ref: "*ref(definitions.requester)"
+      $ref: "#/definitions/requester"
   base_stream:
     retriever:
-      $ref: "*ref(definitions.retriever)"
+      $ref: "#/definitions/retriever"
   data_stream:
-    $ref: "*ref(definitions.base_stream)"
+    $ref: "#/definitions/base_stream"
     $options:
       name: "data"
       path: "/Active Worker Download"
 
 streams:
-  - "*ref(definitions.data_stream)"
+  - "#/definitions/data_stream"
 
 check:
   stream_names:

--- a/airbyte-integrations/connectors/source-secoda/source_secoda/secoda.yaml
+++ b/airbyte-integrations/connectors/source-secoda/source_secoda/secoda.yaml
@@ -19,7 +19,7 @@ definitions:
           action: FAIL
   cursor_paginator:
     type: DefaultPaginator
-    url_base: "*ref(definitions.requester.url_base)"
+    url_base: "#/definitions/requester/url_base"
     page_token_option:
       inject_into: path
     page_size_option:
@@ -32,37 +32,37 @@ definitions:
       page_size: 1
   retriever:
     record_selector:
-      $ref: "*ref(definitions.selector)"
+      $ref: "#/definitions/selector"
     paginator:
-      $ref: "*ref(definitions.cursor_paginator)"
+      $ref: "#/definitions/cursor_paginator"
     requester:
-      $ref: "*ref(definitions.requester)"
+      $ref: "#/definitions/requester"
   base_stream:
     retriever:
-      $ref: "*ref(definitions.retriever)"
+      $ref: "#/definitions/retriever"
   tables_stream:
-    $ref: "*ref(definitions.base_stream)"
+    $ref: "#/definitions/base_stream"
     $options:
       name: "tables"
       primary_key: "id"
       path: "/table/tables/"
   terms_stream:
-    $ref: "*ref(definitions.base_stream)"
+    $ref: "#/definitions/base_stream"
     $options:
       name: "terms"
       primary_key: "id"
       path: "/dictionary/terms/"
   collections_stream:
-    $ref: "*ref(definitions.base_stream)"
+    $ref: "#/definitions/base_stream"
     $options:
       name: "collections"
       primary_key: "id"
       path: "/collection/collections/"
 
 streams:
-  - "*ref(definitions.tables_stream)"
-  - "*ref(definitions.terms_stream)"
-  - "*ref(definitions.collections_stream)"
+  - "#/definitions/tables_stream"
+  - "#/definitions/terms_stream"
+  - "#/definitions/collections_stream"
 
 check:
   stream_names:

--- a/airbyte-integrations/connectors/source-sendgrid/source_sendgrid/sendgrid.yaml
+++ b/airbyte-integrations/connectors/source-sendgrid/source_sendgrid/sendgrid.yaml
@@ -17,8 +17,8 @@ definitions:
       api_token: "{{ config.apikey }}"
   cursor_paginator:
     type: DefaultPaginator
-    url_base: "*ref(definitions.requester.url_base)"
-    page_size: "*ref(definitions.page_size)"
+    url_base: "#/definitions/requester/url_base"
+    page_size: "#/definitions/page_size"
     limit_option:
       inject_into: "request_parameter"
       field_name: "page_size"
@@ -30,8 +30,8 @@ definitions:
   offset_paginator:
     type: DefaultPaginator
     $options:
-      url_base: "*ref(definitions.requester.url_base)"
-      page_size: "*ref(definitions.page_size)"
+      url_base: "#/definitions/requester/url_base"
+      page_size: "#/definitions/page_size"
     limit_option:
       inject_into: "request_parameter"
       field_name: "limit"
@@ -52,7 +52,7 @@ definitions:
     end_datetime:
       datetime: "{{ now_utc() }}"
       datetime_format: "%Y-%m-%d %H:%M:%S.%f%z"
-    step: "*ref(definitions.step)"
+    step: "#/definitions/step"
     cursor_field: "{{ options.stream_cursor_field }}"
     start_time_option:
       field_name: "start_time"
@@ -70,7 +70,7 @@ definitions:
     end_datetime:
       datetime: "{{ now_utc() }}"
       datetime_format: "%Y-%m-%d %H:%M:%S.%f%z"
-    step: "*ref(definitions.step)"
+    step: "#/definitions/step"
     cursor_field: "{{ options.stream_cursor_field }}"
     datetime_format: "%Y-%m-%dT%H:%M:%S.%f%z"
     cursor_granularity: "PT0.000001S"
@@ -78,84 +78,84 @@ definitions:
   base_stream:
     type: DeclarativeStream
     schema_loader:
-      $ref: "*ref(definitions.schema_loader)"
+      $ref: "#/definitions/schema_loader"
     retriever:
-      $ref: "*ref(definitions.retriever)"
+      $ref: "#/definitions/retriever"
       record_selector:
         extractor:
           field_pointer: []
       requester:
-        $ref: "*ref(definitions.requester)"
+        $ref: "#/definitions/requester"
       paginator:
         type: NoPagination
 streams:
-  - $ref: "*ref(definitions.base_stream)"
+  - $ref: "#/definitions/base_stream"
     $options:
       name: "lists"
       primary_key: "id"
       path: "/v3/marketing/lists"
       field_pointer: ["result"]
     retriever:
-      $ref: "*ref(definitions.base_stream.retriever)"
+      $ref: "#/definitions/base_stream/retriever"
       paginator:
-        $ref: "*ref(definitions.cursor_paginator)"
-  - $ref: "*ref(definitions.base_stream)"
+        $ref: "#/definitions/cursor_paginator"
+  - $ref: "#/definitions/base_stream"
     $options:
       name: "campaigns"
       primary_key: "id"
       path: "/v3/marketing/campaigns"
       field_pointer: ["result"]
     retriever:
-      $ref: "*ref(definitions.base_stream.retriever)"
+      $ref: "#/definitions/base_stream/retriever"
       paginator:
-        $ref: "*ref(definitions.cursor_paginator)"
-  - $ref: "*ref(definitions.base_stream)"
+        $ref: "#/definitions/cursor_paginator"
+  - $ref: "#/definitions/base_stream"
     $options:
       name: "contacts"
       primary_key: "id"
       path: "/v3/marketing/contacts"
       field_pointer: ["result"]
-  - $ref: "*ref(definitions.base_stream)"
+  - $ref: "#/definitions/base_stream"
     $options:
       name: "stats_automations"
       primary_key: "id"
       path: "/v3/marketing/stats/automations"
       field_pointer: ["results"]
     retriever:
-      $ref: "*ref(definitions.base_stream.retriever)"
+      $ref: "#/definitions/base_stream/retriever"
       paginator:
-        $ref: "*ref(definitions.cursor_paginator)"
-  - $ref: "*ref(definitions.base_stream)"
+        $ref: "#/definitions/cursor_paginator"
+  - $ref: "#/definitions/base_stream"
     $options:
       name: "segments"
       primary_key: "id"
       path: "/v3/marketing/segments"
       field_pointer: ["results"]
-  - $ref: "*ref(definitions.base_stream)"
+  - $ref: "#/definitions/base_stream"
     $options:
       name: "single_sends"
       primary_key: "id"
       path: "/v3/marketing/stats/singlesends"
       field_pointer: ["results"]
     retriever:
-      $ref: "*ref(definitions.base_stream.retriever)"
+      $ref: "#/definitions/base_stream/retriever"
       paginator:
-        $ref: "*ref(definitions.cursor_paginator)"
-  - $ref: "*ref(definitions.base_stream)"
+        $ref: "#/definitions/cursor_paginator"
+  - $ref: "#/definitions/base_stream"
     $options:
       name: "templates"
       primary_key: "id"
       path: "/v3/templates"
       field_pointer: ["result"]
     retriever:
-      $ref: "*ref(definitions.base_stream.retriever)"
+      $ref: "#/definitions/base_stream/retriever"
       requester:
-        $ref: "*ref(definitions.base_stream.retriever.requester)"
+        $ref: "#/definitions/base_stream/retriever/requester"
         request_parameters:
           generations: "legacy,dynamic"
       paginator:
-        $ref: "*ref(definitions.cursor_paginator)"
-  - $ref: "*ref(definitions.base_stream)"
+        $ref: "#/definitions/cursor_paginator"
+  - $ref: "#/definitions/base_stream"
     $options:
       name: "bounces"
       primary_key: "email"
@@ -163,12 +163,12 @@ streams:
       path: "/v3/suppression/bounces"
       field_pointer: []
     retriever:
-      $ref: "*ref(definitions.base_stream.retriever)"
+      $ref: "#/definitions/base_stream/retriever"
       paginator:
-        $ref: "*ref(definitions.offset_paginator)"
+        $ref: "#/definitions/offset_paginator"
       stream_slicer:
-        $ref: "*ref(definitions.stream_slicer)"
-  - $ref: "*ref(definitions.base_stream)"
+        $ref: "#/definitions/stream_slicer"
+  - $ref: "#/definitions/base_stream"
     $options:
       name: "global_suppressions"
       primary_key: "email"
@@ -176,12 +176,12 @@ streams:
       path: "/v3/suppression/unsubscribes"
       field_pointer: []
     retriever:
-      $ref: "*ref(definitions.base_stream.retriever)"
+      $ref: "#/definitions/base_stream/retriever"
       paginator:
-        $ref: "*ref(definitions.offset_paginator)"
+        $ref: "#/definitions/offset_paginator"
       stream_slicer:
-        $ref: "*ref(definitions.stream_slicer)"
-  - $ref: "*ref(definitions.base_stream)"
+        $ref: "#/definitions/stream_slicer"
+  - $ref: "#/definitions/base_stream"
     $options:
       name: "blocks"
       primary_key: "email"
@@ -189,28 +189,28 @@ streams:
       path: "/v3/suppression/blocks"
       field_pointer: []
     retriever:
-      $ref: "*ref(definitions.base_stream.retriever)"
+      $ref: "#/definitions/base_stream/retriever"
       paginator:
-        $ref: "*ref(definitions.offset_paginator)"
+        $ref: "#/definitions/offset_paginator"
       stream_slicer:
-        $ref: "*ref(definitions.stream_slicer)"
-  - $ref: "*ref(definitions.base_stream)"
+        $ref: "#/definitions/stream_slicer"
+  - $ref: "#/definitions/base_stream"
     $options:
       name: "suppression_groups"
       primary_key: "id"
       path: "/v3/asm/groups"
       field_pointer: []
-  - $ref: "*ref(definitions.base_stream)"
+  - $ref: "#/definitions/base_stream"
     $options:
       name: "suppression_group_members"
       primary_key: "group_id"
       path: "/v3/asm/suppressions"
       field_pointer: []
     retriever:
-      $ref: "*ref(definitions.base_stream.retriever)"
+      $ref: "#/definitions/base_stream/retriever"
       paginator:
-        $ref: "*ref(definitions.offset_paginator)"
-  - $ref: "*ref(definitions.base_stream)"
+        $ref: "#/definitions/offset_paginator"
+  - $ref: "#/definitions/base_stream"
     $options:
       name: "invalid_emails"
       primary_key: "email"
@@ -218,12 +218,12 @@ streams:
       path: "/v3/suppression/invalid_emails"
       field_pointer: []
     retriever:
-      $ref: "*ref(definitions.base_stream.retriever)"
+      $ref: "#/definitions/base_stream/retriever"
       paginator:
-        $ref: "*ref(definitions.offset_paginator)"
+        $ref: "#/definitions/offset_paginator"
       stream_slicer:
-        $ref: "*ref(definitions.stream_slicer)"
-  - $ref: "*ref(definitions.base_stream)"
+        $ref: "#/definitions/stream_slicer"
+  - $ref: "#/definitions/base_stream"
     $options:
       name: "spam_reports"
       primary_key: "email"
@@ -231,12 +231,12 @@ streams:
       path: "/v3/suppression/spam_reports"
       field_pointer: []
     retriever:
-      $ref: "*ref(definitions.base_stream.retriever)"
+      $ref: "#/definitions/base_stream/retriever"
       paginator:
-        $ref: "*ref(definitions.offset_paginator)"
+        $ref: "#/definitions/offset_paginator"
       stream_slicer:
-        $ref: "*ref(definitions.stream_slicer)"
-  - $ref: "*ref(definitions.base_stream)"
+        $ref: "#/definitions/stream_slicer"
+  - $ref: "#/definitions/base_stream"
     $options:
       name: "messages"
       primary_key: "msg_id"
@@ -244,14 +244,14 @@ streams:
       path: "/v3/messages"
       field_pointer: []
     retriever:
-      $ref: "*ref(definitions.base_stream.retriever)"
+      $ref: "#/definitions/base_stream/retriever"
       requester:
-        $ref: "*ref(definitions.requester)"
+        $ref: "#/definitions/requester"
         request_parameters:
           limit: "1000"
           query: 'last_event_time BETWEEN TIMESTAMP "{{stream_slice.start_time}}" AND TIMESTAMP "{{stream_slice.end_time}}"'
       stream_slicer:
-        $ref: "*ref(definitions.messages_stream_slicer)"
+        $ref: "#/definitions/messages_stream_slicer"
 check:
   type: CheckStream
   stream_names: ["lists"]

--- a/airbyte-integrations/connectors/source-sendinblue/source_sendinblue/sendinblue.yaml
+++ b/airbyte-integrations/connectors/source-sendinblue/source_sendinblue/sendinblue.yaml
@@ -14,7 +14,7 @@ definitions:
   offset_paginator:
     type: DefaultPaginator
     $options:
-      url_base: "*ref(definitions.requester.url_base)"
+      url_base: "#/definitions/requester/url_base"
     pagination_strategy:
       type: "OffsetIncrement"
       page_size: 100
@@ -26,16 +26,16 @@ definitions:
       field_name: "limit"
   retriever:
     record_selector:
-      $ref: "*ref(definitions.selector)"
+      $ref: "#/definitions/selector"
     paginator:
-      $ref: "*ref(definitions.offset_paginator)"
+      $ref: "#/definitions/offset_paginator"
     requester:
-      $ref: "*ref(definitions.requester)"
+      $ref: "#/definitions/requester"
   base_stream:
     retriever:
-      $ref: "*ref(definitions.retriever)"
+      $ref: "#/definitions/retriever"
   campaigns_stream:
-    $ref: "*ref(definitions.base_stream)"
+    $ref: "#/definitions/base_stream"
     $options:
       name: "campaigns"
       primary_key: "id"
@@ -43,26 +43,26 @@ definitions:
   campaign_stream_slicer:
     type: SubstreamSlicer
     parent_stream_configs:
-      - stream: "*ref(definitions.campaigns_stream)"
+      - stream: "#/definitions/campaigns_stream"
         parent_key: id
         stream_slice_field: campaign_id
   templates_stream:
-    $ref: "*ref(definitions.base_stream)"
+    $ref: "#/definitions/base_stream"
     $options:
       name: templates
       primary_key: id
       path: "/smtp/templates"
   contacts_stream:
-    $ref: "*ref(definitions.base_stream)"
+    $ref: "#/definitions/base_stream"
     $options:
       name: contacts
       primary_key: id
       path: "/contacts"
 
 streams:
-  - "*ref(definitions.campaigns_stream)"
-  - "*ref(definitions.templates_stream)"
-  - "*ref(definitions.contacts_stream)"
+  - "#/definitions/campaigns_stream"
+  - "#/definitions/templates_stream"
+  - "#/definitions/contacts_stream"
 
 check:
   stream_names:

--- a/airbyte-integrations/connectors/source-senseforce/source_senseforce/senseforce.yaml
+++ b/airbyte-integrations/connectors/source-senseforce/source_senseforce/senseforce.yaml
@@ -37,10 +37,10 @@ definitions:
 
   retriever:
     record_selector:
-      $ref: "*ref(definitions.selector)"
+      $ref: "#/definitions/selector"
     paginator:
       type: DefaultPaginator
-      url_base: "*ref(definitions.requester.url_base)"
+      url_base: "#/definitions/requester/url_base"
       page_size_option:
         inject_into: "request_parameter"
         field_name: "limit"
@@ -51,15 +51,15 @@ definitions:
         field_name: "offset"
         inject_into: "request_parameter"
     stream_slicer:
-      $ref: "*ref(definitions.stream_slicer)"
+      $ref: "#/definitions/stream_slicer"
     requester:
-      $ref: "*ref(definitions.requester)"
+      $ref: "#/definitions/requester"
 
   base_stream:
     retriever:
-      $ref: "*ref(definitions.retriever)"
+      $ref: "#/definitions/retriever"
   dataset_stream:
-    $ref: "*ref(definitions.base_stream)"
+    $ref: "#/definitions/base_stream"
     $options:
       name: "dataset"
       primary_key:
@@ -73,7 +73,7 @@ definitions:
             value: "{{ record['timestamp'] | int / 1000 }}"
 
 streams:
-  - "*ref(definitions.dataset_stream)"
+  - "#/definitions/dataset_stream"
 
 check:
   stream_names:

--- a/airbyte-integrations/connectors/source-sentry/source_sentry/sentry.yaml
+++ b/airbyte-integrations/connectors/source-sentry/source_sentry/sentry.yaml
@@ -19,8 +19,8 @@ definitions:
       api_token: "{{ config.auth_token }}"
   paginator:
     type: DefaultPaginator
-    url_base: "*ref(definitions.requester.url_base)"
-    page_size: "*ref(definitions.page_size)"
+    url_base: "#/definitions/requester/url_base"
+    page_size: "#/definitions/page_size"
     limit_option:
       inject_into: "request_parameter"
       field_name: ""
@@ -43,63 +43,63 @@ streams:
       name: "events"
     primary_key: "id"
     schema_loader:
-      $ref: "*ref(definitions.schema_loader)"
+      $ref: "#/definitions/schema_loader"
     retriever:
-      $ref: "*ref(definitions.retriever)"
+      $ref: "#/definitions/retriever"
       record_selector:
-        $ref: "*ref(definitions.selector)"
+        $ref: "#/definitions/selector"
       requester:
-        $ref: "*ref(definitions.requester)"
+        $ref: "#/definitions/requester"
         path: "projects/{{config.organization}}/{{config.project}}/events/"
         request_parameters:
           full: "true"
       paginator:
-        $ref: "*ref(definitions.paginator)"
+        $ref: "#/definitions/paginator"
   - type: DeclarativeStream
     $options:
       name: "issues"
     primary_key: "id"
     schema_loader:
-      $ref: "*ref(definitions.schema_loader)"
+      $ref: "#/definitions/schema_loader"
     retriever:
-      $ref: "*ref(definitions.retriever)"
+      $ref: "#/definitions/retriever"
       record_selector:
-        $ref: "*ref(definitions.selector)"
+        $ref: "#/definitions/selector"
       requester:
-        $ref: "*ref(definitions.requester)"
+        $ref: "#/definitions/requester"
         path: "projects/{{config.organization}}/{{config.project}}/issues/"
         request_parameters:
           statsPeriod: ""
           query: ""
       paginator:
-        $ref: "*ref(definitions.paginator)"
+        $ref: "#/definitions/paginator"
   - type: DeclarativeStream
     $options:
       name: "projects"
     primary_key: "id"
     schema_loader:
-      $ref: "*ref(definitions.schema_loader)"
+      $ref: "#/definitions/schema_loader"
     retriever:
-      $ref: "*ref(definitions.retriever)"
+      $ref: "#/definitions/retriever"
       record_selector:
-        $ref: "*ref(definitions.selector)"
+        $ref: "#/definitions/selector"
       requester:
-        $ref: "*ref(definitions.requester)"
+        $ref: "#/definitions/requester"
         path: "projects/"
       paginator:
-        $ref: "*ref(definitions.paginator)"
+        $ref: "#/definitions/paginator"
   - type: DeclarativeStream
     $options:
       name: "project_detail"
     primary_key: "id"
     schema_loader:
-      $ref: "*ref(definitions.schema_loader)"
+      $ref: "#/definitions/schema_loader"
     retriever:
-      $ref: "*ref(definitions.retriever)"
+      $ref: "#/definitions/retriever"
       record_selector:
-        $ref: "*ref(definitions.selector)"
+        $ref: "#/definitions/selector"
       requester:
-        $ref: "*ref(definitions.requester)"
+        $ref: "#/definitions/requester"
         path: "projects/{{config.organization}}/{{config.project}}/"
       paginator:
         type: NoPagination

--- a/airbyte-integrations/connectors/source-smaily/source_smaily/smaily.yaml
+++ b/airbyte-integrations/connectors/source-smaily/source_smaily/smaily.yaml
@@ -13,7 +13,7 @@ definitions:
       password: "{{config['api_password']}}"
   increment_paginator:
     type: DefaultPaginator
-    url_base: "*ref(definitions.requester.url_base)"
+    url_base: "#/definitions/requester/url_base"
     page_size_option:
       inject_into: "request_parameter"
       field_name: "limit"
@@ -25,75 +25,75 @@ definitions:
       field_name: "page"
   retriever:
     record_selector:
-      $ref: "*ref(definitions.selector)"
+      $ref: "#/definitions/selector"
     paginator:
       type: NoPagination
     requester:
-      $ref: "*ref(definitions.requester)"
+      $ref: "#/definitions/requester"
   base_stream:
     retriever:
-      $ref: "*ref(definitions.retriever)"
+      $ref: "#/definitions/retriever"
   # API Docs: https://smaily.com/help/api/organizations/list-users-of-an-organization/
   users_stream:
-    $ref: "*ref(definitions.base_stream)"
+    $ref: "#/definitions/base_stream"
     $options:
       name: "users"
       primary_key: "id"
       path: "/organizations/users.php"
     retriever:
-      $ref: "*ref(definitions.retriever)"
+      $ref: "#/definitions/retriever"
       paginator:
-        $ref: "*ref(definitions.increment_paginator)"
+        $ref: "#/definitions/increment_paginator"
   # API Docs: https://smaily.com/help/api/segments/list-segments/
   segments_stream:
-    $ref: "*ref(definitions.base_stream)"
+    $ref: "#/definitions/base_stream"
     $options:
       name: "segments"
       primary_key: "id"
       path: "/list.php"
   # API Docs: https://smaily.com/help/api/campaigns-3/list-campaigns/
   campaigns_stream:
-    $ref: "*ref(definitions.base_stream)"
+    $ref: "#/definitions/base_stream"
     $options:
       name: "campaigns"
       primary_key: "id"
       path: "/campaign.php"
   # API Docs: https://smaily.com/help/api/templates-2/list-templates/
   templates_stream:
-    $ref: "*ref(definitions.base_stream)"
+    $ref: "#/definitions/base_stream"
     $options:
       name: "templates"
       primary_key: "id"
       path: "/templates.php"
     retriever:
-      $ref: "*ref(definitions.retriever)"
+      $ref: "#/definitions/retriever"
       paginator:
-        $ref: "*ref(definitions.increment_paginator)"
+        $ref: "#/definitions/increment_paginator"
         pagination_strategy:
           type: PageIncrement
           page_size: 1000
   # API Docs: https://smaily.com/help/api/automations-2/list-automation-workflows/
   automations_stream:
-    $ref: "*ref(definitions.base_stream)"
+    $ref: "#/definitions/base_stream"
     $options:
       name: "automations"
       primary_key: "id"
       path: "/autoresponder.php"
   # API Docs: https://smaily.com/help/api/a-b-tests/list-a-b-tests/
   ab_tests_stream:
-    $ref: "*ref(definitions.base_stream)"
+    $ref: "#/definitions/base_stream"
     $options:
       name: "ab_tests"
       primary_key: "id"
       path: "/split.php"
 
 streams:
-  - "*ref(definitions.users_stream)"
-  - "*ref(definitions.segments_stream)"
-  - "*ref(definitions.campaigns_stream)"
-  - "*ref(definitions.templates_stream)"
-  - "*ref(definitions.automations_stream)"
-  - "*ref(definitions.ab_tests_stream)"
+  - "#/definitions/users_stream"
+  - "#/definitions/segments_stream"
+  - "#/definitions/campaigns_stream"
+  - "#/definitions/templates_stream"
+  - "#/definitions/automations_stream"
+  - "#/definitions/ab_tests_stream"
 
 check:
   stream_names: ["users"]

--- a/airbyte-integrations/connectors/source-smartengage/source_smartengage/smartengage.yaml
+++ b/airbyte-integrations/connectors/source-smartengage/source_smartengage/smartengage.yaml
@@ -13,17 +13,17 @@ definitions:
       api_token: "{{ config['api_key'] }}"
   retriever:
     record_selector:
-      $ref: "*ref(definitions.selector)"
+      $ref: "#/definitions/selector"
     paginator:
       type: NoPagination
     requester:
-      $ref: "*ref(definitions.requester)"
+      $ref: "#/definitions/requester"
   base_stream:
     retriever:
-      $ref: "*ref(definitions.retriever)"
+      $ref: "#/definitions/retriever"
   # API Docs: https://smartengage.com/docs/#list-all-avatars
   avatars_stream:
-    $ref: "*ref(definitions.base_stream)"
+    $ref: "#/definitions/base_stream"
     $options:
       name: "avatars"
       primary_key: "avatar_id"
@@ -31,60 +31,60 @@ definitions:
   avatars_stream_slicer:
     type: SubstreamSlicer
     parent_stream_configs:
-      - stream: "*ref(definitions.avatars_stream)"
+      - stream: "#/definitions/avatars_stream"
         parent_key: "avatar_id"
         stream_slice_field: "avatar_id"
   # API Docs: https://smartengage.com/docs/#list-all-tags
   tags_stream:
-    $ref: "*ref(definitions.base_stream)"
+    $ref: "#/definitions/base_stream"
     $options:
       name: "tags"
       primary_key: "tag_id"
       path: "/tags/list"
     retriever:
-      $ref: "*ref(definitions.retriever)"
+      $ref: "#/definitions/retriever"
       requester:
-        $ref: "*ref(definitions.requester)"
+        $ref: "#/definitions/requester"
         request_parameters:
           avatar_id: "{{ stream_slice.avatar_id }}"
       stream_slicer:
-        $ref: "*ref(definitions.avatars_stream_slicer)"
+        $ref: "#/definitions/avatars_stream_slicer"
   # API Docs: https://smartengage.com/docs/#list-all-custom-fields
   custom_fields_stream:
-    $ref: "*ref(definitions.base_stream)"
+    $ref: "#/definitions/base_stream"
     $options:
       name: "custom_fields"
       primary_key: "custom_field_id"
       path: "/customfields/list"
     retriever:
-      $ref: "*ref(definitions.retriever)"
+      $ref: "#/definitions/retriever"
       requester:
-        $ref: "*ref(definitions.requester)"
+        $ref: "#/definitions/requester"
         request_parameters:
           avatar_id: "{{ stream_slice.avatar_id }}"
       stream_slicer:
-        $ref: "*ref(definitions.avatars_stream_slicer)"
+        $ref: "#/definitions/avatars_stream_slicer"
   # API Docs: https://smartengage.com/docs/#list-all-sequences
   sequences_stream:
-    $ref: "*ref(definitions.base_stream)"
+    $ref: "#/definitions/base_stream"
     $options:
       name: "sequences"
       primary_key: "sequence_id"
       path: "/sequences/list"
     retriever:
-      $ref: "*ref(definitions.retriever)"
+      $ref: "#/definitions/retriever"
       requester:
-        $ref: "*ref(definitions.requester)"
+        $ref: "#/definitions/requester"
         request_parameters:
           avatar_id: "{{ stream_slice.avatar_id }}"
       stream_slicer:
-        $ref: "*ref(definitions.avatars_stream_slicer)"
+        $ref: "#/definitions/avatars_stream_slicer"
 
 streams:
-  - "*ref(definitions.avatars_stream)"
-  - "*ref(definitions.tags_stream)"
-  - "*ref(definitions.custom_fields_stream)"
-  - "*ref(definitions.sequences_stream)"
+  - "#/definitions/avatars_stream"
+  - "#/definitions/tags_stream"
+  - "#/definitions/custom_fields_stream"
+  - "#/definitions/sequences_stream"
 
 check:
   stream_names: ["tags"]

--- a/airbyte-integrations/connectors/source-sonar-cloud/source_sonar_cloud/sonar_cloud.yaml
+++ b/airbyte-integrations/connectors/source-sonar-cloud/source_sonar_cloud/sonar_cloud.yaml
@@ -17,7 +17,7 @@ definitions:
       api_token: "{{ config['user_token'] }}"
   increment_paginator:
     type: "DefaultPaginator"
-    url_base: "*ref(definitions.requester.url_base)"
+    url_base: "#/definitions/requester/url_base"
     page_size_option:
       inject_into: "request_parameter"
       field_name: "ps"
@@ -29,37 +29,37 @@ definitions:
       field_name: "p"
   retriever:
     record_selector:
-      $ref: "*ref(definitions.selector)"
+      $ref: "#/definitions/selector"
     paginator:
-      $ref: "*ref(definitions.increment_paginator)"
+      $ref: "#/definitions/increment_paginator"
     requester:
-      $ref: "*ref(definitions.requester)"
+      $ref: "#/definitions/requester"
   base_stream:
     retriever:
-      $ref: "*ref(definitions.retriever)"
+      $ref: "#/definitions/retriever"
   components_stream:
-    $ref: "*ref(definitions.base_stream)"
+    $ref: "#/definitions/base_stream"
     $options:
       name: "components"
       primary_key: "key"
       path: "/components/search"
   issues_stream:
-    $ref: "*ref(definitions.base_stream)"
+    $ref: "#/definitions/base_stream"
     $options:
       name: "issues"
       primary_key: "key"
       path: "/issues/search?componentKeys={{ ','.join(config.get('component_keys', [])) }}"
   metrics_stream:
-    $ref: "*ref(definitions.base_stream)"
+    $ref: "#/definitions/base_stream"
     $options:
       name: "metrics"
       primary_key: "id"
       path: "/metrics/search"
 
 streams:
-  - "*ref(definitions.components_stream)"
-  - "*ref(definitions.issues_stream)"
-  - "*ref(definitions.metrics_stream)"
+  - "#/definitions/components_stream"
+  - "#/definitions/issues_stream"
+  - "#/definitions/metrics_stream"
 
 check:
   stream_names:

--- a/airbyte-integrations/connectors/source-spacex-api/source_spacex_api/spacex_api.yaml
+++ b/airbyte-integrations/connectors/source-spacex-api/source_spacex_api/spacex_api.yaml
@@ -11,124 +11,124 @@ definitions:
 
   retriever:
     record_selector:
-      $ref: "*ref(definitions.selector)"
+      $ref: "#/definitions/selector"
     paginator:
       type: NoPagination
     requester:
-      $ref: "*ref(definitions.requester)"
+      $ref: "#/definitions/requester"
 
   base_stream:
     schema_loader:
       type: JsonSchema
       file_path: "./source_spacex_api/schemas/{{ options['name'] }}.json"
     retriever:
-      $ref: "*ref(definitions.retriever)"
+      $ref: "#/definitions/retriever"
 
   launches_stream:
-    $ref: "*ref(definitions.base_stream)"
+    $ref: "#/definitions/base_stream"
     $options:
       name: "launches"
       primary_key: "id"
       path: "/launches/{{config['options'] or config['id'] or latest}}"
 
   capsules_stream:
-    $ref: "*ref(definitions.base_stream)"
+    $ref: "#/definitions/base_stream"
     $options:
       name: "capsules"
       primary_key: "id"
       path: "/capsules"
 
   company_stream:
-    $ref: "*ref(definitions.base_stream)"
+    $ref: "#/definitions/base_stream"
     $options:
       name: "company"
       primary_key: "id"
       path: "/company"
 
   crew_stream:
-    $ref: "*ref(definitions.base_stream)"
+    $ref: "#/definitions/base_stream"
     $options:
       name: "crew"
       primary_key: "id"
       path: "/crew"
 
   cores_stream:
-    $ref: "*ref(definitions.base_stream)"
+    $ref: "#/definitions/base_stream"
     $options:
       name: "cores"
       primary_key: "id"
       path: "/cores"
 
   dragons_stream:
-    $ref: "*ref(definitions.base_stream)"
+    $ref: "#/definitions/base_stream"
     $options:
       name: "dragons"
       primary_key: "id"
       path: "/dragons"
 
   landpads_stream:
-    $ref: "*ref(definitions.base_stream)"
+    $ref: "#/definitions/base_stream"
     $options:
       name: "landpads"
       primary_key: "id"
       path: "/landpads"
 
   payloads_stream:
-    $ref: "*ref(definitions.base_stream)"
+    $ref: "#/definitions/base_stream"
     $options:
       name: "payloads"
       primary_key: "id"
       path: "/payloads"
 
   history_stream:
-    $ref: "*ref(definitions.base_stream)"
+    $ref: "#/definitions/base_stream"
     $options:
       name: "history"
       primary_key: "id"
       path: "/history"
 
   rockets_stream:
-    $ref: "*ref(definitions.base_stream)"
+    $ref: "#/definitions/base_stream"
     $options:
       name: "rockets"
       primary_key: "id"
       path: "/rockets"
 
   roadster_stream:
-    $ref: "*ref(definitions.base_stream)"
+    $ref: "#/definitions/base_stream"
     $options:
       name: "roadster"
       primary_key: "id"
       path: "/roadster"
 
   ships_stream:
-    $ref: "*ref(definitions.base_stream)"
+    $ref: "#/definitions/base_stream"
     $options:
       name: "ships"
       primary_key: "id"
       path: "/ships"
 
   starlink_stream:
-    $ref: "*ref(definitions.base_stream)"
+    $ref: "#/definitions/base_stream"
     $options:
       name: "starlink"
       primary_key: "id"
       path: "/starlink"
 
 streams:
-  - "*ref(definitions.launches_stream)"
-  - "*ref(definitions.capsules_stream)"
-  - "*ref(definitions.company_stream)"
-  - "*ref(definitions.crew_stream)"
-  - "*ref(definitions.cores_stream)"
-  - "*ref(definitions.dragons_stream)"
-  - "*ref(definitions.landpads_stream)"
-  - "*ref(definitions.payloads_stream)"
-  - "*ref(definitions.history_stream)"
-  - "*ref(definitions.rockets_stream)"
-  - "*ref(definitions.roadster_stream)"
-  - "*ref(definitions.ships_stream)"
-  - "*ref(definitions.starlink_stream)"
+  - "#/definitions/launches_stream"
+  - "#/definitions/capsules_stream"
+  - "#/definitions/company_stream"
+  - "#/definitions/crew_stream"
+  - "#/definitions/cores_stream"
+  - "#/definitions/dragons_stream"
+  - "#/definitions/landpads_stream"
+  - "#/definitions/payloads_stream"
+  - "#/definitions/history_stream"
+  - "#/definitions/rockets_stream"
+  - "#/definitions/roadster_stream"
+  - "#/definitions/ships_stream"
+  - "#/definitions/starlink_stream"
 
 check:
   stream_names:

--- a/airbyte-integrations/connectors/source-square/source_square/square.yaml
+++ b/airbyte-integrations/connectors/source-square/source_square/square.yaml
@@ -24,22 +24,22 @@ definitions:
     http_method: "GET"
     authenticator:
       class_name: source_square.components.AuthenticatorSquare
-      bearer: "*ref(definitions.bearer_authenticator)"
-      oauth: "*ref(definitions.oauth_authenticator)"
+      bearer: "#/definitions/bearer_authenticator"
+      oauth: "#/definitions/oauth_authenticator"
 
     request_headers:
       Square-Version: "2022-10-19"
       Content-Type: "application/json"
   retriever:
     record_selector:
-      $ref: "*ref(definitions.selector)"
+      $ref: "#/definitions/selector"
     requester:
-      $ref: "*ref(definitions.requester)"
+      $ref: "#/definitions/requester"
 
   base_stream:
     type: DeclarativeStream
     retriever:
-      $ref: "*ref(definitions.retriever)"
+      $ref: "#/definitions/retriever"
       paginator:
         type: DefaultPaginator
         pagination_strategy:
@@ -54,21 +54,21 @@ definitions:
           inject_into: "request_parameter"
           field_name: "cursor"
         url_base:
-          $ref: "*ref(definitions.requester.url_base)"
+          $ref: "#/definitions/requester/url_base"
 
   base_incremental_stream:
     $options:
       stream_cursor_field: "created_at"
     retriever:
-      $ref: "*ref(definitions.retriever)"
+      $ref: "#/definitions/retriever"
       requester:
-        $ref: "*ref(definitions.requester)"
+        $ref: "#/definitions/requester"
         request_body_json:
           sort_order: "ASC"
           sort_field: "CREATED_AT"
       paginator:
         type: DefaultPaginator
-        url_base: "*ref(definitions.requester.url_base)"
+        url_base: "#/definitions/requester/url_base"
         pagination_strategy:
           page_size: 100
           type: "CursorPagination"
@@ -96,18 +96,18 @@ definitions:
           field_name: begin_time
           inject_into: body_json
   base_catalog_objects_stream:
-    $ref: "*ref(definitions.base_incremental_stream)"
+    $ref: "#/definitions/base_incremental_stream"
     stream_cursor_field: "updated_at"
     $options:
       primary_key: "id"
       path: "/catalog/search"
     retriever:
-      $ref: "*ref(definitions.retriever)"
+      $ref: "#/definitions/retriever"
       record_selector:
         extractor:
           field_pointer: ["objects"]
       requester:
-        $ref: "*ref(definitions.requester)"
+        $ref: "#/definitions/requester"
         http_method: "POST"
         request_body_json:
           include_related_objects: "{{ False }}"
@@ -115,7 +115,7 @@ definitions:
           object_types: "{{ [options['object_type']] }}"
       paginator:
         type: DefaultPaginator
-        url_base: "*ref(definitions.requester.url_base)"
+        url_base: "#/definitions/requester/url_base"
         pagination_strategy:
           page_size: 1000
           type: "CursorPagination"
@@ -144,33 +144,33 @@ definitions:
           inject_into: body_json
   base_stream_page_json_limit:
     retriever:
-      $ref: "*ref(definitions.retriever)"
+      $ref: "#/definitions/retriever"
       requester:
-        $ref: "*ref(definitions.requester)"
+        $ref: "#/definitions/requester"
         http_method: "POST"
 
   customers_stream:
-    $ref: "*ref(definitions.base_stream)"
+    $ref: "#/definitions/base_stream"
     $options:
       name: "customers"
       primary_key: "id"
       path: "/customers"
     retriever:
-      $ref: "*ref(definitions.retriever)"
+      $ref: "#/definitions/retriever"
       requester:
-        $ref: "*ref(definitions.requester)"
+        $ref: "#/definitions/requester"
         request_parameters:
           sort_order: ASC
           sort_field: CREATED_AT
 
   shifts_stream:
-    $ref: "*ref(definitions.base_stream_page_json_limit)"
+    $ref: "#/definitions/base_stream_page_json_limit"
     $options:
       name: "shifts"
       primary_key: "id"
       path: "labor/shifts/search"
     retriever:
-      $ref: "*ref(definitions.base_stream_page_json_limit.retriever)"
+      $ref: "#/definitions/base_stream_page_json_limit/retriever"
       paginator:
         pagination_strategy:
           page_size: 200
@@ -179,22 +179,22 @@ definitions:
           field_name: "limit"
 
   team_members_stream:
-    $ref: "*ref(definitions.base_stream_page_json_limit)"
+    $ref: "#/definitions/base_stream_page_json_limit"
     $options:
       name: "team_members"
       primary_key: "id"
       path: "/team-members/search"
 
   team_member_wages_stream:
-    $ref: "*ref(definitions.base_stream)"
+    $ref: "#/definitions/base_stream"
     $options:
       name: "team_member_wages"
       primary_key: "id"
       path: "/labor/team-member-wages"
     retriever:
-      $ref: "*ref(definitions.retriever)"
+      $ref: "#/definitions/retriever"
       requester:
-        $ref: "*ref(definitions.requester)"
+        $ref: "#/definitions/requester"
         request_parameters:
           sort_order: ASC
           sort_field: CREATED_AT
@@ -202,75 +202,75 @@ definitions:
         pagination_strategy:
           page_size: 200
   locations_stream:
-    $ref: "*ref(definitions.base_stream)"
+    $ref: "#/definitions/base_stream"
     $options:
       name: "locations"
       primary_key: "id"
       path: "/locations"
 
   categories_stream:
-    $ref: "*ref(definitions.base_catalog_objects_stream)"
+    $ref: "#/definitions/base_catalog_objects_stream"
     $options:
       name: "categories"
       object_type: "CATEGORY"
       path: "/catalog/search"
 
   items_stream:
-    $ref: "*ref(definitions.base_catalog_objects_stream)"
+    $ref: "#/definitions/base_catalog_objects_stream"
     $options:
       name: "items"
       object_type: "ITEM"
       path: "/catalog/search"
 
   discounts_stream:
-    $ref: "*ref(definitions.base_catalog_objects_stream)"
+    $ref: "#/definitions/base_catalog_objects_stream"
     $options:
       name: "discounts"
       object_type: "DISCOUNT"
       path: "/catalog/search"
 
   taxes_stream:
-    $ref: "*ref(definitions.base_catalog_objects_stream)"
+    $ref: "#/definitions/base_catalog_objects_stream"
     $options:
       name: "taxes"
       object_type: "TAX"
       path: "/catalog/search"
 
   modifier_list_stream:
-    $ref: "*ref(definitions.base_catalog_objects_stream)"
+    $ref: "#/definitions/base_catalog_objects_stream"
     $options:
       name: "modifier_list"
       object_type: "MODIFIER_LIST"
       path: "/catalog/search"
 
   refunds_stream:
-    $ref: "*ref(definitions.base_incremental_stream)"
+    $ref: "#/definitions/base_incremental_stream"
     $options:
       name: "refunds"
       primary_key: "id"
       path: "/refunds"
     retriever:
-      $ref: "*ref(definitions.base_incremental_stream.retriever)"
+      $ref: "#/definitions/base_incremental_stream/retriever"
 
   payments_stream:
-    $ref: "*ref(definitions.base_incremental_stream)"
+    $ref: "#/definitions/base_incremental_stream"
     $options:
       name: "payments"
       primary_key: "id"
       path: "/payments"
     retriever:
-      $ref: "*ref(definitions.base_incremental_stream.retriever)"
+      $ref: "#/definitions/base_incremental_stream/retriever"
 
   orders_stream:
-    $ref: "*ref(definitions.base_stream_page_json_limit)"
+    $ref: "#/definitions/base_stream_page_json_limit"
     $options:
       name: "orders"
       primary_key: "id"
       path: "/orders/search"
     retriever:
-      $ref: "*ref(definitions.base_stream_page_json_limit.retriever)"
+      $ref: "#/definitions/base_stream_page_json_limit/retriever"
       requester:
-        $ref: "*ref(definitions.base_stream_page_json_limit.retriever.requester)"
+        $ref: "#/definitions/base_stream_page_json_limit/retriever/requester"
         http_method: "POST"
         request_body_json:
           limit: "{{ 500 }}"
@@ -285,24 +285,24 @@ definitions:
         step: P30D
         datetime_format: "%Y-%m-%dT%H:%M:%S.%fZ"
         cursor_granularity: "PT0.000001S"
-        parent_stream: "*ref(definitions.locations_stream)"
+        parent_stream: "#/definitions/locations_stream"
         cursor_field: "updated_at"
         parent_key: "id"
 
 streams:
-  - "*ref(definitions.customers_stream)"
-  - "*ref(definitions.locations_stream)"
-  - "*ref(definitions.shifts_stream)"
-  - "*ref(definitions.team_members_stream)"
-  - "*ref(definitions.team_member_wages_stream)"
-  - "*ref(definitions.items_stream)"
-  - "*ref(definitions.categories_stream)"
-  - "*ref(definitions.discounts_stream)"
-  - "*ref(definitions.taxes_stream)"
-  - "*ref(definitions.modifier_list_stream)"
-  - "*ref(definitions.refunds_stream)"
-  - "*ref(definitions.payments_stream)"
-  - "*ref(definitions.orders_stream)"
+  - "#/definitions/customers_stream"
+  - "#/definitions/locations_stream"
+  - "#/definitions/shifts_stream"
+  - "#/definitions/team_members_stream"
+  - "#/definitions/team_member_wages_stream"
+  - "#/definitions/items_stream"
+  - "#/definitions/categories_stream"
+  - "#/definitions/discounts_stream"
+  - "#/definitions/taxes_stream"
+  - "#/definitions/modifier_list_stream"
+  - "#/definitions/refunds_stream"
+  - "#/definitions/payments_stream"
+  - "#/definitions/orders_stream"
 
 check:
   stream_names:

--- a/airbyte-integrations/connectors/source-statuspage/source_statuspage/statuspage.yaml
+++ b/airbyte-integrations/connectors/source-statuspage/source_statuspage/statuspage.yaml
@@ -23,7 +23,7 @@ definitions:
   offset_paginator:
     type: DefaultPaginator
     $options:
-      url_base: "*ref(definitions.requester.url_base)"
+      url_base: "#/definitions/requester/url_base"
     pagination_strategy:
       type: "OffsetIncrement"
       page_size: 100
@@ -35,16 +35,16 @@ definitions:
       field_name: "limit"
   retriever:
     record_selector:
-      $ref: "*ref(definitions.selector)"
+      $ref: "#/definitions/selector"
     paginator:
-      $ref: "*ref(definitions.offset_paginator)"
+      $ref: "#/definitions/offset_paginator"
     requester:
-      $ref: "*ref(definitions.requester)"
+      $ref: "#/definitions/requester"
   base_stream:
     retriever:
-      $ref: "*ref(definitions.retriever)"
+      $ref: "#/definitions/retriever"
   pages_stream:
-    $ref: "*ref(definitions.base_stream)"
+    $ref: "#/definitions/base_stream"
     $options:
       name: "pages"
       primary_key: "id"
@@ -52,100 +52,100 @@ definitions:
   page_stream_slicer:
     type: SubstreamSlicer
     parent_stream_configs:
-      - stream: "*ref(definitions.pages_stream)"
+      - stream: "#/definitions/pages_stream"
         parent_key: id
         stream_slice_field: page_id
   subscribers_stream:
-    $ref: "*ref(definitions.base_stream)"
+    $ref: "#/definitions/base_stream"
     $options:
       name: "subscribers"
       primary_key: "id"
     retriever:
-      $ref: "*ref(definitions.retriever)"
+      $ref: "#/definitions/retriever"
       requester:
-        $ref: "*ref(definitions.requester)"
+        $ref: "#/definitions/requester"
         path: "/pages/{{ stream_slice.page_id }}/subscribers"
       stream_slicer:
-        $ref: "*ref(definitions.page_stream_slicer)"
+        $ref: "#/definitions/page_stream_slicer"
       record_selector:
-        $ref: "*ref(definitions.selector)"
+        $ref: "#/definitions/selector"
   subscribers_histogram_by_state_stream:
-    $ref: "*ref(definitions.base_stream)"
+    $ref: "#/definitions/base_stream"
     $options:
       name: "subscribers_histogram_by_state"
     retriever:
-      $ref: "*ref(definitions.retriever)"
+      $ref: "#/definitions/retriever"
       requester:
-        $ref: "*ref(definitions.requester)"
+        $ref: "#/definitions/requester"
         path: "/pages/{{ stream_slice.page_id }}/subscribers/histogram_by_state"
       stream_slicer:
-        $ref: "*ref(definitions.page_stream_slicer)"
+        $ref: "#/definitions/page_stream_slicer"
       record_selector:
-        $ref: "*ref(definitions.selector)"
+        $ref: "#/definitions/selector"
   incident_templates_stream:
-    $ref: "*ref(definitions.base_stream)"
+    $ref: "#/definitions/base_stream"
     $options:
       name: "incident_templates"
       primary_key: "id"
     retriever:
-      $ref: "*ref(definitions.retriever)"
+      $ref: "#/definitions/retriever"
       requester:
-        $ref: "*ref(definitions.requester)"
+        $ref: "#/definitions/requester"
         path: "/pages/{{ stream_slice.page_id }}/incident_templates"
       stream_slicer:
-        $ref: "*ref(definitions.page_stream_slicer)"
+        $ref: "#/definitions/page_stream_slicer"
       record_selector:
-        $ref: "*ref(definitions.selector)"
+        $ref: "#/definitions/selector"
   incidents_stream:
-    $ref: "*ref(definitions.base_stream)"
+    $ref: "#/definitions/base_stream"
     $options:
       name: "incidents"
       primary_key: "id"
     retriever:
-      $ref: "*ref(definitions.retriever)"
+      $ref: "#/definitions/retriever"
       requester:
-        $ref: "*ref(definitions.requester)"
+        $ref: "#/definitions/requester"
         path: "/pages/{{ stream_slice.page_id }}/incidents"
       stream_slicer:
-        $ref: "*ref(definitions.page_stream_slicer)"
+        $ref: "#/definitions/page_stream_slicer"
       record_selector:
-        $ref: "*ref(definitions.selector)"
+        $ref: "#/definitions/selector"
   components_stream:
-    $ref: "*ref(definitions.base_stream)"
+    $ref: "#/definitions/base_stream"
     $options:
       name: "components"
       primary_key: "id"
     retriever:
-      $ref: "*ref(definitions.retriever)"
+      $ref: "#/definitions/retriever"
       requester:
-        $ref: "*ref(definitions.requester)"
+        $ref: "#/definitions/requester"
         path: "/pages/{{ stream_slice.page_id }}/components"
       stream_slicer:
-        $ref: "*ref(definitions.page_stream_slicer)"
+        $ref: "#/definitions/page_stream_slicer"
       record_selector:
-        $ref: "*ref(definitions.selector)"
+        $ref: "#/definitions/selector"
   metrics_stream:
-    $ref: "*ref(definitions.base_stream)"
+    $ref: "#/definitions/base_stream"
     $options:
       name: "metrics"
       primary_key: "id"
     retriever:
-      $ref: "*ref(definitions.retriever)"
+      $ref: "#/definitions/retriever"
       requester:
-        $ref: "*ref(definitions.requester)"
+        $ref: "#/definitions/requester"
         path: "/pages/{{ stream_slice.page_id }}/metrics"
       stream_slicer:
-        $ref: "*ref(definitions.page_stream_slicer)"
+        $ref: "#/definitions/page_stream_slicer"
       record_selector:
-        $ref: "*ref(definitions.selector)"
+        $ref: "#/definitions/selector"
 streams:
-  - "*ref(definitions.pages_stream)"
-  - "*ref(definitions.subscribers_stream)"
-  - "*ref(definitions.subscribers_histogram_by_state_stream)"
-  - "*ref(definitions.incident_templates_stream)"
-  - "*ref(definitions.incidents_stream)"
-  - "*ref(definitions.components_stream)"
-  - "*ref(definitions.metrics_stream)"
+  - "#/definitions/pages_stream"
+  - "#/definitions/subscribers_stream"
+  - "#/definitions/subscribers_histogram_by_state_stream"
+  - "#/definitions/incident_templates_stream"
+  - "#/definitions/incidents_stream"
+  - "#/definitions/components_stream"
+  - "#/definitions/metrics_stream"
 check:
   stream_names:
     - "pages"

--- a/airbyte-integrations/connectors/source-survey-sparrow/source_survey_sparrow/survey_sparrow.yaml
+++ b/airbyte-integrations/connectors/source-survey-sparrow/source_survey_sparrow/survey_sparrow.yaml
@@ -13,7 +13,7 @@ definitions:
       api_token: "{{ config['access_token'] }}"
   retriever:
     record_selector:
-      $ref: "*ref(definitions.selector)"
+      $ref: "#/definitions/selector"
     paginator:
       type: "DefaultPaginator"
       page_size_option:
@@ -21,27 +21,27 @@ definitions:
         field_name: "limit"
       pagination_strategy:
         type: "PageIncrement"
-        page_size: "*ref(definitions.page_size)"
+        page_size: "#/definitions/page_size"
       page_token_option:
         inject_into: "request_parameter"
         field_name: "page"
-      url_base: "*ref(definitions.requester.url_base)"
+      url_base: "#/definitions/requester/url_base"
     requester:
-      $ref: "*ref(definitions.requester)"
+      $ref: "#/definitions/requester"
   base_stream:
     schema_loader:
       type: JsonSchema
       file_path: "./source_survey_sparrow/schemas/{{ options['name'] }}.json"
     retriever:
-      $ref: "*ref(definitions.retriever)"
+      $ref: "#/definitions/retriever"
   contacts_stream:
-    $ref: "*ref(definitions.base_stream)"
+    $ref: "#/definitions/base_stream"
     $options:
       name: "contacts"
       primary_key: "id"
       path: "/contacts"
   contact_lists_stream:
-    $ref: "*ref(definitions.base_stream)"
+    $ref: "#/definitions/base_stream"
     $options:
       name: "contact_lists"
       primary_key: "id"
@@ -49,13 +49,13 @@ definitions:
     paginator:
       type: "NoPagination"
   questions_stream:
-    $ref: "*ref(definitions.base_stream)"
+    $ref: "#/definitions/base_stream"
     $options:
       name: "questions"
       primary_key: "id"
       path: "/questions"
     retriever:
-      $ref: "*ref(definitions.base_stream.retriever)"
+      $ref: "#/definitions/base_stream/retriever"
       stream_slicer:
         type: "ListStreamSlicer"
         slice_values: "{{ config.get('survey_id') }}"
@@ -64,13 +64,13 @@ definitions:
           field_name: "survey_id"
           inject_into: "request_parameter"
   responses_stream:
-    $ref: "*ref(definitions.base_stream)"
+    $ref: "#/definitions/base_stream"
     $options:
       name: "responses"
       primary_key: "id"
       path: "/responses"
     retriever:
-      $ref: "*ref(definitions.base_stream.retriever)"
+      $ref: "#/definitions/base_stream/retriever"
       stream_slicer:
         type: "ListStreamSlicer"
         slice_values: "{{ config.get('survey_id') }}"
@@ -79,39 +79,39 @@ definitions:
           field_name: "survey_id"
           inject_into: "request_parameter"
   roles_stream:
-    $ref: "*ref(definitions.base_stream)"
+    $ref: "#/definitions/base_stream"
     $options:
       name: "roles"
       primary_key: "id"
       path: "/roles"
   surveys_stream:
-    $ref: "*ref(definitions.base_stream)"
+    $ref: "#/definitions/base_stream"
     $options:
       name: "surveys"
       primary_key: "id"
       path: "/surveys"
   survey_folders_stream:
-    $ref: "*ref(definitions.base_stream)"
+    $ref: "#/definitions/base_stream"
     $options:
       name: "survey_folders"
       primary_key: "id"
       path: "/survey_folders"
   users_stream:
-    $ref: "*ref(definitions.base_stream)"
+    $ref: "#/definitions/base_stream"
     $options:
       name: "users"
       primary_key: "id"
       path: "/users"
 
 streams:
-  - "*ref(definitions.contacts_stream)"
-  - "*ref(definitions.contact_lists_stream)"
-  - "*ref(definitions.questions_stream)"
-  - "*ref(definitions.responses_stream)"
-  - "*ref(definitions.roles_stream)"
-  - "*ref(definitions.surveys_stream)"
-  - "*ref(definitions.survey_folders_stream)"
-  - "*ref(definitions.users_stream)"
+  - "#/definitions/contacts_stream"
+  - "#/definitions/contact_lists_stream"
+  - "#/definitions/questions_stream"
+  - "#/definitions/responses_stream"
+  - "#/definitions/roles_stream"
+  - "#/definitions/surveys_stream"
+  - "#/definitions/survey_folders_stream"
+  - "#/definitions/users_stream"
 
 check:
   stream_names:

--- a/airbyte-integrations/connectors/source-tempo/source_tempo/tempo.yaml
+++ b/airbyte-integrations/connectors/source-tempo/source_tempo/tempo.yaml
@@ -27,7 +27,7 @@ definitions:
     type: SimpleRetriever
     name: "{{ options['name'] }}"
     record_selector:
-      $ref: "*ref(definitions.selector)"
+      $ref: "#/definitions/selector"
     paginator:
       type: DefaultPaginator
       pagination_strategy:
@@ -40,29 +40,29 @@ definitions:
         inject_into: "request_parameter"
       page_token_option:
         inject_into: "path"
-      url_base: "*ref(definitions.requester.url_base)"
+      url_base: "#/definitions/requester/url_base"
   base_stream:
     primary_key: "id"
     retriever:
-      $ref: "*ref(definitions.retriever)"
+      $ref: "#/definitions/retriever"
       requester:
-        $ref: "*ref(definitions.requester)"
+        $ref: "#/definitions/requester"
   accounts_stream:
-    $ref: "*ref(definitions.base_stream)"
+    $ref: "#/definitions/base_stream"
     $options:
       name: "accounts"
       path: "accounts"
   customers_stream:
-    $ref: "*ref(definitions.base_stream)"
+    $ref: "#/definitions/base_stream"
     $options:
       name: "customers"
       path: "customers"
   worklogs_stream:
-    $ref: "*ref(definitions.base_stream)"
+    $ref: "#/definitions/base_stream"
     stream_cursor_field: "startDate"
     retriever:
-      $ref: "*ref(definitions.retriever)"
-      requester: "*ref(definitions.requester)"
+      $ref: "#/definitions/retriever"
+      requester: "#/definitions/requester"
       stream_slicer:
         cursor_field: "startDate"
         datetime_format: "%Y-%m-%d"
@@ -86,16 +86,16 @@ definitions:
       path: "worklogs"
     primary_key: "tempoWorklogId"
   workload_schemes_stream:
-    $ref: "*ref(definitions.base_stream)"
+    $ref: "#/definitions/base_stream"
     $options:
       name: "workload-schemes"
       path: "workload-schemes"
 
 streams:
-  - "*ref(definitions.accounts_stream)"
-  - "*ref(definitions.customers_stream)"
-  - "*ref(definitions.worklogs_stream)"
-  - "*ref(definitions.workload_schemes_stream)"
+  - "#/definitions/accounts_stream"
+  - "#/definitions/customers_stream"
+  - "#/definitions/worklogs_stream"
+  - "#/definitions/workload_schemes_stream"
 
 check:
   type: CheckStream

--- a/airbyte-integrations/connectors/source-the-guardian-api/source_the_guardian_api/the_guardian_api.yaml
+++ b/airbyte-integrations/connectors/source-the-guardian-api/source_the_guardian_api/the_guardian_api.yaml
@@ -38,10 +38,10 @@ definitions:
 
   retriever:
     record_selector:
-      $ref: "*ref(definitions.selector)"
+      $ref: "#/definitions/selector"
     paginator:
       type: "DefaultPaginator"
-      url_base: "*ref(definitions.requester.url_base)"
+      url_base: "#/definitions/requester/url_base"
       pagination_strategy:
         class_name: "source_the_guardian_api.custom_page_strategy.CustomPageIncrement"
         page_size: 10
@@ -52,14 +52,14 @@ definitions:
         inject_into: "body_data"
         field_name: "page_size"
     requester:
-      $ref: "*ref(definitions.requester)"
+      $ref: "#/definitions/requester"
     stream_slicer:
-      $ref: "*ref(definitions.stream_slicer)"
+      $ref: "#/definitions/stream_slicer"
   base_stream:
     retriever:
-      $ref: "*ref(definitions.retriever)"
+      $ref: "#/definitions/retriever"
   content_stream:
-    $ref: "*ref(definitions.base_stream)"
+    $ref: "#/definitions/base_stream"
     $options:
       name: "content"
       primary_key: "id"
@@ -67,7 +67,7 @@ definitions:
       stream_cursor_field: "webPublicationDate"
 
 streams:
-  - "*ref(definitions.content_stream)"
+  - "#/definitions/content_stream"
 
 check:
   stream_names:

--- a/airbyte-integrations/connectors/source-tmdb/source_tmdb/tmdb.yaml
+++ b/airbyte-integrations/connectors/source-tmdb/source_tmdb/tmdb.yaml
@@ -33,18 +33,18 @@ definitions:
         }}
   retriever:
     record_selector:
-      $ref: "*ref(definitions.selector)"
+      $ref: "#/definitions/selector"
     paginator:
       type: NoPagination
     requester:
-      $ref: "*ref(definitions.requester)"
+      $ref: "#/definitions/requester"
 
   base_stream:
     schema_loader:
       type: JsonSchema
       file_path: "./source_tmdb/schemas/{{ options['name'] }}.json"
     retriever:
-      $ref: "*ref(definitions.retriever)"
+      $ref: "#/definitions/retriever"
 
   page_stream:
     schema_loader:
@@ -52,10 +52,10 @@ definitions:
       file_path: "./source_tmdb/schemas/{{ options['name'] }}.json"
     retriever:
       record_selector:
-        $ref: "*ref(definitions.selector)"
+        $ref: "#/definitions/selector"
       paginator:
         type: "DefaultPaginator"
-        url_base: "*ref(definitions.requester.url_base)"
+        url_base: "#/definitions/requester/url_base"
         pagination_strategy:
           type: "PageIncrement"
           page_size: 1000
@@ -66,233 +66,233 @@ definitions:
           inject_into: "request_parameter"
           field_name: ""
       requester:
-        $ref: "*ref(definitions.requester)"
+        $ref: "#/definitions/requester"
 
   certification_movie_stream:
-    $ref: "*ref(definitions.base_stream)"
+    $ref: "#/definitions/base_stream"
     $options:
       name: "certification_movie"
       path: "/certification/movie/list"
 
   certification_tv_stream:
-    $ref: "*ref(definitions.base_stream)"
+    $ref: "#/definitions/base_stream"
     $options:
       name: "certification_tv"
       path: "/certification/tv/list"
 
   changes_movie_stream:
-    $ref: "*ref(definitions.page_stream)"
+    $ref: "#/definitions/page_stream"
     $options:
       name: "changes_movie"
       path: "/movie/changes"
 
   changes_tv_stream:
-    $ref: "*ref(definitions.page_stream)"
+    $ref: "#/definitions/page_stream"
     $options:
       name: "changes_tv"
       path: "/tv/changes"
 
   changes_person_stream:
-    $ref: "*ref(definitions.page_stream)"
+    $ref: "#/definitions/page_stream"
     $options:
       name: "changes_person"
       path: "/person/changes"
 
   movies_details_stream:
-    $ref: "*ref(definitions.base_stream)"
+    $ref: "#/definitions/base_stream"
     $options:
       name: "movies_details"
       path: "/movie/{{ config['movie_id'] }}"
 
   movies_alternative_titles_stream:
-    $ref: "*ref(definitions.base_stream)"
+    $ref: "#/definitions/base_stream"
     $options:
       name: "movies_alternative_titles"
       path: "/movie/{{ config['movie_id'] }}/alternative_titles"
 
   movies_credits_stream:
-    $ref: "*ref(definitions.base_stream)"
+    $ref: "#/definitions/base_stream"
     $options:
       name: "movies_credits"
       path: "/movie/{{ config['movie_id'] }}/credits"
 
   movies_external_ids_stream:
-    $ref: "*ref(definitions.base_stream)"
+    $ref: "#/definitions/base_stream"
     $options:
       name: "movies_external_ids"
       path: "/movie/{{ config['movie_id'] }}/external_ids"
 
   movies_images_stream:
-    $ref: "*ref(definitions.base_stream)"
+    $ref: "#/definitions/base_stream"
     $options:
       name: "movies_images"
       path: "/movie/{{ config['movie_id'] }}/images"
 
   movies_keywords_stream:
-    $ref: "*ref(definitions.base_stream)"
+    $ref: "#/definitions/base_stream"
     $options:
       name: "movies_keywords"
       path: "/movie/{{ config['movie_id'] }}/keywords"
 
   movies_lists_stream:
-    $ref: "*ref(definitions.base_stream)"
+    $ref: "#/definitions/base_stream"
     $options:
       name: "movies_lists"
       path: "/movie/{{ config['movie_id'] }}/lists"
 
   movies_recommendations_stream:
-    $ref: "*ref(definitions.base_stream)"
+    $ref: "#/definitions/base_stream"
     $options:
       name: "movies_recommendations"
       path: "/movie/{{ config['movie_id'] }}/recommendations"
 
   movies_releases_dates_stream:
-    $ref: "*ref(definitions.base_stream)"
+    $ref: "#/definitions/base_stream"
     $options:
       name: "movies_releases_dates"
       path: "/movie/{{ config['movie_id'] }}/release_dates"
 
   movies_reviews_stream:
-    $ref: "*ref(definitions.base_stream)"
+    $ref: "#/definitions/base_stream"
     $options:
       name: "movies_reviews"
       path: "/movie/{{ config['movie_id'] }}/reviews"
 
   movies_similar_movies_stream:
-    $ref: "*ref(definitions.base_stream)"
+    $ref: "#/definitions/base_stream"
     $options:
       name: "movies_similar_movies"
       path: "/movie/{{ config['movie_id'] }}/similar"
 
   movies_translations_stream:
-    $ref: "*ref(definitions.base_stream)"
+    $ref: "#/definitions/base_stream"
     $options:
       name: "movies_translations"
       path: "/movie/{{ config['movie_id'] }}/translations"
 
   movies_videos_stream:
-    $ref: "*ref(definitions.base_stream)"
+    $ref: "#/definitions/base_stream"
     $options:
       name: "movies_videos"
       path: "/movie/{{ config['movie_id'] }}/videos"
 
   movies_watch_providers_stream:
-    $ref: "*ref(definitions.base_stream)"
+    $ref: "#/definitions/base_stream"
     $options:
       name: "movies_watch_providers"
       path: "/movie/{{ config['movie_id'] }}/watch/providers"
 
   movies_latest_stream:
-    $ref: "*ref(definitions.base_stream)"
+    $ref: "#/definitions/base_stream"
     $options:
       name: "movies_latest"
       path: "/movie/latest"
 
   movies_now_playing_stream:
-    $ref: "*ref(definitions.page_stream)"
+    $ref: "#/definitions/page_stream"
     $options:
       name: "movies_now_playing"
       path: "/movie/now_playing"
 
   movies_popular_stream:
-    $ref: "*ref(definitions.page_stream)"
+    $ref: "#/definitions/page_stream"
     $options:
       name: "movies_popular"
       path: "/movie/popular"
 
   movies_top_rated_stream:
-    $ref: "*ref(definitions.page_stream)"
+    $ref: "#/definitions/page_stream"
     $options:
       name: "movies_top_rated"
       path: "/movie/top_rated"
 
   movies_upcoming_stream:
-    $ref: "*ref(definitions.page_stream)"
+    $ref: "#/definitions/page_stream"
     $options:
       name: "movies_upcoming"
       path: "/movie/upcoming"
 
   trending_stream:
-    $ref: "*ref(definitions.base_stream)"
+    $ref: "#/definitions/base_stream"
     $options:
       name: "trending"
       path: "/trending/all/day"
 
   search_companies_stream:
-    $ref: "*ref(definitions.page_stream)"
+    $ref: "#/definitions/page_stream"
     $options:
       name: "search_companies"
       path: "/search/company"
 
   search_collections_stream:
-    $ref: "*ref(definitions.page_stream)"
+    $ref: "#/definitions/page_stream"
     $options:
       name: "search_collections"
       path: "/search/collection"
 
   search_keywords_stream:
-    $ref: "*ref(definitions.page_stream)"
+    $ref: "#/definitions/page_stream"
     $options:
       name: "search_keywords"
       path: "/search/keyword"
 
   search_movies_stream:
-    $ref: "*ref(definitions.page_stream)"
+    $ref: "#/definitions/page_stream"
     $options:
       name: "search_movies"
       path: "/search/movie"
 
   search_multi_stream:
-    $ref: "*ref(definitions.page_stream)"
+    $ref: "#/definitions/page_stream"
     $options:
       name: "search_multi"
       path: "/search/multi"
 
   search_people_stream:
-    $ref: "*ref(definitions.page_stream)"
+    $ref: "#/definitions/page_stream"
     $options:
       name: "search_people"
       path: "/search/person"
 
   search_tv_shows_stream:
-    $ref: "*ref(definitions.page_stream)"
+    $ref: "#/definitions/page_stream"
     $options:
       name: "search_tv_shows"
       path: "/search/tv"
 
 streams:
-  - "*ref(definitions.certification_movie_stream)"
-  - "*ref(definitions.certification_tv_stream)"
-  - "*ref(definitions.changes_movie_stream)"
-  - "*ref(definitions.changes_tv_stream)"
-  - "*ref(definitions.changes_person_stream)"
-  - "*ref(definitions.movies_details_stream)"
-  - "*ref(definitions.movies_alternative_titles_stream)"
-  - "*ref(definitions.movies_credits_stream)"
-  - "*ref(definitions.movies_external_ids_stream)"
-  - "*ref(definitions.movies_images_stream)"
-  - "*ref(definitions.movies_keywords_stream)"
-  - "*ref(definitions.movies_latest_stream)"
-  - "*ref(definitions.movies_lists_stream)"
-  - "*ref(definitions.movies_now_playing_stream)"
-  - "*ref(definitions.movies_popular_stream)"
-  - "*ref(definitions.movies_recommendations_stream)"
-  - "*ref(definitions.movies_releases_dates_stream)"
-  - "*ref(definitions.movies_reviews_stream)"
-  - "*ref(definitions.movies_similar_movies_stream)"
-  - "*ref(definitions.movies_top_rated_stream)"
-  - "*ref(definitions.movies_translations_stream)"
-  - "*ref(definitions.movies_upcoming_stream)"
-  - "*ref(definitions.movies_videos_stream)"
-  - "*ref(definitions.movies_watch_providers_stream)"
-  - "*ref(definitions.trending_stream)"
-  - "*ref(definitions.search_collections_stream)"
-  - "*ref(definitions.search_companies_stream)"
-  - "*ref(definitions.search_keywords_stream)"
-  - "*ref(definitions.search_movies_stream)"
-  - "*ref(definitions.search_multi_stream)"
-  - "*ref(definitions.search_people_stream)"
-  - "*ref(definitions.search_tv_shows_stream)"
+  - "#/definitions/certification_movie_stream"
+  - "#/definitions/certification_tv_stream"
+  - "#/definitions/changes_movie_stream"
+  - "#/definitions/changes_tv_stream"
+  - "#/definitions/changes_person_stream"
+  - "#/definitions/movies_details_stream"
+  - "#/definitions/movies_alternative_titles_stream"
+  - "#/definitions/movies_credits_stream"
+  - "#/definitions/movies_external_ids_stream"
+  - "#/definitions/movies_images_stream"
+  - "#/definitions/movies_keywords_stream"
+  - "#/definitions/movies_latest_stream"
+  - "#/definitions/movies_lists_stream"
+  - "#/definitions/movies_now_playing_stream"
+  - "#/definitions/movies_popular_stream"
+  - "#/definitions/movies_recommendations_stream"
+  - "#/definitions/movies_releases_dates_stream"
+  - "#/definitions/movies_reviews_stream"
+  - "#/definitions/movies_similar_movies_stream"
+  - "#/definitions/movies_top_rated_stream"
+  - "#/definitions/movies_translations_stream"
+  - "#/definitions/movies_upcoming_stream"
+  - "#/definitions/movies_videos_stream"
+  - "#/definitions/movies_watch_providers_stream"
+  - "#/definitions/trending_stream"
+  - "#/definitions/search_collections_stream"
+  - "#/definitions/search_companies_stream"
+  - "#/definitions/search_keywords_stream"
+  - "#/definitions/search_movies_stream"
+  - "#/definitions/search_multi_stream"
+  - "#/definitions/search_people_stream"
+  - "#/definitions/search_tv_shows_stream"
 
 check:
   stream_names:

--- a/airbyte-integrations/connectors/source-toggl/source_toggl/toggl.yaml
+++ b/airbyte-integrations/connectors/source-toggl/source_toggl/toggl.yaml
@@ -19,7 +19,7 @@ definitions:
       password: "api_token"
   increment_paginator:
     type: "DefaultPaginator"
-    url_base: "*ref(definitions.requester.url_base)"
+    url_base: "#/definitions/requester/url_base"
     page_size_option:
       inject_into: "request_parameter"
       field_name: "per_page"
@@ -31,52 +31,52 @@ definitions:
       field_name: "page"
   retriever:
     record_selector:
-      $ref: "*ref(definitions.selector)"
+      $ref: "#/definitions/selector"
     paginator:
       type: NoPagination
     requester:
-      $ref: "*ref(definitions.requester)"
+      $ref: "#/definitions/requester"
   base_stream:
     retriever:
-      $ref: "*ref(definitions.retriever)"
+      $ref: "#/definitions/retriever"
   time_entries_stream:
-    $ref: "*ref(definitions.base_stream)"
+    $ref: "#/definitions/base_stream"
     $options:
       name: "time_entries"
       primary_key: "id"
       path: "/api/v9/me/time_entries"
   organizations_stream:
-    $ref: "*ref(definitions.base_stream)"
+    $ref: "#/definitions/base_stream"
     $options:
       name: "organizations"
       primary_key: "id"
       path: "/api/v9/organizations/{{ config['organization_id'] }}"
   organizations_users_stream:
-    $ref: "*ref(definitions.base_stream)"
+    $ref: "#/definitions/base_stream"
     $options:
       name: "organizations_users"
       primary_key: "id"
       path: "/api/v9/organizations/{{ config['organization_id'] }}/users"
   organizations_groups_stream:
-    $ref: "*ref(definitions.base_stream)"
+    $ref: "#/definitions/base_stream"
     $options:
       name: "organizations_groups"
       primary_key: "group_id"
       path: "/api/v9/organizations/{{ config['organization_id'] }}/groups"
   workspace_stream:
-    $ref: "*ref(definitions.base_stream)"
+    $ref: "#/definitions/base_stream"
     $options:
       name: "workspace"
       primary_key: ""
       path: "/api/v9/workspaces/{{ config['workspace_id'] }}/statistics"
   workspace_clients_stream:
-    $ref: "*ref(definitions.base_stream)"
+    $ref: "#/definitions/base_stream"
     $options:
       name: "workspace_clients"
       primary_key: "id"
       path: "/api/v9/workspaces/{{ config['workspace_id'] }}/clients"
   workspace_projects_stream:
-    $ref: "*ref(definitions.base_stream)"
+    $ref: "#/definitions/base_stream"
     $options:
       name: "workspace_projects"
       primary_key: "id"
@@ -84,11 +84,11 @@ definitions:
   workspace_tasks_stream:
     retriever:
       record_selector:
-        $ref: "*ref(definitions.data_selector)"
+        $ref: "#/definitions/data_selector"
       paginator:
-        $ref: "*ref(definitions.increment_paginator)"
+        $ref: "#/definitions/increment_paginator"
       requester:
-        $ref: "*ref(definitions.requester)"
+        $ref: "#/definitions/requester"
         request_parameters: ""
     $options:
       name: "workspace_tasks"
@@ -96,14 +96,14 @@ definitions:
       path: "/api/v9/workspaces/{{ config['workspace_id'] }}/tasks"
 
 streams:
-  - "*ref(definitions.time_entries_stream)"
-  - "*ref(definitions.organizations_stream)"
-  - "*ref(definitions.organizations_users_stream)"
-  - "*ref(definitions.organizations_groups_stream)"
-  - "*ref(definitions.workspace_stream)"
-  - "*ref(definitions.workspace_clients_stream)"
-  - "*ref(definitions.workspace_projects_stream)"
-  - "*ref(definitions.workspace_tasks_stream)"
+  - "#/definitions/time_entries_stream"
+  - "#/definitions/organizations_stream"
+  - "#/definitions/organizations_users_stream"
+  - "#/definitions/organizations_groups_stream"
+  - "#/definitions/workspace_stream"
+  - "#/definitions/workspace_clients_stream"
+  - "#/definitions/workspace_projects_stream"
+  - "#/definitions/workspace_tasks_stream"
 
 check:
   stream_names:

--- a/airbyte-integrations/connectors/source-tvmaze-schedule/source_tvmaze_schedule/tvmaze_schedule.yaml
+++ b/airbyte-integrations/connectors/source-tvmaze-schedule/source_tvmaze_schedule/tvmaze_schedule.yaml
@@ -33,39 +33,39 @@ definitions:
       inject_into: "request_parameter"
   retriever:
     record_selector:
-      $ref: "*ref(definitions.selector)"
+      $ref: "#/definitions/selector"
     paginator:
       type: NoPagination
     requester:
-      $ref: "*ref(definitions.requester)"
+      $ref: "#/definitions/requester"
     stream_slicer:
-      $ref: "*ref(definitions.stream_slicer)"
+      $ref: "#/definitions/stream_slicer"
   base_stream:
     retriever:
-      $ref: "*ref(definitions.retriever)"
+      $ref: "#/definitions/retriever"
   domestic_stream:
-    $ref: "*ref(definitions.base_stream)"
+    $ref: "#/definitions/base_stream"
     $options:
       name: "domestic"
       primary_key: "id"
       path: "/schedule"
   web_stream:
-    $ref: "*ref(definitions.base_stream)"
+    $ref: "#/definitions/base_stream"
     $options:
       name: "web"
       primary_key: "id"
       path: "/schedule"
   future_stream:
-    $ref: "*ref(definitions.base_stream)"
+    $ref: "#/definitions/base_stream"
     $options:
       name: "future"
       primary_key: "id"
       path: "/schedule/full"
 
 streams:
-  - "*ref(definitions.domestic_stream)"
-  - "*ref(definitions.web_stream)"
-  - "*ref(definitions.future_stream)"
+  - "#/definitions/domestic_stream"
+  - "#/definitions/web_stream"
+  - "#/definitions/future_stream"
 
 check:
   stream_names:

--- a/airbyte-integrations/connectors/source-twilio-taskrouter/source_twilio_taskrouter/twilio_taskrouter.yaml
+++ b/airbyte-integrations/connectors/source-twilio-taskrouter/source_twilio_taskrouter/twilio_taskrouter.yaml
@@ -14,9 +14,9 @@ definitions:
       password: "{{ config['auth_token'] }}"
   retriever:
     record_selector:
-      $ref: "*ref(definitions.selector)"
+      $ref: "#/definitions/selector"
     requester:
-      $ref: "*ref(definitions.requester)"
+      $ref: "#/definitions/requester"
   default_paginator:
     type: "DefaultPaginator"
     page_size_option:
@@ -31,14 +31,14 @@ definitions:
     url_base: "https://taskrouter.twilio.com"
   base_stream:
     retriever:
-      $ref: "*ref(definitions.retriever)"
+      $ref: "#/definitions/retriever"
   base_stream_with_pagination:
     retriever:
-      $ref: "*ref(definitions.retriever)"
+      $ref: "#/definitions/retriever"
       paginator:
-        $ref: "*ref(definitions.default_paginator)"
+        $ref: "#/definitions/default_paginator"
   workspaces_stream:
-    $ref: "*ref(definitions.base_stream_with_pagination)"
+    $ref: "#/definitions/base_stream_with_pagination"
     $options:
       name: "workspaces"
       path: "/v1/Workspaces"
@@ -47,28 +47,28 @@ definitions:
   workspace_stream_slicer:
     type: SubstreamSlicer
     parent_stream_configs:
-      - stream: "*ref(definitions.workspaces_stream)"
+      - stream: "#/definitions/workspaces_stream"
         parent_key: sid
         stream_slice_field: id
 
   workers_stream:
-    $ref: "*ref(definitions.base_stream_with_pagination)"
+    $ref: "#/definitions/base_stream_with_pagination"
     $options:
       name: "workers"
       primary_key: "sid"
       path: "/v1/Workspaces/{{ stream_slice.id }}/Workers"
     retriever:
-      $ref: "*ref(definitions.retriever)"
+      $ref: "#/definitions/retriever"
       requester:
-        $ref: "*ref(definitions.requester)"
+        $ref: "#/definitions/requester"
       paginator:
-        $ref: "*ref(definitions.default_paginator)"
+        $ref: "#/definitions/default_paginator"
       stream_slicer:
-        $ref: "*ref(definitions.workspace_stream_slicer)"
+        $ref: "#/definitions/workspace_stream_slicer"
 
 streams:
-  - "*ref(definitions.workspaces_stream)"
-  - "*ref(definitions.workers_stream)"
+  - "#/definitions/workspaces_stream"
+  - "#/definitions/workers_stream"
 
 check:
   stream_names:

--- a/airbyte-integrations/connectors/source-twitter/source_twitter/twitter.yaml
+++ b/airbyte-integrations/connectors/source-twitter/source_twitter/twitter.yaml
@@ -34,7 +34,7 @@ definitions:
       inject_into: request_parameter
   retriever:
     record_selector:
-      $ref: "*ref(definitions.selector)"
+      $ref: "#/definitions/selector"
     paginator:
       type: DefaultPaginator
       pagination_strategy:
@@ -48,22 +48,22 @@ definitions:
       page_token_option:
         field_name: "next_token"
         inject_into: "request_parameter"
-      url_base: "*ref(definitions.requester.url_base)"
+      url_base: "#/definitions/requester/url_base"
     requester:
-      $ref: "*ref(definitions.requester)"
+      $ref: "#/definitions/requester"
 
   base_stream:
     retriever:
-      $ref: "*ref(definitions.retriever)"
+      $ref: "#/definitions/retriever"
 
   tweets_stream:
-    $ref: "*ref(definitions.base_stream)"
+    $ref: "#/definitions/base_stream"
     $options:
       name: "tweets"
       path: "/search/recent"
 
 streams:
-  - "*ref(definitions.tweets_stream)"
+  - "#/definitions/tweets_stream"
 
 check:
   stream_names:

--- a/airbyte-integrations/connectors/source-tyntec-sms/source_tyntec_sms/tyntec_sms.yaml
+++ b/airbyte-integrations/connectors/source-tyntec-sms/source_tyntec_sms/tyntec_sms.yaml
@@ -14,17 +14,17 @@ definitions:
       api_token: "{{ config['api_key'] }}"
   retriever:
     record_selector:
-      $ref: "*ref(definitions.selector)"
+      $ref: "#/definitions/selector"
     paginator:
       type: NoPagination
     requester:
-      $ref: "*ref(definitions.requester)"
+      $ref: "#/definitions/requester"
   base_stream:
     retriever:
-      $ref: "*ref(definitions.retriever)"
+      $ref: "#/definitions/retriever"
   # API Docs: https://api.tyntec.com/reference/sms/current.html#sms-api-Send%20SMS%20(GET)
   sms_stream:
-    $ref: "*ref(definitions.base_stream)"
+    $ref: "#/definitions/base_stream"
     $options:
       name: "sms"
       primary_key: "requestId"
@@ -32,49 +32,49 @@ definitions:
   sms_stream_slicer:
     type: SubstreamSlicer
     parent_stream_configs:
-      - stream: "*ref(definitions.sms_stream)"
+      - stream: "#/definitions/sms_stream"
         parent_key: "requestId"
         stream_slice_field: "requestId"
   # API Docs: https://api.tyntec.com/reference/sms/current.html#sms-api-Read%20SMS%20status
   messages_stream:
-    $ref: "*ref(definitions.base_stream)"
+    $ref: "#/definitions/base_stream"
     $options:
       name: "messages"
       primary_key: "requestId"
     retriever:
-      $ref: "*ref(definitions.retriever)"
+      $ref: "#/definitions/retriever"
       record_selector:
-        $ref: "*ref(definitions.selector)"
+        $ref: "#/definitions/selector"
       requester:
-        $ref: "*ref(definitions.requester)"
+        $ref: "#/definitions/requester"
         path: "/messaging/v1/messages/{{ stream_slice.requestId }}"
       stream_slicer:
-        $ref: "*ref(definitions.sms_stream_slicer)"
+        $ref: "#/definitions/sms_stream_slicer"
   # API Docs: https://api.tyntec.com/reference/sms/current.html#sms-api-List%20all%20contacts
   contacts_stream:
-    $ref: "*ref(definitions.base_stream)"
+    $ref: "#/definitions/base_stream"
     $options:
       name: "contacts"
       path: "/byon/contacts/v1"
   # API Docs: https://api.tyntec.com/reference/sms/current.html#sms-api-List%20all%20phone%20numbers
   phones_stream:
-    $ref: "*ref(definitions.base_stream)"
+    $ref: "#/definitions/base_stream"
     $options:
       name: "phones"
       path: "/byon/phonebook/v1/numbers"
   # API Docs: https://api.tyntec.com/reference/sms/current.html#sms-api-List%20all%20phones
   registrations_stream:
-    $ref: "*ref(definitions.base_stream)"
+    $ref: "#/definitions/base_stream"
     $options:
       name: "registrations"
       path: "/byon/provisioning/v1"
 
 streams:
-  - "*ref(definitions.sms_stream)"
-  - "*ref(definitions.messages_stream)"
-  - "*ref(definitions.contacts_stream)"
-  - "*ref(definitions.phones_stream)"
-  - "*ref(definitions.registrations_stream)"
+  - "#/definitions/sms_stream"
+  - "#/definitions/messages_stream"
+  - "#/definitions/contacts_stream"
+  - "#/definitions/phones_stream"
+  - "#/definitions/registrations_stream"
 
 check:
   stream_names:

--- a/airbyte-integrations/connectors/source-vantage/source_vantage/vantage.yaml
+++ b/airbyte-integrations/connectors/source-vantage/source_vantage/vantage.yaml
@@ -12,7 +12,7 @@ definitions:
       api_token: "{{ config['access_token'] }}"
   increment_paginator:
     type: "DefaultPaginator"
-    url_base: "*ref(definitions.requester.url_base)"
+    url_base: "#/definitions/requester/url_base"
     page_size_option:
       inject_into: "request_parameter"
       field_name: "limit"
@@ -24,43 +24,43 @@ definitions:
       field_name: "page"
   retriever:
     record_selector:
-      $ref: "*ref(definitions.selector)"
+      $ref: "#/definitions/selector"
     paginator:
-      $ref: "*ref(definitions.increment_paginator)"
+      $ref: "#/definitions/increment_paginator"
     requester:
-      $ref: "*ref(definitions.requester)"
+      $ref: "#/definitions/requester"
   base_stream:
     retriever:
-      $ref: "*ref(definitions.retriever)"
+      $ref: "#/definitions/retriever"
   providers_stream:
-    $ref: "*ref(definitions.base_stream)"
+    $ref: "#/definitions/base_stream"
     $options:
       name: "providers"
       primary_key: "id"
       path: "/providers"
   services_stream:
-    $ref: "*ref(definitions.base_stream)"
+    $ref: "#/definitions/base_stream"
     $options:
       name: "services"
       primary_key: "id"
       path: "/services"
   products_stream:
-    $ref: "*ref(definitions.base_stream)"
+    $ref: "#/definitions/base_stream"
     $options:
       name: "products"
       primary_key: "id"
       path: "/products"
   reports_stream:
-    $ref: "*ref(definitions.base_stream)"
+    $ref: "#/definitions/base_stream"
     $options:
       name: "reports"
       primary_key: "id"
       path: "/reports"
 streams:
-  - "*ref(definitions.providers_stream)"
-  - "*ref(definitions.services_stream)"
-  - "*ref(definitions.products_stream)"
-  - "*ref(definitions.reports_stream)"
+  - "#/definitions/providers_stream"
+  - "#/definitions/services_stream"
+  - "#/definitions/products_stream"
+  - "#/definitions/reports_stream"
 
 check:
   stream_names:

--- a/airbyte-integrations/connectors/source-vitally/source_vitally/vitally.yaml
+++ b/airbyte-integrations/connectors/source-vitally/source_vitally/vitally.yaml
@@ -12,7 +12,7 @@ definitions:
       username: "{{ config['api_key'] }}"
   retriever:
     record_selector:
-      $ref: "*ref(definitions.selector)"
+      $ref: "#/definitions/selector"
     paginator:
       type: DefaultPaginator
       pagination_strategy:
@@ -26,80 +26,80 @@ definitions:
         field_name: "from"
         inject_into: "request_parameter"
       url_base:
-        $ref: "*ref(definitions.requester.url_base)"
+        $ref: "#/definitions/requester/url_base"
     requester:
-      $ref: "*ref(definitions.requester)"
+      $ref: "#/definitions/requester"
 
   # base stream
   base_stream:
     retriever:
-      $ref: "*ref(definitions.retriever)"
+      $ref: "#/definitions/retriever"
 
   # stream definitions
   accounts_stream:
-    $ref: "*ref(definitions.base_stream)"
+    $ref: "#/definitions/base_stream"
     $options:
       name: "accounts"
       primary_key: "id"
       path: "/accounts"
     retriever:
-      $ref: "*ref(definitions.base_stream.retriever)"
+      $ref: "#/definitions/base_stream/retriever"
       requester:
-        $ref: "*ref(definitions.requester)"
+        $ref: "#/definitions/requester"
         request_parameters:
           status: "{{ config['status'] }}"
   admins_stream:
-    $ref: "*ref(definitions.base_stream)"
+    $ref: "#/definitions/base_stream"
     $options:
       name: "admins"
       primary_key: "id"
       path: "/admins"
   conversations_stream:
-    $ref: "*ref(definitions.base_stream)"
+    $ref: "#/definitions/base_stream"
     $options:
       name: "conversations"
       primary_key: "id"
       path: "/conversations"
   notes_stream:
-    $ref: "*ref(definitions.base_stream)"
+    $ref: "#/definitions/base_stream"
     $options:
       name: "notes"
       primary_key: "id"
       path: "/notes"
   nps_responses_stream:
-    $ref: "*ref(definitions.base_stream)"
+    $ref: "#/definitions/base_stream"
     $options:
       name: "nps_responses"
       primary_key: "id"
       path: "/npsResponses"
   organizations_stream:
-    $ref: "*ref(definitions.base_stream)"
+    $ref: "#/definitions/base_stream"
     $options:
       name: "organizations"
       primary_key: "id"
       path: "/organizations"
   tasks_stream:
-    $ref: "*ref(definitions.base_stream)"
+    $ref: "#/definitions/base_stream"
     $options:
       name: "tasks"
       primary_key: "id"
       path: "/tasks"
   users_stream:
-    $ref: "*ref(definitions.base_stream)"
+    $ref: "#/definitions/base_stream"
     $options:
       name: "users"
       primary_key: "id"
       path: "/users"
 
 streams:
-  - "*ref(definitions.accounts_stream)"
-  - "*ref(definitions.admins_stream)"
-  - "*ref(definitions.conversations_stream)"
-  - "*ref(definitions.notes_stream)"
-  - "*ref(definitions.nps_responses_stream)"
-  - "*ref(definitions.organizations_stream)"
-  - "*ref(definitions.tasks_stream)"
-  - "*ref(definitions.users_stream)"
+  - "#/definitions/accounts_stream"
+  - "#/definitions/admins_stream"
+  - "#/definitions/conversations_stream"
+  - "#/definitions/notes_stream"
+  - "#/definitions/nps_responses_stream"
+  - "#/definitions/organizations_stream"
+  - "#/definitions/tasks_stream"
+  - "#/definitions/users_stream"
 
 check:
   stream_names:

--- a/airbyte-integrations/connectors/source-waiteraid/source_waiteraid/waiteraid.yaml
+++ b/airbyte-integrations/connectors/source-waiteraid/source_waiteraid/waiteraid.yaml
@@ -24,23 +24,23 @@ definitions:
     cursor_field: "{{ options['stream_cursor_field'] }}"
   retriever:
     record_selector:
-      $ref: "*ref(definitions.selector)"
+      $ref: "#/definitions/selector"
     paginator:
       type: NoPagination
     requester:
-      $ref: "*ref(definitions.requester)"
+      $ref: "#/definitions/requester"
   base_stream:
     retriever:
-      $ref: "*ref(definitions.retriever)"
+      $ref: "#/definitions/retriever"
   booking_stream:
-    $ref: "*ref(definitions.base_stream)"
+    $ref: "#/definitions/base_stream"
     $options:
       name: "booking"
       path: "/wa-api/searchBooking"
       stream_cursor_field: "date"
 
 streams:
-  - "*ref(definitions.booking_stream)"
+  - "#/definitions/booking_stream"
 
 check:
   stream_names:

--- a/airbyte-integrations/connectors/source-whisky-hunter/source_whisky_hunter/whisky_hunter.yaml
+++ b/airbyte-integrations/connectors/source-whisky-hunter/source_whisky_hunter/whisky_hunter.yaml
@@ -9,34 +9,34 @@ definitions:
     http_method: "GET"
   retriever:
     record_selector:
-      $ref: "*ref(definitions.selector)"
+      $ref: "#/definitions/selector"
     paginator:
       type: NoPagination
     requester:
-      $ref: "*ref(definitions.requester)"
+      $ref: "#/definitions/requester"
   base_stream:
     retriever:
-      $ref: "*ref(definitions.retriever)"
+      $ref: "#/definitions/retriever"
   auctions_data_stream:
-    $ref: "*ref(definitions.base_stream)"
+    $ref: "#/definitions/base_stream"
     $options:
       name: "auctions_data"
       path: "/auctions_data/?format=json"
   auctions_info_stream:
-    $ref: "*ref(definitions.base_stream)"
+    $ref: "#/definitions/base_stream"
     $options:
       name: "auctions_info"
       path: "/auctions_info?format=json"
   distilleries_info_stream:
-    $ref: "*ref(definitions.base_stream)"
+    $ref: "#/definitions/base_stream"
     $options:
       name: "distilleries_info"
       path: "/distilleries_info/?format=json"
 
 streams:
-  - "*ref(definitions.auctions_data_stream)"
-  - "*ref(definitions.auctions_info_stream)"
-  - "*ref(definitions.distilleries_info_stream)"
+  - "#/definitions/auctions_data_stream"
+  - "#/definitions/auctions_info_stream"
+  - "#/definitions/distilleries_info_stream"
 
 check:
   stream_names:

--- a/airbyte-integrations/connectors/source-wikipedia-pageviews/source_wikipedia_pageviews/wikipedia_pageviews.yaml
+++ b/airbyte-integrations/connectors/source-wikipedia-pageviews/source_wikipedia_pageviews/wikipedia_pageviews.yaml
@@ -32,37 +32,37 @@ definitions:
 
   per_article_requester:
     $options:
-      $ref: "*ref(definitions.requester)"
+      $ref: "#/definitions/requester"
     path: "/per-article/{{config.project}}/{{config.access}}/{{config.agent}}/{{config.article}}/daily/{{stream_slice.start_time}}/{{stream_slice.end_time}}"
   top_requester:
     $options:
-      $ref: "*ref(definitions.requester)"
+      $ref: "#/definitions/requester"
     path: "/top/{{config.project}}/{{config.access}}/{{stream_slice.start_time}}"
   per_article_retriever:
     record_selector:
-      $ref: "*ref(definitions.selector)"
+      $ref: "#/definitions/selector"
     paginator:
       type: NoPagination
     requester:
-      $ref: "*ref(definitions.per_article_requester)"
+      $ref: "#/definitions/per_article_requester"
     stream_slicer:
-      $ref: "*ref(definitions.per_article_stream_slicer)"
+      $ref: "#/definitions/per_article_stream_slicer"
 
   top_retriever:
     record_selector:
-      $ref: "*ref(definitions.selector)"
+      $ref: "#/definitions/selector"
     paginator:
       type: NoPagination
     requester:
-      $ref: "*ref(definitions.top_requester)"
+      $ref: "#/definitions/top_requester"
     stream_slicer:
-      $ref: "*ref(definitions.top_stream_slicer)"
+      $ref: "#/definitions/top_stream_slicer"
   per_article_stream:
     schema_loader:
       type: JsonSchema
       file_path: "./source_wikipedia_pageviews/schemas/{{ options['name'] }}.json"
     retriever:
-      $ref: "*ref(definitions.per_article_retriever)"
+      $ref: "#/definitions/per_article_retriever"
     $options:
       name: "per-article"
   top_stream:
@@ -70,13 +70,13 @@ definitions:
       type: JsonSchema
       file_path: "./source_wikipedia_pageviews/schemas/{{ options['name'] }}.json"
     retriever:
-      $ref: "*ref(definitions.top_retriever)"
+      $ref: "#/definitions/top_retriever"
     $options:
       name: "top"
 
 streams:
-  - "*ref(definitions.per_article_stream)"
-  - "*ref(definitions.top_stream)"
+  - "#/definitions/per_article_stream"
+  - "#/definitions/top_stream"
 
 check:
   stream_names:

--- a/airbyte-integrations/connectors/source-woocommerce/source_woocommerce/woocommerce.yaml
+++ b/airbyte-integrations/connectors/source-woocommerce/source_woocommerce/woocommerce.yaml
@@ -39,11 +39,11 @@ definitions:
     cursor_field: "{{ options['stream_cursor_field'] }}"
   retriever:
     record_selector:
-      $ref: "*ref(definitions.selector)"
+      $ref: "#/definitions/selector"
     paginator:
       type: DefaultPaginator
       $options:
-        url_base: "*ref(definitions.requester.url_base)"
+        url_base: "#/definitions/requester/url_base"
       pagination_strategy:
         type: "OffsetIncrement"
         page_size: 100
@@ -54,43 +54,43 @@ definitions:
         inject_into: "request_parameter"
         field_name: "per_page"
     requester:
-      $ref: "*ref(definitions.requester)"
+      $ref: "#/definitions/requester"
   base_stream:
     retriever:
-      $ref: "*ref(definitions.retriever)"
+      $ref: "#/definitions/retriever"
   base_incremental_stream:
     retriever:
-      $ref: "*ref(definitions.retriever)"
+      $ref: "#/definitions/retriever"
       stream_slicer:
-        $ref: "*ref(definitions.date_stream_slicer)"
+        $ref: "#/definitions/date_stream_slicer"
   customers_stream:
-    $ref: "*ref(definitions.base_stream)"
+    $ref: "#/definitions/base_stream"
     $options:
       name: "customers"
       primary_key: "id"
       path: "/customers"
   coupons_stream:
-    $ref: "*ref(definitions.base_incremental_stream)"
+    $ref: "#/definitions/base_incremental_stream"
     $options:
       name: "coupons"
       stream_cursor_field: "date_modified_gmt"
       primary_key: "id"
       path: "/coupons"
   orders_stream:
-    $ref: "*ref(definitions.base_incremental_stream)"
+    $ref: "#/definitions/base_incremental_stream"
     $options:
       name: "orders"
       stream_cursor_field: "date_modified_gmt"
       primary_key: "id"
       path: "/orders"
   order_notes_stream:
-    $ref: "*ref(definitions.base_stream)"
+    $ref: "#/definitions/base_stream"
     retriever:
-      $ref: "*ref(definitions.retriever)"
+      $ref: "#/definitions/retriever"
       stream_slicer:
         type: SubstreamSlicer
         parent_stream_configs:
-          - stream: "*ref(definitions.orders_stream)"
+          - stream: "#/definitions/orders_stream"
             parent_key: id
             stream_slice_field: id
     $options:
@@ -98,20 +98,20 @@ definitions:
       primary_key: "id"
       path: "/orders/{{ stream_slice.id }}/notes"
   products_stream:
-    $ref: "*ref(definitions.base_incremental_stream)"
+    $ref: "#/definitions/base_incremental_stream"
     $options:
       name: "products"
       stream_cursor_field: "date_modified_gmt"
       primary_key: "id"
       path: "/products"
   product_variations_stream:
-    $ref: "*ref(definitions.base_stream)"
+    $ref: "#/definitions/base_stream"
     retriever:
-      $ref: "*ref(definitions.retriever)"
+      $ref: "#/definitions/retriever"
       stream_slicer:
         type: SubstreamSlicer
         parent_stream_configs:
-          - stream: "*ref(definitions.products_stream)"
+          - stream: "#/definitions/products_stream"
             parent_key: id
             stream_slice_field: id
     $options:
@@ -119,25 +119,25 @@ definitions:
       primary_key: "id"
       path: "/products/{{ stream_slice.id }}/variations"
   payment_gateways_stream:
-    $ref: "*ref(definitions.base_stream)"
+    $ref: "#/definitions/base_stream"
     $options:
       name: "payment_gateways"
       primary_key: "id"
       path: "/payment_gateways"
   product_attributes_stream:
-    $ref: "*ref(definitions.base_stream)"
+    $ref: "#/definitions/base_stream"
     $options:
       name: "product_attributes"
       primary_key: "id"
       path: "/products/attributes"
   product_attribute_terms_stream:
-    $ref: "*ref(definitions.base_stream)"
+    $ref: "#/definitions/base_stream"
     retriever:
-      $ref: "*ref(definitions.retriever)"
+      $ref: "#/definitions/retriever"
       stream_slicer:
         type: SubstreamSlicer
         parent_stream_configs:
-          - stream: "*ref(definitions.product_attributes_stream)"
+          - stream: "#/definitions/product_attributes_stream"
             parent_key: id
             stream_slice_field: id
     $options:
@@ -145,17 +145,17 @@ definitions:
       primary_key: "id"
       path: "/products/attributes/{{ stream_slice.id }}/terms"
   product_categories_stream:
-    $ref: "*ref(definitions.base_stream)"
+    $ref: "#/definitions/base_stream"
     $options:
       name: "product_categories"
       primary_key: "id"
       path: "/products/categories"
   product_reviews_stream:
-    $ref: "*ref(definitions.base_incremental_stream)"
+    $ref: "#/definitions/base_incremental_stream"
     retriever:
-      $ref: "*ref(definitions.retriever)"
+      $ref: "#/definitions/retriever"
       stream_slicer:
-        $ref: "*ref(definitions.date_stream_slicer)"
+        $ref: "#/definitions/date_stream_slicer"
         start_time_option:
           field_name: after
           inject_into: request_parameter
@@ -168,25 +168,25 @@ definitions:
       primary_key: "id"
       path: "/products/reviews"
   product_shipping_classes_stream:
-    $ref: "*ref(definitions.base_stream)"
+    $ref: "#/definitions/base_stream"
     $options:
       name: "product_shipping_classes"
       primary_key: "id"
       path: "/products/shipping_classes"
   product_tags_stream:
-    $ref: "*ref(definitions.base_stream)"
+    $ref: "#/definitions/base_stream"
     $options:
       name: "product_tags"
       primary_key: "id"
       path: "/products/tags"
   refunds_stream:
-    $ref: "*ref(definitions.base_stream)"
+    $ref: "#/definitions/base_stream"
     retriever:
-      $ref: "*ref(definitions.retriever)"
+      $ref: "#/definitions/retriever"
       stream_slicer:
         type: SubstreamSlicer
         parent_stream_configs:
-          - stream: "*ref(definitions.orders_stream)"
+          - stream: "#/definitions/orders_stream"
             parent_key: id
             stream_slice_field: id
     $options:
@@ -194,13 +194,13 @@ definitions:
       primary_key: "id"
       path: "/orders/{{ stream_slice.id }}/refunds"
   shipping_methods_stream:
-    $ref: "*ref(definitions.base_stream)"
+    $ref: "#/definitions/base_stream"
     $options:
       name: "shipping_methods"
       primary_key: "id"
       path: "/shipping_methods"
   shipping_zones_stream:
-    $ref: "*ref(definitions.base_stream)"
+    $ref: "#/definitions/base_stream"
     $options:
       name: "shipping_zones"
       primary_key: "id"
@@ -208,70 +208,70 @@ definitions:
   shipping_stream_slicer:
     type: SubstreamSlicer
     parent_stream_configs:
-      - stream: "*ref(definitions.shipping_zones_stream)"
+      - stream: "#/definitions/shipping_zones_stream"
         parent_key: id
         stream_slice_field: id
   shipping_zone_locations_stream:
-    $ref: "*ref(definitions.base_stream)"
+    $ref: "#/definitions/base_stream"
     retriever:
-      $ref: "*ref(definitions.retriever)"
+      $ref: "#/definitions/retriever"
       stream_slicer:
-        $ref: "*ref(definitions.shipping_stream_slicer)"
+        $ref: "#/definitions/shipping_stream_slicer"
     $options:
       name: "shipping_zone_locations"
       primary_key: ["code", "type"]
       path: "/shipping/zones/{{ stream_slice.id }}/locations"
   shipping_zone_methods_stream:
-    $ref: "*ref(definitions.base_stream)"
+    $ref: "#/definitions/base_stream"
     retriever:
-      $ref: "*ref(definitions.retriever)"
+      $ref: "#/definitions/retriever"
       stream_slicer:
-        $ref: "*ref(definitions.shipping_stream_slicer)"
+        $ref: "#/definitions/shipping_stream_slicer"
     $options:
       name: "shipping_zone_methods"
       primary_key: "instance_id"
       path: "/shipping/zones/{{ stream_slice.id }}/methods"
   system_status_tools_stream:
-    $ref: "*ref(definitions.base_stream)"
+    $ref: "#/definitions/base_stream"
     $options:
       name: "system_status_tools"
       primary_key: "id"
       path: "/system_status/tools"
   tax_classes_stream:
-    $ref: "*ref(definitions.base_stream)"
+    $ref: "#/definitions/base_stream"
     $options:
       name: "tax_classes"
       primary_key: ["slug", "name"]
       path: "/taxes/classes"
   tax_rates_stream:
-    $ref: "*ref(definitions.base_stream)"
+    $ref: "#/definitions/base_stream"
     $options:
       name: "tax_rates"
       primary_key: "id"
       path: "/taxes"
 
 streams:
-  - "*ref(definitions.customers_stream)"
-  - "*ref(definitions.coupons_stream)"
-  - "*ref(definitions.orders_stream)"
-  - "*ref(definitions.order_notes_stream)"
-  - "*ref(definitions.payment_gateways_stream)"
-  - "*ref(definitions.products_stream)"
-  - "*ref(definitions.product_attributes_stream)"
-  - "*ref(definitions.product_attribute_terms_stream)"
-  - "*ref(definitions.product_categories_stream)"
-  - "*ref(definitions.product_reviews_stream)"
-  - "*ref(definitions.product_shipping_classes_stream)"
-  - "*ref(definitions.product_tags_stream)"
-  - "*ref(definitions.product_variations_stream)"
-  - "*ref(definitions.refunds_stream)"
-  - "*ref(definitions.shipping_methods_stream)"
-  - "*ref(definitions.shipping_zone_locations_stream)"
-  - "*ref(definitions.shipping_zone_methods_stream)"
-  - "*ref(definitions.shipping_zones_stream)"
-  - "*ref(definitions.system_status_tools_stream)"
-  - "*ref(definitions.tax_classes_stream)"
-  - "*ref(definitions.tax_rates_stream)"
+  - "#/definitions/customers_stream"
+  - "#/definitions/coupons_stream"
+  - "#/definitions/orders_stream"
+  - "#/definitions/order_notes_stream"
+  - "#/definitions/payment_gateways_stream"
+  - "#/definitions/products_stream"
+  - "#/definitions/product_attributes_stream"
+  - "#/definitions/product_attribute_terms_stream"
+  - "#/definitions/product_categories_stream"
+  - "#/definitions/product_reviews_stream"
+  - "#/definitions/product_shipping_classes_stream"
+  - "#/definitions/product_tags_stream"
+  - "#/definitions/product_variations_stream"
+  - "#/definitions/refunds_stream"
+  - "#/definitions/shipping_methods_stream"
+  - "#/definitions/shipping_zone_locations_stream"
+  - "#/definitions/shipping_zone_methods_stream"
+  - "#/definitions/shipping_zones_stream"
+  - "#/definitions/system_status_tools_stream"
+  - "#/definitions/tax_classes_stream"
+  - "#/definitions/tax_rates_stream"
 
 check:
   stream_names:

--- a/airbyte-integrations/connectors/source-workable/source_workable/workable.yaml
+++ b/airbyte-integrations/connectors/source-workable/source_workable/workable.yaml
@@ -18,12 +18,12 @@ definitions:
       created_after: "{{ config['start_date'] }}"
   retriever:
     record_selector:
-      $ref: "*ref(definitions.selector)"
+      $ref: "#/definitions/selector"
     requester:
-      $ref: "*ref(definitions.requester)"
+      $ref: "#/definitions/requester"
     paginator:
       type: DefaultPaginator
-      url_base: "*ref(definitions.requester.url_base)"
+      url_base: "#/definitions/requester/url_base"
       limit_option:
         inject_into: "request_parameter"
         field_name: ""
@@ -36,33 +36,33 @@ definitions:
         type: "CursorPagination"
         cursor_value: "{{ response.paging.next }}"
         stop_condition: "{{ 'next' not in response['paging'] }}"
-        page_size: "*ref(definitions.page_size)"
+        page_size: "#/definitions/page_size"
   base_stream:
     retriever:
-      $ref: "*ref(definitions.retriever)"
+      $ref: "#/definitions/retriever"
   jobs_stream: # https://workable.readme.io/reference/jobs
-    $ref: "*ref(definitions.base_stream)"
+    $ref: "#/definitions/base_stream"
     $options:
       name: "jobs"
       primary_key: "id"
       path: "/spi/v3/jobs"
       field_pointer: ["jobs"]
   candidates_stream: # https://workable.readme.io/reference/job-candidates-index
-    $ref: "*ref(definitions.base_stream)"
+    $ref: "#/definitions/base_stream"
     $options:
       name: "candidates"
       primary_key: "id"
       path: "/spi/v3/candidates"
       field_pointer: ["candidates"]
   stages_stream: # https://workable.readme.io/reference/stages
-    $ref: "*ref(definitions.base_stream)"
+    $ref: "#/definitions/base_stream"
     $options:
       name: "stages"
       primary_key: "slug"
       path: "/spi/v3/stages"
       field_pointer: ["stages"]
   recruiters_stream: # https://workable.readme.io/reference/recruiters
-    $ref: "*ref(definitions.base_stream)"
+    $ref: "#/definitions/base_stream"
     $options:
       name: "recruiters"
       primary_key: "id"
@@ -70,10 +70,10 @@ definitions:
       field_pointer: ["recruiters"]
 
 streams:
-  - "*ref(definitions.jobs_stream)"
-  - "*ref(definitions.candidates_stream)"
-  - "*ref(definitions.stages_stream)"
-  - "*ref(definitions.recruiters_stream)"
+  - "#/definitions/jobs_stream"
+  - "#/definitions/candidates_stream"
+  - "#/definitions/stages_stream"
+  - "#/definitions/recruiters_stream"
 
 check:
   stream_names:

--- a/airbyte-integrations/connectors/source-workramp/source_workramp/workramp.yaml
+++ b/airbyte-integrations/connectors/source-workramp/source_workramp/workramp.yaml
@@ -12,7 +12,7 @@ definitions:
       api_token: "{{ config['api_key'] }}"
   retriever:
     record_selector:
-      $ref: "*ref(definitions.selector)"
+      $ref: "#/definitions/selector"
     paginator:
       type: "DefaultPaginator"
       page_size_option:
@@ -25,58 +25,58 @@ definitions:
         inject_into: "request_parameter"
         field_name: "page"
       url_base:
-        $ref: "*ref(definitions.requester.url_base)"
+        $ref: "#/definitions/requester/url_base"
     requester:
-      $ref: "*ref(definitions.requester)"
+      $ref: "#/definitions/requester"
 
   base_stream:
     retriever:
-      $ref: "*ref(definitions.retriever)"
+      $ref: "#/definitions/retriever"
 
   awarded_certifications_stream:
-    $ref: "*ref(definitions.base_stream)"
+    $ref: "#/definitions/base_stream"
     $options:
       name: "awarded_certifications"
       primary_key: "id"
       path: "/awarded_certifications"
   certifications_stream:
-    $ref: "*ref(definitions.base_stream)"
+    $ref: "#/definitions/base_stream"
     $options:
       name: "certifications"
       primary_key: "id"
       path: "/certifications"
   paths_users_stream:
-    $ref: "*ref(definitions.base_stream)"
+    $ref: "#/definitions/base_stream"
     $options:
       name: "paths_users"
       primary_key: "id"
       path: "/paths_users"
   registrations_stream:
-    $ref: "*ref(definitions.base_stream)"
+    $ref: "#/definitions/base_stream"
     $options:
       name: "registrations"
       primary_key: "id"
       path: "/registrations"
   trainings_stream:
-    $ref: "*ref(definitions.base_stream)"
+    $ref: "#/definitions/base_stream"
     $options:
       name: "trainings"
       primary_key: "id"
       path: "/trainings"
   users_stream:
-    $ref: "*ref(definitions.base_stream)"
+    $ref: "#/definitions/base_stream"
     $options:
       name: "users"
       primary_key: "id"
       path: "/users"
 
 streams:
-  - "*ref(definitions.awarded_certifications_stream)"
-  - "*ref(definitions.certifications_stream)"
-  - "*ref(definitions.paths_users_stream)"
-  - "*ref(definitions.registrations_stream)"
-  - "*ref(definitions.trainings_stream)"
-  - "*ref(definitions.users_stream)"
+  - "#/definitions/awarded_certifications_stream"
+  - "#/definitions/certifications_stream"
+  - "#/definitions/paths_users_stream"
+  - "#/definitions/registrations_stream"
+  - "#/definitions/trainings_stream"
+  - "#/definitions/users_stream"
 
 check:
   stream_names:

--- a/airbyte-integrations/connectors/source-zapier-supported-storage/source_zapier_supported_storage/zapier_supported_storage.yaml
+++ b/airbyte-integrations/connectors/source-zapier-supported-storage/source_zapier_supported_storage/zapier_supported_storage.yaml
@@ -11,22 +11,22 @@ definitions:
       secret: "{{ config['secret'] }}"
   retriever:
     record_selector:
-      $ref: "*ref(definitions.selector)"
+      $ref: "#/definitions/selector"
     paginator:
       type: NoPagination
     requester:
-      $ref: "*ref(definitions.requester)"
+      $ref: "#/definitions/requester"
   base_stream:
     retriever:
-      $ref: "*ref(definitions.retriever)"
+      $ref: "#/definitions/retriever"
   zapier_supported_storage_stream:
-    $ref: "*ref(definitions.base_stream)"
+    $ref: "#/definitions/base_stream"
     $options:
       name: "zapier_supported_storage"
       path: "/records"
 
 streams:
-  - "*ref(definitions.zapier_supported_storage_stream)"
+  - "#/definitions/zapier_supported_storage_stream"
 
 check:
   stream_names:

--- a/airbyte-integrations/connectors/source-zenloop/source_zenloop/zenloop.yaml
+++ b/airbyte-integrations/connectors/source-zenloop/source_zenloop/zenloop.yaml
@@ -19,7 +19,7 @@ definitions:
       url_base: "https://api.zenloop.com/v1/"
     name: "{{ options['name'] }}"
     record_selector:
-      $ref: "*ref(definitions.selector)"
+      $ref: "#/definitions/selector"
     paginator:
       type: DefaultPaginator
       pagination_strategy:
@@ -34,22 +34,22 @@ definitions:
   base_stream:
     type: DeclarativeStream
     retriever:
-      $ref: "*ref(definitions.retriever)"
+      $ref: "#/definitions/retriever"
       requester:
-        $ref: "*ref(definitions.requester)"
+        $ref: "#/definitions/requester"
   incremental_base_stream:
-    $ref: "*ref(definitions.base_stream)"
+    $ref: "#/definitions/base_stream"
     stream_cursor_field: "inserted_at"
     retriever:
-      $ref: "*ref(definitions.retriever)"
+      $ref: "#/definitions/retriever"
       requester:
-        $ref: "*ref(definitions.requester)"
+        $ref: "#/definitions/requester"
         request_parameters:
           order_type: "desc"
           order_by: "inserted_at"
           date_shortcut: "custom"
   surveys:
-    $ref: "*ref(definitions.base_stream)"
+    $ref: "#/definitions/base_stream"
     $options:
       name: "surveys"
       path: "surveys"
@@ -59,11 +59,11 @@ definitions:
     $options:
       config_parent_field: "survey_id"
     parent_stream_configs:
-      - stream: "*ref(definitions.surveys)"
+      - stream: "#/definitions/surveys"
         parent_key: public_hash_id
         stream_slice_field: id
   survey_groups:
-    $ref: "*ref(definitions.base_stream)"
+    $ref: "#/definitions/base_stream"
     $options:
       name: "survey_groups"
       path: "survey_groups"
@@ -73,7 +73,7 @@ definitions:
     $options:
       config_parent_field: "survey_group_id"
     parent_stream_configs:
-      - stream: "*ref(definitions.survey_groups)"
+      - stream: "#/definitions/survey_groups"
         parent_key: public_hash_id
         stream_slice_field: id
   date_slicer:
@@ -95,54 +95,54 @@ definitions:
       field_name: "date_from"
       inject_into: "request_parameter"
   properties:
-    $ref: "*ref(definitions.base_stream)"
+    $ref: "#/definitions/base_stream"
     $options:
       name: "properties"
       data_field: "properties"
     retriever:
-      $ref: "*ref(definitions.retriever)"
+      $ref: "#/definitions/retriever"
       requester:
-        $ref: "*ref(definitions.requester)"
+        $ref: "#/definitions/requester"
         path: "{{ 'surveys/' + config['survey_id'] + '/properties' if config['survey_id'] else 'surveys/' + stream_slice.id + '/properties' }}"
       stream_slicer:
-        $ref: "*ref(definitions.surveys_slicer)"
+        $ref: "#/definitions/surveys_slicer"
   answers:
-    $ref: "*ref(definitions.incremental_base_stream)"
+    $ref: "#/definitions/incremental_base_stream"
     $options:
       name: "answers"
       data_field: "answers"
     retriever:
-      $ref: "*ref(definitions.retriever)"
+      $ref: "#/definitions/retriever"
       requester:
-        $ref: "*ref(definitions.incremental_base_stream.retriever.requester)"
+        $ref: "#/definitions/incremental_base_stream/retriever/requester"
         path: "{{ 'surveys/' + stream_slice.id + '/answers' }}"
       stream_slicer:
         type: CartesianProductStreamSlicer
         stream_slicers:
-          - "*ref(definitions.surveys_slicer)"
-          - "*ref(definitions.date_slicer)"
+          - "#/definitions/surveys_slicer"
+          - "#/definitions/date_slicer"
   answers_survey_group:
-    $ref: "*ref(definitions.incremental_base_stream)"
+    $ref: "#/definitions/incremental_base_stream"
     $options:
       name: "answers_survey_group"
       data_field: "answers"
     retriever:
-      $ref: "*ref(definitions.retriever)"
+      $ref: "#/definitions/retriever"
       requester:
-        $ref: "*ref(definitions.incremental_base_stream.retriever.requester)"
+        $ref: "#/definitions/incremental_base_stream/retriever/requester"
         path: "{{ 'survey_groups/' + stream_slice.id + '/answers' }}"
       stream_slicer:
         type: CartesianProductStreamSlicer
         stream_slicers:
-          - "*ref(definitions.survey_groups_slicer)"
-          - "*ref(definitions.date_slicer)"
+          - "#/definitions/survey_groups_slicer"
+          - "#/definitions/date_slicer"
 
 streams:
-  - "*ref(definitions.surveys)"
-  - "*ref(definitions.survey_groups)"
-  - "*ref(definitions.properties)"
-  - "*ref(definitions.answers)"
-  - "*ref(definitions.answers_survey_group)"
+  - "#/definitions/surveys"
+  - "#/definitions/survey_groups"
+  - "#/definitions/properties"
+  - "#/definitions/answers"
+  - "#/definitions/answers_survey_group"
 
 check:
   type: CheckStream

--- a/airbyte-integrations/connectors/source-zoom/source_zoom/zoom.yaml
+++ b/airbyte-integrations/connectors/source-zoom/source_zoom/zoom.yaml
@@ -21,11 +21,11 @@ definitions:
     page_token_option:
       field_name: "next_page_token"
       inject_into: "request_parameter"
-    url_base: "*ref(definitions.requester.url_base)"
+    url_base: "#/definitions/requester/url_base"
 
   retriever:
     requester:
-      $ref: "*ref(definitions.requester)"
+      $ref: "#/definitions/requester"
 
   schema_loader:
     type: JsonSchema
@@ -33,15 +33,15 @@ definitions:
 
   users_stream:
     schema_loader:
-      $ref: "*ref(definitions.schema_loader)"
+      $ref: "#/definitions/schema_loader"
     retriever:
       paginator:
-        $ref: "*ref(definitions.zoom_paginator)"
+        $ref: "#/definitions/zoom_paginator"
       record_selector:
         extractor:
           type: DpathExtractor
           field_pointer: ["users"]
-      $ref: "*ref(definitions.retriever)"
+      $ref: "#/definitions/retriever"
     $options:
       name: "users"
       primary_key: "id"
@@ -49,31 +49,31 @@ definitions:
 
   meetings_list_tmp_stream:
     schema_loader:
-      $ref: "*ref(definitions.schema_loader)"
+      $ref: "#/definitions/schema_loader"
     $options:
       name: "meetings_list_tmp"
       primary_key: "id"
     retriever:
       paginator:
-        $ref: "*ref(definitions.zoom_paginator)"
+        $ref: "#/definitions/zoom_paginator"
       record_selector:
         extractor:
           type: DpathExtractor
           field_pointer: ["meetings"]
-      $ref: "*ref(definitions.retriever)"
+      $ref: "#/definitions/retriever"
       requester:
-        $ref: "*ref(definitions.requester)"
+        $ref: "#/definitions/requester"
         path: "/users/{{ stream_slice.parent_id }}/meetings"
       stream_slicer:
         type: SubstreamSlicer
         parent_stream_configs:
-          - stream: "*ref(definitions.users_stream)"
+          - stream: "#/definitions/users_stream"
             parent_key: "id"
             stream_slice_field: "parent_id"
 
   meetings_stream:
     schema_loader:
-      $ref: "*ref(definitions.schema_loader)"
+      $ref: "#/definitions/schema_loader"
     $options:
       name: "meetings"
       primary_key: "id"
@@ -84,33 +84,33 @@ definitions:
         extractor:
           type: DpathExtractor
           field_pointer: []
-      $ref: "*ref(definitions.retriever)"
+      $ref: "#/definitions/retriever"
       requester:
-        $ref: "*ref(definitions.requester)"
+        $ref: "#/definitions/requester"
         path: "/meetings/{{ stream_slice.parent_id }}"
       stream_slicer:
         type: SubstreamSlicer
         parent_stream_configs:
-          - stream: "*ref(definitions.meetings_list_tmp_stream)"
+          - stream: "#/definitions/meetings_list_tmp_stream"
             parent_key: "id"
             stream_slice_field: "parent_id"
 
   meeting_registrants_stream:
     schema_loader:
-      $ref: "*ref(definitions.schema_loader)"
+      $ref: "#/definitions/schema_loader"
     $options:
       name: "meeting_registrants"
       primary_key: "id"
     retriever:
       paginator:
-        $ref: "*ref(definitions.zoom_paginator)"
+        $ref: "#/definitions/zoom_paginator"
       record_selector:
         extractor:
           type: DpathExtractor
           field_pointer: ["registrants"]
-      $ref: "*ref(definitions.retriever)"
+      $ref: "#/definitions/retriever"
       requester:
-        $ref: "*ref(definitions.requester)"
+        $ref: "#/definitions/requester"
         path: "/meetings/{{ stream_slice.parent_id }}/registrants"
         error_handler:
           type: CompositeErrorHandler
@@ -124,7 +124,7 @@ definitions:
       stream_slicer:
         type: SubstreamSlicer
         parent_stream_configs:
-          - stream: "*ref(definitions.meetings_list_tmp_stream)"
+          - stream: "#/definitions/meetings_list_tmp_stream"
             parent_key: "id"
             stream_slice_field: "parent_id"
     transformations:
@@ -135,7 +135,7 @@ definitions:
 
   meeting_polls_stream:
     schema_loader:
-      $ref: "*ref(definitions.schema_loader)"
+      $ref: "#/definitions/schema_loader"
     $options:
       name: "meeting_polls"
       primary_key: "id"
@@ -146,9 +146,9 @@ definitions:
         extractor:
           type: DpathExtractor
           field_pointer: ["polls"]
-      $ref: "*ref(definitions.retriever)"
+      $ref: "#/definitions/retriever"
       requester:
-        $ref: "*ref(definitions.requester)"
+        $ref: "#/definitions/requester"
         path: "/meetings/{{ stream_slice.parent_id }}/polls"
         error_handler:
           type: CompositeErrorHandler
@@ -162,7 +162,7 @@ definitions:
       stream_slicer:
         type: SubstreamSlicer
         parent_stream_configs:
-          - stream: "*ref(definitions.meetings_list_tmp_stream)"
+          - stream: "#/definitions/meetings_list_tmp_stream"
             parent_key: "id"
             stream_slice_field: "parent_id"
     transformations:
@@ -173,7 +173,7 @@ definitions:
 
   meeting_poll_results_stream:
     schema_loader:
-      $ref: "*ref(definitions.schema_loader)"
+      $ref: "#/definitions/schema_loader"
     $options:
       name: "meeting_poll_results"
     retriever:
@@ -183,9 +183,9 @@ definitions:
         extractor:
           type: DpathExtractor
           field_pointer: ["questions"]
-      $ref: "*ref(definitions.retriever)"
+      $ref: "#/definitions/retriever"
       requester:
-        $ref: "*ref(definitions.requester)"
+        $ref: "#/definitions/requester"
         path: "/past_meetings/{{ stream_slice.parent_id }}/polls"
         error_handler:
           type: CompositeErrorHandler
@@ -200,7 +200,7 @@ definitions:
       stream_slicer:
         type: SubstreamSlicer
         parent_stream_configs:
-          - stream: "*ref(definitions.meetings_list_tmp_stream)"
+          - stream: "#/definitions/meetings_list_tmp_stream"
             parent_key: "uuid"
             stream_slice_field: "parent_id"
     transformations:
@@ -211,7 +211,7 @@ definitions:
 
   meeting_registration_questions_stream:
     schema_loader:
-      $ref: "*ref(definitions.schema_loader)"
+      $ref: "#/definitions/schema_loader"
     $options:
       name: "meeting_registration_questions"
     retriever:
@@ -221,9 +221,9 @@ definitions:
         extractor:
           type: DpathExtractor
           field_pointer: []
-      $ref: "*ref(definitions.retriever)"
+      $ref: "#/definitions/retriever"
       requester:
-        $ref: "*ref(definitions.requester)"
+        $ref: "#/definitions/requester"
         path: "/meetings/{{ stream_slice.parent_id }}/registrants/questions"
         error_handler:
           type: CompositeErrorHandler
@@ -237,7 +237,7 @@ definitions:
       stream_slicer:
         type: SubstreamSlicer
         parent_stream_configs:
-          - stream: "*ref(definitions.meetings_list_tmp_stream)"
+          - stream: "#/definitions/meetings_list_tmp_stream"
             parent_key: "id"
             stream_slice_field: "parent_id"
     transformations:
@@ -248,20 +248,20 @@ definitions:
 
   webinars_list_tmp_stream:
     schema_loader:
-      $ref: "*ref(definitions.schema_loader)"
+      $ref: "#/definitions/schema_loader"
     $options:
       name: "webinars_list_tmp"
       primary_key: "id"
     retriever:
       paginator:
-        $ref: "*ref(definitions.zoom_paginator)"
+        $ref: "#/definitions/zoom_paginator"
       record_selector:
         extractor:
           type: DpathExtractor
           field_pointer: ["webinars"]
-      $ref: "*ref(definitions.retriever)"
+      $ref: "#/definitions/retriever"
       requester:
-        $ref: "*ref(definitions.requester)"
+        $ref: "#/definitions/requester"
         path: "/users/{{ stream_slice.parent_id }}/webinars"
         error_handler:
           type: CompositeErrorHandler
@@ -275,13 +275,13 @@ definitions:
       stream_slicer:
         type: SubstreamSlicer
         parent_stream_configs:
-          - stream: "*ref(definitions.users_stream)"
+          - stream: "#/definitions/users_stream"
             parent_key: "id"
             stream_slice_field: "parent_id"
 
   webinars_stream:
     schema_loader:
-      $ref: "*ref(definitions.schema_loader)"
+      $ref: "#/definitions/schema_loader"
     $options:
       name: "webinars"
       primary_key: "id"
@@ -292,9 +292,9 @@ definitions:
         extractor:
           type: DpathExtractor
           field_pointer: []
-      $ref: "*ref(definitions.retriever)"
+      $ref: "#/definitions/retriever"
       requester:
-        $ref: "*ref(definitions.requester)"
+        $ref: "#/definitions/requester"
         path: "/webinars/{{ stream_slice.parent_id }}"
         error_handler:
           type: CompositeErrorHandler
@@ -310,13 +310,13 @@ definitions:
       stream_slicer:
         type: SubstreamSlicer
         parent_stream_configs:
-          - stream: "*ref(definitions.webinars_list_tmp_stream)"
+          - stream: "#/definitions/webinars_list_tmp_stream"
             parent_key: "id"
             stream_slice_field: "parent_id"
 
   webinar_panelists_stream:
     schema_loader:
-      $ref: "*ref(definitions.schema_loader)"
+      $ref: "#/definitions/schema_loader"
     $options:
       name: "webinar_panelists"
     retriever:
@@ -326,9 +326,9 @@ definitions:
         extractor:
           type: DpathExtractor
           field_pointer: ["panelists"]
-      $ref: "*ref(definitions.retriever)"
+      $ref: "#/definitions/retriever"
       requester:
-        $ref: "*ref(definitions.requester)"
+        $ref: "#/definitions/requester"
         path: "/webinars/{{ stream_slice.parent_id }}/panelists"
         error_handler:
           type: CompositeErrorHandler
@@ -343,7 +343,7 @@ definitions:
       stream_slicer:
         type: SubstreamSlicer
         parent_stream_configs:
-          - stream: "*ref(definitions.webinars_list_tmp_stream)"
+          - stream: "#/definitions/webinars_list_tmp_stream"
             parent_key: "id"
             stream_slice_field: "parent_id"
     transformations:
@@ -354,19 +354,19 @@ definitions:
 
   webinar_registrants_stream:
     schema_loader:
-      $ref: "*ref(definitions.schema_loader)"
+      $ref: "#/definitions/schema_loader"
     $options:
       name: "webinar_registrants"
     retriever:
       paginator:
-        $ref: "*ref(definitions.zoom_paginator)"
+        $ref: "#/definitions/zoom_paginator"
       record_selector:
         extractor:
           type: DpathExtractor
           field_pointer: ["registrants"]
-      $ref: "*ref(definitions.retriever)"
+      $ref: "#/definitions/retriever"
       requester:
-        $ref: "*ref(definitions.requester)"
+        $ref: "#/definitions/requester"
         path: "/webinars/{{ stream_slice.parent_id }}/registrants"
         error_handler:
           type: CompositeErrorHandler
@@ -381,7 +381,7 @@ definitions:
       stream_slicer:
         type: SubstreamSlicer
         parent_stream_configs:
-          - stream: "*ref(definitions.webinars_list_tmp_stream)"
+          - stream: "#/definitions/webinars_list_tmp_stream"
             parent_key: "id"
             stream_slice_field: "parent_id"
     transformations:
@@ -392,20 +392,20 @@ definitions:
 
   webinar_absentees_stream:
     schema_loader:
-      $ref: "*ref(definitions.schema_loader)"
+      $ref: "#/definitions/schema_loader"
     $options:
       name: "webinar_absentees"
       primary_key: "id"
     retriever:
       paginator:
-        $ref: "*ref(definitions.zoom_paginator)"
+        $ref: "#/definitions/zoom_paginator"
       record_selector:
         extractor:
           type: DpathExtractor
           field_pointer: ["registrants"]
-      $ref: "*ref(definitions.retriever)"
+      $ref: "#/definitions/retriever"
       requester:
-        $ref: "*ref(definitions.requester)"
+        $ref: "#/definitions/requester"
         path: "/past_webinars/{{ stream_slice.parent_uuid }}/absentees"
         error_handler:
           type: CompositeErrorHandler
@@ -420,7 +420,7 @@ definitions:
       stream_slicer:
         type: SubstreamSlicer
         parent_stream_configs:
-          - stream: "*ref(definitions.webinars_list_tmp_stream)"
+          - stream: "#/definitions/webinars_list_tmp_stream"
             parent_key: "uuid"
             stream_slice_field: "parent_uuid"
     transformations:
@@ -431,7 +431,7 @@ definitions:
 
   webinar_polls_stream:
     schema_loader:
-      $ref: "*ref(definitions.schema_loader)"
+      $ref: "#/definitions/schema_loader"
     $options:
       name: "webinar_polls"
     retriever:
@@ -441,9 +441,9 @@ definitions:
         extractor:
           type: DpathExtractor
           field_pointer: ["polls"]
-      $ref: "*ref(definitions.retriever)"
+      $ref: "#/definitions/retriever"
       requester:
-        $ref: "*ref(definitions.requester)"
+        $ref: "#/definitions/requester"
         path: "/webinars/{{ stream_slice.parent_id }}/polls"
         error_handler:
           type: CompositeErrorHandler
@@ -458,7 +458,7 @@ definitions:
       stream_slicer:
         type: SubstreamSlicer
         parent_stream_configs:
-          - stream: "*ref(definitions.webinars_list_tmp_stream)"
+          - stream: "#/definitions/webinars_list_tmp_stream"
             parent_key: "id"
             stream_slice_field: "parent_id"
     transformations:
@@ -469,7 +469,7 @@ definitions:
 
   webinar_poll_results_stream:
     schema_loader:
-      $ref: "*ref(definitions.schema_loader)"
+      $ref: "#/definitions/schema_loader"
     $options:
       name: "webinar_poll_results"
     retriever:
@@ -479,9 +479,9 @@ definitions:
         extractor:
           type: DpathExtractor
           field_pointer: ["questions"]
-      $ref: "*ref(definitions.retriever)"
+      $ref: "#/definitions/retriever"
       requester:
-        $ref: "*ref(definitions.requester)"
+        $ref: "#/definitions/requester"
         path: "/past_webinars/{{ stream_slice.parent_id }}/polls"
         error_handler:
           type: CompositeErrorHandler
@@ -494,7 +494,7 @@ definitions:
       stream_slicer:
         type: SubstreamSlicer
         parent_stream_configs:
-          - stream: "*ref(definitions.webinars_list_tmp_stream)"
+          - stream: "#/definitions/webinars_list_tmp_stream"
             parent_key: "uuid"
             stream_slice_field: "parent_id"
     transformations:
@@ -505,7 +505,7 @@ definitions:
 
   webinar_registration_questions_stream:
     schema_loader:
-      $ref: "*ref(definitions.schema_loader)"
+      $ref: "#/definitions/schema_loader"
     $options:
       name: "webinar_registration_questions"
     retriever:
@@ -515,9 +515,9 @@ definitions:
         extractor:
           type: DpathExtractor
           field_pointer: []
-      $ref: "*ref(definitions.retriever)"
+      $ref: "#/definitions/retriever"
       requester:
-        $ref: "*ref(definitions.requester)"
+        $ref: "#/definitions/requester"
         path: "/webinars/{{ stream_slice.parent_id }}/registrants/questions"
         error_handler:
           type: CompositeErrorHandler
@@ -531,7 +531,7 @@ definitions:
       stream_slicer:
         type: SubstreamSlicer
         parent_stream_configs:
-          - stream: "*ref(definitions.webinars_list_tmp_stream)"
+          - stream: "#/definitions/webinars_list_tmp_stream"
             parent_key: "id"
             stream_slice_field: "parent_id"
     transformations:
@@ -542,7 +542,7 @@ definitions:
 
   webinar_tracking_sources_stream:
     schema_loader:
-      $ref: "*ref(definitions.schema_loader)"
+      $ref: "#/definitions/schema_loader"
     $options:
       name: "webinar_tracking_sources"
       primary_key: "id"
@@ -553,9 +553,9 @@ definitions:
         extractor:
           type: DpathExtractor
           field_pointer: ["tracking_sources"]
-      $ref: "*ref(definitions.retriever)"
+      $ref: "#/definitions/retriever"
       requester:
-        $ref: "*ref(definitions.requester)"
+        $ref: "#/definitions/requester"
         path: "/webinars/{{ stream_slice.parent_id }}/tracking_sources"
         error_handler:
           type: CompositeErrorHandler
@@ -568,7 +568,7 @@ definitions:
       stream_slicer:
         type: SubstreamSlicer
         parent_stream_configs:
-          - stream: "*ref(definitions.webinars_list_tmp_stream)"
+          - stream: "#/definitions/webinars_list_tmp_stream"
             parent_key: "id"
             stream_slice_field: "parent_id"
     transformations:
@@ -579,7 +579,7 @@ definitions:
 
   webinar_qna_results_stream:
     schema_loader:
-      $ref: "*ref(definitions.schema_loader)"
+      $ref: "#/definitions/schema_loader"
     $options:
       name: "webinar_qna_results"
     retriever:
@@ -589,9 +589,9 @@ definitions:
         extractor:
           type: DpathExtractor
           field_pointer: ["questions"]
-      $ref: "*ref(definitions.retriever)"
+      $ref: "#/definitions/retriever"
       requester:
-        $ref: "*ref(definitions.requester)"
+        $ref: "#/definitions/requester"
         path: "/past_webinars/{{ stream_slice.parent_id }}/qa"
         error_handler:
           type: CompositeErrorHandler
@@ -604,7 +604,7 @@ definitions:
       stream_slicer:
         type: SubstreamSlicer
         parent_stream_configs:
-          - stream: "*ref(definitions.webinars_list_tmp_stream)"
+          - stream: "#/definitions/webinars_list_tmp_stream"
             parent_key: "uuid"
             stream_slice_field: "parent_id"
     transformations:
@@ -615,7 +615,7 @@ definitions:
 
   report_meetings_stream:
     schema_loader:
-      $ref: "*ref(definitions.schema_loader)"
+      $ref: "#/definitions/schema_loader"
     $options:
       name: "report_meetings"
       primary_key: "id"
@@ -626,9 +626,9 @@ definitions:
         extractor:
           type: DpathExtractor
           field_pointer: ["tracking_sources"]
-      $ref: "*ref(definitions.retriever)"
+      $ref: "#/definitions/retriever"
       requester:
-        $ref: "*ref(definitions.requester)"
+        $ref: "#/definitions/requester"
         path: "/report/meetings/{{ stream_slice.parent_id }}"
         error_handler:
           type: CompositeErrorHandler
@@ -641,7 +641,7 @@ definitions:
       stream_slicer:
         type: SubstreamSlicer
         parent_stream_configs:
-          - stream: "*ref(definitions.meetings_list_tmp_stream)"
+          - stream: "#/definitions/meetings_list_tmp_stream"
             parent_key: "uuid"
             stream_slice_field: "parent_id"
     transformations:
@@ -652,20 +652,20 @@ definitions:
 
   report_meeting_participants_stream:
     schema_loader:
-      $ref: "*ref(definitions.schema_loader)"
+      $ref: "#/definitions/schema_loader"
     $options:
       name: "report_meeting_participants"
       primary_key: "id"
     retriever:
       paginator:
-        $ref: "*ref(definitions.zoom_paginator)"
+        $ref: "#/definitions/zoom_paginator"
       record_selector:
         extractor:
           type: DpathExtractor
           field_pointer: ["participants"]
-      $ref: "*ref(definitions.retriever)"
+      $ref: "#/definitions/retriever"
       requester:
-        $ref: "*ref(definitions.requester)"
+        $ref: "#/definitions/requester"
         path: "/report/meetings/{{ stream_slice.parent_id }}/participants"
         error_handler:
           type: CompositeErrorHandler
@@ -678,7 +678,7 @@ definitions:
       stream_slicer:
         type: SubstreamSlicer
         parent_stream_configs:
-          - stream: "*ref(definitions.meetings_list_tmp_stream)"
+          - stream: "#/definitions/meetings_list_tmp_stream"
             parent_key: "uuid"
             stream_slice_field: "parent_id"
     transformations:
@@ -689,7 +689,7 @@ definitions:
 
   report_webinars_stream:
     schema_loader:
-      $ref: "*ref(definitions.schema_loader)"
+      $ref: "#/definitions/schema_loader"
     $options:
       name: "report_webinars"
     retriever:
@@ -699,9 +699,9 @@ definitions:
         extractor:
           type: DpathExtractor
           field_pointer: []
-      $ref: "*ref(definitions.retriever)"
+      $ref: "#/definitions/retriever"
       requester:
-        $ref: "*ref(definitions.requester)"
+        $ref: "#/definitions/requester"
         path: "/report/webinars/{{ stream_slice.parent_id }}"
         error_handler:
           type: CompositeErrorHandler
@@ -714,7 +714,7 @@ definitions:
       stream_slicer:
         type: SubstreamSlicer
         parent_stream_configs:
-          - stream: "*ref(definitions.webinars_list_tmp_stream)"
+          - stream: "#/definitions/webinars_list_tmp_stream"
             parent_key: "uuid"
             stream_slice_field: "parent_id"
     transformations:
@@ -725,19 +725,19 @@ definitions:
 
   report_webinar_participants_stream:
     schema_loader:
-      $ref: "*ref(definitions.schema_loader)"
+      $ref: "#/definitions/schema_loader"
     $options:
       name: "report_webinar_participants"
     retriever:
       paginator:
-        $ref: "*ref(definitions.zoom_paginator)"
+        $ref: "#/definitions/zoom_paginator"
       record_selector:
         extractor:
           type: DpathExtractor
           field_pointer: ["participants"]
-      $ref: "*ref(definitions.retriever)"
+      $ref: "#/definitions/retriever"
       requester:
-        $ref: "*ref(definitions.requester)"
+        $ref: "#/definitions/requester"
         path: "/report/webinars/{{ stream_slice.parent_id }}/participants"
         error_handler:
           type: CompositeErrorHandler
@@ -750,7 +750,7 @@ definitions:
       stream_slicer:
         type: SubstreamSlicer
         parent_stream_configs:
-          - stream: "*ref(definitions.webinars_list_tmp_stream)"
+          - stream: "#/definitions/webinars_list_tmp_stream"
             parent_key: "uuid"
             stream_slice_field: "parent_id"
     transformations:
@@ -760,25 +760,25 @@ definitions:
             value: "{{ stream_slice.parent_id }}"
 
 streams:
-  - "*ref(definitions.users_stream)"
-  - "*ref(definitions.meetings_stream)"
-  - "*ref(definitions.meeting_registrants_stream)"
-  - "*ref(definitions.meeting_polls_stream)"
-  - "*ref(definitions.meeting_poll_results_stream)"
-  - "*ref(definitions.meeting_registration_questions_stream)"
-  - "*ref(definitions.webinars_stream)"
-  - "*ref(definitions.webinar_panelists_stream)"
-  - "*ref(definitions.webinar_registrants_stream)"
-  - "*ref(definitions.webinar_absentees_stream)"
-  - "*ref(definitions.webinar_polls_stream)"
-  - "*ref(definitions.webinar_poll_results_stream)"
-  - "*ref(definitions.webinar_registration_questions_stream)"
-  - "*ref(definitions.webinar_tracking_sources_stream)"
-  - "*ref(definitions.webinar_qna_results_stream)"
-  - "*ref(definitions.report_meetings_stream)"
-  - "*ref(definitions.report_meeting_participants_stream)"
-  - "*ref(definitions.report_webinars_stream)"
-  - "*ref(definitions.report_webinar_participants_stream)"
+  - "#/definitions/users_stream"
+  - "#/definitions/meetings_stream"
+  - "#/definitions/meeting_registrants_stream"
+  - "#/definitions/meeting_polls_stream"
+  - "#/definitions/meeting_poll_results_stream"
+  - "#/definitions/meeting_registration_questions_stream"
+  - "#/definitions/webinars_stream"
+  - "#/definitions/webinar_panelists_stream"
+  - "#/definitions/webinar_registrants_stream"
+  - "#/definitions/webinar_absentees_stream"
+  - "#/definitions/webinar_polls_stream"
+  - "#/definitions/webinar_poll_results_stream"
+  - "#/definitions/webinar_registration_questions_stream"
+  - "#/definitions/webinar_tracking_sources_stream"
+  - "#/definitions/webinar_qna_results_stream"
+  - "#/definitions/report_meetings_stream"
+  - "#/definitions/report_meeting_participants_stream"
+  - "#/definitions/report_webinars_stream"
+  - "#/definitions/report_webinar_participants_stream"
 
 check:
   stream_names:


### PR DESCRIPTION
## What
Updates all manifests to the new `ref` format, `#/`.

## How
Runs the script from https://github.com/airbytehq/airbyte/pull/21434/files#diff-ecce74fe42149d709b5dd2f582fed104fdd21c81fd2603b06d117182ed49d4e3.

## 🚨 User Impact 🚨
Currently we are not planning to create a new release for all of the sources with updated manifests; the updated manifests will be in place and the sources can be re-relased as needed.

## Pre-merge Checklist

- [x] Spot check sources with the [`/test connector=connectors/<name>` command](https://docs.airbyte.io/connector-development#updating-an-existing-connector)
- [x] Run `./gradlew validateSourceYamlManifest`