### PR TITLE
Allow all origin in cors

### DIFF
--- a/airbyte-server/src/main/resources/application.yml
+++ b/airbyte-server/src/main/resources/application.yml
@@ -22,7 +22,7 @@ micronaut:
       configurations:
         web:
           allowedOrigins:
-            - ^http(|s)://www\..*$
+            - ^.*$
 airbyte:
   cloud:
     storage:

--- a/airbyte-server/src/main/resources/application.yml
+++ b/airbyte-server/src/main/resources/application.yml
@@ -19,6 +19,10 @@ micronaut:
     port: 8001
     cors:
       enabled: true
+      configurations:
+        web:
+          allowedOrigins:
+            - ^http(|s)://www\..*$
 airbyte:
   cloud:
     storage:


### PR DESCRIPTION
## What
Micronaut has some check in the CORS filter specifiv to the localhost. This will allow all the Cors requests, including the one coming from localhost.