### PR TITLE
Fix an npe on a sort fuction

### DIFF
--- a/airbyte-workers/src/main/java/io/airbyte/workers/temporal/scheduling/activities/JobCreationAndStatusUpdateActivityImpl.java
+++ b/airbyte-workers/src/main/java/io/airbyte/workers/temporal/scheduling/activities/JobCreationAndStatusUpdateActivityImpl.java
@@ -78,6 +78,8 @@ import java.util.OptionalLong;
 import java.util.Set;
 import java.util.UUID;
 import java.util.stream.Collectors;
+import java.util.stream.Stream;
+
 import lombok.extern.slf4j.Slf4j;
 
 @Slf4j
@@ -484,9 +486,11 @@ public class JobCreationAndStatusUpdateActivityImpl implements JobCreationAndSta
   private static final Comparator<ReleaseStage> RELEASE_STAGE_COMPARATOR = Comparator.comparingInt(RELEASE_STAGE_ORDER::get);
 
   private static List<ReleaseStage> orderByReleaseStageAsc(final List<ReleaseStage> releaseStages) {
-    final List<ReleaseStage> copiedList = new ArrayList<>(releaseStages);
-    copiedList.sort(RELEASE_STAGE_COMPARATOR);
-    return copiedList;
+    // Using collector to get a mutable list
+    return releaseStages.stream()
+            .filter(stage -> stage != null)
+            .sorted(RELEASE_STAGE_COMPARATOR)
+            .toList();
   }
 
   /**

--- a/airbyte-workers/src/main/java/io/airbyte/workers/temporal/scheduling/activities/JobCreationAndStatusUpdateActivityImpl.java
+++ b/airbyte-workers/src/main/java/io/airbyte/workers/temporal/scheduling/activities/JobCreationAndStatusUpdateActivityImpl.java
@@ -14,6 +14,7 @@ import static io.airbyte.metrics.lib.ApmTraceConstants.Tags.JOB_ID_KEY;
 import static io.airbyte.persistence.job.models.AttemptStatus.FAILED;
 
 import com.fasterxml.jackson.databind.JsonNode;
+import com.google.common.annotations.VisibleForTesting;
 import com.google.common.collect.Lists;
 import datadog.trace.api.Trace;
 import io.airbyte.commons.docker.DockerUtils;
@@ -482,7 +483,8 @@ public class JobCreationAndStatusUpdateActivityImpl implements JobCreationAndSta
       ReleaseStage.generally_available, 4);
   private static final Comparator<ReleaseStage> RELEASE_STAGE_COMPARATOR = Comparator.comparingInt(RELEASE_STAGE_ORDER::get);
 
-  private static List<ReleaseStage> orderByReleaseStageAsc(final List<ReleaseStage> releaseStages) {
+  @VisibleForTesting
+  static List<ReleaseStage> orderByReleaseStageAsc(final List<ReleaseStage> releaseStages) {
     // Using collector to get a mutable list
     return releaseStages.stream()
         .filter(stage -> stage != null)

--- a/airbyte-workers/src/main/java/io/airbyte/workers/temporal/scheduling/activities/JobCreationAndStatusUpdateActivityImpl.java
+++ b/airbyte-workers/src/main/java/io/airbyte/workers/temporal/scheduling/activities/JobCreationAndStatusUpdateActivityImpl.java
@@ -66,7 +66,6 @@ import io.micronaut.core.util.CollectionUtils;
 import jakarta.inject.Singleton;
 import java.io.IOException;
 import java.nio.file.Path;
-import java.util.ArrayList;
 import java.util.Collections;
 import java.util.Comparator;
 import java.util.HashSet;
@@ -78,8 +77,6 @@ import java.util.OptionalLong;
 import java.util.Set;
 import java.util.UUID;
 import java.util.stream.Collectors;
-import java.util.stream.Stream;
-
 import lombok.extern.slf4j.Slf4j;
 
 @Slf4j
@@ -488,9 +485,9 @@ public class JobCreationAndStatusUpdateActivityImpl implements JobCreationAndSta
   private static List<ReleaseStage> orderByReleaseStageAsc(final List<ReleaseStage> releaseStages) {
     // Using collector to get a mutable list
     return releaseStages.stream()
-            .filter(stage -> stage != null)
-            .sorted(RELEASE_STAGE_COMPARATOR)
-            .toList();
+        .filter(stage -> stage != null)
+        .sorted(RELEASE_STAGE_COMPARATOR)
+        .toList();
   }
 
   /**

--- a/airbyte-workers/src/test/java/io/airbyte/workers/temporal/scheduling/activities/JobCreationAndStatusUpdateActivityTest.java
+++ b/airbyte-workers/src/test/java/io/airbyte/workers/temporal/scheduling/activities/JobCreationAndStatusUpdateActivityTest.java
@@ -542,7 +542,7 @@ class JobCreationAndStatusUpdateActivityTest {
     final List<ReleaseStage> expected = List.of(ReleaseStage.custom, ReleaseStage.alpha, ReleaseStage.beta, ReleaseStage.generally_available);
 
     Assertions.assertThat(JobCreationAndStatusUpdateActivityImpl.orderByReleaseStageAsc(input))
-            .containsExactlyElementsOf(expected);
+        .containsExactlyElementsOf(expected);
   }
 
 }

--- a/airbyte-workers/src/test/java/io/airbyte/workers/temporal/scheduling/activities/JobCreationAndStatusUpdateActivityTest.java
+++ b/airbyte-workers/src/test/java/io/airbyte/workers/temporal/scheduling/activities/JobCreationAndStatusUpdateActivityTest.java
@@ -33,6 +33,7 @@ import io.airbyte.config.helpers.LogConfigs;
 import io.airbyte.config.persistence.ConfigNotFoundException;
 import io.airbyte.config.persistence.ConfigRepository;
 import io.airbyte.config.persistence.StreamResetPersistence;
+import io.airbyte.db.instance.configs.jooq.generated.enums.ReleaseStage;
 import io.airbyte.persistence.job.JobCreator;
 import io.airbyte.persistence.job.JobNotifier;
 import io.airbyte.persistence.job.JobPersistence;
@@ -533,6 +534,15 @@ class JobCreationAndStatusUpdateActivityTest {
       Mockito.verifyNoMoreInteractions(mJobPersistence, mJobNotifier, mJobtracker);
     }
 
+  }
+
+  @Test
+  void testReleaseStageOrdering() {
+    final List<ReleaseStage> input = List.of(ReleaseStage.alpha, ReleaseStage.custom, ReleaseStage.beta, ReleaseStage.generally_available);
+    final List<ReleaseStage> expected = List.of(ReleaseStage.custom, ReleaseStage.alpha, ReleaseStage.beta, ReleaseStage.generally_available);
+
+    Assertions.assertThat(JobCreationAndStatusUpdateActivityImpl.orderByReleaseStageAsc(input))
+            .containsExactlyElementsOf(expected);
   }
 
 }


### PR DESCRIPTION
## What
An Npe exception during the sort of the release stages was causing confusing on build. This error was not terminal and would likely pass the test. This is filtering null values before sorting.
