### PR TITLE
🪟 🐛 Force refresh of firebase token after verifying email

### DIFF
--- a/airbyte-webapp/src/packages/cloud/lib/auth/GoogleAuthService.ts
+++ b/airbyte-webapp/src/packages/cloud/lib/auth/GoogleAuthService.ts
@@ -20,6 +20,8 @@ import {
   signInWithPopup,
   GoogleAuthProvider,
   GithubAuthProvider,
+  getIdToken,
+  reload,
 } from "firebase/auth";
 
 import { Provider } from "config";
@@ -144,7 +146,13 @@ export class GoogleAuthService {
   }
 
   async confirmEmailVerify(code: string): Promise<void> {
-    return applyActionCode(this.auth, code);
+    await applyActionCode(this.auth, code);
+
+    // Reload the user and get a fresh token with email_verified: true
+    if (this.auth.currentUser) {
+      await reload(this.auth.currentUser);
+      await getIdToken(this.auth.currentUser, true);
+    }
   }
 
   async signInWithEmailLink(email: string): Promise<UserCredential> {


### PR DESCRIPTION
## What
Forces firebase to fetch a new ID token (JWT) after a user verifies their email. This new token will have `email_verified: true`, to reflect the new user status. By default, firebase will not get a new token until 5 mins before it expires, so we need to explicitly refresh it in this case.