### PR TITLE
Checkboxes in dropdowns now correctly visually update when clicked

### DIFF
--- a/airbyte-webapp/src/components/ui/DropDown/components/Option.tsx
+++ b/airbyte-webapp/src/components/ui/DropDown/components/Option.tsx
@@ -60,13 +60,13 @@ export const DropDownOption: React.FC<DropDownOptionProps> = (props) => {
         isSelected={props.isSelected && !props.isMulti}
         isDisabled={props.isDisabled}
         isFocused={props.isFocused}
-        onClick={(e) => {
+        onClick={(event) => {
           // This custom onClick handler prevents the click event from bubbling up outside of the option
           // for cases where the Dropdown is a child of a clickable parent such as a table row.
           props.selectOption(props.data);
-          e.stopPropagation();
+          event.stopPropagation();
           // The checkbox does not work properly without this
-          e.preventDefault();
+          event.preventDefault();
         }}
       >
         <DropDownText primary={props.data.primary} secondary={props.data.secondary} fullText={props.data.fullText}>

--- a/airbyte-webapp/src/components/ui/DropDown/components/Option.tsx
+++ b/airbyte-webapp/src/components/ui/DropDown/components/Option.tsx
@@ -60,11 +60,13 @@ export const DropDownOption: React.FC<DropDownOptionProps> = (props) => {
         isSelected={props.isSelected && !props.isMulti}
         isDisabled={props.isDisabled}
         isFocused={props.isFocused}
-        onClick={(event) => {
+        onClick={(e) => {
           // This custom onClick handler prevents the click event from bubbling up outside of the option
           // for cases where the Dropdown is a child of a clickable parent such as a table row.
           props.selectOption(props.data);
-          event.stopPropagation();
+          e.stopPropagation();
+          // The checkbox does not work properly without this
+          e.preventDefault();
         }}
       >
         <DropDownText primary={props.data.primary} secondary={props.data.secondary} fullText={props.data.fullText}>


### PR DESCRIPTION
## What
Resolves #21707
Checkboxes in the select dropdown triggered logic, but did not cause a visual change.

## How
preventDefault causes the checkboxes to stop toggling themselves and to instead only toggle based on the data.