### PR TITLE
authenticate when calling setup-python

### DIFF
--- a/.github/workflows/gradle.yml
+++ b/.github/workflows/gradle.yml
@@ -124,6 +124,7 @@ jobs:
       - uses: actions/setup-python@v4
         with:
           python-version: "3.9"
+          token: ${{ env.PAT }}
 
       - name: Set up CI Gradle Properties
         run: |
@@ -229,6 +230,7 @@ jobs:
       - uses: actions/setup-python@v4
         with:
           python-version: "3.9"
+          token: ${{ env.PAT }}
 
       - name: Install Pyenv
         run: python3 -m pip install virtualenv==16.7.9 --user
@@ -412,6 +414,7 @@ jobs:
       - uses: actions/setup-python@v4
         with:
           python-version: "3.9"
+          token: ${{ env.PAT }}
 
       - name: Set up CI Gradle Properties
         run: |
@@ -535,6 +538,7 @@ jobs:
       - uses: actions/setup-python@v4
         with:
           python-version: "3.9"
+          token: ${{ env.PAT }}
 
       - name: Delete default old docker and replace it with a new one
         shell: bash
@@ -666,6 +670,7 @@ jobs:
       - uses: actions/setup-python@v4
         with:
           python-version: "3.9"
+          token: ${{ env.PAT }}
 
       - uses: actions/setup-node@v3
         with:
@@ -800,6 +805,7 @@ jobs:
         if: always()
         with:
           python-version: "3.9"
+          token: ${{ env.PAT }}
 
       - name: Publish Platform Test Results
         uses: EnricoMi/publish-unit-test-result-action@v2
@@ -945,6 +951,7 @@ jobs:
       - uses: actions/setup-python@v4
         with:
           python-version: "3.9"
+          token: ${{ env.PAT }}
 
       - name: Install unzip
         shell: bash
@@ -1021,6 +1028,7 @@ jobs:
         if: always()
         with:
           python-version: "3.9"
+          token: ${{ env.PAT }}
 
       - name: Publish Kube Test Results
         id: kube-results
@@ -1191,6 +1199,7 @@ jobs:
       - uses: actions/setup-python@v4
         with:
           python-version: "3.9"
+          token: ${{ env.PAT }}
 
       - uses: actions/setup-java@v1
         with:


### PR DESCRIPTION
## What
We have two problems currently

1. We call setup-python 9 times in our airbyte ci workflow. That's a LOT of downloading of basically the same files over and over
2. setup-python auth's using GITHUB_TOKEN[ if you don't specify a token](https://github.com/actions/setup-python/blob/a6eba85bba13ec8929458742a9c19803934c4340/docs/advanced-usage.md?plain=1#L545). This is causing rate limit issues. We want to instead use a PAT to auth which has higher rate limits.

## How
Solve 2 because it's a quick fix. Acknowledge 1 needs to be solved either by caching or some other solution. Other setup-platform actions like setup-node have fallbacks to hit other places but it doesn't look like the team behind setup-python are interested in adding that functionality to their action, unfortunately.


