### PR TITLE
Update to latest Micronaut release

### DIFF
--- a/deps.toml
+++ b/deps.toml
@@ -20,7 +20,10 @@ jooq = "3.13.4"
 junit-jupiter = "5.9.1"
 log4j = "2.17.2"
 lombok = "1.18.24"
-micronaut = "3.8.1"
+micronaut = "3.8.2"
+micronaut-data = "3.9.4"
+micronaut-jaxrs = "3.4.0"
+micronaut-security = "3.9.2"
 micronaut-test = "3.8.0"
 platform-testcontainers = "1.17.3"
 postgresql = "42.3.5"
@@ -103,6 +106,7 @@ platform-testcontainers-postgresql = { module = "org.testcontainers:postgresql",
 postgresql = { module = "org.postgresql:postgresql", version.ref = "postgresql" }
 quartz-scheduler = { module = "org.quartz-scheduler:quartz", version = "2.3.2" }
 reactor-core = { module = "io.projectreactor:reactor-core", version.ref = "reactor" }
+reactor-test = { module = "io.projectreactor:reactor-test", version.ref = "reactor" }
 s3 = { module = "software.amazon.awssdk:s3", version = "2.16.84" }
 slf4j-api = { module = "org.slf4j:slf4j-api", version.ref = "slf4j" }
 spotbugs-annotations = { module = "com.github.spotbugs:spotbugs-annotations", version = "4.7.3" }
@@ -117,21 +121,22 @@ jakarta-inject = { module = "jakarta.annotation:jakarta.annotation-api", version
 javax-transaction = { module = "javax.transaction:javax.transaction-api", version = "1.3" }
 micronaut-bom = { module = "io.micronaut:micronaut-bom", version.ref = "micronaut" }
 micronaut-cache-caffeine = { module = "io.micronaut.cache:micronaut-cache-caffeine", version = "3.5.0"}
-micronaut-data-processor = { module = "io.micronaut.data:micronaut-data-processor", version = "3.9.4" }
-micronaut-data-tx = { module = "io.micronaut.data:micronaut-data-tx", version = "3.9.4" }
+micronaut-data-processor = { module = "io.micronaut.data:micronaut-data-processor", version.ref = "micronaut-data" }
+micronaut-data-tx = { module = "io.micronaut.data:micronaut-data-tx", version.ref = "micronaut-data" }
 micronaut-flyway = { module = "io.micronaut.flyway:micronaut-flyway", version = "5.4.1" }
 micronaut-inject = { module = "io.micronaut:micronaut-inject" }
+micronaut-http = { module = "io.micronaut:micronaut-http", version.ref = "micronaut" }
 micronaut-http-client = { module = "io.micronaut:micronaut-http-client" }
-micronaut-http-server-netty = { module = "io.micronaut:micronaut-http-server-netty" }
+micronaut-http-server-netty = { module = "io.micronaut:micronaut-http-server-netty", version.ref = "micronaut" }
 micronaut-inject-java = { module = "io.micronaut:micronaut-inject-java", version.ref = "micronaut" }
-micronaut-jaxrs-processor = { module = "io.micronaut.jaxrs:micronaut-jaxrs-processor", version = "3.4.0" }
-micronaut-jaxrs-server = { module = "io.micronaut.jaxrs:micronaut-jaxrs-server", version = "3.4.0" }
+micronaut-jaxrs-processor = { module = "io.micronaut.jaxrs:micronaut-jaxrs-processor", version.ref = "micronaut-jaxrs" }
+micronaut-jaxrs-server = { module = "io.micronaut.jaxrs:micronaut-jaxrs-server", version.ref = "micronaut-jaxrs" }
 micronaut-jdbc = { module = "io.micronaut.sql:micronaut-jdbc", version = "4.7.2" }
 micronaut-jdbc-hikari = { module = "io.micronaut.sql:micronaut-jdbc-hikari" }
 micronaut-jooq = { module = "io.micronaut.sql:micronaut-jooq" }
 micronaut-management = { module = "io.micronaut:micronaut-management" }
 micronaut-runtime = { module = "io.micronaut:micronaut-runtime" }
-micronaut-security = { module = "io.micronaut.security:micronaut-security", version = "3.9.0" }
+micronaut-security = { module = "io.micronaut.security:micronaut-security", version.ref = "micronaut-security" }
 micronaut-test-core = { module = "io.micronaut.test:micronaut-test-core", version.ref = "micronaut-test" }
 micronaut-test-junit5 = { module = "io.micronaut.test:micronaut-test-junit5", version.ref = "micronaut-test" }
 micronaut-validation = { module = "io.micronaut:micronaut-validation" }


### PR DESCRIPTION
## What
* https://github.com/micronaut-projects/micronaut-core/releases/tag/v3.8.2
* Expose dependencies required for authentication

## How
* Update to latest Micronaut release
* Add dependencies to catalog that are required to convert the cloud auth filter to Micronaut

## Recommended reading order
1. `deps.toml`

## Tests

* All unit tests pass
* Project builds locally