### PR TITLE
🪟 🔧 Include module name in CSS class names

### DIFF
--- a/airbyte-webapp/vite.config.ts
+++ b/airbyte-webapp/vite.config.ts
@@ -69,6 +69,11 @@ export default defineConfig(({ mode }) => {
     define: {
       ...processEnv,
     },
+    css: {
+      modules: {
+        generateScopedName: "[name]__[local]__[contenthash:6]",
+      },
+    },
     resolve: {
       alias: {
         // Allow @use "scss/" imports in SASS


### PR DESCRIPTION
## What

Makes CSS class names be generated in a format to contain the original file name. See the screenshot (except the highlighted row, which is a styled component):

![screenshot-20230123-213530](https://user-images.githubusercontent.com/877229/214147438-e8f1e7ea-60ca-44ac-a8cf-aa51bd984489.png)
