### PR TITLE
:window: :wrench: Cleaner error handling for authService's `sendVerificationEmail`

### DIFF
--- a/airbyte-webapp/src/packages/cloud/components/experiments/FreeConnectorProgram/EnrollmentModal/useShowEnrollmentModal.tsx
+++ b/airbyte-webapp/src/packages/cloud/components/experiments/FreeConnectorProgram/EnrollmentModal/useShowEnrollmentModal.tsx
@@ -19,15 +19,13 @@ export const useShowEnrollmentModal = () => {
   const { registerNotification } = useNotificationService();
 
   const verifyEmail = () =>
-    sendEmailVerification()
-      .then(() => {
-        registerNotification({
-          id: "fcp/verify-email",
-          text: formatMessage({ id: "freeConnectorProgram.enrollmentModal.validationEmailConfirmation" }),
-          type: ToastType.INFO,
-        });
-      })
-      .catch(); // don't crash the page on error
+    sendEmailVerification().then(() => {
+      registerNotification({
+        id: "fcp/verify-email",
+        text: formatMessage({ id: "freeConnectorProgram.enrollmentModal.validationEmailConfirmation" }),
+        type: ToastType.INFO,
+      });
+    });
 
   return {
     showEnrollmentModal: () => {

--- a/airbyte-webapp/src/packages/cloud/services/auth/AuthService.tsx
+++ b/airbyte-webapp/src/packages/cloud/services/auth/AuthService.tsx
@@ -242,9 +242,7 @@ export const AuthenticationProvider: React.FC<React.PropsWithChildren<unknown>> 
         await authService.resetPassword(email);
       },
       async sendEmailVerification(): Promise<void> {
-        try {
-          await authService.sendEmailVerifiedLink();
-        } catch (error) {
+        return authService.sendEmailVerifiedLink().catch((error) => {
           switch (error.code) {
             case AuthErrorCodes.NETWORK_REQUEST_FAILED:
               registerNotification({
@@ -273,8 +271,7 @@ export const AuthenticationProvider: React.FC<React.PropsWithChildren<unknown>> 
                 type: ToastType.ERROR,
               });
           }
-          throw error;
-        }
+        });
       },
       async verifyEmail(code: string): Promise<void> {
         await authService.confirmEmailVerify(code);

--- a/airbyte-webapp/src/packages/cloud/views/credits/CreditsPage/components/EmailVerificationHint.tsx
+++ b/airbyte-webapp/src/packages/cloud/views/credits/CreditsPage/components/EmailVerificationHint.tsx
@@ -31,7 +31,7 @@ export const EmailVerificationHint: React.FC<Props> = ({ className }) => {
 
   const onResendVerificationMail = async () => {
     // the shared error handling inside `sendEmailVerification` suffices
-    await sendEmailVerification().catch();
+    await sendEmailVerification();
     setIsEmailResend(true);
   };
 


### PR DESCRIPTION
## What
When I first extracted this error handling code from `EmailVerificationHint.tsx` in https://github.com/airbytehq/airbyte/pull/21623 so the enrollment modal could take advantage of it too, I missed a basic structural fix (because the internal API defined in `authService` had an identical type signature as the upstream `firebase/auth` function it wrapped, it Seemed Obvious:tm: that it was appropriate to port its error-handling code unchanged). To wit: because it handled errors _within_ the `Promise`, rather than _via_ the `Promise`, success/error code paths were being defined in different scopes; the only way to invalidate a downstream `.then` which should only run on success was to reraise the error. This lead to arbitrary and ugly `.catch()`es getting tacked onto both usage sites just to avoid crashing the page from an already-handled error.

But, like: that's the whole reason `Promise.prototype.catch` exists, though.

## Testing
Manually tested via the enrollment modal, behaves exactly as before in both error and success states.