### PR TITLE
improve logging of find-valid-pat script

### DIFF
--- a/tools/bin/find_non_rate_limited_PAT
+++ b/tools/bin/find_non_rate_limited_PAT
@@ -50,7 +50,7 @@ for personal_access_token in $@
 
 done
 
-echo -e "$red_text""::error NO more request availible! Yell at topher or someone on infra!""$default_text"
+echo -e "$red_text""::error Either PR changes are proposed by non-contributor who is prohibited to access repo secrets or NO more request available!""$default_text"
+echo -e "$red_text""::error Yell at Topher or someone on infra""$default_text"
 
 exit 1
-


### PR DESCRIPTION
Improve error logging of `find_non_rate_limited_PAT` script to cover case when PR changes are proposed by non-contributor

Example - https://airbytehq.slack.com/archives/C046KQF5GBT/p1673547644086219