### PR TITLE
[ISSUE #19981] improve changelog in slack notification

### DIFF
--- a/.github/workflows/publish-cdk-command-manually.yml
+++ b/.github/workflows/publish-cdk-command-manually.yml
@@ -178,14 +178,14 @@ jobs:
                         "type": "section",
                         "text": {
                             "type": "mrkdwn",
-                            "text": "A new version of Airbyte CDK has been released!\n\n"
+                            "text": "A new version of Airbyte CDK has been released with changelog: ${{ github.event.inputs.changelog-message }}!\n\n"
                         }
                     },
                     {
                         "type": "section",
                         "text": {
                             "type": "mrkdwn",
-                            "text": "See details on <https://github.com/airbytehq/airbyte/blob/master/airbyte-cdk/python/CHANGELOG.md?plain=1#L3-L4|CHANGELOG.md> and <https://github.com/${{github.repository}}/actions/runs/${{github.run_id}}|GitHub>\n"
+                            "text": "See details on <https://github.com/${{github.repository}}/actions/runs/${{github.run_id}}|GitHub>\n"
                         }
                     }
                 ]


### PR DESCRIPTION
## What
On release, the Slack notification redirect to lines 3 and 4 of the changelog (url: https://github.com/airbytehq/airbyte/blob/master/airbyte-cdk/python/CHANGELOG.md?plain=1#L3-L4). This causes some issue:
* When there is a new release, this link is not update on previous Slack notification release and therefore is not useful
* If a release is done in a branch, the link still points on master (we try to avoid releasing in branches but it seems it's still something that is helpful in some cases like https://github.com/airbytehq/airbyte/pull/21703#issuecomment-1400652322)