### PR TITLE
🪟 🐛 Fix test with potentially mismatching time values

### DIFF
--- a/airbyte-webapp/src/components/connection/JobProgress/utils.test.ts
+++ b/airbyte-webapp/src/components/connection/JobProgress/utils.test.ts
@@ -47,15 +47,13 @@ describe("#progressBarCalculations", () => {
   });
 });
 
-const makeAttempt = (
-  totalStats: AttemptStats = {},
-  streamStats: AttemptStreamStats[] = [],
+const makeAttempt = (totalStats: AttemptStats = {}, streamStats: AttemptStreamStats[] = []) => {
+  const now = Date.now();
   // API returns time in seconds
-  createdAt = Date.now() / 1000 - 10,
-  updatedAt = Date.now() / 1000,
-  id = 123,
-  status: AttemptStatus = "running"
-) => {
+  const createdAt = now / 1000 - 10;
+  const updatedAt = now / 1000;
+  const id = 123;
+  const status: AttemptStatus = "running";
   const attempt: AttemptRead = { id, status, createdAt, updatedAt, totalStats, streamStats };
   return attempt;
 };


### PR DESCRIPTION
## What
In the test setup there are two subsequent calls to `Date.now()` that are not guaranteed to return the same millisecond. This test failed because they were off by a millisecond: https://github.com/airbytehq/airbyte-cloud/actions/runs/3996900752/jobs/6857563137#step:3:16508

I just adjusted the `makeAttempt()` setup slightly so there is only one call to `Date.now()`