### PR TITLE
[ISSUE #21559] run migration

### DIFF
--- a/airbyte-integrations/connectors/source-activecampaign/source_activecampaign/manifest.yaml
+++ b/airbyte-integrations/connectors/source-activecampaign/source_activecampaign/manifest.yaml
@@ -22,7 +22,6 @@ definitions:
     # API Docs: https://developers.activecampaign.com/reference/pagination
     paginator:
       type: DefaultPaginator
-      url_base: "#/definitions/requester/url_base"
       page_size_option:
         inject_into: "request_parameter"
         field_name: "limit"

--- a/airbyte-integrations/connectors/source-aha/source_aha/manifest.yaml
+++ b/airbyte-integrations/connectors/source-aha/source_aha/manifest.yaml
@@ -27,7 +27,6 @@ definitions:
       api_token: "{{ config['api_key'] }}"
   increment_paginator:
     type: "DefaultPaginator"
-    url_base: "#/definitions/requester/url_base"
     page_size_option:
       inject_into: "request_parameter"
       field_name: "per_page"

--- a/airbyte-integrations/connectors/source-ashby/source_ashby/manifest.yaml
+++ b/airbyte-integrations/connectors/source-ashby/source_ashby/manifest.yaml
@@ -25,8 +25,6 @@ definitions:
       page_token_option:
         inject_into: "body_json"
         field_name: "cursor"
-      url_base:
-        $ref: "#/definitions/requester/url_base"
     requester:
       $ref: "#/definitions/requester"
 

--- a/airbyte-integrations/connectors/source-braze/source_braze/manifest.yaml
+++ b/airbyte-integrations/connectors/source-braze/source_braze/manifest.yaml
@@ -23,7 +23,6 @@ definitions:
       $ref: "#/definitions/list_selector"
     paginator:
       type: DefaultPaginator
-      url_base: "{{ config['url'] }}"
       pagination_strategy:
         type: PageIncrement
         page_size: 2

--- a/airbyte-integrations/connectors/source-chartmogul/source_chartmogul/manifest.yaml
+++ b/airbyte-integrations/connectors/source-chartmogul/source_chartmogul/manifest.yaml
@@ -20,7 +20,6 @@ definitions:
       $ref: "#/definitions/retriever"
       paginator:
         type: DefaultPaginator
-        url_base: "#/definitions/requester/url_base"
         pagination_strategy:
           type: "PageIncrement"
           start_from_page: 1
@@ -44,7 +43,6 @@ definitions:
           start-date: "{{ config.start_date }}"
       paginator:
         type: DefaultPaginator
-        url_base: "#/definitions/requester/url_base"
         pagination_strategy:
           type: "CursorPagination"
           cursor_value: "{{ response['entries'][-1]['uuid'] }}"

--- a/airbyte-integrations/connectors/source-coinmarketcap/source_coinmarketcap/manifest.yaml
+++ b/airbyte-integrations/connectors/source-coinmarketcap/source_coinmarketcap/manifest.yaml
@@ -14,7 +14,6 @@ definitions:
   offset_paginator:
     type: DefaultPaginator
     $parameters:
-      url_base: "#/definitions/requester/url_base"
     page_size_option:
       inject_into: "request_parameter"
       field_name: "limit"

--- a/airbyte-integrations/connectors/source-convertkit/source_convertkit/manifest.yaml
+++ b/airbyte-integrations/connectors/source-convertkit/source_convertkit/manifest.yaml
@@ -12,7 +12,6 @@ definitions:
       api_secret: "{{ config['api_secret'] }}"
   increment_paginator:
     type: DefaultPaginator
-    url_base: "#/definitions/requester/url_base"
     page_size_option:
       inject_into: "request_parameter"
       field_name: "limit"

--- a/airbyte-integrations/connectors/source-courier/source_courier/manifest.yaml
+++ b/airbyte-integrations/connectors/source-courier/source_courier/manifest.yaml
@@ -29,7 +29,6 @@ definitions:
 
   cursor_paginator:
     type: DefaultPaginator
-    url_base: "#/definitions/requester/url_base"
     page_token_option:
       field_name: cursor
       inject_into: request_parameter

--- a/airbyte-integrations/connectors/source-datascope/source_datascope/manifest.yaml
+++ b/airbyte-integrations/connectors/source-datascope/source_datascope/manifest.yaml
@@ -37,7 +37,6 @@ definitions:
       $ref: "#/definitions/selector"
     paginator:
       type: DefaultPaginator
-      url_base: "#/definitions/requester/url_base"
       page_size_option:
         inject_into: "request_parameter"
         field_name: "limit"
@@ -57,7 +56,6 @@ definitions:
       $ref: "#/definitions/selector"
     paginator:
       type: DefaultPaginator
-      url_base: "#/definitions/requester/url_base"
       page_size_option:
         inject_into: "request_parameter"
         field_name: "limit"

--- a/airbyte-integrations/connectors/source-delighted/source_delighted/manifest.yaml
+++ b/airbyte-integrations/connectors/source-delighted/source_delighted/manifest.yaml
@@ -54,7 +54,6 @@ definitions:
       page_token_option:
         field_name: "page"
         inject_into: "request_parameter"
-      url_base: "#/definitions/requester/url_base"
     requester:
       $ref: "#/definitions/requester"
     stream_slicer:
@@ -80,7 +79,6 @@ definitions:
           inject_into: "request_parameter"
         page_token_option:
           inject_into: "path"
-        url_base: "#/definitions/requester/url_base"
     $parameters:
       name: "people"
       path: "people.json"

--- a/airbyte-integrations/connectors/source-emailoctopus/source_emailoctopus/manifest.yaml
+++ b/airbyte-integrations/connectors/source-emailoctopus/source_emailoctopus/manifest.yaml
@@ -11,7 +11,6 @@ definitions:
       api_key: "{{ config['api_key'] }}"
   increment_paginator:
     type: DefaultPaginator
-    url_base: "#/definitions/requester/url_base"
     pagination_strategy:
       type: PageIncrement
       page_size: 50

--- a/airbyte-integrations/connectors/source-getlago/source_getlago/manifest.yaml
+++ b/airbyte-integrations/connectors/source-getlago/source_getlago/manifest.yaml
@@ -12,7 +12,6 @@ definitions:
       api_token: "{{ config['api_key'] }}"
   cursor_paginator:
     type: DefaultPaginator
-    url_base: "#/definitions/requester/url_base"
     page_token_option:
       inject_into: request_parameter
       field_name: "page"

--- a/airbyte-integrations/connectors/source-gong/source_gong/manifest.yaml
+++ b/airbyte-integrations/connectors/source-gong/source_gong/manifest.yaml
@@ -29,8 +29,6 @@ definitions:
       page_token_option:
         field_name: "cursor"
         inject_into: "request_parameter"
-      url_base:
-        $ref: "#/definitions/requester/url_base"
     requester:
       $ref: "#/definitions/requester"
 

--- a/airbyte-integrations/connectors/source-greenhouse/source_greenhouse/manifest.yaml
+++ b/airbyte-integrations/connectors/source-greenhouse/source_greenhouse/manifest.yaml
@@ -44,7 +44,6 @@ definitions:
         inject_into: "request_parameter"
       page_token_option:
         inject_into: "path"
-      url_base: "#/definitions/requester/url_base"
   base_stream:
     type: DeclarativeStream
     $parameters:

--- a/airbyte-integrations/connectors/source-gutendex/source_gutendex/manifest.yaml
+++ b/airbyte-integrations/connectors/source-gutendex/source_gutendex/manifest.yaml
@@ -21,7 +21,6 @@ definitions:
       $ref: "#/definitions/selector"
     paginator:
       type: "DefaultPaginator"
-      url_base: "#/definitions/requester/url_base"
       pagination_strategy:
         type: "PageIncrement"
         page_size: 32

--- a/airbyte-integrations/connectors/source-intruder/source_intruder/manifest.yaml
+++ b/airbyte-integrations/connectors/source-intruder/source_intruder/manifest.yaml
@@ -13,7 +13,6 @@ definitions:
   offset_paginator:
     type: DefaultPaginator
     $parameters:
-      url_base: "#/definitions/requester/url_base"
     pagination_strategy:
       type: "OffsetIncrement"
       page_size: 100

--- a/airbyte-integrations/connectors/source-launchdarkly/source_launchdarkly/manifest.yaml
+++ b/airbyte-integrations/connectors/source-launchdarkly/source_launchdarkly/manifest.yaml
@@ -14,7 +14,6 @@ definitions:
   offset_paginator:
     type: DefaultPaginator
     $parameters:
-      url_base: "#/definitions/requester/url_base"
     pagination_strategy:
       type: "OffsetIncrement"
       page_size: 20

--- a/airbyte-integrations/connectors/source-lokalise/source_lokalise/manifest.yaml
+++ b/airbyte-integrations/connectors/source-lokalise/source_lokalise/manifest.yaml
@@ -16,7 +16,6 @@ definitions:
 
   increment_paginator:
     type: "DefaultPaginator"
-    url_base: "#/definitions/requester/url_base"
     pagination_strategy:
       type: "PageIncrement"
       page_size: 1000

--- a/airbyte-integrations/connectors/source-mailerlite/source_mailerlite/manifest.yaml
+++ b/airbyte-integrations/connectors/source-mailerlite/source_mailerlite/manifest.yaml
@@ -14,7 +14,6 @@ definitions:
 
   increment_paginator:
     type: "DefaultPaginator"
-    url_base: "#/definitions/requester/url_base"
     page_size_option:
       inject_into: "request_parameter"
       field_name: "limit"

--- a/airbyte-integrations/connectors/source-mailersend/source_mailersend/manifest.yaml
+++ b/airbyte-integrations/connectors/source-mailersend/source_mailersend/manifest.yaml
@@ -38,7 +38,6 @@ definitions:
     page_token_option:
       inject_into: "request_parameter"
       field_name: "page"
-    url_base: "#/definitions/requester/url_base"
   retriever:
     record_selector:
       $ref: "#/definitions/selector"

--- a/airbyte-integrations/connectors/source-monday/source_monday/manifest.yaml
+++ b/airbyte-integrations/connectors/source-monday/source_monday/manifest.yaml
@@ -30,7 +30,6 @@ definitions:
           backoff_time_in_seconds: 60
   default_paginator:
     type: "DefaultPaginator"
-    url_base: "https://api.monday.com/v2"
     pagination_strategy:
       type: "PageIncrement"
       start_from_page: 1

--- a/airbyte-integrations/connectors/source-n8n/source_n8n/manifest.yaml
+++ b/airbyte-integrations/connectors/source-n8n/source_n8n/manifest.yaml
@@ -18,7 +18,6 @@ definitions:
       $ref: "#/definitions/selector"
     paginator:
       type: DefaultPaginator
-      url_base: "#/definitions/requester/url_base"
       page_size_option:
         inject_into: "request_parameter"
         field_name: ""

--- a/airbyte-integrations/connectors/source-newsdata/source_newsdata/manifest.yaml
+++ b/airbyte-integrations/connectors/source-newsdata/source_newsdata/manifest.yaml
@@ -32,7 +32,6 @@ definitions:
     page_size_option: # This is useless, only there because it is required, but page sizes are managed automatically by API subscription type
       field_name: "X-Pagination-Page-Size"
       inject_into: "header"
-    url_base: "#/definitions/base_requester/url_base"
   latest_stream:
     $ref: "#/definitions/base_stream"
     $parameters:

--- a/airbyte-integrations/connectors/source-omnisend/source_omnisend/manifest.yaml
+++ b/airbyte-integrations/connectors/source-omnisend/source_omnisend/manifest.yaml
@@ -16,7 +16,6 @@ definitions:
       $ref: "#/definitions/selector"
     paginator:
       type: DefaultPaginator
-      url_base: "#/definitions/requester/url_base"
       page_size_option:
         inject_into: "request_parameter"
         field_name: "limit"

--- a/airbyte-integrations/connectors/source-oura/source_oura/manifest.yaml
+++ b/airbyte-integrations/connectors/source-oura/source_oura/manifest.yaml
@@ -29,7 +29,6 @@ definitions:
     page_token_option:
       field_name: "next_token"
       inject_into: "request_parameter"
-    url_base: "#/definitions/base_requester/url_base"
     page_size_option: # Not used, but check fails without it
       field_name: ""
       inject_into: "request_parameter"

--- a/airbyte-integrations/connectors/source-partnerstack/source_partnerstack/manifest.yaml
+++ b/airbyte-integrations/connectors/source-partnerstack/source_partnerstack/manifest.yaml
@@ -33,8 +33,6 @@ definitions:
       page_token_option:
         field_name: "starting_after"
         inject_into: "request_parameter"
-      url_base:
-        $ref: "#/definitions/requester/url_base"
     requester:
       $ref: "#/definitions/requester"
     stream_slicer:

--- a/airbyte-integrations/connectors/source-pocket/source_pocket/manifest.yaml
+++ b/airbyte-integrations/connectors/source-pocket/source_pocket/manifest.yaml
@@ -35,7 +35,6 @@ definitions:
       $ref: "#/definitions/selector"
     paginator:
       type: "DefaultPaginator"
-      url_base: "#/definitions/requester/url_base"
       page_size_option:
         inject_into: "request_parameter"
         field_name: "count"

--- a/airbyte-integrations/connectors/source-posthog/source_posthog/manifest.yaml
+++ b/airbyte-integrations/connectors/source-posthog/source_posthog/manifest.yaml
@@ -27,7 +27,6 @@ definitions:
       $ref: "#/definitions/selector"
     paginator:
       type: "DefaultPaginator"
-      url_base: "#/definitions/requester/url_base"
       page_size_option:
         inject_into: "request_parameter"
         field_name: "limit"
@@ -142,7 +141,6 @@ definitions:
               inject_into: request_parameter
       paginator:
         type: "DefaultPaginator"
-        url_base: "#/definitions/requester/url_base"
         page_size_option:
           inject_into: "request_parameter"
           field_name: "limit"

--- a/airbyte-integrations/connectors/source-postmarkapp/source_postmarkapp/manifest.yaml
+++ b/airbyte-integrations/connectors/source-postmarkapp/source_postmarkapp/manifest.yaml
@@ -47,7 +47,6 @@ definitions:
     paginator:
       type: DefaultPaginator
       $parameters:
-        url_base: "#/definitions/requester/url_base"
       pagination_strategy:
         type: "OffsetIncrement"
         page_size: 500
@@ -65,7 +64,6 @@ definitions:
     paginator:
       type: DefaultPaginator
       $parameters:
-        url_base: "#/definitions/requester/url_base"
       pagination_strategy:
         type: "OffsetIncrement"
         page_size: 500

--- a/airbyte-integrations/connectors/source-prestashop/source_prestashop/manifest.yaml
+++ b/airbyte-integrations/connectors/source-prestashop/source_prestashop/manifest.yaml
@@ -20,7 +20,6 @@ definitions:
       $ref: "#/definitions/selector"
     paginator:
       type: DefaultPaginator
-      url_base: "#/definitions/requester/url_base"
       pagination_strategy:
         type: "OffsetIncrement"
         page_size: 50

--- a/airbyte-integrations/connectors/source-recreation/source_recreation/manifest.yaml
+++ b/airbyte-integrations/connectors/source-recreation/source_recreation/manifest.yaml
@@ -24,7 +24,6 @@ definitions:
     paginator:
       type: "DefaultPaginator"
       $parameters:
-        url_base: "#/definitions/requester/url_base"
       page_size_option:
         inject_into: "request_parameter"
         field_name: "limit"

--- a/airbyte-integrations/connectors/source-secoda/source_secoda/manifest.yaml
+++ b/airbyte-integrations/connectors/source-secoda/source_secoda/manifest.yaml
@@ -19,7 +19,6 @@ definitions:
           action: FAIL
   cursor_paginator:
     type: DefaultPaginator
-    url_base: "#/definitions/requester/url_base"
     page_token_option:
       inject_into: path
     page_size_option:

--- a/airbyte-integrations/connectors/source-sendgrid/source_sendgrid/manifest.yaml
+++ b/airbyte-integrations/connectors/source-sendgrid/source_sendgrid/manifest.yaml
@@ -17,7 +17,6 @@ definitions:
       api_token: "{{ config.apikey }}"
   cursor_paginator:
     type: DefaultPaginator
-    url_base: "#/definitions/requester/url_base"
     page_size: "#/definitions/page_size"
     limit_option:
       inject_into: "request_parameter"

--- a/airbyte-integrations/connectors/source-sendinblue/source_sendinblue/manifest.yaml
+++ b/airbyte-integrations/connectors/source-sendinblue/source_sendinblue/manifest.yaml
@@ -14,7 +14,6 @@ definitions:
   offset_paginator:
     type: DefaultPaginator
     $parameters:
-      url_base: "#/definitions/requester/url_base"
     pagination_strategy:
       type: "OffsetIncrement"
       page_size: 100

--- a/airbyte-integrations/connectors/source-senseforce/source_senseforce/manifest.yaml
+++ b/airbyte-integrations/connectors/source-senseforce/source_senseforce/manifest.yaml
@@ -40,7 +40,6 @@ definitions:
       $ref: "#/definitions/selector"
     paginator:
       type: DefaultPaginator
-      url_base: "#/definitions/requester/url_base"
       page_size_option:
         inject_into: "request_parameter"
         field_name: "limit"

--- a/airbyte-integrations/connectors/source-sentry/source_sentry/manifest.yaml
+++ b/airbyte-integrations/connectors/source-sentry/source_sentry/manifest.yaml
@@ -19,7 +19,6 @@ definitions:
       api_token: "{{ config.auth_token }}"
   paginator:
     type: DefaultPaginator
-    url_base: "#/definitions/requester/url_base"
     page_size: "#/definitions/page_size"
     limit_option:
       inject_into: "request_parameter"

--- a/airbyte-integrations/connectors/source-smaily/source_smaily/manifest.yaml
+++ b/airbyte-integrations/connectors/source-smaily/source_smaily/manifest.yaml
@@ -13,7 +13,6 @@ definitions:
       password: "{{config['api_password']}}"
   increment_paginator:
     type: DefaultPaginator
-    url_base: "#/definitions/requester/url_base"
     page_size_option:
       inject_into: "request_parameter"
       field_name: "limit"

--- a/airbyte-integrations/connectors/source-square/source_square/manifest.yaml
+++ b/airbyte-integrations/connectors/source-square/source_square/manifest.yaml
@@ -53,8 +53,6 @@ definitions:
         page_token_option:
           inject_into: "request_parameter"
           field_name: "cursor"
-        url_base:
-          $ref: "#/definitions/requester/url_base"
 
   base_incremental_stream:
     $parameters:
@@ -68,7 +66,6 @@ definitions:
           sort_field: "CREATED_AT"
       paginator:
         type: DefaultPaginator
-        url_base: "#/definitions/requester/url_base"
         pagination_strategy:
           page_size: 100
           type: "CursorPagination"
@@ -115,7 +112,6 @@ definitions:
           object_types: "{{ [parameters['object_type']] }}"
       paginator:
         type: DefaultPaginator
-        url_base: "#/definitions/requester/url_base"
         pagination_strategy:
           page_size: 1000
           type: "CursorPagination"

--- a/airbyte-integrations/connectors/source-statuspage/source_statuspage/manifest.yaml
+++ b/airbyte-integrations/connectors/source-statuspage/source_statuspage/manifest.yaml
@@ -23,7 +23,6 @@ definitions:
   offset_paginator:
     type: DefaultPaginator
     $parameters:
-      url_base: "#/definitions/requester/url_base"
     pagination_strategy:
       type: "OffsetIncrement"
       page_size: 100

--- a/airbyte-integrations/connectors/source-tempo/source_tempo/manifest.yaml
+++ b/airbyte-integrations/connectors/source-tempo/source_tempo/manifest.yaml
@@ -40,7 +40,6 @@ definitions:
         inject_into: "request_parameter"
       page_token_option:
         inject_into: "path"
-      url_base: "#/definitions/requester/url_base"
   base_stream:
     primary_key: "id"
     retriever:

--- a/airbyte-integrations/connectors/source-tmdb/source_tmdb/manifest.yaml
+++ b/airbyte-integrations/connectors/source-tmdb/source_tmdb/manifest.yaml
@@ -55,7 +55,6 @@ definitions:
         $ref: "#/definitions/selector"
       paginator:
         type: "DefaultPaginator"
-        url_base: "#/definitions/requester/url_base"
         pagination_strategy:
           type: "PageIncrement"
           page_size: 1000

--- a/airbyte-integrations/connectors/source-toggl/source_toggl/manifest.yaml
+++ b/airbyte-integrations/connectors/source-toggl/source_toggl/manifest.yaml
@@ -19,7 +19,6 @@ definitions:
       password: "api_token"
   increment_paginator:
     type: "DefaultPaginator"
-    url_base: "#/definitions/requester/url_base"
     page_size_option:
       inject_into: "request_parameter"
       field_name: "per_page"

--- a/airbyte-integrations/connectors/source-twitter/source_twitter/manifest.yaml
+++ b/airbyte-integrations/connectors/source-twitter/source_twitter/manifest.yaml
@@ -48,7 +48,6 @@ definitions:
       page_token_option:
         field_name: "next_token"
         inject_into: "request_parameter"
-      url_base: "#/definitions/requester/url_base"
     requester:
       $ref: "#/definitions/requester"
 

--- a/airbyte-integrations/connectors/source-vantage/source_vantage/manifest.yaml
+++ b/airbyte-integrations/connectors/source-vantage/source_vantage/manifest.yaml
@@ -12,7 +12,6 @@ definitions:
       api_token: "{{ config['access_token'] }}"
   increment_paginator:
     type: "DefaultPaginator"
-    url_base: "#/definitions/requester/url_base"
     page_size_option:
       inject_into: "request_parameter"
       field_name: "limit"

--- a/airbyte-integrations/connectors/source-vitally/source_vitally/manifest.yaml
+++ b/airbyte-integrations/connectors/source-vitally/source_vitally/manifest.yaml
@@ -25,8 +25,6 @@ definitions:
       page_token_option:
         field_name: "from"
         inject_into: "request_parameter"
-      url_base:
-        $ref: "#/definitions/requester/url_base"
     requester:
       $ref: "#/definitions/requester"
 

--- a/airbyte-integrations/connectors/source-woocommerce/source_woocommerce/manifest.yaml
+++ b/airbyte-integrations/connectors/source-woocommerce/source_woocommerce/manifest.yaml
@@ -43,7 +43,6 @@ definitions:
     paginator:
       type: DefaultPaginator
       $parameters:
-        url_base: "#/definitions/requester/url_base"
       pagination_strategy:
         type: "OffsetIncrement"
         page_size: 100

--- a/airbyte-integrations/connectors/source-workable/source_workable/manifest.yaml
+++ b/airbyte-integrations/connectors/source-workable/source_workable/manifest.yaml
@@ -23,7 +23,6 @@ definitions:
       $ref: "#/definitions/requester"
     paginator:
       type: DefaultPaginator
-      url_base: "#/definitions/requester/url_base"
       limit_option:
         inject_into: "request_parameter"
         field_name: ""

--- a/airbyte-integrations/connectors/source-workramp/source_workramp/manifest.yaml
+++ b/airbyte-integrations/connectors/source-workramp/source_workramp/manifest.yaml
@@ -24,8 +24,6 @@ definitions:
       page_token_option:
         inject_into: "request_parameter"
         field_name: "page"
-      url_base:
-        $ref: "#/definitions/requester/url_base"
     requester:
       $ref: "#/definitions/requester"
 

--- a/airbyte-integrations/connectors/source-zoom/source_zoom/manifest.yaml
+++ b/airbyte-integrations/connectors/source-zoom/source_zoom/manifest.yaml
@@ -21,7 +21,6 @@ definitions:
     page_token_option:
       field_name: "next_page_token"
       inject_into: "request_parameter"
-    url_base: "#/definitions/requester/url_base"
 
   retriever:
     requester:


### PR DESCRIPTION
## What
* Migration for https://github.com/airbytehq/airbyte/pull/21823

## Notes
There are 52 sources using DefaultPaginator. However, the following sources uses $options to pass the url_base and therefore didn't need to be updated:
* callrail
* gocardless
* zenloop