### PR TITLE
[Low-Code CDK] Remove JsonSchema type in favor of JsonSchemaFileLoader

### DIFF
--- a/airbyte-cdk/python/airbyte_cdk/sources/declarative/declarative_component_schema.yaml
+++ b/airbyte-cdk/python/airbyte_cdk/sources/declarative/declarative_component_schema.yaml
@@ -717,7 +717,7 @@ definitions:
       - type
     properties:
       type:
-        enum: [JsonFileSchemaLoader, JsonSchema] # TODO As part of Beta, remove JsonSchema and update connectors to use JsonFileSchemaLoader
+        enum: [JsonFileSchemaLoader]
       file_path:
         type: string
       $parameters:

--- a/airbyte-cdk/python/airbyte_cdk/sources/declarative/models/declarative_component_schema.py
+++ b/airbyte-cdk/python/airbyte_cdk/sources/declarative/models/declarative_component_schema.py
@@ -197,13 +197,8 @@ class InlineSchemaLoader(BaseModel):
     schema_: Optional[Dict[str, Any]] = Field(None, alias="schema")
 
 
-class Type(Enum):
-    JsonFileSchemaLoader = "JsonFileSchemaLoader"
-    JsonSchema = "JsonSchema"
-
-
 class JsonFileSchemaLoader(BaseModel):
-    type: Type
+    type: Literal["JsonFileSchemaLoader"]
     file_path: Optional[str] = None
     parameters: Optional[Dict[str, Any]] = Field(None, alias="$parameters")
 

--- a/airbyte-cdk/python/airbyte_cdk/sources/declarative/parsers/class_types_registry.py
+++ b/airbyte-cdk/python/airbyte_cdk/sources/declarative/parsers/class_types_registry.py
@@ -79,7 +79,6 @@ CLASS_TYPES_REGISTRY: Mapping[str, Type] = {
     "InterpolatedBoolean": InterpolatedBoolean,
     "InterpolatedRequestOptionsProvider": InterpolatedRequestOptionsProvider,
     "InterpolatedString": InterpolatedString,
-    "JsonSchema": JsonFileSchemaLoader,  # todo remove after hacktoberfest and update connectors to use JsonFileSchemaLoader
     "JsonFileSchemaLoader": JsonFileSchemaLoader,
     "ListStreamSlicer": ListStreamSlicer,
     "MinMaxDatetime": MinMaxDatetime,

--- a/airbyte-integrations/connectors/source-alpha-vantage/source_alpha_vantage/alpha_vantage.yaml
+++ b/airbyte-integrations/connectors/source-alpha-vantage/source_alpha_vantage/alpha_vantage.yaml
@@ -2,7 +2,7 @@ version: "0.1.1"
 
 definitions:
   schema_loader:
-    type: JsonSchema
+    type: JsonFileSchemaLoader
     file_path: "./source_alpha_vantage/schemas/{{ parameters['name'] }}.json"
   selector:
     type: RecordSelector

--- a/airbyte-integrations/connectors/source-callrail/source_callrail/callrail.yaml
+++ b/airbyte-integrations/connectors/source-callrail/source_callrail/callrail.yaml
@@ -5,7 +5,7 @@ definitions:
   step: "P100D"
 
   schema_loader:
-    type: JsonSchema
+    type: JsonFileSchemaLoader
     file_path: "./source_callrail/schemas/{{ parameters['name'] }}.json"
 
   requester:

--- a/airbyte-integrations/connectors/source-clickup-api/source_clickup_api/clickup_api.yaml
+++ b/airbyte-integrations/connectors/source-clickup-api/source_clickup_api/clickup_api.yaml
@@ -2,7 +2,7 @@ version: "0.1.0"
 
 definitions:
   schema_loader:
-    type: JsonSchema
+    type: JsonFileSchemaLoader
     file_path: "./source_clickup_api/schemas/{{ parameters['name'] }}.json"
   singleSelector:
     type: RecordSelector

--- a/airbyte-integrations/connectors/source-close-com/source_close_com/close_com.yaml
+++ b/airbyte-integrations/connectors/source-close-com/source_close_com/close_com.yaml
@@ -2,7 +2,7 @@ version: "0.1.0"
 
 definitions:
   schema_loader:
-    type: JsonSchema
+    type: JsonFileSchemaLoader
     file_path: "./source_close_com/schemas/{{ parameters['name'] }}.json"
   selector:
     type: RecordSelector

--- a/airbyte-integrations/connectors/source-instatus/source_instatus/instatus.yaml
+++ b/airbyte-integrations/connectors/source-instatus/source_instatus/instatus.yaml
@@ -50,7 +50,7 @@ definitions:
       $ref: "#/definitions/user_field_selector"
 
   schema_loader:
-    type: JsonSchema
+    type: JsonFileSchemaLoader
     file_path: "./source_instatus/schemas/{{ parameters['name'] }}.json"
 
   base_stream:

--- a/airbyte-integrations/connectors/source-pexels-api/source_pexels_api/pexels_api.yaml
+++ b/airbyte-integrations/connectors/source-pexels-api/source_pexels_api/pexels_api.yaml
@@ -65,14 +65,14 @@ definitions:
 
   base_stream:
     schema_loader:
-      type: JsonSchema
+      type: JsonFileSchemaLoader
       file_path: "./source_pexels_api/schemas/{{ parameters['name'] }}.json"
     retriever:
       $ref: "#/definitions/retriever"
 
   page_stream:
     schema_loader:
-      type: JsonSchema
+      type: JsonFileSchemaLoader
       file_path: "./source_pexels_api/schemas/{{ parameters['name'] }}.json"
     retriever:
       record_selector:

--- a/airbyte-integrations/connectors/source-pocket/source_pocket/pocket.yaml
+++ b/airbyte-integrations/connectors/source-pocket/source_pocket/pocket.yaml
@@ -51,7 +51,7 @@ definitions:
     retriever:
       $ref: "#/definitions/retriever"
     schema_loader:
-      type: "JsonSchema"
+      type: "JsonFileSchemaLoader"
   retrieve_stream:
     $ref: "#/definitions/base_stream"
     $parameters:

--- a/airbyte-integrations/connectors/source-punk-api/source_punk_api/punk_api.yaml
+++ b/airbyte-integrations/connectors/source-punk-api/source_punk_api/punk_api.yaml
@@ -46,14 +46,14 @@ definitions:
 
   base_stream:
     schema_loader:
-      type: JsonSchema
+      type: JsonFileSchemaLoader
       file_path: "./source_punk_api/schemas/{{ parameters['name'] }}.json"
     retriever:
       $ref: "#/definitions/retriever"
 
   page_stream:
     schema_loader:
-      type: JsonSchema
+      type: JsonFileSchemaLoader
       file_path: "./source_punk_api/schemas/{{ parameters['name'] }}.json"
     retriever:
       record_selector:

--- a/airbyte-integrations/connectors/source-pypi/source_pypi/pypi.yaml
+++ b/airbyte-integrations/connectors/source-pypi/source_pypi/pypi.yaml
@@ -2,7 +2,7 @@ version: "0.1.0"
 
 definitions:
   schema_loader:
-    type: JsonSchema
+    type: JsonFileSchemaLoader
     file_path: "./source_pypi/schemas/{{ parameters['name'] }}.json"
   selector:
     extractor:

--- a/airbyte-integrations/connectors/source-recruitee/source_recruitee/recruitee.yaml
+++ b/airbyte-integrations/connectors/source-recruitee/source_recruitee/recruitee.yaml
@@ -2,7 +2,7 @@ version: "0.1.0"
 
 definitions:
   schema_loader:
-    type: JsonSchema
+    type: JsonFileSchemaLoader
     file_path: "./source_sentry/schemas/{{ parameters.name }}.json"
   selector:
     extractor:

--- a/airbyte-integrations/connectors/source-secoda/source_secoda/secoda.yaml
+++ b/airbyte-integrations/connectors/source-secoda/source_secoda/secoda.yaml
@@ -2,7 +2,7 @@ version: "0.1.0"
 
 definitions:
   schema_loader:
-    type: JsonSchema
+    type: JsonFileSchemaLoader
     file_path: "./source_secoda/schemas/{{ parameters.name }}.json"
   selector:
     extractor:

--- a/airbyte-integrations/connectors/source-spacex-api/source_spacex_api/spacex_api.yaml
+++ b/airbyte-integrations/connectors/source-spacex-api/source_spacex_api/spacex_api.yaml
@@ -19,7 +19,7 @@ definitions:
 
   base_stream:
     schema_loader:
-      type: JsonSchema
+      type: JsonFileSchemaLoader
       file_path: "./source_spacex_api/schemas/{{ parameters['name'] }}.json"
     retriever:
       $ref: "#/definitions/retriever"

--- a/airbyte-integrations/connectors/source-survey-sparrow/source_survey_sparrow/survey_sparrow.yaml
+++ b/airbyte-integrations/connectors/source-survey-sparrow/source_survey_sparrow/survey_sparrow.yaml
@@ -30,7 +30,7 @@ definitions:
       $ref: "#/definitions/requester"
   base_stream:
     schema_loader:
-      type: JsonSchema
+      type: JsonFileSchemaLoader
       file_path: "./source_survey_sparrow/schemas/{{ parameters['name'] }}.json"
     retriever:
       $ref: "#/definitions/retriever"

--- a/airbyte-integrations/connectors/source-tmdb/source_tmdb/tmdb.yaml
+++ b/airbyte-integrations/connectors/source-tmdb/source_tmdb/tmdb.yaml
@@ -41,14 +41,14 @@ definitions:
 
   base_stream:
     schema_loader:
-      type: JsonSchema
+      type: JsonFileSchemaLoader
       file_path: "./source_tmdb/schemas/{{ parameters['name'] }}.json"
     retriever:
       $ref: "#/definitions/retriever"
 
   page_stream:
     schema_loader:
-      type: JsonSchema
+      type: JsonFileSchemaLoader
       file_path: "./source_tmdb/schemas/{{ parameters['name'] }}.json"
     retriever:
       record_selector:

--- a/airbyte-integrations/connectors/source-wikipedia-pageviews/source_wikipedia_pageviews/wikipedia_pageviews.yaml
+++ b/airbyte-integrations/connectors/source-wikipedia-pageviews/source_wikipedia_pageviews/wikipedia_pageviews.yaml
@@ -59,7 +59,7 @@ definitions:
       $ref: "#/definitions/top_stream_slicer"
   per_article_stream:
     schema_loader:
-      type: JsonSchema
+      type: JsonFileSchemaLoader
       file_path: "./source_wikipedia_pageviews/schemas/{{ parameters['name'] }}.json"
     retriever:
       $ref: "#/definitions/per_article_retriever"
@@ -67,7 +67,7 @@ definitions:
       name: "per-article"
   top_stream:
     schema_loader:
-      type: JsonSchema
+      type: JsonFileSchemaLoader
       file_path: "./source_wikipedia_pageviews/schemas/{{ parameters['name'] }}.json"
     retriever:
       $ref: "#/definitions/top_retriever"

--- a/airbyte-integrations/connectors/source-workable/source_workable/workable.yaml
+++ b/airbyte-integrations/connectors/source-workable/source_workable/workable.yaml
@@ -3,7 +3,7 @@ version: "0.1.0"
 definitions:
   page_size: 100
   schema_loader:
-    type: JsonSchema
+    type: JsonFileSchemaLoader
     file_path: "./source_sentry/schemas/{{ parameters.name }}.json"
   selector:
     extractor:

--- a/airbyte-integrations/connectors/source-zoom/source_zoom/zoom.yaml
+++ b/airbyte-integrations/connectors/source-zoom/source_zoom/zoom.yaml
@@ -28,7 +28,7 @@ definitions:
       $ref: "#/definitions/requester"
 
   schema_loader:
-    type: JsonSchema
+    type: JsonFileSchemaLoader
     file_path: "./source_zoom/schemas/{{ parameters['name'] }}.json"
 
   users_stream:


### PR DESCRIPTION
Closes https://github.com/airbytehq/airbyte/issues/19698

## What
Earlier we decided to rename JsonSchema to JsonFileSchemaLoader since this more accurately described what the component was doing. To retain backwards compatibility we supported both in the `declarative_component_schema.yaml` w/ JsonSchema acting as sort of an alias.

This is a breaking change so we are packaging this up in the promotion of low-code to Beta.

## How
When we first renamed the component, we allowed for both `JsonSchema` and `JsonFileSchemaLoader` in the string literal. But now that we're deprecating this alias, its as simple as modifying the schema YAML and rerunning the model generation.

Given the few usages of JsonSchema, I just performed a replace all from PyCharm for simplicity so no migration is included

## Recommended reading order
1. `declarative_component_schema.yaml`
