### PR TITLE
📚 Fix: Update the example schema-generator path to the new airbyte-integrations path

### DIFF
--- a/tools/schema_generator/README.md
+++ b/tools/schema_generator/README.md
@@ -25,7 +25,7 @@ $ pip install -r requirements.txt
 To use a connectors `run` command we first need an AirbyteConfiguredCatalog:
 
 ```bash
-$ cd ../../connectors/<your-connector> # you need to use the tool at the root folder of a connector
+$ ../../airbyte-integrations/connectors/<your-connector> # you need to use the tool at the root folder of a connector
 $ docker run --rm -v $(pwd)/secrets:/secrets airbyte/<your-connector-image-name>:dev discover --config /secrets/config.json | schema_generator --configure-catalog
 ```
 This will created the file **configured_catalog.json** in the **integration_tests** folder in the current working directory.


### PR DESCRIPTION
## What
The example in the schema-generator README.md references an old path to the `connectors` folder.

## How
This updates the example path to include the new parent directory `airbyte-integrations`

## 🚨 User Impact 🚨
Users can follow the readme and use the schema generator with one less issue

## Pre-merge Checklist

- [ ] PR name follows [PR naming conventions](https://docs.airbyte.com/contributing-to-airbyte/issues-and-pull-requests)
