### PR TITLE
🪟 🎨 Remove z-index rule from Switch component handle

### DIFF
--- a/airbyte-webapp/src/components/ui/Switch/Switch.module.scss
+++ b/airbyte-webapp/src/components/ui/Switch/Switch.module.scss
@@ -1,6 +1,5 @@
 @use "scss/colors";
 @use "scss/variables";
-@use "scss/z-indices";
 
 @mixin knob-transform($position, $size) {
   @if $position == left {
@@ -99,7 +98,6 @@
 
     &::before {
       position: absolute;
-      z-index: z-indices.$switchSliderBefore;
       content: "";
       background: colors.$white;
       transition: variables.$transition;

--- a/airbyte-webapp/src/scss/_z-indices.scss
+++ b/airbyte-webapp/src/scss/_z-indices.scss
@@ -6,6 +6,5 @@ $sidebar: 9999;
 $schemaChangesBackdropContent: 4;
 $schemaChangesBackdrop: 3;
 $dropdownMenu: 2;
-$switchSliderBefore: 1;
 $tableScroll: 1;
 $panelSplitter: 0;


### PR DESCRIPTION
## What
Removes the z-index from the Switch handle CSS rule. This is an old rule that may no longer be needed. Tested and could not find any situations where the Switch was rendering incorrectly.