### PR TITLE
🪟🔧 use https instead of http for localhost:3000 in e2e webapp tests

### DIFF
--- a/airbyte-webapp-e2e-tests/cypress.json
+++ b/airbyte-webapp-e2e-tests/cypress.json
@@ -1,6 +1,6 @@
 {
   "projectId": "916nvw",
-  "baseUrl": "http://localhost:3000",
+  "baseUrl": "https://localhost:3000",
   "testFiles": ["**/*.spec.*"],
   "viewportHeight": 800,
   "viewportWidth": 1280,
@@ -14,6 +14,6 @@
     "host": "localhost",
     "database": "airbyte_ci_source",
     "password": "secret_password",
-    "port":5433
+    "port": 5433
   }
 }

--- a/airbyte-webapp-e2e-tests/package.json
+++ b/airbyte-webapp-e2e-tests/package.json
@@ -7,8 +7,8 @@
   },
   "scripts": {
     "cypress:open": "cypress open",
-    "cypress:ci": "CYPRESS_BASE_URL=http://localhost:8000 cypress run",
-    "cypress:ci:record": "CYPRESS_BASE_URL=http://localhost:8000 cypress run --record --key $CYPRESS_KEY",
+    "cypress:ci": "CYPRESS_BASE_URL=https://localhost:8000 cypress run",
+    "cypress:ci:record": "CYPRESS_BASE_URL=https://localhost:8000 cypress run --record --key $CYPRESS_KEY",
     "createdbsource": "docker run --rm -d -p 5433:5432 -e POSTGRES_PASSWORD=secret_password -e POSTGRES_DB=airbyte_ci_source --name airbyte_ci_pg_source postgres",
     "createdbdestination": "docker run --rm -d -p 5434:5432 -e POSTGRES_PASSWORD=secret_password -e POSTGRES_DB=airbyte_ci_destination --name airbyte_ci_pg_destination postgres",
     "createdummyapi": "docker run --rm -d -p 6767:6767 --network=airbyte_airbyte_internal --mount type=bind,source=\"$(pwd)\"/dummy_api.js,target=/index.js --name=dummy_api node:16-alpine \"index.js\"",

--- a/airbyte-webapp-e2e-tests/package.json
+++ b/airbyte-webapp-e2e-tests/package.json
@@ -7,8 +7,8 @@
   },
   "scripts": {
     "cypress:open": "cypress open",
-    "cypress:ci": "CYPRESS_BASE_URL=https://localhost:8000 cypress run",
-    "cypress:ci:record": "CYPRESS_BASE_URL=https://localhost:8000 cypress run --record --key $CYPRESS_KEY",
+    "cypress:ci": "CYPRESS_BASE_URL=http://localhost:8000 cypress run",
+    "cypress:ci:record": "CYPRESS_BASE_URL=http://localhost:8000 cypress run --record --key $CYPRESS_KEY",
     "createdbsource": "docker run --rm -d -p 5433:5432 -e POSTGRES_PASSWORD=secret_password -e POSTGRES_DB=airbyte_ci_source --name airbyte_ci_pg_source postgres",
     "createdbdestination": "docker run --rm -d -p 5434:5432 -e POSTGRES_PASSWORD=secret_password -e POSTGRES_DB=airbyte_ci_destination --name airbyte_ci_pg_destination postgres",
     "createdummyapi": "docker run --rm -d -p 6767:6767 --network=airbyte_airbyte_internal --mount type=bind,source=\"$(pwd)\"/dummy_api.js,target=/index.js --name=dummy_api node:16-alpine \"index.js\"",


### PR DESCRIPTION
## What
The switch to Vite caused local E2E tests to be unable to run successfully, as they were trying to use `http://localhost:3000`, instead of `https://localhost:3000`, which is now required.

## How
This PR fixes the issue by switching `http` to `https` for that baseUrl