### PR TITLE
Low Code CDK: only allow `name` and `primary_key` on `DeclarativeStream` components

### DIFF
--- a/airbyte-cdk/python/airbyte_cdk/sources/declarative/declarative_component_schema.yaml
+++ b/airbyte-cdk/python/airbyte_cdk/sources/declarative/declarative_component_schema.yaml
@@ -589,15 +589,12 @@ definitions:
     type: object
     required:
       - type
-      - name
       - path
       - url_base
     properties:
       type:
         type: string
         enum: [HttpRequester]
-      name:
-        type: string
       path:
         type: string
       url_base:
@@ -984,15 +981,10 @@ definitions:
         anyOf:
           - "$ref": "#/definitions/CustomRequester"
           - "$ref": "#/definitions/HttpRequester"
-      name:
-        type: string
-        default: ""
       paginator:
         anyOf:
           - "$ref": "#/definitions/DefaultPaginator"
           - "$ref": "#/definitions/NoPagination"
-      primary_key:
-        "$ref": "#/definitions/PrimaryKey"
       stream_slicer:
         anyOf:
           - "$ref": "#/definitions/CartesianProductStreamSlicer"

--- a/airbyte-cdk/python/airbyte_cdk/sources/declarative/declarative_component_schema.yaml
+++ b/airbyte-cdk/python/airbyte_cdk/sources/declarative/declarative_component_schema.yaml
@@ -596,10 +596,13 @@ definitions:
         type: string
         enum: [HttpRequester]
       path:
+        description: The specific endpoint to fetch data from for a resource.
         type: string
       url_base:
+        description: The root of the API source.
         type: string
       authenticator:
+        description: Authenticator component that defines how to authenticate to the source.
         anyOf:
           - "$ref": "#/definitions/ApiKeyAuthenticator"
           - "$ref": "#/definitions/BasicHttpAuthenticator"
@@ -609,11 +612,13 @@ definitions:
           - "$ref": "#/definitions/NoAuth"
           - "$ref": "#/definitions/SessionTokenAuthenticator"
       error_handler:
+        description: Error handler component that defines how to handle errors.
         anyOf:
           - "$ref": "#/definitions/DefaultErrorHandler"
           - "$ref": "#/definitions/CustomErrorHandler"
           - "$ref": "#/definitions/CompositeErrorHandler"
       http_method:
+        description: The HTTP method used to fetch data from the source (can be GET or POST).
         anyOf:
           - type: string
           - type: string
@@ -976,16 +981,20 @@ definitions:
         type: string
         enum: [SimpleRetriever]
       record_selector:
+        description: Component that describes how to extract records from a HTTP response.
         "$ref": "#/definitions/RecordSelector"
       requester:
+        description: Requester component that describes how to prepare HTTP requests to send to the source API.
         anyOf:
           - "$ref": "#/definitions/CustomRequester"
           - "$ref": "#/definitions/HttpRequester"
       paginator:
+        description: Paginator component that describes how to navigate through the API's pages.
         anyOf:
           - "$ref": "#/definitions/DefaultPaginator"
           - "$ref": "#/definitions/NoPagination"
       stream_slicer:
+        description: StreamSlicer component that describes how to partition the stream, enabling incremental syncs and checkpointing.
         anyOf:
           - "$ref": "#/definitions/CartesianProductStreamSlicer"
           - "$ref": "#/definitions/CustomStreamSlicer"

--- a/airbyte-cdk/python/airbyte_cdk/sources/declarative/declarative_component_schema.yaml
+++ b/airbyte-cdk/python/airbyte_cdk/sources/declarative/declarative_component_schema.yaml
@@ -468,16 +468,7 @@ definitions:
         default: ""
       primary_key:
         definition: The primary key of the stream
-        anyOf:
-          - type: string
-          - type: array
-            items:
-              type: string
-          - type: array
-            items:
-              type: array
-              items:
-                type: string
+        "$ref": "#/definitions/PrimaryKey"
         default: ""
       schema_loader:
         definition: The schema loader used to retrieve the schema for the current stream

--- a/airbyte-cdk/python/airbyte_cdk/sources/declarative/models/declarative_component_schema.py
+++ b/airbyte-cdk/python/airbyte_cdk/sources/declarative/models/declarative_component_schema.py
@@ -398,7 +398,6 @@ class CompositeErrorHandler(BaseModel):
 
 class HttpRequester(BaseModel):
     type: Literal["HttpRequester"]
-    name: str
     path: str
     url_base: str
     authenticator: Optional[
@@ -486,9 +485,7 @@ class SimpleRetriever(BaseModel):
     type: Literal["SimpleRetriever"]
     record_selector: RecordSelector
     requester: Union[CustomRequester, HttpRequester]
-    name: Optional[str] = ""
     paginator: Optional[Union[DefaultPaginator, NoPagination]] = None
-    primary_key: Optional[PrimaryKey] = None
     stream_slicer: Optional[
         Union[
             CartesianProductStreamSlicer,

--- a/airbyte-cdk/python/airbyte_cdk/sources/declarative/models/declarative_component_schema.py
+++ b/airbyte-cdk/python/airbyte_cdk/sources/declarative/models/declarative_component_schema.py
@@ -474,7 +474,7 @@ class DeclarativeStream(BaseModel):
     type: Literal["DeclarativeStream"]
     retriever: Union[CustomRetriever, SimpleRetriever]
     name: Optional[str] = ""
-    primary_key: Optional[Union[str, List[str], List[List[str]]]] = ""
+    primary_key: Optional[PrimaryKey] = ""
     schema_loader: Optional[Union[InlineSchemaLoader, JsonFileSchemaLoader]] = None
     transformations: Optional[List[Union[AddFields, CustomTransformation, RemoveFields]]] = None
     parameters: Optional[Dict[str, Any]] = Field(None, alias="$parameters")

--- a/airbyte-cdk/python/airbyte_cdk/sources/declarative/models/declarative_component_schema.py
+++ b/airbyte-cdk/python/airbyte_cdk/sources/declarative/models/declarative_component_schema.py
@@ -398,8 +398,8 @@ class CompositeErrorHandler(BaseModel):
 
 class HttpRequester(BaseModel):
     type: Literal["HttpRequester"]
-    path: str
-    url_base: str
+    path: str = Field(..., description="The specific endpoint to fetch data from for a resource.")
+    url_base: str = Field(..., description="The root of the API source.")
     authenticator: Optional[
         Union[
             ApiKeyAuthenticator,
@@ -410,9 +410,17 @@ class HttpRequester(BaseModel):
             NoAuth,
             SessionTokenAuthenticator,
         ]
-    ] = None
-    error_handler: Optional[Union[DefaultErrorHandler, CustomErrorHandler, CompositeErrorHandler]] = None
-    http_method: Optional[Union[str, HttpMethodEnum]] = "GET"
+    ] = Field(
+        None,
+        description="Authenticator component that defines how to authenticate to the source.",
+    )
+    error_handler: Optional[Union[DefaultErrorHandler, CustomErrorHandler, CompositeErrorHandler]] = Field(
+        None, description="Error handler component that defines how to handle errors."
+    )
+    http_method: Optional[Union[str, HttpMethodEnum]] = Field(
+        "GET",
+        description="The HTTP method used to fetch data from the source (can be GET or POST).",
+    )
     request_body_data: Optional[Union[str, Dict[str, str]]] = Field(
         None,
         description="Specifies how to populate the body of the request with a non-JSON payload. If returns a ready text that it will be sent as is. If returns a dict that it will be converted to a urlencoded form.",
@@ -483,9 +491,18 @@ class ParentStreamConfig(BaseModel):
 
 class SimpleRetriever(BaseModel):
     type: Literal["SimpleRetriever"]
-    record_selector: RecordSelector
-    requester: Union[CustomRequester, HttpRequester]
-    paginator: Optional[Union[DefaultPaginator, NoPagination]] = None
+    record_selector: RecordSelector = Field(
+        ...,
+        description="Component that describes how to extract records from a HTTP response.",
+    )
+    requester: Union[CustomRequester, HttpRequester] = Field(
+        ...,
+        description="Requester component that describes how to prepare HTTP requests to send to the source API.",
+    )
+    paginator: Optional[Union[DefaultPaginator, NoPagination]] = Field(
+        None,
+        description="Paginator component that describes how to navigate through the API's pages.",
+    )
     stream_slicer: Optional[
         Union[
             CartesianProductStreamSlicer,
@@ -495,7 +512,10 @@ class SimpleRetriever(BaseModel):
             SingleSlice,
             SubstreamSlicer,
         ]
-    ] = None
+    ] = Field(
+        None,
+        description="StreamSlicer component that describes how to partition the stream, enabling incremental syncs and checkpointing.",
+    )
     parameters: Optional[Dict[str, Any]] = Field(None, alias="$parameters")
 
 

--- a/airbyte-cdk/python/airbyte_cdk/sources/declarative/parsers/model_to_component_factory.py
+++ b/airbyte-cdk/python/airbyte_cdk/sources/declarative/parsers/model_to_component_factory.py
@@ -404,7 +404,7 @@ class ModelToComponentFactory:
         )
 
     def create_declarative_stream(self, model: DeclarativeStreamModel, config: Config, **kwargs) -> DeclarativeStream:
-        retriever = self._create_component_from_model(model=model.retriever, config=config)
+        retriever = self._create_component_from_model(model=model.retriever, config=config, name=model.name, primary_key=model.primary_key)
 
         cursor_field = self._get_cursor_field_from_stream_slicer(model)
 
@@ -681,8 +681,10 @@ class ModelToComponentFactory:
             parameters=model.parameters,
         )
 
-    def create_simple_retriever(self, model: SimpleRetrieverModel, config: Config, **kwargs) -> SimpleRetriever:
-        requester = self._create_component_from_model(model=model.requester, config=config)
+    def create_simple_retriever(
+        self, model: SimpleRetrieverModel, config: Config, *, name: str, primary_key: Optional[Union[str, List[str], List[List[str]]]]
+    ) -> SimpleRetriever:
+        requester = self._create_component_from_model(model=model.requester, config=config, name=name)
         record_selector = self._create_component_from_model(model=model.record_selector, config=config)
         url_base = model.requester.url_base if hasattr(model.requester, "url_base") else requester.get_url_base()
         paginator = (
@@ -698,9 +700,9 @@ class ModelToComponentFactory:
 
         if self._limit_slices_fetched:
             return SimpleRetrieverTestReadDecorator(
-                name=model.parameters.get("name", ""),
+                name=name,
                 paginator=paginator,
-                primary_key=model.parameters.get("primary_key"),
+                primary_key=primary_key,
                 requester=requester,
                 record_selector=record_selector,
                 stream_slicer=stream_slicer,
@@ -709,9 +711,9 @@ class ModelToComponentFactory:
                 parameters=model.parameters,
             )
         return SimpleRetriever(
-            name=model.parameters.get("name", ""),
+            name=name,
             paginator=paginator,
-            primary_key=model.parameters.get("primary_key"),
+            primary_key=primary_key,
             requester=requester,
             record_selector=record_selector,
             stream_slicer=stream_slicer,

--- a/airbyte-cdk/python/airbyte_cdk/sources/declarative/parsers/model_to_component_factory.py
+++ b/airbyte-cdk/python/airbyte_cdk/sources/declarative/parsers/model_to_component_factory.py
@@ -515,7 +515,7 @@ class ModelToComponentFactory:
     def create_exponential_backoff_strategy(model: ExponentialBackoffStrategyModel, config: Config) -> ExponentialBackoffStrategy:
         return ExponentialBackoffStrategy(factor=model.factor, parameters=model.parameters, config=config)
 
-    def create_http_requester(self, model: HttpRequesterModel, config: Config, **kwargs) -> HttpRequester:
+    def create_http_requester(self, model: HttpRequesterModel, config: Config, *, name: str, **kwargs) -> HttpRequester:
         authenticator = self._create_component_from_model(model=model.authenticator, config=config) if model.authenticator else None
         error_handler = (
             self._create_component_from_model(model=model.error_handler, config=config)
@@ -533,7 +533,7 @@ class ModelToComponentFactory:
         )
 
         return HttpRequester(
-            name=model.parameters.get("name", "") if model.parameters else "",
+            name=name,
             url_base=model.url_base,
             path=model.path,
             authenticator=authenticator,

--- a/airbyte-cdk/python/airbyte_cdk/sources/declarative/parsers/model_to_component_factory.py
+++ b/airbyte-cdk/python/airbyte_cdk/sources/declarative/parsers/model_to_component_factory.py
@@ -404,7 +404,8 @@ class ModelToComponentFactory:
         )
 
     def create_declarative_stream(self, model: DeclarativeStreamModel, config: Config, **kwargs) -> DeclarativeStream:
-        retriever = self._create_component_from_model(model=model.retriever, config=config, name=model.name, primary_key=model.primary_key)
+        primary_key = model.primary_key.__root__ if model.primary_key else None
+        retriever = self._create_component_from_model(model=model.retriever, config=config, name=model.name, primary_key=primary_key)
 
         cursor_field = self._get_cursor_field_from_stream_slicer(model)
 
@@ -422,7 +423,7 @@ class ModelToComponentFactory:
                 transformations.append(self._create_component_from_model(model=transformation_model, config=config))
         return DeclarativeStream(
             name=model.name,
-            primary_key=model.primary_key,
+            primary_key=primary_key,
             retriever=retriever,
             schema_loader=schema_loader,
             stream_cursor_field=cursor_field or [],
@@ -515,7 +516,7 @@ class ModelToComponentFactory:
     def create_exponential_backoff_strategy(model: ExponentialBackoffStrategyModel, config: Config) -> ExponentialBackoffStrategy:
         return ExponentialBackoffStrategy(factor=model.factor, parameters=model.parameters, config=config)
 
-    def create_http_requester(self, model: HttpRequesterModel, config: Config, *, name: str, **kwargs) -> HttpRequester:
+    def create_http_requester(self, model: HttpRequesterModel, config: Config, *, name: str) -> HttpRequester:
         authenticator = self._create_component_from_model(model=model.authenticator, config=config) if model.authenticator else None
         error_handler = (
             self._create_component_from_model(model=model.error_handler, config=config)

--- a/airbyte-cdk/python/airbyte_cdk/sources/declarative/parsers/model_to_component_factory.py
+++ b/airbyte-cdk/python/airbyte_cdk/sources/declarative/parsers/model_to_component_factory.py
@@ -533,7 +533,7 @@ class ModelToComponentFactory:
         )
 
         return HttpRequester(
-            name=model.name,
+            name=model.parameters.get("name", "") if model.parameters else "",
             url_base=model.url_base,
             path=model.path,
             authenticator=authenticator,
@@ -698,9 +698,9 @@ class ModelToComponentFactory:
 
         if self._limit_slices_fetched:
             return SimpleRetrieverTestReadDecorator(
-                name=model.name,
+                name=model.parameters.get("name", ""),
                 paginator=paginator,
-                primary_key=model.primary_key.__root__ if model.primary_key else None,
+                primary_key=model.parameters.get("primary_key"),
                 requester=requester,
                 record_selector=record_selector,
                 stream_slicer=stream_slicer,
@@ -709,9 +709,9 @@ class ModelToComponentFactory:
                 parameters=model.parameters,
             )
         return SimpleRetriever(
-            name=model.name,
+            name=model.parameters.get("name", ""),
             paginator=paginator,
-            primary_key=model.primary_key.__root__ if model.primary_key else None,
+            primary_key=model.parameters.get("primary_key"),
             requester=requester,
             record_selector=record_selector,
             stream_slicer=stream_slicer,

--- a/airbyte-cdk/python/unit_tests/sources/declarative/parsers/test_model_to_component_factory.py
+++ b/airbyte-cdk/python/unit_tests/sources/declarative/parsers/test_model_to_component_factory.py
@@ -116,7 +116,6 @@ requester:
   request_parameters:
     unit: "day"
 retriever:
-  name: "{{ parameters['name'] }}"
   stream_slicer:
     type: DatetimeStreamSlicer
     start_datetime: "{{ config['start_time'] }}"
@@ -128,7 +127,6 @@ retriever:
       datetime_format: "%Y-%m-%dT%H:%M:%S.%f%z"
   paginator:
     type: NoPagination
-  primary_key: "{{ parameters['primary_key'] }}"
 partial_stream:
   type: DeclarativeStream
   schema_loader:
@@ -138,10 +136,11 @@ list_stream:
   $ref: "#/partial_stream"
   $parameters:
     name: "lists"
-    primary_key: "id"
     extractor:
       $ref: "#/extractor"
       field_path: ["{{ parameters['name'] }}"]
+  name: "lists"
+  primary_key: "id"
   retriever:
     $ref: "#/retriever"
     requester:
@@ -345,17 +344,17 @@ def test_create_substream_slicer():
           field_path: []
     stream_A:
       type: DeclarativeStream
+      name: "A"
+      primary_key: "id"
       $parameters:
-        name: "A"
-        primary_key: "id"
         retriever: "#/retriever"
         url_base: "https://airbyte.io"
         schema_loader: "#/schema_loader"
     stream_B:
       type: DeclarativeStream
+      name: "B"
+      primary_key: "id"
       $parameters:
-        name: "B"
-        primary_key: "id"
         retriever: "#/retriever"
         url_base: "https://airbyte.io"
         schema_loader: "#/schema_loader"
@@ -650,9 +649,10 @@ def test_config_with_defaults():
     content = """
     lists_stream:
       type: "DeclarativeStream"
+      name: "lists"
+      primary_key: id
       $parameters:
         name: "lists"
-        primary_key: id
         url_base: "https://api.sendgrid.com"
         schema_loader:
           name: "{{ parameters.stream_name }}"
@@ -734,10 +734,7 @@ def test_create_default_paginator():
     paginator_manifest = transformer.propagate_types_and_parameters("", resolved_manifest["paginator"], {})
 
     paginator = factory.create_component(
-        model_type=DefaultPaginatorModel,
-        component_definition=paginator_manifest,
-        config=input_config,
-        url_base="https://airbyte.io"
+        model_type=DefaultPaginatorModel, component_definition=paginator_manifest, config=input_config, url_base="https://airbyte.io"
     )
 
     assert isinstance(paginator, DefaultPaginator)

--- a/airbyte-cdk/python/unit_tests/sources/declarative/parsers/test_model_to_component_factory.py
+++ b/airbyte-cdk/python/unit_tests/sources/declarative/parsers/test_model_to_component_factory.py
@@ -583,15 +583,16 @@ requester:
     header: header_value
   {error_handler}
     """
+    name = "name"
     parsed_manifest = YamlDeclarativeSource._parse(content)
     resolved_manifest = resolver.preprocess_manifest(parsed_manifest)
     requester_manifest = transformer.propagate_types_and_parameters("", resolved_manifest["requester"], {})
 
-    selector = factory.create_component(model_type=HttpRequesterModel, component_definition=requester_manifest, config=input_config)
+    selector = factory.create_component(model_type=HttpRequesterModel, component_definition=requester_manifest, config=input_config, name=name)
 
     assert isinstance(selector, HttpRequester)
     assert selector._method == HttpMethod.GET
-    assert selector.name == "lists"
+    assert selector.name == "name"
     assert selector.path.string == "/v3/marketing/lists"
     assert selector.url_base.string == "https://api.sendgrid.com"
 

--- a/airbyte-cdk/python/unit_tests/sources/declarative/parsers/test_model_to_component_factory.py
+++ b/airbyte-cdk/python/unit_tests/sources/declarative/parsers/test_model_to_component_factory.py
@@ -108,7 +108,6 @@ metadata_paginator:
       page_size: 10
 requester:
   type: HttpRequester
-  name: "{{ parameters['name'] }}"
   url_base: "https://api.sendgrid.com/v3/"
   http_method: "GET"
   authenticator:
@@ -201,8 +200,8 @@ spec:
     assert add_fields.fields[0].value.string == "{{ response.to_add }}"
 
     assert isinstance(stream.retriever, SimpleRetriever)
-    assert stream.retriever.primary_key == "{{ parameters['primary_key'] }}"
-    assert stream.retriever.name == "lists"
+    assert stream.retriever.primary_key == stream.primary_key
+    assert stream.retriever.name == stream.name
 
     assert isinstance(stream.retriever.record_selector, RecordSelector)
 
@@ -229,6 +228,7 @@ spec:
 
     assert isinstance(stream.retriever.requester, HttpRequester)
     assert stream.retriever.requester.http_method == HttpMethod.GET
+    assert stream.retriever.requester.name == stream.name
     assert stream.retriever.requester.path.string == "{{ next_page_token['next_page_url'] }}"
     assert stream.retriever.requester.path.default == "{{ next_page_token['next_page_url'] }}"
 
@@ -338,7 +338,6 @@ def test_create_substream_slicer():
       name: "{{ parameters['stream_name'] }}"
     retriever:
       requester:
-        name: "{{ parameters['name'] }}"
         type: "HttpRequester"
         path: "kek"
       record_selector:
@@ -694,6 +693,8 @@ def test_config_with_defaults():
     assert stream.primary_key == "id"
     assert stream.name == "lists"
     assert isinstance(stream.retriever, SimpleRetriever)
+    assert stream.retriever.name == stream.name
+    assert stream.retriever.primary_key == stream.primary_key
 
     assert isinstance(stream.schema_loader, JsonFileSchemaLoader)
     assert stream.schema_loader.file_path.string == "./source_sendgrid/schemas/{{ parameters.name }}.yaml"
@@ -849,13 +850,11 @@ def test_custom_components_do_not_contain_extra_fields():
                     "primary_key": "id",
                     "retriever": {
                         "type": "SimpleRetriever",
-                        "name": "a_parent",
-                        "primary_key": "id",
                         "record_selector": {
                             "type": "RecordSelector",
                             "extractor": {"type": "DpathExtractor", "field_path": []},
                         },
-                        "requester": {"type": "HttpRequester", "name": "a_parent", "url_base": "https://airbyte.io", "path": "some"},
+                        "requester": {"type": "HttpRequester", "url_base": "https://airbyte.io", "path": "some"},
                     },
                     "schema_loader": {
                         "type": "JsonFileSchemaLoader",
@@ -897,13 +896,11 @@ def test_parse_custom_component_fields_if_subcomponent():
                     "primary_key": "id",
                     "retriever": {
                         "type": "SimpleRetriever",
-                        "name": "a_parent",
-                        "primary_key": "id",
                         "record_selector": {
                             "type": "RecordSelector",
                             "extractor": {"type": "DpathExtractor", "field_path": []},
                         },
-                        "requester": {"type": "HttpRequester", "name": "a_parent", "url_base": "https://airbyte.io", "path": "some"},
+                        "requester": {"type": "HttpRequester", "url_base": "https://airbyte.io", "path": "some"},
                     },
                     "schema_loader": {
                         "type": "JsonFileSchemaLoader",
@@ -1032,11 +1029,8 @@ class TestCreateTransformations:
             "primary_key": [],
             "retriever": {
                 "type": "SimpleRetriever",
-                "name": "test",
-                "primary_key": [],
                 "requester": {
                     "type": "HttpRequester",
-                    "name": "test",
                     "url_base": "http://localhost:6767/",
                     "path": "items/",
                     "request_options_provider": {

--- a/airbyte-integrations/connector-templates/source-configuration-based/source_{{snakeCase name}}/manifest.yaml.hbs
+++ b/airbyte-integrations/connector-templates/source-configuration-based/source_{{snakeCase name}}/manifest.yaml.hbs
@@ -27,9 +27,9 @@ definitions:
       $ref: "#/definitions/retriever"
   customers_stream:
     $ref: "#/definitions/base_stream"
+    name: "customers"
+    primary_key: "id"
     $parameters:
-      name: "customers"
-      primary_key: "id"
       path: "/example"
 
 streams:

--- a/airbyte-integrations/connectors/source-callrail/source_callrail/manifest.yaml
+++ b/airbyte-integrations/connectors/source-callrail/source_callrail/manifest.yaml
@@ -58,7 +58,6 @@ definitions:
     $parameters:
       name: "calls"
       cursor_field: "start_time"
-    name: "calls"
     primary_key: "id"
     schema_loader:
       $ref: "#/definitions/schema_loader"
@@ -74,7 +73,6 @@ definitions:
     $parameters:
       name: "conversations"
       cursor_field: "last_message_at"
-    name: "conversations"
     primary_key: "id"
     schema_loader:
       $ref: "#/definitions/schema_loader"
@@ -90,7 +88,6 @@ definitions:
     $parameters:
       name: "users"
       cursor_field: "created_at"
-    name: "users"
     primary_key: "id"
     schema_loader:
       $ref: "#/definitions/schema_loader"
@@ -104,7 +101,6 @@ definitions:
     $parameters:
       name: "companies"
       cursor_field: "created_at"
-    name: "companies"
     primary_key: "id"
     schema_loader:
       $ref: "#/definitions/schema_loader"

--- a/airbyte-integrations/connectors/source-callrail/source_callrail/manifest.yaml
+++ b/airbyte-integrations/connectors/source-callrail/source_callrail/manifest.yaml
@@ -56,6 +56,7 @@ definitions:
 
   calls_stream:
     $parameters:
+      name: "calls"
       cursor_field: "start_time"
     name: "calls"
     primary_key: "id"
@@ -71,6 +72,7 @@ definitions:
 
   conversations_stream:
     $parameters:
+      name: "conversations"
       cursor_field: "last_message_at"
     name: "conversations"
     primary_key: "id"
@@ -86,6 +88,7 @@ definitions:
 
   users_stream:
     $parameters:
+      name: "users"
       cursor_field: "created_at"
     name: "users"
     primary_key: "id"
@@ -99,6 +102,7 @@ definitions:
 
   companies_stream:
     $parameters:
+      name: "companies"
       cursor_field: "created_at"
     name: "companies"
     primary_key: "id"

--- a/airbyte-integrations/connectors/source-callrail/source_callrail/manifest.yaml
+++ b/airbyte-integrations/connectors/source-callrail/source_callrail/manifest.yaml
@@ -10,7 +10,6 @@ definitions:
 
   requester:
     type: HttpRequester
-    name: "{{ parameters['name'] }}"
     http_method: "GET"
     authenticator:
       type: ApiKeyAuthenticator
@@ -36,8 +35,6 @@ definitions:
     type: SimpleRetriever
     $parameters:
       url_base: "https://api.callrail.com/v3/a/"
-    name: "{{ parameters['name'] }}"
-    primary_key: "{{ parameters['primary_key'] }}"
     record_selector:
       extractor:
         type: DpathExtractor

--- a/airbyte-integrations/connectors/source-callrail/source_callrail/manifest.yaml
+++ b/airbyte-integrations/connectors/source-callrail/source_callrail/manifest.yaml
@@ -56,8 +56,8 @@ definitions:
 
   calls_stream:
     $parameters:
-      name: "calls"
       cursor_field: "start_time"
+    name: "calls"
     primary_key: "id"
     schema_loader:
       $ref: "#/definitions/schema_loader"
@@ -71,8 +71,8 @@ definitions:
 
   conversations_stream:
     $parameters:
-      name: "conversations"
       cursor_field: "last_message_at"
+    name: "conversations"
     primary_key: "id"
     schema_loader:
       $ref: "#/definitions/schema_loader"
@@ -86,8 +86,8 @@ definitions:
 
   users_stream:
     $parameters:
-      name: "users"
       cursor_field: "created_at"
+    name: "users"
     primary_key: "id"
     schema_loader:
       $ref: "#/definitions/schema_loader"
@@ -99,8 +99,8 @@ definitions:
 
   companies_stream:
     $parameters:
-      name: "companies"
       cursor_field: "created_at"
+    name: "companies"
     primary_key: "id"
     schema_loader:
       $ref: "#/definitions/schema_loader"

--- a/airbyte-integrations/connectors/source-clickup-api/source_clickup_api/manifest.yaml
+++ b/airbyte-integrations/connectors/source-clickup-api/source_clickup_api/manifest.yaml
@@ -30,8 +30,7 @@ definitions:
 
 streams:
   - type: DeclarativeStream
-    $parameters:
-      name: "user"
+    name: "user"
     schema_loader:
       $ref: "#/definitions/schema_loader"
     retriever:
@@ -44,8 +43,7 @@ streams:
       record_selector:
         $ref: "#/definitions/singleSelector"
   - type: DeclarativeStream
-    $parameters:
-      name: "team"
+    name: "team"
     schema_loader:
       $ref: "#/definitions/schema_loader"
     retriever:
@@ -58,8 +56,7 @@ streams:
       record_selector:
         $ref: "#/definitions/arraySelector"
   - type: DeclarativeStream
-    $parameters:
-      name: "list"
+    name: "list"
     schema_loader:
       $ref: "#/definitions/schema_loader"
     retriever:
@@ -72,8 +69,7 @@ streams:
       record_selector:
         $ref: "#/definitions/arraySelector"
   - type: DeclarativeStream
-    $parameters:
-      name: "space"
+    name: "space"
     schema_loader:
       $ref: "#/definitions/schema_loader"
     retriever:
@@ -86,8 +82,7 @@ streams:
       record_selector:
         $ref: "#/definitions/arraySelector"
   - type: DeclarativeStream
-    $parameters:
-      name: "folder"
+    name: "folder"
     schema_loader:
       $ref: "#/definitions/schema_loader"
     retriever:
@@ -100,8 +95,7 @@ streams:
       record_selector:
         $ref: "#/definitions/arraySelector"
   - type: DeclarativeStream
-    $parameters:
-      name: "task"
+    name: "task"
     schema_loader:
       $ref: "#/definitions/schema_loader"
     retriever:

--- a/airbyte-integrations/connectors/source-clickup-api/source_clickup_api/manifest.yaml
+++ b/airbyte-integrations/connectors/source-clickup-api/source_clickup_api/manifest.yaml
@@ -16,7 +16,6 @@ definitions:
       field_path: ["{{ parameters['name']  }}s"]
   requester:
     type: HttpRequester
-    name: "{{ parameters['name'] }}"
     http_method: "GET"
     authenticator:
       type: ApiKeyAuthenticator
@@ -28,8 +27,6 @@ definitions:
     type: SimpleRetriever
     $parameters:
       url_base: "https://api.clickup.com/api/v2"
-    name: "{{ parameters['name'] }}"
-    primary_key: "{{ parameters['primary_key'] }}"
 
 streams:
   - type: DeclarativeStream

--- a/airbyte-integrations/connectors/source-clickup-api/source_clickup_api/manifest.yaml
+++ b/airbyte-integrations/connectors/source-clickup-api/source_clickup_api/manifest.yaml
@@ -32,7 +32,6 @@ streams:
   - type: DeclarativeStream
     $parameters:
       name: "user"
-    name: "user"
     schema_loader:
       $ref: "#/definitions/schema_loader"
     retriever:
@@ -47,7 +46,6 @@ streams:
   - type: DeclarativeStream
     $parameters:
       name: "team"
-    name: "team"
     schema_loader:
       $ref: "#/definitions/schema_loader"
     retriever:
@@ -62,7 +60,6 @@ streams:
   - type: DeclarativeStream
     $parameters:
       name: "list"
-    name: "list"
     schema_loader:
       $ref: "#/definitions/schema_loader"
     retriever:
@@ -77,7 +74,6 @@ streams:
   - type: DeclarativeStream
     $parameters:
       name: "space"
-    name: "space"
     schema_loader:
       $ref: "#/definitions/schema_loader"
     retriever:
@@ -92,7 +88,6 @@ streams:
   - type: DeclarativeStream
     $parameters:
       name: "folder"
-    name: "folder"
     schema_loader:
       $ref: "#/definitions/schema_loader"
     retriever:
@@ -107,7 +102,6 @@ streams:
   - type: DeclarativeStream
     $parameters:
       name: "task"
-    name: "task"
     schema_loader:
       $ref: "#/definitions/schema_loader"
     retriever:

--- a/airbyte-integrations/connectors/source-clickup-api/source_clickup_api/manifest.yaml
+++ b/airbyte-integrations/connectors/source-clickup-api/source_clickup_api/manifest.yaml
@@ -30,6 +30,8 @@ definitions:
 
 streams:
   - type: DeclarativeStream
+    $parameters:
+      name: "user"
     name: "user"
     schema_loader:
       $ref: "#/definitions/schema_loader"
@@ -43,6 +45,8 @@ streams:
       record_selector:
         $ref: "#/definitions/singleSelector"
   - type: DeclarativeStream
+    $parameters:
+      name: "team"
     name: "team"
     schema_loader:
       $ref: "#/definitions/schema_loader"
@@ -56,6 +60,8 @@ streams:
       record_selector:
         $ref: "#/definitions/arraySelector"
   - type: DeclarativeStream
+    $parameters:
+      name: "list"
     name: "list"
     schema_loader:
       $ref: "#/definitions/schema_loader"
@@ -69,6 +75,8 @@ streams:
       record_selector:
         $ref: "#/definitions/arraySelector"
   - type: DeclarativeStream
+    $parameters:
+      name: "space"
     name: "space"
     schema_loader:
       $ref: "#/definitions/schema_loader"
@@ -82,6 +90,8 @@ streams:
       record_selector:
         $ref: "#/definitions/arraySelector"
   - type: DeclarativeStream
+    $parameters:
+      name: "folder"
     name: "folder"
     schema_loader:
       $ref: "#/definitions/schema_loader"
@@ -95,6 +105,8 @@ streams:
       record_selector:
         $ref: "#/definitions/arraySelector"
   - type: DeclarativeStream
+    $parameters:
+      name: "task"
     name: "task"
     schema_loader:
       $ref: "#/definitions/schema_loader"

--- a/airbyte-integrations/connectors/source-courier/source_courier/manifest.yaml
+++ b/airbyte-integrations/connectors/source-courier/source_courier/manifest.yaml
@@ -59,9 +59,9 @@ definitions:
   ## MESSAGES API ##
   messages_stream:
     $ref: "#/definitions/base_stream"
+    name: "messages"
     primary_key: id
     $parameters:
-      name: "messages"
       path: "/messages"
     retriever:
       $ref: "#/definitions/retriever"
@@ -89,9 +89,8 @@ definitions:
   message_info_stream:
     $ref: "#/definitions/base_stream"
     type: DeclarativeStream
+    name: message_info
     primary_key: id
-    $parameters:
-      name: message_info
     retriever:
       $ref: "#/definitions/retriever"
       requester:
@@ -104,8 +103,7 @@ definitions:
 
   message_history_stream:
     type: DeclarativeStream
-    $parameters:
-      name: message_history
+    name: message_history
     primary_key: message_id
     schema_loader:
       $ref: "#/definitions/schema_loader"
@@ -123,8 +121,7 @@ definitions:
 
   message_output_stream:
     type: DeclarativeStream
-    $parameters:
-      name: message_output
+    name: message_output
     primary_key: message_id
     schema_loader:
       $ref: "#/definitions/schema_loader"

--- a/airbyte-integrations/connectors/source-courier/source_courier/manifest.yaml
+++ b/airbyte-integrations/connectors/source-courier/source_courier/manifest.yaml
@@ -20,7 +20,6 @@ definitions:
 
   requester:
     type: HttpRequester
-    name: "{{ parameters['name'] }}"
     url_base: "https://api.courier.com"
     http_method: "GET"
     authenticator:
@@ -42,8 +41,6 @@ definitions:
 
   retriever:
     type: SimpleRetriever
-    name: "{{ parameters['name'] }}"
-    primary_key: "{{ parameters['primary_key'] }}"
     record_selector:
       $ref: "#/definitions/results_selector"
 

--- a/airbyte-integrations/connectors/source-courier/source_courier/manifest.yaml
+++ b/airbyte-integrations/connectors/source-courier/source_courier/manifest.yaml
@@ -62,6 +62,7 @@ definitions:
     name: "messages"
     primary_key: id
     $parameters:
+      name: "messages"
       path: "/messages"
     retriever:
       $ref: "#/definitions/retriever"
@@ -91,6 +92,8 @@ definitions:
     type: DeclarativeStream
     name: message_info
     primary_key: id
+    $parameters:
+      name: message_info
     retriever:
       $ref: "#/definitions/retriever"
       requester:
@@ -103,6 +106,8 @@ definitions:
 
   message_history_stream:
     type: DeclarativeStream
+    $parameters:
+      name: message_history
     name: message_history
     primary_key: message_id
     schema_loader:
@@ -121,6 +126,8 @@ definitions:
 
   message_output_stream:
     type: DeclarativeStream
+    $parameters:
+      name: message_output
     name: message_output
     primary_key: message_id
     schema_loader:

--- a/airbyte-integrations/connectors/source-courier/source_courier/manifest.yaml
+++ b/airbyte-integrations/connectors/source-courier/source_courier/manifest.yaml
@@ -59,7 +59,6 @@ definitions:
   ## MESSAGES API ##
   messages_stream:
     $ref: "#/definitions/base_stream"
-    name: "messages"
     primary_key: id
     $parameters:
       name: "messages"
@@ -90,7 +89,6 @@ definitions:
   message_info_stream:
     $ref: "#/definitions/base_stream"
     type: DeclarativeStream
-    name: message_info
     primary_key: id
     $parameters:
       name: message_info
@@ -108,7 +106,6 @@ definitions:
     type: DeclarativeStream
     $parameters:
       name: message_history
-    name: message_history
     primary_key: message_id
     schema_loader:
       $ref: "#/definitions/schema_loader"
@@ -128,7 +125,6 @@ definitions:
     type: DeclarativeStream
     $parameters:
       name: message_output
-    name: message_output
     primary_key: message_id
     schema_loader:
       $ref: "#/definitions/schema_loader"

--- a/airbyte-integrations/connectors/source-delighted/source_delighted/manifest.yaml
+++ b/airbyte-integrations/connectors/source-delighted/source_delighted/manifest.yaml
@@ -77,6 +77,7 @@ definitions:
         page_token_option:
           inject_into: "path"
     $parameters:
+      name: "people"
       path: "people.json"
       cursor_field: "created_at"
   bounces:
@@ -85,6 +86,7 @@ definitions:
     primary_key: "person_id"
     $parameters:
       cursor_field: "bounced_at"
+      name: "bounces"
       path: "bounces.json"
   unsubscribes:
     $ref: "#/definitions/base_stream"
@@ -92,6 +94,7 @@ definitions:
     primary_key: "person_id"
     $parameters:
       cursor_field: "unsubscribed_at"
+      name: "unsubscribes"
       path: "unsubscribes.json"
   survey_responses:
     $ref: "#/definitions/base_stream"
@@ -108,6 +111,7 @@ definitions:
           inject_into: "request_parameter"
     $parameters:
       cursor_field: "updated_at"
+      name: "survey_responses"
       path: "survey_responses.json"
 
 streams:

--- a/airbyte-integrations/connectors/source-delighted/source_delighted/manifest.yaml
+++ b/airbyte-integrations/connectors/source-delighted/source_delighted/manifest.yaml
@@ -61,7 +61,6 @@ definitions:
       $ref: "#/definitions/retriever"
   people:
     $ref: "#/definitions/base_stream"
-    name: "people"
     retriever:
       $ref: "#/definitions/retriever"
       paginator:
@@ -82,7 +81,6 @@ definitions:
       cursor_field: "created_at"
   bounces:
     $ref: "#/definitions/base_stream"
-    name: "bounces"
     primary_key: "person_id"
     $parameters:
       cursor_field: "bounced_at"
@@ -90,7 +88,6 @@ definitions:
       path: "bounces.json"
   unsubscribes:
     $ref: "#/definitions/base_stream"
-    name: "unsubscribes"
     primary_key: "person_id"
     $parameters:
       cursor_field: "unsubscribed_at"
@@ -98,7 +95,6 @@ definitions:
       path: "unsubscribes.json"
   survey_responses:
     $ref: "#/definitions/base_stream"
-    name: "survey_responses"
     retriever:
       $ref: "#/definitions/retriever"
       stream_slicer:

--- a/airbyte-integrations/connectors/source-delighted/source_delighted/manifest.yaml
+++ b/airbyte-integrations/connectors/source-delighted/source_delighted/manifest.yaml
@@ -61,6 +61,7 @@ definitions:
       $ref: "#/definitions/retriever"
   people:
     $ref: "#/definitions/base_stream"
+    name: "people"
     retriever:
       $ref: "#/definitions/retriever"
       paginator:
@@ -76,25 +77,25 @@ definitions:
         page_token_option:
           inject_into: "path"
     $parameters:
-      name: "people"
       path: "people.json"
       cursor_field: "created_at"
   bounces:
     $ref: "#/definitions/base_stream"
+    name: "bounces"
     primary_key: "person_id"
     $parameters:
       cursor_field: "bounced_at"
-      name: "bounces"
       path: "bounces.json"
   unsubscribes:
     $ref: "#/definitions/base_stream"
+    name: "unsubscribes"
     primary_key: "person_id"
     $parameters:
       cursor_field: "unsubscribed_at"
-      name: "unsubscribes"
       path: "unsubscribes.json"
   survey_responses:
     $ref: "#/definitions/base_stream"
+    name: "survey_responses"
     retriever:
       $ref: "#/definitions/retriever"
       stream_slicer:
@@ -107,7 +108,6 @@ definitions:
           inject_into: "request_parameter"
     $parameters:
       cursor_field: "updated_at"
-      name: "survey_responses"
       path: "survey_responses.json"
 
 streams:

--- a/airbyte-integrations/connectors/source-delighted/source_delighted/manifest.yaml
+++ b/airbyte-integrations/connectors/source-delighted/source_delighted/manifest.yaml
@@ -8,7 +8,6 @@ definitions:
       field_path: []
   requester:
     type: HttpRequester
-    name: "{{ parameters['name'] }}"
     url_base: "https://api.delighted.com/v1/"
     http_method: "GET"
     authenticator:
@@ -38,7 +37,6 @@ definitions:
     type: DatetimeStreamSlicer
   retriever:
     type: SimpleRetriever
-    name: "{{ parameters['name'] }}"
     record_selector:
       $ref: "#/definitions/selector"
     paginator:

--- a/airbyte-integrations/connectors/source-gocardless/source_gocardless/manifest.yaml
+++ b/airbyte-integrations/connectors/source-gocardless/source_gocardless/manifest.yaml
@@ -12,7 +12,6 @@ definitions:
         - "{{ parameters['name'] }}"
   requester:
     type: HttpRequester
-    name: "{{ parameters['name'] }}"
     http_method: "GET"
     authenticator:
       type: BearerAuthenticator
@@ -25,8 +24,6 @@ definitions:
     type: SimpleRetriever
     $parameters:
       url_base: "{{ 'https://api.gocardless.com' if config['gocardless_environment'] == 'live' else 'https://api-sandbox.gocardless.com' }}"
-    name: "{{ parameters['name'] }}"
-    primary_key: "{{ parameters['primary_key'] }}"
     record_selector:
       $ref: "#/definitions/selector"
     paginator:

--- a/airbyte-integrations/connectors/source-gocardless/source_gocardless/manifest.yaml
+++ b/airbyte-integrations/connectors/source-gocardless/source_gocardless/manifest.yaml
@@ -45,6 +45,7 @@ definitions:
 streams:
   - type: DeclarativeStream
     $parameters:
+      name: "payments"
     name: "payments"
     primary_key: "id"
     schema_loader:
@@ -55,6 +56,8 @@ streams:
         $ref: "#/definitions/requester"
         path: "/payments"
   - type: DeclarativeStream
+    $parameters:
+      name: "refunds"
     name: "refunds"
     primary_key: "id"
     schema_loader:
@@ -65,6 +68,8 @@ streams:
         $ref: "#/definitions/requester"
         path: "/refunds"
   - type: DeclarativeStream
+    $parameters:
+      name: "mandates"
     name: "mandates"
     primary_key: "id"
     schema_loader:
@@ -75,6 +80,8 @@ streams:
         $ref: "#/definitions/requester"
         path: "/mandates"
   - type: DeclarativeStream
+    $parameters:
+      name: "payouts"
     name: "payouts"
     primary_key: "id"
     schema_loader:

--- a/airbyte-integrations/connectors/source-gocardless/source_gocardless/manifest.yaml
+++ b/airbyte-integrations/connectors/source-gocardless/source_gocardless/manifest.yaml
@@ -45,7 +45,7 @@ definitions:
 streams:
   - type: DeclarativeStream
     $parameters:
-      name: "payments"
+    name: "payments"
     primary_key: "id"
     schema_loader:
       $ref: "#/definitions/schema_loader"
@@ -55,8 +55,7 @@ streams:
         $ref: "#/definitions/requester"
         path: "/payments"
   - type: DeclarativeStream
-    $parameters:
-      name: "refunds"
+    name: "refunds"
     primary_key: "id"
     schema_loader:
       $ref: "#/definitions/schema_loader"
@@ -66,8 +65,7 @@ streams:
         $ref: "#/definitions/requester"
         path: "/refunds"
   - type: DeclarativeStream
-    $parameters:
-      name: "mandates"
+    name: "mandates"
     primary_key: "id"
     schema_loader:
       $ref: "#/definitions/schema_loader"
@@ -77,8 +75,7 @@ streams:
         $ref: "#/definitions/requester"
         path: "/mandates"
   - type: DeclarativeStream
-    $parameters:
-      name: "payouts"
+    name: "payouts"
     primary_key: "id"
     schema_loader:
       $ref: "#/definitions/schema_loader"

--- a/airbyte-integrations/connectors/source-gocardless/source_gocardless/manifest.yaml
+++ b/airbyte-integrations/connectors/source-gocardless/source_gocardless/manifest.yaml
@@ -46,7 +46,6 @@ streams:
   - type: DeclarativeStream
     $parameters:
       name: "payments"
-    name: "payments"
     primary_key: "id"
     schema_loader:
       $ref: "#/definitions/schema_loader"
@@ -58,7 +57,6 @@ streams:
   - type: DeclarativeStream
     $parameters:
       name: "refunds"
-    name: "refunds"
     primary_key: "id"
     schema_loader:
       $ref: "#/definitions/schema_loader"
@@ -70,7 +68,6 @@ streams:
   - type: DeclarativeStream
     $parameters:
       name: "mandates"
-    name: "mandates"
     primary_key: "id"
     schema_loader:
       $ref: "#/definitions/schema_loader"
@@ -82,7 +79,6 @@ streams:
   - type: DeclarativeStream
     $parameters:
       name: "payouts"
-    name: "payouts"
     primary_key: "id"
     schema_loader:
       $ref: "#/definitions/schema_loader"

--- a/airbyte-integrations/connectors/source-greenhouse/source_greenhouse/manifest.yaml
+++ b/airbyte-integrations/connectors/source-greenhouse/source_greenhouse/manifest.yaml
@@ -43,6 +43,8 @@ definitions:
         inject_into: "path"
   base_stream:
     type: DeclarativeStream
+    $parameters:
+      name: "applications"
     name: "applications"
     primary_key: "id"
     schema_loader:
@@ -63,6 +65,7 @@ definitions:
   applications_stream:
     $ref: "#/definitions/base_incremental_stream"
     $parameters:
+      name: "applications"
       path: "applications"
     name: "applications"
     retriever:
@@ -75,30 +78,37 @@ definitions:
   candidates_stream:
     $ref: "#/definitions/base_incremental_stream"
     $parameters:
+      name: "candidates"
       path: "candidates"
     name: "candidates"
   close_reasons_stream:
     $ref: "#/definitions/base_stream"
     $parameters:
+      name: "close_reasons"
       path: "close_reasons"
     name: "close_reasons"
     primary_key: "id"
   degrees_stream:
     $ref: "#/definitions/base_stream"
     $parameters:
+      name: "degrees"
       path: "degrees"
     name: "degrees"
   departments_stream:
     $ref: "#/definitions/base_stream"
     $parameters:
+      name: "departments"
       path: "departments"
     name: "departments"
   jobs_stream:
     $ref: "#/definitions/base_incremental_stream"
     $parameters:
+      name: "jobs"
       path: "jobs"
     name: "jobs"
   jobs_openings_stream:
+    $parameters:
+      name: "jobs_openings"
     name: "jobs_openings"
     primary_key: "id"
     schema_loader:
@@ -116,6 +126,8 @@ definitions:
             stream_slice_field: "parent_id"
   applications_demographics_answers_stream:
     $ref: "#/definitions/base_stream"
+    $parameters:
+      name: "applications_demographics_answers"
     name: "applications_demographics_answers"
     retriever:
       $ref: "#/definitions/retriever"
@@ -131,6 +143,8 @@ definitions:
         parent_key: "id"
   applications_interviews_stream:
     $ref: "#/definitions/base_stream"
+    $parameters:
+      name: "applications_interviews"
     name: "applications_interviews"
     retriever:
       $ref: "#/definitions/retriever"
@@ -147,15 +161,19 @@ definitions:
   custom_fields_stream:
     $ref: "#/definitions/base_stream"
     $parameters:
+      name: "custom_fields"
       path: "custom_fields"
     name: "custom_fields"
   questions_stream:
     $ref: "#/definitions/base_stream"
     $parameters:
+      name: "demographics_questions"
       path: "demographics/questions"
     name: "demographics_questions"
   demographics_answers_answer_options_stream:
     $parameters:
+      name: "demographics_answers_answer_options"
+      primary_key: "id"
       schema_loader:
         $ref: "#/definitions/schema_loader"
       retriever:
@@ -174,10 +192,13 @@ definitions:
   demographics_question_sets_stream:
     $ref: "#/definitions/base_stream"
     $parameters:
+      name: "demographics_question_sets"
       path: "demographics/question_sets"
     name: "demographics_question_sets"
   demographics_question_sets_questions_stream:
     $parameters:
+      name: "demographics_question_sets_questions"
+      primary_key: "id"
       schema_loader:
         $ref: "#/definitions/schema_loader"
       retriever:
@@ -196,21 +217,25 @@ definitions:
   interviews_stream:
     $ref: "#/definitions/base_incremental_stream"
     $parameters:
+      name: "interviews"
       path: "scheduled_interviews"
     name: "interviews"
   job_posts_stream:
     $ref: "#/definitions/base_incremental_stream"
     $parameters:
+      name: "job_posts"
       path: "job_posts"
     name: "job_posts"
   job_stages_stream:
     $ref: "#/definitions/base_incremental_stream"
     $parameters:
+      name: "job_stages"
       path: "job_stages"
     name: "job_stages"
   jobs_stages_stream:
     $ref: "#/definitions/base_stream"
     $parameters:
+      name: "jobs_stages"
       path: "jobs/{{ stream_slice.parent_id }}/stages"
     name: "jobs_stages"
     retriever:
@@ -228,36 +253,43 @@ definitions:
   offers_stream:
     $ref: "#/definitions/base_incremental_stream"
     $parameters:
+      name: "offers"
       path: "offers"
     name: "offers"
   rejection_reasons_stream:
     $ref: "#/definitions/base_stream"
     $parameters:
+      name: "rejection_reasons"
       path: "rejection_reasons"
     name: "rejection_reasons"
   scorecards_stream:
     $ref: "#/definitions/base_incremental_stream"
     $parameters:
+      name: "scorecards"
       path: "scorecards"
     name: "scorecards"
   sources_stream:
     $ref: "#/definitions/base_stream"
     $parameters:
+      name: "sources"
       path: "sources"
     name: "sources"
   users_stream:
     $ref: "#/definitions/base_incremental_stream"
     $parameters:
+      name: "users"
       path: "users"
     name: "users"
   demographics_answers_stream:
     $ref: "#/definitions/base_incremental_stream"
     $parameters:
+      name: "demographics_answers"
       path: "demographics/answers"
     name: "demographics_answers"
   demographics_answer_options_stream:
     $ref: "#/definitions/base_stream"
     $parameters:
+      name: "demographics_answer_options"
       path: "demographics/answer_options"
     name: "demographics_answer_options"
 streams:

--- a/airbyte-integrations/connectors/source-greenhouse/source_greenhouse/manifest.yaml
+++ b/airbyte-integrations/connectors/source-greenhouse/source_greenhouse/manifest.yaml
@@ -11,7 +11,6 @@ definitions:
       field_path: []
   requester:
     type: HttpRequester
-    name: "{{ parameters['name'] }}"
     url_base: "https://harvest.greenhouse.io/v1/"
     http_method: "GET"
     error_handler:
@@ -28,8 +27,6 @@ definitions:
       username: "{{ config['api_key'] }}"
   retriever:
     type: SimpleRetriever
-    name: "{{ parameters['name'] }}"
-    primary_key: "{{ parameters['primary_key'] }}"
     record_selector:
       $ref: "#/definitions/selector"
     paginator:

--- a/airbyte-integrations/connectors/source-greenhouse/source_greenhouse/manifest.yaml
+++ b/airbyte-integrations/connectors/source-greenhouse/source_greenhouse/manifest.yaml
@@ -45,7 +45,6 @@ definitions:
     type: DeclarativeStream
     $parameters:
       name: "applications"
-    name: "applications"
     primary_key: "id"
     schema_loader:
       $ref: "#/definitions/schema_loader"
@@ -67,7 +66,6 @@ definitions:
     $parameters:
       name: "applications"
       path: "applications"
-    name: "applications"
     retriever:
       $ref: "#/definitions/retriever"
       requester: "#/definitions/requester"
@@ -80,36 +78,30 @@ definitions:
     $parameters:
       name: "candidates"
       path: "candidates"
-    name: "candidates"
   close_reasons_stream:
     $ref: "#/definitions/base_stream"
     $parameters:
       name: "close_reasons"
       path: "close_reasons"
-    name: "close_reasons"
     primary_key: "id"
   degrees_stream:
     $ref: "#/definitions/base_stream"
     $parameters:
       name: "degrees"
       path: "degrees"
-    name: "degrees"
   departments_stream:
     $ref: "#/definitions/base_stream"
     $parameters:
       name: "departments"
       path: "departments"
-    name: "departments"
   jobs_stream:
     $ref: "#/definitions/base_incremental_stream"
     $parameters:
       name: "jobs"
       path: "jobs"
-    name: "jobs"
   jobs_openings_stream:
     $parameters:
       name: "jobs_openings"
-    name: "jobs_openings"
     primary_key: "id"
     schema_loader:
       $ref: "#/definitions/schema_loader"
@@ -128,7 +120,6 @@ definitions:
     $ref: "#/definitions/base_stream"
     $parameters:
       name: "applications_demographics_answers"
-    name: "applications_demographics_answers"
     retriever:
       $ref: "#/definitions/retriever"
       requester:
@@ -145,7 +136,6 @@ definitions:
     $ref: "#/definitions/base_stream"
     $parameters:
       name: "applications_interviews"
-    name: "applications_interviews"
     retriever:
       $ref: "#/definitions/retriever"
       requester:
@@ -163,13 +153,11 @@ definitions:
     $parameters:
       name: "custom_fields"
       path: "custom_fields"
-    name: "custom_fields"
   questions_stream:
     $ref: "#/definitions/base_stream"
     $parameters:
       name: "demographics_questions"
       path: "demographics/questions"
-    name: "demographics_questions"
   demographics_answers_answer_options_stream:
     $parameters:
       name: "demographics_answers_answer_options"
@@ -187,14 +175,11 @@ definitions:
             - stream: "#/definitions/questions_stream"
               parent_key: "id"
               stream_slice_field: "parent_id"
-    name: "demographics_answers_answer_options"
-    primary_key: "id"
   demographics_question_sets_stream:
     $ref: "#/definitions/base_stream"
     $parameters:
       name: "demographics_question_sets"
       path: "demographics/question_sets"
-    name: "demographics_question_sets"
   demographics_question_sets_questions_stream:
     $parameters:
       name: "demographics_question_sets_questions"
@@ -212,32 +197,26 @@ definitions:
             - stream: "#/definitions/demographics_question_sets_stream"
               parent_key: "id"
               stream_slice_field: "parent_id"
-    name: "demographics_question_sets_questions"
-    primary_key: "id"
   interviews_stream:
     $ref: "#/definitions/base_incremental_stream"
     $parameters:
       name: "interviews"
       path: "scheduled_interviews"
-    name: "interviews"
   job_posts_stream:
     $ref: "#/definitions/base_incremental_stream"
     $parameters:
       name: "job_posts"
       path: "job_posts"
-    name: "job_posts"
   job_stages_stream:
     $ref: "#/definitions/base_incremental_stream"
     $parameters:
       name: "job_stages"
       path: "job_stages"
-    name: "job_stages"
   jobs_stages_stream:
     $ref: "#/definitions/base_stream"
     $parameters:
       name: "jobs_stages"
       path: "jobs/{{ stream_slice.parent_id }}/stages"
-    name: "jobs_stages"
     retriever:
       $ref: "#/definitions/retriever"
       requester:
@@ -255,43 +234,36 @@ definitions:
     $parameters:
       name: "offers"
       path: "offers"
-    name: "offers"
   rejection_reasons_stream:
     $ref: "#/definitions/base_stream"
     $parameters:
       name: "rejection_reasons"
       path: "rejection_reasons"
-    name: "rejection_reasons"
   scorecards_stream:
     $ref: "#/definitions/base_incremental_stream"
     $parameters:
       name: "scorecards"
       path: "scorecards"
-    name: "scorecards"
   sources_stream:
     $ref: "#/definitions/base_stream"
     $parameters:
       name: "sources"
       path: "sources"
-    name: "sources"
   users_stream:
     $ref: "#/definitions/base_incremental_stream"
     $parameters:
       name: "users"
       path: "users"
-    name: "users"
   demographics_answers_stream:
     $ref: "#/definitions/base_incremental_stream"
     $parameters:
       name: "demographics_answers"
       path: "demographics/answers"
-    name: "demographics_answers"
   demographics_answer_options_stream:
     $ref: "#/definitions/base_stream"
     $parameters:
       name: "demographics_answer_options"
       path: "demographics/answer_options"
-    name: "demographics_answer_options"
 streams:
   - "#/definitions/applications_stream"
   - "#/definitions/applications_demographics_answers_stream"

--- a/airbyte-integrations/connectors/source-greenhouse/source_greenhouse/manifest.yaml
+++ b/airbyte-integrations/connectors/source-greenhouse/source_greenhouse/manifest.yaml
@@ -43,8 +43,7 @@ definitions:
         inject_into: "path"
   base_stream:
     type: DeclarativeStream
-    $parameters:
-      name: "applications"
+    name: "applications"
     primary_key: "id"
     schema_loader:
       $ref: "#/definitions/schema_loader"
@@ -64,8 +63,8 @@ definitions:
   applications_stream:
     $ref: "#/definitions/base_incremental_stream"
     $parameters:
-      name: "applications"
       path: "applications"
+    name: "applications"
     retriever:
       $ref: "#/definitions/retriever"
       requester: "#/definitions/requester"
@@ -76,32 +75,31 @@ definitions:
   candidates_stream:
     $ref: "#/definitions/base_incremental_stream"
     $parameters:
-      name: "candidates"
       path: "candidates"
+    name: "candidates"
   close_reasons_stream:
     $ref: "#/definitions/base_stream"
     $parameters:
-      name: "close_reasons"
       path: "close_reasons"
+    name: "close_reasons"
     primary_key: "id"
   degrees_stream:
     $ref: "#/definitions/base_stream"
     $parameters:
-      name: "degrees"
       path: "degrees"
+    name: "degrees"
   departments_stream:
     $ref: "#/definitions/base_stream"
     $parameters:
-      name: "departments"
       path: "departments"
+    name: "departments"
   jobs_stream:
     $ref: "#/definitions/base_incremental_stream"
     $parameters:
-      name: "jobs"
       path: "jobs"
+    name: "jobs"
   jobs_openings_stream:
-    $parameters:
-      name: "jobs_openings"
+    name: "jobs_openings"
     primary_key: "id"
     schema_loader:
       $ref: "#/definitions/schema_loader"
@@ -118,8 +116,7 @@ definitions:
             stream_slice_field: "parent_id"
   applications_demographics_answers_stream:
     $ref: "#/definitions/base_stream"
-    $parameters:
-      name: "applications_demographics_answers"
+    name: "applications_demographics_answers"
     retriever:
       $ref: "#/definitions/retriever"
       requester:
@@ -134,8 +131,7 @@ definitions:
         parent_key: "id"
   applications_interviews_stream:
     $ref: "#/definitions/base_stream"
-    $parameters:
-      name: "applications_interviews"
+    name: "applications_interviews"
     retriever:
       $ref: "#/definitions/retriever"
       requester:
@@ -151,17 +147,15 @@ definitions:
   custom_fields_stream:
     $ref: "#/definitions/base_stream"
     $parameters:
-      name: "custom_fields"
       path: "custom_fields"
+    name: "custom_fields"
   questions_stream:
     $ref: "#/definitions/base_stream"
     $parameters:
-      name: "demographics_questions"
       path: "demographics/questions"
+    name: "demographics_questions"
   demographics_answers_answer_options_stream:
     $parameters:
-      name: "demographics_answers_answer_options"
-      primary_key: "id"
       schema_loader:
         $ref: "#/definitions/schema_loader"
       retriever:
@@ -175,15 +169,15 @@ definitions:
             - stream: "#/definitions/questions_stream"
               parent_key: "id"
               stream_slice_field: "parent_id"
+    name: "demographics_answers_answer_options"
+    primary_key: "id"
   demographics_question_sets_stream:
     $ref: "#/definitions/base_stream"
     $parameters:
-      name: "demographics_question_sets"
       path: "demographics/question_sets"
+    name: "demographics_question_sets"
   demographics_question_sets_questions_stream:
     $parameters:
-      name: "demographics_question_sets_questions"
-      primary_key: "id"
       schema_loader:
         $ref: "#/definitions/schema_loader"
       retriever:
@@ -197,26 +191,28 @@ definitions:
             - stream: "#/definitions/demographics_question_sets_stream"
               parent_key: "id"
               stream_slice_field: "parent_id"
+    name: "demographics_question_sets_questions"
+    primary_key: "id"
   interviews_stream:
     $ref: "#/definitions/base_incremental_stream"
     $parameters:
-      name: "interviews"
       path: "scheduled_interviews"
+    name: "interviews"
   job_posts_stream:
     $ref: "#/definitions/base_incremental_stream"
     $parameters:
-      name: "job_posts"
       path: "job_posts"
+    name: "job_posts"
   job_stages_stream:
     $ref: "#/definitions/base_incremental_stream"
     $parameters:
-      name: "job_stages"
       path: "job_stages"
+    name: "job_stages"
   jobs_stages_stream:
     $ref: "#/definitions/base_stream"
     $parameters:
-      name: "jobs_stages"
       path: "jobs/{{ stream_slice.parent_id }}/stages"
+    name: "jobs_stages"
     retriever:
       $ref: "#/definitions/retriever"
       requester:
@@ -232,38 +228,38 @@ definitions:
   offers_stream:
     $ref: "#/definitions/base_incremental_stream"
     $parameters:
-      name: "offers"
       path: "offers"
+    name: "offers"
   rejection_reasons_stream:
     $ref: "#/definitions/base_stream"
     $parameters:
-      name: "rejection_reasons"
       path: "rejection_reasons"
+    name: "rejection_reasons"
   scorecards_stream:
     $ref: "#/definitions/base_incremental_stream"
     $parameters:
-      name: "scorecards"
       path: "scorecards"
+    name: "scorecards"
   sources_stream:
     $ref: "#/definitions/base_stream"
     $parameters:
-      name: "sources"
       path: "sources"
+    name: "sources"
   users_stream:
     $ref: "#/definitions/base_incremental_stream"
     $parameters:
-      name: "users"
       path: "users"
+    name: "users"
   demographics_answers_stream:
     $ref: "#/definitions/base_incremental_stream"
     $parameters:
-      name: "demographics_answers"
       path: "demographics/answers"
+    name: "demographics_answers"
   demographics_answer_options_stream:
     $ref: "#/definitions/base_stream"
     $parameters:
-      name: "demographics_answer_options"
       path: "demographics/answer_options"
+    name: "demographics_answer_options"
 streams:
   - "#/definitions/applications_stream"
   - "#/definitions/applications_demographics_answers_stream"

--- a/airbyte-integrations/connectors/source-posthog/source_posthog/manifest.yaml
+++ b/airbyte-integrations/connectors/source-posthog/source_posthog/manifest.yaml
@@ -12,7 +12,6 @@ definitions:
 
   requester:
     type: HttpRequester
-    name: "{{ parameters['name'] }}"
     url_base: "{{ config['base_url'] or 'https://app.posthog.com'}}/api/"
     http_method: "GET"
     authenticator:
@@ -21,8 +20,6 @@ definitions:
 
   retriever:
     type: SimpleRetriever
-    name: "{{ parameters['name'] }}"
-    primary_key: "{{ parameters['primary_key'] }}"
     record_selector:
       $ref: "#/definitions/selector"
     paginator:

--- a/airbyte-integrations/connectors/source-posthog/source_posthog/manifest.yaml
+++ b/airbyte-integrations/connectors/source-posthog/source_posthog/manifest.yaml
@@ -46,6 +46,7 @@ definitions:
   projects_stream:
     $ref: "#/definitions/base_stream"
     $parameters:
+      name: "projects"
       path: "projects"
     name: "projects"
 
@@ -66,35 +67,41 @@ definitions:
   cohorts_stream:
     $ref: "#/definitions/base_slicing_stream"
     $parameters:
+      name: "cohorts"
       path: "cohorts"
     name: "cohorts"
 
   feature_flags_stream:
     $ref: "#/definitions/base_slicing_stream"
     $parameters:
+      name: "feature_flags"
       path: "feature_flags"
     name: "feature_flags"
 
   persons_stream:
     $ref: "#/definitions/base_slicing_stream"
     $parameters:
+      name: "persons"
       path: "persons"
     name: "persons"
 
   annotations_stream:
     $ref: "#/definitions/base_slicing_stream"
     $parameters:
+      name: "annotations"
       path: "annotations"
     name: "annotations"
 
   insights_stream:
     $ref: "#/definitions/base_slicing_stream"
     $parameters:
+      name: "insights"
       path: "insights"
     name: "insights"
 
   events_stream:
     $parameters:
+      name: "events"
       path: "events"
     name: "events"
     primary_key: "id"
@@ -102,8 +109,8 @@ definitions:
       $ref: "#/definitions/schema_loader"
     retriever:
       class_name: source_posthog.components.EventsSimpleRetriever
-      name: "#/definitions/events_stream/name"
-      primary_key: "#/definitions/events_stream/primary_key"
+      name: "{{ parameters['name'] }}"
+      primary_key: "{{ parameters['primary_key'] }}"
       record_selector:
         $ref: "#/definitions/selector"
       requester:

--- a/airbyte-integrations/connectors/source-posthog/source_posthog/manifest.yaml
+++ b/airbyte-integrations/connectors/source-posthog/source_posthog/manifest.yaml
@@ -46,8 +46,8 @@ definitions:
   projects_stream:
     $ref: "#/definitions/base_stream"
     $parameters:
-      name: "projects"
       path: "projects"
+    name: "projects"
 
   base_slicing_stream:
     $ref: "#/definitions/base_stream"
@@ -66,44 +66,44 @@ definitions:
   cohorts_stream:
     $ref: "#/definitions/base_slicing_stream"
     $parameters:
-      name: "cohorts"
       path: "cohorts"
+    name: "cohorts"
 
   feature_flags_stream:
     $ref: "#/definitions/base_slicing_stream"
     $parameters:
-      name: "feature_flags"
       path: "feature_flags"
+    name: "feature_flags"
 
   persons_stream:
     $ref: "#/definitions/base_slicing_stream"
     $parameters:
-      name: "persons"
       path: "persons"
+    name: "persons"
 
   annotations_stream:
     $ref: "#/definitions/base_slicing_stream"
     $parameters:
-      name: "annotations"
       path: "annotations"
+    name: "annotations"
 
   insights_stream:
     $ref: "#/definitions/base_slicing_stream"
     $parameters:
-      name: "insights"
       path: "insights"
+    name: "insights"
 
   events_stream:
     $parameters:
-      name: "events"
       path: "events"
+    name: "events"
     primary_key: "id"
     schema_loader:
       $ref: "#/definitions/schema_loader"
     retriever:
       class_name: source_posthog.components.EventsSimpleRetriever
-      name: "{{ parameters['name'] }}"
-      primary_key: "{{ parameters['primary_key'] }}"
+      name: "#/definitions/events_stream/name"
+      primary_key: "#/definitions/events_stream/primary_key"
       record_selector:
         $ref: "#/definitions/selector"
       requester:

--- a/airbyte-integrations/connectors/source-posthog/source_posthog/manifest.yaml
+++ b/airbyte-integrations/connectors/source-posthog/source_posthog/manifest.yaml
@@ -48,7 +48,6 @@ definitions:
     $parameters:
       name: "projects"
       path: "projects"
-    name: "projects"
 
   base_slicing_stream:
     $ref: "#/definitions/base_stream"
@@ -69,41 +68,35 @@ definitions:
     $parameters:
       name: "cohorts"
       path: "cohorts"
-    name: "cohorts"
 
   feature_flags_stream:
     $ref: "#/definitions/base_slicing_stream"
     $parameters:
       name: "feature_flags"
       path: "feature_flags"
-    name: "feature_flags"
 
   persons_stream:
     $ref: "#/definitions/base_slicing_stream"
     $parameters:
       name: "persons"
       path: "persons"
-    name: "persons"
 
   annotations_stream:
     $ref: "#/definitions/base_slicing_stream"
     $parameters:
       name: "annotations"
       path: "annotations"
-    name: "annotations"
 
   insights_stream:
     $ref: "#/definitions/base_slicing_stream"
     $parameters:
       name: "insights"
       path: "insights"
-    name: "insights"
 
   events_stream:
     $parameters:
       name: "events"
       path: "events"
-    name: "events"
     primary_key: "id"
     schema_loader:
       $ref: "#/definitions/schema_loader"

--- a/airbyte-integrations/connectors/source-sendgrid/source_sendgrid/manifest.yaml
+++ b/airbyte-integrations/connectors/source-sendgrid/source_sendgrid/manifest.yaml
@@ -9,7 +9,6 @@ definitions:
 
   requester:
     type: HttpRequester
-    name: "{{ parameters['name'] }}"
     url_base: "https://api.sendgrid.com"
     http_method: "GET"
     authenticator:
@@ -41,8 +40,6 @@ definitions:
       type: "OffsetIncrement"
   retriever:
     type: SimpleRetriever
-    name: "{{ parameters['name'] }}"
-    primary_key: "{{ parameters['primary_key'] }}"
   stream_slicer:
     type: "DatetimeStreamSlicer"
     start_datetime:

--- a/airbyte-integrations/connectors/source-sendgrid/source_sendgrid/manifest.yaml
+++ b/airbyte-integrations/connectors/source-sendgrid/source_sendgrid/manifest.yaml
@@ -85,6 +85,8 @@ definitions:
 streams:
   - $ref: "#/definitions/base_stream"
     $parameters:
+      name: "lists"
+      primary_key: "id"
       path: "/v3/marketing/lists"
       field_path: ["result"]
     name: "lists"
@@ -95,6 +97,8 @@ streams:
         $ref: "#/definitions/cursor_paginator"
   - $ref: "#/definitions/base_stream"
     $parameters:
+      name: "campaigns"
+      primary_key: "id"
       path: "/v3/marketing/campaigns"
       field_path: ["result"]
     name: "campaigns"
@@ -105,12 +109,16 @@ streams:
         $ref: "#/definitions/cursor_paginator"
   - $ref: "#/definitions/base_stream"
     $parameters:
+      name: "contacts"
+      primary_key: "id"
       path: "/v3/marketing/contacts"
       field_path: ["result"]
     name: "contacts"
     primary_key: "id"
   - $ref: "#/definitions/base_stream"
     $parameters:
+      name: "stats_automations"
+      primary_key: "id"
       path: "/v3/marketing/stats/automations"
       field_path: ["results"]
     name: "stats_automations"
@@ -121,12 +129,16 @@ streams:
         $ref: "#/definitions/cursor_paginator"
   - $ref: "#/definitions/base_stream"
     $parameters:
+      name: "segments"
+      primary_key: "id"
       path: "/v3/marketing/segments"
       field_path: ["results"]
     name: "segments"
     primary_key: "id"
   - $ref: "#/definitions/base_stream"
     $parameters:
+      name: "single_sends"
+      primary_key: "id"
       path: "/v3/marketing/stats/singlesends"
       field_path: ["results"]
     name: "single_sends"
@@ -137,6 +149,8 @@ streams:
         $ref: "#/definitions/cursor_paginator"
   - $ref: "#/definitions/base_stream"
     $parameters:
+      name: "templates"
+      primary_key: "id"
       path: "/v3/templates"
       field_path: ["result"]
     name: "templates"
@@ -151,6 +165,8 @@ streams:
         $ref: "#/definitions/cursor_paginator"
   - $ref: "#/definitions/base_stream"
     $parameters:
+      name: "bounces"
+      primary_key: "email"
       cursor_field: "created"
       path: "/v3/suppression/bounces"
       field_path: []
@@ -164,6 +180,8 @@ streams:
         $ref: "#/definitions/stream_slicer"
   - $ref: "#/definitions/base_stream"
     $parameters:
+      name: "global_suppressions"
+      primary_key: "email"
       cursor_field: "created"
       path: "/v3/suppression/unsubscribes"
       field_path: []
@@ -177,6 +195,8 @@ streams:
         $ref: "#/definitions/stream_slicer"
   - $ref: "#/definitions/base_stream"
     $parameters:
+      name: "blocks"
+      primary_key: "email"
       cursor_field: "created"
       path: "/v3/suppression/blocks"
       field_path: []
@@ -190,12 +210,16 @@ streams:
         $ref: "#/definitions/stream_slicer"
   - $ref: "#/definitions/base_stream"
     $parameters:
+      name: "suppression_groups"
+      primary_key: "id"
       path: "/v3/asm/groups"
       field_path: []
     name: "suppression_groups"
     primary_key: "id"
   - $ref: "#/definitions/base_stream"
     $parameters:
+      name: "suppression_group_members"
+      primary_key: "group_id"
       path: "/v3/asm/suppressions"
       field_path: []
     name: "suppression_group_members"
@@ -206,6 +230,8 @@ streams:
         $ref: "#/definitions/offset_paginator"
   - $ref: "#/definitions/base_stream"
     $parameters:
+      name: "invalid_emails"
+      primary_key: "email"
       cursor_field: "created"
       path: "/v3/suppression/invalid_emails"
       field_path: []
@@ -219,6 +245,8 @@ streams:
         $ref: "#/definitions/stream_slicer"
   - $ref: "#/definitions/base_stream"
     $parameters:
+      name: "spam_reports"
+      primary_key: "email"
       cursor_field: "created"
       path: "/v3/suppression/spam_reports"
       field_path: []
@@ -232,6 +260,8 @@ streams:
         $ref: "#/definitions/stream_slicer"
   - $ref: "#/definitions/base_stream"
     $parameters:
+      name: "messages"
+      primary_key: "msg_id"
       cursor_field: "last_event_time"
       path: "/v3/messages"
       field_path: []

--- a/airbyte-integrations/connectors/source-sendgrid/source_sendgrid/manifest.yaml
+++ b/airbyte-integrations/connectors/source-sendgrid/source_sendgrid/manifest.yaml
@@ -85,62 +85,62 @@ definitions:
 streams:
   - $ref: "#/definitions/base_stream"
     $parameters:
-      name: "lists"
-      primary_key: "id"
       path: "/v3/marketing/lists"
       field_path: ["result"]
+    name: "lists"
+    primary_key: "id"
     retriever:
       $ref: "#/definitions/base_stream/retriever"
       paginator:
         $ref: "#/definitions/cursor_paginator"
   - $ref: "#/definitions/base_stream"
     $parameters:
-      name: "campaigns"
-      primary_key: "id"
       path: "/v3/marketing/campaigns"
       field_path: ["result"]
+    name: "campaigns"
+    primary_key: "id"
     retriever:
       $ref: "#/definitions/base_stream/retriever"
       paginator:
         $ref: "#/definitions/cursor_paginator"
   - $ref: "#/definitions/base_stream"
     $parameters:
-      name: "contacts"
-      primary_key: "id"
       path: "/v3/marketing/contacts"
       field_path: ["result"]
+    name: "contacts"
+    primary_key: "id"
   - $ref: "#/definitions/base_stream"
     $parameters:
-      name: "stats_automations"
-      primary_key: "id"
       path: "/v3/marketing/stats/automations"
       field_path: ["results"]
+    name: "stats_automations"
+    primary_key: "id"
     retriever:
       $ref: "#/definitions/base_stream/retriever"
       paginator:
         $ref: "#/definitions/cursor_paginator"
   - $ref: "#/definitions/base_stream"
     $parameters:
-      name: "segments"
-      primary_key: "id"
       path: "/v3/marketing/segments"
       field_path: ["results"]
+    name: "segments"
+    primary_key: "id"
   - $ref: "#/definitions/base_stream"
     $parameters:
-      name: "single_sends"
-      primary_key: "id"
       path: "/v3/marketing/stats/singlesends"
       field_path: ["results"]
+    name: "single_sends"
+    primary_key: "id"
     retriever:
       $ref: "#/definitions/base_stream/retriever"
       paginator:
         $ref: "#/definitions/cursor_paginator"
   - $ref: "#/definitions/base_stream"
     $parameters:
-      name: "templates"
-      primary_key: "id"
       path: "/v3/templates"
       field_path: ["result"]
+    name: "templates"
+    primary_key: "id"
     retriever:
       $ref: "#/definitions/base_stream/retriever"
       requester:
@@ -151,11 +151,11 @@ streams:
         $ref: "#/definitions/cursor_paginator"
   - $ref: "#/definitions/base_stream"
     $parameters:
-      name: "bounces"
-      primary_key: "email"
       cursor_field: "created"
       path: "/v3/suppression/bounces"
       field_path: []
+    name: "bounces"
+    primary_key: "email"
     retriever:
       $ref: "#/definitions/base_stream/retriever"
       paginator:
@@ -164,11 +164,11 @@ streams:
         $ref: "#/definitions/stream_slicer"
   - $ref: "#/definitions/base_stream"
     $parameters:
-      name: "global_suppressions"
-      primary_key: "email"
       cursor_field: "created"
       path: "/v3/suppression/unsubscribes"
       field_path: []
+    name: "global_suppressions"
+    primary_key: "email"
     retriever:
       $ref: "#/definitions/base_stream/retriever"
       paginator:
@@ -177,11 +177,11 @@ streams:
         $ref: "#/definitions/stream_slicer"
   - $ref: "#/definitions/base_stream"
     $parameters:
-      name: "blocks"
-      primary_key: "email"
       cursor_field: "created"
       path: "/v3/suppression/blocks"
       field_path: []
+    name: "blocks"
+    primary_key: "email"
     retriever:
       $ref: "#/definitions/base_stream/retriever"
       paginator:
@@ -190,27 +190,27 @@ streams:
         $ref: "#/definitions/stream_slicer"
   - $ref: "#/definitions/base_stream"
     $parameters:
-      name: "suppression_groups"
-      primary_key: "id"
       path: "/v3/asm/groups"
       field_path: []
+    name: "suppression_groups"
+    primary_key: "id"
   - $ref: "#/definitions/base_stream"
     $parameters:
-      name: "suppression_group_members"
-      primary_key: "group_id"
       path: "/v3/asm/suppressions"
       field_path: []
+    name: "suppression_group_members"
+    primary_key: "group_id"
     retriever:
       $ref: "#/definitions/base_stream/retriever"
       paginator:
         $ref: "#/definitions/offset_paginator"
   - $ref: "#/definitions/base_stream"
     $parameters:
-      name: "invalid_emails"
-      primary_key: "email"
       cursor_field: "created"
       path: "/v3/suppression/invalid_emails"
       field_path: []
+    name: "invalid_emails"
+    primary_key: "email"
     retriever:
       $ref: "#/definitions/base_stream/retriever"
       paginator:
@@ -219,11 +219,11 @@ streams:
         $ref: "#/definitions/stream_slicer"
   - $ref: "#/definitions/base_stream"
     $parameters:
-      name: "spam_reports"
-      primary_key: "email"
       cursor_field: "created"
       path: "/v3/suppression/spam_reports"
       field_path: []
+    name: "spam_reports"
+    primary_key: "email"
     retriever:
       $ref: "#/definitions/base_stream/retriever"
       paginator:
@@ -232,11 +232,11 @@ streams:
         $ref: "#/definitions/stream_slicer"
   - $ref: "#/definitions/base_stream"
     $parameters:
-      name: "messages"
-      primary_key: "msg_id"
       cursor_field: "last_event_time"
       path: "/v3/messages"
       field_path: []
+    name: "messages"
+    primary_key: "msg_id"
     retriever:
       $ref: "#/definitions/base_stream/retriever"
       requester:

--- a/airbyte-integrations/connectors/source-sendgrid/source_sendgrid/manifest.yaml
+++ b/airbyte-integrations/connectors/source-sendgrid/source_sendgrid/manifest.yaml
@@ -89,8 +89,6 @@ streams:
       primary_key: "id"
       path: "/v3/marketing/lists"
       field_path: ["result"]
-    name: "lists"
-    primary_key: "id"
     retriever:
       $ref: "#/definitions/base_stream/retriever"
       paginator:
@@ -101,8 +99,6 @@ streams:
       primary_key: "id"
       path: "/v3/marketing/campaigns"
       field_path: ["result"]
-    name: "campaigns"
-    primary_key: "id"
     retriever:
       $ref: "#/definitions/base_stream/retriever"
       paginator:
@@ -113,16 +109,12 @@ streams:
       primary_key: "id"
       path: "/v3/marketing/contacts"
       field_path: ["result"]
-    name: "contacts"
-    primary_key: "id"
   - $ref: "#/definitions/base_stream"
     $parameters:
       name: "stats_automations"
       primary_key: "id"
       path: "/v3/marketing/stats/automations"
       field_path: ["results"]
-    name: "stats_automations"
-    primary_key: "id"
     retriever:
       $ref: "#/definitions/base_stream/retriever"
       paginator:
@@ -133,16 +125,12 @@ streams:
       primary_key: "id"
       path: "/v3/marketing/segments"
       field_path: ["results"]
-    name: "segments"
-    primary_key: "id"
   - $ref: "#/definitions/base_stream"
     $parameters:
       name: "single_sends"
       primary_key: "id"
       path: "/v3/marketing/stats/singlesends"
       field_path: ["results"]
-    name: "single_sends"
-    primary_key: "id"
     retriever:
       $ref: "#/definitions/base_stream/retriever"
       paginator:
@@ -153,8 +141,6 @@ streams:
       primary_key: "id"
       path: "/v3/templates"
       field_path: ["result"]
-    name: "templates"
-    primary_key: "id"
     retriever:
       $ref: "#/definitions/base_stream/retriever"
       requester:
@@ -170,8 +156,6 @@ streams:
       cursor_field: "created"
       path: "/v3/suppression/bounces"
       field_path: []
-    name: "bounces"
-    primary_key: "email"
     retriever:
       $ref: "#/definitions/base_stream/retriever"
       paginator:
@@ -185,8 +169,6 @@ streams:
       cursor_field: "created"
       path: "/v3/suppression/unsubscribes"
       field_path: []
-    name: "global_suppressions"
-    primary_key: "email"
     retriever:
       $ref: "#/definitions/base_stream/retriever"
       paginator:
@@ -200,8 +182,6 @@ streams:
       cursor_field: "created"
       path: "/v3/suppression/blocks"
       field_path: []
-    name: "blocks"
-    primary_key: "email"
     retriever:
       $ref: "#/definitions/base_stream/retriever"
       paginator:
@@ -214,16 +194,12 @@ streams:
       primary_key: "id"
       path: "/v3/asm/groups"
       field_path: []
-    name: "suppression_groups"
-    primary_key: "id"
   - $ref: "#/definitions/base_stream"
     $parameters:
       name: "suppression_group_members"
       primary_key: "group_id"
       path: "/v3/asm/suppressions"
       field_path: []
-    name: "suppression_group_members"
-    primary_key: "group_id"
     retriever:
       $ref: "#/definitions/base_stream/retriever"
       paginator:
@@ -235,8 +211,6 @@ streams:
       cursor_field: "created"
       path: "/v3/suppression/invalid_emails"
       field_path: []
-    name: "invalid_emails"
-    primary_key: "email"
     retriever:
       $ref: "#/definitions/base_stream/retriever"
       paginator:
@@ -250,8 +224,6 @@ streams:
       cursor_field: "created"
       path: "/v3/suppression/spam_reports"
       field_path: []
-    name: "spam_reports"
-    primary_key: "email"
     retriever:
       $ref: "#/definitions/base_stream/retriever"
       paginator:
@@ -265,8 +237,6 @@ streams:
       cursor_field: "last_event_time"
       path: "/v3/messages"
       field_path: []
-    name: "messages"
-    primary_key: "msg_id"
     retriever:
       $ref: "#/definitions/base_stream/retriever"
       requester:

--- a/airbyte-integrations/connectors/source-sentry/source_sentry/manifest.yaml
+++ b/airbyte-integrations/connectors/source-sentry/source_sentry/manifest.yaml
@@ -34,9 +34,8 @@ definitions:
 
 streams:
   - type: DeclarativeStream
-    $parameters:
-      # https://docs.sentry.io/api/events/list-a-projects-events/
-      name: "events"
+    # https://docs.sentry.io/api/events/list-a-projects-events/
+    name: "events"
     primary_key: "id"
     schema_loader:
       $ref: "#/definitions/schema_loader"
@@ -52,8 +51,7 @@ streams:
       paginator:
         $ref: "#/definitions/paginator"
   - type: DeclarativeStream
-    $parameters:
-      name: "issues"
+    name: "issues"
     primary_key: "id"
     schema_loader:
       $ref: "#/definitions/schema_loader"
@@ -70,8 +68,7 @@ streams:
       paginator:
         $ref: "#/definitions/paginator"
   - type: DeclarativeStream
-    $parameters:
-      name: "projects"
+    name: "projects"
     primary_key: "id"
     schema_loader:
       $ref: "#/definitions/schema_loader"
@@ -85,8 +82,7 @@ streams:
       paginator:
         $ref: "#/definitions/paginator"
   - type: DeclarativeStream
-    $parameters:
-      name: "project_detail"
+    name: "project_detail"
     primary_key: "id"
     schema_loader:
       $ref: "#/definitions/schema_loader"

--- a/airbyte-integrations/connectors/source-sentry/source_sentry/manifest.yaml
+++ b/airbyte-integrations/connectors/source-sentry/source_sentry/manifest.yaml
@@ -37,7 +37,6 @@ streams:
     $parameters:
       # https://docs.sentry.io/api/events/list-a-projects-events/
       name: "events"
-    name: "events"
     primary_key: "id"
     schema_loader:
       $ref: "#/definitions/schema_loader"
@@ -55,7 +54,6 @@ streams:
   - type: DeclarativeStream
     $parameters:
       name: "issues"
-    name: "issues"
     primary_key: "id"
     schema_loader:
       $ref: "#/definitions/schema_loader"
@@ -74,7 +72,6 @@ streams:
   - type: DeclarativeStream
     $parameters:
       name: "projects"
-    name: "projects"
     primary_key: "id"
     schema_loader:
       $ref: "#/definitions/schema_loader"
@@ -90,7 +87,6 @@ streams:
   - type: DeclarativeStream
     $parameters:
       name: "project_detail"
-    name: "project_detail"
     primary_key: "id"
     schema_loader:
       $ref: "#/definitions/schema_loader"

--- a/airbyte-integrations/connectors/source-sentry/source_sentry/manifest.yaml
+++ b/airbyte-integrations/connectors/source-sentry/source_sentry/manifest.yaml
@@ -11,7 +11,6 @@ definitions:
       field_path: []
   requester:
     type: HttpRequester
-    name: "{{ parameters['name'] }}"
     url_base: "https://{{ config.hostname }}/api/0/"
     http_method: "GET"
     authenticator:
@@ -32,8 +31,6 @@ definitions:
       stop_condition: "{{ headers.link.next.results != 'true' }}"
   retriever:
     type: SimpleRetriever
-    name: "{{ parameters['name'] }}"
-    primary_key: "{{ parameters['primary_key'] }}"
 
 streams:
   - type: DeclarativeStream

--- a/airbyte-integrations/connectors/source-sentry/source_sentry/manifest.yaml
+++ b/airbyte-integrations/connectors/source-sentry/source_sentry/manifest.yaml
@@ -34,7 +34,9 @@ definitions:
 
 streams:
   - type: DeclarativeStream
-    # https://docs.sentry.io/api/events/list-a-projects-events/
+    $parameters:
+      # https://docs.sentry.io/api/events/list-a-projects-events/
+      name: "events"
     name: "events"
     primary_key: "id"
     schema_loader:
@@ -51,6 +53,8 @@ streams:
       paginator:
         $ref: "#/definitions/paginator"
   - type: DeclarativeStream
+    $parameters:
+      name: "issues"
     name: "issues"
     primary_key: "id"
     schema_loader:
@@ -68,6 +72,8 @@ streams:
       paginator:
         $ref: "#/definitions/paginator"
   - type: DeclarativeStream
+    $parameters:
+      name: "projects"
     name: "projects"
     primary_key: "id"
     schema_loader:
@@ -82,6 +88,8 @@ streams:
       paginator:
         $ref: "#/definitions/paginator"
   - type: DeclarativeStream
+    $parameters:
+      name: "project_detail"
     name: "project_detail"
     primary_key: "id"
     schema_loader:

--- a/airbyte-integrations/connectors/source-tempo/source_tempo/manifest.yaml
+++ b/airbyte-integrations/connectors/source-tempo/source_tempo/manifest.yaml
@@ -49,13 +49,11 @@ definitions:
     $parameters:
       name: "accounts"
       path: "accounts"
-    name: "accounts"
   customers_stream:
     $ref: "#/definitions/base_stream"
     $parameters:
       name: "customers"
       path: "customers"
-    name: "customers"
   worklogs_stream:
     $ref: "#/definitions/base_stream"
     retriever:
@@ -82,14 +80,12 @@ definitions:
     $parameters:
       name: "worklogs"
       path: "worklogs"
-    name: "worklogs"
     primary_key: "tempoWorklogId"
   workload_schemes_stream:
     $ref: "#/definitions/base_stream"
     $parameters:
       name: "workload-schemes"
       path: "workload-schemes"
-    name: "workload-schemes"
 
 streams:
   - "#/definitions/accounts_stream"

--- a/airbyte-integrations/connectors/source-tempo/source_tempo/manifest.yaml
+++ b/airbyte-integrations/connectors/source-tempo/source_tempo/manifest.yaml
@@ -8,7 +8,6 @@ definitions:
       field_path: ["results"]
   requester:
     type: HttpRequester
-    name: "{{ parameters['name'] }}"
     url_base: "https://api.tempo.io/4/"
     http_method: "GET"
     error_handler:
@@ -25,7 +24,6 @@ definitions:
       api_token: "{{ config['api_token'] }}"
   retriever:
     type: SimpleRetriever
-    name: "{{ parameters['name'] }}"
     record_selector:
       $ref: "#/definitions/selector"
     paginator:

--- a/airbyte-integrations/connectors/source-tempo/source_tempo/manifest.yaml
+++ b/airbyte-integrations/connectors/source-tempo/source_tempo/manifest.yaml
@@ -47,11 +47,13 @@ definitions:
   accounts_stream:
     $ref: "#/definitions/base_stream"
     $parameters:
+      name: "accounts"
       path: "accounts"
     name: "accounts"
   customers_stream:
     $ref: "#/definitions/base_stream"
     $parameters:
+      name: "customers"
       path: "customers"
     name: "customers"
   worklogs_stream:
@@ -78,12 +80,14 @@ definitions:
           inject_into: "request_parameter"
         type: DatetimeStreamSlicer
     $parameters:
+      name: "worklogs"
       path: "worklogs"
     name: "worklogs"
     primary_key: "tempoWorklogId"
   workload_schemes_stream:
     $ref: "#/definitions/base_stream"
     $parameters:
+      name: "workload-schemes"
       path: "workload-schemes"
     name: "workload-schemes"
 

--- a/airbyte-integrations/connectors/source-tempo/source_tempo/manifest.yaml
+++ b/airbyte-integrations/connectors/source-tempo/source_tempo/manifest.yaml
@@ -47,13 +47,13 @@ definitions:
   accounts_stream:
     $ref: "#/definitions/base_stream"
     $parameters:
-      name: "accounts"
       path: "accounts"
+    name: "accounts"
   customers_stream:
     $ref: "#/definitions/base_stream"
     $parameters:
-      name: "customers"
       path: "customers"
+    name: "customers"
   worklogs_stream:
     $ref: "#/definitions/base_stream"
     retriever:
@@ -78,14 +78,14 @@ definitions:
           inject_into: "request_parameter"
         type: DatetimeStreamSlicer
     $parameters:
-      name: "worklogs"
       path: "worklogs"
+    name: "worklogs"
     primary_key: "tempoWorklogId"
   workload_schemes_stream:
     $ref: "#/definitions/base_stream"
     $parameters:
-      name: "workload-schemes"
       path: "workload-schemes"
+    name: "workload-schemes"
 
 streams:
   - "#/definitions/accounts_stream"

--- a/airbyte-integrations/connectors/source-zenloop/source_zenloop/manifest.yaml
+++ b/airbyte-integrations/connectors/source-zenloop/source_zenloop/manifest.yaml
@@ -51,7 +51,6 @@ definitions:
       name: "surveys"
       path: "surveys"
       data_field: "surveys"
-    name: "surveys"
   surveys_slicer:
     class_name: source_zenloop.components.ZenloopSubstreamSlicer
     $parameters:
@@ -66,7 +65,6 @@ definitions:
       name: "survey_groups"
       path: "survey_groups"
       data_field: "survey_groups"
-    name: "survey_groups"
   survey_groups_slicer:
     class_name: source_zenloop.components.ZenloopSubstreamSlicer
     $parameters:
@@ -98,7 +96,6 @@ definitions:
     $parameters:
       name: "properties"
       data_field: "properties"
-    name: "properties"
     retriever:
       $ref: "#/definitions/retriever"
       requester:
@@ -111,7 +108,6 @@ definitions:
     $parameters:
       name: "answers"
       data_field: "answers"
-    name: "answers"
     retriever:
       $ref: "#/definitions/retriever"
       requester:
@@ -127,7 +123,6 @@ definitions:
     $parameters:
       name: "answers_survey_group"
       data_field: "answers"
-    name: "answers_survey_group"
     retriever:
       $ref: "#/definitions/retriever"
       requester:

--- a/airbyte-integrations/connectors/source-zenloop/source_zenloop/manifest.yaml
+++ b/airbyte-integrations/connectors/source-zenloop/source_zenloop/manifest.yaml
@@ -8,7 +8,6 @@ definitions:
       field_path: ["{{ parameters['data_field'] }}"]
   requester:
     type: HttpRequester
-    name: "{{ parameters['name'] }}"
     http_method: "GET"
     authenticator:
       type: BearerAuthenticator
@@ -17,7 +16,6 @@ definitions:
     type: SimpleRetriever
     $parameters:
       url_base: "https://api.zenloop.com/v1/"
-    name: "{{ parameters['name'] }}"
     record_selector:
       $ref: "#/definitions/selector"
     paginator:

--- a/airbyte-integrations/connectors/source-zenloop/source_zenloop/manifest.yaml
+++ b/airbyte-integrations/connectors/source-zenloop/source_zenloop/manifest.yaml
@@ -48,9 +48,9 @@ definitions:
   surveys:
     $ref: "#/definitions/base_stream"
     $parameters:
-      name: "surveys"
       path: "surveys"
       data_field: "surveys"
+    name: "surveys"
   surveys_slicer:
     class_name: source_zenloop.components.ZenloopSubstreamSlicer
     $parameters:
@@ -62,9 +62,9 @@ definitions:
   survey_groups:
     $ref: "#/definitions/base_stream"
     $parameters:
-      name: "survey_groups"
       path: "survey_groups"
       data_field: "survey_groups"
+    name: "survey_groups"
   survey_groups_slicer:
     class_name: source_zenloop.components.ZenloopSubstreamSlicer
     $parameters:
@@ -94,8 +94,8 @@ definitions:
   properties:
     $ref: "#/definitions/base_stream"
     $parameters:
-      name: "properties"
       data_field: "properties"
+    name: "properties"
     retriever:
       $ref: "#/definitions/retriever"
       requester:
@@ -106,8 +106,8 @@ definitions:
   answers:
     $ref: "#/definitions/incremental_base_stream"
     $parameters:
-      name: "answers"
       data_field: "answers"
+    name: "answers"
     retriever:
       $ref: "#/definitions/retriever"
       requester:
@@ -121,8 +121,8 @@ definitions:
   answers_survey_group:
     $ref: "#/definitions/incremental_base_stream"
     $parameters:
-      name: "answers_survey_group"
       data_field: "answers"
+    name: "answers_survey_group"
     retriever:
       $ref: "#/definitions/retriever"
       requester:

--- a/airbyte-integrations/connectors/source-zenloop/source_zenloop/manifest.yaml
+++ b/airbyte-integrations/connectors/source-zenloop/source_zenloop/manifest.yaml
@@ -48,6 +48,7 @@ definitions:
   surveys:
     $ref: "#/definitions/base_stream"
     $parameters:
+      name: "surveys"
       path: "surveys"
       data_field: "surveys"
     name: "surveys"
@@ -62,6 +63,7 @@ definitions:
   survey_groups:
     $ref: "#/definitions/base_stream"
     $parameters:
+      name: "survey_groups"
       path: "survey_groups"
       data_field: "survey_groups"
     name: "survey_groups"
@@ -94,6 +96,7 @@ definitions:
   properties:
     $ref: "#/definitions/base_stream"
     $parameters:
+      name: "properties"
       data_field: "properties"
     name: "properties"
     retriever:
@@ -106,6 +109,7 @@ definitions:
   answers:
     $ref: "#/definitions/incremental_base_stream"
     $parameters:
+      name: "answers"
       data_field: "answers"
     name: "answers"
     retriever:
@@ -121,6 +125,7 @@ definitions:
   answers_survey_group:
     $ref: "#/definitions/incremental_base_stream"
     $parameters:
+      name: "answers_survey_group"
       data_field: "answers"
     name: "answers_survey_group"
     retriever:

--- a/docs/connector-development/config-based/understanding-the-yaml-file/request-options.md
+++ b/docs/connector-development/config-based/understanding-the-yaml-file/request-options.md
@@ -38,7 +38,6 @@ Example:
 ```yaml
 requester:
   type: HttpRequester
-  name: "{{ parameters['name'] }}"
   url_base: "https://api.exchangeratesapi.io/v1/"
   http_method: "GET"
   request_options_provider:
@@ -55,7 +54,6 @@ It is also possible to configure add a json-encoded body to outgoing requests.
 ```yaml
 requester:
   type: HttpRequester
-  name: "{{ parameters['name'] }}"
   url_base: "https://api.exchangeratesapi.io/v1/"
   http_method: "GET"
   request_options_provider:

--- a/docs/connector-development/config-based/understanding-the-yaml-file/requester.md
+++ b/docs/connector-development/config-based/understanding-the-yaml-file/requester.md
@@ -21,14 +21,11 @@ The schema of a requester object is:
     type: object
     additionalProperties: true
     required:
-      - name
       - url_base
       - path
     properties:
       "$parameters":
         "$ref": "#/definitions/$parameters"
-      name:
-        type: string
       url_base:
         type: string
         description: "base url"

--- a/docs/connector-development/config-based/understanding-the-yaml-file/yaml-overview.md
+++ b/docs/connector-development/config-based/understanding-the-yaml-file/yaml-overview.md
@@ -66,16 +66,11 @@ The schema of a retriever object is:
     type: object
     additionalProperties: true
     required:
-      - name
       - requester
       - record_selector
     properties:
       "$parameters":
         "$ref": "#/definitions/$parameters"
-      name:
-        type: string
-      primary_key:
-        "$ref": "#/definitions/PrimaryKey"
       requester:
         "$ref": "#/definitions/Requester"
       record_selector:


### PR DESCRIPTION
Closes https://github.com/airbytehq/airbyte/issues/21560.

## What
Avoid duplication/simplify UX by removing the `name` and `primary_key` fields from the `SimpleRetriever` and `HttpRequester` components, which can inherit it as needed from `DeclarativeStream`.

## Recommended reading order
1. First commit - updates to the CDK & documentation
2. Second commit - migration of existing manifests to remove `name` and `primary_key` from non-`DeclarativeStream` components.

- [x] `./gradlew validateSourceYamlManifest` is passing after updating the manifests
- [x] Documentation which references the component is updated as needed
