### PR TITLE
replace fixture

### DIFF
--- a/airbyte-integrations/bases/source-acceptance-test/source_acceptance_test/tests/test_core.py
+++ b/airbyte-integrations/bases/source-acceptance-test/source_acceptance_test/tests/test_core.py
@@ -87,11 +87,11 @@ class TestSpec(BaseTest):
 
     @pytest.fixture(name="skip_backward_compatibility_tests")
     def skip_backward_compatibility_tests_fixture(
-            self,
-            inputs: SpecTestConfig,
-            previous_connector_docker_runner: ConnectorRunner,
-            previous_connector_spec: ConnectorSpecification,
-            actual_connector_spec: ConnectorSpecification,
+        self,
+        inputs: SpecTestConfig,
+        previous_connector_docker_runner: ConnectorRunner,
+        previous_connector_spec: ConnectorSpecification,
+        actual_connector_spec: ConnectorSpecification,
     ) -> bool:
         if actual_connector_spec == previous_connector_spec:
             pytest.skip("The previous and actual specifications are identical.")
@@ -157,7 +157,7 @@ class TestSpec(BaseTest):
         for variant_path in variant_paths:
             top_level_obj = schema_helper.get_node(variant_path[:-1])
             assert (
-                    top_level_obj.get("type") == "object"
+                top_level_obj.get("type") == "object"
             ), f"The top-level definition in a `oneOf` block should have type: object. misconfigured object: {top_level_obj}. {docs_msg}"
 
             variants = schema_helper.get_node(variant_path)
@@ -174,17 +174,17 @@ class TestSpec(BaseTest):
                 if all(["const" in variant["properties"][common_prop] for variant in variants]):
                     const_common_props.add(common_prop)
             assert (
-                    len(const_common_props) == 1
+                len(const_common_props) == 1
             ), f"There should be exactly one common property with 'const' keyword for {oneof_path} subobjects. {docs_msg}"
 
             const_common_prop = const_common_props.pop()
             for n, variant in enumerate(variants):
                 prop_obj = variant["properties"][const_common_prop]
                 assert (
-                        "default" not in prop_obj
+                    "default" not in prop_obj
                 ), f"There should not be 'default' keyword in common property {oneof_path}[{n}].{const_common_prop}. Use `const` instead. {docs_msg}"
                 assert (
-                        "enum" not in prop_obj
+                    "enum" not in prop_obj
                 ), f"There should not be 'enum' keyword in common property {oneof_path}[{n}].{const_common_prop}. Use `const` instead. {docs_msg}"
 
     def test_required(self):
@@ -442,11 +442,11 @@ class TestSpec(BaseTest):
     @pytest.mark.default_timeout(60)
     @pytest.mark.backward_compatibility
     def test_backward_compatibility(
-            self,
-            skip_backward_compatibility_tests: bool,
-            actual_connector_spec: ConnectorSpecification,
-            previous_connector_spec: ConnectorSpecification,
-            number_of_configs_to_generate: int = 100,
+        self,
+        skip_backward_compatibility_tests: bool,
+        actual_connector_spec: ConnectorSpecification,
+        previous_connector_spec: ConnectorSpecification,
+        number_of_configs_to_generate: int = 100,
     ):
         """Check if the current spec is backward_compatible with the previous one"""
         assert isinstance(actual_connector_spec, ConnectorSpecification) and isinstance(previous_connector_spec, ConnectorSpecification)
@@ -496,11 +496,11 @@ class TestConnection(BaseTest):
 class TestDiscovery(BaseTest):
     @pytest.fixture(name="skip_backward_compatibility_tests")
     def skip_backward_compatibility_tests_fixture(
-            self,
-            inputs: DiscoveryTestConfig,
-            previous_connector_docker_runner: ConnectorRunner,
-            discovered_catalog: MutableMapping[str, AirbyteStream],
-            previous_discovered_catalog: MutableMapping[str, AirbyteStream],
+        self,
+        inputs: DiscoveryTestConfig,
+        previous_connector_docker_runner: ConnectorRunner,
+        discovered_catalog: MutableMapping[str, AirbyteStream],
+        previous_discovered_catalog: MutableMapping[str, AirbyteStream],
     ) -> bool:
         if discovered_catalog == previous_discovered_catalog:
             pytest.skip("The previous and actual discovered catalogs are identical.")
@@ -590,10 +590,10 @@ class TestDiscovery(BaseTest):
     @pytest.mark.default_timeout(60)
     @pytest.mark.backward_compatibility
     def test_backward_compatibility(
-            self,
-            skip_backward_compatibility_tests: bool,
-            discovered_catalog: MutableMapping[str, AirbyteStream],
-            previous_discovered_catalog: MutableMapping[str, AirbyteStream],
+        self,
+        skip_backward_compatibility_tests: bool,
+        discovered_catalog: MutableMapping[str, AirbyteStream],
+        previous_discovered_catalog: MutableMapping[str, AirbyteStream],
     ):
         """Check if the current catalog is backward_compatible with the previous one."""
         assert isinstance(discovered_catalog, MutableMapping) and isinstance(previous_discovered_catalog, MutableMapping)
@@ -715,11 +715,11 @@ class TestBasicRead(BaseTest):
         assert not stream_name_to_empty_fields_mapping, msg
 
     def _validate_expected_records(
-            self,
-            records: List[AirbyteRecordMessage],
-            expected_records_by_stream: MutableMapping[str, List[MutableMapping]],
-            flags,
-            detailed_logger: Logger,
+        self,
+        records: List[AirbyteRecordMessage],
+        expected_records_by_stream: MutableMapping[str, List[MutableMapping]],
+        flags,
+        detailed_logger: Logger,
     ):
         """
         We expect some records from stream to match expected_records, partially or fully, in exact or any order.
@@ -756,11 +756,11 @@ class TestBasicRead(BaseTest):
 
     @pytest.fixture(name="configured_catalog")
     def configured_catalog_fixture(
-            self,
-            test_strictness_level: Config.TestStrictnessLevel,
-            configured_catalog_path: Optional[str],
-            discovered_catalog: MutableMapping[str, AirbyteStream],
-            empty_streams: Set[EmptyStreamConfiguration],
+        self,
+        test_strictness_level: Config.TestStrictnessLevel,
+        configured_catalog_path: Optional[str],
+        discovered_catalog: MutableMapping[str, AirbyteStream],
+        empty_streams: Set[EmptyStreamConfiguration],
     ) -> ConfiguredAirbyteCatalog:
         """Build a configured catalog for basic read only.
         We discard the use of custom configured catalog if:
@@ -787,16 +787,16 @@ class TestBasicRead(BaseTest):
             return build_configured_catalog_from_custom_catalog(configured_catalog_path, discovered_catalog)
 
     def test_read(
-            self,
-            connector_config,
-            configured_catalog,
-            expect_records_config: ExpectedRecordsConfig,
-            should_validate_schema: Boolean,
-            should_validate_data_points: Boolean,
-            empty_streams: Set[EmptyStreamConfiguration],
-            expected_records_by_stream: MutableMapping[str, List[MutableMapping]],
-            docker_runner: ConnectorRunner,
-            detailed_logger,
+        self,
+        connector_config,
+        configured_catalog,
+        expect_records_config: ExpectedRecordsConfig,
+        should_validate_schema: Boolean,
+        should_validate_data_points: Boolean,
+        empty_streams: Set[EmptyStreamConfiguration],
+        expected_records_by_stream: MutableMapping[str, List[MutableMapping]],
+        docker_runner: ConnectorRunner,
+        detailed_logger,
     ):
         output = docker_runner.call_read(connector_config, configured_catalog)
         records = [message.record for message in filter_output(output, Type.RECORD)]
@@ -810,7 +810,7 @@ class TestBasicRead(BaseTest):
         for pks, record in primary_keys_for_records(streams=configured_catalog.streams, records=records):
             for pk_path, pk_value in pks.items():
                 assert (
-                        pk_value is not None
+                    pk_value is not None
                 ), f"Primary key subkeys {repr(pk_path)} have null values or not present in {record.stream} stream records."
 
         # TODO: remove this condition after https://github.com/airbytehq/airbyte/issues/8312 is done
@@ -868,13 +868,13 @@ class TestBasicRead(BaseTest):
 
     @staticmethod
     def compare_records(
-            stream_name: str,
-            actual: List[Mapping[str, Any]],
-            expected: List[Mapping[str, Any]],
-            extra_fields: bool,
-            exact_order: bool,
-            extra_records: bool,
-            detailed_logger: Logger,
+        stream_name: str,
+        actual: List[Mapping[str, Any]],
+        expected: List[Mapping[str, Any]],
+        extra_fields: bool,
+        exact_order: bool,
+        extra_records: bool,
+        detailed_logger: Logger,
     ):
         """Compare records using combination of restrictions"""
         if exact_order:


### PR DESCRIPTION
## What
* A test fixture cannot be found
```
file /Users/alex/code/airbyte/airbyte-integrations/bases/source-acceptance-test/source_acceptance_test/tests/test_core.py, line 396
      def test_date_format(self, connector_specification: dict, detailed_logger):
E       fixture 'connector_specification' not found
>       available fixtures: acceptance_test_config, actual_connector_spec, base_path, cache, cache_discovered_catalog, cached_schemas, capfd, capfdbinary, caplog, capsys, capsysbinary, class_mocker, configured_catalog, configured_catalog_path, connection_specification, connector_config, connector_config_path, connector_setup, connector_spec, connector_spec_dict, connector_spec_path, cov, detailed_logger, discovered_catalog, docker_runner, doctest_namespace, empty_streams, expect_records_config, expected_records_by_stream, image_tag, invalid_connector_config, invalid_connector_config_path, malformed_connector_config, mocker, module_mocker, monkeypatch, no_cover, package_mocker, previous_cached_schemas, previous_connector_docker_runner, previous_connector_image_name, previous_connector_spec, previous_discovered_catalog, pull_docker_image, pytestconfig, record_property, record_testsuite_property, record_xml_attribute, recwarn, requests_mock, secret_property_names, session_mocker, skip_backward_compatibility_tests, test_strictness_level, tmp_path, tmp_path_factory, tmpdir, tmpdir_factory
>       use 'pytest --fixtures [testpath]' for help on them.
```

## How
* Replace the fixture with `connection_spec`

## Recommended reading order
1. `x.java`
2. `y.python`

## 🚨 User Impact 🚨
Are there any breaking changes? What is the end result perceived by the user? If yes, please merge this PR with the 🚨🚨 emoji so changelog authors can further highlight this if needed.

## Pre-merge Checklist
Expand the relevant checklist and delete the others.

<details><summary><strong>New Connector</strong></summary>

### Community member or Airbyter

- [ ] **Community member?** Grant edit access to maintainers ([instructions](https://docs.github.com/en/github/collaborating-with-pull-requests/working-with-forks/allowing-changes-to-a-pull-request-branch-created-from-a-fork#enabling-repository-maintainer-permissions-on-existing-pull-requests))
- [ ] Secrets in the connector's spec are annotated with `airbyte_secret`
- [ ] Unit & integration tests added and passing. Community members, please provide proof of success locally e.g: screenshot or copy-paste unit, integration, and acceptance test output. To run acceptance tests for a Python connector, follow instructions in the README. For java connectors run `./gradlew :airbyte-integrations:connectors:<name>:integrationTest`.
- [ ] Code reviews completed
- [ ] Documentation updated
    - [ ] Connector's `README.md`
    - [ ] Connector's `bootstrap.md`. See [description and examples](https://docs.google.com/document/d/1ypdgmwmEHWv-TrO4_YOQ7pAJGVrMp5BOkEVh831N260/edit?usp=sharing)
    - [ ] `docs/integrations/<source or destination>/<name>.md` including changelog. See changelog [example](https://docs.airbyte.io/integrations/sources/stripe#changelog)
    - [ ] `docs/integrations/README.md`
    - [ ] `airbyte-integrations/builds.md`
- [ ] PR name follows [PR naming conventions](https://docs.airbyte.com/contributing-to-airbyte/issues-and-pull-requests)

### Airbyter

If this is a community PR, the Airbyte engineer reviewing this PR is responsible for the below items.

- [ ] Create a non-forked branch based on this PR and test the below items on it
- [ ] Build is successful
- [ ] If new credentials are required for use in CI, add them to GSM. [Instructions](https://docs.airbyte.io/connector-development#using-credentials-in-ci).
- [ ] [`/test connector=connectors/<name>` command](https://docs.airbyte.io/connector-development#updating-an-existing-connector) is passing
- [ ] New Connector version released on Dockerhub by running the `/publish` command described [here](https://docs.airbyte.io/connector-development#updating-an-existing-connector)
- [ ] After the connector is published, connector added to connector index as described [here](https://docs.airbyte.io/connector-development#publishing-a-connector)
- [ ] Seed specs have been re-generated by building the platform and committing the changes to the seed spec files, as described [here](https://docs.airbyte.io/connector-development#publishing-a-connector)

</details>

<details><summary><strong>Updating a connector</strong></summary>

### Community member or Airbyter

- [ ] Grant edit access to maintainers ([instructions](https://docs.github.com/en/github/collaborating-with-pull-requests/working-with-forks/allowing-changes-to-a-pull-request-branch-created-from-a-fork#enabling-repository-maintainer-permissions-on-existing-pull-requests))
- [ ] Secrets in the connector's spec are annotated with `airbyte_secret`
- [ ] Unit & integration tests added and passing. Community members, please provide proof of success locally e.g: screenshot or copy-paste unit, integration, and acceptance test output. To run acceptance tests for a Python connector, follow instructions in the README. For java connectors run `./gradlew :airbyte-integrations:connectors:<name>:integrationTest`.
- [ ] Code reviews completed
- [ ] Documentation updated
    - [ ] Connector's `README.md`
    - [ ] Connector's `bootstrap.md`. See [description and examples](https://docs.google.com/document/d/1ypdgmwmEHWv-TrO4_YOQ7pAJGVrMp5BOkEVh831N260/edit?usp=sharing)
    - [ ] Changelog updated in `docs/integrations/<source or destination>/<name>.md` including changelog. See changelog [example](https://docs.airbyte.io/integrations/sources/stripe#changelog)
- [ ] PR name follows [PR naming conventions](https://docs.airbyte.com/contributing-to-airbyte/issues-and-pull-requests)

### Airbyter

If this is a community PR, the Airbyte engineer reviewing this PR is responsible for the below items.

- [ ] Create a non-forked branch based on this PR and test the below items on it
- [ ] Build is successful
- [ ] If new credentials are required for use in CI, add them to GSM. [Instructions](https://docs.airbyte.io/connector-development#using-credentials-in-ci).
- [ ] [`/test connector=connectors/<name>` command](https://docs.airbyte.io/connector-development#updating-an-existing-connector) is passing
- [ ] New Connector version released on Dockerhub and connector version bumped by running the `/publish` command described [here](https://docs.airbyte.io/connector-development#updating-an-existing-connector)

</details>

<details><summary><strong>Connector Generator</strong></summary>

- [ ] Issue acceptance criteria met
- [ ] PR name follows [PR naming conventions](https://docs.airbyte.com/contributing-to-airbyte/issues-and-pull-requests)
- [ ] If adding a new generator, add it to the [list of scaffold modules being tested](https://github.com/airbytehq/airbyte/blob/master/airbyte-integrations/connector-templates/generator/build.gradle#L41)
- [ ] The generator test modules (all connectors with `-scaffold` in their name) have been updated with the latest scaffold by running `./gradlew :airbyte-integrations:connector-templates:generator:testScaffoldTemplates` then checking in your changes
- [ ] Documentation which references the generator is updated as needed

</details>

## Tests

<details><summary><strong>Unit</strong></summary>

*Put your unit tests output here.*

</details>

<details><summary><strong>Integration</strong></summary>

*Put your integration tests output here.*

</details>

<details><summary><strong>Acceptance</strong></summary>

*Put your acceptance tests output here.*

</details>
