### PR TITLE
Revert "Extend SATs to capture UI limitations (#21451)"

### DIFF
--- a/airbyte-integrations/bases/source-acceptance-test/CHANGELOG.md
+++ b/airbyte-integrations/bases/source-acceptance-test/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## 0.4.0
+Revert 0.3.0
+
+## 0.3.0
+(Broken) Add various stricter checks for specs (see PR for details). [#21451](https://github.com/airbytehq/airbyte/pull/21451)
+
 ## 0.2.26
 Check `future_state` only for incremental streams. [#21248](https://github.com/airbytehq/airbyte/pull/21248)
 

--- a/airbyte-integrations/bases/source-acceptance-test/CHANGELOG.md
+++ b/airbyte-integrations/bases/source-acceptance-test/CHANGELOG.md
@@ -1,8 +1,5 @@
 # Changelog
 
-## 0.3.0
-Add various stricter checks for specs (see PR for details). [#21451](https://github.com/airbytehq/airbyte/pull/21451)
-
 ## 0.2.26
 Check `future_state` only for incremental streams. [#21248](https://github.com/airbytehq/airbyte/pull/21248)
 

--- a/airbyte-integrations/bases/source-acceptance-test/Dockerfile
+++ b/airbyte-integrations/bases/source-acceptance-test/Dockerfile
@@ -33,7 +33,7 @@ COPY pytest.ini setup.py ./
 COPY source_acceptance_test ./source_acceptance_test
 RUN pip install .
 
-LABEL io.airbyte.version=0.2.26
+LABEL io.airbyte.version=0.4.0
 LABEL io.airbyte.name=airbyte/source-acceptance-test
 
 ENTRYPOINT ["python", "-m", "pytest", "-p", "source_acceptance_test.plugin", "-r", "fEsx"]

--- a/airbyte-integrations/bases/source-acceptance-test/Dockerfile
+++ b/airbyte-integrations/bases/source-acceptance-test/Dockerfile
@@ -33,7 +33,7 @@ COPY pytest.ini setup.py ./
 COPY source_acceptance_test ./source_acceptance_test
 RUN pip install .
 
-LABEL io.airbyte.version=0.3.0
+LABEL io.airbyte.version=0.2.26
 LABEL io.airbyte.name=airbyte/source-acceptance-test
 
 ENTRYPOINT ["python", "-m", "pytest", "-p", "source_acceptance_test.plugin", "-r", "fEsx"]

--- a/airbyte-integrations/bases/source-acceptance-test/source_acceptance_test/tests/test_core.py
+++ b/airbyte-integrations/bases/source-acceptance-test/source_acceptance_test/tests/test_core.py
@@ -76,19 +76,11 @@ def secret_property_names_fixture():
     )
 
 
-DATE_PATTERN = "^[0-9]{2}-[0-9]{2}-[0-9]{4}$"
-DATETIME_PATTERN = "^[0-9]{4}-[0-9]{2}-[0-9]{2}(T[0-9]{2}:[0-9]{2}:[0-9]{2})?$"
-
-
 @pytest.mark.default_timeout(10)
 class TestSpec(BaseTest):
 
     spec_cache: ConnectorSpecification = None
     previous_spec_cache: ConnectorSpecification = None
-
-    @pytest.fixture(name="connection_specification", scope="class")
-    def connection_specification_fixture(self, connector_spec_dict: dict) -> dict:
-        return connector_spec_dict["connectionSpecification"]
 
     @pytest.fixture(name="skip_backward_compatibility_tests")
     def skip_backward_compatibility_tests_fixture(
@@ -227,15 +219,22 @@ class TestSpec(BaseTest):
         Some fields can not hold a secret by design, others can.
         Null type as well as boolean can not hold a secret value.
         A string, a number or an integer type can always store secrets.
-        Secret objects and arrays can not be rendered correctly in the UI:
+        Objects and arrays can hold a secret in case they are generic,
+        meaning their inner structure is not described in details with properties/items.
         A field with a constant value can not hold a secret as well.
         """
         unsecure_types = {"string", "integer", "number"}
         type_ = prop["type"]
+        is_property_generic_object = type_ == "object" and not any(
+            [prop.get("properties", {}), prop.get("anyOf", []), prop.get("oneOf", []), prop.get("allOf", [])]
+        )
+        is_property_generic_array = type_ == "array" and not any([prop.get("items", []), prop.get("prefixItems", [])])
         is_property_constant_value = bool(prop.get("const"))
         can_store_secret = any(
             [
                 isinstance(type_, str) and type_ in unsecure_types,
+                is_property_generic_object,
+                is_property_generic_array,
                 isinstance(type_, list) and (set(type_) & unsecure_types),
             ]
         )
@@ -253,7 +252,7 @@ class TestSpec(BaseTest):
         secrets_exposed = []
         non_secrets_hidden = []
         spec_properties = connector_spec_dict["connectionSpecification"]["properties"]
-        for type_path, type_value in dpath.util.search(spec_properties, "**/type", yielded=True):
+        for type_path, value in dpath.util.search(spec_properties, "**/type", yielded=True):
             _, is_property_name_secret = self._is_spec_property_name_secret(type_path, secret_property_names)
             if not is_property_name_secret:
                 continue
@@ -269,7 +268,7 @@ class TestSpec(BaseTest):
 
         if non_secrets_hidden:
             properties = "\n".join(non_secrets_hidden)
-            pytest.fail(
+            detailed_logger.warning(
                 f"""Some properties are marked with `airbyte_secret` although they probably should not be.
                 Please double check them. If they're okay, please fix this test.
                 {properties}"""
@@ -280,139 +279,6 @@ class TestSpec(BaseTest):
                 f"""The following properties should be marked with `airbyte_secret!`
                     {properties}"""
             )
-
-    def _fail_on_errors(self, errors: List[str]):
-        if len(errors) > 0:
-            pytest.fail("\n".join(errors))
-
-    def test_property_type_is_not_array(self, connector_specification: dict):
-        """
-        Each field has one or multiple types, but the UI only supports a single type and optionally "null" as a second type.
-        """
-        errors = []
-        for type_path, type_value in dpath.util.search(connector_specification, "**/properties/*/type", yielded=True):
-            if isinstance(type_value, List):
-                number_of_types = len(type_value)
-                if number_of_types != 2 and number_of_types != 1:
-                    errors.append(
-                        f"{type_path} is not either a simple type or an array of a simple type plus null: {type_value} (for example: type: [string, null])"
-                    )
-                if number_of_types == 2 and type_value[1] != "null":
-                    errors.append(
-                        f"Second type of {type_path} is not null: {type_value}. Type can either be a simple type or an array of a simple type plus null (for example: type: [string, null])"
-                    )
-        self._fail_on_errors(errors)
-
-    def test_object_not_empty(self, connector_specification: dict):
-        """
-        Each object field needs to have at least one property as the UI won't be able to show them otherwise.
-        If the whole spec is empty, it's allowed to have a single empty object at the top level
-        """
-        schema_helper = JsonSchemaHelper(connector_specification)
-        errors = []
-        for type_path, type_value in dpath.util.search(connector_specification, "**/type", yielded=True):
-            if type_path == "type":
-                # allow empty root object
-                continue
-            if type_value == "object":
-                property = schema_helper.get_parent(type_path)
-                if "oneOf" not in property and ("properties" not in property or len(property["properties"]) == 0):
-                    errors.append(
-                        f"{type_path} is an empty object which will not be represented correctly in the UI. Either remove or add specific properties"
-                    )
-        self._fail_on_errors(errors)
-
-    def test_array_type(self, connector_specification: dict):
-        """
-        Each array has one or multiple types for its items, but the UI only supports a single type which can either be object, string or an enum
-        """
-        schema_helper = JsonSchemaHelper(connector_specification)
-        errors = []
-        for type_path, type_type in dpath.util.search(connector_specification, "**/type", yielded=True):
-            property_definition = schema_helper.get_parent(type_path)
-            if type_type != "array":
-                # unrelated "items", not an array definition
-                continue
-            items_value = property_definition.get("items", None)
-            if items_value is None:
-                continue
-            elif isinstance(items_value, List):
-                errors.append(f"{type_path} is not just a single item type: {items_value}")
-            elif items_value.get("type") not in ["object", "string", "number", "integer"] and "enum" not in items_value:
-                errors.append(f"Items of {type_path} has to be either object or string or define an enum")
-        self._fail_on_errors(errors)
-
-    def test_forbidden_complex_types(self, connector_specification: dict):
-        """
-        not, anyOf, patternProperties, prefixItems, allOf, if, then, else, dependentSchemas and dependentRequired are not allowed
-        """
-        forbidden_keys = [
-            "not",
-            "anyOf",
-            "patternProperties",
-            "prefixItems",
-            "allOf",
-            "if",
-            "then",
-            "else",
-            "dependentSchemas",
-            "dependentRequired",
-        ]
-        found_keys = set()
-        for forbidden_key in forbidden_keys:
-            for path, value in dpath.util.search(connector_specification, f"**/{forbidden_key}", yielded=True):
-                found_keys.add(path)
-
-        for forbidden_key in forbidden_keys:
-            # remove forbidden keys if they are used as properties directly
-            for path, _value in dpath.util.search(connector_specification, f"**/properties/{forbidden_key}", yielded=True):
-                found_keys.remove(path)
-
-        if len(found_keys) > 0:
-            key_list = ", ".join(found_keys)
-            pytest.fail(f"Found the following disallowed JSON schema features: {key_list}")
-
-    def test_date_pattern(self, connector_specification: dict, detailed_logger):
-        """
-        Properties with format date or date-time should always have a pattern defined how the date/date-time should be formatted
-        that corresponds with the format the datepicker component is creating.
-        """
-        schema_helper = JsonSchemaHelper(connector_specification)
-        for format_path, format in dpath.util.search(connector_specification, "**/format", yielded=True):
-            if not isinstance(format, str):
-                # format is not a format definition here but a property named format
-                continue
-            property_definition = schema_helper.get_parent(format_path)
-            pattern = property_definition.get("pattern")
-            if format == "date" and not pattern == DATE_PATTERN:
-                detailed_logger.warning(
-                    f"{format_path} is defining a date format without the corresponding pattern. Consider setting the pattern to {DATE_PATTERN} to make it easier for users to edit this field in the UI."
-                )
-            if format == "date-time" and not pattern == DATETIME_PATTERN:
-                detailed_logger.warning(
-                    f"{format_path} is defining a date-time format without the corresponding pattern Consider setting the pattern to {DATETIME_PATTERN} to make it easier for users to edit this field in the UI."
-                )
-
-    def test_date_format(self, connector_specification: dict, detailed_logger):
-        """
-        Properties with a pattern that looks like a date should have their format set to date or date-time.
-        """
-        schema_helper = JsonSchemaHelper(connector_specification)
-        for pattern_path, pattern in dpath.util.search(connector_specification, "**/pattern", yielded=True):
-            if not isinstance(pattern, str):
-                # pattern is not a pattern definition here but a property named pattern
-                continue
-            if pattern == DATE_PATTERN or pattern == DATETIME_PATTERN:
-                property_definition = schema_helper.get_parent(pattern_path)
-                format = property_definition.get("format")
-                if not format == "date" and pattern == DATE_PATTERN:
-                    detailed_logger.warning(
-                        f"{pattern_path} is defining a pattern that looks like a date without setting the format to `date`. Consider specifying the format to make it easier for users to edit this field in the UI."
-                    )
-                if not format == "date-time" and pattern == DATETIME_PATTERN:
-                    detailed_logger.warning(
-                        f"{pattern_path} is defining a pattern that looks like a date-time without setting the format to `date-time`. Consider specifying the format to make it easier for users to edit this field in the UI."
-                    )
 
     def test_defined_refs_exist_in_json_spec_file(self, connector_spec_dict: dict):
         """Checking for the presence of unresolved `$ref`s values within each json spec file"""

--- a/airbyte-integrations/bases/source-acceptance-test/source_acceptance_test/utils/json_schema_helper.py
+++ b/airbyte-integrations/bases/source-acceptance-test/source_acceptance_test/utils/json_schema_helper.py
@@ -6,7 +6,6 @@
 from functools import reduce
 from typing import Any, Dict, List, Mapping, Optional, Set, Text, Union
 
-import dpath.util
 import pendulum
 from jsonref import JsonRef
 
@@ -121,16 +120,6 @@ class JsonSchemaHelper:
                 node = self.get_ref(node["$ref"])
             node = node[segment]
         return node
-
-    def get_parent(self, path: str) -> Any:
-        """
-        Returns the parent dict of a given path within the `obj` dict
-        """
-        absolute_path = f"/{path}"
-        parent_path, _ = absolute_path.rsplit(sep="/", maxsplit=1)
-        if parent_path == "":
-            return self._schema
-        return dpath.util.get(self._schema, parent_path)
 
     def find_nodes(self, keys: List[str]) -> List[List[str]]:
         """Find all paths that lead to nodes with the specified keys.

--- a/airbyte-integrations/bases/source-acceptance-test/unit_tests/test_spec.py
+++ b/airbyte-integrations/bases/source-acceptance-test/unit_tests/test_spec.py
@@ -652,267 +652,102 @@ def test_additional_properties_is_true(connector_spec, expectation):
 
 
 @pytest.mark.parametrize(
-    "connector_spec, should_fail",
+    "connector_spec, should_fail, is_warning_logged",
     (
         (
-            {"type": "object", "properties": {"api_token": {"type": "string", "airbyte_secret": True}}},
+            {
+                "connectionSpecification": {"type": "object", "properties": {"api_token": {"type": "string", "airbyte_secret": True}}}
+            },
             False,
+            False
         ),
-        ({"type": "object", "properties": {"api_token": {"type": "null"}}}, False),
-        ({"type": "object", "properties": {"refresh_token": {"type": "boolean", "airbyte_secret": True}}}, True),
-        ({"type": "object", "properties": {"refresh_token": {"type": ["null", "string"]}}}, True),
-        ({"type": "object", "properties": {"credentials": {"type": "array", "items": {"type": "string"}}}}, True),
-        ({"type": "object", "properties": {"auth": {"oneOf": [{"api_token": {"type": "string"}}]}}}, True),
         (
             {
-                "type": "object",
-                "properties": {"credentials": {"oneOf": [{"type": "object", "properties": {"api_key": {"type": "string"}}}]}},
+                "connectionSpecification": {"type": "object", "properties": {"api_token": {"type": "null"}}}
+            },
+            False,
+            False
+        ),
+        (
+            {
+                "connectionSpecification": {"type": "object", "properties": {"refresh_token": {"type": "boolean", "airbyte_secret": True}}}
+            },
+            False,
+            True
+        ),
+        (
+            {
+                "connectionSpecification": {"type": "object", "properties": {"jwt": {"type": "object"}}}
             },
             True,
+            False
         ),
-        ({"type": "object", "properties": {"start_date": {"type": ["null", "string"]}}}, False),
-        ({"type": "object", "properties": {"credentials": {"oneOf": [{"type": "string", "const": "OAuth2.0"}]}}}, False),
+        (
+            {
+                "connectionSpecification": {"type": "object", "properties": {"refresh_token": {"type": ["null", "string"]}}}
+            },
+            True,
+            False
+        ),
+        (
+            {
+                "connectionSpecification": {"type": "object", "properties": {"credentials": {"type": "array"}}}
+            },
+            True,
+            False
+        ),
+        (
+            {
+                "connectionSpecification": {"type": "object", "properties": {"credentials": {"type": "array", "items": {"type": "string"}}}}
+            },
+            True,
+            False
+        ),
+        (
+            {
+                "connectionSpecification": {"type": "object", "properties": {"auth": {"oneOf": [{"api_token": {"type": "string"}}]}}}
+            },
+            True,
+            False
+        ),
+        (
+            {
+                "connectionSpecification": {"type": "object", "properties": {"credentials": {"oneOf": [{"type": "object", "properties": {"api_key": {"type": "string"}}}]}}}
+            },
+            True,
+            False
+        ),
+        (
+            {
+                "connectionSpecification": {"type": "object", "properties": {"start_date": {"type": ["null", "string"]}}}
+            },
+            False,
+            False
+        ),
+        (
+            {
+                 "connectionSpecification": {"type": "object", "properties": {"credentials": {"oneOf": [{"type": "string", "const": "OAuth2.0"}]}}}
+            },
+            False,
+            False
+        )
     ),
 )
-def test_airbyte_secret(mocker, connector_spec, should_fail):
+def test_airbyte_secret(mocker, connector_spec, should_fail, is_warning_logged):
     mocker.patch.object(conftest.pytest, "fail")
     t = _TestSpec()
     logger = mocker.Mock()
-    t.test_secret_is_properly_marked(
-        {"connectionSpecification": connector_spec}, logger, ("api_key", "api_token", "refresh_token", "jwt", "credentials")
-    )
+    t.test_secret_is_properly_marked(connector_spec, logger, ("api_key", "api_token", "refresh_token", "jwt", "credentials"))
     if should_fail:
         conftest.pytest.fail.assert_called_once()
     else:
         conftest.pytest.fail.assert_not_called()
-
-
-@pytest.mark.parametrize(
-    "connector_spec, should_fail",
-    (
-        ({"type": "object", "properties": {"refresh_token": {"type": ["boolean", "string"]}}}, True),
-        ({"type": "object", "properties": {"refresh_token": {"type": []}}}, True),
-        ({"type": "object", "properties": {"refresh_token": {"type": ["string"]}}}, False),
-        ({"type": "object", "properties": {"refresh_token": {"type": "string"}}}, False),
-        ({"type": "object", "properties": {"refresh_token": {"type": ["boolean", "null"]}}}, False),
-    ),
-)
-def test_property_type_is_not_array(mocker, connector_spec, should_fail):
-    mocker.patch.object(conftest.pytest, "fail")
-    t = _TestSpec()
-    t.test_property_type_is_not_array(connector_spec)
-    if should_fail:
-        conftest.pytest.fail.assert_called_once()
-    else:
-        conftest.pytest.fail.assert_not_called()
-
-
-@pytest.mark.parametrize(
-    "connector_spec, should_fail",
-    (
-        ({"type": "object", "properties": {"refresh_token": {"type": "boolean", "airbyte_secret": True}}}, False),
-        ({"type": "object", "properties": {}}, False),
-        ({"type": "object", "properties": {"jwt": {"type": "object"}}}, True),
-        (
-            {
-                "type": "object",
-                "properties": {
-                    "jwt": {
-                        "type": "object",
-                        "oneOf": [
-                            {"type": "object", "properties": {"a": {"type": "string"}}},
-                            {"type": "object", "properties": {"b": {"type": "string"}}},
-                        ],
-                    }
-                },
-            },
-            False,
-        ),
-        (
-            {
-                "type": "object",
-                "properties": {
-                    "jwt": {
-                        "type": "object",
-                        "oneOf": [
-                            {"type": "object", "properties": {"a": {"type": "string"}}},
-                            {"type": "object", "properties": {"b": {"type": "string"}}},
-                            {"type": "object", "properties": {}},
-                        ],
-                    }
-                },
-            },
-            True,
-        ),
-        ({"type": "object", "properties": {"jwt": {"type": "object", "properties": {}}}}, True),
-    ),
-)
-def test_object_not_empty(mocker, connector_spec, should_fail):
-    mocker.patch.object(conftest.pytest, "fail")
-    t = _TestSpec()
-    t.test_object_not_empty(connector_spec)
-    if should_fail:
-        conftest.pytest.fail.assert_called_once()
-    else:
-        conftest.pytest.fail.assert_not_called()
-
-
-@pytest.mark.parametrize(
-    "connector_spec, should_fail",
-    (
-        ({"type": "object", "properties": {"list": {"type": "array"}}}, False),
-        ({"type": "object", "properties": {"list": {"type": "array", "items": [{"type": "string"}, {"type": "boolean"}]}}}, True),
-        ({"type": "object", "properties": {"list": {"type": "array", "items": {"type": "string"}}}}, False),
-        ({"type": "object", "properties": {"list": {"type": "array", "items": {"type": "number"}}}}, False),
-        ({"type": "object", "properties": {"list": {"type": "array", "items": {"type": "integer"}}}}, False),
-        ({"type": "object", "properties": {"list": {"type": "array", "items": {"type": "boolean"}}}}, True),
-        ({"type": "object", "properties": {"list": {"type": "array", "items": {"type": "number", "enum": [1, 2, 3]}}}}, False),
-        ({"type": "object", "properties": {"list": {"type": "array", "items": {"enum": ["a", "b", "c"]}}}}, False),
-        (
-            {
-                "type": "object",
-                "properties": {"list": {"type": "array", "items": {"type": "object", "properties": {"a": {"type": "string"}}}}},
-            },
-            False,
-        ),
-        ({"type": "object", "properties": {"list": {"type": "array", "items": {"type": "boolean"}}}}, True),
-    ),
-)
-def test_array_type(mocker, connector_spec, should_fail):
-    mocker.patch.object(conftest.pytest, "fail")
-    t = _TestSpec()
-    t.test_array_type(connector_spec)
-    if should_fail:
-        conftest.pytest.fail.assert_called_once()
-    else:
-        conftest.pytest.fail.assert_not_called()
-
-
-@pytest.mark.parametrize(
-    "connector_spec, should_fail",
-    (
-        ({"type": "object", "properties": {"a": {"type": "string"}}}, False),
-        ({"type": "object", "properties": {"a": {"type": "string", "allOf": [{"type": "string"}, {"maxLength": 5}]}}}, True),
-        ({"type": "object", "properties": {"allOf": {"type": "string"}}}, False),
-        (
-            {
-                "type": "object",
-                "properties": {"allOf": {"type": "object", "patternProperties": {"^S_": {"type": "string"}, "^I_": {"type": "integer"}}}},
-            },
-            True,
-        ),
-        (
-            {
-                "type": "object",
-                "properties": {
-                    "list": {
-                        "type": "array",
-                        "prefixItems": [{"enum": ["Street", "Avenue", "Boulevard"]}, {"enum": ["NW", "NE", "SW", "SE"]}],
-                    }
-                },
-            },
-            True,
-        ),
-    ),
-)
-def test_forbidden_complex_types(mocker, connector_spec, should_fail):
-    mocker.patch.object(conftest.pytest, "fail")
-    t = _TestSpec()
-    t.test_forbidden_complex_types(connector_spec)
-    if should_fail:
-        conftest.pytest.fail.assert_called_once()
-    else:
-        conftest.pytest.fail.assert_not_called()
-
-
-@pytest.mark.parametrize(
-    "connector_spec, is_warning_logged",
-    (
-        ({"type": "object", "properties": {"date": {"type": "string"}}}, False),
-        ({"type": "object", "properties": {"date": {"type": "string", "format": "date"}}}, True),
-        ({"type": "object", "properties": {"date": {"type": "string", "format": "date-time"}}}, True),
-        (
-            {"type": "object", "properties": {"date": {"type": "string", "format": "date", "pattern": "^[0-9]{2}-[0-9]{2}-[0-9]{4}$"}}},
-            False,
-        ),
-        (
-            {
-                "type": "object",
-                "properties": {
-                    "date": {
-                        "type": "string",
-                        "format": "date-time",
-                        "pattern": "^[0-9]{4}-[0-9]{2}-[0-9]{2}(T[0-9]{2}:[0-9]{2}:[0-9]{2})?$",
-                    }
-                },
-            },
-            False,
-        ),
-        ({"type": "object", "properties": {"date": {"type": "string", "pattern": "^[0-9]{2}-[0-9]{2}-[0-9]{4}$"}}}, False),
-        (
-            {
-                "type": "object",
-                "properties": {"date": {"type": "string", "pattern": "^[0-9]{4}-[0-9]{2}-[0-9]{2}(T[0-9]{2}:[0-9]{2}:[0-9]{2})?$"}},
-            },
-            False,
-        ),
-    ),
-)
-def test_date_pattern(mocker, connector_spec, is_warning_logged):
-    mocker.patch.object(conftest.pytest, "fail")
-    logger = mocker.Mock()
-    t = _TestSpec()
-    t.test_date_pattern(connector_spec, logger)
-    conftest.pytest.fail.assert_not_called()
     if is_warning_logged:
         _, args, _ = logger.warning.mock_calls[0]
         msg, *_ = args
-        assert "Consider setting the pattern" in msg
-
-
-@pytest.mark.parametrize(
-    "connector_spec, is_warning_logged",
-    (
-        ({"type": "object", "properties": {"date": {"type": "string"}}}, False),
-        ({"type": "object", "properties": {"format": {"type": "string"}}}, False),
-        ({"type": "object", "properties": {"date": {"type": "string", "pattern": "[a-z]*"}}}, False),
-        (
-            {"type": "object", "properties": {"date": {"type": "string", "format": "date", "pattern": "^[0-9]{2}-[0-9]{2}-[0-9]{4}$"}}},
-            False,
-        ),
-        (
-            {
-                "type": "object",
-                "properties": {
-                    "date": {
-                        "type": "string",
-                        "format": "date-time",
-                        "pattern": "^[0-9]{4}-[0-9]{2}-[0-9]{2}(T[0-9]{2}:[0-9]{2}:[0-9]{2})?$",
-                    }
-                },
-            },
-            False,
-        ),
-        ({"type": "object", "properties": {"date": {"type": "string", "pattern": "^[0-9]{2}-[0-9]{2}-[0-9]{4}$"}}}, True),
-        (
-            {
-                "type": "object",
-                "properties": {"date": {"type": "string", "pattern": "^[0-9]{4}-[0-9]{2}-[0-9]{2}(T[0-9]{2}:[0-9]{2}:[0-9]{2})?$"}},
-            },
-            True,
-        ),
-    ),
-)
-def test_date_format(mocker, connector_spec, is_warning_logged):
-    mocker.patch.object(conftest.pytest, "fail")
-    logger = mocker.Mock()
-    t = _TestSpec()
-    t.test_date_format(connector_spec, logger)
-    conftest.pytest.fail.assert_not_called()
-    if is_warning_logged:
-        _, args, _ = logger.warning.mock_calls[0]
-        msg, *_ = args
-        assert "Consider specifying the format" in msg
+        assert "Some properties are marked with `airbyte_secret` although they probably should not be" in msg
+    else:
+        logger.warning.assert_not_called()
 
 
 @pytest.mark.parametrize(
@@ -922,15 +757,12 @@ def test_date_format(mocker, connector_spec, is_warning_logged):
         ("properties/start_date/type", "start_date", False),
         ("properties/credentials/oneOf/1/properties/api_token/type", "api_token", True),
         ("properties/type", None, False),  # root element
-        ("properties/accounts/items/2/properties/jwt/type", "jwt", True),
-    ),
+        ("properties/accounts/items/2/properties/jwt/type", "jwt", True)
+    )
 )
 def test_is_spec_property_name_secret(path, expected_name, expected_result):
     t = _TestSpec()
-    assert t._is_spec_property_name_secret(path, ("api_key", "api_token", "refresh_token", "jwt", "credentials")) == (
-        expected_name,
-        expected_result,
-    )
+    assert t._is_spec_property_name_secret(path, ("api_key", "api_token", "refresh_token", "jwt", "credentials")) == (expected_name, expected_result)
 
 
 @pytest.mark.parametrize(
@@ -943,12 +775,14 @@ def test_is_spec_property_name_secret(path, expected_name, expected_result):
         ({"type": "number"}, True),
         ({"type": ["null", "string"]}, True),
         ({"type": ["null", "boolean"]}, False),
-        ({"type": "object"}, False),
+        ({"type": "object"}, True),
+        # the object itself cannot hold a secret but the inner items can and will be processed separately
         ({"type": "object", "properties": {"api_key": {}}}, False),
-        ({"type": "array"}, False),
+        ({"type": "array"}, True),
+        # same as object
         ({"type": "array", "items": {"type": "string"}}, False),
-        ({"type": "string", "const": "OAuth2.0"}, False),
-    ),
+        ({"type": "string", "const": "OAuth2.0"}, False)
+    )
 )
 def test_property_can_store_secret(property_def, can_store_secret):
     t = _TestSpec()


### PR DESCRIPTION
This reverts commit fa2c03ab4ceb4bde6f0c34c8799b771ca4f81a14.

## What
* Reverts https://github.com/airbytehq/airbyte/pull/21451 because SATs are broken

```
file /Users/alex/code/airbyte/airbyte-integrations/bases/source-acceptance-test/source_acceptance_test/tests/test_core.py, line 396
      def test_date_format(self, connector_specification: dict, detailed_logger):
E       fixture 'connector_specification' not found
>       available fixtures: acceptance_test_config, actual_connector_spec, base_path, cache, cache_discovered_catalog, cached_schemas, capfd, capfdbinary, caplog, capsys, capsysbinary, class_mocker, configured_catalog, configured_catalog_path, connection_specification, connector_config, connector_config_path, connector_setup, connector_spec, connector_spec_dict, connector_spec_path, cov, detailed_logger, discovered_catalog, docker_runner, doctest_namespace, empty_streams, expect_records_config, expected_records_by_stream, image_tag, invalid_connector_config, invalid_connector_config_path, malformed_connector_config, mocker, module_mocker, monkeypatch, no_cover, package_mocker, previous_cached_schemas, previous_connector_docker_runner, previous_connector_image_name, previous_connector_spec, previous_discovered_catalog, pull_docker_image, pytestconfig, record_property, record_testsuite_property, record_xml_attribute, recwarn, requests_mock, secret_property_names, session_mocker, skip_backward_compatibility_tests, test_strictness_level, tmp_path, tmp_path_factory, tmpdir, tmpdir_factory
>       use 'pytest --fixtures [testpath]' for help on them.
```

## How
*Describe the solution*

## Recommended reading order
1. `x.java`
2. `y.python`

## 🚨 User Impact 🚨
Are there any breaking changes? What is the end result perceived by the user? If yes, please merge this PR with the 🚨🚨 emoji so changelog authors can further highlight this if needed.

## Pre-merge Checklist
Expand the relevant checklist and delete the others.

<details><summary><strong>New Connector</strong></summary>

### Community member or Airbyter

- [ ] **Community member?** Grant edit access to maintainers ([instructions](https://docs.github.com/en/github/collaborating-with-pull-requests/working-with-forks/allowing-changes-to-a-pull-request-branch-created-from-a-fork#enabling-repository-maintainer-permissions-on-existing-pull-requests))
- [ ] Secrets in the connector's spec are annotated with `airbyte_secret`
- [ ] Unit & integration tests added and passing. Community members, please provide proof of success locally e.g: screenshot or copy-paste unit, integration, and acceptance test output. To run acceptance tests for a Python connector, follow instructions in the README. For java connectors run `./gradlew :airbyte-integrations:connectors:<name>:integrationTest`.
- [ ] Code reviews completed
- [ ] Documentation updated
    - [ ] Connector's `README.md`
    - [ ] Connector's `bootstrap.md`. See [description and examples](https://docs.google.com/document/d/1ypdgmwmEHWv-TrO4_YOQ7pAJGVrMp5BOkEVh831N260/edit?usp=sharing)
    - [ ] `docs/integrations/<source or destination>/<name>.md` including changelog. See changelog [example](https://docs.airbyte.io/integrations/sources/stripe#changelog)
    - [ ] `docs/integrations/README.md`
    - [ ] `airbyte-integrations/builds.md`
- [ ] PR name follows [PR naming conventions](https://docs.airbyte.com/contributing-to-airbyte/issues-and-pull-requests)

### Airbyter

If this is a community PR, the Airbyte engineer reviewing this PR is responsible for the below items.

- [ ] Create a non-forked branch based on this PR and test the below items on it
- [ ] Build is successful
- [ ] If new credentials are required for use in CI, add them to GSM. [Instructions](https://docs.airbyte.io/connector-development#using-credentials-in-ci).
- [ ] [`/test connector=connectors/<name>` command](https://docs.airbyte.io/connector-development#updating-an-existing-connector) is passing
- [ ] New Connector version released on Dockerhub by running the `/publish` command described [here](https://docs.airbyte.io/connector-development#updating-an-existing-connector)
- [ ] After the connector is published, connector added to connector index as described [here](https://docs.airbyte.io/connector-development#publishing-a-connector)
- [ ] Seed specs have been re-generated by building the platform and committing the changes to the seed spec files, as described [here](https://docs.airbyte.io/connector-development#publishing-a-connector)

</details>

<details><summary><strong>Updating a connector</strong></summary>

### Community member or Airbyter

- [ ] Grant edit access to maintainers ([instructions](https://docs.github.com/en/github/collaborating-with-pull-requests/working-with-forks/allowing-changes-to-a-pull-request-branch-created-from-a-fork#enabling-repository-maintainer-permissions-on-existing-pull-requests))
- [ ] Secrets in the connector's spec are annotated with `airbyte_secret`
- [ ] Unit & integration tests added and passing. Community members, please provide proof of success locally e.g: screenshot or copy-paste unit, integration, and acceptance test output. To run acceptance tests for a Python connector, follow instructions in the README. For java connectors run `./gradlew :airbyte-integrations:connectors:<name>:integrationTest`.
- [ ] Code reviews completed
- [ ] Documentation updated
    - [ ] Connector's `README.md`
    - [ ] Connector's `bootstrap.md`. See [description and examples](https://docs.google.com/document/d/1ypdgmwmEHWv-TrO4_YOQ7pAJGVrMp5BOkEVh831N260/edit?usp=sharing)
    - [ ] Changelog updated in `docs/integrations/<source or destination>/<name>.md` including changelog. See changelog [example](https://docs.airbyte.io/integrations/sources/stripe#changelog)
- [ ] PR name follows [PR naming conventions](https://docs.airbyte.com/contributing-to-airbyte/issues-and-pull-requests)

### Airbyter

If this is a community PR, the Airbyte engineer reviewing this PR is responsible for the below items.

- [ ] Create a non-forked branch based on this PR and test the below items on it
- [ ] Build is successful
- [ ] If new credentials are required for use in CI, add them to GSM. [Instructions](https://docs.airbyte.io/connector-development#using-credentials-in-ci).
- [ ] [`/test connector=connectors/<name>` command](https://docs.airbyte.io/connector-development#updating-an-existing-connector) is passing
- [ ] New Connector version released on Dockerhub and connector version bumped by running the `/publish` command described [here](https://docs.airbyte.io/connector-development#updating-an-existing-connector)

</details>

<details><summary><strong>Connector Generator</strong></summary>

- [ ] Issue acceptance criteria met
- [ ] PR name follows [PR naming conventions](https://docs.airbyte.com/contributing-to-airbyte/issues-and-pull-requests)
- [ ] If adding a new generator, add it to the [list of scaffold modules being tested](https://github.com/airbytehq/airbyte/blob/master/airbyte-integrations/connector-templates/generator/build.gradle#L41)
- [ ] The generator test modules (all connectors with `-scaffold` in their name) have been updated with the latest scaffold by running `./gradlew :airbyte-integrations:connector-templates:generator:testScaffoldTemplates` then checking in your changes
- [ ] Documentation which references the generator is updated as needed

</details>

## Tests

<details><summary><strong>Unit</strong></summary>

*Put your unit tests output here.*

</details>

<details><summary><strong>Integration</strong></summary>

*Put your integration tests output here.*

</details>

<details><summary><strong>Acceptance</strong></summary>

*Put your acceptance tests output here.*

</details>
