### PR TITLE
Base Java S3: Update Avro TimeWithTimezone schema mapping

### DIFF
--- a/airbyte-integrations/bases/base-java-s3/src/main/java/io/airbyte/integrations/destination/s3/avro/JsonSchemaType.java
+++ b/airbyte-integrations/bases/base-java-s3/src/main/java/io/airbyte/integrations/destination/s3/avro/JsonSchemaType.java
@@ -23,7 +23,7 @@ public enum JsonSchemaType {
   DATE_V1("WellKnownTypes.json#/definitions/Date", Schema.Type.INT),
   TIMESTAMP_WITH_TIMEZONE_V1("WellKnownTypes.json#/definitions/TimestampWithTimezone", Schema.Type.LONG),
   TIMESTAMP_WITHOUT_TIMEZONE_V1("WellKnownTypes.json#/definitions/TimestampWithoutTimezone", Schema.Type.LONG),
-  TIME_WITH_TIMEZONE_V1("WellKnownTypes.json#/definitions/TimeWithTimezone", Schema.Type.LONG),
+  TIME_WITH_TIMEZONE_V1("WellKnownTypes.json#/definitions/TimeWithTimezone", Schema.Type.STRING),
   TIME_WITHOUT_TIMEZONE_V1("WellKnownTypes.json#/definitions/TimeWithoutTimezone", Schema.Type.LONG),
   OBJECT("object", Schema.Type.RECORD),
   ARRAY("array", Schema.Type.ARRAY),

--- a/airbyte-integrations/bases/base-java-s3/src/main/java/io/airbyte/integrations/destination/s3/avro/JsonToAvroSchemaConverter.java
+++ b/airbyte-integrations/bases/base-java-s3/src/main/java/io/airbyte/integrations/destination/s3/avro/JsonToAvroSchemaConverter.java
@@ -225,11 +225,11 @@ public class JsonToAvroSchemaConverter {
 
     final Schema fieldSchema;
     switch (fieldType) {
-      case INTEGER_V1, NUMBER_V1, BOOLEAN_V1, STRING_V1, BINARY_DATA_V1 -> fieldSchema = Schema.create(fieldType.getAvroType());
+      case INTEGER_V1, NUMBER_V1, BOOLEAN_V1, STRING_V1, TIME_WITH_TIMEZONE_V1, BINARY_DATA_V1 -> fieldSchema = Schema.create(fieldType.getAvroType());
       case DATE_V1 -> fieldSchema = LogicalTypes.date().addToSchema(Schema.create(Schema.Type.INT));
       case TIMESTAMP_WITH_TIMEZONE_V1, TIMESTAMP_WITHOUT_TIMEZONE_V1 -> fieldSchema = LogicalTypes.timestampMicros()
           .addToSchema(Schema.create(Schema.Type.LONG));
-      case TIME_WITH_TIMEZONE_V1, TIME_WITHOUT_TIMEZONE_V1 -> fieldSchema = LogicalTypes.timeMicros().addToSchema(Schema.create(Schema.Type.LONG));
+      case TIME_WITHOUT_TIMEZONE_V1 -> fieldSchema = LogicalTypes.timeMicros().addToSchema(Schema.create(Schema.Type.LONG));
       case INTEGER_V0, NUMBER_V0, NUMBER_INT_V0, NUMBER_BIGINT_V0, NUMBER_FLOAT_V0, BOOLEAN_V0 -> fieldSchema =
           Schema.create(fieldType.getAvroType());
       case STRING_V0 -> {

--- a/airbyte-integrations/bases/base-java-s3/src/main/java/io/airbyte/integrations/destination/s3/avro/JsonToAvroSchemaConverter.java
+++ b/airbyte-integrations/bases/base-java-s3/src/main/java/io/airbyte/integrations/destination/s3/avro/JsonToAvroSchemaConverter.java
@@ -225,7 +225,8 @@ public class JsonToAvroSchemaConverter {
 
     final Schema fieldSchema;
     switch (fieldType) {
-      case INTEGER_V1, NUMBER_V1, BOOLEAN_V1, STRING_V1, TIME_WITH_TIMEZONE_V1, BINARY_DATA_V1 -> fieldSchema = Schema.create(fieldType.getAvroType());
+      case INTEGER_V1, NUMBER_V1, BOOLEAN_V1, STRING_V1, TIME_WITH_TIMEZONE_V1, BINARY_DATA_V1 -> fieldSchema =
+          Schema.create(fieldType.getAvroType());
       case DATE_V1 -> fieldSchema = LogicalTypes.date().addToSchema(Schema.create(Schema.Type.INT));
       case TIMESTAMP_WITH_TIMEZONE_V1, TIMESTAMP_WITHOUT_TIMEZONE_V1 -> fieldSchema = LogicalTypes.timestampMicros()
           .addToSchema(Schema.create(Schema.Type.LONG));

--- a/airbyte-integrations/bases/base-java-s3/src/test/resources/parquet/json_schema_converter/type_conversion_test_cases_v1.json
+++ b/airbyte-integrations/bases/base-java-s3/src/test/resources/parquet/json_schema_converter/type_conversion_test_cases_v1.json
@@ -204,9 +204,7 @@
     "jsonFieldSchema": {
       "$ref": "WellKnownTypes.json#/definitions/TimeWithTimezone"
     },
-    "avroFieldType": [
-      "null", "string"
-    ]
+    "avroFieldType": ["null", "string"]
   },
   {
     "fieldName": "array_field_without_items",

--- a/airbyte-integrations/bases/base-java-s3/src/test/resources/parquet/json_schema_converter/type_conversion_test_cases_v1.json
+++ b/airbyte-integrations/bases/base-java-s3/src/test/resources/parquet/json_schema_converter/type_conversion_test_cases_v1.json
@@ -205,9 +205,7 @@
       "$ref": "WellKnownTypes.json#/definitions/TimeWithTimezone"
     },
     "avroFieldType": [
-      "null",
-      { "type": "long", "logicalType": "time-micros" },
-      "string"
+      "null", "string"
     ]
   },
   {

--- a/airbyte-integrations/bases/standard-destination-test/src/main/java/io/airbyte/integrations/standardtest/destination/comparator/AdvancedTestDataComparator.java
+++ b/airbyte-integrations/bases/standard-destination-test/src/main/java/io/airbyte/integrations/standardtest/destination/comparator/AdvancedTestDataComparator.java
@@ -105,8 +105,10 @@ public class AdvancedTestDataComparator implements TestDataComparator {
       return compareDateTimeValues(expectedValue.asText(), actualValue.asText());
     } else if (isDateValue(expectedValue.asText())) {
       return compareDateValues(expectedValue.asText(), actualValue.asText());
-    } else if (isTimeWithTimezone(expectedValue.asText()) || isTimeWithoutTimezone(expectedValue.asText())) {
-      return compareTime(expectedValue.asText(), actualValue.asText());
+    } else if (isTimeWithTimezone(expectedValue.asText())) {
+      return compareTimeWithTimeZone(expectedValue.asText(), actualValue.asText());
+    } else if (isTimeWithoutTimezone(expectedValue.asText())) {
+      return compareTimeWithoutTimeZone(expectedValue.asText(), actualValue.asText());
     } else if (expectedValue.isArray()) {
       return compareArrays(expectedValue, actualValue);
     } else if (expectedValue.isObject()) {
@@ -215,7 +217,11 @@ public class AdvancedTestDataComparator implements TestDataComparator {
     return compareTextValues(airbyteMessageValue, destinationValue);
   }
 
-  protected boolean compareTime(final String airbyteMessageValue, final String destinationValue) {
+  protected boolean compareTimeWithoutTimeZone(final String airbyteMessageValue, final String destinationValue) {
+    return compareTextValues(airbyteMessageValue, destinationValue);
+  }
+
+  protected boolean compareTimeWithTimeZone(final String airbyteMessageValue, final String destinationValue) {
     return compareTextValues(airbyteMessageValue, destinationValue);
   }
 

--- a/airbyte-integrations/connectors/destination-gcs/src/test-integration/java/io/airbyte/integrations/destination/gcs/GcsAvroTestDataComparator.java
+++ b/airbyte-integrations/connectors/destination-gcs/src/test-integration/java/io/airbyte/integrations/destination/gcs/GcsAvroTestDataComparator.java
@@ -37,7 +37,7 @@ public class GcsAvroTestDataComparator extends AdvancedTestDataComparator {
   }
 
   @Override
-  protected boolean compareTime(final String airbyteMessageValue, final String destinationValue) {
+  protected boolean compareTimeWithoutTimeZone(final String airbyteMessageValue, final String destinationValue) {
     LocalTime destinationDate = LocalTime.ofInstant(getInstantFromEpoch(destinationValue), ZoneOffset.UTC);
     LocalTime expectedDate = LocalTime.parse(airbyteMessageValue, DateTimeFormatter.ISO_TIME);
     return expectedDate.equals(destinationDate);

--- a/airbyte-integrations/connectors/destination-s3/src/test-integration/java/io/airbyte/integrations/destination/s3/S3AvroParquetTestDataComparator.java
+++ b/airbyte-integrations/connectors/destination-s3/src/test-integration/java/io/airbyte/integrations/destination/s3/S3AvroParquetTestDataComparator.java
@@ -41,7 +41,7 @@ public class S3AvroParquetTestDataComparator extends AdvancedTestDataComparator 
   }
 
   @Override
-  protected boolean compareTime(final String airbyteMessageValue, final String destinationValue) {
+  protected boolean compareTimeWithoutTimeZone(final String airbyteMessageValue, final String destinationValue) {
     var destinationDate = LocalTime.ofInstant(getInstantFromEpoch(destinationValue), ZoneOffset.UTC);
     var expectedDate = LocalTime.parse(airbyteMessageValue, DateTimeFormatter.ISO_TIME);
     return expectedDate.equals(destinationDate);


### PR DESCRIPTION
## What
Current mapping for S3 Avro TimeWithTimezone type is:
`TIME_WITH_TIMEZONE_V1("WellKnownTypes.json#/definitions/TimeWithTimezone", Schema.Type.LONG)`
However for most of destinations the time with time zone is stored as a String type since most of those connectors does not support the format like: `01:23:45.678-10:30` .  
This become an issue when we use upload Avro files for Bigquery Denormalized. For storing time with time zone we have to use STRING type in Bigquery and Avro used LONG and as a result sync will fail with type mismatch.

## How
Update the S3 Avro TimeWithTimezone mapping to: 
`TIME_WITH_TIMEZONE_V1("WellKnownTypes.json#/definitions/TimeWithTimezone", Schema.Type.String)`
Here is an example how normalization handle time with time zone: 
```
{% macro default__type_time_with_timezone() %}
    time with time zone
{% endmacro %}

{%- macro mysql__type_time_with_timezone() -%}
    char(1024)
{%- endmacro -%}

{%- macro sqlserver__type_time_with_timezone() -%}
    NVARCHAR(max)
{%- endmacro -%}

{% macro bigquery__type_time_with_timezone() %}
    STRING
{% endmacro %}

{% macro oracle__type_time_with_timezone() %}
    varchar2(4000)
{% endmacro %}

{% macro snowflake__type_time_with_timezone() %}
    varchar
{% endmacro %}

{% macro redshift__type_time_with_timezone() %}
    TIMETZ
{% endmacro %}

{% macro clickhouse__type_time_with_timezone() %}
    String
{% endmacro %}

{%- macro tidb__type_time_with_timezone() -%}
    char(1000)
{%- endmacro -%}

```
Most of normilized connectors using string/varchar type so maybe we could do the same way for Avro staging.

## Recommended reading order
1. `JsonSchemaType.java` - new type mapping 
2. `JsonToAvroSchemaConverter.java` - removed `LogicalTypes` for TIME_WITH_TIMEZONE_V1
3. Other just tests adaptation 

## 🚨 User Impact 🚨
Since the V1 protocol is not yet used no user impact
