### PR TITLE
Revert `allowedHosts` missing value checks

### DIFF
--- a/airbyte-workers/src/main/java/io/airbyte/workers/utils/ConfigReplacer.java
+++ b/airbyte-workers/src/main/java/io/airbyte/workers/utils/ConfigReplacer.java
@@ -48,10 +48,6 @@ public class ConfigReplacer {
     final List<String> hosts = allowedHosts.getHosts();
     for (String host : hosts) {
       final String replacedString = sub.replace(host);
-      if (replacedString.contains("${")) {
-        throw new IOException(
-            "The allowed host value, '" + host + "', is expecting an interpolation value from the connector's configuration, but none is present");
-      }
       resolvedHosts.add(replacedString);
     }
 

--- a/airbyte-workers/src/test/java/io/airbyte/workers/utils/ConfigReplacerTest.java
+++ b/airbyte-workers/src/test/java/io/airbyte/workers/utils/ConfigReplacerTest.java
@@ -42,23 +42,4 @@ class ConfigReplacerTest {
     assertThat(response.getHosts()).isEqualTo(expected);
   }
 
-  @Test()
-  void getAllowedHostsMissingValue() throws IOException {
-    final AllowedHosts allowedHosts = new AllowedHosts();
-    final List<String> hosts = new ArrayList();
-    hosts.add("${subdomain}.vendor.com");
-    allowedHosts.setHosts(hosts);
-
-    final String configJson = "{\"password\": \"abc123\"}";
-    final JsonNode config = mapper.readValue(configJson, JsonNode.class);
-
-    try {
-      replacer.getAllowedHosts(allowedHosts, config);
-      throw new RuntimeException("should not get here");
-    } catch (Exception e) {
-      assertThat(e).hasMessage(
-          "The allowed host value, '${subdomain}.vendor.com', is expecting an interpolation value from the connector's configuration, but none is present");
-    }
-  }
-
 }


### PR DESCRIPTION
https://github.com/airbytehq/airbyte/pull/21676 introduced a check to ensure that the interpolated values required for allowedHosts from connector configs was present, and threw an error if missing. This caused on call errors (https://github.com/airbytehq/oncall/issues/1373).

This PR removes that check as we aren't yet requiring this data to build the firewalls.  A deeper analysis of the problem will be done in https://github.com/airbytehq/airbyte/issues/21921