### PR TITLE
Support config sub-values for `allowedHosts`

### DIFF
--- a/airbyte-config/init/src/main/resources/seed/source_definitions.yaml
+++ b/airbyte-config/init/src/main/resources/seed/source_definitions.yaml
@@ -1349,6 +1349,7 @@
   allowedHosts:
     hosts:
       - "${host}"
+      - "${tunnel_method.tunnel_host}"
 - name: Postmark App
   sourceDefinitionId: cde75ca1-1e28-4a0f-85bb-90c546de9f1f
   dockerRepository: airbyte/source-postmarkapp

--- a/airbyte-workers/src/main/java/io/airbyte/workers/utils/ConfigReplacer.java
+++ b/airbyte-workers/src/main/java/io/airbyte/workers/utils/ConfigReplacer.java
@@ -35,18 +35,34 @@ public class ConfigReplacer {
    * for a connector has a single depth.
    */
   public AllowedHosts getAllowedHosts(AllowedHosts allowedHosts, JsonNode config) throws IOException {
-    if (allowedHosts == null || allowedHosts.getHosts() == null) {
+    if (allowedHosts == null || allowedHosts.getHosts() == null || allowedHosts.getHosts().size() == 0) {
       return null;
     }
 
     final List<String> resolvedHosts = new ArrayList<>();
     final Map<String, String> valuesMap = new HashMap<>();
     final JsonParser jsonParser = config.traverse();
+
+    List<String> prefixes = new ArrayList<>();
     while (!jsonParser.isClosed()) {
-      if (jsonParser.nextToken() == JsonToken.FIELD_NAME) {
+      final JsonToken type = jsonParser.nextToken();
+      if (type == JsonToken.FIELD_NAME) {
         final String key = jsonParser.getCurrentName();
-        if (config.get(key) != null) {
-          valuesMap.put(key, config.get(key).textValue());
+        // the interface for allowedHosts is dot notation, e.g. `"${tunnel_method.tunnel_host}"`
+        final String fullKey = (prefixes.isEmpty() ? "" : String.join(".", prefixes) + ".") + key;
+        // the search path for JSON nodes is slash notation, e.g. `"/tunnel_method/tunnel_host"`
+        final String lookupKey = "/" + (prefixes.isEmpty() ? "" : String.join("/", prefixes) + "/") + key;
+        final String value = config.at(lookupKey).textValue();
+        if (value != null) {
+          valuesMap.put(fullKey, value);
+        }
+      } else if (type == JsonToken.START_OBJECT) {
+        if (jsonParser.getCurrentName() != null) {
+          prefixes.add(jsonParser.getCurrentName());
+        }
+      } else if (type == JsonToken.END_OBJECT) {
+        if (!prefixes.isEmpty()) {
+          prefixes.remove(prefixes.size() - 1);
         }
       }
     }
@@ -55,11 +71,14 @@ public class ConfigReplacer {
     final List<String> hosts = allowedHosts.getHosts();
     for (String host : hosts) {
       final String replacedString = sub.replace(host);
-      if (replacedString.contains("${")) {
-        this.logger.error(
-            "The allowedHost value, '" + host + "', is expecting an interpolation value from the connector's configuration, but none is present");
+      if (!replacedString.contains("${")) {
+        resolvedHosts.add(replacedString);
       }
-      resolvedHosts.add(replacedString);
+    }
+
+    if (resolvedHosts.isEmpty()) {
+      this.logger.error(
+          "All allowedHosts values are un-replaced.  Check this connector's configuration or actor definition - " + allowedHosts.getHosts());
     }
 
     final AllowedHosts resolvedAllowedHosts = new AllowedHosts();

--- a/airbyte-workers/src/main/java/io/airbyte/workers/utils/ConfigReplacer.java
+++ b/airbyte-workers/src/main/java/io/airbyte/workers/utils/ConfigReplacer.java
@@ -52,7 +52,15 @@ public class ConfigReplacer {
         final String fullKey = (prefixes.isEmpty() ? "" : String.join(".", prefixes) + ".") + key;
         // the search path for JSON nodes is slash notation, e.g. `"/tunnel_method/tunnel_host"`
         final String lookupKey = "/" + (prefixes.isEmpty() ? "" : String.join("/", prefixes) + "/") + key;
-        final String value = config.at(lookupKey).textValue();
+
+        String value = config.at(lookupKey).textValue();
+        if (value == null) {
+          final Number numberValue = config.at(lookupKey).numberValue();
+          if (numberValue != null) {
+            value = numberValue.toString();
+          }
+        }
+
         if (value != null) {
           valuesMap.put(fullKey, value);
         }

--- a/airbyte-workers/src/main/java/io/airbyte/workers/utils/ConfigReplacer.java
+++ b/airbyte-workers/src/main/java/io/airbyte/workers/utils/ConfigReplacer.java
@@ -35,7 +35,7 @@ public class ConfigReplacer {
    * for a connector has a single depth.
    */
   public AllowedHosts getAllowedHosts(AllowedHosts allowedHosts, JsonNode config) throws IOException {
-    if (allowedHosts == null || allowedHosts.getHosts() == null || allowedHosts.getHosts().size() == 0) {
+    if (allowedHosts == null || allowedHosts.getHosts() == null) {
       return null;
     }
 
@@ -84,7 +84,7 @@ public class ConfigReplacer {
       }
     }
 
-    if (resolvedHosts.isEmpty()) {
+    if (resolvedHosts.isEmpty() && !hosts.isEmpty()) {
       this.logger.error(
           "All allowedHosts values are un-replaced.  Check this connector's configuration or actor definition - " + allowedHosts.getHosts());
     }

--- a/airbyte-workers/src/test/java/io/airbyte/workers/utils/ConfigReplacerTest.java
+++ b/airbyte-workers/src/test/java/io/airbyte/workers/utils/ConfigReplacerTest.java
@@ -31,6 +31,7 @@ class ConfigReplacerTest {
     hosts.add("localhost");
     hosts.add("static-site.com");
     hosts.add("${host}");
+    hosts.add("${number}");
     hosts.add("${subdomain}.vendor.com");
     hosts.add("${tunnel_method.tunnel_host}");
     allowedHosts.setHosts(hosts);
@@ -39,11 +40,12 @@ class ConfigReplacerTest {
     expected.add("localhost");
     expected.add("static-site.com");
     expected.add("foo.com");
+    expected.add("123");
     expected.add("account.vendor.com");
     expected.add("1.2.3.4");
 
     final String configJson =
-        "{\"host\": \"foo.com\", \"subdomain\": \"account\", \"password\": \"abc123\", \"tunnel_method\": {\"tunnel_host\": \"1.2.3.4\"}}";
+        "{\"host\": \"foo.com\", \"number\": 123, \"subdomain\": \"account\", \"password\": \"abc123\", \"tunnel_method\": {\"tunnel_host\": \"1.2.3.4\"}}";
     final JsonNode config = mapper.readValue(configJson, JsonNode.class);
     final AllowedHosts response = replacer.getAllowedHosts(allowedHosts, config);
 

--- a/airbyte-workers/src/test/java/io/airbyte/workers/utils/ConfigReplacerTest.java
+++ b/airbyte-workers/src/test/java/io/airbyte/workers/utils/ConfigReplacerTest.java
@@ -69,4 +69,17 @@ class ConfigReplacerTest {
     assertThat(response.getHosts()).isEqualTo(expected);
   }
 
+  @Test
+  void ensureEmptyArrayRemains() throws IOException {
+    final AllowedHosts allowedHosts = new AllowedHosts();
+    allowedHosts.setHosts(new ArrayList());
+    final List<String> expected = new ArrayList<>();
+
+    final String configJson = "{}";
+    final JsonNode config = mapper.readValue(configJson, JsonNode.class);
+    final AllowedHosts response = replacer.getAllowedHosts(allowedHosts, config);
+
+    assertThat(response.getHosts()).isEqualTo(expected);
+  }
+
 }

--- a/airbyte-workers/src/test/java/io/airbyte/workers/utils/ConfigReplacerTest.java
+++ b/airbyte-workers/src/test/java/io/airbyte/workers/utils/ConfigReplacerTest.java
@@ -24,6 +24,7 @@ class ConfigReplacerTest {
   final ObjectMapper mapper = new ObjectMapper();
 
   @Test
+  @SuppressWarnings("PMD.AvoidUsingHardCodedIP")
   void getAllowedHostsGeneralTest() throws IOException {
     final AllowedHosts allowedHosts = new AllowedHosts();
     final List<String> hosts = new ArrayList();
@@ -31,6 +32,7 @@ class ConfigReplacerTest {
     hosts.add("static-site.com");
     hosts.add("${host}");
     hosts.add("${subdomain}.vendor.com");
+    hosts.add("${tunnel_method.tunnel_host}");
     allowedHosts.setHosts(hosts);
 
     final List<String> expected = new ArrayList<>();
@@ -38,8 +40,27 @@ class ConfigReplacerTest {
     expected.add("static-site.com");
     expected.add("foo.com");
     expected.add("account.vendor.com");
+    expected.add("1.2.3.4");
 
-    final String configJson = "{\"host\": \"foo.com\", \"subdomain\": \"account\", \"password\": \"abc123\"}";
+    final String configJson =
+        "{\"host\": \"foo.com\", \"subdomain\": \"account\", \"password\": \"abc123\", \"tunnel_method\": {\"tunnel_host\": \"1.2.3.4\"}}";
+    final JsonNode config = mapper.readValue(configJson, JsonNode.class);
+    final AllowedHosts response = replacer.getAllowedHosts(allowedHosts, config);
+
+    assertThat(response.getHosts()).isEqualTo(expected);
+  }
+
+  @Test
+  void getAllowedHostsNestingTest() throws IOException {
+    final AllowedHosts allowedHosts = new AllowedHosts();
+    final List<String> hosts = new ArrayList();
+    hosts.add("value-${a.b.c.d}");
+    allowedHosts.setHosts(hosts);
+
+    final List<String> expected = new ArrayList<>();
+    expected.add("value-100");
+
+    final String configJson = "{\"a\": {\"b\": {\"c\": {\"d\": 100 }}}, \"array\": [1,2,3]}";
     final JsonNode config = mapper.readValue(configJson, JsonNode.class);
     final AllowedHosts response = replacer.getAllowedHosts(allowedHosts, config);
 


### PR DESCRIPTION
Following https://github.com/airbytehq/airbyte/pull/21676 and closes https://github.com/airbytehq/airbyte/issues/21913, this PR adds support for allowedHosts that come from sub-keys in the connector's configuration.  

For example, configs for postgres sources which use SSH tunnels might look like:

```json
{
  "ssl": false,
  "host": "real-server-ip.com",
  "port": 5432,
  "schemas": [ "public" ],
  "database": "datawarehouse",
  "password": { "_secret": "..." },
  "ssl_mode": { "mode": "disable" },
  "username": "db-username",
  "tunnel_method": {
    "tunnel_host": "1.2.3.4",
    "tunnel_port": 22,
    "tunnel_user": "ssh-username",
    "tunnel_method": "SSH_PASSWORD_AUTH",
    "tunnel_user_password": { "_secret": "..." }
  },
}
```

Which means allowedHosts should support both `host` and `tunnel_method.tunnel_host`.