### PR TITLE
add attempt created to used codepath

### DIFF
--- a/airbyte-workers/src/main/java/io/airbyte/workers/temporal/scheduling/activities/JobCreationAndStatusUpdateActivityImpl.java
+++ b/airbyte-workers/src/main/java/io/airbyte/workers/temporal/scheduling/activities/JobCreationAndStatusUpdateActivityImpl.java
@@ -223,12 +223,13 @@ public class JobCreationAndStatusUpdateActivityImpl implements JobCreationAndSta
     try {
       final long jobId = input.getJobId();
       ApmTraceUtils.addTagsToTrace(Map.of(JOB_ID_KEY, jobId));
-      final Job createdJob = jobPersistence.getJob(jobId);
+      final Job job = jobPersistence.getJob(jobId);
 
-      final WorkerRun workerRun = temporalWorkerRunFactory.create(createdJob);
+      final WorkerRun workerRun = temporalWorkerRunFactory.create(job);
       final Path logFilePath = workerRun.getJobRoot().resolve(LogClientSingleton.LOG_FILENAME);
       final int persistedAttemptNumber = jobPersistence.createAttempt(jobId, logFilePath);
       emitJobIdToReleaseStagesMetric(OssMetricsRegistry.ATTEMPT_CREATED_BY_RELEASE_STAGE, jobId);
+      emitAttemptCreatedEvent(job, persistedAttemptNumber);
 
       LogClientSingleton.getInstance().setJobMdc(workerEnvironment, logConfigs, workerRun.getJobRoot());
       return new AttemptNumberCreationOutput(persistedAttemptNumber);


### PR DESCRIPTION
Looks like I added the call to emit an attempt_created event in the wrong spot. I think it was a dead code path. Added to the real code path. Scheduled message in dev-platform-move to follow up on whether the dead code path can be removed.