### PR TITLE
Source Netsuite: retry with next dateformat in list `%Y-%m-%d`

### DIFF
--- a/airbyte-integrations/connectors/source-netsuite/Dockerfile
+++ b/airbyte-integrations/connectors/source-netsuite/Dockerfile
@@ -35,5 +35,5 @@ COPY source_netsuite ./source_netsuite
 ENV AIRBYTE_ENTRYPOINT "python /airbyte/integration_code/main.py"
 ENTRYPOINT ["python", "/airbyte/integration_code/main.py"]
 
-LABEL io.airbyte.version=0.1.3
+LABEL io.airbyte.version=0.1.4
 LABEL io.airbyte.name=airbyte/source-netsuite

--- a/airbyte-integrations/connectors/source-netsuite/source_netsuite/streams.py
+++ b/airbyte-integrations/connectors/source-netsuite/source_netsuite/streams.py
@@ -184,9 +184,10 @@ class NetsuiteStream(HttpStream, ABC):
                         self.index_datetime_format += 1
                         if self.index_datetime_format < len(NETSUITE_INPUT_DATE_FORMATS):
                             self.logger.warn(f"Stream `{self.name}`: retry using next date format `{self.default_datetime_format}")
-                            raise DateFormatExeption
+                            return True
                         else:
                             self.logger.error(f"DATE FORMAT exception. Cannot read using known formats {NETSUITE_INPUT_DATE_FORMATS}")
+                            raise DateFormatExeption
 
                     # handle other known errors
                     self.logger.error(f"Stream `{self.name}`: {error_code} error occured, full error message: {detail_message}")

--- a/docs/integrations/sources/netsuite.md
+++ b/docs/integrations/sources/netsuite.md
@@ -123,8 +123,9 @@ The connector is restricted by Netsuite [Concurrency Limit per Integration](http
 
 ## Changelog
 
-| Version | Date       | Pull Request                                             | Subject                     |
-| :------ | :--------- | :------------------------------------------------------- | :-------------------------- |
+| Version | Date       | Pull Request                                             | Subject                                                   |
+|:--------|:-----------|:---------------------------------------------------------|:----------------------------------------------------------|
+| 0.1.4   | 2023-01-27 | [21968](https://github.com/airbytehq/airbyte/pull/21968) | Dateformat issue fix                                      |
 | 0.1.3   | 2023-01-20 | [21645](https://github.com/airbytehq/airbyte/pull/21645) | Minor issues fix, Setup Guide corrections for public docs |
-| 0.1.1   | 2022-09-28 | [17304](https://github.com/airbytehq/airbyte/pull/17304) | Migrate to per-stream state |
-| 0.1.0   | 2022-09-15 | [16093](https://github.com/airbytehq/airbyte/pull/16093) | Initial Alpha release       |
+| 0.1.1   | 2022-09-28 | [17304](https://github.com/airbytehq/airbyte/pull/17304) | Migrate to per-stream state                               |
+| 0.1.0   | 2022-09-15 | [16093](https://github.com/airbytehq/airbyte/pull/16093) | Initial Alpha release                                     |


### PR DESCRIPTION
## What
[Issue: Netsuite source connector dateformat error](https://github.com/airbytehq/airbyte/issues/21965)

## How
Return true to retry with next dateformat in list, and only when reaches the end of the list raise the exception.

## Pre-merge Checklist

### Community member or Airbyter

- [X] Grant edit access to maintainers ([instructions](https://docs.github.com/en/github/collaborating-with-pull-requests/working-with-forks/allowing-changes-to-a-pull-request-branch-created-from-a-fork#enabling-repository-maintainer-permissions-on-existing-pull-requests))
- [X] Secrets in the connector's spec are annotated with `airbyte_secret`
- [X] Unit & integration tests added and passing. Community members, please provide proof of success locally e.g: screenshot or copy-paste unit, integration, and acceptance test output. To run acceptance tests for a Python connector, follow instructions in the README. For java connectors run `./gradlew :airbyte-integrations:connectors:<name>:integrationTest`.
- [ ] Code reviews completed
- [X] Documentation updated
    - [X] Connector's `README.md`
    - [X] Connector's `bootstrap.md`. See [description and examples](https://docs.google.com/document/d/1ypdgmwmEHWv-TrO4_YOQ7pAJGVrMp5BOkEVh831N260/edit?usp=sharing)
    - [X] Changelog updated in `docs/integrations/<source or destination>/<name>.md` including changelog. See changelog [example](https://docs.airbyte.io/integrations/sources/stripe#changelog)
- [X] PR name follows [PR naming conventions](https://docs.airbyte.com/contributing-to-airbyte/issues-and-pull-requests)

### Airbyter

If this is a community PR, the Airbyte engineer reviewing this PR is responsible for the below items.

- [ ] Create a non-forked branch based on this PR and test the below items on it
- [ ] Build is successful
- [ ] If new credentials are required for use in CI, add them to GSM. [Instructions](https://docs.airbyte.io/connector-development#using-credentials-in-ci).
- [ ] [`/test connector=connectors/<name>` command](https://docs.airbyte.io/connector-development#updating-an-existing-connector) is passing
- [ ] New Connector version released on Dockerhub and connector version bumped by running the `/publish` command described [here](https://docs.airbyte.io/connector-development#updating-an-existing-connector)

</details>
