### PR TITLE
`AlwaysAllowedHosts`

### DIFF
--- a/airbyte-config/config-models/src/main/java/io/airbyte/config/constants/AlwaysAllowedHosts.java
+++ b/airbyte-config/config-models/src/main/java/io/airbyte/config/constants/AlwaysAllowedHosts.java
@@ -1,0 +1,27 @@
+/*
+ * Copyright (c) 2022 Airbyte, Inc., all rights reserved.
+ */
+
+package io.airbyte.config.constants;
+
+import java.util.ArrayList;
+import java.util.List;
+
+public class AlwaysAllowedHosts {
+
+  private final List<String> hosts = new ArrayList<>();
+
+  public AlwaysAllowedHosts() {
+    // DataDog. See https://docs.datadoghq.com/agent/proxy/?tab=linux and change the location tabs
+    hosts.add("*.datadoghq.com");
+    hosts.add("*.datadoghq.eu");
+
+    // Sentry.  See https://docs.sentry.io/api/ for more information
+    hosts.add("*.sentry.io");
+  }
+
+  public List<String> getHosts() {
+    return hosts;
+  }
+
+}

--- a/airbyte-config/config-models/src/main/java/io/airbyte/config/constants/AlwaysAllowedHosts.java
+++ b/airbyte-config/config-models/src/main/java/io/airbyte/config/constants/AlwaysAllowedHosts.java
@@ -4,21 +4,17 @@
 
 package io.airbyte.config.constants;
 
-import java.util.ArrayList;
 import java.util.List;
 
 public class AlwaysAllowedHosts {
 
-  private final List<String> hosts = new ArrayList<>();
+  private final List<String> hosts = List.of(
+      // DataDog. See https://docs.datadoghq.com/agent/proxy/?tab=linux and change the location tabs
+      "*.datadoghq.com",
+      "*.datadoghq.eu",
 
-  public AlwaysAllowedHosts() {
-    // DataDog. See https://docs.datadoghq.com/agent/proxy/?tab=linux and change the location tabs
-    hosts.add("*.datadoghq.com");
-    hosts.add("*.datadoghq.eu");
-
-    // Sentry. See https://docs.sentry.io/api/ for more information
-    hosts.add("*.sentry.io");
-  }
+      // Sentry. See https://docs.sentry.io/api/ for more information
+      "*.sentry.io");
 
   public List<String> getHosts() {
     return hosts;

--- a/airbyte-config/config-models/src/main/java/io/airbyte/config/constants/AlwaysAllowedHosts.java
+++ b/airbyte-config/config-models/src/main/java/io/airbyte/config/constants/AlwaysAllowedHosts.java
@@ -16,7 +16,7 @@ public class AlwaysAllowedHosts {
     hosts.add("*.datadoghq.com");
     hosts.add("*.datadoghq.eu");
 
-    // Sentry.  See https://docs.sentry.io/api/ for more information
+    // Sentry. See https://docs.sentry.io/api/ for more information
     hosts.add("*.sentry.io");
   }
 

--- a/airbyte-workers/src/main/java/io/airbyte/workers/utils/ConfigReplacer.java
+++ b/airbyte-workers/src/main/java/io/airbyte/workers/utils/ConfigReplacer.java
@@ -8,6 +8,7 @@ import com.fasterxml.jackson.core.JsonParser;
 import com.fasterxml.jackson.core.JsonToken;
 import com.fasterxml.jackson.databind.JsonNode;
 import io.airbyte.config.AllowedHosts;
+import io.airbyte.config.constants.AlwaysAllowedHosts;
 import java.io.IOException;
 import java.util.ArrayList;
 import java.util.HashMap;
@@ -24,6 +25,8 @@ import org.slf4j.Logger;
 public class ConfigReplacer {
 
   private final Logger logger;
+  private final AlwaysAllowedHosts alwaysAllowedHosts = new AlwaysAllowedHosts();
+
 
   public ConfigReplacer(Logger logger) {
     this.logger = logger;
@@ -88,6 +91,8 @@ public class ConfigReplacer {
       this.logger.error(
           "All allowedHosts values are un-replaced.  Check this connector's configuration or actor definition - " + allowedHosts.getHosts());
     }
+
+    resolvedHosts.addAll(alwaysAllowedHosts.getHosts());
 
     final AllowedHosts resolvedAllowedHosts = new AllowedHosts();
     resolvedAllowedHosts.setHosts(resolvedHosts);

--- a/airbyte-workers/src/main/java/io/airbyte/workers/utils/ConfigReplacer.java
+++ b/airbyte-workers/src/main/java/io/airbyte/workers/utils/ConfigReplacer.java
@@ -27,7 +27,6 @@ public class ConfigReplacer {
   private final Logger logger;
   private final AlwaysAllowedHosts alwaysAllowedHosts = new AlwaysAllowedHosts();
 
-
   public ConfigReplacer(Logger logger) {
     this.logger = logger;
   }

--- a/airbyte-workers/src/test/java/io/airbyte/workers/utils/ConfigReplacerTest.java
+++ b/airbyte-workers/src/test/java/io/airbyte/workers/utils/ConfigReplacerTest.java
@@ -98,4 +98,16 @@ class ConfigReplacerTest {
     assertThat(response).isEqualTo(null);
   }
 
+  @Test
+  void alwaysAllowedHostsListIsImmutable() {
+    List<String> hosts = alwaysAllowedHosts.getHosts();
+
+    try {
+      hosts.add("foo.com");
+      throw new IOException("should not get here");
+    } catch (Exception e) {
+      assertThat(e).isInstanceOf(UnsupportedOperationException.class);
+    }
+  }
+
 }

--- a/airbyte-workers/src/test/java/io/airbyte/workers/utils/ConfigReplacerTest.java
+++ b/airbyte-workers/src/test/java/io/airbyte/workers/utils/ConfigReplacerTest.java
@@ -9,6 +9,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import io.airbyte.config.AllowedHosts;
+import io.airbyte.config.constants.AlwaysAllowedHosts;
 import java.io.IOException;
 import java.util.ArrayList;
 import java.util.List;
@@ -22,6 +23,7 @@ class ConfigReplacerTest {
 
   final ConfigReplacer replacer = new ConfigReplacer(logger);
   final ObjectMapper mapper = new ObjectMapper();
+  final AlwaysAllowedHosts alwaysAllowedHosts = new AlwaysAllowedHosts();
 
   @Test
   @SuppressWarnings("PMD.AvoidUsingHardCodedIP")
@@ -43,6 +45,7 @@ class ConfigReplacerTest {
     expected.add("123");
     expected.add("account.vendor.com");
     expected.add("1.2.3.4");
+    expected.addAll(alwaysAllowedHosts.getHosts());
 
     final String configJson =
         "{\"host\": \"foo.com\", \"number\": 123, \"subdomain\": \"account\", \"password\": \"abc123\", \"tunnel_method\": {\"tunnel_host\": \"1.2.3.4\"}}";
@@ -61,6 +64,7 @@ class ConfigReplacerTest {
 
     final List<String> expected = new ArrayList<>();
     expected.add("value-100");
+    expected.addAll(alwaysAllowedHosts.getHosts());
 
     final String configJson = "{\"a\": {\"b\": {\"c\": {\"d\": 100 }}}, \"array\": [1,2,3]}";
     final JsonNode config = mapper.readValue(configJson, JsonNode.class);
@@ -70,16 +74,28 @@ class ConfigReplacerTest {
   }
 
   @Test
-  void ensureEmptyArrayRemains() throws IOException {
+  void ensureEmptyArrayIncludesAlwaysAllowedHosts() throws IOException {
     final AllowedHosts allowedHosts = new AllowedHosts();
     allowedHosts.setHosts(new ArrayList());
+
     final List<String> expected = new ArrayList<>();
+    expected.addAll(alwaysAllowedHosts.getHosts());
 
     final String configJson = "{}";
     final JsonNode config = mapper.readValue(configJson, JsonNode.class);
     final AllowedHosts response = replacer.getAllowedHosts(allowedHosts, config);
 
     assertThat(response.getHosts()).isEqualTo(expected);
+    assertThat(response.getHosts()).contains("*.datadoghq.com");
+  }
+
+  @Test
+  void nullAllowedHostsRemainsNull() throws IOException {
+    final String configJson = "{}";
+    final JsonNode config = mapper.readValue(configJson, JsonNode.class);
+    final AllowedHosts response = replacer.getAllowedHosts(null, config);
+
+    assertThat(response).isEqualTo(null);
   }
 
 }


### PR DESCRIPTION
Closes https://github.com/airbytehq/airbyte/issues/21952

This PR gives the platform the ability to inject allowedHosts which are always valid for all connectors.  This includes endpoints we would use for logging or telemetry.