### PR TITLE
[Connector Builder] Set default value for end_datetime

### DIFF
--- a/airbyte-webapp/src/components/connectorBuilder/Builder/StreamSlicerSection.tsx
+++ b/airbyte-webapp/src/components/connectorBuilder/Builder/StreamSlicerSection.tsx
@@ -82,7 +82,7 @@ export const StreamSlicerSection: React.FC<StreamSlicerSectionProps> = ({ stream
       label: "Datetime",
       typeValue: "DatetimeStreamSlicer",
       default: {
-        datetime_format: "",
+        datetime_format: "%Y-%m-%d %H:%M:%S.%f+00:00",
         start_datetime: "",
         end_datetime: "{{ now_utc() }}",
         step: "",

--- a/airbyte-webapp/src/components/connectorBuilder/Builder/StreamSlicerSection.tsx
+++ b/airbyte-webapp/src/components/connectorBuilder/Builder/StreamSlicerSection.tsx
@@ -84,7 +84,7 @@ export const StreamSlicerSection: React.FC<StreamSlicerSectionProps> = ({ stream
       default: {
         datetime_format: "",
         start_datetime: "",
-        end_datetime: "",
+        end_datetime: "{{ now_utc() }}",
         step: "",
         cursor_field: "",
       },


### PR DESCRIPTION
## What
Resolves https://github.com/airbytehq/airbyte/issues/21572

## How
Sets the default value of `end_datetime` to `{{ now_utc() }}` using the existing BuilderOneOf default value mechanism.