### PR TITLE
🪟 🔧 Add typescript version to VSCode settings

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -41,5 +41,6 @@
     "editor.codeActionsOnSave": {
       "source.fixAll.stylelint": true
     }
-  }
+  },
+  "typescript.tsdk": "./airbyte-webapp/node_modules/typescript/lib"
 }


### PR DESCRIPTION
## What
Adds a link to the `airbyte-webapp` typescript module so that VSCode can correctly suggest a matching TS version to use for its checker.