### PR TITLE
Add version check on normalization

### DIFF
--- a/airbyte-workers/src/main/java/io/airbyte/workers/temporal/sync/NormalizationActivityImpl.java
+++ b/airbyte-workers/src/main/java/io/airbyte/workers/temporal/sync/NormalizationActivityImpl.java
@@ -9,6 +9,7 @@ import static io.airbyte.metrics.lib.ApmTraceConstants.Tags.ATTEMPT_NUMBER_KEY;
 import static io.airbyte.metrics.lib.ApmTraceConstants.Tags.DESTINATION_DOCKER_IMAGE_KEY;
 import static io.airbyte.metrics.lib.ApmTraceConstants.Tags.JOB_ID_KEY;
 
+import com.google.common.annotations.VisibleForTesting;
 import datadog.trace.api.Trace;
 import io.airbyte.api.client.AirbyteApiClient;
 import io.airbyte.api.client.model.generated.JobIdRequestBody;
@@ -164,6 +165,7 @@ public class NormalizationActivityImpl implements NormalizationActivity {
         .withResourceRequirements(normalizationResourceRequirements);
   }
 
+  @VisibleForTesting
   static boolean normalizationSupportsV1DataTypes(final IntegrationLauncherConfig destinationLauncherConfig) {
     try {
       final String[] normalizationImage = destinationLauncherConfig.getNormalizationDockerImage().split(":", 2);

--- a/airbyte-workers/src/test/java/io/airbyte/workers/temporal/sync/NormalizationActivityImplTest.java
+++ b/airbyte-workers/src/test/java/io/airbyte/workers/temporal/sync/NormalizationActivityImplTest.java
@@ -1,0 +1,28 @@
+/*
+ * Copyright (c) 2022 Airbyte, Inc., all rights reserved.
+ */
+
+package io.airbyte.workers.temporal.sync;
+
+import io.airbyte.persistence.job.models.IntegrationLauncherConfig;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+
+class NormalizationActivityImplTest {
+
+  @Test
+  void checkNormalizationDataTypesSupportFromVersionString() {
+    Assertions.assertFalse(NormalizationActivityImpl.normalizationSupportsV1DataTypes(withNormalizationVersion("0.2.5")));
+    Assertions.assertFalse(NormalizationActivityImpl.normalizationSupportsV1DataTypes(withNormalizationVersion("0.1.1")));
+    Assertions.assertTrue(NormalizationActivityImpl.normalizationSupportsV1DataTypes(withNormalizationVersion("0.3.0")));
+    Assertions.assertTrue(NormalizationActivityImpl.normalizationSupportsV1DataTypes(withNormalizationVersion("0.4.1")));
+    Assertions.assertTrue(NormalizationActivityImpl.normalizationSupportsV1DataTypes(withNormalizationVersion("dev")));
+    Assertions.assertTrue(NormalizationActivityImpl.normalizationSupportsV1DataTypes(withNormalizationVersion("protocolv1")));
+  }
+
+  private IntegrationLauncherConfig withNormalizationVersion(final String version) {
+    return new IntegrationLauncherConfig()
+        .withNormalizationDockerImage("normalization:" + version);
+  }
+
+}


### PR DESCRIPTION
## What

Moving forward, the platform is ensuring that the normalization always sees data types v1.
Add a check to make sure we do not run an older version of normalization with the newer data types as it would lead to the columns being typed to the most generic type. (JSONB for postgresql for example)

## How

Add a check on normalization version and fail with an explicit message.

