### PR TITLE
🪟 🧹 Clean up NotificationService imports

### DIFF
--- a/airbyte-webapp/src/App.tsx
+++ b/airbyte-webapp/src/App.tsx
@@ -14,7 +14,7 @@ import { ConfirmationModalService } from "hooks/services/ConfirmationModal";
 import { defaultOssFeatures, FeatureService } from "hooks/services/Feature";
 import { FormChangeTrackerService } from "hooks/services/FormChangeTracker";
 import { ModalServiceProvider } from "hooks/services/Modal";
-import NotificationService from "hooks/services/Notification";
+import { NotificationService } from "hooks/services/Notification";
 import { AnalyticsProvider } from "views/common/AnalyticsProvider";
 import { StoreProvider } from "views/common/StoreProvider";
 

--- a/airbyte-webapp/src/hooks/services/Notification/NotificationService.tsx
+++ b/airbyte-webapp/src/hooks/services/Notification/NotificationService.tsx
@@ -9,7 +9,7 @@ import { Notification, NotificationServiceApi, NotificationServiceState } from "
 
 const notificationServiceContext = React.createContext<NotificationServiceApi | null>(null);
 
-const NotificationService = ({ children }: { children: React.ReactNode }) => {
+export const NotificationService = React.memo(({ children }: { children: React.ReactNode }) => {
   const [state, { addNotification, clearAll, deleteNotificationById }] = useTypesafeReducer<
     NotificationServiceState,
     typeof actions
@@ -47,7 +47,7 @@ const NotificationService = ({ children }: { children: React.ReactNode }) => {
       ) : null}
     </>
   );
-};
+});
 
 export const useNotificationService: (
   notification?: Notification,
@@ -80,5 +80,3 @@ export const useNotificationService: (
     unregisterAllNotifications: notificationService.clearAll,
   };
 };
-
-export default React.memo(NotificationService);

--- a/airbyte-webapp/src/hooks/services/Notification/index.ts
+++ b/airbyte-webapp/src/hooks/services/Notification/index.ts
@@ -1,0 +1,2 @@
+export { NotificationService, useNotificationService } from "./NotificationService";
+export * from "./types";

--- a/airbyte-webapp/src/hooks/services/Notification/index.tsx
+++ b/airbyte-webapp/src/hooks/services/Notification/index.tsx
@@ -1,5 +1,0 @@
-import NotificationService, { useNotificationService } from "./NotificationService";
-export * from "./types";
-
-export default NotificationService;
-export { NotificationService, useNotificationService };

--- a/airbyte-webapp/src/packages/cloud/App.tsx
+++ b/airbyte-webapp/src/packages/cloud/App.tsx
@@ -13,7 +13,7 @@ import { ConfirmationModalService } from "hooks/services/ConfirmationModal";
 import { defaultCloudFeatures, FeatureService } from "hooks/services/Feature";
 import { FormChangeTrackerService } from "hooks/services/FormChangeTracker";
 import { ModalServiceProvider } from "hooks/services/Modal";
-import NotificationServiceProvider from "hooks/services/Notification";
+import { NotificationService } from "hooks/services/Notification";
 import en from "locales/en.json";
 import { Routing } from "packages/cloud/cloudRoutes";
 import cloudLocales from "packages/cloud/locales/en.json";
@@ -35,7 +35,7 @@ const Services: React.FC<React.PropsWithChildren<unknown>> = ({ children }) => (
   <AnalyticsProvider>
     <AppMonitoringServiceProvider>
       <ApiErrorBoundary>
-        <NotificationServiceProvider>
+        <NotificationService>
           <ConfirmationModalService>
             <ModalServiceProvider>
               <FormChangeTrackerService>
@@ -51,7 +51,7 @@ const Services: React.FC<React.PropsWithChildren<unknown>> = ({ children }) => (
               </FormChangeTrackerService>
             </ModalServiceProvider>
           </ConfirmationModalService>
-        </NotificationServiceProvider>
+        </NotificationService>
       </ApiErrorBoundary>
     </AppMonitoringServiceProvider>
   </AnalyticsProvider>


### PR DESCRIPTION
## What
Simplifies the export/imports for NotificationService

## How
Ensures that there is only one way to import the NotificationService and removes the default export.
