### PR TITLE
🪟 🔧  [Connector Builder] add back middlewares and request correct url

### DIFF
--- a/airbyte-webapp/src/config/config.ts
+++ b/airbyte-webapp/src/config/config.ts
@@ -6,7 +6,10 @@ export const config: AirbyteWebappConfig = {
     enabled: window.TRACKING_STRATEGY === "segment",
   },
   apiUrl: window.API_URL ?? process.env.REACT_APP_API_URL ?? `http://${window.location.hostname}:8001/api`,
-  connectorBuilderApiUrl: process.env.REACT_APP_CONNECTOR_BUILDER_API_URL ?? `http://${window.location.hostname}:8003`,
+  connectorBuilderApiUrl:
+    window.CONNECTOR_BUILDER_API_URL ??
+    process.env.REACT_APP_CONNECTOR_BUILDER_API_URL ??
+    `http://${window.location.hostname}:8003`,
   version: window.AIRBYTE_VERSION ?? "dev",
   integrationUrl: process.env.REACT_APP_INTEGRATION_DOCS_URLS ?? "/docs",
   oauthRedirectUrl: `${window.location.protocol}//${window.location.host}`,

--- a/airbyte-webapp/src/services/connectorBuilder/ConnectorBuilderApiService.ts
+++ b/airbyte-webapp/src/services/connectorBuilder/ConnectorBuilderApiService.ts
@@ -11,6 +11,7 @@ import {
 } from "core/request/ConnectorBuilderClient";
 import { ConnectorManifest } from "core/request/ConnectorManifest";
 import { useSuspenseQuery } from "services/connector/useSuspenseQuery";
+import { useDefaultRequestMiddlewares } from "services/useDefaultRequestMiddlewares";
 import { useInitService } from "services/useInitService";
 
 const connectorBuilderKeys = {
@@ -25,9 +26,10 @@ const connectorBuilderKeys = {
 
 function useConnectorBuilderService() {
   const config = useConfig();
+  const middlewares = useDefaultRequestMiddlewares();
   return useInitService(
-    () => new ConnectorBuilderRequestService(config.connectorBuilderApiUrl),
-    [config.connectorBuilderApiUrl]
+    () => new ConnectorBuilderRequestService(config.connectorBuilderApiUrl, middlewares),
+    [config.connectorBuilderApiUrl, middlewares]
   );
 }
 


### PR DESCRIPTION
## What
Fix the URL that is being requested for the connector builder server to be on the same domain, so that basic auth works on prod.

Also add back in middlewares since they will be needed when we add this to cloud

This was accidentally removed during the config provider refactor: https://github.com/airbytehq/airbyte/pull/21456/files#diff-3bf74e0deb63a2c070f4f8935d1bb61ddd16f0bb4e1b47e6bd8af55d85f24650L14
