### PR TITLE
🪟 🔧 Only retry end2end test using cypress not workflows

### DIFF
--- a/.github/workflows/gradle.yml
+++ b/.github/workflows/gradle.yml
@@ -564,11 +564,7 @@ jobs:
           EOF
 
       - name: Build Platform Docker Images
-        uses: Wandalen/wretry.action@master
-        with:
-          command: SUB_BUILD=PLATFORM ./gradlew --no-daemon assemble --scan
-          attempt_limit: 3
-          attempt_delay: 5000 # in ms
+        run: SUB_BUILD=PLATFORM ./gradlew --no-daemon assemble --scan
 
       - name: Run End-to-End Frontend Tests
         env:

--- a/airbyte-webapp-e2e-tests/cypress.json
+++ b/airbyte-webapp-e2e-tests/cypress.json
@@ -5,7 +5,7 @@
   "viewportHeight": 800,
   "viewportWidth": 1280,
   "retries": {
-    "runMode": 2,
+    "runMode": 5,
     "openMode": 0
   },
   "defaultCommandTimeout": 10000,


### PR DESCRIPTION
## What

Use only Cypress logic to retry tests, since retryign the whole workflow causes more problems and is rather slow.