### PR TITLE
🪟 🔧 Fix Enter/Tab behavior in TagInput to allow single-character values

### DIFF
--- a/airbyte-webapp/src/components/ui/TagInput/TagInput.tsx
+++ b/airbyte-webapp/src/components/ui/TagInput/TagInput.tsx
@@ -117,13 +117,14 @@ export const TagInput: React.FC<TagInputProps> = ({ onChange, fieldValue, name, 
 
   // handle when user presses keyboard keys in the input
   const handleKeyDown: KeyboardEventHandler<HTMLDivElement> = (event) => {
+    console.log(inputValue);
     if (!inputValue || !inputValue.length) {
       return;
     }
     switch (event.key) {
       case "Enter":
       case "Tab":
-        inputValue.trim().length > 1 && onChange([...fieldValue, inputValue.trim()]);
+        inputValue.trim().length >= 1 && onChange([...fieldValue, inputValue.trim()]);
 
         event.preventDefault();
         setInputValue("");

--- a/airbyte-webapp/src/components/ui/TagInput/TagInput.tsx
+++ b/airbyte-webapp/src/components/ui/TagInput/TagInput.tsx
@@ -117,7 +117,6 @@ export const TagInput: React.FC<TagInputProps> = ({ onChange, fieldValue, name, 
 
   // handle when user presses keyboard keys in the input
   const handleKeyDown: KeyboardEventHandler<HTMLDivElement> = (event) => {
-    console.log(inputValue);
     if (!inputValue || !inputValue.length) {
       return;
     }


### PR DESCRIPTION
## What
The TagInput component (the input component Airbyte uses for array values) currently has a bug in which single-character values cannot be added by pressing Enter or Tab.

Single-character values _can_ be added by pressing one of the delimiter keys (`,` or `;`), because the logic for that is implemented correctly: [it checks](https://github.com/airbytehq/airbyte/blob/c05888a359890f235fc2c8f64b6a7f64bf86637b/airbyte-webapp/src/components/ui/TagInput/TagInput.tsx#L112) that the current input value after `trim()` has a length > 1, which is necessary because it needs to have some other character besides the delimiter character for it to be a non-empty value.

## How
The problem is that the Enter/Tab logic copied this `inputValue.trim().length > 1` check, but that isn't the right logic to use for the Enter/Tab behavior, because there is no delimiter character to account for. This logic instead should be checking if `inputValue.trim().length >= 1`, since in this case `inputValue` contains only the characters of the value to be added. 

This PR makes that fix.