### PR TITLE
🪟 🐛 Fix issue with opener window closed

### DIFF
--- a/airbyte-webapp/src/hooks/services/useConnectorAuth.tsx
+++ b/airbyte-webapp/src/hooks/services/useConnectorAuth.tsx
@@ -210,7 +210,7 @@ export function useResolveNavigate(): void {
   const query = useQuery();
 
   useEffectOnce(() => {
-    window.opener.postMessage(query);
+    window.opener?.postMessage(query);
     window.close();
   });
 }

--- a/airbyte-webapp/src/hooks/services/useConnectorAuth.tsx
+++ b/airbyte-webapp/src/hooks/services/useConnectorAuth.tsx
@@ -197,7 +197,13 @@ export function useRunOauthFlow(
     [completeOauth]
   );
 
+  const onCloseWindow = useCallback(() => {
+    windowObjectReference?.close();
+  }, []);
+
   useEvent("message", onOathGranted);
+  // Close popup oauth window when we close the original tab
+  useEvent("beforeunload", onCloseWindow);
 
   return {
     loading: loadingCompleteOauth || loading,


### PR DESCRIPTION
## What

This fixes a weird edge-casey issue (that I've seen some users run into), when starting an OAuth flow for a connector and then closing the original Airbyte tab, but keep the OAuth flow popup open and finish it. Currently it will bring you back to the webapp after the flow, and we'll try to call `window.opener.postMessage`, but `window.opener` (the original tab) is now closed so we'll crash the popup window also with a "Ooops something went wrong" screen.

Changing this, so in case the original tab was closed and you still finish the OAuth flow, we'll just close this, and basically ignore it, since the user aborted setting up the connector by closing that tab.