### PR TITLE
Handle logging non-JSON-serializable classes in stream slices

### DIFF
--- a/airbyte-cdk/python/airbyte_cdk/sources/abstract_source.py
+++ b/airbyte-cdk/python/airbyte_cdk/sources/abstract_source.py
@@ -243,7 +243,8 @@ class AbstractSource(Source, ABC):
             has_slices = True
             if logger.isEnabledFor(logging.DEBUG):
                 yield AirbyteMessage(
-                    type=MessageType.LOG, log=AirbyteLogMessage(level=Level.INFO, message=f"{self.SLICE_LOG_PREFIX}{json.dumps(_slice, default=str)}")
+                    type=MessageType.LOG,
+                    log=AirbyteLogMessage(level=Level.INFO, message=f"{self.SLICE_LOG_PREFIX}{json.dumps(_slice, default=str)}"),
                 )
             records = stream_instance.read_records(
                 sync_mode=SyncMode.incremental,
@@ -295,7 +296,8 @@ class AbstractSource(Source, ABC):
         for _slice in slices:
             if logger.isEnabledFor(logging.DEBUG):
                 yield AirbyteMessage(
-                    type=MessageType.LOG, log=AirbyteLogMessage(level=Level.INFO, message=f"{self.SLICE_LOG_PREFIX}{json.dumps(_slice, default=str)}")
+                    type=MessageType.LOG,
+                    log=AirbyteLogMessage(level=Level.INFO, message=f"{self.SLICE_LOG_PREFIX}{json.dumps(_slice, default=str)}"),
                 )
             record_data_or_messages = stream_instance.read_records(
                 stream_slice=_slice,

--- a/airbyte-cdk/python/airbyte_cdk/sources/abstract_source.py
+++ b/airbyte-cdk/python/airbyte_cdk/sources/abstract_source.py
@@ -243,7 +243,7 @@ class AbstractSource(Source, ABC):
             has_slices = True
             if logger.isEnabledFor(logging.DEBUG):
                 yield AirbyteMessage(
-                    type=MessageType.LOG, log=AirbyteLogMessage(level=Level.INFO, message=f"{self.SLICE_LOG_PREFIX}{json.dumps(_slice)}")
+                    type=MessageType.LOG, log=AirbyteLogMessage(level=Level.INFO, message=f"{self.SLICE_LOG_PREFIX}{json.dumps(_slice, default=str)}")
                 )
             records = stream_instance.read_records(
                 sync_mode=SyncMode.incremental,
@@ -295,7 +295,7 @@ class AbstractSource(Source, ABC):
         for _slice in slices:
             if logger.isEnabledFor(logging.DEBUG):
                 yield AirbyteMessage(
-                    type=MessageType.LOG, log=AirbyteLogMessage(level=Level.INFO, message=f"{self.SLICE_LOG_PREFIX}{json.dumps(_slice)}")
+                    type=MessageType.LOG, log=AirbyteLogMessage(level=Level.INFO, message=f"{self.SLICE_LOG_PREFIX}{json.dumps(_slice, default=str)}")
                 )
             record_data_or_messages = stream_instance.read_records(
                 stream_slice=_slice,

--- a/airbyte-cdk/python/unit_tests/sources/test_abstract_source.py
+++ b/airbyte-cdk/python/unit_tests/sources/test_abstract_source.py
@@ -3,6 +3,7 @@
 #
 
 import copy
+import datetime
 import logging
 from collections import defaultdict
 from typing import Any, Callable, Dict, Iterable, List, Mapping, MutableMapping, Optional, Tuple, Union
@@ -330,12 +331,17 @@ def test_valid_full_refresh_read_with_slices(mocker):
 
     assert expected == messages
 
-
-def test_read_full_refresh_with_slices_sends_slice_messages(mocker):
+@pytest.mark.parametrize(
+    "slices",
+    [
+        [{"1": "1"}, {"2": "2"}],
+        [{"date": datetime.date(year=2023, month=1, day=1)}, {"date": datetime.date(year=2023, month=1, day=1)}]
+    ]
+)
+def test_read_full_refresh_with_slices_sends_slice_messages(mocker, slices):
     """Given the logger is debug and a full refresh, AirbyteMessages are sent for slices"""
     debug_logger = logging.getLogger("airbyte.debug")
     debug_logger.setLevel(logging.DEBUG)
-    slices = [{"1": "1"}, {"2": "2"}]
     stream = MockStream(
         [({"sync_mode": SyncMode.full_refresh, "stream_slice": s}, [s]) for s in slices],
         name="s1",

--- a/airbyte-cdk/python/unit_tests/sources/test_abstract_source.py
+++ b/airbyte-cdk/python/unit_tests/sources/test_abstract_source.py
@@ -331,6 +331,7 @@ def test_valid_full_refresh_read_with_slices(mocker):
 
     assert expected == messages
 
+
 @pytest.mark.parametrize(
     "slices",
     [


### PR DESCRIPTION
## What
*Describe what the change is solving*
*It helps to add screenshots if it affects the frontend.*
Avoid issues like [these](https://github.com/airbytehq/airbyte/actions/runs/4028599066/jobs/6925677028#step:11:1805) when trying to log stream slices which contain values that are not serializable. Note that in the case of the linked action, the `streamslice` class is not a `Mapping`, so it's not the most valid case here. However, when I implemented that as a TypedDict instead, I ran into the same issue for `datetime` formats, and I think they're a valid case we should support, hence that being the test case. 

## How
*Describe the solution*
When dumping, if a class is not json serializable, dump it as a string.
