### PR TITLE
Low code cdk to beta remove checkpoint interval

### DIFF
--- a/airbyte-cdk/python/airbyte_cdk/sources/declarative/declarative_component_schema.yaml
+++ b/airbyte-cdk/python/airbyte_cdk/sources/declarative/declarative_component_schema.yaml
@@ -462,9 +462,6 @@ definitions:
         anyOf:
           - "$ref": "#/definitions/CustomRetriever"
           - "$ref": "#/definitions/SimpleRetriever"
-      checkpoint_interval:
-        definition: How often the stream will checkpoint state (i.e. emit a STATE message)
-        type: integer
       name:
         definition: The stream name
         type: string

--- a/airbyte-cdk/python/airbyte_cdk/sources/declarative/declarative_stream.py
+++ b/airbyte-cdk/python/airbyte_cdk/sources/declarative/declarative_stream.py
@@ -28,7 +28,6 @@ class DeclarativeStream(Stream):
         stream_cursor_field (Optional[List[str]]): The cursor field
         transformations (List[RecordTransformation]): A list of transformations to be applied to each output record in the
         stream. Transformations are applied in the order in which they are defined.
-        checkpoint_interval (Optional[int]): How often the stream will checkpoint state (i.e: emit a STATE message)
     """
 
     retriever: Retriever
@@ -42,7 +41,6 @@ class DeclarativeStream(Stream):
     _schema_loader: SchemaLoader = field(init=False, repr=False, default=None)
     stream_cursor_field: Optional[Union[List[str], str]] = None
     transformations: List[RecordTransformation] = None
-    checkpoint_interval: Optional[int] = None
 
     def __post_init__(self, parameters: Mapping[str, Any]):
         self.stream_cursor_field = self.stream_cursor_field or []
@@ -69,20 +67,6 @@ class DeclarativeStream(Stream):
     def name(self, value: str) -> None:
         if not isinstance(value, property):
             self._name = value
-
-    @property
-    def state_checkpoint_interval(self) -> Optional[int]:
-        """
-        Decides how often to checkpoint state (i.e: emit a STATE message). E.g: if this returns a value of 100, then state is persisted after reading
-        100 records, then 200, 300, etc.. A good default value is 1000 although your mileage may vary depending on the underlying data source.
-
-        Checkpointing a stream avoids re-reading records in the case a sync is failed or cancelled.
-
-        return None if state should not be checkpointed e.g: because records returned from the underlying data source are not returned in
-        ascending order with respect to the cursor field. This can happen if the source does not support reading records in ascending order of
-        created_at date (or whatever the cursor is). In those cases, state must only be saved once the full stream has been read.
-        """
-        return self.checkpoint_interval
 
     @property
     def state(self) -> MutableMapping[str, Any]:

--- a/airbyte-cdk/python/airbyte_cdk/sources/declarative/models/declarative_component_schema.py
+++ b/airbyte-cdk/python/airbyte_cdk/sources/declarative/models/declarative_component_schema.py
@@ -466,7 +466,6 @@ class DeclarativeStream(BaseModel):
 
     type: Literal["DeclarativeStream"]
     retriever: Union[CustomRetriever, SimpleRetriever]
-    checkpoint_interval: Optional[int] = None
     name: Optional[str] = ""
     primary_key: Optional[Union[str, List[str], List[List[str]]]] = ""
     schema_loader: Optional[Union[InlineSchemaLoader, JsonFileSchemaLoader]] = None

--- a/airbyte-cdk/python/airbyte_cdk/sources/declarative/parsers/model_to_component_factory.py
+++ b/airbyte-cdk/python/airbyte_cdk/sources/declarative/parsers/model_to_component_factory.py
@@ -419,7 +419,6 @@ class ModelToComponentFactory:
             for transformation_model in model.transformations:
                 transformations.append(self._create_component_from_model(model=transformation_model, config=config))
         return DeclarativeStream(
-            checkpoint_interval=model.checkpoint_interval,
             name=model.name,
             primary_key=model.primary_key,
             retriever=retriever,

--- a/airbyte-cdk/python/unit_tests/sources/declarative/test_declarative_stream.py
+++ b/airbyte-cdk/python/unit_tests/sources/declarative/test_declarative_stream.py
@@ -31,7 +31,6 @@ def test_declarative_stream():
         {"date": "2021-01-02"},
         {"date": "2021-01-03"},
     ]
-    checkpoint_interval = 1000
 
     retriever = MagicMock()
     retriever.state = state
@@ -52,7 +51,6 @@ def test_declarative_stream():
         retriever=retriever,
         config=config,
         transformations=transformations,
-        checkpoint_interval=checkpoint_interval,
         parameters={},
     )
 
@@ -64,7 +62,6 @@ def test_declarative_stream():
     assert stream.primary_key == primary_key
     assert stream.cursor_field == cursor_field
     assert stream.stream_slices(sync_mode=SyncMode.incremental, cursor_field=cursor_field, stream_state=None) == stream_slices
-    assert stream.state_checkpoint_interval == checkpoint_interval
     for transformation in transformations:
         assert len(transformation.transform.call_args_list) == len(records)
         expected_calls = [

--- a/docs/connector-development/config-based/low-code-cdk-overview.md
+++ b/docs/connector-development/config-based/low-code-cdk-overview.md
@@ -124,7 +124,6 @@ For each stream, configure the following components:
 |                        | Stream Slicer   | Describes how to partition the stream, enabling incremental syncs and checkpointing                                                                                                                                                   |
 | Cursor field           |                 | Field to use as stream cursor. Can either be a string, or a list of strings if the cursor is a nested field.                                                                                                                          |
 | Transformations        |                 | A set of transformations to be applied on the records read from the source before emitting them to the destination                                                                                                                    |
-| Checkpoint interval    |                 | Defines the interval, in number of records, at which incremental syncs should be checkpointed                                                                                                                                         |
 
 For a deep dive into each of the components, refer to [Understanding the YAML file](./understanding-the-yaml-file/yaml-overview.md) or the [full YAML Schema definition](../../../airbyte-cdk/python/airbyte_cdk/sources/declarative/declarative_component_schema.yaml)
 

--- a/docs/connector-development/config-based/understanding-the-yaml-file/yaml-overview.md
+++ b/docs/connector-development/config-based/understanding-the-yaml-file/yaml-overview.md
@@ -35,8 +35,6 @@ The stream object is represented in the YAML file as:
         type: string
       transformations:
         "$ref": "#/definitions/RecordTransformation"
-      checkpoint_interval:
-        type: integer
       schema_loader:
         "$ref": "#/definitions/InlineSchemaLoader"
 ```


### PR DESCRIPTION
Closes https://github.com/airbytehq/airbyte/issues/21239.

Allowing the connector developers to configure the checkpoint interval adds complexity for very little value. This PR removes the option from the component schema and will let the framework decide on when to checkpoint.

No manifests were identified with `checkpoint_interval.`