### PR TITLE
HOTFIX: Point slack at summary builds not history

### DIFF
--- a/tools/bin/build_report.py
+++ b/tools/bin/build_report.py
@@ -30,7 +30,7 @@ SOURCE_DEFINITIONS_YAML = f"{CONNECTOR_DEFINITIONS_DIR}/source_definitions.yaml"
 DESTINATION_DEFINITIONS_YAML = f"{CONNECTOR_DEFINITIONS_DIR}/destination_definitions.yaml"
 CONNECTORS_ROOT_PATH = "./airbyte-integrations/connectors"
 RELEVANT_BASE_MODULES = ["base-normalization", "source-acceptance-test"]
-CONNECTOR_BUILD_OUTPUT_URL = "https://dnsgjos7lj2fu.cloudfront.net/tests/history/connectors"
+CONNECTOR_BUILD_OUTPUT_URL = "https://dnsgjos7lj2fu.cloudfront.net/tests/summary/connectors"
 
 # Global vars
 TESTED_SOURCE = []


### PR DESCRIPTION
## What
In my last PR #22029 I broke the build slack command by switching it to the wrong path

## Change
This corrects it to the right path.
