### PR TITLE
HOTFIX: Add version prefix to build status files

### DIFF
--- a/tools/ci_connector_ops/ci_connector_ops/qa_engine/inputs.py
+++ b/tools/ci_connector_ops/ci_connector_ops/qa_engine/inputs.py
@@ -33,7 +33,7 @@ class BUILD_STATUSES(str, Enum):
 
 
 def get_connector_build_output_url(connector_technical_name: str, connector_version: str) -> str:
-    return f"{CONNECTOR_BUILD_OUTPUT_URL}/{connector_technical_name}/{connector_version}.json"
+    return f"{CONNECTOR_BUILD_OUTPUT_URL}/{connector_technical_name}/version-{connector_version}.json"
 
 def fetch_latest_build_status_for_connector_version(connector_technical_name: str, connector_version: str) ->BUILD_STATUSES:
     """Fetch the latest build status for a given connector version."""

--- a/tools/ci_connector_ops/tests/test_qa_engine/test_inputs.py
+++ b/tools/ci_connector_ops/tests/test_qa_engine/test_inputs.py
@@ -121,7 +121,7 @@ def test_fetch_latest_build_status_for_connector_version(mocker, connector_name,
     mock_get = mocker.patch.object(requests, 'get', return_value=mock_response)
 
     assert inputs.fetch_latest_build_status_for_connector_version(connector_name, connector_version) == expected_status
-    assert mock_get.call_args == call(f"{constants.CONNECTOR_BUILD_OUTPUT_URL}/{connector_name}/{connector_version}.json")
+    assert mock_get.call_args == call(f"{constants.CONNECTOR_BUILD_OUTPUT_URL}/{connector_name}/version-{connector_version}.json")
 
 def test_fetch_latest_build_status_for_connector_version_invalid_status(mocker, caplog):
     connector_name = "connectors/source-pokeapi"

--- a/tools/status/report.sh
+++ b/tools/status/report.sh
@@ -22,6 +22,7 @@ fi
 BUCKET_WRITE_ROOT=/tmp/bucket_write_root
 LAST_TEN_ROOT=/tmp/last_ten_root
 SUMMARY_WRITE_ROOT=/tmp/summary_write_root
+VERSION_PREFIX="version-"
 
 DOCKER_VERSION=$(get_connector_version "$CONNECTOR")
 
@@ -65,8 +66,11 @@ function write_job_log() {
 
 function pull_latest_job_logs() {
   # pull the logs for the latest ten jobs for this connector
+  # note this is done by key as each log has a timestamp in the filename
+  # ensuring that the version specific runs are filtered out.
   LAST_TEN_FILES=$(aws s3api list-objects-v2 --bucket "$BUCKET"  \
-    --query "reverse(sort_by(Contents[?contains(Key, \`tests/history/$CONNECTOR\`)], &LastModified))[:10].Key" \
+    --prefix "tests/history/$CONNECTOR" \
+    --query "reverse(sort_by(Contents[?!contains(Key, \`$VERSION_PREFIX\`)], &Key))[:10].Key" \
     --output=text)
 
   rm -r $LAST_TEN_ROOT || true


### PR DESCRIPTION
## What
When migrating previous build status reports from `test/history/${CONNECTOR}` to `test/history/connectors/${CONNECTOR}` the information for `last_modified_at` was set to today.

This caused our login for the reports to be invalid

## How
This solves it by
1. Making the LAST_10 logs work off the unix timestamp included in the filename
2. Adding a version prefix to all versioned logs 
3. filtering out those versioned logs when getting the top 10

## Roadblocks Encountered
A few were encountered here.
1. AWS s3 cli made it difficult to non destructively copy files to the new destinations
2. AWS list-objects-api doesnt let you match on regex

# Post merge

- [x] Copy the previous build artifacts to the new path using the script below
- [x] Ensure all semver artifacts are removed
- [x] Run the integrations workflow
- [ ] Run the report status workflow
- [ ] Run the build report workflow

### s3 copy script
```sh
aws s3 cp "s3://airbyte-connector-build-status/tests/history" s3://airbyte-connector-build-status/tests/history/connectors/ --recursive  --exclude "*" --include "source-*" --exclude "connectors/*" --profile dev
```
```sh
aws s3 cp "s3://airbyte-connector-build-status/tests/history" s3://airbyte-connector-build-status/tests/history/connectors/ --recursive  --exclude "*" --include "destinations-*" --exclude "connectors/*" --profile dev
```
