### PR TITLE
Disable QA engine check

### DIFF
--- a/.github/workflows/test-command.yml
+++ b/.github/workflows/test-command.yml
@@ -156,7 +156,8 @@ jobs:
           retention-days: 3
       - name: Run QA checks for ${{ github.event.inputs.connector }}
         id: qa_checks
-        if: always()
+        # TODO: Disabled for on master until #22127 resolved
+        if: contains(github.ref, "feat-qa-engine")
         run: |
           run-qa-checks ${{ github.event.inputs.connector }}
       - name: Report Status

--- a/tools/status/report.sh
+++ b/tools/status/report.sh
@@ -56,7 +56,7 @@ function write_job_log() {
   # if docker version has a value, write it to a file with the docker version as the name
   # else output an error to the build log
   if [ -n "$DOCKER_VERSION" ]; then
-    echo "$job_log_json" > tests/history/"$CONNECTOR"/"$DOCKER_VERSION".json
+    echo "$job_log_json" > tests/history/"$CONNECTOR"/"$VERSION_PREFIX""$DOCKER_VERSION".json
   else
     echo "ERROR: Could not find docker version for $CONNECTOR"
   fi


### PR DESCRIPTION
## What
Related to #22127 

The QA engine check is failing on the ec2 runner as runner uses the github checkout action which does not include the full git history by default

This disables that check for now

## How
This disables this check on all branches that do not contain `feat-qa-engine` in their name.

