### PR TITLE
🪟 🐛 Enable segment by default

### DIFF
--- a/airbyte-webapp/src/config/config.ts
+++ b/airbyte-webapp/src/config/config.ts
@@ -3,7 +3,7 @@ import { AirbyteWebappConfig } from "./types";
 export const config: AirbyteWebappConfig = {
   segment: {
     token: window.SEGMENT_TOKEN ?? process.env.REACT_APP_SEGMENT_TOKEN,
-    enabled: window.TRACKING_STRATEGY === "segment",
+    enabled: !window.TRACKING_STRATEGY || window.TRACKING_STRATEGY === "segment",
   },
   apiUrl: window.API_URL ?? process.env.REACT_APP_API_URL ?? `http://${window.location.hostname}:8001/api`,
   connectorBuilderApiUrl:


### PR DESCRIPTION
## What
Sets our config `segment.enabled` setting to `true` by default.

## How
In https://github.com/airbytehq/airbyte/pull/21456 we refactored how config is set, and mistakenly made `segment.enabled` dependent on whether `window.TRACKING_STRATEGY === "segment"`. In previous config, `segment.enabled` was set to `true` by default, so we should keep that behavior.
