### PR TITLE
🪟 🔧 Add isCorporate to Airbyte.UI.User.Create

### DIFF
--- a/airbyte-webapp/src/packages/cloud/services/auth/AuthService.tsx
+++ b/airbyte-webapp/src/packages/cloud/services/auth/AuthService.tsx
@@ -188,9 +188,8 @@ export const AuthenticationProvider: React.FC<React.PropsWithChildren<unknown>> 
       hasPasswordLogin(): boolean {
         return !!state.providers?.includes("password");
       },
-      hasCorporateEmail(email?: string): boolean {
-        const userEmail = email ?? state.currentUser?.email;
-        return !FREE_EMAIL_SERVICE_PROVIDERS.some((provider) => userEmail?.endsWith(`@${provider}`));
+      hasCorporateEmail(email: string | undefined = state.currentUser?.email): boolean {
+        return !FREE_EMAIL_SERVICE_PROVIDERS.some((provider) => email?.endsWith(`@${provider}`));
       },
       async login(values: { email: string; password: string }): Promise<void> {
         await authService.login(values.email, values.password);

--- a/airbyte-webapp/src/packages/cloud/services/auth/AuthService.tsx
+++ b/airbyte-webapp/src/packages/cloud/services/auth/AuthService.tsx
@@ -62,7 +62,7 @@ interface AuthContextApi {
   loggedOut: boolean;
   providers: string[] | null;
   hasPasswordLogin: () => boolean;
-  hasCorporateEmail: () => boolean;
+  hasCorporateEmail: (email?: string) => boolean;
   login: AuthLogin;
   loginWithOAuth: (provider: OAuthProviders) => Observable<OAuthLoginState>;
   signUpWithEmailLink: (form: { name: string; email: string; password: string; news: boolean }) => Promise<void>;
@@ -116,6 +116,7 @@ export const AuthenticationProvider: React.FC<React.PropsWithChildren<unknown>> 
       user_id: firebaseUser.uid,
       name: user.name,
       email: user.email,
+      isCorporate: ctx.hasCorporateEmail(user.email),
       // Which login provider was used, e.g. "password", "google.com", "github.com"
       provider: firebaseUser.providerData[0]?.providerId,
       ...getUtmFromStorage(),
@@ -187,8 +188,9 @@ export const AuthenticationProvider: React.FC<React.PropsWithChildren<unknown>> 
       hasPasswordLogin(): boolean {
         return !!state.providers?.includes("password");
       },
-      hasCorporateEmail(): boolean {
-        return !FREE_EMAIL_SERVICE_PROVIDERS.some((provider) => state.currentUser?.email.endsWith(`@${provider}`));
+      hasCorporateEmail(email?: string): boolean {
+        const userEmail = email ?? state.currentUser?.email;
+        return !FREE_EMAIL_SERVICE_PROVIDERS.some((provider) => userEmail?.endsWith(`@${provider}`));
       },
       async login(values: { email: string; password: string }): Promise<void> {
         await authService.login(values.email, values.password);


### PR DESCRIPTION
We use this event to track conversions across paid channels such as Google Ads.
Since we are only interested in corporate signups, we only want to track a successful conversion in those cases.
Previously, we only added the `isCorporate` flag on `.identify()` but we need this info also in `.track('Airbyte.UI.User.Create')`

Context: https://docs.google.com/document/d/13JbXLgAEVQmMoCBOPdDzAKpzwvqGclMcGSdA3bQ5KYQ/edit?disco=AAAAofb14Pg

