### PR TITLE
Remove `checkpoint_interval` from source-prestashop manifest

### DIFF
--- a/airbyte-integrations/connectors/source-prestashop/source_prestashop/manifest.yaml
+++ b/airbyte-integrations/connectors/source-prestashop/source_prestashop/manifest.yaml
@@ -31,7 +31,6 @@ definitions:
   base_incremental_stream:
     $ref: "#/definitions/base_stream"
     stream_cursor_field: "date_upd"
-    checkpoint_interval: 500
     retriever:
       $ref: "#/definitions/retriever"
       stream_slicer:


### PR DESCRIPTION
Follow-up from https://github.com/airbytehq/airbyte/pull/22120, removing `checkpoint_interval` from source-prestashop's manifest.