### PR TITLE
[FIX] Change quotes to fix test-command.yml

### DIFF
--- a/.github/workflows/test-command.yml
+++ b/.github/workflows/test-command.yml
@@ -157,7 +157,7 @@ jobs:
       - name: Run QA checks for ${{ github.event.inputs.connector }}
         id: qa_checks
         # TODO: Disabled for on master until #22127 resolved
-        if: contains(github.ref, "feat-qa-engine")
+        if: contains(github.ref, 'feat-qa-engine')
         run: |
           run-qa-checks ${{ github.event.inputs.connector }}
       - name: Report Status


### PR DESCRIPTION
## What
The if statement in the qa-engine check is failing as github actions prefers single quotes

https://github.com/airbytehq/airbyte/actions/runs/4055079918
https://github.com/actions/runner/issues/866

## How
This changes to single quotes
