### PR TITLE
copy publishing task from root project

### DIFF
--- a/airbyte-featureflag/build.gradle.kts
+++ b/airbyte-featureflag/build.gradle.kts
@@ -3,6 +3,7 @@ import org.jetbrains.kotlin.gradle.tasks.KotlinCompile
 
 plugins {
     `java-library`
+    `maven-publish`
     kotlin("jvm") version "1.8.0"
     kotlin("kapt") version "1.8.0"
 }
@@ -36,4 +37,18 @@ tasks.withType<KotlinCompile> {
 
 tasks.test {
     useJUnitPlatform()
+}
+
+publishing {
+    repositories {
+        publications {
+            create<MavenPublication>("${project.name}") {
+                groupId = "{$project.group}"
+                artifactId = "${project.name}"
+                version = "${rootProject.version}"
+                repositories.add(rootProject.repositories.getByName("cloudrepo"))
+                from(components["java"])
+            }
+        }
+    }
 }


### PR DESCRIPTION
## What
- Kotlin subprojects don't appear to have a way to call a function defined in the root-project
- as a quick-fix, redefine the publishing task in this Kotlin project
- medium-term-fix (not part of this PR); one of the following
    - convert the `getPublishArtifactsTask` dynamic task to work in the same way that the docker-image task works
    - create an `airbyte` gradle plugin that exposes all this functionality via configuration block

