### PR TITLE
Annotate endpoints that are secured at the workspace level

### DIFF
--- a/airbyte-commons/src/main/java/io/airbyte/commons/auth/SecuredWorkspace.java
+++ b/airbyte-commons/src/main/java/io/airbyte/commons/auth/SecuredWorkspace.java
@@ -1,0 +1,23 @@
+/*
+ * Copyright (c) 2022 Airbyte, Inc., all rights reserved.
+ */
+
+package io.airbyte.commons.auth;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Inherited;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+/**
+ * Used to mark a controller route as requiring authorization at the workspace level. Works in
+ * conjunction with {@link io.micronaut.security.annotation.Secured}, which denotes the required
+ * roles that should be associated with the user and workspace.
+ */
+@Retention(RetentionPolicy.RUNTIME)
+@Target({ElementType.METHOD})
+@Inherited
+public @interface SecuredWorkspace {
+
+}

--- a/airbyte-featureflag/build.gradle.kts
+++ b/airbyte-featureflag/build.gradle.kts
@@ -43,7 +43,7 @@ publishing {
     repositories {
         publications {
             create<MavenPublication>("${project.name}") {
-                groupId = "{$project.group}"
+                groupId = "${project.group}"
                 artifactId = "${project.name}"
                 version = "${rootProject.version}"
                 repositories.add(rootProject.repositories.getByName("cloudrepo"))

--- a/airbyte-server/src/main/java/io/airbyte/server/apis/ConnectionApiController.java
+++ b/airbyte-server/src/main/java/io/airbyte/server/apis/ConnectionApiController.java
@@ -16,6 +16,7 @@ import io.airbyte.api.model.generated.ConnectionSearch;
 import io.airbyte.api.model.generated.ConnectionUpdate;
 import io.airbyte.api.model.generated.JobInfoRead;
 import io.airbyte.api.model.generated.WorkspaceIdRequestBody;
+import io.airbyte.commons.auth.SecuredWorkspace;
 import io.airbyte.commons.server.handlers.ConnectionsHandler;
 import io.airbyte.commons.server.handlers.OperationsHandler;
 import io.airbyte.commons.server.handlers.SchedulerHandler;
@@ -51,6 +52,7 @@ public class ConnectionApiController implements ConnectionApi {
   @Override
   @Post(uri = "/create")
   @Secured({EDITOR})
+  @SecuredWorkspace
   public ConnectionRead createConnection(@Body final ConnectionCreate connectionCreate) {
     return ApiHelper.execute(() -> connectionsHandler.createConnection(connectionCreate));
   }
@@ -58,6 +60,7 @@ public class ConnectionApiController implements ConnectionApi {
   @Override
   @Post(uri = "/update")
   @Secured({EDITOR})
+  @SecuredWorkspace
   public ConnectionRead updateConnection(@Body final ConnectionUpdate connectionUpdate) {
     return ApiHelper.execute(() -> connectionsHandler.updateConnection(connectionUpdate));
   }
@@ -65,6 +68,7 @@ public class ConnectionApiController implements ConnectionApi {
   @Override
   @Post(uri = "/list")
   @Secured({READER})
+  @SecuredWorkspace
   public ConnectionReadList listConnectionsForWorkspace(@Body final WorkspaceIdRequestBody workspaceIdRequestBody) {
     return ApiHelper.execute(() -> connectionsHandler.listConnectionsForWorkspace(workspaceIdRequestBody));
   }
@@ -72,6 +76,7 @@ public class ConnectionApiController implements ConnectionApi {
   @Override
   @Post(uri = "/list_all")
   @Secured({READER})
+  @SecuredWorkspace
   public ConnectionReadList listAllConnectionsForWorkspace(@Body final WorkspaceIdRequestBody workspaceIdRequestBody) {
     return ApiHelper.execute(() -> connectionsHandler.listAllConnectionsForWorkspace(workspaceIdRequestBody));
   }
@@ -85,6 +90,7 @@ public class ConnectionApiController implements ConnectionApi {
   @Override
   @Post(uri = "/get")
   @Secured({READER})
+  @SecuredWorkspace
   public ConnectionRead getConnection(@Body final ConnectionIdRequestBody connectionIdRequestBody) {
     return ApiHelper.execute(() -> connectionsHandler.getConnection(connectionIdRequestBody.getConnectionId()));
   }
@@ -93,6 +99,7 @@ public class ConnectionApiController implements ConnectionApi {
   @Post(uri = "/delete")
   @Status(HttpStatus.NO_CONTENT)
   @Secured({EDITOR})
+  @SecuredWorkspace
   public void deleteConnection(@Body final ConnectionIdRequestBody connectionIdRequestBody) {
     ApiHelper.execute(() -> {
       operationsHandler.deleteOperationsForConnection(connectionIdRequestBody);
@@ -104,6 +111,7 @@ public class ConnectionApiController implements ConnectionApi {
   @Override
   @Post(uri = "/sync")
   @Secured({EDITOR})
+  @SecuredWorkspace
   public JobInfoRead syncConnection(@Body final ConnectionIdRequestBody connectionIdRequestBody) {
     return ApiHelper.execute(() -> schedulerHandler.syncConnection(connectionIdRequestBody));
   }
@@ -111,6 +119,7 @@ public class ConnectionApiController implements ConnectionApi {
   @Override
   @Post(uri = "/reset")
   @Secured({EDITOR})
+  @SecuredWorkspace
   public JobInfoRead resetConnection(@Body final ConnectionIdRequestBody connectionIdRequestBody) {
     return ApiHelper.execute(() -> schedulerHandler.resetConnection(connectionIdRequestBody));
   }

--- a/airbyte-server/src/main/java/io/airbyte/server/apis/DestinationApiController.java
+++ b/airbyte-server/src/main/java/io/airbyte/server/apis/DestinationApiController.java
@@ -17,6 +17,7 @@ import io.airbyte.api.model.generated.DestinationReadList;
 import io.airbyte.api.model.generated.DestinationSearch;
 import io.airbyte.api.model.generated.DestinationUpdate;
 import io.airbyte.api.model.generated.WorkspaceIdRequestBody;
+import io.airbyte.commons.auth.SecuredWorkspace;
 import io.airbyte.commons.server.handlers.DestinationHandler;
 import io.airbyte.commons.server.handlers.SchedulerHandler;
 import io.micronaut.context.annotation.Requires;
@@ -44,6 +45,7 @@ public class DestinationApiController implements DestinationApi {
 
   @Post(uri = "/check_connection")
   @Secured({EDITOR})
+  @SecuredWorkspace
   @Override
   public CheckConnectionRead checkConnectionToDestination(@Body final DestinationIdRequestBody destinationIdRequestBody) {
     return ApiHelper.execute(() -> schedulerHandler.checkDestinationConnectionFromDestinationId(destinationIdRequestBody));
@@ -51,6 +53,7 @@ public class DestinationApiController implements DestinationApi {
 
   @Post(uri = "/check_connection_for_update")
   @Secured({EDITOR})
+  @SecuredWorkspace
   @Override
   public CheckConnectionRead checkConnectionToDestinationForUpdate(@Body final DestinationUpdate destinationUpdate) {
     return ApiHelper.execute(() -> schedulerHandler.checkDestinationConnectionFromDestinationIdForUpdate(destinationUpdate));
@@ -64,6 +67,7 @@ public class DestinationApiController implements DestinationApi {
 
   @Post(uri = "/create")
   @Secured({EDITOR})
+  @SecuredWorkspace
   @Override
   public DestinationRead createDestination(@Body final DestinationCreate destinationCreate) {
     return ApiHelper.execute(() -> destinationHandler.createDestination(destinationCreate));
@@ -71,6 +75,7 @@ public class DestinationApiController implements DestinationApi {
 
   @Post(uri = "/delete")
   @Secured({EDITOR})
+  @SecuredWorkspace
   @Override
   @Status(HttpStatus.NO_CONTENT)
   public void deleteDestination(@Body final DestinationIdRequestBody destinationIdRequestBody) {
@@ -82,6 +87,7 @@ public class DestinationApiController implements DestinationApi {
 
   @Post(uri = "/get")
   @Secured({READER})
+  @SecuredWorkspace
   @Override
   public DestinationRead getDestination(@Body final DestinationIdRequestBody destinationIdRequestBody) {
     return ApiHelper.execute(() -> destinationHandler.getDestination(destinationIdRequestBody));
@@ -89,6 +95,7 @@ public class DestinationApiController implements DestinationApi {
 
   @Post(uri = "/list")
   @Secured({READER})
+  @SecuredWorkspace
   @Override
   public DestinationReadList listDestinationsForWorkspace(@Body final WorkspaceIdRequestBody workspaceIdRequestBody) {
     return ApiHelper.execute(() -> destinationHandler.listDestinationsForWorkspace(workspaceIdRequestBody));
@@ -102,6 +109,7 @@ public class DestinationApiController implements DestinationApi {
 
   @Post(uri = "/update")
   @Secured({EDITOR})
+  @SecuredWorkspace
   @Override
   public DestinationRead updateDestination(@Body final DestinationUpdate destinationUpdate) {
     return ApiHelper.execute(() -> destinationHandler.updateDestination(destinationUpdate));

--- a/airbyte-server/src/main/java/io/airbyte/server/apis/DestinationDefinitionApiController.java
+++ b/airbyte-server/src/main/java/io/airbyte/server/apis/DestinationDefinitionApiController.java
@@ -19,6 +19,7 @@ import io.airbyte.api.model.generated.DestinationDefinitionUpdate;
 import io.airbyte.api.model.generated.PrivateDestinationDefinitionRead;
 import io.airbyte.api.model.generated.PrivateDestinationDefinitionReadList;
 import io.airbyte.api.model.generated.WorkspaceIdRequestBody;
+import io.airbyte.commons.auth.SecuredWorkspace;
 import io.airbyte.commons.server.handlers.DestinationDefinitionsHandler;
 import io.micronaut.context.annotation.Context;
 import io.micronaut.context.annotation.Requires;
@@ -44,6 +45,7 @@ public class DestinationDefinitionApiController implements DestinationDefinition
 
   @Post(uri = "/create_custom")
   @Secured({EDITOR})
+  @SecuredWorkspace
   @Override
   public DestinationDefinitionRead createCustomDestinationDefinition(final CustomDestinationDefinitionCreate customDestinationDefinitionCreate) {
     return ApiHelper.execute(() -> destinationDefinitionsHandler.createCustomDestinationDefinition(customDestinationDefinitionCreate));
@@ -69,6 +71,7 @@ public class DestinationDefinitionApiController implements DestinationDefinition
 
   @Post(uri = "/get_for_workspace")
   @Secured({READER})
+  @SecuredWorkspace
   @Override
   public DestinationDefinitionRead getDestinationDefinitionForWorkspace(final DestinationDefinitionIdWithWorkspaceId destinationDefinitionIdWithWorkspaceId) {
     return ApiHelper.execute(() -> destinationDefinitionsHandler.getDestinationDefinitionForWorkspace(destinationDefinitionIdWithWorkspaceId));
@@ -91,6 +94,7 @@ public class DestinationDefinitionApiController implements DestinationDefinition
 
   @Post(uri = "/list_for_workspace")
   @Secured({READER})
+  @SecuredWorkspace
   @Override
   public DestinationDefinitionReadList listDestinationDefinitionsForWorkspace(final WorkspaceIdRequestBody workspaceIdRequestBody) {
     return ApiHelper.execute(() -> destinationDefinitionsHandler.listDestinationDefinitionsForWorkspace(workspaceIdRequestBody));

--- a/airbyte-server/src/main/java/io/airbyte/server/apis/DestinationOauthApiController.java
+++ b/airbyte-server/src/main/java/io/airbyte/server/apis/DestinationOauthApiController.java
@@ -12,6 +12,7 @@ import io.airbyte.api.model.generated.CompleteDestinationOAuthRequest;
 import io.airbyte.api.model.generated.DestinationOauthConsentRequest;
 import io.airbyte.api.model.generated.OAuthConsentRead;
 import io.airbyte.api.model.generated.SetInstancewideDestinationOauthParamsRequestBody;
+import io.airbyte.commons.auth.SecuredWorkspace;
 import io.airbyte.commons.server.handlers.OAuthHandler;
 import io.micronaut.context.annotation.Context;
 import io.micronaut.context.annotation.Requires;
@@ -36,6 +37,7 @@ public class DestinationOauthApiController implements DestinationOauthApi {
 
   @Post("/complete_oauth")
   @Secured({EDITOR})
+  @SecuredWorkspace
   @Override
   public Map<String, Object> completeDestinationOAuth(final CompleteDestinationOAuthRequest completeDestinationOAuthRequest) {
     return ApiHelper.execute(() -> oAuthHandler.completeDestinationOAuth(completeDestinationOAuthRequest));
@@ -43,6 +45,7 @@ public class DestinationOauthApiController implements DestinationOauthApi {
 
   @Post("/get_consent_url")
   @Secured({EDITOR})
+  @SecuredWorkspace
   @Override
   public OAuthConsentRead getDestinationOAuthConsent(final DestinationOauthConsentRequest destinationOauthConsentRequest) {
     return ApiHelper.execute(() -> oAuthHandler.getDestinationOAuthConsent(destinationOauthConsentRequest));

--- a/airbyte-server/src/main/java/io/airbyte/server/apis/JobsApiController.java
+++ b/airbyte-server/src/main/java/io/airbyte/server/apis/JobsApiController.java
@@ -18,6 +18,7 @@ import io.airbyte.api.model.generated.JobInfoRead;
 import io.airbyte.api.model.generated.JobListRequestBody;
 import io.airbyte.api.model.generated.JobOptionalRead;
 import io.airbyte.api.model.generated.JobReadList;
+import io.airbyte.commons.auth.SecuredWorkspace;
 import io.airbyte.commons.server.handlers.JobHistoryHandler;
 import io.airbyte.commons.server.handlers.SchedulerHandler;
 import io.micronaut.context.annotation.Context;
@@ -44,6 +45,7 @@ public class JobsApiController implements JobsApi {
 
   @Post("/cancel")
   @Secured({EDITOR})
+  @SecuredWorkspace
   @Override
   public JobInfoRead cancelJob(final JobIdRequestBody jobIdRequestBody) {
     return ApiHelper.execute(() -> schedulerHandler.cancelJob(jobIdRequestBody));
@@ -58,6 +60,7 @@ public class JobsApiController implements JobsApi {
 
   @Post("/get_debug_info")
   @Secured({READER})
+  @SecuredWorkspace
   @Override
   public JobDebugInfoRead getJobDebugInfo(final JobIdRequestBody jobIdRequestBody) {
     return ApiHelper.execute(() -> jobHistoryHandler.getJobDebugInfo(jobIdRequestBody));
@@ -65,6 +68,7 @@ public class JobsApiController implements JobsApi {
 
   @Post("/get")
   @Secured({READER})
+  @SecuredWorkspace
   @Override
   public JobInfoRead getJobInfo(final JobIdRequestBody jobIdRequestBody) {
     return ApiHelper.execute(() -> jobHistoryHandler.getJobInfo(jobIdRequestBody));
@@ -72,6 +76,7 @@ public class JobsApiController implements JobsApi {
 
   @Post("/get_light")
   @Secured({READER})
+  @SecuredWorkspace
   @Override
   public JobInfoLightRead getJobInfoLight(final JobIdRequestBody jobIdRequestBody) {
     return ApiHelper.execute(() -> jobHistoryHandler.getJobInfoLight(jobIdRequestBody));
@@ -86,6 +91,7 @@ public class JobsApiController implements JobsApi {
 
   @Post("/list")
   @Secured({READER})
+  @SecuredWorkspace
   @Override
   public JobReadList listJobsFor(final JobListRequestBody jobListRequestBody) {
     return ApiHelper.execute(() -> jobHistoryHandler.listJobsFor(jobListRequestBody));

--- a/airbyte-server/src/main/java/io/airbyte/server/apis/OperationApiController.java
+++ b/airbyte-server/src/main/java/io/airbyte/server/apis/OperationApiController.java
@@ -17,6 +17,7 @@ import io.airbyte.api.model.generated.OperationRead;
 import io.airbyte.api.model.generated.OperationReadList;
 import io.airbyte.api.model.generated.OperationUpdate;
 import io.airbyte.api.model.generated.OperatorConfiguration;
+import io.airbyte.commons.auth.SecuredWorkspace;
 import io.airbyte.commons.server.handlers.OperationsHandler;
 import io.micronaut.context.annotation.Requires;
 import io.micronaut.http.HttpStatus;
@@ -49,12 +50,14 @@ public class OperationApiController implements OperationApi {
   @Post("/create")
   @Override
   @Secured({EDITOR})
+  @SecuredWorkspace
   public OperationRead createOperation(@Body final OperationCreate operationCreate) {
     return ApiHelper.execute(() -> operationsHandler.createOperation(operationCreate));
   }
 
   @Post("/delete")
   @Secured({EDITOR})
+  @SecuredWorkspace
   @Override
   @Status(HttpStatus.NO_CONTENT)
   public void deleteOperation(@Body final OperationIdRequestBody operationIdRequestBody) {
@@ -66,6 +69,7 @@ public class OperationApiController implements OperationApi {
 
   @Post("/get")
   @Secured({READER})
+  @SecuredWorkspace
   @Override
   public OperationRead getOperation(@Body final OperationIdRequestBody operationIdRequestBody) {
     return ApiHelper.execute(() -> operationsHandler.getOperation(operationIdRequestBody));
@@ -73,6 +77,7 @@ public class OperationApiController implements OperationApi {
 
   @Post("/list")
   @Secured({READER})
+  @SecuredWorkspace
   @Override
   public OperationReadList listOperationsForConnection(@Body final ConnectionIdRequestBody connectionIdRequestBody) {
     return ApiHelper.execute(() -> operationsHandler.listOperationsForConnection(connectionIdRequestBody));
@@ -80,6 +85,7 @@ public class OperationApiController implements OperationApi {
 
   @Post("/update")
   @Secured({EDITOR})
+  @SecuredWorkspace
   @Override
   public OperationRead updateOperation(@Body final OperationUpdate operationUpdate) {
     return ApiHelper.execute(() -> operationsHandler.updateOperation(operationUpdate));

--- a/airbyte-server/src/main/java/io/airbyte/server/apis/SchedulerApiController.java
+++ b/airbyte-server/src/main/java/io/airbyte/server/apis/SchedulerApiController.java
@@ -12,6 +12,7 @@ import io.airbyte.api.model.generated.CheckConnectionRead;
 import io.airbyte.api.model.generated.DestinationCoreConfig;
 import io.airbyte.api.model.generated.SourceCoreConfig;
 import io.airbyte.api.model.generated.SourceDiscoverSchemaRead;
+import io.airbyte.commons.auth.SecuredWorkspace;
 import io.airbyte.commons.server.handlers.SchedulerHandler;
 import io.micronaut.context.annotation.Requires;
 import io.micronaut.http.annotation.Controller;
@@ -47,6 +48,7 @@ public class SchedulerApiController implements SchedulerApi {
 
   @Post("/sources/discover_schema")
   @Secured({EDITOR})
+  @SecuredWorkspace
   @Override
   public SourceDiscoverSchemaRead executeSourceDiscoverSchema(final SourceCoreConfig sourceCoreConfig) {
     return ApiHelper.execute(() -> schedulerHandler.discoverSchemaForSourceFromSourceCreate(sourceCoreConfig));

--- a/airbyte-server/src/main/java/io/airbyte/server/apis/SourceApiController.java
+++ b/airbyte-server/src/main/java/io/airbyte/server/apis/SourceApiController.java
@@ -22,6 +22,7 @@ import io.airbyte.api.model.generated.SourceReadList;
 import io.airbyte.api.model.generated.SourceSearch;
 import io.airbyte.api.model.generated.SourceUpdate;
 import io.airbyte.api.model.generated.WorkspaceIdRequestBody;
+import io.airbyte.commons.auth.SecuredWorkspace;
 import io.airbyte.commons.server.handlers.SchedulerHandler;
 import io.airbyte.commons.server.handlers.SourceHandler;
 import io.micronaut.context.annotation.Requires;
@@ -48,6 +49,7 @@ public class SourceApiController implements SourceApi {
 
   @Post("/check_connection")
   @Secured({EDITOR})
+  @SecuredWorkspace
   @Override
   public CheckConnectionRead checkConnectionToSource(final SourceIdRequestBody sourceIdRequestBody) {
     return ApiHelper.execute(() -> schedulerHandler.checkSourceConnectionFromSourceId(sourceIdRequestBody));
@@ -55,6 +57,7 @@ public class SourceApiController implements SourceApi {
 
   @Post("/check_connection_for_update")
   @Secured({EDITOR})
+  @SecuredWorkspace
   @Override
   public CheckConnectionRead checkConnectionToSourceForUpdate(final SourceUpdate sourceUpdate) {
     return ApiHelper.execute(() -> schedulerHandler.checkSourceConnectionFromSourceIdForUpdate(sourceUpdate));
@@ -68,6 +71,7 @@ public class SourceApiController implements SourceApi {
 
   @Post("/create")
   @Secured({EDITOR})
+  @SecuredWorkspace
   @Override
   public SourceRead createSource(final SourceCreate sourceCreate) {
     return ApiHelper.execute(() -> sourceHandler.createSource(sourceCreate));
@@ -75,6 +79,7 @@ public class SourceApiController implements SourceApi {
 
   @Post("/delete")
   @Secured({EDITOR})
+  @SecuredWorkspace
   @Override
   @Status(HttpStatus.NO_CONTENT)
   public void deleteSource(final SourceIdRequestBody sourceIdRequestBody) {
@@ -86,6 +91,7 @@ public class SourceApiController implements SourceApi {
 
   @Post("/discover_schema")
   @Secured({EDITOR})
+  @SecuredWorkspace
   @Override
   public SourceDiscoverSchemaRead discoverSchemaForSource(final SourceDiscoverSchemaRequestBody sourceDiscoverSchemaRequestBody) {
     return ApiHelper.execute(() -> schedulerHandler.discoverSchemaForSourceFromSourceId(sourceDiscoverSchemaRequestBody));
@@ -93,6 +99,7 @@ public class SourceApiController implements SourceApi {
 
   @Post("/get")
   @Secured({READER})
+  @SecuredWorkspace
   @Override
   public SourceRead getSource(final SourceIdRequestBody sourceIdRequestBody) {
     return ApiHelper.execute(() -> sourceHandler.getSource(sourceIdRequestBody));
@@ -100,6 +107,7 @@ public class SourceApiController implements SourceApi {
 
   @Post("/most_recent_source_actor_catalog")
   @Secured({READER})
+  @SecuredWorkspace
   @Override
   public ActorCatalogWithUpdatedAt getMostRecentSourceActorCatalog(final SourceIdRequestBody sourceIdRequestBody) {
     return ApiHelper.execute(() -> sourceHandler.getMostRecentSourceActorCatalogWithUpdatedAt(sourceIdRequestBody));
@@ -107,6 +115,7 @@ public class SourceApiController implements SourceApi {
 
   @Post("/list")
   @Secured({READER})
+  @SecuredWorkspace
   @Override
   public SourceReadList listSourcesForWorkspace(final WorkspaceIdRequestBody workspaceIdRequestBody) {
     return ApiHelper.execute(() -> sourceHandler.listSourcesForWorkspace(workspaceIdRequestBody));
@@ -120,6 +129,7 @@ public class SourceApiController implements SourceApi {
 
   @Post("/update")
   @Secured({EDITOR})
+  @SecuredWorkspace
   @Override
   public SourceRead updateSource(final SourceUpdate sourceUpdate) {
     return ApiHelper.execute(() -> sourceHandler.updateSource(sourceUpdate));

--- a/airbyte-server/src/main/java/io/airbyte/server/apis/SourceDefinitionApiController.java
+++ b/airbyte-server/src/main/java/io/airbyte/server/apis/SourceDefinitionApiController.java
@@ -19,6 +19,7 @@ import io.airbyte.api.model.generated.SourceDefinitionRead;
 import io.airbyte.api.model.generated.SourceDefinitionReadList;
 import io.airbyte.api.model.generated.SourceDefinitionUpdate;
 import io.airbyte.api.model.generated.WorkspaceIdRequestBody;
+import io.airbyte.commons.auth.SecuredWorkspace;
 import io.airbyte.commons.server.handlers.SourceDefinitionsHandler;
 import io.micronaut.context.annotation.Context;
 import io.micronaut.context.annotation.Requires;
@@ -44,6 +45,7 @@ public class SourceDefinitionApiController implements SourceDefinitionApi {
 
   @Post("/create_custom")
   @Secured({EDITOR})
+  @SecuredWorkspace
   @Override
   public SourceDefinitionRead createCustomSourceDefinition(final CustomSourceDefinitionCreate customSourceDefinitionCreate) {
     return ApiHelper.execute(() -> sourceDefinitionsHandler.createCustomSourceDefinition(customSourceDefinitionCreate));
@@ -69,6 +71,7 @@ public class SourceDefinitionApiController implements SourceDefinitionApi {
 
   @Post("/get_for_workspace")
   @Secured({READER})
+  @SecuredWorkspace
   @Override
   public SourceDefinitionRead getSourceDefinitionForWorkspace(final SourceDefinitionIdWithWorkspaceId sourceDefinitionIdWithWorkspaceId) {
     return ApiHelper.execute(() -> sourceDefinitionsHandler.getSourceDefinitionForWorkspace(sourceDefinitionIdWithWorkspaceId));
@@ -104,6 +107,7 @@ public class SourceDefinitionApiController implements SourceDefinitionApi {
 
   @Post("/list_for_workspace")
   @Secured({READER})
+  @SecuredWorkspace
   @Override
   public SourceDefinitionReadList listSourceDefinitionsForWorkspace(final WorkspaceIdRequestBody workspaceIdRequestBody) {
     return ApiHelper.execute(() -> sourceDefinitionsHandler.listSourceDefinitionsForWorkspace(workspaceIdRequestBody));

--- a/airbyte-server/src/main/java/io/airbyte/server/apis/SourceOauthApiController.java
+++ b/airbyte-server/src/main/java/io/airbyte/server/apis/SourceOauthApiController.java
@@ -12,6 +12,7 @@ import io.airbyte.api.model.generated.CompleteSourceOauthRequest;
 import io.airbyte.api.model.generated.OAuthConsentRead;
 import io.airbyte.api.model.generated.SetInstancewideSourceOauthParamsRequestBody;
 import io.airbyte.api.model.generated.SourceOauthConsentRequest;
+import io.airbyte.commons.auth.SecuredWorkspace;
 import io.airbyte.commons.server.handlers.OAuthHandler;
 import io.micronaut.context.annotation.Requires;
 import io.micronaut.http.annotation.Body;
@@ -35,6 +36,7 @@ public class SourceOauthApiController implements SourceOauthApi {
 
   @Post("/complete_oauth")
   @Secured({EDITOR})
+  @SecuredWorkspace
   @Override
   public Map<String, Object> completeSourceOAuth(@Body final CompleteSourceOauthRequest completeSourceOauthRequest) {
     return ApiHelper.execute(() -> oAuthHandler.completeSourceOAuth(completeSourceOauthRequest));
@@ -42,6 +44,7 @@ public class SourceOauthApiController implements SourceOauthApi {
 
   @Post("/get_consent_url")
   @Secured({EDITOR})
+  @SecuredWorkspace
   @Override
   public OAuthConsentRead getSourceOAuthConsent(@Body final SourceOauthConsentRequest sourceOauthConsentRequest) {
     return ApiHelper.execute(() -> oAuthHandler.getSourceOAuthConsent(sourceOauthConsentRequest));

--- a/airbyte-server/src/main/java/io/airbyte/server/apis/StateApiController.java
+++ b/airbyte-server/src/main/java/io/airbyte/server/apis/StateApiController.java
@@ -11,6 +11,7 @@ import io.airbyte.api.generated.StateApi;
 import io.airbyte.api.model.generated.ConnectionIdRequestBody;
 import io.airbyte.api.model.generated.ConnectionState;
 import io.airbyte.api.model.generated.ConnectionStateCreateOrUpdate;
+import io.airbyte.commons.auth.SecuredWorkspace;
 import io.airbyte.commons.server.handlers.StateHandler;
 import io.micronaut.context.annotation.Requires;
 import io.micronaut.http.annotation.Controller;
@@ -39,6 +40,7 @@ public class StateApiController implements StateApi {
 
   @Post("/get")
   @Secured({READER})
+  @SecuredWorkspace
   @Override
   public ConnectionState getState(final ConnectionIdRequestBody connectionIdRequestBody) {
     return ApiHelper.execute(() -> stateHandler.getState(connectionIdRequestBody));

--- a/airbyte-server/src/main/java/io/airbyte/server/apis/WebBackendApiController.java
+++ b/airbyte-server/src/main/java/io/airbyte/server/apis/WebBackendApiController.java
@@ -21,6 +21,7 @@ import io.airbyte.api.model.generated.WebBackendConnectionUpdate;
 import io.airbyte.api.model.generated.WebBackendGeographiesListResult;
 import io.airbyte.api.model.generated.WebBackendWorkspaceState;
 import io.airbyte.api.model.generated.WebBackendWorkspaceStateResult;
+import io.airbyte.commons.auth.SecuredWorkspace;
 import io.airbyte.commons.server.handlers.WebBackendCheckUpdatesHandler;
 import io.airbyte.commons.server.handlers.WebBackendConnectionsHandler;
 import io.airbyte.commons.server.handlers.WebBackendGeographiesHandler;
@@ -50,6 +51,7 @@ public class WebBackendApiController implements WebBackendApi {
 
   @Post("/state/get_type")
   @Secured({READER})
+  @SecuredWorkspace
   @Override
   public ConnectionStateType getStateType(final ConnectionIdRequestBody connectionIdRequestBody) {
     return ApiHelper.execute(() -> webBackendConnectionsHandler.getStateType(connectionIdRequestBody));
@@ -64,6 +66,7 @@ public class WebBackendApiController implements WebBackendApi {
 
   @Post("/connections/create")
   @Secured({EDITOR})
+  @SecuredWorkspace
   @Override
   public WebBackendConnectionRead webBackendCreateConnection(final WebBackendConnectionCreate webBackendConnectionCreate) {
     return ApiHelper.execute(() -> webBackendConnectionsHandler.webBackendCreateConnection(webBackendConnectionCreate));
@@ -71,6 +74,7 @@ public class WebBackendApiController implements WebBackendApi {
 
   @Post("/connections/get")
   @Secured({READER})
+  @SecuredWorkspace
   @Override
   public WebBackendConnectionRead webBackendGetConnection(final WebBackendConnectionRequestBody webBackendConnectionRequestBody) {
     return ApiHelper.execute(() -> webBackendConnectionsHandler.webBackendGetConnection(webBackendConnectionRequestBody));
@@ -78,6 +82,7 @@ public class WebBackendApiController implements WebBackendApi {
 
   @Post("/workspace/state")
   @Secured({READER})
+  @SecuredWorkspace
   @Override
   public WebBackendWorkspaceStateResult webBackendGetWorkspaceState(final WebBackendWorkspaceState webBackendWorkspaceState) {
     return ApiHelper.execute(() -> webBackendConnectionsHandler.getWorkspaceState(webBackendWorkspaceState));
@@ -85,6 +90,7 @@ public class WebBackendApiController implements WebBackendApi {
 
   @Post("/connections/list")
   @Secured({READER})
+  @SecuredWorkspace
   @Override
   public WebBackendConnectionReadList webBackendListConnectionsForWorkspace(final WebBackendConnectionListRequestBody webBackendConnectionListRequestBody) {
     return ApiHelper.execute(() -> webBackendConnectionsHandler.webBackendListConnectionsForWorkspace(webBackendConnectionListRequestBody));

--- a/airbyte-server/src/main/java/io/airbyte/server/apis/WorkspaceApiController.java
+++ b/airbyte-server/src/main/java/io/airbyte/server/apis/WorkspaceApiController.java
@@ -6,6 +6,7 @@ package io.airbyte.server.apis;
 
 import static io.airbyte.commons.auth.AuthRoleConstants.AUTHENTICATED_USER;
 import static io.airbyte.commons.auth.AuthRoleConstants.OWNER;
+import static io.airbyte.commons.auth.AuthRoleConstants.READER;
 
 import io.airbyte.api.generated.WorkspaceApi;
 import io.airbyte.api.model.generated.ConnectionIdRequestBody;
@@ -17,6 +18,7 @@ import io.airbyte.api.model.generated.WorkspaceRead;
 import io.airbyte.api.model.generated.WorkspaceReadList;
 import io.airbyte.api.model.generated.WorkspaceUpdate;
 import io.airbyte.api.model.generated.WorkspaceUpdateName;
+import io.airbyte.commons.auth.SecuredWorkspace;
 import io.airbyte.commons.server.handlers.WorkspacesHandler;
 import io.micronaut.context.annotation.Requires;
 import io.micronaut.http.HttpStatus;
@@ -49,6 +51,7 @@ public class WorkspaceApiController implements WorkspaceApi {
 
   @Post("/delete")
   @Secured({OWNER})
+  @SecuredWorkspace
   @Override
   @Status(HttpStatus.NO_CONTENT)
   public void deleteWorkspace(@Body final WorkspaceIdRequestBody workspaceIdRequestBody) {
@@ -60,6 +63,7 @@ public class WorkspaceApiController implements WorkspaceApi {
 
   @Post("/get")
   @Secured({OWNER})
+  @SecuredWorkspace
   @Override
   public WorkspaceRead getWorkspace(@Body final WorkspaceIdRequestBody workspaceIdRequestBody) {
     return ApiHelper.execute(() -> workspacesHandler.getWorkspace(workspaceIdRequestBody));
@@ -67,6 +71,7 @@ public class WorkspaceApiController implements WorkspaceApi {
 
   @Post("/get_by_slug")
   @Secured({OWNER})
+  @SecuredWorkspace
   @Override
   public WorkspaceRead getWorkspaceBySlug(@Body final SlugRequestBody slugRequestBody) {
     return ApiHelper.execute(() -> workspacesHandler.getWorkspaceBySlug(slugRequestBody));
@@ -81,6 +86,7 @@ public class WorkspaceApiController implements WorkspaceApi {
 
   @Post("/update")
   @Secured({OWNER})
+  @SecuredWorkspace
   @Override
   public WorkspaceRead updateWorkspace(@Body final WorkspaceUpdate workspaceUpdate) {
     return ApiHelper.execute(() -> workspacesHandler.updateWorkspace(workspaceUpdate));
@@ -88,6 +94,7 @@ public class WorkspaceApiController implements WorkspaceApi {
 
   @Post("/tag_feedback_status_as_done")
   @Secured({OWNER})
+  @SecuredWorkspace
   @Override
   public void updateWorkspaceFeedback(@Body final WorkspaceGiveFeedback workspaceGiveFeedback) {
     ApiHelper.execute(() -> {
@@ -98,13 +105,14 @@ public class WorkspaceApiController implements WorkspaceApi {
 
   @Post("/update_name")
   @Secured({OWNER})
+  @SecuredWorkspace
   @Override
   public WorkspaceRead updateWorkspaceName(@Body final WorkspaceUpdateName workspaceUpdateName) {
     return ApiHelper.execute(() -> workspacesHandler.updateWorkspaceName(workspaceUpdateName));
   }
 
   @Post("/get_by_connection_id")
-  @Secured({AUTHENTICATED_USER})
+  @Secured({READER})
   @Override
   public WorkspaceRead getWorkspaceByConnectionId(@Body final ConnectionIdRequestBody connectionIdRequestBody) {
     return ApiHelper.execute(() -> workspacesHandler.getWorkspaceByConnectionId(connectionIdRequestBody));


### PR DESCRIPTION
## What
* Identify endpoints that require workspace-level roles for authentication

## How
* Add a marker annotation that can be used to identify workspace-level secured endpoints
* Update existing endpoints that currently use workspace-level authentication in cloud

The authentication provider in cloud will scan for these annotations to build a list of endpoints that require fetching workspace roles for a user.

## Recommended reading order
1. `SecuredWorkspace.java`
2. `*Controller.java`

## Tests

* All tests pass
* Project builds locally
* Tested in Cloud with new Micronaut authentication provider
