### PR TITLE
Introduce new pattern of Github PAT usage for #2641

### DIFF
--- a/.github/workflows/approve-and-merge-dispatch.yml
+++ b/.github/workflows/approve-and-merge-dispatch.yml
@@ -6,20 +6,11 @@ jobs:
   approveAndMergeDispatch:
     runs-on: ubuntu-latest
     steps:
-      - name: Checkout Airbyte
-        uses: actions/checkout@v3
-      - name: Check PAT rate limits
-        run: |
-          ./tools/bin/find_non_rate_limited_PAT \
-            ${{ secrets.AIRBYTEIO_PAT }} \
-            ${{ secrets.OCTAVIA_GITHUB_RUNNER_TOKEN }} \
-            ${{ secrets.SUPERTOPHER_PAT }}
-
       - name: Auto Approve Slash Command Dispatch
         uses: peter-evans/slash-command-dispatch@v3
         id: scd
         with:
-          token: ${{ env.PAT }}
+          token: ${{ secrets.GH_PAT_APPROVINGTON_OCTAVIA }}
           permission: write
           issue-type: pull-request
           repository: airbytehq/airbyte-cloud

--- a/.github/workflows/commands-for-testing-tool.yml
+++ b/.github/workflows/commands-for-testing-tool.yml
@@ -13,15 +13,6 @@ jobs:
       comment-id: ${{ steps.comment-info.outputs.comment-id }}
       command: ${{ steps.regex.outputs.first_match }}
     steps:
-      - name: Checkout Airbyte
-        uses: actions/checkout@v3
-      - name: Check PAT rate limits
-        run: |
-          ./tools/bin/find_non_rate_limited_PAT \
-            ${{ secrets.AIRBYTEIO_PAT }} \
-            ${{ secrets.OSS_BUILD_RUNNER_GITHUB_PAT }} \
-            ${{ secrets.SUPERTOPHER_PAT }} \
-            ${{ secrets.DAVINCHIA_PAT }}
       - name: Get PR repo and ref
         id: getref
         run: |

--- a/.github/workflows/connector_integration_tests.yml
+++ b/.github/workflows/connector_integration_tests.yml
@@ -28,7 +28,7 @@ jobs:
       - name: Launch Integration Tests
         run: python ./tools/bin/ci_integration_workflow_launcher.py base-normalization source-acceptance-test source:beta source:GA destination:beta destination:GA
         env:
-          GITHUB_TOKEN: ${{ secrets.SLASH_COMMAND_PAT }}
+          GITHUB_TOKEN: ${{ secrets.GH_PAT_MAINTENANCE_OSS }}
   launch_integration_tests_alpha_only:
     runs-on: ubuntu-latest
     if: github.ref == 'refs/heads/master'
@@ -47,4 +47,4 @@ jobs:
       - name: Launch Integration Tests (Alpha connectors)
         run: python ./tools/bin/ci_integration_workflow_launcher.py source:alpha destination:alpha
         env:
-          GITHUB_TOKEN: ${{ secrets.SLASH_COMMAND_PAT }}
+          GITHUB_TOKEN: ${{ secrets.GH_PAT_MAINTENANCE_OSS }}

--- a/.github/workflows/deploy-oss-catalog.yml
+++ b/.github/workflows/deploy-oss-catalog.yml
@@ -36,14 +36,9 @@ jobs:
           gcs_bucket_name="prod-airbyte-cloud-connector-metadata-service"
           catalog_path="airbyte-config/init/src/main/resources/seed/oss_catalog.json"
           gsutil -h "Cache-Control:public, max-age=10" cp "$catalog_path" "gs://$gcs_bucket_name/oss_catalog.json"
-      - name: Check PAT rate limits
-        run: |
-          ./tools/bin/find_non_rate_limited_PAT \
-            ${{ secrets.OCTAVIA_4_ROOT_ACCESS }} \
-            ${{ secrets.OCTAVIA_PAT }}
       - name: Trigger Cloud catalog generation
         uses: peter-evans/repository-dispatch@v2
         with:
-          token: ${{ env.PAT }}
+          token: ${{ secrets.GH_PAT_MAINTENANCE_OCTAVIA }}
           repository: airbytehq/airbyte-cloud
           event-type: generate-cloud-catalog

--- a/.github/workflows/gke-kube-test-command.yml
+++ b/.github/workflows/gke-kube-test-command.yml
@@ -33,10 +33,8 @@ jobs:
       - name: Check PAT rate limits
         run: |
           ./tools/bin/find_non_rate_limited_PAT \
-            ${{ secrets.AIRBYTEIO_PAT }} \
-            ${{ secrets.OSS_BUILD_RUNNER_GITHUB_PAT }} \
-            ${{ secrets.SUPERTOPHER_PAT }} \
-            ${{ secrets.DAVINCHIA_PAT }}
+            ${{ secrets.GH_PAT_BUILD_RUNNER_OSS }} \
+            ${{ secrets.GH_PAT_BUILD_RUNNER_BACKUP }}
       - name: Start AWS Runner
         id: start-ec2-runner
         uses: ./.github/actions/start-aws-runner
@@ -152,10 +150,8 @@ jobs:
       - name: Check PAT rate limits
         run: |
           ./tools/bin/find_non_rate_limited_PAT \
-            ${{ secrets.AIRBYTEIO_PAT }} \
-            ${{ secrets.OSS_BUILD_RUNNER_GITHUB_PAT }} \
-            ${{ secrets.SUPERTOPHER_PAT }} \
-            ${{ secrets.DAVINCHIA_PAT }}
+            ${{ secrets.GH_PAT_BUILD_RUNNER_OSS }} \
+            ${{ secrets.GH_PAT_BUILD_RUNNER_BACKUP }}
       - name: Stop EC2 runner
         uses: supertopher/ec2-github-runner@base64v1.0.10
         with:

--- a/.github/workflows/gradle.yml
+++ b/.github/workflows/gradle.yml
@@ -124,7 +124,6 @@ jobs:
       - uses: actions/setup-python@v4
         with:
           python-version: "3.9"
-          token: ${{ env.PAT }}
 
       - name: Set up CI Gradle Properties
         run: |
@@ -191,10 +190,8 @@ jobs:
       - name: Check PAT rate limits
         run: |
           ./tools/bin/find_non_rate_limited_PAT \
-            ${{ secrets.AIRBYTEIO_PAT }} \
-            ${{ secrets.OSS_BUILD_RUNNER_GITHUB_PAT }} \
-            ${{ secrets.SUPERTOPHER_PAT }} \
-            ${{ secrets.DAVINCHIA_PAT }}
+            ${{ secrets.GH_PAT_BUILD_RUNNER_OSS }} \
+            ${{ secrets.GH_PAT_BUILD_RUNNER_BACKUP }}
       - name: Start AWS Runner
         id: start-ec2-runner
         uses: ./.github/actions/start-aws-runner
@@ -230,7 +227,6 @@ jobs:
       - uses: actions/setup-python@v4
         with:
           python-version: "3.9"
-          token: ${{ env.PAT }}
 
       - name: Install Pyenv
         run: python3 -m pip install virtualenv==16.7.9 --user
@@ -345,10 +341,8 @@ jobs:
       - name: Check PAT rate limits
         run: |
           ./tools/bin/find_non_rate_limited_PAT \
-            ${{ secrets.AIRBYTEIO_PAT }} \
-            ${{ secrets.OSS_BUILD_RUNNER_GITHUB_PAT }} \
-            ${{ secrets.SUPERTOPHER_PAT }} \
-            ${{ secrets.DAVINCHIA_PAT }}
+            ${{ secrets.GH_PAT_BUILD_RUNNER_OSS }} \
+            ${{ secrets.GH_PAT_BUILD_RUNNER_BACKUP }}
       - name: Stop EC2 runner
         uses: supertopher/ec2-github-runner@base64v1.0.10
         with:
@@ -378,10 +372,8 @@ jobs:
       - name: Check PAT rate limits
         run: |
           ./tools/bin/find_non_rate_limited_PAT \
-            ${{ secrets.AIRBYTEIO_PAT }} \
-            ${{ secrets.OSS_BUILD_RUNNER_GITHUB_PAT }} \
-            ${{ secrets.SUPERTOPHER_PAT }} \
-            ${{ secrets.DAVINCHIA_PAT }}
+            ${{ secrets.GH_PAT_BUILD_RUNNER_OSS }} \
+            ${{ secrets.GH_PAT_BUILD_RUNNER_BACKUP }}
       - name: Start AWS Runner
         id: start-ec2-runner
         uses: ./.github/actions/start-aws-runner
@@ -414,7 +406,6 @@ jobs:
       - uses: actions/setup-python@v4
         with:
           python-version: "3.9"
-          token: ${{ env.PAT }}
 
       - name: Set up CI Gradle Properties
         run: |
@@ -469,10 +460,8 @@ jobs:
       - name: Check PAT rate limits
         run: |
           ./tools/bin/find_non_rate_limited_PAT \
-            ${{ secrets.AIRBYTEIO_PAT }} \
-            ${{ secrets.OSS_BUILD_RUNNER_GITHUB_PAT }} \
-            ${{ secrets.SUPERTOPHER_PAT }} \
-            ${{ secrets.DAVINCHIA_PAT }}
+            ${{ secrets.GH_PAT_BUILD_RUNNER_OSS }} \
+            ${{ secrets.GH_PAT_BUILD_RUNNER_BACKUP }}
       - name: Stop EC2 runner
         uses: supertopher/ec2-github-runner@base64v1.0.10
         with:
@@ -502,10 +491,8 @@ jobs:
       - name: Check PAT rate limits
         run: |
           ./tools/bin/find_non_rate_limited_PAT \
-            ${{ secrets.AIRBYTEIO_PAT }} \
-            ${{ secrets.OSS_BUILD_RUNNER_GITHUB_PAT }} \
-            ${{ secrets.SUPERTOPHER_PAT }} \
-            ${{ secrets.DAVINCHIA_PAT }}
+            ${{ secrets.GH_PAT_BUILD_RUNNER_OSS }} \
+            ${{ secrets.GH_PAT_BUILD_RUNNER_BACKUP }}
       - name: Start AWS Runner
         id: start-ec2-runner
         uses: ./.github/actions/start-aws-runner
@@ -538,7 +525,6 @@ jobs:
       - uses: actions/setup-python@v4
         with:
           python-version: "3.9"
-          token: ${{ env.PAT }}
 
       - name: Delete default old docker and replace it with a new one
         shell: bash
@@ -602,10 +588,8 @@ jobs:
       - name: Check PAT rate limits
         run: |
           ./tools/bin/find_non_rate_limited_PAT \
-            ${{ secrets.AIRBYTEIO_PAT }} \
-            ${{ secrets.OSS_BUILD_RUNNER_GITHUB_PAT }} \
-            ${{ secrets.SUPERTOPHER_PAT }} \
-            ${{ secrets.DAVINCHIA_PAT }}
+            ${{ secrets.GH_PAT_BUILD_RUNNER_OSS }} \
+            ${{ secrets.GH_PAT_BUILD_RUNNER_BACKUP }}
       - name: Stop EC2 runner
         uses: supertopher/ec2-github-runner@base64v1.0.10
         with:
@@ -635,10 +619,8 @@ jobs:
       - name: Check PAT rate limits
         run: |
           ./tools/bin/find_non_rate_limited_PAT \
-            ${{ secrets.AIRBYTEIO_PAT }} \
-            ${{ secrets.OSS_BUILD_RUNNER_GITHUB_PAT }} \
-            ${{ secrets.SUPERTOPHER_PAT }} \
-            ${{ secrets.DAVINCHIA_PAT }}
+            ${{ secrets.GH_PAT_BUILD_RUNNER_OSS }} \
+            ${{ secrets.GH_PAT_BUILD_RUNNER_BACKUP }}
       - name: Start AWS Runner
         id: start-ec2-runner
         uses: ./.github/actions/start-aws-runner
@@ -670,7 +652,6 @@ jobs:
       - uses: actions/setup-python@v4
         with:
           python-version: "3.9"
-          token: ${{ env.PAT }}
 
       - uses: actions/setup-node@v3
         with:
@@ -805,7 +786,6 @@ jobs:
         if: always()
         with:
           python-version: "3.9"
-          token: ${{ env.PAT }}
 
       - name: Publish Platform Test Results
         uses: EnricoMi/publish-unit-test-result-action@v2
@@ -881,10 +861,8 @@ jobs:
       - name: Check PAT rate limits
         run: |
           ./tools/bin/find_non_rate_limited_PAT \
-            ${{ secrets.AIRBYTEIO_PAT }} \
-            ${{ secrets.OSS_BUILD_RUNNER_GITHUB_PAT }} \
-            ${{ secrets.SUPERTOPHER_PAT }} \
-            ${{ secrets.DAVINCHIA_PAT }}
+            ${{ secrets.GH_PAT_BUILD_RUNNER_OSS }} \
+            ${{ secrets.GH_PAT_BUILD_RUNNER_BACKUP }}
       - name: Stop EC2 runner
         uses: supertopher/ec2-github-runner@base64v1.0.10
         with:
@@ -913,10 +891,8 @@ jobs:
       - name: Check PAT rate limits
         run: |
           ./tools/bin/find_non_rate_limited_PAT \
-            ${{ secrets.AIRBYTEIO_PAT }} \
-            ${{ secrets.OSS_BUILD_RUNNER_GITHUB_PAT }} \
-            ${{ secrets.SUPERTOPHER_PAT }} \
-            ${{ secrets.DAVINCHIA_PAT }}
+            ${{ secrets.GH_PAT_BUILD_RUNNER_OSS }} \
+            ${{ secrets.GH_PAT_BUILD_RUNNER_BACKUP }}
       - name: Start AWS Runner
         id: start-ec2-runner
         uses: ./.github/actions/start-aws-runner
@@ -951,7 +927,6 @@ jobs:
       - uses: actions/setup-python@v4
         with:
           python-version: "3.9"
-          token: ${{ env.PAT }}
 
       - name: Install unzip
         shell: bash
@@ -1028,7 +1003,6 @@ jobs:
         if: always()
         with:
           python-version: "3.9"
-          token: ${{ env.PAT }}
 
       - name: Publish Kube Test Results
         id: kube-results
@@ -1109,10 +1083,8 @@ jobs:
       - name: Check PAT rate limits
         run: |
           ./tools/bin/find_non_rate_limited_PAT \
-            ${{ secrets.AIRBYTEIO_PAT }} \
-            ${{ secrets.OSS_BUILD_RUNNER_GITHUB_PAT }} \
-            ${{ secrets.SUPERTOPHER_PAT }} \
-            ${{ secrets.DAVINCHIA_PAT }}
+            ${{ secrets.GH_PAT_BUILD_RUNNER_OSS }} \
+            ${{ secrets.GH_PAT_BUILD_RUNNER_BACKUP }}
       - name: Stop EC2 runner
         uses: supertopher/ec2-github-runner@base64v1.0.10
         with:
@@ -1141,10 +1113,8 @@ jobs:
       - name: Check PAT rate limits
         run: |
           ./tools/bin/find_non_rate_limited_PAT \
-            ${{ secrets.AIRBYTEIO_PAT }} \
-            ${{ secrets.OSS_BUILD_RUNNER_GITHUB_PAT }} \
-            ${{ secrets.SUPERTOPHER_PAT }} \
-            ${{ secrets.DAVINCHIA_PAT }}
+            ${{ secrets.GH_PAT_BUILD_RUNNER_OSS }} \
+            ${{ secrets.GH_PAT_BUILD_RUNNER_BACKUP }}
       - name: Start AWS Runner
         id: start-ec2-runner
         uses: ./.github/actions/start-aws-runner
@@ -1199,7 +1169,6 @@ jobs:
       - uses: actions/setup-python@v4
         with:
           python-version: "3.9"
-          token: ${{ env.PAT }}
 
       - uses: actions/setup-java@v1
         with:
@@ -1344,10 +1313,8 @@ jobs:
       - name: Check PAT rate limits
         run: |
           ./tools/bin/find_non_rate_limited_PAT \
-            ${{ secrets.AIRBYTEIO_PAT }} \
-            ${{ secrets.OSS_BUILD_RUNNER_GITHUB_PAT }} \
-            ${{ secrets.SUPERTOPHER_PAT }} \
-            ${{ secrets.DAVINCHIA_PAT }}
+            ${{ secrets.GH_PAT_BUILD_RUNNER_OSS }} \
+            ${{ secrets.GH_PAT_BUILD_RUNNER_BACKUP }}
       - name: Stop EC2 runner
         uses: supertopher/ec2-github-runner@base64v1.0.10
         with:

--- a/.github/workflows/label-github-issues-by-context.yml
+++ b/.github/workflows/label-github-issues-by-context.yml
@@ -8,20 +8,12 @@ jobs:
     name: "Add Labels to Issues.  Safe to Merge on fail"
     runs-on: ubuntu-latest
     steps:
-      - name: Checkout Airbyte Repo for PAT command
-        uses: actions/checkout@v3
-      - name: Check PAT rate limits
-        # Cannot share PAT outside of JOB context
-        run: |
-          ./tools/bin/find_non_rate_limited_PAT \
-            ${{ secrets.OCTAVIA_4_ROOT_ACCESS }} \
-            ${{ secrets.OCTAVIA_PAT }}
       - name: Run Issue Command from workflow-actions
         uses: nick-fields/private-action-loader@v3
         with:
-          pal-repo-token: "${{ env.PAT }}"
+          pal-repo-token: "${{ secrets.GH_PAT_MAINTENANCE_OCTAVIA }}"
           pal-repo-name: airbytehq/workflow-actions@production
           # the following input gets passed to the private
-          token: "${{ env.PAT }}"
+          token: "${{ secrets.GH_PAT_MAINTENANCE_OCTAVIA }}"
           # ref: https://github.com/airbytehq/workflow-actions/blob/main/src/bin_issue.ts
           command: "issue"

--- a/.github/workflows/label-github-issues-by-path.yml
+++ b/.github/workflows/label-github-issues-by-path.yml
@@ -10,16 +10,8 @@ jobs:
     name: "Label PRs based on files changes"
     runs-on: ubuntu-latest
     steps:
-      - name: Checkout Airbyte Repo for PAT command
-        uses: actions/checkout@v2
-      - name: Check PAT rate limits
-        # Cannot share PAT outside of JOB context
-        run: |
-          ./tools/bin/find_non_rate_limited_PAT \
-            ${{ secrets.OCTAVIA_4_ROOT_ACCESS }} \
-            ${{ secrets.OCTAVIA_PAT }}
       - name: "Label PR based on changed files"
         uses: actions/labeler@v3
         with:
-          repo-token: "${{ env.PAT }}"
+          repo-token: "${{ secrets.GH_PAT_MAINTENANCE_OCTAVIA }}"
           sync-labels: true

--- a/.github/workflows/label-prs-by-context.yml
+++ b/.github/workflows/label-prs-by-context.yml
@@ -10,19 +10,11 @@ jobs:
     name: "Add Labels to PRs.  Safe to Merge on fail"
     runs-on: ubuntu-latest
     steps:
-      - name: Checkout Airbyte Repo for PAT command
-        uses: actions/checkout@v3
-      - name: Check PAT rate limits
-        # Cannot share PAT outside of JOB context
-        run: |
-          ./tools/bin/find_non_rate_limited_PAT \
-            ${{ secrets.OCTAVIA_4_ROOT_ACCESS }} \
-            ${{ secrets.OCTAVIA_PAT }}
       - name: Run Issue Command from workflow-actions
         uses: nick-fields/private-action-loader@v3
         with:
-          pal-repo-token: "${{ env.PAT }}"
+          pal-repo-token: "${{ GH_PAT_MAINTENANCE_OCTAVIA }}"
           pal-repo-name: airbytehq/workflow-actions@production
           # the following input gets passed to the private action
-          token: "${{ env.PAT }}"
+          token: "${{ GH_PAT_MAINTENANCE_OCTAVIA }}"
           command: "pull"

--- a/.github/workflows/notify-on-push-to-master.yml
+++ b/.github/workflows/notify-on-push-to-master.yml
@@ -10,18 +10,10 @@ jobs:
     name: "Fire a Repo Dispatch event to airbyte-cloud"
     runs-on: ubuntu-latest
     steps:
-      - name: Checkout Airbyte Repo for PAT command
-        uses: actions/checkout@v3
-      - name: Check PAT rate limits
-        # Cannot share PAT outside of JOB context
-        run: |
-          ./tools/bin/find_non_rate_limited_PAT \
-            ${{ secrets.OCTAVIA_4_ROOT_ACCESS }} \
-            ${{ secrets.OCTAVIA_PAT }}
       - name: Repository Dispatch
         uses: peter-evans/repository-dispatch@v2
         with:
-          token: ${{ env.PAT }}
+          token: ${{ GH_PAT_MAINTENANCE_OCTAVIA }}
           repository: airbytehq/airbyte-cloud
           event-type: oss-push-to-master
           client-payload: '{"ref": "${{ github.ref }}", "sha": "${{ github.sha }}"}'

--- a/.github/workflows/publish-cdk-command-manually.yml
+++ b/.github/workflows/publish-cdk-command-manually.yml
@@ -43,7 +43,7 @@ jobs:
         with:
           repository: ${{ github.event.inputs.repo }}
           ref: ${{ github.event.inputs.gitref }}
-          token: ${{ secrets.AIRBYTEIO_PAT }}
+          token: ${{ secrets.GH_PAT_MAINTENANCE_OSS }}
       - name: "Publish Airbyte CDK: bump version"
         run: |
           pip install bumpversion

--- a/.github/workflows/publish-command.yml
+++ b/.github/workflows/publish-command.yml
@@ -47,10 +47,8 @@ jobs:
       - name: Check PAT rate limits
         run: |
           ./tools/bin/find_non_rate_limited_PAT \
-            ${{ secrets.AIRBYTEIO_PAT }} \
-            ${{ secrets.OSS_BUILD_RUNNER_GITHUB_PAT }} \
-            ${{ secrets.SUPERTOPHER_PAT }} \
-            ${{ secrets.DAVINCHIA_PAT }}
+            ${{ secrets.GH_PAT_BUILD_RUNNER_OSS }} \
+            ${{ secrets.GH_PAT_BUILD_RUNNER_BACKUP }}
       - name: Start AWS Runner
         id: start-ec2-runner
         uses: ./.github/actions/start-aws-runner
@@ -75,10 +73,8 @@ jobs:
       - name: Check PAT rate limits
         run: |
           ./tools/bin/find_non_rate_limited_PAT \
-            ${{ secrets.AIRBYTEIO_PAT }} \
-            ${{ secrets.OSS_BUILD_RUNNER_GITHUB_PAT }} \
-            ${{ secrets.SUPERTOPHER_PAT }} \
-            ${{ secrets.DAVINCHIA_PAT }}
+            ${{ secrets.GH_PAT_BUILD_RUNNER_OSS }} \
+            ${{ secrets.GH_PAT_BUILD_RUNNER_BACKUP }}
       - name: Start AWS Runner
         id: start-ec2-runner
         uses: ./.github/actions/start-aws-runner
@@ -103,10 +99,8 @@ jobs:
       - name: Check PAT rate limits
         run: |
           ./tools/bin/find_non_rate_limited_PAT \
-            ${{ secrets.AIRBYTEIO_PAT }} \
-            ${{ secrets.OSS_BUILD_RUNNER_GITHUB_PAT }} \
-            ${{ secrets.SUPERTOPHER_PAT }} \
-            ${{ secrets.DAVINCHIA_PAT }}
+            ${{ secrets.GH_PAT_BUILD_RUNNER_OSS }} \
+            ${{ secrets.GH_PAT_BUILD_RUNNER_BACKUP }}
       - name: Start AWS Runner
         id: start-ec2-runner
         uses: ./.github/actions/start-aws-runner
@@ -131,10 +125,8 @@ jobs:
       - name: Check PAT rate limits
         run: |
           ./tools/bin/find_non_rate_limited_PAT \
-            ${{ secrets.AIRBYTEIO_PAT }} \
-            ${{ secrets.OSS_BUILD_RUNNER_GITHUB_PAT }} \
-            ${{ secrets.SUPERTOPHER_PAT }} \
-            ${{ secrets.DAVINCHIA_PAT }}
+            ${{ secrets.GH_PAT_BUILD_RUNNER_OSS }} \
+            ${{ secrets.GH_PAT_BUILD_RUNNER_BACKUP }}
       - name: Start AWS Runner
         id: start-ec2-runner
         uses: ./.github/actions/start-aws-runner
@@ -159,10 +151,8 @@ jobs:
       - name: Check PAT rate limits
         run: |
           ./tools/bin/find_non_rate_limited_PAT \
-            ${{ secrets.AIRBYTEIO_PAT }} \
-            ${{ secrets.OSS_BUILD_RUNNER_GITHUB_PAT }} \
-            ${{ secrets.SUPERTOPHER_PAT }} \
-            ${{ secrets.DAVINCHIA_PAT }}
+            ${{ secrets.GH_PAT_BUILD_RUNNER_OSS }} \
+            ${{ secrets.GH_PAT_BUILD_RUNNER_BACKUP }}
       - name: Start AWS Runner
         id: start-ec2-runner
         uses: ./.github/actions/start-aws-runner
@@ -250,7 +240,7 @@ jobs:
         with:
           repository: ${{ github.event.inputs.repo }}
           ref: ${{ github.event.inputs.gitref }}
-          token: ${{ secrets.OCTAVIA_PAT }}
+          token: ${{ secrets.GH_PAT_MAINTENANCE_OSS }}
       - name: Install Java
         uses: actions/setup-java@v3
         with:
@@ -440,10 +430,8 @@ jobs:
       - name: Check PAT rate limits
         run: |
           ./tools/bin/find_non_rate_limited_PAT \
-            ${{ secrets.AIRBYTEIO_PAT }} \
-            ${{ secrets.OSS_BUILD_RUNNER_GITHUB_PAT }} \
-            ${{ secrets.SUPERTOPHER_PAT }} \
-            ${{ secrets.DAVINCHIA_PAT }}
+            ${{ secrets.GH_PAT_BUILD_RUNNER_OSS }} \
+            ${{ secrets.GH_PAT_BUILD_RUNNER_BACKUP }}
       - name: Stop EC2 runner
         uses: airbytehq/ec2-github-runner@base64v1.1.0
         with:
@@ -497,10 +485,8 @@ jobs:
       - name: Check PAT rate limits
         run: |
           ./tools/bin/find_non_rate_limited_PAT \
-            ${{ secrets.AIRBYTEIO_PAT }} \
-            ${{ secrets.OSS_BUILD_RUNNER_GITHUB_PAT }} \
-            ${{ secrets.SUPERTOPHER_PAT }} \
-            ${{ secrets.DAVINCHIA_PAT }}
+            ${{ secrets.GH_PAT_BUILD_RUNNER_OSS }} \
+            ${{ secrets.GH_PAT_BUILD_RUNNER_BACKUP }}
       - name: Stop EC2 runner
         uses: airbytehq/ec2-github-runner@base64v1.1.0
         with:

--- a/.github/workflows/publish-connector-command.yml
+++ b/.github/workflows/publish-connector-command.yml
@@ -44,10 +44,8 @@ jobs:
 #      - name: Check PAT rate limits
 #        run: |
 #          ./tools/bin/find_non_rate_limited_PAT \
-#            ${{ secrets.AIRBYTEIO_PAT }} \
-#            ${{ secrets.OSS_BUILD_RUNNER_GITHUB_PAT }} \
-#            ${{ secrets.SUPERTOPHER_PAT }} \
-#            ${{ secrets.DAVINCHIA_PAT }}
+#            ${{ secrets.GH_PAT_BUILD_RUNNER_OSS }} \
+#            ${{ secrets.GH_PAT_BUILD_RUNNER_BACKUP }}
 #      - name: Start AWS Runner
 #        id: start-ec2-runner
 #        uses: ./.github/actions/start-aws-runner
@@ -92,7 +90,7 @@ jobs:
 #        with:
 #          repository: ${{ github.event.inputs.repo }}
 #          ref: ${{ github.event.inputs.gitref }}
-#          token: ${{ secrets.OCTAVIA_PAT }}
+#          token: ${{ secrets.GH_PAT_MAINTENANCE_OSS }}
 #      - name: Install Java
 #        uses: actions/setup-java@v3
 #        with:
@@ -195,10 +193,8 @@ jobs:
 #      - name: Check PAT rate limits
 #        run: |
 #          ./tools/bin/find_non_rate_limited_PAT \
-#            ${{ secrets.AIRBYTEIO_PAT }} \
-#            ${{ secrets.OSS_BUILD_RUNNER_GITHUB_PAT }} \
-#            ${{ secrets.SUPERTOPHER_PAT }} \
-#            ${{ secrets.DAVINCHIA_PAT }}
+#            ${{ secrets.GH_PAT_BUILD_RUNNER_OSS }} \
+#            ${{ secrets.GH_PAT_BUILD_RUNNER_BACKUP }}
 #      - name: Stop EC2 runner
 #        uses: supertopher/ec2-github-runner@base64v1.0.10
 #        with:

--- a/.github/workflows/publish-helm-charts.yml
+++ b/.github/workflows/publish-helm-charts.yml
@@ -57,7 +57,7 @@ jobs:
       - uses: actions/checkout@v3
         with:
           repository: "airbytehq/helm-charts"
-          token: ${{ secrets.OCTAVIA_PAT }}
+          token: ${{ secrets.GH_PAT_MAINTENANCE_OSS }}
           path: "airbyte-oss"
 
       - name: Replace semantic version in main chart for deps

--- a/.github/workflows/publish-oss-for-cloud.yml
+++ b/.github/workflows/publish-oss-for-cloud.yml
@@ -25,10 +25,8 @@ jobs:
       - name: Check PAT rate limits
         run: |
           ./tools/bin/find_non_rate_limited_PAT \
-            ${{ secrets.AIRBYTEIO_PAT }} \
-            ${{ secrets.OSS_BUILD_RUNNER_GITHUB_PAT }} \
-            ${{ secrets.SUPERTOPHER_PAT }} \
-            ${{ secrets.DAVINCHIA_PAT }}
+            ${{ secrets.GH_PAT_BUILD_RUNNER_OSS }} \
+            ${{ secrets.GH_PAT_BUILD_RUNNER_BACKUP }}
       - name: Start AWS Runner
         id: start-ec2-runner
         uses: ./.github/actions/start-aws-runner
@@ -181,10 +179,8 @@ jobs:
       - name: Check PAT rate limits
         run: |
           ./tools/bin/find_non_rate_limited_PAT \
-            ${{ secrets.AIRBYTEIO_PAT }} \
-            ${{ secrets.OSS_BUILD_RUNNER_GITHUB_PAT }} \
-            ${{ secrets.SUPERTOPHER_PAT }} \
-            ${{ secrets.DAVINCHIA_PAT }}
+            ${{ secrets.GH_PAT_BUILD_RUNNER_OSS }} \
+            ${{ secrets.GH_PAT_BUILD_RUNNER_BACKUP }}
       - name: Stop EC2 runner
         uses: airbytehq/ec2-github-runner@base64v1.1.0
         with:

--- a/.github/workflows/release-airbyte-os.yml
+++ b/.github/workflows/release-airbyte-os.yml
@@ -23,10 +23,8 @@ jobs:
       - name: Check PAT rate limits
         run: |
           ./tools/bin/find_non_rate_limited_PAT \
-            ${{ secrets.AIRBYTEIO_PAT }} \
-            ${{ secrets.OSS_BUILD_RUNNER_GITHUB_PAT }} \
-            ${{ secrets.SUPERTOPHER_PAT }} \
-            ${{ secrets.DAVINCHIA_PAT }}
+            ${{ secrets.GH_PAT_BUILD_RUNNER_OSS }} \
+            ${{ secrets.GH_PAT_BUILD_RUNNER_BACKUP }}
       - name: Start AWS Runner
         id: start-ec2-runner
         uses: ./.github/actions/start-aws-runner
@@ -131,7 +129,7 @@ jobs:
         id: cpr
         uses: peter-evans/create-pull-request@v3
         with:
-          token: ${{ secrets.SLASH_COMMAND_PAT }}
+          token: ${{ secrets.GH_PAT_MAINTENANCE_OCTAVIA }}
           branch: bump-version
           branch-suffix: random
           delete-branch: true
@@ -164,10 +162,8 @@ jobs:
       - name: Check PAT rate limits
         run: |
           ./tools/bin/find_non_rate_limited_PAT \
-            ${{ secrets.AIRBYTEIO_PAT }} \
-            ${{ secrets.OSS_BUILD_RUNNER_GITHUB_PAT }} \
-            ${{ secrets.SUPERTOPHER_PAT }} \
-            ${{ secrets.DAVINCHIA_PAT }}
+            ${{ secrets.GH_PAT_BUILD_RUNNER_OSS }} \
+            ${{ secrets.GH_PAT_BUILD_RUNNER_BACKUP }}
       - name: Stop EC2 runner
         uses: supertopher/ec2-github-runner@base64v1.0.10
         with:

--- a/.github/workflows/slash-commands.yml
+++ b/.github/workflows/slash-commands.yml
@@ -8,17 +8,6 @@ jobs:
     if: ${{ github.event.issue.pull_request }}
     runs-on: ubuntu-latest
     steps:
-      - name: Checkout Airbyte
-        uses: actions/checkout@v3
-
-      - name: Check PAT rate limits
-        run: |
-          ./tools/bin/find_non_rate_limited_PAT \
-            ${{ secrets.AIRBYTEIO_PAT }} \
-            ${{ secrets.OSS_BUILD_RUNNER_GITHUB_PAT }} \
-            ${{ secrets.SUPERTOPHER_PAT }} \
-            ${{ secrets.DAVINCHIA_PAT }}
-
       - name: Get PR repo and ref
         id: getref
         run: |
@@ -30,7 +19,7 @@ jobs:
         id: scd
         uses: peter-evans/slash-command-dispatch@v2
         with:
-          token: ${{ env.PAT }}
+          token: ${{ secrets.GH_PAT_MAINTENANCE_OCTAVIA }}
           commands: |
             test
             test-performance

--- a/.github/workflows/terminate-zombie-build-instances.yml
+++ b/.github/workflows/terminate-zombie-build-instances.yml
@@ -44,5 +44,5 @@ jobs:
         uses: actions/checkout@v3
       - name: List and Terminate GH actions in status 'offline'
         env:
-          GITHUB_PAT: ${{ secrets.OCTAVIA_PAT }}
+          GITHUB_PAT: ${{ secrets.GH_PAT_MAINTENANCE_OCTAVIA }}
         run: ./tools/bin/gh_action_zombie_killer

--- a/.github/workflows/test-command.yml
+++ b/.github/workflows/test-command.yml
@@ -25,8 +25,6 @@ jobs:
     name: "Custom UUID of workflow run"
     timeout-minutes: 10
     runs-on: ubuntu-latest
-    outputs:
-      pat: ${{ steps.variables.outputs.pat }}
     steps:
       - name: UUID ${{ github.event.inputs.uuid }}
         run: true
@@ -47,10 +45,8 @@ jobs:
       - name: Check PAT rate limits
         run: |
           ./tools/bin/find_non_rate_limited_PAT \
-            ${{ secrets.AIRBYTEIO_PAT }} \
-            ${{ secrets.OSS_BUILD_RUNNER_GITHUB_PAT }} \
-            ${{ secrets.SUPERTOPHER_PAT }} \
-            ${{ secrets.DAVINCHIA_PAT }}
+            ${{ secrets.GH_PAT_BUILD_RUNNER_OSS }} \
+            ${{ secrets.GH_PAT_BUILD_RUNNER_BACKUP }}
       - name: Start AWS Runner
         id: start-ec2-runner
         uses: ./.github/actions/start-aws-runner
@@ -206,10 +202,8 @@ jobs:
       - name: Check PAT rate limits
         run: |
           ./tools/bin/find_non_rate_limited_PAT \
-            ${{ secrets.AIRBYTEIO_PAT }} \
-            ${{ secrets.OSS_BUILD_RUNNER_GITHUB_PAT }} \
-            ${{ secrets.SUPERTOPHER_PAT }} \
-            ${{ secrets.DAVINCHIA_PAT }}
+            ${{ secrets.GH_PAT_BUILD_RUNNER_OSS }} \
+            ${{ secrets.GH_PAT_BUILD_RUNNER_BACKUP }}
       - name: Stop EC2 runner
         uses: supertopher/ec2-github-runner@base64v1.0.10
         with:

--- a/.github/workflows/test-performance-command.yml
+++ b/.github/workflows/test-performance-command.yml
@@ -42,10 +42,8 @@ jobs:
       - name: Check PAT rate limits
         run: |
           ./tools/bin/find_non_rate_limited_PAT \
-            ${{ secrets.AIRBYTEIO_PAT }} \
-            ${{ secrets.OSS_BUILD_RUNNER_GITHUB_PAT }} \
-            ${{ secrets.SUPERTOPHER_PAT }} \
-            ${{ secrets.DAVINCHIA_PAT }}
+            ${{ secrets.GH_PAT_BUILD_RUNNER_OSS }} \
+            ${{ secrets.GH_PAT_BUILD_RUNNER_BACKUP }}
       - name: Start AWS Runner
         id: start-ec2-runner
         uses: ./.github/actions/start-aws-runner
@@ -202,10 +200,8 @@ jobs:
       - name: Check PAT rate limits
         run: |
           ./tools/bin/find_non_rate_limited_PAT \
-            ${{ secrets.AIRBYTEIO_PAT }} \
-            ${{ secrets.OSS_BUILD_RUNNER_GITHUB_PAT }} \
-            ${{ secrets.SUPERTOPHER_PAT }} \
-            ${{ secrets.DAVINCHIA_PAT }}
+            ${{ secrets.GH_PAT_BUILD_RUNNER_OSS }} \
+            ${{ secrets.GH_PAT_BUILD_RUNNER_BACKUP }}
       - name: Stop EC2 runner
         uses: supertopher/ec2-github-runner@base64v1.0.10
         with:


### PR DESCRIPTION
As per [#2641](https://app.zenhub.com/workspaces/production-engineering-632380080186f5001a13d1dd/issues/gh/airbytehq/airbyte-cloud/2641) updating GH workflows in cloud repo to reflect changes in PAT usage

The following naming pattern is introduced - `GH_PAT_<role>_<repo>`

Proposed changes:
| previous PAT names| proposed PAT names| 
|-|-|
|OSS_BUILD_RUNNER_GITHUB_PAT |GH_PAT_BUILD_RUNNER_OSS |
|CLOUD_BUILD_RUNNER_GITHUB_PAT |GH_PAT_BUILD_RUNNER_CLOUD |
|SUPERTOPHER_PAT |GH_PAT_BUILD_RUNNER_BACKUP |
|OCTAVIA_APPROVINGTON_APPROVAL_PAT |GH_PAT_APPROVINGTON_OCTAVIA |
|AIRBYTEIO_PAT |GH_PAT_MAINTENANCE_OSS |
|DAVINCHIA_PAT|GH_PAT_MAINTENANCE_CLOUD |
|OCTAVIA_PAT |GH_PAT_MAINTENANCE_OCTAVIA |
|OCTAVIA_4_ROOT_ACCESS |GH_PAT_ROOT_ACCESS_OCTAVIA |

Comments:
 - All  new `GH_PAT_*` tokens are already [created on org level](https://github.com/organizations/airbytehq/settings/secrets/actions) and ready for use, all their repository access is preserved.
 - `SUPERTOPHER_PAT` was chosen to be a backup PAT for start/stop aws instances both in OSS and Cloud repo.
 - `OCTAVIA_4_ROOT_ACCESS` pat is too permission excessive (x-oauth-scopes: admin:enterprise, admin:org, admin:org_hook, admin:repo_hook, delete:packages, gist, notifications, project, repo, user, workflow, write:discussion, write:packages) that's why it is proposed not to use this token in our workflows and use it only as `last resport` and in exceptional cases.
 - `OCTAVIA_PAT` has broader permissions comparing to `AIRBYTEIO_PAT/DAVINCHIA_PAT` that's why it can be used to work with labeling & slash commands workflows.