### PR TITLE
Add missing flags.yml download

### DIFF
--- a/docs/deploying-airbyte/on-digitalocean-droplet.md
+++ b/docs/deploying-airbyte/on-digitalocean-droplet.md
@@ -43,7 +43,7 @@ To install and start Airbyte :
 
 ```bash
   mkdir airbyte && cd airbyte
-  wget https://raw.githubusercontent.com/airbytehq/airbyte/master/{.env,docker-compose.yaml}
+  wget https://raw.githubusercontent.com/airbytehq/airbyte/master/{.env,flags.yaml,docker-compose.yaml}
   docker compose up -d
 ```
 

--- a/docs/deploying-airbyte/on-digitalocean-droplet.md
+++ b/docs/deploying-airbyte/on-digitalocean-droplet.md
@@ -43,7 +43,7 @@ To install and start Airbyte :
 
 ```bash
   mkdir airbyte && cd airbyte
-  wget https://raw.githubusercontent.com/airbytehq/airbyte/master/{.env,flags.yaml,docker-compose.yaml}
+  wget https://raw.githubusercontent.com/airbytehq/airbyte/master/{.env,flags.yml,docker-compose.yaml}
   docker compose up -d
 ```
 


### PR DESCRIPTION

## What
*Describe what the change is solving*

If this option is not present, then `docker compose up -d` errors with:

    Error response from daemon: invalid mount config for type "bind": bind source path does not exist: /root/airbyte/flags.yml

*It helps to add screenshots if it affects the frontend.*

## How
*Describe the solution*

Add the missing flag.

## Recommended reading order

The one file that was changed.