### PR TITLE
Checkout entire git history in test-command

### DIFF
--- a/.github/workflows/test-command.yml
+++ b/.github/workflows/test-command.yml
@@ -82,6 +82,7 @@ jobs:
         with:
           repository: ${{ github.event.inputs.repo }}
           ref: ${{ github.event.inputs.gitref }}
+          fetch-depth: 0
       - name: Install Java
         uses: actions/setup-java@v3
         with:

--- a/.github/workflows/test-command.yml
+++ b/.github/workflows/test-command.yml
@@ -153,8 +153,7 @@ jobs:
           retention-days: 3
       - name: Run QA checks for ${{ github.event.inputs.connector }}
         id: qa_checks
-        # TODO: Disabled for on master until #22127 resolved
-        if: contains(github.ref, 'feat-qa-engine')
+        if: always()
         run: |
           run-qa-checks ${{ github.event.inputs.connector }}
       - name: Report Status

--- a/.github/workflows/test-command.yml
+++ b/.github/workflows/test-command.yml
@@ -152,8 +152,7 @@ jobs:
           retention-days: 3
       - name: Run QA checks for ${{ github.event.inputs.connector }}
         id: qa_checks
-        # TODO: Disabled for on master until #22127 resolved
-        if: contains(github.ref, 'feat-qa-engine')
+        if: always()
         run: |
           run-qa-checks ${{ github.event.inputs.connector }}
       - name: Report Status

--- a/.github/workflows/test-command.yml
+++ b/.github/workflows/test-command.yml
@@ -82,7 +82,6 @@ jobs:
         with:
           repository: ${{ github.event.inputs.repo }}
           ref: ${{ github.event.inputs.gitref }}
-          fetch-depth: 0
       - name: Install Java
         uses: actions/setup-java@v3
         with:
@@ -153,7 +152,8 @@ jobs:
           retention-days: 3
       - name: Run QA checks for ${{ github.event.inputs.connector }}
         id: qa_checks
-        if: always()
+        # TODO: Disabled for on master until #22127 resolved
+        if: contains(github.ref, 'feat-qa-engine')
         run: |
           run-qa-checks ${{ github.event.inputs.connector }}
       - name: Report Status

--- a/tools/ci_connector_ops/ci_connector_ops/utils.py
+++ b/tools/ci_connector_ops/ci_connector_ops/utils.py
@@ -13,15 +13,14 @@ import requests
 import yaml
 
 # ensure we are at the repository root
-os.chdir(os.path.dirname(os.path.abspath(__file__)))
-os.chdir('../../..')
+# os.chdir(os.path.dirname(os.path.abspath(__file__)))
+# os.chdir('../../..')
 
 # print the current working directory
 print("Current working directory:")
 print(os.getcwd())
 
-REPO_ROOT = "."
-
+REPO_ROOT = "../../"
 AIRBYTE_REPO = git.Repo(REPO_ROOT)
 DIFFED_BRANCH = "origin/master"
 OSS_CATALOG_URL = "https://storage.googleapis.com/prod-airbyte-cloud-connector-metadata-service/oss_catalog.json"

--- a/tools/ci_connector_ops/ci_connector_ops/utils.py
+++ b/tools/ci_connector_ops/ci_connector_ops/utils.py
@@ -16,7 +16,13 @@ import yaml
 os.chdir(os.path.dirname(os.path.abspath(__file__)))
 os.chdir('../../..')
 
-AIRBYTE_REPO = git.Repo(".")
+# print the current working directory
+print("Current working directory:")
+print(os.getcwd())
+
+REPO_ROOT = "."
+
+AIRBYTE_REPO = git.Repo(REPO_ROOT)
 DIFFED_BRANCH = "origin/master"
 OSS_CATALOG_URL = "https://storage.googleapis.com/prod-airbyte-cloud-connector-metadata-service/oss_catalog.json"
 CONNECTOR_PATH_PREFIX = "airbyte-integrations/connectors"

--- a/tools/ci_connector_ops/ci_connector_ops/utils.py
+++ b/tools/ci_connector_ops/ci_connector_ops/utils.py
@@ -12,13 +12,19 @@ import git
 import requests
 import yaml
 
+file_path = os.path.abspath(__file__)
+
+print(f"Start directory: {os.getcwd()}")
+print(f"File: {__file__}")
+print(f"File path: {file_path}")
+print(f"File directory: {os.path.dirname(file_path)}")
+
 # ensure we are at the repository root
 os.chdir(os.path.dirname(os.path.abspath(__file__)))
 # os.chdir('../../..')
 
 # print the current working directory
-print("Current working directory:")
-print(os.getcwd())
+print(f"Current working directory: {os.getcwd()}")
 
 AIRBYTE_REPO = git.Repo(".", search_parent_directories=True)
 

--- a/tools/ci_connector_ops/ci_connector_ops/utils.py
+++ b/tools/ci_connector_ops/ci_connector_ops/utils.py
@@ -20,7 +20,12 @@ os.chdir('../../..')
 print("Current working directory:")
 print(os.getcwd())
 
-AIRBYTE_REPO = git.Repo(".")
+AIRBYTE_REPO = git.Repo(search_parent_directories=True)
+
+branch = AIRBYTE_REPO.active_branch
+print(f"Active Branch: {branch.name}")
+
+
 DIFFED_BRANCH = "origin/master"
 OSS_CATALOG_URL = "https://storage.googleapis.com/prod-airbyte-cloud-connector-metadata-service/oss_catalog.json"
 CONNECTOR_PATH_PREFIX = "airbyte-integrations/connectors"

--- a/tools/ci_connector_ops/ci_connector_ops/utils.py
+++ b/tools/ci_connector_ops/ci_connector_ops/utils.py
@@ -2,36 +2,15 @@
 # Copyright (c) 2022 Airbyte, Inc., all rights reserved.
 #
 
-
 from dataclasses import dataclass
 import logging
 from pathlib import Path
 from typing import Dict, Optional, Set, Tuple, List
-import os
 import git
 import requests
 import yaml
 
-file_path = os.path.abspath(__file__)
-
-print(f"Start directory: {os.getcwd()}")
-print(f"File: {__file__}")
-print(f"File path: {file_path}")
-print(f"File directory: {os.path.dirname(file_path)}")
-
-# ensure we are at the repository root
-# os.chdir(os.path.dirname(os.path.abspath(__file__)))
-# os.chdir('../../..')
-
-# print the current working directory
-print(f"Current working directory: {os.getcwd()}")
-
 AIRBYTE_REPO = git.Repo(search_parent_directories=True)
-
-branch = AIRBYTE_REPO.active_branch
-print(f"Active Branch: {branch.name}")
-
-
 DIFFED_BRANCH = "origin/master"
 OSS_CATALOG_URL = "https://storage.googleapis.com/prod-airbyte-cloud-connector-metadata-service/oss_catalog.json"
 CONNECTOR_PATH_PREFIX = "airbyte-integrations/connectors"
@@ -42,14 +21,11 @@ SOURCE_DEFINITIONS_FILE_PATH = "airbyte-config/init/src/main/resources/seed/sour
 DESTINATION_DEFINITIONS_FILE_PATH = "airbyte-config/init/src/main/resources/seed/destination_definitions.yaml"
 DEFINITIONS_FILE_PATH = {"source": SOURCE_DEFINITIONS_FILE_PATH, "destination": DESTINATION_DEFINITIONS_FILE_PATH}
 
-
 def download_catalog(catalog_url):
     response = requests.get(catalog_url)
     return response.json()
 
-
 OSS_CATALOG = download_catalog(OSS_CATALOG_URL)
-
 
 class ConnectorInvalidNameError(Exception):
     pass
@@ -63,7 +39,6 @@ def read_definitions(definitions_file_path: str) -> Dict:
 
 def get_connector_name_from_path(path):
     return path.split("/")[2]
-
 
 def get_changed_acceptance_test_config(diff_regex: Optional[str]=None) -> Set[str]:
     """Retrieve a list of connector names for which the acceptance_test_config file was changed in the current branch (compared to master).

--- a/tools/ci_connector_ops/ci_connector_ops/utils.py
+++ b/tools/ci_connector_ops/ci_connector_ops/utils.py
@@ -13,15 +13,14 @@ import requests
 import yaml
 
 # ensure we are at the repository root
-# os.chdir(os.path.dirname(os.path.abspath(__file__)))
-# os.chdir('../../..')
+os.chdir(os.path.dirname(os.path.abspath(__file__)))
+os.chdir('../../..')
 
 # print the current working directory
 print("Current working directory:")
 print(os.getcwd())
 
-REPO_ROOT = "../../"
-AIRBYTE_REPO = git.Repo(REPO_ROOT)
+AIRBYTE_REPO = git.Repo(".")
 DIFFED_BRANCH = "origin/master"
 OSS_CATALOG_URL = "https://storage.googleapis.com/prod-airbyte-cloud-connector-metadata-service/oss_catalog.json"
 CONNECTOR_PATH_PREFIX = "airbyte-integrations/connectors"

--- a/tools/ci_connector_ops/ci_connector_ops/utils.py
+++ b/tools/ci_connector_ops/ci_connector_ops/utils.py
@@ -20,13 +20,13 @@ print(f"File path: {file_path}")
 print(f"File directory: {os.path.dirname(file_path)}")
 
 # ensure we are at the repository root
-os.chdir(os.path.dirname(os.path.abspath(__file__)))
+# os.chdir(os.path.dirname(os.path.abspath(__file__)))
 # os.chdir('../../..')
 
 # print the current working directory
 print(f"Current working directory: {os.getcwd()}")
 
-AIRBYTE_REPO = git.Repo(".", search_parent_directories=True)
+AIRBYTE_REPO = git.Repo(search_parent_directories=True)
 
 branch = AIRBYTE_REPO.active_branch
 print(f"Active Branch: {branch.name}")

--- a/tools/ci_connector_ops/ci_connector_ops/utils.py
+++ b/tools/ci_connector_ops/ci_connector_ops/utils.py
@@ -14,13 +14,13 @@ import yaml
 
 # ensure we are at the repository root
 os.chdir(os.path.dirname(os.path.abspath(__file__)))
-os.chdir('../../..')
+# os.chdir('../../..')
 
 # print the current working directory
 print("Current working directory:")
 print(os.getcwd())
 
-AIRBYTE_REPO = git.Repo(search_parent_directories=True)
+AIRBYTE_REPO = git.Repo(".", search_parent_directories=True)
 
 branch = AIRBYTE_REPO.active_branch
 print(f"Active Branch: {branch.name}")

--- a/tools/status/report.sh
+++ b/tools/status/report.sh
@@ -15,10 +15,7 @@ CONNECTOR=$1
 REPOSITORY=$2
 RUN_ID=$3
 TEST_OUTCOME=$4
-
-# TODO: Disabled for on master until #22127 resolved
-# QA_CHECKS_OUTCOME=$5
-QA_CHECKS_OUTCOME=success
+QA_CHECKS_OUTCOME=$5
 
 # Ensure connector is prefixed with connectors/
 # TODO (ben): In the future we should just hard error if this is not the case


### PR DESCRIPTION
## What
We were seeing a failure as the git history was not available.

Fix #22127 

## How
I believe the issue is that we didnt have the full history of the project.

This PR should let us test that that is true as we download full history

## 🚨 User Impact 🚨
This could result in longer than acceptable build times

## Pre-merge Checklist
- [x] Check that the qa-engine step runs successfully by running the Integration action on this branch
- [x] Compare the run time against an integration test on master
- [x] Discuss the impact with the @airbytehq/connector-operations team

## Post-merge Checklist
- [x] Remove the branch conditional in `test-command.yml`
- [x] Update `report.sh` to use the `QA_CHECKS_OUTCOME` argument again