### PR TITLE
update ConfigFileClient to allow an invalid path

### DIFF
--- a/airbyte-featureflag/src/test/kotlin/ClientTest.kt
+++ b/airbyte-featureflag/src/test/kotlin/ClientTest.kt
@@ -68,6 +68,32 @@ class ConfigFileClientTest {
     }
 
     @Test
+    fun `verify missing file returns default flag state`() {
+        val client: FeatureFlagClient = ConfigFileClient(Path.of("src", "test", "resources", "feature-flags-dne-missing.yml"))
+        val defaultFalse = Temporary(key = "default-false")
+        val defaultTrue = Temporary(key = "default-true", default = true)
+
+        val ctx = Workspace("workspace")
+        with(client) {
+            assertTrue { enabled(defaultTrue, ctx) }
+            assertFalse { enabled(defaultFalse, ctx) }
+        }
+    }
+
+    @Test
+    fun `verify directory instead of file returns default flag state`() {
+        val client: FeatureFlagClient = ConfigFileClient(Path.of("src", "test", "resources"))
+        val defaultFalse = Temporary(key = "default-false")
+        val defaultTrue = Temporary(key = "default-true", default = true)
+
+        val ctx = Workspace("workspace")
+        with(client) {
+            assertTrue { enabled(defaultTrue, ctx) }
+            assertFalse { enabled(defaultFalse, ctx) }
+        }
+    }
+
+    @Test
     @Ignore
     fun `verify config-file reload capabilities`() {
         val contents0 = """flags:


### PR DESCRIPTION
## What
- allow `ConfigFileClient` to accept an invalid path
    - now logs a messages instead of throwing an exception 

## How
- check if the files exists before attempting to read it

