### PR TITLE
Normalization: handle nested objects correctly

### DIFF
--- a/airbyte-integrations/bases/base-normalization/normalization/transform_catalog/stream_processor.py
+++ b/airbyte-integrations/bases/base-normalization/normalization/transform_catalog/stream_processor.py
@@ -15,6 +15,7 @@ from normalization.transform_catalog import dbt_macro
 from normalization.transform_catalog.destination_name_transformer import DestinationNameTransformer, transform_json_naming
 from normalization.transform_catalog.table_name_registry import TableNameRegistry
 from normalization.transform_catalog.utils import (
+    contains_typeless_schema,
     get_array_items,
     is_airbyte_column,
     is_array,
@@ -362,11 +363,7 @@ class StreamProcessor(object):
             elif is_combining_node(properties[field]):
                 # TODO: merge properties of all combinations
                 pass
-            elif (
-                data_type.TYPE_VAR_NAME not in properties[field]
-                and data_type.REF_TYPE_VAR_NAME not in properties[field]
-                and data_type.ONE_OF_VAR_NAME not in properties[field]
-            ) or is_object(properties[field]):
+            elif contains_typeless_schema(properties[field]) or is_object(properties[field]):
                 # properties without 'type' field are treated like properties with 'type' = 'object'
                 children_properties = find_properties_object([], field, properties[field])
                 is_nested_array = False
@@ -462,17 +459,16 @@ where 1 = 1
             table_alias = ""
 
         json_extract = jinja_call(f"json_extract('{table_alias}', {json_column_name}, {json_path})")
-        if data_type.REF_TYPE_VAR_NAME in definition or data_type.TYPE_VAR_NAME in definition or data_type.ONE_OF_VAR_NAME in definition:
-            if is_array(definition):
-                json_extract = jinja_call(f"json_extract_array({json_column_name}, {json_path}, {normalized_json_path})")
-                if is_simple_property(get_array_items(definition, {data_type.TYPE_VAR_NAME: "object"})):
-                    json_extract = jinja_call(f"json_extract_string_array({json_column_name}, {json_path}, {normalized_json_path})")
-            elif is_object(definition):
-                json_extract = jinja_call(f"json_extract('{table_alias}', {json_column_name}, {json_path}, {normalized_json_path})")
-            elif is_date(definition) or is_time(definition) or is_datetime(definition):
-                json_extract = jinja_call(f"json_extract_scalar({json_column_name}, {json_path}, {normalized_json_path})")
-            elif is_simple_property(definition):
-                json_extract = jinja_call(f"json_extract_scalar({json_column_name}, {json_path}, {normalized_json_path})")
+        if is_array(definition):
+            json_extract = jinja_call(f"json_extract_array({json_column_name}, {json_path}, {normalized_json_path})")
+            if is_simple_property(get_array_items(definition, {data_type.TYPE_VAR_NAME: "object"})):
+                json_extract = jinja_call(f"json_extract_string_array({json_column_name}, {json_path}, {normalized_json_path})")
+        elif is_object(definition):
+            json_extract = jinja_call(f"json_extract('{table_alias}', {json_column_name}, {json_path}, {normalized_json_path})")
+        elif is_date(definition) or is_time(definition) or is_datetime(definition):
+            json_extract = jinja_call(f"json_extract_scalar({json_column_name}, {json_path}, {normalized_json_path})")
+        elif is_simple_property(definition):
+            json_extract = jinja_call(f"json_extract_scalar({json_column_name}, {json_path}, {normalized_json_path})")
 
         return f"{json_extract} as {column_name}"
 
@@ -512,6 +508,7 @@ where 1 = 1
 
     def cast_property_type(self, property_name: str, column_name: str, jinja_column: str) -> Any:  # noqa: C901
         definition = self.properties[property_name]
+        is_numeric = False
         if (
             data_type.TYPE_VAR_NAME not in definition
             and data_type.REF_TYPE_VAR_NAME not in definition
@@ -524,9 +521,7 @@ where 1 = 1
         elif is_object(definition):
             sql_type = jinja_call("type_json()")
         # Treat simple types from wider scope TO narrower type: string > boolean > integer > number
-        elif (data_type.REF_TYPE_VAR_NAME in definition and is_string(definition)) or (
-            data_type.ONE_OF_VAR_NAME in definition and is_string(definition)
-        ):
+        elif is_string(definition):
             sql_type = jinja_call("dbt_utils.type_string()")
             if self.destination_type == DestinationType.CLICKHOUSE:
                 trimmed_column_name = f"trim(BOTH '\"' from {column_name})"
@@ -536,21 +531,18 @@ where 1 = 1
                 # Cast to `text` datatype. See https://github.com/airbytehq/airbyte/issues/7994
                 sql_type = f"{sql_type}(1024)"
 
-        elif (data_type.REF_TYPE_VAR_NAME in definition and is_boolean(definition)) or (
-            data_type.ONE_OF_VAR_NAME in definition and is_boolean(definition)
-        ):
+        elif is_boolean(definition):
             cast_operation = jinja_call(f"cast_to_boolean({jinja_column})")
             return f"{cast_operation} as {column_name}"
         elif is_big_integer(definition):
             sql_type = jinja_call("type_very_large_integer()")
-        elif (data_type.REF_TYPE_VAR_NAME in definition and is_long(definition)) or (
-            data_type.ONE_OF_VAR_NAME in definition and is_long(definition)
-        ):
+            is_numeric = True
+        elif is_long(definition):
             sql_type = jinja_call("dbt_utils.type_bigint()")
-        elif (data_type.REF_TYPE_VAR_NAME in definition and is_number(definition)) or (
-            data_type.ONE_OF_VAR_NAME in definition and is_number(definition)
-        ):
+            is_numeric = True
+        elif is_number(definition):
             sql_type = jinja_call("dbt_utils.type_float()")
+            is_numeric = True
         elif is_datetime(definition):
             if self.destination_type == DestinationType.SNOWFLAKE:
                 # snowflake uses case when statement to parse timestamp field
@@ -604,9 +596,7 @@ where 1 = 1
                 return f'nullif(cast({column_name} as {sql_type}), "") as {column_name}'
             replace_operation = jinja_call(f"empty_string_to_null({jinja_column})")
             return f"cast({replace_operation} as {sql_type}) as {column_name}"
-        elif (data_type.REF_TYPE_VAR_NAME in definition and is_binary_datatype(definition)) or (
-            data_type.ONE_OF_VAR_NAME in definition and is_binary_datatype(definition)
-        ):
+        elif is_binary_datatype(definition):
             if self.destination_type.value == DestinationType.POSTGRES.value:
                 # sql_type = "bytea"
                 sql_type = jinja_call("type_binary()")
@@ -649,10 +639,7 @@ where 1 = 1
             return column_name
 
         if self.destination_type == DestinationType.CLICKHOUSE:
-            if data_type.REF_TYPE_VAR_NAME in definition and (
-                data_type.NUMBER_TYPE in definition[data_type.REF_TYPE_VAR_NAME]
-                or data_type.INTEGER_TYPE in definition[data_type.REF_TYPE_VAR_NAME]
-            ):
+            if is_numeric:
                 trimmed_column_name = f"trim(BOTH '\"' from {column_name})"
                 return f"accurateCastOrNull({trimmed_column_name}, '{sql_type}') as {column_name}"
             else:
@@ -1119,7 +1106,7 @@ from dedup_data where {{ airbyte_row_num }} = 1
         if path and len(path) == 1:
             field = path[0]
             if not is_airbyte_column(field):
-                if is_number(self.properties[field]) or is_object(self.properties[field]):
+                if is_number(self.properties[field]) or is_object(self.properties[field]) or contains_typeless_schema(self.properties[field]):
                     # some destinations don't handle float columns (or complex types) as primary keys, turn them to string
                     return f"cast({column_names[field][0]} as {jinja_call('dbt_utils.type_string()')})"
                 else:

--- a/airbyte-integrations/bases/base-normalization/normalization/transform_catalog/stream_processor.py
+++ b/airbyte-integrations/bases/base-normalization/normalization/transform_catalog/stream_processor.py
@@ -17,6 +17,7 @@ from normalization.transform_catalog.table_name_registry import TableNameRegistr
 from normalization.transform_catalog.utils import (
     contains_typeless_schema,
     get_array_items,
+    has_exactly_one_complex_option,
     is_airbyte_column,
     is_array,
     is_big_integer,
@@ -360,7 +361,7 @@ class StreamProcessor(object):
             json_column_name = ""
             if is_airbyte_column(field):
                 pass
-            elif is_combining_node(properties[field]):
+            elif is_combining_node(properties[field]) and not has_exactly_one_complex_option(properties[field]):
                 # TODO: merge properties of all combinations
                 pass
             elif contains_typeless_schema(properties[field]) or is_object(properties[field]):
@@ -509,11 +510,7 @@ where 1 = 1
     def cast_property_type(self, property_name: str, column_name: str, jinja_column: str) -> Any:  # noqa: C901
         definition = self.properties[property_name]
         is_numeric = False
-        if (
-            data_type.TYPE_VAR_NAME not in definition
-            and data_type.REF_TYPE_VAR_NAME not in definition
-            and data_type.ONE_OF_VAR_NAME not in definition
-        ):
+        if contains_typeless_schema(definition):
             print(f"WARN: Unknown type for column {property_name} at {self.current_json_path()}: {definition}")
             return column_name
         elif is_array(definition):

--- a/airbyte-integrations/bases/base-normalization/normalization/transform_catalog/stream_processor.py
+++ b/airbyte-integrations/bases/base-normalization/normalization/transform_catalog/stream_processor.py
@@ -514,7 +514,7 @@ where 1 = 1
             and data_type.REF_TYPE_VAR_NAME not in definition
             and data_type.ONE_OF_VAR_NAME not in definition
         ):
-            print(f"WARN: Unknown type for column {property_name} at {self.current_json_path()}")
+            print(f"WARN: Unknown type for column {property_name} at {self.current_json_path()}: {definition}")
             return column_name
         elif is_array(definition):
             return column_name
@@ -1106,7 +1106,11 @@ from dedup_data where {{ airbyte_row_num }} = 1
         if path and len(path) == 1:
             field = path[0]
             if not is_airbyte_column(field):
-                if is_number(self.properties[field]) or is_object(self.properties[field]) or contains_typeless_schema(self.properties[field]):
+                if (
+                    is_number(self.properties[field])
+                    or is_object(self.properties[field])
+                    or contains_typeless_schema(self.properties[field])
+                ):
                     # some destinations don't handle float columns (or complex types) as primary keys, turn them to string
                     return f"cast({column_names[field][0]} as {jinja_call('dbt_utils.type_string()')})"
                 else:

--- a/airbyte-integrations/bases/base-normalization/normalization/transform_catalog/stream_processor.py
+++ b/airbyte-integrations/bases/base-normalization/normalization/transform_catalog/stream_processor.py
@@ -766,11 +766,7 @@ where 1 = 1
         the curly brackets.
         """
 
-        if (
-            data_type.TYPE_VAR_NAME not in definition
-            and data_type.REF_TYPE_VAR_NAME not in definition
-            and data_type.ONE_OF_VAR_NAME not in definition
-        ):
+        if contains_typeless_schema(definition):
             col = column_name
         elif data_type.REF_TYPE_VAR_NAME in definition and is_boolean(definition):
             col = f"boolean_to_string({column_name})"

--- a/airbyte-integrations/bases/base-normalization/normalization/transform_catalog/utils.py
+++ b/airbyte-integrations/bases/base-normalization/normalization/transform_catalog/utils.py
@@ -23,12 +23,12 @@ def is_type_included(definition: dict, is_type: Callable[[dict], bool]) -> bool:
         return is_type(definition)
 
 
-def get_type_param(definition: dict, is_type: Callable[[dict], bool], param: str, default_value) -> any:
+def get_type_param(definition: dict, is_type: Callable[[dict], bool], param: str, default_value):
     # We're going to just pick the first oneOf entry. We don't handle conflicts yet.
     if data_type.ONE_OF_VAR_NAME in definition:
         for option in definition[data_type.ONE_OF_VAR_NAME]:
             # Recurse just in case this is yet another oneOf, for whatever reason
-            return get_type_param(option[param], is_type, param, default_value)
+            return get_type_param(option, is_type, param, default_value)
     elif is_type(definition) and param in definition:
         # We're guaranteed that this isn't a oneOf, so this should be a raw array decl (or whatever)
         return definition[param]
@@ -115,7 +115,7 @@ def is_array(definition: dict) -> bool:
     )
 
 
-def get_array_items(definition: dict, default_value) -> any:
+def get_array_items(definition: dict, default_value):
     return get_type_param(
         definition,
         is_array,

--- a/airbyte-integrations/bases/base-normalization/normalization/transform_catalog/utils.py
+++ b/airbyte-integrations/bases/base-normalization/normalization/transform_catalog/utils.py
@@ -18,7 +18,7 @@ def remove_jinja(command: str) -> str:
 
 def is_type_included(definition: dict, is_type: Callable[[dict], bool]) -> bool:
     if data_type.ONE_OF_VAR_NAME in definition:
-        return bool(any(is_type(option) for option in definition[data_type.ONE_OF_VAR_NAME]))
+        return bool(any(is_type_included(option, is_type) for option in definition[data_type.ONE_OF_VAR_NAME]))
     else:
         return is_type(definition)
 
@@ -132,6 +132,14 @@ def is_object(definition: dict) -> bool:
     return is_type_included(
         definition, lambda schema: data_type.TYPE_VAR_NAME in schema and is_object_schema(schema[data_type.TYPE_VAR_NAME])
     )
+
+
+def is_typeless_schema(definition: dict) -> bool:
+    return data_type.TYPE_VAR_NAME not in definition and data_type.REF_TYPE_VAR_NAME not in definition
+
+
+def contains_typeless_schema(definition: dict) -> bool:
+    return is_type_included(definition, is_typeless_schema)
 
 
 def is_airbyte_column(name: str) -> bool:

--- a/airbyte-integrations/bases/standard-destination-test/src/main/java/io/airbyte/integrations/standardtest/destination/DestinationAcceptanceTest.java
+++ b/airbyte-integrations/bases/standard-destination-test/src/main/java/io/airbyte/integrations/standardtest/destination/DestinationAcceptanceTest.java
@@ -145,10 +145,18 @@ public abstract class DestinationAcceptanceTest {
   }
 
   protected String getNormalizationImageName() {
+    final String normalizationVersion;
+    // Normalization >= 0.3.0 requires a different catalog format, so pin to 0.2.25 here.
+    // If you need to make a normalization update for a connector update, you'll need to also upgrade to protocol v1.
+    if (getProtocolVersion() == ProtocolVersion.V0){
+      normalizationVersion = "0.2.25";
+    } else {
+      normalizationVersion = NORMALIZATION_VERSION;
+    }
     return getOptionalDestinationDefinitionFromProvider(getImageNameWithoutTag())
         .filter(standardDestinationDefinition -> Objects.nonNull(standardDestinationDefinition.getNormalizationConfig()))
         .map(standardDestinationDefinition -> standardDestinationDefinition.getNormalizationConfig().getNormalizationRepository() + ":"
-            + NORMALIZATION_VERSION)
+            + normalizationVersion)
         .orElse(null);
   }
 


### PR DESCRIPTION
We're currently not prioritizing objects/arrays correctly in some cases. E.g. v0 schema:
```json
{"type": ["string", "object"], "properties": {}}
```

which becomes v1 schema:
```json
{
  "oneOf": [
    {"$ref": "....String"},
    {"type": "object", "properties": {}}
  ]
}
```

is being interpreted as a string, rather than object.