### PR TITLE
🪟 🔧 Switch to the new airbyte-cloud repo name

### DIFF
--- a/airbyte-webapp/scripts/environment.js
+++ b/airbyte-webapp/scripts/environment.js
@@ -9,7 +9,7 @@ if (!process.env.AB_ENV) {
 
 const envFile = path.resolve(
   __dirname,
-  "../../../airbyte-cloud/cloud-webapp/development",
+  "../../../airbyte-platform-internal/cloud-webapp/development",
   `.env.${process.env.AB_ENV}`
 );
 
@@ -17,7 +17,7 @@ if (!fs.existsSync(envFile)) {
   console.error(
     `~~~ This mode is for Airbyte employees only. ~~~\n` +
       `Could not find .env file for environment ${process.env.AB_ENV} (looking at ${envFile}).\n` +
-      `Make sure you have the latest airbyte-cloud repository checked out in a directory directly next to the airbyte OSS repository.\n`
+      `Make sure you have the latest airbyte-platform-internal repository checked out in a directory directly next to the airbyte OSS repository.\n`
   );
   process.exit(42);
 }


### PR DESCRIPTION
## What

Fixes the path to load our environment variables from to represent the new repository name `airbyte-platform-internal`. We'll need to locally rename this for everyone developing once this is merged.