### PR TITLE
Remove test card from empty actor form

### DIFF
--- a/airbyte-webapp/src/locales/en.json
+++ b/airbyte-webapp/src/locales/en.json
@@ -65,7 +65,6 @@
   "form.saveChangesAndTest": "Test and save",
   "form.sourceRetest": "Retest saved source",
   "form.destinationRetest": "Retest saved destination",
-  "form.test": "Test",
   "form.sourceRetestTitle": "Test the source",
   "form.destinationRetestTitle": "Test the destination",
   "form.discardChanges": "Discard changes",

--- a/airbyte-webapp/src/views/Connector/ConnectorCard/components/Controls.tsx
+++ b/airbyte-webapp/src/views/Connector/ConnectorCard/components/Controls.tsx
@@ -36,9 +36,12 @@ export const Controls: React.FC<IProps> = ({
   onCancelClick,
   ...restProps
 }) => {
+  const showTestCard =
+    hasDefinition &&
+    (isEditMode || isTestConnectionInProgress || restProps.connectionTestSuccess || restProps.errorMessage);
   return (
     <>
-      {hasDefinition && (
+      {showTestCard && (
         <TestCard
           {...restProps}
           dirty={dirty}

--- a/airbyte-webapp/src/views/Connector/ConnectorCard/components/TestCard.tsx
+++ b/airbyte-webapp/src/views/Connector/ConnectorCard/components/TestCard.tsx
@@ -84,12 +84,13 @@ export const TestCard: React.FC<IProps> = ({
               <FormattedMessage id={`form.${formType}RetestTitle`} />
             </Text>
           </FlexItem>
-          {isTestConnectionInProgress ? (
+          {isTestConnectionInProgress || !isEditMode ? (
             <Button
               className={styles.button}
               icon={<FontAwesomeIcon icon={faClose} />}
               variant="secondary"
               type="button"
+              disabled={!isTestConnectionInProgress}
               onClick={() => onCancelTesting?.()}
             >
               <FormattedMessage id="form.cancel" />
@@ -101,9 +102,9 @@ export const TestCard: React.FC<IProps> = ({
               variant="secondary"
               icon={<FontAwesomeIcon icon={faRefresh} />}
               // disable if there are changes in edit mode because the retest API can currently only test the saved state
-              disabled={!isValid || (isEditMode && dirty)}
+              disabled={!isValid || dirty}
             >
-              <FormattedMessage id={!isEditMode ? "form.test" : `form.${formType}Retest`} />
+              <FormattedMessage id={`form.${formType}Retest`} />
             </Button>
           )}
         </FlexContainer>


### PR DESCRIPTION
## What

This PR removes the "Test" CTA from the empty source/destination form to make it more likely for the user to succeed setting up their connection (related discussion here: https://github.com/airbytehq/airbyte/pull/21698#issuecomment-1404876653 )

## How
* When in edit mode:
  * Always show test card with "Retest" button to retest saved state
  * Disable "Retest" button if the form is dirty
* When in new mode:
  * Only show test card if testing is in progress or was successful/failed
  * Do not show a "Test" button
  * Show a cancel button (disabled if the connection test is not in progress)

https://www.loom.com/share/58ec66cb14d241809881d7480b1bb211
