### PR TITLE
🪟 🐛 Fix ResizablePanel component

### DIFF
--- a/airbyte-webapp/src/components/ui/ResizablePanels/ResizablePanels.module.scss
+++ b/airbyte-webapp/src/components/ui/ResizablePanels/ResizablePanels.module.scss
@@ -71,8 +71,17 @@
   height: 3px;
 }
 
+.fullWidth {
+  // Overwrite the flex-grow set by the react-reflex to stretch a container to full width
+  flex-grow: 1 !important;
+}
+
 .splitter {
   // !important is necessary to override the default reflex styles
   border: 0 !important;
   background-color: transparent !important;
+}
+
+.hidden {
+  display: none;
 }

--- a/airbyte-webapp/src/components/ui/ResizablePanels/ResizablePanels.tsx
+++ b/airbyte-webapp/src/components/ui/ResizablePanels/ResizablePanels.tsx
@@ -75,7 +75,7 @@ export const ResizablePanels: React.FC<ResizablePanelsProps> = ({
   return (
     <ReflexContainer className={className} orientation={orientation}>
       <ReflexElement
-        className={classNames(styles.panelStyle, firstPanel.className)}
+        className={classNames(styles.panelStyle, firstPanel.className, { [styles.fullWidth]: hideSecondPanel })}
         propagateDimensions
         minSize={firstPanel.minWidth}
         flex={firstPanel.flex}
@@ -85,37 +85,34 @@ export const ResizablePanels: React.FC<ResizablePanelsProps> = ({
       >
         <PanelContainer overlay={firstPanel.overlay}>{firstPanel.children}</PanelContainer>
       </ReflexElement>
-      {/* NOTE: ReflexElement will not load its contents if wrapped in an empty jsx tag along with ReflexSplitter.  They must be evaluated/rendered separately. */}
-      {!hideSecondPanel && (
-        <ReflexSplitter className={styles.splitter}>
-          <div
-            className={classNames({
-              [styles.panelGrabberVertical]: orientation === "vertical",
-              [styles.panelGrabberHorizontal]: orientation === "horizontal",
-            })}
-          >
-            <div
-              className={classNames(styles.handleIcon, {
-                [styles.handleIconVertical]: orientation === "vertical",
-                [styles.handleIconHorizontal]: orientation === "horizontal",
-              })}
-            />
-          </div>
-        </ReflexSplitter>
-      )}
-      {!hideSecondPanel && (
-        <ReflexElement
-          className={classNames(styles.panelStyle, secondPanel.className)}
-          propagateDimensions
-          minSize={secondPanel.minWidth}
-          flex={secondPanel.flex}
-          onStopResize={(args) => {
-            secondPanel.onStopResize?.(args.component.props.flex);
-          }}
+      <ReflexSplitter className={classNames(styles.splitter, { [styles.hidden]: hideSecondPanel })}>
+        <div
+          className={classNames({
+            [styles.panelGrabberVertical]: orientation === "vertical",
+            [styles.panelGrabberHorizontal]: orientation === "horizontal",
+          })}
         >
-          <PanelContainer overlay={secondPanel.overlay}>{secondPanel.children}</PanelContainer>
-        </ReflexElement>
-      )}
+          <div
+            className={classNames(styles.handleIcon, {
+              [styles.handleIconVertical]: orientation === "vertical",
+              [styles.handleIconHorizontal]: orientation === "horizontal",
+            })}
+          />
+        </div>
+      </ReflexSplitter>
+      <ReflexElement
+        className={classNames(styles.panelStyle, secondPanel.className, {
+          [styles.hidden]: hideSecondPanel,
+        })}
+        propagateDimensions
+        minSize={secondPanel.minWidth}
+        flex={secondPanel.flex}
+        onStopResize={(args) => {
+          secondPanel.onStopResize?.(args.component.props.flex);
+        }}
+      >
+        {!hideSecondPanel && <PanelContainer overlay={secondPanel.overlay}>{secondPanel.children}</PanelContainer>}
+      </ReflexElement>
     </ReflexContainer>
   );
 };

--- a/airbyte-webapp/src/components/ui/StepsIndicator/StepsIndicator.tsx
+++ b/airbyte-webapp/src/components/ui/StepsIndicator/StepsIndicator.tsx
@@ -44,7 +44,7 @@ export const StepsIndicator: React.FC<StepsIndicatorProps> = ({ className, steps
   return (
     <div className={classNames(className, styles.steps)}>
       {steps.map((step, index) => (
-        <StepIndicator step={step} isCurrent={activeStep === step.id} isCompleted={index < activeIndex} />
+        <StepIndicator key={step.id} step={step} isCurrent={activeStep === step.id} isCompleted={index < activeIndex} />
       ))}
     </div>
   );


### PR DESCRIPTION
## What

Fixes a bug that the resizable panel component doesn't render anything, if you first set `hideSecondPanel` to `true` and then to `false`. You can currently seeing this on master by clicking in an empty workspace on a source icon in the empty connection page, which will bring you do the setup for that connector, but nothing will render, due to this issue.

## How

`react-reflex` has apparently a problem when the second panel is first not rendered and then rendered and ends up rendering it with 0 width. The only thing to get it reworking was fully rerendering the component (by changing a `key` on the `ReflexContainer`), which worked to fix the issue, but also added a couple of new issues. So after syncing with Teal, we decided to change this to handle the hiding in CSS only, which also fixes the issue and is was less buggy.

We just hide the content of the 2nd panel, so that this component doesn't render unnecessarily.