### PR TITLE
🪟 🐛 Hot-fix exception in streams table when stream does not have direct properties

### DIFF
--- a/airbyte-webapp/src/components/connection/CatalogTree/CatalogSection.tsx
+++ b/airbyte-webapp/src/components/connection/CatalogTree/CatalogSection.tsx
@@ -59,7 +59,10 @@ const CatalogSectionInner: React.FC<CatalogSectionInnerProps> = ({
     return traversedFields.sort(naturalComparatorBy((field) => field.cleanedName));
   }, [stream?.jsonSchema, stream?.name]);
 
-  const numberOfFieldsInStream = Object.keys(streamNode?.stream?.jsonSchema?.properties).length ?? 0;
+  // FIXME: Temp fix to return empty object when the json schema does not have .properties
+  // This prevents the table from crashing but still will not render the fields in the stream.
+  const streamProperties = streamNode?.stream?.jsonSchema?.properties ?? {};
+  const numberOfFieldsInStream = Object.keys(streamProperties).length ?? 0;
 
   const {
     destDefinitionSpecification: { supportedDestinationSyncModes },

--- a/airbyte-webapp/src/components/connection/CatalogTree/styles.tsx
+++ b/airbyte-webapp/src/components/connection/CatalogTree/styles.tsx
@@ -13,8 +13,8 @@ export const CheckboxCell = styled(HeaderCell)`
 `;
 
 export const ArrowCell = styled(HeaderCell)`
+  min-width: 40px;
   max-width: 40px;
-  width: 40px;
 `;
 
 export const NameContainer = styled.span`


### PR DESCRIPTION
## What
Hot-fix an issue in the streams table that crashed the whole page when the properties in the stream were not of the expected shape. Still investigating the root cause and next steps, so this is a temporary fix to prevent it from impacting users.

However, the fields cannot be expanded in the table in streams where the problem occurs. This will be fixed separately.

This is occurring with the Stripe source with `plans` stream in that plans is currently `{ oneOf: [{ properties: ... }, 'WellKnownTypes/String' }]` when the code can only support `{ properties: }` 

## How
Returns an empty object so that the code can take the length correctly. Ensures that the table renders well without the expandable fields.