### PR TITLE
🐛 Source Airtable: fix cases with empty `result` while discover the schema

### DIFF
--- a/airbyte-config/init/src/main/resources/seed/source_definitions.yaml
+++ b/airbyte-config/init/src/main/resources/seed/source_definitions.yaml
@@ -17,7 +17,7 @@
 - name: Airtable
   sourceDefinitionId: 14c6e7ea-97ed-4f5e-a7b5-25e9a80b8212
   dockerRepository: airbyte/source-airtable
-  dockerImageTag: 2.0.1
+  dockerImageTag: 2.0.2
   documentationUrl: https://docs.airbyte.com/integrations/sources/airtable
   icon: airtable.svg
   sourceType: api

--- a/airbyte-config/init/src/main/resources/seed/source_specs.yaml
+++ b/airbyte-config/init/src/main/resources/seed/source_specs.yaml
@@ -178,7 +178,7 @@
     supportsNormalization: false
     supportsDBT: false
     supported_destination_sync_modes: []
-- dockerImage: "airbyte/source-airtable:2.0.1"
+- dockerImage: "airbyte/source-airtable:2.0.2"
   spec:
     documentationUrl: "https://docs.airbyte.com/integrations/sources/airtable"
     connectionSpecification:

--- a/airbyte-integrations/connectors/source-airtable/Dockerfile
+++ b/airbyte-integrations/connectors/source-airtable/Dockerfile
@@ -34,5 +34,5 @@ COPY source_airtable ./source_airtable
 ENV AIRBYTE_ENTRYPOINT "python /airbyte/integration_code/main.py"
 ENTRYPOINT ["python", "/airbyte/integration_code/main.py"]
 
-LABEL io.airbyte.version=2.0.1
+LABEL io.airbyte.version=2.0.2
 LABEL io.airbyte.name=airbyte/source-airtable

--- a/airbyte-integrations/connectors/source-airtable/source_airtable/schema_helpers.py
+++ b/airbyte-integrations/connectors/source-airtable/source_airtable/schema_helpers.py
@@ -60,6 +60,8 @@ SIMPLE_AIRTABLE_TYPES: Dict = {
     "singleLineText": SchemaTypes.string,
     "externalSyncSource": SchemaTypes.string,
     "url": SchemaTypes.string,
+    # referal default type
+    "simpleText": SchemaTypes.string,
 }
 
 # returns the `array of Any` where Any is based on Simple Types.
@@ -89,17 +91,22 @@ class SchemaHelpers:
             name: str = SchemaHelpers.clean_name(field.get("name"))
             original_type: str = field.get("type")
             options: Dict = field.get("options", {})
-            exec_type: str = options.get("result", {}).get("type") if options else None
-            field_type: str = exec_type if exec_type else original_type
+            options_result: Dict = options.get("result", {})
+            exec_type: str = options_result.get("type") if options_result else None
 
             # choose the JsonSchema Type for known Airtable Types
             if original_type in COMPLEX_AIRTABLE_TYPES.keys():
                 complex_type = deepcopy(COMPLEX_AIRTABLE_TYPES.get(original_type))
                 # process arrays with values
+                field_type: str = exec_type if exec_type else "simpleText"
+                # For cases with `options.result` == None, we should apply the type `string`.
+                # Other edge cases, if `field_type` not in SIMPLE_AIRTABLE_TYPES, fall back to "simpleText" == `string`
+                # reference issue: https://github.com/airbytehq/oncall/issues/1432#issuecomment-1412743120
                 if complex_type == SchemaTypes.array_with_any:
                     complex_type["items"] = deepcopy(SIMPLE_AIRTABLE_TYPES.get(field_type))
                 properties.update(**{name: complex_type})
             elif original_type in SIMPLE_AIRTABLE_TYPES.keys():
+                field_type: str = exec_type if exec_type else original_type
                 properties.update(**{name: deepcopy(SIMPLE_AIRTABLE_TYPES.get(field_type))})
             else:
                 # Airtable may add more field types in the future and don't consider it a breaking change

--- a/docs/integrations/sources/airtable.md
+++ b/docs/integrations/sources/airtable.md
@@ -103,6 +103,7 @@ See information about rate limits [here](https://airtable.com/developers/web/api
 
 | Version | Date       | Pull Request                                             | Subject                                                |
 |:--------|:-----------|:---------------------------------------------------------|:-------------------------------------------------------|
+| 2.0.2   | 2023-02-01 | [22245](https://github.com/airbytehq/airbyte/pull/22245) | Fix for empty `result` object when discovering the schema
 | 2.0.1   | 2023-02-01 | [22224](https://github.com/airbytehq/airbyte/pull/22224) | Fixed broken `API Key` authentication
 | 2.0.0   | 2023-01-27 | [21962](https://github.com/airbytehq/airbyte/pull/21962) | Added casting of native Airtable data types to JsonSchema types
 | 1.0.2   | 2023-01-25 | [20934](https://github.com/airbytehq/airbyte/pull/20934) | Added `OAuth2.0` authentication support 


### PR DESCRIPTION
## What
Resolving:  https://github.com/airbytehq/oncall/issues/1432

## How
- for certain fields types, the `result` object could be `Null`, which means we should fallback to  `string` type

## 🚨 User Impact 🚨
No impact is expected. Just fixing the blocker.

## Pre-merge Checklist
Expand the relevant checklist and delete the others.

<details><summary><strong>Updating a connector</strong></summary>

### Community member or Airbyter

- [ ] Unit & integration tests added and passing. Community members, please provide proof of success locally e.g: screenshot or copy-paste unit, integration, and acceptance test output. To run acceptance tests for a Python connector, follow instructions in the README. For java connectors run `./gradlew :airbyte-integrations:connectors:<name>:integrationTest`.
- [ ] Code reviews completed
- [ ] Documentation updated
    - [ ] Connector's `README.md`
    - [ ] Connector's `bootstrap.md`. See [description and examples](https://docs.google.com/document/d/1ypdgmwmEHWv-TrO4_YOQ7pAJGVrMp5BOkEVh831N260/edit?usp=sharing)
    - [ ] Changelog updated in `docs/integrations/<source or destination>/<name>.md` including changelog. See changelog [example](https://docs.airbyte.io/integrations/sources/stripe#changelog)
- [ ] PR name follows [PR naming conventions](https://docs.airbyte.com/contributing-to-airbyte/issues-and-pull-requests)

### Airbyter

If this is a community PR, the Airbyte engineer reviewing this PR is responsible for the below items.

- [ ] Create a non-forked branch based on this PR and test the below items on it
- [ ] Build is successful
- [ ] If new credentials are required for use in CI, add them to GSM. [Instructions](https://docs.airbyte.io/connector-development#using-credentials-in-ci).
- [ ] [`/test connector=connectors/<name>` command](https://docs.airbyte.io/connector-development#updating-an-existing-connector) is passing
- [ ] New Connector version released on Dockerhub and connector version bumped by running the `/publish` command described [here](https://docs.airbyte.io/connector-development#updating-an-existing-connector)

</details>
