### PR TITLE
Go back v0 as default

### DIFF
--- a/airbyte-bootloader/src/main/resources/application.yml
+++ b/airbyte-bootloader/src/main/resources/application.yml
@@ -22,7 +22,7 @@ airbyte:
     target:
       range:
         min-version: ${AIRBYTE_PROTOCOL_VERSION_MIN:0.0.0}
-        max-version: ${AIRBYTE_PROTOCOL_VERSION_MAX:1.0.0}
+        max-version: ${AIRBYTE_PROTOCOL_VERSION_MAX:0.3.0}
   secret:
     persistence: ${SECRET_PERSISTENCE:TESTING_CONFIG_DB_TABLE}
     store:

--- a/airbyte-commons-protocol/src/main/java/io/airbyte/commons/protocol/migrations/MigrationContainer.java
+++ b/airbyte-commons-protocol/src/main/java/io/airbyte/commons/protocol/migrations/MigrationContainer.java
@@ -16,7 +16,9 @@ public class MigrationContainer<T extends Migration> {
 
   private final List<T> migrationsToRegister;
   private final SortedMap<String, T> migrations = new TreeMap<>();
-  private String mostRecentMajorVersion = "";
+
+  // mostRecentMajorVersion defaults to v0 as no migration is required
+  private String mostRecentMajorVersion = "0";
 
   public MigrationContainer(final List<T> migrations) {
     this.migrationsToRegister = migrations;

--- a/airbyte-commons-protocol/src/main/java/io/airbyte/commons/protocol/migrations/v1/AirbyteMessageMigrationV1.java
+++ b/airbyte-commons-protocol/src/main/java/io/airbyte/commons/protocol/migrations/v1/AirbyteMessageMigrationV1.java
@@ -24,13 +24,13 @@ import io.airbyte.protocol.models.ConfiguredAirbyteCatalog;
 import io.airbyte.protocol.models.ConfiguredAirbyteStream;
 import io.airbyte.protocol.models.JsonSchemaReferenceTypes;
 import io.airbyte.validation.json.JsonSchemaValidator;
-import jakarta.inject.Singleton;
 import java.util.Iterator;
 import java.util.Map.Entry;
 import java.util.Objects;
 import java.util.Optional;
 
-@Singleton
+// Disable V1 Migration, uncomment to re-enable
+// @Singleton
 public class AirbyteMessageMigrationV1 implements AirbyteMessageMigration<io.airbyte.protocol.models.v0.AirbyteMessage, AirbyteMessage> {
 
   private final JsonSchemaValidator validator;

--- a/airbyte-commons-protocol/src/main/java/io/airbyte/commons/protocol/migrations/v1/ConfiguredAirbyteCatalogMigrationV1.java
+++ b/airbyte-commons-protocol/src/main/java/io/airbyte/commons/protocol/migrations/v1/ConfiguredAirbyteCatalogMigrationV1.java
@@ -11,9 +11,9 @@ import io.airbyte.commons.version.AirbyteProtocolVersion;
 import io.airbyte.commons.version.Version;
 import io.airbyte.protocol.models.ConfiguredAirbyteCatalog;
 import io.airbyte.protocol.models.ConfiguredAirbyteStream;
-import jakarta.inject.Singleton;
 
-@Singleton
+// Disable V1 Migration, uncomment to re-enable
+// @Singleton
 public class ConfiguredAirbyteCatalogMigrationV1
     implements ConfiguredAirbyteCatalogMigration<io.airbyte.protocol.models.v0.ConfiguredAirbyteCatalog, ConfiguredAirbyteCatalog> {
 

--- a/airbyte-commons-protocol/src/main/java/io/airbyte/commons/protocol/migrations/v1/SchemaMigrationV1.java
+++ b/airbyte-commons-protocol/src/main/java/io/airbyte/commons/protocol/migrations/v1/SchemaMigrationV1.java
@@ -65,7 +65,7 @@ public class SchemaMigrationV1 {
    * Detects any schema that looks like a reference type declaration, e.g.: { "$ref":
    * "WellKnownTypes.json...." } or { "oneOf": [{"$ref": "..."}, {"type": "object"}] }
    */
-  private static boolean isPrimitiveReferenceTypeDeclaration(final JsonNode schema) {
+  static boolean isPrimitiveReferenceTypeDeclaration(final JsonNode schema) {
     if (!schema.isObject()) {
       // Non-object schemas (i.e. true/false) never need to be modified
       return false;

--- a/airbyte-commons-protocol/src/main/java/io/airbyte/commons/protocol/serde/AirbyteMessageV0Deserializer.java
+++ b/airbyte-commons-protocol/src/main/java/io/airbyte/commons/protocol/serde/AirbyteMessageV0Deserializer.java
@@ -5,7 +5,7 @@
 package io.airbyte.commons.protocol.serde;
 
 import io.airbyte.commons.version.AirbyteProtocolVersion;
-import io.airbyte.protocol.models.v0.AirbyteMessage;
+import io.airbyte.protocol.models.AirbyteMessage;
 import jakarta.inject.Singleton;
 
 @Singleton

--- a/airbyte-commons-protocol/src/main/java/io/airbyte/commons/protocol/serde/AirbyteMessageV0Serializer.java
+++ b/airbyte-commons-protocol/src/main/java/io/airbyte/commons/protocol/serde/AirbyteMessageV0Serializer.java
@@ -5,7 +5,7 @@
 package io.airbyte.commons.protocol.serde;
 
 import io.airbyte.commons.version.AirbyteProtocolVersion;
-import io.airbyte.protocol.models.v0.AirbyteMessage;
+import io.airbyte.protocol.models.AirbyteMessage;
 import jakarta.inject.Singleton;
 
 @Singleton

--- a/airbyte-commons-protocol/src/test/java/io/airbyte/commons/protocol/MigratorsMicronautTest.java
+++ b/airbyte-commons-protocol/src/test/java/io/airbyte/commons/protocol/MigratorsMicronautTest.java
@@ -22,7 +22,7 @@ class MigratorsMicronautTest {
 
   // This should contain the list of all the supported majors of the airbyte protocol except the most
   // recent one since the migrations themselves are keyed on the lower version.
-  final Set<String> SUPPORTED_VERSIONS = Set.of("0");
+  final Set<String> SUPPORTED_VERSIONS = Set.of();
 
   @Test
   void testAirbyteMessageMigrationInjection() {

--- a/airbyte-commons-protocol/src/test/java/io/airbyte/commons/protocol/serde/AirbyteMessageV0SerDeTest.java
+++ b/airbyte-commons-protocol/src/test/java/io/airbyte/commons/protocol/serde/AirbyteMessageV0SerDeTest.java
@@ -7,9 +7,9 @@ package io.airbyte.commons.protocol.serde;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 
 import io.airbyte.commons.json.Jsons;
-import io.airbyte.protocol.models.v0.AirbyteMessage;
-import io.airbyte.protocol.models.v0.AirbyteMessage.Type;
-import io.airbyte.protocol.models.v0.ConnectorSpecification;
+import io.airbyte.protocol.models.AirbyteMessage;
+import io.airbyte.protocol.models.AirbyteMessage.Type;
+import io.airbyte.protocol.models.ConnectorSpecification;
 import java.net.URI;
 import java.net.URISyntaxException;
 import org.junit.jupiter.api.Test;

--- a/airbyte-commons-worker/src/test/java/io/airbyte/workers/internal/VersionedAirbyteStreamFactoryTest.java
+++ b/airbyte-commons-worker/src/test/java/io/airbyte/workers/internal/VersionedAirbyteStreamFactoryTest.java
@@ -12,8 +12,6 @@ import io.airbyte.commons.protocol.AirbyteMessageMigrator;
 import io.airbyte.commons.protocol.AirbyteMessageSerDeProvider;
 import io.airbyte.commons.protocol.AirbyteProtocolVersionedMigratorFactory;
 import io.airbyte.commons.protocol.ConfiguredAirbyteCatalogMigrator;
-import io.airbyte.commons.protocol.migrations.v1.AirbyteMessageMigrationV1;
-import io.airbyte.commons.protocol.migrations.v1.ConfiguredAirbyteCatalogMigrationV1;
 import io.airbyte.commons.protocol.serde.AirbyteMessageV0Deserializer;
 import io.airbyte.commons.protocol.serde.AirbyteMessageV0Serializer;
 import io.airbyte.commons.protocol.serde.AirbyteMessageV1Deserializer;

--- a/airbyte-commons-worker/src/test/java/io/airbyte/workers/internal/VersionedAirbyteStreamFactoryTest.java
+++ b/airbyte-commons-worker/src/test/java/io/airbyte/workers/internal/VersionedAirbyteStreamFactoryTest.java
@@ -45,10 +45,12 @@ class VersionedAirbyteStreamFactoryTest {
         List.of(new AirbyteMessageV0Serializer(), new AirbyteMessageV1Serializer())));
     serDeProvider.initialize();
     final AirbyteMessageMigrator airbyteMessageMigrator = new AirbyteMessageMigrator(
-        List.of(new AirbyteMessageMigrationV1()));
+        // TODO once data types v1 is re-enabled, this test should contain the migration
+        List.of(/* new AirbyteMessageMigrationV1() */));
     airbyteMessageMigrator.initialize();
     final ConfiguredAirbyteCatalogMigrator configuredAirbyteCatalogMigrator = new ConfiguredAirbyteCatalogMigrator(
-        List.of(new ConfiguredAirbyteCatalogMigrationV1()));
+        // TODO once data types v1 is re-enabled, this test should contain the migration
+        List.of(/* new ConfiguredAirbyteCatalogMigrationV1() */));
     configuredAirbyteCatalogMigrator.initialize();
     migratorFactory = spy(new AirbyteProtocolVersionedMigratorFactory(airbyteMessageMigrator, configuredAirbyteCatalogMigrator));
   }

--- a/airbyte-config/config-models/src/main/java/io/airbyte/config/EnvConfigs.java
+++ b/airbyte-config/config-models/src/main/java/io/airbyte/config/EnvConfigs.java
@@ -218,7 +218,7 @@ public class EnvConfigs implements Configs {
   private static final long DEFAULT_MAX_SYNC_WORKERS = 5;
   private static final long DEFAULT_MAX_NOTIFY_WORKERS = 5;
   private static final String DEFAULT_NETWORK = "host";
-  private static final Version DEFAULT_AIRBYTE_PROTOCOL_VERSION_MAX = new Version("1.0.0");
+  private static final Version DEFAULT_AIRBYTE_PROTOCOL_VERSION_MAX = new Version("0.3.0");
   private static final Version DEFAULT_AIRBYTE_PROTOCOL_VERSION_MIN = new Version("0.0.0");
   private static final String AUTO_DETECT_SCHEMA = "AUTO_DETECT_SCHEMA";
   private static final String APPLY_FIELD_SELECTION = "APPLY_FIELD_SELECTION";

--- a/airbyte-config/config-persistence/src/main/java/io/airbyte/config/persistence/DbConverter.java
+++ b/airbyte-config/config-persistence/src/main/java/io/airbyte/config/persistence/DbConverter.java
@@ -98,7 +98,9 @@ public class DbConverter {
   private static ConfiguredAirbyteCatalog parseConfiguredAirbyteCatalog(final String configuredAirbyteCatalogString) {
     final ConfiguredAirbyteCatalog configuredAirbyteCatalog = Jsons.deserialize(configuredAirbyteCatalogString, ConfiguredAirbyteCatalog.class);
     // On-the-fly migration of persisted data types related objects (protocol v0->v1)
-    CatalogMigrationV1Helper.upgradeSchemaIfNeeded(configuredAirbyteCatalog);
+    // TODO feature flag this for data types rollout
+    // CatalogMigrationV1Helper.upgradeSchemaIfNeeded(configuredAirbyteCatalog);
+    CatalogMigrationV1Helper.downgradeSchemaIfNeeded(configuredAirbyteCatalog);
     return configuredAirbyteCatalog;
   }
 
@@ -249,7 +251,9 @@ public class DbConverter {
   public static AirbyteCatalog parseAirbyteCatalog(final String airbyteCatalogString) {
     final AirbyteCatalog airbyteCatalog = Jsons.deserialize(airbyteCatalogString, AirbyteCatalog.class);
     // On-the-fly migration of persisted data types related objects (protocol v0->v1)
-    CatalogMigrationV1Helper.upgradeSchemaIfNeeded(airbyteCatalog);
+    // TODO feature flag this for data types rollout
+    // CatalogMigrationV1Helper.upgradeSchemaIfNeeded(airbyteCatalog);
+    CatalogMigrationV1Helper.downgradeSchemaIfNeeded(airbyteCatalog);
     return airbyteCatalog;
   }
 

--- a/airbyte-config/config-persistence/src/test/java/io/airbyte/config/persistence/ConfigRepositoryE2EReadWriteTest.java
+++ b/airbyte-config/config-persistence/src/test/java/io/airbyte/config/persistence/ConfigRepositoryE2EReadWriteTest.java
@@ -161,7 +161,7 @@ class ConfigRepositoryE2EReadWriteTest extends BaseConfigDatabaseTest {
     configRepository.writeSourceConnectionNoSecrets(source);
 
     final AirbyteCatalog actorCatalog = CatalogHelpers.createAirbyteCatalog("clothes", Field.of("name", JsonSchemaType.STRING));
-    final AirbyteCatalog expectedActorCatalog = CatalogHelpers.createAirbyteCatalog("clothes", Field.of("name", JsonSchemaType.STRING_V1));
+    final AirbyteCatalog expectedActorCatalog = CatalogHelpers.createAirbyteCatalog("clothes", Field.of("name", JsonSchemaType.STRING));
     configRepository.writeActorCatalogFetchEvent(
         actorCatalog, source.getSourceId(), DOCKER_IMAGE_TAG, CONFIG_HASH);
 
@@ -201,7 +201,8 @@ class ConfigRepositoryE2EReadWriteTest extends BaseConfigDatabaseTest {
     assertEquals(expectedActorCatalog, Jsons.object(catalogNewConfig.get().getCatalog(), AirbyteCatalog.class));
 
     final int catalogDbEntry2 = database.query(ctx -> ctx.selectCount().from(ACTOR_CATALOG)).fetchOne().into(int.class);
-    assertEquals(2, catalogDbEntry2);
+    // TODO this should be 2 once we re-enable datatypes v1
+    assertEquals(1, catalogDbEntry2);
   }
 
   @Test
@@ -484,13 +485,15 @@ class ConfigRepositoryE2EReadWriteTest extends BaseConfigDatabaseTest {
   }
 
   private List<StandardSync> copyWithV1Types(final List<StandardSync> syncs) {
-    return syncs.stream()
-        .map(standardSync -> {
-          final StandardSync copiedStandardSync = Jsons.deserialize(Jsons.serialize(standardSync), StandardSync.class);
-          copiedStandardSync.setCatalog(MockData.getConfiguredCatalogWithV1DataTypes());
-          return copiedStandardSync;
-        })
-        .toList();
+    return syncs;
+    // TODO adjust with data types feature flag testing
+//    return syncs.stream()
+//        .map(standardSync -> {
+//          final StandardSync copiedStandardSync = Jsons.deserialize(Jsons.serialize(standardSync), StandardSync.class);
+//          copiedStandardSync.setCatalog(MockData.getConfiguredCatalogWithV1DataTypes());
+//          return copiedStandardSync;
+//        })
+//        .toList();
   }
 
   private void assertSyncsMatch(final List<StandardSync> expectedSyncs, final List<StandardSync> actualSyncs) {

--- a/airbyte-config/config-persistence/src/test/java/io/airbyte/config/persistence/ConfigRepositoryE2EReadWriteTest.java
+++ b/airbyte-config/config-persistence/src/test/java/io/airbyte/config/persistence/ConfigRepositoryE2EReadWriteTest.java
@@ -487,13 +487,14 @@ class ConfigRepositoryE2EReadWriteTest extends BaseConfigDatabaseTest {
   private List<StandardSync> copyWithV1Types(final List<StandardSync> syncs) {
     return syncs;
     // TODO adjust with data types feature flag testing
-//    return syncs.stream()
-//        .map(standardSync -> {
-//          final StandardSync copiedStandardSync = Jsons.deserialize(Jsons.serialize(standardSync), StandardSync.class);
-//          copiedStandardSync.setCatalog(MockData.getConfiguredCatalogWithV1DataTypes());
-//          return copiedStandardSync;
-//        })
-//        .toList();
+    // return syncs.stream()
+    // .map(standardSync -> {
+    // final StandardSync copiedStandardSync = Jsons.deserialize(Jsons.serialize(standardSync),
+    // StandardSync.class);
+    // copiedStandardSync.setCatalog(MockData.getConfiguredCatalogWithV1DataTypes());
+    // return copiedStandardSync;
+    // })
+    // .toList();
   }
 
   private void assertSyncsMatch(final List<StandardSync> expectedSyncs, final List<StandardSync> actualSyncs) {

--- a/airbyte-config/init/src/main/resources/seed/destination_definitions.yaml
+++ b/airbyte-config/init/src/main/resources/seed/destination_definitions.yaml
@@ -45,7 +45,7 @@
   icon: bigquery.svg
   normalizationConfig:
     normalizationRepository: airbyte/normalization
-    normalizationTag: 0.2.25
+    normalizationTag: 0.3.2
     normalizationIntegrationType: bigquery
   supportsDbt: true
   resourceRequirements:
@@ -91,7 +91,7 @@
   releaseStage: alpha
   normalizationConfig:
     normalizationRepository: airbyte/normalization-clickhouse
-    normalizationTag: 0.2.25
+    normalizationTag: 0.3.2
     normalizationIntegrationType: clickhouse
   supportsDbt: true
 - name: Cloudflare R2
@@ -213,7 +213,7 @@
   releaseStage: alpha
   normalizationConfig:
     normalizationRepository: airbyte/normalization-mssql
-    normalizationTag: 0.2.25
+    normalizationTag: 0.3.2
     normalizationIntegrationType: mssql
   supportsDbt: true
 - name: MeiliSearch
@@ -239,7 +239,7 @@
   releaseStage: alpha
   normalizationConfig:
     normalizationRepository: airbyte/normalization-mysql
-    normalizationTag: 0.2.25
+    normalizationTag: 0.3.2
     normalizationIntegrationType: mysql
   supportsDbt: true
 - name: Oracle
@@ -251,7 +251,7 @@
   releaseStage: alpha
   normalizationConfig:
     normalizationRepository: airbyte/normalization-oracle
-    normalizationTag: 0.2.25
+    normalizationTag: 0.3.2
     normalizationIntegrationType: oracle
   supportsDbt: true
 - name: Postgres
@@ -263,7 +263,7 @@
   releaseStage: alpha
   normalizationConfig:
     normalizationRepository: airbyte/normalization
-    normalizationTag: 0.2.25
+    normalizationTag: 0.3.2
     normalizationIntegrationType: postgres
   supportsDbt: true
 - name: Pulsar
@@ -295,7 +295,7 @@
   icon: redshift.svg
   normalizationConfig:
     normalizationRepository: airbyte/normalization-redshift
-    normalizationTag: 0.2.25
+    normalizationTag: 0.3.2
     normalizationIntegrationType: redshift
   supportsDbt: true
   resourceRequirements:
@@ -353,7 +353,7 @@
   icon: snowflake.svg
   normalizationConfig:
     normalizationRepository: airbyte/normalization-snowflake
-    normalizationTag: 0.2.25
+    normalizationTag: 0.3.2
     normalizationIntegrationType: snowflake
   supportsDbt: true
   resourceRequirements:
@@ -407,7 +407,7 @@
   releaseStage: alpha
   normalizationConfig:
     normalizationRepository: airbyte/normalization-tidb
-    normalizationTag: 0.2.25
+    normalizationTag: 0.3.2
     normalizationIntegrationType: tidb
   supportsDbt: true
 - name: Typesense

--- a/airbyte-config/init/src/main/resources/seed/destination_definitions.yaml
+++ b/airbyte-config/init/src/main/resources/seed/destination_definitions.yaml
@@ -45,7 +45,7 @@
   icon: bigquery.svg
   normalizationConfig:
     normalizationRepository: airbyte/normalization
-    normalizationTag: 0.3.2
+    normalizationTag: 0.2.25
     normalizationIntegrationType: bigquery
   supportsDbt: true
   resourceRequirements:
@@ -91,7 +91,7 @@
   releaseStage: alpha
   normalizationConfig:
     normalizationRepository: airbyte/normalization-clickhouse
-    normalizationTag: 0.3.2
+    normalizationTag: 0.2.25
     normalizationIntegrationType: clickhouse
   supportsDbt: true
 - name: Cloudflare R2
@@ -213,7 +213,7 @@
   releaseStage: alpha
   normalizationConfig:
     normalizationRepository: airbyte/normalization-mssql
-    normalizationTag: 0.3.2
+    normalizationTag: 0.2.25
     normalizationIntegrationType: mssql
   supportsDbt: true
 - name: MeiliSearch
@@ -239,7 +239,7 @@
   releaseStage: alpha
   normalizationConfig:
     normalizationRepository: airbyte/normalization-mysql
-    normalizationTag: 0.3.2
+    normalizationTag: 0.2.25
     normalizationIntegrationType: mysql
   supportsDbt: true
 - name: Oracle
@@ -251,7 +251,7 @@
   releaseStage: alpha
   normalizationConfig:
     normalizationRepository: airbyte/normalization-oracle
-    normalizationTag: 0.3.2
+    normalizationTag: 0.2.25
     normalizationIntegrationType: oracle
   supportsDbt: true
 - name: Postgres
@@ -263,7 +263,7 @@
   releaseStage: alpha
   normalizationConfig:
     normalizationRepository: airbyte/normalization
-    normalizationTag: 0.3.2
+    normalizationTag: 0.2.25
     normalizationIntegrationType: postgres
   supportsDbt: true
 - name: Pulsar
@@ -295,7 +295,7 @@
   icon: redshift.svg
   normalizationConfig:
     normalizationRepository: airbyte/normalization-redshift
-    normalizationTag: 0.3.2
+    normalizationTag: 0.2.25
     normalizationIntegrationType: redshift
   supportsDbt: true
   resourceRequirements:
@@ -353,7 +353,7 @@
   icon: snowflake.svg
   normalizationConfig:
     normalizationRepository: airbyte/normalization-snowflake
-    normalizationTag: 0.3.2
+    normalizationTag: 0.2.25
     normalizationIntegrationType: snowflake
   supportsDbt: true
   resourceRequirements:
@@ -407,7 +407,7 @@
   releaseStage: alpha
   normalizationConfig:
     normalizationRepository: airbyte/normalization-tidb
-    normalizationTag: 0.3.2
+    normalizationTag: 0.2.25
     normalizationIntegrationType: tidb
   supportsDbt: true
 - name: Typesense

--- a/airbyte-persistence/job-persistence/src/main/java/io/airbyte/persistence/job/DefaultJobPersistence.java
+++ b/airbyte-persistence/job-persistence/src/main/java/io/airbyte/persistence/job/DefaultJobPersistence.java
@@ -931,9 +931,13 @@ public class DefaultJobPersistence implements JobPersistence {
     final JobConfig jobConfig = Jsons.deserialize(jobConfigString, JobConfig.class);
     // On-the-fly migration of persisted data types related objects (protocol v0->v1)
     if (jobConfig.getConfigType() == ConfigType.SYNC && jobConfig.getSync() != null) {
-      CatalogMigrationV1Helper.upgradeSchemaIfNeeded(jobConfig.getSync().getConfiguredAirbyteCatalog());
+      // TODO feature flag this for data types rollout
+      // CatalogMigrationV1Helper.upgradeSchemaIfNeeded(jobConfig.getSync().getConfiguredAirbyteCatalog());
+      CatalogMigrationV1Helper.downgradeSchemaIfNeeded(jobConfig.getSync().getConfiguredAirbyteCatalog());
     } else if (jobConfig.getConfigType() == ConfigType.RESET_CONNECTION && jobConfig.getResetConnection() != null) {
-      CatalogMigrationV1Helper.upgradeSchemaIfNeeded(jobConfig.getResetConnection().getConfiguredAirbyteCatalog());
+      // TODO feature flag this for data types rollout
+      // CatalogMigrationV1Helper.upgradeSchemaIfNeeded(jobConfig.getResetConnection().getConfiguredAirbyteCatalog());
+      CatalogMigrationV1Helper.downgradeSchemaIfNeeded(jobConfig.getResetConnection().getConfiguredAirbyteCatalog());
     }
     return jobConfig;
   }
@@ -960,9 +964,13 @@ public class DefaultJobPersistence implements JobPersistence {
     final JobOutput jobOutput = Jsons.deserialize(jobOutputString, JobOutput.class);
     // On-the-fly migration of persisted data types related objects (protocol v0->v1)
     if (jobOutput.getOutputType() == OutputType.DISCOVER_CATALOG && jobOutput.getDiscoverCatalog() != null) {
-      CatalogMigrationV1Helper.upgradeSchemaIfNeeded(jobOutput.getDiscoverCatalog().getCatalog());
+      // TODO feature flag this for data types rollout
+      // CatalogMigrationV1Helper.upgradeSchemaIfNeeded(jobOutput.getDiscoverCatalog().getCatalog());
+      CatalogMigrationV1Helper.downgradeSchemaIfNeeded(jobOutput.getDiscoverCatalog().getCatalog());
     } else if (jobOutput.getOutputType() == OutputType.SYNC && jobOutput.getSync() != null) {
-      CatalogMigrationV1Helper.upgradeSchemaIfNeeded(jobOutput.getSync().getOutputCatalog());
+      // TODO feature flag this for data types rollout
+      // CatalogMigrationV1Helper.upgradeSchemaIfNeeded(jobOutput.getSync().getOutputCatalog());
+      CatalogMigrationV1Helper.downgradeSchemaIfNeeded(jobOutput.getSync().getOutputCatalog());
     }
     return jobOutput;
   }

--- a/airbyte-server/src/main/resources/application.yml
+++ b/airbyte-server/src/main/resources/application.yml
@@ -81,7 +81,7 @@ airbyte:
     root: ${WORKSPACE_ROOT}
   protocol:
     min-version: ${AIRBYTE_PROTOCOL_VERSION_MIN:0.0.0}
-    max-version: ${AIRBYTE_PROTOCOL_VERSION_MAX:1.0.0}
+    max-version: ${AIRBYTE_PROTOCOL_VERSION_MAX:0.3.0}
 
 temporal:
   cloud:

--- a/airbyte-test-utils/src/main/java/io/airbyte/test/utils/AirbyteAcceptanceTestHarness.java
+++ b/airbyte-test-utils/src/main/java/io/airbyte/test/utils/AirbyteAcceptanceTestHarness.java
@@ -585,19 +585,6 @@ public class AirbyteAcceptanceTestHarness {
     return database.query(context -> context.fetch(String.format("SELECT * FROM %s;", table)))
         .stream()
         .map(Record::intoMap)
-        .map(rec -> {
-          // The protocol requires converting numbers to strings. source-postgres does that internally,
-          // but we're querying the DB directly, so we have to do it manually.
-          final Map<String, Object> stringifiedNumbers = new HashMap<>();
-          for (final String key : rec.keySet()) {
-            Object o = rec.get(key);
-            if (o instanceof Number) {
-              o = o.toString();
-            }
-            stringifiedNumbers.put(key, o);
-          }
-          return stringifiedNumbers;
-        })
         .map(Jsons::jsonNode)
         .collect(Collectors.toList());
   }

--- a/airbyte-tests/src/acceptanceTests/java/io/airbyte/test/acceptance/BasicAcceptanceTests.java
+++ b/airbyte-tests/src/acceptanceTests/java/io/airbyte/test/acceptance/BasicAcceptanceTests.java
@@ -46,6 +46,7 @@ import io.airbyte.api.client.model.generated.ConnectionScheduleDataCron;
 import io.airbyte.api.client.model.generated.ConnectionScheduleType;
 import io.airbyte.api.client.model.generated.ConnectionState;
 import io.airbyte.api.client.model.generated.ConnectionStatus;
+import io.airbyte.api.client.model.generated.DataType;
 import io.airbyte.api.client.model.generated.DestinationDefinitionIdRequestBody;
 import io.airbyte.api.client.model.generated.DestinationDefinitionIdWithWorkspaceId;
 import io.airbyte.api.client.model.generated.DestinationDefinitionRead;
@@ -319,8 +320,8 @@ class BasicAcceptanceTests {
     final AirbyteCatalog actual = testHarness.discoverSourceSchema(sourceId);
 
     final Map<String, Map<String, String>> fields = ImmutableMap.of(
-        COLUMN_ID, ImmutableMap.of(REF, INTEGER_REFERENCE),
-        COLUMN_NAME, ImmutableMap.of(REF, STRING_REFERENCE));
+        COLUMN_ID, ImmutableMap.of(TYPE, DataType.NUMBER.getValue(), "airbyte_type", "integer"),
+        COLUMN_NAME, ImmutableMap.of(TYPE, DataType.STRING.getValue()));
     final JsonNode jsonSchema = Jsons.jsonNode(ImmutableMap.builder()
         .put(TYPE, "object")
         .put("properties", fields)
@@ -573,8 +574,8 @@ class BasicAcceptanceTests {
     // add new records and run again.
     final Database source = testHarness.getSourceDatabase();
     final List<JsonNode> expectedRawRecords = testHarness.retrieveSourceRecords(source, STREAM_NAME);
-    expectedRawRecords.add(Jsons.jsonNode(ImmutableMap.builder().put(COLUMN_ID, "6").put(COLUMN_NAME, "sherif").build()));
-    expectedRawRecords.add(Jsons.jsonNode(ImmutableMap.builder().put(COLUMN_ID, "7").put(COLUMN_NAME, "chris").build()));
+    expectedRawRecords.add(Jsons.jsonNode(ImmutableMap.builder().put(COLUMN_ID, 6).put(COLUMN_NAME, "sherif").build()));
+    expectedRawRecords.add(Jsons.jsonNode(ImmutableMap.builder().put(COLUMN_ID, 7).put(COLUMN_NAME, "chris").build()));
     source.query(ctx -> ctx.execute("UPDATE id_and_name SET id=6 WHERE name='sherif'"));
     source.query(ctx -> ctx.execute("INSERT INTO id_and_name(id, name) VALUES(7, 'chris')"));
     // retrieve latest snapshot of source records after modifications; the deduplicated table in
@@ -627,7 +628,7 @@ class BasicAcceptanceTests {
     final Database source = testHarness.getSourceDatabase();
     // get contents of source before mutating records.
     final List<JsonNode> expectedRecords = testHarness.retrieveSourceRecords(source, STREAM_NAME);
-    expectedRecords.add(Jsons.jsonNode(ImmutableMap.builder().put(COLUMN_ID, "6").put(COLUMN_NAME, GERALT).build()));
+    expectedRecords.add(Jsons.jsonNode(ImmutableMap.builder().put(COLUMN_ID, 6).put(COLUMN_NAME, GERALT).build()));
     // add a new record
     source.query(ctx -> ctx.execute("INSERT INTO id_and_name(id, name) VALUES(6, 'geralt')"));
     // mutate a record that was already synced with out updating its cursor value. if we are actually
@@ -925,7 +926,7 @@ class BasicAcceptanceTests {
     final Database sourceDatabase = testHarness.getSourceDatabase();
     // get contents of source before mutating records.
     final List<JsonNode> expectedRecords = testHarness.retrieveSourceRecords(sourceDatabase, STREAM_NAME);
-    expectedRecords.add(Jsons.jsonNode(ImmutableMap.builder().put(COLUMN_ID, "6").put(COLUMN_NAME, GERALT).build()));
+    expectedRecords.add(Jsons.jsonNode(ImmutableMap.builder().put(COLUMN_ID, 6).put(COLUMN_NAME, GERALT).build()));
     // add a new record
     sourceDatabase.query(ctx -> ctx.execute("INSERT INTO id_and_name(id, name) VALUES(6, 'geralt')"));
     // mutate a record that was already synced with out updating its cursor value. if we are actually
@@ -1226,9 +1227,9 @@ class BasicAcceptanceTests {
         testHarness.retrieveSourceRecords(source, STAGING_SCHEMA_NAME + "." + COOL_EMPLOYEES_TABLE_NAME);
     final List<JsonNode> expectedRecordsAwesomePeople =
         testHarness.retrieveSourceRecords(source, STAGING_SCHEMA_NAME + "." + AWESOME_PEOPLE_TABLE_NAME);
-    expectedRecordsIdAndName.add(Jsons.jsonNode(ImmutableMap.builder().put(COLUMN_ID, "6").put(COLUMN_NAME, GERALT).build()));
-    expectedRecordsCoolEmployees.add(Jsons.jsonNode(ImmutableMap.builder().put(COLUMN_ID, "6").put(COLUMN_NAME, GERALT).build()));
-    expectedRecordsAwesomePeople.add(Jsons.jsonNode(ImmutableMap.builder().put(COLUMN_ID, "3").put(COLUMN_NAME, GERALT).build()));
+    expectedRecordsIdAndName.add(Jsons.jsonNode(ImmutableMap.builder().put(COLUMN_ID, 6).put(COLUMN_NAME, GERALT).build()));
+    expectedRecordsCoolEmployees.add(Jsons.jsonNode(ImmutableMap.builder().put(COLUMN_ID, 6).put(COLUMN_NAME, GERALT).build()));
+    expectedRecordsAwesomePeople.add(Jsons.jsonNode(ImmutableMap.builder().put(COLUMN_ID, 3).put(COLUMN_NAME, GERALT).build()));
     // add a new record to each table
     source.query(ctx -> ctx.execute("INSERT INTO id_and_name(id, name) VALUES(6, 'geralt')"));
     source.query(ctx -> ctx.execute("INSERT INTO staging.cool_employees(id, name) VALUES(6, 'geralt')"));
@@ -1463,8 +1464,8 @@ class BasicAcceptanceTests {
     source.query(ctx -> ctx.execute("INSERT INTO id_and_name(id, name) VALUES(6, 'mike')"));
     source.query(ctx -> ctx.execute("INSERT INTO id_and_name(id, name) VALUES(7, 'chris')"));
     // The expected new raw records should only have the ID column.
-    expectedRawRecords.add(Jsons.jsonNode(ImmutableMap.builder().put(COLUMN_ID, "6").build()));
-    expectedRawRecords.add(Jsons.jsonNode(ImmutableMap.builder().put(COLUMN_ID, "7").build()));
+    expectedRawRecords.add(Jsons.jsonNode(ImmutableMap.builder().put(COLUMN_ID, 6).build()));
+    expectedRawRecords.add(Jsons.jsonNode(ImmutableMap.builder().put(COLUMN_ID, 7).build()));
     final JobInfoRead connectionSyncRead2 = apiClient.getConnectionApi()
         .syncConnection(new ConnectionIdRequestBody().connectionId(connectionId));
     waitForSuccessfulJob(apiClient.getJobsApi(), connectionSyncRead2.getJob());

--- a/airbyte-tests/src/acceptanceTests/java/io/airbyte/test/acceptance/CdcAcceptanceTests.java
+++ b/airbyte-tests/src/acceptanceTests/java/io/airbyte/test/acceptance/CdcAcceptanceTests.java
@@ -298,7 +298,7 @@ class CdcAcceptanceTests {
     source.query(ctx -> ctx.execute("DELETE FROM id_and_name WHERE id=1"));
 
     final Map<String, Object> deletedRecordMap = new HashMap<>();
-    deletedRecordMap.put(COLUMN_ID, "1");
+    deletedRecordMap.put(COLUMN_ID, 1);
     deletedRecordMap.put(COLUMN_NAME, null);
     expectedIdAndNameRecords.add(new DestinationCdcRecordMatcher(
         Jsons.jsonNode(deletedRecordMap),

--- a/airbyte-tests/src/acceptanceTests/java/io/airbyte/test/acceptance/CdcAcceptanceTests.java
+++ b/airbyte-tests/src/acceptanceTests/java/io/airbyte/test/acceptance/CdcAcceptanceTests.java
@@ -194,11 +194,11 @@ class CdcAcceptanceTests {
     // new value and an updated_at time corresponding to this update query
     source.query(ctx -> ctx.execute("UPDATE id_and_name SET name='yennefer' WHERE id=2"));
     expectedIdAndNameRecords.add(new DestinationCdcRecordMatcher(
-        Jsons.jsonNode(ImmutableMap.builder().put(COLUMN_ID, "6").put(COLUMN_NAME, "geralt").build()),
+        Jsons.jsonNode(ImmutableMap.builder().put(COLUMN_ID, 6).put(COLUMN_NAME, "geralt").build()),
         beforeFirstUpdate,
         Optional.empty()));
     expectedIdAndNameRecords.add(new DestinationCdcRecordMatcher(
-        Jsons.jsonNode(ImmutableMap.builder().put(COLUMN_ID, "2").put(COLUMN_NAME, "yennefer").build()),
+        Jsons.jsonNode(ImmutableMap.builder().put(COLUMN_ID, 2).put(COLUMN_NAME, "yennefer").build()),
         beforeFirstUpdate,
         Optional.empty()));
 
@@ -206,11 +206,11 @@ class CdcAcceptanceTests {
     source.query(ctx -> ctx.execute("INSERT INTO color_palette(id, color) VALUES(4, 'yellow')"));
     source.query(ctx -> ctx.execute("UPDATE color_palette SET color='purple' WHERE id=2"));
     expectedColorPaletteRecords.add(new DestinationCdcRecordMatcher(
-        Jsons.jsonNode(ImmutableMap.builder().put(COLUMN_ID, "4").put(COLUMN_COLOR, "yellow").build()),
+        Jsons.jsonNode(ImmutableMap.builder().put(COLUMN_ID, 4).put(COLUMN_COLOR, "yellow").build()),
         beforeFirstUpdate,
         Optional.empty()));
     expectedColorPaletteRecords.add(new DestinationCdcRecordMatcher(
-        Jsons.jsonNode(ImmutableMap.builder().put(COLUMN_ID, "2").put(COLUMN_COLOR, "purple").build()),
+        Jsons.jsonNode(ImmutableMap.builder().put(COLUMN_ID, 2).put(COLUMN_COLOR, "purple").build()),
         beforeFirstUpdate,
         Optional.empty()));
 
@@ -431,13 +431,13 @@ class CdcAcceptanceTests {
     final Instant beforeInsert = Instant.now();
     source.query(ctx -> ctx.execute("INSERT INTO id_and_name(id, name) VALUES(6, 'geralt')"));
     expectedIdAndNameRecords.add(new DestinationCdcRecordMatcher(
-        Jsons.jsonNode(ImmutableMap.builder().put(COLUMN_ID, "6").put(COLUMN_NAME, "geralt").build()),
+        Jsons.jsonNode(ImmutableMap.builder().put(COLUMN_ID, 6).put(COLUMN_NAME, "geralt").build()),
         beforeInsert,
         Optional.empty()));
 
     source.query(ctx -> ctx.execute("INSERT INTO color_palette(id, color) VALUES(4, 'yellow')"));
     expectedColorPaletteRecords.add(new DestinationCdcRecordMatcher(
-        Jsons.jsonNode(ImmutableMap.builder().put(COLUMN_ID, "4").put(COLUMN_COLOR, "yellow").build()),
+        Jsons.jsonNode(ImmutableMap.builder().put(COLUMN_ID, 4).put(COLUMN_COLOR, "yellow").build()),
         beforeInsert,
         Optional.empty()));
 

--- a/airbyte-workers/src/test/java/io/airbyte/workers/temporal/sync/NormalizationActivityImplTest.java
+++ b/airbyte-workers/src/test/java/io/airbyte/workers/temporal/sync/NormalizationActivityImplTest.java
@@ -17,7 +17,7 @@ class NormalizationActivityImplTest {
     Assertions.assertTrue(NormalizationActivityImpl.normalizationSupportsV1DataTypes(withNormalizationVersion("0.3.0")));
     Assertions.assertTrue(NormalizationActivityImpl.normalizationSupportsV1DataTypes(withNormalizationVersion("0.4.1")));
     Assertions.assertTrue(NormalizationActivityImpl.normalizationSupportsV1DataTypes(withNormalizationVersion("dev")));
-    Assertions.assertTrue(NormalizationActivityImpl.normalizationSupportsV1DataTypes(withNormalizationVersion("protocolv1")));
+    Assertions.assertFalse(NormalizationActivityImpl.normalizationSupportsV1DataTypes(withNormalizationVersion("protocolv1")));
   }
 
   private IntegrationLauncherConfig withNormalizationVersion(final String version) {


### PR DESCRIPTION
## What
Addresses complications with upgrading the platform and normalization to support V1 protocol changes. This change will focus on making sure that platform is downgrading V1 protocols on-the-fly to ensure the catalog stored is V0. This effort will need to be in coordination with the normalization being downgraded to support V0 protocol

## How
Adjust changes that were made to update the protocol version to V1 to go back and support V0 protocol until the migration process can be handled 

## Recommended reading order
1. `x.java`
2. `y.python`

