### PR TITLE
Perform catalog diff on get request

### DIFF
--- a/airbyte-commons-server/src/main/java/io/airbyte/commons/server/handlers/WebBackendConnectionsHandler.java
+++ b/airbyte-commons-server/src/main/java/io/airbyte/commons/server/handlers/WebBackendConnectionsHandler.java
@@ -209,9 +209,6 @@ public class WebBackendConnectionsHandler {
       webBackendConnectionRead.setLatestSyncJobStatus(job.getStatus());
     });
 
-    // final Optional<ActorCatalogFetchEvent> mostRecentFetchEvent =
-    // configRepository.getMostRecentActorCatalogFetchEventForSource(connectionRead.getSourceId());
-
     final SchemaChange schemaChange = getSchemaChange(connectionRead, diff);
 
     webBackendConnectionRead.setSchemaChange(schemaChange);

--- a/airbyte-commons-server/src/test/resources/valid_schema.json
+++ b/airbyte-commons-server/src/test/resources/valid_schema.json
@@ -1,0 +1,34 @@
+{
+  "type": "object",
+  "properties": {
+    "tags": {
+      "type": "object",
+      "properties": {
+        "tags": {
+          "type": "array",
+          "items": {
+            "type": ["null", "object"],
+            "anyOf": [
+              {
+                "type": "object",
+                "properties": {
+                  "id": {
+                    "type": "integer"
+                  },
+                  "name": {
+                    "type": "string"
+                  },
+                  "type": {
+                    "type": "string"
+                  }
+                }
+              },
+              { "type": "null" }
+            ]
+          }
+        }
+      }
+    }
+  },
+  "additionalProperties": false
+}


### PR DESCRIPTION
Resolves https://github.com/airbytehq/oncall/issues/1413

Instead of checking whether there is a new source catalog id for a connection's source, perform a complete catalog diff to determine whether there are schema changes.

There is a bug where schema refreshes result in new actor_catalogs even when there are no schema changes present. This means users' connection pages tell them there are schema changes, and when they refresh their schemas, there are no changes to apply.

This PR changes the Connection Get endpoint so instead of checking whether there is a new actor_catalog available, we perform a full Catalog Diff between the connection's existing catalog and the most recently detected source catalog.