### PR TITLE
:window: :bug: Poll backend for Free Connector Program enrollment success

### DIFF
--- a/airbyte-webapp/src/core/request/pollUntil.test.ts
+++ b/airbyte-webapp/src/core/request/pollUntil.test.ts
@@ -1,0 +1,67 @@
+import { pollUntil } from "./pollUntil";
+
+// a toy promise that can be polled for a specific response
+const fourZerosAndThenSeven = () => {
+  let _callCount = 0;
+  return () => Promise.resolve([0, 0, 0, 0, 7][_callCount++]);
+};
+// eslint-disable-next-line
+const truthyResponse = (x: any) => !!x;
+
+describe("pollUntil", () => {
+  describe("when maxTimeout is not provided", () => {
+    it("calls the provided apiFn until condition returns true and resolves to its final return value", () => {
+      const pollableFn = fourZerosAndThenSeven();
+
+      return expect(pollUntil(pollableFn, truthyResponse, 1)).resolves.toBe(7);
+    });
+  });
+
+  describe("when condition returns true before maxTimeout is reached", () => {
+    it("calls the provided apiFn until condition returns true and resolves to its final return value", () => {
+      const pollableFn = fourZerosAndThenSeven();
+
+      return expect(pollUntil(pollableFn, truthyResponse, 1, 100)).resolves.toBe(7);
+    });
+  });
+
+  describe("when maxTimeout is reached before condition returns true", () => {
+    it("resolves to false", () => {
+      const pollableFn = fourZerosAndThenSeven();
+
+      return expect(pollUntil(pollableFn, truthyResponse, 100, 1)).resolves.toBe(false);
+    });
+
+    // Because the timing of the polling depends on both the provided `interval` and the
+    // execution time of `apiFn`, the timing of polling iterations isn't entirely
+    // deterministic; it's precise enough for its job, but it's difficult to make precise
+    // test assertions about polling behavior without long interval/maxTimeout bogging
+    // down the test suite.
+    it("calls its apiFn arg no more than (maxTimeout / interval) times", async () => {
+      let _callCount = 0;
+      let lastCalledValue = 999;
+      const pollableFn = () =>
+        Promise.resolve([1, 2, 3, 4, 5][_callCount++]).then((val) => {
+          lastCalledValue = val;
+          return val;
+        });
+
+      await pollUntil(pollableFn, (_) => false, 20, 78);
+
+      // In theory, this is what just happened:
+      // | time elapsed | value (source)  |
+      // |--------------+-----------------|
+      // |          0ms | 1 (poll)        |
+      // |         20ms | 2 (poll)        |
+      // |         40ms | 3 (poll)        |
+      // |         60ms | 4 (poll)        |
+      // |         78ms | false (timeout) |
+      //
+      // In practice, since the polling interval isn't started until after `apiFn`
+      // resolves to a value, the actual call counts are slightly nondeterministic. We
+      // could ignore that fact with a slow enough interval, but who wants slow tests?
+      expect(lastCalledValue > 2).toBe(true);
+      expect(lastCalledValue <= 4).toBe(true);
+    });
+  });
+});

--- a/airbyte-webapp/src/core/request/pollUntil.test.ts
+++ b/airbyte-webapp/src/core/request/pollUntil.test.ts
@@ -9,35 +9,35 @@ const fourZerosAndThenSeven = () => {
 const truthyResponse = (x: any) => !!x;
 
 describe("pollUntil", () => {
-  describe("when maxTimeout is not provided", () => {
+  describe("when maxTimeoutMs is not provided", () => {
     it("calls the provided apiFn until condition returns true and resolves to its final return value", () => {
       const pollableFn = fourZerosAndThenSeven();
 
-      return expect(pollUntil(pollableFn, truthyResponse, { interval: 1 })).resolves.toBe(7);
+      return expect(pollUntil(pollableFn, truthyResponse, { intervalMs: 1 })).resolves.toBe(7);
     });
   });
 
-  describe("when condition returns true before maxTimeout is reached", () => {
+  describe("when condition returns true before maxTimeoutMs is reached", () => {
     it("calls the provided apiFn until condition returns true and resolves to its final return value", () => {
       const pollableFn = fourZerosAndThenSeven();
 
-      return expect(pollUntil(pollableFn, truthyResponse, { interval: 1, maxTimeout: 100 })).resolves.toBe(7);
+      return expect(pollUntil(pollableFn, truthyResponse, { intervalMs: 1, maxTimeoutMs: 100 })).resolves.toBe(7);
     });
   });
 
-  describe("when maxTimeout is reached before condition returns true", () => {
+  describe("when maxTimeoutMs is reached before condition returns true", () => {
     it("resolves to false", () => {
       const pollableFn = fourZerosAndThenSeven();
 
-      return expect(pollUntil(pollableFn, truthyResponse, { interval: 100, maxTimeout: 1 })).resolves.toBe(false);
+      return expect(pollUntil(pollableFn, truthyResponse, { intervalMs: 100, maxTimeoutMs: 1 })).resolves.toBe(false);
     });
 
-    // Because the timing of the polling depends on both the provided `interval` and the
+    // Because the timing of the polling depends on both the provided `intervalMs` and the
     // execution time of `apiFn`, the timing of polling iterations isn't entirely
     // deterministic; it's precise enough for its job, but it's difficult to make precise
-    // test assertions about polling behavior without long interval/maxTimeout bogging
+    // test assertions about polling behavior without long intervalMs/maxTimeoutMs bogging
     // down the test suite.
-    it("calls its apiFn arg no more than (maxTimeout / interval) times", async () => {
+    it("calls its apiFn arg no more than (maxTimeoutMs / intervalMs) times", async () => {
       let _callCount = 0;
       let lastCalledValue = 999;
       const pollableFn = () =>
@@ -46,7 +46,7 @@ describe("pollUntil", () => {
           return val;
         });
 
-      await pollUntil(pollableFn, (_) => false, { interval: 20, maxTimeout: 78 });
+      await pollUntil(pollableFn, (_) => false, { intervalMs: 20, maxTimeoutMs: 78 });
 
       // In theory, this is what just happened:
       // | time elapsed | value (source)  |
@@ -57,9 +57,9 @@ describe("pollUntil", () => {
       // |         60ms | 4 (poll)        |
       // |         78ms | false (timeout) |
       //
-      // In practice, since the polling interval isn't started until after `apiFn`
+      // In practice, since the polling intervalMs isn't started until after `apiFn`
       // resolves to a value, the actual call counts are slightly nondeterministic. We
-      // could ignore that fact with a slow enough interval, but who wants slow tests?
+      // could ignore that fact with a slow enough intervalMs, but who wants slow tests?
       expect(lastCalledValue > 2).toBe(true);
       expect(lastCalledValue <= 4).toBe(true);
     });

--- a/airbyte-webapp/src/core/request/pollUntil.test.ts
+++ b/airbyte-webapp/src/core/request/pollUntil.test.ts
@@ -13,7 +13,7 @@ describe("pollUntil", () => {
     it("calls the provided apiFn until condition returns true and resolves to its final return value", () => {
       const pollableFn = fourZerosAndThenSeven();
 
-      return expect(pollUntil(pollableFn, truthyResponse, 1)).resolves.toBe(7);
+      return expect(pollUntil(pollableFn, truthyResponse, { interval: 1 })).resolves.toBe(7);
     });
   });
 
@@ -21,7 +21,7 @@ describe("pollUntil", () => {
     it("calls the provided apiFn until condition returns true and resolves to its final return value", () => {
       const pollableFn = fourZerosAndThenSeven();
 
-      return expect(pollUntil(pollableFn, truthyResponse, 1, 100)).resolves.toBe(7);
+      return expect(pollUntil(pollableFn, truthyResponse, { interval: 1, maxTimeout: 100 })).resolves.toBe(7);
     });
   });
 
@@ -29,7 +29,7 @@ describe("pollUntil", () => {
     it("resolves to false", () => {
       const pollableFn = fourZerosAndThenSeven();
 
-      return expect(pollUntil(pollableFn, truthyResponse, 100, 1)).resolves.toBe(false);
+      return expect(pollUntil(pollableFn, truthyResponse, { interval: 100, maxTimeout: 1 })).resolves.toBe(false);
     });
 
     // Because the timing of the polling depends on both the provided `interval` and the
@@ -46,7 +46,7 @@ describe("pollUntil", () => {
           return val;
         });
 
-      await pollUntil(pollableFn, (_) => false, 20, 78);
+      await pollUntil(pollableFn, (_) => false, { interval: 20, maxTimeout: 78 });
 
       // In theory, this is what just happened:
       // | time elapsed | value (source)  |

--- a/airbyte-webapp/src/core/request/pollUntil.ts
+++ b/airbyte-webapp/src/core/request/pollUntil.ts
@@ -5,16 +5,16 @@ import { timer, delay, from, concatMap, takeWhile, last, raceWith, lastValueFrom
 export function pollUntil<ResponseType>(
   apiFn: () => Promise<ResponseType>,
   condition: (res: ResponseType) => boolean,
-  options: { interval: number; maxTimeout?: number }
+  options: { intervalMs: number; maxTimeoutMs?: number }
 ) {
-  const { interval, maxTimeout } = options;
-  const poll$ = timer(0, interval).pipe(
-    concatMap((_) => from(apiFn())),
+  const { intervalMs, maxTimeoutMs } = options;
+  const poll$ = timer(0, intervalMs).pipe(
+    concatMap(() => from(apiFn())),
     takeWhile((result) => !condition(result), true),
     last()
   );
 
-  const timeout$ = maxTimeout ? from([false]).pipe(delay(maxTimeout)) : NEVER;
+  const timeout$ = maxTimeoutMs ? from([false]).pipe(delay(maxTimeoutMs)) : NEVER;
 
   return lastValueFrom(poll$.pipe(raceWith(timeout$)));
 }

--- a/airbyte-webapp/src/core/request/pollUntil.ts
+++ b/airbyte-webapp/src/core/request/pollUntil.ts
@@ -1,0 +1,20 @@
+import { timer, delay, from, concatMap, takeWhile, last, raceWith, lastValueFrom, NEVER } from "rxjs";
+
+// Known issues:
+// - the case where `apiFn` returns `false` and `condition(false) === true` is impossible to distinguish from a timeout
+export function pollUntil<ResponseType>(
+  apiFn: () => Promise<ResponseType>,
+  condition: (res: ResponseType) => boolean,
+  interval: number,
+  maxTimeout?: number
+) {
+  const poll$ = timer(0, interval).pipe(
+    concatMap((_) => from(apiFn())),
+    takeWhile((result) => !condition(result), true),
+    last()
+  );
+
+  const timeout$ = maxTimeout ? from([false]).pipe(delay(maxTimeout)) : NEVER;
+
+  return lastValueFrom(poll$.pipe(raceWith(timeout$)));
+}

--- a/airbyte-webapp/src/core/request/pollUntil.ts
+++ b/airbyte-webapp/src/core/request/pollUntil.ts
@@ -5,9 +5,9 @@ import { timer, delay, from, concatMap, takeWhile, last, raceWith, lastValueFrom
 export function pollUntil<ResponseType>(
   apiFn: () => Promise<ResponseType>,
   condition: (res: ResponseType) => boolean,
-  interval: number,
-  maxTimeout?: number
+  options: { interval: number; maxTimeout?: number }
 ) {
+  const { interval, maxTimeout } = options;
   const poll$ = timer(0, interval).pipe(
     concatMap((_) => from(apiFn())),
     takeWhile((result) => !condition(result), true),

--- a/airbyte-webapp/src/packages/cloud/components/experiments/FreeConnectorProgram/hooks/useFreeConnectorProgram.ts
+++ b/airbyte-webapp/src/packages/cloud/components/experiments/FreeConnectorProgram/hooks/useFreeConnectorProgram.ts
@@ -40,7 +40,7 @@ export const useFreeConnectorProgram = () => {
       pollUntil(
         () => webBackendGetFreeConnectorProgramInfoForWorkspace({ workspaceId }, requestOptions),
         ({ hasPaymentAccountSaved }) => hasPaymentAccountSaved,
-        { interval: 1000, maxTimeout: 10000 }
+        { intervalMs: 1000, maxTimeoutMs: 10000 }
       ).then((maybeFcpInfo) => {
         if (maybeFcpInfo) {
           setSearchParams({}, { replace: true });

--- a/airbyte-webapp/src/packages/cloud/components/experiments/FreeConnectorProgram/hooks/useFreeConnectorProgram.ts
+++ b/airbyte-webapp/src/packages/cloud/components/experiments/FreeConnectorProgram/hooks/useFreeConnectorProgram.ts
@@ -40,8 +40,7 @@ export const useFreeConnectorProgram = () => {
       pollUntil(
         () => webBackendGetFreeConnectorProgramInfoForWorkspace({ workspaceId }, requestOptions),
         ({ hasPaymentAccountSaved }) => hasPaymentAccountSaved,
-        1000,
-        10000
+        { interval: 1000, maxTimeout: 10000 }
       ).then((maybeFcpInfo) => {
         if (maybeFcpInfo) {
           setSearchParams({}, { replace: true });

--- a/airbyte-webapp/src/packages/cloud/locales/en.json
+++ b/airbyte-webapp/src/packages/cloud/locales/en.json
@@ -182,6 +182,7 @@
   "freeConnectorProgram.enrollNow": "Enroll now!",
   "freeConnectorProgram.enroll.description": "Enroll in the <b>Free Connector Program</b> to use Alpha and Beta connectors for <b>free</b>.",
   "freeConnectorProgram.enroll.success": "Successfully enrolled in the Free Connector Program",
+  "freeConnectorProgram.enroll.failure": "Unable to verify that payment details were saved successfully. Please contact support for additional help.",
   "freeConnectorProgram.enrollmentModal.title": "Free connector program",
   "freeConnectorProgram.enrollmentModal.free": "<p1>Alpha and Beta Connectors are free while you're in the program.</p1><p2>The whole Connection is free until both Connectors have moved into General Availability (GA)</p2>",
   "freeConnectorProgram.enrollmentModal.emailNotification": "We will email you before your connection will start being charged.",


### PR DESCRIPTION
## What
Closes https://github.com/airbytehq/airbyte/issues/22302.

- when a user navigates to a page whose render invokes `useFreeConnectorProgram()` with the `fcpEnrollmentSuccess` query param, starts polling the FCP program info endpoint
- if polled return value ever says hasPaymentAccountSaved is true, stop polling, hide enrollment banners, and show success UI
- if 10s elapses with no enrollment, show an error popup instead

## How
Adds a general-purpose `pollUntil` function, then uses that to poll the endpoint.

## Recommended reading order
1. `useFreeConnectorProgram.ts`
2. `pollUntil.ts` or `pollUntil.test.ts`, depending on how you feel about rxjs, followed by the other