### PR TITLE
[Low-Code CDK] Rremove stream_cursor_field from stream and derive it from stream_slicer

### DIFF
--- a/airbyte-cdk/python/airbyte_cdk/sources/declarative/declarative_component_schema.yaml
+++ b/airbyte-cdk/python/airbyte_cdk/sources/declarative/declarative_component_schema.yaml
@@ -484,13 +484,6 @@ definitions:
         anyOf:
           - "$ref": "#/definitions/InlineSchemaLoader"
           - "$ref": "#/definitions/JsonFileSchemaLoader"
-      stream_cursor_field:
-        definition: The field of the records being read that will be used during checkpointing
-        anyOf:
-          - type: string
-          - type: array
-            items:
-              - type: string
       transformations:
         definition: A list of transformations to be applied to each output record in the
         type: array

--- a/airbyte-cdk/python/airbyte_cdk/sources/declarative/models/declarative_component_schema.py
+++ b/airbyte-cdk/python/airbyte_cdk/sources/declarative/models/declarative_component_schema.py
@@ -469,7 +469,6 @@ class DeclarativeStream(BaseModel):
     name: Optional[str] = ""
     primary_key: Optional[Union[str, List[str], List[List[str]]]] = ""
     schema_loader: Optional[Union[InlineSchemaLoader, JsonFileSchemaLoader]] = None
-    stream_cursor_field: Optional[Union[str, List[str]]] = None
     transformations: Optional[List[Union[AddFields, CustomTransformation, RemoveFields]]] = None
     parameters: Optional[Dict[str, Any]] = Field(None, alias="$parameters")
 

--- a/airbyte-cdk/python/airbyte_cdk/sources/declarative/parsers/model_to_component_factory.py
+++ b/airbyte-cdk/python/airbyte_cdk/sources/declarative/parsers/model_to_component_factory.py
@@ -406,6 +406,8 @@ class ModelToComponentFactory:
     def create_declarative_stream(self, model: DeclarativeStreamModel, config: Config, **kwargs) -> DeclarativeStream:
         retriever = self._create_component_from_model(model=model.retriever, config=config)
 
+        cursor_field = self._get_cursor_field_from_stream_slicer(model)
+
         if model.schema_loader:
             schema_loader = self._create_component_from_model(model=model.schema_loader, config=config)
         else:
@@ -423,11 +425,20 @@ class ModelToComponentFactory:
             primary_key=model.primary_key,
             retriever=retriever,
             schema_loader=schema_loader,
-            stream_cursor_field=model.stream_cursor_field or [],
+            stream_cursor_field=cursor_field or [],
             transformations=transformations,
             config=config,
             parameters={},
         )
+
+    @staticmethod
+    def _get_cursor_field_from_stream_slicer(model: DeclarativeStreamModel) -> Optional[Union[str, List[str]]]:
+        if not model.retriever or not model.retriever.stream_slicer:
+            return None
+        elif hasattr(model.retriever.stream_slicer, "cursor_field"):
+            return model.retriever.stream_slicer.cursor_field
+        else:
+            return None
 
     def create_default_error_handler(self, model: DefaultErrorHandlerModel, config: Config, **kwargs) -> DefaultErrorHandler:
         backoff_strategies = []

--- a/airbyte-cdk/python/airbyte_cdk/sources/declarative/parsers/model_to_component_factory.py
+++ b/airbyte-cdk/python/airbyte_cdk/sources/declarative/parsers/model_to_component_factory.py
@@ -437,6 +437,22 @@ class ModelToComponentFactory:
             return None
         elif hasattr(model.retriever.stream_slicer, "cursor_field"):
             return model.retriever.stream_slicer.cursor_field
+        elif isinstance(model.retriever.stream_slicer, CartesianProductStreamSlicerModel):
+            # TODO: Remove once we redesign stream slicers
+            # This condition is a temporary hack to derive the cursor_field for streams that use a CartesianProductStreamSlicer that
+            # contains at least one cursor_field implying that it is an incremental stream. We have an upcoming PR that aims to decouple
+            # incremental and iteration concepts and once we support that, we can remove this logic and reference the cursor field stored
+            # in model.incremental_sync.cursor_field.
+            for slicer in model.retriever.stream_slicer.stream_slicers:
+                if hasattr(slicer, "cursor_field"):
+                    return slicer.cursor_field
+        elif isinstance(model.retriever.stream_slicer, dict) and "stream_slicers" in model.retriever.stream_slicer:
+            # TODO: Remove once we redesign stream slicers
+            # Similar to the above. This covers the case for CustomStreamSlicer whose model will be in the form of dictionaries instead
+            # of Pydantic fields. Hence why we need to handle this temporary hack a little differently
+            for slicer in model.retriever.stream_slicer["stream_slicers"]:
+                if "cursor_field" in slicer:
+                    return slicer.get("cursor_field")
         else:
             return None
 

--- a/airbyte-cdk/python/unit_tests/sources/declarative/parsers/test_model_to_component_factory.py
+++ b/airbyte-cdk/python/unit_tests/sources/declarative/parsers/test_model_to_component_factory.py
@@ -119,7 +119,14 @@ requester:
 retriever:
   name: "{{ parameters['name'] }}"
   stream_slicer:
-    type: SingleSlice
+    type: DatetimeStreamSlicer
+    start_datetime: "{{ config['start_time'] }}"
+    end_datetime: "{{ config['end_time'] }}"
+    step: "P10D"
+    cursor_field: "created"
+    cursor_granularity: "PT0.000001S"
+    $parameters:
+      datetime_format: "%Y-%m-%dT%H:%M:%S.%f%z"
   paginator:
     type: NoPagination
   primary_key: "{{ parameters['primary_key'] }}"
@@ -128,7 +135,6 @@ partial_stream:
   schema_loader:
     type: JsonFileSchemaLoader
     file_path: "./source_sendgrid/schemas/{{ parameters.name }}.json"
-  cursor_field: [ ]
 list_stream:
   $ref: "#/partial_stream"
   $parameters:
@@ -178,12 +184,12 @@ spec:
 
     stream_manifest = manifest["list_stream"]
     assert stream_manifest["type"] == "DeclarativeStream"
-    assert stream_manifest["cursor_field"] == []
     stream = factory.create_component(model_type=DeclarativeStreamModel, component_definition=stream_manifest, config=input_config)
 
     assert isinstance(stream, DeclarativeStream)
     assert stream.primary_key == "id"
     assert stream.name == "lists"
+    assert stream.stream_cursor_field == "created"
 
     assert isinstance(stream.schema_loader, JsonFileSchemaLoader)
     assert stream.schema_loader._get_json_filepath() == "./source_sendgrid/schemas/lists.json"

--- a/airbyte-integrations/connectors/source-braze/source_braze/manifest.yaml
+++ b/airbyte-integrations/connectors/source-braze/source_braze/manifest.yaml
@@ -113,21 +113,18 @@ definitions:
   kpi_daily_new_users_stream:
     retriever:
       $ref: "#/definitions/sliced_retriever"
-    stream_cursor_field: "time"
     $parameters:
       name: "kpi_daily_new_users"
       path: "/kpi/new_users/data_series"
   kpi_daily_active_users_stream:
     retriever:
       $ref: "#/definitions/sliced_retriever"
-    stream_cursor_field: "time"
     $parameters:
       name: "kpi_daily_active_users"
       path: "/kpi/dau/data_series"
   kpi_daily_app_uninstalls_stream:
     retriever:
       $ref: "#/definitions/sliced_retriever"
-    stream_cursor_field: "time"
     $parameters:
       name: "kpi_daily_app_uninstalls"
       path: "/kpi/uninstalls/data_series"
@@ -153,7 +150,6 @@ definitions:
         fields:
           - path: ["campaign_id"]
             value: "{{ stream_slice.campaign_id }}"
-    stream_cursor_field: "time"
   canvases_analytics_substream_config:
     retriever:
       $ref: "#/definitions/sliced_retriever"
@@ -177,7 +173,6 @@ definitions:
         fields:
           - path: ["canvas_id"]
             value: "{{ stream_slice.canvas_id }}"
-    stream_cursor_field: "time"
   cards_analytics_substream_config:
     retriever:
       $ref: "#/definitions/sliced_retriever"
@@ -198,7 +193,6 @@ definitions:
         fields:
           - path: ["card_id"]
             value: "{{ stream_slice.card_id }}"
-    stream_cursor_field: "time"
   segments_analytics_substream_config:
     retriever:
       $ref: "#/definitions/sliced_retriever"
@@ -219,7 +213,6 @@ definitions:
         fields:
           - path: ["segment_id"]
             value: "{{ stream_slice.segment_id }}"
-    stream_cursor_field: "time"
   events_analytics_substream_config:
     retriever:
       $ref: "#/definitions/sliced_retriever"
@@ -244,7 +237,6 @@ definitions:
         fields:
           - path: ["event_id"]
             value: "{{ stream_slice.event }}"
-    stream_cursor_field: "time"
 
   campaigns_analytics_stream:
     $ref: "#/definitions/campaigns_analytics_substream_config"

--- a/airbyte-integrations/connectors/source-callrail/source_callrail/manifest.yaml
+++ b/airbyte-integrations/connectors/source-callrail/source_callrail/manifest.yaml
@@ -26,7 +26,6 @@ definitions:
       datetime: "{{ today_utc() }}"
       datetime_format: "%Y-%m-%d"
     step: "#/definitions/step"
-    cursor_field: "{{ parameters.stream_cursor_field }}"
     start_time_option:
       field_name: "start_date"
       inject_into: "request_parameter"
@@ -61,7 +60,7 @@ definitions:
   calls_stream:
     $parameters:
       name: "calls"
-      stream_cursor_field: "start_time"
+      cursor_field: "start_time"
     primary_key: "id"
     schema_loader:
       $ref: "#/definitions/schema_loader"
@@ -76,7 +75,7 @@ definitions:
   conversations_stream:
     $parameters:
       name: "conversations"
-      stream_cursor_field: "last_message_at"
+      cursor_field: "last_message_at"
     primary_key: "id"
     schema_loader:
       $ref: "#/definitions/schema_loader"
@@ -91,7 +90,7 @@ definitions:
   users_stream:
     $parameters:
       name: "users"
-      stream_cursor_field: "created_at"
+      cursor_field: "created_at"
     primary_key: "id"
     schema_loader:
       $ref: "#/definitions/schema_loader"
@@ -104,7 +103,7 @@ definitions:
   companies_stream:
     $parameters:
       name: "companies"
-      stream_cursor_field: "created_at"
+      cursor_field: "created_at"
     primary_key: "id"
     schema_loader:
       $ref: "#/definitions/schema_loader"

--- a/airbyte-integrations/connectors/source-close-com/source_close_com/manifest.yaml
+++ b/airbyte-integrations/connectors/source-close-com/source_close_com/manifest.yaml
@@ -132,7 +132,6 @@ definitions:
         $ref: "#/definitions/stream_slicer__cursor_date_updated"
       requester:
         $ref: "#/definitions/requester"
-    stream_cursor_field: "date_updated"
   incremental_cursor_based_stream:
     $ref: "#/definitions/incremental_stream"
     retriever:
@@ -146,7 +145,6 @@ definitions:
       $ref: "#/definitions/incremental_stream/retriever"
       stream_slicer:
         $ref: "#/definitions/stream_slicer__cursor_date_created"
-    stream_cursor_field: "date_created"
     $parameters:
       items_per_page: 100
 
@@ -164,7 +162,6 @@ definitions:
     $parameters:
       path: "task"
       items_per_page: 1000
-    stream_cursor_field: "date_created"
 
   connected_accounts_base_stream:
     $ref: "#/definitions/full_refresh_stream"

--- a/airbyte-integrations/connectors/source-coin-api/source_coin_api/manifest.yaml
+++ b/airbyte-integrations/connectors/source-coin-api/source_coin_api/manifest.yaml
@@ -50,14 +50,12 @@ definitions:
       name: "ohlcv_historical_data"
       primary_key: "time_period_start"
       path: "/ohlcv/{{ config['symbol_id'] }}/history"
-      stream_cursor_field: "time_period_start"
   trades_historical_data_stream:
     $ref: "#/definitions/base_stream"
     $parameters:
       name: "trades_historical_data"
       primary_key: "uuid"
       path: "/trades/{{ config['symbol_id'] }}/history"
-      stream_cursor_field: "time_exchange"
   quotes_historical_data_stream:
     $ref: "#/definitions/base_stream"
     $parameters:

--- a/airbyte-integrations/connectors/source-datascope/source_datascope/manifest.yaml
+++ b/airbyte-integrations/connectors/source-datascope/source_datascope/manifest.yaml
@@ -24,7 +24,7 @@ definitions:
     # There is a discrepancy between the format of the cursor `created_at` and the granularity of the API hence "P1D"
     # here instead of "PT1M" if we were to check the datetime_format
     cursor_granularity: "P1D"
-    cursor_field: "{{ parameters['stream_cursor_field'] }}"
+    cursor_field: "created_at"
     start_time_option:
       field_name: "start"
       inject_into: "request_parameter"
@@ -83,7 +83,6 @@ definitions:
       name: "answers"
       primary_key: "form_answer_id"
       path: "/v2/answers"
-      stream_cursor_field: "created_at"
   lists_stream:
     retriever:
       $ref: "#/definitions/retriever_non_incremental"
@@ -97,7 +96,6 @@ definitions:
       name: "notifications"
       primary_key: "id"
       path: "/notifications"
-      stream_cursor_field: "created_at"
 streams:
   - "#/definitions/location_stream"
   - "#/definitions/answers_stream"

--- a/airbyte-integrations/connectors/source-delighted/source_delighted/manifest.yaml
+++ b/airbyte-integrations/connectors/source-delighted/source_delighted/manifest.yaml
@@ -20,7 +20,6 @@ definitions:
         - type: WaitTimeFromHeader
           header: "Retry-After"
   stream_slicer:
-    cursor_field: "{{ parameters['stream_cursor_field'] }}"
     datetime_format: "%s"
     cursor_granularity: "PT1S"
     start_datetime:
@@ -64,7 +63,6 @@ definitions:
       $ref: "#/definitions/retriever"
   people:
     $ref: "#/definitions/base_stream"
-    stream_cursor_field: "created_at"
     retriever:
       $ref: "#/definitions/retriever"
       paginator:
@@ -82,26 +80,23 @@ definitions:
     $parameters:
       name: "people"
       path: "people.json"
-      stream_cursor_field: "created_at"
+      cursor_field: "created_at"
   bounces:
     $ref: "#/definitions/base_stream"
     primary_key: "person_id"
-    stream_cursor_field: "bounced_at"
     $parameters:
-      stream_cursor_field: "bounced_at"
+      cursor_field: "bounced_at"
       name: "bounces"
       path: "bounces.json"
   unsubscribes:
     $ref: "#/definitions/base_stream"
     primary_key: "person_id"
-    stream_cursor_field: "unsubscribed_at"
     $parameters:
-      stream_cursor_field: "unsubscribed_at"
+      cursor_field: "unsubscribed_at"
       name: "unsubscribes"
       path: "unsubscribes.json"
   survey_responses:
     $ref: "#/definitions/base_stream"
-    stream_cursor_field: "updated_at"
     retriever:
       $ref: "#/definitions/retriever"
       stream_slicer:
@@ -113,7 +108,7 @@ definitions:
           field_name: "updated_since"
           inject_into: "request_parameter"
     $parameters:
-      stream_cursor_field: "updated_at"
+      cursor_field: "updated_at"
       name: "survey_responses"
       path: "survey_responses.json"
 

--- a/airbyte-integrations/connectors/source-gnews/source_gnews/manifest.yaml
+++ b/airbyte-integrations/connectors/source-gnews/source_gnews/manifest.yaml
@@ -37,7 +37,7 @@ definitions:
       step: "P1W"
       datetime_format: "%Y-%m-%dT%H:%M:%SZ"
       cursor_granularity: "PT1S"
-      cursor_field: "{{ parameters['stream_cursor_field'] }}"
+      cursor_field: "publishedAt"
   common_parameters:
     token: "{{ config['api_key'] }}"
     lang: "{{ config['language'] }}"
@@ -55,7 +55,7 @@ definitions:
       name: "search"
       primary_key: "url"
       path: "/search"
-      stream_cursor_field: "publishedAt"
+      cursor_field: "publishedAt"
     retriever:
       $ref: "#/definitions/base_retriever"
       requester:
@@ -73,7 +73,6 @@ definitions:
       name: "top_headlines"
       primary_key: "url"
       path: "/top-headlines"
-      stream_cursor_field: "publishedAt"
     retriever:
       $ref: "#/definitions/base_retriever"
       requester:

--- a/airbyte-integrations/connectors/source-gocardless/source_gocardless/manifest.yaml
+++ b/airbyte-integrations/connectors/source-gocardless/source_gocardless/manifest.yaml
@@ -49,7 +49,6 @@ streams:
   - type: DeclarativeStream
     $parameters:
       name: "payments"
-      stream_cursor_field: "created_at"
     primary_key: "id"
     schema_loader:
       $ref: "#/definitions/schema_loader"
@@ -61,7 +60,6 @@ streams:
   - type: DeclarativeStream
     $parameters:
       name: "refunds"
-      stream_cursor_field: "created_at"
     primary_key: "id"
     schema_loader:
       $ref: "#/definitions/schema_loader"
@@ -73,7 +71,6 @@ streams:
   - type: DeclarativeStream
     $parameters:
       name: "mandates"
-      stream_cursor_field: "created_at"
     primary_key: "id"
     schema_loader:
       $ref: "#/definitions/schema_loader"
@@ -85,7 +82,6 @@ streams:
   - type: DeclarativeStream
     $parameters:
       name: "payouts"
-      stream_cursor_field: "created_at"
     primary_key: "id"
     schema_loader:
       $ref: "#/definitions/schema_loader"

--- a/airbyte-integrations/connectors/source-greenhouse/source_greenhouse/manifest.yaml
+++ b/airbyte-integrations/connectors/source-greenhouse/source_greenhouse/manifest.yaml
@@ -57,7 +57,6 @@ definitions:
         $ref: "#/definitions/requester"
   base_incremental_stream:
     $ref: "#/definitions/base_stream"
-    stream_cursor_field: "updated_at"
     retriever:
       $ref: "#/definitions/retriever"
       requester: "#/definitions/requester"
@@ -70,7 +69,6 @@ definitions:
     $parameters:
       name: "applications"
       path: "applications"
-    stream_cursor_field: "applied_at"
     retriever:
       $ref: "#/definitions/retriever"
       requester: "#/definitions/requester"
@@ -125,7 +123,6 @@ definitions:
     $ref: "#/definitions/base_stream"
     $parameters:
       name: "applications_demographics_answers"
-    stream_cursor_field: "updated_at"
     retriever:
       $ref: "#/definitions/retriever"
       requester:
@@ -142,7 +139,6 @@ definitions:
     $ref: "#/definitions/base_stream"
     $parameters:
       name: "applications_interviews"
-    stream_cursor_field: "updated_at"
     retriever:
       $ref: "#/definitions/retriever"
       requester:
@@ -224,7 +220,6 @@ definitions:
     $parameters:
       name: "jobs_stages"
       path: "jobs/{{ stream_slice.parent_id }}/stages"
-      stream_cursor_field: "updated_at"
     retriever:
       $ref: "#/definitions/retriever"
       requester:

--- a/airbyte-integrations/connectors/source-mailersend/source_mailersend/manifest.yaml
+++ b/airbyte-integrations/connectors/source-mailersend/source_mailersend/manifest.yaml
@@ -21,7 +21,7 @@ definitions:
       datetime: "{{ now_utc().strftime('%s') }}"
       datetime_format: "%s"
     step: "P1D"
-    cursor_field: "{{ parameters['stream_cursor_field'] }}"
+    cursor_field: "created_at"
     start_time_option:
       field_name: "date_from"
       inject_into: "request_parameter"
@@ -56,7 +56,6 @@ definitions:
       name: "activity"
       primary_key: "id"
       path: "/activity/{{ config['domain_id'] }}"
-      stream_cursor_field: "created_at"
 
 streams:
   - "#/definitions/activity_stream"

--- a/airbyte-integrations/connectors/source-nytimes/source_nytimes/manifest.yaml
+++ b/airbyte-integrations/connectors/source-nytimes/source_nytimes/manifest.yaml
@@ -28,12 +28,11 @@ definitions:
         step: "P1M"
         datetime_format: "%Y-%m-%dT%H:%M:%S%z"
         cursor_granularity: "PT1S"
-        cursor_field: "{{ parameters['stream_cursor_field'] }}"
+        cursor_field: "pub_date"
     $parameters:
       name: "archive"
       primary_key: "_id"
       path: "/archive/v1/{{ stream_slice['start_time'].split('-')[0] | int }}/{{ stream_slice['start_time'].split('-')[1] | int }}.json"
-      stream_cursor_field: "pub_date"
   most_popular_emailed_stream:
     retriever:
       $ref: "#/definitions/retriever"

--- a/airbyte-integrations/connectors/source-partnerstack/source_partnerstack/manifest.yaml
+++ b/airbyte-integrations/connectors/source-partnerstack/source_partnerstack/manifest.yaml
@@ -50,7 +50,6 @@ definitions:
       name: "customers"
       primary_key: "key"
       path: "/customers"
-      stream_cursor_field: "updated_at"
   deals_stream:
     $ref: "#/definitions/base_stream"
     $parameters:

--- a/airbyte-integrations/connectors/source-posthog/source_posthog/manifest.yaml
+++ b/airbyte-integrations/connectors/source-posthog/source_posthog/manifest.yaml
@@ -101,7 +101,6 @@ definitions:
       name: "events"
       path: "events"
     primary_key: "id"
-    stream_cursor_field: "timestamp"
     schema_loader:
       $ref: "#/definitions/schema_loader"
     retriever:

--- a/airbyte-integrations/connectors/source-prestashop/source_prestashop/manifest.yaml
+++ b/airbyte-integrations/connectors/source-prestashop/source_prestashop/manifest.yaml
@@ -30,7 +30,6 @@ definitions:
       $ref: "#/definitions/retriever"
   base_incremental_stream:
     $ref: "#/definitions/base_stream"
-    stream_cursor_field: "date_upd"
     checkpoint_interval: 500
     retriever:
       $ref: "#/definitions/retriever"
@@ -213,7 +212,6 @@ definitions:
       cursor_field: "date_upd"
   messages_stream:
     $ref: "#/definitions/base_incremental_stream"
-    stream_cursor_field: "date_add"
     $parameters:
       name: "messages"
       path: "/messages"
@@ -222,7 +220,6 @@ definitions:
       cursor_field: "date_add"
   order_carriers_stream:
     $ref: "#/definitions/base_incremental_stream"
-    stream_cursor_field: "date_add"
     $parameters:
       name: "order_carriers"
       path: "/order_carriers"
@@ -238,7 +235,6 @@ definitions:
       primary_key: "id"
   order_histories_stream:
     $ref: "#/definitions/base_incremental_stream"
-    stream_cursor_field: "date_add"
     $parameters:
       name: "order_histories"
       path: "/order_histories"
@@ -247,7 +243,6 @@ definitions:
       cursor_field: "date_add"
   order_invoices_stream:
     $ref: "#/definitions/base_incremental_stream"
-    stream_cursor_field: "date_add"
     $parameters:
       name: "order_invoices"
       path: "/order_invoices"
@@ -256,7 +251,6 @@ definitions:
       cursor_field: "date_add"
   order_payments_stream:
     $ref: "#/definitions/base_incremental_stream"
-    stream_cursor_field: "date_add"
     $parameters:
       name: "order_payments"
       path: "/order_payments"
@@ -402,7 +396,6 @@ definitions:
       cursor_field: "date_upd"
   stock_movements_stream:
     $ref: "#/definitions/base_incremental_stream"
-    stream_cursor_field: "date_add"
     $parameters:
       name: "stock_movements"
       path: "/stock_movements"

--- a/airbyte-integrations/connectors/source-sendgrid/source_sendgrid/manifest.yaml
+++ b/airbyte-integrations/connectors/source-sendgrid/source_sendgrid/manifest.yaml
@@ -52,7 +52,6 @@ definitions:
       datetime: "{{ now_utc() }}"
       datetime_format: "%Y-%m-%d %H:%M:%S.%f%z"
     step: "#/definitions/step"
-    cursor_field: "{{ parameters.stream_cursor_field }}"
     start_time_option:
       field_name: "start_time"
       inject_into: "request_parameter"
@@ -70,7 +69,6 @@ definitions:
       datetime: "{{ now_utc() }}"
       datetime_format: "%Y-%m-%d %H:%M:%S.%f%z"
     step: "#/definitions/step"
-    cursor_field: "{{ parameters.stream_cursor_field }}"
     datetime_format: "%Y-%m-%dT%H:%M:%S.%f%z"
     cursor_granularity: "PT0.000001S"
 
@@ -158,7 +156,7 @@ streams:
     $parameters:
       name: "bounces"
       primary_key: "email"
-      stream_cursor_field: "created"
+      cursor_field: "created"
       path: "/v3/suppression/bounces"
       field_path: []
     retriever:
@@ -171,7 +169,7 @@ streams:
     $parameters:
       name: "global_suppressions"
       primary_key: "email"
-      stream_cursor_field: "created"
+      cursor_field: "created"
       path: "/v3/suppression/unsubscribes"
       field_path: []
     retriever:
@@ -184,7 +182,7 @@ streams:
     $parameters:
       name: "blocks"
       primary_key: "email"
-      stream_cursor_field: "created"
+      cursor_field: "created"
       path: "/v3/suppression/blocks"
       field_path: []
     retriever:
@@ -213,7 +211,7 @@ streams:
     $parameters:
       name: "invalid_emails"
       primary_key: "email"
-      stream_cursor_field: "created"
+      cursor_field: "created"
       path: "/v3/suppression/invalid_emails"
       field_path: []
     retriever:
@@ -226,7 +224,7 @@ streams:
     $parameters:
       name: "spam_reports"
       primary_key: "email"
-      stream_cursor_field: "created"
+      cursor_field: "created"
       path: "/v3/suppression/spam_reports"
       field_path: []
     retriever:
@@ -239,7 +237,7 @@ streams:
     $parameters:
       name: "messages"
       primary_key: "msg_id"
-      stream_cursor_field: "last_event_time"
+      cursor_field: "last_event_time"
       path: "/v3/messages"
       field_path: []
     retriever:

--- a/airbyte-integrations/connectors/source-senseforce/source_senseforce/manifest.yaml
+++ b/airbyte-integrations/connectors/source-senseforce/source_senseforce/manifest.yaml
@@ -33,7 +33,7 @@ definitions:
     step: "P100D" #TODO: Add {{ config['slice_range'] ~ d }} here, once it's possible to use config-values for step definition
     datetime_format: "%s"
     cursor_granularity: "PT1S"
-    cursor_field: "{{ parameters['stream_cursor_field'] }}"
+    cursor_field: "airbyte_cursor"
 
   retriever:
     record_selector:
@@ -64,7 +64,6 @@ definitions:
       primary_key:
         - "id"
       path: "/api/dataset/execute/{{ config['dataset_id']}}"
-      stream_cursor_field: "airbyte_cursor"
     transformations:
       - type: AddFields
         fields:

--- a/airbyte-integrations/connectors/source-square/source_square/manifest.yaml
+++ b/airbyte-integrations/connectors/source-square/source_square/manifest.yaml
@@ -55,8 +55,6 @@ definitions:
           field_name: "cursor"
 
   base_incremental_stream:
-    $parameters:
-      stream_cursor_field: "created_at"
     retriever:
       $ref: "#/definitions/retriever"
       requester:
@@ -94,7 +92,6 @@ definitions:
           inject_into: body_json
   base_catalog_objects_stream:
     $ref: "#/definitions/base_incremental_stream"
-    stream_cursor_field: "updated_at"
     $parameters:
       primary_key: "id"
       path: "/catalog/search"

--- a/airbyte-integrations/connectors/source-tempo/source_tempo/manifest.yaml
+++ b/airbyte-integrations/connectors/source-tempo/source_tempo/manifest.yaml
@@ -58,7 +58,6 @@ definitions:
       path: "customers"
   worklogs_stream:
     $ref: "#/definitions/base_stream"
-    stream_cursor_field: "startDate"
     retriever:
       $ref: "#/definitions/retriever"
       requester: "#/definitions/requester"

--- a/airbyte-integrations/connectors/source-the-guardian-api/source_the_guardian_api/manifest.yaml
+++ b/airbyte-integrations/connectors/source-the-guardian-api/source_the_guardian_api/manifest.yaml
@@ -28,7 +28,7 @@ definitions:
     step: "P7D"
     datetime_format: "%Y-%m-%dT%H:%M:%SZ"
     cursor_granularity: "PT1S"
-    cursor_field: "{{ parameters['stream_cursor_field'] }}"
+    cursor_field: "webPublicationDate"
     start_time_option:
       field_name: "from-date"
       inject_into: "request_parameter"
@@ -64,7 +64,6 @@ definitions:
       name: "content"
       primary_key: "id"
       path: "/search"
-      stream_cursor_field: "webPublicationDate"
 
 streams:
   - "#/definitions/content_stream"

--- a/airbyte-integrations/connectors/source-waiteraid/source_waiteraid/manifest.yaml
+++ b/airbyte-integrations/connectors/source-waiteraid/source_waiteraid/manifest.yaml
@@ -21,7 +21,7 @@ definitions:
       datetime_format: "%Y-%m-%d %H:%M:%S.%f"
     step: "1d"
     datetime_format: "%Y-%m-%d"
-    cursor_field: "{{ parameters['stream_cursor_field'] }}"
+    cursor_field: "date"
   retriever:
     record_selector:
       $ref: "#/definitions/selector"
@@ -37,7 +37,6 @@ definitions:
     $parameters:
       name: "booking"
       path: "/wa-api/searchBooking"
-      stream_cursor_field: "date"
 
 streams:
   - "#/definitions/booking_stream"

--- a/airbyte-integrations/connectors/source-woocommerce/source_woocommerce/manifest.yaml
+++ b/airbyte-integrations/connectors/source-woocommerce/source_woocommerce/manifest.yaml
@@ -36,7 +36,7 @@ definitions:
     end_time_option:
       field_name: modified_before
       inject_into: request_parameter
-    cursor_field: "{{ parameters['stream_cursor_field'] }}"
+    cursor_field: "date_modified_gmt"
   retriever:
     record_selector:
       $ref: "#/definitions/selector"
@@ -71,14 +71,12 @@ definitions:
     $ref: "#/definitions/base_incremental_stream"
     $parameters:
       name: "coupons"
-      stream_cursor_field: "date_modified_gmt"
       primary_key: "id"
       path: "/coupons"
   orders_stream:
     $ref: "#/definitions/base_incremental_stream"
     $parameters:
       name: "orders"
-      stream_cursor_field: "date_modified_gmt"
       primary_key: "id"
       path: "/orders"
   order_notes_stream:
@@ -99,7 +97,6 @@ definitions:
     $ref: "#/definitions/base_incremental_stream"
     $parameters:
       name: "products"
-      stream_cursor_field: "date_modified_gmt"
       primary_key: "id"
       path: "/products"
   product_variations_stream:
@@ -162,7 +159,6 @@ definitions:
           inject_into: request_parameter
     $parameters:
       name: "product_reviews"
-      stream_cursor_field: "date_created_gmt"
       primary_key: "id"
       path: "/products/reviews"
   product_shipping_classes_stream:

--- a/airbyte-integrations/connectors/source-zenloop/source_zenloop/components.py
+++ b/airbyte-integrations/connectors/source-zenloop/source_zenloop/components.py
@@ -25,7 +25,7 @@ class ZenloopSubstreamSlicer(SubstreamSlicer):
         create stream_slices according SubstreamSlicer logic.
 
         """
-        parent_field = self._options.get("config_parent_field")
+        parent_field = self._parameters.get("config_parent_field")
         custom_stream_state_value = self.config.get(parent_field)
 
         if not custom_stream_state_value:

--- a/airbyte-integrations/connectors/source-zenloop/source_zenloop/manifest.yaml
+++ b/airbyte-integrations/connectors/source-zenloop/source_zenloop/manifest.yaml
@@ -39,7 +39,6 @@ definitions:
         $ref: "#/definitions/requester"
   incremental_base_stream:
     $ref: "#/definitions/base_stream"
-    stream_cursor_field: "inserted_at"
     retriever:
       $ref: "#/definitions/retriever"
       requester:


### PR DESCRIPTION
Closes https://github.com/airbytehq/airbyte/issues/21561

## What
For connectors that implement incremental syncs, we currently require that the cursor be specified in two location. `stream_cursor_field` on DeclarativeStream and `cursor_field` on various Stream Slicers. This is verbose and often confusing as it is not made clear that a cursors are only used for incremental syncs which are implemented by way of a stream slicer.

## How
This PR deprecates the `stream_cursor_field` field on a DeclarativeStream. Under the hood while constructing declarative components, a Stream will derive the cursor value by looking at -> Stream -> Retriever -> Slicer -> Cursor Field. The schema is modified and relevant constructors.

Where this starts to get a little bit tricky is in how some of the existing connectors were using the `stream_cursor_value` in some unique ways. This wasn't quite a one size fits all solution so I did not use a migration script. I will annotate some comments to explain my thinking on how I modified some of the connectors now that the field has been deprecated on the stream.

## Recommended reading order
1. `declarative_component_schema.yaml`
2. `model_to_component_factory.py`
