### PR TITLE
Allow state storage to be cross-cloud configurable in helm

### DIFF
--- a/charts/airbyte-server/templates/deployment.yaml
+++ b/charts/airbyte-server/templates/deployment.yaml
@@ -175,6 +175,11 @@ spec:
             configMapKeyRef:
               name: {{ .Release.Name }}-airbyte-env
               key: S3_MINIO_ENDPOINT
+        - name: WORKER_STATE_STORAGE_TYPE
+          valueFrom:
+            configMapKeyRef:
+              name: {{ .Release.Name }}-airbyte-env
+              key: WORKER_STATE_STORAGE_TYPE
         - name: STATE_STORAGE_MINIO_BUCKET_NAME
           valueFrom:
             configMapKeyRef:
@@ -190,11 +195,47 @@ spec:
             secretKeyRef:
               name: {{ .Release.Name }}-airbyte-secrets
               key: STATE_STORAGE_MINIO_SECRET_ACCESS_KEY
+        {{- if eq .Values.global.state.storage.type "MINIO" }}
         - name: STATE_STORAGE_MINIO_ENDPOINT
           valueFrom:
             configMapKeyRef:
               name: {{ .Release.Name }}-airbyte-env
               key: STATE_STORAGE_MINIO_ENDPOINT
+        {{- end }}
+        - name: STATE_STORAGE_S3_BUCKET_NAME
+          valueFrom:
+            configMapKeyRef:
+              name: {{ .Release.Name }}-airbyte-env
+              key: S3_LOG_BUCKET
+        - name: STATE_STORAGE_S3_ACCESS_KEY
+          valueFrom:
+            secretKeyRef:
+              name: {{ .Release.Name }}-airbyte-secrets
+              key: AWS_ACCESS_KEY_ID
+        - name: STATE_STORAGE_S3_SECRET_ACCESS_KEY
+          valueFrom:
+            secretKeyRef:
+              name: {{ .Release.Name }}-airbyte-secrets
+              key: AWS_SECRET_ACCESS_KEY
+        {{- if eq .Values.global.state.storage.type "S3" }}
+        - name: STATE_STORAGE_S3_REGION
+          valueFrom:
+            configMapKeyRef:
+              name: {{ .Release.Name }}-airbyte-env
+              key: S3_LOG_BUCKET_REGION
+        {{- end }}
+        - name: STATE_STORAGE_GCS_APPLICATION_CREDENTIALS
+          valueFrom:
+            configMapKeyRef:
+              name: {{ .Release.Name }}-airbyte-env
+              key: GOOGLE_APPLICATION_CREDENTIALS
+        {{- if eq .Values.global.state.storage.type "GCS" }}
+        - name: STATE_STORAGE_GCS_BUCKET_NAME
+          valueFrom:
+            configMapKeyRef:
+              name: {{ .Release.Name }}-airbyte-env
+              key: GCS_LOG_BUCKET
+        {{- end }}
         - name: S3_PATH_STYLE_ACCESS
           valueFrom:
             configMapKeyRef:

--- a/charts/airbyte-webapp/templates/deployment.yaml
+++ b/charts/airbyte-webapp/templates/deployment.yaml
@@ -51,6 +51,10 @@ spec:
       initContainers:
       {{- toYaml .Values.extraInitContainers | nindent 6 }}
       {{- end }}
+      {{- if .Values.securityContext }}
+      securityContext: 
+      {{- toYaml .Values.securityContext | nindent 8 }}
+      {{- end }}
       containers:
       - name: airbyte-webapp-container
         image: {{ printf "%s:%s" .Values.image.repository (include "webapp.imageTag" .) }}

--- a/charts/airbyte-worker/templates/deployment.yaml
+++ b/charts/airbyte-worker/templates/deployment.yaml
@@ -250,11 +250,47 @@ spec:
             secretKeyRef:
               name: {{ .Release.Name }}-airbyte-secrets
               key: STATE_STORAGE_MINIO_SECRET_ACCESS_KEY
+        {{- if eq .Values.global.state.storage.type "MINIO" }}
         - name: STATE_STORAGE_MINIO_ENDPOINT
           valueFrom:
             configMapKeyRef:
               name: {{ .Release.Name }}-airbyte-env
               key: STATE_STORAGE_MINIO_ENDPOINT
+        {{- end }}
+        - name: STATE_STORAGE_S3_BUCKET_NAME
+          valueFrom:
+            configMapKeyRef:
+              name: {{ .Release.Name }}-airbyte-env
+              key: S3_LOG_BUCKET
+        - name: STATE_STORAGE_S3_ACCESS_KEY
+          valueFrom:
+            secretKeyRef:
+              name: {{ .Release.Name }}-airbyte-secrets
+              key: AWS_ACCESS_KEY_ID
+        - name: STATE_STORAGE_S3_SECRET_ACCESS_KEY
+          valueFrom:
+            secretKeyRef:
+              name: {{ .Release.Name }}-airbyte-secrets
+              key: AWS_SECRET_ACCESS_KEY
+        {{- if eq .Values.global.state.storage.type "S3" }}
+        - name: STATE_STORAGE_S3_REGION
+          valueFrom:
+            configMapKeyRef:
+              name: {{ .Release.Name }}-airbyte-env
+              key: S3_LOG_BUCKET_REGION
+        {{- end }}
+        - name: STATE_STORAGE_GCS_APPLICATION_CREDENTIALS
+          valueFrom:
+            configMapKeyRef:
+              name: {{ .Release.Name }}-airbyte-env
+              key: GOOGLE_APPLICATION_CREDENTIALS
+        {{- if eq .Values.global.state.storage.type "GCS" }}
+        - name: STATE_STORAGE_GCS_BUCKET_NAME
+          valueFrom:
+            configMapKeyRef:
+              name: {{ .Release.Name }}-airbyte-env
+              key: GCS_LOG_BUCKET
+        {{- end }}
         - name: INTERNAL_API_HOST
           valueFrom:
             configMapKeyRef:

--- a/charts/airbyte/Chart.lock
+++ b/charts/airbyte/Chart.lock
@@ -12,10 +12,10 @@ dependencies:
   repository: https://airbytehq.github.io/helm-charts/
   version: 0.43.22
 - name: server
-  repository: https://airbytehq.github.io/helm-charts/
+  repository: file://../airbyte-server
   version: 0.43.22
 - name: worker
-  repository: https://airbytehq.github.io/helm-charts/
+  repository: file://../airbyte-worker
   version: 0.43.22
 - name: pod-sweeper
   repository: https://airbytehq.github.io/helm-charts/
@@ -29,5 +29,5 @@ dependencies:
 - name: connector-builder-server
   repository: https://airbytehq.github.io/helm-charts/
   version: 0.43.22
-digest: sha256:3f86ccd42c1eb353dd2d45237b21706c6d8a1d564dc8babb26c0fd961c56ed9d
-generated: "2023-01-25T02:03:57.511452543Z"
+digest: sha256:cd0bc2180d518dc292c8d02e62e87f2150e9b6c81d48424cb7c216f0569b8d0c
+generated: "2023-02-01T23:26:15.204239-05:00"

--- a/charts/airbyte/Chart.lock
+++ b/charts/airbyte/Chart.lock
@@ -9,7 +9,7 @@ dependencies:
   repository: https://airbytehq.github.io/helm-charts/
   version: 0.43.22
 - name: webapp
-  repository: https://airbytehq.github.io/helm-charts/
+  repository: file://../airbyte-webapp
   version: 0.43.22
 - name: server
   repository: file://../airbyte-server
@@ -29,5 +29,5 @@ dependencies:
 - name: connector-builder-server
   repository: https://airbytehq.github.io/helm-charts/
   version: 0.43.22
-digest: sha256:cd0bc2180d518dc292c8d02e62e87f2150e9b6c81d48424cb7c216f0569b8d0c
-generated: "2023-02-01T23:26:15.204239-05:00"
+digest: sha256:7d1eda404923cc92c040d9364115c18813831441ec7773414356c6be12c5b6cf
+generated: "2023-10-27T13:57:11.494879-04:00"

--- a/charts/airbyte/Chart.yaml
+++ b/charts/airbyte/Chart.yaml
@@ -39,15 +39,15 @@ dependencies:
     version: 0.43.22
   - condition: webapp.enabled
     name: webapp
-    repository: "https://airbytehq.github.io/helm-charts/"
+    repository: file://../airbyte-webapp
     version: 0.43.22
   - condition: server.enabled
     name: server
-    repository: "https://airbytehq.github.io/helm-charts/"
+    repository: file://../airbyte-server
     version: 0.43.22
   - condition: worker.enabled
     name: worker
-    repository: "https://airbytehq.github.io/helm-charts/"
+    repository: file://../airbyte-worker
     version: 0.43.22
   - condition: pod-sweeper.enabled
     name: pod-sweeper


### PR DESCRIPTION
## What
Helm installs have broken log views for non minio storage

## How
Currently this is hardcoded to work w/ minio only which breaks optimal gcp and aws setups.  I believe this is enough to get everything working end-to-end by just defaulting to the existing log config creds.

## Recommended reading order
1. `x.java`
2. `y.python`

## 🚨 User Impact 🚨
Are there any breaking changes? What is the end result perceived by the user? If yes, please merge this PR with the 🚨🚨 emoji so changelog authors can further highlight this if needed.

## Pre-merge Checklist
Expand the relevant checklist and delete the others.

<details><summary><strong>New Connector</strong></summary>

### Community member or Airbyter

- [ ] **Community member?** Grant edit access to maintainers ([instructions](https://docs.github.com/en/github/collaborating-with-pull-requests/working-with-forks/allowing-changes-to-a-pull-request-branch-created-from-a-fork#enabling-repository-maintainer-permissions-on-existing-pull-requests))
- [ ] Secrets in the connector's spec are annotated with `airbyte_secret`
- [ ] Unit & integration tests added and passing. Community members, please provide proof of success locally e.g: screenshot or copy-paste unit, integration, and acceptance test output. To run acceptance tests for a Python connector, follow instructions in the README. For java connectors run `./gradlew :airbyte-integrations:connectors:<name>:integrationTest`.
- [ ] Code reviews completed
- [ ] Documentation updated
    - [ ] Connector's `README.md`
    - [ ] Connector's `bootstrap.md`. See [description and examples](https://docs.google.com/document/d/1ypdgmwmEHWv-TrO4_YOQ7pAJGVrMp5BOkEVh831N260/edit?usp=sharing)
    - [ ] `docs/integrations/<source or destination>/<name>.md` including changelog. See changelog [example](https://docs.airbyte.io/integrations/sources/stripe#changelog)
    - [ ] `docs/integrations/README.md`
    - [ ] `airbyte-integrations/builds.md`
- [ ] PR name follows [PR naming conventions](https://docs.airbyte.com/contributing-to-airbyte/issues-and-pull-requests)

### Airbyter

If this is a community PR, the Airbyte engineer reviewing this PR is responsible for the below items.

- [ ] Create a non-forked branch based on this PR and test the below items on it
- [ ] Build is successful
- [ ] If new credentials are required for use in CI, add them to GSM. [Instructions](https://docs.airbyte.io/connector-development#using-credentials-in-ci).
- [ ] [`/test connector=connectors/<name>` command](https://docs.airbyte.io/connector-development#updating-an-existing-connector) is passing
- [ ] New Connector version released on Dockerhub by running the `/publish` command described [here](https://docs.airbyte.io/connector-development#updating-an-existing-connector)
- [ ] After the connector is published, connector added to connector index as described [here](https://docs.airbyte.io/connector-development#publishing-a-connector)
- [ ] Seed specs have been re-generated by building the platform and committing the changes to the seed spec files, as described [here](https://docs.airbyte.io/connector-development#publishing-a-connector)

</details>

<details><summary><strong>Updating a connector</strong></summary>

### Community member or Airbyter

- [ ] Grant edit access to maintainers ([instructions](https://docs.github.com/en/github/collaborating-with-pull-requests/working-with-forks/allowing-changes-to-a-pull-request-branch-created-from-a-fork#enabling-repository-maintainer-permissions-on-existing-pull-requests))
- [ ] Secrets in the connector's spec are annotated with `airbyte_secret`
- [ ] Unit & integration tests added and passing. Community members, please provide proof of success locally e.g: screenshot or copy-paste unit, integration, and acceptance test output. To run acceptance tests for a Python connector, follow instructions in the README. For java connectors run `./gradlew :airbyte-integrations:connectors:<name>:integrationTest`.
- [ ] Code reviews completed
- [ ] Documentation updated
    - [ ] Connector's `README.md`
    - [ ] Connector's `bootstrap.md`. See [description and examples](https://docs.google.com/document/d/1ypdgmwmEHWv-TrO4_YOQ7pAJGVrMp5BOkEVh831N260/edit?usp=sharing)
    - [ ] Changelog updated in `docs/integrations/<source or destination>/<name>.md` including changelog. See changelog [example](https://docs.airbyte.io/integrations/sources/stripe#changelog)
- [ ] PR name follows [PR naming conventions](https://docs.airbyte.com/contributing-to-airbyte/issues-and-pull-requests)

### Airbyter

If this is a community PR, the Airbyte engineer reviewing this PR is responsible for the below items.

- [ ] Create a non-forked branch based on this PR and test the below items on it
- [ ] Build is successful
- [ ] If new credentials are required for use in CI, add them to GSM. [Instructions](https://docs.airbyte.io/connector-development#using-credentials-in-ci).
- [ ] [`/test connector=connectors/<name>` command](https://docs.airbyte.io/connector-development#updating-an-existing-connector) is passing
- [ ] New Connector version released on Dockerhub and connector version bumped by running the `/publish` command described [here](https://docs.airbyte.io/connector-development#updating-an-existing-connector)

</details>

<details><summary><strong>Connector Generator</strong></summary>

- [ ] Issue acceptance criteria met
- [ ] PR name follows [PR naming conventions](https://docs.airbyte.com/contributing-to-airbyte/issues-and-pull-requests)
- [ ] If adding a new generator, add it to the [list of scaffold modules being tested](https://github.com/airbytehq/airbyte/blob/master/airbyte-integrations/connector-templates/generator/build.gradle#L41)
- [ ] The generator test modules (all connectors with `-scaffold` in their name) have been updated with the latest scaffold by running `./gradlew :airbyte-integrations:connector-templates:generator:testScaffoldTemplates` then checking in your changes
- [ ] Documentation which references the generator is updated as needed

</details>
