### PR TITLE
🪟 🎨🔧 Remove oauth position ff

### DIFF
--- a/airbyte-webapp/src/hooks/services/Experiment/experiments.ts
+++ b/airbyte-webapp/src/hooks/services/Experiment/experiments.ts
@@ -18,7 +18,6 @@ export interface Experiments {
   "authPage.signup.hideName": boolean;
   "authPage.signup.hideCompanyName": boolean;
   "onboarding.speedyConnection": boolean;
-  "authPage.oauth.position": "top" | "bottom";
   "connection.onboarding.sources": string;
   "connection.onboarding.destinations": string;
   "connection.autoDetectSchemaChanges": boolean;

--- a/airbyte-webapp/src/packages/cloud/views/auth/LoginPage/LoginPage.module.scss
+++ b/airbyte-webapp/src/packages/cloud/views/auth/LoginPage/LoginPage.module.scss
@@ -3,9 +3,3 @@
 .forgotPassword {
   font-size: 12px;
 }
-
-.container {
-  display: flex;
-  flex-direction: column;
-  gap: variables.$spacing-xl;
-}

--- a/airbyte-webapp/src/packages/cloud/views/auth/LoginPage/LoginPage.module.scss
+++ b/airbyte-webapp/src/packages/cloud/views/auth/LoginPage/LoginPage.module.scss
@@ -1,3 +1,11 @@
+@use "scss/variables";
+
 .forgotPassword {
   font-size: 12px;
+}
+
+.container {
+  display: flex;
+  flex-direction: column;
+  gap: variables.$spacing-xl;
 }

--- a/airbyte-webapp/src/packages/cloud/views/auth/LoginPage/LoginPage.module.scss
+++ b/airbyte-webapp/src/packages/cloud/views/auth/LoginPage/LoginPage.module.scss
@@ -1,5 +1,3 @@
-@use "scss/variables";
-
 .forgotPassword {
   font-size: 12px;
 }

--- a/airbyte-webapp/src/packages/cloud/views/auth/LoginPage/LoginPage.tsx
+++ b/airbyte-webapp/src/packages/cloud/views/auth/LoginPage/LoginPage.tsx
@@ -7,6 +7,7 @@ import * as yup from "yup";
 import { LabeledInput, Link } from "components";
 import { HeadTitle } from "components/common/HeadTitle";
 import { Button } from "components/ui/Button";
+import { FlexContainer } from "components/ui/Flex";
 
 import { PageTrackingCodes, useTrackPage } from "hooks/services/Analytics";
 import { useQuery } from "hooks/useQuery";
@@ -35,7 +36,7 @@ export const LoginPage: React.FC = () => {
   useTrackPage(PageTrackingCodes.LOGIN);
 
   return (
-    <div className={styles.container}>
+    <FlexContainer direction="column" gap="xl">
       <HeadTitle titles={[{ id: "login.login" }]} />
       <FormTitle>
         <FormattedMessage id="login.loginTitle" />
@@ -116,6 +117,6 @@ export const LoginPage: React.FC = () => {
         )}
       </Formik>
       <Disclaimer />
-    </div>
+    </FlexContainer>
   );
 };

--- a/airbyte-webapp/src/packages/cloud/views/auth/LoginPage/LoginPage.tsx
+++ b/airbyte-webapp/src/packages/cloud/views/auth/LoginPage/LoginPage.tsx
@@ -1,4 +1,4 @@
-import { Field, FieldProps, Formik } from "formik";
+import { Field, FieldProps, Formik, Form } from "formik";
 import React from "react";
 import { FormattedMessage, useIntl } from "react-intl";
 import { NavigateOptions, To, useNavigate } from "react-router-dom";
@@ -13,7 +13,7 @@ import { useQuery } from "hooks/useQuery";
 import { CloudRoutes } from "packages/cloud/cloudRoutePaths";
 import { FieldError } from "packages/cloud/lib/errors/FieldError";
 import { useAuthService } from "packages/cloud/services/auth/AuthService";
-import { BottomBlock, FieldItem, Form } from "packages/cloud/views/auth/components/FormComponents";
+import { BottomBlock, FieldItem } from "packages/cloud/views/auth/components/FormComponents";
 import { FormTitle } from "packages/cloud/views/auth/components/FormTitle";
 
 import styles from "./LoginPage.module.scss";
@@ -35,12 +35,14 @@ export const LoginPage: React.FC = () => {
   useTrackPage(PageTrackingCodes.LOGIN);
 
   return (
-    <div>
+    <div className={styles.container}>
       <HeadTitle titles={[{ id: "login.login" }]} />
       <FormTitle>
         <FormattedMessage id="login.loginTitle" />
       </FormTitle>
 
+      <OAuthLogin />
+      <Separator />
       <Formik
         initialValues={{
           email: "",
@@ -113,9 +115,6 @@ export const LoginPage: React.FC = () => {
           </Form>
         )}
       </Formik>
-
-      <Separator />
-      <OAuthLogin />
       <Disclaimer />
     </div>
   );

--- a/airbyte-webapp/src/packages/cloud/views/auth/SignupPage/SignupPage.module.scss
+++ b/airbyte-webapp/src/packages/cloud/views/auth/SignupPage/SignupPage.module.scss
@@ -1,12 +1,6 @@
 @use "../../../../../scss/colors";
 @use "../../../../../scss/variables";
 
-.container {
-  display: flex;
-  flex-direction: column;
-  gap: variables.$spacing-xl;
-}
-
 .title {
   width: 250px;
   margin-bottom: variables.$spacing-md;

--- a/airbyte-webapp/src/packages/cloud/views/auth/SignupPage/SignupPage.tsx
+++ b/airbyte-webapp/src/packages/cloud/views/auth/SignupPage/SignupPage.tsx
@@ -2,6 +2,7 @@ import React from "react";
 import { FormattedMessage } from "react-intl";
 
 import { HeadTitle } from "components/common/HeadTitle";
+import { FlexContainer } from "components/ui/Flex";
 import { Heading } from "components/ui/Heading";
 
 import { PageTrackingCodes, useTrackPage } from "hooks/services/Analytics";
@@ -20,7 +21,7 @@ const SignupPage: React.FC<SignupPageProps> = ({ highlightStyle }) => {
   useTrackPage(PageTrackingCodes.SIGNUP);
 
   return (
-    <div className={styles.container}>
+    <FlexContainer direction="column" gap="xl">
       <HeadTitle titles={[{ id: "login.signup" }]} />
       <Heading as="h1" size="xl" className={styles.title}>
         <FormattedMessage
@@ -40,7 +41,7 @@ const SignupPage: React.FC<SignupPageProps> = ({ highlightStyle }) => {
       <Separator />
       <SignupForm />
       <Disclaimer />
-    </div>
+    </FlexContainer>
   );
 };
 

--- a/airbyte-webapp/src/packages/cloud/views/auth/SignupPage/SignupPage.tsx
+++ b/airbyte-webapp/src/packages/cloud/views/auth/SignupPage/SignupPage.tsx
@@ -5,7 +5,6 @@ import { HeadTitle } from "components/common/HeadTitle";
 import { Heading } from "components/ui/Heading";
 
 import { PageTrackingCodes, useTrackPage } from "hooks/services/Analytics";
-import { useExperiment } from "hooks/services/Experiment";
 
 import { Separator } from "./components/Separator";
 import { Disclaimer, SignupForm } from "./components/SignupForm";
@@ -19,7 +18,6 @@ interface SignupPageProps {
 
 const SignupPage: React.FC<SignupPageProps> = ({ highlightStyle }) => {
   useTrackPage(PageTrackingCodes.SIGNUP);
-  const oAuthPosition = useExperiment("authPage.oauth.position", "bottom");
 
   return (
     <div className={styles.container}>
@@ -37,19 +35,10 @@ const SignupPage: React.FC<SignupPageProps> = ({ highlightStyle }) => {
         />
       </Heading>
       <SpecialBlock />
-      {oAuthPosition === "top" && (
-        <>
-          <OAuthLogin />
-          <Separator />
-        </>
-      )}
+
+      <OAuthLogin />
+      <Separator />
       <SignupForm />
-      {oAuthPosition === "bottom" && (
-        <>
-          <Separator />
-          <OAuthLogin />
-        </>
-      )}
       <Disclaimer />
     </div>
   );


### PR DESCRIPTION
We validated that having oauth signup methods on top led to better conversion rate.

This PR just removes the feature flag we used and set the ouath on top of the signup form.

I also took the chance to change the position in the login page for consistency 

<img width="1263" alt="Screen Shot 2023-02-02 at 10 41 22 AM" src="https://user-images.githubusercontent.com/45267095/216290187-082aa779-9a0c-446a-87af-bc2db9c4400e.png">
