### PR TITLE
🪟 🐛 Fixes getAvailableSyncModesOptions function to return intersection of sync mode options

### DIFF
--- a/airbyte-webapp/src/components/connection/CatalogTree/next/BulkEditPanel.test.tsx
+++ b/airbyte-webapp/src/components/connection/CatalogTree/next/BulkEditPanel.test.tsx
@@ -210,9 +210,7 @@ describe("<BulkEditPanel />", () => {
 
   it("getAvailableSyncModesOptions should work correctly", () => {
     const expectedResult: SyncModeOption[] = [
-      { value: { syncMode: "incremental", destinationSyncMode: "append_dedup" } },
       { value: { syncMode: "full_refresh", destinationSyncMode: "overwrite" } },
-      { value: { syncMode: "incremental", destinationSyncMode: "append" } },
       { value: { syncMode: "full_refresh", destinationSyncMode: "append" } },
     ];
     const actualResult = getAvailableSyncModesOptions(

--- a/airbyte-webapp/src/components/connection/CatalogTree/next/BulkEditPanel.tsx
+++ b/airbyte-webapp/src/components/connection/CatalogTree/next/BulkEditPanel.tsx
@@ -66,7 +66,7 @@ export const getAvailableSyncModesOptions = (
   syncModes?: DestinationSyncMode[]
 ): SyncModeOption[] =>
   SUPPORTED_MODES.filter(([syncMode, destinationSyncMode]) => {
-    const supportableModes = intersection(nodes.flatMap((n) => n.stream?.supportedSyncModes));
+    const supportableModes = intersection(...nodes.map((n) => n.stream?.supportedSyncModes));
     return supportableModes.includes(syncMode) && syncModes?.includes(destinationSyncMode);
   }).map(([syncMode, destinationSyncMode]) => ({
     value: { syncMode, destinationSyncMode },


### PR DESCRIPTION
## What
Closes [#21029](https://github.com/airbytehq/airbyte/issues/21029)

## How
Fixes usage of `intersection` `lodash` function to receive correct arguments