### PR TITLE
Add connector acceptance test for mysql

### DIFF
--- a/airbyte-integrations/connectors/destination-mysql/acceptance-test-config.yml
+++ b/airbyte-integrations/connectors/destination-mysql/acceptance-test-config.yml
@@ -1,0 +1,5 @@
+connector_image: airbyte/destination-mysql:dev
+tests:
+  spec:
+   - spec_path: "integration_test/expected_spec.json"
+     config_path: "integration_test/config.json"

--- a/airbyte-integrations/connectors/destination-mysql/build.gradle
+++ b/airbyte-integrations/connectors/destination-mysql/build.gradle
@@ -2,6 +2,7 @@ plugins {
     id 'application'
     id 'airbyte-docker'
     id 'airbyte-integration-test-java'
+    id 'airbyte-connector-acceptance-test'
 }
 
 application {

--- a/airbyte-integrations/connectors/destination-mysql/integration_test/config.json
+++ b/airbyte-integrations/connectors/destination-mysql/integration_test/config.json
@@ -1,0 +1,6 @@
+{
+    "host": "localhost",
+    "port": 1234,
+    "username": "test",
+    "database": "db"
+}

--- a/airbyte-integrations/connectors/destination-mysql/integration_test/expected_spec.json
+++ b/airbyte-integrations/connectors/destination-mysql/integration_test/expected_spec.json
@@ -1,0 +1,191 @@
+{
+  "documentationUrl": "https://docs.airbyte.io/integrations/destinations/mysql",
+  "connectionSpecification": {
+    "$schema": "http://json-schema.org/draft-07/schema#",
+    "title": "MySQL Destination Spec",
+    "type": "object",
+    "required": [
+      "host",
+      "port",
+      "username",
+      "database"
+    ],
+    "additionalProperties": true,
+    "properties": {
+      "host": {
+        "title": "Host",
+        "description": "Hostname of the database.",
+        "type": "string",
+        "order": 0
+      },
+      "port": {
+        "title": "Port",
+        "description": "Port of the database.",
+        "type": "integer",
+        "minimum": 0,
+        "maximum": 65536,
+        "default": 3306,
+        "examples": [
+          "3306"
+        ],
+        "order": 1
+      },
+      "database": {
+        "title": "DB Name",
+        "description": "Name of the database.",
+        "type": "string",
+        "order": 2
+      },
+      "username": {
+        "title": "User",
+        "description": "Username to use to access the database.",
+        "type": "string",
+        "order": 3
+      },
+      "password": {
+        "title": "Password",
+        "description": "Password associated with the username.",
+        "type": "string",
+        "airbyte_secret": true,
+        "order": 4
+      },
+      "ssl": {
+        "title": "SSL Connection",
+        "description": "Encrypt data using SSL.",
+        "type": "boolean",
+        "default": true,
+        "order": 5
+      },
+      "jdbc_url_params": {
+        "description": "Additional properties to pass to the JDBC URL string when connecting to the database formatted as 'key=value' pairs separated by the symbol '&'. (example: key1=value1&key2=value2&key3=value3).",
+        "title": "JDBC URL Params",
+        "type": "string",
+        "order": 6
+      },
+      "tunnel_method": {
+        "type": "object",
+        "title": "SSH Tunnel Method",
+        "description": "Whether to initiate an SSH tunnel before connecting to the database, and if so, which kind of authentication to use.",
+        "oneOf": [
+          {
+            "title": "No Tunnel",
+            "required": [
+              "tunnel_method"
+            ],
+            "properties": {
+              "tunnel_method": {
+                "description": "No ssh tunnel needed to connect to database",
+                "type": "string",
+                "const": "NO_TUNNEL",
+                "order": 0
+              }
+            }
+          },
+          {
+            "title": "SSH Key Authentication",
+            "required": [
+              "tunnel_method",
+              "tunnel_host",
+              "tunnel_port",
+              "tunnel_user",
+              "ssh_key"
+            ],
+            "properties": {
+              "tunnel_method": {
+                "description": "Connect through a jump server tunnel host using username and ssh key",
+                "type": "string",
+                "const": "SSH_KEY_AUTH",
+                "order": 0
+              },
+              "tunnel_host": {
+                "title": "SSH Tunnel Jump Server Host",
+                "description": "Hostname of the jump server host that allows inbound ssh tunnel.",
+                "type": "string",
+                "order": 1
+              },
+              "tunnel_port": {
+                "title": "SSH Connection Port",
+                "description": "Port on the proxy/jump server that accepts inbound ssh connections.",
+                "type": "integer",
+                "minimum": 0,
+                "maximum": 65536,
+                "default": 22,
+                "examples": [
+                  "22"
+                ],
+                "order": 2
+              },
+              "tunnel_user": {
+                "title": "SSH Login Username",
+                "description": "OS-level username for logging into the jump server host.",
+                "type": "string",
+                "order": 3
+              },
+              "ssh_key": {
+                "title": "SSH Private Key",
+                "description": "OS-level user account ssh key credentials in RSA PEM format ( created with ssh-keygen -t rsa -m PEM -f myuser_rsa )",
+                "type": "string",
+                "airbyte_secret": true,
+                "multiline": true,
+                "order": 4
+              }
+            }
+          },
+          {
+            "title": "Password Authentication",
+            "required": [
+              "tunnel_method",
+              "tunnel_host",
+              "tunnel_port",
+              "tunnel_user",
+              "tunnel_user_password"
+            ],
+            "properties": {
+              "tunnel_method": {
+                "description": "Connect through a jump server tunnel host using username and password authentication",
+                "type": "string",
+                "const": "SSH_PASSWORD_AUTH",
+                "order": 0
+              },
+              "tunnel_host": {
+                "title": "SSH Tunnel Jump Server Host",
+                "description": "Hostname of the jump server host that allows inbound ssh tunnel.",
+                "type": "string",
+                "order": 1
+              },
+              "tunnel_port": {
+                "title": "SSH Connection Port",
+                "description": "Port on the proxy/jump server that accepts inbound ssh connections.",
+                "type": "integer",
+                "minimum": 0,
+                "maximum": 65536,
+                "default": 22,
+                "examples": [
+                  "22"
+                ],
+                "order": 2
+              },
+              "tunnel_user": {
+                "title": "SSH Login Username",
+                "description": "OS-level username for logging into the jump server host",
+                "type": "string",
+                "order": 3
+              },
+              "tunnel_user_password": {
+                "title": "Password",
+                "description": "OS-level password for logging into the jump server host",
+                "type": "string",
+                "airbyte_secret": true,
+                "order": 4
+              }
+            }
+          }
+        ]
+      }
+    }
+  },
+  "supportsIncremental": true,
+  "supportsNormalization": true,
+  "supportsDBT": true,
+  "supported_destination_sync_modes": ["overwrite","append"]
+}

--- a/airbyte-integrations/connectors/destination-mysql/integration_test/expected_spec.json
+++ b/airbyte-integrations/connectors/destination-mysql/integration_test/expected_spec.json
@@ -1,5 +1,5 @@
 {
-  "documentationUrl": "https://docs.airbyte.io/integrations/destinations/mysql",
+  "documentationUrl": "https://docs.airbyte.com/integrations/destinations/mysql",
   "connectionSpecification": {
     "$schema": "http://json-schema.org/draft-07/schema#",
     "title": "MySQL Destination Spec",

--- a/buildSrc/src/main/groovy/airbyte-connector-acceptance-test.gradle
+++ b/buildSrc/src/main/groovy/airbyte-connector-acceptance-test.gradle
@@ -19,7 +19,7 @@ class AirbyteConnectorAcceptanceTestPlugin implements Plugin<Project> {
                         '-w', "$targetMountDirectory",
                         '-e', "AIRBYTE_SAT_CONNECTOR_DIR=${project.projectDir.absolutePath}",
                         'airbyte/connector-acceptance-test:dev',
-                        '-p', 'integration_tests.acceptance',
+                        '--acceptance-test-config', targetMountDirectory,
                     ]
                     commandLine args
                 }


### PR DESCRIPTION
This PR adds a connector acceptance test for the spec to the mysql destination. This ensures the spec is respecting all limitations which is important for providing a functional configuration form to the user in the UI.

Also had to do a minor adjustment to the gradle plugin to make it work (it probably works for other cases related to some implicit dependies between tasks that don't work for the tests of this connector): https://github.com/airbytehq/airbyte/pull/22317/files#diff-6a042a48a0e852de076678fb1b2bd5ee79f3efad8f7e35c8267476c8185e88b4L22