### PR TITLE
[Connector Builder] Set placeholder documentation_url for builder-generated spec

### DIFF
--- a/airbyte-webapp/src/components/connectorBuilder/types.ts
+++ b/airbyte-webapp/src/components/connectorBuilder/types.ts
@@ -636,7 +636,7 @@ export const convertToManifest = (values: BuilderFormValues): ConnectorManifest 
 
   const spec: Spec = {
     connection_specification: specSchema,
-    documentation_url: "https://docsurl.com",
+    documentation_url: "https://example.org",
     type: "Spec",
   };
 

--- a/airbyte-webapp/src/components/connectorBuilder/types.ts
+++ b/airbyte-webapp/src/components/connectorBuilder/types.ts
@@ -636,7 +636,7 @@ export const convertToManifest = (values: BuilderFormValues): ConnectorManifest 
 
   const spec: Spec = {
     connection_specification: specSchema,
-    documentation_url: "",
+    documentation_url: "https://docsurl.com",
     type: "Spec",
   };
 


### PR DESCRIPTION
## What
See slack context: https://airbytehq-team.slack.com/archives/C03TP6W8081/p1675365814016559?thread_ts=1675198798.481999&cid=C03TP6W8081

Manifests generated by the connector builder currently do not pass integration tests and cannot be used, because they have an empty documentation_url.

This issue platform issue will handle fixing the airbyte-server to not fail in this case: https://github.com/airbytehq/airbyte/issues/22242
But until that is complete, we should have an intermediate solution here to fix the problem in the meantime.

## How
This PR addresses the issue by setting `documentation_url` in the manifest produce by the connector builder to the placeholder documentation url we have used in other connectors so far.

This can be removed once https://github.com/airbytehq/airbyte/issues/22242 is complete

