### PR TITLE
Update CODEOWNERS for connector acceptance tests to connector ops

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,7 +1,7 @@
 # CDK and Connector Acceptance Tests
 /airbyte-cdk/ @airbytehq/connector-extensibility
-/airbyte-integrations/bases/connector-acceptance-tests/ @airbytehq/connector-extensibility
 /airbyte-integrations/connector-templates/ @airbytehq/connector-extensibility
+/airbyte-integrations/bases/connector-acceptance-tests/ @airbytehq/connector-operations
 
 # Oauth
 /airbyte-oauth/ @airbytehq/connector-operations


### PR DESCRIPTION
Updating to reflect the ownership agreed upon [in team charters](https://docs.google.com/document/d/1RWFgsghGD8pRxSDg7LmqfCkPFsGzMx0ej36Hw94ux0w/edit)