### PR TITLE
Remove manual docker upgrades from workflows

### DIFF
--- a/.github/actions/build-and-push-branch/action.yml
+++ b/.github/actions/build-and-push-branch/action.yml
@@ -13,16 +13,6 @@ inputs:
 runs:
   using: "composite"
   steps:
-    - name: Delete default old docker and replace it with a new one
-      shell: bash
-      run: |
-        sudo rm /var/lib/dpkg/lock
-        sudo rm /var/lib/dpkg/lock-frontend
-        sudo apt-get remove docker.io || sudo apt-get remove docker
-        curl -fsSL https://get.docker.com | bash -
-        sudo rm -f /var/lib/dpkg/lock
-        sudo rm -f /var/lib/dpkg/lock-frontend
-
     - name: Build
       id: build
       uses: ./.github/actions/build-branch

--- a/.github/workflows/gradle.yml
+++ b/.github/workflows/gradle.yml
@@ -528,16 +528,6 @@ jobs:
         with:
           python-version: "3.9"
 
-      - name: Delete default old docker and replace it with a new one
-        shell: bash
-        run: |
-          sudo rm /var/lib/dpkg/lock
-          sudo rm /var/lib/dpkg/lock-frontend
-          sudo apt-get remove docker.io || sudo apt-get remove docker
-          curl -fsSL https://get.docker.com | bash -
-          sudo rm -f /var/lib/dpkg/lock
-          sudo rm -f /var/lib/dpkg/lock-frontend
-
       - name: Set up CI Gradle Properties
         run: |
           mkdir -p ~/.gradle/
@@ -654,16 +644,6 @@ jobs:
       - uses: actions/setup-node@v3
         with:
           node-version: "lts/*"
-
-      - name: Delete default old docker and replace it with a new one
-        shell: bash
-        run: |
-          sudo rm /var/lib/dpkg/lock
-          sudo rm /var/lib/dpkg/lock-frontend
-          sudo apt-get remove docker.io || sudo apt-get remove docker
-          curl -fsSL https://get.docker.com | bash -
-          sudo rm -f /var/lib/dpkg/lock
-          sudo rm -f /var/lib/dpkg/lock-frontend
 
       - name: Set up CI Gradle Properties
         run: |


### PR DESCRIPTION
## What

Removes the manual docker upgrades in the workflow files. We should always extend the AMI image that's used for our CI runners when we need to make adjustments to packages, and not put it into the workflow files. This also is flaky since Gradle parallelizes tasks and we're manually messing with lock files here of apt.

Since our AMI used for CI runners already has the newest docker version as of today, removing those upgraded should be fine.