### PR TITLE
🪟 🔧 [Connector Builder] Add telemetry for landing page events

### DIFF
--- a/airbyte-webapp/src/core/analytics/types.ts
+++ b/airbyte-webapp/src/core/analytics/types.ts
@@ -32,6 +32,7 @@ export const enum Action {
 
   // Connector Builder Actions
   CONNECTOR_BUILDER_START = "ConnectorBuilderStart",
+  CONNECTOR_BUILDER_EDIT = "ConnectorBuilderEdit",
   API_URL_CREATE = "ApiUrlCreated",
   AUTHENTICATION_METHOD_SELECT = "AuthenticationMethodSelect",
   GLOBAL_CONFIGURATION_SELECT = "GlobalConfigurationSelect",
@@ -53,6 +54,10 @@ export const enum Action {
   DISCARD_YAML_CHANGES = "DiscardYamlChanges",
   OVERWRITE_SCHEMA = "OverwriteSchema",
   MERGE_SCHEMA = "MergeSchema",
+  UI_INCOMPATIBLE_YAML_IMPORTED = "UiIncompatibleYamlImported",
+  UI_COMPATIBLE_YAML_IMPORTED = "UiCompatibleYamlImported",
+  INVALID_YAML_UPLOADED = "InvalidYamlUploaded",
+  START_FROM_SCRATCH = "StartFromScratch",
 }
 
 export type EventParams = Record<string, unknown>;

--- a/airbyte-webapp/src/pages/connectorBuilder/ConnectorBuilderEditPage/ConnectorBuilderEditPage.tsx
+++ b/airbyte-webapp/src/pages/connectorBuilder/ConnectorBuilderEditPage/ConnectorBuilderEditPage.tsx
@@ -28,8 +28,8 @@ const ConnectorBuilderEditPageInner: React.FC = React.memo(() => {
   const analyticsService = useAnalyticsService();
 
   useEffect(() => {
-    analyticsService.track(Namespace.CONNECTOR_BUILDER, Action.CONNECTOR_BUILDER_START, {
-      actionDescription: "Connector Builder UI Opened",
+    analyticsService.track(Namespace.CONNECTOR_BUILDER, Action.CONNECTOR_BUILDER_EDIT, {
+      actionDescription: "Connector Builder UI /edit page opened",
     });
   }, [analyticsService]);
 


### PR DESCRIPTION
## What
Adds telemetry for actions taken in the new connector builder landing page

## How
Moves the `Connector Builder Start` event from ConnectorBuilderEditPage to ConnectorBuilderLandingPage, replacing that event in the Edit page with a `ConnectorBuilderEdit` event, since the landing page is the new "starting point".

Tracks events for each of the cases that the user can end up in when importing:
- Start from scratch
- Invalid YAML uploaded
- UI-incompatible YAML imported
- UI-compatible YAML imported
