### PR TITLE
Catch empty state in incremental SAT

### DIFF
--- a/airbyte-integrations/bases/connector-acceptance-test/connector_acceptance_test/tests/test_incremental.py
+++ b/airbyte-integrations/bases/connector-acceptance-test/connector_acceptance_test/tests/test_incremental.py
@@ -180,7 +180,7 @@ class TestIncremental(BaseTest):
             latest_state = states_1[-1].state.data
             state_input = states_1[-1].state.data
 
-        parsed_records_1 = records_with_state(records_1, latest_state, stream_mapping, cursor_paths);
+        parsed_records_1 = list(records_with_state(records_1, latest_state, stream_mapping, cursor_paths));
 
         # This catches the case of a connector that emits an invalid state that is not compatible with the schema
         # See https://github.com/airbytehq/airbyte/issues/21863 to understand more

--- a/airbyte-integrations/bases/connector-acceptance-test/connector_acceptance_test/tests/test_incremental.py
+++ b/airbyte-integrations/bases/connector-acceptance-test/connector_acceptance_test/tests/test_incremental.py
@@ -180,12 +180,11 @@ class TestIncremental(BaseTest):
             latest_state = states_1[-1].state.data
             state_input = states_1[-1].state.data
 
-
         parsed_records_1 = records_with_state(records_1, latest_state, stream_mapping, cursor_paths);
 
         # This catches the case of a connector that emits an invalid state that is not compatible with the schema
         # See https://github.com/airbytehq/airbyte/issues/21863 to understand more
-        assert parsed_records_1, "Should produce at least one record with state"
+        assert parsed_records_1, "At least one valid state should be produced, given a cursor path"
 
         for record_value, state_value, stream_name in parsed_records_1:
             assert (
@@ -194,13 +193,6 @@ class TestIncremental(BaseTest):
 
         output = docker_runner.call_read_with_state(connector_config, configured_catalog_for_incremental, state=state_input)
         records_2 = filter_output(output, type_=Type.RECORD)
-
-
-        assert records_2, "Should produce at least one record on subsequent read"
-
-        parsed_records_2 = records_with_state(records_1, latest_state, stream_mapping, cursor_paths);
-        assert parsed_records_2, "Should produce at least one record with state"
-
 
         for record_value, state_value, stream_name in records_with_state(records_2, latest_state, stream_mapping, cursor_paths):
             assert compare_cursor_with_threshold(

--- a/airbyte-integrations/bases/connector-acceptance-test/connector_acceptance_test/tests/test_incremental.py
+++ b/airbyte-integrations/bases/connector-acceptance-test/connector_acceptance_test/tests/test_incremental.py
@@ -180,7 +180,7 @@ class TestIncremental(BaseTest):
             latest_state = states_1[-1].state.data
             state_input = states_1[-1].state.data
 
-        parsed_records_1 = list(records_with_state(records_1, latest_state, stream_mapping, cursor_paths));
+        parsed_records_1 = list(records_with_state(records_1, latest_state, stream_mapping, cursor_paths))
 
         # This catches the case of a connector that emits an invalid state that is not compatible with the schema
         # See https://github.com/airbytehq/airbyte/issues/21863 to understand more
@@ -198,7 +198,6 @@ class TestIncremental(BaseTest):
             assert compare_cursor_with_threshold(
                 record_value, state_value, threshold_days
             ), f"Second incremental sync should produce records older or equal to cursor value from the state. Stream: {stream_name}"
-
 
     def test_read_sequential_slices(
         self, inputs: IncrementalConfig, connector_config, configured_catalog_for_incremental, cursor_paths, docker_runner: ConnectorRunner

--- a/airbyte-integrations/bases/connector-acceptance-test/unit_tests/test_incremental.py
+++ b/airbyte-integrations/bases/connector-acceptance-test/unit_tests/test_incremental.py
@@ -275,10 +275,6 @@ def test_incremental_two_sequential_reads_state_invalid(
 
     call_read_with_state_output_messages = build_messages_from_record_data(stream_name, records2)
 
-    print("call_read_output_messages[1]")
-    print(call_read_output_messages[1])
-    # assert False
-
     docker_runner_mock = MagicMock()
     docker_runner_mock.call_read.return_value = call_read_output_messages
     docker_runner_mock.call_read_with_state.return_value = call_read_with_state_output_messages

--- a/airbyte-integrations/bases/connector-acceptance-test/unit_tests/test_incremental.py
+++ b/airbyte-integrations/bases/connector-acceptance-test/unit_tests/test_incremental.py
@@ -94,13 +94,6 @@ def test_compare_cursor_with_threshold(record_value, state_value, threshold_days
     [
         ([{"date": "2020-01-01"}, {"date": "2020-01-02"}], [], "2020-01-02", 0, does_not_raise()),
         (
-            [{"date": {}}, {"date": {}}],
-            [],
-            "2020-01-02",
-            0,
-            pytest.raises(AssertionError, match="At least one valid state should be produced, given a cursor path")
-        ),
-        (
             [{"date": "2020-01-02"}, {"date": "2020-01-03"}],
             [],
             "2020-01-02",

--- a/airbyte-integrations/bases/connector-acceptance-test/unit_tests/test_incremental.py
+++ b/airbyte-integrations/bases/connector-acceptance-test/unit_tests/test_incremental.py
@@ -227,7 +227,7 @@ def test_incremental_two_sequential_reads(
             {'test_stream': ['dateCreated']},
             [{"dateCreated": "2020-01-01T01:01:01.000000Z"}, {"dateCreated": "2020-01-02T01:01:01.000000Z"}],
             [],
-            {"test_stream": {}},
+            {},
             pytest.raises(AssertionError, match="At least one valid state should be produced, given a cursor path")
         ),
     ],
@@ -266,8 +266,8 @@ def test_incremental_two_sequential_reads_state_invalid(
         ]
     else:
         call_read_output_messages = [
-            *build_messages_from_record_data("test_stream", {"test_stream": latest_state}),
-            build_state_message(latest_state),
+            *build_messages_from_record_data("test_stream", records1),
+            build_state_message({"test_stream": latest_state}),
         ]
 
 

--- a/airbyte-integrations/bases/connector-acceptance-test/unit_tests/test_incremental.py
+++ b/airbyte-integrations/bases/connector-acceptance-test/unit_tests/test_incremental.py
@@ -235,7 +235,7 @@ def test_incremental_two_sequential_reads(
 @pytest.mark.parametrize(
     "run_per_stream_test",
     [
-        # pytest.param(False, id="test_two_sequential_reads_using_a_mock_connector_emitting_legacy_state"),
+        pytest.param(False, id="test_two_sequential_reads_using_a_mock_connector_emitting_legacy_state"),
         pytest.param(True, id="test_two_sequential_reads_using_a_mock_connector_emitting_per_stream_state"),
     ],
 )
@@ -247,7 +247,7 @@ def test_incremental_two_sequential_reads_state_invalid(
         streams=[
             ConfiguredAirbyteStream(
                 stream=AirbyteStream(
-                    name="test_stream",
+                    name=stream_name,
                     json_schema={"type": "object", "properties": cursor_type},
                     supported_sync_modes=[SyncMode.full_refresh, SyncMode.incremental],
                 ),
@@ -262,16 +262,18 @@ def test_incremental_two_sequential_reads_state_invalid(
     if run_per_stream_test:
         call_read_output_messages = [
             *build_messages_from_record_data(stream_name, records1),
-            build_per_stream_state_message(descriptor=StreamDescriptor(name="test_stream"), stream_state=latest_state),
+            build_per_stream_state_message(descriptor=StreamDescriptor(name=stream_name), stream_state=latest_state),
         ]
     else:
+        stream_state = dict()
+        stream_state[stream_name] = latest_state
         call_read_output_messages = [
-            *build_messages_from_record_data("test_stream", records1),
-            build_state_message({"test_stream": latest_state}),
+            *build_messages_from_record_data(stream_name, records1),
+            build_state_message(stream_state),
         ]
 
 
-    call_read_with_state_output_messages = build_messages_from_record_data("test_stream", records2)
+    call_read_with_state_output_messages = build_messages_from_record_data(stream_name, records2)
 
     print("call_read_output_messages[1]")
     print(call_read_output_messages[1])

--- a/airbyte-integrations/bases/connector-acceptance-test/unit_tests/test_incremental.py
+++ b/airbyte-integrations/bases/connector-acceptance-test/unit_tests/test_incremental.py
@@ -94,6 +94,13 @@ def test_compare_cursor_with_threshold(record_value, state_value, threshold_days
     [
         ([{"date": "2020-01-01"}, {"date": "2020-01-02"}], [], "2020-01-02", 0, does_not_raise()),
         (
+            [{"date": {}}, {"date": {}}],
+            [],
+            "2020-01-02",
+            0,
+            pytest.raises(AssertionError, match="At least one valid state should be produced, given a cursor path")
+        ),
+        (
             [{"date": "2020-01-02"}, {"date": "2020-01-03"}],
             [],
             "2020-01-02",
@@ -190,6 +197,100 @@ def test_incremental_two_sequential_reads(
             cursor_paths=cursor_paths,
             docker_runner=docker_runner_mock,
         )
+
+
+@pytest.mark.parametrize(
+    "stream_name, cursor_type, cursor_paths, records1, records2, latest_state, expected_error",
+    [
+        (
+            "test_stream",
+            {
+                    "dateCreated": {
+                        "type": "string",
+                        "format": "date-time"
+                    }
+            },
+            {'test_stream': ['dateCreated']},
+            [{"dateCreated": "2020-01-01T01:01:01.000000Z"}, {"dateCreated": "2020-01-02T01:01:01.000000Z"}],
+            [],
+            {"dateCreated": "2020-01-02T01:01:01.000000Z"},
+            does_not_raise(),
+        ),
+        (
+            "test_stream",
+            {
+                    "dateCreated": {
+                        "type": "string",
+                        "format": "date-time"
+                    }
+            },
+            {'test_stream': ['dateCreated']},
+            [{"dateCreated": "2020-01-01T01:01:01.000000Z"}, {"dateCreated": "2020-01-02T01:01:01.000000Z"}],
+            [],
+            {"test_stream": {}},
+            pytest.raises(AssertionError, match="At least one valid state should be produced, given a cursor path")
+        ),
+    ],
+)
+@pytest.mark.parametrize(
+    "run_per_stream_test",
+    [
+        # pytest.param(False, id="test_two_sequential_reads_using_a_mock_connector_emitting_legacy_state"),
+        pytest.param(True, id="test_two_sequential_reads_using_a_mock_connector_emitting_per_stream_state"),
+    ],
+)
+def test_incremental_two_sequential_reads_state_invalid(
+    stream_name, records1, records2, latest_state, cursor_type, cursor_paths, expected_error, run_per_stream_test
+):
+    input_config = IncrementalConfig()
+    catalog = ConfiguredAirbyteCatalog(
+        streams=[
+            ConfiguredAirbyteStream(
+                stream=AirbyteStream(
+                    name="test_stream",
+                    json_schema={"type": "object", "properties": cursor_type},
+                    supported_sync_modes=[SyncMode.full_refresh, SyncMode.incremental],
+                ),
+                sync_mode=SyncMode.incremental,
+                destination_sync_mode=DestinationSyncMode.overwrite,
+                default_cursor_field=["dateCreated"],
+                cursor_field=["dateCreated"],
+            )
+        ]
+    )
+
+    if run_per_stream_test:
+        call_read_output_messages = [
+            *build_messages_from_record_data(stream_name, records1),
+            build_per_stream_state_message(descriptor=StreamDescriptor(name="test_stream"), stream_state=latest_state),
+        ]
+    else:
+        call_read_output_messages = [
+            *build_messages_from_record_data("test_stream", {"test_stream": latest_state}),
+            build_state_message(latest_state),
+        ]
+
+
+    call_read_with_state_output_messages = build_messages_from_record_data("test_stream", records2)
+
+    print("call_read_output_messages[1]")
+    print(call_read_output_messages[1])
+    # assert False
+
+    docker_runner_mock = MagicMock()
+    docker_runner_mock.call_read.return_value = call_read_output_messages
+    docker_runner_mock.call_read_with_state.return_value = call_read_with_state_output_messages
+
+    t = _TestIncremental()
+    with expected_error:
+        t.test_two_sequential_reads(
+            inputs=input_config,
+            connector_config=MagicMock(),
+            configured_catalog_for_incremental=catalog,
+            cursor_paths=cursor_paths,
+            docker_runner=docker_runner_mock,
+        )
+
 
 
 @pytest.mark.parametrize(

--- a/airbyte-integrations/bases/connector-acceptance-test/unit_tests/test_incremental.py
+++ b/airbyte-integrations/bases/connector-acceptance-test/unit_tests/test_incremental.py
@@ -272,7 +272,6 @@ def test_incremental_two_sequential_reads_state_invalid(
             build_state_message(stream_state),
         ]
 
-
     call_read_with_state_output_messages = build_messages_from_record_data(stream_name, records2)
 
     docker_runner_mock = MagicMock()
@@ -288,7 +287,6 @@ def test_incremental_two_sequential_reads_state_invalid(
             cursor_paths=cursor_paths,
             docker_runner=docker_runner_mock,
         )
-
 
 
 @pytest.mark.parametrize(


### PR DESCRIPTION
## What
Improves the incremental SAT test to catch the case in which the STATE message yields no cursor value

closes #21863 

## Whats left todo

- [x] Add unit tests
- [x] Break test into own test case
- [x] Discuss concerns with team

## Concerns
@airbytehq/connector-operations I have a few areas im unsure on with these tests that I want to discuss before making any large changes

### 1. `records_with_state` can emit an empty list even if called with many records
One of the issues here is that the `records_with_state` function uses the `continue` function if no `state_value` is found for a record.

If this happens for all records then BOOM empty list.

In the previous context of the `test_two_sequential_reads` test that is considered a pass.

But to me that seems like an error, if no state can be infered from any record using the cursor, then they havent given us a passing test config.

Is that right?

**Impact if so: changing the SAT to account for it may cause previously passing connectors to fail**

### 2. In `test_two_sequential_reads` we do not ensure that we get data on the second read
We should make sure that the test case can test for two reads that result in data. 

Is that right?

**Impact if so: changing the SAT to account for it WILL cause previously passing connectors to fail. Latest version of sentry for example**
