### PR TITLE
Source Google Ads: support use_segments_date field in spec for custom query

### DIFF
--- a/airbyte-integrations/connectors/source-google-ads/source_google_ads/custom_query_stream.py
+++ b/airbyte-integrations/connectors/source-google-ads/source_google_ads/custom_query_stream.py
@@ -10,11 +10,12 @@ from .streams import IncrementalGoogleAdsStream
 
 
 class CustomQuery(IncrementalGoogleAdsStream):
+    use_segments_date = True
     def __init__(self, custom_query_config, **kwargs):
         self.custom_query_config = custom_query_config
         self.user_defined_query = custom_query_config["query"]
         if "use_segments_date" in self.custom_query_config and self.custom_query_config["use_segments_date"] == False:
-            self.cursor_field = None
+            self.use_segments_date = False
         super().__init__(**kwargs)
 
     @property
@@ -62,7 +63,7 @@ class CustomQuery(IncrementalGoogleAdsStream):
         }
         fields = CustomQuery.get_query_fields(self.user_defined_query)
         if "use_segments_date" in self.custom_query_config and self.custom_query_config["use_segments_date"] == False:
-            self.cursor_field = None
+            self.use_segments_date = False
         else:
             fields.append(self.cursor_field)
         google_schema = self.google_ads_client.get_fields_metadata(fields)

--- a/airbyte-integrations/connectors/source-google-ads/source_google_ads/custom_query_stream.py
+++ b/airbyte-integrations/connectors/source-google-ads/source_google_ads/custom_query_stream.py
@@ -13,6 +13,8 @@ class CustomQuery(IncrementalGoogleAdsStream):
     def __init__(self, custom_query_config, **kwargs):
         self.custom_query_config = custom_query_config
         self.user_defined_query = custom_query_config["query"]
+        if "use_segments_date" in self.custom_query_config and self.custom_query_config["use_segments_date"] == False:
+            self.cursor_field = None
         super().__init__(**kwargs)
 
     @property
@@ -31,7 +33,7 @@ class CustomQuery(IncrementalGoogleAdsStream):
 
     def get_query(self, stream_slice: Mapping[str, Any] = None) -> str:
         start_date, end_date = stream_slice.get("start_date"), stream_slice.get("end_date")
-        return self.insert_segments_date_expr(self.user_defined_query, start_date, end_date)
+        return self.insert_segments_date_expr(self.user_defined_query, start_date, end_date, self.custom_query_config)
 
     # IncrementalGoogleAdsStream uses get_json_schema a lot while parsing
     # responses, caching playing crucial role for performance here.
@@ -59,7 +61,10 @@ class CustomQuery(IncrementalGoogleAdsStream):
             "DATE": "string",
         }
         fields = CustomQuery.get_query_fields(self.user_defined_query)
-        fields.append(self.cursor_field)
+        if "use_segments_date" in self.custom_query_config and self.custom_query_config["use_segments_date"] == False:
+            self.cursor_field = None
+        else:
+            fields.append(self.cursor_field)
         google_schema = self.google_ads_client.get_fields_metadata(fields)
 
         for field in fields:
@@ -107,7 +112,7 @@ class CustomQuery(IncrementalGoogleAdsStream):
         return [f.strip() for f in fields.split(",")]
 
     @staticmethod
-    def insert_segments_date_expr(query: str, start_date: str, end_date: str) -> str:
+    def insert_segments_date_expr(query: str, start_date: str, end_date: str, custom_query_config = {"use_segments_date":True}) -> str:
         """
         Insert segments.date condition to break query into slices for incremental stream.
         :param query Origin user defined query
@@ -120,8 +125,11 @@ class CustomQuery(IncrementalGoogleAdsStream):
         if not columns:
             raise Exception("Not valid GAQL expression")
         columns = columns.group(1)
-        new_columns = columns + ", segments.date\n"
-        result_query = query.replace(columns, new_columns)
+        if "use_segments_date" in custom_query_config and custom_query_config["use_segments_date"] == False:
+            result_query = query
+        else:
+            new_columns = columns + ", segments.date\n"
+            result_query = query.replace(columns, new_columns)
 
         # Modify/insert where condition
         where_cond = CustomQuery.WHERE_EXPR.search(result_query)

--- a/airbyte-integrations/connectors/source-google-ads/source_google_ads/spec.json
+++ b/airbyte-integrations/connectors/source-google-ads/source_google_ads/spec.json
@@ -100,6 +100,12 @@
               "type": "string",
               "title": "Destination Table Name",
               "description": "The table name in your destination database for choosen query."
+            },
+            "use_segments_date": {
+              "type": "boolean",
+              "title": "Sometimes doesn't need segments.date",
+              "description": "True for use segment_date,and false for no segments.date field when query",
+              "default": true
             }
           }
         }

--- a/airbyte-integrations/connectors/source-google-ads/source_google_ads/streams.py
+++ b/airbyte-integrations/connectors/source-google-ads/source_google_ads/streams.py
@@ -228,7 +228,8 @@ class IncrementalGoogleAdsStream(GoogleAdsStream, IncrementalMixin, ABC):
                         self.incremental_sieve_logger.info(f"Updated state for customer {customer_id}. Full state is {self.state}.")
                         yield record
                         continue
-                    self.state = {customer_id: {self.cursor_field: record[self.cursor_field]}}
+                    if self.cursor_field is not None:
+                        self.state = {customer_id: {self.cursor_field: record[self.cursor_field]}}
                     self.incremental_sieve_logger.info(f"Initialized state for customer {customer_id}. Full state is {self.state}.")
                     yield record
                     continue

--- a/airbyte-integrations/connectors/source-google-ads/source_google_ads/streams.py
+++ b/airbyte-integrations/connectors/source-google-ads/source_google_ads/streams.py
@@ -190,7 +190,7 @@ class IncrementalGoogleAdsStream(GoogleAdsStream, IncrementalMixin, ABC):
             end_date = self._end_date
             logger.info(f"Generating slices for customer {customer.id}. Start date is {start_date}, end date is {end_date}")
 
-            if self.cursor_field is not None:
+            if self.use_segments_date :
                 for chunk in chunk_date_range(
                         start_date=start_date,
                         end_date=end_date,
@@ -237,9 +237,9 @@ class IncrementalGoogleAdsStream(GoogleAdsStream, IncrementalMixin, ABC):
                         self.incremental_sieve_logger.info(f"Updated state for customer {customer_id}. Full state is {self.state}.")
                         yield record
                         continue
-                    if self.cursor_field is not None:
+                    if self.use_segments_date :
                         self.state = {customer_id: {self.cursor_field: record[self.cursor_field]}}
-                    self.incremental_sieve_logger.info(f"Initialized state for customer {customer_id}. Full state is {self.state}.")
+                        self.incremental_sieve_logger.info(f"Initialized state for customer {customer_id}. Full state is {self.state}.")
                     yield record
                     continue
             except GoogleAdsException as exception:

--- a/airbyte-integrations/connectors/source-google-ads/unit_tests/test_custom_query.py
+++ b/airbyte-integrations/connectors/source-google-ads/unit_tests/test_custom_query.py
@@ -23,3 +23,21 @@ FROM search_term_view
 WHERE segments.date BETWEEN '1980-01-01' AND '1980-01-01'
 """
     )
+
+def test_custom_query_without_segments_date():
+    input_q = """SELECT ad_group.resource_name, ad_group.status, ad_group.target_cpa_micros, ad_group.target_cpm_micros,
+     ad_group.target_roas, ad_group.targeting_setting.target_restrictions, ad_group.tracking_url_template, ad_group.type,
+     ad_group.url_custom_parameters, campaign.accessible_bidding_strategy, campaign.ad_serving_optimization_status,
+     campaign.advertising_channel_type, campaign.advertising_channel_sub_type, campaign.app_campaign_setting.app_id,
+     campaign.app_campaign_setting.app_store FROM search_term_view"""
+    output_q = CustomQuery.insert_segments_date_expr(input_q, "1980-01-01", "1980-01-01",{"use_segments_date":False})
+    assert (
+            output_q
+            == """SELECT ad_group.resource_name, ad_group.status, ad_group.target_cpa_micros, ad_group.target_cpm_micros,
+     ad_group.target_roas, ad_group.targeting_setting.target_restrictions, ad_group.tracking_url_template, ad_group.type,
+     ad_group.url_custom_parameters, campaign.accessible_bidding_strategy, campaign.ad_serving_optimization_status,
+     campaign.advertising_channel_type, campaign.advertising_channel_sub_type, campaign.app_campaign_setting.app_id,
+     campaign.app_campaign_setting.app_store FROM search_term_view
+WHERE segments.date BETWEEN '1980-01-01' AND '1980-01-01'
+"""
+    )


### PR DESCRIPTION
support use_segments_date field in spec for custom query

## What
support use_segments_date field in spec for custom query

## How
Add new field use_segments_date in spec.json for custom query. You can switch it for custom query. Because sometimes does not need segemts.date on custom query.
![image](https://user-images.githubusercontent.com/241873/216509414-a9ddfad2-3cc7-4ed4-9c3a-b92c5d76acc7.png)

