### PR TITLE
Fix naming of functions for pod sweeper

### DIFF
--- a/charts/airbyte-pod-sweeper/templates/configmap.yaml
+++ b/charts/airbyte-pod-sweeper/templates/configmap.yaml
@@ -10,12 +10,12 @@ metadata:
 data:
   sweep-pod.sh: |
     #!/bin/bash
-    get_worker_pods () {
+    get_job_pods () {
         kubectl -n ${KUBE_NAMESPACE} -L airbyte -l airbyte=job-pod \
           --field-selector status.phase!=Running get pods \
           -o=jsonpath='{range .items[*]} {.metadata.name} {.status.phase} {.status.conditions[0].lastTransitionTime} {.status.startTime}{"\n"}{end}'
     }
-    delete_worker_pod() {
+    delete_pod() {
         printf "From status '%s' since '%s', " $2 $3
         echo "$1" | grep -v "STATUS" | awk '{print $1}' | xargs --no-run-if-empty kubectl -n ${KUBE_NAMESPACE} delete pod
     }
@@ -29,7 +29,7 @@ data:
         NON_SUCCESS_DATE=`date -d $NON_SUCCESS_DATE_STR +%s`
         (
             IFS=$'\n'
-            for POD in `get_worker_pods`; do
+            for POD in `get_job_pods`; do
                 IFS=' '
                 POD_NAME=`echo $POD | cut -d " " -f 1`
                 POD_STATUS=`echo $POD | cut -d " " -f 2`
@@ -38,11 +38,11 @@ data:
                 POD_DATE=`date -d ${POD_DATE_STR:-$POD_START_DATE_STR} '+%s'`
                 if [ "$POD_STATUS" = "Succeeded" ]; then
                 if [ "$POD_DATE" -lt "$SUCCESS_DATE" ]; then
-                    delete_worker_pod "$POD_NAME" "$POD_STATUS" "$POD_DATE_STR"
+                    delete_pod "$POD_NAME" "$POD_STATUS" "$POD_DATE_STR"
                 fi
                 else
                 if [ "$POD_DATE" -lt "$NON_SUCCESS_DATE" ]; then
-                    delete_worker_pod "$POD_NAME" "$POD_STATUS" "$POD_DATE_STR"
+                    delete_pod "$POD_NAME" "$POD_STATUS" "$POD_DATE_STR"
                 fi
                 fi
             done

--- a/kube/resources/pod-sweeper.yaml
+++ b/kube/resources/pod-sweeper.yaml
@@ -6,13 +6,13 @@ data:
   sweep-pod.sh: |
     #!/bin/bash
 
-    get_worker_pods () {
+    get_job_pods () {
       kubectl -n ${KUBE_NAMESPACE} -L airbyte -l airbyte=job-pod \
         --field-selector status.phase!=Running get pods \
         -o=jsonpath='{range .items[*]} {.metadata.name} {.status.phase} {.status.conditions[0].lastTransitionTime} {.status.startTime}{"\n"}{end}'
     }
 
-    delete_worker_pod() {
+    delete_pod() {
       printf "From status '%s' since '%s', " $2 $3
       echo "$1" | grep -v "STATUS" | awk '{print $1}' | xargs --no-run-if-empty kubectl -n ${KUBE_NAMESPACE} delete pod
     }
@@ -27,7 +27,7 @@ data:
       NON_SUCCESS_DATE=`date -d $NON_SUCCESS_DATE_STR +%s`
       (
           IFS=$'\n'
-          for POD in `get_worker_pods`; do
+          for POD in `get_job_pods`; do
               IFS=' '
               POD_NAME=`echo $POD | cut -d " " -f 1`
               POD_STATUS=`echo $POD | cut -d " " -f 2`
@@ -36,11 +36,11 @@ data:
               POD_DATE=`date -d ${POD_DATE_STR:-$POD_START_DATE_STR} '+%s'`
               if [ "$POD_STATUS" = "Succeeded" ]; then
                 if [ "$POD_DATE" -lt "$SUCCESS_DATE" ]; then
-                  delete_worker_pod "$POD_NAME" "$POD_STATUS" "$POD_DATE_STR"
+                  delete_pod "$POD_NAME" "$POD_STATUS" "$POD_DATE_STR"
                 fi
               else
                 if [ "$POD_DATE" -lt "$NON_SUCCESS_DATE" ]; then
-                  delete_worker_pod "$POD_NAME" "$POD_STATUS" "$POD_DATE_STR"
+                  delete_pod "$POD_NAME" "$POD_STATUS" "$POD_DATE_STR"
                 fi
               fi
           done


### PR DESCRIPTION
## What
pod sweeper was changed to sweeping job pods instead of worker pods through https://github.com/airbytehq/airbyte/pull/21829, but the method names were not changed.

## 🚨 User Impact 🚨
Change is only for code readability, no impact on behavior.
