### PR TITLE
🪟 🔧 Connector Builder frontend fixes for low_code_cdk_to_beta

### DIFF
--- a/airbyte-connector-builder-server/setup.py
+++ b/airbyte-connector-builder-server/setup.py
@@ -41,7 +41,7 @@ setup(
     },
     packages=find_packages(exclude=("unit_tests", "integration_tests", "docs")),
     package_data={},
-    install_requires=["airbyte-cdk==0.25", "fastapi", "uvicorn"],
+    install_requires=["airbyte-cdk==0.27", "fastapi", "uvicorn"],
     python_requires=">=3.9.11",
     extras_require={
         "tests": [

--- a/airbyte-webapp/src/components/connectorBuilder/types.ts
+++ b/airbyte-webapp/src/components/connectorBuilder/types.ts
@@ -582,19 +582,16 @@ function builderStreamToDeclarativeSteam(
         url_base: values.global?.urlBase,
         path: stream.urlPath,
         http_method: stream.httpMethod,
-        request_options_provider: {
-          type: "InterpolatedRequestOptionsProvider",
-          request_parameters: Object.fromEntries(stream.requestOptions.requestParameters),
-          request_headers: Object.fromEntries(stream.requestOptions.requestHeaders),
-          request_body_json: Object.fromEntries(stream.requestOptions.requestBody),
-        },
+        request_parameters: Object.fromEntries(stream.requestOptions.requestParameters),
+        request_headers: Object.fromEntries(stream.requestOptions.requestHeaders),
+        request_body_json: Object.fromEntries(stream.requestOptions.requestBody),
         authenticator: builderAuthenticatorToManifest(values.global),
       },
       record_selector: {
         type: "RecordSelector",
         extractor: {
           type: "DpathExtractor",
-          field_pointer: stream.fieldPointer,
+          field_path: stream.fieldPointer,
         },
       },
       paginator: stream.paginator
@@ -609,7 +606,6 @@ function builderStreamToDeclarativeSteam(
             },
             page_size_option: stream.paginator.pageSizeOption,
             pagination_strategy: stream.paginator.strategy,
-            url_base: values.global?.urlBase,
           }
         : { type: "NoPagination" },
       stream_slicer: builderStreamSlicerToManifest(values, stream.streamSlicer, [...visitedStreams, stream.id]),

--- a/airbyte-webapp/src/components/connectorBuilder/useManifestToBuilderForm.test.ts
+++ b/airbyte-webapp/src/components/connectorBuilder/useManifestToBuilderForm.test.ts
@@ -25,7 +25,7 @@ const stream1: DeclarativeStream = {
       type: "RecordSelector",
       extractor: {
         type: "DpathExtractor",
-        field_pointer: [],
+        field_path: [],
       },
     },
     requester: {
@@ -253,12 +253,9 @@ describe("Conversion successfully results in", () => {
         merge({}, stream1, {
           retriever: {
             requester: {
-              request_options_provider: {
-                type: "InterpolatedRequestOptionsProvider",
-                request_parameters: {
-                  k1: "v1",
-                  k2: "v2",
-                },
+              request_parameters: {
+                k1: "v1",
+                k2: "v2",
               },
             },
           },


### PR DESCRIPTION
## What
This PR address the breaking frontend changes added to low_code_cdk_to_beta so far by fixing them in the connector builder frontend.

The only breaking changes merged into low_code_cdk_to_beta so far which had an effect on the frontend were the following:
https://github.com/airbytehq/airbyte/pull/21403 (removing `request_options_provider` and moving its children up to the `requester` level)
https://github.com/airbytehq/airbyte/pull/21823 (removing `url_base` from paginator)
https://github.com/airbytehq/airbyte/pull/21990 (renaming `field_pointer` to `field_path`)

## How
This PR fixes the above breaking changes by adjusting both the YAML -> UI and the UI -> YAML conversion logic to account for the changes.
One nice thing about how we've structured the code here is that those are the only places that need to be adjusted. We can leave the frontend form structure completely untouched for these smaller changes.

In order to properly **test** these changes, this requires several manual steps:
1. `cd` into the `airbyte/airbyte-connector-builder-server` directory and follow the steps in the airbyte-connector-builder-server's [Getting started section of the README](https://github.com/airbytehq/airbyte-platform/blob/main/airbyte-connector-builder-server/README.md#getting-started), but don't yet run the `uvicorn` command. 
3. Before running the uvicorn command, execute the following to pull in the local CDK code: `pip uninstall airbyte_cdk && pip install -e $AIRBYTE_ROOT/airbyte-cdk/python/` (replacing `$AIRBYTE_ROOT` with the path to your `airbyte` repo directory)
4. Run the uvicorn command in the readme (`uvicorn connector_builder.entrypoint:app --host 0.0.0.0 --port 8080`)
5. Apply the following diff in order to point the dev webapp to the locally running uvicorn connector builder server, rather than the dockerized one:
    ```
    diff --git a/airbyte-webapp/src/config/config.ts b/airbyte-webapp/src/config/config.ts
    index f0843d0c46c..0f9b238e44c 100644
    --- a/airbyte-webapp/src/config/config.ts
    +++ b/airbyte-webapp/src/config/config.ts
    @@ -7,6 +7,7 @@ export const config: AirbyteWebappConfig = {
       },
       apiUrl: window.API_URL ?? process.env.REACT_APP_API_URL ?? `http://${window.location.hostname}:8001/api`,
       connectorBuilderApiUrl:
    +    "http://0.0.0.0:8080" ??
         window.CONNECTOR_BUILDER_API_URL ??
         process.env.REACT_APP_CONNECTOR_BUILDER_API_URL ??
         `http://${window.location.hostname}:8003`,
    ```
6. Allow `Insecure content` in your browser for localhost:3000. Find instructions for this [here](https://experienceleague.adobe.com/docs/target/using/experiences/vec/troubleshoot-composer/mixed-content.html?lang=en). This is required because our `localhost:3000` runs on HTTPS, whereas uvicorn runs on HTTP, and by default chrome does not allow an HTTPS page to make requests to an HTTP url.
7. Open `https://localhost:3000/connector-builder` and try it out!