### PR TITLE
only compute diff if the schema discovery actually succeeded

### DIFF
--- a/airbyte-commons-server/src/main/java/io/airbyte/commons/server/handlers/SchedulerHandler.java
+++ b/airbyte-commons-server/src/main/java/io/airbyte/commons/server/handlers/SchedulerHandler.java
@@ -269,7 +269,7 @@ public class SchedulerHandler {
               isCustomConnector);
       final SourceDiscoverSchemaRead discoveredSchema = retrieveDiscoveredSchema(persistedCatalogId, sourceDef);
 
-      if (discoverSchemaRequestBody.getConnectionId() != null) {
+      if (persistedCatalogId.isSuccess() && discoverSchemaRequestBody.getConnectionId() != null) {
         // modify discoveredSchema object to add CatalogDiff, containsBreakingChange, and connectionStatus
         generateCatalogDiffsAndDisableConnectionsIfNeeded(discoveredSchema, discoverSchemaRequestBody);
       }


### PR DESCRIPTION
## What
Prevent NPE when we try to diff schemas after unsuccessful schema discovery.

## How
Previously, we always tried to compute a diff. Now we only compute a diff if the discovery job was successful.

## Testing
Added unit test coverage for the unhappy path here.