### PR TITLE
fix: add or to env_vars to properly propagate global values 

### DIFF
--- a/charts/airbyte-bootloader/templates/pod.yaml
+++ b/charts/airbyte-bootloader/templates/pod.yaml
@@ -88,7 +88,7 @@ spec:
         {{- end }}
 
         # Values from env
-        {{- if .Values.env_vars }}
+        {{- if or .Values.env_vars .Values.global.env_vars }}
         {{- range $k, $v := mergeOverwrite .Values.env_vars .Values.global.env_vars }}
         - name: {{ $k }}
           value: {{ $v | quote }}

--- a/charts/airbyte-connector-builder-server/templates/deployment.yaml
+++ b/charts/airbyte-connector-builder-server/templates/deployment.yaml
@@ -53,7 +53,7 @@ spec:
               name: {{ .Release.Name }}-airbyte-env
               key: AIRBYTE_VERSION
         {{- end }}
-        
+
         # Values from secret
         {{- if .Values.secrets }}
         {{- range $k, $v := .Values.secrets }}
@@ -66,7 +66,7 @@ spec:
         {{- end }}
 
         # Values from env
-        {{- if .Values.env_vars }}
+        {{- if or .Values.env_vars .Values.global.env_vars }}
         {{- range $k, $v := mergeOverwrite .Values.env_vars .Values.global.env_vars }}
         - name: {{ $k }}
           value: {{ $v | quote }}

--- a/charts/airbyte-cron/templates/deployment.yaml
+++ b/charts/airbyte-cron/templates/deployment.yaml
@@ -82,7 +82,7 @@ spec:
               secretKeyRef:
                 name: {{ .Release.Name }}-airbyte-secrets
                 key: DATABASE_USER
-          - name: MICRONAUT_ENVIRONMENTS      
+          - name: MICRONAUT_ENVIRONMENTS
             valueFrom:
               configMapKeyRef:
                 name: {{ .Release.Name }}-airbyte-env
@@ -111,7 +111,7 @@ spec:
             valueFrom:
               configMapKeyRef:
                 name: {{ .Release.Name }}-airbyte-env
-                key: WORKSPACE_ROOT 
+                key: WORKSPACE_ROOT
           {{- end }}
 
           # Values from secret
@@ -126,7 +126,7 @@ spec:
           {{- end }}
 
           # Values from env
-          {{- if .Values.env_vars }}
+          {{- if or .Values.env_vars .Values.global.env_vars }}
           {{- range $k, $v := mergeOverwrite .Values.env_vars .Values.global.env_vars }}
           - name: {{ $k }}
             value: {{ $v | quote }}

--- a/charts/airbyte-metrics/templates/deployment.yaml
+++ b/charts/airbyte-metrics/templates/deployment.yaml
@@ -99,7 +99,7 @@ spec:
         {{- end }}
 
         # Values from env
-        {{- if .Values.env_vars }}
+        {{- if or .Values.env_vars .Values.global.env_vars }}
         {{- range $k, $v := mergeOverwrite .Values.env_vars .Values.global.env_vars }}
         - name: {{ $k }}
           value: {{ $v | quote }}

--- a/charts/airbyte-server/templates/deployment.yaml
+++ b/charts/airbyte-server/templates/deployment.yaml
@@ -243,7 +243,7 @@ spec:
         {{- end }}
 
         # Values from env
-        {{- if .Values.env_vars }}
+        {{- if or .Values.env_vars .Values.global.env_vars }}
         {{- range $k, $v := mergeOverwrite .Values.env_vars .Values.global.env_vars }}
         - name: {{ $k }}
           value: {{ $v | quote }}

--- a/charts/airbyte-temporal/templates/deployment.yaml
+++ b/charts/airbyte-temporal/templates/deployment.yaml
@@ -97,7 +97,7 @@ spec:
         {{- end }}
 
         # Values from env
-        {{- if .Values.env_vars }}
+        {{- if or .Values.env_vars .Values.global.env_vars }}
         {{- range $k, $v := mergeOverwrite .Values.env_vars .Values.global.env_vars }}
           - name: {{ $k }}
             value: {{ $v | quote }}

--- a/charts/airbyte-webapp/templates/deployment.yaml
+++ b/charts/airbyte-webapp/templates/deployment.yaml
@@ -100,7 +100,7 @@ spec:
         {{- end }}
 
         # Values from env
-        {{- if .Values.env_vars }}
+        {{- if or .Values.env_vars .Values.global.env_vars }}
         {{- range $k, $v := mergeOverwrite .Values.env_vars .Values.global.env_vars }}
         - name: {{ $k }}
           value: {{ $v | quote }}

--- a/charts/airbyte-worker/templates/deployment.yaml
+++ b/charts/airbyte-worker/templates/deployment.yaml
@@ -354,7 +354,7 @@ spec:
         {{- end }}
 
         # Values from env
-        {{- if .Values.env_vars }}
+        {{- if or .Values.env_vars .Values.global.env_vars }}
         {{- range $k, $v := mergeOverwrite .Values.env_vars .Values.global.env_vars }}
         - name: {{ $k }}
           value: {{ $v | quote }}


### PR DESCRIPTION
## What
- It repairs proper propagation of global env_vars to applications

## How
```yaml
{{- if .Values.env_vars }}
```
To this:
```yaml
{{- if or .Values.env_vars .Values.global.env_vars }}
```

Resolves: #22389 