### PR TITLE
🪟🐛 Connector form: Fix squeezed status icon

### DIFF
--- a/airbyte-webapp/src/components/ui/StatusIcon/StatusIcon.tsx
+++ b/airbyte-webapp/src/components/ui/StatusIcon/StatusIcon.tsx
@@ -46,6 +46,7 @@ const Container = styled.div<Pick<StatusIconProps, "big" | "value">>`
   text-align: center;
   display: inline-block;
   vertical-align: middle;
+  flex-shrink: 0;
 `;
 
 const Badge = styled(Container)<{ status: Exclude<StatusIconStatus, "loading"> }>`

--- a/airbyte-webapp/src/views/Connector/ConnectorForm/components/TestingConnectionError.tsx
+++ b/airbyte-webapp/src/views/Connector/ConnectorForm/components/TestingConnectionError.tsx
@@ -2,7 +2,7 @@ import React from "react";
 import { FormattedMessage } from "react-intl";
 
 import { Callout } from "components/ui/Callout";
-import { FlexContainer } from "components/ui/Flex";
+import { FlexContainer, FlexItem } from "components/ui/Flex";
 import { StatusIcon } from "components/ui/StatusIcon";
 import { Text } from "components/ui/Text";
 
@@ -12,7 +12,9 @@ const ErrorSection: React.FC<{
 }> = ({ errorMessage, errorTitle }) => (
   <Callout variant="error">
     <FlexContainer alignItems="flex-start" gap="sm">
-      <StatusIcon />
+      <FlexItem>
+        <StatusIcon />
+      </FlexItem>
       <FlexContainer direction="column">
         <Text size="lg">{errorTitle}</Text>
         <Text>{errorMessage}</Text>

--- a/airbyte-webapp/src/views/Connector/ConnectorForm/components/TestingConnectionError.tsx
+++ b/airbyte-webapp/src/views/Connector/ConnectorForm/components/TestingConnectionError.tsx
@@ -2,7 +2,7 @@ import React from "react";
 import { FormattedMessage } from "react-intl";
 
 import { Callout } from "components/ui/Callout";
-import { FlexContainer, FlexItem } from "components/ui/Flex";
+import { FlexContainer } from "components/ui/Flex";
 import { StatusIcon } from "components/ui/StatusIcon";
 import { Text } from "components/ui/Text";
 
@@ -12,9 +12,7 @@ const ErrorSection: React.FC<{
 }> = ({ errorMessage, errorTitle }) => (
   <Callout variant="error">
     <FlexContainer alignItems="flex-start" gap="sm">
-      <FlexItem>
-        <StatusIcon />
-      </FlexItem>
+      <StatusIcon />
       <FlexContainer direction="column">
         <Text size="lg">{errorTitle}</Text>
         <Text>{errorMessage}</Text>


### PR DESCRIPTION
If the space is tight, the status icon in the connector form can be shown in a squeezed way. This PR makes sure it's always shown properly by preventing it to shrink in a flex context:
<img width="450" alt="Screenshot 2023-02-05 at 16 47 45" src="https://user-images.githubusercontent.com/1508364/216857478-b227575d-1d83-44e0-bf75-a3acc167c6a3.png">
<img width="460" alt="Screenshot 2023-02-05 at 16 48 54" src="https://user-images.githubusercontent.com/1508364/216857480-e62ea4d3-c4ee-464f-8dac-027e8e06fbfc.png">

I know this is changing a styled component without converting it and I started this work but then realized there's a bit more work to that because there are so many special cases and doing it right would require quite a bit of refactoring. I will create a separate issue for that and tackle it as a filler once I find the time