### PR TITLE
Use shallow clone in the getting started example

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,7 +47,7 @@ Explore our [demo app](https://demo.airbyte.io/).
 You can run Airbyte locally with Docker.
 
 ```bash
-git clone https://github.com/airbytehq/airbyte.git
+git clone --depth 1 https://github.com/airbytehq/airbyte.git
 cd airbyte
 docker compose up
 ```


### PR DESCRIPTION
## What
The AirByte repository got pretty big. This results in rather long clone time for getting started, which is mostly redundant. By using the `--depth` option the clone becomes much faster.

## How
Minor update in the main README file.
Add `--depth 1` for the clone example.

## 🚨 User Impact 🚨
In case of users without experience with git changing branches can be harder after clone.
