### PR TITLE
🪟 🔧 Fix pnpm cache path

### DIFF
--- a/.github/actions/cache-build-artifacts/action.yml
+++ b/.github/actions/cache-build-artifacts/action.yml
@@ -35,7 +35,7 @@ runs:
       uses: actions/cache@v3
       with:
         path: |
-          ~/.pnpm-store
+          ~/.local/share/pnpm/store
         key: ${{ inputs.cache-key }}-pnpm-${{ runner.os }}-${{ hashFiles('**/pnpm-lock.yaml') }}
         restore-keys: |
           ${{ inputs.cache-key }}-pnpm-${{ runner.os }}-


### PR DESCRIPTION
## What

Fixes the path our cache action caches to the actual path pnpm uses since 7+. Currently this will simply not cache anything.

Why in general hard-code this and not call `pnpm store path` in the CI to determine this? Unfortunately we only use `pnpm` as part of the gradle build, i.e. gradle manage and installs it locally for running the `PnpmTasks`, therefore we don't have access here to the `pnpm` command.

Can now see that this is caching properly: https://github.com/airbytehq/airbyte/actions/runs/4105643245/jobs/7082836185#step:17:8 compared to https://github.com/airbytehq/airbyte/actions/runs/4105203337/jobs/7081776144#step:17:8 on master which doesn't cache `pnpm` properly yet.