### PR TITLE
fix eslint issues for webapp

### DIFF
--- a/airbyte-webapp/src/components/EntityTable/ConnectionTable.tsx
+++ b/airbyte-webapp/src/components/EntityTable/ConnectionTable.tsx
@@ -10,7 +10,6 @@ import { ConnectionScheduleType, SchemaChange } from "core/request/AirbyteClient
 import { FeatureItem, useFeature } from "hooks/services/Feature";
 import { useQuery } from "hooks/useQuery";
 
-import { NextTable } from "../ui/NextTable";
 import ConnectionSettingsCell from "./components/ConnectionSettingsCell";
 import { ConnectionStatusCell } from "./components/ConnectionStatusCell";
 import { ConnectorNameCell } from "./components/ConnectorNameCell";
@@ -19,6 +18,7 @@ import { LastSyncCell } from "./components/LastSyncCell";
 import { StatusCell } from "./components/StatusCell";
 import styles from "./ConnectionTable.module.scss";
 import { ConnectionTableDataItem, SortOrderEnum } from "./types";
+import { NextTable } from "../ui/NextTable";
 
 interface ConnectionTableProps {
   data: ConnectionTableDataItem[];

--- a/airbyte-webapp/src/components/EntityTable/components/ConnectionStatusCell.tsx
+++ b/airbyte-webapp/src/components/EntityTable/components/ConnectionStatusCell.tsx
@@ -4,9 +4,9 @@ import { useIntl } from "react-intl";
 import { StatusIcon } from "components/ui/StatusIcon";
 import { StatusIconStatus } from "components/ui/StatusIcon/StatusIcon";
 
-import { Status } from "../types";
 import styles from "./ConnectionStatusCell.module.scss";
 import { EntityNameCell } from "./EntityNameCell";
+import { Status } from "../types";
 
 interface ConnectionStatusCellProps {
   status: string | null;

--- a/airbyte-webapp/src/components/common/ConfirmationModal/ConfirmationModal.tsx
+++ b/airbyte-webapp/src/components/common/ConfirmationModal/ConfirmationModal.tsx
@@ -4,8 +4,8 @@ import { FormattedMessage } from "react-intl";
 import { Button } from "components/ui/Button";
 import { Modal } from "components/ui/Modal";
 
-import useLoadingState from "../../../hooks/useLoadingState";
 import styles from "./ConfirmationModal.module.scss";
+import useLoadingState from "../../../hooks/useLoadingState";
 
 export interface ConfirmationModalProps {
   onClose: () => void;

--- a/airbyte-webapp/src/components/connection/CatalogTree/next/CatalogTreeTableRow.tsx
+++ b/airbyte-webapp/src/components/connection/CatalogTree/next/CatalogTreeTableRow.tsx
@@ -9,13 +9,13 @@ import { Text } from "components/ui/Text";
 
 import { useBulkEditSelect } from "hooks/services/BulkEdit/BulkEditService";
 
-import { StreamHeaderProps } from "../StreamHeader";
 import { CatalogTreeTableCell } from "./CatalogTreeTableCell";
 import styles from "./CatalogTreeTableRow.module.scss";
 import { CatalogTreeTableRowIcon } from "./CatalogTreeTableRowIcon";
 import { StreamPathSelect } from "./StreamPathSelect";
 import { SyncModeSelect } from "./SyncModeSelect";
 import { useCatalogTreeTableRowProps } from "./useCatalogTreeTableRowProps";
+import { StreamHeaderProps } from "../StreamHeader";
 
 export const CatalogTreeTableRow: React.FC<StreamHeaderProps> = ({
   stream,

--- a/airbyte-webapp/src/components/connection/CatalogTree/next/StreamDetailsPanel/StreamFieldsTable/CursorCell/CursorCell.tsx
+++ b/airbyte-webapp/src/components/connection/CatalogTree/next/StreamDetailsPanel/StreamFieldsTable/CursorCell/CursorCell.tsx
@@ -7,8 +7,8 @@ import { Tooltip, TooltipLearnMoreLink } from "components/ui/Tooltip";
 
 import { links } from "utils/links";
 
-import { TableStream } from "../StreamFieldsTable";
 import styles from "./CursorCell.module.scss";
+import { TableStream } from "../StreamFieldsTable";
 
 interface CursorCellProps extends CellContext<TableStream, boolean | undefined> {
   isCursorDefinitionSupported: boolean;

--- a/airbyte-webapp/src/components/connection/CatalogTree/next/StreamDetailsPanel/StreamFieldsTable/StreamFieldsTable.tsx
+++ b/airbyte-webapp/src/components/connection/CatalogTree/next/StreamDetailsPanel/StreamFieldsTable/StreamFieldsTable.tsx
@@ -17,12 +17,12 @@ import { useConnectionFormService } from "hooks/services/ConnectionForm/Connecti
 import { useExperiment } from "hooks/services/Experiment";
 import { getDataType } from "utils/useTranslateDataType";
 
-import { CatalogTreeTableCell } from "../../CatalogTreeTableCell";
 import { ConnectorHeaderGroupIcon } from "./ConnectorHeaderGroupIcon";
 import { CursorCell } from "./CursorCell";
 import { PKCell } from "./PKCell";
 import styles from "./StreamFieldsTable.module.scss";
 import { SyncFieldCell } from "./SyncFieldCell";
+import { CatalogTreeTableCell } from "../../CatalogTreeTableCell";
 
 export interface TableStream {
   field: SyncSchemaField;

--- a/airbyte-webapp/src/components/connectorBuilder/Builder/InputsForm.tsx
+++ b/airbyte-webapp/src/components/connectorBuilder/Builder/InputsForm.tsx
@@ -13,9 +13,9 @@ import { FormikPatch } from "core/form/FormikPatch";
 import { AirbyteJSONSchema } from "core/jsonSchema/types";
 import { useAnalyticsService } from "hooks/services/Analytics";
 
-import { BuilderFormInput, BuilderFormValues, getInferredInputs } from "../types";
 import { BuilderField } from "./BuilderField";
 import styles from "./InputsForm.module.scss";
+import { BuilderFormInput, BuilderFormValues, getInferredInputs } from "../types";
 
 const supportedTypes = ["string", "integer", "number", "array", "boolean", "enum", "unknown"] as const;
 
@@ -25,7 +25,7 @@ export interface InputInEditing {
   required: boolean;
   isNew?: boolean;
   showDefaultValueField: boolean;
-  type: typeof supportedTypes[number];
+  type: (typeof supportedTypes)[number];
   isInferredInputOverride: boolean;
 }
 

--- a/airbyte-webapp/src/components/connectorBuilder/StreamTestingPanel/StreamSelector.tsx
+++ b/airbyte-webapp/src/components/connectorBuilder/StreamTestingPanel/StreamSelector.tsx
@@ -12,8 +12,8 @@ import {
   useConnectorBuilderFormState,
 } from "services/connectorBuilder/ConnectorBuilderStateService";
 
-import { ReactComponent as CaretDownIcon } from "../../ui/ListBox/CaretDownIcon.svg";
 import styles from "./StreamSelector.module.scss";
+import { ReactComponent as CaretDownIcon } from "../../ui/ListBox/CaretDownIcon.svg";
 
 interface StreamSelectorProps {
   className?: string;

--- a/airbyte-webapp/src/components/connectorBuilder/StreamTestingPanel/StreamTestButton.tsx
+++ b/airbyte-webapp/src/components/connectorBuilder/StreamTestingPanel/StreamTestButton.tsx
@@ -9,8 +9,8 @@ import { Tooltip } from "components/ui/Tooltip";
 
 import { useConnectorBuilderFormState } from "services/connectorBuilder/ConnectorBuilderStateService";
 
-import { useBuilderErrors } from "../useBuilderErrors";
 import styles from "./StreamTestButton.module.scss";
+import { useBuilderErrors } from "../useBuilderErrors";
 
 interface StreamTestButtonProps {
   readStream: () => void;

--- a/airbyte-webapp/src/components/connectorBuilder/YamlEditor/YamlEditor.tsx
+++ b/airbyte-webapp/src/components/connectorBuilder/YamlEditor/YamlEditor.tsx
@@ -14,11 +14,11 @@ import { useAnalyticsService } from "hooks/services/Analytics";
 import { useConfirmationModalService } from "hooks/services/ConfirmationModal";
 import { useConnectorBuilderFormState } from "services/connectorBuilder/ConnectorBuilderStateService";
 
+import styles from "./YamlEditor.module.scss";
 import { UiYamlToggleButton } from "../Builder/UiYamlToggleButton";
 import { DownloadYamlButton } from "../DownloadYamlButton";
 import { convertToManifest } from "../types";
 import { useManifestToBuilderForm } from "../useManifestToBuilderForm";
-import styles from "./YamlEditor.module.scss";
 
 interface YamlEditorProps {
   toggleYamlEditor: () => void;

--- a/airbyte-webapp/src/core/request/apiOverride.ts
+++ b/airbyte-webapp/src/core/request/apiOverride.ts
@@ -1,7 +1,7 @@
-import { AirbyteWebappConfig } from "../../config";
 import { CommonRequestError } from "./CommonRequestError";
 import { RequestMiddleware } from "./RequestMiddleware";
 import { VersionError } from "./VersionError";
+import { AirbyteWebappConfig } from "../../config";
 
 export interface ApiOverrideRequestOptions {
   config: Pick<AirbyteWebappConfig, "apiUrl">;

--- a/airbyte-webapp/src/hooks/services/ConnectionEdit/ConnectionEditService.test.tsx
+++ b/airbyte-webapp/src/hooks/services/ConnectionEdit/ConnectionEditService.test.tsx
@@ -12,8 +12,8 @@ import { TestWrapper } from "test-utils/testutils";
 
 import { WebBackendConnectionRead, WebBackendConnectionUpdate } from "core/request/AirbyteClient";
 
-import { useConnectionFormService } from "../ConnectionForm/ConnectionFormService";
 import { ConnectionEditServiceProvider, useConnectionEditService } from "./ConnectionEditService";
+import { useConnectionFormService } from "../ConnectionForm/ConnectionFormService";
 
 jest.mock("services/connector/SourceDefinitionService", () => ({
   useSourceDefinition: () => mockSourceDefinition,

--- a/airbyte-webapp/src/hooks/services/useConnectionHook.tsx
+++ b/airbyte-webapp/src/hooks/services/useConnectionHook.tsx
@@ -12,6 +12,10 @@ import { ConnectionService } from "core/domain/connection/ConnectionService";
 import { useInitService } from "services/useInitService";
 import { useCurrentWorkspaceId } from "services/workspaces/WorkspacesService";
 
+import { useAnalyticsService } from "./Analytics";
+import { useAppMonitoringService } from "./AppMonitoringService";
+import { useNotificationService } from "./Notification";
+import { useCurrentWorkspace } from "./useWorkspace";
 import { useConfig } from "../../config";
 import {
   ConnectionScheduleData,
@@ -31,10 +35,6 @@ import {
 import { useSuspenseQuery } from "../../services/connector/useSuspenseQuery";
 import { SCOPE_WORKSPACE } from "../../services/Scope";
 import { useDefaultRequestMiddlewares } from "../../services/useDefaultRequestMiddlewares";
-import { useAnalyticsService } from "./Analytics";
-import { useAppMonitoringService } from "./AppMonitoringService";
-import { useNotificationService } from "./Notification";
-import { useCurrentWorkspace } from "./useWorkspace";
 
 export const connectionsKeys = {
   all: [SCOPE_WORKSPACE, "connections"] as const,

--- a/airbyte-webapp/src/hooks/services/useConnectorAuth.tsx
+++ b/airbyte-webapp/src/hooks/services/useConnectorAuth.tsx
@@ -13,11 +13,11 @@ import { DestinationOauthConsentRequest, SourceOauthConsentRequest } from "core/
 import { isCommonRequestError } from "core/request/CommonRequestError";
 import { useConnectorForm } from "views/Connector/ConnectorForm/connectorFormContext";
 
-import { useDefaultRequestMiddlewares } from "../../services/useDefaultRequestMiddlewares";
-import { useQuery } from "../useQuery";
 import { useAppMonitoringService } from "./AppMonitoringService";
 import { useNotificationService } from "./Notification";
 import { useCurrentWorkspace } from "./useWorkspace";
+import { useDefaultRequestMiddlewares } from "../../services/useDefaultRequestMiddlewares";
+import { useQuery } from "../useQuery";
 
 let windowObjectReference: Window | null = null; // global variable
 

--- a/airbyte-webapp/src/hooks/services/useDestinationHook.tsx
+++ b/airbyte-webapp/src/hooks/services/useDestinationHook.tsx
@@ -7,14 +7,14 @@ import { DestinationService } from "core/domain/connector/DestinationService";
 import { useInitService } from "services/useInitService";
 import { isDefined } from "utils/common";
 
+import { useAnalyticsService } from "./Analytics";
+import { useRemoveConnectionsFromList } from "./useConnectionHook";
+import { useCurrentWorkspace } from "./useWorkspace";
 import { useConfig } from "../../config";
 import { DestinationRead, WebBackendConnectionListItem } from "../../core/request/AirbyteClient";
 import { useSuspenseQuery } from "../../services/connector/useSuspenseQuery";
 import { SCOPE_WORKSPACE } from "../../services/Scope";
 import { useDefaultRequestMiddlewares } from "../../services/useDefaultRequestMiddlewares";
-import { useAnalyticsService } from "./Analytics";
-import { useRemoveConnectionsFromList } from "./useConnectionHook";
-import { useCurrentWorkspace } from "./useWorkspace";
 
 export const destinationsKeys = {
   all: [SCOPE_WORKSPACE, "destinations"] as const,

--- a/airbyte-webapp/src/hooks/services/useSourceHook.tsx
+++ b/airbyte-webapp/src/hooks/services/useSourceHook.tsx
@@ -10,13 +10,13 @@ import { JobInfo } from "core/domain/job";
 import { useInitService } from "services/useInitService";
 import { isDefined } from "utils/common";
 
+import { useAnalyticsService } from "./Analytics";
+import { useRemoveConnectionsFromList } from "./useConnectionHook";
+import { useCurrentWorkspace } from "./useWorkspace";
 import { SourceRead, WebBackendConnectionListItem } from "../../core/request/AirbyteClient";
 import { useSuspenseQuery } from "../../services/connector/useSuspenseQuery";
 import { SCOPE_WORKSPACE } from "../../services/Scope";
 import { useDefaultRequestMiddlewares } from "../../services/useDefaultRequestMiddlewares";
-import { useAnalyticsService } from "./Analytics";
-import { useRemoveConnectionsFromList } from "./useConnectionHook";
-import { useCurrentWorkspace } from "./useWorkspace";
 
 export const sourcesKeys = {
   all: [SCOPE_WORKSPACE, "sources"] as const,

--- a/airbyte-webapp/src/packages/cloud/cloudRoutes.tsx
+++ b/airbyte-webapp/src/packages/cloud/cloudRoutes.tsx
@@ -14,12 +14,12 @@ import { useCurrentWorkspace, WorkspaceServiceProvider } from "services/workspac
 import { setSegmentAnonymousId, useGetSegmentAnonymousId } from "utils/crossDomainUtils";
 import { CompleteOauthRequest } from "views/CompleteOauthRequest";
 
-import { RoutePaths, DestinationPaths } from "../../pages/routePaths";
 import { CloudRoutes } from "./cloudRoutePaths";
 import { CreditStatus } from "./lib/domain/cloudWorkspaces/types";
 import { LDExperimentServiceProvider } from "./services/thirdParty/launchdarkly";
 import { useGetCloudWorkspace } from "./services/workspaces/CloudWorkspacesService";
 import { VerifyEmailAction } from "./views/FirebaseActionRoute";
+import { RoutePaths, DestinationPaths } from "../../pages/routePaths";
 
 const MainView = React.lazy(() => import("packages/cloud/views/layout/MainView"));
 const WorkspacesPage = React.lazy(() => import("packages/cloud/views/workspaces"));

--- a/airbyte-webapp/src/packages/cloud/views/auth/components/GitBlock/GitBlock.test.tsx
+++ b/airbyte-webapp/src/packages/cloud/views/auth/components/GitBlock/GitBlock.test.tsx
@@ -3,8 +3,8 @@ import { IntlProvider } from "react-intl";
 
 import { ConfigContext, config } from "config";
 
-import en from "../../../../locales/en.json";
 import { GitBlock, GitBlockProps } from "./GitBlock";
+import en from "../../../../locales/en.json";
 
 const renderGitBlock = (props?: GitBlockProps) =>
   render(

--- a/airbyte-webapp/src/pages/connections/ConnectionPage/ConnectionPageTitle.tsx
+++ b/airbyte-webapp/src/pages/connections/ConnectionPage/ConnectionPageTitle.tsx
@@ -16,8 +16,8 @@ import { useConnectionEditService } from "hooks/services/ConnectionEdit/Connecti
 import { useFeature, FeatureItem } from "hooks/services/Feature";
 import { InlineEnrollmentCallout } from "packages/cloud/components/experiments/FreeConnectorProgram/InlineEnrollmentCallout";
 
-import { ConnectionRoutePaths } from "../types";
 import styles from "./ConnectionPageTitle.module.scss";
+import { ConnectionRoutePaths } from "../types";
 
 export const ConnectionPageTitle: React.FC = () => {
   const params = useParams<{ id: string; "*": ConnectionRoutePaths }>();

--- a/airbyte-webapp/src/pages/destination/DestinationSettingsPage/DestinationSettingsPage.tsx
+++ b/airbyte-webapp/src/pages/destination/DestinationSettingsPage/DestinationSettingsPage.tsx
@@ -16,8 +16,8 @@ import { useGetDestinationDefinitionSpecification } from "services/connector/Des
 import { ConnectorCard } from "views/Connector/ConnectorCard";
 import { ConnectorCardValues } from "views/Connector/ConnectorForm/types";
 
-import { DestinationOutletContext } from "../types";
 import styles from "./DestinationSettings.module.scss";
+import { DestinationOutletContext } from "../types";
 
 export const DestinationSettingsPage: React.FC = () => {
   const { destination } = useOutletContext<DestinationOutletContext>();

--- a/airbyte-webapp/src/pages/routes.tsx
+++ b/airbyte-webapp/src/pages/routes.tsx
@@ -10,8 +10,8 @@ import { useListWorkspaces } from "services/workspaces/WorkspacesService";
 import { CompleteOauthRequest } from "views/CompleteOauthRequest";
 import MainView from "views/layout/MainView";
 
-import { WorkspaceRead } from "../core/request/AirbyteClient";
 import { RoutePaths, DestinationPaths } from "./routePaths";
+import { WorkspaceRead } from "../core/request/AirbyteClient";
 
 const ConnectionsRoutes = React.lazy(() => import("./connections/ConnectionsRoutes"));
 const CreateConnectionPage = React.lazy(() => import("./connections/CreateConnectionPage"));

--- a/airbyte-webapp/src/views/Connector/ConnectorCard/ConnectorCard.tsx
+++ b/airbyte-webapp/src/views/Connector/ConnectorCard/ConnectorCard.tsx
@@ -14,14 +14,14 @@ import { LogsRequestError } from "core/request/LogsRequestError";
 import { generateMessageFromError } from "utils/errorStatusMessage";
 import { ConnectorCardValues, ConnectorForm, ConnectorFormValues } from "views/Connector/ConnectorForm";
 
-import { useDocumentationPanelContext } from "../ConnectorDocumentationLayout/DocumentationPanelContext";
-import { ConnectorDefinitionTypeControl } from "../ConnectorForm/components/Controls/ConnectorServiceTypeControl";
-import { FetchingConnectorError } from "../ConnectorForm/components/TestingConnectionError";
 import { Controls } from "./components/Controls";
 import ShowLoadingMessage from "./components/ShowLoadingMessage";
 import styles from "./ConnectorCard.module.scss";
 import { useAnalyticsTrackFunctions } from "./useAnalyticsTrackFunctions";
 import { useTestConnector } from "./useTestConnector";
+import { useDocumentationPanelContext } from "../ConnectorDocumentationLayout/DocumentationPanelContext";
+import { ConnectorDefinitionTypeControl } from "../ConnectorForm/components/Controls/ConnectorServiceTypeControl";
+import { FetchingConnectorError } from "../ConnectorForm/components/TestingConnectionError";
 
 // TODO: need to clean up the ConnectorCard and ConnectorForm props,
 // since some of props are used in both components, and some of them used just as a prop-drill

--- a/airbyte-webapp/src/views/Connector/ConnectorCard/components/TestCard.tsx
+++ b/airbyte-webapp/src/views/Connector/ConnectorCard/components/TestCard.tsx
@@ -12,9 +12,9 @@ import { Text } from "components/ui/Text";
 
 import { SynchronousJobRead } from "core/request/AirbyteClient";
 
-import { TestingConnectionError } from "../../ConnectorForm/components/TestingConnectionError";
 import styles from "./TestCard.module.scss";
 import TestingConnectionSuccess from "./TestingConnectionSuccess";
+import { TestingConnectionError } from "../../ConnectorForm/components/TestingConnectionError";
 
 interface IProps {
   formType: "source" | "destination";

--- a/airbyte-webapp/src/views/Connector/ConnectorForm/ConnectorForm.test.tsx
+++ b/airbyte-webapp/src/views/Connector/ConnectorForm/ConnectorForm.test.tsx
@@ -10,8 +10,8 @@ import { AirbyteJSONSchema } from "core/jsonSchema/types";
 import { DestinationDefinitionSpecificationRead } from "core/request/AirbyteClient";
 import { ConnectorForm } from "views/Connector/ConnectorForm";
 
-import { DocumentationPanelContext } from "../ConnectorDocumentationLayout/DocumentationPanelContext";
 import { ConnectorFormValues } from "./types";
+import { DocumentationPanelContext } from "../ConnectorDocumentationLayout/DocumentationPanelContext";
 
 // hack to fix tests. https://github.com/remarkjs/react-markdown/issues/635
 jest.mock("components/ui/Markdown", () => ({ children }: React.PropsWithChildren<unknown>) => <>{children}</>);

--- a/airbyte-webapp/src/views/Connector/ConnectorForm/components/Controls/ConnectorServiceTypeControl/ConnectorDefinitionTypeControl.tsx
+++ b/airbyte-webapp/src/views/Connector/ConnectorForm/components/Controls/ConnectorServiceTypeControl/ConnectorDefinitionTypeControl.tsx
@@ -29,10 +29,10 @@ import { FreeTag } from "packages/cloud/components/experiments/FreeConnectorProg
 import { useDocumentationPanelContext } from "views/Connector/ConnectorDocumentationLayout/DocumentationPanelContext";
 import RequestConnectorModal from "views/Connector/RequestConnectorModal";
 
-import { WarningMessage } from "../../WarningMessage";
 import styles from "./ConnectorServiceTypeControl.module.scss";
 import { useAnalyticsTrackFunctions } from "./useAnalyticsTrackFunctions";
 import { getSortedDropdownDataUsingExperiment } from "./utils";
+import { WarningMessage } from "../../WarningMessage";
 
 // eslint-disable-next-line @typescript-eslint/no-explicit-any
 type MenuWithRequestButtonProps = MenuListProps<DropDownOptionDataItem, false> & { selectProps: any };

--- a/airbyte-webapp/src/views/Connector/ConnectorForm/components/Sections/auth/AuthSection.tsx
+++ b/airbyte-webapp/src/views/Connector/ConnectorForm/components/Sections/auth/AuthSection.tsx
@@ -4,8 +4,8 @@ import { isSourceDefinitionSpecificationDraft } from "core/domain/connector/sour
 import { FeatureItem, IfFeatureEnabled } from "hooks/services/Feature";
 import { useConnectorForm } from "views/Connector/ConnectorForm/connectorFormContext";
 
-import { SectionContainer } from "../SectionContainer";
 import { AuthButton } from "./AuthButton";
+import { SectionContainer } from "../SectionContainer";
 
 export const AuthSection: React.FC = () => {
   const { selectedConnectorDefinitionSpecification } = useConnectorForm();


### PR DESCRIPTION
## What
An earlier merge from master caused imports in airbyte-webapp to be incorrectly ordered. 

This PR fixes those issues.

## How
Ran `npm run lint -- --fix` in the airbyte-webapp/ directory to generate these fixes and bring the low_code_cdk_to_beta branch in sync with master.
