### PR TITLE
feat: Setting concurrency for Airbyte CI workflow

### DIFF
--- a/.github/workflows/gradle.yml
+++ b/.github/workflows/gradle.yml
@@ -1,5 +1,9 @@
 name: Airbyte CI
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
 env:
   S3_BUILD_CACHE_ACCESS_KEY_ID: ${{ secrets.SELF_RUNNER_AWS_ACCESS_KEY_ID }}
   S3_BUILD_CACHE_SECRET_KEY: ${{ secrets.SELF_RUNNER_AWS_SECRET_ACCESS_KEY }}


### PR DESCRIPTION
## What
[Airbyte CI](https://github.com/airbytehq/airbyte/actions/workflows/gradle.yml) workflow is executed when pushing a commit to the branch meanwhile the workflow is being already executed by a previous pushed commit.

On average this test takes around 35 minutes, with some peaks of more than 1 hour.
This ends into wasted resources, as new pushes overwrites workflow results.

## How
To avoid resource wasting, we can make use of `concurrency` [keyword](https://docs.github.com/en/actions/using-workflows/workflow-syntax-for-github-actions#concurrency), cancelling the workflow for the same branch.