### PR TITLE
document that web backends should not have db access

### DIFF
--- a/airbyte-commons-server/src/main/java/io/airbyte/commons/server/handlers/WebBackendCheckUpdatesHandler.java
+++ b/airbyte-commons-server/src/main/java/io/airbyte/commons/server/handlers/WebBackendCheckUpdatesHandler.java
@@ -18,17 +18,24 @@ import java.util.UUID;
 import java.util.stream.Collectors;
 import lombok.extern.slf4j.Slf4j;
 
+/**
+ * The web backend is an abstraction that allows the frontend to structure data in such a way that
+ * it is easier for a react frontend to consume. It should NOT have direct access to the database.
+ * It should operate exclusively by calling other endpoints that are exposed in the API.
+ **/
 @Slf4j
 @Singleton
 public class WebBackendCheckUpdatesHandler {
 
   private static final int NO_CHANGES_FOUND = 0;
 
-  final ConfigRepository configRepository;
+  // todo (cgardens) - this handler should NOT have access to the db. only access via handler.
+  @Deprecated
+  final ConfigRepository configRepositoryDoNotUse;
   final AirbyteGithubStore githubStore;
 
-  public WebBackendCheckUpdatesHandler(final ConfigRepository configRepository, final AirbyteGithubStore githubStore) {
-    this.configRepository = configRepository;
+  public WebBackendCheckUpdatesHandler(final ConfigRepository configRepositoryDoNotUse, final AirbyteGithubStore githubStore) {
+    this.configRepositoryDoNotUse = configRepositoryDoNotUse;
     this.githubStore = githubStore;
   }
 
@@ -47,7 +54,7 @@ public class WebBackendCheckUpdatesHandler {
     final Map<UUID, String> newActorDefToDockerImageTag;
 
     try {
-      currentActorDefToDockerImageTag = configRepository.listStandardDestinationDefinitions(false)
+      currentActorDefToDockerImageTag = configRepositoryDoNotUse.listStandardDestinationDefinitions(false)
           .stream()
           .map(def -> Map.entry(def.getDestinationDefinitionId(), def.getDockerImageTag()))
           .toList();
@@ -73,7 +80,7 @@ public class WebBackendCheckUpdatesHandler {
     final Map<UUID, String> newActorDefToDockerImageTag;
 
     try {
-      currentActorDefToDockerImageTag = configRepository.listStandardSourceDefinitions(false)
+      currentActorDefToDockerImageTag = configRepositoryDoNotUse.listStandardSourceDefinitions(false)
           .stream()
           .map(def -> Map.entry(def.getSourceDefinitionId(), def.getDockerImageTag()))
           .toList();

--- a/airbyte-commons-server/src/main/java/io/airbyte/commons/server/handlers/WebBackendConnectionsHandler.java
+++ b/airbyte-commons-server/src/main/java/io/airbyte/commons/server/handlers/WebBackendConnectionsHandler.java
@@ -75,6 +75,11 @@ import java.util.UUID;
 import java.util.function.Function;
 import java.util.stream.Collectors;
 
+/**
+ * The web backend is an abstraction that allows the frontend to structure data in such a way that
+ * it is easier for a react frontend to consume. It should NOT have direct access to the database.
+ * It should operate exclusively by calling other endpoints that are exposed in the API.
+ **/
 @Singleton
 public class WebBackendConnectionsHandler {
 
@@ -87,7 +92,8 @@ public class WebBackendConnectionsHandler {
   private final OperationsHandler operationsHandler;
   private final EventRunner eventRunner;
   // todo (cgardens) - this handler should NOT have access to the db. only access via handler.
-  private final ConfigRepository configRepository;
+  @Deprecated
+  private final ConfigRepository configRepositoryDoNotUse;
 
   public WebBackendConnectionsHandler(final ConnectionsHandler connectionsHandler,
                                       final StateHandler stateHandler,
@@ -97,7 +103,7 @@ public class WebBackendConnectionsHandler {
                                       final SchedulerHandler schedulerHandler,
                                       final OperationsHandler operationsHandler,
                                       final EventRunner eventRunner,
-                                      final ConfigRepository configRepository) {
+                                      final ConfigRepository configRepositoryDoNotUse) {
     this.connectionsHandler = connectionsHandler;
     this.stateHandler = stateHandler;
     this.sourceHandler = sourceHandler;
@@ -106,14 +112,14 @@ public class WebBackendConnectionsHandler {
     this.schedulerHandler = schedulerHandler;
     this.operationsHandler = operationsHandler;
     this.eventRunner = eventRunner;
-    this.configRepository = configRepository;
+    this.configRepositoryDoNotUse = configRepositoryDoNotUse;
   }
 
   public WebBackendWorkspaceStateResult getWorkspaceState(final WebBackendWorkspaceState webBackendWorkspaceState) throws IOException {
     final var workspaceId = webBackendWorkspaceState.getWorkspaceId();
-    final var connectionCount = configRepository.countConnectionsForWorkspace(workspaceId);
-    final var destinationCount = configRepository.countDestinationsForWorkspace(workspaceId);
-    final var sourceCount = configRepository.countSourcesForWorkspace(workspaceId);
+    final var connectionCount = configRepositoryDoNotUse.countConnectionsForWorkspace(workspaceId);
+    final var destinationCount = configRepositoryDoNotUse.countDestinationsForWorkspace(workspaceId);
+    final var sourceCount = configRepositoryDoNotUse.countSourcesForWorkspace(workspaceId);
 
     return new WebBackendWorkspaceStateResult()
         .hasConnections(connectionCount > 0)
@@ -135,7 +141,7 @@ public class WebBackendConnectionsHandler {
         // passing 'false' so that deleted connections are not included
         false);
 
-    final List<StandardSync> standardSyncs = configRepository.listWorkspaceStandardSyncs(query);
+    final List<StandardSync> standardSyncs = configRepositoryDoNotUse.listWorkspaceStandardSyncs(query);
     final List<UUID> sourceIds = standardSyncs.stream().map(StandardSync::getSourceId).toList();
     final List<UUID> destinationIds = standardSyncs.stream().map(StandardSync::getDestinationId).toList();
     final List<UUID> connectionIds = standardSyncs.stream().map(StandardSync::getConnectionId).toList();
@@ -148,7 +154,7 @@ public class WebBackendConnectionsHandler {
     // right status filtering for this.
     final Map<UUID, JobRead> runningJobByConnectionId = getRunningJobByConnectionId(connectionIds);
     final Map<UUID, ActorCatalogFetchEvent> newestFetchEventsByActorId =
-        configRepository.getMostRecentActorCatalogFetchEventForSources(sourceIds);
+        configRepositoryDoNotUse.getMostRecentActorCatalogFetchEventForSources(sourceIds);
 
     final List<WebBackendConnectionListItem> connectionItems = Lists.newArrayList();
 
@@ -177,14 +183,14 @@ public class WebBackendConnectionsHandler {
   }
 
   private Map<UUID, SourceSnippetRead> getSourceSnippetReadById(final List<UUID> sourceIds) throws IOException {
-    return configRepository.getSourceAndDefinitionsFromSourceIds(sourceIds)
+    return configRepositoryDoNotUse.getSourceAndDefinitionsFromSourceIds(sourceIds)
         .stream()
         .map(sourceAndDefinition -> SourceHandler.toSourceSnippetRead(sourceAndDefinition.source(), sourceAndDefinition.definition()))
         .collect(Collectors.toMap(SourceSnippetRead::getSourceId, Function.identity()));
   }
 
   private Map<UUID, DestinationSnippetRead> getDestinationSnippetReadById(final List<UUID> destinationIds) throws IOException {
-    return configRepository.getDestinationAndDefinitionsFromDestinationIds(destinationIds)
+    return configRepositoryDoNotUse.getDestinationAndDefinitionsFromDestinationIds(destinationIds)
         .stream()
         .map(destinationAndDefinition -> DestinationHandler.toDestinationSnippetRead(destinationAndDefinition.destination(),
             destinationAndDefinition.definition()))
@@ -210,7 +216,7 @@ public class WebBackendConnectionsHandler {
     });
 
     final Optional<ActorCatalogFetchEvent> mostRecentFetchEvent =
-        configRepository.getMostRecentActorCatalogFetchEventForSource(connectionRead.getSourceId());
+        configRepositoryDoNotUse.getMostRecentActorCatalogFetchEventForSource(connectionRead.getSourceId());
 
     final SchemaChange schemaChange = getSchemaChange(connectionRead, currentSourceCatalogId, mostRecentFetchEvent);
 
@@ -539,13 +545,15 @@ public class WebBackendConnectionsHandler {
     if (webBackendConnectionPatch.getSyncCatalog() != null) {
       // Get the most recent actor catalog fetched for this connection's source and the newly updated sync
       // catalog
-      Optional<ActorCatalog> mostRecentActorCatalog = configRepository.getMostRecentActorCatalogForSource(originalConnectionRead.getSourceId());
-      AirbyteCatalog newAirbyteCatalog = webBackendConnectionPatch.getSyncCatalog();
+      final Optional<ActorCatalog> mostRecentActorCatalog =
+          configRepositoryDoNotUse.getMostRecentActorCatalogForSource(originalConnectionRead.getSourceId());
+      final AirbyteCatalog newAirbyteCatalog = webBackendConnectionPatch.getSyncCatalog();
       // Get the diff between these two catalogs to check for breaking changes
       if (mostRecentActorCatalog.isPresent()) {
         final io.airbyte.protocol.models.AirbyteCatalog mostRecentAirbyteCatalog =
             Jsons.object(mostRecentActorCatalog.get().getCatalog(), io.airbyte.protocol.models.AirbyteCatalog.class);
-        final StandardSourceDefinition sourceDefinition = configRepository.getSourceDefinitionFromSource(originalConnectionRead.getSourceId());
+        final StandardSourceDefinition sourceDefinition =
+            configRepositoryDoNotUse.getSourceDefinitionFromSource(originalConnectionRead.getSourceId());
         final CatalogDiff catalogDiff =
             connectionsHandler.getDiff(newAirbyteCatalog, CatalogConverter.toApi(mostRecentAirbyteCatalog, sourceDefinition),
                 CatalogConverter.toConfiguredProtocol(newAirbyteCatalog));
@@ -556,7 +564,7 @@ public class WebBackendConnectionsHandler {
     // before doing any updates, fetch the existing catalog so that it can be diffed
     // with the final catalog to determine which streams might need to be reset.
     final ConfiguredAirbyteCatalog oldConfiguredCatalog =
-        configRepository.getConfiguredCatalogForConnection(connectionId);
+        configRepositoryDoNotUse.getConfiguredCatalogForConnection(connectionId);
 
     final List<UUID> newAndExistingOperationIds = createOrUpdateOperations(originalConnectionRead, webBackendConnectionPatch);
 
@@ -619,7 +627,7 @@ public class WebBackendConnectionsHandler {
         final ConnectionStateType stateType = getStateType(connectionIdRequestBody);
 
         if (stateType == ConnectionStateType.LEGACY || stateType == ConnectionStateType.NOT_SET) {
-          streamsToReset = configRepository.getAllStreamsForConnection(connectionId);
+          streamsToReset = configRepositoryDoNotUse.getAllStreamsForConnection(connectionId);
         }
         eventRunner.resetConnection(
             connectionId,
@@ -728,7 +736,7 @@ public class WebBackendConnectionsHandler {
   @VisibleForTesting
   protected static ConnectionUpdate toConnectionPatch(final WebBackendConnectionUpdate webBackendConnectionPatch,
                                                       final List<UUID> finalOperationIds,
-                                                      boolean breakingChange) {
+                                                      final boolean breakingChange) {
     final ConnectionUpdate connectionPatch = new ConnectionUpdate();
 
     connectionPatch.connectionId(webBackendConnectionPatch.getConnectionId());

--- a/airbyte-commons-server/src/main/java/io/airbyte/commons/server/handlers/WebBackendGeographiesHandler.java
+++ b/airbyte-commons-server/src/main/java/io/airbyte/commons/server/handlers/WebBackendGeographiesHandler.java
@@ -10,6 +10,11 @@ import jakarta.inject.Singleton;
 import java.util.Arrays;
 import java.util.Collections;
 
+/**
+ * The web backend is an abstraction that allows the frontend to structure data in such a way that
+ * it is easier for a react frontend to consume. It should NOT have direct access to the database.
+ * It should operate exclusively by calling other endpoints that are exposed in the API.
+ **/
 @Singleton
 public class WebBackendGeographiesHandler {
 


### PR DESCRIPTION
## What
* it was a mistake that `ConfigRepository` was ever added to the web backend. 
* it is now now not easy to remove, but we need to more clearly signal to people that they should not use it for new cases (which keeps happening).
* add java doc explaining the purpose of the webbackend.

## How
* rename the field to make it clear that it shouldn't be used.
* deprecate the field