### PR TITLE
Fix bumpversion config

### DIFF
--- a/.bumpversion.cfg
+++ b/.bumpversion.cfg
@@ -22,9 +22,9 @@ serialize =
 
 [bumpversion:file:airbyte-server/Dockerfile]
 
-[bumpversion:file:airbyte-webapp/package-lock.json]
-
 [bumpversion:file:airbyte-webapp/package.json]
+search = "version": "{current_version}"
+replace = "version": "{new_version}"
 
 [bumpversion:file:airbyte-workers/Dockerfile]
 
@@ -49,10 +49,14 @@ serialize =
 [bumpversion:file:docs/operator-guides/upgrading-airbyte.md]
 
 [bumpversion:file:kube/overlays/stable-with-resource-limits/.env]
+search = AIRBYTE_VERSION={current_version}
+replace = AIRBYTE_VERSION={new_version}
 
 [bumpversion:file:kube/overlays/stable-with-resource-limits/kustomization.yaml]
 
 [bumpversion:file:kube/overlays/stable/.env]
+search = AIRBYTE_VERSION={current_version}
+replace = AIRBYTE_VERSION={new_version}
 
 [bumpversion:file:kube/overlays/stable/kustomization.yaml]
 
@@ -63,7 +67,11 @@ serialize =
 [bumpversion:file:octavia-cli/install.sh]
 
 [bumpversion:file:octavia-cli/setup.py]
+search = version="{current_version}"
+replace = version="{new_version}"
 
 [bumpversion:file:airbyte-connector-builder-server/Dockerfile]
 
 [bumpversion:file:airbyte-connector-builder-server/setup.py]
+search = version="{current_version}"
+replace = version="{new_version}"


### PR DESCRIPTION
## What

Fixes https://github.com/airbytehq/airbyte/issues/19674

Change the `bumpconfig` configuration file to not blindly update all versions that might occasionally be the same as ours in some files. This could have broken in case e.g. any dependency in the webapp would have had the same version that we have, on any OSS release.

I went through all the files and for all files I felt there is a danger we might update arbitrary other versions, that are in that file, I added a clear `search`/`replace` config that now only updates the version we actually want to update.

I've also removed the `package-lock.json`, since it doesn't exist anymore since our change to `pnpm` and the `pnpm-lock.yml` file doesn't have our own version printed in it (in contrast to the npm lock file).

You can test this locally by making sure to put the same version as our current one in each of the files with a `search`/`replace` and check that using the `bumpversion` tool will only bump the correct version. That's how I validated it locally.