### PR TITLE
remove commons-cli dependency from integrations

### DIFF
--- a/airbyte-commons-cli/src/main/java/io/airbyte/commons/cli/Clis.java
+++ b/airbyte-commons-cli/src/main/java/io/airbyte/commons/cli/Clis.java
@@ -10,8 +10,6 @@ import org.apache.commons.cli.CommandLine;
 import org.apache.commons.cli.CommandLineParser;
 import org.apache.commons.cli.DefaultParser;
 import org.apache.commons.cli.HelpFormatter;
-import org.apache.commons.cli.Option;
-import org.apache.commons.cli.OptionGroup;
 import org.apache.commons.cli.Options;
 import org.apache.commons.cli.ParseException;
 
@@ -47,22 +45,6 @@ public class Clis {
 
   public static CommandLine parse(final String[] args, final Options options) {
     return parse(args, options, new DefaultParser());
-  }
-
-  /**
-   * Provide a fluent interface for building an OptionsGroup.
-   *
-   * @param isRequired - is the option group required
-   * @param options - options in the option group
-   * @return the created option group.
-   */
-  public static OptionGroup createOptionGroup(final boolean isRequired, final Option... options) {
-    final OptionGroup optionGroup = new OptionGroup();
-    optionGroup.setRequired(isRequired);
-    for (final Option option : options) {
-      optionGroup.addOption(option);
-    }
-    return optionGroup;
   }
 
   public static CommandLineParser getRelaxedParser() {

--- a/airbyte-commons-cli/src/test/java/io/airbyte/commons/cli/ClisTest.java
+++ b/airbyte-commons-cli/src/test/java/io/airbyte/commons/cli/ClisTest.java
@@ -10,7 +10,6 @@ import static org.junit.jupiter.api.Assertions.assertThrows;
 import org.apache.commons.cli.CommandLine;
 import org.apache.commons.cli.DefaultParser;
 import org.apache.commons.cli.Option;
-import org.apache.commons.cli.OptionGroup;
 import org.apache.commons.cli.Options;
 import org.junit.jupiter.api.Test;
 
@@ -18,23 +17,6 @@ class ClisTest {
 
   private static final String ALPHA = "alpha";
   private static final String BETA = "beta";
-
-  @Test
-  void testCreateOptionGroup() {
-    final Option optionA = new Option("a", ALPHA);
-    final Option optionB = new Option("b", BETA);
-    final OptionGroup optionGroupExpected = new OptionGroup();
-    optionGroupExpected.addOption(optionA);
-    optionGroupExpected.addOption(optionB);
-
-    final OptionGroup optionGroupActual = Clis.createOptionGroup(
-        false,
-        optionA,
-        optionB);
-
-    // hack: OptionGroup does not define hashcode, so compare its string instead of the object itself.
-    assertEquals(optionGroupExpected.toString(), optionGroupActual.toString());
-  }
 
   @Test
   void testParse() {

--- a/airbyte-integrations/bases/base-java/build.gradle
+++ b/airbyte-integrations/bases/base-java/build.gradle
@@ -6,7 +6,6 @@ plugins {
 dependencies {
     implementation project(':airbyte-protocol:protocol-models')
     implementation project(':airbyte-config:config-models')
-    implementation project(':airbyte-commons-cli')
     implementation project(':airbyte-json-validation')
 
     implementation 'commons-cli:commons-cli:1.4'

--- a/airbyte-integrations/bases/base-java/build.gradle
+++ b/airbyte-integrations/bases/base-java/build.gradle
@@ -6,6 +6,7 @@ plugins {
 dependencies {
     implementation project(':airbyte-protocol:protocol-models')
     implementation project(':airbyte-config:config-models')
+    implementation project(':airbyte-commons-cli')
     implementation project(':airbyte-json-validation')
 
     implementation 'commons-cli:commons-cli:1.4'

--- a/airbyte-integrations/bases/base-java/src/main/java/io/airbyte/integrations/base/IntegrationCliParser.java
+++ b/airbyte-integrations/bases/base-java/src/main/java/io/airbyte/integrations/base/IntegrationCliParser.java
@@ -18,6 +18,7 @@ import org.slf4j.LoggerFactory;
 
 // todo (cgardens) - use argparse4j.github.io instead of org.apache.commons.cli to leverage better
 // sub-parser support.
+
 /**
  * Parses command line args to a type safe config object for each command type.
  */
@@ -25,28 +26,35 @@ public class IntegrationCliParser {
 
   private static final Logger LOGGER = LoggerFactory.getLogger(IntegrationCliParser.class);
 
-  private static final OptionGroup COMMAND_GROUP = Clis.createOptionGroup(
-      true,
-      Option.builder()
-          .longOpt(Command.SPEC.toString().toLowerCase())
-          .desc("outputs the json configuration specification")
-          .build(),
-      Option.builder()
-          .longOpt(Command.CHECK.toString().toLowerCase())
-          .desc("checks the config can be used to connect")
-          .build(),
-      Option.builder()
-          .longOpt(Command.DISCOVER.toString().toLowerCase())
-          .desc("outputs a catalog describing the source's catalog")
-          .build(),
-      Option.builder()
-          .longOpt(Command.READ.toString().toLowerCase())
-          .desc("reads the source and outputs messages to STDOUT")
-          .build(),
-      Option.builder()
-          .longOpt(Command.WRITE.toString().toLowerCase())
-          .desc("writes messages from STDIN to the integration")
-          .build());
+  private static final OptionGroup COMMAND_GROUP;
+
+  static {
+    final var optionGroup = new OptionGroup();
+    optionGroup.setRequired(true);
+
+    optionGroup.addOption(Option.builder()
+        .longOpt(Command.SPEC.toString().toLowerCase())
+        .desc("outputs the json configuration specification")
+        .build());
+    optionGroup.addOption(Option.builder()
+        .longOpt(Command.CHECK.toString().toLowerCase())
+        .desc("checks the config can be used to connect")
+        .build());
+    optionGroup.addOption(Option.builder()
+        .longOpt(Command.DISCOVER.toString().toLowerCase())
+        .desc("outputs a catalog describing the source's catalog")
+        .build());
+    optionGroup.addOption(Option.builder()
+        .longOpt(Command.READ.toString().toLowerCase())
+        .desc("reads the source and outputs messages to STDOUT")
+        .build());
+    optionGroup.addOption(Option.builder()
+        .longOpt(Command.WRITE.toString().toLowerCase())
+        .desc("writes messages from STDIN to the integration")
+        .build());
+
+    COMMAND_GROUP = optionGroup;
+  }
 
   public IntegrationConfig parse(final String[] args) {
     final Command command = parseCommand(args);


### PR DESCRIPTION
## What
- ~remove `airbyte-commons-cli` dependency from `airbyte-integrations`~
- move some code from `airbyte-commons-cli` to `airbyte-integrations`
    - turns out there are more dependencies than initially realized

## How
- move the method `createOptionGroup` from `commons-cli` to `integrations`