### PR TITLE
remove tryNotification from WorkspaceHandler

### DIFF
--- a/airbyte-commons-server/build.gradle
+++ b/airbyte-commons-server/build.gradle
@@ -38,7 +38,6 @@ dependencies {
     implementation project(':airbyte-metrics:metrics-lib')
     implementation project(':airbyte-db:db-lib')
     implementation project(":airbyte-json-validation")
-    implementation project(':airbyte-notification')
     implementation project(':airbyte-oauth')
     implementation project(':airbyte-protocol:protocol-models')
     implementation project(':airbyte-persistence:job-persistence')

--- a/airbyte-server/src/main/java/io/airbyte/server/apis/NotificationsApiController.java
+++ b/airbyte-server/src/main/java/io/airbyte/server/apis/NotificationsApiController.java
@@ -12,7 +12,6 @@ import io.airbyte.api.model.generated.NotificationRead;
 import io.airbyte.api.model.generated.NotificationRead.StatusEnum;
 import io.airbyte.commons.server.converters.NotificationConverter;
 import io.airbyte.commons.server.errors.IdNotFoundKnownException;
-import io.airbyte.commons.server.handlers.WorkspacesHandler;
 import io.airbyte.notification.NotificationClient;
 import io.micronaut.context.annotation.Requires;
 import io.micronaut.http.annotation.Body;
@@ -28,11 +27,7 @@ import java.io.IOException;
 @Secured(SecurityRule.IS_AUTHENTICATED)
 public class NotificationsApiController implements NotificationsApi {
 
-  private final WorkspacesHandler workspacesHandler;
-
-  public NotificationsApiController(final WorkspacesHandler workspacesHandler) {
-    this.workspacesHandler = workspacesHandler;
-  }
+  public NotificationsApiController() {}
 
   @Post
   @Secured({AUTHENTICATED_USER})

--- a/airbyte-server/src/main/java/io/airbyte/server/apis/NotificationsApiController.java
+++ b/airbyte-server/src/main/java/io/airbyte/server/apis/NotificationsApiController.java
@@ -9,13 +9,18 @@ import static io.airbyte.commons.auth.AuthRoleConstants.AUTHENTICATED_USER;
 import io.airbyte.api.generated.NotificationsApi;
 import io.airbyte.api.model.generated.Notification;
 import io.airbyte.api.model.generated.NotificationRead;
+import io.airbyte.api.model.generated.NotificationRead.StatusEnum;
+import io.airbyte.commons.server.converters.NotificationConverter;
+import io.airbyte.commons.server.errors.IdNotFoundKnownException;
 import io.airbyte.commons.server.handlers.WorkspacesHandler;
+import io.airbyte.notification.NotificationClient;
 import io.micronaut.context.annotation.Requires;
 import io.micronaut.http.annotation.Body;
 import io.micronaut.http.annotation.Controller;
 import io.micronaut.http.annotation.Post;
 import io.micronaut.security.annotation.Secured;
 import io.micronaut.security.rules.SecurityRule;
+import java.io.IOException;
 
 @Controller("/api/v1/notifications/try")
 @Requires(property = "airbyte.deployment-mode",
@@ -33,7 +38,24 @@ public class NotificationsApiController implements NotificationsApi {
   @Secured({AUTHENTICATED_USER})
   @Override
   public NotificationRead tryNotificationConfig(@Body final Notification notification) {
-    return ApiHelper.execute(() -> workspacesHandler.tryNotification(notification));
+    return ApiHelper.execute(() -> tryNotification(notification));
+  }
+
+  private NotificationRead tryNotification(final Notification notification) {
+    try {
+      final NotificationClient notificationClient = NotificationClient.createNotificationClient(NotificationConverter.toConfig(notification));
+      final String messageFormat = "Hello World! This is a test from Airbyte to try %s notification settings for sync %s";
+      final boolean failureNotified = notificationClient.notifyFailure(String.format(messageFormat, notification.getNotificationType(), "failures"));
+      final boolean successNotified = notificationClient.notifySuccess(String.format(messageFormat, notification.getNotificationType(), "successes"));
+      if (failureNotified || successNotified) {
+        return new NotificationRead().status(StatusEnum.SUCCEEDED);
+      }
+    } catch (final IllegalArgumentException e) {
+      throw new IdNotFoundKnownException(e.getMessage(), notification.getNotificationType().name(), e);
+    } catch (final IOException | InterruptedException e) {
+      return new NotificationRead().status(StatusEnum.FAILED).message(e.getMessage());
+    }
+    return new NotificationRead().status(StatusEnum.FAILED);
   }
 
 }


### PR DESCRIPTION
## What
- remove `airbyte-notification` dependency from `airbyte-commons-server`

## How
- move the `tryNotifcation` method from the `WorkspaceHandler` to the `NotificationsApiController`
    - I'm unsure why `tryNotification` was part of the `WorkspaceHandler`, it has no dependencies on anything workspace
