### PR TITLE
🪟 🧹 Remove experimentation flags for OAuth

### DIFF
--- a/airbyte-webapp/src/hooks/services/Experiment/experiments.ts
+++ b/airbyte-webapp/src/hooks/services/Experiment/experiments.ts
@@ -17,10 +17,6 @@ export interface Experiments {
   "authPage.hideSelfHostedCTA": boolean;
   "authPage.signup.hideName": boolean;
   "authPage.signup.hideCompanyName": boolean;
-  "authPage.oauth.google": boolean;
-  "authPage.oauth.github": boolean;
-  "authPage.oauth.google.signUpPage": boolean;
-  "authPage.oauth.github.signUpPage": boolean;
   "onboarding.speedyConnection": boolean;
   "authPage.oauth.position": "top" | "bottom";
   "connection.onboarding.sources": string;

--- a/airbyte-webapp/src/packages/cloud/views/auth/OAuthLogin/OAuthLogin.test.tsx
+++ b/airbyte-webapp/src/packages/cloud/views/auth/OAuthLogin/OAuthLogin.test.tsx
@@ -4,7 +4,6 @@ import { EMPTY } from "rxjs";
 import { TestWrapper } from "test-utils/testutils";
 
 import type { useExperiment } from "hooks/services/Experiment";
-import type { Experiments } from "hooks/services/Experiment/experiments";
 
 const mockUseExperiment = jest.fn<ReturnType<typeof useExperiment>, Parameters<typeof useExperiment>>();
 jest.doMock("hooks/services/Experiment", () => ({
@@ -22,55 +21,12 @@ jest.doMock("packages/cloud/services/auth/AuthService", () => ({
 // eslint-disable-next-line @typescript-eslint/no-var-requires
 const { OAuthLogin } = require("./OAuthLogin");
 
-const createUseExperimentMock = (options: {
-  google?: boolean;
-  github?: boolean;
-  googleSignUp?: boolean;
-  githubSignUp?: boolean;
-}) => {
-  return (key: keyof Experiments) => {
-    switch (key) {
-      case "authPage.oauth.github":
-        return options.github ?? false;
-      case "authPage.oauth.google":
-        return options.google ?? false;
-      case "authPage.oauth.github.signUpPage":
-        return options.githubSignUp ?? true;
-      case "authPage.oauth.google.signUpPage":
-        return options.googleSignUp ?? true;
-      default:
-        throw new Error(`${key} is not mocked`);
-    }
-  };
-};
-
 describe("OAuthLogin", () => {
   beforeEach(() => {
     mockUseExperiment.mockReset();
     mockUseExperiment.mockReturnValue(true);
     mockLoginWithOAuth.mockReset();
     mockLoginWithOAuth.mockReturnValue(EMPTY);
-  });
-
-  it("should render all enabled logins", () => {
-    mockUseExperiment.mockImplementation(createUseExperimentMock({ google: true, github: true }));
-    const { getByTestId } = render(<OAuthLogin />, { wrapper: TestWrapper });
-    expect(getByTestId("googleOauthLogin")).toBeInTheDocument();
-    expect(getByTestId("githubOauthLogin")).toBeInTheDocument();
-  });
-
-  it("should not render buttons that are disabled", () => {
-    mockUseExperiment.mockImplementation(createUseExperimentMock({ google: false, github: true }));
-    const { getByTestId, queryByTestId } = render(<OAuthLogin />, { wrapper: TestWrapper });
-    expect(queryByTestId("googleOauthLogin")).not.toBeInTheDocument();
-    expect(getByTestId("githubOauthLogin")).toBeInTheDocument();
-  });
-
-  it("should not render disabled buttons for sign-up page", () => {
-    mockUseExperiment.mockImplementation(createUseExperimentMock({ google: true, github: true, googleSignUp: false }));
-    const { getByTestId, queryByTestId } = render(<OAuthLogin isSignUpPage />, { wrapper: TestWrapper });
-    expect(queryByTestId("googleOauthLogin")).not.toBeInTheDocument();
-    expect(getByTestId("githubOauthLogin")).toBeInTheDocument();
   });
 
   it("should call auth service for Google", () => {

--- a/airbyte-webapp/src/packages/cloud/views/auth/OAuthLogin/OAuthLogin.tsx
+++ b/airbyte-webapp/src/packages/cloud/views/auth/OAuthLogin/OAuthLogin.tsx
@@ -5,7 +5,6 @@ import { Subscription } from "rxjs";
 
 import { Spinner } from "components/ui/Spinner";
 
-import { useExperiment } from "hooks/services/Experiment";
 import { OAuthProviders } from "packages/cloud/lib/auth/AuthProviders";
 import { useAuthService } from "packages/cloud/services/auth/AuthService";
 
@@ -31,34 +30,16 @@ const GoogleButton: React.FC<{ onClick: () => void }> = ({ onClick }) => {
   );
 };
 
-interface OAuthLoginProps {
-  isSignUpPage?: boolean;
-}
-
-export const OAuthLogin: React.FC<OAuthLoginProps> = ({ isSignUpPage }) => {
+export const OAuthLogin: React.FC = () => {
   const { formatMessage } = useIntl();
   const { loginWithOAuth } = useAuthService();
   const stateSubscription = useRef<Subscription>();
   const [errorCode, setErrorCode] = useState<string>();
   const [isLoading, setLoading] = useState(false);
 
-  const isGitHubLoginEnabled = useExperiment("authPage.oauth.github", true);
-  const isGoogleLoginEnabled = useExperiment("authPage.oauth.google", true);
-  const isGitHubEnabledOnSignUp = useExperiment("authPage.oauth.github.signUpPage", true);
-  const isGoogleEnabledOnSignUp = useExperiment("authPage.oauth.google.signUpPage", true);
-
-  const showGoogleLogin = isGoogleLoginEnabled && (!isSignUpPage || isGoogleEnabledOnSignUp);
-  const showGitHubLogin = isGitHubLoginEnabled && (!isSignUpPage || isGitHubEnabledOnSignUp);
-
-  const isAnyOauthEnabled = showGoogleLogin || showGitHubLogin;
-
   useUnmount(() => {
     stateSubscription.current?.unsubscribe();
   });
-
-  if (!isAnyOauthEnabled) {
-    return null;
-  }
 
   const getErrorMessage = (error: string): string | undefined => {
     switch (error) {
@@ -107,8 +88,8 @@ export const OAuthLogin: React.FC<OAuthLoginProps> = ({ isSignUpPage }) => {
       )}
       {!isLoading && (
         <div className={styles.buttons}>
-          {showGoogleLogin && <GoogleButton onClick={() => login("google")} />}
-          {showGitHubLogin && <GitHubButton onClick={() => login("github")} />}
+          <GoogleButton onClick={() => login("google")} />
+          <GitHubButton onClick={() => login("github")} />
         </div>
       )}
       {errorMessage && <div className={styles.error}>{errorMessage}</div>}

--- a/airbyte-webapp/src/packages/cloud/views/auth/SignupPage/SignupPage.tsx
+++ b/airbyte-webapp/src/packages/cloud/views/auth/SignupPage/SignupPage.tsx
@@ -39,7 +39,7 @@ const SignupPage: React.FC<SignupPageProps> = ({ highlightStyle }) => {
       <SpecialBlock />
       {oAuthPosition === "top" && (
         <>
-          <OAuthLogin isSignUpPage />
+          <OAuthLogin />
           <Separator />
         </>
       )}
@@ -47,7 +47,7 @@ const SignupPage: React.FC<SignupPageProps> = ({ highlightStyle }) => {
       {oAuthPosition === "bottom" && (
         <>
           <Separator />
-          <OAuthLogin isSignUpPage />
+          <OAuthLogin />
         </>
       )}
       <Disclaimer />


### PR DESCRIPTION
## What

Remove the OAuth experimentation flags from the code. We have this fully rolled out by now, and we can't even use them as a killswitch really, because users wouldn't be able to log in properly anymore, so talked to Natalie, and we decided to remove those flags fully.