### PR TITLE
🪟 🎨 🐛 Fix long name overflow and field path names in Catalog Diff modal

### DIFF
--- a/airbyte-webapp/src/components/connection/CatalogDiffModal/DiffAccordionHeader.module.scss
+++ b/airbyte-webapp/src/components/connection/CatalogDiffModal/DiffAccordionHeader.module.scss
@@ -1,5 +1,6 @@
 @forward "./StreamRow.module.scss";
 @forward "./DiffSection.module.scss";
+@use "scss/colors";
 @use "scss/variables";
 
 .row {
@@ -8,6 +9,10 @@
 
 .namespace {
   padding-left: variables.$spacing-sm;
+}
+
+.grey {
+  color: colors.$grey-300;
 }
 
 .name {

--- a/airbyte-webapp/src/components/connection/CatalogDiffModal/DiffAccordionHeader.module.scss
+++ b/airbyte-webapp/src/components/connection/CatalogDiffModal/DiffAccordionHeader.module.scss
@@ -9,3 +9,7 @@
 .namespace {
   padding-left: variables.$spacing-sm;
 }
+
+.name {
+  width: 290px;
+}

--- a/airbyte-webapp/src/components/connection/CatalogDiffModal/DiffAccordionHeader.tsx
+++ b/airbyte-webapp/src/components/connection/CatalogDiffModal/DiffAccordionHeader.tsx
@@ -25,21 +25,24 @@ export const DiffAccordionHeader: React.FC<DiffAccordionHeaderProps> = ({
   newCount,
   changedCount,
 }) => {
-  const nameCellStyle = classnames(styles.nameCell, styles.row);
-
-  const namespaceCellStyles = classnames(styles.nameCell, styles.row, styles.namespace);
-
   const { formatMessage } = useIntl();
+
+  const nameCellStyle = classnames(styles.nameCell, styles.row);
+  const namespaceCellStyles = classnames(styles.nameCell, styles.row, styles.namespace);
 
   return (
     <>
       <ModificationIcon />
       <div className={namespaceCellStyles} aria-labelledby={formatMessage({ id: "connection.updateSchema.namespace" })}>
-        {open ? <FontAwesomeIcon icon={faAngleDown} /> : <FontAwesomeIcon icon={faAngleRight} />}
-        <div>{streamDescriptor.namespace}</div>
+        <FontAwesomeIcon icon={open ?  faAngleDown: faAngleRight} fixedWidth /> 
+        <div title={streamDescriptor.namespace} className={styles.text}>
+        {streamDescriptor.namespace}
+        </div>
       </div>
       <div className={nameCellStyle} aria-labelledby={formatMessage({ id: "connection.updateSchema.streamName" })}>
-        <div>{streamDescriptor.name}</div>
+      <div title={streamDescriptor.name} className={styles.text}>
+        {streamDescriptor.name}
+        </div>
       </div>
       <DiffIconBlock removedCount={removedCount} newCount={newCount} changedCount={changedCount} />
     </>

--- a/airbyte-webapp/src/components/connection/CatalogDiffModal/DiffAccordionHeader.tsx
+++ b/airbyte-webapp/src/components/connection/CatalogDiffModal/DiffAccordionHeader.tsx
@@ -30,13 +30,15 @@ export const DiffAccordionHeader: React.FC<DiffAccordionHeaderProps> = ({
   const nameCellStyle = classnames(styles.nameCell, styles.row, styles.name);
   const namespaceCellStyles = classnames(styles.nameCell, styles.row, styles.namespace);
 
+  const namespace = streamDescriptor.namespace ?? formatMessage({ id: "form.noNamespace" });
+
   return (
     <>
       <ModificationIcon />
       <div className={namespaceCellStyles} aria-labelledby={formatMessage({ id: "connection.updateSchema.namespace" })}>
         <FontAwesomeIcon icon={open ? faAngleDown : faAngleRight} fixedWidth />
-        <div title={streamDescriptor.namespace} className={styles.text}>
-          {streamDescriptor.namespace}
+        <div title={namespace} className={classnames(styles.text, { [styles.grey]: !streamDescriptor.namespace })}>
+          {namespace}
         </div>
       </div>
       <div className={nameCellStyle} aria-labelledby={formatMessage({ id: "connection.updateSchema.streamName" })}>

--- a/airbyte-webapp/src/components/connection/CatalogDiffModal/DiffAccordionHeader.tsx
+++ b/airbyte-webapp/src/components/connection/CatalogDiffModal/DiffAccordionHeader.tsx
@@ -27,21 +27,21 @@ export const DiffAccordionHeader: React.FC<DiffAccordionHeaderProps> = ({
 }) => {
   const { formatMessage } = useIntl();
 
-  const nameCellStyle = classnames(styles.nameCell, styles.row);
+  const nameCellStyle = classnames(styles.nameCell, styles.row, styles.name);
   const namespaceCellStyles = classnames(styles.nameCell, styles.row, styles.namespace);
 
   return (
     <>
       <ModificationIcon />
       <div className={namespaceCellStyles} aria-labelledby={formatMessage({ id: "connection.updateSchema.namespace" })}>
-        <FontAwesomeIcon icon={open ?  faAngleDown: faAngleRight} fixedWidth /> 
+        <FontAwesomeIcon icon={open ? faAngleDown : faAngleRight} fixedWidth />
         <div title={streamDescriptor.namespace} className={styles.text}>
-        {streamDescriptor.namespace}
+          {streamDescriptor.namespace}
         </div>
       </div>
       <div className={nameCellStyle} aria-labelledby={formatMessage({ id: "connection.updateSchema.streamName" })}>
-      <div title={streamDescriptor.name} className={styles.text}>
-        {streamDescriptor.name}
+        <div title={streamDescriptor.name} className={styles.text}>
+          {streamDescriptor.name}
         </div>
       </div>
       <DiffIconBlock removedCount={removedCount} newCount={newCount} changedCount={changedCount} />

--- a/airbyte-webapp/src/components/connection/CatalogDiffModal/DiffSection.module.scss
+++ b/airbyte-webapp/src/components/connection/CatalogDiffModal/DiffSection.module.scss
@@ -16,7 +16,7 @@
   display: flex;
   flex-direction: row;
   align-items: center;
-  padding: 0 variables.$spacing-md 0 variables.$spacing-2xl;
+  padding: 0 variables.$spacing-lg;
   width: 100%;
   height: 22px;
 
@@ -28,6 +28,14 @@
     font-size: 10px;
     color: colors.$grey;
     line-height: 12px;
+  }
+
+  & .namespaceHeader {
+    padding-left: 25px;
+  }
+
+  & .nameHeader {
+    padding-left: variables.$spacing-md;
   }
 }
 

--- a/airbyte-webapp/src/components/connection/CatalogDiffModal/DiffSection.tsx
+++ b/airbyte-webapp/src/components/connection/CatalogDiffModal/DiffSection.tsx
@@ -32,15 +32,14 @@ export const DiffSection: React.FC<DiffSectionProps> = ({ streams, catalog, diff
         <DiffHeader diffCount={streams.length} diffVerb={diffVerb} diffType="stream" />
       </div>
       <table aria-label={`${diffVerb} streams table`} className={styles.table}>
-        <thead className={styles.sectionSubHeader}>
-          <tr>
-            <th>
+        <thead>
+          <tr className={styles.sectionSubHeader}>
+            <th className={styles.namespaceHeader}>
               <FormattedMessage id="connection.updateSchema.namespace" />
             </th>
-            <th>
+            <th colSpan={2} className={styles.nameHeader}>
               <FormattedMessage id="connection.updateSchema.streamName" />
             </th>
-            <th />
           </tr>
         </thead>
         <tbody>

--- a/airbyte-webapp/src/components/connection/CatalogDiffModal/FieldRow.module.scss
+++ b/airbyte-webapp/src/components/connection/CatalogDiffModal/FieldRow.module.scss
@@ -59,12 +59,12 @@ tr:last-child .content {
   margin: 0 variables.$spacing-md;
 }
 
-.cell {
-  &.update {
-    span {
-      background-color: rgba(98, 94, 255, 10%);
-      padding: variables.$spacing-sm;
-      border-radius: variables.$border-radius-xs;
-    }
-  }
+.cell.update .dataType {
+  background-color: rgba(98, 94, 255, 10%);
+  padding: variables.$spacing-sm;
+  border-radius: variables.$border-radius-xs;
+  display: flex;
+  flex-direction: row;
+  align-items: center;
+  gap: variables.$spacing-sm;
 }

--- a/airbyte-webapp/src/components/connection/CatalogDiffModal/FieldRow.module.scss
+++ b/airbyte-webapp/src/components/connection/CatalogDiffModal/FieldRow.module.scss
@@ -1,5 +1,6 @@
-@use "scss/variables";
 @use "scss/colors";
+@use "scss/mixins";
+@use "scss/variables";
 
 .row {
   display: flex;
@@ -59,12 +60,26 @@ tr:last-child .content {
   margin: 0 variables.$spacing-md;
 }
 
-.cell.update .dataType {
-  background-color: rgba(98, 94, 255, 10%);
-  padding: variables.$spacing-sm;
-  border-radius: variables.$border-radius-xs;
-  display: flex;
-  flex-direction: row;
-  align-items: center;
-  gap: variables.$spacing-sm;
+.fieldName {
+  @include mixins.overflow-ellipsis;
+
+  :not(.withType) & {
+    max-width: 470px;
+  }
+
+  .withType & {
+    max-width: 200px;
+  }
+}
+
+.cell {
+  &.update .dataType {
+    background-color: rgba(98, 94, 255, 10%);
+    padding: variables.$spacing-sm;
+    border-radius: variables.$border-radius-xs;
+    display: flex;
+    flex-direction: row;
+    align-items: center;
+    gap: variables.$spacing-sm;
+  }
 }

--- a/airbyte-webapp/src/components/connection/CatalogDiffModal/FieldRow.tsx
+++ b/airbyte-webapp/src/components/connection/CatalogDiffModal/FieldRow.tsx
@@ -37,9 +37,14 @@ export const FieldRow: React.FC<FieldRowProps> = ({ transform }) => {
   });
 
   const updateCellStyle = classnames(styles.cell, styles.update);
+  const hasTypeChange = oldType && newType;
 
   return (
-    <tr className={styles.row}>
+    <tr
+      className={classnames(styles.row, {
+        [styles.withType]: hasTypeChange,
+      })}
+    >
       <td className={contentStyle}>
         <div className={styles.iconContainer}>
           {diffType === "add" ? (
@@ -52,9 +57,11 @@ export const FieldRow: React.FC<FieldRowProps> = ({ transform }) => {
             </div>
           )}
         </div>
-        {fieldName}
+        <div title={fieldName} className={styles.fieldName}>
+          {fieldName}
+        </div>
       </td>
-      {oldType && newType && (
+      {hasTypeChange && (
         <td className={contentStyle}>
           <div className={updateCellStyle}>
             <span className={styles.dataType}>

--- a/airbyte-webapp/src/components/connection/CatalogDiffModal/FieldRow.tsx
+++ b/airbyte-webapp/src/components/connection/CatalogDiffModal/FieldRow.tsx
@@ -1,7 +1,8 @@
-import { faArrowRight, faMinus, faPlus } from "@fortawesome/free-solid-svg-icons";
+import { faMinus, faPlus } from "@fortawesome/free-solid-svg-icons";
 import { FontAwesomeIcon } from "@fortawesome/react-fontawesome";
 import classnames from "classnames";
 
+import { ArrowRightIcon } from "components/icons/ArrowRightIcon";
 import { ModificationIcon } from "components/icons/ModificationIcon";
 
 import { FieldTransform } from "core/request/AirbyteClient";
@@ -56,8 +57,8 @@ export const FieldRow: React.FC<FieldRowProps> = ({ transform }) => {
       {oldType && newType && (
         <td className={contentStyle}>
           <div className={updateCellStyle}>
-            <span>
-              {oldType} <FontAwesomeIcon icon={faArrowRight} /> {newType}
+            <span className={styles.dataType}>
+              {oldType} <ArrowRightIcon /> {newType}
             </span>
           </div>
         </td>

--- a/airbyte-webapp/src/components/connection/CatalogDiffModal/FieldRow.tsx
+++ b/airbyte-webapp/src/components/connection/CatalogDiffModal/FieldRow.tsx
@@ -13,7 +13,7 @@ interface FieldRowProps {
 }
 
 export const FieldRow: React.FC<FieldRowProps> = ({ transform }) => {
-  const fieldName = transform.fieldName[transform.fieldName.length - 1];
+  const fieldName = transform.fieldName.join(".");
   const diffType = transform.transformType.includes("add")
     ? "add"
     : transform.transformType.includes("remove")

--- a/airbyte-webapp/src/components/connection/CatalogDiffModal/FieldSection.module.scss
+++ b/airbyte-webapp/src/components/connection/CatalogDiffModal/FieldSection.module.scss
@@ -25,7 +25,7 @@
 }
 
 .namespaceSubHeader {
-  padding-left: 20px;
+  padding-left: 25px;
 }
 
 .fieldRowsContainer {

--- a/airbyte-webapp/src/components/connection/CatalogDiffModal/FieldSection.module.scss
+++ b/airbyte-webapp/src/components/connection/CatalogDiffModal/FieldSection.module.scss
@@ -24,6 +24,10 @@
   }
 }
 
+.namespaceSubHeader {
+  padding-left: 20px;
+}
+
 .fieldRowsContainer {
   padding: 0 variables.$spacing-lg;
 

--- a/airbyte-webapp/src/components/connection/CatalogDiffModal/FieldSection.tsx
+++ b/airbyte-webapp/src/components/connection/CatalogDiffModal/FieldSection.tsx
@@ -20,7 +20,7 @@ export const FieldSection: React.FC<FieldSectionProps> = ({ streams, diffVerb })
         <DiffHeader diffCount={streams.length} diffVerb={diffVerb} diffType="stream" />
       </div>
       <div className={styles.fieldSubHeader}>
-        <div id={formatMessage({ id: "connection.updateSchema.namespace" })}>
+        <div id={formatMessage({ id: "connection.updateSchema.namespace" })} className={styles.namespaceSubHeader}>
           <FormattedMessage id="connection.updateSchema.namespace" />
         </div>
         <div id={formatMessage({ id: "connection.updateSchema.streamName" })}>

--- a/airbyte-webapp/src/components/connection/CatalogDiffModal/StreamRow.module.scss
+++ b/airbyte-webapp/src/components/connection/CatalogDiffModal/StreamRow.module.scss
@@ -1,5 +1,6 @@
 @use "scss/colors";
 @use "scss/variables";
+@use "scss/mixins";
 
 .row {
   display: flex;
@@ -63,10 +64,17 @@
 .nameCell,
 %nameCell {
   width: 150px;
-  text-align: left;
+
+  &.lg {
+    width: 385px;
+  }
 
   & .row {
     display: flex;
     flex-direction: row;
   }
+}
+
+.text {
+  @include mixins.overflow-ellipsis;
 }

--- a/airbyte-webapp/src/components/connection/CatalogDiffModal/StreamRow.tsx
+++ b/airbyte-webapp/src/components/connection/CatalogDiffModal/StreamRow.tsx
@@ -34,6 +34,8 @@ export const StreamRow: React.FC<StreamRowProps> = ({ streamTransform, syncMode,
 
   const itemName = streamTransform.streamDescriptor.name;
   const namespace = streamTransform.streamDescriptor.namespace;
+  const hasSyncModeChange = diffVerb === "removed" && syncMode;
+
   return (
     <tr className={rowStyle}>
       <td className={styles.nameCell}>
@@ -47,11 +49,24 @@ export const StreamRow: React.FC<StreamRowProps> = ({ streamTransform, syncMode,
               <ModificationIcon />
             )}
           </div>
-          {namespace}
+          <div title={namespace} className={styles.text}>
+            {namespace}
+          </div>
         </div>
       </td>
-      <td className={styles.nameCell}>{itemName}</td>
-      <td>{diffVerb === "removed" && syncMode && <SyncModeBox syncModeString={syncMode} />} </td>
+      <td
+        className={classnames(styles.nameCell, { [styles.lg]: !hasSyncModeChange })}
+        colSpan={hasSyncModeChange ? 1 : 2}
+      >
+        <div title={itemName} className={styles.text}>
+          {itemName}
+        </div>
+      </td>
+      {hasSyncModeChange && (
+        <td>
+          <SyncModeBox syncModeString={syncMode} />
+        </td>
+      )}
     </tr>
   );
 };

--- a/airbyte-webapp/src/components/connection/CatalogDiffModal/index.stories.tsx
+++ b/airbyte-webapp/src/components/connection/CatalogDiffModal/index.stories.tsx
@@ -63,11 +63,19 @@ const fullCatalogDiff: CatalogDiff = {
   transforms: [
     {
       transformType: "update_stream",
-      streamDescriptor: { namespace: "apple", name: "harissa_paste" },
+      streamDescriptor: { namespace: "too_long_of_a_namespace", name: "too_long_of_a_name_for_this" },
       updateStream: [
         { transformType: "add_field", fieldName: ["users", "phone"], breaking: false },
         { transformType: "add_field", fieldName: ["users", "email"], breaking: false },
         { transformType: "remove_field", fieldName: ["users", "lastName"], breaking: false },
+        {
+          transformType: "remove_field",
+          fieldName:
+            "universe.milky_way_galaxy.earth.land.north_america.alaska.yukon.businesses.stores.names.created_at".split(
+              "."
+            ),
+          breaking: false,
+        },
         {
           transformType: "update_field_schema",
           breaking: false,
@@ -77,7 +85,7 @@ const fullCatalogDiff: CatalogDiff = {
         {
           transformType: "update_field_schema",
           breaking: false,
-          fieldName: ["users", "updated_at"],
+          fieldName: ["package_dimensions", "size", "width", "updated_at"],
           updateFieldSchema: { oldSchema: { type: "string" }, newSchema: { type: "DateTime" } },
         },
       ],
@@ -88,7 +96,10 @@ const fullCatalogDiff: CatalogDiff = {
     },
     {
       transformType: "add_stream",
-      streamDescriptor: { namespace: "apple", name: "carrot" },
+      streamDescriptor: {
+        namespace: "too_long_of_a_namespace",
+        name: "too_long_of_a_name_for_this_too_long_of_a_name_for_this_too_long_of_a_name_for_this",
+      },
     },
     {
       transformType: "remove_stream",

--- a/airbyte-webapp/src/components/connection/CatalogDiffModal/utils.tsx
+++ b/airbyte-webapp/src/components/connection/CatalogDiffModal/utils.tsx
@@ -14,7 +14,12 @@ export const getSortedDiff = <T extends StreamTransform | FieldTransform>(diffAr
     }
 
     if (transform.transformType.includes("update")) {
-      sortedDiff.changedItems.push(transform);
+      const { updateFieldSchema } = transform as FieldTransform;
+      if (!updateFieldSchema || updateFieldSchema.newSchema.type !== updateFieldSchema.oldSchema.type) {
+        // Push any change except except when it's FieldTransform a same -> same type update (e.g. object -> object)
+        // because for objects, the properties of that field will be shown as added or removed in the modal
+        sortedDiff.changedItems.push(transform);
+      }
     }
   });
   return sortedDiff;

--- a/airbyte-webapp/src/scss/_mixins.scss
+++ b/airbyte-webapp/src/scss/_mixins.scss
@@ -1,5 +1,11 @@
 @use "./variables";
 
+@mixin overflow-ellipsis {
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
 @mixin shadow {
   box-shadow: variables.$box-shadow;
 }


### PR DESCRIPTION
## What
Related to #22493

This change mainly fixes a few of the issues in the catalog diff modal

* Long names for namespace, stream name, or field name overflowing to the next column. Now, these fields will be truncated with an ellipsis
* Field names were not showing the full path with dot notation, which made it confusing. For example, instead of showing that "user.name" and "company.name" were added to the stream, it would show the last part of the path so you would see what seems to be a duplicate "name" entry.
* Some of the column names were misaligned, and now they are not

Before:
![image](https://user-images.githubusercontent.com/168664/217660360-34b9fb17-9919-46e3-952d-ee33f88bcc01.png)


After:
![Screen Shot 2023-02-08 at 16 52 26](https://user-images.githubusercontent.com/168664/217659548-6945c38c-a12c-427d-afdd-366d4ab881d4.png)

## How
* Lots of CSS work
* Added mixin for text overflow issues
* Updated storybook to include long names as examples

