### PR TITLE
Trivial grammar fix: add missing "be"

### DIFF
--- a/docs/integrations/destinations/s3.md
+++ b/docs/integrations/destinations/s3.md
@@ -52,7 +52,7 @@ NOTE: If the S3 cluster is not configured to use TLS, the connection to Amazon S
     * **S3 Endpoint**
         * Leave empty if using AWS S3, fill in S3 URL if using Minio S3.
     * **S3 Filename pattern**
-      * The pattern allows you to set the file-name format for the S3 staging file(s), next placeholders combinations are currently supported: {date}, {date:yyyy_MM}, {timestamp}, {timestamp:millis}, {timestamp:micros}, {part_number}, {sync_id}, {format_extension}. Please, don't use empty space and not supportable placeholders, as they won't recognized.
+      * The pattern allows you to set the file-name format for the S3 staging file(s), next placeholders combinations are currently supported: {date}, {date:yyyy_MM}, {timestamp}, {timestamp:millis}, {timestamp:micros}, {part_number}, {sync_id}, {format_extension}. Please, don't use empty space and not supportable placeholders, as they won't be recognized.
 5. Click `Set up destination`.
 <!-- /env:cloud -->
 


### PR DESCRIPTION
## What
Trivial drive-by grammar fix: replaces the clause "as they won't recognized" with "as they won't **be** recognized".