### PR TITLE
🐛📚 Octavia-cli docs: Fix incorrect env vars for airbyte-username and airbyte-password

### DIFF
--- a/octavia-cli/README.md
+++ b/octavia-cli/README.md
@@ -138,10 +138,10 @@ docker compose run octavia-cli <command>`
 ### `octavia` command flags
 
 | **Flag**                                 | **Description**                                                                   | **Env Variable**           | **Default**                                            |
-| ---------------------------------------- | --------------------------------------------------------------------------------- | -------------------------- | ------------------------------------------------------ |
+| ---------------------------------------- | --------------------------------------------------------------------------------- |----------------------------| ------------------------------------------------------ |
 | `--airbyte-url`                          | Airbyte instance URL.                                                             | `AIRBYTE_URL`              | `http://localhost:8000`                                |
-| `--airbyte-username`                     | Airbyte instance username (basic auth).                                           | `AIRBYTE_URL`              | `airbyte`                                              |
-| `--airbyte-password`                     | Airbyte instance password (basic auth).                                           | `AIRBYTE_URL`              | `password`                                             |
+| `--airbyte-username`                     | Airbyte instance username (basic auth).                                           | `AIRBYTE_USERNAME`         | `airbyte`                                              |
+| `--airbyte-password`                     | Airbyte instance password (basic auth).                                           | `AIRBYTE_PASSWORD`         | `password`                                             |
 | `--workspace-id`                         | Airbyte workspace id.                                                             | `AIRBYTE_WORKSPACE_ID`     | The first workspace id found on your Airbyte instance. |
 | `--enable-telemetry/--disable-telemetry` | Enable or disable the sending of telemetry data.                                  | `OCTAVIA_ENABLE_TELEMETRY` | True                                                   |
 | `--api-http-header`                      | HTTP Header value pairs passed while calling Airbyte's API                        | None                       | None                                                   |


### PR DESCRIPTION
## What
* This is a fix for #22567 

- [X] Documentation updated
    - [X] Octavia-cli's `README.md`
   
*PS: Mentioning @sh4sh as discussed in Slack*