### PR TITLE
Source Amplitude: removed empty stream from testing

### DIFF
--- a/airbyte-integrations/connectors/source-amplitude/integration_tests/streams_with_output_records_catalog.json
+++ b/airbyte-integrations/connectors/source-amplitude/integration_tests/streams_with_output_records_catalog.json
@@ -2,16 +2,6 @@
   "streams": [
     {
       "stream": {
-        "name": "cohorts",
-        "json_schema": {},
-        "supported_sync_modes": ["full_refresh"],
-        "source_defined_primary_key": [["id"]]
-      },
-      "sync_mode": "full_refresh",
-      "destination_sync_mode": "overwrite"
-    },
-    {
-      "stream": {
         "name": "active_users",
         "json_schema": {},
         "supported_sync_modes": ["full_refresh", "incremental"],


### PR DESCRIPTION
removed stream cohorts from streams_with_output_records_catalog.json(it has no records).