### PR TITLE
🪟 🐛 Fix new table tooltips

### DIFF
--- a/airbyte-webapp/package.json
+++ b/airbyte-webapp/package.json
@@ -63,6 +63,7 @@
     "react-datepicker": "^4.8.0",
     "react-dom": "^17.0.2",
     "react-helmet-async": "^1.3.0",
+    "react-intersection-observer": "^9.4.2",
     "react-intl": "^6.1.1",
     "react-lazylog": "^4.5.3",
     "react-markdown": "^7.0.1",

--- a/airbyte-webapp/pnpm-lock.yaml
+++ b/airbyte-webapp/pnpm-lock.yaml
@@ -102,6 +102,7 @@ specifiers:
   react-datepicker: ^4.8.0
   react-dom: ^17.0.2
   react-helmet-async: ^1.3.0
+  react-intersection-observer: ^9.4.2
   react-intl: ^6.1.1
   react-lazylog: ^4.5.3
   react-markdown: ^7.0.1
@@ -183,6 +184,7 @@ dependencies:
   react-datepicker: 4.8.0_sfoxds7t5ydpegc3knd667wn6m
   react-dom: 17.0.2_react@17.0.2
   react-helmet-async: 1.3.0_sfoxds7t5ydpegc3knd667wn6m
+  react-intersection-observer: 9.4.2_react@17.0.2
   react-intl: 6.2.5_oatgdhaahtizs2uezdzbohxvne
   react-lazylog: 4.5.3_sfoxds7t5ydpegc3knd667wn6m
   react-markdown: 7.1.2_q5o373oqrklnndq2vhekyuzhxi
@@ -12736,6 +12738,14 @@ packages:
     dependencies:
       react: 17.0.2
     dev: true
+
+  /react-intersection-observer/9.4.2_react@17.0.2:
+    resolution: {integrity: sha512-AdK+ryzZ7U9ZJYttDUZ8q2Am3nqE0exg5Ryl5Y124KeVsix/1hGZPbdu58EqA98TwnzwDNWHxg/kwNawmIiUig==}
+    peerDependencies:
+      react: ^15.0.0 || ^16.0.0 || ^17.0.0 || ^18.0.0
+    dependencies:
+      react: 17.0.2
+    dev: false
 
   /react-intl/6.2.5_oatgdhaahtizs2uezdzbohxvne:
     resolution: {integrity: sha512-nz21POTKbE0sPEuEJU4o5YTZYY7VlIYCPNJaD6D2+xKyk6Noj6DoUK0LRO9LXuQNUuQ044IZl3m6ymzZRj8XFQ==}

--- a/airbyte-webapp/src/components/connection/CatalogTree/next/CatalogTreeTableCell.tsx
+++ b/airbyte-webapp/src/components/connection/CatalogTree/next/CatalogTreeTableCell.tsx
@@ -1,6 +1,7 @@
 import classNames from "classnames";
-import React, { useCallback, useEffect, useRef, useState } from "react";
-import { useWindowSize } from "react-use";
+import React, { useEffect, useRef, useState } from "react";
+import { useInView } from "react-intersection-observer";
+import { debounceTime, fromEvent } from "rxjs";
 
 import { Tooltip } from "components/ui/Tooltip";
 
@@ -22,17 +23,6 @@ const sizeMap: Record<Sizes, string> = {
   large: styles.large,
 };
 
-const TooltipText: React.FC<{ textNodes: Element[] }> = ({ textNodes }) => {
-  if (!textNodes.length) {
-    return null;
-  }
-  const text = textNodes.map((t) => decodeURIComponent(t.innerHTML)).join(" | ");
-  // This is not a safe use, and need to be removed still.
-  // https://github.com/airbytehq/airbyte/issues/22196
-  // eslint-disable-next-line react/no-danger
-  return <div dangerouslySetInnerHTML={{ __html: text }} />;
-};
-
 export const CatalogTreeTableCell: React.FC<React.PropsWithChildren<CatalogTreeTableCellProps>> = ({
   size = "medium",
   withTooltip,
@@ -40,49 +30,60 @@ export const CatalogTreeTableCell: React.FC<React.PropsWithChildren<CatalogTreeT
   children,
 }) => {
   const [tooltipDisabled, setTooltipDisabled] = useState(true);
-  const [textNodes, setTextNodes] = useState<Element[]>([]);
-  const cell = useRef<HTMLDivElement | null>(null);
+  const cellContent = useRef<HTMLSpanElement | null>(null);
 
-  const { width: windowWidth } = useWindowSize();
-
-  const getTextNodes = useCallback(() => {
-    if (withTooltip && cell.current) {
-      setTextNodes(Array.from(cell.current.querySelectorAll(`[data-type="text"]`)));
-    }
-  }, [withTooltip]);
+  const { inView, ref: inViewRef } = useInView({ delay: 500 });
 
   useEffect(() => {
-    // windowWidth is only here so this functionality changes based on window width
-    if (textNodes.length && windowWidth) {
-      const [scrollWidths, clientWidths] = textNodes.reduce(
-        ([scrollWidths, clientWidths], textNode) => {
-          if (textNode) {
-            scrollWidths += textNode.scrollWidth;
-            clientWidths += textNode.clientWidth;
-          }
-          return [scrollWidths, clientWidths];
-        },
-        [0, 0]
-      );
-
-      if (scrollWidths > clientWidths) {
-        setTooltipDisabled(false);
-      } else {
-        setTooltipDisabled(true);
-      }
+    if (!inView || !withTooltip) {
+      // Only handle resize events on the window for this cell (to determine if the tooltip)
+      // needs to be shown if the cell is actually in view
+      return;
     }
-  }, [textNodes, windowWidth]);
+
+    // Calculate based on any potentially truncated `<Text>` element inside this cell, whether
+    // the tooltip should show.
+    const calculateTooltipVisible = () => {
+      const hasEllipsisedElement = Array.from(cellContent.current?.querySelectorAll(`[data-type="text"]`) ?? []).some(
+        (el) => el.scrollWidth > el.clientWidth
+      );
+      setTooltipDisabled(!hasEllipsisedElement);
+    };
+
+    // Recalculate if tooltips should be visible for this cell if the (debounced) window size changes
+    const subscription = fromEvent(window, "resize", { passive: false })
+      // Debounce, since the resize event fires constantly while a user's still resizing the window
+      .pipe(debounceTime(500))
+      .subscribe(() => {
+        calculateTooltipVisible();
+      });
+
+    calculateTooltipVisible();
+
+    return () => {
+      subscription.unsubscribe();
+    };
+  }, [inView, withTooltip]);
 
   return (
-    <div ref={cell} className={classNames(styles.tableCell, className, sizeMap[size])} onMouseEnter={getTextNodes}>
+    <div className={classNames(styles.tableCell, className, sizeMap[size])}>
       {withTooltip ? (
         <Tooltip
           className={classNames(styles.noEllipsis, styles.fullWidthTooltip)}
-          control={children}
+          control={
+            <span
+              ref={(el) => {
+                inViewRef(el);
+                cellContent.current = el;
+              }}
+            >
+              {children}
+            </span>
+          }
           placement="bottom-start"
           disabled={tooltipDisabled}
         >
-          <TooltipText textNodes={textNodes} />
+          {cellContent.current?.textContent}
         </Tooltip>
       ) : (
         children


### PR DESCRIPTION
## What

Fixes https://github.com/airbytehq/airbyte/issues/22196

This fixes the performance issue introduced with the tooltip in the new table as well as the XSS vulnerability introduced by it.

## How

### Performance 

The main problem for performance was that we used `useWindowSize()` hook, which caused on every window resize event this component to be rerendered, i.e. EVERY cell in the whole table got rerendered when the window size changed.

With this change we're making sure to only have those cell rerender (i.e. even listen on the window size) that are currently visible using `react-intersection-observer`, which is a React layer around the Intersection Observer API of the browser and thus can do that reasonably fast.

We also debounce the resize events a bit, since they are fired usually for nearly every pixel you resize the window, so while the user resizes their window we're getting A LOT OF those events, and we don't necessarily determine that tooltip state until they're mostly done with resizing, so debouncing it for 500ms.

### Security

Remove the `dangerouslySetInnerHTML` and instead just use the ref to the current element, and using it `textContent` to show in the modal. This will not take over any HTML elements, but I don't see why we'd need that, given that those cells usually contain field names (and shouldn't have HTML in it) As well as the tooltip just being an additional insight if your screen is too small.