### PR TITLE
QA-Engine: Persist daily reports to GCS

### DIFF
--- a/.github/workflows/run-qa-engine.yml
+++ b/.github/workflows/run-qa-engine.yml
@@ -10,7 +10,7 @@ on:
 jobs:
   run-qa-engine:
     name: "Run QA Engine"
-    #if: github.ref == 'refs/heads/master'
+    if: github.ref == 'refs/heads/master'
     runs-on: ubuntu-latest
     steps:
       - name: Checkout Airbyte

--- a/.github/workflows/run-qa-engine.yml
+++ b/.github/workflows/run-qa-engine.yml
@@ -2,10 +2,10 @@ name: Run QA Engine
 
 on:
   workflow_dispatch:
-  # schedule:
-  ## 1pm UTC is 6am PDT.
-  ## same time as Generate Build Report
-  # - cron: "0 13 * * *"
+  schedule:
+    # 1pm UTC is 6am PDT.
+    # same time as Generate Build Report
+    - cron: "0 13 * * *"
 
 jobs:
   run-qa-engine:
@@ -32,3 +32,4 @@ jobs:
           QA_ENGINE_AIRBYTE_DATA_PROD_SA: "${{ secrets.QA_ENGINE_AIRBYTE_DATA_PROD_SA }}"
           GITHUB_API_TOKEN: ${{ secrets.GH_PAT_MAINTENANCE_OCTAVIA }}
         run: run-qa-engine
+        # run: run-qa-engine --create-prs

--- a/.github/workflows/run-qa-engine.yml
+++ b/.github/workflows/run-qa-engine.yml
@@ -18,7 +18,7 @@ jobs:
       - name: Setup Cloud SDK
         uses: google-github-actions/setup-gcloud@v0
         with:
-          service_account_key: ${{ secrets.PROD_SPEC_CACHE_SA_KEY }}
+          service_account_key: ${{ secrets.QA_ENGINE_AIRBYTE_DATA_PROD_SA }}
           export_default_credentials: true
       - name: Install Python
         uses: actions/setup-python@v4
@@ -29,7 +29,6 @@ jobs:
       - name: Run QA Engine
         env:
           LOGLEVEL: INFO
-          QA_ENGINE_AIRBYTE_DATA_PROD_SA: "${{ secrets.QA_ENGINE_AIRBYTE_DATA_PROD_SA }}"
           GITHUB_API_TOKEN: ${{ secrets.GH_PAT_MAINTENANCE_OCTAVIA }}
         run: run-qa-engine
         # TODO: enable PR creation when all the QA checks are implemented:

--- a/.github/workflows/run-qa-engine.yml
+++ b/.github/workflows/run-qa-engine.yml
@@ -32,4 +32,5 @@ jobs:
           QA_ENGINE_AIRBYTE_DATA_PROD_SA: "${{ secrets.QA_ENGINE_AIRBYTE_DATA_PROD_SA }}"
           GITHUB_API_TOKEN: ${{ secrets.GH_PAT_MAINTENANCE_OCTAVIA }}
         run: run-qa-engine
+        # TODO: enable PR creation when all the QA checks are implemented:
         # run: run-qa-engine --create-prs

--- a/.github/workflows/run-qa-engine.yml
+++ b/.github/workflows/run-qa-engine.yml
@@ -10,7 +10,7 @@ on:
 jobs:
   run-qa-engine:
     name: "Run QA Engine"
-    if: github.ref == 'refs/heads/master'
+    #if: github.ref == 'refs/heads/master'
     runs-on: ubuntu-latest
     steps:
       - name: Checkout Airbyte

--- a/tools/ci_connector_ops/ci_connector_ops/qa_engine/constants.py
+++ b/tools/ci_connector_ops/ci_connector_ops/qa_engine/constants.py
@@ -13,7 +13,7 @@ INAPPROPRIATE_FOR_CLOUD_USE_CONNECTORS = [
     "b76be0a6-27dc-4560-95f6-2623da0bd7b6",  # Local SQL Lite
 ]
 
-GCS_QA_REPORT_PATH = "gs://prod-airbyte-cloud-connector-metadata-service/qa_report.json"
+GCS_QA_REPORT_PATH = "gs://airbyte-data-connectors-qa-engine/"
 AIRBYTE_PLATFORM_INTERNAL_REPO_OWNER = "airbytehq"
 AIRBYTE_PLATFORM_INTERNAL_REPO_NAME = "airbyte-platform-internal"
 AIRBYTE_PLATFORM_INTERNAL_GITHUB_REPO_URL = (

--- a/tools/ci_connector_ops/ci_connector_ops/qa_engine/main.py
+++ b/tools/ci_connector_ops/ci_connector_ops/qa_engine/main.py
@@ -4,15 +4,20 @@
 
 import logging
 
-from . import cloud_availability_updater, enrichments, inputs, validations
-from .constants import CLOUD_CATALOG_URL, OSS_CATALOG_URL
+import click
+
+from . import cloud_availability_updater, enrichments, inputs, outputs, validations
+from .constants import CLOUD_CATALOG_URL, GCS_QA_REPORT_PATH, OSS_CATALOG_URL
 
 logging.basicConfig(level=logging.INFO)
 
 logger = logging.getLogger(__name__)
 
 
-def main():
+@click.command()
+@click.option("--create-prs", is_flag=True)
+def main(create_prs):
+    breakpoint()
     logger.info("Fetch the OSS connectors catalog.")
     oss_catalog = inputs.fetch_remote_catalog(OSS_CATALOG_URL)
     logger.info("Fetch the Cloud connectors catalog.")
@@ -23,7 +28,10 @@ def main():
     enriched_catalog = enrichments.get_enriched_catalog(oss_catalog, cloud_catalog, adoption_metrics_per_connector_version)
     logger.info("Start the QA report generation.")
     qa_report = validations.get_qa_report(enriched_catalog, len(oss_catalog))
-    logger.info("Start the QA report generation.")
+    logger.info("Persist QA report to GCS")
+    outputs.persist_qa_report(qa_report, GCS_QA_REPORT_PATH, public_fields_only=False)
     eligible_connectors = validations.get_connectors_eligible_for_cloud(qa_report)
-    logger.info("Start eligible connectors deployment to Cloud.")
-    cloud_availability_updater.deploy_eligible_connectors_to_cloud_repo(eligible_connectors)
+
+    if create_prs:
+        logger.info("Start eligible connectors deployment to Cloud.")
+        cloud_availability_updater.deploy_eligible_connectors_to_cloud_repo(eligible_connectors)

--- a/tools/ci_connector_ops/ci_connector_ops/qa_engine/main.py
+++ b/tools/ci_connector_ops/ci_connector_ops/qa_engine/main.py
@@ -17,7 +17,6 @@ logger = logging.getLogger(__name__)
 @click.command()
 @click.option("--create-prs", is_flag=True)
 def main(create_prs):
-    breakpoint()
     logger.info("Fetch the OSS connectors catalog.")
     oss_catalog = inputs.fetch_remote_catalog(OSS_CATALOG_URL)
     logger.info("Fetch the Cloud connectors catalog.")
@@ -30,8 +29,8 @@ def main(create_prs):
     qa_report = validations.get_qa_report(enriched_catalog, len(oss_catalog))
     logger.info("Persist QA report to GCS")
     outputs.persist_qa_report(qa_report, GCS_QA_REPORT_PATH, public_fields_only=False)
-    eligible_connectors = validations.get_connectors_eligible_for_cloud(qa_report)
 
     if create_prs:
         logger.info("Start eligible connectors deployment to Cloud.")
+        eligible_connectors = validations.get_connectors_eligible_for_cloud(qa_report)
         cloud_availability_updater.deploy_eligible_connectors_to_cloud_repo(eligible_connectors)

--- a/tools/ci_connector_ops/ci_connector_ops/qa_engine/outputs.py
+++ b/tools/ci_connector_ops/ci_connector_ops/qa_engine/outputs.py
@@ -3,13 +3,18 @@
 #
 
 
+from datetime import datetime
+
 import pandas as pd
 
 from .models import ConnectorQAReport
 
-def persist_qa_report(qa_report: pd.DataFrame, path: str, public_fields_only: bool =True):
+
+def persist_qa_report(qa_report: pd.DataFrame, path: str, public_fields_only: bool = True) -> str:
+    report_generation_date = datetime.strftime(qa_report["report_generation_datetime"].max(), "%Y%m%d")
+    path = path + f"{report_generation_date}_qa_report.jsonl"
     final_fields = [
-        field.name for field in ConnectorQAReport.__fields__.values() 
-        if field.field_info.extra["is_public"] or not public_fields_only
+        field.name for field in ConnectorQAReport.__fields__.values() if field.field_info.extra["is_public"] or not public_fields_only
     ]
-    qa_report[final_fields].to_json(path, orient="records")
+    qa_report[final_fields].to_json(path, orient="records", lines=True)
+    return path

--- a/tools/ci_connector_ops/setup.py
+++ b/tools/ci_connector_ops/setup.py
@@ -5,6 +5,7 @@
 from setuptools import find_packages, setup
 
 MAIN_REQUIREMENTS = [
+    "click~=8.1.3",
     "requests",
     "PyYAML~=6.0",
     "GitPython~=3.1.29",

--- a/tools/ci_connector_ops/tests/test_qa_engine/test_cloud_availability_updater.py
+++ b/tools/ci_connector_ops/tests/test_qa_engine/test_cloud_availability_updater.py
@@ -1,5 +1,5 @@
 #
-# Copyright (c) 2022 Airbyte, Inc., all rights reserved.
+# Copyright (c) 2023 Airbyte, Inc., all rights reserved.
 #
 
 
@@ -167,11 +167,11 @@ def test_create_pr(mocker, pr_already_created):
     response = cloud_availability_updater.create_pr(connector, "my_awesome_branch")
     expected_url = "https://api.github.com/repos/airbytehq/airbyte-platform-internal/pulls"
     expected_body = f"""The Cloud Availability Updater decided that it's the right time to make {connector.connector_name} available on Cloud!
-    Technical name: {connector.connector_technical_name}
-    Version: {connector.connector_version}
-    Definition ID: {connector.connector_definition_id}
-    OSS sync success rate: {connector.sync_success_rate}
-    OSS number of connections: {connector.number_of_connections}
+    - Technical name: {connector.connector_technical_name}
+    - Version: {connector.connector_version}
+    - Definition ID: {connector.connector_definition_id}
+    - OSS sync success rate: {connector.sync_success_rate}
+    - OSS number of connections: {connector.number_of_connections}
     """
     expected_data = {
         "title": "🤖 Add source-foobar to cloud",

--- a/tools/ci_connector_ops/tests/test_qa_engine/test_inputs.py
+++ b/tools/ci_connector_ops/tests/test_qa_engine/test_inputs.py
@@ -53,12 +53,7 @@ def test_fetch_adoption_metrics_per_connector_version(mocker):
     adoption_metrics_per_connector_version = inputs.fetch_adoption_metrics_per_connector_version()
     assert isinstance(adoption_metrics_per_connector_version, pd.DataFrame)
     assert set(adoption_metrics_per_connector_version.columns) == expected_columns
-    inputs.service_account.Credentials.from_service_account_info.assert_called_with({"type": "fake_service_account"})
-    inputs.pd.read_gbq.assert_called_with(
-        expected_sql_query,
-        project_id=expected_project_id,
-        credentials=inputs.service_account.Credentials.from_service_account_info.return_value,
-    )
+    inputs.pd.read_gbq.assert_called_with(expected_sql_query, project_id=expected_project_id)
 
 
 @pytest.mark.parametrize(

--- a/tools/ci_connector_ops/tests/test_qa_engine/test_inputs.py
+++ b/tools/ci_connector_ops/tests/test_qa_engine/test_inputs.py
@@ -4,13 +4,13 @@
 
 
 from importlib.resources import files
+from unittest.mock import MagicMock, call
 
 import pandas as pd
 import pytest
-from unittest.mock import MagicMock, call
 import requests
+from ci_connector_ops.qa_engine import constants, inputs
 
-from ci_connector_ops.qa_engine import inputs, constants
 
 @pytest.mark.parametrize("catalog_url", [constants.OSS_CATALOG_URL, constants.CLOUD_CATALOG_URL])
 def test_fetch_remote_catalog(catalog_url):
@@ -20,21 +20,24 @@ def test_fetch_remote_catalog(catalog_url):
     assert all(expected_column in catalog.columns for expected_column in expected_columns)
     assert set(catalog.connector_type.unique()) == {"source", "destination"}
 
+
 def test_fetch_adoption_metrics_per_connector_version(mocker):
-    fake_bigquery_results = pd.DataFrame([{
-        "connector_definition_id": "abcdefgh",
-        "connector_version": "0.0.0",
-        "number_of_connections": 10,
-        "number_of_users": 2,
-        "succeeded_syncs_count": 12,
-        "failed_syncs_count": 1,
-        "total_syncs_count": 3,
-        "sync_success_rate": .99,
-        "unexpected_column": "foobar"
-    }])
+    fake_bigquery_results = pd.DataFrame(
+        [
+            {
+                "connector_definition_id": "abcdefgh",
+                "connector_version": "0.0.0",
+                "number_of_connections": 10,
+                "number_of_users": 2,
+                "succeeded_syncs_count": 12,
+                "failed_syncs_count": 1,
+                "total_syncs_count": 3,
+                "sync_success_rate": 0.99,
+                "unexpected_column": "foobar",
+            }
+        ]
+    )
     mocker.patch.object(inputs.pd, "read_gbq", mocker.Mock(return_value=fake_bigquery_results))
-    mocker.patch.object(inputs.os, "environ", {"QA_ENGINE_AIRBYTE_DATA_PROD_SA": '{"type": "fake_service_account"}'})
-    mocker.patch.object(inputs.service_account.Credentials, "from_service_account_info")
     expected_columns = {
         "connector_definition_id",
         "connector_version",
@@ -50,78 +53,71 @@ def test_fetch_adoption_metrics_per_connector_version(mocker):
     adoption_metrics_per_connector_version = inputs.fetch_adoption_metrics_per_connector_version()
     assert isinstance(adoption_metrics_per_connector_version, pd.DataFrame)
     assert set(adoption_metrics_per_connector_version.columns) == expected_columns
-    inputs.service_account.Credentials.from_service_account_info.assert_called_with(
-        {"type": "fake_service_account"}
-    )
+    inputs.service_account.Credentials.from_service_account_info.assert_called_with({"type": "fake_service_account"})
     inputs.pd.read_gbq.assert_called_with(
         expected_sql_query,
         project_id=expected_project_id,
-        credentials=inputs.service_account.Credentials.from_service_account_info.return_value
+        credentials=inputs.service_account.Credentials.from_service_account_info.return_value,
     )
 
-@pytest.mark.parametrize("connector_name, connector_version, mocked_json_payload, mocked_status_code, expected_status", [
-    (
-        "connectors/source-pokeapi",
-        "0.1.5",
-        {
-            "link": "https://github.com/airbytehq/airbyte/actions/runs/4029659593",
-            "outcome": "success",
-            "docker_version": "0.1.5",
-            "timestamp": "1674872401",
-            "connector": "connectors/source-pokeapi"
-        },
-        200,
-        inputs.BUILD_STATUSES.SUCCESS
-    ),
-    (
-        "connectors/source-pokeapi",
-        "0.1.5",
-        {
-            "link": "https://github.com/airbytehq/airbyte/actions/runs/4029659593",
-            "outcome": "failure",
-            "docker_version": "0.1.5",
-            "timestamp": "1674872401",
-            "connector": "connectors/source-pokeapi"
-        },
-        200,
-        inputs.BUILD_STATUSES.FAILURE
-    ),
-    (
-        "connectors/source-pokeapi",
-        "0.1.5",
-        None,
-        404,
-        inputs.BUILD_STATUSES.NOT_FOUND
-    ),
-    (
-        "connectors/source-pokeapi",
-        "0.1.5",
-        {
-            "link": "https://github.com/airbytehq/airbyte/actions/runs/4029659593",
-            "docker_version": "0.1.5",
-            "timestamp": "1674872401",
-            "connector": "connectors/source-pokeapi"
-        },
-        200,
-        inputs.BUILD_STATUSES.NOT_FOUND
-    ),
-    (
-        "connectors/source-pokeapi",
-        "0.1.5",
-        None,
-        404,
-        inputs.BUILD_STATUSES.NOT_FOUND
-    ),
-])
-def test_fetch_latest_build_status_for_connector_version(mocker, connector_name, connector_version, mocked_json_payload, mocked_status_code, expected_status):
+
+@pytest.mark.parametrize(
+    "connector_name, connector_version, mocked_json_payload, mocked_status_code, expected_status",
+    [
+        (
+            "connectors/source-pokeapi",
+            "0.1.5",
+            {
+                "link": "https://github.com/airbytehq/airbyte/actions/runs/4029659593",
+                "outcome": "success",
+                "docker_version": "0.1.5",
+                "timestamp": "1674872401",
+                "connector": "connectors/source-pokeapi",
+            },
+            200,
+            inputs.BUILD_STATUSES.SUCCESS,
+        ),
+        (
+            "connectors/source-pokeapi",
+            "0.1.5",
+            {
+                "link": "https://github.com/airbytehq/airbyte/actions/runs/4029659593",
+                "outcome": "failure",
+                "docker_version": "0.1.5",
+                "timestamp": "1674872401",
+                "connector": "connectors/source-pokeapi",
+            },
+            200,
+            inputs.BUILD_STATUSES.FAILURE,
+        ),
+        ("connectors/source-pokeapi", "0.1.5", None, 404, inputs.BUILD_STATUSES.NOT_FOUND),
+        (
+            "connectors/source-pokeapi",
+            "0.1.5",
+            {
+                "link": "https://github.com/airbytehq/airbyte/actions/runs/4029659593",
+                "docker_version": "0.1.5",
+                "timestamp": "1674872401",
+                "connector": "connectors/source-pokeapi",
+            },
+            200,
+            inputs.BUILD_STATUSES.NOT_FOUND,
+        ),
+        ("connectors/source-pokeapi", "0.1.5", None, 404, inputs.BUILD_STATUSES.NOT_FOUND),
+    ],
+)
+def test_fetch_latest_build_status_for_connector_version(
+    mocker, connector_name, connector_version, mocked_json_payload, mocked_status_code, expected_status
+):
     # Mock the api call to get the latest build status for a connector version
     mock_response = MagicMock()
     mock_response.json.return_value = mocked_json_payload
     mock_response.status_code = mocked_status_code
-    mock_get = mocker.patch.object(requests, 'get', return_value=mock_response)
+    mock_get = mocker.patch.object(requests, "get", return_value=mock_response)
 
     assert inputs.fetch_latest_build_status_for_connector_version(connector_name, connector_version) == expected_status
     assert mock_get.call_args == call(f"{constants.CONNECTOR_BUILD_OUTPUT_URL}/{connector_name}/version-{connector_version}.json")
+
 
 def test_fetch_latest_build_status_for_connector_version_invalid_status(mocker, caplog):
     connector_name = "connectors/source-pokeapi"
@@ -131,13 +127,13 @@ def test_fetch_latest_build_status_for_connector_version_invalid_status(mocker, 
         "outcome": "unknown_outcome_123",
         "docker_version": "0.1.5",
         "timestamp": "1674872401",
-        "connector": "connectors/source-pokeapi"
+        "connector": "connectors/source-pokeapi",
     }
     # Mock the api call to get the latest build status for a connector version
     mock_response = MagicMock()
     mock_response.json.return_value = mocked_json_payload
     mock_response.status_code = 200
-    mocker.patch.object(requests, 'get', return_value=mock_response)
+    mocker.patch.object(requests, "get", return_value=mock_response)
 
     assert inputs.fetch_latest_build_status_for_connector_version(connector_name, connector_version) == inputs.BUILD_STATUSES.NOT_FOUND
-    assert 'Error: Unexpected build status value: unknown_outcome_123 for connector connectors/source-pokeapi:0.1.5' in caplog.text
+    assert "Error: Unexpected build status value: unknown_outcome_123 for connector connectors/source-pokeapi:0.1.5" in caplog.text

--- a/tools/ci_connector_ops/tests/test_qa_engine/test_main.py
+++ b/tools/ci_connector_ops/tests/test_qa_engine/test_main.py
@@ -1,12 +1,17 @@
 #
-# Copyright (c) 2022 Airbyte, Inc., all rights reserved.
+# Copyright (c) 2023 Airbyte, Inc., all rights reserved.
 #
 
 
+import pytest
 from ci_connector_ops.qa_engine import main
+from click.testing import CliRunner
 
 
-def test_main(mocker, dummy_qa_report):
+@pytest.mark.parametrize("create_prs", [False, True])
+def test_main(mocker, dummy_qa_report, create_prs):
+    runner = CliRunner()
+
     mock_oss_catalog = mocker.Mock(__len__=mocker.Mock(return_value=42))
     mock_cloud_catalog = mocker.Mock()
 
@@ -16,8 +21,12 @@ def test_main(mocker, dummy_qa_report):
     mocker.patch.object(main.validations, "get_qa_report", mocker.Mock(return_value=dummy_qa_report))
     mocker.patch.object(main.validations, "get_connectors_eligible_for_cloud")
     mocker.patch.object(main.cloud_availability_updater, "deploy_eligible_connectors_to_cloud_repo")
+    mocker.patch.object(main.outputs, "persist_qa_report")
 
-    main.main()
+    if create_prs:
+        runner.invoke(main.main, ["--create-prs"])
+    else:
+        runner.invoke(main.main)
 
     assert main.inputs.fetch_remote_catalog.call_count == 2
     main.inputs.fetch_remote_catalog.assert_has_calls([mocker.call(main.OSS_CATALOG_URL), mocker.call(main.CLOUD_CATALOG_URL)])
@@ -25,7 +34,11 @@ def test_main(mocker, dummy_qa_report):
         mock_oss_catalog, mock_cloud_catalog, main.inputs.fetch_adoption_metrics_per_connector_version.return_value
     )
     main.validations.get_qa_report.assert_called_with(main.enrichments.get_enriched_catalog.return_value, len(mock_oss_catalog))
-    main.validations.get_connectors_eligible_for_cloud.assert_called_with(main.validations.get_qa_report.return_value)
-    main.cloud_availability_updater.deploy_eligible_connectors_to_cloud_repo.assert_called_with(
-        main.validations.get_connectors_eligible_for_cloud.return_value
+    main.outputs.persist_qa_report.assert_called_with(
+        main.validations.get_qa_report.return_value, main.GCS_QA_REPORT_PATH, public_fields_only=False
     )
+    if create_prs:
+        main.validations.get_connectors_eligible_for_cloud.assert_called_with(main.validations.get_qa_report.return_value)
+        main.cloud_availability_updater.deploy_eligible_connectors_to_cloud_repo.assert_called_with(
+            main.validations.get_connectors_eligible_for_cloud.return_value
+        )

--- a/tools/ci_connector_ops/tests/test_qa_engine/test_outputs.py
+++ b/tools/ci_connector_ops/tests/test_qa_engine/test_outputs.py
@@ -5,18 +5,14 @@
 
 import pandas as pd
 import pytest
-
 from ci_connector_ops.qa_engine import outputs
+
 
 @pytest.mark.parametrize("public_fields_only", [True, False])
 def test_persist_qa_report_public_fields_only(tmp_path, dummy_qa_report, public_fields_only):
-    output_path = tmp_path / "qa_report.json"
-    outputs.persist_qa_report(dummy_qa_report, output_path, public_fields_only=public_fields_only)
+    output_path = outputs.persist_qa_report(dummy_qa_report, str(tmp_path), public_fields_only=public_fields_only)
     qa_report_from_disk = pd.read_json(output_path)
-    private_fields = {
-        field.name for field in outputs.ConnectorQAReport.__fields__.values() 
-        if not field.field_info.extra["is_public"]
-    }
+    private_fields = {field.name for field in outputs.ConnectorQAReport.__fields__.values() if not field.field_info.extra["is_public"]}
     available_fields = set(qa_report_from_disk.columns)
     if public_fields_only:
         assert not private_fields.issubset(available_fields)

--- a/tools/ci_connector_ops/tests/test_qa_engine/test_outputs.py
+++ b/tools/ci_connector_ops/tests/test_qa_engine/test_outputs.py
@@ -9,9 +9,9 @@ from ci_connector_ops.qa_engine import outputs
 
 
 @pytest.mark.parametrize("public_fields_only", [True, False])
-def test_persist_qa_report_public_fields_only(tmp_path, dummy_qa_report, public_fields_only):
+def test_persist_qa_report(tmp_path, dummy_qa_report, public_fields_only):
     output_path = outputs.persist_qa_report(dummy_qa_report, str(tmp_path), public_fields_only=public_fields_only)
-    qa_report_from_disk = pd.read_json(output_path)
+    qa_report_from_disk = pd.read_json(output_path, lines=True)
     private_fields = {field.name for field in outputs.ConnectorQAReport.__fields__.values() if not field.field_info.extra["is_public"]}
     available_fields = set(qa_report_from_disk.columns)
     if public_fields_only:


### PR DESCRIPTION
## What
@airbytehq/airbyte-analytics created a dedicated private bucket to store QA reports.
I want to make the QA engine write these reports to GCS in JSONL with generation in the file names.
It will be available on metabase [here](https://airbyte.metabaseapp.com/question/1810-qa-report) 

## How
* Tweak `persist_qa_report` function
* Fix some tests
* Add a CLI flag to optionally create PRs: so that we can run the daily report generation without creating PRs.


