### PR TITLE
🪟 🐛 [Connector Builder] add check for undefined values.checkStreams

### DIFF
--- a/airbyte-webapp/src/components/connectorBuilder/types.ts
+++ b/airbyte-webapp/src/components/connectorBuilder/types.ts
@@ -643,7 +643,7 @@ export const convertToManifest = (values: BuilderFormValues): ConnectorManifest 
   };
 
   const streamNames = values.streams.map((s) => s.name);
-  const validCheckStreamNames = values.checkStreams.filter((checkStream) => streamNames.includes(checkStream));
+  const validCheckStreamNames = (values.checkStreams ?? []).filter((checkStream) => streamNames.includes(checkStream));
   const correctedCheckStreams =
     validCheckStreamNames.length > 0 ? validCheckStreamNames : streamNames.length > 0 ? [streamNames[0]] : [];
 


### PR DESCRIPTION
## What
Fixes an issue where a field was added to BuilderFormValues which was not set in local storage, causing the builder UI to crash.
