### PR TITLE
fix: Double `Run Helm End-to-End Acceptance Tests` timeout

### DIFF
--- a/.github/workflows/gradle.yml
+++ b/.github/workflows/gradle.yml
@@ -1216,7 +1216,7 @@ jobs:
           AWS_S3_BUCKET: airbyte-ci-ac-tests-logs
           SECRET_STORE_GCP_CREDENTIALS: ${{ secrets.SECRET_STORE_GCP_CREDENTIALS }}
           SECRET_STORE_GCP_PROJECT_ID: ${{ secrets.SECRET_STORE_GCP_PROJECT_ID }}
-        timeout-minutes: 20
+        timeout-minutes: 40
         uses: Wandalen/wretry.action@master
         with:
           command: CI=true IS_MINIKUBE=true ./tools/bin/acceptance_test_kube_helm.sh


### PR DESCRIPTION
## What
As we add more tests to the Acceptance test, the time to finish them is growing. Nowadays the step `Run Helm End-to-End Acceptance Tests` timeouts after 20 minutes running the tests.

This problem is blocking PR merges to master.

## How
Double step timeout for `Run Helm End-to-End Acceptance Tests` step.
