### PR TITLE
:window: :tada: show FCP enrollment banner on create connector page

### DIFF
--- a/airbyte-webapp/src/packages/cloud/components/experiments/FreeConnectorProgram/InlineEnrollmentCallout.module.scss
+++ b/airbyte-webapp/src/packages/cloud/components/experiments/FreeConnectorProgram/InlineEnrollmentCallout.module.scss
@@ -6,6 +6,10 @@
   width: 100%;
 }
 
+.withBottomMargin {
+  margin-bottom: variables.$spacing-lg;
+}
+
 .enrollLink {
   text-decoration: underline;
   cursor: pointer;

--- a/airbyte-webapp/src/packages/cloud/components/experiments/FreeConnectorProgram/InlineEnrollmentCallout.tsx
+++ b/airbyte-webapp/src/packages/cloud/components/experiments/FreeConnectorProgram/InlineEnrollmentCallout.tsx
@@ -1,3 +1,4 @@
+import classNames from "classnames";
 import React, { PropsWithChildren } from "react";
 import { FormattedMessage } from "react-intl";
 
@@ -17,7 +18,12 @@ export const EnrollLink: React.FC<PropsWithChildren<unknown>> = ({ children }) =
     </button>
   );
 };
-export const InlineEnrollmentCallout: React.FC = () => {
+
+interface InlineEnrollmentCalloutProps {
+  withBottomMargin?: boolean;
+}
+
+export const InlineEnrollmentCallout: React.FC<InlineEnrollmentCalloutProps> = ({ withBottomMargin }) => {
   const { userDidEnroll, enrollmentStatusQuery } = useFreeConnectorProgram();
   const { showEnrollmentUi } = enrollmentStatusQuery.data || {};
 
@@ -26,7 +32,7 @@ export const InlineEnrollmentCallout: React.FC = () => {
   }
 
   return (
-    <Callout variant="info" className={styles.container}>
+    <Callout variant="info" className={classNames(styles.container, { [styles.withBottomMargin]: withBottomMargin })}>
       <Text size="sm">
         <FormattedMessage
           id="freeConnectorProgram.youCanEnroll"

--- a/airbyte-webapp/src/packages/cloud/components/experiments/FreeConnectorProgram/hooks/useFreeConnectorProgram.ts
+++ b/airbyte-webapp/src/packages/cloud/components/experiments/FreeConnectorProgram/hooks/useFreeConnectorProgram.ts
@@ -34,16 +34,20 @@ export const useFreeConnectorProgram = () => {
   const { registerNotification } = useNotificationService();
   const { trackError } = useAppMonitoringService();
 
+  const removeStripeSuccessQuery = () => {
+    const { [STRIPE_SUCCESS_QUERY]: _, ...unrelatedSearchParams } = Object.fromEntries(searchParams);
+    setSearchParams(unrelatedSearchParams, { replace: true });
+  };
+
   useEffectOnce(() => {
     if (searchParams.has(STRIPE_SUCCESS_QUERY)) {
-      // Remove the stripe parameter from the URL
       pollUntil(
         () => webBackendGetFreeConnectorProgramInfoForWorkspace({ workspaceId }, requestOptions),
         ({ hasPaymentAccountSaved }) => hasPaymentAccountSaved,
         { intervalMs: 1000, maxTimeoutMs: 10000 }
       ).then((maybeFcpInfo) => {
         if (maybeFcpInfo) {
-          setSearchParams({}, { replace: true });
+          removeStripeSuccessQuery();
           setUserDidEnroll(true);
           registerNotification({
             id: "fcp/enrollment-success",

--- a/airbyte-webapp/src/pages/connections/CreateConnectionPage/CreateConnectionPage.tsx
+++ b/airbyte-webapp/src/pages/connections/CreateConnectionPage/CreateConnectionPage.tsx
@@ -1,4 +1,4 @@
-import React, { useState } from "react";
+import React, { useState, useEffect } from "react";
 import { FormattedMessage, useIntl } from "react-intl";
 import { useLocation, useNavigate, useSearchParams } from "react-router-dom";
 
@@ -60,14 +60,44 @@ function usePreloadData(): {
   destinationDefinition?: DestinationDefinitionRead;
 } {
   const location = useLocation();
+  const navigate = useNavigate();
   const [searchParams, setSearchParams] = useSearchParams();
 
-  const sourceId = hasSourceId(location.state) ? location.state.sourceId : searchParams.get("sourceId");
-  const source = useGetSource(sourceId);
+  const sourceIdFromLocationState = hasSourceId(location.state) && location.state.sourceId;
+  const sourceIdFromSearchParams = searchParams.get("sourceId");
+  const sourceId = sourceIdFromLocationState || sourceIdFromSearchParams;
 
-  if (source && source.sourceId !== searchParams.get("sourceId")) {
-    setSearchParams({ sourceId: source.sourceId });
-  }
+  /**
+   * There are two places we may find a sourceId, depending on the scenario. This effect
+   * keeps them in sync according to the following logic:
+   *   0) if `location.state.sourceId` and the `sourceId` query param are both unset or
+   *      are both set to the same value, then we don't need to take any action.
+   *   1) else if `location.state.sourceId` exists, we arrived at this page via the legacy
+   *      internal "routing" system, meaning there has been a user interaction
+   *      specifically selecting that source. This is the highest precedence source of
+   *      truth, so if it exists we explicitly set the sourceId query param to match it.
+   *   2) else if there's a `sourceId` query param, we arrived at this page via a fresh
+   *      page load. This logic was added to support the airbyte-cloud's free connector
+   *      program enrollment flow: it involves a round-trip visit to a Stripe domain,
+   *      which wipes location.state. We explicitly navigate to the current path
+   *      (including the current query string) with `location.state.sourceId` set.
+   */
+  useEffect(() => {
+    if (sourceIdFromLocationState && sourceIdFromSearchParams === sourceIdFromLocationState) {
+      // sourceId is set and everything is in sync, no further action needed
+    } else if (sourceIdFromLocationState) {
+      sourceId && setSearchParams({ sourceId });
+    } else if (sourceIdFromSearchParams) {
+      // we have to simultaneously set both the query string and location.state to avoid
+      // an infinite mutually recursive rerender loop:
+      //   A: set location.state and rerender; GOTO B
+      //   B: set query param and rerender; GOTO A
+      navigate(`${location.search}`, { state: { sourceId }, replace: true });
+    } else {
+      // sourceId is unset and everything is in sync, no further action needed
+    }
+  }, [sourceIdFromLocationState, sourceIdFromSearchParams, setSearchParams, navigate, sourceId, location.search]);
+  const source = useGetSource(sourceId);
 
   const sourceDefinition = useSourceDefinition(source?.sourceDefinitionId);
 
@@ -85,7 +115,7 @@ export const CreateConnectionPage: React.FC = () => {
   const navigate = useNavigate();
   const { clearAllFormChanges } = useFormChangeTrackerService();
 
-  // TODO: Probably there is a better way to figure it out instead of just checking third elem
+  // TODO: select UI and behavior based on the route using, you know, the router
   const locationType = location.pathname.split("/")[3];
 
   const type: EntityStepsTypes =

--- a/airbyte-webapp/src/pages/connections/CreateConnectionPage/CreateConnectionPage.tsx
+++ b/airbyte-webapp/src/pages/connections/CreateConnectionPage/CreateConnectionPage.tsx
@@ -21,6 +21,7 @@ import { useTrackPage, PageTrackingCodes } from "hooks/services/Analytics";
 import { useFormChangeTrackerService } from "hooks/services/FormChangeTracker";
 import { useGetDestination } from "hooks/services/useDestinationHook";
 import { useGetSource } from "hooks/services/useSourceHook";
+import { InlineEnrollmentCallout } from "packages/cloud/components/experiments/FreeConnectorProgram/InlineEnrollmentCallout";
 import { useDestinationDefinition } from "services/connector/DestinationDefinitionService";
 import { useSourceDefinition } from "services/connector/SourceDefinitionService";
 import { ConnectorDocumentationWrapper } from "views/Connector/ConnectorDocumentationLayout";
@@ -188,6 +189,7 @@ export const CreateConnectionPage: React.FC = () => {
       } else if (currentEntityStep === EntityStepsTypes.DESTINATION) {
         return (
           <>
+            {source && <InlineEnrollmentCallout withBottomMargin />}
             {type === EntityStepsTypes.CONNECTION && (
               <ExistingEntityForm type="destination" onSubmit={onSelectExistingDestination} />
             )}

--- a/airbyte-webapp/src/pages/connections/CreateConnectionPage/CreateConnectionPage.tsx
+++ b/airbyte-webapp/src/pages/connections/CreateConnectionPage/CreateConnectionPage.tsx
@@ -29,13 +29,13 @@ import { ConnectionCreateDestinationForm } from "./ConnectionCreateDestinationFo
 import { ConnectionCreateSourceForm } from "./ConnectionCreateSourceForm";
 import ExistingEntityForm from "./ExistingEntityForm";
 
-export enum StepsTypes {
+enum StepsTypes {
   CREATE_ENTITY = "createEntity",
   CREATE_CONNECTOR = "createConnector",
   CREATE_CONNECTION = "createConnection",
 }
 
-export enum EntityStepsTypes {
+enum EntityStepsTypes {
   SOURCE = "source",
   DESTINATION = "destination",
   CONNECTION = "connection",

--- a/airbyte-webapp/src/pages/connections/CreateConnectionPage/CreateConnectionPage.tsx
+++ b/airbyte-webapp/src/pages/connections/CreateConnectionPage/CreateConnectionPage.tsx
@@ -1,6 +1,6 @@
 import React, { useState } from "react";
 import { FormattedMessage, useIntl } from "react-intl";
-import { useLocation, useNavigate } from "react-router-dom";
+import { useLocation, useNavigate, useSearchParams } from "react-router-dom";
 
 import { LoadingPage } from "components";
 import { CloudInviteUsersHint } from "components/CloudInviteUsersHint";
@@ -60,8 +60,14 @@ function usePreloadData(): {
   destinationDefinition?: DestinationDefinitionRead;
 } {
   const location = useLocation();
+  const [searchParams, setSearchParams] = useSearchParams();
 
-  const source = useGetSource(hasSourceId(location.state) ? location.state.sourceId : null);
+  const sourceId = hasSourceId(location.state) ? location.state.sourceId : searchParams.get("sourceId");
+  const source = useGetSource(sourceId);
+
+  if (source && source.sourceId !== searchParams.get("sourceId")) {
+    setSearchParams({ sourceId: source.sourceId });
+  }
 
   const sourceDefinition = useSourceDefinition(source?.sourceDefinitionId);
 

--- a/airbyte-webapp/src/pages/connections/CreateConnectionPage/CreateConnectionPage.tsx
+++ b/airbyte-webapp/src/pages/connections/CreateConnectionPage/CreateConnectionPage.tsx
@@ -200,7 +200,7 @@ export const CreateConnectionPage: React.FC = () => {
               }
             />
           )}
-          <InlineEnrollmentCallout withBottomMargin />
+          {currentStep !== StepsTypes.CREATE_CONNECTION && <InlineEnrollmentCallout withBottomMargin />}
           {renderStep()}
         </FormPageContent>
       </ConnectorDocumentationWrapper>

--- a/airbyte-webapp/src/pages/connections/CreateConnectionPage/CreateConnectionPage.tsx
+++ b/airbyte-webapp/src/pages/connections/CreateConnectionPage/CreateConnectionPage.tsx
@@ -114,7 +114,6 @@ export const CreateConnectionPage: React.FC = () => {
       } else if (currentEntityStep === EntityStepsTypes.DESTINATION) {
         return (
           <>
-            {source && <InlineEnrollmentCallout withBottomMargin />}
             {type === EntityStepsTypes.CONNECTION && (
               <ExistingEntityForm type="destination" onSubmit={onSelectExistingDestination} />
             )}
@@ -201,6 +200,7 @@ export const CreateConnectionPage: React.FC = () => {
               }
             />
           )}
+          <InlineEnrollmentCallout withBottomMargin />
           {renderStep()}
         </FormPageContent>
       </ConnectorDocumentationWrapper>

--- a/airbyte-webapp/src/pages/connections/CreateConnectionPage/usePreloadData.ts
+++ b/airbyte-webapp/src/pages/connections/CreateConnectionPage/usePreloadData.ts
@@ -38,41 +38,75 @@ export function usePreloadData(): {
   const sourceIdFromSearchParams = searchParams.get("sourceId");
   const sourceId = sourceIdFromLocationState || sourceIdFromSearchParams;
 
+  const destinationIdFromLocationState = hasDestinationId(location.state) && location.state.destinationId;
+  const destinationIdFromSearchParams = searchParams.get("destinationId");
+  const destinationId = destinationIdFromLocationState || destinationIdFromSearchParams;
+
   /**
-   * There are two places we may find a sourceId, depending on the scenario. This effect
-   * keeps them in sync according to the following logic:
-   *   0) if `location.state.sourceId` and the `sourceId` query param are both unset or
+   * There are two places we may find a sourceId or destinationId, depending on the
+   * scenario. This effect keeps each of them in sync according to the following logic;
+   * sourceId and destinationId sort out their sources of truth by parallel logic, so I'll
+   * use `connectorId` as a generic stand-in:
+   *   0) if `location.state.connectorId` and the `connectorId` query param are both unset or
    *      are both set to the same value, then we don't need to take any action.
-   *   1) else if `location.state.sourceId` exists, we arrived at this page via the legacy
+   *   1) else if `location.state.connectorId` exists, we arrived at this page via the legacy
    *      internal "routing" system, meaning there has been a user interaction
-   *      specifically selecting that source. This is the highest precedence source of
-   *      truth, so if it exists we explicitly set the sourceId query param to match it.
-   *   2) else if there's a `sourceId` query param, we arrived at this page via a fresh
+   *      specifically selecting that source/destination. This is the highest precedence
+   *      source of truth, so if it exists we just want to make the `connectorId` query
+   *      param match it.
+   *   2) else if there's a `connectorId` query param, we arrived at this page via a fresh
    *      page load. This logic was added to support the airbyte-cloud's free connector
-   *      program enrollment flow: it involves a round-trip visit to a Stripe domain,
-   *      which wipes location.state. We explicitly navigate to the current path
-   *      (including the current query string) with `location.state.sourceId` set.
+   *      program enrollment flow (which involves a round-trip visit to a Stripe domain,
+   *      which wipes location.state), but it's not explicitly tied to it. We explicitly
+   *      navigate to the current path (including the current query string, to avoid going
+   *      around in circles) while setting the missing `location.state.connectorId`.
+   *
+   * There are several states for each kind of connector, so let's extract a bunch of named
+   * boolean variables to try to keep the combinations readable.
    */
+  const sourceIdInBoth = sourceIdFromLocationState && sourceIdFromSearchParams === sourceIdFromLocationState;
+  const sourceIdInNeither = !sourceIdFromLocationState && !sourceIdFromSearchParams;
+  const sourceIdInSync = sourceIdInBoth || sourceIdInNeither;
+
+  const destinationIdInBoth =
+    destinationIdFromLocationState && destinationIdFromSearchParams === destinationIdFromLocationState;
+  const destinationIdInNeither = !destinationIdFromLocationState && !destinationIdFromSearchParams;
+  const destinationIdInSync = destinationIdInBoth || destinationIdInNeither;
+
   useEffect(() => {
-    if (sourceIdFromLocationState && sourceIdFromSearchParams === sourceIdFromLocationState) {
-      // sourceId is set and everything is in sync, no further action needed
-    } else if (sourceIdFromLocationState) {
-      sourceId && setSearchParams({ sourceId });
-    } else if (sourceIdFromSearchParams) {
-      // we have to simultaneously set both the query string and location.state to avoid
-      // an infinite mutually recursive rerender loop:
+    const availableConnectorIds = { ...(sourceId ? { sourceId } : {}), ...(destinationId ? { destinationId } : {}) };
+
+    // the source conditions are the top-level, with destination conditions nested inside
+    if (sourceIdInSync && destinationIdInSync) {
+      // no further action needed here
+    } else if (sourceIdFromLocationState || destinationIdFromLocationState) {
+      // location state takes precedence if search params and location.state have to be synced
+      setSearchParams(availableConnectorIds);
+    } else if (sourceIdFromSearchParams || destinationIdFromSearchParams) {
+      // here, we have to simultaneously set matching query string and location.state
+      // values to avoid a mutually recursive infinite loop:
       //   A: set location.state and rerender; GOTO B
       //   B: set query param and rerender; GOTO A
-      navigate(`${location.search}`, { state: { sourceId }, replace: true });
-    } else {
-      // sourceId is unset and everything is in sync, no further action needed
+      navigate(`${location.search}`, { state: availableConnectorIds, replace: true });
     }
-  }, [sourceIdFromLocationState, sourceIdFromSearchParams, setSearchParams, navigate, sourceId, location.search]);
+  }, [
+    destinationId,
+    destinationIdFromLocationState,
+    destinationIdFromSearchParams,
+    destinationIdInSync,
+    location.search,
+    navigate,
+    setSearchParams,
+    sourceId,
+    sourceIdFromLocationState,
+    sourceIdFromSearchParams,
+    sourceIdInSync,
+  ]);
   const source = useGetSource(sourceId);
 
   const sourceDefinition = useSourceDefinition(source?.sourceDefinitionId);
 
-  const destination = useGetDestination(hasDestinationId(location.state) ? location.state.destinationId : null);
+  const destination = useGetDestination(destinationId);
   const destinationDefinition = useDestinationDefinition(destination?.destinationDefinitionId);
 
   return { source, sourceDefinition, destination, destinationDefinition };

--- a/airbyte-webapp/src/pages/connections/CreateConnectionPage/usePreloadData.ts
+++ b/airbyte-webapp/src/pages/connections/CreateConnectionPage/usePreloadData.ts
@@ -1,0 +1,79 @@
+import { useEffect } from "react";
+import { useLocation, useNavigate, useSearchParams } from "react-router-dom";
+
+import {
+  DestinationDefinitionRead,
+  DestinationRead,
+  SourceDefinitionRead,
+  SourceRead,
+} from "core/request/AirbyteClient";
+import { useGetDestination } from "hooks/services/useDestinationHook";
+import { useGetSource } from "hooks/services/useSourceHook";
+import { useDestinationDefinition } from "services/connector/DestinationDefinitionService";
+import { useSourceDefinition } from "services/connector/SourceDefinitionService";
+
+export function hasSourceId(state: unknown): state is { sourceId: string } {
+  return typeof state === "object" && state !== null && typeof (state as { sourceId?: string }).sourceId === "string";
+}
+
+export function hasDestinationId(state: unknown): state is { destinationId: string } {
+  return (
+    typeof state === "object" &&
+    state !== null &&
+    typeof (state as { destinationId?: string }).destinationId === "string"
+  );
+}
+
+export function usePreloadData(): {
+  sourceDefinition?: SourceDefinitionRead;
+  destination?: DestinationRead;
+  source?: SourceRead;
+  destinationDefinition?: DestinationDefinitionRead;
+} {
+  const location = useLocation();
+  const navigate = useNavigate();
+  const [searchParams, setSearchParams] = useSearchParams();
+
+  const sourceIdFromLocationState = hasSourceId(location.state) && location.state.sourceId;
+  const sourceIdFromSearchParams = searchParams.get("sourceId");
+  const sourceId = sourceIdFromLocationState || sourceIdFromSearchParams;
+
+  /**
+   * There are two places we may find a sourceId, depending on the scenario. This effect
+   * keeps them in sync according to the following logic:
+   *   0) if `location.state.sourceId` and the `sourceId` query param are both unset or
+   *      are both set to the same value, then we don't need to take any action.
+   *   1) else if `location.state.sourceId` exists, we arrived at this page via the legacy
+   *      internal "routing" system, meaning there has been a user interaction
+   *      specifically selecting that source. This is the highest precedence source of
+   *      truth, so if it exists we explicitly set the sourceId query param to match it.
+   *   2) else if there's a `sourceId` query param, we arrived at this page via a fresh
+   *      page load. This logic was added to support the airbyte-cloud's free connector
+   *      program enrollment flow: it involves a round-trip visit to a Stripe domain,
+   *      which wipes location.state. We explicitly navigate to the current path
+   *      (including the current query string) with `location.state.sourceId` set.
+   */
+  useEffect(() => {
+    if (sourceIdFromLocationState && sourceIdFromSearchParams === sourceIdFromLocationState) {
+      // sourceId is set and everything is in sync, no further action needed
+    } else if (sourceIdFromLocationState) {
+      sourceId && setSearchParams({ sourceId });
+    } else if (sourceIdFromSearchParams) {
+      // we have to simultaneously set both the query string and location.state to avoid
+      // an infinite mutually recursive rerender loop:
+      //   A: set location.state and rerender; GOTO B
+      //   B: set query param and rerender; GOTO A
+      navigate(`${location.search}`, { state: { sourceId }, replace: true });
+    } else {
+      // sourceId is unset and everything is in sync, no further action needed
+    }
+  }, [sourceIdFromLocationState, sourceIdFromSearchParams, setSearchParams, navigate, sourceId, location.search]);
+  const source = useGetSource(sourceId);
+
+  const sourceDefinition = useSourceDefinition(source?.sourceDefinitionId);
+
+  const destination = useGetDestination(hasDestinationId(location.state) ? location.state.destinationId : null);
+  const destinationDefinition = useDestinationDefinition(destination?.destinationDefinitionId);
+
+  return { source, sourceDefinition, destination, destinationDefinition };
+}


### PR DESCRIPTION
## What
Shows the FCP enrollment banner on the create connection page. 

## Awkward detour
The existing create connection page uses `location.state` to track the progressing  connector definition, whether they are selecting a source or destination, and so on; but as `location.state` is an ephemeral, in-memory thing, it gets blown away by the enrollment workflow's round-trip visit to an external stripe domain. There would be a ton of benefits to rewriting the routing and control-flow wholesale, with the url changing with the workflow steps, functioning history navigation, and the already-selected connector ids referenced in path params like `/workspaces/39f35e75-3719-44c5-9ed1-03a82144d141/sources/7b63a93f-c296-45ac-965b-6988a023ec9b/connections/new` or whatever instead of `location.state`*, I decided the path of least resistance would be to just slap the connectorIds in a query param and keep it in sync with `location.state` (the source of truth if present) with `useEffect`.

There were enough confusing threads of logic to follow and fussy interactions between `location.state` and url changes that I'm not sure how much effort I actually saved by working around the existing routing scheme.

\* and hey, as long as I'm wishing,  a reducer to advance through workflow steps from different starting points by dispatching actions instead of imperative code would be nice too.

### does it show the new banner when it ought to?
|              | did show | no show |
|---|---|---|
| should | :heavy_check_mark: | :construction: : |
| no plz  | :construction: : | :ballot_box_with_check: |
#### :ballot_box_with_check: new workspace, creating first source, GA source
![image](https://user-images.githubusercontent.com/7516653/218033952-1a8adf6f-47af-43bc-a472-aaf1fed90a16.png)

#### :heavy_check_mark: new workspace, creating first source, alpha/beta
![image](https://user-images.githubusercontent.com/7516653/218034535-3ba56a23-6826-45d0-887f-b49ea83c8320.png)

#### :heavy_check_mark: creating second source, GA connector, first was alpha/beta
![image](https://user-images.githubusercontent.com/7516653/218036294-11d8c4a7-9169-46c0-9553-640fa4df3c81.png)

#### :heavy_check_mark: creating connector with prefilled destinationId
![image](https://user-images.githubusercontent.com/7516653/218063648-81fb7d5e-23eb-4e7a-a65e-96af88d956f2.png)

## Recommended reading order
1. `x.java`
2. `y.python`

## 🚨 User Impact 🚨
Are there any breaking changes? What is the end result perceived by the user? If yes, please merge this PR with the 🚨🚨 emoji so changelog authors can further highlight this if needed.

## Pre-merge Checklist
Expand the relevant checklist and delete the others.

<details><summary><strong>New Connector</strong></summary>

### Community member or Airbyter

- [ ] **Community member?** Grant edit access to maintainers ([instructions](https://docs.github.com/en/github/collaborating-with-pull-requests/working-with-forks/allowing-changes-to-a-pull-request-branch-created-from-a-fork#enabling-repository-maintainer-permissions-on-existing-pull-requests))
- [ ] Secrets in the connector's spec are annotated with `airbyte_secret`
- [ ] Unit & integration tests added and passing. Community members, please provide proof of success locally e.g: screenshot or copy-paste unit, integration, and acceptance test output. To run acceptance tests for a Python connector, follow instructions in the README. For java connectors run `./gradlew :airbyte-integrations:connectors:<name>:integrationTest`.
- [ ] Code reviews completed
- [ ] Documentation updated
    - [ ] Connector's `README.md`
    - [ ] Connector's `bootstrap.md`. See [description and examples](https://docs.google.com/document/d/1ypdgmwmEHWv-TrO4_YOQ7pAJGVrMp5BOkEVh831N260/edit?usp=sharing)
    - [ ] `docs/integrations/<source or destination>/<name>.md` including changelog. See changelog [example](https://docs.airbyte.io/integrations/sources/stripe#changelog)
    - [ ] `docs/integrations/README.md`
    - [ ] `airbyte-integrations/builds.md`
- [ ] PR name follows [PR naming conventions](https://docs.airbyte.com/contributing-to-airbyte/issues-and-pull-requests)

### Airbyter

If this is a community PR, the Airbyte engineer reviewing this PR is responsible for the below items.

- [ ] Create a non-forked branch based on this PR and test the below items on it
- [ ] Build is successful
- [ ] If new credentials are required for use in CI, add them to GSM. [Instructions](https://docs.airbyte.io/connector-development#using-credentials-in-ci).
- [ ] [`/test connector=connectors/<name>` command](https://docs.airbyte.io/connector-development#updating-an-existing-connector) is passing
- [ ] New Connector version released on Dockerhub by running the `/publish` command described [here](https://docs.airbyte.io/connector-development#updating-an-existing-connector)
- [ ] After the connector is published, connector added to connector index as described [here](https://docs.airbyte.io/connector-development#publishing-a-connector)
- [ ] Seed specs have been re-generated by building the platform and committing the changes to the seed spec files, as described [here](https://docs.airbyte.io/connector-development#publishing-a-connector)

</details>

<details><summary><strong>Updating a connector</strong></summary>

### Community member or Airbyter

- [ ] Grant edit access to maintainers ([instructions](https://docs.github.com/en/github/collaborating-with-pull-requests/working-with-forks/allowing-changes-to-a-pull-request-branch-created-from-a-fork#enabling-repository-maintainer-permissions-on-existing-pull-requests))
- [ ] Secrets in the connector's spec are annotated with `airbyte_secret`
- [ ] Unit & integration tests added and passing. Community members, please provide proof of success locally e.g: screenshot or copy-paste unit, integration, and acceptance test output. To run acceptance tests for a Python connector, follow instructions in the README. For java connectors run `./gradlew :airbyte-integrations:connectors:<name>:integrationTest`.
- [ ] Code reviews completed
- [ ] Documentation updated
    - [ ] Connector's `README.md`
    - [ ] Connector's `bootstrap.md`. See [description and examples](https://docs.google.com/document/d/1ypdgmwmEHWv-TrO4_YOQ7pAJGVrMp5BOkEVh831N260/edit?usp=sharing)
    - [ ] Changelog updated in `docs/integrations/<source or destination>/<name>.md` including changelog. See changelog [example](https://docs.airbyte.io/integrations/sources/stripe#changelog)
- [ ] PR name follows [PR naming conventions](https://docs.airbyte.com/contributing-to-airbyte/issues-and-pull-requests)

### Airbyter

If this is a community PR, the Airbyte engineer reviewing this PR is responsible for the below items.

- [ ] Create a non-forked branch based on this PR and test the below items on it
- [ ] Build is successful
- [ ] If new credentials are required for use in CI, add them to GSM. [Instructions](https://docs.airbyte.io/connector-development#using-credentials-in-ci).
- [ ] [`/test connector=connectors/<name>` command](https://docs.airbyte.io/connector-development#updating-an-existing-connector) is passing
- [ ] New Connector version released on Dockerhub and connector version bumped by running the `/publish` command described [here](https://docs.airbyte.io/connector-development#updating-an-existing-connector)

</details>

<details><summary><strong>Connector Generator</strong></summary>

- [ ] Issue acceptance criteria met
- [ ] PR name follows [PR naming conventions](https://docs.airbyte.com/contributing-to-airbyte/issues-and-pull-requests)
- [ ] If adding a new generator, add it to the [list of scaffold modules being tested](https://github.com/airbytehq/airbyte/blob/master/airbyte-integrations/connector-templates/generator/build.gradle#L41)
- [ ] The generator test modules (all connectors with `-scaffold` in their name) have been updated with the latest scaffold by running `./gradlew :airbyte-integrations:connector-templates:generator:testScaffoldTemplates` then checking in your changes
- [ ] Documentation which references the generator is updated as needed

</details>
