### PR TITLE
Revert "Helm: set new attribute (#22114)"

### DIFF
--- a/charts/airbyte/templates/env-configmap.yaml
+++ b/charts/airbyte/templates/env-configmap.yaml
@@ -42,7 +42,7 @@ data:
 {{- end }}
   JOBS_DATABASE_MINIMUM_FLYWAY_MIGRATION_VERSION: "0.29.15.001"
   LOCAL_ROOT: /tmp/airbyte_local
-  RUN_DATABASE_MIGRATION_ON_STARTUP: {{ .Values.airbyte-bootloader.runDatabaseMigrationsOnStartup | default "true"  }}
+  RUN_DATABASE_MIGRATION_ON_STARTUP: "true"
   S3_LOG_BUCKET: {{ .Values.global.logs.s3.bucket | quote }}
   S3_LOG_BUCKET_REGION: {{ .Values.global.logs.s3.bucketRegion | quote }}
   S3_MINIO_ENDPOINT: {{ include "airbyte.minio.endpoint" . | quote }}
@@ -58,9 +58,9 @@ data:
   WORKSPACE_ROOT: /workspace
   METRIC_CLIENT: {{ .Values.global.metrics.metricClient | default "" | quote }}
   OTEL_COLLECTOR_ENDPOINT: {{ .Values.global.metrics.otelCollectorEndpoint | default "" | quote }}
-  ACTIVITY_MAX_ATTEMPT: {{ .Values.worker.activityMaxAttempt | default ""  }}
-  ACTIVITY_INITIAL_DELAY_BETWEEN_ATTEMPTS_SECONDS: {{ .Values.worker.activityInitialDelayBetweenAttemptsSeconds | default ""  }}
-  ACTIVITY_MAX_DELAY_BETWEEN_ATTEMPTS_SECONDS: {{ .Values.worker.activityMaxDelayBetweenAttemptsSeconds | default ""  }}
+  ACTIVITY_MAX_ATTEMPT: ""
+  ACTIVITY_INITIAL_DELAY_BETWEEN_ATTEMPTS_SECONDS: ""
+  ACTIVITY_MAX_DELAY_BETWEEN_ATTEMPTS_SECONDS: ""
   WORKFLOW_FAILURE_RESTART_DELAY_SECONDS: ""
   USE_STREAM_CAPABLE_STATE: "true"
   AUTO_DETECT_SCHEMA: "true"
@@ -71,5 +71,5 @@ data:
   WORKER_LOGS_STORAGE_TYPE: {{ .Values.global.logs.storage.type | quote }}
   WORKER_STATE_STORAGE_TYPE:  {{ .Values.global.state.storage.type | quote }}
   SHOULD_RUN_NOTIFY_WORKFLOWS: "false"
-  MAX_NOTIFY_WORKERS: {{ .Values.worker.maxNotifyWorkers | default "5"  }}
+  MAX_NOTIFY_WORKERS: "5"
 {{- end }}

--- a/charts/airbyte/values.yaml
+++ b/charts/airbyte/values.yaml
@@ -819,11 +819,6 @@ worker:
     enabled: true
     image: ""
 
-  ## current no exist documentations
-  activityMaxAttempt: ""
-  activityInitialDelayBetweenAttemptsSeconds: ""
-  activityMaxDelayBetweenAttemptsSeconds: ""
-
 ## @section Metrics parameters
 metrics:
   enabled: false
@@ -1061,9 +1056,6 @@ airbyte-bootloader:
   ##     emptyDir: {}
   ##
   extraVolumes: []
-
-  ## run database migrations on startup true|false
-  runDatabaseMigrationsOnStartup: "true"
 
 ## @section Temporal parameters
 ## TODO: Move to consuming temporal from a dedicated helm chart

--- a/charts/airbyte/values.yaml.test
+++ b/charts/airbyte/values.yaml.test
@@ -807,10 +807,6 @@ worker:
     enabled: true
     image: ""
 
-  activityMaxAttempt: ""
-  activityInitialDelayBetweenAttemptsSeconds: ""
-  activityMaxDelayBetweenAttemptsSeconds: ""
-
 ## @section Metrics parameters
 metrics:
   enabled: false
@@ -1048,9 +1044,6 @@ airbyte-bootloader:
   ##     emptyDir: {}
   ##
   extraVolumes: []
-
-  ## run database migrations on startup true|false
-  runDatabaseMigrationsOnStartup: "true"
 
 ## @section Temporal parameters
 ## TODO: Move to consuming temporal from a dedicated helm chart


### PR DESCRIPTION
This reverts commit 39402c1664ae88f33f273e631388f3a6b6ae35cf.

## What
Revert bad Helm change.

That PR introduced a '-' in a value name, which isn't allowed.

Example failing run: https://github.com/airbytehq/airbyte/actions/runs/4143579215/jobs/7165614852
Some background context: https://github.com/helm/helm/issues/2192
Issue reported: https://github.com/airbytehq/airbyte/issues/22699

## How
`git revert 39402c1664ae88f33f273e631388f3a6b6ae35cf`
