### PR TITLE
🪟 🐛 Fix clearing source-defined cursor or primary key when there's a valid update

### DIFF
--- a/airbyte-webapp/src/components/connection/ConnectionForm/calculateInitialCatalog.ts
+++ b/airbyte-webapp/src/components/connection/ConnectionForm/calculateInitialCatalog.ts
@@ -37,7 +37,6 @@ const clearBreakingFieldChanges = (nodeStream: SyncSchemaStream, breakingChanges
       .map((update) => update.fieldName);
 
     // if there is a primary key in the config, and any of its field paths were removed, we'll be clearing it
-    // The source-defined primary key already been updated by verifySourceDefinedProperties
     if (
       !!primaryKey?.length &&
       primaryKey?.some((primaryKeyPath) => breakingFieldPaths.some((path) => isEqual(primaryKeyPath, path)))
@@ -46,7 +45,6 @@ const clearBreakingFieldChanges = (nodeStream: SyncSchemaStream, breakingChanges
     }
 
     // if there is a cursor field, and any of its field path was removed, we'll be clearing it
-    // The source-defined cursor has already been updated by verifySourceDefinedProperties
     if (!!cursorField?.length && breakingFieldPaths.some((path) => isEqual(path, cursorField))) {
       clearCursorField = true;
     }

--- a/airbyte-webapp/src/components/connection/ConnectionForm/calculateInitialCatalog.ts
+++ b/airbyte-webapp/src/components/connection/ConnectionForm/calculateInitialCatalog.ts
@@ -21,42 +21,49 @@ const clearBreakingFieldChanges = (nodeStream: SyncSchemaStream, breakingChanges
     return nodeStream;
   }
 
+  const { primaryKey, cursorField } = nodeStream.config;
+
   let clearPrimaryKey = false;
   let clearCursorField = false;
 
   for (const streamTransformation of breakingChangesByStream) {
-    // get all of the removed field paths for this transformation
-    const removedFieldPaths = streamTransformation.updateStream?.map((update) => update.fieldName);
-
-    if (!removedFieldPaths?.length) {
+    if (!streamTransformation.updateStream || !streamTransformation.updateStream?.length) {
       continue;
     }
 
+    // get all of the removed field paths for this transformation
+    const breakingFieldPaths = streamTransformation.updateStream
+      .filter(({ breaking }) => breaking)
+      .map((update) => update.fieldName);
+
     // if there is a primary key in the config, and any of its field paths were removed, we'll be clearing it
+    // The source-defined primary key already been updated by verifySourceDefinedProperties
     if (
-      !!nodeStream.config?.primaryKey?.length &&
-      nodeStream.config?.primaryKey?.some((key) => removedFieldPaths.some((removedPath) => isEqual(key, removedPath)))
+      !!primaryKey?.length &&
+      primaryKey?.some((primaryKeyPath) => breakingFieldPaths.some((path) => isEqual(primaryKeyPath, path)))
     ) {
       clearPrimaryKey = true;
     }
 
     // if there is a cursor field, and any of its field path was removed, we'll be clearing it
-    if (
-      !!nodeStream.config?.cursorField?.length &&
-      removedFieldPaths.some((removedPath) => isEqual(removedPath, nodeStream?.config?.cursorField))
-    ) {
+    // The source-defined cursor has already been updated by verifySourceDefinedProperties
+    if (!!cursorField?.length && breakingFieldPaths.some((path) => isEqual(path, cursorField))) {
       clearCursorField = true;
     }
   }
 
-  return {
-    ...nodeStream,
-    config: {
-      ...nodeStream.config,
-      primaryKey: clearPrimaryKey ? [] : nodeStream.config.primaryKey,
-      cursorField: clearCursorField ? [] : nodeStream.config.cursorField,
-    },
-  };
+  if (clearPrimaryKey || clearCursorField) {
+    return {
+      ...nodeStream,
+      config: {
+        ...nodeStream.config,
+        primaryKey: clearPrimaryKey ? [] : nodeStream.config.primaryKey,
+        cursorField: clearCursorField ? [] : nodeStream.config.cursorField,
+      },
+    };
+  }
+
+  return nodeStream;
 };
 
 const verifySourceDefinedProperties = (streamNode: SyncSchemaStream, isEditMode: boolean) => {
@@ -187,19 +194,19 @@ const calculateInitialCatalog = (
           streamIdFromDiff.namespace === nodeStream.stream?.namespace
       );
 
-      // narrow down the breaking field changes from this connection to only those relevant to this stream
-      const breakingChangesByStream =
-        streamsWithBreakingFieldChanges && streamsWithBreakingFieldChanges.length > 0
-          ? streamsWithBreakingFieldChanges.filter((streamTransformFromDiff) => {
-              return (
-                streamTransformFromDiff.streamDescriptor.name === nodeStream.stream?.name &&
-                streamTransformFromDiff.streamDescriptor.namespace === nodeStream.stream?.namespace
-              );
-            })
-          : [];
-
       // if we're in edit or readonly mode and the stream is not new, check for breaking changes then return
       if (isNotCreateMode && !isStreamNew) {
+        // narrow down the breaking field changes from this connection to only those relevant to this stream
+        const breakingChangesByStream =
+          streamsWithBreakingFieldChanges && streamsWithBreakingFieldChanges.length > 0
+            ? streamsWithBreakingFieldChanges.filter(({ streamDescriptor }) => {
+                return (
+                  streamDescriptor.name === nodeStream.stream?.name &&
+                  streamDescriptor.namespace === nodeStream.stream?.namespace
+                );
+              })
+            : [];
+
         return clearBreakingFieldChanges(nodeStream, breakingChangesByStream);
       }
 

--- a/airbyte-webapp/src/core/domain/catalog/traverseSchemaToField.test.ts
+++ b/airbyte-webapp/src/core/domain/catalog/traverseSchemaToField.test.ts
@@ -2,7 +2,7 @@ import { AirbyteJSONSchema } from "core/jsonSchema/types";
 
 import { traverseSchemaToField } from "./traverseSchemaToField";
 
-describe(`${traverseSchemaToField}`, () => {
+describe(`${traverseSchemaToField.name}`, () => {
   it("traverses a nested schema", () => {
     const nestedSchema: AirbyteJSONSchema = {
       $schema: "http://json-schema.org/draft-04/schema#",


### PR DESCRIPTION
## What
This fixes a scenario where a stream has an updated source-defined cursor and primary key, but the web app would clear it when the new field used in the source-defined cursor or primary key was added during the stream refresh. Now it checks to ensure that it removes the breaking changes.

Here's a scenario where this would occur:

* Previous cursor: ['created_at']
* New cursor: [ 'updated_at']
* Diff: Remove field 'updated_at', Add field 'created_at'
* Resulting cursor: []

Because the diff is adding 'created_at' and the code was not checking to see if this was important, it would set the cursor to an empty array.

## How
* The catalogDiff already signals which fields in the change are breaking. Before determining in the primary key or cursor need to be cleared in `clearBreakingFieldChanges`, the `breaking` flag filters the list of updates.
* Updated unit tests to support a scenario where the source-defined key or cursor would be updated with newly added fields.
* Code cleanup around `calculateInitialCatalog.`