### PR TITLE
Source-DynamoDB : Publish version 0.1.1

### DIFF
--- a/airbyte-config/init/src/main/resources/seed/source_definitions.yaml
+++ b/airbyte-config/init/src/main/resources/seed/source_definitions.yaml
@@ -468,7 +468,7 @@
 - name: DynamoDB
   sourceDefinitionId: 50401137-8871-4c5a-abb7-1f5fda35545a
   dockerRepository: airbyte/source-dynamodb
-  dockerImageTag: 0.1.0
+  dockerImageTag: 0.1.1
   documentationUrl: https://docs.airbyte.com/integrations/sources/dynamodb
   icon: dynamodb.svg
   sourceType: api

--- a/airbyte-config/init/src/main/resources/seed/source_specs.yaml
+++ b/airbyte-config/init/src/main/resources/seed/source_specs.yaml
@@ -3401,7 +3401,7 @@
     supportsNormalization: false
     supportsDBT: false
     supported_destination_sync_modes: []
-- dockerImage: "airbyte/source-dynamodb:0.1.0"
+- dockerImage: "airbyte/source-dynamodb:0.1.1"
   spec:
     documentationUrl: "https://docs.airbyte.com/integrations/sources/dynamodb"
     connectionSpecification:

--- a/docs/integrations/sources/dynamodb.md
+++ b/docs/integrations/sources/dynamodb.md
@@ -61,5 +61,5 @@ This guide describes in details how you can configure the connector to connect w
 
 | Version | Date       | Pull Request | Subject         |
 |:--------|:-----------|:-------------|:----------------|
-| 0.1.1   | 02-09-2023 | https://github.com/airbytehq/airbyte/pull/22682             | Build fixes     |
+| 0.1.1   | 02-09-2023 | https://github.com/airbytehq/airbyte/pull/22682             | Fix build     |
 | 0.1.0   | 11-14-2022 | https://github.com/airbytehq/airbyte/pull/18750             | Initial version |


### PR DESCRIPTION
Publish failed in https://github.com/airbytehq/airbyte/pull/22682, due to existence of 0.1.1 which was published in https://github.com/airbytehq/airbyte/pull/20172. Deleted 0.1.1 from dockerhub and republishing