### PR TITLE
set workspaceId on destinationCoreConfig

### DIFF
--- a/airbyte-commons-server/src/main/java/io/airbyte/commons/server/handlers/SchedulerHandler.java
+++ b/airbyte-commons-server/src/main/java/io/airbyte/commons/server/handlers/SchedulerHandler.java
@@ -241,7 +241,8 @@ public class SchedulerHandler {
     final DestinationCoreConfig destinationCoreConfig = new DestinationCoreConfig()
         .destinationId(updatedDestination.getDestinationId())
         .connectionConfiguration(updatedDestination.getConfiguration())
-        .destinationDefinitionId(updatedDestination.getDestinationDefinitionId());
+        .destinationDefinitionId(updatedDestination.getDestinationDefinitionId())
+        .workspaceId(updatedDestination.getWorkspaceId());
 
     return checkDestinationConnectionFromDestinationCreate(destinationCoreConfig);
   }

--- a/airbyte-commons-server/src/test/java/io/airbyte/commons/server/handlers/SchedulerHandlerTest.java
+++ b/airbyte-commons-server/src/test/java/io/airbyte/commons/server/handlers/SchedulerHandlerTest.java
@@ -391,7 +391,8 @@ class SchedulerHandlerTest {
     final DestinationConnection submittedDestination = new DestinationConnection()
         .withDestinationId(destination.getDestinationId())
         .withDestinationDefinitionId(destination.getDestinationDefinitionId())
-        .withConfiguration(destination.getConfiguration());
+        .withConfiguration(destination.getConfiguration())
+        .withWorkspaceId(destination.getWorkspaceId());
     when(synchronousSchedulerClient.createDestinationCheckConnectionJob(submittedDestination, DESTINATION_DOCKER_IMAGE,
         new Version(DESTINATION_PROTOCOL_VERSION), false))
             .thenReturn((SynchronousResponse<StandardCheckConnectionOutput>) jobResponse);


### PR DESCRIPTION
## What
See Slack channel #p0-unable-to-update-existing-destination-02-10-23

The check workflow now requires a destination's workspaceId to perform a check job successfully. The code path for triggering a check workflow for destination updates unfortunately did not set the workspaceId correctly on the DestinationCoreConfig object, so the workspaceId value was `null` when read by the RouterService.

## How
Set the workspaceId on the DestinationCoreConfig
