### PR TITLE
QA checks: Validate the connector code does not contain `http://` URL 

### DIFF
--- a/tools/ci_connector_ops/ci_connector_ops/qa_checks.py
+++ b/tools/ci_connector_ops/ci_connector_ops/qa_checks.py
@@ -98,6 +98,7 @@ def read_all_files_in_directory(directory: Path, ignored_directories: Optional[S
 
 
 IGNORED_DIRECTORIES_FOR_HTTPS_CHECKS = {".venv", "tests", "unit_tests", "integration_tests", "build", "source-file"}
+IGNORED_URLS_PREFIX = {"http://json-schema.org", "http://localhost"}
 
 
 def check_connector_https_url_only(connector: Connector) -> bool:
@@ -111,10 +112,11 @@ def check_connector_https_url_only(connector: Connector) -> bool:
     """
     files_with_http_url = set()
     for filename, line in read_all_files_in_directory(connector.code_directory, IGNORED_DIRECTORIES_FOR_HTTPS_CHECKS):
-        if "http://json-schema.org" or "http://localhost" in line:
+        if any([prefix in line.lower() for prefix in IGNORED_URLS_PREFIX]):
             continue
         if "http://" in line.lower():
             files_with_http_url.add(str(filename))
+
     if files_with_http_url:
         files_with_http_url = "\n\t- ".join(files_with_http_url)
         print(f"The following files have http:// URLs:\n\t- {files_with_http_url}")

--- a/tools/ci_connector_ops/ci_connector_ops/qa_checks.py
+++ b/tools/ci_connector_ops/ci_connector_ops/qa_checks.py
@@ -103,7 +103,16 @@ def read_all_files_in_directory(
                 continue
 
 
-IGNORED_DIRECTORIES_FOR_HTTPS_CHECKS = {".venv", "tests", "unit_tests", "integration_tests", "build", "source-file", ".pytest_cache"}
+IGNORED_DIRECTORIES_FOR_HTTPS_CHECKS = {
+    ".venv",
+    "tests",
+    "unit_tests",
+    "integration_tests",
+    "build",
+    "source-file",
+    ".pytest_cache",
+    "acceptance_tests_logs",
+}
 IGNORED_FILENAME_PATTERN_FOR_HTTPS_CHECKS = {"*Test.java"}
 IGNORED_URLS_PREFIX = {"http://json-schema.org", "http://localhost"}
 

--- a/tools/ci_connector_ops/ci_connector_ops/qa_checks.py
+++ b/tools/ci_connector_ops/ci_connector_ops/qa_checks.py
@@ -185,6 +185,9 @@ QA_CHECKS = [
     # check_documentation_follows_guidelines,
     check_changelog_entry_is_updated,
     check_connector_icon_is_available,
+    # TODO - check_connector_https_url_only might be redundant once the following issues are closed
+    # https://github.com/airbytehq/airbyte/issues/20552
+    # https://github.com/airbytehq/airbyte/issues/21606
     check_connector_https_url_only,
     check_connector_has_no_critical_vulnerabilities,
 ]

--- a/tools/ci_connector_ops/ci_connector_ops/qa_checks.py
+++ b/tools/ci_connector_ops/ci_connector_ops/qa_checks.py
@@ -113,7 +113,7 @@ def check_connector_https_url_only(connector: Connector) -> bool:
     for filename, line in read_all_files_in_directory(connector.code_directory, IGNORED_DIRECTORIES_FOR_HTTPS_CHECKS):
         if "http://json-schema.org" or "http://localhost" in line:
             continue
-        if "http://" in line:
+        if "http://" in line.lower():
             files_with_http_url.add(str(filename))
     if files_with_http_url:
         files_with_http_url = "\n\t- ".join(files_with_http_url)

--- a/tools/ci_connector_ops/setup.py
+++ b/tools/ci_connector_ops/setup.py
@@ -22,7 +22,7 @@ TEST_REQUIREMENTS = [
 ]
 
 setup(
-    version="0.1.11",
+    version="0.1.12",
     name="ci_connector_ops",
     description="Packaged maintained by the connector operations team to perform CI for connectors",
     author="Airbyte",

--- a/tools/ci_connector_ops/tests/test_qa_checks.py
+++ b/tools/ci_connector_ops/tests/test_qa_checks.py
@@ -112,7 +112,7 @@ def test_run_qa_checks_error(capsys, mocker):
 
 def test_check_connector_https_url_only(capsys, tmp_path, mocker):
     file_with_http_url_path = Path(tmp_path / "file_with_http_url.foo")
-    qa_checks.PATH_PATTERNS_TO_IGNORE_FOR_HTTPS_CHECKS = set()
+    qa_checks.IGNORED_DIRECTORIES_FOR_HTTPS_CHECKS = set()
     Path(tmp_path / "file_without_https_url.foo").touch()
     Path(tmp_path / "my_directory").mkdir()
     nested_file_with_http_url_path = Path(tmp_path / "my_directory/nested_file_with_http_url.foo")


### PR DESCRIPTION
## What
Closes https://github.com/airbytehq/airbyte/issues/21717
We want to make sure no connector uses plain HTTP:// urls.

## How
* Implement a grep style qa check to:
  *  read all readable files in a connector
  * ignore a couple of files with patterns (`.venv`, `test`)
  * ignore json schema HTTP urls.
 
## 🚨 User Impact 🚨
This new QA check is likely to make fail the build of a couple of connectors:

Failing alpha connectors:
	- source-activecampaign
	- source-shortio
	- source-statuspage
	- source-surveycto
	- source-tmdb
	- source-visma-economic
	- source-weatherstack
	- source-zuora
	- destination-doris
	- destination-iceberg
	- destination-google-sheets

Failing generally_available connectors:
	- source-github
	- source-google-search-console
	- source-google-sheets
	- source-marketo
	- source-stripe
	- destination-s3

