### PR TITLE
source-google-search-console: update docstring to remove http url

### DIFF
--- a/airbyte-integrations/connectors/source-google-search-console/source_google_search_console/streams.py
+++ b/airbyte-integrations/connectors/source-google-search-console/source_google_search_console/streams.py
@@ -239,13 +239,13 @@ class SearchAnalytics(GoogleSearchConsole, ABC):
 
         {
           "stream": {
-            "http://domain1.com": {
+            "https://domain1.com": {
               "web": {"date": "2022-01-03"},
               "news": {"date": "2022-01-03"},
               "image": {"date": "2022-01-03"},
               "video": {"date": "2022-01-03"}
             },
-            "http://domain2.com": {
+            "https://domain2.com": {
               "web": {"date": "2022-01-03"},
               "news": {"date": "2022-01-03"},
               "image": {"date": "2022-01-03"},


### PR DESCRIPTION
## What
https://github.com/airbytehq/airbyte/issues/22878
Everything is in the title.
We want the new QA check (https://github.com/airbytehq/airbyte/pull/22854) to pass for source-google-search-console
No version bump / publish should be required as we update the `get_updated_state` docstring.
