### PR TITLE
source-marketo: no http url in docstring

### DIFF
--- a/airbyte-integrations/connectors/source-marketo/source_marketo/source.py
+++ b/airbyte-integrations/connectors/source-marketo/source_marketo/source.py
@@ -332,7 +332,7 @@ class MarketoExportStatus(MarketoStream):
 class Leads(MarketoExportBase):
     """
     Return list of all leeds.
-    API Docs: http://developers.marketo.com/rest-api/bulk-extract/bulk-lead-extract/
+    API Docs: https://developers.marketo.com/rest-api/bulk-extract/bulk-lead-extract/
     """
 
     cursor_field = "updatedAt"
@@ -349,7 +349,7 @@ class Activities(MarketoExportBase):
     """
     Base class for all the activities streams,
     provides functionality for dynamically created classes as streams of data.
-    API Docs: http://developers.marketo.com/rest-api/bulk-extract/bulk-activity-extract/
+    API Docs: https://developers.marketo.com/rest-api/bulk-extract/bulk-activity-extract/
     """
 
     primary_key = "marketoGUID"
@@ -411,7 +411,7 @@ class Activities(MarketoExportBase):
 class ActivityTypes(MarketoStream):
     """
     Return list of all activity types.
-    API Docs: http://developers.marketo.com/rest-api/lead-database/activities/#describe
+    API Docs: https://developers.marketo.com/rest-api/lead-database/activities/#describe
     """
 
     def path(self, stream_slice: Mapping[str, Any] = None, **kwargs) -> str:
@@ -421,7 +421,7 @@ class ActivityTypes(MarketoStream):
 class Programs(IncrementalMarketoStream):
     """
     Return list of all programs.
-    API Docs: http://developers.marketo.com/rest-api/assets/programs/#by_date_range
+    API Docs: https://developers.marketo.com/rest-api/assets/programs/#by_date_range
     """
 
     cursor_field = "updatedAt"


### PR DESCRIPTION
## What
https://github.com/airbytehq/airbyte/issues/22878
Everything is in the title.
We want the new QA check (https://github.com/airbytehq/airbyte/pull/22854) to pass for source-marketo.
No version bump / publish should be required as we only update docstrings.
