### PR TITLE
Source Instagram: Fix for user_lifetime_insights KeyError bug.

### DIFF
--- a/airbyte-integrations/connectors/source-instagram/source_instagram/streams.py
+++ b/airbyte-integrations/connectors/source-instagram/source_instagram/streams.py
@@ -121,7 +121,7 @@ class UserLifetimeInsights(InstagramStream):
                 "page_id": account["page_id"],
                 "business_account_id": ig_account.get("id"),
                 "metric": insight["name"],
-                "date": insight["values"][0]["end_time"],
+                "date": datetime.utcnow().strftime("%Y-%m-%dT%H:%M:%S+0000"),
                 "value": insight["values"][0]["value"],
             }
 

--- a/airbyte-integrations/connectors/source-instagram/unit_tests/test_streams.py
+++ b/airbyte-integrations/connectors/source-instagram/unit_tests/test_streams.py
@@ -114,7 +114,7 @@ def test_user_lifetime_insights_read(api, config, user_insight_data, requests_mo
             "page_id": "act_unknown_account",
             "business_account_id": "test_id",
             "metric": "impressions",
-            "date": "2020-05-04T07:00:00+0000",
+            "date": datetime.utcnow().strftime("%Y-%m-%dT%H:%M:%S+0000"),
             "value": 4,
         }
     ]

--- a/docs/integrations/sources/instagram.md
+++ b/docs/integrations/sources/instagram.md
@@ -92,7 +92,7 @@ AirbyteRecords are required to conform to the [Airbyte type](https://docs.airbyt
 
 | Version | Date       | Pull Request                                             | Subject                                                                                                         |
 |:--------|:-----------|:---------------------------------------------------------|:----------------------------------------------------------------------------------------------------------------|
-| 1.0.3   | 2023-02-13 | [21602](https://github.com/airbytehq/airbyte/pull/TBD)   | Fix for user_lifetime_insights KeyError bug.                                                                    |
+| 1.0.2   | 2023-02-13 | [22928](https://github.com/airbytehq/airbyte/pull/22928) | Fix for user_lifetime_insights KeyError bug.                                                                    |
 | 1.0.1   | 2023-01-19 | [21602](https://github.com/airbytehq/airbyte/pull/21602) | Handle abnormally large state values                                                                            |
 | 1.0.0   | 2022-09-23 | [17110](https://github.com/airbytehq/airbyte/pull/17110) | Remove custom read function and migrate to per-stream state                                                     |
 | 0.1.11  | 2022-09-08 | [16428](https://github.com/airbytehq/airbyte/pull/16428) | Fix requests metrics for Reels media product type                                                               |

--- a/docs/integrations/sources/instagram.md
+++ b/docs/integrations/sources/instagram.md
@@ -92,6 +92,7 @@ AirbyteRecords are required to conform to the [Airbyte type](https://docs.airbyt
 
 | Version | Date       | Pull Request                                             | Subject                                                                                                         |
 |:--------|:-----------|:---------------------------------------------------------|:----------------------------------------------------------------------------------------------------------------|
+| 1.0.3   | 2023-02-13 | [21602](https://github.com/airbytehq/airbyte/pull/TBD)   | Fix for user_lifetime_insights KeyError bug.                                                                    |
 | 1.0.1   | 2023-01-19 | [21602](https://github.com/airbytehq/airbyte/pull/21602) | Handle abnormally large state values                                                                            |
 | 1.0.0   | 2022-09-23 | [17110](https://github.com/airbytehq/airbyte/pull/17110) | Remove custom read function and migrate to per-stream state                                                     |
 | 0.1.11  | 2022-09-08 | [16428](https://github.com/airbytehq/airbyte/pull/16428) | Fix requests metrics for Reels media product type                                                               |


### PR DESCRIPTION
## What
Current Behavior
When a connection is created and data sync is triggered. While streaming user_lifetime_insights the sync job fails because the stream records are expected to have end_time field present. But as per the [documentation](https://developers.facebook.com/docs/instagram-api/guides/insights/), lifetime insights wouldn't have that field. Hence, its throwing an error and job fails.
Fixed https://github.com/airbytehq/airbyte/pull/22928 bug.

Expected Behavior
That field should not be parsed from the graph api response, instead the datetime at which the record was fetched, that can be used as end_time.

## How
Replaced the part where the end_time is parsed from response and updating the timestamp at which the record was fetched.

<details><summary><strong>Updating a connector</strong></summary>

### Community member or Airbyter

- [ ] Grant edit access to maintainers ([instructions](https://docs.github.com/en/github/collaborating-with-pull-requests/working-with-forks/allowing-changes-to-a-pull-request-branch-created-from-a-fork#enabling-repository-maintainer-permissions-on-existing-pull-requests))
- [ ] Secrets in the connector's spec are annotated with `airbyte_secret`
- [ ] Unit & integration tests added and passing. Community members, please provide proof of success locally e.g: screenshot or copy-paste unit, integration, and acceptance test output. To run acceptance tests for a Python connector, follow instructions in the README. For java connectors run `./gradlew :airbyte-integrations:connectors:<name>:integrationTest`.
- [ ] Code reviews completed
- [ ] Documentation updated
    - [ ] Connector's `README.md`
    - [ ] Connector's `bootstrap.md`. See [description and examples](https://docs.google.com/document/d/1ypdgmwmEHWv-TrO4_YOQ7pAJGVrMp5BOkEVh831N260/edit?usp=sharing)
    - [x] Changelog updated in `docs/integrations/<source or destination>/<name>.md` including changelog. See changelog [example](https://docs.airbyte.io/integrations/sources/stripe#changelog)
- [ ] PR name follows [PR naming conventions](https://docs.airbyte.com/contributing-to-airbyte/issues-and-pull-requests)

</details>

## Unit Tests
```
======================= 33 passed, 13 warnings in 35.61s =======================

> Task :airbyte-integrations:connectors:source-instagram:unitTest
Name                           Stmts   Miss  Cover
--------------------------------------------------
source_instagram/source.py        31      0   100%
source_instagram/__init__.py       2      0   100%
source_instagram/common.py        36      3    92%
source_instagram/streams.py      205     20    90%
source_instagram/api.py           59      7    88%
--------------------------------------------------
TOTAL                            333     30    91%
```

## Acceptance Tests
```

         ---------- coverage: platform darwin, python 3.9.6-final-0 -----------
         Name                                                    Stmts   Miss  Cover   Missing
         -------------------------------------------------------------------------------------
         connector_acceptance_test/base.py                          12      4    67%   16-19
         connector_acceptance_test/config.py                       141      5    96%   87, 93, 239, 243-244
         connector_acceptance_test/conftest.py                     217    101    53%   37, 43-45, 50, 55, 78, 84, 90-92, 111, 116-118, 124-126, 132-133, 138-139, 144, 150, 159-168, 174-179, 194, 218, 249, 255, 263-271, 279-292, 300-313, 318-324, 331-342, 349-365
         connector_acceptance_test/plugin.py                        69     25    64%   22-23, 31, 36, 120-140, 144-148
         connector_acceptance_test/tests/test_core.py              476    117    75%   53, 58, 97-108, 113-120, 124-125, 129-130, 380, 400, 438, 476-493, 506-517, 521-526, 532, 565-570, 608-615, 658-660, 663, 728-736, 748-751, 756, 812-813, 819, 822, 858-868, 881-906
         connector_acceptance_test/tests/test_incremental.py       162     14    91%   58-65, 70-83, 252
         connector_acceptance_test/utils/asserts.py                 39      2    95%   62-63
         connector_acceptance_test/utils/common.py                  94      8    91%   32-38, 72, 75
         connector_acceptance_test/utils/compare.py                 62     23    63%   21-51, 68, 97-99
         connector_acceptance_test/utils/connector_runner.py       133     33    75%   24-27, 46-47, 50-54, 57-58, 73-75, 78-80, 83-85, 88-90, 93-95, 124-125, 159-161, 208
         connector_acceptance_test/utils/json_schema_helper.py     114     13    89%   31-32, 39, 42, 66-69, 97, 121, 203-205
         -------------------------------------------------------------------------------------
         TOTAL                                                    1711    345    80%

         5 files skipped due to complete coverage.

         Required test coverage of 74.0% reached. Total coverage: 79.84%

         Results (165.79s):
              484 passed
```

