### PR TITLE
connector-acceptance-tests: support custom environment variables

### DIFF
--- a/airbyte-integrations/bases/connector-acceptance-test/CHANGELOG.md
+++ b/airbyte-integrations/bases/connector-acceptance-test/CHANGELOG.md
@@ -1,5 +1,8 @@
 # Changelog
 
+## 0.6.0
+Allow passing custom environment variables to the connector under test. [#22937](https://github.com/airbytehq/airbyte/pull/22937).
+
 ## 0.5.3
 Spec tests: Make `oneOf` checks work for nested `oneOf`s. [#22395](https://github.com/airbytehq/airbyte/pull/22395)
 

--- a/airbyte-integrations/bases/connector-acceptance-test/Dockerfile
+++ b/airbyte-integrations/bases/connector-acceptance-test/Dockerfile
@@ -33,7 +33,7 @@ COPY pytest.ini setup.py ./
 COPY connector_acceptance_test ./connector_acceptance_test
 RUN pip install .
 
-LABEL io.airbyte.version=0.5.3
+LABEL io.airbyte.version=0.6.0
 LABEL io.airbyte.name=airbyte/connector-acceptance-test
 
 ENTRYPOINT ["python", "-m", "pytest", "-p", "connector_acceptance_test.plugin", "-r", "fEsx"]

--- a/airbyte-integrations/bases/connector-acceptance-test/connector_acceptance_test/config.py
+++ b/airbyte-integrations/bases/connector-acceptance-test/connector_acceptance_test/config.py
@@ -200,6 +200,9 @@ class Config(BaseConfig):
         default=TestStrictnessLevel.low,
         description="Corresponds to a strictness level of the test suite and will change which tests are mandatory for a successful run.",
     )
+    custom_environment_variables: Optional[Mapping] = Field(
+        default={}, description="Mapping of custom environment variables to pass to the connector under test."
+    )
 
     @staticmethod
     def is_legacy(config: dict) -> bool:

--- a/airbyte-integrations/bases/connector-acceptance-test/connector_acceptance_test/conftest.py
+++ b/airbyte-integrations/bases/connector-acceptance-test/connector_acceptance_test/conftest.py
@@ -11,7 +11,7 @@ from glob import glob
 from logging import Logger
 from pathlib import Path
 from subprocess import STDOUT, check_output, run
-from typing import Any, List, MutableMapping, Optional, Set
+from typing import Any, List, Mapping, MutableMapping, Optional, Set
 
 import pytest
 from airbyte_cdk.models import AirbyteRecordMessage, AirbyteStream, ConfiguredAirbyteCatalog, ConnectorSpecification, Type
@@ -53,6 +53,11 @@ def test_strictness_level_fixture(acceptance_test_config: Config) -> Config.Test
 @pytest.fixture(name="cache_discovered_catalog", scope="session")
 def cache_discovered_catalog_fixture(acceptance_test_config: Config) -> bool:
     return acceptance_test_config.cache_discovered_catalog
+
+
+@pytest.fixture(name="custom_environment_variables", scope="session")
+def custom_environment_variables_fixture(acceptance_test_config: Config) -> Mapping:
+    return acceptance_test_config.custom_environment_variables
 
 
 @pytest.fixture(name="connector_config_path")
@@ -140,8 +145,13 @@ def connector_spec_fixture(connector_spec_path) -> ConnectorSpecification:
 
 
 @pytest.fixture(name="docker_runner")
-def docker_runner_fixture(image_tag, tmp_path, connector_config_path) -> ConnectorRunner:
-    return ConnectorRunner(image_tag, volume=tmp_path, connector_configuration_path=connector_config_path)
+def docker_runner_fixture(image_tag, tmp_path, connector_config_path, custom_environment_variables) -> ConnectorRunner:
+    return ConnectorRunner(
+        image_tag,
+        volume=tmp_path,
+        connector_configuration_path=connector_config_path,
+        custom_environment_variables=custom_environment_variables,
+    )
 
 
 @pytest.fixture(name="previous_connector_image_name")
@@ -308,7 +318,7 @@ def detailed_logger() -> Logger:
     logger.setLevel(logging.DEBUG)
     fh = logging.FileHandler(filename, mode="w")
     fh.setFormatter(formatter)
-    logger.log_json_list = lambda l: logger.info(json.dumps(list(l), indent=1))
+    logger.log_json_list = lambda line: logger.info(json.dumps(list(line), indent=1))
     logger.handlers = [fh]
     return logger
 

--- a/airbyte-integrations/bases/connector-acceptance-test/connector_acceptance_test/utils/connector_runner.py
+++ b/airbyte-integrations/bases/connector-acceptance-test/connector_acceptance_test/utils/connector_runner.py
@@ -17,7 +17,13 @@ from pydantic import ValidationError
 
 
 class ConnectorRunner:
-    def __init__(self, image_name: str, volume: Path, connector_configuration_path: Optional[Path] = None):
+    def __init__(
+        self,
+        image_name: str,
+        volume: Path,
+        connector_configuration_path: Optional[Path] = None,
+        custom_environment_variables: Optional[Mapping] = {},
+    ):
         self._client = docker.from_env()
         try:
             self._image = self._client.images.get(image_name)
@@ -28,6 +34,7 @@ class ConnectorRunner:
         self._runs = 0
         self._volume_base = volume
         self._connector_configuration_path = connector_configuration_path
+        self._custom_environment_variables = custom_environment_variables
 
     @property
     def output_folder(self) -> Path:
@@ -106,6 +113,7 @@ class ConnectorRunner:
             volumes=volumes,
             network_mode="host",
             detach=True,
+            environment=self._custom_environment_variables,
             **kwargs,
         )
         with open(self.output_folder / "raw", "wb+") as f:

--- a/airbyte-integrations/bases/connector-acceptance-test/unit_tests/test_container_runner.py
+++ b/airbyte-integrations/bases/connector-acceptance-test/unit_tests/test_container_runner.py
@@ -37,10 +37,19 @@ class TestContainerRunner:
         ]
         mocker.patch.object(connector_runner.ConnectorRunner, "read", mocker.Mock(return_value=records_reads))
         mocker.patch.object(connector_runner.ConnectorRunner, "_persist_new_configuration")
-
-        runner = connector_runner.ConnectorRunner("source-test:dev", tmp_path, connector_configuration_path=old_configuration_path)
+        runner = connector_runner.ConnectorRunner(
+            "source-test:dev", tmp_path, connector_configuration_path=old_configuration_path, custom_environment_variables={"foo": "bar"}
+        )
         list(runner.run("dummy_cmd"))
         runner._persist_new_configuration.assert_called_once_with(new_configuration, 1)
+        runner._client.containers.run.assert_called_once_with(
+            image=runner._image,
+            command="dummy_cmd",
+            volumes={str(tmp_path) + "/run_1/input": {"bind": "/data"}, str(tmp_path) + "/run_1/output": {"bind": "/local", "mode": "rw"}},
+            network_mode="host",
+            detach=True,
+            environment={"foo": "bar"},
+        )
 
     @pytest.mark.parametrize(
         "pass_configuration_path, old_configuration, new_configuration, new_configuration_emitted_at, expect_new_configuration",

--- a/airbyte-integrations/connectors/source-postgres/acceptance-test-config.yml
+++ b/airbyte-integrations/connectors/source-postgres/acceptance-test-config.yml
@@ -2,6 +2,8 @@
 # for more information about how to configure these tests
 connector_image: airbyte/source-postgres:dev
 test_strictness_level: high
+custom_environment_variables:
+  USE_STREAM_CAPABLE_STATE: true
 acceptance_tests:
   spec:
     tests:

--- a/docs/connector-development/testing-connectors/connector-acceptance-tests-reference.md
+++ b/docs/connector-development/testing-connectors/connector-acceptance-tests-reference.md
@@ -84,6 +84,8 @@ Example of `acceptance-test-config.yml`:
 ```yaml
 connector_image: string # Docker image to test, for example 'airbyte/source-pokeapi:0.1.0'
 base_path: string # Base path for all relative paths, optional, default - ./
+custom_environment_variables:
+  foo: bar
 acceptance_tests: # Tests configuration
   spec: # list of the test inputs
     bypass_reason: "Explain why you skipped this test"
@@ -398,4 +400,14 @@ or prevent network access for this connector entirely
 ```yaml
 allowedHosts:
   hosts: []
+```
+
+## Custom environment variable
+
+The connector under tests can be run with custom environment variables:
+```yaml
+connector_image: "airbyte/source-pokeapi"
+custom_environment_variables:
+  my_custom_environment_variable: value
+...
 ```


### PR DESCRIPTION
## What
After investigation with @rodireich I discovered that some of our java connectors require custom environment variables to behave as we expect them to behave in tests.

This PR allow passing custom environment variable in `acceptance-test-config.yaml` that will be passed to the container (connector) under test.

## How
* Expose a new `custom_environment_variables` configuration field in the acceptance test configuration model.
* Store this field value in a session fixture
* Use this new value to create instantiate the docker runner (in a fixture too)
* Call the docker run client with this new  field value 

## Recommended reading order
1. https://github.com/airbytehq/airbyte/blob/27ee556c2662372c9fe24e073d2eadd2808cc155/airbyte-integrations/bases/connector-acceptance-test/connector_acceptance_test/config.py#L203
2. https://github.com/airbytehq/airbyte/blob/27ee556c2662372c9fe24e073d2eadd2808cc155/airbyte-integrations/bases/connector-acceptance-test/connector_acceptance_test/conftest.py#L59
3. https://github.com/airbytehq/airbyte/blob/27ee556c2662372c9fe24e073d2eadd2808cc155/airbyte-integrations/bases/connector-acceptance-test/connector_acceptance_test/conftest.py#L148
4. https://github.com/airbytehq/airbyte/blob/27ee556c2662372c9fe24e073d2eadd2808cc155/airbyte-integrations/bases/connector-acceptance-test/connector_acceptance_test/utils/connector_runner.py#L104

## 🚨 User Impact 🚨
This should not break any existing configuration as the new field is optional and defaults to empty dict.

