### PR TITLE
Acceptance Test: Fix states for `LEGACY` incremental syncs

### DIFF
--- a/airbyte-integrations/bases/connector-acceptance-test/connector_acceptance_test/tests/test_incremental.py
+++ b/airbyte-integrations/bases/connector-acceptance-test/connector_acceptance_test/tests/test_incremental.py
@@ -121,7 +121,6 @@ def records_with_state(records, state, stream_mapping, state_cursor_paths) -> It
                     try:
                         for stream_state in state["streams"]:
                             if stream_state["stream_name"] == stream_name:
-                                print({stream_state["cursor_field"][0]: stream_state["cursor"]})
                                 state_value = cursor_field.parse(
                                     record={stream_state["cursor_field"][0]: stream_state["cursor"]}
                                 )

--- a/airbyte-integrations/bases/connector-acceptance-test/connector_acceptance_test/utils/json_schema_helper.py
+++ b/airbyte-integrations/bases/connector-acceptance-test/connector_acceptance_test/utils/json_schema_helper.py
@@ -43,11 +43,17 @@ class CatalogField:
             return pendulum.parse(value)
         return value
 
+    def _cast_value(self, value: Any) -> Any:
+        if value:
+            if self.schema["airbyte_type"] == 'integer':
+              return int(value)
+        return value
+
     def parse(self, record: Mapping[str, Any], path: Optional[List[str]] = None) -> Any:
         """Extract field value from the record and cast it to native type"""
         path = path or self.path
         value = reduce(lambda data, key: data[key], path, record)
-        return self._parse_value(value)
+        return self._parse_value(self._cast_value(value))
 
 
 class JsonSchemaHelper:

--- a/airbyte-integrations/connectors/source-postgres/integration_tests/incremental_configured_catalog.json
+++ b/airbyte-integrations/connectors/source-postgres/integration_tests/incremental_configured_catalog.json
@@ -20,13 +20,13 @@
                     "incremental"
                 ],
                 "default_cursor_field": [],
-                "source_defined_primary_key": [],
+                "source_defined_primary_key": [["id"]],
                 "namespace": "public"
             },
             "sync_mode": "incremental",
             "destination_sync_mode": "append",
             "cursor_field": ["id"],
-            "user_defined_primary_key": ["id"]
+            "user_defined_primary_key": [["id"]]
         }
     ]
 }

--- a/airbyte-integrations/connectors/source-postgres/integration_tests/seed.sql
+++ b/airbyte-integrations/connectors/source-postgres/integration_tests/seed.sql
@@ -3,7 +3,7 @@ ALTER ROLE postgres WITH REPLICATION;
 CREATE
     TABLE
         id_and_name(
-            id INTEGER,
+            id INTEGER PRIMARY KEY,
             name VARCHAR(200)
         );
 


### PR DESCRIPTION
## What
The tests were failing for `LEGACY` states in the incremental mode.
Tested with Postgres Source.

## How
To fix the error in the acceptance test I had to rework on the `records_with_state` function, responsible of getting the record and state value.

The schema for `LEGACY` states was a bit different and I had to include new logic to fit them. Also, for Incremental states I have faced the error in with the value in the state is string instead of integer, so I had to include a casting function to sort it out. So far I have only included casting to `int`.

These are examples on the state data in the messages:
 ### LEGACY non CDC state data
```
{'cdc': False, 'streams': [{'stream_name': 'id_and_name', 'stream_namespace': 'public', 'cursor_field': ['id'], 'cursor': '3', 'cursor_record_count': 1}]}
```

### LEGACY CDC state data
```
{'cdc': False, 'cdc_state': {'state': {'{"schema":null,"payload":["postgres",{"server":"postgres"}]}': '{"transaction_id":null,"lsn":2101199320,"txId":1055370,"ts_usec":1676304204421970}'}}, 'streams': [{'stream_name': 'id_and_name', 'stream_namespace': 'public', 'cursor_field': ['id']}]}
```

Also, modified the `seed.sql` for Postgres as the tables for CDC **MUST** have a primary key.

## NOTES
When working in this issue, I realise that CDC state messages are adding `cdc: False` in the state message.
Not investigated if this only impact `LEGACY` state messages or it's happening to new state messages.