### PR TITLE
🪟 🔧 Fix ESLint watcher

### DIFF
--- a/airbyte-webapp/vite.config.ts
+++ b/airbyte-webapp/vite.config.ts
@@ -43,7 +43,7 @@ export default defineConfig(({ mode }) => {
           // Align error popover button with the react-query dev tool button
           badgeStyle: "transform: translate(-135px,-11px)",
         },
-        eslint: { lintCommand: `eslint --max-warnings=0 --ext js,ts,tsx src` },
+        eslint: { lintCommand: `eslint --max-warnings=0 --ext .js,.ts,.tsx src` },
         stylelint: {
           lintCommand: 'stylelint "src/**/*.{css,scss}"',
           // We need to overwrite this during development, since otherwise `files` are wrongly


### PR DESCRIPTION
## What

Currently the ESLint running in dev mode is not automatically checking changed files again. This is caused by `vite-checker-plugin` internally comparing the file extension against the array of file extensions from `--ext`. Though those are expected to contain the `.` of the file extension, which I forgot to put in here. ESLint itself when running still works fine, but the file watcher checked: `['tsx', 'ts', 'js'].includes('.tsx')` which always failed and thus never reran on file changes.

Fixins this now by correctly using periods in the command.

We also have a problem that stylelint doesn't rerun, which needs to be fixed in `vite-plugin-checker`. I opened a PR there: https://github.com/fi3ework/vite-plugin-checker/pull/219