### PR TITLE
Connector-builder-server: suppress verbose test output

### DIFF
--- a/airbyte-connector-builder-server/run_tests.sh
+++ b/airbyte-connector-builder-server/run_tests.sh
@@ -6,10 +6,10 @@ cd $1
 set -e
 
 # Install dependencies
-pip install -e .
-pip install -e '.[main]'
-pip install -e '.[tests]'
+pip install -q -e .
+pip install -q -e '.[main]'
+pip install -q -e '.[tests]'
 
 # Run the tests
-python -m coverage run -m pytest unit_tests -c pytest.ini
-python -m coverage run -m pytest integration_tests -c pytest.ini
+python -m coverage run -m pytest -p no:logging --disable-warnings unit_tests -c pytest.ini
+python -m coverage run -m pytest -p no:logging --disable-warnings integration_tests -c pytest.ini

--- a/airbyte-connector-builder-server/run_tests.sh
+++ b/airbyte-connector-builder-server/run_tests.sh
@@ -7,7 +7,6 @@ set -e
 
 # Install dependencies
 pip install -q -e .
-pip install -q -e '.[main]'
 pip install -q -e '.[tests]'
 
 # Run the tests


### PR DESCRIPTION
## What
This change makes it so that `run_tests.sh` only provides verbose error messages if there is a problem. Otherwise it prints a clean test summary like the following: 

```
(.venv) ➜  airbyte-connector-builder-server git:(sherif/suppress-builder-server-test-output) ✗ ./run_tests.sh .
WARNING: You are using pip version 22.0.4; however, version 23.0 is available.
You should consider upgrading via the '/Users/sherif/code/airbyte/airbyte-connector-builder-server/.venv/bin/python -m pip install --upgrade pip' command.
WARNING: connector-builder-server 0.40.32 does not provide the extra 'main'
WARNING: You are using pip version 22.0.4; however, version 23.0 is available.
You should consider upgrading via the '/Users/sherif/code/airbyte/airbyte-connector-builder-server/.venv/bin/python -m pip install --upgrade pip' command.
WARNING: You are using pip version 22.0.4; however, version 23.0 is available.
You should consider upgrading via the '/Users/sherif/code/airbyte/airbyte-connector-builder-server/.venv/bin/python -m pip install --upgrade pip' command.
============================================================================================================================ test session starts =============================================================================================================================
platform darwin -- Python 3.9.11, pytest-6.2.5, py-1.11.0, pluggy-1.0.0
rootdir: /Users/sherif/code/airbyte/airbyte-connector-builder-server/unit_tests, configfile: ../pytest.ini
plugins: mock-3.10.0, recording-0.12.1, requests-mock-1.10.0, cov-4.0.0, anyio-3.6.2
collected 41 items

unit_tests/test_unit_test.py .                                                                                                                                                                                                                                         [  2%]
unit_tests/connector_builder/impl/test_default_api.py ................................                                                                                                                                                                                 [ 80%]
unit_tests/connector_builder/impl/test_low_code_cdk_adapter.py ........                                                                                                                                                                                                [100%]

====================================================================================================================== 41 passed, 26 warnings in 3.15s =======================================================================================================================
============================================================================================================================ test session starts =============================================================================================================================
platform darwin -- Python 3.9.11, pytest-6.2.5, py-1.11.0, pluggy-1.0.0
rootdir: /Users/sherif/code/airbyte/airbyte-connector-builder-server/integration_tests, configfile: ../pytest.ini
plugins: mock-3.10.0, recording-0.12.1, requests-mock-1.10.0, cov-4.0.0, anyio-3.6.2
collected 1 item

integration_tests/test_integration_test.py .                                                                                                                                                                                                                           [100%]

======================================================================================================================= 1 passed, 4 warnings in 0.01s ========================================================================================================================
```