### PR TITLE
Fix build by ignoring normalization's CDK models linting errors

### DIFF
--- a/airbyte-integrations/bases/base-normalization/normalization/transform_catalog/catalog_processor.py
+++ b/airbyte-integrations/bases/base-normalization/normalization/transform_catalog/catalog_processor.py
@@ -9,7 +9,7 @@ import re
 from typing import Any, Dict, List, Set
 
 import yaml
-from airbyte_cdk.models.airbyte_protocol import DestinationSyncMode, SyncMode
+from airbyte_cdk.models.airbyte_protocol import DestinationSyncMode, SyncMode # type: ignore
 from normalization.destination_type import DestinationType
 from normalization.transform_catalog import dbt_macro
 from normalization.transform_catalog.destination_name_transformer import DestinationNameTransformer

--- a/airbyte-integrations/bases/base-normalization/normalization/transform_catalog/stream_processor.py
+++ b/airbyte-integrations/bases/base-normalization/normalization/transform_catalog/stream_processor.py
@@ -8,7 +8,7 @@ import re
 from enum import Enum
 from typing import Any, Dict, List, Optional, Tuple, Union
 
-from airbyte_cdk.models.airbyte_protocol import DestinationSyncMode, SyncMode
+from airbyte_cdk.models.airbyte_protocol import DestinationSyncMode, SyncMode # type: ignore 
 from jinja2 import Template
 from normalization.destination_type import DestinationType
 from normalization.transform_catalog import dbt_macro

--- a/airbyte-integrations/bases/base-normalization/setup.py
+++ b/airbyte-integrations/bases/base-normalization/setup.py
@@ -12,7 +12,7 @@ setuptools.setup(
     author_email="contact@airbyte.io",
     url="https://github.com/airbytehq/airbyte",
     packages=setuptools.find_packages(),
-    install_requires=["airbyte-cdk", "pyyaml", "jinja2", "types-PyYAML"],
+    install_requires=["airbyte-cdk~=0.28", "pyyaml", "jinja2", "types-PyYAML"],
     package_data={"": ["*.yml"]},
     setup_requires=["pytest-runner"],
     entry_points={


### PR DESCRIPTION
## What
#22518 did some namespacing magic to make it look like files from the `airbyte-protocol-models` pypi package are actually part of the CDK package. But I think this is causing errors in linting. 

For example, with normalization's venv activated, running `from airbyte_cdk.models.airbyte_protocol import DestinationSyncMode, SyncMode` succeeds but mypy fails with the error 

```
[python] .venv/bin/python -m mypy normalization --config-file /actions-runner/_work/airbyte/airbyte/pyproject.toml
	 normalization/transform_catalog/stream_processor.py:11:1: error: Module
	 "airbyte_cdk.models.airbyte_protocol" has no attribute "DestinationSyncMode" 
	 [attr-defined]
	     from airbyte_cdk.models.airbyte_protocol import DestinationSyncMode, S...
	     ^
	 normalization/transform_catalog/stream_processor.py:11:1: error: Module
	 "airbyte_cdk.models.airbyte_protocol" has no attribute "SyncMode" 
	 [attr-defined]
	     from airbyte_cdk.models.airbyte_protocol import DestinationSyncMode, S...
	     ^
	 normalization/transform_catalog/catalog_processor.py:12:1: error: Module
	 "airbyte_cdk.models.airbyte_protocol" has no attribute "DestinationSyncMode" 
	 [attr-defined]
	     from airbyte_cdk.models.airbyte_protocol import DestinationSyncMode, S...
	     ^
	 normalization/transform_catalog/catalog_processor.py:12:1: error: Module
	 "airbyte_cdk.models.airbyte_protocol" has no attribute "SyncMode" 
	 [attr-defined]
	     from airbyte_cdk.models.airbyte_protocol import DestinationSyncMode, S...
	     ^
	 Found 4 errors in 2 files (checked 13 source files)
```

See an example of this [here](https://github.com/airbytehq/airbyte/actions/runs/4168517245/jobs/7215431148)

This PR tells mypy to ignore those imports for now until we figure out how to fix the mypy problems. 

## How
manually ignore those imports 
