### PR TITLE
fix normalization build

### DIFF
--- a/airbyte-integrations/bases/base-normalization/setup.py
+++ b/airbyte-integrations/bases/base-normalization/setup.py
@@ -12,7 +12,7 @@ setuptools.setup(
     author_email="contact@airbyte.io",
     url="https://github.com/airbytehq/airbyte",
     packages=setuptools.find_packages(),
-    install_requires=["airbyte-cdk~=0.28", "pyyaml", "jinja2", "types-PyYAML"],
+    install_requires=["airbyte-cdk", "pyyaml", "jinja2", "types-PyYAML"],
     package_data={"": ["*.yml"]},
     setup_requires=["pytest-runner"],
     entry_points={


### PR DESCRIPTION
## What
A previous PR pinned the build to `airbyte-cdk~=0.28`. This breaks the oracle normalization image build because it is using dbt:0.19.1 which uses python3.8 (and CDK has supports 3.9 only since ~April). This PR removes that constraint as it seems like the build is working just fine without it (and oracle normalization hasn't really been touched in a while and doesn't seem to depend on the CDK in any real way other than to get types for a couple of Airbyte Protocol classes)
