### PR TITLE
Fix typo in example in error handing doc

### DIFF
--- a/docs/connector-development/config-based/understanding-the-yaml-file/error-handling.md
+++ b/docs/connector-development/config-based/understanding-the-yaml-file/error-handling.md
@@ -114,7 +114,7 @@ requester:
   <...>
   error_handler:
     response_filters:
-        - error_message_contain: "ignorethisresponse"
+        - error_message_contains: "ignorethisresponse"
           action: IGNORE
 ```
 


### PR DESCRIPTION
Documentation: Missing 's' on end of field `error_message_contains`