### PR TITLE
only run review requirements on source connectors

### DIFF
--- a/.github/workflows/connector_teams_review_requirements.yml
+++ b/.github/workflows/connector_teams_review_requirements.yml
@@ -5,6 +5,8 @@ on:
     paths:
       - "airbyte-integrations/connectors/source-**"
   pull_request_review:
+    paths:
+      - "airbyte-integrations/connectors/source-**"
 jobs:
   check-review-requirements:
     name: "Check if a review is required from Connector teams"


### PR DESCRIPTION


## What
I think this is misconfigured to run on EVERY pull request review event instead of just pull request review events on certain paths. Need to verify that is the case.

## How
only fire on pull request review events for certain paths
