### PR TITLE
Add WorkspaceId to Job Reset configs

### DIFF
--- a/airbyte-persistence/job-persistence/src/main/java/io/airbyte/persistence/job/DefaultJobCreator.java
+++ b/airbyte-persistence/job-persistence/src/main/java/io/airbyte/persistence/job/DefaultJobCreator.java
@@ -137,7 +137,8 @@ public class DefaultJobCreator implements JobCreator {
             workerResourceRequirements))
         .withResetSourceConfiguration(new ResetSourceConfiguration().withStreamsToReset(streamsToReset))
         .withIsSourceCustomConnector(false)
-        .withIsDestinationCustomConnector(isDestinationCustomConnector);
+        .withIsDestinationCustomConnector(isDestinationCustomConnector)
+        .withWorkspaceId(destination.getWorkspaceId());
 
     final JobConfig jobConfig = new JobConfig()
         .withConfigType(ConfigType.RESET_CONNECTION)

--- a/airbyte-persistence/job-persistence/src/test/java/io/airbyte/persistence/job/DefaultJobCreatorTest.java
+++ b/airbyte-persistence/job-persistence/src/test/java/io/airbyte/persistence/job/DefaultJobCreatorTest.java
@@ -412,7 +412,8 @@ class DefaultJobCreatorTest {
         .withResourceRequirements(workerResourceRequirements)
         .withResetSourceConfiguration(new ResetSourceConfiguration().withStreamsToReset(streamsToReset))
         .withIsSourceCustomConnector(false)
-        .withIsDestinationCustomConnector(false);
+        .withIsDestinationCustomConnector(false)
+        .withWorkspaceId(DESTINATION_CONNECTION.getWorkspaceId());
 
     final JobConfig jobConfig = new JobConfig()
         .withConfigType(ConfigType.RESET_CONNECTION)
@@ -464,7 +465,8 @@ class DefaultJobCreatorTest {
         .withResourceRequirements(workerResourceRequirements)
         .withResetSourceConfiguration(new ResetSourceConfiguration().withStreamsToReset(streamsToReset))
         .withIsSourceCustomConnector(false)
-        .withIsDestinationCustomConnector(false);
+        .withIsDestinationCustomConnector(false)
+        .withWorkspaceId(DESTINATION_CONNECTION.getWorkspaceId());
 
     final JobConfig jobConfig = new JobConfig()
         .withConfigType(ConfigType.RESET_CONNECTION)


### PR DESCRIPTION
## What
* We are not setting the workspaceId for resets, this may prevent some feature flags to work as expected.

## How
* Pass the workspaceId for resets.

