### PR TITLE
Strict comparison normalization: Use launchdarkly feature flag

### DIFF
--- a/airbyte-featureflag/src/main/kotlin/Flags.kt
+++ b/airbyte-featureflag/src/main/kotlin/Flags.kt
@@ -19,6 +19,8 @@ object ApplyFieldSelection : EnvVar(envVar = "APPLY_FIELD_SELECTION")
 
 object PerfBackgroundJsonValidation : Temporary(key = "performance.backgroundJsonSchemaValidation")
 
+object StrictComparisonNormalizationEnabled : Temporary(key = "normalization.strictComparisonNormalizationEnabled")
+
 object FieldSelectionEnabled : Temporary(key="connection.columnSelection")
 
 // NOTE: this is deprecated in favor of FieldSelectionEnabled and will be removed once that flag is fully deployed.

--- a/airbyte-workers/src/main/java/io/airbyte/workers/temporal/sync/NormalizationActivityImpl.java
+++ b/airbyte-workers/src/main/java/io/airbyte/workers/temporal/sync/NormalizationActivityImpl.java
@@ -119,7 +119,6 @@ public class NormalizationActivityImpl implements NormalizationActivity {
   public NormalizationSummary normalize(final JobRunConfig jobRunConfig,
                                         final IntegrationLauncherConfig destinationLauncherConfig,
                                         final NormalizationInput input) {
-
     ApmTraceUtils.addTagsToTrace(
         Map.of(ATTEMPT_NUMBER_KEY, jobRunConfig.getAttemptId(), JOB_ID_KEY, jobRunConfig.getJobId(), DESTINATION_DOCKER_IMAGE_KEY,
             destinationLauncherConfig.getDockerImage()));

--- a/flags.yml
+++ b/flags.yml
@@ -3,3 +3,5 @@ flags:
     enabled: false
   - name: heartbeat.failSync
     enabled: false
+  - name: normalization.strictComparisonNormalizationEnabled
+    enabled: false


### PR DESCRIPTION
## What
flag defined in https://app.launchdarkly.com/default/production/features/normalization.strictComparisonNormalizationEnabled

image tag continues to be an env var though, since it needs to be an arbitrary string

## How
if workspace is in either the env var, _or_ the feature flag, then use the strict_comparison normalization image. This will make the transition smoother (i.e. anyone already in the env var continues to work, and then we can add more workspaces via launchdarkly)

## Recommended reading order
yes, I recommend you read the files in order

## 🚨 User Impact 🚨
none