### PR TITLE
airbyte-commons-server bugfix: tolerate empty documentationUrl in connector spec 

### DIFF
--- a/airbyte-commons-server/src/main/java/io/airbyte/commons/server/handlers/SchedulerHandler.java
+++ b/airbyte-commons-server/src/main/java/io/airbyte/commons/server/handlers/SchedulerHandler.java
@@ -346,11 +346,15 @@ public class SchedulerHandler {
     final UUID sourceDefinitionId = sourceDefinitionIdWithWorkspaceId.getSourceDefinitionId();
     final StandardSourceDefinition source = configRepository.getStandardSourceDefinition(sourceDefinitionId);
     final ConnectorSpecification spec = source.getSpec();
+
     final SourceDefinitionSpecificationRead specRead = new SourceDefinitionSpecificationRead()
         .jobInfo(jobConverter.getSynchronousJobRead(SynchronousJobMetadata.mock(ConfigType.GET_SPEC)))
         .connectionSpecification(spec.getConnectionSpecification())
-        .documentationUrl(spec.getDocumentationUrl().toString())
         .sourceDefinitionId(sourceDefinitionId);
+
+    if (spec.getDocumentationUrl() != null) {
+      specRead.documentationUrl(spec.getDocumentationUrl().toString());
+    }
 
     final Optional<AuthSpecification> authSpec = OauthModelConverter.getAuthSpec(spec);
     authSpec.ifPresent(specRead::setAuthSpecification);

--- a/airbyte-commons-server/src/test/java/io/airbyte/commons/server/handlers/SchedulerHandlerTest.java
+++ b/airbyte-commons-server/src/test/java/io/airbyte/commons/server/handlers/SchedulerHandlerTest.java
@@ -142,6 +142,10 @@ class SchedulerHandlerTest {
       .withChangelogUrl(Exceptions.toRuntime(() -> new URI("https://google.com")))
       .withConnectionSpecification(Jsons.jsonNode(new HashMap<>()));
 
+  private static final ConnectorSpecification CONNECTOR_SPECIFICATION_WITHOUT_DOCS_URL = new ConnectorSpecification()
+      .withChangelogUrl(Exceptions.toRuntime(() -> new URI("https://google.com")))
+      .withConnectionSpecification(Jsons.jsonNode(new HashMap<>()));
+
   private static final StreamDescriptor STREAM_DESCRIPTOR = new StreamDescriptor().withName("1");
 
   private SchedulerHandler schedulerHandler;
@@ -303,6 +307,26 @@ class SchedulerHandlerTest {
 
     verify(configRepository).getStandardSourceDefinition(sourceDefinitionIdWithWorkspaceId.getSourceDefinitionId());
     assertEquals(CONNECTOR_SPECIFICATION.getConnectionSpecification(), response.getConnectionSpecification());
+  }
+
+  @Test
+  void testGetSourceSpecWithoutDocs() throws JsonValidationException, IOException, ConfigNotFoundException {
+    final SourceDefinitionIdWithWorkspaceId sourceDefinitionIdWithWorkspaceId =
+        new SourceDefinitionIdWithWorkspaceId().sourceDefinitionId(UUID.randomUUID()).workspaceId(UUID.randomUUID());
+
+    final StandardSourceDefinition sourceDefinition = new StandardSourceDefinition()
+        .withName(NAME)
+        .withDockerRepository(SOURCE_DOCKER_REPO)
+        .withDockerImageTag(SOURCE_DOCKER_TAG)
+        .withSourceDefinitionId(sourceDefinitionIdWithWorkspaceId.getSourceDefinitionId())
+        .withSpec(CONNECTOR_SPECIFICATION_WITHOUT_DOCS_URL);
+    when(configRepository.getStandardSourceDefinition(sourceDefinitionIdWithWorkspaceId.getSourceDefinitionId()))
+        .thenReturn(sourceDefinition);
+
+    final SourceDefinitionSpecificationRead response = schedulerHandler.getSourceDefinitionSpecification(sourceDefinitionIdWithWorkspaceId);
+
+    verify(configRepository).getStandardSourceDefinition(sourceDefinitionIdWithWorkspaceId.getSourceDefinitionId());
+    assertEquals(CONNECTOR_SPECIFICATION_WITHOUT_DOCS_URL.getConnectionSpecification(), response.getConnectionSpecification());
   }
 
   @Test


### PR DESCRIPTION
## What
Closes https://github.com/airbytehq/airbyte/issues/22242
Closes https://github.com/airbytehq/airbyte/issues/23040

I've manually verified that this fixes the issue reported in #23040 in a local deployment of Airbyte OSS. 

## How
Only attempt to call `.toString()` on `documentationUrl` if it's not null.