### PR TITLE
Hide the react query devtool button in cypress

### DIFF
--- a/airbyte-webapp-e2e-tests/cypress.json
+++ b/airbyte-webapp-e2e-tests/cypress.json
@@ -2,6 +2,7 @@
   "projectId": "916nvw",
   "baseUrl": "https://localhost:3000",
   "testFiles": ["**/*.spec.*"],
+  "supportFile": "cypress/support/e2e.ts",
   "viewportHeight": 800,
   "viewportWidth": 1280,
   "retries": {

--- a/airbyte-webapp-e2e-tests/cypress/support/e2e.ts
+++ b/airbyte-webapp-e2e-tests/cypress/support/e2e.ts
@@ -1,0 +1,10 @@
+Cypress.on("window:load", (window) => {
+  // Hide the react-query devtool button during tests, to it never accidentally overlaps some button
+  // that cypress needs to click
+  const style = document.createElement("style");
+  style.setAttribute("data-style", "cypress-injected");
+  style.textContent = `
+    #react-query-devtool-btn { display: none !important; }
+  `;
+  window.document.head.appendChild(style);
+});

--- a/airbyte-webapp/src/views/common/StoreProvider.tsx
+++ b/airbyte-webapp/src/views/common/StoreProvider.tsx
@@ -18,7 +18,7 @@ const StoreProvider: React.FC<React.PropsWithChildren<unknown>> = ({ children })
     <ReactQueryDevtools
       initialIsOpen={false}
       position="bottom-right"
-      toggleButtonProps={{ style: { transform: "translateX(-75px)" } }}
+      toggleButtonProps={{ style: { transform: "translateX(-75px)" }, id: "react-query-devtool-btn" }}
     />
     {children}
   </QueryClientProvider>


### PR DESCRIPTION
## What

Hides the react query devtools button while running in cypress. When developing locally you usually have a dev version running that you run cypress tests against (via `cypress:open`), which has that button visible by default. We've seen cases where the button overlaps another button and cypress can't click that unerlying button in this case. So making sure we always hide that button when running cypress cases.