### PR TITLE
ci: weekly builds for alpha connectors

### DIFF
--- a/.github/workflows/connector_integration_tests_alpha.yml
+++ b/.github/workflows/connector_integration_tests_alpha.yml
@@ -1,4 +1,4 @@
-name: Connector Integration Tests
+name: Connector Integration Tests (Alpha connectors only)
 
 # Launches the connector integration tests
 
@@ -6,11 +6,10 @@ on:
   workflow_dispatch:
   schedule:
     # 11am UTC is 4am PDT.
-    - cron: "0 11 * * *"
+    - cron: "0 11 * * 0"
 
 jobs:
-  launch_integration_tests:
-    timeout-minutes: 30
+  launch_integration_tests_alpha_only:
     runs-on: ubuntu-latest
     if: github.ref == 'refs/heads/master'
     steps:
@@ -25,7 +24,7 @@ jobs:
         run: |
           python -m pip install --upgrade pip
           pip install PyYAML requests
-      - name: Launch Integration Tests
-        run: python ./tools/bin/ci_integration_workflow_launcher.py base-normalization connector-acceptance-test source:beta source:GA destination:beta destination:GA
+      - name: Launch Integration Tests (Alpha connectors)
+        run: python ./tools/bin/ci_integration_workflow_launcher.py source:alpha destination:alpha
         env:
           GITHUB_TOKEN: ${{ secrets.GH_PAT_MAINTENANCE_OSS }}


### PR DESCRIPTION
We want to run the alpha connectors builds weekly instead of nightly for cost reasons.