### PR TITLE
Only generate api client code as needed

### DIFF
--- a/airbyte-webapp/package.json
+++ b/airbyte-webapp/package.json
@@ -8,13 +8,13 @@
   },
   "scripts": {
     "prepare": "cd .. && husky install airbyte-webapp/.husky",
-    "prestart": "pnpm run generate-client",
+    "prestart": "TS_NODE_TRANSPILE_ONLY=true pnpm run generate-client",
     "start": "NODE_OPTIONS='-r ./scripts/dev-overwrites.js' vite",
-    "prestart:cloud": "pnpm run generate-client",
+    "prestart:cloud": "TS_NODE_TRANSPILE_ONLY=true pnpm run generate-client",
     "start:cloud": "AB_ENV=${AB_ENV-frontend-dev} NODE_OPTIONS='-r ./scripts/environment.js -r ./scripts/dev-overwrites.js' vite",
     "prebuild": "pnpm run generate-client",
     "build": "vite build",
-    "pretest": "pnpm run generate-client",
+    "pretest": "TS_NODE_TRANSPILE_ONLY=true pnpm run generate-client",
     "test": "jest --watch",
     "test:ci": "jest --watchAll=false --silent",
     "test:coverage": "jest --coverage --watchAll=false",
@@ -25,7 +25,7 @@
     "stylelint": "stylelint 'src/**/*.{css,scss}'",
     "stylelint-check": "stylelint-config-prettier-scss-check",
     "license-check": "node ./scripts/license-check.js",
-    "generate-client": "./scripts/load-declarative-schema.sh && orval",
+    "generate-client": "./scripts/load-declarative-schema.sh && ts-node --skip-project ./scripts/regenerate-api-clients.ts",
     "validate-links": "ts-node --skip-project ./scripts/validate-links.ts"
   },
   "dependencies": {

--- a/airbyte-webapp/package.json
+++ b/airbyte-webapp/package.json
@@ -180,27 +180,13 @@
     "minimatch": "^3.0.5"
   },
   "lint-staged": {
-    "src/**/*.{js,jsx,ts,tsx}": [
-      "eslint --fix"
-    ],
-    "src/**/*.{css,scss,md,json}": [
-      "prettier --write"
-    ],
-    "{public,src}/**/*.{css,scss}": [
-      "stylelint --fix"
-    ]
+    "src/**/*.{js,jsx,ts,tsx}": ["eslint --fix"],
+    "src/**/*.{css,scss,md,json}": ["prettier --write"],
+    "{public,src}/**/*.{css,scss}": ["stylelint --fix"]
   },
   "browserslist": {
-    "production": [
-      ">0.2%",
-      "not dead",
-      "not op_mini all"
-    ],
-    "development": [
-      "last 1 chrome version",
-      "last 1 firefox version",
-      "last 1 safari version"
-    ]
+    "production": [">0.2%", "not dead", "not op_mini all"],
+    "development": ["last 1 chrome version", "last 1 firefox version", "last 1 safari version"]
   },
   "pnpm": {
     "patchedDependencies": {

--- a/airbyte-webapp/scripts/regenerate-api-clients.ts
+++ b/airbyte-webapp/scripts/regenerate-api-clients.ts
@@ -1,13 +1,17 @@
 import { statSync, existsSync } from "fs";
-import { resolve } from "path";
+import { resolve, basename } from "path";
+
+import chalk from "chalk";
 
 import conf from "../orval.config";
 
 const lastTouched = (filepath: string) => statSync(resolve(filepath)).mtime;
 
-for (const [, api] of Object.entries(conf)) {
+for (const api of Object.values(conf)) {
   if (!existsSync(api.output.target) || lastTouched(api.input) > lastTouched(api.output.target)) {
     // no need to read and parse the orval lib if all files are up to date
     require("orval").generate(api);
+  } else {
+    console.log(`🎉 ${chalk.green(basename(api.output.target))} is up-to-date`);
   }
 }

--- a/airbyte-webapp/scripts/regenerate-api-clients.ts
+++ b/airbyte-webapp/scripts/regenerate-api-clients.ts
@@ -1,0 +1,13 @@
+import { statSync, existsSync } from "fs";
+import { resolve } from "path";
+
+import conf from "../orval.config";
+
+const lastTouched = (filepath: string) => statSync(resolve(filepath)).mtime;
+
+for (const [, api] of Object.entries(conf)) {
+  if (!existsSync(api.output.target) || lastTouched(api.input) > lastTouched(api.output.target)) {
+    // no need to read and parse the orval lib if all files are up to date
+    require("orval").generate(api);
+  }
+}


### PR DESCRIPTION
## What
Replaces the bare `orval` call in `package.json["scripts"]["generate-client"]` with a new node script that only (re)generates API client files that are missing or out of date (as determined by [the files' `mtime`](https://www.gnu.org/software/coreutils/manual/html_node/File-timestamps.html)). This significantly speeds up startup time for scripts that rely on `generate-client`, like `start`, `start:cloud`, and `test`.