### PR TITLE
qa-engine: disable PR creation during code freeze

### DIFF
--- a/.github/workflows/run-qa-engine.yml
+++ b/.github/workflows/run-qa-engine.yml
@@ -28,4 +28,5 @@ jobs:
         env:
           LOGLEVEL: INFO
           GITHUB_API_TOKEN: ${{ secrets.GH_PAT_MAINTENANCE_OCTAVIA }}
-        run: run-qa-engine --create-prs
+        #run: run-qa-engine --create-prs
+        run: run-qa-engine


### PR DESCRIPTION
## What
Disable the automatic creation of PR by the QA Engine during the code freeze.
The current PR creation logic is about to change but will not be changed before the code freeze.
To avoid creating/updating a lot of PRs on our internal repo I prefer to disable PR creation during code freeze.