### PR TITLE
Run temporal related endpoints on IO task executor

### DIFF
--- a/airbyte-server/src/main/java/io/airbyte/server/apis/ConnectionApiController.java
+++ b/airbyte-server/src/main/java/io/airbyte/server/apis/ConnectionApiController.java
@@ -26,6 +26,8 @@ import io.micronaut.http.annotation.Body;
 import io.micronaut.http.annotation.Controller;
 import io.micronaut.http.annotation.Post;
 import io.micronaut.http.annotation.Status;
+import io.micronaut.scheduling.TaskExecutors;
+import io.micronaut.scheduling.annotation.ExecuteOn;
 import io.micronaut.security.annotation.Secured;
 import io.micronaut.security.rules.SecurityRule;
 
@@ -50,6 +52,7 @@ public class ConnectionApiController implements ConnectionApi {
   @Post(uri = "/create")
   @Secured({EDITOR})
   @SecuredWorkspace
+  @ExecuteOn(TaskExecutors.IO)
   public ConnectionRead createConnection(@Body final ConnectionCreate connectionCreate) {
     return ApiHelper.execute(() -> connectionsHandler.createConnection(connectionCreate));
   }
@@ -58,6 +61,7 @@ public class ConnectionApiController implements ConnectionApi {
   @Post(uri = "/update")
   @Secured({EDITOR})
   @SecuredWorkspace
+  @ExecuteOn(TaskExecutors.IO)
   public ConnectionRead updateConnection(@Body final ConnectionUpdate connectionUpdate) {
     return ApiHelper.execute(() -> connectionsHandler.updateConnection(connectionUpdate));
   }
@@ -97,6 +101,7 @@ public class ConnectionApiController implements ConnectionApi {
   @Status(HttpStatus.NO_CONTENT)
   @Secured({EDITOR})
   @SecuredWorkspace
+  @ExecuteOn(TaskExecutors.IO)
   public void deleteConnection(@Body final ConnectionIdRequestBody connectionIdRequestBody) {
     ApiHelper.execute(() -> {
       operationsHandler.deleteOperationsForConnection(connectionIdRequestBody);
@@ -109,6 +114,7 @@ public class ConnectionApiController implements ConnectionApi {
   @Post(uri = "/sync")
   @Secured({EDITOR})
   @SecuredWorkspace
+  @ExecuteOn(TaskExecutors.IO)
   public JobInfoRead syncConnection(@Body final ConnectionIdRequestBody connectionIdRequestBody) {
     return ApiHelper.execute(() -> schedulerHandler.syncConnection(connectionIdRequestBody));
   }
@@ -117,6 +123,7 @@ public class ConnectionApiController implements ConnectionApi {
   @Post(uri = "/reset")
   @Secured({EDITOR})
   @SecuredWorkspace
+  @ExecuteOn(TaskExecutors.IO)
   public JobInfoRead resetConnection(@Body final ConnectionIdRequestBody connectionIdRequestBody) {
     return ApiHelper.execute(() -> schedulerHandler.resetConnection(connectionIdRequestBody));
   }

--- a/airbyte-server/src/main/java/io/airbyte/server/apis/DestinationApiController.java
+++ b/airbyte-server/src/main/java/io/airbyte/server/apis/DestinationApiController.java
@@ -25,6 +25,8 @@ import io.micronaut.http.annotation.Body;
 import io.micronaut.http.annotation.Controller;
 import io.micronaut.http.annotation.Post;
 import io.micronaut.http.annotation.Status;
+import io.micronaut.scheduling.TaskExecutors;
+import io.micronaut.scheduling.annotation.ExecuteOn;
 import io.micronaut.security.annotation.Secured;
 import io.micronaut.security.rules.SecurityRule;
 
@@ -43,6 +45,7 @@ public class DestinationApiController implements DestinationApi {
   @Post(uri = "/check_connection")
   @Secured({EDITOR})
   @SecuredWorkspace
+  @ExecuteOn(TaskExecutors.IO)
   @Override
   public CheckConnectionRead checkConnectionToDestination(@Body final DestinationIdRequestBody destinationIdRequestBody) {
     return ApiHelper.execute(() -> schedulerHandler.checkDestinationConnectionFromDestinationId(destinationIdRequestBody));
@@ -51,6 +54,7 @@ public class DestinationApiController implements DestinationApi {
   @Post(uri = "/check_connection_for_update")
   @Secured({EDITOR})
   @SecuredWorkspace
+  @ExecuteOn(TaskExecutors.IO)
   @Override
   public CheckConnectionRead checkConnectionToDestinationForUpdate(@Body final DestinationUpdate destinationUpdate) {
     return ApiHelper.execute(() -> schedulerHandler.checkDestinationConnectionFromDestinationIdForUpdate(destinationUpdate));

--- a/airbyte-server/src/main/java/io/airbyte/server/apis/DestinationDefinitionApiController.java
+++ b/airbyte-server/src/main/java/io/airbyte/server/apis/DestinationDefinitionApiController.java
@@ -26,6 +26,8 @@ import io.micronaut.http.HttpStatus;
 import io.micronaut.http.annotation.Controller;
 import io.micronaut.http.annotation.Post;
 import io.micronaut.http.annotation.Status;
+import io.micronaut.scheduling.TaskExecutors;
+import io.micronaut.scheduling.annotation.ExecuteOn;
 import io.micronaut.security.annotation.Secured;
 import io.micronaut.security.rules.SecurityRule;
 
@@ -43,6 +45,7 @@ public class DestinationDefinitionApiController implements DestinationDefinition
   @Post(uri = "/create_custom")
   @Secured({EDITOR})
   @SecuredWorkspace
+  @ExecuteOn(TaskExecutors.IO)
   @Override
   public DestinationDefinitionRead createCustomDestinationDefinition(final CustomDestinationDefinitionCreate customDestinationDefinitionCreate) {
     return ApiHelper.execute(() -> destinationDefinitionsHandler.createCustomDestinationDefinition(customDestinationDefinitionCreate));

--- a/airbyte-server/src/main/java/io/airbyte/server/apis/JobsApiController.java
+++ b/airbyte-server/src/main/java/io/airbyte/server/apis/JobsApiController.java
@@ -24,6 +24,8 @@ import io.airbyte.commons.server.handlers.SchedulerHandler;
 import io.micronaut.context.annotation.Context;
 import io.micronaut.http.annotation.Controller;
 import io.micronaut.http.annotation.Post;
+import io.micronaut.scheduling.TaskExecutors;
+import io.micronaut.scheduling.annotation.ExecuteOn;
 import io.micronaut.security.annotation.Secured;
 import io.micronaut.security.rules.SecurityRule;
 
@@ -43,6 +45,7 @@ public class JobsApiController implements JobsApi {
   @Post("/cancel")
   @Secured({EDITOR})
   @SecuredWorkspace
+  @ExecuteOn(TaskExecutors.IO)
   @Override
   public JobInfoRead cancelJob(final JobIdRequestBody jobIdRequestBody) {
     return ApiHelper.execute(() -> schedulerHandler.cancelJob(jobIdRequestBody));
@@ -58,6 +61,7 @@ public class JobsApiController implements JobsApi {
   @Post("/get_debug_info")
   @Secured({READER})
   @SecuredWorkspace
+  @ExecuteOn(TaskExecutors.IO)
   @Override
   public JobDebugInfoRead getJobDebugInfo(final JobIdRequestBody jobIdRequestBody) {
     return ApiHelper.execute(() -> jobHistoryHandler.getJobDebugInfo(jobIdRequestBody));

--- a/airbyte-server/src/main/java/io/airbyte/server/apis/SchedulerApiController.java
+++ b/airbyte-server/src/main/java/io/airbyte/server/apis/SchedulerApiController.java
@@ -16,6 +16,8 @@ import io.airbyte.commons.auth.SecuredWorkspace;
 import io.airbyte.commons.server.handlers.SchedulerHandler;
 import io.micronaut.http.annotation.Controller;
 import io.micronaut.http.annotation.Post;
+import io.micronaut.scheduling.TaskExecutors;
+import io.micronaut.scheduling.annotation.ExecuteOn;
 import io.micronaut.security.annotation.Secured;
 import io.micronaut.security.rules.SecurityRule;
 
@@ -31,6 +33,7 @@ public class SchedulerApiController implements SchedulerApi {
 
   @Post("/destinations/check_connection")
   @Secured({AUTHENTICATED_USER})
+  @ExecuteOn(TaskExecutors.IO)
   @Override
   public CheckConnectionRead executeDestinationCheckConnection(final DestinationCoreConfig destinationCoreConfig) {
     return ApiHelper.execute(() -> schedulerHandler.checkDestinationConnectionFromDestinationCreate(destinationCoreConfig));
@@ -38,6 +41,7 @@ public class SchedulerApiController implements SchedulerApi {
 
   @Post("/sources/check_connection")
   @Secured({AUTHENTICATED_USER})
+  @ExecuteOn(TaskExecutors.IO)
   @Override
   public CheckConnectionRead executeSourceCheckConnection(final SourceCoreConfig sourceCoreConfig) {
     return ApiHelper.execute(() -> schedulerHandler.checkSourceConnectionFromSourceCreate(sourceCoreConfig));
@@ -46,6 +50,7 @@ public class SchedulerApiController implements SchedulerApi {
   @Post("/sources/discover_schema")
   @Secured({EDITOR})
   @SecuredWorkspace
+  @ExecuteOn(TaskExecutors.IO)
   @Override
   public SourceDiscoverSchemaRead executeSourceDiscoverSchema(final SourceCoreConfig sourceCoreConfig) {
     return ApiHelper.execute(() -> schedulerHandler.discoverSchemaForSourceFromSourceCreate(sourceCoreConfig));

--- a/airbyte-server/src/main/java/io/airbyte/server/apis/SourceApiController.java
+++ b/airbyte-server/src/main/java/io/airbyte/server/apis/SourceApiController.java
@@ -29,6 +29,8 @@ import io.micronaut.http.HttpStatus;
 import io.micronaut.http.annotation.Controller;
 import io.micronaut.http.annotation.Post;
 import io.micronaut.http.annotation.Status;
+import io.micronaut.scheduling.TaskExecutors;
+import io.micronaut.scheduling.annotation.ExecuteOn;
 import io.micronaut.security.annotation.Secured;
 import io.micronaut.security.rules.SecurityRule;
 
@@ -47,6 +49,7 @@ public class SourceApiController implements SourceApi {
   @Post("/check_connection")
   @Secured({EDITOR})
   @SecuredWorkspace
+  @ExecuteOn(TaskExecutors.IO)
   @Override
   public CheckConnectionRead checkConnectionToSource(final SourceIdRequestBody sourceIdRequestBody) {
     return ApiHelper.execute(() -> schedulerHandler.checkSourceConnectionFromSourceId(sourceIdRequestBody));
@@ -55,6 +58,7 @@ public class SourceApiController implements SourceApi {
   @Post("/check_connection_for_update")
   @Secured({EDITOR})
   @SecuredWorkspace
+  @ExecuteOn(TaskExecutors.IO)
   @Override
   public CheckConnectionRead checkConnectionToSourceForUpdate(final SourceUpdate sourceUpdate) {
     return ApiHelper.execute(() -> schedulerHandler.checkSourceConnectionFromSourceIdForUpdate(sourceUpdate));
@@ -89,6 +93,7 @@ public class SourceApiController implements SourceApi {
   @Post("/discover_schema")
   @Secured({EDITOR})
   @SecuredWorkspace
+  @ExecuteOn(TaskExecutors.IO)
   @Override
   public SourceDiscoverSchemaRead discoverSchemaForSource(final SourceDiscoverSchemaRequestBody sourceDiscoverSchemaRequestBody) {
     return ApiHelper.execute(() -> schedulerHandler.discoverSchemaForSourceFromSourceId(sourceDiscoverSchemaRequestBody));

--- a/airbyte-server/src/main/java/io/airbyte/server/apis/SourceDefinitionApiController.java
+++ b/airbyte-server/src/main/java/io/airbyte/server/apis/SourceDefinitionApiController.java
@@ -26,6 +26,8 @@ import io.micronaut.http.HttpStatus;
 import io.micronaut.http.annotation.Controller;
 import io.micronaut.http.annotation.Post;
 import io.micronaut.http.annotation.Status;
+import io.micronaut.scheduling.TaskExecutors;
+import io.micronaut.scheduling.annotation.ExecuteOn;
 import io.micronaut.security.annotation.Secured;
 import io.micronaut.security.rules.SecurityRule;
 
@@ -43,6 +45,7 @@ public class SourceDefinitionApiController implements SourceDefinitionApi {
   @Post("/create_custom")
   @Secured({EDITOR})
   @SecuredWorkspace
+  @ExecuteOn(TaskExecutors.IO)
   @Override
   public SourceDefinitionRead createCustomSourceDefinition(final CustomSourceDefinitionCreate customSourceDefinitionCreate) {
     return ApiHelper.execute(() -> sourceDefinitionsHandler.createCustomSourceDefinition(customSourceDefinitionCreate));

--- a/airbyte-server/src/main/java/io/airbyte/server/apis/WebBackendApiController.java
+++ b/airbyte-server/src/main/java/io/airbyte/server/apis/WebBackendApiController.java
@@ -27,6 +27,8 @@ import io.airbyte.commons.server.handlers.WebBackendConnectionsHandler;
 import io.airbyte.commons.server.handlers.WebBackendGeographiesHandler;
 import io.micronaut.http.annotation.Controller;
 import io.micronaut.http.annotation.Post;
+import io.micronaut.scheduling.TaskExecutors;
+import io.micronaut.scheduling.annotation.ExecuteOn;
 import io.micronaut.security.annotation.Secured;
 import io.micronaut.security.rules.SecurityRule;
 
@@ -64,6 +66,7 @@ public class WebBackendApiController implements WebBackendApi {
   @Post("/connections/create")
   @Secured({EDITOR})
   @SecuredWorkspace
+  @ExecuteOn(TaskExecutors.IO)
   @Override
   public WebBackendConnectionRead webBackendCreateConnection(final WebBackendConnectionCreate webBackendConnectionCreate) {
     return ApiHelper.execute(() -> webBackendConnectionsHandler.webBackendCreateConnection(webBackendConnectionCreate));
@@ -103,6 +106,7 @@ public class WebBackendApiController implements WebBackendApi {
   @Post("/connections/update")
   @Secured({EDITOR})
   @SecuredWorkspace
+  @ExecuteOn(TaskExecutors.IO)
   @Override
   public WebBackendConnectionRead webBackendUpdateConnection(final WebBackendConnectionUpdate webBackendConnectionUpdate) {
     return ApiHelper.execute(() -> webBackendConnectionsHandler.webBackendUpdateConnection(webBackendConnectionUpdate));

--- a/airbyte-server/src/main/resources/application.yml
+++ b/airbyte-server/src/main/resources/application.yml
@@ -1,6 +1,9 @@
 micronaut:
   application:
     name: airbyte-server
+  executors:
+    io:
+      type: fixed
   security:
     authentication-provider-strategy: ALL
     enabled: ${API_AUTHORIZATION_ENABLED:false}


### PR DESCRIPTION
## What
* Avoid slow/blocking operations within controller endpoints

## How
* Utilize the Micronaut IO task executor to ensure that endpoints that interact with Temporal do not operate on the main Netty event loop
* [Micronaut Reactive HTTP Request Processing](https://docs.micronaut.io/latest/guide/#reactiveServer)

## Recommended reading order
1. `*Controller.java`
