### PR TITLE
Destination CSV: Delete duplicate doc

### DIFF
--- a/docs/integrations/destinations/csv.md
+++ b/docs/integrations/destinations/csv.md
@@ -1,9 +1,0 @@
-# CSV 
-
-The Airbyte Destination for CSV files.
-
-## Changelog
-
-| Version | Date       | Pull Request                                             | Subject      |
-| :------ | :--------- | :------------------------------------------------------- | :----------- |
-| 0.2.10  | 2022-08-08 | [13932](https://github.com/airbytehq/airbyte/pull/13932) | Bump version |


### PR DESCRIPTION
## What
Closes [#23160](https://github.com/airbytehq/airbyte/issues/23160)
Deletes a duplicate doc for [destination CSV](https://docs.airbyte.com/integrations/destinations/csv)
Leaving the correct one at [destination Local CSV](https://docs.airbyte.com/integrations/destinations/local-csv)

## Recommended reading order
1. `docs/integrations/destinations/csv.md`

## 🚨 User Impact 🚨
There should be no breaking changes.