### PR TITLE
:window: :tada: Handle existing service tokens

### DIFF
--- a/airbyte-webapp/src/packages/cloud/locales/en.json
+++ b/airbyte-webapp/src/packages/cloud/locales/en.json
@@ -100,6 +100,8 @@
   "settings.workspaceSettings": "Workspace settings",
   "settings.integrationSettings": "Integration settings",
   "settings.integrationSettings.dbtCloudSettings": "dbt Cloud Integration",
+  "settings.integrationSettings.dbtCloudSettings.actions.replace": "Replace service token",
+  "settings.integrationSettings.dbtCloudSettings.actions.delete": "Delete service token",
   "settings.integrationSettings.dbtCloudSettings.form.serviceToken": "Service Token",
   "settings.integrationSettings.dbtCloudSettings.form.description": "To use the dbt Cloud integration, enter your service token here. <lnk>Learn more</lnk>.",
   "settings.integrationSettings.dbtCloudSettings.form.advancedOptions": "Advanced options",

--- a/airbyte-webapp/src/packages/cloud/views/settings/integrations/DbtCloudSettingsView.module.scss
+++ b/airbyte-webapp/src/packages/cloud/views/settings/integrations/DbtCloudSettingsView.module.scss
@@ -3,12 +3,21 @@
 
 .controlGroup {
   display: flex;
-  justify-content: flex-end;
   margin-top: variables.$spacing-xl;
 
-  .button {
-    margin-left: variables.$spacing-md;
+  &.formButtons {
+    justify-content: flex-end;
   }
+}
+
+.button:not(:first-child) {
+  margin-left: variables.$spacing-md;
+}
+
+// the duplicate class is a specificity hack: without it, the Button component's default
+// variant styling overrides this instead of vice versa
+.replaceButton.replaceButton {
+  color: colors.$grey-800;
 }
 
 .cardContent {

--- a/airbyte-webapp/src/packages/cloud/views/settings/integrations/DbtCloudSettingsView.tsx
+++ b/airbyte-webapp/src/packages/cloud/views/settings/integrations/DbtCloudSettingsView.tsx
@@ -1,3 +1,6 @@
+import { faRecycle, faTrash } from "@fortawesome/free-solid-svg-icons";
+import { FontAwesomeIcon } from "@fortawesome/react-fontawesome";
+import classNames from "classnames";
 import { Field, FieldProps, Form, Formik } from "formik";
 import React, { useState } from "react";
 import { FormattedMessage, useIntl } from "react-intl";
@@ -6,73 +9,127 @@ import { LabeledInput } from "components/LabeledInput";
 import { Button } from "components/ui/Button";
 import { Text } from "components/ui/Text";
 
-import { useSubmitDbtCloudIntegrationConfig } from "packages/cloud/services/dbtCloud";
+import { useDbtCloudServiceToken } from "packages/cloud/services/dbtCloud";
 import { SettingsCard } from "pages/SettingsPage/pages/SettingsComponents";
 import { links } from "utils/links";
 
 import styles from "./DbtCloudSettingsView.module.scss";
 
+const cleanedErrorMessage = (e: Error): string => e.message.replace("Internal Server Error: ", "");
+
 export const DbtCloudSettingsView: React.FC = () => {
   const { formatMessage } = useIntl();
-  const { mutate: submitDbtCloudIntegrationConfig, isLoading } = useSubmitDbtCloudIntegrationConfig();
+  const { hasExistingToken, saveToken, isSavingToken, deleteToken, isDeletingToken } = useDbtCloudServiceToken();
   const [hasValidationError, setHasValidationError] = useState(false);
-  const [validationMessage, setValidationMessage] = useState("");
-  return (
-    <SettingsCard title={<FormattedMessage id="settings.integrationSettings.dbtCloudSettings" />}>
-      <div className={styles.cardContent}>
-        <Formik
-          initialValues={{
-            serviceToken: "",
-          }}
-          onSubmit={({ serviceToken }, { resetForm }) => {
-            setHasValidationError(false);
-            setValidationMessage("");
-            return submitDbtCloudIntegrationConfig(serviceToken, {
-              onError: (e) => {
-                setHasValidationError(true);
+  const [confirmationMessage, setConfirmationMessage] = useState("");
+  const [isReplacingToken, setIsReplacingToken] = useState(false);
 
-                setValidationMessage(e.message.replace("Internal Server Error: ", ""));
+  const ServiceTokenForm = () => (
+    <Formik
+      initialValues={{
+        serviceToken: "",
+      }}
+      onSubmit={({ serviceToken }) => {
+        setHasValidationError(false);
+        setConfirmationMessage("");
+        return saveToken(serviceToken, {
+          onError: (e) => {
+            setHasValidationError(true);
+
+            setConfirmationMessage(cleanedErrorMessage(e));
+          },
+          onSuccess: () => {
+            setConfirmationMessage(formatMessage({ id: "settings.integrationSettings.dbtCloudSettings.form.success" }));
+          },
+        });
+      }}
+    >
+      <Form>
+        <Field name="serviceToken">
+          {({ field }: FieldProps<string>) => (
+            <LabeledInput
+              {...field}
+              label={<FormattedMessage id="settings.integrationSettings.dbtCloudSettings.form.serviceToken" />}
+              error={hasValidationError}
+              message={confirmationMessage}
+              type="text"
+            />
+          )}
+        </Field>
+        <div className={classNames(styles.controlGroup, styles.formButtons)}>
+          {hasExistingToken && (
+            <Button
+              variant="secondary"
+              onClick={(e) => {
+                e.preventDefault();
+                setIsReplacingToken(false);
+              }}
+            >
+              Cancel
+            </Button>
+          )}
+          <Button variant="primary" type="submit" className={styles.button} isLoading={isSavingToken}>
+            <FormattedMessage id="settings.integrationSettings.dbtCloudSettings.form.submit" />
+          </Button>
+        </div>
+      </Form>
+    </Formik>
+  );
+
+  const ReplaceOrDeleteToken = () => {
+    return (
+      <div className={styles.controlGroup}>
+        <Button
+          className={classNames(styles.button, styles.replaceButton)}
+          variant="light"
+          icon={<FontAwesomeIcon icon={faRecycle} />}
+          onClick={() => {
+            setConfirmationMessage("");
+            setIsReplacingToken(true);
+          }}
+        >
+          <FormattedMessage id="settings.integrationSettings.dbtCloudSettings.actions.replace" />
+        </Button>
+        <Button
+          variant="danger"
+          className={styles.button}
+          onClick={() => {
+            deleteToken(void 0, {
+              onError: (e) => {
+                // TODO pop up error toast
+                console.error(e);
               },
               onSuccess: () => {
-                setValidationMessage(
-                  formatMessage({ id: "settings.integrationSettings.dbtCloudSettings.form.success" })
-                );
-                resetForm();
+                // TODO pop up success toast
+                console.log("I never liked that token, anyway.");
               },
             });
           }}
+          isLoading={isDeletingToken}
+          icon={<FontAwesomeIcon icon={faTrash} />}
         >
-          <Form>
-            <Text className={styles.description}>
-              <FormattedMessage
-                id="settings.integrationSettings.dbtCloudSettings.form.description"
-                values={{
-                  lnk: (node: React.ReactNode) => (
-                    <a href={links.dbtCloudIntegrationDocs} target="_blank" rel="noreferrer">
-                      {node}
-                    </a>
-                  ),
-                }}
-              />
-            </Text>
-            <Field name="serviceToken">
-              {({ field }: FieldProps<string>) => (
-                <LabeledInput
-                  {...field}
-                  label={<FormattedMessage id="settings.integrationSettings.dbtCloudSettings.form.serviceToken" />}
-                  error={hasValidationError}
-                  message={validationMessage}
-                  type="text"
-                />
-              )}
-            </Field>
-            <div className={styles.controlGroup}>
-              <Button variant="primary" type="submit" className={styles.button} isLoading={isLoading}>
-                <FormattedMessage id="settings.integrationSettings.dbtCloudSettings.form.submit" />
-              </Button>
-            </div>
-          </Form>
-        </Formik>
+          <FormattedMessage id="settings.integrationSettings.dbtCloudSettings.actions.delete" />
+        </Button>
+      </div>
+    );
+  };
+
+  return (
+    <SettingsCard title={<FormattedMessage id="settings.integrationSettings.dbtCloudSettings" />}>
+      <div className={styles.cardContent}>
+        <Text className={styles.description}>
+          <FormattedMessage
+            id="settings.integrationSettings.dbtCloudSettings.form.description"
+            values={{
+              lnk: (node: React.ReactNode) => (
+                <a href={links.dbtCloudIntegrationDocs} target="_blank" rel="noreferrer">
+                  {node}
+                </a>
+              ),
+            }}
+          />
+        </Text>
+        {hasExistingToken && !isReplacingToken ? <ReplaceOrDeleteToken /> : <ServiceTokenForm />}
       </div>
     </SettingsCard>
   );


### PR DESCRIPTION
## There are a few issues with the MVP dbt Cloud settings page
- it gives no visual indication if a service token has already been saved, which is suboptimal
- while you can replace an existing token with a different one, there is currently no way to remove the integration altogether, which is table stakes functionality for this feature going forwards
- speaking of issues: this PR closes https://github.com/airbytehq/airbyte/issues/23018 and https://github.com/airbytehq/airbyte/issues/23017

## So what are you going to do about it, huh?
- in a workspace with no dbt Cloud integration, there are no apparent changes: users see the text input for entering a service token and a submit button
- in a workspace with an existing integration, users see a pair of buttons: one to replace the current service token and one to remove it
- clicking the "replace service token" button replaces the button group with the service token text input, but with an additional "cancel" button to restore the button group
- clicking the "delete service token" button does what it says on the tin; when the deletion request successfully returns, the page rerenders in its "no existing integration" state

## A bit more about deletion
Although there is [an open issue about it](https://github.com/airbytehq/airbyte-internal-issues/issues/6028), there's not currently a way to properly delete the service token in the backend. What we can do is use a PATCH-type update to set the workspace's webhook operator configs to a list devoid of their dbt Cloud token.

## How about some pictures tho
Great idea.

![dbtcloud--managing-tokens_360](https://user-images.githubusercontent.com/7516653/219582734-040cc441-e1c7-4f8a-beea-6059c11e0ab3.gif)
