### PR TITLE
[connector builder] Return string format to allow for connector read() that return non-object responses

### DIFF
--- a/airbyte-connector-builder-server/connector_builder/generated/models/http_response.py
+++ b/airbyte-connector-builder-server/connector_builder/generated/models/http_response.py
@@ -1,9 +1,12 @@
 # coding: utf-8
+#
+# Copyright (c) 2023 Airbyte, Inc., all rights reserved.
+#
 
 from __future__ import annotations
-from datetime import date, datetime  # noqa: F401
 
 import re  # noqa: F401
+from datetime import date, datetime  # noqa: F401
 from typing import Any, Dict, List, Optional  # noqa: F401
 
 from pydantic import AnyUrl, BaseModel, EmailStr, validator  # noqa: F401
@@ -22,7 +25,8 @@ class HttpResponse(BaseModel):
     """
 
     status: int
-    body: Optional[Dict[str, Any]] = None
+    body: Optional[str] = None
     headers: Optional[Dict[str, Any]] = None
+
 
 HttpResponse.update_forward_refs()

--- a/airbyte-connector-builder-server/connector_builder/generated/models/http_response.py
+++ b/airbyte-connector-builder-server/connector_builder/generated/models/http_response.py
@@ -1,12 +1,9 @@
 # coding: utf-8
-#
-# Copyright (c) 2023 Airbyte, Inc., all rights reserved.
-#
 
 from __future__ import annotations
+from datetime import date, datetime  # noqa: F401
 
 import re  # noqa: F401
-from datetime import date, datetime  # noqa: F401
 from typing import Any, Dict, List, Optional  # noqa: F401
 
 from pydantic import AnyUrl, BaseModel, EmailStr, validator  # noqa: F401
@@ -27,6 +24,5 @@ class HttpResponse(BaseModel):
     status: int
     body: Optional[str] = None
     headers: Optional[Dict[str, Any]] = None
-
 
 HttpResponse.update_forward_refs()

--- a/airbyte-connector-builder-server/connector_builder/impl/default_api.py
+++ b/airbyte-connector-builder-server/connector_builder/impl/default_api.py
@@ -156,7 +156,7 @@ spec:
             logs=log_messages,
             slices=slices,
             test_read_limit_reached=self._has_reached_limit(slices),
-            inferred_schema=schema_inferrer.get_stream_schema(stream_read_request_body.stream)
+            inferred_schema=schema_inferrer.get_stream_schema(stream_read_request_body.stream),
         )
 
     def _has_reached_limit(self, slices):
@@ -286,7 +286,7 @@ spec:
         raw_response = log_message.message.partition("response:")[2]
         try:
             response = json.loads(raw_response)
-            body = json.loads(response.get("body", "{}"))
+            body = response.get("body", "{}")
             return HttpResponse(status=response.get("status_code"), body=body, headers=response.get("headers"))
         except JSONDecodeError as error:
             self.logger.warning(f"Failed to parse log message into response object with error: {error}")

--- a/airbyte-connector-builder-server/src/main/openapi/openapi.yaml
+++ b/airbyte-connector-builder-server/src/main/openapi/openapi.yaml
@@ -213,7 +213,7 @@ components:
           type: integer
           description: The status of the response
         body:
-          type: object
+          type: string
           description: The body of the HTTP response, if present
         headers:
           type: object

--- a/airbyte-webapp/src/components/connectorBuilder/StreamTestingPanel/PageDisplay.tsx
+++ b/airbyte-webapp/src/components/connectorBuilder/StreamTestingPanel/PageDisplay.tsx
@@ -40,7 +40,16 @@ export const PageDisplay: React.FC<PageDisplayProps> = ({ page, className, infer
 
   const formattedRecords = useMemo(() => formatJson(page.records), [page.records]);
   const formattedRequest = useMemo(() => formatJson(page.request), [page.request]);
-  const formattedResponse = useMemo(() => formatJson(page.response), [page.response]);
+  const formattedResponse = useMemo(() => {
+    if (!page.response) {
+      return "";
+    }
+    const unpackedBodyResponse = {
+      ...page.response,
+      body: page.response.body ? JSON.parse(page.response.body) : undefined,
+    };
+    return formatJson(unpackedBodyResponse);
+  }, [page.response]);
   const formattedSchema = useMemo(() => inferredSchema && formatJson(inferredSchema, true), [inferredSchema]);
 
   let defaultTabIndex = 0;

--- a/airbyte-webapp/src/components/connectorBuilder/StreamTestingPanel/PageDisplay.tsx
+++ b/airbyte-webapp/src/components/connectorBuilder/StreamTestingPanel/PageDisplay.tsx
@@ -41,12 +41,21 @@ export const PageDisplay: React.FC<PageDisplayProps> = ({ page, className, infer
   const formattedRecords = useMemo(() => formatJson(page.records), [page.records]);
   const formattedRequest = useMemo(() => formatJson(page.request), [page.request]);
   const formattedResponse = useMemo(() => {
-    if (!page.response) {
+    if (!page.response || !page.response.body) {
       return "";
     }
+    let parsedBody: unknown;
+    try {
+      // body is a string containing JSON most of the time, but not always.
+      // Attempt to parse and fall back to the raw string if unsuccessfull.
+      parsedBody = JSON.parse(page.response.body);
+    } catch {
+      parsedBody = page.response.body;
+    }
+
     const unpackedBodyResponse = {
       ...page.response,
-      body: page.response.body ? JSON.parse(page.response.body) : undefined,
+      body: parsedBody,
     };
     return formatJson(unpackedBodyResponse);
   }, [page.response]);


### PR DESCRIPTION
Closes https://github.com/airbytehq/airbyte/issues/20764

## What
When we first implement request/response in the connector builder server, we operated under the assumption that responses would always be in an object format. However, in many cases, APIs return responses as a list or possibly even a string. In these cases we would fail the request with:
```
"Could not perform read with with error: [ErrorWrapper(exc=DictError(), loc=('body',))]"
```

## How
We've decided to let the frontend code handle the parsing of the response into it's relevant class due to limitations of the openapi spec not allowing for `anyOf`. This PR changes the openapi spec to reflect that responses will come in the form of a string. This also performs the small change to no longer parse the response body into json object and pass the escaped string w/o any modification.

The result should look like:
```
{
    "status": 200,
    "body": "[{\"id\":937971,\"name\":\"Pliancy - Staging\",\"color\":\"313d4b\",\"currency\":{\"id\":\"usd\",\"name\":\"United States Dollar\",\"iso_code\":\"USD\",\"symbol\":\"$\",\"symbol_first\":true},\"from\":\"Web\",\"max_users\":0,\"seats\":11,\"max_projects\":0,\"plan_id\":221,\"plan_name\":\"Unlimited\",\"next_charge\":\"2023-02-18\",\"industry\":\"\",\"memory_retention_days\":0,\"num_users\":10,\"num_projects\":55,\"active_projects_count\":55,\"total_projects_count\":95,\"status\":\"active\",\"beta\":false,\"azure_ad_enabled\":false,\"expired\":false,\"trial\":false,\"days_to_end_trial\":0}]",
    "headers": {
        "something": "here"
    }
}
```

## Recommended reading order
1. `openapi.yaml`
2. `default_api.py`
