### PR TITLE
Prevent invalid entries for array of numbers

### DIFF
--- a/airbyte-webapp/src/components/ui/TagInput/TagInput.module.scss
+++ b/airbyte-webapp/src/components/ui/TagInput/TagInput.module.scss
@@ -12,3 +12,15 @@
   borderRadius: variables.$border-radius-md;
   paddingLeft: variables.$spacing-sm;
 }
+
+.hideArrowButtons {
+  input::-webkit-outer-spin-button,
+  input::-webkit-inner-spin-button {
+    appearance: none;
+    margin: 0;
+  }
+
+  input[type="number"] {
+    appearance: textfield;
+  }
+}

--- a/airbyte-webapp/src/components/ui/TagInput/TagInput.tsx
+++ b/airbyte-webapp/src/components/ui/TagInput/TagInput.tsx
@@ -145,8 +145,9 @@ export const TagInput: React.FC<TagInputProps> = ({ onChange, fieldValue, name, 
    * This needs to be implemented outside of the onBlur prop of react-select because it's not default behavior.
    */
   const onBlurControl = () => {
-    if (inputValue) {
-      onChange([...fieldValue, inputValue]);
+    const normalizedInput = normalizeInput(inputValue);
+    if (normalizedInput) {
+      onChange([...fieldValue, normalizedInput]);
       setInputValue("");
     }
   };

--- a/airbyte-webapp/src/components/ui/TagInput/TagInput.tsx
+++ b/airbyte-webapp/src/components/ui/TagInput/TagInput.tsx
@@ -1,13 +1,18 @@
+import classNames from "classnames";
 import uniqueId from "lodash/uniqueId";
-import { KeyboardEventHandler, useMemo, useState } from "react";
-import { ActionMeta, GroupBase, MultiValue, OnChangeValue, StylesConfig } from "react-select";
+import { ComponentType, KeyboardEventHandler, useMemo, useState } from "react";
+import { ActionMeta, GroupBase, MultiValue, OnChangeValue, StylesConfig, components, InputProps } from "react-select";
 import CreatableSelect from "react-select/creatable";
 
 import styles from "./TagInput.module.scss";
 
-const components = {
+const overwrittenComponents = {
   DropdownIndicator: null,
 };
+
+const NumberInput: ComponentType<InputProps<Tag, true, GroupBase<Tag>>> = (
+  props: InputProps<Tag, true, GroupBase<Tag>>
+) => <components.Input {...props} type="number" className={classNames(props.className, styles.hideArrowButtons)} />;
 
 const customStyles: StylesConfig<Tag, true, GroupBase<Tag>> = {
   multiValue: (provided) => ({
@@ -99,24 +104,16 @@ export const TagInput: React.FC<TagInputProps> = ({ onChange, fieldValue, name, 
     onChange(updatedTags.map((tag) => generateStringFromTag(tag)));
   };
 
-  function normalizeInput(input: string) {
-    if (itemType !== "number" && itemType !== "integer") {
-      return input.trim();
-    }
-    const parsedNumber = itemType === "number" ? Number.parseFloat(input) : Number.parseInt(input);
-    if (isNaN(parsedNumber)) {
-      return "";
-    }
-    return String(parsedNumber);
-  }
-
   // handle when a user types OR pastes in the input
   const handleInputChange = (inputValue: string) => {
     setInputValue(inputValue);
 
     delimiters.forEach((delimiter) => {
       if (inputValue.includes(delimiter)) {
-        const newTagStrings = inputValue.split(delimiter).map(normalizeInput).filter(Boolean);
+        const newTagStrings = inputValue
+          .split(delimiter)
+          .map((tag) => tag.trim())
+          .filter(Boolean);
 
         inputValue.trim().length > 1 && onChange([...fieldValue, ...newTagStrings]);
         setInputValue("");
@@ -132,7 +129,7 @@ export const TagInput: React.FC<TagInputProps> = ({ onChange, fieldValue, name, 
     switch (event.key) {
       case "Enter":
       case "Tab":
-        const normalizedInput = normalizeInput(inputValue);
+        const normalizedInput = inputValue.trim();
         normalizedInput.length >= 1 && onChange([...fieldValue, normalizedInput]);
 
         event.preventDefault();
@@ -145,7 +142,7 @@ export const TagInput: React.FC<TagInputProps> = ({ onChange, fieldValue, name, 
    * This needs to be implemented outside of the onBlur prop of react-select because it's not default behavior.
    */
   const onBlurControl = () => {
-    const normalizedInput = normalizeInput(inputValue);
+    const normalizedInput = inputValue.trim();
     if (normalizedInput) {
       onChange([...fieldValue, normalizedInput]);
       setInputValue("");
@@ -157,7 +154,11 @@ export const TagInput: React.FC<TagInputProps> = ({ onChange, fieldValue, name, 
       <CreatableSelect
         inputId={id}
         name={name}
-        components={components}
+        components={
+          itemType === "number" || itemType === "integer"
+            ? { ...overwrittenComponents, Input: NumberInput }
+            : overwrittenComponents
+        }
         inputValue={inputValue}
         placeholder=""
         aria-invalid={Boolean(error)}

--- a/airbyte-webapp/src/core/form/schemaToFormBlock.ts
+++ b/airbyte-webapp/src/core/form/schemaToFormBlock.ts
@@ -119,6 +119,15 @@ export const jsonSchemaToFormBlock = (
     };
   }
 
+  const type = (Array.isArray(jsonSchema.type) ? jsonSchema.type[0] : jsonSchema.type) ?? "null";
+  const itemType =
+    type === "array" &&
+    jsonSchema.items &&
+    !Array.isArray(jsonSchema.items) &&
+    typeof jsonSchema.items === "object" &&
+    !Array.isArray(jsonSchema.items.type) &&
+    jsonSchema.items.type;
+
   return {
     ...pickDefaultFields(jsonSchema),
     _type: "formItem",
@@ -128,7 +137,8 @@ export const jsonSchemaToFormBlock = (
     isSecret: !!jsonSchema.airbyte_secret,
     multiline: !!jsonSchema.multiline,
     format: jsonSchema.format,
-    type: (Array.isArray(jsonSchema.type) ? jsonSchema.type[0] : jsonSchema.type) ?? "null",
+    type,
+    itemType: itemType || undefined,
   };
 };
 

--- a/airbyte-webapp/src/core/form/types.ts
+++ b/airbyte-webapp/src/core/form/types.ts
@@ -29,6 +29,10 @@ interface FormItem extends FormRelevantJSONSchema {
 export interface FormBaseItem extends FormItem {
   _type: "formItem";
   type: JSONSchema7TypeName;
+  /**
+   * In case type is array, itemType specifies the type of the items
+   * */
+  itemType?: JSONSchema7TypeName;
   isSecret?: boolean;
   multiline?: boolean;
 }

--- a/airbyte-webapp/src/views/Connector/ConnectorForm/components/Property/Control.tsx
+++ b/airbyte-webapp/src/views/Connector/ConnectorForm/components/Property/Control.tsx
@@ -45,6 +45,7 @@ export const Control: React.FC<ControlProps> = ({ property, name, disabled, erro
         {() => (
           <TagInput
             name={name}
+            itemType={property.itemType}
             fieldValue={field.value || []}
             onChange={(tagLabels) => helpers.setValue(tagLabels)}
             error={!!meta.error}


### PR DESCRIPTION
## What

Fixes https://github.com/airbytehq/airbyte/issues/22850

## How
https://github.com/airbytehq/airbyte/issues/22850 is caused by the fact that the `TagInput` control doesn't validate whether the typed input is confirming to the type specified in the schema. In case of number or integer entries in an array this leads to errors during casting the form values which is done in multiple places.

This PR fixes the problem using a `type="number"` input instead so it's not even possible to enter invalid numbers in the first place.

Note: This implementation does not allow to enter multiple values using the `,` or `;` key to enter multiple values (Enter or Tab have to be used), didn't find a good solution for this, correctness seemed more important to me than ease-of-use features and given that it's a rare case (this is the only place a numeric array is used in existing connectors AFAICT), I didn't want to go down this rabbit hole right now.