### PR TITLE
don't run airbyte ci on schedule

### DIFF
--- a/.github/workflows/gradle.yml
+++ b/.github/workflows/gradle.yml
@@ -16,8 +16,6 @@ on:
           - "true"
           - "false"
         required: false
-  schedule:
-    - cron: "0 */1 * * *"
   push:
     branches:
       - master


### PR DESCRIPTION
## What
Ever since we started looking only at modified files, this workflow has been wasting minutes running on cron and doing nothing
