### PR TITLE
🪟🐛 Connector builder: Replace instead of navigate

### DIFF
--- a/airbyte-webapp/src/pages/connectorBuilder/ConnectorBuilderLandingPage/ConnectorBuilderLandingPage.tsx
+++ b/airbyte-webapp/src/pages/connectorBuilder/ConnectorBuilderLandingPage/ConnectorBuilderLandingPage.tsx
@@ -54,7 +54,7 @@ const ConnectorBuilderLandingPageInner: React.FC = () => {
       !isEqual(initialStoredFormValues.current, DEFAULT_BUILDER_FORM_VALUES) ||
       !isEqual(initialStoredManifest.current, DEFAULT_JSON_MANIFEST_VALUES)
     ) {
-      navigate(ConnectorBuilderRoutePaths.Edit);
+      navigate(ConnectorBuilderRoutePaths.Edit, { replace: true });
     }
   }, [navigate]);
 


### PR DESCRIPTION
This PR fixes the issue that navigating back after going to the builder UI currently doesn't work.

The problem is that the user is redirected from the landing page to the edit page, but this navigation is writing a new history entry, so navigating "back" will lead the user to the landing page again, which will immediately redirect them again.

This PR sets the replace option which replaces the landing page history entry instead of writing a new one.

## How to test

* Enable the builder navigation links experiment (`.experiments.json`):
```
{
    "connectorBuilder.showNavigationLinks": true
}
```
* Click the "Builder" nav item
* Click back button
* You get back to where you came from