### PR TITLE
[DRAFT] Show recently used workspaces

### DIFF
--- a/airbyte-webapp/src/components/workspaces/FrequentlyUsedWorkspaces.module.scss
+++ b/airbyte-webapp/src/components/workspaces/FrequentlyUsedWorkspaces.module.scss
@@ -1,0 +1,14 @@
+@use "scss/colors";
+@use "scss/variables";
+
+.frequentlyUsedWorkspaces {
+  padding-bottom: variables.$spacing-2xl;
+  margin-bottom: variables.$spacing-2xl;
+  border-bottom: variables.$border-thick solid colors.$grey-100;
+
+  &__list {
+    margin: variables.$spacing-xl 0 0;
+    padding: 0;
+    list-style: none;
+  }
+}

--- a/airbyte-webapp/src/components/workspaces/FrequentlyUsedWorkspaces.module.scss
+++ b/airbyte-webapp/src/components/workspaces/FrequentlyUsedWorkspaces.module.scss
@@ -5,9 +5,14 @@
   padding-bottom: variables.$spacing-2xl;
   margin-bottom: variables.$spacing-2xl;
   border-bottom: variables.$border-thick solid colors.$grey-100;
+  text-align: left;
+
+  &__heading {
+    color: colors.$grey-300;
+    margin-bottom: variables.$spacing-lg;
+  }
 
   &__list {
-    margin: variables.$spacing-xl 0 0;
     padding: 0;
     list-style: none;
   }

--- a/airbyte-webapp/src/components/workspaces/FrequentlyUsedWorkspaces.tsx
+++ b/airbyte-webapp/src/components/workspaces/FrequentlyUsedWorkspaces.tsx
@@ -1,0 +1,90 @@
+import { useEffect, useState } from "react";
+import { useIntl } from "react-intl";
+
+import { Heading } from "components/ui/Heading";
+
+import { CloudWorkspace } from "packages/cloud/lib/domain/cloudWorkspaces/types";
+import WorkspaceItem from "packages/cloud/views/workspaces/WorkspacesPage/components/WorkspaceItem";
+import { useCurrentWorkspaceId, useWorkspaceService } from "services/workspaces/WorkspacesService";
+
+import styles from "./FrequentlyUsedWorkspaces.module.scss";
+
+interface FrequentlyUsedWorkspacesProps {
+  workspaces: CloudWorkspace[];
+}
+
+const LOCAL_STORAGE_KEY = "ab_frequently_used_workspaces";
+
+export const useTrackFrequentlyUsedWorkspaces = () => {
+  const [frequentlyUsedWorkspaces, setFrequentlyUsedWorkspaces] = useState<string[]>(() => {
+    const workspaces = localStorage.getItem(LOCAL_STORAGE_KEY);
+    return workspaces ? JSON.parse(workspaces) : [];
+  });
+  const workspaceId = useCurrentWorkspaceId();
+
+  useEffect(() => {
+    if (workspaceId) {
+      setFrequentlyUsedWorkspaces((previousWorkspaces) => {
+        const newWorkspaces = [workspaceId, ...previousWorkspaces.filter((id) => id !== workspaceId)].slice(0, 5);
+        localStorage.setItem(LOCAL_STORAGE_KEY, JSON.stringify(newWorkspaces));
+        return newWorkspaces;
+      });
+    }
+  }, [frequentlyUsedWorkspaces, workspaceId]);
+};
+
+export const FrequentlyUsedWorkspaces: React.FC<FrequentlyUsedWorkspacesProps> = ({ workspaces }) => {
+  const { selectWorkspace } = useWorkspaceService();
+  const { formatMessage } = useIntl();
+  let frequentlyUsedWorkspaceIds: string[];
+
+  try {
+    frequentlyUsedWorkspaceIds = JSON.parse(localStorage.getItem(LOCAL_STORAGE_KEY) || "[]");
+    if (!Array.isArray(frequentlyUsedWorkspaceIds)) {
+      throw new Error("Malformed localStorage item");
+    }
+  } catch {
+    localStorage.removeItem(LOCAL_STORAGE_KEY);
+    return null;
+  }
+
+  // We should only show frequently used workspaces if the user has more than 10 available
+  if (workspaces.length < 10 || frequentlyUsedWorkspaceIds.length === 0) {
+    return null;
+  }
+
+  const frequentlyUsedWorkspaces = workspaces.filter((workspace) =>
+    frequentlyUsedWorkspaceIds.includes(workspace.workspaceId)
+  );
+
+  // In case one of the frequently used workspaces is no longer available
+  if (frequentlyUsedWorkspaces.length === 0) {
+    return null;
+  }
+
+  const sortedWorkspaces = frequentlyUsedWorkspaceIds.reduce<CloudWorkspace[]>((workspaces, id) => {
+    const found = frequentlyUsedWorkspaces.find((workspace) => workspace.workspaceId === id);
+    if (!found) {
+      // Remove any IDs that cannot be resolved to a workspace
+      localStorage.setItem(LOCAL_STORAGE_KEY, JSON.stringify(frequentlyUsedWorkspaceIds.filter((_id) => _id !== id)));
+    } else {
+      workspaces.push(found);
+    }
+    return workspaces;
+  }, []);
+
+  return (
+    <div className={styles.frequentlyUsedWorkspaces}>
+      <Heading as="h2" size="sm">
+        {formatMessage({ id: "workspaces.frequentlyUsedWorkspacesTitle" })}
+      </Heading>
+      <div className={styles.frequentlyUsedWorkspaces__list}>
+        {sortedWorkspaces.map((workspace) => (
+          <WorkspaceItem key={workspace.workspaceId} id={workspace.workspaceId} onClick={selectWorkspace}>
+            {workspace.name}
+          </WorkspaceItem>
+        ))}
+      </div>
+    </div>
+  );
+};

--- a/airbyte-webapp/src/packages/cloud/cloudRoutes.tsx
+++ b/airbyte-webapp/src/packages/cloud/cloudRoutes.tsx
@@ -4,6 +4,7 @@ import { useEffectOnce } from "react-use";
 
 import { ApiErrorBoundary } from "components/common/ApiErrorBoundary";
 import LoadingPage from "components/LoadingPage";
+import { useTrackFrequentlyUsedWorkspaces } from "components/workspaces/FrequentlyUsedWorkspaces";
 
 import { useAnalyticsIdentifyUser, useAnalyticsRegisterValues } from "hooks/services/Analytics/useAnalyticsService";
 import { useApiHealthPoll } from "hooks/services/Health";
@@ -39,6 +40,7 @@ const DefaultView = React.lazy(() => import("./views/DefaultView"));
 
 const MainRoutes: React.FC = () => {
   const workspace = useCurrentWorkspace();
+  useTrackFrequentlyUsedWorkspaces();
 
   const analyticsContext = useMemo(
     () => ({

--- a/airbyte-webapp/src/packages/cloud/locales/en.json
+++ b/airbyte-webapp/src/packages/cloud/locales/en.json
@@ -200,5 +200,7 @@
   "freeConnectorProgram.enrollmentModal.enrollButtonText": "Enroll now!",
   "freeConnectorProgram.enrollmentModal.unvalidatedEmailButtonText": "Resend email validation",
   "freeConnectorProgram.releaseStageBadge.free": "Free",
-  "freeConnectorProgram.youCanEnroll": "You can <enrollLink>enroll</enrollLink> in the <b>Free Connector Program</b> to use Alpha and Beta connectors for <freeText>free</freeText>."
+  "freeConnectorProgram.youCanEnroll": "You can <enrollLink>enroll</enrollLink> in the <b>Free Connector Program</b> to use Alpha and Beta connectors for <freeText>free</freeText>.",
+
+  "workspaces.frequentlyUsedWorkspacesTitle": "Frequently used workspaces"
 }

--- a/airbyte-webapp/src/packages/cloud/locales/en.json
+++ b/airbyte-webapp/src/packages/cloud/locales/en.json
@@ -202,5 +202,6 @@
   "freeConnectorProgram.releaseStageBadge.free": "Free",
   "freeConnectorProgram.youCanEnroll": "You can <enrollLink>enroll</enrollLink> in the <b>Free Connector Program</b> to use Alpha and Beta connectors for <freeText>free</freeText>.",
 
+  "workspaces.allWorkspacesListHeader": "All workspaces",
   "workspaces.frequentlyUsedWorkspacesTitle": "Frequently used workspaces"
 }

--- a/airbyte-webapp/src/packages/cloud/views/workspaces/WorkspacesPage/components/WorkspaceItem.module.scss
+++ b/airbyte-webapp/src/packages/cloud/views/workspaces/WorkspacesPage/components/WorkspaceItem.module.scss
@@ -15,6 +15,10 @@
   background: colors.$white;
   border-radius: variables.$border-radius-lg;
   border: none;
+
+  &:last-child {
+    margin-bottom: 0;
+  }
 }
 
 .iconColor {

--- a/airbyte-webapp/src/packages/cloud/views/workspaces/WorkspacesPage/components/WorkspacesList.module.scss
+++ b/airbyte-webapp/src/packages/cloud/views/workspaces/WorkspacesPage/components/WorkspacesList.module.scss
@@ -1,0 +1,15 @@
+@use "scss/colors";
+@use "scss/variables";
+
+.workspacesList {
+  width: 100%;
+  max-width: 550px;
+  margin: 0 auto;
+  padding-bottom: 26px;
+
+  &__heading {
+    text-align: left;
+    margin-bottom: variables.$spacing-lg;
+    color: colors.$grey-300;
+  }
+}

--- a/airbyte-webapp/src/packages/cloud/views/workspaces/WorkspacesPage/components/WorkspacesList.tsx
+++ b/airbyte-webapp/src/packages/cloud/views/workspaces/WorkspacesPage/components/WorkspacesList.tsx
@@ -1,7 +1,11 @@
 import React from "react";
-import styled from "styled-components";
+import { useIntl } from "react-intl";
 
-import { FrequentlyUsedWorkspaces } from "components/workspaces/FrequentlyUsedWorkspaces";
+import { Heading } from "components/ui/Heading";
+import {
+  FrequentlyUsedWorkspaces,
+  getFrequentlyUsedWorkspacesFromLocalStorage,
+} from "components/workspaces/FrequentlyUsedWorkspaces";
 
 import {
   useCreateCloudWorkspace,
@@ -11,29 +15,31 @@ import { useWorkspaceService } from "services/workspaces/WorkspacesService";
 
 import WorkspaceItem from "./WorkspaceItem";
 import WorkspacesControl from "./WorkspacesControl";
-
-const Content = styled.div`
-  width: 100%;
-  max-width: 550px;
-  margin: 0 auto;
-  padding-bottom: 26px;
-`;
+import styles from "./WorkspacesList.module.scss";
 
 const WorkspacesList: React.FC = () => {
   const workspaces = useListCloudWorkspaces();
   const { selectWorkspace } = useWorkspaceService();
   const { mutateAsync: createCloudWorkspace } = useCreateCloudWorkspace();
+  const { formatMessage } = useIntl();
+  const showFrequentlyUsedWorkspaces =
+    workspaces.length >= 10 && getFrequentlyUsedWorkspacesFromLocalStorage().length > 0;
 
   return (
-    <Content>
-      {workspaces.length >= 10 && <FrequentlyUsedWorkspaces workspaces={workspaces} />}
+    <div className={styles.workspacesList}>
+      {showFrequentlyUsedWorkspaces && <FrequentlyUsedWorkspaces workspaces={workspaces} />}
+      {showFrequentlyUsedWorkspaces && (
+        <Heading as="h2" size="sm" className={styles.workspacesList__heading}>
+          {formatMessage({ id: "workspaces.allWorkspacesListHeader" })}
+        </Heading>
+      )}
       {workspaces.map((workspace) => (
         <WorkspaceItem key={workspace.workspaceId} id={workspace.workspaceId} onClick={selectWorkspace}>
           {workspace.name}
         </WorkspaceItem>
       ))}
       <WorkspacesControl onSubmit={createCloudWorkspace} />
-    </Content>
+    </div>
   );
 };
 

--- a/airbyte-webapp/src/packages/cloud/views/workspaces/WorkspacesPage/components/WorkspacesList.tsx
+++ b/airbyte-webapp/src/packages/cloud/views/workspaces/WorkspacesPage/components/WorkspacesList.tsx
@@ -1,6 +1,8 @@
 import React from "react";
 import styled from "styled-components";
 
+import { FrequentlyUsedWorkspaces } from "components/workspaces/FrequentlyUsedWorkspaces";
+
 import {
   useCreateCloudWorkspace,
   useListCloudWorkspaces,
@@ -24,6 +26,7 @@ const WorkspacesList: React.FC = () => {
 
   return (
     <Content>
+      {workspaces.length >= 10 && <FrequentlyUsedWorkspaces workspaces={workspaces} />}
       {workspaces.map((workspace) => (
         <WorkspaceItem key={workspace.workspaceId} id={workspace.workspaceId} onClick={selectWorkspace}>
           {workspace.name}


### PR DESCRIPTION
## What
*Describe what the change is solving*
*It helps to add screenshots if it affects the frontend.*

![image](https://user-images.githubusercontent.com/7550957/219714776-f79a781b-93fd-4971-8cc9-388052d7efc9.png)


## How
*Describe the solution*

## Recommended reading order
1. `x.java`
2. `y.python`

## 🚨 User Impact 🚨
Are there any breaking changes? What is the end result perceived by the user? If yes, please merge this PR with the 🚨🚨 emoji so changelog authors can further highlight this if needed.

## Pre-merge Checklist
Expand the relevant checklist and delete the others.

<details><summary><strong>New Connector</strong></summary>

### Community member or Airbyter

- [ ] **Community member?** Grant edit access to maintainers ([instructions](https://docs.github.com/en/github/collaborating-with-pull-requests/working-with-forks/allowing-changes-to-a-pull-request-branch-created-from-a-fork#enabling-repository-maintainer-permissions-on-existing-pull-requests))
- [ ] Secrets in the connector's spec are annotated with `airbyte_secret`
- [ ] Unit & integration tests added and passing. Community members, please provide proof of success locally e.g: screenshot or copy-paste unit, integration, and acceptance test output. To run acceptance tests for a Python connector, follow instructions in the README. For java connectors run `./gradlew :airbyte-integrations:connectors:<name>:integrationTest`.
- [ ] Code reviews completed
- [ ] Documentation updated
    - [ ] Connector's `README.md`
    - [ ] Connector's `bootstrap.md`. See [description and examples](https://docs.google.com/document/d/1ypdgmwmEHWv-TrO4_YOQ7pAJGVrMp5BOkEVh831N260/edit?usp=sharing)
    - [ ] `docs/integrations/<source or destination>/<name>.md` including changelog. See changelog [example](https://docs.airbyte.io/integrations/sources/stripe#changelog)
    - [ ] `docs/integrations/README.md`
    - [ ] `airbyte-integrations/builds.md`
- [ ] PR name follows [PR naming conventions](https://docs.airbyte.com/contributing-to-airbyte/issues-and-pull-requests)

### Airbyter

If this is a community PR, the Airbyte engineer reviewing this PR is responsible for the below items.

- [ ] Create a non-forked branch based on this PR and test the below items on it
- [ ] Build is successful
- [ ] If new credentials are required for use in CI, add them to GSM. [Instructions](https://docs.airbyte.io/connector-development#using-credentials-in-ci).
- [ ] [`/test connector=connectors/<name>` command](https://docs.airbyte.io/connector-development#updating-an-existing-connector) is passing
- [ ] New Connector version released on Dockerhub by running the `/publish` command described [here](https://docs.airbyte.io/connector-development#updating-an-existing-connector)
- [ ] After the connector is published, connector added to connector index as described [here](https://docs.airbyte.io/connector-development#publishing-a-connector)
- [ ] Seed specs have been re-generated by building the platform and committing the changes to the seed spec files, as described [here](https://docs.airbyte.io/connector-development#publishing-a-connector)

</details>

<details><summary><strong>Updating a connector</strong></summary>

### Community member or Airbyter

- [ ] Grant edit access to maintainers ([instructions](https://docs.github.com/en/github/collaborating-with-pull-requests/working-with-forks/allowing-changes-to-a-pull-request-branch-created-from-a-fork#enabling-repository-maintainer-permissions-on-existing-pull-requests))
- [ ] Secrets in the connector's spec are annotated with `airbyte_secret`
- [ ] Unit & integration tests added and passing. Community members, please provide proof of success locally e.g: screenshot or copy-paste unit, integration, and acceptance test output. To run acceptance tests for a Python connector, follow instructions in the README. For java connectors run `./gradlew :airbyte-integrations:connectors:<name>:integrationTest`.
- [ ] Code reviews completed
- [ ] Documentation updated
    - [ ] Connector's `README.md`
    - [ ] Connector's `bootstrap.md`. See [description and examples](https://docs.google.com/document/d/1ypdgmwmEHWv-TrO4_YOQ7pAJGVrMp5BOkEVh831N260/edit?usp=sharing)
    - [ ] Changelog updated in `docs/integrations/<source or destination>/<name>.md` including changelog. See changelog [example](https://docs.airbyte.io/integrations/sources/stripe#changelog)
- [ ] PR name follows [PR naming conventions](https://docs.airbyte.com/contributing-to-airbyte/issues-and-pull-requests)

### Airbyter

If this is a community PR, the Airbyte engineer reviewing this PR is responsible for the below items.

- [ ] Create a non-forked branch based on this PR and test the below items on it
- [ ] Build is successful
- [ ] If new credentials are required for use in CI, add them to GSM. [Instructions](https://docs.airbyte.io/connector-development#using-credentials-in-ci).
- [ ] [`/test connector=connectors/<name>` command](https://docs.airbyte.io/connector-development#updating-an-existing-connector) is passing
- [ ] New Connector version released on Dockerhub and connector version bumped by running the `/publish` command described [here](https://docs.airbyte.io/connector-development#updating-an-existing-connector)

</details>

<details><summary><strong>Connector Generator</strong></summary>

- [ ] Issue acceptance criteria met
- [ ] PR name follows [PR naming conventions](https://docs.airbyte.com/contributing-to-airbyte/issues-and-pull-requests)
- [ ] If adding a new generator, add it to the [list of scaffold modules being tested](https://github.com/airbytehq/airbyte/blob/master/airbyte-integrations/connector-templates/generator/build.gradle#L41)
- [ ] The generator test modules (all connectors with `-scaffold` in their name) have been updated with the latest scaffold by running `./gradlew :airbyte-integrations:connector-templates:generator:testScaffoldTemplates` then checking in your changes
- [ ] Documentation which references the generator is updated as needed

</details>
