### PR TITLE
Remove kube-acceptance-test requirement from gradle.yml 

### DIFF
--- a/.github/workflows/gradle.yml
+++ b/.github/workflows/gradle.yml
@@ -1069,7 +1069,6 @@ jobs:
       - frontend-build
       - octavia-cli-build
       - platform-build
-      - kube-acceptance-test
       # Todo: Kyryl turn this on.
       # - helm-acceptance-test
     if: ${{ failure() && github.ref == 'refs/heads/master' }}
@@ -1104,7 +1103,6 @@ jobs:
       - frontend-build
       - octavia-cli-build
       - platform-build
-      - kube-acceptance-test
       # Todo: Kyryl turn this on.
       # - helm-acceptance-test
     if: success()

--- a/.github/workflows/gradle.yml
+++ b/.github/workflows/gradle.yml
@@ -64,7 +64,7 @@ jobs:
               - 'airbyte-integrations/connectors/(destination-jdbc|destination-postgres|source-jdbc|source-postgres)/**'
               - 'airbyte-config/init/src/main/resources/seed/(source|destination)_definitions.yaml'
               - 'docker-compose*.yaml'
-              - '(charts|kube)/**'
+              - 'charts/**'
             build:
               - '.github/**'
               - 'buildSrc/**'
@@ -831,7 +831,7 @@ jobs:
           label: ${{ needs.start-platform-build-runner.outputs.label }}
           ec2-instance-id: ${{ needs.start-platform-build-runner.outputs.ec2-instance-id }}
 
-  # ## Kube Acceptance Tests
+  # ## Helm Acceptance Tests
   # # Docker acceptance tests run as part of the build job.
   # # In case of self-hosted EC2 errors, remove this block.
   start-helm-acceptance-test-runner:


### PR DESCRIPTION
## What
CI run is failing here: https://github.com/airbytehq/airbyte/actions/runs/4208178699

Looks like there's a couple errant requirements for kube-acceptance-test in the slack notifs config after sunsetting kustomize in https://github.com/airbytehq/airbyte/pull/23187, this PR should get it unblocked

## How
Removed kube-acceptance-test requirement from `notify-failure-slack-channel` and `notify-failure-slack-channel-fixed-broken-build`

Cleaned up a `kube` folder mention (non-breaking) and fixed a comment 