### PR TITLE
Extend state aggregator

### DIFF
--- a/airbyte-commons-worker/src/main/java/io/airbyte/workers/internal/state_aggregator/SingleStateAggregator.java
+++ b/airbyte-commons-worker/src/main/java/io/airbyte/workers/internal/state_aggregator/SingleStateAggregator.java
@@ -23,6 +23,16 @@ class SingleStateAggregator implements StateAggregator {
     state = stateMessage;
   }
 
+  @Override
+  public void ingest(final StateAggregator stateAggregator) {
+    if (stateAggregator instanceof SingleStateAggregator) {
+      ingest(((SingleStateAggregator) stateAggregator).state);
+    } else {
+      throw new IllegalArgumentException(
+          "Got an incompatible StateAggregator: " + stateAggregator.getClass().getName() + ", expected SingleStateAggregator");
+    }
+  }
+
   @Trace(operationName = WORKER_OPERATION_NAME)
   @Override
   public State getAggregated() {
@@ -39,6 +49,11 @@ class SingleStateAggregator implements StateAggregator {
       return new State()
           .withState(Jsons.jsonNode(List.of(state)));
     }
+  }
+
+  @Override
+  public boolean isEmpty() {
+    return state == null;
   }
 
 }

--- a/airbyte-commons-worker/src/main/java/io/airbyte/workers/internal/state_aggregator/StateAggregator.java
+++ b/airbyte-commons-worker/src/main/java/io/airbyte/workers/internal/state_aggregator/StateAggregator.java
@@ -11,6 +11,10 @@ public interface StateAggregator {
 
   void ingest(AirbyteStateMessage stateMessage);
 
+  void ingest(StateAggregator stateAggregator);
+
   State getAggregated();
+
+  boolean isEmpty();
 
 }

--- a/airbyte-commons-worker/src/main/java/io/airbyte/workers/internal/state_aggregator/StreamStateAggregator.java
+++ b/airbyte-commons-worker/src/main/java/io/airbyte/workers/internal/state_aggregator/StreamStateAggregator.java
@@ -31,6 +31,18 @@ class StreamStateAggregator implements StateAggregator {
     aggregatedState.put(stateMessage.getStream().getStreamDescriptor(), stateMessage);
   }
 
+  @Override
+  public void ingest(final StateAggregator stateAggregator) {
+    if (stateAggregator instanceof StreamStateAggregator) {
+      for (final var message : ((StreamStateAggregator) stateAggregator).aggregatedState.values()) {
+        ingest(message);
+      }
+    } else {
+      throw new IllegalArgumentException(
+          "Got an incompatible StateAggregator: " + stateAggregator.getClass().getName() + ", expected StreamStateAggregator");
+    }
+  }
+
   @Trace(operationName = WORKER_OPERATION_NAME)
   @Override
   public State getAggregated() {
@@ -38,6 +50,11 @@ class StreamStateAggregator implements StateAggregator {
     return new State()
         .withState(
             Jsons.jsonNode(aggregatedState.values()));
+  }
+
+  @Override
+  public boolean isEmpty() {
+    return aggregatedState.isEmpty();
   }
 
 }

--- a/airbyte-commons-worker/src/test/java/io/airbyte/workers/internal/state_aggregator/StateAggregatorTest.java
+++ b/airbyte-commons-worker/src/test/java/io/airbyte/workers/internal/state_aggregator/StateAggregatorTest.java
@@ -196,12 +196,7 @@ class StateAggregatorTest {
     otherStateAggregator.ingest(stateA2);
 
     Assertions.assertThatThrownBy(() -> {
-      try {
-        stateAggregator.ingest(otherStateAggregator);
-      } catch (Exception e) {
-        System.out.println(e);
-        throw e;
-      }
+      stateAggregator.ingest(otherStateAggregator);
     });
 
     Assertions.assertThatThrownBy(() -> {


### PR DESCRIPTION
## What

Extend StateAggegrator interface:
* Add `isEmpty()` which should tell whether the aggregator contains states
* Add `ingest(StateAggregator other)` to inges all state messages from the other aggregator into the current one.

Relates to #23046 

## How

Due to the recursive nature of how we implemented the interface, extra checks have been added into the `SingleStateAggregator` and `StreamStateAggregator` to fail explicitly in case of unexpected behavior.
The only valid use cases should be when merging data from aggregators of the same nature.
