### PR TITLE
Add sync persistence for states

### DIFF
--- a/airbyte-commons-worker/src/main/java/io/airbyte/workers/internal/state_aggregator/StateAggregatorFactory.java
+++ b/airbyte-commons-worker/src/main/java/io/airbyte/workers/internal/state_aggregator/StateAggregatorFactory.java
@@ -1,3 +1,7 @@
+/*
+ * Copyright (c) 2023 Airbyte, Inc., all rights reserved.
+ */
+
 package io.airbyte.workers.internal.state_aggregator;
 
 import io.airbyte.commons.features.FeatureFlags;
@@ -13,4 +17,5 @@ public class StateAggregatorFactory {
   public StateAggregator create() {
     return new DefaultStateAggregator(featureFlags.useStreamCapableState());
   }
+
 }

--- a/airbyte-commons-worker/src/main/java/io/airbyte/workers/internal/state_aggregator/StateAggregatorFactory.java
+++ b/airbyte-commons-worker/src/main/java/io/airbyte/workers/internal/state_aggregator/StateAggregatorFactory.java
@@ -1,0 +1,16 @@
+package io.airbyte.workers.internal.state_aggregator;
+
+import io.airbyte.commons.features.FeatureFlags;
+
+public class StateAggregatorFactory {
+
+  final FeatureFlags featureFlags;
+
+  public StateAggregatorFactory(final FeatureFlags featureFlags) {
+    this.featureFlags = featureFlags;
+  }
+
+  public StateAggregator create() {
+    return new DefaultStateAggregator(featureFlags.useStreamCapableState());
+  }
+}

--- a/airbyte-commons-worker/src/main/java/io/airbyte/workers/internal/sync_persistence/SyncPersistence.java
+++ b/airbyte-commons-worker/src/main/java/io/airbyte/workers/internal/sync_persistence/SyncPersistence.java
@@ -1,0 +1,13 @@
+/*
+ * Copyright (c) 2023 Airbyte, Inc., all rights reserved.
+ */
+
+package io.airbyte.workers.internal.sync_persistence;
+
+import io.airbyte.protocol.models.AirbyteStateMessage;
+
+public interface SyncPersistence extends AutoCloseable {
+
+  void persist(final AirbyteStateMessage stateMessage);
+
+}

--- a/airbyte-commons-worker/src/main/java/io/airbyte/workers/internal/sync_persistence/SyncPersistenceImpl.java
+++ b/airbyte-commons-worker/src/main/java/io/airbyte/workers/internal/sync_persistence/SyncPersistenceImpl.java
@@ -1,0 +1,175 @@
+/*
+ * Copyright (c) 2023 Airbyte, Inc., all rights reserved.
+ */
+
+package io.airbyte.workers.internal.sync_persistence;
+
+import io.airbyte.api.client.AirbyteApiClient;
+import io.airbyte.api.client.generated.StateApi;
+import io.airbyte.api.client.invoker.generated.ApiException;
+import io.airbyte.api.client.model.generated.ConnectionStateCreateOrUpdate;
+import io.airbyte.commons.converters.StateConverter;
+import io.airbyte.config.State;
+import io.airbyte.config.StateWrapper;
+import io.airbyte.config.helpers.StateMessageHelper;
+import io.airbyte.protocol.models.AirbyteStateMessage;
+import io.airbyte.workers.internal.state_aggregator.StateAggregator;
+import io.airbyte.workers.internal.state_aggregator.StateAggregatorFactory;
+import java.util.Optional;
+import java.util.UUID;
+import java.util.concurrent.ScheduledExecutorService;
+import java.util.concurrent.ScheduledFuture;
+import java.util.concurrent.TimeUnit;
+import lombok.extern.slf4j.Slf4j;
+
+@Slf4j
+public class SyncPersistenceImpl implements SyncPersistence {
+
+  final long RUN_IMMEDIATELY = 0;
+
+  private final UUID connectionId;
+  private final StateApi stateApi;
+  private final StateAggregatorFactory stateAggregatorFactory;
+
+  private StateAggregator stateBuffer;
+  private StateAggregator stateToFlush;
+  private final ScheduledExecutorService stateFlushExecutorService;
+  private ScheduledFuture<?> stateFlushFuture;
+  private final long stateFlushPeriodInSeconds;
+
+  public SyncPersistenceImpl(final UUID connectionId,
+                             final StateApi stateApi,
+                             final StateAggregatorFactory stateAggregatorFactory,
+                             final ScheduledExecutorService scheduledExecutorService,
+                             long stateFlushPeriodInSeconds) {
+    this.connectionId = connectionId;
+    this.stateApi = stateApi;
+    this.stateAggregatorFactory = stateAggregatorFactory;
+    this.stateFlushExecutorService = scheduledExecutorService;
+    this.stateBuffer = this.stateAggregatorFactory.create();
+    this.stateFlushPeriodInSeconds = stateFlushPeriodInSeconds;
+  }
+
+  @Override
+  public void persist(AirbyteStateMessage stateMessage) {
+    stateBuffer.ingest(stateMessage);
+    startBackgroundFlushStateTask();
+  }
+
+  private void startBackgroundFlushStateTask() {
+    if (stateFlushFuture != null) {
+      return;
+    }
+
+    // Making sure we only start one of background flush task
+    synchronized (this) {
+      if (stateFlushFuture == null) {
+        stateFlushFuture =
+            stateFlushExecutorService.scheduleAtFixedRate(this::flushState, RUN_IMMEDIATELY, stateFlushPeriodInSeconds, TimeUnit.SECONDS);
+      }
+    }
+  }
+
+  /**
+   * Stop background data flush thread and attempt to flush pending data
+   *
+   * If there is already flush in progress, wait for it to terminate. If it didn't terminate during
+   * the allocated time, we exit rather than attempting a concurrent write that could lead to
+   * non-deterministic behavior.
+   *
+   * For the final flush, we will retry in case of failures since there is no more "scheduled" attempt
+   * after this.
+   */
+  @Override
+  public void close() {
+    // stop the buffered refresh
+    stateFlushExecutorService.shutdown();
+
+    // Wait for previous running task to terminate
+    try {
+      final boolean terminated = stateFlushExecutorService.awaitTermination(60, TimeUnit.SECONDS);
+      if (!terminated) {
+        // Ongoing flush failed to terminate within the allocated time
+        log.info("Pending persist operation took too long to complete, most recent states may have been lost");
+
+        // This is the hard case, if the backend persisted the data, we may write duplicate
+        // We exit to avoid non-deterministic write attempts
+        return;
+      }
+    } catch (final InterruptedException e) {
+      // The current thread is getting interrupted
+      // TODO Metrics
+      log.info("SyncPersistence has been interrupted while terminating, most recent states may have been lost", e);
+
+      // This is also a hard case, if the backend persisted the data, we may write duplicate
+      // We exit to avoid non-deterministic write attempts
+      return;
+    }
+
+    if (hasDataToFlush()) {
+      // we still have data to flush
+      prepareDataForFlush();
+      AirbyteApiClient.retryWithJitter(() -> {
+        doFlushState();
+        return null;
+      }, "Flush States from SyncPersistenceImpl");
+    }
+  }
+
+  private boolean hasDataToFlush() {
+    return !stateBuffer.isEmpty() || stateToFlush != null;
+  }
+
+  /**
+   * FlushState method for the ScheduledExecutorService
+   *
+   * This method is swallowing exceptions on purpose. We do not want to fail or retry in a regular
+   * run, the retry is deferred to the next run which will merge the data from the previous failed
+   * attempt and the recent buffered data.
+   */
+  private void flushState() {
+    prepareDataForFlush();
+
+    try {
+      doFlushState();
+    } catch (final Exception e) {
+      log.warn("Failed to persist state for connectionId {}", connectionId, e);
+    }
+  }
+
+  private void prepareDataForFlush() {
+    final StateAggregator stateBufferToFlush = stateBuffer;
+    stateBuffer = stateAggregatorFactory.create();
+
+    if (stateToFlush == null) {
+      // Happy path, previous flush was successful
+      stateToFlush = stateBufferToFlush;
+    } else {
+      // Merging states from the previous attempt with the incoming buffer to flush
+      stateToFlush.ingest(stateBufferToFlush);
+    }
+  }
+
+  private void doFlushState() throws ApiException {
+    if (stateToFlush.isEmpty()) {
+      return;
+    }
+
+    final State state = stateToFlush.getAggregated();
+    final Optional<StateWrapper> maybeStateWrapper = StateMessageHelper.getTypedState(state.getState(), true);
+
+    if (maybeStateWrapper.isEmpty()) {
+      return;
+    }
+
+    final ConnectionStateCreateOrUpdate stateApiRequest = new ConnectionStateCreateOrUpdate()
+        .connectionId(connectionId)
+        .connectionState(StateConverter.toClient(connectionId, maybeStateWrapper.get()));
+
+    stateApi.createOrUpdateState(stateApiRequest);
+
+    // Only reset stateToFlush if the API call was successful
+    stateToFlush = null;
+  }
+
+}

--- a/airbyte-commons-worker/src/main/java/io/airbyte/workers/internal/sync_persistence/SyncPersistenceImpl.java
+++ b/airbyte-commons-worker/src/main/java/io/airbyte/workers/internal/sync_persistence/SyncPersistenceImpl.java
@@ -26,6 +26,7 @@ import lombok.extern.slf4j.Slf4j;
 public class SyncPersistenceImpl implements SyncPersistence {
 
   final long RUN_IMMEDIATELY = 0;
+  final long FLUSH_TERMINATION_TIMEOUT_IN_SECONDS = 60;
 
   private final UUID connectionId;
   private final StateApi stateApi;
@@ -87,7 +88,7 @@ public class SyncPersistenceImpl implements SyncPersistence {
 
     // Wait for previous running task to terminate
     try {
-      final boolean terminated = stateFlushExecutorService.awaitTermination(60, TimeUnit.SECONDS);
+      final boolean terminated = stateFlushExecutorService.awaitTermination(FLUSH_TERMINATION_TIMEOUT_IN_SECONDS, TimeUnit.SECONDS);
       if (!terminated) {
         // Ongoing flush failed to terminate within the allocated time
         log.info("Pending persist operation took too long to complete, most recent states may have been lost");

--- a/airbyte-commons-worker/src/test/java/io/airbyte/workers/internal/sync_persistence/SyncPersistenceImplTest.java
+++ b/airbyte-commons-worker/src/test/java/io/airbyte/workers/internal/sync_persistence/SyncPersistenceImplTest.java
@@ -1,0 +1,285 @@
+/*
+ * Copyright (c) 2023 Airbyte, Inc., all rights reserved.
+ */
+
+package io.airbyte.workers.internal.sync_persistence;
+
+import static io.airbyte.protocol.models.AirbyteStateMessage.AirbyteStateType.STREAM;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyLong;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.clearInvocations;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.reset;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import io.airbyte.api.client.generated.StateApi;
+import io.airbyte.api.client.invoker.generated.ApiException;
+import io.airbyte.api.client.model.generated.ConnectionState;
+import io.airbyte.api.client.model.generated.ConnectionStateCreateOrUpdate;
+import io.airbyte.api.client.model.generated.ConnectionStateType;
+import io.airbyte.api.client.model.generated.StreamState;
+import io.airbyte.commons.features.FeatureFlags;
+import io.airbyte.commons.json.Jsons;
+import io.airbyte.protocol.models.AirbyteStateMessage;
+import io.airbyte.protocol.models.AirbyteStreamState;
+import io.airbyte.protocol.models.StreamDescriptor;
+import io.airbyte.workers.internal.state_aggregator.StateAggregatorFactory;
+import java.util.List;
+import java.util.UUID;
+import java.util.concurrent.ScheduledExecutorService;
+import java.util.concurrent.ScheduledFuture;
+import java.util.concurrent.TimeUnit;
+import org.assertj.core.api.CollectionAssert;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.mockito.ArgumentCaptor;
+
+class SyncPersistenceImplTest {
+
+  private final long FLUSH_PERIOD = 60;
+
+  private SyncPersistenceImpl syncPersistence;
+  private StateApi stateApi;
+  private ScheduledExecutorService executorService;
+  private ArgumentCaptor<Runnable> actualFlushMethod;
+
+  private UUID connectionId;
+
+  @BeforeEach
+  void beforeEach() {
+    connectionId = UUID.randomUUID();
+
+    // Setting up an ArgumentCaptor to be able to manually trigger the actual flush method rather than
+    // relying on the ScheduledExecutorService and having to deal with Thread.sleep in the tests.
+    actualFlushMethod = ArgumentCaptor.forClass(Runnable.class);
+
+    // Wire the executor service with arg captures
+    executorService = mock(ScheduledExecutorService.class);
+    when(executorService.scheduleAtFixedRate(actualFlushMethod.capture(), eq(0L), eq(FLUSH_PERIOD), eq(TimeUnit.SECONDS)))
+        .thenReturn(mock(ScheduledFuture.class));
+
+    // Setting syncPersistence
+    stateApi = mock(StateApi.class);
+    final FeatureFlags featureFlags = mock(FeatureFlags.class);
+    when(featureFlags.useStreamCapableState()).thenReturn(true);
+    syncPersistence = new SyncPersistenceImpl(connectionId, stateApi, new StateAggregatorFactory(featureFlags), executorService, FLUSH_PERIOD);
+  }
+
+  @AfterEach
+  void afterEach() {
+    syncPersistence.close();
+  }
+
+  @Test
+  void testPersistHappyPath() throws ApiException {
+    final AirbyteStateMessage stateA1 = getStreamState("A", 1);
+    syncPersistence.persist(stateA1);
+    verify(executorService).scheduleAtFixedRate(any(Runnable.class), eq(0L), eq(FLUSH_PERIOD), eq(TimeUnit.SECONDS));
+    clearInvocations(executorService);
+
+    // Simulating the expected flush execution
+    actualFlushMethod.getValue().run();
+    verifyStateUpdateApiCall(List.of(stateA1));
+    clearInvocations(stateApi);
+
+    final AirbyteStateMessage stateB1 = getStreamState("B", 1);
+    final AirbyteStateMessage stateC2 = getStreamState("C", 2);
+    syncPersistence.persist(stateB1);
+    syncPersistence.persist(stateC2);
+
+    // Forcing a second flush
+    actualFlushMethod.getValue().run();
+    verifyStateUpdateApiCall(List.of(stateB1, stateC2));
+    clearInvocations(stateApi);
+
+    // Forcing another flush without data to flush
+    actualFlushMethod.getValue().run();
+    verify(stateApi, never()).createOrUpdateState(any());
+    clearInvocations(stateApi);
+
+    // scheduleAtFixedRate should not have received any other calls
+    verify(executorService, never()).scheduleAtFixedRate(any(), anyLong(), anyLong(), any());
+  }
+
+  @Test
+  void testPersistWithApiFailures() throws ApiException {
+    final AirbyteStateMessage stateF1 = getStreamState("F", 1);
+    syncPersistence.persist(stateF1);
+
+    // Set API call to fail
+    when(stateApi.createOrUpdateState(any())).thenThrow(new ApiException());
+
+    // Flushing
+    actualFlushMethod.getValue().run();
+    verifyStateUpdateApiCall(List.of(stateF1));
+    clearInvocations(stateApi);
+
+    // Adding more states
+    final AirbyteStateMessage stateG1 = getStreamState("G", 1);
+    syncPersistence.persist(stateG1);
+
+    // Flushing again
+    actualFlushMethod.getValue().run();
+    verifyStateUpdateApiCall(List.of(stateF1, stateG1));
+    clearInvocations(stateApi);
+
+    // Adding more states
+    final AirbyteStateMessage stateF2 = getStreamState("F", 2);
+    syncPersistence.persist(stateF2);
+
+    // Flushing again
+    actualFlushMethod.getValue().run();
+    verifyStateUpdateApiCall(List.of(stateF2, stateG1));
+    clearInvocations(stateApi);
+
+    // Clear the error state from the API
+    reset(stateApi);
+
+    // Flushing again
+    actualFlushMethod.getValue().run();
+    verifyStateUpdateApiCall(List.of(stateF2, stateG1));
+    clearInvocations(stateApi);
+
+    // Sanity check Flushing again should not trigger an API call since all the data has been
+    // successfully flushed
+    actualFlushMethod.getValue().run();
+    verify(stateApi, never()).createOrUpdateState(any());
+  }
+
+  @Test
+  void testClose() throws InterruptedException, ApiException {
+    // Adding a state to flush, this state should get flushed when we close syncPersistence
+    final AirbyteStateMessage stateA2 = getStreamState("A", 2);
+    syncPersistence.persist(stateA2);
+
+    // Shutdown, we expect the executor service to be stopped and an stateApi to be called
+    when(executorService.awaitTermination(anyLong(), any())).thenReturn(true);
+    syncPersistence.close();
+    verify(executorService).shutdown();
+    verifyStateUpdateApiCall(List.of(stateA2));
+  }
+
+  @Test
+  void testCloseMergeStatesFromPreviousFailure() throws ApiException, InterruptedException {
+    // Adding a state to flush, this state should get flushed when we close syncPersistence
+    final AirbyteStateMessage stateA2 = getStreamState("closeA", 2);
+    syncPersistence.persist(stateA2);
+
+    // Trigger a failure
+    when(stateApi.createOrUpdateState(any())).thenThrow(new ApiException());
+    actualFlushMethod.getValue().run();
+
+    final AirbyteStateMessage stateB1 = getStreamState("closeB", 1);
+    syncPersistence.persist(stateB1);
+
+    // Final flush
+    reset(stateApi);
+    when(executorService.awaitTermination(anyLong(), any())).thenReturn(true);
+    syncPersistence.close();
+    verifyStateUpdateApiCall(List.of(stateA2, stateB1));
+  }
+
+  @Test
+  void testCloseShouldAttemptToRetryFinalFlush() throws ApiException, InterruptedException {
+    final AirbyteStateMessage state = getStreamState("final retry", 2);
+    syncPersistence.persist(state);
+
+    // Setup some API failures
+    when(stateApi.createOrUpdateState(any()))
+        .thenThrow(new ApiException())
+        .thenReturn(mock(ConnectionState.class));
+
+    // Final flush
+    when(executorService.awaitTermination(anyLong(), any())).thenReturn(true);
+    syncPersistence.close();
+    verify(stateApi, times(2)).createOrUpdateState(buildStateRequest(connectionId, List.of(state)));
+  }
+
+  @Test
+  void testCloseWhenFailBecauseFlushTookTooLong() throws InterruptedException, ApiException {
+    syncPersistence.persist(getStreamState("oops", 42));
+
+    // Simulates a flush taking too long to terminate
+    when(executorService.awaitTermination(anyLong(), any())).thenReturn(false);
+
+    syncPersistence.close();
+    verify(executorService).shutdown();
+    // Since the previous write has an unknown state, we do not attempt to persist after the close
+    verify(stateApi, never()).createOrUpdateState(any());
+  }
+
+  @Test
+  void testCloseWhenFailBecauseThreadInterrupted() throws InterruptedException, ApiException {
+    syncPersistence.persist(getStreamState("oops", 42));
+
+    // Simulates a flush taking too long to terminate
+    when(executorService.awaitTermination(anyLong(), any())).thenThrow(new InterruptedException());
+
+    syncPersistence.close();
+    verify(executorService).shutdown();
+    // Since the previous write has an unknown state, we do not attempt to persist after the close
+    verify(stateApi, never()).createOrUpdateState(any());
+  }
+
+  @Test
+  void testCloseWithPendingFlushShouldCallTheApi() throws InterruptedException, ApiException {
+    // Shutdown, we expect the executor service to be stopped and an stateApi to be called
+    when(executorService.awaitTermination(anyLong(), any())).thenReturn(true);
+    syncPersistence.close();
+    verify(executorService).shutdown();
+    verify(stateApi, never()).createOrUpdateState(any());
+  }
+
+  private void verifyStateUpdateApiCall(final List<AirbyteStateMessage> expectedStateMessages) {
+    // Using an ArgumentCaptor because we do not have an ordering constraint on the states, so we need
+    // to add an unordered collection equals
+    final ArgumentCaptor<ConnectionStateCreateOrUpdate> captor = ArgumentCaptor.forClass(ConnectionStateCreateOrUpdate.class);
+
+    try {
+      verify(stateApi).createOrUpdateState(captor.capture());
+    } catch (ApiException e) {
+      throw new RuntimeException(e);
+    }
+    final ConnectionStateCreateOrUpdate actual = captor.getValue();
+    final ConnectionStateCreateOrUpdate expected = buildStateRequest(connectionId, expectedStateMessages);
+
+    // Checking the stream states
+    CollectionAssert.assertThatCollection(actual.getConnectionState().getStreamState())
+        .containsExactlyInAnyOrderElementsOf(expected.getConnectionState().getStreamState());
+
+    // Checking the rest of the payload
+    actual.getConnectionState().setStreamState(List.of());
+    expected.getConnectionState().setStreamState(List.of());
+    assertEquals(expected, actual);
+  }
+
+  private ConnectionStateCreateOrUpdate buildStateRequest(final UUID connectionId, final List<AirbyteStateMessage> stateMessages) {
+    return new ConnectionStateCreateOrUpdate()
+        .connectionId(connectionId)
+        .connectionState(new ConnectionState()
+            .connectionId(connectionId)
+            .stateType(ConnectionStateType.STREAM)
+            .streamState(
+                stateMessages.stream().map(s -> new StreamState()
+                    .streamDescriptor(
+                        new io.airbyte.api.client.model.generated.StreamDescriptor().name(s.getStream().getStreamDescriptor().getName()))
+                    .streamState(s.getStream().getStreamState())).toList()));
+  }
+
+  private AirbyteStateMessage getStreamState(final String streamName, final int stateValue) {
+    return new AirbyteStateMessage().withType(STREAM)
+        .withStream(
+            new AirbyteStreamState()
+                .withStreamDescriptor(
+                    new StreamDescriptor()
+                        .withName(streamName))
+                .withStreamState(Jsons.jsonNode(stateValue)));
+  }
+
+}


### PR DESCRIPTION
## What

Add SyncPersistence implementation.
This contains the main logic and the tests, it is not yet plugged.
There will be a subsequent PR to start using this new class. It will come with the related Micronaut changes for injection, the metrics for observability and should be gated by a feature flag.

Closes #23046 
Depends on https://github.com/airbytehq/airbyte/pull/23233
