### PR TITLE
update deploy docs wget url to point to airbyte-platform repo

### DIFF
--- a/docs/deploying-airbyte/on-aws-ec2.md
+++ b/docs/deploying-airbyte/on-aws-ec2.md
@@ -62,7 +62,7 @@ ssh -i $SSH_KEY ec2-user@$INSTANCE_IP
 
 ``` bash
 mkdir airbyte && cd airbyte
-wget https://raw.githubusercontent.com/airbytehq/airbyte/master/{.env,flags.yml,docker-compose.yaml}
+wget https://raw.githubusercontent.com/airbytehq/airbyte-platform/main/{.env,flags.yml,docker-compose.yaml}
 docker compose up -d # run the Docker container
 ```
 

--- a/docs/deploying-airbyte/on-azure-vm-cloud-shell.md
+++ b/docs/deploying-airbyte/on-azure-vm-cloud-shell.md
@@ -77,7 +77,7 @@ Download Airbyte and deploy it in the VM using Docker Compose:
 3. Download Airbyte from GitHub: 
 
     ```bash
-    wget https://raw.githubusercontent.com/airbytehq/airbyte/master/{.env,flags.yml,docker-compose.yaml}
+    wget https://raw.githubusercontent.com/airbytehq/airbyte-platform/main/{.env,flags.yml,docker-compose.yaml}
     ```
 
 4. To start Airbyte, run the following command:

--- a/docs/deploying-airbyte/on-digitalocean-droplet.md
+++ b/docs/deploying-airbyte/on-digitalocean-droplet.md
@@ -43,7 +43,7 @@ To install and start Airbyte :
 
 ```bash
   mkdir airbyte && cd airbyte
-  wget https://raw.githubusercontent.com/airbytehq/airbyte/master/{.env,flags.yml,docker-compose.yaml}
+  wget https://raw.githubusercontent.com/airbytehq/airbyte-platform/main/{.env,flags.yml,docker-compose.yaml}
   docker compose up -d
 ```
 

--- a/docs/deploying-airbyte/on-gcp-compute-engine.md
+++ b/docs/deploying-airbyte/on-gcp-compute-engine.md
@@ -83,7 +83,7 @@ gcloud --project=$PROJECT_ID beta compute ssh $INSTANCE_NAME
 
 ```bash
 mkdir airbyte && cd airbyte
-curl -sOO https://raw.githubusercontent.com/airbytehq/airbyte/master/{.env,docker-compose.yaml,flags.yml}
+curl -sOO https://raw.githubusercontent.com/airbytehq/airbyte-platform/main/{.env,flags.yml,docker-compose.yaml}
 docker compose up -d
 ```
 

--- a/docs/deploying-airbyte/on-oci-vm.md
+++ b/docs/deploying-airbyte/on-oci-vm.md
@@ -59,7 +59,7 @@ Download the Airbyte repository and deploy it on the VM:
 	```bash
 	mkdir airbyte && cd airbyte
 
-	wget https://raw.githubusercontent.com/airbytehq/airbyte/master/{.env,flags.yml,docker-compose.yaml}
+	wget https://raw.githubusercontent.com/airbytehq/airbyte-platform/main/{.env,flags.yml,docker-compose.yaml}
 	```
 
 2. Run the following commands to get Airbyte running on your OCI VM instance using Docker compose:

--- a/docs/operator-guides/upgrading-airbyte.md
+++ b/docs/operator-guides/upgrading-airbyte.md
@@ -47,7 +47,7 @@ Airbyte version 0.40.32 or later requires [Docker Compose V2](https://docs.docke
 
    i. If you are running Airbyte from a cloned version of the Airbyte GitHub repo and want to use the current most recent stable version, just `git pull`.
 
-   ii. If you are running Airbyte from downloaded `docker-compose.yaml` and `.env` files without a GitHub repo, run `wget -N https://raw.githubusercontent.com/airbytehq/airbyte/master/{.env,flags.yml,docker-compose.yaml}` to pull the latest versions and overwrite both files.
+   ii. If you are running Airbyte from downloaded `docker-compose.yaml` and `.env` files without a GitHub repo, run `wget -N https://raw.githubusercontent.com/airbytehq/airbyte-platform/main/{.env,flags.yml,docker-compose.yaml}` to pull the latest versions and overwrite both files.
 
 3. Bring Airbyte back online.
 


### PR DESCRIPTION
## What
#23214 deleted platform files that are referred in deploy docs.
especially this - https://raw.githubusercontent.com/airbytehq/airbyte/master/{.env,flags.yml,docker-compose.yaml}

## How
Updating the doc to point to airbyte-platform repo