### PR TITLE
test-command: change report status condition

### DIFF
--- a/.github/workflows/test-command.yml
+++ b/.github/workflows/test-command.yml
@@ -155,7 +155,7 @@ jobs:
         run: |
           run-qa-checks ${{ github.event.inputs.connector }}
       - name: Report Status
-        if: github.ref == 'refs/heads/master' && always()
+        if: github.event.inputs.gitref == 'master' && always()
         run: ./tools/status/report.sh ${{ github.event.inputs.connector }} ${{github.repository}} ${{github.run_id}} ${{steps.test.outcome}} ${{steps.qa_checks.outcome}}
         env:
           AWS_ACCESS_KEY_ID: ${{ secrets.STATUS_API_AWS_ACCESS_KEY_ID }}


### PR DESCRIPTION
Solve https://github.com/airbytehq/airbyte/issues/23215

## What
When a /test command is dispatched from a PR the `github.ref` is always `master` because the workflow runs on the master branch (even though it checkouts the value of the `gitref` inputs and runs tests on the correct branch).
The `Reports status` step which builds [this kind of page](https://dnsgjos7lj2fu.cloudfront.net/tests/summary/connectors/source-pokeapi) is therefore executed on non-main branches, which is not what we want... We want these build pages to only gather nightly builds results from `master`. 


## How
Change the conditional logic that runs `Report status`:
- use `github.event.inputs.gitref` input variable instead of `github.ref` to check if we're on the `master` branch.

