### PR TITLE
Update readme to reflect getting started after project split

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,12 +44,12 @@ Explore our [demo app](https://demo.airbyte.io/).
 
 ### Run Airbyte locally
 
-You can run Airbyte locally with Docker.
+You can run Airbyte locally with Docker. The shell script below will retrieve the requisite docker files from the [platform repository](https://github.com/airbytehq/airbyte-platform) and run docker compose for you.
 
 ```bash
 git clone --depth 1 https://github.com/airbytehq/airbyte.git
 cd airbyte
-docker compose up
+./run-ab-platform.sh
 ```
 
 Login to the web app at [http://localhost:8000](http://localhost:8000) by entering the default credentials found in your .env file.
@@ -80,6 +80,8 @@ Sign up for [Airbyte Cloud](https://cloud.airbyte.io/signup).
 ## Contributing
 
 Get started by checking Github issues and creating a Pull Request. An easy way to start contributing is to update an existing connector or create a new connector using the low-code and Python CDKs. You can find the code for existing connectors in the [connectors](https://github.com/airbytehq/airbyte/tree/master/airbyte-integrations/connectors) directory. The Airbyte platform is written in Java, and the frontend in React. You can also contribute to our docs and tutorials. Advanced Airbyte users can apply to the [Maintainer program](https://airbyte.com/maintainer-program) and [Writer Program](https://airbyte.com/write-for-the-community).
+
+If you would like to make a contribution to the platform itself, please refer to guides in [the platform repository](https://github.com/airbytehq/airbyte-platform)
 
 Read the [Contributing guide](https://docs.airbyte.com/contributing-to-airbyte/).
 

--- a/run-ab-platform.sh
+++ b/run-ab-platform.sh
@@ -1,3 +1,5 @@
+#!/usr/bin/bash
+
 # Run away from anything even a little scary
 set -o nounset # -u exit if a variable is not set
 set -o errexit # -f exit for any command failure


### PR DESCRIPTION
## What
Reflects the new way for users new to airbyte to quickly get started

## How
Previously end users ran "docker compose up" to get started. Now that these docker files live in [airbyte-platform](https://github.com/airbytehq/airbyte-platform), end users run a simple shell script that retrieves them and executes the command.

This also resolves an issue noted in #23243 that the bash script was missing `#!/usr/bin/bash` at the top

```bash
./run-ab-platform.sh
```

## Recommended reading order
1. `README.md`


