### PR TITLE
Deploy OSS Connector Catalog to GCS - now uses `gradlew :airbyte-config:specs:generateOssConnectorCatalog`

### DIFF
--- a/.github/workflows/deploy-oss-catalog.yml
+++ b/.github/workflows/deploy-oss-catalog.yml
@@ -29,7 +29,7 @@ jobs:
           distribution: "zulu"
           java-version: "17"
       - name: Generate catalog
-        run: SUB_BUILD=PLATFORM ./gradlew :airbyte-config:init:generateOssConnectorCatalog
+        run: SUB_BUILD=ALL_CONNECTORS ./gradlew :airbyte-config:specs:generateOssConnectorCatalog
       - name: Upload catalog to GCS
         shell: bash
         run: |


### PR DESCRIPTION
Fixes problems like this - https://github.com/airbytehq/airbyte/actions/runs/4236401817/jobs/7361182555