### PR TITLE
Publish connectors whose dockerfile versions were already updated 

### DIFF
--- a/airbyte-config/init/src/main/resources/seed/destination_definitions.yaml
+++ b/airbyte-config/init/src/main/resources/seed/destination_definitions.yaml
@@ -426,7 +426,7 @@
 - name: Databend
   destinationDefinitionId: 302e4d8e-08d3-4098-acd4-ac67ca365b88
   dockerRepository: airbyte/destination-databend
-  dockerImageTag: 0.1.0
+  dockerImageTag: 0.1.1
   icon: databend.svg
   documentationUrl: https://docs.airbyte.com/integrations/destinations/databend
   releaseStage: alpha

--- a/airbyte-config/init/src/main/resources/seed/destination_specs.yaml
+++ b/airbyte-config/init/src/main/resources/seed/destination_specs.yaml
@@ -7189,7 +7189,7 @@
     supported_destination_sync_modes:
     - "overwrite"
     - "append"
-- dockerImage: "airbyte/destination-databend:0.1.0"
+- dockerImage: "airbyte/destination-databend:0.1.1"
   spec:
     documentationUrl: "https://docs.airbyte.com/integrations/destinations/databend"
     connectionSpecification:
@@ -7207,14 +7207,6 @@
           description: "Hostname of the database."
           type: "string"
           order: 0
-        protocol:
-          title: "Protocol"
-          description: "Protocol of the host."
-          type: "string"
-          examples:
-          - "https"
-          default: "https"
-          order: 1
         port:
           title: "Port"
           description: "Port of the database."

--- a/airbyte-config/init/src/main/resources/seed/source_definitions.yaml
+++ b/airbyte-config/init/src/main/resources/seed/source_definitions.yaml
@@ -1469,7 +1469,7 @@
 - name: Recharge
   sourceDefinitionId: 45d2e135-2ede-49e1-939f-3e3ec357a65e
   dockerRepository: airbyte/source-recharge
-  dockerImageTag: 0.2.5
+  dockerImageTag: 0.2.6
   documentationUrl: https://docs.airbyte.com/integrations/sources/recharge
   icon: recharge.svg
   sourceType: api
@@ -1800,7 +1800,7 @@
 - name: TikTok Marketing
   sourceDefinitionId: 4bfac00d-ce15-44ff-95b9-9e3c3e8fbd35
   dockerRepository: airbyte/source-tiktok-marketing
-  dockerImageTag: 2.0.1
+  dockerImageTag: 2.0.2
   documentationUrl: https://docs.airbyte.com/integrations/sources/tiktok-marketing
   icon: tiktok.svg
   sourceType: api

--- a/airbyte-config/init/src/main/resources/seed/source_definitions.yaml
+++ b/airbyte-config/init/src/main/resources/seed/source_definitions.yaml
@@ -1649,7 +1649,7 @@
 - name: Slack
   sourceDefinitionId: c2281cee-86f9-4a86-bb48-d23286b4c7bd
   dockerRepository: airbyte/source-slack
-  dockerImageTag: 0.1.22
+  dockerImageTag: 0.1.23
   documentationUrl: https://docs.airbyte.com/integrations/sources/slack
   icon: slack.svg
   sourceType: api

--- a/airbyte-config/init/src/main/resources/seed/source_specs.yaml
+++ b/airbyte-config/init/src/main/resources/seed/source_specs.yaml
@@ -13634,7 +13634,7 @@
     supportsNormalization: false
     supportsDBT: false
     supported_destination_sync_modes: []
-- dockerImage: "airbyte/source-slack:0.1.22"
+- dockerImage: "airbyte/source-slack:0.1.23"
   spec:
     documentationUrl: "https://docs.airbyte.com/integrations/sources/slack"
     connectionSpecification:

--- a/airbyte-config/init/src/main/resources/seed/source_specs.yaml
+++ b/airbyte-config/init/src/main/resources/seed/source_specs.yaml
@@ -12338,7 +12338,7 @@
     supportsNormalization: false
     supportsDBT: false
     supported_destination_sync_modes: []
-- dockerImage: "airbyte/source-recharge:0.2.5"
+- dockerImage: "airbyte/source-recharge:0.2.6"
   spec:
     documentationUrl: "https://docs.airbyte.com/integrations/sources/recharge"
     connectionSpecification:
@@ -14959,7 +14959,7 @@
     supportsNormalization: false
     supportsDBT: false
     supported_destination_sync_modes: []
-- dockerImage: "airbyte/source-tiktok-marketing:2.0.1"
+- dockerImage: "airbyte/source-tiktok-marketing:2.0.2"
   spec:
     documentationUrl: "https://docs.airbyte.com/integrations/sources/tiktok-marketing"
     changelogUrl: "https://docs.airbyte.com/integrations/sources/tiktok-marketing"

--- a/docs/integrations/sources/recharge.md
+++ b/docs/integrations/sources/recharge.md
@@ -75,8 +75,8 @@ The Recharge connector should gracefully handle Recharge API limitations under n
 ## Changelog
 
 | Version | Date       | Pull Request                                             | Subject                                                                                   |
-|:--------| :--------- | :------------------------------------------------------- | :---------------------------------------------------------------------------------------- |
-| 0.2.6   | 2023-02-07 | [22473](https://github.com/airbytehq/airbyte/pull/22473) | Use default availability strategy
+|:--------|:-----------| :------------------------------------------------------- | :---------------------------------------------------------------------------------------- |
+| 0.2.6   | 2023-02-21 | [22473](https://github.com/airbytehq/airbyte/pull/22473) | Use default availability strategy
 | 0.2.5   | 2023-01-27 | [22021](https://github.com/airbytehq/airbyte/pull/22021) | Set `AvailabilityStrategy` for streams explicitly to `None`                                                     |
 | 0.2.4   | 2022-10-11 | [17822](https://github.com/airbytehq/airbyte/pull/17822) | Do not parse JSON in `should_retry`                                                       |
 | 0.2.3   | 2022-10-11 | [17822](https://github.com/airbytehq/airbyte/pull/17822) | Do not parse JSON in `should_retry`                                                       |

--- a/docs/integrations/sources/slack.md
+++ b/docs/integrations/sources/slack.md
@@ -136,7 +136,7 @@ It is recommended to sync required channels only, this can be done by specifying
 
 | Version | Date       | Pull Request                                             | Subject                                                     |
 |:--------|:-----------|:---------------------------------------------------------|:------------------------------------------------------------|
-| 0.1.23  | 2023-01-30 | [21907](https://github.com/airbytehq/airbyte/pull/21907) | Do not join channels that not gonna be synced               |
+| 0.1.23  | 2023-02-21 | [21907](https://github.com/airbytehq/airbyte/pull/21907) | Do not join channels that not gonna be synced               |
 | 0.1.22  | 2023-01-27 | [22022](https://github.com/airbytehq/airbyte/pull/22022) | Set `AvailabilityStrategy` for streams explicitly to `None` |
 | 0.1.21  | 2023-01-12 | [21321](https://github.com/airbytehq/airbyte/pull/21321) | Retry Timeout error                                         |
 | 0.1.20  | 2022-12-21 | [20767](https://github.com/airbytehq/airbyte/pull/20767) | Update schema                                               |


### PR DESCRIPTION
## What
The following connectors have dockerfile versions higher than on dockerhub because they weren't published, although their code was merged to master: 
* source-recharge ([PR](https://github.com/airbytehq/airbyte/pull/22473))
* source-slack ([PR](https://github.com/airbytehq/airbyte/pull/21907))

The following were published but the *_definitions.yml file wasn't generated automatically and wasn't manually updated accordingly: 
* source-tiktok-marketing ([publish comment](https://github.com/airbytehq/airbyte/pull/22309#issuecomment-1413852910))
* destination-databend ([PR](https://github.com/airbytehq/airbyte/pull/21182) - looks like they were generated, but a later force push removed them)


## How to fix
Publish the first 2 in this PR, updating the changelogs accordingly. Only changes should be changelog dates and commits made automatically via the publish workflow. 

After the first 2 are published, manually update source_definitions.yml and destination_definitons.yml to reflect the correct latest versions for databend and tiktok marketing.
