### PR TITLE
:sparkles: update release pipeline to build platform from airbyte-platform

### DIFF
--- a/.bumpversion.cfg
+++ b/.bumpversion.cfg
@@ -8,43 +8,7 @@ serialize =
 
 [bumpversion:file:.bumpversion.cfg]
 
-[bumpversion:file:.env]
-
-[bumpversion:file:airbyte-bootloader/Dockerfile]
-
-[bumpversion:file:airbyte-container-orchestrator/Dockerfile]
-
-[bumpversion:file:airbyte-cron/Dockerfile]
-
-[bumpversion:file:airbyte-metrics/reporter/Dockerfile]
-
-[bumpversion:file:airbyte-proxy/Dockerfile]
-
-[bumpversion:file:airbyte-server/Dockerfile]
-
-[bumpversion:file:airbyte-webapp/package.json]
-search = "version": "{current_version}"
-replace = "version": "{new_version}"
-
-[bumpversion:file:airbyte-workers/Dockerfile]
-
-[bumpversion:file:charts/airbyte-bootloader/Chart.yaml]
-
-[bumpversion:file:charts/airbyte-cron/Chart.yaml]
-
-[bumpversion:file:charts/airbyte-server/Chart.yaml]
-
-[bumpversion:file:charts/airbyte-temporal/Chart.yaml]
-
-[bumpversion:file:charts/airbyte-webapp/Chart.yaml]
-
-[bumpversion:file:charts/airbyte-worker/Chart.yaml]
-
-[bumpversion:file:charts/airbyte/Chart.yaml]
-
-[bumpversion:file:charts/airbyte-connector-builder-server/Chart.yaml]
-
-[bumpversion:file:charts/airbyte/README.md]
+[bumpversion:file:gradle.properties]
 
 [bumpversion:file:docs/operator-guides/upgrading-airbyte.md]
 
@@ -55,11 +19,5 @@ replace = "version": "{new_version}"
 [bumpversion:file:octavia-cli/install.sh]
 
 [bumpversion:file:octavia-cli/setup.py]
-search = version="{current_version}"
-replace = version="{new_version}"
-
-[bumpversion:file:airbyte-connector-builder-server/Dockerfile]
-
-[bumpversion:file:airbyte-connector-builder-server/setup.py]
 search = version="{current_version}"
 replace = version="{new_version}"

--- a/.github/actions/start-aws-runner/action.yml
+++ b/.github/actions/start-aws-runner/action.yml
@@ -35,7 +35,7 @@ runs:
   using: "composite"
   steps:
     - name: Configure AWS credentials
-      uses: aws-actions/configure-aws-credentials@v1
+      uses: aws-actions/configure-aws-credentials@v1-node16
       with:
         aws-access-key-id: ${{ inputs.aws-access-key-id }}
         aws-secret-access-key: ${{ inputs.aws-secret-access-key }}

--- a/.github/workflows/release-airbyte-os.yml
+++ b/.github/workflows/release-airbyte-os.yml
@@ -1,10 +1,6 @@
 name: Release Open Source Airbyte
 concurrency: release-airbyte
 
-
-# TODO: If we continue to use this action from here it needs to be updated to point to airbyte-platform
-# where appropriate
-
 on:
   workflow_dispatch:
     inputs:
@@ -12,6 +8,7 @@ on:
         description: "Please choose the type of version upgrade : major|minor|patch"
         required: true
         default: "patch"
+
 jobs:
   # In case of self-hosted EC2 errors, remove this block.
   start-release-airbyte-runner:
@@ -24,11 +21,13 @@ jobs:
     steps:
       - name: Checkout Airbyte
         uses: actions/checkout@v3
+
       - name: Check PAT rate limits
         run: |
           ./tools/bin/find_non_rate_limited_PAT \
             ${{ secrets.GH_PAT_BUILD_RUNNER_OSS }} \
             ${{ secrets.GH_PAT_BUILD_RUNNER_BACKUP }}
+
       - name: Start AWS Runner
         id: start-ec2-runner
         uses: ./.github/actions/start-aws-runner
@@ -37,15 +36,16 @@ jobs:
           aws-secret-access-key: ${{ secrets.SELF_RUNNER_AWS_SECRET_ACCESS_KEY }}
           github-token: ${{ env.PAT }}
 
-  releaseAirbyte:
+  release-airbyte-platform:
     # In case of self-hosted EC2 errors, removed the `needs` line and switch back to running on ubuntu-latest.
-    needs: start-release-airbyte-runner # required to start the main job when the runner is ready
+    needs:
+      - start-release-airbyte-runner
     runs-on: ${{ needs.start-release-airbyte-runner.outputs.label }} # run the job on the newly created runner
     steps:
-      - name: Checkout
-        uses: actions/checkout@v3
+      - uses: actions/setup-python@v4
         with:
-          fetch-depth: 0
+          python-version: "3.9"
+
       - uses: actions/setup-java@v3
         with:
           distribution: "zulu"
@@ -55,12 +55,18 @@ jobs:
         with:
           node-version: "lts/*"
 
-      # necessary to install pip
-      - uses: actions/setup-python@v4
+      - name: Checkout Airbyte Platform
+        uses: actions/checkout@v3
         with:
-          python-version: "3.9"
-      - name: Release Airbyte
-        id: release_airbyte
+          repository: airbytehq/airbyte-platform
+          ref: main
+          path: airbyte-platform
+          fetch-depth: 0
+          token: ${{ secrets.GH_PAT_MAINTENANCE_OCTAVIA }}
+
+      - name: Release Airbyte Platform
+        id: release_airbyte_platform
+        working-directory: airbyte-platform
         env:
           DOCKER_HUB_USERNAME: ${{ secrets.DOCKER_HUB_USERNAME }}
           DOCKER_HUB_PASSWORD: ${{ secrets.DOCKER_HUB_PASSWORD }}
@@ -68,17 +74,109 @@ jobs:
           CLOUDREPO_USER: ${{ secrets.CLOUDREPO_USER }}
           CLOUDREPO_PASSWORD: ${{ secrets.CLOUDREPO_PASSWORD }}
         run: |
-          ./tools/bin/release_version.sh
+          ./tools/bin/release_version.sh  # this script calls the bump_version.sh script
+
+      - name: Auto Commit Version for Airbyte Platform
+        uses: stefanzweifel/git-auto-commit-action@v4
+        with:
+          repository: airbyte-platform
+          commit_message: Bump Airbyte version from ${{ steps.release_airbyte_platform.outputs.PREV_VERSION }} to ${{ steps.release_airbyte_platform.outputs.NEW_VERSION }}
+
+      - name: Generate Change Log for Airbyte Platform
+        working-directory: airbyte-platform
+        env:
+          PREV_VERSION: ${{ steps.release_airbyte_platform.outputs.PREV_VERSION }}
+          GIT_REVISION: ${{ steps.release_airbyte_platform.outputs.GIT_REVISION }}
+        run: |
+          CHANGELOG=`PAGER=cat git log v${PREV_VERSION}..${GIT_REVISION} --oneline --decorate=no`
+          echo "CHANGELOG<<EOF" >> $GITHUB_ENV
+          echo -e "$CHANGELOG" >> $GITHUB_ENV
+          echo "EOF" >> $GITHUB_ENV
+
+      - name: Create Release for Airbyte Platform
+        id: create_release
+        uses: ncipollo/release-action@v1
+        env:
+          NEW_VERSION: ${{ steps.release_airbyte_platform.outputs.NEW_VERSION }}
+        with:
+          owner: airbytehq
+          repo: airbyte-platform
+          body: ${{ env.CHANGELOG }}
+          token: ${{ secrets.GH_PAT_MAINTENANCE_OCTAVIA }}
+          tag: v${{ env.NEW_VERSION }}
+
+  release-airbyte:
+    # In case of self-hosted EC2 errors, removed the `needs` line and switch back to running on ubuntu-latest.
+    needs:
+      - start-release-airbyte-runner
+      - release-airbyte-platform
+    runs-on: ${{ needs.start-release-airbyte-runner.outputs.label }} # run the job on the newly created runner
+    steps:
+      - uses: actions/setup-python@v4
+        with:
+          python-version: "3.9"
+
+      - name: Checkout Airbyte
+        uses: actions/checkout@v3
+        with:
+          repository: airbytehq/airbyte
+          ref: master
+          path: airbyte
+          fetch-depth: 0
+
+      - name: Bump Version for Airbyte
+        id: bump_version
+        working-directory: airbyte
+        env:
+          PART_TO_BUMP: ${{ github.event.inputs.partToBump }}
+        run: |
+          ./tools/bin/bump_version.sh
+
+      - name: Run run-ab-platform script to download artifacts from Airbyte Platform
+        working-directory: airbyte
+        run: |
+          ./run-ab-platform.sh --refresh
+          ./run-ab-platform.sh --download
+
+      - name: Auto Commit Version and Platform Artifacts into Airbyte
+        uses: stefanzweifel/git-auto-commit-action@v4
+        with:
+          repository: airbyte
+          commit_message: Bump Airbyte version from ${{ steps.bump_version.outputs.PREV_VERSION }} to ${{ steps.bump_version.outputs.NEW_VERSION }}
+
+      - name: Generate Change Log for Airbyte
+        working-directory: airbyte
+        env:
+          PREV_VERSION: ${{ steps.bump_version.outputs.PREV_VERSION }}
+          GIT_REVISION: ${{ steps.bump_version.outputs.GIT_REVISION }}
+        run: |
+          CHANGELOG=`PAGER=cat git log v${PREV_VERSION}..${GIT_REVISION} --oneline --decorate=no`
+          echo "CHANGELOG<<EOF" >> $GITHUB_ENV
+          echo -e "$CHANGELOG" >> $GITHUB_ENV
+          echo "EOF" >> $GITHUB_ENV
+
+      - name: Create Release for Airbyte
+        id: create_release
+        uses: ncipollo/release-action@v1
+        env:
+          NEW_VERSION: ${{ steps.bump_version.outputs.NEW_VERSION }}
+        with:
+          owner: airbytehq
+          repo: airbyte
+          body: ${{ env.CHANGELOG }}
+          token: ${{ secrets.GITHUB_TOKEN }}
+          tag: v${{ env.NEW_VERSION }}
 
   # We are releasing octavia from a separate job because:
   # - The self hosted runner used in releaseAirbyte does not have the docker buildx command to build multi-arch images
-  releaseOctavia:
+  release-octavia:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
         uses: actions/checkout@v3
         with:
           fetch-depth: 0
+
       - uses: actions/setup-java@v3
         with:
           distribution: "zulu"
@@ -87,6 +185,7 @@ jobs:
       - uses: actions/setup-python@v4
         with:
           python-version: "3.9"
+
       - name: Release Octavia
         id: release_octavia
         env:
@@ -95,60 +194,13 @@ jobs:
           PART_TO_BUMP: ${{ github.event.inputs.partToBump }}
         run: ./tools/bin/release_version_octavia.sh
 
-  createPullRequest:
-    needs:
-      - releaseAirbyte
-      - releaseOctavia
-    runs-on: ubuntu-latest
-    steps:
-      - name: Checkout
-        uses: actions/checkout@v3
-        with:
-          fetch-depth: 0
-      # necessary to install pip
-      - uses: actions/setup-python@v4
-        with:
-          python-version: "3.9"
-      - name: Bump version
-        id: bump_version
-        env:
-          PART_TO_BUMP: ${{ github.event.inputs.partToBump }}
-        run: ./tools/bin/bump_version.sh
-      - name: Get PR Body
-        id: pr_body
-        env:
-          PREV_VERSION: ${{ steps.bump_version.outputs.PREV_VERSION }}
-          NEW_VERSION: ${{ steps.bump_version.outputs.NEW_VERSION }}
-          GIT_REVISION: ${{ steps.bump_version.outputs.GIT_REVISION }}
-        run: |
-          chmod +x tools/bin/pr_body.sh
-          body=$(./tools/bin/pr_body.sh)
-          echo "PR_BODY<<EOF" >> $GITHUB_ENV
-          echo "$body" >> $GITHUB_ENV
-          echo "EOF" >> $GITHUB_ENV
-      - name: Create Pull Request
-        id: cpr
-        uses: peter-evans/create-pull-request@v3
-        with:
-          token: ${{ secrets.GH_PAT_MAINTENANCE_OCTAVIA }}
-          branch: bump-version
-          branch-suffix: random
-          delete-branch: true
-          title: Bump Airbyte version from ${{ steps.bump_version.outputs.PREV_VERSION }} to ${{ steps.bump_version.outputs.NEW_VERSION }}
-          body: ${{ env.PR_BODY }}
-          commit-message: Bump Airbyte version from ${{ steps.bump_version.outputs.PREV_VERSION }} to ${{ steps.bump_version.outputs.NEW_VERSION }}
-      - name: PR Details
-        run: |
-          echo "Pull Request Number - ${{ steps.cpr.outputs.pull-request-number }}"
-          echo "Pull Request URL - ${{ steps.cpr.outputs.pull-request-url }}"
-
   # In case of self-hosted EC2 errors, remove this block.
   stop-release-airbyte-runner:
     name: "Release Airbyte: Stop EC2 Runner"
     timeout-minutes: 10
     needs:
       - start-release-airbyte-runner # required to get output from the start-runner job
-      - releaseAirbyte # required to wait when the main job is done
+      - release-airbyte # required to wait when the main job is done
     runs-on: ubuntu-latest
     if: ${{ always() }} # required to stop the runner even if the error happened in the previous jobs
     steps:

--- a/tools/bin/bump_version.sh
+++ b/tools/bin/bump_version.sh
@@ -9,13 +9,13 @@ if ! test "$(tty)" == "not a tty"; then
 fi
 
 set -o xtrace
-PREV_VERSION=$(grep -w VERSION .env | cut -d"=" -f2)
+PREV_VERSION=$(grep -w VERSION gradle.properties | cut -d"=" -f2)
 GIT_REVISION=$(git rev-parse HEAD)
 
 pip install bumpversion
 bumpversion "$PART_TO_BUMP" # PART_TO_BUMP comes from the Github action (patch,major,minor)
 
-NEW_VERSION=$(grep -w VERSION .env | cut -d"=" -f2)
+NEW_VERSION=$(grep -w VERSION gradle.properties | cut -d"=" -f2)
 export VERSION=$NEW_VERSION # for safety, since lib.sh exports a VERSION that is now outdated
 
 set +o xtrace


### PR DESCRIPTION
:sparkles: update release pipeline to build platform from airbyte-platform

dev runs of this pr can be found here: https://github.com/airbytehq/airbyte/actions/workflows/release-airbyte-os.yml

I've tested the `create_release` step for both `airbyte` and `airbyte-platform`.
What I haven't tested are:
- publishing docker images step for airbyte-platform
- the auto commit steps for both.

What also should be noted: the artifacts from the `run-ab-platform.sh` script need to be commited into the repo for them to be included in the release.

---
Stack created with [Sapling](https://sapling-scm.com). Best reviewed with [ReviewStack](https://reviewstack.dev/airbytehq/airbyte/pull/23323).
* __->__ #23323
