### PR TITLE
destination-exasol: fix gradle dependencies

### DIFF
--- a/airbyte-integrations/connectors/destination-exasol/build.gradle
+++ b/airbyte-integrations/connectors/destination-exasol/build.gradle
@@ -11,8 +11,8 @@ application {
 dependencies {
     implementation project(':airbyte-db:db-lib')
     implementation project(':airbyte-config:config-models')
-    implementation project(':airbyte-protocol:protocol-models')
     implementation project(':airbyte-integrations:bases:base-java')
+    implementation libs.airbyte.protocol
     implementation files(project(':airbyte-integrations:bases:base-java').airbyteDocker.outputs)
     implementation project(':airbyte-integrations:connectors:destination-jdbc')
 


### PR DESCRIPTION
## What
`destination-exasol` declares a `:airbyte-protocol:protocol-models` dependency that is no longer part of the `airbyte` repo.
It makes the project evaluation fail when running any `integrationTest` task on a connector and will break nightly build runs.

## How
Replace project dependencies `:airbyte-protocol:protocol-models`  with `implementation libs.airbyte.protocol`