### PR TITLE
Update the airbyte quickstart to use `./run-ab-platform.sh`

### DIFF
--- a/docs/quickstart/deploy-airbyte.md
+++ b/docs/quickstart/deploy-airbyte.md
@@ -8,7 +8,7 @@ Deploying Airbyte Open-Source just takes two steps.
 ```bash
 git clone https://github.com/airbytehq/airbyte.git
 cd airbyte
-docker compose up
+./run-ab-platform.sh 
 ```
 
 Once you see an Airbyte banner, the UI is ready to go at [http://localhost:8000](http://localhost:8000)! You will be asked for a username and password. By default, that's username `airbyte` and password `password`. Once you deploy airbyte to your servers, **be sure to change these** in your `.env` file.


### PR DESCRIPTION
After the monorepo change, the instructions to run airbuyte have changed. 

As a note, this means that Airbyte no longer runs on windows.  We will need to make a .bat script as well... (https://github.com/airbytehq/monorepo/issues/33)