### PR TITLE
:bug: run airbyte job only by disabling airbyte-platform steps

### DIFF
--- a/.github/workflows/release-airbyte-os.yml
+++ b/.github/workflows/release-airbyte-os.yml
@@ -65,6 +65,7 @@ jobs:
           token: ${{ secrets.GH_PAT_MAINTENANCE_OCTAVIA }}
 
       - name: Release Airbyte Platform
+        if: false # disable
         id: release_airbyte_platform
         working-directory: airbyte-platform
         env:
@@ -77,12 +78,14 @@ jobs:
           ./tools/bin/release_version.sh  # this script calls the bump_version.sh script
 
       - name: Auto Commit Version for Airbyte Platform
+        if: false # disable
         uses: stefanzweifel/git-auto-commit-action@v4
         with:
           repository: airbyte-platform
           commit_message: Bump Airbyte version from ${{ steps.release_airbyte_platform.outputs.PREV_VERSION }} to ${{ steps.release_airbyte_platform.outputs.NEW_VERSION }}
 
       - name: Generate Change Log for Airbyte Platform
+        if: false # disable
         working-directory: airbyte-platform
         env:
           PREV_VERSION: ${{ steps.release_airbyte_platform.outputs.PREV_VERSION }}
@@ -94,6 +97,7 @@ jobs:
           echo "EOF" >> $GITHUB_ENV
 
       - name: Create Release for Airbyte Platform
+        if: false # disable
         id: create_release
         uses: ncipollo/release-action@v1
         env:


### PR DESCRIPTION
:bug: run airbyte job only by disabling airbyte-platform steps

---
Stack created with [Sapling](https://sapling-scm.com). Best reviewed with [ReviewStack](https://reviewstack.dev/airbytehq/airbyte/pull/23420).
* __->__ #23420
