### PR TITLE
Run CATs with local CDK in CI

### DIFF
--- a/.github/workflows/test-command.yml
+++ b/.github/workflows/test-command.yml
@@ -23,6 +23,9 @@ on:
         description: "Set a specific connector acceptance test version to use. Enter 'dev' to test, build and use a local version of Connector Acceptance Test."
         required: false
         default: "latest"
+      local_cdk:
+        description: "Run Connector Acceptance Tests against the CDK version on the current branch."
+        required: false
 jobs:
   uuid:
     name: "Custom UUID of workflow run"
@@ -119,7 +122,7 @@ jobs:
           S3_BUILD_CACHE_SECRET_KEY: ${{ secrets.SELF_RUNNER_AWS_SECRET_ACCESS_KEY }}
         uses: Wandalen/wretry.action@master
         with:
-          command: ./tools/bin/ci_integration_test.sh ${{ github.event.inputs.connector }}
+          command: ./tools/bin/ci_integration_test.sh ${{ github.event.inputs.connector }} ${{ github.event.inputs.local_cdk }}
           attempt_limit: 3
           attempt_delay: 10000 # in ms
       - name: Update Integration Test Credentials after test run for ${{ github.event.inputs.connector }}

--- a/airbyte-integrations/scripts/build-connector-image-with-local-cdk.sh
+++ b/airbyte-integrations/scripts/build-connector-image-with-local-cdk.sh
@@ -1,4 +1,4 @@
-#!/usr/bin/env sh
+#!/usr/bin/env bash
 
 set -e
 
@@ -7,6 +7,8 @@ source "$ROOT_DIR/airbyte-integrations/scripts/utils.sh"
 
 [ -n "$CONNECTOR_TAG" ] || die "Missing CONNECTOR_TAG"
 [ -n "$CONNECTOR_NAME" ] || die "Missing CONNECTOR_NAME"
+
+echo "Building docker image for $CONNECTOR_NAME with local CDK"
 
 CDK_DIR="$ROOT_DIR/airbyte-cdk/python"
 CONNECTOR_DIR="$ROOT_DIR/airbyte-integrations/connectors/$CONNECTOR_NAME"

--- a/buildSrc/src/main/groovy/airbyte-docker.gradle
+++ b/buildSrc/src/main/groovy/airbyte-docker.gradle
@@ -56,10 +56,30 @@ abstract class AirbyteDockerTask extends DefaultTask {
         }
     }
 
+    def buildDockerfileWithLocalCdk(String scriptPath, String fileName) {
+        if (project.file(fileName).exists()) {
+            def tag = DockerHelpers.getDevTaggedImage(projectDir, dockerfileName)
+            project.exec {
+                environment "CONNECTOR_TAG", tag
+                environment "CONNECTOR_NAME", project.findProperty('connectorAcceptanceTest.connectorName')
+                commandLine scriptPath
+            }
+        }
+    }
+
     @TaskAction
     def dockerTask() {
-        def scriptPath = Paths.get(rootDir.absolutePath, 'tools/bin/build_image.sh').toString()
-        buildDockerfile(scriptPath, dockerfileName)
+        if (
+            project.hasProperty('connectorAcceptanceTest.useLocalCdk') &&
+            project.properties["connectorAcceptanceTest.useLocalCdk"]
+        ) {
+            def scriptPath = Paths.get(rootDir.absolutePath, 'airbyte-integrations/scripts/build-connector-image-with-local-cdk.sh').toString()
+            buildDockerfileWithLocalCdk(scriptPath, dockerfileName)
+        }
+        else {
+            def scriptPath = Paths.get(rootDir.absolutePath, 'tools/bin/build_image.sh').toString()
+            buildDockerfile(scriptPath, dockerfileName)
+        }
     }
 }
 

--- a/docs/connector-development/testing-connectors/README.md
+++ b/docs/connector-development/testing-connectors/README.md
@@ -45,6 +45,7 @@ Here are some example commands:
 3. `/test connector=connectors/source-sendgrid` - Runs integration tests for a single connector on the latest PR commit.
 4. `/test connector=source-sendgrid ref=master` - Runs integration tests for a single connector on a different branch.
 5. `/test connector=source-sendgrid ref=d5c53102` - Runs integration tests for a single connector on a specific commit.
+5. `/test connector=source-sendgrid local_cdk=1` - Runs integration tests for a single connector on the latest PR commit, against any CDK changes on that commit.
 
 A command dispatcher GitHub workflow will launch on comment submission. This dispatcher will add an :eyes: reaction to the comment when it starts processing. If there is an error dispatching your request, an error will be appended to your comment. If it launches the test run successfully, a :rocket: reaction will appear on your comment.
 

--- a/tools/bin/ci_integration_test.sh
+++ b/tools/bin/ci_integration_test.sh
@@ -7,6 +7,7 @@ set -e
 # runs integration tests for an integration name
 
 connector="$1"
+local_cdk="$2"
 all_integration_tests=$(./gradlew integrationTest --dry-run | grep 'integrationTest SKIPPED' | cut -d: -f 4)
 run() {
 if [[ "$connector" == "all" ]] ; then
@@ -40,7 +41,7 @@ else
   fi
   if [ -n "$selected_integration_test" ] ; then
     echo "Running: ./gradlew --no-daemon --scan $integrationTestCommand"
-    ./gradlew --no-daemon --scan "$integrationTestCommand"
+    ./gradlew --no-daemon --scan "$integrationTestCommand" -PconnectorAcceptanceTest.useLocalCdk=$local_cdk -PconnectorAcceptanceTest.connectorName=$connector_name
   else
     echo "Connector '$connector' not found..."
     return 1


### PR DESCRIPTION
## What
Updates the /test command to take an optional `local_cdk` argument that, when set, will test the connector against changes made to the CDK on the current branch.

Usage:
`/test connector=<CONNECTOR NAME> local_cdk=1`

## How
- Modifies the /test config file (test-command.yml) to accept the `local_cdk` argument, which it passes to the `tools/bin/ci_integration_test.sh` script when running connector acceptance tests.
- Modifies `ci_integration_test.sh` so that the connectors' integration tests are invoked with the `connectorAcceptanceTest.useLocalCdk` and `connectorAcceptanceTest.connectorName` gradle properties.
- The `airbyteDocker` plugin builds the docker image that's run during connector acceptance tests, so we also modify
the plugin to call the `build-connector-image-with-local-cdk.sh` script if the `connectorAcceptanceTest.useLocalCdk` property is set. 

## Testing
This PR updates to the /test command, and so needs to be tested by triggering the workflow manually so it will run against changes on this branch.

When the workflow is triggered with the `local_cdk` variable set, we can see from [CI output](https://github.com/airbytehq/airbyte/actions/runs/4285089531/jobs/7462965563) that the `build-connector-image-with-local-cdk.sh` script is run.
<img width="548" alt="image" src="https://user-images.githubusercontent.com/5257313/221641381-6f70a816-9087-42b1-beb8-68884f6481da.png">

When the workflow is triggered against a version of the CDK with an exception, [the exception is printed to the CI output](https://github.com/airbytehq/airbyte/actions/runs/4284671344/jobs/7461988929).
<img width="1280" alt="image" src="https://user-images.githubusercontent.com/5257313/221641839-d4d85c4d-b9fd-45e9-92b0-93f052672d77.png">

## Pre-merge Checklist
- [x] Documentation updated