### PR TITLE
QA Checks for strict-encrypt connectors should use regular variants

### DIFF
--- a/tools/ci_connector_ops/ci_connector_ops/qa_checks.py
+++ b/tools/ci_connector_ops/ci_connector_ops/qa_checks.py
@@ -198,7 +198,7 @@ def run_qa_checks():
     if not connector_technical_name.startswith("source-") and not connector_technical_name.startswith("destination-"):
         print("No QA check to run as this is not a connector.")
         sys.exit(0)
-    if connector_technical_name.__contains__("-strict-encrypt"):
+    if connector_technical_name.endswith("-strict-encrypt"):
         connector_technical_name = connector_technical_name.replace("-strict-encrypt", "")
         print("Checking connector " + connector_technical_name + " due to strict-encrypt")
     connector = Connector(connector_technical_name)

--- a/tools/ci_connector_ops/ci_connector_ops/qa_checks.py
+++ b/tools/ci_connector_ops/ci_connector_ops/qa_checks.py
@@ -198,6 +198,9 @@ def run_qa_checks():
     if not connector_technical_name.startswith("source-") and not connector_technical_name.startswith("destination-"):
         print("No QA check to run as this is not a connector.")
         sys.exit(0)
+    if connector_technical_name.__contains__("-strict-encrypt"):
+        connector_technical_name = connector_technical_name.replace("-strict-encrypt", "")
+        print("Checking connector " + connector_technical_name + " due to strict-encrypt")
     connector = Connector(connector_technical_name)
     print(f"Running QA checks for {connector_technical_name}:{connector.version}")
     qa_check_results = {qa_check.__name__: qa_check(connector) for qa_check in QA_CHECKS}

--- a/tools/ci_connector_ops/setup.py
+++ b/tools/ci_connector_ops/setup.py
@@ -24,7 +24,7 @@ TEST_REQUIREMENTS = [
 ]
 
 setup(
-    version="0.1.14",
+    version="0.1.15",
     name="ci_connector_ops",
     description="Packaged maintained by the connector operations team to perform CI for connectors",
     author="Airbyte",


### PR DESCRIPTION
When running QA Checks for strict-encrypt source, we should be checking the metadata of the original variant.  Solves problems like [this](https://github.com/airbytehq/airbyte/actions/runs/4266720151/jobs/7427589422) from https://github.com/airbytehq/airbyte/pull/18782