### PR TITLE
Prepare connectors for `docker scan` testing

### DIFF
--- a/.github/workflows/test-command.yml
+++ b/.github/workflows/test-command.yml
@@ -122,10 +122,9 @@ jobs:
           command: ./tools/bin/ci_integration_test.sh ${{ github.event.inputs.connector }}
           attempt_limit: 3
           attempt_delay: 10000 # in ms
-      # Disabled until the majority of connectors have their base images updated
-      # - name: Scan ${{ github.event.inputs.connector }}
-      #   id: scan
-      #   run: ./tools/bin/ci_docker_scan.sh ${{ github.event.inputs.connector }}
+      - name: Scan ${{ github.event.inputs.connector }}
+        id: scan
+        run: ./tools/bin/ci_docker_scan.sh ${{ github.event.inputs.connector }}
       - name: Update Integration Test Credentials after test run for ${{ github.event.inputs.connector }}
         if: always()
         run: |

--- a/.github/workflows/test-command.yml
+++ b/.github/workflows/test-command.yml
@@ -122,6 +122,10 @@ jobs:
           command: ./tools/bin/ci_integration_test.sh ${{ github.event.inputs.connector }}
           attempt_limit: 3
           attempt_delay: 10000 # in ms
+      # Disabled until the majority of connectors have their base images updated
+      # - name: Scan ${{ github.event.inputs.connector }}
+      #   id: scan
+      #   run: ./tools/bin/ci_docker_scan.sh ${{ github.event.inputs.connector }}
       - name: Update Integration Test Credentials after test run for ${{ github.event.inputs.connector }}
         if: always()
         run: |

--- a/airbyte-cdk/python/Dockerfile
+++ b/airbyte-cdk/python/Dockerfile
@@ -1,13 +1,16 @@
 FROM python:3.9.11-alpine3.15 as base
 
+# alwyays update dependencies
+RUN apk update && apk upgrade -a
+
 # build and load all requirements
 FROM base as builder
 WORKDIR /airbyte/integration_code
 
-# upgrade pip to the latest version
+# upgrade pip and install libs
 RUN apk --no-cache upgrade \
     && pip install --upgrade pip \
-    && apk --no-cache add tzdata build-base
+    && apk --no-cache add tzdata build-base bash
 
 # install airbyte-cdk
 RUN pip install --prefix=/install airbyte-cdk==0.29.0
@@ -22,8 +25,7 @@ COPY --from=builder /install /usr/local
 COPY --from=builder /usr/share/zoneinfo/Etc/UTC /etc/localtime
 RUN echo "Etc/UTC" > /etc/timezone
 
-# bash is installed for more convenient debugging.
-RUN apk --no-cache add bash
+
 
 # copy payload code only
 COPY source_declarative_manifest/main.py ./

--- a/airbyte-integrations/bases/base-java/Dockerfile
+++ b/airbyte-integrations/bases/base-java/Dockerfile
@@ -1,5 +1,8 @@
 ARG JDK_VERSION=17.0.4
 FROM amazoncorretto:${JDK_VERSION}
+
+RUN yum update -y
+
 COPY --from=airbyte/integration-base:dev /airbyte /airbyte
 
 RUN yum install -y tar openssl && yum clean all

--- a/airbyte-integrations/bases/base/Dockerfile
+++ b/airbyte-integrations/bases/base/Dockerfile
@@ -1,5 +1,7 @@
 FROM amazonlinux:2022.0.20220831.1
 
+RUN yum update -y
+
 WORKDIR /airbyte
 
 COPY base.sh .

--- a/airbyte-integrations/bases/connector-acceptance-test/Dockerfile
+++ b/airbyte-integrations/bases/connector-acceptance-test/Dockerfile
@@ -1,13 +1,16 @@
 FROM python:3.9.11-alpine3.15 as base
 
+# alwyays update dependencies
+RUN apk update && apk upgrade -a
+
 # build and load all requirements
 FROM base as builder
 WORKDIR /airbyte/integration_code
 
-# upgrade pip to the latest version
+# upgrade pip and install libs
 RUN apk --no-cache upgrade \
     && pip install --upgrade pip \
-    && apk --no-cache add tzdata build-base
+    && apk --no-cache add tzdata build-base bash
 
 COPY setup.py ./
 # install necessary packages to a temporary folder
@@ -23,8 +26,7 @@ COPY --from=builder /install /usr/local
 # add default timezone settings
 COPY --from=builder /usr/share/zoneinfo/Etc/UTC /etc/localtime
 RUN echo "Etc/UTC" > /etc/timezone
-# Bash is installed for more convenient debugging.
-RUN apk --no-cache add bash
+
 
 ENV ACCEPTANCE_TEST_DOCKER_CONTAINER 1
 

--- a/airbyte-integrations/connector-templates/destination-python/Dockerfile
+++ b/airbyte-integrations/connector-templates/destination-python/Dockerfile
@@ -1,13 +1,16 @@
 FROM python:3.9.11-alpine3.15 as base
 
+# alwyays update dependencies
+RUN apk update && apk upgrade -a
+
 # build and load all requirements
 FROM base as builder
 WORKDIR /airbyte/integration_code
 
-# upgrade pip to the latest version
+# upgrade pip and install libs
 RUN apk --no-cache upgrade \
     && pip install --upgrade pip \
-    && apk --no-cache add tzdata build-base
+    && apk --no-cache add tzdata build-base bash
 
 
 COPY setup.py ./
@@ -24,8 +27,7 @@ COPY --from=builder /install /usr/local
 COPY --from=builder /usr/share/zoneinfo/Etc/UTC /etc/localtime
 RUN echo "Etc/UTC" > /etc/timezone
 
-# bash is installed for more convenient debugging.
-RUN apk --no-cache add bash
+
 
 # copy payload code only
 COPY main.py ./

--- a/airbyte-integrations/connector-templates/source-configuration-based/Dockerfile
+++ b/airbyte-integrations/connector-templates/source-configuration-based/Dockerfile
@@ -1,13 +1,16 @@
 FROM python:3.9.11-alpine3.15 as base
 
+# alwyays update dependencies
+RUN apk update && apk upgrade -a
+
 # build and load all requirements
 FROM base as builder
 WORKDIR /airbyte/integration_code
 
-# upgrade pip to the latest version
+# upgrade pip and install libs
 RUN apk --no-cache upgrade \
     && pip install --upgrade pip \
-    && apk --no-cache add tzdata build-base
+    && apk --no-cache add tzdata build-base bash
 
 
 COPY setup.py ./
@@ -24,8 +27,7 @@ COPY --from=builder /install /usr/local
 COPY --from=builder /usr/share/zoneinfo/Etc/UTC /etc/localtime
 RUN echo "Etc/UTC" > /etc/timezone
 
-# bash is installed for more convenient debugging.
-RUN apk --no-cache add bash
+
 
 # copy payload code only
 COPY main.py ./

--- a/airbyte-integrations/connector-templates/source-python-http-api/Dockerfile
+++ b/airbyte-integrations/connector-templates/source-python-http-api/Dockerfile
@@ -1,13 +1,16 @@
-FROM python:3.9.13-alpine3.15 as base
+FROM python:3.9.11-alpine3.15 as base
+
+# alwyays update dependencies
+RUN apk update && apk upgrade -a
 
 # build and load all requirements
 FROM base as builder
 WORKDIR /airbyte/integration_code
 
-# upgrade pip to the latest version
+# upgrade pip and install libs
 RUN apk --no-cache upgrade \
     && pip install --upgrade pip \
-    && apk --no-cache add tzdata build-base
+    && apk --no-cache add tzdata build-base bash
 
 
 COPY setup.py ./
@@ -24,8 +27,7 @@ COPY --from=builder /install /usr/local
 COPY --from=builder /usr/share/zoneinfo/Etc/UTC /etc/localtime
 RUN echo "Etc/UTC" > /etc/timezone
 
-# bash is installed for more convenient debugging.
-RUN apk --no-cache add bash
+
 
 # copy payload code only
 COPY main.py ./

--- a/airbyte-integrations/connector-templates/source-python/Dockerfile
+++ b/airbyte-integrations/connector-templates/source-python/Dockerfile
@@ -1,13 +1,16 @@
 FROM python:3.9.11-alpine3.15 as base
 
+# alwyays update dependencies
+RUN apk update && apk upgrade -a
+
 # build and load all requirements
 FROM base as builder
 WORKDIR /airbyte/integration_code
 
-# upgrade pip to the latest version
+# upgrade pip and install libs
 RUN apk --no-cache upgrade \
     && pip install --upgrade pip \
-    && apk --no-cache add tzdata build-base
+    && apk --no-cache add tzdata build-base bash
 
 
 COPY setup.py ./
@@ -24,8 +27,7 @@ COPY --from=builder /install /usr/local
 COPY --from=builder /usr/share/zoneinfo/Etc/UTC /etc/localtime
 RUN echo "Etc/UTC" > /etc/timezone
 
-# bash is installed for more convenient debugging.
-RUN apk --no-cache add bash
+
 
 # copy payload code only
 COPY main.py ./

--- a/airbyte-integrations/connector-templates/source-singer/Dockerfile
+++ b/airbyte-integrations/connector-templates/source-singer/Dockerfile
@@ -1,4 +1,7 @@
-FROM python:3.9-slim
+FROM python:3.9.11-alpine3.15 as base
+
+# alwyays update dependencies
+RUN apk update && apk upgrade -a
 
 # Bash is installed for more convenient debugging.
 RUN apt-get update && apt-get install -y bash && apt-get install -y gcc && rm -rf /var/lib/apt/lists/*

--- a/airbyte-integrations/connector-templates/source-singer/Dockerfile
+++ b/airbyte-integrations/connector-templates/source-singer/Dockerfile
@@ -3,8 +3,10 @@ FROM python:3.9.11-alpine3.15 as base
 # alwyays update dependencies
 RUN apk update && apk upgrade -a
 
-# Bash is installed for more convenient debugging.
-RUN apt-get update && apt-get install -y bash && apt-get install -y gcc && rm -rf /var/lib/apt/lists/*
+# upgrade pip and install libs
+RUN apk --no-cache upgrade \
+    && pip install --upgrade pip \
+    && apk --no-cache add tzdata build-base bash
 
 WORKDIR /airbyte/integration_code
 COPY source_{{snakeCase name}}_singer ./source_{{snakeCase name}}_singer

--- a/airbyte-integrations/connectors/destination-amazon-sqs/Dockerfile
+++ b/airbyte-integrations/connectors/destination-amazon-sqs/Dockerfile
@@ -1,13 +1,16 @@
 FROM python:3.9.11-alpine3.15 as base
 
+# alwyays update dependencies
+RUN apk update && apk upgrade -a
+
 # build and load all requirements
 FROM base as builder
 WORKDIR /airbyte/integration_code
 
-# upgrade pip to the latest version
+# upgrade pip and install libs
 RUN apk --no-cache upgrade \
     && pip install --upgrade pip \
-    && apk --no-cache add tzdata build-base
+    && apk --no-cache add tzdata build-base bash
 
 
 COPY setup.py ./
@@ -24,8 +27,7 @@ COPY --from=builder /install /usr/local
 COPY --from=builder /usr/share/zoneinfo/Etc/UTC /etc/localtime
 RUN echo "Etc/UTC" > /etc/timezone
 
-# bash is installed for more convenient debugging.
-RUN apk --no-cache add bash
+
 
 # copy payload code only
 COPY main.py ./

--- a/airbyte-integrations/connectors/destination-aws-datalake/Dockerfile
+++ b/airbyte-integrations/connectors/destination-aws-datalake/Dockerfile
@@ -1,5 +1,11 @@
-FROM python:3.9-slim
-# FROM python:3.9.11-alpine3.15
+FROM python:3.9.11-alpine3.15 as base
+
+# alwyays update dependencies
+RUN apk update && apk upgrade -a
+# FROM python:3.9.11-alpine3.15 as base
+
+# alwyays update dependencies
+RUN apk update && apk upgrade -a
 
 # Bash is installed for more convenient debugging.
 # RUN apt-get update && apt-get install -y bash && rm -rf /var/lib/apt/lists/*

--- a/airbyte-integrations/connectors/destination-aws-datalake/Dockerfile
+++ b/airbyte-integrations/connectors/destination-aws-datalake/Dockerfile
@@ -2,13 +2,11 @@ FROM python:3.9.11-alpine3.15 as base
 
 # alwyays update dependencies
 RUN apk update && apk upgrade -a
-# FROM python:3.9.11-alpine3.15 as base
 
-# alwyays update dependencies
-RUN apk update && apk upgrade -a
-
-# Bash is installed for more convenient debugging.
-# RUN apt-get update && apt-get install -y bash && rm -rf /var/lib/apt/lists/*
+# upgrade pip and install libs
+RUN apk --no-cache upgrade \
+    && pip install --upgrade pip \
+    && apk --no-cache add tzdata build-base bash
 
 WORKDIR /airbyte/integration_code
 COPY destination_aws_datalake ./destination_aws_datalake

--- a/airbyte-integrations/connectors/destination-databend/Dockerfile
+++ b/airbyte-integrations/connectors/destination-databend/Dockerfile
@@ -1,13 +1,16 @@
 FROM python:3.9.11-alpine3.15 as base
 
+# alwyays update dependencies
+RUN apk update && apk upgrade -a
+
 # build and load all requirements
 FROM base as builder
 WORKDIR /airbyte/integration_code
 
-# upgrade pip to the latest version
+# upgrade pip and install libs
 RUN apk --no-cache upgrade \
     && pip install --upgrade pip \
-    && apk --no-cache add tzdata build-base
+    && apk --no-cache add tzdata build-base bash
 
 
 COPY setup.py ./
@@ -24,8 +27,7 @@ COPY --from=builder /install /usr/local
 COPY --from=builder /usr/share/zoneinfo/Etc/UTC /etc/localtime
 RUN echo "Etc/UTC" > /etc/timezone
 
-# bash is installed for more convenient debugging.
-RUN apk --no-cache add bash
+
 
 # copy payload code only
 COPY main.py ./

--- a/airbyte-integrations/connectors/destination-duckdb/Dockerfile
+++ b/airbyte-integrations/connectors/destination-duckdb/Dockerfile
@@ -1,5 +1,11 @@
-FROM python:3.9.11 as base
+FROM python:3.9.11-alpine3.15 as base
+
+# alwyays update dependencies
+RUN apk update && apk upgrade -a
 # FROM python:3.9.11-alpine3.15 as base
+
+# alwyays update dependencies
+RUN apk update && apk upgrade -a
 # switched from alpine as there were tons of errors (in case you want to switch back to alpine)
 # - https://stackoverflow.com/a/57485724/5246670
 # - numpy error: https://stackoverflow.com/a/22411624/5246670

--- a/airbyte-integrations/connectors/destination-duckdb/Dockerfile
+++ b/airbyte-integrations/connectors/destination-duckdb/Dockerfile
@@ -2,23 +2,18 @@ FROM python:3.9.11-alpine3.15 as base
 
 # alwyays update dependencies
 RUN apk update && apk upgrade -a
-# FROM python:3.9.11-alpine3.15 as base
 
-# alwyays update dependencies
-RUN apk update && apk upgrade -a
-# switched from alpine as there were tons of errors (in case you want to switch back to alpine)
-# - https://stackoverflow.com/a/57485724/5246670
-# - numpy error: https://stackoverflow.com/a/22411624/5246670
-# - libstdc++ https://github.com/amancevice/docker-pandas/issues/12#issuecomment-717215043
-# - musl-dev linux-headers g++ because of: https://stackoverflow.com/a/40407099/5246670
+# upgrade pip and install libs
+RUN apk --no-cache upgrade \
+    && pip install --upgrade pip \
+    && apk --no-cache add tzdata build-base bash
+
+# Install custom deps for this connector
+RUN apk add libffi-dev musl-dev g++
 
 # build and load all requirements
 FROM base as builder
 WORKDIR /airbyte/integration_code
-
-# upgrade pip to the latest version
-RUN apt-get update && apt-get -y upgrade \
-    && pip install --upgrade pip
 
 COPY setup.py ./
 # install necessary packages to a temporary folder

--- a/airbyte-integrations/connectors/destination-firebolt/Dockerfile
+++ b/airbyte-integrations/connectors/destination-firebolt/Dockerfile
@@ -1,4 +1,7 @@
-FROM python:3.9-slim as base
+FROM python:3.9.11-alpine3.15 as base
+
+# alwyays update dependencies
+RUN apk update && apk upgrade -a
 
 # build and load all requirements
 FROM base as builder

--- a/airbyte-integrations/connectors/destination-firestore/Dockerfile
+++ b/airbyte-integrations/connectors/destination-firestore/Dockerfile
@@ -1,5 +1,8 @@
 FROM python:3.9.11-alpine3.15 as base
 
+# alwyays update dependencies
+RUN apk update && apk upgrade -a
+
 # build and load all requirements
 FROM base as builder
 WORKDIR /airbyte/integration_code
@@ -26,8 +29,7 @@ COPY --from=builder /install /usr/local
 COPY --from=builder /usr/share/zoneinfo/Etc/UTC /etc/localtime
 RUN echo "Etc/UTC" > /etc/timezone
 
-# bash is installed for more convenient debugging.
-RUN apk --no-cache add bash
+
 
 # this is used by grpc
 RUN apk --no-cache add libstdc++

--- a/airbyte-integrations/connectors/destination-google-sheets/Dockerfile
+++ b/airbyte-integrations/connectors/destination-google-sheets/Dockerfile
@@ -1,7 +1,12 @@
-FROM python:3.9-slim
+FROM python:3.9.11-alpine3.15 as base
 
-# Bash is installed for more convenient debugging.
-RUN apt-get update && apt-get install -y bash && rm -rf /var/lib/apt/lists/*
+# alwyays update dependencies
+RUN apk update && apk upgrade -a
+
+# upgrade pip and install libs
+RUN apk --no-cache upgrade \
+    && pip install --upgrade pip \
+    && apk --no-cache add tzdata build-base bash
 
 ENV AIRBYTE_ENTRYPOINT "python /airbyte/integration_code/main.py"
 

--- a/airbyte-integrations/connectors/destination-kvdb/Dockerfile
+++ b/airbyte-integrations/connectors/destination-kvdb/Dockerfile
@@ -1,7 +1,12 @@
-FROM python:3.9.11-alpine3.15
+FROM python:3.9.11-alpine3.15 as base
 
-# Bash is installed for more convenient debugging.
-RUN apt-get update && apt-get install -y bash && rm -rf /var/lib/apt/lists/*
+# alwyays update dependencies
+RUN apk update && apk upgrade -a
+
+# upgrade pip and install libs
+RUN apk --no-cache upgrade \
+    && pip install --upgrade pip \
+    && apk --no-cache add tzdata build-base bash
 
 WORKDIR /airbyte/integration_code
 COPY destination_kvdb ./destination_kvdb

--- a/airbyte-integrations/connectors/destination-meilisearch/Dockerfile
+++ b/airbyte-integrations/connectors/destination-meilisearch/Dockerfile
@@ -1,13 +1,16 @@
 FROM python:3.9.11-alpine3.15 as base
 
+# alwyays update dependencies
+RUN apk update && apk upgrade -a
+
 # build and load all requirements
 FROM base as builder
 WORKDIR /airbyte/integration_code
 
-# upgrade pip to the latest version
+# upgrade pip and install libs
 RUN apk --no-cache upgrade \
     && pip install --upgrade pip \
-    && apk --no-cache add tzdata build-base
+    && apk --no-cache add tzdata build-base bash
 
 
 COPY setup.py ./
@@ -24,8 +27,7 @@ COPY --from=builder /install /usr/local
 COPY --from=builder /usr/share/zoneinfo/Etc/UTC /etc/localtime
 RUN echo "Etc/UTC" > /etc/timezone
 
-# bash is installed for more convenient debugging.
-RUN apk --no-cache add bash
+
 
 # copy payload code only
 COPY main.py ./

--- a/airbyte-integrations/connectors/destination-rabbitmq/Dockerfile
+++ b/airbyte-integrations/connectors/destination-rabbitmq/Dockerfile
@@ -1,13 +1,16 @@
 FROM python:3.9.11-alpine3.15 as base
 
+# alwyays update dependencies
+RUN apk update && apk upgrade -a
+
 # build and load all requirements
 FROM base as builder
 WORKDIR /airbyte/integration_code
 
-# upgrade pip to the latest version
+# upgrade pip and install libs
 RUN apk --no-cache upgrade \
     && pip install --upgrade pip \
-    && apk --no-cache add tzdata build-base
+    && apk --no-cache add tzdata build-base bash
 
 
 COPY setup.py ./
@@ -24,8 +27,7 @@ COPY --from=builder /install /usr/local
 COPY --from=builder /usr/share/zoneinfo/Etc/UTC /etc/localtime
 RUN echo "Etc/UTC" > /etc/timezone
 
-# bash is installed for more convenient debugging.
-RUN apk --no-cache add bash
+
 
 # copy payload code only
 COPY main.py ./

--- a/airbyte-integrations/connectors/destination-scaffold-destination-python/Dockerfile
+++ b/airbyte-integrations/connectors/destination-scaffold-destination-python/Dockerfile
@@ -1,13 +1,16 @@
 FROM python:3.9.11-alpine3.15 as base
 
+# alwyays update dependencies
+RUN apk update && apk upgrade -a
+
 # build and load all requirements
 FROM base as builder
 WORKDIR /airbyte/integration_code
 
-# upgrade pip to the latest version
+# upgrade pip and install libs
 RUN apk --no-cache upgrade \
     && pip install --upgrade pip \
-    && apk --no-cache add tzdata build-base
+    && apk --no-cache add tzdata build-base bash
 
 
 COPY setup.py ./
@@ -24,8 +27,7 @@ COPY --from=builder /install /usr/local
 COPY --from=builder /usr/share/zoneinfo/Etc/UTC /etc/localtime
 RUN echo "Etc/UTC" > /etc/timezone
 
-# bash is installed for more convenient debugging.
-RUN apk --no-cache add bash
+
 
 # copy payload code only
 COPY main.py ./

--- a/airbyte-integrations/connectors/destination-sftp-json/Dockerfile
+++ b/airbyte-integrations/connectors/destination-sftp-json/Dockerfile
@@ -1,4 +1,7 @@
-FROM python:3.9-slim
+FROM python:3.9.11-alpine3.15 as base
+
+# alwyays update dependencies
+RUN apk update && apk upgrade -a
 
 WORKDIR /airbyte/integration_code
 COPY destination_sftp_json ./destination_sftp_json

--- a/airbyte-integrations/connectors/destination-sqlite/Dockerfile
+++ b/airbyte-integrations/connectors/destination-sqlite/Dockerfile
@@ -1,13 +1,16 @@
 FROM python:3.9.11-alpine3.15 as base
 
+# alwyays update dependencies
+RUN apk update && apk upgrade -a
+
 # build and load all requirements
 FROM base as builder
 WORKDIR /airbyte/integration_code
 
-# upgrade pip to the latest version
+# upgrade pip and install libs
 RUN apk --no-cache upgrade \
     && pip install --upgrade pip \
-    && apk --no-cache add tzdata build-base
+    && apk --no-cache add tzdata build-base bash
 
 
 COPY setup.py ./
@@ -24,8 +27,7 @@ COPY --from=builder /install /usr/local
 COPY --from=builder /usr/share/zoneinfo/Etc/UTC /etc/localtime
 RUN echo "Etc/UTC" > /etc/timezone
 
-# bash is installed for more convenient debugging.
-RUN apk --no-cache add bash
+
 
 # copy payload code only
 COPY main.py ./

--- a/airbyte-integrations/connectors/destination-typesense/Dockerfile
+++ b/airbyte-integrations/connectors/destination-typesense/Dockerfile
@@ -1,13 +1,16 @@
 FROM python:3.9.11-alpine3.15 as base
 
+# alwyays update dependencies
+RUN apk update && apk upgrade -a
+
 # build and load all requirements
 FROM base as builder
 WORKDIR /airbyte/integration_code
 
-# upgrade pip to the latest version
+# upgrade pip and install libs
 RUN apk --no-cache upgrade \
     && pip install --upgrade pip \
-    && apk --no-cache add tzdata build-base
+    && apk --no-cache add tzdata build-base bash
 
 
 COPY setup.py ./
@@ -24,8 +27,7 @@ COPY --from=builder /install /usr/local
 COPY --from=builder /usr/share/zoneinfo/Etc/UTC /etc/localtime
 RUN echo "Etc/UTC" > /etc/timezone
 
-# bash is installed for more convenient debugging.
-RUN apk --no-cache add bash
+
 
 # copy payload code only
 COPY main.py ./

--- a/airbyte-integrations/connectors/destination-weaviate/Dockerfile
+++ b/airbyte-integrations/connectors/destination-weaviate/Dockerfile
@@ -1,13 +1,16 @@
 FROM python:3.9.11-alpine3.15 as base
 
+# alwyays update dependencies
+RUN apk update && apk upgrade -a
+
 # build and load all requirements
 FROM base as builder
 WORKDIR /airbyte/integration_code
 
-# upgrade pip to the latest version
+# upgrade pip and install libs
 RUN apk --no-cache upgrade \
     && pip install --upgrade pip \
-    && apk --no-cache add tzdata build-base
+    && apk --no-cache add tzdata build-base bash
 
 
 COPY setup.py ./
@@ -24,8 +27,7 @@ COPY --from=builder /install /usr/local
 COPY --from=builder /usr/share/zoneinfo/Etc/UTC /etc/localtime
 RUN echo "Etc/UTC" > /etc/timezone
 
-# bash is installed for more convenient debugging.
-RUN apk --no-cache add bash
+
 
 # copy payload code only
 COPY main.py ./

--- a/airbyte-integrations/connectors/source-activecampaign/Dockerfile
+++ b/airbyte-integrations/connectors/source-activecampaign/Dockerfile
@@ -1,13 +1,16 @@
 FROM python:3.9.11-alpine3.15 as base
 
+# alwyays update dependencies
+RUN apk update && apk upgrade -a
+
 # build and load all requirements
 FROM base as builder
 WORKDIR /airbyte/integration_code
 
-# upgrade pip to the latest version
+# upgrade pip and install libs
 RUN apk --no-cache upgrade \
     && pip install --upgrade pip \
-    && apk --no-cache add tzdata build-base
+    && apk --no-cache add tzdata build-base bash
 
 
 COPY setup.py ./
@@ -24,8 +27,7 @@ COPY --from=builder /install /usr/local
 COPY --from=builder /usr/share/zoneinfo/Etc/UTC /etc/localtime
 RUN echo "Etc/UTC" > /etc/timezone
 
-# bash is installed for more convenient debugging.
-RUN apk --no-cache add bash
+
 
 # copy payload code only
 COPY main.py ./

--- a/airbyte-integrations/connectors/source-adjust/Dockerfile
+++ b/airbyte-integrations/connectors/source-adjust/Dockerfile
@@ -1,13 +1,16 @@
 FROM python:3.9.11-alpine3.15 as base
 
+# alwyays update dependencies
+RUN apk update && apk upgrade -a
+
 # build and load all requirements
 FROM base as builder
 WORKDIR /airbyte/integration_code
 
-# upgrade pip to the latest version
+# upgrade pip and install libs
 RUN apk --no-cache upgrade \
     && pip install --upgrade pip \
-    && apk --no-cache add tzdata build-base
+    && apk --no-cache add tzdata build-base bash
 
 
 COPY setup.py ./
@@ -24,8 +27,7 @@ COPY --from=builder /install /usr/local
 COPY --from=builder /usr/share/zoneinfo/Etc/UTC /etc/localtime
 RUN echo "Etc/UTC" > /etc/timezone
 
-# bash is installed for more convenient debugging.
-RUN apk --no-cache add bash
+
 
 # copy payload code only
 COPY main.py ./

--- a/airbyte-integrations/connectors/source-aha/Dockerfile
+++ b/airbyte-integrations/connectors/source-aha/Dockerfile
@@ -1,13 +1,16 @@
 FROM python:3.9.11-alpine3.15 as base
 
+# alwyays update dependencies
+RUN apk update && apk upgrade -a
+
 # build and load all requirements
 FROM base as builder
 WORKDIR /airbyte/integration_code
 
-# upgrade pip to the latest version
+# upgrade pip and install libs
 RUN apk --no-cache upgrade \
     && pip install --upgrade pip \
-    && apk --no-cache add tzdata build-base
+    && apk --no-cache add tzdata build-base bash
 
 
 COPY setup.py ./
@@ -24,8 +27,7 @@ COPY --from=builder /install /usr/local
 COPY --from=builder /usr/share/zoneinfo/Etc/UTC /etc/localtime
 RUN echo "Etc/UTC" > /etc/timezone
 
-# bash is installed for more convenient debugging.
-RUN apk --no-cache add bash
+
 
 # copy payload code only
 COPY main.py ./

--- a/airbyte-integrations/connectors/source-airtable/Dockerfile
+++ b/airbyte-integrations/connectors/source-airtable/Dockerfile
@@ -1,13 +1,16 @@
 FROM python:3.9.11-alpine3.15 as base
 
+# alwyays update dependencies
+RUN apk update && apk upgrade -a
+
 # build and load all requirements
 FROM base as builder
 WORKDIR /airbyte/integration_code
 
-# upgrade pip to the latest version
+# upgrade pip and install libs
 RUN apk --no-cache upgrade \
     && pip install --upgrade pip \
-    && apk --no-cache add tzdata build-base
+    && apk --no-cache add tzdata build-base bash
 
 
 COPY setup.py ./
@@ -24,8 +27,7 @@ COPY --from=builder /install /usr/local
 COPY --from=builder /usr/share/zoneinfo/Etc/UTC /etc/localtime
 RUN echo "Etc/UTC" > /etc/timezone
 
-# bash is installed for more convenient debugging.
-RUN apk --no-cache add bash
+
 
 # copy payload code only
 COPY main.py ./

--- a/airbyte-integrations/connectors/source-alpha-vantage/Dockerfile
+++ b/airbyte-integrations/connectors/source-alpha-vantage/Dockerfile
@@ -1,13 +1,16 @@
 FROM python:3.9.11-alpine3.15 as base
 
+# alwyays update dependencies
+RUN apk update && apk upgrade -a
+
 # build and load all requirements
 FROM base as builder
 WORKDIR /airbyte/integration_code
 
-# upgrade pip to the latest version
+# upgrade pip and install libs
 RUN apk --no-cache upgrade \
     && pip install --upgrade pip \
-    && apk --no-cache add tzdata build-base
+    && apk --no-cache add tzdata build-base bash
 
 
 COPY setup.py ./
@@ -24,8 +27,7 @@ COPY --from=builder /install /usr/local
 COPY --from=builder /usr/share/zoneinfo/Etc/UTC /etc/localtime
 RUN echo "Etc/UTC" > /etc/timezone
 
-# bash is installed for more convenient debugging.
-RUN apk --no-cache add bash
+
 
 # copy payload code only
 COPY main.py ./

--- a/airbyte-integrations/connectors/source-amazon-ads/Dockerfile
+++ b/airbyte-integrations/connectors/source-amazon-ads/Dockerfile
@@ -1,7 +1,12 @@
-FROM python:3.9-slim
+FROM python:3.9.11-alpine3.15 as base
 
-# Bash is installed for more convenient debugging.
-RUN apt-get update && apt-get install -y bash && rm -rf /var/lib/apt/lists/*
+# alwyays update dependencies
+RUN apk update && apk upgrade -a
+
+# upgrade pip and install libs
+RUN apk --no-cache upgrade \
+    && pip install --upgrade pip \
+    && apk --no-cache add tzdata build-base bash
 
 WORKDIR /airbyte/integration_code
 COPY source_amazon_ads ./source_amazon_ads

--- a/airbyte-integrations/connectors/source-amazon-seller-partner/Dockerfile
+++ b/airbyte-integrations/connectors/source-amazon-seller-partner/Dockerfile
@@ -1,7 +1,12 @@
-FROM python:3.9-slim
+FROM python:3.9.11-alpine3.15 as base
 
-# Bash is installed for more convenient debugging.
-RUN apt-get update && apt-get install -y bash && rm -rf /var/lib/apt/lists/*
+# alwyays update dependencies
+RUN apk update && apk upgrade -a
+
+# upgrade pip and install libs
+RUN apk --no-cache upgrade \
+    && pip install --upgrade pip \
+    && apk --no-cache add tzdata build-base bash
 
 WORKDIR /airbyte/integration_code
 COPY source_amazon_seller_partner ./source_amazon_seller_partner

--- a/airbyte-integrations/connectors/source-amazon-sqs/Dockerfile
+++ b/airbyte-integrations/connectors/source-amazon-sqs/Dockerfile
@@ -1,13 +1,16 @@
 FROM python:3.9.11-alpine3.15 as base
 
+# alwyays update dependencies
+RUN apk update && apk upgrade -a
+
 # build and load all requirements
 FROM base as builder
 WORKDIR /airbyte/integration_code
 
-# upgrade pip to the latest version
+# upgrade pip and install libs
 RUN apk --no-cache upgrade \
     && pip install --upgrade pip \
-    && apk --no-cache add tzdata build-base
+    && apk --no-cache add tzdata build-base bash
 
 
 COPY setup.py ./
@@ -24,8 +27,7 @@ COPY --from=builder /install /usr/local
 COPY --from=builder /usr/share/zoneinfo/Etc/UTC /etc/localtime
 RUN echo "Etc/UTC" > /etc/timezone
 
-# bash is installed for more convenient debugging.
-RUN apk --no-cache add bash
+
 
 # copy payload code only
 COPY main.py ./

--- a/airbyte-integrations/connectors/source-amplitude/Dockerfile
+++ b/airbyte-integrations/connectors/source-amplitude/Dockerfile
@@ -1,7 +1,12 @@
-FROM python:3.9-slim
+FROM python:3.9.11-alpine3.15 as base
 
-# Bash is installed for more convenient debugging.
-RUN apt-get update && apt-get install -y bash && rm -rf /var/lib/apt/lists/*
+# alwyays update dependencies
+RUN apk update && apk upgrade -a
+
+# upgrade pip and install libs
+RUN apk --no-cache upgrade \
+    && pip install --upgrade pip \
+    && apk --no-cache add tzdata build-base bash
 
 WORKDIR /airbyte/integration_code
 COPY source_amplitude ./source_amplitude

--- a/airbyte-integrations/connectors/source-apify-dataset/Dockerfile
+++ b/airbyte-integrations/connectors/source-apify-dataset/Dockerfile
@@ -1,7 +1,12 @@
-FROM python:3.9-slim
+FROM python:3.9.11-alpine3.15 as base
 
-# Bash is installed for more convenient debugging.
-RUN apt-get update && apt-get install -y bash && rm -rf /var/lib/apt/lists/*
+# alwyays update dependencies
+RUN apk update && apk upgrade -a
+
+# upgrade pip and install libs
+RUN apk --no-cache upgrade \
+    && pip install --upgrade pip \
+    && apk --no-cache add tzdata build-base bash
 
 WORKDIR /airbyte/integration_code
 COPY source_apify_dataset ./source_apify_dataset

--- a/airbyte-integrations/connectors/source-appfollow/Dockerfile
+++ b/airbyte-integrations/connectors/source-appfollow/Dockerfile
@@ -1,13 +1,16 @@
 FROM python:3.9.11-alpine3.15 as base
 
+# alwyays update dependencies
+RUN apk update && apk upgrade -a
+
 # build and load all requirements
 FROM base as builder
 WORKDIR /airbyte/integration_code
 
-# upgrade pip to the latest version
+# upgrade pip and install libs
 RUN apk --no-cache upgrade \
     && pip install --upgrade pip \
-    && apk --no-cache add tzdata build-base
+    && apk --no-cache add tzdata build-base bash
 
 
 COPY setup.py ./
@@ -24,8 +27,7 @@ COPY --from=builder /install /usr/local
 COPY --from=builder /usr/share/zoneinfo/Etc/UTC /etc/localtime
 RUN echo "Etc/UTC" > /etc/timezone
 
-# bash is installed for more convenient debugging.
-RUN apk --no-cache add bash
+
 
 # copy payload code only
 COPY main.py ./

--- a/airbyte-integrations/connectors/source-appsflyer/Dockerfile
+++ b/airbyte-integrations/connectors/source-appsflyer/Dockerfile
@@ -1,5 +1,8 @@
 FROM python:3.9.11-alpine3.15 as base
 
+# alwyays update dependencies
+RUN apk update && apk upgrade -a
+
 # build and load all requirements
 FROM base as builder
 WORKDIR /airbyte/integration_code
@@ -24,8 +27,7 @@ COPY --from=builder /install /usr/local
 COPY --from=builder /usr/share/zoneinfo/Etc/UTC /etc/localtime
 RUN echo "Etc/UTC" > /etc/timezone
 
-# bash is installed for more convenient debugging.
-RUN apk --no-cache add bash
+
 
 # copy payload code only
 COPY main.py ./

--- a/airbyte-integrations/connectors/source-appstore-singer/Dockerfile
+++ b/airbyte-integrations/connectors/source-appstore-singer/Dockerfile
@@ -1,13 +1,16 @@
 FROM python:3.9.11-alpine3.15 as base
 
+# alwyays update dependencies
+RUN apk update && apk upgrade -a
+
 # build and load all requirements
 FROM base as builder
 WORKDIR /airbyte/integration_code
 
-# upgrade pip to the latest version
+# upgrade pip and install libs
 RUN apk --no-cache upgrade \
     && pip install --upgrade pip \
-    && apk --no-cache add tzdata build-base libffi-dev openssl-dev
+    && apk --no-cache add tzdata build-base bash libffi-dev openssl-dev
 
 
 COPY setup.py ./
@@ -24,8 +27,7 @@ COPY --from=builder /install /usr/local
 COPY --from=builder /usr/share/zoneinfo/Etc/UTC /etc/localtime
 RUN echo "Etc/UTC" > /etc/timezone
 
-# bash is installed for more convenient debugging.
-RUN apk --no-cache add bash
+
 
 # copy payload code only
 COPY main.py ./

--- a/airbyte-integrations/connectors/source-asana/Dockerfile
+++ b/airbyte-integrations/connectors/source-asana/Dockerfile
@@ -1,7 +1,12 @@
-FROM python:3.9-slim
+FROM python:3.9.11-alpine3.15 as base
 
-# Bash is installed for more convenient debugging.
-RUN apt-get update && apt-get install -y bash && rm -rf /var/lib/apt/lists/*
+# alwyays update dependencies
+RUN apk update && apk upgrade -a
+
+# upgrade pip and install libs
+RUN apk --no-cache upgrade \
+    && pip install --upgrade pip \
+    && apk --no-cache add tzdata build-base bash
 
 WORKDIR /airbyte/integration_code
 COPY source_asana ./source_asana

--- a/airbyte-integrations/connectors/source-ashby/Dockerfile
+++ b/airbyte-integrations/connectors/source-ashby/Dockerfile
@@ -4,10 +4,10 @@ FROM --platform=linux/amd64 python:3.9.11-alpine3.15 as base
 FROM base as builder
 WORKDIR /airbyte/integration_code
 
-# upgrade pip to the latest version
+# upgrade pip and install libs
 RUN apk --no-cache upgrade \
     && pip install --upgrade pip \
-    && apk --no-cache add tzdata build-base
+    && apk --no-cache add tzdata build-base bash
 
 
 COPY setup.py ./
@@ -24,8 +24,7 @@ COPY --from=builder /install /usr/local
 COPY --from=builder /usr/share/zoneinfo/Etc/UTC /etc/localtime
 RUN echo "Etc/UTC" > /etc/timezone
 
-# bash is installed for more convenient debugging.
-RUN apk --no-cache add bash
+
 
 # copy payload code only
 COPY main.py ./

--- a/airbyte-integrations/connectors/source-auth0/Dockerfile
+++ b/airbyte-integrations/connectors/source-auth0/Dockerfile
@@ -1,13 +1,16 @@
-FROM python:3.9.13-alpine3.15 as base
+FROM python:3.9.11-alpine3.15 as base
+
+# alwyays update dependencies
+RUN apk update && apk upgrade -a
 
 # build and load all requirements
 FROM base as builder
 WORKDIR /airbyte/integration_code
 
-# upgrade pip to the latest version
+# upgrade pip and install libs
 RUN apk --no-cache upgrade \
     && pip install --upgrade pip \
-    && apk --no-cache add tzdata build-base
+    && apk --no-cache add tzdata build-base bash
 
 
 COPY setup.py ./
@@ -24,8 +27,7 @@ COPY --from=builder /install /usr/local
 COPY --from=builder /usr/share/zoneinfo/Etc/UTC /etc/localtime
 RUN echo "Etc/UTC" > /etc/timezone
 
-# bash is installed for more convenient debugging.
-RUN apk --no-cache add bash
+
 
 # copy payload code only
 COPY main.py ./

--- a/airbyte-integrations/connectors/source-aws-cloudtrail/Dockerfile
+++ b/airbyte-integrations/connectors/source-aws-cloudtrail/Dockerfile
@@ -1,7 +1,12 @@
-FROM python:3.9-slim
+FROM python:3.9.11-alpine3.15 as base
 
-# Bash is installed for more convenient debugging.
-RUN apt-get update && apt-get install -y bash && rm -rf /var/lib/apt/lists/*
+# alwyays update dependencies
+RUN apk update && apk upgrade -a
+
+# upgrade pip and install libs
+RUN apk --no-cache upgrade \
+    && pip install --upgrade pip \
+    && apk --no-cache add tzdata build-base bash
 
 ENV AIRBYTE_ENTRYPOINT "python /airbyte/integration_code/main.py"
 

--- a/airbyte-integrations/connectors/source-azure-table/Dockerfile
+++ b/airbyte-integrations/connectors/source-azure-table/Dockerfile
@@ -1,13 +1,16 @@
 FROM python:3.9.11-alpine3.15 as base
 
+# alwyays update dependencies
+RUN apk update && apk upgrade -a
+
 # build and load all requirements
 FROM base as builder
 WORKDIR /airbyte/integration_code
 
-# upgrade pip to the latest version
+# upgrade pip and install libs
 RUN apk --no-cache upgrade \
     && pip install --upgrade pip \
-    && apk --no-cache add tzdata build-base
+    && apk --no-cache add tzdata build-base bash
 
 
 COPY setup.py ./
@@ -24,8 +27,7 @@ COPY --from=builder /install /usr/local
 COPY --from=builder /usr/share/zoneinfo/Etc/UTC /etc/localtime
 RUN echo "Etc/UTC" > /etc/timezone
 
-# bash is installed for more convenient debugging.
-RUN apk --no-cache add bash
+
 
 # copy payload code only
 COPY main.py ./

--- a/airbyte-integrations/connectors/source-babelforce/Dockerfile
+++ b/airbyte-integrations/connectors/source-babelforce/Dockerfile
@@ -1,13 +1,16 @@
 FROM python:3.9.11-alpine3.15 as base
 
+# alwyays update dependencies
+RUN apk update && apk upgrade -a
+
 # build and load all requirements
 FROM base as builder
 WORKDIR /airbyte/integration_code
 
-# upgrade pip to the latest version
+# upgrade pip and install libs
 RUN apk --no-cache upgrade \
     && pip install --upgrade pip \
-    && apk --no-cache add tzdata build-base
+    && apk --no-cache add tzdata build-base bash
 
 
 COPY setup.py ./
@@ -24,8 +27,7 @@ COPY --from=builder /install /usr/local
 COPY --from=builder /usr/share/zoneinfo/Etc/UTC /etc/localtime
 RUN echo "Etc/UTC" > /etc/timezone
 
-# bash is installed for more convenient debugging.
-RUN apk --no-cache add bash
+
 
 # copy payload code only
 COPY main.py ./

--- a/airbyte-integrations/connectors/source-bamboo-hr/Dockerfile
+++ b/airbyte-integrations/connectors/source-bamboo-hr/Dockerfile
@@ -1,7 +1,12 @@
-FROM python:3.9-slim
+FROM python:3.9.11-alpine3.15 as base
 
-# Bash is installed for more convenient debugging.
-RUN apt-get update && apt-get install -y bash && rm -rf /var/lib/apt/lists/*
+# alwyays update dependencies
+RUN apk update && apk upgrade -a
+
+# upgrade pip and install libs
+RUN apk --no-cache upgrade \
+    && pip install --upgrade pip \
+    && apk --no-cache add tzdata build-base bash
 
 WORKDIR /airbyte/integration_code
 COPY source_bamboo_hr ./source_bamboo_hr

--- a/airbyte-integrations/connectors/source-bigcommerce/Dockerfile
+++ b/airbyte-integrations/connectors/source-bigcommerce/Dockerfile
@@ -1,7 +1,12 @@
-FROM python:3.9-slim
+FROM python:3.9.11-alpine3.15 as base
 
-# Bash is installed for more convenient debugging.
-RUN apt-get update && apt-get install -y bash && rm -rf /var/lib/apt/lists/*
+# alwyays update dependencies
+RUN apk update && apk upgrade -a
+
+# upgrade pip and install libs
+RUN apk --no-cache upgrade \
+    && pip install --upgrade pip \
+    && apk --no-cache add tzdata build-base bash
 
 WORKDIR /airbyte/integration_code
 COPY source_bigcommerce ./source_bigcommerce

--- a/airbyte-integrations/connectors/source-bing-ads/Dockerfile
+++ b/airbyte-integrations/connectors/source-bing-ads/Dockerfile
@@ -1,7 +1,12 @@
-FROM python:3.9-slim
+FROM python:3.9.11-alpine3.15 as base
 
-# Bash is installed for more convenient debugging.
-RUN apt-get update && apt-get install -y bash && rm -rf /var/lib/apt/lists/*
+# alwyays update dependencies
+RUN apk update && apk upgrade -a
+
+# upgrade pip and install libs
+RUN apk --no-cache upgrade \
+    && pip install --upgrade pip \
+    && apk --no-cache add tzdata build-base bash
 
 WORKDIR /airbyte/integration_code
 COPY source_bing_ads ./source_bing_ads

--- a/airbyte-integrations/connectors/source-braintree/Dockerfile
+++ b/airbyte-integrations/connectors/source-braintree/Dockerfile
@@ -1,7 +1,12 @@
-FROM python:3.9-slim
+FROM python:3.9.11-alpine3.15 as base
 
-# Bash is installed for more convenient debugging.
-RUN apt-get update && apt-get install -y bash && rm -rf /var/lib/apt/lists/*
+# alwyays update dependencies
+RUN apk update && apk upgrade -a
+
+# upgrade pip and install libs
+RUN apk --no-cache upgrade \
+    && pip install --upgrade pip \
+    && apk --no-cache add tzdata build-base bash
 
 WORKDIR /airbyte/integration_code
 COPY source_braintree ./source_braintree

--- a/airbyte-integrations/connectors/source-braze/Dockerfile
+++ b/airbyte-integrations/connectors/source-braze/Dockerfile
@@ -1,13 +1,16 @@
 FROM python:3.9.11-alpine3.15 as base
 
+# alwyays update dependencies
+RUN apk update && apk upgrade -a
+
 # build and load all requirements
 FROM base as builder
 WORKDIR /airbyte/integration_code
 
-# upgrade pip to the latest version
+# upgrade pip and install libs
 RUN apk --no-cache upgrade \
     && pip install --upgrade pip \
-    && apk --no-cache add tzdata build-base
+    && apk --no-cache add tzdata build-base bash
 
 
 COPY setup.py ./
@@ -24,8 +27,7 @@ COPY --from=builder /install /usr/local
 COPY --from=builder /usr/share/zoneinfo/Etc/UTC /etc/localtime
 RUN echo "Etc/UTC" > /etc/timezone
 
-# bash is installed for more convenient debugging.
-RUN apk --no-cache add bash
+
 
 # copy payload code only
 COPY main.py ./

--- a/airbyte-integrations/connectors/source-breezometer/Dockerfile
+++ b/airbyte-integrations/connectors/source-breezometer/Dockerfile
@@ -1,13 +1,16 @@
 FROM python:3.9.11-alpine3.15 as base
 
+# alwyays update dependencies
+RUN apk update && apk upgrade -a
+
 # build and load all requirements
 FROM base as builder
 WORKDIR /airbyte/integration_code
 
-# upgrade pip to the latest version
+# upgrade pip and install libs
 RUN apk --no-cache upgrade \
     && pip install --upgrade pip \
-    && apk --no-cache add tzdata build-base
+    && apk --no-cache add tzdata build-base bash
 
 
 COPY setup.py ./
@@ -24,8 +27,7 @@ COPY --from=builder /install /usr/local
 COPY --from=builder /usr/share/zoneinfo/Etc/UTC /etc/localtime
 RUN echo "Etc/UTC" > /etc/timezone
 
-# bash is installed for more convenient debugging.
-RUN apk --no-cache add bash
+
 
 # copy payload code only
 COPY main.py ./

--- a/airbyte-integrations/connectors/source-callrail/Dockerfile
+++ b/airbyte-integrations/connectors/source-callrail/Dockerfile
@@ -1,13 +1,16 @@
 FROM python:3.9.11-alpine3.15 as base
 
+# alwyays update dependencies
+RUN apk update && apk upgrade -a
+
 # build and load all requirements
 FROM base as builder
 WORKDIR /airbyte/integration_code
 
-# upgrade pip to the latest version
+# upgrade pip and install libs
 RUN apk --no-cache upgrade \
     && pip install --upgrade pip \
-    && apk --no-cache add tzdata build-base
+    && apk --no-cache add tzdata build-base bash
 
 
 COPY setup.py ./
@@ -24,8 +27,7 @@ COPY --from=builder /install /usr/local
 COPY --from=builder /usr/share/zoneinfo/Etc/UTC /etc/localtime
 RUN echo "Etc/UTC" > /etc/timezone
 
-# bash is installed for more convenient debugging.
-RUN apk --no-cache add bash
+
 
 # copy payload code only
 COPY main.py ./

--- a/airbyte-integrations/connectors/source-cart/Dockerfile
+++ b/airbyte-integrations/connectors/source-cart/Dockerfile
@@ -1,4 +1,7 @@
 FROM python:3.9.11-alpine3.15 as base
+
+# alwyays update dependencies
+RUN apk update && apk upgrade -a
 FROM base as builder
 
 

--- a/airbyte-integrations/connectors/source-chargebee/Dockerfile
+++ b/airbyte-integrations/connectors/source-chargebee/Dockerfile
@@ -1,7 +1,12 @@
-FROM python:3.9-slim
+FROM python:3.9.11-alpine3.15 as base
 
-# Bash is installed for more convenient debugging.
-RUN apt-get update && apt-get install -y bash && rm -rf /var/lib/apt/lists/*
+# alwyays update dependencies
+RUN apk update && apk upgrade -a
+
+# upgrade pip and install libs
+RUN apk --no-cache upgrade \
+    && pip install --upgrade pip \
+    && apk --no-cache add tzdata build-base bash
 
 ENV AIRBYTE_ENTRYPOINT "python /airbyte/integration_code/main.py"
 

--- a/airbyte-integrations/connectors/source-chargify/Dockerfile
+++ b/airbyte-integrations/connectors/source-chargify/Dockerfile
@@ -1,13 +1,16 @@
 FROM python:3.9.11-alpine3.15 as base
 
+# alwyays update dependencies
+RUN apk update && apk upgrade -a
+
 # build and load all requirements
 FROM base as builder
 WORKDIR /airbyte/integration_code
 
-# upgrade pip to the latest version
+# upgrade pip and install libs
 RUN apk --no-cache upgrade \
     && pip install --upgrade pip \
-    && apk --no-cache add tzdata build-base
+    && apk --no-cache add tzdata build-base bash
 
 
 COPY setup.py ./
@@ -24,8 +27,7 @@ COPY --from=builder /install /usr/local
 COPY --from=builder /usr/share/zoneinfo/Etc/UTC /etc/localtime
 RUN echo "Etc/UTC" > /etc/timezone
 
-# bash is installed for more convenient debugging.
-RUN apk --no-cache add bash
+
 
 # copy payload code only
 COPY main.py ./

--- a/airbyte-integrations/connectors/source-chartmogul/Dockerfile
+++ b/airbyte-integrations/connectors/source-chartmogul/Dockerfile
@@ -1,13 +1,16 @@
 FROM python:3.9.11-alpine3.15 as base
 
+# alwyays update dependencies
+RUN apk update && apk upgrade -a
+
 # build and load all requirements
 FROM base as builder
 WORKDIR /airbyte/integration_code
 
-# upgrade pip to the latest version
+# upgrade pip and install libs
 RUN apk --no-cache upgrade \
     && pip install --upgrade pip \
-    && apk --no-cache add tzdata build-base
+    && apk --no-cache add tzdata build-base bash
 
 
 COPY setup.py ./
@@ -24,8 +27,7 @@ COPY --from=builder /install /usr/local
 COPY --from=builder /usr/share/zoneinfo/Etc/UTC /etc/localtime
 RUN echo "Etc/UTC" > /etc/timezone
 
-# bash is installed for more convenient debugging.
-RUN apk --no-cache add bash
+
 
 # copy payload code only
 COPY main.py ./

--- a/airbyte-integrations/connectors/source-clickup-api/Dockerfile
+++ b/airbyte-integrations/connectors/source-clickup-api/Dockerfile
@@ -1,13 +1,16 @@
 FROM python:3.9.11-alpine3.15 as base
 
+# alwyays update dependencies
+RUN apk update && apk upgrade -a
+
 # build and load all requirements
 FROM base as builder
 WORKDIR /airbyte/integration_code
 
-# upgrade pip to the latest version
+# upgrade pip and install libs
 RUN apk --no-cache upgrade \
     && pip install --upgrade pip \
-    && apk --no-cache add tzdata build-base
+    && apk --no-cache add tzdata build-base bash
 
 
 COPY setup.py ./
@@ -24,8 +27,7 @@ COPY --from=builder /install /usr/local
 COPY --from=builder /usr/share/zoneinfo/Etc/UTC /etc/localtime
 RUN echo "Etc/UTC" > /etc/timezone
 
-# bash is installed for more convenient debugging.
-RUN apk --no-cache add bash
+
 
 # copy payload code only
 COPY main.py ./

--- a/airbyte-integrations/connectors/source-clockify/Dockerfile
+++ b/airbyte-integrations/connectors/source-clockify/Dockerfile
@@ -1,13 +1,16 @@
-FROM python:3.9.13-alpine3.15 as base
+FROM python:3.9.11-alpine3.15 as base
+
+# alwyays update dependencies
+RUN apk update && apk upgrade -a
 
 # build and load all requirements
 FROM base as builder
 WORKDIR /airbyte/integration_code
 
-# upgrade pip to the latest version
+# upgrade pip and install libs
 RUN apk --no-cache upgrade \
     && pip install --upgrade pip \
-    && apk --no-cache add tzdata build-base
+    && apk --no-cache add tzdata build-base bash
 
 
 COPY setup.py ./
@@ -24,8 +27,7 @@ COPY --from=builder /install /usr/local
 COPY --from=builder /usr/share/zoneinfo/Etc/UTC /etc/localtime
 RUN echo "Etc/UTC" > /etc/timezone
 
-# bash is installed for more convenient debugging.
-RUN apk --no-cache add bash
+
 
 # copy payload code only
 COPY main.py ./

--- a/airbyte-integrations/connectors/source-close-com/Dockerfile
+++ b/airbyte-integrations/connectors/source-close-com/Dockerfile
@@ -1,7 +1,12 @@
-FROM python:3.9-slim
+FROM python:3.9.11-alpine3.15 as base
 
-# Bash is installed for more convenient debugging.
-RUN apt-get update && apt-get install -y bash && rm -rf /var/lib/apt/lists/*
+# alwyays update dependencies
+RUN apk update && apk upgrade -a
+
+# upgrade pip and install libs
+RUN apk --no-cache upgrade \
+    && pip install --upgrade pip \
+    && apk --no-cache add tzdata build-base bash
 
 WORKDIR /airbyte/integration_code
 COPY source_close_com ./source_close_com

--- a/airbyte-integrations/connectors/source-coda/Dockerfile
+++ b/airbyte-integrations/connectors/source-coda/Dockerfile
@@ -1,13 +1,16 @@
-FROM python:3.9.13-alpine3.15 as base
+FROM python:3.9.11-alpine3.15 as base
+
+# alwyays update dependencies
+RUN apk update && apk upgrade -a
 
 # build and load all requirements
 FROM base as builder
 WORKDIR /airbyte/integration_code
 
-# upgrade pip to the latest version
+# upgrade pip and install libs
 RUN apk --no-cache upgrade \
     && pip install --upgrade pip \
-    && apk --no-cache add tzdata build-base
+    && apk --no-cache add tzdata build-base bash
 
 
 COPY setup.py ./
@@ -24,8 +27,7 @@ COPY --from=builder /install /usr/local
 COPY --from=builder /usr/share/zoneinfo/Etc/UTC /etc/localtime
 RUN echo "Etc/UTC" > /etc/timezone
 
-# bash is installed for more convenient debugging.
-RUN apk --no-cache add bash
+
 
 # copy payload code only
 COPY main.py ./

--- a/airbyte-integrations/connectors/source-coin-api/Dockerfile
+++ b/airbyte-integrations/connectors/source-coin-api/Dockerfile
@@ -1,13 +1,16 @@
 FROM python:3.9.11-alpine3.15 as base
 
+# alwyays update dependencies
+RUN apk update && apk upgrade -a
+
 # build and load all requirements
 FROM base as builder
 WORKDIR /airbyte/integration_code
 
-# upgrade pip to the latest version
+# upgrade pip and install libs
 RUN apk --no-cache upgrade \
     && pip install --upgrade pip \
-    && apk --no-cache add tzdata build-base
+    && apk --no-cache add tzdata build-base bash
 
 
 COPY setup.py ./
@@ -24,8 +27,7 @@ COPY --from=builder /install /usr/local
 COPY --from=builder /usr/share/zoneinfo/Etc/UTC /etc/localtime
 RUN echo "Etc/UTC" > /etc/timezone
 
-# bash is installed for more convenient debugging.
-RUN apk --no-cache add bash
+
 
 # copy payload code only
 COPY main.py ./

--- a/airbyte-integrations/connectors/source-coingecko-coins/Dockerfile
+++ b/airbyte-integrations/connectors/source-coingecko-coins/Dockerfile
@@ -1,13 +1,16 @@
 FROM python:3.9.11-alpine3.15 as base
 
+# alwyays update dependencies
+RUN apk update && apk upgrade -a
+
 # build and load all requirements
 FROM base as builder
 WORKDIR /airbyte/integration_code
 
-# upgrade pip to the latest version
+# upgrade pip and install libs
 RUN apk --no-cache upgrade \
     && pip install --upgrade pip \
-    && apk --no-cache add tzdata build-base
+    && apk --no-cache add tzdata build-base bash
 
 
 COPY setup.py ./
@@ -24,8 +27,7 @@ COPY --from=builder /install /usr/local
 COPY --from=builder /usr/share/zoneinfo/Etc/UTC /etc/localtime
 RUN echo "Etc/UTC" > /etc/timezone
 
-# bash is installed for more convenient debugging.
-RUN apk --no-cache add bash
+
 
 # copy payload code only
 COPY main.py ./

--- a/airbyte-integrations/connectors/source-coinmarketcap/Dockerfile
+++ b/airbyte-integrations/connectors/source-coinmarketcap/Dockerfile
@@ -1,13 +1,16 @@
 FROM python:3.9.11-alpine3.15 as base
 
+# alwyays update dependencies
+RUN apk update && apk upgrade -a
+
 # build and load all requirements
 FROM base as builder
 WORKDIR /airbyte/integration_code
 
-# upgrade pip to the latest version
+# upgrade pip and install libs
 RUN apk --no-cache upgrade \
     && pip install --upgrade pip \
-    && apk --no-cache add tzdata build-base
+    && apk --no-cache add tzdata build-base bash
 
 
 COPY setup.py ./
@@ -24,8 +27,7 @@ COPY --from=builder /install /usr/local
 COPY --from=builder /usr/share/zoneinfo/Etc/UTC /etc/localtime
 RUN echo "Etc/UTC" > /etc/timezone
 
-# bash is installed for more convenient debugging.
-RUN apk --no-cache add bash
+
 
 # copy payload code only
 COPY main.py ./

--- a/airbyte-integrations/connectors/source-commcare/Dockerfile
+++ b/airbyte-integrations/connectors/source-commcare/Dockerfile
@@ -1,4 +1,7 @@
-FROM python:3.9.15-slim-bullseye as base
+FROM python:3.9.11-alpine3.15 as base
+
+# alwyays update dependencies
+RUN apk update && apk upgrade -a
 
 # build and load all requirements
 FROM base as builder

--- a/airbyte-integrations/connectors/source-commcare/Dockerfile
+++ b/airbyte-integrations/connectors/source-commcare/Dockerfile
@@ -7,12 +7,13 @@ RUN apk update && apk upgrade -a
 FROM base as builder
 WORKDIR /airbyte/integration_code
 
-# upgrade pip to the latest version
-RUN apt-get update && apt-get install -y && rm -rf /var/lib/apt/lists/* \
+# upgrade pip and install libs
+RUN apk --no-cache upgrade \
     && pip install --upgrade pip \
-    && python3 -m pip install --upgrade setuptools
+    && apk --no-cache add tzdata build-base bash
 
-RUN DEBIAN_FRONTEND=noninteractive TZ=Etc/UTC apt-get -y install tzdata
+# Install custom deps for this connector
+RUN apk add libffi-dev musl-dev g++
 
 COPY setup.py ./
 # install necessary packages to a temporary folder
@@ -27,9 +28,6 @@ COPY --from=builder /install /usr/local
 # add default timezone settings
 COPY --from=builder /usr/share/zoneinfo/Etc/UTC /etc/localtime
 RUN echo "Etc/UTC" > /etc/timezone
-
-# bash is installed for more convenient debugging.
-# RUN apk --no-cache add bash
 
 # copy payload code only
 COPY main.py ./

--- a/airbyte-integrations/connectors/source-commercetools/Dockerfile
+++ b/airbyte-integrations/connectors/source-commercetools/Dockerfile
@@ -1,5 +1,8 @@
 FROM python:3.9.11-alpine3.15 as base
 
+# alwyays update dependencies
+RUN apk update && apk upgrade -a
+
 # build and load all requirements
 FROM base as builder
 WORKDIR /airbyte/integration_code
@@ -24,8 +27,7 @@ COPY --from=builder /install /usr/local
 COPY --from=builder /usr/share/zoneinfo/Etc/UTC /etc/localtime
 RUN echo "Etc/UTC" > /etc/timezone
 
-# bash is installed for more convenient debugging.
-RUN apk --no-cache add bash
+
 
 # copy payload code only
 COPY main.py ./

--- a/airbyte-integrations/connectors/source-configcat/Dockerfile
+++ b/airbyte-integrations/connectors/source-configcat/Dockerfile
@@ -1,13 +1,16 @@
 FROM python:3.9.11-alpine3.15 as base
 
+# alwyays update dependencies
+RUN apk update && apk upgrade -a
+
 # build and load all requirements
 FROM base as builder
 WORKDIR /airbyte/integration_code
 
-# upgrade pip to the latest version
+# upgrade pip and install libs
 RUN apk --no-cache upgrade \
     && pip install --upgrade pip \
-    && apk --no-cache add tzdata build-base
+    && apk --no-cache add tzdata build-base bash
 
 
 COPY setup.py ./
@@ -24,8 +27,7 @@ COPY --from=builder /install /usr/local
 COPY --from=builder /usr/share/zoneinfo/Etc/UTC /etc/localtime
 RUN echo "Etc/UTC" > /etc/timezone
 
-# bash is installed for more convenient debugging.
-RUN apk --no-cache add bash
+
 
 # copy payload code only
 COPY main.py ./

--- a/airbyte-integrations/connectors/source-confluence/Dockerfile
+++ b/airbyte-integrations/connectors/source-confluence/Dockerfile
@@ -1,13 +1,16 @@
 FROM python:3.9.11-alpine3.15 as base
 
+# alwyays update dependencies
+RUN apk update && apk upgrade -a
+
 # build and load all requirements
 FROM base as builder
 WORKDIR /airbyte/integration_code
 
-# upgrade pip to the latest version
+# upgrade pip and install libs
 RUN apk --no-cache upgrade \
     && pip install --upgrade pip \
-    && apk --no-cache add tzdata build-base
+    && apk --no-cache add tzdata build-base bash
 
 
 COPY setup.py ./
@@ -24,8 +27,7 @@ COPY --from=builder /install /usr/local
 COPY --from=builder /usr/share/zoneinfo/Etc/UTC /etc/localtime
 RUN echo "Etc/UTC" > /etc/timezone
 
-# bash is installed for more convenient debugging.
-RUN apk --no-cache add bash
+
 
 # copy payload code only
 COPY main.py ./

--- a/airbyte-integrations/connectors/source-convertkit/Dockerfile
+++ b/airbyte-integrations/connectors/source-convertkit/Dockerfile
@@ -1,13 +1,16 @@
 FROM python:3.9.11-alpine3.15 as base
 
+# alwyays update dependencies
+RUN apk update && apk upgrade -a
+
 # build and load all requirements
 FROM base as builder
 WORKDIR /airbyte/integration_code
 
-# upgrade pip to the latest version
+# upgrade pip and install libs
 RUN apk --no-cache upgrade \
     && pip install --upgrade pip \
-    && apk --no-cache add tzdata build-base
+    && apk --no-cache add tzdata build-base bash
 
 
 COPY setup.py ./
@@ -24,8 +27,7 @@ COPY --from=builder /install /usr/local
 COPY --from=builder /usr/share/zoneinfo/Etc/UTC /etc/localtime
 RUN echo "Etc/UTC" > /etc/timezone
 
-# bash is installed for more convenient debugging.
-RUN apk --no-cache add bash
+
 
 # copy payload code only
 COPY main.py ./

--- a/airbyte-integrations/connectors/source-convex/Dockerfile
+++ b/airbyte-integrations/connectors/source-convex/Dockerfile
@@ -1,13 +1,16 @@
-FROM python:3.9.13-alpine3.15 as base
+FROM python:3.9.11-alpine3.15 as base
+
+# alwyays update dependencies
+RUN apk update && apk upgrade -a
 
 # build and load all requirements
 FROM base as builder
 WORKDIR /airbyte/integration_code
 
-# upgrade pip to the latest version
+# upgrade pip and install libs
 RUN apk --no-cache upgrade \
     && pip install --upgrade pip \
-    && apk --no-cache add tzdata build-base
+    && apk --no-cache add tzdata build-base bash
 
 
 COPY setup.py ./
@@ -24,8 +27,7 @@ COPY --from=builder /install /usr/local
 COPY --from=builder /usr/share/zoneinfo/Etc/UTC /etc/localtime
 RUN echo "Etc/UTC" > /etc/timezone
 
-# bash is installed for more convenient debugging.
-RUN apk --no-cache add bash
+
 
 # copy payload code only
 COPY main.py ./

--- a/airbyte-integrations/connectors/source-copper/Dockerfile
+++ b/airbyte-integrations/connectors/source-copper/Dockerfile
@@ -1,13 +1,16 @@
-FROM python:3.9.13-alpine3.15 as base
+FROM python:3.9.11-alpine3.15 as base
+
+# alwyays update dependencies
+RUN apk update && apk upgrade -a
 
 # build and load all requirements
 FROM base as builder
 WORKDIR /airbyte/integration_code
 
-# upgrade pip to the latest version
+# upgrade pip and install libs
 RUN apk --no-cache upgrade \
     && pip install --upgrade pip \
-    && apk --no-cache add tzdata build-base
+    && apk --no-cache add tzdata build-base bash
 
 
 COPY setup.py ./
@@ -24,8 +27,7 @@ COPY --from=builder /install /usr/local
 COPY --from=builder /usr/share/zoneinfo/Etc/UTC /etc/localtime
 RUN echo "Etc/UTC" > /etc/timezone
 
-# bash is installed for more convenient debugging.
-RUN apk --no-cache add bash
+
 
 # copy payload code only
 COPY main.py ./

--- a/airbyte-integrations/connectors/source-courier/Dockerfile
+++ b/airbyte-integrations/connectors/source-courier/Dockerfile
@@ -1,13 +1,16 @@
 FROM python:3.9.11-alpine3.15 as base
 
+# alwyays update dependencies
+RUN apk update && apk upgrade -a
+
 # build and load all requirements
 FROM base as builder
 WORKDIR /airbyte/integration_code
 
-# upgrade pip to the latest version
+# upgrade pip and install libs
 RUN apk --no-cache upgrade \
     && pip install --upgrade pip \
-    && apk --no-cache add tzdata build-base
+    && apk --no-cache add tzdata build-base bash
 
 
 COPY setup.py ./
@@ -24,8 +27,7 @@ COPY --from=builder /install /usr/local
 COPY --from=builder /usr/share/zoneinfo/Etc/UTC /etc/localtime
 RUN echo "Etc/UTC" > /etc/timezone
 
-# bash is installed for more convenient debugging.
-RUN apk --no-cache add bash
+
 
 # copy payload code only
 COPY main.py ./

--- a/airbyte-integrations/connectors/source-datadog/Dockerfile
+++ b/airbyte-integrations/connectors/source-datadog/Dockerfile
@@ -1,7 +1,12 @@
-FROM python:3.9-slim
+FROM python:3.9.11-alpine3.15 as base
 
-# Bash is installed for more convenient debugging.
-RUN apt-get update && apt-get install -y bash && rm -rf /var/lib/apt/lists/*
+# alwyays update dependencies
+RUN apk update && apk upgrade -a
+
+# upgrade pip and install libs
+RUN apk --no-cache upgrade \
+    && pip install --upgrade pip \
+    && apk --no-cache add tzdata build-base bash
 
 WORKDIR /airbyte/integration_code
 COPY source_datadog ./source_datadog

--- a/airbyte-integrations/connectors/source-datascope/Dockerfile
+++ b/airbyte-integrations/connectors/source-datascope/Dockerfile
@@ -1,13 +1,16 @@
 FROM python:3.9.11-alpine3.15 as base
 
+# alwyays update dependencies
+RUN apk update && apk upgrade -a
+
 # build and load all requirements
 FROM base as builder
 WORKDIR /airbyte/integration_code
 
-# upgrade pip to the latest version
+# upgrade pip and install libs
 RUN apk --no-cache upgrade \
     && pip install --upgrade pip \
-    && apk --no-cache add tzdata build-base
+    && apk --no-cache add tzdata build-base bash
 
 
 COPY setup.py ./
@@ -24,8 +27,7 @@ COPY --from=builder /install /usr/local
 COPY --from=builder /usr/share/zoneinfo/Etc/UTC /etc/localtime
 RUN echo "Etc/UTC" > /etc/timezone
 
-# bash is installed for more convenient debugging.
-RUN apk --no-cache add bash
+
 
 # copy payload code only
 COPY main.py ./

--- a/airbyte-integrations/connectors/source-delighted/Dockerfile
+++ b/airbyte-integrations/connectors/source-delighted/Dockerfile
@@ -1,7 +1,12 @@
-FROM python:3.9-slim
+FROM python:3.9.11-alpine3.15 as base
 
-# Bash is installed for more convenient debugging.
-RUN apt-get update && apt-get install -y bash && rm -rf /var/lib/apt/lists/*
+# alwyays update dependencies
+RUN apk update && apk upgrade -a
+
+# upgrade pip and install libs
+RUN apk --no-cache upgrade \
+    && pip install --upgrade pip \
+    && apk --no-cache add tzdata build-base bash
 
 WORKDIR /airbyte/integration_code
 COPY setup.py ./

--- a/airbyte-integrations/connectors/source-dixa/Dockerfile
+++ b/airbyte-integrations/connectors/source-dixa/Dockerfile
@@ -1,7 +1,12 @@
-FROM python:3.9-slim
+FROM python:3.9.11-alpine3.15 as base
 
-# Bash is installed for more convenient debugging.
-RUN apt-get update && apt-get install -y bash && rm -rf /var/lib/apt/lists/*
+# alwyays update dependencies
+RUN apk update && apk upgrade -a
+
+# upgrade pip and install libs
+RUN apk --no-cache upgrade \
+    && pip install --upgrade pip \
+    && apk --no-cache add tzdata build-base bash
 
 WORKDIR /airbyte/integration_code
 COPY source_dixa ./source_dixa

--- a/airbyte-integrations/connectors/source-dockerhub/Dockerfile
+++ b/airbyte-integrations/connectors/source-dockerhub/Dockerfile
@@ -1,13 +1,16 @@
 FROM python:3.9.11-alpine3.15 as base
 
+# alwyays update dependencies
+RUN apk update && apk upgrade -a
+
 # build and load all requirements
 FROM base as builder
 WORKDIR /airbyte/integration_code
 
-# upgrade pip to the latest version
+# upgrade pip and install libs
 RUN apk --no-cache upgrade \
     && pip install --upgrade pip \
-    && apk --no-cache add tzdata build-base
+    && apk --no-cache add tzdata build-base bash
 
 
 COPY setup.py ./
@@ -24,8 +27,7 @@ COPY --from=builder /install /usr/local
 COPY --from=builder /usr/share/zoneinfo/Etc/UTC /etc/localtime
 RUN echo "Etc/UTC" > /etc/timezone
 
-# bash is installed for more convenient debugging.
-RUN apk --no-cache add bash
+
 
 # copy payload code only
 COPY main.py ./

--- a/airbyte-integrations/connectors/source-dremio/Dockerfile
+++ b/airbyte-integrations/connectors/source-dremio/Dockerfile
@@ -1,13 +1,16 @@
 FROM python:3.9.11-alpine3.15 as base
 
+# alwyays update dependencies
+RUN apk update && apk upgrade -a
+
 # build and load all requirements
 FROM base as builder
 WORKDIR /airbyte/integration_code
 
-# upgrade pip to the latest version
+# upgrade pip and install libs
 RUN apk --no-cache upgrade \
     && pip install --upgrade pip \
-    && apk --no-cache add tzdata build-base
+    && apk --no-cache add tzdata build-base bash
 
 
 COPY setup.py ./
@@ -24,8 +27,7 @@ COPY --from=builder /install /usr/local
 COPY --from=builder /usr/share/zoneinfo/Etc/UTC /etc/localtime
 RUN echo "Etc/UTC" > /etc/timezone
 
-# bash is installed for more convenient debugging.
-RUN apk --no-cache add bash
+
 
 # copy payload code only
 COPY main.py ./

--- a/airbyte-integrations/connectors/source-drift/Dockerfile
+++ b/airbyte-integrations/connectors/source-drift/Dockerfile
@@ -1,13 +1,16 @@
 FROM python:3.9.11-alpine3.15 as base
 
+# alwyays update dependencies
+RUN apk update && apk upgrade -a
+
 # build and load all requirements
 FROM base as builder
 WORKDIR /airbyte/integration_code
 
-# upgrade pip to the latest version
+# upgrade pip and install libs
 RUN apk --no-cache upgrade \
     && pip install --upgrade pip \
-    && apk --no-cache add tzdata build-base
+    && apk --no-cache add tzdata build-base bash
 
 
 COPY setup.py ./
@@ -24,8 +27,7 @@ COPY --from=builder /install /usr/local
 COPY --from=builder /usr/share/zoneinfo/Etc/UTC /etc/localtime
 RUN echo "Etc/UTC" > /etc/timezone
 
-# bash is installed for more convenient debugging.
-RUN apk --no-cache add bash
+
 
 # copy payload code only
 COPY main.py ./

--- a/airbyte-integrations/connectors/source-dv-360/Dockerfile
+++ b/airbyte-integrations/connectors/source-dv-360/Dockerfile
@@ -1,13 +1,16 @@
-FROM python:3.7.11-alpine3.14 as base
+FROM python:3.9.11-alpine3.15 as base
+
+# alwyays update dependencies
+RUN apk update && apk upgrade -a
 
 # build and load all requirements
 FROM base as builder
 WORKDIR /airbyte/integration_code
 
-# upgrade pip to the latest version
+# upgrade pip and install libs
 RUN apk --no-cache upgrade \
     && pip install --upgrade pip \
-    && apk --no-cache add tzdata build-base
+    && apk --no-cache add tzdata build-base bash
 
 
 COPY setup.py ./
@@ -24,8 +27,7 @@ COPY --from=builder /install /usr/local
 COPY --from=builder /usr/share/zoneinfo/Etc/UTC /etc/localtime
 RUN echo "Etc/UTC" > /etc/timezone
 
-# bash is installed for more convenient debugging.
-RUN apk --no-cache add bash
+
 
 # copy payload code only
 COPY main.py ./

--- a/airbyte-integrations/connectors/source-emailoctopus/Dockerfile
+++ b/airbyte-integrations/connectors/source-emailoctopus/Dockerfile
@@ -1,13 +1,16 @@
 FROM python:3.9.11-alpine3.15 as base
 
+# alwyays update dependencies
+RUN apk update && apk upgrade -a
+
 # build and load all requirements
 FROM base as builder
 WORKDIR /airbyte/integration_code
 
-# upgrade pip to the latest version
+# upgrade pip and install libs
 RUN apk --no-cache upgrade \
     && pip install --upgrade pip \
-    && apk --no-cache add tzdata build-base
+    && apk --no-cache add tzdata build-base bash
 
 
 COPY setup.py ./
@@ -24,8 +27,7 @@ COPY --from=builder /install /usr/local
 COPY --from=builder /usr/share/zoneinfo/Etc/UTC /etc/localtime
 RUN echo "Etc/UTC" > /etc/timezone
 
-# bash is installed for more convenient debugging.
-RUN apk --no-cache add bash
+
 
 # copy payload code only
 COPY main.py ./

--- a/airbyte-integrations/connectors/source-exchange-rates/Dockerfile
+++ b/airbyte-integrations/connectors/source-exchange-rates/Dockerfile
@@ -1,7 +1,12 @@
-FROM python:3.9-slim
+FROM python:3.9.11-alpine3.15 as base
 
-# Bash is installed for more convenient debugging.
-RUN apt-get update && apt-get install -y bash && rm -rf /var/lib/apt/lists/*
+# alwyays update dependencies
+RUN apk update && apk upgrade -a
+
+# upgrade pip and install libs
+RUN apk --no-cache upgrade \
+    && pip install --upgrade pip \
+    && apk --no-cache add tzdata build-base bash
 
 ENV CODE_PATH="source_exchange_rates"
 ENV WORKDIR=/airbyte/integration_code

--- a/airbyte-integrations/connectors/source-facebook-marketing/Dockerfile
+++ b/airbyte-integrations/connectors/source-facebook-marketing/Dockerfile
@@ -1,7 +1,12 @@
-FROM python:3.9-slim
+FROM python:3.9.11-alpine3.15 as base
 
-# Bash is installed for more convenient debugging.
-RUN apt-get update && apt-get install -y bash && rm -rf /var/lib/apt/lists/*
+# alwyays update dependencies
+RUN apk update && apk upgrade -a
+
+# upgrade pip and install libs
+RUN apk --no-cache upgrade \
+    && pip install --upgrade pip \
+    && apk --no-cache add tzdata build-base bash
 
 WORKDIR /airbyte/integration_code
 COPY source_facebook_marketing ./source_facebook_marketing

--- a/airbyte-integrations/connectors/source-facebook-pages/Dockerfile
+++ b/airbyte-integrations/connectors/source-facebook-pages/Dockerfile
@@ -1,13 +1,16 @@
 FROM python:3.9.11-alpine3.15 as base
 
+# alwyays update dependencies
+RUN apk update && apk upgrade -a
+
 # build and load all requirements
 FROM base as builder
 WORKDIR /airbyte/integration_code
 
-# upgrade pip to the latest version
+# upgrade pip and install libs
 RUN apk --no-cache upgrade \
     && pip install --upgrade pip \
-    && apk --no-cache add tzdata build-base
+    && apk --no-cache add tzdata build-base bash
 
 
 COPY setup.py ./
@@ -24,8 +27,7 @@ COPY --from=builder /install /usr/local
 COPY --from=builder /usr/share/zoneinfo/Etc/UTC /etc/localtime
 RUN echo "Etc/UTC" > /etc/timezone
 
-# bash is installed for more convenient debugging.
-RUN apk --no-cache add bash
+
 
 # copy payload code only
 COPY main.py ./

--- a/airbyte-integrations/connectors/source-faker/Dockerfile
+++ b/airbyte-integrations/connectors/source-faker/Dockerfile
@@ -1,13 +1,16 @@
 FROM python:3.9.11-alpine3.15 as base
 
+# alwyays update dependencies
+RUN apk update && apk upgrade -a
+
 # build and load all requirements
 FROM base as builder
 WORKDIR /airbyte/integration_code
 
-# upgrade pip to the latest version
+# upgrade pip and install libs
 RUN apk --no-cache upgrade \
     && pip install --upgrade pip \
-    && apk --no-cache add tzdata build-base
+    && apk --no-cache add tzdata build-base bash
 
 
 COPY setup.py ./
@@ -24,8 +27,7 @@ COPY --from=builder /install /usr/local
 COPY --from=builder /usr/share/zoneinfo/Etc/UTC /etc/localtime
 RUN echo "Etc/UTC" > /etc/timezone
 
-# bash is installed for more convenient debugging.
-RUN apk --no-cache add bash
+
 
 # copy payload code only
 COPY main.py ./

--- a/airbyte-integrations/connectors/source-fastbill/Dockerfile
+++ b/airbyte-integrations/connectors/source-fastbill/Dockerfile
@@ -1,13 +1,16 @@
-FROM python:3.9.13-alpine3.15 as base
+FROM python:3.9.11-alpine3.15 as base
+
+# alwyays update dependencies
+RUN apk update && apk upgrade -a
 
 # build and load all requirements
 FROM base as builder
 WORKDIR /airbyte/integration_code
 
-# upgrade pip to the latest version
+# upgrade pip and install libs
 RUN apk --no-cache upgrade \
     && pip install --upgrade pip \
-    && apk --no-cache add tzdata build-base
+    && apk --no-cache add tzdata build-base bash
 
 
 COPY setup.py ./
@@ -24,8 +27,7 @@ COPY --from=builder /install /usr/local
 COPY --from=builder /usr/share/zoneinfo/Etc/UTC /etc/localtime
 RUN echo "Etc/UTC" > /etc/timezone
 
-# bash is installed for more convenient debugging.
-RUN apk --no-cache add bash
+
 
 # copy payload code only
 COPY main.py ./

--- a/airbyte-integrations/connectors/source-fauna/Dockerfile
+++ b/airbyte-integrations/connectors/source-fauna/Dockerfile
@@ -1,13 +1,16 @@
 FROM python:3.9.11-alpine3.15 as base
 
+# alwyays update dependencies
+RUN apk update && apk upgrade -a
+
 # build and load all requirements
 FROM base as builder
 WORKDIR /airbyte/integration_code
 
-# upgrade pip to the latest version
+# upgrade pip and install libs
 RUN apk --no-cache upgrade \
     && pip install --upgrade pip \
-    && apk --no-cache add tzdata build-base
+    && apk --no-cache add tzdata build-base bash
 
 
 COPY setup.py ./
@@ -24,8 +27,7 @@ COPY --from=builder /install /usr/local
 COPY --from=builder /usr/share/zoneinfo/Etc/UTC /etc/localtime
 RUN echo "Etc/UTC" > /etc/timezone
 
-# bash is installed for more convenient debugging.
-RUN apk --no-cache add bash
+
 
 # copy payload code only
 COPY main.py ./

--- a/airbyte-integrations/connectors/source-file/Dockerfile
+++ b/airbyte-integrations/connectors/source-file/Dockerfile
@@ -1,4 +1,7 @@
-FROM python:3.9-slim as base
+FROM python:3.9.11-alpine3.15 as base
+
+# alwyays update dependencies
+RUN apk update && apk upgrade -a
 FROM base as builder
 
 RUN apt-get update

--- a/airbyte-integrations/connectors/source-file/Dockerfile
+++ b/airbyte-integrations/connectors/source-file/Dockerfile
@@ -2,9 +2,14 @@ FROM python:3.9.11-alpine3.15 as base
 
 # alwyays update dependencies
 RUN apk update && apk upgrade -a
+
 FROM base as builder
 
-RUN apt-get update
+# upgrade pip and install libs
+RUN apk --no-cache upgrade \
+    && pip install --upgrade pip \
+    && apk --no-cache add tzdata build-base bash
+
 WORKDIR /airbyte/integration_code
 COPY setup.py ./
 RUN pip install --prefix=/install .

--- a/airbyte-integrations/connectors/source-firebolt/Dockerfile
+++ b/airbyte-integrations/connectors/source-firebolt/Dockerfile
@@ -1,13 +1,16 @@
 FROM python:3.9.11-alpine3.15 as base
 
+# alwyays update dependencies
+RUN apk update && apk upgrade -a
+
 # build and load all requirements
 FROM base as builder
 WORKDIR /airbyte/integration_code
 
-# upgrade pip to the latest version
+# upgrade pip and install libs
 RUN apk --no-cache upgrade \
     && pip install --upgrade pip \
-    && apk --no-cache add tzdata build-base
+    && apk --no-cache add tzdata build-base bash
 
 RUN apk add libffi-dev
 
@@ -25,8 +28,7 @@ COPY --from=builder /install /usr/local
 COPY --from=builder /usr/share/zoneinfo/Etc/UTC /etc/localtime
 RUN echo "Etc/UTC" > /etc/timezone
 
-# bash is installed for more convenient debugging.
-RUN apk --no-cache add bash
+
 
 # copy payload code only
 COPY main.py ./

--- a/airbyte-integrations/connectors/source-flexport/Dockerfile
+++ b/airbyte-integrations/connectors/source-flexport/Dockerfile
@@ -1,13 +1,16 @@
 FROM python:3.9.11-alpine3.15 as base
 
+# alwyays update dependencies
+RUN apk update && apk upgrade -a
+
 # build and load all requirements
 FROM base as builder
 WORKDIR /airbyte/integration_code
 
-# upgrade pip to the latest version
+# upgrade pip and install libs
 RUN apk --no-cache upgrade \
     && pip install --upgrade pip \
-    && apk --no-cache add tzdata build-base
+    && apk --no-cache add tzdata build-base bash
 
 
 COPY setup.py ./
@@ -24,8 +27,7 @@ COPY --from=builder /install /usr/local
 COPY --from=builder /usr/share/zoneinfo/Etc/UTC /etc/localtime
 RUN echo "Etc/UTC" > /etc/timezone
 
-# bash is installed for more convenient debugging.
-RUN apk --no-cache add bash
+
 
 # copy payload code only
 COPY main.py ./

--- a/airbyte-integrations/connectors/source-freshcaller/Dockerfile
+++ b/airbyte-integrations/connectors/source-freshcaller/Dockerfile
@@ -1,13 +1,16 @@
 FROM python:3.9.11-alpine3.15 as base
 
+# alwyays update dependencies
+RUN apk update && apk upgrade -a
+
 # build and load all requirements
 FROM base as builder
 WORKDIR /airbyte/integration_code
 
-# upgrade pip to the latest version
+# upgrade pip and install libs
 RUN apk --no-cache upgrade \
     && pip install --upgrade pip \
-    && apk --no-cache add tzdata build-base
+    && apk --no-cache add tzdata build-base bash
 
 
 COPY setup.py ./
@@ -24,8 +27,7 @@ COPY --from=builder /install /usr/local
 COPY --from=builder /usr/share/zoneinfo/Etc/UTC /etc/localtime
 RUN echo "Etc/UTC" > /etc/timezone
 
-# bash is installed for more convenient debugging.
-RUN apk --no-cache add bash
+
 
 # copy payload code only
 COPY main.py ./

--- a/airbyte-integrations/connectors/source-freshdesk/Dockerfile
+++ b/airbyte-integrations/connectors/source-freshdesk/Dockerfile
@@ -1,13 +1,16 @@
 FROM python:3.9.11-alpine3.15 as base
 
+# alwyays update dependencies
+RUN apk update && apk upgrade -a
+
 # build and load all requirements
 FROM base as builder
 WORKDIR /airbyte/integration_code
 
-# upgrade pip to the latest version
+# upgrade pip and install libs
 RUN apk --no-cache upgrade \
     && pip install --upgrade pip \
-    && apk --no-cache add tzdata build-base
+    && apk --no-cache add tzdata build-base bash
 
 
 COPY setup.py ./
@@ -24,8 +27,7 @@ COPY --from=builder /install /usr/local
 COPY --from=builder /usr/share/zoneinfo/Etc/UTC /etc/localtime
 RUN echo "Etc/UTC" > /etc/timezone
 
-# bash is installed for more convenient debugging.
-RUN apk --no-cache add bash
+
 
 # copy payload code only
 COPY main.py ./

--- a/airbyte-integrations/connectors/source-freshsales/Dockerfile
+++ b/airbyte-integrations/connectors/source-freshsales/Dockerfile
@@ -1,13 +1,16 @@
 FROM python:3.9.11-alpine3.15 as base
 
+# alwyays update dependencies
+RUN apk update && apk upgrade -a
+
 # build and load all requirements
 FROM base as builder
 WORKDIR /airbyte/integration_code
 
-# upgrade pip to the latest version
+# upgrade pip and install libs
 RUN apk --no-cache upgrade \
     && pip install --upgrade pip \
-    && apk --no-cache add tzdata build-base
+    && apk --no-cache add tzdata build-base bash
 
 
 COPY setup.py ./
@@ -24,8 +27,7 @@ COPY --from=builder /install /usr/local
 COPY --from=builder /usr/share/zoneinfo/Etc/UTC /etc/localtime
 RUN echo "Etc/UTC" > /etc/timezone
 
-# bash is installed for more convenient debugging.
-RUN apk --no-cache add bash
+
 
 # copy payload code only
 COPY main.py ./

--- a/airbyte-integrations/connectors/source-freshservice/Dockerfile
+++ b/airbyte-integrations/connectors/source-freshservice/Dockerfile
@@ -1,7 +1,12 @@
-FROM python:3.9-slim
+FROM python:3.9.11-alpine3.15 as base
 
-# Bash is installed for more convenient debugging.
-RUN apt-get update && apt-get install -y bash && rm -rf /var/lib/apt/lists/*
+# alwyays update dependencies
+RUN apk update && apk upgrade -a
+
+# upgrade pip and install libs
+RUN apk --no-cache upgrade \
+    && pip install --upgrade pip \
+    && apk --no-cache add tzdata build-base bash
 
 WORKDIR /airbyte/integration_code
 COPY source_freshservice ./source_freshservice

--- a/airbyte-integrations/connectors/source-genesys/Dockerfile
+++ b/airbyte-integrations/connectors/source-genesys/Dockerfile
@@ -1,13 +1,16 @@
-FROM python:3.9.13-alpine3.15 as base
+FROM python:3.9.11-alpine3.15 as base
+
+# alwyays update dependencies
+RUN apk update && apk upgrade -a
 
 # build and load all requirements
 FROM base as builder
 WORKDIR /airbyte/integration_code
 
-# upgrade pip to the latest version
+# upgrade pip and install libs
 RUN apk --no-cache upgrade \
     && pip install --upgrade pip \
-    && apk --no-cache add tzdata build-base
+    && apk --no-cache add tzdata build-base bash
 
 
 COPY setup.py ./
@@ -24,8 +27,7 @@ COPY --from=builder /install /usr/local
 COPY --from=builder /usr/share/zoneinfo/Etc/UTC /etc/localtime
 RUN echo "Etc/UTC" > /etc/timezone
 
-# bash is installed for more convenient debugging.
-RUN apk --no-cache add bash
+
 
 # copy payload code only
 COPY main.py ./

--- a/airbyte-integrations/connectors/source-getlago/Dockerfile
+++ b/airbyte-integrations/connectors/source-getlago/Dockerfile
@@ -1,13 +1,16 @@
 FROM python:3.9.11-alpine3.15 as base
 
+# alwyays update dependencies
+RUN apk update && apk upgrade -a
+
 # build and load all requirements
 FROM base as builder
 WORKDIR /airbyte/integration_code
 
-# upgrade pip to the latest version
+# upgrade pip and install libs
 RUN apk --no-cache upgrade \
     && pip install --upgrade pip \
-    && apk --no-cache add tzdata build-base
+    && apk --no-cache add tzdata build-base bash
 
 
 COPY setup.py ./
@@ -24,8 +27,7 @@ COPY --from=builder /install /usr/local
 COPY --from=builder /usr/share/zoneinfo/Etc/UTC /etc/localtime
 RUN echo "Etc/UTC" > /etc/timezone
 
-# bash is installed for more convenient debugging.
-RUN apk --no-cache add bash
+
 
 # copy payload code only
 COPY main.py ./

--- a/airbyte-integrations/connectors/source-github/Dockerfile
+++ b/airbyte-integrations/connectors/source-github/Dockerfile
@@ -1,7 +1,12 @@
-FROM python:3.9-slim
+FROM python:3.9.11-alpine3.15 as base
 
-# Bash is installed for more convenient debugging.
-RUN apt-get update && apt-get install -y bash && rm -rf /var/lib/apt/lists/*
+# alwyays update dependencies
+RUN apk update && apk upgrade -a
+
+# upgrade pip and install libs
+RUN apk --no-cache upgrade \
+    && pip install --upgrade pip \
+    && apk --no-cache add tzdata build-base bash
 
 WORKDIR /airbyte/integration_code
 COPY source_github ./source_github

--- a/airbyte-integrations/connectors/source-gitlab/Dockerfile
+++ b/airbyte-integrations/connectors/source-gitlab/Dockerfile
@@ -1,7 +1,12 @@
-FROM python:3.9-slim
+FROM python:3.9.11-alpine3.15 as base
 
-# Bash is installed for more convenient debugging.
-RUN apt-get update && apt-get install -y bash && rm -rf /var/lib/apt/lists/*
+# alwyays update dependencies
+RUN apk update && apk upgrade -a
+
+# upgrade pip and install libs
+RUN apk --no-cache upgrade \
+    && pip install --upgrade pip \
+    && apk --no-cache add tzdata build-base bash
 
 ENV AIRBYTE_ENTRYPOINT "python /airbyte/integration_code/main.py"
 

--- a/airbyte-integrations/connectors/source-glassfrog/Dockerfile
+++ b/airbyte-integrations/connectors/source-glassfrog/Dockerfile
@@ -1,13 +1,16 @@
 FROM python:3.9.11-alpine3.15 as base
 
+# alwyays update dependencies
+RUN apk update && apk upgrade -a
+
 # build and load all requirements
 FROM base as builder
 WORKDIR /airbyte/integration_code
 
-# upgrade pip to the latest version
+# upgrade pip and install libs
 RUN apk --no-cache upgrade \
     && pip install --upgrade pip \
-    && apk --no-cache add tzdata build-base
+    && apk --no-cache add tzdata build-base bash
 
 
 COPY setup.py ./
@@ -24,8 +27,7 @@ COPY --from=builder /install /usr/local
 COPY --from=builder /usr/share/zoneinfo/Etc/UTC /etc/localtime
 RUN echo "Etc/UTC" > /etc/timezone
 
-# bash is installed for more convenient debugging.
-RUN apk --no-cache add bash
+
 
 # copy payload code only
 COPY main.py ./

--- a/airbyte-integrations/connectors/source-gnews/Dockerfile
+++ b/airbyte-integrations/connectors/source-gnews/Dockerfile
@@ -1,13 +1,16 @@
 FROM python:3.9.11-alpine3.15 as base
 
+# alwyays update dependencies
+RUN apk update && apk upgrade -a
+
 # build and load all requirements
 FROM base as builder
 WORKDIR /airbyte/integration_code
 
-# upgrade pip to the latest version
+# upgrade pip and install libs
 RUN apk --no-cache upgrade \
     && pip install --upgrade pip \
-    && apk --no-cache add tzdata build-base
+    && apk --no-cache add tzdata build-base bash
 
 
 COPY setup.py ./
@@ -24,8 +27,7 @@ COPY --from=builder /install /usr/local
 COPY --from=builder /usr/share/zoneinfo/Etc/UTC /etc/localtime
 RUN echo "Etc/UTC" > /etc/timezone
 
-# bash is installed for more convenient debugging.
-RUN apk --no-cache add bash
+
 
 # copy payload code only
 COPY main.py ./

--- a/airbyte-integrations/connectors/source-gocardless/Dockerfile
+++ b/airbyte-integrations/connectors/source-gocardless/Dockerfile
@@ -1,13 +1,16 @@
 FROM python:3.9.11-alpine3.15 as base
 
+# alwyays update dependencies
+RUN apk update && apk upgrade -a
+
 # build and load all requirements
 FROM base as builder
 WORKDIR /airbyte/integration_code
 
-# upgrade pip to the latest version
+# upgrade pip and install libs
 RUN apk --no-cache upgrade \
     && pip install --upgrade pip \
-    && apk --no-cache add tzdata build-base
+    && apk --no-cache add tzdata build-base bash
 
 
 COPY setup.py ./
@@ -24,8 +27,7 @@ COPY --from=builder /install /usr/local
 COPY --from=builder /usr/share/zoneinfo/Etc/UTC /etc/localtime
 RUN echo "Etc/UTC" > /etc/timezone
 
-# bash is installed for more convenient debugging.
-RUN apk --no-cache add bash
+
 
 # copy payload code only
 COPY main.py ./

--- a/airbyte-integrations/connectors/source-gong/Dockerfile
+++ b/airbyte-integrations/connectors/source-gong/Dockerfile
@@ -1,13 +1,16 @@
 FROM python:3.9.11-alpine3.15 as base
 
+# alwyays update dependencies
+RUN apk update && apk upgrade -a
+
 # build and load all requirements
 FROM base as builder
 WORKDIR /airbyte/integration_code
 
-# upgrade pip to the latest version
+# upgrade pip and install libs
 RUN apk --no-cache upgrade \
     && pip install --upgrade pip \
-    && apk --no-cache add tzdata build-base
+    && apk --no-cache add tzdata build-base bash
 
 
 COPY setup.py ./
@@ -24,8 +27,7 @@ COPY --from=builder /install /usr/local
 COPY --from=builder /usr/share/zoneinfo/Etc/UTC /etc/localtime
 RUN echo "Etc/UTC" > /etc/timezone
 
-# bash is installed for more convenient debugging.
-RUN apk --no-cache add bash
+
 
 # copy payload code only
 COPY main.py ./

--- a/airbyte-integrations/connectors/source-google-ads/Dockerfile
+++ b/airbyte-integrations/connectors/source-google-ads/Dockerfile
@@ -1,7 +1,12 @@
-FROM python:3.9-slim
+FROM python:3.9.11-alpine3.15 as base
 
-# Bash is installed for more convenient debugging.
-RUN apt-get update && apt-get install -y bash && rm -rf /var/lib/apt/lists/*
+# alwyays update dependencies
+RUN apk update && apk upgrade -a
+
+# upgrade pip and install libs
+RUN apk --no-cache upgrade \
+    && pip install --upgrade pip \
+    && apk --no-cache add tzdata build-base bash
 
 ENV AIRBYTE_ENTRYPOINT "python /airbyte/integration_code/main.py"
 

--- a/airbyte-integrations/connectors/source-google-analytics-data-api/Dockerfile
+++ b/airbyte-integrations/connectors/source-google-analytics-data-api/Dockerfile
@@ -1,4 +1,7 @@
-FROM python:3.9.11-slim as base
+FROM python:3.9.11-alpine3.15 as base
+
+# alwyays update dependencies
+RUN apk update && apk upgrade -a
 
 # build and load all requirements
 FROM base as builder

--- a/airbyte-integrations/connectors/source-google-analytics-v4/Dockerfile
+++ b/airbyte-integrations/connectors/source-google-analytics-v4/Dockerfile
@@ -1,7 +1,12 @@
-FROM python:3.9-slim
+FROM python:3.9.11-alpine3.15 as base
 
-# Bash is installed for more convenient debugging.
-RUN apt-get update && apt-get install -y bash && rm -rf /var/lib/apt/lists/*
+# alwyays update dependencies
+RUN apk update && apk upgrade -a
+
+# upgrade pip and install libs
+RUN apk --no-cache upgrade \
+    && pip install --upgrade pip \
+    && apk --no-cache add tzdata build-base bash
 
 WORKDIR /airbyte/integration_code
 COPY setup.py ./

--- a/airbyte-integrations/connectors/source-google-directory/Dockerfile
+++ b/airbyte-integrations/connectors/source-google-directory/Dockerfile
@@ -1,13 +1,16 @@
 FROM python:3.9.11-alpine3.15 as base
 
+# alwyays update dependencies
+RUN apk update && apk upgrade -a
+
 # build and load all requirements
 FROM base as builder
 WORKDIR /airbyte/integration_code
 
-# upgrade pip to the latest version
+# upgrade pip and install libs
 RUN apk --no-cache upgrade \
     && pip install --upgrade pip \
-    && apk --no-cache add tzdata build-base
+    && apk --no-cache add tzdata build-base bash
 
 
 COPY setup.py ./
@@ -24,8 +27,7 @@ COPY --from=builder /install /usr/local
 COPY --from=builder /usr/share/zoneinfo/Etc/UTC /etc/localtime
 RUN echo "Etc/UTC" > /etc/timezone
 
-# bash is installed for more convenient debugging.
-RUN apk --no-cache add bash
+
 
 # copy payload code only
 COPY main.py ./

--- a/airbyte-integrations/connectors/source-google-pagespeed-insights/Dockerfile
+++ b/airbyte-integrations/connectors/source-google-pagespeed-insights/Dockerfile
@@ -1,13 +1,16 @@
 FROM python:3.9.11-alpine3.15 as base
 
+# alwyays update dependencies
+RUN apk update && apk upgrade -a
+
 # build and load all requirements
 FROM base as builder
 WORKDIR /airbyte/integration_code
 
-# upgrade pip to the latest version
+# upgrade pip and install libs
 RUN apk --no-cache upgrade \
     && pip install --upgrade pip \
-    && apk --no-cache add tzdata build-base
+    && apk --no-cache add tzdata build-base bash
 
 
 COPY setup.py ./
@@ -24,8 +27,7 @@ COPY --from=builder /install /usr/local
 COPY --from=builder /usr/share/zoneinfo/Etc/UTC /etc/localtime
 RUN echo "Etc/UTC" > /etc/timezone
 
-# bash is installed for more convenient debugging.
-RUN apk --no-cache add bash
+
 
 # copy payload code only
 COPY main.py ./

--- a/airbyte-integrations/connectors/source-google-search-console/Dockerfile
+++ b/airbyte-integrations/connectors/source-google-search-console/Dockerfile
@@ -1,7 +1,12 @@
-FROM python:3.9-slim
+FROM python:3.9.11-alpine3.15 as base
 
-# Bash is installed for more convenient debugging.
-RUN apt-get update && apt-get install -y bash && rm -rf /var/lib/apt/lists/*
+# alwyays update dependencies
+RUN apk update && apk upgrade -a
+
+# upgrade pip and install libs
+RUN apk --no-cache upgrade \
+    && pip install --upgrade pip \
+    && apk --no-cache add tzdata build-base bash
 
 WORKDIR /airbyte/integration_code
 COPY source_google_search_console ./source_google_search_console

--- a/airbyte-integrations/connectors/source-google-search-console/credentials/Dockerfile
+++ b/airbyte-integrations/connectors/source-google-search-console/credentials/Dockerfile
@@ -1,6 +1,11 @@
-FROM python:3.9-slim
+FROM python:3.9.11-alpine3.15 as base
 
-# Bash is installed for more convenient debugging.
-RUN apt-get update && apt-get install -y bash && rm -rf /var/lib/apt/lists/*
+# alwyays update dependencies
+RUN apk update && apk upgrade -a
+
+# upgrade pip and install libs
+RUN apk --no-cache upgrade \
+    && pip install --upgrade pip \
+    && apk --no-cache add tzdata build-base bash
 COPY . ./
 RUN pip install . --use-feature=in-tree-build

--- a/airbyte-integrations/connectors/source-google-sheets/Dockerfile
+++ b/airbyte-integrations/connectors/source-google-sheets/Dockerfile
@@ -1,13 +1,16 @@
 FROM python:3.9.11-alpine3.15 as base
 
+# alwyays update dependencies
+RUN apk update && apk upgrade -a
+
 # build and load all requirements
 FROM base as builder
 WORKDIR /airbyte/integration_code
 
-# upgrade pip to the latest version
+# upgrade pip and install libs
 RUN apk --no-cache upgrade \
     && pip install --upgrade pip \
-    && apk --no-cache add tzdata build-base
+    && apk --no-cache add tzdata build-base bash
 
 
 COPY setup.py ./
@@ -24,8 +27,7 @@ COPY --from=builder /install /usr/local
 COPY --from=builder /usr/share/zoneinfo/Etc/UTC /etc/localtime
 RUN echo "Etc/UTC" > /etc/timezone
 
-# bash is installed for more convenient debugging.
-RUN apk --no-cache add bash
+
 
 # copy payload code only
 COPY main.py ./

--- a/airbyte-integrations/connectors/source-google-webfonts/Dockerfile
+++ b/airbyte-integrations/connectors/source-google-webfonts/Dockerfile
@@ -1,13 +1,16 @@
 FROM python:3.9.11-alpine3.15 as base
 
+# alwyays update dependencies
+RUN apk update && apk upgrade -a
+
 # build and load all requirements
 FROM base as builder
 WORKDIR /airbyte/integration_code
 
-# upgrade pip to the latest version
+# upgrade pip and install libs
 RUN apk --no-cache upgrade \
     && pip install --upgrade pip \
-    && apk --no-cache add tzdata build-base
+    && apk --no-cache add tzdata build-base bash
 
 
 COPY setup.py ./
@@ -24,8 +27,7 @@ COPY --from=builder /install /usr/local
 COPY --from=builder /usr/share/zoneinfo/Etc/UTC /etc/localtime
 RUN echo "Etc/UTC" > /etc/timezone
 
-# bash is installed for more convenient debugging.
-RUN apk --no-cache add bash
+
 
 # copy payload code only
 COPY main.py ./

--- a/airbyte-integrations/connectors/source-google-workspace-admin-reports/Dockerfile
+++ b/airbyte-integrations/connectors/source-google-workspace-admin-reports/Dockerfile
@@ -1,13 +1,16 @@
 FROM python:3.9.11-alpine3.15 as base
 
+# alwyays update dependencies
+RUN apk update && apk upgrade -a
+
 # build and load all requirements
 FROM base as builder
 WORKDIR /airbyte/integration_code
 
-# upgrade pip to the latest version
+# upgrade pip and install libs
 RUN apk --no-cache upgrade \
     && pip install --upgrade pip \
-    && apk --no-cache add tzdata build-base
+    && apk --no-cache add tzdata build-base bash
 
 
 COPY setup.py ./
@@ -24,8 +27,7 @@ COPY --from=builder /install /usr/local
 COPY --from=builder /usr/share/zoneinfo/Etc/UTC /etc/localtime
 RUN echo "Etc/UTC" > /etc/timezone
 
-# bash is installed for more convenient debugging.
-RUN apk --no-cache add bash
+
 
 # copy payload code only
 COPY main.py ./

--- a/airbyte-integrations/connectors/source-greenhouse/Dockerfile
+++ b/airbyte-integrations/connectors/source-greenhouse/Dockerfile
@@ -1,7 +1,12 @@
-FROM python:3.9-slim
+FROM python:3.9.11-alpine3.15 as base
 
-# Bash is installed for more convenient debugging.
-RUN apt-get update && apt-get install -y bash && rm -rf /var/lib/apt/lists/*
+# alwyays update dependencies
+RUN apk update && apk upgrade -a
+
+# upgrade pip and install libs
+RUN apk --no-cache upgrade \
+    && pip install --upgrade pip \
+    && apk --no-cache add tzdata build-base bash
 
 WORKDIR /airbyte/integration_code
 COPY setup.py ./

--- a/airbyte-integrations/connectors/source-gridly/Dockerfile
+++ b/airbyte-integrations/connectors/source-gridly/Dockerfile
@@ -1,13 +1,16 @@
-FROM python:3.9.13-alpine3.15 as base
+FROM python:3.9.11-alpine3.15 as base
+
+# alwyays update dependencies
+RUN apk update && apk upgrade -a
 
 # build and load all requirements
 FROM base as builder
 WORKDIR /airbyte/integration_code
 
-# upgrade pip to the latest version
+# upgrade pip and install libs
 RUN apk --no-cache upgrade \
     && pip install --upgrade pip \
-    && apk --no-cache add tzdata build-base
+    && apk --no-cache add tzdata build-base bash
 
 
 COPY setup.py ./
@@ -24,8 +27,7 @@ COPY --from=builder /install /usr/local
 COPY --from=builder /usr/share/zoneinfo/Etc/UTC /etc/localtime
 RUN echo "Etc/UTC" > /etc/timezone
 
-# bash is installed for more convenient debugging.
-RUN apk --no-cache add bash
+
 
 # copy payload code only
 COPY main.py ./

--- a/airbyte-integrations/connectors/source-gutendex/Dockerfile
+++ b/airbyte-integrations/connectors/source-gutendex/Dockerfile
@@ -1,13 +1,16 @@
 FROM python:3.9.11-alpine3.15 as base
 
+# alwyays update dependencies
+RUN apk update && apk upgrade -a
+
 # build and load all requirements
 FROM base as builder
 WORKDIR /airbyte/integration_code
 
-# upgrade pip to the latest version
+# upgrade pip and install libs
 RUN apk --no-cache upgrade \
     && pip install --upgrade pip \
-    && apk --no-cache add tzdata build-base
+    && apk --no-cache add tzdata build-base bash
 
 
 COPY setup.py ./
@@ -24,8 +27,7 @@ COPY --from=builder /install /usr/local
 COPY --from=builder /usr/share/zoneinfo/Etc/UTC /etc/localtime
 RUN echo "Etc/UTC" > /etc/timezone
 
-# bash is installed for more convenient debugging.
-RUN apk --no-cache add bash
+
 
 # copy payload code only
 COPY main.py ./

--- a/airbyte-integrations/connectors/source-harvest/Dockerfile
+++ b/airbyte-integrations/connectors/source-harvest/Dockerfile
@@ -1,7 +1,12 @@
-FROM python:3.9-slim
+FROM python:3.9.11-alpine3.15 as base
 
-# Bash is installed for more convenient debugging.
-RUN apt-get update && apt-get install -y bash && rm -rf /var/lib/apt/lists/*
+# alwyays update dependencies
+RUN apk update && apk upgrade -a
+
+# upgrade pip and install libs
+RUN apk --no-cache upgrade \
+    && pip install --upgrade pip \
+    && apk --no-cache add tzdata build-base bash
 
 WORKDIR /airbyte/integration_code
 COPY source_harvest ./source_harvest

--- a/airbyte-integrations/connectors/source-hellobaton/Dockerfile
+++ b/airbyte-integrations/connectors/source-hellobaton/Dockerfile
@@ -1,13 +1,16 @@
 FROM python:3.9.11-alpine3.15 as base
 
+# alwyays update dependencies
+RUN apk update && apk upgrade -a
+
 # build and load all requirements
 FROM base as builder
 WORKDIR /airbyte/integration_code
 
-# upgrade pip to the latest version
+# upgrade pip and install libs
 RUN apk --no-cache upgrade \
     && pip install --upgrade pip \
-    && apk --no-cache add tzdata build-base
+    && apk --no-cache add tzdata build-base bash
 
 
 COPY setup.py ./
@@ -24,8 +27,7 @@ COPY --from=builder /install /usr/local
 COPY --from=builder /usr/share/zoneinfo/Etc/UTC /etc/localtime
 RUN echo "Etc/UTC" > /etc/timezone
 
-# bash is installed for more convenient debugging.
-RUN apk --no-cache add bash
+
 
 # copy payload code only
 COPY main.py ./

--- a/airbyte-integrations/connectors/source-hubplanner/Dockerfile
+++ b/airbyte-integrations/connectors/source-hubplanner/Dockerfile
@@ -1,7 +1,12 @@
-FROM python:3.9-slim
+FROM python:3.9.11-alpine3.15 as base
 
-# Bash is installed for more convenient debugging.
-RUN apt-get update && apt-get install -y bash && rm -rf /var/lib/apt/lists/*
+# alwyays update dependencies
+RUN apk update && apk upgrade -a
+
+# upgrade pip and install libs
+RUN apk --no-cache upgrade \
+    && pip install --upgrade pip \
+    && apk --no-cache add tzdata build-base bash
 
 WORKDIR /airbyte/integration_code
 COPY source_hubplanner ./source_hubplanner

--- a/airbyte-integrations/connectors/source-hubspot/Dockerfile
+++ b/airbyte-integrations/connectors/source-hubspot/Dockerfile
@@ -1,13 +1,16 @@
 FROM python:3.9.11-alpine3.15 as base
 
+# alwyays update dependencies
+RUN apk update && apk upgrade -a
+
 # build and load all requirements
 FROM base as builder
 WORKDIR /airbyte/integration_code
 
-# upgrade pip to the latest version
+# upgrade pip and install libs
 RUN apk --no-cache upgrade \
     && pip install --upgrade pip \
-    && apk --no-cache add tzdata build-base
+    && apk --no-cache add tzdata build-base bash
 
 COPY setup.py ./
 
@@ -24,8 +27,7 @@ COPY --from=builder /install /usr/local
 COPY --from=builder /usr/share/zoneinfo/Etc/UTC /etc/localtime
 RUN echo "Etc/UTC" > /etc/timezone
 
-# bash is installed for more convenient debugging.
-RUN apk --no-cache add bash
+
 
 # copy payload code only
 COPY main.py ./

--- a/airbyte-integrations/connectors/source-insightly/Dockerfile
+++ b/airbyte-integrations/connectors/source-insightly/Dockerfile
@@ -1,13 +1,16 @@
-FROM python:3.9.13-alpine3.15 as base
+FROM python:3.9.11-alpine3.15 as base
+
+# alwyays update dependencies
+RUN apk update && apk upgrade -a
 
 # build and load all requirements
 FROM base as builder
 WORKDIR /airbyte/integration_code
 
-# upgrade pip to the latest version
+# upgrade pip and install libs
 RUN apk --no-cache upgrade \
     && pip install --upgrade pip \
-    && apk --no-cache add tzdata build-base
+    && apk --no-cache add tzdata build-base bash
 
 
 COPY setup.py ./
@@ -24,8 +27,7 @@ COPY --from=builder /install /usr/local
 COPY --from=builder /usr/share/zoneinfo/Etc/UTC /etc/localtime
 RUN echo "Etc/UTC" > /etc/timezone
 
-# bash is installed for more convenient debugging.
-RUN apk --no-cache add bash
+
 
 # copy payload code only
 COPY main.py ./

--- a/airbyte-integrations/connectors/source-instagram/Dockerfile
+++ b/airbyte-integrations/connectors/source-instagram/Dockerfile
@@ -1,7 +1,12 @@
-FROM python:3.9-slim
+FROM python:3.9.11-alpine3.15 as base
 
-# Bash is installed for more convenient debugging.
-RUN apt-get update && apt-get install -y bash && rm -rf /var/lib/apt/lists/*
+# alwyays update dependencies
+RUN apk update && apk upgrade -a
+
+# upgrade pip and install libs
+RUN apk --no-cache upgrade \
+    && pip install --upgrade pip \
+    && apk --no-cache add tzdata build-base bash
 
 WORKDIR /airbyte/integration_code
 COPY source_instagram ./source_instagram

--- a/airbyte-integrations/connectors/source-instatus/Dockerfile
+++ b/airbyte-integrations/connectors/source-instatus/Dockerfile
@@ -1,13 +1,16 @@
 FROM python:3.9.11-alpine3.15 as base
 
+# alwyays update dependencies
+RUN apk update && apk upgrade -a
+
 # build and load all requirements
 FROM base as builder
 WORKDIR /airbyte/integration_code
 
-# upgrade pip to the latest version
+# upgrade pip and install libs
 RUN apk --no-cache upgrade \
     && pip install --upgrade pip \
-    && apk --no-cache add tzdata build-base
+    && apk --no-cache add tzdata build-base bash
 
 
 COPY setup.py ./
@@ -24,8 +27,7 @@ COPY --from=builder /install /usr/local
 COPY --from=builder /usr/share/zoneinfo/Etc/UTC /etc/localtime
 RUN echo "Etc/UTC" > /etc/timezone
 
-# bash is installed for more convenient debugging.
-RUN apk --no-cache add bash
+
 
 # copy payload code only
 COPY main.py ./

--- a/airbyte-integrations/connectors/source-intercom/Dockerfile
+++ b/airbyte-integrations/connectors/source-intercom/Dockerfile
@@ -1,5 +1,8 @@
 FROM python:3.9.11-alpine3.15 as base
 
+# alwyays update dependencies
+RUN apk update && apk upgrade -a
+
 # build and load all requirements
 FROM base as builder
 WORKDIR /airbyte/integration_code
@@ -25,8 +28,7 @@ COPY --from=builder /install /usr/local
 COPY --from=builder /usr/share/zoneinfo/Etc/UTC /etc/localtime
 RUN echo "Etc/UTC" > /etc/timezone
 
-# bash is installed for more convenient debugging.
-RUN apk --no-cache add bash
+
 
 # copy payload code only
 COPY main.py ./

--- a/airbyte-integrations/connectors/source-intruder/Dockerfile
+++ b/airbyte-integrations/connectors/source-intruder/Dockerfile
@@ -1,13 +1,16 @@
 FROM python:3.9.11-alpine3.15 as base
 
+# alwyays update dependencies
+RUN apk update && apk upgrade -a
+
 # build and load all requirements
 FROM base as builder
 WORKDIR /airbyte/integration_code
 
-# upgrade pip to the latest version
+# upgrade pip and install libs
 RUN apk --no-cache upgrade \
     && pip install --upgrade pip \
-    && apk --no-cache add tzdata build-base
+    && apk --no-cache add tzdata build-base bash
 
 
 COPY setup.py ./
@@ -24,8 +27,7 @@ COPY --from=builder /install /usr/local
 COPY --from=builder /usr/share/zoneinfo/Etc/UTC /etc/localtime
 RUN echo "Etc/UTC" > /etc/timezone
 
-# bash is installed for more convenient debugging.
-RUN apk --no-cache add bash
+
 
 # copy payload code only
 COPY main.py ./

--- a/airbyte-integrations/connectors/source-ip2whois/Dockerfile
+++ b/airbyte-integrations/connectors/source-ip2whois/Dockerfile
@@ -1,13 +1,16 @@
 FROM python:3.9.11-alpine3.15 as base
 
+# alwyays update dependencies
+RUN apk update && apk upgrade -a
+
 # build and load all requirements
 FROM base as builder
 WORKDIR /airbyte/integration_code
 
-# upgrade pip to the latest version
+# upgrade pip and install libs
 RUN apk --no-cache upgrade \
     && pip install --upgrade pip \
-    && apk --no-cache add tzdata build-base
+    && apk --no-cache add tzdata build-base bash
 
 
 COPY setup.py ./
@@ -24,8 +27,7 @@ COPY --from=builder /install /usr/local
 COPY --from=builder /usr/share/zoneinfo/Etc/UTC /etc/localtime
 RUN echo "Etc/UTC" > /etc/timezone
 
-# bash is installed for more convenient debugging.
-RUN apk --no-cache add bash
+
 
 # copy payload code only
 COPY main.py ./

--- a/airbyte-integrations/connectors/source-iterable/Dockerfile
+++ b/airbyte-integrations/connectors/source-iterable/Dockerfile
@@ -1,7 +1,12 @@
-FROM python:3.9-slim
+FROM python:3.9.11-alpine3.15 as base
 
-# Bash is installed for more convenient debugging.
-RUN apt-get update && apt-get install -y bash && rm -rf /var/lib/apt/lists/*
+# alwyays update dependencies
+RUN apk update && apk upgrade -a
+
+# upgrade pip and install libs
+RUN apk --no-cache upgrade \
+    && pip install --upgrade pip \
+    && apk --no-cache add tzdata build-base bash
 
 WORKDIR /airbyte/integration_code
 COPY source_iterable ./source_iterable

--- a/airbyte-integrations/connectors/source-jira/Dockerfile
+++ b/airbyte-integrations/connectors/source-jira/Dockerfile
@@ -1,7 +1,12 @@
-FROM python:3.9-slim
+FROM python:3.9.11-alpine3.15 as base
 
-# Bash is installed for more convenient debugging.
-RUN apt-get update && apt-get install -y bash && rm -rf /var/lib/apt/lists/*
+# alwyays update dependencies
+RUN apk update && apk upgrade -a
+
+# upgrade pip and install libs
+RUN apk --no-cache upgrade \
+    && pip install --upgrade pip \
+    && apk --no-cache add tzdata build-base bash
 
 WORKDIR /airbyte/integration_code
 COPY source_jira ./source_jira

--- a/airbyte-integrations/connectors/source-k6-cloud/Dockerfile
+++ b/airbyte-integrations/connectors/source-k6-cloud/Dockerfile
@@ -1,13 +1,16 @@
 FROM python:3.9.11-alpine3.15 as base
 
+# alwyays update dependencies
+RUN apk update && apk upgrade -a
+
 # build and load all requirements
 FROM base as builder
 WORKDIR /airbyte/integration_code
 
-# upgrade pip to the latest version
+# upgrade pip and install libs
 RUN apk --no-cache upgrade \
     && pip install --upgrade pip \
-    && apk --no-cache add tzdata build-base
+    && apk --no-cache add tzdata build-base bash
 
 
 COPY setup.py ./
@@ -24,8 +27,7 @@ COPY --from=builder /install /usr/local
 COPY --from=builder /usr/share/zoneinfo/Etc/UTC /etc/localtime
 RUN echo "Etc/UTC" > /etc/timezone
 
-# bash is installed for more convenient debugging.
-RUN apk --no-cache add bash
+
 
 # copy payload code only
 COPY main.py ./

--- a/airbyte-integrations/connectors/source-klarna/Dockerfile
+++ b/airbyte-integrations/connectors/source-klarna/Dockerfile
@@ -1,13 +1,16 @@
-FROM python:3.9.13-alpine3.15 as base
+FROM python:3.9.11-alpine3.15 as base
+
+# alwyays update dependencies
+RUN apk update && apk upgrade -a
 
 # build and load all requirements
 FROM base as builder
 WORKDIR /airbyte/integration_code
 
-# upgrade pip to the latest version
+# upgrade pip and install libs
 RUN apk --no-cache upgrade \
     && pip install --upgrade pip \
-    && apk --no-cache add tzdata build-base
+    && apk --no-cache add tzdata build-base bash
 
 
 COPY setup.py ./
@@ -24,8 +27,7 @@ COPY --from=builder /install /usr/local
 COPY --from=builder /usr/share/zoneinfo/Etc/UTC /etc/localtime
 RUN echo "Etc/UTC" > /etc/timezone
 
-# bash is installed for more convenient debugging.
-RUN apk --no-cache add bash
+
 
 # copy payload code only
 COPY main.py ./

--- a/airbyte-integrations/connectors/source-klaviyo/Dockerfile
+++ b/airbyte-integrations/connectors/source-klaviyo/Dockerfile
@@ -1,13 +1,16 @@
 FROM python:3.9.11-alpine3.15 as base
 
+# alwyays update dependencies
+RUN apk update && apk upgrade -a
+
 # build and load all requirements
 FROM base as builder
 WORKDIR /airbyte/integration_code
 
-# upgrade pip to the latest version
+# upgrade pip and install libs
 RUN apk --no-cache upgrade \
     && pip install --upgrade pip \
-    && apk --no-cache add tzdata build-base
+    && apk --no-cache add tzdata build-base bash
 
 
 COPY setup.py ./
@@ -24,8 +27,7 @@ COPY --from=builder /install /usr/local
 COPY --from=builder /usr/share/zoneinfo/Etc/UTC /etc/localtime
 RUN echo "Etc/UTC" > /etc/timezone
 
-# bash is installed for more convenient debugging.
-RUN apk --no-cache add bash
+
 
 # copy payload code only
 COPY main.py ./

--- a/airbyte-integrations/connectors/source-kustomer-singer/Dockerfile
+++ b/airbyte-integrations/connectors/source-kustomer-singer/Dockerfile
@@ -1,5 +1,8 @@
 FROM python:3.9.11-alpine3.15 as base
 
+# alwyays update dependencies
+RUN apk update && apk upgrade -a
+
 # build and load all requirements
 FROM base as builder
 WORKDIR /airbyte/integration_code
@@ -26,8 +29,7 @@ COPY --from=builder /install /usr/local
 COPY --from=builder /usr/share/zoneinfo/Etc/UTC /etc/localtime
 RUN echo "Etc/UTC" > /etc/timezone
 
-# bash is installed for more convenient debugging.
-RUN apk --no-cache add bash
+
 
 # copy payload code only
 COPY main.py ./

--- a/airbyte-integrations/connectors/source-kyriba/Dockerfile
+++ b/airbyte-integrations/connectors/source-kyriba/Dockerfile
@@ -1,13 +1,16 @@
-FROM python:3.7.11-alpine3.14 as base
+FROM python:3.9.11-alpine3.15 as base
+
+# alwyays update dependencies
+RUN apk update && apk upgrade -a
 
 # build and load all requirements
 FROM base as builder
 WORKDIR /airbyte/integration_code
 
-# upgrade pip to the latest version
+# upgrade pip and install libs
 RUN apk --no-cache upgrade \
     && pip install --upgrade pip \
-    && apk --no-cache add tzdata build-base
+    && apk --no-cache add tzdata build-base bash
 
 
 COPY setup.py ./
@@ -24,8 +27,7 @@ COPY --from=builder /install /usr/local
 COPY --from=builder /usr/share/zoneinfo/Etc/UTC /etc/localtime
 RUN echo "Etc/UTC" > /etc/timezone
 
-# bash is installed for more convenient debugging.
-RUN apk --no-cache add bash
+
 
 # copy payload code only
 COPY main.py ./

--- a/airbyte-integrations/connectors/source-launchdarkly/Dockerfile
+++ b/airbyte-integrations/connectors/source-launchdarkly/Dockerfile
@@ -1,13 +1,16 @@
 FROM python:3.9.11-alpine3.15 as base
 
+# alwyays update dependencies
+RUN apk update && apk upgrade -a
+
 # build and load all requirements
 FROM base as builder
 WORKDIR /airbyte/integration_code
 
-# upgrade pip to the latest version
+# upgrade pip and install libs
 RUN apk --no-cache upgrade \
     && pip install --upgrade pip \
-    && apk --no-cache add tzdata build-base
+    && apk --no-cache add tzdata build-base bash
 
 
 COPY setup.py ./
@@ -24,8 +27,7 @@ COPY --from=builder /install /usr/local
 COPY --from=builder /usr/share/zoneinfo/Etc/UTC /etc/localtime
 RUN echo "Etc/UTC" > /etc/timezone
 
-# bash is installed for more convenient debugging.
-RUN apk --no-cache add bash
+
 
 # copy payload code only
 COPY main.py ./

--- a/airbyte-integrations/connectors/source-lemlist/Dockerfile
+++ b/airbyte-integrations/connectors/source-lemlist/Dockerfile
@@ -1,13 +1,16 @@
 FROM python:3.9.11-alpine3.15 as base
 
+# alwyays update dependencies
+RUN apk update && apk upgrade -a
+
 # build and load all requirements
 FROM base as builder
 WORKDIR /airbyte/integration_code
 
-# upgrade pip to the latest version
+# upgrade pip and install libs
 RUN apk --no-cache upgrade \
     && pip install --upgrade pip \
-    && apk --no-cache add tzdata build-base
+    && apk --no-cache add tzdata build-base bash
 
 
 COPY setup.py ./
@@ -24,8 +27,7 @@ COPY --from=builder /install /usr/local
 COPY --from=builder /usr/share/zoneinfo/Etc/UTC /etc/localtime
 RUN echo "Etc/UTC" > /etc/timezone
 
-# bash is installed for more convenient debugging.
-RUN apk --no-cache add bash
+
 
 # copy payload code only
 COPY main.py ./

--- a/airbyte-integrations/connectors/source-lever-hiring/Dockerfile
+++ b/airbyte-integrations/connectors/source-lever-hiring/Dockerfile
@@ -1,5 +1,8 @@
 FROM python:3.9.11-alpine3.15 as base
 
+# alwyays update dependencies
+RUN apk update && apk upgrade -a
+
 # build and load all requirements
 FROM base as builder
 WORKDIR /airbyte/integration_code
@@ -24,8 +27,7 @@ COPY --from=builder /install /usr/local
 COPY --from=builder /usr/share/zoneinfo/Etc/UTC /etc/localtime
 RUN echo "Etc/UTC" > /etc/timezone
 
-# bash is installed for more convenient debugging.
-RUN apk --no-cache add bash
+
 
 # copy payload code only
 COPY main.py ./

--- a/airbyte-integrations/connectors/source-linkedin-ads/Dockerfile
+++ b/airbyte-integrations/connectors/source-linkedin-ads/Dockerfile
@@ -1,19 +1,22 @@
 FROM python:3.9.11-alpine3.15 as base
 
-# build and load all requirements 
+# alwyays update dependencies
+RUN apk update && apk upgrade -a
+
+# build and load all requirements
 FROM base as builder
 WORKDIR /airbyte/integration_code
 
-# upgrade pip to the latest version
+# upgrade pip and install libs
 RUN apk --no-cache upgrade \
     && pip install --upgrade pip \
-    && apk --no-cache add tzdata build-base
+    && apk --no-cache add tzdata build-base bash
 
 COPY setup.py ./
-# install necessary packages to a temporary folder 
+# install necessary packages to a temporary folder
 RUN pip install --prefix=/install .
 
-# build a clean environment  
+# build a clean environment
 FROM base
 WORKDIR /airbyte/integration_code
 
@@ -23,8 +26,7 @@ COPY --from=builder /install /usr/local
 COPY --from=builder /usr/share/zoneinfo/Etc/UTC /etc/localtime
 RUN echo "Etc/UTC" > /etc/timezone
 
-# bash is installed for more convenient debugging.
-RUN apk --no-cache add bash
+
 
 # copy payload code only
 COPY main.py ./

--- a/airbyte-integrations/connectors/source-linkedin-pages/Dockerfile
+++ b/airbyte-integrations/connectors/source-linkedin-pages/Dockerfile
@@ -1,13 +1,16 @@
 FROM python:3.9.11-alpine3.15 as base
 
+# alwyays update dependencies
+RUN apk update && apk upgrade -a
+
 # build and load all requirements
 FROM base as builder
 WORKDIR /airbyte/integration_code
 
-# upgrade pip to the latest version
+# upgrade pip and install libs
 RUN apk --no-cache upgrade \
     && pip install --upgrade pip \
-    && apk --no-cache add tzdata build-base
+    && apk --no-cache add tzdata build-base bash
 
 
 COPY setup.py ./
@@ -24,8 +27,7 @@ COPY --from=builder /install /usr/local
 COPY --from=builder /usr/share/zoneinfo/Etc/UTC /etc/localtime
 RUN echo "Etc/UTC" > /etc/timezone
 
-# bash is installed for more convenient debugging.
-RUN apk --no-cache add bash
+
 
 # copy payload code only
 COPY main.py ./

--- a/airbyte-integrations/connectors/source-linnworks/Dockerfile
+++ b/airbyte-integrations/connectors/source-linnworks/Dockerfile
@@ -1,13 +1,16 @@
 FROM python:3.9.11-alpine3.15 as base
 
+# alwyays update dependencies
+RUN apk update && apk upgrade -a
+
 # build and load all requirements
 FROM base as builder
 WORKDIR /airbyte/integration_code
 
-# upgrade pip to the latest version
+# upgrade pip and install libs
 RUN apk --no-cache upgrade \
     && pip install --upgrade pip \
-    && apk --no-cache add tzdata build-base
+    && apk --no-cache add tzdata build-base bash
 
 
 COPY setup.py ./
@@ -24,8 +27,7 @@ COPY --from=builder /install /usr/local
 COPY --from=builder /usr/share/zoneinfo/Etc/UTC /etc/localtime
 RUN echo "Etc/UTC" > /etc/timezone
 
-# bash is installed for more convenient debugging.
-RUN apk --no-cache add bash
+
 
 # copy payload code only
 COPY main.py ./

--- a/airbyte-integrations/connectors/source-lokalise/Dockerfile
+++ b/airbyte-integrations/connectors/source-lokalise/Dockerfile
@@ -1,13 +1,16 @@
 FROM python:3.9.11-alpine3.15 as base
 
+# alwyays update dependencies
+RUN apk update && apk upgrade -a
+
 # build and load all requirements
 FROM base as builder
 WORKDIR /airbyte/integration_code
 
-# upgrade pip to the latest version
+# upgrade pip and install libs
 RUN apk --no-cache upgrade \
     && pip install --upgrade pip \
-    && apk --no-cache add tzdata build-base
+    && apk --no-cache add tzdata build-base bash
 
 
 COPY setup.py ./
@@ -24,8 +27,7 @@ COPY --from=builder /install /usr/local
 COPY --from=builder /usr/share/zoneinfo/Etc/UTC /etc/localtime
 RUN echo "Etc/UTC" > /etc/timezone
 
-# bash is installed for more convenient debugging.
-RUN apk --no-cache add bash
+
 
 # copy payload code only
 COPY main.py ./

--- a/airbyte-integrations/connectors/source-looker/Dockerfile
+++ b/airbyte-integrations/connectors/source-looker/Dockerfile
@@ -1,13 +1,16 @@
 FROM python:3.9.11-alpine3.15 as base
 
+# alwyays update dependencies
+RUN apk update && apk upgrade -a
+
 # build and load all requirements
 FROM base as builder
 WORKDIR /airbyte/integration_code
 
-# upgrade pip to the latest version
+# upgrade pip and install libs
 RUN apk --no-cache upgrade \
     && pip install --upgrade pip \
-    && apk --no-cache add tzdata build-base
+    && apk --no-cache add tzdata build-base bash
 
 COPY setup.py ./
 # install necessary packages to a temporary folder
@@ -23,8 +26,7 @@ COPY --from=builder /install /usr/local
 COPY --from=builder /usr/share/zoneinfo/Etc/UTC /etc/localtime
 RUN echo "Etc/UTC" > /etc/timezone
 
-# bash is installed for more convenient debugging.
-RUN apk --no-cache add bash
+
 
 # copy payload code only
 COPY main.py ./

--- a/airbyte-integrations/connectors/source-mailchimp/Dockerfile
+++ b/airbyte-integrations/connectors/source-mailchimp/Dockerfile
@@ -1,7 +1,12 @@
-FROM python:3.9-slim
+FROM python:3.9.11-alpine3.15 as base
 
-# Bash is installed for more convenient debugging.
-RUN apt-get update && apt-get install -y bash && rm -rf /var/lib/apt/lists/*
+# alwyays update dependencies
+RUN apk update && apk upgrade -a
+
+# upgrade pip and install libs
+RUN apk --no-cache upgrade \
+    && pip install --upgrade pip \
+    && apk --no-cache add tzdata build-base bash
 
 WORKDIR /airbyte/integration_code
 COPY setup.py ./

--- a/airbyte-integrations/connectors/source-mailerlite/Dockerfile
+++ b/airbyte-integrations/connectors/source-mailerlite/Dockerfile
@@ -1,13 +1,16 @@
 FROM python:3.9.11-alpine3.15 as base
 
+# alwyays update dependencies
+RUN apk update && apk upgrade -a
+
 # build and load all requirements
 FROM base as builder
 WORKDIR /airbyte/integration_code
 
-# upgrade pip to the latest version
+# upgrade pip and install libs
 RUN apk --no-cache upgrade \
     && pip install --upgrade pip \
-    && apk --no-cache add tzdata build-base
+    && apk --no-cache add tzdata build-base bash
 
 
 COPY setup.py ./
@@ -24,8 +27,7 @@ COPY --from=builder /install /usr/local
 COPY --from=builder /usr/share/zoneinfo/Etc/UTC /etc/localtime
 RUN echo "Etc/UTC" > /etc/timezone
 
-# bash is installed for more convenient debugging.
-RUN apk --no-cache add bash
+
 
 # copy payload code only
 COPY main.py ./

--- a/airbyte-integrations/connectors/source-mailersend/Dockerfile
+++ b/airbyte-integrations/connectors/source-mailersend/Dockerfile
@@ -1,13 +1,16 @@
 FROM python:3.9.11-alpine3.15 as base
 
+# alwyays update dependencies
+RUN apk update && apk upgrade -a
+
 # build and load all requirements
 FROM base as builder
 WORKDIR /airbyte/integration_code
 
-# upgrade pip to the latest version
+# upgrade pip and install libs
 RUN apk --no-cache upgrade \
     && pip install --upgrade pip \
-    && apk --no-cache add tzdata build-base
+    && apk --no-cache add tzdata build-base bash
 
 
 COPY setup.py ./
@@ -24,8 +27,7 @@ COPY --from=builder /install /usr/local
 COPY --from=builder /usr/share/zoneinfo/Etc/UTC /etc/localtime
 RUN echo "Etc/UTC" > /etc/timezone
 
-# bash is installed for more convenient debugging.
-RUN apk --no-cache add bash
+
 
 # copy payload code only
 COPY main.py ./

--- a/airbyte-integrations/connectors/source-mailgun/Dockerfile
+++ b/airbyte-integrations/connectors/source-mailgun/Dockerfile
@@ -1,13 +1,16 @@
 FROM python:3.9.11-alpine3.15 as base
 
+# alwyays update dependencies
+RUN apk update && apk upgrade -a
+
 # build and load all requirements
 FROM base as builder
 WORKDIR /airbyte/integration_code
 
-# upgrade pip to the latest version
+# upgrade pip and install libs
 RUN apk --no-cache upgrade \
     && pip install --upgrade pip \
-    && apk --no-cache add tzdata build-base
+    && apk --no-cache add tzdata build-base bash
 
 
 COPY setup.py ./
@@ -24,8 +27,7 @@ COPY --from=builder /install /usr/local
 COPY --from=builder /usr/share/zoneinfo/Etc/UTC /etc/localtime
 RUN echo "Etc/UTC" > /etc/timezone
 
-# bash is installed for more convenient debugging.
-RUN apk --no-cache add bash
+
 
 # copy payload code only
 COPY main.py ./

--- a/airbyte-integrations/connectors/source-mailjet-mail/Dockerfile
+++ b/airbyte-integrations/connectors/source-mailjet-mail/Dockerfile
@@ -1,13 +1,16 @@
 FROM python:3.9.11-alpine3.15 as base
 
+# alwyays update dependencies
+RUN apk update && apk upgrade -a
+
 # build and load all requirements
 FROM base as builder
 WORKDIR /airbyte/integration_code
 
-# upgrade pip to the latest version
+# upgrade pip and install libs
 RUN apk --no-cache upgrade \
     && pip install --upgrade pip \
-    && apk --no-cache add tzdata build-base
+    && apk --no-cache add tzdata build-base bash
 
 
 COPY setup.py ./
@@ -24,8 +27,7 @@ COPY --from=builder /install /usr/local
 COPY --from=builder /usr/share/zoneinfo/Etc/UTC /etc/localtime
 RUN echo "Etc/UTC" > /etc/timezone
 
-# bash is installed for more convenient debugging.
-RUN apk --no-cache add bash
+
 
 # copy payload code only
 COPY main.py ./

--- a/airbyte-integrations/connectors/source-mailjet-sms/Dockerfile
+++ b/airbyte-integrations/connectors/source-mailjet-sms/Dockerfile
@@ -1,13 +1,16 @@
 FROM python:3.9.11-alpine3.15 as base
 
+# alwyays update dependencies
+RUN apk update && apk upgrade -a
+
 # build and load all requirements
 FROM base as builder
 WORKDIR /airbyte/integration_code
 
-# upgrade pip to the latest version
+# upgrade pip and install libs
 RUN apk --no-cache upgrade \
     && pip install --upgrade pip \
-    && apk --no-cache add tzdata build-base
+    && apk --no-cache add tzdata build-base bash
 
 
 COPY setup.py ./
@@ -24,8 +27,7 @@ COPY --from=builder /install /usr/local
 COPY --from=builder /usr/share/zoneinfo/Etc/UTC /etc/localtime
 RUN echo "Etc/UTC" > /etc/timezone
 
-# bash is installed for more convenient debugging.
-RUN apk --no-cache add bash
+
 
 # copy payload code only
 COPY main.py ./

--- a/airbyte-integrations/connectors/source-marketo/Dockerfile
+++ b/airbyte-integrations/connectors/source-marketo/Dockerfile
@@ -1,5 +1,8 @@
 FROM python:3.9.11-alpine3.15 as base
 
+# alwyays update dependencies
+RUN apk update && apk upgrade -a
+
 # build and load all requirements
 FROM base as builder
 WORKDIR /airbyte/integration_code
@@ -24,8 +27,7 @@ COPY --from=builder /install /usr/local
 COPY --from=builder /usr/share/zoneinfo/Etc/UTC /etc/localtime
 RUN echo "Etc/UTC" > /etc/timezone
 
-# bash is installed for more convenient debugging.
-RUN apk --no-cache add bash
+
 
 # copy payload code only
 COPY main.py ./

--- a/airbyte-integrations/connectors/source-metabase/Dockerfile
+++ b/airbyte-integrations/connectors/source-metabase/Dockerfile
@@ -1,7 +1,12 @@
-FROM python:3.9-slim
+FROM python:3.9.11-alpine3.15 as base
 
-# Bash is installed for more convenient debugging.
-RUN apt-get update && apt-get install -y bash && rm -rf /var/lib/apt/lists/*
+# alwyays update dependencies
+RUN apk update && apk upgrade -a
+
+# upgrade pip and install libs
+RUN apk --no-cache upgrade \
+    && pip install --upgrade pip \
+    && apk --no-cache add tzdata build-base bash
 
 WORKDIR /airbyte/integration_code
 COPY source_metabase ./source_metabase

--- a/airbyte-integrations/connectors/source-microsoft-dataverse/Dockerfile
+++ b/airbyte-integrations/connectors/source-microsoft-dataverse/Dockerfile
@@ -1,13 +1,16 @@
-FROM python:3.9.13-alpine3.15 as base
+FROM python:3.9.11-alpine3.15 as base
+
+# alwyays update dependencies
+RUN apk update && apk upgrade -a
 
 # build and load all requirements
 FROM base as builder
 WORKDIR /airbyte/integration_code
 
-# upgrade pip to the latest version
+# upgrade pip and install libs
 RUN apk --no-cache upgrade \
     && pip install --upgrade pip \
-    && apk --no-cache add tzdata build-base
+    && apk --no-cache add tzdata build-base bash
 
 
 COPY setup.py ./
@@ -24,8 +27,7 @@ COPY --from=builder /install /usr/local
 COPY --from=builder /usr/share/zoneinfo/Etc/UTC /etc/localtime
 RUN echo "Etc/UTC" > /etc/timezone
 
-# bash is installed for more convenient debugging.
-RUN apk --no-cache add bash
+
 
 # copy payload code only
 COPY main.py ./

--- a/airbyte-integrations/connectors/source-microsoft-teams/Dockerfile
+++ b/airbyte-integrations/connectors/source-microsoft-teams/Dockerfile
@@ -1,13 +1,16 @@
 FROM python:3.9.11-alpine3.15 as base
 
+# alwyays update dependencies
+RUN apk update && apk upgrade -a
+
 # build and load all requirements
 FROM base as builder
 WORKDIR /airbyte/integration_code
 
-# upgrade pip to the latest version
+# upgrade pip and install libs
 RUN apk --no-cache upgrade \
     && pip install --upgrade pip \
-    && apk --no-cache add tzdata build-base libffi-dev
+    && apk --no-cache add tzdata build-base bash libffi-dev
 
 
 COPY setup.py ./
@@ -24,8 +27,7 @@ COPY --from=builder /install /usr/local
 COPY --from=builder /usr/share/zoneinfo/Etc/UTC /etc/localtime
 RUN echo "Etc/UTC" > /etc/timezone
 
-# bash is installed for more convenient debugging.
-RUN apk --no-cache add bash
+
 
 # copy payload code only
 COPY main.py ./

--- a/airbyte-integrations/connectors/source-mixpanel/Dockerfile
+++ b/airbyte-integrations/connectors/source-mixpanel/Dockerfile
@@ -1,7 +1,12 @@
-FROM python:3.9-slim
+FROM python:3.9.11-alpine3.15 as base
 
-# Bash is installed for more convenient debugging.
-RUN apt-get update && apt-get install -y bash && rm -rf /var/lib/apt/lists/*
+# alwyays update dependencies
+RUN apk update && apk upgrade -a
+
+# upgrade pip and install libs
+RUN apk --no-cache upgrade \
+    && pip install --upgrade pip \
+    && apk --no-cache add tzdata build-base bash
 
 WORKDIR /airbyte/integration_code
 COPY source_mixpanel ./source_mixpanel

--- a/airbyte-integrations/connectors/source-monday/Dockerfile
+++ b/airbyte-integrations/connectors/source-monday/Dockerfile
@@ -1,13 +1,16 @@
 FROM python:3.9.11-alpine3.15 as base
 
+# alwyays update dependencies
+RUN apk update && apk upgrade -a
+
 # build and load all requirements
 FROM base as builder
 WORKDIR /airbyte/integration_code
 
-# upgrade pip to the latest version
+# upgrade pip and install libs
 RUN apk --no-cache upgrade \
     && pip install --upgrade pip \
-    && apk --no-cache add tzdata build-base
+    && apk --no-cache add tzdata build-base bash
 
 
 COPY setup.py ./
@@ -24,8 +27,7 @@ COPY --from=builder /install /usr/local
 COPY --from=builder /usr/share/zoneinfo/Etc/UTC /etc/localtime
 RUN echo "Etc/UTC" > /etc/timezone
 
-# bash is installed for more convenient debugging.
-RUN apk --no-cache add bash
+
 
 # copy payload code only
 COPY main.py ./

--- a/airbyte-integrations/connectors/source-my-hours/Dockerfile
+++ b/airbyte-integrations/connectors/source-my-hours/Dockerfile
@@ -1,13 +1,16 @@
 FROM python:3.9.11-alpine3.15 as base
 
+# alwyays update dependencies
+RUN apk update && apk upgrade -a
+
 # build and load all requirements
 FROM base as builder
 WORKDIR /airbyte/integration_code
 
-# upgrade pip to the latest version
+# upgrade pip and install libs
 RUN apk --no-cache upgrade \
     && pip install --upgrade pip \
-    && apk --no-cache add tzdata build-base
+    && apk --no-cache add tzdata build-base bash
 
 
 COPY setup.py ./
@@ -24,8 +27,7 @@ COPY --from=builder /install /usr/local
 COPY --from=builder /usr/share/zoneinfo/Etc/UTC /etc/localtime
 RUN echo "Etc/UTC" > /etc/timezone
 
-# bash is installed for more convenient debugging.
-RUN apk --no-cache add bash
+
 
 # copy payload code only
 COPY main.py ./

--- a/airbyte-integrations/connectors/source-n8n/Dockerfile
+++ b/airbyte-integrations/connectors/source-n8n/Dockerfile
@@ -1,13 +1,16 @@
 FROM python:3.9.11-alpine3.15 as base
 
+# alwyays update dependencies
+RUN apk update && apk upgrade -a
+
 # build and load all requirements
 FROM base as builder
 WORKDIR /airbyte/integration_code
 
-# upgrade pip to the latest version
+# upgrade pip and install libs
 RUN apk --no-cache upgrade \
     && pip install --upgrade pip \
-    && apk --no-cache add tzdata build-base
+    && apk --no-cache add tzdata build-base bash
 
 
 COPY setup.py ./
@@ -24,8 +27,7 @@ COPY --from=builder /install /usr/local
 COPY --from=builder /usr/share/zoneinfo/Etc/UTC /etc/localtime
 RUN echo "Etc/UTC" > /etc/timezone
 
-# bash is installed for more convenient debugging.
-RUN apk --no-cache add bash
+
 
 # copy payload code only
 COPY main.py ./

--- a/airbyte-integrations/connectors/source-nasa/Dockerfile
+++ b/airbyte-integrations/connectors/source-nasa/Dockerfile
@@ -1,13 +1,16 @@
-FROM python:3.9.13-alpine3.15 as base
+FROM python:3.9.11-alpine3.15 as base
+
+# alwyays update dependencies
+RUN apk update && apk upgrade -a
 
 # build and load all requirements
 FROM base as builder
 WORKDIR /airbyte/integration_code
 
-# upgrade pip to the latest version
+# upgrade pip and install libs
 RUN apk --no-cache upgrade \
     && pip install --upgrade pip \
-    && apk --no-cache add tzdata build-base
+    && apk --no-cache add tzdata build-base bash
 
 
 COPY setup.py ./
@@ -24,8 +27,7 @@ COPY --from=builder /install /usr/local
 COPY --from=builder /usr/share/zoneinfo/Etc/UTC /etc/localtime
 RUN echo "Etc/UTC" > /etc/timezone
 
-# bash is installed for more convenient debugging.
-RUN apk --no-cache add bash
+
 
 # copy payload code only
 COPY main.py ./

--- a/airbyte-integrations/connectors/source-netsuite/Dockerfile
+++ b/airbyte-integrations/connectors/source-netsuite/Dockerfile
@@ -1,13 +1,16 @@
-FROM python:3.9.13-alpine3.15 as base
+FROM python:3.9.11-alpine3.15 as base
+
+# alwyays update dependencies
+RUN apk update && apk upgrade -a
 
 # build and load all requirements
 FROM base as builder
 WORKDIR /airbyte/integration_code
 
-# upgrade pip to the latest version
+# upgrade pip and install libs
 RUN apk --no-cache upgrade \
     && pip install --upgrade pip \
-    && apk --no-cache add tzdata build-base
+    && apk --no-cache add tzdata build-base bash
 
 
 COPY setup.py ./
@@ -24,8 +27,7 @@ COPY --from=builder /install /usr/local
 COPY --from=builder /usr/share/zoneinfo/Etc/UTC /etc/localtime
 RUN echo "Etc/UTC" > /etc/timezone
 
-# bash is installed for more convenient debugging.
-RUN apk --no-cache add bash
+
 
 # copy payload code only
 COPY main.py ./

--- a/airbyte-integrations/connectors/source-news-api/Dockerfile
+++ b/airbyte-integrations/connectors/source-news-api/Dockerfile
@@ -1,13 +1,16 @@
 FROM python:3.9.11-alpine3.15 as base
 
+# alwyays update dependencies
+RUN apk update && apk upgrade -a
+
 # build and load all requirements
 FROM base as builder
 WORKDIR /airbyte/integration_code
 
-# upgrade pip to the latest version
+# upgrade pip and install libs
 RUN apk --no-cache upgrade \
     && pip install --upgrade pip \
-    && apk --no-cache add tzdata build-base
+    && apk --no-cache add tzdata build-base bash
 
 
 COPY setup.py ./
@@ -24,8 +27,7 @@ COPY --from=builder /install /usr/local
 COPY --from=builder /usr/share/zoneinfo/Etc/UTC /etc/localtime
 RUN echo "Etc/UTC" > /etc/timezone
 
-# bash is installed for more convenient debugging.
-RUN apk --no-cache add bash
+
 
 # copy payload code only
 COPY main.py ./

--- a/airbyte-integrations/connectors/source-newsdata/Dockerfile
+++ b/airbyte-integrations/connectors/source-newsdata/Dockerfile
@@ -1,13 +1,16 @@
 FROM python:3.9.11-alpine3.15 as base
 
+# alwyays update dependencies
+RUN apk update && apk upgrade -a
+
 # build and load all requirements
 FROM base as builder
 WORKDIR /airbyte/integration_code
 
-# upgrade pip to the latest version
+# upgrade pip and install libs
 RUN apk --no-cache upgrade \
     && pip install --upgrade pip \
-    && apk --no-cache add tzdata build-base
+    && apk --no-cache add tzdata build-base bash
 
 
 COPY setup.py ./
@@ -24,8 +27,7 @@ COPY --from=builder /install /usr/local
 COPY --from=builder /usr/share/zoneinfo/Etc/UTC /etc/localtime
 RUN echo "Etc/UTC" > /etc/timezone
 
-# bash is installed for more convenient debugging.
-RUN apk --no-cache add bash
+
 
 # copy payload code only
 COPY main.py ./

--- a/airbyte-integrations/connectors/source-notion/Dockerfile
+++ b/airbyte-integrations/connectors/source-notion/Dockerfile
@@ -1,13 +1,16 @@
 FROM python:3.9.11-alpine3.15 as base
 
+# alwyays update dependencies
+RUN apk update && apk upgrade -a
+
 # build and load all requirements
 FROM base as builder
 WORKDIR /airbyte/integration_code
 
-# upgrade pip to the latest version
+# upgrade pip and install libs
 RUN apk --no-cache upgrade \
     && pip install --upgrade pip \
-    && apk --no-cache add tzdata build-base
+    && apk --no-cache add tzdata build-base bash
 
 
 COPY setup.py ./
@@ -24,8 +27,7 @@ COPY --from=builder /install /usr/local
 COPY --from=builder /usr/share/zoneinfo/Etc/UTC /etc/localtime
 RUN echo "Etc/UTC" > /etc/timezone
 
-# bash is installed for more convenient debugging.
-RUN apk --no-cache add bash
+
 
 # copy payload code only
 COPY main.py ./

--- a/airbyte-integrations/connectors/source-nytimes/Dockerfile
+++ b/airbyte-integrations/connectors/source-nytimes/Dockerfile
@@ -1,13 +1,16 @@
 FROM python:3.9.11-alpine3.15 as base
 
+# alwyays update dependencies
+RUN apk update && apk upgrade -a
+
 # build and load all requirements
 FROM base as builder
 WORKDIR /airbyte/integration_code
 
-# upgrade pip to the latest version
+# upgrade pip and install libs
 RUN apk --no-cache upgrade \
     && pip install --upgrade pip \
-    && apk --no-cache add tzdata build-base
+    && apk --no-cache add tzdata build-base bash
 
 
 COPY setup.py ./
@@ -24,8 +27,7 @@ COPY --from=builder /install /usr/local
 COPY --from=builder /usr/share/zoneinfo/Etc/UTC /etc/localtime
 RUN echo "Etc/UTC" > /etc/timezone
 
-# bash is installed for more convenient debugging.
-RUN apk --no-cache add bash
+
 
 # copy payload code only
 COPY main.py ./

--- a/airbyte-integrations/connectors/source-okta/Dockerfile
+++ b/airbyte-integrations/connectors/source-okta/Dockerfile
@@ -1,7 +1,12 @@
-FROM python:3.9-slim
+FROM python:3.9.11-alpine3.15 as base
 
-# Bash is installed for more convenient debugging.
-RUN apt-get update && apt-get install -y bash && rm -rf /var/lib/apt/lists/*
+# alwyays update dependencies
+RUN apk update && apk upgrade -a
+
+# upgrade pip and install libs
+RUN apk --no-cache upgrade \
+    && pip install --upgrade pip \
+    && apk --no-cache add tzdata build-base bash
 
 WORKDIR /airbyte/integration_code
 COPY source_okta ./source_okta

--- a/airbyte-integrations/connectors/source-omnisend/Dockerfile
+++ b/airbyte-integrations/connectors/source-omnisend/Dockerfile
@@ -1,13 +1,16 @@
 FROM python:3.9.11-alpine3.15 as base
 
+# alwyays update dependencies
+RUN apk update && apk upgrade -a
+
 # build and load all requirements
 FROM base as builder
 WORKDIR /airbyte/integration_code
 
-# upgrade pip to the latest version
+# upgrade pip and install libs
 RUN apk --no-cache upgrade \
     && pip install --upgrade pip \
-    && apk --no-cache add tzdata build-base
+    && apk --no-cache add tzdata build-base bash
 
 
 COPY setup.py ./
@@ -24,8 +27,7 @@ COPY --from=builder /install /usr/local
 COPY --from=builder /usr/share/zoneinfo/Etc/UTC /etc/localtime
 RUN echo "Etc/UTC" > /etc/timezone
 
-# bash is installed for more convenient debugging.
-RUN apk --no-cache add bash
+
 
 # copy payload code only
 COPY main.py ./

--- a/airbyte-integrations/connectors/source-onesignal/Dockerfile
+++ b/airbyte-integrations/connectors/source-onesignal/Dockerfile
@@ -1,13 +1,16 @@
 FROM python:3.9.11-alpine3.15 as base
 
+# alwyays update dependencies
+RUN apk update && apk upgrade -a
+
 # build and load all requirements
 FROM base as builder
 WORKDIR /airbyte/integration_code
 
-# upgrade pip to the latest version
+# upgrade pip and install libs
 RUN apk --no-cache upgrade \
     && pip install --upgrade pip \
-    && apk --no-cache add tzdata build-base
+    && apk --no-cache add tzdata build-base bash
 
 
 COPY setup.py ./
@@ -24,8 +27,7 @@ COPY --from=builder /install /usr/local
 COPY --from=builder /usr/share/zoneinfo/Etc/UTC /etc/localtime
 RUN echo "Etc/UTC" > /etc/timezone
 
-# bash is installed for more convenient debugging.
-RUN apk --no-cache add bash
+
 
 # copy payload code only
 COPY main.py ./

--- a/airbyte-integrations/connectors/source-openweather/Dockerfile
+++ b/airbyte-integrations/connectors/source-openweather/Dockerfile
@@ -1,13 +1,16 @@
 FROM python:3.9.11-alpine3.15 as base
 
+# alwyays update dependencies
+RUN apk update && apk upgrade -a
+
 # build and load all requirements
 FROM base as builder
 WORKDIR /airbyte/integration_code
 
-# upgrade pip to the latest version
+# upgrade pip and install libs
 RUN apk --no-cache upgrade \
     && pip install --upgrade pip \
-    && apk --no-cache add tzdata build-base
+    && apk --no-cache add tzdata build-base bash
 
 
 COPY setup.py ./
@@ -24,8 +27,7 @@ COPY --from=builder /install /usr/local
 COPY --from=builder /usr/share/zoneinfo/Etc/UTC /etc/localtime
 RUN echo "Etc/UTC" > /etc/timezone
 
-# bash is installed for more convenient debugging.
-RUN apk --no-cache add bash
+
 
 # copy payload code only
 COPY main.py ./

--- a/airbyte-integrations/connectors/source-orb/Dockerfile
+++ b/airbyte-integrations/connectors/source-orb/Dockerfile
@@ -1,13 +1,16 @@
 FROM python:3.9.11-alpine3.15 as base
 
+# alwyays update dependencies
+RUN apk update && apk upgrade -a
+
 # build and load all requirements
 FROM base as builder
 WORKDIR /airbyte/integration_code
 
-# upgrade pip to the latest version
+# upgrade pip and install libs
 RUN apk --no-cache upgrade \
     && pip install --upgrade pip \
-    && apk --no-cache add tzdata build-base
+    && apk --no-cache add tzdata build-base bash
 
 
 COPY setup.py ./
@@ -24,8 +27,7 @@ COPY --from=builder /install /usr/local
 COPY --from=builder /usr/share/zoneinfo/Etc/UTC /etc/localtime
 RUN echo "Etc/UTC" > /etc/timezone
 
-# bash is installed for more convenient debugging.
-RUN apk --no-cache add bash
+
 
 # copy payload code only
 COPY main.py ./

--- a/airbyte-integrations/connectors/source-orbit/Dockerfile
+++ b/airbyte-integrations/connectors/source-orbit/Dockerfile
@@ -1,13 +1,16 @@
 FROM python:3.9.11-alpine3.15 as base
 
+# alwyays update dependencies
+RUN apk update && apk upgrade -a
+
 # build and load all requirements
 FROM base as builder
 WORKDIR /airbyte/integration_code
 
-# upgrade pip to the latest version
+# upgrade pip and install libs
 RUN apk --no-cache upgrade \
     && pip install --upgrade pip \
-    && apk --no-cache add tzdata build-base
+    && apk --no-cache add tzdata build-base bash
 
 
 COPY setup.py ./
@@ -24,8 +27,7 @@ COPY --from=builder /install /usr/local
 COPY --from=builder /usr/share/zoneinfo/Etc/UTC /etc/localtime
 RUN echo "Etc/UTC" > /etc/timezone
 
-# bash is installed for more convenient debugging.
-RUN apk --no-cache add bash
+
 
 # copy payload code only
 COPY main.py ./

--- a/airbyte-integrations/connectors/source-oura/Dockerfile
+++ b/airbyte-integrations/connectors/source-oura/Dockerfile
@@ -1,13 +1,16 @@
 FROM python:3.9.11-alpine3.15 as base
 
+# alwyays update dependencies
+RUN apk update && apk upgrade -a
+
 # build and load all requirements
 FROM base as builder
 WORKDIR /airbyte/integration_code
 
-# upgrade pip to the latest version
+# upgrade pip and install libs
 RUN apk --no-cache upgrade \
     && pip install --upgrade pip \
-    && apk --no-cache add tzdata build-base
+    && apk --no-cache add tzdata build-base bash
 
 
 COPY setup.py ./
@@ -24,8 +27,7 @@ COPY --from=builder /install /usr/local
 COPY --from=builder /usr/share/zoneinfo/Etc/UTC /etc/localtime
 RUN echo "Etc/UTC" > /etc/timezone
 
-# bash is installed for more convenient debugging.
-RUN apk --no-cache add bash
+
 
 # copy payload code only
 COPY main.py ./

--- a/airbyte-integrations/connectors/source-outreach/Dockerfile
+++ b/airbyte-integrations/connectors/source-outreach/Dockerfile
@@ -1,13 +1,16 @@
 FROM python:3.9.11-alpine3.15 as base
 
+# alwyays update dependencies
+RUN apk update && apk upgrade -a
+
 # build and load all requirements
 FROM base as builder
 WORKDIR /airbyte/integration_code
 
-# upgrade pip to the latest version
+# upgrade pip and install libs
 RUN apk --no-cache upgrade \
     && pip install --upgrade pip \
-    && apk --no-cache add tzdata build-base
+    && apk --no-cache add tzdata build-base bash
 
 
 COPY setup.py ./
@@ -24,8 +27,7 @@ COPY --from=builder /install /usr/local
 COPY --from=builder /usr/share/zoneinfo/Etc/UTC /etc/localtime
 RUN echo "Etc/UTC" > /etc/timezone
 
-# bash is installed for more convenient debugging.
-RUN apk --no-cache add bash
+
 
 # copy payload code only
 COPY main.py ./

--- a/airbyte-integrations/connectors/source-pardot/Dockerfile
+++ b/airbyte-integrations/connectors/source-pardot/Dockerfile
@@ -1,13 +1,16 @@
 FROM python:3.9.11-alpine3.15 as base
 
+# alwyays update dependencies
+RUN apk update && apk upgrade -a
+
 # build and load all requirements
 FROM base as builder
 WORKDIR /airbyte/integration_code
 
-# upgrade pip to the latest version
+# upgrade pip and install libs
 RUN apk --no-cache upgrade \
     && pip install --upgrade pip \
-    && apk --no-cache add tzdata build-base
+    && apk --no-cache add tzdata build-base bash
 
 
 COPY setup.py ./
@@ -24,8 +27,7 @@ COPY --from=builder /install /usr/local
 COPY --from=builder /usr/share/zoneinfo/Etc/UTC /etc/localtime
 RUN echo "Etc/UTC" > /etc/timezone
 
-# bash is installed for more convenient debugging.
-RUN apk --no-cache add bash
+
 
 # copy payload code only
 COPY main.py ./

--- a/airbyte-integrations/connectors/source-partnerstack/Dockerfile
+++ b/airbyte-integrations/connectors/source-partnerstack/Dockerfile
@@ -1,13 +1,16 @@
 FROM python:3.9.11-alpine3.15 as base
 
+# alwyays update dependencies
+RUN apk update && apk upgrade -a
+
 # build and load all requirements
 FROM base as builder
 WORKDIR /airbyte/integration_code
 
-# upgrade pip to the latest version
+# upgrade pip and install libs
 RUN apk --no-cache upgrade \
     && pip install --upgrade pip \
-    && apk --no-cache add tzdata build-base
+    && apk --no-cache add tzdata build-base bash
 
 
 COPY setup.py ./
@@ -24,8 +27,7 @@ COPY --from=builder /install /usr/local
 COPY --from=builder /usr/share/zoneinfo/Etc/UTC /etc/localtime
 RUN echo "Etc/UTC" > /etc/timezone
 
-# bash is installed for more convenient debugging.
-RUN apk --no-cache add bash
+
 
 # copy payload code only
 COPY main.py ./

--- a/airbyte-integrations/connectors/source-paypal-transaction/Dockerfile
+++ b/airbyte-integrations/connectors/source-paypal-transaction/Dockerfile
@@ -1,7 +1,12 @@
-FROM python:3.9-slim
+FROM python:3.9.11-alpine3.15 as base
 
-# Bash is installed for more convenient debugging.
-RUN apt-get update && apt-get install -y bash && rm -rf /var/lib/apt/lists/*
+# alwyays update dependencies
+RUN apk update && apk upgrade -a
+
+# upgrade pip and install libs
+RUN apk --no-cache upgrade \
+    && pip install --upgrade pip \
+    && apk --no-cache add tzdata build-base bash
 
 WORKDIR /airbyte/integration_code
 COPY source_paypal_transaction ./source_paypal_transaction

--- a/airbyte-integrations/connectors/source-paystack/Dockerfile
+++ b/airbyte-integrations/connectors/source-paystack/Dockerfile
@@ -1,13 +1,16 @@
 FROM python:3.9.11-alpine3.15 as base
 
+# alwyays update dependencies
+RUN apk update && apk upgrade -a
+
 # build and load all requirements
 FROM base as builder
 WORKDIR /airbyte/integration_code
 
-# upgrade pip to the latest version
+# upgrade pip and install libs
 RUN apk --no-cache upgrade \
     && pip install --upgrade pip \
-    && apk --no-cache add tzdata build-base
+    && apk --no-cache add tzdata build-base bash
 
 
 COPY setup.py ./
@@ -24,8 +27,7 @@ COPY --from=builder /install /usr/local
 COPY --from=builder /usr/share/zoneinfo/Etc/UTC /etc/localtime
 RUN echo "Etc/UTC" > /etc/timezone
 
-# bash is installed for more convenient debugging.
-RUN apk --no-cache add bash
+
 
 # copy payload code only
 COPY main.py ./

--- a/airbyte-integrations/connectors/source-persistiq/Dockerfile
+++ b/airbyte-integrations/connectors/source-persistiq/Dockerfile
@@ -1,13 +1,16 @@
 FROM python:3.9.11-alpine3.15 as base
 
+# alwyays update dependencies
+RUN apk update && apk upgrade -a
+
 # build and load all requirements
 FROM base as builder
 WORKDIR /airbyte/integration_code
 
-# upgrade pip to the latest version
+# upgrade pip and install libs
 RUN apk --no-cache upgrade \
     && pip install --upgrade pip \
-    && apk --no-cache add tzdata build-base
+    && apk --no-cache add tzdata build-base bash
 
 
 COPY setup.py ./
@@ -24,8 +27,7 @@ COPY --from=builder /install /usr/local
 COPY --from=builder /usr/share/zoneinfo/Etc/UTC /etc/localtime
 RUN echo "Etc/UTC" > /etc/timezone
 
-# bash is installed for more convenient debugging.
-RUN apk --no-cache add bash
+
 
 # copy payload code only
 COPY main.py ./

--- a/airbyte-integrations/connectors/source-pexels-api/Dockerfile
+++ b/airbyte-integrations/connectors/source-pexels-api/Dockerfile
@@ -1,13 +1,16 @@
 FROM python:3.9.11-alpine3.15 as base
 
+# alwyays update dependencies
+RUN apk update && apk upgrade -a
+
 # build and load all requirements
 FROM base as builder
 WORKDIR /airbyte/integration_code
 
-# upgrade pip to the latest version
+# upgrade pip and install libs
 RUN apk --no-cache upgrade \
     && pip install --upgrade pip \
-    && apk --no-cache add tzdata build-base
+    && apk --no-cache add tzdata build-base bash
 
 
 COPY setup.py ./
@@ -24,8 +27,7 @@ COPY --from=builder /install /usr/local
 COPY --from=builder /usr/share/zoneinfo/Etc/UTC /etc/localtime
 RUN echo "Etc/UTC" > /etc/timezone
 
-# bash is installed for more convenient debugging.
-RUN apk --no-cache add bash
+
 
 # copy payload code only
 COPY main.py ./

--- a/airbyte-integrations/connectors/source-pinterest/Dockerfile
+++ b/airbyte-integrations/connectors/source-pinterest/Dockerfile
@@ -1,13 +1,16 @@
 FROM python:3.9.11-alpine3.15 as base
 
+# alwyays update dependencies
+RUN apk update && apk upgrade -a
+
 # build and load all requirements
 FROM base as builder
 WORKDIR /airbyte/integration_code
 
-# upgrade pip to the latest version
+# upgrade pip and install libs
 RUN apk --no-cache upgrade \
     && pip install --upgrade pip \
-    && apk --no-cache add tzdata build-base
+    && apk --no-cache add tzdata build-base bash
 
 
 COPY setup.py ./
@@ -24,8 +27,7 @@ COPY --from=builder /install /usr/local
 COPY --from=builder /usr/share/zoneinfo/Etc/UTC /etc/localtime
 RUN echo "Etc/UTC" > /etc/timezone
 
-# bash is installed for more convenient debugging.
-RUN apk --no-cache add bash
+
 
 # copy payload code only
 COPY main.py ./

--- a/airbyte-integrations/connectors/source-pipedrive/Dockerfile
+++ b/airbyte-integrations/connectors/source-pipedrive/Dockerfile
@@ -1,7 +1,12 @@
-FROM python:3.9-slim
+FROM python:3.9.11-alpine3.15 as base
 
-# Bash is installed for more convenient debugging.
-RUN apt-get update && apt-get install -y bash && rm -rf /var/lib/apt/lists/*
+# alwyays update dependencies
+RUN apk update && apk upgrade -a
+
+# upgrade pip and install libs
+RUN apk --no-cache upgrade \
+    && pip install --upgrade pip \
+    && apk --no-cache add tzdata build-base bash
 
 WORKDIR /airbyte/integration_code
 COPY source_pipedrive ./source_pipedrive

--- a/airbyte-integrations/connectors/source-pivotal-tracker/Dockerfile
+++ b/airbyte-integrations/connectors/source-pivotal-tracker/Dockerfile
@@ -1,13 +1,16 @@
 FROM python:3.9.11-alpine3.15 as base
 
+# alwyays update dependencies
+RUN apk update && apk upgrade -a
+
 # build and load all requirements
 FROM base as builder
 WORKDIR /airbyte/integration_code
 
-# upgrade pip to the latest version
+# upgrade pip and install libs
 RUN apk --no-cache upgrade \
     && pip install --upgrade pip \
-    && apk --no-cache add tzdata build-base
+    && apk --no-cache add tzdata build-base bash
 
 
 COPY setup.py ./
@@ -24,8 +27,7 @@ COPY --from=builder /install /usr/local
 COPY --from=builder /usr/share/zoneinfo/Etc/UTC /etc/localtime
 RUN echo "Etc/UTC" > /etc/timezone
 
-# bash is installed for more convenient debugging.
-RUN apk --no-cache add bash
+
 
 # copy payload code only
 COPY main.py ./

--- a/airbyte-integrations/connectors/source-plaid/Dockerfile
+++ b/airbyte-integrations/connectors/source-plaid/Dockerfile
@@ -1,13 +1,16 @@
 FROM python:3.9.11-alpine3.15 as base
 
+# alwyays update dependencies
+RUN apk update && apk upgrade -a
+
 # build and load all requirements
 FROM base as builder
 WORKDIR /airbyte/integration_code
 
-# upgrade pip to the latest version
+# upgrade pip and install libs
 RUN apk --no-cache upgrade \
     && pip install --upgrade pip \
-    && apk --no-cache add tzdata build-base
+    && apk --no-cache add tzdata build-base bash
 
 
 COPY setup.py ./
@@ -24,8 +27,7 @@ COPY --from=builder /install /usr/local
 COPY --from=builder /usr/share/zoneinfo/Etc/UTC /etc/localtime
 RUN echo "Etc/UTC" > /etc/timezone
 
-# bash is installed for more convenient debugging.
-RUN apk --no-cache add bash
+
 
 # copy payload code only
 COPY main.py ./

--- a/airbyte-integrations/connectors/source-plausible/Dockerfile
+++ b/airbyte-integrations/connectors/source-plausible/Dockerfile
@@ -1,13 +1,16 @@
 FROM python:3.9.11-alpine3.15 as base
 
+# alwyays update dependencies
+RUN apk update && apk upgrade -a
+
 # build and load all requirements
 FROM base as builder
 WORKDIR /airbyte/integration_code
 
-# upgrade pip to the latest version
+# upgrade pip and install libs
 RUN apk --no-cache upgrade \
     && pip install --upgrade pip \
-    && apk --no-cache add tzdata build-base
+    && apk --no-cache add tzdata build-base bash
 
 
 COPY setup.py ./
@@ -24,8 +27,7 @@ COPY --from=builder /install /usr/local
 COPY --from=builder /usr/share/zoneinfo/Etc/UTC /etc/localtime
 RUN echo "Etc/UTC" > /etc/timezone
 
-# bash is installed for more convenient debugging.
-RUN apk --no-cache add bash
+
 
 # copy payload code only
 COPY main.py ./

--- a/airbyte-integrations/connectors/source-pocket/Dockerfile
+++ b/airbyte-integrations/connectors/source-pocket/Dockerfile
@@ -1,13 +1,16 @@
 FROM python:3.9.11-alpine3.15 as base
 
+# alwyays update dependencies
+RUN apk update && apk upgrade -a
+
 # build and load all requirements
 FROM base as builder
 WORKDIR /airbyte/integration_code
 
-# upgrade pip to the latest version
+# upgrade pip and install libs
 RUN apk --no-cache upgrade \
     && pip install --upgrade pip \
-    && apk --no-cache add tzdata build-base
+    && apk --no-cache add tzdata build-base bash
 
 
 COPY setup.py ./
@@ -24,8 +27,7 @@ COPY --from=builder /install /usr/local
 COPY --from=builder /usr/share/zoneinfo/Etc/UTC /etc/localtime
 RUN echo "Etc/UTC" > /etc/timezone
 
-# bash is installed for more convenient debugging.
-RUN apk --no-cache add bash
+
 
 # copy payload code only
 COPY main.py ./

--- a/airbyte-integrations/connectors/source-pokeapi/Dockerfile
+++ b/airbyte-integrations/connectors/source-pokeapi/Dockerfile
@@ -1,7 +1,12 @@
-FROM python:3.9-slim
+FROM python:3.9.11-alpine3.15 as base
 
-# Bash is installed for more convenient debugging.
-RUN apt-get update && apt-get install -y bash && rm -rf /var/lib/apt/lists/*
+# alwyays update dependencies
+RUN apk update && apk upgrade -a
+
+# upgrade pip and install libs
+RUN apk --no-cache upgrade \
+    && pip install --upgrade pip \
+    && apk --no-cache add tzdata build-base bash
 
 
 WORKDIR /airbyte/integration_code

--- a/airbyte-integrations/connectors/source-polygon-stock-api/Dockerfile
+++ b/airbyte-integrations/connectors/source-polygon-stock-api/Dockerfile
@@ -1,13 +1,16 @@
 FROM python:3.9.11-alpine3.15 as base
 
+# alwyays update dependencies
+RUN apk update && apk upgrade -a
+
 # build and load all requirements
 FROM base as builder
 WORKDIR /airbyte/integration_code
 
-# upgrade pip to the latest version
+# upgrade pip and install libs
 RUN apk --no-cache upgrade \
     && pip install --upgrade pip \
-    && apk --no-cache add tzdata build-base
+    && apk --no-cache add tzdata build-base bash
 
 
 COPY setup.py ./
@@ -24,8 +27,7 @@ COPY --from=builder /install /usr/local
 COPY --from=builder /usr/share/zoneinfo/Etc/UTC /etc/localtime
 RUN echo "Etc/UTC" > /etc/timezone
 
-# bash is installed for more convenient debugging.
-RUN apk --no-cache add bash
+
 
 # copy payload code only
 COPY main.py ./

--- a/airbyte-integrations/connectors/source-posthog/Dockerfile
+++ b/airbyte-integrations/connectors/source-posthog/Dockerfile
@@ -1,7 +1,12 @@
-FROM python:3.9-slim
+FROM python:3.9.11-alpine3.15 as base
 
-# Bash is installed for more convenient debugging.
-RUN apt-get update && apt-get install -y bash && rm -rf /var/lib/apt/lists/*
+# alwyays update dependencies
+RUN apk update && apk upgrade -a
+
+# upgrade pip and install libs
+RUN apk --no-cache upgrade \
+    && pip install --upgrade pip \
+    && apk --no-cache add tzdata build-base bash
 
 WORKDIR /airbyte/integration_code
 COPY source_posthog ./source_posthog

--- a/airbyte-integrations/connectors/source-postmarkapp/Dockerfile
+++ b/airbyte-integrations/connectors/source-postmarkapp/Dockerfile
@@ -1,13 +1,16 @@
 FROM python:3.9.11-alpine3.15 as base
 
+# alwyays update dependencies
+RUN apk update && apk upgrade -a
+
 # build and load all requirements
 FROM base as builder
 WORKDIR /airbyte/integration_code
 
-# upgrade pip to the latest version
+# upgrade pip and install libs
 RUN apk --no-cache upgrade \
     && pip install --upgrade pip \
-    && apk --no-cache add tzdata build-base
+    && apk --no-cache add tzdata build-base bash
 
 
 COPY setup.py ./
@@ -24,8 +27,7 @@ COPY --from=builder /install /usr/local
 COPY --from=builder /usr/share/zoneinfo/Etc/UTC /etc/localtime
 RUN echo "Etc/UTC" > /etc/timezone
 
-# bash is installed for more convenient debugging.
-RUN apk --no-cache add bash
+
 
 # copy payload code only
 COPY main.py ./

--- a/airbyte-integrations/connectors/source-prestashop/Dockerfile
+++ b/airbyte-integrations/connectors/source-prestashop/Dockerfile
@@ -1,7 +1,12 @@
-FROM python:3.9-slim
+FROM python:3.9.11-alpine3.15 as base
 
-# Bash is installed for more convenient debugging.
-RUN apt-get update && apt-get install -y bash && rm -rf /var/lib/apt/lists/*
+# alwyays update dependencies
+RUN apk update && apk upgrade -a
+
+# upgrade pip and install libs
+RUN apk --no-cache upgrade \
+    && pip install --upgrade pip \
+    && apk --no-cache add tzdata build-base bash
 
 WORKDIR /airbyte/integration_code
 COPY source_prestashop ./source_prestashop

--- a/airbyte-integrations/connectors/source-primetric/Dockerfile
+++ b/airbyte-integrations/connectors/source-primetric/Dockerfile
@@ -1,13 +1,16 @@
-FROM python:3.9.13-alpine3.15 as base
+FROM python:3.9.11-alpine3.15 as base
+
+# alwyays update dependencies
+RUN apk update && apk upgrade -a
 
 # build and load all requirements
 FROM base as builder
 WORKDIR /airbyte/integration_code
 
-# upgrade pip to the latest version
+# upgrade pip and install libs
 RUN apk --no-cache upgrade \
     && pip install --upgrade pip \
-    && apk --no-cache add tzdata build-base
+    && apk --no-cache add tzdata build-base bash
 
 
 COPY setup.py ./
@@ -24,8 +27,7 @@ COPY --from=builder /install /usr/local
 COPY --from=builder /usr/share/zoneinfo/Etc/UTC /etc/localtime
 RUN echo "Etc/UTC" > /etc/timezone
 
-# bash is installed for more convenient debugging.
-RUN apk --no-cache add bash
+
 
 # copy payload code only
 COPY main.py ./

--- a/airbyte-integrations/connectors/source-public-apis/Dockerfile
+++ b/airbyte-integrations/connectors/source-public-apis/Dockerfile
@@ -1,13 +1,16 @@
-FROM python:3.9.13-alpine3.15 as base
+FROM python:3.9.11-alpine3.15 as base
+
+# alwyays update dependencies
+RUN apk update && apk upgrade -a
 
 # build and load all requirements
 FROM base as builder
 WORKDIR /airbyte/integration_code
 
-# upgrade pip to the latest version
+# upgrade pip and install libs
 RUN apk --no-cache upgrade \
     && pip install --upgrade pip \
-    && apk --no-cache add tzdata build-base
+    && apk --no-cache add tzdata build-base bash
 
 
 COPY setup.py ./
@@ -24,8 +27,7 @@ COPY --from=builder /install /usr/local
 COPY --from=builder /usr/share/zoneinfo/Etc/UTC /etc/localtime
 RUN echo "Etc/UTC" > /etc/timezone
 
-# bash is installed for more convenient debugging.
-RUN apk --no-cache add bash
+
 
 # copy payload code only
 COPY main.py ./

--- a/airbyte-integrations/connectors/source-punk-api/Dockerfile
+++ b/airbyte-integrations/connectors/source-punk-api/Dockerfile
@@ -1,13 +1,16 @@
 FROM python:3.9.11-alpine3.15 as base
 
+# alwyays update dependencies
+RUN apk update && apk upgrade -a
+
 # build and load all requirements
 FROM base as builder
 WORKDIR /airbyte/integration_code
 
-# upgrade pip to the latest version
+# upgrade pip and install libs
 RUN apk --no-cache upgrade \
     && pip install --upgrade pip \
-    && apk --no-cache add tzdata build-base
+    && apk --no-cache add tzdata build-base bash
 
 
 COPY setup.py ./
@@ -24,8 +27,7 @@ COPY --from=builder /install /usr/local
 COPY --from=builder /usr/share/zoneinfo/Etc/UTC /etc/localtime
 RUN echo "Etc/UTC" > /etc/timezone
 
-# bash is installed for more convenient debugging.
-RUN apk --no-cache add bash
+
 
 # copy payload code only
 COPY main.py ./

--- a/airbyte-integrations/connectors/source-pypi/Dockerfile
+++ b/airbyte-integrations/connectors/source-pypi/Dockerfile
@@ -1,13 +1,16 @@
 FROM python:3.9.11-alpine3.15 as base
 
+# alwyays update dependencies
+RUN apk update && apk upgrade -a
+
 # build and load all requirements
 FROM base as builder
 WORKDIR /airbyte/integration_code
 
-# upgrade pip to the latest version
+# upgrade pip and install libs
 RUN apk --no-cache upgrade \
     && pip install --upgrade pip \
-    && apk --no-cache add tzdata build-base
+    && apk --no-cache add tzdata build-base bash
 
 
 COPY setup.py ./
@@ -24,8 +27,7 @@ COPY --from=builder /install /usr/local
 COPY --from=builder /usr/share/zoneinfo/Etc/UTC /etc/localtime
 RUN echo "Etc/UTC" > /etc/timezone
 
-# bash is installed for more convenient debugging.
-RUN apk --no-cache add bash
+
 
 # copy payload code only
 COPY main.py ./

--- a/airbyte-integrations/connectors/source-python-http-tutorial/Dockerfile
+++ b/airbyte-integrations/connectors/source-python-http-tutorial/Dockerfile
@@ -1,7 +1,12 @@
-FROM python:3.9-slim
+FROM python:3.9.11-alpine3.15 as base
 
-# Bash is installed for more convenient debugging.
-RUN apt-get update && apt-get install -y bash && rm -rf /var/lib/apt/lists/*
+# alwyays update dependencies
+RUN apk update && apk upgrade -a
+
+# upgrade pip and install libs
+RUN apk --no-cache upgrade \
+    && pip install --upgrade pip \
+    && apk --no-cache add tzdata build-base bash
 
 WORKDIR /airbyte/integration_code
 COPY source_python_http_tutorial ./source_python_http_tutorial

--- a/airbyte-integrations/connectors/source-qonto/Dockerfile
+++ b/airbyte-integrations/connectors/source-qonto/Dockerfile
@@ -1,13 +1,16 @@
-FROM python:3.9.13-alpine3.15 as base
+FROM python:3.9.11-alpine3.15 as base
+
+# alwyays update dependencies
+RUN apk update && apk upgrade -a
 
 # build and load all requirements
 FROM base as builder
 WORKDIR /airbyte/integration_code
 
-# upgrade pip to the latest version
+# upgrade pip and install libs
 RUN apk --no-cache upgrade \
     && pip install --upgrade pip \
-    && apk --no-cache add tzdata build-base
+    && apk --no-cache add tzdata build-base bash
 
 
 COPY setup.py ./
@@ -24,8 +27,7 @@ COPY --from=builder /install /usr/local
 COPY --from=builder /usr/share/zoneinfo/Etc/UTC /etc/localtime
 RUN echo "Etc/UTC" > /etc/timezone
 
-# bash is installed for more convenient debugging.
-RUN apk --no-cache add bash
+
 
 # copy payload code only
 COPY main.py ./

--- a/airbyte-integrations/connectors/source-qualaroo/Dockerfile
+++ b/airbyte-integrations/connectors/source-qualaroo/Dockerfile
@@ -1,5 +1,8 @@
 FROM python:3.9.11-alpine3.15 as base
 
+# alwyays update dependencies
+RUN apk update && apk upgrade -a
+
 # build and load all requirements
 FROM base as builder
 WORKDIR /airbyte/integration_code
@@ -19,8 +22,7 @@ WORKDIR /airbyte/integration_code
 # copy all loaded and built libraries to a pure basic image
 COPY --from=builder /install /usr/local
 
-# Bash is installed for more convenient debugging.
-RUN apk --no-cache add bash
+
 
 # copy payload code only
 COPY main.py ./

--- a/airbyte-integrations/connectors/source-quickbooks-singer/Dockerfile
+++ b/airbyte-integrations/connectors/source-quickbooks-singer/Dockerfile
@@ -1,5 +1,8 @@
 FROM python:3.9.11-alpine3.15 as base
 
+# alwyays update dependencies
+RUN apk update && apk upgrade -a
+
 # build and load all requirements
 FROM base as builder
 WORKDIR /airbyte/integration_code
@@ -26,8 +29,7 @@ COPY --from=builder /install /usr/local
 COPY --from=builder /usr/share/zoneinfo/Etc/UTC /etc/localtime
 RUN echo "Etc/UTC" > /etc/timezone
 
-# bash is installed for more convenient debugging.
-RUN apk --no-cache add bash
+
 
 # copy payload code only
 COPY main.py ./

--- a/airbyte-integrations/connectors/source-railz/Dockerfile
+++ b/airbyte-integrations/connectors/source-railz/Dockerfile
@@ -1,13 +1,16 @@
 FROM python:3.9.11-alpine3.15 as base
 
+# alwyays update dependencies
+RUN apk update && apk upgrade -a
+
 # build and load all requirements
 FROM base as builder
 WORKDIR /airbyte/integration_code
 
-# upgrade pip to the latest version
+# upgrade pip and install libs
 RUN apk --no-cache upgrade \
     && pip install --upgrade pip \
-    && apk --no-cache add tzdata build-base
+    && apk --no-cache add tzdata build-base bash
 
 
 COPY setup.py ./
@@ -24,8 +27,7 @@ COPY --from=builder /install /usr/local
 COPY --from=builder /usr/share/zoneinfo/Etc/UTC /etc/localtime
 RUN echo "Etc/UTC" > /etc/timezone
 
-# bash is installed for more convenient debugging.
-RUN apk --no-cache add bash
+
 
 # copy payload code only
 COPY main.py ./

--- a/airbyte-integrations/connectors/source-rd-station-marketing/Dockerfile
+++ b/airbyte-integrations/connectors/source-rd-station-marketing/Dockerfile
@@ -1,13 +1,16 @@
 FROM python:3.9.11-alpine3.15 as base
 
+# alwyays update dependencies
+RUN apk update && apk upgrade -a
+
 # build and load all requirements
 FROM base as builder
 WORKDIR /airbyte/integration_code
 
-# upgrade pip to the latest version
+# upgrade pip and install libs
 RUN apk --no-cache upgrade \
     && pip install --upgrade pip \
-    && apk --no-cache add tzdata build-base
+    && apk --no-cache add tzdata build-base bash
 
 
 COPY setup.py ./
@@ -24,8 +27,7 @@ COPY --from=builder /install /usr/local
 COPY --from=builder /usr/share/zoneinfo/Etc/UTC /etc/localtime
 RUN echo "Etc/UTC" > /etc/timezone
 
-# bash is installed for more convenient debugging.
-RUN apk --no-cache add bash
+
 
 # copy payload code only
 COPY main.py ./

--- a/airbyte-integrations/connectors/source-recharge/Dockerfile
+++ b/airbyte-integrations/connectors/source-recharge/Dockerfile
@@ -1,7 +1,12 @@
-FROM python:3.9-slim
+FROM python:3.9.11-alpine3.15 as base
 
-# Bash is installed for more convenient debugging.
-RUN apt-get update && apt-get install -y bash && rm -rf /var/lib/apt/lists/*
+# alwyays update dependencies
+RUN apk update && apk upgrade -a
+
+# upgrade pip and install libs
+RUN apk --no-cache upgrade \
+    && pip install --upgrade pip \
+    && apk --no-cache add tzdata build-base bash
 
 WORKDIR /airbyte/integration_code
 COPY source_recharge ./source_recharge

--- a/airbyte-integrations/connectors/source-recreation/Dockerfile
+++ b/airbyte-integrations/connectors/source-recreation/Dockerfile
@@ -1,13 +1,16 @@
 FROM python:3.9.11-alpine3.15 as base
 
+# alwyays update dependencies
+RUN apk update && apk upgrade -a
+
 # build and load all requirements
 FROM base as builder
 WORKDIR /airbyte/integration_code
 
-# upgrade pip to the latest version
+# upgrade pip and install libs
 RUN apk --no-cache upgrade \
     && pip install --upgrade pip \
-    && apk --no-cache add tzdata build-base
+    && apk --no-cache add tzdata build-base bash
 
 
 COPY setup.py ./
@@ -24,8 +27,7 @@ COPY --from=builder /install /usr/local
 COPY --from=builder /usr/share/zoneinfo/Etc/UTC /etc/localtime
 RUN echo "Etc/UTC" > /etc/timezone
 
-# bash is installed for more convenient debugging.
-RUN apk --no-cache add bash
+
 
 # copy payload code only
 COPY main.py ./

--- a/airbyte-integrations/connectors/source-recruitee/Dockerfile
+++ b/airbyte-integrations/connectors/source-recruitee/Dockerfile
@@ -1,13 +1,16 @@
 FROM python:3.9.11-alpine3.15 as base
 
+# alwyays update dependencies
+RUN apk update && apk upgrade -a
+
 # build and load all requirements
 FROM base as builder
 WORKDIR /airbyte/integration_code
 
-# upgrade pip to the latest version
+# upgrade pip and install libs
 RUN apk --no-cache upgrade \
     && pip install --upgrade pip \
-    && apk --no-cache add tzdata build-base
+    && apk --no-cache add tzdata build-base bash
 
 
 COPY setup.py ./
@@ -24,8 +27,7 @@ COPY --from=builder /install /usr/local
 COPY --from=builder /usr/share/zoneinfo/Etc/UTC /etc/localtime
 RUN echo "Etc/UTC" > /etc/timezone
 
-# bash is installed for more convenient debugging.
-RUN apk --no-cache add bash
+
 
 # copy payload code only
 COPY main.py ./

--- a/airbyte-integrations/connectors/source-recurly/Dockerfile
+++ b/airbyte-integrations/connectors/source-recurly/Dockerfile
@@ -1,13 +1,16 @@
 FROM python:3.9.11-alpine3.15 as base
 
+# alwyays update dependencies
+RUN apk update && apk upgrade -a
+
 # build and load all requirements
 FROM base as builder
 WORKDIR /airbyte/integration_code
 
-# upgrade pip to the latest version
+# upgrade pip and install libs
 RUN apk --no-cache upgrade \
     && pip install --upgrade pip \
-    && apk --no-cache add tzdata build-base
+    && apk --no-cache add tzdata build-base bash
 
 
 COPY setup.py ./
@@ -24,8 +27,7 @@ COPY --from=builder /install /usr/local
 COPY --from=builder /usr/share/zoneinfo/Etc/UTC /etc/localtime
 RUN echo "Etc/UTC" > /etc/timezone
 
-# bash is installed for more convenient debugging.
-RUN apk --no-cache add bash
+
 
 # copy payload code only
 COPY main.py ./

--- a/airbyte-integrations/connectors/source-reply-io/Dockerfile
+++ b/airbyte-integrations/connectors/source-reply-io/Dockerfile
@@ -1,13 +1,16 @@
 FROM python:3.9.11-alpine3.15 as base
 
+# alwyays update dependencies
+RUN apk update && apk upgrade -a
+
 # build and load all requirements
 FROM base as builder
 WORKDIR /airbyte/integration_code
 
-# upgrade pip to the latest version
+# upgrade pip and install libs
 RUN apk --no-cache upgrade \
     && pip install --upgrade pip \
-    && apk --no-cache add tzdata build-base
+    && apk --no-cache add tzdata build-base bash
 
 
 COPY setup.py ./
@@ -24,8 +27,7 @@ COPY --from=builder /install /usr/local
 COPY --from=builder /usr/share/zoneinfo/Etc/UTC /etc/localtime
 RUN echo "Etc/UTC" > /etc/timezone
 
-# bash is installed for more convenient debugging.
-RUN apk --no-cache add bash
+
 
 # copy payload code only
 COPY main.py ./

--- a/airbyte-integrations/connectors/source-retently/Dockerfile
+++ b/airbyte-integrations/connectors/source-retently/Dockerfile
@@ -1,4 +1,7 @@
-FROM python:3.9-slim as base
+FROM python:3.9.11-alpine3.15 as base
+
+# alwyays update dependencies
+RUN apk update && apk upgrade -a
 
 # build and load all requirements
 FROM base as builder

--- a/airbyte-integrations/connectors/source-retently/Dockerfile
+++ b/airbyte-integrations/connectors/source-retently/Dockerfile
@@ -7,11 +7,10 @@ RUN apk update && apk upgrade -a
 FROM base as builder
 WORKDIR /airbyte/integration_code
 
-# upgrade pip to the latest version
-# RUN apk --no-cache upgrade \
-#     && pip install --upgrade pip \
-#     && apk --no-cache add tzdata
-
+# upgrade pip and install libs
+RUN apk --no-cache upgrade \
+    && pip install --upgrade pip \
+    && apk --no-cache add tzdata build-base bash
 
 COPY setup.py ./
 # install necessary packages to a temporary folder
@@ -26,9 +25,6 @@ COPY --from=builder /install /usr/local
 # add default timezone settings
 COPY --from=builder /usr/share/zoneinfo/Etc/UTC /etc/localtime
 RUN echo "Etc/UTC" > /etc/timezone
-
-# bash is installed for more convenient debugging.
-# RUN apk --no-cache add bash
 
 # copy payload code only
 COPY main.py ./

--- a/airbyte-integrations/connectors/source-retently/source_retently/source.py
+++ b/airbyte-integrations/connectors/source-retently/source_retently/source.py
@@ -106,16 +106,16 @@ class RetentlyStream(HttpStream):
             **next_page,
         }
 
+# Duplicated below, does not compile
+# class Campaigns(RetentlyStream):
+#     json_path = "campaigns"
 
-class Campaigns(RetentlyStream):
-    json_path = "campaigns"
+#     def path(self, **kwargs) -> str:
+#         return "campaigns"
 
-    def path(self, **kwargs) -> str:
-        return "campaigns"
-
-    # does not support pagination
-    def next_page_token(self, response: requests.Response) -> Optional[Mapping[str, Any]]:
-        return None
+#     # does not support pagination
+#     def next_page_token(self, response: requests.Response) -> Optional[Mapping[str, Any]]:
+#         return None
 
 
 class Companies(RetentlyStream):
@@ -137,15 +137,15 @@ class Customers(RetentlyStream):
     ) -> str:
         return "nps/customers"
 
+# Duplicated below, does not compile
+# class Feedback(RetentlyStream):
+#     json_path = "responses"
 
-class Feedback(RetentlyStream):
-    json_path = "responses"
-
-    def path(
-        self,
-        **kwargs,
-    ) -> str:
-        return "feedback"
+#     def path(
+#         self,
+#         **kwargs,
+#     ) -> str:
+#         return "feedback"
 
 
 class Outbox(RetentlyStream):
@@ -166,9 +166,11 @@ class Reports(RetentlyStream):
         **kwargs,
     ) -> str:
         return "reports"
+
     # does not support pagination
     def next_page_token(self, response: requests.Response) -> Optional[Mapping[str, Any]]:
         return None
+
 
 class Nps(RetentlyStream):
     json_path = None
@@ -202,6 +204,7 @@ class Templates(RetentlyStream):
         data = response.json().get("data")
         yield data
 
+
 class Campaigns(RetentlyStream):
     json_path = "campaigns"
 
@@ -222,6 +225,7 @@ class Campaigns(RetentlyStream):
         for d in stream_data:
             yield d
 
+
 class Feedback(RetentlyStream):
     json_path = "responses"
 
@@ -229,4 +233,3 @@ class Feedback(RetentlyStream):
         self, stream_state: Mapping[str, Any] = None, stream_slice: Mapping[str, Any] = None, next_page_token: Mapping[str, Any] = None
     ) -> str:
         return "feedback"
-

--- a/airbyte-integrations/connectors/source-rki-covid/Dockerfile
+++ b/airbyte-integrations/connectors/source-rki-covid/Dockerfile
@@ -1,13 +1,16 @@
 FROM python:3.9.11-alpine3.15 as base
 
-# build and load all requirements 
+# alwyays update dependencies
+RUN apk update && apk upgrade -a
+
+# build and load all requirements
 FROM base as builder
 WORKDIR /airbyte/integration_code
 
-# upgrade pip to the latest version
+# upgrade pip and install libs
 RUN apk --no-cache upgrade \
     && pip install --upgrade pip \
-    && apk --no-cache add tzdata build-base
+    && apk --no-cache add tzdata build-base bash
 
 COPY setup.py ./
 # install necessary packages to a temporary folder

--- a/airbyte-integrations/connectors/source-rocket-chat/Dockerfile
+++ b/airbyte-integrations/connectors/source-rocket-chat/Dockerfile
@@ -1,13 +1,16 @@
 FROM python:3.9.11-alpine3.15 as base
 
+# alwyays update dependencies
+RUN apk update && apk upgrade -a
+
 # build and load all requirements
 FROM base as builder
 WORKDIR /airbyte/integration_code
 
-# upgrade pip to the latest version
+# upgrade pip and install libs
 RUN apk --no-cache upgrade \
     && pip install --upgrade pip \
-    && apk --no-cache add tzdata build-base
+    && apk --no-cache add tzdata build-base bash
 
 
 COPY setup.py ./
@@ -24,8 +27,7 @@ COPY --from=builder /install /usr/local
 COPY --from=builder /usr/share/zoneinfo/Etc/UTC /etc/localtime
 RUN echo "Etc/UTC" > /etc/timezone
 
-# bash is installed for more convenient debugging.
-RUN apk --no-cache add bash
+
 
 # copy payload code only
 COPY main.py ./

--- a/airbyte-integrations/connectors/source-rss/Dockerfile
+++ b/airbyte-integrations/connectors/source-rss/Dockerfile
@@ -1,13 +1,16 @@
-FROM python:3.9.13-alpine3.15 as base
+FROM python:3.9.11-alpine3.15 as base
+
+# alwyays update dependencies
+RUN apk update && apk upgrade -a
 
 # build and load all requirements
 FROM base as builder
 WORKDIR /airbyte/integration_code
 
-# upgrade pip to the latest version
+# upgrade pip and install libs
 RUN apk --no-cache upgrade \
     && pip install --upgrade pip \
-    && apk --no-cache add tzdata build-base
+    && apk --no-cache add tzdata build-base bash
 
 
 COPY setup.py ./
@@ -24,8 +27,7 @@ COPY --from=builder /install /usr/local
 COPY --from=builder /usr/share/zoneinfo/Etc/UTC /etc/localtime
 RUN echo "Etc/UTC" > /etc/timezone
 
-# bash is installed for more convenient debugging.
-RUN apk --no-cache add bash
+
 
 # copy payload code only
 COPY main.py ./

--- a/airbyte-integrations/connectors/source-s3/Dockerfile
+++ b/airbyte-integrations/connectors/source-s3/Dockerfile
@@ -1,4 +1,7 @@
-FROM python:3.9-slim as base
+FROM python:3.9.11-alpine3.15 as base
+
+# alwyays update dependencies
+RUN apk update && apk upgrade -a
 FROM base as builder
 
 RUN apt-get update

--- a/airbyte-integrations/connectors/source-s3/Dockerfile
+++ b/airbyte-integrations/connectors/source-s3/Dockerfile
@@ -2,6 +2,12 @@ FROM python:3.9.11-alpine3.15 as base
 
 # alwyays update dependencies
 RUN apk update && apk upgrade -a
+
+# upgrade pip and install libs
+RUN apk --no-cache upgrade \
+    && pip install --upgrade pip \
+    && apk --no-cache add tzdata build-base bash
+
 FROM base as builder
 
 RUN apt-get update

--- a/airbyte-integrations/connectors/source-salesforce/Dockerfile
+++ b/airbyte-integrations/connectors/source-salesforce/Dockerfile
@@ -1,7 +1,12 @@
-FROM python:3.9-slim
+FROM python:3.9.11-alpine3.15 as base
 
-# Bash is installed for more convenient debugging.
-RUN apt-get update && apt-get install -y bash && rm -rf /var/lib/apt/lists/*
+# alwyays update dependencies
+RUN apk update && apk upgrade -a
+
+# upgrade pip and install libs
+RUN apk --no-cache upgrade \
+    && pip install --upgrade pip \
+    && apk --no-cache add tzdata build-base bash
 
 ENV AIRBYTE_ENTRYPOINT "python /airbyte/integration_code/main.py"
 

--- a/airbyte-integrations/connectors/source-salesloft/Dockerfile
+++ b/airbyte-integrations/connectors/source-salesloft/Dockerfile
@@ -1,5 +1,8 @@
 FROM python:3.9.11-alpine3.15 as base
 
+# alwyays update dependencies
+RUN apk update && apk upgrade -a
+
 # build and load all requirements
 FROM base as builder
 WORKDIR /airbyte/integration_code
@@ -24,8 +27,7 @@ COPY --from=builder /install /usr/local
 COPY --from=builder /usr/share/zoneinfo/Etc/UTC /etc/localtime
 RUN echo "Etc/UTC" > /etc/timezone
 
-# bash is installed for more convenient debugging.
-RUN apk --no-cache add bash
+
 
 # copy payload code only
 COPY main.py ./

--- a/airbyte-integrations/connectors/source-sap-fieldglass/Dockerfile
+++ b/airbyte-integrations/connectors/source-sap-fieldglass/Dockerfile
@@ -1,13 +1,16 @@
 FROM python:3.9.11-alpine3.15 as base
 
+# alwyays update dependencies
+RUN apk update && apk upgrade -a
+
 # build and load all requirements
 FROM base as builder
 WORKDIR /airbyte/integration_code
 
-# upgrade pip to the latest version
+# upgrade pip and install libs
 RUN apk --no-cache upgrade \
     && pip install --upgrade pip \
-    && apk --no-cache add tzdata build-base
+    && apk --no-cache add tzdata build-base bash
 
 
 COPY setup.py ./
@@ -24,8 +27,7 @@ COPY --from=builder /install /usr/local
 COPY --from=builder /usr/share/zoneinfo/Etc/UTC /etc/localtime
 RUN echo "Etc/UTC" > /etc/timezone
 
-# bash is installed for more convenient debugging.
-RUN apk --no-cache add bash
+
 
 # copy payload code only
 COPY main.py ./

--- a/airbyte-integrations/connectors/source-scaffold-source-http/Dockerfile
+++ b/airbyte-integrations/connectors/source-scaffold-source-http/Dockerfile
@@ -1,13 +1,16 @@
-FROM python:3.9.13-alpine3.15 as base
+FROM python:3.9.11-alpine3.15 as base
+
+# alwyays update dependencies
+RUN apk update && apk upgrade -a
 
 # build and load all requirements
 FROM base as builder
 WORKDIR /airbyte/integration_code
 
-# upgrade pip to the latest version
+# upgrade pip and install libs
 RUN apk --no-cache upgrade \
     && pip install --upgrade pip \
-    && apk --no-cache add tzdata build-base
+    && apk --no-cache add tzdata build-base bash
 
 
 COPY setup.py ./
@@ -24,8 +27,7 @@ COPY --from=builder /install /usr/local
 COPY --from=builder /usr/share/zoneinfo/Etc/UTC /etc/localtime
 RUN echo "Etc/UTC" > /etc/timezone
 
-# bash is installed for more convenient debugging.
-RUN apk --no-cache add bash
+
 
 # copy payload code only
 COPY main.py ./

--- a/airbyte-integrations/connectors/source-scaffold-source-python/Dockerfile
+++ b/airbyte-integrations/connectors/source-scaffold-source-python/Dockerfile
@@ -1,13 +1,16 @@
 FROM python:3.9.11-alpine3.15 as base
 
+# alwyays update dependencies
+RUN apk update && apk upgrade -a
+
 # build and load all requirements
 FROM base as builder
 WORKDIR /airbyte/integration_code
 
-# upgrade pip to the latest version
+# upgrade pip and install libs
 RUN apk --no-cache upgrade \
     && pip install --upgrade pip \
-    && apk --no-cache add tzdata build-base
+    && apk --no-cache add tzdata build-base bash
 
 
 COPY setup.py ./
@@ -24,8 +27,7 @@ COPY --from=builder /install /usr/local
 COPY --from=builder /usr/share/zoneinfo/Etc/UTC /etc/localtime
 RUN echo "Etc/UTC" > /etc/timezone
 
-# bash is installed for more convenient debugging.
-RUN apk --no-cache add bash
+
 
 # copy payload code only
 COPY main.py ./

--- a/airbyte-integrations/connectors/source-search-metrics/Dockerfile
+++ b/airbyte-integrations/connectors/source-search-metrics/Dockerfile
@@ -1,13 +1,16 @@
 FROM python:3.9.11-alpine3.15 as base
 
+# alwyays update dependencies
+RUN apk update && apk upgrade -a
+
 # build and load all requirements
 FROM base as builder
 WORKDIR /airbyte/integration_code
 
-# upgrade pip to the latest version
+# upgrade pip and install libs
 RUN apk --no-cache upgrade \
     && pip install --upgrade pip \
-    && apk --no-cache add tzdata build-base
+    && apk --no-cache add tzdata build-base bash
 
 
 COPY setup.py ./
@@ -24,8 +27,7 @@ COPY --from=builder /install /usr/local
 COPY --from=builder /usr/share/zoneinfo/Etc/UTC /etc/localtime
 RUN echo "Etc/UTC" > /etc/timezone
 
-# bash is installed for more convenient debugging.
-RUN apk --no-cache add bash
+
 
 # copy payload code only
 COPY main.py ./

--- a/airbyte-integrations/connectors/source-secoda/Dockerfile
+++ b/airbyte-integrations/connectors/source-secoda/Dockerfile
@@ -1,13 +1,16 @@
 FROM python:3.9.11-alpine3.15 as base
 
+# alwyays update dependencies
+RUN apk update && apk upgrade -a
+
 # build and load all requirements
 FROM base as builder
 WORKDIR /airbyte/integration_code
 
-# upgrade pip to the latest version
+# upgrade pip and install libs
 RUN apk --no-cache upgrade \
     && pip install --upgrade pip \
-    && apk --no-cache add tzdata build-base
+    && apk --no-cache add tzdata build-base bash
 
 
 COPY setup.py ./
@@ -24,8 +27,7 @@ COPY --from=builder /install /usr/local
 COPY --from=builder /usr/share/zoneinfo/Etc/UTC /etc/localtime
 RUN echo "Etc/UTC" > /etc/timezone
 
-# bash is installed for more convenient debugging.
-RUN apk --no-cache add bash
+
 
 # copy payload code only
 COPY main.py ./

--- a/airbyte-integrations/connectors/source-sendgrid/Dockerfile
+++ b/airbyte-integrations/connectors/source-sendgrid/Dockerfile
@@ -1,7 +1,12 @@
-FROM python:3.9-slim
+FROM python:3.9.11-alpine3.15 as base
 
-# Bash is installed for more convenient debugging.
-RUN apt-get update && apt-get install -y bash && rm -rf /var/lib/apt/lists/*
+# alwyays update dependencies
+RUN apk update && apk upgrade -a
+
+# upgrade pip and install libs
+RUN apk --no-cache upgrade \
+    && pip install --upgrade pip \
+    && apk --no-cache add tzdata build-base bash
 
 WORKDIR /airbyte/integration_code
 COPY source_sendgrid ./source_sendgrid

--- a/airbyte-integrations/connectors/source-sendinblue/Dockerfile
+++ b/airbyte-integrations/connectors/source-sendinblue/Dockerfile
@@ -1,13 +1,16 @@
 FROM python:3.9.11-alpine3.15 as base
 
+# alwyays update dependencies
+RUN apk update && apk upgrade -a
+
 # build and load all requirements
 FROM base as builder
 WORKDIR /airbyte/integration_code
 
-# upgrade pip to the latest version
+# upgrade pip and install libs
 RUN apk --no-cache upgrade \
     && pip install --upgrade pip \
-    && apk --no-cache add tzdata build-base
+    && apk --no-cache add tzdata build-base bash
 
 
 COPY setup.py ./
@@ -24,8 +27,7 @@ COPY --from=builder /install /usr/local
 COPY --from=builder /usr/share/zoneinfo/Etc/UTC /etc/localtime
 RUN echo "Etc/UTC" > /etc/timezone
 
-# bash is installed for more convenient debugging.
-RUN apk --no-cache add bash
+
 
 # copy payload code only
 COPY main.py ./

--- a/airbyte-integrations/connectors/source-senseforce/Dockerfile
+++ b/airbyte-integrations/connectors/source-senseforce/Dockerfile
@@ -1,13 +1,16 @@
 FROM python:3.9.11-alpine3.15 as base
 
+# alwyays update dependencies
+RUN apk update && apk upgrade -a
+
 # build and load all requirements
 FROM base as builder
 WORKDIR /airbyte/integration_code
 
-# upgrade pip to the latest version
+# upgrade pip and install libs
 RUN apk --no-cache upgrade \
     && pip install --upgrade pip \
-    && apk --no-cache add tzdata build-base
+    && apk --no-cache add tzdata build-base bash
 
 
 COPY setup.py ./
@@ -24,8 +27,7 @@ COPY --from=builder /install /usr/local
 COPY --from=builder /usr/share/zoneinfo/Etc/UTC /etc/localtime
 RUN echo "Etc/UTC" > /etc/timezone
 
-# bash is installed for more convenient debugging.
-RUN apk --no-cache add bash
+
 
 # copy payload code only
 COPY main.py ./

--- a/airbyte-integrations/connectors/source-sentry/Dockerfile
+++ b/airbyte-integrations/connectors/source-sentry/Dockerfile
@@ -1,13 +1,16 @@
 FROM python:3.9.11-alpine3.15 as base
 
+# alwyays update dependencies
+RUN apk update && apk upgrade -a
+
 # build and load all requirements
 FROM base as builder
 WORKDIR /airbyte/integration_code
 
-# upgrade pip to the latest version
+# upgrade pip and install libs
 RUN apk --no-cache upgrade \
     && pip install --upgrade pip \
-    && apk --no-cache add tzdata build-base
+    && apk --no-cache add tzdata build-base bash
 
 
 COPY setup.py ./
@@ -24,8 +27,7 @@ COPY --from=builder /install /usr/local
 COPY --from=builder /usr/share/zoneinfo/Etc/UTC /etc/localtime
 RUN echo "Etc/UTC" > /etc/timezone
 
-# bash is installed for more convenient debugging.
-RUN apk --no-cache add bash
+
 
 # copy payload code only
 COPY main.py ./

--- a/airbyte-integrations/connectors/source-sftp-bulk/Dockerfile
+++ b/airbyte-integrations/connectors/source-sftp-bulk/Dockerfile
@@ -1,5 +1,11 @@
-FROM python:3.9-slim
-# FROM python:3.9.11-alpine3.15
+FROM python:3.9.11-alpine3.15 as base
+
+# alwyays update dependencies
+RUN apk update && apk upgrade -a
+# FROM python:3.9.11-alpine3.15 as base
+
+# alwyays update dependencies
+RUN apk update && apk upgrade -a
 
 # Bash is installed for more convenient debugging.
 # RUN apt-get update && apt-get install -y bash && rm -rf /var/lib/apt/lists/*

--- a/airbyte-integrations/connectors/source-sftp-bulk/Dockerfile
+++ b/airbyte-integrations/connectors/source-sftp-bulk/Dockerfile
@@ -2,13 +2,11 @@ FROM python:3.9.11-alpine3.15 as base
 
 # alwyays update dependencies
 RUN apk update && apk upgrade -a
-# FROM python:3.9.11-alpine3.15 as base
 
-# alwyays update dependencies
-RUN apk update && apk upgrade -a
-
-# Bash is installed for more convenient debugging.
-# RUN apt-get update && apt-get install -y bash && rm -rf /var/lib/apt/lists/*
+# upgrade pip and install libs
+RUN apk --no-cache upgrade \
+    && pip install --upgrade pip \
+    && apk --no-cache add tzdata build-base bash
 
 WORKDIR /airbyte/integration_code
 COPY source_sftp_bulk ./source_sftp_bulk

--- a/airbyte-integrations/connectors/source-shopify/Dockerfile
+++ b/airbyte-integrations/connectors/source-shopify/Dockerfile
@@ -1,5 +1,8 @@
 FROM python:3.9.11-alpine3.15 as base
 
+# alwyays update dependencies
+RUN apk update && apk upgrade -a
+
 # build and load all requirements
 FROM base as builder
 WORKDIR /airbyte/integration_code
@@ -18,8 +21,7 @@ WORKDIR /airbyte/integration_code
 # copy all loaded and built libraries to a pure basic image
 COPY --from=builder /install /usr/local
 
-# Bash is installed for more convenient debugging.
-RUN apk --no-cache add bash
+
 
 # copy payload code only
 COPY main.py ./

--- a/airbyte-integrations/connectors/source-shortio/Dockerfile
+++ b/airbyte-integrations/connectors/source-shortio/Dockerfile
@@ -1,7 +1,12 @@
-FROM python:3.9-slim
+FROM python:3.9.11-alpine3.15 as base
 
-# Bash is installed for more convenient debugging.
-RUN apt-get update && apt-get install -y bash && rm -rf /var/lib/apt/lists/*
+# alwyays update dependencies
+RUN apk update && apk upgrade -a
+
+# upgrade pip and install libs
+RUN apk --no-cache upgrade \
+    && pip install --upgrade pip \
+    && apk --no-cache add tzdata build-base bash
 
 WORKDIR /airbyte/integration_code
 COPY source_shortio ./source_shortio

--- a/airbyte-integrations/connectors/source-slack/Dockerfile
+++ b/airbyte-integrations/connectors/source-slack/Dockerfile
@@ -1,7 +1,12 @@
-FROM python:3.9-slim
+FROM python:3.9.11-alpine3.15 as base
 
-# Bash is installed for more convenient debugging.
-RUN apt-get update && apt-get install -y bash && rm -rf /var/lib/apt/lists/*
+# alwyays update dependencies
+RUN apk update && apk upgrade -a
+
+# upgrade pip and install libs
+RUN apk --no-cache upgrade \
+    && pip install --upgrade pip \
+    && apk --no-cache add tzdata build-base bash
 
 ENV CODE_PATH="source_slack"
 ENV WORKDIR=/airbyte/integration_code

--- a/airbyte-integrations/connectors/source-smaily/Dockerfile
+++ b/airbyte-integrations/connectors/source-smaily/Dockerfile
@@ -1,13 +1,16 @@
 FROM python:3.9.11-alpine3.15 as base
 
+# alwyays update dependencies
+RUN apk update && apk upgrade -a
+
 # build and load all requirements
 FROM base as builder
 WORKDIR /airbyte/integration_code
 
-# upgrade pip to the latest version
+# upgrade pip and install libs
 RUN apk --no-cache upgrade \
     && pip install --upgrade pip \
-    && apk --no-cache add tzdata build-base
+    && apk --no-cache add tzdata build-base bash
 
 
 COPY setup.py ./
@@ -24,8 +27,7 @@ COPY --from=builder /install /usr/local
 COPY --from=builder /usr/share/zoneinfo/Etc/UTC /etc/localtime
 RUN echo "Etc/UTC" > /etc/timezone
 
-# bash is installed for more convenient debugging.
-RUN apk --no-cache add bash
+
 
 # copy payload code only
 COPY main.py ./

--- a/airbyte-integrations/connectors/source-smartengage/Dockerfile
+++ b/airbyte-integrations/connectors/source-smartengage/Dockerfile
@@ -1,13 +1,16 @@
 FROM python:3.9.11-alpine3.15 as base
 
+# alwyays update dependencies
+RUN apk update && apk upgrade -a
+
 # build and load all requirements
 FROM base as builder
 WORKDIR /airbyte/integration_code
 
-# upgrade pip to the latest version
+# upgrade pip and install libs
 RUN apk --no-cache upgrade \
     && pip install --upgrade pip \
-    && apk --no-cache add tzdata build-base
+    && apk --no-cache add tzdata build-base bash
 
 
 COPY setup.py ./
@@ -24,8 +27,7 @@ COPY --from=builder /install /usr/local
 COPY --from=builder /usr/share/zoneinfo/Etc/UTC /etc/localtime
 RUN echo "Etc/UTC" > /etc/timezone
 
-# bash is installed for more convenient debugging.
-RUN apk --no-cache add bash
+
 
 # copy payload code only
 COPY main.py ./

--- a/airbyte-integrations/connectors/source-smartsheets/Dockerfile
+++ b/airbyte-integrations/connectors/source-smartsheets/Dockerfile
@@ -1,7 +1,12 @@
-FROM python:3.9-slim
+FROM python:3.9.11-alpine3.15 as base
 
-# Bash is installed for more convenient debugging.
-RUN apt-get update && apt-get install -y bash && rm -rf /var/lib/apt/lists/*
+# alwyays update dependencies
+RUN apk update && apk upgrade -a
+
+# upgrade pip and install libs
+RUN apk --no-cache upgrade \
+    && pip install --upgrade pip \
+    && apk --no-cache add tzdata build-base bash
 
 ENV CODE_PATH="source_smartsheets"
 

--- a/airbyte-integrations/connectors/source-snapchat-marketing/Dockerfile
+++ b/airbyte-integrations/connectors/source-snapchat-marketing/Dockerfile
@@ -1,4 +1,7 @@
 FROM python:3.9.11-alpine3.15 as base
+
+# alwyays update dependencies
+RUN apk update && apk upgrade -a
 FROM base as builder
 
 

--- a/airbyte-integrations/connectors/source-sonar-cloud/Dockerfile
+++ b/airbyte-integrations/connectors/source-sonar-cloud/Dockerfile
@@ -1,13 +1,16 @@
 FROM python:3.9.11-alpine3.15 as base
 
+# alwyays update dependencies
+RUN apk update && apk upgrade -a
+
 # build and load all requirements
 FROM base as builder
 WORKDIR /airbyte/integration_code
 
-# upgrade pip to the latest version
+# upgrade pip and install libs
 RUN apk --no-cache upgrade \
     && pip install --upgrade pip \
-    && apk --no-cache add tzdata build-base
+    && apk --no-cache add tzdata build-base bash
 
 
 COPY setup.py ./
@@ -24,8 +27,7 @@ COPY --from=builder /install /usr/local
 COPY --from=builder /usr/share/zoneinfo/Etc/UTC /etc/localtime
 RUN echo "Etc/UTC" > /etc/timezone
 
-# bash is installed for more convenient debugging.
-RUN apk --no-cache add bash
+
 
 # copy payload code only
 COPY main.py ./

--- a/airbyte-integrations/connectors/source-spacex-api/Dockerfile
+++ b/airbyte-integrations/connectors/source-spacex-api/Dockerfile
@@ -1,13 +1,16 @@
 FROM python:3.9.11-alpine3.15 as base
 
+# alwyays update dependencies
+RUN apk update && apk upgrade -a
+
 # build and load all requirements
 FROM base as builder
 WORKDIR /airbyte/integration_code
 
-# upgrade pip to the latest version
+# upgrade pip and install libs
 RUN apk --no-cache upgrade \
     && pip install --upgrade pip \
-    && apk --no-cache add tzdata build-base
+    && apk --no-cache add tzdata build-base bash
 
 
 COPY setup.py ./
@@ -24,8 +27,7 @@ COPY --from=builder /install /usr/local
 COPY --from=builder /usr/share/zoneinfo/Etc/UTC /etc/localtime
 RUN echo "Etc/UTC" > /etc/timezone
 
-# bash is installed for more convenient debugging.
-RUN apk --no-cache add bash
+
 
 # copy payload code only
 COPY main.py ./

--- a/airbyte-integrations/connectors/source-square/Dockerfile
+++ b/airbyte-integrations/connectors/source-square/Dockerfile
@@ -1,13 +1,16 @@
 FROM python:3.9.11-alpine3.15 as base
 
+# alwyays update dependencies
+RUN apk update && apk upgrade -a
+
 # build and load all requirements
 FROM base as builder
 WORKDIR /airbyte/integration_code
 
-# upgrade pip to the latest version
+# upgrade pip and install libs
 RUN apk --no-cache upgrade \
     && pip install --upgrade pip \
-    && apk --no-cache add tzdata build-base
+    && apk --no-cache add tzdata build-base bash
 
 
 COPY setup.py ./
@@ -24,8 +27,7 @@ COPY --from=builder /install /usr/local
 COPY --from=builder /usr/share/zoneinfo/Etc/UTC /etc/localtime
 RUN echo "Etc/UTC" > /etc/timezone
 
-# bash is installed for more convenient debugging.
-RUN apk --no-cache add bash
+
 
 # copy payload code only
 COPY main.py ./

--- a/airbyte-integrations/connectors/source-statuspage/Dockerfile
+++ b/airbyte-integrations/connectors/source-statuspage/Dockerfile
@@ -1,13 +1,16 @@
 FROM python:3.9.11-alpine3.15 as base
 
+# alwyays update dependencies
+RUN apk update && apk upgrade -a
+
 # build and load all requirements
 FROM base as builder
 WORKDIR /airbyte/integration_code
 
-# upgrade pip to the latest version
+# upgrade pip and install libs
 RUN apk --no-cache upgrade \
     && pip install --upgrade pip \
-    && apk --no-cache add tzdata build-base
+    && apk --no-cache add tzdata build-base bash
 
 
 COPY setup.py ./
@@ -24,8 +27,7 @@ COPY --from=builder /install /usr/local
 COPY --from=builder /usr/share/zoneinfo/Etc/UTC /etc/localtime
 RUN echo "Etc/UTC" > /etc/timezone
 
-# bash is installed for more convenient debugging.
-RUN apk --no-cache add bash
+
 
 # copy payload code only
 COPY main.py ./

--- a/airbyte-integrations/connectors/source-stock-ticker-api-tutorial/Dockerfile
+++ b/airbyte-integrations/connectors/source-stock-ticker-api-tutorial/Dockerfile
@@ -1,4 +1,7 @@
-FROM python:3.9-slim
+FROM python:3.9.11-alpine3.15 as base
+
+# alwyays update dependencies
+RUN apk update && apk upgrade -a
 
 # We change to a directory unique to us
 WORKDIR /airbyte/integration_code

--- a/airbyte-integrations/connectors/source-strava/Dockerfile
+++ b/airbyte-integrations/connectors/source-strava/Dockerfile
@@ -1,13 +1,16 @@
 FROM python:3.9.11-alpine3.15 as base
 
+# alwyays update dependencies
+RUN apk update && apk upgrade -a
+
 # build and load all requirements
 FROM base as builder
 WORKDIR /airbyte/integration_code
 
-# upgrade pip to the latest version
+# upgrade pip and install libs
 RUN apk --no-cache upgrade \
     && pip install --upgrade pip \
-    && apk --no-cache add tzdata build-base
+    && apk --no-cache add tzdata build-base bash
 
 
 COPY setup.py ./
@@ -24,8 +27,7 @@ COPY --from=builder /install /usr/local
 COPY --from=builder /usr/share/zoneinfo/Etc/UTC /etc/localtime
 RUN echo "Etc/UTC" > /etc/timezone
 
-# bash is installed for more convenient debugging.
-RUN apk --no-cache add bash
+
 
 # copy payload code only
 COPY main.py ./

--- a/airbyte-integrations/connectors/source-stripe/Dockerfile
+++ b/airbyte-integrations/connectors/source-stripe/Dockerfile
@@ -1,7 +1,12 @@
-FROM python:3.9-slim
+FROM python:3.9.11-alpine3.15 as base
 
-# Bash is installed for more convenient debugging.
-RUN apt-get update && apt-get install -y bash && rm -rf /var/lib/apt/lists/*
+# alwyays update dependencies
+RUN apk update && apk upgrade -a
+
+# upgrade pip and install libs
+RUN apk --no-cache upgrade \
+    && pip install --upgrade pip \
+    && apk --no-cache add tzdata build-base bash
 
 WORKDIR /airbyte/integration_code
 COPY setup.py ./

--- a/airbyte-integrations/connectors/source-survey-sparrow/Dockerfile
+++ b/airbyte-integrations/connectors/source-survey-sparrow/Dockerfile
@@ -1,13 +1,16 @@
 FROM python:3.9.11-alpine3.15 as base
 
+# alwyays update dependencies
+RUN apk update && apk upgrade -a
+
 # build and load all requirements
 FROM base as builder
 WORKDIR /airbyte/integration_code
 
-# upgrade pip to the latest version
+# upgrade pip and install libs
 RUN apk --no-cache upgrade \
     && pip install --upgrade pip \
-    && apk --no-cache add tzdata build-base
+    && apk --no-cache add tzdata build-base bash
 
 
 COPY setup.py ./
@@ -24,8 +27,7 @@ COPY --from=builder /install /usr/local
 COPY --from=builder /usr/share/zoneinfo/Etc/UTC /etc/localtime
 RUN echo "Etc/UTC" > /etc/timezone
 
-# bash is installed for more convenient debugging.
-RUN apk --no-cache add bash
+
 
 # copy payload code only
 COPY main.py ./

--- a/airbyte-integrations/connectors/source-surveycto/Dockerfile
+++ b/airbyte-integrations/connectors/source-surveycto/Dockerfile
@@ -1,4 +1,4 @@
-FROM python:3.9.11-alpine3.15 as base
+FROM python:3.10.10-alpine3.17 as base
 
 # alwyays update dependencies
 RUN apk update && apk upgrade -a
@@ -7,14 +7,13 @@ RUN apk update && apk upgrade -a
 FROM base as builder
 WORKDIR /airbyte/integration_code
 
-# upgrade pip to the latest version
-RUN apt-get update && apt-get install -y && rm -rf /var/lib/apt/lists/* \
-    # apk --no-cache upgrade \
+# upgrade pip and install libs
+RUN apk --no-cache upgrade \
     && pip install --upgrade pip \
-    && python3 -m pip install --upgrade setuptools
+    && apk --no-cache add tzdata build-base bash
 
-RUN DEBIAN_FRONTEND=noninteractive TZ=Etc/UTC apt-get -y install tzdata
-
+# Install custom deps for this connector
+RUN apk add libffi-dev musl-dev g++
 
 COPY setup.py ./
 # install necessary packages to a temporary folder
@@ -29,9 +28,6 @@ COPY --from=builder /install /usr/local
 # add default timezone settings
 COPY --from=builder /usr/share/zoneinfo/Etc/UTC /etc/localtime
 RUN echo "Etc/UTC" > /etc/timezone
-
-# bash is installed for more convenient debugging.
-#RUN apk --no-cache add bash
 
 # copy payload code only
 COPY main.py ./

--- a/airbyte-integrations/connectors/source-surveycto/Dockerfile
+++ b/airbyte-integrations/connectors/source-surveycto/Dockerfile
@@ -1,4 +1,7 @@
-FROM python:3.10.8-slim-bullseye as base
+FROM python:3.9.11-alpine3.15 as base
+
+# alwyays update dependencies
+RUN apk update && apk upgrade -a
 
 # build and load all requirements
 FROM base as builder
@@ -9,7 +12,7 @@ RUN apt-get update && apt-get install -y && rm -rf /var/lib/apt/lists/* \
     # apk --no-cache upgrade \
     && pip install --upgrade pip \
     && python3 -m pip install --upgrade setuptools
-    
+
 RUN DEBIAN_FRONTEND=noninteractive TZ=Etc/UTC apt-get -y install tzdata
 
 

--- a/airbyte-integrations/connectors/source-surveymonkey/Dockerfile
+++ b/airbyte-integrations/connectors/source-surveymonkey/Dockerfile
@@ -1,7 +1,12 @@
-FROM python:3.9-slim
+FROM python:3.9.11-alpine3.15 as base
 
-# Bash is installed for more convenient debugging.
-RUN apt-get update && apt-get install -y bash && rm -rf /var/lib/apt/lists/*
+# alwyays update dependencies
+RUN apk update && apk upgrade -a
+
+# upgrade pip and install libs
+RUN apk --no-cache upgrade \
+    && pip install --upgrade pip \
+    && apk --no-cache add tzdata build-base bash
 
 WORKDIR /airbyte/integration_code
 COPY source_surveymonkey ./source_surveymonkey

--- a/airbyte-integrations/connectors/source-talkdesk-explore/Dockerfile
+++ b/airbyte-integrations/connectors/source-talkdesk-explore/Dockerfile
@@ -1,13 +1,16 @@
-FROM python:3.7.11-alpine3.14 as base
+FROM python:3.9.11-alpine3.15 as base
+
+# alwyays update dependencies
+RUN apk update && apk upgrade -a
 
 # build and load all requirements
 FROM base as builder
 WORKDIR /airbyte/integration_code
 
-# upgrade pip to the latest version
+# upgrade pip and install libs
 RUN apk --no-cache upgrade \
     && pip install --upgrade pip \
-    && apk --no-cache add tzdata build-base
+    && apk --no-cache add tzdata build-base bash
 
 
 COPY setup.py ./
@@ -24,8 +27,7 @@ COPY --from=builder /install /usr/local
 COPY --from=builder /usr/share/zoneinfo/Etc/UTC /etc/localtime
 RUN echo "Etc/UTC" > /etc/timezone
 
-# bash is installed for more convenient debugging.
-RUN apk --no-cache add bash
+
 
 # copy payload code only
 COPY main.py ./

--- a/airbyte-integrations/connectors/source-tempo/Dockerfile
+++ b/airbyte-integrations/connectors/source-tempo/Dockerfile
@@ -1,13 +1,16 @@
 FROM python:3.9.11-alpine3.15 as base
 
+# alwyays update dependencies
+RUN apk update && apk upgrade -a
+
 # build and load all requirements
 FROM base as builder
 WORKDIR /airbyte/integration_code
 
-# upgrade pip to the latest version
+# upgrade pip and install libs
 RUN apk --no-cache upgrade \
     && pip install --upgrade pip \
-    && apk --no-cache add tzdata build-base
+    && apk --no-cache add tzdata build-base bash
 
 
 COPY setup.py ./
@@ -24,8 +27,7 @@ COPY --from=builder /install /usr/local
 COPY --from=builder /usr/share/zoneinfo/Etc/UTC /etc/localtime
 RUN echo "Etc/UTC" > /etc/timezone
 
-# bash is installed for more convenient debugging.
-RUN apk --no-cache add bash
+
 
 # copy payload code only
 COPY main.py ./

--- a/airbyte-integrations/connectors/source-the-guardian-api/Dockerfile
+++ b/airbyte-integrations/connectors/source-the-guardian-api/Dockerfile
@@ -1,13 +1,16 @@
 FROM python:3.9.11-alpine3.15 as base
 
+# alwyays update dependencies
+RUN apk update && apk upgrade -a
+
 # build and load all requirements
 FROM base as builder
 WORKDIR /airbyte/integration_code
 
-# upgrade pip to the latest version
+# upgrade pip and install libs
 RUN apk --no-cache upgrade \
     && pip install --upgrade pip \
-    && apk --no-cache add tzdata build-base
+    && apk --no-cache add tzdata build-base bash
 
 
 COPY setup.py ./
@@ -24,8 +27,7 @@ COPY --from=builder /install /usr/local
 COPY --from=builder /usr/share/zoneinfo/Etc/UTC /etc/localtime
 RUN echo "Etc/UTC" > /etc/timezone
 
-# bash is installed for more convenient debugging.
-RUN apk --no-cache add bash
+
 
 # copy payload code only
 COPY main.py ./

--- a/airbyte-integrations/connectors/source-tiktok-marketing/Dockerfile
+++ b/airbyte-integrations/connectors/source-tiktok-marketing/Dockerfile
@@ -1,19 +1,22 @@
 FROM python:3.9.11-alpine3.15 as base
 
-# build and load all requirements 
+# alwyays update dependencies
+RUN apk update && apk upgrade -a
+
+# build and load all requirements
 FROM base as builder
 WORKDIR /airbyte/integration_code
 
-# upgrade pip to the latest version
+# upgrade pip and install libs
 RUN apk --no-cache upgrade \
     && pip install --upgrade pip \
-    && apk --no-cache add tzdata build-base
+    && apk --no-cache add tzdata build-base bash
 
 COPY setup.py ./
-# install necessary packages to a temporary folder 
+# install necessary packages to a temporary folder
 RUN pip install --prefix=/install .
 
-# build a clean environment  
+# build a clean environment
 FROM base
 WORKDIR /airbyte/integration_code
 
@@ -22,8 +25,7 @@ COPY --from=builder /install /usr/local
 # add default timezone settings
 COPY --from=builder /usr/share/zoneinfo/Etc/UTC /etc/localtime
 RUN echo "Etc/UTC" > /etc/timezone
-# Bash is installed for more convenient debugging.
-RUN apk --no-cache add bash
+
 
 # copy payload code only
 COPY main.py ./

--- a/airbyte-integrations/connectors/source-timely/Dockerfile
+++ b/airbyte-integrations/connectors/source-timely/Dockerfile
@@ -1,13 +1,16 @@
 FROM python:3.9.11-alpine3.15 as base
 
+# alwyays update dependencies
+RUN apk update && apk upgrade -a
+
 # build and load all requirements
 FROM base as builder
 WORKDIR /airbyte/integration_code
 
-# upgrade pip to the latest version
+# upgrade pip and install libs
 RUN apk --no-cache upgrade \
     && pip install --upgrade pip \
-    && apk --no-cache add tzdata build-base
+    && apk --no-cache add tzdata build-base bash
 
 
 COPY setup.py ./
@@ -24,8 +27,7 @@ COPY --from=builder /install /usr/local
 COPY --from=builder /usr/share/zoneinfo/Etc/UTC /etc/localtime
 RUN echo "Etc/UTC" > /etc/timezone
 
-# bash is installed for more convenient debugging.
-RUN apk --no-cache add bash
+
 
 # copy payload code only
 COPY main.py ./

--- a/airbyte-integrations/connectors/source-tmdb/Dockerfile
+++ b/airbyte-integrations/connectors/source-tmdb/Dockerfile
@@ -1,13 +1,16 @@
 FROM python:3.9.11-alpine3.15 as base
 
+# alwyays update dependencies
+RUN apk update && apk upgrade -a
+
 # build and load all requirements
 FROM base as builder
 WORKDIR /airbyte/integration_code
 
-# upgrade pip to the latest version
+# upgrade pip and install libs
 RUN apk --no-cache upgrade \
     && pip install --upgrade pip \
-    && apk --no-cache add tzdata build-base
+    && apk --no-cache add tzdata build-base bash
 
 
 COPY setup.py ./
@@ -24,8 +27,7 @@ COPY --from=builder /install /usr/local
 COPY --from=builder /usr/share/zoneinfo/Etc/UTC /etc/localtime
 RUN echo "Etc/UTC" > /etc/timezone
 
-# bash is installed for more convenient debugging.
-RUN apk --no-cache add bash
+
 
 # copy payload code only
 COPY main.py ./

--- a/airbyte-integrations/connectors/source-toggl/Dockerfile
+++ b/airbyte-integrations/connectors/source-toggl/Dockerfile
@@ -1,13 +1,16 @@
 FROM python:3.9.11-alpine3.15 as base
 
+# alwyays update dependencies
+RUN apk update && apk upgrade -a
+
 # build and load all requirements
 FROM base as builder
 WORKDIR /airbyte/integration_code
 
-# upgrade pip to the latest version
+# upgrade pip and install libs
 RUN apk --no-cache upgrade \
     && pip install --upgrade pip \
-    && apk --no-cache add tzdata build-base
+    && apk --no-cache add tzdata build-base bash
 
 
 COPY setup.py ./
@@ -24,8 +27,7 @@ COPY --from=builder /install /usr/local
 COPY --from=builder /usr/share/zoneinfo/Etc/UTC /etc/localtime
 RUN echo "Etc/UTC" > /etc/timezone
 
-# bash is installed for more convenient debugging.
-RUN apk --no-cache add bash
+
 
 # copy payload code only
 COPY main.py ./

--- a/airbyte-integrations/connectors/source-tplcentral/Dockerfile
+++ b/airbyte-integrations/connectors/source-tplcentral/Dockerfile
@@ -1,13 +1,16 @@
 FROM python:3.9.11-alpine3.15 as base
 
+# alwyays update dependencies
+RUN apk update && apk upgrade -a
+
 # build and load all requirements
 FROM base as builder
 WORKDIR /airbyte/integration_code
 
-# upgrade pip to the latest version
+# upgrade pip and install libs
 RUN apk --no-cache upgrade \
     && pip install --upgrade pip \
-    && apk --no-cache add tzdata build-base
+    && apk --no-cache add tzdata build-base bash
 
 
 COPY setup.py ./
@@ -24,8 +27,7 @@ COPY --from=builder /install /usr/local
 COPY --from=builder /usr/share/zoneinfo/Etc/UTC /etc/localtime
 RUN echo "Etc/UTC" > /etc/timezone
 
-# bash is installed for more convenient debugging.
-RUN apk --no-cache add bash
+
 
 # copy payload code only
 COPY main.py ./

--- a/airbyte-integrations/connectors/source-trello/Dockerfile
+++ b/airbyte-integrations/connectors/source-trello/Dockerfile
@@ -1,5 +1,8 @@
 FROM python:3.9.11-alpine3.15 as base
 
+# alwyays update dependencies
+RUN apk update && apk upgrade -a
+
 # build and load all requirements
 FROM base as builder
 WORKDIR /airbyte/integration_code
@@ -19,8 +22,7 @@ WORKDIR /airbyte/integration_code
 # copy all loaded and built libraries to a pure basic image
 COPY --from=builder /install /usr/local
 
-# Bash is installed for more convenient debugging.
-RUN apk --no-cache add bash
+
 
 # copy payload code only
 COPY main.py ./

--- a/airbyte-integrations/connectors/source-tvmaze-schedule/Dockerfile
+++ b/airbyte-integrations/connectors/source-tvmaze-schedule/Dockerfile
@@ -1,13 +1,16 @@
 FROM python:3.9.11-alpine3.15 as base
 
+# alwyays update dependencies
+RUN apk update && apk upgrade -a
+
 # build and load all requirements
 FROM base as builder
 WORKDIR /airbyte/integration_code
 
-# upgrade pip to the latest version
+# upgrade pip and install libs
 RUN apk --no-cache upgrade \
     && pip install --upgrade pip \
-    && apk --no-cache add tzdata build-base
+    && apk --no-cache add tzdata build-base bash
 
 
 COPY setup.py ./
@@ -24,8 +27,7 @@ COPY --from=builder /install /usr/local
 COPY --from=builder /usr/share/zoneinfo/Etc/UTC /etc/localtime
 RUN echo "Etc/UTC" > /etc/timezone
 
-# bash is installed for more convenient debugging.
-RUN apk --no-cache add bash
+
 
 # copy payload code only
 COPY main.py ./

--- a/airbyte-integrations/connectors/source-twilio-taskrouter/Dockerfile
+++ b/airbyte-integrations/connectors/source-twilio-taskrouter/Dockerfile
@@ -1,13 +1,16 @@
 FROM python:3.9.11-alpine3.15 as base
 
+# alwyays update dependencies
+RUN apk update && apk upgrade -a
+
 # build and load all requirements
 FROM base as builder
 WORKDIR /airbyte/integration_code
 
-# upgrade pip to the latest version
+# upgrade pip and install libs
 RUN apk --no-cache upgrade \
     && pip install --upgrade pip \
-    && apk --no-cache add tzdata build-base
+    && apk --no-cache add tzdata build-base bash
 
 
 COPY setup.py ./
@@ -24,8 +27,7 @@ COPY --from=builder /install /usr/local
 COPY --from=builder /usr/share/zoneinfo/Etc/UTC /etc/localtime
 RUN echo "Etc/UTC" > /etc/timezone
 
-# bash is installed for more convenient debugging.
-RUN apk --no-cache add bash
+
 
 # copy payload code only
 COPY main.py ./

--- a/airbyte-integrations/connectors/source-twilio/Dockerfile
+++ b/airbyte-integrations/connectors/source-twilio/Dockerfile
@@ -1,7 +1,12 @@
-FROM python:3.9-slim
+FROM python:3.9.11-alpine3.15 as base
 
-# Bash is installed for more convenient debugging.
-RUN apt-get update && apt-get install -y bash && rm -rf /var/lib/apt/lists/*
+# alwyays update dependencies
+RUN apk update && apk upgrade -a
+
+# upgrade pip and install libs
+RUN apk --no-cache upgrade \
+    && pip install --upgrade pip \
+    && apk --no-cache add tzdata build-base bash
 
 WORKDIR /airbyte/integration_code
 COPY setup.py ./

--- a/airbyte-integrations/connectors/source-twitter/Dockerfile
+++ b/airbyte-integrations/connectors/source-twitter/Dockerfile
@@ -1,13 +1,16 @@
 FROM python:3.9.11-alpine3.15 as base
 
+# alwyays update dependencies
+RUN apk update && apk upgrade -a
+
 # build and load all requirements
 FROM base as builder
 WORKDIR /airbyte/integration_code
 
-# upgrade pip to the latest version
+# upgrade pip and install libs
 RUN apk --no-cache upgrade \
     && pip install --upgrade pip \
-    && apk --no-cache add tzdata build-base
+    && apk --no-cache add tzdata build-base bash
 
 
 COPY setup.py ./
@@ -24,8 +27,7 @@ COPY --from=builder /install /usr/local
 COPY --from=builder /usr/share/zoneinfo/Etc/UTC /etc/localtime
 RUN echo "Etc/UTC" > /etc/timezone
 
-# bash is installed for more convenient debugging.
-RUN apk --no-cache add bash
+
 
 # copy payload code only
 COPY main.py ./

--- a/airbyte-integrations/connectors/source-tyntec-sms/Dockerfile
+++ b/airbyte-integrations/connectors/source-tyntec-sms/Dockerfile
@@ -1,13 +1,16 @@
 FROM python:3.9.11-alpine3.15 as base
 
+# alwyays update dependencies
+RUN apk update && apk upgrade -a
+
 # build and load all requirements
 FROM base as builder
 WORKDIR /airbyte/integration_code
 
-# upgrade pip to the latest version
+# upgrade pip and install libs
 RUN apk --no-cache upgrade \
     && pip install --upgrade pip \
-    && apk --no-cache add tzdata build-base
+    && apk --no-cache add tzdata build-base bash
 
 
 COPY setup.py ./
@@ -24,8 +27,7 @@ COPY --from=builder /install /usr/local
 COPY --from=builder /usr/share/zoneinfo/Etc/UTC /etc/localtime
 RUN echo "Etc/UTC" > /etc/timezone
 
-# bash is installed for more convenient debugging.
-RUN apk --no-cache add bash
+
 
 # copy payload code only
 COPY main.py ./

--- a/airbyte-integrations/connectors/source-typeform/Dockerfile
+++ b/airbyte-integrations/connectors/source-typeform/Dockerfile
@@ -1,7 +1,12 @@
-FROM python:3.9-slim
+FROM python:3.9.11-alpine3.15 as base
 
-# Bash is installed for more convenient debugging.
-RUN apt-get update && apt-get install -y bash && rm -rf /var/lib/apt/lists/*
+# alwyays update dependencies
+RUN apk update && apk upgrade -a
+
+# upgrade pip and install libs
+RUN apk --no-cache upgrade \
+    && pip install --upgrade pip \
+    && apk --no-cache add tzdata build-base bash
 
 WORKDIR /airbyte/integration_code
 COPY setup.py ./

--- a/airbyte-integrations/connectors/source-us-census/Dockerfile
+++ b/airbyte-integrations/connectors/source-us-census/Dockerfile
@@ -1,7 +1,12 @@
-FROM python:3.9-slim
+FROM python:3.9.11-alpine3.15 as base
 
-# Bash is installed for more convenient debugging.
-RUN apt-get update && apt-get install -y bash && rm -rf /var/lib/apt/lists/*
+# alwyays update dependencies
+RUN apk update && apk upgrade -a
+
+# upgrade pip and install libs
+RUN apk --no-cache upgrade \
+    && pip install --upgrade pip \
+    && apk --no-cache add tzdata build-base bash
 
 WORKDIR /airbyte/integration_code
 COPY source_us_census ./source_us_census

--- a/airbyte-integrations/connectors/source-vantage/Dockerfile
+++ b/airbyte-integrations/connectors/source-vantage/Dockerfile
@@ -1,13 +1,16 @@
 FROM python:3.9.11-alpine3.15 as base
 
+# alwyays update dependencies
+RUN apk update && apk upgrade -a
+
 # build and load all requirements
 FROM base as builder
 WORKDIR /airbyte/integration_code
 
-# upgrade pip to the latest version
+# upgrade pip and install libs
 RUN apk --no-cache upgrade \
     && pip install --upgrade pip \
-    && apk --no-cache add tzdata build-base
+    && apk --no-cache add tzdata build-base bash
 
 
 COPY setup.py ./
@@ -24,8 +27,7 @@ COPY --from=builder /install /usr/local
 COPY --from=builder /usr/share/zoneinfo/Etc/UTC /etc/localtime
 RUN echo "Etc/UTC" > /etc/timezone
 
-# bash is installed for more convenient debugging.
-RUN apk --no-cache add bash
+
 
 # copy payload code only
 COPY main.py ./

--- a/airbyte-integrations/connectors/source-visma-economic/Dockerfile
+++ b/airbyte-integrations/connectors/source-visma-economic/Dockerfile
@@ -1,13 +1,16 @@
 FROM python:3.9.11-alpine3.15 as base
 
+# alwyays update dependencies
+RUN apk update && apk upgrade -a
+
 # build and load all requirements
 FROM base as builder
 WORKDIR /airbyte/integration_code
 
-# upgrade pip to the latest version
+# upgrade pip and install libs
 RUN apk --no-cache upgrade \
     && pip install --upgrade pip \
-    && apk --no-cache add tzdata build-base
+    && apk --no-cache add tzdata build-base bash
 
 
 COPY setup.py ./
@@ -24,8 +27,7 @@ COPY --from=builder /install /usr/local
 COPY --from=builder /usr/share/zoneinfo/Etc/UTC /etc/localtime
 RUN echo "Etc/UTC" > /etc/timezone
 
-# bash is installed for more convenient debugging.
-RUN apk --no-cache add bash
+
 
 # copy payload code only
 COPY main.py ./

--- a/airbyte-integrations/connectors/source-vitally/Dockerfile
+++ b/airbyte-integrations/connectors/source-vitally/Dockerfile
@@ -1,13 +1,16 @@
 FROM python:3.9.11-alpine3.15 as base
 
+# alwyays update dependencies
+RUN apk update && apk upgrade -a
+
 # build and load all requirements
 FROM base as builder
 WORKDIR /airbyte/integration_code
 
-# upgrade pip to the latest version
+# upgrade pip and install libs
 RUN apk --no-cache upgrade \
     && pip install --upgrade pip \
-    && apk --no-cache add tzdata build-base
+    && apk --no-cache add tzdata build-base bash
 
 
 COPY setup.py ./
@@ -24,8 +27,7 @@ COPY --from=builder /install /usr/local
 COPY --from=builder /usr/share/zoneinfo/Etc/UTC /etc/localtime
 RUN echo "Etc/UTC" > /etc/timezone
 
-# bash is installed for more convenient debugging.
-RUN apk --no-cache add bash
+
 
 # copy payload code only
 COPY main.py ./

--- a/airbyte-integrations/connectors/source-waiteraid/Dockerfile
+++ b/airbyte-integrations/connectors/source-waiteraid/Dockerfile
@@ -1,13 +1,16 @@
 FROM python:3.9.11-alpine3.15 as base
 
+# alwyays update dependencies
+RUN apk update && apk upgrade -a
+
 # build and load all requirements
 FROM base as builder
 WORKDIR /airbyte/integration_code
 
-# upgrade pip to the latest version
+# upgrade pip and install libs
 RUN apk --no-cache upgrade \
     && pip install --upgrade pip \
-    && apk --no-cache add tzdata build-base
+    && apk --no-cache add tzdata build-base bash
 
 
 COPY setup.py ./
@@ -24,8 +27,7 @@ COPY --from=builder /install /usr/local
 COPY --from=builder /usr/share/zoneinfo/Etc/UTC /etc/localtime
 RUN echo "Etc/UTC" > /etc/timezone
 
-# bash is installed for more convenient debugging.
-RUN apk --no-cache add bash
+
 
 # copy payload code only
 COPY main.py ./

--- a/airbyte-integrations/connectors/source-weatherstack/Dockerfile
+++ b/airbyte-integrations/connectors/source-weatherstack/Dockerfile
@@ -1,13 +1,16 @@
-FROM python:3.9.13-alpine3.15 as base
+FROM python:3.9.11-alpine3.15 as base
+
+# alwyays update dependencies
+RUN apk update && apk upgrade -a
 
 # build and load all requirements
 FROM base as builder
 WORKDIR /airbyte/integration_code
 
-# upgrade pip to the latest version
+# upgrade pip and install libs
 RUN apk --no-cache upgrade \
     && pip install --upgrade pip \
-    && apk --no-cache add tzdata build-base
+    && apk --no-cache add tzdata build-base bash
 
 
 COPY setup.py ./
@@ -24,8 +27,7 @@ COPY --from=builder /install /usr/local
 COPY --from=builder /usr/share/zoneinfo/Etc/UTC /etc/localtime
 RUN echo "Etc/UTC" > /etc/timezone
 
-# bash is installed for more convenient debugging.
-RUN apk --no-cache add bash
+
 
 # copy payload code only
 COPY main.py ./

--- a/airbyte-integrations/connectors/source-webflow/Dockerfile
+++ b/airbyte-integrations/connectors/source-webflow/Dockerfile
@@ -1,13 +1,16 @@
 FROM python:3.9.11-alpine3.15 as base
 
+# alwyays update dependencies
+RUN apk update && apk upgrade -a
+
 # build and load all requirements
 FROM base as builder
 WORKDIR /airbyte/integration_code
 
-# upgrade pip to the latest version
+# upgrade pip and install libs
 RUN apk --no-cache upgrade \
     && pip install --upgrade pip \
-    && apk --no-cache add tzdata build-base
+    && apk --no-cache add tzdata build-base bash
 
 
 COPY setup.py ./
@@ -24,8 +27,7 @@ COPY --from=builder /install /usr/local
 COPY --from=builder /usr/share/zoneinfo/Etc/UTC /etc/localtime
 RUN echo "Etc/UTC" > /etc/timezone
 
-# bash is installed for more convenient debugging.
-RUN apk --no-cache add bash
+
 
 # copy payload code only
 COPY main.py ./

--- a/airbyte-integrations/connectors/source-whisky-hunter/Dockerfile
+++ b/airbyte-integrations/connectors/source-whisky-hunter/Dockerfile
@@ -1,13 +1,16 @@
 FROM python:3.9.11-alpine3.15 as base
 
+# alwyays update dependencies
+RUN apk update && apk upgrade -a
+
 # build and load all requirements
 FROM base as builder
 WORKDIR /airbyte/integration_code
 
-# upgrade pip to the latest version
+# upgrade pip and install libs
 RUN apk --no-cache upgrade \
     && pip install --upgrade pip \
-    && apk --no-cache add tzdata build-base
+    && apk --no-cache add tzdata build-base bash
 
 
 COPY setup.py ./
@@ -24,8 +27,7 @@ COPY --from=builder /install /usr/local
 COPY --from=builder /usr/share/zoneinfo/Etc/UTC /etc/localtime
 RUN echo "Etc/UTC" > /etc/timezone
 
-# bash is installed for more convenient debugging.
-RUN apk --no-cache add bash
+
 
 # copy payload code only
 COPY main.py ./

--- a/airbyte-integrations/connectors/source-wikipedia-pageviews/Dockerfile
+++ b/airbyte-integrations/connectors/source-wikipedia-pageviews/Dockerfile
@@ -1,13 +1,16 @@
 FROM python:3.9.11-alpine3.15 as base
 
+# alwyays update dependencies
+RUN apk update && apk upgrade -a
+
 # build and load all requirements
 FROM base as builder
 WORKDIR /airbyte/integration_code
 
-# upgrade pip to the latest version
+# upgrade pip and install libs
 RUN apk --no-cache upgrade \
     && pip install --upgrade pip \
-    && apk --no-cache add tzdata build-base
+    && apk --no-cache add tzdata build-base bash
 
 
 COPY setup.py ./
@@ -24,8 +27,7 @@ COPY --from=builder /install /usr/local
 COPY --from=builder /usr/share/zoneinfo/Etc/UTC /etc/localtime
 RUN echo "Etc/UTC" > /etc/timezone
 
-# bash is installed for more convenient debugging.
-RUN apk --no-cache add bash
+
 
 # copy payload code only
 COPY main.py ./

--- a/airbyte-integrations/connectors/source-woocommerce/Dockerfile
+++ b/airbyte-integrations/connectors/source-woocommerce/Dockerfile
@@ -1,13 +1,16 @@
 FROM python:3.9.11-alpine3.15 as base
 
+# alwyays update dependencies
+RUN apk update && apk upgrade -a
+
 # build and load all requirements
 FROM base as builder
 WORKDIR /airbyte/integration_code
 
-# upgrade pip to the latest version
+# upgrade pip and install libs
 RUN apk --no-cache upgrade \
     && pip install --upgrade pip \
-    && apk --no-cache add tzdata build-base
+    && apk --no-cache add tzdata build-base bash
 
 
 COPY setup.py ./
@@ -24,8 +27,7 @@ COPY --from=builder /install /usr/local
 COPY --from=builder /usr/share/zoneinfo/Etc/UTC /etc/localtime
 RUN echo "Etc/UTC" > /etc/timezone
 
-# bash is installed for more convenient debugging.
-RUN apk --no-cache add bash
+
 
 # copy payload code only
 COPY main.py ./

--- a/airbyte-integrations/connectors/source-workable/Dockerfile
+++ b/airbyte-integrations/connectors/source-workable/Dockerfile
@@ -1,13 +1,16 @@
 FROM python:3.9.11-alpine3.15 as base
 
+# alwyays update dependencies
+RUN apk update && apk upgrade -a
+
 # build and load all requirements
 FROM base as builder
 WORKDIR /airbyte/integration_code
 
-# upgrade pip to the latest version
+# upgrade pip and install libs
 RUN apk --no-cache upgrade \
     && pip install --upgrade pip \
-    && apk --no-cache add tzdata build-base
+    && apk --no-cache add tzdata build-base bash
 
 
 COPY setup.py ./
@@ -24,8 +27,7 @@ COPY --from=builder /install /usr/local
 COPY --from=builder /usr/share/zoneinfo/Etc/UTC /etc/localtime
 RUN echo "Etc/UTC" > /etc/timezone
 
-# bash is installed for more convenient debugging.
-RUN apk --no-cache add bash
+
 
 # copy payload code only
 COPY main.py ./

--- a/airbyte-integrations/connectors/source-workramp/Dockerfile
+++ b/airbyte-integrations/connectors/source-workramp/Dockerfile
@@ -1,13 +1,16 @@
 FROM python:3.9.11-alpine3.15 as base
 
+# alwyays update dependencies
+RUN apk update && apk upgrade -a
+
 # build and load all requirements
 FROM base as builder
 WORKDIR /airbyte/integration_code
 
-# upgrade pip to the latest version
+# upgrade pip and install libs
 RUN apk --no-cache upgrade \
     && pip install --upgrade pip \
-    && apk --no-cache add tzdata build-base
+    && apk --no-cache add tzdata build-base bash
 
 
 COPY setup.py ./
@@ -24,8 +27,7 @@ COPY --from=builder /install /usr/local
 COPY --from=builder /usr/share/zoneinfo/Etc/UTC /etc/localtime
 RUN echo "Etc/UTC" > /etc/timezone
 
-# bash is installed for more convenient debugging.
-RUN apk --no-cache add bash
+
 
 # copy payload code only
 COPY main.py ./

--- a/airbyte-integrations/connectors/source-wrike/Dockerfile
+++ b/airbyte-integrations/connectors/source-wrike/Dockerfile
@@ -1,13 +1,16 @@
 FROM python:3.9.11-alpine3.15 as base
 
+# alwyays update dependencies
+RUN apk update && apk upgrade -a
+
 # build and load all requirements
 FROM base as builder
 WORKDIR /airbyte/integration_code
 
-# upgrade pip to the latest version
+# upgrade pip and install libs
 RUN apk --no-cache upgrade \
     && pip install --upgrade pip \
-    && apk --no-cache add tzdata build-base
+    && apk --no-cache add tzdata build-base bash
 
 
 COPY setup.py ./
@@ -24,8 +27,7 @@ COPY --from=builder /install /usr/local
 COPY --from=builder /usr/share/zoneinfo/Etc/UTC /etc/localtime
 RUN echo "Etc/UTC" > /etc/timezone
 
-# bash is installed for more convenient debugging.
-RUN apk --no-cache add bash
+
 
 # copy payload code only
 COPY main.py ./

--- a/airbyte-integrations/connectors/source-xero/Dockerfile
+++ b/airbyte-integrations/connectors/source-xero/Dockerfile
@@ -1,13 +1,16 @@
-FROM python:3.9.13-alpine3.15 as base
+FROM python:3.9.11-alpine3.15 as base
+
+# alwyays update dependencies
+RUN apk update && apk upgrade -a
 
 # build and load all requirements
 FROM base as builder
 WORKDIR /airbyte/integration_code
 
-# upgrade pip to the latest version
+# upgrade pip and install libs
 RUN apk --no-cache upgrade \
     && pip install --upgrade pip \
-    && apk --no-cache add tzdata build-base
+    && apk --no-cache add tzdata build-base bash
 
 
 COPY setup.py ./
@@ -24,8 +27,7 @@ COPY --from=builder /install /usr/local
 COPY --from=builder /usr/share/zoneinfo/Etc/UTC /etc/localtime
 RUN echo "Etc/UTC" > /etc/timezone
 
-# bash is installed for more convenient debugging.
-RUN apk --no-cache add bash
+
 
 # copy payload code only
 COPY main.py ./

--- a/airbyte-integrations/connectors/source-xkcd/Dockerfile
+++ b/airbyte-integrations/connectors/source-xkcd/Dockerfile
@@ -1,13 +1,16 @@
-FROM python:3.9.13-alpine3.15 as base
+FROM python:3.9.11-alpine3.15 as base
+
+# alwyays update dependencies
+RUN apk update && apk upgrade -a
 
 # build and load all requirements
 FROM base as builder
 WORKDIR /airbyte/integration_code
 
-# upgrade pip to the latest version
+# upgrade pip and install libs
 RUN apk --no-cache upgrade \
     && pip install --upgrade pip \
-    && apk --no-cache add tzdata build-base
+    && apk --no-cache add tzdata build-base bash
 
 
 COPY setup.py ./
@@ -24,8 +27,7 @@ COPY --from=builder /install /usr/local
 COPY --from=builder /usr/share/zoneinfo/Etc/UTC /etc/localtime
 RUN echo "Etc/UTC" > /etc/timezone
 
-# bash is installed for more convenient debugging.
-RUN apk --no-cache add bash
+
 
 # copy payload code only
 COPY main.py ./

--- a/airbyte-integrations/connectors/source-yahoo-finance-price/Dockerfile
+++ b/airbyte-integrations/connectors/source-yahoo-finance-price/Dockerfile
@@ -1,13 +1,16 @@
 FROM python:3.9.11-alpine3.15 as base
 
+# alwyays update dependencies
+RUN apk update && apk upgrade -a
+
 # build and load all requirements
 FROM base as builder
 WORKDIR /airbyte/integration_code
 
-# upgrade pip to the latest version
+# upgrade pip and install libs
 RUN apk --no-cache upgrade \
     && pip install --upgrade pip \
-    && apk --no-cache add tzdata build-base
+    && apk --no-cache add tzdata build-base bash
 
 
 COPY setup.py ./
@@ -24,8 +27,7 @@ COPY --from=builder /install /usr/local
 COPY --from=builder /usr/share/zoneinfo/Etc/UTC /etc/localtime
 RUN echo "Etc/UTC" > /etc/timezone
 
-# bash is installed for more convenient debugging.
-RUN apk --no-cache add bash
+
 
 # copy payload code only
 COPY main.py ./

--- a/airbyte-integrations/connectors/source-yandex-metrica/Dockerfile
+++ b/airbyte-integrations/connectors/source-yandex-metrica/Dockerfile
@@ -1,13 +1,16 @@
 FROM python:3.9.11-alpine3.15 as base
 
+# alwyays update dependencies
+RUN apk update && apk upgrade -a
+
 # build and load all requirements
 FROM base as builder
 WORKDIR /airbyte/integration_code
 
-# upgrade pip to the latest version
+# upgrade pip and install libs
 RUN apk --no-cache upgrade \
     && pip install --upgrade pip \
-    && apk --no-cache add tzdata build-base
+    && apk --no-cache add tzdata build-base bash
 
 
 COPY setup.py ./
@@ -24,8 +27,7 @@ COPY --from=builder /install /usr/local
 COPY --from=builder /usr/share/zoneinfo/Etc/UTC /etc/localtime
 RUN echo "Etc/UTC" > /etc/timezone
 
-# bash is installed for more convenient debugging.
-RUN apk --no-cache add bash
+
 
 # copy payload code only
 COPY main.py ./

--- a/airbyte-integrations/connectors/source-younium/Dockerfile
+++ b/airbyte-integrations/connectors/source-younium/Dockerfile
@@ -1,13 +1,16 @@
-FROM python:3.9.13-alpine3.15 as base
+FROM python:3.9.11-alpine3.15 as base
+
+# alwyays update dependencies
+RUN apk update && apk upgrade -a
 
 # build and load all requirements
 FROM base as builder
 WORKDIR /airbyte/integration_code
 
-# upgrade pip to the latest version
+# upgrade pip and install libs
 RUN apk --no-cache upgrade \
     && pip install --upgrade pip \
-    && apk --no-cache add tzdata build-base
+    && apk --no-cache add tzdata build-base bash
 
 
 COPY setup.py ./
@@ -24,8 +27,7 @@ COPY --from=builder /install /usr/local
 COPY --from=builder /usr/share/zoneinfo/Etc/UTC /etc/localtime
 RUN echo "Etc/UTC" > /etc/timezone
 
-# bash is installed for more convenient debugging.
-RUN apk --no-cache add bash
+
 
 # copy payload code only
 COPY main.py ./

--- a/airbyte-integrations/connectors/source-youtube-analytics/Dockerfile
+++ b/airbyte-integrations/connectors/source-youtube-analytics/Dockerfile
@@ -1,13 +1,16 @@
 FROM python:3.9.11-alpine3.15 as base
 
+# alwyays update dependencies
+RUN apk update && apk upgrade -a
+
 # build and load all requirements
 FROM base as builder
 WORKDIR /airbyte/integration_code
 
-# upgrade pip to the latest version
+# upgrade pip and install libs
 RUN apk --no-cache upgrade \
     && pip install --upgrade pip \
-    && apk --no-cache add tzdata build-base
+    && apk --no-cache add tzdata build-base bash
 
 
 COPY setup.py ./
@@ -24,8 +27,7 @@ COPY --from=builder /install /usr/local
 COPY --from=builder /usr/share/zoneinfo/Etc/UTC /etc/localtime
 RUN echo "Etc/UTC" > /etc/timezone
 
-# bash is installed for more convenient debugging.
-RUN apk --no-cache add bash
+
 
 # copy payload code only
 COPY main.py ./

--- a/airbyte-integrations/connectors/source-zapier-supported-storage/Dockerfile
+++ b/airbyte-integrations/connectors/source-zapier-supported-storage/Dockerfile
@@ -1,13 +1,16 @@
 FROM python:3.9.11-alpine3.15 as base
 
+# alwyays update dependencies
+RUN apk update && apk upgrade -a
+
 # build and load all requirements
 FROM base as builder
 WORKDIR /airbyte/integration_code
 
-# upgrade pip to the latest version
+# upgrade pip and install libs
 RUN apk --no-cache upgrade \
     && pip install --upgrade pip \
-    && apk --no-cache add tzdata build-base
+    && apk --no-cache add tzdata build-base bash
 
 
 COPY setup.py ./
@@ -24,8 +27,7 @@ COPY --from=builder /install /usr/local
 COPY --from=builder /usr/share/zoneinfo/Etc/UTC /etc/localtime
 RUN echo "Etc/UTC" > /etc/timezone
 
-# bash is installed for more convenient debugging.
-RUN apk --no-cache add bash
+
 
 # copy payload code only
 COPY main.py ./

--- a/airbyte-integrations/connectors/source-zendesk-chat/Dockerfile
+++ b/airbyte-integrations/connectors/source-zendesk-chat/Dockerfile
@@ -1,7 +1,12 @@
-FROM python:3.9-slim
+FROM python:3.9.11-alpine3.15 as base
 
-# Bash is installed for more convenient debugging.
-RUN apt-get update && apt-get install -y bash && rm -rf /var/lib/apt/lists/*
+# alwyays update dependencies
+RUN apk update && apk upgrade -a
+
+# upgrade pip and install libs
+RUN apk --no-cache upgrade \
+    && pip install --upgrade pip \
+    && apk --no-cache add tzdata build-base bash
 
 ENV CODE_PATH="source_zendesk_chat"
 ENV AIRBYTE_IMPL_MODULE="source_zendesk_chat"

--- a/airbyte-integrations/connectors/source-zendesk-sell/Dockerfile
+++ b/airbyte-integrations/connectors/source-zendesk-sell/Dockerfile
@@ -1,13 +1,16 @@
-FROM python:3.9.13-alpine3.15 as base
+FROM python:3.9.11-alpine3.15 as base
+
+# alwyays update dependencies
+RUN apk update && apk upgrade -a
 
 # build and load all requirements
 FROM base as builder
 WORKDIR /airbyte/integration_code
 
-# upgrade pip to the latest version
+# upgrade pip and install libs
 RUN apk --no-cache upgrade \
     && pip install --upgrade pip \
-    && apk --no-cache add tzdata build-base
+    && apk --no-cache add tzdata build-base bash
 
 
 COPY setup.py ./
@@ -24,8 +27,7 @@ COPY --from=builder /install /usr/local
 COPY --from=builder /usr/share/zoneinfo/Etc/UTC /etc/localtime
 RUN echo "Etc/UTC" > /etc/timezone
 
-# bash is installed for more convenient debugging.
-RUN apk --no-cache add bash
+
 
 # copy payload code only
 COPY main.py ./

--- a/airbyte-integrations/connectors/source-zendesk-sunshine/Dockerfile
+++ b/airbyte-integrations/connectors/source-zendesk-sunshine/Dockerfile
@@ -1,7 +1,12 @@
-FROM python:3.9-slim
+FROM python:3.9.11-alpine3.15 as base
 
-# Bash is installed for more convenient debugging.
-RUN apt-get update && apt-get install -y bash && rm -rf /var/lib/apt/lists/*
+# alwyays update dependencies
+RUN apk update && apk upgrade -a
+
+# upgrade pip and install libs
+RUN apk --no-cache upgrade \
+    && pip install --upgrade pip \
+    && apk --no-cache add tzdata build-base bash
 
 WORKDIR /airbyte/integration_code
 COPY source_zendesk_sunshine ./source_zendesk_sunshine

--- a/airbyte-integrations/connectors/source-zendesk-support/Dockerfile
+++ b/airbyte-integrations/connectors/source-zendesk-support/Dockerfile
@@ -1,4 +1,7 @@
 FROM python:3.9.11-alpine3.15 as base
+
+# alwyays update dependencies
+RUN apk update && apk upgrade -a
 FROM base as builder
 
 

--- a/airbyte-integrations/connectors/source-zendesk-talk/Dockerfile
+++ b/airbyte-integrations/connectors/source-zendesk-talk/Dockerfile
@@ -1,7 +1,12 @@
-FROM python:3.9-slim
+FROM python:3.9.11-alpine3.15 as base
 
-# Bash is installed for more convenient debugging.
-RUN apt-get update && apt-get install -y bash && rm -rf /var/lib/apt/lists/*
+# alwyays update dependencies
+RUN apk update && apk upgrade -a
+
+# upgrade pip and install libs
+RUN apk --no-cache upgrade \
+    && pip install --upgrade pip \
+    && apk --no-cache add tzdata build-base bash
 
 WORKDIR /airbyte/integration_code
 COPY source_zendesk_talk ./source_zendesk_talk

--- a/airbyte-integrations/connectors/source-zenefits/Dockerfile
+++ b/airbyte-integrations/connectors/source-zenefits/Dockerfile
@@ -1,13 +1,16 @@
 FROM python:3.9.11-alpine3.15 as base
 
+# alwyays update dependencies
+RUN apk update && apk upgrade -a
+
 # build and load all requirements
 FROM base as builder
 WORKDIR /airbyte/integration_code
 
-# upgrade pip to the latest version
+# upgrade pip and install libs
 RUN apk --no-cache upgrade \
     && pip install --upgrade pip \
-    && apk --no-cache add tzdata build-base
+    && apk --no-cache add tzdata build-base bash
 
 
 COPY setup.py ./
@@ -24,8 +27,7 @@ COPY --from=builder /install /usr/local
 COPY --from=builder /usr/share/zoneinfo/Etc/UTC /etc/localtime
 RUN echo "Etc/UTC" > /etc/timezone
 
-# bash is installed for more convenient debugging.
-RUN apk --no-cache add bash
+
 
 # copy payload code only
 COPY main.py ./

--- a/airbyte-integrations/connectors/source-zenloop/Dockerfile
+++ b/airbyte-integrations/connectors/source-zenloop/Dockerfile
@@ -1,13 +1,16 @@
 FROM python:3.9.11-alpine3.15 as base
 
+# alwyays update dependencies
+RUN apk update && apk upgrade -a
+
 # build and load all requirements
 FROM base as builder
 WORKDIR /airbyte/integration_code
 
-# upgrade pip to the latest version
+# upgrade pip and install libs
 RUN apk --no-cache upgrade \
     && pip install --upgrade pip \
-    && apk --no-cache add tzdata build-base
+    && apk --no-cache add tzdata build-base bash
 
 
 COPY setup.py ./
@@ -24,8 +27,7 @@ COPY --from=builder /install /usr/local
 COPY --from=builder /usr/share/zoneinfo/Etc/UTC /etc/localtime
 RUN echo "Etc/UTC" > /etc/timezone
 
-# bash is installed for more convenient debugging.
-RUN apk --no-cache add bash
+
 
 # copy payload code only
 COPY main.py ./

--- a/airbyte-integrations/connectors/source-zoho-crm/Dockerfile
+++ b/airbyte-integrations/connectors/source-zoho-crm/Dockerfile
@@ -1,13 +1,16 @@
-FROM python:3.7.11-alpine3.14 as base
+FROM python:3.9.11-alpine3.15 as base
+
+# alwyays update dependencies
+RUN apk update && apk upgrade -a
 
 # build and load all requirements
 FROM base as builder
 WORKDIR /airbyte/integration_code
 
-# upgrade pip to the latest version
+# upgrade pip and install libs
 RUN apk --no-cache upgrade \
     && pip install --upgrade pip \
-    && apk --no-cache add tzdata build-base
+    && apk --no-cache add tzdata build-base bash
 
 
 COPY setup.py ./
@@ -24,8 +27,7 @@ COPY --from=builder /install /usr/local
 COPY --from=builder /usr/share/zoneinfo/Etc/UTC /etc/localtime
 RUN echo "Etc/UTC" > /etc/timezone
 
-# bash is installed for more convenient debugging.
-RUN apk --no-cache add bash
+
 
 # copy payload code only
 COPY main.py ./

--- a/airbyte-integrations/connectors/source-zoom/Dockerfile
+++ b/airbyte-integrations/connectors/source-zoom/Dockerfile
@@ -1,13 +1,16 @@
 FROM python:3.9.11-alpine3.15 as base
 
+# alwyays update dependencies
+RUN apk update && apk upgrade -a
+
 # build and load all requirements
 FROM base as builder
 WORKDIR /airbyte/integration_code
 
-# upgrade pip to the latest version
+# upgrade pip and install libs
 RUN apk --no-cache upgrade \
     && pip install --upgrade pip \
-    && apk --no-cache add tzdata build-base
+    && apk --no-cache add tzdata build-base bash
 
 
 COPY setup.py ./
@@ -24,8 +27,7 @@ COPY --from=builder /install /usr/local
 COPY --from=builder /usr/share/zoneinfo/Etc/UTC /etc/localtime
 RUN echo "Etc/UTC" > /etc/timezone
 
-# bash is installed for more convenient debugging.
-RUN apk --no-cache add bash
+
 
 # copy payload code only
 COPY main.py ./

--- a/airbyte-integrations/connectors/source-zuora/Dockerfile
+++ b/airbyte-integrations/connectors/source-zuora/Dockerfile
@@ -1,19 +1,22 @@
 FROM python:3.9.11-alpine3.15 as base
 
-# build and load all requirements 
+# alwyays update dependencies
+RUN apk update && apk upgrade -a
+
+# build and load all requirements
 FROM base as builder
 WORKDIR /airbyte/integration_code
 
-# upgrade pip to the latest version
+# upgrade pip and install libs
 RUN apk --no-cache upgrade \
     && pip install --upgrade pip \
-    && apk --no-cache add tzdata build-base
+    && apk --no-cache add tzdata build-base bash
 
 COPY setup.py ./
-# install necessary packages to a temporary folder 
+# install necessary packages to a temporary folder
 RUN pip install --prefix=/install .
 
-# build a clean environment  
+# build a clean environment
 FROM base
 WORKDIR /airbyte/integration_code
 
@@ -23,8 +26,7 @@ COPY --from=builder /install /usr/local
 COPY --from=builder /usr/share/zoneinfo/Etc/UTC /etc/localtime
 RUN echo "Etc/UTC" > /etc/timezone
 
-# bash is installed for more convenient debugging.
-RUN apk --no-cache add bash
+
 
 # copy payload code only
 COPY main.py ./

--- a/docs/connector-development/tutorials/build-a-connector-the-hard-way.md
+++ b/docs/connector-development/tutorials/build-a-connector-the-hard-way.md
@@ -6,10 +6,10 @@ description: Building a source connector without using any helpers to learn the 
 
 This tutorial walks you through building a simple Airbyte source without using any helpers to demonstrate the following concepts in Action:
 
-* [The Airbyte Specification](../../understanding-airbyte/airbyte-protocol.md) and the interface implemented by a source connector
-* [The AirbyteCatalog](../../understanding-airbyte/beginners-guide-to-catalog.md)
-* [Packaging your connector](https://docs.airbyte.io/connector-development#1.-implement-and-package-the-connector)
-* [Testing your connector](../testing-connectors/connector-acceptance-tests-reference.md)
+- [The Airbyte Specification](../../understanding-airbyte/airbyte-protocol.md) and the interface implemented by a source connector
+- [The AirbyteCatalog](../../understanding-airbyte/beginners-guide-to-catalog.md)
+- [Packaging your connector](https://docs.airbyte.io/connector-development#1.-implement-and-package-the-connector)
+- [Testing your connector](../testing-connectors/connector-acceptance-tests-reference.md)
 
 At the end of this tutorial, you will have a working source that you will be able to use in the Airbyte UI.
 
@@ -21,8 +21,8 @@ This tutorial can be done entirely on your local workstation.
 
 To run this tutorial, you'll need:
 
-* Docker, Python, and Java with the versions listed in the [tech stack section](../../understanding-airbyte/tech-stack.md).
-* The `requests` Python package installed via `pip install requests` \(or `pip3` if `pip` is linked to a Python2 installation on your system\)
+- Docker, Python, and Java with the versions listed in the [tech stack section](../../understanding-airbyte/tech-stack.md).
+- The `requests` Python package installed via `pip install requests` \(or `pip3` if `pip` is linked to a Python2 installation on your system\)
 
 **A note on running Python**: all the commands below assume that `python` points to a version of Python 3.9 or greater. Verify this by running
 
@@ -34,9 +34,10 @@ Python 3.9.11
 On some systems, `python` points to a Python2 installation and `python3` points to Python3. If this is the case on your machine, substitute all `python` commands in this guide with `python3` . Otherwise, make sure to install Python 3 before beginning.
 
 You need also to install `requests` python library:
-````bash
-pip install requests 
-````
+
+```bash
+pip install requests
+```
 
 ## Our connector: a stock ticker API
 
@@ -47,7 +48,7 @@ Here's the outline of what we'll do to build our connector:
 1. Use the Airbyte connector template to bootstrap the connector package
 2. Implement the methods required by the Airbyte Specification for our connector:
    1. `spec`: declares the user-provided credentials or configuration needed to run the connector
-   2. `check`: tests if the connector can connect with the underlying data source  with the user-provided configuration
+   2. `check`: tests if the connector can connect with the underlying data source with the user-provided configuration
    3. `discover`: declares the different streams of data that this connector can output
    4. `read`: reads data from the underlying data source \(The stock ticker API\)
 3. Package the connector in a Docker image
@@ -56,8 +57,8 @@ Here's the outline of what we'll do to build our connector:
 
 Once we've completed the above steps, we will have built a functioning connector. Then, we'll add some optional functionality:
 
-* Support [incremental sync](../../understanding-airbyte/connections/incremental-append.md)
-* Add custom integration tests
+- Support [incremental sync](../../understanding-airbyte/connections/incremental-append.md)
+- Add custom integration tests
 
 ### 1. Bootstrap the connector package
 
@@ -147,10 +148,10 @@ Let's create a [JSONSchema](http://json-schema.org/) file `spec.json` encoding t
 }
 ```
 
-* `documentationUrl` is the URL that will appear in the UI for the user to gain more info about this connector. Typically this points to `docs.airbyte.io/integrations/sources/source-<connector_name>` but to keep things simple we won't show adding documentation
-* `title` is the "human readable" title displayed in the UI. Without this field, The Stock Ticker field will have the title `stock_ticker` in the UI
-* `description` will be shown in the Airbyte UI under each field to help the user understand it
-* `airbyte_secret` used by Airbyte to determine if the field should be displayed as a password \(e.g: `********`\) in the UI and not readable from the API
+- `documentationUrl` is the URL that will appear in the UI for the user to gain more info about this connector. Typically this points to `docs.airbyte.io/integrations/sources/source-<connector_name>` but to keep things simple we won't show adding documentation
+- `title` is the "human readable" title displayed in the UI. Without this field, The Stock Ticker field will have the title `stock_ticker` in the UI
+- `description` will be shown in the Airbyte UI under each field to help the user understand it
+- `airbyte_secret` used by Airbyte to determine if the field should be displayed as a password \(e.g: `********`\) in the UI and not readable from the API
 
 We'll save this file in the root directory of our connector. Now we have the following files:
 
@@ -234,7 +235,6 @@ Some notes on the above code:
 1. As described in the [specification](https://docs.airbyte.com/understanding-airbyte/airbyte-protocol/#key-takeaways), Airbyte connectors are CLIs which communicate via stdout, so the output of the command is simply a JSON string formatted according to the Airbyte Specification. So to "return" a value we use `print` to output the return value to stdout
 2. All Airbyte commands can output log messages that take the form `{"type":"LOG", "log":"message"}`, so we create a helper method `log(message)` to allow logging
 3. All Airbyte commands can output error messages that take the form `{"type":"TRACE", "trace": {"type": "ERROR", "emitted_at": current_time_in_ms, "error": {"message": error_message}}}}`, so we create a helper method `log_error(message)` to allow error messages
-
 
 Now if we run `python source.py spec` we should see the specification printed out:
 
@@ -504,8 +504,8 @@ python source.py read --config <config_file_path> --catalog <configured_catalog.
 
 Each of these are described in the Airbyte Specification in detail, but we'll give a quick description of the two options we haven't seen so far:
 
-* `--catalog` points to a Configured Catalog. The Configured Catalog contains the contents for the Catalog \(remember the Catalog we output from discover?\). It also contains some configuration information that describes how the data will by replicated. For example, we had `supported_sync_modes` in the Catalog. In the Configured Catalog, we select which of the `supported_sync_modes` we want to use by specifying the `sync_mode` field. \(This is the most complicated concept when working Airbyte, so if it is still not making sense that's okay for now. If you're just dying to understand how the Configured Catalog works checkout the [Beginner's Guide to the Airbyte Catalog](../../understanding-airbyte/beginners-guide-to-catalog.md)\)
-* `--state` points to a state file. The state file is only relevant when some Streams are synced with the sync mode `incremental`, so we'll cover the state file in more detail in the incremental section below
+- `--catalog` points to a Configured Catalog. The Configured Catalog contains the contents for the Catalog \(remember the Catalog we output from discover?\). It also contains some configuration information that describes how the data will by replicated. For example, we had `supported_sync_modes` in the Catalog. In the Configured Catalog, we select which of the `supported_sync_modes` we want to use by specifying the `sync_mode` field. \(This is the most complicated concept when working Airbyte, so if it is still not making sense that's okay for now. If you're just dying to understand how the Configured Catalog works checkout the [Beginner's Guide to the Airbyte Catalog](../../understanding-airbyte/beginners-guide-to-catalog.md)\)
+- `--state` points to a state file. The state file is only relevant when some Streams are synced with the sync mode `incremental`, so we'll cover the state file in more detail in the incremental section below
 
 For our connector, the contents of those two files should be very unsurprising: the connector only supports one Stream, `stock_prices`, so we'd expect the input catalog to contain that stream configured to sync in full refresh. Since our connector doesn't support incremental sync \(yet!\) we'll ignore the state option for now.
 
@@ -556,7 +556,7 @@ def log_error(error_message):
     log_json = {"type": "TRACE", "trace": {"type": "ERROR", "emitted_at": current_time_in_ms, "error": {"message": error_message}}}
     print(json.dumps(log_json))
 
-   
+
 def read(config, catalog):
     # Assert required configuration was provided
     if "api_key" not in config or "stock_ticker" not in config:
@@ -619,7 +619,7 @@ elif command == "read":
     read(config, configured_catalog)
 ```
 
-and: 
+and:
 
 ```python
         log_error("Invalid command. Allowable commands: [spec, check, discover, read]")
@@ -922,7 +922,10 @@ A full connector in less than 200 lines of code. Not bad! We're now ready to pac
 Our connector is very lightweight, so the Dockerfile needed to run it is very light as well. We edit the autogenerated `Dockerfile` so that its contents are as followed:
 
 ```Dockerfile
-FROM python:3.9-slim
+FROM python:3.9.11-alpine3.15 as base
+
+# alwyays update dependencies
+RUN apk update && apk upgrade -a
 
 # We change to a directory unique to us
 WORKDIR /airbyte/integration_code
@@ -982,8 +985,7 @@ and with that, we've packaged our connector in a functioning Docker image. The l
 
 The minimum requirement for testing your connector is to pass the [Connector Acceptance Test](https://docs.airbyte.com/connector-development/testing-connectors/connector-acceptance-tests-reference) suite. The connector acceptence test is a blackbox test suite containing a number of tests that validate your connector behaves as intended by the Airbyte Specification. You're encouraged to add custom test cases for your connector where it makes sense to do so e.g: to test edge cases that are not covered by the standard suite. But at the very least, you must pass Airbyte's acceptance test suite.
 
-The code generator should have already generated a YAML file which configures the test suite. In order to run it, modify the `acceptance-test-config.yaml` file to look like this: 
-
+The code generator should have already generated a YAML file which configures the test suite. In order to run it, modify the `acceptance-test-config.yaml` file to look like this:
 
 ```yaml
 # See [Connector Acceptance Tests](https://docs.airbyte.io/connector-development/testing-connectors/connector-acceptance-tests-reference)
@@ -992,26 +994,26 @@ connector_image: airbyte/source-stock-ticker-api:dev
 acceptance_tests:
   basic_read:
     tests:
-    - config_path: secrets/valid_config.json
-      configured_catalog_path: fullrefresh_configured_catalog.json
-      empty_streams: []
+      - config_path: secrets/valid_config.json
+        configured_catalog_path: fullrefresh_configured_catalog.json
+        empty_streams: []
   connection:
     tests:
-    - config_path: secrets/valid_config.json
-      status: succeed
-    - config_path: secrets/invalid_config.json
-      status: failed
+      - config_path: secrets/valid_config.json
+        status: succeed
+      - config_path: secrets/invalid_config.json
+        status: failed
   discovery:
     tests:
-    - config_path: secrets/valid_config.json
+      - config_path: secrets/valid_config.json
   full_refresh:
     tests:
-    - config_path: secrets/valid_config.json
-      configured_catalog_path: fullrefresh_configured_catalog.json
+      - config_path: secrets/valid_config.json
+        configured_catalog_path: fullrefresh_configured_catalog.json
   spec:
     tests:
-    - config_path: secrets/valid_config.json
-      spec_path: spec.json
+      - config_path: secrets/valid_config.json
+        spec_path: spec.json
 #  incremental: # TODO uncomment this once you implement incremental sync in part 2 of the tutorial
 #    tests:
 #    - config_path: "secrets/config.json"
@@ -1032,7 +1034,7 @@ collecting ...
  test_core.py ✓✓✓✓✓✓✓✓✓✓✓✓✓✓✓✓✓✓✓                                                                                                                                                                                                                                                                                                                           95% █████████▌
  test_full_refresh.py ✓                                                                                                                                                                                                                                                                                                                                    100% ██████████
 
-================== short test summary info ================== 
+================== short test summary info ==================
 SKIPPED [1] connector_acceptance_test/plugin.py:56: Skipping TestIncremental.test_two_sequential_reads because not found in the config
 
 Results (8.91s):
@@ -1091,7 +1093,7 @@ docker compose up
 When Airbyte server is done starting up, it prints the following banner in the log output \(it can take 10-20 seconds for the server to start\):
 
 ```bash
-airbyte-server      | 2022-03-11 18:38:33 INFO i.a.s.ServerApp(start):121 - 
+airbyte-server      | 2022-03-11 18:38:33 INFO i.a.s.ServerApp(start):121 -
 airbyte-server      |     ___    _      __          __
 airbyte-server      |    /   |  (_)____/ /_  __  __/ /____
 airbyte-server      |   / /| | / / ___/ __ \/ / / / __/ _ \
@@ -1102,7 +1104,7 @@ airbyte-server      | --------------------------------------
 airbyte-server      |  Now ready at http://localhost:8000/
 airbyte-server      | --------------------------------------
 airbyte-server      | Version: dev
-airbyte-server      | 
+airbyte-server      |
 ```
 
 After you see the above banner printed out in the terminal window where you are running `docker compose up`, visit [http://localhost:8000](http://localhost:8000) in your browser and log in with the default credentials: username `airbyte` and password `password`.
@@ -1144,12 +1146,12 @@ to find your connector by typing part of its name:
 After you select your connector in the Source type dropdown, the modal will show two more fields: API Key and Stock Ticker.
 Remember that `spec.json` file you created at the very beginning of this tutorial? These fields should correspond to the `properties`
 section of that file. Copy-paste your Polygon.io API key and a stock ticker into these fields and then click "Set up source"
-button at the bottom right of the modal. 
+button at the bottom right of the modal.
 
 ![](../../.gitbook/assets/newsourcetutorial_source_config.png)
 
 Once you click "Set up source", Airbyte will spin up your connector and run "check" method to verify the configuration.
-You will see a progress bar briefly and if the configuration is valid, you will see a success message, 
+You will see a progress bar briefly and if the configuration is valid, you will see a success message,
 the modal will close and you will see your connector on the updated Sources page.
 
 ![](../../.gitbook/assets/newsourcetutorial_sources_stock_ticker.png)
@@ -1171,7 +1173,7 @@ Select "Mirror source structure" in the Destination Namespace, check the checkbo
 
 ![](../../.gitbook/assets/newsourcetutorial_configure_connection.png)
 
-Ta-da! Your connection is now configured to sync once a day. You will see your new connection on the next screen: 
+Ta-da! Your connection is now configured to sync once a day. You will see your new connection on the next screen:
 
 ![](../../.gitbook/assets/newsourcetutorial_connection_done.png)
 
@@ -1203,12 +1205,15 @@ Armed with the knowledge you gained in this guide, here are some places you can 
 This section is not yet complete and will be completed soon. Please reach out to us on [Slack](https://slack.airbyte.io) or [Github](https://github.com/airbytehq/airbyte) if you need the information promised by these sections immediately.
 
 ### Incremental sync
+
 Follow the [next tutorial](adding-incremental-sync.md) to implement incremental sync.
 
 ### Connector Development Kit
+
 Like we mention at the beginning of the tutorial, this guide is meant more for understanding than as a blueprint for implementing production connectors. See the [Connector Development Kit](https://github.com/airbytehq/airbyte/tree/master/airbyte-cdk/python/docs/tutorials) for the frameworks you should use to build production-ready connectors.
 
 ### Language specific helpers
- * [Building a Python Source](https://docs.airbyte.com/connector-development/tutorials/building-a-python-source)
- * [Building a Python Destination](https://docs.airbyte.com/connector-development/tutorials/building-a-python-destination)
- * [Building a Java Destination](https://docs.airbyte.com/connector-development/tutorials/building-a-java-destination)
+
+- [Building a Python Source](https://docs.airbyte.com/connector-development/tutorials/building-a-python-source)
+- [Building a Python Destination](https://docs.airbyte.com/connector-development/tutorials/building-a-python-destination)
+- [Building a Java Destination](https://docs.airbyte.com/connector-development/tutorials/building-a-java-destination)

--- a/octavia-cli/Dockerfile
+++ b/octavia-cli/Dockerfile
@@ -1,4 +1,7 @@
-FROM python:3.9-slim as base
+FROM python:3.9.11-alpine3.15 as base
+
+# alwyays update dependencies
+RUN apk update && apk upgrade -a
 
 RUN apt-get upgrade \
     && pip install --upgrade pip

--- a/tools/bin/ci_docker_scan.sh
+++ b/tools/bin/ci_docker_scan.sh
@@ -1,0 +1,41 @@
+#!/usr/bin/env bash
+
+set -e
+
+. tools/lib/lib.sh
+
+# build & runs docker scan for an integration name
+# run from the root of the monorepo
+# utilization like `./tools/bin/ci_docker_scan.sh source-github`
+
+connector="$1"
+tag="dev"
+severity="medium"
+
+if [[ "$connector" == *"base-normalization"* ]]; then
+  echo "Skipping base scan..."
+  exit 0
+elif [[ "$connector" == *"source-acceptance-test"* ]]; then
+  buildCommand="$(_to_gradle_path "airbyte-integrations/bases/$connector_name" build)"
+  export SUB_BUILD="CONNECTORS_BASE"
+elif [[ "$connector" == *"bases"* ]]; then
+  echo "Skipping base scan..."
+  exit 0
+elif [[ "$connector" == *"connectors"* ]]; then
+  buildCommand="$(_to_gradle_path "airbyte-integrations/$connector" build)"
+else
+  buildCommand=":airbyte-integrations:connectors:$connector:build"
+fi
+
+if [ -n "$buildCommand" ] ; then
+  echo "----- Building $connector Container -----"
+  echo "Running: ./gradlew --no-daemon --scan $buildCommand -x test -x _unitTestCoverage"
+  ./gradlew --no-daemon --scan "$buildCommand" -x test -x _unitTestCoverage
+else
+  echo "Connector '$connector' not found..."
+  exit 1
+fi
+
+echo "----- Starting $connector Docker Scan -----"
+
+docker scan --accept-license --severity="$severity" "airbyte/$connector:$tag"

--- a/tools/code-generator/Dockerfile
+++ b/tools/code-generator/Dockerfile
@@ -1,4 +1,7 @@
-FROM python:3.11.0b5-alpine3.15 as base
+FROM python:3.9.11-alpine3.15 as base
+
+# alwyays update dependencies
+RUN apk update && apk upgrade -a
 FROM base as builder
 
 

--- a/tools/openapi2jsonschema/Dockerfile
+++ b/tools/openapi2jsonschema/Dockerfile
@@ -1,4 +1,7 @@
-FROM python:3.9-slim
+FROM python:3.9.11-alpine3.15 as base
+
+# alwyays update dependencies
+RUN apk update && apk upgrade -a
 
 RUN apt-get update && apt-get install -y git && rm -rf /var/lib/apt/lists/*
 


### PR DESCRIPTION
This PR replaces https://github.com/airbytehq/airbyte/pull/21631
This PR closes https://github.com/airbytehq/airbyte-internal-issues/issues/1292

This PR prepares to add `docker scan` to our `/test` connector test.  Docker scan queries the SNYK database of vulnerabilities and checks that nothing shady is going on within our connectors.

This PR 
1. Adds `./tools/bin/ci_docker_scan.sh` to build the connector and `run docker` scan against it.  You can try this locally e.g. `./tools/bin/ci_docker_scan.sh soruce-github`
2. Update all the python connectors to 
    a. use `python:3.9.11-alpine3.15` as their base image and run `RUN apk update && apk upgrade -a` as part of the build process, updating all system packages.  About ~30 connectors used an outdated ubuntu base image before this change.  We'll get smaller connector images now!
    b. run `RUN yum update -y` for our base Java images


Note:
At this moment, all the python connectors seem to build and pass the `docker scan` now.  I didn't test every connector, but the ~20 I did locally are OK.  None of the Java connectors pass

Here's the output for scanning `source-postgres` due to out-of-date java dependencies:

```
Testing airbyte/source-postgres:dev...

Tested 278 dependencies for known issues, found 20 issues.


Issues to fix by upgrading:

  Upgrade com.amazonaws:aws-java-sdk-s3@1.12.6 to com.amazonaws:aws-java-sdk-s3@1.12.414 to fix
  ✗ Directory Traversal [Medium Severity][https://security.snyk.io/vuln/SNYK-JAVA-COMAMAZONAWS-2952700] in com.amazonaws:aws-java-sdk-s3@1.12.6
    introduced by com.amazonaws:aws-java-sdk-s3@1.12.6

  Upgrade io.netty:netty-codec@4.1.63.Final to io.netty:netty-codec@4.1.68.Final to fix
  ✗ Denial of Service (DoS) [High Severity][https://security.snyk.io/vuln/SNYK-JAVA-IONETTY-1584063] in io.netty:netty-codec@4.1.63.Final
    introduced by io.netty:netty-codec@4.1.63.Final
  ✗ Denial of Service (DoS) [High Severity][https://security.snyk.io/vuln/SNYK-JAVA-IONETTY-1584064] in io.netty:netty-codec@4.1.63.Final
    introduced by io.netty:netty-codec@4.1.63.Final

  Upgrade io.netty:netty-codec-http@4.1.63.Final to io.netty:netty-codec-http@4.1.71.Final to fix
  ✗ HTTP Request Smuggling [Medium Severity][https://security.snyk.io/vuln/SNYK-JAVA-IONETTY-2314893] in io.netty:netty-codec-http@4.1.63.Final
    introduced by io.netty:netty-codec-http@4.1.63.Final

  Upgrade io.netty:netty-common@4.1.63.Final to io.netty:netty-common@4.1.77.Final to fix
  ✗ Information Exposure [Medium Severity][https://security.snyk.io/vuln/SNYK-JAVA-IONETTY-2812456] in io.netty:netty-common@4.1.63.Final
    introduced by io.netty:netty-common@4.1.63.Final

  Upgrade org.apache.commons:commons-compress@1.20 to org.apache.commons:commons-compress@1.21 to fix
  ✗ Denial of Service (DoS) [Medium Severity][https://security.snyk.io/vuln/SNYK-JAVA-ORGAPACHECOMMONS-1316638] in org.apache.commons:commons-compress@1.20
    introduced by org.apache.commons:commons-compress@1.20
  ✗ Denial of Service (DoS) [Medium Severity][https://security.snyk.io/vuln/SNYK-JAVA-ORGAPACHECOMMONS-1316639] in org.apache.commons:commons-compress@1.20
    introduced by org.apache.commons:commons-compress@1.20
  ✗ Denial of Service (DoS) [Medium Severity][https://security.snyk.io/vuln/SNYK-JAVA-ORGAPACHECOMMONS-1316640] in org.apache.commons:commons-compress@1.20
    introduced by org.apache.commons:commons-compress@1.20
  ✗ Denial of Service (DoS) [High Severity][https://security.snyk.io/vuln/SNYK-JAVA-ORGAPACHECOMMONS-1316641] in org.apache.commons:commons-compress@1.20
    introduced by org.apache.commons:commons-compress@1.20

  Upgrade org.apache.kafka:kafka-clients@3.2.0 to org.apache.kafka:kafka-clients@3.4.0 to fix
  ✗ Deserialization of Untrusted Data (new) [Medium Severity][https://security.snyk.io/vuln/SNYK-JAVA-ORGAPACHEKAFKA-3317161] in org.apache.kafka:kafka-clients@3.2.0
    introduced by org.apache.kafka:kafka-clients@3.2.0

  Upgrade org.apache.sshd:sshd-common@2.8.0 to org.apache.sshd:sshd-common@2.9.2 to fix
  ✗ Deserialization of Untrusted Data [High Severity][https://security.snyk.io/vuln/SNYK-JAVA-ORGAPACHESSHD-3121053] in org.apache.sshd:sshd-common@2.8.0
    introduced by org.apache.sshd:sshd-common@2.8.0

  Upgrade org.bouncycastle:bcprov-jdk15on@1.66 to org.bouncycastle:bcprov-jdk15on@1.69 to fix
  ✗ Cryptographic Issues [Medium Severity][https://security.snyk.io/vuln/SNYK-JAVA-ORGBOUNCYCASTLE-2841508] in org.bouncycastle:bcprov-jdk15on@1.66
    introduced by org.bouncycastle:bcprov-jdk15on@1.66
  ✗ Comparison Using Wrong Factors [High Severity][https://security.snyk.io/vuln/SNYK-JAVA-ORGBOUNCYCASTLE-1052448] in org.bouncycastle:bcprov-jdk15on@1.66
    introduced by org.bouncycastle:bcprov-jdk15on@1.66

  Upgrade org.elasticsearch:elasticsearch@7.11.1 to org.elasticsearch:elasticsearch@7.17.1 to fix
  ✗ Cross-site Scripting (XSS) [Medium Severity][https://security.snyk.io/vuln/SNYK-JAVA-ORGELASTICSEARCH-2431020] in org.elasticsearch:elasticsearch@7.11.1
    introduced by org.elasticsearch:elasticsearch@7.11.1
  ✗ Improper Access Control [Medium Severity][https://security.snyk.io/vuln/SNYK-JAVA-ORGELASTICSEARCH-1536746] in org.elasticsearch:elasticsearch@7.11.1
    introduced by org.elasticsearch:elasticsearch@7.11.1
  ✗ Information Exposure [Medium Severity][https://security.snyk.io/vuln/SNYK-JAVA-ORGELASTICSEARCH-1324571] in org.elasticsearch:elasticsearch@7.11.1
    introduced by org.elasticsearch:elasticsearch@7.11.1
  ✗ Denial of Service (DoS) [Medium Severity][https://security.snyk.io/vuln/SNYK-JAVA-ORGELASTICSEARCH-1324572] in org.elasticsearch:elasticsearch@7.11.1
    introduced by org.elasticsearch:elasticsearch@7.11.1
  ✗ Information Disclosure [Medium Severity][https://security.snyk.io/vuln/SNYK-JAVA-ORGELASTICSEARCH-1089258] in org.elasticsearch:elasticsearch@7.11.1
    introduced by org.elasticsearch:elasticsearch@7.11.1


Issues with no direct upgrade or patch:
  ✗ Improper Certificate Validation [Medium Severity][https://security.snyk.io/vuln/SNYK-JAVA-IONETTY-1042268] in io.netty:netty-handler@4.1.63.Final
    introduced by io.netty:netty-handler@4.1.63.Final
  No upgrade or patch available
  ✗ Arbitrary Code Execution [Medium Severity][https://security.snyk.io/vuln/SNYK-JAVA-ORGYAML-3152153] in org.yaml:snakeyaml@1.33
    introduced by org.yaml:snakeyaml@1.33
  No upgrade or patch available



Organization:      evantahlerairbyte
Package manager:   maven
Target file:       /airbyte/lib
Project name:      airbyte/source-postgres:dev:/airbyte/lib
Docker image:      airbyte/source-postgres:dev
Licenses:          enabled


Tested 2 projects, 1 contained vulnerable paths.
```