### PR TITLE
📚 Documentation Typo Fix in Developing On Docker

### DIFF
--- a/docs/contributing-to-airbyte/developing-on-docker.md
+++ b/docs/contributing-to-airbyte/developing-on-docker.md
@@ -68,7 +68,7 @@ The version will be automatically replace with new version when releasing the OS
 
 ### New module
 
-This is trickier than handling the version of an exiting module.
+This is trickier than handling the version of an existing module.
 First your docker file generating an image need to be added to the `.bumpversion.cfg`. For each and every version you want to build with, the 
 docker image will need to be manually tag and push until the PR is merge. The reason is that the build has a check to know if all the potential 
 docker images are present in the docker repository. It is done the following way:


### PR DESCRIPTION
## What
There seems to be a [typo](https://docs.airbyte.com/contributing-to-airbyte/developing-on-docker#:~:text=version%20of%20an-,exiting%20module,-.%20First%20your%20docker) in the **New module** section of developing-on-docker.md.

The previous section talks about **Existing modules** which makes more sense that `exiting modules` is a typo for `existing modules`

![image](https://user-images.githubusercontent.com/38592186/221357267-93471a1a-93c5-4f77-aee2-565460c30a4d.png)

