### PR TITLE
Source Faker: export json files

### DIFF
--- a/airbyte-integrations/connectors/source-faker/setup.py
+++ b/airbyte-integrations/connectors/source-faker/setup.py
@@ -19,7 +19,7 @@ setup(
     author_email="evan@airbyte.io",
     packages=find_packages(),
     install_requires=MAIN_REQUIREMENTS,
-    package_data={"": ["*.json", "schemas/*.json"]},
+    package_data={"": ["*.json", "schemas/*.json", "record_data/*.json"]},
     extras_require={
         "tests": TEST_REQUIREMENTS,
     },

--- a/airbyte-integrations/connectors/source-faker/setup.py
+++ b/airbyte-integrations/connectors/source-faker/setup.py
@@ -19,7 +19,7 @@ setup(
     author_email="evan@airbyte.io",
     packages=find_packages(),
     install_requires=MAIN_REQUIREMENTS,
-    package_data={"": ["*.json"]},
+    package_data={"": ["*.json", "schemas/*.json"]},
     extras_require={
         "tests": TEST_REQUIREMENTS,
     },


### PR DESCRIPTION
## What
This bundles all the JSONs in the `schemas/` directory with the wheel/pip package which gets built when someone runs `pip install` against this package. 

The motivation is that I'm working on a project which directly imports connectors such as this one from another python package e.g `from source_faker import SourceFaker`. But `read` and `discover` don't run properly since this these JSON files are needed for the connector to work but are not being packaged with the pip package produced by this connector. 

## Notes
This is not meaningful enough to require publishing a new connector version so I won't do it. But I'll run `/test` anyways