### PR TITLE
feat: Set number of forks to execute tests in parallel

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -354,6 +354,8 @@ subprojects { subproj ->
     }
 
     test {
+        maxParallelForks = Runtime.runtime.availableProcessors() ?: 1
+
         jacoco {
             enabled = true
             excludes = ['**/*Test*', '**/generated*']

--- a/buildSrc/src/main/groovy/airbyte-integration-test-java.gradle
+++ b/buildSrc/src/main/groovy/airbyte-integration-test-java.gradle
@@ -22,7 +22,9 @@ class AirbyteIntegrationTestJavaPlugin implements Plugin<Project> {
         }
 
         project.task('integrationTestJava', type: Test) {
-            testClassesDirs += project.sourceSets.integrationTestJava.output.classesDirs
+            mustRunAfter project.test
+
+            testClassesDirs = project.sourceSets.integrationTestJava.output.classesDirs
             classpath += project.sourceSets.integrationTestJava.runtimeClasspath
 
             useJUnitPlatform {
@@ -37,15 +39,12 @@ class AirbyteIntegrationTestJavaPlugin implements Plugin<Project> {
                 // showStandardStreams = true
             }
 
-            outputs.upToDateWhen { false }
-
             if(project.hasProperty('airbyteDocker')) {
                 dependsOn project.airbyteDocker
             }
 
             maxHeapSize = '3g'
-
-            mustRunAfter project.test
+            maxParallelForks = Runtime.runtime.availableProcessors() ?: 1
 
             // This is needed to make the destination-snowflake tests succeed - https://github.com/snowflakedb/snowflake-jdbc/issues/589#issuecomment-983944767
             jvmArgs = ["--add-opens=java.base/java.nio=ALL-UNNAMED"]

--- a/buildSrc/src/main/groovy/airbyte-integration-test-java.gradle
+++ b/buildSrc/src/main/groovy/airbyte-integration-test-java.gradle
@@ -39,6 +39,8 @@ class AirbyteIntegrationTestJavaPlugin implements Plugin<Project> {
                 // showStandardStreams = true
             }
 
+            outputs.upToDateWhen { false }
+
             if(project.hasProperty('airbyteDocker')) {
                 dependsOn project.airbyteDocker
             }


### PR DESCRIPTION
## What
Based on the issues [23390](https://github.com/airbytehq/airbyte/issues/23390), the integration test executes already executed tests.
Also based on [23391](https://github.com/airbytehq/airbyte/issues/23391), test are run in serial.
The idea is to remove redundant tests and execute them in parallel to reduce total execution time.

## How
To fix the redundancy in the integration test, we just need to assign the test classes from the integration test folder, and not append them to the already tested tests.

To execute tests in parallel, modifying the variable `maxParallelForks` is enough (default is `1`). Modified for both, `test` and `integrationTest`.
The property `org.gradle.parallel=true` is already set up in `gradle.properties` file, but without `maxParallelForks` it just use one thread.
Also to mention, that this parallelise test internally, meaning that test inside `test` or `integration tests` are running in parallel, but not mixing them. It still has the dependency.

⚠️ This change impacts all connectors (test) and all Java connectors (integration tests) ⚠️ 


## Test
Before changes:
<img width="538" alt="Screenshot 2023-02-28 at 15 30 00" src="https://user-images.githubusercontent.com/42538006/221883782-e90de472-14f9-4919-8105-5f5395735dc8.png">
<img width="790" alt="Screenshot 2023-02-28 at 16 04 26" src="https://user-images.githubusercontent.com/42538006/221893450-d40de6eb-99a3-4c33-af80-95e314e5f78a.png">

After changes:
<img width="532" alt="Screenshot 2023-02-28 at 15 29 03" src="https://user-images.githubusercontent.com/42538006/221883603-282395b4-395f-4991-b0d4-8aaf06c29db9.png">
<img width="795" alt="Screenshot 2023-02-28 at 16 03 48" src="https://user-images.githubusercontent.com/42538006/221893329-66e37130-d444-4bd4-a4d9-2476e2a6c394.png">


## Future work
There are test that are not compatible to run in parallel and they randomly fail:
```
CdcWalLogsPostgresSourceDatatypeTest > testDataTypes() FAILED

[1097](https://github.com/airbytehq/airbyte/actions/runs/4292195225/jobs/7478361953#step:11:1099) org.opentest4j.AssertionFailedError: The streamer test_2_numeric should return all expected values. Missing values: [123, null, 1.2345678901234567E9] ==> expected: <true> but was: <false>
```