### PR TITLE
Added support for periodic buffer flush with tests and uses env variable

### DIFF
--- a/airbyte-config/config-models/src/main/java/io/airbyte/config/Configs.java
+++ b/airbyte-config/config-models/src/main/java/io/airbyte/config/Configs.java
@@ -348,6 +348,8 @@ public interface Configs {
    */
   String getFeatureFlagClient();
 
+  int getFlushBufferFrequencyInMinutes();
+
   /**
    * Defines a default map of environment variables to use for any launched job containers. The
    * expected format is a JSON encoded String -> String map. Make sure to escape properly. Defaults to

--- a/airbyte-config/config-models/src/main/java/io/airbyte/config/EnvConfigs.java
+++ b/airbyte-config/config-models/src/main/java/io/airbyte/config/EnvConfigs.java
@@ -228,6 +228,10 @@ public class EnvConfigs implements Configs {
   private static final String STRICT_COMPARISON_NORMALIZATION_WORKSPACES = "STRICT_COMPARISON_NORMALIZATION_WORKSPACES";
   private static final String STRICT_COMPARISON_NORMALIZATION_TAG = "STRICT_COMPARISON_NORMALIZATION_TAG";
 
+  // The frequency of buffer flushing for destination connectors
+  public static final String PERIODIC_BUFFER_FLUSH = "PERIODIC_BUFFER_FLUSH";
+  public static final int FLUSH_FREQUENCY_MINUTES = 15;
+
   public static final Map<String, Function<EnvConfigs, String>> JOB_SHARED_ENVS = Map.of(
       AIRBYTE_VERSION, (instance) -> instance.getAirbyteVersion().serialize(),
       AIRBYTE_ROLE, EnvConfigs::getAirbyteRole,
@@ -347,6 +351,10 @@ public class EnvConfigs implements Configs {
 
   public Optional<String> getLocalCatalogPath() {
     return Optional.ofNullable(getEnv(LOCAL_CONNECTOR_CATALOG_PATH));
+  }
+
+  public int getFlushBufferFrequencyInMinutes() {
+    return getEnvOrDefault(PERIODIC_BUFFER_FLUSH, FLUSH_FREQUENCY_MINUTES);
   }
 
   @Override

--- a/airbyte-config/config-models/src/test/java/io/airbyte/config/EnvConfigsTest.java
+++ b/airbyte-config/config-models/src/test/java/io/airbyte/config/EnvConfigsTest.java
@@ -368,7 +368,7 @@ class EnvConfigsTest {
     assertEquals(List.of(), config.getDDConstantTags());
 
     envMap.put(EnvConfigs.DD_CONSTANT_TAGS, "airbyte_instance:dev,k8s-cluster:eks-dev");
-    List<String> expected = List.of("airbyte_instance:dev", "k8s-cluster:eks-dev");
+    final List<String> expected = List.of("airbyte_instance:dev", "k8s-cluster:eks-dev");
     assertEquals(expected, config.getDDConstantTags());
     assertEquals(2, config.getDDConstantTags().size());
   }
@@ -469,6 +469,12 @@ class EnvConfigsTest {
         "DEPLOYMENT_MODE", "CLOUD",
         "WORKER_ENVIRONMENT", "DOCKER");
     assertEquals(expected, config.getJobDefaultEnvMap());
+  }
+
+  @Test
+  void testPeriodicBufferFlushRetrieval() {
+    envMap.put(EnvConfigs.PERIODIC_BUFFER_FLUSH, String.valueOf(EnvConfigs.FLUSH_FREQUENCY_MINUTES));
+    assertEquals(EnvConfigs.FLUSH_FREQUENCY_MINUTES, config.getFlushBufferFrequencyInMinutes());
   }
 
   @Test

--- a/airbyte-integrations/bases/base-java/src/main/java/io/airbyte/integrations/destination/record_buffer/InMemoryRecordBufferingStrategy.java
+++ b/airbyte-integrations/bases/base-java/src/main/java/io/airbyte/integrations/destination/record_buffer/InMemoryRecordBufferingStrategy.java
@@ -63,7 +63,6 @@ public class InMemoryRecordBufferingStrategy implements BufferingStrategy {
     if (bufferSizeInBytes + messageSizeInBytes > maxQueueSizeInBytes) {
       flushAll();
       flushed = Optional.of(BufferFlushType.FLUSH_ALL);
-      bufferSizeInBytes = 0;
     }
 
     final List<AirbyteRecordMessage> bufferedRecords = streamBuffer.computeIfAbsent(stream, k -> new ArrayList<>());
@@ -91,6 +90,7 @@ public class InMemoryRecordBufferingStrategy implements BufferingStrategy {
     }
     close();
     clear();
+    bufferSizeInBytes = 0;
   }
 
   @Override

--- a/airbyte-integrations/bases/base-java/src/main/java/io/airbyte/integrations/destination/record_buffer/SerializedBufferingStrategy.java
+++ b/airbyte-integrations/bases/base-java/src/main/java/io/airbyte/integrations/destination/record_buffer/SerializedBufferingStrategy.java
@@ -133,7 +133,6 @@ public class SerializedBufferingStrategy implements BufferingStrategy {
     }
     close();
     clear();
-
     totalBufferSizeInBytes = 0;
   }
 


### PR DESCRIPTION
## What
Closes #21626

Adds support for periodic buffer flush (15 minute) interval buffer flushing when _any_ new AirbyteMessage is passed into the Destination connector. This is supported by _all_ connectors that use `ConsumerFactory` to create their `MessageConsumer`

## How
Updates `BufferedStreamConsumer` to handle periodic flushing while also adding the variable as an environment variable so this can be applied across all Destination connectors that use `BufferedStreamConsumer` and by relation `ConsumerFactory`

Also, fixes a bug where external calls to `flushAll()` did not result in reseting the amount of data available for buffer. This was alleviated by moving logic for reseting available data to within `flushAll()` method

Lastly, adds a comment to the `generateRecords` methods in `BufferedStreamConsumerTest` that better indicates records are generated in 160 byte increments in case people expect exact AirbyteMessage in bytes

## Recommended reading order
1. `BufferedStreamConsumer.java`
2. `BufferedStreamConsumerTest.java`
3. `InMemorySerializedBufferingStrategy.java`
4. `Configs.java`
5. `EnvConfigs.java`
6. `EnvConfigsTest.java`

## 🚨 User Impact 🚨
Are there any breaking changes? What is the end result perceived by the user? If yes, please merge this PR with the 🚨🚨 emoji so changelog authors can further highlight this if needed.

## Pre-merge Checklist
Expand the relevant checklist and delete the others.

<details><summary><strong>New Connector</strong></summary>

### Community member or Airbyter

- [ ] **Community member?** Grant edit access to maintainers ([instructions](https://docs.github.com/en/github/collaborating-with-pull-requests/working-with-forks/allowing-changes-to-a-pull-request-branch-created-from-a-fork#enabling-repository-maintainer-permissions-on-existing-pull-requests))
- [ ] Secrets in the connector's spec are annotated with `airbyte_secret`
- [ ] Unit & integration tests added and passing. Community members, please provide proof of success locally e.g: screenshot or copy-paste unit, integration, and acceptance test output. To run acceptance tests for a Python connector, follow instructions in the README. For java connectors run `./gradlew :airbyte-integrations:connectors:<name>:integrationTest`.
- [ ] Code reviews completed
- [ ] Documentation updated
    - [ ] Connector's `README.md`
    - [ ] Connector's `bootstrap.md`. See [description and examples](https://docs.google.com/document/d/1ypdgmwmEHWv-TrO4_YOQ7pAJGVrMp5BOkEVh831N260/edit?usp=sharing)
    - [ ] `docs/integrations/<source or destination>/<name>.md` including changelog. See changelog [example](https://docs.airbyte.io/integrations/sources/stripe#changelog)
    - [ ] `docs/integrations/README.md`
    - [ ] `airbyte-integrations/builds.md`
- [ ] PR name follows [PR naming conventions](https://docs.airbyte.com/contributing-to-airbyte/issues-and-pull-requests)

### Airbyter

If this is a community PR, the Airbyte engineer reviewing this PR is responsible for the below items.

- [ ] Create a non-forked branch based on this PR and test the below items on it
- [ ] Build is successful
- [ ] If new credentials are required for use in CI, add them to GSM. [Instructions](https://docs.airbyte.io/connector-development#using-credentials-in-ci).
- [ ] [`/test connector=connectors/<name>` command](https://docs.airbyte.io/connector-development#updating-an-existing-connector) is passing
- [ ] New Connector version released on Dockerhub by running the `/publish` command described [here](https://docs.airbyte.io/connector-development#updating-an-existing-connector)
- [ ] After the connector is published, connector added to connector index as described [here](https://docs.airbyte.io/connector-development#publishing-a-connector)
- [ ] Seed specs have been re-generated by building the platform and committing the changes to the seed spec files, as described [here](https://docs.airbyte.io/connector-development#publishing-a-connector)

</details>

<details><summary><strong>Updating a connector</strong></summary>

### Community member or Airbyter

- [ ] Grant edit access to maintainers ([instructions](https://docs.github.com/en/github/collaborating-with-pull-requests/working-with-forks/allowing-changes-to-a-pull-request-branch-created-from-a-fork#enabling-repository-maintainer-permissions-on-existing-pull-requests))
- [ ] Secrets in the connector's spec are annotated with `airbyte_secret`
- [ ] Unit & integration tests added and passing. Community members, please provide proof of success locally e.g: screenshot or copy-paste unit, integration, and acceptance test output. To run acceptance tests for a Python connector, follow instructions in the README. For java connectors run `./gradlew :airbyte-integrations:connectors:<name>:integrationTest`.
- [ ] Code reviews completed
- [ ] Documentation updated
    - [ ] Connector's `README.md`
    - [ ] Connector's `bootstrap.md`. See [description and examples](https://docs.google.com/document/d/1ypdgmwmEHWv-TrO4_YOQ7pAJGVrMp5BOkEVh831N260/edit?usp=sharing)
    - [ ] Changelog updated in `docs/integrations/<source or destination>/<name>.md` including changelog. See changelog [example](https://docs.airbyte.io/integrations/sources/stripe#changelog)
- [ ] PR name follows [PR naming conventions](https://docs.airbyte.com/contributing-to-airbyte/issues-and-pull-requests)

### Airbyter

If this is a community PR, the Airbyte engineer reviewing this PR is responsible for the below items.

- [ ] Create a non-forked branch based on this PR and test the below items on it
- [ ] Build is successful
- [ ] If new credentials are required for use in CI, add them to GSM. [Instructions](https://docs.airbyte.io/connector-development#using-credentials-in-ci).
- [ ] [`/test connector=connectors/<name>` command](https://docs.airbyte.io/connector-development#updating-an-existing-connector) is passing
- [ ] New Connector version released on Dockerhub and connector version bumped by running the `/publish` command described [here](https://docs.airbyte.io/connector-development#updating-an-existing-connector)

</details>

<details><summary><strong>Connector Generator</strong></summary>

- [ ] Issue acceptance criteria met
- [ ] PR name follows [PR naming conventions](https://docs.airbyte.com/contributing-to-airbyte/issues-and-pull-requests)
- [ ] If adding a new generator, add it to the [list of scaffold modules being tested](https://github.com/airbytehq/airbyte/blob/master/airbyte-integrations/connector-templates/generator/build.gradle#L41)
- [ ] The generator test modules (all connectors with `-scaffold` in their name) have been updated with the latest scaffold by running `./gradlew :airbyte-integrations:connector-templates:generator:testScaffoldTemplates` then checking in your changes
- [ ] Documentation which references the generator is updated as needed

</details>
