### PR TITLE
Docs: Fixed some links and added some text to Manage your Airbyte Cloud workspace

### DIFF
--- a/docs/cloud/managing-airbyte-cloud/edit-stream-configuration.md
+++ b/docs/cloud/managing-airbyte-cloud/edit-stream-configuration.md
@@ -11,7 +11,7 @@ The **Transfer** and **Streams** settings include the following parameters:
 | Parameter                            | Description                                                                         |
 |--------------------------------------|-------------------------------------------------------------------------------------|
 | Replication frequency                | How often the data syncs                                                            |
-| [Non-breaking schema updates](https://docs.airbyte.com/cloud/managing-airbyte-cloud/manage-schema-changes) detected | How Airbyte handles syncs when it detects non-breaking schema changes in the source |
+| [Non-breaking schema updates](https://docs.airbyte.com/cloud/managing-airbyte-cloud/manage-schema-changes/#review-non-breaking-schema-changes) detected | How Airbyte handles syncs when it detects non-breaking schema changes in the source |
 | Destination Namespace                | Where the replicated data is written                                                |
 | Destination Stream Prefix            | Helps you identify streams from different connectors                                |
 

--- a/docs/cloud/managing-airbyte-cloud/manage-airbyte-cloud-workspace.md
+++ b/docs/cloud/managing-airbyte-cloud/manage-airbyte-cloud-workspace.md
@@ -60,7 +60,7 @@ To delete a workspace:
 
 ## Single workspace vs. multiple workspaces
  
-You can use one or multiple workspaces with Airbyte Cloud. 
+You can use one or multiple workspaces with Airbyte Cloud, which gives you flexibility in managing user access and billing.
  
 ### Access
 | Number of workspaces | Benefits                                                                      | Considerations                                                                                                                              |

--- a/docs/readme.md
+++ b/docs/readme.md
@@ -6,7 +6,7 @@ Whether you are an Airbyte user or contributor, we have docs for you!
 
 Browse the [connector catalog](integrations) to find the connector you want. In case the connector is not yet supported on Airbyte Cloud, consider using [Airbyte Open Source](#for-airbyte-open-source-users).
 
-Next, check out the [step-by-step tutorial](cloud/getting-started-with-airbyte-cloud) to sign up for Airbyte Cloud, understand Airbyte [concepts](cloud/core-concepts.md), and run your first sync. Then learn how to [manage your Airbyte Cloud account](https://docs.airbyte.com/cloud/category/managing-airbyte-cloud).
+Next, check out the [step-by-step tutorial](cloud/getting-started-with-airbyte-cloud) to sign up for Airbyte Cloud, understand Airbyte [concepts](cloud/core-concepts.md), and run your first sync. Then learn how to [manage your Airbyte Cloud account](https://docs.airbyte.com/category/managing-airbyte-cloud).
 
 ### For Airbyte Open Source users
 


### PR DESCRIPTION
Fixed a couple of links from the [Cloud docs restructure](https://github.com/airbytehq/airbyte/pull/23319) and added a line of text to [Single workspaces vs multiple workspaces](https://docs.airbyte.com/cloud/managing-airbyte-cloud/manage-airbyte-cloud-workspace#single-workspace-vs-multiple-workspaces). 