### PR TITLE
Connector Acceptance Test: Fix Test Discovery backward_compatibility

### DIFF
--- a/airbyte-integrations/bases/connector-acceptance-test/CHANGELOG.md
+++ b/airbyte-integrations/bases/connector-acceptance-test/CHANGELOG.md
@@ -1,5 +1,8 @@
 # Changelog
 
+## 0.7.1
+Fix Test Discovery `backward_compatibility` fixture. [#23681](https://github.com/airbytehq/airbyte/pull/23681)
+
 ## 0.7.0
 Basic read test: add `ignored_fields`, change configuration format by adding optional `bypass_reason` [#22996](https://github.com/airbytehq/airbyte/pull/22996)
 

--- a/airbyte-integrations/bases/connector-acceptance-test/Dockerfile
+++ b/airbyte-integrations/bases/connector-acceptance-test/Dockerfile
@@ -33,7 +33,7 @@ COPY pytest.ini setup.py ./
 COPY connector_acceptance_test ./connector_acceptance_test
 RUN pip install .
 
-LABEL io.airbyte.version=0.7.0
+LABEL io.airbyte.version=0.7.1
 LABEL io.airbyte.name=airbyte/connector-acceptance-test
 
 ENTRYPOINT ["python", "-m", "pytest", "-p", "connector_acceptance_test.plugin", "-r", "fEsx"]

--- a/airbyte-integrations/bases/connector-acceptance-test/connector_acceptance_test/tests/test_core.py
+++ b/airbyte-integrations/bases/connector-acceptance-test/connector_acceptance_test/tests/test_core.py
@@ -501,21 +501,22 @@ class TestDiscovery(BaseTest):
     def skip_backward_compatibility_tests_fixture(
         self,
         inputs: DiscoveryTestConfig,
-        previous_connector_docker_runner: ConnectorRunner,
-        discovered_catalog: MutableMapping[str, AirbyteStream],
-        previous_discovered_catalog: MutableMapping[str, AirbyteStream],
+        previous_connector_docker_runner: ConnectorRunner
     ) -> bool:
-        if discovered_catalog == previous_discovered_catalog:
-            pytest.skip("The previous and actual discovered catalogs are identical.")
-
-        if previous_connector_docker_runner is None:
-            pytest.skip("The previous connector image could not be retrieved.")
-
         # Get the real connector version in case 'latest' is used in the config:
         previous_connector_version = previous_connector_docker_runner._image.labels.get("io.airbyte.version")
 
         if previous_connector_version == inputs.backward_compatibility_tests_config.disable_for_version:
             pytest.skip(f"Backward compatibility tests are disabled for version {previous_connector_version}.")
+
+        def test_catalog_compatibility(
+                discovered_catalog: MutableMapping[str, AirbyteStream],
+                previous_discovered_catalog: MutableMapping[str, AirbyteStream]):
+            if discovered_catalog == previous_discovered_catalog:
+                pytest.skip("The previous and actual discovered catalogs are identical.")
+
+            if previous_connector_docker_runner is None:
+                pytest.skip("The previous connector image could not be retrieved.")
         return False
 
     def test_discover(self, connector_config, docker_runner: ConnectorRunner):

--- a/airbyte-integrations/bases/connector-acceptance-test/connector_acceptance_test/tests/test_core.py
+++ b/airbyte-integrations/bases/connector-acceptance-test/connector_acceptance_test/tests/test_core.py
@@ -514,9 +514,7 @@ class TestDiscovery(BaseTest):
 
     @pytest.fixture(name="skip_backward_catalog_tests")
     def skip_backward_catalog_fixture(
-            self,
-            discovered_catalog: MutableMapping[str, AirbyteStream],
-            previous_discovered_catalog: MutableMapping[str, AirbyteStream]
+        self, discovered_catalog: MutableMapping[str, AirbyteStream], previous_discovered_catalog: MutableMapping[str, AirbyteStream]
     ) -> bool:
         if discovered_catalog == previous_discovered_catalog:
             pytest.skip("The previous and actual discovered catalogs are identical.")

--- a/airbyte-integrations/bases/connector-acceptance-test/connector_acceptance_test/tests/test_core.py
+++ b/airbyte-integrations/bases/connector-acceptance-test/connector_acceptance_test/tests/test_core.py
@@ -499,9 +499,7 @@ class TestConnection(BaseTest):
 class TestDiscovery(BaseTest):
     @pytest.fixture(name="skip_backward_compatibility_tests")
     def skip_backward_compatibility_tests_fixture(
-        self,
-        inputs: DiscoveryTestConfig,
-        previous_connector_docker_runner: ConnectorRunner
+        self, inputs: DiscoveryTestConfig, previous_connector_docker_runner: ConnectorRunner
     ) -> bool:
         # Get the real connector version in case 'latest' is used in the config:
         previous_connector_version = previous_connector_docker_runner._image.labels.get("io.airbyte.version")
@@ -510,13 +508,14 @@ class TestDiscovery(BaseTest):
             pytest.skip(f"Backward compatibility tests are disabled for version {previous_connector_version}.")
 
         def test_catalog_compatibility(
-                discovered_catalog: MutableMapping[str, AirbyteStream],
-                previous_discovered_catalog: MutableMapping[str, AirbyteStream]):
+            discovered_catalog: MutableMapping[str, AirbyteStream], previous_discovered_catalog: MutableMapping[str, AirbyteStream]
+        ):
             if discovered_catalog == previous_discovered_catalog:
                 pytest.skip("The previous and actual discovered catalogs are identical.")
 
             if previous_connector_docker_runner is None:
                 pytest.skip("The previous connector image could not be retrieved.")
+
         return False
 
     def test_discover(self, connector_config, docker_runner: ConnectorRunner):

--- a/airbyte-integrations/bases/connector-acceptance-test/unit_tests/test_backward_compatibility.py
+++ b/airbyte-integrations/bases/connector-acceptance-test/unit_tests/test_backward_compatibility.py
@@ -1334,4 +1334,4 @@ def test_catalog_backward_compatibility(previous_discovered_catalog, discovered_
     t = _TestDiscovery()
     expectation = pytest.raises(NonBackwardCompatibleError) if should_fail else does_not_raise()
     with expectation:
-        t.test_backward_compatibility(False, discovered_catalog, previous_discovered_catalog)
+        t.test_backward_compatibility(False, False, discovered_catalog, previous_discovered_catalog)


### PR DESCRIPTION
## What
Fix Test Discovery `backward_compatibility` fixture.

In `test_backward_compatibility` we call `skip_backward_compatibility_tests_fixture`, which, in turn, calls another fixtures:

1. `inputs`
2. `previous_connector_docker_runner`
3. `discovered_catalog`
4. `previous_discovered_catalog`

In my case, call of `discovered_catalog` and `previous_discovered_catalog` with the same config file will raise an error due to schema error. 

## How

To bypass it, I divided this fixture into 2 to check input version before catalogs comparison:

1. Check flag from provided configuration
2. Check and compare catalogs

In this case, we will not face error in second fixture if we have a flag in first one.



