### PR TITLE
Low CDK: duration macro added

### DIFF
--- a/airbyte-cdk/python/airbyte_cdk/sources/declarative/interpolation/macros.py
+++ b/airbyte-cdk/python/airbyte_cdk/sources/declarative/interpolation/macros.py
@@ -8,6 +8,7 @@ import numbers
 from typing import Union
 
 from dateutil import parser
+from isodate import parse_duration
 
 """
 This file contains macros that can be evaluated by a `JinjaInterpolation` object
@@ -96,6 +97,16 @@ def day_delta(num_days: int, format: str = "%Y-%m-%dT%H:%M:%S.%f%z") -> str:
     return (datetime.datetime.now(datetime.timezone.utc) + datetime.timedelta(days=num_days)).strftime(format)
 
 
+def duration(datestring: str):
+    """
+    Converts ISO8601 duration to datetime.timedelta
+
+    Usage:
+    `"{{ now_utc() - duration('P1D') }}"`
+    """
+    return parse_duration(datestring)
+
+
 def format_datetime(dt: Union[str, datetime.datetime], format: str):
     """
     Converts datetime to another format
@@ -108,5 +119,5 @@ def format_datetime(dt: Union[str, datetime.datetime], format: str):
     return parser.parse(dt).strftime(format)
 
 
-_macros_list = [now_local, now_utc, today_utc, timestamp, max, day_delta, format_datetime]
+_macros_list = [now_local, now_utc, today_utc, timestamp, max, day_delta, duration, format_datetime]
 macros = {f.__name__: f for f in _macros_list}

--- a/airbyte-cdk/python/unit_tests/sources/declarative/interpolation/test_macros.py
+++ b/airbyte-cdk/python/unit_tests/sources/declarative/interpolation/test_macros.py
@@ -17,6 +17,7 @@ from airbyte_cdk.sources.declarative.interpolation.macros import macros
         ("test_max", "max", True),
         ("test_day_delta", "day_delta", True),
         ("test_format_datetime", "format_datetime", True),
+        ("test_duration", "duration", True),
         ("test_not_a_macro", "thisisnotavalidmacro", False),
     ],
 )
@@ -31,3 +32,8 @@ def test_format_datetime():
     format_datetime = macros["format_datetime"]
     assert format_datetime("2022-01-01T01:01:01Z", "%Y-%m-%d") == "2022-01-01"
     assert format_datetime(datetime.datetime(2022, 1, 1, 1, 1, 1), "%Y-%m-%d") == "2022-01-01"
+
+
+def test_duration():
+    duration = macros["duration"]
+    assert duration("P1D") == datetime.timedelta(days=1)


### PR DESCRIPTION
## What
Converts ISO8601 duration to datetime.timedelta

Usage:
`"{{ now_utc() - duration('P1D') }}"`