### PR TITLE
qa-engine: exclude destination weviate and exasol

### DIFF
--- a/tools/ci_connector_ops/ci_connector_ops/qa_engine/constants.py
+++ b/tools/ci_connector_ops/ci_connector_ops/qa_engine/constants.py
@@ -18,6 +18,8 @@ INAPPROPRIATE_FOR_CLOUD_USE_CONNECTORS = [
     "f3802bc4-5406-4752-9e8d-01e504ca8194",  # destination-mqtt, no strict-encrypt variant
     "825c5ee3-ed9a-4dd1-a2b6-79ed722f7b13",  # destination-redpanda, no strict-encrypt variant
     "58e6f9da-904e-11ed-a1eb-0242ac120002",  # destination-teradata, no strict-encrypt variant
+    "bb6071d9-6f34-4766-bec2-d1d4ed81a653",  # destination-exasol, no strict-encrypt variant
+    "7b7d7a0d-954c-45a0-bcfc-39a634b97736",  # destination-weviate, no strict-encrypt variant
 ]
 
 GCS_QA_REPORT_PATH = "gs://airbyte-data-connectors-qa-engine/"

--- a/tools/ci_connector_ops/setup.py
+++ b/tools/ci_connector_ops/setup.py
@@ -24,7 +24,7 @@ TEST_REQUIREMENTS = [
 ]
 
 setup(
-    version="0.1.15",
+    version="0.1.16",
     name="ci_connector_ops",
     description="Packaged maintained by the connector operations team to perform CI for connectors",
     author="Airbyte",


### PR DESCRIPTION
## What
For safety, we want to not mark the destinations without a strict encrypt variant available on cloud.
This PR explicitly excludes `destination-weviate` and `destination-exasol`.
