### PR TITLE
Docs: Updated Airbyte Cloud doc titles

### DIFF
--- a/docs/cloud/managing-airbyte-cloud/manage-airbyte-cloud-notifications.md
+++ b/docs/cloud/managing-airbyte-cloud/manage-airbyte-cloud-notifications.md
@@ -1,4 +1,4 @@
-# Manage Airbyte Cloud notifications
+# Manage notifications
 
 This page provides guidance on how to manage notifications for Airbyte Cloud, allowing you to stay up-to-date on the activities in your workspace. 
 

--- a/docs/cloud/managing-airbyte-cloud/manage-airbyte-cloud-workspace.md
+++ b/docs/cloud/managing-airbyte-cloud/manage-airbyte-cloud-workspace.md
@@ -1,4 +1,4 @@
-# Manage your Airbyte Cloud workspace
+# Manage your workspace
 
 An Airbyte Cloud workspace allows you to collaborate with other users and manage connections under a shared billing account.
 


### PR DESCRIPTION
Removed "Airbyte Cloud" from a couple doc titles for consistency. 