### PR TITLE
Fixes required fields on SurveyMonkey UI

### DIFF
--- a/airbyte-integrations/connectors/source-surveymonkey/source_surveymonkey/spec.json
+++ b/airbyte-integrations/connectors/source-surveymonkey/source_surveymonkey/spec.json
@@ -19,7 +19,7 @@
         "title": "SurveyMonkey Authorization Method",
         "description": "The authorization method to use to retrieve data from SurveyMonkey",
         "type": "object",
-        "required": ["auth_method", "access_token"],
+        "required": ["auth_method", "access_token", "client_id", "client_secret"],
         "order": 2,
         "properties": {
           "auth_method": {


### PR DESCRIPTION
Closes #23769 

## What
The SurveyMonkey UI displays the 'Client ID' and 'Client Secret' fields as optional, but they are actually required for successful setup.
![image](https://user-images.githubusercontent.com/62539376/223389556-37859c18-dcba-42c9-a697-714e79523a8f.png)


## How
This pull request fixes the issue by updating the UI to reflect their true required status.
![image](https://user-images.githubusercontent.com/62539376/223390557-5e26a1f9-f87e-44a0-80a6-1553894bbb1e.png)
