### PR TITLE
Source Zoho CRM: Set airbyte type to string for zoho autonumbers when they include prefix or suffix

### DIFF
--- a/airbyte-integrations/connectors/source-zoho-crm/unit_tests/parametrize.py
+++ b/airbyte-integrations/connectors/source-zoho-crm/unit_tests/parametrize.py
@@ -6,17 +6,17 @@ from collections import namedtuple
 
 import pytest
 
-TestCase = namedtuple("TestCase", ("json_type", "data_type", "length", "decimal_place", "api_name", "pick_list_values", "expected_values"))
+TestCase = namedtuple("TestCase", ("json_type", "data_type", "length", "decimal_place", "api_name", "pick_list_values", "autonumber", "expected_values"))
 
 
 datatype_inputs = pytest.mark.parametrize(
     TestCase._fields,
     (
-        TestCase("boolean", "boolean", None, None, "Field", [], {"title": "Field", "type": ["null", "boolean"]}),
-        TestCase("double", "double", None, 3, "Field", [], {"multipleOf": 0.001, "title": "Field", "type": ["null", "number"]}),
-        TestCase("double", "currency", None, 2, "Field", [], {"multipleOf": 0.01, "title": "Field", "type": ["null", "number"]}),
-        TestCase("integer", "integer", None, None, "Field", [], {"title": "Field", "type": ["null", "integer"]}),
-        TestCase("string", "profileimage", 256, None, "Field", [], {"maxLength": 256, "title": "Field", "type": ["null", "string"]}),
+        TestCase("boolean", "boolean", None, None, "Field", [], None, {"title": "Field", "type": ["null", "boolean"]}),
+        TestCase("double", "double", None, 3, "Field", [], None, {"multipleOf": 0.001, "title": "Field", "type": ["null", "number"]}),
+        TestCase("double", "currency", None, 2, "Field", [], None, {"multipleOf": 0.01, "title": "Field", "type": ["null", "number"]}),
+        TestCase("integer", "integer", None, None, "Field", [], None, {"title": "Field", "type": ["null", "integer"]}),
+        TestCase("string", "profileimage", 256, None, "Field", [], None, {"maxLength": 256, "title": "Field", "type": ["null", "string"]}),
         TestCase(
             "string",
             "picklist",
@@ -24,9 +24,10 @@ datatype_inputs = pytest.mark.parametrize(
             None,
             "Field",
             ["Chelsea", "Arsenal", "ManUtd"],
+            None,
             {"enum": [None, "Chelsea", "Arsenal", "ManUtd"], "maxLength": 128, "title": "Field", "type": ["null", "string"]},
         ),
-        TestCase("string", "textarea", 1024, None, "Field", [], {"maxLength": 1024, "title": "Field", "type": ["null", "string"]}),
+        TestCase("string", "textarea", 1024, None, "Field", [], None, {"maxLength": 1024, "title": "Field", "type": ["null", "string"]}),
         TestCase(
             "string",
             "website",
@@ -34,6 +35,7 @@ datatype_inputs = pytest.mark.parametrize(
             None,
             "Field",
             [],
+            None,
             {
                 "format": "uri",
                 "maxLength": 256,
@@ -48,6 +50,7 @@ datatype_inputs = pytest.mark.parametrize(
             None,
             "Field",
             [],
+            None,
             {
                 "format": "date",
                 "maxLength": 16,
@@ -62,6 +65,7 @@ datatype_inputs = pytest.mark.parametrize(
             None,
             "Field",
             [],
+            None,
             {
                 "format": "date-time",
                 "maxLength": 32,
@@ -69,8 +73,8 @@ datatype_inputs = pytest.mark.parametrize(
                 "type": ["null", "string"],
             },
         ),
-        TestCase("string", "text", 1024, None, "Field", [], {"maxLength": 1024, "title": "Field", "type": ["null", "string"]}),
-        TestCase("string", "phone", 16, None, "Field", [], {"maxLength": 16, "title": "Field", "type": ["null", "string"]}),
+        TestCase("string", "text", 1024, None, "Field", [], None, {"maxLength": 1024, "title": "Field", "type": ["null", "string"]}),
+        TestCase("string", "phone", 16, None, "Field", [], None, {"maxLength": 16, "title": "Field", "type": ["null", "string"]}),
         TestCase(
             "string",
             "bigint",
@@ -78,6 +82,7 @@ datatype_inputs = pytest.mark.parametrize(
             None,
             "Field",
             [],
+            None,
             {
                 "airbyte_type": "big_integer",
                 "maxLength": None,
@@ -92,6 +97,7 @@ datatype_inputs = pytest.mark.parametrize(
             None,
             "Reminder",
             ["15 min", "30 min", "1 hour"],
+            None,
             {"format": "date-time", "title": "Reminder", "type": ["null", "string"]},
         ),
         TestCase(
@@ -101,23 +107,10 @@ datatype_inputs = pytest.mark.parametrize(
             None,
             "Field",
             [],
+            None,
             {
                 "format": "email",
                 "maxLength": 256,
-                "title": "Field",
-                "type": ["null", "string"],
-            },
-        ),
-        TestCase(
-            "string",
-            "autonumber",
-            512,
-            None,
-            "Field",
-            [],
-            {
-                "airbyte_type": "big_integer",
-                "maxLength": 512,
                 "title": "Field",
                 "type": ["null", "string"],
             },
@@ -129,6 +122,7 @@ datatype_inputs = pytest.mark.parametrize(
             None,
             "Field",
             [],
+            None,
             {
                 "additionalProperties": False,
                 "properties": {
@@ -141,8 +135,8 @@ datatype_inputs = pytest.mark.parametrize(
                 "type": ["null", "object"],
             },
         ),
-        TestCase("jsonobject", "RRULE", None, None, "Field", [], {"type": ["null", "object"]}),
-        TestCase("jsonobject", "ALARM", None, None, "Field", [], {"type": ["null", "object"]}),
+        TestCase("jsonobject", "RRULE", None, None, "Field", [], None, {"type": ["null", "object"]}),
+        TestCase("jsonobject", "ALARM", None, None, "Field", [], None, {"type": ["null", "object"]}),
         TestCase(
             "jsonobject",
             "lookup",
@@ -150,6 +144,7 @@ datatype_inputs = pytest.mark.parametrize(
             None,
             "Field",
             [],
+            None,
             {
                 "additionalProperties": False,
                 "properties": {"id": {"type": "string"}, "name": {"type": ["null", "string"]}},
@@ -165,9 +160,19 @@ datatype_inputs = pytest.mark.parametrize(
             None,
             "Field",
             [],
+            None,
             {"items": {"airbyte_type": "big_integer", "type": "string"}, "title": "Field", "type": "array"},
         ),
-        TestCase("jsonarray", "text", 2056, None, "Field", [], {"items": {"type": "string"}, "title": "Field", "type": "array"}),
+        TestCase(
+            "jsonarray",
+            "text",
+            2056,
+            None,
+            "Field",
+            [],
+            None,
+            {"items": {"type": "string"}, "title": "Field", "type": "array"}
+        ),
         TestCase(
             "jsonarray",
             "text",
@@ -175,6 +180,7 @@ datatype_inputs = pytest.mark.parametrize(
             None,
             "Pricing_Details",
             [],
+            None,
             {"items": {"type": "object"}, "title": "Pricing_Details", "type": "array"},
         ),
         TestCase(
@@ -184,6 +190,7 @@ datatype_inputs = pytest.mark.parametrize(
             None,
             "Product_Details",
             [],
+            None,
             {"items": {"type": "object"}, "title": "Product_Details", "type": "array"},
         ),
         TestCase(
@@ -193,6 +200,7 @@ datatype_inputs = pytest.mark.parametrize(
             None,
             "Tag",
             [],
+            None,
             {
                 "items": {
                     "additionalProperties": False,
@@ -211,12 +219,46 @@ datatype_inputs = pytest.mark.parametrize(
             None,
             "Field",
             ["A", "B", "C", "D"],
+            None,
             {
                 "items": {"enum": [None, "A", "B", "C", "D"], "type": ["null", "string"]},
                 "minItems": 1,
                 "title": "Field",
                 "type": "array",
                 "uniqueItems": True,
+            },
+        ),
+        TestCase(
+            "string",
+            "autonumber",
+            512,
+            None,
+            "Field",
+            [],
+            {
+                'prefix': 'prefix',
+                'suffix': 'suffix',
+            },
+            {
+                "format": "string",
+                "maxLength": 512,
+                "title": "Field",
+                "type": ["null", "string"],
+            },
+        ),
+        TestCase(
+            "string",
+            "autonumber",
+            512,
+            None,
+            "Field",
+            [],
+            None,
+            {
+                "airbyte_type": "big_integer",
+                "maxLength": 512,
+                "title": "Field",
+                "type": ["null", "string"],
             },
         ),
     ),

--- a/airbyte-integrations/connectors/source-zoho-crm/unit_tests/test_types.py
+++ b/airbyte-integrations/connectors/source-zoho-crm/unit_tests/test_types.py
@@ -6,7 +6,7 @@ from dataclasses import asdict
 
 import pytest
 from source_zoho_crm.exceptions import IncompleteMetaDataException, UnknownDataTypeException
-from source_zoho_crm.types import FieldMeta, ModuleMeta, ZohoBaseType, ZohoPickListItem
+from source_zoho_crm.types import FieldMeta, ModuleMeta, ZohoBaseType, ZohoPickListItem, AutoNumberDict
 
 from .parametrize import datatype_inputs
 
@@ -76,7 +76,7 @@ def test_field_schema_unknown_type():
 
 
 @datatype_inputs
-def test_field_schema(json_type, data_type, length, decimal_place, api_name, pick_list_values, expected_values):
+def test_field_schema(json_type, data_type, length, decimal_place, api_name, pick_list_values, autonumber, expected_values):
     if pick_list_values:
         pick_list_values = [ZohoPickListItem(actual_value=value, display_value=value) for value in pick_list_values]
     field = FieldMeta(
@@ -88,5 +88,6 @@ def test_field_schema(json_type, data_type, length, decimal_place, api_name, pic
         system_mandatory=True,
         display_label=api_name,
         pick_list_values=pick_list_values,
+        auto_number=(AutoNumberDict.from_dict(autonumber or { 'prefix': '', 'suffix': '' })),
     )
     assert field.schema == expected_values


### PR DESCRIPTION
## What
Zoho connector assumes any autonumber data type maps to airbyte's big_integer. But that is not true as in Zoho you can create incremental fields with strings in them via the prefix/suffix config params resulting in values of the sort "customer14". This results in fields that fail to normalize because airbyte encounters strings in columns that are typed as big_integer.

Example of autonumber metadata from zoho api:

```json
 {
            "system_mandatory": false,
            "webhook": true,
            "json_type": "string",
            "crypt": null,
            "field_label": "Propuesta Name",
            "tooltip": null,
            "created_source": "default",
            "field_read_only": false,
            "display_label": "CustomModule Name",
            "ui_type": 111,
            "read_only": false,
            "association_details": null,
            "businesscard_supported": false,
            "currency": {},
            "id": "<redacted>",
            "custom_field": false,
            "lookup": {},
            "visible": true,
            "length": 120,
            "view_type": {
                "view": true,
                "edit": false,
                "quick_create": false,
                "create": false
            },
            "subform": null,
            "external": null,
            "api_name": "Name",
            "unique": {},
            "history_tracking": false,
            "data_type": "autonumber",
            "formula": {},
            "decimal_place": null,
            "mass_update": false,
            "multiselectlookup": {},
            "pick_list_values": [],
            "auto_number": {
                "starting_number_length": 4,
                "prefix": "Presupuesto",
                "start_number": 9861,
                "suffix": ""
            }
        }
```

## How
When the autonumber includes a prefix or suffix we set the airbyte type string instead of big_integer, otherwise we fallback to big_integer.

I'm no python expert by any means so feel free to correct all my mistakes in this PR.

## 🚨 User Impact 🚨
New zoho discover_catalog calls will parse autonumbers with prefix or suffix as strings instead of big integers. This does not break current connections but changes expected behaviour of new connections with this source.

## Pre-merge Checklist
?

### Community member or Airbyter

- [ ] **Community member?** Grant edit access to maintainers ([instructions](https://docs.github.com/en/github/collaborating-with-pull-requests/working-with-forks/allowing-changes-to-a-pull-request-branch-created-from-a-fork#enabling-repository-maintainer-permissions-on-existing-pull-requests))
- [ ] Secrets in the connector's spec are annotated with `airbyte_secret`
- [ ] Unit & integration tests added and passing. Community members, please provide proof of success locally e.g: screenshot or copy-paste unit, integration, and acceptance test output. To run acceptance tests for a Python connector, follow instructions in the README. For java connectors run `./gradlew :airbyte-integrations:connectors:<name>:integrationTest`.
- [ ] Code reviews completed
- [ ] Documentation updated
    - [ ] Connector's `README.md`
    - [ ] Connector's `bootstrap.md`. See [description and examples](https://docs.google.com/document/d/1ypdgmwmEHWv-TrO4_YOQ7pAJGVrMp5BOkEVh831N260/edit?usp=sharing)
    - [ ] `docs/integrations/<source or destination>/<name>.md` including changelog. See changelog [example](https://docs.airbyte.io/integrations/sources/stripe#changelog)
    - [ ] `docs/integrations/README.md`
    - [ ] `airbyte-integrations/builds.md`
- [ ] PR name follows [PR naming conventions](https://docs.airbyte.com/contributing-to-airbyte/issues-and-pull-requests)

### Airbyter

If this is a community PR, the Airbyte engineer reviewing this PR is responsible for the below items.

- [ ] Create a non-forked branch based on this PR and test the below items on it
- [ ] Build is successful
- [ ] If new credentials are required for use in CI, add them to GSM. [Instructions](https://docs.airbyte.io/connector-development#using-credentials-in-ci).
- [ ] [`/test connector=connectors/<name>` command](https://docs.airbyte.io/connector-development#updating-an-existing-connector) is passing
- [ ] New Connector version released on Dockerhub by running the `/publish` command described [here](https://docs.airbyte.io/connector-development#updating-an-existing-connector)
- [ ] After the connector is published, connector added to connector index as described [here](https://docs.airbyte.io/connector-development#publishing-a-connector)
- [ ] Seed specs have been re-generated by building the platform and committing the changes to the seed spec files, as described [here](https://docs.airbyte.io/connector-development#publishing-a-connector)

</details>

<details><summary><strong>Updating a connector</strong></summary>

### Community member or Airbyter

- [ ] Grant edit access to maintainers ([instructions](https://docs.github.com/en/github/collaborating-with-pull-requests/working-with-forks/allowing-changes-to-a-pull-request-branch-created-from-a-fork#enabling-repository-maintainer-permissions-on-existing-pull-requests))
- [ ] Secrets in the connector's spec are annotated with `airbyte_secret`
- [ ] Unit & integration tests added and passing. Community members, please provide proof of success locally e.g: screenshot or copy-paste unit, integration, and acceptance test output. To run acceptance tests for a Python connector, follow instructions in the README. For java connectors run `./gradlew :airbyte-integrations:connectors:<name>:integrationTest`.
- [ ] Code reviews completed
- [ ] Documentation updated
    - [ ] Connector's `README.md`
    - [ ] Connector's `bootstrap.md`. See [description and examples](https://docs.google.com/document/d/1ypdgmwmEHWv-TrO4_YOQ7pAJGVrMp5BOkEVh831N260/edit?usp=sharing)
    - [ ] Changelog updated in `docs/integrations/<source or destination>/<name>.md` including changelog. See changelog [example](https://docs.airbyte.io/integrations/sources/stripe#changelog)
- [ ] PR name follows [PR naming conventions](https://docs.airbyte.com/contributing-to-airbyte/issues-and-pull-requests)

### Airbyter

If this is a community PR, the Airbyte engineer reviewing this PR is responsible for the below items.

- [ ] Create a non-forked branch based on this PR and test the below items on it
- [ ] Build is successful
- [ ] If new credentials are required for use in CI, add them to GSM. [Instructions](https://docs.airbyte.io/connector-development#using-credentials-in-ci).
- [ ] [`/test connector=connectors/<name>` command](https://docs.airbyte.io/connector-development#updating-an-existing-connector) is passing
- [ ] New Connector version released on Dockerhub and connector version bumped by running the `/publish` command described [here](https://docs.airbyte.io/connector-development#updating-an-existing-connector)

</details>

<details><summary><strong>Connector Generator</strong></summary>

- [ ] Issue acceptance criteria met
- [ ] PR name follows [PR naming conventions](https://docs.airbyte.com/contributing-to-airbyte/issues-and-pull-requests)
- [ ] If adding a new generator, add it to the [list of scaffold modules being tested](https://github.com/airbytehq/airbyte/blob/master/airbyte-integrations/connector-templates/generator/build.gradle#L41)
- [ ] The generator test modules (all connectors with `-scaffold` in their name) have been updated with the latest scaffold by running `./gradlew :airbyte-integrations:connector-templates:generator:testScaffoldTemplates` then checking in your changes
- [ ] Documentation which references the generator is updated as needed

</details>
