### PR TITLE
TEST to fix pipeline issue

### DIFF
--- a/.github/workflows/gradle.yml
+++ b/.github/workflows/gradle.yml
@@ -279,8 +279,11 @@ jobs:
         with:
           python-version: "3.9"
 
-      - name: Install Pyenv
-        run: python3 -m pip install virtualenv==16.7.9 --user
+      - name: Install & Setup Pyenv
+        run: |
+          python3 -m pip install virtualenv==16.7.9 --user
+          cd airbyte-cdk/python
+          python3 -m venv .venv
 
       - name: Install automake
         run: apt-get install -y automake build-essential libtool libtool-bin autoconf

--- a/.github/workflows/gradle.yml
+++ b/.github/workflows/gradle.yml
@@ -280,10 +280,12 @@ jobs:
           python-version: "3.9"
 
       - name: Install & Setup Pyenv
+        # Normally, the `ru.vyarus.use-python` lib should create this environment properly. However, we have seen cases
+        # where the .venv folder exists, but we get "Cannot run program ".venv/bin/python": error=2, No such file or directory"
+        # Running `python3 -m venv .venv` here seems to fix the issue
         run: |
           python3 -m pip install virtualenv==16.7.9 --user
-          cd airbyte-cdk/python
-          python3 -m venv .venv
+          python3 -m venv airbyte-cdk/python/.venv
 
       - name: Install automake
         run: apt-get install -y automake build-essential libtool libtool-bin autoconf


### PR DESCRIPTION
## What
Fixes error like https://github.com/airbytehq/airbyte/actions/runs/4327429815/jobs/7556319706

My best hypothesis right now is that .venv exists but `.venv/bin/python` does not. The reason I think this is the case is that [this checks](https://github.com/xvik/gradle-use-python-plugin/blob/2.3.0/src/main/groovy/ru/vyarus/gradle/plugin/python/task/CheckPythonTask.groovy#L44) passes and the method `exists` [only check if the venv folder exists and is not empty](https://github.com/xvik/gradle-use-python-plugin/blob/2.3.0/src/main/groovy/ru/vyarus/gradle/plugin/python/cmd/Virtualenv.groovy#L104). However, the python binary is clearly not there. 