### PR TITLE
temporary fix for Connectors Base CI

### DIFF
--- a/.github/workflows/gradle.yml
+++ b/.github/workflows/gradle.yml
@@ -261,11 +261,6 @@ jobs:
         with:
           ref: ${{ github.head_ref }}
 
-      - name: Cache Build Artifacts
-        uses: ./.github/actions/cache-build-artifacts
-        with:
-          cache-key: ${{ secrets.CACHE_VERSION }}
-
       - uses: actions/setup-java@v3
         with:
           distribution: "zulu"


### PR DESCRIPTION
## What
Fixes error like https://github.com/airbytehq/airbyte/actions/runs/4327429815/jobs/7556319706

Caching seems to screw the venv. I'll investigate further but this should enable the PRs to be merged at least