### PR TITLE
Revert "temporary fix for Connectors Base CI (#23829)"

### DIFF
--- a/.github/workflows/gradle.yml
+++ b/.github/workflows/gradle.yml
@@ -261,6 +261,11 @@ jobs:
         with:
           ref: ${{ github.head_ref }}
 
+      - name: Cache Build Artifacts
+        uses: ./.github/actions/cache-build-artifacts
+        with:
+          cache-key: ${{ secrets.CACHE_VERSION }}
+
       - uses: actions/setup-java@v3
         with:
           distribution: "zulu"


### PR DESCRIPTION
This reverts commit ed0a4233bbfe5ef8e27ce5f6d80aa1b278d8bae8.

## What
I have identified the specific cache entry that is problematic: https://github.com/airbytehq/airbyte/pull/23834/commits From [this](https://github.com/airbytehq/airbyte/actions/caches?query=Linux-da513e5f2c48cdcc4f1da1d02cf5c0dae8c682f3a92c8600dc7371190ec93341-0ecd6c3153bdf6e7e5693a8f341b2fe8c7f26544f4800c2780d273f236414309-ae5c4f5dec8447f64463ce2a3c94cf616d4dc91ab34212339d02715358a01fae-5974cced2ba720a1dff875ae305c5f96ca455a7f5352ff9091d6a12c0f4e188a), I can see the cache entry was created on `March 3, 2023 3:31 PM EST` (see image). I can see that there was an issue when creating the cache entry: https://github.com/airbytehq/airbyte/actions/runs/4327035598/jobs/7555230176#step:49:4. The message suggests that the cache entry was already created but I can’t find anything on master. 

<img width="1558" alt="image" src="https://user-images.githubusercontent.com/3360483/223528199-a1194836-16c0-4bc0-bf67-23dfd981ad2f.png">

Based on the above, I have deleted the cache entry. This caused the cache entry to be re-created properly this time (see https://github.com/airbytehq/airbyte/actions/runs/4357857324/jobs/7617709307#step:17:1320). I have opened [a PR to re-enable caching](https://github.com/airbytehq/airbyte/pull/23839).If you see this error again, we can disable the cache and investigate why those faulty cache entries get created