### PR TITLE
Docs: Added info about consecutive sync failures

### DIFF
--- a/docs/cloud/managing-airbyte-cloud/understand-airbyte-cloud-limits.md
+++ b/docs/cloud/managing-airbyte-cloud/understand-airbyte-cloud-limits.md
@@ -6,6 +6,8 @@ Understanding the following limitations will help you more effectively manage Ai
 * Max number of sources in a workspace: 100
 * Max number of destinations in a workspace: 100
 * Max number of connections in a workspace: 100
+* Max number of consecutive sync failures before a connection is paused: 100
+* Max number of days with consecutive sync failures before a connection is paused: 14 days
 * Max number of streams that can be returned by a source in a discover call: 1K
 * Max number of streams that can be configured to sync in a single connection: 1K
 * Size of a single record: 100MB


### PR DESCRIPTION
Added info about consecutive sync failures to [Understand Airbyte Cloud limits](https://docs.airbyte.com/cloud/managing-airbyte-cloud/understand-airbyte-cloud-limits)