### PR TITLE
Property to limit test parallelisation

### DIFF
--- a/airbyte-integrations/connectors/destination-snowflake/gradle.properties
+++ b/airbyte-integrations/connectors/destination-snowflake/gradle.properties
@@ -1,0 +1,1 @@
+numThreads=3

--- a/airbyte-integrations/connectors/destination-snowflake/gradle.properties
+++ b/airbyte-integrations/connectors/destination-snowflake/gradle.properties
@@ -1,1 +1,1 @@
-numThreads=3
+numberThreads=3

--- a/airbyte-integrations/connectors/destination-snowflake/gradle.properties
+++ b/airbyte-integrations/connectors/destination-snowflake/gradle.properties
@@ -1,1 +1,1 @@
-numberThreads=3
+numberThreads=2

--- a/build.gradle
+++ b/build.gradle
@@ -354,7 +354,10 @@ subprojects { subproj ->
     }
 
     test {
-        maxParallelForks = Runtime.runtime.availableProcessors() ?: 1
+        //This allows to set up a `gradle.properties` file inside the connector folder to reduce number of threads and reduce parallelization.
+        //Specially useful for connectors that shares resources (like Redshift or Snowflake).
+        ext.numThreads = project.hasProperty('numThreads') ? project.getProperty('numThreads') : Runtime.runtime.availableProcessors() ?: 1
+        maxParallelForks = numThreads
 
         jacoco {
             enabled = true

--- a/build.gradle
+++ b/build.gradle
@@ -356,8 +356,8 @@ subprojects { subproj ->
     test {
         //This allows to set up a `gradle.properties` file inside the connector folder to reduce number of threads and reduce parallelization.
         //Specially useful for connectors that shares resources (like Redshift or Snowflake).
-        ext.numThreads = project.hasProperty('numThreads') ? project.getProperty('numThreads') : Runtime.runtime.availableProcessors() ?: 1
-        maxParallelForks = numThreads
+        ext.numThreads = project.hasProperty('numberThreads') ? project.getProperty('numberThreads') : Runtime.runtime.availableProcessors() ?: 1
+        maxParallelForks = numberThreads
 
         jacoco {
             enabled = true

--- a/build.gradle
+++ b/build.gradle
@@ -342,6 +342,7 @@ subprojects { subproj ->
     // make tag accessible in submodules.
     ext {
         cloudStorageTestTagName = 'cloud-storage'
+        numberThreads = project.hasProperty('numberThreads') ? project.getProperty('numberThreads') : Runtime.runtime.availableProcessors() ?: 1
     }
 
     spotbugs {
@@ -356,7 +357,6 @@ subprojects { subproj ->
     test {
         //This allows to set up a `gradle.properties` file inside the connector folder to reduce number of threads and reduce parallelization.
         //Specially useful for connectors that shares resources (like Redshift or Snowflake).
-        ext.numThreads = project.hasProperty('numberThreads') ? project.getProperty('numberThreads') : Runtime.runtime.availableProcessors() ?: 1
         maxParallelForks = numberThreads
 
         jacoco {

--- a/buildSrc/src/main/groovy/airbyte-integration-test-java.gradle
+++ b/buildSrc/src/main/groovy/airbyte-integration-test-java.gradle
@@ -47,7 +47,7 @@ class AirbyteIntegrationTestJavaPlugin implements Plugin<Project> {
 
             //This allows to set up a `gradle.properties` file inside the connector folder to reduce number of threads and reduce parallelization.
             //Specially useful for connectors that shares resources (like Redshift or Snowflake).
-            ext.numThreads = project.hasProperty('numberThreads') ? project.getProperty('numberThreads') : Runtime.runtime.availableProcessors() ?: 1
+            ext.numberThreads = project.hasProperty('numberThreads') ? project.getProperty('numberThreads') : Runtime.runtime.availableProcessors() ?: 1
             maxHeapSize = '3g'
             maxParallelForks = numberThreads
 

--- a/buildSrc/src/main/groovy/airbyte-integration-test-java.gradle
+++ b/buildSrc/src/main/groovy/airbyte-integration-test-java.gradle
@@ -45,8 +45,11 @@ class AirbyteIntegrationTestJavaPlugin implements Plugin<Project> {
                 dependsOn project.airbyteDocker
             }
 
+            //This allows to set up a `gradle.properties` file inside the connector folder to reduce number of threads and reduce parallelization.
+            //Specially useful for connectors that shares resources (like Redshift or Snowflake).
+            ext.numThreads = project.hasProperty('numThreads') ? project.getProperty('numThreads') : Runtime.runtime.availableProcessors() ?: 1
             maxHeapSize = '3g'
-            maxParallelForks = Runtime.runtime.availableProcessors() ?: 1
+            maxParallelForks = numThreads
 
             // This is needed to make the destination-snowflake tests succeed - https://github.com/snowflakedb/snowflake-jdbc/issues/589#issuecomment-983944767
             jvmArgs = ["--add-opens=java.base/java.nio=ALL-UNNAMED"]

--- a/buildSrc/src/main/groovy/airbyte-integration-test-java.gradle
+++ b/buildSrc/src/main/groovy/airbyte-integration-test-java.gradle
@@ -47,9 +47,9 @@ class AirbyteIntegrationTestJavaPlugin implements Plugin<Project> {
 
             //This allows to set up a `gradle.properties` file inside the connector folder to reduce number of threads and reduce parallelization.
             //Specially useful for connectors that shares resources (like Redshift or Snowflake).
-            ext.numThreads = project.hasProperty('numThreads') ? project.getProperty('numThreads') : Runtime.runtime.availableProcessors() ?: 1
+            ext.numThreads = project.hasProperty('numberThreads') ? project.getProperty('numberThreads') : Runtime.runtime.availableProcessors() ?: 1
             maxHeapSize = '3g'
-            maxParallelForks = numThreads
+            maxParallelForks = numberThreads
 
             // This is needed to make the destination-snowflake tests succeed - https://github.com/snowflakedb/snowflake-jdbc/issues/589#issuecomment-983944767
             jvmArgs = ["--add-opens=java.base/java.nio=ALL-UNNAMED"]

--- a/buildSrc/src/main/groovy/airbyte-performance-test-java.gradle
+++ b/buildSrc/src/main/groovy/airbyte-performance-test-java.gradle
@@ -22,7 +22,7 @@ class AirbytePerformanceTestJavaPlugin implements Plugin<Project> {
         }
 
         project.task('performanceTestJava', type: Test) {
-            testClassesDirs += project.sourceSets.performanceTestJava.output.classesDirs
+            testClassesDirs = project.sourceSets.performanceTestJava.output.classesDirs
             classpath += project.sourceSets.performanceTestJava.runtimeClasspath
 
             systemProperty "cpuLimit", System.getProperty("cpuLimit")


### PR DESCRIPTION
## What
After adding parallelisation in the test pipelines, some of the connectors started to fail (specially the ones that uses shared resource)
[PR](https://github.com/airbytehq/airbyte/pull/23506)

## How
Both `test` and `integrationTest` has been modified to include a property in `gradle.properties` file in the connector folder so we keep parallelisation by default with maximum threads possible but at the same time we let connector owners to configure the number of threads.
That is really useful for connectors that shares resources and are limited (like Redshift or Snowflake that are limited by number of connections).

To limit the parallelism, is it enough to create `gradle.properties` file and include this line on it:
```
numberThreads=X
```
Where X is the desired parallelisation.

Also, this PR removes the concatenation of test for performance tests, so are not run multiple times.

Example with a `println` when I had set up 3 threads, now should show 2 threads (removed as we don't want to have prints ):
<img width="668" alt="Screenshot 2023-03-08 at 12 09 42" src="https://user-images.githubusercontent.com/42538006/223789862-e998c36e-9577-426d-9c27-22c856ee478d.png">

## Recommended reading order
No recommendation

## 🚨 User Impact 🚨
The users that have issues with the test should create a `gradle.properties` file with the limitation desired.
