### PR TITLE
Force push docs to the gh_pages branch

### DIFF
--- a/tools/bin/deploy_docusaurus
+++ b/tools/bin/deploy_docusaurus
@@ -136,7 +136,7 @@ git push --force
 # non functional. for debugging
 git rev-parse --abbrev-ref HEAD
 
-git co -
+git checkout -
 
 set +o xtrace
 echo -e "$blue_text""Script exiting 0 GREAT SUCCESS!!!?""$default_text"

--- a/tools/bin/deploy_docusaurus
+++ b/tools/bin/deploy_docusaurus
@@ -130,7 +130,8 @@ git add CNAME
 # Skip pre-commit hooks fire_elmo.jpg
 PRE_COMMIT_ALLOW_NO_CONFIG=1 git commit --message "Adds CNAME to deploy for $revision"
 
-git push
+# These are raw static files, we aren't trying to resolve conflicts
+git push --force
 
 # non functional. for debugging
 git rev-parse --abbrev-ref HEAD


### PR DESCRIPTION
## What
docs changes to deploy.  we need to force push to the gh_pages branch

ran locally.  looks sane 
<img width="854" alt="Screenshot 2023-03-08 at 11 09 48 AM" src="https://user-images.githubusercontent.com/2591516/223781574-4f4b267f-6bd6-44a2-8be5-9e57f147aa3e.png">
