### PR TITLE
fix tests for postgres source

### DIFF
--- a/airbyte-integrations/connectors/source-postgres/acceptance-test-config.yml
+++ b/airbyte-integrations/connectors/source-postgres/acceptance-test-config.yml
@@ -9,11 +9,11 @@ acceptance_tests:
       - spec_path: "src/test-integration/resources/expected_spec.json"
         config_path: "secrets/config.json"
         backward_compatibility_tests_config:
-          disable_for_version: "1.0.51"
+          disable_for_version: "1.0.52"
       - spec_path: "src/test-integration/resources/expected_spec.json"
         config_path: "secrets/config_cdc.json"
         backward_compatibility_tests_config:
-          disable_for_version: "1.0.51"
+          disable_for_version: "1.0.52"
   connection:
     tests:
       - config_path: "secrets/config.json"


### PR DESCRIPTION
master is broken cause we published 1.0.52 in this PR https://github.com/airbytehq/airbyte/pull/23845 at a previous commit but never changed the backward compatibility test in master