### PR TITLE
Revert "Revert "temporary fix for Connectors Base CI (#23829)""

### DIFF
--- a/.github/workflows/gradle.yml
+++ b/.github/workflows/gradle.yml
@@ -261,11 +261,6 @@ jobs:
         with:
           ref: ${{ github.head_ref }}
 
-      - name: Cache Build Artifacts
-        uses: ./.github/actions/cache-build-artifacts
-        with:
-          cache-key: ${{ secrets.CACHE_VERSION }}
-
       - uses: actions/setup-java@v3
         with:
           distribution: "zulu"


### PR DESCRIPTION
Reverts airbytehq/airbyte#23839
I tested on this PR that disabling caching fixes CI: https://github.com/airbytehq/airbyte/pull/23851