### PR TITLE
avoid cache overlap between cdk-build and connectors-build

### DIFF
--- a/.github/actions/cache-build-artifacts/action.yml
+++ b/.github/actions/cache-build-artifacts/action.yml
@@ -4,10 +4,6 @@ inputs:
   cache-key:
     description: "Key to use for caching"
     required: true
-  cache-python:
-    description: "Whether to cache Python dependencies. Only relevant if building connector modules. true or false"
-    default: "true"
-    required: true
 
 runs:
   using: "composite"

--- a/.github/workflows/gradle.yml
+++ b/.github/workflows/gradle.yml
@@ -169,11 +169,6 @@ jobs:
       - name: Checkout Airbyte
         uses: actions/checkout@v3
 
-      - name: Cache Build Artifacts
-        uses: ./.github/actions/cache-build-artifacts
-        with:
-          cache-key: ${{ secrets.CACHE_VERSION }}
-
       - uses: actions/setup-java@v3
         with:
           distribution: "zulu"
@@ -260,6 +255,11 @@ jobs:
         uses: actions/checkout@v3
         with:
           ref: ${{ github.head_ref }}
+
+      - name: Cache Build Artifacts
+        uses: ./.github/actions/cache-build-artifacts
+        with:
+          cache-key: ${{ secrets.CACHE_VERSION }}
 
       - uses: actions/setup-java@v3
         with:

--- a/.github/workflows/gradle.yml
+++ b/.github/workflows/gradle.yml
@@ -169,6 +169,11 @@ jobs:
       - name: Checkout Airbyte
         uses: actions/checkout@v3
 
+      - name: Cache Build Artifacts
+        uses: ./.github/actions/cache-build-artifacts
+        with:
+          cache-key: ${{ secrets.CACHE_VERSION }}-cdk
+
       - uses: actions/setup-java@v3
         with:
           distribution: "zulu"
@@ -259,7 +264,7 @@ jobs:
       - name: Cache Build Artifacts
         uses: ./.github/actions/cache-build-artifacts
         with:
-          cache-key: ${{ secrets.CACHE_VERSION }}
+          cache-key: ${{ secrets.CACHE_VERSION }}-connectors
 
       - uses: actions/setup-java@v3
         with:


### PR DESCRIPTION
## What
Create specific caches for cdk and connector builds. This will avoid cache overlap and bad cache entries being created