### PR TITLE
fix: Cast the number of threads to integer in the Java connector tests 😵‍💫 

### DIFF
--- a/airbyte-integrations/connectors/destination-snowflake/gradle.properties
+++ b/airbyte-integrations/connectors/destination-snowflake/gradle.properties
@@ -1,1 +1,1 @@
-numberThreads=1
+numberThreads=3

--- a/airbyte-integrations/connectors/destination-snowflake/gradle.properties
+++ b/airbyte-integrations/connectors/destination-snowflake/gradle.properties
@@ -1,1 +1,1 @@
-numberThreads=2
+numberThreads=1

--- a/build.gradle
+++ b/build.gradle
@@ -342,7 +342,7 @@ subprojects { subproj ->
     // make tag accessible in submodules.
     ext {
         cloudStorageTestTagName = 'cloud-storage'
-        numberThreads = project.hasProperty('numberThreads') ? project.getProperty('numberThreads') : Runtime.runtime.availableProcessors() ?: 1
+        numberThreads = project.hasProperty('numberThreads') ? project.getProperty('numberThreads') as int : Runtime.runtime.availableProcessors() ?: 1
     }
 
     spotbugs {
@@ -358,7 +358,6 @@ subprojects { subproj ->
         //This allows to set up a `gradle.properties` file inside the connector folder to reduce number of threads and reduce parallelization.
         //Specially useful for connectors that shares resources (like Redshift or Snowflake).
         maxParallelForks = numberThreads
-
         jacoco {
             enabled = true
             excludes = ['**/*Test*', '**/generated*']

--- a/buildSrc/src/main/groovy/airbyte-integration-test-java.gradle
+++ b/buildSrc/src/main/groovy/airbyte-integration-test-java.gradle
@@ -47,7 +47,7 @@ class AirbyteIntegrationTestJavaPlugin implements Plugin<Project> {
 
             //This allows to set up a `gradle.properties` file inside the connector folder to reduce number of threads and reduce parallelization.
             //Specially useful for connectors that shares resources (like Redshift or Snowflake).
-            ext.numberThreads = project.hasProperty('numberThreads') ? project.getProperty('numberThreads') : Runtime.runtime.availableProcessors() ?: 1
+            ext.numberThreads = project.hasProperty('numberThreads') ? project.getProperty('numberThreads') as int : Runtime.runtime.availableProcessors() ?: 1
             maxHeapSize = '3g'
             maxParallelForks = numberThreads
 


### PR DESCRIPTION
# What
When introducing the property to limit the parallelism, it executes with more threads than expected ([PR](https://github.com/airbytehq/airbyte/pull/23870)).

# Solution
The problem is that when gradle reads the property file (parameter `numberThreads=2`), it was reading the ASCII value of `2` (50) and the test were executed with 50 threads instead of 2 😭 

To sort this out, we cast the property to `int`.