### PR TITLE
Low-code CDK: Override refresh_access_token logic DeclarativeOAuthAuthenticator

### DIFF
--- a/airbyte-cdk/python/airbyte_cdk/sources/declarative/auth/oauth.py
+++ b/airbyte-cdk/python/airbyte_cdk/sources/declarative/auth/oauth.py
@@ -3,7 +3,7 @@
 #
 
 from dataclasses import InitVar, dataclass, field
-from typing import Any, List, Mapping, Optional, Union
+from typing import Any, List, Mapping, Optional, Union, Tuple
 
 import pendulum
 from airbyte_cdk.sources.declarative.auth.declarative_authenticator import DeclarativeAuthenticator
@@ -91,6 +91,26 @@ class DeclarativeOauth2Authenticator(AbstractOauth2Authenticator, DeclarativeAut
 
     def get_refresh_request_body(self) -> Mapping[str, Any]:
         return self._refresh_request_body.eval(self.config)
+
+    def refresh_access_token(self) -> Tuple[str, Any]:
+        """
+        Returns the refresh token and its lifespan in seconds
+
+        This overrides the parent class method because the parent class assumes the "expires_in" field is always an int representing
+         seconds till token expiry.
+
+        However, this class provides the ability to determine the expiry date of an access token either by using (pseudocode):
+        * expiry_datetime = datetime.now() + seconds_till_access_token_expiry # in this option we have to calculate expiry timestamp, OR
+        * expiry_datetime = parse(response.headers["expires_at"]) # in this option the API tells us exactly when access token expires
+
+        :return: a tuple of (access_token, either token_lifespan_in_seconds or datetime_of_token_expiry)
+
+        # TODO this is a hack and should be better encapsulated/enabled by the AbstractOAuthAuthenticator i.e: that class should have
+                a method which takes the HTTP response and returns a timestamp for when the access token will expire which subclasses
+                such as this one can override or just configure directly.
+        """
+        response_json = self._get_refresh_access_token_response()
+        return response_json[self.get_access_token_name()], response_json[self.get_expires_in_name()]
 
     def get_token_expiry_date(self) -> pendulum.DateTime:
         return self._token_expiry_date

--- a/airbyte-cdk/python/airbyte_cdk/sources/declarative/auth/oauth.py
+++ b/airbyte-cdk/python/airbyte_cdk/sources/declarative/auth/oauth.py
@@ -3,7 +3,7 @@
 #
 
 from dataclasses import InitVar, dataclass, field
-from typing import Any, List, Mapping, Optional, Union, Tuple
+from typing import Any, List, Mapping, Optional, Tuple, Union
 
 import pendulum
 from airbyte_cdk.sources.declarative.auth.declarative_authenticator import DeclarativeAuthenticator

--- a/airbyte-cdk/python/airbyte_cdk/sources/declarative/auth/oauth.py
+++ b/airbyte-cdk/python/airbyte_cdk/sources/declarative/auth/oauth.py
@@ -101,7 +101,7 @@ class DeclarativeOauth2Authenticator(AbstractOauth2Authenticator, DeclarativeAut
 
         However, this class provides the ability to determine the expiry date of an access token either by using (pseudocode):
         * expiry_datetime = datetime.now() + seconds_till_access_token_expiry # in this option we have to calculate expiry timestamp, OR
-        * expiry_datetime = parse(response.headers["expires_at"]) # in this option the API tells us exactly when access token expires
+        * expiry_datetime = parse(response.body["expires_at"]) # in this option the API tells us exactly when access token expires
 
         :return: a tuple of (access_token, either token_lifespan_in_seconds or datetime_of_token_expiry)
 
@@ -115,11 +115,11 @@ class DeclarativeOauth2Authenticator(AbstractOauth2Authenticator, DeclarativeAut
     def get_token_expiry_date(self) -> pendulum.DateTime:
         return self._token_expiry_date
 
-    def set_token_expiry_date(self, initial_time: pendulum.DateTime, value: Union[str, int]):
+    def set_token_expiry_date(self, value: Union[str, int]):
         if self.token_expiry_date_format:
             self._token_expiry_date = pendulum.from_format(value, self.token_expiry_date_format)
         else:
-            self._token_expiry_date = initial_time.add(seconds=value)
+            self._token_expiry_date = pendulum.now().add(seconds=value)
 
     @property
     def access_token(self) -> str:

--- a/airbyte-cdk/python/airbyte_cdk/sources/streams/http/requests_native_auth/abstract_oauth.py
+++ b/airbyte-cdk/python/airbyte_cdk/sources/streams/http/requests_native_auth/abstract_oauth.py
@@ -97,7 +97,7 @@ class AbstractOauth2Authenticator(AuthBase):
         :return: a tuple of (access_token, token_lifespan_in_seconds)
         """
         response_json = self._get_refresh_access_token_response()
-        return response_json[self.get_access_token_name()], response_json[self.get_expires_in_name()]
+        return response_json[self.get_access_token_name()], int(response_json[self.get_expires_in_name()])
 
     @abstractmethod
     def get_token_refresh_endpoint(self) -> str:

--- a/airbyte-cdk/python/airbyte_cdk/sources/streams/http/requests_native_auth/abstract_oauth.py
+++ b/airbyte-cdk/python/airbyte_cdk/sources/streams/http/requests_native_auth/abstract_oauth.py
@@ -35,10 +35,9 @@ class AbstractOauth2Authenticator(AuthBase):
     def get_access_token(self) -> str:
         """Returns the access token"""
         if self.token_has_expired():
-            current_datetime = pendulum.now()
             token, expires_in = self.refresh_access_token()
             self.access_token = token
-            self.set_token_expiry_date(current_datetime, expires_in)
+            self.set_token_expiry_date(expires_in)
 
         return self.access_token
 
@@ -124,7 +123,7 @@ class AbstractOauth2Authenticator(AuthBase):
         """Expiration date of the access token"""
 
     @abstractmethod
-    def set_token_expiry_date(self, initial_time: pendulum.DateTime, value: Union[str, int]):
+    def set_token_expiry_date(self, value: Union[str, int]):
         """Setter for access token expiration date"""
 
     @abstractmethod

--- a/airbyte-cdk/python/airbyte_cdk/sources/streams/http/requests_native_auth/abstract_oauth.py
+++ b/airbyte-cdk/python/airbyte_cdk/sources/streams/http/requests_native_auth/abstract_oauth.py
@@ -97,7 +97,7 @@ class AbstractOauth2Authenticator(AuthBase):
         :return: a tuple of (access_token, token_lifespan_in_seconds)
         """
         response_json = self._get_refresh_access_token_response()
-        return response_json[self.get_access_token_name()], int(response_json[self.get_expires_in_name()])
+        return response_json[self.get_access_token_name()], response_json[self.get_expires_in_name()]
 
     @abstractmethod
     def get_token_refresh_endpoint(self) -> str:

--- a/airbyte-cdk/python/airbyte_cdk/sources/streams/http/requests_native_auth/oauth.py
+++ b/airbyte-cdk/python/airbyte_cdk/sources/streams/http/requests_native_auth/oauth.py
@@ -234,6 +234,6 @@ class SingleUseRefreshTokenOauth2Authenticator(Oauth2Authenticator):
         response_json = self._get_refresh_access_token_response()
         return (
             response_json[self.get_access_token_name()],
-            response_json[self.get_expires_in_name()],
+            int(response_json[self.get_expires_in_name()]),
             response_json[self.get_refresh_token_name()],
         )

--- a/airbyte-cdk/python/airbyte_cdk/sources/streams/http/requests_native_auth/oauth.py
+++ b/airbyte-cdk/python/airbyte_cdk/sources/streams/http/requests_native_auth/oauth.py
@@ -234,6 +234,6 @@ class SingleUseRefreshTokenOauth2Authenticator(Oauth2Authenticator):
         response_json = self._get_refresh_access_token_response()
         return (
             response_json[self.get_access_token_name()],
-            int(response_json[self.get_expires_in_name()]),
+            response_json[self.get_expires_in_name()],
             response_json[self.get_refresh_token_name()],
         )

--- a/airbyte-cdk/python/airbyte_cdk/sources/streams/http/requests_native_auth/oauth.py
+++ b/airbyte-cdk/python/airbyte_cdk/sources/streams/http/requests_native_auth/oauth.py
@@ -75,11 +75,11 @@ class Oauth2Authenticator(AbstractOauth2Authenticator):
     def get_token_expiry_date(self) -> pendulum.DateTime:
         return self._token_expiry_date
 
-    def set_token_expiry_date(self, initial_time: pendulum.DateTime, value: Union[str, int]):
+    def set_token_expiry_date(self, value: Union[str, int]):
         if self._token_expiry_date_format:
             self._token_expiry_date = pendulum.from_format(value, self._token_expiry_date_format)
         else:
-            self._token_expiry_date = initial_time.add(seconds=value)
+            self._token_expiry_date = pendulum.now().add(seconds=value)
 
     @property
     def access_token(self) -> str:

--- a/airbyte-cdk/python/unit_tests/sources/streams/http/requests_native_auth/test_requests_native_auth.py
+++ b/airbyte-cdk/python/unit_tests/sources/streams/http/requests_native_auth/test_requests_native_auth.py
@@ -163,12 +163,6 @@ class TestOauth2Authenticator:
 
         assert ("access_token", 1000) == token
 
-        # Test with expires_in as str
-        mocker.patch.object(resp, "json", return_value={"access_token": "access_token", "expires_in": "2000"})
-        token = oauth.refresh_access_token()
-
-        assert ("access_token", 2000) == token
-
     @pytest.mark.parametrize("error_code", (429, 500, 502, 504))
     def test_refresh_access_token_retry(self, error_code, requests_mock):
         oauth = Oauth2Authenticator(
@@ -266,7 +260,6 @@ class TestSingleUseRefreshTokenOauth2Authenticator:
             connector_config,
             token_refresh_endpoint="foobar",
         )
-
         authenticator._get_refresh_access_token_response = mocker.Mock(
             return_value={
                 authenticator.get_access_token_name(): "new_access_token",
@@ -275,16 +268,6 @@ class TestSingleUseRefreshTokenOauth2Authenticator:
             }
         )
         assert authenticator.refresh_access_token() == ("new_access_token", 42, "new_refresh_token")
-
-        # Test with expires_in as str
-        authenticator._get_refresh_access_token_response = mocker.Mock(
-            return_value={
-                authenticator.get_access_token_name(): "new_access_token",
-                authenticator.get_expires_in_name(): "1000",
-                authenticator.get_refresh_token_name(): "new_refresh_token",
-            }
-        )
-        assert authenticator.refresh_access_token() == ("new_access_token", 1000, "new_refresh_token")
 
 
 def mock_request(method, url, data):

--- a/airbyte-cdk/python/unit_tests/sources/streams/http/requests_native_auth/test_requests_native_auth.py
+++ b/airbyte-cdk/python/unit_tests/sources/streams/http/requests_native_auth/test_requests_native_auth.py
@@ -163,6 +163,12 @@ class TestOauth2Authenticator:
 
         assert ("access_token", 1000) == token
 
+        # Test with expires_in as str
+        mocker.patch.object(resp, "json", return_value={"access_token": "access_token", "expires_in": "2000"})
+        token = oauth.refresh_access_token()
+
+        assert ("access_token", 2000) == token
+
     @pytest.mark.parametrize("error_code", (429, 500, 502, 504))
     def test_refresh_access_token_retry(self, error_code, requests_mock):
         oauth = Oauth2Authenticator(
@@ -260,6 +266,7 @@ class TestSingleUseRefreshTokenOauth2Authenticator:
             connector_config,
             token_refresh_endpoint="foobar",
         )
+
         authenticator._get_refresh_access_token_response = mocker.Mock(
             return_value={
                 authenticator.get_access_token_name(): "new_access_token",
@@ -268,6 +275,16 @@ class TestSingleUseRefreshTokenOauth2Authenticator:
             }
         )
         assert authenticator.refresh_access_token() == ("new_access_token", 42, "new_refresh_token")
+
+        # Test with expires_in as str
+        authenticator._get_refresh_access_token_response = mocker.Mock(
+            return_value={
+                authenticator.get_access_token_name(): "new_access_token",
+                authenticator.get_expires_in_name(): "1000",
+                authenticator.get_refresh_token_name(): "new_refresh_token",
+            }
+        )
+        assert authenticator.refresh_access_token() == ("new_access_token", 1000, "new_refresh_token")
 
 
 def mock_request(method, url, data):


### PR DESCRIPTION
## What
Enable airbytehq/airbyte#20301 to be merged. Initially it failed unit tests due to the issues mentioned here https://github.com/airbytehq/airbyte/issues/23926

TL;DR `DeclarativeOAuthAuthenticator` breaks some assumptions made by `OAuthAuthenticator` in service of adding a new feature. This PR fixes the issue temporarily by pushing down the new feature logic into `DeclarativeOAuthAuthenticator` instead to enable airbytehq/airbyte#20301 to go through. 

Also contains the changes from airbytehq/airbyte#20301