### PR TITLE
[ISSUE #24059] fix reset pagination issue

### DIFF
--- a/airbyte-cdk/python/airbyte_cdk/sources/declarative/requesters/paginators/default_paginator.py
+++ b/airbyte-cdk/python/airbyte_cdk/sources/declarative/requesters/paginators/default_paginator.py
@@ -153,6 +153,7 @@ class DefaultPaginator(Paginator):
 
     def reset(self):
         self.pagination_strategy.reset()
+        self._token = None
 
     def _get_request_options(self, option_type: RequestOptionType) -> Mapping[str, Any]:
         options = {}

--- a/airbyte-cdk/python/unit_tests/sources/declarative/requesters/paginators/test_default_paginator.py
+++ b/airbyte-cdk/python/unit_tests/sources/declarative/requesters/paginators/test_default_paginator.py
@@ -15,6 +15,7 @@ from airbyte_cdk.sources.declarative.requesters.paginators.default_paginator imp
     RequestOption,
     RequestOptionType,
 )
+from airbyte_cdk.sources.declarative.requesters.paginators.strategies.offset_increment import OffsetIncrement
 from airbyte_cdk.sources.declarative.requesters.paginators.strategies.cursor_pagination_strategy import CursorPaginationStrategy
 from airbyte_cdk.sources.declarative.requesters.request_path import RequestPath
 
@@ -183,11 +184,17 @@ def test_reset():
     page_token_request_option = RequestOption(inject_into=RequestOptionType.request_parameter, field_name="offset", parameters={})
     url_base = "https://airbyte.io"
     config = {}
-    strategy = MagicMock()
-    DefaultPaginator(
+    strategy = OffsetIncrement(config={}, page_size=2, parameters={})
+    paginator = DefaultPaginator(
         strategy, config, url_base, parameters={}, page_size_option=page_size_request_option, page_token_option=page_token_request_option
-    ).reset()
-    assert strategy.reset.called
+    )
+    initial_request_parameters = paginator.get_request_params()
+    paginator.next_page_token(MagicMock(), [{"first key": "first value"}, {"second key": "second value"}])
+    request_parameters_for_second_request = paginator.get_request_params()
+    paginator.reset()
+    request_parameters_after_reset = paginator.get_request_params()
+    assert initial_request_parameters == request_parameters_after_reset
+    assert request_parameters_for_second_request != request_parameters_after_reset
 
 
 def test_limit_page_fetched():

--- a/airbyte-cdk/python/unit_tests/sources/declarative/requesters/paginators/test_default_paginator.py
+++ b/airbyte-cdk/python/unit_tests/sources/declarative/requesters/paginators/test_default_paginator.py
@@ -15,8 +15,8 @@ from airbyte_cdk.sources.declarative.requesters.paginators.default_paginator imp
     RequestOption,
     RequestOptionType,
 )
-from airbyte_cdk.sources.declarative.requesters.paginators.strategies.offset_increment import OffsetIncrement
 from airbyte_cdk.sources.declarative.requesters.paginators.strategies.cursor_pagination_strategy import CursorPaginationStrategy
+from airbyte_cdk.sources.declarative.requesters.paginators.strategies.offset_increment import OffsetIncrement
 from airbyte_cdk.sources.declarative.requesters.request_path import RequestPath
 
 


### PR DESCRIPTION
## What
Addresses #24059 

The issue was that `DefaultPaginator` also had a state but would only clean the one from the strategies. This would not be an issue in the normal flow because `self.pagination_strategy.next_page_token` would return `None` when the pagination was over.

## How
`self._token = None` on reset
