### PR TITLE
connectors-ci: fix secrets upload to GSM

### DIFF
--- a/tools/ci_connector_ops/ci_connector_ops/pipelines/actions/remote_storage.py
+++ b/tools/ci_connector_ops/ci_connector_ops/pipelines/actions/remote_storage.py
@@ -19,6 +19,8 @@ async def upload_to_s3(dagger_client: Client, file_to_upload_path: Path, key: st
     Returns:
         int: Exit code of the upload process.
     """
+    s3_uri = f"s3://{bucket}/{key}"
+    dagger_client = dagger_client.pipeline(f"Upload {file_to_upload_path} to {s3_uri}")
     file_to_upload: File = dagger_client.host().directory(".", include=[str(file_to_upload_path)]).file(str(file_to_upload_path))
     aws_access_key_id: Secret = dagger_client.host().env_variable("AWS_ACCESS_KEY_ID").secret()
     aws_secret_access_key: Secret = dagger_client.host().env_variable("AWS_SECRET_ACCESS_KEY").secret()
@@ -30,5 +32,5 @@ async def upload_to_s3(dagger_client: Client, file_to_upload_path: Path, key: st
         .with_secret_variable("AWS_ACCESS_KEY_ID", aws_access_key_id)
         .with_secret_variable("AWS_SECRET_ACCESS_KEY", aws_secret_access_key)
         .with_secret_variable("AWS_DEFAULT_REGION", aws_region)
-        .with_exec(["s3", "cp", str(file_to_upload_path), f"s3://{bucket}/{key}"])
+        .with_exec(["s3", "cp", str(file_to_upload_path), s3_uri])
     )

--- a/tools/ci_connector_ops/ci_connector_ops/pipelines/actions/secrets.py
+++ b/tools/ci_connector_ops/ci_connector_ops/pipelines/actions/secrets.py
@@ -50,7 +50,8 @@ async def upload(context: ConnectorTestContext, gcp_gsm_env_variable_name: str =
     Returns:
         int: The exit code of the ci-credentials update-secrets command.
     """
-    gsm_secret = context.dagger_client.host().env_variable(gcp_gsm_env_variable_name).secret()
+    dagger_client = context.dagger_client.pipeline(f"Upload secrets for {context.connector.technical_name}")
+    gsm_secret = dagger_client.host().env_variable(gcp_gsm_env_variable_name).secret()
     secrets_path = f"/{context.connector.code_directory}/secrets"
 
     ci_credentials = await environments.with_ci_credentials(context, gsm_secret)

--- a/tools/ci_connector_ops/ci_connector_ops/pipelines/contexts.py
+++ b/tools/ci_connector_ops/ci_connector_ops/pipelines/contexts.py
@@ -151,12 +151,9 @@ class ConnectorTestContext:
             self.state = ContextState.ERROR
             return True
         else:
-            teardown_pipeline = self.dagger_client.pipeline(f"Teardown {self.connector.technical_name}")
+            self.dagger_client = self.dagger_client.pipeline(f"Teardown {self.connector.technical_name}")
             if self.should_save_updated_secrets:
-                await secrets.upload(
-                    teardown_pipeline,
-                    self.connector,
-                )
+                await secrets.upload(self)
             self.test_report.print()
             self.logger.info(self.test_report.to_json())
             local_test_reports_path_root = "tools/ci_connector_ops/test_reports/"
@@ -172,7 +169,7 @@ class ConnectorTestContext:
                 s3_reports_path_root = "python-poc/tests/history/"
                 s3_key = s3_reports_path_root + suffix
                 report_upload_exit_code = await remote_storage.upload_to_s3(
-                    teardown_pipeline, str(local_report_path), s3_key, os.environ["TEST_REPORTS_BUCKET_NAME"]
+                    self.dagger_client, str(local_report_path), s3_key, os.environ["TEST_REPORTS_BUCKET_NAME"]
                 )
                 if report_upload_exit_code != 0:
                     self.logger.error("Uploading the report to S3 failed.")


### PR DESCRIPTION
## What
We previously updated the `upload` signature to take a `context` object but we passed it a `client`...
