### PR TITLE
Connector Builder: set `exclude_unset=True` when returning `AirbyteMessage`s

### DIFF
--- a/airbyte-cdk/python/connector_builder/main.py
+++ b/airbyte-cdk/python/connector_builder/main.py
@@ -44,7 +44,7 @@ def handle_request(args: List[str]):
     config = get_config_from_args(args)
     source = create_source(config)
     if "__command" in config:
-        return handle_connector_builder_request(source, config).json()
+        return handle_connector_builder_request(source, config).json(exclude_unset=True)
     else:
         raise ValueError("Missing __command argument in config file.")
 
@@ -55,4 +55,4 @@ if __name__ == "__main__":
     except Exception as exc:
         error = AirbyteTracedException.from_exception(exc, message="Error handling request.")
         m = error.as_airbyte_message()
-        print(error.as_airbyte_message().json())
+        print(error.as_airbyte_message().json(exclude_unset=True))


### PR DESCRIPTION
## What
Fixes an issue where we were sending `AirbyteMessage` json from the CDK without setting `exclude_unset=True` in the json call. This was causing these messages to fail [validation](https://github.com/airbytehq/airbyte-platform-internal/blob/2e2c9466de22821076a853c31de0ecaa04a14e20/oss/airbyte-commons-worker/src/main/java/io/airbyte/workers/internal/DefaultAirbyteStreamFactory.java#L114) performed by the connector builder server.