### PR TITLE
CDK: build_refresh_request_headers added

### DIFF
--- a/airbyte-cdk/python/airbyte_cdk/sources/streams/http/requests_native_auth/abstract_oauth.py
+++ b/airbyte-cdk/python/airbyte_cdk/sources/streams/http/requests_native_auth/abstract_oauth.py
@@ -69,6 +69,14 @@ class AbstractOauth2Authenticator(AuthBase):
 
         return payload
 
+    def build_refresh_request_headers(self) -> Mapping[str, Any]:
+        """
+        Returns the request headers to set on the refresh request
+
+        Override to define additional parameters
+        """
+        return None
+
     @backoff.on_exception(
         backoff.expo,
         DefaultBackoffException,
@@ -79,7 +87,7 @@ class AbstractOauth2Authenticator(AuthBase):
     )
     def _get_refresh_access_token_response(self):
         try:
-            response = requests.request(method="POST", url=self.get_token_refresh_endpoint(), data=self.build_refresh_request_body())
+            response = requests.request(method="POST", url=self.get_token_refresh_endpoint(), data=self.build_refresh_request_body(), headers=self.build_refresh_request_headers())
             response.raise_for_status()
             return response.json()
         except requests.exceptions.RequestException as e:

--- a/airbyte-cdk/python/airbyte_cdk/sources/streams/http/requests_native_auth/abstract_oauth.py
+++ b/airbyte-cdk/python/airbyte_cdk/sources/streams/http/requests_native_auth/abstract_oauth.py
@@ -87,7 +87,12 @@ class AbstractOauth2Authenticator(AuthBase):
     )
     def _get_refresh_access_token_response(self):
         try:
-            response = requests.request(method="POST", url=self.get_token_refresh_endpoint(), data=self.build_refresh_request_body(), headers=self.build_refresh_request_headers())
+            response = requests.request(
+                method="POST",
+                url=self.get_token_refresh_endpoint(),
+                data=self.build_refresh_request_body(),
+                headers=self.build_refresh_request_headers(),
+            )
             response.raise_for_status()
             return response.json()
         except requests.exceptions.RequestException as e:

--- a/airbyte-cdk/python/unit_tests/sources/declarative/auth/test_oauth.py
+++ b/airbyte-cdk/python/unit_tests/sources/declarative/auth/test_oauth.py
@@ -128,7 +128,7 @@ class TestOauth2Authenticator:
         assert oauth.get_token_expiry_date() == pendulum.parse(next_day)
 
 
-def mock_request(method, url, data):
+def mock_request(method, url, data, headers):
     if url == "refresh_end":
         return resp
-    raise Exception(f"Error while refreshing access token with request: {method}, {url}, {data}")
+    raise Exception(f"Error while refreshing access token with request: {method}, {url}, {data}, {headers}")

--- a/airbyte-cdk/python/unit_tests/sources/streams/http/requests_native_auth/test_requests_native_auth.py
+++ b/airbyte-cdk/python/unit_tests/sources/streams/http/requests_native_auth/test_requests_native_auth.py
@@ -290,7 +290,7 @@ class TestSingleUseRefreshTokenOauth2Authenticator:
         assert authenticator.refresh_access_token() == ("new_access_token", 1000, "new_refresh_token")
 
 
-def mock_request(method, url, data):
+def mock_request(method, url, data, headers):
     if url == "refresh_end":
         return resp
-    raise Exception(f"Error while refreshing access token with request: {method}, {url}, {data}")
+    raise Exception(f"Error while refreshing access token with request: {method}, {url}, {data}, {headers}")


### PR DESCRIPTION
## What
I would like to have the possibility to customize headers `_get refresh access_token response` in inherited classes.