### PR TITLE
Fix: only build docker images with the local CDK for connectors

### DIFF
--- a/buildSrc/src/main/groovy/airbyte-docker.gradle
+++ b/buildSrc/src/main/groovy/airbyte-docker.gradle
@@ -71,7 +71,8 @@ abstract class AirbyteDockerTask extends DefaultTask {
     def dockerTask() {
         if (
             project.hasProperty('connectorAcceptanceTest.useLocalCdk') &&
-            project.properties["connectorAcceptanceTest.useLocalCdk"]
+            project.properties["connectorAcceptanceTest.useLocalCdk"] &&
+            project.parent.project.name.equals("connectors")
         ) {
             def scriptPath = Paths.get(rootDir.absolutePath, 'airbyte-integrations/scripts/build-connector-image-with-local-cdk.sh').toString()
             buildDockerfileWithLocalCdk(scriptPath, dockerfileName)


### PR DESCRIPTION
## What
Fixes an issue identified in https://github.com/airbytehq/airbyte/pull/24240 - when the `local_cdk` and `connector-acceptance-test-version` arguments were used when running CATs, the `dockerTask` plugin was building a connector image, but tagging it as a CAT image.

## How
Modifies the `dockerTask` plugin so that it only calls the function to build images with the local CDK if the project's parent is "connectors".