### PR TITLE
ci_credentials: fix overwriting 'data' before getting nextPageToken

### DIFF
--- a/tools/ci_credentials/README.md
+++ b/tools/ci_credentials/README.md
@@ -29,7 +29,7 @@ Download a Service account json key that has access to Google Secrets Manager.
 * Click on "ADD KEY -> Create new key" and select JSON. This will download a file on your computer
 
 ### Setup ci_credentials
-* In your .zshrc, add: export GCP_GSM_CREDENTIALS=`cat <path to JSON file>`
+* In your .zshrc, add: `export GCP_GSM_CREDENTIALS=cat $(<path to JSON file>)`
 * Follow README.md under `tools/ci_credentials`
 
 After making a change, you have to reinstall it to run the bash command: `pip install --quiet -e ./tools/ci_*`
@@ -44,11 +44,18 @@ The `VERSION=dev` will make it so it knows to use your local current working dir
 ci_credentials --help
 ```
 
-### Write to storage
+### Write credentials for a specific connector to local storage
 To download GSM secrets to `airbyte-integrations/connectors/source-bings-ads/secrets`:
 ```bash
 ci_credentials source-bing-ads write-to-storage
 ```
+
+### Write credentials for all connectors to local storage
+To download GSM secrets to for all available connectors into their respective `secrets` directories:
+```bash
+ci_credentials all write-to-storage
+```
+
 
 ### Update secrets
 To upload to GSM newly updated configurations from `airbyte-integrations/connectors/source-bings-ads/secrets/updated_configurations`:

--- a/tools/ci_credentials/ci_credentials/secrets_manager.py
+++ b/tools/ci_credentials/ci_credentials/secrets_manager.py
@@ -81,8 +81,8 @@ class SecretsManager:
             if next_token:
                 params["pageToken"] = next_token
 
-            data = self.api.get(url, params=params)
-            for secret_info in data.get("secrets") or []:
+            all_secrets_data = self.api.get(url, params=params)
+            for secret_info in all_secrets_data.get("secrets") or []:
                 secret_name = secret_info["name"]
                 connector_name = secret_info.get("labels", {}).get("connector")
                 if not connector_name:
@@ -103,14 +103,14 @@ class SecretsManager:
                 self.logger.info(f"found GSM secret: {log_name} = > {filename}")
 
                 versions_url = f"https://secretmanager.googleapis.com/v1/{secret_name}/versions"
-                data = self.api.get(versions_url)
-                enabled_versions = [version["name"] for version in data["versions"] if version["state"] == "ENABLED"]
+                versions_data = self.api.get(versions_url)
+                enabled_versions = [version["name"] for version in versions_data["versions"] if version["state"] == "ENABLED"]
                 if len(enabled_versions) > 1:
                     self.logger.critical(f"{log_name} should have one enabled version at the same time!!!")
                 enabled_version = enabled_versions[0]
                 secret_url = f"https://secretmanager.googleapis.com/v1/{enabled_version}:access"
-                data = self.api.get(secret_url)
-                secret_value = data.get("payload", {}).get("data")
+                secret_data = self.api.get(secret_url)
+                secret_value = secret_data.get("payload", {}).get("data")
                 if not secret_value:
                     self.logger.warning(f"{log_name} has empty value")
                     continue
@@ -126,7 +126,7 @@ class SecretsManager:
                 remote_secret = RemoteSecret(connector_name, filename, secret_value, enabled_version)
                 secrets.append(remote_secret)
 
-            next_token = data.get("nextPageToken")
+            next_token = all_secrets_data.get("nextPageToken")
             if not next_token:
                 break
 


### PR DESCRIPTION
## What
* Fix issue where `VERSION=dev ci_credentials all write-to-storage` would only write 100 secrets instead of the full 408
* Updates to readme

## How
Use diffferent variable names when getting `data` from various endpoints. Previously we were overwriting the `data` variable with different contents - therefore the `nextPageToken` was either not there or invalid by the time we tried to use it, so we never got the next page. 

Cherrypicked from https://github.com/airbytehq/airbyte/pull/24254 as it was quasi-necessary to run all CATs locally (you can run ci_credentials per connector, but that's slow), and I figured other people might be able to use this now. 
