### PR TITLE
connectors-ci: new workflow for dagger nightly builds

### DIFF
--- a/.github/workflows/connector_nightly_builds_dagger.yml
+++ b/.github/workflows/connector_nightly_builds_dagger.yml
@@ -1,0 +1,55 @@
+name: POC Connectors CI - nightly builds
+
+on:
+  schedule:
+    # 11AM UTC is 12AM CET, 4AM PST.
+    - cron: "0 11 * * *"
+  workflow_dispatch:
+
+jobs:
+  connectors_ci:
+    name: Connectors CI
+    timeout-minutes: 240 # 4 hours
+    runs-on: large-runner
+    steps:
+      - name: Get start timestamp
+        id: get-start-timestamp
+        run: echo "::set-output name=start-timestamp::$(date +%s)"
+      - name: Checkout Airbyte
+        uses: actions/checkout@v3
+        with:
+          repository: ${{ github.event.inputs.repo }}
+          ref: ${{ github.event.inputs.gitref }}
+      - name: Extract branch name
+        shell: bash
+        if: github.event_name == 'workflow_dispatch'
+        run: echo "##[set-output name=branch;]$(echo ${GITHUB_REF#refs/heads/})"
+        id: extract_branch
+      - name: Install Python 3.10
+        uses: actions/setup-python@v4
+        with:
+          python-version: "3.10"
+      - name: Install ci-connector-ops package
+        run: pip install ./tools/ci_connector_ops\[pipelines]\
+      - name: Run nightly builds
+        run: |
+          export _EXPERIMENTAL_DAGGER_RUNNER_HOST="unix:///var/run/buildkit/buildkitd.sock"
+          DAGGER_CLI_COMMIT="67c7e7635cf4ea0e446e2fed522a3e314c960f6a"
+          DAGGER_TMP_BINDIR="/tmp/dagger_${DAGGER_CLI_COMMIT}"
+          export _EXPERIMENTAL_DAGGER_CLI_BIN="$DAGGER_TMP_BINDIR/dagger"
+          if [ ! -f  "$_EXPERIMENTAL_DAGGER_CLI_BIN" ]; then
+              mkdir -p "$DAGGER_TMP_BINDIR"
+              curl "https://dl.dagger.io/dagger/main/${DAGGER_CLI_COMMIT}/dagger_${DAGGER_CLI_COMMIT}_$(uname -s | tr A-Z a-z)_$(uname -m | sed s/x86_64/amd64/).tar.gz" | tar xvz -C "$DAGGER_TMP_BINDIR"
+          fi
+          connectors-ci --is-ci --gha-workflow-run-id=${{ github.run_id }} test-connectors --release-stage=beta --release-stage=generally_available
+        env:
+          GCP_GSM_CREDENTIALS: ${{ secrets.GCP_GSM_CREDENTIALS }}
+          AWS_ACCESS_KEY_ID: ${{ secrets.STATUS_API_AWS_ACCESS_KEY_ID }}
+          AWS_SECRET_ACCESS_KEY: ${{ secrets.STATUS_API_AWS_SECRET_ACCESS_KEY }}
+          AWS_DEFAULT_REGION: "us-east-2"
+          TEST_REPORTS_BUCKET_NAME: "airbyte-connector-build-status"
+          CI_GITHUB_ACCESS_TOKEN: ${{ secrets.GH_PAT_MAINTENANCE_OCTAVIA }}
+          CI_GIT_BRANCH: ${{ steps.extract_branch.outputs.branch }}
+          CI_GIT_REVISION: ${{ github.sha }}
+          CI_CONTEXT: "nightly_builds"
+          CI_PIPELINE_START_TIMESTAMP: ${{ steps.get-start-timestamp.outputs.start-timestamp }}


### PR DESCRIPTION
## What
Closes #23970
This new workflow is made to run nightly builds on the **large warm runner** the infra team provisioned.
It should be able to leverage caching to speed up nightly builds.

## How
* Declare a new scheduled workflow (everyday at 11AM UTC to not overlap with the future legacy nightly builds running earlier in the day).
* Run nightly builds for GA and Beta connectors only.
