### PR TITLE
Airbyte CDK: skip slices in a substream slicer

### DIFF
--- a/airbyte-cdk/python/airbyte_cdk/sources/declarative/declarative_component_schema.yaml
+++ b/airbyte-cdk/python/airbyte_cdk/sources/declarative/declarative_component_schema.yaml
@@ -852,6 +852,8 @@ definitions:
         "$ref": "#/definitions/DeclarativeStream"
       partition_field:
         type: string
+      skip_slices:
+        type: string
       request_option:
         "$ref": "#/definitions/RequestOption"
       $parameters:

--- a/airbyte-cdk/python/airbyte_cdk/sources/declarative/models/declarative_component_schema.py
+++ b/airbyte-cdk/python/airbyte_cdk/sources/declarative/models/declarative_component_schema.py
@@ -501,8 +501,8 @@ class ParentStreamConfig(BaseModel):
     parent_key: str
     stream: DeclarativeStream
     partition_field: str
-    request_option: Optional[RequestOption] = None
     skip_slices: Optional[str] = None
+    request_option: Optional[RequestOption] = None
     parameters: Optional[Dict[str, Any]] = Field(None, alias="$parameters")
 
 

--- a/airbyte-cdk/python/airbyte_cdk/sources/declarative/models/declarative_component_schema.py
+++ b/airbyte-cdk/python/airbyte_cdk/sources/declarative/models/declarative_component_schema.py
@@ -502,6 +502,7 @@ class ParentStreamConfig(BaseModel):
     stream: DeclarativeStream
     partition_field: str
     request_option: Optional[RequestOption] = None
+    skip_slices: Optional[str] = None
     parameters: Optional[Dict[str, Any]] = Field(None, alias="$parameters")
 
 

--- a/airbyte-cdk/python/airbyte_cdk/sources/declarative/parsers/model_to_component_factory.py
+++ b/airbyte-cdk/python/airbyte_cdk/sources/declarative/parsers/model_to_component_factory.py
@@ -674,6 +674,7 @@ class ModelToComponentFactory:
             request_option=request_option,
             stream=declarative_stream,
             partition_field=model.partition_field,
+            skip_slices=model.skip_slices,
             config=config,
             parameters=model.parameters,
         )

--- a/airbyte-cdk/python/unit_tests/sources/declarative/partition_routers/test_substream_partition_router.py
+++ b/airbyte-cdk/python/unit_tests/sources/declarative/partition_routers/test_substream_partition_router.py
@@ -99,6 +99,22 @@ class MockStream(Stream):
             ],
         ),
         (
+            "test_skip_slices",
+            [
+                ParentStreamConfig(
+                    stream=MockStream(parent_slices, all_parent_data, "first_stream"),
+                    parent_key="id",
+                    partition_field="first_stream_id",
+                    skip_slices="{{ parent_record['id'] != 1 }}",
+                    parameters={},
+                    config={},
+                )
+            ],
+            [
+                {"parent_slice": {"slice": "first"}, "first_stream_id": 1},
+            ],
+        ),
+        (
             "test_multiple_parent_streams",
             [
                 ParentStreamConfig(


### PR DESCRIPTION
## What
Some source APIs may return deleted entities, whereis subentities associated with them would be inaccessible and result in 404 or other errors -- this should be handled.

## How
Introduce a `skip_records` parameter for a `SubStreamPartitionRouter.ParentStreamConfig` class. Usage example:
```
  contact_stream:
    $ref: "#/definitions/base_stream"
    retriever:
      $ref: "#/definitions/retriever"
      partition_router:
        type: SubstreamPartitionRouter
        parent_stream_configs:
          - type: ParentStreamConfig
            stream: "#/definitions/customer_stream"
            parent_key: id
            partition_field: id
            skip_slices: "{{ parent_record['deleted'] }}"
```   