### PR TITLE
Revert "Destination MSSQL: make Azure Synapse Compatibility In Test"

### DIFF
--- a/airbyte-integrations/connectors/destination-mssql/src/main/java/io/airbyte/integrations/destination/mssql/SqlServerOperations.java
+++ b/airbyte-integrations/connectors/destination-mssql/src/main/java/io/airbyte/integrations/destination/mssql/SqlServerOperations.java
@@ -35,7 +35,7 @@ public class SqlServerOperations implements SqlOperations {
         "IF NOT EXISTS (SELECT * FROM sys.tables t JOIN sys.schemas s ON t.schema_id = s.schema_id "
             + "WHERE s.name = '%s' AND t.name = '%s') "
             + "CREATE TABLE %s.%s ( \n"
-            + "%s VARCHAR(64) PRIMARY KEY NONCLUSTERED NOT ENFORCED,\n"
+            + "%s VARCHAR(64) PRIMARY KEY,\n"
             + "%s NVARCHAR(MAX),\n" // Microsoft SQL Server specific: NVARCHAR can store Unicode meanwhile VARCHAR - not
             + "%s DATETIMEOFFSET(7) DEFAULT SYSDATETIMEOFFSET()\n"
             + ");\n",


### PR DESCRIPTION
Fixes https://github.com/airbytehq/airbyte/issues/23890
Reverts airbytehq/airbyte#18294. That change broke integration tests and normalization tests. Looks like normal MS SQL does not support `ENFORCED` keyword.

