### PR TITLE
update cli version to fix cpu resource exhaustion

### DIFF
--- a/.github/workflows/connector_nightly_builds_dagger.yml
+++ b/.github/workflows/connector_nightly_builds_dagger.yml
@@ -44,7 +44,7 @@ jobs:
       - name: Test connectors
         run: |
           export _EXPERIMENTAL_DAGGER_RUNNER_HOST="unix:///var/run/buildkit/buildkitd.sock"
-          DAGGER_CLI_COMMIT="67c7e7635cf4ea0e446e2fed522a3e314c960f6a"
+          DAGGER_CLI_COMMIT="2ecd496bc97805bb0c018e2ca333dc0648950eb1"
           DAGGER_TMP_BINDIR="/tmp/dagger_${DAGGER_CLI_COMMIT}"
           export _EXPERIMENTAL_DAGGER_CLI_BIN="$DAGGER_TMP_BINDIR/dagger"
           if [ ! -f  "$_EXPERIMENTAL_DAGGER_CLI_BIN" ]; then


### PR DESCRIPTION
## What
Resolves an issue where Dagger would fail because it was too resource hungry: https://github.com/dagger/dagger/pull/4824
