### PR TITLE
Update strava and paystack acceptance-test-config.ymls

### DIFF
--- a/airbyte-integrations/connectors/source-paystack/acceptance-test-config.yml
+++ b/airbyte-integrations/connectors/source-paystack/acceptance-test-config.yml
@@ -23,6 +23,7 @@ acceptance_tests:
             bypass_reason: "unable to seed, this stream requires third party system"
         expect_records:
           path: "integration_tests/expected_records.jsonl"
+        fail_on_extra_columns: false
   incremental:
     tests:
       - config_path: "secrets/config.json"

--- a/airbyte-integrations/connectors/source-strava/acceptance-test-config.yml
+++ b/airbyte-integrations/connectors/source-strava/acceptance-test-config.yml
@@ -20,6 +20,7 @@ acceptance_tests:
       - config_path: "secrets/config.json"
         expect_records:
           path: "integration_tests/expected_records.jsonl"
+        fail_on_extra_columns: false
   incremental:
     tests:
       - config_path: "secrets/config.json"


### PR DESCRIPTION
These connectors were alpha when I originally automated the adding of bypass reasons in https://github.com/airbytehq/airbyte/pull/23985. After pulling in master, they're beta, and we don't want them to fail in connector health! (I'd already run all the tests, including alphas -- these ones failed due to extra columns).