### PR TITLE
Source Slack: revert version 0.1.24

### DIFF
--- a/airbyte-integrations/connectors/source-slack/Dockerfile
+++ b/airbyte-integrations/connectors/source-slack/Dockerfile
@@ -17,5 +17,5 @@ COPY main.py ./
 ENV AIRBYTE_ENTRYPOINT "python /airbyte/integration_code/main.py"
 ENTRYPOINT ["python", "/airbyte/integration_code/main.py"]
 
-LABEL io.airbyte.version=0.1.24
+LABEL io.airbyte.version=0.1.25
 LABEL io.airbyte.name=airbyte/source-slack

--- a/airbyte-integrations/connectors/source-slack/source_slack/source.py
+++ b/airbyte-integrations/connectors/source-slack/source_slack/source.py
@@ -21,7 +21,7 @@ from pendulum import DateTime, Period
 class SlackStream(HttpStream, ABC):
     url_base = "https://slack.com/api/"
     primary_key = "id"
-    page_size = 1000
+    page_size = 100
 
     @property
     def max_retries(self) -> int:

--- a/airbyte-integrations/connectors/source-slack/unit_tests/conftest.py
+++ b/airbyte-integrations/connectors/source-slack/unit_tests/conftest.py
@@ -12,7 +12,7 @@ import pytest
 def conversations_list(requests_mock):
     return requests_mock.register_uri(
         "GET",
-        "https://slack.com/api/conversations.list?limit=1000&types=public_channel",
+        "https://slack.com/api/conversations.list?limit=100&types=public_channel",
         json={
             "channels": [
                 {"name": "advice-data-architecture", "id": 1},

--- a/airbyte-integrations/connectors/source-slack/unit_tests/test_source.py
+++ b/airbyte-integrations/connectors/source-slack/unit_tests/test_source.py
@@ -32,7 +32,7 @@ def test_streams(conversations_list, join_channels, config, is_valid):
             "Bad request",
             False,
             "Got an exception while trying to set up the connection: 400 Client Error: "
-            "None for url: https://slack.com/api/users.list?limit=1000. Most probably, there are no users in the given Slack instance or "
+            "None for url: https://slack.com/api/users.list?limit=100. Most probably, there are no users in the given Slack instance or "
             "your token is incorrect",
         ),
         (
@@ -40,13 +40,13 @@ def test_streams(conversations_list, join_channels, config, is_valid):
             "Forbidden",
             False,
             "Got an exception while trying to set up the connection: 403 Client Error: "
-            "None for url: https://slack.com/api/users.list?limit=1000. Most probably, there are no users in the given Slack instance or "
+            "None for url: https://slack.com/api/users.list?limit=100. Most probably, there are no users in the given Slack instance or "
             "your token is incorrect",
         ),
     ),
 )
 def test_check_connection(token_config, requests_mock, status_code, response, is_connection_successful, error_msg):
-    requests_mock.register_uri("GET", "https://slack.com/api/users.list?limit=1000", status_code=status_code, json=response)
+    requests_mock.register_uri("GET", "https://slack.com/api/users.list?limit=100", status_code=status_code, json=response)
     source = SourceSlack()
     success, error = source.check_connection(logger=logging.getLogger("airbyte"), config=token_config)
     assert success is is_connection_successful

--- a/docs/integrations/sources/slack.md
+++ b/docs/integrations/sources/slack.md
@@ -136,7 +136,7 @@ It is recommended to sync required channels only, this can be done by specifying
 
 | Version | Date       | Pull Request                                             | Subject                                                     |
 |:--------|:-----------|:---------------------------------------------------------|:------------------------------------------------------------|
-| 0.1.25  | 2023-03-24 | [00000](https://github.com/airbytehq/airbyte/pull/00000) | Revert version 0.1.24 because it causes heavy rate limiting |
+| 0.1.25  | 2023-03-24 | [24454](https://github.com/airbytehq/airbyte/pull/24454) | Revert version 0.1.24 because it causes heavy rate limiting |
 | 0.1.24  | 2023-03-20 | [24126](https://github.com/airbytehq/airbyte/pull/24126) | Increase page size to 1000                                  |
 | 0.1.23  | 2023-02-21 | [21907](https://github.com/airbytehq/airbyte/pull/21907) | Do not join channels that not gonna be synced               |
 | 0.1.22  | 2023-01-27 | [22022](https://github.com/airbytehq/airbyte/pull/22022) | Set `AvailabilityStrategy` for streams explicitly to `None` |

--- a/docs/integrations/sources/slack.md
+++ b/docs/integrations/sources/slack.md
@@ -136,6 +136,7 @@ It is recommended to sync required channels only, this can be done by specifying
 
 | Version | Date       | Pull Request                                             | Subject                                                     |
 |:--------|:-----------|:---------------------------------------------------------|:------------------------------------------------------------|
+| 0.1.25  | 2023-03-24 | [00000](https://github.com/airbytehq/airbyte/pull/00000) | Revert version 0.1.24 because it causes heavy rate limiting |
 | 0.1.24  | 2023-03-20 | [24126](https://github.com/airbytehq/airbyte/pull/24126) | Increase page size to 1000                                  |
 | 0.1.23  | 2023-02-21 | [21907](https://github.com/airbytehq/airbyte/pull/21907) | Do not join channels that not gonna be synced               |
 | 0.1.22  | 2023-01-27 | [22022](https://github.com/airbytehq/airbyte/pull/22022) | Set `AvailabilityStrategy` for streams explicitly to `None` |


### PR DESCRIPTION
## What
https://github.com/airbytehq/oncall/issues/1709

## How
Reverting to previous version because the Slack API seems to apply heavy rate limiting when we use page size much bigger then recommended (1000 vs 200).
