### PR TITLE
Airbyte CDK: update pydantic version to 1.10

### DIFF
--- a/airbyte-cdk/python/setup.py
+++ b/airbyte-cdk/python/setup.py
@@ -54,7 +54,7 @@ setup(
         "jsonref~=0.2",
         "pendulum",
         "genson==1.2.2",
-        "pydantic~=1.9.2",
+        "pydantic~=1.10",
         "python-dateutil",
         "PyYAML~=5.4",
         "requests",


### PR DESCRIPTION
## What
The airbyte cdk models throws an exception when trying to import in python 3.11

```
    from airbyte_protocol.models.airbyte_protocol import *
  File "/Users/mattotodd/Library/Caches/pypoetry/virtualenvs/proj-zOVad83R-py3.11/lib/python3.11/site-packages/airbyte_protocol/models/__init__.py", line 3, in <module>
    from .airbyte_protocol import *
  File "/Users/mattotodd/Library/Caches/pypoetry/virtualenvs/proj-zOVad83R-py3.11/lib/python3.11/site-packages/airbyte_protocol/models/airbyte_protocol.py", line 374, in <module>
    class AirbyteStateMessage(BaseModel):
  File "/Users/mattotodd/Library/Caches/pypoetry/virtualenvs/proj-zOVad83R-py3.11/lib/python3.11/site-packages/pydantic/main.py", line 292, in __new__
    cls.__signature__ = ClassAttribute('__signature__', generate_model_signature(cls.__init__, fields, config))
                                                        ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/Users/mattotodd/Library/Caches/pypoetry/virtualenvs/proj-zOVad83R-py3.11/lib/python3.11/site-packages/pydantic/utils.py", line 258, in generate_model_signature
    merged_params[param_name] = Parameter(
                                ^^^^^^^^^^
  File "/Users/mattotodd/.pyenv/versions/3.11.2/lib/python3.11/inspect.py", line 2722, in __init__
    raise ValueError('{!r} is not a valid parameter name'.format(name))
ValueError: 'global' is not a valid parameter name
```

## How
Update pydantic dependency to 1.10.  The issue is[ resolved here](https://github.com/pydantic/pydantic/issues/4011)


## 🚨 User Impact 🚨
[Breaking changes described here](https://github.com/pydantic/pydantic/releases/tag/v1.10.0a1): 

- The compiled boolean (whether pydantic is compiled with cython) has been moved from main.py to version.py
- Now that Config.extra is supported, dataclass ignores by default extra arguments (like BaseModel)



