### PR TITLE
Add bypasses for extra fields test

### DIFF
--- a/airbyte-integrations/connectors/source-chargebee/acceptance-test-config.yml
+++ b/airbyte-integrations/connectors/source-chargebee/acceptance-test-config.yml
@@ -5,64 +5,65 @@ test_strictness_level: high
 acceptance_tests:
   spec:
     tests:
-      - spec_path: "source_chargebee/spec.yaml"
+    - spec_path: "source_chargebee/spec.yaml"
   connection:
     tests:
-      - config_path: "secrets/config.json"
-        status: "succeed"
-      - config_path: "integration_tests/invalid_config.json"
-        status: "failed"
+    - config_path: "secrets/config.json"
+      status: "succeed"
+    - config_path: "integration_tests/invalid_config.json"
+      status: "failed"
   discovery:
     tests:
-      - config_path: "secrets/config.json"
-        backward_compatibility_tests_config:
-          disable_for_version: "0.2.1" # New streams were added; fixed fields type
+    - config_path: "secrets/config.json"
+      backward_compatibility_tests_config:
+        disable_for_version: "0.2.1"   # New streams were added; fixed fields type
   basic_read:
     tests:
-      - config_path: "secrets/config.json"
-        timeout_seconds: 1200
-        empty_streams:
-          - name: "addon"
-            bypass_reason: "Not permitted for this site"
-          - name: "plan"
-            bypass_reason: "Not permitted for this site"
-          - name: "virtual_bank_account"
-            bypass_reason: "Cannot populate with test data"
-          - name: "subscription"
-            bypass_reason: "Unstable data. Field current_term_start updated daily"
-          - name: "customer"
-            bypass_reason: "Unstable data. Depends on subscription"
-          - name: "invoice"
-            bypass_reason: "Unstable data. Depends on subscription"
-          - name: "credit_note"
-            bypass_reason: "Unstable data. Depends on subscription"
-          - name: "event"
-            bypass_reason: "Unstable data. Depends on subscription"
-          - name: "unbilled_charge"
-            bypass_reason: "Empty stream. Unstable data"
-          - name: "hosted_page"
-            bypass_reason: "Empty stream. Unstable data"
-        expect_records:
-          path: "integration_tests/expected_records.jsonl"
-          extra_fields: no
-          exact_order: no
-          extra_records: yes
+    - config_path: "secrets/config.json"
+      timeout_seconds: 1200
+      empty_streams:
+      - name: "addon"
+        bypass_reason: "Not permitted for this site"
+      - name: "plan"
+        bypass_reason: "Not permitted for this site"
+      - name: "virtual_bank_account"
+        bypass_reason: "Cannot populate with test data"
+      - name: "subscription"
+        bypass_reason: "Unstable data. Field current_term_start updated daily"
+      - name: "customer"
+        bypass_reason: "Unstable data. Depends on subscription"
+      - name: "invoice"
+        bypass_reason: "Unstable data. Depends on subscription"
+      - name: "credit_note"
+        bypass_reason: "Unstable data. Depends on subscription"
+      - name: "event"
+        bypass_reason: "Unstable data. Depends on subscription"
+      - name: "unbilled_charge"
+        bypass_reason: "Empty stream. Unstable data"
+      - name: "hosted_page"
+        bypass_reason: "Empty stream. Unstable data"
+      expect_records:
+        path: "integration_tests/expected_records.jsonl"
+        extra_fields: no
+        exact_order: no
+        extra_records: yes
+      fail_on_extra_columns: false
   incremental:
     tests:
-      - config_path: "secrets/config.json"
-        timeout_seconds: 2400
-        configured_catalog_path: "integration_tests/configured_catalog.json"
-        future_state:
-          future_state_path: "integration_tests/future_state.json"
-          missing_streams:
-            - name: attached_item
-              bypass_reason: "This stream is Full-Refresh only"
-            - name: contact
-              bypass_reason: "This stream is Full-Refresh only"
-            - name: quote_line_group
-              bypass_reason: "This stream is Full-Refresh only"
+    - config_path: "secrets/config.json"
+      timeout_seconds: 2400
+      configured_catalog_path: "integration_tests/configured_catalog.json"
+      future_state:
+        future_state_path: "integration_tests/future_state.json"
+        missing_streams:
+        - name: attached_item
+          bypass_reason: "This stream is Full-Refresh only"
+        - name: contact
+          bypass_reason: "This stream is Full-Refresh only"
+        - name: quote_line_group
+          bypass_reason: "This stream is Full-Refresh only"
   full_refresh:
     tests:
-      - config_path: "secrets/config.json"
-        timeout_seconds: 2400
-        configured_catalog_path: "integration_tests/configured_catalog.json"
+    - config_path: "secrets/config.json"
+      timeout_seconds: 2400
+      configured_catalog_path: "integration_tests/configured_catalog.json"

--- a/airbyte-integrations/connectors/source-close-com/acceptance-test-config.yml
+++ b/airbyte-integrations/connectors/source-close-com/acceptance-test-config.yml
@@ -4,64 +4,65 @@ connector_image: airbyte/source-close-com:dev
 acceptance_tests:
   spec:
     tests:
-      - spec_path: "source_close_com/spec.json"
+    - spec_path: "source_close_com/spec.json"
   connection:
     tests:
-      - config_path: "secrets/config.json"
-        status: "succeed"
-      - config_path: "integration_tests/invalid_config.json"
-        status: "failed"
+    - config_path: "secrets/config.json"
+      status: "succeed"
+    - config_path: "integration_tests/invalid_config.json"
+      status: "failed"
   discovery:
     tests:
-      - config_path: "secrets/config.json"
+    - config_path: "secrets/config.json"
         # Some field types was changed for streams.
         # custom_activities: id field was added
         # custom_email_connected_accounts: imap field was changed to object
         # smart_views: imap field was changed to object
-        backward_compatibility_tests_config:
-          disable_for_version: "0.1.0"
+      backward_compatibility_tests_config:
+        disable_for_version: "0.1.0"
   basic_read:
     tests:
-      - config_path: "secrets/config.json"
-        configured_catalog_path: "integration_tests/configured_catalog.json"
-        expect_records:
-          path: "integration_tests/expected_records.jsonl"
-        empty_streams:
-          - name: missed_call_tasks
-            bypass_reason: "unable to populate"
-          - name: answered_detached_call_tasks
-            bypass_reason: "unable to populate"
-          - name: incoming_sms_tasks
-            bypass_reason: "unable to populate"
-          - name: send_as
-            bypass_reason: "unable to populate"
-          - name: voicemail_tasks
-            bypass_reason: "unable to populate"
-          - name: leads
-            bypass_reason: "unable to test due to fast-changing data"
-          - name: events
-            bypass_reason: "unable to test due to fast-changing data"
-          - name: users
-            bypass_reason: "unable to test due to fast-changing data"
-          - name: contacts
-            bypass_reason: "unable to test due to fast-changing data"
-          - name: google_connected_accounts
-            bypass_reason: "unable to test due to fast-changing data"
-          - name: custom_email_connected_accounts
-            bypass_reason: "unable to test due to fast-changing data"
-          - name: zoom_connected_accounts
-            bypass_reason: "unable to test due to fast-changing data"
-          - name: email_bulk_actions
-            bypass_reason: "unable to test due to fast-changing data"
-          - name: incoming_email_tasks
-            bypass_reason: "unable to test due to fast-changing data"
+    - config_path: "secrets/config.json"
+      configured_catalog_path: "integration_tests/configured_catalog.json"
+      expect_records:
+        path: "integration_tests/expected_records.jsonl"
+      empty_streams:
+      - name: missed_call_tasks
+        bypass_reason: "unable to populate"
+      - name: answered_detached_call_tasks
+        bypass_reason: "unable to populate"
+      - name: incoming_sms_tasks
+        bypass_reason: "unable to populate"
+      - name: send_as
+        bypass_reason: "unable to populate"
+      - name: voicemail_tasks
+        bypass_reason: "unable to populate"
+      - name: leads
+        bypass_reason: "unable to test due to fast-changing data"
+      - name: events
+        bypass_reason: "unable to test due to fast-changing data"
+      - name: users
+        bypass_reason: "unable to test due to fast-changing data"
+      - name: contacts
+        bypass_reason: "unable to test due to fast-changing data"
+      - name: google_connected_accounts
+        bypass_reason: "unable to test due to fast-changing data"
+      - name: custom_email_connected_accounts
+        bypass_reason: "unable to test due to fast-changing data"
+      - name: zoom_connected_accounts
+        bypass_reason: "unable to test due to fast-changing data"
+      - name: email_bulk_actions
+        bypass_reason: "unable to test due to fast-changing data"
+      - name: incoming_email_tasks
+        bypass_reason: "unable to test due to fast-changing data"
+      fail_on_extra_columns: false
   incremental:
     tests:
-      - config_path: "secrets/config.json"
-        configured_catalog_path: "integration_tests/configured_catalog.json"
-        future_state:
-          future_state_path: "integration_tests/abnormal_state.json"
+    - config_path: "secrets/config.json"
+      configured_catalog_path: "integration_tests/configured_catalog.json"
+      future_state:
+        future_state_path: "integration_tests/abnormal_state.json"
   full_refresh:
     tests:
-      - config_path: "secrets/config.json"
-        configured_catalog_path: "integration_tests/configured_catalog.json"
+    - config_path: "secrets/config.json"
+      configured_catalog_path: "integration_tests/configured_catalog.json"

--- a/airbyte-integrations/connectors/source-github/acceptance-test-config.yml
+++ b/airbyte-integrations/connectors/source-github/acceptance-test-config.yml
@@ -3,143 +3,139 @@ test_strictness_level: "high"
 acceptance_tests:
   spec:
     tests:
-      - spec_path: "source_github/spec.json"
+    - spec_path: "source_github/spec.json"
   connection:
     tests:
-      - config_path: "secrets/config.json"
-        status: "succeed"
-      - config_path: "secrets/config_oauth.json"
-        status: "succeed"
-      - config_path: "integration_tests/invalid_config.json"
-        status: "failed"
+    - config_path: "secrets/config.json"
+      status: "succeed"
+    - config_path: "secrets/config_oauth.json"
+      status: "succeed"
+    - config_path: "integration_tests/invalid_config.json"
+      status: "failed"
   discovery:
     tests:
-      - config_path: "secrets/config.json"
-      - config_path: "secrets/config_oauth.json"
+    - config_path: "secrets/config.json"
+    - config_path: "secrets/config_oauth.json"
   basic_read:
     tests:
-      - config_path: "secrets/config.json"
-        expect_records:
-          path: "integration_tests/expected_records.jsonl"
-          extra_fields: no
-          exact_order: no
-          extra_records: yes
-        empty_streams:
-          - name: "events"
-            bypass_reason: "Only events created within the past 90 days can be showed"
-        ignored_fields:
-          workflow_jobs:
-            - name: steps/*/started_at
-              bypass_reason: "depend on changing data"
-            - name: steps/*/completed_at
-              bypass_reason: "depend on changing data"
-          organizations:
-            - name: followers
-              bypass_reason: "fast changing data"
-            - name: updated_at
-              bypass_reason: "fast changing data"
-            - name: plan
-              bypass_reason: "fast changing data"
-            - name: public_repos
-              bypass_reason: "fast changing data"
-            - name: total_private_repos
-              bypass_reason: "fast changing data"
-            - name: owned_private_repos
-              bypass_reason: "fast changing data"
-          repositories:
-            - name: updated_at
-              bypass_reason: "fast changing data"
-            - name: pushed_at
-              bypass_reason: "fast changing data"
-            - name: size
-              bypass_reason: "fast changing data"
-            - name: stargazers_count
-              bypass_reason: "fast changing data"
-            - name: watchers_count
-              bypass_reason: "fast changing data"
-            - name: forks_count
-              bypass_reason: "fast changing data"
-            - name: forks
-              bypass_reason: "fast changing data"
-            - name: open_issues
-              bypass_reason: "fast changing data"
-            - name: open_issues_count
-              bypass_reason: "fast changing data"
-            - name: watchers
-              bypass_reason: "fast changing data"
+    - config_path: "secrets/config.json"
+      expect_records:
+        path: "integration_tests/expected_records.jsonl"
+        extra_fields: no
+        exact_order: no
+        extra_records: yes
+      empty_streams:
+      - name: "events"
+        bypass_reason: "Only events created within the past 90 days can be showed"
+      ignored_fields:
+        workflow_jobs:
+        - name: steps/*/started_at
+          bypass_reason: "depend on changing data"
+        - name: steps/*/completed_at
+          bypass_reason: "depend on changing data"
+        organizations:
+        - name: followers
+          bypass_reason: "fast changing data"
+        - name: updated_at
+          bypass_reason: "fast changing data"
+        - name: plan
+          bypass_reason: "fast changing data"
+        - name: public_repos
+          bypass_reason: "fast changing data"
+        - name: total_private_repos
+          bypass_reason: "fast changing data"
+        - name: owned_private_repos
+          bypass_reason: "fast changing data"
+        repositories:
+        - name: updated_at
+          bypass_reason: "fast changing data"
+        - name: pushed_at
+          bypass_reason: "fast changing data"
+        - name: size
+          bypass_reason: "fast changing data"
+        - name: stargazers_count
+          bypass_reason: "fast changing data"
+        - name: watchers_count
+          bypass_reason: "fast changing data"
+        - name: forks_count
+          bypass_reason: "fast changing data"
+        - name: forks
+          bypass_reason: "fast changing data"
+        - name: open_issues
+          bypass_reason: "fast changing data"
+        - name: open_issues_count
+          bypass_reason: "fast changing data"
+        - name: watchers
+          bypass_reason: "fast changing data"
+      fail_on_extra_columns: false
   incremental:
     tests:
-      - config_path: "secrets/config.json"
-        configured_catalog_path: "integration_tests/configured_catalog.json"
-        future_state:
-          future_state_path: "integration_tests/abnormal_state.json"
-        cursor_paths:
-          comments: ["airbytehq/integration-test", "updated_at"]
-          commit_comment_reactions:
-            ["airbytehq/integration-test", "55538825", "created_at"]
-          commit_comments: ["airbytehq/integration-test", "updated_at"]
-          commits: ["airbytehq/integration-test", "master", "created_at"]
-          deployments: ["airbytehq/integration-test", "updated_at"]
-          events: ["airbytehq/integration-test", "created_at"]
-          issue_comment_reactions:
-            ["airbytehq/integration-test", "907296275", "created_at"]
-          issue_events: ["airbytehq/integration-test", "created_at"]
-          issue_milestones: ["airbytehq/integration-test", "updated_at"]
-          issue_reactions: ["airbytehq/integration-test", "created_at"]
-          issues: ["airbytehq/integration-test", "updated_at"]
-          project_cards:
-            ["airbytehq/integration-test", "13167124", "17807006", "updated_at"]
-          project_columns:
-            ["airbytehq/integration-test", "13167124", "updated_at"]
-          projects: ["airbytehq/integration-test", "updated_at"]
-          pull_request_comment_reactions:
-            ["airbytehq/integration-test", "699253726", "created_at"]
-          pull_request_stats: ["airbytehq/integration-test", "updated_at"]
-          pull_requests: ["airbytehq/integration-test", "updated_at"]
-          releases: ["airbytehq/integration-test", "created_at"]
-          repositories: ["airbytehq", "updated_at"]
-          review_comments: ["airbytehq/integration-test", "updated_at"]
-          reviews: ["airbytehq/integration-test", "updated_at"]
-          stargazers: ["airbytehq/integration-test", "starred_at"]
-          workflow_runs: ["airbytehq/integration-test", "updated_at"]
-          workflows: ["airbytehq/integration-test", "updated_at"]
-          workflow_jobs: ["airbytehq/integration-test", "completed_at"]
+    - config_path: "secrets/config.json"
+      configured_catalog_path: "integration_tests/configured_catalog.json"
+      future_state:
+        future_state_path: "integration_tests/abnormal_state.json"
+      cursor_paths:
+        comments: ["airbytehq/integration-test", "updated_at"]
+        commit_comment_reactions: ["airbytehq/integration-test", "55538825", "created_at"]
+        commit_comments: ["airbytehq/integration-test", "updated_at"]
+        commits: ["airbytehq/integration-test", "master", "created_at"]
+        deployments: ["airbytehq/integration-test", "updated_at"]
+        events: ["airbytehq/integration-test", "created_at"]
+        issue_comment_reactions: ["airbytehq/integration-test", "907296275", "created_at"]
+        issue_events: ["airbytehq/integration-test", "created_at"]
+        issue_milestones: ["airbytehq/integration-test", "updated_at"]
+        issue_reactions: ["airbytehq/integration-test", "created_at"]
+        issues: ["airbytehq/integration-test", "updated_at"]
+        project_cards: ["airbytehq/integration-test", "13167124", "17807006", "updated_at"]
+        project_columns: ["airbytehq/integration-test", "13167124", "updated_at"]
+        projects: ["airbytehq/integration-test", "updated_at"]
+        pull_request_comment_reactions: ["airbytehq/integration-test", "699253726", "created_at"]
+        pull_request_stats: ["airbytehq/integration-test", "updated_at"]
+        pull_requests: ["airbytehq/integration-test", "updated_at"]
+        releases: ["airbytehq/integration-test", "created_at"]
+        repositories: ["airbytehq", "updated_at"]
+        review_comments: ["airbytehq/integration-test", "updated_at"]
+        reviews: ["airbytehq/integration-test", "updated_at"]
+        stargazers: ["airbytehq/integration-test", "starred_at"]
+        workflow_runs: ["airbytehq/integration-test", "updated_at"]
+        workflows: ["airbytehq/integration-test", "updated_at"]
+        workflow_jobs: ["airbytehq/integration-test", "completed_at"]
   full_refresh:
     tests:
-      - config_path: "secrets/config.json"
-        configured_catalog_path: "integration_tests/configured_catalog.json"
-        ignored_fields:
-          organizations:
-            - name: followers
-              bypass_reason: "fast changing data"
-            - name: updated_at
-              bypass_reason: "fast changing data"
-            - name: plan
-              bypass_reason: "fast changing data"
-            - name: public_repos
-              bypass_reason: "fast changing data"
-            - name: total_private_repos
-              bypass_reason: "fast changing data"
-            - name: owned_private_repos
-              bypass_reason: "fast changing data"
-          repositories:
-            - name: updated_at
-              bypass_reason: "fast changing data"
-            - name: pushed_at
-              bypass_reason: "fast changing data"
-            - name: size
-              bypass_reason: "fast changing data"
-            - name: stargazers_count
-              bypass_reason: "fast changing data"
-            - name: watchers_count
-              bypass_reason: "fast changing data"
-            - name: forks_count
-              bypass_reason: "fast changing data"
-            - name: forks
-              bypass_reason: "fast changing data"
-            - name: open_issues
-              bypass_reason: "fast changing data"
-            - name: open_issues_count
-              bypass_reason: "fast changing data"
-            - name: watchers
-              bypass_reason: "fast changing data"
+    - config_path: "secrets/config.json"
+      configured_catalog_path: "integration_tests/configured_catalog.json"
+      ignored_fields:
+        organizations:
+        - name: followers
+          bypass_reason: "fast changing data"
+        - name: updated_at
+          bypass_reason: "fast changing data"
+        - name: plan
+          bypass_reason: "fast changing data"
+        - name: public_repos
+          bypass_reason: "fast changing data"
+        - name: total_private_repos
+          bypass_reason: "fast changing data"
+        - name: owned_private_repos
+          bypass_reason: "fast changing data"
+        repositories:
+        - name: updated_at
+          bypass_reason: "fast changing data"
+        - name: pushed_at
+          bypass_reason: "fast changing data"
+        - name: size
+          bypass_reason: "fast changing data"
+        - name: stargazers_count
+          bypass_reason: "fast changing data"
+        - name: watchers_count
+          bypass_reason: "fast changing data"
+        - name: forks_count
+          bypass_reason: "fast changing data"
+        - name: forks
+          bypass_reason: "fast changing data"
+        - name: open_issues
+          bypass_reason: "fast changing data"
+        - name: open_issues_count
+          bypass_reason: "fast changing data"
+        - name: watchers
+          bypass_reason: "fast changing data"

--- a/airbyte-integrations/connectors/source-gitlab/acceptance-test-config.yml
+++ b/airbyte-integrations/connectors/source-gitlab/acceptance-test-config.yml
@@ -3,49 +3,52 @@ test_strictness_level: "high"
 acceptance_tests:
   spec:
     tests:
-      - spec_path: "source_gitlab/spec.json"
+    - spec_path: "source_gitlab/spec.json"
   connection:
     tests:
-      - config_path: "secrets/config.json"
-        status: "succeed"
-      - config_path: "secrets/config_oauth.json"
-        status: "succeed"
-      - config_path: "integration_tests/invalid_config.json"
-        status: "failed"
+    - config_path: "secrets/config.json"
+      status: "succeed"
+    - config_path: "secrets/config_oauth.json"
+      status: "succeed"
+    - config_path: "integration_tests/invalid_config.json"
+      status: "failed"
   discovery:
     tests:
-      - config_path: "secrets/config.json"
+    - config_path: "secrets/config.json"
   basic_read:
     tests:
-      - config_path: "secrets/config.json"
-        timeout_seconds: 3600
-        expect_records:
-          path: "integration_tests/expected_records.jsonl"
-      - config_path: "secrets/config_with_ids.json"
-        timeout_seconds: 3600
-        empty_streams:
-          - name: "epics"
-            bypass_reason: "Group in this config does not have epics. This stream is tested in the above TC."
-          - name: "epic_issues"
-            bypass_reason: "Group in this config does not have epics issues. This stream is tested in the above TC."
-        expect_records:
-          path: "integration_tests/expected_records_with_ids.jsonl"
-      - config_path: "secrets/config_oauth.json"
-        timeout_seconds: 3600
-        expect_records:
-          path: "integration_tests/expected_records.jsonl"
+    - config_path: "secrets/config.json"
+      timeout_seconds: 3600
+      expect_records:
+        path: "integration_tests/expected_records.jsonl"
+      fail_on_extra_columns: false
+    - config_path: "secrets/config_with_ids.json"
+      timeout_seconds: 3600
+      empty_streams:
+      - name: "epics"
+        bypass_reason: "Group in this config does not have epics. This stream is tested in the above TC."
+      - name: "epic_issues"
+        bypass_reason: "Group in this config does not have epics issues. This stream is tested in the above TC."
+      expect_records:
+        path: "integration_tests/expected_records_with_ids.jsonl"
+      fail_on_extra_columns: false
+    - config_path: "secrets/config_oauth.json"
+      timeout_seconds: 3600
+      expect_records:
+        path: "integration_tests/expected_records.jsonl"
+      fail_on_extra_columns: false
   incremental:
     tests:
-      - config_path: "secrets/config_with_ids.json"
-        configured_catalog_path: "integration_tests/incremental_catalog.json"
-        future_state:
-          future_state_path: "integration_tests/abnormal_state.json"
-        cursor_paths:
-          commits: ["25157276", "created_at"]
-          issues: ["25157276", "updated_at"]
-          merge_requests: ["25157276", "updated_at"]
-          pipelines: ["25157276", "updated_at"]
+    - config_path: "secrets/config_with_ids.json"
+      configured_catalog_path: "integration_tests/incremental_catalog.json"
+      future_state:
+        future_state_path: "integration_tests/abnormal_state.json"
+      cursor_paths:
+        commits: ["25157276", "created_at"]
+        issues: ["25157276", "updated_at"]
+        merge_requests: ["25157276", "updated_at"]
+        pipelines: ["25157276", "updated_at"]
   full_refresh:
     tests:
-      - config_path: "secrets/config.json"
-        configured_catalog_path: "integration_tests/configured_catalog.json"
+    - config_path: "secrets/config.json"
+      configured_catalog_path: "integration_tests/configured_catalog.json"

--- a/airbyte-integrations/connectors/source-harvest/acceptance-test-config.yml
+++ b/airbyte-integrations/connectors/source-harvest/acceptance-test-config.yml
@@ -3,36 +3,37 @@ test_strictness_level: "high"
 acceptance_tests:
   spec:
     tests:
-      - spec_path: "source_harvest/spec.json"
+    - spec_path: "source_harvest/spec.json"
   connection:
     tests:
-      - config_path: "secrets/config.json"
-        status: "succeed"
-      - config_path: "secrets/old_config.json"
-        status: "succeed"
-      - config_path: "secrets/config_oauth.json"
-        status: "succeed"
-      - config_path: "integration_tests/invalid_config.json"
-        status: "failed"
+    - config_path: "secrets/config.json"
+      status: "succeed"
+    - config_path: "secrets/old_config.json"
+      status: "succeed"
+    - config_path: "secrets/config_oauth.json"
+      status: "succeed"
+    - config_path: "integration_tests/invalid_config.json"
+      status: "failed"
   discovery:
     tests:
-      - config_path: "secrets/config.json"
+    - config_path: "secrets/config.json"
   basic_read:
     tests:
-      - config_path: "secrets/config.json"
-        expect_records:
-          path: "integration_tests/expected_records.jsonl"
+    - config_path: "secrets/config.json"
+      expect_records:
+        path: "integration_tests/expected_records.jsonl"
+      fail_on_extra_columns: false
   incremental:
     tests:
-      - config_path: "secrets/config_with_date_range.json"
-        configured_catalog_path: "integration_tests/incremental_catalog.json"
-        future_state:
-          future_state_path: "integration_tests/abnormal_state.json"
-        cursor_paths:
-          contacts: ["updated_at"]
-          expenses_clients: ["to"]
-        timeout_seconds: 2400
+    - config_path: "secrets/config_with_date_range.json"
+      configured_catalog_path: "integration_tests/incremental_catalog.json"
+      future_state:
+        future_state_path: "integration_tests/abnormal_state.json"
+      cursor_paths:
+        contacts: ["updated_at"]
+        expenses_clients: ["to"]
+      timeout_seconds: 2400
   full_refresh:
     tests:
-      - config_path: "secrets/config.json"
-        configured_catalog_path: "integration_tests/configured_catalog.json"
+    - config_path: "secrets/config.json"
+      configured_catalog_path: "integration_tests/configured_catalog.json"

--- a/airbyte-integrations/connectors/source-hubspot/acceptance-test-config.yml
+++ b/airbyte-integrations/connectors/source-hubspot/acceptance-test-config.yml
@@ -3,80 +3,81 @@ test_strictness_level: high
 acceptance_tests:
   spec:
     tests:
-      - spec_path: source_hubspot/spec.yaml
+    - spec_path: source_hubspot/spec.yaml
   connection:
     tests:
-      - config_path: secrets/config_oauth.json
-        status: succeed
-      - config_path: integration_tests/invalid_config.json
-        status: failed
-      - config_path: integration_tests/invalid_config_oauth.json
-        status: failed
-      - config_path: integration_tests/invalid_config_wrong_title.json
-        status: failed
+    - config_path: secrets/config_oauth.json
+      status: succeed
+    - config_path: integration_tests/invalid_config.json
+      status: failed
+    - config_path: integration_tests/invalid_config_oauth.json
+      status: failed
+    - config_path: integration_tests/invalid_config_wrong_title.json
+      status: failed
   discovery:
     tests:
-      - config_path: secrets/config_oauth.json
+    - config_path: secrets/config_oauth.json
   basic_read:
     tests:
-      - config_path: secrets/config_oauth.json
-        expect_records:
-          path: integration_tests/expected_records.jsonl
-        timeout_seconds: 3600
-        empty_streams:
-          - name: form_submissions
-            bypass_reason: Unable to populate
-          - name: ticket_pipelines
-            bypass_reason: Unable to populate
-          - name: engagements_meetings
-            bypass_reason: Unable to populate
-          - name: engagements_emails
-            bypass_reason: Unable to populate
-          - name: engagements_calls
-            bypass_reason: Unable to populate
-          - name: quotes
-            bypass_reason: Unable to populate
-        ignored_fields:
-          contact_lists:
-          - name: ilsFilterBranch
-            bypass_reason: Floating fields order
-          companies:
-          - name: properties/hs_time_*
-            bypass_reason: Hubspot time depend on current time
-          contacts:
-          - name: properties/hs_time_*
-            bypass_reason: Hubspot time depend on current time
-          - name: properties/hs_latest_source_timestamp
-            bypass_reason: Hubspot time depend on current time
-          deals:
-          - name: properties/hs_time_*
-            bypass_reason: Hubspot time depend on current time
-          tickets:
-          - name: properties/hs_time_*
-            bypass_reason: Hubspot time depend on current time
+    - config_path: secrets/config_oauth.json
+      expect_records:
+        path: integration_tests/expected_records.jsonl
+      timeout_seconds: 3600
+      empty_streams:
+      - name: form_submissions
+        bypass_reason: Unable to populate
+      - name: ticket_pipelines
+        bypass_reason: Unable to populate
+      - name: engagements_meetings
+        bypass_reason: Unable to populate
+      - name: engagements_emails
+        bypass_reason: Unable to populate
+      - name: engagements_calls
+        bypass_reason: Unable to populate
+      - name: quotes
+        bypass_reason: Unable to populate
+      ignored_fields:
+        contact_lists:
+        - name: ilsFilterBranch
+          bypass_reason: Floating fields order
+        companies:
+        - name: properties/hs_time_*
+          bypass_reason: Hubspot time depend on current time
+        contacts:
+        - name: properties/hs_time_*
+          bypass_reason: Hubspot time depend on current time
+        - name: properties/hs_latest_source_timestamp
+          bypass_reason: Hubspot time depend on current time
+        deals:
+        - name: properties/hs_time_*
+          bypass_reason: Hubspot time depend on current time
+        tickets:
+        - name: properties/hs_time_*
+          bypass_reason: Hubspot time depend on current time
+      fail_on_extra_columns: false
   full_refresh:
     tests:
-      - config_path: secrets/config_oauth.json
-        configured_catalog_path: sample_files/full_refresh_oauth_catalog.json
-        ignored_fields:
-          contact_lists:
-          - name: ilsFilterBranch
-            bypass_reason: Floating fields order
-          companies:
-          - name: properties/hs_time_*
-            bypass_reason: Hubspot time depend on current time
-          contacts:
-          - name: properties/hs_time_*
-            bypass_reason: Hubspot time depend on current time
-          deals:
-          - name: properties/hs_time_*
-            bypass_reason: Hubspot time depend on current time
-          tickets:
-          - name: properties/hs_time_*
-            bypass_reason: Hubspot time depend on current time
+    - config_path: secrets/config_oauth.json
+      configured_catalog_path: sample_files/full_refresh_oauth_catalog.json
+      ignored_fields:
+        contact_lists:
+        - name: ilsFilterBranch
+          bypass_reason: Floating fields order
+        companies:
+        - name: properties/hs_time_*
+          bypass_reason: Hubspot time depend on current time
+        contacts:
+        - name: properties/hs_time_*
+          bypass_reason: Hubspot time depend on current time
+        deals:
+        - name: properties/hs_time_*
+          bypass_reason: Hubspot time depend on current time
+        tickets:
+        - name: properties/hs_time_*
+          bypass_reason: Hubspot time depend on current time
   incremental:
     tests:
-      - config_path: secrets/config_oauth.json
-        configured_catalog_path: sample_files/incremental_catalog.json
-        future_state:
-          future_state_path: integration_tests/abnormal_state.json
+    - config_path: secrets/config_oauth.json
+      configured_catalog_path: sample_files/incremental_catalog.json
+      future_state:
+        future_state_path: integration_tests/abnormal_state.json

--- a/airbyte-integrations/connectors/source-jira/acceptance-test-config.yml
+++ b/airbyte-integrations/connectors/source-jira/acceptance-test-config.yml
@@ -5,35 +5,36 @@ test_strictness_level: high
 acceptance_tests:
   spec:
     tests:
-      - spec_path: "source_jira/spec.json"
+    - spec_path: "source_jira/spec.json"
   connection:
     tests:
-      - config_path: "secrets/config.json"
-        status: "succeed"
-      - config_path: "integration_tests/invalid_config.json"
-        status: "failed"
+    - config_path: "secrets/config.json"
+      status: "succeed"
+    - config_path: "integration_tests/invalid_config.json"
+      status: "failed"
   discovery:
     tests:
-      - config_path: "secrets/config.json"
+    - config_path: "secrets/config.json"
   basic_read:
     tests:
-      - config_path: "secrets/config.json"
-        expect_records:
-          path: "integration_tests/expected_records.jsonl"
-        empty_streams:
-          - name: "issue_properties"
-            bypass_reason: "unable to populate"
-          - name: "project_permission_schemes"
-            bypass_reason: "unable to populate"
-          - name: "screen_tab_fields"
-            bypass_reason: "unable to populate"
+    - config_path: "secrets/config.json"
+      expect_records:
+        path: "integration_tests/expected_records.jsonl"
+      empty_streams:
+      - name: "issue_properties"
+        bypass_reason: "unable to populate"
+      - name: "project_permission_schemes"
+        bypass_reason: "unable to populate"
+      - name: "screen_tab_fields"
+        bypass_reason: "unable to populate"
+      fail_on_extra_columns: false
   incremental:
     tests:
-      - config_path: "secrets/config.json"
-        configured_catalog_path: "integration_tests/configured_catalog.json"
-        future_state:
-          future_state_path: "integration_tests/abnormal_state.json"
+    - config_path: "secrets/config.json"
+      configured_catalog_path: "integration_tests/configured_catalog.json"
+      future_state:
+        future_state_path: "integration_tests/abnormal_state.json"
   full_refresh:
     tests:
-      - config_path: "secrets/config.json"
-        configured_catalog_path: "integration_tests/configured_catalog.json"
+    - config_path: "secrets/config.json"
+      configured_catalog_path: "integration_tests/configured_catalog.json"

--- a/airbyte-integrations/connectors/source-mailchimp/acceptance-test-config.yml
+++ b/airbyte-integrations/connectors/source-mailchimp/acceptance-test-config.yml
@@ -3,56 +3,58 @@ test_strictness_level: high
 acceptance_tests:
   spec:
     tests:
-      - spec_path: "source_mailchimp/spec.json"
+    - spec_path: "source_mailchimp/spec.json"
   connection:
     tests:
       # for old spec config (without oneOf)
-      - config_path: "secrets/config.json"
-        status: "succeed"
+    - config_path: "secrets/config.json"
+      status: "succeed"
       # for auth with API token
-      - config_path: "secrets/config_apikey.json"
-        status: "succeed"
+    - config_path: "secrets/config_apikey.json"
+      status: "succeed"
       # for auth with oauth2 token
-      - config_path: "secrets/config_oauth.json"
-        status: "succeed"
-      - config_path: "integration_tests/invalid_config.json"
-        status: "failed"
-      - config_path: "integration_tests/invalid_config_apikey.json"
-        status: "failed"
-      - config_path: "integration_tests/invalid_config_oauth.json"
-        status: "failed"
+    - config_path: "secrets/config_oauth.json"
+      status: "succeed"
+    - config_path: "integration_tests/invalid_config.json"
+      status: "failed"
+    - config_path: "integration_tests/invalid_config_apikey.json"
+      status: "failed"
+    - config_path: "integration_tests/invalid_config_oauth.json"
+      status: "failed"
   discovery:
     tests:
       # for old spec config (without oneOf)
-      - config_path: "secrets/config.json"
+    - config_path: "secrets/config.json"
       # for auth with API token
-      - config_path: "secrets/config_apikey.json"
+    - config_path: "secrets/config_apikey.json"
       # for auth with oauth2 token
-      - config_path: "secrets/config_oauth.json"
+    - config_path: "secrets/config_oauth.json"
   basic_read:
     tests:
-      - config_path: "secrets/config.json"
-        expect_records:
-          bypass_reason: "Risk to disclose internal data. Need to set up a sandbox account - https://github.com/airbytehq/airbyte/issues/20726"
-      - config_path: "secrets/config_oauth.json"
-        expect_records:
-          bypass_reason: "Risk to disclose internal data. Need to set up a sandbox account - https://github.com/airbytehq/airbyte/issues/20726"
+    - config_path: "secrets/config.json"
+      expect_records:
+        bypass_reason: "Risk to disclose internal data. Need to set up a sandbox account - https://github.com/airbytehq/airbyte/issues/20726"
+      fail_on_extra_columns: false
+    - config_path: "secrets/config_oauth.json"
+      expect_records:
+        bypass_reason: "Risk to disclose internal data. Need to set up a sandbox account - https://github.com/airbytehq/airbyte/issues/20726"
+      fail_on_extra_columns: false
   incremental:
     tests:
-      - config_path: "secrets/config.json"
-        configured_catalog_path: "integration_tests/configured_catalog.json"
-        future_state:
-          future_state_path: "integration_tests/state.json"
-        cursor_paths:
-          lists: ["date_created"]
-          campaigns: ["create_time"]
-          email_activity: ["49d68626f3", "timestamp"]
-          reports: ["send_time"]
+    - config_path: "secrets/config.json"
+      configured_catalog_path: "integration_tests/configured_catalog.json"
+      future_state:
+        future_state_path: "integration_tests/state.json"
+      cursor_paths:
+        lists: ["date_created"]
+        campaigns: ["create_time"]
+        email_activity: ["49d68626f3", "timestamp"]
+        reports: ["send_time"]
   # Email activities stream has working campaigns with email newsletters.
   # Due to this sequential_reads test could be failed.
   full_refresh:
     tests:
-      - config_path: "secrets/config.json"
-        configured_catalog_path: "integration_tests/configured_catalog_without_email_activities.json"
-      - config_path: "secrets/config_oauth.json"
-        configured_catalog_path: "integration_tests/configured_catalog_without_email_activities.json"
+    - config_path: "secrets/config.json"
+      configured_catalog_path: "integration_tests/configured_catalog_without_email_activities.json"
+    - config_path: "secrets/config_oauth.json"
+      configured_catalog_path: "integration_tests/configured_catalog_without_email_activities.json"

--- a/airbyte-integrations/connectors/source-notion/acceptance-test-config.yml
+++ b/airbyte-integrations/connectors/source-notion/acceptance-test-config.yml
@@ -5,30 +5,31 @@ test_strictness_level: high
 acceptance_tests:
   spec:
     tests:
-      - spec_path: "source_notion/spec.json"
+    - spec_path: "source_notion/spec.json"
   connection:
     tests:
-      - config_path: "secrets/config.json"
-        status: "succeed"
-      - config_path: "secrets/config_oauth.json"
-        status: "succeed"
-      - config_path: "integration_tests/invalid_config.json"
-        status: "failed"
+    - config_path: "secrets/config.json"
+      status: "succeed"
+    - config_path: "secrets/config_oauth.json"
+      status: "succeed"
+    - config_path: "integration_tests/invalid_config.json"
+      status: "failed"
   discovery:
     tests:
-      - config_path: "secrets/config.json"
+    - config_path: "secrets/config.json"
   basic_read:
     tests:
-      - config_path: "secrets/config.json"
-        expect_records:
-          path: "integration_tests/expected_records.txt.jsonl"
+    - config_path: "secrets/config.json"
+      expect_records:
+        path: "integration_tests/expected_records.txt.jsonl"
+      fail_on_extra_columns: false
   incremental:
     tests:
-      - config_path: "secrets/config.json"
-        configured_catalog_path: "integration_tests/incremental_catalog.json"
-        future_state:
-          future_state_path: "integration_tests/abnormal_state.json"
+    - config_path: "secrets/config.json"
+      configured_catalog_path: "integration_tests/incremental_catalog.json"
+      future_state:
+        future_state_path: "integration_tests/abnormal_state.json"
   full_refresh:
     tests:
-      - config_path: "secrets/config.json"
-        configured_catalog_path: "integration_tests/configured_catalog.json"
+    - config_path: "secrets/config.json"
+      configured_catalog_path: "integration_tests/configured_catalog.json"

--- a/airbyte-integrations/connectors/source-sendgrid/acceptance-test-config.yml
+++ b/airbyte-integrations/connectors/source-sendgrid/acceptance-test-config.yml
@@ -3,59 +3,60 @@ test_strictness_level: "high"
 acceptance_tests:
   spec:
     tests:
-      - spec_path: "source_sendgrid/spec.json"
-        backward_compatibility_tests_config:
-          disable_for_version: "0.3.0"
+    - spec_path: "source_sendgrid/spec.json"
+      backward_compatibility_tests_config:
+        disable_for_version: "0.3.0"
   connection:
     tests:
-      - config_path: "secrets/config.json"
-        status: "succeed"
-      - config_path: "secrets/old_config.json"
-        status: "succeed"
-      - config_path: "integration_tests/invalid_time.json"
-        status: "failed"
-      - config_path: "integration_tests/invalid_api_key.json"
-        status: "failed"
+    - config_path: "secrets/config.json"
+      status: "succeed"
+    - config_path: "secrets/old_config.json"
+      status: "succeed"
+    - config_path: "integration_tests/invalid_time.json"
+      status: "failed"
+    - config_path: "integration_tests/invalid_api_key.json"
+      status: "failed"
   discovery:
     tests:
-      - config_path: "secrets/old_config.json"
-        backward_compatibility_tests_config:
-          disable_for_version: "0.3.0"
+    - config_path: "secrets/old_config.json"
+      backward_compatibility_tests_config:
+        disable_for_version: "0.3.0"
   basic_read:
     tests:
-      - config_path: "secrets/config.json"
-        expect_records:
-          path: "integration_tests/expected_records.jsonl"
-          extra_fields: no
-          exact_order: no
-          extra_records: yes
-        empty_streams:
-          - name: spam_reports
-            bypass_reason: "can not populate"
-          - name: invalid_emails
-            bypass_reason: "can not populate"
-          - name: blocks
-            bypass_reason: "can not populate"
-        ignored_fields:
-          segments:
-          - name: sample_updated_at
-            bypass_reason: "depend on current date"
-          - name: next_sample_update
-            bypass_reason: "depend on current date"
+    - config_path: "secrets/config.json"
+      expect_records:
+        path: "integration_tests/expected_records.jsonl"
+        extra_fields: no
+        exact_order: no
+        extra_records: yes
+      empty_streams:
+      - name: spam_reports
+        bypass_reason: "can not populate"
+      - name: invalid_emails
+        bypass_reason: "can not populate"
+      - name: blocks
+        bypass_reason: "can not populate"
+      ignored_fields:
+        segments:
+        - name: sample_updated_at
+          bypass_reason: "depend on current date"
+        - name: next_sample_update
+          bypass_reason: "depend on current date"
+      fail_on_extra_columns: false
   incremental:
     tests:
-      - config_path: "secrets/config.json"
-        configured_catalog_path: "integration_tests/no_spam_reports_configured_catalog.json"
-        future_state:
-          future_state_path: "integration_tests/abnormal_state.json"
-        cursor_paths:
-          global_suppressions: ["created"]
-          blocks: ["created"]
-          bounces: ["created"]
-          invalid_emails: ["created"]
+    - config_path: "secrets/config.json"
+      configured_catalog_path: "integration_tests/no_spam_reports_configured_catalog.json"
+      future_state:
+        future_state_path: "integration_tests/abnormal_state.json"
+      cursor_paths:
+        global_suppressions: ["created"]
+        blocks: ["created"]
+        bounces: ["created"]
+        invalid_emails: ["created"]
           # TODO: create spam_reports records
           # spam_reports: ["created"]
   full_refresh:
     tests:
-      - config_path: "secrets/config.json"
-        configured_catalog_path: "integration_tests/configured_catalog.json"
+    - config_path: "secrets/config.json"
+      configured_catalog_path: "integration_tests/configured_catalog.json"

--- a/airbyte-integrations/connectors/source-sentry/acceptance-test-config.yml
+++ b/airbyte-integrations/connectors/source-sentry/acceptance-test-config.yml
@@ -17,10 +17,11 @@ acceptance_tests:
         - name: plugins/*/features
           bypass_reason: "Order features return randomly"
         projects:
-          - name: features
-            bypass_reason: "Order features return randomly"
-          - name: organization/features
-            bypass_reason: "Order features return randomly"
+        - name: features
+          bypass_reason: "Order features return randomly"
+        - name: organization/features
+          bypass_reason: "Order features return randomly"
+      fail_on_extra_columns: false
   connection:
     tests:
     - config_path: secrets/config.json

--- a/airbyte-integrations/connectors/source-twilio/acceptance-test-config.yml
+++ b/airbyte-integrations/connectors/source-twilio/acceptance-test-config.yml
@@ -3,61 +3,62 @@ test_strictness_level: high
 acceptance_tests:
   spec:
     tests:
-      - spec_path: "source_twilio/spec.json"
+    - spec_path: "source_twilio/spec.json"
   connection:
     tests:
-      - config_path: "secrets/config.json"
-        status: "succeed"
-      - config_path: "integration_tests/invalid_config.json"
-        status: "failed"
+    - config_path: "secrets/config.json"
+      status: "succeed"
+    - config_path: "integration_tests/invalid_config.json"
+      status: "failed"
   discovery:
     tests:
-      - config_path: "secrets/config.json"
+    - config_path: "secrets/config.json"
   basic_read:
     tests:
-      - config_path: "secrets/config.json"
-        expect_records:
-          path: "integration_tests/expected_records.jsonl"
-        empty_streams:
+    - config_path: "secrets/config.json"
+      expect_records:
+        path: "integration_tests/expected_records.jsonl"
+      empty_streams:
           # TODO: SAT should be able to exclude expected records validation on the stream > field level
           # to avoid exposures such as `auth_token`
           # reference: https://github.com/airbytehq/airbyte/pull/20430
-          - name: "accounts"
-            bypass_reason: "expected records could not be provided without field bypassing, skipping for now. Read #TODO above."
-          - name: "alerts"
-            bypass_reason: "alerts are transient - they emerge and disappear from time to time"
-          - name: "dependent_phone_numbers"
-            bypass_reason: "stream not filled yet"
-          - name: "conference_participants"
-            bypass_reason: "stream not filled yet"
-          - name: "keys"
-            bypass_reason: "stream not filled yet"
-          - name: "available_phone_numbers_local"
-            bypass_reason: "very volatile data"
-          - name: "available_phone_numbers_mobile"
-            bypass_reason: "very volatile data"
-          - name: "available_phone_numbers_toll_free"
-            bypass_reason: "very volatile data"
-          - name: "usage_records"
-            bypass_reason: "very volatile data"
-        timeout_seconds: 600
+      - name: "accounts"
+        bypass_reason: "expected records could not be provided without field bypassing, skipping for now. Read #TODO above."
+      - name: "alerts"
+        bypass_reason: "alerts are transient - they emerge and disappear from time to time"
+      - name: "dependent_phone_numbers"
+        bypass_reason: "stream not filled yet"
+      - name: "conference_participants"
+        bypass_reason: "stream not filled yet"
+      - name: "keys"
+        bypass_reason: "stream not filled yet"
+      - name: "available_phone_numbers_local"
+        bypass_reason: "very volatile data"
+      - name: "available_phone_numbers_mobile"
+        bypass_reason: "very volatile data"
+      - name: "available_phone_numbers_toll_free"
+        bypass_reason: "very volatile data"
+      - name: "usage_records"
+        bypass_reason: "very volatile data"
+      timeout_seconds: 600
+      fail_on_extra_columns: false
   incremental:
     tests:
-      - config_path: "secrets/config.json"
-        configured_catalog_path: "integration_tests/incremental_catalog.json"
-        future_state:
-          future_state_path: "integration_tests/abnormal_state.json"
-        timeout_seconds: 3600
-      - config_path: "secrets/config_with_lookback.json"
-        configured_catalog_path: "integration_tests/incremental_catalog.json"
-        future_state:
-          future_state_path: "integration_tests/abnormal_state.json"
-        threshold_days: 30
-        timeout_seconds: 3600
+    - config_path: "secrets/config.json"
+      configured_catalog_path: "integration_tests/incremental_catalog.json"
+      future_state:
+        future_state_path: "integration_tests/abnormal_state.json"
+      timeout_seconds: 3600
+    - config_path: "secrets/config_with_lookback.json"
+      configured_catalog_path: "integration_tests/incremental_catalog.json"
+      future_state:
+        future_state_path: "integration_tests/abnormal_state.json"
+      threshold_days: 30
+      timeout_seconds: 3600
   full_refresh:
     tests:
-      - config_path: "secrets/config.json"
+    - config_path: "secrets/config.json"
         # `constant_records_catalog.json` does not contain the available phone numbers streams,
         # as they may change on each request
-        configured_catalog_path: "integration_tests/constant_records_catalog.json"
-        timeout_seconds: 3600
+      configured_catalog_path: "integration_tests/constant_records_catalog.json"
+      timeout_seconds: 3600

--- a/airbyte-integrations/connectors/source-woocommerce/acceptance-test-config.yml
+++ b/airbyte-integrations/connectors/source-woocommerce/acceptance-test-config.yml
@@ -4,36 +4,37 @@ connector_image: airbyte/source-woocommerce:dev
 acceptance_tests:
   spec:
     tests:
-      - spec_path: "source_woocommerce/spec.yaml"
+    - spec_path: "source_woocommerce/spec.yaml"
   connection:
     tests:
-      - config_path: "secrets/config.json"
-        status: "succeed"
-      - config_path: "integration_tests/invalid_config.json"
-        status: "failed"
-        timeout_seconds: 300
+    - config_path: "secrets/config.json"
+      status: "succeed"
+    - config_path: "integration_tests/invalid_config.json"
+      status: "failed"
+      timeout_seconds: 300
   discovery:
     tests:
-      - config_path: "secrets/config.json"
-        backward_compatibility_tests_config:
-          disable_for_version: "0.1.2"
+    - config_path: "secrets/config.json"
+      backward_compatibility_tests_config:
+        disable_for_version: "0.1.2"
   basic_read:
     tests:
-      - config_path: "secrets/config.json"
-        configured_catalog_path: "integration_tests/configured_catalog.json"
-        timeout_seconds: 3600
-        expect_records:
-          path: "integration_tests/expected_records.jsonl"
-          extra_fields: no
-          exact_order: no
-          extra_records: no
+    - config_path: "secrets/config.json"
+      configured_catalog_path: "integration_tests/configured_catalog.json"
+      timeout_seconds: 3600
+      expect_records:
+        path: "integration_tests/expected_records.jsonl"
+        extra_fields: no
+        exact_order: no
+        extra_records: no
+      fail_on_extra_columns: false
   incremental:
     tests:
-      - config_path: "secrets/config.json"
-        configured_catalog_path: "integration_tests/configured_catalog.json"
-        future_state:
-          future_state_path: "integration_tests/abnormal_state.json"
+    - config_path: "secrets/config.json"
+      configured_catalog_path: "integration_tests/configured_catalog.json"
+      future_state:
+        future_state_path: "integration_tests/abnormal_state.json"
   full_refresh:
     tests:
-      - config_path: "secrets/config.json"
-        configured_catalog_path: "integration_tests/configured_catalog.json"
+    - config_path: "secrets/config.json"
+      configured_catalog_path: "integration_tests/configured_catalog.json"

--- a/airbyte-integrations/connectors/source-xero/acceptance-test-config.yml
+++ b/airbyte-integrations/connectors/source-xero/acceptance-test-config.yml
@@ -5,50 +5,51 @@ test_strictness_level: "high"
 acceptance_tests:
   spec:
     tests:
-      - spec_path: "source_xero/spec.yaml"
-        backward_compatibility_tests_config:
-          disable_for_version: "0.1.0"
+    - spec_path: "source_xero/spec.yaml"
+      backward_compatibility_tests_config:
+        disable_for_version: "0.1.0"
   connection:
     tests:
-      - config_path: "secrets/config.json"
-        status: "succeed"
-      - config_path: "integration_tests/invalid_config.json"
-        status: "failed"
+    - config_path: "secrets/config.json"
+      status: "succeed"
+    - config_path: "integration_tests/invalid_config.json"
+      status: "failed"
   discovery:
     tests:
-      - config_path: "secrets/config.json"
-        backward_compatibility_tests_config:
-          disable_for_version: "0.1.0"
+    - config_path: "secrets/config.json"
+      backward_compatibility_tests_config:
+        disable_for_version: "0.1.0"
   basic_read:
     tests:
-      - config_path: "secrets/config.json"
-        expect_records:
-          path: "integration_tests/expected_records.jsonl"
-          extra_fields: no
-          exact_order: no
-          extra_records: yes
-        empty_streams:
-          - name: "bank_transfers"
-            bypass_reason: "Empty stream, further investigation is required"
-          - name: "employees"
-            bypass_reason: "Empty stream, further investigation is required"
-          - name: "manual_journals"
-            bypass_reason: "Empty stream, further investigation is required"
-          - name: "overpayments"
-            bypass_reason: "Empty stream, further investigation is required"
-          - name: "prepayments"
-            bypass_reason: "Empty stream, further investigation is required"
-          - name: "repeating_invoices"
-            bypass_reason: "Empty stream, further investigation is required"
-          - name: "tracking_categories"
-            bypass_reason: "Empty stream, further investigation is required"
+    - config_path: "secrets/config.json"
+      expect_records:
+        path: "integration_tests/expected_records.jsonl"
+        extra_fields: no
+        exact_order: no
+        extra_records: yes
+      empty_streams:
+      - name: "bank_transfers"
+        bypass_reason: "Empty stream, further investigation is required"
+      - name: "employees"
+        bypass_reason: "Empty stream, further investigation is required"
+      - name: "manual_journals"
+        bypass_reason: "Empty stream, further investigation is required"
+      - name: "overpayments"
+        bypass_reason: "Empty stream, further investigation is required"
+      - name: "prepayments"
+        bypass_reason: "Empty stream, further investigation is required"
+      - name: "repeating_invoices"
+        bypass_reason: "Empty stream, further investigation is required"
+      - name: "tracking_categories"
+        bypass_reason: "Empty stream, further investigation is required"
+      fail_on_extra_columns: false
   incremental:
     tests:
-      - config_path: "secrets/config.json"
-        configured_catalog_path: "integration_tests/configured_catalog.json"
-        future_state:
-          future_state_path: "integration_tests/abnormal_state.json"
+    - config_path: "secrets/config.json"
+      configured_catalog_path: "integration_tests/configured_catalog.json"
+      future_state:
+        future_state_path: "integration_tests/abnormal_state.json"
   full_refresh:
     tests:
-      - config_path: "secrets/config.json"
-        configured_catalog_path: "integration_tests/configured_catalog.json"
+    - config_path: "secrets/config.json"
+      configured_catalog_path: "integration_tests/configured_catalog.json"


### PR DESCRIPTION
## What
* Some tests never turned up with results locally. They didn't get bypass for the extra fields test when they should have, and thus they've been failing connector health since. This adds bypasses for those tests.
