### PR TITLE
source-confluence: Update acceptance-test-config.yml

### DIFF
--- a/airbyte-integrations/connectors/source-confluence/acceptance-test-config.yml
+++ b/airbyte-integrations/connectors/source-confluence/acceptance-test-config.yml
@@ -20,7 +20,7 @@ acceptance_tests:
       configured_catalog_path: "integration_tests/configured_catalog.json"
       expect_records:
         path: "integration_tests/expected_records.jsonl"
-      fail_on_extra_fields: false
+      fail_on_extra_columns: false
   full_refresh:
     tests:
     - config_path: "secrets/config.json"


### PR DESCRIPTION
## What
* fix acceptance tests failing wiith
```
INTERNALERROR> acceptance_tests -> basic_read -> tests -> 0 -> fail_on_extra_fields
INTERNALERROR>   extra fields not permitted (type=value_error.extra)
```
* Use correct param (see e.g. https://github.com/airbytehq/airbyte/pull/24552)