### PR TITLE
Fix Mac build by un-ignoring normalization's CDK models linting error…

### DIFF
--- a/airbyte-integrations/bases/base-normalization/normalization/transform_catalog/catalog_processor.py
+++ b/airbyte-integrations/bases/base-normalization/normalization/transform_catalog/catalog_processor.py
@@ -9,7 +9,7 @@ import re
 from typing import Any, Dict, List, Set
 
 import yaml
-from airbyte_cdk.models.airbyte_protocol import DestinationSyncMode, SyncMode  # type: ignore
+from airbyte_cdk.models.airbyte_protocol import DestinationSyncMode, SyncMode
 from normalization.destination_type import DestinationType
 from normalization.transform_catalog import dbt_macro
 from normalization.transform_catalog.destination_name_transformer import DestinationNameTransformer

--- a/airbyte-integrations/bases/base-normalization/normalization/transform_catalog/stream_processor.py
+++ b/airbyte-integrations/bases/base-normalization/normalization/transform_catalog/stream_processor.py
@@ -8,7 +8,7 @@ import re
 from enum import Enum
 from typing import Any, Dict, List, Optional, Tuple, Union
 
-from airbyte_cdk.models.airbyte_protocol import DestinationSyncMode, SyncMode  # type: ignore
+from airbyte_cdk.models.airbyte_protocol import DestinationSyncMode, SyncMode
 from jinja2 import Template
 from normalization.destination_type import DestinationType
 from normalization.transform_catalog import dbt_macro


### PR DESCRIPTION
Following up on this change: https://github.com/airbytehq/airbyte/pull/22963, I am removing the `ignore`, because the root cause that motivated those has been solved and now the linter is complaining about these `ignore`s.