### PR TITLE
Refactor State Mgmt. ahead of async flush

### DIFF
--- a/airbyte-integrations/bases/base-java-s3/src/main/java/io/airbyte/integrations/destination/s3/S3ConsumerFactory.java
+++ b/airbyte-integrations/bases/base-java-s3/src/main/java/io/airbyte/integrations/destination/s3/S3ConsumerFactory.java
@@ -45,12 +45,12 @@ public class S3ConsumerFactory {
                                        final ConfiguredAirbyteCatalog catalog) {
     final List<WriteConfig> writeConfigs = createWriteConfigs(storageOperations, namingResolver, s3Config, catalog);
     return new BufferedStreamConsumer(
-        outputRecordCollector,
         onStartFunction(storageOperations, writeConfigs),
         new SerializedBufferingStrategy(
             onCreateBuffer,
             catalog,
-            flushBufferFunction(storageOperations, writeConfigs, catalog)),
+            flushBufferFunction(storageOperations, writeConfigs, catalog),
+            outputRecordCollector),
         onCloseFunction(storageOperations, writeConfigs),
         catalog,
         storageOperations::isValidData);

--- a/airbyte-integrations/bases/base-java/src/main/java/io/airbyte/integrations/destination/buffered_stream_consumer/BufferedStreamConsumer.java
+++ b/airbyte-integrations/bases/base-java/src/main/java/io/airbyte/integrations/destination/buffered_stream_consumer/BufferedStreamConsumer.java
@@ -13,8 +13,6 @@ import io.airbyte.commons.functional.CheckedFunction;
 import io.airbyte.commons.json.Jsons;
 import io.airbyte.integrations.base.AirbyteMessageConsumer;
 import io.airbyte.integrations.base.FailureTrackingAirbyteMessageConsumer;
-import io.airbyte.integrations.destination.dest_state_lifecycle_manager.DefaultDestStateLifecycleManager;
-import io.airbyte.integrations.destination.dest_state_lifecycle_manager.DestStateLifecycleManager;
 import io.airbyte.integrations.destination.record_buffer.BufferFlushType;
 import io.airbyte.integrations.destination.record_buffer.BufferingStrategy;
 import io.airbyte.protocol.models.v0.AirbyteMessage;
@@ -28,7 +26,6 @@ import java.util.HashMap;
 import java.util.Map;
 import java.util.Optional;
 import java.util.Set;
-import java.util.function.Consumer;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -36,17 +33,15 @@ import org.slf4j.LoggerFactory;
  * This class consumes AirbyteMessages from the worker.
  *
  * <p>
- * Record Messages: It adds record messages to a buffer. Under 2 conditions, it will flush the
- * records in the buffer to a temporary table in the destination. Condition 1: The buffer fills up
- * (the buffer is designed to be small enough as not to exceed the memory of the container).
- * Condition 2: On close.
+ * Record Messages: It adds record messages to a buffer. Under 2 conditions, it will flush the records in the buffer to a temporary table in the
+ * destination. Condition 1: The buffer fills up (the buffer is designed to be small enough as not to exceed the memory of the container). Condition
+ * 2: On close.
  * </p>
  *
  * <p>
- * State Messages: This consumer tracks the last state message it has accepted. It also tracks the
- * last state message that was committed to the temporary table. For now, we only emit a message if
- * everything is successful. Once checkpointing is turned on, we will emit the state message as long
- * as the onClose successfully commits any messages to the raw table.
+ * State Messages: This consumer tracks the last state message it has accepted. It also tracks the last state message that was committed to the
+ * temporary table. For now, we only emit a message if everything is successful. Once checkpointing is turned on, we will emit the state message as
+ * long as the onClose successfully commits any messages to the raw table.
  * </p>
  *
  * <p>
@@ -54,25 +49,19 @@ import org.slf4j.LoggerFactory;
  * </p>
  *
  * <p>
- * Throughout the lifecycle of the consumer, messages get promoted from buffered to flushed to
- * committed. A record message when it is received is immediately buffered. When the buffer fills
- * up, all buffered records are flushed out of memory using the user-provided recordBuffer. When
- * this flush happens, a state message is moved from pending to flushed. On close, if the
- * user-provided onClose function is successful, then the flushed state record is considered
- * committed and is then emitted. We expect this class to only ever emit either 1 state message (in
- * the case of a full or partial success) or 0 state messages (in the case where the onClose step
- * was never reached or did not complete without exception).
+ * Throughout the lifecycle of the consumer, messages get promoted from buffered to flushed to committed. A record message when it is received is
+ * immediately buffered. When the buffer fills up, all buffered records are flushed out of memory using the user-provided recordBuffer. When this
+ * flush happens, a state message is moved from pending to flushed. On close, if the user-provided onClose function is successful, then the flushed
+ * state record is considered committed and is then emitted. We expect this class to only ever emit either 1 state message (in the case of a full or
+ * partial success) or 0 state messages (in the case where the onClose step was never reached or did not complete without exception).
  * </p>
  *
  * <p>
- * When a record is "flushed" it is moved from the docker container to the destination. By
- * convention, it is usually placed in some sort of temporary storage on the destination (e.g. a
- * temporary database or file store). The logic in close handles committing the temporary
- * representation data to the final store (e.g. final table). In the case of staging destinations
- * they often have additional temporary stores. The common pattern for staging destination is that
- * flush pushes the data into a staging area in cloud storage and then close copies from staging to
- * a temporary table AND then copies from the temporary table into the final table. This abstraction
- * is blind to the detail of how staging destinations implement their close.
+ * When a record is "flushed" it is moved from the docker container to the destination. By convention, it is usually placed in some sort of temporary
+ * storage on the destination (e.g. a temporary database or file store). The logic in close handles committing the temporary representation data to
+ * the final store (e.g. final table). In the case of staging destinations they often have additional temporary stores. The common pattern for staging
+ * destination is that flush pushes the data into a staging area in cloud storage and then close copies from staging to a temporary table AND then
+ * copies from the temporary table into the final table. This abstraction is blind to the detail of how staging destinations implement their close.
  * </p>
  */
 public class BufferedStreamConsumer extends FailureTrackingAirbyteMessageConsumer implements AirbyteMessageConsumer {
@@ -85,9 +74,8 @@ public class BufferedStreamConsumer extends FailureTrackingAirbyteMessageConsume
   private final ConfiguredAirbyteCatalog catalog;
   private final CheckedFunction<JsonNode, Boolean, Exception> isValidRecord;
   private final Map<AirbyteStreamNameNamespacePair, Long> streamToIgnoredRecordCount;
-  private final Consumer<AirbyteMessage> outputRecordCollector;
   private final BufferingStrategy bufferingStrategy;
-  private final DestStateLifecycleManager stateManager;
+
 
   private boolean hasStarted;
   private boolean hasClosed;
@@ -95,14 +83,12 @@ public class BufferedStreamConsumer extends FailureTrackingAirbyteMessageConsume
   private Instant nextFlushDeadline;
   private final Duration bufferFlushFrequency;
 
-  public BufferedStreamConsumer(final Consumer<AirbyteMessage> outputRecordCollector,
-                                final VoidCallable onStart,
-                                final BufferingStrategy bufferingStrategy,
-                                final CheckedConsumer<Boolean, Exception> onClose,
-                                final ConfiguredAirbyteCatalog catalog,
-                                final CheckedFunction<JsonNode, Boolean, Exception> isValidRecord) {
-    this(outputRecordCollector,
-        onStart,
+  public BufferedStreamConsumer(final VoidCallable onStart,
+      final BufferingStrategy bufferingStrategy,
+      final CheckedConsumer<Boolean, Exception> onClose,
+      final ConfiguredAirbyteCatalog catalog,
+      final CheckedFunction<JsonNode, Boolean, Exception> isValidRecord) {
+    this(onStart,
         bufferingStrategy,
         onClose,
         catalog,
@@ -115,14 +101,12 @@ public class BufferedStreamConsumer extends FailureTrackingAirbyteMessageConsume
    * should take in an Instant parameter which would require refactoring all MessageConsumers
    */
   @VisibleForTesting
-  BufferedStreamConsumer(final Consumer<AirbyteMessage> outputRecordCollector,
-                         final VoidCallable onStart,
-                         final BufferingStrategy bufferingStrategy,
-                         final CheckedConsumer<Boolean, Exception> onClose,
-                         final ConfiguredAirbyteCatalog catalog,
-                         final CheckedFunction<JsonNode, Boolean, Exception> isValidRecord,
-                         final Duration flushFrequency) {
-    this.outputRecordCollector = outputRecordCollector;
+  BufferedStreamConsumer(final VoidCallable onStart,
+      final BufferingStrategy bufferingStrategy,
+      final CheckedConsumer<Boolean, Exception> onClose,
+      final ConfiguredAirbyteCatalog catalog,
+      final CheckedFunction<JsonNode, Boolean, Exception> isValidRecord,
+      final Duration flushFrequency) {
     this.hasStarted = false;
     this.hasClosed = false;
     this.onStart = onStart;
@@ -132,7 +116,6 @@ public class BufferedStreamConsumer extends FailureTrackingAirbyteMessageConsume
     this.isValidRecord = isValidRecord;
     this.streamToIgnoredRecordCount = new HashMap<>();
     this.bufferingStrategy = bufferingStrategy;
-    this.stateManager = new DefaultDestStateLifecycleManager();
     this.bufferFlushFrequency = flushFrequency;
   }
 
@@ -141,15 +124,15 @@ public class BufferedStreamConsumer extends FailureTrackingAirbyteMessageConsume
     // todo (cgardens) - if we reuse this pattern, consider moving it into FailureTrackingConsumer.
     Preconditions.checkState(!hasStarted, "Consumer has already been started.");
     hasStarted = true;
-    nextFlushDeadline = Instant.now().plus(bufferFlushFrequency);
+    resetFlushDeadline();
     streamToIgnoredRecordCount.clear();
     LOGGER.info("{} started.", BufferedStreamConsumer.class);
     onStart.call();
   }
 
   /**
-   * AcceptTracked will still process AirbyteMessages as usual with the addition of periodically
-   * flushing buffer and writing data to destination storage
+   * AcceptTracked will still process AirbyteMessages as usual with the addition of periodically flushing buffer and writing data to destination
+   * storage
    *
    * @param message {@link AirbyteMessage} to be processed
    * @throws Exception
@@ -174,44 +157,22 @@ public class BufferedStreamConsumer extends FailureTrackingAirbyteMessageConsume
       final Optional<BufferFlushType> flushType = bufferingStrategy.addRecord(stream, message);
       // if present means that a flush occurred
       if (flushType.isPresent()) {
-        if (BufferFlushType.FLUSH_ALL.equals(flushType.get())) {
-          markStatesAsFlushedToDestination();
-        } else if (BufferFlushType.FLUSH_SINGLE_STREAM.equals(flushType.get())) {
-          if (stateManager.supportsPerStreamFlush()) {
-            // per-stream instance can handle flush of just a single stream
-            markStatesAsFlushedToDestination();
-          }
-          /*
-           * We don't mark {@link AirbyteStateMessage} as committed in the case with GLOBAL/LEGACY because
-           * within a single stream being flushed it is not deterministic that all the AirbyteRecordMessages
-           * have been committed
-           */
-        }
+        resetFlushDeadline();
       }
     } else if (message.getType() == Type.STATE) {
-      stateManager.addState(message);
+      bufferingStrategy.addStateMessage(message);
     } else {
       LOGGER.warn("Unexpected message: " + message.getType());
     }
     periodicBufferFlush();
   }
 
-  /**
-   * After marking states as committed, return the state message to platform then clear state messages
-   * to avoid resending the same state message to the platform. Also updates the next time a buffer
-   * flush should occur since it is deterministic that when this method is called all data has been
-   * successfully committed to destination
-   */
-  private void markStatesAsFlushedToDestination() {
-    stateManager.markPendingAsCommitted();
-    stateManager.listCommitted().forEach(outputRecordCollector);
-    stateManager.clearCommitted();
+  private void resetFlushDeadline() {
     nextFlushDeadline = Instant.now().plus(bufferFlushFrequency);
   }
 
   /**
-   * Periodically flushes buffered data to destination storage when exceeding flush deadline. Also
-   * resets the last time a flush occurred
+   * Periodically flushes buffered data to destination storage when exceeding flush deadline. Also resets the last time a flush occurred
    */
   private void periodicBufferFlush() {
     // When the last time the buffered has been flushed exceed the frequency, flush the current
@@ -219,8 +180,8 @@ public class BufferedStreamConsumer extends FailureTrackingAirbyteMessageConsume
     if (Instant.now().isAfter(nextFlushDeadline)) {
       LOGGER.info("Periodic buffer flush started");
       try {
-        bufferingStrategy.flushAll();
-        markStatesAsFlushedToDestination();
+        bufferingStrategy.flushAllStreams();
+        resetFlushDeadline();
       } catch (final Exception e) {
         LOGGER.error("Periodic buffer flush failed", e);
       }
@@ -234,10 +195,9 @@ public class BufferedStreamConsumer extends FailureTrackingAirbyteMessageConsume
   }
 
   /**
-   * Cleans up buffer based on whether the sync was successful or some exception occurred. In the case
-   * where a failure occurred we do a simple clean up any lingering data. Otherwise, flush any
-   * remaining data that has been stored. This is fine even if the state has not been received since
-   * this Airbyte promises at least once delivery
+   * Cleans up buffer based on whether the sync was successful or some exception occurred. In the case where a failure occurred we do a simple clean
+   * up any lingering data. Otherwise, flush any remaining data that has been stored. This is fine even if the state has not been received since this
+   * Airbyte promises at least once delivery
    *
    * @param hasFailed true if the stream replication failed partway through, false otherwise
    * @throws Exception
@@ -256,32 +216,13 @@ public class BufferedStreamConsumer extends FailureTrackingAirbyteMessageConsume
       LOGGER.info("executing on success close procedure.");
       // When flushing the buffer, this will call the respective #flushBufferFunction which bundles
       // the flush and commit operation, so if successful then mark state as committed
-      bufferingStrategy.flushAll();
-      markStatesAsFlushedToDestination();
+      bufferingStrategy.flushAllStreams();
+      resetFlushDeadline();
     }
     bufferingStrategy.close();
 
     try {
-      /*
-       * TODO: (ryankfu) Remove usage of hasFailed with onClose after all destination connectors have been
-       * updated to support checkpointing
-       *
-       * flushed is empty in 2 cases: 1. either it is full refresh (no state is emitted necessarily) 2. it
-       * is stream but no states were flushed in both of these cases, if there was a failure, we should
-       * not bother committing. otherwise attempt to commit
-       */
-      if (stateManager.listFlushed().isEmpty()) {
-        onClose.accept(hasFailed);
-      } else {
-        /*
-         * if any state message was flushed that means we should try to commit what we have. if
-         * hasFailed=false, then it could be full success. if hasFailed=true, then going for partial
-         * success.
-         */
-        onClose.accept(false);
-      }
-
-      stateManager.listCommitted().forEach(outputRecordCollector);
+      onClose.accept(hasFailed);
     } catch (final Exception e) {
       LOGGER.error("Close failed.", e);
       throw e;

--- a/airbyte-integrations/bases/base-java/src/main/java/io/airbyte/integrations/destination/record_buffer/BufferingStrategy.java
+++ b/airbyte-integrations/bases/base-java/src/main/java/io/airbyte/integrations/destination/record_buffer/BufferingStrategy.java
@@ -35,16 +35,22 @@ public interface BufferingStrategy extends AutoCloseable {
   /**
    * Flush buffered messages in a writer from a particular stream
    */
-  void flushWriter(AirbyteStreamNameNamespacePair stream, SerializableBuffer writer) throws Exception;
+  void flushSingleStream(AirbyteStreamNameNamespacePair stream, SerializableBuffer writer) throws Exception;
 
   /**
    * Flush all writers that were buffering message data so far.
    */
-  void flushAll() throws Exception;
+  void flushAllStreams() throws Exception;
 
   /**
    * Removes all stream buffers.
    */
   void clear() throws Exception;
 
+  /**
+   * State management as it relates to flushing and state commit
+   * acknowledgement is handled by the BufferingStrategy now
+   * @param message
+   */
+  void addStateMessage(AirbyteMessage message);
 }

--- a/airbyte-integrations/bases/base-java/src/main/java/io/airbyte/integrations/destination/record_buffer/InMemoryRecordBufferingStrategy.java
+++ b/airbyte-integrations/bases/base-java/src/main/java/io/airbyte/integrations/destination/record_buffer/InMemoryRecordBufferingStrategy.java
@@ -7,6 +7,8 @@ package io.airbyte.integrations.destination.record_buffer;
 import io.airbyte.integrations.destination.buffered_stream_consumer.CheckAndRemoveRecordWriter;
 import io.airbyte.integrations.destination.buffered_stream_consumer.RecordSizeEstimator;
 import io.airbyte.integrations.destination.buffered_stream_consumer.RecordWriter;
+import io.airbyte.integrations.destination.dest_state_lifecycle_manager.DefaultDestStateLifecycleManager;
+import io.airbyte.integrations.destination.dest_state_lifecycle_manager.DestStateLifecycleManager;
 import io.airbyte.protocol.models.v0.AirbyteMessage;
 import io.airbyte.protocol.models.v0.AirbyteRecordMessage;
 import io.airbyte.protocol.models.v0.AirbyteStreamNameNamespacePair;
@@ -15,20 +17,21 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
+import java.util.function.Consumer;
 import org.apache.commons.io.FileUtils;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 /**
- * This is the default implementation of a {@link BufferStorage} to be backward compatible. Data is
- * being buffered in a {@link List<AirbyteRecordMessage>} as they are being consumed.
- *
- * This should be deprecated as we slowly move towards using {@link SerializedBufferingStrategy}
- * instead.
+ * This is the default implementation of a {@link BufferStorage} to be backward compatible. Data is being buffered in a
+ * {@link List<AirbyteRecordMessage>} as they are being consumed.
+ * <p>
+ * This should be deprecated as we slowly move towards using {@link SerializedBufferingStrategy} instead.
  */
 public class InMemoryRecordBufferingStrategy implements BufferingStrategy {
 
   private static final Logger LOGGER = LoggerFactory.getLogger(InMemoryRecordBufferingStrategy.class);
+  private final Consumer<AirbyteMessage> outputRecordCollector;
 
   private Map<AirbyteStreamNameNamespacePair, List<AirbyteRecordMessage>> streamBuffer = new HashMap<>();
   private final RecordWriter<AirbyteRecordMessage> recordWriter;
@@ -36,23 +39,30 @@ public class InMemoryRecordBufferingStrategy implements BufferingStrategy {
   private String fileName;
 
   private final RecordSizeEstimator recordSizeEstimator;
+  private final DestStateLifecycleManager stateManager;
   private final long maxQueueSizeInBytes;
   private long bufferSizeInBytes;
 
-  public InMemoryRecordBufferingStrategy(final RecordWriter<AirbyteRecordMessage> recordWriter,
-                                         final long maxQueueSizeInBytes) {
-    this(recordWriter, null, maxQueueSizeInBytes);
+  public InMemoryRecordBufferingStrategy(
+      final RecordWriter<AirbyteRecordMessage> recordWriter,
+      final long maxQueueSizeInBytes,
+      final Consumer<AirbyteMessage> outputRecordCollector) {
+    this(recordWriter, null, maxQueueSizeInBytes, outputRecordCollector);
   }
 
-  public InMemoryRecordBufferingStrategy(final RecordWriter<AirbyteRecordMessage> recordWriter,
-                                         final CheckAndRemoveRecordWriter checkAndRemoveRecordWriter,
-                                         final long maxQueueSizeInBytes) {
+  public InMemoryRecordBufferingStrategy(
+      final RecordWriter<AirbyteRecordMessage> recordWriter,
+      final CheckAndRemoveRecordWriter checkAndRemoveRecordWriter,
+      final long maxQueueSizeInBytes,
+      final Consumer<AirbyteMessage> outputRecordCollector) {
     this.recordWriter = recordWriter;
     this.checkAndRemoveRecordWriter = checkAndRemoveRecordWriter;
 
     this.maxQueueSizeInBytes = maxQueueSizeInBytes;
     this.bufferSizeInBytes = 0;
     this.recordSizeEstimator = new RecordSizeEstimator();
+    this.stateManager = new DefaultDestStateLifecycleManager();
+    this.outputRecordCollector = outputRecordCollector;
   }
 
   @Override
@@ -61,7 +71,7 @@ public class InMemoryRecordBufferingStrategy implements BufferingStrategy {
 
     final long messageSizeInBytes = recordSizeEstimator.getEstimatedByteSize(message.getRecord());
     if (bufferSizeInBytes + messageSizeInBytes > maxQueueSizeInBytes) {
-      flushAll();
+      flushAllStreams();
       flushed = Optional.of(BufferFlushType.FLUSH_ALL);
     }
 
@@ -73,14 +83,15 @@ public class InMemoryRecordBufferingStrategy implements BufferingStrategy {
   }
 
   @Override
-  public void flushWriter(final AirbyteStreamNameNamespacePair stream, final SerializableBuffer writer) throws Exception {
+  public void flushSingleStream(final AirbyteStreamNameNamespacePair stream, final SerializableBuffer writer) throws Exception {
     LOGGER.info("Flushing single stream {}: {} records", stream.getName(), streamBuffer.get(stream).size());
     recordWriter.accept(stream, streamBuffer.get(stream));
+    markStatesAsFlushedToDestination();
     LOGGER.info("Flushing completed for {}", stream.getName());
   }
 
   @Override
-  public void flushAll() throws Exception {
+  public void flushAllStreams() throws Exception {
     for (final Map.Entry<AirbyteStreamNameNamespacePair, List<AirbyteRecordMessage>> entry : streamBuffer.entrySet()) {
       LOGGER.info("Flushing {}: {} records ({})", entry.getKey().getName(), entry.getValue().size(),
           FileUtils.byteCountToDisplaySize(bufferSizeInBytes));
@@ -90,14 +101,30 @@ public class InMemoryRecordBufferingStrategy implements BufferingStrategy {
       }
       LOGGER.info("Flushing completed for {}", entry.getKey().getName());
     }
-    close();
+    markStatesAsFlushedToDestination();
     clear();
     bufferSizeInBytes = 0;
+  }
+
+  /**
+   * After marking states as committed, return the state message to platform then clear state messages to avoid resending the same state message to
+   * the platform. Also updates the next time a buffer flush should occur since it is deterministic that when this method is called all data has been
+   * successfully committed to destination
+   */
+  private void markStatesAsFlushedToDestination() {
+    stateManager.markPendingAsCommitted();
+    stateManager.listCommitted().forEach(outputRecordCollector);
+    stateManager.clearCommitted();
   }
 
   @Override
   public void clear() {
     streamBuffer = new HashMap<>();
+  }
+
+  @Override
+  public void addStateMessage(final AirbyteMessage message) {
+    stateManager.addState(message);
   }
 
   @Override

--- a/airbyte-integrations/bases/base-java/src/main/java/io/airbyte/integrations/destination/record_buffer/SerializedBufferingStrategy.java
+++ b/airbyte-integrations/bases/base-java/src/main/java/io/airbyte/integrations/destination/record_buffer/SerializedBufferingStrategy.java
@@ -7,6 +7,7 @@ package io.airbyte.integrations.destination.record_buffer;
 import io.airbyte.commons.functional.CheckedBiConsumer;
 import io.airbyte.commons.functional.CheckedBiFunction;
 import io.airbyte.commons.string.Strings;
+import io.airbyte.integrations.destination.dest_state_lifecycle_manager.DefaultDestStateLifecycleManager;
 import io.airbyte.protocol.models.v0.AirbyteMessage;
 import io.airbyte.protocol.models.v0.AirbyteStreamNameNamespacePair;
 import io.airbyte.protocol.models.v0.ConfiguredAirbyteCatalog;
@@ -16,13 +17,14 @@ import java.util.List;
 import java.util.Map;
 import java.util.Map.Entry;
 import java.util.Optional;
+import java.util.function.Consumer;
 import org.apache.commons.io.FileUtils;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 /**
- * Buffering Strategy used to convert {@link io.airbyte.protocol.models.AirbyteRecordMessage} into a
- * stream of bytes to more readily save and transmit information
+ * Buffering Strategy used to convert {@link io.airbyte.protocol.models.AirbyteRecordMessage} into a stream of bytes to more readily save and transmit
+ * information
  *
  * <p>
  * This class is meant to be used in conjunction with {@link SerializableBuffer}
@@ -34,32 +36,38 @@ public class SerializedBufferingStrategy implements BufferingStrategy {
 
   private final CheckedBiFunction<AirbyteStreamNameNamespacePair, ConfiguredAirbyteCatalog, SerializableBuffer, Exception> onCreateBuffer;
   private final CheckedBiConsumer<AirbyteStreamNameNamespacePair, SerializableBuffer, Exception> onStreamFlush;
+  private final DefaultDestStateLifecycleManager stateManager;
 
   private Map<AirbyteStreamNameNamespacePair, SerializableBuffer> allBuffers = new HashMap<>();
   private long totalBufferSizeInBytes;
   private final ConfiguredAirbyteCatalog catalog;
+  private final Consumer<AirbyteMessage> outputRecordCollector;
 
   /**
-   * Creates instance of Serialized Buffering Strategy used to handle the logic of flushing buffer
-   * with an associated buffer type
+   * Creates instance of Serialized Buffering Strategy used to handle the logic of flushing buffer with an associated buffer type
    *
-   * @param onCreateBuffer type of buffer used upon creation
-   * @param catalog collection of {@link io.airbyte.protocol.models.ConfiguredAirbyteStream}
-   * @param onStreamFlush buffer flush logic used throughout the streaming of messages
+   * @param onCreateBuffer        type of buffer used upon creation
+   * @param catalog               collection of {@link io.airbyte.protocol.models.ConfiguredAirbyteStream}
+   * @param onStreamFlush         buffer flush logic used throughout the streaming of messages
+   * @param outputRecordCollector
    */
-  public SerializedBufferingStrategy(final CheckedBiFunction<AirbyteStreamNameNamespacePair, ConfiguredAirbyteCatalog, SerializableBuffer, Exception> onCreateBuffer,
-                                     final ConfiguredAirbyteCatalog catalog,
-                                     final CheckedBiConsumer<AirbyteStreamNameNamespacePair, SerializableBuffer, Exception> onStreamFlush) {
+  public SerializedBufferingStrategy(
+      final CheckedBiFunction<AirbyteStreamNameNamespacePair, ConfiguredAirbyteCatalog, SerializableBuffer, Exception> onCreateBuffer,
+      final ConfiguredAirbyteCatalog catalog,
+      final CheckedBiConsumer<AirbyteStreamNameNamespacePair, SerializableBuffer, Exception> onStreamFlush,
+      final Consumer<AirbyteMessage> outputRecordCollector) {
     this.onCreateBuffer = onCreateBuffer;
     this.catalog = catalog;
     this.onStreamFlush = onStreamFlush;
+    this.outputRecordCollector = outputRecordCollector;
     this.totalBufferSizeInBytes = 0;
+    this.stateManager = new DefaultDestStateLifecycleManager();
   }
 
   /**
    * Handles both adding records and when buffer is full to also flush
    *
-   * @param stream stream associated with record
+   * @param stream  stream associated with record
    * @param message {@link AirbyteMessage} to buffer
    * @return Optional which contains a {@link BufferFlushType} if a flush occurred, otherwise empty)
    * @throws Exception
@@ -72,30 +80,21 @@ public class SerializedBufferingStrategy implements BufferingStrategy {
      * Creates a new buffer for each stream if buffers do not already exist, else return already
      * computed buffer
      */
-    final SerializableBuffer streamBuffer = allBuffers.computeIfAbsent(stream, k -> {
-      LOGGER.info("Starting a new buffer for stream {} (current state: {} in {} buffers)",
-          stream.getName(),
-          FileUtils.byteCountToDisplaySize(totalBufferSizeInBytes),
-          allBuffers.size());
-      try {
-        return onCreateBuffer.apply(stream, catalog);
-      } catch (final Exception e) {
-        LOGGER.error("Failed to create a new buffer for stream {}", stream.getName(), e);
-        throw new RuntimeException(e);
-      }
-    });
+    final SerializableBuffer streamBuffer = getBufferForStream(stream);
     if (streamBuffer == null) {
       throw new RuntimeException(String.format("Failed to create/get streamBuffer for stream %s.%s", stream.getNamespace(), stream.getName()));
     }
+
     final long actualMessageSizeInBytes = streamBuffer.accept(message.getRecord());
+
     totalBufferSizeInBytes += actualMessageSizeInBytes;
     // Flushes buffer when either the buffer was completely filled or only a single stream was filled
     if (totalBufferSizeInBytes >= streamBuffer.getMaxTotalBufferSizeInBytes()
         || allBuffers.size() >= streamBuffer.getMaxConcurrentStreamsInBuffer()) {
-      flushAll();
+      flushAllStreams();
       flushed = Optional.of(BufferFlushType.FLUSH_ALL);
     } else if (streamBuffer.getByteCount() >= streamBuffer.getMaxPerStreamBufferSizeInBytes()) {
-      flushWriter(stream, streamBuffer);
+      flushSingleStream(stream, streamBuffer);
       /*
        * Note: This branch is needed to indicate to the {@link DefaultDestStateLifeCycleManager} that an
        * individual stream was flushed, there is no guarantee that it will flush records in the same order
@@ -116,32 +115,65 @@ public class SerializedBufferingStrategy implements BufferingStrategy {
     return flushed;
   }
 
+  private SerializableBuffer getBufferForStream(final AirbyteStreamNameNamespacePair stream) {
+    return allBuffers.computeIfAbsent(stream, k -> {
+      LOGGER.info("Starting a new buffer for stream {} (current state: {} in {} buffers)",
+          stream.getName(),
+          FileUtils.byteCountToDisplaySize(totalBufferSizeInBytes),
+          allBuffers.size());
+      try {
+        return onCreateBuffer.apply(stream, catalog);
+      } catch (final Exception e) {
+        LOGGER.error("Failed to create a new buffer for stream {}", stream.getName(), e);
+        throw new RuntimeException(e);
+      }
+    });
+  }
+
   @Override
-  public void flushWriter(final AirbyteStreamNameNamespacePair stream, final SerializableBuffer writer) throws Exception {
+  public void flushSingleStream(final AirbyteStreamNameNamespacePair stream, final SerializableBuffer writer) throws Exception {
     LOGGER.info("Flushing buffer of stream {} ({})", stream.getName(), FileUtils.byteCountToDisplaySize(writer.getByteCount()));
     onStreamFlush.accept(stream, writer);
+    markStatesAsFlushedToDestination();
     totalBufferSizeInBytes -= writer.getByteCount();
     allBuffers.remove(stream);
     LOGGER.info("Flushing completed for {}", stream.getName());
   }
 
   @Override
-  public void flushAll() throws Exception {
+  public void flushAllStreams() throws Exception {
     LOGGER.info("Flushing all {} current buffers ({} in total)", allBuffers.size(), FileUtils.byteCountToDisplaySize(totalBufferSizeInBytes));
     for (final Entry<AirbyteStreamNameNamespacePair, SerializableBuffer> entry : allBuffers.entrySet()) {
       LOGGER.info("Flushing buffer of stream {} ({})", entry.getKey().getName(), FileUtils.byteCountToDisplaySize(entry.getValue().getByteCount()));
       onStreamFlush.accept(entry.getKey(), entry.getValue());
       LOGGER.info("Flushing completed for {}", entry.getKey().getName());
     }
+    markStatesAsFlushedToDestination();
     close();
     clear();
     totalBufferSizeInBytes = 0;
+  }
+
+  /**
+   * After marking states as committed, return the state message to platform then clear state messages to avoid resending the same state message to
+   * the platform. Also updates the next time a buffer flush should occur since it is deterministic that when this method is called all data has been
+   * successfully committed to destination
+   */
+  private void markStatesAsFlushedToDestination() {
+    stateManager.markPendingAsCommitted();
+    stateManager.listCommitted().forEach(outputRecordCollector);
+    stateManager.clearCommitted();
   }
 
   @Override
   public void clear() throws Exception {
     LOGGER.debug("Reset all buffers");
     allBuffers = new HashMap<>();
+  }
+
+  @Override
+  public void addStateMessage(final AirbyteMessage message) {
+    stateManager.addState(message);
   }
 
   @Override

--- a/airbyte-integrations/bases/base-java/src/test/java/io/airbyte/integrations/destination/record_buffer/InMemoryRecordBufferingStrategyTest.java
+++ b/airbyte-integrations/bases/base-java/src/test/java/io/airbyte/integrations/destination/record_buffer/InMemoryRecordBufferingStrategyTest.java
@@ -19,6 +19,7 @@ import io.airbyte.protocol.models.v0.AirbyteRecordMessage;
 import io.airbyte.protocol.models.v0.AirbyteStreamNameNamespacePair;
 import java.util.List;
 import java.util.Optional;
+import java.util.function.Consumer;
 import org.junit.jupiter.api.Test;
 
 public class InMemoryRecordBufferingStrategyTest {
@@ -31,9 +32,13 @@ public class InMemoryRecordBufferingStrategyTest {
   @SuppressWarnings("unchecked")
   private final RecordWriter<AirbyteRecordMessage> recordWriter = mock(RecordWriter.class);
 
+  @SuppressWarnings("unchecked")
+  private final Consumer<AirbyteMessage> outputRecordCollector = mock(Consumer.class);
+
   @Test
   public void testBuffering() throws Exception {
-    final InMemoryRecordBufferingStrategy buffering = new InMemoryRecordBufferingStrategy(recordWriter, MAX_QUEUE_SIZE_IN_BYTES);
+    final InMemoryRecordBufferingStrategy buffering = new InMemoryRecordBufferingStrategy(recordWriter, MAX_QUEUE_SIZE_IN_BYTES,
+        outputRecordCollector);
     final AirbyteStreamNameNamespacePair stream1 = new AirbyteStreamNameNamespacePair("stream1", "namespace");
     final AirbyteStreamNameNamespacePair stream2 = new AirbyteStreamNameNamespacePair("stream2", null);
     final AirbyteMessage message1 = generateMessage(stream1);
@@ -56,7 +61,7 @@ public class InMemoryRecordBufferingStrategyTest {
     buffering.addRecord(stream2, message4);
 
     // force flush to terminate test
-    buffering.flushAll();
+    buffering.flushAllStreams();
     verify(recordWriter, times(1)).accept(stream2, List.of(message3.getRecord(), message4.getRecord()));
   }
 

--- a/airbyte-integrations/connectors/destination-bigquery/src/main/java/io/airbyte/integrations/destination/bigquery/BigQueryStagingConsumerFactory.java
+++ b/airbyte-integrations/connectors/destination-bigquery/src/main/java/io/airbyte/integrations/destination/bigquery/BigQueryStagingConsumerFactory.java
@@ -56,12 +56,12 @@ public class BigQueryStagingConsumerFactory {
         targetTableNameTransformer);
 
     return new BufferedStreamConsumer(
-        outputRecordCollector,
         onStartFunction(bigQueryGcsOperations, writeConfigs),
         new SerializedBufferingStrategy(
             onCreateBuffer,
             catalog,
-            flushBufferFunction(bigQueryGcsOperations, writeConfigs, catalog)),
+            flushBufferFunction(bigQueryGcsOperations, writeConfigs, catalog),
+            outputRecordCollector),
         onCloseFunction(bigQueryGcsOperations, writeConfigs),
         catalog,
         json -> true);


### PR DESCRIPTION
First refactor to push the state management into the BufferingStrategy impls. We need this because when we add async flush and commit, we'll need to push the details of the state at the time of the async job creation so as to tie the state messages to the result of the flush.


## What
For upcoming performance work, we want to move the entire flush process to be async. This will introduce some complications like error propagation, state/flush acknowledgement, etc. Do some (hopefully no-op) pre-refactor to minimize the size of the final async work.

## How
Push state management and acknowledgement into the BufferingStrategy impls.



## 🚨 User Impact 🚨
*Are there any breaking changes? What is the end result perceived by the user?*
🤞 Hopefully not

*For connector PRs, use this section to explain which type of semantic versioning bump occurs as a result of the changes. Refer to our [Semantic Versioning for Connectors](https://docs.airbyte.com/contributing-to-airbyte/semantic-versioning-for-connectors) guidelines for more information. **Breaking changes to connectors must be documented by an Airbyte engineer (PR author, or reviewer for community PRs) by using the [Breaking Change Release Playbook](https://docs.google.com/document/d/1VYQggHbL_PN0dDDu7rCyzBLGRtX-R3cpwXaY8QxEgzw/edit).***

*If there are breaking changes, please merge this PR with the 🚨🚨 emoji so changelog authors can further highlight this if needed.*

No breaking changes are expected

## Pre-merge Checklist
*Expand the relevant checklist and delete the others.*

<details><summary><strong>New Connector</strong></summary>

### Community member or Airbyter

- [ ] **Community member?** Grant edit access to maintainers ([instructions](https://docs.github.com/en/github/collaborating-with-pull-requests/working-with-forks/allowing-changes-to-a-pull-request-branch-created-from-a-fork#enabling-repository-maintainer-permissions-on-existing-pull-requests))
- [ ] Secrets in the connector's spec are annotated with `airbyte_secret`
- [ ] Unit & integration tests added and passing. Community members, please provide proof of success locally e.g: screenshot or copy-paste unit, integration, and acceptance test output. To run acceptance tests for a Python connector, follow instructions in the README. For java connectors run `./gradlew :airbyte-integrations:connectors:<name>:integrationTest`.
- [ ] Code reviews completed
- [ ] Connector version is set to `0.0.1`
    - [ ] `Dockerfile` has version `0.0.1`
- [ ] Documentation updated
    - [ ] Connector's `README.md`
    - [ ] Connector's `bootstrap.md`. See [description and examples](https://docs.google.com/document/d/1ypdgmwmEHWv-TrO4_YOQ7pAJGVrMp5BOkEVh831N260/edit?usp=sharing)
    - [ ] `docs/integrations/<source or destination>/<name>.md` including changelog with an entry for the initial version. See changelog [example](https://docs.airbyte.io/integrations/sources/stripe#changelog)
    - [ ] `docs/integrations/README.md`
    - [ ] `airbyte-integrations/builds.md`
- [ ] PR name follows [PR naming conventions](https://docs.airbyte.com/contributing-to-airbyte/issues-and-pull-requests)

### Airbyter

If this is a community PR, the Airbyte engineer reviewing this PR is responsible for the below items.

- [ ] Create a non-forked branch based on this PR and test the below items on it
- [ ] Build is successful
- [ ] If new credentials are required for use in CI, add them to GSM. [Instructions](https://docs.airbyte.io/connector-development#using-credentials-in-ci).
- [ ] [`/test connector=connectors/<name>` command](https://docs.airbyte.io/connector-development#updating-an-existing-connector) is passing
- [ ] New Connector version released on Dockerhub by running the `/publish` command described [here](https://docs.airbyte.io/connector-development#updating-an-existing-connector)
- [ ] After the connector is published, connector added to connector index as described [here](https://docs.airbyte.io/connector-development#publishing-a-connector)
- [ ] Seed specs have been re-generated by building the platform and committing the changes to the seed spec files, as described [here](https://docs.airbyte.io/connector-development#publishing-a-connector)

</details>

<details><summary><strong>Updating a connector</strong></summary>

### Community member or Airbyter

- [ ] Grant edit access to maintainers ([instructions](https://docs.github.com/en/github/collaborating-with-pull-requests/working-with-forks/allowing-changes-to-a-pull-request-branch-created-from-a-fork#enabling-repository-maintainer-permissions-on-existing-pull-requests))
- [ ] Secrets in the connector's spec are annotated with `airbyte_secret`
- [ ] Unit & integration tests added and passing. Community members, please provide proof of success locally e.g: screenshot or copy-paste unit, integration, and acceptance test output. To run acceptance tests for a Python connector, follow instructions in the README. For java connectors run `./gradlew :airbyte-integrations:connectors:<name>:integrationTest`.
- [ ] Code reviews completed
- [ ] Connector version has been incremented
    - [ ] Version has been bumped according to our [Semantic Versioning for Connectors](https://docs.airbyte.com/contributing-to-airbyte/semantic-versioning-for-connectors) guidelines
    - [ ] `Dockerfile` has updated version
- [ ] Documentation updated
    - [ ] Connector's `README.md`
    - [ ] Connector's `bootstrap.md`. See [description and examples](https://docs.google.com/document/d/1ypdgmwmEHWv-TrO4_YOQ7pAJGVrMp5BOkEVh831N260/edit?usp=sharing)
    - [ ] Changelog updated in `docs/integrations/<source or destination>/<name>.md` with an entry for the new version. See changelog [example](https://docs.airbyte.io/integrations/sources/stripe#changelog)

- [ ] PR name follows [PR naming conventions](https://docs.airbyte.com/contributing-to-airbyte/issues-and-pull-requests)

### Airbyter

If this is a community PR, the Airbyte engineer reviewing this PR is responsible for the below items.

- [ ] Create a non-forked branch based on this PR and test the below items on it
- [ ] Build is successful
- [ ] If new credentials are required for use in CI, add them to GSM. [Instructions](https://docs.airbyte.io/connector-development#using-credentials-in-ci).
- [ ] [`/test connector=connectors/<name>` command](https://docs.airbyte.io/connector-development#updating-an-existing-connector) is passing
- [ ] New Connector version released on Dockerhub and connector version bumped by running the `/publish` command described [here](https://docs.airbyte.io/connector-development#updating-an-existing-connector)

</details>

<details><summary><strong>Connector Generator</strong></summary>

- [ ] Issue acceptance criteria met
- [ ] PR name follows [PR naming conventions](https://docs.airbyte.com/contributing-to-airbyte/issues-and-pull-requests)
- [ ] If adding a new generator, add it to the [list of scaffold modules being tested](https://github.com/airbytehq/airbyte/blob/master/airbyte-integrations/connector-templates/generator/build.gradle#L41)
- [ ] The generator test modules (all connectors with `-scaffold` in their name) have been updated with the latest scaffold by running `./gradlew :airbyte-integrations:connector-templates:generator:testScaffoldTemplates` then checking in your changes
- [ ] Documentation which references the generator is updated as needed

</details>
