### PR TITLE
Source Younium: Adding Booking and Account streams

### DIFF
--- a/airbyte-integrations/connectors/source-younium/integration_tests/configured_catalog.json
+++ b/airbyte-integrations/connectors/source-younium/integration_tests/configured_catalog.json
@@ -2,6 +2,15 @@
   "streams": [
     {
       "stream": {
+        "name": "account",
+        "json_schema": {},
+        "supported_sync_modes": ["full_refresh"]
+      },
+      "sync_mode": "full_refresh",
+      "destination_sync_mode": "overwrite"
+    },
+    {
+      "stream": {
         "name": "booking",
         "json_schema": {},
         "supported_sync_modes": ["full_refresh"]

--- a/airbyte-integrations/connectors/source-younium/integration_tests/configured_catalog.json
+++ b/airbyte-integrations/connectors/source-younium/integration_tests/configured_catalog.json
@@ -2,6 +2,15 @@
   "streams": [
     {
       "stream": {
+        "name": "booking",
+        "json_schema": {},
+        "supported_sync_modes": ["full_refresh"]
+      },
+      "sync_mode": "full_refresh",
+      "destination_sync_mode": "overwrite"
+    },
+    {
+      "stream": {
         "name": "invoice",
         "json_schema": {},
         "supported_sync_modes": ["full_refresh"]

--- a/airbyte-integrations/connectors/source-younium/source_younium/schemas/account.json
+++ b/airbyte-integrations/connectors/source-younium/source_younium/schemas/account.json
@@ -1,0 +1,315 @@
+{
+  "$schema" : "https://json-schema.org/draft/2020-12/schema",
+  "type" : "object",
+  "properties" : {
+    "id" : {
+      "type" : "string",
+      "format" : "uuid"
+    },
+    "parentAccountId" : {
+      "type" : "string",
+      "format" : "uuid",
+      "nullable" : true
+    },
+    "accountNumber" : {
+      "type" : "string",
+      "nullable" : true
+    },
+    "accountType" : {
+      "allOf" : [
+        {
+          "$ref" : "#/$defs/AccountType"
+        }
+      ]
+    },
+    "inactive" : {
+      "type" : "boolean"
+    },
+    "invoiceDeliveryMethod" : {
+      "allOf" : [
+        {
+          "$ref" : "#/$defs/InvoiceDeliveryMethod"
+        }
+      ]
+    },
+    "accountsReceivable" : {
+      "type" : "string",
+      "nullable" : true
+    },
+    "currencyCode" : {
+      "type" : "string",
+      "nullable" : true
+    },
+    "defaultPaymentTerm" : {
+      "type" : "string",
+      "nullable" : true
+    },
+    "domain" : {
+      "type" : "string",
+      "nullable" : true
+    },
+    "electronicInvoiceAddress" : {
+      "type" : "string",
+      "nullable" : true
+    },
+    "electronicInvoiceAddressScheme" : {
+      "type" : "string",
+      "description" : "Electronic Invoice Scheme (EAS) code list.  Read more on: https://docs.peppol.eu/poacc/billing/3.0/codelist/eas/",
+      "nullable" : true,
+      "example" : "0007"
+    },
+    "imageUrl" : {
+      "type" : "string",
+      "nullable" : true
+    },
+    "invoiceEmailAddress" : {
+      "type" : "string",
+      "nullable" : true
+    },
+    "invoiceEmailCcAddresses" : {
+      "type" : "string",
+      "nullable" : true
+    },
+    "reminderEmailAddress" : {
+      "type" : "string",
+      "nullable" : true
+    },
+    "name" : {
+      "type" : "string",
+      "nullable" : true
+    },
+    "organizationNumber" : {
+      "type" : "string",
+      "nullable" : true
+    },
+    "ourReference" : {
+      "type" : "string",
+      "nullable" : true
+    },
+    "taxRegistrationNumber" : {
+      "type" : "string",
+      "nullable" : true
+    },
+    "taxTemplate" : {
+      "type" : "string",
+      "nullable" : true
+    },
+    "yourReference" : {
+      "type" : "string",
+      "nullable" : true
+    },
+    "invoiceTemplateId" : {
+      "type" : "string",
+      "format" : "uuid",
+      "nullable" : true
+    },
+    "invoiceBatchGroupId" : {
+      "type" : "string",
+      "format" : "uuid",
+      "nullable" : true
+    },
+    "defaultInvoiceAddress" : {
+      "allOf" : [
+        {
+          "$ref" : "#/$defs/AddressResponse"
+        }
+      ],
+      "nullable" : true
+    },
+    "defaultDeliveryAddress" : {
+      "allOf" : [
+        {
+          "$ref" : "#/$defs/AddressResponse"
+        }
+      ],
+      "nullable" : true
+    },
+    "addresses" : {
+      "type" : "array",
+      "items" : {
+        "$ref" : "#/$defs/AddressResponse"
+      },
+      "nullable" : true
+    },
+    "customFields" : {
+      "type" : "object",
+      "additionalProperties" : {},
+      "nullable" : true
+    },
+    "onlinePaymentDetails" : {
+      "allOf" : [
+        {
+          "$ref" : "#/$defs/OnlinePaymentDetailsResponse"
+        }
+      ],
+      "nullable" : true
+    },
+    "externalERPId" : {
+      "type" : "string",
+      "nullable" : true
+    },
+    "externalCRMId" : {
+      "type" : "string",
+      "nullable" : true
+    },
+    "cmrr" : {
+      "allOf" : [
+        {
+          "$ref" : "#/$defs/CurrencyAmount"
+        }
+      ],
+      "nullable" : true
+    },
+    "acv" : {
+      "allOf" : [
+        {
+          "$ref" : "#/$defs/CurrencyAmount"
+        }
+      ],
+      "nullable" : true
+    },
+    "emrr" : {
+      "allOf" : [
+        {
+          "$ref" : "#/$defs/CurrencyAmount"
+        }
+      ],
+      "nullable" : true
+    },
+    "oneTimeFees" : {
+      "allOf" : [
+        {
+          "$ref" : "#/$defs/CurrencyAmount"
+        }
+      ],
+      "nullable" : true
+    },
+    "tcv" : {
+      "allOf" : [
+        {
+          "$ref" : "#/$defs/CurrencyAmount"
+        }
+      ],
+      "nullable" : true
+    }
+  },
+  "additionalProperties" : false,
+  "$defs" : {
+    "AccountType" : {
+      "enum" : [
+        "Customer",
+        "Reseller",
+        "Subsidiary",
+        "Prospect",
+        "Other"
+      ],
+      "type" : "string"
+    },
+    "AddressResponse" : {
+      "type" : "object",
+      "properties" : {
+        "id" : {
+          "type" : "string",
+          "format" : "uuid",
+          "nullable" : true
+        },
+        "description" : {
+          "type" : "string",
+          "nullable" : true
+        },
+        "name" : {
+          "type" : "string",
+          "nullable" : true
+        },
+        "street" : {
+          "type" : "string",
+          "nullable" : true
+        },
+        "street2" : {
+          "type" : "string",
+          "nullable" : true
+        },
+        "city" : {
+          "type" : "string",
+          "nullable" : true
+        },
+        "county" : {
+          "type" : "string",
+          "nullable" : true
+        },
+        "state" : {
+          "type" : "string",
+          "nullable" : true
+        },
+        "zip" : {
+          "type" : "string",
+          "nullable" : true
+        },
+        "country" : {
+          "type" : "string",
+          "nullable" : true
+        }
+      },
+      "additionalProperties" : false
+    },
+    "CurrencyAmount" : {
+      "type" : "object",
+      "properties" : {
+        "amount" : {
+          "type" : "number",
+          "format" : "double"
+        },
+        "currencyCode" : {
+          "type" : "string",
+          "nullable" : true
+        },
+        "currencyConversionDate" : {
+          "type" : "string",
+          "format" : "date-time",
+          "nullable" : true
+        },
+        "baseCurrencyAmount" : {
+          "type" : "number",
+          "format" : "double"
+        },
+        "baseCurrencyCode" : {
+          "type" : "string",
+          "nullable" : true
+        }
+      },
+      "additionalProperties" : false
+    },
+    "InvoiceDeliveryMethod" : {
+      "enum" : [
+        "Email",
+        "Print",
+        "ElectronicInvoice",
+        "ExternalPrint",
+        "AutomaticElectronicRouting"
+      ],
+      "type" : "string"
+    },
+    "OnlinePaymentDetailsResponse" : {
+      "type" : "object",
+      "properties" : {
+        "created" : {
+          "type" : "string",
+          "format" : "date-time"
+        },
+        "modified" : {
+          "type" : "string",
+          "format" : "date-time"
+        },
+        "stripeCustomerId" : {
+          "type" : "string",
+          "nullable" : true
+        },
+        "stripePaymentMethodId" : {
+          "type" : "string",
+          "nullable" : true
+        }
+      },
+      "additionalProperties" : false
+    }
+  }
+}

--- a/airbyte-integrations/connectors/source-younium/source_younium/schemas/booking.json
+++ b/airbyte-integrations/connectors/source-younium/source_younium/schemas/booking.json
@@ -1,0 +1,345 @@
+{
+  "$schema" : "https://json-schema.org/draft/2020-12/schema",
+  "type" : "object",
+  "properties" : {
+    "id" : {
+      "type" : "string",
+      "format" : "uuid"
+    },
+    "currency" : {
+      "type" : "string",
+      "nullable" : true
+    },
+    "bookingType" : {
+      "allOf" : [
+        {
+          "$ref" : "#/$defs/BookingType"
+        }
+      ]
+    },
+    "accountCategory" : {
+      "allOf" : [
+        {
+          "$ref" : "#/$defs/AccountCategory"
+        }
+      ]
+    },
+    "changeType" : {
+      "allOf" : [
+        {
+          "$ref" : "#/$defs/ChangeType"
+        }
+      ]
+    },
+    "cmrr" : {
+      "allOf" : [
+        {
+          "$ref" : "#/$defs/AmountWithBaseCurrency"
+        }
+      ],
+      "nullable" : true
+    },
+    "acv" : {
+      "allOf" : [
+        {
+          "$ref" : "#/$defs/AmountWithBaseCurrency"
+        }
+      ],
+      "nullable" : true
+    },
+    "emrr" : {
+      "allOf" : [
+        {
+          "$ref" : "#/$defs/AmountWithBaseCurrency"
+        }
+      ],
+      "nullable" : true
+    },
+    "oneTimeFees" : {
+      "allOf" : [
+        {
+          "$ref" : "#/$defs/AmountWithBaseCurrency"
+        }
+      ],
+      "nullable" : true
+    },
+    "tcv" : {
+      "allOf" : [
+        {
+          "$ref" : "#/$defs/AmountWithBaseCurrency"
+        }
+      ],
+      "nullable" : true
+    },
+    "fmrr" : {
+      "allOf" : [
+        {
+          "$ref" : "#/$defs/AmountWithBaseCurrency"
+        }
+      ],
+      "nullable" : true
+    },
+    "effectiveDate" : {
+      "type" : "string",
+      "format" : "date-time"
+    },
+    "bookingLines" : {
+      "type" : "array",
+      "items" : {
+        "$ref" : "#/$defs/BookingLineResponse"
+      },
+      "nullable" : true
+    },
+    "classification" : {
+      "allOf" : [
+        {
+          "$ref" : "#/$defs/BookingClassificationResponse"
+        }
+      ],
+      "nullable" : true
+    },
+    "order" : {
+      "allOf" : [
+        {
+          "$ref" : "#/$defs/SimpleOrderModel"
+        }
+      ],
+      "nullable" : true
+    },
+    "notes" : {
+      "type" : "string",
+      "nullable" : true
+    }
+  },
+  "additionalProperties" : false,
+  "$defs" : {
+    "AccountCategory" : {
+      "enum" : [
+        "New",
+        "Existing",
+        "Lost"
+      ],
+      "type" : "string"
+    },
+    "AmountWithBaseCurrency" : {
+      "type" : "object",
+      "properties" : {
+        "amount" : {
+          "type" : "number",
+          "format" : "double",
+          "nullable" : true
+        },
+        "amountInBaseCurrency" : {
+          "type" : "number",
+          "format" : "double",
+          "nullable" : true
+        }
+      },
+      "additionalProperties" : false
+    },
+    "BookingClassificationResponse" : {
+      "type" : "object",
+      "properties" : {
+        "name" : {
+          "type" : "string",
+          "nullable" : true
+        },
+        "description" : {
+          "type" : "string",
+          "nullable" : true
+        },
+        "chartColor" : {
+          "type" : "string",
+          "nullable" : true
+        },
+        "isSystemClassification" : {
+          "type" : "boolean"
+        },
+        "classificationType" : {
+          "allOf" : [
+            {
+              "$ref" : "#/$defs/BookingClassificationType"
+            }
+          ],
+          "nullable" : true
+        }
+      },
+      "additionalProperties" : false
+    },
+    "BookingClassificationType" : {
+      "enum" : [
+        "NewCustomer",
+        "Expansion",
+        "Contraction",
+        "CustomerChurn",
+        "NoChange",
+        "SplitOrder"
+      ],
+      "type" : "string"
+    },
+    "BookingLineResponse" : {
+      "type" : "object",
+      "properties" : {
+        "charge" : {
+          "allOf" : [
+            {
+              "$ref" : "#/$defs/SimpleOrderChargeModel"
+            }
+          ],
+          "nullable" : true
+        },
+        "cmrr" : {
+          "allOf" : [
+            {
+              "$ref" : "#/$defs/CurrencyAmount"
+            }
+          ],
+          "nullable" : true
+        },
+        "acv" : {
+          "allOf" : [
+            {
+              "$ref" : "#/$defs/CurrencyAmount"
+            }
+          ],
+          "nullable" : true
+        },
+        "emrr" : {
+          "allOf" : [
+            {
+              "$ref" : "#/$defs/CurrencyAmount"
+            }
+          ],
+          "nullable" : true
+        },
+        "oneTimeFees" : {
+          "allOf" : [
+            {
+              "$ref" : "#/$defs/CurrencyAmount"
+            }
+          ],
+          "nullable" : true
+        },
+        "tcv" : {
+          "allOf" : [
+            {
+              "$ref" : "#/$defs/CurrencyAmount"
+            }
+          ],
+          "nullable" : true
+        },
+        "fmrr" : {
+          "allOf" : [
+            {
+              "$ref" : "#/$defs/CurrencyAmount"
+            }
+          ],
+          "nullable" : true
+        }
+      },
+      "additionalProperties" : false
+    },
+    "BookingType" : {
+      "enum" : [
+        "New",
+        "Change",
+        "Churn"
+      ],
+      "type" : "string"
+    },
+    "ChangeType" : {
+      "enum" : [
+        "Upsell",
+        "Downsell",
+        "Renewal",
+        "None",
+        "PriceAdjustment",
+        "Milestone",
+        "CancelledDelivery",
+        "AssociatedCharge",
+        "SplitOrder"
+      ],
+      "type" : "string"
+    },
+    "CurrencyAmount" : {
+      "type" : "object",
+      "properties" : {
+        "amount" : {
+          "type" : "number",
+          "format" : "double"
+        },
+        "currencyCode" : {
+          "type" : "string",
+          "nullable" : true
+        },
+        "currencyConversionDate" : {
+          "type" : "string",
+          "format" : "date-time",
+          "nullable" : true
+        },
+        "baseCurrencyAmount" : {
+          "type" : "number",
+          "format" : "double"
+        },
+        "baseCurrencyCode" : {
+          "type" : "string",
+          "nullable" : true
+        }
+      },
+      "additionalProperties" : false
+    },
+    "SimpleOrderChargeModel" : {
+      "type" : "object",
+      "properties" : {
+        "name" : {
+          "type" : "string",
+          "nullable" : true
+        },
+        "chargeNumber" : {
+          "type" : "string",
+          "nullable" : true,
+          "example" : "OPC-000001"
+        },
+        "description" : {
+          "type" : "string",
+          "nullable" : true
+        },
+        "id" : {
+          "type" : "string",
+          "format" : "uuid"
+        },
+        "externalERPId" : {
+          "type" : "string",
+          "nullable" : true
+        },
+        "externalCRMId" : {
+          "type" : "string",
+          "nullable" : true
+        }
+      },
+      "additionalProperties" : false
+    },
+    "SimpleOrderModel" : {
+      "type" : "object",
+      "properties" : {
+        "orderNumber" : {
+          "type" : "string",
+          "nullable" : true
+        },
+        "id" : {
+          "type" : "string",
+          "format" : "uuid"
+        },
+        "externalERPId" : {
+          "type" : "string",
+          "nullable" : true
+        },
+        "externalCRMId" : {
+          "type" : "string",
+          "nullable" : true
+        }
+      },
+      "additionalProperties" : false
+    }
+  }
+}

--- a/airbyte-integrations/connectors/source-younium/source_younium/source.py
+++ b/airbyte-integrations/connectors/source-younium/source_younium/source.py
@@ -63,6 +63,13 @@ class YouniumStream(HttpStream, ABC):
         response_results = response.json()
         yield from response_results.get("data", [])
 
+class Booking(YouniumStream):
+    primary_key = "id"
+
+    def path(
+        self, stream_state: Mapping[str, Any] = None, stream_slice: Mapping[str, Any] = None, next_page_token: Mapping[str, Any] = None
+    ) -> str:
+        return "Bookings"
 
 class Invoice(YouniumStream):
     primary_key = "id"
@@ -128,4 +135,9 @@ class SourceYounium(AbstractSource):
         :param config: A Mapping of the user input configuration as defined in the connector spec.
         """
         auth = self.get_auth(config)
-        return [Invoice(authenticator=auth, **config), Product(authenticator=auth, **config), Subscription(authenticator=auth, **config)]
+        return [
+            Booking(authenticator=auth, **config),
+            Invoice(authenticator=auth, **config),
+            Product(authenticator=auth, **config),
+            Subscription(authenticator=auth, **config),
+        ]

--- a/airbyte-integrations/connectors/source-younium/source_younium/source.py
+++ b/airbyte-integrations/connectors/source-younium/source_younium/source.py
@@ -63,6 +63,14 @@ class YouniumStream(HttpStream, ABC):
         response_results = response.json()
         yield from response_results.get("data", [])
 
+class Account(YouniumStream):
+    primary_key = "id"
+
+    def path(
+        self, stream_state: Mapping[str, Any] = None, stream_slice: Mapping[str, Any] = None, next_page_token: Mapping[str, Any] = None
+    ) -> str:
+        return "Accounts"
+
 class Booking(YouniumStream):
     primary_key = "id"
 
@@ -136,6 +144,7 @@ class SourceYounium(AbstractSource):
         """
         auth = self.get_auth(config)
         return [
+            Account(authenticator=auth, **config),
             Booking(authenticator=auth, **config),
             Invoice(authenticator=auth, **config),
             Product(authenticator=auth, **config),

--- a/airbyte-integrations/connectors/source-younium/unit_tests/test_source.py
+++ b/airbyte-integrations/connectors/source-younium/unit_tests/test_source.py
@@ -47,5 +47,5 @@ def test_streams(mocker):
     config_mock = {"playground": False, "username": "dummy_username", "password": "dummy_password"}
     streams = source.streams(config_mock)
 
-    expected_streams_number = 3
+    expected_streams_number = 5
     assert len(streams) == expected_streams_number

--- a/docs/integrations/sources/younium.md
+++ b/docs/integrations/sources/younium.md
@@ -33,6 +33,7 @@ The Younium source connector supports the following [sync modes](https://docs.ai
 
 ## Supported Streams
 
+- [Bookings](https://developer.younium.com/api-details#api=Production_API2-0&operation=Get-Bookings)
 - [Subscriptions](https://developer.younium.com/api-details#api=Production_API2-0&operation=Get-Subscriptions)
 - [Products](https://developer.younium.com/api-details#api=Production_API2-0&operation=Get-Products)
 - [Invoices](https://developer.younium.com/api-details#api=Production_API2-0&operation=Get-Invoices)

--- a/docs/integrations/sources/younium.md
+++ b/docs/integrations/sources/younium.md
@@ -33,6 +33,7 @@ The Younium source connector supports the following [sync modes](https://docs.ai
 
 ## Supported Streams
 
+- [Accounts](https://developer.younium.com/api-details#api=Production_API2-0&operation=Get-Accounts)
 - [Bookings](https://developer.younium.com/api-details#api=Production_API2-0&operation=Get-Bookings)
 - [Subscriptions](https://developer.younium.com/api-details#api=Production_API2-0&operation=Get-Subscriptions)
 - [Products](https://developer.younium.com/api-details#api=Production_API2-0&operation=Get-Products)

--- a/docs/integrations/sources/younium.md
+++ b/docs/integrations/sources/younium.md
@@ -41,6 +41,7 @@ The Younium source connector supports the following [sync modes](https://docs.ai
 
 ## Changelog
 
-| Version | Date       | Pull Request                                             | Subject                             |
-| :------ | :--------- | :------------------------------------------------------- | :---------------------------------- |
-| 0.1.0   | 2022-11-09 | [18758](https://github.com/airbytehq/airbyte/pull/18758) | 🎉 New Source: Younium [python cdk] |
+| Version | Date       | Pull Request                                             | Subject                                            |
+| :------ | :--------- | :------------------------------------------------------- |:---------------------------------------------------|
+| 0.1.0   | 2022-11-09 | [18758](https://github.com/airbytehq/airbyte/pull/18758) | 🎉 New Source: Younium [python cdk]                |
+| 0.2.0   | 2023-03-29 | [24655](https://github.com/airbytehq/airbyte/pull/24655) | Source Younium: Adding Booking and Account streams |


### PR DESCRIPTION
## What
We needed to get Booking with Booking lines, which are the transaction level data on an order as well as the Account stream. 

This is to fix issue #24654

## How
Added the booking and account stream to the existing source connecting


## 🚨 User Impact 🚨
No breaking changes, when the connector is refreshed the two new streams should appear for syncing.

## Pre-merge Checklist
*Expand the relevant checklist and delete the others.*

<details><summary><strong>New Connector</strong></summary>

### Community member

- [ ] **Community member?** Grant edit access to maintainers ([instructions](https://docs.github.com/en/github/collaborating-with-pull-requests/working-with-forks/allowing-changes-to-a-pull-request-branch-created-from-a-fork#enabling-repository-maintainer-permissions-on-existing-pull-requests))
- [ ] Unit & integration tests added and passing. Community members, please provide proof of success locally e.g: screenshot or copy-paste unit, integration, and acceptance test output. To run acceptance tests for a Python connector, follow instructions in the README. For java connectors run `./gradlew :airbyte-integrations:connectors:<name>:integrationTest`.
- [ ] Code reviews completed
- [ ] Connector version is set to `0.0.1`
    - [ ] `Dockerfile` has version `0.0.1`
- [ ] Documentation updated
    - [ ] Connector's `README.md`
    - [ ] Connector's `bootstrap.md`. See [description and examples](https://docs.google.com/document/d/1ypdgmwmEHWv-TrO4_YOQ7pAJGVrMp5BOkEVh831N260/edit?usp=sharing)
    - [ ] `docs/integrations/<source or destination>/<name>.md` including changelog with an entry for the initial version. See changelog [example](https://docs.airbyte.io/integrations/sources/stripe#changelog)
    - [ ] `docs/integrations/README.md`
    - [ ] `airbyte-integrations/builds.md`
- [ ] PR name follows [PR naming conventions](https://docs.airbyte.com/contributing-to-airbyte/issues-and-pull-requests)



