### PR TITLE
Refactorings prior to async flush work

### DIFF
--- a/airbyte-integrations/bases/base-java-s3/src/main/java/io/airbyte/integrations/destination/s3/S3ConsumerFactory.java
+++ b/airbyte-integrations/bases/base-java-s3/src/main/java/io/airbyte/integrations/destination/s3/S3ConsumerFactory.java
@@ -5,7 +5,6 @@
 package io.airbyte.integrations.destination.s3;
 
 import com.google.common.base.Preconditions;
-import io.airbyte.commons.functional.CheckedBiConsumer;
 import io.airbyte.commons.functional.CheckedBiFunction;
 import io.airbyte.commons.json.Jsons;
 import io.airbyte.integrations.base.AirbyteMessageConsumer;
@@ -13,6 +12,7 @@ import io.airbyte.integrations.destination.NamingConventionTransformer;
 import io.airbyte.integrations.destination.buffered_stream_consumer.BufferedStreamConsumer;
 import io.airbyte.integrations.destination.buffered_stream_consumer.OnCloseFunction;
 import io.airbyte.integrations.destination.buffered_stream_consumer.OnStartFunction;
+import io.airbyte.integrations.destination.record_buffer.FlushBufferFunction;
 import io.airbyte.integrations.destination.record_buffer.SerializableBuffer;
 import io.airbyte.integrations.destination.record_buffer.SerializedBufferingStrategy;
 import io.airbyte.protocol.models.v0.AirbyteMessage;
@@ -108,9 +108,9 @@ public class S3ConsumerFactory {
     return new AirbyteStreamNameNamespacePair(config.getStreamName(), config.getNamespace());
   }
 
-  private CheckedBiConsumer<AirbyteStreamNameNamespacePair, SerializableBuffer, Exception> flushBufferFunction(final BlobStorageOperations storageOperations,
-                                                                                                               final List<WriteConfig> writeConfigs,
-                                                                                                               final ConfiguredAirbyteCatalog catalog) {
+  private FlushBufferFunction flushBufferFunction(final BlobStorageOperations storageOperations,
+                                                  final List<WriteConfig> writeConfigs,
+                                                  final ConfiguredAirbyteCatalog catalog) {
     final Map<AirbyteStreamNameNamespacePair, WriteConfig> pairToWriteConfig =
         writeConfigs.stream()
             .collect(Collectors.toUnmodifiableMap(

--- a/airbyte-integrations/bases/base-java-s3/src/main/java/io/airbyte/integrations/destination/s3/S3ConsumerFactory.java
+++ b/airbyte-integrations/bases/base-java-s3/src/main/java/io/airbyte/integrations/destination/s3/S3ConsumerFactory.java
@@ -119,7 +119,8 @@ public class S3ConsumerFactory {
       LOGGER.info("Flushing buffer for stream {} ({}) to storage", streamName.getName(), FileUtils.byteCountToDisplaySize(buffer.getByteCount()));
       if (!pairToWriteConfig.containsKey(streamName)) {
         throw new IllegalArgumentException(
-            String.format("Message contained record from a stream %s that was not in the catalog. \ncatalog: %s", streamName, Jsons.serialize(catalog)));
+            String.format("Message contained record from a stream %s that was not in the catalog. \ncatalog: %s", streamName,
+                Jsons.serialize(catalog)));
       }
 
       final WriteConfig writeConfig = pairToWriteConfig.get(streamName);

--- a/airbyte-integrations/bases/base-java-s3/src/main/java/io/airbyte/integrations/destination/s3/S3ConsumerFactory.java
+++ b/airbyte-integrations/bases/base-java-s3/src/main/java/io/airbyte/integrations/destination/s3/S3ConsumerFactory.java
@@ -45,12 +45,12 @@ public class S3ConsumerFactory {
                                        final ConfiguredAirbyteCatalog catalog) {
     final List<WriteConfig> writeConfigs = createWriteConfigs(storageOperations, namingResolver, s3Config, catalog);
     return new BufferedStreamConsumer(
-        outputRecordCollector,
         onStartFunction(storageOperations, writeConfigs),
         new SerializedBufferingStrategy(
             onCreateBuffer,
             catalog,
-            flushBufferFunction(storageOperations, writeConfigs, catalog)),
+            flushBufferFunction(storageOperations, writeConfigs, catalog),
+            outputRecordCollector),
         onCloseFunction(storageOperations, writeConfigs),
         catalog,
         storageOperations::isValidData);

--- a/airbyte-integrations/bases/base-java-s3/src/main/java/io/airbyte/integrations/destination/s3/SerializedBufferFactory.java
+++ b/airbyte-integrations/bases/base-java-s3/src/main/java/io/airbyte/integrations/destination/s3/SerializedBufferFactory.java
@@ -4,9 +4,9 @@
 
 package io.airbyte.integrations.destination.s3;
 
-import io.airbyte.commons.functional.CheckedBiFunction;
 import io.airbyte.commons.json.Jsons;
 import io.airbyte.integrations.destination.record_buffer.BufferStorage;
+import io.airbyte.integrations.destination.record_buffer.CreateBufferFunction;
 import io.airbyte.integrations.destination.record_buffer.SerializableBuffer;
 import io.airbyte.integrations.destination.s3.avro.AvroSerializedBuffer;
 import io.airbyte.integrations.destination.s3.avro.S3AvroFormatConfig;
@@ -15,8 +15,6 @@ import io.airbyte.integrations.destination.s3.csv.S3CsvFormatConfig;
 import io.airbyte.integrations.destination.s3.jsonl.JsonLSerializedBuffer;
 import io.airbyte.integrations.destination.s3.jsonl.S3JsonlFormatConfig;
 import io.airbyte.integrations.destination.s3.parquet.ParquetSerializedBuffer;
-import io.airbyte.protocol.models.v0.AirbyteStreamNameNamespacePair;
-import io.airbyte.protocol.models.v0.ConfiguredAirbyteCatalog;
 import java.util.concurrent.Callable;
 import java.util.function.Function;
 import org.slf4j.Logger;
@@ -43,8 +41,8 @@ public class SerializedBufferFactory {
    * creating a new buffer where to store data. Note that we typically associate which format is being
    * stored in the storage object thanks to its file extension.
    */
-  public static CheckedBiFunction<AirbyteStreamNameNamespacePair, ConfiguredAirbyteCatalog, SerializableBuffer, Exception> getCreateFunction(final S3DestinationConfig config,
-                                                                                                                                             final Function<String, BufferStorage> createStorageFunctionWithoutExtension) {
+  public static CreateBufferFunction getCreateFunction(final S3DestinationConfig config,
+                                                       final Function<String, BufferStorage> createStorageFunctionWithoutExtension) {
     final S3FormatConfig formatConfig = config.getFormatConfig();
     LOGGER.info("S3 format config: {}", formatConfig.toString());
     switch (formatConfig.getFormat()) {

--- a/airbyte-integrations/bases/base-java-s3/src/main/java/io/airbyte/integrations/destination/s3/avro/AvroSerializedBuffer.java
+++ b/airbyte-integrations/bases/base-java-s3/src/main/java/io/airbyte/integrations/destination/s3/avro/AvroSerializedBuffer.java
@@ -4,10 +4,9 @@
 
 package io.airbyte.integrations.destination.s3.avro;
 
-import io.airbyte.commons.functional.CheckedBiFunction;
 import io.airbyte.integrations.destination.record_buffer.BaseSerializedBuffer;
 import io.airbyte.integrations.destination.record_buffer.BufferStorage;
-import io.airbyte.integrations.destination.record_buffer.SerializableBuffer;
+import io.airbyte.integrations.destination.record_buffer.CreateBufferFunction;
 import io.airbyte.protocol.models.v0.AirbyteRecordMessage;
 import io.airbyte.protocol.models.v0.AirbyteStreamNameNamespacePair;
 import io.airbyte.protocol.models.v0.ConfiguredAirbyteCatalog;
@@ -63,8 +62,8 @@ public class AvroSerializedBuffer extends BaseSerializedBuffer {
     dataFileWriter.close();
   }
 
-  public static CheckedBiFunction<AirbyteStreamNameNamespacePair, ConfiguredAirbyteCatalog, SerializableBuffer, Exception> createFunction(final S3AvroFormatConfig config,
-                                                                                                                                          final Callable<BufferStorage> createStorageFunction) {
+  public static CreateBufferFunction createFunction(final S3AvroFormatConfig config,
+                                                    final Callable<BufferStorage> createStorageFunction) {
     final CodecFactory codecFactory = config.getCodecFactory();
     return (final AirbyteStreamNameNamespacePair stream, final ConfiguredAirbyteCatalog catalog) -> {
       final JsonToAvroSchemaConverter schemaConverter = new JsonToAvroSchemaConverter();

--- a/airbyte-integrations/bases/base-java-s3/src/main/java/io/airbyte/integrations/destination/s3/csv/CsvSerializedBuffer.java
+++ b/airbyte-integrations/bases/base-java-s3/src/main/java/io/airbyte/integrations/destination/s3/csv/CsvSerializedBuffer.java
@@ -4,10 +4,9 @@
 
 package io.airbyte.integrations.destination.s3.csv;
 
-import io.airbyte.commons.functional.CheckedBiFunction;
 import io.airbyte.integrations.destination.record_buffer.BaseSerializedBuffer;
 import io.airbyte.integrations.destination.record_buffer.BufferStorage;
-import io.airbyte.integrations.destination.record_buffer.SerializableBuffer;
+import io.airbyte.integrations.destination.record_buffer.CreateBufferFunction;
 import io.airbyte.integrations.destination.s3.util.CompressionType;
 import io.airbyte.protocol.models.v0.AirbyteRecordMessage;
 import io.airbyte.protocol.models.v0.AirbyteStreamNameNamespacePair;
@@ -71,9 +70,8 @@ public class CsvSerializedBuffer extends BaseSerializedBuffer {
     csvPrinter.close();
   }
 
-  public static CheckedBiFunction<AirbyteStreamNameNamespacePair, ConfiguredAirbyteCatalog, SerializableBuffer, Exception> createFunction(
-                                                                                                                                          final S3CsvFormatConfig config,
-                                                                                                                                          final Callable<BufferStorage> createStorageFunction) {
+  public static CreateBufferFunction createFunction(final S3CsvFormatConfig config,
+                                                    final Callable<BufferStorage> createStorageFunction) {
     return (final AirbyteStreamNameNamespacePair stream, final ConfiguredAirbyteCatalog catalog) -> {
       if (config == null) {
         return new CsvSerializedBuffer(createStorageFunction.call(), new StagingDatabaseCsvSheetGenerator(), true);

--- a/airbyte-integrations/bases/base-java-s3/src/main/java/io/airbyte/integrations/destination/s3/jsonl/JsonLSerializedBuffer.java
+++ b/airbyte-integrations/bases/base-java-s3/src/main/java/io/airbyte/integrations/destination/s3/jsonl/JsonLSerializedBuffer.java
@@ -72,7 +72,7 @@ public class JsonLSerializedBuffer extends BaseSerializedBuffer {
   }
 
   public static CreateBufferFunction createFunction(final S3JsonlFormatConfig config,
-                                                                                                                                          final Callable<BufferStorage> createStorageFunction) {
+                                                    final Callable<BufferStorage> createStorageFunction) {
     return (final AirbyteStreamNameNamespacePair stream, final ConfiguredAirbyteCatalog catalog) -> {
       final CompressionType compressionType = config == null
           ? S3DestinationConstants.DEFAULT_COMPRESSION_TYPE

--- a/airbyte-integrations/bases/base-java-s3/src/main/java/io/airbyte/integrations/destination/s3/jsonl/JsonLSerializedBuffer.java
+++ b/airbyte-integrations/bases/base-java-s3/src/main/java/io/airbyte/integrations/destination/s3/jsonl/JsonLSerializedBuffer.java
@@ -8,13 +8,12 @@ import com.fasterxml.jackson.core.type.TypeReference;
 import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.databind.node.ObjectNode;
-import io.airbyte.commons.functional.CheckedBiFunction;
 import io.airbyte.commons.jackson.MoreMappers;
 import io.airbyte.commons.json.Jsons;
 import io.airbyte.integrations.base.JavaBaseConstants;
 import io.airbyte.integrations.destination.record_buffer.BaseSerializedBuffer;
 import io.airbyte.integrations.destination.record_buffer.BufferStorage;
-import io.airbyte.integrations.destination.record_buffer.SerializableBuffer;
+import io.airbyte.integrations.destination.record_buffer.CreateBufferFunction;
 import io.airbyte.integrations.destination.s3.S3DestinationConstants;
 import io.airbyte.integrations.destination.s3.util.CompressionType;
 import io.airbyte.integrations.destination.s3.util.Flattening;
@@ -54,7 +53,7 @@ public class JsonLSerializedBuffer extends BaseSerializedBuffer {
     json.put(JavaBaseConstants.COLUMN_NAME_AB_ID, UUID.randomUUID().toString());
     json.put(JavaBaseConstants.COLUMN_NAME_EMITTED_AT, recordMessage.getEmittedAt());
     if (flattenData) {
-      Map<String, JsonNode> data = MAPPER.convertValue(recordMessage.getData(), new TypeReference<>() {});
+      final Map<String, JsonNode> data = MAPPER.convertValue(recordMessage.getData(), new TypeReference<>() {});
       json.setAll(data);
     } else {
       json.set(JavaBaseConstants.COLUMN_NAME_DATA, recordMessage.getData());
@@ -72,7 +71,7 @@ public class JsonLSerializedBuffer extends BaseSerializedBuffer {
     printWriter.close();
   }
 
-  public static CheckedBiFunction<AirbyteStreamNameNamespacePair, ConfiguredAirbyteCatalog, SerializableBuffer, Exception> createFunction(final S3JsonlFormatConfig config,
+  public static CreateBufferFunction createFunction(final S3JsonlFormatConfig config,
                                                                                                                                           final Callable<BufferStorage> createStorageFunction) {
     return (final AirbyteStreamNameNamespacePair stream, final ConfiguredAirbyteCatalog catalog) -> {
       final CompressionType compressionType = config == null

--- a/airbyte-integrations/bases/base-java-s3/src/main/java/io/airbyte/integrations/destination/s3/parquet/ParquetSerializedBuffer.java
+++ b/airbyte-integrations/bases/base-java-s3/src/main/java/io/airbyte/integrations/destination/s3/parquet/ParquetSerializedBuffer.java
@@ -6,7 +6,7 @@ package io.airbyte.integrations.destination.s3.parquet;
 
 import static org.apache.parquet.avro.AvroWriteSupport.WRITE_OLD_LIST_STRUCTURE;
 
-import io.airbyte.commons.functional.CheckedBiFunction;
+import io.airbyte.integrations.destination.record_buffer.CreateBufferFunction;
 import io.airbyte.integrations.destination.record_buffer.FileBuffer;
 import io.airbyte.integrations.destination.record_buffer.SerializableBuffer;
 import io.airbyte.integrations.destination.s3.S3DestinationConfig;
@@ -72,7 +72,7 @@ public class ParquetSerializedBuffer implements SerializableBuffer {
     Files.deleteIfExists(bufferFile);
     avroRecordFactory = new AvroRecordFactory(schema, AvroConstants.JSON_CONVERTER);
     final S3ParquetFormatConfig formatConfig = (S3ParquetFormatConfig) config.getFormatConfig();
-    Configuration avroConfig = new Configuration();
+    final Configuration avroConfig = new Configuration();
     avroConfig.setBoolean(WRITE_OLD_LIST_STRUCTURE, false);
     parquetWriter = AvroParquetWriter.<Record>builder(HadoopOutputFile
         .fromPath(new org.apache.hadoop.fs.Path(bufferFile.toUri()), avroConfig))
@@ -161,7 +161,7 @@ public class ParquetSerializedBuffer implements SerializableBuffer {
     }
   }
 
-  public static CheckedBiFunction<AirbyteStreamNameNamespacePair, ConfiguredAirbyteCatalog, SerializableBuffer, Exception> createFunction(final S3DestinationConfig s3DestinationConfig) {
+  public static CreateBufferFunction createFunction(final S3DestinationConfig s3DestinationConfig) {
     return (final AirbyteStreamNameNamespacePair stream, final ConfiguredAirbyteCatalog catalog) -> new ParquetSerializedBuffer(s3DestinationConfig,
         stream, catalog);
   }

--- a/airbyte-integrations/bases/base-java/src/main/java/io/airbyte/integrations/destination/buffered_stream_consumer/BufferedStreamConsumer.java
+++ b/airbyte-integrations/bases/base-java/src/main/java/io/airbyte/integrations/destination/buffered_stream_consumer/BufferedStreamConsumer.java
@@ -84,7 +84,6 @@ public class BufferedStreamConsumer extends FailureTrackingAirbyteMessageConsume
   private final Map<AirbyteStreamNameNamespacePair, Long> streamToIgnoredRecordCount;
   private final BufferingStrategy bufferingStrategy;
 
-
   private boolean hasStarted;
   private boolean hasClosed;
 
@@ -176,8 +175,8 @@ public class BufferedStreamConsumer extends FailureTrackingAirbyteMessageConsume
   }
 
   /**
-   * Updates the next time a buffer flush should occur since it is deterministic that when this method is called all data has been
-   * scheduled to flush to the destination
+   * Updates the next time a buffer flush should occur since it is deterministic that when this method
+   * is called all data has been scheduled to flush to the destination
    */
   private void resetFlushDeadline() {
     nextFlushDeadline = Instant.now().plus(bufferFlushFrequency);

--- a/airbyte-integrations/bases/base-java/src/main/java/io/airbyte/integrations/destination/buffered_stream_consumer/BufferedStreamConsumer.java
+++ b/airbyte-integrations/bases/base-java/src/main/java/io/airbyte/integrations/destination/buffered_stream_consumer/BufferedStreamConsumer.java
@@ -165,6 +165,7 @@ public class BufferedStreamConsumer extends FailureTrackingAirbyteMessageConsume
       final Optional<BufferFlushType> flushType = bufferingStrategy.addRecord(stream, message);
       // if present means that a flush occurred
       if (flushType.isPresent()) {
+        // this resets the time based flushing behavior
         resetFlushDeadline();
       }
     } else if (message.getType() == Type.STATE) {

--- a/airbyte-integrations/bases/base-java/src/main/java/io/airbyte/integrations/destination/record_buffer/BufferingStrategy.java
+++ b/airbyte-integrations/bases/base-java/src/main/java/io/airbyte/integrations/destination/record_buffer/BufferingStrategy.java
@@ -48,9 +48,11 @@ public interface BufferingStrategy extends AutoCloseable {
   void clear() throws Exception;
 
   /**
-   * State management as it relates to flushing and state commit
-   * acknowledgement is handled by the BufferingStrategy now
+   * State management as it relates to flushing and state commit acknowledgement is handled by the
+   * BufferingStrategy now
+   *
    * @param message the incoming AirbyteMessage state object
    */
   void addStateMessage(AirbyteMessage message);
+
 }

--- a/airbyte-integrations/bases/base-java/src/main/java/io/airbyte/integrations/destination/record_buffer/BufferingStrategy.java
+++ b/airbyte-integrations/bases/base-java/src/main/java/io/airbyte/integrations/destination/record_buffer/BufferingStrategy.java
@@ -35,16 +35,22 @@ public interface BufferingStrategy extends AutoCloseable {
   /**
    * Flush buffered messages in a writer from a particular stream
    */
-  void flushWriter(AirbyteStreamNameNamespacePair stream, SerializableBuffer writer) throws Exception;
+  void flushSingleStream(AirbyteStreamNameNamespacePair stream, SerializableBuffer writer) throws Exception;
 
   /**
    * Flush all writers that were buffering message data so far.
    */
-  void flushAll() throws Exception;
+  void flushAllStreams() throws Exception;
 
   /**
    * Removes all stream buffers.
    */
   void clear() throws Exception;
 
+  /**
+   * State management as it relates to flushing and state commit
+   * acknowledgement is handled by the BufferingStrategy now
+   * @param message the incoming AirbyteMessage state object
+   */
+  void addStateMessage(AirbyteMessage message);
 }

--- a/airbyte-integrations/bases/base-java/src/main/java/io/airbyte/integrations/destination/record_buffer/CreateBufferFunction.java
+++ b/airbyte-integrations/bases/base-java/src/main/java/io/airbyte/integrations/destination/record_buffer/CreateBufferFunction.java
@@ -1,3 +1,7 @@
+/*
+ * Copyright (c) 2023 Airbyte, Inc., all rights reserved.
+ */
+
 package io.airbyte.integrations.destination.record_buffer;
 
 import io.airbyte.commons.functional.CheckedBiFunction;
@@ -11,4 +15,5 @@ public interface CreateBufferFunction extends
   @Override
   SerializableBuffer apply(AirbyteStreamNameNamespacePair streamName, ConfiguredAirbyteCatalog configuredCatalog)
       throws Exception;
+
 }

--- a/airbyte-integrations/bases/base-java/src/main/java/io/airbyte/integrations/destination/record_buffer/CreateBufferFunction.java
+++ b/airbyte-integrations/bases/base-java/src/main/java/io/airbyte/integrations/destination/record_buffer/CreateBufferFunction.java
@@ -1,0 +1,14 @@
+package io.airbyte.integrations.destination.record_buffer;
+
+import io.airbyte.commons.functional.CheckedBiFunction;
+import io.airbyte.protocol.models.v0.AirbyteStreamNameNamespacePair;
+import io.airbyte.protocol.models.v0.ConfiguredAirbyteCatalog;
+
+@FunctionalInterface
+public interface CreateBufferFunction extends
+    CheckedBiFunction<AirbyteStreamNameNamespacePair, ConfiguredAirbyteCatalog, SerializableBuffer, Exception> {
+
+  @Override
+  SerializableBuffer apply(AirbyteStreamNameNamespacePair streamName, ConfiguredAirbyteCatalog configuredCatalog)
+      throws Exception;
+}

--- a/airbyte-integrations/bases/base-java/src/main/java/io/airbyte/integrations/destination/record_buffer/FlushBufferFunction.java
+++ b/airbyte-integrations/bases/base-java/src/main/java/io/airbyte/integrations/destination/record_buffer/FlushBufferFunction.java
@@ -3,8 +3,9 @@ package io.airbyte.integrations.destination.record_buffer;
 import io.airbyte.commons.functional.CheckedBiConsumer;
 import io.airbyte.protocol.models.v0.AirbyteStreamNameNamespacePair;
 
+@FunctionalInterface
 public interface FlushBufferFunction extends CheckedBiConsumer<AirbyteStreamNameNamespacePair, SerializableBuffer, Exception> {
 
   @Override
-  void accept(AirbyteStreamNameNamespacePair airbyteStreamNameNamespacePair, SerializableBuffer serializableBuffer) throws Exception;
+  void accept(AirbyteStreamNameNamespacePair streamName, SerializableBuffer buffer) throws Exception;
 }

--- a/airbyte-integrations/bases/base-java/src/main/java/io/airbyte/integrations/destination/record_buffer/FlushBufferFunction.java
+++ b/airbyte-integrations/bases/base-java/src/main/java/io/airbyte/integrations/destination/record_buffer/FlushBufferFunction.java
@@ -1,0 +1,10 @@
+package io.airbyte.integrations.destination.record_buffer;
+
+import io.airbyte.commons.functional.CheckedBiConsumer;
+import io.airbyte.protocol.models.v0.AirbyteStreamNameNamespacePair;
+
+public interface FlushBufferFunction extends CheckedBiConsumer<AirbyteStreamNameNamespacePair, SerializableBuffer, Exception> {
+
+  @Override
+  void accept(AirbyteStreamNameNamespacePair airbyteStreamNameNamespacePair, SerializableBuffer serializableBuffer) throws Exception;
+}

--- a/airbyte-integrations/bases/base-java/src/main/java/io/airbyte/integrations/destination/record_buffer/FlushBufferFunction.java
+++ b/airbyte-integrations/bases/base-java/src/main/java/io/airbyte/integrations/destination/record_buffer/FlushBufferFunction.java
@@ -1,3 +1,7 @@
+/*
+ * Copyright (c) 2023 Airbyte, Inc., all rights reserved.
+ */
+
 package io.airbyte.integrations.destination.record_buffer;
 
 import io.airbyte.commons.functional.CheckedBiConsumer;
@@ -8,4 +12,5 @@ public interface FlushBufferFunction extends CheckedBiConsumer<AirbyteStreamName
 
   @Override
   void accept(AirbyteStreamNameNamespacePair streamName, SerializableBuffer buffer) throws Exception;
+
 }

--- a/airbyte-integrations/bases/base-java/src/main/java/io/airbyte/integrations/destination/record_buffer/InMemoryRecordBufferingStrategy.java
+++ b/airbyte-integrations/bases/base-java/src/main/java/io/airbyte/integrations/destination/record_buffer/InMemoryRecordBufferingStrategy.java
@@ -106,8 +106,8 @@ public class InMemoryRecordBufferingStrategy implements BufferingStrategy {
   }
 
   /**
-   * After marking states as committed, return the state message to platform then clear state messages to avoid resending the same state message to
-   * the platform.
+   * After marking states as committed, return the state message to platform then clear state messages
+   * to avoid resending the same state message to the platform.
    */
   private void markStatesAsFlushedToDestination() {
     stateManager.markPendingAsCommitted();

--- a/airbyte-integrations/bases/base-java/src/main/java/io/airbyte/integrations/destination/record_buffer/SerializedBufferingStrategy.java
+++ b/airbyte-integrations/bases/base-java/src/main/java/io/airbyte/integrations/destination/record_buffer/SerializedBufferingStrategy.java
@@ -7,6 +7,7 @@ package io.airbyte.integrations.destination.record_buffer;
 import io.airbyte.commons.functional.CheckedBiConsumer;
 import io.airbyte.commons.functional.CheckedBiFunction;
 import io.airbyte.commons.string.Strings;
+import io.airbyte.integrations.destination.dest_state_lifecycle_manager.DefaultDestStateLifecycleManager;
 import io.airbyte.protocol.models.v0.AirbyteMessage;
 import io.airbyte.protocol.models.v0.AirbyteStreamNameNamespacePair;
 import io.airbyte.protocol.models.v0.ConfiguredAirbyteCatalog;
@@ -16,6 +17,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.Map.Entry;
 import java.util.Optional;
+import java.util.function.Consumer;
 import org.apache.commons.io.FileUtils;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -34,10 +36,12 @@ public class SerializedBufferingStrategy implements BufferingStrategy {
 
   private final CheckedBiFunction<AirbyteStreamNameNamespacePair, ConfiguredAirbyteCatalog, SerializableBuffer, Exception> onCreateBuffer;
   private final CheckedBiConsumer<AirbyteStreamNameNamespacePair, SerializableBuffer, Exception> onStreamFlush;
+  private final DefaultDestStateLifecycleManager stateManager;
 
   private Map<AirbyteStreamNameNamespacePair, SerializableBuffer> allBuffers = new HashMap<>();
   private long totalBufferSizeInBytes;
   private final ConfiguredAirbyteCatalog catalog;
+  private final Consumer<AirbyteMessage> outputRecordCollector;
 
   /**
    * Creates instance of Serialized Buffering Strategy used to handle the logic of flushing buffer
@@ -49,11 +53,14 @@ public class SerializedBufferingStrategy implements BufferingStrategy {
    */
   public SerializedBufferingStrategy(final CheckedBiFunction<AirbyteStreamNameNamespacePair, ConfiguredAirbyteCatalog, SerializableBuffer, Exception> onCreateBuffer,
                                      final ConfiguredAirbyteCatalog catalog,
-                                     final CheckedBiConsumer<AirbyteStreamNameNamespacePair, SerializableBuffer, Exception> onStreamFlush) {
+                                     final CheckedBiConsumer<AirbyteStreamNameNamespacePair, SerializableBuffer, Exception> onStreamFlush,
+                                     final Consumer<AirbyteMessage> outputRecordCollector) {
     this.onCreateBuffer = onCreateBuffer;
     this.catalog = catalog;
     this.onStreamFlush = onStreamFlush;
+    this.outputRecordCollector = outputRecordCollector;
     this.totalBufferSizeInBytes = 0;
+    this.stateManager = new DefaultDestStateLifecycleManager();
   }
 
   /**
@@ -72,30 +79,21 @@ public class SerializedBufferingStrategy implements BufferingStrategy {
      * Creates a new buffer for each stream if buffers do not already exist, else return already
      * computed buffer
      */
-    final SerializableBuffer streamBuffer = allBuffers.computeIfAbsent(stream, k -> {
-      LOGGER.info("Starting a new buffer for stream {} (current state: {} in {} buffers)",
-          stream.getName(),
-          FileUtils.byteCountToDisplaySize(totalBufferSizeInBytes),
-          allBuffers.size());
-      try {
-        return onCreateBuffer.apply(stream, catalog);
-      } catch (final Exception e) {
-        LOGGER.error("Failed to create a new buffer for stream {}", stream.getName(), e);
-        throw new RuntimeException(e);
-      }
-    });
+    final SerializableBuffer streamBuffer = getBufferForStream(stream);
     if (streamBuffer == null) {
       throw new RuntimeException(String.format("Failed to create/get streamBuffer for stream %s.%s", stream.getNamespace(), stream.getName()));
     }
+
     final long actualMessageSizeInBytes = streamBuffer.accept(message.getRecord());
+
     totalBufferSizeInBytes += actualMessageSizeInBytes;
     // Flushes buffer when either the buffer was completely filled or only a single stream was filled
     if (totalBufferSizeInBytes >= streamBuffer.getMaxTotalBufferSizeInBytes()
         || allBuffers.size() >= streamBuffer.getMaxConcurrentStreamsInBuffer()) {
-      flushAll();
+      flushAllStreams();
       flushed = Optional.of(BufferFlushType.FLUSH_ALL);
     } else if (streamBuffer.getByteCount() >= streamBuffer.getMaxPerStreamBufferSizeInBytes()) {
-      flushWriter(stream, streamBuffer);
+      flushSingleStream(stream, streamBuffer);
       /*
        * Note: This branch is needed to indicate to the {@link DefaultDestStateLifeCycleManager} that an
        * individual stream was flushed, there is no guarantee that it will flush records in the same order
@@ -116,32 +114,64 @@ public class SerializedBufferingStrategy implements BufferingStrategy {
     return flushed;
   }
 
+  private SerializableBuffer getBufferForStream(final AirbyteStreamNameNamespacePair stream) {
+    return allBuffers.computeIfAbsent(stream, k -> {
+      LOGGER.info("Starting a new buffer for stream {} (current state: {} in {} buffers)",
+          stream.getName(),
+          FileUtils.byteCountToDisplaySize(totalBufferSizeInBytes),
+          allBuffers.size());
+      try {
+        return onCreateBuffer.apply(stream, catalog);
+      } catch (final Exception e) {
+        LOGGER.error("Failed to create a new buffer for stream {}", stream.getName(), e);
+        throw new RuntimeException(e);
+      }
+    });
+  }
+
   @Override
-  public void flushWriter(final AirbyteStreamNameNamespacePair stream, final SerializableBuffer writer) throws Exception {
+  public void flushSingleStream(final AirbyteStreamNameNamespacePair stream, final SerializableBuffer writer) throws Exception {
     LOGGER.info("Flushing buffer of stream {} ({})", stream.getName(), FileUtils.byteCountToDisplaySize(writer.getByteCount()));
     onStreamFlush.accept(stream, writer);
+    markStatesAsFlushedToDestination();
     totalBufferSizeInBytes -= writer.getByteCount();
     allBuffers.remove(stream);
     LOGGER.info("Flushing completed for {}", stream.getName());
   }
 
   @Override
-  public void flushAll() throws Exception {
+  public void flushAllStreams() throws Exception {
     LOGGER.info("Flushing all {} current buffers ({} in total)", allBuffers.size(), FileUtils.byteCountToDisplaySize(totalBufferSizeInBytes));
     for (final Entry<AirbyteStreamNameNamespacePair, SerializableBuffer> entry : allBuffers.entrySet()) {
       LOGGER.info("Flushing buffer of stream {} ({})", entry.getKey().getName(), FileUtils.byteCountToDisplaySize(entry.getValue().getByteCount()));
       onStreamFlush.accept(entry.getKey(), entry.getValue());
       LOGGER.info("Flushing completed for {}", entry.getKey().getName());
     }
+    markStatesAsFlushedToDestination();
     close();
     clear();
     totalBufferSizeInBytes = 0;
+  }
+
+  /**
+   * After marking states as committed, return the state message to platform then clear state messages to avoid resending the same state message to
+   * the platform.
+   */
+  private void markStatesAsFlushedToDestination() {
+    stateManager.markPendingAsCommitted();
+    stateManager.listCommitted().forEach(outputRecordCollector);
+    stateManager.clearCommitted();
   }
 
   @Override
   public void clear() throws Exception {
     LOGGER.debug("Reset all buffers");
     allBuffers = new HashMap<>();
+  }
+
+  @Override
+  public void addStateMessage(final AirbyteMessage message) {
+    stateManager.addState(message);
   }
 
   @Override

--- a/airbyte-integrations/bases/base-java/src/main/java/io/airbyte/integrations/destination/record_buffer/SerializedBufferingStrategy.java
+++ b/airbyte-integrations/bases/base-java/src/main/java/io/airbyte/integrations/destination/record_buffer/SerializedBufferingStrategy.java
@@ -154,8 +154,8 @@ public class SerializedBufferingStrategy implements BufferingStrategy {
   }
 
   /**
-   * After marking states as committed, return the state message to platform then clear state messages to avoid resending the same state message to
-   * the platform.
+   * After marking states as committed, return the state message to platform then clear state messages
+   * to avoid resending the same state message to the platform.
    */
   private void markStatesAsFlushedToDestination() {
     stateManager.markPendingAsCommitted();

--- a/airbyte-integrations/bases/base-java/src/main/java/io/airbyte/integrations/destination/record_buffer/SerializedBufferingStrategy.java
+++ b/airbyte-integrations/bases/base-java/src/main/java/io/airbyte/integrations/destination/record_buffer/SerializedBufferingStrategy.java
@@ -160,7 +160,8 @@ public class SerializedBufferingStrategy implements BufferingStrategy {
   }
 
   /**
-   * Get the states that will be flushed to the destination. Callers will pass this list to reportStatesAsFlushed() once completed.
+   * Get the states that will be flushed to the destination. Callers will pass this list to
+   * reportStatesAsFlushed() once completed.
    *
    * @return Queue of AirbyteMessage state messages
    */

--- a/airbyte-integrations/bases/base-java/src/main/java/io/airbyte/integrations/destination/record_buffer/SerializedBufferingStrategy.java
+++ b/airbyte-integrations/bases/base-java/src/main/java/io/airbyte/integrations/destination/record_buffer/SerializedBufferingStrategy.java
@@ -4,7 +4,6 @@
 
 package io.airbyte.integrations.destination.record_buffer;
 
-import io.airbyte.commons.functional.CheckedBiConsumer;
 import io.airbyte.commons.functional.CheckedBiFunction;
 import io.airbyte.commons.string.Strings;
 import io.airbyte.integrations.destination.dest_state_lifecycle_manager.DefaultDestStateLifecycleManager;
@@ -35,7 +34,7 @@ public class SerializedBufferingStrategy implements BufferingStrategy {
   private static final Logger LOGGER = LoggerFactory.getLogger(SerializedBufferingStrategy.class);
 
   private final CheckedBiFunction<AirbyteStreamNameNamespacePair, ConfiguredAirbyteCatalog, SerializableBuffer, Exception> onCreateBuffer;
-  private final CheckedBiConsumer<AirbyteStreamNameNamespacePair, SerializableBuffer, Exception> onStreamFlush;
+  private final FlushBufferFunction onStreamFlush;
   private final DefaultDestStateLifecycleManager stateManager;
 
   private Map<AirbyteStreamNameNamespacePair, SerializableBuffer> allBuffers = new HashMap<>();
@@ -53,7 +52,7 @@ public class SerializedBufferingStrategy implements BufferingStrategy {
    */
   public SerializedBufferingStrategy(final CheckedBiFunction<AirbyteStreamNameNamespacePair, ConfiguredAirbyteCatalog, SerializableBuffer, Exception> onCreateBuffer,
                                      final ConfiguredAirbyteCatalog catalog,
-                                     final CheckedBiConsumer<AirbyteStreamNameNamespacePair, SerializableBuffer, Exception> onStreamFlush,
+                                     final FlushBufferFunction onStreamFlush,
                                      final Consumer<AirbyteMessage> outputRecordCollector) {
     this.onCreateBuffer = onCreateBuffer;
     this.catalog = catalog;

--- a/airbyte-integrations/bases/base-java/src/test/java/io/airbyte/integrations/destination/record_buffer/InMemoryRecordBufferingStrategyTest.java
+++ b/airbyte-integrations/bases/base-java/src/test/java/io/airbyte/integrations/destination/record_buffer/InMemoryRecordBufferingStrategyTest.java
@@ -19,6 +19,7 @@ import io.airbyte.protocol.models.v0.AirbyteRecordMessage;
 import io.airbyte.protocol.models.v0.AirbyteStreamNameNamespacePair;
 import java.util.List;
 import java.util.Optional;
+import java.util.function.Consumer;
 import org.junit.jupiter.api.Test;
 
 public class InMemoryRecordBufferingStrategyTest {
@@ -31,9 +32,12 @@ public class InMemoryRecordBufferingStrategyTest {
   @SuppressWarnings("unchecked")
   private final RecordWriter<AirbyteRecordMessage> recordWriter = mock(RecordWriter.class);
 
+  @SuppressWarnings("unchecked")
+  private final Consumer<AirbyteMessage> outputRecordCollector = mock(Consumer.class);
+
   @Test
   public void testBuffering() throws Exception {
-    final InMemoryRecordBufferingStrategy buffering = new InMemoryRecordBufferingStrategy(recordWriter, MAX_QUEUE_SIZE_IN_BYTES);
+    final InMemoryRecordBufferingStrategy buffering = new InMemoryRecordBufferingStrategy(recordWriter, MAX_QUEUE_SIZE_IN_BYTES, outputRecordCollector);
     final AirbyteStreamNameNamespacePair stream1 = new AirbyteStreamNameNamespacePair("stream1", "namespace");
     final AirbyteStreamNameNamespacePair stream2 = new AirbyteStreamNameNamespacePair("stream2", null);
     final AirbyteMessage message1 = generateMessage(stream1);
@@ -56,7 +60,7 @@ public class InMemoryRecordBufferingStrategyTest {
     buffering.addRecord(stream2, message4);
 
     // force flush to terminate test
-    buffering.flushAll();
+    buffering.flushAllStreams();
     verify(recordWriter, times(1)).accept(stream2, List.of(message3.getRecord(), message4.getRecord()));
   }
 

--- a/airbyte-integrations/bases/base-java/src/test/java/io/airbyte/integrations/destination/record_buffer/InMemoryRecordBufferingStrategyTest.java
+++ b/airbyte-integrations/bases/base-java/src/test/java/io/airbyte/integrations/destination/record_buffer/InMemoryRecordBufferingStrategyTest.java
@@ -37,7 +37,8 @@ public class InMemoryRecordBufferingStrategyTest {
 
   @Test
   public void testBuffering() throws Exception {
-    final InMemoryRecordBufferingStrategy buffering = new InMemoryRecordBufferingStrategy(recordWriter, MAX_QUEUE_SIZE_IN_BYTES, outputRecordCollector);
+    final InMemoryRecordBufferingStrategy buffering =
+        new InMemoryRecordBufferingStrategy(recordWriter, MAX_QUEUE_SIZE_IN_BYTES, outputRecordCollector);
     final AirbyteStreamNameNamespacePair stream1 = new AirbyteStreamNameNamespacePair("stream1", "namespace");
     final AirbyteStreamNameNamespacePair stream2 = new AirbyteStreamNameNamespacePair("stream2", null);
     final AirbyteMessage message1 = generateMessage(stream1);

--- a/airbyte-integrations/bases/base-java/src/test/java/io/airbyte/integrations/destination/record_buffer/SerializedBufferingStrategyTest.java
+++ b/airbyte-integrations/bases/base-java/src/test/java/io/airbyte/integrations/destination/record_buffer/SerializedBufferingStrategyTest.java
@@ -15,7 +15,6 @@ import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
 import com.fasterxml.jackson.databind.JsonNode;
-import io.airbyte.commons.functional.CheckedBiConsumer;
 import io.airbyte.commons.functional.CheckedBiFunction;
 import io.airbyte.commons.json.Jsons;
 import io.airbyte.protocol.models.v0.AirbyteMessage;
@@ -41,9 +40,7 @@ public class SerializedBufferingStrategyTest {
   private static final long MAX_PER_STREAM_BUFFER_SIZE_BYTES = 21L;
 
   private final ConfiguredAirbyteCatalog catalog = mock(ConfiguredAirbyteCatalog.class);
-  @SuppressWarnings("unchecked")
-  private final CheckedBiConsumer<AirbyteStreamNameNamespacePair, SerializableBuffer, Exception> perStreamFlushHook =
-      mock(CheckedBiConsumer.class);
+  private final FlushBufferFunction perStreamFlushHook = mock(FlushBufferFunction.class);
 
   private final SerializableBuffer recordWriter1 = mock(SerializableBuffer.class);
   private final SerializableBuffer recordWriter2 = mock(SerializableBuffer.class);

--- a/airbyte-integrations/bases/base-java/src/test/java/io/airbyte/integrations/destination/record_buffer/SerializedBufferingStrategyTest.java
+++ b/airbyte-integrations/bases/base-java/src/test/java/io/airbyte/integrations/destination/record_buffer/SerializedBufferingStrategyTest.java
@@ -15,7 +15,6 @@ import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
 import com.fasterxml.jackson.databind.JsonNode;
-import io.airbyte.commons.functional.CheckedBiFunction;
 import io.airbyte.commons.json.Jsons;
 import io.airbyte.protocol.models.v0.AirbyteMessage;
 import io.airbyte.protocol.models.v0.AirbyteRecordMessage;
@@ -211,7 +210,7 @@ public class SerializedBufferingStrategyTest {
         .withData(MESSAGE_DATA));
   }
 
-  private CheckedBiFunction<AirbyteStreamNameNamespacePair, ConfiguredAirbyteCatalog, SerializableBuffer, Exception> onCreateBufferFunction() {
+  private CreateBufferFunction onCreateBufferFunction() {
     return (stream, catalog) -> switch (stream.getName()) {
       case STREAM_1 -> recordWriter1;
       case STREAM_2 -> recordWriter2;

--- a/airbyte-integrations/bases/base-java/src/test/java/io/airbyte/integrations/destination/record_buffer/SerializedBufferingStrategyTest.java
+++ b/airbyte-integrations/bases/base-java/src/test/java/io/airbyte/integrations/destination/record_buffer/SerializedBufferingStrategyTest.java
@@ -71,7 +71,8 @@ public class SerializedBufferingStrategyTest {
 
   @Test
   public void testPerStreamThresholdFlush() throws Exception {
-    final SerializedBufferingStrategy buffering = new SerializedBufferingStrategy(onCreateBufferFunction(), catalog, perStreamFlushHook, outputRecordCollector);
+    final SerializedBufferingStrategy buffering =
+        new SerializedBufferingStrategy(onCreateBufferFunction(), catalog, perStreamFlushHook, outputRecordCollector);
     final AirbyteStreamNameNamespacePair stream1 = new AirbyteStreamNameNamespacePair(STREAM_1, "namespace");
     final AirbyteStreamNameNamespacePair stream2 = new AirbyteStreamNameNamespacePair(STREAM_2, null);
     // To test per stream threshold, we are sending multiple test messages on a single stream
@@ -114,7 +115,8 @@ public class SerializedBufferingStrategyTest {
 
   @Test
   public void testTotalStreamThresholdFlush() throws Exception {
-    final SerializedBufferingStrategy buffering = new SerializedBufferingStrategy(onCreateBufferFunction(), catalog, perStreamFlushHook, outputRecordCollector);
+    final SerializedBufferingStrategy buffering =
+        new SerializedBufferingStrategy(onCreateBufferFunction(), catalog, perStreamFlushHook, outputRecordCollector);
     final AirbyteStreamNameNamespacePair stream1 = new AirbyteStreamNameNamespacePair(STREAM_1, "namespace");
     final AirbyteStreamNameNamespacePair stream2 = new AirbyteStreamNameNamespacePair(STREAM_2, "namespace");
     final AirbyteStreamNameNamespacePair stream3 = new AirbyteStreamNameNamespacePair(STREAM_3, "namespace");
@@ -160,7 +162,8 @@ public class SerializedBufferingStrategyTest {
 
   @Test
   public void testConcurrentStreamThresholdFlush() throws Exception {
-    final SerializedBufferingStrategy buffering = new SerializedBufferingStrategy(onCreateBufferFunction(), catalog, perStreamFlushHook, outputRecordCollector);
+    final SerializedBufferingStrategy buffering =
+        new SerializedBufferingStrategy(onCreateBufferFunction(), catalog, perStreamFlushHook, outputRecordCollector);
     final AirbyteStreamNameNamespacePair stream1 = new AirbyteStreamNameNamespacePair(STREAM_1, "namespace1");
     final AirbyteStreamNameNamespacePair stream2 = new AirbyteStreamNameNamespacePair(STREAM_2, "namespace2");
     final AirbyteStreamNameNamespacePair stream3 = new AirbyteStreamNameNamespacePair(STREAM_3, null);
@@ -202,7 +205,8 @@ public class SerializedBufferingStrategyTest {
 
   @Test
   public void testCreateBufferFailure() {
-    final SerializedBufferingStrategy buffering = new SerializedBufferingStrategy(onCreateBufferFunction(), catalog, perStreamFlushHook, outputRecordCollector);
+    final SerializedBufferingStrategy buffering =
+        new SerializedBufferingStrategy(onCreateBufferFunction(), catalog, perStreamFlushHook, outputRecordCollector);
     final AirbyteStreamNameNamespacePair stream = new AirbyteStreamNameNamespacePair("unknown_stream", "namespace1");
     assertThrows(RuntimeException.class, () -> buffering.addRecord(stream, generateMessage(stream)));
   }

--- a/airbyte-integrations/connectors/destination-bigquery/src/main/java/io/airbyte/integrations/destination/bigquery/BigQueryAvroSerializedBuffer.java
+++ b/airbyte-integrations/connectors/destination-bigquery/src/main/java/io/airbyte/integrations/destination/bigquery/BigQueryAvroSerializedBuffer.java
@@ -5,16 +5,14 @@
 package io.airbyte.integrations.destination.bigquery;
 
 import com.fasterxml.jackson.databind.JsonNode;
-import io.airbyte.commons.functional.CheckedBiFunction;
 import io.airbyte.integrations.destination.bigquery.formatter.BigQueryRecordFormatter;
 import io.airbyte.integrations.destination.record_buffer.BufferStorage;
-import io.airbyte.integrations.destination.record_buffer.SerializableBuffer;
+import io.airbyte.integrations.destination.record_buffer.CreateBufferFunction;
 import io.airbyte.integrations.destination.s3.avro.AvroSerializedBuffer;
 import io.airbyte.integrations.destination.s3.avro.S3AvroFormatConfig;
 import io.airbyte.protocol.models.v0.AirbyteRecordMessage;
 import io.airbyte.protocol.models.v0.AirbyteStream;
 import io.airbyte.protocol.models.v0.AirbyteStreamNameNamespacePair;
-import io.airbyte.protocol.models.v0.ConfiguredAirbyteCatalog;
 import java.io.IOException;
 import java.util.concurrent.Callable;
 import java.util.function.BiFunction;
@@ -46,10 +44,10 @@ public class BigQueryAvroSerializedBuffer extends AvroSerializedBuffer {
     dataFileWriter.append(avroRecordFactory.getAvroRecord(recordFormatter.formatRecord(recordMessage)));
   }
 
-  public static CheckedBiFunction<AirbyteStreamNameNamespacePair, ConfiguredAirbyteCatalog, SerializableBuffer, Exception> createFunction(final S3AvroFormatConfig config,
-                                                                                                                                          final Function<JsonNode, BigQueryRecordFormatter> recordFormatterCreator,
-                                                                                                                                          final BiFunction<BigQueryRecordFormatter, AirbyteStreamNameNamespacePair, Schema> schemaCreator,
-                                                                                                                                          final Callable<BufferStorage> createStorageFunction) {
+  public static CreateBufferFunction createFunction(final S3AvroFormatConfig config,
+                                                    final Function<JsonNode, BigQueryRecordFormatter> recordFormatterCreator,
+                                                    final BiFunction<BigQueryRecordFormatter, AirbyteStreamNameNamespacePair, Schema> schemaCreator,
+                                                    final Callable<BufferStorage> createStorageFunction) {
     final CodecFactory codecFactory = config.getCodecFactory();
     return (pair, catalog) -> {
       final AirbyteStream stream = catalog.getStreams()

--- a/airbyte-integrations/connectors/destination-bigquery/src/main/java/io/airbyte/integrations/destination/bigquery/BigQueryDestination.java
+++ b/airbyte-integrations/connectors/destination-bigquery/src/main/java/io/airbyte/integrations/destination/bigquery/BigQueryDestination.java
@@ -16,7 +16,6 @@ import com.google.cloud.storage.Storage;
 import com.google.cloud.storage.StorageOptions;
 import com.google.common.base.Charsets;
 import io.airbyte.commons.exceptions.ConfigErrorException;
-import io.airbyte.commons.functional.CheckedBiFunction;
 import io.airbyte.commons.json.Jsons;
 import io.airbyte.integrations.BaseConnector;
 import io.airbyte.integrations.base.AirbyteMessageConsumer;
@@ -36,8 +35,8 @@ import io.airbyte.integrations.destination.gcs.GcsDestinationConfig;
 import io.airbyte.integrations.destination.gcs.GcsNameTransformer;
 import io.airbyte.integrations.destination.gcs.GcsStorageOperations;
 import io.airbyte.integrations.destination.gcs.util.GcsUtils;
+import io.airbyte.integrations.destination.record_buffer.CreateBufferFunction;
 import io.airbyte.integrations.destination.record_buffer.FileBuffer;
-import io.airbyte.integrations.destination.record_buffer.SerializableBuffer;
 import io.airbyte.integrations.destination.s3.avro.S3AvroFormatConfig;
 import io.airbyte.protocol.models.v0.AirbyteConnectionStatus;
 import io.airbyte.protocol.models.v0.AirbyteConnectionStatus.Status;
@@ -305,7 +304,7 @@ public class BigQueryDestination extends BaseConnector implements Destination {
         keepStagingFiles);
     final S3AvroFormatConfig avroFormatConfig = (S3AvroFormatConfig) gcsConfig.getFormatConfig();
     final Function<JsonNode, BigQueryRecordFormatter> recordFormatterCreator = getRecordFormatterCreator(namingResolver);
-    final CheckedBiFunction<AirbyteStreamNameNamespacePair, ConfiguredAirbyteCatalog, SerializableBuffer, Exception> onCreateBuffer =
+    final CreateBufferFunction onCreateBuffer =
         BigQueryAvroSerializedBuffer.createFunction(
             avroFormatConfig,
             recordFormatterCreator,

--- a/airbyte-integrations/connectors/destination-bigquery/src/main/java/io/airbyte/integrations/destination/bigquery/BigQueryStagingConsumerFactory.java
+++ b/airbyte-integrations/connectors/destination-bigquery/src/main/java/io/airbyte/integrations/destination/bigquery/BigQueryStagingConsumerFactory.java
@@ -8,13 +8,13 @@ import com.fasterxml.jackson.databind.JsonNode;
 import com.google.common.base.Functions;
 import com.google.common.base.Preconditions;
 import io.airbyte.commons.concurrency.VoidCallable;
-import io.airbyte.commons.functional.CheckedBiConsumer;
 import io.airbyte.commons.functional.CheckedBiFunction;
 import io.airbyte.commons.functional.CheckedConsumer;
 import io.airbyte.commons.json.Jsons;
 import io.airbyte.integrations.base.AirbyteMessageConsumer;
 import io.airbyte.integrations.destination.bigquery.formatter.BigQueryRecordFormatter;
 import io.airbyte.integrations.destination.buffered_stream_consumer.BufferedStreamConsumer;
+import io.airbyte.integrations.destination.record_buffer.FlushBufferFunction;
 import io.airbyte.integrations.destination.record_buffer.SerializableBuffer;
 import io.airbyte.integrations.destination.record_buffer.SerializedBufferingStrategy;
 import io.airbyte.protocol.models.v0.AirbyteMessage;
@@ -140,9 +140,9 @@ public class BigQueryStagingConsumerFactory {
    * @param writeConfigs book keeping configurations for writing and storing state to write records
    * @param catalog configured Airbyte catalog
    */
-  private CheckedBiConsumer<AirbyteStreamNameNamespacePair, SerializableBuffer, Exception> flushBufferFunction(final BigQueryStagingOperations bigQueryGcsOperations,
-                                                                                                               final Map<AirbyteStreamNameNamespacePair, BigQueryWriteConfig> writeConfigs,
-                                                                                                               final ConfiguredAirbyteCatalog catalog) {
+  private FlushBufferFunction flushBufferFunction(final BigQueryStagingOperations bigQueryGcsOperations,
+                                                  final Map<AirbyteStreamNameNamespacePair, BigQueryWriteConfig> writeConfigs,
+                                                  final ConfiguredAirbyteCatalog catalog) {
     return (pair, writer) -> {
       LOGGER.info("Flushing buffer for stream {} ({}) to staging", pair.getName(), FileUtils.byteCountToDisplaySize(writer.getByteCount()));
       if (!writeConfigs.containsKey(pair)) {

--- a/airbyte-integrations/connectors/destination-bigquery/src/main/java/io/airbyte/integrations/destination/bigquery/BigQueryStagingConsumerFactory.java
+++ b/airbyte-integrations/connectors/destination-bigquery/src/main/java/io/airbyte/integrations/destination/bigquery/BigQueryStagingConsumerFactory.java
@@ -56,12 +56,12 @@ public class BigQueryStagingConsumerFactory {
         targetTableNameTransformer);
 
     return new BufferedStreamConsumer(
-        outputRecordCollector,
         onStartFunction(bigQueryGcsOperations, writeConfigs),
         new SerializedBufferingStrategy(
             onCreateBuffer,
             catalog,
-            flushBufferFunction(bigQueryGcsOperations, writeConfigs, catalog)),
+            flushBufferFunction(bigQueryGcsOperations, writeConfigs, catalog),
+            outputRecordCollector),
         onCloseFunction(bigQueryGcsOperations, writeConfigs),
         catalog,
         json -> true);

--- a/airbyte-integrations/connectors/destination-elasticsearch/src/main/java/io/airbyte/integrations/destination/elasticsearch/ElasticsearchAirbyteMessageConsumerFactory.java
+++ b/airbyte-integrations/connectors/destination-elasticsearch/src/main/java/io/airbyte/integrations/destination/elasticsearch/ElasticsearchAirbyteMessageConsumerFactory.java
@@ -49,9 +49,8 @@ public class ElasticsearchAirbyteMessageConsumerFactory {
                                               final ConfiguredAirbyteCatalog catalog) {
 
     return new BufferedStreamConsumer(
-        outputRecordCollector,
         onStartFunction(connection, writeConfigs),
-        new InMemoryRecordBufferingStrategy(recordWriterFunction(connection, writeConfigs), MAX_BATCH_SIZE_BYTES),
+        new InMemoryRecordBufferingStrategy(recordWriterFunction(connection, writeConfigs), MAX_BATCH_SIZE_BYTES, outputRecordCollector),
         onCloseFunction(connection),
         catalog,
         isValidFunction(connection));
@@ -101,10 +100,10 @@ public class ElasticsearchAirbyteMessageConsumerFactory {
     };
   }
 
-  private static List<String> extractErrorReport(BulkResponse response) {
+  private static List<String> extractErrorReport(final BulkResponse response) {
     final Map<String, ErrorCause> errorResult = new HashMap<>();
     response.items().forEach(item -> {
-      IndexResponseItem index = item.index();
+      final IndexResponseItem index = item.index();
       errorResult.put(index.index(), index.error());
     });
     final List<String> errorReport = new ArrayList<>();

--- a/airbyte-integrations/connectors/destination-jdbc/src/main/java/io/airbyte/integrations/destination/jdbc/JdbcBufferedConsumerFactory.java
+++ b/airbyte-integrations/connectors/destination-jdbc/src/main/java/io/airbyte/integrations/destination/jdbc/JdbcBufferedConsumerFactory.java
@@ -57,9 +57,9 @@ public class JdbcBufferedConsumerFactory {
     final List<WriteConfig> writeConfigs = createWriteConfigs(namingResolver, config, catalog, sqlOperations.isSchemaRequired());
 
     return new BufferedStreamConsumer(
-        outputRecordCollector,
         onStartFunction(database, sqlOperations, writeConfigs),
-        new InMemoryRecordBufferingStrategy(recordWriterFunction(database, sqlOperations, writeConfigs, catalog), DEFAULT_MAX_BATCH_SIZE_BYTES),
+        new InMemoryRecordBufferingStrategy(recordWriterFunction(database, sqlOperations, writeConfigs, catalog), DEFAULT_MAX_BATCH_SIZE_BYTES,
+            outputRecordCollector),
         onCloseFunction(database, sqlOperations, writeConfigs),
         catalog,
         sqlOperations::isValidData);
@@ -193,9 +193,8 @@ public class JdbcBufferedConsumerFactory {
         sqlOperations.dropTableIfExists(database, schemaName, tmpTableName);
       }
       LOGGER.info("Cleaning tmp tables in destination completed.");
-    }
+    };
 
-    ;
   }
 
   private static AirbyteStreamNameNamespacePair toNameNamespacePair(final WriteConfig config) {

--- a/airbyte-integrations/connectors/destination-jdbc/src/main/java/io/airbyte/integrations/destination/jdbc/copy/CopyConsumerFactory.java
+++ b/airbyte-integrations/connectors/destination-jdbc/src/main/java/io/airbyte/integrations/destination/jdbc/copy/CopyConsumerFactory.java
@@ -55,12 +55,12 @@ public class CopyConsumerFactory {
 
     final Map<AirbyteStreamNameNamespacePair, Long> pairToIgnoredRecordCount = new HashMap<>();
     return new BufferedStreamConsumer(
-        outputRecordCollector,
         onStartFunction(pairToIgnoredRecordCount),
         new InMemoryRecordBufferingStrategy(
             recordWriterFunction(pairToCopier, sqlOperations, pairToIgnoredRecordCount),
             removeStagingFilePrinter(pairToCopier),
-            DEFAULT_MAX_BATCH_SIZE_BYTES),
+            DEFAULT_MAX_BATCH_SIZE_BYTES,
+            outputRecordCollector),
         onCloseFunction(pairToCopier, database, sqlOperations, pairToIgnoredRecordCount, dataSource),
         catalog,
         sqlOperations::isValidData);
@@ -93,7 +93,7 @@ public class CopyConsumerFactory {
   private static RecordWriter<AirbyteRecordMessage> recordWriterFunction(final Map<AirbyteStreamNameNamespacePair, StreamCopier> pairToCopier,
                                                                          final SqlOperations sqlOperations,
                                                                          final Map<AirbyteStreamNameNamespacePair, Long> pairToIgnoredRecordCount) {
-    return (AirbyteStreamNameNamespacePair pair, List<AirbyteRecordMessage> records) -> {
+    return (final AirbyteStreamNameNamespacePair pair, final List<AirbyteRecordMessage> records) -> {
       final var fileName = pairToCopier.get(pair).prepareStagingFile();
       for (final AirbyteRecordMessage recordMessage : records) {
         final var id = UUID.randomUUID();
@@ -109,7 +109,7 @@ public class CopyConsumerFactory {
   }
 
   private static CheckAndRemoveRecordWriter removeStagingFilePrinter(final Map<AirbyteStreamNameNamespacePair, StreamCopier> pairToCopier) {
-    return (AirbyteStreamNameNamespacePair pair, String stagingFileName) -> {
+    return (final AirbyteStreamNameNamespacePair pair, final String stagingFileName) -> {
       final String currentFileName = pairToCopier.get(pair).getCurrentFile();
       if (stagingFileName != null && currentFileName != null && !stagingFileName.equals(currentFileName)) {
         pairToCopier.get(pair).closeNonCurrentStagingFileWriters();

--- a/airbyte-integrations/connectors/destination-jdbc/src/main/java/io/airbyte/integrations/destination/staging/StagingConsumerFactory.java
+++ b/airbyte-integrations/connectors/destination-jdbc/src/main/java/io/airbyte/integrations/destination/staging/StagingConsumerFactory.java
@@ -11,7 +11,6 @@ import com.fasterxml.jackson.databind.JsonNode;
 import com.google.common.annotations.VisibleForTesting;
 import com.google.common.base.Preconditions;
 import io.airbyte.commons.exceptions.ConfigErrorException;
-import io.airbyte.commons.functional.CheckedBiConsumer;
 import io.airbyte.commons.functional.CheckedBiFunction;
 import io.airbyte.commons.json.Jsons;
 import io.airbyte.db.jdbc.JdbcDatabase;
@@ -21,6 +20,7 @@ import io.airbyte.integrations.destination.buffered_stream_consumer.BufferedStre
 import io.airbyte.integrations.destination.buffered_stream_consumer.OnCloseFunction;
 import io.airbyte.integrations.destination.buffered_stream_consumer.OnStartFunction;
 import io.airbyte.integrations.destination.jdbc.WriteConfig;
+import io.airbyte.integrations.destination.record_buffer.FlushBufferFunction;
 import io.airbyte.integrations.destination.record_buffer.SerializableBuffer;
 import io.airbyte.integrations.destination.record_buffer.SerializedBufferingStrategy;
 import io.airbyte.protocol.models.v0.AirbyteMessage;
@@ -183,11 +183,10 @@ public class StagingConsumerFactory {
    * @return
    */
   @VisibleForTesting
-  CheckedBiConsumer<AirbyteStreamNameNamespacePair, SerializableBuffer, Exception> flushBufferFunction(
-                                                                                                       final JdbcDatabase database,
-                                                                                                       final StagingOperations stagingOperations,
-                                                                                                       final List<WriteConfig> writeConfigs,
-                                                                                                       final ConfiguredAirbyteCatalog catalog) {
+  FlushBufferFunction flushBufferFunction(final JdbcDatabase database,
+                                          final StagingOperations stagingOperations,
+                                          final List<WriteConfig> writeConfigs,
+                                          final ConfiguredAirbyteCatalog catalog) {
     final Set<WriteConfig> conflictingStreams = new HashSet<>();
     final Map<AirbyteStreamNameNamespacePair, WriteConfig> pairToWriteConfig = new HashMap<>();
     for (final WriteConfig config : writeConfigs) {

--- a/airbyte-integrations/connectors/destination-jdbc/src/main/java/io/airbyte/integrations/destination/staging/StagingConsumerFactory.java
+++ b/airbyte-integrations/connectors/destination-jdbc/src/main/java/io/airbyte/integrations/destination/staging/StagingConsumerFactory.java
@@ -73,12 +73,12 @@ public class StagingConsumerFactory {
                                        final boolean purgeStagingData) {
     final List<WriteConfig> writeConfigs = createWriteConfigs(namingResolver, config, catalog);
     return new BufferedStreamConsumer(
-        outputRecordCollector,
         onStartFunction(database, stagingOperations, writeConfigs),
         new SerializedBufferingStrategy(
             onCreateBuffer,
             catalog,
-            flushBufferFunction(database, stagingOperations, writeConfigs, catalog)),
+            flushBufferFunction(database, stagingOperations, writeConfigs, catalog),
+            outputRecordCollector),
         onCloseFunction(database, stagingOperations, writeConfigs, purgeStagingData),
         catalog,
         stagingOperations::isValidData);

--- a/airbyte-integrations/connectors/destination-jdbc/src/main/java/io/airbyte/integrations/destination/staging/StagingConsumerFactory.java
+++ b/airbyte-integrations/connectors/destination-jdbc/src/main/java/io/airbyte/integrations/destination/staging/StagingConsumerFactory.java
@@ -11,7 +11,6 @@ import com.fasterxml.jackson.databind.JsonNode;
 import com.google.common.annotations.VisibleForTesting;
 import com.google.common.base.Preconditions;
 import io.airbyte.commons.exceptions.ConfigErrorException;
-import io.airbyte.commons.functional.CheckedBiFunction;
 import io.airbyte.commons.json.Jsons;
 import io.airbyte.db.jdbc.JdbcDatabase;
 import io.airbyte.integrations.base.AirbyteMessageConsumer;
@@ -20,8 +19,8 @@ import io.airbyte.integrations.destination.buffered_stream_consumer.BufferedStre
 import io.airbyte.integrations.destination.buffered_stream_consumer.OnCloseFunction;
 import io.airbyte.integrations.destination.buffered_stream_consumer.OnStartFunction;
 import io.airbyte.integrations.destination.jdbc.WriteConfig;
+import io.airbyte.integrations.destination.record_buffer.CreateBufferFunction;
 import io.airbyte.integrations.destination.record_buffer.FlushBufferFunction;
-import io.airbyte.integrations.destination.record_buffer.SerializableBuffer;
 import io.airbyte.integrations.destination.record_buffer.SerializedBufferingStrategy;
 import io.airbyte.protocol.models.v0.AirbyteMessage;
 import io.airbyte.protocol.models.v0.AirbyteStream;
@@ -67,7 +66,7 @@ public class StagingConsumerFactory {
                                        final JdbcDatabase database,
                                        final StagingOperations stagingOperations,
                                        final NamingConventionTransformer namingResolver,
-                                       final CheckedBiFunction<AirbyteStreamNameNamespacePair, ConfiguredAirbyteCatalog, SerializableBuffer, Exception> onCreateBuffer,
+                                       final CreateBufferFunction onCreateBuffer,
                                        final JsonNode config,
                                        final ConfiguredAirbyteCatalog catalog,
                                        final boolean purgeStagingData) {
@@ -206,21 +205,21 @@ public class StagingConsumerFactory {
           conflictingStreams.stream().map(config -> config.getNamespace() + "." + config.getStreamName()).collect(joining(", ")));
       throw new ConfigErrorException(message);
     }
-    return (pair, writer) -> {
-      LOGGER.info("Flushing buffer for stream {} ({}) to staging", pair.getName(), FileUtils.byteCountToDisplaySize(writer.getByteCount()));
-      if (!pairToWriteConfig.containsKey(pair)) {
+    return (streamName, buffer) -> {
+      LOGGER.info("Flushing buffer for stream {} ({}) to staging", streamName.getName(), FileUtils.byteCountToDisplaySize(buffer.getByteCount()));
+      if (!pairToWriteConfig.containsKey(streamName)) {
         throw new IllegalArgumentException(
             String.format("Message contained record from a stream that was not in the catalog. \ncatalog: %s", Jsons.serialize(catalog)));
       }
 
-      final WriteConfig writeConfig = pairToWriteConfig.get(pair);
+      final WriteConfig writeConfig = pairToWriteConfig.get(streamName);
       final String schemaName = writeConfig.getOutputSchemaName();
       final String stageName = stagingOperations.getStageName(schemaName, writeConfig.getStreamName());
       final String stagingPath =
           stagingOperations.getStagingPath(RANDOM_CONNECTION_ID, schemaName, writeConfig.getStreamName(), writeConfig.getWriteDatetime());
-      try (writer) {
-        writer.flush();
-        final String stagedFile = stagingOperations.uploadRecordsToStage(database, writer, schemaName, stageName, stagingPath);
+      try (buffer) {
+        buffer.flush();
+        final String stagedFile = stagingOperations.uploadRecordsToStage(database, buffer, schemaName, stageName, stagingPath);
         copyIntoTableFromStage(database, stageName, stagingPath, List.of(stagedFile), writeConfig.getOutputTableName(), schemaName,
             stagingOperations);
       } catch (final Exception e) {

--- a/airbyte-integrations/connectors/destination-s3-glue/src/main/java/io/airbyte/integrations/destination/s3_glue/S3GlueConsumerFactory.java
+++ b/airbyte-integrations/connectors/destination-s3-glue/src/main/java/io/airbyte/integrations/destination/s3_glue/S3GlueConsumerFactory.java
@@ -7,7 +7,6 @@ package io.airbyte.integrations.destination.s3_glue;
 import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.node.ObjectNode;
 import com.google.common.base.Preconditions;
-import io.airbyte.commons.functional.CheckedBiConsumer;
 import io.airbyte.commons.functional.CheckedBiFunction;
 import io.airbyte.commons.json.Jsons;
 import io.airbyte.integrations.base.AirbyteMessageConsumer;
@@ -16,6 +15,7 @@ import io.airbyte.integrations.destination.NamingConventionTransformer;
 import io.airbyte.integrations.destination.buffered_stream_consumer.BufferedStreamConsumer;
 import io.airbyte.integrations.destination.buffered_stream_consumer.OnCloseFunction;
 import io.airbyte.integrations.destination.buffered_stream_consumer.OnStartFunction;
+import io.airbyte.integrations.destination.record_buffer.FlushBufferFunction;
 import io.airbyte.integrations.destination.record_buffer.SerializableBuffer;
 import io.airbyte.integrations.destination.record_buffer.SerializedBufferingStrategy;
 import io.airbyte.integrations.destination.s3.BlobStorageOperations;
@@ -123,9 +123,9 @@ public class S3GlueConsumerFactory {
     return new AirbyteStreamNameNamespacePair(config.getStreamName(), config.getNamespace());
   }
 
-  private CheckedBiConsumer<AirbyteStreamNameNamespacePair, SerializableBuffer, Exception> flushBufferFunction(final BlobStorageOperations storageOperations,
-                                                                                                               final List<S3GlueWriteConfig> writeConfigs,
-                                                                                                               final ConfiguredAirbyteCatalog catalog) {
+  private FlushBufferFunction flushBufferFunction(final BlobStorageOperations storageOperations,
+                                                  final List<S3GlueWriteConfig> writeConfigs,
+                                                  final ConfiguredAirbyteCatalog catalog) {
     final Map<AirbyteStreamNameNamespacePair, WriteConfig> pairToWriteConfig =
         writeConfigs.stream()
             .collect(Collectors.toUnmodifiableMap(S3GlueConsumerFactory::toNameNamespacePair, Function.identity()));

--- a/airbyte-integrations/connectors/destination-s3-glue/src/main/java/io/airbyte/integrations/destination/s3_glue/S3GlueConsumerFactory.java
+++ b/airbyte-integrations/connectors/destination-s3-glue/src/main/java/io/airbyte/integrations/destination/s3_glue/S3GlueConsumerFactory.java
@@ -7,7 +7,6 @@ package io.airbyte.integrations.destination.s3_glue;
 import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.node.ObjectNode;
 import com.google.common.base.Preconditions;
-import io.airbyte.commons.functional.CheckedBiFunction;
 import io.airbyte.commons.json.Jsons;
 import io.airbyte.integrations.base.AirbyteMessageConsumer;
 import io.airbyte.integrations.base.JavaBaseConstants;
@@ -15,8 +14,8 @@ import io.airbyte.integrations.destination.NamingConventionTransformer;
 import io.airbyte.integrations.destination.buffered_stream_consumer.BufferedStreamConsumer;
 import io.airbyte.integrations.destination.buffered_stream_consumer.OnCloseFunction;
 import io.airbyte.integrations.destination.buffered_stream_consumer.OnStartFunction;
+import io.airbyte.integrations.destination.record_buffer.CreateBufferFunction;
 import io.airbyte.integrations.destination.record_buffer.FlushBufferFunction;
-import io.airbyte.integrations.destination.record_buffer.SerializableBuffer;
 import io.airbyte.integrations.destination.record_buffer.SerializedBufferingStrategy;
 import io.airbyte.integrations.destination.s3.BlobStorageOperations;
 import io.airbyte.integrations.destination.s3.S3DestinationConfig;
@@ -48,7 +47,7 @@ public class S3GlueConsumerFactory {
                                        final BlobStorageOperations storageOperations,
                                        final MetastoreOperations metastoreOperations,
                                        final NamingConventionTransformer namingResolver,
-                                       final CheckedBiFunction<AirbyteStreamNameNamespacePair, ConfiguredAirbyteCatalog, SerializableBuffer, Exception> onCreateBuffer,
+                                       final CreateBufferFunction onCreateBuffer,
                                        final S3DestinationConfig s3Config,
                                        final GlueDestinationConfig glueConfig,
                                        final ConfiguredAirbyteCatalog catalog) {
@@ -130,18 +129,18 @@ public class S3GlueConsumerFactory {
         writeConfigs.stream()
             .collect(Collectors.toUnmodifiableMap(S3GlueConsumerFactory::toNameNamespacePair, Function.identity()));
 
-    return (pair, writer) -> {
-      LOGGER.info("Flushing buffer for stream {} ({}) to storage", pair.getName(), FileUtils.byteCountToDisplaySize(writer.getByteCount()));
-      if (!pairToWriteConfig.containsKey(pair)) {
+    return (streamName, buffer) -> {
+      LOGGER.info("Flushing buffer for stream {} ({}) to storage", streamName.getName(), FileUtils.byteCountToDisplaySize(buffer.getByteCount()));
+      if (!pairToWriteConfig.containsKey(streamName)) {
         throw new IllegalArgumentException(
-            String.format("Message contained record from a stream %s that was not in the catalog. \ncatalog: %s", pair, Jsons.serialize(catalog)));
+            String.format("Message contained record from a stream %s that was not in the catalog. \ncatalog: %s", streamName, Jsons.serialize(catalog)));
       }
 
-      final WriteConfig writeConfig = pairToWriteConfig.get(pair);
-      try (writer) {
-        writer.flush();
+      final WriteConfig writeConfig = pairToWriteConfig.get(streamName);
+      try (buffer) {
+        buffer.flush();
         writeConfig.addStoredFile(storageOperations.uploadRecordsToBucket(
-            writer,
+            buffer,
             writeConfig.getNamespace(),
             writeConfig.getStreamName(),
             writeConfig.getFullOutputPath()));


### PR DESCRIPTION


## What
*Refactor some of the buffering/flushing code prior to introducing async flush

Move the tracking of state and writing of flush results to the BufferingStrategy impls.

This refactor will allow us to better manage what the state is at the time of a flush. When flushes are moved to async behavior (coming soon), it will be helpful to track the last known state at that point.

## Recommended reading order
* recommend reviewing each commit one at a time.

## 🚨 User Impact 🚨
*Are there any breaking changes? What is the end result perceived by the user?*
Not expecting any user impact

*For connector PRs, use this section to explain which type of semantic versioning bump occurs as a result of the changes. Refer to our [Semantic Versioning for Connectors](https://docs.airbyte.com/contributing-to-airbyte/semantic-versioning-for-connectors) guidelines for more information. **Breaking changes to connectors must be documented by an Airbyte engineer (PR author, or reviewer for community PRs) by using the [Breaking Change Release Playbook](https://docs.google.com/document/d/1VYQggHbL_PN0dDDu7rCyzBLGRtX-R3cpwXaY8QxEgzw/edit).***

*If there are breaking changes, please merge this PR with the 🚨🚨 emoji so changelog authors can further highlight this if needed.*


## Pre-merge Checklist
*Expand the relevant checklist and delete the others.*

<details><summary><strong>New Connector</strong></summary>

### Community member or Airbyter

- [ ] **Community member?** Grant edit access to maintainers ([instructions](https://docs.github.com/en/github/collaborating-with-pull-requests/working-with-forks/allowing-changes-to-a-pull-request-branch-created-from-a-fork#enabling-repository-maintainer-permissions-on-existing-pull-requests))
- [ ] Secrets in the connector's spec are annotated with `airbyte_secret`
- [ ] Unit & integration tests added and passing. Community members, please provide proof of success locally e.g: screenshot or copy-paste unit, integration, and acceptance test output. To run acceptance tests for a Python connector, follow instructions in the README. For java connectors run `./gradlew :airbyte-integrations:connectors:<name>:integrationTest`.
- [ ] Code reviews completed
- [ ] Connector version is set to `0.0.1`
    - [ ] `Dockerfile` has version `0.0.1`
- [ ] Documentation updated
    - [ ] Connector's `README.md`
    - [ ] Connector's `bootstrap.md`. See [description and examples](https://docs.google.com/document/d/1ypdgmwmEHWv-TrO4_YOQ7pAJGVrMp5BOkEVh831N260/edit?usp=sharing)
    - [ ] `docs/integrations/<source or destination>/<name>.md` including changelog with an entry for the initial version. See changelog [example](https://docs.airbyte.io/integrations/sources/stripe#changelog)
    - [ ] `docs/integrations/README.md`
    - [ ] `airbyte-integrations/builds.md`
- [ ] PR name follows [PR naming conventions](https://docs.airbyte.com/contributing-to-airbyte/issues-and-pull-requests)

### Airbyter

If this is a community PR, the Airbyte engineer reviewing this PR is responsible for the below items.

- [ ] Create a non-forked branch based on this PR and test the below items on it
- [ ] Build is successful
- [ ] If new credentials are required for use in CI, add them to GSM. [Instructions](https://docs.airbyte.io/connector-development#using-credentials-in-ci).
- [ ] [`/test connector=connectors/<name>` command](https://docs.airbyte.io/connector-development#updating-an-existing-connector) is passing
- [ ] New Connector version released on Dockerhub by running the `/publish` command described [here](https://docs.airbyte.io/connector-development#updating-an-existing-connector)
- [ ] After the connector is published, connector added to connector index as described [here](https://docs.airbyte.io/connector-development#publishing-a-connector)
- [ ] Seed specs have been re-generated by building the platform and committing the changes to the seed spec files, as described [here](https://docs.airbyte.io/connector-development#publishing-a-connector)

</details>

<details><summary><strong>Updating a connector</strong></summary>

### Community member or Airbyter

- [ ] Grant edit access to maintainers ([instructions](https://docs.github.com/en/github/collaborating-with-pull-requests/working-with-forks/allowing-changes-to-a-pull-request-branch-created-from-a-fork#enabling-repository-maintainer-permissions-on-existing-pull-requests))
- [ ] Secrets in the connector's spec are annotated with `airbyte_secret`
- [ ] Unit & integration tests added and passing. Community members, please provide proof of success locally e.g: screenshot or copy-paste unit, integration, and acceptance test output. To run acceptance tests for a Python connector, follow instructions in the README. For java connectors run `./gradlew :airbyte-integrations:connectors:<name>:integrationTest`.
- [ ] Code reviews completed
- [ ] Connector version has been incremented
    - [ ] Version has been bumped according to our [Semantic Versioning for Connectors](https://docs.airbyte.com/contributing-to-airbyte/semantic-versioning-for-connectors) guidelines
    - [ ] `Dockerfile` has updated version
- [ ] Documentation updated
    - [ ] Connector's `README.md`
    - [ ] Connector's `bootstrap.md`. See [description and examples](https://docs.google.com/document/d/1ypdgmwmEHWv-TrO4_YOQ7pAJGVrMp5BOkEVh831N260/edit?usp=sharing)
    - [ ] Changelog updated in `docs/integrations/<source or destination>/<name>.md` with an entry for the new version. See changelog [example](https://docs.airbyte.io/integrations/sources/stripe#changelog)

- [ ] PR name follows [PR naming conventions](https://docs.airbyte.com/contributing-to-airbyte/issues-and-pull-requests)

### Airbyter

If this is a community PR, the Airbyte engineer reviewing this PR is responsible for the below items.

- [ ] Create a non-forked branch based on this PR and test the below items on it
- [ ] Build is successful
- [ ] If new credentials are required for use in CI, add them to GSM. [Instructions](https://docs.airbyte.io/connector-development#using-credentials-in-ci).
- [ ] [`/test connector=connectors/<name>` command](https://docs.airbyte.io/connector-development#updating-an-existing-connector) is passing
- [ ] New Connector version released on Dockerhub and connector version bumped by running the `/publish` command described [here](https://docs.airbyte.io/connector-development#updating-an-existing-connector)

</details>

<details><summary><strong>Connector Generator</strong></summary>

- [ ] Issue acceptance criteria met
- [ ] PR name follows [PR naming conventions](https://docs.airbyte.com/contributing-to-airbyte/issues-and-pull-requests)
- [ ] If adding a new generator, add it to the [list of scaffold modules being tested](https://github.com/airbytehq/airbyte/blob/master/airbyte-integrations/connector-templates/generator/build.gradle#L41)
- [ ] The generator test modules (all connectors with `-scaffold` in their name) have been updated with the latest scaffold by running `./gradlew :airbyte-integrations:connector-templates:generator:testScaffoldTemplates` then checking in your changes
- [ ] Documentation which references the generator is updated as needed

</details>
