### PR TITLE
Low-Code CDK: make RecordFilter.filter_records as generator

### DIFF
--- a/airbyte-cdk/python/airbyte_cdk/sources/declarative/extractors/record_filter.py
+++ b/airbyte-cdk/python/airbyte_cdk/sources/declarative/extractors/record_filter.py
@@ -33,4 +33,6 @@ class RecordFilter:
         next_page_token: Optional[Mapping[str, Any]] = None,
     ) -> List[Record]:
         kwargs = {"stream_state": stream_state, "stream_slice": stream_slice, "next_page_token": next_page_token}
-        return [record for record in records if self._filter_interpolator.eval(self.config, record=record, **kwargs)]
+        for record in records:
+            if self._filter_interpolator.eval(self.config, record=record, **kwargs):
+                yield record

--- a/airbyte-cdk/python/unit_tests/sources/declarative/extractors/test_record_filter.py
+++ b/airbyte-cdk/python/unit_tests/sources/declarative/extractors/test_record_filter.py
@@ -52,4 +52,4 @@ def test_record_filter(test_name, filter_template, records, expected_records):
     actual_records = record_filter.filter_records(
         records, stream_state=stream_state, stream_slice=stream_slice, next_page_token=next_page_token
     )
-    assert actual_records == expected_records
+    assert list(actual_records) == expected_records

--- a/airbyte-cdk/python/unit_tests/sources/declarative/extractors/test_record_selector.py
+++ b/airbyte-cdk/python/unit_tests/sources/declarative/extractors/test_record_selector.py
@@ -78,7 +78,7 @@ def test_record_filter(test_name, field_path, filter_template, body, expected_re
     actual_records = record_selector.select_records(
         response=response, stream_state=stream_state, stream_slice=stream_slice, next_page_token=next_page_token
     )
-    assert actual_records == expected_records
+    assert list(actual_records) == expected_records
 
 
 def create_response(body):


### PR DESCRIPTION
This PR Improves this issue: https://github.com/airbytehq/airbyte/pull/22362

## Description

The `source-amplitude` connector's `events` stream returns a large amount of data from the API, which consumes a significant amount of memory. This data is then processed by the `RecordFilter.filter_records` function to produce a new list that duplicates memory usage, causing the connector to consume even more memory before issuing the first record.

## Solution

To improve memory usage and speed up the production of the first record, we can modify `RecordFilter.filter_records` to be a generator instead of returning a list. This will enable the function to yield one record at a time, without having to process the entire dataset at once. By doing so, we can reduce memory consumption and improve the efficiency of the connector.
