### PR TITLE
Group documentation navigation

### DIFF
--- a/docs/operator-guides/security.md
+++ b/docs/operator-guides/security.md
@@ -102,7 +102,7 @@ Only certain Airbyte staff can access Airbyte infrastructure and technical logs 
 
 ### Network security
 
-Depending on your [data residency](https://docs.airbyte.com/cloud/managing-airbyte-cloud#choose-your-default-data-residency) location, you may need to allowlist the following IP addresses to enable access to Airbyte:
+Depending on your [data residency](https://docs.airbyte.com/cloud/managing-airbyte-cloud/manage-data-residency) location, you may need to allowlist the following IP addresses to enable access to Airbyte:
 
 #### United States and Airbyte Default
 

--- a/docs/readme.md
+++ b/docs/readme.md
@@ -6,7 +6,7 @@ Whether you are an Airbyte user or contributor, we have docs for you!
 
 Browse the [connector catalog](https://docs.airbyte.com/integrations/) to find the connector you want. In case the connector is not yet supported on Airbyte Cloud, consider using [Airbyte Open Source](#for-airbyte-open-source-users).
 
-Next, check out the [step-by-step tutorial](https://docs.airbyte.com/cloud/getting-started-with-airbyte-cloud) to sign up for Airbyte Cloud, understand Airbyte [concepts](https://docs.airbyte.com/cloud/core-concepts), and run your first sync. Then learn how to [manage your Airbyte Cloud account](https://docs.airbyte.com/category/managing-airbyte-cloud).
+Next, check out the [step-by-step tutorial](https://docs.airbyte.com/cloud/getting-started-with-airbyte-cloud) to sign up for Airbyte Cloud, understand Airbyte [concepts](https://docs.airbyte.com/cloud/core-concepts), and run your first sync. Then learn how to [use your Airbyte Cloud account](https://docs.airbyte.com/category/using-airbyte-cloud).
 
 ### For Airbyte Open Source users
 

--- a/docusaurus/docusaurus.config.js
+++ b/docusaurus/docusaurus.config.js
@@ -64,7 +64,11 @@ const config = {
                         },
                         {
                             from: '/cloud/managing-airbyte-cloud',
-                            to: '/category/managing-airbyte-cloud',
+                            to: '/category/using-airbyte-cloud',
+                        },
+                        {
+                            from: '/category/managing-airbyte-cloud',
+                            to: '/category/using-airbyte-cloud'
                         },
                         {
                             from: '/cloud/dbt-cloud-integration',

--- a/docusaurus/sidebars.js
+++ b/docusaurus/sidebars.js
@@ -22,6 +22,402 @@ function getSourceConnectors() {
 function getDestinationConnectors() {
     return getFilenamesInDir("integrations/destinations/", destinationDocs, ["readme"]);
 }
+
+const sectionHeader = (title) => ({
+  type: 'html',
+  value: title,
+  className: 'navbar__category',
+});
+
+const buildAConnector = {
+  type: 'category',
+  label: 'Build a Connector',
+  items: [
+    {
+      type: 'doc',
+      label: 'Overview',
+      id: 'connector-development/README',
+    },
+    {
+      type: 'category',
+      label: 'Low-code connector development',
+      items: [
+        'connector-development/config-based/connector-builder-ui',
+        {
+          label: 'Low-code CDK Intro',
+          type: 'doc',
+          id: 'connector-development/config-based/low-code-cdk-overview',
+        },
+        {
+          type: 'category',
+          label: 'Tutorial',
+          items: [
+            'connector-development/config-based/tutorial/getting-started',
+            'connector-development/config-based/tutorial/create-source',
+            'connector-development/config-based/tutorial/install-dependencies',
+            'connector-development/config-based/tutorial/connecting-to-the-API-source',
+            'connector-development/config-based/tutorial/reading-data',
+            'connector-development/config-based/tutorial/incremental-reads',
+            'connector-development/config-based/tutorial/testing',
+          ],
+        },
+        {
+          type: 'category',
+          label: 'Understanding the YAML file',
+          link: {
+            type: 'doc',
+            id: 'connector-development/config-based/understanding-the-yaml-file/yaml-overview',
+          },
+          items: [
+            {
+              type: `category`,
+              label: `Requester`,
+              link: {
+                type: 'doc',
+                id: 'connector-development/config-based/understanding-the-yaml-file/requester',
+              },
+              items: [
+                'connector-development/config-based/understanding-the-yaml-file/request-options',
+                'connector-development/config-based/understanding-the-yaml-file/authentication',
+                'connector-development/config-based/understanding-the-yaml-file/error-handling',
+              ]
+          },
+            'connector-development/config-based/understanding-the-yaml-file/incremental-syncs',
+            'connector-development/config-based/understanding-the-yaml-file/pagination',
+            'connector-development/config-based/understanding-the-yaml-file/partition-router',
+            'connector-development/config-based/understanding-the-yaml-file/record-selector',
+            'connector-development/config-based/understanding-the-yaml-file/reference',
+          ]
+        },
+        'connector-development/config-based/advanced-topics',
+      ]
+    },
+
+    {
+      type: 'category',
+      label: 'Connector Development Kit',
+      link: {
+        type: 'doc',
+        id: 'connector-development/cdk-python/README',
+      },
+      items: [
+        'connector-development/cdk-python/basic-concepts',
+        'connector-development/cdk-python/schemas',
+        'connector-development/cdk-python/full-refresh-stream',
+        'connector-development/cdk-python/incremental-stream',
+        'connector-development/cdk-python/http-streams',
+        'connector-development/cdk-python/python-concepts',
+        'connector-development/cdk-python/stream-slices',
+      ]
+    },
+    {
+      type: 'category',
+      label: 'Testing Connectors',
+      link: {
+        type: 'doc',
+        id: 'connector-development/testing-connectors/README',
+      },
+      items: [
+        'connector-development/testing-connectors/connector-acceptance-tests-reference',
+        'connector-development/testing-connectors/legacy-standard-source-tests',
+        'connector-development/testing-connectors/source-acceptance-tests-reference',
+        'connector-development/testing-connectors/standard-source-tests',
+        'connector-development/testing-connectors/testing-a-local-catalog-in-development',
+      ]
+    },
+    {
+      type: 'category',
+      label: 'Tutorials',
+      items:[
+        'connector-development/tutorials/cdk-speedrun',
+        {
+            type: 'category',
+            label: 'Python CDK: Creating a HTTP API Source',
+            items: [
+              'connector-development/tutorials/cdk-tutorial-python-http/getting-started',
+              'connector-development/tutorials/cdk-tutorial-python-http/creating-the-source',
+              'connector-development/tutorials/cdk-tutorial-python-http/install-dependencies',
+              'connector-development/tutorials/cdk-tutorial-python-http/define-inputs',
+              'connector-development/tutorials/cdk-tutorial-python-http/connection-checking',
+              'connector-development/tutorials/cdk-tutorial-python-http/declare-schema',
+              'connector-development/tutorials/cdk-tutorial-python-http/read-data',
+              'connector-development/tutorials/cdk-tutorial-python-http/use-connector-in-airbyte',
+              'connector-development/tutorials/cdk-tutorial-python-http/test-your-connector',
+            ]
+        },
+        'connector-development/tutorials/building-a-python-source',
+        'connector-development/tutorials/building-a-python-destination',
+        'connector-development/tutorials/building-a-java-destination',
+        'connector-development/tutorials/profile-java-connector-memory'
+      ]
+    },
+    'connector-development/connector-specification-reference',
+    'connector-development/best-practices',
+    'connector-development/ux-handbook',
+  ]
+};
+
+const connectorCatalog = {
+  type: 'category',
+  label: 'Connector Catalog',
+  link: {
+    type: 'doc',
+    id: 'integrations/README',
+  },
+  items: [
+    {
+      type: 'category',
+      label: 'Sources',
+      link: {
+        type: 'generated-index',
+      },
+      items: getSourceConnectors()
+    },
+    {
+      type: 'category',
+      label: 'Destinations',
+      link: {
+        type: 'generated-index',
+      },
+      items: getDestinationConnectors()
+    },
+    {
+      type: 'doc',
+      id: "integrations/custom-connectors",
+    },
+  ]
+};
+
+const contributeToAirbyte = {
+  type: 'category',
+  label: 'Contribute to Airbyte',
+  items: [
+    'contributing-to-airbyte/README',
+    'contributing-to-airbyte/code-of-conduct',
+    'contributing-to-airbyte/maintainer-code-of-conduct',
+    'contributing-to-airbyte/developing-locally',
+    'contributing-to-airbyte/developing-on-docker',
+    'contributing-to-airbyte/developing-on-kubernetes',
+    'contributing-to-airbyte/python-gradle-setup',
+    'contributing-to-airbyte/code-style',
+    'contributing-to-airbyte/issues-and-pull-requests',
+    'contributing-to-airbyte/gradle-cheatsheet',
+    'contributing-to-airbyte/gradle-dependency-update',
+    {
+      type: 'category',
+      label: 'Updating documentation',
+      link: {
+        type: 'doc',
+        id: 'contributing-to-airbyte/updating-documentation',
+      },
+      items: [
+        {
+          type: 'link',
+          label: 'Connector doc template',
+          href: 'https://hackmd.io/Bz75cgATSbm7DjrAqgl4rw',
+        },
+      ]
+    },
+  ]
+};
+
+const airbyteCloud = [
+  {
+    type: 'doc',
+    label: 'Getting Started',
+    id: "cloud/getting-started-with-airbyte-cloud",
+  },
+  'cloud/core-concepts',
+  {
+    type: 'category',
+    label: 'Using Airbyte Cloud',
+    link: {
+      type: 'generated-index',
+    },
+    items: [
+      'cloud/managing-airbyte-cloud/edit-stream-configuration',
+      'cloud/managing-airbyte-cloud/manage-schema-changes',
+      'cloud/managing-airbyte-cloud/manage-data-residency',
+      'cloud/managing-airbyte-cloud/manage-credits',
+      'cloud/managing-airbyte-cloud/review-sync-summary',
+      'cloud/managing-airbyte-cloud/manage-airbyte-cloud-notifications',
+      'cloud/managing-airbyte-cloud/dbt-cloud-integration',
+      'cloud/managing-airbyte-cloud/manage-airbyte-cloud-workspace',
+      'cloud/managing-airbyte-cloud/understand-airbyte-cloud-limits',
+      'cloud/managing-airbyte-cloud/review-connection-state',
+    ],        
+  },
+];
+
+const ossGettingStarted = {
+  type: 'category',
+  label: 'Getting Started',
+  link: {
+    type: 'generated-index',
+  },
+  items: [
+    'quickstart/deploy-airbyte',
+    'quickstart/add-a-source',
+    'quickstart/add-a-destination',
+    'quickstart/set-up-a-connection',
+  ],
+};
+
+const deployAirbyte = {
+  type: 'category',
+  label: 'Deploy Airbyte',
+  link: {
+    type: 'generated-index',
+  },
+  items: [
+    {
+      type: 'doc',
+      label: 'On your local machine',
+      id: 'deploying-airbyte/local-deployment',
+    },
+    {
+      type: 'doc',
+      label: 'On AWS EC2',
+      id: 'deploying-airbyte/on-aws-ec2',
+    },
+
+    {
+      type: 'doc',
+      label: 'On Azure',
+      id:'deploying-airbyte/on-azure-vm-cloud-shell',
+    },
+    {
+      type: 'doc',
+      label: 'On Google (GCP)',
+      id:'deploying-airbyte/on-gcp-compute-engine',
+    },
+    {
+      type: 'doc',
+      label: 'On Kubernetes using Kustomize',
+      id:'deploying-airbyte/on-kubernetes',
+    },
+    {
+      type: 'doc',
+      label: 'On Kubernetes using Helm',
+      id:'deploying-airbyte/on-kubernetes-via-helm',
+    },
+    {
+      type: 'doc',
+      label: 'On Restack',
+      id:'deploying-airbyte/on-restack',
+    },
+    {
+      type: 'doc',
+      label: 'On Plural',
+      id:'deploying-airbyte/on-plural',
+    },
+    {
+      type: 'doc',
+      label: 'On Oracle Cloud',
+      id:'deploying-airbyte/on-oci-vm',
+    },
+    {
+      type: 'doc',
+      label: 'On DigitalOcean',
+      id:'deploying-airbyte/on-digitalocean-droplet',
+    },
+  ],
+};
+
+const troubleshoot = {
+  type: 'category',
+  label: 'Troubleshooting',
+  items: [
+    'troubleshooting/README',
+    'troubleshooting/on-deploying',
+    'troubleshooting/new-connection',
+    'troubleshooting/running-sync',
+  ],
+};
+
+const operatorGuide = {
+  type: 'category',
+  label: 'Manage Airbyte',
+  link: {
+    type: 'generated-index',
+  },
+  items: [
+    'operator-guides/upgrading-airbyte',
+    'operator-guides/reset',
+    'operator-guides/configuring-airbyte-db',
+    'operator-guides/configuring-connector-resources',
+    'operator-guides/browsing-output-logs',
+    'operator-guides/using-the-airflow-airbyte-operator',
+    'operator-guides/using-prefect-task',
+    'operator-guides/using-dagster-integration',
+    'operator-guides/locating-files-local-destination',
+    {
+      type: 'category',
+      label: 'Transformations and Normalization',
+      items: [
+        'operator-guides/transformation-and-normalization/transformations-with-sql',
+        'operator-guides/transformation-and-normalization/transformations-with-dbt',
+        'operator-guides/transformation-and-normalization/transformations-with-airbyte',
+        ]
+      },
+      {
+        type: 'category',
+        label: 'Configuring Airbyte',
+        link: {
+          type: 'doc',
+          id: 'operator-guides/configuring-airbyte',
+        },
+        items: [
+            'operator-guides/sentry-integration',
+          ]
+      },
+    'operator-guides/using-custom-connectors',
+    'operator-guides/scaling-airbyte',
+    'operator-guides/configuring-sync-notifications',
+    'operator-guides/collecting-metrics',
+  ],
+};
+
+const understandingAirbyte = {
+  type: 'category',
+  label: 'Understand Airbyte',
+  items: [
+    'understanding-airbyte/beginners-guide-to-catalog',
+    'understanding-airbyte/airbyte-protocol',
+    'understanding-airbyte/airbyte-protocol-docker',
+    'understanding-airbyte/basic-normalization',
+    {
+      type: 'category',
+      label: 'Connections and Sync Modes',
+      items: [
+        {
+          type: 'doc',
+          label: 'Connections Overview',
+          id: "understanding-airbyte/connections/README",
+        },
+        'understanding-airbyte/connections/full-refresh-overwrite',
+        'understanding-airbyte/connections/full-refresh-append',
+        'understanding-airbyte/connections/incremental-append',
+        'understanding-airbyte/connections/incremental-deduped-history',
+      ]
+    },
+    'understanding-airbyte/operations',
+    'understanding-airbyte/high-level-view',
+    'understanding-airbyte/jobs',
+    'understanding-airbyte/tech-stack',
+    'understanding-airbyte/cdc',
+    'understanding-airbyte/namespaces',
+    'understanding-airbyte/supported-data-types',
+    'understanding-airbyte/json-avro-conversion',
+    'understanding-airbyte/database-data-catalog',
+  ]
+};
+
+const security = {
+  type: 'doc',
+  id: "operator-guides/security",
+};
+
 module.exports = {
   mySidebar: [
     {
@@ -29,390 +425,17 @@ module.exports = {
       label: 'Start here',
       id: "readme",
     },
-    {
-      type: 'category',
-      label: 'Connector Catalog',
-      link: {
-        type: 'doc',
-        id: 'integrations/README',
-      },
-      items: [
-          {
-            type: 'category',
-            label: 'Sources',
-            link: {
-              type: 'generated-index',
-            },
-            items: getSourceConnectors()
-          },
-          {
-            type: 'category',
-            label: 'Destinations',
-            link: {
-              type: 'generated-index',
-            },
-            items: getDestinationConnectors()
-          },
-          {
-            type: 'doc',
-            id: "integrations/custom-connectors",
-          },
-        ]
-
-      },
-    {
-      type: 'category',
-      label: 'Airbyte Cloud',
-      items: [
-        {
-          type: 'doc',
-          label: 'Getting Started',
-          id: "cloud/getting-started-with-airbyte-cloud",
-        },
-        'cloud/core-concepts',
-        {
-          type: 'category',
-          label: 'Managing Airbyte Cloud',
-          link: {
-            type: 'generated-index',
-          },
-          items: [
-            'cloud/managing-airbyte-cloud/edit-stream-configuration',
-            'cloud/managing-airbyte-cloud/manage-schema-changes',
-            'cloud/managing-airbyte-cloud/manage-data-residency',
-            'cloud/managing-airbyte-cloud/manage-credits',
-            'cloud/managing-airbyte-cloud/review-sync-summary',
-            'cloud/managing-airbyte-cloud/manage-airbyte-cloud-notifications',
-            'cloud/managing-airbyte-cloud/dbt-cloud-integration',
-            'cloud/managing-airbyte-cloud/manage-airbyte-cloud-workspace',
-            'cloud/managing-airbyte-cloud/understand-airbyte-cloud-limits',
-            'cloud/managing-airbyte-cloud/review-connection-state',
-          ],        
-        },
-      ],
-    },
-    {
-      type: 'category',
-      label: 'Airbyte Open Source Quick Start',
-      link: {
-        type: 'generated-index',
-      },
-      items: [
-        'quickstart/deploy-airbyte',
-        'quickstart/add-a-source',
-        'quickstart/add-a-destination',
-        'quickstart/set-up-a-connection',
-      ],
-    },
-    {
-      type: 'category',
-      label: 'Deploy Airbyte Open Source',
-      link: {
-        type: 'generated-index',
-      },
-      items: [
-        {
-          type: 'doc',
-          label: 'On your local machine',
-          id: 'deploying-airbyte/local-deployment',
-        },
-        {
-          type: 'doc',
-          label: 'On AWS EC2',
-          id: 'deploying-airbyte/on-aws-ec2',
-        },
-
-        {
-          type: 'doc',
-          label: 'On Azure',
-          id:'deploying-airbyte/on-azure-vm-cloud-shell',
-        },
-        {
-          type: 'doc',
-          label: 'On Google (GCP)',
-          id:'deploying-airbyte/on-gcp-compute-engine',
-        },
-        {
-          type: 'doc',
-          label: 'On Kubernetes using Kustomize',
-          id:'deploying-airbyte/on-kubernetes',
-        },
-        {
-          type: 'doc',
-          label: 'On Kubernetes using Helm',
-          id:'deploying-airbyte/on-kubernetes-via-helm',
-        },
-        {
-          type: 'doc',
-          label: 'On Restack',
-          id:'deploying-airbyte/on-restack',
-        },
-        {
-          type: 'doc',
-          label: 'On Plural',
-          id:'deploying-airbyte/on-plural',
-        },
-        {
-          type: 'doc',
-          label: 'On Oracle Cloud',
-          id:'deploying-airbyte/on-oci-vm',
-        },
-        {
-          type: 'doc',
-          label: 'On DigitalOcean',
-          id:'deploying-airbyte/on-digitalocean-droplet',
-        },
-      ],
-    },
-    {
-      type: 'category',
-      label: 'Manage Airbyte Open Source',
-      link: {
-        type: 'generated-index',
-      },
-      items: [
-        'operator-guides/upgrading-airbyte',
-        'operator-guides/reset',
-        'operator-guides/configuring-airbyte-db',
-        'operator-guides/configuring-connector-resources',
-        'operator-guides/browsing-output-logs',
-        'operator-guides/using-the-airflow-airbyte-operator',
-        'operator-guides/using-prefect-task',
-        'operator-guides/using-dagster-integration',
-        'operator-guides/locating-files-local-destination',
-        {
-          type: 'category',
-          label: 'Transformations and Normalization',
-          items: [
-            'operator-guides/transformation-and-normalization/transformations-with-sql',
-            'operator-guides/transformation-and-normalization/transformations-with-dbt',
-            'operator-guides/transformation-and-normalization/transformations-with-airbyte',
-            ]
-          },
-          {
-            type: 'category',
-            label: 'Configuring Airbyte',
-            link: {
-              type: 'doc',
-              id: 'operator-guides/configuring-airbyte',
-            },
-            items: [
-                'operator-guides/sentry-integration',
-              ]
-          },
-        'operator-guides/using-custom-connectors',
-        'operator-guides/scaling-airbyte',
-        'operator-guides/configuring-sync-notifications',
-        'operator-guides/collecting-metrics',
-      ],
-    },
-    {
-      type: 'category',
-      label: 'Troubleshoot Airbyte',
-      items: [
-        'troubleshooting/README',
-        'troubleshooting/on-deploying',
-        'troubleshooting/new-connection',
-        'troubleshooting/running-sync',
-      ],
-    },
-    {
-      type: 'category',
-      label: 'Build a connector',
-      items: [
-        {
-          type: 'doc',
-          label: 'Overview',
-          id: 'connector-development/README',
-        },
-        {
-          type: 'category',
-          label: 'Low-code connector development',
-          items: [
-            'connector-development/config-based/connector-builder-ui',
-            {
-              label: 'Low-code CDK Intro',
-              type: 'doc',
-              id: 'connector-development/config-based/low-code-cdk-overview',
-            },
-            {
-              type: 'category',
-              label: 'Tutorial',
-              items: [
-                'connector-development/config-based/tutorial/getting-started',
-                'connector-development/config-based/tutorial/create-source',
-                'connector-development/config-based/tutorial/install-dependencies',
-                'connector-development/config-based/tutorial/connecting-to-the-API-source',
-                'connector-development/config-based/tutorial/reading-data',
-                'connector-development/config-based/tutorial/incremental-reads',
-                'connector-development/config-based/tutorial/testing',
-              ],
-            },
-            {
-              type: 'category',
-              label: 'Understanding the YAML file',
-              link: {
-                type: 'doc',
-                id: 'connector-development/config-based/understanding-the-yaml-file/yaml-overview',
-              },
-              items: [
-                {
-                  type: `category`,
-                  label: `Requester`,
-                  link: {
-                    type: 'doc',
-                    id: 'connector-development/config-based/understanding-the-yaml-file/requester',
-                  },
-                  items: [
-                    'connector-development/config-based/understanding-the-yaml-file/request-options',
-                    'connector-development/config-based/understanding-the-yaml-file/authentication',
-                    'connector-development/config-based/understanding-the-yaml-file/error-handling',
-                  ]
-              },
-                'connector-development/config-based/understanding-the-yaml-file/incremental-syncs',
-                'connector-development/config-based/understanding-the-yaml-file/pagination',
-                'connector-development/config-based/understanding-the-yaml-file/partition-router',
-                'connector-development/config-based/understanding-the-yaml-file/record-selector',
-                'connector-development/config-based/understanding-the-yaml-file/reference',
-              ]
-            },
-            'connector-development/config-based/advanced-topics',
-          ]
-        },
-
-        {
-          type: 'category',
-          label: 'Connector Development Kit',
-          link: {
-            type: 'doc',
-            id: 'connector-development/cdk-python/README',
-          },
-          items: [
-            'connector-development/cdk-python/basic-concepts',
-            'connector-development/cdk-python/schemas',
-            'connector-development/cdk-python/full-refresh-stream',
-            'connector-development/cdk-python/incremental-stream',
-            'connector-development/cdk-python/http-streams',
-            'connector-development/cdk-python/python-concepts',
-            'connector-development/cdk-python/stream-slices',
-          ]
-        },
-        {
-          type: 'category',
-          label: 'Testing Connectors',
-          link: {
-            type: 'doc',
-            id: 'connector-development/testing-connectors/README',
-          },
-          items: [
-            'connector-development/testing-connectors/connector-acceptance-tests-reference',
-            'connector-development/testing-connectors/legacy-standard-source-tests',
-            'connector-development/testing-connectors/source-acceptance-tests-reference',
-            'connector-development/testing-connectors/standard-source-tests',
-            'connector-development/testing-connectors/testing-a-local-catalog-in-development',
-          ]
-        },
-        {
-          type: 'category',
-          label: 'Tutorials',
-          items:[
-            'connector-development/tutorials/cdk-speedrun',
-            {
-                type: 'category',
-                label: 'Python CDK: Creating a HTTP API Source',
-                items: [
-                  'connector-development/tutorials/cdk-tutorial-python-http/getting-started',
-                  'connector-development/tutorials/cdk-tutorial-python-http/creating-the-source',
-                  'connector-development/tutorials/cdk-tutorial-python-http/install-dependencies',
-                  'connector-development/tutorials/cdk-tutorial-python-http/define-inputs',
-                  'connector-development/tutorials/cdk-tutorial-python-http/connection-checking',
-                  'connector-development/tutorials/cdk-tutorial-python-http/declare-schema',
-                  'connector-development/tutorials/cdk-tutorial-python-http/read-data',
-                  'connector-development/tutorials/cdk-tutorial-python-http/use-connector-in-airbyte',
-                  'connector-development/tutorials/cdk-tutorial-python-http/test-your-connector',
-                ]
-            },
-            'connector-development/tutorials/building-a-python-source',
-            'connector-development/tutorials/building-a-python-destination',
-            'connector-development/tutorials/building-a-java-destination',
-            'connector-development/tutorials/profile-java-connector-memory'
-          ]
-        },
-        'connector-development/connector-specification-reference',
-        'connector-development/best-practices',
-        'connector-development/ux-handbook',
-      ]
-    },
-    {
-      type: 'category',
-      label: 'Contribute to Airbyte',
-      items: [
-        'contributing-to-airbyte/README',
-        'contributing-to-airbyte/code-of-conduct',
-        'contributing-to-airbyte/maintainer-code-of-conduct',
-        'contributing-to-airbyte/developing-locally',
-        'contributing-to-airbyte/developing-on-docker',
-        'contributing-to-airbyte/developing-on-kubernetes',
-        'contributing-to-airbyte/python-gradle-setup',
-        'contributing-to-airbyte/code-style',
-        'contributing-to-airbyte/issues-and-pull-requests',
-        'contributing-to-airbyte/gradle-cheatsheet',
-        'contributing-to-airbyte/gradle-dependency-update',
-        {
-          type: 'category',
-          label: 'Updating documentation',
-          link: {
-            type: 'doc',
-            id: 'contributing-to-airbyte/updating-documentation',
-          },
-          items: [
-            {
-              type: 'link',
-              label: 'Connector doc template',
-              href: 'https://hackmd.io/Bz75cgATSbm7DjrAqgl4rw',
-            },
-          ]
-        },
-      ]
-    },
-    {
-      type: 'category',
-      label: 'Understand Airbyte',
-      items: [
-        'understanding-airbyte/beginners-guide-to-catalog',
-        'understanding-airbyte/airbyte-protocol',
-        'understanding-airbyte/airbyte-protocol-docker',
-        'understanding-airbyte/basic-normalization',
-        {
-          type: 'category',
-          label: 'Connections and Sync Modes',
-          items: [
-            {
-              type: 'doc',
-              label: 'Connections Overview',
-              id: "understanding-airbyte/connections/README",
-            },
-            'understanding-airbyte/connections/full-refresh-overwrite',
-            'understanding-airbyte/connections/full-refresh-append',
-            'understanding-airbyte/connections/incremental-append',
-            'understanding-airbyte/connections/incremental-deduped-history',
-          ]
-        },
-        'understanding-airbyte/operations',
-        'understanding-airbyte/high-level-view',
-        'understanding-airbyte/jobs',
-        'understanding-airbyte/tech-stack',
-        'understanding-airbyte/cdc',
-        'understanding-airbyte/namespaces',
-        'understanding-airbyte/supported-data-types',
-        'understanding-airbyte/json-avro-conversion',
-        'understanding-airbyte/database-data-catalog',
-      ]
-    },
-    {
-      type: 'doc',
-      id: "operator-guides/security",
-    },
+    sectionHeader("Airbyte Connectors"),
+    connectorCatalog,
+    buildAConnector,
+    sectionHeader("Airbyte Cloud"),
+    ...airbyteCloud,
+    sectionHeader("Airbyte Open Source (OSS)"),
+    ossGettingStarted,
+    deployAirbyte,
+    operatorGuide,
+    troubleshoot,
+    sectionHeader("Developer Guides"),
     {
       type: 'doc',
       id: "api-documentation",
@@ -421,6 +444,10 @@ module.exports = {
       type: 'doc',
       id: "cli-documentation",
     },
+    understandingAirbyte,
+    contributeToAirbyte,
+    sectionHeader("Resources"),
+    security,
     {
       type: 'category',
       label: 'Project Overview',

--- a/docusaurus/src/css/custom.css
+++ b/docusaurus/src/css/custom.css
@@ -4,7 +4,7 @@
  * work well for content-centric websites.
  */
 
- @import url('https://fonts.googleapis.com/css2?family=Inter&display=swap');
+ @import url('https://fonts.googleapis.com/css2?family=Inter:wght@200;300;400;700&display=swap');
 
 /* You can override the default Infima variables here. */
 :root {
@@ -73,6 +73,13 @@ html[data-theme='dark'] .docusaurus-highlight-code-line {
     text-decoration: none;
 }
 
+.navbar__category {
+  font-weight: 200;
+  font-size: 0.8em;
+  opacity: 0.8;
+  padding: 1em var(--ifm-menu-link-padding-horizontal) 0;
+}
+
 .codeBlockContainer_I0IT {
     box-shadow: none !important;
 }
@@ -88,7 +95,7 @@ img {
 }
 
 .menu__link--sublist-caret:after {
-    background: var(--ifm-menu-link-sublist-icon) 50%/1.5rem 1.5rem;
+    background: var(--ifm-menu-link-sublist-icon) 50%/2rem 2rem;
     min-width: 1.25rem;
 }
 


### PR DESCRIPTION
## What

Groups the navigation in the documentation into several categories, to make it easier to parse.

Also since they are grouped now I removed the duplicate "Airbyte" or "Open Source" from some of the menu entries, if they were redundant. So the new structure looks as follows:

![screenshot-20230402-232008](https://user-images.githubusercontent.com/877229/229379747-965ff10c-12e9-4e9e-85ce-f5eca4d6a9d2.png)

The only links changed due to that, are the `category/` links if the page itself doesn't have a content. I fixed the only link I found we have to one, but I don't think we need a redirect for them, since we don't link from any other places to them afaik.

Also fixed some broken links as part of this PR, as well as making sure those carets in the menu are now all the same size.