### PR TITLE
🐛 Source Amplitude : Updates cursor_field in the Amplitude Events stream to the proper field server_upload_time

### DIFF
--- a/airbyte-integrations/connectors/source-amplitude/Dockerfile
+++ b/airbyte-integrations/connectors/source-amplitude/Dockerfile
@@ -12,5 +12,5 @@ RUN pip install .
 ENV AIRBYTE_ENTRYPOINT "python /airbyte/integration_code/main.py"
 ENTRYPOINT ["python", "/airbyte/integration_code/main.py"]
 
-LABEL io.airbyte.version=0.1.24
+LABEL io.airbyte.version=0.1.25
 LABEL io.airbyte.name=airbyte/source-amplitude

--- a/airbyte-integrations/connectors/source-amplitude/acceptance-test-config.yml
+++ b/airbyte-integrations/connectors/source-amplitude/acceptance-test-config.yml
@@ -34,3 +34,6 @@ acceptance_tests:
       configured_catalog_path: "integration_tests/configured_catalog.json"
       future_state:
         future_state_path: "integration_tests/abnormal_state.json"
+      empty_streams:
+        - name: "events"
+          bypass_reason: "Fix wrong cursor field to address Issue #16943, to keep old connections compatible"

--- a/airbyte-integrations/connectors/source-amplitude/unit_tests/test_api.py
+++ b/airbyte-integrations/connectors/source-amplitude/unit_tests/test_api.py
@@ -234,8 +234,8 @@ class TestEventsStream:
             data_region="Standard Server",
             event_time_interval={"size_unit": "days", "size": 1}
         )
-        current_state = {"event_time": ""}
-        latest_record = {"event_time": "2021-05-27 11:59:53.710000"}
+        current_state = {"server_upload_time": ""}
+        latest_record = {"server_upload_time": "2021-05-27 11:59:53.710000"}
         result = stream.get_updated_state(current_state, latest_record)
         assert result == latest_record
 

--- a/docs/integrations/sources/amplitude.md
+++ b/docs/integrations/sources/amplitude.md
@@ -43,6 +43,7 @@ The Amplitude connector ideally should gracefully handle Amplitude API limitatio
 
 | Version | Date       | Pull Request                                             | Subject                                                                                         |
 |:--------|:-----------|:---------------------------------------------------------|:------------------------------------------------------------------------------------------------|
+| 0.1.25  | 2023-04-03 | [24780](https://github.com/airbytehq/airbyte/pull/24780) | Updates cursor_field in the Amplitude Events stream to the proper field `server_upload_time`      |
 | 0.1.24  | 2023-03-28 | [21022](https://github.com/airbytehq/airbyte/pull/21022) | Enable event stream time interval selection                                                     |
 | 0.1.23  | 2023-03-02 | [23087](https://github.com/airbytehq/airbyte/pull/23087) | Specified date formatting in specification                                                      |
 | 0.1.22  | 2023-02-17 | [23192](https://github.com/airbytehq/airbyte/pull/23192) | Skip the stream if `start_date` is specified in the future.                                     


### PR DESCRIPTION
## What
Addressing Issue https://github.com/airbytehq/airbyte/issues/16943 - Source amplitude uses wrong field as "cursor_field"  
Set cursor to server_upload_time

## How
Updates "cursor_field" in the Amplitude Events stream to the proper field server_upload_time

## Recommended reading order
1. `x.java`
2. `y.python`

## 🚨 User Impact 🚨
*Are there any breaking changes? What is the end result perceived by the user?*
This is a fix PR, it should be a minor release.


## Pre-merge Checklist
*Expand the relevant checklist and delete the others.*

<details><summary><strong>Updating a connector</strong></summary>

### Community member or Airbyter

- [ ] Grant edit access to maintainers ([instructions](https://docs.github.com/en/github/collaborating-with-pull-requests/working-with-forks/allowing-changes-to-a-pull-request-branch-created-from-a-fork#enabling-repository-maintainer-permissions-on-existing-pull-requests))
- [ ] Secrets in the connector's spec are annotated with `airbyte_secret`
- [ ] Unit & integration tests added and passing. Community members, please provide proof of success locally e.g: screenshot or copy-paste unit, integration, and acceptance test output. To run acceptance tests for a Python connector, follow instructions in the README. For java connectors run `./gradlew :airbyte-integrations:connectors:<name>:integrationTest`.
- [ ] Code reviews completed
- [x] Connector version has been incremented
    - [x] Version has been bumped according to our [Semantic Versioning for Connectors](https://docs.airbyte.com/contributing-to-airbyte/semantic-versioning-for-connectors) guidelines
    - [x] `Dockerfile` has updated version
- [ ] Documentation updated
    - [ ] Connector's `README.md`
    - [ ] Connector's `bootstrap.md`. See [description and examples](https://docs.google.com/document/d/1ypdgmwmEHWv-TrO4_YOQ7pAJGVrMp5BOkEVh831N260/edit?usp=sharing)
    - [x] Changelog updated in `docs/integrations/<source or destination>/<name>.md` with an entry for the new version. See changelog [example](https://docs.airbyte.io/integrations/sources/stripe#changelog)

- [ ] PR name follows [PR naming conventions](https://docs.airbyte.com/contributing-to-airbyte/issues-and-pull-requests)

### Airbyter

If this is a community PR, the Airbyte engineer reviewing this PR is responsible for the below items.

- [ ] Create a non-forked branch based on this PR and test the below items on it
- [ ] Build is successful
- [ ] If new credentials are required for use in CI, add them to GSM. [Instructions](https://docs.airbyte.io/connector-development#using-credentials-in-ci).
- [ ] [`/test connector=connectors/<name>` command](https://docs.airbyte.io/connector-development#updating-an-existing-connector) is passing
- [ ] New Connector version released on Dockerhub and connector version bumped by running the `/publish` command described [here](https://docs.airbyte.io/connector-development#updating-an-existing-connector)

</details>
