### PR TITLE
Override the zendesk support threshold

### DIFF
--- a/airbyte-config/init/src/main/resources/seed/source_definitions.yaml
+++ b/airbyte-config/init/src/main/resources/seed/source_definitions.yaml
@@ -2377,6 +2377,7 @@
     hosts:
       - "${subdomain}.zendesk.com"
       - zendesk.com
+  maxSecondsBetweenMessages: 7200
 - name: Zendesk Talk
   sourceDefinitionId: c8630570-086d-4a40-99ae-ea5b18673071
   dockerRepository: airbyte/source-zendesk-talk


### PR DESCRIPTION
## What
increase the zendesk support heartbeat timeout threshold to 2 hours since 1 our seems too small for the way the rate limitation is handle, eg: https://cloud.airbyte.com/workspaces/97f366e4-2729-4db0-9569-e671ee1380bc/connections/f4f00ca2-fac3-49a8-88b5-faab1046572a/status