### PR TITLE
raise zenhub threshold to 3 hours

### DIFF
--- a/airbyte-config/init/src/main/resources/seed/source_definitions.yaml
+++ b/airbyte-config/init/src/main/resources/seed/source_definitions.yaml
@@ -2377,7 +2377,7 @@
     hosts:
       - "${subdomain}.zendesk.com"
       - zendesk.com
-  maxSecondsBetweenMessages: 7200
+  maxSecondsBetweenMessages: 10800
 - name: Zendesk Talk
   sourceDefinitionId: c8630570-086d-4a40-99ae-ea5b18673071
   dockerRepository: airbyte/source-zendesk-talk


### PR DESCRIPTION
## What
Zenhub need to be raise more, [this connection](https://cloud.airbyte.com/workspaces/39efecfe-da74-4678-98e9-eb1b51c80b63/connections/7b78f2d5-9dfd-47a5-96ad-f657361198f8/status) needed more than 2 hours
