### PR TITLE
Staging destinations: Syncs shouldn't stomp on each other

### DIFF
--- a/airbyte-integrations/connectors/destination-snowflake/src/main/java/io/airbyte/integrations/destination/snowflake/SnowflakeInternalStagingSqlOperations.java
+++ b/airbyte-integrations/connectors/destination-snowflake/src/main/java/io/airbyte/integrations/destination/snowflake/SnowflakeInternalStagingSqlOperations.java
@@ -45,7 +45,8 @@ public class SnowflakeInternalStagingSqlOperations extends SnowflakeSqlStagingOp
   public String getStageName(final String namespace, final String streamName) {
     return nameTransformer.applyDefaultCase(String.join("_",
         nameTransformer.convertStreamName(namespace),
-        nameTransformer.convertStreamName(streamName)));
+        nameTransformer.convertStreamName(streamName),
+        UUID.randomUUID().toString()));
   }
 
   @Override


### PR DESCRIPTION
As seen in https://github.com/airbytehq/oncall/issues/1790, https://github.com/airbytehq/oncall/issues/1751, and a number of other issues - we have problems when multiple syncs run simultaneously into the same destination table. None of them are situations that we _want_ to support - e.g. user intentionally configuring multiple connections to the same destination table, or platform incorrectly starting a new attempt when a previous attempt is still running.

But we probably (maybe?) should behave a little less fragile-ly? In theory, there's nothing stopping us from loading the raw tables with data in these cases, even if that raw data will look kind of weird.

Caveats:
* full refresh overwrite? Maybe there's some potential race condition that results in duplicate data?
* are there other cases where we do bad things?