### PR TITLE
Fix version bump mistakes

### DIFF
--- a/docs/operator-guides/upgrading-airbyte.md
+++ b/docs/operator-guides/upgrading-airbyte.md
@@ -33,7 +33,7 @@ If you use custom connectors, this upgrade requires all of your connector specs 
 
 :::note
 
-Airbyte version 0.43.0 or later requires [Docker Compose V2](https://docs.docker.com/compose/compose-v2/) to be [installed](https://docs.docker.com/compose/install/) before upgrading.
+Airbyte version 0.40.27 or later requires [Docker Compose V2](https://docs.docker.com/compose/compose-v2/) to be [installed](https://docs.docker.com/compose/install/) before upgrading.
 
 :::
 

--- a/octavia-cli/README.md
+++ b/octavia-cli/README.md
@@ -710,9 +710,9 @@ You can disable telemetry by setting the `OCTAVIA_ENABLE_TELEMETRY` environment 
 ## Changelog
 
 | Version | Date       | Description                                                                           | PR                                                          |
-| ------- | ---------- | ------------------------------------------------------------------------------------- | ----------------------------------------------------------- |
-| 0.43.0  | 2022-10-13 | Use Basic Authentication for making API requests                                      | [#17982](https://github.com/airbytehq/airbyte/pull/17982)   |
-| 0.43.0 | 2022-08-10 | Enable cron and basic scheduling                                                      | [#15253](https://github.com/airbytehq/airbyte/pull/15253)   |
+|---------| ---------- | ------------------------------------------------------------------------------------- | ----------------------------------------------------------- |
+| 0.41.0  | 2022-10-13 | Use Basic Authentication for making API requests                                      | [#17982](https://github.com/airbytehq/airbyte/pull/17982)   |
+| 0.40.0  | 2022-08-10 | Enable cron and basic scheduling                                                      | [#15253](https://github.com/airbytehq/airbyte/pull/15253)   |
 | 0.39.33 | 2022-07-05 | Add `octavia import all` command                                                      | [#14374](https://github.com/airbytehq/airbyte/pull/14374)   |
 | 0.39.32 | 2022-06-30 | Create import command to import and manage existing Airbyte resource from octavia-cli | [#14137](https://github.com/airbytehq/airbyte/pull/14137)   |
 | 0.39.27 | 2022-06-24 | Create get command to retrieve resources JSON representation                          | [#13254](https://github.com/airbytehq/airbyte/pull/13254)   |


### PR DESCRIPTION
## What

Some versions from our docs/changelogs have been auto-bumped by mistake. Restore them to what they were meant to be originally.

## How

Restore the versions to what they were meant to be, new runs of bumpversion should ignore them in the future.