### PR TITLE
Destination BigQuery: 1s1t poc

### DIFF
--- a/airbyte-integrations/connectors/destination-bigquery/src/main/java/io/airbyte/integrations/destination/bigquery/BigQueryGcsOperations.java
+++ b/airbyte-integrations/connectors/destination-bigquery/src/main/java/io/airbyte/integrations/destination/bigquery/BigQueryGcsOperations.java
@@ -209,4 +209,9 @@ public class BigQueryGcsOperations implements BigQueryStagingOperations {
     createTableIfNotExists(tableId, schema);
   }
 
+  @Override
+  public BigQuery getBigQuery() {
+    return bigQuery;
+  }
+
 }

--- a/airbyte-integrations/connectors/destination-bigquery/src/main/java/io/airbyte/integrations/destination/bigquery/BigQueryStagingConsumerFactory.java
+++ b/airbyte-integrations/connectors/destination-bigquery/src/main/java/io/airbyte/integrations/destination/bigquery/BigQueryStagingConsumerFactory.java
@@ -5,10 +5,8 @@
 package io.airbyte.integrations.destination.bigquery;
 
 import com.fasterxml.jackson.databind.JsonNode;
-import com.google.api.gax.paging.Page;
 import com.google.cloud.bigquery.BigQuery;
 import com.google.cloud.bigquery.Schema;
-import com.google.cloud.bigquery.Table;
 import com.google.cloud.bigquery.TableId;
 import com.google.common.base.Functions;
 import com.google.common.base.Preconditions;

--- a/airbyte-integrations/connectors/destination-bigquery/src/main/java/io/airbyte/integrations/destination/bigquery/BigQueryStagingConsumerFactory.java
+++ b/airbyte-integrations/connectors/destination-bigquery/src/main/java/io/airbyte/integrations/destination/bigquery/BigQueryStagingConsumerFactory.java
@@ -213,7 +213,7 @@ public class BigQueryStagingConsumerFactory {
          * commentary: Normalization has a ton of extra logic here, and we probably need to port that over.
          * E.g. tablename length, reserved words, maybe other stuff that I'm unaware of.
          */
-        String finalTableName = new BigQuerySQLNameTransformer().convertStreamName(streamIdentifier.getName());
+        String finalTableName = "edgao_1s1t_test_" +  new BigQuerySQLNameTransformer().convertStreamName(streamIdentifier.getName());
 
         // TODO this doesn't compile yet. Need to pass jsonschema into writeConfig
         Schema finalSchema = ops.getTableSchema(writeConfig.configuredAirbyteStream());

--- a/airbyte-integrations/connectors/destination-bigquery/src/main/java/io/airbyte/integrations/destination/bigquery/BigQueryStagingConsumerFactory.java
+++ b/airbyte-integrations/connectors/destination-bigquery/src/main/java/io/airbyte/integrations/destination/bigquery/BigQueryStagingConsumerFactory.java
@@ -217,7 +217,7 @@ public class BigQueryStagingConsumerFactory {
         String finalTableName = new BigQuerySQLNameTransformer().convertStreamName(streamIdentifier.getName());
 
         // TODO this doesn't compile yet. Need to pass jsonschema into writeConfig
-        Schema finalSchema = ops.getTableSchema(writeConfig);
+        Schema finalSchema = ops.getTableSchema(writeConfig.configuredAirbyteStream());
 
         if (writeConfig.syncMode() == DestinationSyncMode.OVERWRITE) {
           bigQueryGcsOperations.dropTableIfExists(writeConfig.datasetId(), TableId.of(writeConfig.datasetId(), finalTableName));

--- a/airbyte-integrations/connectors/destination-bigquery/src/main/java/io/airbyte/integrations/destination/bigquery/BigQueryStagingConsumerFactory.java
+++ b/airbyte-integrations/connectors/destination-bigquery/src/main/java/io/airbyte/integrations/destination/bigquery/BigQueryStagingConsumerFactory.java
@@ -92,7 +92,8 @@ public class BigQueryStagingConsumerFactory {
               tmpTableNameTransformer.apply(streamName),
               targetTableNameTransformer.apply(streamName),
               recordFormatter.getBigQuerySchema(),
-              configuredStream.getDestinationSyncMode());
+              configuredStream.getDestinationSyncMode(),
+              configuredStream);
 
           LOGGER.info("BigQuery write config: {}", writeConfig);
 
@@ -222,7 +223,7 @@ public class BigQueryStagingConsumerFactory {
         }
 
         ops.createOrAlterTable(writeConfig.datasetId(), finalTableName, finalSchema);
-        ops.mergeFromRawTable(writeConfig.datasetId(), writeConfig.targetTableId().getTable(), finalTableName, finalSchema);
+        ops.mergeFromRawTable(writeConfig.datasetId(), writeConfig.targetTableId().getTable(), finalTableName, writeConfig.configuredAirbyteStream());
       }
 
       LOGGER.info("done typing+deduping");

--- a/airbyte-integrations/connectors/destination-bigquery/src/main/java/io/airbyte/integrations/destination/bigquery/BigQueryStagingConsumerFactory.java
+++ b/airbyte-integrations/connectors/destination-bigquery/src/main/java/io/airbyte/integrations/destination/bigquery/BigQueryStagingConsumerFactory.java
@@ -223,7 +223,7 @@ public class BigQueryStagingConsumerFactory {
         }
 
         ops.createOrAlterTable(writeConfig.datasetId(), finalTableName, finalSchema);
-        ops.mergeFromRawTable(writeConfig.datasetId(), writeConfig.targetTableId().getTable(), finalTableName, writeConfig.configuredAirbyteStream());
+        ops.mergeFromRawTable(writeConfig.datasetId(), writeConfig.targetTableId().getTable(), finalTableName, writeConfig.configuredAirbyteStream(), finalSchema);
       }
 
       LOGGER.info("done typing+deduping");

--- a/airbyte-integrations/connectors/destination-bigquery/src/main/java/io/airbyte/integrations/destination/bigquery/BigQueryStagingOperations.java
+++ b/airbyte-integrations/connectors/destination-bigquery/src/main/java/io/airbyte/integrations/destination/bigquery/BigQueryStagingOperations.java
@@ -4,6 +4,7 @@
 
 package io.airbyte.integrations.destination.bigquery;
 
+import com.google.cloud.bigquery.BigQuery;
 import com.google.cloud.bigquery.Schema;
 import com.google.cloud.bigquery.TableId;
 import io.airbyte.integrations.destination.record_buffer.SerializableBuffer;
@@ -79,4 +80,5 @@ public interface BigQueryStagingOperations {
 
   void truncateTableIfExists(final String datasetId, final TableId tableId, Schema schema);
 
+  BigQuery getBigQuery();
 }

--- a/airbyte-integrations/connectors/destination-bigquery/src/main/java/io/airbyte/integrations/destination/bigquery/BigQueryWriteConfig.java
+++ b/airbyte-integrations/connectors/destination-bigquery/src/main/java/io/airbyte/integrations/destination/bigquery/BigQueryWriteConfig.java
@@ -6,6 +6,7 @@ package io.airbyte.integrations.destination.bigquery;
 
 import com.google.cloud.bigquery.Schema;
 import com.google.cloud.bigquery.TableId;
+import io.airbyte.protocol.models.v0.ConfiguredAirbyteStream;
 import io.airbyte.protocol.models.v0.DestinationSyncMode;
 import java.util.ArrayList;
 import java.util.List;
@@ -13,26 +14,28 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 /**
- * @param streamName output stream name
+ * @param streamName              output stream name
  * @param namespace
- * @param datasetId the dataset ID is equivalent to output schema
- * @param datasetLocation location of dataset (e.g. US, EU)
- * @param tmpTableId BigQuery temporary table
- * @param targetTableId BigQuery final raw table
- * @param tableSchema schema for the table
- * @param syncMode BigQuery's mapping of write modes to Airbyte's sync mode
- * @param stagedFiles collection of staged files to copy data from
+ * @param datasetId               the dataset ID is equivalent to output schema
+ * @param datasetLocation         location of dataset (e.g. US, EU)
+ * @param tmpTableId              BigQuery temporary table
+ * @param targetTableId           BigQuery final raw table
+ * @param tableSchema             schema for the table
+ * @param syncMode                BigQuery's mapping of write modes to Airbyte's sync mode
+ * @param stagedFiles             collection of staged files to copy data from
+ * @param configuredAirbyteStream
  */
 public record BigQueryWriteConfig(
-                                  String streamName,
-                                  String namespace,
-                                  String datasetId,
-                                  String datasetLocation,
-                                  TableId tmpTableId,
-                                  TableId targetTableId,
-                                  Schema tableSchema,
-                                  DestinationSyncMode syncMode,
-                                  List<String> stagedFiles) {
+    String streamName,
+    String namespace,
+    String datasetId,
+    String datasetLocation,
+    TableId tmpTableId,
+    TableId targetTableId,
+    Schema tableSchema,
+    DestinationSyncMode syncMode,
+    List<String> stagedFiles,
+    ConfiguredAirbyteStream configuredAirbyteStream) {
 
   private static final Logger LOGGER = LoggerFactory.getLogger(BigQueryWriteConfig.class);
 
@@ -43,7 +46,8 @@ public record BigQueryWriteConfig(
                              final String tmpTableName,
                              final String targetTableName,
                              final Schema tableSchema,
-                             final DestinationSyncMode syncMode) {
+                             final DestinationSyncMode syncMode,
+                             final ConfiguredAirbyteStream configuredAirbyteStream) {
     this(
         streamName,
         namespace,
@@ -53,7 +57,8 @@ public record BigQueryWriteConfig(
         TableId.of(datasetId, targetTableName),
         tableSchema,
         syncMode,
-        new ArrayList<>());
+        new ArrayList<>(),
+        configuredAirbyteStream);
   }
 
   public void addStagedFile(final String file) {

--- a/airbyte-integrations/connectors/destination-bigquery/src/main/java/io/airbyte/integrations/destination/bigquery/materialization/BigQueryMaterializationOperations.java
+++ b/airbyte-integrations/connectors/destination-bigquery/src/main/java/io/airbyte/integrations/destination/bigquery/materialization/BigQueryMaterializationOperations.java
@@ -51,7 +51,8 @@ public class BigQueryMaterializationOperations implements MaterializationOperati
    * commentary: Some of this is equivalent to normalization code - the stuff around extracting JSON fields
    * and casting their types, etc.
    *
-   * The stuff around explicitly writing a merge / insert is new; dbt handles that for us.
+   * The stuff around explicitly writing a merge / insert is new; dbt handles that for us. That's also destination-specific;
+   * e.g. some destinations might need explicit UPDATE and INSERT statements.
    *
    * The DELETE thing is new, and an improvement over normalization (where we need a separate DELETE call)
    */

--- a/airbyte-integrations/connectors/destination-bigquery/src/main/java/io/airbyte/integrations/destination/bigquery/materialization/BigQueryMaterializationOperations.java
+++ b/airbyte-integrations/connectors/destination-bigquery/src/main/java/io/airbyte/integrations/destination/bigquery/materialization/BigQueryMaterializationOperations.java
@@ -145,7 +145,7 @@ public class BigQueryMaterializationOperations implements MaterializationOperati
   @Override
   public void mergeFromRawTable(String dataset, String rawTable, String finalTable, ConfiguredAirbyteStream stream, Schema schema) throws InterruptedException {
     // TODO handle non dedup sync modes (i.e. no PK) - probably needs to be an INSERT instead of MERGE
-    // TODO handle CDC (multiple new raw records for a single PK)
+    // TODO handle CDC/resets (multiple raw records for a single PK)
     // TODO we should save this generated SQL. Just log it for now, but thats going to be super unergonomic
     // TODO we need to stick another _airbyte_eimtted_at > whatever clause somewhere maybe, to avoid a full table scan?
     /*

--- a/airbyte-integrations/connectors/destination-bigquery/src/main/java/io/airbyte/integrations/destination/bigquery/materialization/BigQueryMaterializationOperations.java
+++ b/airbyte-integrations/connectors/destination-bigquery/src/main/java/io/airbyte/integrations/destination/bigquery/materialization/BigQueryMaterializationOperations.java
@@ -145,7 +145,7 @@ public class BigQueryMaterializationOperations implements MaterializationOperati
   @Override
   public void mergeFromRawTable(String dataset, String rawTable, String finalTable, ConfiguredAirbyteStream stream, Schema schema) throws InterruptedException {
     // TODO handle non dedup sync modes (i.e. no PK) - probably needs to be an INSERT instead of MERGE
-    // TODO handle CDC/resets (multiple raw records for a single PK)
+    // TODO handle CDC/soft resets (multiple raw records for a single PK)
     // TODO we should save this generated SQL. Just log it for now, but thats going to be super unergonomic
     // TODO we need to stick another _airbyte_eimtted_at > whatever clause somewhere maybe, to avoid a full table scan?
     /*

--- a/airbyte-integrations/connectors/destination-bigquery/src/main/java/io/airbyte/integrations/destination/bigquery/materialization/BigQueryMaterializationOperations.java
+++ b/airbyte-integrations/connectors/destination-bigquery/src/main/java/io/airbyte/integrations/destination/bigquery/materialization/BigQueryMaterializationOperations.java
@@ -34,12 +34,15 @@ public class BigQueryMaterializationOperations {
     // TODO we probably should only do the getDataset().list() once per dataset
     // TODO maybe we put the raw table in a different dataset from the final table
     final Page<Table> page = bigquery.getDataset(datasetId).list();
+    boolean tableExists = false;
     for (Table table : page.getValues()) {
       if (tableName.equals(table.getFriendlyName())) {
         // TODO table exists - check existing table schema + alter table to match schema (maybe also alter partitoining/clustering)
-      } else {
-        // TODO table doesn't exist - create it with schema + partitoining + clustering
+        tableExists = true;
       }
+    }
+    if (!tableExists) {
+      // TODO table doesn't exist - create it with schema + partitoining + clustering
     }
   }
 

--- a/airbyte-integrations/connectors/destination-bigquery/src/main/java/io/airbyte/integrations/destination/bigquery/materialization/BigQueryMaterializationOperations.java
+++ b/airbyte-integrations/connectors/destination-bigquery/src/main/java/io/airbyte/integrations/destination/bigquery/materialization/BigQueryMaterializationOperations.java
@@ -21,7 +21,7 @@ public class BigQueryMaterializationOperations implements MaterializationOperati
   }
 
   /*
-   * commentary: this is equivalent to existing normalization code.
+   * commentary: this is equivalent to existing normalization code. It's the whole "convert jsonschema types to sql types" thing.
    */
   public Schema getTableSchema(ConfiguredAirbyteStream stream) {
     // TODO

--- a/airbyte-integrations/connectors/destination-bigquery/src/main/java/io/airbyte/integrations/destination/bigquery/materialization/BigQueryMaterializationOperations.java
+++ b/airbyte-integrations/connectors/destination-bigquery/src/main/java/io/airbyte/integrations/destination/bigquery/materialization/BigQueryMaterializationOperations.java
@@ -11,7 +11,8 @@ import com.google.cloud.bigquery.Table;
 import io.airbyte.protocol.models.v0.ConfiguredAirbyteStream;
 
 // name is debatable :P but "BigQueryTypingAndDedupingOperations" is a really sad name
-public class BigQueryMaterializationOperations {
+// `Schema` here is a com.google.cloud.bigquery.Schema
+public class BigQueryMaterializationOperations implements MaterializationOperations<Schema> {
 
   private final BigQuery bigquery;
 
@@ -54,7 +55,7 @@ public class BigQueryMaterializationOperations {
    *
    * The DELETE thing is new, and an improvement over normalization (where we need a separate DELETE call)
    */
-  public void mergeFromRawTable(String dataset, String rawTable, String finalTable, Schema schema) {
+  public void mergeFromRawTable(String dataset, String rawTable, String finalTable, ConfiguredAirbyteStream stream) {
     // TODO generate a SQL query >.>
     // TODO handle non dedup sync modes (i.e. no PK) - probably needs to be an INSERT instead of MERGE
     // TODO handle CDC (multiple new raw records for a single PK)

--- a/airbyte-integrations/connectors/destination-bigquery/src/main/java/io/airbyte/integrations/destination/bigquery/materialization/BigQueryMaterializationOperations.java
+++ b/airbyte-integrations/connectors/destination-bigquery/src/main/java/io/airbyte/integrations/destination/bigquery/materialization/BigQueryMaterializationOperations.java
@@ -52,7 +52,7 @@ public class BigQueryMaterializationOperations implements MaterializationOperati
   @Override
   public Schema getTableSchema(ConfiguredAirbyteStream stream) {
     final JsonNode jsonSchema = stream.getStream().getJsonSchema();
-    if (jsonSchema.hasNonNull("properties")) {
+    if (!jsonSchema.hasNonNull("properties")) {
       // TODO we probably should handle this in some reasonable way
       throw new IllegalArgumentException("Top-level stream schema must be an object; got " + jsonSchema);
     }

--- a/airbyte-integrations/connectors/destination-bigquery/src/main/java/io/airbyte/integrations/destination/bigquery/materialization/BigQueryMaterializationOperations.java
+++ b/airbyte-integrations/connectors/destination-bigquery/src/main/java/io/airbyte/integrations/destination/bigquery/materialization/BigQueryMaterializationOperations.java
@@ -61,6 +61,7 @@ public class BigQueryMaterializationOperations implements MaterializationOperati
     // TODO handle non dedup sync modes (i.e. no PK) - probably needs to be an INSERT instead of MERGE
     // TODO handle CDC (multiple new raw records for a single PK)
     // TODO we should save this generated SQL. Just log it for now, but thats going to be super unergonomic
+    // TODO we need to stick another _airbyte_eimtted_at > whatever clause somewhere maybe, to avoid a full table scan?
     /*
     WITH new_raw_records AS (
       SELECT * FROM dataset.rawTable

--- a/airbyte-integrations/connectors/destination-bigquery/src/main/java/io/airbyte/integrations/destination/bigquery/materialization/BigQueryMaterializationOperations.java
+++ b/airbyte-integrations/connectors/destination-bigquery/src/main/java/io/airbyte/integrations/destination/bigquery/materialization/BigQueryMaterializationOperations.java
@@ -1,0 +1,78 @@
+/*
+ * Copyright (c) 2023 Airbyte, Inc., all rights reserved.
+ */
+
+package io.airbyte.integrations.destination.bigquery.materialization;
+
+import com.google.api.gax.paging.Page;
+import com.google.cloud.bigquery.BigQuery;
+import com.google.cloud.bigquery.Schema;
+import com.google.cloud.bigquery.Table;
+import io.airbyte.protocol.models.v0.ConfiguredAirbyteStream;
+
+public class BigQueryMaterializationOperations {
+
+  private final BigQuery bigquery;
+
+  public BigQueryMaterializationOperations(final BigQuery bigquery) {
+    this.bigquery = bigquery;
+  }
+
+  /*
+   * commentary: this is equivalent to existing normalization code.
+   */
+  public Schema getTableSchema(ConfiguredAirbyteStream stream) {
+    // TODO
+    return null;
+  }
+
+  /*
+   * commentary: This is new code. dbt handled this for us transparently.
+   */
+  public void createOrAlterTable(String datasetId, String tableName, Schema schema) {
+    // TODO we probably should only do the getDataset().list() once per dataset
+    // TODO maybe we put the raw table in a different dataset from the final table
+    final Page<Table> page = bigquery.getDataset(datasetId).list();
+    for (Table table : page.getValues()) {
+      if (tableName.equals(table.getFriendlyName())) {
+        // TODO table exists - check existing table schema + alter table to match schema (maybe also alter partitoining/clustering)
+      } else {
+        // TODO table doesn't exist - create it with schema + partitoining + clustering
+      }
+    }
+  }
+
+  /*
+   * commentary: Some of this is equivalent to normalization code - the stuff around extracting JSON fields
+   * and casting their types, etc.
+   *
+   * The stuff around explicitly writing a merge / insert is new; dbt handles that for us.
+   */
+  public void mergeFromRawTable(String dataset, String rawTable, String finalTable, Schema schema) {
+    // TODO generate a SQL query >.>
+    // TODO handle non dedup sync modes (i.e. no PK) - probably needs to be an INSERT instead of MERGE
+    // TODO handle CDC (i.e. multiple new raw records for a single PK)
+    /*
+    WITH new_raw_records AS (
+      SELECT * FROM dataset.rawTable
+      WHERE _airbyte_emitted_at > (SELECT MAX(_airbyte_emitted_at) FROM dataset.finalTable)
+    ), flattened_raw_records AS (
+      SELECT
+        json_extract(_airbyte_data, field1) AS field1,
+        ...additional extract calls for each top-level field...
+      FROM new_raw_records
+    ), typed_raw_records AS (
+      CAST(field1 AS type1) AS field1,
+      ...
+      FROM flattened_raw_records
+    )
+    MERGE dataset.finalTable T
+    USING dataset.typed_raw_records S
+    ON T.primary_key = S.primary_key
+    WHEN MATCHED THEN
+      UPDATE SET field1 = S.field1, ...
+    WHEN NOT MATCHED THEN
+      INSERT (field1, ...) VALUES (S.field1, ...)
+     */
+  }
+}

--- a/airbyte-integrations/connectors/destination-bigquery/src/main/java/io/airbyte/integrations/destination/bigquery/materialization/BigQueryMaterializationOperations.java
+++ b/airbyte-integrations/connectors/destination-bigquery/src/main/java/io/airbyte/integrations/destination/bigquery/materialization/BigQueryMaterializationOperations.java
@@ -10,6 +10,7 @@ import com.google.cloud.bigquery.Schema;
 import com.google.cloud.bigquery.Table;
 import io.airbyte.protocol.models.v0.ConfiguredAirbyteStream;
 
+// name is debatable :P but "BigQueryTypingAndDedupingOperations" is a really sad name
 public class BigQueryMaterializationOperations {
 
   private final BigQuery bigquery;
@@ -47,11 +48,14 @@ public class BigQueryMaterializationOperations {
    * and casting their types, etc.
    *
    * The stuff around explicitly writing a merge / insert is new; dbt handles that for us.
+   *
+   * The DELETE thing is new, and an improvement over normalization (where we need a separate DELETE call)
    */
   public void mergeFromRawTable(String dataset, String rawTable, String finalTable, Schema schema) {
     // TODO generate a SQL query >.>
     // TODO handle non dedup sync modes (i.e. no PK) - probably needs to be an INSERT instead of MERGE
-    // TODO handle CDC (i.e. multiple new raw records for a single PK)
+    // TODO handle CDC (multiple new raw records for a single PK)
+    // TODO we should save this generated SQL. Just log it for now, but thats going to be super unergonomic
     /*
     WITH new_raw_records AS (
       SELECT * FROM dataset.rawTable
@@ -60,6 +64,7 @@ public class BigQueryMaterializationOperations {
       SELECT
         json_extract(_airbyte_data, field1) AS field1,
         ...additional extract calls for each top-level field...
+        _airbyte_emitted_at, other metadata columns...
       FROM new_raw_records
     ), typed_raw_records AS (
       CAST(field1 AS type1) AS field1,
@@ -69,6 +74,9 @@ public class BigQueryMaterializationOperations {
     MERGE dataset.finalTable T
     USING dataset.typed_raw_records S
     ON T.primary_key = S.primary_key
+    -- only generate this clause if stream contains the column + is incremenaldedup
+    WHEN MATCHED AND _airbyte_cdc_deleted_at IS NOT NULL THEN
+      DELETE
     WHEN MATCHED THEN
       UPDATE SET field1 = S.field1, ...
     WHEN NOT MATCHED THEN

--- a/airbyte-integrations/connectors/destination-bigquery/src/main/java/io/airbyte/integrations/destination/bigquery/materialization/MaterializationOperations.java
+++ b/airbyte-integrations/connectors/destination-bigquery/src/main/java/io/airbyte/integrations/destination/bigquery/materialization/MaterializationOperations.java
@@ -1,0 +1,13 @@
+package io.airbyte.integrations.destination.bigquery.materialization;
+
+import io.airbyte.protocol.models.v0.ConfiguredAirbyteStream;
+
+// super rough guess at what this interface looks like.
+// maybe we don't actually want this thing to be shared
+// but we definitely will want something for jdbc destinations at least
+public interface MaterializationOperations<Schema> {
+
+  Schema getTableSchema(ConfiguredAirbyteStream stream);
+  void createOrAlterTable(String datasetId, String tableName, Schema schema);
+  void mergeFromRawTable(String dataset, String rawTable, String finalTable, ConfiguredAirbyteStream stream);
+}

--- a/airbyte-integrations/connectors/destination-bigquery/src/main/java/io/airbyte/integrations/destination/bigquery/materialization/MaterializationOperations.java
+++ b/airbyte-integrations/connectors/destination-bigquery/src/main/java/io/airbyte/integrations/destination/bigquery/materialization/MaterializationOperations.java
@@ -9,5 +9,5 @@ public interface MaterializationOperations<Schema> {
 
   Schema getTableSchema(ConfiguredAirbyteStream stream);
   void createOrAlterTable(String datasetId, String tableName, Schema schema);
-  void mergeFromRawTable(String dataset, String rawTable, String finalTable, ConfiguredAirbyteStream stream);
+  void mergeFromRawTable(String dataset, String rawTable, String finalTable, ConfiguredAirbyteStream stream, Schema schema) throws InterruptedException;
 }


### PR DESCRIPTION
convert jsonschema to bq schema (very poorly)

create table using that schema (doesn't yet handle schema evolution)

runs a sql statement like
```sql
MERGE edgao_test_1s1t.testtest T
USING (
  WITH new_raw_records AS (
    SELECT * FROM edgao_test_1s1t._airbyte_raw_testtest
    WHERE _airbyte_emitted_at > (SELECT COALESCE(MAX(_airbyte_emitted_at), '0001-01-01 00:00:00') FROM edgao_test_1s1t.edgao_1s1t_test_testtest)
  ), flattened_raw_records AS (
    SELECT
      JSON_EXTRACT(_airbyte_data, '$.updated_at') AS updated_at,
      JSON_EXTRACT(_airbyte_data, '$.name') AS name,
      JSON_EXTRACT(_airbyte_data, '$.id') AS id,

      _airbyte_emitted_at
    FROM new_raw_records
  )
  SELECT
    CAST(updated_at AS NUMERIC) AS updated_at,
    CAST(name AS STRING) AS name,
    CAST(id AS NUMERIC) AS id,

    _airbyte_emitted_at
  FROM flattened_raw_records
) S
ON T.id = S.id

WHEN MATCHED THEN
  UPDATE SET updated_at = S.updated_at,name = S.name,id = S.id, _airbyte_emitted_at = S._airbyte_emitted_at
WHEN NOT MATCHED THEN
  INSERT (updated_at,name,id, _airbyte_emitted_at) VALUES (S.updated_at,S.name,S.id, S._airbyte_emitted_at)
```