### PR TITLE
low-code: Remove NoAuth from the interface

### DIFF
--- a/airbyte-cdk/python/airbyte_cdk/sources/declarative/declarative_component_schema.yaml
+++ b/airbyte-cdk/python/airbyte_cdk/sources/declarative/declarative_component_schema.yaml
@@ -678,7 +678,6 @@ definitions:
           - "$ref": "#/definitions/CustomAuthenticator"
           - "$ref": "#/definitions/OAuthAuthenticator"
           - "$ref": "#/definitions/SingleUseRefreshTokenOAuthAuthenticator"
-          - "$ref": "#/definitions/NoAuth"
           - "$ref": "#/definitions/SessionTokenAuthenticator"
       error_handler:
         description: Error handler component that defines how to handle errors.
@@ -833,18 +832,6 @@ definitions:
         type: string
       min_datetime:
         type: string
-      $parameters:
-        type: object
-        additionalProperties: true
-  NoAuth:
-    description: Authenticator for requests requiring no authentication
-    type: object
-    required:
-      - type
-    properties:
-      type:
-        type: string
-        enum: [NoAuth]
       $parameters:
         type: object
         additionalProperties: true

--- a/airbyte-cdk/python/airbyte_cdk/sources/declarative/models/declarative_component_schema.py
+++ b/airbyte-cdk/python/airbyte_cdk/sources/declarative/models/declarative_component_schema.py
@@ -252,11 +252,6 @@ class MinMaxDatetime(BaseModel):
     parameters: Optional[Dict[str, Any]] = Field(None, alias="$parameters")
 
 
-class NoAuth(BaseModel):
-    type: Literal["NoAuth"]
-    parameters: Optional[Dict[str, Any]] = Field(None, alias="$parameters")
-
-
 class NoPagination(BaseModel):
     type: Literal["NoPagination"]
 
@@ -529,7 +524,6 @@ class HttpRequester(BaseModel):
             CustomAuthenticator,
             OAuthAuthenticator,
             SingleUseRefreshTokenOAuthAuthenticator,
-            NoAuth,
             SessionTokenAuthenticator,
         ]
     ] = Field(

--- a/airbyte-cdk/python/airbyte_cdk/sources/declarative/parsers/model_to_component_factory.py
+++ b/airbyte-cdk/python/airbyte_cdk/sources/declarative/parsers/model_to_component_factory.py
@@ -57,7 +57,6 @@ from airbyte_cdk.sources.declarative.models.declarative_component_schema import 
 from airbyte_cdk.sources.declarative.models.declarative_component_schema import JsonFileSchemaLoader as JsonFileSchemaLoaderModel
 from airbyte_cdk.sources.declarative.models.declarative_component_schema import ListPartitionRouter as ListPartitionRouterModel
 from airbyte_cdk.sources.declarative.models.declarative_component_schema import MinMaxDatetime as MinMaxDatetimeModel
-from airbyte_cdk.sources.declarative.models.declarative_component_schema import NoAuth as NoAuthModel
 from airbyte_cdk.sources.declarative.models.declarative_component_schema import NoPagination as NoPaginationModel
 from airbyte_cdk.sources.declarative.models.declarative_component_schema import OAuthAuthenticator as OAuthAuthenticatorModel
 from airbyte_cdk.sources.declarative.models.declarative_component_schema import OffsetIncrement as OffsetIncrementModel

--- a/airbyte-cdk/python/airbyte_cdk/sources/declarative/parsers/model_to_component_factory.py
+++ b/airbyte-cdk/python/airbyte_cdk/sources/declarative/parsers/model_to_component_factory.py
@@ -153,7 +153,6 @@ class ModelToComponentFactory:
             JsonFileSchemaLoaderModel: self.create_json_file_schema_loader,
             ListPartitionRouterModel: self.create_list_partition_router,
             MinMaxDatetimeModel: self.create_min_max_datetime,
-            NoAuthModel: self.create_no_auth,
             NoPaginationModel: self.create_no_pagination,
             OAuthAuthenticatorModel: self.create_oauth_authenticator,
             SingleUseRefreshTokenOAuthAuthenticatorModel: self.create_single_use_refresh_token_oauth_authenticator,
@@ -639,10 +638,6 @@ class ModelToComponentFactory:
             min_datetime=model.min_datetime,
             parameters=model.parameters,
         )
-
-    @staticmethod
-    def create_no_auth(model: NoAuthModel, config: Config, **kwargs) -> NoAuth:
-        return NoAuth(parameters=model.parameters)
 
     @staticmethod
     def create_no_pagination(model: NoPaginationModel, config: Config, **kwargs) -> NoPagination:

--- a/airbyte-cdk/python/airbyte_cdk/sources/declarative/parsers/model_to_component_factory.py
+++ b/airbyte-cdk/python/airbyte_cdk/sources/declarative/parsers/model_to_component_factory.py
@@ -10,7 +10,6 @@ import re
 from typing import Any, Callable, List, Literal, Mapping, Optional, Type, Union, get_args, get_origin, get_type_hints
 
 from airbyte_cdk.sources.declarative.auth import DeclarativeOauth2Authenticator
-from airbyte_cdk.sources.declarative.auth.declarative_authenticator import NoAuth
 from airbyte_cdk.sources.declarative.auth.token import (
     ApiKeyAuthenticator,
     BasicHttpAuthenticator,

--- a/airbyte-integrations/connectors/source-alpha-vantage/source_alpha_vantage/manifest.yaml
+++ b/airbyte-integrations/connectors/source-alpha-vantage/source_alpha_vantage/manifest.yaml
@@ -14,8 +14,6 @@ definitions:
   requester:
     url_base: "https://www.alphavantage.co"
     http_method: "GET"
-    authenticator:
-      type: NoAuth
     request_parameters:
       apikey: "{{ config['api_key'] }}"
       symbol: "{{ config['symbol'] }}"
@@ -27,8 +25,6 @@ definitions:
   retriever:
     record_selector:
       $ref: "#/definitions/selector"
-    paginator:
-      type: NoPagination
     requester:
       $ref: "#/definitions/requester"
   base_stream:


### PR DESCRIPTION
## What
The `NoAuth` object does not need to be exposed in the DSL because the HttpRequester's authenticator field is optional.

This removes the `NoAuth` from the manifest schema so we don't need to document and maintain it.

The `NoAuth` object is only used explicitly once for source-alpha-vantage

## How
- Remove `NoAuth` from the definitions
- Update the model to component factory
- Update source-alpha-vantage to implicitly use no auth

## Recommended reading order
1. `airbyte-cdk/python/airbyte_cdk/sources/declarative/declarative_component_schema.yaml`
2. `airbyte-cdk/python/airbyte_cdk/sources/declarative/parsers/model_to_component_factory.py`
3. `airbyte-integrations/connectors/source-alpha-vantage/source_alpha_vantage/manifest.yaml`

## Testing
Tested locally because we can't run CATs with the local version of the CDK using CI.
I tested the following:
- `./airbyte-cdk/python/bin/run-cats-with-local-cdk.sh -c source-alpha-vantage`
- `./airbyte-cdk/python/bin/run-cats-with-local-cdk.sh -c source-gnews`
- `./airbyte-cdk/python/bin/run-cats-with-local-cdk.sh -c source-greenhouse`

Dagger CI pipeline is failing because it doesn't test with local changes to the CDK