### PR TITLE
low-code: remove mentions of NoPagination from existing manifests

### DIFF
--- a/airbyte-integrations/connector-templates/source-configuration-based/source_{{snakeCase name}}/manifest.yaml.hbs
+++ b/airbyte-integrations/connector-templates/source-configuration-based/source_{{snakeCase name}}/manifest.yaml.hbs
@@ -17,8 +17,6 @@ definitions:
     type: SimpleRetriever
     record_selector:
       $ref: "#/definitions/selector"
-    paginator:
-      type: NoPagination
     requester:
       $ref: "#/definitions/requester"
   base_stream:

--- a/airbyte-integrations/connectors/source-alpha-vantage/source_alpha_vantage/manifest.yaml
+++ b/airbyte-integrations/connectors/source-alpha-vantage/source_alpha_vantage/manifest.yaml
@@ -27,8 +27,6 @@ definitions:
   retriever:
     record_selector:
       $ref: "#/definitions/selector"
-    paginator:
-      type: NoPagination
     requester:
       $ref: "#/definitions/requester"
   base_stream:

--- a/airbyte-integrations/connectors/source-braze/source_braze/manifest.yaml
+++ b/airbyte-integrations/connectors/source-braze/source_braze/manifest.yaml
@@ -105,8 +105,6 @@ definitions:
   non_paginated_retriever:
     record_selector:
       $ref: "#/definitions/base_selector"
-    paginator:
-      type: NoPagination
     requester:
       $ref: "#/definitions/requester"
     incremental_sync:

--- a/airbyte-integrations/connectors/source-breezometer/source_breezometer/manifest.yaml
+++ b/airbyte-integrations/connectors/source-breezometer/source_breezometer/manifest.yaml
@@ -9,8 +9,6 @@ definitions:
     retriever:
       record_selector:
         $ref: "#/definitions/selector"
-      paginator:
-        type: NoPagination
       requester:
         url_base: "https://api.breezometer.com"
         http_method: "GET"
@@ -27,8 +25,6 @@ definitions:
     retriever:
       record_selector:
         $ref: "#/definitions/selector"
-      paginator:
-        type: NoPagination
       requester:
         url_base: "https://api.breezometer.com"
         http_method: "GET"
@@ -46,8 +42,6 @@ definitions:
     retriever:
       record_selector:
         $ref: "#/definitions/selector"
-      paginator:
-        type: NoPagination
       requester:
         url_base: "https://api.breezometer.com"
         http_method: "GET"
@@ -65,8 +59,6 @@ definitions:
     retriever:
       record_selector:
         $ref: "#/definitions/selector"
-      paginator:
-        type: NoPagination
       requester:
         url_base: "https://api.breezometer.com"
         http_method: "GET"
@@ -84,8 +76,6 @@ definitions:
     retriever:
       record_selector:
         $ref: "#/definitions/selector"
-      paginator:
-        type: NoPagination
       requester:
         url_base: "https://api.breezometer.com"
         http_method: "GET"
@@ -102,8 +92,6 @@ definitions:
     retriever:
       record_selector:
         $ref: "#/definitions/selector"
-      paginator:
-        type: NoPagination
       requester:
         url_base: "https://api.breezometer.com"
         http_method: "GET"
@@ -120,8 +108,6 @@ definitions:
     retriever:
       record_selector:
         $ref: "#/definitions/selector"
-      paginator:
-        type: NoPagination
       requester:
         url_base: "https://api.breezometer.com"
         http_method: "GET"
@@ -138,8 +124,6 @@ definitions:
     retriever:
       record_selector:
         $ref: "#/definitions/selector"
-      paginator:
-        type: NoPagination
       requester:
         url_base: "https://api.breezometer.com"
         http_method: "GET"

--- a/airbyte-integrations/connectors/source-chartmogul/source_chartmogul/manifest.yaml
+++ b/airbyte-integrations/connectors/source-chartmogul/source_chartmogul/manifest.yaml
@@ -69,8 +69,6 @@ definitions:
           start-date: "{{ format_datetime(config['start_date'], '%Y-%m-%d') }}"
           end-date: "{{ now_utc().strftime('%Y-%m-%d') }}"
           interval: "{{ config['interval'] }}"
-      paginator:
-        type: NoPagination
     $parameters:
       name: "customer_count"
       primary_key: "date"

--- a/airbyte-integrations/connectors/source-clickup-api/source_clickup_api/manifest.yaml
+++ b/airbyte-integrations/connectors/source-clickup-api/source_clickup_api/manifest.yaml
@@ -21,8 +21,6 @@ definitions:
       type: ApiKeyAuthenticator
       header: "Authorization"
       api_token: "{{ config['api_token'] }}"
-  paginator:
-    type: NoPagination
   retriever:
     type: SimpleRetriever
     $parameters:

--- a/airbyte-integrations/connectors/source-close-com/source_close_com/manifest.yaml
+++ b/airbyte-integrations/connectors/source-close-com/source_close_com/manifest.yaml
@@ -103,8 +103,6 @@ definitions:
       $ref: "#/definitions/selector"
     requester:
       $ref: "#/definitions/requester"
-    paginator:
-      type: NoPagination
 
   base_stream:
     retriever:

--- a/airbyte-integrations/connectors/source-coin-api/source_coin_api/manifest.yaml
+++ b/airbyte-integrations/connectors/source-coin-api/source_coin_api/manifest.yaml
@@ -20,8 +20,6 @@ definitions:
   retriever:
     record_selector:
       $ref: "#/definitions/selector"
-    paginator:
-      type: NoPagination
     requester:
       $ref: "#/definitions/requester"
   base_stream:

--- a/airbyte-integrations/connectors/source-coingecko-coins/source_coingecko_coins/manifest.yaml
+++ b/airbyte-integrations/connectors/source-coingecko-coins/source_coingecko_coins/manifest.yaml
@@ -29,8 +29,6 @@ definitions:
   retriever:
     record_selector:
       $ref: "#/definitions/selector"
-    paginator:
-      type: NoPagination
     requester:
       $ref: "#/definitions/requester"
   base_stream:

--- a/airbyte-integrations/connectors/source-coinmarketcap/source_coinmarketcap/manifest.yaml
+++ b/airbyte-integrations/connectors/source-coinmarketcap/source_coinmarketcap/manifest.yaml
@@ -50,8 +50,6 @@ definitions:
     retriever:
       record_selector:
         $ref: "#/definitions/selector"
-      paginator:
-        type: NoPagination
       requester:
         $ref: "#/definitions/requester"
         request_parameters:

--- a/airbyte-integrations/connectors/source-configcat/source_configcat/manifest.yaml
+++ b/airbyte-integrations/connectors/source-configcat/source_configcat/manifest.yaml
@@ -14,8 +14,6 @@ definitions:
   retriever:
     record_selector:
       $ref: "#/definitions/selector"
-    paginator:
-      type: NoPagination
     requester:
       $ref: "#/definitions/requester"
   base_stream:

--- a/airbyte-integrations/connectors/source-convertkit/source_convertkit/manifest.yaml
+++ b/airbyte-integrations/connectors/source-convertkit/source_convertkit/manifest.yaml
@@ -25,8 +25,6 @@ definitions:
   retriever:
     record_selector:
       $ref: "#/definitions/selector"
-    paginator:
-      type: NoPagination
     requester:
       $ref: "#/definitions/requester"
   base_stream:

--- a/airbyte-integrations/connectors/source-dremio/source_dremio/manifest.yaml
+++ b/airbyte-integrations/connectors/source-dremio/source_dremio/manifest.yaml
@@ -16,8 +16,6 @@ definitions:
   retriever:
     record_selector:
       $ref: "#/definitions/selector"
-    paginator:
-      type: NoPagination
     requester:
       $ref: "#/definitions/requester"
   base_stream:

--- a/airbyte-integrations/connectors/source-emailoctopus/source_emailoctopus/manifest.yaml
+++ b/airbyte-integrations/connectors/source-emailoctopus/source_emailoctopus/manifest.yaml
@@ -24,8 +24,6 @@ definitions:
   retriever:
     record_selector:
       $ref: "#/definitions/selector"
-    paginator:
-      type: NoPagination
     requester:
       $ref: "#/definitions/requester"
   base_stream:

--- a/airbyte-integrations/connectors/source-everhour/source_everhour/everhour.yaml
+++ b/airbyte-integrations/connectors/source-everhour/source_everhour/everhour.yaml
@@ -16,8 +16,6 @@ definitions:
   retriever:
     record_selector:
       $ref: "#/definitions/selector"
-    paginator:
-      type: NoPagination
     requester:
       $ref: "#/definitions/requester"
   base_stream:

--- a/airbyte-integrations/connectors/source-facebook-pages/source_facebook_pages/manifest.yaml
+++ b/airbyte-integrations/connectors/source-facebook-pages/source_facebook_pages/manifest.yaml
@@ -40,8 +40,6 @@ definitions:
   retriever:
     record_selector:
       $ref: "#/definitions/selector"
-    paginator:
-      type: NoPagination
     requester:
       $ref: "#/definitions/requester"
 

--- a/airbyte-integrations/connectors/source-gnews/source_gnews/manifest.yaml
+++ b/airbyte-integrations/connectors/source-gnews/source_gnews/manifest.yaml
@@ -24,8 +24,6 @@ definitions:
   base_retriever:
     record_selector:
       $ref: "#/definitions/selector"
-    paginator:
-      type: NoPagination
   incremental_sync:
     type: "DatetimeBasedCursor"
     start_datetime:

--- a/airbyte-integrations/connectors/source-google-pagespeed-insights/source_google_pagespeed_insights/manifest.yaml
+++ b/airbyte-integrations/connectors/source-google-pagespeed-insights/source_google_pagespeed_insights/manifest.yaml
@@ -26,8 +26,6 @@ definitions:
   retriever:
     record_selector:
       $ref: "#/definitions/selector"
-    paginator:
-      type: NoPagination
     requester:
       $ref: "#/definitions/requester"
     partition_router:

--- a/airbyte-integrations/connectors/source-google-webfonts/source_google_webfonts/manifest.yaml
+++ b/airbyte-integrations/connectors/source-google-webfonts/source_google_webfonts/manifest.yaml
@@ -15,8 +15,6 @@ definitions:
   retriever:
     record_selector:
       $ref: "#/definitions/selector"
-    paginator:
-      type: NoPagination
     requester:
       $ref: "#/definitions/requester"
 

--- a/airbyte-integrations/connectors/source-instatus/source_instatus/manifest.yaml
+++ b/airbyte-integrations/connectors/source-instatus/source_instatus/manifest.yaml
@@ -40,8 +40,6 @@ definitions:
   retriever:
     record_selector:
       $ref: "#/definitions/selector"
-    paginator:
-      type: NoPagination
     requester:
       $ref: "#/definitions/requester"
 

--- a/airbyte-integrations/connectors/source-intercom/source_intercom/manifest.yaml
+++ b/airbyte-integrations/connectors/source-intercom/source_intercom/manifest.yaml
@@ -203,8 +203,6 @@ definitions:
       cursor_field: "updated_at"
     retriever:
       $ref: "#/definitions/stream_full_refresh/retriever"
-      paginator:
-        type: "NoPagination"
       record_selector:
         $ref: "#/definitions/selector"
         record_filter:

--- a/airbyte-integrations/connectors/source-ip2whois/source_ip2whois/manifest.yaml
+++ b/airbyte-integrations/connectors/source-ip2whois/source_ip2whois/manifest.yaml
@@ -13,8 +13,6 @@ definitions:
   retriever:
     record_selector:
       $ref: "#/definitions/selector"
-    paginator:
-      type: NoPagination
     requester:
       $ref: "#/definitions/requester"
   base_stream:

--- a/airbyte-integrations/connectors/source-k6-cloud/source_k6_cloud/manifest.yaml
+++ b/airbyte-integrations/connectors/source-k6-cloud/source_k6_cloud/manifest.yaml
@@ -39,8 +39,6 @@ definitions:
     retriever:
       record_selector:
         $ref: "#/definitions/selector"
-      paginator:
-        type: NoPagination
       requester:
         $ref: "#/definitions/requester"
     $parameters:

--- a/airbyte-integrations/connectors/source-mailerlite/source_mailerlite/manifest.yaml
+++ b/airbyte-integrations/connectors/source-mailerlite/source_mailerlite/manifest.yaml
@@ -28,8 +28,6 @@ definitions:
   retriever:
     record_selector:
       $ref: "#/definitions/selector"
-    paginator:
-      type: NoPagination
     requester:
       $ref: "#/definitions/requester"
 

--- a/airbyte-integrations/connectors/source-mailjet-mail/source_mailjet_mail/manifest.yaml
+++ b/airbyte-integrations/connectors/source-mailjet-mail/source_mailjet_mail/manifest.yaml
@@ -26,8 +26,6 @@ definitions:
   retriever:
     record_selector:
       $ref: "#/definitions/selector"
-    paginator:
-      type: NoPagination
     requester:
       $ref: "#/definitions/requester"
   base_stream:

--- a/airbyte-integrations/connectors/source-mailjet-sms/source_mailjet_sms/manifest.yaml
+++ b/airbyte-integrations/connectors/source-mailjet-sms/source_mailjet_sms/manifest.yaml
@@ -28,8 +28,6 @@ definitions:
   retriever:
     record_selector:
       $ref: "#/definitions/selector"
-    paginator:
-      type: NoPagination
     requester:
       $ref: "#/definitions/requester"
   base_stream:

--- a/airbyte-integrations/connectors/source-metabase/source_metabase/manifest.yaml
+++ b/airbyte-integrations/connectors/source-metabase/source_metabase/manifest.yaml
@@ -25,15 +25,11 @@ definitions:
   retriever:
     record_selector:
       $ref: "#/definitions/selector"
-    paginator:
-      type: NoPagination
     requester:
       $ref: "#/definitions/requester"
   data_field_retriever:
     record_selector:
       $ref: "#/definitions/data_field_selector"
-    paginator:
-      type: NoPagination
     requester:
       $ref: "#/definitions/requester"
   base_stream:

--- a/airbyte-integrations/connectors/source-monday/source_monday/manifest.yaml
+++ b/airbyte-integrations/connectors/source-monday/source_monday/manifest.yaml
@@ -50,8 +50,6 @@ definitions:
   base_nopagination_stream:
     retriever:
       $ref: "#/definitions/retriever"
-      paginator:
-        type: NoPagination
   items_stream:
     $ref: "#/definitions/base_stream"
     retriever:

--- a/airbyte-integrations/connectors/source-nytimes/source_nytimes/manifest.yaml
+++ b/airbyte-integrations/connectors/source-nytimes/source_nytimes/manifest.yaml
@@ -7,8 +7,6 @@ definitions:
     request_parameters:
       api-key: "{{ config['api_key'] }}"
   retriever:
-    paginator:
-      type: NoPagination
     requester:
       $ref: "#/definitions/requester"
   archive_stream:

--- a/airbyte-integrations/connectors/source-pendo/source_pendo/manifest.yaml
+++ b/airbyte-integrations/connectors/source-pendo/source_pendo/manifest.yaml
@@ -200,8 +200,6 @@ streams:
         extractor:
           type: DpathExtractor
           field_path: []
-      paginator:
-        type: NoPagination
   - type: DeclarativeStream
     name: Feature
     primary_key:
@@ -415,8 +413,6 @@ streams:
         extractor:
           type: DpathExtractor
           field_path: []
-      paginator:
-        type: NoPagination
   - type: DeclarativeStream
     name: Report
     primary_key:
@@ -1078,8 +1074,6 @@ streams:
         extractor:
           type: DpathExtractor
           field_path: []
-      paginator:
-        type: NoPagination
   - type: DeclarativeStream
     name: Guide
     primary_key:
@@ -1944,8 +1938,6 @@ streams:
         extractor:
           type: DpathExtractor
           field_path: []
-      paginator:
-        type: NoPagination
   - type: DeclarativeStream
     name: Account Metadata
     primary_key: []
@@ -2241,8 +2233,6 @@ streams:
         extractor:
           type: DpathExtractor
           field_path: []
-      paginator:
-        type: NoPagination
   - type: DeclarativeStream
     name: Visitor Metadata
     primary_key: []
@@ -2957,8 +2947,6 @@ streams:
         extractor:
           type: DpathExtractor
           field_path: []
-      paginator:
-        type: NoPagination
 spec:
   connection_specification:
     $schema: http://json-schema.org/draft-07/schema#

--- a/airbyte-integrations/connectors/source-pexels-api/source_pexels_api/manifest.yaml
+++ b/airbyte-integrations/connectors/source-pexels-api/source_pexels_api/manifest.yaml
@@ -58,8 +58,6 @@ definitions:
   retriever:
     record_selector:
       $ref: "#/definitions/selector"
-    paginator:
-      type: NoPagination
     requester:
       $ref: "#/definitions/requester"
 

--- a/airbyte-integrations/connectors/source-plausible/source_plausible/manifest.yaml
+++ b/airbyte-integrations/connectors/source-plausible/source_plausible/manifest.yaml
@@ -25,8 +25,6 @@ definitions:
   retriever:
     record_selector:
       $ref: "#/definitions/selector"
-    paginator:
-      type: NoPagination
     requester:
       $ref: "#/definitions/requester"
   base_stream:

--- a/airbyte-integrations/connectors/source-polygon-stock-api/source_polygon_stock_api/manifest.yaml
+++ b/airbyte-integrations/connectors/source-polygon-stock-api/source_polygon_stock_api/manifest.yaml
@@ -14,8 +14,6 @@ definitions:
   retriever:
     record_selector:
       $ref: "#/definitions/selector"
-    paginator:
-      type: NoPagination
     requester:
       $ref: "#/definitions/requester"
   base_stream:

--- a/airbyte-integrations/connectors/source-punk-api/source_punk_api/manifest.yaml
+++ b/airbyte-integrations/connectors/source-punk-api/source_punk_api/manifest.yaml
@@ -18,8 +18,6 @@ definitions:
   retriever:
     record_selector:
       $ref: "#/definitions/selector"
-    paginator:
-      type: NoPagination
     requester:
       $ref: "#/definitions/requester"
 

--- a/airbyte-integrations/connectors/source-pypi/source_pypi/manifest.yaml
+++ b/airbyte-integrations/connectors/source-pypi/source_pypi/manifest.yaml
@@ -16,8 +16,6 @@ definitions:
   retriever:
     record_selector:
       $ref: "#/definitions/selector"
-    paginator:
-      type: NoPagination
     requester:
       $ref: "#/definitions/requester"
   base_stream:

--- a/airbyte-integrations/connectors/source-recruitee/source_recruitee/manifest.yaml
+++ b/airbyte-integrations/connectors/source-recruitee/source_recruitee/manifest.yaml
@@ -17,8 +17,6 @@ definitions:
   retriever:
     record_selector:
       $ref: "#/definitions/selector"
-    paginator:
-      type: NoPagination
     requester:
       $ref: "#/definitions/requester"
     primary_key: "id"

--- a/airbyte-integrations/connectors/source-reply-io/source_reply_io/manifest.yaml
+++ b/airbyte-integrations/connectors/source-reply-io/source_reply_io/manifest.yaml
@@ -21,8 +21,6 @@ definitions:
   retriever:
     record_selector:
       $ref: "#/definitions/selector"
-    paginator:
-      type: NoPagination
     requester:
       $ref: "#/definitions/requester"
 

--- a/airbyte-integrations/connectors/source-rocket-chat/source_rocket_chat/manifest.yaml
+++ b/airbyte-integrations/connectors/source-rocket-chat/source_rocket_chat/manifest.yaml
@@ -34,8 +34,6 @@ definitions:
   custom_retriever:
     record_selector:
       $ref: "#/definitions/update_selector"
-    paginator:
-      type: NoPagination
     requester:
       $ref: "#/definitions/requester"
   retriever:
@@ -73,8 +71,6 @@ definitions:
     retriever:
       record_selector:
         $ref: "#/definitions/selector"
-      paginator:
-        type: NoPagination
       requester:
         $ref: "#/definitions/requester"
     $parameters:

--- a/airbyte-integrations/connectors/source-sap-fieldglass/source_sap_fieldglass/manifest.yaml
+++ b/airbyte-integrations/connectors/source-sap-fieldglass/source_sap_fieldglass/manifest.yaml
@@ -17,8 +17,6 @@ definitions:
   retriever:
     record_selector:
       $ref: "#/definitions/selector"
-    paginator:
-      type: NoPagination
     requester:
       $ref: "#/definitions/requester"
   base_stream:

--- a/airbyte-integrations/connectors/source-sendgrid/source_sendgrid/manifest.yaml
+++ b/airbyte-integrations/connectors/source-sendgrid/source_sendgrid/manifest.yaml
@@ -80,8 +80,6 @@ definitions:
           field_path: []
       requester:
         $ref: "#/definitions/requester"
-      paginator:
-        type: NoPagination
 streams:
   - $ref: "#/definitions/base_stream"
     $parameters:

--- a/airbyte-integrations/connectors/source-sentry/source_sentry/manifest.yaml
+++ b/airbyte-integrations/connectors/source-sentry/source_sentry/manifest.yaml
@@ -98,8 +98,6 @@ streams:
       requester:
         $ref: "#/definitions/requester"
         path: "projects/{{config.organization}}/{{config.project}}/"
-      paginator:
-        type: NoPagination
 check:
   type: CheckStream
   stream_names: ["project_detail"]

--- a/airbyte-integrations/connectors/source-smaily/source_smaily/manifest.yaml
+++ b/airbyte-integrations/connectors/source-smaily/source_smaily/manifest.yaml
@@ -26,8 +26,6 @@ definitions:
   retriever:
     record_selector:
       $ref: "#/definitions/selector"
-    paginator:
-      type: NoPagination
     requester:
       $ref: "#/definitions/requester"
   base_stream:

--- a/airbyte-integrations/connectors/source-smartengage/source_smartengage/manifest.yaml
+++ b/airbyte-integrations/connectors/source-smartengage/source_smartengage/manifest.yaml
@@ -14,8 +14,6 @@ definitions:
   retriever:
     record_selector:
       $ref: "#/definitions/selector"
-    paginator:
-      type: NoPagination
     requester:
       $ref: "#/definitions/requester"
   base_stream:

--- a/airbyte-integrations/connectors/source-spacex-api/source_spacex_api/manifest.yaml
+++ b/airbyte-integrations/connectors/source-spacex-api/source_spacex_api/manifest.yaml
@@ -12,8 +12,6 @@ definitions:
   retriever:
     record_selector:
       $ref: "#/definitions/selector"
-    paginator:
-      type: NoPagination
     requester:
       $ref: "#/definitions/requester"
 

--- a/airbyte-integrations/connectors/source-survey-sparrow/source_survey_sparrow/manifest.yaml
+++ b/airbyte-integrations/connectors/source-survey-sparrow/source_survey_sparrow/manifest.yaml
@@ -46,8 +46,6 @@ definitions:
       name: "contact_lists"
       primary_key: "id"
       path: "/contact_lists"
-    paginator:
-      type: "NoPagination"
   questions_stream:
     $ref: "#/definitions/base_stream"
     $parameters:

--- a/airbyte-integrations/connectors/source-tmdb/source_tmdb/manifest.yaml
+++ b/airbyte-integrations/connectors/source-tmdb/source_tmdb/manifest.yaml
@@ -34,8 +34,6 @@ definitions:
   retriever:
     record_selector:
       $ref: "#/definitions/selector"
-    paginator:
-      type: NoPagination
     requester:
       $ref: "#/definitions/requester"
 

--- a/airbyte-integrations/connectors/source-toggl/source_toggl/manifest.yaml
+++ b/airbyte-integrations/connectors/source-toggl/source_toggl/manifest.yaml
@@ -32,8 +32,6 @@ definitions:
   retriever:
     record_selector:
       $ref: "#/definitions/selector"
-    paginator:
-      type: NoPagination
     requester:
       $ref: "#/definitions/requester"
   base_stream:

--- a/airbyte-integrations/connectors/source-tvmaze-schedule/source_tvmaze_schedule/manifest.yaml
+++ b/airbyte-integrations/connectors/source-tvmaze-schedule/source_tvmaze_schedule/manifest.yaml
@@ -34,8 +34,6 @@ definitions:
   retriever:
     record_selector:
       $ref: "#/definitions/selector"
-    paginator:
-      type: NoPagination
     requester:
       $ref: "#/definitions/requester"
   base_stream:

--- a/airbyte-integrations/connectors/source-tyntec-sms/source_tyntec_sms/manifest.yaml
+++ b/airbyte-integrations/connectors/source-tyntec-sms/source_tyntec_sms/manifest.yaml
@@ -15,8 +15,6 @@ definitions:
   retriever:
     record_selector:
       $ref: "#/definitions/selector"
-    paginator:
-      type: NoPagination
     requester:
       $ref: "#/definitions/requester"
   base_stream:

--- a/airbyte-integrations/connectors/source-unleash/source_unleash/unleash.yaml
+++ b/airbyte-integrations/connectors/source-unleash/source_unleash/unleash.yaml
@@ -29,8 +29,6 @@ definitions:
   retriever:
     record_selector:
       $ref: "#/definitions/selector"
-    paginator:
-      type: NoPagination
     requester:
       $ref: "#/definitions/requester"
 

--- a/airbyte-integrations/connectors/source-waiteraid/source_waiteraid/manifest.yaml
+++ b/airbyte-integrations/connectors/source-waiteraid/source_waiteraid/manifest.yaml
@@ -14,8 +14,6 @@ definitions:
   retriever:
     record_selector:
       $ref: "#/definitions/selector"
-    paginator:
-      type: NoPagination
     requester:
       $ref: "#/definitions/requester"
   base_stream:

--- a/airbyte-integrations/connectors/source-whisky-hunter/source_whisky_hunter/manifest.yaml
+++ b/airbyte-integrations/connectors/source-whisky-hunter/source_whisky_hunter/manifest.yaml
@@ -10,8 +10,6 @@ definitions:
   retriever:
     record_selector:
       $ref: "#/definitions/selector"
-    paginator:
-      type: NoPagination
     requester:
       $ref: "#/definitions/requester"
   base_stream:

--- a/airbyte-integrations/connectors/source-wikipedia-pageviews/source_wikipedia_pageviews/manifest.yaml
+++ b/airbyte-integrations/connectors/source-wikipedia-pageviews/source_wikipedia_pageviews/manifest.yaml
@@ -41,16 +41,12 @@ definitions:
   per_article_retriever:
     record_selector:
       $ref: "#/definitions/selector"
-    paginator:
-      type: NoPagination
     requester:
       $ref: "#/definitions/per_article_requester"
 
   top_retriever:
     record_selector:
       $ref: "#/definitions/selector"
-    paginator:
-      type: NoPagination
     requester:
       $ref: "#/definitions/top_requester"
   per_article_stream:

--- a/airbyte-integrations/connectors/source-zapier-supported-storage/source_zapier_supported_storage/manifest.yaml
+++ b/airbyte-integrations/connectors/source-zapier-supported-storage/source_zapier_supported_storage/manifest.yaml
@@ -12,8 +12,6 @@ definitions:
   retriever:
     record_selector:
       $ref: "#/definitions/selector"
-    paginator:
-      type: NoPagination
     requester:
       $ref: "#/definitions/requester"
   base_stream:

--- a/airbyte-integrations/connectors/source-zoom/source_zoom/manifest.yaml
+++ b/airbyte-integrations/connectors/source-zoom/source_zoom/manifest.yaml
@@ -78,8 +78,6 @@ definitions:
       name: "meetings"
       primary_key: "id"
     retriever:
-      paginator:
-        type: NoPagination
       record_selector:
         extractor:
           type: DpathExtractor
@@ -140,8 +138,6 @@ definitions:
       name: "meeting_polls"
       primary_key: "id"
     retriever:
-      paginator:
-        type: NoPagination
       record_selector:
         extractor:
           type: DpathExtractor
@@ -177,8 +173,6 @@ definitions:
     $parameters:
       name: "meeting_poll_results"
     retriever:
-      paginator:
-        type: NoPagination
       record_selector:
         extractor:
           type: DpathExtractor
@@ -215,8 +209,6 @@ definitions:
     $parameters:
       name: "meeting_registration_questions"
     retriever:
-      paginator:
-        type: NoPagination
       record_selector:
         extractor:
           type: DpathExtractor
@@ -286,8 +278,6 @@ definitions:
       name: "webinars"
       primary_key: "id"
     retriever:
-      paginator:
-        type: NoPagination
       record_selector:
         extractor:
           type: DpathExtractor
@@ -320,8 +310,6 @@ definitions:
     $parameters:
       name: "webinar_panelists"
     retriever:
-      paginator:
-        type: NoPagination
       record_selector:
         extractor:
           type: DpathExtractor
@@ -435,8 +423,6 @@ definitions:
     $parameters:
       name: "webinar_polls"
     retriever:
-      paginator:
-        type: NoPagination
       record_selector:
         extractor:
           type: DpathExtractor
@@ -473,8 +459,6 @@ definitions:
     $parameters:
       name: "webinar_poll_results"
     retriever:
-      paginator:
-        type: NoPagination
       record_selector:
         extractor:
           type: DpathExtractor
@@ -509,8 +493,6 @@ definitions:
     $parameters:
       name: "webinar_registration_questions"
     retriever:
-      paginator:
-        type: NoPagination
       record_selector:
         extractor:
           type: DpathExtractor
@@ -547,8 +529,6 @@ definitions:
       name: "webinar_tracking_sources"
       primary_key: "id"
     retriever:
-      paginator:
-        type: NoPagination
       record_selector:
         extractor:
           type: DpathExtractor
@@ -583,8 +563,6 @@ definitions:
     $parameters:
       name: "webinar_qna_results"
     retriever:
-      paginator:
-        type: NoPagination
       record_selector:
         extractor:
           type: DpathExtractor
@@ -620,8 +598,6 @@ definitions:
       name: "report_meetings"
       primary_key: "id"
     retriever:
-      paginator:
-        type: NoPagination
       record_selector:
         extractor:
           type: DpathExtractor
@@ -693,8 +669,6 @@ definitions:
     $parameters:
       name: "report_webinars"
     retriever:
-      paginator:
-        type: NoPagination
       record_selector:
         extractor:
           type: DpathExtractor


### PR DESCRIPTION
## What
The NoPagination object does not need to be exposed in the DSL because the SimpleRetriever's paginator field is optional.

This PR removes explicit mentions of `NoPagination` from the existing manifests. Removing the field from the schema will be done in a follow up PR.

This PR also removes the field from the template, which explains why it is so widely used.

Removing the explicit mention of NoPagination does not change the connector's behavior, so I do not plan on releasing a new version.

Tested with:
- `./airbyte-cdk/python/bin/run-cats-with-local-cdk.sh -c source-alpha-vantage`
- 