### PR TITLE
install dbt + copy normalization code into dest-bq

### DIFF
--- a/airbyte-integrations/connectors/destination-bigquery/Dockerfile
+++ b/airbyte-integrations/connectors/destination-bigquery/Dockerfile
@@ -10,6 +10,23 @@ RUN tar xf ${APPLICATION}.tar --strip-components=1 && rm -rf ${APPLICATION}.tar
 
 FROM airbyte/integration-base-java:dev
 
+RUN yum install -y python3 python3-devel jq sshpass git && \
+  alternatives --install /usr/bin/python python /usr/bin/python3 60 && \
+  python -m ensurepip --upgrade && \
+  pip3 install dbt-bigquery==1.0.0
+
+# Luckily, none of normalization's files conflict with destination-bigquery's files :)
+# We don't enforce that in any way, but hopefully we're only living in this state for a short time.
+COPY --from=airbyte/normalization:dev /airbyte /airbyte
+# Install python dependencies
+WORKDIR /airbyte/base_python_structs
+RUN pip3 install .
+WORKDIR /airbyte/normalization_code
+RUN pip3 install .
+WORKDIR /airbyte/normalization_code/dbt-template/
+# Download external dbt dependencies
+RUN dbt deps
+
 WORKDIR /airbyte
 
 ENV APPLICATION destination-bigquery

--- a/airbyte-integrations/connectors/destination-bigquery/build.gradle
+++ b/airbyte-integrations/connectors/destination-bigquery/build.gradle
@@ -35,6 +35,12 @@ dependencies {
     implementation files(project(':airbyte-integrations:bases:base-java').airbyteDocker.outputs)
 }
 
+tasks.named("airbyteDocker") {
+    // this is really inefficent (because base-normalization:airbyteDocker builds 9 docker images)
+    // but it's also just simple to implement
+    dependsOn project(':airbyte-integrations:bases:base-normalization').airbyteDocker
+}
+
 configurations.all {
   resolutionStrategy {
     // at time of writing: deps.toml declares google-cloud-storage 2.17.2


### PR DESCRIPTION
## What
As title. Closes https://github.com/airbytehq/airbyte/issues/24877; does the first part of https://github.com/airbytehq/airbyte/issues/24878 (i.e. copying in the normalization code).

After this PR is closed:
* it is physically possible to run normalization from inside the `airbyte/destination-bigquery` container, but not via `docker run airbyte/destination-bigquery`
* the `destination-bigquery:airbyteDocker` task is slower (because it requires running `base-normalization:airbyteDocker`)
    * this was just a shortcut to not deal with copying files around in gradle; IMO that's fine (potentially hot take: the difference between `/test` taking 30 and 40 minutes is... not huge, in that you still end up with "go do something else for a while")
        * also, apparently `/test` was already building normalization docker anyway :shrug:
    * added a note in https://github.com/airbytehq/airbyte/issues/24880 about test runtime to avoid thousand-cutting ourselves
    * we _could_ actually reference a specific version of normalization, which would be faster at build-time, and possibly superior (versioned libraries :P )

## How
* install a bunch of stuff that normalization needs (python, jq, sshpass, git, dbt)
* add a gradle dependency on normalization's docker image
* copy normalization files from the docker image
    * as noted above - this is a massive hack; this _should_ be a gradle file-copy to pull the normalization code into the docker context + COPY commands in the dockerfile
    * also copy in the `pip install` commands from the normalization dockerfile (these are now `pip3` because python's ecosystem is weird)

Tested by manually running normalization:
1. Copied in a config.json + catalog.json
2. `./entrypoint.sh run --config inp/config.json --catalog inp/catalog.json --integration-type bigquery`
3. Normalization ran successfully: (note the `Completed successfully` message) `{"code": "Z030", "data": {"keyboard_interrupt": false, "num_errors": 0, "num_warnings": 0}, "invocation_id": "298843ec-2591-4b9f-8ce1-906ade085f85", "level": "info", "log_version": 1, "msg": "\u001b[32mCompleted successfully\u001b[0m", "node_info": {}, "pid": 229, "thread_name": "MainThread", "ts": "2023-04-10T23:03:47.545267Z", "type": "log_line"}`

## Recommended reading order
1. build.gradle
4. dockerfile

## 🚨 User Impact 🚨
None. This has basically no runtime impact (just a slightly larger docker image).