### PR TITLE
Add metadata gcs sensor to Dagster

### DIFF
--- a/.github/actions/run-dagger-pipeline/action.yml
+++ b/.github/actions/run-dagger-pipeline/action.yml
@@ -17,11 +17,6 @@ runs:
       id: get-start-timestamp
       run: echo "::set-output name=start-timestamp::$(date +%s)"
       shell: bash
-    - name: Login to DockerHub
-      run: "docker login -u ${DOCKER_HUB_USERNAME} -p ${DOCKER_HUB_PASSWORD}"
-      env:
-        DOCKER_HUB_USERNAME: ${{ secrets.DOCKER_HUB_USERNAME }}
-        DOCKER_HUB_PASSWORD: ${{ secrets.DOCKER_HUB_PASSWORD }}
     - name: Checkout Airbyte
       uses: actions/checkout@v3
       with:

--- a/airbyte-ci/connectors/metadata_service/lib/metadata_service/constants.py
+++ b/airbyte-ci/connectors/metadata_service/lib/metadata_service/constants.py
@@ -1,0 +1,2 @@
+METADATA_FILE_NAME = "metadata.yaml"
+METADATA_FOLDER = "metadata"

--- a/airbyte-ci/connectors/metadata_service/lib/metadata_service/gcs_upload.py
+++ b/airbyte-ci/connectors/metadata_service/lib/metadata_service/gcs_upload.py
@@ -8,6 +8,19 @@ import yaml
 from google.cloud import storage
 from google.oauth2 import service_account
 from metadata_service.models.generated.ConnectorMetadataDefinitionV1 import ConnectorMetadataDefinitionV1
+from metadata_service.constants import METADATA_FILE_NAME, METADATA_FOLDER
+
+
+def get_metadata_file_path(dockerRepository: str, version: str) -> str:
+    """Get the path to the metadata file for a specific version of a connector.
+
+    Args:
+        dockerRepository (str): Name of the connector docker image.
+        version (str): Version of the connector.
+    Returns:
+        str: Path to the metadata file.
+    """
+    return f"{METADATA_FOLDER}/{dockerRepository}/{version}/{METADATA_FILE_NAME}"
 
 
 def upload_metadata_to_gcs(bucket_name: str, metadata_file_path: Path, service_account_file_path: Path) -> Tuple[bool, str]:
@@ -31,8 +44,11 @@ def upload_metadata_to_gcs(bucket_name: str, metadata_file_path: Path, service_a
     storage_client = storage.Client(credentials=credentials)
     bucket = storage_client.bucket(bucket_name)
 
-    version_blob = bucket.blob(f"metadata/{metadata.data.dockerRepository}/{metadata.data.dockerImageTag}/metadata.yaml")
-    latest_blob = bucket.blob(f"metadata/{metadata.data.dockerRepository}/latest/metadata.yaml")
+    version_path = get_metadata_file_path(metadata.data.dockerRepository, metadata.data.dockerImageTag)
+    latest_path = get_metadata_file_path(metadata.data.dockerRepository, "latest")
+
+    version_blob = bucket.blob(version_path)
+    latest_blob = bucket.blob(latest_path)
     if not version_blob.exists():
         version_blob.upload_from_filename(str(metadata_file_path))
         uploaded = True

--- a/airbyte-ci/connectors/metadata_service/orchestrator/orchestrator/__init__.py
+++ b/airbyte-ci/connectors/metadata_service/orchestrator/orchestrator/__init__.py
@@ -39,7 +39,8 @@ from orchestrator.assets.dev import (
 )
 
 from orchestrator.jobs.catalog import generate_catalog_markdown, generate_local_metadata_files, generate_catalog
-from orchestrator.sensors.catalog import catalog_updated_sensor, metadata_updated_sensor
+from orchestrator.sensors.catalog import catalog_updated_sensor
+from orchestrator.sensors.metadata import metadata_updated_sensor
 
 from orchestrator.config import REPORT_FOLDER, CATALOG_FOLDER, CONNECTORS_PATH, CONNECTOR_REPO_NAME, METADATA_FOLDER
 

--- a/airbyte-ci/connectors/metadata_service/orchestrator/orchestrator/__init__.py
+++ b/airbyte-ci/connectors/metadata_service/orchestrator/orchestrator/__init__.py
@@ -11,7 +11,6 @@ from orchestrator.assets.catalog_report import (
     all_destinations_dataframe,
     connector_catalog_location_markdown,
     connector_catalog_location_html,
-    metadata_directory_report,
 )
 from orchestrator.assets.catalog import (
     oss_destinations_dataframe,
@@ -26,6 +25,7 @@ from orchestrator.assets.catalog import (
 from orchestrator.assets.metadata import (
     catalog_derived_metadata_definitions,
     valid_metadata_report_dataframe,
+    metadata_definitions,
 )
 
 from orchestrator.assets.dev import (
@@ -35,6 +35,7 @@ from orchestrator.assets.dev import (
     cloud_catalog_diff,
     cloud_catalog_diff_dataframe,
     oss_catalog_diff_dataframe,
+    metadata_directory_report,
 )
 
 from orchestrator.jobs.catalog import generate_catalog_markdown, generate_local_metadata_files, generate_catalog
@@ -66,6 +67,7 @@ ASSETS = [
     cloud_catalog_diff_dataframe,
     oss_catalog_diff_dataframe,
     metadata_directory_report,
+    metadata_definitions,
 ]
 
 RESOURCES = {

--- a/airbyte-ci/connectors/metadata_service/orchestrator/orchestrator/__init__.py
+++ b/airbyte-ci/connectors/metadata_service/orchestrator/orchestrator/__init__.py
@@ -37,7 +37,7 @@ from orchestrator.assets.dev import (
     oss_catalog_diff_dataframe,
 )
 
-from orchestrator.jobs.catalog import generate_catalog_markdown, generate_local_metadata_files
+from orchestrator.jobs.catalog import generate_catalog_markdown, generate_local_metadata_files, generate_catalog
 from orchestrator.sensors.catalog import catalog_updated_sensor, metadata_updated_sensor
 
 from orchestrator.config import REPORT_FOLDER, CATALOG_FOLDER, CONNECTORS_PATH, CONNECTOR_REPO_NAME, METADATA_FOLDER
@@ -89,7 +89,7 @@ RESOURCES = {
 
 SENSORS = [
     catalog_updated_sensor(job=generate_catalog_markdown, resources_def=RESOURCES),
-    metadata_updated_sensor(job=generate_catalog_markdown, resources_def=RESOURCES)
+    metadata_updated_sensor(job=generate_catalog, resources_def=RESOURCES)
 ]
 
 SCHEDULES = []

--- a/airbyte-ci/connectors/metadata_service/orchestrator/orchestrator/__init__.py
+++ b/airbyte-ci/connectors/metadata_service/orchestrator/orchestrator/__init__.py
@@ -92,7 +92,7 @@ RESOURCES = {
 
 SENSORS = [
     catalog_updated_sensor(job=generate_catalog_markdown, resources_def=RESOURCES),
-    metadata_updated_sensor(job=generate_catalog, resources_def=RESOURCES)
+    metadata_updated_sensor(job=generate_catalog, resources_def=RESOURCES),
 ]
 
 SCHEDULES = []

--- a/airbyte-ci/connectors/metadata_service/orchestrator/orchestrator/__init__.py
+++ b/airbyte-ci/connectors/metadata_service/orchestrator/orchestrator/__init__.py
@@ -42,7 +42,8 @@ from orchestrator.jobs.catalog import generate_catalog_markdown, generate_local_
 from orchestrator.sensors.catalog import catalog_updated_sensor
 from orchestrator.sensors.metadata import metadata_updated_sensor
 
-from orchestrator.config import REPORT_FOLDER, CATALOG_FOLDER, CONNECTORS_PATH, CONNECTOR_REPO_NAME, METADATA_FOLDER
+from orchestrator.config import REPORT_FOLDER, CATALOG_FOLDER, CONNECTORS_PATH, CONNECTOR_REPO_NAME
+from metadata_service.constants import METADATA_FILE_NAME, METADATA_FOLDER
 
 ASSETS = [
     oss_destinations_dataframe,
@@ -82,12 +83,10 @@ RESOURCES = {
         }
     ),
     "gcs_bucket_manager": gcs_bucket_manager.configured({"gcs_bucket": {"env": "METADATA_BUCKET"}}),
-    "catalog_report_directory_manager": gcs_file_manager.configured(
-        {"gcs_bucket": {"env": "METADATA_BUCKET"}, "gcs_prefix": REPORT_FOLDER}
-    ),
-    "metadata_folder_blobs": gcs_directory_blobs.configured({"gcs_prefix": METADATA_FOLDER}),
-    "latest_oss_catalog_gcs_file": gcs_file_blob.configured({"gcs_prefix": CATALOG_FOLDER, "gcs_filename": "oss_catalog.json"}),
-    "latest_cloud_catalog_gcs_file": gcs_file_blob.configured({"gcs_prefix": CATALOG_FOLDER, "gcs_filename": "cloud_catalog.json"}),
+    "catalog_report_directory_manager": gcs_file_manager.configured({"gcs_bucket": {"env": "METADATA_BUCKET"}, "prefix": REPORT_FOLDER}),
+    "metadata_file_blobs": gcs_directory_blobs.configured({"prefix": METADATA_FOLDER, "suffix": METADATA_FILE_NAME}),
+    "latest_oss_catalog_gcs_file": gcs_file_blob.configured({"prefix": CATALOG_FOLDER, "gcs_filename": "oss_catalog.json"}),
+    "latest_cloud_catalog_gcs_file": gcs_file_blob.configured({"prefix": CATALOG_FOLDER, "gcs_filename": "cloud_catalog.json"}),
 }
 
 SENSORS = [

--- a/airbyte-ci/connectors/metadata_service/orchestrator/orchestrator/assets/catalog_report.py
+++ b/airbyte-ci/connectors/metadata_service/orchestrator/orchestrator/assets/catalog_report.py
@@ -172,7 +172,7 @@ def all_destinations_dataframe(
 @asset(required_resource_keys={"metadata_folder_blobs"}, group_name=GROUP_NAME)
 def metadata_directory_report(context):
     metadata_folder_blobs = context.resources.metadata_folder_blobs
-    blobs = [blob for blob in metadata_folder_blobs if blob.name.endswith("metadata.yaml")]
-    blobs_df = pd.DataFrame([{"name", blob.name} for blob in blobs])
+    blobs = [blob.name for blob in metadata_folder_blobs if blob.name.endswith("metadata.yaml")]
+    blobs_df = pd.DataFrame(blobs)
 
     return output_dataframe(blobs_df)

--- a/airbyte-ci/connectors/metadata_service/orchestrator/orchestrator/assets/catalog_report.py
+++ b/airbyte-ci/connectors/metadata_service/orchestrator/orchestrator/assets/catalog_report.py
@@ -2,7 +2,6 @@ import pandas as pd
 from dagster import MetadataValue, Output, asset
 
 from orchestrator.templates.render import render_connector_catalog_locations_html, render_connector_catalog_locations_markdown
-from orchestrator.utils.dagster_helpers import output_dataframe
 
 GROUP_NAME = "catalog_reports"
 
@@ -149,6 +148,7 @@ def all_sources_dataframe(
         github_connector_folders=github_connector_folders,
         cached_specs=cached_specs,
     )
+
 
 @asset(group_name=GROUP_NAME)
 def all_destinations_dataframe(

--- a/airbyte-ci/connectors/metadata_service/orchestrator/orchestrator/assets/catalog_report.py
+++ b/airbyte-ci/connectors/metadata_service/orchestrator/orchestrator/assets/catalog_report.py
@@ -167,12 +167,3 @@ def all_destinations_dataframe(
         github_connector_folders=github_connector_folders,
         cached_specs=cached_specs,
     )
-
-
-@asset(required_resource_keys={"metadata_folder_blobs"}, group_name=GROUP_NAME)
-def metadata_directory_report(context):
-    metadata_folder_blobs = context.resources.metadata_folder_blobs
-    blobs = [blob.name for blob in metadata_folder_blobs if blob.name.endswith("metadata.yaml")]
-    blobs_df = pd.DataFrame(blobs)
-
-    return output_dataframe(blobs_df)

--- a/airbyte-ci/connectors/metadata_service/orchestrator/orchestrator/assets/catalog_report.py
+++ b/airbyte-ci/connectors/metadata_service/orchestrator/orchestrator/assets/catalog_report.py
@@ -2,6 +2,7 @@ import pandas as pd
 from dagster import MetadataValue, Output, asset
 
 from orchestrator.templates.render import render_connector_catalog_locations_html, render_connector_catalog_locations_markdown
+from orchestrator.utils.dagster_helpers import output_dataframe
 
 GROUP_NAME = "catalog_reports"
 
@@ -151,18 +152,9 @@ def all_destinations_dataframe(
 
 
 @asset(group_name=GROUP_NAME)
-def all_sources_dataframe(
-    cloud_sources_dataframe, oss_sources_dataframe, github_connector_folders, valid_metadata_report_dataframe, cached_specs
-) -> pd.DataFrame:
-    """
-    Merge the cloud and oss source catalogs into a single dataframe.
-    """
-    return augment_and_normalize_connector_dataframes(
-        cloud_df=cloud_sources_dataframe,
-        oss_df=oss_sources_dataframe,
-        primaryKey="sourceDefinitionId",
-        connector_type="source",
-        valid_metadata_report_dataframe=valid_metadata_report_dataframe,
-        github_connector_folders=github_connector_folders,
-        cached_specs=cached_specs,
-    )
+def metadata_directory_report(context):
+    metadata_folder_blobs = resources.metadata_folder_blobs
+    blobs = [blob for blob in metadata_folder_blobs if blob.name.endswith("metadata.yml")]
+    blobs_df = pd.DataFrame([blob for blob in blobs])
+
+    return output_dataframe(blobs_df)

--- a/airbyte-ci/connectors/metadata_service/orchestrator/orchestrator/assets/catalog_report.py
+++ b/airbyte-ci/connectors/metadata_service/orchestrator/orchestrator/assets/catalog_report.py
@@ -133,6 +133,24 @@ def connector_catalog_location_markdown(context, all_destinations_dataframe, all
 
 
 @asset(group_name=GROUP_NAME)
+def all_sources_dataframe(
+    cloud_sources_dataframe, oss_sources_dataframe, github_connector_folders, valid_metadata_report_dataframe, cached_specs
+) -> pd.DataFrame:
+    """
+    Merge the cloud and oss sources catalogs into a single dataframe.
+    """
+
+    return augment_and_normalize_connector_dataframes(
+        cloud_df=cloud_sources_dataframe,
+        oss_df=oss_sources_dataframe,
+        primaryKey="sourceDefinitionId",
+        connector_type="source",
+        valid_metadata_report_dataframe=valid_metadata_report_dataframe,
+        github_connector_folders=github_connector_folders,
+        cached_specs=cached_specs,
+    )
+
+@asset(group_name=GROUP_NAME)
 def all_destinations_dataframe(
     cloud_destinations_dataframe, oss_destinations_dataframe, github_connector_folders, valid_metadata_report_dataframe, cached_specs
 ) -> pd.DataFrame:
@@ -151,10 +169,10 @@ def all_destinations_dataframe(
     )
 
 
-@asset(group_name=GROUP_NAME)
+@asset(required_resource_keys={"metadata_folder_blobs"}, group_name=GROUP_NAME)
 def metadata_directory_report(context):
-    metadata_folder_blobs = resources.metadata_folder_blobs
-    blobs = [blob for blob in metadata_folder_blobs if blob.name.endswith("metadata.yml")]
-    blobs_df = pd.DataFrame([blob for blob in blobs])
+    metadata_folder_blobs = context.resources.metadata_folder_blobs
+    blobs = [blob for blob in metadata_folder_blobs if blob.name.endswith("metadata.yaml")]
+    blobs_df = pd.DataFrame([{"name", blob.name} for blob in blobs])
 
     return output_dataframe(blobs_df)

--- a/airbyte-ci/connectors/metadata_service/orchestrator/orchestrator/assets/dev.py
+++ b/airbyte-ci/connectors/metadata_service/orchestrator/orchestrator/assets/dev.py
@@ -253,3 +253,11 @@ def cloud_catalog_diff_dataframe(cloud_catalog_diff: dict) -> OutputDataFrame:
 def oss_catalog_diff_dataframe(oss_catalog_diff: dict) -> OutputDataFrame:
     diff_df = pd.DataFrame.from_dict(oss_catalog_diff)
     return output_dataframe(diff_df)
+
+@asset(required_resource_keys={"metadata_folder_blobs"}, group_name=GROUP_NAME)
+def metadata_directory_report(context):
+    metadata_folder_blobs = context.resources.metadata_folder_blobs
+    blobs = [blob.name for blob in metadata_folder_blobs if blob.name.endswith("metadata.yaml")]
+    blobs_df = pd.DataFrame(blobs)
+
+    return output_dataframe(blobs_df)

--- a/airbyte-ci/connectors/metadata_service/orchestrator/orchestrator/assets/dev.py
+++ b/airbyte-ci/connectors/metadata_service/orchestrator/orchestrator/assets/dev.py
@@ -254,6 +254,7 @@ def oss_catalog_diff_dataframe(oss_catalog_diff: dict) -> OutputDataFrame:
     diff_df = pd.DataFrame.from_dict(oss_catalog_diff)
     return output_dataframe(diff_df)
 
+
 @asset(required_resource_keys={"metadata_folder_blobs"}, group_name=GROUP_NAME)
 def metadata_directory_report(context):
     metadata_folder_blobs = context.resources.metadata_folder_blobs

--- a/airbyte-ci/connectors/metadata_service/orchestrator/orchestrator/assets/dev.py
+++ b/airbyte-ci/connectors/metadata_service/orchestrator/orchestrator/assets/dev.py
@@ -255,10 +255,10 @@ def oss_catalog_diff_dataframe(oss_catalog_diff: dict) -> OutputDataFrame:
     return output_dataframe(diff_df)
 
 
-@asset(required_resource_keys={"metadata_folder_blobs"}, group_name=GROUP_NAME)
+@asset(required_resource_keys={"metadata_file_blobs"}, group_name=GROUP_NAME)
 def metadata_directory_report(context):
-    metadata_folder_blobs = context.resources.metadata_folder_blobs
-    blobs = [blob.name for blob in metadata_folder_blobs if blob.name.endswith("metadata.yaml")]
+    metadata_file_blobs = context.resources.metadata_file_blobs
+    blobs = [blob.name for blob in metadata_file_blobs if blob.name.endswith("metadata.yaml")]
     blobs_df = pd.DataFrame(blobs)
 
     return output_dataframe(blobs_df)

--- a/airbyte-ci/connectors/metadata_service/orchestrator/orchestrator/assets/metadata.py
+++ b/airbyte-ci/connectors/metadata_service/orchestrator/orchestrator/assets/metadata.py
@@ -5,6 +5,7 @@ from dagster import Output, asset
 import yaml
 
 from metadata_service.models.generated.ConnectorMetadataDefinitionV1 import ConnectorMetadataDefinitionV1
+
 from orchestrator.utils.object_helpers import are_values_equal, merge_values
 from orchestrator.utils.dagster_helpers import OutputDataFrame, output_dataframe
 from orchestrator.models.metadata import PartialMetadataDefinition
@@ -209,13 +210,12 @@ def catalog_derived_metadata_definitions(
     return Output(all_definitions, metadata={"count": len(all_definitions)})
 
 
-@asset(required_resource_keys={"metadata_folder_blobs"}, group_name=GROUP_NAME)
+@asset(required_resource_keys={"metadata_file_blobs"}, group_name=GROUP_NAME)
 def metadata_definitions(context):
-    metadata_folder_blobs = context.resources.metadata_folder_blobs
-    blobs = [blob for blob in metadata_folder_blobs if blob.name.endswith("metadata.yml")]
+    metadata_file_blobs = context.resources.metadata_file_blobs
 
     metadata_definitions = []
-    for blob in blobs:
+    for blob in metadata_file_blobs:
         yaml_string = blob.download_as_string().decode("utf-8")
         metadata_dict = yaml.safe_load(yaml_string)
         metadata_def = ConnectorMetadataDefinitionV1.parse_obj(metadata_dict)

--- a/airbyte-ci/connectors/metadata_service/orchestrator/orchestrator/assets/metadata.py
+++ b/airbyte-ci/connectors/metadata_service/orchestrator/orchestrator/assets/metadata.py
@@ -208,10 +208,11 @@ def catalog_derived_metadata_definitions(
     all_definitions = sources_metadata_list + destinations_metadata_list
     return Output(all_definitions, metadata={"count": len(all_definitions)})
 
+
 @asset(required_resource_keys={"metadata_folder_blobs"}, group_name=GROUP_NAME)
 def metadata_definitions(context):
     metadata_folder_blobs = context.resources.metadata_folder_blobs
-    blobs = [blob for blob in metadata_folder_blobs if blob.name.endswith("metadata.yaml")]
+    blobs = [blob for blob in metadata_folder_blobs if blob.name.endswith("metadata.yml")]
 
     metadata_definitions = []
     for blob in blobs:

--- a/airbyte-ci/connectors/metadata_service/orchestrator/orchestrator/config.py
+++ b/airbyte-ci/connectors/metadata_service/orchestrator/orchestrator/config.py
@@ -1,4 +1,5 @@
 CATALOG_FOLDER = "catalogs"
 REPORT_FOLDER = "generated_reports"
+METADATA_FOLDER = "metadata"
 CONNECTOR_REPO_NAME = "airbytehq/airbyte"
 CONNECTORS_PATH = "airbyte-integrations/connectors"

--- a/airbyte-ci/connectors/metadata_service/orchestrator/orchestrator/config.py
+++ b/airbyte-ci/connectors/metadata_service/orchestrator/orchestrator/config.py
@@ -1,5 +1,5 @@
 CATALOG_FOLDER = "catalogs"
 REPORT_FOLDER = "generated_reports"
-METADATA_FOLDER = "metadata"
+
 CONNECTOR_REPO_NAME = "airbytehq/airbyte"
 CONNECTORS_PATH = "airbyte-integrations/connectors"

--- a/airbyte-ci/connectors/metadata_service/orchestrator/orchestrator/jobs/catalog.py
+++ b/airbyte-ci/connectors/metadata_service/orchestrator/orchestrator/jobs/catalog.py
@@ -1,6 +1,9 @@
 from dagster import define_asset_job
 
 
+generate_catalog = define_asset_job(
+    name="generate_catalog", selection=["metadata_directory_report"]
+)
 generate_catalog_markdown = define_asset_job(
     name="generate_catalog_markdown", selection=["connector_catalog_location_html", "connector_catalog_location_markdown"]
 )

--- a/airbyte-ci/connectors/metadata_service/orchestrator/orchestrator/jobs/catalog.py
+++ b/airbyte-ci/connectors/metadata_service/orchestrator/orchestrator/jobs/catalog.py
@@ -2,7 +2,7 @@ from dagster import define_asset_job
 
 
 generate_catalog = define_asset_job(
-    name="generate_catalog", selection=["metadata_directory_report"]
+    name="generate_catalog", selection=["metadata_directory_report", "metadata_definitions"]
 )
 generate_catalog_markdown = define_asset_job(
     name="generate_catalog_markdown", selection=["connector_catalog_location_html", "connector_catalog_location_markdown"]

--- a/airbyte-ci/connectors/metadata_service/orchestrator/orchestrator/jobs/catalog.py
+++ b/airbyte-ci/connectors/metadata_service/orchestrator/orchestrator/jobs/catalog.py
@@ -1,9 +1,7 @@
 from dagster import define_asset_job
 
 
-generate_catalog = define_asset_job(
-    name="generate_catalog", selection=["metadata_directory_report", "metadata_definitions"]
-)
+generate_catalog = define_asset_job(name="generate_catalog", selection=["metadata_directory_report", "metadata_definitions"])
 generate_catalog_markdown = define_asset_job(
     name="generate_catalog_markdown", selection=["connector_catalog_location_html", "connector_catalog_location_markdown"]
 )

--- a/airbyte-ci/connectors/metadata_service/orchestrator/orchestrator/resources/gcp.py
+++ b/airbyte-ci/connectors/metadata_service/orchestrator/orchestrator/resources/gcp.py
@@ -85,6 +85,7 @@ def gcs_file_blob(resource_context: InitResourceContext) -> storage.Blob:
 
     return gcs_file_blob
 
+
 @resource(
     required_resource_keys={"gcs_bucket_manager"},
     config_schema={

--- a/airbyte-ci/connectors/metadata_service/orchestrator/orchestrator/resources/gcp.py
+++ b/airbyte-ci/connectors/metadata_service/orchestrator/orchestrator/resources/gcp.py
@@ -39,7 +39,7 @@ def gcs_bucket_manager(resource_context: InitResourceContext) -> storage.Bucket:
     required_resource_keys={"gcp_gcs_client"},
     config_schema={
         "gcs_bucket": StringSource,
-        "gcs_prefix": StringSource,
+        "prefix": StringSource,
     },
 )
 def gcs_file_manager(resource_context) -> GCSFileManager:
@@ -53,14 +53,14 @@ def gcs_file_manager(resource_context) -> GCSFileManager:
     return GCSFileManager(
         client=storage_client,
         gcs_bucket=resource_context.resource_config["gcs_bucket"],
-        gcs_base_key=resource_context.resource_config["gcs_prefix"],
+        gcs_base_key=resource_context.resource_config["prefix"],
     )
 
 
 @resource(
     required_resource_keys={"gcs_bucket_manager"},
     config_schema={
-        "gcs_prefix": StringSource,
+        "prefix": StringSource,
         "gcs_filename": StringSource,
     },
 )
@@ -73,9 +73,9 @@ def gcs_file_blob(resource_context: InitResourceContext) -> storage.Blob:
     """
     bucket = resource_context.resources.gcs_bucket_manager
 
-    gcs_prefix = resource_context.resource_config["gcs_prefix"]
+    prefix = resource_context.resource_config["prefix"]
     gcs_filename = resource_context.resource_config["gcs_filename"]
-    gcs_file_path = f"{gcs_prefix}/{gcs_filename}"
+    gcs_file_path = f"{prefix}/{gcs_filename}"
 
     resource_context.log.info(f"retrieving gcs file blob for {gcs_file_path}")
 
@@ -89,7 +89,8 @@ def gcs_file_blob(resource_context: InitResourceContext) -> storage.Blob:
 @resource(
     required_resource_keys={"gcs_bucket_manager"},
     config_schema={
-        "gcs_prefix": StringSource,
+        "prefix": StringSource,
+        "suffix": StringSource,
     },
 )
 def gcs_directory_blobs(resource_context: InitResourceContext) -> storage.Blob:
@@ -97,10 +98,13 @@ def gcs_directory_blobs(resource_context: InitResourceContext) -> storage.Blob:
     List all blobs in a bucket that match the prefix.
     """
     bucket = resource_context.resources.gcs_bucket_manager
-    gcs_prefix = resource_context.resource_config["gcs_prefix"]
+    prefix = resource_context.resource_config["prefix"]
+    suffix = resource_context.resource_config["suffix"]
 
-    resource_context.log.info(f"retrieving gcs file blobs for {gcs_prefix}")
+    resource_context.log.info(f"retrieving gcs file blobs for prefix: {prefix}, suffix: {suffix}")
 
-    gcs_file_blobs = bucket.list_blobs(prefix=gcs_prefix)
+    gcs_file_blobs = bucket.list_blobs(prefix=prefix)
+    if suffix:
+        gcs_file_blobs = [blob for blob in gcs_file_blobs if blob.name.endswith(suffix)]
 
     return gcs_file_blobs

--- a/airbyte-ci/connectors/metadata_service/orchestrator/orchestrator/resources/gcp.py
+++ b/airbyte-ci/connectors/metadata_service/orchestrator/orchestrator/resources/gcp.py
@@ -84,3 +84,22 @@ def gcs_file_blob(resource_context: InitResourceContext) -> storage.Blob:
         raise Exception(f"File does not exist at path: {gcs_file_path}")
 
     return gcs_file_blob
+
+@resource(
+    required_resource_keys={"gcs_bucket_manager"},
+    config_schema={
+        "gcs_prefix": StringSource,
+    },
+)
+def gcs_directory_blobs(resource_context: InitResourceContext) -> storage.Blob:
+    """
+    List all blobs in a bucket that match the prefix.
+    """
+    bucket = resource_context.resources.gcs_bucket_manager
+    gcs_prefix = resource_context.resource_config["gcs_prefix"]
+
+    resource_context.log.info(f"retrieving gcs file blobs for {gcs_prefix}")
+
+    gcs_file_blobs = bucket.list_blobs(prefix=gcs_prefix)
+
+    return gcs_file_blobs

--- a/airbyte-ci/connectors/metadata_service/orchestrator/orchestrator/sensors/catalog.py
+++ b/airbyte-ci/connectors/metadata_service/orchestrator/orchestrator/sensors/catalog.py
@@ -1,4 +1,3 @@
-
 from dagster import sensor, RunRequest, SkipReason, SensorDefinition, SensorEvaluationContext, build_resources, DefaultSensorStatus
 
 from orchestrator.utils.dagster_helpers import serialize_composite_etag_cursor

--- a/airbyte-ci/connectors/metadata_service/orchestrator/orchestrator/sensors/catalog.py
+++ b/airbyte-ci/connectors/metadata_service/orchestrator/orchestrator/sensors/catalog.py
@@ -75,12 +75,8 @@ def metadata_updated_sensor(job, resources_def) -> SensorDefinition:
 
             context.log.info(f"Old etag cursor: {etag_cursor}")
 
-
-            # TODO ensure blobs is a list of all metadata.yml files
-            # metadata_blobs = metadata_bucket.list_blobs(prefix=METADATA_FOLDER)
-
-            gcs_metadata_blobs = resources.gcs_metadata_blobs
-            new_etag_cursors = [blob.etag for blob in gcs_metadata_blobs]
+            metadata_folder_blobs = resources.metadata_folder_blobs
+            new_etag_cursors = [blob.etag for blob in metadata_folder_blobs if blob.name.endswith("metadata.yml")]
             new_etag_cursor_set = set(new_etag_cursors)
             context.log.info(f"New etag cursor: {new_etag_cursor_set}")
 

--- a/airbyte-ci/connectors/metadata_service/orchestrator/orchestrator/sensors/catalog.py
+++ b/airbyte-ci/connectors/metadata_service/orchestrator/orchestrator/sensors/catalog.py
@@ -1,16 +1,7 @@
-from typing import List, Optional
+
 from dagster import sensor, RunRequest, SkipReason, SensorDefinition, SensorEvaluationContext, build_resources, DefaultSensorStatus
 
-CURSOR_SEPARATOR = ":"
-
-def deserialize_composite_etag_cursor(etag_cursor: Optional[str]) -> List[str]:
-    if etag_cursor is None:
-        return []
-
-    return etag_cursor.split(CURSOR_SEPARATOR)
-
-def serialize_composite_etag_cursor(etags: List[str]):
-    return CURSOR_SEPARATOR.join(etags)
+from orchestrator.utils.dagster_helpers import serialize_composite_etag_cursor
 
 
 def catalog_updated_sensor(job, resources_def) -> SensorDefinition:
@@ -45,51 +36,8 @@ def catalog_updated_sensor(job, resources_def) -> SensorDefinition:
                 context.log.info("No new catalogs in GCS bucket")
                 return SkipReason("No new catalogs in GCS bucket")
 
-            context.update_cursor(new_etag_cursor)  # Question: what happens if the run fails? is the cursor still updated?
+            context.update_cursor(new_etag_cursor)
             context.log.info("New catalogs in GCS bucket")
             return RunRequest(run_key="updated_catalogs")
 
     return catalog_updated_sensor_definition
-
-
-def metadata_updated_sensor(job, resources_def) -> SensorDefinition:
-    """
-    TODO
-    """
-
-    @sensor(
-        name=f"{job.name}_on_metadata_updated",
-        job=job,
-        minimum_interval_seconds=30,
-        default_status=DefaultSensorStatus.STOPPED,
-    )
-    def metadata_updated_sensor_definition(context: SensorEvaluationContext):
-        context.log.info("Starting gcs_metadata_updated_sensor")
-
-        with build_resources(resources_def) as resources:
-            context.log.info("Got resources for gcs_metadata_updated_sensor")
-
-            etag_cursor_raw = context.cursor or None
-            etag_cursor = deserialize_composite_etag_cursor(etag_cursor_raw)
-            etag_cursor_set = set(etag_cursor)
-
-            context.log.info(f"Old etag cursor: {etag_cursor}")
-
-            metadata_folder_blobs = resources.metadata_folder_blobs
-            ## TODO, yaml vs yml
-            new_etag_cursors = [blob.etag for blob in metadata_folder_blobs if blob.name.endswith("metadata.yaml")]
-            new_etag_cursor_set = set(new_etag_cursors)
-            context.log.info(f"New etag cursor: {new_etag_cursor_set}")
-
-            # Note: ETAGs are GCS's way of providing a version number for a file
-            # Another option would be to use the last modified date or MD5 hash
-            if etag_cursor_set == new_etag_cursor_set:
-                context.log.info("No new updated_metadata_files in GCS bucket")
-                return SkipReason("No new updated_metadata_files in GCS bucket")
-
-            serialized_new_etag_cursor = serialize_composite_etag_cursor(new_etag_cursors)
-            context.update_cursor(serialized_new_etag_cursor)  # Question: what happens if the run fails? is the cursor still updated?
-            context.log.info("New updated_metadata_files in GCS bucket")
-            return RunRequest(run_key="updated_metadata_files")
-
-    return metadata_updated_sensor_definition

--- a/airbyte-ci/connectors/metadata_service/orchestrator/orchestrator/sensors/catalog.py
+++ b/airbyte-ci/connectors/metadata_service/orchestrator/orchestrator/sensors/catalog.py
@@ -76,7 +76,8 @@ def metadata_updated_sensor(job, resources_def) -> SensorDefinition:
             context.log.info(f"Old etag cursor: {etag_cursor}")
 
             metadata_folder_blobs = resources.metadata_folder_blobs
-            new_etag_cursors = [blob.etag for blob in metadata_folder_blobs if blob.name.endswith("metadata.yml")]
+            ## TODO, yaml vs yml
+            new_etag_cursors = [blob.etag for blob in metadata_folder_blobs if blob.name.endswith("metadata.yaml")]
             new_etag_cursor_set = set(new_etag_cursors)
             context.log.info(f"New etag cursor: {new_etag_cursor_set}")
 

--- a/airbyte-ci/connectors/metadata_service/orchestrator/orchestrator/sensors/catalog.py
+++ b/airbyte-ci/connectors/metadata_service/orchestrator/orchestrator/sensors/catalog.py
@@ -1,9 +1,16 @@
-from typing import List
+from typing import List, Optional
 from dagster import sensor, RunRequest, SkipReason, SensorDefinition, SensorEvaluationContext, build_resources, DefaultSensorStatus
 
+CURSOR_SEPARATOR = ":"
 
-def generate_composite_etag_cursor(etags: List[str]):
-    return ":".join(etags)
+def deserialize_composite_etag_cursor(etag_cursor: Optional[str]) -> List[str]:
+    if etag_cursor is None:
+        return []
+
+    return etag_cursor.split(CURSOR_SEPARATOR)
+
+def serialize_composite_etag_cursor(etags: List[str]):
+    return CURSOR_SEPARATOR.join(etags)
 
 
 def catalog_updated_sensor(job, resources_def) -> SensorDefinition:
@@ -27,7 +34,7 @@ def catalog_updated_sensor(job, resources_def) -> SensorDefinition:
             etag_cursor = context.cursor or None
             context.log.info(f"Old etag cursor: {etag_cursor}")
 
-            new_etag_cursor = generate_composite_etag_cursor(
+            new_etag_cursor = serialize_composite_etag_cursor(
                 [resources.latest_oss_catalog_gcs_file.etag, resources.latest_cloud_catalog_gcs_file.etag]
             )
             context.log.info(f"New etag cursor: {new_etag_cursor}")
@@ -43,3 +50,49 @@ def catalog_updated_sensor(job, resources_def) -> SensorDefinition:
             return RunRequest(run_key="updated_catalogs")
 
     return catalog_updated_sensor_definition
+
+
+def metadata_updated_sensor(job, resources_def) -> SensorDefinition:
+    """
+    TODO
+    """
+
+    @sensor(
+        name=f"{job.name}_on_metadata_updated",
+        job=job,
+        minimum_interval_seconds=30,
+        default_status=DefaultSensorStatus.STOPPED,
+    )
+    def metadata_updated_sensor_definition(context: SensorEvaluationContext):
+        context.log.info("Starting gcs_metadata_updated_sensor")
+
+        with build_resources(resources_def) as resources:
+            context.log.info("Got resources for gcs_metadata_updated_sensor")
+
+            etag_cursor_raw = context.cursor or None
+            etag_cursor = deserialize_composite_etag_cursor(etag_cursor_raw)
+            etag_cursor_set = set(etag_cursor)
+
+            context.log.info(f"Old etag cursor: {etag_cursor}")
+
+
+            # TODO ensure blobs is a list of all metadata.yml files
+            # metadata_blobs = metadata_bucket.list_blobs(prefix=METADATA_FOLDER)
+
+            gcs_metadata_blobs = resources.gcs_metadata_blobs
+            new_etag_cursors = [blob.etag for blob in gcs_metadata_blobs]
+            new_etag_cursor_set = set(new_etag_cursors)
+            context.log.info(f"New etag cursor: {new_etag_cursor_set}")
+
+            # Note: ETAGs are GCS's way of providing a version number for a file
+            # Another option would be to use the last modified date or MD5 hash
+            if etag_cursor_set == new_etag_cursor_set:
+                context.log.info("No new updated_metadata_files in GCS bucket")
+                return SkipReason("No new updated_metadata_files in GCS bucket")
+
+            serialized_new_etag_cursor = serialize_composite_etag_cursor(new_etag_cursors)
+            context.update_cursor(serialized_new_etag_cursor)  # Question: what happens if the run fails? is the cursor still updated?
+            context.log.info("New updated_metadata_files in GCS bucket")
+            return RunRequest(run_key="updated_metadata_files")
+
+    return metadata_updated_sensor_definition

--- a/airbyte-ci/connectors/metadata_service/orchestrator/orchestrator/sensors/catalog.py
+++ b/airbyte-ci/connectors/metadata_service/orchestrator/orchestrator/sensors/catalog.py
@@ -1,6 +1,6 @@
 from dagster import sensor, RunRequest, SkipReason, SensorDefinition, SensorEvaluationContext, build_resources, DefaultSensorStatus
 
-from orchestrator.utils.dagster_helpers import serialize_composite_etag_cursor
+from orchestrator.utils.dagster_helpers import serialize_composite_etags_cursor
 
 
 def catalog_updated_sensor(job, resources_def) -> SensorDefinition:
@@ -24,7 +24,7 @@ def catalog_updated_sensor(job, resources_def) -> SensorDefinition:
             etag_cursor = context.cursor or None
             context.log.info(f"Old etag cursor: {etag_cursor}")
 
-            new_etag_cursor = serialize_composite_etag_cursor(
+            new_etag_cursor = serialize_composite_etags_cursor(
                 [resources.latest_oss_catalog_gcs_file.etag, resources.latest_cloud_catalog_gcs_file.etag]
             )
             context.log.info(f"New etag cursor: {new_etag_cursor}")

--- a/airbyte-ci/connectors/metadata_service/orchestrator/orchestrator/sensors/metadata.py
+++ b/airbyte-ci/connectors/metadata_service/orchestrator/orchestrator/sensors/metadata.py
@@ -27,8 +27,7 @@ def metadata_updated_sensor(job, resources_def) -> SensorDefinition:
             context.log.info(f"Old etag cursor: {etag_cursor}")
 
             metadata_folder_blobs = resources.metadata_folder_blobs
-            ## TODO, yaml vs yml
-            new_etag_cursors = [blob.etag for blob in metadata_folder_blobs if blob.name.endswith("metadata.yaml")]
+            new_etag_cursors = [blob.etag for blob in metadata_folder_blobs if blob.name.endswith("metadata.yml")]
             new_etag_cursor_set = set(new_etag_cursors)
             context.log.info(f"New etag cursor: {new_etag_cursor_set}")
 

--- a/airbyte-ci/connectors/metadata_service/orchestrator/orchestrator/sensors/metadata.py
+++ b/airbyte-ci/connectors/metadata_service/orchestrator/orchestrator/sensors/metadata.py
@@ -1,0 +1,46 @@
+from dagster import sensor, RunRequest, SkipReason, SensorDefinition, SensorEvaluationContext, build_resources, DefaultSensorStatus
+from orchestrator.utils.dagster_helpers import deserialize_composite_etag_cursor, serialize_composite_etag_cursor
+
+
+def metadata_updated_sensor(job, resources_def) -> SensorDefinition:
+    """
+    This sensor is responsible for polling the metadata folder in GCS for new or updated metadata files.
+    If it notices that the etags have changed, it will trigger the given job.
+    """
+
+    @sensor(
+        name=f"{job.name}_on_metadata_updated",
+        job=job,
+        minimum_interval_seconds=30,
+        default_status=DefaultSensorStatus.STOPPED,
+    )
+    def metadata_updated_sensor_definition(context: SensorEvaluationContext):
+        context.log.info("Starting gcs_metadata_updated_sensor")
+
+        with build_resources(resources_def) as resources:
+            context.log.info("Got resources for gcs_metadata_updated_sensor")
+
+            etag_cursor_raw = context.cursor or None
+            etag_cursor = deserialize_composite_etag_cursor(etag_cursor_raw)
+            etag_cursor_set = set(etag_cursor)
+
+            context.log.info(f"Old etag cursor: {etag_cursor}")
+
+            metadata_folder_blobs = resources.metadata_folder_blobs
+            ## TODO, yaml vs yml
+            new_etag_cursors = [blob.etag for blob in metadata_folder_blobs if blob.name.endswith("metadata.yaml")]
+            new_etag_cursor_set = set(new_etag_cursors)
+            context.log.info(f"New etag cursor: {new_etag_cursor_set}")
+
+            # Note: ETAGs are GCS's way of providing a version number for a file
+            # Another option would be to use the last modified date or MD5 hash
+            if etag_cursor_set == new_etag_cursor_set:
+                context.log.info("No new updated_metadata_files in GCS bucket")
+                return SkipReason("No new updated_metadata_files in GCS bucket")
+
+            serialized_new_etag_cursor = serialize_composite_etag_cursor(new_etag_cursors)
+            context.update_cursor(serialized_new_etag_cursor)
+            context.log.info("New updated_metadata_files in GCS bucket")
+            return RunRequest(run_key="updated_metadata_files")
+
+    return metadata_updated_sensor_definition

--- a/airbyte-ci/connectors/metadata_service/orchestrator/orchestrator/utils/dagster_helpers.py
+++ b/airbyte-ci/connectors/metadata_service/orchestrator/orchestrator/utils/dagster_helpers.py
@@ -19,5 +19,6 @@ def deserialize_composite_etag_cursor(etag_cursor: Optional[str]) -> List[str]:
 
     return etag_cursor.split(CURSOR_SEPARATOR)
 
+
 def serialize_composite_etag_cursor(etags: List[str]):
     return CURSOR_SEPARATOR.join(etags)

--- a/airbyte-ci/connectors/metadata_service/orchestrator/orchestrator/utils/dagster_helpers.py
+++ b/airbyte-ci/connectors/metadata_service/orchestrator/orchestrator/utils/dagster_helpers.py
@@ -1,8 +1,9 @@
 from dagster import MetadataValue, Output
 import pandas as pd
-from typing import NewType
+from typing import Optional, List
 
 OutputDataFrame = Output[pd.DataFrame]
+CURSOR_SEPARATOR = ":"
 
 
 def output_dataframe(result_df: pd.DataFrame) -> Output[pd.DataFrame]:
@@ -10,3 +11,13 @@ def output_dataframe(result_df: pd.DataFrame) -> Output[pd.DataFrame]:
     Returns a Dagster Output object with a dataframe as the result and a markdown preview.
     """
     return Output(result_df, metadata={"count": len(result_df), "preview": MetadataValue.md(result_df.to_markdown())})
+
+
+def deserialize_composite_etag_cursor(etag_cursor: Optional[str]) -> List[str]:
+    if etag_cursor is None:
+        return []
+
+    return etag_cursor.split(CURSOR_SEPARATOR)
+
+def serialize_composite_etag_cursor(etags: List[str]):
+    return CURSOR_SEPARATOR.join(etags)

--- a/airbyte-ci/connectors/metadata_service/orchestrator/orchestrator/utils/dagster_helpers.py
+++ b/airbyte-ci/connectors/metadata_service/orchestrator/orchestrator/utils/dagster_helpers.py
@@ -13,12 +13,28 @@ def output_dataframe(result_df: pd.DataFrame) -> Output[pd.DataFrame]:
     return Output(result_df, metadata={"count": len(result_df), "preview": MetadataValue.md(result_df.to_markdown())})
 
 
-def deserialize_composite_etag_cursor(etag_cursor: Optional[str]) -> List[str]:
-    if etag_cursor is None:
-        return []
+def deserialize_composite_etags_cursor(etag_cursors: Optional[str]) -> List[str]:
+    """Deserialize a cursor string into a list of etags.
 
-    return etag_cursor.split(CURSOR_SEPARATOR)
+    Args:
+        etag_cursors (Optional[str]): A cursor string
+
+    Returns:
+        List[str]: A list of etags
+    """
+    return etag_cursors.split(CURSOR_SEPARATOR) if etag_cursors else []
 
 
-def serialize_composite_etag_cursor(etags: List[str]):
+def serialize_composite_etags_cursor(etags: List[str]) -> str:
+    """Serialize a list of etags into a cursor string.
+
+    Dagster cursors are strings, so we need to serialize the list of etags into a string.
+    https://docs.dagster.io/concepts/partitions-schedules-sensors/sensors#idempotence-and-cursors
+
+    Args:
+        etags (List[str]): unique etag ids from GCS
+
+    Returns:
+        str: A cursor string
+    """
     return CURSOR_SEPARATOR.join(etags)

--- a/airbyte-ci/connectors/metadata_service/orchestrator/tests/test_debug.py
+++ b/airbyte-ci/connectors/metadata_service/orchestrator/tests/test_debug.py
@@ -39,10 +39,10 @@ def debug_catalog_projection():
         ),
         "gcs_bucket_manager": gcs_bucket_manager.configured({"gcs_bucket": {"env": "METADATA_BUCKET"}}),
         "catalog_report_directory_manager": gcs_file_manager.configured(
-            {"gcs_bucket": {"env": "METADATA_BUCKET"}, "gcs_prefix": REPORT_FOLDER}
+            {"gcs_bucket": {"env": "METADATA_BUCKET"}, "prefix": REPORT_FOLDER}
         ),
-        "latest_oss_catalog_gcs_file": gcs_file_blob.configured({"gcs_prefix": CATALOG_FOLDER, "gcs_filename": "oss_catalog.json"}),
-        "latest_cloud_catalog_gcs_file": gcs_file_blob.configured({"gcs_prefix": CATALOG_FOLDER, "gcs_filename": "cloud_catalog.json"}),
+        "latest_oss_catalog_gcs_file": gcs_file_blob.configured({"prefix": CATALOG_FOLDER, "gcs_filename": "oss_catalog.json"}),
+        "latest_cloud_catalog_gcs_file": gcs_file_blob.configured({"prefix": CATALOG_FOLDER, "gcs_filename": "cloud_catalog.json"}),
     }
 
     context = build_op_context(resources=resources)


### PR DESCRIPTION
## What
Adds a metadata sensor to our dagster project

## How
Adds a sensor that looks for changes to metadata.yaml files in a given bucket

When it notices changes it runs two example asset jobs
1. metadata_directory_report
2. metadata_definitions

closes #24022 

