### PR TITLE
connectors-ci: add missing init files

### DIFF
--- a/tools/ci_connector_ops/ci_connector_ops/pipelines/commands/__init__.py
+++ b/tools/ci_connector_ops/ci_connector_ops/pipelines/commands/__init__.py
@@ -1,0 +1,3 @@
+#
+# Copyright (c) 2023 Airbyte, Inc., all rights reserved.
+#

--- a/tools/ci_connector_ops/ci_connector_ops/pipelines/commands/groups/__init__.py
+++ b/tools/ci_connector_ops/ci_connector_ops/pipelines/commands/groups/__init__.py
@@ -1,0 +1,3 @@
+#
+# Copyright (c) 2023 Airbyte, Inc., all rights reserved.
+#


### PR DESCRIPTION
## What
`__init__.py` files were missing after we refactored the pipelines package structure. It caused import errors like :

```
    return _bootstrap._gcd_import(name[level:], package, level)
  File "<frozen importlib._bootstrap>", line 1050, in _gcd_import
  File "<frozen importlib._bootstrap>", line 1027, in _find_and_load
  File "<frozen importlib._bootstrap>", line 992, in _find_and_load_unlocked
  File "<frozen importlib._bootstrap>", line 241, in _call_with_frames_removed
  File "<frozen importlib._bootstrap>", line 1050, in _gcd_import
  File "<frozen importlib._bootstrap>", line 1027, in _find_and_load
  File "<frozen importlib._bootstrap>", line 1004, in _find_and_load_unlocked
ModuleNotFoundError: No module named 'ci_connector_ops.pipelines.commands'
```