### PR TITLE
metadata validation: *.yml > *.yaml

### DIFF
--- a/.github/workflows/metadata_validate_manifest_dagger.yml
+++ b/.github/workflows/metadata_validate_manifest_dagger.yml
@@ -5,7 +5,7 @@ on:
   pull_request:
     # TODO (ben): Change to any connector change once the metadata service is in use
     paths:
-      - "airbyte-integrations/connectors/**/metadata.yml"
+      - "airbyte-integrations/connectors/**/metadata.yaml"
 jobs:
   metadata_service_ci:
     name: Validate Metadata Manifest for Connectors


### PR DESCRIPTION
## What
Metadata files extension is `.yaml` and not `.yml`. This typo prevents the metadata validation workflow to run on metadata files.