### PR TITLE
airbyte-ci: add missing init file for pipelines subpackage

### DIFF
--- a/tools/ci_connector_ops/ci_connector_ops/pipelines/pipelines/__init__.py
+++ b/tools/ci_connector_ops/ci_connector_ops/pipelines/pipelines/__init__.py
@@ -1,0 +1,3 @@
+#
+# Copyright (c) 2023 Airbyte, Inc., all rights reserved.
+#


### PR DESCRIPTION
An `__init__.py` file was missing which prevented correct import of the python subpackage when running in non editable mode.
