### PR TITLE
airbyte-ci: improve metadata validation perfs

### DIFF
--- a/tools/ci_connector_ops/ci_connector_ops/pipelines/pipelines/metadata.py
+++ b/tools/ci_connector_ops/ci_connector_ops/pipelines/pipelines/metadata.py
@@ -1,54 +1,41 @@
-import dagger
-from typing import Optional, Set, List
+#
+# Copyright (c) 2023 Airbyte, Inc., all rights reserved.
+#
 from pathlib import Path
+from typing import Optional, Set
 
+import dagger
+from ci_connector_ops.pipelines.actions.environments import with_poetry_module
 from ci_connector_ops.pipelines.bases import Step, StepStatus, TestReport
-from ci_connector_ops.pipelines.actions.environments import with_poetry_module, with_pipx_module, DEFAULT_PYTHON_EXCLUDE
 from ci_connector_ops.pipelines.contexts import PipelineContext
-from ci_connector_ops.pipelines.utils import (
-    DAGGER_CONFIG,
-    execute_concurrently,
-)
+from ci_connector_ops.pipelines.utils import DAGGER_CONFIG, execute_concurrently
 
 METADATA_DIR = "airbyte-ci/connectors/metadata_service"
 METADATA_LIB_MODULE_PATH = "lib"
 METADATA_ORCHESTRATOR_MODULE_PATH = "orchestrator"
 
 
-class TestPoetryModule(Step):
+class PoetryRun(Step):
     def __init__(self, context: PipelineContext, title: str, parent_dir_path: str, module_path: str):
         self.title = title
-        self.parent_dir_path = parent_dir_path
+        super().__init__(context)
+        self.parent_dir = self.context.get_repo_dir(parent_dir_path)
         self.module_path = module_path
-        super().__init__(context)
+        self.poetry_run_container = with_poetry_module(self.context, self.parent_dir, self.module_path).with_entrypoint(["poetry", "run"])
+
+    async def _run(self, poetry_run_args: list) -> StepStatus:
+        poetry_run_exec = self.poetry_run_container.with_exec(poetry_run_args)
+        return await self.get_step_result(poetry_run_exec)
+
+
+class MetadataValidation(PoetryRun):
+    def __init__(self, context: PipelineContext, metadata_file_path: Path):
+        super().__init__(context, f"Validate {metadata_file_path}", METADATA_DIR, METADATA_LIB_MODULE_PATH)
+        self.metadata_file = self.context.get_repo_dir(str(metadata_file_path), include=["metadata.yaml"]).file("metadata.yaml")
+        self.poetry_run_container = self.poetry_run_container.with_mounted_file("metadata.yaml", self.metadata_file)
 
     async def _run(self) -> StepStatus:
-        # TODO (ben): Use the GlobalExclusion when merged (https://github.com/airbytehq/airbyte/pull/24225/files#diff-c86417158894333350d986efd59ffada645270c1c65b4eec7645a0b63ac2d915R46)
-        parent_dir = self.context.get_repo_dir(self.parent_dir_path, exclude=DEFAULT_PYTHON_EXCLUDE)
-        metadata_lib_module = with_poetry_module(self.context, parent_dir, self.module_path)
-        run_test = metadata_lib_module.with_exec(["poetry", "run", "pytest"])
-        return await self.get_step_result(run_test)
-
-
-class SimpleExecStep(Step):
-    def __init__(self, context: PipelineContext, title: str, args: List[str], parent_container: dagger.Container):
-        self.title = title
-        self.args = args
-        self.parent_container = parent_container
-        super().__init__(context)
-
-    async def _run(self) -> StepStatus:
-        run_command = self.parent_container.with_exec(self.args)
-        return await self.get_step_result(run_command)
-
-
-def metadata_validation_step(metadata_pipeline_context: PipelineContext, metadata_path: Path, parent_container: dagger.Container) -> Step:
-    return SimpleExecStep(
-        context=metadata_pipeline_context,
-        title=f"Validate Connector Metadata Manifest: {metadata_path}",
-        args=["metadata_service", "validate", str(metadata_path)],
-        parent_container=parent_container,
-    )
+        return await super()._run(["metadata_service", "validate", "metadata.yaml"])
 
 
 async def run_metadata_validation_pipeline(
@@ -72,21 +59,10 @@ async def run_metadata_validation_pipeline(
 
     async with dagger.Connection(DAGGER_CONFIG) as dagger_client:
         metadata_pipeline_context.dagger_client = dagger_client.pipeline(metadata_pipeline_context.pipeline_name)
-
         async with metadata_pipeline_context:
-            parent_container = with_pipx_module(
-                metadata_pipeline_context,
-                ".",
-                f"{METADATA_DIR}/{METADATA_LIB_MODULE_PATH}",
-                include=["airbyte-integrations/connectors/*"],
-            )
+            validation_steps = [MetadataValidation(metadata_pipeline_context, metadata_path).run for metadata_path in metadata_source_paths]
 
-            validation_steps = [
-                metadata_validation_step(metadata_pipeline_context, metadata_path, parent_container).run
-                for metadata_path in metadata_source_paths
-            ]
-
-            results = await execute_concurrently(validation_steps)
+            results = await execute_concurrently(validation_steps, concurrency=len(validation_steps))
             metadata_pipeline_context.test_report = TestReport(pipeline_context=metadata_pipeline_context, steps_results=results)
 
         return metadata_pipeline_context.test_report.success
@@ -113,13 +89,13 @@ async def run_metadata_lib_test_pipeline(
     async with dagger.Connection(DAGGER_CONFIG) as dagger_client:
         metadata_pipeline_context.dagger_client = dagger_client.pipeline(metadata_pipeline_context.pipeline_name)
         async with metadata_pipeline_context:
-            test_lib_step = TestPoetryModule(
+            test_lib_step = PoetryRun(
                 context=metadata_pipeline_context,
                 title="Test Metadata Service Lib",
                 parent_dir_path=METADATA_DIR,
                 module_path=METADATA_LIB_MODULE_PATH,
             )
-            result = await test_lib_step.run()
+            result = await test_lib_step.run(["pytest"])
             metadata_pipeline_context.test_report = TestReport(pipeline_context=metadata_pipeline_context, steps_results=[result])
 
     return metadata_pipeline_context.test_report.success
@@ -146,13 +122,13 @@ async def run_metadata_orchestrator_test_pipeline(
     async with dagger.Connection(DAGGER_CONFIG) as dagger_client:
         metadata_pipeline_context.dagger_client = dagger_client.pipeline(metadata_pipeline_context.pipeline_name)
         async with metadata_pipeline_context:
-            test_orch_step = TestPoetryModule(
+            test_orch_step = PoetryRun(
                 context=metadata_pipeline_context,
                 title="Test Metadata Service Orchestrator",
                 parent_dir_path=METADATA_DIR,
                 module_path=METADATA_ORCHESTRATOR_MODULE_PATH,
             )
-            result = await test_orch_step.run()
+            result = await test_orch_step.run(["pytest"])
             metadata_pipeline_context.test_report = TestReport(pipeline_context=metadata_pipeline_context, steps_results=[result])
 
     return metadata_pipeline_context.test_report.success


### PR DESCRIPTION
## What
The previous approach lacked of concurrency and I think the use of Pipx is not required as simply running poetry run in containers provide enough isolation.
## How
* Create a PoetryRun step used to run `poetry run pytest` 
* Create a MetadataValidation(PoetryRun) step to run the ` poetry run metadata_service validate <yaml file>`
* Mount metadata files to the validation container with poetry to avoid mounting full connector dir.

**Validating all the connectors metadata takes 30s vs 220s before**