### PR TITLE
Connector builder: set pages and slices limits

### DIFF
--- a/airbyte-cdk/python/airbyte_cdk/connector_builder/connector_builder_handler.py
+++ b/airbyte-cdk/python/airbyte_cdk/connector_builder/connector_builder_handler.py
@@ -36,14 +36,14 @@ class TestReadLimits:
 
 def get_limits(config: Mapping[str, Any]) -> TestReadLimits:
     command_config = config.get("__test_read_config", {})
-    max_pages_per_slice = command_config.get(MAX_PAGES_PER_SLICE_KEY, DEFAULT_MAXIMUM_NUMBER_OF_PAGES_PER_SLICE) or DEFAULT_MAXIMUM_NUMBER_OF_PAGES_PER_SLICE
-    max_slices = command_config.get(MAX_SLICES_KEY, DEFAULT_MAXIMUM_NUMBER_OF_SLICES) or DEFAULT_MAXIMUM_NUMBER_OF_SLICES
-    max_records = command_config.get(MAX_RECORDS_KEY, DEFAULT_MAXIMUM_RECORDS) or DEFAULT_MAXIMUM_RECORDS
+    max_pages_per_slice = command_config.get(MAX_PAGES_PER_SLICE_KEY) or DEFAULT_MAXIMUM_NUMBER_OF_PAGES_PER_SLICE
+    max_slices = command_config.get(MAX_SLICES_KEY) or DEFAULT_MAXIMUM_NUMBER_OF_SLICES
+    max_records = command_config.get(MAX_RECORDS_KEY) or DEFAULT_MAXIMUM_RECORDS
     return TestReadLimits(max_records, max_pages_per_slice, max_slices)
 
 
 def create_source(config: Mapping[str, Any], limits: TestReadLimits) -> ManifestDeclarativeSource:
-    manifest = config.get("__injected_declarative_manifest")
+    manifest = config["__injected_declarative_manifest"]
     return ManifestDeclarativeSource(
         source_config=manifest, component_factory=ModelToComponentFactory(
             emit_connector_builder_messages=True,

--- a/airbyte-cdk/python/airbyte_cdk/connector_builder/connector_builder_handler.py
+++ b/airbyte-cdk/python/airbyte_cdk/connector_builder/connector_builder_handler.py
@@ -14,31 +14,49 @@ from airbyte_cdk.models import Type as MessageType
 from airbyte_cdk.sources.declarative.declarative_source import DeclarativeSource
 from airbyte_cdk.sources.declarative.declarative_stream import DeclarativeStream
 from airbyte_cdk.sources.declarative.manifest_declarative_source import ManifestDeclarativeSource
+from airbyte_cdk.sources.declarative.parsers.model_to_component_factory import ModelToComponentFactory
 from airbyte_cdk.sources.streams.http import HttpStream
 from airbyte_cdk.utils.traced_exception import AirbyteTracedException
 
 DEFAULT_MAXIMUM_NUMBER_OF_PAGES_PER_SLICE = 5
 DEFAULT_MAXIMUM_NUMBER_OF_SLICES = 5
-DEFAULT_MAX_RECORDS = 100
+DEFAULT_MAXIMUM_RECORDS = 100
+
+MAX_PAGES_PER_SLICE_KEY = "max_pages_per_slice"
+MAX_SLICES_KEY = "max_slices"
+MAX_RECORDS_KEY = "max_records"
 
 
-def get_limits(config: Mapping[str, Any]):
+@dataclasses.dataclass
+class TestReadLimits:
+    max_records: int = dataclasses.field(default=DEFAULT_MAXIMUM_RECORDS)
+    max_pages_per_slice: int = dataclasses.field(default=DEFAULT_MAXIMUM_NUMBER_OF_PAGES_PER_SLICE)
+    max_slices: int = dataclasses.field(default=DEFAULT_MAXIMUM_NUMBER_OF_SLICES)
+
+
+def get_limits(config: Mapping[str, Any]) -> TestReadLimits:
     command_config = config.get("__test_read_config", {})
-    max_pages_per_slice = command_config.get("max_pages_per_slice", DEFAULT_MAXIMUM_NUMBER_OF_PAGES_PER_SLICE) or DEFAULT_MAXIMUM_NUMBER_OF_PAGES_PER_SLICE
-    max_slices = command_config.get("max_slices", DEFAULT_MAXIMUM_NUMBER_OF_SLICES) or DEFAULT_MAXIMUM_NUMBER_OF_SLICES
-    max_records = command_config.get("max_records", DEFAULT_MAX_RECORDS) or DEFAULT_MAX_RECORDS
-    return {
-        "max_pages_per_slice": max_pages_per_slice,
-        "max_records": max_records,
-        "max_slices": max_slices,
-    }
+    max_pages_per_slice = command_config.get(MAX_PAGES_PER_SLICE_KEY, DEFAULT_MAXIMUM_NUMBER_OF_PAGES_PER_SLICE) or DEFAULT_MAXIMUM_NUMBER_OF_PAGES_PER_SLICE
+    max_slices = command_config.get(MAX_SLICES_KEY, DEFAULT_MAXIMUM_NUMBER_OF_SLICES) or DEFAULT_MAXIMUM_NUMBER_OF_SLICES
+    max_records = command_config.get(MAX_RECORDS_KEY, DEFAULT_MAXIMUM_RECORDS) or DEFAULT_MAXIMUM_RECORDS
+    return TestReadLimits(max_records, max_pages_per_slice, max_slices)
 
 
-def read_stream(source: DeclarativeSource, config: Mapping[str, Any], configured_catalog: ConfiguredAirbyteCatalog, max_pages_per_slice: int, max_slices: int, max_records: int) -> AirbyteMessage:
+def create_source(config: Mapping[str, Any], limits: TestReadLimits) -> ManifestDeclarativeSource:
+    manifest = config.get("__injected_declarative_manifest")
+    return ManifestDeclarativeSource(
+        source_config=manifest, component_factory=ModelToComponentFactory(
+            emit_connector_builder_messages=True,
+            limit_pages_fetched_per_slice=limits.max_pages_per_slice,
+            limit_slices_fetched=limits.max_slices)
+    )
+
+
+def read_stream(source: DeclarativeSource, config: Mapping[str, Any], configured_catalog: ConfiguredAirbyteCatalog, limits: TestReadLimits) -> AirbyteMessage:
     try:
-        handler = MessageGrouper(max_pages_per_slice, max_slices)
+        handler = MessageGrouper(limits.max_pages_per_slice, limits.max_slices)
         stream_name = configured_catalog.streams[0].stream.name  # The connector builder only supports a single stream
-        stream_read = handler.get_message_groups(source, config, configured_catalog, max_records)
+        stream_read = handler.get_message_groups(source, config, configured_catalog, limits.max_records)
         return AirbyteMessage(
             type=MessageType.RECORD,
             record=AirbyteRecordMessage(data=dataclasses.asdict(stream_read), stream=stream_name, emitted_at=_emitted_at()),

--- a/airbyte-cdk/python/unit_tests/connector_builder/test_connector_builder_handler.py
+++ b/airbyte-cdk/python/unit_tests/connector_builder/test_connector_builder_handler.py
@@ -11,9 +11,11 @@ from unittest.mock import patch
 import pytest
 from airbyte_cdk import connector_builder
 from airbyte_cdk.connector_builder.connector_builder_handler import (
-    DEFAULT_MAX_RECORDS,
     DEFAULT_MAXIMUM_NUMBER_OF_PAGES_PER_SLICE,
     DEFAULT_MAXIMUM_NUMBER_OF_SLICES,
+    DEFAULT_MAXIMUM_RECORDS,
+    TestReadLimits,
+    create_source,
     get_limits,
     list_streams,
     resolve_manifest,
@@ -160,7 +162,8 @@ def test_resolve_manifest(valid_resolve_manifest_config_file):
     command = "resolve_manifest"
     config["__command"] = command
     source = ManifestDeclarativeSource(MANIFEST)
-    resolved_manifest = handle_connector_builder_request(source, command, config, create_configured_catalog("dummy_stream"))
+    limits = TestReadLimits()
+    resolved_manifest = handle_connector_builder_request(source, command, config, create_configured_catalog("dummy_stream"), limits)
 
     expected_resolved_manifest = {
         "type": "DeclarativeSource",
@@ -323,9 +326,10 @@ def test_read():
             emitted_at=1,
         ),
     )
+    limits = TestReadLimits()
     with patch("airbyte_cdk.connector_builder.message_grouper.MessageGrouper.get_message_groups", return_value=stream_read):
         output_record = handle_connector_builder_request(
-            source, "test_read", config, ConfiguredAirbyteCatalog.parse_obj(CONFIGURED_CATALOG)
+            source, "test_read", config, ConfiguredAirbyteCatalog.parse_obj(CONFIGURED_CATALOG), limits
         )
         output_record.record.emitted_at = 1
         assert output_record == expected_airbyte_message
@@ -341,7 +345,8 @@ def test_read_returns_error_response(mock_from_exception):
     mock_from_exception.return_value = stack_trace
 
     source = MockManifestDeclarativeSource()
-    response = read_stream(source, TEST_READ_CONFIG, ConfiguredAirbyteCatalog.parse_obj(CONFIGURED_CATALOG))
+    limits = TestReadLimits()
+    response = read_stream(source, TEST_READ_CONFIG, ConfiguredAirbyteCatalog.parse_obj(CONFIGURED_CATALOG), limits)
 
     expected_stream_read = StreamRead(logs=[LogMessage("error_message - a stack trace", "ERROR")],
                                       slices=[StreamReadSlicesInner(
@@ -456,8 +461,9 @@ def test_list_streams_integration_test():
     command = "list_streams"
     config["__command"] = command
     source = ManifestDeclarativeSource(MANIFEST)
+    limits = TestReadLimits()
 
-    list_streams = handle_connector_builder_request(source, command, config, None)
+    list_streams = handle_connector_builder_request(source, command, config, None, limits)
 
     assert list_streams.record.data == {
         "streams": [{"name": "stream_with_custom_requester", "url": "https://api.sendgrid.com/v3/marketing/lists"}]
@@ -481,14 +487,28 @@ def create_mock_declarative_stream(http_stream):
 @pytest.mark.parametrize(
     "test_name, config, expected_max_records, expected_max_slices, expected_max_pages_per_slice",
     [
-        ("test_no_test_read_config", {}, DEFAULT_MAX_RECORDS, DEFAULT_MAXIMUM_NUMBER_OF_SLICES, DEFAULT_MAXIMUM_NUMBER_OF_PAGES_PER_SLICE),
-        ("test_no_values_set", {"__test_read_config": {}}, DEFAULT_MAX_RECORDS, DEFAULT_MAXIMUM_NUMBER_OF_SLICES, DEFAULT_MAXIMUM_NUMBER_OF_PAGES_PER_SLICE),
+        ("test_no_test_read_config", {}, DEFAULT_MAXIMUM_RECORDS, DEFAULT_MAXIMUM_NUMBER_OF_SLICES, DEFAULT_MAXIMUM_NUMBER_OF_PAGES_PER_SLICE),
+        ("test_no_values_set", {"__test_read_config": {}}, DEFAULT_MAXIMUM_RECORDS, DEFAULT_MAXIMUM_NUMBER_OF_SLICES, DEFAULT_MAXIMUM_NUMBER_OF_PAGES_PER_SLICE),
         ("test_values_are_set", {"__test_read_config": {"max_slices": 1, "max_pages_per_slice": 2, "max_records": 3}}, 3, 1, 2),
     ],
 )
 def test_get_limits(test_name, config, expected_max_records, expected_max_slices, expected_max_pages_per_slice):
     limits = get_limits(config)
-    max_pages_per_slice, max_records, max_slices = limits["max_pages_per_slice"], limits["max_records"], limits["max_slices"]
-    assert max_records == expected_max_records
-    assert max_pages_per_slice == expected_max_pages_per_slice
-    assert max_slices == expected_max_slices
+    assert limits.max_records == expected_max_records
+    assert limits.max_pages_per_slice == expected_max_pages_per_slice
+    assert limits.max_slices == expected_max_slices
+
+
+def test_create_source():
+    max_records = 3
+    max_pages_per_slice = 2
+    max_slices = 1
+    limits = TestReadLimits(max_records, max_pages_per_slice, max_slices)
+
+    config = {"__injected_declarative_manifest": MANIFEST}
+
+    source = create_source(config, limits)
+
+    assert isinstance(source, ManifestDeclarativeSource)
+    assert source._constructor._limit_pages_fetched_per_slice == limits.max_pages_per_slice
+    assert source._constructor._limit_slices_fetched == limits.max_slices


### PR DESCRIPTION
## What
* The main method needs to set the limits on the number of slices and the number of pages per slice we'll fetch in a test read

## How
* Create a `TestReadLimits` dataclass to encapsulate the limits on number of records, number of slices, and number of pages per slice
* set the limits when creating the source
* add unit tests

## Recommended reading order
1. `airbyte-cdk/python/airbyte_cdk/connector_builder/connector_builder_handler.py`
2. `airbyte-cdk/python/airbyte_cdk/connector_builder/main.py`
3. `airbyte-cdk/python/unit_tests/connector_builder/test_connector_builder_handler.py`

## Testing
Confirmed a test read from the atelier-server only returns 5 pages
```
curl -X POST 'localhost/v1/stream/read' \
  -H 'Accept: */*' \
  -H 'Accept-Language: en-US,en;q=0.9' \
  -H 'Authorization: Basic YWlyYnl0ZTpwYXNzd29yZA==' \
  -H 'Connection: keep-alive' \
  -H 'Cookie: ajs_user_id=868ac191-c872-417c-8935-e09e782c5ae5; ajs_anonymous_id=1387f288-277d-41d4-940e-7f23777ab1b7; _gcl_au=1.1.960841038.1678276956' \
  -H 'Origin: http://localhost:8000' \
  -H 'Referer: http://localhost:8000/workspaces/868ac191-c872-417c-8935-e09e782c5ae5/connector-builder/edit/08aafe21-da67-4a32-8046-a6ef89e3b066' \
  -H 'Sec-Fetch-Dest: empty' \
  -H 'Sec-Fetch-Mode: cors' \
  -H 'Sec-Fetch-Site: same-origin' \
  -H 'User-Agent: Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/112.0.0.0 Safari/537.36' \
  -H 'content-type: application/json' \
  -H 'sec-ch-ua: "Chromium";v="112", "Google Chrome";v="112", "Not:A-Brand";v="99"' \
  -H 'sec-ch-ua-mobile: ?0' \
  -H 'sec-ch-ua-platform: "macOS"' \
  -H 'x-airbyte-analytic-source: webapp' \
  --data-raw $'{"manifest":{"version":"0.30.1","type":"DeclarativeSource","check":{"type":"CheckStream","stream_names":["items"]},"streams":[{"type":"DeclarativeStream","name":"items","primary_key":[],"schema_loader":{"type":"InlineSchemaLoader","schema":{}},"retriever":{"type":"SimpleRetriever","requester":{"type":"HttpRequester","url_base":"http://localhost:6767/items","path":"items","http_method":"GET","request_parameters":{},"request_headers":{},"request_body_json":{},"authenticator":{"type":"BearerAuthenticator","api_token":"{{ config[\'api_key\'] }}"}},"record_selector":{"type":"RecordSelector","extractor":{"type":"DpathExtractor","field_path":["items"]}},"paginator":{"type":"NoPagination"},"partition_router":[{"type":"ListPartitionRouter","values":["0","1","2","3","4","5","6"],"cursor_field":"item_id"}]}}],"spec":{"connection_specification":{"$schema":"http://json-schema.org/draft-07/schema#","type":"object","required":["api_key"],"properties":{"api_key":{"type":"string","title":"API Key","airbyte_secret":true}},"additionalProperties":true},"documentation_url":"https://example.org","type":"Spec"}},"stream":"items","config":{"api_key":"theauthkey"}}' \
  --compressed | gron | grep pages | grep \.response\.status
  % Total    % Received % Xferd  Average Speed   Time    Time     Time  Current
                                 Dload  Upload   Total   Spent    Left  Speed
100  1631  100   475  100  1156    752   1830 --:--:-- --:--:-- --:--:--  2597
json.slices[0].pages[0].response.status = 200;
json.slices[0].pages[1].response.status = 200;
json.slices[0].pages[2].response.status = 200;
json.slices[0].pages[3].response.status = 200;
json.slices[0].pages[4].response.status = 200;
```