### PR TITLE
metadata: fix strict-encrypt metadata dockerRepository

### DIFF
--- a/airbyte-integrations/connectors/destination-clickhouse-strict-encrypt/metadata.yaml
+++ b/airbyte-integrations/connectors/destination-clickhouse-strict-encrypt/metadata.yaml
@@ -8,7 +8,7 @@ data:
   connectorType: destination
   definitionId: ce0d828e-1dc4-496c-b122-2da42e637e48
   dockerImageTag: 0.2.3
-  dockerRepository: airbyte/destination-clickhouse
+  dockerRepository: airbyte/destination-clickhouse-strict-encrypt
   githubIssueLabel: destination-clickhouse
   icon: clickhouse.svg
   license: MIT

--- a/airbyte-integrations/connectors/destination-elasticsearch-strict-encrypt/metadata.yaml
+++ b/airbyte-integrations/connectors/destination-elasticsearch-strict-encrypt/metadata.yaml
@@ -8,7 +8,7 @@ data:
   connectorType: destination
   definitionId: 68f351a7-2745-4bef-ad7f-996b8e51bb8c
   dockerImageTag: 0.1.6
-  dockerRepository: airbyte/destination-elasticsearch
+  dockerRepository: airbyte/destination-elasticsearch-strict-encrypt
   githubIssueLabel: destination-elasticsearch
   icon: elasticsearch.svg
   license: MIT

--- a/airbyte-integrations/connectors/destination-mongodb-strict-encrypt/metadata.yaml
+++ b/airbyte-integrations/connectors/destination-mongodb-strict-encrypt/metadata.yaml
@@ -8,7 +8,7 @@ data:
   connectorType: destination
   definitionId: 8b746512-8c2e-6ac1-4adc-b59faafd473c
   dockerImageTag: 0.1.9
-  dockerRepository: airbyte/destination-mongodb
+  dockerRepository: airbyte/destination-mongodb-strict-encrypt
   githubIssueLabel: destination-mongodb
   icon: mongodb.svg
   license: MIT

--- a/airbyte-integrations/connectors/destination-mssql-strict-encrypt/metadata.yaml
+++ b/airbyte-integrations/connectors/destination-mssql-strict-encrypt/metadata.yaml
@@ -8,7 +8,7 @@ data:
   connectorType: destination
   definitionId: d4353156-9217-4cad-8dd7-c108fd4f74cf
   dockerImageTag: 0.1.23
-  dockerRepository: airbyte/destination-mssql
+  dockerRepository: airbyte/destination-mssql-strict-encrypt
   githubIssueLabel: destination-mssql
   icon: mssql.svg
   license: MIT

--- a/airbyte-integrations/connectors/destination-mysql-strict-encrypt/metadata.yaml
+++ b/airbyte-integrations/connectors/destination-mysql-strict-encrypt/metadata.yaml
@@ -8,7 +8,7 @@ data:
   connectorType: destination
   definitionId: ca81ee7c-3163-4246-af40-094cc31e5e42
   dockerImageTag: 0.1.20
-  dockerRepository: airbyte/destination-mysql
+  dockerRepository: airbyte/destination-mysql-strict-encrypt
   githubIssueLabel: destination-mysql
   icon: mysql.svg
   license: MIT

--- a/airbyte-integrations/connectors/destination-oracle-strict-encrypt/metadata.yaml
+++ b/airbyte-integrations/connectors/destination-oracle-strict-encrypt/metadata.yaml
@@ -8,7 +8,7 @@ data:
   connectorType: destination
   definitionId: 3986776d-2319-4de9-8af8-db14c0996e72
   dockerImageTag: 0.1.19
-  dockerRepository: airbyte/destination-oracle
+  dockerRepository: airbyte/destination-oracle-strict-encrypt
   githubIssueLabel: destination-oracle
   icon: oracle.svg
   license: MIT

--- a/airbyte-integrations/connectors/destination-postgres-strict-encrypt/metadata.yaml
+++ b/airbyte-integrations/connectors/destination-postgres-strict-encrypt/metadata.yaml
@@ -8,7 +8,7 @@ data:
   connectorType: destination
   definitionId: 25c5221d-dce2-4163-ade9-739ef790f503
   dockerImageTag: 0.3.27
-  dockerRepository: airbyte/destination-postgres
+  dockerRepository: airbyte/destination-postgres-strict-encrypt
   githubIssueLabel: destination-postgres
   icon: postgresql.svg
   license: MIT

--- a/airbyte-integrations/connectors/source-alloydb-strict-encrypt/metadata.yaml
+++ b/airbyte-integrations/connectors/source-alloydb-strict-encrypt/metadata.yaml
@@ -12,7 +12,7 @@ data:
   connectorType: source
   definitionId: 1fa90628-2b9e-11ed-a261-0242ac120002
   dockerImageTag: 2.0.17
-  dockerRepository: airbyte/source-alloydb
+  dockerRepository: airbyte/source-alloydb-strict-encrypt
   githubIssueLabel: source-alloydb
   icon: alloydb.svg
   license: MIT

--- a/airbyte-integrations/connectors/source-clickhouse-strict-encrypt/metadata.yaml
+++ b/airbyte-integrations/connectors/source-clickhouse-strict-encrypt/metadata.yaml
@@ -12,7 +12,7 @@ data:
   connectorType: source
   definitionId: bad83517-5e54-4a3d-9b53-63e85fbd4d7c
   dockerImageTag: 0.1.17
-  dockerRepository: airbyte/source-clickhouse
+  dockerRepository: airbyte/source-clickhouse-strict-encrypt
   githubIssueLabel: source-clickhouse
   icon: clickhouse.svg
   license: MIT

--- a/airbyte-integrations/connectors/source-cockroachdb-strict-encrypt/metadata.yaml
+++ b/airbyte-integrations/connectors/source-cockroachdb-strict-encrypt/metadata.yaml
@@ -11,7 +11,7 @@ data:
   connectorType: source
   definitionId: 9fa5862c-da7c-11eb-8d19-0242ac130003
   dockerImageTag: 0.1.22
-  dockerRepository: airbyte/source-cockroachdb
+  dockerRepository: airbyte/source-cockroachdb-strict-encrypt
   githubIssueLabel: source-cockroachdb
   icon: cockroachdb.svg
   license: MIT

--- a/airbyte-integrations/connectors/source-mongodb-strict-encrypt/metadata.yaml
+++ b/airbyte-integrations/connectors/source-mongodb-strict-encrypt/metadata.yaml
@@ -8,7 +8,7 @@ data:
   connectorType: source
   definitionId: b2e713cd-cc36-4c0a-b5bd-b47cb8a0561e
   dockerImageTag: 0.1.19
-  dockerRepository: airbyte/source-mongodb-v2
+  dockerRepository: airbyte/source-mongodb-strict-encrypt
   githubIssueLabel: source-mongodb-v2
   icon: mongodb.svg
   license: MIT

--- a/airbyte-integrations/connectors/source-mssql-strict-encrypt/metadata.yaml
+++ b/airbyte-integrations/connectors/source-mssql-strict-encrypt/metadata.yaml
@@ -12,7 +12,7 @@ data:
   connectorType: source
   definitionId: b5ea17b1-f170-46dc-bc31-cc744ca984c1
   dockerImageTag: 1.0.9
-  dockerRepository: airbyte/source-mssql
+  dockerRepository: airbyte/source-mssql-strict-encrypt
   githubIssueLabel: source-mssql
   icon: mssql.svg
   license: MIT

--- a/airbyte-integrations/connectors/source-mysql-strict-encrypt/metadata.yaml
+++ b/airbyte-integrations/connectors/source-mysql-strict-encrypt/metadata.yaml
@@ -12,7 +12,7 @@ data:
   connectorType: source
   definitionId: 435bb9a5-7887-4809-aa58-28c27df0d7ad
   dockerImageTag: 2.0.12
-  dockerRepository: airbyte/source-mysql
+  dockerRepository: airbyte/source-mysql-strict-encrypt
   githubIssueLabel: source-mysql
   icon: mysql.svg
   license: MIT

--- a/airbyte-integrations/connectors/source-oracle-strict-encrypt/metadata.yaml
+++ b/airbyte-integrations/connectors/source-oracle-strict-encrypt/metadata.yaml
@@ -12,7 +12,7 @@ data:
   connectorType: source
   definitionId: b39a7370-74c3-45a6-ac3a-380d48520a83
   dockerImageTag: 0.3.24
-  dockerRepository: airbyte/source-oracle
+  dockerRepository: airbyte/source-oracle-strict-encrypt
   githubIssueLabel: source-oracle
   icon: oracle.svg
   license: MIT

--- a/airbyte-integrations/connectors/source-postgres-strict-encrypt/metadata.yaml
+++ b/airbyte-integrations/connectors/source-postgres-strict-encrypt/metadata.yaml
@@ -12,7 +12,7 @@ data:
   connectorType: source
   definitionId: decd338e-5647-4c0b-adf4-da0e75f5a750
   dockerImageTag: 2.0.17
-  dockerRepository: airbyte/source-postgres
+  dockerRepository: airbyte/source-postgres-strict-encrypt
   githubIssueLabel: source-postgres
   icon: postgresql.svg
   license: MIT


### PR DESCRIPTION
## What
The docker registry for strict-encrypt connectors was referencing their non strict-encrypt equivalents.