### PR TITLE
metadata-ci: update the dagger cli commit id

### DIFF
--- a/.github/actions/run-dagger-pipeline/action.yml
+++ b/.github/actions/run-dagger-pipeline/action.yml
@@ -38,7 +38,7 @@ runs:
       shell: bash
       run: |
         export _EXPERIMENTAL_DAGGER_RUNNER_HOST="unix:///var/run/buildkit/buildkitd.sock"
-        DAGGER_CLI_COMMIT="67c7e7635cf4ea0e446e2fed522a3e314c960f6a"
+        DAGGER_CLI_COMMIT="f0119bcde82e06731558a8baf70d6e7d271b21d1"
         DAGGER_TMP_BINDIR="/tmp/dagger_${DAGGER_CLI_COMMIT}"
         export _EXPERIMENTAL_DAGGER_CLI_BIN="$DAGGER_TMP_BINDIR/dagger"
         if [ ! -f  "$_EXPERIMENTAL_DAGGER_CLI_BIN" ]; then


### PR DESCRIPTION
## What
Updates the dagger CLI commit id to be consistent with the [other dagger workflows](https://github.com/airbytehq/airbyte/blob/master/.github/workflows/connector_integration_test_single_dagger.yml#L1)
