### PR TITLE
destination-s3-glue: Fix precision and scale of decimal type

### DIFF
--- a/airbyte-integrations/connectors/destination-s3-glue/Dockerfile
+++ b/airbyte-integrations/connectors/destination-s3-glue/Dockerfile
@@ -14,5 +14,5 @@ ENV APPLICATION destination-s3-glue
 
 COPY --from=build /airbyte /airbyte
 
-LABEL io.airbyte.version=0.1.5
+LABEL io.airbyte.version=0.1.6
 LABEL io.airbyte.name=airbyte/destination-s3-glue

--- a/airbyte-integrations/connectors/destination-s3-glue/src/main/java/io/airbyte/integrations/destination/s3_glue/GlueOperations.java
+++ b/airbyte-integrations/connectors/destination-s3-glue/src/main/java/io/airbyte/integrations/destination/s3_glue/GlueOperations.java
@@ -129,7 +129,9 @@ public class GlueOperations implements MetastoreOperations {
         if (jsonNode.has("airbyte_type") && jsonNode.get("airbyte_type").asText().equals("integer")) {
           yield "int";
         }
-        yield "decimal";  // Default to use decimal as it is a more precise type and allows for large values
+        // Default to use decimal as it is a more precise type and allows for large values
+        // Set the default scale and precision to 38 to allow or the widest range of values
+        yield "decimal(38,38)";
       }
       case "boolean" -> "boolean";
       case "integer" -> "int";

--- a/docs/integrations/destinations/s3-glue.md
+++ b/docs/integrations/destinations/s3-glue.md
@@ -245,6 +245,7 @@ Output files can be compressed. The default option is GZIP compression. If compr
 
 | Version | Date       | Pull Request                                             | Subject                                                                                 |
 |:--------|:-----------|:---------------------------------------------------------|:----------------------------------------------------------------------------------------|
+| 0.1.6   | 2023-04-13 | [25178](https://github.com/airbytehq/airbyte/pull/25178) | Fix decimal precision and scale to allow for a wider range of numeric values         |
 | 0.1.5   | 2023-04-11 | [25048](https://github.com/airbytehq/airbyte/pull/25048) | Fix config schema to support new JSONL flattening configuration interface               |
 | 0.1.4   | 2023-03-10 | [23950](https://github.com/airbytehq/airbyte/pull/23950) | Fix schema syntax error for struct fields and handle missing `items` in array fields    |
 | 0.1.3   | 2023-02-10 | [22822](https://github.com/airbytehq/airbyte/pull/22822) | Fix data type for _ab_emitted_at column in table definition                             |


### PR DESCRIPTION
The decimal type in Hive will default to a precision of 10 and a scale of 0, meaning that it cannot handle numbers larger than 10 digits. The maximum values for precision and scale are 38 and 38 respectively. This updates the decimal type specified in destination schemas to use the maximum values for the broadest compatibility with numeric values.

If a table is using the default precision of 10 and a number is present which exceeds that many digits then the query engine will throw a `fieldValue cannot be null` error message which is very cryptic.

## What
Allow for handling of larger numeric values in Glue tables without throwing errors due to null fieldValues

## How
Set the precision and scale of decimal fields to their maximum value of 38 rather than the default of 10,0

## Recommended reading order
1. GlueOperations.java

## 🚨 User Impact 🚨
Users with numeric values larger than 10 and less than 38 digits will be able to query those columns without error.


## Pre-merge Checklist

<details><summary><strong>Updating a connector</strong></summary>

### Community member or Airbyter

- [ ] Grant edit access to maintainers ([instructions](https://docs.github.com/en/github/collaborating-with-pull-requests/working-with-forks/allowing-changes-to-a-pull-request-branch-created-from-a-fork#enabling-repository-maintainer-permissions-on-existing-pull-requests))
- [ ] Secrets in the connector's spec are annotated with `airbyte_secret`
- [ ] Unit & integration tests added and passing. Community members, please provide proof of success locally e.g: screenshot or copy-paste unit, integration, and acceptance test output. To run acceptance tests for a Python connector, follow instructions in the README. For java connectors run `./gradlew :airbyte-integrations:connectors:<name>:integrationTest`.
- [ ] Code reviews completed
- [ ] Connector version has been incremented
    - [ ] Version has been bumped according to our [Semantic Versioning for Connectors](https://docs.airbyte.com/contributing-to-airbyte/#semantic-versioning-for-connectors) guidelines
    - [ ] `Dockerfile` has updated version
- [ ] Documentation updated
    - [ ] Connector's `README.md`
    - [ ] Connector's `bootstrap.md`. See [description and examples](https://docs.google.com/document/d/1ypdgmwmEHWv-TrO4_YOQ7pAJGVrMp5BOkEVh831N260/edit?usp=sharing)
    - [ ] Changelog updated in `docs/integrations/<source or destination>/<name>.md` with an entry for the new version. See changelog [example](https://docs.airbyte.io/integrations/sources/stripe#changelog)

- [ ] PR name follows [PR naming conventions](https://docs.airbyte.com/contributing-to-airbyte/issues-and-pull-requests)

### Airbyter

If this is a community PR, the Airbyte engineer reviewing this PR is responsible for the below items.

- [ ] Create a non-forked branch based on this PR and test the below items on it
- [ ] Build is successful
- [ ] If new credentials are required for use in CI, add them to GSM. [Instructions](https://docs.airbyte.io/connector-development#using-credentials-in-ci).
- [ ] [`/test connector=connectors/<name>` command](https://docs.airbyte.io/connector-development#updating-an-existing-connector) is passing
- [ ] New Connector version released on Dockerhub and connector version bumped by running the `/publish` command described [here](https://docs.airbyte.io/connector-development#updating-an-existing-connector)

</details>
