### PR TITLE
Add is_optional flag to connector tests to report check failures as warnings

### DIFF
--- a/tools/ci_connector_ops/ci_connector_ops/pipelines/contexts.py
+++ b/tools/ci_connector_ops/ci_connector_ops/pipelines/contexts.py
@@ -66,6 +66,7 @@ class PipelineContext:
         gha_workflow_run_url: Optional[str] = None,
         pipeline_start_timestamp: Optional[int] = None,
         ci_context: Optional[str] = None,
+        is_ci_optional: bool = False,
     ):
         """Initialize a pipeline context.
 
@@ -87,6 +88,7 @@ class PipelineContext:
         self.created_at = datetime.utcnow()
         self.ci_context = ci_context
         self.state = ContextState.INITIALIZED
+        self.is_ci_optional = is_ci_optional
 
         self.logger = logging.getLogger(self.pipeline_name)
         self.dagger_client = None
@@ -133,6 +135,7 @@ class PipelineContext:
             "context": self.pipeline_name,
             "should_send": self.is_pr,
             "logger": self.logger,
+            "is_optional": self.is_ci_optional,
         }
 
     def get_repo_dir(self, subdir: str = ".", exclude: Optional[List[str]] = None, include: Optional[List[str]] = None) -> Directory:
@@ -266,6 +269,8 @@ class ConnectorTestContext(PipelineContext):
             gha_workflow_run_url=gha_workflow_run_url,
             pipeline_start_timestamp=pipeline_start_timestamp,
             ci_context=ci_context,
+            # TODO: remove this once stable and our default pipeline
+            is_ci_optional=True,
         )
 
     @property

--- a/tools/ci_connector_ops/ci_connector_ops/pipelines/tests/java_connectors.py
+++ b/tools/ci_connector_ops/ci_connector_ops/pipelines/tests/java_connectors.py
@@ -161,7 +161,6 @@ class GradleTask(Step, ABC):
         return command
 
     async def _run(self) -> StepResult:
-
         connector_under_test = (
             environments.with_gradle(
                 self.context, self.build_include, docker_service_name=self.docker_service_name, bind_to_docker_host=self.BIND_TO_DOCKER_HOST


### PR DESCRIPTION
## What
Java connectors were failing the new dagger pipeline (when /test passed) and blocking merge.
https://github.com/airbytehq/airbyte/pull/25120
https://airbytehq-team.slack.com/archives/C03VDJ4FMJB/p1681490346947469

## How
This adds a new option to pipelines to have optional failures.

## Notes for reviewer
1. Github doesnt have a warning status, so we have to use success.

