### PR TITLE
Fix manifest_declarative_source + add unit tests

### DIFF
--- a/airbyte-cdk/python/airbyte_cdk/sources/declarative/manifest_declarative_source.py
+++ b/airbyte-cdk/python/airbyte_cdk/sources/declarative/manifest_declarative_source.py
@@ -130,7 +130,7 @@ class ManifestDeclarativeSource(DeclarativeSource):
         yield from super().read(logger, config, catalog, state)
 
     def should_log_slice_message(self, logger: logging.Logger):
-        return self._emit_connector_builder_messages or super(self).should_log_slice_message(logger)
+        return self._emit_connector_builder_messages or super().should_log_slice_message(logger)
 
     def _configure_logger_level(self, logger: logging.Logger):
         """

--- a/airbyte-cdk/python/unit_tests/sources/declarative/test_manifest_declarative_source.py
+++ b/airbyte-cdk/python/unit_tests/sources/declarative/test_manifest_declarative_source.py
@@ -769,7 +769,7 @@ def _create_page(response_body):
     return _create_request(), _create_response(response_body)
 
 
-@patch.object(HttpStream, "_fetch_next_page", side_effect=(_create_page({"rates": [{"ABC": 0}, {"AED": 1}],"_metadata": {"next": "next"}}), _create_page({"result": [{"id": 2}],"_metadata": {"next": "next"}})) * 10)
+@patch.object(HttpStream, "_fetch_next_page", side_effect=(_create_page({"rates": [{"ABC": 0}, {"AED": 1}],"_metadata": {"next": "next"}}), _create_page({"rates": [{"USD": 2}],"_metadata": {"next": "next"}})) * 10)
 def test_read_manifest_declarative_source_no_pagination_no_incremental(mock_http_stream):
     _stream_name = "Rates"
     manifest = {
@@ -969,3 +969,112 @@ def test_read_manifest_declarative_source_with_pagination_no_incremental(mock_ht
     assert output_data[0].record.data == {"ABC": 0}
     assert output_data[1].record.data == {"AED": 1}
     assert output_data[2].record.data == {"USD": 2}
+
+
+@patch.object(HttpStream, "_fetch_next_page", side_effect=(
+        _create_page({"rates": [{"ABC": 0, "partition": 0}, {"AED": 1, "partition": 0}], "_metadata": {"next": "next"}}),
+        _create_page({"rates": [{"ABC": 2, "partition": 1}], "_metadata": {"next": "next"}}),
+                                                           ))
+def test_read_manifest_declarative_source_no_pagination_with_partition_router(mock_http_stream):
+    _stream_name = "Rates"
+    manifest = {
+        "version": "0.34.2",
+        "type": "DeclarativeSource",
+        "check": {
+            "type": "CheckStream",
+            "stream_names": [
+                "Rates"
+            ]
+        },
+        "streams": [
+            {
+                "type": "DeclarativeStream",
+                "name": "Rates",
+                "primary_key": [],
+                "schema_loader": {
+                    "type": "InlineSchemaLoader",
+                    "schema": {
+                        "$schema": "http://json-schema.org/schema#",
+                        "properties": {
+                            "ABC": {
+                                "type": "number"
+                            },
+                            "AED": {
+                                "type": "number"
+                            },
+                            "partition": {
+                                "type": "number"
+                            }
+                        },
+                        "type": "object"
+                    }
+                },
+                "retriever": {
+                    "type": "SimpleRetriever",
+                    "requester": {
+                        "type": "HttpRequester",
+                        "url_base": "https://api.apilayer.com",
+                        "path": "/exchangerates_data/latest",
+                        "http_method": "GET",
+                        "request_parameters": {},
+                        "request_headers": {},
+                        "request_body_json": {},
+                        "authenticator": {
+                            "type": "ApiKeyAuthenticator",
+                            "header": "apikey",
+                            "api_token": "{{ config['api_key'] }}"
+                        }
+                    },
+                    "partition_router": {
+                        "type": "ListPartitionRouter",
+                        "values": ["0", "1"],
+                        "cursor_field": "partition"
+                    },
+                    "record_selector": {
+                        "type": "RecordSelector",
+                        "extractor": {
+                            "type": "DpathExtractor",
+                            "field_path": [
+                                "rates"
+                            ]
+                        }
+                    },
+                    "paginator": {
+                        "type": "NoPagination"
+                    }
+                }
+            }
+        ],
+        "spec": {
+            "connection_specification": {
+                "$schema": "http://json-schema.org/draft-07/schema#",
+                "type": "object",
+                "required": [
+                    "api_key"
+                ],
+                "properties": {
+                    "api_key": {
+                        "type": "string",
+                        "title": "API Key",
+                        "airbyte_secret": True
+                    }
+                },
+                "additionalProperties": True
+            },
+            "documentation_url": "https://example.org",
+            "type": "Spec"
+        }
+    }
+    config = {"__injected_declarative_manifest": manifest}
+
+    catalog = ConfiguredAirbyteCatalog(streams=[
+        ConfiguredAirbyteStream(stream=AirbyteStream(name=_stream_name, json_schema={}, supported_sync_modes=[SyncMode.full_refresh]), sync_mode=SyncMode.full_refresh, destination_sync_mode=DestinationSyncMode.append)
+    ])
+
+    source = ManifestDeclarativeSource(source_config=config.get("__injected_declarative_manifest"))
+    output_data = list(source.read(logger, config, catalog, {}))
+
+    assert len(output_data) == 3
+    assert output_data[0].record.data == {"ABC": 0, "partition": 0}
+    assert output_data[1].record.data == {"AED": 1, "partition": 0}
+    assert output_data[2].record.data == {"ABC": 2, "partition": 1}

--- a/airbyte-cdk/python/unit_tests/sources/declarative/test_manifest_declarative_source.py
+++ b/airbyte-cdk/python/unit_tests/sources/declarative/test_manifest_declarative_source.py
@@ -6,7 +6,7 @@ import json
 import logging
 import os
 import sys
-from typing import List, Mapping, Any
+from typing import Any, List, Mapping
 from unittest.mock import call, patch
 
 import pytest

--- a/airbyte-cdk/python/unit_tests/sources/declarative/test_manifest_declarative_source.py
+++ b/airbyte-cdk/python/unit_tests/sources/declarative/test_manifest_declarative_source.py
@@ -6,7 +6,7 @@ import json
 import logging
 import os
 import sys
-from unittest.mock import patch, call
+from unittest.mock import call, patch
 
 import pytest
 import requests

--- a/airbyte-cdk/python/unit_tests/sources/declarative/test_manifest_declarative_source.py
+++ b/airbyte-cdk/python/unit_tests/sources/declarative/test_manifest_declarative_source.py
@@ -2,15 +2,29 @@
 # Copyright (c) 2023 Airbyte, Inc., all rights reserved.
 #
 
+import json
 import logging
 import os
 import sys
 from unittest.mock import patch
 
 import pytest
+import requests
 import yaml
+from airbyte_cdk.models import (
+    AirbyteLogMessage,
+    AirbyteMessage,
+    AirbyteStream,
+    ConfiguredAirbyteCatalog,
+    ConfiguredAirbyteStream,
+    DestinationSyncMode,
+    Level,
+    SyncMode,
+    Type,
+)
 from airbyte_cdk.sources.declarative.declarative_stream import DeclarativeStream
 from airbyte_cdk.sources.declarative.manifest_declarative_source import ManifestDeclarativeSource
+from airbyte_cdk.sources.streams.http import HttpStream
 from jsonschema.exceptions import ValidationError
 
 logger = logging.getLogger("airbyte")
@@ -727,3 +741,126 @@ class TestManifestDeclarativeSource:
         list(source.read(debug_logger, {}, {}, {}))
 
         assert debug_logger.isEnabledFor(logging.DEBUG)
+
+
+def request_log_message(request: dict) -> AirbyteMessage:
+    return AirbyteMessage(type=Type.LOG, log=AirbyteLogMessage(level=Level.INFO, message=f"request:{json.dumps(request)}"))
+
+
+def response_log_message(response: dict) -> AirbyteMessage:
+    return AirbyteMessage(type=Type.LOG, log=AirbyteLogMessage(level=Level.INFO, message=f"response:{json.dumps(response)}"))
+
+
+def _create_request():
+    url = "https://example.com/api"
+    headers = {'Content-Type': 'application/json'}
+    return requests.Request('POST', url, headers=headers, json={"key": "value"}).prepare()
+
+
+def _create_response(body):
+    response = requests.Response()
+    response.status_code = 200
+    response._content = bytes(json.dumps(body), "utf-8")
+    response.headers["Content-Type"] = "application/json"
+    return response
+
+
+def _create_page(response_body):
+    return _create_request(), _create_response(response_body)
+
+
+@patch.object(HttpStream, "_fetch_next_page", side_effect=(_create_page({"rates": [{"ABC": 0}, {"AED": 1}],"_metadata": {"next": "next"}}), _create_page({"result": [{"id": 2}],"_metadata": {"next": "next"}})) * 10)
+def test_read_manifest_declarative_source_no_pagination_no_incremental(mock_http_stream):
+    _stream_name = "Rates"
+    manifest = {
+        "version": "0.34.2",
+        "type": "DeclarativeSource",
+        "check": {
+            "type": "CheckStream",
+            "stream_names": [
+                "Rates"
+            ]
+        },
+        "streams": [
+            {
+                "type": "DeclarativeStream",
+                "name": "Rates",
+                "primary_key": [],
+                "schema_loader": {
+                    "type": "InlineSchemaLoader",
+                    "schema": {
+                        "$schema": "http://json-schema.org/schema#",
+                        "properties": {
+                            "ABC": {
+                                "type": "number"
+                            },
+                            "AED": {
+                                "type": "number"
+                            },
+                        },
+                        "type": "object"
+                    }
+                },
+                "retriever": {
+                    "type": "SimpleRetriever",
+                    "requester": {
+                        "type": "HttpRequester",
+                        "url_base": "https://api.apilayer.com",
+                        "path": "/exchangerates_data/latest",
+                        "http_method": "GET",
+                        "request_parameters": {},
+                        "request_headers": {},
+                        "request_body_json": {},
+                        "authenticator": {
+                            "type": "ApiKeyAuthenticator",
+                            "header": "apikey",
+                            "api_token": "{{ config['api_key'] }}"
+                        }
+                    },
+                    "record_selector": {
+                        "type": "RecordSelector",
+                        "extractor": {
+                            "type": "DpathExtractor",
+                            "field_path": [
+                                "rates"
+                            ]
+                        }
+                    },
+                    "paginator": {
+                        "type": "NoPagination"
+                    }
+                }
+            }
+        ],
+        "spec": {
+            "connection_specification": {
+                "$schema": "http://json-schema.org/draft-07/schema#",
+                "type": "object",
+                "required": [
+                    "api_key"
+                ],
+                "properties": {
+                    "api_key": {
+                        "type": "string",
+                        "title": "API Key",
+                        "airbyte_secret": True
+                    }
+                },
+                "additionalProperties": True
+            },
+            "documentation_url": "https://example.org",
+            "type": "Spec"
+        }
+    }
+    config = {"__injected_declarative_manifest": manifest}
+
+    catalog = ConfiguredAirbyteCatalog(streams=[
+        ConfiguredAirbyteStream(stream=AirbyteStream(name=_stream_name, json_schema={}, supported_sync_modes=[SyncMode.full_refresh]), sync_mode=SyncMode.full_refresh, destination_sync_mode=DestinationSyncMode.append)
+    ])
+
+    source = ManifestDeclarativeSource(source_config=config.get("__injected_declarative_manifest"))
+    output_data = list(source.read(logger, config, catalog, {}))
+
+    assert len(output_data) == 2
+    assert output_data[0].record.data == {"ABC": 0}
+    assert output_data[1].record.data == {"AED": 1}

--- a/airbyte-cdk/python/unit_tests/sources/declarative/test_manifest_declarative_source.py
+++ b/airbyte-cdk/python/unit_tests/sources/declarative/test_manifest_declarative_source.py
@@ -864,3 +864,108 @@ def test_read_manifest_declarative_source_no_pagination_no_incremental(mock_http
     assert len(output_data) == 2
     assert output_data[0].record.data == {"ABC": 0}
     assert output_data[1].record.data == {"AED": 1}
+
+
+@patch.object(HttpStream, "_fetch_next_page", side_effect=(_create_page({"rates": [{"ABC": 0}, {"AED": 1}],"_metadata": {"next": "next"}}), _create_page({"rates": [{"USD": 2}],"_metadata": {}})) * 10)
+def test_read_manifest_declarative_source_with_pagination_no_incremental(mock_http_stream):
+    _stream_name = "Rates"
+    manifest = {
+        "version": "0.34.2",
+        "type": "DeclarativeSource",
+        "check": {
+            "type": "CheckStream",
+            "stream_names": [
+                "Rates"
+            ]
+        },
+        "streams": [
+            {
+                "type": "DeclarativeStream",
+                "name": "Rates",
+                "primary_key": [],
+                "schema_loader": {
+                    "type": "InlineSchemaLoader",
+                    "schema": {
+                        "$schema": "http://json-schema.org/schema#",
+                        "properties": {
+                            "ABC": {
+                                "type": "number"
+                            },
+                            "AED": {
+                                "type": "number"
+                            },
+                            "USD": {
+                                "type": "number"
+                            },
+                        },
+                        "type": "object"
+                    }
+                },
+                "retriever": {
+                    "type": "SimpleRetriever",
+                    "requester": {
+                        "type": "HttpRequester",
+                        "url_base": "https://api.apilayer.com",
+                        "path": "/exchangerates_data/latest",
+                        "http_method": "GET",
+                        "request_parameters": {},
+                        "request_headers": {},
+                        "request_body_json": {},
+                        "authenticator": {
+                            "type": "ApiKeyAuthenticator",
+                            "header": "apikey",
+                            "api_token": "{{ config['api_key'] }}"
+                        }
+                    },
+                    "record_selector": {
+                        "type": "RecordSelector",
+                        "extractor": {
+                            "type": "DpathExtractor",
+                            "field_path": [
+                                "rates"
+                            ]
+                        }
+                    },
+                    "paginator": {
+                        "type": "DefaultPaginator",
+                        "page_size": 2,
+                        "page_size_option": {"inject_into": "request_parameter", "field_name": "page_size"},
+                        "page_token_option": {"inject_into": "path", "type": "RequestPath"},
+                        "pagination_strategy": {"type": "CursorPagination", "cursor_value": "{{ response._metadata.next }}", "page_size": 2},
+                    },
+                }
+            }
+        ],
+        "spec": {
+            "connection_specification": {
+                "$schema": "http://json-schema.org/draft-07/schema#",
+                "type": "object",
+                "required": [
+                    "api_key"
+                ],
+                "properties": {
+                    "api_key": {
+                        "type": "string",
+                        "title": "API Key",
+                        "airbyte_secret": True
+                    }
+                },
+                "additionalProperties": True
+            },
+            "documentation_url": "https://example.org",
+            "type": "Spec"
+        }
+    }
+    config = {"__injected_declarative_manifest": manifest}
+
+    catalog = ConfiguredAirbyteCatalog(streams=[
+        ConfiguredAirbyteStream(stream=AirbyteStream(name=_stream_name, json_schema={}, supported_sync_modes=[SyncMode.full_refresh]), sync_mode=SyncMode.full_refresh, destination_sync_mode=DestinationSyncMode.append)
+    ])
+
+    source = ManifestDeclarativeSource(source_config=config.get("__injected_declarative_manifest"))
+    output_data = list(source.read(logger, config, catalog, {}))
+
+    assert len(output_data) == 3
+    assert output_data[0].record.data == {"ABC": 0}
+    assert output_data[1].record.data == {"AED": 1}
+    assert output_data[2].record.data == {"USD": 2}


### PR DESCRIPTION
## What
1. Fix a typo I introduced in my [last PR](https://github.com/airbytehq/airbyte/pull/25180)
2. Add a few "integration tests" for manifest declarative source

## How
1. `super(self)` -> `super()`
2. test with and without pagination and partition router

## Recommended reading order
1. `airbyte-cdk/python/airbyte_cdk/sources/declarative/manifest_declarative_source.py`
3. `airbyte-cdk/python/unit_tests/sources/declarative/test_manifest_declarative_source.py`