### PR TITLE
Add compatibility guide to sidebar

### DIFF
--- a/docusaurus/sidebars.js
+++ b/docusaurus/sidebars.js
@@ -43,6 +43,7 @@ const buildAConnector = {
       label: 'Low-code connector development',
       items: [
         'connector-development/config-based/connector-builder-ui',
+        'connector-development/config-based/connector-builder-compatibility',
         {
           label: 'Low-code CDK Intro',
           type: 'doc',


### PR DESCRIPTION
## What
* Add the connector builder compatibility guide to the docs sidebar in the `Low-code connector development` section