### PR TITLE
Cleanup some logging in source db connectors

### DIFF
--- a/airbyte-integrations/connectors/source-jdbc/src/main/java/io/airbyte/integrations/source/jdbc/AbstractJdbcSource.java
+++ b/airbyte-integrations/connectors/source-jdbc/src/main/java/io/airbyte/integrations/source/jdbc/AbstractJdbcSource.java
@@ -179,7 +179,7 @@ public abstract class AbstractJdbcSource<Datatype> extends AbstractDbSource<Data
                 .map(f -> {
                   final Datatype datatype = sourceOperations.getDatabaseFieldType(f);
                   final JsonSchemaType jsonType = getAirbyteType(datatype);
-                  LOGGER.info("Table {} column {} (type {}[{}], nullable {}) -> {}",
+                  LOGGER.debug("Table {} column {} (type {}[{}], nullable {}) -> {}",
                       fields.get(0).get(INTERNAL_TABLE_NAME).asText(),
                       f.get(INTERNAL_COLUMN_NAME).asText(),
                       f.get(INTERNAL_COLUMN_TYPE_NAME).asText(),

--- a/airbyte-integrations/connectors/source-postgres/src/main/java/io/airbyte/integrations/source/postgres/PostgresSource.java
+++ b/airbyte-integrations/connectors/source-postgres/src/main/java/io/airbyte/integrations/source/postgres/PostgresSource.java
@@ -240,11 +240,11 @@ public class PostgresSource extends AbstractJdbcSource<PostgresType> implements 
       // process explicitly selected (from UI) schemas
       final List<TableInfo<CommonField<PostgresType>>> internals = new ArrayList<>();
       for (final String schema : schemas) {
-        LOGGER.info("Checking schema: {}", schema);
+        LOGGER.debug("Checking schema: {}", schema);
         final List<TableInfo<CommonField<PostgresType>>> tables = super.discoverInternal(database, schema);
         internals.addAll(tables);
         for (final TableInfo<CommonField<PostgresType>> table : tables) {
-          LOGGER.info("Found table: {}.{}", table.getNameSpace(), table.getName());
+          LOGGER.debug("Found table: {}.{}", table.getNameSpace(), table.getName());
         }
       }
       return internals;

--- a/airbyte-integrations/connectors/source-relational-db/src/main/java/io/airbyte/integrations/source/relationaldb/state/CursorManager.java
+++ b/airbyte-integrations/connectors/source-relational-db/src/main/java/io/airbyte/integrations/source/relationaldb/state/CursorManager.java
@@ -163,8 +163,11 @@ public class CursorManager<S> {
         if (stateOptional.map(cursorFieldFunction).equals(streamOptional.map(ConfiguredAirbyteStream::getCursorField))) {
           cursor = stateOptional.map(cursorFunction).orElse(null);
           cursorRecordCount = stateOptional.map(cursorRecordCountFunction).orElse(0L);
-          LOGGER.info("Found matching cursor in state. Stream: {}. Cursor Field: {} Value: {} Count: {}",
-              pair, cursorField, cursor, cursorRecordCount);
+          // If a matching cursor is found in the state, and it's value is null - this indicates a CDC stream and we shouldn't log anything.
+          if (cursor != null) {
+            LOGGER.info("Found matching cursor in state. Stream: {}. Cursor Field: {} Value: {} Count: {}",
+                pair, cursorField, cursor, cursorRecordCount);
+          }
           // if cursor field in catalog and state are different.
         } else {
           cursor = null;


### PR DESCRIPTION
Some logging fixes: 
- Stop logging all the tables/columns in the users schema. In general this should only be scoped to streams/columns users has configured
- Logging CursorInfo is fairly pointless if we're in CDC mode