### PR TITLE
Use proper release tag when copying files

### DIFF
--- a/run-ab-platform.sh
+++ b/run-ab-platform.sh
@@ -4,6 +4,8 @@
 set -o nounset # -u exit if a variable is not set
 set -o errexit # -f exit for any command failure
 
+# Get the version specified in the .env file
+version_tag="v$(cat .env | grep ^VERSION | cut -d '=' -f 2)"
 
 # text color escape codes (please note \033 == \e but OSX doesn't respect the \e)
 blue_text='\033[94m'
@@ -41,7 +43,7 @@ docker_compose_debug_yaml="docker-compose.debug.yaml"
                      flags="flags.yml"
 # any string is an array to POSIX shell. Space seperates values
 all_files="$docker_compose_yaml $docker_compose_debug_yaml $dot_env $dot_env_dev $flags"
-base_github_url="https://raw.githubusercontent.com/airbytehq/airbyte-platform/main/"
+base_github_url="https://raw.githubusercontent.com/airbytehq/airbyte-platform/$version_tag/"
 
 ############################################################
 # Download                                                 #


### PR DESCRIPTION
## What
The [run-ab-platform.sh](https://github.com/airbytehq/airbyte/blob/master/run-ab-platform.sh) script copies some files from `airbytehq/airbyte-platform` before running `docker compose up`. When copying those files, we were referencing the `main` branch when really we should be referencing the tag for the current release. This PR fixes the script to copy files from the current release.

## How
- Checks the version specified in `.env` of this repo
- Copies files from `airbytehq/airbyte` using the tag `v${version}` (e.g. `v0.44.0`)