### PR TITLE
Dagger: Return true on valid exit in Dagger Commands

### DIFF
--- a/tools/ci_connector_ops/ci_connector_ops/pipelines/commands/groups/metadata.py
+++ b/tools/ci_connector_ops/ci_connector_ops/pipelines/commands/groups/metadata.py
@@ -40,7 +40,7 @@ def validate(ctx: click.Context, modified_only: bool):
         metadata_to_validate = get_modified_metadata_files(modified_files)
         if not metadata_to_validate:
             click.secho("No modified metadata found. Skipping metadata validation.")
-            return
+            return True
     else:
         click.secho("Will run metadata validation on all the metadata files found in the repo.")
         metadata_to_validate = get_all_metadata_files()
@@ -73,12 +73,12 @@ def upload(ctx: click.Context, gcs_bucket_name: str, gcs_credentials: str, modif
     if modified_only:
         if ctx.obj["ci_context"] is not CIContext.MASTER and ctx.obj["git_branch"] != "master":
             click.secho("Not on the master branch. Skipping metadata upload.")
-            return
+            return True
         modified_files = ctx.obj["modified_files_in_commit"]
         metadata_to_upload = get_modified_metadata_files(modified_files)
         if not metadata_to_upload:
             click.secho("No modified metadata found. Skipping metadata upload.")
-            return
+            return True
     else:
         metadata_to_upload = get_all_metadata_files()
 

--- a/tools/ci_connector_ops/ci_connector_ops/pipelines/commands/groups/metadata.py
+++ b/tools/ci_connector_ops/ci_connector_ops/pipelines/commands/groups/metadata.py
@@ -34,7 +34,7 @@ def metadata(ctx: click.Context):
 @metadata.command(cls=DaggerPipelineCommand, help="Commands related to validating the metadata files.")
 @click.option("--modified-only/--all", default=True)
 @click.pass_context
-def validate(ctx: click.Context, modified_only: bool):
+def validate(ctx: click.Context, modified_only: bool) -> bool:
     if modified_only:
         modified_files = ctx.obj["modified_files_in_branch"]
         metadata_to_validate = get_modified_metadata_files(modified_files)
@@ -69,7 +69,7 @@ def validate(ctx: click.Context, modified_only: bool):
 )
 @click.option("--modified-only/--all", default=True)
 @click.pass_context
-def upload(ctx: click.Context, gcs_bucket_name: str, gcs_credentials: str, modified_only: bool):
+def upload(ctx: click.Context, gcs_bucket_name: str, gcs_credentials: str, modified_only: bool) -> bool:
     if modified_only:
         if ctx.obj["ci_context"] is not CIContext.MASTER and ctx.obj["git_branch"] != "master":
             click.secho("Not on the master branch. Skipping metadata upload.")
@@ -109,7 +109,7 @@ def deploy(ctx: click.Context):
 
 @deploy.command(cls=DaggerPipelineCommand, name="orchestrator", help="Deploy the metadata service orchestrator to production")
 @click.pass_context
-def deploy_orchestrator(ctx: click.Context):
+def deploy_orchestrator(ctx: click.Context) -> bool:
     return anyio.run(
         run_metadata_orchestrator_deploy_pipeline,
         ctx.obj["is_local"],
@@ -132,7 +132,7 @@ def test(ctx: click.Context):
 
 @test.command(cls=DaggerPipelineCommand, name="lib", help="Run tests for the metadata service library.")
 @click.pass_context
-def test_lib(ctx: click.Context):
+def test_lib(ctx: click.Context) -> bool:
     return anyio.run(
         run_metadata_lib_test_pipeline,
         ctx.obj["is_local"],
@@ -146,7 +146,7 @@ def test_lib(ctx: click.Context):
 
 @test.command(cls=DaggerPipelineCommand, name="orchestrator", help="Run tests for the metadata service orchestrator.")
 @click.pass_context
-def test_orchestrator(ctx: click.Context):
+def test_orchestrator(ctx: click.Context) -> bool:
     return anyio.run(
         run_metadata_orchestrator_test_pipeline,
         ctx.obj["is_local"],

--- a/tools/ci_connector_ops/ci_connector_ops/pipelines/utils.py
+++ b/tools/ci_connector_ops/ci_connector_ops/pipelines/utils.py
@@ -291,11 +291,11 @@ class DaggerPipelineCommand(click.Command):
             Any: The invocation return value.
         """
         command_name = self.name
-        click.secho(f"Running {command_name}...")
+        click.secho(f"Running Dagger Command {command_name}...")
         try:
             pipeline_success = super().invoke(ctx)
             if not pipeline_success:
-                raise DaggerError(f"{command_name} failed.")
+                raise DaggerError(f"Dagger Command {command_name} failed.")
         except DaggerError as e:
             click.secho(str(e), err=True, fg="red")
             return sys.exit(1)


### PR DESCRIPTION
## What
Airbyte-ci commands were failing on skip because we were not returning a boolean value denoting pass or fail

## How
This updates our commands to return True when skipped. It also improved the start/failed error messaging

closes #25326 