### PR TITLE
Add version info to publish comment

### DIFF
--- a/.github/workflows/publish-command.yml
+++ b/.github/workflows/publish-command.yml
@@ -203,13 +203,13 @@ jobs:
           body: |
             <br>
 
-            | Connector | Did it publish? | Were definitions generated? |
+            | Connector | Version | Did it publish? | Were definitions generated? |
       - name: Create table separator
         uses: peter-evans/create-or-update-comment@v1
         with:
           comment-id: ${{ github.event.inputs.comment-id }}
           body: |
-            | --- | --- | --- |
+            | --- | --- | --- | --- |
   publish-image:
     timeout-minutes: 240
     needs:
@@ -394,7 +394,7 @@ jobs:
         with:
           comment-id: ${{ github.event.inputs.comment-id }}
           body: |
-            | ${{ matrix.connector }} | ${{ env.PUBLISH_OUTCOME }} | ${{ env.AUTO_BUMP_OUTCOME }} |
+            | ${{ matrix.connector }} | ${{ env.IMAGE_VERSION }} | ${{ env.PUBLISH_OUTCOME }} | ${{ env.AUTO_BUMP_OUTCOME }} |
   add-helpful-info-to-git-comment:
     if: ${{ always() && github.event.inputs.comment-id }}
     name: Add extra info to git comment


### PR DESCRIPTION
## What

It was bugging me that you had to go to docker hub to see what version tag actually got published, specially in the case of pre-releases. This PR adds the info to the table in the PR comment.
