### PR TITLE
Use git to get latest tag

### DIFF
--- a/run-ab-platform.sh
+++ b/run-ab-platform.sh
@@ -4,8 +4,8 @@
 set -o nounset # -u exit if a variable is not set
 set -o errexit # -f exit for any command failure
 
-# Get the version specified in the .env file
-version_tag="v$(cat .env | grep ^VERSION | cut -d '=' -f 2)"
+# Get the latest release tag
+version_tag="$(git describe --abbrev=0 --tags)"
 
 # text color escape codes (please note \033 == \e but OSX doesn't respect the \e)
 blue_text='\033[94m'


### PR DESCRIPTION
## What
I recently merged a change to `./run-ab-platform.sh` that targets the correct version when downloading assets: https://github.com/airbytehq/airbyte/pull/25311

My approach was to use `.env` as a source of truth. It turns out that during our GHA to publish a new OSS version, `.env` gets deleted right before we try to download those assets 🙃 . See related failure here: https://github.com/airbytehq/airbyte-platform-internal/actions/runs/4752327395/jobs/8443714748

This PR changes how we get the latest tag. Instead of looking in `.env` for a `VERSION`, it checks the latest tag with `git`.
