### PR TITLE
Add script for latest-release branch

### DIFF
--- a/tools/bin/bump_latest_branch.sh
+++ b/tools/bin/bump_latest_branch.sh
@@ -1,0 +1,27 @@
+#!/bin/bash
+
+echo "Bumping version in latest release branch"
+
+MAIN_BRANCH="master"
+LATEST_RELEASE_BRANCH_NAME="latest-release"
+
+function cleanup {
+    git switch $MAIN_BRANCH
+}
+trap cleanup EXIT
+
+# Fetch tags, as we probably have only a shallow clone of the repo
+git fetch origin "refs/tags/*:refs/tags/*"
+
+LATEST_TAG=$(git describe --tags --abbrev=0)
+echo "Most recent tag found: $LATEST_TAG"
+
+# In case the branch exists locally, delete it silently, since we will be recreating it and force-pushing
+git branch -D $LATEST_RELEASE_BRANCH_NAME &>/dev/null   
+
+git checkout tags/$LATEST_TAG -b $LATEST_RELEASE_BRANCH_NAME
+
+git push -f origin $LATEST_RELEASE_BRANCH_NAME
+
+# Switch back to master
+cleanup

--- a/tools/bin/bump_latest_branch.sh
+++ b/tools/bin/bump_latest_branch.sh
@@ -3,7 +3,7 @@
 echo "Bumping version in latest release branch"
 
 MAIN_BRANCH="master"
-LATEST_RELEASE_BRANCH_NAME="latest-release"
+LATEST_RELEASE_BRANCH="latest-release"
 
 function cleanup {
     git switch $MAIN_BRANCH
@@ -17,11 +17,11 @@ LATEST_TAG=$(git describe --tags --abbrev=0)
 echo "Most recent tag found: $LATEST_TAG"
 
 # In case the branch exists locally, delete it silently, since we will be recreating it and force-pushing
-git branch -D $LATEST_RELEASE_BRANCH_NAME &>/dev/null   
+git branch -D $LATEST_RELEASE_BRANCH &>/dev/null   
 
-git checkout tags/$LATEST_TAG -b $LATEST_RELEASE_BRANCH_NAME
+git checkout tags/$LATEST_TAG -b $LATEST_RELEASE_BRANCH
 
-git push -f origin $LATEST_RELEASE_BRANCH_NAME
+git push -f origin $LATEST_RELEASE_BRANCH
 
 # Switch back to master
 cleanup


### PR DESCRIPTION
## What
This PR adds a script that can be run to synchronize a `latest-release` branch with the latest release tag in this repo. This could be useful for people who want to get the latest `docker-compose.yaml` to spin up airbyte without cloning the repo and running `./run-ab-platform.sh`

This script would be run during the OSS release workflow over in `airbytehq/airbyte-platform-internal`, example PR here: https://github.com/airbytehq/airbyte-platform-internal/pull/6036
