### PR TITLE
Put warning regarding connectors compatibility with older version of …

### DIFF
--- a/docs/integrations/sources/facebook-pages.md
+++ b/docs/integrations/sources/facebook-pages.md
@@ -6,6 +6,9 @@ This page contains the setup guide and reference information for the Facebook Pa
 
 To set up the Facebook Pages source connector with Airbyte, you'll need to create your Facebook Application and use both long-lived Page access token and Facebook Page ID.
 
+:::note
+The Facebook Pages souce connector is currently only compatible with v15 of the Facebook Graph API.
+:::
 
 ## Setup guide
 ### Step 1: Set up Facebook Pages


### PR DESCRIPTION
Places warning that the FB Pages Source Connector is not compatible with the newest version of the Facebook Graph API