### PR TITLE
low-code: Alias stream_interval and stream_partition to stream_slice in interpolation context

### DIFF
--- a/airbyte-cdk/python/airbyte_cdk/sources/declarative/interpolation/jinja.py
+++ b/airbyte-cdk/python/airbyte_cdk/sources/declarative/interpolation/jinja.py
@@ -31,6 +31,9 @@ class JinjaInterpolation(Interpolation):
     Additional information on jinja templating can be found at https://jinja.palletsprojects.com/en/3.1.x/templates/#
     """
 
+    ALIASES = {"stream_interval": "stream_slice",
+               "stream_partition": "stream_slice"}
+
     def __init__(self):
         self._environment = Environment()
         self._environment.filters.update(**filters)
@@ -38,6 +41,15 @@ class JinjaInterpolation(Interpolation):
 
     def eval(self, input_str: str, config: Config, default: Optional[str] = None, **additional_parameters):
         context = {"config": config, **additional_parameters}
+
+        for alias, equivalent in self.ALIASES.items():
+            if "stream_slice" in context:
+                if alias in context:
+                    pass
+                    #raise RuntimeError("")
+                else:
+                    context[alias] = context[equivalent]
+
         try:
             if isinstance(input_str, str):
                 result = self._eval(input_str, context)

--- a/airbyte-cdk/python/airbyte_cdk/sources/declarative/interpolation/jinja.py
+++ b/airbyte-cdk/python/airbyte_cdk/sources/declarative/interpolation/jinja.py
@@ -43,12 +43,10 @@ class JinjaInterpolation(Interpolation):
         context = {"config": config, **additional_parameters}
 
         for alias, equivalent in self.ALIASES.items():
-            if "stream_slice" in context:
-                if alias in context:
-                    pass
-                    #raise RuntimeError("")
-                else:
-                    context[alias] = context[equivalent]
+            if alias in context:
+                raise ValueError(f"Found reserved keyword {alias} in interpolation context. This is unexpected and indicative of a bug in the CDK.")
+            elif equivalent in context:
+                context[alias] = context[equivalent]
 
         try:
             if isinstance(input_str, str):

--- a/airbyte-cdk/python/airbyte_cdk/sources/declarative/interpolation/jinja.py
+++ b/airbyte-cdk/python/airbyte_cdk/sources/declarative/interpolation/jinja.py
@@ -31,8 +31,7 @@ class JinjaInterpolation(Interpolation):
     Additional information on jinja templating can be found at https://jinja.palletsprojects.com/en/3.1.x/templates/#
     """
 
-    ALIASES = {"stream_interval": "stream_slice",
-               "stream_partition": "stream_slice"}
+    ALIASES = {"stream_interval": "stream_slice", "stream_partition": "stream_slice"}
 
     def __init__(self):
         self._environment = Environment()
@@ -44,7 +43,9 @@ class JinjaInterpolation(Interpolation):
 
         for alias, equivalent in self.ALIASES.items():
             if alias in context:
-                raise ValueError(f"Found reserved keyword {alias} in interpolation context. This is unexpected and indicative of a bug in the CDK.")
+                raise ValueError(
+                    f"Found reserved keyword {alias} in interpolation context. This is unexpected and indicative of a bug in the CDK."
+                )
             elif equivalent in context:
                 context[alias] = context[equivalent]
 

--- a/airbyte-cdk/python/airbyte_cdk/sources/declarative/interpolation/jinja.py
+++ b/airbyte-cdk/python/airbyte_cdk/sources/declarative/interpolation/jinja.py
@@ -31,7 +31,11 @@ class JinjaInterpolation(Interpolation):
     Additional information on jinja templating can be found at https://jinja.palletsprojects.com/en/3.1.x/templates/#
     """
 
-    ALIASES = {"stream_interval": "stream_slice", "stream_partition": "stream_slice"}
+    # These aliases are used to deprecate existing keywords without breaking all existing connectors.
+    ALIASES = {
+        "stream_interval": "stream_slice", # Use stream_interval to access incremental_sync values
+        "stream_partition": "stream_slice" # Use stream_partition to access partition router's values
+    }
 
     def __init__(self):
         self._environment = Environment()
@@ -43,6 +47,7 @@ class JinjaInterpolation(Interpolation):
 
         for alias, equivalent in self.ALIASES.items():
             if alias in context:
+                # This is unexpected. We could ignore or log a warning, but failing loudly should result in fewer surprises
                 raise ValueError(
                     f"Found reserved keyword {alias} in interpolation context. This is unexpected and indicative of a bug in the CDK."
                 )

--- a/airbyte-cdk/python/airbyte_cdk/sources/declarative/interpolation/jinja.py
+++ b/airbyte-cdk/python/airbyte_cdk/sources/declarative/interpolation/jinja.py
@@ -33,8 +33,8 @@ class JinjaInterpolation(Interpolation):
 
     # These aliases are used to deprecate existing keywords without breaking all existing connectors.
     ALIASES = {
-        "stream_interval": "stream_slice", # Use stream_interval to access incremental_sync values
-        "stream_partition": "stream_slice" # Use stream_partition to access partition router's values
+        "stream_interval": "stream_slice",  # Use stream_interval to access incremental_sync values
+        "stream_partition": "stream_slice",  # Use stream_partition to access partition router's values
     }
 
     def __init__(self):

--- a/airbyte-cdk/python/unit_tests/sources/declarative/interpolation/test_jinja.py
+++ b/airbyte-cdk/python/unit_tests/sources/declarative/interpolation/test_jinja.py
@@ -46,6 +46,7 @@ def test_literals(test_name, s, value):
     val = interpolation.eval(s, None)
     assert val == value
 
+
 @pytest.mark.parametrize(
     "test_name, context, input_string, expected_value",
     [
@@ -73,6 +74,19 @@ def test_stream_slice_alias(test_name, context, input_string, expected_value):
     config = {}
     val = interpolation.eval(input_string, config, **context)
     assert val == expected_value
+
+
+@pytest.mark.parametrize(
+    "test_name, alias", [
+        ("test_error_is_raised_if_stream_interval_in_context", "stream_interval"),
+        ("test_error_is_raised_if_stream_partition_in_context", "stream_partition"),
+    ]
+)
+def test_error_is_raised_if_alias_is_already_in_context(test_name, alias):
+    config = {}
+    context = {alias: "a_value"}
+    with pytest.raises(ValueError):
+        interpolation.eval("a_key", config, **context)
 
 
 def test_positive_day_delta():

--- a/airbyte-cdk/python/unit_tests/sources/declarative/interpolation/test_jinja.py
+++ b/airbyte-cdk/python/unit_tests/sources/declarative/interpolation/test_jinja.py
@@ -34,15 +34,16 @@ def test_get_value_from_a_list_of_mappings():
 
 
 @pytest.mark.parametrize(
-    "test_name, s, value",
+    "s, value",
     [
-        ("test_number", "{{1}}", 1),
-        ("test_list", "{{[1,2]}}", [1, 2]),
-        ("test_dict", "{{ {1:2} }}", {1: 2}),
-        ("test_addition", "{{ 1+2 }}", 3),
+        pytest.param("{{1}}", 1, id="test_number"),
+        pytest.param("{{1}}", 1, id="test_number"),
+        pytest.param("{{[1,2]}}", [1, 2], id="test_list"),
+        pytest.param("{{ {1:2} }}", {1: 2}, id="test_dict"),
+        pytest.param("{{ 1+2 }}", 3, id="test_addition"),
     ],
 )
-def test_literals(test_name, s, value):
+def test_literals(s, value):
     val = interpolation.eval(s, None)
     assert val == value
 
@@ -88,12 +89,12 @@ def test_stream_slice_alias(context, input_string, expected_value):
 
 
 @pytest.mark.parametrize(
-    "test_name, alias", [
-        ("test_error_is_raised_if_stream_interval_in_context", "stream_interval"),
-        ("test_error_is_raised_if_stream_partition_in_context", "stream_partition"),
+    "alias", [
+        pytest.param("stream_interval", id="test_error_is_raised_if_stream_interval_in_context"),
+        pytest.param("stream_partition", id="test_error_is_raised_if_stream_partition_in_context"),
     ]
 )
-def test_error_is_raised_if_alias_is_already_in_context(test_name, alias):
+def test_error_is_raised_if_alias_is_already_in_context(alias):
     config = {}
     context = {alias: "a_value"}
     with pytest.raises(ValueError):

--- a/airbyte-cdk/python/unit_tests/sources/declarative/interpolation/test_jinja.py
+++ b/airbyte-cdk/python/unit_tests/sources/declarative/interpolation/test_jinja.py
@@ -46,6 +46,34 @@ def test_literals(test_name, s, value):
     val = interpolation.eval(s, None)
     assert val == value
 
+@pytest.mark.parametrize(
+    "test_name, context, input_string, expected_value",
+    [
+        ("test_get_value_from_stream_slice",
+         {"stream_slice": {"stream_slice_key": "hello"}},
+         "{{ stream_slice['stream_slice_key'] }}", "hello"),
+        ("test_get_value_from_stream_slice_no_stream_slice",
+         {},
+         "{{ stream_slice['stream_slice_key'] }}", None),
+        ("test_get_value_from_stream_partition",
+         {"stream_slice": {"stream_slice_key": "hello"}},
+         "{{ stream_partition['stream_slice_key'] }}", "hello"),
+        ("test_get_value_from_stream_partition_no_stream_slice",
+         {},
+         "{{ stream_partition['stream_slice_key'] }}", None),
+        ("test_get_value_from_stream_partition",
+         {"stream_slice": {"stream_slice_key": "hello"}},
+         "{{ stream_interval['stream_slice_key'] }}", "hello"),
+        ("test_get_value_from_stream_interval_no_stream_slice",
+         {},
+         "{{ stream_interval['stream_slice_key'] }}", None),
+    ],
+)
+def test_stream_slice_alias(test_name, context, input_string, expected_value):
+    config = {}
+    val = interpolation.eval(input_string, config, **context)
+    assert val == expected_value
+
 
 def test_positive_day_delta():
     delta_template = "{{ day_delta(25) }}"

--- a/airbyte-cdk/python/unit_tests/sources/declarative/interpolation/test_jinja.py
+++ b/airbyte-cdk/python/unit_tests/sources/declarative/interpolation/test_jinja.py
@@ -119,15 +119,15 @@ def test_negative_day_delta():
 
 
 @pytest.mark.parametrize(
-    "test_name, s, expected_value",
+    "s, expected_value",
     [
-        ("test_timestamp_from_timestamp", "{{ timestamp(1621439283) }}", 1621439283),
-        ("test_timestamp_from_string", "{{ timestamp('2021-05-19') }}", 1621382400),
-        ("test_timestamp_from_rfc3339", "{{ timestamp('2017-01-01T00:00:00.0Z') }}", 1483228800),
-        ("test_max", "{{ max(1,2) }}", 2),
+        pytest.param("{{ timestamp(1621439283) }}", 1621439283, id="test_timestamp_from_timestamp"),
+        pytest.param("{{ timestamp('2021-05-19') }}", 1621382400, id="test_timestamp_from_string"),
+        pytest.param("{{ timestamp('2017-01-01T00:00:00.0Z') }}", 1483228800, id="test_timestamp_from_rfc3339"),
+        pytest.param("{{ max(1,2) }}", 2, id="test_max"),
     ],
 )
-def test_macros(test_name, s, expected_value):
+def test_macros(s, expected_value):
     interpolation = JinjaInterpolation()
     config = {}
     val = interpolation.eval(s, config)

--- a/airbyte-cdk/python/unit_tests/sources/declarative/interpolation/test_jinja.py
+++ b/airbyte-cdk/python/unit_tests/sources/declarative/interpolation/test_jinja.py
@@ -48,29 +48,40 @@ def test_literals(test_name, s, value):
 
 
 @pytest.mark.parametrize(
-    "test_name, context, input_string, expected_value",
+    "context, input_string, expected_value",
     [
-        ("test_get_value_from_stream_slice",
-         {"stream_slice": {"stream_slice_key": "hello"}},
-         "{{ stream_slice['stream_slice_key'] }}", "hello"),
-        ("test_get_value_from_stream_slice_no_stream_slice",
-         {},
-         "{{ stream_slice['stream_slice_key'] }}", None),
-        ("test_get_value_from_stream_partition",
-         {"stream_slice": {"stream_slice_key": "hello"}},
-         "{{ stream_partition['stream_slice_key'] }}", "hello"),
-        ("test_get_value_from_stream_partition_no_stream_slice",
-         {},
-         "{{ stream_partition['stream_slice_key'] }}", None),
-        ("test_get_value_from_stream_partition",
-         {"stream_slice": {"stream_slice_key": "hello"}},
-         "{{ stream_interval['stream_slice_key'] }}", "hello"),
-        ("test_get_value_from_stream_interval_no_stream_slice",
-         {},
-         "{{ stream_interval['stream_slice_key'] }}", None),
+        pytest.param(
+            {"stream_slice": {"stream_slice_key": "hello"}},
+            "{{ stream_slice['stream_slice_key'] }}",
+            "hello",
+            id="test_get_value_from_stream_slice"),
+        pytest.param(
+            {},
+            "{{ stream_slice['stream_slice_key'] }}",
+            None,
+            id="test_get_value_from_stream_slice_no_slice"
+        ),
+        pytest.param(
+            {"stream_slice": {"stream_slice_key": "hello"}},
+            "{{ stream_partition['stream_slice_key'] }}",
+            "hello",
+            id="test_get_value_from_stream_slicer"
+        ),
+        pytest.param(
+            {},
+            "{{ stream_partition['stream_slice_key'] }}",
+            None,
+            id="test_get_value_from_stream_partition_no_stream_slice"
+        ),
+        pytest.param(
+            {"stream_slice": {"stream_slice_key": "hello"}},
+            "{{ stream_interval['stream_slice_key'] }}",
+            "hello",
+            id="test_get_value_from_stream_interval"
+        )
     ],
 )
-def test_stream_slice_alias(test_name, context, input_string, expected_value):
+def test_stream_slice_alias(context, input_string, expected_value):
     config = {}
     val = interpolation.eval(input_string, config, **context)
     assert val == expected_value

--- a/airbyte-integrations/connectors/source-greenhouse/source_greenhouse/manifest.yaml
+++ b/airbyte-integrations/connectors/source-greenhouse/source_greenhouse/manifest.yaml
@@ -111,7 +111,7 @@ definitions:
       $ref: "#/definitions/retriever"
       requester:
         $ref: "#/definitions/requester"
-        path: "jobs/{{ stream_partition.parent_id }}/openings"
+        path: "jobs/{{ stream_slice.parent_id }}/openings"
       partition_router:
         type: SubstreamPartitionRouter
         parent_stream_configs:
@@ -126,7 +126,7 @@ definitions:
       $ref: "#/definitions/retriever"
       requester:
         $ref: "#/definitions/requester"
-        path: "applications/{{ stream_partition.parent_id }}/demographics/answers"
+        path: "applications/{{ stream_slice.parent_id }}/demographics/answers"
     incremental_sync:
       type: CustomIncrementalSync
       class_name: source_greenhouse.components.GreenHouseSubstreamSlicer
@@ -143,7 +143,7 @@ definitions:
       $ref: "#/definitions/retriever"
       requester:
         $ref: "#/definitions/requester"
-        path: "applications/{{ stream_partition.parent_id }}/scheduled_interviews"
+        path: "applications/{{ stream_slice.parent_id }}/scheduled_interviews"
     incremental_sync:
       type: CustomIncrementalSync
       class_name: source_greenhouse.components.GreenHouseSubstreamSlicer
@@ -172,7 +172,7 @@ definitions:
         $ref: "#/definitions/retriever"
         requester:
           $ref: "#/definitions/requester"
-          path: "demographics/questions/{{ stream_partition.parent_id }}/answer_options"
+          path: "demographics/questions/{{ stream_slice.parent_id }}/answer_options"
         partition_router:
           type: SubstreamPartitionRouter
           parent_stream_configs:
@@ -194,7 +194,7 @@ definitions:
         $ref: "#/definitions/retriever"
         requester:
           $ref: "#/definitions/requester"
-          path: "demographics/question_sets/{{ stream_partition.parent_id }}/questions"
+          path: "demographics/question_sets/{{ stream_slice.parent_id }}/questions"
         partition_router:
           type: SubstreamPartitionRouter
           parent_stream_configs:
@@ -220,12 +220,12 @@ definitions:
     $ref: "#/definitions/base_stream"
     $parameters:
       name: "jobs_stages"
-      path: "jobs/{{ stream_partition.parent_id }}/stages"
+      path: "jobs/{{ stream_slice.parent_id }}/stages"
     retriever:
       $ref: "#/definitions/retriever"
       requester:
         $ref: "#/definitions/requester"
-        path: "jobs/{{ stream_partition.parent_id }}/stages"
+        path: "jobs/{{ stream_slice.parent_id }}/stages"
     incremental_sync:
       type: CustomIncrementalSync
       class_name: source_greenhouse.components.GreenHouseSubstreamSlicer

--- a/airbyte-integrations/connectors/source-greenhouse/source_greenhouse/manifest.yaml
+++ b/airbyte-integrations/connectors/source-greenhouse/source_greenhouse/manifest.yaml
@@ -111,7 +111,7 @@ definitions:
       $ref: "#/definitions/retriever"
       requester:
         $ref: "#/definitions/requester"
-        path: "jobs/{{ stream_slice.parent_id }}/openings"
+        path: "jobs/{{ stream_partition.parent_id }}/openings"
       partition_router:
         type: SubstreamPartitionRouter
         parent_stream_configs:
@@ -126,7 +126,7 @@ definitions:
       $ref: "#/definitions/retriever"
       requester:
         $ref: "#/definitions/requester"
-        path: "applications/{{ stream_slice.parent_id }}/demographics/answers"
+        path: "applications/{{ stream_partition.parent_id }}/demographics/answers"
     incremental_sync:
       type: CustomIncrementalSync
       class_name: source_greenhouse.components.GreenHouseSubstreamSlicer
@@ -143,7 +143,7 @@ definitions:
       $ref: "#/definitions/retriever"
       requester:
         $ref: "#/definitions/requester"
-        path: "applications/{{ stream_slice.parent_id }}/scheduled_interviews"
+        path: "applications/{{ stream_partition.parent_id }}/scheduled_interviews"
     incremental_sync:
       type: CustomIncrementalSync
       class_name: source_greenhouse.components.GreenHouseSubstreamSlicer
@@ -172,7 +172,7 @@ definitions:
         $ref: "#/definitions/retriever"
         requester:
           $ref: "#/definitions/requester"
-          path: "demographics/questions/{{ stream_slice.parent_id }}/answer_options"
+          path: "demographics/questions/{{ stream_partition.parent_id }}/answer_options"
         partition_router:
           type: SubstreamPartitionRouter
           parent_stream_configs:
@@ -194,7 +194,7 @@ definitions:
         $ref: "#/definitions/retriever"
         requester:
           $ref: "#/definitions/requester"
-          path: "demographics/question_sets/{{ stream_slice.parent_id }}/questions"
+          path: "demographics/question_sets/{{ stream_partition.parent_id }}/questions"
         partition_router:
           type: SubstreamPartitionRouter
           parent_stream_configs:
@@ -220,12 +220,12 @@ definitions:
     $ref: "#/definitions/base_stream"
     $parameters:
       name: "jobs_stages"
-      path: "jobs/{{ stream_slice.parent_id }}/stages"
+      path: "jobs/{{ stream_partition.parent_id }}/stages"
     retriever:
       $ref: "#/definitions/retriever"
       requester:
         $ref: "#/definitions/requester"
-        path: "jobs/{{ stream_slice.parent_id }}/stages"
+        path: "jobs/{{ stream_partition.parent_id }}/stages"
     incremental_sync:
       type: CustomIncrementalSync
       class_name: source_greenhouse.components.GreenHouseSubstreamSlicer


### PR DESCRIPTION
## What
* This PR handles a subset of https://github.com/airbytehq/airbyte/issues/24723.

Allow connector developer to refer to the stream slice using two new keywords:
- stream_interval
- stream_partition

The end-goal is for `stream_interval` to be used to refer to incremental_sync's values and `stream_partition` to refer to partition router's values. This will enable us to stop referring to `stream_slice` from the connector builder.

This is a fairly heavy lift today because
1. These concepts do not exist in all layers of the CDK. It's all just stream slices from the SimpleRetriever's point of view.
2. Removing the stream_slice keyword would be an expensive breaking change.
Since we don't have the appetite to completely replace the `stream_slice` keyword, we instead copy the value to `stream_partition` and `stream_interval`. 

Not included in this PR:
- Updating the reference docs. Will be done as part of https://github.com/airbytehq/airbyte/pull/25117 (https://github.com/airbytehq/airbyte/pull/25117/commits/0e5f5b51aabd5ba2c1f8b73a2112dcf3800f73b3)

## How
* If stream_slice is the Jinja context, copy it's value to the `stream_interval` and `stream_partition` keys
* If `stream_interval` or `stream_partition` are already in the context, raise an exception because that is unexpected

## Recommended reading order
1. `airbyte-cdk/python/airbyte_cdk/sources/declarative/interpolation/jinja.py`
4. `airbyte-cdk/python/unit_tests/sources/declarative/interpolation/test_jinja.py`