### PR TITLE
connectors-ci: refactor to use `run_steps`

### DIFF
--- a/tools/ci_connector_ops/ci_connector_ops/pipelines/actions/__init__.py
+++ b/tools/ci_connector_ops/ci_connector_ops/pipelines/actions/__init__.py
@@ -2,3 +2,60 @@
 # Copyright (c) 2023 Airbyte, Inc., all rights reserved.
 #
 """The actions package is made to declare reusable pipeline components."""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING, List, Tuple, Union
+
+import asyncer
+from ci_connector_ops.pipelines.bases import Step, StepStatus
+
+if TYPE_CHECKING:
+    from ci_connector_ops.pipelines.bases import StepResult
+
+
+async def run_steps(
+    steps_and_run_args: List[Union[Step, Tuple[Step, Tuple]] | List[Union[Step, Tuple[Step, Tuple]]]], results: List[StepResult] = []
+) -> List[StepResult]:
+    """Run multiple steps sequentially, or in parallel if steps are wrapped into a sublist.
+
+    Args:
+        steps_and_run_args (List[Union[Step, Tuple[Step, Tuple]] | List[Union[Step, Tuple[Step, Tuple]]]]): List of steps to run, if steps are wrapped in a sublist they will be executed in parallel. run function arguments can be passed as a tuple along the Step instance.
+        results (List[StepResult], optional): List of step results, used for recursion.
+
+    Returns:
+        List[StepResult]: List of step results.
+    """
+    # If there are no steps to run, return the results
+    if not steps_and_run_args:
+        return results
+
+    # If any of the previous steps failed, skip the remaining steps
+    if any(result.status is StepStatus.FAILURE for result in results):
+        skipped_results = []
+        for step_and_run_args in steps_and_run_args:
+            if isinstance(steps_and_run_args, Tuple):
+                skipped_results.append(step_and_run_args[0].skip())
+            else:
+                skipped_results.append(step_and_run_args.skip())
+        return results + skipped_results
+
+    # Pop the next step to run
+    steps_to_run, remaining_steps = steps_and_run_args[0], steps_and_run_args[1:]
+
+    # wrap the step in a list if it is not already (allows for parallel steps)
+    if not isinstance(steps_to_run, list):
+        steps_to_run = [steps_to_run]
+
+    async with asyncer.create_task_group() as task_group:
+        tasks = []
+        for step in steps_to_run:
+            if isinstance(step, Step):
+                tasks.append(task_group.soonify(step.run)())
+            elif isinstance(step, Tuple) and isinstance(step[0], Step) and isinstance(step[1], Tuple):
+                step, run_args = step
+                tasks.append(task_group.soonify(step.run)(*run_args))
+
+    new_results = [task.value for task in tasks]
+
+    return await run_steps(remaining_steps, results + new_results)

--- a/tools/ci_connector_ops/ci_connector_ops/pipelines/bases.py
+++ b/tools/ci_connector_ops/ci_connector_ops/pipelines/bases.py
@@ -11,7 +11,7 @@ from abc import ABC, abstractmethod
 from dataclasses import dataclass, field
 from datetime import datetime
 from enum import Enum
-from typing import TYPE_CHECKING, ClassVar, List, Optional, Tuple
+from typing import TYPE_CHECKING, Any, ClassVar, List, Optional, Tuple
 
 import asyncer
 from ci_connector_ops.pipelines.actions import environments
@@ -126,7 +126,13 @@ class Step(ABC):
             soon_exit_code = task_group.soonify(with_exit_code)(container)
             soon_stderr = task_group.soonify(with_stderr)(container)
             soon_stdout = task_group.soonify(with_stdout)(container)
-        return StepResult(self, StepStatus.from_exit_code(soon_exit_code.value), stderr=soon_stderr.value, stdout=soon_stdout.value)
+        return StepResult(
+            self,
+            StepStatus.from_exit_code(soon_exit_code.value),
+            stderr=soon_stderr.value,
+            stdout=soon_stdout.value,
+            output_artifact=container,
+        )
 
 
 class PytestStep(Step, ABC):
@@ -194,6 +200,7 @@ class StepResult:
     created_at: datetime = field(default_factory=datetime.utcnow)
     stderr: Optional[str] = None
     stdout: Optional[str] = None
+    output_artifact: Any = None
 
     def __repr__(self) -> str:  # noqa D105
         return f"{self.step.title}: {self.status.value}"

--- a/tools/ci_connector_ops/ci_connector_ops/pipelines/builds/__init__.py
+++ b/tools/ci_connector_ops/ci_connector_ops/pipelines/builds/__init__.py
@@ -61,10 +61,12 @@ async def run_connector_build_pipeline(context: ConnectorContext, semaphore: any
     async with semaphore:
         async with context:
             build_results_per_platform = await run_connector_build(context)
-            step_results = [value[0] for value in build_results_per_platform.values()]
+            step_results = list(build_results_per_platform.values())
             if context.is_local:
-                _, connector_container = build_results_per_platform[LOCAL_BUILD_PLATFORM]
-                load_image_result = await common.LoadContainerToLocalDockerHost(context, connector_container).run()
+                build_result_for_local_platform = build_results_per_platform[LOCAL_BUILD_PLATFORM]
+                load_image_result = await common.LoadContainerToLocalDockerHost(
+                    context, build_result_for_local_platform.output_artifact
+                ).run()
                 step_results.append(load_image_result)
             context.report = ConnectorReport(context, step_results, name="BUILD RESULTS")
         return context.report

--- a/tools/ci_connector_ops/ci_connector_ops/pipelines/builds/java_connectors.py
+++ b/tools/ci_connector_ops/ci_connector_ops/pipelines/builds/java_connectors.py
@@ -3,12 +3,10 @@
 #
 
 
-from typing import Optional, Tuple
-
 from ci_connector_ops.pipelines.actions import environments
 from ci_connector_ops.pipelines.bases import GradleTask, StepResult, StepStatus
 from ci_connector_ops.pipelines.builds.common import BuildConnectorImageBase
-from dagger import Container, File, QueryError
+from dagger import File, QueryError
 
 
 class BuildConnectorImage(BuildConnectorImageBase, GradleTask):
@@ -39,11 +37,10 @@ class BuildConnectorImage(BuildConnectorImageBase, GradleTask):
             )
         return distTar.file(tar_files[0])
 
-    async def _run(self) -> Tuple[StepResult, Optional[Container]]:
+    async def _run(self) -> StepResult:
         try:
             tar_file = await self.build_tar()
             java_connector = await environments.with_airbyte_java_connector(self.context, tar_file, self.build_platform)
-            step_result = await self.get_step_result(java_connector.with_exec(["spec"]))
-            return step_result, java_connector
+            return await self.get_step_result(java_connector.with_exec(["spec"]))
         except QueryError as e:
-            return StepResult(self, StepStatus.FAILURE, stderr=str(e)), None
+            return StepResult(self, StepStatus.FAILURE, stderr=str(e))

--- a/tools/ci_connector_ops/ci_connector_ops/pipelines/builds/normalization.py
+++ b/tools/ci_connector_ops/ci_connector_ops/pipelines/builds/normalization.py
@@ -1,12 +1,10 @@
 #
 # Copyright (c) 2023 Airbyte, Inc., all rights reserved.
 #
-from typing import Tuple
 
 from ci_connector_ops.pipelines.actions import environments
 from ci_connector_ops.pipelines.bases import Step, StepResult, StepStatus
 from ci_connector_ops.pipelines.contexts import ConnectorContext
-from dagger import Container
 
 
 # TODO this class could be deleted
@@ -26,9 +24,9 @@ class BuildOrPullNormalization(Step):
         self.normalization_image = normalization_image
         self.title = f"Build {self.normalization_image}" if self.use_dev_normalization else f"Pull {self.normalization_image}"
 
-    async def _run(self) -> Tuple[StepResult, Container]:
+    async def _run(self) -> StepResult:
         if self.use_dev_normalization:
             build_normalization_container = environments.with_normalization(self.context)
         else:
             build_normalization_container = self.context.dagger_client.container().from_(self.normalization_image)
-        return StepResult(self, StepStatus.SUCCESS), build_normalization_container
+        return StepResult(self, StepStatus.SUCCESS, output_artifact=build_normalization_container)

--- a/tools/ci_connector_ops/ci_connector_ops/pipelines/builds/python_connectors.py
+++ b/tools/ci_connector_ops/ci_connector_ops/pipelines/builds/python_connectors.py
@@ -2,12 +2,10 @@
 # Copyright (c) 2023 Airbyte, Inc., all rights reserved.
 #
 
-from typing import Optional, Tuple
-
 from ci_connector_ops.pipelines.actions.environments import with_airbyte_python_connector
 from ci_connector_ops.pipelines.bases import StepResult, StepStatus
 from ci_connector_ops.pipelines.builds.common import BuildConnectorImageBase
-from dagger import Container, QueryError
+from dagger import QueryError
 
 
 class BuildConnectorImage(BuildConnectorImageBase):
@@ -16,10 +14,9 @@ class BuildConnectorImage(BuildConnectorImageBase):
     A spec command is run on the container to validate it was built successfully.
     """
 
-    async def _run(self) -> Tuple[StepResult, Optional[Container]]:
+    async def _run(self) -> StepResult:
         connector = with_airbyte_python_connector(self.context, self.build_platform)
         try:
-            build_result = await self.get_step_result(connector.with_exec(["spec"]))
-            return build_result, connector
+            return await self.get_step_result(connector.with_exec(["spec"]))
         except QueryError as e:
-            return StepResult(self, StepStatus.FAILURE, stderr=str(e)), None
+            return StepResult(self, StepStatus.FAILURE, stderr=str(e))

--- a/tools/ci_connector_ops/ci_connector_ops/pipelines/pipelines/metadata.py
+++ b/tools/ci_connector_ops/ci_connector_ops/pipelines/pipelines/metadata.py
@@ -3,12 +3,12 @@
 #
 import uuid
 from pathlib import Path
-from typing import List, Optional, Set
+from typing import Optional, Set
 
-import asyncer
 import dagger
+from ci_connector_ops.pipelines.actions import run_steps
 from ci_connector_ops.pipelines.actions.environments import with_pip_packages, with_poetry_module, with_python_base
-from ci_connector_ops.pipelines.bases import Report, Step, StepResult, StepStatus
+from ci_connector_ops.pipelines.bases import Report, Step, StepResult
 from ci_connector_ops.pipelines.contexts import PipelineContext
 from ci_connector_ops.pipelines.utils import DAGGER_CONFIG, METADATA_FILE_NAME, execute_concurrently
 
@@ -17,30 +17,6 @@ METADATA_LIB_MODULE_PATH = "lib"
 METADATA_ORCHESTRATOR_MODULE_PATH = "orchestrator"
 
 # HELPERS
-
-
-async def run_steps(steps: List[Step | List[Step]], results: List[StepResult] = []) -> List[StepResult]:
-    # If there are no steps to run, return the results
-    if not steps:
-        return results
-
-    # If any of the previous steps failed, skip the remaining steps
-    if any(result.status == StepStatus.FAILURE for result in results):
-        skipped_results = [step.skip() for step in steps]
-        return results + skipped_results
-
-    # Pop the next step to run
-    steps_to_run, remaining_steps = steps[0], steps[1:]
-
-    # wrap the step in a list if it is not already (allows for parallel steps)
-    if not isinstance(steps_to_run, list):
-        steps_to_run = [steps_to_run]
-
-    async with asyncer.create_task_group() as task_group:
-        tasks = [task_group.soonify(step_to_run.run)() for step_to_run in steps_to_run]
-
-    new_results = [task.value for task in tasks]
-    return await run_steps(remaining_steps, results + new_results)
 
 
 def get_metadata_file_from_path(context: PipelineContext, metadata_path: Path) -> dagger.File:
@@ -64,7 +40,7 @@ class PoetryRun(Step):
         self.module_path = module_path
         self.poetry_run_container = with_poetry_module(self.context, self.parent_dir, self.module_path).with_entrypoint(["poetry", "run"])
 
-    async def _run(self, poetry_run_args: list) -> StepStatus:
+    async def _run(self, poetry_run_args: list) -> StepResult:
         poetry_run_exec = self.poetry_run_container.with_exec(poetry_run_args)
         return await self.get_step_result(poetry_run_exec)
 
@@ -77,7 +53,7 @@ class MetadataValidation(PoetryRun):
             METADATA_FILE_NAME, get_metadata_file_from_path(context, metadata_path)
         )
 
-    async def _run(self) -> StepStatus:
+    async def _run(self) -> StepResult:
         return await super()._run(["metadata_service", "validate", METADATA_FILE_NAME])
 
 
@@ -96,7 +72,7 @@ class MetadataUpload(PoetryRun):
             .with_env_variable("CACHEBUSTER", str(uuid.uuid4()))
         )
 
-    async def _run(self) -> StepStatus:
+    async def _run(self) -> StepResult:
         return await super()._run(
             [
                 "metadata_service",
@@ -127,7 +103,7 @@ class DeployOrchestrator(Step):
         "3.9",
     ]
 
-    async def _run(self) -> StepStatus:
+    async def _run(self) -> StepResult:
         parent_dir = self.context.get_repo_dir(METADATA_DIR)
         python_base = with_python_base(self.context)
         python_with_dependencies = with_pip_packages(python_base, ["dagster-cloud==1.2.6", "poetry2setup==1.1.0"])
@@ -154,7 +130,7 @@ class TestOrchestrator(PoetryRun):
             module_path=METADATA_ORCHESTRATOR_MODULE_PATH,
         )
 
-    async def _run(self) -> StepStatus:
+    async def _run(self) -> StepResult:
         return await super()._run(["pytest"])
 
 

--- a/tools/ci_connector_ops/ci_connector_ops/pipelines/tests/java_connectors.py
+++ b/tools/ci_connector_ops/ci_connector_ops/pipelines/tests/java_connectors.py
@@ -7,7 +7,7 @@
 from typing import List, Optional
 
 import anyio
-from ci_connector_ops.pipelines.actions import environments, secrets
+from ci_connector_ops.pipelines.actions import environments, run_steps, secrets
 from ci_connector_ops.pipelines.bases import GradleTask, StepResult, StepStatus
 from ci_connector_ops.pipelines.builds import LOCAL_BUILD_PLATFORM
 from ci_connector_ops.pipelines.builds.java_connectors import BuildConnectorImage
@@ -70,64 +70,27 @@ async def run_all_tests(context: ConnectorContext) -> List[StepResult]:
     Returns:
         List[StepResult]: The results of all the tests steps.
     """
-    step_results = []
-    build_connector_step = BuildConnectorImage(context, LOCAL_BUILD_PLATFORM)
-    unit_tests_step = UnitTests(context)
-    build_normalization_step = None
+    context.secrets_dir = await secrets.get_connector_secret_dir(context)
+
+    step_results = await run_steps([BuildConnectorImage(context, LOCAL_BUILD_PLATFORM), UnitTests(context)])
+
     if context.connector.supports_normalization:
         normalization_image = f"{context.connector.normalization_repository}:dev"
         context.logger.info(f"This connector supports normalization: will build {normalization_image}.")
-        build_normalization_step = BuildOrPullNormalization(context, normalization_image)
-    integration_tests_java_step = IntegrationTestJava(context)
-    acceptance_tests_step = AcceptanceTests(context)
-
-    normalization_tar_file = None
-    if build_normalization_step:
-        context.logger.info("Run build normalization step.")
-        build_normalization_results, normalization_container = await build_normalization_step.run()
-        if build_normalization_results.status is StepStatus.FAILURE:
-            return step_results + [
-                build_normalization_results,
-                build_connector_step.skip(),
-                unit_tests_step.skip(),
-                integration_tests_java_step.skip(),
-                acceptance_tests_step.skip(),
-            ]
+        build_normalization_results = await BuildOrPullNormalization(context, normalization_image).run()
+        normalization_container = build_normalization_results.output_artifact
         normalization_tar_file, _ = await export_container_to_tarball(context, normalization_container)
-        context.logger.info(f"{build_normalization_step.normalization_image} was successfully built.")
         step_results.append(build_normalization_results)
+    else:
+        normalization_tar_file = None
 
-    context.logger.info("Run build connector step")
-    build_connector_results, connector_container = await build_connector_step.run()
-    if build_connector_results.status is StepStatus.FAILURE:
-        return step_results + [
-            build_connector_results,
-            unit_tests_step.skip(),
-            integration_tests_java_step.skip(),
-            acceptance_tests_step.skip(),
-        ]
+    connector_container = step_results[0].output_artifact
     connector_image_tar_file, _ = await export_container_to_tarball(context, connector_container)
-    context.logger.info("The connector was successfully built.")
-    step_results.append(build_connector_results)
 
-    context.secrets_dir = await secrets.get_connector_secret_dir(context)
-
-    context.logger.info("Run unit tests.")
-    unit_test_results = await unit_tests_step.run()
-    if unit_test_results.status is StepStatus.FAILURE:
-        return step_results + [
-            unit_test_results,
-            build_connector_step.skip(),
-            integration_tests_java_step.skip(),
-            acceptance_tests_step.skip(),
-        ]
-    context.logger.info("Unit tests successfully ran.")
-    step_results.append(unit_test_results)
-
-    context.logger.info("Start acceptance tests.")
-    acceptance_test_results = await acceptance_tests_step.run(connector_image_tar_file)
-    step_results.append(acceptance_test_results)
-    context.logger.info("Start integration tests.")
-    integration_test_results = await integration_tests_java_step.run(connector_image_tar_file, normalization_tar_file)
-    step_results.append(integration_test_results)
-    return step_results
+    return await run_steps(
+        [
+            (IntegrationTestJava(context), (connector_image_tar_file, normalization_tar_file)),
+            (AcceptanceTests(context), (connector_image_tar_file)),
+        ],
+        results=step_results,
+    )

--- a/tools/ci_connector_ops/ci_connector_ops/pipelines/tests/python_connectors.py
+++ b/tools/ci_connector_ops/ci_connector_ops/pipelines/tests/python_connectors.py
@@ -4,10 +4,10 @@
 
 """This module groups steps made to run tests for a specific Python connector given a test context."""
 
-from typing import List, Tuple
+from typing import List
 
 import asyncer
-from ci_connector_ops.pipelines.actions import environments, secrets
+from ci_connector_ops.pipelines.actions import environments, run_steps, secrets
 from ci_connector_ops.pipelines.bases import Step, StepResult, StepStatus
 from ci_connector_ops.pipelines.builds import LOCAL_BUILD_PLATFORM
 from ci_connector_ops.pipelines.builds.python_connectors import BuildConnectorImage
@@ -57,14 +57,14 @@ class ConnectorPackageInstall(Step):
 
     title = "Connector package install"
 
-    async def _run(self) -> Tuple[StepResult, Container]:
+    async def _run(self) -> StepResult:
         """Install the connector under test package in a Python container.
 
         Returns:
-            Tuple[StepResult, Container]: Failure or success of the package installation and the connector under test container (with the connector package installed).
+            StepResult: Failure or success of the package installation and the connector under test container (with the connector package installed).
         """
         connector_under_test = await environments.with_installed_airbyte_connector(self.context)
-        return (await self.get_step_result(connector_under_test)), connector_under_test
+        return await self.get_step_result(connector_under_test)
 
 
 class UnitTests(PytestStep):
@@ -114,50 +114,32 @@ async def run_all_tests(context: ConnectorContext) -> List[StepResult]:
     Returns:
         List[StepResult]: The results of all the steps that ran or were skipped.
     """
-    connector_package_install_step = ConnectorPackageInstall(context)
-    unit_tests_step = UnitTests(context)
-    build_connector_image_step = BuildConnectorImage(context, LOCAL_BUILD_PLATFORM)
-    integration_tests_step = IntegrationTests(context)
-    acceptance_test_step = AcceptanceTests(context)
 
-    context.logger.info("Run the connector package install step.")
-    package_install_results, connector_under_test = await connector_package_install_step.run()
-    context.logger.info("Successfully ran the connector package install step.")
+    step_results = await run_steps(
+        [
+            ConnectorPackageInstall(context),
+            BuildConnectorImage(context, LOCAL_BUILD_PLATFORM),
+        ]
+    )
+    if any([step_result.status is StepStatus.FAILURE for step_result in step_results]):
+        return step_results
+    connector_package_install_results, build_connector_image_results = step_results[0], step_results[1]
+    connector_image_tar_file, _ = await export_container_to_tarball(context, build_connector_image_results.output_artifact)
+    connector_container = connector_package_install_results.output_artifact
 
-    context.logger.info("Run the unit tests step.")
-    unit_tests_results = await unit_tests_step.run(connector_under_test)
+    unit_test_results = await UnitTests(context).run(connector_container)
+    if unit_test_results.status is StepStatus.FAILURE:
+        return step_results + [unit_test_results]
 
-    results = [
-        package_install_results,
-        unit_tests_results,
-    ]
-
-    if unit_tests_results.status is StepStatus.FAILURE:
-        return results + [build_connector_image_step.skip(), integration_tests_step.skip(), acceptance_test_step.skip()]
-    context.logger.info("Successfully ran the unit tests step.")
-
-    if not context.connector.acceptance_test_config["connector_image"].endswith(":dev"):
-        context.logger.info("Not building the connector image as CAT is run with a non dev version of the connector.")
-        connector_image_tar_file = None
-    else:
-        context.logger.info("Run the build connector image step.")
-        build_connector_image_results, connector_container = await build_connector_image_step.run()
-        results.append(build_connector_image_results)
-        if build_connector_image_results.status is StepStatus.FAILURE:
-            return results + [integration_tests_step.skip(), acceptance_test_step.skip()]
-        connector_image_tar_file, _ = await export_container_to_tarball(context, connector_container)
-        context.logger.info("Successfully ran the build connector image step.")
-
-    context.logger.info("Retrieve the connector secrets.")
     context.secrets_dir = await secrets.get_connector_secret_dir(context)
-    context.logger.info("Run integration tests and acceptance tests in parallel.")
+
     async with asyncer.create_task_group() as task_group:
         tasks = [
-            task_group.soonify(IntegrationTests(context).run)(connector_under_test),
+            task_group.soonify(IntegrationTests(context).run)(connector_container),
             task_group.soonify(AcceptanceTests(context).run)(connector_image_tar_file),
         ]
 
-    return results + [task.value for task in tasks]
+    return step_results + [task.value for task in tasks]
 
 
 async def run_code_format_checks(context: ConnectorContext) -> List[StepResult]:


### PR DESCRIPTION
## What
@bnchrch implemented a nice function to run multiple pipeline steps and handle their failures:
`run_steps`.
In this PR I'm adapting it so that it can call the `run` method of `Step` with custom arguments.
I'm also changing the `StepResult` model to receive a `output_artifact` attribute.
This attribute will help enforce the fact that `_run` method should return `StepResult` and not tuple of `StepResult` and output artifact. Some `Step._run` indeed returned additional objects that are used downstream for other steps. This `output_artifact` attributes should receive these objects. 
