### PR TITLE
[ISSUE #23382] ignore backoff configuration on test reads

### DIFF
--- a/airbyte-cdk/python/airbyte_cdk/connector_builder/connector_builder_handler.py
+++ b/airbyte-cdk/python/airbyte_cdk/connector_builder/connector_builder_handler.py
@@ -50,7 +50,9 @@ def create_source(config: Mapping[str, Any], limits: TestReadLimits) -> Manifest
         component_factory=ModelToComponentFactory(
             emit_connector_builder_messages=True,
             limit_pages_fetched_per_slice=limits.max_pages_per_slice,
-            limit_slices_fetched=limits.max_slices)
+            limit_slices_fetched=limits.max_slices,
+            disable_retries=True
+        )
     )
 
 

--- a/airbyte-cdk/python/airbyte_cdk/sources/declarative/parsers/model_to_component_factory.py
+++ b/airbyte-cdk/python/airbyte_cdk/sources/declarative/parsers/model_to_component_factory.py
@@ -112,12 +112,17 @@ DEFAULT_BACKOFF_STRATEGY = ExponentialBackoffStrategy
 
 class ModelToComponentFactory:
     def __init__(
-        self, limit_pages_fetched_per_slice: int = None, limit_slices_fetched: int = None, emit_connector_builder_messages: bool = False
+        self,
+        limit_pages_fetched_per_slice: int = None,
+        limit_slices_fetched: int = None,
+        emit_connector_builder_messages: bool = False,
+        disable_retries=False,
     ):
         self._init_mappings()
         self._limit_pages_fetched_per_slice = limit_pages_fetched_per_slice
         self._limit_slices_fetched = limit_slices_fetched
         self._emit_connector_builder_messages = emit_connector_builder_messages
+        self._disable_retries = disable_retries
 
     def _init_mappings(self):
         self.PYDANTIC_MODEL_TO_CONSTRUCTOR: [Type[BaseModel], Callable] = {
@@ -779,6 +784,7 @@ class ModelToComponentFactory:
                 config=config,
                 maximum_number_of_slices=self._limit_slices_fetched,
                 parameters=model.parameters,
+                disable_retries=self._disable_retries,
             )
         return SimpleRetriever(
             name=name,
@@ -789,6 +795,7 @@ class ModelToComponentFactory:
             stream_slicer=stream_slicer or SinglePartitionRouter(parameters={}),
             config=config,
             parameters=model.parameters,
+            disable_retries=self._disable_retries,
         )
 
     @staticmethod

--- a/airbyte-cdk/python/unit_tests/connector_builder/test_connector_builder_handler.py
+++ b/airbyte-cdk/python/unit_tests/connector_builder/test_connector_builder_handler.py
@@ -535,6 +535,7 @@ def test_create_source():
     assert isinstance(source, ManifestDeclarativeSource)
     assert source._constructor._limit_pages_fetched_per_slice == limits.max_pages_per_slice
     assert source._constructor._limit_slices_fetched == limits.max_slices
+    assert source.streams(config={})[0].retriever.max_retries == 0
 
 
 def request_log_message(request: dict) -> AirbyteMessage:

--- a/airbyte-cdk/python/unit_tests/sources/declarative/parsers/test_model_to_component_factory.py
+++ b/airbyte-cdk/python/unit_tests/sources/declarative/parsers/test_model_to_component_factory.py
@@ -1360,3 +1360,29 @@ def test_simple_retriever_emit_log_messages():
     )
 
     assert isinstance(retriever, SimpleRetrieverTestReadDecorator)
+
+
+def test_ignore_retry():
+    requester_model = {
+        "type": "SimpleRetriever",
+        "record_selector": {
+            "type": "RecordSelector",
+            "extractor": {
+                "type": "DpathExtractor",
+                "field_path": [],
+            },
+        },
+        "requester": {"type": "HttpRequester", "name": "list", "url_base": "orange.com", "path": "/v1/api"},
+    }
+
+    connector_builder_factory = ModelToComponentFactory(disable_retries=True)
+    retriever = connector_builder_factory.create_component(
+        model_type=SimpleRetrieverModel,
+        component_definition=requester_model,
+        config={},
+        name="Test",
+        primary_key="id",
+        stream_slicer=None,
+    )
+
+    assert retriever.max_retries == 0

--- a/airbyte-cdk/python/unit_tests/sources/declarative/retrievers/test_simple_retriever.py
+++ b/airbyte-cdk/python/unit_tests/sources/declarative/retrievers/test_simple_retriever.py
@@ -256,6 +256,48 @@ def test_parse_response(test_name, status_code, response_status, len_expected_re
         assert len(records) == len_expected_records
 
 
+def test_max_retries_given_error_handler_has_max_retries():
+    requester = MagicMock()
+    requester.error_handler = MagicMock()
+    requester.error_handler.max_retries = 10
+    retriever = SimpleRetriever(
+        name="stream_name",
+        primary_key=primary_key,
+        requester=requester,
+        record_selector=MagicMock(),
+        parameters={},
+        config={}
+    )
+    assert retriever.max_retries == 10
+
+
+def test_max_retries_given_error_handler_without_max_retries():
+    requester = MagicMock()
+    requester.error_handler = MagicMock(spec=[u'without_max_retries_attribute'])
+    retriever = SimpleRetriever(
+        name="stream_name",
+        primary_key=primary_key,
+        requester=requester,
+        record_selector=MagicMock(),
+        parameters={},
+        config={}
+    )
+    assert retriever.max_retries == 5
+
+
+def test_max_retries_given_disable_retries():
+    retriever = SimpleRetriever(
+        name="stream_name",
+        primary_key=primary_key,
+        requester=MagicMock(),
+        record_selector=MagicMock(),
+        disable_retries=True,
+        parameters={},
+        config={}
+    )
+    assert retriever.max_retries == 0
+
+
 @pytest.mark.parametrize(
     "test_name, response_action, retry_in, expected_backoff_time",
     [


### PR DESCRIPTION
## What
Addresses https://github.com/airbytehq/airbyte/issues/23382

Previous behaviour:
```
2023-04-24 10:41:12 [    INFO] Starting syncing ManifestDeclarativeSource (abstract_source.py:95)
2023-04-24 10:41:12 [    INFO] Syncing stream: test  (abstract_source.py:184)
2023-04-24 10:41:12 [    INFO] Backing off _send(...) for 5.0s (requests.exceptions.ConnectionError: ('Connection aborted.', RemoteDisconnected('Remote end closed connection without response'))) (_common.py:105)
2023-04-24 10:41:12 [    INFO] Caught retryable error '('Connection aborted.', RemoteDisconnected('Remote end closed connection without response'))' after 1 tries. Waiting 5 seconds then retrying... (rate_limiting.py:31)
2023-04-24 10:41:17 [    INFO] Backing off _send(...) for 10.0s (requests.exceptions.ConnectionError: ('Connection aborted.', RemoteDisconnected('Remote end closed connection without response'))) (_common.py:105)
2023-04-24 10:41:17 [    INFO] Caught retryable error '('Connection aborted.', RemoteDisconnected('Remote end closed connection without response'))' after 2 tries. Waiting 10 seconds then retrying... (rate_limiting.py:31)
```

New behaviour:
```
2023-04-24 10:29:18 [    INFO] Starting syncing ManifestDeclarativeSource (abstract_source.py:95)
2023-04-24 10:29:18 [    INFO] Syncing stream: test  (abstract_source.py:184)
2023-04-24 10:29:18 [   ERROR] Giving up _send(...) after 1 tries (requests.exceptions.ConnectionError: ('Connection aborted.', RemoteDisconnected('Remote end closed connection without response'))) (_common.py:120)
2023-04-24 10:29:18 [   ERROR] Encountered an exception while reading stream test (abstract_source.py:126)
Traceback (most recent call last):
```

## How
Override SimpleRetriever. max_retries to take into account:
* disabling of the retries
* max_retries from the error_handler

## Recommended reading order
1. `airbyte-cdk/python/airbyte_cdk/sources/declarative/retrievers/simple_retriever.py` where max_retries is overridden
2. `airbyte-cdk/python/airbyte_cdk/sources/declarative/parsers/model_to_component_factory.py` where the flag is defined to by disable retries
3. `airbyte-cdk/python/airbyte_cdk/connector_builder/connector_builder_handler.py` where it is configured for the connector builder

## 🚨 User Impact 🚨
No breaking changes
* Connector builder will not retry anymore. This also includes the case defined by https://github.com/airbytehq/airbyte-internal-issues/issues/2696 (even though it does not solve the issue because we don't rely on the ErrorHandler when `disable_retries` is not configured) which probably reduce the priority of this ticket
* The max retries will be based on the ErrorHandler and not on HttpStream.max_retries
