### PR TITLE
FIX: Add shell to dagger action

### DIFF
--- a/.github/actions/run-dagger-pipeline/action.yml
+++ b/.github/actions/run-dagger-pipeline/action.yml
@@ -18,6 +18,7 @@ runs:
       run: echo "::set-output name=start-timestamp::$(date +%s)"
       shell: bash
     - name: Login to DockerHub
+      shell: bash
       run: "docker login -u ${DOCKER_HUB_USERNAME} -p ${DOCKER_HUB_PASSWORD}"
       env:
         DOCKER_HUB_USERNAME: ${{ secrets.DOCKER_HUB_USERNAME }}


### PR DESCRIPTION
## Overview
We have a github action failing likely due to not being run in a shell context

https://github.com/airbytehq/airbyte/actions/runs/4792052561?pr=25306

## Solution
This fixes that by adding the shell declaration

## Notes for reviewer
Im unclear why we are logging into docker in during every dagger action. @alafanechere do you know if theres a specific reason?

Also Im going to cowboy 🤠  merge this and we can address that question in another PR if need be :)