### PR TITLE
Fix: Remove docker hub step from generic dagger action

### DIFF
--- a/.github/actions/run-dagger-pipeline/action.yml
+++ b/.github/actions/run-dagger-pipeline/action.yml
@@ -17,12 +17,6 @@ runs:
       id: get-start-timestamp
       run: echo "::set-output name=start-timestamp::$(date +%s)"
       shell: bash
-    - name: Login to DockerHub
-      shell: bash
-      run: "docker login -u ${DOCKER_HUB_USERNAME} -p ${DOCKER_HUB_PASSWORD}"
-      env:
-        DOCKER_HUB_USERNAME: ${{ secrets.DOCKER_HUB_USERNAME }}
-        DOCKER_HUB_PASSWORD: ${{ secrets.DOCKER_HUB_PASSWORD }}
     - name: Checkout Airbyte
       uses: actions/checkout@v3
       with:

--- a/.github/workflows/publish_connectors.yml
+++ b/.github/workflows/publish_connectors.yml
@@ -25,9 +25,13 @@ jobs:
       GCS_CREDENTIALS: ${{ secrets.METADATA_SERVICE_DEV_GCS_CREDENTIALS }}
       SPEC_CACHE_SERVICE_ACCOUNT_KEY: ${{ secrets.SPEC_CACHE_SERVICE_ACCOUNT_KEY }}
       METADATA_SERVICE_ACCOUNT_KEY: ${{ secrets.METADATA_SERVICE_DEV_GCS_CREDENTIALS }}
+      DOCKER_HUB_USERNAME: ${{ secrets.DOCKER_HUB_USERNAME }}
+      DOCKER_HUB_PASSWORD: ${{ secrets.DOCKER_HUB_PASSWORD }}
     steps:
       - name: Checkout Airbyte
         uses: actions/checkout@v2
+      - name: Login to DockerHub
+        run: "docker login -u ${DOCKER_HUB_USERNAME} -p ${DOCKER_HUB_PASSWORD}"
       - name: Publish modified connectors
         id: publish-modified-connectors
         if: github.event_name == 'push'


### PR DESCRIPTION
## What
Removes the dockerhub login step from the dagger action as its not a prerequisite

Related to https://github.com/airbytehq/airbyte/pull/25458

## Notes for reviewer
@alafanechere Im going to merge this in but lets discuss if this was the right approach tomorrow