### PR TITLE
connectors-ci: reduce nightly builds concurrency to 10

### DIFF
--- a/.github/workflows/connector_nightly_builds_dagger.yml
+++ b/.github/workflows/connector_nightly_builds_dagger.yml
@@ -56,7 +56,7 @@ jobs:
             mkdir -p "$DAGGER_TMP_BINDIR"
             curl "https://dl.dagger.io/dagger/main/${DAGGER_CLI_COMMIT}/dagger_${DAGGER_CLI_COMMIT}_$(uname -s | tr A-Z a-z)_$(uname -m | sed s/x86_64/amd64/).tar.gz" | tar xvz -C "$DAGGER_TMP_BINDIR"
           fi
-          airbyte-ci --is-ci --gha-workflow-run-id=${{ github.run_id }} connectors ${{ inputs.test-connectors-options || '--concurrency=20 --release-stage=generally_available --release-stage=beta' }} test
+          airbyte-ci --is-ci --gha-workflow-run-id=${{ github.run_id }} connectors ${{ inputs.test-connectors-options || '--concurrency=10 --release-stage=generally_available --release-stage=beta' }} test
         env:
           _EXPERIMENTAL_DAGGER_CLOUD_TOKEN: "p.eyJ1IjogIjFiZjEwMmRjLWYyZmQtNDVhNi1iNzM1LTgxNzI1NGFkZDU2ZiIsICJpZCI6ICJlNjk3YzZiYy0yMDhiLTRlMTktODBjZC0yNjIyNGI3ZDBjMDEifQ.hT6eMOYt3KZgNoVGNYI3_v4CC-s19z8uQsBkGrBhU3k"
           GCP_GSM_CREDENTIALS: ${{ secrets.GCP_GSM_CREDENTIALS }}


### PR DESCRIPTION
## What
Reduce concurrency of nightly builds to 10 (max 10 connectors tested in parallel). This is to try to workaround OOM errors.
