### PR TITLE
connectors-ci: fix missing env var on publish workflow

### DIFF
--- a/.github/workflows/publish_connectors.yml
+++ b/.github/workflows/publish_connectors.yml
@@ -19,14 +19,19 @@ jobs:
     name: Publish connectors
     runs-on: medium-runner
     env:
+      AWS_ACCESS_KEY_ID: ${{ secrets.STATUS_API_AWS_ACCESS_KEY_ID }}
+      AWS_DEFAULT_REGION: "us-east-2"
+      AWS_SECRET_ACCESS_KEY: ${{ secrets.STATUS_API_AWS_SECRET_ACCESS_KEY }}
       CI_GITHUB_ACCESS_TOKEN: ${{ secrets.GH_PAT_MAINTENANCE_OCTAVIA }}
-      SPEC_CACHE_BUCKET_NAME: io-airbyte-cloud-spec-cache
-      METADATA_SERVICE_BUCKET_NAME: dev-airbyte-cloud-connector-metadata-service
-      GCS_CREDENTIALS: ${{ secrets.METADATA_SERVICE_DEV_GCS_CREDENTIALS }}
-      SPEC_CACHE_SERVICE_ACCOUNT_KEY: ${{ secrets.SPEC_CACHE_SERVICE_ACCOUNT_KEY }}
-      METADATA_SERVICE_ACCOUNT_KEY: ${{ secrets.METADATA_SERVICE_DEV_GCS_CREDENTIALS }}
-      DOCKER_HUB_USERNAME: ${{ secrets.DOCKER_HUB_USERNAME }}
       DOCKER_HUB_PASSWORD: ${{ secrets.DOCKER_HUB_PASSWORD }}
+      DOCKER_HUB_USERNAME: ${{ secrets.DOCKER_HUB_USERNAME }}
+      GCP_GSM_CREDENTIALS: ${{ secrets.GCP_GSM_CREDENTIALS }}
+      GCS_CREDENTIALS: ${{ secrets.METADATA_SERVICE_DEV_GCS_CREDENTIALS }}
+      METADATA_SERVICE_ACCOUNT_KEY: ${{ secrets.METADATA_SERVICE_DEV_GCS_CREDENTIALS }}
+      METADATA_SERVICE_BUCKET_NAME: dev-airbyte-cloud-connector-metadata-service
+      SPEC_CACHE_BUCKET_NAME: io-airbyte-cloud-spec-cache
+      SPEC_CACHE_SERVICE_ACCOUNT_KEY: ${{ secrets.SPEC_CACHE_SERVICE_ACCOUNT_KEY }}
+      TEST_REPORTS_BUCKET_NAME: "airbyte-connector-build-status"
     steps:
       - name: Checkout Airbyte
         uses: actions/checkout@v2

--- a/airbyte-integrations/connectors/destination-starburst-galaxy/metadata.yaml
+++ b/airbyte-integrations/connectors/destination-starburst-galaxy/metadata.yaml
@@ -1,0 +1,18 @@
+data:
+  registries:
+    cloud:
+      enabled: false
+    oss:
+      enabled: true
+  connectorSubtype: database
+  connectorType: destination
+  definitionId: 4528e960-6f7b-4412-8555-7e0097e1da17
+  dockerImageTag: 0.0.1
+  dockerRepository: airbyte/destination-starbust-galaxy
+  githubIssueLabel: destination-starbust-galaxy
+  icon: starburst-galaxy.svg
+  license: MIT
+  name: Startbust Galaxy
+  releaseStage: alpha
+  supportUrl: https://docs.airbyte.com/integrations/destinations/starbust-galaxy
+metadataSpecVersion: "1.0"


### PR DESCRIPTION
## What
A couple of required env var were missing to publish updated metadata files and connectors
