### PR TITLE
connectors-ci: fix modified files detection on master

### DIFF
--- a/airbyte-integrations/connectors/destination-s3-glue/metadata.yaml
+++ b/airbyte-integrations/connectors/destination-s3-glue/metadata.yaml
@@ -7,7 +7,7 @@ data:
   connectorSubtype: file
   connectorType: destination
   definitionId: 471e5cab-8ed1-49f3-ba11-79c687784737
-  dockerImageTag: 0.1.4
+  dockerImageTag: 0.1.6
   dockerRepository: airbyte/destination-s3-glue
   githubIssueLabel: destination-s3-glue
   icon: s3-glue.svg

--- a/tools/ci_connector_ops/ci_connector_ops/pipelines/commands/airbyte_ci.py
+++ b/tools/ci_connector_ops/ci_connector_ops/pipelines/commands/airbyte_ci.py
@@ -54,6 +54,7 @@ def airbyte_ci(
     ctx.obj["pipeline_start_timestamp"] = pipeline_start_timestamp
     ctx.obj["modified_files_in_branch"] = get_modified_files_in_branch(git_branch, git_revision, diffed_branch, is_local)
     ctx.obj["modified_files_in_commit"] = get_modified_files_in_commit(git_branch, git_revision, is_local)
+    ctx.obj["modified_files"] = ctx.obj["modified_files_in_commit"] if git_branch == "master" else ctx.obj["modified_files_in_branch"]
 
 
 airbyte_ci.add_command(connectors)

--- a/tools/ci_connector_ops/ci_connector_ops/pipelines/commands/groups/connectors.py
+++ b/tools/ci_connector_ops/ci_connector_ops/pipelines/commands/groups/connectors.py
@@ -108,7 +108,7 @@ def connectors(
     )
 
     selected_connectors = get_all_released_connectors()
-    modified_connectors = get_modified_connectors(ctx.obj["modified_files_in_branch"])
+    modified_connectors = get_modified_connectors(ctx.obj["modified_files"])
     if modified:
         selected_connectors = modified_connectors
     else:
@@ -246,7 +246,7 @@ def publish(
             abort=True,
         )
     if ctx.obj["modified"]:
-        selected_connectors = get_modified_connectors(get_modified_metadata_files(ctx.obj["modified_files_in_commit"]))
+        selected_connectors = get_modified_connectors(get_modified_metadata_files(ctx.obj["modified_files"]))
         selected_connectors_names = [connector.technical_name for connector in selected_connectors]
     else:
         selected_connectors = ctx.obj["selected_connectors"]

--- a/tools/ci_connector_ops/ci_connector_ops/pipelines/commands/groups/metadata.py
+++ b/tools/ci_connector_ops/ci_connector_ops/pipelines/commands/groups/metadata.py
@@ -8,10 +8,10 @@ import click
 from ci_connector_ops.pipelines.contexts import CIContext
 from ci_connector_ops.pipelines.pipelines.metadata import (
     run_metadata_lib_test_pipeline,
+    run_metadata_orchestrator_deploy_pipeline,
     run_metadata_orchestrator_test_pipeline,
     run_metadata_upload_pipeline,
     run_metadata_validation_pipeline,
-    run_metadata_orchestrator_deploy_pipeline,
 )
 from ci_connector_ops.pipelines.utils import DaggerPipelineCommand, get_all_metadata_files, get_modified_metadata_files
 from rich.logging import RichHandler
@@ -36,8 +36,7 @@ def metadata(ctx: click.Context):
 @click.pass_context
 def validate(ctx: click.Context, modified_only: bool) -> bool:
     if modified_only:
-        modified_files = ctx.obj["modified_files_in_branch"]
-        metadata_to_validate = get_modified_metadata_files(modified_files)
+        metadata_to_validate = get_modified_metadata_files(ctx.obj["modified_files"])
         if not metadata_to_validate:
             click.secho("No modified metadata found. Skipping metadata validation.")
             return True
@@ -74,8 +73,7 @@ def upload(ctx: click.Context, gcs_bucket_name: str, gcs_credentials: str, modif
         if ctx.obj["ci_context"] is not CIContext.MASTER and ctx.obj["git_branch"] != "master":
             click.secho("Not on the master branch. Skipping metadata upload.")
             return True
-        modified_files = ctx.obj["modified_files_in_commit"]
-        metadata_to_upload = get_modified_metadata_files(modified_files)
+        metadata_to_upload = get_modified_metadata_files(ctx.obj["modified_files"])
         if not metadata_to_upload:
             click.secho("No modified metadata found. Skipping metadata upload.")
             return True

--- a/tools/ci_connector_ops/ci_connector_ops/pipelines/utils.py
+++ b/tools/ci_connector_ops/ci_connector_ops/pipelines/utils.py
@@ -11,7 +11,7 @@ import sys
 import unicodedata
 from glob import glob
 from pathlib import Path
-from typing import TYPE_CHECKING, Any, Callable, List, Optional, Set, Tuple
+from typing import TYPE_CHECKING, Any, Callable, List, Optional, Set, Tuple, Union
 
 import anyio
 import asyncer
@@ -214,17 +214,19 @@ def get_modified_files_in_commit(current_git_branch: str, current_git_revision: 
         return anyio.run(get_modified_files_in_commit_remote, current_git_branch, current_git_revision)
 
 
-def get_modified_connectors(modified_files: Set[str]) -> Set[Connector]:
+def get_modified_connectors(modified_files: Set[Union[str, Path]]) -> Set[Connector]:
     """Create a set of modified connectors according to the modified files on the branch."""
     modified_connectors = []
     for file_path in modified_files:
-        if file_path.startswith(SOURCE_CONNECTOR_PATH_PREFIX) or file_path.startswith(DESTINATION_CONNECTOR_PATH_PREFIX):
-            modified_connectors.append(Connector(get_connector_name_from_path(file_path)))
+        if str(file_path).startswith(SOURCE_CONNECTOR_PATH_PREFIX) or str(file_path).startswith(DESTINATION_CONNECTOR_PATH_PREFIX):
+            modified_connectors.append(Connector(get_connector_name_from_path(str(file_path))))
     return set(modified_connectors)
 
 
-def get_modified_metadata_files(modified_files: Set[str]) -> Set[Path]:
-    return {Path(f) for f in modified_files if f.endswith(METADATA_FILE_NAME) and f.startswith("airbyte-integrations/connectors")}
+def get_modified_metadata_files(modified_files: Set[Union[str, Path]]) -> Set[Path]:
+    return {
+        Path(str(f)) for f in modified_files if str(f).endswith(METADATA_FILE_NAME) and str(f).startswith("airbyte-integrations/connectors")
+    }
 
 
 def get_all_metadata_files() -> Set[Path]:


### PR DESCRIPTION
## What
Under the connector command group the logic to detect modified connectors was relying on the list of modified files on the branch.
When running on master this logic does not make sense as diffing master with master does not lead to any modified files.

## How
- Expose a `modified_files` list in the click context object
- If we're on the master branch the list of modified files is built from the `git diff` of the latest commit. If not on master the current branch is diffed with master to retrieve the list of modified files.
