### PR TITLE
Docusaurus: Change port for local development

### DIFF
--- a/docusaurus/package.json
+++ b/docusaurus/package.json
@@ -4,7 +4,7 @@
   "private": true,
   "scripts": {
     "docusaurus": "docusaurus",
-    "start": "docusaurus start",
+    "start": "docusaurus start --port 3005",
     "build": "docusaurus build",
     "swizzle": "docusaurus swizzle",
     "deploy": "docusaurus deploy",


### PR DESCRIPTION
When running `yarn start` to develop docs locally, it's using port 3000, just like the webapp dev server. This PR changes the port to 3005 so it's possible to run webapp dev server and docs dev server side by side.