### PR TITLE
connectors-ci: fix secrets used to write to spec cache

### DIFF
--- a/.github/workflows/publish_connectors.yml
+++ b/.github/workflows/publish_connectors.yml
@@ -30,7 +30,7 @@ jobs:
       METADATA_SERVICE_ACCOUNT_KEY: ${{ secrets.METADATA_SERVICE_DEV_GCS_CREDENTIALS }}
       METADATA_SERVICE_BUCKET_NAME: dev-airbyte-cloud-connector-metadata-service
       SPEC_CACHE_BUCKET_NAME: io-airbyte-cloud-spec-cache
-      SPEC_CACHE_SERVICE_ACCOUNT_KEY: ${{ secrets.SPEC_CACHE_SERVICE_ACCOUNT_KEY }}
+      SPEC_CACHE_SERVICE_ACCOUNT_KEY: ${{ secrets.SPEC_CACHE_SERVICE_ACCOUNT_KEY_PUBLISH }}
       TEST_REPORTS_BUCKET_NAME: "airbyte-connector-build-status"
     steps:
       - name: Checkout Airbyte

--- a/tools/ci_connector_ops/ci_connector_ops/pipelines/actions/__init__.py
+++ b/tools/ci_connector_ops/ci_connector_ops/pipelines/actions/__init__.py
@@ -34,7 +34,7 @@ async def run_steps(
     if any(result.status is StepStatus.FAILURE for result in results):
         skipped_results = []
         for step_and_run_args in steps_and_run_args:
-            if isinstance(steps_and_run_args, Tuple):
+            if isinstance(step_and_run_args, Tuple):
                 skipped_results.append(step_and_run_args[0].skip())
             else:
                 skipped_results.append(step_and_run_args.skip())

--- a/tools/ci_connector_ops/ci_connector_ops/pipelines/utils.py
+++ b/tools/ci_connector_ops/ci_connector_ops/pipelines/utils.py
@@ -6,6 +6,7 @@
 from __future__ import annotations
 
 import datetime
+import json
 import re
 import sys
 import unicodedata
@@ -342,3 +343,10 @@ async def export_container_to_tarball(context: ConnectorContext, container: Cont
         return exported_file, local_path
     else:
         return None, None
+
+
+def sanitize_gcs_service_account_key(raw_value: str) -> str:
+    try:
+        return json.dumps(json.loads(raw_value))
+    except json.JSONDecodeError:
+        return raw_value


### PR DESCRIPTION
## What
The `SPEC_CACHE_SERVICE_ACCOUNT_KEY` env var originally contained a value the `gcloud` CLI can't read.
It's specific to this SA key and I guess it's something related to the format of the GitHub secrets.
I can't decrypt the value of this secret in a safe way so I decided to create a new key from the existing service and load it to a new secret: `SPEC_CACHE_SERVICE_ACCOUNT_KEY_PUBLISH`

I confirm that this change is working by running the publish pipeline one this branch: https://github.com/airbytehq/airbyte/actions/runs/4796582820/jobs/8532511262
