### PR TITLE
connectors-ci: use dockerfile for python connectors

### DIFF
--- a/tools/ci_connector_ops/ci_connector_ops/pipelines/actions/environments.py
+++ b/tools/ci_connector_ops/ci_connector_ops/pipelines/actions/environments.py
@@ -624,7 +624,18 @@ async def with_airbyte_java_connector(context: ConnectorContext, connector_java_
     )
 
 
-def with_airbyte_python_connector(context: ConnectorContext, build_platform: Platform):
+def with_airbyte_python_connector(context: ConnectorContext, build_platform):
+    pip_cache: CacheVolume = context.dagger_client.cache_volume("pip_cache")
+    return (
+        context.dagger_client.container(platform=build_platform)
+        .with_mounted_cache("/root/.cache/pip", pip_cache)
+        .build(context.get_connector_dir())
+        .with_label("io.airbyte.version", context.metadata["dockerImageTag"])
+        .with_label("io.airbyte.name", context.metadata["dockerRepository"])
+    )
+
+
+def with_airbyte_python_connector_full_dagger(context: ConnectorContext, build_platform: Platform):
     pip_cache: CacheVolume = context.dagger_client.cache_volume("pip_cache")
     base = context.dagger_client.container(platform=build_platform).from_("python:3.9.11-alpine3.15")
     snake_case_name = context.connector.technical_name.replace("-", "_")


### PR DESCRIPTION
## What
I originally tried to replicate with Dagger the Dockerfile in the generator for python connectors.
I realized we can't adopt this Dockerfile for a couple of connectors because some of connectors python dependencies are not compatible with the alpine base image we are using.

This is pretty well explained on a recent destination:
```
# FROM python:3.9.11-alpine3.15 as base
# switched from alpine as there were tons of errors (in case you want to switch back to alpine)
# - https://stackoverflow.com/a/57485724/5246670
# - numpy error: https://stackoverflow.com/a/22411624/5246670
# - libstdc++ https://github.com/amancevice/docker-pandas/issues/12#issuecomment-717215043
# - musl-dev linux-headers g++ because of: https://stackoverflow.com/a/40407099/5246670
```

**I think it's safer to rely on connectors dockerfile to build them at the moment.**

**The connectors that can't use the alpine base images are the one relying on libraries like `pandas` and `pyarrows`**:
* source-salesforce
* source-file
* source-sendgrid
... 

## How
Change `with_airbyte_python_connector` function to use connector specific dockerfile.

