### PR TITLE
Source Netsuite: Make input date format configurable (#21965)

### DIFF
--- a/airbyte-integrations/connectors/source-netsuite/Dockerfile
+++ b/airbyte-integrations/connectors/source-netsuite/Dockerfile
@@ -35,5 +35,5 @@ COPY source_netsuite ./source_netsuite
 ENV AIRBYTE_ENTRYPOINT "python /airbyte/integration_code/main.py"
 ENTRYPOINT ["python", "/airbyte/integration_code/main.py"]
 
-LABEL io.airbyte.version=0.1.3
+LABEL io.airbyte.version=0.1.4
 LABEL io.airbyte.name=airbyte/source-netsuite

--- a/airbyte-integrations/connectors/source-netsuite/sample_files/config.json
+++ b/airbyte-integrations/connectors/source-netsuite/sample_files/config.json
@@ -6,5 +6,6 @@
   "token_secret": "a3c....",
   "start_datetime": "2022-06-01T00:00:01Z",
   "object_types": ["customer"],
-  "window_in_days": 30
+  "window_in_days": 30,
+  "netsuite_input_date_format": "%d/%m/%Y"
 }

--- a/airbyte-integrations/connectors/source-netsuite/sample_files/invalid_config.json
+++ b/airbyte-integrations/connectors/source-netsuite/sample_files/invalid_config.json
@@ -6,5 +6,6 @@
   "token_secret": "a3c....",
   "start_datetime": "2022-06-01T00:00:01Z",
   "object_types": ["customer"],
-  "window_in_days": 30
+  "window_in_days": 30,
+  "netsuite_input_date_format": "%m...",
 }

--- a/airbyte-integrations/connectors/source-netsuite/source_netsuite/constraints.py
+++ b/airbyte-integrations/connectors/source-netsuite/source_netsuite/constraints.py
@@ -39,5 +39,5 @@ INCREMENTAL_CURSOR: str = "lastModifiedDate"
 CUSTOM_INCREMENTAL_CURSOR: str = "lastmodified"
 
 
-NETSUITE_INPUT_DATE_FORMATS: list[str] = ["%m/%d/%Y", "%Y-%m-%d"]
+DEFAULT_NETSUITE_INPUT_DATE_FORMAT: str = "%m/%d/%Y"
 NETSUITE_OUTPUT_DATETIME_FORMAT: str = "%Y-%m-%dT%H:%M:%SZ"

--- a/airbyte-integrations/connectors/source-netsuite/source_netsuite/source.py
+++ b/airbyte-integrations/connectors/source-netsuite/source_netsuite/source.py
@@ -107,6 +107,7 @@ class SourceNetsuite(AbstractSource):
         base_url: str,
         start_datetime: str,
         window_in_days: int,
+        netsuite_input_date_format: str,
         max_retry: int = 3,
     ) -> Union[NetsuiteStream, IncrementalNetsuiteStream, CustomIncrementalNetsuiteStream]:
 
@@ -116,6 +117,7 @@ class SourceNetsuite(AbstractSource):
             "base_url": base_url,
             "start_datetime": start_datetime,
             "window_in_days": window_in_days,
+            "netsuite_input_date_format": netsuite_input_date_format,
         }
 
         schema = schemas[object_name]
@@ -162,6 +164,7 @@ class SourceNetsuite(AbstractSource):
                 "base_url": base_url,
                 "start_datetime": config["start_datetime"],
                 "window_in_days": config["window_in_days"],
+                "netsuite_input_date_format": config["netsuite_input_date_format"],
                 "schemas": schemas,
             }
         )

--- a/airbyte-integrations/connectors/source-netsuite/source_netsuite/spec.yaml
+++ b/airbyte-integrations/connectors/source-netsuite/source_netsuite/spec.yaml
@@ -51,16 +51,22 @@ connectionSpecification:
       order: 5
       examples: ["customer", "salesorder", "etc"]
       default: []
+    netsuite_input_dateformat:
+      type: string
+      title: Netsuite Input Date Format
+      description: The date format used in Netsuite API queries.
+      order: 6
+      default: "%m/%d/%Y"
     start_datetime:
       type: string
       title: Start Date
       description: Starting point for your data replication, in format of "YYYY-MM-DDTHH:mm:ssZ"
-      order: 6
+      order: 7
       pattern: "^[0-9]{4}-[0-9]{2}-[0-9]{2}T[0-9]{2}:[0-9]{2}:[0-9]{2}Z$"
       examples: ["2017-01-25T00:00:00Z"]
     window_in_days:
       type: integer
       title: Window in Days
       description: The amount of days used to query the data with date chunks. Set smaller value, if you have lots of data.
-      order: 7
+      order: 8
       default: 30


### PR DESCRIPTION
## What

As explained in #21965, the connector is failing to guess the correct input date format when querying the Netsuite API and this is making the requests to fail under some circumstances. 

Apparently [there's no way to retrieve the correct format from Netsuite via REST API](https://github.com/airbytehq/airbyte/pull/21971#issuecomment-1415695014), so currently the connector tries to guess it using a trial-and-error approach by testing against `DateFormatException`

The current implementation seemed to present some bugs, and @ChloeConnor tried to fix those in #21971. 

But even after fixing them, the current brute-force approach may not be a reliable solution. This is because a date like **Dec 1st 2023** could be represented in multiple ways, such as `dd/mm/YY` (01/12/2023) or `mm/dd/YY` (12/01/2023). Both representations are ambiguous and can be parsed incorrectly using either `%d/%m/%Y` or `%m/%d/%Y` without causing an exception.

We encountered that problem in our local setup,  after implementing the fix from #21971 and it led to further errors, problems and data inconsistencies.

## How

* Remove brute-force approach implementation.
* Add **Netsuite Input Date Format** as a new configurable property in the connector, so the user can populate it with the format matching their Netsuite setup. The default value remains the same (`%m/%d/%Y`). 

## 🚨 User Impact 🚨

Users using formats other than the default one – i.e. `%m/%d/%Y`, will need to populate **Netsuite Input Date Format**.  I don't think this can be considered a breaking change since the current solution wasn't really working in the first place. 

## Pre-merge Checklist

### Community member or Airbyter

- [x] Grant edit access to maintainers ([instructions](https://docs.github.com/en/github/collaborating-with-pull-requests/working-with-forks/allowing-changes-to-a-pull-request-branch-created-from-a-fork#enabling-repository-maintainer-permissions-on-existing-pull-requests))
- [x] Secrets in the connector's spec are annotated with `airbyte_secret`
- [x] Unit & integration tests added and passing. Community members, please provide proof of success locally e.g: screenshot or copy-paste unit, integration, and acceptance test output. To run acceptance tests for a Python connector, follow instructions in the README. For java connectors run `./gradlew :airbyte-integrations:connectors:<name>:integrationTest`.
- [ ] Code reviews completed
- [x] Connector version has been incremented
    - [x] Version has been bumped according to our [Semantic Versioning for Connectors](https://docs.airbyte.com/contributing-to-airbyte/#semantic-versioning-for-connectors) guidelines
    - [x] `Dockerfile` has updated version
- [ ] Documentation updated
    - [ ] Connector's `README.md`
    - [ ] Connector's `bootstrap.md`. See [description and examples](https://docs.google.com/document/d/1ypdgmwmEHWv-TrO4_YOQ7pAJGVrMp5BOkEVh831N260/edit?usp=sharing)
    - [ ] Changelog updated in `docs/integrations/<source or destination>/<name>.md` with an entry for the new version. See changelog [example](https://docs.airbyte.io/integrations/sources/stripe#changelog)
- [x] PR name follows [PR naming conventions](https://docs.airbyte.com/contributing-to-airbyte/issues-and-pull-requests)

### Airbyter

If this is a community PR, the Airbyte engineer reviewing this PR is responsible for the below items.

- [ ] Create a non-forked branch based on this PR and test the below items on it
- [ ] Build is successful
- [ ] If new credentials are required for use in CI, add them to GSM. [Instructions](https://docs.airbyte.io/connector-development#using-credentials-in-ci).
- [ ] [`/test connector=connectors/<name>` command](https://docs.airbyte.io/connector-development#updating-an-existing-connector) is passing
- [ ] New Connector version released on Dockerhub and connector version bumped by running the `/publish` command described [here](https://docs.airbyte.io/connector-development#updating-an-existing-connector)
