### PR TITLE
connectors-ci: use pip install instead of python -m pip install 

### DIFF
--- a/tools/ci_connector_ops/ci_connector_ops/pipelines/actions/environments.py
+++ b/tools/ci_connector_ops/ci_connector_ops/pipelines/actions/environments.py
@@ -230,7 +230,7 @@ def with_pip_packages(base_container: Container, packages_to_install: List[str])
         Container: A container with the pip packages installed.
 
     """
-    package_install_command = ["python", "-m", "pip", "install"]
+    package_install_command = ["pip", "install"]
     return base_container.with_exec(package_install_command + packages_to_install)
 
 


### PR DESCRIPTION
## What
In the[ `publish` pipeline ](https://github.com/airbytehq/airbyte/actions/runs/4798181638/jobs/8536120015 )the metadata validation step fails because the metadata lib can't be installed:
```
│ │ ModuleNotFoundError: No module named 'click'                             │ │

```

## How
I don't know why exactly but using `pip install` instead of `python -m pip install` fixes the problem.
