### PR TITLE
source-surveycto: bump version in metadata.yaml

### DIFF
--- a/airbyte-integrations/connectors/source-surveycto/metadata.yaml
+++ b/airbyte-integrations/connectors/source-surveycto/metadata.yaml
@@ -7,7 +7,7 @@ data:
   connectorSubtype: api
   connectorType: source
   definitionId: dd4632f4-15e0-4649-9b71-41719fb1fdee
-  dockerImageTag: 0.1.0
+  dockerImageTag: 0.1.1
   dockerRepository: airbyte/source-surveycto
   githubIssueLabel: source-surveycto
   icon: surveycto.svg


### PR DESCRIPTION
Bumping the docker tag in the `metadata.yaml` of this connector to trigger a publish on merge (for testing).