### PR TITLE
[NOT TO BE MERGED] Do not expose substream as stream

### DIFF
--- a/airbyte-integrations/connectors/source-statuspage/integration_tests/configured_catalog.json
+++ b/airbyte-integrations/connectors/source-statuspage/integration_tests/configured_catalog.json
@@ -2,15 +2,6 @@
   "streams": [
     {
       "stream": {
-        "name": "pages",
-        "json_schema": {},
-        "supported_sync_modes": ["full_refresh"]
-      },
-      "sync_mode": "full_refresh",
-      "destination_sync_mode": "overwrite"
-    },
-    {
-      "stream": {
         "name": "subscribers",
         "json_schema": {},
         "supported_sync_modes": ["full_refresh"]

--- a/airbyte-integrations/connectors/source-statuspage/source_statuspage/manifest.yaml
+++ b/airbyte-integrations/connectors/source-statuspage/source_statuspage/manifest.yaml
@@ -138,7 +138,6 @@ definitions:
       record_selector:
         $ref: "#/definitions/selector"
 streams:
-  - "#/definitions/pages_stream"
   - "#/definitions/subscribers_stream"
   - "#/definitions/subscribers_histogram_by_state_stream"
   - "#/definitions/incident_templates_stream"
@@ -147,4 +146,4 @@ streams:
   - "#/definitions/metrics_stream"
 check:
   stream_names:
-    - "pages"
+    - "subscribers"


### PR DESCRIPTION
Draft to show how we can have substreams not exposed

Running `airbyte/airbyte-integrations/connectors/source-statuspage/main.py read --config secrets/config.json --catalog integration_tests/configured_catalog.json` still works without generating errors