### PR TITLE
connectors-ci: new checks to validate connector version

### DIFF
--- a/tools/ci_connector_ops/ci_connector_ops/pipelines/README.md
+++ b/tools/ci_connector_ops/ci_connector_ops/pipelines/README.md
@@ -16,6 +16,7 @@ This documentation should be helpful for both local and CI use of the CLI. We in
 ### Install
 ```bash
 # Make sure that the current Python version is >= 3.10
+pyenv shell 3.10
 pip install "ci-connector-ops[pipelines] @ git+https://github.com/airbytehq/airbyte.git@master#subdirectory=tools/ci_connector_ops"
 cd airbyte
 airbyte-ci
@@ -108,6 +109,11 @@ Test connectors changed on the current branch:
 ```mermaid
 flowchart TD
     entrypoint[[For each selected connector]]
+    subgraph version ["Connector version checks"]
+        sem["Check version follows semantic versionning"]
+        incr["Check version is incremented"]
+        sem --> incr
+    end
     subgraph static ["Static code analysis"]
       qa[Run QA checks]
       fmt[Run code format checks]
@@ -126,8 +132,9 @@ flowchart TD
         build-->integration
         build-->cat
     end
-    entrypoint-->static
-    entrypoint-->tests
+    entrypoint-->version
+    version-->static
+    version-->tests
     report["Build test report"]
     tests-->report
     static-->report

--- a/tools/ci_connector_ops/ci_connector_ops/pipelines/commands/groups/connectors.py
+++ b/tools/ci_connector_ops/ci_connector_ops/pipelines/commands/groups/connectors.py
@@ -107,25 +107,40 @@ def connectors(
         logger=logger,
     )
 
-    selected_connectors = get_all_released_connectors()
-    modified_connectors = get_modified_connectors(ctx.obj["modified_files"])
-    if modified:
-        selected_connectors = modified_connectors
-    else:
-        selected_connectors.update(modified_connectors)
-    if names:
-        selected_connectors = {connector for connector in selected_connectors if connector.technical_name in names}
-    if languages:
-        selected_connectors = {connector for connector in selected_connectors if connector.language in languages}
-    if release_stages:
-        selected_connectors = {connector for connector in selected_connectors if connector.release_stage in release_stages}
+    all_connectors = get_all_released_connectors()
 
-    if not selected_connectors:
+    modified_connectors_and_files = get_modified_connectors(ctx.obj["modified_files"])
+    # We select all connectors by default
+    selected_connectors_and_files = {connector: modified_connectors_and_files.get(connector, []) for connector in all_connectors}
+
+    if names:
+        selected_connectors_and_files = {
+            connector: selected_connectors_and_files[connector]
+            for connector in selected_connectors_and_files
+            if connector.technical_name in names
+        }
+    if languages:
+        selected_connectors_and_files = {
+            connector: selected_connectors_and_files[connector]
+            for connector in selected_connectors_and_files
+            if connector.language in languages
+        }
+    if release_stages:
+        selected_connectors_and_files = {
+            connector: selected_connectors_and_files[connector]
+            for connector in selected_connectors_and_files
+            if connector.release_stage in release_stages
+        }
+    if modified:
+        selected_connectors_and_files = {
+            connector: modified_files for connector, modified_files in selected_connectors_and_files.items() if modified_files
+        }
+    if not selected_connectors_and_files:
         click.secho("No connector were selected according to your inputs. Please double check your filters.", fg="yellow")
         sys.exit(0)
 
-    ctx.obj["selected_connectors"] = selected_connectors
-    ctx.obj["selected_connectors_names"] = [c.technical_name for c in selected_connectors]
+    ctx.obj["selected_connectors_and_files"] = selected_connectors_and_files
+    ctx.obj["selected_connectors_names"] = [c.technical_name for c in selected_connectors_and_files.keys()]
 
 
 @connectors.command(cls=DaggerPipelineCommand, help="Test all the selected connectors.")
@@ -146,12 +161,13 @@ def test(
             ctx.obj["is_local"],
             ctx.obj["git_branch"],
             ctx.obj["git_revision"],
+            modified_files,
             ctx.obj["use_remote_secrets"],
             gha_workflow_run_url=ctx.obj.get("gha_workflow_run_url"),
             pipeline_start_timestamp=ctx.obj.get("pipeline_start_timestamp"),
             ci_context=ctx.obj.get("ci_context"),
         )
-        for connector in ctx.obj["selected_connectors"]
+        for connector, modified_files in ctx.obj["selected_connectors_and_files"].items()
     ]
     try:
         anyio.run(run_connectors_pipelines, connectors_tests_contexts, run_connector_test_pipeline, "Test Pipeline", ctx.obj["concurrency"])
@@ -189,12 +205,13 @@ def build(ctx: click.Context) -> bool:
             ctx.obj["is_local"],
             ctx.obj["git_branch"],
             ctx.obj["git_revision"],
+            modified_files,
             ctx.obj["use_remote_secrets"],
             gha_workflow_run_url=ctx.obj.get("gha_workflow_run_url"),
             pipeline_start_timestamp=ctx.obj.get("pipeline_start_timestamp"),
             ci_context=ctx.obj.get("ci_context"),
         )
-        for connector in ctx.obj["selected_connectors"]
+        for connector, modified_files in ctx.obj["selected_connectors_and_files"].items()
     ]
     anyio.run(run_connectors_pipelines, connectors_contexts, run_connector_build_pipeline, "Build Pipeline", ctx.obj["concurrency"])
 
@@ -246,10 +263,10 @@ def publish(
             abort=True,
         )
     if ctx.obj["modified"]:
-        selected_connectors = get_modified_connectors(get_modified_metadata_files(ctx.obj["modified_files"]))
-        selected_connectors_names = [connector.technical_name for connector in selected_connectors]
+        selected_connectors_and_files = get_modified_connectors(get_modified_metadata_files(ctx.obj["modified_files"]))
+        selected_connectors_names = [connector.technical_name for connector in selected_connectors_and_files.keys()]
     else:
-        selected_connectors = ctx.obj["selected_connectors"]
+        selected_connectors_and_files = ctx.obj["selected_connectors_and_files"]
         selected_connectors_names = ctx.obj["selected_connectors_names"]
 
     click.secho(f"Will publish the following connectors: {', '.join(selected_connectors_names)}.", fg="green")
@@ -263,12 +280,13 @@ def publish(
             ctx.obj["is_local"],
             ctx.obj["git_branch"],
             ctx.obj["git_revision"],
+            modified_files,
             ctx.obj["use_remote_secrets"],
             gha_workflow_run_url=ctx.obj.get("gha_workflow_run_url"),
             pipeline_start_timestamp=ctx.obj.get("pipeline_start_timestamp"),
             ci_context=ctx.obj.get("ci_context"),
         )
-        for connector in selected_connectors
+        for connector, modified_files in selected_connectors_and_files.items()
     ]
     connectors_contexts = anyio.run(
         run_connectors_pipelines,

--- a/tools/ci_connector_ops/ci_connector_ops/pipelines/contexts.py
+++ b/tools/ci_connector_ops/ci_connector_ops/pipelines/contexts.py
@@ -65,6 +65,7 @@ class PipelineContext:
         is_local: bool,
         git_branch: str,
         git_revision: str,
+        modified_files: List[str],
         gha_workflow_run_url: Optional[str] = None,
         pipeline_start_timestamp: Optional[int] = None,
         ci_context: Optional[str] = None,
@@ -77,6 +78,7 @@ class PipelineContext:
             is_local (bool): Whether the context is for a local run or a CI run.
             git_branch (str): The current git branch name.
             git_revision (str): The current git revision, commit hash.
+            modified_files (List[str]): The list of modified files for this context.
             gha_workflow_run_url (Optional[str], optional): URL to the github action workflow run. Only valid for CI run. Defaults to None.
             pipeline_start_timestamp (Optional[int], optional): Timestamp at which the pipeline started. Defaults to None.
             ci_context (Optional[str], optional): Pull requests, workflow dispatch or nightly build. Defaults to None.
@@ -85,13 +87,13 @@ class PipelineContext:
         self.is_local = is_local
         self.git_branch = git_branch
         self.git_revision = git_revision
+        self.modified_files = modified_files
         self.gha_workflow_run_url = gha_workflow_run_url
         self.pipeline_start_timestamp = pipeline_start_timestamp
         self.created_at = datetime.utcnow()
         self.ci_context = ci_context
         self.state = ContextState.INITIALIZED
         self.is_ci_optional = is_ci_optional
-
         self.logger = logging.getLogger(self.pipeline_name)
         self.dagger_client = None
         self._report = None
@@ -249,6 +251,7 @@ class ConnectorContext(PipelineContext):
             is_local (bool): Whether the context is for a local run or a CI run.
             git_branch (str): The current git branch name.
             git_revision (str): The current git revision, commit hash.
+            modified_files (List[str]): The list of modified files for this context.
             use_remote_secrets (bool, optional): Whether to download secrets for GSM or use the local secrets. Defaults to True.
             connector_acceptance_test_image (Optional[str], optional): The image to use to run connector acceptance tests. Defaults to DEFAULT_CONNECTOR_ACCEPTANCE_TEST_IMAGE.
             gha_workflow_run_url (Optional[str], optional): URL to the github action workflow run. Only valid for CI run. Defaults to None.

--- a/tools/ci_connector_ops/ci_connector_ops/pipelines/contexts.py
+++ b/tools/ci_connector_ops/ci_connector_ops/pipelines/contexts.py
@@ -65,7 +65,6 @@ class PipelineContext:
         is_local: bool,
         git_branch: str,
         git_revision: str,
-        modified_files: List[str],
         gha_workflow_run_url: Optional[str] = None,
         pipeline_start_timestamp: Optional[int] = None,
         ci_context: Optional[str] = None,
@@ -78,7 +77,6 @@ class PipelineContext:
             is_local (bool): Whether the context is for a local run or a CI run.
             git_branch (str): The current git branch name.
             git_revision (str): The current git revision, commit hash.
-            modified_files (List[str]): The list of modified files for this context.
             gha_workflow_run_url (Optional[str], optional): URL to the github action workflow run. Only valid for CI run. Defaults to None.
             pipeline_start_timestamp (Optional[int], optional): Timestamp at which the pipeline started. Defaults to None.
             ci_context (Optional[str], optional): Pull requests, workflow dispatch or nightly build. Defaults to None.
@@ -87,13 +85,13 @@ class PipelineContext:
         self.is_local = is_local
         self.git_branch = git_branch
         self.git_revision = git_revision
-        self.modified_files = modified_files
         self.gha_workflow_run_url = gha_workflow_run_url
         self.pipeline_start_timestamp = pipeline_start_timestamp
         self.created_at = datetime.utcnow()
         self.ci_context = ci_context
         self.state = ContextState.INITIALIZED
         self.is_ci_optional = is_ci_optional
+
         self.logger = logging.getLogger(self.pipeline_name)
         self.dagger_client = None
         self._report = None
@@ -251,7 +249,6 @@ class ConnectorContext(PipelineContext):
             is_local (bool): Whether the context is for a local run or a CI run.
             git_branch (str): The current git branch name.
             git_revision (str): The current git revision, commit hash.
-            modified_files (List[str]): The list of modified files for this context.
             use_remote_secrets (bool, optional): Whether to download secrets for GSM or use the local secrets. Defaults to True.
             connector_acceptance_test_image (Optional[str], optional): The image to use to run connector acceptance tests. Defaults to DEFAULT_CONNECTOR_ACCEPTANCE_TEST_IMAGE.
             gha_workflow_run_url (Optional[str], optional): URL to the github action workflow run. Only valid for CI run. Defaults to None.

--- a/tools/ci_connector_ops/ci_connector_ops/pipelines/contexts.py
+++ b/tools/ci_connector_ops/ci_connector_ops/pipelines/contexts.py
@@ -235,6 +235,7 @@ class ConnectorContext(PipelineContext):
         is_local: bool,
         git_branch: bool,
         git_revision: bool,
+        modified_files: List[str],
         use_remote_secrets: bool = True,
         connector_acceptance_test_image: Optional[str] = DEFAULT_CONNECTOR_ACCEPTANCE_TEST_IMAGE,
         gha_workflow_run_url: Optional[str] = None,
@@ -259,7 +260,7 @@ class ConnectorContext(PipelineContext):
         self.connector = connector
         self.use_remote_secrets = use_remote_secrets
         self.connector_acceptance_test_image = connector_acceptance_test_image
-
+        self.modified_files = modified_files
         self._secrets_dir = None
         self._updated_secrets_dir = None
 

--- a/tools/ci_connector_ops/ci_connector_ops/pipelines/tests/common.py
+++ b/tools/ci_connector_ops/ci_connector_ops/pipelines/tests/common.py
@@ -6,6 +6,7 @@
 
 from abc import ABC, abstractmethod
 from functools import cached_property
+from pathlib import Path
 from typing import ClassVar, Optional
 
 import asyncer
@@ -13,7 +14,7 @@ import requests
 import yaml
 from ci_connector_ops.pipelines.actions import environments
 from ci_connector_ops.pipelines.bases import PytestStep, Step, StepResult, StepStatus
-from ci_connector_ops.pipelines.contexts import CIContext
+from ci_connector_ops.pipelines.contexts import CIContext, PipelineContext
 from ci_connector_ops.pipelines.utils import METADATA_FILE_NAME
 from ci_connector_ops.utils import DESTINATION_DEFINITIONS_FILE_PATH, SOURCE_DEFINITIONS_FILE_PATH
 from dagger import File
@@ -26,9 +27,14 @@ class VersionCheck(Step, ABC):
     GITHUB_URL_PREFIX_FOR_CONNECTORS = "https://raw.githubusercontent.com/airbytehq/airbyte/master/airbyte-integrations/connectors"
     failure_message: ClassVar
 
+    def __init__(self, context: PipelineContext, metadata_path: Path) -> None:
+        super().__init__(context)
+        self.current_metadata = yaml.safe_load(metadata_path.read_text())["data"]
+        self.connector_technical_name = self.metadata["dockerRepository"].split("/")[-1]
+
     @property
     def github_master_metadata_url(self):
-        return f"{self.GITHUB_URL_PREFIX_FOR_CONNECTORS}/{self.context.connector.technical_name}/{METADATA_FILE_NAME}"
+        return f"{self.GITHUB_URL_PREFIX_FOR_CONNECTORS}/{self.connector_technical_name}/{METADATA_FILE_NAME}"
 
     @cached_property
     def master_metadata(self) -> dict:
@@ -43,7 +49,7 @@ class VersionCheck(Step, ABC):
 
     @property
     def current_connector_version(self) -> version.Version:
-        return version.parse(str(self.context.metadata["dockerImageTag"]))
+        return version.parse(str(self.current_metadata["dockerImageTag"]))
 
     @property
     def success_result(self) -> StepResult:

--- a/tools/ci_connector_ops/ci_connector_ops/pipelines/utils.py
+++ b/tools/ci_connector_ops/ci_connector_ops/pipelines/utils.py
@@ -162,9 +162,14 @@ async def get_modified_files_in_branch_remote(
 
 
 def get_modified_files_in_branch_local(current_git_revision: str, diffed_branch: str = "master") -> Set[str]:
-    """Use git diff to spot the modified files on the local branch."""
+    """Use git diff and git status to spot the modified files on the local branch."""
     airbyte_repo = git.Repo()
     modified_files = airbyte_repo.git.diff("--diff-filter=MA", "--name-only", f"{diffed_branch}...{current_git_revision}").split("\n")
+    status_output = airbyte_repo.git.status("--porcelain")
+    for not_committed_change in status_output.split("\n"):
+        file_path = not_committed_change.strip().split(" ")[-1]
+        if file_path:
+            modified_files.append(file_path)
     return set(modified_files)
 
 
@@ -215,13 +220,17 @@ def get_modified_files_in_commit(current_git_branch: str, current_git_revision: 
         return anyio.run(get_modified_files_in_commit_remote, current_git_branch, current_git_revision)
 
 
-def get_modified_connectors(modified_files: Set[Union[str, Path]]) -> Set[Connector]:
-    """Create a set of modified connectors according to the modified files on the branch."""
-    modified_connectors = []
+def get_modified_connectors(modified_files: Set[Union[str, Path]]) -> dict[Connector, List[str]]:
+    """Create a mapping of modified connectors (key) and modified files (value)."""
+    modified_connectors = {}
     for file_path in modified_files:
         if str(file_path).startswith(SOURCE_CONNECTOR_PATH_PREFIX) or str(file_path).startswith(DESTINATION_CONNECTOR_PATH_PREFIX):
-            modified_connectors.append(Connector(get_connector_name_from_path(str(file_path))))
-    return set(modified_connectors)
+            modified_connector = Connector(get_connector_name_from_path(str(file_path)))
+            if modified_connector in modified_connectors:
+                modified_connectors[modified_connector].append(file_path)
+            else:
+                modified_connectors[modified_connector] = [file_path]
+    return modified_connectors
 
 
 def get_modified_metadata_files(modified_files: Set[Union[str, Path]]) -> Set[Path]:

--- a/tools/ci_connector_ops/setup.py
+++ b/tools/ci_connector_ops/setup.py
@@ -42,7 +42,7 @@ QA_ENGINE_REQUIREMENTS = [
     "pytablewriter~=0.64.2",
 ]
 
-PIPELINES_REQUIREMENTS = ["dagger-io==0.5.0", "asyncer", "anyio", "more-itertools", "docker"]
+PIPELINES_REQUIREMENTS = ["dagger-io==0.5.0", "asyncer", "anyio", "more-itertools", "docker", "requests", "packaging"]
 
 setup(
     version="0.2.1",

--- a/tools/ci_connector_ops/setup.py
+++ b/tools/ci_connector_ops/setup.py
@@ -42,7 +42,7 @@ QA_ENGINE_REQUIREMENTS = [
     "pytablewriter~=0.64.2",
 ]
 
-PIPELINES_REQUIREMENTS = ["dagger-io==0.5.0", "asyncer", "anyio", "more-itertools", "docker", "requests", "packaging"]
+PIPELINES_REQUIREMENTS = ["dagger-io==0.5.0", "asyncer", "anyio", "more-itertools", "docker", "requests", "semver"]
 
 setup(
     version="0.2.1",


### PR DESCRIPTION
## What
Closes #25329

When a connector is modified we want to enforce a connector version increment in the `metadata.yaml` file in the `dockerImageTag` field.
The version that will eventually be published on merge is pulled from the metadata file, it's why we want to check the version is bumped in this file.


## How
If the CI context is not master and connectors files were modified:
* Check that the `dockerImageTag` in the `metadata.yaml` file follows semantic versionning
* Pull the `master` version of `metadata.yaml` from `raw.github.com`
* Check that the current connector version is an increment of the master version.
