### PR TITLE
Connector builder doc fixes

### DIFF
--- a/docs/connector-development/connector-builder-ui/overview.md
+++ b/docs/connector-development/connector-builder-ui/overview.md
@@ -1,13 +1,13 @@
 # Connector Builder Intro
 
-The connector builder UI provides an ergonomic iteration interface on top of the [low-code YAML format](https://docs.airbyte.com/connector-development/config-based/understanding-the-yaml-file/yaml-overview) and to use built connectors for syncs within the same workspace directly from within the UI. We recommend using it to iterate on your low-code connectors.
+The connector builder UI provides an intuitive UI on top of the [low-code YAML format](https://docs.airbyte.com/connector-development/config-based/understanding-the-yaml-file/yaml-overview) and to use built connectors for syncs within the same workspace directly from within the UI. We recommend using it to iterate on your low-code connectors.
 
 :::caution
 The connector builder UI is in beta, which means it’s still in active development and may include backward-incompatible changes. Share feedback and requests with us on our Slack channel or email us at feedback@airbyte.io
 
-**The connector builder does not yet have a link in the sidebar, to navigate to it manually change the URL path in your browsers address bar to `/<your workspace id>/connector-builder`**
+**The connector builder does not yet have a link in the sidebar, to navigate to it manually change the URL path in your browser's address bar to `/<your workspace id>/connector-builder`**
 
-Developer updates will be announced via our #public-help-connector-development Slack channel. If you are using the CDK, please join to stay up to date on changes and issues.
+Developer updates will be announced via our #help-connector-development Slack channel. If you are using the CDK, please join to stay up to date on changes and issues.
 :::
 
 
@@ -15,7 +15,7 @@ Developer updates will be announced via our #public-help-connector-development S
 
 The connector builder is the right tool if the following points are met:
 * You want to integrate with a JSON-based HTTP API as a source of records
-* The API you want to integrate with doesn't exist yet as a connector in the [connector catalog](./category/sources).
+* The API you want to integrate with doesn't exist yet as a connector in the [connector catalog](/category/sources).
 * The API is suitable for the connector builder as per the
 [compatibility guide](./connector-builder-compatibility.md).
 
@@ -23,7 +23,7 @@ The connector builder is the right tool if the following points are met:
 
 The high level flow for using the connector builder is as follows:
 
-1. Run the Airbyte webapp to access the connector builder
+1. Access the connector builder in the Airbyte webapp
 2. Use the connector builder to iterate on your low-code connector
 3. Once the connector is ready, publish it to the local workspace
 4. Configure a Source based on the released connector
@@ -55,10 +55,10 @@ This section is only relevant if you want to contribute your connector back to t
 
 The connector builder leverages the [low-code CDK](https://docs.airbyte.com/connector-development/config-based/understanding-the-yaml-file/yaml-overview) under the hood, turning all configurations into the YAML format. While in most cases it's not necessary to interact with the YAML representation, it can be used to export the connector specification into a file and build a docker image containing the connector which can be shared more widely:
 
-2. Use the connector builder to iterate on your low-code connector
-3. Export the YAML into a low-code connector module on your local machine
-4. Build the connector's Docker image
-5. Use the built connector image in Airbyte
+1. Use the connector builder to iterate on your low-code connector
+2. Export the YAML into a low-code connector module on your local machine
+3. Build the connector's Docker image
+4. Use the built connector image in Airbyte
 
 Once you're done iterating on your connector in the UI, you'll need to export the low-code YAML representation of the connector to your local filesystem into a connector module. This YAML can be downloaded by clicking the `Download Config` button in the bottom-left.
 

--- a/docs/connector-development/connector-builder-ui/tutorial.mdx
+++ b/docs/connector-development/connector-builder-ui/tutorial.mdx
@@ -45,7 +45,7 @@ Besides an Exchange Rates API key, only a browser and an up-to-date running Airb
 ## Step 2 - Basic configuration
 
 :::caution
-**The connector builder does not yet have a link in the sidebar, to navigate to it manually change the URL path in your browsers address bar to `/<your workspace id>/connector-builder`**
+**The connector builder does not yet have a link in the sidebar, to navigate to it manually change the URL path in your browser's address bar to `/<your workspace id>/connector-builder`**
 :::
 
 ### Creating a connector builder project

--- a/docusaurus/sidebars.js
+++ b/docusaurus/sidebars.js
@@ -40,7 +40,7 @@ const buildAConnector = {
     },
     {
       type: 'category',
-      label: 'Connector builder',
+      label: 'Connector Builder',
       items: [
         'connector-development/connector-builder-ui/overview',
         'connector-development/connector-builder-ui/connector-builder-compatibility',
@@ -49,6 +49,7 @@ const buildAConnector = {
           type: 'category',
           label: 'Concepts',
           items: [
+            'connector-development/connector-builder-ui/authentication',
             'connector-development/connector-builder-ui/record-processing',
             'connector-development/connector-builder-ui/pagination',
             'connector-development/connector-builder-ui/incremental-sync',


### PR DESCRIPTION
A couple small fixes to the newly introduced connector builder documentation:
* Improve wording
* Fix typo
* Fix broken link and wrong slack channel name
* Add missing section to the sidebar