### PR TITLE
Remove checklist from PR template

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -17,30 +17,30 @@
 *If there are breaking changes, please merge this PR with the 🚨🚨 emoji so changelog authors can further highlight this if needed.*
 
 
-## Pre-merge Checklist
+## Pre-merge Actions
 *Expand the relevant checklist and delete the others.*
 
 <details><summary><strong>New Connector</strong></summary>
 
 ### Community member or Airbyter
 
-- [ ] **Community member?** Grant edit access to maintainers ([instructions](https://docs.github.com/en/github/collaborating-with-pull-requests/working-with-forks/allowing-changes-to-a-pull-request-branch-created-from-a-fork#enabling-repository-maintainer-permissions-on-existing-pull-requests))
-- [ ] Unit & integration tests added and passing. Community members, please provide proof of success locally e.g: screenshot or copy-paste unit, integration, and acceptance test output. To run acceptance tests for a Python connector, follow instructions in the README. For java connectors run `./gradlew :airbyte-integrations:connectors:<name>:integrationTest`.
-- [ ] Connector version is set to `0.0.1`
-    - [ ] `Dockerfile` has version `0.0.1`
-- [ ] Documentation updated
-    - [ ] Connector's `README.md`
-    - [ ] Connector's `bootstrap.md`. See [description and examples](https://docs.google.com/document/d/1ypdgmwmEHWv-TrO4_YOQ7pAJGVrMp5BOkEVh831N260/edit?usp=sharing)
-    - [ ] `docs/integrations/<source or destination>/<name>.md` including changelog with an entry for the initial version. See changelog [example](https://docs.airbyte.io/integrations/sources/stripe#changelog)
-    - [ ] `docs/integrations/README.md`
+- **Community member?** Grant edit access to maintainers ([instructions](https://docs.github.com/en/github/collaborating-with-pull-requests/working-with-forks/allowing-changes-to-a-pull-request-branch-created-from-a-fork#enabling-repository-maintainer-permissions-on-existing-pull-requests))
+- Unit & integration tests added and passing. Community members, please provide proof of success locally e.g: screenshot or copy-paste unit, integration, and acceptance test output. To run acceptance tests for a Python connector, follow instructions in the README. For java connectors run `./gradlew :airbyte-integrations:connectors:<name>:integrationTest`.
+- Connector version is set to `0.0.1`
+    - `Dockerfile` has version `0.0.1`
+- Documentation updated
+    - Connector's `README.md`
+    - Connector's `bootstrap.md`. See [description and examples](https://docs.google.com/document/d/1ypdgmwmEHWv-TrO4_YOQ7pAJGVrMp5BOkEVh831N260/edit?usp=sharing)
+    - `docs/integrations/<source or destination>/<name>.md` including changelog with an entry for the initial version. See changelog [example](https://docs.airbyte.io/integrations/sources/stripe#changelog)
+    - `docs/integrations/README.md`
 
 ### Airbyter
 
 If this is a community PR, the Airbyte engineer reviewing this PR is responsible for the below items.
 
-- [ ] Create a non-forked branch based on this PR and test the below items on it
-- [ ] Build is successful
-- [ ] If new credentials are required for use in CI, add them to GSM. [Instructions](https://docs.airbyte.io/connector-development#using-credentials-in-ci).
+- Create a non-forked branch based on this PR and test the below items on it
+- Build is successful
+- If new credentials are required for use in CI, add them to GSM. [Instructions](https://docs.airbyte.io/connector-development#using-credentials-in-ci).
 
 </details>
 
@@ -48,26 +48,26 @@ If this is a community PR, the Airbyte engineer reviewing this PR is responsible
 
 ### Community member or Airbyter
 
-- [ ] Grant edit access to maintainers ([instructions](https://docs.github.com/en/github/collaborating-with-pull-requests/working-with-forks/allowing-changes-to-a-pull-request-branch-created-from-a-fork#enabling-repository-maintainer-permissions-on-existing-pull-requests))
-- [ ] Unit & integration tests added
+- Grant edit access to maintainers ([instructions](https://docs.github.com/en/github/collaborating-with-pull-requests/working-with-forks/allowing-changes-to-a-pull-request-branch-created-from-a-fork#enabling-repository-maintainer-permissions-on-existing-pull-requests))
+- Unit & integration tests added
 
 
 ### Airbyter
 
 If this is a community PR, the Airbyte engineer reviewing this PR is responsible for the below items.
 
-- [ ] Create a non-forked branch based on this PR and test the below items on it
-- [ ] Build is successful
-- [ ] If new credentials are required for use in CI, add them to GSM. [Instructions](https://docs.airbyte.io/connector-development#using-credentials-in-ci).
+- Create a non-forked branch based on this PR and test the below items on it
+- Build is successful
+- If new credentials are required for use in CI, add them to GSM. [Instructions](https://docs.airbyte.io/connector-development#using-credentials-in-ci).
 
 </details>
 
 <details><summary><strong>Connector Generator</strong></summary>
 
-- [ ] Issue acceptance criteria met
-- [ ] PR name follows [PR naming conventions](https://docs.airbyte.com/contributing-to-airbyte/issues-and-pull-requests)
-- [ ] If adding a new generator, add it to the [list of scaffold modules being tested](https://github.com/airbytehq/airbyte/blob/master/airbyte-integrations/connector-templates/generator/build.gradle#L41)
-- [ ] The generator test modules (all connectors with `-scaffold` in their name) have been updated with the latest scaffold by running `./gradlew :airbyte-integrations:connector-templates:generator:testScaffoldTemplates` then checking in your changes
-- [ ] Documentation which references the generator is updated as needed
+- Issue acceptance criteria met
+- PR name follows [PR naming conventions](https://docs.airbyte.com/contributing-to-airbyte/issues-and-pull-requests)
+- If adding a new generator, add it to the [list of scaffold modules being tested](https://github.com/airbytehq/airbyte/blob/master/airbyte-integrations/connector-templates/generator/build.gradle#L41)
+- The generator test modules (all connectors with `-scaffold` in their name) have been updated with the latest scaffold by running `./gradlew :airbyte-integrations:connector-templates:generator:testScaffoldTemplates` then checking in your changes
+- Documentation which references the generator is updated as needed
 
 </details>

--- a/.github/workflows/connector_checklist.yml
+++ b/.github/workflows/connector_checklist.yml
@@ -1,7 +1,7 @@
 name: Add Connector Merge Checklist
 on:
   pull_request:
-    types: [opened]
+    types: [opened, reopened]
     paths:
       - "airbyte-integrations/connectors/source-**"
       - "airbyte-integrations/connectors/destination-**"
@@ -17,7 +17,7 @@ jobs:
         uses: wyozi/contextual-qa-checklist-action@master
         with:
           comment-header: "### Before Merging a Connector Pull Request \n\n Wow! What a great pull request you have here! 🎉 \n\n To merge this PR, ensure the following has been done/considered for each connector added or updated: \n\n"
-          comment-footer: "If the checklist is complete, but the CI check is failing, toggle the github label `checklist-action-run` on/off to re-run the checklist."
+          comment-footer: "If the checklist is complete, but the CI check is failing, \n\n1. Check for hidden checklists in your PR description \n\n2. Toggle the github label `checklist-action-run` on/off to re-run the checklist CI."
           show-paths: false
           input-file: airbyte-ci/connectors/CONNECTOR_CHECKLIST.yaml
           gh-token: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/connector_checklist_require.yml
+++ b/.github/workflows/connector_checklist_require.yml
@@ -11,6 +11,12 @@ jobs:
     name: Require Connector Merge Checklist Job
     runs-on: ubuntu-latest
     steps:
-      - uses: mheap/require-checklist-action@v2
+      - name: Ensure All Checklist Checked
+        uses: mheap/require-checklist-action@v2
         with:
           requireChecklist: false # TODO (ben) reenable in one week once pull request templates have been updated
+      - name: Send Error Message
+        if: failure()
+        run: |
+          echo "::error::All checklist items not checked. Review your PR description and comments for unchecked items."
+          exit 1

--- a/.github/workflows/connector_checklist_require.yml
+++ b/.github/workflows/connector_checklist_require.yml
@@ -13,4 +13,4 @@ jobs:
     steps:
       - uses: mheap/require-checklist-action@v2
         with:
-          requireChecklist: true # If this is true and there are no checklists detected, the action will fail
+          requireChecklist: false # TODO (ben) reenable in one week once pull request templates have been updated


### PR DESCRIPTION
## What
There were a few problems that came together for subtley failing builds

1. Many PRs have checklist hidden/ignored in the description
2. PRs created before the checklist action was added, meant required checklist but no checklist added

## How this fixes that
1. Mark that checklists are not needed (for now)
2. Remove checklist from template