### PR TITLE
Source S3: fix CAT tests

### DIFF
--- a/airbyte-integrations/connectors/source-s3/integration_tests/integration_test.py
+++ b/airbyte-integrations/connectors/source-s3/integration_tests/integration_test.py
@@ -70,8 +70,12 @@ class TestIncrementalFileStreamS3(AbstractTestIncrementalFileStream):
         try:
             self.s3_client.head_bucket(Bucket=bucket_name)
         except ClientError:
-            acl = "private" if private else "public-read"
-            self.s3_client.create_bucket(ACL=acl, Bucket=bucket_name, CreateBucketConfiguration=location)
+            if private:
+                self.s3_client.create_bucket(Bucket=bucket_name, CreateBucketConfiguration=location)
+            else:
+                self.s3_client.create_bucket(Bucket=bucket_name, CreateBucketConfiguration=location, ObjectOwnership='ObjectWriter')
+                self.s3_client.delete_public_access_block(Bucket=bucket_name)
+                self.s3_client.put_bucket_acl(Bucket=bucket_name, ACL='public-read')
 
         # wait here until the bucket is ready
         ready = False


### PR DESCRIPTION
## What
After this:
https://aws.amazon.com/it/about-aws/whats-new/2022/12/amazon-s3-automatically-enable-block-public-access-disable-access-control-lists-buckets-april-2023/

Source S3 CAT tests started to fail