### PR TITLE
[ISSUE #25646] support parsing of non utc dates

### DIFF
--- a/airbyte-cdk/python/airbyte_cdk/sources/declarative/datetime/datetime_parser.py
+++ b/airbyte-cdk/python/airbyte_cdk/sources/declarative/datetime/datetime_parser.py
@@ -16,7 +16,7 @@ class DatetimeParser:
     Instead of using the directive directly, we can use datetime.fromtimestamp and dt.timestamp()
     """
 
-    def parse(self, date: Union[str, int], format: str, timezone):
+    def parse(self, date: Union[str, int], format: str):
         # "%s" is a valid (but unreliable) directive for formatting, but not for parsing
         # It is defined as
         # The number of seconds since the Epoch, 1970-01-01 00:00:00+0000 (UTC). https://man7.org/linux/man-pages/man3/strptime.3.html
@@ -24,11 +24,11 @@ class DatetimeParser:
         # The recommended way to parse a date from its timestamp representation is to use datetime.fromtimestamp
         # See https://stackoverflow.com/a/4974930
         if format == "%s":
-            return datetime.datetime.fromtimestamp(int(date), tz=timezone)
+            return datetime.datetime.fromtimestamp(int(date), tz=datetime.timezone.utc)
 
         parsed_datetime = datetime.datetime.strptime(str(date), format)
         if self._is_naive(parsed_datetime):
-            return parsed_datetime.replace(tzinfo=timezone)
+            return parsed_datetime.replace(tzinfo=datetime.timezone.utc)
         return parsed_datetime
 
     def format(self, dt: datetime.datetime, format: str) -> str:

--- a/airbyte-cdk/python/airbyte_cdk/sources/declarative/datetime/datetime_parser.py
+++ b/airbyte-cdk/python/airbyte_cdk/sources/declarative/datetime/datetime_parser.py
@@ -25,8 +25,11 @@ class DatetimeParser:
         # See https://stackoverflow.com/a/4974930
         if format == "%s":
             return datetime.datetime.fromtimestamp(int(date), tz=timezone)
-        else:
+
+        parsed_datetime = datetime.datetime.strptime(str(date), format)
+        if self._is_naive(parsed_datetime):
             return datetime.datetime.strptime(str(date), format).replace(tzinfo=timezone)
+        return parsed_datetime
 
     def format(self, dt: datetime.datetime, format: str) -> str:
         # strftime("%s") is unreliable because it ignores the time zone information and assumes the time zone of the system it's running on
@@ -36,3 +39,6 @@ class DatetimeParser:
             return str(int(dt.timestamp()))
         else:
             return dt.strftime(format)
+
+    def _is_naive(self, dt: datetime.datetime) -> bool:
+        return dt.tzinfo is None or dt.tzinfo.utcoffset(dt) is None

--- a/airbyte-cdk/python/airbyte_cdk/sources/declarative/datetime/datetime_parser.py
+++ b/airbyte-cdk/python/airbyte_cdk/sources/declarative/datetime/datetime_parser.py
@@ -28,7 +28,7 @@ class DatetimeParser:
 
         parsed_datetime = datetime.datetime.strptime(str(date), format)
         if self._is_naive(parsed_datetime):
-            return datetime.datetime.strptime(str(date), format).replace(tzinfo=timezone)
+            return parsed_datetime.replace(tzinfo=timezone)
         return parsed_datetime
 
     def format(self, dt: datetime.datetime, format: str) -> str:

--- a/airbyte-cdk/python/airbyte_cdk/sources/declarative/datetime/min_max_datetime.py
+++ b/airbyte-cdk/python/airbyte_cdk/sources/declarative/datetime/min_max_datetime.py
@@ -39,12 +39,9 @@ class MinMaxDatetime:
 
     def __post_init__(self, parameters: Mapping[str, Any]):
         self.datetime = InterpolatedString.create(self.datetime, parameters=parameters or {})
-        self.timezone = dt.timezone.utc
         self._parser = DatetimeParser()
         self.min_datetime = InterpolatedString.create(self.min_datetime, parameters=parameters) if self.min_datetime else None
         self.max_datetime = InterpolatedString.create(self.max_datetime, parameters=parameters) if self.max_datetime else None
-
-        self._timezone = dt.timezone.utc
 
     def get_datetime(self, config, **additional_parameters) -> dt.datetime:
         """
@@ -58,17 +55,17 @@ class MinMaxDatetime:
         if not datetime_format:
             datetime_format = "%Y-%m-%dT%H:%M:%S.%f%z"
 
-        time = self._parser.parse(str(self.datetime.eval(config, **additional_parameters)), datetime_format, self.timezone)
+        time = self._parser.parse(str(self.datetime.eval(config, **additional_parameters)), datetime_format)
 
         if self.min_datetime:
             min_time = str(self.min_datetime.eval(config, **additional_parameters))
             if min_time:
-                min_time = self._parser.parse(min_time, datetime_format, self.timezone)
+                min_time = self._parser.parse(min_time, datetime_format)
                 time = max(time, min_time)
         if self.max_datetime:
             max_time = str(self.max_datetime.eval(config, **additional_parameters))
             if max_time:
-                max_time = self._parser.parse(max_time, datetime_format, self.timezone)
+                max_time = self._parser.parse(max_time, datetime_format)
                 time = min(time, max_time)
         return time
 

--- a/airbyte-cdk/python/airbyte_cdk/sources/declarative/incremental/datetime_based_cursor.py
+++ b/airbyte-cdk/python/airbyte_cdk/sources/declarative/incremental/datetime_based_cursor.py
@@ -159,7 +159,7 @@ class DatetimeBasedCursor(StreamSlicer):
         return comparator(cursor_date, default_date)
 
     def parse_date(self, date: str) -> datetime.datetime:
-        return self._parser.parse(date, self.datetime_format, self._timezone)
+        return self._parser.parse(date, self.datetime_format)
 
     @classmethod
     def _parse_timedelta(cls, time_str) -> Union[datetime.timedelta, Duration]:

--- a/airbyte-cdk/python/unit_tests/sources/declarative/datetime/test_datetime_parser.py
+++ b/airbyte-cdk/python/unit_tests/sources/declarative/datetime/test_datetime_parser.py
@@ -34,7 +34,7 @@ from airbyte_cdk.sources.declarative.datetime.datetime_parser import DatetimePar
 )
 def test_parse_date(test_name, input_date, date_format, expected_output_date):
     parser = DatetimeParser()
-    output_date = parser.parse(input_date, date_format, datetime.timezone.utc)
+    output_date = parser.parse(input_date, date_format)
     assert expected_output_date == output_date
 
 

--- a/airbyte-cdk/python/unit_tests/sources/declarative/datetime/test_datetime_parser.py
+++ b/airbyte-cdk/python/unit_tests/sources/declarative/datetime/test_datetime_parser.py
@@ -18,6 +18,12 @@ from airbyte_cdk.sources.declarative.datetime.datetime_parser import DatetimePar
             datetime.datetime(2021, 1, 1, 0, 0, tzinfo=datetime.timezone.utc),
         ),
         (
+                "test_parse_date_iso_with_timezone_not_utc",
+                "2021-01-01T00:00:00.000000+0400",
+                "%Y-%m-%dT%H:%M:%S.%f%z",
+                datetime.datetime(2021, 1, 1, 0, 0, tzinfo=datetime.timezone(datetime.timedelta(seconds=14400))),
+        ),
+        (
             "test_parse_timestamp",
             "1609459200",
             "%s",

--- a/airbyte-cdk/python/unit_tests/sources/declarative/parsers/test_model_to_component_factory.py
+++ b/airbyte-cdk/python/unit_tests/sources/declarative/parsers/test_model_to_component_factory.py
@@ -437,7 +437,6 @@ def test_datetime_based_cursor():
     stream_slicer = factory.create_component(model_type=DatetimeBasedCursorModel, component_definition=slicer_manifest, config=input_config)
 
     assert isinstance(stream_slicer, DatetimeBasedCursor)
-    assert stream_slicer._timezone == datetime.timezone.utc
     assert stream_slicer._step == datetime.timedelta(days=10)
     assert stream_slicer.cursor_field.string == "created"
     assert stream_slicer.cursor_granularity == "PT0.000001S"
@@ -451,7 +450,6 @@ def test_datetime_based_cursor():
 
     assert isinstance(stream_slicer.start_datetime, MinMaxDatetime)
     assert stream_slicer.start_datetime._datetime_format == "%Y-%m-%dT%H:%M:%S.%f%z"
-    assert stream_slicer.start_datetime._timezone == datetime.timezone.utc
     assert stream_slicer.start_datetime.datetime.string == "{{ config['start_time'] }}"
     assert stream_slicer.start_datetime.min_datetime.string == "{{ config['start_time'] + day_delta(2) }}"
 


### PR DESCRIPTION
## What
Addresses https://github.com/airbytehq/airbyte/issues/25646

## How
Only assume UTC datetime when the parsed datetime is naive 

## 🚨 User Impact 🚨
It safe to deploy without migration because this is actually fixing an issue that occurs today i.e. today if an API returns a datetime with a timezone, we strip this timezone and:
* have duplicate if the timezone is -X (for example `2023-04-27T06:29:50-01:00` is converted to `2023-04-27T06:29:50-00:00` which is actually one hour less and therefore the records between `2023-04-27T06:29:50-00:00` and `2023-04-27T07:29:50-00:00` will be fetched twice)
* have missing records if the timezone is +X
