### PR TITLE
🐛 Source Hubspot: check for non-valid `start_date` in input configuration

### DIFF
--- a/airbyte-config-oss/init-oss/src/main/resources/seed/oss_catalog.json
+++ b/airbyte-config-oss/init-oss/src/main/resources/seed/oss_catalog.json
@@ -15437,7 +15437,7 @@
     "sourceDefinitionId": "36c891d9-4bd9-43ac-bad2-10e12756272c",
     "name": "HubSpot",
     "dockerRepository": "airbyte/source-hubspot",
-    "dockerImageTag": "0.6.1",
+    "dockerImageTag": "0.6.2",
     "documentationUrl": "https://docs.airbyte.com/integrations/sources/hubspot",
     "icon": "hubspot.svg",
     "sourceType": "api",

--- a/airbyte-config-oss/init-oss/src/main/resources/seed/source_definitions.yaml
+++ b/airbyte-config-oss/init-oss/src/main/resources/seed/source_definitions.yaml
@@ -943,7 +943,7 @@
 - name: HubSpot
   sourceDefinitionId: 36c891d9-4bd9-43ac-bad2-10e12756272c
   dockerRepository: airbyte/source-hubspot
-  dockerImageTag: 0.6.1
+  dockerImageTag: 0.6.2
   documentationUrl: https://docs.airbyte.com/integrations/sources/hubspot
   icon: hubspot.svg
   sourceType: api

--- a/airbyte-config-oss/init-oss/src/main/resources/seed/source_specs.yaml
+++ b/airbyte-config-oss/init-oss/src/main/resources/seed/source_specs.yaml
@@ -6968,7 +6968,7 @@
     supportsNormalization: false
     supportsDBT: false
     supported_destination_sync_modes: []
-- dockerImage: "airbyte/source-hubspot:0.6.1"
+- dockerImage: "airbyte/source-hubspot:0.6.2"
   spec:
     documentationUrl: "https://docs.airbyte.com/integrations/sources/hubspot"
     connectionSpecification:

--- a/airbyte-integrations/connectors/source-hubspot/Dockerfile
+++ b/airbyte-integrations/connectors/source-hubspot/Dockerfile
@@ -34,5 +34,5 @@ COPY source_hubspot ./source_hubspot
 ENV AIRBYTE_ENTRYPOINT "python /airbyte/integration_code/main.py"
 ENTRYPOINT ["python", "/airbyte/integration_code/main.py"]
 
-LABEL io.airbyte.version=0.6.1
+LABEL io.airbyte.version=0.6.2
 LABEL io.airbyte.name=airbyte/source-hubspot

--- a/airbyte-integrations/connectors/source-hubspot/metadata.yaml
+++ b/airbyte-integrations/connectors/source-hubspot/metadata.yaml
@@ -10,7 +10,7 @@ data:
   connectorSubtype: api
   connectorType: source
   definitionId: 36c891d9-4bd9-43ac-bad2-10e12756272c
-  dockerImageTag: 0.4.0
+  dockerImageTag: 0.6.2
   dockerRepository: airbyte/source-hubspot
   githubIssueLabel: source-hubspot
   icon: hubspot.svg

--- a/airbyte-integrations/connectors/source-hubspot/source_hubspot/errors.py
+++ b/airbyte-integrations/connectors/source-hubspot/source_hubspot/errors.py
@@ -3,6 +3,8 @@
 #
 
 
+from typing import Any
+
 from requests import HTTPError
 
 
@@ -31,3 +33,12 @@ class HubspotAccessDenied(HubspotError):
 
 class HubspotRateLimited(HubspotError):
     """429 Rate Limit Reached"""
+
+
+class InvalidStartDateConfigError(Exception):
+    """Raises when the User inputs wrong or invalid `start_date` in inout configuration"""
+
+    def __init__(self, actual_value: Any, message: str):
+        super().__init__(
+            f"The value for `start_date` entered `{actual_value}` is ivalid and could not be processed.\nPlease use the real date/time value.\nFull message: {message}"
+        )

--- a/airbyte-integrations/connectors/source-hubspot/source_hubspot/streams.py
+++ b/airbyte-integrations/connectors/source-hubspot/source_hubspot/streams.py
@@ -22,7 +22,7 @@ from airbyte_cdk.sources.streams.http.requests_native_auth import Oauth2Authenti
 from airbyte_cdk.sources.utils.transform import TransformConfig, TypeTransformer
 from requests import codes
 from source_hubspot.constants import OAUTH_CREDENTIALS, PRIVATE_APP_CREDENTIALS
-from source_hubspot.errors import HubspotAccessDenied, HubspotInvalidAuth, HubspotRateLimited, HubspotTimeout
+from source_hubspot.errors import HubspotAccessDenied, HubspotInvalidAuth, HubspotRateLimited, HubspotTimeout, InvalidStartDateConfigError
 from source_hubspot.helpers import APIv1Property, APIv3Property, GroupByKey, IRecordPostProcessor, IURLPropertyRepresentation, StoreAsIs
 
 # we got this when provided API Token has incorrect format
@@ -254,7 +254,10 @@ class Stream(HttpStream, ABC):
 
         self._start_date = start_date
         if isinstance(self._start_date, str):
-            self._start_date = pendulum.parse(self._start_date)
+            try:
+                self._start_date = pendulum.parse(self._start_date)
+            except pendulum.parsing.exceptions.ParserError as e:
+                raise InvalidStartDateConfigError(self._start_date, e)
         creds_title = self._credentials["credentials_title"]
         if creds_title in (OAUTH_CREDENTIALS, PRIVATE_APP_CREDENTIALS):
             self._authenticator = api.get_authenticator()

--- a/airbyte-integrations/connectors/source-hubspot/unit_tests/conftest.py
+++ b/airbyte-integrations/connectors/source-hubspot/unit_tests/conftest.py
@@ -37,6 +37,11 @@ def config_fixture():
     return {"start_date": "2021-01-10T00:00:00Z", "credentials": {"credentials_title": "Private App Credentials", "access_token": "test_access_token"}}
 
 
+@pytest.fixture(name="config_invalid_date")
+def config_invalid_date_fixture():
+    return {"start_date": "2000-00-00T00:00:00Z", "credentials": {"credentials_title": "Private App Credentials", "access_token": "test_access_token"}}
+
+
 @pytest.fixture(name="some_credentials")
 def some_credentials_fixture():
     return {"credentials_title": "Private App Credentials", "access_token": "wrong token"}

--- a/airbyte-integrations/connectors/source-hubspot/unit_tests/test_source.py
+++ b/airbyte-integrations/connectors/source-hubspot/unit_tests/test_source.py
@@ -10,7 +10,7 @@ from unittest.mock import MagicMock
 import pendulum
 import pytest
 from airbyte_cdk.models import ConfiguredAirbyteCatalog, SyncMode, Type
-from source_hubspot.errors import HubspotRateLimited
+from source_hubspot.errors import HubspotRateLimited, InvalidStartDateConfigError
 from source_hubspot.helpers import APIv3Property
 from source_hubspot.source import SourceHubspot
 from source_hubspot.streams import API, Companies, Deals, Engagements, MarketingEmails, Products, Stream
@@ -59,6 +59,13 @@ def test_check_connection_exception(config):
 
     assert not ok
     assert error_msg
+
+
+def test_check_connection_invalid_start_date_exception(config_invalid_date):
+    with pytest.raises(InvalidStartDateConfigError):
+        ok, error_msg = SourceHubspot().check_connection(logger, config=config_invalid_date)
+        assert not ok
+        assert error_msg
 
 
 def test_streams(config):

--- a/docs/integrations/sources/hubspot.md
+++ b/docs/integrations/sources/hubspot.md
@@ -137,6 +137,7 @@ Now that you have set up the Hubspot source connector, check out the following H
 
 | Version | Date       | Pull Request                                             | Subject                                                                                                                                                    |
 |:--------|:-----------|:---------------------------------------------------------|:-----------------------------------------------------------------------------------------------------------------------------------------------------------|
+| 0.6.2   | 2023-04-28 | [25667](https://github.com/airbytehq/airbyte/pull/25667) | Fixed bug with `Invalid Date` like `2000-00-00T00:00:00Z` while settip up the connector  |
 | 0.6.1   | 2023-04-10 | [21423](https://github.com/airbytehq/airbyte/pull/21423) | Update scope for `DealPipelines` stream to only `crm.objects.contacts.read`                                                                                |
 | 0.6.0   | 2023-04-07 | [24980](https://github.com/airbytehq/airbyte/pull/24980) | Add new stream `DealsArchived`                                                                                                                             |
 | 0.5.2   | 2023-04-07 | [24915](https://github.com/airbytehq/airbyte/pull/24915) | Fix field key parsing (replace whitespace with uderscore)                                                                                                  |


### PR DESCRIPTION
## What
Resolving: https://github.com/airbytehq/oncall/issues/1928

## How
- added `try...catch` to catch non-valid `date-time` values while `check` 
- added `unit_test` to cover the case

## Recommended reading order
2. `y.python`

## 🚨 User Impact 🚨
No impact is expected, this is non breaking change.


## Pre-merge Actions
*Expand the relevant checklist and delete the others.*

<details><summary><strong>New Connector</strong></summary>

### Community member or Airbyter

- **Community member?** Grant edit access to maintainers ([instructions](https://docs.github.com/en/github/collaborating-with-pull-requests/working-with-forks/allowing-changes-to-a-pull-request-branch-created-from-a-fork#enabling-repository-maintainer-permissions-on-existing-pull-requests))
- Unit & integration tests added and passing. Community members, please provide proof of success locally e.g: screenshot or copy-paste unit, integration, and acceptance test output. To run acceptance tests for a Python connector, follow instructions in the README. For java connectors run `./gradlew :airbyte-integrations:connectors:<name>:integrationTest`.
- Connector version is set to `0.0.1`
    - `Dockerfile` has version `0.0.1`
- Documentation updated
    - Connector's `README.md`
    - Connector's `bootstrap.md`. See [description and examples](https://docs.google.com/document/d/1ypdgmwmEHWv-TrO4_YOQ7pAJGVrMp5BOkEVh831N260/edit?usp=sharing)
    - `docs/integrations/<source or destination>/<name>.md` including changelog with an entry for the initial version. See changelog [example](https://docs.airbyte.io/integrations/sources/stripe#changelog)
    - `docs/integrations/README.md`

### Airbyter

If this is a community PR, the Airbyte engineer reviewing this PR is responsible for the below items.

- Create a non-forked branch based on this PR and test the below items on it
- Build is successful
- If new credentials are required for use in CI, add them to GSM. [Instructions](https://docs.airbyte.io/connector-development#using-credentials-in-ci).

</details>

<details><summary><strong>Updating a connector</strong></summary>

### Community member or Airbyter

- Grant edit access to maintainers ([instructions](https://docs.github.com/en/github/collaborating-with-pull-requests/working-with-forks/allowing-changes-to-a-pull-request-branch-created-from-a-fork#enabling-repository-maintainer-permissions-on-existing-pull-requests))
- Unit & integration tests added


### Airbyter

If this is a community PR, the Airbyte engineer reviewing this PR is responsible for the below items.

- Create a non-forked branch based on this PR and test the below items on it
- Build is successful
- If new credentials are required for use in CI, add them to GSM. [Instructions](https://docs.airbyte.io/connector-development#using-credentials-in-ci).

</details>

<details><summary><strong>Connector Generator</strong></summary>

- Issue acceptance criteria met
- PR name follows [PR naming conventions](https://docs.airbyte.com/contributing-to-airbyte/issues-and-pull-requests)
- If adding a new generator, add it to the [list of scaffold modules being tested](https://github.com/airbytehq/airbyte/blob/master/airbyte-integrations/connector-templates/generator/build.gradle#L41)
- The generator test modules (all connectors with `-scaffold` in their name) have been updated with the latest scaffold by running `./gradlew :airbyte-integrations:connector-templates:generator:testScaffoldTemplates` then checking in your changes
- Documentation which references the generator is updated as needed

</details>
