### PR TITLE
[ISSUE #24720] connector builder set slice descriptor

### DIFF
--- a/airbyte-cdk/python/airbyte_cdk/connector_builder/message_grouper.py
+++ b/airbyte-cdk/python/airbyte_cdk/connector_builder/message_grouper.py
@@ -6,19 +6,12 @@ import json
 import logging
 from copy import deepcopy
 from json import JSONDecodeError
-from typing import Any, Iterable, Iterator, List, Mapping, Optional, Union
+from typing import Any, Dict, Iterable, Iterator, List, Mapping, Optional, Union
 from urllib.parse import parse_qs, urlparse
 
-from airbyte_cdk.connector_builder.models import (
-    HttpRequest,
-    HttpResponse,
-    LogMessage,
-    StreamRead,
-    StreamReadPages,
-    StreamReadSlices,
-    StreamReadSlicesInner,
-)
+from airbyte_cdk.connector_builder.models import HttpRequest, HttpResponse, LogMessage, StreamRead, StreamReadPages, StreamReadSlices
 from airbyte_cdk.entrypoint import AirbyteEntrypoint
+from airbyte_cdk.sources import AbstractSource
 from airbyte_cdk.sources.declarative.declarative_source import DeclarativeSource
 from airbyte_cdk.utils import AirbyteTracedException
 from airbyte_cdk.utils.schema_inferrer import SchemaInferrer
@@ -104,6 +97,7 @@ class MessageGrouper:
         records_count = 0
         at_least_one_page_in_group = False
         current_page_records = []
+        current_slice_descriptor: Dict[str, Any] = None
         current_slice_pages = []
         current_page_request: Optional[HttpRequest] = None
         current_page_response: Optional[HttpResponse] = None
@@ -115,10 +109,14 @@ class MessageGrouper:
                 current_page_request = None
                 current_page_response = None
 
-            if at_least_one_page_in_group and message.type == MessageType.LOG and message.log.message.startswith("slice:"):
-                yield StreamReadSlices(pages=current_slice_pages)
+            if at_least_one_page_in_group and message.type == MessageType.LOG and message.log.message.startswith(AbstractSource.SLICE_LOG_PREFIX):
+                yield StreamReadSlices(pages=current_slice_pages, slice_descriptor=current_slice_descriptor)
+                current_slice_descriptor = self._parse_slice_description(message.log.message)
                 current_slice_pages = []
                 at_least_one_page_in_group = False
+            elif message.type == MessageType.LOG and message.log.message.startswith(AbstractSource.SLICE_LOG_PREFIX):
+                # parsing the first slice
+                current_slice_descriptor = self._parse_slice_description(message.log.message)
             elif message.type == MessageType.LOG and message.log.message.startswith("request:"):
                 if not at_least_one_page_in_group:
                     at_least_one_page_in_group = True
@@ -139,7 +137,7 @@ class MessageGrouper:
                 schema_inferrer.accumulate(message.record)
         else:
             self._close_page(current_page_request, current_page_response, current_slice_pages, current_page_records, validate_page_complete=not had_error)
-            yield StreamReadSlices(pages=current_slice_pages)
+            yield StreamReadSlices(pages=current_slice_pages, slice_descriptor=current_slice_descriptor)
 
     @staticmethod
     def _need_to_close_page(at_least_one_page_in_group: bool, message: AirbyteMessage) -> bool:
@@ -207,7 +205,7 @@ class MessageGrouper:
             self.logger.warning(f"Failed to parse log message into response object with error: {error}")
             return None
 
-    def _has_reached_limit(self, slices: List[StreamReadSlicesInner]):
+    def _has_reached_limit(self, slices: List[StreamReadPages]):
         if len(slices) >= self._max_slices:
             return True
 
@@ -215,6 +213,9 @@ class MessageGrouper:
             if len(slice.pages) >= self._max_pages_per_slice:
                 return True
         return False
+
+    def _parse_slice_description(self, log_message):
+        return json.loads(log_message.replace(AbstractSource.SLICE_LOG_PREFIX, "", 1))
 
     @classmethod
     def _create_configure_catalog(cls, stream_name: str) -> ConfiguredAirbyteCatalog:

--- a/airbyte-cdk/python/airbyte_cdk/connector_builder/models.py
+++ b/airbyte-cdk/python/airbyte_cdk/connector_builder/models.py
@@ -3,7 +3,6 @@
 #
 
 from dataclasses import dataclass
-from datetime import datetime
 from typing import Any, Dict, List, Optional
 
 
@@ -31,23 +30,10 @@ class StreamReadPages:
 
 
 @dataclass
-class StreamReadSlicesInnerPagesInner:
-    records: List[object]
-    request: Optional[HttpRequest]
-    response: Optional[HttpResponse]
-
-
-@dataclass
-class StreamReadSlicesInnerSliceDescriptor:
-    start_datetime: Optional[datetime]
-    list_item: Optional[str]
-
-
-@dataclass
-class StreamReadSlicesInner:
-    pages: List[StreamReadSlicesInnerPagesInner]
-    slice_descriptor: Optional[StreamReadSlicesInnerSliceDescriptor]
-    state: Optional[Dict[str, Any]]
+class StreamReadSlices:
+    pages: List[StreamReadPages]
+    slice_descriptor: Dict[str, Any]
+    state: Optional[Dict[str, Any]] = None
 
 
 @dataclass
@@ -59,7 +45,7 @@ class LogMessage:
 @dataclass
 class StreamRead(object):
     logs: List[LogMessage]
-    slices: List[StreamReadSlicesInner]
+    slices: List[StreamReadSlices]
     test_read_limit_reached: bool
     inferred_schema: Optional[Dict[str, Any]]
 
@@ -71,16 +57,3 @@ class StreamReadRequestBody:
     config: Dict[str, Any]
     state: Optional[Dict[str, Any]]
     record_limit: Optional[int]
-
-
-@dataclass
-class StreamReadSliceDescriptor:
-    start_datetime: Optional[datetime] = None
-    list_item: Optional[str] = None
-
-
-@dataclass
-class StreamReadSlices:
-    pages: List[StreamReadPages]
-    slice_descriptor: Optional[StreamReadSliceDescriptor] = None
-    state: Optional[Dict[str, Any]] = None

--- a/airbyte-cdk/python/unit_tests/connector_builder/test_connector_builder_handler.py
+++ b/airbyte-cdk/python/unit_tests/connector_builder/test_connector_builder_handler.py
@@ -23,7 +23,7 @@ from airbyte_cdk.connector_builder.connector_builder_handler import (
     resolve_manifest,
 )
 from airbyte_cdk.connector_builder.main import handle_connector_builder_request, handle_request, read_stream
-from airbyte_cdk.connector_builder.models import LogMessage, StreamRead, StreamReadSlicesInner, StreamReadSlicesInnerPagesInner
+from airbyte_cdk.connector_builder.models import LogMessage, StreamRead, StreamReadPages, StreamReadSlices
 from airbyte_cdk.models import (
     AirbyteLogMessage,
     AirbyteMessage,
@@ -346,8 +346,8 @@ def test_read():
     stream_read = StreamRead(
         logs=[{"message": "here be a log message"}],
         slices=[
-            StreamReadSlicesInner(
-                pages=[StreamReadSlicesInnerPagesInner(records=[real_record], request=None, response=None)],
+            StreamReadSlices(
+                pages=[StreamReadPages(records=[real_record], request=None, response=None)],
                 slice_descriptor=None,
                 state=None,
             )
@@ -403,8 +403,8 @@ def test_read_returns_error_response(mock_from_exception):
     response = read_stream(source, TEST_READ_CONFIG, ConfiguredAirbyteCatalog.parse_obj(CONFIGURED_CATALOG), limits)
 
     expected_stream_read = StreamRead(logs=[LogMessage("error_message - a stack trace", "ERROR")],
-                                      slices=[StreamReadSlicesInner(
-                                          pages=[StreamReadSlicesInnerPagesInner(records=[], request=None, response=None)],
+                                      slices=[StreamReadSlices(
+                                          pages=[StreamReadPages(records=[], request=None, response=None)],
                                           slice_descriptor=None, state=None)],
                                       test_read_limit_reached=False,
                                       inferred_schema=None)

--- a/airbyte-cdk/python/unit_tests/connector_builder/test_message_grouper.py
+++ b/airbyte-cdk/python/unit_tests/connector_builder/test_message_grouper.py
@@ -445,11 +445,11 @@ def test_get_grouped_messages_with_many_slices(mock_entrypoint_read):
 
     mock_source = make_mock_source(mock_entrypoint_read, iter(
             [
-                slice_message(),
+                slice_message('{"descriptor": "first_slice"}'),
                 request_log_message(request),
                 response_log_message(response),
                 record_message("hashiras", {"name": "Muichiro Tokito"}),
-                slice_message(),
+                slice_message('{"descriptor": "second_slice"}'),
                 request_log_message(request),
                 response_log_message(response),
                 record_message("hashiras", {"name": "Shinobu Kocho"}),
@@ -472,9 +472,11 @@ def test_get_grouped_messages_with_many_slices(mock_entrypoint_read):
     assert not stream_read.test_read_limit_reached
     assert len(stream_read.slices) == 2
 
+    assert stream_read.slices[0].slice_descriptor == {"descriptor": "first_slice"}
     assert len(stream_read.slices[0].pages) == 1
     assert len(stream_read.slices[0].pages[0].records) == 1
 
+    assert stream_read.slices[1].slice_descriptor == {"descriptor": "second_slice"}
     assert len(stream_read.slices[1].pages) == 3
     assert len(stream_read.slices[1].pages[0].records) == 2
     assert len(stream_read.slices[1].pages[1].records) == 1
@@ -546,5 +548,5 @@ def record_message(stream: str, data: dict) -> AirbyteMessage:
     return AirbyteMessage(type=MessageType.RECORD, record=AirbyteRecordMessage(stream=stream, data=data, emitted_at=1234))
 
 
-def slice_message() -> AirbyteMessage:
-    return AirbyteMessage(type=MessageType.LOG, log=AirbyteLogMessage(level=Level.INFO, message='slice:{"key": "value"}'))
+def slice_message(slice_descriptor: str = '{"key": "value"}') -> AirbyteMessage:
+    return AirbyteMessage(type=MessageType.LOG, log=AirbyteLogMessage(level=Level.INFO, message="slice:" + slice_descriptor))


### PR DESCRIPTION
## What
Addresses the CDK part of https://github.com/airbytehq/airbyte/issues/24720

## How)
Sending a `Dict[str, Any]` (see the issue for an explanation as to why)

## 🚨 User Impact 🚨
This is technically a breaking change but in practice it was always null so it shouldn't break to connector-builder-server. Note that when updating the connector-builder-server to use the new CDK version, the frontend will need to be updated at the same time to avoid it to parse the slice descriptor as the previous `StreamReadSliceDescriptor` object