### PR TITLE
Introduce FlushTask into flushing process.

### DIFF
--- a/airbyte-integrations/bases/base-java/src/main/java/io/airbyte/integrations/destination/record_buffer/BufferingStrategy.java
+++ b/airbyte-integrations/bases/base-java/src/main/java/io/airbyte/integrations/destination/record_buffer/BufferingStrategy.java
@@ -35,7 +35,7 @@ public interface BufferingStrategy extends AutoCloseable {
   /**
    * Flush buffered messages in a buffer from a particular stream
    */
-  void flushSingleBuffer(AirbyteStreamNameNamespacePair stream, SerializableBuffer buffer) throws Exception;
+  void flushSingleBuffer(AirbyteStreamNameNamespacePair stream) throws Exception;
 
   /**
    * Flush all buffers that were buffering message data so far.

--- a/airbyte-integrations/bases/base-java/src/main/java/io/airbyte/integrations/destination/record_buffer/FlushTask.java
+++ b/airbyte-integrations/bases/base-java/src/main/java/io/airbyte/integrations/destination/record_buffer/FlushTask.java
@@ -1,3 +1,7 @@
+/*
+ * Copyright (c) 2023 Airbyte, Inc., all rights reserved.
+ */
+
 package io.airbyte.integrations.destination.record_buffer;
 
 import io.airbyte.protocol.models.v0.AirbyteStreamNameNamespacePair;
@@ -7,6 +11,7 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 public class FlushTask implements Callable<Void> {
+
   private static final Logger LOGGER = LoggerFactory.getLogger(FlushTask.class);
 
   private final FlushBufferFunction flushBufferFunction;
@@ -27,5 +32,5 @@ public class FlushTask implements Callable<Void> {
     LOGGER.info("Flushing completed for {}", stream.getName());
     return null;
   }
-}
 
+}

--- a/airbyte-integrations/bases/base-java/src/main/java/io/airbyte/integrations/destination/record_buffer/FlushTask.java
+++ b/airbyte-integrations/bases/base-java/src/main/java/io/airbyte/integrations/destination/record_buffer/FlushTask.java
@@ -1,0 +1,31 @@
+package io.airbyte.integrations.destination.record_buffer;
+
+import io.airbyte.protocol.models.v0.AirbyteStreamNameNamespacePair;
+import java.util.concurrent.Callable;
+import org.apache.commons.io.FileUtils;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+public class FlushTask implements Callable<Void> {
+  private static final Logger LOGGER = LoggerFactory.getLogger(FlushTask.class);
+
+  private final FlushBufferFunction flushBufferFunction;
+  private final AirbyteStreamNameNamespacePair stream;
+  private final SerializableBuffer buffer;
+
+  public FlushTask(final FlushBufferFunction flushBufferFunction, final AirbyteStreamNameNamespacePair stream, final SerializableBuffer buffer) {
+    this.flushBufferFunction = flushBufferFunction;
+    this.stream = stream;
+    this.buffer = buffer;
+  }
+
+  @Override
+  public Void call() throws Exception {
+    LOGGER.info("Flushing buffer of stream {} ({})", stream.getName(), FileUtils.byteCountToDisplaySize(buffer.getByteCount()));
+    flushBufferFunction.accept(stream, buffer);
+    buffer.close();
+    LOGGER.info("Flushing completed for {}", stream.getName());
+    return null;
+  }
+}
+

--- a/airbyte-integrations/bases/base-java/src/main/java/io/airbyte/integrations/destination/record_buffer/InMemoryRecordBufferingStrategy.java
+++ b/airbyte-integrations/bases/base-java/src/main/java/io/airbyte/integrations/destination/record_buffer/InMemoryRecordBufferingStrategy.java
@@ -15,6 +15,7 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
+import java.util.concurrent.ConcurrentHashMap;
 import org.apache.commons.io.FileUtils;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -30,7 +31,7 @@ public class InMemoryRecordBufferingStrategy implements BufferingStrategy {
 
   private static final Logger LOGGER = LoggerFactory.getLogger(InMemoryRecordBufferingStrategy.class);
 
-  private Map<AirbyteStreamNameNamespacePair, List<AirbyteRecordMessage>> streamBuffer = new HashMap<>();
+  private Map<AirbyteStreamNameNamespacePair, List<AirbyteRecordMessage>> streamBuffer = new ConcurrentHashMap<>();
   private final RecordWriter<AirbyteRecordMessage> recordWriter;
   private final CheckAndRemoveRecordWriter checkAndRemoveRecordWriter;
   private String fileName;
@@ -73,7 +74,7 @@ public class InMemoryRecordBufferingStrategy implements BufferingStrategy {
   }
 
   @Override
-  public void flushSingleBuffer(final AirbyteStreamNameNamespacePair stream, final SerializableBuffer buffer) throws Exception {
+  public void flushSingleBuffer(final AirbyteStreamNameNamespacePair stream) throws Exception {
     LOGGER.info("Flushing single stream {}: {} records", stream.getName(), streamBuffer.get(stream).size());
     recordWriter.accept(stream, streamBuffer.get(stream));
     LOGGER.info("Flushing completed for {}", stream.getName());

--- a/airbyte-integrations/bases/base-java/src/main/java/io/airbyte/integrations/destination/record_buffer/SerializedBufferingStrategy.java
+++ b/airbyte-integrations/bases/base-java/src/main/java/io/airbyte/integrations/destination/record_buffer/SerializedBufferingStrategy.java
@@ -151,7 +151,7 @@ public class SerializedBufferingStrategy implements BufferingStrategy {
     final Future<Void> flushFuture = executorService.submit(new FlushTask(onStreamFlush, stream, buffer));
 
     // todo: add flushFuture to async work tracker but for the direct executor, we will just check
-    // todo:    the future inline like this.
+    // todo: the future inline like this.
     try {
       flushFuture.get();
     } catch (InterruptedException | ExecutionException e) {
@@ -179,7 +179,6 @@ public class SerializedBufferingStrategy implements BufferingStrategy {
 
     totalBufferSizeInBytes = 0;
   }
-
 
   @Override
   public void clear() throws Exception {

--- a/airbyte-integrations/bases/base-java/src/main/java/io/airbyte/integrations/destination/record_buffer/StateAcknowledgementTask.java
+++ b/airbyte-integrations/bases/base-java/src/main/java/io/airbyte/integrations/destination/record_buffer/StateAcknowledgementTask.java
@@ -1,3 +1,7 @@
+/*
+ * Copyright (c) 2023 Airbyte, Inc., all rights reserved.
+ */
+
 package io.airbyte.integrations.destination.record_buffer;
 
 import java.util.concurrent.Callable;
@@ -8,4 +12,5 @@ public class StateAcknowledgementTask implements Callable<Void> {
   public Void call() throws Exception {
     return null;
   }
+
 }

--- a/airbyte-integrations/bases/base-java/src/main/java/io/airbyte/integrations/destination/record_buffer/StateAcknowledgementTask.java
+++ b/airbyte-integrations/bases/base-java/src/main/java/io/airbyte/integrations/destination/record_buffer/StateAcknowledgementTask.java
@@ -1,0 +1,11 @@
+package io.airbyte.integrations.destination.record_buffer;
+
+import java.util.concurrent.Callable;
+
+public class StateAcknowledgementTask implements Callable<Void> {
+
+  @Override
+  public Void call() throws Exception {
+    return null;
+  }
+}


### PR DESCRIPTION
This is a Work In Progress PR to illustrate some examples.

## What
Modify the flushing methods in SerializedBufferingStrategy to submit FlushTasks for the flush operation. This does not yet take account of the State Acknowledgement but a placeholder Task is created. This work should probably be done in isolation (in async copies of these classes so that only Snowflake will be affected.



## 🚨 User Impact 🚨
*Are there any breaking changes? What is the end result perceived by the user?*

*For connector PRs, use this section to explain which type of semantic versioning bump occurs as a result of the changes. Refer to our [Semantic Versioning for Connectors](https://docs.airbyte.com/contributing-to-airbyte/#semantic-versioning-for-connectors) guidelines for more information. **Breaking changes to connectors must be documented by an Airbyte engineer (PR author, or reviewer for community PRs) by using the [Breaking Change Release Playbook](https://docs.google.com/document/d/1VYQggHbL_PN0dDDu7rCyzBLGRtX-R3cpwXaY8QxEgzw/edit).***

*If there are breaking changes, please merge this PR with the 🚨🚨 emoji so changelog authors can further highlight this if needed.*


## Pre-merge Actions
*Expand the relevant checklist and delete the others.*

<details><summary><strong>New Connector</strong></summary>

### Community member or Airbyter

- **Community member?** Grant edit access to maintainers ([instructions](https://docs.github.com/en/github/collaborating-with-pull-requests/working-with-forks/allowing-changes-to-a-pull-request-branch-created-from-a-fork#enabling-repository-maintainer-permissions-on-existing-pull-requests))
- Unit & integration tests added and passing. Community members, please provide proof of success locally e.g: screenshot or copy-paste unit, integration, and acceptance test output. To run acceptance tests for a Python connector, follow instructions in the README. For java connectors run `./gradlew :airbyte-integrations:connectors:<name>:integrationTest`.
- Connector version is set to `0.0.1`
    - `Dockerfile` has version `0.0.1`
- Documentation updated
    - Connector's `README.md`
    - Connector's `bootstrap.md`. See [description and examples](https://docs.google.com/document/d/1ypdgmwmEHWv-TrO4_YOQ7pAJGVrMp5BOkEVh831N260/edit?usp=sharing)
    - `docs/integrations/<source or destination>/<name>.md` including changelog with an entry for the initial version. See changelog [example](https://docs.airbyte.io/integrations/sources/stripe#changelog)
    - `docs/integrations/README.md`

### Airbyter

If this is a community PR, the Airbyte engineer reviewing this PR is responsible for the below items.

- Create a non-forked branch based on this PR and test the below items on it
- Build is successful
- If new credentials are required for use in CI, add them to GSM. [Instructions](https://docs.airbyte.io/connector-development#using-credentials-in-ci).

</details>

<details><summary><strong>Updating a connector</strong></summary>

### Community member or Airbyter

- Grant edit access to maintainers ([instructions](https://docs.github.com/en/github/collaborating-with-pull-requests/working-with-forks/allowing-changes-to-a-pull-request-branch-created-from-a-fork#enabling-repository-maintainer-permissions-on-existing-pull-requests))
- Unit & integration tests added


### Airbyter

If this is a community PR, the Airbyte engineer reviewing this PR is responsible for the below items.

- Create a non-forked branch based on this PR and test the below items on it
- Build is successful
- If new credentials are required for use in CI, add them to GSM. [Instructions](https://docs.airbyte.io/connector-development#using-credentials-in-ci).

</details>

<details><summary><strong>Connector Generator</strong></summary>

- Issue acceptance criteria met
- PR name follows [PR naming conventions](https://docs.airbyte.com/contributing-to-airbyte/issues-and-pull-requests)
- If adding a new generator, add it to the [list of scaffold modules being tested](https://github.com/airbytehq/airbyte/blob/master/airbyte-integrations/connector-templates/generator/build.gradle#L41)
- The generator test modules (all connectors with `-scaffold` in their name) have been updated with the latest scaffold by running `./gradlew :airbyte-integrations:connector-templates:generator:testScaffoldTemplates` then checking in your changes
- Documentation which references the generator is updated as needed

</details>
