### PR TITLE
Build list of connectors in docusourus react component

### DIFF
--- a/docs/integrations/README.md
+++ b/docs/integrations/README.md
@@ -14,7 +14,7 @@ Airbyte uses a grading system for connectors to help you understand what to expe
 
 For more information about the grading system, see [Product Release Stages](https://docs.airbyte.com/project-overview/product-release-stages)
 
-_[View the connectors registries full screen](https://connectors.airbyte.com/files/generated_reports/connector_registry_report.html)_
+_[View the connector registries in full](https://connectors.airbyte.com/files/generated_reports/connector_registry_report.html)_
 
 ## Sources
 

--- a/docs/integrations/README.md
+++ b/docs/integrations/README.md
@@ -1,3 +1,5 @@
+import ConnectorRegistry from '@site/src/components/ConnectorRegistry';
+
 # Connector Catalog
 
 ## Connector Release Stages
@@ -14,10 +16,10 @@ For more information about the grading system, see [Product Release Stages](http
 
 _[View the connectors registries full screen](https://connectors.airbyte.com/files/generated_reports/connector_registry_report.html)_
 
-<iframe
-    src="https://connectors.airbyte.com/files/generated_reports/connector_registry_report.html"
-    frameborder="0"
-    width="958" /* This is docusarus body width on desktop */
-    height="2000"
-    allowtransparency
-></iframe>
+## Sources
+
+<ConnectorRegistry type="source"/>
+
+## Destinations
+
+<ConnectorRegistry type="destination"/>

--- a/docusaurus/src/components/ConnectorRegistry.jsx
+++ b/docusaurus/src/components/ConnectorRegistry.jsx
@@ -73,7 +73,7 @@ export default function ConnectorRegistry({ type }) {
               .replace("source-", "")
               .replace("destination-", "");
             const iconLink = `${iconBase}/${connector.icon}`;
-            const docsLink = `/integrations/${type}s/${codeName}`;
+            const docsLink = `/integrations/${type}s/${codeName}`; // not using documentationUrl so we can have relative links
             const sourceLink = `${sourceBase}/${baseName}`;
             const bugsLink = `${bugsBase}:connectors/${type}/${codeName}`;
             const isCloud = cloudRegistry[type + "s"].find(

--- a/docusaurus/src/components/ConnectorRegistry.jsx
+++ b/docusaurus/src/components/ConnectorRegistry.jsx
@@ -1,19 +1,12 @@
 import React from "react";
 import { useEffect, useState } from "react";
 
-const oss_registry_url =
-  "https://connectors.airbyte.com/api/v0/catalog/oss_catalog.json";
-const cloud_registry_url =
-  "https://connectors.airbyte.com/api/v0/catalog/cloud_catalog.json";
-const iconBase =
-  "https://raw.githubusercontent.com/airbytehq/airbyte/master/airbyte-config-oss/init-oss/src/main/resources/icons";
-const iconStyle = { maxWidth: 25 };
-const sourceBase =
-  "https://github.com/airbytehq/airbyte/tree/master/airbyte-integrations/connectors";
-const bugsBase =
-  "https://github.com/airbytehq/airbyte/issues?q=is:open+is:issue+label"; // :connectors/source/activecampaign
+const registry_url =
+  "https://connectors.airbyte.com/files/generated_reports/connector_registry_report.json";
 
-function fetchCatalog(url, setter) {
+const iconStyle = { maxWidth: 25 };
+
+async function fetchCatalog(url, setter) {
   const response = await fetch(url);
   const registry = await response.json();
   setter(registry);
@@ -23,33 +16,31 @@ function fetchCatalog(url, setter) {
 Sorts connectors by release stage and then name
 */
 function connectorSort(a, b) {
-  if (a.releaseStage !== b.releaseStage) {
-    if (a.releaseStage === "generally_available") return -3;
-    if (b.releaseStage === "generally_available") return 3;
-    if (a.releaseStage === "beta") return -2;
-    if (b.releaseStage === "beta") return 2;
-    if (a.releaseStage === "alpha") return -1;
-    if (b.releaseStage === "alpha") return 1;
+  if (a.releaseStage_oss !== b.releaseStage_oss) {
+    if (a.releaseStage_oss === "generally_available") return -3;
+    if (b.releaseStage_oss === "generally_available") return 3;
+    if (a.releaseStage_oss === "beta") return -2;
+    if (b.releaseStage_oss === "beta") return 2;
+    if (a.releaseStage_oss === "alpha") return -1;
+    if (b.releaseStage_oss === "alpha") return 1;
   }
 
-  if (a.name < b.name) return -1;
-  if (a.name > b.name) return 1;
+  if (a.name_oss < b.name_oss) return -1;
+  if (a.name_oss > b.name_oss) return 1;
 }
 
 export default function ConnectorRegistry({ type }) {
-  const [ossRegistry, setOssRegistry] = useState([]);
-  const [cloudRegistry, setCloudRegistry] = useState([]);
+  const [registry, setRegistry] = useState([]);
 
   useEffect(() => {
-    fetchCatalog(oss_registry_url, setOssRegistry);
-    fetchCatalog(cloud_registry_url, setCloudRegistry);
+    fetchCatalog(registry_url, setRegistry);
   }, []);
 
-  if (ossRegistry.length === 0 || cloudRegistry.length === 0)
-    return <div>{`Loading ${type}s...`}</div>;
+  if (registry.length === 0) return <div>{`Loading ${type}s...`}</div>;
 
-  // makes the assumption that the OSS registry is a superset of the cloud registry
-  const connectors = ossRegistry[type + "s"];
+  const connectors = registry
+    .filter((c) => c.connector_type === type)
+    .filter((c) => c.name_oss);
 
   return (
     <div>
@@ -67,45 +58,39 @@ export default function ConnectorRegistry({ type }) {
         </thead>
         <tbody>
           {connectors.sort(connectorSort).map((connector) => {
-            const baseName = connector.dockerRepository.replace("airbyte/", "");
-            const codeName = baseName
-              .replace("source-", "")
-              .replace("destination-", "");
-            const iconLink = `${iconBase}/${connector.icon}`;
-            const docsLink = `/integrations/${type}s/${codeName}`; // not using documentationUrl so we can have relative links
-            const sourceLink = `${sourceBase}/${baseName}`;
-            const bugsLink = `${bugsBase}:connectors/${type}/${codeName}`;
-            const isCloud = cloudRegistry[type + "s"].find(
-              (c) => c.name === connector.name
-            );
+            const docsLink = connector.documentationUrl_oss?.replace(
+              "https://docs.airbyte.com",
+              ""
+            ); // not using documentationUrl so we can have relative links
 
             return (
-              <tr key={`${type}-${baseName}`}>
+              <tr key={`${connector.definitionId}`}>
                 <td>
                   <strong>
-                    <a href={docsLink}>{connector.name}</a>
+                    <a href={docsLink}>{connector.name_oss}</a>
                   </strong>
                 </td>
                 <td>
-                  {connector.icon ? (
-                    <img src={iconLink} style={iconStyle} />
+                  {connector.icon_url ? (
+                    <img src={connector.icon_url} style={iconStyle} />
                   ) : null}
                 </td>
                 {/* min width to prevent wrapping */}
                 <td style={{ minWidth: 75 }}>
                   <a href={docsLink}>📕</a>
-                  <a href={sourceLink}>⚙️</a>
-                  <a href={bugsLink}>🐛</a>
+                  <a href={connector.github_url}>⚙️</a>
+                  <a href={connector.issue_url}>🐛</a>
                 </td>
                 <td>
-                  <small>{connector.releaseStage}</small>
+                  <small>{connector.releaseStage_oss}</small>
                 </td>
-                <td>✅</td>
-                <td>{isCloud ? "✅" : "❌"}</td>
+                <td>{connector.is_oss ? "✅" : "❌"}</td>
+                <td>{connector.is_cloud ? "✅" : "❌"}</td>
                 <td>
                   <small>
                     <code>
-                      {connector.dockerRepository}:{connector.dockerImageTag}
+                      {connector.dockerRepository_oss}:
+                      {connector.dockerImageTag_oss}
                     </code>
                   </small>
                 </td>

--- a/docusaurus/src/components/ConnectorRegistry.jsx
+++ b/docusaurus/src/components/ConnectorRegistry.jsx
@@ -1,0 +1,120 @@
+import React from "react";
+import { useEffect, useState } from "react";
+
+const oss_registry_url =
+  "https://connectors.airbyte.com/api/v0/catalog/oss_catalog.json";
+const cloud_registry_url =
+  "https://connectors.airbyte.com/api/v0/catalog/cloud_catalog.json";
+const iconBase =
+  "https://raw.githubusercontent.com/airbytehq/airbyte/master/airbyte-config-oss/init-oss/src/main/resources/icons";
+const iconStyle = { maxWidth: 25 };
+const sourceBase =
+  "https://github.com/airbytehq/airbyte/tree/master/airbyte-integrations/connectors";
+const bugsBase =
+  "https://github.com/airbytehq/airbyte/issues?q=is:open+is:issue+label"; // :connectors/source/activecampaign
+
+async function fetchCatalog(url, setter) {
+  const response = await fetch(url);
+  const registry = await response.json();
+  setter(registry);
+  return registry;
+}
+
+/*
+Sorts connectors by release stage and then name
+*/
+function connectorSort(a, b) {
+  if (a.releaseStage !== b.releaseStage) {
+    if (a.releaseStage === "generally_available") return -3;
+    if (b.releaseStage === "generally_available") return 3;
+    if (a.releaseStage === "beta") return -2;
+    if (b.releaseStage === "beta") return 2;
+    if (a.releaseStage === "alpha") return -1;
+    if (b.releaseStage === "alpha") return 1;
+  }
+
+  if (a.name < b.name) return -1;
+  if (a.name > b.name) return 1;
+}
+
+export default function ConnectorRegistry({ type }) {
+  const [ossRegistry, setOssRegistry] = useState([]);
+  const [cloudRegistry, setCloudRegistry] = useState([]);
+
+  useEffect(async () => {
+    await fetchCatalog(oss_registry_url, setOssRegistry);
+    await fetchCatalog(cloud_registry_url, setCloudRegistry);
+  }, []);
+
+  if (ossRegistry.length === 0 || cloudRegistry.length === 0)
+    return <div>{`Loading ${type}s...`}</div>;
+
+  // makes the assumption that the OSS registry is a superset of the cloud registry
+  const connectors = ossRegistry[type + "s"];
+
+  return (
+    <div>
+      <table>
+        <thead>
+          <tr>
+            <th>Connector Name</th>
+            <th>Icon</th>
+            <th>Links</th>
+            <th>Release Stage</th>
+            <th>OSS</th>
+            <th>Cloud</th>
+            <th>Docker Image</th>
+          </tr>
+        </thead>
+        <tbody>
+          {connectors.sort(connectorSort).map((connector) => {
+            const baseName = connector.dockerRepository.replace("airbyte/", "");
+            const codeName = baseName
+              .replace("source-", "")
+              .replace("destination-", "");
+            const iconLink = `${iconBase}/${connector.icon}`;
+            const docsLink = `/integrations/${type}s/${codeName}`;
+            const sourceLink = `${sourceBase}/${baseName}`;
+            const bugsLink = `${bugsBase}:connectors/${type}/${codeName}`;
+            const isCloud = cloudRegistry[type + "s"].find(
+              (c) => c.name === connector.name
+            );
+
+            return (
+              <tr key={`${type}-${baseName}`}>
+                <td>
+                  <strong>
+                    <a href={docsLink}>{connector.name}</a>
+                  </strong>
+                </td>
+                <td>
+                  {connector.icon ? (
+                    <img src={iconLink} style={iconStyle} />
+                  ) : null}
+                </td>
+                {/* min width to prevent wrapping */}
+                <td style={{ minWidth: 75 }}>
+                  <a href={docsLink}>📕</a>
+                  <a href={sourceLink}>⚙️</a>
+                  <a href={bugsLink}>🐛</a>
+                </td>
+                <td>
+                  <small>{connector.releaseStage}</small>
+                </td>
+                <td>✅</td>
+                <td>{isCloud ? "✅" : "❌"}</td>
+                <td>
+                  <small>
+                    <code>
+                      {connector.dockerRepository}:${connector.dockerImageTag}
+                    </code>
+                  </small>
+                </td>
+              </tr>
+            );
+          })}
+        </tbody>
+      </table>
+    </div>
+  );
+}

--- a/docusaurus/src/components/ConnectorRegistry.jsx
+++ b/docusaurus/src/components/ConnectorRegistry.jsx
@@ -13,11 +13,10 @@ const sourceBase =
 const bugsBase =
   "https://github.com/airbytehq/airbyte/issues?q=is:open+is:issue+label"; // :connectors/source/activecampaign
 
-async function fetchCatalog(url, setter) {
+function fetchCatalog(url, setter) {
   const response = await fetch(url);
   const registry = await response.json();
   setter(registry);
-  return registry;
 }
 
 /*

--- a/docusaurus/src/components/ConnectorRegistry.jsx
+++ b/docusaurus/src/components/ConnectorRegistry.jsx
@@ -106,7 +106,7 @@ export default function ConnectorRegistry({ type }) {
                 <td>
                   <small>
                     <code>
-                      {connector.dockerRepository}:${connector.dockerImageTag}
+                      {connector.dockerRepository}:{connector.dockerImageTag}
                     </code>
                   </small>
                 </td>

--- a/docusaurus/src/components/ConnectorRegistry.jsx
+++ b/docusaurus/src/components/ConnectorRegistry.jsx
@@ -40,9 +40,9 @@ export default function ConnectorRegistry({ type }) {
   const [ossRegistry, setOssRegistry] = useState([]);
   const [cloudRegistry, setCloudRegistry] = useState([]);
 
-  useEffect(async () => {
-    await fetchCatalog(oss_registry_url, setOssRegistry);
-    await fetchCatalog(cloud_registry_url, setCloudRegistry);
+  useEffect(() => {
+    fetchCatalog(oss_registry_url, setOssRegistry);
+    fetchCatalog(cloud_registry_url, setCloudRegistry);
   }, []);
 
   if (ossRegistry.length === 0 || cloudRegistry.length === 0)


### PR DESCRIPTION
Closes https://github.com/airbytehq/airbyte/issues/25678.

We load the list of connectors from the registry. We sort them by release stage and then alphabetically.  We only show relevant information. 

Building the list in-page with react vs an iFrame allows the styling and scrolling to function as expected

<img width="1744" alt="Screenshot 2023-04-28 at 2 13 54 PM" src="https://user-images.githubusercontent.com/303226/235255426-719086a6-fcbc-4d94-89f9-91f525f68efb.png">
<img width="1744" alt="Screenshot 2023-04-28 at 2 13 52 PM" src="https://user-images.githubusercontent.com/303226/235255428-672a4843-78d5-4019-bee2-8ef840fa6660.png">
