### PR TITLE
low-code: Update docs on incremental syncs

### DIFF
--- a/airbyte-cdk/python/airbyte_cdk/sources/declarative/declarative_component_schema.yaml
+++ b/airbyte-cdk/python/airbyte_cdk/sources/declarative/declarative_component_schema.yaml
@@ -561,8 +561,11 @@ definitions:
         enum: [DatetimeBasedCursor]
       cursor_field:
         title: Cursor Field
-        description: The location of the value on a record that will be used as a bookmark during sync.
+        description: The location of the value on a record that will be used as a bookmark during sync. To ensure no data loss, the API must return records in ascending order based on the cursor field. Nested fields are not supported, so the field must be at the top level of the record. You can use a combination of Add Field and Remove Field transformations to move the nested field to the top.
         type: string
+        interpolation_context:
+          - config
+          - stream_state
         examples:
           - "created_at"
           - "{{ config['record_cursor'] }}"
@@ -589,6 +592,7 @@ definitions:
         examples:
           - "2021-01-1T00:00:00Z"
           - "{{ now_utc() }}"
+          - "{{ day_delta(-1) }}"
       start_datetime:
         title: Start Datetime
         description: The datetime that determines the earliest record that should be synced.
@@ -2076,7 +2080,6 @@ interpolation:
       examples:
         - "{{ day_delta(25) }}"
         - "{{ day_delta(25, format='%Y-%m-%d') }}"
-        - "{{ config['start_time'] + day_delta(2) }}"
     - title: Duration
       description: Converts an ISO8601 duratioin to datetime.timedelta.
       arguments:

--- a/airbyte-cdk/python/airbyte_cdk/sources/declarative/models/declarative_component_schema.py
+++ b/airbyte-cdk/python/airbyte_cdk/sources/declarative/models/declarative_component_schema.py
@@ -841,7 +841,7 @@ class DatetimeBasedCursor(BaseModel):
     type: Literal["DatetimeBasedCursor"]
     cursor_field: str = Field(
         ...,
-        description="The location of the value on a record that will be used as a bookmark during sync.",
+        description="The location of the value on a record that will be used as a bookmark during sync. To ensure no data loss, the API must return records in ascending order based on the cursor field. Nested fields are not supported, so the field must be at the top level of the record. You can use a combination of Add Field and Remove Field transformations to move the nested field to the top.",
         examples=["created_at", "{{ config['record_cursor'] }}"],
         title="Cursor Field",
     )
@@ -860,7 +860,7 @@ class DatetimeBasedCursor(BaseModel):
     end_datetime: Union[str, MinMaxDatetime] = Field(
         ...,
         description="The datetime that determines the last record that should be synced.",
-        examples=["2021-01-1T00:00:00Z", "{{ now_utc() }}"],
+        examples=["2021-01-1T00:00:00Z", "{{ now_utc() }}", "{{ day_delta(-1) }}"],
         title="End Datetime",
     )
     start_datetime: Union[str, MinMaxDatetime] = Field(

--- a/docs/connector-development/connector-builder-ui/incremental-sync.md
+++ b/docs/connector-development/connector-builder-ui/incremental-sync.md
@@ -7,8 +7,10 @@ This is especially important if there are a large number of records to sync and/
 Incremental syncs are usually implemented using a cursor value (like a timestamp) that delineates which data was pulled and which data is new. A very common cursor value is an `updated_at` timestamp. This cursor means that records whose `updated_at` value is less than or equal than that cursor value have been synced already, and that the next sync should only export records whose `updated_at` value is greater than the cursor value.
 
 To use incremental syncs, the API endpoint needs to fullfil the following requirements:
-* Records contain a date/time field that defines when this record was last updated (the "cursor field")
+* Records contain a top-level date/time field that defines when this record was last updated (the "cursor field")
+  * If the record's cursor field is nested, you can use an "Add Field" transformation to copy it to the top-level, and a Remove Field to remove it from the object. This will effectively move the field to the top-level of the record.
 * It's possible to filter/request records by the cursor field
+* The records sorted in ascending order based on their cursor field
 
 The knowledge of a cursor value also allows the Airbyte system to automatically keep a history of changes to records in the destination. To learn more about how different modes of incremental syncs, check out the [Incremental Sync - Append](/understanding-airbyte/connections/incremental-append/) and [Incremental Sync - Deduped History](/understanding-airbyte/connections/incremental-deduped-history) pages.
 

--- a/docs/connector-development/connector-builder-ui/incremental-sync.md
+++ b/docs/connector-development/connector-builder-ui/incremental-sync.md
@@ -8,9 +8,9 @@ Incremental syncs are usually implemented using a cursor value (like a timestamp
 
 To use incremental syncs, the API endpoint needs to fullfil the following requirements:
 * Records contain a top-level date/time field that defines when this record was last updated (the "cursor field")
-  * If the record's cursor field is nested, you can use an "Add Field" transformation to copy it to the top-level, and a Remove Field to remove it from the object. This will effectively move the field to the top-level of the record.
+  * If the record's cursor field is nested, you can use an "Add Field" transformation to copy it to the top-level, and a Remove Field to remove it from the object. This will effectively move the field to the top-level of the record
 * It's possible to filter/request records by the cursor field
-* The records sorted in ascending order based on their cursor field
+* The records are sorted in ascending order based on their cursor field
 
 The knowledge of a cursor value also allows the Airbyte system to automatically keep a history of changes to records in the destination. To learn more about how different modes of incremental syncs, check out the [Incremental Sync - Append](/understanding-airbyte/connections/incremental-append/) and [Incremental Sync - Deduped History](/understanding-airbyte/connections/incremental-deduped-history) pages.
 


### PR DESCRIPTION
## What
* Clarify that records must be sorted in ascending order according to their cursor field
* Clarify that the cursor field cannot be nested
* Document which interpolation values are supported
* Remove an erroneous example usage of day_delta()
* Add a non-obvious example usage of day_delta()

## Recommended reading order
1. `airbyte-cdk/python/airbyte_cdk/sources/declarative/declarative_component_schema.yaml`
2. `docs/connector-development/connector-builder-ui/incremental-sync.md`

## 🚨 User Impact 🚨
Better documentation