### PR TITLE
destination-s3-glue: Fix decimal type syntax

### DIFF
--- a/airbyte-integrations/connectors/destination-s3-glue/Dockerfile
+++ b/airbyte-integrations/connectors/destination-s3-glue/Dockerfile
@@ -14,5 +14,5 @@ ENV APPLICATION destination-s3-glue
 
 COPY --from=build /airbyte /airbyte
 
-LABEL io.airbyte.version=0.1.6
+LABEL io.airbyte.version=0.1.7
 LABEL io.airbyte.name=airbyte/destination-s3-glue

--- a/airbyte-integrations/connectors/destination-s3-glue/src/main/java/io/airbyte/integrations/destination/s3_glue/GlueOperations.java
+++ b/airbyte-integrations/connectors/destination-s3-glue/src/main/java/io/airbyte/integrations/destination/s3_glue/GlueOperations.java
@@ -130,8 +130,8 @@ public class GlueOperations implements MetastoreOperations {
           yield "int";
         }
         // Default to use decimal as it is a more precise type and allows for large values
-        // Set the default scale and precision to 38 to allow or the widest range of values
-        yield "decimal(38,38)";
+        // Set the default scale 38 to allow for the widest range of values
+        yield "decimal(38)";
       }
       case "boolean" -> "boolean";
       case "integer" -> "int";

--- a/docs/integrations/destinations/s3-glue.md
+++ b/docs/integrations/destinations/s3-glue.md
@@ -245,7 +245,8 @@ Output files can be compressed. The default option is GZIP compression. If compr
 
 | Version | Date       | Pull Request                                             | Subject                                                                                 |
 |:--------|:-----------|:---------------------------------------------------------|:----------------------------------------------------------------------------------------|
-| 0.1.6   | 2023-04-13 | [25178](https://github.com/airbytehq/airbyte/pull/25178) | Fix decimal precision and scale to allow for a wider range of numeric values         |
+| 0.1.7   | 2023-05-01 | [25724](https://github.com/airbytehq/airbyte/pull/25724) | Fix decimal type creation syntax to avoid overflow                                      |
+| 0.1.6   | 2023-04-13 | [25178](https://github.com/airbytehq/airbyte/pull/25178) | Fix decimal precision and scale to allow for a wider range of numeric values            |
 | 0.1.5   | 2023-04-11 | [25048](https://github.com/airbytehq/airbyte/pull/25048) | Fix config schema to support new JSONL flattening configuration interface               |
 | 0.1.4   | 2023-03-10 | [23950](https://github.com/airbytehq/airbyte/pull/23950) | Fix schema syntax error for struct fields and handle missing `items` in array fields    |
 | 0.1.3   | 2023-02-10 | [22822](https://github.com/airbytehq/airbyte/pull/22822) | Fix data type for _ab_emitted_at column in table definition                             |


### PR DESCRIPTION
## What
The definition of the decimal type as `decimal(38,38)` was incorrect as it caused the query engine to interpret that as meaning that all 38 digits had to be to the right of the decimal place, so any whole number values would overflow. Setting it as `decimal(38)` allows for the full 38 digits, but with flexible scale.

## How
Set the decimal type creation syntax to only specify the precision, leaving the scale as a flexible value.

## Recommended reading order
1. `GlueOperations.java`

## 🚨 User Impact 🚨
Any `select *` queries using a decimal type will no longer result in `fieldValue cannot be null` errors.

## Pre-merge Actions


<details><summary><strong>Updating a connector</strong></summary>

### Community member or Airbyter

- Grant edit access to maintainers ([instructions](https://docs.github.com/en/github/collaborating-with-pull-requests/working-with-forks/allowing-changes-to-a-pull-request-branch-created-from-a-fork#enabling-repository-maintainer-permissions-on-existing-pull-requests))
- Unit & integration tests added


### Airbyter

If this is a community PR, the Airbyte engineer reviewing this PR is responsible for the below items.

- Create a non-forked branch based on this PR and test the below items on it
- Build is successful
- If new credentials are required for use in CI, add them to GSM. [Instructions](https://docs.airbyte.io/connector-development#using-credentials-in-ci).

</details>