### PR TITLE
Refresh token is optional

### DIFF
--- a/airbyte-cdk/python/airbyte_cdk/sources/declarative/auth/oauth.py
+++ b/airbyte-cdk/python/airbyte_cdk/sources/declarative/auth/oauth.py
@@ -37,11 +37,11 @@ class DeclarativeOauth2Authenticator(AbstractOauth2Authenticator, DeclarativeAut
     token_refresh_endpoint: Union[InterpolatedString, str]
     client_id: Union[InterpolatedString, str]
     client_secret: Union[InterpolatedString, str]
-    refresh_token: Union[InterpolatedString, str]
     config: Mapping[str, Any]
     parameters: InitVar[Mapping[str, Any]]
     scopes: Optional[List[str]] = None
     token_expiry_date: Optional[Union[InterpolatedString, str]] = None
+    refresh_token: Union[InterpolatedString, str] = field(default=None)
     _token_expiry_date: pendulum.DateTime = field(init=False, repr=False, default=None)
     token_expiry_date_format: str = None
     access_token_name: Union[InterpolatedString, str] = "access_token"

--- a/airbyte-cdk/python/airbyte_cdk/sources/declarative/declarative_component_schema.yaml
+++ b/airbyte-cdk/python/airbyte_cdk/sources/declarative/declarative_component_schema.yaml
@@ -647,7 +647,6 @@ definitions:
       - type
       - client_id
       - client_secret
-      - refresh_token
       - token_refresh_endpoint
     properties:
       type:

--- a/airbyte-cdk/python/airbyte_cdk/sources/declarative/models/declarative_component_schema.py
+++ b/airbyte-cdk/python/airbyte_cdk/sources/declarative/models/declarative_component_schema.py
@@ -277,8 +277,8 @@ class OAuthAuthenticator(BaseModel):
         ],
         title="Client Secret",
     )
-    refresh_token: str = Field(
-        ...,
+    refresh_token: Optional[str] = Field(
+        None,
         description="Credential artifact used to get a new access token.",
         examples=[
             "{{ config['refresh_token'] }}",


### PR DESCRIPTION
## What
The OAuthAuthenticator's refresh_token should be optional. See https://github.com/airbytehq/airbyte/issues/25400

## How
* Make the refresh_token field optional

## Recommended reading order
1. `airbyte-cdk/python/airbyte_cdk/sources/declarative/declarative_component_schema.yaml`
2. `airbyte-cdk/python/airbyte_cdk/sources/declarative/models/declarative_component_schema.py`