### PR TITLE
Source Sentry: Change stream that is used during check

### DIFF
--- a/airbyte-config-oss/init-oss/src/main/resources/seed/oss_catalog.json
+++ b/airbyte-config-oss/init-oss/src/main/resources/seed/oss_catalog.json
@@ -28174,7 +28174,7 @@
     "sourceDefinitionId": "cdaf146a-9b75-49fd-9dd2-9d64a0bb4781",
     "name": "Sentry",
     "dockerRepository": "airbyte/source-sentry",
-    "dockerImageTag": "0.2.1",
+    "dockerImageTag": "0.2.2",
     "documentationUrl": "https://docs.airbyte.com/integrations/sources/sentry",
     "icon": "sentry.svg",
     "sourceType": "api",

--- a/airbyte-config-oss/init-oss/src/main/resources/seed/source_definitions.yaml
+++ b/airbyte-config-oss/init-oss/src/main/resources/seed/source_definitions.yaml
@@ -2465,7 +2465,7 @@
 - sourceDefinitionId: cdaf146a-9b75-49fd-9dd2-9d64a0bb4781
   name: Sentry
   dockerRepository: airbyte/source-sentry
-  dockerImageTag: 0.2.1
+  dockerImageTag: 0.2.2
   documentationUrl: https://docs.airbyte.com/integrations/sources/sentry
   icon: sentry.svg
   sourceType: api

--- a/airbyte-config-oss/init-oss/src/main/resources/seed/source_specs.yaml
+++ b/airbyte-config-oss/init-oss/src/main/resources/seed/source_specs.yaml
@@ -17938,7 +17938,7 @@
     supportsNormalization: false
     supportsDBT: false
     supported_destination_sync_modes: []
-- dockerImage: "airbyte/source-sentry:0.2.1"
+- dockerImage: "airbyte/source-sentry:0.2.2"
   spec:
     documentationUrl: "https://docs.airbyte.com/integrations/sources/sentry"
     connectionSpecification:

--- a/airbyte-integrations/connectors/source-sentry/Dockerfile
+++ b/airbyte-integrations/connectors/source-sentry/Dockerfile
@@ -34,5 +34,5 @@ COPY source_sentry ./source_sentry
 ENV AIRBYTE_ENTRYPOINT "python /airbyte/integration_code/main.py"
 ENTRYPOINT ["python", "/airbyte/integration_code/main.py"]
 
-LABEL io.airbyte.version=0.2.1
+LABEL io.airbyte.version=0.2.2
 LABEL io.airbyte.name=airbyte/source-sentry

--- a/airbyte-integrations/connectors/source-sentry/metadata.yaml
+++ b/airbyte-integrations/connectors/source-sentry/metadata.yaml
@@ -10,7 +10,7 @@ data:
   connectorSubtype: api
   connectorType: source
   definitionId: cdaf146a-9b75-49fd-9dd2-9d64a0bb4781
-  dockerImageTag: 0.2.0
+  dockerImageTag: 0.2.2
   dockerRepository: airbyte/source-sentry
   githubIssueLabel: source-sentry
   icon: sentry.svg

--- a/airbyte-integrations/connectors/source-sentry/source_sentry/source.py
+++ b/airbyte-integrations/connectors/source-sentry/source_sentry/source.py
@@ -18,16 +18,14 @@ from .streams import Events, Issues, ProjectDetail, Projects, Releases
 class SourceSentry(AbstractSource):
     def check_connection(self, logger, config) -> Tuple[bool, Any]:
         try:
-            events_stream = Events(
+            stream = ProjectDetail(
                 authenticator=TokenAuthenticator(token=config["auth_token"]),
                 hostname=config.get("hostname"),
                 organization=config.get("organization"),
                 project=config.get("project"),
             )
-            next(events_stream.read_records(sync_mode=SyncMode.full_refresh))
+            next(stream.read_records(sync_mode=SyncMode.full_refresh))
             return True, None
-        except HTTPError:
-            return False, "Check failed: either project's or organization's name is invalid"
         except Exception as e:
             return False, e
 

--- a/airbyte-integrations/connectors/source-sentry/source_sentry/source.py
+++ b/airbyte-integrations/connectors/source-sentry/source_sentry/source.py
@@ -9,7 +9,6 @@ from airbyte_cdk.models import SyncMode
 from airbyte_cdk.sources import AbstractSource
 from airbyte_cdk.sources.streams import Stream
 from airbyte_cdk.sources.streams.http.auth import TokenAuthenticator
-from requests.exceptions import HTTPError
 
 from .streams import Events, Issues, ProjectDetail, Projects, Releases
 

--- a/airbyte-integrations/connectors/source-sentry/unit_tests/test_source.py
+++ b/airbyte-integrations/connectors/source-sentry/unit_tests/test_source.py
@@ -6,7 +6,7 @@ from unittest.mock import MagicMock
 
 from airbyte_cdk.logger import AirbyteLogger
 from source_sentry.source import SourceSentry
-from source_sentry.streams import Events
+from source_sentry.streams import ProjectDetail
 
 
 def test_source_wrong_credentials(requests_mock):
@@ -18,7 +18,7 @@ def test_source_wrong_credentials(requests_mock):
 def test_check_connection(mocker):
     source = SourceSentry()
     logger_mock, config_mock = MagicMock(), MagicMock()
-    mocker.patch.object(Events, "read_records", return_value=iter([{"id": "1", "name": "test"}]))
+    mocker.patch.object(ProjectDetail, "read_records", return_value=iter([{"id": "1", "name": "test"}]))
     assert source.check_connection(logger_mock, config_mock) == (True, None)
 
 

--- a/docs/integrations/sources/sentry.md
+++ b/docs/integrations/sources/sentry.md
@@ -47,7 +47,7 @@ The Sentry source connector supports the following [sync modes](https://docs.air
 
 | Version | Date       | Pull Request                                             | Subject                                                     |
 |:--------|:-----------|:---------------------------------------------------------|:------------------------------------------------------------|
-| 0.2.2   | 2023-05-02 | [00000](https://github.com/airbytehq/airbyte/pull/00000) | Change stream that used in check_connection                                         |
+| 0.2.2   | 2023-05-02 | [25759](https://github.com/airbytehq/airbyte/pull/25759) | Change stream that used in check_connection                                         |
 | 0.2.1   | 2023-04-27 | [25602](https://github.com/airbytehq/airbyte/pull/25602) | Add validation of project and organization names during connector setup                                         |
 | 0.2.0   | 2023-04-03 | [23923](https://github.com/airbytehq/airbyte/pull/23923) | Add Releases stream                                         |
 | 0.1.12  | 2023-03-01 | [23619](https://github.com/airbytehq/airbyte/pull/23619) | Fix bug when `stream state` is `None` or any other bad value occurs                     |

--- a/docs/integrations/sources/sentry.md
+++ b/docs/integrations/sources/sentry.md
@@ -47,6 +47,7 @@ The Sentry source connector supports the following [sync modes](https://docs.air
 
 | Version | Date       | Pull Request                                             | Subject                                                     |
 |:--------|:-----------|:---------------------------------------------------------|:------------------------------------------------------------|
+| 0.2.2   | 2023-05-02 | [00000](https://github.com/airbytehq/airbyte/pull/00000) | Change stream that used in check_connection                                         |
 | 0.2.1   | 2023-04-27 | [25602](https://github.com/airbytehq/airbyte/pull/25602) | Add validation of project and organization names during connector setup                                         |
 | 0.2.0   | 2023-04-03 | [23923](https://github.com/airbytehq/airbyte/pull/23923) | Add Releases stream                                         |
 | 0.1.12  | 2023-03-01 | [23619](https://github.com/airbytehq/airbyte/pull/23619) | Fix bug when `stream state` is `None` or any other bad value occurs                     |


### PR DESCRIPTION
## What
Fix issue during check in case if `events` stream is empty

## How
use `ProjectDetail` stream
