### PR TITLE
fix doc naming for DatetimeCursorBased to DatetimeBasedCursor

### DIFF
--- a/docs/connector-development/config-based/understanding-the-yaml-file/incremental-syncs.md
+++ b/docs/connector-development/config-based/understanding-the-yaml-file/incremental-syncs.md
@@ -154,7 +154,7 @@ For instance, if the API supports filtering using the request parameters `create
 
 ```yaml
 incremental_sync:
-  type: DatetimeCursorBased
+  type: DatetimeBasedCursor
   <...>
   start_time_option:
     type: RequestOption

--- a/docs/connector-development/config-based/understanding-the-yaml-file/yaml-overview.md
+++ b/docs/connector-development/config-based/understanding-the-yaml-file/yaml-overview.md
@@ -62,7 +62,7 @@ If you want to allow your stream to be configured so that only data that has cha
 
 Given a start time, an end time, and a step function, it will partition the interval [start, end] into small windows of the size described by the step.
 
-More information on `incremental_sync` configurations and the `DatetimeCursorBased` component can be found in the [incremental syncs](./incremental-syncs.md) section.
+More information on `incremental_sync` configurations and the `DatetimeBasedCursor` component can be found in the [incremental syncs](./incremental-syncs.md) section.
 
 ## Data retriever
 


### PR DESCRIPTION
Hello Airbyte Community,

It's my first contribution on the project.
I saw a small error on documentation.

## What
Update docs to rename DatetimeCursorBased to DatetimeBasedCursor

Thanks