### PR TITLE
Declarative CDK: Advanced Auth - support revoking tokens flag

### DIFF
--- a/airbyte-cdk/python/airbyte_cdk/sources/declarative/declarative_component_schema.yaml
+++ b/airbyte-cdk/python/airbyte_cdk/sources/declarative/declarative_component_schema.yaml
@@ -150,6 +150,11 @@ definitions:
         type: string
         examples:
           - "Oauth"
+      supports_revoking_tokens:
+        title: "Supports revoking tokens"
+        description: If the connector OAuth flow supports revoking tokens or not.
+        type: boolean
+        default: false
       oauth_config_specification:
         "$ref": "#/definitions/OAuthConfigSpecification"
   BasicHttpAuthenticator:

--- a/airbyte-cdk/python/airbyte_cdk/sources/declarative/models/declarative_component_schema.py
+++ b/airbyte-cdk/python/airbyte_cdk/sources/declarative/models/declarative_component_schema.py
@@ -799,6 +799,7 @@ class AuthFlow(BaseModel):
         examples=["Oauth"],
         title="Predicate value",
     )
+    supports_revoking_tokens: Optional[bool] = False
     oauth_config_specification: Optional[OAuthConfigSpecification] = None
 
 

--- a/airbyte-cdk/python/airbyte_cdk/sources/declarative/models/declarative_component_schema.py
+++ b/airbyte-cdk/python/airbyte_cdk/sources/declarative/models/declarative_component_schema.py
@@ -799,7 +799,11 @@ class AuthFlow(BaseModel):
         examples=["Oauth"],
         title="Predicate value",
     )
-    supports_revoking_tokens: Optional[bool] = False
+    supports_revoking_tokens: Optional[bool] = Field(
+        False,
+        description="If the connector OAuth flow supports revoking tokens or not.",
+        title="Supports revoking tokens",
+    )
     oauth_config_specification: Optional[OAuthConfigSpecification] = None
 
 

--- a/airbyte-cdk/python/setup.py
+++ b/airbyte-cdk/python/setup.py
@@ -46,7 +46,7 @@ setup(
     packages=find_packages(exclude=("unit_tests",)),
     package_data={"airbyte_cdk": ["py.typed", "sources/declarative/declarative_component_schema.yaml"]},
     install_requires=[
-        "airbyte-protocol-models==0.4.6",
+        "airbyte-protocol-models==0.4.0",
         "backoff",
         "dpath~=2.0.1",
         "isodate~=0.6.1",

--- a/airbyte-cdk/python/setup.py
+++ b/airbyte-cdk/python/setup.py
@@ -46,7 +46,7 @@ setup(
     packages=find_packages(exclude=("unit_tests",)),
     package_data={"airbyte_cdk": ["py.typed", "sources/declarative/declarative_component_schema.yaml"]},
     install_requires=[
-        "airbyte-protocol-models==0.3.6",
+        "airbyte-protocol-models==0.4.6",
         "backoff",
         "dpath~=2.0.1",
         "isodate~=0.6.1",


### PR DESCRIPTION
## What
Some APIs require we implement access token revocation to make our apps public. This is a starting point to implement the button: connector's spec tells the platform UI whether to show the button or not.

See https://docs.google.com/document/d/1g5roa5M89pMaCmbx9je11fs_MPo7wNflaCGSmBNCNdI/edit# for more details

## How
Replicate https://github.com/airbytehq/airbyte-protocol/pull/37 for the declarative CDK