### PR TITLE
Destination BigQuery: fix build by forcing urllib3 1.26.15

### DIFF
--- a/airbyte-integrations/connectors/destination-bigquery/Dockerfile
+++ b/airbyte-integrations/connectors/destination-bigquery/Dockerfile
@@ -26,7 +26,7 @@ RUN pip3 install .
 WORKDIR /airbyte/normalization_code/dbt-template/
 # Download external dbt dependencies
 # amazon linux 2 isn't compatible with urllib3 2.x, so force 1.26.15
-RUN pip3 install urllib3<2
+RUN pip3 install "urllib3<2"
 RUN dbt deps
 
 WORKDIR /airbyte

--- a/airbyte-integrations/connectors/destination-bigquery/Dockerfile
+++ b/airbyte-integrations/connectors/destination-bigquery/Dockerfile
@@ -26,7 +26,7 @@ RUN pip3 install .
 WORKDIR /airbyte/normalization_code/dbt-template/
 # Download external dbt dependencies
 # amazon linux 2 isn't compatible with urllib3 2.x, so force 1.26.15
-RUN pip3 install urllib3==1.26.15
+RUN pip3 install urllib3<2
 RUN dbt deps
 
 WORKDIR /airbyte

--- a/airbyte-integrations/connectors/destination-bigquery/Dockerfile
+++ b/airbyte-integrations/connectors/destination-bigquery/Dockerfile
@@ -25,6 +25,8 @@ WORKDIR /airbyte/normalization_code
 RUN pip3 install .
 WORKDIR /airbyte/normalization_code/dbt-template/
 # Download external dbt dependencies
+# amazon linux 2 isn't compatible with urllib3 2.x, so force 1.26.15
+RUN pip3 install urllib3==1.26.15
 RUN dbt deps
 
 WORKDIR /airbyte


### PR DESCRIPTION
## What

Based on these Connector Base Build [run](https://github.com/airbytehq/airbyte/actions/runs/4873850288/jobs/8694044838#step:18:20720)

urllib3 2.0 isn't compatible with amazon linux 2 (https://github.com/urllib3/urllib3/issues/2168). We're planning to remove the dbt dependency anyway, so for now just manually install the latest 1.x version to get our build back to green.

This is equivalent to what's in production:
```
$ docker run -it --entrypoint=bash airbyte/destination-bigquery:1.3.4
bash-4.2# pip3 list | grep urllib
urllib3                  1.26.15

$ docker run -it --entrypoint=bash airbyte/destination-bigquery:dev
bash-4.2# pip3 list | grep urllib
urllib3                  1.26.15
```

I won't publish this, since it's literally no change.