### PR TITLE
pin the version of requests lib

### DIFF
--- a/airbyte-cdk/python/setup.py
+++ b/airbyte-cdk/python/setup.py
@@ -57,7 +57,7 @@ setup(
         "pydantic~=1.9.2",
         "python-dateutil",
         "PyYAML~=5.4",
-        "requests",
+        "requests==2.29.0",
         "requests_cache",
         "Deprecated~=1.2",
         "Jinja2~=3.1.2",


### PR DESCRIPTION
## What
* urllib3 has had a major version bump which is breaking the connector builder.
 * from 1.26.15 to 2.0.2 