### PR TITLE
Source MSSQL: Add CDC Change LSN to CDC Metadata

### DIFF
--- a/airbyte-integrations/bases/standard-source-test/src/main/java/io/airbyte/integrations/standardtest/source/SourceAcceptanceTest.java
+++ b/airbyte-integrations/bases/standard-source-test/src/main/java/io/airbyte/integrations/standardtest/source/SourceAcceptanceTest.java
@@ -44,6 +44,7 @@ public abstract class SourceAcceptanceTest extends AbstractSourceConnectorTest {
   public static final String CDC_LOG_FILE = "_ab_cdc_log_file";
   public static final String CDC_LOG_POS = "_ab_cdc_log_pos";
   public static final String CDC_EVENT_SERIAL_NO = "_ab_cdc_event_serial_no";
+  public static final String CDC_CHANGE_LSN = "_ab_cdc_change_lsn";
 
   private static final Logger LOGGER = LoggerFactory.getLogger(SourceAcceptanceTest.class);
 
@@ -359,6 +360,7 @@ public abstract class SourceAcceptanceTest extends AbstractSourceConnectorTest {
     ((ObjectNode) clone.getData()).remove(CDC_UPDATED_AT);
     ((ObjectNode) clone.getData()).remove(CDC_DELETED_AT);
     ((ObjectNode) clone.getData()).remove(CDC_EVENT_SERIAL_NO);
+    ((ObjectNode) clone.getData()).remove(CDC_CHANGE_LSN);
     return clone;
   }
 

--- a/airbyte-integrations/connectors/source-mssql/src/main/java/io/airbyte/integrations/source/mssql/MssqlCdcConnectorMetadataInjector.java
+++ b/airbyte-integrations/connectors/source-mssql/src/main/java/io/airbyte/integrations/source/mssql/MssqlCdcConnectorMetadataInjector.java
@@ -17,7 +17,7 @@ public class MssqlCdcConnectorMetadataInjector implements CdcMetadataInjector {
   @Override
   public void addMetaData(final ObjectNode event, final JsonNode source) {
     final String commitLsn = source.get("commit_lsn").asText();
-    final String commitLsn = source.get("change_lsn").asText();
+    final String change_lsn = source.get("change_lsn").asText();
     final String eventSerialNo = source.get("event_serial_no").asText();
     event.put(CDC_LSN, commitLsn);
     event.put(CDC_CHANGE_LSN, change_lsn);

--- a/airbyte-integrations/connectors/source-mssql/src/main/java/io/airbyte/integrations/source/mssql/MssqlCdcConnectorMetadataInjector.java
+++ b/airbyte-integrations/connectors/source-mssql/src/main/java/io/airbyte/integrations/source/mssql/MssqlCdcConnectorMetadataInjector.java
@@ -6,6 +6,7 @@ package io.airbyte.integrations.source.mssql;
 
 import static io.airbyte.integrations.source.mssql.MssqlSource.CDC_EVENT_SERIAL_NO;
 import static io.airbyte.integrations.source.mssql.MssqlSource.CDC_LSN;
+import static io.airbyte.integrations.source.mssql.MssqlSource.CDC_CHANGE_LSN;
 
 import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.node.ObjectNode;
@@ -16,8 +17,10 @@ public class MssqlCdcConnectorMetadataInjector implements CdcMetadataInjector {
   @Override
   public void addMetaData(final ObjectNode event, final JsonNode source) {
     final String commitLsn = source.get("commit_lsn").asText();
+    final String commitLsn = source.get("change_lsn").asText();
     final String eventSerialNo = source.get("event_serial_no").asText();
     event.put(CDC_LSN, commitLsn);
+    event.put(CDC_CHANGE_LSN, change_lsn);
     event.put(CDC_EVENT_SERIAL_NO, eventSerialNo);
   }
 

--- a/airbyte-integrations/connectors/source-mssql/src/main/java/io/airbyte/integrations/source/mssql/MssqlSource.java
+++ b/airbyte-integrations/connectors/source-mssql/src/main/java/io/airbyte/integrations/source/mssql/MssqlSource.java
@@ -79,6 +79,7 @@ public class MssqlSource extends AbstractJdbcSource<JDBCType> implements Source 
   public static final String MSSQL_CDC_OFFSET = "mssql_cdc_offset";
   public static final String MSSQL_DB_HISTORY = "mssql_db_history";
   public static final String CDC_LSN = "_ab_cdc_lsn";
+  public static final String CDC_CHANGE_LSN = "_ab_cdc_change_lsn";
   public static final String CDC_EVENT_SERIAL_NO = "_ab_cdc_event_serial_no";
   private static final String HIERARCHYID = "hierarchyid";
   private static final int INTERMEDIATE_STATE_EMISSION_FREQUENCY = 10_000;

--- a/airbyte-integrations/connectors/source-mssql/src/main/java/io/airbyte/integrations/source/mssql/MssqlSource.java
+++ b/airbyte-integrations/connectors/source-mssql/src/main/java/io/airbyte/integrations/source/mssql/MssqlSource.java
@@ -499,6 +499,7 @@ public class MssqlSource extends AbstractJdbcSource<JDBCType> implements Source 
 
     final JsonNode stringType = Jsons.jsonNode(ImmutableMap.of("type", "string"));
     properties.set(CDC_LSN, stringType);
+    properties.set(CDC_CHANGE_LSN, stringType);
     properties.set(CDC_UPDATED_AT, stringType);
     properties.set(CDC_DELETED_AT, stringType);
     properties.set(CDC_EVENT_SERIAL_NO, stringType);

--- a/airbyte-integrations/connectors/source-mssql/src/test/java/io/airbyte/integrations/source/mssql/CdcMssqlSourceTest.java
+++ b/airbyte-integrations/connectors/source-mssql/src/test/java/io/airbyte/integrations/source/mssql/CdcMssqlSourceTest.java
@@ -8,6 +8,7 @@ import static io.airbyte.integrations.debezium.internals.DebeziumEventUtils.CDC_
 import static io.airbyte.integrations.debezium.internals.DebeziumEventUtils.CDC_UPDATED_AT;
 import static io.airbyte.integrations.source.mssql.MssqlSource.CDC_EVENT_SERIAL_NO;
 import static io.airbyte.integrations.source.mssql.MssqlSource.CDC_LSN;
+import static io.airbyte.integrations.source.mssql.MssqlSource.CDC_CHANGE_LSN;
 import static io.airbyte.integrations.source.mssql.MssqlSource.DRIVER_CLASS;
 import static io.airbyte.integrations.source.mssql.MssqlSource.MSSQL_CDC_OFFSET;
 import static io.airbyte.integrations.source.mssql.MssqlSource.MSSQL_DB_HISTORY;
@@ -372,6 +373,7 @@ public class CdcMssqlSourceTest extends CdcSourceTest {
   @Override
   protected void removeCDCColumns(final ObjectNode data) {
     data.remove(CDC_LSN);
+    data.remove(CDC_CHANGE_LSN);
     data.remove(CDC_UPDATED_AT);
     data.remove(CDC_DELETED_AT);
     data.remove(CDC_EVENT_SERIAL_NO);
@@ -407,6 +409,7 @@ public class CdcMssqlSourceTest extends CdcSourceTest {
   @Override
   protected void assertNullCdcMetaData(final JsonNode data) {
     assertNull(data.get(CDC_LSN));
+    assertNull(data.get(CDC_CHANGE_LSN));
     assertNull(data.get(CDC_UPDATED_AT));
     assertNull(data.get(CDC_DELETED_AT));
     assertNull(data.get(CDC_EVENT_SERIAL_NO));
@@ -415,6 +418,7 @@ public class CdcMssqlSourceTest extends CdcSourceTest {
   @Override
   protected void assertCdcMetaData(final JsonNode data, final boolean deletedAtNull) {
     assertNotNull(data.get(CDC_LSN));
+    assertNotNull(data.get(CDC_CHANGE_LSN));
     assertNotNull(data.get(CDC_EVENT_SERIAL_NO));
     assertNotNull(data.get(CDC_UPDATED_AT));
     if (deletedAtNull) {
@@ -431,6 +435,7 @@ public class CdcMssqlSourceTest extends CdcSourceTest {
 
     final JsonNode stringType = Jsons.jsonNode(ImmutableMap.of("type", "string"));
     properties.set(CDC_LSN, stringType);
+    properties.set(CDC_CHANGE_LSN, stringType);
     properties.set(CDC_UPDATED_AT, stringType);
     properties.set(CDC_DELETED_AT, stringType);
     properties.set(CDC_EVENT_SERIAL_NO, stringType);


### PR DESCRIPTION
## What
This change allows for the differentiation of two updates made within the same transaction on sql server when using the cdc sync. This will enable users to rebuild the current version of a table from cdc events without relying on insertion order.
## How
The Debezium event already provides this information in the json event this change just passes it through
*Describe the solution*

## 🚨 User Impact 🚨
Minor changes which are backwards compatible 


## Pre-merge Actions

<strong>Updating a connector</strong>

### Community member or Airbyter

- Grant edit access to maintainers ([instructions](https://docs.github.com/en/github/collaborating-with-pull-requests/working-with-forks/allowing-changes-to-a-pull-request-branch-created-from-a-fork#enabling-repository-maintainer-permissions-on-existing-pull-requests))
- Unit & integration tests added




### Airbyter

If this is a community PR, the Airbyte engineer reviewing this PR is responsible for the below items.

- Create a non-forked branch based on this PR and test the below items on it
- Build is successful
- If new credentials are required for use in CI, add them to GSM. [Instructions](https://docs.airbyte.io/connector-development#using-credentials-in-ci).


