### PR TITLE
connectors-ci: send slack message and set execute timeout

### DIFF
--- a/.github/workflows/publish_connectors.yml
+++ b/.github/workflows/publish_connectors.yml
@@ -47,7 +47,7 @@ jobs:
           # Setting concurrency to 1 for safety:
           # High concurrency can lead to resource issues for java connectors.
           # As speed is not a concern in this context I think not publishing connectors in parallel is fine.
-          subcommand: "connectors --concurrency=1 --execute-timeout=1800 --modified publish --pre-release"
+          subcommand: "connectors --concurrency=1 --execute-timeout=3600 --modified publish --pre-release"
           context: "master"
       - name: Publish connectors
         id: publish-connectors

--- a/.github/workflows/publish_connectors.yml
+++ b/.github/workflows/publish_connectors.yml
@@ -32,6 +32,7 @@ jobs:
       SPEC_CACHE_BUCKET_NAME: io-airbyte-cloud-spec-cache
       SPEC_CACHE_SERVICE_ACCOUNT_KEY: ${{ secrets.SPEC_CACHE_SERVICE_ACCOUNT_KEY_PUBLISH }}
       TEST_REPORTS_BUCKET_NAME: "airbyte-connector-build-status"
+      SLACK_WEBHOOK: ${{ secrets.PUBLISH_ON_MERGE_SLACK_WEBHOOK }}
     steps:
       - name: Checkout Airbyte
         uses: actions/checkout@v2
@@ -46,7 +47,7 @@ jobs:
           # Setting concurrency to 1 for safety:
           # High concurrency can lead to resource issues for java connectors.
           # As speed is not a concern in this context I think not publishing connectors in parallel is fine.
-          subcommand: "connectors --concurrency=1 --modified publish --pre-release"
+          subcommand: "connectors --concurrency=1 --execute-timeout=1800 --modified publish --pre-release"
           context: "master"
       - name: Publish connectors
         id: publish-connectors

--- a/tools/ci_connector_ops/ci_connector_ops/pipelines/pipelines/connectors.py
+++ b/tools/ci_connector_ops/ci_connector_ops/pipelines/pipelines/connectors.py
@@ -3,23 +3,29 @@
 #
 """This module groups the functions to run full pipelines for connector testing."""
 
-from typing import Callable, List
+import sys
+from typing import Callable, List, Optional
 
 import anyio
 import dagger
 from ci_connector_ops.pipelines.contexts import ConnectorContext
-from ci_connector_ops.pipelines.utils import DAGGER_CONFIG
+from dagger import Config
 
 GITHUB_GLOBAL_CONTEXT = "[POC please ignore] Connectors CI"
 GITHUB_GLOBAL_DESCRIPTION = "Running connectors tests"
 
 
 async def run_connectors_pipelines(
-    contexts: List[ConnectorContext], connector_pipeline: Callable, pipeline_name: str, concurrency: int, *args
+    contexts: List[ConnectorContext],
+    connector_pipeline: Callable,
+    pipeline_name: str,
+    concurrency: int,
+    execute_timeout: Optional[int],
+    *args,
 ) -> List[ConnectorContext]:
     """Run a connector pipeline for all the connector contexts."""
     semaphore = anyio.Semaphore(concurrency)
-    async with dagger.Connection(DAGGER_CONFIG) as dagger_client:
+    async with dagger.Connection(Config(log_output=sys.stderr, execute_timeout=execute_timeout)) as dagger_client:
         async with anyio.create_task_group() as tg:
             for context in contexts:
                 context.dagger_client = dagger_client.pipeline(f"{context.connector.technical_name} - {pipeline_name}")

--- a/tools/ci_connector_ops/ci_connector_ops/pipelines/slack.py
+++ b/tools/ci_connector_ops/ci_connector_ops/pipelines/slack.py
@@ -1,0 +1,15 @@
+#
+# Copyright (c) 2023 Airbyte, Inc., all rights reserved.
+#
+
+import json
+import os
+
+import requests
+
+
+def send_message_to_webhook(message: str, channel: str) -> dict:
+    payload = {"channel": f"#{channel}", "username": "Connectors CI/CD Bot", "text": message}
+    response = requests.post(os.environ["SLACK_WEBHOOK"], data={"payload": json.dumps(payload)})
+    response.raise_for_status()
+    return response


### PR DESCRIPTION
## What
Closes #25844
Closes #25845

We want to send update to slack channels when a pipeline context starts and stops (success or failure).
We also want publish pipeline to fail if a dagger operation takes more than 1H.


## How
* Send message to #publish-on-merge-updates when entering or exiting 
* Set an execute timeout to 1H
<img width="418" alt="Screen Shot 2023-05-05 at 16 33 58" src="https://user-images.githubusercontent.com/5551758/236586081-94c9ac2e-1a6d-46c0-b2e0-127468f9a212.png">

