### PR TITLE
connectors-ci: fix mounted secrets path

### DIFF
--- a/tools/ci_connector_ops/ci_connector_ops/pipelines/tests/python_connectors.py
+++ b/tools/ci_connector_ops/ci_connector_ops/pipelines/tests/python_connectors.py
@@ -81,9 +81,7 @@ class UnitTests(PytestStep):
         Returns:
             StepResult: Failure or success of the unit tests with stdout and stdout.
         """
-        connector_under_test_with_secrets = connector_under_test.with_directory(
-            f"{self.context.connector.code_directory}/secrets", self.context.secrets_dir
-        )
+        connector_under_test_with_secrets = connector_under_test.with_directory("secrets", self.context.secrets_dir)
         return await self._run_tests_in_directory(connector_under_test_with_secrets, "unit_tests")
 
 
@@ -101,9 +99,7 @@ class IntegrationTests(PytestStep):
         Returns:
             StepResult: Failure or success of the integration tests with stdout and stdout.
         """
-        connector_under_test_with_secrets = connector_under_test.with_directory(
-            f"{self.context.connector.code_directory}/secrets", self.context.secrets_dir
-        )
+        connector_under_test_with_secrets = connector_under_test.with_directory("secrets", self.context.secrets_dir)
 
         return await self._run_tests_in_directory(connector_under_test_with_secrets, "integration_tests")
 


### PR DESCRIPTION
## What
The secrets folder was not mounted to the right path on UnitTests and IntegrationTests