### PR TITLE
Rectify schema to accept string values in lead_id

### DIFF
--- a/airbyte-integrations/connectors/source-pipedrive/source_pipedrive/schemas/notes.json
+++ b/airbyte-integrations/connectors/source-pipedrive/source_pipedrive/schemas/notes.json
@@ -18,7 +18,7 @@
       "type": ["null", "integer"]
     },
     "lead_id": {
-      "type": ["null", "integer"]
+      "type": ["null", "string"]
     },
     "content": {
       "type": ["null", "string"]


### PR DESCRIPTION
The lead_id is a string and generates errors when importing notes

## What
Systematic error when importing notes during dbt normalization

## How
Modified schema from int to string
