### PR TITLE
Connector builder documentation: Small adjustments

### DIFF
--- a/docs/connector-development/connector-builder-ui/authentication.md
+++ b/docs/connector-development/connector-builder-ui/authentication.md
@@ -26,7 +26,6 @@ If requests are authenticated using the Basic HTTP authentication method, the do
 - "Basic Auth"
 - "Basic HTTP"
 - "Authorization: Basic"
-- "Base64"
 
 The Basic HTTP authentication method is a standard and doesn't require any further configuration. Username and password are set via "Testing values" in the connector builder and by the end user when configuring this connector as a Source.
 

--- a/docs/connector-development/connector-builder-ui/connector-builder-compatibility.md
+++ b/docs/connector-development/connector-builder-ui/connector-builder-compatibility.md
@@ -87,7 +87,6 @@ Are requests authenticated using the Basic HTTP authentication method? You can s
 - "Basic Auth"
 - "Basic HTTP"
 - "Authorization: Basic"
-- "Base64"
 
 Example: [Greenhouse](https://developers.greenhouse.io/harvest.html#introduction)
 
@@ -123,7 +122,7 @@ Example:
 - Yes: [Gitlab](https://docs.gitlab.com/ee/api/oauth2.html)
 - No: [Square](https://developer.squareup.com/docs/oauth-api/overview), [Woocommerce](https://woocommerce.github.io/woocommerce-rest-api-docs/#introduction)
 
-If the OAuth flow requires a single-use refresh token, use the [Python CDK](https://github.com/airbytehq/airbyte/issues/18035).
+If the OAuth flow requires a single-use refresh token, use the Python CDK.
 If the refresh request requires custom query parameters or request headers, use the Python CDK.
 If the refresh request requires a [grant type](https://oauth.net/2/grant-types/) that is not "Refresh Token", such as an Authorization Code, or a PKCE, use the Python CDK. 
 If the authentication mechanism is OAuth flow 2.0 with refresh token and does not require refreshing the refresh token or custom query params, it is compatible with the Connector Builder.
@@ -147,7 +146,7 @@ If the data is not formatted as JSON, use the Python CDK.
 ## How are records paginated?
 Look up the pagination mechanism in the API documentation, and identify which type it is.
 
-Here are the standard pagination mechanisms:
+Here are the standard pagination mechanisms the connector builder supports:
 
 ### Page count
 Endpoints using page count pagination accept two pagination parameters
@@ -178,7 +177,7 @@ Example: [Greenhouse](https://developers.greenhouse.io/harvest.html#pagination)
 The Connector Builder currently only supports key-value query params and request body parameters.
 This means endpoints requiring [GraphQL](https://graphql.org/) are not well supported at the moment.
 
-An example of an endpoint that would be tricky to implement with the Connector Builder is [SproutSocial’s Analytics endpoint](https://api.sproutsocial.com/docs/#analytics-endpoints).
+An example of an endpoint that can't be implemented with the Connector Builder is [SproutSocial’s Analytics endpoint](https://api.sproutsocial.com/docs/#analytics-endpoints).
 
 The endpoint requires a list of filters and metrics.
 

--- a/docs/connector-development/connector-builder-ui/overview.md
+++ b/docs/connector-development/connector-builder-ui/overview.md
@@ -68,12 +68,6 @@ Follow the instructions in the connector README to build the Docker image. Typic
 
 From this point on your connector is a regular low-code CDK connector and can be distributed as a docker image and made part of the regular Airbyte connector catalog - you can find the [publish process on the overview page](/connector-development/#publishing-a-connector).
 
-### Building the connector image
-
-Follow the instructions in the connector README to build the Docker image. Typically this will be something like `docker build . -t airbyte/source-<name>:<version>`.
-
-Once you've built the connector image, [follow these instructions](https://docs.airbyte.com/integrations/custom-connectors#adding-your-connectors-in-the-ui) to add your connector to your Airbyte instance.
-
 ## Examples
 
 A lot of [Airbyte-managed connectors](https://github.com/airbytehq/airbyte/tree/master/airbyte-integrations/connectors) are based on the low-code CDK. They can be identified by the `manifest.yaml` file in place of python files.


### PR DESCRIPTION
I asked for feedback about our docs, doing some small fixes here:
* Remove "base64" as a keyword to look for for basic auth - while it's often related to basic auth, it can also mean something else and the "basic" is a very official term to look for
* Removed a link to an issue for single use refresh tokens - this link won't help users if they have to implement this themselves and might only be frustrating
* Clarify some wordings
* Remove a paragraph with duplicate information (the same stuff is already stated on the same page)