### PR TITLE
connectors-ci: always run metadata validation and report success if no validation happened

### DIFF
--- a/.github/workflows/metadata_validate_manifest_dagger.yml
+++ b/.github/workflows/metadata_validate_manifest_dagger.yml
@@ -3,10 +3,6 @@ name: Connectors' metadata.yaml files validation
 on:
   workflow_dispatch:
   pull_request:
-    paths:
-      - "airbyte-integrations/connectors/source-**"
-      - "airbyte-integrations/connectors/destination-**"
-      - "airbyte-integrations/connectors/third-party/**"
 
 jobs:
   connectors_metadata_validation:

--- a/tools/ci_connector_ops/ci_connector_ops/pipelines/bases.py
+++ b/tools/ci_connector_ops/ci_connector_ops/pipelines/bases.py
@@ -229,7 +229,7 @@ class Report:
 
     @property
     def success(self) -> bool:  # noqa D102
-        return len(self.failed_steps) == 0 and len(self.steps_results) > 0
+        return len(self.failed_steps) == 0
 
     @property
     def run_duration(self) -> int:  # noqa D102

--- a/tools/ci_connector_ops/ci_connector_ops/pipelines/commands/groups/metadata.py
+++ b/tools/ci_connector_ops/ci_connector_ops/pipelines/commands/groups/metadata.py
@@ -19,6 +19,7 @@ from rich.logging import RichHandler
 logging.basicConfig(level=logging.INFO, format="%(name)s: %(message)s", datefmt="[%X]", handlers=[RichHandler(rich_tracebacks=True)])
 logger = logging.getLogger(__name__)
 
+
 # MAIN GROUP
 
 
@@ -37,9 +38,6 @@ def metadata(ctx: click.Context):
 def validate(ctx: click.Context, modified_only: bool) -> bool:
     if modified_only:
         metadata_to_validate = get_modified_metadata_files(ctx.obj["modified_files"])
-        if not metadata_to_validate:
-            click.secho("No modified metadata found. Skipping metadata validation.")
-            return True
     else:
         click.secho("Will run metadata validation on all the metadata files found in the repo.")
         metadata_to_validate = get_all_metadata_files()

--- a/tools/ci_connector_ops/ci_connector_ops/pipelines/pipelines/metadata.py
+++ b/tools/ci_connector_ops/ci_connector_ops/pipelines/pipelines/metadata.py
@@ -65,20 +65,13 @@ class MetadataUpload(PoetryRun):
         self.gcs_bucket_name = gcs_bucket_name
         super().__init__(context, title, METADATA_DIR, METADATA_LIB_MODULE_PATH)
 
-        docker_hub_username_secret: dagger.Secret = (
-            self.context.dagger_client.host().env_variable("DOCKER_HUB_USERNAME").secret()
-        )
+        docker_hub_username_secret: dagger.Secret = self.context.dagger_client.host().env_variable("DOCKER_HUB_USERNAME").secret()
 
-        docker_hub_password_secret: dagger.Secret = (
-            self.context.dagger_client.host().env_variable("DOCKER_HUB_PASSWORD").secret()
-        )
+        docker_hub_password_secret: dagger.Secret = self.context.dagger_client.host().env_variable("DOCKER_HUB_PASSWORD").secret()
 
         self.poetry_run_container = (
-            self.poetry_run_container
-            .with_file(METADATA_FILE_NAME, get_metadata_file_from_path(context, metadata_path))
-            .with_new_file(
-                self.GCS_CREDENTIALS_CONTAINER_PATH, gcs_credentials.replace("\n", "")
-            )
+            self.poetry_run_container.with_file(METADATA_FILE_NAME, get_metadata_file_from_path(context, metadata_path))
+            .with_new_file(self.GCS_CREDENTIALS_CONTAINER_PATH, gcs_credentials.replace("\n", ""))
             .with_secret_variable("DOCKER_HUB_USERNAME", docker_hub_username_secret)
             .with_secret_variable("DOCKER_HUB_PASSWORD", docker_hub_password_secret)
             # The cache buster ensures we always run the upload command (in case of remote bucket change)
@@ -160,7 +153,7 @@ async def run_metadata_validation_pipeline(
     metadata_to_validate: Set[Path],
 ) -> bool:
     metadata_pipeline_context = PipelineContext(
-        pipeline_name="Metadata Service Validation Pipeline",
+        pipeline_name="Validate metadata.yaml files",
         is_local=is_local,
         git_branch=git_branch,
         git_revision=git_revision,


### PR DESCRIPTION
## What
We want to make the metadata validation a required Github status check when a PR targets `master`.
Required checks can't be dynamically declared, so we have to run the metadata validation pipelines on all the PRs, even those not editing the `metadata.yaml` files.


## How
* Change the GHA workflow to perform metadata validation on all PRs.
* Emit a success status check when no metadata files were modified.

## 🚨 User Impact 🚨
@bnchrch the `Validate metadata.yaml files` check should be declared as mandatory. Not the `Connectors' metadata.yaml files validation` why:

* `Connectors' metadata.yaml files validation`: it's the GHA workflow run. IMO it should always succeeds unless an unhandled exception happenned.
* `Validate metadata.yaml files`: It's the actual status update sent by Dagger pipelines.