### PR TITLE
Source Amazon Ads: get rid of `fail_on_extra_columns: false` in SAT

### DIFF
--- a/airbyte-config-oss/init-oss/src/main/resources/seed/oss_catalog.json
+++ b/airbyte-config-oss/init-oss/src/main/resources/seed/oss_catalog.json
@@ -8688,7 +8688,7 @@
     "sourceDefinitionId": "c6b0a29e-1da9-4512-9002-7bfd0cba2246",
     "name": "Amazon Ads",
     "dockerRepository": "airbyte/source-amazon-ads",
-    "dockerImageTag": "1.0.5",
+    "dockerImageTag": "1.0.6",
     "documentationUrl": "https://docs.airbyte.com/integrations/sources/amazon-ads",
     "icon": "amazonads.svg",
     "sourceType": "api",

--- a/airbyte-config-oss/init-oss/src/main/resources/seed/source_definitions.yaml
+++ b/airbyte-config-oss/init-oss/src/main/resources/seed/source_definitions.yaml
@@ -73,7 +73,7 @@
 - name: Amazon Ads
   sourceDefinitionId: c6b0a29e-1da9-4512-9002-7bfd0cba2246
   dockerRepository: airbyte/source-amazon-ads
-  dockerImageTag: 1.0.5
+  dockerImageTag: 1.0.6
   documentationUrl: https://docs.airbyte.com/integrations/sources/amazon-ads
   icon: amazonads.svg
   sourceType: api

--- a/airbyte-config-oss/init-oss/src/main/resources/seed/source_specs.yaml
+++ b/airbyte-config-oss/init-oss/src/main/resources/seed/source_specs.yaml
@@ -852,7 +852,7 @@
     supportsNormalization: false
     supportsDBT: false
     supported_destination_sync_modes: []
-- dockerImage: "airbyte/source-amazon-ads:1.0.5"
+- dockerImage: "airbyte/source-amazon-ads:1.0.6"
   spec:
     documentationUrl: "https://docs.airbyte.com/integrations/sources/amazon-ads"
     connectionSpecification:

--- a/airbyte-integrations/connectors/source-amazon-ads/Dockerfile
+++ b/airbyte-integrations/connectors/source-amazon-ads/Dockerfile
@@ -14,5 +14,5 @@ ENTRYPOINT ["python", "/airbyte/integration_code/main.py"]
 
 
 
-LABEL io.airbyte.version=1.0.5
+LABEL io.airbyte.version=1.0.6
 LABEL io.airbyte.name=airbyte/source-amazon-ads

--- a/airbyte-integrations/connectors/source-amazon-ads/acceptance-test-config.yml
+++ b/airbyte-integrations/connectors/source-amazon-ads/acceptance-test-config.yml
@@ -28,7 +28,6 @@ acceptance_tests:
         timeout_seconds: 2400
         expect_records:
           path: integration_tests/expected_records.jsonl
-        fail_on_extra_columns: false
   connection:
     tests:
       - config_path: secrets/config.json

--- a/airbyte-integrations/connectors/source-amazon-ads/metadata.yaml
+++ b/airbyte-integrations/connectors/source-amazon-ads/metadata.yaml
@@ -8,7 +8,7 @@ data:
   connectorSubtype: api
   connectorType: source
   definitionId: c6b0a29e-1da9-4512-9002-7bfd0cba2246
-  dockerImageTag: 1.0.5
+  dockerImageTag: 1.0.6
   dockerRepository: airbyte/source-amazon-ads
   githubIssueLabel: source-amazon-ads
   icon: amazonads.svg

--- a/airbyte-integrations/connectors/source-amazon-ads/source_amazon_ads/schemas/common.py
+++ b/airbyte-integrations/connectors/source-amazon-ads/source_amazon_ads/schemas/common.py
@@ -36,6 +36,9 @@ class CatalogModel(BaseModel):
                 if "type" in prop:
                     if allow_none:
                         prop["type"] = ["null", prop["type"]]
+                    if prop["type"] == "array" and prop["items"]:
+                        if prop["items"].pop("additionalProperties", None):
+                            prop["items"]["additionalProperties"] = True
 
 
 class MetricsReport(CatalogModel):

--- a/airbyte-integrations/connectors/source-amazon-ads/source_amazon_ads/schemas/sponsored_display.py
+++ b/airbyte-integrations/connectors/source-amazon-ads/source_amazon_ads/schemas/sponsored_display.py
@@ -3,7 +3,7 @@
 #
 
 from decimal import Decimal
-from typing import List, Dict
+from typing import Dict, List
 
 from .common import CatalogModel, Targeting
 

--- a/airbyte-integrations/connectors/source-amazon-ads/source_amazon_ads/schemas/sponsored_display.py
+++ b/airbyte-integrations/connectors/source-amazon-ads/source_amazon_ads/schemas/sponsored_display.py
@@ -3,6 +3,7 @@
 #
 
 from decimal import Decimal
+from typing import List, Dict
 
 from .common import CatalogModel, Targeting
 
@@ -29,6 +30,7 @@ class DisplayAdGroup(CatalogModel):
     bidOptimization: str
     state: str
     tactic: str
+    creativeType: str
 
 
 class DisplayProductAds(CatalogModel):
@@ -41,4 +43,5 @@ class DisplayProductAds(CatalogModel):
 
 
 class DisplayTargeting(Targeting):
-    pass
+    expression: List[Dict[str, str]]
+    resolvedExpression: List[Dict[str, str]]

--- a/airbyte-integrations/connectors/source-amazon-ads/source_amazon_ads/schemas/sponsored_products.py
+++ b/airbyte-integrations/connectors/source-amazon-ads/source_amazon_ads/schemas/sponsored_products.py
@@ -27,6 +27,7 @@ class ProductCampaign(CatalogModel):
     targetingType: str
     state: str
     dailyBudget: Decimal
+    ruleBasedBudget: Dict[str, str]
     startDate: str
     endDate: str = None
     premiumBidAdjustment: bool
@@ -52,3 +53,5 @@ class ProductAd(CatalogModel):
 
 class ProductTargeting(Targeting):
     campaignId: Decimal
+    expression: List[Dict[str, str]]
+    resolvedExpression: List[Dict[str, str]]

--- a/airbyte-integrations/connectors/source-amazon-ads/unit_tests/conftest.py
+++ b/airbyte-integrations/connectors/source-amazon-ads/unit_tests/conftest.py
@@ -62,7 +62,7 @@ def product_ads_response():
 @fixture
 def targeting_response():
     return """
-[{"targetId":123,"adGroupId":321,"state":"enabled","expressionType":"manual","bid":1.5,"expression":{"type":"asinSameAs","value":"B0123456789"},"resolvedExpression":{"type":"views","values":{"type":"asinCategorySameAs","value":"B0123456789"}}}]
+[{"targetId":123,"adGroupId":321,"state":"enabled","expressionType":"manual","bid":1.5,"expression":[{"type":"asinSameAs","value":"B0123456789"}],"resolvedExpression":[{"type":"views","values":{"type":"asinCategorySameAs","value":"B0123456789"}}]}]
 """
 
 

--- a/docs/integrations/sources/amazon-ads.md
+++ b/docs/integrations/sources/amazon-ads.md
@@ -94,6 +94,7 @@ Information about expected report generation waiting time you may find [here](ht
 
 | Version | Date       | Pull Request                                             | Subject                                                                                                         |
 |:--------|:-----------|:---------------------------------------------------------|:----------------------------------------------------------------------------------------------------------------|
+| 1.0.5   | 2023-05-09 | [25792](https://github.com/airbytehq/airbyte/pull/25792) | Small schema fixes                                                                                              |
 | 1.0.5   | 2023-05-08 | [25885](https://github.com/airbytehq/airbyte/pull/25885) | Improve error handling for attribution_report(s) streams                                                        |
 | 1.0.4   | 2023-05-04 | [25792](https://github.com/airbytehq/airbyte/pull/25792) | Add availability strategy for basic streams (not including report streams)                                      |
 | 1.0.3   | 2023-04-13 | [25146](https://github.com/airbytehq/airbyte/pull/25146) | Validate pk for reports when expected pk is not returned                                                        |

--- a/docs/integrations/sources/amazon-ads.md
+++ b/docs/integrations/sources/amazon-ads.md
@@ -94,7 +94,7 @@ Information about expected report generation waiting time you may find [here](ht
 
 | Version | Date       | Pull Request                                             | Subject                                                                                                         |
 |:--------|:-----------|:---------------------------------------------------------|:----------------------------------------------------------------------------------------------------------------|
-| 1.0.6   | 2023-05-09 | [25792](https://github.com/airbytehq/airbyte/pull/25792) | Small schema fixes                                                                                              |
+| 1.0.6   | 2023-05-09 | [25913](https://github.com/airbytehq/airbyte/pull/25913) | Small schema fixes                                                                                              |
 | 1.0.5   | 2023-05-08 | [25885](https://github.com/airbytehq/airbyte/pull/25885) | Improve error handling for attribution_report(s) streams                                                        |
 | 1.0.4   | 2023-05-04 | [25792](https://github.com/airbytehq/airbyte/pull/25792) | Add availability strategy for basic streams (not including report streams)                                      |
 | 1.0.3   | 2023-04-13 | [25146](https://github.com/airbytehq/airbyte/pull/25146) | Validate pk for reports when expected pk is not returned                                                        |

--- a/docs/integrations/sources/amazon-ads.md
+++ b/docs/integrations/sources/amazon-ads.md
@@ -94,7 +94,7 @@ Information about expected report generation waiting time you may find [here](ht
 
 | Version | Date       | Pull Request                                             | Subject                                                                                                         |
 |:--------|:-----------|:---------------------------------------------------------|:----------------------------------------------------------------------------------------------------------------|
-| 1.0.5   | 2023-05-09 | [25792](https://github.com/airbytehq/airbyte/pull/25792) | Small schema fixes                                                                                              |
+| 1.0.6   | 2023-05-09 | [25792](https://github.com/airbytehq/airbyte/pull/25792) | Small schema fixes                                                                                              |
 | 1.0.5   | 2023-05-08 | [25885](https://github.com/airbytehq/airbyte/pull/25885) | Improve error handling for attribution_report(s) streams                                                        |
 | 1.0.4   | 2023-05-04 | [25792](https://github.com/airbytehq/airbyte/pull/25792) | Add availability strategy for basic streams (not including report streams)                                      |
 | 1.0.3   | 2023-04-13 | [25146](https://github.com/airbytehq/airbyte/pull/25146) | Validate pk for reports when expected pk is not returned                                                        |


### PR DESCRIPTION
## What
Amazon Ads passes CAT without declaring `fail_on_extra_columns: false`


## How
The following descriptions of streams that pass undeclared columns come from results of the failed connector acceptance test:

```
columns.txt:./source-amazon-ads.txt-88-The sponsored_display_ad_groups stream has the following schema errors:
columns.txt:./source-amazon-ads.txt:89:Additional properties are not allowed ('creativeType' was unexpected)
columns.txt:./source-amazon-ads.txt-112-The sponsored_display_targetings stream has the following schema errors:
columns.txt:./source-amazon-ads.txt:113:Additional properties are not allowed ('expression', 'resolvedExpression' were unexpected)
columns.txt:./source-amazon-ads.txt-133-The sponsored_product_campaigns stream has the following schema errors:
columns.txt:./source-amazon-ads.txt:134:Additional properties are not allowed ('ruleBasedBudget' was unexpected)
columns.txt:./source-amazon-ads.txt-175-The sponsored_product_targetings stream has the following schema errors:
columns.txt:./source-amazon-ads.txt:176:Additional properties are not allowed ('expression', 'resolvedExpression' were unexpected)

```

1. Add the missing properties indicated by the `Additional properties are not allowed ('<column>', 'column' were unexpected)` logs to the connector's spec.
2. Remove `fail_on_extra_columns: false` from the `acceptance-test-config.yml` file.
3. Commit changes to spec and `acceptance-test-config.yml` and open a PR.
4. Run tests on the connector, either automatically via CI or manually via the `/test` command
5. Profit!
