### PR TITLE
🚨🚨 Destination Clickhouse: Add cluster support and custom CA verification

### DIFF
--- a/airbyte-integrations/bases/base-normalization/normalization/transform_config/transform.py
+++ b/airbyte-integrations/bases/base-normalization/normalization/transform_config/transform.py
@@ -316,6 +316,16 @@ class TransformConfig:
     @staticmethod
     def transform_clickhouse(config: Dict[str, Any]):
         print("transform_clickhouse")
+
+        deploy_type = config.get("deploy_type", {})
+        engine = config.get("engine", "MergeTree")
+        is_cluster_mode = deploy_type.get("deploy_type") == "self-hosted-cluster"
+        cluster = ""
+        if is_cluster_mode:
+            cluster = deploy_type.get("cluster", "")
+            if deploy_type.get("replication", False):
+                engine = f"Replicated{engine}"
+
         # https://docs.getdbt.com/reference/warehouse-profiles/clickhouse-profile
         dbt_config = {
             "type": "clickhouse",
@@ -325,6 +335,9 @@ class TransformConfig:
             "port": config["port"],
             "schema": config["database"],
             "user": config["username"],
+            "cluster": cluster,
+            "cluster_mode": is_cluster_mode,
+            "engine": engine,
         }
         if "password" in config:
             dbt_config["password"] = config["password"]

--- a/airbyte-integrations/bases/base-normalization/unit_tests/test_transform_config.py
+++ b/airbyte-integrations/bases/base-normalization/unit_tests/test_transform_config.py
@@ -435,7 +435,20 @@ class TestTransformConfig:
         assert extract_schema(actual) == "my_db"
 
     def test_transform_clickhouse(self):
-        input = {"host": "airbyte.io", "port": 9440, "database": "default", "username": "ch", "password": "password1234", "ssl": True}
+        input = {
+            "host": "airbyte.io",
+            "port": 9440,
+            "database": "default",
+            "username": "ch",
+            "password": "password1234",
+            "ssl": True,
+            "deploy_type": {
+                "deploy_type": "self-hosted-cluster",
+                "cluster": "my-cluster",
+                "replication": True
+            },
+            "engine": "MergeTree"
+        }
 
         actual = TransformConfig().transform_clickhouse(input)
         expected = {
@@ -448,6 +461,9 @@ class TestTransformConfig:
             "user": "ch",
             "password": "password1234",
             "secure": True,
+            "cluster_mode": True,
+            "cluster": "my-cluster",
+            "engine": "ReplicatedMergeTree"
         }
 
         assert expected == actual

--- a/airbyte-integrations/connectors/destination-clickhouse/Dockerfile
+++ b/airbyte-integrations/connectors/destination-clickhouse/Dockerfile
@@ -16,5 +16,5 @@ ENV APPLICATION destination-clickhouse
 
 COPY --from=build /airbyte /airbyte
 
-LABEL io.airbyte.version=0.2.3
+LABEL io.airbyte.version=0.3.0
 LABEL io.airbyte.name=airbyte/destination-clickhouse

--- a/airbyte-integrations/connectors/destination-clickhouse/build.gradle
+++ b/airbyte-integrations/connectors/destination-clickhouse/build.gradle
@@ -18,6 +18,7 @@ dependencies {
     implementation files(project(':airbyte-integrations:bases:base-java').airbyteDocker.outputs)
 
     implementation 'com.clickhouse:clickhouse-jdbc:0.3.2-patch10:all'
+    implementation 'org.apache.commons:commons-text:1.10.0'
 
     // https://mvnrepository.com/artifact/org.testcontainers/clickhouse
     testImplementation libs.connectors.destination.testcontainers.clickhouse

--- a/airbyte-integrations/connectors/destination-clickhouse/metadata.yaml
+++ b/airbyte-integrations/connectors/destination-clickhouse/metadata.yaml
@@ -2,7 +2,7 @@ data:
   connectorSubtype: database
   connectorType: destination
   definitionId: ce0d828e-1dc4-496c-b122-2da42e637e48
-  dockerImageTag: 0.2.3
+  dockerImageTag: 0.3.0
   dockerRepository: airbyte/destination-clickhouse
   githubIssueLabel: destination-clickhouse
   icon: clickhouse.svg

--- a/airbyte-integrations/connectors/destination-clickhouse/src/main/java/io/airbyte/integrations/destination/clickhouse/ClickhouseDestination.java
+++ b/airbyte-integrations/connectors/destination-clickhouse/src/main/java/io/airbyte/integrations/destination/clickhouse/ClickhouseDestination.java
@@ -12,16 +12,25 @@ import io.airbyte.db.factory.DataSourceFactory;
 import io.airbyte.db.factory.DatabaseDriver;
 import io.airbyte.db.jdbc.JdbcDatabase;
 import io.airbyte.db.jdbc.JdbcUtils;
+import io.airbyte.integrations.base.AirbyteMessageConsumer;
 import io.airbyte.integrations.base.Destination;
 import io.airbyte.integrations.base.IntegrationRunner;
 import io.airbyte.integrations.base.ssh.SshWrappedDestination;
 import io.airbyte.integrations.destination.NamingConventionTransformer;
 import io.airbyte.integrations.destination.jdbc.AbstractJdbcDestination;
+import io.airbyte.integrations.destination.jdbc.JdbcBufferedConsumerFactory;
+import io.airbyte.integrations.destination.jdbc.SqlOperations;
 import io.airbyte.protocol.models.v0.AirbyteConnectionStatus;
 import io.airbyte.protocol.models.v0.AirbyteConnectionStatus.Status;
+import io.airbyte.protocol.models.v0.AirbyteMessage;
+import io.airbyte.protocol.models.v0.ConfiguredAirbyteCatalog;
+import java.io.IOException;
+import java.io.PrintWriter;
+import java.nio.charset.StandardCharsets;
 import java.util.Collections;
 import java.util.List;
 import java.util.Map;
+import java.util.function.Consumer;
 import javax.sql.DataSource;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -34,10 +43,17 @@ public class ClickhouseDestination extends AbstractJdbcDestination implements De
 
   public static final String HTTPS_PROTOCOL = "https";
   public static final String HTTP_PROTOCOL = "http";
+  public static final String SSL_VERIFICATION_METHOD_KEY = "ssl_mode";
+  public static final String DEFAULT_SSL_VERIFICATION_METHOD = "none";
+  public static final String CA_CERT_FILENAME = "ca.crt";
+
+  // Create an extra SqlOperations object because the one in the superclass is
+  // private and we need to access it
+  private final ClickhouseSqlOperations configurableSqlOperations;
 
   static final List<String> SSL_PARAMETERS = ImmutableList.of(
       "socket_timeout=3000000",
-      "sslmode=NONE");
+      "ssl=true");
   static final List<String> DEFAULT_PARAMETERS = ImmutableList.of(
       "socket_timeout=3000000");
 
@@ -47,11 +63,32 @@ public class ClickhouseDestination extends AbstractJdbcDestination implements De
 
   public ClickhouseDestination() {
     super(DRIVER_CLASS, new ClickhouseSQLNameTransformer(), new ClickhouseSqlOperations());
+    configurableSqlOperations = new ClickhouseSqlOperations();
+  }
+
+  @Override
+  protected SqlOperations getSqlOperations() {
+    return configurableSqlOperations;
+  }
+
+  private static void createCertificateFile(String fileName, String fileValue) throws IOException {
+    try (final PrintWriter out = new PrintWriter(fileName, StandardCharsets.UTF_8)) {
+      out.print(fileValue);
+    }
   }
 
   @Override
   public JsonNode toJdbcConfig(final JsonNode config) {
     final boolean isSsl = JdbcUtils.useSsl(config);
+    final String sslVerificationMethod = config.has(SSL_VERIFICATION_METHOD_KEY)
+        && config.get(SSL_VERIFICATION_METHOD_KEY).has("mode")
+            ? config.get(SSL_VERIFICATION_METHOD_KEY).get("mode").asText()
+            : DEFAULT_SSL_VERIFICATION_METHOD;
+    final String caCertificate = config.has(SSL_VERIFICATION_METHOD_KEY)
+        && config.get(SSL_VERIFICATION_METHOD_KEY).has("ca_certificate")
+            ? config.get(SSL_VERIFICATION_METHOD_KEY).get("ca_certificate").asText()
+            : null;
+
     final StringBuilder jdbcUrl = new StringBuilder(
         String.format(DatabaseDriver.CLICKHOUSE.getUrlFormatString(),
             isSsl ? HTTPS_PROTOCOL : HTTP_PROTOCOL,
@@ -61,6 +98,16 @@ public class ClickhouseDestination extends AbstractJdbcDestination implements De
 
     if (isSsl) {
       jdbcUrl.append("?").append(String.join("&", SSL_PARAMETERS));
+      jdbcUrl.append(String.format("&sslmode=%s", sslVerificationMethod));
+
+      if (sslVerificationMethod.equals("strict") && caCertificate != null && !caCertificate.equals("")) {
+        try {
+          createCertificateFile(CA_CERT_FILENAME, caCertificate);
+        } catch (final IOException e) {
+          throw new RuntimeException("Failed to create encryption file");
+        }
+        jdbcUrl.append(String.format("&sslrootcert=%s", CA_CERT_FILENAME));
+      }
     } else {
       jdbcUrl.append("?").append(String.join("&", DEFAULT_PARAMETERS));
     }
@@ -87,7 +134,8 @@ public class ClickhouseDestination extends AbstractJdbcDestination implements De
       final JdbcDatabase database = getDatabase(dataSource);
       final NamingConventionTransformer namingResolver = getNamingResolver();
       final String outputSchema = namingResolver.getIdentifier(config.get(JdbcUtils.DATABASE_KEY).asText());
-      attemptSQLCreateAndDropTableOperations(outputSchema, database, namingResolver, getSqlOperations());
+      configurableSqlOperations.setConfig(ClickhouseDestinationConfig.get(config));
+      attemptSQLCreateAndDropTableOperations(outputSchema, database, namingResolver, configurableSqlOperations);
       return new AirbyteConnectionStatus().withStatus(Status.SUCCEEDED);
     } catch (final Exception e) {
       LOGGER.error("Exception while checking connection: ", e);
@@ -113,6 +161,16 @@ public class ClickhouseDestination extends AbstractJdbcDestination implements De
     LOGGER.info("starting destination: {}", ClickhouseDestination.class);
     new IntegrationRunner(destination).run(args);
     LOGGER.info("completed destination: {}", ClickhouseDestination.class);
+  }
+
+  @Override
+  public AirbyteMessageConsumer getConsumer(final JsonNode config,
+                                            final ConfiguredAirbyteCatalog catalog,
+                                            final Consumer<AirbyteMessage> outputRecordCollector) {
+    configurableSqlOperations.setConfig(ClickhouseDestinationConfig.get(config));
+    return JdbcBufferedConsumerFactory.create(outputRecordCollector, getDatabase(getDataSource(config)),
+        configurableSqlOperations, getNamingResolver(), config,
+        catalog);
   }
 
 }

--- a/airbyte-integrations/connectors/destination-clickhouse/src/main/java/io/airbyte/integrations/destination/clickhouse/ClickhouseDestinationConfig.java
+++ b/airbyte-integrations/connectors/destination-clickhouse/src/main/java/io/airbyte/integrations/destination/clickhouse/ClickhouseDestinationConfig.java
@@ -1,0 +1,22 @@
+/*
+ * Copyright (c) 2023 Airbyte, Inc., all rights reserved.
+ */
+
+package io.airbyte.integrations.destination.clickhouse;
+
+import com.fasterxml.jackson.databind.JsonNode;
+
+// This configuration class does not include the default JDBC configuration parameters.
+public record ClickhouseDestinationConfig(String engine,
+                                          ClickhouseDestinationDeployTypeConfig deploy_config) {
+
+  public final static String DEFAULT_ENGINE = "MergeTree";
+
+  public static ClickhouseDestinationConfig get(final JsonNode config) {
+    return new ClickhouseDestinationConfig(
+        config.has("engine") ? config.get("engine").asText() : DEFAULT_ENGINE,
+        config.has("deploy_type") ? ClickhouseDestinationDeployTypeConfig.get(config.get("deploy_type"))
+            : ClickhouseDestinationDeployTypeConfig.defaultConfig());
+  }
+
+}

--- a/airbyte-integrations/connectors/destination-clickhouse/src/main/java/io/airbyte/integrations/destination/clickhouse/ClickhouseDestinationDeployTypeConfig.java
+++ b/airbyte-integrations/connectors/destination-clickhouse/src/main/java/io/airbyte/integrations/destination/clickhouse/ClickhouseDestinationDeployTypeConfig.java
@@ -1,0 +1,27 @@
+/*
+ * Copyright (c) 2023 Airbyte, Inc., all rights reserved.
+ */
+
+package io.airbyte.integrations.destination.clickhouse;
+
+import com.fasterxml.jackson.databind.JsonNode;
+
+public record ClickhouseDestinationDeployTypeConfig(String type, String cluster, boolean replication) {
+
+  public static final String DEFAULT_DEPLOY_TYPE = "clickhouse-cloud";
+  public static final String DEFAULT_CLUSTER_NAME = "default";
+  public static final boolean DEFAULT_REPLICATION = false;
+
+  public static ClickhouseDestinationDeployTypeConfig get(final JsonNode config) {
+    return new ClickhouseDestinationDeployTypeConfig(
+        config.has("deploy_type") ? config.get("deploy_type").asText() : DEFAULT_DEPLOY_TYPE,
+        config.has("cluster") ? config.get("cluster").asText() : DEFAULT_CLUSTER_NAME,
+        config.has("replication") ? config.get("replication").asBoolean() : DEFAULT_REPLICATION);
+  }
+
+  public static ClickhouseDestinationDeployTypeConfig defaultConfig() {
+    return new ClickhouseDestinationDeployTypeConfig(DEFAULT_DEPLOY_TYPE, DEFAULT_CLUSTER_NAME,
+        DEFAULT_REPLICATION);
+  }
+
+}

--- a/airbyte-integrations/connectors/destination-clickhouse/src/main/java/io/airbyte/integrations/destination/clickhouse/ClickhouseSqlOperations.java
+++ b/airbyte-integrations/connectors/destination-clickhouse/src/main/java/io/airbyte/integrations/destination/clickhouse/ClickhouseSqlOperations.java
@@ -15,17 +15,35 @@ import java.io.File;
 import java.io.IOException;
 import java.nio.file.Files;
 import java.sql.SQLException;
+import java.util.HashMap;
 import java.util.List;
+import java.util.Map;
+import org.apache.commons.text.StringSubstitutor;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 public class ClickhouseSqlOperations extends JdbcSqlOperations {
 
   private static final Logger LOGGER = LoggerFactory.getLogger(ClickhouseSqlOperations.class);
+  private ClickhouseDestinationConfig config;
+
+  public void setConfig(final ClickhouseDestinationConfig config) {
+    this.config = config;
+  }
 
   @Override
   public void createSchemaIfNotExists(final JdbcDatabase database, final String schemaName) throws Exception {
-    database.execute(String.format("CREATE DATABASE IF NOT EXISTS %s;\n", schemaName));
+    StringBuilder query = new StringBuilder("CREATE DATABASE IF NOT EXISTS ${schema}");
+    if (config.deploy_config().type().equals("self-hosted-cluster")) {
+      query.append(" ON CLUSTER ${cluster}");
+    }
+    query.append(";\n");
+
+    Map<String, String> params = new HashMap<String, String>();
+    params.put("schema", schemaName);
+    params.put("cluster", config.deploy_config().cluster());
+
+    database.execute(StringSubstitutor.replace(query, params));
   }
 
   @Override
@@ -35,19 +53,93 @@ public class ClickhouseSqlOperations extends JdbcSqlOperations {
 
   @Override
   public String createTableQuery(final JdbcDatabase database, final String schemaName, final String tableName) {
-    return String.format(
-        "CREATE TABLE IF NOT EXISTS %s.%s ( \n"
-            + "%s String,\n"
-            + "%s String,\n"
-            + "%s DateTime64(3, 'GMT') DEFAULT now(),\n"
-            + "PRIMARY KEY(%s)\n"
-            + ")\n"
-            + "ENGINE = MergeTree;\n",
-        schemaName, tableName,
-        JavaBaseConstants.COLUMN_NAME_AB_ID,
-        JavaBaseConstants.COLUMN_NAME_DATA,
-        JavaBaseConstants.COLUMN_NAME_EMITTED_AT,
-        JavaBaseConstants.COLUMN_NAME_AB_ID);
+    StringBuilder query = new StringBuilder("CREATE TABLE IF NOT EXISTS ${schema}.${table}");
+
+    // On self-hosted, if clustering is enabled, change the table name to x_mat to
+    // indicate this is the materialized set of tables. Later on, we'll create the
+    // Distributed virtual tables with name x on top of these materialized tables.
+    // On Clickhouse Cloud, there is automatic sharding and replication so we don't
+    // need to do this.
+    if (config.deploy_config().type().equals("self-hosted-cluster")) {
+      query.append("_mat ON CLUSTER ${cluster}");
+    }
+
+    query.append(" ( \n"
+        + "${col_name_ab_id} String,\n"
+        + "${col_name_data} String,\n"
+        + "${col_name_emitted_at} DateTime64(3, 'GMT') DEFAULT now(),\n"
+        + "PRIMARY KEY(${col_name_ab_id})\n"
+        + ")\n"
+        + "ENGINE = ");
+
+    if (config.deploy_config().replication()) {
+      query.append("Replicated");
+    }
+    query.append("${engine}(");
+    // If we have a self hosted cluster, we need to add additional Keeper parameters
+    if (config.deploy_config().type().equals("self-hosted-cluster")) {
+      query.append("'/clickhouse/tables/{shard}/{database}/{table}', '{replica}'");
+    }
+    query.append(");\n");
+
+    // On a self-hosted cluster, we now create the Distributed virtual table,
+    // sharding on a hashed Airbyte record ID
+    if (config.deploy_config().type().equals("self-hosted-cluster")) {
+      query.append(
+          "CREATE TABLE IF NOT EXISTS ${schema}.${table} ON CLUSTER ${cluster} AS ${schema}.${table}_mat ENGINE = Distributed(${cluster}, ${schema}, ${table}_mat, cityHash64(${col_name_ab_id}));\n");
+    }
+
+    Map<String, String> params = new HashMap<String, String>();
+    params.put("schema", schemaName);
+    params.put("table", tableName);
+    params.put("cluster", config.deploy_config().cluster());
+    params.put("engine", config.engine());
+    params.put("col_name_ab_id", JavaBaseConstants.COLUMN_NAME_AB_ID);
+    params.put("col_name_data", JavaBaseConstants.COLUMN_NAME_DATA);
+    params.put("col_name_emitted_at", JavaBaseConstants.COLUMN_NAME_EMITTED_AT);
+
+    return StringSubstitutor.replace(query, params);
+  }
+
+  @Override
+  public void dropTableIfExists(final JdbcDatabase database, final String schemaName, final String tableName)
+      throws SQLException {
+    StringBuilder query = new StringBuilder("DROP TABLE IF EXISTS ${schema}.${table}");
+
+    if (config.deploy_config().type().equals("self-hosted-cluster")) {
+      query.append(" ON CLUSTER ${cluster};\n");
+      query.append("DROP TABLE IF EXISTS ${schema}.${table}_mat ON CLUSTER ${cluster}");
+    }
+    query.append(";\n");
+
+    Map<String, String> params = new HashMap<String, String>();
+    params.put("schema", schemaName);
+    params.put("table", tableName);
+    params.put("cluster", config.deploy_config().cluster());
+
+    String formattedQuery = StringSubstitutor.replace(query, params);
+
+    try {
+      database.execute(formattedQuery);
+    } catch (SQLException e) {
+      throw checkForKnownConfigExceptions(e).orElseThrow(() -> e);
+    }
+  }
+
+  @Override
+  public String truncateTableQuery(final JdbcDatabase database, final String schemaName, final String tableName) {
+    StringBuilder query = new StringBuilder("TRUNCATE TABLE ${schema}.${table}");
+    if (config.deploy_config().type().equals("self-hosted-cluster")) {
+      query.append(" ON CLUSTER ${cluster}");
+    }
+    query.append(";\n");
+
+    Map<String, String> params = new HashMap<String, String>();
+    params.put("schema", schemaName);
+    params.put("table", tableName);
+    params.put("cluster", config.deploy_config().cluster());
+
+    return StringSubstitutor.replace(query, params);
   }
 
   @Override
@@ -94,8 +186,9 @@ public class ClickhouseSqlOperations extends JdbcSqlOperations {
             Files.delete(tmpFile.toPath());
           }
         } catch (final IOException e) {
-          if (primaryException != null)
+          if (primaryException != null) {
             e.addSuppressed(primaryException);
+          }
           throw new RuntimeException(e);
         }
       }

--- a/airbyte-integrations/connectors/destination-clickhouse/src/main/java/io/airbyte/integrations/destination/clickhouse/ClickhouseSqlOperations.java
+++ b/airbyte-integrations/connectors/destination-clickhouse/src/main/java/io/airbyte/integrations/destination/clickhouse/ClickhouseSqlOperations.java
@@ -130,7 +130,7 @@ public class ClickhouseSqlOperations extends JdbcSqlOperations {
   public String truncateTableQuery(final JdbcDatabase database, final String schemaName, final String tableName) {
     StringBuilder query = new StringBuilder("TRUNCATE TABLE ${schema}.${table}");
     if (config.deploy_config().type().equals("self-hosted-cluster")) {
-      query.append(" ON CLUSTER ${cluster}");
+      query.append("_mat ON CLUSTER ${cluster}");
     }
     query.append(";\n");
 

--- a/airbyte-integrations/connectors/destination-clickhouse/src/main/resources/spec.json
+++ b/airbyte-integrations/connectors/destination-clickhouse/src/main/resources/spec.json
@@ -8,7 +8,16 @@
     "$schema": "http://json-schema.org/draft-07/schema#",
     "title": "ClickHouse Destination Spec",
     "type": "object",
-    "required": ["host", "port", "database", "username"],
+    "required": [
+      "host",
+      "port",
+      "database",
+      "username",
+      "engine",
+      "ssl_mode",
+      "ssl",
+      "deploy_type"
+    ],
     "additionalProperties": true,
     "properties": {
       "host": {
@@ -28,13 +37,13 @@
         "order": 1
       },
       "database": {
-        "title": "DB Name",
+        "title": "Database name",
         "description": "Name of the database.",
         "type": "string",
         "order": 2
       },
       "username": {
-        "title": "User",
+        "title": "Username",
         "description": "Username to use to access the database.",
         "type": "string",
         "order": 3
@@ -58,6 +67,145 @@
         "type": "boolean",
         "default": false,
         "order": 6
+      },
+      "ssl_mode": {
+        "title": "SSL verification mode",
+        "description": "Select the method of server SSL certificate verification.",
+        "type": "object",
+        "order": 7,
+        "oneOf": [
+          {
+            "title": "none",
+            "description": "Disable SSL verification.",
+            "required": ["mode"],
+            "properties": {
+              "mode": {
+                "type": "string",
+                "const": "none",
+                "enum": ["none"],
+                "default": "none",
+                "order": 0
+              }
+            }
+          },
+          {
+            "title": "strict",
+            "description": "Strict verification of server certificate (recommended).",
+            "required": ["mode"],
+            "properties": {
+              "mode": {
+                "type": "string",
+                "const": "strict",
+                "enum": ["strict"],
+                "default": "strict",
+                "order": 0
+              },
+              "ca_certificate": {
+                "type": "string",
+                "title": "CA certificate",
+                "description": "If you leave this empty, the default certificate bundle is used.",
+                "multiline": true,
+                "order": 1
+              }
+            }
+          }
+        ]
+      },
+      "engine": {
+        "title": "Engine",
+        "description": "Engine to use for new tables. The default is <b>MergeTree</b>. Refer to the <a href=\"https://clickhouse.com/docs/en/engines/table-engines\">documentation</a> for an explanation of all types.",
+        "type": "string",
+        "order": 8,
+        "default": "MergeTree",
+        "enum": [
+          "MergeTree",
+          "ReplacingMergeTree",
+          "SummingMergeTree",
+          "AggregatingMergeTree",
+          "CollapsingMergeTree",
+          "VersionedCollapsingMergeTree"
+        ]
+      },
+      "deploy_type": {
+        "title": "Deployment type",
+        "description": "Select the type of Clickhouse installation that you use.",
+        "type": "object",
+        "order": 9,
+        "oneOf": [
+          {
+            "title": "clickhouse-cloud",
+            "additionalProperties": false,
+            "description": "Clickhouse Cloud.",
+            "required": [
+              "deploy_type"
+            ],
+            "properties": {
+              "deploy_type": {
+                "type": "string",
+                "const": "clickhouse-cloud",
+                "enum": [
+                  "clickhouse-cloud"
+                ],
+                "default": "clickhouse-cloud",
+                "order": 0
+              }
+            }
+          },
+          {
+            "title": "self-hosted-single-node",
+            "additionalProperties": false,
+            "description": "A single-node self-hosted Clickhouse instance.",
+            "required": [
+              "deploy_type"
+            ],
+            "properties": {
+              "deploy_type": {
+                "type": "string",
+                "const": "self-hosted-single-node",
+                "enum": [
+                  "self-hosted-single-node"
+                ],
+                "default": "self-hosted-single-node",
+                "order": 0
+              }
+            }
+          },
+          {
+            "title": "self-hosted-cluster",
+            "additionalProperties": false,
+            "description": "A self-hosted Clickhouse cluster.",
+            "required": [
+              "deploy_type",
+              "replication",
+              "cluster"
+            ],
+            "properties": {
+              "deploy_type": {
+                "type": "string",
+                "const": "self-hosted-cluster",
+                "enum": [
+                  "self-hosted-cluster"
+                ],
+                "default": "self-hosted-cluster",
+                "order": 0
+              },
+              "replication": {
+                "title": "Replication",
+                "description": "Enable replication by using the Replicated version of the table engine you selected above.",
+                "type": "boolean",
+                "default": false,
+                "order": 1
+              },
+              "cluster": {
+                "title": "Cluster name",
+                "description": "The name of the cluster to write to.",
+                "default": "default",
+                "type": "string",
+                "order": 2
+              }
+            }
+          }
+        ]
       }
     }
   }

--- a/airbyte-integrations/connectors/destination-clickhouse/src/test/java/io/airbyte/integrations/destination/clickhouse/ClickhouseDestinationSpecTest.java
+++ b/airbyte-integrations/connectors/destination-clickhouse/src/test/java/io/airbyte/integrations/destination/clickhouse/ClickhouseDestinationSpecTest.java
@@ -36,7 +36,14 @@ public class ClickhouseDestinationSpecTest {
       + "\"port\" : 8123,  "
       + "\"host\" : \"localhost\",  "
       + "\"jdbc_url_params\" : \"property1=pValue1&property2=pValue2\",  "
-      + "\"ssl\" : true "
+      + "\"ssl\" : true, "
+      + "\"ssl_mode\": {"
+      + "  \"mode\": \"none\""
+      + "},"
+      + "\"engine\" : \"MergeTree\", "
+      + "\"deploy_type\" : {"
+      + "  \"deploy_type\": \"clickhouse-cloud\""
+      + "}"
       + "}";
 
   private static JsonNode schema;

--- a/docs/integrations/destinations/clickhouse.md
+++ b/docs/integrations/destinations/clickhouse.md
@@ -44,7 +44,7 @@ You need a ClickHouse user with the following permissions:
 You can create such a user by running:
 
 ```
-GRANT CREATE ON * TO airbyte_user;
+GRANT SELECT, INSERT, ALTER, CREATE DATABASE, CREATE TABLE, DROP TABLE, TRUNCATE ON database.* TO airbyte_user;
 ```
 
 You can also use a pre-existing user but we highly recommend creating a dedicated user for Airbyte.
@@ -62,7 +62,7 @@ You should now have all the requirements needed to configure ClickHouse as a des
 * **Username**
 * **Password**
 * **Database**
-* **Jdbc_url_params**
+* **Engine** (default `MergeTree`)
 
 ## Naming Conventions
 
@@ -80,6 +80,7 @@ Therefore, Airbyte ClickHouse destination will create tables and schemas using t
 
 | Version | Date       | Pull Request                                               | Subject                                                             |
 |:--------|:-----------|:-----------------------------------------------------------|:--------------------------------------------------------------------|
+| 0.3.0   | 2023-05-09 | [\#25914](https://github.com/airbytehq/airbyte/pull/25914)             | Add cluster and custom CA verification support                      |
 | 0.2.3   | 2023-04-04 | [\#24604](https://github.com/airbytehq/airbyte/pull/24604) | Support for destination checkpointing                               |
 | 0.2.2   | 2023-02-21 | [\#21509](https://github.com/airbytehq/airbyte/pull/21509) | Compatibility update with security patch for strict encrypt version |
 | 0.2.1   | 2022-12-06 | [\#19573](https://github.com/airbytehq/airbyte/pull/19573) | Update dbt version to 1.3.1                                         |


### PR DESCRIPTION
## What
This PR adds support for self-hosted Clickhouse instances that are clustered (i.e. use replication or sharding).
This solves issue #9134.

It also adds strict SSL verification with a custom CA.

## How
- Since the `SqlOperations` object needs additional configuration, I've created additional config classes and pass them to a new, configurable `SqlOperations` object
- Based on the selected configuration, the SQL queries are built using `StringBuilder`s
- For self-hosted-cluster configuration, the `ON CLUSTER` statement is added to all SQL queries. Additionally, a `Distributed` virtual table is created on top of the materialized tables to allow for distributed querying.
- Added an option for choosing the engine for new tables that are created by the destination. This feature is also useful for Clickhouse Cloud.
- Use `StringSubstitutor` instead of `String.format` to avoid repetition.
- Differentiate between the `none` (no verification) and `strict` (CA verification) SSL modes. Additionally allow a custom CA certificate to be provided, which is then exclusively used to verify the server certificate.

**Question: I was unsure which files in `airbyte-config`/`airbyte-config-oss` to change exactly. There's a lot of files like `oss_registry.json` and `connector_registry.json` that copy the spec from the connector. Should I copy the spec in there or is this an automated process?**

## Recommended reading order
1. Start with `spec.json` to see all new configuration options
2. See `ClickhouseDestination.java` for the new CA verification config and the passing of configuration variables to the `SqlOperations` object.
3. See `ClickhouseSqlOperations.java` for the query building for clustered self-hosted Clickhouse.

## 🚨 User Impact 🚨
Breaking change. Since new parameters were added, which are not optional, users will need to change the settings of their destination, selecting the proper `engine`, `ssl_mode` and `deploy_type`.

If desired, I can make the new parameters optional, which will prevent breaking changes, but it doesn't make much sense for enums to be optional in my opinion.

**Question: should I increase the major version because of this breaking change? It would mean moving from `0.x.y` to `1.x.y` which makes it seem like the connector is GA instead of alpha.**

*For connector PRs, use this section to explain which type of semantic versioning bump occurs as a result of the changes. Refer to our [Semantic Versioning for Connectors](https://docs.airbyte.com/contributing-to-airbyte/#semantic-versioning-for-connectors) guidelines for more information. **Breaking changes to connectors must be documented by an Airbyte engineer (PR author, or reviewer for community PRs) by using the [Breaking Change Release Playbook](https://docs.google.com/document/d/1VYQggHbL_PN0dDDu7rCyzBLGRtX-R3cpwXaY8QxEgzw/edit).***

*If there are breaking changes, please merge this PR with the 🚨🚨 emoji so changelog authors can further highlight this if needed.*

## Pre-merge Actions
*Expand the relevant checklist and delete the others.*

<details><summary><strong>Updating a connector</strong></summary>

### Community member or Airbyter

- Grant edit access to maintainers ([instructions](https://docs.github.com/en/github/collaborating-with-pull-requests/working-with-forks/allowing-changes-to-a-pull-request-branch-created-from-a-fork#enabling-repository-maintainer-permissions-on-existing-pull-requests))
- Unit & integration tests added

### Airbyter

If this is a community PR, the Airbyte engineer reviewing this PR is responsible for the below items.

- Create a non-forked branch based on this PR and test the below items on it
- Build is successful
- If new credentials are required for use in CI, add them to GSM. [Instructions](https://docs.airbyte.io/connector-development#using-credentials-in-ci).

</details>
