### PR TITLE
connectors-ci: remove slack channel mention on publish failures

### DIFF
--- a/tools/ci_connector_ops/ci_connector_ops/pipelines/contexts.py
+++ b/tools/ci_connector_ops/ci_connector_ops/pipelines/contexts.py
@@ -421,6 +421,7 @@ class ConnectorContext(PipelineContext):
         if self.state is ContextState.FAILURE:
             message += "🔴"
         message += f" {self.state.value['description']}"
-        if self.state is ContextState.FAILURE:
-            message += "\ncc. <!channel>"
+        # TODO: renable this when pipeline is stable
+        # if self.state is ContextState.FAILURE:
+        #     message += "\ncc. <!channel>"
         return message


### PR DESCRIPTION
## What
The channel mention are annoying.
Removing them until our publish pipeline is more stable and in production.
