### PR TITLE
📝 Add info on egress costs for Cloud storage connectors

### DIFF
--- a/docs/integrations/destinations/azure-blob-storage.md
+++ b/docs/integrations/destinations/azure-blob-storage.md
@@ -6,6 +6,10 @@ This destination writes data to Azure Blob Storage.
 
 The Airbyte Azure Blob Storage destination allows you to sync data to Azure Blob Storage. Each stream is written to its own blob under the container.
 
+::::info
+Cloud storage may incur egress costs. Egress refers to data that is transferred out of the cloud storage system, such as when you download files or access them from a different location. For more information, see the [Azure Blob Storage pricing guide](https://azure.microsoft.com/en-us/pricing/details/storage/blobs/).
+::::
+
 ## Prerequisites
 - For Airbyte Open Source users using the [Postgres](https://docs.airbyte.com/integrations/sources/postgres) source connector, [upgrade](https://docs.airbyte.com/operator-guides/upgrading-airbyte/) your Airbyte platform to version `v0.40.0-alpha` or newer and upgrade your AzureBlobStorage connector to version `0.1.6` or newer
 

--- a/docs/integrations/destinations/azure-blob-storage.md
+++ b/docs/integrations/destinations/azure-blob-storage.md
@@ -6,9 +6,9 @@ This destination writes data to Azure Blob Storage.
 
 The Airbyte Azure Blob Storage destination allows you to sync data to Azure Blob Storage. Each stream is written to its own blob under the container.
 
-::::info
+:::info
 Cloud storage may incur egress costs. Egress refers to data that is transferred out of the cloud storage system, such as when you download files or access them from a different location. For more information, see the [Azure Blob Storage pricing guide](https://azure.microsoft.com/en-us/pricing/details/storage/blobs/).
-::::
+:::
 
 ## Prerequisites
 - For Airbyte Open Source users using the [Postgres](https://docs.airbyte.com/integrations/sources/postgres) source connector, [upgrade](https://docs.airbyte.com/operator-guides/upgrading-airbyte/) your Airbyte platform to version `v0.40.0-alpha` or newer and upgrade your AzureBlobStorage connector to version `0.1.6` or newer

--- a/docs/integrations/destinations/gcs.md
+++ b/docs/integrations/destinations/gcs.md
@@ -6,6 +6,10 @@ This destination writes data to GCS bucket.
 
 The Airbyte GCS destination allows you to sync data to cloud storage buckets. Each stream is written to its own directory under the bucket.
 
+::::info
+Cloud storage may incur egress costs. Egress refers to data that is transferred out of the cloud storage system, such as when you download files or access them from a different location. For more information, see the [Google Cloud Storage pricing guide](https://cloud.google.com/storage/pricing).
+::::
+
 ### Sync overview
 
 #### Features

--- a/docs/integrations/destinations/gcs.md
+++ b/docs/integrations/destinations/gcs.md
@@ -6,9 +6,9 @@ This destination writes data to GCS bucket.
 
 The Airbyte GCS destination allows you to sync data to cloud storage buckets. Each stream is written to its own directory under the bucket.
 
-::::info
+:::info
 Cloud storage may incur egress costs. Egress refers to data that is transferred out of the cloud storage system, such as when you download files or access them from a different location. For more information, see the [Google Cloud Storage pricing guide](https://cloud.google.com/storage/pricing).
-::::
+:::
 
 ### Sync overview
 

--- a/docs/integrations/destinations/s3.md
+++ b/docs/integrations/destinations/s3.md
@@ -2,6 +2,10 @@
 
 This page guides you through the process of setting up the S3 destination connector.
 
+::::info
+Cloud storage may incur egress costs. Egress refers to data that is transferred out of the cloud storage system, such as when you download files or access them from a different location. For more information, see the [Amazon S3 pricing guide](https://aws.amazon.com/s3/pricing/).
+::::
+
 ## Prerequisites
 
 List of required fields:

--- a/docs/integrations/destinations/s3.md
+++ b/docs/integrations/destinations/s3.md
@@ -2,9 +2,9 @@
 
 This page guides you through the process of setting up the S3 destination connector.
 
-::::info
+:::info
 Cloud storage may incur egress costs. Egress refers to data that is transferred out of the cloud storage system, such as when you download files or access them from a different location. For more information, see the [Amazon S3 pricing guide](https://aws.amazon.com/s3/pricing/).
-::::
+:::
 
 ## Prerequisites
 

--- a/docs/integrations/sources/azure-blob-storage.md
+++ b/docs/integrations/sources/azure-blob-storage.md
@@ -2,6 +2,9 @@
 
 This page contains the setup guide and reference information for the Azure Blob Storage source connector.
 
+::::info
+Cloud storage may incur egress costs. Egress refers to data that is transferred out of the cloud storage system, such as when you download files or access them from a different location. For more information, see the [Azure Blob Storage pricing guide](https://azure.microsoft.com/en-us/pricing/details/storage/blobs/).
+::::
 
 ## Setup guide
 

--- a/docs/integrations/sources/azure-blob-storage.md
+++ b/docs/integrations/sources/azure-blob-storage.md
@@ -2,9 +2,9 @@
 
 This page contains the setup guide and reference information for the Azure Blob Storage source connector.
 
-::::info
+:::info
 Cloud storage may incur egress costs. Egress refers to data that is transferred out of the cloud storage system, such as when you download files or access them from a different location. For more information, see the [Azure Blob Storage pricing guide](https://azure.microsoft.com/en-us/pricing/details/storage/blobs/).
-::::
+:::
 
 ## Setup guide
 

--- a/docs/integrations/sources/gcs.md
+++ b/docs/integrations/sources/gcs.md
@@ -2,9 +2,9 @@
 
 This page guides you through the process of setting up the GCS source connector. This connector supports loading multiple CSV files (non compressed) from a GCS directory. The conntector will check for all files ending in `.csv`, even nested files.
 
-::::info
+:::info
 Cloud storage may incur egress costs. Egress refers to data that is transferred out of the cloud storage system, such as when you download files or access them from a different location. For more information, see the [Google Cloud Storage pricing guide](https://cloud.google.com/storage/pricing).
-::::
+:::
 
 ## Prerequisites
 

--- a/docs/integrations/sources/gcs.md
+++ b/docs/integrations/sources/gcs.md
@@ -2,6 +2,10 @@
 
 This page guides you through the process of setting up the GCS source connector. This connector supports loading multiple CSV files (non compressed) from a GCS directory. The conntector will check for all files ending in `.csv`, even nested files.
 
+::::info
+Cloud storage may incur egress costs. Egress refers to data that is transferred out of the cloud storage system, such as when you download files or access them from a different location. For more information, see the [Google Cloud Storage pricing guide](https://cloud.google.com/storage/pricing).
+::::
+
 ## Prerequisites
 
 * JSON credentials for the service account that has access to GCS. For more details check [instructions](https://cloud.google.com/iam/docs/creating-managing-service-accounts)

--- a/docs/integrations/sources/s3.md
+++ b/docs/integrations/sources/s3.md
@@ -2,9 +2,9 @@
 
 This page contains the setup guide and reference information for the Amazon S3 source connector.
 
-::::info
+:::info
 Cloud storage may incur egress costs. Egress refers to data that is transferred out of the cloud storage system, such as when you download files or access them from a different location. For more information, see the [Amazon S3 pricing guide](https://aws.amazon.com/s3/pricing/).
-::::
+:::
 
 ## Prerequisites
 

--- a/docs/integrations/sources/s3.md
+++ b/docs/integrations/sources/s3.md
@@ -2,6 +2,10 @@
 
 This page contains the setup guide and reference information for the Amazon S3 source connector.
 
+::::info
+Cloud storage may incur egress costs. Egress refers to data that is transferred out of the cloud storage system, such as when you download files or access them from a different location. For more information, see the [Amazon S3 pricing guide](https://aws.amazon.com/s3/pricing/).
+::::
+
 ## Prerequisites
 
 Define file pattern, see the [Path Patterns section](s3.md#path-patterns)


### PR DESCRIPTION
## What

- Add info blurb to GCS, S3, and Azure Blob Storage source and destination docs
- This info links to pricing documentation for each Cloud provider
- This is indented to bring more transparency to users of these connectors
