### PR TITLE
source-s3: update connector version in metadata.yaml

### DIFF
--- a/airbyte-integrations/connectors/source-s3/metadata.yaml
+++ b/airbyte-integrations/connectors/source-s3/metadata.yaml
@@ -5,7 +5,7 @@ data:
   connectorSubtype: file
   connectorType: source
   definitionId: 69589781-7828-43c5-9f63-8925b1c1ccc2
-  dockerImageTag: 2.1.5
+  dockerImageTag: 2.2.0
   dockerRepository: airbyte/source-s3
   githubIssueLabel: source-s3
   icon: s3.svg


### PR DESCRIPTION
## What
The connector version in `metadata.yaml`  was not updated and did not match the dockerfile version.
More context on how it happened [here](https://airbytehq-team.slack.com/archives/C056HGD1QSW/p1683711184017929)
