### PR TITLE
Update dagster sensors to use a md5 based cursor

### DIFF
--- a/airbyte-ci/connectors/metadata_service/lib/metadata_service/docker_hub.py
+++ b/airbyte-ci/connectors/metadata_service/lib/metadata_service/docker_hub.py
@@ -55,7 +55,7 @@ def is_image_on_docker_hub(image_name: str, version: str) -> bool:
     Returns:
         bool: True if the image and version exists on Docker Hub, False otherwise.
     """
-    repo, image = image_name.split("/")
+    repo, image = image_name.split("/", 1)
     tags = get_image_tags(repo, image)
 
     return version in tags

--- a/airbyte-ci/connectors/metadata_service/orchestrator/orchestrator/sensors/metadata.py
+++ b/airbyte-ci/connectors/metadata_service/orchestrator/orchestrator/sensors/metadata.py
@@ -1,5 +1,5 @@
 from dagster import sensor, RunRequest, SkipReason, SensorDefinition, SensorEvaluationContext, build_resources, DefaultSensorStatus
-from orchestrator.utils.dagster_helpers import string_array_to_cursor
+from orchestrator.utils.dagster_helpers import string_array_to_hash
 
 
 def metadata_updated_sensor(job, resources_def) -> SensorDefinition:
@@ -20,18 +20,15 @@ def metadata_updated_sensor(job, resources_def) -> SensorDefinition:
         with build_resources(resources_def) as resources:
             context.log.info("Got resources for gcs_metadata_updated_sensor")
 
-            etags_cursor_raw = context.cursor or []
-            etags_cursor = string_array_to_cursor(etags_cursor_raw)
-
-            context.log.info(f"Old etag cursor: {etags_cursor}")
+            context.log.info(f"Old etag cursor: {context.cursor}")
 
             latest_metadata_file_blobs = resources.latest_metadata_file_blobs
-            new_etags_cursor = string_array_to_cursor([blob.etag for blob in latest_metadata_file_blobs])
+            new_etags_cursor = string_array_to_hash([blob.etag for blob in latest_metadata_file_blobs])
             context.log.info(f"New etag cursor: {new_etags_cursor}")
 
             # Note: ETAGs are GCS's way of providing a version number for a file
             # Another option would be to use the last modified date or MD5 hash
-            if etags_cursor == new_etags_cursor:
+            if context.cursor == new_etags_cursor:
                 context.log.info("No new updated_metadata_files in GCS bucket")
                 return SkipReason("No new updated_metadata_files in GCS bucket")
 

--- a/airbyte-ci/connectors/metadata_service/orchestrator/orchestrator/sensors/metadata.py
+++ b/airbyte-ci/connectors/metadata_service/orchestrator/orchestrator/sensors/metadata.py
@@ -1,5 +1,5 @@
 from dagster import sensor, RunRequest, SkipReason, SensorDefinition, SensorEvaluationContext, build_resources, DefaultSensorStatus
-from orchestrator.utils.dagster_helpers import deserialize_composite_etags_cursor, serialize_composite_etags_cursor
+from orchestrator.utils.dagster_helpers import string_array_to_cursor
 
 
 def metadata_updated_sensor(job, resources_def) -> SensorDefinition:
@@ -20,26 +20,24 @@ def metadata_updated_sensor(job, resources_def) -> SensorDefinition:
         with build_resources(resources_def) as resources:
             context.log.info("Got resources for gcs_metadata_updated_sensor")
 
-            etags_cursor_raw = context.cursor or None
-            etags_cursor = deserialize_composite_etags_cursor(etags_cursor_raw)
-            etags_cursor_set = set(etags_cursor)
+            etags_cursor_raw = context.cursor or []
+            etags_cursor = string_array_to_cursor(etags_cursor_raw)
 
             context.log.info(f"Old etag cursor: {etags_cursor}")
 
             latest_metadata_file_blobs = resources.latest_metadata_file_blobs
-            new_etags_cursor_set = {blob.etag for blob in latest_metadata_file_blobs}
-            context.log.info(f"New etag cursor: {new_etags_cursor_set}")
+            new_etags_cursor = string_array_to_cursor([blob.etag for blob in latest_metadata_file_blobs])
+            context.log.info(f"New etag cursor: {new_etags_cursor}")
 
             # Note: ETAGs are GCS's way of providing a version number for a file
             # Another option would be to use the last modified date or MD5 hash
-            if etags_cursor_set == new_etags_cursor_set:
+            if etags_cursor == new_etags_cursor:
                 context.log.info("No new updated_metadata_files in GCS bucket")
                 return SkipReason("No new updated_metadata_files in GCS bucket")
 
-            serialized_new_etags_cursor = serialize_composite_etags_cursor(list(new_etags_cursor_set))
-            context.update_cursor(serialized_new_etags_cursor)
+            context.update_cursor(new_etags_cursor)
             context.log.info("New updated_metadata_files in GCS bucket")
-            run_key = f"updated_metadata_files:{serialized_new_etags_cursor}"
+            run_key = f"updated_metadata_files:{new_etags_cursor}"
             return RunRequest(run_key=run_key)
 
     return metadata_updated_sensor_definition

--- a/airbyte-ci/connectors/metadata_service/orchestrator/orchestrator/sensors/registry.py
+++ b/airbyte-ci/connectors/metadata_service/orchestrator/orchestrator/sensors/registry.py
@@ -1,6 +1,6 @@
 from dagster import sensor, RunRequest, SkipReason, SensorDefinition, SensorEvaluationContext, build_resources, DefaultSensorStatus
 
-from orchestrator.utils.dagster_helpers import serialize_composite_etags_cursor
+from orchestrator.utils.dagster_helpers import string_array_to_cursor
 
 
 def registry_updated_sensor(job, resources_def) -> SensorDefinition:
@@ -21,24 +21,27 @@ def registry_updated_sensor(job, resources_def) -> SensorDefinition:
         with build_resources(resources_def) as resources:
             context.log.info("Got resources for gcs_registry_updated_sensor")
 
-            etag_cursor = context.cursor or None
-            context.log.info(f"Old etag cursor: {etag_cursor}")
+            etags_cursor_raw = context.cursor or []
+            etags_cursor = string_array_to_cursor(etags_cursor_raw)
+
+            context.log.info(f"Old etag cursor: {etags_cursor}")
 
             # TODO (ben) stop using legacy resources when we remove the legacy registry
-            new_etag_cursor = serialize_composite_etags_cursor(
+            new_etags_cursor = string_array_to_cursor(
                 [resources.legacy_oss_registry_gcs_blob.etag, resources.legacy_cloud_registry_gcs_blob.etag]
             )
-            context.log.info(f"New etag cursor: {new_etag_cursor}")
+
+            context.log.info(f"New etag cursor: {new_etags_cursor}")
 
             # Note: ETAGs are GCS's way of providing a version number for a file
             # Another option would be to use the last modified date or MD5 hash
-            if etag_cursor == new_etag_cursor:
+            if etags_cursor == new_etags_cursor:
                 context.log.info("No new registries in GCS bucket")
                 return SkipReason("No new registries in GCS bucket")
 
-            context.update_cursor(new_etag_cursor)
+            context.update_cursor(new_etags_cursor)
             context.log.info("New registries in GCS bucket")
-            run_key = f"updated_registries:{new_etag_cursor}"
+            run_key = f"updated_registries:{new_etags_cursor}"
             return RunRequest(run_key=run_key)
 
     return registry_updated_sensor_definition

--- a/airbyte-ci/connectors/metadata_service/orchestrator/orchestrator/utils/dagster_helpers.py
+++ b/airbyte-ci/connectors/metadata_service/orchestrator/orchestrator/utils/dagster_helpers.py
@@ -1,5 +1,6 @@
 from dagster import MetadataValue, Output
 import pandas as pd
+import hashlib
 from typing import Optional, List
 
 OutputDataFrame = Output[pd.DataFrame]
@@ -12,29 +13,15 @@ def output_dataframe(result_df: pd.DataFrame) -> Output[pd.DataFrame]:
     """
     return Output(result_df, metadata={"count": len(result_df), "preview": MetadataValue.md(result_df.to_markdown())})
 
-
-def deserialize_composite_etags_cursor(etag_cursors: Optional[str]) -> List[str]:
-    """Deserialize a cursor string into a list of etags.
-
-    Args:
-        etag_cursors (Optional[str]): A cursor string
-
-    Returns:
-        List[str]: A list of etags
-    """
-    return etag_cursors.split(CURSOR_SEPARATOR) if etag_cursors else []
-
-
-def serialize_composite_etags_cursor(etags: List[str]) -> str:
-    """Serialize a list of etags into a cursor string.
-
-    Dagster cursors are strings, so we need to serialize the list of etags into a string.
-    https://docs.dagster.io/concepts/partitions-schedules-sensors/sensors#idempotence-and-cursors
+def string_array_to_cursor(strings: List[str]) -> str:
+    """Hash a list of strings into a cursor string.
 
     Args:
-        etags (List[str]): unique etag ids from GCS
+        unique_strings (List[str]): unique strings
 
     Returns:
         str: A cursor string
     """
-    return CURSOR_SEPARATOR.join(etags)
+    unique_strings = list(set(strings))
+    unique_strings.sort()
+    return hashlib.md5(str(unique_strings).encode('utf-8')).hexdigest()

--- a/airbyte-ci/connectors/metadata_service/orchestrator/orchestrator/utils/dagster_helpers.py
+++ b/airbyte-ci/connectors/metadata_service/orchestrator/orchestrator/utils/dagster_helpers.py
@@ -14,7 +14,7 @@ def output_dataframe(result_df: pd.DataFrame) -> Output[pd.DataFrame]:
     return Output(result_df, metadata={"count": len(result_df), "preview": MetadataValue.md(result_df.to_markdown())})
 
 
-def string_array_to_cursor(strings: List[str]) -> str:
+def string_array_to_hash(strings: List[str]) -> str:
     """Hash a list of strings into a cursor string.
 
     Args:

--- a/airbyte-ci/connectors/metadata_service/orchestrator/orchestrator/utils/dagster_helpers.py
+++ b/airbyte-ci/connectors/metadata_service/orchestrator/orchestrator/utils/dagster_helpers.py
@@ -13,6 +13,7 @@ def output_dataframe(result_df: pd.DataFrame) -> Output[pd.DataFrame]:
     """
     return Output(result_df, metadata={"count": len(result_df), "preview": MetadataValue.md(result_df.to_markdown())})
 
+
 def string_array_to_cursor(strings: List[str]) -> str:
     """Hash a list of strings into a cursor string.
 
@@ -24,4 +25,4 @@ def string_array_to_cursor(strings: List[str]) -> str:
     """
     unique_strings = list(set(strings))
     unique_strings.sort()
-    return hashlib.md5(str(unique_strings).encode('utf-8')).hexdigest()
+    return hashlib.md5(str(unique_strings).encode("utf-8")).hexdigest()

--- a/airbyte-ci/connectors/metadata_service/orchestrator/tests/test_dagster_helpers.py
+++ b/airbyte-ci/connectors/metadata_service/orchestrator/tests/test_dagster_helpers.py
@@ -1,32 +1,32 @@
-from orchestrator.utils.dagster_helpers import string_array_to_cursor
+from orchestrator.utils.dagster_helpers import string_array_to_hash
 
 
-def test_string_array_to_cursor_is_deterministic():
+def test_string_array_to_hash_is_deterministic():
     strings = ["hello", "world", "foo", "bar", "baz"]
-    assert string_array_to_cursor(strings) == string_array_to_cursor(strings)
+    assert string_array_to_hash(strings) == string_array_to_hash(strings)
 
 
-def test_string_array_to_cursor_ignores_repeated_strings():
+def test_string_array_to_hash_ignores_repeated_strings():
     strings = ["hello", "world", "foo", "bar", "baz"]
     repeated_strings = ["hello", "world", "foo", "bar", "baz", "foo", "bar"]
-    assert string_array_to_cursor(strings) == string_array_to_cursor(repeated_strings)
+    assert string_array_to_hash(strings) == string_array_to_hash(repeated_strings)
 
 
-def test_string_array_to_cursor_outputs_on_empty_list():
-    assert string_array_to_cursor([])
+def test_string_array_to_hash_outputs_on_empty_list():
+    assert string_array_to_hash([])
 
 
-def test_string_array_to_cursor_ignores_value_order_input():
+def test_string_array_to_hash_ignores_value_order_input():
     strings = ["baz", "bar", "foo", "world", "hello"]
     same_but_different_order = ["hello", "world", "foo", "bar", "baz"]
-    assert string_array_to_cursor(strings) == string_array_to_cursor(same_but_different_order)
+    assert string_array_to_hash(strings) == string_array_to_hash(same_but_different_order)
 
 
-def test_string_array_to_cursor_differs():
-    unique_cursor_1 = string_array_to_cursor(["hello", "world", "foo"])
-    unique_cursor_2 = string_array_to_cursor(["hello", "world", "foo", "bar", "baz", "foo", "bar"])
-    unique_cursor_3 = string_array_to_cursor(["hello", "world", "baz"])
-    unique_cursor_4 = string_array_to_cursor(["world", "baz"])
+def test_string_array_to_hash_differs():
+    unique_cursor_1 = string_array_to_hash(["hello", "world", "foo"])
+    unique_cursor_2 = string_array_to_hash(["hello", "world", "foo", "bar", "baz", "foo", "bar"])
+    unique_cursor_3 = string_array_to_hash(["hello", "world", "baz"])
+    unique_cursor_4 = string_array_to_hash(["world", "baz"])
 
     unique_set = set([unique_cursor_1, unique_cursor_2, unique_cursor_3, unique_cursor_4])
     assert len(unique_set) == 4

--- a/airbyte-ci/connectors/metadata_service/orchestrator/tests/test_dagster_helpers.py
+++ b/airbyte-ci/connectors/metadata_service/orchestrator/tests/test_dagster_helpers.py
@@ -1,27 +1,32 @@
 from orchestrator.utils.dagster_helpers import string_array_to_cursor
 
+
 def test_string_array_to_cursor_is_deterministic():
-    strings = ['hello', 'world', 'foo', 'bar', 'baz']
+    strings = ["hello", "world", "foo", "bar", "baz"]
     assert string_array_to_cursor(strings) == string_array_to_cursor(strings)
 
+
 def test_string_array_to_cursor_ignores_repeated_strings():
-    strings = ['hello', 'world', 'foo', 'bar', 'baz']
-    repeated_strings = ['hello', 'world', 'foo', 'bar', 'baz', 'foo', 'bar']
+    strings = ["hello", "world", "foo", "bar", "baz"]
+    repeated_strings = ["hello", "world", "foo", "bar", "baz", "foo", "bar"]
     assert string_array_to_cursor(strings) == string_array_to_cursor(repeated_strings)
+
 
 def test_string_array_to_cursor_outputs_on_empty_list():
     assert string_array_to_cursor([])
 
+
 def test_string_array_to_cursor_ignores_value_order_input():
-    strings = ['baz', 'bar', 'foo', 'world', 'hello']
-    same_but_different_order = ['hello', 'world', 'foo', 'bar', 'baz']
+    strings = ["baz", "bar", "foo", "world", "hello"]
+    same_but_different_order = ["hello", "world", "foo", "bar", "baz"]
     assert string_array_to_cursor(strings) == string_array_to_cursor(same_but_different_order)
 
+
 def test_string_array_to_cursor_differs():
-    unique_cursor_1 = string_array_to_cursor(['hello', 'world', 'foo'])
-    unique_cursor_2 = string_array_to_cursor(['hello', 'world', 'foo', 'bar', 'baz', 'foo', 'bar'])
-    unique_cursor_3 = string_array_to_cursor(['hello', 'world', 'baz'])
-    unique_cursor_4 = string_array_to_cursor(['world', 'baz'])
+    unique_cursor_1 = string_array_to_cursor(["hello", "world", "foo"])
+    unique_cursor_2 = string_array_to_cursor(["hello", "world", "foo", "bar", "baz", "foo", "bar"])
+    unique_cursor_3 = string_array_to_cursor(["hello", "world", "baz"])
+    unique_cursor_4 = string_array_to_cursor(["world", "baz"])
 
     unique_set = set([unique_cursor_1, unique_cursor_2, unique_cursor_3, unique_cursor_4])
     assert len(unique_set) == 4

--- a/airbyte-ci/connectors/metadata_service/orchestrator/tests/test_dagster_helpers.py
+++ b/airbyte-ci/connectors/metadata_service/orchestrator/tests/test_dagster_helpers.py
@@ -1,0 +1,27 @@
+from orchestrator.utils.dagster_helpers import string_array_to_cursor
+
+def test_string_array_to_cursor_is_deterministic():
+    strings = ['hello', 'world', 'foo', 'bar', 'baz']
+    assert string_array_to_cursor(strings) == string_array_to_cursor(strings)
+
+def test_string_array_to_cursor_ignores_repeated_strings():
+    strings = ['hello', 'world', 'foo', 'bar', 'baz']
+    repeated_strings = ['hello', 'world', 'foo', 'bar', 'baz', 'foo', 'bar']
+    assert string_array_to_cursor(strings) == string_array_to_cursor(repeated_strings)
+
+def test_string_array_to_cursor_outputs_on_empty_list():
+    assert string_array_to_cursor([])
+
+def test_string_array_to_cursor_ignores_value_order_input():
+    strings = ['baz', 'bar', 'foo', 'world', 'hello']
+    same_but_different_order = ['hello', 'world', 'foo', 'bar', 'baz']
+    assert string_array_to_cursor(strings) == string_array_to_cursor(same_but_different_order)
+
+def test_string_array_to_cursor_differs():
+    unique_cursor_1 = string_array_to_cursor(['hello', 'world', 'foo'])
+    unique_cursor_2 = string_array_to_cursor(['hello', 'world', 'foo', 'bar', 'baz', 'foo', 'bar'])
+    unique_cursor_3 = string_array_to_cursor(['hello', 'world', 'baz'])
+    unique_cursor_4 = string_array_to_cursor(['world', 'baz'])
+
+    unique_set = set([unique_cursor_1, unique_cursor_2, unique_cursor_3, unique_cursor_4])
+    assert len(unique_set) == 4


### PR DESCRIPTION
## What
We have far to many metadata files to use a concatenated string array as a cursor.

This PR updates our cursors to be MD5 versions of the underlying string arrays