### PR TITLE
[INVESTIGATION] Understand relative cost of `PUT` and `COPY` operations for ❄️ 

### DIFF
--- a/airbyte-integrations/bases/bases-destination-jdbc-async/src/main/java/io/airbyte/integrations/destination/jdbc/WriteConfig.java
+++ b/airbyte-integrations/bases/bases-destination-jdbc-async/src/main/java/io/airbyte/integrations/destination/jdbc/WriteConfig.java
@@ -5,6 +5,8 @@
 package io.airbyte.integrations.destination.jdbc;
 
 import io.airbyte.protocol.models.v0.DestinationSyncMode;
+import java.util.ArrayList;
+import java.util.List;
 import org.joda.time.DateTime;
 import org.joda.time.DateTimeZone;
 
@@ -21,6 +23,7 @@ public class WriteConfig {
   private final String outputTableName;
   private final DestinationSyncMode syncMode;
   private final DateTime writeDatetime;
+  private final List<String> stagedFiles;
 
   public WriteConfig(final String streamName,
                      final String namespace,
@@ -45,6 +48,7 @@ public class WriteConfig {
     this.outputTableName = outputTableName;
     this.syncMode = syncMode;
     this.writeDatetime = writeDatetime;
+    this.stagedFiles = new ArrayList<>();
   }
 
   public String getStreamName() {
@@ -73,6 +77,18 @@ public class WriteConfig {
 
   public DateTime getWriteDatetime() {
     return writeDatetime;
+  }
+
+  public List<String> getStagedFiles() {
+    return stagedFiles;
+  }
+
+  public void addStagedFile(final String file) {
+    stagedFiles.add(file);
+  }
+
+  public void clearStagedFiles() {
+    stagedFiles.clear();
   }
 
   @Override

--- a/airbyte-integrations/connectors/destination-snowflake/src/main/java/io/airbyte/integrations/destination/snowflake/SnowflakeInternalStagingSqlOperations.java
+++ b/airbyte-integrations/connectors/destination-snowflake/src/main/java/io/airbyte/integrations/destination/snowflake/SnowflakeInternalStagingSqlOperations.java
@@ -67,6 +67,7 @@ public class SnowflakeInternalStagingSqlOperations extends SnowflakeSqlStagingOp
       throws IOException {
     final List<Exception> exceptionsThrown = new ArrayList<>();
     boolean succeeded = false;
+    LOGGER.info("Starting to uploadRecordsToStage");
     while (exceptionsThrown.size() < UPLOAD_RETRY_LIMIT && !succeeded) {
       try {
         uploadRecordsToBucket(database, stageName, stagingPath, recordsData);
@@ -162,8 +163,10 @@ public class SnowflakeInternalStagingSqlOperations extends SnowflakeSqlStagingOp
     try {
       final String query = getCopyQuery(stageName, stagingPath, stagedFiles, tableName, schemaName);
       LOGGER.debug("Executing query: {}", query);
+      LOGGER.info("Starting copy execution");
       database.execute(query);
-    } catch (SQLException e) {
+      LOGGER.info("Ending copy execution");
+    } catch (final SQLException e) {
       throw checkForKnownConfigExceptions(e).orElseThrow(() -> e);
     }
   }
@@ -193,7 +196,7 @@ public class SnowflakeInternalStagingSqlOperations extends SnowflakeSqlStagingOp
       final String query = getDropQuery(stageName);
       LOGGER.debug("Executing query: {}", query);
       database.execute(query);
-    } catch (SQLException e) {
+    } catch (final SQLException e) {
       throw checkForKnownConfigExceptions(e).orElseThrow(() -> e);
     }
   }
@@ -214,7 +217,7 @@ public class SnowflakeInternalStagingSqlOperations extends SnowflakeSqlStagingOp
       final String query = getRemoveQuery(stageName);
       LOGGER.debug("Executing query: {}", query);
       database.execute(query);
-    } catch (SQLException e) {
+    } catch (final SQLException e) {
       throw checkForKnownConfigExceptions(e).orElseThrow(() -> e);
     }
   }


### PR DESCRIPTION
## What
Closes https://github.com/airbytehq/airbyte/issues/25933

Understand the relative cost in time for `PUT` (moving file from buffer to staging area) and `COPY` (moving file from staging to table)

## How
Target a few levers:
- Add log lines for when `PUT` and `COPY` operations start/end
- If 10 writes (aka `PUT` & `COPY`) ~= 10 `PUT` _then_ one `COPY` of 10 files (current evidence shows this is slightly faster)
- Does having one large `PUT` (e.g. 1 GB) differ from several smaller `PUT` (e.g. 100 MB x10) 

## Notes
- Weird quirks - Snowflake measured roughly a total of 100 MB loaded but the sync measured about 648.72 MB
  - This seems like our internal measure is off by a factor of 6.5 times

### Baseline - Snowflake version (1.0.2)
![Screen Shot 2023-05-10 at 14 13 28](https://github.com/airbytehq/airbyte/assets/108309971/eb1198de-b541-4c9d-8d07-94ea872c172a)

### Offset COPY operation (every 10 `PUT`, execute one `COPY`)
![Screen Shot 2023-05-10 at 14 13 18](https://github.com/airbytehq/airbyte/assets/108309971/5ab7af3b-e448-470e-bc73-bfa00a5fa0b5)

### Snowflake's table size (NOTE: total amounts to 100 MB vs internal measurement is 648.72 MB
![Screen Shot 2023-05-10 at 14 13 47](https://github.com/airbytehq/airbyte/assets/108309971/b5d6f2d8-c612-4bdb-bc53-cb236eef5c12)


## Recommended reading order
1. `WriteConfig.java`
2. `StagingConsumerFactory.java`

## 🚨 User Impact 🚨
*Are there any breaking changes? What is the end result perceived by the user?*

*For connector PRs, use this section to explain which type of semantic versioning bump occurs as a result of the changes. Refer to our [Semantic Versioning for Connectors](https://docs.airbyte.com/contributing-to-airbyte/#semantic-versioning-for-connectors) guidelines for more information. **Breaking changes to connectors must be documented by an Airbyte engineer (PR author, or reviewer for community PRs) by using the [Breaking Change Release Playbook](https://docs.google.com/document/d/1VYQggHbL_PN0dDDu7rCyzBLGRtX-R3cpwXaY8QxEgzw/edit).***

*If there are breaking changes, please merge this PR with the 🚨🚨 emoji so changelog authors can further highlight this if needed.*


## Pre-merge Actions
*Expand the relevant checklist and delete the others.*

<details><summary><strong>New Connector</strong></summary>

### Community member or Airbyter

- **Community member?** Grant edit access to maintainers ([instructions](https://docs.github.com/en/github/collaborating-with-pull-requests/working-with-forks/allowing-changes-to-a-pull-request-branch-created-from-a-fork#enabling-repository-maintainer-permissions-on-existing-pull-requests))
- Unit & integration tests added and passing. Community members, please provide proof of success locally e.g: screenshot or copy-paste unit, integration, and acceptance test output. To run acceptance tests for a Python connector, follow instructions in the README. For java connectors run `./gradlew :airbyte-integrations:connectors:<name>:integrationTest`.
- Connector version is set to `0.0.1`
    - `Dockerfile` has version `0.0.1`
- Documentation updated
    - Connector's `README.md`
    - Connector's `bootstrap.md`. See [description and examples](https://docs.google.com/document/d/1ypdgmwmEHWv-TrO4_YOQ7pAJGVrMp5BOkEVh831N260/edit?usp=sharing)
    - `docs/integrations/<source or destination>/<name>.md` including changelog with an entry for the initial version. See changelog [example](https://docs.airbyte.io/integrations/sources/stripe#changelog)
    - `docs/integrations/README.md`

### Airbyter

If this is a community PR, the Airbyte engineer reviewing this PR is responsible for the below items.

- Create a non-forked branch based on this PR and test the below items on it
- Build is successful
- If new credentials are required for use in CI, add them to GSM. [Instructions](https://docs.airbyte.io/connector-development#using-credentials-in-ci).

</details>

<details><summary><strong>Updating a connector</strong></summary>

### Community member or Airbyter

- Grant edit access to maintainers ([instructions](https://docs.github.com/en/github/collaborating-with-pull-requests/working-with-forks/allowing-changes-to-a-pull-request-branch-created-from-a-fork#enabling-repository-maintainer-permissions-on-existing-pull-requests))
- Unit & integration tests added


### Airbyter

If this is a community PR, the Airbyte engineer reviewing this PR is responsible for the below items.

- Create a non-forked branch based on this PR and test the below items on it
- Build is successful
- If new credentials are required for use in CI, add them to GSM. [Instructions](https://docs.airbyte.io/connector-development#using-credentials-in-ci).

</details>

<details><summary><strong>Connector Generator</strong></summary>

- Issue acceptance criteria met
- PR name follows [PR naming conventions](https://docs.airbyte.com/contributing-to-airbyte/issues-and-pull-requests#pull-request-title-convention)
- If adding a new generator, add it to the [list of scaffold modules being tested](https://github.com/airbytehq/airbyte/blob/master/airbyte-integrations/connector-templates/generator/build.gradle#L41)
- The generator test modules (all connectors with `-scaffold` in their name) have been updated with the latest scaffold by running `./gradlew :airbyte-integrations:connector-templates:generator:testScaffoldTemplates` then checking in your changes
- Documentation which references the generator is updated as needed

</details>
