### PR TITLE
[ISSUE #25953] connector-atelier pip compile upgrade when CDK release

### DIFF
--- a/.github/workflows/publish-cdk-command-manually.yml
+++ b/.github/workflows/publish-cdk-command-manually.yml
@@ -298,7 +298,7 @@ jobs:
           echo ${{needs.bump-version.outputs.new_cdk_version}} > oss/airbyte-connector-builder-resources/CDK_VERSION
           cd oss/airbyte-connector-atelier-server
           pip install pip-tools
-          pip-compile
+          pip-compile --upgrade
       - name: Create Pull Request
         id: create-pull-request
         uses: peter-evans/create-pull-request@v4


### PR DESCRIPTION
## What
Without the `--upgrade` option, we would keep old version until they become non-compatible. Adding the option will allow us to keep more up-to-date lib versions