### PR TITLE
Low code CDK: Make refresh token in oauth authenticator optional

### DIFF
--- a/airbyte-cdk/python/airbyte_cdk/sources/declarative/auth/oauth.py
+++ b/airbyte-cdk/python/airbyte_cdk/sources/declarative/auth/oauth.py
@@ -31,15 +31,15 @@ class DeclarativeOauth2Authenticator(AbstractOauth2Authenticator, DeclarativeAut
         token_expiry_date (Optional[Union[InterpolatedString, str]]): The access token expiration date
         token_expiry_date_format str: format of the datetime; provide it if expires_in is returned in datetime instead of seconds
         refresh_request_body (Optional[Mapping[str, Any]]): The request body to send in the refresh request
-        grant_type: The grant_type to request for access_token
+        grant_type: The grant_type to request for access_token. If set to refresh_token, the refresh_token parameter has to be provided
     """
 
     token_refresh_endpoint: Union[InterpolatedString, str]
     client_id: Union[InterpolatedString, str]
     client_secret: Union[InterpolatedString, str]
-    refresh_token: Union[InterpolatedString, str]
     config: Mapping[str, Any]
     parameters: InitVar[Mapping[str, Any]]
+    refresh_token: Optional[Union[InterpolatedString, str]] = None
     scopes: Optional[List[str]] = None
     token_expiry_date: Optional[Union[InterpolatedString, str]] = None
     _token_expiry_date: pendulum.DateTime = field(init=False, repr=False, default=None)
@@ -53,7 +53,8 @@ class DeclarativeOauth2Authenticator(AbstractOauth2Authenticator, DeclarativeAut
         self.token_refresh_endpoint = InterpolatedString.create(self.token_refresh_endpoint, parameters=parameters)
         self.client_id = InterpolatedString.create(self.client_id, parameters=parameters)
         self.client_secret = InterpolatedString.create(self.client_secret, parameters=parameters)
-        self.refresh_token = InterpolatedString.create(self.refresh_token, parameters=parameters)
+        if self.refresh_token is not None:
+            self.refresh_token = InterpolatedString.create(self.refresh_token, parameters=parameters)
         self.access_token_name = InterpolatedString.create(self.access_token_name, parameters=parameters)
         self.expires_in_name = InterpolatedString.create(self.expires_in_name, parameters=parameters)
         self.grant_type = InterpolatedString.create(self.grant_type, parameters=parameters)
@@ -65,6 +66,9 @@ class DeclarativeOauth2Authenticator(AbstractOauth2Authenticator, DeclarativeAut
         )
         self._access_token = None
 
+        if self.get_grant_type() == "refresh_token" and self.refresh_token is None:
+            raise ValueError("OAuthAuthenticator needs a refresh_token parameter if grant_type is set to `refresh_token`")
+
     def get_token_refresh_endpoint(self) -> str:
         return self.token_refresh_endpoint.eval(self.config)
 
@@ -74,8 +78,8 @@ class DeclarativeOauth2Authenticator(AbstractOauth2Authenticator, DeclarativeAut
     def get_client_secret(self) -> str:
         return self.client_secret.eval(self.config)
 
-    def get_refresh_token(self) -> str:
-        return self.refresh_token.eval(self.config)
+    def get_refresh_token(self) -> Optional[str]:
+        return None if self.refresh_token is None else self.refresh_token.eval(self.config)
 
     def get_scopes(self) -> [str]:
         return self.scopes

--- a/airbyte-cdk/python/airbyte_cdk/sources/declarative/declarative_component_schema.yaml
+++ b/airbyte-cdk/python/airbyte_cdk/sources/declarative/declarative_component_schema.yaml
@@ -647,7 +647,6 @@ definitions:
       - type
       - client_id
       - client_secret
-      - refresh_token
       - token_refresh_endpoint
     properties:
       type:

--- a/airbyte-cdk/python/airbyte_cdk/sources/declarative/models/declarative_component_schema.py
+++ b/airbyte-cdk/python/airbyte_cdk/sources/declarative/models/declarative_component_schema.py
@@ -277,8 +277,8 @@ class OAuthAuthenticator(BaseModel):
         ],
         title="Client Secret",
     )
-    refresh_token: str = Field(
-        ...,
+    refresh_token: Optional[str] = Field(
+        None,
         description="Credential artifact used to get a new access token.",
         examples=[
             "{{ config['refresh_token'] }}",

--- a/airbyte-cdk/python/airbyte_cdk/sources/streams/http/requests_native_auth/abstract_oauth.py
+++ b/airbyte-cdk/python/airbyte_cdk/sources/streams/http/requests_native_auth/abstract_oauth.py
@@ -4,7 +4,7 @@
 
 import logging
 from abc import abstractmethod
-from typing import Any, List, Mapping, MutableMapping, Tuple, Union
+from typing import Any, List, Mapping, MutableMapping, Optional, Tuple, Union
 
 import backoff
 import pendulum
@@ -111,7 +111,7 @@ class AbstractOauth2Authenticator(AuthBase):
         """The client secret to authenticate"""
 
     @abstractmethod
-    def get_refresh_token(self) -> str:
+    def get_refresh_token(self) -> Optional[str]:
         """The token used to refresh the access token when it expires"""
 
     @abstractmethod

--- a/airbyte-cdk/python/airbyte_cdk/sources/streams/http/requests_native_auth/oauth.py
+++ b/airbyte-cdk/python/airbyte_cdk/sources/streams/http/requests_native_auth/oauth.py
@@ -22,7 +22,7 @@ class Oauth2Authenticator(AbstractOauth2Authenticator):
         token_refresh_endpoint: str,
         client_id: str,
         client_secret: str,
-        refresh_token,
+        refresh_token: str,
         scopes: List[str] = None,
         token_expiry_date: pendulum.DateTime = None,
         token_expiry_date_format: str = None,

--- a/airbyte-cdk/python/airbyte_cdk/sources/streams/http/requests_native_auth/oauth.py
+++ b/airbyte-cdk/python/airbyte_cdk/sources/streams/http/requests_native_auth/oauth.py
@@ -2,7 +2,7 @@
 # Copyright (c) 2023 Airbyte, Inc., all rights reserved.
 #
 
-from typing import Any, List, Mapping, Optional, Sequence, Tuple, Union
+from typing import Any, List, Mapping, Sequence, Tuple, Union
 
 import dpath
 import pendulum

--- a/airbyte-cdk/python/airbyte_cdk/sources/streams/http/requests_native_auth/oauth.py
+++ b/airbyte-cdk/python/airbyte_cdk/sources/streams/http/requests_native_auth/oauth.py
@@ -2,7 +2,7 @@
 # Copyright (c) 2023 Airbyte, Inc., all rights reserved.
 #
 
-from typing import Any, List, Mapping, Sequence, Tuple, Union
+from typing import Any, List, Mapping, Optional, Sequence, Tuple, Union
 
 import dpath
 import pendulum
@@ -22,7 +22,7 @@ class Oauth2Authenticator(AbstractOauth2Authenticator):
         token_refresh_endpoint: str,
         client_id: str,
         client_secret: str,
-        refresh_token: str,
+        refresh_token,
         scopes: List[str] = None,
         token_expiry_date: pendulum.DateTime = None,
         token_expiry_date_format: str = None,

--- a/airbyte-cdk/python/unit_tests/sources/declarative/auth/test_oauth.py
+++ b/airbyte-cdk/python/unit_tests/sources/declarative/auth/test_oauth.py
@@ -65,6 +65,42 @@ class TestOauth2Authenticator:
         }
         assert body == expected
 
+    def test_refresh_without_refresh_token(self):
+        """
+        Should work fine for grant_type client_credentials.
+        """
+        oauth = DeclarativeOauth2Authenticator(
+            token_refresh_endpoint="{{ config['refresh_endpoint'] }}",
+            client_id="{{ config['client_id'] }}",
+            client_secret="{{ config['client_secret'] }}",
+            config=config,
+            parameters={},
+            grant_type="client_credentials",
+        )
+        body = oauth.build_refresh_request_body()
+        expected = {
+            "grant_type": "client_credentials",
+            "client_id": "some_client_id",
+            "client_secret": "some_client_secret",
+            "refresh_token": None,
+            "scopes": None,
+        }
+        assert body == expected
+
+    def test_error_on_refresh_token_grant_without_refresh_token(self):
+        """
+        Should throw an error if grant_type refresh_token is configured without refresh_token.
+        """
+        with pytest.raises(ValueError):
+            DeclarativeOauth2Authenticator(
+                token_refresh_endpoint="{{ config['refresh_endpoint'] }}",
+                client_id="{{ config['client_id'] }}",
+                client_secret="{{ config['client_secret'] }}",
+                config=config,
+                parameters={},
+                grant_type="refresh_token",
+            )
+
     def test_refresh_access_token(self, mocker):
         oauth = DeclarativeOauth2Authenticator(
             token_refresh_endpoint="{{ config['refresh_endpoint'] }}",


### PR DESCRIPTION
## What

Fixes https://github.com/airbytehq/airbyte/issues/23450

## How

Makes the refresh_token parameter optional in schema and python classes, add test to fail if it's not set for grant_type "refresh_token".
