### PR TITLE
connectors-ci: less scary but harmless error log on publish

### DIFF
--- a/tools/ci_connector_ops/ci_connector_ops/pipelines/publish.py
+++ b/tools/ci_connector_ops/ci_connector_ops/pipelines/publish.py
@@ -23,12 +23,11 @@ class CheckConnectorImageDoesNotExist(Step):
         manifest_inspect = (
             environments.with_docker_cli(self.context)
             .with_env_variable("CACHEBUSTER", str(uuid.uuid4()))
-            .with_exec(["docker", "manifest", "inspect", self.context.docker_image_name])
+            .with_exec(["sh", "-c", f"docker manifest inspect {self.context.docker_image_name} || true"])
         )
         manifest_inspect_exit_code = await with_exit_code(manifest_inspect)
         manifest_inspect_stderr = await with_stderr(manifest_inspect)
         manifest_inspect_stdout = await with_stdout(manifest_inspect)
-
         if manifest_inspect_exit_code != 0 and "no such manifest" in manifest_inspect_stderr:
             return StepResult(self, status=StepStatus.SUCCESS, stdout=f"No manifest found for {self.context.docker_image_from_metadata}.")
         else:


### PR DESCRIPTION
## What
Closes https://github.com/airbytehq/airbyte/issues/25622

To check if an image can be publish we first check with a `docker manifest` command that the image does not exists yet. When an image does not exists the `docker manifest` command returns a 1 exit code that leads to scary dagger logs and can be confusing for log readers.

## How
Make the command always return `0` status code by piping it to `true`
The rest of the logic does not change: the `docker manifest` output is available on stderr and we read it to confirm the absence of the image.
