### PR TITLE
Revert "Add path filter (#26018)"

### DIFF
--- a/.github/workflows/metadata_validate_manifest_dagger.yml
+++ b/.github/workflows/metadata_validate_manifest_dagger.yml
@@ -3,8 +3,6 @@ name: Connectors' metadata.yaml files validation
 on:
   workflow_dispatch:
   pull_request:
-    paths:
-      - "airbyte-integrations/connectors/**/metadata.yaml"
 
 jobs:
   connectors_metadata_validation:


### PR DESCRIPTION
This reverts commit 4d59d0345def77050dc69c6c0dd4a13488a8c1af to bring back the validate check for all prs

@marcosmarxm We've had to bring this back due to an awkward state between this being both a required check and a check that exists outside of github actions.

Were exploring the best way to make this check a non blocker to merging community PRs. But for now you will have to fork their branch yourself.

We're sorry for adding a bit of work here.