### PR TITLE
🐛Source MySQL: remove SSL toggle for OSS MySQL

### DIFF
--- a/airbyte-config-oss/init-oss/src/main/resources/seed/oss_catalog.json
+++ b/airbyte-config-oss/init-oss/src/main/resources/seed/oss_catalog.json
@@ -18538,7 +18538,7 @@
     "sourceDefinitionId": "435bb9a5-7887-4809-aa58-28c27df0d7ad",
     "name": "MySQL",
     "dockerRepository": "airbyte/source-mysql",
-    "dockerImageTag": "2.0.21",
+    "dockerImageTag": "2.0.22",
     "documentationUrl": "https://docs.airbyte.com/integrations/sources/mysql",
     "icon": "mysql.svg",
     "sourceType": "database",
@@ -18590,13 +18590,6 @@
             "title": "JDBC URL Parameters (Advanced)",
             "type": "string",
             "order": 5
-          },
-          "ssl": {
-            "title": "SSL Connection",
-            "description": "Encrypt data using SSL.",
-            "type": "boolean",
-            "default": true,
-            "order": 6
           },
           "ssl_mode": {
             "title": "SSL modes",

--- a/airbyte-config-oss/init-oss/src/main/resources/seed/source_definitions.yaml
+++ b/airbyte-config-oss/init-oss/src/main/resources/seed/source_definitions.yaml
@@ -1315,7 +1315,7 @@
 - name: MySQL
   sourceDefinitionId: 435bb9a5-7887-4809-aa58-28c27df0d7ad
   dockerRepository: airbyte/source-mysql
-  dockerImageTag: 2.0.21
+  dockerImageTag: 2.0.22
   documentationUrl: https://docs.airbyte.com/integrations/sources/mysql
   icon: mysql.svg
   sourceType: database

--- a/airbyte-config-oss/init-oss/src/main/resources/seed/source_specs.yaml
+++ b/airbyte-config-oss/init-oss/src/main/resources/seed/source_specs.yaml
@@ -9617,7 +9617,7 @@
     supportsNormalization: false
     supportsDBT: false
     supported_destination_sync_modes: []
-- dockerImage: "airbyte/source-mysql:2.0.21"
+- dockerImage: "airbyte/source-mysql:2.0.22"
   spec:
     documentationUrl: "https://docs.airbyte.com/integrations/sources/mysql"
     connectionSpecification:
@@ -9671,12 +9671,6 @@
           title: "JDBC URL Parameters (Advanced)"
           type: "string"
           order: 5
-        ssl:
-          title: "SSL Connection"
-          description: "Encrypt data using SSL."
-          type: "boolean"
-          default: true
-          order: 6
         ssl_mode:
           title: "SSL modes"
           description: "SSL connection modes. Read more <a href=\"https://dev.mysql.com/doc/connector-j/8.0/en/connector-j-reference-using-ssl.html\"\

--- a/airbyte-integrations/connectors/source-mysql-strict-encrypt/Dockerfile
+++ b/airbyte-integrations/connectors/source-mysql-strict-encrypt/Dockerfile
@@ -16,6 +16,6 @@ ENV APPLICATION source-mysql-strict-encrypt
 
 COPY --from=build /airbyte /airbyte
 
-LABEL io.airbyte.version=2.0.21
+LABEL io.airbyte.version=2.0.22
 
 LABEL io.airbyte.name=airbyte/source-mysql-strict-encrypt

--- a/airbyte-integrations/connectors/source-mysql-strict-encrypt/src/main/java/io/airbyte/integrations/source/mysql_strict_encrypt/MySqlStrictEncryptSource.java
+++ b/airbyte-integrations/connectors/source-mysql-strict-encrypt/src/main/java/io/airbyte/integrations/source/mysql_strict_encrypt/MySqlStrictEncryptSource.java
@@ -7,7 +7,6 @@ package io.airbyte.integrations.source.mysql_strict_encrypt;
 import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.node.ObjectNode;
 import io.airbyte.commons.json.Jsons;
-import io.airbyte.db.jdbc.JdbcUtils;
 import io.airbyte.integrations.base.IntegrationRunner;
 import io.airbyte.integrations.base.Source;
 import io.airbyte.integrations.base.spec_modification.SpecModifyingSource;
@@ -47,7 +46,6 @@ public class MySqlStrictEncryptSource extends SpecModifyingSource implements Sou
   @Override
   public ConnectorSpecification modifySpec(final ConnectorSpecification originalSpec) {
     final ConnectorSpecification spec = Jsons.clone(originalSpec);
-    ((ObjectNode) spec.getConnectionSpecification().get("properties")).remove(JdbcUtils.SSL_KEY);
     ((ObjectNode) spec.getConnectionSpecification().get("properties").get(SSL_MODE)).put("default", SSL_MODE_REQUIRED);
     return spec;
   }

--- a/airbyte-integrations/connectors/source-mysql-strict-encrypt/src/main/java/io/airbyte/integrations/source/mysql_strict_encrypt/MySqlStrictEncryptSource.java
+++ b/airbyte-integrations/connectors/source-mysql-strict-encrypt/src/main/java/io/airbyte/integrations/source/mysql_strict_encrypt/MySqlStrictEncryptSource.java
@@ -32,6 +32,8 @@ public class MySqlStrictEncryptSource extends SpecModifyingSource implements Sou
   public static final String SSL_MODE_PREFERRED = "preferred";
   public static final String SSL_MODE_REQUIRED = "required";
 
+  public static final String SSL_MODE_DISABLE = "disable";
+
   private static final Logger LOGGER = LoggerFactory.getLogger(MySqlStrictEncryptSource.class);
   private static final String SSL_MODE_DESCRIPTION = "SSL connection modes. " +
       "<li><b>required</b> - Always connect with SSL. If the MySQL server doesn’t support SSL, the connection will not be established. Certificate Authority (CA) and Hostname are not verified.</li>"
@@ -59,8 +61,8 @@ public class MySqlStrictEncryptSource extends SpecModifyingSource implements Sou
         && config.get(TUNNEL_METHOD).get(TUNNEL_METHOD).asText().equals(NO_TUNNEL)) {
       // If no SSH tunnel
       if (config.has(SSL_MODE) && config.get(SSL_MODE).has(MODE)) {
-        if (Set.of(SSL_MODE_PREFERRED).contains(config.get(SSL_MODE).get(MODE).asText())) {
-          // Fail in case SSL mode is preferred
+        if (Set.of(SSL_MODE_DISABLE, SSL_MODE_PREFERRED).contains(config.get(SSL_MODE).get(MODE).asText())) {
+          // Fail in case SSL mode is disable, preferred
           return new AirbyteConnectionStatus()
               .withStatus(Status.FAILED)
               .withMessage(

--- a/airbyte-integrations/connectors/source-mysql/Dockerfile
+++ b/airbyte-integrations/connectors/source-mysql/Dockerfile
@@ -16,6 +16,6 @@ ENV APPLICATION source-mysql
 
 COPY --from=build /airbyte /airbyte
 
-LABEL io.airbyte.version=2.0.21
+LABEL io.airbyte.version=2.0.22
 
 LABEL io.airbyte.name=airbyte/source-mysql

--- a/airbyte-integrations/connectors/source-mysql/metadata.yaml
+++ b/airbyte-integrations/connectors/source-mysql/metadata.yaml
@@ -6,7 +6,7 @@ data:
   connectorSubtype: database
   connectorType: source
   definitionId: 435bb9a5-7887-4809-aa58-28c27df0d7ad
-  dockerImageTag: 2.0.21
+  dockerImageTag: 2.0.22
   dockerRepository: airbyte/source-mysql
   githubIssueLabel: source-mysql
   icon: mysql.svg

--- a/airbyte-integrations/connectors/source-mysql/src/main/resources/spec.json
+++ b/airbyte-integrations/connectors/source-mysql/src/main/resources/spec.json
@@ -47,13 +47,6 @@
         "type": "string",
         "order": 5
       },
-      "ssl": {
-        "title": "SSL Connection",
-        "description": "Encrypt data using SSL.",
-        "type": "boolean",
-        "default": true,
-        "order": 6
-      },
       "ssl_mode": {
         "title": "SSL modes",
         "description": "SSL connection modes. Read more <a href=\"https://dev.mysql.com/doc/connector-j/8.0/en/connector-j-reference-using-ssl.html\"> in the docs</a>.",

--- a/airbyte-integrations/connectors/source-mysql/src/test-integration/resources/expected_spec.json
+++ b/airbyte-integrations/connectors/source-mysql/src/test-integration/resources/expected_spec.json
@@ -47,13 +47,6 @@
         "type": "string",
         "order": 5
       },
-      "ssl": {
-        "title": "SSL Connection",
-        "description": "Encrypt data using SSL.",
-        "type": "boolean",
-        "default": true,
-        "order": 6
-      },
       "ssl_mode": {
         "title": "SSL modes",
         "description": "SSL connection modes. Read more <a href=\"https://dev.mysql.com/doc/connector-j/8.0/en/connector-j-reference-using-ssl.html\"> in the docs</a>.",

--- a/docs/integrations/sources/mysql.md
+++ b/docs/integrations/sources/mysql.md
@@ -261,6 +261,7 @@ WHERE actor_definition_id ='435bb9a5-7887-4809-aa58-28c27df0d7ad' AND (configura
 
 | Version | Date       | Pull Request                                               | Subject                                                                                                                                         |
 |:--------|:-----------|:-----------------------------------------------------------|:------------------------------------------------------------------------------------------------------------------------------------------------|
+| 2.0.22  | 2023-05-12 | [26050](https://github.com/airbytehq/airbyte/pull/26050)   | Removed SSL toggle and rely on SSL mode dropdown to enable/disable SSL                                                                          |
 | 2.0.21  | 2023-05-10 | [25460](https://github.com/airbytehq/airbyte/pull/25460)   | Handle a decimal number with 0 decimal points as an integer                                                                                     |
 | 2.0.20  | 2023-05-01 | [25740](https://github.com/airbytehq/airbyte/pull/25740)   | Disable index logging                                                                                                                           |
 | 2.0.19  | 2023-04-26 | [25401](https://github.com/airbytehq/airbyte/pull/25401)   | CDC : Upgrade Debezium to version 2.2.0                                                                                                         |


### PR DESCRIPTION
## What
[Issue airbytehq/airbyte-internal-issues#1652](https://github.com/airbytehq/airbyte-internal-issues/issues/1652)
According to [nguyenaiden](https://github.com/nguyenaiden?scrlybrkr=29e8f549),
"Currently, MySQL has a SSL Connection toggle to enable/disable traffic encryption. This does not match with our Postgres source connector (OSS)."

## Solution
Remove the ssl key from `spec.json` for `source-postgres` and rely on `ssl_mode` key as the source of truth.