### PR TITLE
Source FreshCaller: fix spec type check

### DIFF
--- a/airbyte-integrations/connectors/source-freshcaller/Dockerfile
+++ b/airbyte-integrations/connectors/source-freshcaller/Dockerfile
@@ -35,5 +35,5 @@ COPY source_freshcaller ./source_freshcaller
 ENV AIRBYTE_ENTRYPOINT "python /airbyte/integration_code/main.py"
 ENTRYPOINT ["python", "/airbyte/integration_code/main.py"]
 
-LABEL io.airbyte.version=0.1.1
+LABEL io.airbyte.version=0.2.0
 LABEL io.airbyte.name=airbyte/source-freshcaller

--- a/airbyte-integrations/connectors/source-freshcaller/Dockerfile
+++ b/airbyte-integrations/connectors/source-freshcaller/Dockerfile
@@ -35,5 +35,5 @@ COPY source_freshcaller ./source_freshcaller
 ENV AIRBYTE_ENTRYPOINT "python /airbyte/integration_code/main.py"
 ENTRYPOINT ["python", "/airbyte/integration_code/main.py"]
 
-LABEL io.airbyte.version=0.1.0
+LABEL io.airbyte.version=0.1.1
 LABEL io.airbyte.name=airbyte/source-freshcaller

--- a/airbyte-integrations/connectors/source-freshcaller/acceptance-test-config.yml
+++ b/airbyte-integrations/connectors/source-freshcaller/acceptance-test-config.yml
@@ -2,6 +2,8 @@ connector_image: airbyte/source-freshcaller:dev
 tests:
   spec:
     - spec_path: "source_freshcaller/spec.json"
+      backward_compatibility_tests_config:
+        disable_for_version: 0.1.0 # Fix start_date type
   connection:
     - config_path: "secrets/config.json"
       status: "succeed"

--- a/airbyte-integrations/connectors/source-freshcaller/metadata.yaml
+++ b/airbyte-integrations/connectors/source-freshcaller/metadata.yaml
@@ -2,7 +2,7 @@ data:
   connectorSubtype: api
   connectorType: source
   definitionId: 8a5d48f6-03bb-4038-a942-a8d3f175cca3
-  dockerImageTag: 0.1.1
+  dockerImageTag: 0.2.0
   dockerRepository: airbyte/source-freshcaller
   githubIssueLabel: source-freshcaller
   icon: freshcaller.svg

--- a/airbyte-integrations/connectors/source-freshcaller/metadata.yaml
+++ b/airbyte-integrations/connectors/source-freshcaller/metadata.yaml
@@ -2,7 +2,7 @@ data:
   connectorSubtype: api
   connectorType: source
   definitionId: 8a5d48f6-03bb-4038-a942-a8d3f175cca3
-  dockerImageTag: 0.1.0
+  dockerImageTag: 0.1.1
   dockerRepository: airbyte/source-freshcaller
   githubIssueLabel: source-freshcaller
   icon: freshcaller.svg

--- a/airbyte-integrations/connectors/source-freshcaller/setup.py
+++ b/airbyte-integrations/connectors/source-freshcaller/setup.py
@@ -6,8 +6,7 @@
 from setuptools import find_packages, setup
 
 MAIN_REQUIREMENTS = [
-    "airbyte-cdk~=0.1",
-    "pendulum==1.2.0",
+    "airbyte-cdk~=0.2",
 ]
 
 TEST_REQUIREMENTS = [

--- a/airbyte-integrations/connectors/source-freshcaller/source_freshcaller/schemas/call_metrics.json
+++ b/airbyte-integrations/connectors/source-freshcaller/source_freshcaller/schemas/call_metrics.json
@@ -1,5 +1,5 @@
 {
-  "$schema": "http://json-schema.org/draft-04/schema#",
+  "$schema": "https://json-schema.org/draft-07/schema#",
   "type": "object",
   "additionalProperties": true,
   "properties": {

--- a/airbyte-integrations/connectors/source-freshcaller/source_freshcaller/schemas/calls.json
+++ b/airbyte-integrations/connectors/source-freshcaller/source_freshcaller/schemas/calls.json
@@ -1,5 +1,5 @@
 {
-  "$schema": "http://json-schema.org/draft-04/schema#",
+  "$schema": "https://json-schema.org/draft-07/schema#",
   "type": "object",
   "additionalProperties": true,
   "properties": {
@@ -99,8 +99,25 @@
       },
       "type": ["object", "null"]
     },
-
+    "recording_to_redact": {
+      "type": ["object", "null"],
+      "properties": {
+        "id": {
+          "type": ["integer", "null"]
+        },
+        "url": {
+          "type": ["string", "null"]
+        },
+        "duration": {
+          "type": ["number", "null"]
+        },
+        "duration_unit": {
+          "type": ["string", "null"]
+        }
+      }
+    },
     "participants": {
+      "type": ["array", "null"],
       "items": {
         "properties": {
           "id": {
@@ -155,7 +172,9 @@
           }
         },
         "type": "object"
-      },
+      }
+    },
+    "parallel_call_groups": {
       "type": ["array", "null"]
     }
   }

--- a/airbyte-integrations/connectors/source-freshcaller/source_freshcaller/schemas/teams.json
+++ b/airbyte-integrations/connectors/source-freshcaller/source_freshcaller/schemas/teams.json
@@ -1,5 +1,5 @@
 {
-  "$schema": "http://json-schema.org/draft-04/schema#",
+  "$schema": "https://json-schema.org/draft-07/schema#",
   "type": "object",
   "additionalProperties": true,
   "properties": {

--- a/airbyte-integrations/connectors/source-freshcaller/source_freshcaller/schemas/users.json
+++ b/airbyte-integrations/connectors/source-freshcaller/source_freshcaller/schemas/users.json
@@ -1,5 +1,5 @@
 {
-  "$schema": "http://json-schema.org/draft-04/schema#",
+  "$schema": "https://json-schema.org/draft-07/schema#",
   "type": "object",
   "additionalProperties": true,
   "properties": {

--- a/airbyte-integrations/connectors/source-freshcaller/source_freshcaller/spec.json
+++ b/airbyte-integrations/connectors/source-freshcaller/source_freshcaller/spec.json
@@ -28,6 +28,7 @@
         "title": "Start Date",
         "description": "UTC date and time. Any data created after this date will be replicated.",
         "format": "date-time",
+        "type": "string",
         "pattern": "^[0-9]{4}-[0-9]{2}-[0-9]{2}T[0-9]{2}:[0-9]{2}:[0-9]{2}Z$",
         "examples": ["2022-01-01T12:00:00Z"]
       },

--- a/airbyte-integrations/connectors/source-freshcaller/source_freshcaller/spec.json
+++ b/airbyte-integrations/connectors/source-freshcaller/source_freshcaller/spec.json
@@ -1,7 +1,7 @@
 {
   "documentationUrl": "https://docs.airbyte.com/integrations/sources/freshcaller",
   "connectionSpecification": {
-    "$schema": "http://json-schema.org/draft-07/schema#",
+    "$schema": "https://json-schema.org/draft-07/schema#",
     "title": "Freshcaller Spec",
     "type": "object",
     "required": ["domain", "api_key", "start_date"],

--- a/airbyte-integrations/connectors/source-freshcaller/source_freshcaller/streams.py
+++ b/airbyte-integrations/connectors/source-freshcaller/source_freshcaller/streams.py
@@ -126,7 +126,7 @@ class APIIncrementalFreshcallerStream(FreshcallerStream):
             ...]
         """
         start_date = pendulum.parse(self.start_date).in_timezone("UTC")
-        end_date = pendulum.utcnow().subtract(minutes=self.sync_lag_minutes)  # have a safe lag
+        end_date = pendulum.now('UTC').subtract(minutes=self.sync_lag_minutes)  # have a safe lag
 
         # Determine stream_state, if no stream_state we use start_date
         if stream_state:
@@ -134,7 +134,7 @@ class APIIncrementalFreshcallerStream(FreshcallerStream):
             start_date = pendulum.parse(start_date) if isinstance(start_date, str) else start_date
             start_date = start_date.in_tz("UTC")
         # use the lowest date between start_date and self.end_date, otherwise API fails if start_date is in future
-        start_date: pendulum.Pendulum = min(start_date, end_date)
+        start_date: pendulum.DateTime = min(start_date, end_date)
         date_slices = []
 
         while start_date <= end_date:

--- a/airbyte-integrations/connectors/source-freshcaller/source_freshcaller/streams.py
+++ b/airbyte-integrations/connectors/source-freshcaller/source_freshcaller/streams.py
@@ -126,7 +126,7 @@ class APIIncrementalFreshcallerStream(FreshcallerStream):
             ...]
         """
         start_date = pendulum.parse(self.start_date).in_timezone("UTC")
-        end_date = pendulum.now('UTC').subtract(minutes=self.sync_lag_minutes)  # have a safe lag
+        end_date = pendulum.now("UTC").subtract(minutes=self.sync_lag_minutes)  # have a safe lag
 
         # Determine stream_state, if no stream_state we use start_date
         if stream_state:

--- a/docs/integrations/sources/freshcaller.md
+++ b/docs/integrations/sources/freshcaller.md
@@ -40,4 +40,8 @@ The Freshcaller connector should not run into Freshcaller API limitations under 
 Please read [How to find your API key](https://support.freshdesk.com/en/support/solutions/articles/225435-where-can-i-find-my-api-key-).
 
 ## Changelog
-| 0.1.0   | 2022-08-11 | [14759](https://github.com/airbytehq/airbyte/pull/14759)   | 🎉 New Source: Freshcaller       |
+
+| Version | Date       | Pull Request                                             | Subject                              |
+|:--------|:-----------|:---------------------------------------------------------|:-------------------------------------|
+| 0.1.1   | 2023-05-15 | [26065](https://github.com/airbytehq/airbyte/pull/26065) | Fix spec type check for `start_date` |
+| 0.1.0   | 2022-08-11 | [14759](https://github.com/airbytehq/airbyte/pull/14759) | 🎉 New Source: Freshcaller           |

--- a/docs/integrations/sources/freshcaller.md
+++ b/docs/integrations/sources/freshcaller.md
@@ -43,5 +43,5 @@ Please read [How to find your API key](https://support.freshdesk.com/en/support/
 
 | Version | Date       | Pull Request                                             | Subject                              |
 |:--------|:-----------|:---------------------------------------------------------|:-------------------------------------|
-| 0.1.1   | 2023-05-15 | [26065](https://github.com/airbytehq/airbyte/pull/26065) | Fix spec type check for `start_date` |
+| 0.2.0   | 2023-05-15 | [26065](https://github.com/airbytehq/airbyte/pull/26065) | Fix spec type check for `start_date` |
 | 0.1.0   | 2022-08-11 | [14759](https://github.com/airbytehq/airbyte/pull/14759) | 🎉 New Source: Freshcaller           |


### PR DESCRIPTION
## What
Resolve https://github.com/airbytehq/airbyte/issues/25688
Handle config errors for `start_date`
`Start_date` field was not declared as a `string` in `jsonschema`, but was rendered as a string in UI.
This may have caused a problem with validation (see screenshot from https://github.com/airbytehq/airbyte/issues/25688)

## How
Fix spec type for `start_date`

## Recommended reading order
1. `y.python`

## 🚨 User Impact 🚨

no breaking changes

## Pre-merge Actions

<details><summary><strong>Updating a connector</strong></summary>

### Community member or Airbyter

- Grant edit access to maintainers ([instructions](https://docs.github.com/en/github/collaborating-with-pull-requests/working-with-forks/allowing-changes-to-a-pull-request-branch-created-from-a-fork#enabling-repository-maintainer-permissions-on-existing-pull-requests))
- Unit & integration tests added


### Airbyter

If this is a community PR, the Airbyte engineer reviewing this PR is responsible for the below items.

- Create a non-forked branch based on this PR and test the below items on it
- Build is successful
- If new credentials are required for use in CI, add them to GSM. [Instructions](https://docs.airbyte.io/connector-development#using-credentials-in-ci).

</details>
