### PR TITLE
connectors-ci: sanitize the publish logic and write tests for it

### DIFF
--- a/tools/ci_connector_ops/ci_connector_ops/pipelines/actions/environments.py
+++ b/tools/ci_connector_ops/ci_connector_ops/pipelines/actions/environments.py
@@ -10,30 +10,18 @@ import os
 import uuid
 from typing import TYPE_CHECKING, List, Optional, Tuple
 
+from ci_connector_ops.pipelines.consts import (
+    CI_CONNECTOR_OPS_SOURCE_PATH,
+    CI_CREDENTIALS_SOURCE_PATH,
+    CONNECTOR_TESTING_REQUIREMENTS,
+    DEFAULT_PYTHON_EXCLUDE,
+    PYPROJECT_TOML_FILE_PATH,
+)
 from ci_connector_ops.pipelines.utils import get_file_contents, slugify, with_exit_code
 from dagger import CacheSharingMode, CacheVolume, Container, Directory, File, Platform, Secret
 
 if TYPE_CHECKING:
     from ci_connector_ops.pipelines.contexts import ConnectorContext, PipelineContext
-
-
-PYPROJECT_TOML_FILE_PATH = "pyproject.toml"
-
-CONNECTOR_TESTING_REQUIREMENTS = [
-    "pip==21.3.1",
-    "mccabe==0.6.1",
-    "flake8==4.0.1",
-    "pyproject-flake8==0.0.1a2",
-    "black==22.3.0",
-    "isort==5.6.4",
-    "pytest==6.2.5",
-    "coverage[toml]==6.3.1",
-    "pytest-custom_exit_code",
-]
-
-DEFAULT_PYTHON_EXCLUDE = ["**/.venv", "**/__pycache__"]
-CI_CREDENTIALS_SOURCE_PATH = "tools/ci_credentials"
-CI_CONNECTOR_OPS_SOURCE_PATH = "tools/ci_connector_ops"
 
 
 def with_python_base(context: PipelineContext, python_image_name: str = "python:3.9-slim") -> Container:

--- a/tools/ci_connector_ops/ci_connector_ops/pipelines/bases.py
+++ b/tools/ci_connector_ops/ci_connector_ops/pipelines/bases.py
@@ -11,13 +11,13 @@ from abc import ABC, abstractmethod
 from dataclasses import dataclass, field
 from datetime import datetime
 from enum import Enum
-from typing import TYPE_CHECKING, Any, ClassVar, List, Optional, Tuple
+from typing import TYPE_CHECKING, Any, ClassVar, List, Optional
 
 import asyncer
-from ci_connector_ops.pipelines.actions import environments
-from ci_connector_ops.pipelines.utils import check_path_in_workdir, slugify, with_exit_code, with_stderr, with_stdout
-from ci_connector_ops.utils import Connector, console
-from dagger import CacheVolume, Container, Directory, QueryError
+from ci_connector_ops.pipelines.consts import PYPROJECT_TOML_FILE_PATH
+from ci_connector_ops.pipelines.utils import check_path_in_workdir, with_exit_code, with_stderr, with_stdout
+from ci_connector_ops.utils import console
+from dagger import Container, QueryError
 from rich.console import Group
 from rich.panel import Panel
 from rich.style import Style
@@ -168,9 +168,7 @@ class PytestStep(Step, ABC):
         Returns:
             Tuple[StepStatus, Optional[str], Optional[str]]: Tuple of StepStatus, stderr and stdout.
         """
-        test_config = (
-            "pytest.ini" if await check_path_in_workdir(connector_under_test, "pytest.ini") else "/" + environments.PYPROJECT_TOML_FILE_PATH
-        )
+        test_config = "pytest.ini" if await check_path_in_workdir(connector_under_test, "pytest.ini") else "/" + PYPROJECT_TOML_FILE_PATH
         if await check_path_in_workdir(connector_under_test, test_directory):
             tester = connector_under_test.with_exec(
                 [
@@ -365,130 +363,3 @@ class ConnectorReport(Report):
 
         main_panel = Panel(Group(*to_render), title=main_panel_title, subtitle=duration_subtitle)
         console.print(main_panel)
-
-
-class GradleTask(Step, ABC):
-    """
-    A step to run a Gradle task.
-
-    Attributes:
-        task_name (str): The Gradle task name to run.
-        title (str): The step title.
-    """
-
-    DEFAULT_TASKS_TO_EXCLUDE = ["airbyteDocker"]
-    BIND_TO_DOCKER_HOST = True
-    gradle_task_name: ClassVar
-
-    # TODO more robust way to find all projects on which the task depends?
-    JAVA_BUILD_INCLUDE = [
-        "airbyte-api",
-        "airbyte-commons-cli",
-        "airbyte-commons-protocol",
-        "airbyte-commons",
-        "airbyte-config",
-        "airbyte-connector-test-harnesses",
-        "airbyte-db",
-        "airbyte-integrations/bases",
-        "airbyte-json-validation",
-        "airbyte-protocol",
-        "airbyte-test-utils",
-        "airbyte-config-oss",
-    ]
-
-    SOURCE_BUILD_INCLUDE = [
-        "airbyte-integrations/connectors/source-jdbc",
-        "airbyte-integrations/connectors/source-relational-db",
-    ]
-
-    DESTINATION_BUILD_INCLUDE = [
-        "airbyte-integrations/bases/bases-destination-jdbc",
-        "airbyte-integrations/connectors/destination-gcs",
-        "airbyte-integrations/connectors/destination-azure-blob-storage",
-    ]
-
-    # These are the lines we remove from the connector gradle file to ignore specific tasks / plugins.
-    LINES_TO_REMOVE_FROM_GRADLE_FILE = [
-        # Do not build normalization with Gradle - we build normalization with Dagger in the BuildOrPullNormalization step.
-        "project(':airbyte-integrations:bases:base-normalization').airbyteDocker.output",
-    ]
-
-    @property
-    def docker_service_name(self) -> str:
-        return slugify(f"gradle-{self.title}")
-
-    @property
-    def connector_java_build_cache(self) -> CacheVolume:
-        return self.context.dagger_client.cache_volume("connector_java_build_cache")
-
-    def get_related_connectors(self) -> List[Connector]:
-        """Retrieve the list of related connectors.
-        This is used to include source code of non strict-encrypt connectors when running build for a strict-encrypt connector.
-
-        Returns:
-            List[Connector]: The list of related connectors.
-        """
-        if self.context.connector.technical_name.endswith("-strict-encrypt"):
-            return [Connector(self.context.connector.technical_name.replace("-strict-encrypt", ""))]
-        if self.context.connector.technical_name == "source-file-secure":
-            return [Connector("source-file")]
-        return []
-
-    @property
-    def build_include(self) -> List[str]:
-        """Retrieve the list of source code directory required to run a Java connector Gradle task.
-
-        The list is different according to the connector type.
-
-        Returns:
-            List[str]: List of directories or files to be mounted to the container to run a Java connector Gradle task.
-        """
-        to_include = self.JAVA_BUILD_INCLUDE
-
-        if self.context.connector.connector_type == "source":
-            to_include += self.SOURCE_BUILD_INCLUDE
-        elif self.context.connector.connector_type == "destination":
-            to_include += self.DESTINATION_BUILD_INCLUDE
-        else:
-            raise ValueError(f"{self.context.connector.connector_type} is not supported")
-
-        with_related_connectors_source_code = to_include + [str(connector.code_directory) for connector in self.get_related_connectors()]
-        return with_related_connectors_source_code
-
-    async def _get_patched_connector_dir(self) -> Directory:
-        """Patch the build.gradle file of the connector under test by removing the lines declared in LINES_TO_REMOVE_FROM_GRADLE_FILE.
-
-        Returns:
-            Directory: The patched connector directory
-        """
-
-        gradle_file_content = await self.context.get_connector_dir(include=["build.gradle"]).file("build.gradle").contents()
-        patched_file_content = ""
-        for line in gradle_file_content.split("\n"):
-            if not any(line_to_remove in line for line_to_remove in self.LINES_TO_REMOVE_FROM_GRADLE_FILE):
-                patched_file_content += line + "\n"
-        return self.context.get_connector_dir().with_new_file("build.gradle", patched_file_content)
-
-    def _get_gradle_command(self, extra_options: Tuple[str] = ("--no-daemon", "--scan")) -> List:
-        command = (
-            ["./gradlew"]
-            + list(extra_options)
-            + [f":airbyte-integrations:connectors:{self.context.connector.technical_name}:{self.gradle_task_name}"]
-        )
-        for task in self.DEFAULT_TASKS_TO_EXCLUDE:
-            command += ["-x", task]
-        return command
-
-    async def _run(self) -> StepResult:
-        connector_under_test = (
-            environments.with_gradle(
-                self.context, self.build_include, docker_service_name=self.docker_service_name, bind_to_docker_host=self.BIND_TO_DOCKER_HOST
-            )
-            .with_mounted_directory(str(self.context.connector.code_directory), await self._get_patched_connector_dir())
-            # Disable the Ryuk container because it needs privileged docker access that does not work:
-            .with_env_variable("TESTCONTAINERS_RYUK_DISABLED", "true")
-            .with_directory(f"{self.context.connector.code_directory}/secrets", self.context.secrets_dir)
-            .with_exec(self._get_gradle_command())
-        )
-
-        return await self.get_step_result(connector_under_test)

--- a/tools/ci_connector_ops/ci_connector_ops/pipelines/builds/__init__.py
+++ b/tools/ci_connector_ops/ci_connector_ops/pipelines/builds/__init__.py
@@ -3,11 +3,13 @@
 #
 """This module groups factory like functions to dispatch builds steps according to the connector language."""
 
+from __future__ import annotations
+
 import platform
-from typing import Optional, Tuple
+from typing import TYPE_CHECKING, Optional, Tuple
 
 import anyio
-from ci_connector_ops.pipelines.bases import ConnectorReport, StepResult
+from ci_connector_ops.pipelines.bases import ConnectorReport
 from ci_connector_ops.pipelines.builds import common, java_connectors, python_connectors
 from ci_connector_ops.pipelines.contexts import ConnectorContext
 from ci_connector_ops.utils import ConnectorLanguage
@@ -15,6 +17,9 @@ from dagger import Container, Platform
 
 BUILD_PLATFORMS = [Platform("linux/amd64"), Platform("linux/arm64")]
 LOCAL_BUILD_PLATFORM = Platform(f"linux/{platform.machine()}")
+
+if TYPE_CHECKING:
+    from ci_connector_ops.pipelines.bases import StepResult
 
 
 class NoBuildStepForLanguageError(Exception):

--- a/tools/ci_connector_ops/ci_connector_ops/pipelines/builds/java_connectors.py
+++ b/tools/ci_connector_ops/ci_connector_ops/pipelines/builds/java_connectors.py
@@ -4,8 +4,9 @@
 
 
 from ci_connector_ops.pipelines.actions import environments
-from ci_connector_ops.pipelines.bases import GradleTask, StepResult, StepStatus
+from ci_connector_ops.pipelines.bases import StepResult, StepStatus
 from ci_connector_ops.pipelines.builds.common import BuildConnectorImageBase
+from ci_connector_ops.pipelines.gradle import GradleTask
 from dagger import File, QueryError
 
 

--- a/tools/ci_connector_ops/ci_connector_ops/pipelines/consts.py
+++ b/tools/ci_connector_ops/ci_connector_ops/pipelines/consts.py
@@ -1,0 +1,20 @@
+#
+# Copyright (c) 2023 Airbyte, Inc., all rights reserved.
+#
+PYPROJECT_TOML_FILE_PATH = "pyproject.toml"
+
+CONNECTOR_TESTING_REQUIREMENTS = [
+    "pip==21.3.1",
+    "mccabe==0.6.1",
+    "flake8==4.0.1",
+    "pyproject-flake8==0.0.1a2",
+    "black==22.3.0",
+    "isort==5.6.4",
+    "pytest==6.2.5",
+    "coverage[toml]==6.3.1",
+    "pytest-custom_exit_code",
+]
+
+DEFAULT_PYTHON_EXCLUDE = ["**/.venv", "**/__pycache__"]
+CI_CREDENTIALS_SOURCE_PATH = "tools/ci_credentials"
+CI_CONNECTOR_OPS_SOURCE_PATH = "tools/ci_connector_ops"

--- a/tools/ci_connector_ops/ci_connector_ops/pipelines/contexts.py
+++ b/tools/ci_connector_ops/ci_connector_ops/pipelines/contexts.py
@@ -304,6 +304,7 @@ class ConnectorContext(PipelineContext):
         self.s3_report_key = s3_report_key
         self._secrets_dir = None
         self._updated_secrets_dir = None
+        self._metadata = yaml.safe_load(self.metadata_path.read_text())["data"]
         super().__init__(
             pipeline_name=pipeline_name,
             is_local=is_local,
@@ -352,7 +353,7 @@ class ConnectorContext(PipelineContext):
 
     @property
     def metadata(self) -> dict:
-        return yaml.safe_load(self.metadata_path.read_text())["data"]
+        return self._metadata
 
     @property
     def docker_image_from_metadata(self) -> str:
@@ -438,8 +439,8 @@ class PublishConnectorContext(ConnectorContext):
         metadata_bucket_name: str,
         docker_hub_username: str,
         docker_hub_password: str,
-        slack_webhook: str,
-        reporting_slack_channel: str,
+        slack_webhook: Optional[str],
+        reporting_slack_channel: Optional[str],
         is_local: bool,
         git_branch: bool,
         git_revision: bool,

--- a/tools/ci_connector_ops/ci_connector_ops/pipelines/contexts.py
+++ b/tools/ci_connector_ops/ci_connector_ops/pipelines/contexts.py
@@ -304,7 +304,6 @@ class ConnectorContext(PipelineContext):
         self.s3_report_key = s3_report_key
         self._secrets_dir = None
         self._updated_secrets_dir = None
-        self._metadata = yaml.safe_load(self.metadata_path.read_text())["data"]
         super().__init__(
             pipeline_name=pipeline_name,
             is_local=is_local,
@@ -353,7 +352,7 @@ class ConnectorContext(PipelineContext):
 
     @property
     def metadata(self) -> dict:
-        return self._metadata
+        return yaml.safe_load(self.metadata_path.read_text())["data"]
 
     @property
     def docker_image_from_metadata(self) -> str:
@@ -439,8 +438,8 @@ class PublishConnectorContext(ConnectorContext):
         metadata_bucket_name: str,
         docker_hub_username: str,
         docker_hub_password: str,
-        slack_webhook: Optional[str],
-        reporting_slack_channel: Optional[str],
+        slack_webhook: str,
+        reporting_slack_channel: str,
         is_local: bool,
         git_branch: bool,
         git_revision: bool,

--- a/tools/ci_connector_ops/ci_connector_ops/pipelines/gradle.py
+++ b/tools/ci_connector_ops/ci_connector_ops/pipelines/gradle.py
@@ -1,0 +1,141 @@
+#
+# Copyright (c) 2023 Airbyte, Inc., all rights reserved.
+#
+
+from __future__ import annotations
+
+from abc import ABC
+from typing import ClassVar, List, Tuple
+
+from ci_connector_ops.pipelines.actions import environments
+from ci_connector_ops.pipelines.bases import Step, StepResult
+from ci_connector_ops.pipelines.utils import slugify
+from ci_connector_ops.utils import Connector
+from dagger import CacheVolume, Directory
+
+
+class GradleTask(Step, ABC):
+    """
+    A step to run a Gradle task.
+
+    Attributes:
+        task_name (str): The Gradle task name to run.
+        title (str): The step title.
+    """
+
+    DEFAULT_TASKS_TO_EXCLUDE = ["airbyteDocker"]
+    BIND_TO_DOCKER_HOST = True
+    gradle_task_name: ClassVar
+
+    # TODO more robust way to find all projects on which the task depends?
+    JAVA_BUILD_INCLUDE = [
+        "airbyte-api",
+        "airbyte-commons-cli",
+        "airbyte-commons-protocol",
+        "airbyte-commons",
+        "airbyte-config",
+        "airbyte-connector-test-harnesses",
+        "airbyte-db",
+        "airbyte-integrations/bases",
+        "airbyte-json-validation",
+        "airbyte-protocol",
+        "airbyte-test-utils",
+        "airbyte-config-oss",
+    ]
+
+    SOURCE_BUILD_INCLUDE = [
+        "airbyte-integrations/connectors/source-jdbc",
+        "airbyte-integrations/connectors/source-relational-db",
+    ]
+
+    DESTINATION_BUILD_INCLUDE = [
+        "airbyte-integrations/bases/bases-destination-jdbc",
+        "airbyte-integrations/connectors/destination-gcs",
+        "airbyte-integrations/connectors/destination-azure-blob-storage",
+    ]
+
+    # These are the lines we remove from the connector gradle file to ignore specific tasks / plugins.
+    LINES_TO_REMOVE_FROM_GRADLE_FILE = [
+        # Do not build normalization with Gradle - we build normalization with Dagger in the BuildOrPullNormalization step.
+        "project(':airbyte-integrations:bases:base-normalization').airbyteDocker.output",
+    ]
+
+    @property
+    def docker_service_name(self) -> str:
+        return slugify(f"gradle-{self.title}")
+
+    @property
+    def connector_java_build_cache(self) -> CacheVolume:
+        return self.context.dagger_client.cache_volume("connector_java_build_cache")
+
+    def get_related_connectors(self) -> List[Connector]:
+        """Retrieve the list of related connectors.
+        This is used to include source code of non strict-encrypt connectors when running build for a strict-encrypt connector.
+
+        Returns:
+            List[Connector]: The list of related connectors.
+        """
+        if self.context.connector.technical_name.endswith("-strict-encrypt"):
+            return [Connector(self.context.connector.technical_name.replace("-strict-encrypt", ""))]
+        if self.context.connector.technical_name == "source-file-secure":
+            return [Connector("source-file")]
+        return []
+
+    @property
+    def build_include(self) -> List[str]:
+        """Retrieve the list of source code directory required to run a Java connector Gradle task.
+
+        The list is different according to the connector type.
+
+        Returns:
+            List[str]: List of directories or files to be mounted to the container to run a Java connector Gradle task.
+        """
+        to_include = self.JAVA_BUILD_INCLUDE
+
+        if self.context.connector.connector_type == "source":
+            to_include += self.SOURCE_BUILD_INCLUDE
+        elif self.context.connector.connector_type == "destination":
+            to_include += self.DESTINATION_BUILD_INCLUDE
+        else:
+            raise ValueError(f"{self.context.connector.connector_type} is not supported")
+
+        with_related_connectors_source_code = to_include + [str(connector.code_directory) for connector in self.get_related_connectors()]
+        return with_related_connectors_source_code
+
+    async def _get_patched_connector_dir(self) -> Directory:
+        """Patch the build.gradle file of the connector under test by removing the lines declared in LINES_TO_REMOVE_FROM_GRADLE_FILE.
+
+        Returns:
+            Directory: The patched connector directory
+        """
+
+        gradle_file_content = await self.context.get_connector_dir(include=["build.gradle"]).file("build.gradle").contents()
+        patched_file_content = ""
+        for line in gradle_file_content.split("\n"):
+            if not any(line_to_remove in line for line_to_remove in self.LINES_TO_REMOVE_FROM_GRADLE_FILE):
+                patched_file_content += line + "\n"
+        return self.context.get_connector_dir().with_new_file("build.gradle", patched_file_content)
+
+    def _get_gradle_command(self, extra_options: Tuple[str] = ("--no-daemon", "--scan")) -> List:
+        command = (
+            ["./gradlew"]
+            + list(extra_options)
+            + [f":airbyte-integrations:connectors:{self.context.connector.technical_name}:{self.gradle_task_name}"]
+        )
+        for task in self.DEFAULT_TASKS_TO_EXCLUDE:
+            command += ["-x", task]
+        return command
+
+    async def _run(self) -> StepResult:
+        connector_under_test = (
+            environments.with_gradle(
+                self.context, self.build_include, docker_service_name=self.docker_service_name, bind_to_docker_host=self.BIND_TO_DOCKER_HOST
+            )
+            .with_mounted_directory(str(self.context.connector.code_directory), await self._get_patched_connector_dir())
+            # Disable the Ryuk container because it needs privileged docker access that does not work:
+            .with_env_variable("TESTCONTAINERS_RYUK_DISABLED", "true")
+            .with_directory(f"{self.context.connector.code_directory}/secrets", self.context.secrets_dir)
+            .with_exec(self._get_gradle_command())
+        )
+
+        return await self.get_step_result(connector_under_test)

--- a/tools/ci_connector_ops/ci_connector_ops/pipelines/publish.py
+++ b/tools/ci_connector_ops/ci_connector_ops/pipelines/publish.py
@@ -102,8 +102,9 @@ class UploadSpecToCache(Step):
                     parsed_spec = parsed_json["spec"]
                     ConnectorSpecification.parse_obj(parsed_spec)
                     return json.dumps(parsed_spec)
-            except (json.JSONDecodeError, KeyError, ValidationError, ValueError):
-                raise InvalidSpecOutputError("Could not parse the output of the SPEC command to a valid spec.")
+            except (json.JSONDecodeError, KeyError, ValidationError, ValueError) as e:
+                raise InvalidSpecOutputError(f"Could not parse the output of the SPEC command to a valid spec: {str(e)}")
+        raise InvalidSpecOutputError("No spec found in the output of the SPEC command.")
 
     async def _get_connector_spec(self, connector: Container, deployment_mode: str) -> str:
         spec_output = await connector.with_env_variable("DEPLOYMENT_MODE", deployment_mode).with_exec(["spec"]).stdout()

--- a/tools/ci_connector_ops/ci_connector_ops/pipelines/tests/java_connectors.py
+++ b/tools/ci_connector_ops/ci_connector_ops/pipelines/tests/java_connectors.py
@@ -8,11 +8,12 @@ from typing import List, Optional
 
 import anyio
 from ci_connector_ops.pipelines.actions import environments, run_steps, secrets
-from ci_connector_ops.pipelines.bases import GradleTask, StepResult, StepStatus
+from ci_connector_ops.pipelines.bases import StepResult, StepStatus
 from ci_connector_ops.pipelines.builds import LOCAL_BUILD_PLATFORM
 from ci_connector_ops.pipelines.builds.java_connectors import BuildConnectorImage
 from ci_connector_ops.pipelines.builds.normalization import BuildOrPullNormalization
 from ci_connector_ops.pipelines.contexts import ConnectorContext
+from ci_connector_ops.pipelines.gradle import GradleTask
 from ci_connector_ops.pipelines.tests.common import AcceptanceTests
 from ci_connector_ops.pipelines.utils import export_container_to_tarball
 from dagger import File, QueryError

--- a/tools/ci_connector_ops/setup.py
+++ b/tools/ci_connector_ops/setup.py
@@ -11,7 +11,7 @@ MAIN_REQUIREMENTS = [
     "requests",
     "PyYAML~=6.0",
     "GitPython~=3.1.29",
-    "pydantic~=1.10.4",
+    "pydantic~=1.9",
     "PyGithub~=1.58.0",
     "rich",
 ]
@@ -42,7 +42,16 @@ QA_ENGINE_REQUIREMENTS = [
     "pytablewriter~=0.64.2",
 ]
 
-PIPELINES_REQUIREMENTS = ["dagger-io==0.5.0", "asyncer", "anyio", "more-itertools", "docker", "requests", "semver"]
+PIPELINES_REQUIREMENTS = [
+    "dagger-io==0.5.0",
+    "asyncer",
+    "anyio",
+    "more-itertools",
+    "docker",
+    "requests",
+    "semver",
+    "airbyte-protocol-models",
+]
 
 setup(
     version="0.2.1",

--- a/tools/ci_connector_ops/tests/test_pipelines/__init__.py
+++ b/tools/ci_connector_ops/tests/test_pipelines/__init__.py
@@ -1,0 +1,3 @@
+#
+# Copyright (c) 2023 Airbyte, Inc., all rights reserved.
+#

--- a/tools/ci_connector_ops/tests/test_pipelines/test_publish.py
+++ b/tools/ci_connector_ops/tests/test_pipelines/test_publish.py
@@ -119,7 +119,7 @@ class TestUploadSpecToCache:
             assert step_result.stderr == "upload_to_gcs_stderr"
         if (not valid_spec and successful_upload) or (not valid_spec and not successful_upload):
             assert step_result.status == StepStatus.FAILURE
-            assert step_result.stderr == "Could not parse the output of the SPEC command to a valid spec."
+            assert step_result.stderr == "Could not parse the output of the SPEC command to a valid spec: Invalid spec."
             assert step_result.stdout is None
             publish.upload_to_gcs.assert_not_called()
 

--- a/tools/ci_connector_ops/tests/test_pipelines/test_publish.py
+++ b/tools/ci_connector_ops/tests/test_pipelines/test_publish.py
@@ -1,0 +1,284 @@
+#
+# Copyright (c) 2023 Airbyte, Inc., all rights reserved.
+#
+import json
+import random
+from typing import List
+
+import anyio
+import dagger
+import pytest
+import requests
+from ci_connector_ops.pipelines import publish
+from ci_connector_ops.pipelines.bases import StepStatus
+
+
+@pytest.fixture(scope="module")
+def anyio_backend():
+    return "asyncio"
+
+
+@pytest.fixture(scope="module")
+async def dagger_client():
+    async with dagger.Connection() as client:
+        yield client
+
+
+@pytest.fixture(scope="module")
+def oss_registry():
+    response = requests.get("https://connectors.airbyte.com/files/registries/v0/oss_registry.json")
+    response.raise_for_status()
+    return response.json()
+
+
+pytestmark = [
+    pytest.mark.anyio,
+]
+
+
+class TestCheckConnectorImageDoesNotExists:
+    @pytest.fixture(scope="class")
+    def three_random_connectors_image_names(self, oss_registry: dict) -> List[str]:
+        connectors = oss_registry["sources"] + oss_registry["destinations"]
+        random.shuffle(connectors)
+        return [f"{connector['dockerRepository']}:{connector['dockerImageTag']}" for connector in connectors[:3]]
+
+    @pytest.mark.slow
+    async def test_run(self, mocker, dagger_client, three_random_connectors_image_names):
+        """We pick the first three connectors from the OSS registry and check that they are already published."""
+        for image_name in three_random_connectors_image_names:
+            context = mocker.MagicMock(dagger_client=dagger_client, docker_image_name=image_name)
+            step = publish.CheckConnectorImageDoesNotExist(context)
+            step_result = await step.run()
+            assert step_result.status == StepStatus.SKIPPED
+        image_name = "airbyte/source-pokeapi:0.0.0"
+        context = mocker.MagicMock(dagger_client=dagger_client, docker_image_name=image_name)
+        step = publish.CheckConnectorImageDoesNotExist(context)
+        step_result = await step.run()
+        assert step_result.status == StepStatus.SUCCESS
+
+
+class TestUploadSpecToCache:
+    @pytest.fixture(scope="class")
+    def random_connector(self, oss_registry):
+        return random.choice(oss_registry["sources"] + oss_registry["destinations"])
+
+    @pytest.mark.slow
+    @pytest.mark.parametrize(
+        "valid_spec, successful_upload",
+        [
+            [True, True],
+            [False, True],
+            [True, False],
+            [False, False],
+        ],
+    )
+    async def test_run(self, mocker, dagger_client, tmpdir, valid_spec, successful_upload, random_connector):
+        """Test that the spec is correctly uploaded to the spec cache bucket.
+        We pick a random connector from the oss registry, by nature this connector should have a valid spec and be published.
+        We use load this connector as a Dagger container and run spec against it.
+        We validate that the outputted spec is the same as the one in the OSS registry.
+        We also artificially set the spec to be invalid and check that the step fails.
+        """
+        image_name = f"{random_connector['dockerRepository']}:{random_connector['dockerImageTag']}"
+        expected_spec = random_connector["spec"]
+        connector_container = dagger_client.container().from_(image_name)
+
+        tmp_dir = dagger_client.host().directory(str(tmpdir))
+        upload_exit_code = 0 if successful_upload else 1
+        mocker.patch.object(
+            publish, "upload_to_gcs", mocker.AsyncMock(return_value=(upload_exit_code, "upload_to_gcs_stdout", "upload_to_gcs_stderr"))
+        )
+        mocker.patch.object(publish.UploadSpecToCache, "spec_is_valid", mocker.AsyncMock(return_value=valid_spec))
+        context = mocker.MagicMock(
+            dagger_client=dagger_client, get_connector_dir=mocker.MagicMock(return_value=tmp_dir), docker_image_name=image_name
+        )
+        step = publish.UploadSpecToCache(context)
+        step_result = await step.run(connector_container)
+        if valid_spec:
+            publish.upload_to_gcs.assert_called_once_with(
+                context.dagger_client,
+                mocker.ANY,
+                f"specs/{image_name.replace(':', '/')}/spec.json",
+                context.spec_cache_bucket_name,
+                context.spec_cache_gcs_credentials_secret,
+            )
+
+            spec_file = publish.upload_to_gcs.call_args.args[1]
+            uploaded_content = await spec_file.contents()
+            assert json.loads(uploaded_content) == expected_spec
+
+        if successful_upload and valid_spec:
+            assert step_result.status == StepStatus.SUCCESS
+            assert step_result.stdout == "Uploaded connector spec to spec cache bucket."
+            assert step_result.stderr is None
+        if valid_spec and not successful_upload:
+            assert step_result.status == StepStatus.FAILURE
+            assert step_result.stdout == "upload_to_gcs_stdout"
+            assert step_result.stderr == "upload_to_gcs_stderr"
+        if (not valid_spec and successful_upload) or (not valid_spec and not successful_upload):
+            assert step_result.status == StepStatus.FAILURE
+            assert step_result.stderr == "The spec is not valid. Please fix it before publishing the connector."
+            assert step_result.stdout is None
+            publish.upload_to_gcs.assert_not_called()
+
+
+STEPS_TO_PATCH = [
+    (publish.metadata, "MetadataValidation"),
+    (publish.metadata, "MetadataUpload"),
+    (publish, "CheckConnectorImageDoesNotExist"),
+    (publish, "UploadSpecToCache"),
+    (publish, "PushConnectorImageToRegistry"),
+    (publish, "BuildConnectorForPublish"),
+]
+
+
+async def test_run_connector_publish_pipeline_when_failed_validation(mocker):
+    """We validate the no other steps are called if the metadata validation step fails."""
+    for module, to_mock in STEPS_TO_PATCH:
+        mocker.patch.object(module, to_mock, return_value=mocker.AsyncMock())
+
+    run_metadata_validation = publish.metadata.MetadataValidation.return_value.run
+    run_metadata_validation.return_value = mocker.Mock(status=StepStatus.FAILURE)
+
+    context = mocker.MagicMock()
+    semaphore = anyio.Semaphore(1)
+    report = await publish.run_connector_publish_pipeline(context, semaphore)
+    run_metadata_validation.assert_called_once()
+
+    # Check that nothing else is called
+    for module, to_mock in STEPS_TO_PATCH:
+        if to_mock != "MetadataValidation":
+            getattr(module, to_mock).return_value.run.assert_not_called()
+
+    assert (
+        report.steps_results
+        == context.report.steps_results
+        == [
+            run_metadata_validation.return_value,
+        ]
+    )
+
+
+@pytest.mark.parametrize("check_image_exists_status", [StepStatus.SKIPPED, StepStatus.FAILURE])
+async def test_run_connector_publish_pipeline_when_image_exists_or_failed(mocker, check_image_exists_status):
+    """We validate that when the connector image exists or the check fails, we don't run the rest of the pipeline.
+    We also validate that the metadata upload step is called when the image exists (Skipped status).
+    We do this to ensure that the metadata is still updated in the case where the connector image already exists.
+    It's the role of the metadata service upload command to actually upload the file if the metadata has changed.
+    But we check that the metadata upload step does not happen if the image check fails (Failure status).
+    """
+    for module, to_mock in STEPS_TO_PATCH:
+        mocker.patch.object(module, to_mock, return_value=mocker.AsyncMock())
+
+    run_metadata_validation = publish.metadata.MetadataValidation.return_value.run
+    run_metadata_validation.return_value = mocker.Mock(status=StepStatus.SUCCESS)
+
+    run_check_connector_image_does_not_exist = publish.CheckConnectorImageDoesNotExist.return_value.run
+    run_check_connector_image_does_not_exist.return_value = mocker.Mock(status=check_image_exists_status)
+
+    run_metadata_upload = publish.metadata.MetadataUpload.return_value.run
+
+    context = mocker.MagicMock()
+    semaphore = anyio.Semaphore(1)
+    report = await publish.run_connector_publish_pipeline(context, semaphore)
+    run_metadata_validation.assert_called_once()
+    run_check_connector_image_does_not_exist.assert_called_once()
+
+    # Check that nothing else is called
+    for module, to_mock in STEPS_TO_PATCH:
+        if to_mock not in ["MetadataValidation", "MetadataUpload", "CheckConnectorImageDoesNotExist"]:
+            getattr(module, to_mock).return_value.run.assert_not_called()
+
+    if check_image_exists_status == StepStatus.SKIPPED:
+        run_metadata_upload.assert_called_once()
+        assert (
+            report.steps_results
+            == context.report.steps_results
+            == [
+                run_metadata_validation.return_value,
+                run_check_connector_image_does_not_exist.return_value,
+                run_metadata_upload.return_value,
+            ]
+        )
+    if check_image_exists_status == StepStatus.FAILURE:
+        run_metadata_upload.assert_not_called()
+        assert (
+            report.steps_results
+            == context.report.steps_results
+            == [
+                run_metadata_validation.return_value,
+                run_check_connector_image_does_not_exist.return_value,
+            ]
+        )
+
+
+@pytest.mark.parametrize(
+    "build_step_status, push_step_status, upload_to_spec_cache_step_status, metadata_upload_step_status",
+    [
+        (StepStatus.SUCCESS, StepStatus.SUCCESS, StepStatus.SUCCESS, StepStatus.SUCCESS),
+        (StepStatus.SUCCESS, StepStatus.SUCCESS, StepStatus.SUCCESS, StepStatus.FAILURE),
+        (StepStatus.SUCCESS, StepStatus.SUCCESS, StepStatus.FAILURE, None),
+        (StepStatus.SUCCESS, StepStatus.FAILURE, None, None),
+        (StepStatus.FAILURE, None, None, None),
+    ],
+)
+async def test_run_connector_publish_pipeline_when_image_does_not_exist(
+    mocker, build_step_status, push_step_status, upload_to_spec_cache_step_status, metadata_upload_step_status
+):
+    """We check that the full pipeline is executed as expected when the connector image does not exist and the metadata validation passed."""
+    for module, to_mock in STEPS_TO_PATCH:
+        mocker.patch.object(module, to_mock, return_value=mocker.AsyncMock())
+    publish.metadata.MetadataValidation.return_value.run.return_value = mocker.Mock(
+        name="metadata_validation_result", status=StepStatus.SUCCESS
+    )
+    publish.CheckConnectorImageDoesNotExist.return_value.run.return_value = mocker.Mock(
+        name="check_connector_image_does_not_exist_result", status=StepStatus.SUCCESS
+    )
+
+    built_connector_platform = mocker.Mock()
+    publish.BuildConnectorForPublish.return_value.run.return_value = mocker.Mock(
+        name="build_connector_for_publish_result", status=build_step_status, output_artifact=[built_connector_platform]
+    )
+
+    publish.PushConnectorImageToRegistry.return_value.run.return_value = mocker.Mock(
+        name="push_connector_image_to_registry_result", status=push_step_status
+    )
+    publish.UploadSpecToCache.return_value.run.return_value = mocker.Mock(
+        name="upload_spec_to_cache_result", status=upload_to_spec_cache_step_status
+    )
+    publish.metadata.MetadataUpload.return_value.run.return_value = mocker.Mock(
+        name="metadata_upload_result", status=metadata_upload_step_status
+    )
+
+    context = mocker.MagicMock()
+    semaphore = anyio.Semaphore(1)
+    report = await publish.run_connector_publish_pipeline(context, semaphore)
+
+    steps_to_run = [
+        publish.metadata.MetadataValidation.return_value.run,
+        publish.CheckConnectorImageDoesNotExist.return_value.run,
+        publish.BuildConnectorForPublish.return_value.run,
+        publish.PushConnectorImageToRegistry.return_value.run,
+        publish.UploadSpecToCache.return_value.run,
+        publish.metadata.MetadataUpload.return_value.run,
+    ]
+    for i, step_to_run in enumerate(steps_to_run):
+        if step_to_run.return_value.status is StepStatus.FAILURE or i == len(steps_to_run) - 1:
+            assert len(report.steps_results) == len(context.report.steps_results) == i + 1
+
+            previous_steps = steps_to_run[:i]
+            for step_ran in previous_steps:
+                step_ran.assert_called_once()
+                step_ran.return_value
+
+            remaining_steps = steps_to_run[i + 1 :]
+            for step_to_run in remaining_steps:
+                step_to_run.assert_not_called()
+            break
+    if build_step_status is StepStatus.SUCCESS:
+        publish.PushConnectorImageToRegistry.return_value.run.assert_called_once_with([built_connector_platform])
+    else:
+        publish.PushConnectorImageToRegistry.return_value.run.assert_not_called()
+        publish.UploadSpecToCache.return_value.run.assert_not_called()
+        publish.metadata.MetadataUpload.return_value.run.assert_not_called()


### PR DESCRIPTION
## What
We need tests to double check that our publish logic is working as expected.

## How
* Rewrite `run_connector_publish_pipeline` to make it 💯 explicit (at the expense of parallelization)
* Fix the schema of the written spec to the cache bucket
* Run spec schema validation on specs that will be written to the cache bucket
* Write tests on the publish logic to make sure:
  * The spec file we upload to the spec cache matches the spec format available in the registry
  * No docker push / spec upload happens if the connector image already exists
* ref: move some code around to avoid circular dependency problems
