### PR TITLE
Bump connector builder's record limit to 1000

### DIFF
--- a/airbyte-cdk/python/airbyte_cdk/connector_builder/connector_builder_handler.py
+++ b/airbyte-cdk/python/airbyte_cdk/connector_builder/connector_builder_handler.py
@@ -20,7 +20,7 @@ from airbyte_cdk.utils.traced_exception import AirbyteTracedException
 
 DEFAULT_MAXIMUM_NUMBER_OF_PAGES_PER_SLICE = 5
 DEFAULT_MAXIMUM_NUMBER_OF_SLICES = 5
-DEFAULT_MAXIMUM_RECORDS = 100
+DEFAULT_MAXIMUM_RECORDS = 1000
 
 MAX_PAGES_PER_SLICE_KEY = "max_pages_per_slice"
 MAX_SLICES_KEY = "max_slices"


### PR DESCRIPTION
## What
* Limiting the connector builder to reading 100 records is too restrictive.
* This PR bumps the limit to 1000 records.

## 🚨 User Impact 🚨
* No breaking changes
* The connector builder will return more records