### PR TITLE
Metadata: set cache control headers

### DIFF
--- a/airbyte-ci/connectors/metadata_service/lib/metadata_service/gcs_upload.py
+++ b/airbyte-ci/connectors/metadata_service/lib/metadata_service/gcs_upload.py
@@ -38,6 +38,7 @@ def compute_gcs_md5(file_name: str) -> str:
 
     return base64.b64encode(hash_md5.digest()).decode("utf8")
 
+
 def _save_blob_to_gcs(blob_to_save: storage.blob.Blob, file_path: str) -> bool:
     """Uploads a file to the bucket."""
     print(f"Uploading {file_path} to {blob_to_save.name}...")

--- a/airbyte-ci/connectors/metadata_service/lib/metadata_service/gcs_upload.py
+++ b/airbyte-ci/connectors/metadata_service/lib/metadata_service/gcs_upload.py
@@ -30,13 +30,26 @@ def get_metadata_file_path(dockerRepository: str, version: str) -> str:
     return f"{METADATA_FOLDER}/{dockerRepository}/{version}/{METADATA_FILE_NAME}"
 
 
-def compute_gcs_md5(file_name):
+def compute_gcs_md5(file_name: str) -> str:
     hash_md5 = hashlib.md5()
     with open(file_name, "rb") as f:
         for chunk in iter(lambda: f.read(4096), b""):
             hash_md5.update(chunk)
 
     return base64.b64encode(hash_md5.digest()).decode("utf8")
+
+def _save_blob_to_gcs(blob_to_save: storage.blob.Blob, file_path: str) -> bool:
+    """Uploads a file to the bucket."""
+    print(f"Uploading {file_path} to {blob_to_save.name}...")
+
+    # Set Cache-Control header to no-cache to avoid caching issues
+    # This is IMPORTANT because if we don't set this header, the metadata file will be cached by GCS
+    # and the next time we try to download it, we will get the stale version
+    blob_to_save.cache_control = "no-cache"
+
+    blob_to_save.upload_from_filename(file_path)
+
+    return True
 
 
 def upload_metadata_to_gcs(bucket_name: str, metadata_file_path: Path) -> Tuple[bool, str]:
@@ -93,13 +106,9 @@ def upload_metadata_to_gcs(bucket_name: str, metadata_file_path: Path) -> Tuple[
 
     # upload if md5_hash is different
     if trigger_version_upload:
-        print(f"Uploading {metadata_file_path} to {version_path}...")
-        version_blob.upload_from_filename(str(metadata_file_path))
-        uploaded = True
+        uploaded = _save_blob_to_gcs(version_blob, str(metadata_file_path))
 
     if trigger_latest_upload:
-        print(f"Uploading {metadata_file_path} to {latest_path}...")
-        latest_blob.upload_from_filename(str(metadata_file_path))
-        uploaded = True
+        uploaded = _save_blob_to_gcs(latest_blob, str(metadata_file_path))
 
     return uploaded, version_blob.id

--- a/airbyte-ci/connectors/metadata_service/orchestrator/orchestrator/resources/gcp.py
+++ b/airbyte-ci/connectors/metadata_service/orchestrator/orchestrator/resources/gcp.py
@@ -49,7 +49,13 @@ class ContentTypeAwareGCSFileManager(GCSFileManager):
         gcs_key = self.get_full_key(key + (("." + ext) if ext is not None else ""))
         bucket_obj = self._client.bucket(self._gcs_bucket)
         blob = bucket_obj.blob(gcs_key)
+
+        # Set Cache-Control header to no-cache to avoid caching issues
+        # This is IMPORTANT because if we don't set this header, the metadata file will be cached by GCS
+        # and the next time we try to download it, we will get the stale version
+        blob.cache_control = "no-cache"
         blob.content_type = self.get_content_type(ext)
+
         blob.upload_from_file(file_obj)
         return PublicGCSFileHandle(self._gcs_bucket, gcs_key)
 

--- a/tools/ci_connector_ops/ci_connector_ops/pipelines/commands/groups/connectors.py
+++ b/tools/ci_connector_ops/ci_connector_ops/pipelines/commands/groups/connectors.py
@@ -314,7 +314,6 @@ def publish(
     slack_webhook: str,
     slack_channel: str,
 ):
-
     if ctx.obj["is_local"]:
         click.confirm(
             "Publishing from a local environment is not recommend and requires to be logged in Airbyte's DockerHub registry, do you want to continue?",

--- a/tools/ci_connector_ops/ci_connector_ops/pipelines/publish.py
+++ b/tools/ci_connector_ops/ci_connector_ops/pipelines/publish.py
@@ -139,7 +139,7 @@ class UploadSpecToCache(Step):
                 key,
                 self.context.spec_cache_bucket_name,
                 self.context.spec_cache_gcs_credentials_secret,
-                flags=["--cache-control=\"no-cache\""],
+                flags=['--cache-control="no-cache"'],
             )
             if exit_code != 0:
                 return StepResult(self, status=StepStatus.FAILURE, stdout=stdout, stderr=stderr)

--- a/tools/ci_connector_ops/ci_connector_ops/pipelines/publish.py
+++ b/tools/ci_connector_ops/ci_connector_ops/pipelines/publish.py
@@ -139,6 +139,7 @@ class UploadSpecToCache(Step):
                 key,
                 self.context.spec_cache_bucket_name,
                 self.context.spec_cache_gcs_credentials_secret,
+                flags=["--cache-control=\"no-cache\""],
             )
             if exit_code != 0:
                 return StepResult(self, status=StepStatus.FAILURE, stdout=stdout, stderr=stderr)


### PR DESCRIPTION
## What
Ensure we are not caching the metadata files, spec or registry at the CDN level.

While we had caching disabled, google caches public buckets by default.

More context here: https://airbytehq-team.slack.com/archives/C02U46QK5C3/p1683940962000049?thread_ts=1683925529.873469&cid=C02U46QK5C3


## Notes for reviewers
Google does not have a bucket level setting for this 😢 

So we will want to run this command after deploying
```
gsutil setmeta -r -h "Cache-Control: no-cache" gs://io-airbyte-cloud-spec-cache
gsutil setmeta -r -h "Cache-Control: no-cache" gs://prod-airbyte-cloud-connector-metadata-service
```