### PR TITLE
connectors-ci: slim down Java images

### DIFF
--- a/tools/ci_connector_ops/ci_connector_ops/pipelines/actions/environments.py
+++ b/tools/ci_connector_ops/ci_connector_ops/pipelines/actions/environments.py
@@ -670,9 +670,8 @@ async def with_airbyte_java_connector(context: ConnectorContext, connector_java_
     return (
         base.with_workdir("/airbyte")
         .with_env_variable("APPLICATION", application)
-        .with_directory("builts_artifacts", build_stage.directory("/airbyte"))
+        .with_mounted_directory("builts_artifacts", build_stage.directory("/airbyte"))
         .with_exec(["sh", "-c", "mv builts_artifacts/* ."])
-        .with_exec(["rm", "-rf", "builts_artifacts"])
         .with_label("io.airbyte.version", context.metadata["dockerImageTag"])
         .with_label("io.airbyte.name", context.metadata["dockerRepository"])
         .with_entrypoint(entrypoint)


### PR DESCRIPTION
## What
Java connectors images built with dagger are ~2x bigger that the one built with Dockerfiles.

## How
* Use `with_mounted_directory` instead of `with_directory` to mount the built artifact: The mounted directory is not stored as a buildkit layer. This was the reason why the Dagger built images were fatter. `with_directory` instruction correspond to a docker COPY, stored as a buildkit layer. `with_mounted_directory` acts as a runtime volume mount and is what we shall use for multi stage like builds: 

## Fat (note the `copy` layer) 
<img width="809" alt="Screen Shot 2023-05-15 at 23 20 13" src="https://github.com/airbytehq/airbyte/assets/5551758/35d2bdb6-6b84-47b9-94ee-92817722d1a7">

## Slim (no more `copy` layer)

<img width="956" alt="Screen Shot 2023-05-15 at 23 44 44" src="https://github.com/airbytehq/airbyte/assets/5551758/713d7d78-e54b-4d3b-8b48-dc134a73bdfe">
