### PR TITLE
hotfix: Update QA engine to use metadata to unblock PR

### DIFF
--- a/tools/ci_connector_ops/ci_connector_ops/pipelines/commands/groups/connectors.py
+++ b/tools/ci_connector_ops/ci_connector_ops/pipelines/commands/groups/connectors.py
@@ -314,7 +314,6 @@ def publish(
     slack_webhook: str,
     slack_channel: str,
 ):
-
     if ctx.obj["is_local"]:
         click.confirm(
             "Publishing from a local environment is not recommend and requires to be logged in Airbyte's DockerHub registry, do you want to continue?",

--- a/tools/ci_connector_ops/ci_connector_ops/qa_checks.py
+++ b/tools/ci_connector_ops/ci_connector_ops/qa_checks.py
@@ -32,9 +32,9 @@ def check_documentation_follows_guidelines(connector: Connector) -> bool:
     if not doc_lines[0].startswith("# "):
         print("The connector name is not used as the main header in the documentation.")
         follows_guidelines = False
-    # We usually don't have a definition if the connector is not published.
-    if connector.definition:
-        if doc_lines[0].strip() != f"# {connector.definition['name'].lower()}":
+    # We usually don't have a metadata if the connector is not published.
+    if connector.metadata:
+        if doc_lines[0].strip() != f"# {connector.metadata['name'].lower()}":
             print("The connector name is not used as the main header in the documentation.")
             follows_guidelines = False
     elif not doc_lines[0].startswith("# "):

--- a/tools/ci_connector_ops/ci_connector_ops/utils.py
+++ b/tools/ci_connector_ops/ci_connector_ops/utils.py
@@ -124,8 +124,8 @@ class Connector:
 
     @property
     def icon_path(self) -> Path:
-        if self.definition and self.definition.get("icon"):
-            return Path(f"./airbyte-config-oss/init-oss/src/main/resources/icons/{self.definition['icon']}")
+        if self.metadata and self.metadata.get("icon"):
+            return Path(f"./airbyte-config-oss/init-oss/src/main/resources/icons/{self.metadata['icon']}")
         return Path(f"./airbyte-config-oss/init-oss/src/main/resources/icons/{self.name}.svg")
 
     @property
@@ -133,7 +133,10 @@ class Connector:
         return Path(f"./airbyte-integrations/connectors/{self.technical_name}")
 
     @property
-    def metadata(self) -> dict:
+    def metadata(self) -> Optional[dict]:
+        file_path = self.code_directory / METADATA_FILE_NAME
+        if not file_path.is_file():
+            return None
         return yaml.safe_load((self.code_directory / METADATA_FILE_NAME).read_text())["data"]
 
     @property
@@ -153,6 +156,8 @@ class Connector:
 
     @property
     def version(self) -> str:
+        if self.metadata is None:
+            return self.version_in_dockerfile_label
         return self.metadata["dockerImageTag"]
 
     @property
@@ -168,33 +173,17 @@ class Connector:
             """
         )
 
-    @cached_property
-    def definition(self) -> Optional[dict]:
-        """Find a connector definition from the catalog.
-        Returns:
-            Optional[Dict]: The definition if the connector was found in the catalog. Returns None otherwise.
-        """
-        try:
-            definition_type = self.technical_name.split("-")[0]
-            assert definition_type in ["source", "destination"]
-        except AssertionError:
-            return None
-        definitions = read_definitions(DEFINITIONS_FILE_PATH[definition_type])
-        for definition in definitions:
-            if definition["dockerRepository"].replace(f"{AIRBYTE_DOCKER_REPO}/", "") == self.technical_name:
-                return definition
-
     @property
     def release_stage(self) -> Optional[str]:
-        return self.definition.get("releaseStage") if self.definition else None
+        return self.metadata.get("releaseStage") if self.metadata else None
 
     @property
     def allowed_hosts(self) -> Optional[List[str]]:
-        return self.definition.get("allowedHosts") if self.definition else None
+        return self.metadata.get("allowedHosts") if self.metadata else None
 
     @property
     def suggested_streams(self) -> Optional[List[str]]:
-        return self.definition.get("suggestedStreams") if self.definition else None
+        return self.metadata.get("suggestedStreams") if self.metadata else None
 
     @property
     def acceptance_test_config_path(self) -> Path:
@@ -211,17 +200,17 @@ class Connector:
 
     @property
     def supports_normalization(self) -> bool:
-        return self.definition and self.definition.get("normalizationConfig") is not None
+        return self.metadata and self.metadata.get("normalizationConfig") is not None
 
     @property
     def normalization_repository(self) -> Optional[str]:
         if self.supports_normalization:
-            return f"{self.definition['normalizationConfig']['normalizationRepository']}"
+            return f"{self.metadata['normalizationConfig']['normalizationRepository']}"
 
     @property
     def normalization_tag(self) -> Optional[str]:
         if self.supports_normalization:
-            return f"{self.definition['normalizationConfig']['normalizationTag']}"
+            return f"{self.metadata['normalizationConfig']['normalizationTag']}"
 
     def get_secret_manager(self, gsm_credentials: str):
         return SecretsManager(connector_name=self.technical_name, gsm_credentials=gsm_credentials)

--- a/tools/ci_connector_ops/tests/test_utils.py
+++ b/tools/ci_connector_ops/tests/test_utils.py
@@ -12,7 +12,7 @@ from ci_connector_ops import utils
 class TestConnector:
 
     @pytest.mark.parametrize(
-        "technical_name, expected_type, expected_name, expected_error", 
+        "technical_name, expected_type, expected_name, expected_error",
         [
             ("source-faker", "source", "faker", does_not_raise()),
             ("source-facebook-marketing", "source", "facebook-marketing", does_not_raise()),
@@ -27,7 +27,7 @@ class TestConnector:
             assert connector.connector_type == expected_type
 
     @pytest.mark.parametrize(
-        "connector, exists", 
+        "connector, exists",
         [
             (utils.Connector("source-faker"), True),
             (utils.Connector("source-notpublished"), False),
@@ -38,15 +38,15 @@ class TestConnector:
         assert connector.code_directory == Path(f"./airbyte-integrations/connectors/{connector.technical_name}")
         assert connector.acceptance_test_config_path == connector.code_directory / utils.ACCEPTANCE_TEST_CONFIG_FILE_NAME
         assert connector.documentation_file_path == Path(f"./docs/integrations/{connector.connector_type}s/{connector.name}.md")
-        
+
         if exists:
-            assert isinstance(connector.definition, dict)
+            assert isinstance(connector.metadata, dict)
             assert isinstance(connector.release_stage, str)
             assert isinstance(connector.acceptance_test_config, dict)
-            assert connector.icon_path == Path(f"./airbyte-config-oss/init-oss/src/main/resources/icons/{connector.definition['icon']}")
+            assert connector.icon_path == Path(f"./airbyte-config-oss/init-oss/src/main/resources/icons/{connector.metadata['icon']}")
             assert len(connector.version.split(".")) == 3
         else:
-            assert connector.definition is None
+            assert connector.metadata is None
             assert connector.release_stage is None
             assert connector.acceptance_test_config is None
             assert connector.icon_path == Path(f"./airbyte-config-oss/init-oss/src/main/resources/icons/{connector.name}.svg")


### PR DESCRIPTION
## What
A few problems coincided
1. QA engine relies on the definition files.
2. In the past source/destiantion masks added connectors to cloud without the knowledge of the qa engine
3. The tests for QA engine have not been running.

blocks this PR from running: https://github.com/airbytehq/airbyte/pull/26094

## Solution
update qa engine to use metadat ahead of large cut over

Will be cowboy merging this 🤠 