### PR TITLE
[Hack day] Initial code for adding md5 hash of all columns when reading

### DIFF
--- a/airbyte-integrations/connectors/source-jdbc/src/main/java/io/airbyte/integrations/source/jdbc/AbstractJdbcSource.java
+++ b/airbyte-integrations/connectors/source-jdbc/src/main/java/io/airbyte/integrations/source/jdbc/AbstractJdbcSource.java
@@ -123,7 +123,11 @@ public abstract class AbstractJdbcSource<Datatype> extends AbstractDbSource<Data
     } else {
       // If we are in FULL_REFRESH mode, state messages are never emitted, so we don't care about ordering
       // of the records.
-      return queryTable(database, String.format("SELECT %s FROM %s",
+      final Optional<String> md5ColumnsHash = getMD5ColumnHashQueryFragment(columnNames);
+      final String query = md5ColumnsHash.isEmpty() ?
+          "SELECT %s FROM %s" : String.format("SELECT %%s ,%s FROM %%s", md5ColumnsHash.get());
+
+      return queryTable(database, String.format(query,
           enquoteIdentifierList(columnNames, getQuoteString()),
           getFullyQualifiedTableNameWithQuoting(schemaName, tableName, getQuoteString())), tableName, schemaName);
     }

--- a/airbyte-integrations/connectors/source-postgres/src/main/java/io/airbyte/integrations/source/postgres/PostgresSource.java
+++ b/airbyte-integrations/connectors/source-postgres/src/main/java/io/airbyte/integrations/source/postgres/PostgresSource.java
@@ -706,6 +706,6 @@ public class PostgresSource extends AbstractJdbcSource<PostgresType> implements 
       if(selectedColumns==null || selectedColumns.isEmpty())
         return super.getMD5ColumnHashQueryFragment(selectedColumns);
 
-      return Optional.ofNullable(String.format("md5(ROW(%s)::TEXT)", String.join(",", selectedColumns)));
+      return Optional.ofNullable(String.format("md5(concat(%s)::TEXT)", String.join(",", selectedColumns)));
   }
 }

--- a/airbyte-integrations/connectors/source-postgres/src/main/java/io/airbyte/integrations/source/postgres/PostgresSource.java
+++ b/airbyte-integrations/connectors/source-postgres/src/main/java/io/airbyte/integrations/source/postgres/PostgresSource.java
@@ -85,6 +85,7 @@ import java.util.Collections;
 import java.util.List;
 import java.util.Map;
 import java.util.Objects;
+import java.util.Optional;
 import java.util.OptionalLong;
 import java.util.Set;
 import java.util.function.Supplier;
@@ -700,4 +701,11 @@ public class PostgresSource extends AbstractJdbcSource<PostgresType> implements 
     return result.get(0).get("count").asLong();
   }
 
+  @Override
+  protected Optional<String> getMD5ColumnHashQueryFragment(final List<String> selectedColumns) {
+      if(selectedColumns==null || selectedColumns.isEmpty())
+        return super.getMD5ColumnHashQueryFragment(selectedColumns);
+
+      return Optional.ofNullable(String.format("md5(ROW(%s)::TEXT)", String.join(",", selectedColumns)));
+  }
 }

--- a/airbyte-integrations/connectors/source-relational-db/src/main/java/io/airbyte/integrations/source/relationaldb/AbstractDbSource.java
+++ b/airbyte-integrations/connectors/source-relational-db/src/main/java/io/airbyte/integrations/source/relationaldb/AbstractDbSource.java
@@ -351,6 +351,15 @@ public abstract class AbstractDbSource<DataType, Database extends AbstractDataba
   }
 
   /**
+   * Return a fragment that will be append to the sql query for getting md5 hash of selected columns.
+   * @param selectedColumns list of selected columns.
+   * @return A String that will be append to select query if present.
+   */
+  protected Optional<String> getMD5ColumnHashQueryFragment(final List<String> selectedColumns) {
+    return Optional.empty();
+  }
+
+  /**
    * ReadIterator is used to retrieve records from a source connector
    *
    * @param database Source Database


### PR DESCRIPTION
**!!! Not intended as a mergeable PR !!!**
Initial code for adding md5 hash of all columns when reading from source.


## What
*Describe what the change is solving*
*It helps to add screenshots if it affects the frontend.*

## How
*Describe the solution*

## Recommended reading order
1. `x.java`
2. `y.python`

## 🚨 User Impact 🚨
*Are there any breaking changes? What is the end result perceived by the user?*

*For connector PRs, use this section to explain which type of semantic versioning bump occurs as a result of the changes. Refer to our [Semantic Versioning for Connectors](https://docs.airbyte.com/contributing-to-airbyte/#semantic-versioning-for-connectors) guidelines for more information. **Breaking changes to connectors must be documented by an Airbyte engineer (PR author, or reviewer for community PRs) by using the [Breaking Change Release Playbook](https://docs.google.com/document/d/1VYQggHbL_PN0dDDu7rCyzBLGRtX-R3cpwXaY8QxEgzw/edit).***

*If there are breaking changes, please merge this PR with the 🚨🚨 emoji so changelog authors can further highlight this if needed.*


## Pre-merge Actions
*Expand the relevant checklist and delete the others.*

<details><summary><strong>New Connector</strong></summary>

### Community member or Airbyter

- **Community member?** Grant edit access to maintainers ([instructions](https://docs.github.com/en/github/collaborating-with-pull-requests/working-with-forks/allowing-changes-to-a-pull-request-branch-created-from-a-fork#enabling-repository-maintainer-permissions-on-existing-pull-requests))
- Unit & integration tests added and passing. Community members, please provide proof of success locally e.g: screenshot or copy-paste unit, integration, and acceptance test output. To run acceptance tests for a Python connector, follow instructions in the README. For java connectors run `./gradlew :airbyte-integrations:connectors:<name>:integrationTest`.
- Connector version is set to `0.0.1`
    - `Dockerfile` has version `0.0.1`
- Documentation updated
    - Connector's `README.md`
    - Connector's `bootstrap.md`. See [description and examples](https://docs.google.com/document/d/1ypdgmwmEHWv-TrO4_YOQ7pAJGVrMp5BOkEVh831N260/edit?usp=sharing)
    - `docs/integrations/<source or destination>/<name>.md` including changelog with an entry for the initial version. See changelog [example](https://docs.airbyte.io/integrations/sources/stripe#changelog)
    - `docs/integrations/README.md`

### Airbyter

If this is a community PR, the Airbyte engineer reviewing this PR is responsible for the below items.

- Create a non-forked branch based on this PR and test the below items on it
- Build is successful
- If new credentials are required for use in CI, add them to GSM. [Instructions](https://docs.airbyte.io/connector-development#using-credentials-in-ci).

</details>

<details><summary><strong>Updating a connector</strong></summary>

### Community member or Airbyter

- Grant edit access to maintainers ([instructions](https://docs.github.com/en/github/collaborating-with-pull-requests/working-with-forks/allowing-changes-to-a-pull-request-branch-created-from-a-fork#enabling-repository-maintainer-permissions-on-existing-pull-requests))
- Unit & integration tests added


### Airbyter

If this is a community PR, the Airbyte engineer reviewing this PR is responsible for the below items.

- Create a non-forked branch based on this PR and test the below items on it
- Build is successful
- If new credentials are required for use in CI, add them to GSM. [Instructions](https://docs.airbyte.io/connector-development#using-credentials-in-ci).

</details>

<details><summary><strong>Connector Generator</strong></summary>

- Issue acceptance criteria met
- PR name follows [PR naming conventions](https://docs.airbyte.com/contributing-to-airbyte/issues-and-pull-requests#pull-request-title-convention)
- If adding a new generator, add it to the [list of scaffold modules being tested](https://github.com/airbytehq/airbyte/blob/master/airbyte-integrations/connector-templates/generator/build.gradle#L41)
- The generator test modules (all connectors with `-scaffold` in their name) have been updated with the latest scaffold by running `./gradlew :airbyte-integrations:connector-templates:generator:testScaffoldTemplates` then checking in your changes
- Documentation which references the generator is updated as needed

</details>
