### PR TITLE
Fix: Pin metadata to 0.2.7

### DIFF
--- a/airbyte-integrations/connectors/destination-dev-null/metadata.yaml
+++ b/airbyte-integrations/connectors/destination-dev-null/metadata.yaml
@@ -10,8 +10,10 @@ data:
   name: End-to-End Testing (/dev/null)
   registries:
     cloud:
+      dockerImageTag: 0.2.7
       enabled: true
     oss:
+      dockerImageTag: 0.2.7
       enabled: false
   releaseStage: alpha
   supportUrl: https://docs.airbyte.io/integrations/destinations/e2e-test


### PR DESCRIPTION
## What
0.3.0 spec is not building. https://app.warp.dev/block/wbHsOcNIVsQUm49WcviYxo

This pins the connector to an old version

