### PR TITLE
🐛 Destination Clickhouse-strict-encrypt: Remove SSL toggle in spec and add SSL modes

### DIFF
--- a/airbyte-config-oss/init-oss/src/main/resources/seed/destination_definitions.yaml
+++ b/airbyte-config-oss/init-oss/src/main/resources/seed/destination_definitions.yaml
@@ -93,7 +93,7 @@
 - name: Clickhouse
   destinationDefinitionId: ce0d828e-1dc4-496c-b122-2da42e637e48
   dockerRepository: airbyte/destination-clickhouse
-  dockerImageTag: 0.2.3
+  dockerImageTag: 0.2.4
   documentationUrl: https://docs.airbyte.com/integrations/destinations/clickhouse
   icon: clickhouse.svg
   releaseStage: alpha

--- a/airbyte-config-oss/init-oss/src/main/resources/seed/destination_specs.yaml
+++ b/airbyte-config-oss/init-oss/src/main/resources/seed/destination_specs.yaml
@@ -1395,6 +1395,73 @@
           type: "string"
           airbyte_secret: true
           order: 4
+        ssl_mode:
+          title: "SSL modes"
+          description: "SSL connection modes. \n <b>disable</b> - Chose this mode\
+            \ to disable encryption of communication between Airbyte and destination\
+            \ database\n <b>allow</b> - Chose this mode to enable encryption only\
+            \ when required by the source database\n <b>prefer</b> - Chose this mode\
+            \ to allow unencrypted connection only if the source database does not\
+            \ support encryption\n <b>require</b> - Chose this mode to always require\
+            \ encryption. If the source database server does not support encryption,\
+            \ connection will fail\n   See more information - <a href=\"\
+            https://jdbc.postgresql.org/documentation/head/ssl-client.html\"> in the\
+            \ docs</a>."
+          type: "object"
+          order: 7
+          oneOf:
+            - title: "disable"
+              additionalProperties: false
+              description: "Disable SSL."
+              required:
+                - "mode"
+              properties:
+                mode:
+                  type: "string"
+                  const: "disable"
+                  enum:
+                    - "disable"
+                  default: "disable"
+                  order: 0
+            - title: "allow"
+              additionalProperties: false
+              description: "Allow SSL mode."
+              required:
+                - "mode"
+              properties:
+                mode:
+                  type: "string"
+                  const: "allow"
+                  enum:
+                    - "allow"
+                  default: "allow"
+                  order: 0
+            - title: "prefer"
+              additionalProperties: false
+              description: "Prefer SSL mode."
+              required:
+                - "mode"
+              properties:
+                mode:
+                  type: "string"
+                  const: "prefer"
+                  enum:
+                    - "prefer"
+                  default: "prefer"
+                  order: 0
+            - title: "require"
+              additionalProperties: false
+              description: "Require SSL mode."
+              required:
+                - "mode"
+              properties:
+                mode:
+                  type: "string"
+                  const: "require"
+                  enum:
+                    - "require"
+                  default: "require"
+                  order: 0
         jdbc_url_params:
           description: "Additional properties to pass to the JDBC URL string when\
             \ connecting to the database formatted as 'key=value' pairs separated\

--- a/airbyte-config-oss/init-oss/src/main/resources/seed/destination_specs.yaml
+++ b/airbyte-config-oss/init-oss/src/main/resources/seed/destination_specs.yaml
@@ -1350,7 +1350,7 @@
     supported_destination_sync_modes:
     - "overwrite"
     - "append"
-- dockerImage: "airbyte/destination-clickhouse:0.2.3"
+- dockerImage: "airbyte/destination-clickhouse:0.2.4"
   spec:
     documentationUrl: "https://docs.airbyte.com/integrations/destinations/clickhouse"
     connectionSpecification:
@@ -1402,12 +1402,6 @@
           title: "JDBC URL Params"
           type: "string"
           order: 5
-        ssl:
-          title: "SSL Connection"
-          description: "Encrypt data using SSL."
-          type: "boolean"
-          default: false
-          order: 6
         tunnel_method:
           type: "object"
           title: "SSH Tunnel Method"

--- a/airbyte-config-oss/init-oss/src/main/resources/seed/oss_catalog.json
+++ b/airbyte-config-oss/init-oss/src/main/resources/seed/oss_catalog.json
@@ -1209,7 +1209,7 @@
     "destinationDefinitionId": "ce0d828e-1dc4-496c-b122-2da42e637e48",
     "name": "Clickhouse",
     "dockerRepository": "airbyte/destination-clickhouse",
-    "dockerImageTag": "0.2.3",
+    "dockerImageTag": "0.2.4",
     "documentationUrl": "https://docs.airbyte.com/integrations/destinations/clickhouse",
     "icon": "clickhouse.svg",
     "spec": {
@@ -1261,13 +1261,6 @@
             "title": "JDBC URL Params",
             "type": "string",
             "order": 5
-          },
-          "ssl": {
-            "title": "SSL Connection",
-            "description": "Encrypt data using SSL.",
-            "type": "boolean",
-            "default": false,
-            "order": 6
           },
           "tunnel_method": {
             "type": "object",

--- a/airbyte-integrations/connectors/destination-clickhouse-strict-encrypt/Dockerfile
+++ b/airbyte-integrations/connectors/destination-clickhouse-strict-encrypt/Dockerfile
@@ -16,5 +16,5 @@ ENV APPLICATION destination-clickhouse-strict-encrypt
 
 COPY --from=build /airbyte /airbyte
 
-LABEL io.airbyte.version=0.2.3
+LABEL io.airbyte.version=0.2.4
 LABEL io.airbyte.name=airbyte/destination-clickhouse-strict-encrypt

--- a/airbyte-integrations/connectors/destination-clickhouse-strict-encrypt/metadata.yaml
+++ b/airbyte-integrations/connectors/destination-clickhouse-strict-encrypt/metadata.yaml
@@ -7,7 +7,7 @@ data:
   connectorSubtype: database
   connectorType: destination
   definitionId: ce0d828e-1dc4-496c-b122-2da42e637e48
-  dockerImageTag: 0.2.3
+  dockerImageTag: 0.2.4
   dockerRepository: airbyte/destination-clickhouse-strict-encrypt
   githubIssueLabel: destination-clickhouse
   icon: clickhouse.svg

--- a/airbyte-integrations/connectors/destination-clickhouse-strict-encrypt/src/main/java/io/airbyte/integrations/destination/clickhouse/ClickhouseDestinationStrictEncrypt.java
+++ b/airbyte-integrations/connectors/destination-clickhouse-strict-encrypt/src/main/java/io/airbyte/integrations/destination/clickhouse/ClickhouseDestinationStrictEncrypt.java
@@ -25,14 +25,7 @@ public class ClickhouseDestinationStrictEncrypt extends SpecModifyingDestination
   @Override
   public ConnectorSpecification modifySpec(final ConnectorSpecification originalSpec) {
     final ConnectorSpecification spec = Jsons.clone(originalSpec);
-    final ObjectNode connectionProperties = (ObjectNode) spec.getConnectionSpecification().get("properties");
-    final boolean sslEnabled = connectionProperties.has(JdbcUtils.SSL_KEY) && connectionProperties.get(JdbcUtils.SSL_KEY).asBoolean();
-    final boolean sshEnabled = connectionProperties.has("ssh_tunnel_enabled") && connectionProperties.get("ssh_tunnel_enabled").asBoolean();
-
-    if (sslEnabled && sshEnabled) {
-      connectionProperties.remove(JdbcUtils.SSL_KEY);
-    }
-
+    ((ObjectNode) spec.getConnectionSpecification().get("properties")).remove(JdbcUtils.SSL_KEY);
     return spec;
   }
 

--- a/airbyte-integrations/connectors/destination-clickhouse-strict-encrypt/src/main/java/io/airbyte/integrations/destination/clickhouse/ClickhouseDestinationStrictEncrypt.java
+++ b/airbyte-integrations/connectors/destination-clickhouse-strict-encrypt/src/main/java/io/airbyte/integrations/destination/clickhouse/ClickhouseDestinationStrictEncrypt.java
@@ -25,14 +25,7 @@ public class ClickhouseDestinationStrictEncrypt extends SpecModifyingDestination
   @Override
   public ConnectorSpecification modifySpec(final ConnectorSpecification originalSpec) {
     final ConnectorSpecification spec = Jsons.clone(originalSpec);
-    final ObjectNode connectionProperties = (ObjectNode) spec.getConnectionSpecification().get("properties");
-    final boolean sslEnabled = connectionProperties.has(JdbcUtils.SSL_KEY) && connectionProperties.get(JdbcUtils.SSL_KEY).asBoolean();
-    final boolean sshEnabled = connectionProperties.has("ssh_tunnel_enabled") && connectionProperties.get("ssh_tunnel_enabled").asBoolean();
-
-    if (sslEnabled && sshEnabled) {
-      connectionProperties.remove(JdbcUtils.SSL_KEY);
-    }
-
+    ((ObjectNode) spec.getConnectionSpecification().get("properties"))remove(JdbcUtils.SSL_KEY);
     return spec;
   }
 

--- a/airbyte-integrations/connectors/destination-clickhouse-strict-encrypt/src/main/java/io/airbyte/integrations/destination/clickhouse/ClickhouseDestinationStrictEncrypt.java
+++ b/airbyte-integrations/connectors/destination-clickhouse-strict-encrypt/src/main/java/io/airbyte/integrations/destination/clickhouse/ClickhouseDestinationStrictEncrypt.java
@@ -25,7 +25,14 @@ public class ClickhouseDestinationStrictEncrypt extends SpecModifyingDestination
   @Override
   public ConnectorSpecification modifySpec(final ConnectorSpecification originalSpec) {
     final ConnectorSpecification spec = Jsons.clone(originalSpec);
-    ((ObjectNode) spec.getConnectionSpecification().get("properties")).remove(JdbcUtils.SSL_KEY);
+    final ObjectNode connectionProperties = (ObjectNode) spec.getConnectionSpecification().get("properties");
+    final boolean sslEnabled = connectionProperties.has(JdbcUtils.SSL_KEY) && connectionProperties.get(JdbcUtils.SSL_KEY).asBoolean();
+    final boolean sshEnabled = connectionProperties.has("ssh_tunnel_enabled") && connectionProperties.get("ssh_tunnel_enabled").asBoolean();
+
+    if (sslEnabled && sshEnabled) {
+      connectionProperties.remove(JdbcUtils.SSL_KEY);
+    }
+
     return spec;
   }
 

--- a/airbyte-integrations/connectors/destination-clickhouse-strict-encrypt/src/test/resources/expected_spec.json
+++ b/airbyte-integrations/connectors/destination-clickhouse-strict-encrypt/src/test/resources/expected_spec.json
@@ -46,11 +46,79 @@
         "airbyte_secret": true,
         "order": 4
       },
+      "ssl_mode": {
+        "title": "SSL modes",
+        "description": "SSL connection modes. \n <b>disable</b> - Chose this mode to disable encryption of communication between Airbyte and destination database\n <b>allow</b> - Chose this mode to enable encryption only when required by the source database\n <b>prefer</b> - Chose this mode to allow unencrypted connection only if the source database does not support encryption\n <b>require</b> - Chose this mode to always require encryption. If the source database server does not support encryption, connection will fail  \n See more information - <a href=\"https://jdbc.postgresql.org/documentation/head/ssl-client.html\"> in the docs</a>.",
+        "type": "object",
+        "order": 5,
+        "oneOf": [
+          {
+            "title": "disable",
+            "additionalProperties": false,
+            "description": "Disable SSL.",
+            "required": ["mode"],
+            "properties": {
+              "mode": {
+                "type": "string",
+                "const": "disable",
+                "enum": ["disable"],
+                "default": "disable",
+                "order": 0
+              }
+            }
+          },
+          {
+            "title": "allow",
+            "additionalProperties": false,
+            "description": "Allow SSL mode.",
+            "required": ["mode"],
+            "properties": {
+              "mode": {
+                "type": "string",
+                "const": "allow",
+                "enum": ["allow"],
+                "default": "allow",
+                "order": 0
+              }
+            }
+          },
+          {
+            "title": "prefer",
+            "additionalProperties": false,
+            "description": "Prefer SSL mode.",
+            "required": ["mode"],
+            "properties": {
+              "mode": {
+                "type": "string",
+                "const": "prefer",
+                "enum": ["prefer"],
+                "default": "prefer",
+                "order": 0
+              }
+            }
+          },
+          {
+            "title": "require",
+            "additionalProperties": false,
+            "description": "Require SSL mode.",
+            "required": ["mode"],
+            "properties": {
+              "mode": {
+                "type": "string",
+                "const": "require",
+                "enum": ["require"],
+                "default": "require",
+                "order": 0
+              }
+            }
+          }
+        ]
+      },
       "jdbc_url_params": {
         "description": "Additional properties to pass to the JDBC URL string when connecting to the database formatted as 'key=value' pairs separated by the symbol '&'. (example: key1=value1&key2=value2&key3=value3).",
         "title": "JDBC URL Params",
         "type": "string",
-        "order": 5
+        "order": 6
       },
       "tunnel_method": {
         "type": "object",

--- a/airbyte-integrations/connectors/destination-clickhouse/metadata.yaml
+++ b/airbyte-integrations/connectors/destination-clickhouse/metadata.yaml
@@ -2,7 +2,7 @@ data:
   connectorSubtype: database
   connectorType: destination
   definitionId: ce0d828e-1dc4-496c-b122-2da42e637e48
-  dockerImageTag: 0.2.3
+  dockerImageTag: 0.2.4
   dockerRepository: airbyte/destination-clickhouse
   githubIssueLabel: destination-clickhouse
   icon: clickhouse.svg

--- a/airbyte-integrations/connectors/destination-clickhouse/src/main/resources/spec.json
+++ b/airbyte-integrations/connectors/destination-clickhouse/src/main/resources/spec.json
@@ -51,13 +51,6 @@
         "title": "JDBC URL Params",
         "type": "string",
         "order": 5
-      },
-      "ssl": {
-        "title": "SSL Connection",
-        "description": "Encrypt data using SSL.",
-        "type": "boolean",
-        "default": false,
-        "order": 6
       }
     }
   }

--- a/airbyte-integrations/connectors/destination-clickhouse/src/main/resources/spec.json
+++ b/airbyte-integrations/connectors/destination-clickhouse/src/main/resources/spec.json
@@ -46,11 +46,83 @@
         "airbyte_secret": true,
         "order": 4
       },
+      "ssl_mode": {
+        "title": "SSL modes",
+        "description": "SSL connection modes. \n <b>disable</b> - Chose this mode to disable encryption of communication between Airbyte and destination database\n <b>allow</b> - Chose this mode to enable encryption only when required by the source database\n <b>prefer</b> - Chose this mode to allow unencrypted connection only if the source database does not support encryption\n <b>require</b> - Chose this mode to always require encryption. If the source database server does not support encryption, connection will fail\n  <b>verify-ca</b> - Chose this mode to always require encryption and to verify that the source database server has a valid SSL certificate\n  <b>verify-full</b> - This is the most secure mode. Chose this mode to always require encryption and to verify the identity of the source database server\n See more information - <a href=\"https://jdbc.postgresql.org/documentation/head/ssl-client.html\"> in the docs</a>.",
+        "type": "object",
+        "order": 7,
+        "oneOf": [
+          {
+            "title": "disable",
+            "additionalProperties": false,
+            "description": "Disable SSL.",
+            "required": ["mode"],
+            "properties": {
+              "mode": {
+                "type": "string",
+                "const": "disable",
+                "enum": ["disable"],
+                "default": "disable",
+                "order": 0
+              }
+            }
+          },
+          {
+            "title": "allow",
+            "additionalProperties": false,
+            "description": "Allow SSL mode.",
+            "required": ["mode"],
+            "properties": {
+              "mode": {
+                "type": "string",
+                "const": "allow",
+                "enum": ["allow"],
+                "default": "allow",
+                "order": 0
+              }
+            }
+          },
+          {
+            "title": "prefer",
+            "additionalProperties": false,
+            "description": "Prefer SSL mode.",
+            "required": ["mode"],
+            "properties": {
+              "mode": {
+                "type": "string",
+                "const": "prefer",
+                "enum": ["prefer"],
+                "default": "prefer",
+                "order": 0
+              }
+            }
+          },
+          {
+            "title": "require",
+            "additionalProperties": false,
+            "description": "Require SSL mode.",
+            "required": [
+              "mode"
+            ],
+            "properties": {
+              "mode": {
+                "type": "string",
+                "const": "require",
+                "enum": [
+                  "require"
+                ],
+                "default": "require",
+                "order": 0
+              }
+            }
+          }
+        ]
+      },
       "jdbc_url_params": {
-        "description": "Additional properties to pass to the JDBC URL string when connecting to the database formatted as 'key=value' pairs separated by the symbol '&'. (example: key1=value1&key2=value2&key3=value3).",
-        "title": "JDBC URL Params",
-        "type": "string",
-        "order": 5
+            "description": "Additional properties to pass to the JDBC URL string when connecting to the database formatted as 'key=value' pairs separated by the symbol '&'. (example: key1=value1&key2=value2&key3=value3).",
+            "title": "JDBC URL Params",
+            "type": "string",
+            "order": 5
       }
     }
   }

--- a/docs/integrations/destinations/clickhouse.md
+++ b/docs/integrations/destinations/clickhouse.md
@@ -80,6 +80,7 @@ Therefore, Airbyte ClickHouse destination will create tables and schemas using t
 
 | Version | Date       | Pull Request                                               | Subject                                                             |
 |:--------|:-----------|:-----------------------------------------------------------|:--------------------------------------------------------------------|
+| 0.2.4   | 2023-05-15 | [\#](https://github.com/airbytehq/airbyte/pull/)           | Remove ssl toggle for destination clickhouse                        |
 | 0.2.3   | 2023-04-04 | [\#24604](https://github.com/airbytehq/airbyte/pull/24604) | Support for destination checkpointing                               |
 | 0.2.2   | 2023-02-21 | [\#21509](https://github.com/airbytehq/airbyte/pull/21509) | Compatibility update with security patch for strict encrypt version |
 | 0.2.1   | 2022-12-06 | [\#19573](https://github.com/airbytehq/airbyte/pull/19573) | Update dbt version to 1.3.1                                         |

--- a/docs/integrations/destinations/clickhouse.md
+++ b/docs/integrations/destinations/clickhouse.md
@@ -80,7 +80,7 @@ Therefore, Airbyte ClickHouse destination will create tables and schemas using t
 
 | Version | Date       | Pull Request                                               | Subject                                                             |
 |:--------|:-----------|:-----------------------------------------------------------|:--------------------------------------------------------------------|
-| 0.2.4   | 2023-05-15 | [\#](https://github.com/airbytehq/airbyte/pull/)           | Remove ssl toggle for destination clickhouse                        |
+| 0.2.4   | 2023-05-15 | [\#26109](https://github.com/airbytehq/airbyte/pull/26109) | Remove ssl toggle for destination clickhouse                        |
 | 0.2.3   | 2023-04-04 | [\#24604](https://github.com/airbytehq/airbyte/pull/24604) | Support for destination checkpointing                               |
 | 0.2.2   | 2023-02-21 | [\#21509](https://github.com/airbytehq/airbyte/pull/21509) | Compatibility update with security patch for strict encrypt version |
 | 0.2.1   | 2022-12-06 | [\#19573](https://github.com/airbytehq/airbyte/pull/19573) | Update dbt version to 1.3.1                                         |


### PR DESCRIPTION
## What
We are fixing the issue below: 
https://github.com/airbytehq/airbyte/issues/21262
The SSL toggle is redundant when the SSL modes work. 

## How
Remove the ssl key from spec.json for destination-Clickhouse and rely on ssl_mode key as the source of truth.

