### PR TITLE
Source File: Check if reader options is JSON object

### DIFF
--- a/airbyte-config-oss/init-oss/src/main/resources/seed/oss_catalog.json
+++ b/airbyte-config-oss/init-oss/src/main/resources/seed/oss_catalog.json
@@ -12828,7 +12828,7 @@
     "sourceDefinitionId": "778daa7c-feaf-4db6-96f3-70fd645acc77",
     "name": "File (CSV, JSON, Excel, Feather, Parquet)",
     "dockerRepository": "airbyte/source-file",
-    "dockerImageTag": "0.3.4",
+    "dockerImageTag": "0.3.5",
     "documentationUrl": "https://docs.airbyte.com/integrations/sources/file",
     "icon": "file.svg",
     "sourceType": "file",

--- a/airbyte-config-oss/init-oss/src/main/resources/seed/source_definitions.yaml
+++ b/airbyte-config-oss/init-oss/src/main/resources/seed/source_definitions.yaml
@@ -637,7 +637,7 @@
 - name: File (CSV, JSON, Excel, Feather, Parquet)
   sourceDefinitionId: 778daa7c-feaf-4db6-96f3-70fd645acc77
   dockerRepository: airbyte/source-file
-  dockerImageTag: 0.3.4
+  dockerImageTag: 0.3.5
   documentationUrl: https://docs.airbyte.com/integrations/sources/file
   icon: file.svg
   sourceType: file

--- a/airbyte-config-oss/init-oss/src/main/resources/seed/source_specs.yaml
+++ b/airbyte-config-oss/init-oss/src/main/resources/seed/source_specs.yaml
@@ -4567,7 +4567,7 @@
     supportsNormalization: false
     supportsDBT: false
     supported_destination_sync_modes: []
-- dockerImage: "airbyte/source-file:0.3.4"
+- dockerImage: "airbyte/source-file:0.3.5"
   spec:
     documentationUrl: "https://docs.airbyte.com/integrations/sources/file"
     connectionSpecification:

--- a/airbyte-integrations/connectors/source-file-secure/Dockerfile
+++ b/airbyte-integrations/connectors/source-file-secure/Dockerfile
@@ -9,5 +9,5 @@ RUN pip install .
 ENV AIRBYTE_ENTRYPOINT "python /airbyte/integration_code/main.py"
 ENTRYPOINT ["python", "/airbyte/integration_code/main.py"]
 
-LABEL io.airbyte.version=0.3.4
+LABEL io.airbyte.version=0.3.5
 LABEL io.airbyte.name=airbyte/source-file-secure

--- a/airbyte-integrations/connectors/source-file-secure/metadata.yaml
+++ b/airbyte-integrations/connectors/source-file-secure/metadata.yaml
@@ -5,7 +5,7 @@ data:
   connectorSubtype: file
   connectorType: source
   definitionId: 778daa7c-feaf-4db6-96f3-70fd645acc77
-  dockerImageTag: 0.3.4
+  dockerImageTag: 0.3.5
   dockerRepository: airbyte/source-file-secure
   githubIssueLabel: source-file
   icon: file.svg

--- a/airbyte-integrations/connectors/source-file/Dockerfile
+++ b/airbyte-integrations/connectors/source-file/Dockerfile
@@ -17,5 +17,5 @@ COPY source_file ./source_file
 ENV AIRBYTE_ENTRYPOINT "python /airbyte/integration_code/main.py"
 ENTRYPOINT ["python", "/airbyte/integration_code/main.py"]
 
-LABEL io.airbyte.version=0.3.4
+LABEL io.airbyte.version=0.3.5
 LABEL io.airbyte.name=airbyte/source-file

--- a/airbyte-integrations/connectors/source-file/metadata.yaml
+++ b/airbyte-integrations/connectors/source-file/metadata.yaml
@@ -5,7 +5,7 @@ data:
   connectorSubtype: file
   connectorType: source
   definitionId: 778daa7c-feaf-4db6-96f3-70fd645acc77
-  dockerImageTag: 0.3.4
+  dockerImageTag: 0.3.5
   dockerRepository: airbyte/source-file
   githubIssueLabel: source-file
   icon: file.svg

--- a/airbyte-integrations/connectors/source-file/source_file/source.py
+++ b/airbyte-integrations/connectors/source-file/source_file/source.py
@@ -84,8 +84,10 @@ class SourceFile(Source):
         if "reader_options" in config:
             try:
                 config["reader_options"] = json.loads(config["reader_options"])
+                if not isinstance(config["reader_options"], dict):
+                    raise ValueError
             except ValueError:
-                raise ConfigurationError("Field 'reader_options' is not valid JSON. https://www.json.org/")
+                raise ConfigurationError("Field 'reader_options' is not valid JSON object. https://www.json.org/")
         else:
             config["reader_options"] = {}
         config["url"] = dropbox_force_download(config["url"])

--- a/airbyte-integrations/connectors/source-file/source_file/source.py
+++ b/airbyte-integrations/connectors/source-file/source_file/source.py
@@ -85,8 +85,10 @@ class SourceFile(Source):
             try:
                 config["reader_options"] = json.loads(config["reader_options"])
                 if not isinstance(config["reader_options"], dict):
-                    raise ConfigurationError("Field 'reader_options' is not a valid JSON object. "
-                                             "Please provide key-value pairs, See field description for examples.")
+                    raise ConfigurationError(
+                        "Field 'reader_options' is not a valid JSON object. "
+                        "Please provide key-value pairs, See field description for examples."
+                    )
             except ValueError:
                 raise ConfigurationError("Field 'reader_options' is not valid JSON object. https://www.json.org/")
         else:

--- a/airbyte-integrations/connectors/source-file/source_file/source.py
+++ b/airbyte-integrations/connectors/source-file/source_file/source.py
@@ -85,7 +85,8 @@ class SourceFile(Source):
             try:
                 config["reader_options"] = json.loads(config["reader_options"])
                 if not isinstance(config["reader_options"], dict):
-                    raise ValueError
+                    raise ConfigurationError("Field 'reader_options' is not a valid JSON object. "
+                                             "Please provide key-value pairs, See field description for examples.")
             except ValueError:
                 raise ConfigurationError("Field 'reader_options' is not valid JSON object. https://www.json.org/")
         else:

--- a/airbyte-integrations/connectors/source-file/unit_tests/conftest.py
+++ b/airbyte-integrations/connectors/source-file/unit_tests/conftest.py
@@ -35,6 +35,17 @@ def invalid_config(read_file):
 
 
 @pytest.fixture
+def invalid_reader_options_config(read_file):
+    return {
+        "dataset_name": "test",
+        "format": "jsonl",
+        "url": "https://airbyte.com",
+        "reader_options": '["encoding"]',
+        "provider": {"storage": "HTTPS"},
+    }
+
+
+@pytest.fixture
 def config_dropbox_link():
     return {
         "dataset_name": "test",

--- a/airbyte-integrations/connectors/source-file/unit_tests/test_source.py
+++ b/airbyte-integrations/connectors/source-file/unit_tests/test_source.py
@@ -157,7 +157,7 @@ def test_discover(source, config, client):
 def test_check_wrong_reader_options(source, config):
     config["reader_options"] = '{encoding":"utf_16"}'
     assert source.check(logger=logger, config=config) == AirbyteConnectionStatus(
-        status=Status.FAILED, message="Field 'reader_options' is not valid JSON. https://www.json.org/"
+        status=Status.FAILED, message="Field 'reader_options' is not valid JSON object. https://www.json.org/"
     )
 
 

--- a/airbyte-integrations/connectors/source-file/unit_tests/test_source.py
+++ b/airbyte-integrations/connectors/source-file/unit_tests/test_source.py
@@ -131,6 +131,12 @@ def test_check_invalid_config(source, invalid_config):
     assert actual.status == expected.status
 
 
+def test_check_invalid_reader_options(source, invalid_reader_options_config):
+    expected = AirbyteConnectionStatus(status=Status.FAILED)
+    actual = source.check(logger=logger, config=invalid_reader_options_config)
+    assert actual.status == expected.status
+
+
 def test_discover_dropbox_link(source, config_dropbox_link):
     source.discover(logger=logger, config=config_dropbox_link)
 

--- a/docs/integrations/sources/file.md
+++ b/docs/integrations/sources/file.md
@@ -190,7 +190,8 @@ In order to read large files from a remote location, this connector uses the [sm
 ## Changelog
 
 | Version | Date       | Pull Request                                             | Subject                                                                                                 |
-| :------ | :--------- | :------------------------------------------------------- | :------------------------------------------------------------------------------------------------------ |
+|:--------|:-----------|:---------------------------------------------------------|:--------------------------------------------------------------------------------------------------------|
+| 0.3.5   | 2023-05-16 | [26117](https://github.com/airbytehq/airbyte/pull/26117) | Check if reader options is a valid JSON object                                                          |
 | 0.3.4   | 2023-05-10 | [25965](https://github.com/airbytehq/airbyte/pull/25965) | fix Pandas date-time parsing to airbyte type                                                            |
 | 0.3.3   | 2023-05-04 | [25819](https://github.com/airbytehq/airbyte/pull/25819) | GCP service_account_json is a secret                                                                    |
 | 0.3.2   | 2023-05-01 | [25641](https://github.com/airbytehq/airbyte/pull/25641) | Handle network errors                                                                                   |


### PR DESCRIPTION
## What
Resolve https://github.com/airbytehq/oncall/issues/1840


## How
Check if `reader_options` is JSON object

## Recommended reading order
1. `y.python`

## 🚨 User Impact 🚨

no breaking changes


## Pre-merge Actions

<details><summary><strong>Updating a connector</strong></summary>

### Community member or Airbyter

- Grant edit access to maintainers ([instructions](https://docs.github.com/en/github/collaborating-with-pull-requests/working-with-forks/allowing-changes-to-a-pull-request-branch-created-from-a-fork#enabling-repository-maintainer-permissions-on-existing-pull-requests))
- Unit & integration tests added


### Airbyter

If this is a community PR, the Airbyte engineer reviewing this PR is responsible for the below items.

- Create a non-forked branch based on this PR and test the below items on it
- Build is successful
- If new credentials are required for use in CI, add them to GSM. [Instructions](https://docs.airbyte.io/connector-development#using-credentials-in-ci).

</details>