### PR TITLE
connectors-ci: use crane to check if image exists

### DIFF
--- a/tools/ci_connector_ops/ci_connector_ops/pipelines/actions/environments.py
+++ b/tools/ci_connector_ops/ci_connector_ops/pipelines/actions/environments.py
@@ -716,3 +716,7 @@ def with_airbyte_python_connector_full_dagger(context: ConnectorContext, build_p
         .with_label("io.airbyte.version", context.metadata["dockerImageTag"])
         .with_label("io.airbyte.name", context.metadata["dockerRepository"])
     )
+
+
+def with_crane(context: PipelineContext) -> Container:
+    return context.dagger_client.container().from_("gcr.io/go-containerregistry/crane:v0.15.1")

--- a/tools/ci_connector_ops/ci_connector_ops/pipelines/publish.py
+++ b/tools/ci_connector_ops/ci_connector_ops/pipelines/publish.py
@@ -22,21 +22,24 @@ class CheckConnectorImageDoesNotExist(Step):
     title = "Check if the connector docker image does not exist on the registry."
 
     async def _run(self) -> StepResult:
-        manifest_inspect = (
-            environments.with_docker_cli(self.context)
-            .with_env_variable("CACHEBUSTER", str(uuid.uuid4()))
-            .with_exec(["sh", "-c", f"docker manifest inspect {self.context.docker_image_name} || true"])
+        docker_repository, docker_tag = self.context.docker_image_name.split(":")
+        crane_ls = (
+            environments.with_crane(self.context).with_env_variable("CACHEBUSTER", str(uuid.uuid4())).with_exec(["ls", docker_repository])
         )
-        manifest_inspect_stderr = await with_stderr(manifest_inspect)
-        manifest_inspect_stdout = await with_stdout(manifest_inspect)
-        if "no such manifest" in manifest_inspect_stderr:
-            return StepResult(self, status=StepStatus.SUCCESS, stdout=f"No manifest found for {self.context.docker_image_name}.")
-        else:
-            try:
-                json.loads(manifest_inspect_stdout.replace("\n", ""))["manifests"]
+        crane_ls_exit_code = await with_exit_code(crane_ls)
+        crane_ls_stderr = await with_stderr(crane_ls)
+        crane_ls_stdout = await with_stdout(crane_ls)
+        if crane_ls_exit_code != 0:
+            if "NAME_UNKNOWN" in crane_ls_stderr:
+                return StepResult(self, status=StepStatus.SUCCESS, stdout=f"The docker repository {docker_repository} does not exist.")
+            else:
+                return StepResult(self, status=StepStatus.FAILURE, stderr=crane_ls_stderr, stdout=crane_ls_stdout)
+        else:  # The docker repo exists and ls was successful
+            existing_tags = crane_ls_stdout.split("\n")
+            docker_tag_already_exists = docker_tag in existing_tags
+            if docker_tag_already_exists:
                 return StepResult(self, status=StepStatus.SKIPPED, stderr=f"{self.context.docker_image_name} already exists.")
-            except (json.JSONDecodeError, KeyError):
-                return StepResult(self, status=StepStatus.FAILURE, stderr=manifest_inspect_stderr, stdout=manifest_inspect_stdout)
+            return StepResult(self, status=StepStatus.SUCCESS, stdout=f"No manifest found for {self.context.docker_image_name}.")
 
 
 class BuildConnectorForPublish(Step):


### PR DESCRIPTION
## What
[`crane`](https://github.com/google/go-containerregistry/blob/main/cmd/crane/README.md) is a cool tool to inspect docker registry images. It's actively use by the dagger team for investigation.
It has the benefit of not requiring a docker daemon to run.
I want to replace the use of docker cli by crane in the `CheckConnectorImageDoesNotExist` step to not rely on docker in docker pattern that can be unstable ( see https://github.com/airbytehq/airbyte/issues/25877)

## How
**No logical change == no test change == the test are still passing**:
* Use `crane ls` to check the tag available in an image repo
* If the tag is returned we mark the step as SKIPPED and the push to the docker hub won't happen
* If the tag is not returned or the image repo does not exists: SUCCESS, push will happen
* If the `crane ls` command failed we mark the step as FAILURE and push won't hapen 
