### PR TITLE
connectors-ci: credentials to spec cache and metadata bucket not required on pre-release

### DIFF
--- a/tools/ci_connector_ops/ci_connector_ops/pipelines/commands/groups/connectors.py
+++ b/tools/ci_connector_ops/ci_connector_ops/pipelines/commands/groups/connectors.py
@@ -8,7 +8,7 @@ import logging
 import os
 import sys
 from pathlib import Path
-from typing import Tuple
+from typing import Any, Dict, Tuple
 
 import anyio
 import click
@@ -250,28 +250,28 @@ def build(ctx: click.Context) -> bool:
     "--spec-cache-gcs-credentials",
     help="The service account key to upload files to the GCS bucket hosting spec cache.",
     type=click.STRING,
-    required=True,
+    required=False,  # Not required for pre-release pipelines, downstream validation happens for main release pipelines
     envvar="SPEC_CACHE_GCS_CREDENTIALS",
 )
 @click.option(
     "--spec-cache-bucket-name",
     help="The name of the GCS bucket where specs will be cached.",
     type=click.STRING,
-    required=True,
+    required=False,  # Not required for pre-release pipelines, downstream validation happens for main release pipelines
     envvar="SPEC_CACHE_BUCKET_NAME",
 )
 @click.option(
     "--metadata-service-gcs-credentials",
     help="The service account key to upload files to the GCS bucket hosting the metadata files.",
     type=click.STRING,
-    required=True,
+    required=False,  # Not required for pre-release pipelines, downstream validation happens for main release pipelines
     envvar="METADATA_SERVICE_GCS_CREDENTIALS",
 )
 @click.option(
     "--metadata-service-bucket-name",
     help="The name of the GCS bucket where metadata files will be uploaded.",
     type=click.STRING,
-    required=True,
+    required=False,  # Not required for pre-release pipelines, downstream validation happens for main release pipelines
     envvar="METADATA_SERVICE_BUCKET_NAME",
 )
 @click.option(
@@ -314,6 +314,11 @@ def publish(
     slack_webhook: str,
     slack_channel: str,
 ):
+    ctx.obj["spec_cache_gcs_credentials"] = spec_cache_gcs_credentials
+    ctx.obj["spec_cache_bucket_name"] = spec_cache_bucket_name
+    ctx.obj["metadata_service_bucket_name"] = metadata_service_bucket_name
+    ctx.obj["metadata_service_gcs_credentials"] = metadata_service_gcs_credentials
+    validate_publish_options(pre_release, ctx.obj)
     if ctx.obj["is_local"]:
         click.confirm(
             "Publishing from a local environment is not recommend and requires to be logged in Airbyte's DockerHub registry, do you want to continue?",
@@ -360,3 +365,10 @@ def publish(
         ctx.obj["execute_timeout"],
     )
     return all(context.state is ContextState.SUCCESSFUL for context in publish_connector_contexts)
+
+
+def validate_publish_options(pre_release: bool, context_object: Dict[str, Any]):
+    """Validate that the publish options are set correctly."""
+    for k in ["spec_cache_bucket_name", "spec_cache_gcs_credentials", "metadata_service_bucket_name", "metadata_service_gcs_credentials"]:
+        if not pre_release and context_object.get(k) is None:
+            click.Abort(f'The --{k.replace("_", "-")} option is required when running a main release publish pipeline.')

--- a/tools/ci_connector_ops/ci_connector_ops/pipelines/utils.py
+++ b/tools/ci_connector_ops/ci_connector_ops/pipelines/utils.py
@@ -356,7 +356,7 @@ async def export_container_to_tarball(
         return None, None
 
 
-def sanitize_gcs_credentials(raw_value: str) -> str:
+def sanitize_gcs_credentials(raw_value: Optional[str]) -> Optional[str]:
     """Try to parse the raw string input that should contain a json object with the GCS credentials.
     It will raise an exception if the parsing fails and help us to fail fast on invalid credentials input.
 
@@ -366,4 +366,6 @@ def sanitize_gcs_credentials(raw_value: str) -> str:
     Returns:
         str: The raw value string if it was successfully parsed.
     """
+    if raw_value is None:
+        return None
     return json.dumps(json.loads(raw_value))


### PR DESCRIPTION
## What
When publish pre-release images no interaction with the spec cache or metadata bucket happens.
The credentials to connect to these bucket should not be required by the CLI.

## How
* Make the bucket name / credentials CLI options not required
* Add a validate function to fail the command if the credentials do not exists when running for a main release publish