### PR TITLE
Source Google Analytics (GA4): Fix Pagination and add Filters

### DIFF
--- a/airbyte-integrations/connectors/source-google-analytics-data-api/Dockerfile
+++ b/airbyte-integrations/connectors/source-google-analytics-data-api/Dockerfile
@@ -28,5 +28,5 @@ COPY source_google_analytics_data_api ./source_google_analytics_data_api
 ENV AIRBYTE_ENTRYPOINT "python /airbyte/integration_code/main.py"
 ENTRYPOINT ["python", "/airbyte/integration_code/main.py"]
 
-LABEL io.airbyte.version=0.2.2
+LABEL io.airbyte.version=0.2.3
 LABEL io.airbyte.name=airbyte/source-google-analytics-data-api

--- a/airbyte-integrations/connectors/source-google-analytics-data-api/metadata.yaml
+++ b/airbyte-integrations/connectors/source-google-analytics-data-api/metadata.yaml
@@ -7,7 +7,7 @@ data:
   connectorSubtype: api
   connectorType: source
   definitionId: 3cc2eafd-84aa-4dca-93af-322d9dfeec1a
-  dockerImageTag: 0.2.2
+  dockerImageTag: 0.2.3
   dockerRepository: airbyte/source-google-analytics-data-api
   githubIssueLabel: source-google-analytics-data-api
   icon: google-analytics.svg

--- a/airbyte-integrations/connectors/source-google-analytics-data-api/source_google_analytics_data_api/defaults/custom_reports_schema.json
+++ b/airbyte-integrations/connectors/source-google-analytics-data-api/source_google_analytics_data_api/defaults/custom_reports_schema.json
@@ -21,6 +21,23 @@
           "type": "string"
         }
       },
+      "dimensionFilter": {
+        "$ref": "#/$defs/filterExpression"
+      },
+      "metricFilter": {
+        "$ref": "#/$defs/filterExpression"
+      },
+      "offset": {
+        "type": ["integer", "string"],
+        "minimum": 0,
+        "pattern": "^[0-9]+$"
+      },
+      "limit": {
+        "type": ["integer", "string"],
+        "minimum": 0,
+        "maximum": 250000,
+        "pattern": "^([0-9]|[1-9][0-9]{1,4}|1[0-9]{5}|2[0-4][0-9]{4}|250000)$"
+      },
       "cohortSpec": {
         "type": ["null", "object"],
         "properties": {
@@ -129,6 +146,124 @@
             "metricAggregations": {
               "type": ["null", "string"],
               "enum": ["COUNT", "TOTAL", "MAXIMUM", "MINIMUM"]
+            }
+          }
+        }
+      }
+    }
+  },
+  "$defs": {
+    "filterExpressionList": {
+      "type": "object",
+      "properties": {
+        "expressions": {
+          "type": "array",
+          "items": {
+            "$ref": "#/$defs/filterExpression"
+          }
+        }
+      }
+    },
+    "filterExpression": {
+      "type": "object",
+      "properties": {
+        "andGroup": {
+          "$ref": "#/$defs/filterExpressionList"
+        },
+        "orGroup": {
+          "$ref": "#/$defs/filterExpressionList"
+        },
+        "notExpression": {
+          "$ref": "#/$defs/filterExpression"
+        },
+        "filter": {
+          "type": "object",
+          "required": ["fieldName"],
+          "properties": {
+            "fieldName": {
+              "type": "string"
+            },
+            "stringFilter": {
+              "type": "object",
+              "required": ["value"],
+              "properties": {
+                "matchType": {
+                  "type": "string",
+                  "enum": ["MATCH_TYPE_UNSPECIFIED", "EXACT", "BEGINS_WITH", "ENDS_WITH", "CONTAINS", "FULL_REGEXP", "PARTIAL_REGEXP"]
+                },
+                "value": {"type": "string"},
+                "caseSensitive": {
+                  "type": "boolean"
+                }
+              }
+            },
+            "inListFilter": {
+              "type": "object",
+              "required": ["values"],
+              "properties": {
+                "values": {
+                  "type": "array",
+                  "items": {
+                    "type": "string"
+                  },
+                  "minItems": 1
+                },
+                "caseSensitive": {
+                  "type": "boolean"
+                }
+              }
+            },
+            "numericFilter": {
+              "type": "object",
+              "required": ["value"],
+              "properties": {
+                "operation": {
+                  "type": "string",
+                  "enum": ["OPERATION_UNSPECIFIED", "EQUAL", "LESS_THAN", "LESS_THAN_OR_EQUAL", "GREATER_THAN", "GREATER_THAN_OR_EQUAL"]
+                },
+                "value": {
+                  "type": "object",
+                  "properties": {
+                    "int64Value": {
+                      "type": "string",
+                      "pattern": "^[0-9]+$"
+                    },
+                    "doubleValue": {
+                      "type": "number"
+                    }
+                  }
+                }
+              }
+            },
+            "betweenFilter": {
+              "type": "object",
+              "required": ["fromValue", "toValue"],
+              "properties": {
+                "fromValue": {
+                  "type": "object",
+                  "properties": {
+                    "int64Value": {
+                      "type": "string",
+                      "pattern": "^[0-9]+$"
+                    },
+                    "doubleValue": {
+                      "type": "number"
+                    }
+                  }
+                },
+                "toValue": {
+                  "type": "object",
+                  "properties": {
+                    "int64Value": {
+                      "type": "string",
+                      "pattern": "^[0-9]+$"
+                    },
+                    "doubleValue": {
+                      "type": "number"
+                    }
+                  }
+                }
+              }
             }
           }
         }

--- a/airbyte-integrations/connectors/source-google-analytics-data-api/source_google_analytics_data_api/source.py
+++ b/airbyte-integrations/connectors/source-google-analytics-data-api/source_google_analytics_data_api/source.py
@@ -155,12 +155,20 @@ class GoogleAnalyticsDataApiBaseStream(GoogleAnalyticsDataApiAbstractStream):
         r = response.json()
 
         if "rowCount" in r:
-            limit, offset, total_rows = int(self.config["limit"]), int(self.config["offset"]), r["rowCount"]
+            limit = int(self.config["limit"])
+            total_rows = r["rowCount"]
+            if "next_page_offset" in self.config and self.config["next_page_offset"] is not None:
+                offset = int(self.config["next_page_offset"])
+            else:
+                offset = int(self.config["offset"])
 
-            if total_rows <= offset:
+            if total_rows <= offset + limit:
+                self.config["next_page_offset"] = None
                 return None
 
-            return {"limit": str(limit), "offset": str(offset + limit)}
+            self.config["next_page_offset"] = str(offset + limit)
+
+            return {"limit": str(limit), "next_page_offset": str(offset + limit)}
 
     def path(
         self, *, stream_state: Mapping[str, Any] = None, stream_slice: Mapping[str, Any] = None, next_page_token: Mapping[str, Any] = None
@@ -202,19 +210,16 @@ class GoogleAnalyticsDataApiBaseStream(GoogleAnalyticsDataApiAbstractStream):
         next_page_token: Mapping[str, Any] = None,
     ) -> Optional[Mapping]:
 
-        self.config["limit"] = str(self.config["initial_limit"])
-        self.config["offset"] = str(self.config["initial_offset"])
-
-        if next_page_token:
-            self.config.update(next_page_token)
+        self.config["offset"] = str(self.config.get("offset", "0"))
+        self.config["limit"] = str(self.config.get("limit", "10000"))
 
         payload = {
             "metrics": [{"name": m} for m in self.config["metrics"]],
             "dimensions": [{"name": d} for d in self.config["dimensions"]],
             "dateRanges": [stream_slice],
             "returnPropertyQuota": True,
-            "limit": self.config["limit"],
-            "offset": self.config["offset"]
+            "offset": self.config['next_page_offset'] if next_page_token else self.config["offset"],
+            "limit": self.config["limit"]
         }
         if "dimensionFilter" in self.config:
             payload.update({"dimensionFilter": self.config["dimensionFilter"]})
@@ -416,8 +421,8 @@ class SourceGoogleAnalyticsDataApi(AbstractSource):
         stream_config = {
             "metrics": report["metrics"],
             "dimensions": report["dimensions"],
-            "initial_offset": report.get("offset", "0"),
-            "initial_limit": report.get("limit", "10000"),
+            "offset": report.get("offset", "0"),
+            "limit": report.get("limit", "10000"),
             **config
         }
         report_class_tuple = (GoogleAnalyticsDataApiBaseStream,)

--- a/airbyte-integrations/connectors/source-google-analytics-data-api/source_google_analytics_data_api/source.py
+++ b/airbyte-integrations/connectors/source-google-analytics-data-api/source_google_analytics_data_api/source.py
@@ -57,7 +57,7 @@ class GoogleAnalyticsDataApiAbstractStream(HttpStream, ABC):
     http_method = "POST"
     raise_on_http_errors = True
 
-    def __init__(self, *, config: Mapping[str, Any], **kwargs):
+    def __init__(self, *, config: MutableMapping[str, Any], **kwargs):
         super().__init__(**kwargs)
         self._config = config
 
@@ -154,13 +154,13 @@ class GoogleAnalyticsDataApiBaseStream(GoogleAnalyticsDataApiAbstractStream):
     def next_page_token(self, response: requests.Response) -> Optional[Mapping[str, Any]]:
         r = response.json()
 
-        if all(key in r for key in ["limit", "offset", "rowCount"]):
-            limit, offset, total_rows = r["limit"], r["offset"], r["rowCount"]
+        if "rowCount" in r:
+            limit, offset, total_rows = int(self.config["limit"]), int(self.config["offset"]), r["rowCount"]
 
             if total_rows <= offset:
                 return None
 
-            return {"limit": limit, "offset": offset + limit}
+            return {"limit": str(limit), "offset": str(offset + limit)}
 
     def path(
         self, *, stream_state: Mapping[str, Any] = None, stream_slice: Mapping[str, Any] = None, next_page_token: Mapping[str, Any] = None
@@ -201,12 +201,25 @@ class GoogleAnalyticsDataApiBaseStream(GoogleAnalyticsDataApiAbstractStream):
         stream_slice: Mapping[str, Any] = None,
         next_page_token: Mapping[str, Any] = None,
     ) -> Optional[Mapping]:
+
+        self.config["limit"] = str(self.config["initial_limit"])
+        self.config["offset"] = str(self.config["initial_offset"])
+
+        if next_page_token:
+            self.config.update(next_page_token)
+
         payload = {
             "metrics": [{"name": m} for m in self.config["metrics"]],
             "dimensions": [{"name": d} for d in self.config["dimensions"]],
             "dateRanges": [stream_slice],
             "returnPropertyQuota": True,
+            "limit": self.config["limit"],
+            "offset": self.config["offset"]
         }
+        if "dimensionFilter" in self.config:
+            payload.update({"dimensionFilter": self.config["dimensionFilter"]})
+        if "metricFilter" in self.config:
+            payload.update({"dimensionFilter": self.config["metricFilter"]})
         return payload
 
     def stream_slices(
@@ -398,8 +411,20 @@ class SourceGoogleAnalyticsDataApi(AbstractSource):
     def instantiate_report_class(report: dict, config: Mapping[str, Any]) -> GoogleAnalyticsDataApiBaseStream:
         cohort_spec = report.get("cohortSpec")
         pivots = report.get("pivots")
-        stream_config = {"metrics": report["metrics"], "dimensions": report["dimensions"], **config}
+        dimension_filter = report.get('dimensionFilter')
+        metric_filter = report.get('metricFilter')
+        stream_config = {
+            "metrics": report["metrics"],
+            "dimensions": report["dimensions"],
+            "initial_offset": report.get("offset", "0"),
+            "initial_limit": report.get("limit", "10000"),
+            **config
+        }
         report_class_tuple = (GoogleAnalyticsDataApiBaseStream,)
+        if dimension_filter:
+            stream_config["dimensionFilter"] = dimension_filter
+        if metric_filter:
+            stream_config["metricFilter"] = metric_filter
         if pivots:
             stream_config["pivots"] = pivots
             report_class_tuple = (PivotReport,)

--- a/airbyte-integrations/connectors/source-google-analytics-data-api/unit_tests/test_source.py
+++ b/airbyte-integrations/connectors/source-google-analytics-data-api/unit_tests/test_source.py
@@ -93,6 +93,39 @@ def config_gen(config):
                             "\"2020-09-15\" }], \"dimensions\": [\"browser\", \"country\", \"language\"], \"metrics\": [\"sessions\"], "
                             "\"pivots\": {}}]"},
          Status.FAILED, '"custom_reports.0.pivots: {} is not of type \'null\', \'array\'"'),
+        ({"custom_reports": "[{\"name\": \"name\", \"dimensions\": [\"country\"], \"metrics\": [\"sessions\"], "
+                            "\"limit\": \"1\", \"offset\": \"1\"}]"},
+         Status.SUCCEEDED, None),
+        ({"custom_reports": "[{\"name\": \"name\", \"dimensions\": [\"country\"], \"metrics\": [\"sessions\"], "
+                            "\"limit\": 1, \"offset\": 1}]"},
+         Status.SUCCEEDED, None),
+        ({"custom_reports": "[{\"name\": \"name\", \"dimensions\": [\"country\"], \"metrics\": [\"sessions\"], "
+                            "\"limit\": 1.2, \"offset\": 1}]"},
+         Status.FAILED, '"custom_reports.0.limit: 1.2 is not of type \'integer\', \'string\'"'),
+        ({"custom_reports": "[{\"name\": \"name\", \"dimensions\": [\"country\"], \"metrics\": [\"sessions\"], "
+                            "\"limit\": 1, \"offset\": 1.2}]"},
+         Status.FAILED, '"custom_reports.0.offset: 1.2 is not of type \'integer\', \'string\'"'),
+        ({"custom_reports": "[{\"name\": \"name\", \"dimensions\": [\"country\"], \"metrics\": [\"sessions\"], "
+                            "\"limit\": \"1.2\", \"offset\": \"1\"}]"},
+         Status.FAILED, '"custom_reports.0.limit: \'1.2\' does not match \'^([0-9]|[1-9][0-9]{1,4}|1[0-9]{5}|2[0-4][0-9]{4}|250000)$\'"'),
+        ({"custom_reports": "[{\"name\": \"name\", \"dimensions\": [\"country\"], \"metrics\": [\"sessions\"], "
+                            "\"limit\": \"1\", \"offset\": \"1.2\"}]"},
+         Status.FAILED, '"custom_reports.0.offset: \'1.2\' does not match \'^[0-9]+$\'"'),
+        ({"custom_reports": "[{\"name\": \"name\", \"dimensions\": [\"country\"], \"metrics\": [\"sessions\"], "
+                            "\"dimensionFilter\": {\"filter\": {\"fieldName\": \"country\", \"stringFilter\":{\"value\":\"US\"}}}}]"},
+         Status.SUCCEEDED, None),
+        ({"custom_reports": "[{\"name\": \"name\", \"dimensions\": [\"country\"], \"metrics\": [\"sessions\"], "
+                            "\"dimensionFilter\": {\"filter\": {\"fieldNameWrong\": \"country\", \"stringFilter\":{\"value\":\"US\"}}}}]"},
+         Status.FAILED, '"custom_reports.0.dimensionFilter.filter: \'fieldName\' is a required property"'),
+        ({"custom_reports": "[{\"name\": \"name\", \"dimensions\": [\"country\"], \"metrics\": [\"sessions\"], \"dimensionFilter\": "
+                            "{\"filter\": {\"fieldName\": \"country\", \"inListFilter\":{\"values\":[\"US\", \"EU\"]}}}}]"},
+         Status.SUCCEEDED, None),
+        ({"custom_reports": "[{\"name\": \"name\", \"dimensions\": [\"country\"], \"metrics\": [\"sessions\"], \"dimensionFilter\": "
+                            "{\"filter\": {\"fieldName\": \"country\", \"inListFilter\":{\"value\":[\"US\", \"EU\"]}}}}]"},
+         Status.FAILED, '"custom_reports.0.dimensionFilter.filter.inListFilter: \'values\' is a required property"'),
+        ({"custom_reports": "[{\"name\": \"name\", \"dimensions\": [\"country\"], \"metrics\": [\"sessions\"], \"dimensionFilter\": "
+                            "{\"filter\": {\"fieldName\": \"country\", \"inListFilter\":{\"values\":\"US\"}}}}]"},
+         Status.FAILED, '"custom_reports.0.dimensionFilter.filter.inListFilter.values: \'US\' is not of type \'array\'"'),
     ],
 )
 def test_check(requests_mock, config_gen, config_values, status, message):

--- a/docs/integrations/sources/google-analytics-data-api.md
+++ b/docs/integrations/sources/google-analytics-data-api.md
@@ -110,15 +110,16 @@ This connector outputs the following incremental streams:
 
 ## Changelog
 
-| Version | Date       | Pull Request                                             | Subject                                                                                |
-|:--------|:-----------|:---------------------------------------------------------|:---------------------------------------------------------------------------------------|
-| 0.2.2   | 2023-05-12 | [25987](https://github.com/airbytehq/airbyte/pull/25987) | Categorized Config Errors Accurately                                                   |
-| 0.2.1   | 2023-05-11 | [26008](https://github.com/airbytehq/airbyte/pull/26008) | Added handling for `429 - potentiallyThresholdedRequestsPerHour` error                 |
-| 0.2.0   | 2023-04-13 | [25179](https://github.com/airbytehq/airbyte/pull/25179) | Implement support for custom Cohort and Pivot reports                                  |
-| 0.1.3   | 2023-03-10 | [23872](https://github.com/airbytehq/airbyte/pull/23872) | Fix parse + cursor for custom reports                                                  |
-| 0.1.2   | 2023-03-07 | [23822](https://github.com/airbytehq/airbyte/pull/23822) | Improve `rate limits` customer faced error messages and retry logic for `429`          |
-| 0.1.1   | 2023-01-10 | [21169](https://github.com/airbytehq/airbyte/pull/21169) | Slicer updated, unit tests added                                                       |
-| 0.1.0   | 2023-01-08 | [20889](https://github.com/airbytehq/airbyte/pull/20889) | Improved config validation, SAT                                                        |
-| 0.0.3   | 2022-08-15 | [15229](https://github.com/airbytehq/airbyte/pull/15229) | Source Google Analytics Data Api: code refactoring                                     |
-| 0.0.2   | 2022-07-27 | [15087](https://github.com/airbytehq/airbyte/pull/15087) | fix documentationUrl                                                                   |
-| 0.0.1   | 2022-05-09 | [12701](https://github.com/airbytehq/airbyte/pull/12701) | Introduce Google Analytics Data API source                                             |
+| Version | Date       | Pull Request                                             | Subject                                                                       |
+|:--------|:-----------|:---------------------------------------------------------|:------------------------------------------------------------------------------|
+| 0.2.3   | 2023-05-16 | [26066](https://github.com/airbytehq/airbyte/pull/26066) | Fix pagination and added Filters handling                                     |
+| 0.2.2   | 2023-05-12 | [25987](https://github.com/airbytehq/airbyte/pull/25987) | Categorized Config Errors Accurately                                          |
+| 0.2.1   | 2023-05-11 | [26008](https://github.com/airbytehq/airbyte/pull/26008) | Added handling for `429 - potentiallyThresholdedRequestsPerHour` error        |
+| 0.2.0   | 2023-04-13 | [25179](https://github.com/airbytehq/airbyte/pull/25179) | Implement support for custom Cohort and Pivot reports                         |
+| 0.1.3   | 2023-03-10 | [23872](https://github.com/airbytehq/airbyte/pull/23872) | Fix parse + cursor for custom reports                                         |
+| 0.1.2   | 2023-03-07 | [23822](https://github.com/airbytehq/airbyte/pull/23822) | Improve `rate limits` customer faced error messages and retry logic for `429` |
+| 0.1.1   | 2023-01-10 | [21169](https://github.com/airbytehq/airbyte/pull/21169) | Slicer updated, unit tests added                                              |
+| 0.1.0   | 2023-01-08 | [20889](https://github.com/airbytehq/airbyte/pull/20889) | Improved config validation, SAT                                               |
+| 0.0.3   | 2022-08-15 | [15229](https://github.com/airbytehq/airbyte/pull/15229) | Source Google Analytics Data Api: code refactoring                            |
+| 0.0.2   | 2022-07-27 | [15087](https://github.com/airbytehq/airbyte/pull/15087) | fix documentationUrl                                                          |
+| 0.0.1   | 2022-05-09 | [12701](https://github.com/airbytehq/airbyte/pull/12701) | Introduce Google Analytics Data API source                                    |


### PR DESCRIPTION
## What
1. Fixed pagination;
2. Added filters dimensionFilter and metricFilter to the request body.

## How
1. The GA4 runReport hasn't **offset** and **limit** fields (you can see that in [official documentation](https://developers.google.com/analytics/devguides/reporting/data/v1/rest/v1beta/RunReportResponse)). Added a field **next_page_offset** to config and handling this decide the problem;
2. Change unit tests for next_page_token due to absent **offset** and **limit** fields in response.
3. Added filters structure (filters [official documentation](https://developers.google.com/analytics/devguides/reporting/data/v1/rest/v1beta/FilterExpression)) to **custom_reports_schema.json** for validation and handle this fields in **instantiate_report_class** method.