### PR TITLE
POC terraform destination-snowflake test infra

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -57,7 +57,6 @@ profiles.yml
 crash.log
 *.tfstate
 *.tfstate.backup
-*.lock.hcl
 
 # Airflow Demo
 resources/examples/airflow/logs/*

--- a/airbyte-integrations/connectors/destination-snowflake/integration_test_infra/.env.example
+++ b/airbyte-integrations/connectors/destination-snowflake/integration_test_infra/.env.example
@@ -1,0 +1,4 @@
+export SNOWFLAKE_ACCOUNT="GZ45853"
+export SNOWFLAKE_REGION="us-east-2.aws"
+export SNOWFLAKE_USER='airbytetester'
+export SNOWFLAKE_PASSWORD="$(lpass show "Snowflake Oauth integration test account" --password)"

--- a/airbyte-integrations/connectors/destination-snowflake/integration_test_infra/.terraform.lock.hcl
+++ b/airbyte-integrations/connectors/destination-snowflake/integration_test_infra/.terraform.lock.hcl
@@ -1,0 +1,67 @@
+# This file is maintained automatically by "terraform init".
+# Manual edits may be lost in future updates.
+
+provider "registry.terraform.io/hashicorp/google" {
+  version     = "4.65.0"
+  constraints = "~> 4.65.0"
+  hashes = [
+    "h1:WyUL/HHwcoisUXRWP9z/mcwtjHau2folysfI3tcbMpU=",
+    "zh:0d32421e27563b51e6b484580350995cc4a2b8f79dcb3b215799259cc51fcd3e",
+    "zh:13086da7e629dd804937184c9da8f580b592e7b6020cef2d28a0faf277c07f8c",
+    "zh:23ff1161707e3ca20dfb06c9b7b093a698a73d2e19104c279c626e45cc1d1935",
+    "zh:25a369191b67899efca06348c22fab1e9472a2bb126499fd45db5b211cba0856",
+    "zh:2b536c892bcb34628061455dea7c4e4b1909abb0376e2c2264135c078acacc54",
+    "zh:4f38bb5d2fc41fac2a6dc21e68e4f4077390bb4586c7bd5c6e953363c0cd27ea",
+    "zh:5b554bfb1eef27485b1aac9d601145f717fde27c3557fb964e44885ce5642ec5",
+    "zh:6c07a6f9a76d97401005db4a4e8466a7525eb6b29bc2e74fb097548502767a68",
+    "zh:8290dd50953c288d9d0b11434a7500a18c3ee1ff6b9cda34e9b552cacfac0acf",
+    "zh:a0833d1c0e14867985a453154848db5c1c0cb9b07dd916c10fff052ef4ca81fc",
+    "zh:b70022e05bde07432c0b68b35ea0953c1c6cac26015a8053026b1abcf572643c",
+    "zh:f569b65999264a9416862bca5cd2a6177d94ccb0424f3a4ef424428912b9cb3c",
+  ]
+}
+
+provider "registry.terraform.io/hashicorp/random" {
+  version = "3.5.1"
+  hashes = [
+    "h1:sZ7MTSD4FLekNN2wSNFGpM+5slfvpm5A/NLVZiB7CO0=",
+    "zh:04e3fbd610cb52c1017d282531364b9c53ef72b6bc533acb2a90671957324a64",
+    "zh:119197103301ebaf7efb91df8f0b6e0dd31e6ff943d231af35ee1831c599188d",
+    "zh:4d2b219d09abf3b1bb4df93d399ed156cadd61f44ad3baf5cf2954df2fba0831",
+    "zh:6130bdde527587bbe2dcaa7150363e96dbc5250ea20154176d82bc69df5d4ce3",
+    "zh:6cc326cd4000f724d3086ee05587e7710f032f94fc9af35e96a386a1c6f2214f",
+    "zh:78d5eefdd9e494defcb3c68d282b8f96630502cac21d1ea161f53cfe9bb483b3",
+    "zh:b6d88e1d28cf2dfa24e9fdcc3efc77adcdc1c3c3b5c7ce503a423efbdd6de57b",
+    "zh:ba74c592622ecbcef9dc2a4d81ed321c4e44cddf7da799faa324da9bf52a22b2",
+    "zh:c7c5cde98fe4ef1143bd1b3ec5dc04baf0d4cc3ca2c5c7d40d17c0e9b2076865",
+    "zh:dac4bad52c940cd0dfc27893507c1e92393846b024c5a9db159a93c534a3da03",
+    "zh:de8febe2a2acd9ac454b844a4106ed295ae9520ef54dc8ed2faf29f12716b602",
+    "zh:eab0d0495e7e711cca367f7d4df6e322e6c562fc52151ec931176115b83ed014",
+  ]
+}
+
+provider "registry.terraform.io/snowflake-labs/snowflake" {
+  version     = "0.55.1"
+  constraints = "~> 0.55.0"
+  hashes = [
+    "h1:dp2JBwesNlBHrTHxu5J0yxdKUKz3OaVHtGcc9i77GGo=",
+    "zh:0053219261acd0740fa77bf4a3e75bd97dcd8d5d094dfcd9d11fc83beb2bb99d",
+    "zh:1257e76c36970dd45cd1a33ba2ea1d8df3d828027ce258bb86ee7a5728315d2e",
+    "zh:4a9dfeaa0b148f6d3b16339df2efb69eab24b68d223593ad89d596f16e6d1fe1",
+    "zh:6a4e80782d1b94e1ac8c736cd90111b5376aee3e0bacec265399c000f9c9518a",
+    "zh:8369be65c97397baf2fab0b3dd2bd83d36a749da1b283de616091edf6bfc3e53",
+    "zh:8c9249ad1692895e2c7918cfcc37f9062bf2ba4d9bba1b6201860fd1a45c0652",
+    "zh:97aaef0f37d6350a39fe6a25e64eefa58b4f7c23027f1dd3713d443aefba0edd",
+    "zh:98aa0f84f2dc19f904f492e60dda7ce8efb63c01508d9a4e8fccfbb249716c53",
+    "zh:994e0a0e86df68d87dc6787c1a29a8cad91e26e73f032583e640bf07e88a7f4f",
+    "zh:c21247767ee39683abe43ecf806f28854b1c03b1ed38f8bd5a35c35d3ccd8da3",
+    "zh:c9a9b7a6b178c60a57a1d3aa9408394b2183e3ef29c2f015cea3e780e8266f1b",
+    "zh:cbc6acc65a111049b0ff38e883a1b483af78094b190ad321f6d6a88760522a52",
+    "zh:cc191a1b6e104ac71da4462d911622db1caf5b0861450e73b1e65bf4c5a51926",
+    "zh:dcbaabb0e854393c769411ca465fd475ff5c27f99bfd8b92f338c6f75feb4480",
+    "zh:dda655abcf43f91eb3afea82f9a63e922ec76402926d37ec9de8ca27c1eaa0fe",
+    "zh:e16810ca1a39290fbfcaaa3872c4b7f6091ae88dc9da61f30b2639c47b2da82a",
+    "zh:e4b94f947a08145e189fc929eae5394e3534cf59b9b56aba154acd80e23ccac2",
+    "zh:f569b65999264a9416862bca5cd2a6177d94ccb0424f3a4ef424428912b9cb3c",
+  ]
+}

--- a/airbyte-integrations/connectors/destination-snowflake/integration_test_infra/destination_snowflake_no_create_schema_privilege.tf
+++ b/airbyte-integrations/connectors/destination-snowflake/integration_test_infra/destination_snowflake_no_create_schema_privilege.tf
@@ -16,6 +16,7 @@ resource "snowflake_user" "no_create_schema_privilege" {
   password = random_password.password.result
   default_role = snowflake_role.airbyte.name
   default_warehouse = snowflake_warehouse.airbyte_warehouse.name
+  default_namespace = snowflake_database.airbyte_database.name
 }
 
 resource "snowflake_role_grants" "no_create_schema_privilege" {

--- a/airbyte-integrations/connectors/destination-snowflake/integration_test_infra/destination_snowflake_no_create_schema_privilege.tf
+++ b/airbyte-integrations/connectors/destination-snowflake/integration_test_infra/destination_snowflake_no_create_schema_privilege.tf
@@ -1,0 +1,91 @@
+# A snowflake user with no create schema privilege.
+
+resource "snowflake_role" "no_create_schema_privilege" {
+  provider = snowflake.securityadmin
+  name = "ROLE_WITHOUT_CREATE_SCHEMA_PRIVILEGE"
+}
+
+resource "random_password" "password" {
+  length           = 64
+  special          = true
+}
+
+resource "snowflake_user" "no_create_schema_privilege" {
+  provider = snowflake.securityadmin
+  name = "INTEGRATION_TEST_DESTINATION_NO_CREATE_SCHEMA_PRIVILEGE"
+  password = random_password.password.result
+  default_role = snowflake_role.airbyte.name
+  default_warehouse = snowflake_warehouse.airbyte_warehouse.name
+}
+
+resource "snowflake_role_grants" "no_create_schema_privilege" {
+  provider = snowflake.securityadmin
+  role_name = snowflake_role.no_create_schema_privilege.name
+
+  users = [
+    snowflake_user.no_create_schema_privilege.name
+  ]
+}
+
+resource "snowflake_warehouse_grant" "no_create_schema_privilege" {
+  provider = snowflake.sysadmin
+  warehouse_name = snowflake_warehouse.airbyte_warehouse.name
+  privilege = "USAGE"
+  roles = [
+    snowflake_role.no_create_schema_privilege.name
+  ]
+}
+
+resource "snowflake_database_grant" "no_create_schema_privilege" {
+  provider = snowflake.sysadmin
+  database_name = snowflake_database.airbyte_database.name
+  # NB: not ownership
+  privilege = "USAGE"
+  roles = [
+    snowflake_role.airbyte.name
+  ]
+}
+
+resource "snowflake_schema" "no_create_schema_privilege" {
+  provider = snowflake.sysadmin
+  database = snowflake_database.airbyte_database.name
+  name = "INTEGRATION_TEST_DESTINATION_NO_CREATE_SCHEMA_PRIVILEGE"
+}
+
+resource "google_secret_manager_secret" "destination_snowflake_no_create_schema_privilege" {
+  secret_id = "SECRET_DESTINATION_SNOWFLAKE_NO_CREATE_SCHEMA_PRIVILEGE"
+
+  labels = {
+    connector = "destination-snowflake"
+    filename = "no_create_schema_privilege"
+  }
+
+  replication {
+    user_managed {
+      replicas {
+        location = "us-central1"
+      }
+      replicas {
+        location = "us-east1"
+      }
+    }
+  }
+}
+
+resource "google_secret_manager_secret_version" "destination_snowflake_no_create_schema_privilege" {
+  secret = google_secret_manager_secret.destination_snowflake_no_create_schema_privilege.id
+  secret_data = jsonencode({
+    host = local.snowflake_host
+    role = snowflake_role.airbyte.name
+    warehouse = snowflake_warehouse.airbyte_warehouse.name
+    database = snowflake_database.airbyte_database.name
+    schema = snowflake_schema.no_create_schema_privilege.name
+    username = snowflake_user.no_create_schema_privilege.name
+    credentials = {
+      password = random_password.password.result
+    }
+    loading_method = {
+      method = "Internal Staging"
+    }
+  })
+}

--- a/airbyte-integrations/connectors/destination-snowflake/integration_test_infra/destination_snowflake_no_create_schema_privilege.tf
+++ b/airbyte-integrations/connectors/destination-snowflake/integration_test_infra/destination_snowflake_no_create_schema_privilege.tf
@@ -27,22 +27,16 @@ resource "snowflake_role_grants" "no_create_schema_privilege" {
   ]
 }
 
-resource "snowflake_warehouse_grant" "no_create_schema_privilege" {
-  provider = snowflake.sysadmin
-  warehouse_name = snowflake_warehouse.airbyte_warehouse.name
-  privilege = "USAGE"
-  roles = [
-    snowflake_role.no_create_schema_privilege.name
-  ]
-}
-
 resource "snowflake_database_grant" "no_create_schema_privilege" {
   provider = snowflake.sysadmin
   database_name = snowflake_database.airbyte_database.name
   # NB: not ownership
   privilege = "USAGE"
   roles = [
-    snowflake_role.airbyte.name
+    snowflake_role.airbyte.name,
+    "NESH_01",
+    "NESH_ROLE",
+    "TEST_STAGING_ROLE",
   ]
 }
 
@@ -76,7 +70,7 @@ resource "google_secret_manager_secret_version" "destination_snowflake_no_create
   secret = google_secret_manager_secret.destination_snowflake_no_create_schema_privilege.id
   secret_data = jsonencode({
     host = local.snowflake_host
-    role = snowflake_role.airbyte.name
+    role = snowflake_role.no_create_schema_privilege.name
     warehouse = snowflake_warehouse.airbyte_warehouse.name
     database = snowflake_database.airbyte_database.name
     schema = snowflake_schema.no_create_schema_privilege.name

--- a/airbyte-integrations/connectors/destination-snowflake/integration_test_infra/providers.tf
+++ b/airbyte-integrations/connectors/destination-snowflake/integration_test_infra/providers.tf
@@ -1,0 +1,38 @@
+terraform {
+  required_providers {
+    snowflake = {
+      source  = "Snowflake-Labs/snowflake"
+      version = "~> 0.55.0"
+    }
+    google = {
+      source  = "hashicorp/google"
+      version = "~> 4.65.0"
+    }
+  }
+
+  backend "gcs" {
+    bucket = "hackdays-2023-05-terraform-integration-test-envs"
+  }
+}
+
+provider "google" {
+  project = "dataline-integration-testing"
+}
+
+provider "snowflake" {
+  # Source the .env file to add the required environment variables
+  # Make sure you've signed into lpass cli
+  # lpass login joseph.bell@airbyte.io
+  # source ./.env
+  role = "securityadmin"
+  alias = "securityadmin"
+}
+
+provider "snowflake" {
+  # Source the .env file to add the required environment variables
+  # Make sure you've signed into lpass cli
+  # lpass login joseph.bell@airbyte.io
+  # source ./.env
+  role = "sysadmin"
+  alias = "sysadmin"
+}

--- a/airbyte-integrations/connectors/destination-snowflake/integration_test_infra/shared_infra.tf
+++ b/airbyte-integrations/connectors/destination-snowflake/integration_test_infra/shared_infra.tf
@@ -1,0 +1,92 @@
+locals {
+  snowflake_host = "gz45853.us-east-2.aws.snowflakecomputing.com"
+}
+
+resource "snowflake_role" "airbyte" {
+  provider = snowflake.securityadmin
+  name     = "AIRBYTE_ROLE"
+}
+
+resource "snowflake_role_grants" "sysadmin_grants" {
+  provider  = snowflake.securityadmin
+  role_name = snowflake_role.airbyte.name
+  roles     = ["SYSADMIN"]
+}
+
+# resource "snowflake_user" "airbyte_user" {
+#   provider = snowflake.securityadmin
+#   name = "INTEGRATION_TEST_USER_DESTINATION"
+#   password = random_password.password.result
+#   default_role = snowflake_role.airbyte.name
+#   default_warehouse = snowflake_warehouse.airbyte_warehouse.name
+# }
+
+# resource "snowflake_role_grants" "user_grant" {
+#   provider = snowflake.securityadmin
+#   role_name = snowflake_role.airbyte.name
+
+#   users = [
+#     snowflake_user.airbyte_user.name
+#   ]
+# }
+
+resource "snowflake_warehouse" "airbyte_warehouse" {
+  provider       = snowflake.sysadmin
+  name           = "AIRBYTE_WAREHOUSE"
+  warehouse_size = "xsmall"
+  warehouse_type = "STANDARD"
+  auto_suspend   = 3600
+  auto_resume    = true
+  # This has a weird default of 8 and query acceleration can not be enabled, setting to 0 allows progress when
+  # Feature is disabled
+  query_acceleration_max_scale_factor = 0
+}
+
+resource "snowflake_database" "airbyte_database" {
+  provider = snowflake.sysadmin
+  name     = "AIRBYTE_DATABASE"
+}
+
+resource "snowflake_warehouse_grant" "ab_warehouse_grant" {
+  provider       = snowflake.sysadmin
+  warehouse_name = snowflake_warehouse.airbyte_warehouse.name
+  privilege      = "USAGE"
+  roles = [
+    snowflake_role.airbyte.name,
+    # No idea what these are, but terraform plan says they exist
+    "NESH_01",
+    "NESH_ROLE",
+    "SYSADMIN",
+    "SYSADMIN_NATALIE",
+    "TEST_STAGING_ROLE",
+    "TEST_TESH_ROLE",
+    "TEST_TESH_ROLE2",
+  ]
+}
+
+resource "snowflake_database_grant" "ab_db_grant" {
+  provider      = snowflake.sysadmin
+  database_name = snowflake_database.airbyte_database.name
+  privilege     = "OWNERSHIP"
+  roles = [
+    snowflake_role.airbyte.name,
+    # No idea what this is, but terraform plan says it exists
+    "NESH_01"
+  ]
+}
+
+resource "snowflake_schema" "airbyte_schema" {
+  provider = snowflake.sysadmin
+  database = snowflake_database.airbyte_database.name
+  name     = "AIRBYTE_SCHEMA"
+}
+
+resource "snowflake_schema_grant" "ab_aschema_grant" {
+  provider      = snowflake.sysadmin
+  database_name = snowflake_database.airbyte_database.name
+  schema_name   = snowflake_schema.airbyte_schema.name
+  privilege     = "OWNERSHIP"
+  roles = [
+    snowflake_role.airbyte.name
+  ]
+}

--- a/airbyte-integrations/connectors/destination-snowflake/integration_test_infra/shared_infra.tf
+++ b/airbyte-integrations/connectors/destination-snowflake/integration_test_infra/shared_infra.tf
@@ -53,6 +53,7 @@ resource "snowflake_warehouse_grant" "ab_warehouse_grant" {
   privilege      = "USAGE"
   roles = [
     snowflake_role.airbyte.name,
+    snowflake_role.no_create_schema_privilege.name,
     # No idea what these are, but terraform plan says they exist
     "NESH_01",
     "NESH_ROLE",
@@ -69,7 +70,6 @@ resource "snowflake_database_grant" "ab_db_grant" {
   database_name = snowflake_database.airbyte_database.name
   privilege     = "OWNERSHIP"
   roles = [
-    snowflake_role.airbyte.name,
     # No idea what this is, but terraform plan says it exists
     "NESH_01"
   ]


### PR DESCRIPTION
* attempt to create a test case for "we don't have permission to CREATE SCHEMA", which should fail
* terraform is used as documentation for how the user was created
* terraform also automatically creates GSM entry https://console.cloud.google.com/security/secret-manager/secret/SECRET_DESTINATION_SNOWFLAKE_NO_CREATE_SCHEMA_PRIVILEGE/versions?project=dataline-integration-testing

workflow:
1. `cp .env.example .env`
2. `source .env`
3. `terraform plan`

<details>
<summary>terraform plan output</summary>

```
Terraform will perform the following actions:

  # google_secret_manager_secret_version.destination_snowflake_no_create_schema_privilege must be replaced
-/+ resource "google_secret_manager_secret_version" "destination_snowflake_no_create_schema_privilege" {
      ~ create_time  = "2023-05-15T22:27:44.882333Z" -> (known after apply)
      ~ destroy_time = "" -> (known after apply)
      ~ id           = "projects/708867486045/secrets/SECRET_DESTINATION_SNOWFLAKE_NO_CREATE_SCHEMA_PRIVILEGE/versions/2" -> (known after apply)
      ~ name         = "projects/708867486045/secrets/SECRET_DESTINATION_SNOWFLAKE_NO_CREATE_SCHEMA_PRIVILEGE/versions/2" -> (known after apply)
      ~ secret_data  = (sensitive value) # forces replacement
      ~ version      = "2" -> (known after apply)
        # (2 unchanged attributes hidden)
    }

  # snowflake_database_grant.ab_db_grant will be updated in-place
  ~ resource "snowflake_database_grant" "ab_db_grant" {
      + enable_multiple_grants = false
        id                     = "AIRBYTE_DATABASE|NESH_01|false|OWNERSHIP|"
      ~ roles                  = [
          + "AIRBYTE_ROLE",
            # (1 unchanged element hidden)
        ]
        # (4 unchanged attributes hidden)
    }

  # snowflake_database_grant.no_create_schema_privilege will be created
  + resource "snowflake_database_grant" "no_create_schema_privilege" {
      + database_name          = "AIRBYTE_DATABASE"
      + enable_multiple_grants = false
      + id                     = (known after apply)
      + privilege              = "USAGE"
      + roles                  = [
          + "AIRBYTE_ROLE",
        ]
      + with_grant_option      = false
    }

  # snowflake_role.no_create_schema_privilege will be created
  + resource "snowflake_role" "no_create_schema_privilege" {
      + id   = (known after apply)
      + name = "ROLE_WITHOUT_CREATE_SCHEMA_PRIVILEGE"
    }

  # snowflake_role_grants.no_create_schema_privilege will be created
  + resource "snowflake_role_grants" "no_create_schema_privilege" {
      + enable_multiple_grants = false
      + id                     = (known after apply)
      + role_name              = "ROLE_WITHOUT_CREATE_SCHEMA_PRIVILEGE"
      + users                  = [
          + "INTEGRATION_TEST_DESTINATION_NO_CREATE_SCHEMA_PRIVILEGE",
        ]
    }

  # snowflake_role_grants.sysadmin_grants will be updated in-place
  ~ resource "snowflake_role_grants" "sysadmin_grants" {
      + enable_multiple_grants = false
        id                     = "AIRBYTE_ROLE|SYSADMIN|"
      ~ roles                  = [
          + "SYSADMIN",
        ]
        # (2 unchanged attributes hidden)
    }

  # snowflake_schema.no_create_schema_privilege will be created
  + resource "snowflake_schema" "no_create_schema_privilege" {
      + data_retention_days = 1
      + database            = "AIRBYTE_DATABASE"
      + id                  = (known after apply)
      + is_managed          = false
      + is_transient        = false
      + name                = "INTEGRATION_TEST_DESTINATION_NO_CREATE_SCHEMA_PRIVILEGE"
    }

  # snowflake_user.no_create_schema_privilege will be created
  + resource "snowflake_user" "no_create_schema_privilege" {
      + default_role       = "AIRBYTE_ROLE"
      + default_warehouse  = "AIRBYTE_WAREHOUSE"
      + disabled           = (known after apply)
      + display_name       = (known after apply)
      + has_rsa_public_key = (known after apply)
      + id                 = (known after apply)
      + login_name         = (known after apply)
      + name               = "INTEGRATION_TEST_DESTINATION_NO_CREATE_SCHEMA_PRIVILEGE"
      + password           = (sensitive value)
    }

  # snowflake_warehouse_grant.no_create_schema_privilege will be created
  + resource "snowflake_warehouse_grant" "no_create_schema_privilege" {
      + enable_multiple_grants = false
      + id                     = (known after apply)
      + privilege              = "USAGE"
      + roles                  = [
          + "ROLE_WITHOUT_CREATE_SCHEMA_PRIVILEGE",
        ]
      + warehouse_name         = "AIRBYTE_WAREHOUSE"
      + with_grant_option      = false
    }

Plan: 7 to add, 2 to change, 1 to destroy.
```
</details>

<details>
<summary>terraform apply output</summary>

```
Do you want to perform these actions?
  Terraform will perform the actions described above.
  Only 'yes' will be accepted to approve.

  Enter a value: yes

snowflake_role.no_create_schema_privilege: Creating...
snowflake_role_grants.sysadmin_grants: Modifying... [id=AIRBYTE_ROLE|SYSADMIN|]
snowflake_database_grant.no_create_schema_privilege: Creating...
snowflake_database_grant.ab_db_grant: Modifying... [id=AIRBYTE_DATABASE|NESH_01|false|OWNERSHIP|]
google_secret_manager_secret_version.destination_snowflake_no_create_schema_privilege: Destroying... [id=projects/708867486045/secrets/SECRET_DESTINATION_SNOWFLAKE_NO_CREATE_SCHEMA_PRIVILEGE/versions/2]
snowflake_database_grant.ab_db_grant: Modifications complete after 1s [id=AIRBYTE_DATABASE|NESH_01|false|OWNERSHIP|]
snowflake_database_grant.no_create_schema_privilege: Creation complete after 1s [id=AIRBYTE_DATABASE|||USAGE|AIRBYTE_ROLE|false]
snowflake_role_grants.sysadmin_grants: Modifications complete after 1s [id=AIRBYTE_ROLE|SYSADMIN|]
snowflake_role.no_create_schema_privilege: Creation complete after 2s [id=ROLE_WITHOUT_CREATE_SCHEMA_PRIVILEGE]
snowflake_warehouse_grant.no_create_schema_privilege: Creating...
google_secret_manager_secret_version.destination_snowflake_no_create_schema_privilege: Destruction complete after 1s
snowflake_schema.no_create_schema_privilege: Creating...
snowflake_user.no_create_schema_privilege: Creating...
snowflake_warehouse_grant.no_create_schema_privilege: Creation complete after 0s [id=AIRBYTE_WAREHOUSE|||USAGE|ROLE_WITHOUT_CREATE_SCHEMA_PRIVILEGE|false]
snowflake_schema.no_create_schema_privilege: Creation complete after 0s [id=AIRBYTE_DATABASE|INTEGRATION_TEST_DESTINATION_NO_CREATE_SCHEMA_PRIVILEGE]
snowflake_user.no_create_schema_privilege: Creation complete after 0s [id=INTEGRATION_TEST_DESTINATION_NO_CREATE_SCHEMA_PRIVILEGE]
snowflake_role_grants.no_create_schema_privilege: Creating...
google_secret_manager_secret_version.destination_snowflake_no_create_schema_privilege: Creating...
snowflake_role_grants.no_create_schema_privilege: Creation complete after 0s [id=ROLE_WITHOUT_CREATE_SCHEMA_PRIVILEGE|||||false]
google_secret_manager_secret_version.destination_snowflake_no_create_schema_privilege: Creation complete after 1s [id=projects/708867486045/secrets/SECRET_DESTINATION_SNOWFLAKE_NO_CREATE_SCHEMA_PRIVILEGE/versions/3]

Apply complete! Resources: 7 added, 2 changed, 1 destroyed.
```
</details>

<details>
<summary>terraform after `reconcile with reality` commit</summary>

```
10:00:45 edgao:~/code/airbyte/airbyte-integrations/connectors/destination-snowflake/integration_test_infra(snowflake_test_env_terraform () )$ terraform apply
snowflake_warehouse.airbyte_warehouse: Refreshing state... [id=AIRBYTE_WAREHOUSE]
snowflake_role.no_create_schema_privilege: Refreshing state... [id=ROLE_WITHOUT_CREATE_SCHEMA_PRIVILEGE]
random_password.password: Refreshing state... [id=none]
snowflake_database.airbyte_database: Refreshing state... [id=AIRBYTE_DATABASE]
snowflake_role.airbyte: Refreshing state... [id=AIRBYTE_ROLE]
google_secret_manager_secret.destination_snowflake_no_create_schema_privilege: Refreshing state... [id=projects/dataline-integration-testing/secrets/SECRET_DESTINATION_SNOWFLAKE_NO_CREATE_SCHEMA_PRIVILEGE]
snowflake_role_grants.sysadmin_grants: Refreshing state... [id=AIRBYTE_ROLE|SYSADMIN|]
snowflake_schema.no_create_schema_privilege: Refreshing state... [id=AIRBYTE_DATABASE|INTEGRATION_TEST_DESTINATION_NO_CREATE_SCHEMA_PRIVILEGE]
snowflake_schema.airbyte_schema: Refreshing state... [id=AIRBYTE_DATABASE|AIRBYTE_SCHEMA]
snowflake_database_grant.ab_db_grant: Refreshing state... [id=AIRBYTE_DATABASE|NESH_01|false|OWNERSHIP|]
snowflake_database_grant.no_create_schema_privilege: Refreshing state... [id=AIRBYTE_DATABASE|||USAGE|AIRBYTE_ROLE|false]
snowflake_warehouse_grant.ab_warehouse_grant: Refreshing state... [id=AIRBYTE_WAREHOUSE|AIRBYTE_ROLE|false|USAGE]
snowflake_user.no_create_schema_privilege: Refreshing state... [id=INTEGRATION_TEST_DESTINATION_NO_CREATE_SCHEMA_PRIVILEGE]
snowflake_schema_grant.ab_aschema_grant: Refreshing state... [id=AIRBYTE_DATABASE|AIRBYTE_SCHEMA|OWNERSHIP|OWNERSHIP|false|AIRBYTE_ROLE]
snowflake_role_grants.no_create_schema_privilege: Refreshing state... [id=ROLE_WITHOUT_CREATE_SCHEMA_PRIVILEGE|||||false]
google_secret_manager_secret_version.destination_snowflake_no_create_schema_privilege: Refreshing state... [id=projects/708867486045/secrets/SECRET_DESTINATION_SNOWFLAKE_NO_CREATE_SCHEMA_PRIVILEGE/versions/3]

Note: Objects have changed outside of Terraform

Terraform detected the following changes made outside of Terraform since the last "terraform apply":

  # snowflake_warehouse_grant.ab_warehouse_grant has been changed
  ~ resource "snowflake_warehouse_grant" "ab_warehouse_grant" {
        id                = "AIRBYTE_WAREHOUSE|AIRBYTE_ROLE|false|USAGE"
      ~ roles             = [
          + "ROLE_WITHOUT_CREATE_SCHEMA_PRIVILEGE",
            # (8 unchanged elements hidden)
        ]
        # (3 unchanged attributes hidden)
    }
  # snowflake_database_grant.ab_db_grant has been changed
  ~ resource "snowflake_database_grant" "ab_db_grant" {
        id                     = "AIRBYTE_DATABASE|NESH_01|false|OWNERSHIP|"
      ~ roles                  = [
          - "AIRBYTE_ROLE",
            # (1 unchanged element hidden)
        ]
        # (5 unchanged attributes hidden)
    }
  # snowflake_user.no_create_schema_privilege has been changed
  ~ resource "snowflake_user" "no_create_schema_privilege" {
      + default_secondary_roles = []
        id                      = "INTEGRATION_TEST_DESTINATION_NO_CREATE_SCHEMA_PRIVILEGE"
        name                    = "INTEGRATION_TEST_DESTINATION_NO_CREATE_SCHEMA_PRIVILEGE"
        # (12 unchanged attributes hidden)
    }
  # snowflake_database_grant.no_create_schema_privilege has been changed
  ~ resource "snowflake_database_grant" "no_create_schema_privilege" {
        id                     = "AIRBYTE_DATABASE|||USAGE|AIRBYTE_ROLE|false"
      ~ roles                  = [
          + "NESH_01",
          + "NESH_ROLE",
          + "TEST_STAGING_ROLE",
            # (1 unchanged element hidden)
        ]
      + shares                 = []
        # (4 unchanged attributes hidden)
    }
  # snowflake_role_grants.no_create_schema_privilege has been changed
  ~ resource "snowflake_role_grants" "no_create_schema_privilege" {
        id                     = "ROLE_WITHOUT_CREATE_SCHEMA_PRIVILEGE|||||false"
      + roles                  = []
        # (3 unchanged attributes hidden)
    }

Unless you have made equivalent changes to your configuration, or ignored the relevant attributes using ignore_changes, the following plan may include actions to undo or respond to these changes.

────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────

Terraform used the selected providers to generate the following execution plan. Resource actions are indicated with the following symbols:
-/+ destroy and then create replacement

Terraform will perform the following actions:

  # google_secret_manager_secret_version.destination_snowflake_no_create_schema_privilege must be replaced
-/+ resource "google_secret_manager_secret_version" "destination_snowflake_no_create_schema_privilege" {
      ~ create_time  = "2023-05-16T16:23:20.820299Z" -> (known after apply)
      ~ destroy_time = "" -> (known after apply)
      ~ id           = "projects/708867486045/secrets/SECRET_DESTINATION_SNOWFLAKE_NO_CREATE_SCHEMA_PRIVILEGE/versions/3" -> (known after apply)
      ~ name         = "projects/708867486045/secrets/SECRET_DESTINATION_SNOWFLAKE_NO_CREATE_SCHEMA_PRIVILEGE/versions/3" -> (known after apply)
      ~ secret_data  = (sensitive value) # forces replacement
      ~ version      = "3" -> (known after apply)
        # (2 unchanged attributes hidden)
    }

Plan: 1 to add, 0 to change, 1 to destroy.

Do you want to perform these actions?
  Terraform will perform the actions described above.
  Only 'yes' will be accepted to approve.

  Enter a value: yes

google_secret_manager_secret_version.destination_snowflake_no_create_schema_privilege: Destroying... [id=projects/708867486045/secrets/SECRET_DESTINATION_SNOWFLAKE_NO_CREATE_SCHEMA_PRIVILEGE/versions/3]
google_secret_manager_secret_version.destination_snowflake_no_create_schema_privilege: Destruction complete after 1s
google_secret_manager_secret_version.destination_snowflake_no_create_schema_privilege: Creating...
google_secret_manager_secret_version.destination_snowflake_no_create_schema_privilege: Creation complete after 1s [id=projects/708867486045/secrets/SECRET_DESTINATION_SNOWFLAKE_NO_CREATE_SCHEMA_PRIVILEGE/versions/4]

Apply complete! Resources: 1 added, 0 changed, 1 destroyed.
```
</details>

<details>
<summary>and when adding default database</summary>

```
10:13:06 edgao:~/code/airbyte/airbyte-integrations/connectors/destination-snowflake/integration_test_infra(snowflake_test_env_terraform () )$ terraform plan
random_password.password: Refreshing state... [id=none]
snowflake_role.no_create_schema_privilege: Refreshing state... [id=ROLE_WITHOUT_CREATE_SCHEMA_PRIVILEGE]
snowflake_role.airbyte: Refreshing state... [id=AIRBYTE_ROLE]
snowflake_warehouse.airbyte_warehouse: Refreshing state... [id=AIRBYTE_WAREHOUSE]
snowflake_database.airbyte_database: Refreshing state... [id=AIRBYTE_DATABASE]
google_secret_manager_secret.destination_snowflake_no_create_schema_privilege: Refreshing state... [id=projects/dataline-integration-testing/secrets/SECRET_DESTINATION_SNOWFLAKE_NO_CREATE_SCHEMA_PRIVILEGE]
snowflake_schema.airbyte_schema: Refreshing state... [id=AIRBYTE_DATABASE|AIRBYTE_SCHEMA]
snowflake_database_grant.ab_db_grant: Refreshing state... [id=AIRBYTE_DATABASE|NESH_01|false|OWNERSHIP|]
snowflake_schema.no_create_schema_privilege: Refreshing state... [id=AIRBYTE_DATABASE|INTEGRATION_TEST_DESTINATION_NO_CREATE_SCHEMA_PRIVILEGE]
snowflake_database_grant.no_create_schema_privilege: Refreshing state... [id=AIRBYTE_DATABASE|||USAGE|AIRBYTE_ROLE|false]
snowflake_role_grants.sysadmin_grants: Refreshing state... [id=AIRBYTE_ROLE|SYSADMIN|]
snowflake_warehouse_grant.ab_warehouse_grant: Refreshing state... [id=AIRBYTE_WAREHOUSE|AIRBYTE_ROLE|false|USAGE]
snowflake_user.no_create_schema_privilege: Refreshing state... [id=INTEGRATION_TEST_DESTINATION_NO_CREATE_SCHEMA_PRIVILEGE]
snowflake_role_grants.no_create_schema_privilege: Refreshing state... [id=ROLE_WITHOUT_CREATE_SCHEMA_PRIVILEGE|||||false]
google_secret_manager_secret_version.destination_snowflake_no_create_schema_privilege: Refreshing state... [id=projects/708867486045/secrets/SECRET_DESTINATION_SNOWFLAKE_NO_CREATE_SCHEMA_PRIVILEGE/versions/4]
snowflake_schema_grant.ab_aschema_grant: Refreshing state... [id=AIRBYTE_DATABASE|AIRBYTE_SCHEMA|OWNERSHIP|OWNERSHIP|false|AIRBYTE_ROLE]

Terraform used the selected providers to generate the following execution plan. Resource actions are indicated with the following symbols:
  ~ update in-place

Terraform will perform the following actions:

  # snowflake_user.no_create_schema_privilege will be updated in-place
  ~ resource "snowflake_user" "no_create_schema_privilege" {
      ~ default_namespace       = "" -> "AIRBYTE_DATABASE"
        id                      = "INTEGRATION_TEST_DESTINATION_NO_CREATE_SCHEMA_PRIVILEGE"
        name                    = "INTEGRATION_TEST_DESTINATION_NO_CREATE_SCHEMA_PRIVILEGE"
        # (12 unchanged attributes hidden)
    }

Plan: 0 to add, 1 to change, 0 to destroy.

────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────

Note: You didn't use the -out option to save this plan, so Terraform can't guarantee to take exactly these actions if you run "terraform apply" now.
10:13:14 edgao:~/code/airbyte/airbyte-integrations/connectors/destination-snowflake/integration_test_infra(snowflake_test_env_terraform () U)$ terraform apply
Acquiring state lock. This may take a few moments...
random_password.password: Refreshing state... [id=none]
snowflake_role.no_create_schema_privilege: Refreshing state... [id=ROLE_WITHOUT_CREATE_SCHEMA_PRIVILEGE]
snowflake_role.airbyte: Refreshing state... [id=AIRBYTE_ROLE]
snowflake_database.airbyte_database: Refreshing state... [id=AIRBYTE_DATABASE]
snowflake_warehouse.airbyte_warehouse: Refreshing state... [id=AIRBYTE_WAREHOUSE]
google_secret_manager_secret.destination_snowflake_no_create_schema_privilege: Refreshing state... [id=projects/dataline-integration-testing/secrets/SECRET_DESTINATION_SNOWFLAKE_NO_CREATE_SCHEMA_PRIVILEGE]
snowflake_schema.no_create_schema_privilege: Refreshing state... [id=AIRBYTE_DATABASE|INTEGRATION_TEST_DESTINATION_NO_CREATE_SCHEMA_PRIVILEGE]
snowflake_database_grant.ab_db_grant: Refreshing state... [id=AIRBYTE_DATABASE|NESH_01|false|OWNERSHIP|]
snowflake_database_grant.no_create_schema_privilege: Refreshing state... [id=AIRBYTE_DATABASE|||USAGE|AIRBYTE_ROLE|false]
snowflake_role_grants.sysadmin_grants: Refreshing state... [id=AIRBYTE_ROLE|SYSADMIN|]
snowflake_schema.airbyte_schema: Refreshing state... [id=AIRBYTE_DATABASE|AIRBYTE_SCHEMA]
snowflake_warehouse_grant.ab_warehouse_grant: Refreshing state... [id=AIRBYTE_WAREHOUSE|AIRBYTE_ROLE|false|USAGE]
snowflake_user.no_create_schema_privilege: Refreshing state... [id=INTEGRATION_TEST_DESTINATION_NO_CREATE_SCHEMA_PRIVILEGE]
snowflake_schema_grant.ab_aschema_grant: Refreshing state... [id=AIRBYTE_DATABASE|AIRBYTE_SCHEMA|OWNERSHIP|OWNERSHIP|false|AIRBYTE_ROLE]
snowflake_role_grants.no_create_schema_privilege: Refreshing state... [id=ROLE_WITHOUT_CREATE_SCHEMA_PRIVILEGE|||||false]
google_secret_manager_secret_version.destination_snowflake_no_create_schema_privilege: Refreshing state... [id=projects/708867486045/secrets/SECRET_DESTINATION_SNOWFLAKE_NO_CREATE_SCHEMA_PRIVILEGE/versions/4]

Terraform used the selected providers to generate the following execution plan. Resource actions are indicated with the following symbols:
  ~ update in-place

Terraform will perform the following actions:

  # snowflake_user.no_create_schema_privilege will be updated in-place
  ~ resource "snowflake_user" "no_create_schema_privilege" {
      ~ default_namespace       = "" -> "AIRBYTE_DATABASE"
        id                      = "INTEGRATION_TEST_DESTINATION_NO_CREATE_SCHEMA_PRIVILEGE"
        name                    = "INTEGRATION_TEST_DESTINATION_NO_CREATE_SCHEMA_PRIVILEGE"
        # (12 unchanged attributes hidden)
    }

Plan: 0 to add, 1 to change, 0 to destroy.

Do you want to perform these actions?
  Terraform will perform the actions described above.
  Only 'yes' will be accepted to approve.

  Enter a value: yes

snowflake_user.no_create_schema_privilege: Modifying... [id=INTEGRATION_TEST_DESTINATION_NO_CREATE_SCHEMA_PRIVILEGE]
snowflake_user.no_create_schema_privilege: Modifications complete after 2s [id=INTEGRATION_TEST_DESTINATION_NO_CREATE_SCHEMA_PRIVILEGE]

Apply complete! Resources: 0 added, 1 changed, 0 destroyed.
```
</details>