### PR TITLE
Remove auto=bump from /publish

### DIFF
--- a/.github/workflows/publish-command.yml
+++ b/.github/workflows/publish-command.yml
@@ -16,10 +16,6 @@ on:
       comment-id:
         description: "The comment-id of the slash command. Used to update the comment with the status."
         required: false
-      auto-bump-version:
-        description: "after publishing, the workflow will automatically bump the connector version in definitions and generate seed spec"
-        required: true
-        default: "true"
       parallel:
         description: "Switching this to true will spin up 5 build agents instead of 1 and allow multi connector publishes to run in parallel"
         required: true
@@ -31,7 +27,7 @@ on:
       pre-release:
         description: "Should publish a pre-release version"
         required: true
-        default: false
+        default: "false"
 
 jobs:
   ## Gradle Build
@@ -203,7 +199,7 @@ jobs:
           body: |
             <br>
 
-            | Connector | Version | Did it publish? | Were definitions generated? |
+            | Connector | Version | Did it publish? |
       - name: Create table separator
         uses: peter-evans/create-or-update-comment@v1
         with:
@@ -259,13 +255,6 @@ jobs:
           rm -r venv || echo "no pre-existing venv"
           python3 -m virtualenv venv
           source venv/bin/activate
-      - name: Install yq
-        if: github.event.inputs.auto-bump-version == 'true' && github.event.inputs.pre-release != 'true' && success()
-        run: |
-          sudo apt-key adv --keyserver keyserver.ubuntu.com --recv-keys CC86BB64
-          sudo add-apt-repository ppa:rmescandon/yq
-          sudo apt update
-          sudo apt install yq -y
       - name: Install CI scripts
         # all CI python packages have the prefix "ci_"
         run: |
@@ -340,26 +329,6 @@ jobs:
           SENTRY_AUTH_TOKEN: ${{ secrets.SENTRY_CONNECTOR_RELEASE_AUTH_TOKEN }}
           SENTRY_ORG: airbytehq
           SENTRY_PROJECT: connector-incident-management
-      - name: Run gradle process changes
-        if: github.event.inputs.auto-bump-version == 'true' && github.event.inputs.pre-release != 'true' && success()
-        uses: Wandalen/wretry.action@master
-        with:
-          command: ./gradlew :airbyte-config-oss:init-oss:processResources
-          attempt_limit: 3
-          attempt_delay: 5000 # in ms
-      - name: git config
-        if: github.event.inputs.auto-bump-version == 'true' && success()
-        run: |
-          git config user.name 'Octavia Squidington III'
-          git config user.email 'octavia-squidington-iii@users.noreply.github.com'
-      - name: git commit and push
-        if: github.event.inputs.auto-bump-version == 'true' && github.event.inputs.pre-release != 'true' && success()
-        run: |
-          git add -u
-          git commit -m "auto-bump connector version"
-          git pull origin ${{ github.event.inputs.gitref }}
-          git push origin ${{ github.event.inputs.gitref }}
-        id: auto-bump
       - name: Process outcomes into emojis
         if: ${{ always() && github.event.inputs.comment-id }}
         run: |
@@ -368,18 +337,13 @@ jobs:
           else
             echo "PUBLISH_OUTCOME=:x:" >> $GITHUB_ENV
           fi
-          if [[ ${{ steps.auto-bump.outcome }} = "success" ]]; then
-            echo "AUTO_BUMP_OUTCOME=:white_check_mark:" >> $GITHUB_ENV
-          else
-            echo "AUTO_BUMP_OUTCOME=:x:" >> $GITHUB_ENV
-          fi
       - name: Add connector outcome line to table
         if: ${{ always() && github.event.inputs.comment-id }}
         uses: peter-evans/create-or-update-comment@v1
         with:
           comment-id: ${{ github.event.inputs.comment-id }}
           body: |
-            | ${{ matrix.connector }} | ${{ env.IMAGE_VERSION }} | ${{ env.PUBLISH_OUTCOME }} | ${{ env.AUTO_BUMP_OUTCOME }} |
+            | ${{ matrix.connector }} | ${{ env.IMAGE_VERSION }} | ${{ env.PUBLISH_OUTCOME }} |
   add-helpful-info-to-git-comment:
     if: ${{ always() && github.event.inputs.comment-id }}
     name: Add extra info to git comment

--- a/docs/connector-development/README.md
+++ b/docs/connector-development/README.md
@@ -179,7 +179,6 @@ Publishing a connector can be done using the `/publish` command as outlined in t
 * **repo** - Defaults to the main airbyte repo. Set this when building connectors from forked repos. e.g. `repo=userfork/airbyte`
 * **gitref** - Defaults to the branch of the PR where the /publish command is run as a comment. If running manually, set this to your branch where you made changes e.g. `gitref=george/s3-update`
 * **comment-id** - This is automatically filled if you run /publish from a comment and enables the workflow to write back success/fail logs to the git comment.
-* **auto-bump-version** - Defaults to true, automates the post-publish process of bumping the connector's version in the yaml seed definitions and generating spec.
 * **parallel** - Defaults to false. If set to true, a pool of runner agents will be spun up to allow publishing multiple connectors in parallel. Only switch this to true if publishing multiple connectors at once to avoid wasting $$$.
 
 ## Using credentials in CI


### PR DESCRIPTION
## What
Auto bump is no more as of the metadata.yaml migration.

You should be explicitly changing the version in the metadata.yaml file anytime you want to publish.

We are looking at bringing autobump back in the future with conventional commits.

