### PR TITLE
🐛 Source: Stripe Update invoice_items.json so period.end type matches period.start (integer)

### DIFF
--- a/airbyte-integrations/connectors/source-stripe/source_stripe/schemas/invoice_items.json
+++ b/airbyte-integrations/connectors/source-stripe/source_stripe/schemas/invoice_items.json
@@ -105,7 +105,7 @@
       "type": ["null", "object"],
       "properties": {
         "end": {
-          "type": ["null", "number"]
+          "type": ["null", "integer"]
         },
         "start": {
           "type": ["null", "integer"]


### PR DESCRIPTION
## What
In the Stripe Connector, up until about a week ago, on Airbyte cloud, these both were coming through as integer. Then the end started coming across as numeric and getting turned into scientific notation (which broke systems that were expecting integers). This aligns the two values.

## How
changes period.end from `number` to `integer`

## Recommended reading order
1. `x.java`
2. `y.python`

## 🚨 User Impact 🚨
Possibly? This is a datatype change but I am not sure if it is actually a breaking change. 



