### PR TITLE
Fix Azure Blob Storage documentation URL

### DIFF
--- a/airbyte-integrations/connectors/destination-azure-blob-storage/metadata.yaml
+++ b/airbyte-integrations/connectors/destination-azure-blob-storage/metadata.yaml
@@ -20,5 +20,5 @@ data:
         resourceRequirements:
           memory_limit: 1Gi
           memory_request: 1Gi
-  supportUrl: https://docs.airbyte.com/integrations/destinations/azureblobstorage
+  supportUrl: https://docs.airbyte.com/integrations/destinations/azure-blob-storage
 metadataSpecVersion: "1.0"


### PR DESCRIPTION
## What

Fix documentation link for azure blob storage destination, since it's breaking in app docs for this connector.