### PR TITLE
Add OSS/Cloud tags to Google Ads doc

### DIFF
--- a/docs/integrations/sources/google-ads.md
+++ b/docs/integrations/sources/google-ads.md
@@ -10,7 +10,7 @@ This page contains the setup guide and reference information for the Google Ads 
 <!-- /env:oss -->
 
 ## Setup guide
-
+<!-- env:oss -->
 ### Step 1: (For Airbyte Open Source) Apply for a developer token
 
 :::note
@@ -29,7 +29,7 @@ When you apply for a token, make sure to mention:
 - That you have full access to the server running the code (because you're self-hosting Airbyte)
 
 ### Step 2: Set up the Google Ads connector in Airbyte
-
+<!-- /env:oss -->
 <!-- env:cloud -->
 
 **For Airbyte Cloud:**
@@ -51,7 +51,6 @@ To set up Google Ads as a source in Airbyte Cloud:
 <!-- /env:cloud -->
 
 <!-- env:oss -->
-
 **For Airbyte Open Source:**
 
 To set up Google Ads as a source in Airbyte Open Source:
@@ -69,7 +68,6 @@ To set up Google Ads as a source in Airbyte Open Source:
 11. (Optional) Enter a [**Conversion Window**](https://support.google.com/google-ads/answer/3123169?hl=en).
 12. (Optional) Enter the **End Date** in YYYY-MM-DD format. The data added after this date will not be replicated.
 13. Click **Set up source**.
-<!-- /env:oss -->
 
 ## Supported sync modes
 
@@ -118,19 +116,32 @@ Due to Google Ads API constraints, the `click_view` stream retrieves data one da
 :::
 
 For incremental streams, data is synced up to the previous day using your Google Ads account time zone since Google Ads can filter data only by [date](https://developers.google.com/google-ads/api/fields/v11/ad_group_ad#segments.date) without time. Also, some reports cannot load data real-time due to Google Ads [limitations](https://support.google.com/google-ads/answer/2544985?hl=en).
+<!-- /env:oss -->
 
 ## Custom Query: Understanding Google Ads Query Language
+Additional streams for Google Ads can be dynamically created using custom queries. 
 
-:::warning
-Additional streams for Google Ads are dynamically created based on the specified Custom GAQL Queries. For an existing Google Ads source, when you are updating or removing Custom GAQL Queries, you should also ensure that any connections syncing to these streams are either disabled or have had their source schema refreshed.
-:::
+The Google Ads Query Language queries the Google Ads API. Review the [Google Ads Query Language](https://developers.google.com/google-ads/api/docs/query/overview) and the [query builder](https://developers.google.com/google-ads/api/fields/v13/query_validator) to validate your query. You can then add these as custom queries when configuring the Google Ads source.
 
-The Google Ads Query Language can query the Google Ads API. Check out [Google Ads Query Language](https://developers.google.com/google-ads/api/docs/query/overview) and the [query builder](https://developers.google.com/google-ads/api/fields/v13/query_validator). You can add these as custom queries when configuring the Google Ads source.
+Example GAQL Custom Query:
+```
+SELECT 
+    campaign.name, 
+    metrics.conversions, 
+    metrics.conversions_by_conversion_date 
+FROM ad_group
+```
+Note the segments.date is automatically added to the output, and does not need to be specified in the custom query. All custom reports will by synced by day.
 
-Each custom query in the input configuration must work for all the customer account IDs. Otherwise, the customer ID will be skipped for every query that fails the validation test. For example, if your query contains `metrics` fields in the `select` clause, it will not be executed against manager accounts.
+Each custom query in the input configuration must work for all the customer account IDs. Otherwise, the customer ID will be skipped for every query that fails the validation test. For example, if your query contains metrics fields in the select clause, it will not be executed against manager accounts.
 
 Follow Google's guidance on [Selectability between segments and metrics](https://developers.google.com/google-ads/api/docs/reporting/segmentation#selectability_between_segments_and_metrics) when editing custom queries or default stream schemas (which will also be turned into GAQL queries by the connector). Fields like `segments.keyword.info.text`, `segments.keyword.info.match_type`, `segments.keyword.ad_group_criterion` in the `SELECT` clause tell the query to only get the rows of data that have keywords and remove any row that is not associated with a keyword. This is often unobvious and undesired behavior and can lead to missing data records. If you need this field in the stream, add a new stream instead of editing the existing ones.
 
+:::info
+For an existing Google Ads source, when you are updating or removing Custom GAQL Queries, you should also subsequently refresh your source schema to pull in any changes.
+:::
+
+<!-- env:oss -->
 ## Performance considerations
 
 This source is constrained by the [Google Ads API limits](https://developers.google.com/google-ads/api/docs/best-practices/quotas)
@@ -201,3 +212,9 @@ Due to a limitation in the Google Ads API which does not allow getting performan
 | `0.1.3`  | 2021-07-23 | [4788](https://github.com/airbytehq/airbyte/pull/4788)   | Support main streams, fix bug with exception `DATE_RANGE_TOO_NARROW` for incremental streams                                         |
 | `0.1.2`  | 2021-07-06 | [4539](https://github.com/airbytehq/airbyte/pull/4539)   | Add `AIRBYTE_ENTRYPOINT` for Kubernetes support                                                                                      |
 | `0.1.1`  | 2021-06-23 | [4288](https://github.com/airbytehq/airbyte/pull/4288)   | Fix `Bugfix: Correctly declare required parameters`                                                                                  |
+
+<!-- /env:oss -->
+
+<!-- env:cloud -->
+For detailed information on supported sync modes, supported streams, performance considerations, refer to the full documentation for [Google Adwords](https://docs.airbyte.com/integrations/sources/google-ads/).
+<!-- /env:cloud -->

--- a/docs/integrations/sources/google-ads.md
+++ b/docs/integrations/sources/google-ads.md
@@ -216,5 +216,5 @@ Due to a limitation in the Google Ads API which does not allow getting performan
 <!-- /env:oss -->
 
 <!-- env:cloud -->
-For detailed information on supported sync modes, supported streams, performance considerations, refer to the full documentation for [Google Adwords](https://docs.airbyte.com/integrations/sources/google-ads/).
+For detailed information on supported sync modes, supported streams, performance considerations, refer to the full documentation for [Google Ads](https://docs.airbyte.com/integrations/sources/google-ads/).
 <!-- /env:cloud -->


### PR DESCRIPTION
## What
Edit Google Ads doc to contain OSS/Cloud tags to improve readability of the doc and focus Cloud users on the necessary setup components.
- Keeps setup guide and Custom GAQL queries in Cloud
- Removes all other sections (Supported streams, changelog)
- Adds note at bottom that full doc can be accessed by going to docs.