### PR TITLE
Fix version in run-ab-platform.sh script

### DIFF
--- a/run-ab-platform.sh
+++ b/run-ab-platform.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 
-VERSION=0.44.4
+VERSION=0.44.5
 # Run away from anything even a little scary
 set -o nounset # -u exit if a variable is not set
 set -o errexit # -f exit for any command failure"


### PR DESCRIPTION
## What

This PR manually fixes the version that gets pulled when running Airbyte with the run-ab-platform.sh script.
0.44.4 is not the latest release, https://github.com/airbytehq/airbyte-platform-internal/actions/runs/4978002525 actually released 0.44.5

This is just a stopgap measure so users will get the most recent version, we still need to fix the release process so it bumps this to the right number (the one it builds images for)