### PR TITLE
connectors-ci: fix destination-bigquery and destination-dev-null builds

### DIFF
--- a/tools/ci_connector_ops/ci_connector_ops/pipelines/gradle.py
+++ b/tools/ci_connector_ops/ci_connector_ops/pipelines/gradle.py
@@ -79,6 +79,10 @@ class GradleTask(Step, ABC):
             return [Connector(self.context.connector.technical_name.replace("-strict-encrypt", ""))]
         if self.context.connector.technical_name == "source-file-secure":
             return [Connector("source-file")]
+        if self.context.connector.technical_name == "destination-bigquery-denormalized":
+            return [Connector("destination-bigquery")]
+        if self.context.connector.technical_name == "destination-dev-null":
+            return [Connector("destination-e2e-test")]
         return []
 
     @property


### PR DESCRIPTION
* `destination-bigquery-denormalized` needs the source of `destination-bigquery` to be built
* `destination-dev-null` needs the source of `destination-e2e-test` to be built