### PR TITLE
connectors-ci: disable automated tests

### DIFF
--- a/.github/workflows/connector_integration_test_single_dagger.yml
+++ b/.github/workflows/connector_integration_test_single_dagger.yml
@@ -6,10 +6,10 @@ on:
       test-connectors-options:
         description: "Options to pass to the 'airbyte-ci connectors test' command"
         default: "--modified"
-  pull_request:
-    paths:
-      - "airbyte-integrations/connectors/**"
-      - ".github/workflows/connector_integration_test_single_dagger.yml"
+  # pull_request:
+  #   paths:
+  #     - "airbyte-integrations/connectors/**"
+  #     - ".github/workflows/connector_integration_test_single_dagger.yml"
 jobs:
   connectors_ci:
     name: Connectors CI

--- a/.github/workflows/connector_nightly_builds_dagger.yml
+++ b/.github/workflows/connector_nightly_builds_dagger.yml
@@ -1,9 +1,9 @@
 name: POC Connectors CI - nightly builds
 
 on:
-  schedule:
-    # 11AM UTC is 12AM CET, 4AM PST.
-    - cron: "0 8 * * *"
+  # schedule:
+  #   # 11AM UTC is 12AM CET, 4AM PST.
+  #   - cron: "0 8 * * *"
   workflow_dispatch:
     inputs:
       runs-on:


### PR DESCRIPTION
## What
Automated tests running on PRs or for nightly builds are currently all facing timeouts.
I disable to not clog the cluster until resolution.
