### PR TITLE
Source Mongodb: Allow disk use during discover

### DIFF
--- a/airbyte-db/db-lib/src/main/java/io/airbyte/db/mongodb/MongoUtils.java
+++ b/airbyte-db/db-lib/src/main/java/io/airbyte/db/mongodb/MongoUtils.java
@@ -296,8 +296,7 @@ public class MongoUtils {
         new Document("$limit", DISCOVER_LIMIT),
         new Document("$project", new Document("arrayofkeyvalue", new Document("$objectToArray", "$" + fieldName))),
         new Document("$unwind", "$arrayofkeyvalue"),
-        new Document("$group", new Document(ID, null).append("allkeys", new Document("$addToSet", "$arrayofkeyvalue.k")))
-    )).allowDiskUse(true);
+        new Document("$group", new Document(ID, null).append("allkeys", new Document("$addToSet", "$arrayofkeyvalue.k"))))).allowDiskUse(true);
     if (output.cursor().hasNext()) {
       return (List) output.cursor().next().get("allkeys");
     } else {
@@ -311,8 +310,8 @@ public class MongoUtils {
         new Document("$limit", DISCOVER_LIMIT),
         new Document("$project", new Document(ID, 0).append("fieldType", new Document("$type", fieldName))),
         new Document("$group", new Document(ID, new Document("fieldType", "$fieldType"))
-            .append("count", new Document("$sum", 1)))
-    )).allowDiskUse(true);
+            .append("count", new Document("$sum", 1)))))
+        .allowDiskUse(true);
     final var listOfTypes = new ArrayList<String>();
     final var cursor = output.cursor();
     while (cursor.hasNext()) {

--- a/airbyte-db/db-lib/src/main/java/io/airbyte/db/mongodb/MongoUtils.java
+++ b/airbyte-db/db-lib/src/main/java/io/airbyte/db/mongodb/MongoUtils.java
@@ -296,7 +296,8 @@ public class MongoUtils {
         new Document("$limit", DISCOVER_LIMIT),
         new Document("$project", new Document("arrayofkeyvalue", new Document("$objectToArray", "$" + fieldName))),
         new Document("$unwind", "$arrayofkeyvalue"),
-        new Document("$group", new Document(ID, null).append("allkeys", new Document("$addToSet", "$arrayofkeyvalue.k")))));
+        new Document("$group", new Document(ID, null).append("allkeys", new Document("$addToSet", "$arrayofkeyvalue.k")))
+    )).allowDiskUse(true);
     if (output.cursor().hasNext()) {
       return (List) output.cursor().next().get("allkeys");
     } else {
@@ -310,7 +311,8 @@ public class MongoUtils {
         new Document("$limit", DISCOVER_LIMIT),
         new Document("$project", new Document(ID, 0).append("fieldType", new Document("$type", fieldName))),
         new Document("$group", new Document(ID, new Document("fieldType", "$fieldType"))
-            .append("count", new Document("$sum", 1)))));
+            .append("count", new Document("$sum", 1)))
+    )).allowDiskUse(true);
     final var listOfTypes = new ArrayList<String>();
     final var cursor = output.cursor();
     while (cursor.hasNext()) {

--- a/airbyte-integrations/connectors/source-mongodb-strict-encrypt/Dockerfile
+++ b/airbyte-integrations/connectors/source-mongodb-strict-encrypt/Dockerfile
@@ -16,5 +16,5 @@ ENV APPLICATION source-mongodb-strict-encrypt
 
 COPY --from=build /airbyte /airbyte
 
-LABEL io.airbyte.version=0.1.19
+LABEL io.airbyte.version=0.1.20
 LABEL io.airbyte.name=airbyte/source-mongodb-strict-encrypt

--- a/airbyte-integrations/connectors/source-mongodb-strict-encrypt/metadata.yaml
+++ b/airbyte-integrations/connectors/source-mongodb-strict-encrypt/metadata.yaml
@@ -7,7 +7,7 @@ data:
   connectorSubtype: database
   connectorType: source
   definitionId: b2e713cd-cc36-4c0a-b5bd-b47cb8a0561e
-  dockerImageTag: 0.1.19
+  dockerImageTag: 0.1.20
   dockerRepository: airbyte/source-mongodb-strict-encrypt
   githubIssueLabel: source-mongodb-v2
   icon: mongodb.svg

--- a/airbyte-integrations/connectors/source-mongodb-v2/Dockerfile
+++ b/airbyte-integrations/connectors/source-mongodb-v2/Dockerfile
@@ -16,5 +16,5 @@ ENV APPLICATION source-mongodb-v2
 
 COPY --from=build /airbyte /airbyte
 
-LABEL io.airbyte.version=0.1.19
+LABEL io.airbyte.version=0.1.20
 LABEL io.airbyte.name=airbyte/source-mongodb-v2

--- a/airbyte-integrations/connectors/source-mongodb-v2/metadata.yaml
+++ b/airbyte-integrations/connectors/source-mongodb-v2/metadata.yaml
@@ -2,7 +2,7 @@ data:
   connectorSubtype: database
   connectorType: source
   definitionId: b2e713cd-cc36-4c0a-b5bd-b47cb8a0561e
-  dockerImageTag: 0.1.19
+  dockerImageTag: 0.1.20
   dockerRepository: airbyte/source-mongodb-v2
   githubIssueLabel: source-mongodb-v2
   icon: mongodb.svg

--- a/docs/integrations/sources/mongodb-v2.md
+++ b/docs/integrations/sources/mongodb-v2.md
@@ -102,6 +102,7 @@ For more information regarding configuration parameters, please see [MongoDb Doc
 
 | Version | Date       | Pull Request | Subject                                                                                                   |
 |:--------|:-----------| :--- |:----------------------------------------------------------------------------------------------------------|
+| 0.1.20  | 2023-05-23 | [26312](https://github.com/airbytehq/airbyte/pull/26312) | Enable disk use during discover                            |
 | 0.1.19  | 2022-10-07 | [17614](https://github.com/airbytehq/airbyte/pull/17614) | Increased discover performance                             |
 | 0.1.18  | 2022-10-05 | [17590](https://github.com/airbytehq/airbyte/pull/17590) | Add ability to enforce SSL in MongoDB connector and check logic _                                         |
 | 0.1.17  | 2022-09-08 | [16401](https://github.com/airbytehq/airbyte/pull/16401) | Fixed bug with empty strings in fields with __aibyte_transform_                                           |


### PR DESCRIPTION
for https://github.com/airbytehq/alpha-beta-issues/issues/1368

apparently we're seeing `Sort exceeded memory limit of 104857600 bytes, but did not opt in to external sorting` in some cases? https://airbytehq-team.slack.com/archives/C03GD9SV36E/p1684420394826989

which may be solved by allowing mongo to spill to disk https://mkyong.com/mongodb/mongodb-sort-exceeded-memory-limit-of-104857600-bytes/

I'm curious why we need a sort at all, but didn't really dig deep into this.