### PR TITLE
Have integration runner pass string and its size

### DIFF
--- a/airbyte-integrations/bases/base-java/src/main/java/io/airbyte/integrations/base/AirbyteMessageConsumer2.java
+++ b/airbyte-integrations/bases/base-java/src/main/java/io/airbyte/integrations/base/AirbyteMessageConsumer2.java
@@ -1,0 +1,77 @@
+/*
+ * Copyright (c) 2023 Airbyte, Inc., all rights reserved.
+ */
+
+package io.airbyte.integrations.base;
+
+import io.airbyte.commons.concurrency.VoidCallable;
+import io.airbyte.commons.functional.CheckedBiConsumer;
+import io.airbyte.protocol.models.v0.AirbyteMessage;
+
+/**
+ * Interface for the destination's consumption of incoming records wrapped in an
+ * {@link AirbyteMessage}.
+ *
+ * This is via the accept method, which commonly handles parsing, validation, batching and writing
+ * of the transformed data to the final destination i.e. the technical system data is being written
+ * to.
+ *
+ * Lifecycle:
+ * <ul>
+ * <li>1. Instantiate consumer.</li>
+ * <li>2. start() to initialize any resources that need to be created BEFORE the consumer consumes
+ * any messages.</li>
+ * <li>3. Consumes ALL records via {@link AirbyteMessageConsumer2#accept(AirbyteMessage)}</li>
+ * <li>4. Always (on success or failure) finalize by calling
+ * {@link AirbyteMessageConsumer2#close()}</li>
+ * </ul>
+ * We encourage implementing this interface using the {@link FailureTrackingAirbyteMessageConsumer}
+ * class.
+ */
+public interface AirbyteMessageConsumer2 extends CheckedBiConsumer<String, Integer, Exception>, AutoCloseable {
+
+  void start() throws Exception;
+
+  /**
+   * Consumes all {@link AirbyteMessage}s
+   *
+   * @param message {@link AirbyteMessage} to be processed
+   * @throws Exception
+   */
+  @Override
+  void accept(String message, Integer sizeInBytes) throws Exception;
+
+  /**
+   * Executes at the end of consumption of all incoming streamed data regardless of success or failure
+   *
+   * @throws Exception
+   */
+  @Override
+  void close() throws Exception;
+
+  /**
+   * Append a function to be called on {@link AirbyteMessageConsumer2#close}.
+   */
+  static AirbyteMessageConsumer2 appendOnClose(final AirbyteMessageConsumer2 consumer, final VoidCallable voidCallable) {
+    return new AirbyteMessageConsumer2() {
+
+      @Override
+      public void start() throws Exception {
+        consumer.start();
+      }
+
+      @Override
+      public void accept(final String message, final Integer sizeInBytes) throws Exception {
+        consumer.accept(message, sizeInBytes);
+      }
+
+      @Override
+      public void close() throws Exception {
+        consumer.close();
+        voidCallable.call();
+      }
+
+    };
+  }
+
+}

--- a/airbyte-integrations/bases/base-java/src/main/java/io/airbyte/integrations/base/Destination.java
+++ b/airbyte-integrations/bases/base-java/src/main/java/io/airbyte/integrations/base/Destination.java
@@ -29,6 +29,13 @@ public interface Destination extends Integration {
                                      Consumer<AirbyteMessage> outputRecordCollector)
       throws Exception;
 
+  default AirbyteMessageConsumer2 getConsumer2(final JsonNode config,
+                                               final ConfiguredAirbyteCatalog catalog,
+                                               final Consumer<AirbyteMessage> outputRecordCollector)
+      throws Exception {
+    return null;
+  }
+
   static void defaultOutputRecordCollector(final AirbyteMessage message) {
     System.out.println(Jsons.serialize(message));
   }

--- a/airbyte-integrations/bases/base-java/src/main/java/io/airbyte/integrations/base/IntegrationRunner.java
+++ b/airbyte-integrations/bases/base-java/src/main/java/io/airbyte/integrations/base/IntegrationRunner.java
@@ -22,6 +22,8 @@ import io.airbyte.protocol.models.v0.AirbyteMessage;
 import io.airbyte.protocol.models.v0.AirbyteMessage.Type;
 import io.airbyte.protocol.models.v0.ConfiguredAirbyteCatalog;
 import io.airbyte.validation.json.JsonSchemaValidator;
+import java.io.BufferedInputStream;
+import java.io.ByteArrayOutputStream;
 import java.nio.charset.StandardCharsets;
 import java.nio.file.Path;
 import java.util.List;
@@ -58,25 +60,32 @@ public class IntegrationRunner {
   private final Destination destination;
   private final Source source;
   private static JsonSchemaValidator validator;
+  private final boolean useConsumer2;
 
   public IntegrationRunner(final Destination destination) {
-    this(new IntegrationCliParser(), Destination::defaultOutputRecordCollector, destination, null);
+    this(destination, false);
+  }
+
+  public IntegrationRunner(final Destination destination, final boolean useConsumer2) {
+    this(new IntegrationCliParser(), Destination::defaultOutputRecordCollector, destination, null, useConsumer2);
   }
 
   public IntegrationRunner(final Source source) {
-    this(new IntegrationCliParser(), Destination::defaultOutputRecordCollector, null, source);
+    this(new IntegrationCliParser(), Destination::defaultOutputRecordCollector, null, source, false);
   }
 
   @VisibleForTesting
   IntegrationRunner(final IntegrationCliParser cliParser,
                     final Consumer<AirbyteMessage> outputRecordCollector,
                     final Destination destination,
-                    final Source source) {
+                    final Source source,
+                    final boolean useConsumer2) {
+    this.useConsumer2 = useConsumer2;
     Preconditions.checkState(destination != null ^ source != null, "can only pass in a destination or a source");
     this.cliParser = cliParser;
     this.outputRecordCollector = outputRecordCollector;
     // integration iface covers the commands that are the same for both source and destination.
-    this.integration = source != null ? source : destination;
+    integration = source != null ? source : destination;
     this.source = source;
     this.destination = destination;
     validator = new JsonSchemaValidator();
@@ -90,7 +99,7 @@ public class IntegrationRunner {
                     final Destination destination,
                     final Source source,
                     final JsonSchemaValidator jsonSchemaValidator) {
-    this(cliParser, outputRecordCollector, destination, source);
+    this(cliParser, outputRecordCollector, destination, source, false);
     validator = jsonSchemaValidator;
   }
 
@@ -149,8 +158,14 @@ public class IntegrationRunner {
           final ConfiguredAirbyteCatalog catalog = parseConfig(parsed.getCatalogPath(), ConfiguredAirbyteCatalog.class);
 
           final Procedure consumeWriteStreamCallable = () -> {
-            try (final AirbyteMessageConsumer consumer = destination.getConsumer(config, catalog, outputRecordCollector)) {
-              consumeWriteStream(consumer);
+            if (!useConsumer2) {
+              try (final AirbyteMessageConsumer consumer = destination.getConsumer(config, catalog, outputRecordCollector)) {
+                consumeWriteStream(consumer);
+              }
+            } else {
+              try (final AirbyteMessageConsumer2 consumer = destination.getConsumer2(config, catalog, outputRecordCollector)) {
+                consumeWriteStream2(consumer);
+              }
             }
           };
 
@@ -160,8 +175,7 @@ public class IntegrationRunner {
               INTERRUPT_THREAD_DELAY_MINUTES,
               TimeUnit.MINUTES,
               EXIT_THREAD_DELAY_MINUTES,
-              TimeUnit.MINUTES);
-        }
+              TimeUnit.MINUTES);        }
         default -> throw new IllegalStateException("Unexpected value: " + parsed.getCommand());
       }
     } catch (final Exception e) {
@@ -216,6 +230,50 @@ public class IntegrationRunner {
     while (input.hasNext()) {
       consumeMessage(consumer, input.next());
     }
+  }
+
+  @VisibleForTesting
+  static void consumeWriteStream2(final AirbyteMessageConsumer2 consumer) throws Exception {
+    try (final BufferedInputStream bis = new BufferedInputStream(System.in);
+        final ByteArrayOutputStream baos = new ByteArrayOutputStream()) {
+      consumeWriteStream2(consumer, bis, baos);
+    }
+  }
+
+  @VisibleForTesting
+  static void consumeWriteStream2(final AirbyteMessageConsumer2 consumer, final BufferedInputStream bis, final ByteArrayOutputStream baos)
+      throws Exception {
+    // try (final BufferedInputStream bis = new BufferedInputStream(System.in);
+    // final ByteArrayOutputStream baos = new ByteArrayOutputStream()) {
+
+    final byte[] buffer = new byte[8192]; // 8K buffer
+    int bytesRead;
+    int byteCount = 0;
+    boolean lastWasNewLine = false;
+
+    while ((bytesRead = bis.read(buffer)) != -1) {
+      for (int i = 0; i < bytesRead; i++) {
+        final byte b = buffer[i];
+        if (b == '\n' || b == '\r') {
+          if (!lastWasNewLine && baos.size() > 0) {
+            consumer.accept(baos.toString(StandardCharsets.UTF_8), byteCount);
+            baos.reset();
+            byteCount = 0;
+          }
+          lastWasNewLine = true;
+        } else {
+          baos.write(b);
+          byteCount++;
+          lastWasNewLine = false;
+        }
+      }
+    }
+
+    // Handle last line if there's one
+    if (baos.size() > 0) {
+      consumer.accept(baos.toString(StandardCharsets.UTF_8), byteCount);
+    }
+    // }
   }
 
   /**
@@ -289,7 +347,7 @@ public class IntegrationRunner {
    */
   @VisibleForTesting
   static void consumeMessage(final AirbyteMessageConsumer consumer, final String inputString) throws Exception {
-
+    inputString.getBytes(StandardCharsets.UTF_8);
     final Optional<AirbyteMessage> messageOptional = Jsons.tryDeserialize(inputString, AirbyteMessage.class);
     if (messageOptional.isPresent()) {
       consumer.accept(messageOptional.get());

--- a/airbyte-integrations/bases/base-java/src/main/java/io/airbyte/integrations/base/IntegrationRunner.java
+++ b/airbyte-integrations/bases/base-java/src/main/java/io/airbyte/integrations/base/IntegrationRunner.java
@@ -163,6 +163,7 @@ public class IntegrationRunner {
                 consumeWriteStream(consumer);
               }
             } else {
+              LOGGER.info("using consumer2");
               try (final AirbyteMessageConsumer2 consumer = destination.getConsumer2(config, catalog, outputRecordCollector)) {
                 consumeWriteStream2(consumer);
               }
@@ -347,7 +348,6 @@ public class IntegrationRunner {
    */
   @VisibleForTesting
   static void consumeMessage(final AirbyteMessageConsumer consumer, final String inputString) throws Exception {
-    inputString.getBytes(StandardCharsets.UTF_8);
     final Optional<AirbyteMessage> messageOptional = Jsons.tryDeserialize(inputString, AirbyteMessage.class);
     if (messageOptional.isPresent()) {
       consumer.accept(messageOptional.get());

--- a/airbyte-integrations/bases/base-java/src/main/java/io/airbyte/integrations/base/adaptive/AdaptiveDestinationRunner.java
+++ b/airbyte-integrations/bases/base-java/src/main/java/io/airbyte/integrations/base/adaptive/AdaptiveDestinationRunner.java
@@ -82,9 +82,13 @@ public class AdaptiveDestinationRunner {
     }
 
     public void run(final String[] args) throws Exception {
+      run(args, false);
+    }
+
+    public void run(final String[] args, final boolean useStringConsumer) throws Exception {
       final Destination destination = getDestination();
       LOGGER.info("Starting destination: {}", destination.getClass().getName());
-      new IntegrationRunner(destination).run(args);
+      new IntegrationRunner(destination, useStringConsumer).run(args);
       LOGGER.info("Completed destination: {}", destination.getClass().getName());
     }
 

--- a/airbyte-integrations/bases/base-java/src/test/java/io/airbyte/integrations/base/IntegrationRunner2Test.java
+++ b/airbyte-integrations/bases/base-java/src/test/java/io/airbyte/integrations/base/IntegrationRunner2Test.java
@@ -1,0 +1,83 @@
+/*
+ * Copyright (c) 2023 Airbyte, Inc., all rights reserved.
+ */
+
+package io.airbyte.integrations.base;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+import java.io.BufferedInputStream;
+import java.io.ByteArrayInputStream;
+import java.io.ByteArrayOutputStream;
+import java.io.InputStream;
+import java.nio.charset.StandardCharsets;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Scanner;
+import org.junit.jupiter.api.Test;
+
+public class IntegrationRunner2Test {
+
+  @Test
+  void testImplementations() throws Exception {
+    final String[] testInputs = new String[] {
+      "This is line 1\nThis is line 2\nThis is line 3",
+      "This is line 1\n\nThis is line 2\n\n\nThis is line 3",
+      "This is line 1\rThis is line 2\nThis is line 3\r\nThis is line 4",
+      "This is line 1 with emoji 😊\nThis is line 2 with Greek characters: Α, Β, Χ\nThis is line 3 with Cyrillic characters: Д, Ж, З",
+      "This is a very long line that contains a lot of characters...",
+      "This is line 1 with an escaped newline \\n character\nThis is line 2 with another escaped newline \\n character",
+      "This is line 1\n\n",
+      "\nThis is line 2",
+      "\n"
+    };
+
+    for (final String testInput : testInputs) {
+      // get new output
+      final InputStream stream1 = new ByteArrayInputStream(testInput.getBytes(StandardCharsets.UTF_8));
+      final MockConsumer consumer2 = new MockConsumer();
+      try (final BufferedInputStream bis = new BufferedInputStream(stream1);
+          final ByteArrayOutputStream baos = new ByteArrayOutputStream()) {
+        IntegrationRunner.consumeWriteStream2(consumer2, bis, baos);
+      }
+      final List<String> newOutput = consumer2.getOutput();
+
+      // get old output
+      final List<String> oldOutput = new ArrayList<>();
+      final InputStream stream2 = new ByteArrayInputStream(testInput.getBytes(StandardCharsets.UTF_8));
+      final Scanner scanner = new Scanner(stream2, StandardCharsets.UTF_8).useDelimiter("[\r\n]+");
+      while (scanner.hasNext()) {
+        oldOutput.add(scanner.next());
+      }
+
+      assertEquals(oldOutput, newOutput);
+    }
+  }
+
+  private static class MockConsumer implements AirbyteMessageConsumer2 {
+
+    private final List<String> output = new ArrayList<>();
+
+    @Override
+    public void start() throws Exception {
+
+    }
+
+    @Override
+    public void accept(final String message, final Integer sizeInBytes) throws Exception {
+      System.out.println("message = " + message + "sizeInBytes = " + sizeInBytes);
+      output.add(message);
+    }
+
+    @Override
+    public void close() throws Exception {
+
+    }
+
+    public List<String> getOutput() {
+      return new ArrayList<>(output);
+    }
+
+  }
+
+}


### PR DESCRIPTION
## What
* We were struggling with bad size estimates on the async snowflake destination. There's no reason we need to guess; a few a method calls before the message was serialized as a string. This PR adds a new code path to the `IntegrationRunner` that allows it to get the exact size of the message as it deserializes it to a string. It then just passes the string to the destination which let's us play with other optimizations down the road.

## How
* Add code path
* Add test to verify behavior didn't change

## Recommended reading order
1. `airbyte-integrations/bases/base-java/src/main/java/io/airbyte/integrations/base/IntegrationRunner.java`
2. `airbyte-integrations/bases/base-java/src/test/java/io/airbyte/integrations/base/IntegrationRunner2Test.java`
