### PR TITLE
Async Destination V0: Async Stream Consumer

### DIFF
--- a/airbyte-integrations/bases/base-java/src/main/java/io/airbyte/integrations/destination/buffered_stream_consumer/OnCloseFunction.java
+++ b/airbyte-integrations/bases/base-java/src/main/java/io/airbyte/integrations/destination/buffered_stream_consumer/OnCloseFunction.java
@@ -6,6 +6,10 @@ package io.airbyte.integrations.destination.buffered_stream_consumer;
 
 import io.airbyte.commons.functional.CheckedConsumer;
 
+/**
+ * Interface allowing destination to specify clean up logic that must be executed after all
+ * record-related logic has finished.
+ */
 public interface OnCloseFunction extends CheckedConsumer<Boolean, Exception> {
 
   @Override

--- a/airbyte-integrations/bases/base-java/src/main/java/io/airbyte/integrations/destination_async/AsyncStreamConsumer.java
+++ b/airbyte-integrations/bases/base-java/src/main/java/io/airbyte/integrations/destination_async/AsyncStreamConsumer.java
@@ -1,0 +1,174 @@
+/*
+ * Copyright (c) 2023 Airbyte, Inc., all rights reserved.
+ */
+
+package io.airbyte.integrations.destination_async;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import com.google.common.base.Preconditions;
+import io.airbyte.commons.functional.CheckedFunction;
+import io.airbyte.commons.json.Jsons;
+import io.airbyte.integrations.base.AirbyteMessageConsumer;
+import io.airbyte.integrations.destination.buffered_stream_consumer.OnStartFunction;
+import io.airbyte.integrations.destination_async.buffers.BufferEnqueue;
+import io.airbyte.integrations.destination_async.buffers.BufferManager;
+import io.airbyte.protocol.models.v0.AirbyteMessage;
+import io.airbyte.protocol.models.v0.AirbyteMessage.Type;
+import io.airbyte.protocol.models.v0.AirbyteStateMessage.AirbyteStateType;
+import io.airbyte.protocol.models.v0.ConfiguredAirbyteCatalog;
+import io.airbyte.protocol.models.v0.StreamDescriptor;
+import java.util.Optional;
+import java.util.Set;
+import java.util.function.Consumer;
+import lombok.extern.slf4j.Slf4j;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+/**
+ * Async version of the
+ * {@link io.airbyte.integrations.destination.buffered_stream_consumer.BufferedStreamConsumer}.
+ * <p>
+ * With this consumer, a destination is able to continue reading records until hitting the maximum
+ * memory limit governed by {@link GlobalMemoryManager}. Record writing is decoupled via
+ * {@link FlushWorkers}. See the other linked class for more detail.
+ */
+@Slf4j
+public class AsyncStreamConsumer implements AirbyteMessageConsumer {
+
+  private static final Logger LOGGER = LoggerFactory.getLogger(AsyncStreamConsumer.class);
+
+  private static final String NON_STREAM_STATE_IDENTIFIER = "GLOBAL";
+  private final Consumer<AirbyteMessage> outputRecordCollector;
+  private final OnStartFunction onStart;
+  private final OnCloseFunction onClose;
+  private final ConfiguredAirbyteCatalog catalog;
+  private final CheckedFunction<JsonNode, Boolean, Exception> isValidRecord;
+
+  private final BufferManager bufferManager;
+  private final BufferEnqueue bufferEnqueue;
+  private final FlushWorkers flushWorkers;
+  private final Set<StreamDescriptor> streamNames;
+  private final IgnoredRecordsTracker ignoredRecordsTracker;
+
+  private boolean hasStarted;
+  private boolean hasClosed;
+
+  public AsyncStreamConsumer(final Consumer<AirbyteMessage> outputRecordCollector,
+                             final OnStartFunction onStart,
+                             final OnCloseFunction onClose,
+                             final DestinationFlushFunction flusher,
+                             final ConfiguredAirbyteCatalog catalog,
+                             final CheckedFunction<JsonNode, Boolean, Exception> isValidRecord,
+                             final BufferManager bufferManager) {
+    hasStarted = false;
+    hasClosed = false;
+
+    this.outputRecordCollector = outputRecordCollector;
+    this.onStart = onStart;
+    this.onClose = onClose;
+    this.catalog = catalog;
+    this.isValidRecord = isValidRecord;
+    this.bufferManager = bufferManager;
+    this.bufferEnqueue = bufferManager.getBufferEnqueue();
+    this.flushWorkers = new FlushWorkers(this.bufferManager.getBufferDequeue(), flusher);
+    this.streamNames = StreamDescriptorUtils.fromConfiguredCatalog(catalog);
+    this.ignoredRecordsTracker = new IgnoredRecordsTracker();
+  }
+
+  @Override
+  public void start() throws Exception {
+    Preconditions.checkState(!hasStarted, "Consumer has already been started.");
+    hasStarted = true;
+
+    flushWorkers.start();
+
+    LOGGER.info("{} started.", AsyncStreamConsumer.class);
+    onStart.call();
+  }
+
+  @Override
+  public void accept(final AirbyteMessage message) throws Exception {
+    Preconditions.checkState(hasStarted, "Cannot accept records until consumer has started");
+    /*
+     * intentionally putting extractStream outside the buffer manager so that if in the future we want
+     * to try to use a threadpool to partial deserialize to get record type and stream name, we can do
+     * it without touching buffer manager.
+     */
+    extractStream(message)
+        .ifPresent(streamDescriptor -> bufferEnqueue.addRecord(streamDescriptor, message));
+  }
+
+  @Override
+  public void close() throws Exception {
+    Preconditions.checkState(hasStarted, "Cannot close; has not started.");
+    Preconditions.checkState(!hasClosed, "Has already closed.");
+    hasClosed = true;
+
+    // assume closing upload workers will flush all accepted records.
+    // we need to close the workers before closing the bufferManagers (and underlying buffers)
+    // or we risk in-memory data.
+    flushWorkers.close();
+    bufferManager.close();
+    ignoredRecordsTracker.report();
+    onClose.call();
+    LOGGER.info("{} closed.", AsyncStreamConsumer.class);
+  }
+
+  // todo (cgardens) - handle global state.
+  /**
+   * Extract the stream from the message, if the message is a record or state. Otherwise, we don't
+   * care.
+   *
+   * @param message message to extract stream from
+   * @return stream descriptor if the message is a record or state, otherwise empty. In the case of
+   *         global state messages the stream descriptor is hardcoded
+   */
+  private Optional<StreamDescriptor> extractStream(final AirbyteMessage message) {
+    if (message.getType() == Type.RECORD) {
+      final StreamDescriptor streamDescriptor = new StreamDescriptor()
+          .withNamespace(message.getRecord().getNamespace())
+          .withName(message.getRecord().getStream());
+
+      validateRecord(message, streamDescriptor);
+
+      return Optional.of(streamDescriptor);
+    } else if (message.getType() == Type.STATE) {
+      if (message.getState().getType() == AirbyteStateType.STREAM) {
+        return Optional.of(message.getState().getStream().getStreamDescriptor());
+      } else {
+        return Optional.of(new StreamDescriptor().withNamespace(NON_STREAM_STATE_IDENTIFIER).withNamespace(NON_STREAM_STATE_IDENTIFIER));
+      }
+    } else {
+      return Optional.empty();
+    }
+  }
+
+  private void validateRecord(final AirbyteMessage message, final StreamDescriptor streamDescriptor) {
+    // if stream is not part of list of streams to sync to then throw invalid stream exception
+    if (!streamNames.contains(streamDescriptor)) {
+      throwUnrecognizedStream(catalog, message);
+    }
+
+    trackerIsValidRecord(message, streamDescriptor);
+  }
+
+  private void trackerIsValidRecord(final AirbyteMessage message, final StreamDescriptor streamDescriptor) {
+    // todo (cgardens) - is valid should also move inside the tracker, but don't want to blow up more
+    // constructors right now.
+    try {
+
+      if (!isValidRecord.apply(message.getRecord().getData())) {
+        ignoredRecordsTracker.addRecord(streamDescriptor, message);
+      }
+    } catch (final Exception e) {
+      throw new RuntimeException(e);
+    }
+  }
+
+  private static void throwUnrecognizedStream(final ConfiguredAirbyteCatalog catalog, final AirbyteMessage message) {
+    throw new IllegalArgumentException(
+        String.format("Message contained record from a stream that was not in the catalog. \ncatalog: %s , \nmessage: %s",
+            Jsons.serialize(catalog), Jsons.serialize(message)));
+  }
+
+}

--- a/airbyte-integrations/bases/base-java/src/main/java/io/airbyte/integrations/destination_async/FlushWorkers.java
+++ b/airbyte-integrations/bases/base-java/src/main/java/io/airbyte/integrations/destination_async/FlushWorkers.java
@@ -28,8 +28,8 @@ import lombok.extern.slf4j.Slf4j;
  * of Destination work is IO bound.
  * <p>
  * The {@link #supervisorThread} assigns work to worker threads by looping over
- * {@link #bufferManagerDequeue} - a dequeue interface over in-memory queues of
- * {@link AirbyteMessage}. See {@link #retrieveWork()} for assignment logic.
+ * {@link #bufferDequeue} - a dequeue interface over in-memory queues of {@link AirbyteMessage}. See
+ * {@link #retrieveWork()} for assignment logic.
  * <p>
  * Within a worker thread, a worker best-effort reads a
  * {@link DestinationFlushFunction#getOptimalBatchSizeBytes()} batch from the in-memory stream and
@@ -47,12 +47,12 @@ public class FlushWorkers implements AutoCloseable {
   private static final long DEBUG_PERIOD_SECS = 10L;
   private final ScheduledExecutorService supervisorThread = Executors.newScheduledThreadPool(1);
   private final ExecutorService workerPool = Executors.newFixedThreadPool(5);
-  private final BufferDequeue bufferManagerDequeue;
+  private final BufferDequeue bufferDequeue;
   private final DestinationFlushFunction flusher;
   private final ScheduledExecutorService debugLoop = Executors.newSingleThreadScheduledExecutor();
 
-  public FlushWorkers(final BufferDequeue bufferManagerDequeue, final DestinationFlushFunction flushFunction) {
-    this.bufferManagerDequeue = bufferManagerDequeue;
+  public FlushWorkers(final BufferDequeue bufferDequeue, final DestinationFlushFunction flushFunction) {
+    this.bufferDequeue = bufferDequeue;
     flusher = flushFunction;
   }
 
@@ -80,16 +80,16 @@ public class FlushWorkers implements AutoCloseable {
     // todo (cgardens) - i'm not convinced this makes sense. as we get close to the limit, we should
     // flush more eagerly, but "flush all" is never a particularly useful thing in this world.
     // if the total size is > n, flush all buffers
-    if (bufferManagerDequeue.getTotalGlobalQueueSizeBytes() > TOTAL_QUEUES_MAX_SIZE_LIMIT_BYTES) {
+    if (bufferDequeue.getTotalGlobalQueueSizeBytes() > TOTAL_QUEUES_MAX_SIZE_LIMIT_BYTES) {
       flushAll();
     }
 
     // todo (cgardens) - build a score to prioritize which queue to flush next. e.g. if a queue is very
     // large, flush it first. if a queue has not been flushed in a while, flush it next.
     // otherwise, if each individual stream has crossed a specific threshold, flush
-    for (final StreamDescriptor stream : bufferManagerDequeue.getBufferedStreams()) {
-      final var exceedSize = bufferManagerDequeue.getQueueSizeBytes(stream).get() >= QUEUE_FLUSH_THRESHOLD;
-      final var tooLongSinceLastRecord = bufferManagerDequeue.getTimeOfLastRecord(stream)
+    for (final StreamDescriptor stream : bufferDequeue.getBufferedStreams()) {
+      final var exceedSize = bufferDequeue.getQueueSizeBytes(stream).get() >= QUEUE_FLUSH_THRESHOLD;
+      final var tooLongSinceLastRecord = bufferDequeue.getTimeOfLastRecord(stream)
           .map(time -> time.isBefore(Instant.now().minus(MAX_TIME_BETWEEN_REC_MINS, ChronoUnit.MINUTES)))
           .orElse(false);
       if (exceedSize || tooLongSinceLastRecord) {
@@ -113,7 +113,7 @@ public class FlushWorkers implements AutoCloseable {
 
   private void flushAll() {
     log.info("Flushing all buffers..");
-    for (final StreamDescriptor desc : bufferManagerDequeue.getBufferedStreams()) {
+    for (final StreamDescriptor desc : bufferDequeue.getBufferedStreams()) {
       flush(desc);
     }
   }
@@ -122,13 +122,13 @@ public class FlushWorkers implements AutoCloseable {
     workerPool.submit(() -> {
       log.info("Worker picked up work..");
       try {
-        log.info("Attempting to read from queue {}. Current queue size: {}", desc, bufferManagerDequeue.getQueueSizeInRecords(desc).get());
+        log.info("Attempting to read from queue {}. Current queue size: {}", desc, bufferDequeue.getQueueSizeInRecords(desc).get());
 
-        try (final var batch = bufferManagerDequeue.take(desc, flusher.getOptimalBatchSizeBytes())) {
+        try (final var batch = bufferDequeue.take(desc, flusher.getOptimalBatchSizeBytes())) {
           flusher.flush(desc, batch.getData());
         }
 
-        log.info("Worker finished flushing. Current queue size: {}", bufferManagerDequeue.getQueueSizeInRecords(desc));
+        log.info("Worker finished flushing. Current queue size: {}", bufferDequeue.getQueueSizeInRecords(desc));
       } catch (final Exception e) {
         throw new RuntimeException(e);
       }

--- a/airbyte-integrations/bases/base-java/src/main/java/io/airbyte/integrations/destination_async/IgnoredRecordsTracker.java
+++ b/airbyte-integrations/bases/base-java/src/main/java/io/airbyte/integrations/destination_async/IgnoredRecordsTracker.java
@@ -1,0 +1,39 @@
+/*
+ * Copyright (c) 2023 Airbyte, Inc., all rights reserved.
+ */
+
+package io.airbyte.integrations.destination_async;
+
+import com.google.common.annotations.VisibleForTesting;
+import io.airbyte.protocol.models.v0.AirbyteMessage;
+import io.airbyte.protocol.models.v0.StreamDescriptor;
+import java.util.HashMap;
+import java.util.Map;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+public class IgnoredRecordsTracker {
+
+  private static final Logger LOGGER = LoggerFactory.getLogger(IgnoredRecordsTracker.class);
+
+  private final Map<StreamDescriptor, Long> streamToIgnoredRecordCount;
+
+  public IgnoredRecordsTracker() {
+    this(new HashMap<>());
+  }
+
+  @VisibleForTesting
+  IgnoredRecordsTracker(final Map<StreamDescriptor, Long> streamToIgnoredRecordCount) {
+    this.streamToIgnoredRecordCount = streamToIgnoredRecordCount;
+  }
+
+  public void addRecord(final StreamDescriptor streamDescriptor, final AirbyteMessage recordMessage) {
+    streamToIgnoredRecordCount.put(streamDescriptor, streamToIgnoredRecordCount.getOrDefault(streamDescriptor, 0L) + 1L);
+  }
+
+  public void report() {
+    streamToIgnoredRecordCount
+        .forEach((pair, count) -> LOGGER.warn("A total of {} record(s) of data from stream {} were invalid and were ignored.", count, pair));
+  }
+
+}

--- a/airbyte-integrations/bases/base-java/src/main/java/io/airbyte/integrations/destination_async/OnCloseFunction.java
+++ b/airbyte-integrations/bases/base-java/src/main/java/io/airbyte/integrations/destination_async/OnCloseFunction.java
@@ -1,0 +1,9 @@
+/*
+ * Copyright (c) 2023 Airbyte, Inc., all rights reserved.
+ */
+
+package io.airbyte.integrations.destination_async;
+
+import io.airbyte.commons.concurrency.VoidCallable;
+
+public interface OnCloseFunction extends VoidCallable {}

--- a/airbyte-integrations/bases/base-java/src/main/java/io/airbyte/integrations/destination_async/OnCloseFunction.java
+++ b/airbyte-integrations/bases/base-java/src/main/java/io/airbyte/integrations/destination_async/OnCloseFunction.java
@@ -6,4 +6,9 @@ package io.airbyte.integrations.destination_async;
 
 import io.airbyte.commons.concurrency.VoidCallable;
 
+/**
+ * Async version of
+ * {@link io.airbyte.integrations.destination.buffered_stream_consumer.OnCloseFunction}. Separately
+ * out for easier versioning.
+ */
 public interface OnCloseFunction extends VoidCallable {}

--- a/airbyte-integrations/bases/base-java/src/main/java/io/airbyte/integrations/destination_async/StreamDescriptorUtils.java
+++ b/airbyte-integrations/bases/base-java/src/main/java/io/airbyte/integrations/destination_async/StreamDescriptorUtils.java
@@ -1,0 +1,43 @@
+/*
+ * Copyright (c) 2023 Airbyte, Inc., all rights reserved.
+ */
+
+package io.airbyte.integrations.destination_async;
+
+import io.airbyte.protocol.models.v0.AirbyteRecordMessage;
+import io.airbyte.protocol.models.v0.AirbyteStream;
+import io.airbyte.protocol.models.v0.ConfiguredAirbyteCatalog;
+import io.airbyte.protocol.models.v0.ConfiguredAirbyteStream;
+import io.airbyte.protocol.models.v0.StreamDescriptor;
+import java.util.HashSet;
+import java.util.Set;
+
+/**
+ * Boring utility functions that I don't want in my face.
+ */
+public class StreamDescriptorUtils {
+
+  public static StreamDescriptor fromRecordMessage(final AirbyteRecordMessage msg) {
+    return new StreamDescriptor().withName(msg.getStream()).withNamespace(msg.getNamespace());
+  }
+
+  public static StreamDescriptor fromAirbyteStream(final AirbyteStream stream) {
+    return new StreamDescriptor().withName(stream.getName()).withNamespace(stream.getNamespace());
+  }
+
+  public static StreamDescriptor fromConfiguredAirbyteSteam(final ConfiguredAirbyteStream stream) {
+    return fromAirbyteStream(stream.getStream());
+  }
+
+  public static Set<StreamDescriptor> fromConfiguredCatalog(final ConfiguredAirbyteCatalog catalog) {
+    final var pairs = new HashSet<StreamDescriptor>();
+
+    for (final ConfiguredAirbyteStream stream : catalog.getStreams()) {
+      final var pair = fromAirbyteStream(stream.getStream());
+      pairs.add(pair);
+    }
+
+    return pairs;
+  }
+
+}

--- a/airbyte-integrations/bases/base-java/src/main/java/io/airbyte/integrations/destination_async/StreamDescriptorUtils.java
+++ b/airbyte-integrations/bases/base-java/src/main/java/io/airbyte/integrations/destination_async/StreamDescriptorUtils.java
@@ -13,7 +13,7 @@ import java.util.HashSet;
 import java.util.Set;
 
 /**
- * Boring utility functions that I don't want in my face.
+ * Helper functions to extract {@link StreamDescriptor} from other POJOs.
  */
 public class StreamDescriptorUtils {
 


### PR DESCRIPTION
## What
Follow up after #26324 .

Introduce the AsyncStreamConsumer.

After this, one more PR to add the Staging Consumer changes in.

## How
*Describe the solution*

## Recommended reading order
1. `x.java`
2. `y.python`

## 🚨 User Impact 🚨
*Are there any breaking changes? What is the end result perceived by the user?*

*For connector PRs, use this section to explain which type of semantic versioning bump occurs as a result of the changes. Refer to our [Semantic Versioning for Connectors](https://docs.airbyte.com/contributing-to-airbyte/#semantic-versioning-for-connectors) guidelines for more information. **Breaking changes to connectors must be documented by an Airbyte engineer (PR author, or reviewer for community PRs) by using the [Breaking Change Release Playbook](https://docs.google.com/document/d/1VYQggHbL_PN0dDDu7rCyzBLGRtX-R3cpwXaY8QxEgzw/edit).***

*If there are breaking changes, please merge this PR with the 🚨🚨 emoji so changelog authors can further highlight this if needed.*


## Pre-merge Actions
*Expand the relevant checklist and delete the others.*

<details><summary><strong>New Connector</strong></summary>

### Community member or Airbyter

- **Community member?** Grant edit access to maintainers ([instructions](https://docs.github.com/en/github/collaborating-with-pull-requests/working-with-forks/allowing-changes-to-a-pull-request-branch-created-from-a-fork#enabling-repository-maintainer-permissions-on-existing-pull-requests))
- Unit & integration tests added and passing. Community members, please provide proof of success locally e.g: screenshot or copy-paste unit, integration, and acceptance test output. To run acceptance tests for a Python connector, follow instructions in the README. For java connectors run `./gradlew :airbyte-integrations:connectors:<name>:integrationTest`.
- Connector version is set to `0.0.1`
    - `Dockerfile` has version `0.0.1`
- Documentation updated
    - Connector's `README.md`
    - Connector's `bootstrap.md`. See [description and examples](https://docs.google.com/document/d/1ypdgmwmEHWv-TrO4_YOQ7pAJGVrMp5BOkEVh831N260/edit?usp=sharing)
    - `docs/integrations/<source or destination>/<name>.md` including changelog with an entry for the initial version. See changelog [example](https://docs.airbyte.io/integrations/sources/stripe#changelog)
    - `docs/integrations/README.md`

### Airbyter

If this is a community PR, the Airbyte engineer reviewing this PR is responsible for the below items.

- Create a non-forked branch based on this PR and test the below items on it
- Build is successful
- If new credentials are required for use in CI, add them to GSM. [Instructions](https://docs.airbyte.io/connector-development#using-credentials-in-ci).

</details>

<details><summary><strong>Updating a connector</strong></summary>

### Community member or Airbyter

- Grant edit access to maintainers ([instructions](https://docs.github.com/en/github/collaborating-with-pull-requests/working-with-forks/allowing-changes-to-a-pull-request-branch-created-from-a-fork#enabling-repository-maintainer-permissions-on-existing-pull-requests))
- Unit & integration tests added


### Airbyter

If this is a community PR, the Airbyte engineer reviewing this PR is responsible for the below items.

- Create a non-forked branch based on this PR and test the below items on it
- Build is successful
- If new credentials are required for use in CI, add them to GSM. [Instructions](https://docs.airbyte.io/connector-development#using-credentials-in-ci).

</details>

<details><summary><strong>Connector Generator</strong></summary>

- Issue acceptance criteria met
- PR name follows [PR naming conventions](https://docs.airbyte.com/contributing-to-airbyte/issues-and-pull-requests#pull-request-title-convention)
- If adding a new generator, add it to the [list of scaffold modules being tested](https://github.com/airbytehq/airbyte/blob/master/airbyte-integrations/connector-templates/generator/build.gradle#L41)
- The generator test modules (all connectors with `-scaffold` in their name) have been updated with the latest scaffold by running `./gradlew :airbyte-integrations:connector-templates:generator:testScaffoldTemplates` then checking in your changes
- Documentation which references the generator is updated as needed

</details>
