### PR TITLE
async destination -- introduce state

### DIFF
--- a/airbyte-integrations/bases/base-java/src/main/java/io/airbyte/integrations/destination/buffered_stream_consumer/RecordSizeEstimator.java
+++ b/airbyte-integrations/bases/base-java/src/main/java/io/airbyte/integrations/destination/buffered_stream_consumer/RecordSizeEstimator.java
@@ -34,8 +34,8 @@ public class RecordSizeEstimator {
    * determined by {@code sampleBatchSize}.
    */
   public RecordSizeEstimator(final int sampleBatchSize) {
-    this.streamRecordSizeEstimation = new HashMap<>();
-    this.streamSampleCountdown = new HashMap<>();
+    streamRecordSizeEstimation = new HashMap<>();
+    streamSampleCountdown = new HashMap<>();
     this.sampleBatchSize = sampleBatchSize;
   }
 
@@ -71,7 +71,7 @@ public class RecordSizeEstimator {
   }
 
   @VisibleForTesting
-  static long getStringByteSize(final JsonNode data) {
+  public static long getStringByteSize(final JsonNode data) {
     // assume UTF-8 encoding, and each char is 4 bytes long
     return Jsons.serialize(data).length() * 4L;
   }

--- a/airbyte-integrations/bases/base-java/src/main/java/io/airbyte/integrations/destination_async/buffers/MemoryAwareMessageBatch.java
+++ b/airbyte-integrations/bases/base-java/src/main/java/io/airbyte/integrations/destination_async/buffers/MemoryAwareMessageBatch.java
@@ -5,7 +5,11 @@
 package io.airbyte.integrations.destination_async.buffers;
 
 import io.airbyte.integrations.destination_async.GlobalMemoryManager;
+import io.airbyte.integrations.destination_async.buffers.StreamAwareQueue.Meta;
+import io.airbyte.integrations.destination_async.state.AsyncDestinationStateManager;
 import io.airbyte.protocol.models.v0.AirbyteMessage;
+import io.airbyte.protocol.models.v0.StreamDescriptor;
+import java.util.Optional;
 import java.util.stream.Stream;
 
 /**
@@ -21,24 +25,50 @@ import java.util.stream.Stream;
  */
 public class MemoryAwareMessageBatch implements AutoCloseable {
 
-  private Stream<AirbyteMessage> batch;
+  private final StreamDescriptor streamDescriptor;
+  private Stream<Meta> batch;
   private final long sizeInBytes;
   private final GlobalMemoryManager memoryManager;
+  private final AsyncDestinationStateManager stateManager;
+  private final StreamAwareQueue queue; // only here so that we can reset min queue message number.
 
-  public MemoryAwareMessageBatch(final Stream<AirbyteMessage> batch, final long sizeInBytes, final GlobalMemoryManager memoryManager) {
+  private long minMessageNum = 0;
+  private long maxMessageNum = 0;
+
+  public MemoryAwareMessageBatch(
+                                 final StreamDescriptor streamDescriptor,
+                                 final Stream<Meta> batch,
+                                 final long sizeInBytes,
+                                 final GlobalMemoryManager memoryManager,
+                                 final AsyncDestinationStateManager stateManager,
+                                 final StreamAwareQueue queue) {
+    this.streamDescriptor = streamDescriptor;
     this.batch = batch;
     this.sizeInBytes = sizeInBytes;
     this.memoryManager = memoryManager;
+    this.stateManager = stateManager;
+    this.queue = queue;
   }
 
   public Stream<AirbyteMessage> getData() {
-    return batch;
+    return batch.map(meta -> {
+      if (minMessageNum == 0) {
+        minMessageNum = meta.messageNum(); // assumes ascending.
+      }
+      maxMessageNum = meta.messageNum(); // assumes ascending.
+      return meta.message();
+    });
   }
 
   @Override
   public void close() throws Exception {
     batch = null;
     memoryManager.free(sizeInBytes);
+    queue.updateMinMessageNum();
+  }
+
+  public Optional<AirbyteMessage> getState() {
+    return stateManager.completeState(streamDescriptor, minMessageNum, maxMessageNum);
   }
 
 }

--- a/airbyte-integrations/bases/base-java/src/main/java/io/airbyte/integrations/destination_async/buffers/MemoryBoundedLinkedBlockingQueue.java
+++ b/airbyte-integrations/bases/base-java/src/main/java/io/airbyte/integrations/destination_async/buffers/MemoryBoundedLinkedBlockingQueue.java
@@ -4,12 +4,9 @@
 
 package io.airbyte.integrations.destination_async.buffers;
 
-import java.time.Instant;
-import java.util.Optional;
 import java.util.concurrent.LinkedBlockingQueue;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicLong;
-import java.util.concurrent.atomic.AtomicReference;
 import lombok.extern.slf4j.Slf4j;
 
 /**
@@ -17,7 +14,7 @@ import lombok.extern.slf4j.Slf4j;
  * bounded on number of items in the queue, it is bounded by the memory it is allowed to use. The
  * amount of memory it is allowed to use can be resized after it is instantiated.
  * <p>
- * This class intentaionally hides the underlying queue inside of it. For this class to work, it has
+ * This class intentionally hides the underlying queue inside of it. For this class to work, it has
  * to override each method on a queue that adds or removes records from the queue. The Queue
  * interface has a lot of methods to override, and we don't want to spend the time overriding a lot
  * of methods that won't be used. By hiding the queue, we avoid someone accidentally using a queue
@@ -44,16 +41,16 @@ class MemoryBoundedLinkedBlockingQueue<E> {
     this.hiddenQueue.maxMemoryUsage.addAndGet(maxMemoryUsage);
   }
 
-  public Optional<Instant> getTimeOfLastMessage() {
-    return Optional.ofNullable(hiddenQueue.timeOfLastMessage.get());
-  }
-
   public int size() {
     return hiddenQueue.size();
   }
 
   public boolean offer(final E e, final long itemSizeInBytes) {
     return hiddenQueue.offer(e, itemSizeInBytes);
+  }
+
+  public MemoryBoundedLinkedBlockingQueue.MemoryItem<E> peek() {
+    return hiddenQueue.peek();
   }
 
   public MemoryBoundedLinkedBlockingQueue.MemoryItem<E> take() throws InterruptedException {
@@ -78,12 +75,10 @@ class MemoryBoundedLinkedBlockingQueue<E> {
 
     private final AtomicLong currentMemoryUsage;
     private final AtomicLong maxMemoryUsage;
-    private final AtomicReference<Instant> timeOfLastMessage;
 
     public HiddenQueue(final long maxMemoryUsage) {
       currentMemoryUsage = new AtomicLong(0);
       this.maxMemoryUsage = new AtomicLong(maxMemoryUsage);
-      timeOfLastMessage = new AtomicReference<>(null);
     }
 
     public boolean offer(final E e, final long itemSizeInBytes) {
@@ -92,9 +87,6 @@ class MemoryBoundedLinkedBlockingQueue<E> {
         final boolean success = super.offer(new MemoryItem<>(e, itemSizeInBytes));
         if (!success) {
           currentMemoryUsage.addAndGet(-itemSizeInBytes);
-        } else {
-          // it succeeded!
-          timeOfLastMessage.set(Instant.now());
         }
         log.debug("offer status: {}", success);
         return success;

--- a/airbyte-integrations/bases/base-java/src/main/java/io/airbyte/integrations/destination_async/buffers/StreamAwareQueue.java
+++ b/airbyte-integrations/bases/base-java/src/main/java/io/airbyte/integrations/destination_async/buffers/StreamAwareQueue.java
@@ -30,12 +30,8 @@ class StreamAwareQueue {
     return memoryAwareQueue.getCurrentMemoryUsage();
   }
 
-  public long getMaxMemoryUsage() {
-    return memoryAwareQueue.getMaxMemoryUsage();
-  }
-
-  public void setMaxMemoryUsage(final long maxMemoryUsage) {
-    memoryAwareQueue.setMaxMemoryUsage(maxMemoryUsage);
+  public void addMaxMemory(final long maxMemoryUsage) {
+    memoryAwareQueue.addMaxMemory(maxMemoryUsage);
   }
 
   public Optional<Instant> getTimeOfLastMessage() {

--- a/airbyte-integrations/bases/base-java/src/main/java/io/airbyte/integrations/destination_async/buffers/StreamAwareQueue.java
+++ b/airbyte-integrations/bases/base-java/src/main/java/io/airbyte/integrations/destination_async/buffers/StreamAwareQueue.java
@@ -1,0 +1,83 @@
+/*
+ * Copyright (c) 2023 Airbyte, Inc., all rights reserved.
+ */
+
+package io.airbyte.integrations.destination_async.buffers;
+
+import io.airbyte.protocol.models.v0.AirbyteMessage;
+import java.time.Instant;
+import java.util.Optional;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicLong;
+import java.util.concurrent.atomic.AtomicReference;
+import lombok.extern.slf4j.Slf4j;
+
+@Slf4j
+class StreamAwareQueue {
+
+  private final AtomicReference<Instant> timeOfLastMessage;
+  private final AtomicLong minMessageNum;
+
+  private final MemoryBoundedLinkedBlockingQueue<Meta> memoryAwareQueue;
+
+  public StreamAwareQueue(final long maxMemoryUsage) {
+    memoryAwareQueue = new MemoryBoundedLinkedBlockingQueue<>(maxMemoryUsage);
+    timeOfLastMessage = new AtomicReference<>();
+    minMessageNum = new AtomicLong();
+  }
+
+  public long getCurrentMemoryUsage() {
+    return memoryAwareQueue.getCurrentMemoryUsage();
+  }
+
+  public long getMaxMemoryUsage() {
+    return memoryAwareQueue.getMaxMemoryUsage();
+  }
+
+  public void setMaxMemoryUsage(final long maxMemoryUsage) {
+    memoryAwareQueue.setMaxMemoryUsage(maxMemoryUsage);
+  }
+
+  public Optional<Instant> getTimeOfLastMessage() {
+    return Optional.ofNullable(timeOfLastMessage.get());
+  }
+
+  public long getMinMessageNum() {
+    return minMessageNum.get();
+  }
+
+  // todo (make sure it gets set on first write).
+  public void updateMinMessageNum() {
+    if (memoryAwareQueue.peek() != null) {
+      minMessageNum.set(memoryAwareQueue.peek().item().messageNum());
+    }
+  }
+
+  public int size() {
+    return memoryAwareQueue.size();
+  }
+
+  public boolean offer(final AirbyteMessage message, final long messageNum, final long itemSizeInBytes) {
+    if (memoryAwareQueue.offer(new Meta(message, messageNum), itemSizeInBytes)) {
+      timeOfLastMessage.set(Instant.now());
+      return true;
+    } else {
+      return false;
+    }
+  }
+
+  public MemoryBoundedLinkedBlockingQueue.MemoryItem<Meta> take() throws InterruptedException {
+    return memoryAwareQueue.take();
+  }
+
+  public MemoryBoundedLinkedBlockingQueue.MemoryItem<Meta> poll() {
+    return memoryAwareQueue.poll();
+  }
+
+  public MemoryBoundedLinkedBlockingQueue.MemoryItem<Meta> poll(final long timeout, final TimeUnit unit) throws InterruptedException {
+    return memoryAwareQueue.poll(timeout, unit);
+  }
+
+  public record Meta(AirbyteMessage message, long messageNum) {}
+
+}

--- a/airbyte-integrations/bases/base-java/src/main/java/io/airbyte/integrations/destination_async/state/AsyncDestinationStateManager.java
+++ b/airbyte-integrations/bases/base-java/src/main/java/io/airbyte/integrations/destination_async/state/AsyncDestinationStateManager.java
@@ -11,6 +11,7 @@ import java.util.HashMap;
 import java.util.Map;
 import java.util.Optional;
 
+// todo (cgardens) - hook it up to the memory manager.
 public class AsyncDestinationStateManager {
 
   private final Map<StreamDescriptor, StateLifecycle> streamToLifecycle;
@@ -47,17 +48,6 @@ public class AsyncDestinationStateManager {
   public void trackState(final AirbyteMessage message, final long messageNum) {
     setManagerStateTypeIfNotSet(message);
     getOrCreateLifecycle(extractStream(message).orElse(null)).trackState(message, messageNum);
-  }
-
-  /**
-   * Remove a state from tracking. This is helpful if a worker has picked up multiple state messages
-   * in a single batch. For the batch, we only need to emit the highest state message, so we can prune
-   * out the rest.
-   *
-   * @param message message to remove
-   */
-  public void pruneStates(final StreamDescriptor streamDescriptor, final long minMessageNum, final long maxMessageNum) {
-    getLifecycle(streamDescriptor).ifPresent(lifecycle -> lifecycle.pruneStates(minMessageNum, maxMessageNum));
   }
 
   /**

--- a/airbyte-integrations/bases/base-java/src/main/java/io/airbyte/integrations/destination_async/state/AsyncDestinationStateManager.java
+++ b/airbyte-integrations/bases/base-java/src/main/java/io/airbyte/integrations/destination_async/state/AsyncDestinationStateManager.java
@@ -1,0 +1,105 @@
+/*
+ * Copyright (c) 2023 Airbyte, Inc., all rights reserved.
+ */
+
+package io.airbyte.integrations.destination_async.state;
+
+import io.airbyte.protocol.models.v0.AirbyteMessage;
+import io.airbyte.protocol.models.v0.AirbyteStateMessage.AirbyteStateType;
+import io.airbyte.protocol.models.v0.StreamDescriptor;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.Optional;
+
+public class AsyncDestinationStateManager {
+
+  private final Map<StreamDescriptor, StateLifecycle> streamToLifecycle;
+  private AirbyteStateType stateType;
+
+  public AsyncDestinationStateManager() {
+    // todo (cgardens) - eager instantiate?
+    streamToLifecycle = new HashMap<>();
+    stateType = null;
+  }
+
+  private StateLifecycle getOrCreateLifecycle(final StreamDescriptor streamDescriptor) {
+    if (!streamToLifecycle.containsKey(streamDescriptor)) {
+      streamToLifecycle.put(streamDescriptor, new StateLifecycle());
+    }
+    return streamToLifecycle.get(streamDescriptor);
+  }
+
+  private Optional<StateLifecycle> getLifecycle(final StreamDescriptor streamDescriptor) {
+    final StreamDescriptor key = stateType == AirbyteStateType.STREAM ? streamDescriptor : null;
+
+    if (streamToLifecycle.containsKey(key)) {
+      return Optional.ofNullable(streamToLifecycle.get(key));
+    } else {
+      return Optional.empty();
+    }
+  }
+
+  /**
+   *
+   * @param streamDescriptor stream descriptor for the state. null if global state.
+   * @param message state message to track
+   */
+  public void trackState(final AirbyteMessage message, final long messageNum) {
+    setManagerStateTypeIfNotSet(message);
+    getOrCreateLifecycle(extractStream(message).orElse(null)).trackState(message, messageNum);
+  }
+
+  /**
+   * Remove a state from tracking. This is helpful if a worker has picked up multiple state messages
+   * in a single batch. For the batch, we only need to emit the highest state message, so we can prune
+   * out the rest.
+   *
+   * @param message message to remove
+   */
+  public void pruneStates(final StreamDescriptor streamDescriptor, final long minMessageNum, final long maxMessageNum) {
+    getLifecycle(streamDescriptor).ifPresent(lifecycle -> lifecycle.pruneStates(minMessageNum, maxMessageNum));
+  }
+
+  /**
+   * Marks the provided state as completed. It then returns the highest state possible. This
+   * calculated as the highest state for which itself and all the previous states have been flushed.
+   * <p>
+   * For example, if BEFORE this message was called S1: not flushed S2: flushed, S3: not flushed, and
+   * then this method is called with S3, it will return an empty optional, because even though S3 is
+   * flushed, S1 hasn't, so it's not safe to emit any states.
+   * <p>
+   * Now let's say after that method call our states now look like this. S1: not flushed S2: flushed,
+   * S3: flushed. Now, we call this method with S1 and then this method is called with S1. This method
+   * would return S3, because all the states through S3 have now been flushed.
+   *
+   * @param minMessageNum min number that was emitted by batch
+   * @param maxMessageNum max number that was emitted by batch
+   * @return highest state for which itself and all previous states have been flushed.
+   */
+  public Optional<AirbyteMessage> completeState(final StreamDescriptor streamDescriptor, final long minMessageNum, final long maxMessageNum) {
+    return getLifecycle(streamDescriptor).flatMap(lifecycle -> lifecycle.completeState(minMessageNum, maxMessageNum));
+  }
+
+  private Optional<StreamDescriptor> extractStream(final AirbyteMessage message) {
+    return Optional.of(message.getState().getStream().getStreamDescriptor());
+  }
+
+  /**
+   * If the state type for the manager is not set, sets it using the state type from the message. If
+   * the type on the message is null, we assume it is LEGACY. After the first, state message is added
+   * to the manager, the state type is set and is immutable.
+   *
+   * @param message - state message whose state will be used if internal state type is not set
+   */
+  private void setManagerStateTypeIfNotSet(final AirbyteMessage message) {
+    // detect and set state type.
+    if (stateType == null) {
+      if (message.getState().getType() == null) {
+        stateType = AirbyteStateType.LEGACY;
+      } else {
+        stateType = message.getState().getType();
+      }
+    }
+  }
+
+}

--- a/airbyte-integrations/bases/base-java/src/main/java/io/airbyte/integrations/destination_async/state/StateLifecycle.java
+++ b/airbyte-integrations/bases/base-java/src/main/java/io/airbyte/integrations/destination_async/state/StateLifecycle.java
@@ -1,0 +1,132 @@
+/*
+ * Copyright (c) 2023 Airbyte, Inc., all rights reserved.
+ */
+
+package io.airbyte.integrations.destination_async.state;
+
+import io.airbyte.protocol.models.v0.AirbyteMessage;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.NavigableMap;
+import java.util.Optional;
+import java.util.TreeMap;
+
+public class StateLifecycle {
+
+  private final Map<Long, AirbyteMessage> idToState;
+  private final Map<AirbyteMessage, Long> stateToId;
+  private final NavigableMap<Long, Boolean> stateToIsFlushed;
+
+  public StateLifecycle() {
+    idToState = new HashMap<>();
+    stateToId = new HashMap<>();
+    stateToIsFlushed = new TreeMap<>();
+  }
+
+  /**
+   * Adds a state message to be tracked. If the same state message is submitted more than once, the
+   * subsequent submissions are ignored.
+   *
+   * @param message message to track
+   * @param messageNum
+   */
+  public void trackState(final AirbyteMessage message, final long messageNum) {
+    if (!stateToId.containsKey(message)) {
+      idToState.put(messageNum, message);
+      stateToId.put(message, messageNum);
+      stateToIsFlushed.put(messageNum, false);
+    }
+  }
+
+  /**
+   * Remove a state from tracking. This is helpful if a worker has picked up multiple state messages
+   * in a single batch. For the batch, we only need to emit the highest state message, so we can prune
+   * out the rest.
+   *
+   * @param message message to remove
+   */
+  public void pruneStates(final long minMessageNum, final long maxMessageNum) {
+    for (final Long nextId : stateToIsFlushed.subMap(minMessageNum, true, maxMessageNum, true).navigableKeySet()) {
+      removeState(nextId);
+    }
+  }
+
+  private void removeState(final long id) {
+    final AirbyteMessage message = idToState.get(id);
+    stateToId.remove(message);
+    idToState.remove(id);
+    stateToIsFlushed.remove(id);
+  }
+
+  /**
+   * Marks the provided state as completed. It then returns the highest state possible. This
+   * calculated as the highest state for which itself and all the previous states have been flushed.
+   * <p>
+   * For example, if BEFORE this message was called S1: not flushed S2: flushed, S3: not flushed, and
+   * then this method is called with S3, it will return an empty optional, because even though S3 is
+   * flushed, S1 hasn't, so it's not safe to emit any states.
+   * <p>
+   * Now let's say after that method call our states now look like this. S1: not flushed S2: flushed,
+   * S3: flushed. Now, we call this method with S1 and then this method is called with S1. This method
+   * would return S3, because all the states through S3 have now been flushed.
+   *
+   * @param minMessageNum min number that was emitted by batch
+   * @param maxMessageNum max number that was emitted by batch
+   * @return highest state for which itself and all previous states have been flushed.
+   */
+  public Optional<AirbyteMessage> completeState(final long minMessageNum, final long maxMessageNum) {
+    boolean allEncountedStatesFlushed = true;
+    long bestMessageId = 0;
+    for (final Long stateId : stateToIsFlushed.navigableKeySet()) {
+
+      /*
+       * first, we make sure set all the state message in range to flushed.
+       */
+      if (stateId > minMessageNum && stateId < maxMessageNum) {
+        stateToIsFlushed.computeIfPresent(stateId, (a, b) -> true);
+      }
+
+      /*
+       * keep track of any the states we encountered along the way have NOT been flushed.
+       */
+      if (allEncountedStatesFlushed && !stateToIsFlushed.get(stateId)) {
+        allEncountedStatesFlushed = false;
+      }
+
+      /*
+       * as long as we have not encountered an unflushed state, greedily track the best state we could
+       * emit.
+       */
+      if (allEncountedStatesFlushed) {
+        bestMessageId = stateId;
+      }
+
+      /*
+       * we must keep going to the max value, after that go until we find an unflushed state. that gets us
+       * the best state in the case where batches finished out of ord.
+       */
+      if (stateId > maxMessageNum && !allEncountedStatesFlushed) {
+        break;
+      }
+    }
+
+    if (bestMessageId > 0) {
+      final AirbyteMessage airbyteMessage = idToState.get(bestMessageId);
+      removeUpTo(bestMessageId);
+      return Optional.of(airbyteMessage);
+    } else {
+      return Optional.empty();
+    }
+  }
+
+  private void removeUpTo(final long id) {
+    for (final Long nextId : stateToIsFlushed.navigableKeySet()) {
+      if (nextId <= id) {
+        removeState(id);
+      } else {
+        break;
+      }
+    }
+  }
+
+}

--- a/airbyte-integrations/bases/base-java/src/main/java/io/airbyte/integrations/destination_async/state/StateLifecycle.java
+++ b/airbyte-integrations/bases/base-java/src/main/java/io/airbyte/integrations/destination_async/state/StateLifecycle.java
@@ -121,7 +121,7 @@ public class StateLifecycle {
     for (final Long nextId : toRemove.navigableKeySet()) {
       final AirbyteMessage message = idToState.get(nextId);
       stateToId.remove(message);
-      idToState.remove(id);
+      idToState.remove(nextId);
     }
     toRemove.clear();
   }

--- a/airbyte-integrations/bases/base-java/src/test/java/io/airbyte/integrations/destination_async/AsyncStreamConsumerTest.java
+++ b/airbyte-integrations/bases/base-java/src/test/java/io/airbyte/integrations/destination_async/AsyncStreamConsumerTest.java
@@ -1,0 +1,199 @@
+/*
+ * Copyright (c) 2023 Airbyte, Inc., all rights reserved.
+ */
+
+package io.airbyte.integrations.destination_async;
+
+import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import com.google.common.collect.ImmutableMap;
+import com.google.common.collect.Lists;
+import io.airbyte.commons.functional.CheckedFunction;
+import io.airbyte.commons.json.Jsons;
+import io.airbyte.integrations.destination.buffered_stream_consumer.OnStartFunction;
+import io.airbyte.integrations.destination.buffered_stream_consumer.RecordSizeEstimator;
+import io.airbyte.integrations.destination_async.buffers.BufferManager;
+import io.airbyte.protocol.models.Field;
+import io.airbyte.protocol.models.JsonSchemaType;
+import io.airbyte.protocol.models.v0.AirbyteMessage;
+import io.airbyte.protocol.models.v0.AirbyteMessage.Type;
+import io.airbyte.protocol.models.v0.AirbyteRecordMessage;
+import io.airbyte.protocol.models.v0.AirbyteStateMessage;
+import io.airbyte.protocol.models.v0.AirbyteStateMessage.AirbyteStateType;
+import io.airbyte.protocol.models.v0.AirbyteStreamState;
+import io.airbyte.protocol.models.v0.CatalogHelpers;
+import io.airbyte.protocol.models.v0.ConfiguredAirbyteCatalog;
+import io.airbyte.protocol.models.v0.StreamDescriptor;
+import java.time.Instant;
+import java.util.Collection;
+import java.util.List;
+import java.util.function.Consumer;
+import java.util.stream.Stream;
+import org.apache.commons.lang.RandomStringUtils;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.mockito.ArgumentCaptor;
+
+class AsyncStreamConsumerTest {
+
+  private static final String SCHEMA_NAME = "public";
+  private static final String STREAM_NAME = "id_and_name";
+  private static final String STREAM_NAME2 = STREAM_NAME + 2;
+  private static final StreamDescriptor STREAM1_DESC = new StreamDescriptor()
+      .withNamespace(SCHEMA_NAME)
+      .withName(STREAM_NAME);
+
+  private static final ConfiguredAirbyteCatalog CATALOG = new ConfiguredAirbyteCatalog().withStreams(List.of(
+      CatalogHelpers.createConfiguredAirbyteStream(
+          STREAM_NAME,
+          SCHEMA_NAME,
+          Field.of("id", JsonSchemaType.NUMBER),
+          Field.of("name", JsonSchemaType.STRING)),
+      CatalogHelpers.createConfiguredAirbyteStream(
+          STREAM_NAME2,
+          SCHEMA_NAME,
+          Field.of("id", JsonSchemaType.NUMBER),
+          Field.of("name", JsonSchemaType.STRING))));
+
+  private static final AirbyteMessage STATE_MESSAGE1 = new AirbyteMessage()
+      .withType(Type.STATE)
+      .withState(new AirbyteStateMessage()
+          .withType(AirbyteStateType.STREAM)
+          .withStream(new AirbyteStreamState().withStreamDescriptor(STREAM1_DESC).withStreamState(Jsons.jsonNode(1))));
+  private static final AirbyteMessage STATE_MESSAGE2 = new AirbyteMessage()
+      .withType(Type.STATE)
+      .withState(new AirbyteStateMessage()
+          .withType(AirbyteStateType.STREAM)
+          .withStream(new AirbyteStreamState().withStreamDescriptor(STREAM1_DESC).withStreamState(Jsons.jsonNode(2))));
+
+  private AsyncStreamConsumer consumer;
+  private OnStartFunction onStart;
+  private DestinationFlushFunction flushFunction;
+  private OnCloseFunction onClose;
+  private CheckedFunction<JsonNode, Boolean, Exception> isValidRecord;
+  private Consumer<AirbyteMessage> outputRecordCollector;
+
+  @BeforeEach
+  void setup() throws Exception {
+    onStart = mock(OnStartFunction.class);
+    onClose = mock(OnCloseFunction.class);
+    flushFunction = mock(DestinationFlushFunction.class);
+    isValidRecord = mock(CheckedFunction.class);
+    outputRecordCollector = mock(Consumer.class);
+    consumer = new AsyncStreamConsumer(
+        outputRecordCollector,
+        onStart,
+        onClose,
+        flushFunction,
+        CATALOG,
+        isValidRecord,
+        new BufferManager());
+
+    when(isValidRecord.apply(any())).thenReturn(true);
+    when(flushFunction.getOptimalBatchSizeBytes()).thenReturn(10_000L);
+  }
+
+  @Test
+  void test1StreamWith1State() throws Exception {
+    final List<AirbyteMessage> expectedRecords = generateRecords(1_000);
+
+    consumer.start();
+    consumeRecords(consumer, expectedRecords);
+    consumer.accept(STATE_MESSAGE1);
+    consumer.close();
+
+    verifyStartAndClose();
+
+    verifyRecords(STREAM_NAME, SCHEMA_NAME, expectedRecords);
+
+    verify(outputRecordCollector).accept(STATE_MESSAGE1);
+  }
+
+  @Test
+  void test1StreamWith2State() throws Exception {
+    final List<AirbyteMessage> expectedRecords = generateRecords(1_000);
+
+    consumer.start();
+    consumeRecords(consumer, expectedRecords);
+    consumer.accept(STATE_MESSAGE1);
+    consumer.accept(STATE_MESSAGE2);
+    consumer.close();
+
+    verifyStartAndClose();
+
+    verifyRecords(STREAM_NAME, SCHEMA_NAME, expectedRecords);
+
+    verify(outputRecordCollector, times(1)).accept(STATE_MESSAGE2);
+  }
+
+  @Test
+  void test1StreamWith0State() throws Exception {
+    final List<AirbyteMessage> expectedRecords = generateRecords(1_000);
+
+    consumer.start();
+    consumeRecords(consumer, expectedRecords);
+    consumer.close();
+
+    verifyStartAndClose();
+
+    verifyRecords(STREAM_NAME, SCHEMA_NAME, expectedRecords);
+  }
+
+  private static void consumeRecords(final AsyncStreamConsumer consumer, final Collection<AirbyteMessage> records) {
+    records.forEach(m -> {
+      try {
+        consumer.accept(m);
+      } catch (final Exception e) {
+        throw new RuntimeException(e);
+      }
+    });
+  }
+
+  // NOTE: Generates records at chunks of 160 bytes
+  private static List<AirbyteMessage> generateRecords(final long targetSizeInBytes) {
+    final List<AirbyteMessage> output = Lists.newArrayList();
+    long bytesCounter = 0;
+    for (int i = 0;; i++) {
+      final JsonNode payload =
+          Jsons.jsonNode(ImmutableMap.of("id", RandomStringUtils.randomAlphabetic(7), "name", "human " + String.format("%8d", i)));
+      final long sizeInBytes = RecordSizeEstimator.getStringByteSize(payload);
+      bytesCounter += sizeInBytes;
+      final AirbyteMessage airbyteMessage = new AirbyteMessage()
+          .withType(Type.RECORD)
+          .withRecord(new AirbyteRecordMessage()
+              .withStream(STREAM_NAME)
+              .withNamespace(SCHEMA_NAME)
+              .withEmittedAt(Instant.now().toEpochMilli())
+              .withData(payload));
+      if (bytesCounter > targetSizeInBytes) {
+        break;
+      } else {
+        output.add(airbyteMessage);
+      }
+    }
+    return output;
+  }
+
+  private void verifyStartAndClose() throws Exception {
+    verify(onStart).call();
+    verify(onClose).call();
+  }
+
+  @SuppressWarnings("unchecked")
+  private void verifyRecords(final String streamName, final String namespace, final Collection<AirbyteMessage> expectedRecords) throws Exception {
+    final ArgumentCaptor<Stream<AirbyteMessage>> argumentCaptor = ArgumentCaptor.forClass(Stream.class);
+    verify(flushFunction).flush(
+        eq(new StreamDescriptor().withNamespace(namespace).withName(streamName)),
+        argumentCaptor.capture());
+
+    assertEquals(expectedRecords.stream().toList(), argumentCaptor.getValue().toList());
+  }
+
+}

--- a/airbyte-integrations/bases/base-java/src/test/java/io/airbyte/integrations/destination_async/buffers/BufferDequeueTest.java
+++ b/airbyte-integrations/bases/base-java/src/test/java/io/airbyte/integrations/destination_async/buffers/BufferDequeueTest.java
@@ -37,10 +37,10 @@ public class BufferDequeueTest {
       final BufferEnqueue enqueue = bufferManager.getBufferEnqueue();
       final BufferDequeue dequeue = bufferManager.getBufferDequeue();
 
-      enqueue.addRecord(STREAM_DESC, RECORD_MSG_20_BYTES);
-      enqueue.addRecord(STREAM_DESC, RECORD_MSG_20_BYTES);
-      enqueue.addRecord(STREAM_DESC, RECORD_MSG_20_BYTES);
-      enqueue.addRecord(STREAM_DESC, RECORD_MSG_20_BYTES);
+      enqueue.addRecord(STREAM_DESC, RECORD_MSG_20_BYTES, 1);
+      enqueue.addRecord(STREAM_DESC, RECORD_MSG_20_BYTES, 2);
+      enqueue.addRecord(STREAM_DESC, RECORD_MSG_20_BYTES, 3);
+      enqueue.addRecord(STREAM_DESC, RECORD_MSG_20_BYTES, 4);
 
       // total size of records is 80, so we expect 50 to get us 2 records (prefer to under-pull records
       // than over-pull).
@@ -57,9 +57,9 @@ public class BufferDequeueTest {
       final BufferEnqueue enqueue = bufferManager.getBufferEnqueue();
       final BufferDequeue dequeue = bufferManager.getBufferDequeue();
 
-      enqueue.addRecord(STREAM_DESC, RECORD_MSG_20_BYTES);
-      enqueue.addRecord(STREAM_DESC, RECORD_MSG_20_BYTES);
-      enqueue.addRecord(STREAM_DESC, RECORD_MSG_20_BYTES);
+      enqueue.addRecord(STREAM_DESC, RECORD_MSG_20_BYTES, 1);
+      enqueue.addRecord(STREAM_DESC, RECORD_MSG_20_BYTES, 2);
+      enqueue.addRecord(STREAM_DESC, RECORD_MSG_20_BYTES, 3);
 
       try (final MemoryAwareMessageBatch take = dequeue.take(STREAM_DESC, 60)) {
         assertEquals(3, take.getData().toList().size());
@@ -74,8 +74,8 @@ public class BufferDequeueTest {
       final BufferEnqueue enqueue = bufferManager.getBufferEnqueue();
       final BufferDequeue dequeue = bufferManager.getBufferDequeue();
 
-      enqueue.addRecord(STREAM_DESC, RECORD_MSG_20_BYTES);
-      enqueue.addRecord(STREAM_DESC, RECORD_MSG_20_BYTES);
+      enqueue.addRecord(STREAM_DESC, RECORD_MSG_20_BYTES, 1);
+      enqueue.addRecord(STREAM_DESC, RECORD_MSG_20_BYTES, 2);
 
       try (final MemoryAwareMessageBatch take = dequeue.take(STREAM_DESC, Long.MAX_VALUE)) {
         assertEquals(2, take.getData().toList().size());
@@ -92,11 +92,11 @@ public class BufferDequeueTest {
     final BufferEnqueue enqueue = bufferManager.getBufferEnqueue();
     final BufferDequeue dequeue = bufferManager.getBufferDequeue();
 
-    enqueue.addRecord(STREAM_DESC, RECORD_MSG_20_BYTES);
-    enqueue.addRecord(STREAM_DESC, RECORD_MSG_20_BYTES);
+    enqueue.addRecord(STREAM_DESC, RECORD_MSG_20_BYTES, 1);
+    enqueue.addRecord(STREAM_DESC, RECORD_MSG_20_BYTES, 2);
 
     final var secondStream = new StreamDescriptor().withName("stream_2");
-    enqueue.addRecord(secondStream, RECORD_MSG_20_BYTES);
+    enqueue.addRecord(secondStream, RECORD_MSG_20_BYTES, 3);
 
     assertEquals(60, dequeue.getTotalGlobalQueueSizeBytes());
 

--- a/airbyte-integrations/bases/base-java/src/test/java/io/airbyte/integrations/destination_async/buffers/BufferDequeueTest.java
+++ b/airbyte-integrations/bases/base-java/src/test/java/io/airbyte/integrations/destination_async/buffers/BufferDequeueTest.java
@@ -45,7 +45,7 @@ public class BufferDequeueTest {
       // total size of records is 80, so we expect 50 to get us 2 records (prefer to under-pull records
       // than over-pull).
       try (final MemoryAwareMessageBatch take = dequeue.take(STREAM_DESC, 50)) {
-        assertEquals(2, take.getData().toList().size());
+        assertEquals(2, take.getData().size());
       } catch (final Exception e) {
         throw new RuntimeException(e);
       }
@@ -62,7 +62,7 @@ public class BufferDequeueTest {
       enqueue.addRecord(STREAM_DESC, RECORD_MSG_20_BYTES, 3);
 
       try (final MemoryAwareMessageBatch take = dequeue.take(STREAM_DESC, 60)) {
-        assertEquals(3, take.getData().toList().size());
+        assertEquals(3, take.getData().size());
       } catch (final Exception e) {
         throw new RuntimeException(e);
       }
@@ -78,7 +78,7 @@ public class BufferDequeueTest {
       enqueue.addRecord(STREAM_DESC, RECORD_MSG_20_BYTES, 2);
 
       try (final MemoryAwareMessageBatch take = dequeue.take(STREAM_DESC, Long.MAX_VALUE)) {
-        assertEquals(2, take.getData().toList().size());
+        assertEquals(2, take.getData().size());
       } catch (final Exception e) {
         throw new RuntimeException(e);
       }

--- a/airbyte-integrations/bases/base-java/src/test/java/io/airbyte/integrations/destination_async/buffers/BufferEnqueueTest.java
+++ b/airbyte-integrations/bases/base-java/src/test/java/io/airbyte/integrations/destination_async/buffers/BufferEnqueueTest.java
@@ -5,9 +5,11 @@
 package io.airbyte.integrations.destination_async.buffers;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.mockito.Mockito.mock;
 
 import io.airbyte.commons.json.Jsons;
 import io.airbyte.integrations.destination_async.GlobalMemoryManager;
+import io.airbyte.integrations.destination_async.state.AsyncDestinationStateManager;
 import io.airbyte.protocol.models.v0.AirbyteMessage;
 import io.airbyte.protocol.models.v0.AirbyteRecordMessage;
 import io.airbyte.protocol.models.v0.StreamDescriptor;
@@ -20,7 +22,7 @@ public class BufferEnqueueTest {
   void testAddRecordShouldAdd() {
     final var twoMB = 2 * 1024 * 1024;
     final var streamToBuffer = new ConcurrentHashMap<StreamDescriptor, StreamAwareQueue>();
-    final var enqueue = new BufferEnqueue(new GlobalMemoryManager(twoMB), streamToBuffer, stateManager);
+    final var enqueue = new BufferEnqueue(new GlobalMemoryManager(twoMB), streamToBuffer, mock(AsyncDestinationStateManager.class));
 
     final var streamName = "stream";
     final var stream = new StreamDescriptor().withName(streamName);
@@ -41,7 +43,8 @@ public class BufferEnqueueTest {
     final var oneKb = 1024;
     final var initialQueueSizeBytes = 20;
     final var streamToBuffer = new ConcurrentHashMap<StreamDescriptor, StreamAwareQueue>();
-    final var enqueue = new BufferEnqueue(initialQueueSizeBytes, new GlobalMemoryManager(oneKb), streamToBuffer);
+    final var enqueue =
+        new BufferEnqueue(initialQueueSizeBytes, new GlobalMemoryManager(oneKb), streamToBuffer, mock(AsyncDestinationStateManager.class));
 
     final var streamName = "stream";
     final var stream = new StreamDescriptor().withName(streamName);

--- a/airbyte-integrations/bases/base-java/src/test/java/io/airbyte/integrations/destination_async/buffers/MemoryBoundedLinkedBlockingQueueTest.java
+++ b/airbyte-integrations/bases/base-java/src/test/java/io/airbyte/integrations/destination_async/buffers/MemoryBoundedLinkedBlockingQueueTest.java
@@ -27,28 +27,6 @@ public class MemoryBoundedLinkedBlockingQueueTest {
   }
 
   @Test
-  void test() throws InterruptedException {
-    final MemoryBoundedLinkedBlockingQueue<String> queue = new MemoryBoundedLinkedBlockingQueue<>(1024);
-
-    assertEquals(0, queue.getCurrentMemoryUsage());
-    assertNull(queue.getTimeOfLastMessage().orElse(null));
-
-    queue.offer("abc", 6);
-    queue.offer("abc", 6);
-    queue.offer("abc", 6);
-
-    assertEquals(18, queue.getCurrentMemoryUsage());
-    assertNotNull(queue.getTimeOfLastMessage().orElse(null));
-
-    queue.take();
-    queue.take();
-    queue.take();
-
-    assertEquals(0, queue.getCurrentMemoryUsage());
-    assertNotNull(queue.getTimeOfLastMessage().orElse(null));
-  }
-
-  @Test
   void testBlocksOnFullMemory() throws InterruptedException {
     final MemoryBoundedLinkedBlockingQueue<String> queue = new MemoryBoundedLinkedBlockingQueue<>(10);
     assertTrue(queue.offer("abc", 6));

--- a/airbyte-integrations/bases/base-java/src/test/java/io/airbyte/integrations/destination_async/buffers/StreamAwareQueueTest.java
+++ b/airbyte-integrations/bases/base-java/src/test/java/io/airbyte/integrations/destination_async/buffers/StreamAwareQueueTest.java
@@ -1,0 +1,38 @@
+/*
+ * Copyright (c) 2023 Airbyte, Inc., all rights reserved.
+ */
+
+package io.airbyte.integrations.destination_async.buffers;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNull;
+
+import io.airbyte.protocol.models.v0.AirbyteMessage;
+import org.junit.jupiter.api.Test;
+
+public class StreamAwareQueueTest {
+
+  @Test
+  void test() throws InterruptedException {
+    final StreamAwareQueue queue = new StreamAwareQueue(1024);
+
+    assertEquals(0, queue.getCurrentMemoryUsage());
+    assertNull(queue.getTimeOfLastMessage().orElse(null));
+
+    queue.offer(new AirbyteMessage(), 1, 6);
+    queue.offer(new AirbyteMessage(), 2, 6);
+    queue.offer(new AirbyteMessage(), 3, 6);
+
+    assertEquals(18, queue.getCurrentMemoryUsage());
+    assertNotNull(queue.getTimeOfLastMessage().orElse(null));
+
+    queue.take();
+    queue.take();
+    queue.take();
+
+    assertEquals(0, queue.getCurrentMemoryUsage());
+    assertNotNull(queue.getTimeOfLastMessage().orElse(null));
+  }
+
+}

--- a/airbyte-integrations/bases/base-java/src/test/java/io/airbyte/integrations/destination_async/state/StateLifecycleTest.java
+++ b/airbyte-integrations/bases/base-java/src/test/java/io/airbyte/integrations/destination_async/state/StateLifecycleTest.java
@@ -1,0 +1,51 @@
+/*
+ * Copyright (c) 2023 Airbyte, Inc., all rights reserved.
+ */
+
+package io.airbyte.integrations.destination_async.state;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+import io.airbyte.commons.json.Jsons;
+import io.airbyte.protocol.models.v0.AirbyteMessage;
+import io.airbyte.protocol.models.v0.AirbyteStateMessage;
+import java.util.Optional;
+import org.junit.jupiter.api.Test;
+
+class StateLifecycleTest {
+
+  @SuppressWarnings("OptionalGetWithoutIsPresent")
+  @Test
+  void testLifecycle() {
+    final StateLifecycle lifecycle = new StateLifecycle();
+
+    lifecycle.trackState(createState(100), 100);
+    lifecycle.trackState(createState(200), 200);
+    lifecycle.trackState(createState(300), 300);
+    lifecycle.trackState(createState(400), 400);
+
+    assertEquals(Optional.empty(), lifecycle.completeState(199, 301));
+
+    assertEquals(300, getStateMessageIdentifier(lifecycle.completeState(1, 150).get()));
+
+    lifecycle.trackState(createState(500), 500);
+
+    assertEquals(400, getStateMessageIdentifier(lifecycle.completeState(350, 425).get()));
+    assertEquals(500, getStateMessageIdentifier(lifecycle.completeState(450, 500).get()));
+
+    assertEquals(Optional.empty(), lifecycle.completeState(525, 550));
+  }
+
+  /*
+   * shortcut for the sake of the test to just reuse the message number as the contents of the state
+   * message to identify it.
+   */
+  private AirbyteMessage createState(final long messageNum) {
+    return new AirbyteMessage().withState(new AirbyteStateMessage().withData(Jsons.jsonNode(messageNum)));
+  }
+
+  private long getStateMessageIdentifier(final AirbyteMessage message) {
+    return message.getState().getData().asLong();
+  }
+
+}


### PR DESCRIPTION
## What
* Adds a global counter to the destination.
* Uses that to keep track of high watermarks of records that are flushed so that we can decide which state messages are safe to emit.

## Approach
only worried about per-stream right now...
* every record and state message is assigned a message #
* each state message is added into the memory manager _and_ put in the queue. 
* as we pull out of the queue we look at message numbers to determine if what state messages we can emit.

## Recommended reading order
1. `StreamAwareQueue.java` -- start here. I separate anything that isn't strictly memory management out of the memory queue and pulled it up to this level. This level of the onion is aware of streams and airbyte messages.
2. `StateLifecycle.java` -- this is where we track what state messages we have and can emit
3. `MemoryAwareMessageBatch.java` -- i'm not happy with this yet. right now there's a method here that the flusher calls to update the `StateLifecycle` and find out what state message to emit.
