### PR TITLE
Destination Performance Harness: Adds support for incremental syncs with GLOBAL state message emission

### DIFF
--- a/.github/workflows/connector-performance-command.yml
+++ b/.github/workflows/connector-performance-command.yml
@@ -27,6 +27,10 @@ on:
         description: "Number of streams to use for destination performance measurement."
         required: false
         default: "1"
+      sync-mode:
+        description: "Sync mode to use for destination performance measurement."
+        required: false
+        default: "full_refresh"
 jobs:
   uuid:
     name: "Custom UUID of workflow run"
@@ -73,7 +77,8 @@ jobs:
           comment-id: ${{ github.event.inputs.comment-id }}
           body: |
             #### Note: The following `dataset=` values are supported: `1m`<sub>(default)</sub>, `10m`, `20m`, `bottleneck_stream1`.
-            For destination performance only: you can also use `stream-numbers=N` to simulate N number of parallel streams.
+            For destinations only: you can also use `stream-numbers=N` to simulate N number of parallel streams. Additionally, 
+            `sync-mode=incremental` is supported for destinations. For example: `dataset=1m stream-numbers=2 sync-mode=incremental`
             > :runner: ${{github.event.inputs.connector}} https://github.com/${{github.repository}}/actions/runs/${{github.run_id}}.
       - name: Search for valid connector name format
         id: regex
@@ -146,6 +151,7 @@ jobs:
           CONN: ${{ github.event.inputs.connector }}
           DS: ${{ github.event.inputs.dataset }}
           STREAM_NUMBER: ${{ github.event.inputs.stream-number }}
+          SYNC_MODE: ${{ github.event.inputs.sync-mode }}
           PREFIX: '{"type":"LOG","log":{"level":"INFO","message":"INFO i.a.i.p.PerformanceTest(runTest):165'
           SUFFIX: '"}}'
           HARNESS_TYPE: ${{ steps.which-harness.outputs.harness_type }}
@@ -158,6 +164,7 @@ jobs:
           export CONNECTOR_IMAGE_NAME=${CONN/connectors/airbyte}:dev
           export DATASET=$DS
           export STREAM_NUMBER=$STREAM_NUMBER
+          export SYNC_MODE=$SYNC_MODE
           export HARNESS=$HARNESS_TYPE
           envsubst < ./tools/bin/run-harness-process.yaml | kubectl create -f -
           echo "harness is ${{ steps.which-harness.outputs.harness_type }}"

--- a/airbyte-integrations/connectors-performance/destination-harness/src/main/java/io/airbyte/integrations/destination_performance/Main.java
+++ b/airbyte-integrations/connectors-performance/destination-harness/src/main/java/io/airbyte/integrations/destination_performance/Main.java
@@ -39,7 +39,8 @@ public class Main {
     int numOfParallelStreams = 1;
     String syncMode = "full_refresh";
 
-    // TODO (ryankfu): Add a better way to parse arguments
+    // TODO (ryankfu): Add a better way to parse arguments. Take a look at {@link Clis.java} for
+    // references
     switch (args.length) {
       case 1 -> image = args[0];
       case 2 -> {

--- a/airbyte-integrations/connectors-performance/destination-harness/src/test/java/io/airbyte/integrations/destination_performance/MainTest.java
+++ b/airbyte-integrations/connectors-performance/destination-harness/src/test/java/io/airbyte/integrations/destination_performance/MainTest.java
@@ -9,49 +9,80 @@ import static org.junit.jupiter.api.Assertions.*;
 import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;
+import io.airbyte.protocol.models.DestinationSyncMode;
+import io.airbyte.protocol.models.SyncMode;
+import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;
 
 class MainTest {
 
+  private static String simpleCatalog;
+
+  @BeforeAll
+  public static void setup() {
+    simpleCatalog = """
+                      {
+                        "streams": [
+                          {
+                            "stream": {
+                              "name": "users",
+                              "namespace": "PERF_TEST_HARNESS",
+                              "json_schema": {
+                                "type": "object",
+                                "properties": {
+                                  "id": {
+                                    "type": "number",
+                                    "airbyte_type": "integer"
+                                  },
+                                  "academic_degree": {
+                                    "type": "string"
+                                  }
+                                }
+                              },
+                              "default_cursor_field": [],
+                              "supported_sync_modes": ["full_refresh", "incremental"],
+                              "source_defined_primary_key": [["id"]]
+                            },
+                            "sync_mode": "full_refresh",
+                            "primary_key": [["id"]],
+                            "cursor_field": ["updated_at"],
+                            "destination_sync_mode": "overwrite"
+                          }
+                        ]
+                      }
+                    """;
+  }
+
   @Test
   void testDuplicateStreams() throws JsonProcessingException {
-    final String simpleCatalog = """
-                                 {
-                                    "streams": [
-                                      {
-                                        "stream": {
-                                          "name": "users",
-                                          "namespace": "PERF_TEST_HARNESS",
-                                          "json_schema": {
-                                            "type": "object",
-                                            "properties": {
-                                              "id": {
-                                                "type": "number",
-                                                "airbyte_type": "integer"
-                                              },
-                                              "academic_degree": {
-                                                "type": "string"
-                                              }
-                                            }
-                                          },
-                                          "default_cursor_field": [],
-                                          "supported_sync_modes": ["full_refresh", "incremental"],
-                                          "source_defined_primary_key": [["id"]]
-                                        },
-                                        "sync_mode": "full_refresh",
-                                        "primary_key": [["id"]],
-                                        "cursor_field": ["updated_at"],
-                                        "destination_sync_mode": "overwrite"
-                                      }
-                                    ]
-                                  }
-                                 """;
     final ObjectMapper objectMapper = new ObjectMapper();
     final JsonNode root = objectMapper.readTree(simpleCatalog);
+    final JsonNode duplicateRoot = root.deepCopy();
     final int duplicateFactor = 10;
-    Main.duplicateStreams(root, duplicateFactor);
-    assertEquals(duplicateFactor, root.get("streams").size());
-    assertEquals("users9", root.path("streams").get(9).path("stream").path("name").asText());
+    Main.duplicateStreams(duplicateRoot, duplicateFactor);
+    assertEquals(duplicateFactor, duplicateRoot.get("streams").size());
+    assertEquals("users9", duplicateRoot.path("streams").get(9).path("stream").path("name").asText());
+  }
+
+  @Test
+  void testUpdateSyncModeIncrementalAppend() throws JsonProcessingException {
+    final ObjectMapper objectMapper = new ObjectMapper();
+    final JsonNode root = objectMapper.readTree(simpleCatalog);
+    final JsonNode duplicateRoot = root.deepCopy();
+    Main.updateSyncMode(duplicateRoot, "incremental");
+    assertEquals(SyncMode.INCREMENTAL.toString(), duplicateRoot.path("streams").get(0).path("sync_mode").asText());
+    assertEquals(DestinationSyncMode.APPEND.toString(), duplicateRoot.path("streams").get(0).path("destination_sync_mode").asText());
+  }
+
+  @Test
+  void testUpdateSyncModeFullRefreshNoop() throws JsonProcessingException {
+    // expects a no-op when updating sync mode to full_refresh
+    final ObjectMapper objectMapper = new ObjectMapper();
+    final JsonNode root = objectMapper.readTree(simpleCatalog);
+    final JsonNode duplicateRoot = root.deepCopy();
+    Main.updateSyncMode(duplicateRoot, "full_refresh");
+    assertEquals(SyncMode.FULL_REFRESH.toString(), duplicateRoot.path("streams").get(0).path("sync_mode").asText());
+    assertEquals(DestinationSyncMode.OVERWRITE.toString(), duplicateRoot.path("streams").get(0).path("destination_sync_mode").asText());
   }
 
 }

--- a/airbyte-integrations/connectors-performance/source-harness/src/main/java/io/airbyte/integrations/source_performance/Main.java
+++ b/airbyte-integrations/connectors-performance/source-harness/src/main/java/io/airbyte/integrations/source_performance/Main.java
@@ -25,12 +25,27 @@ public class Main {
     log.info("args: {}", Arrays.toString(args));
     String image = null;
     String dataset = "1m";
+    // TODO: (ryankfu) add function parity with destination_performance
+    int numOfParallelStreams = 1;
+    String syncMode = "full_refresh";
 
+    // TODO: (ryankfu) Integrated something akin to {@link Clis} for parsing arguments.
     switch (args.length) {
       case 1 -> image = args[0];
       case 2 -> {
         image = args[0];
         dataset = args[1];
+      }
+      case 3 -> {
+        image = args[0];
+        dataset = args[1];
+        numOfParallelStreams = Integer.parseInt(args[2]);
+      }
+      case 4 -> {
+        image = args[0];
+        dataset = args[1];
+        numOfParallelStreams = Integer.parseInt(args[2]);
+        syncMode = args[3];
       }
       default -> {
         log.info("unexpected arguments");

--- a/airbyte-integrations/connectors/source-mysql/src/main/java/io/airbyte/integrations/source/mysql/MySqlSource.java
+++ b/airbyte-integrations/connectors/source-mysql/src/main/java/io/airbyte/integrations/source/mysql/MySqlSource.java
@@ -393,7 +393,7 @@ public class MySqlSource extends AbstractJdbcSource<MysqlType> implements Source
 
   @Override
   public JdbcDatabase createDatabase(final JsonNode sourceConfig) throws SQLException {
-//    return super.createDatabase(sourceConfig, this::getConnectionProperties);
+    // return super.createDatabase(sourceConfig, this::getConnectionProperties);
     final JsonNode jdbcConfig = toDatabaseConfig(sourceConfig);
     // Create the data source
     final DataSource dataSource = DataSourceFactory.create(
@@ -419,7 +419,8 @@ public class MySqlSource extends AbstractJdbcSource<MysqlType> implements Source
   public Map<String, String> getConnectionProperties(final JsonNode config) {
     final Map<String, String> customProperties =
         config.has(JdbcUtils.JDBC_URL_PARAMS_KEY)
-            ? parseJdbcParameters(config.get(JdbcUtils.JDBC_URL_PARAMS_KEY).asText(), DEFAULT_JDBC_PARAMETERS_DELIMITER) : new HashMap<>();
+            ? parseJdbcParameters(config.get(JdbcUtils.JDBC_URL_PARAMS_KEY).asText(), DEFAULT_JDBC_PARAMETERS_DELIMITER)
+            : new HashMap<>();
     final Map<String, String> defaultProperties = JdbcDataSourceUtils.getDefaultConnectionProperties(config);
     assertCustomParametersDontOverwriteDefaultParameters(customProperties, defaultProperties);
     return MoreMaps.merge(customProperties, defaultProperties);

--- a/airbyte-integrations/connectors/source-mysql/src/test/java/io/airbyte/integrations/source/mysql/MySqlSourceTests.java
+++ b/airbyte-integrations/connectors/source-mysql/src/test/java/io/airbyte/integrations/source/mysql/MySqlSourceTests.java
@@ -195,10 +195,10 @@ public class MySqlSourceTests {
 
   }
 
-
   @Test
   void testParseJdbcParameters() {
-    Map<String, String> parameters = MySqlSource.parseJdbcParameters("theAnswerToLiveAndEverything=42&sessionVariables=max_execution_time=10000&foo=bar", "&");
+    Map<String, String> parameters =
+        MySqlSource.parseJdbcParameters("theAnswerToLiveAndEverything=42&sessionVariables=max_execution_time=10000&foo=bar", "&");
     assertEquals("max_execution_time=10000", parameters.get("sessionVariables"));
     assertEquals("42", parameters.get("theAnswerToLiveAndEverything"));
     assertEquals("bar", parameters.get("foo"));
@@ -229,4 +229,5 @@ public class MySqlSourceTests {
       assertEquals(AirbyteConnectionStatus.Status.SUCCEEDED, check.getStatus());
     }
   }
+
 }

--- a/tools/bin/run-harness-process.yaml
+++ b/tools/bin/run-harness-process.yaml
@@ -8,7 +8,7 @@ spec:
   containers:
   - name: main
     image: airbyte/$HARNESS:dev
-    args: ["$CONNECTOR_IMAGE_NAME", "$DATASET", "$STREAM_NUMBER"]
+    args: ["$CONNECTOR_IMAGE_NAME", "$DATASET", "$STREAM_NUMBER", "$SYNC_MODE"]
     volumeMounts:
       - name: secrets-volume
         mountPath: /airbyte/secrets


### PR DESCRIPTION
## What
Adds support for modifying `sync_mode` and `destination_sync_mode` within the ConfiguredCatalog. Additionally adds support for sending a STATE message every 10k records

Next Steps:
- Add in logic to clean up the destination's table after sync because it will not be cleared up automatically

## How
Adds a new configurable property to GitHub Actions that updates the sync_mode depending on `INCREMENTAL` or `FULL_REFRESH`, tests to confirm the ConfiguredCatalog is being modified as expected

## Recommended reading order
1. `Main.java`
2. `PerformanceHarness.java`
3. `MainTest.java`
4. `run-harness-process.yaml`
5. `connector-performance-command.yml`

## 🚨 User Impact 🚨
*Are there any breaking changes? What is the end result perceived by the user?*

*For connector PRs, use this section to explain which type of semantic versioning bump occurs as a result of the changes. Refer to our [Semantic Versioning for Connectors](https://docs.airbyte.com/contributing-to-airbyte/#semantic-versioning-for-connectors) guidelines for more information. **Breaking changes to connectors must be documented by an Airbyte engineer (PR author, or reviewer for community PRs) by using the [Breaking Change Release Playbook](https://docs.google.com/document/d/1VYQggHbL_PN0dDDu7rCyzBLGRtX-R3cpwXaY8QxEgzw/edit).***

*If there are breaking changes, please merge this PR with the 🚨🚨 emoji so changelog authors can further highlight this if needed.*


## Pre-merge Actions
*Expand the relevant checklist and delete the others.*

<details><summary><strong>New Connector</strong></summary>

### Community member or Airbyter

- **Community member?** Grant edit access to maintainers ([instructions](https://docs.github.com/en/github/collaborating-with-pull-requests/working-with-forks/allowing-changes-to-a-pull-request-branch-created-from-a-fork#enabling-repository-maintainer-permissions-on-existing-pull-requests))
- Unit & integration tests added and passing. Community members, please provide proof of success locally e.g: screenshot or copy-paste unit, integration, and acceptance test output. To run acceptance tests for a Python connector, follow instructions in the README. For java connectors run `./gradlew :airbyte-integrations:connectors:<name>:integrationTest`.
- Connector version is set to `0.0.1`
    - `Dockerfile` has version `0.0.1`
- Documentation updated
    - Connector's `README.md`
    - Connector's `bootstrap.md`. See [description and examples](https://docs.google.com/document/d/1ypdgmwmEHWv-TrO4_YOQ7pAJGVrMp5BOkEVh831N260/edit?usp=sharing)
    - `docs/integrations/<source or destination>/<name>.md` including changelog with an entry for the initial version. See changelog [example](https://docs.airbyte.io/integrations/sources/stripe#changelog)
    - `docs/integrations/README.md`

### Airbyter

If this is a community PR, the Airbyte engineer reviewing this PR is responsible for the below items.

- Create a non-forked branch based on this PR and test the below items on it
- Build is successful
- If new credentials are required for use in CI, add them to GSM. [Instructions](https://docs.airbyte.io/connector-development#using-credentials-in-ci).

</details>

<details><summary><strong>Updating a connector</strong></summary>

### Community member or Airbyter

- Grant edit access to maintainers ([instructions](https://docs.github.com/en/github/collaborating-with-pull-requests/working-with-forks/allowing-changes-to-a-pull-request-branch-created-from-a-fork#enabling-repository-maintainer-permissions-on-existing-pull-requests))
- Unit & integration tests added


### Airbyter

If this is a community PR, the Airbyte engineer reviewing this PR is responsible for the below items.

- Create a non-forked branch based on this PR and test the below items on it
- Build is successful
- If new credentials are required for use in CI, add them to GSM. [Instructions](https://docs.airbyte.io/connector-development#using-credentials-in-ci).

</details>

<details><summary><strong>Connector Generator</strong></summary>

- Issue acceptance criteria met
- PR name follows [PR naming conventions](https://docs.airbyte.com/contributing-to-airbyte/issues-and-pull-requests#pull-request-title-convention)
- If adding a new generator, add it to the [list of scaffold modules being tested](https://github.com/airbytehq/airbyte/blob/master/airbyte-integrations/connector-templates/generator/build.gradle#L41)
- The generator test modules (all connectors with `-scaffold` in their name) have been updated with the latest scaffold by running `./gradlew :airbyte-integrations:connector-templates:generator:testScaffoldTemplates` then checking in your changes
- Documentation which references the generator is updated as needed

</details>
