### PR TITLE
airbyte-ci: add `connectors list` command

### DIFF
--- a/tools/ci_connector_ops/ci_connector_ops/pipelines/README.md
+++ b/tools/ci_connector_ops/ci_connector_ops/pipelines/README.md
@@ -31,6 +31,7 @@ N.B: This project will eventually be moved to `airbyte-ci` root directory.
   * [Options](#options)
 - [`connectors` command subgroup](#connectors-command-subgroup)
   * [Options](#options-1)
+- [`connectors list` command](#connectors-list-command)
 - [`connectors test` command](#connectors-test-command)
   * [Examples](#examples-)
   * [What it runs](#what-it-runs-)
@@ -87,6 +88,30 @@ Available commands:
 | `--language`           | True     |               | Select connectors with a specific language: `python`, `low-code`, `java`. Can be used multiple times to select multiple languages.                                                                                                                                                                    |
 | `--modified`           | False    | False         | Run the pipeline on only the modified connectors on the branch or previous commit (depends on the pipeline implementation).                                                                                                                                                                           |
 | `--concurrency`        | False    | 5             | Control the number of connector pipelines that can run in parallel. Useful to speed up pipelines or control their resource usage.                                                                                                                                                                     |
+
+### <a id="connectors-list-command"></a>`connectors list` command
+Retrieve the list of connectors satisfying the provided filters.
+
+#### Examples
+List all connectors:
+
+`airbyte-ci connectors list`
+
+List generally available connectors:
+
+`airbyte-ci connectors --release-stage=generally_available list`
+
+List connectors changed on the current branch:
+
+`airbyte-ci connectors --modified list`
+
+List connectors with a specific language:
+
+`airbyte-ci connectors --language=python list`
+
+List connectors with multiple filters:
+
+`airbyte-ci connectors --language=low-code --release-stage=generally_available list`
 
 ### <a id="connectors-test-command"></a>`connectors test` command
 Run a test pipeline for one or multiple connectors.

--- a/tools/ci_connector_ops/ci_connector_ops/pipelines/commands/groups/connectors.py
+++ b/tools/ci_connector_ops/ci_connector_ops/pipelines/commands/groups/connectors.py
@@ -20,8 +20,10 @@ from ci_connector_ops.pipelines.pipelines.connectors import run_connectors_pipel
 from ci_connector_ops.pipelines.publish import run_connector_publish_pipeline
 from ci_connector_ops.pipelines.tests import run_connector_test_pipeline
 from ci_connector_ops.pipelines.utils import DaggerPipelineCommand, get_modified_connectors, get_modified_metadata_files
-from ci_connector_ops.utils import ConnectorLanguage, get_all_released_connectors
+from ci_connector_ops.utils import ConnectorLanguage, console, get_all_released_connectors
 from rich.logging import RichHandler
+from rich.table import Table
+from rich.text import Text
 
 # CONSTANTS
 
@@ -374,3 +376,36 @@ def validate_publish_options(pre_release: bool, context_object: Dict[str, Any]):
     for k in ["spec_cache_bucket_name", "spec_cache_gcs_credentials", "metadata_service_bucket_name", "metadata_service_gcs_credentials"]:
         if not pre_release and context_object.get(k) is None:
             click.Abort(f'The --{k.replace("_", "-")} option is required when running a main release publish pipeline.')
+
+
+@connectors.command(cls=DaggerPipelineCommand, help="List all selected connectors.")
+@click.pass_context
+def list(
+    ctx: click.Context,
+):
+    selected_connectors = [
+        (connector, bool(modified_files))
+        for connector, modified_files in ctx.obj["selected_connectors_and_files"].items()
+        if connector.metadata
+    ]
+
+    selected_connectors = sorted(selected_connectors, key=lambda x: x[0].technical_name)
+    table = Table(title=f"{len(selected_connectors)} selected connectors")
+    table.add_column("Modified")
+    table.add_column("Connector")
+    table.add_column("Language")
+    table.add_column("Release stage")
+    table.add_column("Version")
+    table.add_column("Folder")
+
+    for connector, modified in selected_connectors:
+        modified = "X" if modified else ""
+        connector_name = Text(connector.technical_name)
+        language = Text(connector.language.value)
+        release_stage = Text(connector.release_stage)
+        version = Text(connector.version)
+        folder = Text(str(connector.code_directory))
+        table.add_row(modified, connector_name, language, release_stage, version, folder)
+
+    console.print(table)
+    return True

--- a/tools/ci_connector_ops/ci_connector_ops/pipelines/commands/groups/connectors.py
+++ b/tools/ci_connector_ops/ci_connector_ops/pipelines/commands/groups/connectors.py
@@ -401,7 +401,7 @@ def list(
     for connector, modified in selected_connectors:
         modified = "X" if modified else ""
         connector_name = Text(connector.technical_name)
-        language = Text(connector.language.value)
+        language = Text(connector.language.value) if connector.language else "N/A"
         release_stage = Text(connector.release_stage)
         version = Text(connector.version)
         folder = Text(str(connector.code_directory))


### PR DESCRIPTION
## What
I figured it'd be convenient to add a command to list the connectors matching the filters provided to the `connectors` command group.

## Example
When running: `airbyte-ci connectors --language=low-code --release-stage=generally_available list`
<img width="900" alt="Screen Shot 2023-05-24 at 17 07 30" src="https://github.com/airbytehq/airbyte/assets/5551758/de7680af-cd2b-4509-8319-f5429284d594">

