### PR TITLE
amazon seller partner: Update setup instructions

### DIFF
--- a/docs/integrations/sources/amazon-seller-partner.md
+++ b/docs/integrations/sources/amazon-seller-partner.md
@@ -17,8 +17,10 @@ This page guides you through the process of setting up the Amazon Seller Partner
 
 ## Step 1: Set up Amazon Seller Partner
 
-[Register](https://developer-docs.amazon.com/sp-api/docs/registering-your-application) Amazon Seller Partner application.
-[Create](https://docs.aws.amazon.com/general/latest/gr/aws-sec-cred-types.html) IAM user.
+1. [Register](https://developer-docs.amazon.com/sp-api/docs/registering-your-application) Amazon Seller Partner application.
+    - The application must be published as Amazon does not allow external parties such as Airbyte to access draft applications.
+    - If using the connector on Airbyte Cloud, the Redirect URL must be set to `https://cloud.airbyte.com/auth_flow`
+2. [Create](https://docs.aws.amazon.com/general/latest/gr/aws-sec-cred-types.html) IAM user.
 
 ## Step 2: Set up the source connector in Airbyte
 


### PR DESCRIPTION
## What
* The Amazon Seller Partner connector requires setup that is not mentioned in the docs.
 * [The customer's application cannot be a draft](https://developer-docs.amazon.com/sp-api/docs/application-authorization-limits)
 * If using cloud, the redirect URL must be set to https://cloud.airbyte.com/auth_flow
* There is a need for a follow up issue to better understand why the customers need to create their own app instead of using Airbyte's like most connectors do

## How
* Update the docs

## 🚨 User Impact 🚨
* Instructions are updated