### PR TITLE
Async Destination: Error Handling

### DIFF
--- a/airbyte-integrations/bases/base-java/src/main/java/io/airbyte/integrations/destination_async/AsyncStreamConsumer.java
+++ b/airbyte-integrations/bases/base-java/src/main/java/io/airbyte/integrations/destination_async/AsyncStreamConsumer.java
@@ -134,7 +134,6 @@ public class AsyncStreamConsumer implements AirbyteMessageConsumer {
 
   private void propagateFlushWorkerExceptionIfPresent() throws Exception {
     if (flushFailure.isFailed()) {
-      System.out.println(" +++++ propagating flush worker exception");
       throw flushFailure.getException();
     }
   }

--- a/airbyte-integrations/bases/base-java/src/main/java/io/airbyte/integrations/destination_async/AsyncStreamConsumer.java
+++ b/airbyte-integrations/bases/base-java/src/main/java/io/airbyte/integrations/destination_async/AsyncStreamConsumer.java
@@ -124,11 +124,13 @@ public class AsyncStreamConsumer implements AirbyteMessageConsumer {
     // we need to close the workers before closing the bufferManagers (and underlying buffers)
     // or we risk in-memory data.
     flushWorkers.close();
-    propagateFlushWorkerExceptionIfPresent();
 
     bufferManager.close();
     ignoredRecordsTracker.report();
     onClose.call();
+    
+    // as this throws an exception, we need to be after all other close functions.
+    propagateFlushWorkerExceptionIfPresent();
     LOGGER.info("{} closed.", AsyncStreamConsumer.class);
   }
 

--- a/airbyte-integrations/bases/base-java/src/main/java/io/airbyte/integrations/destination_async/state/FlushFailure.java
+++ b/airbyte-integrations/bases/base-java/src/main/java/io/airbyte/integrations/destination_async/state/FlushFailure.java
@@ -18,8 +18,8 @@ public class FlushFailure {
     this.exceptionAtomicReference.set(e);
   }
 
-  public AtomicBoolean isFailed() {
-    return isFailed;
+  public boolean isFailed() {
+    return isFailed.get();
   }
 
   public Exception getException() {

--- a/airbyte-integrations/bases/base-java/src/main/java/io/airbyte/integrations/destination_async/state/FlushFailure.java
+++ b/airbyte-integrations/bases/base-java/src/main/java/io/airbyte/integrations/destination_async/state/FlushFailure.java
@@ -1,0 +1,29 @@
+/*
+ * Copyright (c) 2023 Airbyte, Inc., all rights reserved.
+ */
+
+package io.airbyte.integrations.destination_async.state;
+
+import java.util.concurrent.atomic.AtomicBoolean;
+import java.util.concurrent.atomic.AtomicReference;
+
+public class FlushFailure {
+
+  private final AtomicBoolean isFailed = new AtomicBoolean(false);
+
+  private final AtomicReference<Exception> exceptionAtomicReference = new AtomicReference<>();
+
+  public void propagateException(Exception e) {
+    this.isFailed.set(true);
+    this.exceptionAtomicReference.set(e);
+  }
+
+  public AtomicBoolean isFailed() {
+    return isFailed;
+  }
+
+  public Exception getException() {
+    return exceptionAtomicReference.get();
+  }
+
+}

--- a/airbyte-integrations/bases/base-java/src/test/java/io/airbyte/integrations/destination_async/AsyncStreamConsumerTest.java
+++ b/airbyte-integrations/bases/base-java/src/test/java/io/airbyte/integrations/destination_async/AsyncStreamConsumerTest.java
@@ -82,6 +82,7 @@ class AsyncStreamConsumerTest {
   private OnCloseFunction onClose;
   private Consumer<AirbyteMessage> outputRecordCollector;
   private FlushFailure flushFailure;
+  private BufferManager bufferManager;
 
   @SuppressWarnings("unchecked")
   @BeforeEach
@@ -92,6 +93,7 @@ class AsyncStreamConsumerTest {
     final CheckedFunction<JsonNode, Boolean, Exception> isValidRecord = mock(CheckedFunction.class);
     outputRecordCollector = mock(Consumer.class);
     flushFailure = mock(FlushFailure.class);
+    bufferManager = mock(BufferManager.class);
     consumer = new AsyncStreamConsumer(
         outputRecordCollector,
         onStart,
@@ -99,7 +101,7 @@ class AsyncStreamConsumerTest {
         flushFunction,
         CATALOG,
         isValidRecord,
-        new BufferManager(),
+        bufferManager,
         flushFailure);
 
     when(isValidRecord.apply(any())).thenReturn(true);
@@ -150,6 +152,12 @@ class AsyncStreamConsumerTest {
     verifyStartAndClose();
 
     verifyRecords(STREAM_NAME, SCHEMA_NAME, expectedRecords);
+  }
+
+  @Test
+  void testShouldBlockWhenQueuesAreFull() throws Exception {
+    consumer.start();
+
   }
 
   @Nested

--- a/airbyte-integrations/bases/base-java/src/test/java/io/airbyte/integrations/destination_async/AsyncStreamConsumerTest.java
+++ b/airbyte-integrations/bases/base-java/src/test/java/io/airbyte/integrations/destination_async/AsyncStreamConsumerTest.java
@@ -20,6 +20,7 @@ import io.airbyte.commons.json.Jsons;
 import io.airbyte.integrations.destination.buffered_stream_consumer.OnStartFunction;
 import io.airbyte.integrations.destination.buffered_stream_consumer.RecordSizeEstimator;
 import io.airbyte.integrations.destination_async.buffers.BufferManager;
+import io.airbyte.integrations.destination_async.state.FlushFailure;
 import io.airbyte.protocol.models.Field;
 import io.airbyte.protocol.models.JsonSchemaType;
 import io.airbyte.protocol.models.v0.AirbyteMessage;
@@ -31,6 +32,7 @@ import io.airbyte.protocol.models.v0.AirbyteStreamState;
 import io.airbyte.protocol.models.v0.CatalogHelpers;
 import io.airbyte.protocol.models.v0.ConfiguredAirbyteCatalog;
 import io.airbyte.protocol.models.v0.StreamDescriptor;
+import java.io.IOException;
 import java.time.Instant;
 import java.util.Collection;
 import java.util.List;
@@ -38,6 +40,7 @@ import java.util.function.Consumer;
 import java.util.stream.Stream;
 import org.apache.commons.lang.RandomStringUtils;
 import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
 import org.mockito.ArgumentCaptor;
 
@@ -78,6 +81,7 @@ class AsyncStreamConsumerTest {
   private DestinationFlushFunction flushFunction;
   private OnCloseFunction onClose;
   private Consumer<AirbyteMessage> outputRecordCollector;
+  private FlushFailure flushFailure;
 
   @SuppressWarnings("unchecked")
   @BeforeEach
@@ -87,6 +91,7 @@ class AsyncStreamConsumerTest {
     flushFunction = mock(DestinationFlushFunction.class);
     final CheckedFunction<JsonNode, Boolean, Exception> isValidRecord = mock(CheckedFunction.class);
     outputRecordCollector = mock(Consumer.class);
+    flushFailure = mock(FlushFailure.class);
     consumer = new AsyncStreamConsumer(
         outputRecordCollector,
         onStart,
@@ -94,7 +99,8 @@ class AsyncStreamConsumerTest {
         flushFunction,
         CATALOG,
         isValidRecord,
-        new BufferManager());
+        new BufferManager(),
+        flushFailure);
 
     when(isValidRecord.apply(any())).thenReturn(true);
     when(flushFunction.getOptimalBatchSizeBytes()).thenReturn(10_000L);
@@ -144,6 +150,37 @@ class AsyncStreamConsumerTest {
     verifyStartAndClose();
 
     verifyRecords(STREAM_NAME, SCHEMA_NAME, expectedRecords);
+  }
+
+  @Nested
+  class ErrorHandling {
+
+    @Test
+    void testErrorOnAccept() throws Exception {
+      when(flushFailure.isFailed()).thenReturn(false).thenReturn(true);
+      when(flushFailure.getException()).thenReturn(new IOException("test exception"));
+
+      final var m = new AirbyteMessage()
+          .withType(Type.RECORD)
+          .withRecord(new AirbyteRecordMessage()
+              .withStream(STREAM_NAME)
+              .withNamespace(SCHEMA_NAME)
+              .withEmittedAt(Instant.now().toEpochMilli())
+              .withData(Jsons.deserialize("")));
+      consumer.start();
+      consumer.accept(m);
+      assertThrows(IOException.class, () -> consumer.accept(m));
+    }
+
+    @Test
+    void testErrorOnClose() throws Exception {
+      when(flushFailure.isFailed()).thenReturn(true);
+      when(flushFailure.getException()).thenReturn(new IOException("test exception"));
+
+      consumer.start();
+      assertThrows(IOException.class, () -> consumer.close());
+    }
+
   }
 
   private static void consumeRecords(final AsyncStreamConsumer consumer, final Collection<AirbyteMessage> records) {

--- a/airbyte-integrations/bases/base-java/src/test/java/io/airbyte/integrations/destination_async/FlushWorkersTest.java
+++ b/airbyte-integrations/bases/base-java/src/test/java/io/airbyte/integrations/destination_async/FlushWorkersTest.java
@@ -1,0 +1,58 @@
+/*
+ * Copyright (c) 2023 Airbyte, Inc., all rights reserved.
+ */
+
+package io.airbyte.integrations.destination_async;
+
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+import io.airbyte.integrations.destination_async.buffers.BufferDequeue;
+import io.airbyte.integrations.destination_async.buffers.MemoryAwareMessageBatch;
+import io.airbyte.integrations.destination_async.state.FlushFailure;
+import io.airbyte.protocol.models.v0.AirbyteMessage;
+import io.airbyte.protocol.models.v0.StreamDescriptor;
+import java.io.IOException;
+import java.util.List;
+import java.util.Optional;
+import java.util.Set;
+import java.util.function.Consumer;
+import java.util.stream.Stream;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+
+public class FlushWorkersTest {
+
+  @Test
+  void testErrorHandling() throws Exception {
+    final var desc = new StreamDescriptor().withName("test");
+    final var dequeue = mock(BufferDequeue.class);
+    when(dequeue.getBufferedStreams()).thenReturn(Set.of(desc));
+    when(dequeue.take(desc, 1000)).thenReturn(new MemoryAwareMessageBatch(List.of(), 0, null, null));
+    when(dequeue.getQueueSizeInRecords(desc)).thenReturn(Optional.of(1L));
+    final var collector = mock(Consumer.class);
+
+    final var flushFailure = new FlushFailure();
+    final var workers = new FlushWorkers(dequeue, new ErrorOnFlush(), collector, flushFailure);
+    workers.start();
+    workers.close();
+
+    Assertions.assertTrue(flushFailure.isFailed().get());
+    Assertions.assertEquals(IOException.class, flushFailure.getException().getClass());
+  }
+
+  private static class ErrorOnFlush implements DestinationFlushFunction {
+
+    @Override
+    public void flush(final StreamDescriptor decs, final Stream<AirbyteMessage> stream) throws Exception {
+      throw new IOException("Error on flush");
+    }
+
+    @Override
+    public long getOptimalBatchSizeBytes() {
+      return 1000;
+    }
+
+  }
+
+}

--- a/airbyte-integrations/bases/base-java/src/test/java/io/airbyte/integrations/destination_async/FlushWorkersTest.java
+++ b/airbyte-integrations/bases/base-java/src/test/java/io/airbyte/integrations/destination_async/FlushWorkersTest.java
@@ -37,7 +37,7 @@ public class FlushWorkersTest {
     workers.start();
     workers.close();
 
-    Assertions.assertTrue(flushFailure.isFailed().get());
+    Assertions.assertTrue(flushFailure.isFailed());
     Assertions.assertEquals(IOException.class, flushFailure.getException().getClass());
   }
 


### PR DESCRIPTION
## What
If a flush worker thread throws an exception, propagate that exception up to the main thread for termination.

## How
* catch exceptions in flush workers
* if there is an exception, signal to a carrier object
* in the main loop, always check the carrier object
* this is preferred to futures because it lets us fail fast

## Recommended reading order
All files.

## 🚨 User Impact 🚨
*Are there any breaking changes? What is the end result perceived by the user?*

*For connector PRs, use this section to explain which type of semantic versioning bump occurs as a result of the changes. Refer to our [Semantic Versioning for Connectors](https://docs.airbyte.com/contributing-to-airbyte/#semantic-versioning-for-connectors) guidelines for more information. **Breaking changes to connectors must be documented by an Airbyte engineer (PR author, or reviewer for community PRs) by using the [Breaking Change Release Playbook](https://docs.google.com/document/d/1VYQggHbL_PN0dDDu7rCyzBLGRtX-R3cpwXaY8QxEgzw/edit).***

*If there are breaking changes, please merge this PR with the 🚨🚨 emoji so changelog authors can further highlight this if needed.*


## Pre-merge Actions
*Expand the relevant checklist and delete the others.*

<details><summary><strong>New Connector</strong></summary>

### Community member or Airbyter

- **Community member?** Grant edit access to maintainers ([instructions](https://docs.github.com/en/github/collaborating-with-pull-requests/working-with-forks/allowing-changes-to-a-pull-request-branch-created-from-a-fork#enabling-repository-maintainer-permissions-on-existing-pull-requests))
- Unit & integration tests added and passing. Community members, please provide proof of success locally e.g: screenshot or copy-paste unit, integration, and acceptance test output. To run acceptance tests for a Python connector, follow instructions in the README. For java connectors run `./gradlew :airbyte-integrations:connectors:<name>:integrationTest`.
- Connector version is set to `0.0.1`
    - `Dockerfile` has version `0.0.1`
- Documentation updated
    - Connector's `README.md`
    - Connector's `bootstrap.md`. See [description and examples](https://docs.google.com/document/d/1ypdgmwmEHWv-TrO4_YOQ7pAJGVrMp5BOkEVh831N260/edit?usp=sharing)
    - `docs/integrations/<source or destination>/<name>.md` including changelog with an entry for the initial version. See changelog [example](https://docs.airbyte.io/integrations/sources/stripe#changelog)
    - `docs/integrations/README.md`

### Airbyter

If this is a community PR, the Airbyte engineer reviewing this PR is responsible for the below items.

- Create a non-forked branch based on this PR and test the below items on it
- Build is successful
- If new credentials are required for use in CI, add them to GSM. [Instructions](https://docs.airbyte.io/connector-development#using-credentials-in-ci).

</details>

<details><summary><strong>Updating a connector</strong></summary>

### Community member or Airbyter

- Grant edit access to maintainers ([instructions](https://docs.github.com/en/github/collaborating-with-pull-requests/working-with-forks/allowing-changes-to-a-pull-request-branch-created-from-a-fork#enabling-repository-maintainer-permissions-on-existing-pull-requests))
- Unit & integration tests added


### Airbyter

If this is a community PR, the Airbyte engineer reviewing this PR is responsible for the below items.

- Create a non-forked branch based on this PR and test the below items on it
- Build is successful
- If new credentials are required for use in CI, add them to GSM. [Instructions](https://docs.airbyte.io/connector-development#using-credentials-in-ci).

</details>

<details><summary><strong>Connector Generator</strong></summary>

- Issue acceptance criteria met
- PR name follows [PR naming conventions](https://docs.airbyte.com/contributing-to-airbyte/issues-and-pull-requests#pull-request-title-convention)
- If adding a new generator, add it to the [list of scaffold modules being tested](https://github.com/airbytehq/airbyte/blob/master/airbyte-integrations/connector-templates/generator/build.gradle#L41)
- The generator test modules (all connectors with `-scaffold` in their name) have been updated with the latest scaffold by running `./gradlew :airbyte-integrations:connector-templates:generator:testScaffoldTemplates` then checking in your changes
- Documentation which references the generator is updated as needed

</details>
