### PR TITLE
docs: remove extra space in sources/s3.md

### DIFF
--- a/docs/integrations/sources/s3.md
+++ b/docs/integrations/sources/s3.md
@@ -213,7 +213,7 @@ The avro parser uses [fastavro](https://fastavro.readthedocs.io/en/latest/). Cur
 
 ### Jsonl
 
-The Jsonl parser uses pyarrow hence,only the line-delimited JSON format is supported.For more detailed info, please refer to the [docs] (https://arrow.apache.org/docs/python/generated/pyarrow.json.read_json.html)
+The Jsonl parser uses pyarrow hence,only the line-delimited JSON format is supported.For more detailed info, please refer to the [docs](https://arrow.apache.org/docs/python/generated/pyarrow.json.read_json.html)
 
 ## Changelog
 


### PR DESCRIPTION
## What
removes the extra space in s3.md


before|after
-|-
[docs] (https://arrow.apache.org/docs/python/generated/pyarrow.json.read_json.html) | [docs](https://arrow.apache.org/docs/python/generated/pyarrow.json.read_json.html)

ref: https://docs.airbyte.com/integrations/sources/s3/#jsonl