### PR TITLE
Update VM docs to use run-ab-platform.sh

### DIFF
--- a/docs/deploying-airbyte/on-aws-ec2.md
+++ b/docs/deploying-airbyte/on-aws-ec2.md
@@ -19,7 +19,7 @@ The instructions have been tested on Amazon Linux 2 AMI (HVM).
 
 1. To connect to your instance, run the following command on your local terminal:
 
-``` bash
+```bash
 SSH_KEY=~/Downloads/dataline-key-airbyte.pem # the file path you downloaded the key
 INSTANCE_IP=REPLACE_WITH_YOUR_INSTANCE_IP # find your IP address in the EC2 console under the Instances tab
 chmod 400 $SSH_KEY # or ssh will complain that the key has the wrong permissions
@@ -28,7 +28,7 @@ ssh -i $SSH_KEY ec2-user@$INSTANCE_IP # connect to the aws ec2 instance AMI and 
 
 2. To install Docker, run the following command in your SSH session on the instance terminal:
 
-``` bash
+```bash
 sudo yum update -y
 sudo yum install -y docker
 sudo service docker start
@@ -37,14 +37,14 @@ sudo usermod -a -G docker $USER
 
 3. To install `docker-compose`, run the following command in your ssh session on the instance terminal:
 
-``` bash
+```bash
 sudo yum install -y docker-compose-plugin
 docker compose version
 ```
 
 4. To close the SSH connection, run the following command in your SSH session on the instance terminal:
 
-``` bash
+```bash
 logout
 ```
 
@@ -54,16 +54,17 @@ In your local terminal, run the following commands:
 
 1. Connect to your instance:
 
-``` bash
+```bash
 ssh -i $SSH_KEY ec2-user@$INSTANCE_IP
 ```
 
 2. Install Airbyte:
 
-``` bash
+```bash
 mkdir airbyte && cd airbyte
-wget https://raw.githubusercontent.com/airbytehq/airbyte-platform/main/{.env,flags.yml,docker-compose.yaml}
-docker compose up -d # run the Docker container
+wget https://raw.githubusercontent.com/airbytehq/airbyte/master/run-ab-platform.sh
+chmod +x run-ab-platform.sh
+./run-ab-platform.sh
 ```
 
 ## Connect to Airbyte
@@ -79,8 +80,7 @@ For security reasons, we strongly recommend not exposing Airbyte on Internet ava
 If you want to use different ports, modify `API_URL` in your .env file and restart Airbyte.
 Run the following commands in your workstation terminal from the downloaded key folder:
 
-
-``` bash
+```bash
 # In your workstation terminal
 SSH_KEY=~/Downloads/dataline-key-airbyte.pem
 ssh -i $SSH_KEY -L 8000:localhost:8000 -N -f ec2-user@$INSTANCE_IP

--- a/docs/deploying-airbyte/on-aws-ec2.md
+++ b/docs/deploying-airbyte/on-aws-ec2.md
@@ -64,7 +64,7 @@ ssh -i $SSH_KEY ec2-user@$INSTANCE_IP
 mkdir airbyte && cd airbyte
 wget https://raw.githubusercontent.com/airbytehq/airbyte/master/run-ab-platform.sh
 chmod +x run-ab-platform.sh
-./run-ab-platform.sh
+./run-ab-platform.sh -b
 ```
 
 ## Connect to Airbyte

--- a/docs/deploying-airbyte/on-azure-vm-cloud-shell.md
+++ b/docs/deploying-airbyte/on-azure-vm-cloud-shell.md
@@ -85,7 +85,7 @@ Download Airbyte and deploy it in the VM using Docker Compose:
 
    ```bash
    chmod +x run-ab-platform.sh
-   ./run-ab-platform.sh
+   ./run-ab-platform.sh -b
    ```
 
 ## Connect to Airbyte

--- a/docs/deploying-airbyte/on-azure-vm-cloud-shell.md
+++ b/docs/deploying-airbyte/on-azure-vm-cloud-shell.md
@@ -12,50 +12,51 @@ The instructions have been tested on a standard DS1 v2 (1 vcpu, 3.5 GiB memory) 
 
 Install Docker and Docker Compose in the VM:
 
-1. [Create a new VM](https://learn.microsoft.com/en-us/azure/virtual-machines/) and [generate the SSH keys](https://learn.microsoft.com/en-us/azure/virtual-machines/ssh-keys-portal) to connect to the VM. You’ll need the SSH keys to connect to the VM remotely later. 
+1. [Create a new VM](https://learn.microsoft.com/en-us/azure/virtual-machines/) and [generate the SSH keys](https://learn.microsoft.com/en-us/azure/virtual-machines/ssh-keys-portal) to connect to the VM. You’ll need the SSH keys to connect to the VM remotely later.
 
 2. To connect to the VM, run the following command in the Azure Cloud Shell:
 
-    ```bash
-    ssh <admin username>@<IP address>
-    ```
-    If successfully connected to the VM, the working directory of Cloud Shell should look like this: `<admin username>@<virtual machine name>:~$`
+   ```bash
+   ssh <admin username>@<IP address>
+   ```
+
+   If successfully connected to the VM, the working directory of Cloud Shell should look like this: `<admin username>@<virtual machine name>:~$`
 
 3. To install Docker, run the following commands:
 
-    ```bash
-    sudo apt-get update -y
-    sudo apt-get install apt-transport-https ca-certificates curl gnupg lsb-release -y
-    curl -fsSL https://download.docker.com/linux/ubuntu/gpg | sudo gpg --dearmor -o /usr/share/keyrings/docker-archive-keyring.gpg
-    echo "deb [arch=amd64 signed-by=/usr/share/keyrings/docker-archive-keyring.gpg] https://download.docker.com/linux/ubuntu $(lsb_release -cs) stable" | sudo tee /etc/apt/sources.list.d/docker.list > /dev/null
-    sudo apt-get update
-    sudo apt-get install docker-ce docker-ce-cli -y
-    sudo usermod -a -G docker $USER
-    ```
+   ```bash
+   sudo apt-get update -y
+   sudo apt-get install apt-transport-https ca-certificates curl gnupg lsb-release -y
+   curl -fsSL https://download.docker.com/linux/ubuntu/gpg | sudo gpg --dearmor -o /usr/share/keyrings/docker-archive-keyring.gpg
+   echo "deb [arch=amd64 signed-by=/usr/share/keyrings/docker-archive-keyring.gpg] https://download.docker.com/linux/ubuntu $(lsb_release -cs) stable" | sudo tee /etc/apt/sources.list.d/docker.list > /dev/null
+   sudo apt-get update
+   sudo apt-get install docker-ce docker-ce-cli -y
+   sudo usermod -a -G docker $USER
+   ```
 
 4. To install Docker Compose, run the following command:
 
-    ```bash
-    sudo apt-get install docker-compose-plugin -y
-    ```
+   ```bash
+   sudo apt-get install docker-compose-plugin -y
+   ```
 
 5. Check Docker Compose version:
 
-    ```bash
-    docker compose version
-    ```
+   ```bash
+   docker compose version
+   ```
 
 6. Close the SSH connection to ensure that the group modification is considered:
 
-    ```bash
-    logout
-    ```
+   ```bash
+   logout
+   ```
 
 7. Reconnect to the VM:
 
-    ```bash
-    ssh <admin username>@<IP address>
-    ```
+   ```bash
+   ssh <admin username>@<IP address>
+   ```
 
 ## Install and start Airbyte
 
@@ -63,42 +64,43 @@ Download Airbyte and deploy it in the VM using Docker Compose:
 
 1. Ensure that you are connected to the VM:
 
-    ```bash
-    ssh <admin username>@<IP address>
-    ```
+   ```bash
+   ssh <admin username>@<IP address>
+   ```
 
 2. Create and use a new directory:
 
-    ```bash 
-    mkdir airbyte
-    cd airbyte
-    ```
+   ```bash
+   mkdir airbyte
+   cd airbyte
+   ```
 
-3. Download Airbyte from GitHub: 
+3. Download Airbyte's install script from GitHub:
 
-    ```bash
-    wget https://raw.githubusercontent.com/airbytehq/airbyte-platform/main/{.env,flags.yml,docker-compose.yaml}
-    ```
+   ```bash
+   wget https://raw.githubusercontent.com/airbytehq/airbyte/master/run-ab-platform.sh
+   ```
 
-4. To start Airbyte, run the following command:
+4. To start Airbyte, run the following commands:
 
-    ```bash
-    sudo docker compose up -d
-    ```
+   ```bash
+   chmod +x run-ab-platform.sh
+   ./run-ab-platform.sh
+   ```
 
 ## Connect to Airbyte
 
 Test a remote connection to your VM locally and verify that Airbyte is up and running.
 
-1. In your local machine, open a terminal. 
+1. In your local machine, open a terminal.
 2. Go to the folder where you stored the SSH key.
 3. Create a SSH tunnel for `port 8000` by typing the following command:
 
-    ```bash 
-    ssh -N -L 8000:localhost:8000 -i <your SSH key file> <admin username>@<IP address>
-    ```
+   ```bash
+   ssh -N -L 8000:localhost:8000 -i <your SSH key file> <admin username>@<IP address>
+   ```
 
-4. Open a web browser and navigate to `http://localhost:8000`. You will see Airbyte’s landing page. 
+4. Open a web browser and navigate to `http://localhost:8000`. You will see Airbyte’s landing page.
 
 :::caution
 For security reasons, we strongly recommend not exposing Airbyte on Internet available ports.

--- a/docs/deploying-airbyte/on-digitalocean-droplet.md
+++ b/docs/deploying-airbyte/on-digitalocean-droplet.md
@@ -45,7 +45,7 @@ To install and start Airbyte :
   mkdir airbyte && cd airbyte
   wget https://raw.githubusercontent.com/airbytehq/airbyte/master/run-ab-platform.sh
   chmod +x run-ab-platform.sh
-  ./run-ab-platform.sh
+  ./run-ab-platform.sh -b
 ```
 
 2. Verify the connection by visiting [http://localhost:8000](http://localhost:8000) in your browser.

--- a/docs/deploying-airbyte/on-digitalocean-droplet.md
+++ b/docs/deploying-airbyte/on-digitalocean-droplet.md
@@ -1,6 +1,6 @@
 # Deploy Airbyte on DigitalOcean
 
-This page guides you through deploying Airbyte Open Source on a [DigitalOcean droplet](https://docs.digitalocean.com/products/droplets/how-to/create/) by setting up the deployment environment, and installing and starting Airbyte.  
+This page guides you through deploying Airbyte Open Source on a [DigitalOcean droplet](https://docs.digitalocean.com/products/droplets/how-to/create/) by setting up the deployment environment, and installing and starting Airbyte.
 
 Alternatively, you can deploy Airbyte on DigitalOcean in one click using their [marketplace](https://cloud.digitalocean.com/droplets/new?onboarding_origin=marketplace&appId=95451155&image=airbyte&utm_source=deploying-airbyte_on-digitalocean-droplet).
 
@@ -17,16 +17,16 @@ To deploy Airbyte Open Source on DigitalOcean:
 2. Connect to the droplet using the [Droplet Console](https://www.google.com/url?q=https://docs.digitalocean.com/products/droplets/how-to/connect-with-console/&sa=D&source=docs&ust=1666280581103312&usg=AOvVaw1hyEPyjRsmsRdIgbxZdu6F).
 3. To update the available packages and install Docker, run the following command:
 
-  ```bash
-      sudo apt update
-      sudo apt install apt-transport-https ca-certificates curl software-properties-common
-      curl -fsSL https://download.docker.com/linux/ubuntu/gpg | sudo apt-key add -
-      sudo add-apt-repository "deb [arch=amd64] https://download.docker.com/linux/ubuntu focal stable"
-      sudo apt install docker-ce
-      sudo systemctl status docker
-      sudo usermod -aG docker ${USER}
-      su - ${USER}
-  ```
+```bash
+    sudo apt update
+    sudo apt install apt-transport-https ca-certificates curl software-properties-common
+    curl -fsSL https://download.docker.com/linux/ubuntu/gpg | sudo apt-key add -
+    sudo add-apt-repository "deb [arch=amd64] https://download.docker.com/linux/ubuntu focal stable"
+    sudo apt install docker-ce
+    sudo systemctl status docker
+    sudo usermod -aG docker ${USER}
+    su - ${USER}
+```
 
 4. To install Docker-Compose, run the following command:
 
@@ -43,12 +43,13 @@ To install and start Airbyte :
 
 ```bash
   mkdir airbyte && cd airbyte
-  wget https://raw.githubusercontent.com/airbytehq/airbyte-platform/main/{.env,flags.yml,docker-compose.yaml}
-  docker compose up -d
+  wget https://raw.githubusercontent.com/airbytehq/airbyte/master/run-ab-platform.sh
+  chmod +x run-ab-platform.sh
+  ./run-ab-platform.sh
 ```
 
 2. Verify the connection by visiting [http://localhost:8000](http://localhost:8000) in your browser.
 
 ## Troubleshooting
 
-If you encounter any issues, reach out to our community on [Slack](https://slack.airbyte.com/).  
+If you encounter any issues, reach out to our community on [Slack](https://slack.airbyte.com/).

--- a/docs/deploying-airbyte/on-gcp-compute-engine.md
+++ b/docs/deploying-airbyte/on-gcp-compute-engine.md
@@ -83,8 +83,9 @@ gcloud --project=$PROJECT_ID beta compute ssh $INSTANCE_NAME
 
 ```bash
 mkdir airbyte && cd airbyte
-curl -sOOO https://raw.githubusercontent.com/airbytehq/airbyte-platform/main/{.env,flags.yml,docker-compose.yaml}
-docker compose up -d
+wget https://raw.githubusercontent.com/airbytehq/airbyte/master/run-ab-platform.sh
+chmod +x run-ab-platform.sh
+./run-ab-platform.sh
 ```
 
 ## Connect to Airbyte

--- a/docs/deploying-airbyte/on-gcp-compute-engine.md
+++ b/docs/deploying-airbyte/on-gcp-compute-engine.md
@@ -85,7 +85,7 @@ gcloud --project=$PROJECT_ID beta compute ssh $INSTANCE_NAME
 mkdir airbyte && cd airbyte
 wget https://raw.githubusercontent.com/airbytehq/airbyte/master/run-ab-platform.sh
 chmod +x run-ab-platform.sh
-./run-ab-platform.sh
+./run-ab-platform.sh -b
 ```
 
 ## Connect to Airbyte

--- a/docs/deploying-airbyte/on-oci-vm.md
+++ b/docs/deploying-airbyte/on-oci-vm.md
@@ -54,22 +54,17 @@ docker compose version
 
 Download the Airbyte repository and deploy it on the VM:
 
-1. Run the following commands to clone the Airbyte repo:
+1. Run the following commands to download the Airbyte installation script:
 
    ```bash
    mkdir airbyte && cd airbyte
-   ```
-
    wget https://raw.githubusercontent.com/airbytehq/airbyte/master/run-ab-platform.sh
-
+   chmod +x run-ab-platform.sh
    ```
 
-   ```
-
-2. Run the following commands to get Airbyte running on your OCI VM instance using the installation script:
+2. Run the following command to get Airbyte running on your OCI VM instance using the installation script:
 
    ```bash
-   chmod +x run-ab-platform.sh
    ./run-ab-platform.sh
    ```
 

--- a/docs/deploying-airbyte/on-oci-vm.md
+++ b/docs/deploying-airbyte/on-oci-vm.md
@@ -8,13 +8,13 @@ These instructions have been tested on an Oracle Linux 7 instance.
 
 :::
 
-## Prerequisites 
+## Prerequisites
 
 To deploy Airbyte Open Source on Oracle cloud:
 
-* Create an [OCI VM compute instance](https://docs.oracle.com/en-us/iaas/Content/Compute/Tasks/launchinginstance.htm#Creating_an_Instance)
-* Allowlist a port for a CIDR range in the [security list of your OCI VM Instance subnet](https://docs.oracle.com/en-us/iaas/Content/Network/Concepts/securitylists.htm)
-* Connect to the instance using a [bastion port forwarding session](https://docs.oracle.com/en-us/iaas/Content/Bastion/Tasks/connectingtosessions.htm#connect-port-forwarding)
+- Create an [OCI VM compute instance](https://docs.oracle.com/en-us/iaas/Content/Compute/Tasks/launchinginstance.htm#Creating_an_Instance)
+- Allowlist a port for a CIDR range in the [security list of your OCI VM Instance subnet](https://docs.oracle.com/en-us/iaas/Content/Network/Concepts/securitylists.htm)
+- Connect to the instance using a [bastion port forwarding session](https://docs.oracle.com/en-us/iaas/Content/Bastion/Tasks/connectingtosessions.htm#connect-port-forwarding)
 
 :::caution
 
@@ -56,34 +56,34 @@ Download the Airbyte repository and deploy it on the VM:
 
 1. Run the following commands to clone the Airbyte repo:
 
-	```bash
-	mkdir airbyte && cd airbyte
+   ```bash
+   mkdir airbyte && cd airbyte
+   ```
 
-	wget https://raw.githubusercontent.com/airbytehq/airbyte-platform/main/{.env,flags.yml,docker-compose.yaml}
-	```
+   wget https://raw.githubusercontent.com/airbytehq/airbyte/master/run-ab-platform.sh
 
-2. Run the following commands to get Airbyte running on your OCI VM instance using Docker compose:
+   ```
 
-    ```bash
+   ```
 
-    which docker
+2. Run the following commands to get Airbyte running on your OCI VM instance using the installation script:
 
-    sudo /usr/local/bin/docker compose up -d
-
-    ``` 
+   ```bash
+   chmod +x run-ab-platform.sh
+   ./run-ab-platform.sh
+   ```
 
 3. Open up a Browser and visit port 8000 - [http://localhost:8000/](http://localhost:8000/)
 
-
 Alternatively, you can get Airbyte running on your OCI VM instance using a different approach.
 
-1. In the terminal connected to your OCI Instance for Airbyte, run the command: 
+1. In the terminal connected to your OCI Instance for Airbyte, run the command:
 
-	```bash
-	ssh opc@bastion-host-public-ip -i <private-key-file.key> -L 8000:oci-private-instance-ip:8000
-	```
+   ```bash
+   ssh opc@bastion-host-public-ip -i <private-key-file.key> -L 8000:oci-private-instance-ip:8000
+   ```
 
-	Replace `<private-key-file.key>` with the path to your private key.
+   Replace `<private-key-file.key>` with the path to your private key.
 
 2. On your browser, visit port 8000 [port 8000](http://localhost:8000/)
 

--- a/docs/deploying-airbyte/on-oci-vm.md
+++ b/docs/deploying-airbyte/on-oci-vm.md
@@ -59,13 +59,13 @@ Download the Airbyte repository and deploy it on the VM:
    ```bash
    mkdir airbyte && cd airbyte
    wget https://raw.githubusercontent.com/airbytehq/airbyte/master/run-ab-platform.sh
-   chmod +x run-ab-platform.sh
+   chmod +x run-ab-platform.sh -b
    ```
 
 2. Run the following command to get Airbyte running on your OCI VM instance using the installation script:
 
    ```bash
-   ./run-ab-platform.sh
+   ./run-ab-platform.sh -b 
    ```
 
 3. Open up a Browser and visit port 8000 - [http://localhost:8000/](http://localhost:8000/)


### PR DESCRIPTION
## What
We have some documentation that recommends running airbyte by pulling `docker-compose.yml`, `flags.yml` and `.env` from `airbytehq/airbyte` and then running `docker compose up`. While this works, it will not guarantee that you are on the currently published version of the platform. To guarantee you are spinning up the images with the correct version, you should use the `run-ab-platform.sh` script.

I recommend reading this PR by ignoring whitespace, since some markdown formatting was touched.
