### PR TITLE
qa-checks: ignore SVG from https check

### DIFF
--- a/tools/ci_connector_ops/ci_connector_ops/qa_checks.py
+++ b/tools/ci_connector_ops/ci_connector_ops/qa_checks.py
@@ -116,8 +116,11 @@ IGNORED_DIRECTORIES_FOR_HTTPS_CHECKS = {
     ".hypothesis",
 }
 
-IGNORED_FILENAME_PATTERN_FOR_HTTPS_CHECKS = {"*Test.java", "*.pyc", "*.gz"}
-IGNORED_URLS_PREFIX = {"http://json-schema.org", "http://localhost"}
+IGNORED_FILENAME_PATTERN_FOR_HTTPS_CHECKS = {"*Test.java", "*.pyc", "*.gz", "*.svg"}
+IGNORED_URLS_PREFIX = {
+    "http://json-schema.org",
+    "http://localhost",
+}
 
 
 def is_comment(line: str, file_path: Path):


### PR DESCRIPTION
## What
SVG files can contain http URL and it looks like its fine according to https://github.com/w3c/svgwg/issues/738
