### PR TITLE
allow running run-ab-platform.sh in detached mode

### DIFF
--- a/run-ab-platform.sh
+++ b/run-ab-platform.sh
@@ -169,6 +169,8 @@ if test $? -ne 0; then
 fi
 
 ########## Ending Docker ##########
-docker compose down
-
-echo -e "$blue_text""Stopping Docker Compose""$default_text"
+if [ -z "$dockerDetachedMode" ]; then
+  docker compose down
+else
+  echo -e "$blue_text""Airbyte containers are running!""$default_text"
+fi

--- a/run-ab-platform.sh
+++ b/run-ab-platform.sh
@@ -30,6 +30,7 @@ Help()
    echo -e "   -r --refresh     ${red_text}DELETE${default_text} existing assets and re-download new ones"
    echo -e "   -h --help        Print this Help."
    echo -e "   -x --debug       Verbose mode."
+   echo -e "   -b --background  Run docker compose up in detached mode."
    echo -e ""
 }
 
@@ -82,6 +83,7 @@ DeleteLocalAssets()
   done
 }
 
+dockerDetachedMode=""
 
 # $0 is the currently running program (this file)
 this_file_directory=$(dirname $0)
@@ -105,6 +107,9 @@ for argument in $@; do
       ;;
     -x | --debug)
       set -o xtrace  # -x display every line before execution; enables PS4
+      ;;
+    -b | --background)
+      dockerDetachedMode="-d"
       ;;
     *)
       echo "$argument is not a known command."
@@ -155,7 +160,7 @@ done
 echo
 echo -e "$blue_text""Starting Docker Compose""$default_text"
 
-docker compose up
+docker compose up $dockerDetachedMode
 
 # $? is the exit code of the last command. So here: docker compose up
 if test $? -ne 0; then


### PR DESCRIPTION
## What
Sometimes end users might want to simply start the docker compose process and not retain an open terminal process. This allows them to do that in a single command in the script

## How
Add a flag, -b, that allows end users to run in "background" mode. Unfortunately -d was already taken so we use -b instead.

## Recommended reading order
1. run-ab-platform.sh

## 🚨 User Impact 🚨
No breaking changes
