### PR TITLE
Source Instagram: handle AuthError

### DIFF
--- a/airbyte-integrations/connectors/source-instagram/Dockerfile
+++ b/airbyte-integrations/connectors/source-instagram/Dockerfile
@@ -12,5 +12,5 @@ RUN pip install .
 ENV AIRBYTE_ENTRYPOINT "python /airbyte/integration_code/main.py"
 ENTRYPOINT ["python", "/airbyte/integration_code/main.py"]
 
-LABEL io.airbyte.version=1.0.5
+LABEL io.airbyte.version=1.0.6
 LABEL io.airbyte.name=airbyte/source-instagram

--- a/airbyte-integrations/connectors/source-instagram/acceptance-test-config.yml
+++ b/airbyte-integrations/connectors/source-instagram/acceptance-test-config.yml
@@ -43,7 +43,7 @@ acceptance_tests:
           - name: value
             bypass_reason: Contains PII data
           - name: date
-            bypass_reason: Depend on curent date
+            bypass_reason: Depend on current date
           user_insights:
           - name: date
             bypass_reason: Anonymization for exactly for which date statistics anonymization

--- a/airbyte-integrations/connectors/source-instagram/metadata.yaml
+++ b/airbyte-integrations/connectors/source-instagram/metadata.yaml
@@ -5,7 +5,7 @@ data:
   connectorSubtype: api
   connectorType: source
   definitionId: 6acf6b55-4f1e-4fca-944e-1a3caef8aba8
-  dockerImageTag: 1.0.5
+  dockerImageTag: 1.0.6
   dockerRepository: airbyte/source-instagram
   githubIssueLabel: source-instagram
   icon: instagram.svg

--- a/airbyte-integrations/connectors/source-instagram/setup.py
+++ b/airbyte-integrations/connectors/source-instagram/setup.py
@@ -9,8 +9,6 @@ MAIN_REQUIREMENTS = [
     "airbyte-cdk",
     "cached_property~=1.5",
     "facebook_business~=11.0",
-    "pendulum>=2,<3",
-    "backoff",
 ]
 
 TEST_REQUIREMENTS = [

--- a/airbyte-integrations/connectors/source-instagram/source_instagram/streams.py
+++ b/airbyte-integrations/connectors/source-instagram/source_instagram/streams.py
@@ -344,7 +344,7 @@ class MediaInsights(Media):
             account_id = ig_account.get("id")
             insights = self._get_insights(ig_media, account_id)
             if insights is None:
-                break
+                continue
 
             insights["id"] = ig_media["id"]
             insights["page_id"] = account["page_id"]

--- a/airbyte-integrations/connectors/source-instagram/unit_tests/test_streams.py
+++ b/airbyte-integrations/connectors/source-instagram/unit_tests/test_streams.py
@@ -72,6 +72,56 @@ def test_media_insights_read(api, user_stories_data, user_media_insights_data, r
     assert records == [{"business_account_id": "test_id", "id": "test_id", "impressions": 264, "page_id": "act_unknown_account"}]
 
 
+def test_media_insights_read_error(api, requests_mock):
+    test_id = "test_id"
+    stream = MediaInsights(api=api)
+    media_response = [{"id": "test_id"}, {"id": "test_id_2"}, {"id": "test_id_3"}]
+    requests_mock.register_uri("GET", FacebookSession.GRAPH + f"/{FB_API_VERSION}/{test_id}/media", json={"data": media_response})
+    media_insights_response_test_id = {
+        "name": "impressions",
+        "period": "lifetime",
+        "values": [{"value": 264}],
+        "title": "Impressions",
+        "description": "Total number of times the media object has been seen",
+        "id": "test_id/insights/impressions/lifetime",
+    }
+    requests_mock.register_uri("GET", FacebookSession.GRAPH + f"/{FB_API_VERSION}/{test_id}/insights", json=media_insights_response_test_id)
+    error_response = {
+        "error": {
+            "message": "Invalid parameter",
+            "type": "OAuthException",
+            "code": 100,
+            "error_data": {},
+            "error_subcode": 2108006,
+            "is_transient": False,
+            "error_user_title": "Media posted before business account conversion",
+            "error_user_msg": "The media was posted before the most recent time that the user's account was converted to a business account from a personal account.",
+            "fbtrace_id": "AJiAbw1WoyMzMUhBTxJqpxO"
+        }
+    }
+    requests_mock.register_uri("GET", FacebookSession.GRAPH + f"/{FB_API_VERSION}/test_id_2/insights",  json=error_response, status_code=400)
+    media_insights_response_test_id_3 = {
+        "name": "impressions",
+        "period": "lifetime",
+        "values": [{"value": 300}],
+        "title": "Impressions",
+        "description": "Total number of times the media object has been seen",
+        "id": "test_id_3/insights/impressions/lifetime",
+    }
+    requests_mock.register_uri("GET", FacebookSession.GRAPH + f"/{FB_API_VERSION}/test_id_3/insights", json=media_insights_response_test_id_3)
+
+    records = read_full_refresh(stream)
+    expected_records = [{"business_account_id": "test_id",
+                         "id": "test_id",
+                         "impressions": 264,
+                         "page_id": "act_unknown_account"},
+                        {"business_account_id": "test_id",
+                         "id": "test_id_3",
+                         "impressions": 300,
+                         "page_id": "act_unknown_account"}]
+    assert records == expected_records
+
+
 def test_user_read(api, user_data, requests_mock):
     test_id = "test_id"
     stream = Users(api=api)

--- a/docs/integrations/sources/instagram.md
+++ b/docs/integrations/sources/instagram.md
@@ -82,6 +82,7 @@ AirbyteRecords are required to conform to the [Airbyte type](https://docs.airbyt
 
 | Version | Date       | Pull Request                                             | Subject                                                                                                         |
 |:--------|:-----------|:---------------------------------------------------------|:----------------------------------------------------------------------------------------------------------------|
+| 1.0.6   | 2023-03-28 | [26599](https://github.com/airbytehq/airbyte/pull/26599) | Media posted before business account conversion                                                                 |
 | 1.0.5   | 2023-03-28 | [24634](https://github.com/airbytehq/airbyte/pull/24634) | Add user-friendly message for no instagram_business_accounts case                                               |
 | 1.0.4   | 2023-03-15 | [23671](https://github.com/airbytehq/airbyte/pull/23671) | Add info about main permissions in spec and doc links in error message to navigate user                         |
 | 1.0.3   | 2023-03-14 | [24043](https://github.com/airbytehq/airbyte/pull/24043) | Do not emit incomplete records for `user_insights` stream                                                       |


### PR DESCRIPTION
## What
Resolve https://github.com/airbytehq/airbyte/issues/26536

## How
ignore media insights with `AuthError: Media posted before business account conversion`.

## Recommended reading order
1. `y.python`

## 🚨 User Impact 🚨

no breaking changes

## Pre-merge Actions

<details><summary><strong>Updating a connector</strong></summary>

### Community member or Airbyter

- Grant edit access to maintainers ([instructions](https://docs.github.com/en/github/collaborating-with-pull-requests/working-with-forks/allowing-changes-to-a-pull-request-branch-created-from-a-fork#enabling-repository-maintainer-permissions-on-existing-pull-requests))
- Unit & integration tests added


### Airbyter

If this is a community PR, the Airbyte engineer reviewing this PR is responsible for the below items.

- Create a non-forked branch based on this PR and test the below items on it
- Build is successful
- If new credentials are required for use in CI, add them to GSM. [Instructions](https://docs.airbyte.io/connector-development#using-credentials-in-ci).

</details>
