### PR TITLE
FIX: Remove duplicate version declaration for source-gitlab

### DIFF
--- a/airbyte-integrations/connectors/source-gitlab/Dockerfile
+++ b/airbyte-integrations/connectors/source-gitlab/Dockerfile
@@ -14,5 +14,4 @@ COPY main.py ./
 ENTRYPOINT ["python", "/airbyte/integration_code/main.py"]
 
 LABEL io.airbyte.version=1.2.0
-LABEL io.airbyte.version=1.1.1
 LABEL io.airbyte.name=airbyte/source-gitlab


### PR DESCRIPTION
## What
Removes the previous docker version which was forgotten:
https://github.com/airbytehq/airbyte/commit/01b1673ad11071c56943939cb7471c646f697b6d

