### PR TITLE
Cgardens/make state memory aware

### DIFF
--- a/airbyte-integrations/bases/base-java/src/main/java/io/airbyte/integrations/destination_async/buffers/BufferEnqueue.java
+++ b/airbyte-integrations/bases/base-java/src/main/java/io/airbyte/integrations/destination_async/buffers/BufferEnqueue.java
@@ -46,7 +46,9 @@ public class BufferEnqueue {
     if (message.getType() == Type.RECORD) {
       handleRecord(message);
     } else if (message.getType() == Type.STATE) {
-      stateManager.trackState(message);
+      // todo (cgardens) - feed size into this method. depends on
+      // https://github.com/airbytehq/airbyte/pull/26332
+      stateManager.trackState(message, 1000L);
     }
   }
 

--- a/airbyte-integrations/bases/base-java/src/main/java/io/airbyte/integrations/destination_async/buffers/BufferManager.java
+++ b/airbyte-integrations/bases/base-java/src/main/java/io/airbyte/integrations/destination_async/buffers/BufferManager.java
@@ -41,7 +41,7 @@ public class BufferManager {
     LOGGER.info("Memory available to the JVM {}", FileUtils.byteCountToDisplaySize(maxMemory));
     memoryManager = new GlobalMemoryManager(maxMemory);
     buffers = new ConcurrentHashMap<>();
-    final GlobalAsyncStateManager stateManager = new GlobalAsyncStateManager();
+    final GlobalAsyncStateManager stateManager = new GlobalAsyncStateManager(memoryManager);
     bufferEnqueue = new BufferEnqueue(memoryManager, buffers, stateManager);
     bufferDequeue = new BufferDequeue(memoryManager, buffers, stateManager);
     debugLoop = Executors.newSingleThreadScheduledExecutor();

--- a/airbyte-integrations/bases/base-java/src/test/java/io/airbyte/integrations/destination_async/state/AsyncStateManagerTest.java
+++ b/airbyte-integrations/bases/base-java/src/test/java/io/airbyte/integrations/destination_async/state/AsyncStateManagerTest.java
@@ -1,0 +1,171 @@
+/*
+ * Copyright (c) 2023 Airbyte, Inc., all rights reserved.
+ */
+
+package io.airbyte.integrations.destination_async.state;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.mockito.Mockito.mock;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import com.google.common.collect.ImmutableMap;
+import com.google.common.collect.Lists;
+import io.airbyte.commons.json.Jsons;
+import io.airbyte.integrations.destination_async.GlobalMemoryManager;
+import io.airbyte.integrations.destination_async.buffers.BufferManager;
+import io.airbyte.integrations.destination_async.buffers.StreamAwareQueue;
+import io.airbyte.protocol.models.v0.AirbyteMessage;
+import io.airbyte.protocol.models.v0.AirbyteMessage.Type;
+import io.airbyte.protocol.models.v0.AirbyteRecordMessage;
+import io.airbyte.protocol.models.v0.AirbyteStateMessage;
+import io.airbyte.protocol.models.v0.AirbyteStateMessage.AirbyteStateType;
+import io.airbyte.protocol.models.v0.AirbyteStreamState;
+import io.airbyte.protocol.models.v0.StreamDescriptor;
+import java.time.Instant;
+import java.util.List;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.ConcurrentMap;
+import org.apache.commons.lang.RandomStringUtils;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+class AsyncStateManagerTest {
+  private static final long TOTAL_QUEUES_MAX_SIZE_LIMIT_BYTES = 100 * 1024 * 1024; // 10MB
+  private static final long STATE_MSG_SIZE = 1000;
+  private static final String STREAM_NAME = "id_and_name";
+  private static final String STREAM_NAME2 = STREAM_NAME + 2;
+  private static final StreamDescriptor STREAM1_DESC = new StreamDescriptor()
+      .withName(STREAM_NAME);
+  private static final StreamDescriptor STREAM2_DESC = new StreamDescriptor()
+      .withName(STREAM_NAME2);
+
+  private static final AirbyteMessage GLOBAL_MESSAGE1 = new AirbyteMessage()
+      .withType(Type.STATE)
+      .withState(new AirbyteStateMessage()
+          .withType(AirbyteStateType.GLOBAL));
+  private static final AirbyteMessage STREAM_STATE_MESSAGE1 = new AirbyteMessage()
+      .withType(Type.STATE)
+      .withState(new AirbyteStateMessage()
+          .withType(AirbyteStateType.STREAM)
+          .withStream(new AirbyteStreamState().withStreamDescriptor(STREAM1_DESC).withStreamState(Jsons.jsonNode(1))));
+  private static final AirbyteMessage STREAM_STATE_MESSAGE2 = new AirbyteMessage()
+      .withType(Type.STATE)
+      .withState(new AirbyteStateMessage()
+          .withType(AirbyteStateType.STREAM)
+          .withStream(new AirbyteStreamState().withStreamDescriptor(STREAM1_DESC).withStreamState(Jsons.jsonNode(2))));
+  private GlobalMemoryManager memoryManager;
+
+  @BeforeEach
+  void setup() {
+    memoryManager = mock(GlobalMemoryManager.class);
+  }
+
+  @Test
+  void testEmptyQueuesGlobalState() {
+    final GlobalAsyncStateManager stateManager = new GlobalAsyncStateManager(memoryManager);
+
+    // GLOBAL
+    stateManager.trackState(GLOBAL_MESSAGE1, STATE_MSG_SIZE);
+    assertEquals(List.of(GLOBAL_MESSAGE1), stateManager.flushStates());
+
+    assertThrows(IllegalArgumentException.class, () -> stateManager.trackState(STREAM_STATE_MESSAGE1, STATE_MSG_SIZE));
+  }
+
+  @Test
+  void testEmptyQueuesStreamState() {
+    final GlobalAsyncStateManager stateManager = new GlobalAsyncStateManager(memoryManager);
+
+    // GLOBAL
+    stateManager.trackState(STREAM_STATE_MESSAGE1, STATE_MSG_SIZE);
+    assertEquals(List.of(STREAM_STATE_MESSAGE1), stateManager.flushStates());
+
+    assertThrows(IllegalArgumentException.class, () -> stateManager.trackState(GLOBAL_MESSAGE1, STATE_MSG_SIZE));
+  }
+
+  @Test
+  void testStateAcrossMultipleStreams() throws InterruptedException {
+    final ConcurrentMap<StreamDescriptor, StreamAwareQueue> buffers = new ConcurrentHashMap<>();
+    buffers.put(STREAM1_DESC, new StreamAwareQueue(TOTAL_QUEUES_MAX_SIZE_LIMIT_BYTES));
+    buffers.put(STREAM2_DESC, new StreamAwareQueue(TOTAL_QUEUES_MAX_SIZE_LIMIT_BYTES));
+    final GlobalAsyncStateManager stateManager = new GlobalAsyncStateManager(memoryManager);
+
+    final List<AirbyteMessage> stream1Records = generateRecords(1000, STREAM_NAME);
+    long count = 0;
+    for (final AirbyteMessage r : stream1Records) {
+      buffers.get(STREAM1_DESC).offer(r, count++, 160);
+    }
+
+    final List<AirbyteMessage> stream2Records = generateRecords(1000, STREAM_NAME2);
+    for (final AirbyteMessage r : stream2Records) {
+      if (count % 1120 == 0) {
+        stateManager.trackState(GLOBAL_MESSAGE1, STATE_MSG_SIZE);
+      }
+      buffers.get(STREAM2_DESC).offer(r, count++, 160);
+    }
+
+    // stateManager.claim(STREAM2_DESC, 1500);
+    // drainNRecords(buffers, STREAM2_DESC, 500);
+    // assertEquals(Optional.empty(), stateManager.fulfill(STREAM2_DESC, 1500));
+    //
+    // stateManager.claim(STREAM1_DESC, 900);
+    // drainNRecords(buffers, STREAM1_DESC, 900);
+    // assertEquals(Optional.empty(), stateManager.fulfill(STREAM1_DESC, 900));
+    //
+    // stateManager.claim(STREAM1_DESC, 1000);
+    // drainNRecords(buffers, STREAM1_DESC, 100);
+    // assertEquals(Optional.of(GLOBAL_MESSAGE1), stateManager.fulfill(STREAM1_DESC, 1000));
+  }
+
+  @Test
+  void testOutOfOrderFulfills() {
+    final ConcurrentMap<StreamDescriptor, StreamAwareQueue> buffers = new ConcurrentHashMap<>();
+    buffers.put(STREAM1_DESC, new StreamAwareQueue(TOTAL_QUEUES_MAX_SIZE_LIMIT_BYTES));
+    final GlobalAsyncStateManager stateManager = new GlobalAsyncStateManager(memoryManager);
+
+    final List<AirbyteMessage> stream1Records = generateRecords(1000, STREAM_NAME);
+    long count = 0;
+    for (final AirbyteMessage r : stream1Records) {
+      if (count > 0 && count % 950 == 0) {
+        stateManager.trackState(GLOBAL_MESSAGE1, STATE_MSG_SIZE);
+      }
+      buffers.get(STREAM1_DESC).offer(r, count++, 160);
+    }
+
+    // worker 1
+    // stateManager.claim(STREAM1_DESC, 900);
+    drainNRecords(buffers, STREAM1_DESC, 900);
+    // worker 2
+    // stateManager.claim(STREAM1_DESC, 1001);
+    drainNRecords(buffers, STREAM1_DESC, 100);
+
+    // assertEquals(Optional.empty(), stateManager.fulfill(STREAM1_DESC, 1001));
+    // assertEquals(Optional.of(GLOBAL_MESSAGE1), stateManager.fulfill(STREAM1_DESC, 900));
+  }
+
+  void drainNRecords(final ConcurrentMap<StreamDescriptor, StreamAwareQueue> buffers,
+                     final StreamDescriptor streamDescriptor,
+                     final int numRecord) {
+
+    for (int i = 0; i < numRecord; i++) {
+      buffers.get(streamDescriptor).poll();
+    }
+  }
+
+  private static List<AirbyteMessage> generateRecords(final long numRecords, final String streamName) {
+    final List<AirbyteMessage> output = Lists.newArrayList();
+    for (int i = 0; i < numRecords; i++) {
+      final JsonNode payload =
+          Jsons.jsonNode(ImmutableMap.of("id", RandomStringUtils.randomAlphabetic(7), "name", "human " + String.format("%8d", i)));
+      final AirbyteMessage airbyteMessage = new AirbyteMessage()
+          .withType(Type.RECORD)
+          .withRecord(new AirbyteRecordMessage()
+              .withStream(streamName)
+              .withEmittedAt(Instant.now().toEpochMilli())
+              .withData(payload));
+      output.add(airbyteMessage);
+    }
+    return output;
+  }
+
+}

--- a/airbyte-integrations/bases/base-java/src/test/java/io/airbyte/integrations/destination_async/state/GlobalAsyncStateManagerTest.java
+++ b/airbyte-integrations/bases/base-java/src/test/java/io/airbyte/integrations/destination_async/state/GlobalAsyncStateManagerTest.java
@@ -9,6 +9,7 @@ import static org.junit.jupiter.api.Assertions.assertNotEquals;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 
 import io.airbyte.commons.json.Jsons;
+import io.airbyte.integrations.destination_async.GlobalMemoryManager;
 import io.airbyte.protocol.models.v0.AirbyteMessage;
 import io.airbyte.protocol.models.v0.AirbyteMessage.Type;
 import io.airbyte.protocol.models.v0.AirbyteStateMessage;
@@ -21,6 +22,9 @@ import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
 
 class GlobalAsyncStateManagerTest {
+  private static final long TOTAL_QUEUES_MAX_SIZE_LIMIT_BYTES = 100 * 1024 * 1024; // 10MB
+
+  private static final long STATE_MSG_SIZE = 1000;
 
   private static final String STREAM_NAME = "id_and_name";
   private static final String STREAM_NAME2 = STREAM_NAME + 2;
@@ -53,7 +57,7 @@ class GlobalAsyncStateManagerTest {
 
   @Test
   void testBasic() {
-    final GlobalAsyncStateManager stateManager = new GlobalAsyncStateManager();
+    final GlobalAsyncStateManager stateManager = new GlobalAsyncStateManager(new GlobalMemoryManager(TOTAL_QUEUES_MAX_SIZE_LIMIT_BYTES));
 
     final var firstStateId = stateManager.getStateIdAndIncrementCounter(STREAM1_DESC);
     final var secondStateId = stateManager.getStateIdAndIncrementCounter(STREAM1_DESC);
@@ -64,7 +68,7 @@ class GlobalAsyncStateManagerTest {
     var flushed = stateManager.flushStates();
     assertEquals(0, flushed.size());
 
-    stateManager.trackState(STREAM1_STATE_MESSAGE1);
+    stateManager.trackState(STREAM1_STATE_MESSAGE1, STATE_MSG_SIZE);
     flushed = stateManager.flushStates();
     assertEquals(List.of(STREAM1_STATE_MESSAGE1), flushed);
   }
@@ -74,25 +78,25 @@ class GlobalAsyncStateManagerTest {
 
     @Test
     void testEmptyQueuesGlobalState() {
-      final GlobalAsyncStateManager stateManager = new GlobalAsyncStateManager();
+      final GlobalAsyncStateManager stateManager = new GlobalAsyncStateManager(new GlobalMemoryManager(TOTAL_QUEUES_MAX_SIZE_LIMIT_BYTES));
 
       // GLOBAL
-      stateManager.trackState(GLOBAL_STATE_MESSAGE1);
+      stateManager.trackState(GLOBAL_STATE_MESSAGE1, STATE_MSG_SIZE);
       assertEquals(List.of(GLOBAL_STATE_MESSAGE1), stateManager.flushStates());
 
-      assertThrows(IllegalArgumentException.class, () -> stateManager.trackState(STREAM1_STATE_MESSAGE1));
+      assertThrows(IllegalArgumentException.class, () -> stateManager.trackState(STREAM1_STATE_MESSAGE1, STATE_MSG_SIZE));
     }
 
     @Test
     void testConversion() {
-      final GlobalAsyncStateManager stateManager = new GlobalAsyncStateManager();
+      final GlobalAsyncStateManager stateManager = new GlobalAsyncStateManager(new GlobalMemoryManager(TOTAL_QUEUES_MAX_SIZE_LIMIT_BYTES));
 
       final var preConvertId0 = simulateIncomingRecords(STREAM1_DESC, 10, stateManager);
       final var preConvertId1 = simulateIncomingRecords(STREAM2_DESC, 10, stateManager);
       final var preConvertId2 = simulateIncomingRecords(STREAM3_DESC, 10, stateManager);
       assertEquals(3, Set.of(preConvertId0, preConvertId1, preConvertId2).size());
 
-      stateManager.trackState(GLOBAL_STATE_MESSAGE1);
+      stateManager.trackState(GLOBAL_STATE_MESSAGE1, STATE_MSG_SIZE);
 
       // Since this is actually a global state, we can only flush after all streams are done.
       stateManager.decrement(preConvertId0, 10);
@@ -105,27 +109,27 @@ class GlobalAsyncStateManagerTest {
 
     @Test
     void testCorrectFlushingOneStream() {
-      final GlobalAsyncStateManager stateManager = new GlobalAsyncStateManager();
+      final GlobalAsyncStateManager stateManager = new GlobalAsyncStateManager(new GlobalMemoryManager(TOTAL_QUEUES_MAX_SIZE_LIMIT_BYTES));
 
       final var preConvertId0 = simulateIncomingRecords(STREAM1_DESC, 10, stateManager);
-      stateManager.trackState(GLOBAL_STATE_MESSAGE1);
+      stateManager.trackState(GLOBAL_STATE_MESSAGE1, STATE_MSG_SIZE);
       stateManager.decrement(preConvertId0, 10);
       assertEquals(List.of(GLOBAL_STATE_MESSAGE1), stateManager.flushStates());
 
       final var afterConvertId1 = simulateIncomingRecords(STREAM1_DESC, 10, stateManager);
-      stateManager.trackState(GLOBAL_STATE_MESSAGE2);
+      stateManager.trackState(GLOBAL_STATE_MESSAGE2, STATE_MSG_SIZE);
       stateManager.decrement(afterConvertId1, 10);
       assertEquals(List.of(GLOBAL_STATE_MESSAGE2), stateManager.flushStates());
     }
 
     @Test
     void testCorrectFlushingManyStreams() {
-      final GlobalAsyncStateManager stateManager = new GlobalAsyncStateManager();
+      final GlobalAsyncStateManager stateManager = new GlobalAsyncStateManager(new GlobalMemoryManager(TOTAL_QUEUES_MAX_SIZE_LIMIT_BYTES));
 
       final var preConvertId0 = simulateIncomingRecords(STREAM1_DESC, 10, stateManager);
       final var preConvertId1 = simulateIncomingRecords(STREAM2_DESC, 10, stateManager);
       assertNotEquals(preConvertId0, preConvertId1);
-      stateManager.trackState(GLOBAL_STATE_MESSAGE1);
+      stateManager.trackState(GLOBAL_STATE_MESSAGE1, STATE_MSG_SIZE);
       stateManager.decrement(preConvertId0, 10);
       stateManager.decrement(preConvertId1, 10);
       assertEquals(List.of(GLOBAL_STATE_MESSAGE1), stateManager.flushStates());
@@ -133,7 +137,7 @@ class GlobalAsyncStateManagerTest {
       final var afterConvertId0 = simulateIncomingRecords(STREAM1_DESC, 10, stateManager);
       final var afterConvertId1 = simulateIncomingRecords(STREAM2_DESC, 10, stateManager);
       assertEquals(afterConvertId0, afterConvertId1);
-      stateManager.trackState(GLOBAL_STATE_MESSAGE2);
+      stateManager.trackState(GLOBAL_STATE_MESSAGE2, STATE_MSG_SIZE);
       stateManager.decrement(afterConvertId0, 20);
       assertEquals(List.of(GLOBAL_STATE_MESSAGE2), stateManager.flushStates());
     }
@@ -145,26 +149,26 @@ class GlobalAsyncStateManagerTest {
 
     @Test
     void testEmptyQueues() {
-      final GlobalAsyncStateManager stateManager = new GlobalAsyncStateManager();
+      final GlobalAsyncStateManager stateManager = new GlobalAsyncStateManager(new GlobalMemoryManager(TOTAL_QUEUES_MAX_SIZE_LIMIT_BYTES));
 
       // GLOBAL
-      stateManager.trackState(STREAM1_STATE_MESSAGE1);
+      stateManager.trackState(STREAM1_STATE_MESSAGE1, STATE_MSG_SIZE);
       assertEquals(List.of(STREAM1_STATE_MESSAGE1), stateManager.flushStates());
 
-      assertThrows(IllegalArgumentException.class, () -> stateManager.trackState(GLOBAL_STATE_MESSAGE1));
+      assertThrows(IllegalArgumentException.class, () -> stateManager.trackState(GLOBAL_STATE_MESSAGE1, STATE_MSG_SIZE));
     }
 
     @Test
     void testCorrectFlushingOneStream() {
-      final GlobalAsyncStateManager stateManager = new GlobalAsyncStateManager();
+      final GlobalAsyncStateManager stateManager = new GlobalAsyncStateManager(new GlobalMemoryManager(TOTAL_QUEUES_MAX_SIZE_LIMIT_BYTES));
 
       var stateId = simulateIncomingRecords(STREAM1_DESC, 3, stateManager);
-      stateManager.trackState(STREAM1_STATE_MESSAGE1);
+      stateManager.trackState(STREAM1_STATE_MESSAGE1, STATE_MSG_SIZE);
       stateManager.decrement(stateId, 3);
       assertEquals(List.of(STREAM1_STATE_MESSAGE1), stateManager.flushStates());
 
       stateId = simulateIncomingRecords(STREAM1_DESC, 10, stateManager);
-      stateManager.trackState(STREAM1_STATE_MESSAGE2);
+      stateManager.trackState(STREAM1_STATE_MESSAGE2, STATE_MSG_SIZE);
       stateManager.decrement(stateId, 10);
       assertEquals(List.of(STREAM1_STATE_MESSAGE2), stateManager.flushStates());
 
@@ -172,18 +176,18 @@ class GlobalAsyncStateManagerTest {
 
     @Test
     void testCorrectFlushingManyStream() {
-      final GlobalAsyncStateManager stateManager = new GlobalAsyncStateManager();
+      final GlobalAsyncStateManager stateManager = new GlobalAsyncStateManager(new GlobalMemoryManager(TOTAL_QUEUES_MAX_SIZE_LIMIT_BYTES));
 
       final var stream1StateId = simulateIncomingRecords(STREAM1_DESC, 3, stateManager);
       final var stream2StateId = simulateIncomingRecords(STREAM2_DESC, 7, stateManager);
 
-      stateManager.trackState(STREAM1_STATE_MESSAGE1);
+      stateManager.trackState(STREAM1_STATE_MESSAGE1, STATE_MSG_SIZE);
       stateManager.decrement(stream1StateId, 3);
       assertEquals(List.of(STREAM1_STATE_MESSAGE1), stateManager.flushStates());
 
       stateManager.decrement(stream2StateId, 4);
       assertEquals(List.of(), stateManager.flushStates());
-      stateManager.trackState(STREAM1_STATE_MESSAGE2);
+      stateManager.trackState(STREAM1_STATE_MESSAGE2, STATE_MSG_SIZE);
       stateManager.decrement(stream2StateId, 3);
       // only flush state if counter is 0.
       assertEquals(List.of(STREAM1_STATE_MESSAGE2), stateManager.flushStates());


### PR DESCRIPTION
## What
*Describe what the change is solving*
*It helps to add screenshots if it affects the frontend.*

## How
*Describe the solution*

## Recommended reading order
1. `x.java`
2. `y.python`

## 🚨 User Impact 🚨
*Are there any breaking changes? What is the end result perceived by the user?*

*For connector PRs, use this section to explain which type of semantic versioning bump occurs as a result of the changes. Refer to our [Semantic Versioning for Connectors](https://docs.airbyte.com/contributing-to-airbyte/#semantic-versioning-for-connectors) guidelines for more information. **Breaking changes to connectors must be documented by an Airbyte engineer (PR author, or reviewer for community PRs) by using the [Breaking Change Release Playbook](https://docs.google.com/document/d/1VYQggHbL_PN0dDDu7rCyzBLGRtX-R3cpwXaY8QxEgzw/edit).***

*If there are breaking changes, please merge this PR with the 🚨🚨 emoji so changelog authors can further highlight this if needed.*


## Pre-merge Actions
*Expand the relevant checklist and delete the others.*

<details><summary><strong>New Connector</strong></summary>

### Community member or Airbyter

- **Community member?** Grant edit access to maintainers ([instructions](https://docs.github.com/en/github/collaborating-with-pull-requests/working-with-forks/allowing-changes-to-a-pull-request-branch-created-from-a-fork#enabling-repository-maintainer-permissions-on-existing-pull-requests))
- Unit & integration tests added and passing. Community members, please provide proof of success locally e.g: screenshot or copy-paste unit, integration, and acceptance test output. To run acceptance tests for a Python connector, follow instructions in the README. For java connectors run `./gradlew :airbyte-integrations:connectors:<name>:integrationTest`.
- Connector version is set to `0.0.1`
    - `Dockerfile` has version `0.0.1`
- Documentation updated
    - Connector's `README.md`
    - Connector's `bootstrap.md`. See [description and examples](https://docs.google.com/document/d/1ypdgmwmEHWv-TrO4_YOQ7pAJGVrMp5BOkEVh831N260/edit?usp=sharing)
    - `docs/integrations/<source or destination>/<name>.md` including changelog with an entry for the initial version. See changelog [example](https://docs.airbyte.io/integrations/sources/stripe#changelog)
    - `docs/integrations/README.md`

### Airbyter

If this is a community PR, the Airbyte engineer reviewing this PR is responsible for the below items.

- Create a non-forked branch based on this PR and test the below items on it
- Build is successful
- If new credentials are required for use in CI, add them to GSM. [Instructions](https://docs.airbyte.io/connector-development#using-credentials-in-ci).

</details>

<details><summary><strong>Updating a connector</strong></summary>

### Community member or Airbyter

- Grant edit access to maintainers ([instructions](https://docs.github.com/en/github/collaborating-with-pull-requests/working-with-forks/allowing-changes-to-a-pull-request-branch-created-from-a-fork#enabling-repository-maintainer-permissions-on-existing-pull-requests))
- Unit & integration tests added


### Airbyter

If this is a community PR, the Airbyte engineer reviewing this PR is responsible for the below items.

- Create a non-forked branch based on this PR and test the below items on it
- Build is successful
- If new credentials are required for use in CI, add them to GSM. [Instructions](https://docs.airbyte.io/connector-development#using-credentials-in-ci).

</details>

<details><summary><strong>Connector Generator</strong></summary>

- Issue acceptance criteria met
- PR name follows [PR naming conventions](https://docs.airbyte.com/contributing-to-airbyte/issues-and-pull-requests#pull-request-title-convention)
- If adding a new generator, add it to the [list of scaffold modules being tested](https://github.com/airbytehq/airbyte/blob/master/airbyte-integrations/connector-templates/generator/build.gradle#L41)
- The generator test modules (all connectors with `-scaffold` in their name) have been updated with the latest scaffold by running `./gradlew :airbyte-integrations:connector-templates:generator:testScaffoldTemplates` then checking in your changes
- Documentation which references the generator is updated as needed

</details>
