### PR TITLE
Fix: icon urls in connector reports

### DIFF
--- a/airbyte-ci/connectors/metadata_service/orchestrator/orchestrator/assets/registry_report.py
+++ b/airbyte-ci/connectors/metadata_service/orchestrator/orchestrator/assets/registry_report.py
@@ -111,7 +111,6 @@ def augment_and_normalize_connector_dataframes(
 
     total_registry["issue_url"] = total_registry.apply(issue_url, axis=1)
     total_registry["test_summary_url"] = total_registry.apply(test_summary_url, axis=1)
-    total_registry["icon_url"] = total_registry.apply(icon_url, axis=1)
 
     # Merge docker repo and version into separate columns
     total_registry["docker_image_oss"] = total_registry.apply(lambda x: merge_docker_repo_and_version(x, OSS_SUFFIX), axis=1)
@@ -205,7 +204,7 @@ def connector_registry_report(context, all_destinations_dataframe, all_sources_d
             "title": "Definition Id",
         },
         {
-            "column": "icon_url",
+            "column": "iconUrl_oss",
             "title": "Icon",
             "formatter": icon_image_html,
         },

--- a/docusaurus/src/components/ConnectorRegistry.jsx
+++ b/docusaurus/src/components/ConnectorRegistry.jsx
@@ -71,8 +71,8 @@ export default function ConnectorRegistry({ type }) {
                   </strong>
                 </td>
                 <td>
-                  {connector.icon_url ? (
-                    <img src={connector.icon_url} style={iconStyle} />
+                  {connector.iconUrl_oss ? (
+                    <img src={connector.iconUrl_oss} style={iconStyle} />
                   ) : null}
                 </td>
                 {/* min width to prevent wrapping */}


### PR DESCRIPTION
## What
Updates the following to use the new icon urls
1. https://docs.airbyte.com/integrations/
2. https://connectors.airbyte.com/files/generated_reports/connector_registry_report.html
