### PR TITLE
connectors-ci: run metadata validation on test

### DIFF
--- a/tools/ci_connector_ops/ci_connector_ops/pipelines/README.md
+++ b/tools/ci_connector_ops/ci_connector_ops/pipelines/README.md
@@ -134,14 +134,13 @@ Test connectors changed on the current branch:
 ```mermaid
 flowchart TD
     entrypoint[[For each selected connector]]
-    subgraph version ["Connector version checks"]
-        sem["Check version follows semantic versionning"]
-        incr["Check version is incremented"]
-        sem --> incr
-    end
     subgraph static ["Static code analysis"]
       qa[Run QA checks]
       fmt[Run code format checks]
+      sem["Check version follows semantic versionning"]
+      incr["Check version is incremented"]
+      metadata_validation["Run metadata validation on metadata.yaml"]
+      sem --> incr
     end
     subgraph tests ["Tests"]
         build[Build connector docker image]
@@ -157,9 +156,8 @@ flowchart TD
         build-->integration
         build-->cat
     end
-    entrypoint-->version
-    version-->static
-    version-->tests
+    entrypoint-->static
+    entrypoint-->tests
     report["Build test report"]
     tests-->report
     static-->report

--- a/tools/ci_connector_ops/ci_connector_ops/pipelines/tests/__init__.py
+++ b/tools/ci_connector_ops/ci_connector_ops/pipelines/tests/__init__.py
@@ -13,7 +13,7 @@ from ci_connector_ops.pipelines.contexts import ConnectorContext
 from ci_connector_ops.pipelines.pipelines.metadata import MetadataValidation
 from ci_connector_ops.pipelines.tests import java_connectors, python_connectors
 from ci_connector_ops.pipelines.tests.common import QaChecks, VersionFollowsSemverCheck, VersionIncrementCheck
-from ci_connector_ops.utils import ConnectorLanguage
+from ci_connector_ops.utils import METADATA_FILE_NAME, ConnectorLanguage
 
 LANGUAGE_MAPPING = {
     "run_all_tests": {
@@ -38,7 +38,7 @@ async def run_metadata_validation(context: ConnectorContext) -> List[StepResult]
         List[StepResult]: The results of the metadata validation steps.
     """
     context.logger.info("Run metadata validation.")
-    return [await MetadataValidation(context).run()]
+    return [await MetadataValidation(context, context.connector.code_directory / METADATA_FILE_NAME).run()]
 
 
 async def run_version_checks(context: ConnectorContext) -> List[StepResult]:

--- a/tools/ci_connector_ops/ci_connector_ops/pipelines/tests/__init__.py
+++ b/tools/ci_connector_ops/ci_connector_ops/pipelines/tests/__init__.py
@@ -10,6 +10,7 @@ import anyio
 import asyncer
 from ci_connector_ops.pipelines.bases import ConnectorReport, StepResult
 from ci_connector_ops.pipelines.contexts import ConnectorContext
+from ci_connector_ops.pipelines.pipelines.metadata import MetadataValidation
 from ci_connector_ops.pipelines.tests import java_connectors, python_connectors
 from ci_connector_ops.pipelines.tests.common import QaChecks, VersionFollowsSemverCheck, VersionIncrementCheck
 from ci_connector_ops.utils import ConnectorLanguage
@@ -26,6 +27,18 @@ LANGUAGE_MAPPING = {
         # ConnectorLanguage.JAVA: java_connectors.run_code_format_checks
     },
 }
+
+
+async def run_metadata_validation(context: ConnectorContext) -> List[StepResult]:
+    """Run the metadata validation on a connector.
+    Args:
+        context (ConnectorContext): The current connector context.
+
+    Returns:
+        List[StepResult]: The results of the metadata validation steps.
+    """
+    context.logger.info("Run metadata validation.")
+    return [await MetadataValidation(context).run()]
 
 
 async def run_version_checks(context: ConnectorContext) -> List[StepResult]:
@@ -102,6 +115,7 @@ async def run_connector_test_pipeline(context: ConnectorContext, semaphore: anyi
         async with context:
             async with asyncer.create_task_group() as task_group:
                 tasks = [
+                    task_group.soonify(run_metadata_validation)(context),
                     task_group.soonify(run_version_checks)(context),
                     task_group.soonify(run_qa_checks)(context),
                     task_group.soonify(run_code_format_checks)(context),


### PR DESCRIPTION
## What
Closes #25161 

We want to run metadata validation as part of the main test pipeline for connectors.


## How
Add a new step to run as part of the `run_connector_test_pipeline` function.
<img width="764" alt="Screen Shot 2023-05-26 at 10 38 02" src="https://github.com/airbytehq/airbyte/assets/5551758/1c9da861-9143-4b89-87be-8b619d77942e">


## 🚨 User Impact 🚨
None :Metadata validation currently runs as a separate pipeline whose success is required for merging a PR.
When successful automated test on PR will be required to merge a PR we can remove[ this currently existing pipeline](https://github.com/airbytehq/airbyte/blob/master/.github/workflows/metadata_validate_manifest_dagger.yml#L1). 