### PR TITLE
Source Amazon Ads: fix version in metadata.yaml

### DIFF
--- a/airbyte-integrations/connectors/source-amazon-ads/metadata.yaml
+++ b/airbyte-integrations/connectors/source-amazon-ads/metadata.yaml
@@ -8,7 +8,7 @@ data:
   connectorSubtype: api
   connectorType: source
   definitionId: c6b0a29e-1da9-4512-9002-7bfd0cba2246
-  dockerImageTag: 1.0.6
+  dockerImageTag: 1.1.0
   dockerRepository: airbyte/source-amazon-ads
   githubIssueLabel: source-amazon-ads
   icon: amazonads.svg


### PR DESCRIPTION
## What
*Connector's version in docker image tag and metadata.yaml do not match.*

## How
*Upgrade version in metadata.yaml*
