### PR TITLE
connectors-ci: avoid rate limit on Python install

### DIFF
--- a/.github/actions/run-dagger-pipeline/action.yml
+++ b/.github/actions/run-dagger-pipeline/action.yml
@@ -10,6 +10,9 @@ inputs:
   context:
     description: "CI context (e.g., pull_request, manual)"
     required: true
+  github_token:
+    description: "GitHub token"
+    required: true
 runs:
   using: "composite"
   steps:
@@ -31,6 +34,7 @@ runs:
       uses: actions/setup-python@v4
       with:
         python-version: "3.10"
+        token: ${{ inputs.github_token }}
     - name: Install ci-connector-ops package
       shell: bash
       run: pip install --quiet -e ./tools/ci_connector_ops\[pipelines]\

--- a/.github/workflows/connector_integration_test_single_dagger.yml
+++ b/.github/workflows/connector_integration_test_single_dagger.yml
@@ -38,6 +38,7 @@ jobs:
         uses: actions/setup-python@v4
         with:
           python-version: "3.10"
+          token: ${{ secrets.GH_PAT_MAINTENANCE_OCTAVIA }}
       - name: Install ci-connector-ops package
         run: pip install -e ./tools/ci_connector_ops\[pipelines]\
       - name: Run airbyte-ci connectors test [WORKFLOW DISPATCH]

--- a/.github/workflows/connector_nightly_builds_dagger.yml
+++ b/.github/workflows/connector_nightly_builds_dagger.yml
@@ -44,6 +44,7 @@ jobs:
         uses: actions/setup-python@v4
         with:
           python-version: "3.10"
+          token: ${{ secrets.GH_PAT_MAINTENANCE_OCTAVIA }}
       - name: Install ci-connector-ops package
         run: pip install ./tools/ci_connector_ops\[pipelines]\
       - name: Test connectors

--- a/.github/workflows/gradle.yml
+++ b/.github/workflows/gradle.yml
@@ -108,6 +108,7 @@ jobs:
       - uses: actions/setup-python@v4
         with:
           python-version: "3.9"
+          token: ${{ secrets.GH_PAT_MAINTENANCE_OCTAVIA }}
 
       - name: Set up CI Gradle Properties
         run: |

--- a/.github/workflows/metadata_validate_manifest_dagger.yml
+++ b/.github/workflows/metadata_validate_manifest_dagger.yml
@@ -20,3 +20,4 @@ jobs:
         with:
           subcommand: "metadata validate"
           context: "pull_request"
+          github-token: ${{ secrets.GH_PAT_MAINTENANCE_OCTAVIA }}

--- a/.github/workflows/publish_connectors.yml
+++ b/.github/workflows/publish_connectors.yml
@@ -56,3 +56,4 @@ jobs:
         with:
           subcommand: "connectors ${{ github.event.inputs.connectors-options }} publish ${{ github.event.inputs.publish-options }}"
           context: "manual"
+          github-token: ${{ secrets.GH_PAT_MAINTENANCE_OCTAVIA }}


### PR DESCRIPTION
## What
Python installation from github action are rate limited to 60 install per hour.
[We can pass a GitHub token to overcome this limit 
](https://github.com/actions/setup-python/blob/main/docs/advanced-usage.md#avoiding-rate-limit-issues)