### PR TITLE
Multi-architecture normalization build (local)

### DIFF
--- a/airbyte-integrations/bases/base-normalization/build.gradle
+++ b/airbyte-integrations/bases/base-normalization/build.gradle
@@ -54,11 +54,12 @@ def buildAirbyteDocker(String customConnector) {
     // We are lucky that all the python code dbt uses is mutli-arch compatible
 
     def arch = 'linux/amd64'
-    if (Os.isArch("aarch_64")) {
+    if (Os.isArch("aarch_64") || Os.isArch("aarch64")) {
         arch = 'linux/arm64'
     }
 
     def baseCommand = ['docker', 'buildx', 'build', '--load', '--platform', arch, '-f', getDockerfile(customConnector), '-t', getImageNameWithTag(customConnector), '.']
+    println("Building normalization container: " + baseCommand.join(" "))
 
     return {
         commandLine baseCommand

--- a/airbyte-integrations/bases/base-normalization/build.gradle
+++ b/airbyte-integrations/bases/base-normalization/build.gradle
@@ -1,3 +1,5 @@
+import org.apache.tools.ant.taskdefs.condition.Os
+
 plugins {
     id 'airbyte-docker'
     id 'airbyte-python'
@@ -47,7 +49,17 @@ static def getImageNameWithTag(String customConnector) {
 
 
 def buildAirbyteDocker(String customConnector) {
-    def baseCommand = ['docker', 'build', '.', '-f', getDockerfile(customConnector), '-t', getImageNameWithTag(customConnector)]
+    // def baseCommand = ['docker', 'build', '.', '-f', getDockerfile(customConnector), '-t', getImageNameWithTag(customConnector)]
+    // As the base dbt image (https://hub.docker.com/r/fishtownanalytics/dbt/tags) we are using is only build for amd64, we need to use buildkit to force builds for your local environment
+    // We are lucky that all the python code dbt uses is mutli-arch compatible
+
+    def arch = 'linux/amd64'
+    if (Os.isArch("aarch_64")) {
+        arch = 'linux/arm64'
+    }
+
+    def baseCommand = ['docker', 'buildx', 'build', '--load', '--platform', arch, '-f', getDockerfile(customConnector), '-t', getImageNameWithTag(customConnector), '.']
+
     return {
         commandLine baseCommand
     }


### PR DESCRIPTION
When building and testing normalization locally, we need to force the base images to match the local host OS.

This is not a problem when publishing the connectors as `airbyte-ci`/dagger handles this for us
