### PR TITLE
CAT: Ensure we only generate iso8601 with hypothesis in backwards compatibility test

### DIFF
--- a/airbyte-integrations/bases/connector-acceptance-test/connector_acceptance_test/utils/backward_compatibility.py
+++ b/airbyte-integrations/bases/connector-acceptance-test/connector_acceptance_test/utils/backward_compatibility.py
@@ -5,15 +5,14 @@
 from abc import ABC, abstractmethod
 from deepdiff import DeepDiff
 from enum import Enum
-import datetime
 import jsonschema
 
-from hypothesis import HealthCheck, Verbosity, given, settings, strategies as st
+from hypothesis import HealthCheck, Verbosity, given, settings
 from hypothesis_jsonschema import from_schema
 
 from airbyte_cdk.models import ConnectorSpecification
 from connector_acceptance_test.utils import SecretDict
-from typing import Dict, Any, Tuple
+from typing import Dict, Any
 
 
 class BackwardIncompatibilityContext(Enum):


### PR DESCRIPTION
## What
Ok so we have one GLOBAL problem of our formats do not match ALL valid ISO dates.

But lets ignore that.

The subproblem here is backwards compatibility tests are failing for the following reasons
1. Hypothesis generates date-times that represent all valid RFC3339 values (an ISO subset) (screenshot 1)
2. Our `format` for `date-time` in our specs are very strict about having 3 miliseconds (screenshot 2)

This causes failing backwards compatibility tests ([slack thread](https://airbytehq-team.slack.com/archives/C02UF50V9HA/p1685112086208119))

![image](https://github.com/airbytehq/airbyte/assets/1325608/806d3634-d4d6-43ed-9925-9b091e06d6fd)
![image](https://github.com/airbytehq/airbyte/assets/1325608/eea3e4dd-c89b-4907-b7f2-7e6f7b7f522c)

## Solution
Only generate date-times that represent our valid version

blocks https://github.com/airbytehq/airbyte/pull/26535