### PR TITLE
partial deserialize airbyte message in destination

### DIFF
--- a/airbyte-integrations/bases/base-java/src/main/java/io/airbyte/integrations/destination_async/AsyncStreamConsumer.java
+++ b/airbyte-integrations/bases/base-java/src/main/java/io/airbyte/integrations/destination_async/AsyncStreamConsumer.java
@@ -115,7 +115,7 @@ public class AsyncStreamConsumer implements SerializedAirbyteMessageConsumer {
             validateRecord(message);
           }
 
-          bufferEnqueue.addRecord(message, sizeInBytes * 10);
+          bufferEnqueue.addRecord(message, sizeInBytes);
         });
   }
 

--- a/airbyte-integrations/bases/base-java/src/main/java/io/airbyte/integrations/destination_async/DestinationFlushFunction.java
+++ b/airbyte-integrations/bases/base-java/src/main/java/io/airbyte/integrations/destination_async/DestinationFlushFunction.java
@@ -4,6 +4,7 @@
 
 package io.airbyte.integrations.destination_async;
 
+import io.airbyte.integrations.destination_async.partial_messages.PartialAirbyteMessage;
 import io.airbyte.protocol.models.v0.AirbyteMessage;
 import io.airbyte.protocol.models.v0.StreamDescriptor;
 import java.util.stream.Stream;
@@ -35,7 +36,7 @@ public interface DestinationFlushFunction {
    *        {@link #getOptimalBatchSizeBytes()} size
    * @throws Exception
    */
-  void flush(StreamDescriptor decs, Stream<AirbyteMessage> stream) throws Exception;
+  void flush(StreamDescriptor decs, Stream<PartialAirbyteMessage> stream) throws Exception;
 
   /**
    * When invoking {@link #flush(StreamDescriptor, Stream)}, best effort attempt to invoke flush with

--- a/airbyte-integrations/bases/base-java/src/main/java/io/airbyte/integrations/destination_async/FlushWorkers.java
+++ b/airbyte-integrations/bases/base-java/src/main/java/io/airbyte/integrations/destination_async/FlushWorkers.java
@@ -4,6 +4,7 @@
 
 package io.airbyte.integrations.destination_async;
 
+import io.airbyte.commons.json.Jsons;
 import io.airbyte.integrations.destination_async.buffers.BufferDequeue;
 import io.airbyte.integrations.destination_async.buffers.StreamAwareQueue.MessageWithMeta;
 import io.airbyte.integrations.destination_async.state.FlushFailure;
@@ -200,7 +201,10 @@ public class FlushWorkers implements AutoCloseable {
               AirbyteFileUtils.byteCountToDisplaySize(batch.getSizeInBytes()));
 
           flusher.flush(desc, batch.getData().stream().map(MessageWithMeta::message));
-          batch.flushStates(stateIdToCount).forEach(outputRecordCollector);
+          batch.flushStates(stateIdToCount)
+              .stream()
+              .map(partial -> Jsons.deserialize(partial.getSerialized(), AirbyteMessage.class))
+              .forEach(outputRecordCollector);
         }
 
         log.info("Flush Worker ({}) -- Worker finished flushing. Current queue size: {}",

--- a/airbyte-integrations/bases/base-java/src/main/java/io/airbyte/integrations/destination_async/buffers/BufferEnqueue.java
+++ b/airbyte-integrations/bases/base-java/src/main/java/io/airbyte/integrations/destination_async/buffers/BufferEnqueue.java
@@ -7,8 +7,8 @@ package io.airbyte.integrations.destination_async.buffers;
 import static java.lang.Thread.sleep;
 
 import io.airbyte.integrations.destination_async.GlobalMemoryManager;
+import io.airbyte.integrations.destination_async.partial_messages.PartialAirbyteMessage;
 import io.airbyte.integrations.destination_async.state.GlobalAsyncStateManager;
-import io.airbyte.protocol.models.v0.AirbyteMessage;
 import io.airbyte.protocol.models.v0.AirbyteMessage.Type;
 import io.airbyte.protocol.models.v0.StreamDescriptor;
 import java.util.concurrent.ConcurrentMap;
@@ -38,7 +38,7 @@ public class BufferEnqueue {
    * @param message to buffer
    * @param sizeInBytes
    */
-  public void addRecord(final AirbyteMessage message, final Integer sizeInBytes) {
+  public void addRecord(final PartialAirbyteMessage message, final Integer sizeInBytes) {
     if (message.getType() == Type.RECORD) {
       handleRecord(message, sizeInBytes);
     } else if (message.getType() == Type.STATE) {
@@ -46,7 +46,7 @@ public class BufferEnqueue {
     }
   }
 
-  private void handleRecord(final AirbyteMessage message, final Integer sizeInBytes) {
+  private void handleRecord(final PartialAirbyteMessage message, final Integer sizeInBytes) {
     final StreamDescriptor streamDescriptor = extractStateFromRecord(message);
     if (streamDescriptor != null && !buffers.containsKey(streamDescriptor)) {
       buffers.put(streamDescriptor, new StreamAwareQueue(memoryManager.requestMemory()));
@@ -74,7 +74,7 @@ public class BufferEnqueue {
     }
   }
 
-  private static StreamDescriptor extractStateFromRecord(final AirbyteMessage message) {
+  private static StreamDescriptor extractStateFromRecord(final PartialAirbyteMessage message) {
     return new StreamDescriptor()
         .withNamespace(message.getRecord().getNamespace())
         .withName(message.getRecord().getStream());

--- a/airbyte-integrations/bases/base-java/src/main/java/io/airbyte/integrations/destination_async/buffers/BufferManager.java
+++ b/airbyte-integrations/bases/base-java/src/main/java/io/airbyte/integrations/destination_async/buffers/BufferManager.java
@@ -5,6 +5,7 @@
 package io.airbyte.integrations.destination_async.buffers;
 
 import com.google.common.annotations.VisibleForTesting;
+import io.airbyte.integrations.destination_async.AirbyteFileUtils;
 import io.airbyte.integrations.destination_async.FlushWorkers;
 import io.airbyte.integrations.destination_async.GlobalMemoryManager;
 import io.airbyte.integrations.destination_async.state.GlobalAsyncStateManager;
@@ -71,8 +72,8 @@ public class BufferManager {
 
     queueInfo
         .append(String.format("  Global Mem Manager -- max: %s, allocated: %s (%s MB), %% used: %s",
-            FileUtils.byteCountToDisplaySize(memoryManager.getMaxMemoryBytes()),
-            FileUtils.byteCountToDisplaySize(memoryManager.getCurrentMemoryBytes()),
+            AirbyteFileUtils.byteCountToDisplaySize(memoryManager.getMaxMemoryBytes()),
+            AirbyteFileUtils.byteCountToDisplaySize(memoryManager.getCurrentMemoryBytes()),
             (double) memoryManager.getCurrentMemoryBytes() / 1024 / 1024,
             (double) memoryManager.getCurrentMemoryBytes() / memoryManager.getMaxMemoryBytes()))
         .append(System.lineSeparator());
@@ -81,7 +82,7 @@ public class BufferManager {
       final var queue = entry.getValue();
       queueInfo.append(
           String.format("  Queue name: %s, num records: %d, num bytes: %s",
-              entry.getKey().getName(), queue.size(), FileUtils.byteCountToDisplaySize(queue.getCurrentMemoryUsage())))
+              entry.getKey().getName(), queue.size(), AirbyteFileUtils.byteCountToDisplaySize(queue.getCurrentMemoryUsage())))
           .append(System.lineSeparator());
     }
     log.info(queueInfo.toString());

--- a/airbyte-integrations/bases/base-java/src/main/java/io/airbyte/integrations/destination_async/buffers/MemoryAwareMessageBatch.java
+++ b/airbyte-integrations/bases/base-java/src/main/java/io/airbyte/integrations/destination_async/buffers/MemoryAwareMessageBatch.java
@@ -6,8 +6,8 @@ package io.airbyte.integrations.destination_async.buffers;
 
 import io.airbyte.integrations.destination_async.GlobalMemoryManager;
 import io.airbyte.integrations.destination_async.buffers.StreamAwareQueue.MessageWithMeta;
+import io.airbyte.integrations.destination_async.partial_messages.PartialAirbyteMessage;
 import io.airbyte.integrations.destination_async.state.GlobalAsyncStateManager;
-import io.airbyte.protocol.models.v0.AirbyteMessage;
 import java.util.List;
 import java.util.Map;
 import org.slf4j.Logger;
@@ -64,7 +64,7 @@ public class MemoryAwareMessageBatch implements AutoCloseable {
    *
    * @return list of states that can be flushed
    */
-  public List<AirbyteMessage> flushStates(final Map<Long, Long> stateIdToCount) {
+  public List<PartialAirbyteMessage> flushStates(final Map<Long, Long> stateIdToCount) {
     stateIdToCount.forEach(stateManager::decrement);
     return stateManager.flushStates();
   }

--- a/airbyte-integrations/bases/base-java/src/main/java/io/airbyte/integrations/destination_async/buffers/StreamAwareQueue.java
+++ b/airbyte-integrations/bases/base-java/src/main/java/io/airbyte/integrations/destination_async/buffers/StreamAwareQueue.java
@@ -4,7 +4,7 @@
 
 package io.airbyte.integrations.destination_async.buffers;
 
-import io.airbyte.protocol.models.v0.AirbyteMessage;
+import io.airbyte.integrations.destination_async.partial_messages.PartialAirbyteMessage;
 import java.time.Instant;
 import java.util.Optional;
 import java.util.concurrent.TimeUnit;
@@ -43,7 +43,7 @@ public class StreamAwareQueue {
     return memoryAwareQueue.size();
   }
 
-  public boolean offer(final AirbyteMessage message, final long messageSizeInBytes, final long stateId) {
+  public boolean offer(final PartialAirbyteMessage message, final long messageSizeInBytes, final long stateId) {
     if (memoryAwareQueue.offer(new MessageWithMeta(message, stateId), messageSizeInBytes)) {
       timeOfLastMessage.set(Instant.now());
       return true;
@@ -64,6 +64,6 @@ public class StreamAwareQueue {
     return memoryAwareQueue.poll(timeout, unit);
   }
 
-  public record MessageWithMeta(AirbyteMessage message, long stateId) {}
+  public record MessageWithMeta(PartialAirbyteMessage message, long stateId) {}
 
 }

--- a/airbyte-integrations/bases/base-java/src/main/java/io/airbyte/integrations/destination_async/partial_messages/PartialAirbyteMessage.java
+++ b/airbyte-integrations/bases/base-java/src/main/java/io/airbyte/integrations/destination_async/partial_messages/PartialAirbyteMessage.java
@@ -1,0 +1,88 @@
+/*
+ * Copyright (c) 2023 Airbyte, Inc., all rights reserved.
+ */
+
+package io.airbyte.integrations.destination_async.partial_messages;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.annotation.JsonPropertyDescription;
+import io.airbyte.protocol.models.v0.AirbyteMessage;
+
+public class PartialAirbyteMessage {
+
+  @JsonProperty("type")
+  @JsonPropertyDescription("Message type")
+  private AirbyteMessage.Type type;
+
+  @JsonProperty("record")
+  private PartialAirbyteRecordMessage record;
+
+  @JsonProperty("state")
+  private PartialAirbyteStateMessage state;
+
+  @JsonProperty("serialized")
+  private String serialized;
+
+  public PartialAirbyteMessage() {}
+
+  @JsonProperty("type")
+  public AirbyteMessage.Type getType() {
+    return type;
+  }
+
+  @JsonProperty("type")
+  public void setType(final AirbyteMessage.Type type) {
+    this.type = type;
+  }
+
+  public PartialAirbyteMessage withType(final AirbyteMessage.Type type) {
+    this.type = type;
+    return this;
+  }
+
+  @JsonProperty("record")
+  public PartialAirbyteRecordMessage getRecord() {
+    return record;
+  }
+
+  @JsonProperty("record")
+  public void setRecord(final PartialAirbyteRecordMessage record) {
+    this.record = record;
+  }
+
+  public PartialAirbyteMessage withRecord(final PartialAirbyteRecordMessage record) {
+    this.record = record;
+    return this;
+  }
+
+  @JsonProperty("state")
+  public PartialAirbyteStateMessage getState() {
+    return state;
+  }
+
+  @JsonProperty("state")
+  public void setState(final PartialAirbyteStateMessage state) {
+    this.state = state;
+  }
+
+  public PartialAirbyteMessage withState(final PartialAirbyteStateMessage state) {
+    this.state = state;
+    return this;
+  }
+
+  @JsonProperty("serialized")
+  public String getSerialized() {
+    return serialized;
+  }
+
+  @JsonProperty("serialized")
+  public void setSerialized(final String serialized) {
+    this.serialized = serialized;
+  }
+
+  public PartialAirbyteMessage withSerialized(final String serialized) {
+    this.serialized = serialized;
+    return this;
+  }
+
+}

--- a/airbyte-integrations/bases/base-java/src/main/java/io/airbyte/integrations/destination_async/partial_messages/PartialAirbyteMessage.java
+++ b/airbyte-integrations/bases/base-java/src/main/java/io/airbyte/integrations/destination_async/partial_messages/PartialAirbyteMessage.java
@@ -7,6 +7,7 @@ package io.airbyte.integrations.destination_async.partial_messages;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonPropertyDescription;
 import io.airbyte.protocol.models.v0.AirbyteMessage;
+import java.util.Objects;
 
 public class PartialAirbyteMessage {
 
@@ -83,6 +84,34 @@ public class PartialAirbyteMessage {
   public PartialAirbyteMessage withSerialized(final String serialized) {
     this.serialized = serialized;
     return this;
+  }
+
+  // hack: doesn't contain serialized.
+  @Override
+  public boolean equals(final Object o) {
+    if (this == o) {
+      return true;
+    }
+    if (o == null || getClass() != o.getClass()) {
+      return false;
+    }
+    final PartialAirbyteMessage that = (PartialAirbyteMessage) o;
+    return type == that.type && Objects.equals(record, that.record) && Objects.equals(state, that.state);
+  }
+
+  @Override
+  public int hashCode() {
+    return Objects.hash(type, record, state);
+  }
+
+  @Override
+  public String toString() {
+    return "PartialAirbyteMessage{" +
+        "type=" + type +
+        ", record=" + record +
+        ", state=" + state +
+        ", serialized='" + serialized + '\'' +
+        '}';
   }
 
 }

--- a/airbyte-integrations/bases/base-java/src/main/java/io/airbyte/integrations/destination_async/partial_messages/PartialAirbyteRecordMessage.java
+++ b/airbyte-integrations/bases/base-java/src/main/java/io/airbyte/integrations/destination_async/partial_messages/PartialAirbyteRecordMessage.java
@@ -1,0 +1,48 @@
+/*
+ * Copyright (c) 2023 Airbyte, Inc., all rights reserved.
+ */
+
+package io.airbyte.integrations.destination_async.partial_messages;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+
+public class PartialAirbyteRecordMessage {
+
+  @JsonProperty("namespace")
+  private String namespace;
+  @JsonProperty("stream")
+  private String stream;
+
+  public PartialAirbyteRecordMessage() {}
+
+  @JsonProperty("namespace")
+  public String getNamespace() {
+    return namespace;
+  }
+
+  @JsonProperty("namespace")
+  public void setNamespace(final String namespace) {
+    this.namespace = namespace;
+  }
+
+  public PartialAirbyteRecordMessage withNamespace(final String namespace) {
+    this.namespace = namespace;
+    return this;
+  }
+
+  @JsonProperty("stream")
+  public String getStream() {
+    return stream;
+  }
+
+  @JsonProperty("stream")
+  public void setStream(final String stream) {
+    this.stream = stream;
+  }
+
+  public PartialAirbyteRecordMessage withStream(final String stream) {
+    this.stream = stream;
+    return this;
+  }
+
+}

--- a/airbyte-integrations/bases/base-java/src/main/java/io/airbyte/integrations/destination_async/partial_messages/PartialAirbyteRecordMessage.java
+++ b/airbyte-integrations/bases/base-java/src/main/java/io/airbyte/integrations/destination_async/partial_messages/PartialAirbyteRecordMessage.java
@@ -5,6 +5,7 @@
 package io.airbyte.integrations.destination_async.partial_messages;
 
 import com.fasterxml.jackson.annotation.JsonProperty;
+import java.util.Objects;
 
 public class PartialAirbyteRecordMessage {
 
@@ -43,6 +44,31 @@ public class PartialAirbyteRecordMessage {
   public PartialAirbyteRecordMessage withStream(final String stream) {
     this.stream = stream;
     return this;
+  }
+
+  @Override
+  public boolean equals(final Object o) {
+    if (this == o) {
+      return true;
+    }
+    if (o == null || getClass() != o.getClass()) {
+      return false;
+    }
+    final PartialAirbyteRecordMessage that = (PartialAirbyteRecordMessage) o;
+    return Objects.equals(namespace, that.namespace) && Objects.equals(stream, that.stream);
+  }
+
+  @Override
+  public int hashCode() {
+    return Objects.hash(namespace, stream);
+  }
+
+  @Override
+  public String toString() {
+    return "PartialAirbyteRecordMessage{" +
+        "namespace='" + namespace + '\'' +
+        ", stream='" + stream + '\'' +
+        '}';
   }
 
 }

--- a/airbyte-integrations/bases/base-java/src/main/java/io/airbyte/integrations/destination_async/partial_messages/PartialAirbyteStateMessage.java
+++ b/airbyte-integrations/bases/base-java/src/main/java/io/airbyte/integrations/destination_async/partial_messages/PartialAirbyteStateMessage.java
@@ -1,0 +1,50 @@
+/*
+ * Copyright (c) 2023 Airbyte, Inc., all rights reserved.
+ */
+
+package io.airbyte.integrations.destination_async.partial_messages;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+import io.airbyte.protocol.models.v0.AirbyteStateMessage.AirbyteStateType;
+
+public class PartialAirbyteStateMessage {
+
+  @JsonProperty("type")
+  private AirbyteStateType type;
+
+  @JsonProperty("stream")
+  private PartialAirbyteStreamState stream;
+
+  public PartialAirbyteStateMessage() {}
+
+  @JsonProperty("type")
+  public AirbyteStateType getType() {
+    return type;
+  }
+
+  @JsonProperty("type")
+  public void setType(final AirbyteStateType type) {
+    this.type = type;
+  }
+
+  public PartialAirbyteStateMessage withType(final AirbyteStateType type) {
+    this.type = type;
+    return this;
+  }
+
+  @JsonProperty("stream")
+  public PartialAirbyteStreamState getStream() {
+    return stream;
+  }
+
+  @JsonProperty("stream")
+  public void setStream(final PartialAirbyteStreamState stream) {
+    this.stream = stream;
+  }
+
+  public PartialAirbyteStateMessage withStream(final PartialAirbyteStreamState stream) {
+    this.stream = stream;
+    return this;
+  }
+
+}

--- a/airbyte-integrations/bases/base-java/src/main/java/io/airbyte/integrations/destination_async/partial_messages/PartialAirbyteStateMessage.java
+++ b/airbyte-integrations/bases/base-java/src/main/java/io/airbyte/integrations/destination_async/partial_messages/PartialAirbyteStateMessage.java
@@ -6,6 +6,7 @@ package io.airbyte.integrations.destination_async.partial_messages;
 
 import com.fasterxml.jackson.annotation.JsonProperty;
 import io.airbyte.protocol.models.v0.AirbyteStateMessage.AirbyteStateType;
+import java.util.Objects;
 
 public class PartialAirbyteStateMessage {
 
@@ -45,6 +46,31 @@ public class PartialAirbyteStateMessage {
   public PartialAirbyteStateMessage withStream(final PartialAirbyteStreamState stream) {
     this.stream = stream;
     return this;
+  }
+
+  @Override
+  public boolean equals(final Object o) {
+    if (this == o) {
+      return true;
+    }
+    if (o == null || getClass() != o.getClass()) {
+      return false;
+    }
+    final PartialAirbyteStateMessage that = (PartialAirbyteStateMessage) o;
+    return type == that.type && Objects.equals(stream, that.stream);
+  }
+
+  @Override
+  public int hashCode() {
+    return Objects.hash(type, stream);
+  }
+
+  @Override
+  public String toString() {
+    return "PartialAirbyteStateMessage{" +
+        "type=" + type +
+        ", stream=" + stream +
+        '}';
   }
 
 }

--- a/airbyte-integrations/bases/base-java/src/main/java/io/airbyte/integrations/destination_async/partial_messages/PartialAirbyteStreamState.java
+++ b/airbyte-integrations/bases/base-java/src/main/java/io/airbyte/integrations/destination_async/partial_messages/PartialAirbyteStreamState.java
@@ -1,0 +1,34 @@
+/*
+ * Copyright (c) 2023 Airbyte, Inc., all rights reserved.
+ */
+
+package io.airbyte.integrations.destination_async.partial_messages;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+import io.airbyte.protocol.models.v0.StreamDescriptor;
+
+public class PartialAirbyteStreamState {
+
+  @JsonProperty("stream_descriptor")
+  private StreamDescriptor streamDescriptor;
+
+  public PartialAirbyteStreamState() {
+    streamDescriptor = streamDescriptor;
+  }
+
+  @JsonProperty("stream_descriptor")
+  public StreamDescriptor getStreamDescriptor() {
+    return streamDescriptor;
+  }
+
+  @JsonProperty("stream_descriptor")
+  public void setStreamDescriptor(final StreamDescriptor streamDescriptor) {
+    this.streamDescriptor = streamDescriptor;
+  }
+
+  public PartialAirbyteStreamState withStreamDescriptor(final StreamDescriptor streamDescriptor) {
+    this.streamDescriptor = streamDescriptor;
+    return this;
+  }
+
+}

--- a/airbyte-integrations/bases/base-java/src/main/java/io/airbyte/integrations/destination_async/partial_messages/PartialAirbyteStreamState.java
+++ b/airbyte-integrations/bases/base-java/src/main/java/io/airbyte/integrations/destination_async/partial_messages/PartialAirbyteStreamState.java
@@ -6,6 +6,7 @@ package io.airbyte.integrations.destination_async.partial_messages;
 
 import com.fasterxml.jackson.annotation.JsonProperty;
 import io.airbyte.protocol.models.v0.StreamDescriptor;
+import java.util.Objects;
 
 public class PartialAirbyteStreamState {
 
@@ -29,6 +30,30 @@ public class PartialAirbyteStreamState {
   public PartialAirbyteStreamState withStreamDescriptor(final StreamDescriptor streamDescriptor) {
     this.streamDescriptor = streamDescriptor;
     return this;
+  }
+
+  @Override
+  public boolean equals(final Object o) {
+    if (this == o) {
+      return true;
+    }
+    if (o == null || getClass() != o.getClass()) {
+      return false;
+    }
+    final PartialAirbyteStreamState that = (PartialAirbyteStreamState) o;
+    return Objects.equals(streamDescriptor, that.streamDescriptor);
+  }
+
+  @Override
+  public int hashCode() {
+    return Objects.hash(streamDescriptor);
+  }
+
+  @Override
+  public String toString() {
+    return "PartialAirbyteStreamState{" +
+        "streamDescriptor=" + streamDescriptor +
+        '}';
   }
 
 }

--- a/airbyte-integrations/bases/base-java/src/test/java/io/airbyte/integrations/destination_async/FlushWorkersTest.java
+++ b/airbyte-integrations/bases/base-java/src/test/java/io/airbyte/integrations/destination_async/FlushWorkersTest.java
@@ -9,8 +9,8 @@ import static org.mockito.Mockito.when;
 
 import io.airbyte.integrations.destination_async.buffers.BufferDequeue;
 import io.airbyte.integrations.destination_async.buffers.MemoryAwareMessageBatch;
+import io.airbyte.integrations.destination_async.partial_messages.PartialAirbyteMessage;
 import io.airbyte.integrations.destination_async.state.FlushFailure;
-import io.airbyte.protocol.models.v0.AirbyteMessage;
 import io.airbyte.protocol.models.v0.StreamDescriptor;
 import java.io.IOException;
 import java.util.List;
@@ -57,7 +57,7 @@ public class FlushWorkersTest {
     }
 
     @Override
-    public void flush(final StreamDescriptor desc, final Stream<AirbyteMessage> stream) throws Exception {
+    public void flush(final StreamDescriptor desc, final Stream<PartialAirbyteMessage> stream) throws Exception {
       hasThrownError.set(true);
       throw new IOException("Error on flush");
     }

--- a/airbyte-integrations/bases/base-java/src/test/java/io/airbyte/integrations/destination_async/buffers/BufferDequeueTest.java
+++ b/airbyte-integrations/bases/base-java/src/test/java/io/airbyte/integrations/destination_async/buffers/BufferDequeueTest.java
@@ -26,8 +26,7 @@ public class BufferDequeueTest {
   private static final PartialAirbyteMessage RECORD_MSG_20_BYTES = new PartialAirbyteMessage()
       .withType(Type.RECORD)
       .withRecord(new PartialAirbyteRecordMessage()
-          .withStream(STREAM_NAME)
-          .withData(Jsons.jsonNode(RECORD_20_BYTES)));
+          .withStream(STREAM_NAME));
 
   @Nested
   class Take {

--- a/airbyte-integrations/bases/base-java/src/test/java/io/airbyte/integrations/destination_async/buffers/BufferDequeueTest.java
+++ b/airbyte-integrations/bases/base-java/src/test/java/io/airbyte/integrations/destination_async/buffers/BufferDequeueTest.java
@@ -8,9 +8,9 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import io.airbyte.commons.json.Jsons;
-import io.airbyte.protocol.models.v0.AirbyteMessage;
+import io.airbyte.integrations.destination_async.partial_messages.PartialAirbyteMessage;
+import io.airbyte.integrations.destination_async.partial_messages.PartialAirbyteRecordMessage;
 import io.airbyte.protocol.models.v0.AirbyteMessage.Type;
-import io.airbyte.protocol.models.v0.AirbyteRecordMessage;
 import io.airbyte.protocol.models.v0.StreamDescriptor;
 import java.time.Instant;
 import java.time.temporal.ChronoUnit;
@@ -23,9 +23,9 @@ public class BufferDequeueTest {
   public static final String RECORD_20_BYTES = "abc";
   private static final String STREAM_NAME = "stream1";
   private static final StreamDescriptor STREAM_DESC = new StreamDescriptor().withName(STREAM_NAME);
-  private static final AirbyteMessage RECORD_MSG_20_BYTES = new AirbyteMessage()
+  private static final PartialAirbyteMessage RECORD_MSG_20_BYTES = new PartialAirbyteMessage()
       .withType(Type.RECORD)
-      .withRecord(new AirbyteRecordMessage()
+      .withRecord(new PartialAirbyteRecordMessage()
           .withStream(STREAM_NAME)
           .withData(Jsons.jsonNode(RECORD_20_BYTES)));
 
@@ -99,7 +99,7 @@ public class BufferDequeueTest {
     enqueue.addRecord(RECORD_MSG_20_BYTES, RECORD_SIZE_20_BYTES);
 
     final var secondStream = new StreamDescriptor().withName("stream_2");
-    final AirbyteMessage recordFromSecondStream = Jsons.clone(RECORD_MSG_20_BYTES);
+    final PartialAirbyteMessage recordFromSecondStream = Jsons.clone(RECORD_MSG_20_BYTES);
     recordFromSecondStream.getRecord().withStream(secondStream.getName());
     enqueue.addRecord(recordFromSecondStream, RECORD_SIZE_20_BYTES);
 

--- a/airbyte-integrations/bases/base-java/src/test/java/io/airbyte/integrations/destination_async/buffers/BufferEnqueueTest.java
+++ b/airbyte-integrations/bases/base-java/src/test/java/io/airbyte/integrations/destination_async/buffers/BufferEnqueueTest.java
@@ -7,11 +7,11 @@ package io.airbyte.integrations.destination_async.buffers;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.mockito.Mockito.mock;
 
-import io.airbyte.commons.json.Jsons;
 import io.airbyte.integrations.destination_async.GlobalMemoryManager;
+import io.airbyte.integrations.destination_async.partial_messages.PartialAirbyteMessage;
+import io.airbyte.integrations.destination_async.partial_messages.PartialAirbyteRecordMessage;
 import io.airbyte.integrations.destination_async.state.GlobalAsyncStateManager;
 import io.airbyte.protocol.models.v0.AirbyteMessage;
-import io.airbyte.protocol.models.v0.AirbyteRecordMessage;
 import io.airbyte.protocol.models.v0.StreamDescriptor;
 import java.util.concurrent.ConcurrentHashMap;
 import org.junit.jupiter.api.Test;
@@ -28,11 +28,10 @@ public class BufferEnqueueTest {
 
     final var streamName = "stream";
     final var stream = new StreamDescriptor().withName(streamName);
-    final var record = new AirbyteMessage()
+    final var record = new PartialAirbyteMessage()
         .withType(AirbyteMessage.Type.RECORD)
-        .withRecord(new AirbyteRecordMessage()
-            .withStream(streamName)
-            .withData(Jsons.jsonNode(BufferDequeueTest.RECORD_20_BYTES)));
+        .withRecord(new PartialAirbyteRecordMessage()
+            .withStream(streamName));
 
     enqueue.addRecord(record, RECORD_SIZE_20_BYTES);
     assertEquals(1, streamToBuffer.get(stream).size());
@@ -49,11 +48,10 @@ public class BufferEnqueueTest {
 
     final var streamName = "stream";
     final var stream = new StreamDescriptor().withName(streamName);
-    final var record = new AirbyteMessage()
+    final var record = new PartialAirbyteMessage()
         .withType(AirbyteMessage.Type.RECORD)
-        .withRecord(new AirbyteRecordMessage()
-            .withStream(streamName)
-            .withData(Jsons.jsonNode(BufferDequeueTest.RECORD_20_BYTES)));
+        .withRecord(new PartialAirbyteRecordMessage()
+            .withStream(streamName));
 
     enqueue.addRecord(record, RECORD_SIZE_20_BYTES);
     enqueue.addRecord(record, RECORD_SIZE_20_BYTES);

--- a/airbyte-integrations/bases/base-java/src/test/java/io/airbyte/integrations/destination_async/buffers/StreamAwareQueueTest.java
+++ b/airbyte-integrations/bases/base-java/src/test/java/io/airbyte/integrations/destination_async/buffers/StreamAwareQueueTest.java
@@ -8,7 +8,7 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertNull;
 
-import io.airbyte.protocol.models.v0.AirbyteMessage;
+import io.airbyte.integrations.destination_async.partial_messages.PartialAirbyteMessage;
 import org.junit.jupiter.api.Test;
 
 public class StreamAwareQueueTest {
@@ -20,9 +20,9 @@ public class StreamAwareQueueTest {
     assertEquals(0, queue.getCurrentMemoryUsage());
     assertNull(queue.getTimeOfLastMessage().orElse(null));
 
-    queue.offer(new AirbyteMessage(), 6, 1);
-    queue.offer(new AirbyteMessage(), 6, 2);
-    queue.offer(new AirbyteMessage(), 6, 3);
+    queue.offer(new PartialAirbyteMessage(), 6, 1);
+    queue.offer(new PartialAirbyteMessage(), 6, 2);
+    queue.offer(new PartialAirbyteMessage(), 6, 3);
 
     assertEquals(18, queue.getCurrentMemoryUsage());
     assertNotNull(queue.getTimeOfLastMessage().orElse(null));

--- a/airbyte-integrations/bases/base-java/src/test/java/io/airbyte/integrations/destination_async/state/GlobalAsyncStateManagerTest.java
+++ b/airbyte-integrations/bases/base-java/src/test/java/io/airbyte/integrations/destination_async/state/GlobalAsyncStateManagerTest.java
@@ -8,13 +8,12 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotEquals;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 
-import io.airbyte.commons.json.Jsons;
 import io.airbyte.integrations.destination_async.GlobalMemoryManager;
-import io.airbyte.protocol.models.v0.AirbyteMessage;
+import io.airbyte.integrations.destination_async.partial_messages.PartialAirbyteMessage;
+import io.airbyte.integrations.destination_async.partial_messages.PartialAirbyteStateMessage;
+import io.airbyte.integrations.destination_async.partial_messages.PartialAirbyteStreamState;
 import io.airbyte.protocol.models.v0.AirbyteMessage.Type;
-import io.airbyte.protocol.models.v0.AirbyteStateMessage;
 import io.airbyte.protocol.models.v0.AirbyteStateMessage.AirbyteStateType;
-import io.airbyte.protocol.models.v0.AirbyteStreamState;
 import io.airbyte.protocol.models.v0.StreamDescriptor;
 import java.util.List;
 import java.util.Set;
@@ -37,24 +36,24 @@ class GlobalAsyncStateManagerTest {
   private static final StreamDescriptor STREAM3_DESC = new StreamDescriptor()
       .withName(STREAM_NAME3);
 
-  private static final AirbyteMessage GLOBAL_STATE_MESSAGE1 = new AirbyteMessage()
+  private static final PartialAirbyteMessage GLOBAL_STATE_MESSAGE1 = new PartialAirbyteMessage()
       .withType(Type.STATE)
-      .withState(new AirbyteStateMessage()
-          .withType(AirbyteStateType.GLOBAL).withData(Jsons.jsonNode(1)));
-  private static final AirbyteMessage GLOBAL_STATE_MESSAGE2 = new AirbyteMessage()
+      .withState(new PartialAirbyteStateMessage()
+          .withType(AirbyteStateType.GLOBAL));
+  private static final PartialAirbyteMessage GLOBAL_STATE_MESSAGE2 = new PartialAirbyteMessage()
       .withType(Type.STATE)
-      .withState(new AirbyteStateMessage()
-          .withType(AirbyteStateType.GLOBAL).withData(Jsons.jsonNode(2)));
-  private static final AirbyteMessage STREAM1_STATE_MESSAGE1 = new AirbyteMessage()
+      .withState(new PartialAirbyteStateMessage()
+          .withType(AirbyteStateType.GLOBAL));
+  private static final PartialAirbyteMessage STREAM1_STATE_MESSAGE1 = new PartialAirbyteMessage()
       .withType(Type.STATE)
-      .withState(new AirbyteStateMessage()
+      .withState(new PartialAirbyteStateMessage()
           .withType(AirbyteStateType.STREAM)
-          .withStream(new AirbyteStreamState().withStreamDescriptor(STREAM1_DESC).withStreamState(Jsons.jsonNode(1))));
-  private static final AirbyteMessage STREAM1_STATE_MESSAGE2 = new AirbyteMessage()
+          .withStream(new PartialAirbyteStreamState().withStreamDescriptor(STREAM1_DESC)));
+  private static final PartialAirbyteMessage STREAM1_STATE_MESSAGE2 = new PartialAirbyteMessage()
       .withType(Type.STATE)
-      .withState(new AirbyteStateMessage()
+      .withState(new PartialAirbyteStateMessage()
           .withType(AirbyteStateType.STREAM)
-          .withStream(new AirbyteStreamState().withStreamDescriptor(STREAM1_DESC).withStreamState(Jsons.jsonNode(2))));
+          .withStream(new PartialAirbyteStreamState().withStreamDescriptor(STREAM1_DESC)));
 
   @Test
   void testBasic() {

--- a/airbyte-integrations/bases/bases-destination-jdbc/src/main/java/io/airbyte/integrations/destination/staging/AsyncFlush.java
+++ b/airbyte-integrations/bases/bases-destination-jdbc/src/main/java/io/airbyte/integrations/destination/staging/AsyncFlush.java
@@ -54,6 +54,9 @@ class AsyncFlush implements DestinationFlushFunction {
       // reassign as lambdas require references to be final.
       stream.forEach(record -> {
         try {
+          // todo (cgardens) - most writers just go ahead and re-serialize the contents of the record message.
+          // we should either just pass the raw string or at least have a way to do that and create a default
+          // impl that maintains backwards compatible behavior.
           writer.accept(Jsons.deserialize(record.getSerialized(), AirbyteMessage.class).getRecord());
         } catch (final Exception e) {
           throw new RuntimeException(e);

--- a/airbyte-integrations/bases/bases-destination-jdbc/src/main/java/io/airbyte/integrations/destination/staging/AsyncFlush.java
+++ b/airbyte-integrations/bases/bases-destination-jdbc/src/main/java/io/airbyte/integrations/destination/staging/AsyncFlush.java
@@ -4,13 +4,14 @@
 
 package io.airbyte.integrations.destination.staging;
 
+import io.airbyte.commons.json.Jsons;
 import io.airbyte.db.jdbc.JdbcDatabase;
 import io.airbyte.integrations.destination.jdbc.WriteConfig;
 import io.airbyte.integrations.destination.record_buffer.FileBuffer;
 import io.airbyte.integrations.destination.s3.csv.CsvSerializedBuffer;
 import io.airbyte.integrations.destination.s3.csv.StagingDatabaseCsvSheetGenerator;
 import io.airbyte.integrations.destination_async.DestinationFlushFunction;
-import io.airbyte.protocol.models.Jsons;
+import io.airbyte.integrations.destination_async.partial_messages.PartialAirbyteMessage;
 import io.airbyte.protocol.models.v0.AirbyteMessage;
 import io.airbyte.protocol.models.v0.ConfiguredAirbyteCatalog;
 import io.airbyte.protocol.models.v0.StreamDescriptor;
@@ -42,7 +43,7 @@ class AsyncFlush implements DestinationFlushFunction {
   }
 
   @Override
-  public void flush(final StreamDescriptor decs, final Stream<AirbyteMessage> stream) throws Exception {
+  public void flush(final StreamDescriptor decs, final Stream<PartialAirbyteMessage> stream) throws Exception {
     final CsvSerializedBuffer writer;
     try {
       writer = new CsvSerializedBuffer(
@@ -53,7 +54,7 @@ class AsyncFlush implements DestinationFlushFunction {
       // reassign as lambdas require references to be final.
       stream.forEach(record -> {
         try {
-          writer.accept(record.getRecord());
+          writer.accept(Jsons.deserialize(record.getSerialized(), AirbyteMessage.class).getRecord());
         } catch (final Exception e) {
           throw new RuntimeException(e);
         }


### PR DESCRIPTION
## What
* deserializing the `data` field in the record message makes it hard to predict the memory that will be used. in most cases the destination is not looking at that field anyway and just re-serializing it. this change doesn't both de-serializing that field until it gets to the flusher, which means it will be short lived as that's moments away from it being thrown on the wire.

very much stolen from this old PR from https://github.com/airbytehq/airbyte/pull/17112/files @evantahler and @davinchia 