### PR TITLE
Encapsulate and test triggers for assigning flush workers

### DIFF
--- a/airbyte-integrations/bases/base-java/src/main/java/io/airbyte/integrations/destination_async/DetectStreamToFlush.java
+++ b/airbyte-integrations/bases/base-java/src/main/java/io/airbyte/integrations/destination_async/DetectStreamToFlush.java
@@ -1,0 +1,222 @@
+/*
+ * Copyright (c) 2023 Airbyte, Inc., all rights reserved.
+ */
+
+package io.airbyte.integrations.destination_async;
+
+import com.google.common.annotations.VisibleForTesting;
+import io.airbyte.integrations.destination_async.buffers.BufferDequeue;
+import io.airbyte.protocol.models.v0.StreamDescriptor;
+import java.time.Instant;
+import java.time.temporal.ChronoUnit;
+import java.util.Comparator;
+import java.util.List;
+import java.util.Optional;
+import java.util.Set;
+import java.util.concurrent.atomic.AtomicBoolean;
+import java.util.stream.Collectors;
+import lombok.extern.slf4j.Slf4j;
+import org.apache.commons.lang3.tuple.ImmutablePair;
+
+/**
+ * This class finds the best, next stream to flush.
+ */
+@Slf4j
+public class DetectStreamToFlush {
+
+  private static final double EAGER_FLUSH_THRESHOLD = 0.90;
+  private static final long QUEUE_FLUSH_THRESHOLD_BYTES = 10 * 1024 * 1024; // 10MB
+  private static final long MAX_TIME_BETWEEN_REC_MIN = 5L;
+  private final BufferDequeue bufferDequeue;
+  private final RunningFlushWorkers runningFlushWorkers;
+  private final AtomicBoolean isClosing;
+  private final DestinationFlushFunction flusher;
+
+  public DetectStreamToFlush(final BufferDequeue bufferDequeue,
+                             final RunningFlushWorkers runningFlushWorkers,
+                             final AtomicBoolean isClosing,
+                             final DestinationFlushFunction flusher) {
+    this.bufferDequeue = bufferDequeue;
+    this.runningFlushWorkers = runningFlushWorkers;
+    this.isClosing = isClosing;
+    this.flusher = flusher;
+  }
+
+  /**
+   * Get the best, next stream that is ready to be flushed.
+   *
+   * @return best, next stream to flush. If no stream is ready to be flushed, return empty.
+   */
+  public Optional<StreamDescriptor> getNextStreamToFlush() {
+    return getNextStreamToFlush(computeQueueThreshold());
+  }
+
+  /**
+   * We have a minimum threshold for the size of a queue before we will flush it. The threshold helps
+   * us avoid uploading small amounts of data at a time, which is really resource inefficient.
+   * Depending on certain conditions, we dynamically adjust this threshold.
+   * <p>
+   * Rules:
+   * <li>default - By default the, the threshold is a set at a constant:
+   * QUEUE_FLUSH_THRESHOLD_BYTES.</li>
+   * <li>memory pressure - If we are getting close to maxing out available memory, we reduce it to
+   * zero. This helps in the case where there are a lot of streams, so total memory usage is high, but
+   * each individual queue isn't that large.</li>
+   * <li>closing - If the Flush Worker is closing, we reduce it to zero. We close when all records
+   * have been added to the queue, at which point, our goal is to flush out any non-empty queues.</li>
+   *
+   * @return based on the conditions, the threshold in bytes.
+   */
+  @VisibleForTesting
+  long computeQueueThreshold() {
+    final boolean isBuffer90Full =
+        EAGER_FLUSH_THRESHOLD <= (double) bufferDequeue.getTotalGlobalQueueSizeBytes() / bufferDequeue.getMaxQueueSizeBytes();
+    // when we are closing or queues are very full, flush regardless of how few items are in the queue.
+    return isClosing.get() || isBuffer90Full ? 0 : QUEUE_FLUSH_THRESHOLD_BYTES;
+  }
+
+  // todo (cgardens) - improve prioritization by getting a better estimate of how much data running
+  // workers will process. we have access to their batch sizes after all!
+  /**
+   * Iterates over streams until it finds one that is ready to flush. Streams are ordered by priority.
+   * Return an empty optional if no streams are ready.
+   * <p>
+   * A stream is ready to flush if it either meets a size threshold or a time threshold. See
+   * {@link #isSizeTriggered(StreamDescriptor, long)} and {@link #isTimeTriggered(StreamDescriptor)}
+   * for details on these triggers.
+   *
+   * @param queueSizeThresholdBytes - the size threshold to use for determining if a stream is ready
+   *        to flush.
+   * @return the next stream to flush. if no stream is ready to flush, empty.
+   */
+  @VisibleForTesting
+  Optional<StreamDescriptor> getNextStreamToFlush(final long queueSizeThresholdBytes) {
+    for (final StreamDescriptor stream : orderStreamsByPriority(bufferDequeue.getBufferedStreams())) {
+      final ImmutablePair<Boolean, String> isTimeTriggeredResult = isTimeTriggered(stream);
+      final ImmutablePair<Boolean, String> isSizeTriggeredResult = isSizeTriggered(stream, queueSizeThresholdBytes);
+
+      final String debugString = String.format(
+          "trigger info: %s - %s, %s , %s",
+          stream.getNamespace(),
+          stream.getName(),
+          isTimeTriggeredResult.getRight(),
+          isSizeTriggeredResult.getRight());
+      log.debug("computed: {}", debugString);
+
+      if (isSizeTriggeredResult.getLeft() || isTimeTriggeredResult.getLeft()) {
+        log.info("flushing: {}", debugString);
+
+        return Optional.of(stream);
+      }
+    }
+    return Optional.empty();
+  }
+
+  /**
+   * The time trigger is based on the last time a record was added to the queue. We don't want records
+   * to sit forever, even if the queue is not that full (bad for time to value for users). Also, the
+   * more time passes since a record was added, the less likely another record is coming (caveat is
+   * CDC where it's random).
+   * <p>
+   * This method also returns debug string with info that about the computation. We do it this way, so
+   * that the debug info that is printed is exactly what is used in the computation.
+   *
+   * @param stream stream
+   * @return is time triggered and a debug string
+   */
+  @VisibleForTesting
+  ImmutablePair<Boolean, String> isTimeTriggered(final StreamDescriptor stream) {
+    final Boolean isTimeTriggered = bufferDequeue.getTimeOfLastRecord(stream)
+        .map(time -> time.isBefore(Instant.now().minus(MAX_TIME_BETWEEN_REC_MIN, ChronoUnit.MINUTES)))
+        .orElse(false);
+
+    final String debugString = String.format("time trigger: %s", isTimeTriggered);
+
+    return ImmutablePair.of(isTimeTriggered, debugString);
+  }
+
+  /**
+   * For the size threshold, the size of the data in the queue is compared to the threshold that is
+   * passed into this method.
+   * <p>
+   * One caveat, is that if that stream already has a worker running, we "penalize" its size. We do
+   * this by computing what the size of the queue would be after the running workers for that queue
+   * complete. This is based on a dumb estimate of how much data a worker can process. There is an
+   * opportunity for optimization here, by being smarter about predicting how much data a running
+   * worker is likely to process.
+   * <p>
+   * This method also returns debug string with info that about the computation. We do it this way, so
+   * that the debug info that is printed is exactly what is used in the computation.
+   *
+   * @param stream stream
+   * @param queueSizeThresholdBytes min size threshold to determine if a queue is ready to flush
+   * @return is size triggered and a debug string
+   */
+  @VisibleForTesting
+  ImmutablePair<Boolean, String> isSizeTriggered(final StreamDescriptor stream, final long queueSizeThresholdBytes) {
+    final long currentQueueSize = bufferDequeue.getQueueSizeBytes(stream).orElseThrow();
+    final long sizeOfRunningWorkersEstimate = estimateSizeOfRunningWorkers(stream, currentQueueSize);
+    final long queueSizeAfterRunningWorkers = currentQueueSize - sizeOfRunningWorkersEstimate;
+    final boolean isSizeTriggered = queueSizeAfterRunningWorkers > queueSizeThresholdBytes;
+
+    final String debugString = String.format(
+        "size trigger: %s current threshold b: %s, queue size b: %s, penalty b: %s, after penalty b: %s",
+        isSizeTriggered,
+        AirbyteFileUtils.byteCountToDisplaySize(queueSizeThresholdBytes),
+        AirbyteFileUtils.byteCountToDisplaySize(currentQueueSize),
+        AirbyteFileUtils.byteCountToDisplaySize(sizeOfRunningWorkersEstimate),
+        AirbyteFileUtils.byteCountToDisplaySize(queueSizeAfterRunningWorkers));
+
+    return ImmutablePair.of(isSizeTriggered, debugString);
+  }
+
+  /**
+   * For a stream, determines how many bytes will be processed by CURRENTLY running workers. For the
+   * purpose of this calculation, workers can be in one of two states. First, they can have a batch,
+   * in which case, we can read the size in bytes from the batch to know how many records that batch
+   * will pull of the queue. Second, it might not have a batch yet, in which case, we assume the min
+   * of bytes in the queue or the optimal flush size.
+   * <p>
+   *
+   * @param stream stream
+   * @return estimate of records remaining to be process
+   */
+  @VisibleForTesting
+  long estimateSizeOfRunningWorkers(final StreamDescriptor stream, final long currentQueueSize) {
+    final List<Optional<Long>> runningWorkerBatchesSizes = runningFlushWorkers.getSizesOfRunningWorkerBatches(stream);
+    final long workersWithBatchesSize = runningWorkerBatchesSizes.stream().filter(Optional::isPresent).mapToLong(Optional::get).sum();
+    final long workersWithoutBatchesCount = runningWorkerBatchesSizes.stream().filter(Optional::isEmpty).count();
+    final long workersWithoutBatchesSizeEstimate = Math.min(flusher.getOptimalBatchSizeBytes(), currentQueueSize) * workersWithoutBatchesCount;
+    return (workersWithBatchesSize + workersWithoutBatchesSizeEstimate);
+  }
+
+  // todo (cgardens) - perf test whether it would make sense to flip 1 & 2.
+  /**
+   * Sort stream descriptors in order of priority with which we would want to flush them.
+   * <p>
+   * Priority is in the following order:
+   * <li>1. size in queue (descending)</li>
+   * <li>2. time since last record (ascending)</li>
+   * <li>3. alphabetical by namespace + stream name.</li>
+   * <p>
+   * In other words, move the biggest queues first, because they are most likely to use available
+   * resources optimally. Then get rid of old stuff (time to value for the user and, generally, as the
+   * age of the last record grows, the likelihood of getting any more records from that stream
+   * decreases, so by flushing them, we can totally complete that stream). Finally, tertiary sort by
+   * name so the order is deterministic.
+   *
+   * @param streams streams to sort.
+   * @return streams sorted by priority.
+   */
+  @VisibleForTesting
+  List<StreamDescriptor> orderStreamsByPriority(final Set<StreamDescriptor> streams) {
+    return streams.stream()
+        .sorted(Comparator.comparing((StreamDescriptor s) -> bufferDequeue.getQueueSizeBytes(s).orElseThrow(), Comparator.reverseOrder())
+            // if no time is present, it suggests the queue has no records. set MAX time as a sentinel value to
+            // represent no records.
+            .thenComparing(s -> bufferDequeue.getTimeOfLastRecord(s).orElse(Instant.MAX))
+            .thenComparing(s -> s.getNamespace() + s.getName()))
+        .collect(Collectors.toList());
+  }
+
+}

--- a/airbyte-integrations/bases/base-java/src/main/java/io/airbyte/integrations/destination_async/RunningFlushWorkers.java
+++ b/airbyte-integrations/bases/base-java/src/main/java/io/airbyte/integrations/destination_async/RunningFlushWorkers.java
@@ -1,0 +1,80 @@
+/*
+ * Copyright (c) 2023 Airbyte, Inc., all rights reserved.
+ */
+
+package io.airbyte.integrations.destination_async;
+
+import com.google.common.base.Preconditions;
+import io.airbyte.protocol.models.v0.StreamDescriptor;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Optional;
+import java.util.UUID;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.ConcurrentMap;
+
+/**
+ * Track the number of flush workers (and their size) that are currently running for a given stream.
+ */
+public class RunningFlushWorkers {
+
+  private final ConcurrentMap<StreamDescriptor, ConcurrentMap<UUID, Optional<Long>>> streamToFlushWorkerToBatchSize;
+
+  public RunningFlushWorkers() {
+    streamToFlushWorkerToBatchSize = new ConcurrentHashMap<>();
+  }
+
+  /**
+   * Call this when a worker starts flushing a stream.
+   *
+   * @param stream the stream that is being flushed
+   * @param flushWorkerId flush worker id
+   */
+  public void trackFlushWorker(final StreamDescriptor stream, final UUID flushWorkerId) {
+    streamToFlushWorkerToBatchSize.computeIfAbsent(
+        stream,
+        ignored -> new ConcurrentHashMap<>()).computeIfAbsent(flushWorkerId, ignored -> Optional.empty());
+  }
+
+  /**
+   * Call this when a worker completes flushing a stream.
+   *
+   * @param stream the stream that was flushed
+   * @param flushWorkerId flush worker id
+   */
+  public void completeFlushWorker(final StreamDescriptor stream, final UUID flushWorkerId) {
+    Preconditions.checkState(streamToFlushWorkerToBatchSize.containsKey(stream)
+        && streamToFlushWorkerToBatchSize.get(stream).containsKey(flushWorkerId),
+        "Cannot complete flush worker for stream that has not started.");
+    streamToFlushWorkerToBatchSize.get(stream).remove(flushWorkerId);
+    if (streamToFlushWorkerToBatchSize.get(stream).isEmpty()) {
+      streamToFlushWorkerToBatchSize.remove(stream);
+    }
+  }
+
+  /**
+   * When a worker gets a batch of records, register its size so that it can be referenced for
+   * estimating how many records will be left in the queue after the batch is done.
+   *
+   * @param stream stream
+   * @param batchSize batch size
+   */
+  public void registerBatchSize(final StreamDescriptor stream, final UUID flushWorkerId, final long batchSize) {
+    Preconditions.checkState(streamToFlushWorkerToBatchSize.containsKey(stream)
+        && streamToFlushWorkerToBatchSize.get(stream).containsKey(flushWorkerId),
+        "Cannot register a batch size for a flush worker that has not been initialized");
+    streamToFlushWorkerToBatchSize.get(stream).put(flushWorkerId, Optional.of(batchSize));
+  }
+
+  /**
+   * For a stream get how many bytes are in each running worker. If the worker doesn't have a batch
+   * yet, return empty optional.
+   *
+   * @param stream stream
+   * @return bytes in batches currently being processed
+   */
+  public List<Optional<Long>> getSizesOfRunningWorkerBatches(final StreamDescriptor stream) {
+    return new ArrayList<>(streamToFlushWorkerToBatchSize.getOrDefault(stream, new ConcurrentHashMap<>()).values());
+  }
+
+}

--- a/airbyte-integrations/bases/base-java/src/main/java/io/airbyte/integrations/destination_async/buffers/BufferDequeue.java
+++ b/airbyte-integrations/bases/base-java/src/main/java/io/airbyte/integrations/destination_async/buffers/BufferDequeue.java
@@ -99,6 +99,10 @@ public class BufferDequeue {
     return new HashSet<>(buffers.keySet());
   }
 
+  public long getMaxQueueSizeBytes() {
+    return memoryManager.getMaxMemoryBytes();
+  }
+
   public long getTotalGlobalQueueSizeBytes() {
     return buffers.values().stream().map(MemoryBoundedLinkedBlockingQueue::getCurrentMemoryUsage).mapToLong(Long::longValue).sum();
   }

--- a/airbyte-integrations/bases/base-java/src/test/java/io/airbyte/integrations/destination_async/DetectStreamToFlushTest.java
+++ b/airbyte-integrations/bases/base-java/src/test/java/io/airbyte/integrations/destination_async/DetectStreamToFlushTest.java
@@ -1,0 +1,90 @@
+/*
+ * Copyright (c) 2023 Airbyte, Inc., all rights reserved.
+ */
+
+package io.airbyte.integrations.destination_async;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+import io.airbyte.integrations.destination_async.buffers.BufferDequeue;
+import io.airbyte.protocol.models.v0.StreamDescriptor;
+import java.time.Instant;
+import java.util.List;
+import java.util.Optional;
+import java.util.Set;
+import java.util.concurrent.atomic.AtomicBoolean;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+class DetectStreamToFlushTest {
+
+  public static final Instant NOW = Instant.now();
+  public static final Instant FIVE_MIN_AGO = NOW.minusSeconds(60 * 5);
+  private static final long SIZE_10MB = 10 * 1024 * 1024;
+  private static final long SIZE_200MB = 200 * 1024 * 1024;
+
+  private static final StreamDescriptor DESC1 = new StreamDescriptor().withName("test1");
+
+  private static DestinationFlushFunction flusher;
+
+  @BeforeEach
+  void setup() {
+    flusher = mock(DestinationFlushFunction.class);
+    when(flusher.getOptimalBatchSizeBytes()).thenReturn(SIZE_200MB);
+  }
+
+  @Test
+  void testGetNextSkipsEmptyStreams() {
+    final BufferDequeue bufferDequeue = mock(BufferDequeue.class);
+    when(bufferDequeue.getBufferedStreams()).thenReturn(Set.of(DESC1));
+    when(bufferDequeue.getQueueSizeBytes(DESC1)).thenReturn(Optional.of(0L));
+    final RunningFlushWorkers runningFlushWorkers = mock(RunningFlushWorkers.class);
+    final DetectStreamToFlush detect = new DetectStreamToFlush(bufferDequeue, runningFlushWorkers, new AtomicBoolean(false), flusher);
+    assertEquals(Optional.empty(), detect.getNextStreamToFlush(0));
+  }
+
+  @Test
+  void testGetNextPicksUpOnSizeTrigger() {
+    final BufferDequeue bufferDequeue = mock(BufferDequeue.class);
+    when(bufferDequeue.getBufferedStreams()).thenReturn(Set.of(DESC1));
+    when(bufferDequeue.getQueueSizeBytes(DESC1)).thenReturn(Optional.of(1L));
+    final RunningFlushWorkers runningFlushWorkers = mock(RunningFlushWorkers.class);
+    final DetectStreamToFlush detect = new DetectStreamToFlush(bufferDequeue, runningFlushWorkers, new AtomicBoolean(false), flusher);
+    // if above threshold, triggers
+    assertEquals(Optional.of(DESC1), detect.getNextStreamToFlush(0));
+    // if below threshold, no trigger
+    assertEquals(Optional.empty(), detect.getNextStreamToFlush(1));
+  }
+
+  @Test
+  void testGetNextAccountsForAlreadyRunningWorkers() {
+    final BufferDequeue bufferDequeue = mock(BufferDequeue.class);
+    when(bufferDequeue.getBufferedStreams()).thenReturn(Set.of(DESC1));
+    when(bufferDequeue.getQueueSizeBytes(DESC1)).thenReturn(Optional.of(1L));
+    final RunningFlushWorkers runningFlushWorkers = mock(RunningFlushWorkers.class);
+    when(runningFlushWorkers.getSizesOfRunningWorkerBatches(any())).thenReturn(List.of(Optional.of(SIZE_10MB)));
+    final DetectStreamToFlush detect = new DetectStreamToFlush(bufferDequeue, runningFlushWorkers, new AtomicBoolean(false), flusher);
+    assertEquals(Optional.empty(), detect.getNextStreamToFlush(0));
+  }
+
+  @Test
+  void testGetNextPicksUpOnTimeTrigger() {
+    final BufferDequeue bufferDequeue = mock(BufferDequeue.class);
+    when(bufferDequeue.getBufferedStreams()).thenReturn(Set.of(DESC1));
+    when(bufferDequeue.getQueueSizeBytes(DESC1)).thenReturn(Optional.of(1L));
+    when(bufferDequeue.getTimeOfLastRecord(DESC1))
+        .thenReturn(Optional.empty())
+        .thenReturn(Optional.of(NOW))
+        .thenReturn(Optional.of(FIVE_MIN_AGO));
+    final RunningFlushWorkers runningFlushWorkers = mock(RunningFlushWorkers.class);
+    when(runningFlushWorkers.getSizesOfRunningWorkerBatches(any())).thenReturn(List.of(Optional.of(SIZE_10MB)));
+    final DetectStreamToFlush detect = new DetectStreamToFlush(bufferDequeue, runningFlushWorkers, new AtomicBoolean(false), flusher);
+    assertEquals(Optional.empty(), detect.getNextStreamToFlush(0));
+    assertEquals(Optional.empty(), detect.getNextStreamToFlush(0));
+    assertEquals(Optional.of(DESC1), detect.getNextStreamToFlush(0));
+  }
+
+}

--- a/airbyte-integrations/bases/base-java/src/test/java/io/airbyte/integrations/destination_async/FlushThresholdTest.java
+++ b/airbyte-integrations/bases/base-java/src/test/java/io/airbyte/integrations/destination_async/FlushThresholdTest.java
@@ -1,0 +1,55 @@
+/*
+ * Copyright (c) 2023 Airbyte, Inc., all rights reserved.
+ */
+
+package io.airbyte.integrations.destination_async;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+import io.airbyte.integrations.destination_async.buffers.BufferDequeue;
+import java.util.concurrent.atomic.AtomicBoolean;
+import org.junit.jupiter.api.Test;
+
+public class FlushThresholdTest {
+
+  private static final long SIZE_10MB = 10 * 1024 * 1024;
+
+  @Test
+  void testBaseThreshold() {
+    final AtomicBoolean isClosing = new AtomicBoolean(false);
+    final BufferDequeue bufferDequeue = mock(BufferDequeue.class);
+    final DetectStreamToFlush detect = new DetectStreamToFlush(bufferDequeue, null, isClosing, null);
+    assertEquals(SIZE_10MB, detect.computeQueueThreshold());
+  }
+
+  @Test
+  void testClosingThreshold() {
+    final AtomicBoolean isClosing = new AtomicBoolean(true);
+    final BufferDequeue bufferDequeue = mock(BufferDequeue.class);
+    final DetectStreamToFlush detect = new DetectStreamToFlush(bufferDequeue, null, isClosing, null);
+    assertEquals(0, detect.computeQueueThreshold());
+  }
+
+  @Test
+  void testEagerFlushThresholdBelowThreshold() {
+    final AtomicBoolean isClosing = new AtomicBoolean(false);
+    final BufferDequeue bufferDequeue = mock(BufferDequeue.class);
+    when(bufferDequeue.getTotalGlobalQueueSizeBytes()).thenReturn(8L);
+    when(bufferDequeue.getMaxQueueSizeBytes()).thenReturn(10L);
+    final DetectStreamToFlush detect = new DetectStreamToFlush(bufferDequeue, null, isClosing, null);
+    assertEquals(SIZE_10MB, detect.computeQueueThreshold());
+  }
+
+  @Test
+  void testEagerFlushThresholdAboveThreshold() {
+    final AtomicBoolean isClosing = new AtomicBoolean(false);
+    final BufferDequeue bufferDequeue = mock(BufferDequeue.class);
+    when(bufferDequeue.getTotalGlobalQueueSizeBytes()).thenReturn(9L);
+    when(bufferDequeue.getMaxQueueSizeBytes()).thenReturn(10L);
+    final DetectStreamToFlush detect = new DetectStreamToFlush(bufferDequeue, null, isClosing, null);
+    assertEquals(0, detect.computeQueueThreshold());
+  }
+
+}

--- a/airbyte-integrations/bases/base-java/src/test/java/io/airbyte/integrations/destination_async/RunningFlushWorkersTest.java
+++ b/airbyte-integrations/bases/base-java/src/test/java/io/airbyte/integrations/destination_async/RunningFlushWorkersTest.java
@@ -1,0 +1,86 @@
+/*
+ * Copyright (c) 2023 Airbyte, Inc., all rights reserved.
+ */
+
+package io.airbyte.integrations.destination_async;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
+import io.airbyte.protocol.models.v0.StreamDescriptor;
+import java.util.List;
+import java.util.Optional;
+import java.util.UUID;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+public class RunningFlushWorkersTest {
+
+  private static final long SIZE_10MB = 10 * 1024 * 1024;
+
+  private static final UUID FLUSH_WORKER_ID1 = UUID.randomUUID();
+  private static final UUID FLUSH_WORKER_ID2 = UUID.randomUUID();
+  private static final StreamDescriptor STREAM1 = new StreamDescriptor().withNamespace("namespace1").withName("stream1");
+  private static final StreamDescriptor STREAM2 = new StreamDescriptor().withNamespace("namespace2").withName("stream2");
+
+  private RunningFlushWorkers runningFlushWorkers;
+
+  @BeforeEach
+  void setup() {
+    runningFlushWorkers = new RunningFlushWorkers();
+  }
+
+  @Test
+  void testTrackFlushWorker() {
+    assertThat(runningFlushWorkers.getSizesOfRunningWorkerBatches(STREAM1).size()).isEqualTo(0);
+    runningFlushWorkers.trackFlushWorker(STREAM1, FLUSH_WORKER_ID1);
+    assertThat(runningFlushWorkers.getSizesOfRunningWorkerBatches(STREAM1).size()).isEqualTo(1);
+    runningFlushWorkers.trackFlushWorker(STREAM1, FLUSH_WORKER_ID2);
+    runningFlushWorkers.trackFlushWorker(STREAM2, FLUSH_WORKER_ID1);
+    assertThat(runningFlushWorkers.getSizesOfRunningWorkerBatches(STREAM1).size()).isEqualTo(2);
+  }
+
+  @Test
+  void testCompleteFlushWorker() {
+    runningFlushWorkers.trackFlushWorker(STREAM1, FLUSH_WORKER_ID1);
+    runningFlushWorkers.trackFlushWorker(STREAM1, FLUSH_WORKER_ID2);
+    runningFlushWorkers.completeFlushWorker(STREAM1, FLUSH_WORKER_ID1);
+    assertThat(runningFlushWorkers.getSizesOfRunningWorkerBatches(STREAM1).size()).isEqualTo(1);
+    runningFlushWorkers.completeFlushWorker(STREAM1, FLUSH_WORKER_ID2);
+    assertThat(runningFlushWorkers.getSizesOfRunningWorkerBatches(STREAM1).size()).isEqualTo(0);
+  }
+
+  @Test
+  void testCompleteFlushWorkerWithoutTrackThrowsException() {
+    assertThatThrownBy(() -> runningFlushWorkers.completeFlushWorker(STREAM1, FLUSH_WORKER_ID1))
+        .isInstanceOf(IllegalStateException.class)
+        .hasMessageContaining("Cannot complete flush worker for stream that has not started.");
+  }
+
+  @Test
+  void testMultipleStreams() {
+    runningFlushWorkers.trackFlushWorker(STREAM1, FLUSH_WORKER_ID1);
+    runningFlushWorkers.trackFlushWorker(STREAM2, FLUSH_WORKER_ID1);
+    assertThat(runningFlushWorkers.getSizesOfRunningWorkerBatches(STREAM1).size()).isEqualTo(1);
+    assertThat(runningFlushWorkers.getSizesOfRunningWorkerBatches(STREAM2).size()).isEqualTo(1);
+  }
+
+  @Test
+  void testGetSizesOfRunningWorkerBatches() {
+    runningFlushWorkers.trackFlushWorker(STREAM1, FLUSH_WORKER_ID1);
+    runningFlushWorkers.trackFlushWorker(STREAM1, FLUSH_WORKER_ID2);
+    runningFlushWorkers.trackFlushWorker(STREAM2, FLUSH_WORKER_ID1);
+    assertEquals(List.of(Optional.empty(), Optional.empty()),
+        runningFlushWorkers.getSizesOfRunningWorkerBatches(STREAM1));
+    assertEquals(List.of(Optional.empty()), runningFlushWorkers.getSizesOfRunningWorkerBatches(STREAM2));
+    assertThrows(IllegalStateException.class, () -> runningFlushWorkers.registerBatchSize(STREAM2, FLUSH_WORKER_ID2, SIZE_10MB));
+    runningFlushWorkers.registerBatchSize(STREAM1, FLUSH_WORKER_ID1, SIZE_10MB);
+    runningFlushWorkers.registerBatchSize(STREAM1, FLUSH_WORKER_ID2, SIZE_10MB);
+    runningFlushWorkers.registerBatchSize(STREAM2, FLUSH_WORKER_ID1, SIZE_10MB);
+    assertEquals(List.of(Optional.of(SIZE_10MB), Optional.of(SIZE_10MB)), runningFlushWorkers.getSizesOfRunningWorkerBatches(STREAM1));
+    assertEquals(List.of(Optional.of(SIZE_10MB)), runningFlushWorkers.getSizesOfRunningWorkerBatches(STREAM2));
+  }
+
+}

--- a/airbyte-integrations/bases/base-java/src/test/java/io/airbyte/integrations/destination_async/RunningSizeEstimateTest.java
+++ b/airbyte-integrations/bases/base-java/src/test/java/io/airbyte/integrations/destination_async/RunningSizeEstimateTest.java
@@ -1,0 +1,66 @@
+/*
+ * Copyright (c) 2023 Airbyte, Inc., all rights reserved.
+ */
+
+package io.airbyte.integrations.destination_async;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+import io.airbyte.protocol.models.v0.StreamDescriptor;
+import java.util.Collections;
+import java.util.List;
+import java.util.Optional;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+public class RunningSizeEstimateTest {
+
+  private static final long SIZE_10MB = 10 * 1024 * 1024;
+  private static final long SIZE_20MB = 20 * 1024 * 1024;
+  private static final long SIZE_200MB = 200 * 1024 * 1024;
+  private static final StreamDescriptor DESC1 = new StreamDescriptor().withName("test1");
+
+  private static DestinationFlushFunction flusher;
+
+  @BeforeEach
+  void setup() {
+    flusher = mock(DestinationFlushFunction.class);
+    when(flusher.getOptimalBatchSizeBytes()).thenReturn(SIZE_200MB);
+  }
+
+  @Test
+  void testEstimateZeroWorkers() {
+    final RunningFlushWorkers runningFlushWorkers = mock(RunningFlushWorkers.class);
+    when(runningFlushWorkers.getSizesOfRunningWorkerBatches(any())).thenReturn(Collections.emptyList());
+    final DetectStreamToFlush detect = new DetectStreamToFlush(null, runningFlushWorkers, null, flusher);
+    assertEquals(0, detect.estimateSizeOfRunningWorkers(DESC1, SIZE_10MB));
+  }
+
+  @Test
+  void testEstimateWorkerWithBatch() {
+    final RunningFlushWorkers runningFlushWorkers = mock(RunningFlushWorkers.class);
+    when(runningFlushWorkers.getSizesOfRunningWorkerBatches(any())).thenReturn(List.of(Optional.of(SIZE_20MB)));
+    final DetectStreamToFlush detect = new DetectStreamToFlush(null, runningFlushWorkers, null, flusher);
+    assertEquals(SIZE_20MB, detect.estimateSizeOfRunningWorkers(DESC1, SIZE_10MB));
+  }
+
+  @Test
+  void testEstimateWorkerWithoutBatchAndQueueLessThanOptimalSize() {
+    final RunningFlushWorkers runningFlushWorkers = mock(RunningFlushWorkers.class);
+    when(runningFlushWorkers.getSizesOfRunningWorkerBatches(any())).thenReturn(List.of(Optional.empty()));
+    final DetectStreamToFlush detect = new DetectStreamToFlush(null, runningFlushWorkers, null, flusher);
+    assertEquals(SIZE_10MB, detect.estimateSizeOfRunningWorkers(DESC1, SIZE_10MB));
+  }
+
+  @Test
+  void testEstimateWorkerWithoutBatchAndQueueGreaterThanOptimalSize() {
+    final RunningFlushWorkers runningFlushWorkers = mock(RunningFlushWorkers.class);
+    when(runningFlushWorkers.getSizesOfRunningWorkerBatches(any())).thenReturn(List.of(Optional.empty()));
+    final DetectStreamToFlush detect = new DetectStreamToFlush(null, runningFlushWorkers, null, flusher);
+    assertEquals(SIZE_200MB, detect.estimateSizeOfRunningWorkers(DESC1, SIZE_200MB + 1));
+  }
+
+}

--- a/airbyte-integrations/bases/base-java/src/test/java/io/airbyte/integrations/destination_async/SizeTriggerTest.java
+++ b/airbyte-integrations/bases/base-java/src/test/java/io/airbyte/integrations/destination_async/SizeTriggerTest.java
@@ -1,0 +1,77 @@
+/*
+ * Copyright (c) 2023 Airbyte, Inc., all rights reserved.
+ */
+
+package io.airbyte.integrations.destination_async;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+import io.airbyte.integrations.destination_async.buffers.BufferDequeue;
+import io.airbyte.protocol.models.v0.StreamDescriptor;
+import java.time.Instant;
+import java.util.Collections;
+import java.util.List;
+import java.util.Optional;
+import java.util.Set;
+import java.util.concurrent.atomic.AtomicBoolean;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+public class SizeTriggerTest {
+
+  public static final Instant NOW = Instant.now();
+  public static final Instant FIVE_MIN_AGO = NOW.minusSeconds(60 * 5);
+  private static final long SIZE_10MB = 10 * 1024 * 1024;
+  private static final long SIZE_200MB = 200 * 1024 * 1024;
+
+  private static final StreamDescriptor DESC1 = new StreamDescriptor().withName("test1");
+
+  private static DestinationFlushFunction flusher;
+
+  @BeforeEach
+  void setup() {
+    flusher = mock(DestinationFlushFunction.class);
+    when(flusher.getOptimalBatchSizeBytes()).thenReturn(SIZE_200MB);
+  }
+
+  @Test
+  void testSizeTriggerOnEmptyQueue() {
+    final BufferDequeue bufferDequeue = mock(BufferDequeue.class);
+    when(bufferDequeue.getBufferedStreams()).thenReturn(Set.of(DESC1));
+    when(bufferDequeue.getQueueSizeBytes(DESC1)).thenReturn(Optional.of(0L));
+    final RunningFlushWorkers runningFlushWorkers = mock(RunningFlushWorkers.class);
+    final DetectStreamToFlush detect = new DetectStreamToFlush(bufferDequeue, runningFlushWorkers, new AtomicBoolean(false), flusher);
+    assertEquals(false, detect.isSizeTriggered(DESC1, SIZE_10MB).getLeft());
+  }
+
+  @Test
+  void testSizeTriggerRespectsThreshold() {
+    final BufferDequeue bufferDequeue = mock(BufferDequeue.class);
+    when(bufferDequeue.getBufferedStreams()).thenReturn(Set.of(DESC1));
+    when(bufferDequeue.getQueueSizeBytes(DESC1)).thenReturn(Optional.of(1L));
+    final RunningFlushWorkers runningFlushWorkers = mock(RunningFlushWorkers.class);
+    final DetectStreamToFlush detect = new DetectStreamToFlush(bufferDequeue, runningFlushWorkers, new AtomicBoolean(false), flusher);
+    // if above threshold, triggers
+    assertEquals(true, detect.isSizeTriggered(DESC1, 0).getLeft());
+    // if below threshold, no trigger
+    assertEquals(false, detect.isSizeTriggered(DESC1, SIZE_10MB).getLeft());
+  }
+
+  @Test
+  void testSizeTriggerRespectsRunningWorkersEstimate() {
+    final BufferDequeue bufferDequeue = mock(BufferDequeue.class);
+    when(bufferDequeue.getBufferedStreams()).thenReturn(Set.of(DESC1));
+    when(bufferDequeue.getQueueSizeBytes(DESC1)).thenReturn(Optional.of(1L));
+    final RunningFlushWorkers runningFlushWorkers = mock(RunningFlushWorkers.class);
+    when(runningFlushWorkers.getSizesOfRunningWorkerBatches(any()))
+        .thenReturn(Collections.emptyList())
+        .thenReturn(List.of(Optional.of(SIZE_10MB)));
+    final DetectStreamToFlush detect = new DetectStreamToFlush(bufferDequeue, runningFlushWorkers, new AtomicBoolean(false), flusher);
+    assertEquals(true, detect.isSizeTriggered(DESC1, 0).getLeft());
+    assertEquals(false, detect.isSizeTriggered(DESC1, 0).getLeft());
+  }
+
+}

--- a/airbyte-integrations/bases/base-java/src/test/java/io/airbyte/integrations/destination_async/StreamPriorityTest.java
+++ b/airbyte-integrations/bases/base-java/src/test/java/io/airbyte/integrations/destination_async/StreamPriorityTest.java
@@ -1,0 +1,65 @@
+/*
+ * Copyright (c) 2023 Airbyte, Inc., all rights reserved.
+ */
+
+package io.airbyte.integrations.destination_async;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+import io.airbyte.commons.json.Jsons;
+import io.airbyte.integrations.destination_async.buffers.BufferDequeue;
+import io.airbyte.protocol.models.v0.StreamDescriptor;
+import java.time.Instant;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Optional;
+import java.util.Set;
+import java.util.concurrent.atomic.AtomicBoolean;
+import org.junit.jupiter.api.Test;
+
+public class StreamPriorityTest {
+
+  public static final Instant NOW = Instant.now();
+  public static final Instant FIVE_MIN_AGO = NOW.minusSeconds(60 * 5);
+  private static final StreamDescriptor DESC1 = new StreamDescriptor().withName("test1");
+  private static final StreamDescriptor DESC2 = new StreamDescriptor().withName("test2");
+  private static final Set<StreamDescriptor> DESCS = Set.of(DESC1, DESC2);
+
+  @Test
+  void testOrderByPrioritySize() {
+    final BufferDequeue bufferDequeue = mock(BufferDequeue.class);
+    when(bufferDequeue.getQueueSizeBytes(DESC1)).thenReturn(Optional.of(1L)).thenReturn(Optional.of(0L));
+    when(bufferDequeue.getQueueSizeBytes(DESC2)).thenReturn(Optional.of(0L)).thenReturn(Optional.of(1L));
+    final DetectStreamToFlush detect = new DetectStreamToFlush(bufferDequeue, null, new AtomicBoolean(false), null);
+
+    assertEquals(List.of(DESC1, DESC2), detect.orderStreamsByPriority(DESCS));
+    assertEquals(List.of(DESC2, DESC1), detect.orderStreamsByPriority(DESCS));
+  }
+
+  @Test
+  void testOrderByPrioritySecondarySortByTime() {
+    final BufferDequeue bufferDequeue = mock(BufferDequeue.class);
+    when(bufferDequeue.getQueueSizeBytes(any())).thenReturn(Optional.of(0L));
+    when(bufferDequeue.getTimeOfLastRecord(DESC1)).thenReturn(Optional.of(FIVE_MIN_AGO)).thenReturn(Optional.of(NOW));
+    when(bufferDequeue.getTimeOfLastRecord(DESC2)).thenReturn(Optional.of(NOW)).thenReturn(Optional.of(FIVE_MIN_AGO));
+    final DetectStreamToFlush detect = new DetectStreamToFlush(bufferDequeue, null, new AtomicBoolean(false), null);
+    assertEquals(List.of(DESC1, DESC2), detect.orderStreamsByPriority(DESCS));
+    assertEquals(List.of(DESC2, DESC1), detect.orderStreamsByPriority(DESCS));
+  }
+
+  @Test
+  void testOrderByPriorityTertiarySortByName() {
+    final BufferDequeue bufferDequeue = mock(BufferDequeue.class);
+    when(bufferDequeue.getQueueSizeBytes(any())).thenReturn(Optional.of(0L));
+    when(bufferDequeue.getTimeOfLastRecord(any())).thenReturn(Optional.of(NOW));
+    final DetectStreamToFlush detect = new DetectStreamToFlush(bufferDequeue, null, new AtomicBoolean(false), null);
+    final List<StreamDescriptor> descs = List.of(Jsons.clone(DESC1), Jsons.clone(DESC2));
+    assertEquals(List.of(descs.get(0), descs.get(1)), detect.orderStreamsByPriority(new HashSet<>(descs)));
+    descs.get(0).setName("test3");
+    assertEquals(List.of(descs.get(1), descs.get(0)), detect.orderStreamsByPriority(new HashSet<>(descs)));
+  }
+
+}

--- a/airbyte-integrations/bases/base-java/src/test/java/io/airbyte/integrations/destination_async/TimeTriggerTest.java
+++ b/airbyte-integrations/bases/base-java/src/test/java/io/airbyte/integrations/destination_async/TimeTriggerTest.java
@@ -1,0 +1,39 @@
+/*
+ * Copyright (c) 2023 Airbyte, Inc., all rights reserved.
+ */
+
+package io.airbyte.integrations.destination_async;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+import io.airbyte.integrations.destination_async.buffers.BufferDequeue;
+import io.airbyte.protocol.models.v0.StreamDescriptor;
+import java.time.Instant;
+import java.util.Optional;
+import java.util.Set;
+import org.junit.jupiter.api.Test;
+
+public class TimeTriggerTest {
+
+  public static final Instant NOW = Instant.now();
+  public static final Instant FIVE_MIN_AGO = NOW.minusSeconds(60 * 5);
+
+  private static final StreamDescriptor DESC1 = new StreamDescriptor().withName("test1");
+
+  @Test
+  void testTimeTrigger() {
+    final BufferDequeue bufferDequeue = mock(BufferDequeue.class);
+    when(bufferDequeue.getBufferedStreams()).thenReturn(Set.of(DESC1));
+    when(bufferDequeue.getTimeOfLastRecord(DESC1))
+        .thenReturn(Optional.empty())
+        .thenReturn(Optional.of(NOW))
+        .thenReturn(Optional.of(FIVE_MIN_AGO));
+    final DetectStreamToFlush detect = new DetectStreamToFlush(bufferDequeue, null, null, null);
+    assertEquals(false, detect.isTimeTriggered(DESC1).getLeft());
+    assertEquals(false, detect.isTimeTriggered(DESC1).getLeft());
+    assertEquals(true, detect.isTimeTriggered(DESC1).getLeft());
+  }
+
+}


### PR DESCRIPTION
## What
* The logic for which stream we assign a flush worker is one of the places where we will do the most tuning. That means as we change it, we need to be well encapsulate and well tested.
* This PR is designed to be readable to get someone up to speed on when we trigger. It's good context for the destinations team as the logic for when we decide to flush is a little different than the existing one.

## How
* Moves logic for triggers into its own class.
* Adds rigorous javadoc comments.
* Adds rigorous testing.

## Recommended reading order
1. `DetectStreamToFlush.java`
2. `RunningFlushWorkers.java`

