### PR TITLE
connectors-ci: disable connectors base build for connectors

### DIFF
--- a/.github/workflows/gradle.yml
+++ b/.github/workflows/gradle.yml
@@ -65,7 +65,8 @@ jobs:
               - 'airbyte-api/**'
               - 'octavia-cli/**'
             connectors:
-              - 'airbyte-integrations/**'
+              - 'airbyte-integrations/bases/**'
+              - 'airbyte-integrations/connectors-templates/**'
               - 'airbyte-connector-test-harnesses/acceptance-test-harness/**'
             db:
               - 'airbyte-db/**'


### PR DESCRIPTION
## What
Closes #25582
This [GHA worfklow](https://github.com/airbytehq/airbyte/blob/master/.github/workflows/gradle.yml) performs:
* [octavia-cli build
](https://github.com/airbytehq/airbyte/blob/6d25716871816554dda950b56e24fdf8d5c0d10f/settings.gradle#L138)
* [cdk build](https://github.com/airbytehq/airbyte/blob/6d25716871816554dda950b56e24fdf8d5c0d10f/settings.gradle#L79)
* [connector base build](https://github.com/airbytehq/airbyte/blob/master/settings.gradle#L101)

I believe that these three (time consuming) builds are not required on connectors PR because connectors PRs are not changing any of the "base" listed above. 

## How
* Remove the wildcard on change on the `airbyte-integrationgs/connectors` folder
* Run this connector base build only when something changes on the `bases` folder.


