### PR TITLE
connectors-ci: re-enable automated tests on PRs

### DIFF
--- a/.github/workflows/connector_integration_test_single_dagger.yml
+++ b/.github/workflows/connector_integration_test_single_dagger.yml
@@ -1,5 +1,9 @@
 name: POC Connectors CI - test pipeline
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
 on:
   workflow_dispatch:
     inputs:
@@ -8,7 +12,7 @@ on:
         default: "--modified"
   pull_request:
     paths:
-      #- "airbyte-integrations/connectors/**"
+      - "airbyte-integrations/connectors/**"
       #- ".github/workflows/connector_integration_test_single_dagger.yml"
     types:
       - opened


### PR DESCRIPTION
## What
* Re-enable automated tests on PRs: we want to observe if the infra gained in stability
* Control the concurrency of tests: we want to cancel any test workflow already running on the same branch if any new PR activity is received. 
