### PR TITLE
Source LinkedIn Ads: reduce records limit for Creatives Stream

### DIFF
--- a/airbyte-integrations/connectors/source-linkedin-ads/Dockerfile
+++ b/airbyte-integrations/connectors/source-linkedin-ads/Dockerfile
@@ -33,5 +33,5 @@ COPY source_linkedin_ads ./source_linkedin_ads
 ENV AIRBYTE_ENTRYPOINT "python /airbyte/integration_code/main.py"
 ENTRYPOINT ["python", "/airbyte/integration_code/main.py"]
 
-LABEL io.airbyte.version=0.2.0
+LABEL io.airbyte.version=0.2.1
 LABEL io.airbyte.name=airbyte/source-linkedin-ads

--- a/airbyte-integrations/connectors/source-linkedin-ads/metadata.yaml
+++ b/airbyte-integrations/connectors/source-linkedin-ads/metadata.yaml
@@ -6,7 +6,7 @@ data:
   connectorType: source
   definitionId: 137ece28-5434-455c-8f34-69dc3782f451
   maxSecondsBetweenMessages: 21600
-  dockerImageTag: 0.2.0
+  dockerImageTag: 0.2.1
   dockerRepository: airbyte/source-linkedin-ads
   githubIssueLabel: source-linkedin-ads
   icon: linkedin.svg

--- a/airbyte-integrations/connectors/source-linkedin-ads/source_linkedin_ads/streams.py
+++ b/airbyte-integrations/connectors/source-linkedin-ads/source_linkedin_ads/streams.py
@@ -294,7 +294,8 @@ class Creatives(LinkedInAdsStreamSlicing):
     endpoint = "creatives"
     parent_stream = Accounts
     cursor_field = "lastModifiedAt"
-    records_limit = 100 # q=500 return error 400: Request would return too many entities; see
+    # standard records_limit=500 returns error 400: Request would return too many entities;  https://github.com/airbytehq/oncall/issues/2159
+    records_limit = 100
 
     def path(
         self,

--- a/airbyte-integrations/connectors/source-linkedin-ads/source_linkedin_ads/streams.py
+++ b/airbyte-integrations/connectors/source-linkedin-ads/source_linkedin_ads/streams.py
@@ -294,6 +294,7 @@ class Creatives(LinkedInAdsStreamSlicing):
     endpoint = "creatives"
     parent_stream = Accounts
     cursor_field = "lastModifiedAt"
+    records_limit = 100 # q=500 return error 400: Request would return too many entities; see
 
     def path(
         self,

--- a/airbyte-integrations/connectors/source-linkedin-ads/unit_tests/source_tests/test_source.py
+++ b/airbyte-integrations/connectors/source-linkedin-ads/unit_tests/source_tests/test_source.py
@@ -206,7 +206,7 @@ class TestLinkedInAdsStreamSlicing:
             (
                     Creatives,
                     {"campaign_id": 123},
-                    "count=500&q=criteria",
+                    "count=100&q=criteria",
             )
         ],
         ids=["AccountUsers", "CampaignGroups", "Campaigns", "Creatives"],

--- a/docs/integrations/sources/linkedin-ads.md
+++ b/docs/integrations/sources/linkedin-ads.md
@@ -182,6 +182,7 @@ After 5 unsuccessful attempts - the connector will stop the sync operation. In s
 
 | Version | Date       | Pull Request                                             | Subject                                                                                                         |
 |:--------|:-----------|:---------------------------------------------------------|:----------------------------------------------------------------------------------------------------------------|
+| 0.2.1   | 2023-05-30 | [26780](https://github.com/airbytehq/airbyte/pull/26780) | Reduce records limit for Creatives Stream                                                                       |
 | 0.2.0   | 2023-05-23 | [26372](https://github.com/airbytehq/airbyte/pull/26372) | Migrate to LinkedIn API version: May 2023                                                                       |
 | 0.1.16  | 2023-05-24 | [26512](https://github.com/airbytehq/airbyte/pull/26512) | Removed authSpecification from spec.json in favour of advancedAuth                                              |
 | 0.1.15  | 2023-02-13 | [22940](https://github.com/airbytehq/airbyte/pull/22940) | Specified date formatting in specification                                                                      |


### PR DESCRIPTION
## What

Resolve https://github.com/airbytehq/oncall/issues/2159

## How
reduce records limit for Creatives Stream `500` -> `100`

## Recommended reading order
1. `x.java`
2. `y.python`

## 🚨 User Impact 🚨

No breaking changes


## Pre-merge Actions



<details><summary><strong>Updating a connector</strong></summary>

### Community member or Airbyter

- Grant edit access to maintainers ([instructions](https://docs.github.com/en/github/collaborating-with-pull-requests/working-with-forks/allowing-changes-to-a-pull-request-branch-created-from-a-fork#enabling-repository-maintainer-permissions-on-existing-pull-requests))
- Unit & integration tests added


### Airbyter

If this is a community PR, the Airbyte engineer reviewing this PR is responsible for the below items.

- Create a non-forked branch based on this PR and test the below items on it
- Build is successful
- If new credentials are required for use in CI, add them to GSM. [Instructions](https://docs.airbyte.io/connector-development#using-credentials-in-ci).

</details>

