### PR TITLE
Jacoco report for source-postgres

### DIFF
--- a/.github/workflows/jacoco_report.yml
+++ b/.github/workflows/jacoco_report.yml
@@ -27,4 +27,5 @@ jobs:
           paths: ${{ github.workspace }}/airbyte-integrations/connectors/source-postgres/build/reports/jacoco/test/jacocoTestReport.xml
           token: ${{ secrets.GITHUB_TOKEN }}
           min-coverage-overall: 64
+          title: Coverage report for source-postgres
           update-comment: true

--- a/.github/workflows/jacoco_report.yml
+++ b/.github/workflows/jacoco_report.yml
@@ -9,6 +9,7 @@ jobs:
   build:
     runs-on: ubuntu-latest
     steps:
+      - uses: actions/checkout@v3
       - name: Set up Java
         uses: actions/setup-java@v3
         with:

--- a/.github/workflows/jacoco_report.yml
+++ b/.github/workflows/jacoco_report.yml
@@ -3,7 +3,7 @@ name: Measure coverage
 on:
   pull_request:
     branches:
-      - duy/main
+      - master
 
 jobs:
   build:
@@ -25,5 +25,5 @@ jobs:
         with:
           paths: ${{ github.workspace }}/airbyte-integrations/connectors/source-postgres/build/reports/jacoco/test/jacocoTestReport.xml
           token: ${{ secrets.GITHUB_TOKEN }}
-          min-coverage-overall: 40
-          min-coverage-changed-files: 60
+          min-coverage-overall: 64
+          update-comment: true


### PR DESCRIPTION
## What
[25681](https://app.zenhub.com/workspaces/db--dw-source-connectors-6333360e0a41155061efbcbd/issues/gh/airbytehq/airbyte/25681)
Added an extra step in CI workflow to run and generate a JaCoCo test coverage report for source-postgres. Will be available to other databases when the time comes.
## 🚨 User Impact 🚨
Contributors to the `source-postgres` will be notified if total module coverage drops below 64%, the current percentage. While not blocking, this needs to be addressed by the PR author. Example: 

_Passing:_
![image](https://github.com/airbytehq/airbyte/assets/24193788/76fe83f9-7822-46cf-85fa-fd54b0f8ea8a)
_Failing:_
![image](https://github.com/airbytehq/airbyte/assets/24193788/d79f9f2e-6440-4f56-8f76-7b3820ad9bc7)
