### PR TITLE
🐛 Source Zendesk Sell: Fix typo in docs

### DIFF
--- a/docs/integrations/sources/zendesk-sell.md
+++ b/docs/integrations/sources/zendesk-sell.md
@@ -1,4 +1,4 @@
-# Zendesk Sunshine
+# Zendesk Sell
 
 ## Sync overview
 


### PR DESCRIPTION
## What
*Fix typo in docs title. Was incorrectly labeled `Zendesk Sunshine`
