### PR TITLE
update bump_version to use shell script

### DIFF
--- a/tools/bin/bump_version.sh
+++ b/tools/bin/bump_version.sh
@@ -9,13 +9,29 @@ if ! test "$(tty)" == "not a tty"; then
 fi
 
 set -o xtrace
-PREV_VERSION=$(grep -w VERSION gradle.properties | cut -d"=" -f2)
+REPO=$(git ls-remote --get-url | xargs basename -s .git)
+echo $REPO
+if [ "$REPO" == "airbyte" ]; then
+  PREV_VERSION=$(grep -w VERSION run-ab-platform.sh | cut -d"=" -f2)
+  echo "Bumping version for Airbyte"
+else
+  PREV_VERSION=$(grep -w VERSION .env | cut -d"=" -f2)
+  echo "Bumping version for Airbyte Platform"
+fi
+
 GIT_REVISION=$(git rev-parse HEAD)
 
 pip install bumpversion
 bumpversion "$PART_TO_BUMP" # PART_TO_BUMP comes from the Github action (patch,major,minor)
 
-NEW_VERSION=$(grep -w VERSION gradle.properties | cut -d"=" -f2)
+if [ "$REPO" == "airbyte" ]; then
+  NEW_VERSION=$(grep -w VERSION run-ab-platform.sh | cut -d"=" -f2)
+  echo "Bumping version for Airbyte"
+else
+  NEW_VERSION=$(grep -w VERSION .env | cut -d"=" -f2)
+  echo "Bumping version for Airbyte Platform"
+fi
+
 export VERSION=$NEW_VERSION # for safety, since lib.sh exports a VERSION that is now outdated
 
 set +o xtrace


### PR DESCRIPTION
## What

Resolves https://github.com/airbytehq/airbyte-internal-issues/issues/4408

This change was made in airbyte-platform, but we maintain two copies of this script for now and this also needed to be changed in airbytehq/airbyte

## How
Make the script match whats in airbytehq/airbyte-platform
