### PR TITLE
🤖 Cloud Availability updater: new connectors to deploy [20230531]

### DIFF
--- a/airbyte-integrations/connectors/source-db2/metadata.yaml
+++ b/airbyte-integrations/connectors/source-db2/metadata.yaml
@@ -1,24 +1,24 @@
 data:
   allowedHosts:
     hosts:
-      - ${host}
+    - ${host}
   connectorSubtype: database
   connectorType: source
   definitionId: 447e0381-3780-4b46-bb62-00a4e3c8b8e2
   dockerImageTag: 0.1.19
   dockerRepository: airbyte/source-db2
+  documentationUrl: https://docs.airbyte.com/integrations/sources/db2
   githubIssueLabel: source-db2
   icon: db2.svg
   license: MIT
   name: IBM Db2
   registries:
     cloud:
-      enabled: false
+      enabled: true
     oss:
       enabled: true
   releaseStage: alpha
-  documentationUrl: https://docs.airbyte.com/integrations/sources/db2
   tags:
-    - language:java
-    - language:python
-metadataSpecVersion: "1.0"
+  - language:java
+  - language:python
+metadataSpecVersion: '1.0'

--- a/airbyte-integrations/connectors/source-freshservice/metadata.yaml
+++ b/airbyte-integrations/connectors/source-freshservice/metadata.yaml
@@ -4,17 +4,17 @@ data:
   definitionId: 9bb85338-ea95-4c93-b267-6be89125b267
   dockerImageTag: 1.1.0
   dockerRepository: airbyte/source-freshservice
+  documentationUrl: https://docs.airbyte.com/integrations/sources/freshservice
   githubIssueLabel: source-freshservice
   icon: freshservice.svg
   license: MIT
   name: Freshservice
   registries:
     cloud:
-      enabled: false
+      enabled: true
     oss:
       enabled: true
   releaseStage: alpha
-  documentationUrl: https://docs.airbyte.com/integrations/sources/freshservice
   tags:
-    - language:python
-metadataSpecVersion: "1.0"
+  - language:python
+metadataSpecVersion: '1.0'

--- a/airbyte-integrations/connectors/source-google-pagespeed-insights/metadata.yaml
+++ b/airbyte-integrations/connectors/source-google-pagespeed-insights/metadata.yaml
@@ -4,18 +4,18 @@ data:
   definitionId: 1e9086ab-ddac-4c1d-aafd-ba43ff575fe4
   dockerImageTag: 0.1.1
   dockerRepository: airbyte/source-google-pagespeed-insights
+  documentationUrl: https://docs.airbyte.com/integrations/sources/google-pagespeed-insights
   githubIssueLabel: source-google-pagespeed-insights
   icon: google-pagespeed-insights.svg
   license: MIT
   name: Google PageSpeed Insights
   registries:
     cloud:
-      enabled: false
+      enabled: true
     oss:
       enabled: true
   releaseStage: alpha
-  documentationUrl: https://docs.airbyte.com/integrations/sources/google-pagespeed-insights
   tags:
-    - language:low-code
-    - language:python
-metadataSpecVersion: "1.0"
+  - language:low-code
+  - language:python
+metadataSpecVersion: '1.0'

--- a/airbyte-integrations/connectors/source-yotpo/metadata.yaml
+++ b/airbyte-integrations/connectors/source-yotpo/metadata.yaml
@@ -4,18 +4,18 @@ data:
   definitionId: 18139f00-b1ba-4971-8f80-8387b617cfd8
   dockerImageTag: 0.1.0
   dockerRepository: airbyte/source-yotpo
+  documentationUrl: https://docs.airbyte.com/integrations/sources/yotpo
   githubIssueLabel: source-yotpo
   icon: yotpo.svg
   license: MIT
   name: Yotpo
   registries:
     cloud:
-      enabled: false
+      enabled: true
     oss:
       enabled: true
   releaseStage: alpha
-  documentationUrl: https://docs.airbyte.com/integrations/sources/yotpo
   tags:
-    - language:low-code
-    - language:python
+  - language:low-code
+  - language:python
 metadataSpecVersion: '1.0'


### PR DESCRIPTION
The Cloud Availability Updater decided that it's the right time to make the following 4 connectors available on Cloud!

# Promoted connectors
|    connector_technical_name    |connector_version|      connector_definition_id       |sync_success_rate|number_of_connections|
|--------------------------------|-----------------|------------------------------------|----------------:|--------------------:|
|source-db2                      |0.1.19           |447e0381-3780-4b46-bb62-00a4e3c8b8e2|             XX|                   XX|
|source-freshservice             |1.1.0            |9bb85338-ea95-4c93-b267-6be89125b267|             XX|                    XX|
|source-google-pagespeed-insights|0.1.1            |1e9086ab-ddac-4c1d-aafd-ba43ff575fe4|             XX|                    XX|
|source-yotpo                    |0.1.0            |18139f00-b1ba-4971-8f80-8387b617cfd8|             XX|                    XX|

# Excluded but eligible connectors
|connector_technical_name|connector_version|connector_definition_id|sync_success_rate|number_of_connections|
|------------------------|-----------------|-----------------------|-----------------|---------------------|

 ☝️ These eligible connectors are already in the definitions masks. They might have been explicitly pinned or excluded. We're not adding these for safety.