### PR TITLE
🤖 Cloud Availability updater: new connectors to deploy [20230531]

### DIFF
--- a/airbyte-ci/connectors/qa-engine/qa_engine/constants.py
+++ b/airbyte-ci/connectors/qa-engine/qa_engine/constants.py
@@ -28,6 +28,7 @@ INAPPROPRIATE_FOR_CLOUD_USE_CONNECTORS = [
     "9f760101-60ae-462f-9ee6-b7a9dafd454d",  # destination-kafka, originally ignored in the destination connector masks
     "4528e960-6f7b-4412-8555-7e0097e1da17",  # destination-starburst-galaxy, no strict-encrypt variant
     "aa8ba6fd-4875-d94e-fc8d-4e1e09aa2503",  # source-teradata, no strict-encrypt variant
+    "447e0381-3780-4b46-bb62-00a4e3c8b8e2",  # source-db2, no strict-encrypt variant
 ]
 
 GCS_QA_REPORT_PATH = "gs://airbyte-data-connectors-qa-engine/"

--- a/airbyte-integrations/connectors/source-db2/metadata.yaml
+++ b/airbyte-integrations/connectors/source-db2/metadata.yaml
@@ -13,7 +13,7 @@ data:
   name: IBM Db2
   registries:
     cloud:
-      enabled: false
+      enabled: true
     oss:
       enabled: true
   releaseStage: alpha

--- a/airbyte-integrations/connectors/source-db2/metadata.yaml
+++ b/airbyte-integrations/connectors/source-db2/metadata.yaml
@@ -13,7 +13,7 @@ data:
   name: IBM Db2
   registries:
     cloud:
-      enabled: true
+      enabled: false # Requires a strict-encrypt variant
     oss:
       enabled: true
   releaseStage: alpha

--- a/airbyte-integrations/connectors/source-freshservice/metadata.yaml
+++ b/airbyte-integrations/connectors/source-freshservice/metadata.yaml
@@ -10,7 +10,7 @@ data:
   name: Freshservice
   registries:
     cloud:
-      enabled: false
+      enabled: true
     oss:
       enabled: true
   releaseStage: alpha

--- a/airbyte-integrations/connectors/source-google-pagespeed-insights/metadata.yaml
+++ b/airbyte-integrations/connectors/source-google-pagespeed-insights/metadata.yaml
@@ -10,7 +10,7 @@ data:
   name: Google PageSpeed Insights
   registries:
     cloud:
-      enabled: false
+      enabled: true
     oss:
       enabled: true
   releaseStage: alpha

--- a/airbyte-integrations/connectors/source-yotpo/metadata.yaml
+++ b/airbyte-integrations/connectors/source-yotpo/metadata.yaml
@@ -10,7 +10,7 @@ data:
   name: Yotpo
   registries:
     cloud:
-      enabled: false
+      enabled: true
     oss:
       enabled: true
   releaseStage: alpha


### PR DESCRIPTION
The Cloud Availability Updater decided that it's the right time to make the following 4 connectors available on Cloud!

# Promoted connectors
|    connector_technical_name    |connector_version|      connector_definition_id       |sync_success_rate|number_of_connections|
|--------------------------------|-----------------|------------------------------------|----------------:|--------------------:|
|source-db2                      |0.1.19           |447e0381-3780-4b46-bb62-00a4e3c8b8e2|             XX|                   XX|
|source-freshservice             |1.1.0            |9bb85338-ea95-4c93-b267-6be89125b267|             XX|                    XX|
|source-google-pagespeed-insights|0.1.1            |1e9086ab-ddac-4c1d-aafd-ba43ff575fe4|             XX|                    XX|
|source-yotpo                    |0.1.0            |18139f00-b1ba-4971-8f80-8387b617cfd8|             0.00|                    XX|

# Excluded but eligible connectors
|connector_technical_name|connector_version|connector_definition_id|sync_success_rate|number_of_connections|
|------------------------|-----------------|-----------------------|-----------------|---------------------|

 ☝️ These eligible connectors are already in the definitions masks. They might have been explicitly pinned or excluded. We're not adding these for safety.