### PR TITLE
Revert "Multi-architecture normalization build (local)"

### DIFF
--- a/airbyte-integrations/bases/base-normalization/build.gradle
+++ b/airbyte-integrations/bases/base-normalization/build.gradle
@@ -1,5 +1,3 @@
-import org.apache.tools.ant.taskdefs.condition.Os
-
 plugins {
     id 'airbyte-docker'
     id 'airbyte-python'
@@ -49,18 +47,7 @@ static def getImageNameWithTag(String customConnector) {
 
 
 def buildAirbyteDocker(String customConnector) {
-    // def baseCommand = ['docker', 'build', '.', '-f', getDockerfile(customConnector), '-t', getImageNameWithTag(customConnector)]
-    // As the base dbt image (https://hub.docker.com/r/fishtownanalytics/dbt/tags) we are using is only build for amd64, we need to use buildkit to force builds for your local environment
-    // We are lucky that all the python code dbt uses is mutli-arch compatible
-
-    def arch = 'linux/amd64'
-    if (Os.isArch("aarch_64") || Os.isArch("aarch64")) {
-        arch = 'linux/arm64'
-    }
-
-    def baseCommand = ['docker', 'buildx', 'build', '--load', '--platform', arch, '-f', getDockerfile(customConnector), '-t', getImageNameWithTag(customConnector), '.']
-    println("Building normalization container: " + baseCommand.join(" "))
-
+    def baseCommand = ['docker', 'build', '.', '-f', getDockerfile(customConnector), '-t', getImageNameWithTag(customConnector)]
     return {
         commandLine baseCommand
     }


### PR DESCRIPTION
Reverts airbytehq/airbyte#26677

Currently, all the tests on master fail with the below, which _feels_ relevant:

```
BigQueryStandardDestinationAcceptanceTest > testCustomDbtTransformations() FAILED
    io.airbyte.workers.exception.TestHarnessException: dbt debug Failed.
        at app//io.airbyte.integrations.standardtest.destination.DestinationAcceptanceTest.testCustomDbtTransformations(DestinationAcceptanceTest.java:967)
```