### PR TITLE
cat: integer is a supported airbyte type

### DIFF
--- a/airbyte-integrations/bases/connector-acceptance-test/CHANGELOG.md
+++ b/airbyte-integrations/bases/connector-acceptance-test/CHANGELOG.md
@@ -1,5 +1,8 @@
 # Changelog
 
+## 0.10.3
+Fixing bug: test_catalog_has_supported_data_types , integer is a supported airbyte type.
+
 ## 0.10.2
 Fixing bug: test_catalog_has_supported_data_types was failing when a connector stream property is named 'type'.
 

--- a/airbyte-integrations/bases/connector-acceptance-test/Dockerfile
+++ b/airbyte-integrations/bases/connector-acceptance-test/Dockerfile
@@ -33,7 +33,7 @@ COPY pytest.ini setup.py ./
 COPY connector_acceptance_test ./connector_acceptance_test
 RUN pip install .
 
-LABEL io.airbyte.version=0.10.2
+LABEL io.airbyte.version=0.10.3
 LABEL io.airbyte.name=airbyte/connector-acceptance-test
 
 ENTRYPOINT ["python", "-m", "pytest", "-p", "connector_acceptance_test.plugin", "-r", "fEsx"]

--- a/airbyte-integrations/bases/connector-acceptance-test/connector_acceptance_test/tests/test_core.py
+++ b/airbyte-integrations/bases/connector-acceptance-test/connector_acceptance_test/tests/test_core.py
@@ -568,7 +568,7 @@ class TestConnection(BaseTest):
 class TestDiscovery(BaseTest):
 
     VALID_TYPES = {"null", "string", "number", "integer", "boolean", "object", "array"}
-    VALID_AIRBYTE_TYPES = {"timestamp_with_timezone", "timestamp_without_timezone"}
+    VALID_AIRBYTE_TYPES = {"timestamp_with_timezone", "timestamp_without_timezone", "integer"}
     VALID_FORMATS = {"date-time", "date"}
     VALID_TYPE_FORMAT_COMBINATIONS = [
         ({"string"}, "date"),
@@ -580,6 +580,10 @@ class TestDiscovery(BaseTest):
         ({"string"}, "timestamp_with_timezone"),
         ({"string"}, "timestamp_without_timezone"),
         ({"string", "null"}, "timestamp_with_timezone"),
+        ({"integer"}, "integer"),
+        ({"integer", "null"}, "integer"),
+        ({"number"}, "integer"),
+        ({"number", "null"}, "integer"),
     ]
 
     @pytest.fixture(name="skip_backward_compatibility_tests")


### PR DESCRIPTION
## What
I forgot to add the `integer` airbyte type as a supported on for this [test](https://github.com/airbytehq/airbyte/blob/a1375fe8407e1f16b55fc0cd35db0cd5b3a2ae5c/airbyte-integrations/bases/connector-acceptance-test/connector_acceptance_test/tests/test_core.py#L695)