### PR TITLE
qa-engine: remove sensitive columns from created PR

### DIFF
--- a/airbyte-ci/connectors/qa-engine/pyproject.toml
+++ b/airbyte-ci/connectors/qa-engine/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "qa-engine"
-version = "0.2.1"
+version = "0.2.2"
 description = "Connector QA Engine for Airbyte"
 authors = ["Airbyte <contact@airbyte.io>"]
 readme = "README.md"

--- a/airbyte-ci/connectors/qa-engine/qa_engine/cloud_availability_updater.py
+++ b/airbyte-ci/connectors/qa-engine/qa_engine/cloud_availability_updater.py
@@ -4,16 +4,17 @@
 
 
 import logging
+import shutil
+import tempfile
 from datetime import datetime
 from pathlib import Path
 from typing import Iterable, List, Optional
-from ruamel.yaml import YAML
+
 import git
 import requests
-import tempfile
-import shutil
-from pytablewriter import MarkdownTableWriter
 from pydash.objects import get, set_
+from pytablewriter import MarkdownTableWriter
+from ruamel.yaml import YAML
 
 from .constants import (
     AIRBYTE_GITHUB_REPO_URL,
@@ -36,6 +37,7 @@ logger = logging.getLogger(__name__)
 yaml = YAML()
 yaml.indent(mapping=2, sequence=4, offset=2)
 yaml.preserve_quotes = True
+
 
 def set_git_identity(repo: git.repo) -> git.repo:
     repo.git.config("--global", "user.email", GIT_USER_EMAIL)
@@ -140,7 +142,7 @@ def get_pr_body(eligible_connectors: List[ConnectorQAReport], excluded_connector
         f"The Cloud Availability Updater decided that it's the right time to make the following {len(eligible_connectors)} connectors available on Cloud!"
         + "\n\n"
     )
-    headers = ["connector_technical_name", "connector_version", "connector_definition_id", "sync_success_rate", "number_of_connections"]
+    headers = ["connector_technical_name", "connector_version", "connector_definition_id"]
 
     writer = MarkdownTableWriter(
         max_precision=2,

--- a/airbyte-ci/connectors/qa-engine/tests/test_cloud_availability_updater.py
+++ b/airbyte-ci/connectors/qa-engine/tests/test_cloud_availability_updater.py
@@ -267,15 +267,11 @@ def test_get_pr_body(mocker, eligible_connectors, excluded_connectors):
     assert "connector_technical_name" in pr_body
     assert "connector_version" in pr_body
     assert "connector_definition_id" in pr_body
-    assert "sync_success_rate" in pr_body
-    assert "number_of_connections" in pr_body
     assert "source-pokeapi" in pr_body
     assert "pokeapi-definition-id" in pr_body
     assert "0.0.0" in pr_body
-    assert "0.99" in pr_body
     assert "source-excluded" in pr_body
     assert "excluded-definition-id" in pr_body
-    assert "0.98" in pr_body
 
 
 @freezegun.freeze_time("2023-02-14")


### PR DESCRIPTION
## What
As the cloud availability updater PR is now on a public repo we don't want to share the adoption metrics publicly.