### PR TITLE
Improving error messages to have better messaging in datadog and the …

### DIFF
--- a/airbyte-cdk/python/airbyte_cdk/connector_builder/connector_builder_handler.py
+++ b/airbyte-cdk/python/airbyte_cdk/connector_builder/connector_builder_handler.py
@@ -67,7 +67,7 @@ def read_stream(source: DeclarativeSource, config: Mapping[str, Any], configured
         )
     except Exception as exc:
         error = AirbyteTracedException.from_exception(
-            exc, message=f"Error reading stream with config={config} and catalog={configured_catalog}"
+            exc, message=f"Error reading stream with config={config} and catalog={configured_catalog}: {str(exc)}"
         )
         return error.as_airbyte_message()
 
@@ -83,7 +83,7 @@ def resolve_manifest(source: ManifestDeclarativeSource) -> AirbyteMessage:
             ),
         )
     except Exception as exc:
-        error = AirbyteTracedException.from_exception(exc, message="Error resolving manifest.")
+        error = AirbyteTracedException.from_exception(exc, message=f"Error resolving manifest: {str(exc)}")
         return error.as_airbyte_message()
 
 
@@ -102,7 +102,7 @@ def list_streams(source: ManifestDeclarativeSource, config: Dict[str, Any]) -> A
             ),
         )
     except Exception as exc:
-        return AirbyteTracedException.from_exception(exc, message="Error listing streams.").as_airbyte_message()
+        return AirbyteTracedException.from_exception(exc, message=f"Error listing streams: {str(exc)}").as_airbyte_message()
 
 
 def _get_http_streams(source: ManifestDeclarativeSource, config: Dict[str, Any]) -> List[HttpStream]:

--- a/airbyte-cdk/python/airbyte_cdk/connector_builder/main.py
+++ b/airbyte-cdk/python/airbyte_cdk/connector_builder/main.py
@@ -73,6 +73,6 @@ if __name__ == "__main__":
     try:
         print(handle_request(sys.argv[1:]))
     except Exception as exc:
-        error = AirbyteTracedException.from_exception(exc, message="Error handling request.")
+        error = AirbyteTracedException.from_exception(exc, message=f"Error handling request: {str(exc)}")
         m = error.as_airbyte_message()
         print(error.as_airbyte_message().json(exclude_unset=True))

--- a/airbyte-cdk/python/unit_tests/connector_builder/test_connector_builder_handler.py
+++ b/airbyte-cdk/python/unit_tests/connector_builder/test_connector_builder_handler.py
@@ -483,7 +483,7 @@ def test_given_stream_is_not_declarative_stream_when_list_streams_then_return_ex
     error_message = list_streams(manifest_declarative_source, {})
 
     assert error_message.type == MessageType.TRACE
-    assert "Error listing streams." == error_message.trace.error.message
+    assert error_message.trace.error.message.startswith("Error listing streams")
     assert "A declarative source should only contain streams of type DeclarativeStream" in error_message.trace.error.internal_message
 
 
@@ -496,7 +496,7 @@ def test_given_declarative_stream_retriever_is_not_http_when_list_streams_then_r
     error_message = list_streams(manifest_declarative_source, {})
 
     assert error_message.type == MessageType.TRACE
-    assert "Error listing streams." == error_message.trace.error.message
+    assert error_message.trace.error.message.startswith("Error listing streams")
     assert "A declarative stream should only have a retriever of type HttpStream" in error_message.trace.error.internal_message
 
 
@@ -506,7 +506,7 @@ def test_given_unexpected_error_when_list_streams_then_return_exception_message(
     error_message = list_streams(manifest_declarative_source, {})
 
     assert error_message.type == MessageType.TRACE
-    assert "Error listing streams." == error_message.trace.error.message
+    assert error_message.trace.error.message.startswith("Error listing streams")
     assert "unexpected error" == error_message.trace.error.internal_message
 
 


### PR DESCRIPTION
…frontend

## What
Today, we display to the user the message. However, it often do not contain information regarding the actual error since we blindly catch everything and do not provide information specific to the exception that was raised in the message.

## How
Adding the `str(exception)` in the error message for generic errors.


## 🚨 User Impact 🚨
Nothing breaking. The user will now see `Error handling request: Validation against json schema defined in declarative_component_schema.yaml schema failed` instead of `Error handling request.` for example
