### PR TITLE
Updates to setup guides for APIs

### DIFF
--- a/docs/integrations/sources/amplitude.md
+++ b/docs/integrations/sources/amplitude.md
@@ -27,7 +27,7 @@ The Amplitude source connector supports the following streams:
 * [Events](https://developers.amplitude.com/docs/export-api#export-api---export-your-projects-event-data) \(Incremental sync\)
 
 If there are more endpoints you'd like Airbyte to support, please [create an issue.](https://github.com/airbytehq/airbyte/issues/new/choose)
-
+<!-- env:oss -->
 ## Supported sync modes
 
 The Amplitude source connector supports the following [sync modes](https://docs.airbyte.com/cloud/core-concepts#connection-sync-modes):
@@ -73,3 +73,4 @@ The Amplitude connector ideally should gracefully handle Amplitude API limitatio
 | 0.1.2   | 2021-09-21 | [6353](https://github.com/airbytehq/airbyte/pull/6353)   | Correct output schemas on cohorts, events, active\_users, and average\_session\_lengths streams           |
 | 0.1.1   | 2021-06-09 | [3973](https://github.com/airbytehq/airbyte/pull/3973)   | Add AIRBYTE\_ENTRYPOINT for kubernetes support                                                            |
 | 0.1.0   | 2021-06-08 | [3664](https://github.com/airbytehq/airbyte/pull/3664)   | New Source: Amplitude                                                                                     |
+<!-- /env:oss -->

--- a/docs/integrations/sources/asana.inapp.md
+++ b/docs/integrations/sources/asana.inapp.md
@@ -4,20 +4,10 @@
 
 ## Setup guide
 1. Enter a name for your source
-2. Authenticate using OAuth (recommended) or enter your `personal_access_token`. Please follow these [steps](https://developers.asana.com/docs/personal-access-token) to obtain Personal Access Token for your account.
+2. Authenticate using OAuth (recommended) or enter your `personal_access_token`. Please follow these [steps](https://developers.asana.com/docs/personal-access-token) to obtain a Personal Access Token for your account.
 3. Click **Set up source**
 
-## Supported Streams
-
-- [Custom fields](https://developers.asana.com/docs/custom-fields)
-- [Projects](https://developers.asana.com/docs/projects)
-- [Sections](https://developers.asana.com/docs/sections)
-- [Stories](https://developers.asana.com/docs/stories)
-- [Tags](https://developers.asana.com/docs/tags)
-- [Tasks](https://developers.asana.com/docs/tasks)
-- [Teams](https://developers.asana.com/docs/teams)
-- [Team Memberships](https://developers.asana.com/docs/team-memberships)
-- [Users](https://developers.asana.com/docs/users)
-- [Workspaces](https://developers.asana.com/docs/workspaces)
+### Syncing Multiple Projects
+If you have access to multiple projects, Airbyte will sync data related to all projects you have access to. The ability to filter to specific projects is not available at this time.
 
 For detailed information on supported sync modes, supported streams, performance considerations, refer to the full documentation for [Asana](https://docs.airbyte.com/integrations/sources/asana).

--- a/docs/integrations/sources/asana.inapp.md
+++ b/docs/integrations/sources/asana.inapp.md
@@ -1,0 +1,23 @@
+## Prerequisites
+
+* OAuth access or a Personal Access Token
+
+## Setup guide
+1. Enter a name for your source
+2. Authenticate using OAuth (recommended) or enter your `personal_access_token`. Please follow these [steps](https://developers.asana.com/docs/personal-access-token) to obtain Personal Access Token for your account.
+3. Click **Set up source**
+
+## Supported Streams
+
+- [Custom fields](https://developers.asana.com/docs/custom-fields)
+- [Projects](https://developers.asana.com/docs/projects)
+- [Sections](https://developers.asana.com/docs/sections)
+- [Stories](https://developers.asana.com/docs/stories)
+- [Tags](https://developers.asana.com/docs/tags)
+- [Tasks](https://developers.asana.com/docs/tasks)
+- [Teams](https://developers.asana.com/docs/teams)
+- [Team Memberships](https://developers.asana.com/docs/team-memberships)
+- [Users](https://developers.asana.com/docs/users)
+- [Workspaces](https://developers.asana.com/docs/workspaces)
+
+For detailed information on supported sync modes, supported streams, performance considerations, refer to the full documentation for [Asana](https://docs.airbyte.com/integrations/sources/asana).

--- a/docs/integrations/sources/asana.md
+++ b/docs/integrations/sources/asana.md
@@ -15,7 +15,8 @@ This page contains the setup guide and reference information for the Asana sourc
 1. [Log into your Airbyte Cloud](https://cloud.airbyte.com/workspaces) account.
 2. In the left navigation bar, click **Sources**. In the top-right corner, click **+new source**.
 3. Set the name for your source
-4. Authenticate using OAuth or enter your `personal_access_token`. Please follow these [steps](https://developers.asana.com/docs/personal-access-token) to obtain Personal Access Token for your account.
+4. Authenticate using OAuth (recommended) or enter your `personal_access_token`. Please follow these [steps](https://developers.asana.com/docs/personal-access-token) to obtain Personal Access Token for your account.
+
 5. Click **Set up source**
 
 <!-- env:oss -->

--- a/docs/integrations/sources/asana.md
+++ b/docs/integrations/sources/asana.md
@@ -16,9 +16,7 @@ This page contains the setup guide and reference information for the Asana sourc
 2. In the left navigation bar, click **Sources**. In the top-right corner, click **+new source**.
 3. Set the name for your source
 4. Authenticate using OAuth (recommended) or enter your `personal_access_token`. Please follow these [steps](https://developers.asana.com/docs/personal-access-token) to obtain Personal Access Token for your account.
-
 5. Click **Set up source**
-
 <!-- env:oss -->
 ### For Airbyte OSS:
 

--- a/docs/integrations/sources/asana.md
+++ b/docs/integrations/sources/asana.md
@@ -4,7 +4,7 @@ This page contains the setup guide and reference information for the Asana sourc
 
 ## Prerequisites
 
-* OAuth access or a Personal Access Token
+Please follow these [steps](https://developers.asana.com/docs/personal-access-token) to obtain Personal Access Token for your account.
 
 ## Setup guide
 
@@ -15,9 +15,9 @@ This page contains the setup guide and reference information for the Asana sourc
 1. [Log into your Airbyte Cloud](https://cloud.airbyte.com/workspaces) account.
 2. In the left navigation bar, click **Sources**. In the top-right corner, click **+new source**.
 3. Set the name for your source
-4. Authenticate using OAuth (recommended) or enter your `personal_access_token`. Please follow these [steps](https://developers.asana.com/docs/personal-access-token) to obtain Personal Access Token for your account.
+4. Enter your `personal_access_token`
 5. Click **Set up source**
-<!-- env:oss -->
+
 ### For Airbyte OSS:
 
 1. Navigate to the Airbyte Open Source dashboard
@@ -25,7 +25,7 @@ This page contains the setup guide and reference information for the Asana sourc
 3. Set the name for your source
 4. Enter your `personal_access_token`
 5. Click **Set up source**
-<!-- /env:oss -->
+
 ## Supported sync modes
 
 The Asana source connector supports the following [sync modes](https://docs.airbyte.com/cloud/core-concepts#connection-sync-modes):
@@ -63,15 +63,16 @@ The connector is restricted by normal Asana [requests limitation](https://develo
 | `datetime`               | `datetime`   |
 | `array`                  | `array`      |
 | `object`                 | `object`     |
-<!-- env:oss -->
+
 ## Changelog
 
 | Version | Date       | Pull Request                                             | Subject                                                    |
 | :------ | :--------- | :------------------------------------------------------- | :--------------------------------------------------------- |
+| 0.1.7   | 2023-05-29 | [26716](https://github.com/airbytehq/airbyte/pull/26716) | Remove authSpecification from spec.json, use advancedAuth instead         |
+| 0.1.6   | 2023-05-26 | [26653](https://github.com/airbytehq/airbyte/pull/26653) | Fix order of authentication methods                        |
 | 0.1.5   | 2022-11-16 | [19561](https://github.com/airbytehq/airbyte/pull/19561) | Added errors handling, updated SAT with new format         |
 | 0.1.4   | 2022-08-18 | [15749](https://github.com/airbytehq/airbyte/pull/15749) | Add cache to project stream                                |
 | 0.1.3   | 2021-10-06 | [6832](https://github.com/airbytehq/airbyte/pull/6832)   | Add oauth init flow parameters support                     |
 | 0.1.2   | 2021-09-24 | [6402](https://github.com/airbytehq/airbyte/pull/6402)   | Fix SAT tests: update schemas and invalid_config.json file |
 | 0.1.1   | 2021-06-09 | [3973](https://github.com/airbytehq/airbyte/pull/3973)   | Add entrypoint and bump version for connector              |
 | 0.1.0   | 2021-05-25 | [3510](https://github.com/airbytehq/airbyte/pull/3510)   | New Source: Asana                                          |
-<!-- /env:oss -->

--- a/docs/integrations/sources/asana.md
+++ b/docs/integrations/sources/asana.md
@@ -25,7 +25,7 @@ This page contains the setup guide and reference information for the Asana sourc
 3. Set the name for your source
 4. Enter your `personal_access_token`
 5. Click **Set up source**
-
+<!-- /env:oss -->
 ## Supported sync modes
 
 The Asana source connector supports the following [sync modes](https://docs.airbyte.com/cloud/core-concepts#connection-sync-modes):
@@ -35,7 +35,7 @@ The Asana source connector supports the following [sync modes](https://docs.airb
 | Full Refresh Sync | Yes        |
 | Incremental Sync  | No         |
 | Namespaces        | No         |
-<!-- /env:oss -->
+
 ## Supported Streams
 
 - [Custom fields](https://developers.asana.com/docs/custom-fields)

--- a/docs/integrations/sources/asana.md
+++ b/docs/integrations/sources/asana.md
@@ -4,7 +4,7 @@ This page contains the setup guide and reference information for the Asana sourc
 
 ## Prerequisites
 
-Please follow these [steps](https://developers.asana.com/docs/personal-access-token) to obtain Personal Access Token for your account.
+* OAuth access or a Personal Access Token
 
 ## Setup guide
 
@@ -15,11 +15,10 @@ Please follow these [steps](https://developers.asana.com/docs/personal-access-to
 1. [Log into your Airbyte Cloud](https://cloud.airbyte.com/workspaces) account.
 2. In the left navigation bar, click **Sources**. In the top-right corner, click **+new source**.
 3. Set the name for your source
-4. Enter your `personal_access_token`
+4. Authenticate using OAuth or enter your `personal_access_token`. Please follow these [steps](https://developers.asana.com/docs/personal-access-token) to obtain Personal Access Token for your account.
 5. Click **Set up source**
 
-⚠️ For the moment, oAuth login is disabled for Asana on Airbyte Cloud.
-
+<!-- env:oss -->
 ### For Airbyte OSS:
 
 1. Navigate to the Airbyte Open Source dashboard
@@ -37,7 +36,7 @@ The Asana source connector supports the following [sync modes](https://docs.airb
 | Full Refresh Sync | Yes        |
 | Incremental Sync  | No         |
 | Namespaces        | No         |
-
+<!-- /env:oss -->
 ## Supported Streams
 
 - [Custom fields](https://developers.asana.com/docs/custom-fields)
@@ -65,7 +64,7 @@ The connector is restricted by normal Asana [requests limitation](https://develo
 | `datetime`               | `datetime`   |
 | `array`                  | `array`      |
 | `object`                 | `object`     |
-
+<!-- env:oss -->
 ## Changelog
 
 | Version | Date       | Pull Request                                             | Subject                                                    |
@@ -76,3 +75,4 @@ The connector is restricted by normal Asana [requests limitation](https://develo
 | 0.1.2   | 2021-09-24 | [6402](https://github.com/airbytehq/airbyte/pull/6402)   | Fix SAT tests: update schemas and invalid_config.json file |
 | 0.1.1   | 2021-06-09 | [3973](https://github.com/airbytehq/airbyte/pull/3973)   | Add entrypoint and bump version for connector              |
 | 0.1.0   | 2021-05-25 | [3510](https://github.com/airbytehq/airbyte/pull/3510)   | New Source: Asana                                          |
+<!-- /env:oss -->

--- a/docs/integrations/sources/bamboo-hr.inapp.md
+++ b/docs/integrations/sources/bamboo-hr.inapp.md
@@ -1,0 +1,14 @@
+## Prerequisites
+
+* BambooHR [API Key](https://documentation.bamboohr.com/docs#authentication)
+
+
+## Setup guide
+1. Name your BambooHR connector
+2. Enter your `api_key`. To generate an API key, users should log in and click their name in the upper right-hand corner of any page to get to the user context menu. If they have sufficient permissions, there will be an "API Keys" option in that menu to go to the page.
+3. Enter your `subdomain`. If you access BambooHR at https://mycompany.bamboohr.com, then the subdomain is "mycompany"
+4. (Optional) Enter any `Custom Report Fields` as a comma-separated list of fields to include in your custom reports. Example: `firstName,lastName`. If none are listed, then the [default fields](https://documentation.bamboohr.com/docs/list-of-field-names) will be returned.
+5. Toggle `Custom Reports Include Default Fields`. If true, then the [default fields](https://documentation.bamboohr.com/docs/list-of-field-names) will be returned. If false, then the values defined in `Custom Report Fields` will be returned. 
+6. Click **Set up source**
+
+For detailed information on supported sync modes, supported streams, performance considerations, refer to the full documentation for [BambooHR](https://docs.airbyte.com/integrations/sources/bamboo-hr).

--- a/docs/integrations/sources/bamboo-hr.inapp.md
+++ b/docs/integrations/sources/bamboo-hr.inapp.md
@@ -5,7 +5,7 @@
 
 ## Setup guide
 1. Name your BambooHR connector
-2. Enter your `api_key`. To generate an API key, users should log in and click their name in the upper right-hand corner of any page to get to the user context menu. If they have sufficient permissions, there will be an "API Keys" option in that menu to go to the page.
+2. Enter your `api_key`. To generate an API key, log in and click your name in the upper right-hand corner of any page to get to the user context menu. If you have sufficient administrator permissions, there will be an "API Keys" option in that menu to go to the page.
 3. Enter your `subdomain`. If you access BambooHR at https://mycompany.bamboohr.com, then the subdomain is "mycompany"
 4. (Optional) Enter any `Custom Report Fields` as a comma-separated list of fields to include in your custom reports. Example: `firstName,lastName`. If none are listed, then the [default fields](https://documentation.bamboohr.com/docs/list-of-field-names) will be returned.
 5. Toggle `Custom Reports Include Default Fields`. If true, then the [default fields](https://documentation.bamboohr.com/docs/list-of-field-names) will be returned. If false, then the values defined in `Custom Report Fields` will be returned. 

--- a/docs/integrations/sources/bing-ads.inapp.md
+++ b/docs/integrations/sources/bing-ads.inapp.md
@@ -1,0 +1,33 @@
+## Prerequisites
+* [Microsoft developer token](https://docs.microsoft.com/en-us/advertising/guides/get-started?view=bingads-13#get-developer-token) of an authorized Bing Ads OAuth application
+
+To use the Bing Ads API, you must have a developer token and valid user credentials. You will need to register an OAuth app to get a refresh token.
+1. [Register your application](https://docs.microsoft.com/en-us/advertising/guides/authentication-oauth-register?view=bingads-13) in the Azure portal.
+2. [Request user consent](https://docs.microsoft.com/en-us/advertising/guides/authentication-oauth-consent?view=bingads-13l) to get the authorization code.
+3. Use the authorization code to [get a refresh token](https://docs.microsoft.com/en-us/advertising/guides/authentication-oauth-get-tokens?view=bingads-13).
+
+:::note
+
+The refresh token expires every 90 days. Repeat the authorization process to get a new refresh token. The full authentication process described [here](https://docs.microsoft.com/en-us/advertising/guides/get-started?view=bingads-13#access-token).
+Please be sure to authenticate with the email (personal or work) that you used to sign in to the Bing ads/Microsoft ads platform.
+:::
+
+4. Request your [Microsoft developer token](https://docs.microsoft.com/en-us/advertising/guides/get-started?view=bingads-13#get-developer-token) in the Microsoft Advertising Developer Portal account tab. 
+
+
+## Setup guide
+1. Enter a name for your source.
+2. Enter the developer token
+3. For **Tenant ID**, enter the custom tenant or use the common tenant. If your OAuth app has a custom tenant and you cannot use Microsoft’s recommended common tenant, use the custom tenant in the Tenant ID field when you set up the connector. 
+
+:::info
+The custom tenant is used in the authentication URL, for example: `https://login.microsoftonline.com/<tenant>/oauth2/v2.0/authorize`
+
+:::
+
+4. For **Replication Start Date**, enter the date in YYYY-MM-DD format. The data added on and after this date will be replicated. If this field is blank, Airbyte will replicate all data.
+5. For **Lookback window** (also known as attribution or conversion window), enter the number of **days** to look into the past. If your conversion window has an hours/minutes granularity, round it up to the number of days exceeding. If you're not using performance report streams in incremental mode, let it with 0 default value.
+6. Click **Authenticate your Bing Ads account** and authorize your account.
+8. Click **Set up source**.  
+
+For detailed information on supported sync modes, supported streams, performance considerations, refer to the full documentation for [Bing Ads](https://docs.airbyte.com/integrations/sources/bing-ads).

--- a/docs/integrations/sources/sendgrid.inapp.md
+++ b/docs/integrations/sources/sendgrid.inapp.md
@@ -1,0 +1,23 @@
+## Prerequisites
+
+* [Sendgrid API Key]((https://docs.sendgrid.com/ui/account-and-settings/api-keys#creating-an-api-key)) with
+  * Read-only access to all resources
+  * Full access to marketing resources
+
+## Setup guide
+
+1. Enter a name for your Sendgridconnector.
+2. Enter your `api key`.
+3. (Optional) Enter the `start_time` in YYYY-MM-DDTHH:MM:SSZ format. Dataadded on and after this date will be replicated. If this field is blank, Airbyte will replicate all data.
+4. Click **Set up source**.
+
+### (Optional) Create a read-only API key
+
+While you can set up the Sendgrid connector using any Salesforce user with read permission, we recommend creating a dedicated read-only user for Airbyte. This allows you to granularly control the which resources Airbyte can read.
+
+The API key should be read-only on all resources except Marketing, where it needs Full Access.
+
+Sendgrid provides two different kinds of marketing campaigns, "legacy marketing campaigns" and "new marketing campaigns". **Legacy marketing campaigns are not supported by this source connector**. 
+If you are seeing a `403 FORBIDDEN error message for https://api.sendgrid.com/v3/marketing/campaigns`, it may be because your SendGrid account uses legacy marketing campaigns.
+
+For detailed information on supported sync modes, supported streams, performance considerations, refer to the full documentation for [Sendgrid](https://docs.airbyte.com/integrations/sources/sendgrid).

--- a/docs/integrations/sources/shopify.inapp.md
+++ b/docs/integrations/sources/shopify.inapp.md
@@ -1,0 +1,65 @@
+## Prerequisites
+
+* An Active [Shopify store](https://www.shopify.com) 
+* The Admin API access token of your [Custom App](https://help.shopify.com/en/manual/apps/app-types/custom-apps).
+
+:::note
+
+Our Shopify Source Connector does not support OAuth at this time due to limitations outside of our control. If OAuth for Shopify is critical to your business, [please reach out to us](mailto:product@airbyte.io) to discuss how we may be able to partner on this effort.
+ 
+:::
+
+## Setup guide
+
+1. Name your source.
+2. Enter your Store name. You can find this in your URL when logged in to Shopify or within the Store details section of your Settings.
+3. Enter your Admin API access token. To set up the access token, you will need to set up a custom application. See instructions below on creating a custom app.
+4. Click Set up source
+
+## Creating a Custom App
+Authentication to the Shopify API requies a [custom application](https://help.shopify.com/en/manual/apps/app-types/custom-apps). Follow these instructions to create a custom app and find your Admin API Access Token.
+
+1. Navigate to Settings > App and sales channels > Develop apps > Create an app
+2. Name your new app
+3. Select **Configure Admin API scopes**
+4. Tick all the scopes prefixed with `read_` (e.g. `read_locations`,`read_price_rules`, etc ) and save. See below for the full list of scopes to allow.
+5. Click **Install app** to give this app access to your data. 
+6. Once installed, go to **API Credentials** to copy the **Admin API Access Token**. 
+
+### Scopes Required for Custom App
+Add the following scopes to your custom app to ensure Airbyte can sync all available data. To see a list of streams this source supports, see our full [Shopify documentation](https://docs.airbyte.com/integrations/sources/shopify/).
+* `read_analytics`
+* `read_assigned_fulfillment_orders`
+* `read_gdpr_data_request`
+* `read_locations`
+* `read_price_rules` 
+* `read_product_listings` 
+* `read_products` 
+* `read_reports` 
+* `read_resource_feedbacks` 
+* `read_script_tags` 
+* `read_shipping`
+* `read_locales`
+* `read_shopify_payments_accounts` 
+* `read_shopify_payments_bank_accounts` 
+* `read_shopify_payments_disputes`
+* `read_shopify_payments_payouts`
+* `read_content`
+* `read_themes`
+* `read_third_party_fulfillment_orders`
+* `read_translations`
+* `read_customers`
+* `read_discounts` 
+* `read_draft_orders` 
+* `read_fulfillments` 
+* `read_gift_cards`
+* `read_inventory`
+* `read_legal_policies` 
+* `read_marketing_events` 
+* `read_merchant_managed_fulfillment_orders` 
+* `read_online_store_pages`
+* `read_order_edits`
+* `read_orders`
+
+​
+For detailed information on supported sync modes, supported streams, performance considerations, refer to the full documentation for [Shopify](https://docs.airbyte.com/integrations/sources/shopify).

--- a/docs/integrations/sources/shopify.md
+++ b/docs/integrations/sources/shopify.md
@@ -78,7 +78,7 @@ If child streams are synced alone from the parent stream - the full sync will ta
 
 ## Getting started
 
-This connector support both: `OAuth 2.0` and `API PASSWORD` (for private applications) athentication methods.
+This connector supports the `API PASSWORD` (for private applications) athentication methods.
 
 ### Connect using `API PASSWORD` option
 
@@ -89,6 +89,41 @@ This connector support both: `OAuth 2.0` and `API PASSWORD` (for private applica
    * Note: The UI will show all possible data sources and will show errors when syncing if it doesn't have permissions to access a resource.
 5. The password under the `Admin API` section is what you'll use as the `API PASSWORD` for the integration.
 6. You're ready to set up Shopify in Airbyte!
+
+### Scopes Required for Custom App
+Add the following scopes to your custom app to ensure Airbyte can sync all available data. To see a list of streams this source supports, see our full [Shopify documentation](https://docs.airbyte.com/integrations/sources/shopify/).
+* `read_analytics`
+* `read_assigned_fulfillment_orders`
+* `read_gdpr_data_request`
+* `read_locations`
+* `read_price_rules` 
+* `read_product_listings` 
+* `read_products` 
+* `read_reports` 
+* `read_resource_feedbacks` 
+* `read_script_tags` 
+* `read_shipping`
+* `read_locales`
+* `read_shopify_payments_accounts` 
+* `read_shopify_payments_bank_accounts` 
+* `read_shopify_payments_disputes`
+* `read_shopify_payments_payouts`
+* `read_content`
+* `read_themes`
+* `read_third_party_fulfillment_orders`
+* `read_translations`
+* `read_customers`
+* `read_discounts` 
+* `read_draft_orders` 
+* `read_fulfillments` 
+* `read_gift_cards`
+* `read_inventory`
+* `read_legal_policies` 
+* `read_marketing_events` 
+* `read_merchant_managed_fulfillment_orders` 
+* `read_online_store_pages`
+* `read_order_edits`
+* `read_orders`
 
 ### Output Streams Schemas
 

--- a/docs/integrations/sources/us-census.md
+++ b/docs/integrations/sources/us-census.md
@@ -3,7 +3,7 @@
 ## Overview
 
 This connector syncs data from the [US Census API](https://www.census.gov/data/developers/guidance/api-user-guide.Example_API_Queries.html)
-
+<!-- env:oss -->
 ### Output schema
 
 This source always outputs a single stream, `us_census_stream`. The output of the stream depends on the configuration of the connector.
@@ -16,7 +16,7 @@ This source always outputs a single stream, `us_census_stream`. The output of th
 | Incremental Sync  | No         |
 | SSL connection    | Yes        |
 | Namespaces        | No         |
-
+<!-- /env:oss -->
 ## Getting started
 
 ### Requirements

--- a/docs/integrations/sources/waiteraid.md
+++ b/docs/integrations/sources/waiteraid.md
@@ -17,7 +17,7 @@ You can find or create authentication tokens within [Waiteraid](https://app.wait
 4. Enter your `auth_token` - Waiteraid Authentication Token.
 5. Enter your `restaurant ID` - The Waiteraid ID of the Restaurant you wanto sync. 
 6. Click **Set up source**.
-
+<!-- env:oss -->
 ### For Airbyte OSS:
 
 1. Navigate to the Airbyte Open Source dashboard.
@@ -36,7 +36,7 @@ The Waiteraid source connector supports the following [sync modes](https://docs.
 | Incremental Sync  | No         |
 | SSL connection    | No         |
 | Namespaces        | No         |
-
+<!-- /env:oss -->
 ## Supported Streams
 
 * [Bookings](https://app.waiteraid.com/api-docs/index.html#api_get_bookings)

--- a/docs/integrations/sources/webflow.md
+++ b/docs/integrations/sources/webflow.md
@@ -8,7 +8,7 @@ Webflow is a CMS system that is used for publishing websites and blogs. This con
 
 Webflow uses [Collections](https://developers.webflow.com/#collections) to store different kinds of information. A collection can be "Blog Posts", or "Blog Authors", etc. Collection names are not pre-defined, the number of collections is not known in advance, and the schema for each collection may be different.
 
-This connector dynamically figures our which collections are available, creates the schema for each collection based on data extracted from Webflow, and creates an [Airbyte Stream](https://docs.airbyte.com/connector-development/cdk-python/full-refresh-stream/) for each collection.
+This connector dynamically figures out which collections are available, creates the schema for each collection based on data extracted from Webflow, and creates an [Airbyte Stream](https://docs.airbyte.com/connector-development/cdk-python/full-refresh-stream/) for each collection.
 
 # Webflow credentials
 
@@ -29,7 +29,7 @@ Which should respond with something similar to:
 ```
 
 You will need to provide the `Site id` and `API key` to the Webflow connector in order for it to pull data from your Webflow site.
-
+<!-- env:oss -->
 # Related tutorial
 
 If you are interested in learning more about the Webflow API and implementation details of this connector, you may wish to consult the [tutorial about how to build a connector to extract data from the Webflow API](https://airbyte.com/tutorials/extract-data-from-the-webflow-api).
@@ -41,3 +41,5 @@ If you are interested in learning more about the Webflow API and implementation 
 | 0.1.2   | 2022-07-14 | [14689](https://github.com/airbytehq/airbyte/pull/14689) | Webflow add ids to streams    |
 | 0.1.1   | 2022-06-22 | [13617](https://github.com/airbytehq/airbyte/pull/13617) | Update Spec Documentation URL |
 | 0.1.0   | 2022-06-22 | [13617](https://github.com/airbytehq/airbyte/pull/13617) | Initial release               |
+
+<!-- /env:oss -->

--- a/docs/integrations/sources/woocommerce.md
+++ b/docs/integrations/sources/woocommerce.md
@@ -32,7 +32,7 @@ You will need to generate new API key with read permissions and use `Customer ke
 5. Fill in `Shop Name`. For `https://EXAMPLE.com`, the shop name is 'EXAMPLE.com'.
 6. Choose start date you want to start sync from.
 7. (Optional) Fill in Conversion Window.
-
+<!-- env:oss -->
 ### For Airbyte OSS:
 
 1. Navigate to the Airbyte Open Source dashboard.
@@ -53,7 +53,7 @@ following [sync modes](https://docs.airbyte.com/cloud/core-concepts#connection-s
 - [Full Refresh - Append](https://docs.airbyte.com/understanding-airbyte/connections/full-refresh-append)
 - [Incremental - Append](https://docs.airbyte.com/understanding-airbyte/connections/incremental-append)
 - [Incremental - Deduped History](https://docs.airbyte.com/understanding-airbyte/connections/incremental-deduped-history)
-
+<!-- /env:oss -->
 ## Supported Streams
 
 - [Coupons](https://woocommerce.github.io/woocommerce-rest-api-docs/#coupons) \(Incremental\)


### PR DESCRIPTION
## What
Goal is to improve the usability of docs for Cloud users by centering on setup within the app.

Creates new in-app docs for:
- Asana
- BambooHR
- Bing Ads
- SendGrid
- Shopify

Update existing docs with improved setup information (so non-Cloud users can benefit too):
- Shopify

Update existing docs with OSS tags
- Amplitude
- US Census
- Waiteraid
- Webflow
- Woocommerce

## 🚨 User Impact 🚨
*Are there any breaking changes? What is the end result perceived by the user?*
None