### PR TITLE
Source Mailchimp: fix unsupported data types

### DIFF
--- a/airbyte-integrations/connectors/source-mailchimp/source_mailchimp/schemas/campaigns.json
+++ b/airbyte-integrations/connectors/source-mailchimp/source_mailchimp/schemas/campaigns.json
@@ -413,7 +413,6 @@
         "feed_url": {
           "type": "string",
           "title": "Feed URL",
-          "format": "uri",
           "description": "The URL for the RSS feed."
         },
         "frequency": {


### PR DESCRIPTION
## What
*"format": "uri" is not supported.*

## How
*Delete unsupported data type*
