### PR TITLE
Correct links at bottom of tutorial page

### DIFF
--- a/docs/connector-development/connector-builder-ui/tutorial.mdx
+++ b/docs/connector-development/connector-builder-ui/tutorial.mdx
@@ -223,11 +223,11 @@ Congratulations! You just completed the following steps:
 ## Next steps
 
 This tutorial didn't go into depth about all features that can be used in the connector builder. Check out the concept pages for more information about certain topics:
-* [Authentication](../authentication)
-* [Record processing](../record-processing)
-* [Pagination](../pagination)
-* [Error handling](../error-handling)
-* [Incremental sync](../incremental-sync)
-* [Partitioning](../partitioning)
+* [Authentication](https://docs.airbyte.com/connector-development/connector-builder-ui/authentication/)
+* [Record processing](https://docs.airbyte.com/connector-development/connector-builder-ui/record-processing/)
+* [Pagination](https://docs.airbyte.com/connector-development/connector-builder-ui/pagination/)
+* [Error handling](https://docs.airbyte.com/connector-development/connector-builder-ui/error-handling/)
+* [Incremental sync](https://docs.airbyte.com/connector-development/connector-builder-ui/incremental-sync/)
+* [Partitioning](https://docs.airbyte.com/connector-development/connector-builder-ui/partitioning/)
 
 Not every possible API can be consumed by connectors configured in the connector builder. The [compatibility guide](/connector-development/connector-builder-ui/connector-builder-compatibility#oauth) can help determining whether another technology should be used to integrate an API with the Airbyte platform.

--- a/docs/connector-development/connector-builder-ui/tutorial.mdx
+++ b/docs/connector-development/connector-builder-ui/tutorial.mdx
@@ -223,11 +223,11 @@ Congratulations! You just completed the following steps:
 ## Next steps
 
 This tutorial didn't go into depth about all features that can be used in the connector builder. Check out the concept pages for more information about certain topics:
-* [Authentication](./authentication)
-* [Record processing](./record-processing)
-* [Pagination](./pagination)
-* [Error handling](./error-handling)
-* [Incremental sync](./incremental-sync)
-* [Partitioning](./partitioning)
+* [Authentication](../authentication)
+* [Record processing](../record-processing)
+* [Pagination](../pagination)
+* [Error handling](../error-handling)
+* [Incremental sync](../incremental-sync)
+* [Partitioning](../partitioning)
 
 Not every possible API can be consumed by connectors configured in the connector builder. The [compatibility guide](/connector-development/connector-builder-ui/connector-builder-compatibility#oauth) can help determining whether another technology should be used to integrate an API with the Airbyte platform.

--- a/docs/connector-development/connector-builder-ui/tutorial.mdx
+++ b/docs/connector-development/connector-builder-ui/tutorial.mdx
@@ -223,11 +223,11 @@ Congratulations! You just completed the following steps:
 ## Next steps
 
 This tutorial didn't go into depth about all features that can be used in the connector builder. Check out the concept pages for more information about certain topics:
-* [Authentication](https://docs.airbyte.com/connector-development/connector-builder-ui/authentication/)
-* [Record processing](https://docs.airbyte.com/connector-development/connector-builder-ui/record-processing/)
-* [Pagination](https://docs.airbyte.com/connector-development/connector-builder-ui/pagination/)
-* [Error handling](https://docs.airbyte.com/connector-development/connector-builder-ui/error-handling/)
-* [Incremental sync](https://docs.airbyte.com/connector-development/connector-builder-ui/incremental-sync/)
-* [Partitioning](https://docs.airbyte.com/connector-development/connector-builder-ui/partitioning/)
+* [Authentication](/connector-development/connector-builder-ui/authentication/)
+* [Record processing](/connector-development/connector-builder-ui/record-processing/)
+* [Pagination](/connector-development/connector-builder-ui/pagination/)
+* [Error handling](/connector-development/connector-builder-ui/error-handling/)
+* [Incremental sync](/connector-development/connector-builder-ui/incremental-sync/)
+* [Partitioning](/connector-development/connector-builder-ui/partitioning/)
 
 Not every possible API can be consumed by connectors configured in the connector builder. The [compatibility guide](/connector-development/connector-builder-ui/connector-builder-compatibility#oauth) can help determining whether another technology should be used to integrate an API with the Airbyte platform.


### PR DESCRIPTION
The current links take you to `https://docs.airbyte.com/connector-development/connector-builder-ui/tutorial/record-processing` which is a 404.  I think I changed it correctly to redirect to `https://docs.airbyte.com/connector-development/connector-builder-ui/record-processing` which is the correct url by excluding `/tutorial`

<img width="1564" alt="Screenshot 2023-06-01 at 9 54 56 AM" src="https://github.com/airbytehq/airbyte/assets/104733644/318d2a8b-ca30-43ad-ba36-45983bbf885b">

<img width="875" alt="Screenshot 2023-06-01 at 9 54 08 AM" src="https://github.com/airbytehq/airbyte/assets/104733644/b380ea75-603f-4eea-98f8-8f9409af624b">


