### PR TITLE
cat: skip test_catalog_has_supported_data_types

### DIFF
--- a/airbyte-integrations/bases/connector-acceptance-test/CHANGELOG.md
+++ b/airbyte-integrations/bases/connector-acceptance-test/CHANGELOG.md
@@ -1,5 +1,8 @@
 # Changelog
 
+## 0.10.5
+Skipping test_catalog_has_supported_data_types as it is failing on too many connectors. Will first address globally the type/format problems at scale and then re-enable it.
+
 ## 0.10.4
 Fixing bug: test_catalog_has_supported_data_types should support stream properties having `/` in it.
 

--- a/airbyte-integrations/bases/connector-acceptance-test/Dockerfile
+++ b/airbyte-integrations/bases/connector-acceptance-test/Dockerfile
@@ -33,7 +33,7 @@ COPY pytest.ini setup.py ./
 COPY connector_acceptance_test ./connector_acceptance_test
 RUN pip install .
 
-LABEL io.airbyte.version=0.10.4
+LABEL io.airbyte.version=0.10.5
 LABEL io.airbyte.name=airbyte/connector-acceptance-test
 
 ENTRYPOINT ["python", "-m", "pytest", "-p", "connector_acceptance_test.plugin", "-r", "fEsx"]

--- a/airbyte-integrations/bases/connector-acceptance-test/connector_acceptance_test/tests/test_core.py
+++ b/airbyte-integrations/bases/connector-acceptance-test/connector_acceptance_test/tests/test_core.py
@@ -692,11 +692,11 @@ class TestDiscovery(BaseTest):
         checker = CatalogDiffChecker(previous_discovered_catalog, discovered_catalog)
         checker.assert_is_backward_compatible()
 
+    @pytest.mark.skip("This tests currently leads to too much failures. We need to fix the connectors at scale first.")
     def test_catalog_has_supported_data_types(self, discovered_catalog: Mapping[str, Any]):
         """Check that all streams have supported data types, format and airbyte_types.
         Supported data types are listed there: https://docs.airbyte.com/understanding-airbyte/supported-data-types/
         """
-
         for stream_name, stream_data in discovered_catalog.items():
             schema_helper = JsonSchemaHelper(stream_data.json_schema)
 


### PR DESCRIPTION
## What
This `test_catalog_has_supported_data_types` test currently leads to too much failures on GA connectors. We should first address the invalid format at scale before enabling it.
