### PR TITLE
Fix normalization builds

### DIFF
--- a/airbyte-integrations/bases/base-normalization/setup.py
+++ b/airbyte-integrations/bases/base-normalization/setup.py
@@ -2,6 +2,7 @@
 # Copyright (c) 2023 Airbyte, Inc., all rights reserved.
 #
 
+# Note: cattrs is pinned to the last known working version which does not have conflicts with typing_extensions.  Learn more https://airbytehq-team.slack.com/archives/C03C4AVJWG4/p1685546430990049
 
 import setuptools
 
@@ -12,7 +13,7 @@ setuptools.setup(
     author_email="contact@airbyte.io",
     url="https://github.com/airbytehq/airbyte",
     packages=setuptools.find_packages(),
-    install_requires=["airbyte-cdk", "pyyaml", "jinja2", "types-PyYAML"],
+    install_requires=["airbyte-cdk", "pyyaml", "jinja2", "types-PyYAML", "cattrs==22.2.0"],
     package_data={"": ["*.yml"]},
     setup_requires=["pytest-runner"],
     entry_points={


### PR DESCRIPTION
Fixes dbt issues like `ImportError: cannot import name 'NotRequired' from 'typing_extensions' (/usr/local/lib/python3.9/site-packages/typing_extensions.py)`

There was a new version of a transitive dependency that was released that broke stuff, so we pinned to the previous version.   If we weren't about to delete all of normalization, we'd start using pip freeze  to formally lock down our versions. 