### PR TITLE
connectors-ci: do not run VersionCheck on nightlies

### DIFF
--- a/tools/ci_connector_ops/ci_connector_ops/pipelines/tests/common.py
+++ b/tools/ci_connector_ops/ci_connector_ops/pipelines/tests/common.py
@@ -60,7 +60,7 @@ class VersionCheck(Step, ABC):
     async def _run(self) -> StepResult:
         if not self.should_run:
             return StepResult(self, status=StepStatus.SKIPPED, stdout="No modified files required a version bump.")
-        if self.context.ci_context is CIContext.MASTER:
+        if self.context.ci_context in [CIContext.MASTER, CIContext.NIGHTLY_BUILDS]:
             return StepResult(self, status=StepStatus.SKIPPED, stdout="Version check are not running in master context.")
         try:
             return self.validate()


### PR DESCRIPTION
## What

Version check should not run on nightly builds / master. 
We don't run them on master because its a check that makes sure version is correctly incremented on files.
