### PR TITLE
connectors-ci: re-enable scheduling of nightly builds

### DIFF
--- a/.github/workflows/connector_nightly_builds_dagger.yml
+++ b/.github/workflows/connector_nightly_builds_dagger.yml
@@ -3,7 +3,7 @@ name: POC Connectors CI - nightly builds
 on:
   schedule:
     # 11AM UTC is 12AM CET, 4AM PST.
-    - cron: "0 8 * * *"
+    - cron: "0 11 * * *"
   workflow_dispatch:
     inputs:
       runs-on:

--- a/.github/workflows/connector_nightly_builds_dagger.yml
+++ b/.github/workflows/connector_nightly_builds_dagger.yml
@@ -1,9 +1,9 @@
 name: POC Connectors CI - nightly builds
 
 on:
-  # schedule:
-  #   # 11AM UTC is 12AM CET, 4AM PST.
-  #   - cron: "0 8 * * *"
+  schedule:
+    # 11AM UTC is 12AM CET, 4AM PST.
+    - cron: "0 8 * * *"
   workflow_dispatch:
     inputs:
       runs-on:
@@ -11,7 +11,7 @@ on:
         default: dev-large-runner
         required: true
       test-connectors-options:
-        default: --concurrency=5 --release-stage=generally_available --release-stage=beta
+        default: --concurrency=10 --release-stage=generally_available --release-stage=beta
         required: true
 
 run-name: Test connectors ${{ inputs.test-connectors-options || 'Nightly builds GA and Beta connectors' }}
@@ -57,7 +57,7 @@ jobs:
             mkdir -p "$DAGGER_TMP_BINDIR"
             curl "https://dl.dagger.io/dagger/main/${DAGGER_CLI_COMMIT}/dagger_${DAGGER_CLI_COMMIT}_$(uname -s | tr A-Z a-z)_$(uname -m | sed s/x86_64/amd64/).tar.gz" | tar xvz -C "$DAGGER_TMP_BINDIR"
           fi
-          airbyte-ci --is-ci --gha-workflow-run-id=${{ github.run_id }} connectors ${{ inputs.test-connectors-options || '--concurrency=5 --release-stage=generally_available --release-stage=beta' }} test
+          airbyte-ci --is-ci --gha-workflow-run-id=${{ github.run_id }} connectors ${{ inputs.test-connectors-options || '--concurrency=10 --release-stage=generally_available --release-stage=beta' }} test
         env:
           _EXPERIMENTAL_DAGGER_CLOUD_TOKEN: "p.eyJ1IjogIjFiZjEwMmRjLWYyZmQtNDVhNi1iNzM1LTgxNzI1NGFkZDU2ZiIsICJpZCI6ICJlNjk3YzZiYy0yMDhiLTRlMTktODBjZC0yNjIyNGI3ZDBjMDEifQ.hT6eMOYt3KZgNoVGNYI3_v4CC-s19z8uQsBkGrBhU3k"
           GCP_GSM_CREDENTIALS: ${{ secrets.GCP_GSM_CREDENTIALS }}


### PR DESCRIPTION
## What
We previously disabled nightly builds scheduling as they were not stable. 
Now that bugs were fixed on the Dagger side we can re-schedule them!
