### PR TITLE
Source Metabase: change activity stream

### DIFF
--- a/airbyte-integrations/connectors/source-metabase/source_metabase/manifest.yaml
+++ b/airbyte-integrations/connectors/source-metabase/source_metabase/manifest.yaml
@@ -43,7 +43,7 @@ definitions:
     $ref: "#/definitions/base_stream"
     $parameters:
       name: "activity"
-      path: "activity"
+      path: "activity/recent_views"
   cards_stream:
     $ref: "#/definitions/base_stream"
     $parameters:


### PR DESCRIPTION
## What
*Activity stream is not available on [latest version v0.46](https://www.metabase.com/docs/v0.46/api/activity), so the stream crashes with 404 error. Becasue of Metabase is not versioned there is no way to make the stream work. ([previous version v0.45 for comparison](https://www.metabase.com/docs/v0.45/api/activity))*

## How
*Proposal: change `Activity` stream to use `/activity/recent_views` endpoint instead of deprecated `/activity`*
