### PR TITLE
Fix grep versionbump

### DIFF
--- a/.bumpversion.cfg
+++ b/.bumpversion.cfg
@@ -1,5 +1,5 @@
 [bumpversion]
-current_version = 0.44.8
+current_version = 0.44.9
 commit = False
 tag = False
 parse = (?P<major>\d+)\.(?P<minor>\d+)\.(?P<patch>\d+)(\-[a-z]+)?

--- a/docs/operator-guides/upgrading-airbyte.md
+++ b/docs/operator-guides/upgrading-airbyte.md
@@ -111,7 +111,7 @@ If you are upgrading from (i.e. your current version of Airbyte is) Airbyte vers
    Here's an example of what it might look like with the values filled in. It assumes that the downloaded `airbyte_archive.tar.gz` is in `/tmp`.
 
    ```bash
-   docker run --rm -v /tmp:/config airbyte/migration:0.44.8 --\
+   docker run --rm -v /tmp:/config airbyte/migration:0.44.9 --\
    --input /config/airbyte_archive.tar.gz\
    --output /config/airbyte_archive_migrated.tar.gz
    ```

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,4 +1,4 @@
-VERSION=0.44.8
+VERSION=0.44.9
 
 # NOTE: some of these values are overwritten in CI!
 # NOTE: if you want to override this for your local machine, set overrides in ~/.gradle/gradle.properties

--- a/octavia-cli/Dockerfile
+++ b/octavia-cli/Dockerfile
@@ -14,5 +14,5 @@ USER octavia-cli
 WORKDIR /home/octavia-project
 ENTRYPOINT ["octavia"]
 
-LABEL io.airbyte.version=0.44.8
+LABEL io.airbyte.version=0.44.9
 LABEL io.airbyte.name=airbyte/octavia-cli

--- a/octavia-cli/README.md
+++ b/octavia-cli/README.md
@@ -104,7 +104,7 @@ This script:
 ```bash
 touch ~/.octavia # Create a file to store env variables that will be mapped the octavia-cli container
 mkdir my_octavia_project_directory # Create your octavia project directory where YAML configurations will be stored.
-docker run --name octavia-cli -i --rm -v my_octavia_project_directory:/home/octavia-project --network host --user $(id -u):$(id -g) --env-file ~/.octavia airbyte/octavia-cli:0.44.8
+docker run --name octavia-cli -i --rm -v my_octavia_project_directory:/home/octavia-project --network host --user $(id -u):$(id -g) --env-file ~/.octavia airbyte/octavia-cli:0.44.9
 ```
 
 ### Using `docker-compose`

--- a/octavia-cli/install.sh
+++ b/octavia-cli/install.sh
@@ -3,7 +3,7 @@
 # This install scripts currently only works for ZSH and Bash profiles.
 # It creates an octavia alias in your profile bound to a docker run command and your current user.
 
-VERSION=0.44.8
+VERSION=0.44.9
 OCTAVIA_ENV_FILE=${HOME}/.octavia
 
 detect_profile() {

--- a/octavia-cli/setup.py
+++ b/octavia-cli/setup.py
@@ -15,7 +15,7 @@ README = (HERE / "README.md").read_text()
 
 setup(
     name="octavia-cli",
-    version="0.44.8",
+    version="0.44.9",
     description="A command line interface to manage Airbyte configurations",
     long_description=README,
     author="Airbyte",

--- a/run-ab-platform.sh
+++ b/run-ab-platform.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 
-VERSION=0.44.8
+VERSION=0.44.9
 # Run away from anything even a little scary
 set -o nounset # -u exit if a variable is not set
 set -o errexit # -f exit for any command failure"

--- a/tools/bin/bump_version.sh
+++ b/tools/bin/bump_version.sh
@@ -12,7 +12,7 @@ set -o xtrace
 REPO=$(git ls-remote --get-url | xargs basename -s .git)
 echo $REPO
 if [ "$REPO" == "airbyte" ]; then
-  PREV_VERSION=$(grep -w VERSION run-ab-platform.sh | cut -d"=" -f2)
+  PREV_VERSION=$(grep -w 'VERSION=[0-9]\+\(\.[0-9]\+\)\+' run-ab-platform.sh | cut -d"=" -f2)
   echo "Bumping version for Airbyte"
 else
   PREV_VERSION=$(grep -w VERSION .env | cut -d"=" -f2)


### PR DESCRIPTION
## What
There was a bug in our script that greps run-ab-platform.sh to get the canonical verison that was causing issue with release where, since we changed how we were searching for version it was actually matching two things in the file, making the version bump script unable to actually run

## How
Fixes the bug as well as manually bumps versions to bring them back in line with what airbyte-platform is at
