### PR TITLE
Update pubsub.md correct typo bigquery to pubsub

### DIFF
--- a/docs/integrations/destinations/pubsub.md
+++ b/docs/integrations/destinations/pubsub.md
@@ -80,7 +80,7 @@ Follow the [Creating and Managing Service Account Keys](https://cloud.google.com
 
 ### Setup the PubSub destination in Airbyte
 
-You should now have all the requirements needed to configure BigQuery as a destination in the UI. You'll need the following information to configure the BigQuery destination:
+You should now have all the requirements needed to configure PubSub as a destination in the UI. You'll need the following information to configure the PubSub destination:
 
 * **Project ID**: GCP project id
 * **Topic ID**: name of pubsub topic under the project


### PR DESCRIPTION
## What
I noticed a small typo in the PubSub connector documentation, which seems like it was probably copied from the BigQuery documentation. It mentions BigQuery instead of PubSub twice.

## How
I fixed the typo.

## User Impact 
No breaking changes.

No new version.

## Pre-merge Actions

None, other than checking to make sure the docs change makes sense.

### Community member or Airbyter

- Documentation updated
    - `docs/integrations/destinations/pubsub.md` typo fixed (does this need a changelog?)

Thanks!
