### PR TITLE
Docs roadmap should use shortlink

### DIFF
--- a/docusaurus/sidebars.js
+++ b/docusaurus/sidebars.js
@@ -467,7 +467,7 @@ module.exports = {
         {
           type: 'link',
           label: 'Roadmap',
-          href: 'https://app.harvestr.io/roadmap/view/pQU6gdCyc/airbyte-roadmap',
+          href: 'https://go.airbyte.com/roadmap',
         },
         'project-overview/product-release-stages',
         'project-overview/slack-code-of-conduct',


### PR DESCRIPTION
Harvestr is dead, long live https://go.airbyte.com/roadmap

From https://airbytehq-team.slack.com/archives/C032Y32T065/p1685810772760619