### PR TITLE
🤖 Cloud Availability updater: new connectors to deploy [20230604]

### DIFF
--- a/airbyte-integrations/connectors/source-aha/metadata.yaml
+++ b/airbyte-integrations/connectors/source-aha/metadata.yaml
@@ -10,7 +10,7 @@ data:
   name: Aha
   registries:
     cloud:
-      enabled: false
+      enabled: true
     oss:
       enabled: true
   releaseStage: alpha

--- a/airbyte-integrations/connectors/source-convex/metadata.yaml
+++ b/airbyte-integrations/connectors/source-convex/metadata.yaml
@@ -10,7 +10,7 @@ data:
   name: Convex
   registries:
     cloud:
-      enabled: false
+      enabled: true
     oss:
       enabled: true
   releaseStage: alpha

--- a/airbyte-integrations/connectors/source-lever-hiring/metadata.yaml
+++ b/airbyte-integrations/connectors/source-lever-hiring/metadata.yaml
@@ -10,7 +10,7 @@ data:
   name: Lever Hiring
   registries:
     cloud:
-      enabled: false
+      enabled: true
     oss:
       enabled: true
   releaseStage: alpha


### PR DESCRIPTION
The Cloud Availability Updater decided that it's the right time to make the following 3 connectors available on Cloud!

# Promoted connectors
|connector_technical_name|connector_version|      connector_definition_id       |
|------------------------|-----------------|------------------------------------|
|source-aha              |0.3.0            |81ca39dc-4534-4dd2-b848-b0cfd2c11fce|
|source-convex           |0.1.1            |c332628c-f55c-4017-8222-378cfafda9b2|
|source-lever-hiring     |0.2.0            |3981c999-bd7d-4afc-849b-e53dea90c948|

# Excluded but eligible connectors
|connector_technical_name|connector_version|connector_definition_id|
|------------------------|-----------------|-----------------------|

 ☝️ These eligible connectors are already in the definitions masks. They might have been explicitly pinned or excluded. We're not adding these for safety.