### PR TITLE
nightly builds: from 6 to 10hours timeout

### DIFF
--- a/.github/workflows/connector_nightly_builds_dagger.yml
+++ b/.github/workflows/connector_nightly_builds_dagger.yml
@@ -19,7 +19,7 @@ run-name: Test connectors ${{ inputs.test-connectors-options || 'Nightly builds 
 jobs:
   test_connectors:
     name: Test connectors ${{ inputs.test-connectors-options || 'Nightly builds GA and Beta connectors' }}
-    timeout-minutes: 360 # 6 hours
+    timeout-minutes: 600 # 10 hours
     runs-on: ${{ inputs.runs-on || 'dev-large-runner' }}
     steps:
       - name: Get start timestamp


### PR DESCRIPTION
## What
I observed the [latest nightly build ](https://github.com/airbytehq/airbyte/actions/runs/5168713674) timed out after 6hours. I 
increase to check if it can finish under 10h.

