### PR TITLE
🤖 Cloud Availability updater: new connectors to deploy [20230605]

### DIFF
--- a/airbyte-integrations/connectors/source-aha/Dockerfile
+++ b/airbyte-integrations/connectors/source-aha/Dockerfile
@@ -34,5 +34,5 @@ COPY source_aha ./source_aha
 ENV AIRBYTE_ENTRYPOINT "python /airbyte/integration_code/main.py"
 ENTRYPOINT ["python", "/airbyte/integration_code/main.py"]
 
-LABEL io.airbyte.version=0.3.0
+LABEL io.airbyte.version=0.3.1
 LABEL io.airbyte.name=airbyte/source-aha

--- a/airbyte-integrations/connectors/source-aha/metadata.yaml
+++ b/airbyte-integrations/connectors/source-aha/metadata.yaml
@@ -10,7 +10,7 @@ data:
   name: Aha
   registries:
     cloud:
-      enabled: false
+      enabled: true
     oss:
       enabled: true
   releaseStage: alpha

--- a/airbyte-integrations/connectors/source-aha/metadata.yaml
+++ b/airbyte-integrations/connectors/source-aha/metadata.yaml
@@ -2,7 +2,7 @@ data:
   connectorSubtype: api
   connectorType: source
   definitionId: 81ca39dc-4534-4dd2-b848-b0cfd2c11fce
-  dockerImageTag: 0.3.0
+  dockerImageTag: 0.3.1
   dockerRepository: airbyte/source-aha
   githubIssueLabel: source-aha
   icon: aha.svg

--- a/airbyte-integrations/connectors/source-aha/source_aha/spec.yaml
+++ b/airbyte-integrations/connectors/source-aha/source_aha/spec.yaml
@@ -12,6 +12,7 @@ connectionSpecification:
       type: string
       description: API Key
       title: API Bearer Token
+      airbyte_secret: true
     url:
       type: string
       description: URL

--- a/airbyte-integrations/connectors/source-convex/metadata.yaml
+++ b/airbyte-integrations/connectors/source-convex/metadata.yaml
@@ -10,7 +10,7 @@ data:
   name: Convex
   registries:
     cloud:
-      enabled: false
+      enabled: true
     oss:
       enabled: true
   releaseStage: alpha

--- a/airbyte-integrations/connectors/source-lever-hiring/metadata.yaml
+++ b/airbyte-integrations/connectors/source-lever-hiring/metadata.yaml
@@ -10,7 +10,7 @@ data:
   name: Lever Hiring
   registries:
     cloud:
-      enabled: false
+      enabled: true
     oss:
       enabled: true
   releaseStage: alpha

--- a/docs/integrations/sources/aha.md
+++ b/docs/integrations/sources/aha.md
@@ -37,6 +37,7 @@ Rate Limiting information is updated [here](https://www.aha.io/api#rate-limiting
 
 | Version | Date       | Pull Request                                             | Subject                                         |
 |:--------|:-----------|:---------------------------------------------------------|:------------------------------------------------|
+| 0.3.1   | 2023-06-05 | [27002](https://github.com/airbytehq/airbyte/pull/27002) | Flag spec `api_key` field as `airbyte-secret` |
 | 0.3.0   | 2023-05-30 | [22642](https://github.com/airbytehq/airbyte/pull/22642) | Add `idea_comments`, `idea_endorsements`, and `idea_categories` streams |
 | 0.2.0   | 2023-05-26 | [26666](https://github.com/airbytehq/airbyte/pull/26666) | Fix integration test and schemas                |
 | 0.1.0   | 2022-11-02 | [18883](https://github.com/airbytehq/airbyte/pull/18893) | 🎉 New Source: Aha                              |


### PR DESCRIPTION
The Cloud Availability Updater decided that it's the right time to make the following 3 connectors available on Cloud!

# Promoted connectors
|connector_technical_name|connector_version|      connector_definition_id       |
|------------------------|-----------------|------------------------------------|
|source-aha              |0.3.0            |81ca39dc-4534-4dd2-b848-b0cfd2c11fce|
|source-convex           |0.1.1            |c332628c-f55c-4017-8222-378cfafda9b2|
|source-lever-hiring     |0.2.0            |3981c999-bd7d-4afc-849b-e53dea90c948|

# Excluded but eligible connectors
|connector_technical_name|connector_version|connector_definition_id|
|------------------------|-----------------|-----------------------|

 ☝️ These eligible connectors are already in the definitions masks. They might have been explicitly pinned or excluded. We're not adding these for safety.