### PR TITLE
[WIP] POC to allow control message anywhere

### DIFF
--- a/airbyte-cdk/python/airbyte_cdk/config_observation.py
+++ b/airbyte-cdk/python/airbyte_cdk/config_observation.py
@@ -68,10 +68,14 @@ def observe_connector_config(non_observed_connector_config: MutableMapping[str, 
 
 
 def emit_configuration_as_airbyte_control_message(config: MutableMapping):
+    airbyte_message = create_connector_config_control_message(config)
+    print(airbyte_message.json(exclude_unset=True))
+
+
+def create_connector_config_control_message(config):
     control_message = AirbyteControlMessage(
         type=OrchestratorType.CONNECTOR_CONFIG,
         emitted_at=time.time() * 1000,
         connectorConfig=AirbyteControlConnectorConfigMessage(config=config),
     )
-    airbyte_message = AirbyteMessage(type=Type.CONTROL, control=control_message)
-    print(airbyte_message.json(exclude_unset=True))
+    return AirbyteMessage(type=Type.CONTROL, control=control_message)

--- a/airbyte-cdk/python/airbyte_cdk/connector_builder/message_grouper.py
+++ b/airbyte-cdk/python/airbyte_cdk/connector_builder/message_grouper.py
@@ -16,11 +16,13 @@ from airbyte_cdk.sources.declarative.declarative_source import DeclarativeSource
 from airbyte_cdk.utils import AirbyteTracedException
 from airbyte_cdk.utils.schema_inferrer import SchemaInferrer
 from airbyte_protocol.models.airbyte_protocol import (
+    AirbyteControlMessage,
     AirbyteLogMessage,
     AirbyteMessage,
     AirbyteTraceMessage,
     ConfiguredAirbyteCatalog,
     Level,
+    OrchestratorType,
     TraceType,
 )
 from airbyte_protocol.models.airbyte_protocol import Type as MessageType
@@ -52,6 +54,7 @@ class MessageGrouper:
 
         slices = []
         log_messages = []
+        latest_config_update: AirbyteControlMessage = None
         for message_group in self._get_message_groups(
                 self._read_stream(source, config, configured_catalog),
                 schema_inferrer,
@@ -63,7 +66,9 @@ class MessageGrouper:
                 if message_group.type == TraceType.ERROR:
                     error_message = f"{message_group.error.message} - {message_group.error.stack_trace}"
                     log_messages.append(LogMessage(**{"message": error_message, "level": "ERROR"}))
-
+            elif isinstance(message_group, AirbyteControlMessage):
+                if not latest_config_update or latest_config_update.emitted_at <= message_group.emitted_at:
+                    latest_config_update = message_group
             else:
                 slices.append(message_group)
 
@@ -74,11 +79,12 @@ class MessageGrouper:
             inferred_schema=schema_inferrer.get_stream_schema(
                 configured_catalog.streams[0].stream.name
             ),  # The connector builder currently only supports reading from a single stream at a time
+            latest_config_update=latest_config_update.connectorConfig.config if latest_config_update else None,
         )
 
     def _get_message_groups(
             self, messages: Iterator[AirbyteMessage], schema_inferrer: SchemaInferrer, limit: int
-    ) -> Iterable[Union[StreamReadPages, AirbyteLogMessage, AirbyteTraceMessage]]:
+    ) -> Iterable[Union[StreamReadPages, AirbyteControlMessage, AirbyteLogMessage, AirbyteTraceMessage]]:
         """
         Message groups are partitioned according to when request log messages are received. Subsequent response log messages
         and record messages belong to the prior request log message and when we encounter another request, append the latest
@@ -135,6 +141,8 @@ class MessageGrouper:
                 current_page_records.append(message.record.data)
                 records_count += 1
                 schema_inferrer.accumulate(message.record)
+            elif message.type == MessageType.CONTROL and message.control.type == OrchestratorType.CONNECTOR_CONFIG:
+                yield message.control
         else:
             self._close_page(current_page_request, current_page_response, current_slice_pages, current_page_records, validate_page_complete=not had_error)
             yield StreamReadSlices(pages=current_slice_pages, slice_descriptor=current_slice_descriptor)

--- a/airbyte-cdk/python/airbyte_cdk/connector_builder/message_grouper.py
+++ b/airbyte-cdk/python/airbyte_cdk/connector_builder/message_grouper.py
@@ -79,7 +79,7 @@ class MessageGrouper:
             inferred_schema=schema_inferrer.get_stream_schema(
                 configured_catalog.streams[0].stream.name
             ),  # The connector builder currently only supports reading from a single stream at a time
-            latest_config_update=latest_config_update.connectorConfig.config if latest_config_update else self._clean_config(config),
+            latest_config_update=latest_config_update.connectorConfig.config if latest_config_update else {},
         )
 
     def _get_message_groups(
@@ -224,11 +224,3 @@ class MessageGrouper:
 
     def _parse_slice_description(self, log_message):
         return json.loads(log_message.replace(AbstractSource.SLICE_LOG_PREFIX, "", 1))
-
-    @staticmethod
-    def _clean_config(config: Mapping[str, Any]):
-        cleaned_config = deepcopy(config)
-        for key in config.keys():
-            if key.startswith("__"):
-                del cleaned_config[key]
-        return cleaned_config

--- a/airbyte-cdk/python/airbyte_cdk/connector_builder/models.py
+++ b/airbyte-cdk/python/airbyte_cdk/connector_builder/models.py
@@ -48,6 +48,7 @@ class StreamRead(object):
     slices: List[StreamReadSlices]
     test_read_limit_reached: bool
     inferred_schema: Optional[Dict[str, Any]]
+    latest_config_update: Optional[Dict[str, Any]]
 
 
 @dataclass

--- a/airbyte-cdk/python/airbyte_cdk/sources/declarative/manifest_declarative_source.py
+++ b/airbyte-cdk/python/airbyte_cdk/sources/declarative/manifest_declarative_source.py
@@ -26,6 +26,7 @@ from airbyte_cdk.sources.declarative.parsers.manifest_component_transformer impo
 from airbyte_cdk.sources.declarative.parsers.manifest_reference_resolver import ManifestReferenceResolver
 from airbyte_cdk.sources.declarative.parsers.model_to_component_factory import ModelToComponentFactory
 from airbyte_cdk.sources.declarative.types import ConnectionDefinition
+from airbyte_cdk.sources.message import MessageRepository
 from airbyte_cdk.sources.streams.core import Stream
 from jsonschema.exceptions import ValidationError
 from jsonschema.validators import validate
@@ -61,12 +62,17 @@ class ManifestDeclarativeSource(DeclarativeSource):
         self._debug = debug
         self._emit_connector_builder_messages = emit_connector_builder_messages
         self._constructor = component_factory if component_factory else ModelToComponentFactory(emit_connector_builder_messages)
+        self._message_repository = self._constructor._message_repository
 
         self._validate_source()
 
     @property
     def resolved_manifest(self) -> Mapping[str, Any]:
         return self._source_config
+
+    @property
+    def message_repository(self) -> Union[None, MessageRepository]:
+        return self._message_repository
 
     @property
     def connection_checker(self) -> ConnectionChecker:

--- a/airbyte-cdk/python/airbyte_cdk/sources/declarative/parsers/model_to_component_factory.py
+++ b/airbyte-cdk/python/airbyte_cdk/sources/declarative/parsers/model_to_component_factory.py
@@ -101,6 +101,7 @@ from airbyte_cdk.sources.declarative.stream_slicers import CartesianProductStrea
 from airbyte_cdk.sources.declarative.transformations import AddFields, RemoveFields
 from airbyte_cdk.sources.declarative.transformations.add_fields import AddedFieldDefinition
 from airbyte_cdk.sources.declarative.types import Config
+from airbyte_cdk.sources.message import InMemoryMessageRepository, MessageRepository
 from airbyte_cdk.sources.streams.http.requests_native_auth.oauth import SingleUseRefreshTokenOauth2Authenticator
 from pydantic import BaseModel
 
@@ -123,6 +124,7 @@ class ModelToComponentFactory:
         self._limit_slices_fetched = limit_slices_fetched
         self._emit_connector_builder_messages = emit_connector_builder_messages
         self._disable_retries = disable_retries
+        self._message_repository = InMemoryMessageRepository()
 
     def _init_mappings(self):
         self.PYDANTIC_MODEL_TO_CONSTRUCTOR: [Type[BaseModel], Callable] = {
@@ -675,9 +677,8 @@ class ModelToComponentFactory:
             parameters=model.parameters,
         )
 
-    @staticmethod
     def create_single_use_refresh_token_oauth_authenticator(
-        model: SingleUseRefreshTokenOAuthAuthenticatorModel, config: Config, **kwargs
+        self, model: SingleUseRefreshTokenOAuthAuthenticatorModel, config: Config, **kwargs
     ) -> SingleUseRefreshTokenOauth2Authenticator:
         return SingleUseRefreshTokenOauth2Authenticator(
             config,
@@ -693,6 +694,7 @@ class ModelToComponentFactory:
             grant_type=model.grant_type,
             refresh_request_body=model.refresh_request_body,
             scopes=model.scopes,
+            message_repository=self._message_repository
         )
 
     @staticmethod

--- a/airbyte-cdk/python/airbyte_cdk/sources/message/__init__.py
+++ b/airbyte-cdk/python/airbyte_cdk/sources/message/__init__.py
@@ -1,0 +1,7 @@
+#
+# Copyright (c) 2021 Airbyte, Inc., all rights reserved.
+#
+
+from .repository import InMemoryMessageRepository, MessageRepository
+
+__all__ = ["InMemoryMessageRepository", "MessageRepository"]

--- a/airbyte-cdk/python/airbyte_cdk/sources/message/repository.py
+++ b/airbyte-cdk/python/airbyte_cdk/sources/message/repository.py
@@ -1,0 +1,27 @@
+from abc import ABC, abstractmethod
+from typing import Callable, Iterable
+
+from airbyte_cdk.models import AirbyteMessage
+
+
+class MessageRepository(ABC):
+
+    @abstractmethod
+    def emit_message(self, message: AirbyteMessage) -> None:
+        raise NotImplementedError()
+
+    @abstractmethod
+    def consume_queue(self) -> Iterable[AirbyteMessage]:
+        raise NotImplementedError()
+
+
+class InMemoryMessageRepository(MessageRepository):
+    def __init__(self):
+        self._message_queue = []
+
+    def emit_message(self, message: AirbyteMessage) -> None:
+        self._message_queue.append(message)
+
+    def consume_queue(self) -> Iterable[AirbyteMessage]:
+        while self._message_queue:
+            yield self._message_queue.pop()

--- a/airbyte-cdk/python/airbyte_cdk/sources/streams/http/requests_native_auth/oauth.py
+++ b/airbyte-cdk/python/airbyte_cdk/sources/streams/http/requests_native_auth/oauth.py
@@ -6,7 +6,8 @@ from typing import Any, List, Mapping, Sequence, Tuple, Union
 
 import dpath
 import pendulum
-from airbyte_cdk.config_observation import emit_configuration_as_airbyte_control_message
+from airbyte_cdk.config_observation import create_connector_config_control_message, emit_configuration_as_airbyte_control_message
+from airbyte_cdk.sources.message import MessageRepository
 from airbyte_cdk.sources.streams.http.requests_native_auth.abstract_oauth import AbstractOauth2Authenticator
 
 
@@ -114,6 +115,7 @@ class SingleUseRefreshTokenOauth2Authenticator(Oauth2Authenticator):
         access_token_config_path: Sequence[str] = ("credentials", "access_token"),
         refresh_token_config_path: Sequence[str] = ("credentials", "refresh_token"),
         token_expiry_date_config_path: Sequence[str] = ("credentials", "token_expiry_date"),
+        message_repository: MessageRepository = None
     ):
         """
 
@@ -140,6 +142,7 @@ class SingleUseRefreshTokenOauth2Authenticator(Oauth2Authenticator):
         self._refresh_token_name = refresh_token_name
         self._connector_config = connector_config
         self._validate_connector_config()
+        self._message_repository = message_repository
         super().__init__(
             token_refresh_endpoint,
             self.get_client_id(),
@@ -227,7 +230,8 @@ class SingleUseRefreshTokenOauth2Authenticator(Oauth2Authenticator):
             self.access_token = new_access_token
             self.set_refresh_token(new_refresh_token)
             self.set_token_expiry_date(new_token_expiry_date)
-            emit_configuration_as_airbyte_control_message(self._connector_config)
+            if self._message_repository:
+                self._message_repository.emit_message(create_connector_config_control_message(self._connector_config))
         return self.access_token
 
     def refresh_access_token(self) -> Tuple[str, int, str]:

--- a/airbyte-cdk/python/unit_tests/connector_builder/test_connector_builder_handler.py
+++ b/airbyte-cdk/python/unit_tests/connector_builder/test_connector_builder_handler.py
@@ -354,6 +354,7 @@ def test_read():
         ],
         test_read_limit_reached=False,
         inferred_schema=None,
+        latest_config_update={}
     )
 
     expected_airbyte_message = AirbyteMessage(
@@ -367,6 +368,7 @@ def test_read():
                 ],
                 "test_read_limit_reached": False,
                 "inferred_schema": None,
+                "latest_config_update": {}
             },
             emitted_at=1,
         ),
@@ -407,7 +409,8 @@ def test_read_returns_error_response(mock_from_exception):
                                           pages=[StreamReadPages(records=[], request=None, response=None)],
                                           slice_descriptor=None, state=None)],
                                       test_read_limit_reached=False,
-                                      inferred_schema=None)
+                                      inferred_schema=None,
+                                      latest_config_update={})
 
     expected_message = AirbyteMessage(
         type=MessageType.RECORD,

--- a/airbyte-cdk/python/unit_tests/connector_builder/test_message_grouper.py
+++ b/airbyte-cdk/python/unit_tests/connector_builder/test_message_grouper.py
@@ -553,6 +553,18 @@ def test_given_control_message_then_stream_read_has_config_update(mock_entrypoin
 
 
 @patch('airbyte_cdk.connector_builder.message_grouper.AirbyteEntrypoint.read')
+def test_given_no_control_message_then_use_in_memory_config_change_as_update(mock_entrypoint_read):
+    mock_source = make_mock_source(mock_entrypoint_read, iter(any_request_and_response_with_a_record()))
+    connector_builder_handler = MessageGrouper(MAX_PAGES_PER_SLICE, MAX_SLICES)
+    full_config = {**CONFIG, **{"__injected_declarative_manifest": MANIFEST}}
+    stream_read: StreamRead = connector_builder_handler.get_message_groups(
+        source=mock_source, config=full_config, configured_catalog=create_configured_catalog("hashiras")
+    )
+
+    assert stream_read.latest_config_update == CONFIG
+
+
+@patch('airbyte_cdk.connector_builder.message_grouper.AirbyteEntrypoint.read')
 def test_given_multiple_control_messages_then_stream_read_has_latest_based_on_emitted_at(mock_entrypoint_read):
     earliest = 0
     earliest_config = {"earliest": 0}

--- a/airbyte-cdk/python/unit_tests/connector_builder/test_message_grouper.py
+++ b/airbyte-cdk/python/unit_tests/connector_builder/test_message_grouper.py
@@ -10,13 +10,13 @@ import pytest
 from airbyte_cdk.connector_builder.message_grouper import MessageGrouper
 from airbyte_cdk.connector_builder.models import HttpRequest, HttpResponse, LogMessage, StreamRead, StreamReadPages
 from airbyte_cdk.models import (
-    AirbyteControlMessage,
     AirbyteControlConnectorConfigMessage,
+    AirbyteControlMessage,
     AirbyteLogMessage,
     AirbyteMessage,
     AirbyteRecordMessage,
     Level,
-    OrchestratorType
+    OrchestratorType,
 )
 from airbyte_cdk.models import Type as MessageType
 from unit_tests.connector_builder.utils import create_configured_catalog

--- a/airbyte-cdk/python/unit_tests/connector_builder/test_message_grouper.py
+++ b/airbyte-cdk/python/unit_tests/connector_builder/test_message_grouper.py
@@ -596,7 +596,6 @@ def test_given_multiple_control_messages_with_same_timestamp_then_stream_read_ha
     assert stream_read.latest_config_update == latest_config
 
 
-
 def make_mock_source(mock_entrypoint_read, return_value: Iterator) -> MagicMock:
     mock_source = MagicMock()
     mock_entrypoint_read.return_value = return_value
@@ -628,6 +627,7 @@ def connector_configuration_control_message(emitted_at: float, config: dict) -> 
             connectorConfig=AirbyteControlConnectorConfigMessage(config=config),
         )
     )
+
 
 def any_request_and_response_with_a_record():
     return [

--- a/airbyte-cdk/python/unit_tests/connector_builder/test_message_grouper.py
+++ b/airbyte-cdk/python/unit_tests/connector_builder/test_message_grouper.py
@@ -9,7 +9,15 @@ from unittest.mock import MagicMock, patch
 import pytest
 from airbyte_cdk.connector_builder.message_grouper import MessageGrouper
 from airbyte_cdk.connector_builder.models import HttpRequest, HttpResponse, LogMessage, StreamRead, StreamReadPages
-from airbyte_cdk.models import AirbyteLogMessage, AirbyteMessage, AirbyteRecordMessage, Level
+from airbyte_cdk.models import (
+    AirbyteControlMessage,
+    AirbyteControlConnectorConfigMessage,
+    AirbyteLogMessage,
+    AirbyteMessage,
+    AirbyteRecordMessage,
+    Level,
+    OrchestratorType
+)
 from airbyte_cdk.models import Type as MessageType
 from unit_tests.connector_builder.utils import create_configured_catalog
 
@@ -463,9 +471,9 @@ def test_get_grouped_messages_with_many_slices(mock_entrypoint_read):
         )
     )
 
-    connecto_builder_handler = MessageGrouper(MAX_PAGES_PER_SLICE, MAX_SLICES)
+    connector_builder_handler = MessageGrouper(MAX_PAGES_PER_SLICE, MAX_SLICES)
 
-    stream_read: StreamRead = connecto_builder_handler.get_message_groups(
+    stream_read: StreamRead = connector_builder_handler.get_message_groups(
         source=mock_source, config=CONFIG, configured_catalog=create_configured_catalog("hashiras")
     )
 
@@ -530,6 +538,65 @@ def test_read_stream_returns_error_if_stream_does_not_exist():
     assert "ERROR" in actual_response.logs[0].level
 
 
+@patch('airbyte_cdk.connector_builder.message_grouper.AirbyteEntrypoint.read')
+def test_given_control_message_then_stream_read_has_config_update(mock_entrypoint_read):
+    updated_config = {"x": 1}
+    mock_source = make_mock_source(mock_entrypoint_read, iter(
+        any_request_and_response_with_a_record() + [connector_configuration_control_message(1, updated_config)]
+    ))
+    connector_builder_handler = MessageGrouper(MAX_PAGES_PER_SLICE, MAX_SLICES)
+    stream_read: StreamRead = connector_builder_handler.get_message_groups(
+        source=mock_source, config=CONFIG, configured_catalog=create_configured_catalog("hashiras")
+    )
+
+    assert stream_read.latest_config_update == updated_config
+
+
+@patch('airbyte_cdk.connector_builder.message_grouper.AirbyteEntrypoint.read')
+def test_given_multiple_control_messages_then_stream_read_has_latest_based_on_emitted_at(mock_entrypoint_read):
+    earliest = 0
+    earliest_config = {"earliest": 0}
+    latest = 1
+    latest_config = {"latest": 1}
+    mock_source = make_mock_source(mock_entrypoint_read, iter(
+        any_request_and_response_with_a_record() +
+        [
+            # here, we test that even if messages are emitted in a different order, we still rely on `emitted_at`
+            connector_configuration_control_message(latest, latest_config),
+            connector_configuration_control_message(earliest, earliest_config),
+        ]
+    )
+                                   )
+    connector_builder_handler = MessageGrouper(MAX_PAGES_PER_SLICE, MAX_SLICES)
+    stream_read: StreamRead = connector_builder_handler.get_message_groups(
+        source=mock_source, config=CONFIG, configured_catalog=create_configured_catalog("hashiras")
+    )
+
+    assert stream_read.latest_config_update == latest_config
+
+
+@patch('airbyte_cdk.connector_builder.message_grouper.AirbyteEntrypoint.read')
+def test_given_multiple_control_messages_with_same_timestamp_then_stream_read_has_latest_based_on_message_order(mock_entrypoint_read):
+    emitted_at = 0
+    earliest_config = {"earliest": 0}
+    latest_config = {"latest": 1}
+    mock_source = make_mock_source(mock_entrypoint_read, iter(
+        any_request_and_response_with_a_record() +
+        [
+            connector_configuration_control_message(emitted_at, earliest_config),
+            connector_configuration_control_message(emitted_at, latest_config),
+        ]
+    )
+                                   )
+    connector_builder_handler = MessageGrouper(MAX_PAGES_PER_SLICE, MAX_SLICES)
+    stream_read: StreamRead = connector_builder_handler.get_message_groups(
+        source=mock_source, config=CONFIG, configured_catalog=create_configured_catalog("hashiras")
+    )
+
+    assert stream_read.latest_config_update == latest_config
+
+
+
 def make_mock_source(mock_entrypoint_read, return_value: Iterator) -> MagicMock:
     mock_source = MagicMock()
     mock_entrypoint_read.return_value = return_value
@@ -550,3 +617,21 @@ def record_message(stream: str, data: dict) -> AirbyteMessage:
 
 def slice_message(slice_descriptor: str = '{"key": "value"}') -> AirbyteMessage:
     return AirbyteMessage(type=MessageType.LOG, log=AirbyteLogMessage(level=Level.INFO, message="slice:" + slice_descriptor))
+
+
+def connector_configuration_control_message(emitted_at: float, config: dict) -> AirbyteMessage:
+    return AirbyteMessage(
+        type=MessageType.CONTROL,
+        control=AirbyteControlMessage(
+            type=OrchestratorType.CONNECTOR_CONFIG,
+            emitted_at=emitted_at,
+            connectorConfig=AirbyteControlConnectorConfigMessage(config=config),
+        )
+    )
+
+def any_request_and_response_with_a_record():
+    return [
+        request_log_message({"request": 1}),
+        response_log_message({"response": 2}),
+        record_message("hashiras", {"name": "Shinobu Kocho"}),
+    ]


### PR DESCRIPTION
## What
This is an attempt at creating a mechanism to emit message from anywhere in the code. This has been implement only on ManifestDeclarativeSources and full refresh for now to demonstrate how it could work. Also, tests were not update. However, it has been tested manually using `airbyte_cdk/connector_builder/main.py` and validating that `latest_config_update` was populated properly.

## How
Using a repository, we can store messages to be emitted whenever the AbstractSource feels like it. 

*Benefits*
* No need for hacky solution where we only print to the console which only works if you consume the output of the Python process instead of the output of "read" method
* You can easily see who emits message by searching of MessageRepository usage

*Drawbacks*
* More complex mechanism than "just a print"
    * Things short-circuiting the Python Exception mechanism could lead to loss messages. For example, OOM
        * Should we therefore add handlers for signals to make sure we emit those messages?
* More memory usage since messages need to be store in memory until they are yielded by the AbstractSource
