### PR TITLE
Destination Oracle: install normalization

### DIFF
--- a/airbyte-integrations/connectors/destination-oracle-strict-encrypt/Dockerfile
+++ b/airbyte-integrations/connectors/destination-oracle-strict-encrypt/Dockerfile
@@ -8,9 +8,29 @@
 # Please reach out to the Connectors Operations team if you have any question.
 FROM airbyte/integration-base-java:dev AS build
 
+RUN yum install -y python3 python3-devel jq sshpass git && \
+  alternatives --install /usr/bin/python python /usr/bin/python3 60 && \
+  python -m ensurepip --upgrade && \
+  pip3 install dbt-oracle==0.4.3
+
+# Luckily, none of normalization's files conflict with destination-oracle's files :)
+# We don't enforce that in any way, but hopefully we're only living in this state for a short time.
+COPY --from=airbyte/normalization-oracle:dev /airbyte /airbyte
+# Install python dependencies
+WORKDIR /airbyte/base_python_structs
+RUN pip3 install .
+WORKDIR /airbyte/normalization_code
+RUN pip3 install .
+WORKDIR /airbyte/normalization_code/dbt-template/
+# Download external dbt dependencies
+# amazon linux 2 isn't compatible with urllib3 2.x, so force 1.26.15
+RUN pip3 install "urllib3<2"
+RUN dbt deps
+
 WORKDIR /airbyte
 
 ENV APPLICATION destination-oracle-strict-encrypt
+ENV AIRBYTE_NORMALIZATION_INTEGRATION oracle
 
 COPY build/distributions/${APPLICATION}*.tar ${APPLICATION}.tar
 
@@ -26,3 +46,6 @@ COPY --from=build /airbyte /airbyte
 
 LABEL io.airbyte.version=0.1.19
 LABEL io.airbyte.name=airbyte/destination-oracle-strict-encrypt
+
+ENV AIRBYTE_ENTRYPOINT "/airbyte/run_with_normalization.sh"
+ENTRYPOINT ["/airbyte/run_with_normalization.sh"]

--- a/airbyte-integrations/connectors/destination-oracle-strict-encrypt/Dockerfile
+++ b/airbyte-integrations/connectors/destination-oracle-strict-encrypt/Dockerfile
@@ -8,7 +8,7 @@
 # Please reach out to the Connectors Operations team if you have any question.
 FROM airbyte/integration-base-java:dev AS build
 
-RUN yum install -y python3 python3-devel jq sshpass git && \
+RUN yum install -y python3 python3-devel jq sshpass git gcc-c++ && \
   alternatives --install /usr/bin/python python /usr/bin/python3 60 && \
   python -m ensurepip --upgrade && \
   pip3 install dbt-oracle==0.4.3
@@ -24,7 +24,8 @@ RUN pip3 install .
 WORKDIR /airbyte/normalization_code/dbt-template/
 # Download external dbt dependencies
 # amazon linux 2 isn't compatible with urllib3 2.x, so force 1.26.15
-RUN pip3 install "urllib3<2"
+# and there's some sort of dependency issue with MarkupSafe 2.1.0, so install 2.0.x
+RUN pip3 install "urllib3<2" "MarkupSafe<2.1"
 RUN dbt deps
 
 WORKDIR /airbyte

--- a/airbyte-integrations/connectors/destination-oracle-strict-encrypt/Dockerfile
+++ b/airbyte-integrations/connectors/destination-oracle-strict-encrypt/Dockerfile
@@ -44,7 +44,7 @@ ENV APPLICATION destination-oracle-strict-encrypt
 
 COPY --from=build /airbyte /airbyte
 
-LABEL io.airbyte.version=0.1.19
+LABEL io.airbyte.version=0.1.20
 LABEL io.airbyte.name=airbyte/destination-oracle-strict-encrypt
 
 ENV AIRBYTE_ENTRYPOINT "/airbyte/run_with_normalization.sh"

--- a/airbyte-integrations/connectors/destination-oracle-strict-encrypt/build.gradle
+++ b/airbyte-integrations/connectors/destination-oracle-strict-encrypt/build.gradle
@@ -33,3 +33,7 @@ dependencies {
     implementation files(project(':airbyte-integrations:bases:base-java').airbyteDocker.outputs)
     integrationTestJavaImplementation files(project(':airbyte-integrations:bases:base-normalization').airbyteDocker.outputs)
 }
+
+tasks.named("airbyteDocker") {
+    dependsOn project(':airbyte-integrations:bases:base-normalization').airbyteDockerOracle
+}

--- a/airbyte-integrations/connectors/destination-oracle-strict-encrypt/metadata.yaml
+++ b/airbyte-integrations/connectors/destination-oracle-strict-encrypt/metadata.yaml
@@ -7,7 +7,7 @@ data:
   connectorSubtype: database
   connectorType: destination
   definitionId: 3986776d-2319-4de9-8af8-db14c0996e72
-  dockerImageTag: 0.1.19
+  dockerImageTag: 0.1.20
   dockerRepository: airbyte/destination-oracle-strict-encrypt
   githubIssueLabel: destination-oracle
   icon: oracle.svg

--- a/airbyte-integrations/connectors/destination-oracle/Dockerfile
+++ b/airbyte-integrations/connectors/destination-oracle/Dockerfile
@@ -45,7 +45,7 @@ ENV APPLICATION destination-oracle
 
 COPY --from=build /airbyte /airbyte
 
-LABEL io.airbyte.version=0.1.19
+LABEL io.airbyte.version=0.1.20
 LABEL io.airbyte.name=airbyte/destination-oracle
 
 ENV AIRBYTE_ENTRYPOINT "/airbyte/run_with_normalization.sh"

--- a/airbyte-integrations/connectors/destination-oracle/Dockerfile
+++ b/airbyte-integrations/connectors/destination-oracle/Dockerfile
@@ -8,9 +8,30 @@
 # Please reach out to the Connectors Operations team if you have any question.
 FROM airbyte/integration-base-java:dev AS build
 
+
+RUN yum install -y python3 python3-devel jq sshpass git && \
+  alternatives --install /usr/bin/python python /usr/bin/python3 60 && \
+  python -m ensurepip --upgrade && \
+  pip3 install dbt-oracle==0.4.3
+
+# Luckily, none of normalization's files conflict with destination-oracle's files :)
+# We don't enforce that in any way, but hopefully we're only living in this state for a short time.
+COPY --from=airbyte/normalization-oracle:dev /airbyte /airbyte
+# Install python dependencies
+WORKDIR /airbyte/base_python_structs
+RUN pip3 install .
+WORKDIR /airbyte/normalization_code
+RUN pip3 install .
+WORKDIR /airbyte/normalization_code/dbt-template/
+# Download external dbt dependencies
+# amazon linux 2 isn't compatible with urllib3 2.x, so force 1.26.15
+RUN pip3 install "urllib3<2"
+RUN dbt deps
+
 WORKDIR /airbyte
 
 ENV APPLICATION destination-oracle
+ENV AIRBYTE_NORMALIZATION_INTEGRATION oracle
 
 COPY build/distributions/${APPLICATION}*.tar ${APPLICATION}.tar
 
@@ -26,3 +47,6 @@ COPY --from=build /airbyte /airbyte
 
 LABEL io.airbyte.version=0.1.19
 LABEL io.airbyte.name=airbyte/destination-oracle
+
+ENV AIRBYTE_ENTRYPOINT "/airbyte/run_with_normalization.sh"
+ENTRYPOINT ["/airbyte/run_with_normalization.sh"]

--- a/airbyte-integrations/connectors/destination-oracle/Dockerfile
+++ b/airbyte-integrations/connectors/destination-oracle/Dockerfile
@@ -9,7 +9,7 @@
 FROM airbyte/integration-base-java:dev AS build
 
 
-RUN yum install -y python3 python3-devel jq sshpass git && \
+RUN yum install -y python3 python3-devel jq sshpass git gcc-c++ && \
   alternatives --install /usr/bin/python python /usr/bin/python3 60 && \
   python -m ensurepip --upgrade && \
   pip3 install dbt-oracle==0.4.3
@@ -25,7 +25,8 @@ RUN pip3 install .
 WORKDIR /airbyte/normalization_code/dbt-template/
 # Download external dbt dependencies
 # amazon linux 2 isn't compatible with urllib3 2.x, so force 1.26.15
-RUN pip3 install "urllib3<2"
+# and there's some sort of dependency issue with MarkupSafe 2.1.0, so install 2.0.x
+RUN pip3 install "urllib3<2" "MarkupSafe<2.1"
 RUN dbt deps
 
 WORKDIR /airbyte

--- a/airbyte-integrations/connectors/destination-oracle/build.gradle
+++ b/airbyte-integrations/connectors/destination-oracle/build.gradle
@@ -30,3 +30,7 @@ dependencies {
     implementation files(project(':airbyte-integrations:bases:base-java').airbyteDocker.outputs)
     integrationTestJavaImplementation files(project(':airbyte-integrations:bases:base-normalization').airbyteDocker.outputs)
 }
+
+tasks.named("airbyteDocker") {
+    dependsOn project(':airbyte-integrations:bases:base-normalization').airbyteDockerOracle
+}

--- a/airbyte-integrations/connectors/destination-oracle/metadata.yaml
+++ b/airbyte-integrations/connectors/destination-oracle/metadata.yaml
@@ -2,7 +2,7 @@ data:
   connectorSubtype: database
   connectorType: destination
   definitionId: 3986776d-2319-4de9-8af8-db14c0996e72
-  dockerImageTag: 0.1.19
+  dockerImageTag: 0.1.20
   dockerRepository: airbyte/destination-oracle
   githubIssueLabel: destination-oracle
   icon: oracle.svg

--- a/docs/integrations/destinations/oracle.md
+++ b/docs/integrations/destinations/oracle.md
@@ -114,7 +114,8 @@ Airbyte has the ability to connect to the Oracle source with 3 network connectiv
 
 | Version | Date       | Pull Request                                            | Subject                                                                                                                     |
 |:--------|:-----------|:--------------------------------------------------------|:----------------------------------------------------------------------------------------------------------------------------|
-| 0.1.19   | 2022-07-26 | [\#10719](https://github.com/airbytehq/airbyte/pull/) | Destination Oracle: added custom JDBC parameters support.                                        |
+| 0.1.20  | 2023-06-05 | [\#27027](https://github.com/airbytehq/airbyte/pull/27027) | Internal scaffolding update                                        |
+| 0.1.19  | 2022-07-26 | [\#10719](https://github.com/airbytehq/airbyte/pull/10719) | Destination Oracle: added custom JDBC parameters support.                                        |
 | 0.1.7   | 2022-07-14 | [\#14618](https://github.com/airbytehq/airbyte/pull/14618) | Removed additionalProperties: false from JDBC destination connectors |
 | 0.1.5   | 2022-05-17 | [12820](https://github.com/airbytehq/airbyte/pull/12820) | Improved 'check' operation performance |
 | 0.1.4   | 2022-02-25 | [10421](https://github.com/airbytehq/airbyte/pull/10421) | Refactor JDBC parameters handling and remove DBT support                                                                    |

--- a/tools/ci_connector_ops/ci_connector_ops/pipelines/actions/environments.py
+++ b/tools/ci_connector_ops/ci_connector_ops/pipelines/actions/environments.py
@@ -553,7 +553,7 @@ BASE_DESTINATION_NORMALIZATION_BUILD_CONFIGURATION = {
         "dockerfile": "oracle.Dockerfile",
         "dbt_adapter": "dbt-oracle==0.4.3",
         "integration_name": "oracle",
-        "supports_in_connector_normalization": False,
+        "supports_in_connector_normalization": True,
         "yum_packages": [],
     },
     "destination-postgres": {


### PR DESCRIPTION
closes https://github.com/airbytehq/airbyte/issues/25498

error when running dbt deps - this is probably a dependency conflict. Local build works; hopefully tests pass. Oracle-specific changes are https://github.com/airbytehq/airbyte/pull/27027/commits/5c6b55510c344c13c4a5c5c844f34a875a9c1aeb + https://github.com/airbytehq/airbyte/pull/27027/commits/aa6335b17e925e27fab4dde9f0b34f62d316d733

(edit: tests are failing to docker build >.>)

```
#7 11.95 Traceback (most recent call last):
#7 11.95   File "/usr/local/bin/dbt", line 5, in <module>
#7 11.95     from dbt.main import main
#7 11.95   File "/usr/local/lib/python3.7/site-packages/dbt/main.py", line 13, in <module>
#7 11.95     import dbt.task.run as run_task
#7 11.95   File "/usr/local/lib/python3.7/site-packages/dbt/task/run.py", line 8, in <module>
#7 11.95     from .compile import CompileRunner, CompileTask
#7 11.95   File "/usr/local/lib/python3.7/site-packages/dbt/task/compile.py", line 2, in <module>
#7 11.95     from .runnable import GraphRunnableTask
#7 11.96   File "/usr/local/lib/python3.7/site-packages/dbt/task/runnable.py", line 16, in <module>
#7 11.96     from dbt.task.base import ConfiguredTask
#7 11.96   File "/usr/local/lib/python3.7/site-packages/dbt/task/base.py", line 22, in <module>
#7 11.96     from dbt.adapters.factory import register_adapter
#7 11.96   File "/usr/local/lib/python3.7/site-packages/dbt/adapters/factory.py", line 20, in <module>
#7 11.96     from dbt.adapters.base.plugin import AdapterPlugin
#7 11.96   File "/usr/local/lib/python3.7/site-packages/dbt/adapters/base/__init__.py", line 6, in <module>
#7 11.96     from dbt.adapters.base.connections import BaseConnectionManager  # noqa
#7 11.96   File "/usr/local/lib/python3.7/site-packages/dbt/adapters/base/connections.py", line 18, in <module>
#7 11.97     from dbt.adapters.base.query_headers import (
#7 11.97   File "/usr/local/lib/python3.7/site-packages/dbt/adapters/base/query_headers.py", line 4, in <module>
#7 11.97     from dbt.clients.jinja import QueryStringGenerator
#7 11.97   File "/usr/local/lib/python3.7/site-packages/dbt/clients/jinja.py", line 15, in <module>
#7 11.97     import jinja2
#7 11.97   File "/usr/local/lib/python3.7/site-packages/jinja2/__init__.py", line 12, in <module>
#7 11.97     from .environment import Environment
#7 11.97   File "/usr/local/lib/python3.7/site-packages/jinja2/environment.py", line 25, in <module>
#7 11.97     from .defaults import BLOCK_END_STRING
#7 11.97   File "/usr/local/lib/python3.7/site-packages/jinja2/defaults.py", line 3, in <module>
#7 11.97     from .filters import FILTERS as DEFAULT_FILTERS  # noqa: F401
#7 11.97   File "/usr/local/lib/python3.7/site-packages/jinja2/filters.py", line 13, in <module>
#7 11.97     from markupsafe import soft_unicode
#7 11.97 ImportError: cannot import name 'soft_unicode' from 'markupsafe' (/usr/local/lib64/python3.7/site-packages/markupsafe/__init__.py)
#7 ERROR: process "dbt deps" did not complete successfully: exit code: 1
```