### PR TITLE
[ISSUE #26568] make DatetimeBasedCursor.end_datetime optional

### DIFF
--- a/airbyte-cdk/python/airbyte_cdk/sources/declarative/declarative_component_schema.yaml
+++ b/airbyte-cdk/python/airbyte_cdk/sources/declarative/declarative_component_schema.yaml
@@ -550,7 +550,6 @@ definitions:
     required:
       - type
       - cursor_field
-      - end_datetime
       - datetime_format
       - start_datetime
     properties:

--- a/airbyte-cdk/python/airbyte_cdk/sources/declarative/declarative_component_schema.yaml
+++ b/airbyte-cdk/python/airbyte_cdk/sources/declarative/declarative_component_schema.yaml
@@ -582,7 +582,7 @@ definitions:
           - "PT1S"
       end_datetime:
         title: End Datetime
-        description: The datetime that determines the last record that should be synced.
+        description: The datetime that determines the last record that should be synced. If not provided, `{{ now_utc() }}` will be used.
         anyOf:
           - type: string
           - "$ref": "#/definitions/MinMaxDatetime"

--- a/airbyte-cdk/python/airbyte_cdk/sources/declarative/incremental/datetime_based_cursor.py
+++ b/airbyte-cdk/python/airbyte_cdk/sources/declarative/incremental/datetime_based_cursor.py
@@ -33,7 +33,7 @@ class DatetimeBasedCursor(StreamSlicer):
 
     Attributes:
         start_datetime (Union[MinMaxDatetime, str]): the datetime that determines the earliest record that should be synced
-        end_datetime (Union[MinMaxDatetime, str]): the datetime that determines the last record that should be synced
+        end_datetime (Optional[Union[MinMaxDatetime, str]]): the datetime that determines the last record that should be synced
         step (str): size of the timewindow (ISO8601 duration)
         cursor_field (Union[InterpolatedString, str]): record's cursor field
         datetime_format (str): format of the datetime
@@ -53,7 +53,7 @@ class DatetimeBasedCursor(StreamSlicer):
     parameters: InitVar[Mapping[str, Any]]
     _cursor: dict = field(repr=False, default=None)  # tracks current datetime
     _cursor_end: dict = field(repr=False, default=None)  # tracks end of current stream slice
-    end_datetime: Union[MinMaxDatetime, str] = None
+    end_datetime: Optional[Union[MinMaxDatetime, str]] = None
     step: Optional[Union[InterpolatedString, str]] = None
     cursor_granularity: Optional[str] = None
     start_time_option: Optional[RequestOption] = None

--- a/airbyte-cdk/python/airbyte_cdk/sources/declarative/incremental/datetime_based_cursor.py
+++ b/airbyte-cdk/python/airbyte_cdk/sources/declarative/incremental/datetime_based_cursor.py
@@ -47,13 +47,13 @@ class DatetimeBasedCursor(StreamSlicer):
     """
 
     start_datetime: Union[MinMaxDatetime, str]
-    end_datetime: Union[MinMaxDatetime, str]
     cursor_field: Union[InterpolatedString, str]
     datetime_format: str
     config: Config
     parameters: InitVar[Mapping[str, Any]]
     _cursor: dict = field(repr=False, default=None)  # tracks current datetime
     _cursor_end: dict = field(repr=False, default=None)  # tracks end of current stream slice
+    end_datetime: Union[MinMaxDatetime, str] = None
     step: Optional[Union[InterpolatedString, str]] = None
     cursor_granularity: Optional[str] = None
     start_time_option: Optional[RequestOption] = None
@@ -70,7 +70,7 @@ class DatetimeBasedCursor(StreamSlicer):
             )
         if not isinstance(self.start_datetime, MinMaxDatetime):
             self.start_datetime = MinMaxDatetime(self.start_datetime, parameters)
-        if not isinstance(self.end_datetime, MinMaxDatetime):
+        if self.end_datetime and not isinstance(self.end_datetime, MinMaxDatetime):
             self.end_datetime = MinMaxDatetime(self.end_datetime, parameters)
 
         self._timezone = datetime.timezone.utc
@@ -91,7 +91,7 @@ class DatetimeBasedCursor(StreamSlicer):
         # If datetime format is not specified then start/end datetime should inherit it from the stream slicer
         if not self.start_datetime.datetime_format:
             self.start_datetime.datetime_format = self.datetime_format
-        if not self.end_datetime.datetime_format:
+        if self.end_datetime and not self.end_datetime.datetime_format:
             self.end_datetime.datetime_format = self.datetime_format
 
     def get_stream_state(self) -> StreamState:
@@ -136,7 +136,7 @@ class DatetimeBasedCursor(StreamSlicer):
         """
         stream_state = stream_state or {}
         kwargs = {"stream_state": stream_state}
-        end_datetime = min(self.end_datetime.get_datetime(self.config, **kwargs), datetime.datetime.now(tz=self._timezone))
+        end_datetime = self._select_best_end_datetime(kwargs)
         lookback_delta = self._parse_timedelta(self.lookback_window.eval(self.config, **kwargs) if self.lookback_window else "P0D")
 
         earliest_possible_start_datetime = min(self.start_datetime.get_datetime(self.config, **kwargs), end_datetime)
@@ -144,6 +144,12 @@ class DatetimeBasedCursor(StreamSlicer):
         start_datetime = max(earliest_possible_start_datetime, cursor_datetime) - lookback_delta
 
         return self._partition_daterange(start_datetime, end_datetime, self._step)
+
+    def _select_best_end_datetime(self, kwargs):
+        now = datetime.datetime.now(tz=self._timezone)
+        if not self.end_datetime:
+            return now
+        return min(self.end_datetime.get_datetime(self.config, **kwargs), now)
 
     def _calculate_cursor_datetime_from_state(self, stream_state: Mapping[str, Any]) -> datetime.datetime:
         if self.cursor_field.eval(self.config, stream_state=stream_state) in stream_state:

--- a/airbyte-cdk/python/airbyte_cdk/sources/declarative/models/declarative_component_schema.py
+++ b/airbyte-cdk/python/airbyte_cdk/sources/declarative/models/declarative_component_schema.py
@@ -859,7 +859,7 @@ class DatetimeBasedCursor(BaseModel):
     )
     end_datetime: Optional[Union[str, MinMaxDatetime]] = Field(
         None,
-        description="The datetime that determines the last record that should be synced.",
+        description="The datetime that determines the last record that should be synced. If not provided, `{{ now_utc() }}` will be used.",
         examples=["2021-01-1T00:00:00Z", "{{ now_utc() }}", "{{ day_delta(-1) }}"],
         title="End Datetime",
     )

--- a/airbyte-cdk/python/airbyte_cdk/sources/declarative/models/declarative_component_schema.py
+++ b/airbyte-cdk/python/airbyte_cdk/sources/declarative/models/declarative_component_schema.py
@@ -857,8 +857,8 @@ class DatetimeBasedCursor(BaseModel):
         examples=["PT1S"],
         title="Cursor Granularity",
     )
-    end_datetime: Union[str, MinMaxDatetime] = Field(
-        ...,
+    end_datetime: Optional[Union[str, MinMaxDatetime]] = Field(
+        None,
         description="The datetime that determines the last record that should be synced.",
         examples=["2021-01-1T00:00:00Z", "{{ now_utc() }}", "{{ day_delta(-1) }}"],
         title="End Datetime",

--- a/airbyte-cdk/python/airbyte_cdk/sources/declarative/parsers/model_to_component_factory.py
+++ b/airbyte-cdk/python/airbyte_cdk/sources/declarative/parsers/model_to_component_factory.py
@@ -398,9 +398,11 @@ class ModelToComponentFactory:
         start_datetime = (
             model.start_datetime if isinstance(model.start_datetime, str) else self.create_min_max_datetime(model.start_datetime, config)
         )
-        end_datetime = (
-            model.end_datetime if isinstance(model.end_datetime, str) else self.create_min_max_datetime(model.end_datetime, config)
-        )
+        end_datetime = None
+        if model.end_datetime:
+            end_datetime = (
+                model.end_datetime if isinstance(model.end_datetime, str) else self.create_min_max_datetime(model.end_datetime, config)
+            )
 
         end_time_option = (
             RequestOption(

--- a/airbyte-cdk/python/unit_tests/sources/declarative/incremental/test_datetime_based_cursor.py
+++ b/airbyte-cdk/python/unit_tests/sources/declarative/incremental/test_datetime_based_cursor.py
@@ -589,7 +589,6 @@ def test_step_but_no_cursor_granularity():
             step="P1D",
             cursor_field=InterpolatedString(cursor_field, parameters={}),
             datetime_format="%Y-%m-%d",
-            lookback_window=InterpolatedString("P0D", parameters={}),
             config=config,
             parameters={},
         )
@@ -603,7 +602,6 @@ def test_cursor_granularity_but_no_step():
             cursor_granularity="P1D",
             cursor_field=InterpolatedString(cursor_field, parameters={}),
             datetime_format="%Y-%m-%d",
-            lookback_window=InterpolatedString("P0D", parameters={}),
             config=config,
             parameters={},
         )
@@ -615,12 +613,23 @@ def test_no_cursor_granularity_and_no_step_then_only_return_one_slice():
         end_datetime=MinMaxDatetime("2023-01-01", parameters={}),
         cursor_field=InterpolatedString(cursor_field, parameters={}),
         datetime_format="%Y-%m-%d",
-        lookback_window=InterpolatedString("P0D", parameters={}),
         config=config,
         parameters={},
     )
     stream_slices = cursor.stream_slices(SyncMode.incremental, {})
     assert stream_slices == [{"start_time": "2021-01-01", "end_time": "2023-01-01"}]
+
+
+def test_no_end_datetime(mock_datetime_now):
+    cursor = DatetimeBasedCursor(
+        start_datetime=MinMaxDatetime("2021-01-01", parameters={}),
+        cursor_field=InterpolatedString(cursor_field, parameters={}),
+        datetime_format="%Y-%m-%d",
+        config=config,
+        parameters={},
+    )
+    stream_slices = cursor.stream_slices(SyncMode.incremental, {})
+    assert stream_slices == [{"start_time": "2021-01-01", "end_time": FAKE_NOW.strftime("%Y-%m-%d")}]
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## What
Addresses https://github.com/airbytehq/airbyte/issues/26568

## How
* Removing end_datetime from required fields
* Making DatetimeBasedCursor.end_datetime optional
    * If not provided, we will use `datetime.datetime.now(tz=self._timezone)` as the end_datetime

## 🚨 User Impact 🚨
This is not a breaking change in terms of YAML declarative language but it is a breaking change in terms of Python class since the following code:
```
    DatetimeBasedCursor(
        start,
        end,
        cursor_field,
        config,
        parameters,
        step=step,
        datetime_format=datetime_format,
        cursor_granularity=cursor_granularity,
        lookback_window=lookback_window,
    )
```
... will now trigger the error `TypeError: __init__() got multiple values for argument 'datetime_format'`. In the repo, the parameters are always named like this so it's not an issue but it could be for Python code outside of our repo that instantiate this class:
```
    DatetimeBasedCursor(
        start_datetime=MinMaxDatetime(datetime="2021-01-01T00:00:00.00+0000", datetime_format="%Y-%m-%dT%H:%M:%S.%f%z", parameters={}),
        end_datetime=MinMaxDatetime(datetime="2021-02-01T00:00:00.00+0000", datetime_format="%Y-%m-%dT%H:%M:%S.%f%z", parameters={}),
        step="P10D",
        cursor_field="timestamp",
        datetime_format="%Y-%m-%dT%H:%M:%S.%f%z",
        cursor_granularity="PT0.000001S",
        start_time_option=RequestOption(inject_into="request_parameter", field_name="after", parameters={}),
        end_time_option=RequestOption(inject_into="request_parameter", field_name="before", parameters={}),
        config={},
        parameters={},
    )
```
