### PR TITLE
Metadata Upload Validation: Update to use registry url

### DIFF
--- a/airbyte-ci/connectors/metadata_service/lib/metadata_service/docker_hub.py
+++ b/airbyte-ci/connectors/metadata_service/lib/metadata_service/docker_hub.py
@@ -37,7 +37,4 @@ def is_image_on_docker_hub(image_name: str, version: str) -> bool:
     tag_url = f"https://registry.hub.docker.com/v2/repositories/{image_name}/tags/{version}"
     response = requests.get(tag_url, headers=headers)
 
-    if response.ok:
-        return True
-
-    return False
+    return response.ok

--- a/airbyte-ci/connectors/metadata_service/lib/metadata_service/docker_hub.py
+++ b/airbyte-ci/connectors/metadata_service/lib/metadata_service/docker_hub.py
@@ -21,30 +21,6 @@ def get_docker_hub_auth_token() -> str:
     return token
 
 
-def get_image_tags(repo: str, image: str) -> List[str]:
-    token = get_docker_hub_auth_token()
-    headers = {"Authorization": f"JWT {token}"}
-
-    tags_url = f"https://hub.docker.com/v2/repositories/{repo}/{image}/tags/"
-    params = {"page_size": 100}
-    tags = []
-
-    while True:
-        response = requests.get(tags_url, headers=headers, params=params)
-        if response.status_code != 200:
-            raise ValueError("Failed to fetch image tags from Docker Hub.")
-
-        data = response.json()
-        tags.extend([result["name"] for result in data.get("results", [])])
-
-        if data.get("next"):
-            tags_url = data["next"]
-        else:
-            break
-
-    return tags
-
-
 def is_image_on_docker_hub(image_name: str, version: str) -> bool:
     """Check if a given image and version exists on Docker Hub.
 
@@ -55,7 +31,13 @@ def is_image_on_docker_hub(image_name: str, version: str) -> bool:
     Returns:
         bool: True if the image and version exists on Docker Hub, False otherwise.
     """
-    repo, image = image_name.split("/", 1)
-    tags = get_image_tags(repo, image)
 
-    return version in tags
+    token = get_docker_hub_auth_token()
+    headers = {"Authorization": f"JWT {token}"}
+    tag_url = f"https://registry.hub.docker.com/v2/repositories/{image_name}/tags/{version}"
+    response = requests.get(tag_url, headers=headers)
+
+    if response.ok:
+        return True
+
+    return False

--- a/airbyte-ci/connectors/metadata_service/lib/metadata_service/gcs_upload.py
+++ b/airbyte-ci/connectors/metadata_service/lib/metadata_service/gcs_upload.py
@@ -105,11 +105,10 @@ def upload_metadata_to_gcs(bucket_name: str, metadata_file_path: Path) -> Tuple[
     raw_metadata = yaml.safe_load(metadata_file_path.read_text())
     metadata = ConnectorMetadataDefinitionV0.parse_obj(raw_metadata)
 
-    # TODO (ben) Renable once docker hub api is fixed
-    # print("Validating that the images are on DockerHub...")
-    # is_valid, error = validate_metadata_images_in_dockerhub(metadata)
-    # if not is_valid:
-    #     raise ValueError(error)
+    print("Validating that the images are on DockerHub...")
+    is_valid, error = validate_metadata_images_in_dockerhub(metadata)
+    if not is_valid:
+        raise ValueError(error)
 
     service_account_info = json.loads(os.environ.get("GCS_CREDENTIALS"))
     credentials = service_account.Credentials.from_service_account_info(service_account_info)


### PR DESCRIPTION
## Overview

Docker hubs api can sometimes become out of date leading to our upload incorrectly not finding a docker image in docker hub

this updates the function to use the same url used by the docker and crane cli's

closes #26975 