### PR TITLE
connectors-ci: mask secrets in GHA logs with ::add-mask::

### DIFF
--- a/airbyte-integrations/connectors/source-openweather/metadata.yaml
+++ b/airbyte-integrations/connectors/source-openweather/metadata.yaml
@@ -13,7 +13,7 @@ data:
       enabled: true
     oss:
       enabled: true
-  releaseStage: generally_available
+  releaseStage: alpha
   documentationUrl: https://docs.airbyte.com/integrations/sources/openweather
   tags:
     - language:python

--- a/airbyte-integrations/connectors/source-openweather/metadata.yaml
+++ b/airbyte-integrations/connectors/source-openweather/metadata.yaml
@@ -13,7 +13,7 @@ data:
       enabled: true
     oss:
       enabled: true
-  releaseStage: alpha
+  releaseStage: generally_available
   documentationUrl: https://docs.airbyte.com/integrations/sources/openweather
   tags:
     - language:python

--- a/tools/ci_connector_ops/ci_connector_ops/pipelines/actions/environments.py
+++ b/tools/ci_connector_ops/ci_connector_ops/pipelines/actions/environments.py
@@ -181,8 +181,8 @@ async def with_ci_credentials(context: PipelineContext, gsm_secret: Secret) -> C
     """
     python_base_environment: Container = with_python_base(context)
     ci_credentials = await with_installed_python_package(context, python_base_environment, CI_CREDENTIALS_SOURCE_PATH)
-
-    return ci_credentials.with_env_variable("VERSION", "dev").with_secret_variable("GCP_GSM_CREDENTIALS", gsm_secret).with_workdir("/")
+    ci_credentials = ci_credentials.with_env_variable("VERSION", "dagger_ci")
+    return ci_credentials.with_secret_variable("GCP_GSM_CREDENTIALS", gsm_secret).with_workdir("/")
 
 
 def with_alpine_packages(base_container: Container, packages_to_install: List[str]) -> Container:

--- a/tools/ci_connector_ops/ci_connector_ops/pipelines/actions/secrets.py
+++ b/tools/ci_connector_ops/ci_connector_ops/pipelines/actions/secrets.py
@@ -27,9 +27,6 @@ async def mask_secrets_in_gha_logs(ci_credentials_with_downloaded_secrets: Conta
         # We print directly to stdout because the GHA runner will mask only if the log line starts with "::add-mask::"
         # If we use the dagger logger, or context logger, the log line will start with other stuff and will not be masked
         print(f"::add-mask::{secret_to_mask}")
-        # TODO: remove this print, only used for testing the mask in GHA logs
-        print("THE FOLLOWING LINE SHOULD BE MASKED IN GHA LOGS:")
-        print(secret_to_mask)
 
 
 async def download(context: ConnectorContext, gcp_gsm_env_variable_name: str = "GCP_GSM_CREDENTIALS") -> Directory:

--- a/tools/ci_connector_ops/ci_connector_ops/pipelines/actions/secrets.py
+++ b/tools/ci_connector_ops/ci_connector_ops/pipelines/actions/secrets.py
@@ -27,6 +27,9 @@ async def mask_secrets_in_gha_logs(ci_credentials_with_downloaded_secrets: Conta
         # We print directly to stdout because the GHA runner will mask only if the log line starts with "::add-mask::"
         # If we use the dagger logger, or context logger, the log line will start with other stuff and will not be masked
         print(f"::add-mask::{secret_to_mask}")
+        # TODO: remove this print, only used for testing the mask in GHA logs
+        print("THE FOLLOWING LINE SHOULD BE MASKED IN GHA LOGS:")
+        print(secret_to_mask)
 
 
 async def download(context: ConnectorContext, gcp_gsm_env_variable_name: str = "GCP_GSM_CREDENTIALS") -> Directory:

--- a/tools/ci_credentials/ci_credentials/secrets_manager.py
+++ b/tools/ci_credentials/ci_credentials/secrets_manager.py
@@ -49,7 +49,7 @@ class SecretsManager:
     """Loading, saving and updating all requested secrets into connector folders"""
 
     logger: ClassVar[Logger] = Logger()
-    if os.getenv("VERSION") == "dev":
+    if os.getenv("VERSION") in ["dev", "dagger_ci"]:
         base_folder = Path(os.getcwd())
     else:
         base_folder = Path("/actions-runner/_work/airbyte/airbyte")
@@ -151,9 +151,13 @@ class SecretsManager:
                         for line in str(value).splitlines():
                             line = str(line).strip()
                             # don't output } and such
-                            if len(line) > 1 and not os.getenv("VERSION") == "dev":
-                                # has to be at the beginning of line for Github to notice it
-                                print(f"::add-mask::{line}")
+                            if len(line) > 1:
+                                if not os.getenv("VERSION") in ["dev", "dagger_ci"]:
+                                    # has to be at the beginning of line for Github to notice it
+                                    print(f"::add-mask::{line}")
+                                if os.getenv("VERSION") == "dagger_ci":
+                                    with open("/tmp/secrets_to_mask.txt", "a") as f:
+                                        f.write(f"{line}\n")
                         break
             # see if it's really embedded json and get those values too
             try:

--- a/tools/ci_credentials/setup.py
+++ b/tools/ci_credentials/setup.py
@@ -21,7 +21,7 @@ LOCAL_REQUIREMENTS = [local_pkg("ci_common_utils")]
 TEST_REQUIREMENTS = ["requests-mock", "pytest"]
 
 setup(
-    version="1.0.1",
+    version="1.1.0",
     name="ci_credentials",
     description="CLI tooling to read and manage GSM secrets",
     author="Airbyte",

--- a/tools/ci_credentials/setup.py
+++ b/tools/ci_credentials/setup.py
@@ -7,7 +7,7 @@ from pathlib import Path
 
 from setuptools import find_packages, setup
 
-MAIN_REQUIREMENTS = ["requests", "click~=8.1.3"]
+MAIN_REQUIREMENTS = ["requests", "click~=8.1.3", "pyyaml"]
 
 
 def local_pkg(name: str) -> str:


### PR DESCRIPTION
## What
Closes https://github.com/airbytehq/airbyte/issues/27088

On our connectors testing pipeline our internal `ci_credentials` library is used to download GSM secrets to file system.
In the context of dagger pipeline the interaction with this library is containerized.
This library uses a `VERSION` env var to modulate it's behavior:
If `VERSION=dev`:
* Write secrets to current working directory: it's the behavior we want for dagger pipelines
* Do not print out `::add-mask::` logs that are used to mask secrets in GHA logs

If `VERSION != dev`:
* Write secrets to an absolute path relative to the GHA action runners file system
* Print `::add-mask::` to stdout to make GHA redact the secrets from the logs.

We've originally set the env var to `dev` in our dagger pipeline to get secret written at the right path but we miss the secret masking capabilities while doing it.

## How
This PR changes `ci_credentials` and its usage in our dagger pipeline to:

* Write secrets to a correct path while not using `VERSION=dev`
* Write secrets to mask to a /tmp file that dagger pipeline can read and print out to stdout without any logger prefix.
* Increase the list of keys considered as secrets by consuming our spec mask.

