### PR TITLE
Add metadata field to low-code schema

### DIFF
--- a/airbyte-cdk/python/airbyte_cdk/sources/declarative/declarative_component_schema.yaml
+++ b/airbyte-cdk/python/airbyte_cdk/sources/declarative/declarative_component_schema.yaml
@@ -27,6 +27,10 @@ properties:
     type: object
   spec:
     "$ref": "#/definitions/Spec"
+  metadata:
+    type: object
+    description: For internal use only - used by consumers of declarative manifests for storing related metadata
+    additionalProperties: true
 additionalProperties: false
 definitions:
   AddedFieldDefinition:

--- a/airbyte-cdk/python/airbyte_cdk/sources/declarative/declarative_component_schema.yaml
+++ b/airbyte-cdk/python/airbyte_cdk/sources/declarative/declarative_component_schema.yaml
@@ -29,7 +29,7 @@ properties:
     "$ref": "#/definitions/Spec"
   metadata:
     type: object
-    description: For internal use only - used by consumers of declarative manifests for storing related metadata
+    description: For internal Airbyte use only - DO NOT modify manually. Used by consumers of declarative manifests for storing related metadata.
     additionalProperties: true
 additionalProperties: false
 definitions:

--- a/airbyte-cdk/python/airbyte_cdk/sources/declarative/models/declarative_component_schema.py
+++ b/airbyte-cdk/python/airbyte_cdk/sources/declarative/models/declarative_component_schema.py
@@ -1137,6 +1137,7 @@ class DeclarativeSource(BaseModel):
     schemas: Optional[Schemas] = None
     definitions: Optional[Dict[str, Any]] = None
     spec: Optional[Spec] = None
+    metadata: Optional[Dict[str, Any]] = None
 
 
 class DeclarativeStream(BaseModel):

--- a/airbyte-cdk/python/airbyte_cdk/sources/declarative/models/declarative_component_schema.py
+++ b/airbyte-cdk/python/airbyte_cdk/sources/declarative/models/declarative_component_schema.py
@@ -1137,7 +1137,10 @@ class DeclarativeSource(BaseModel):
     schemas: Optional[Schemas] = None
     definitions: Optional[Dict[str, Any]] = None
     spec: Optional[Spec] = None
-    metadata: Optional[Dict[str, Any]] = None
+    metadata: Optional[Dict[str, Any]] = Field(
+        None,
+        description="For internal use only - used by consumers of declarative manifests for storing related metadata",
+    )
 
 
 class DeclarativeStream(BaseModel):

--- a/airbyte-cdk/python/airbyte_cdk/sources/declarative/models/declarative_component_schema.py
+++ b/airbyte-cdk/python/airbyte_cdk/sources/declarative/models/declarative_component_schema.py
@@ -1139,7 +1139,7 @@ class DeclarativeSource(BaseModel):
     spec: Optional[Spec] = None
     metadata: Optional[Dict[str, Any]] = Field(
         None,
-        description="For internal use only - used by consumers of declarative manifests for storing related metadata",
+        description="For internal Airbyte use only - DO NOT modify manually. Used by consumers of declarative manifests for storing related metadata.",
     )
 
 


### PR DESCRIPTION
## What
Relates to https://github.com/airbytehq/airbyte/issues/25321

We now have a use case where the Connector Builder needs to store some UI-specific data in the connector manifest, as the manifest is the single resource that the builder uses to persist its state.

Specifically, the Connector Builder needs the ability to store an "auto-import schema" boolean flag per stream in the connector manifest. After discussion with Joe and Maxime, we agreed that persisting this in a generic top-level `metadata` field of the connector manifest would be the most straightforward approach, for the following reasons:
- Doesn't require any changes to the persistence layer for connector builder connectors (still just persists the manifest YAML)
- Doesn't affect any existing components in the declarative schema
- Is not specific to the builder - since this is just a generic `metadata` field, technically any consumer of low-code manifests could use this field for whatever they want
- Manifests without any `metadata` set will still be compatible with the Builder - it will just fall back to the default values that it uses when first initializing the metadata values

## 🚨 User Impact 🚨
No breaking changes, since this just adds an optional field to the schema.