### PR TITLE
🐛 source smartsheets: fix error getting optional `metadata_fields` on existing configs

### DIFF
--- a/airbyte-integrations/connectors/source-smartsheets/Dockerfile
+++ b/airbyte-integrations/connectors/source-smartsheets/Dockerfile
@@ -14,5 +14,5 @@ COPY $CODE_PATH ./$CODE_PATH
 ENV AIRBYTE_ENTRYPOINT "python /airbyte/integration_code/main.py"
 ENTRYPOINT ["python", "/airbyte/integration_code/main.py"]
 
-LABEL io.airbyte.version=1.1.0
+LABEL io.airbyte.version=1.1.1
 LABEL io.airbyte.name=airbyte/source-smartsheets

--- a/airbyte-integrations/connectors/source-smartsheets/metadata.yaml
+++ b/airbyte-integrations/connectors/source-smartsheets/metadata.yaml
@@ -6,7 +6,7 @@ data:
   connectorSubtype: api
   connectorType: source
   definitionId: 374ebc65-6636-4ea0-925c-7d35999a8ffc
-  dockerImageTag: 1.1.0
+  dockerImageTag: 1.1.1
   dockerRepository: airbyte/source-smartsheets
   githubIssueLabel: source-smartsheets
   icon: smartsheet.svg
@@ -14,7 +14,6 @@ data:
   name: Smartsheets
   registries:
     cloud:
-      dockerImageTag: 1.0.2 # pinned due to https://github.com/airbytehq/alpha-beta-issues/issues/1400
       enabled: true
     oss:
       enabled: true

--- a/airbyte-integrations/connectors/source-smartsheets/source_smartsheets/sheet.py
+++ b/airbyte-integrations/connectors/source-smartsheets/source_smartsheets/sheet.py
@@ -15,7 +15,7 @@ class SmartSheetAPIWrapper:
     def __init__(self, config: Mapping[str, Any]):
         self._spreadsheet_id = config["spreadsheet_id"]
         self._config = config
-        self._metadata = config["metadata_fields"]
+        self._metadata = config.get("metadata_fields", [])
         self.api_client = smartsheet.Smartsheet(self.get_access_token(config))
         self.api_client.errors_as_exceptions(True)
         # each call to `Sheets` makes a new instance, so we save it here to make no more new objects

--- a/docs/integrations/sources/smartsheets.md
+++ b/docs/integrations/sources/smartsheets.md
@@ -110,7 +110,8 @@ The remaining column datatypes supported by Smartsheets are more complex types (
 
 | Version | Date       | Pull Request                                             | Subject                                                   |
 |:--------|:-----------|:---------------------------------------------------------|:----------------------------------------------------------|
-| 1.1.0   | 2023-06-02 | [22382](https://github.com/airbytehq/airbyte/pull/22382) | Add support for ingesting metadata fields |
+| 1.1.1   | 2023-06-06 | [27096](https://github.com/airbytehq/airbyte/pull/27096) | Fix error when optional metadata fields are not set       |
+| 1.1.0   | 2023-06-02 | [22382](https://github.com/airbytehq/airbyte/pull/22382) | Add support for ingesting metadata fields                 |
 | 1.0.2   | 2023-05-12 | [26024](https://github.com/airbytehq/airbyte/pull/26024) | Fix dependencies conflict                                 |
 | 1.0.1   | 2023-04-27 | [25562](https://github.com/airbytehq/airbyte/pull/25562) | Update testing dependencies                               |
 | 1.0.0   | 2023-02-19 | [23237](https://github.com/airbytehq/airbyte/pull/23237) | Fix OAuth2.0 token refresh                                |


### PR DESCRIPTION
## What

Following up on https://github.com/airbytehq/airbyte/pull/26991, this PR resolves an issue introduced in v1.1.0 (https://github.com/airbytehq/airbyte/pull/22382) when accessing `metadata_fields` on an existing connection that didn't have the field defined. This is an optional field that is ok to be unset.

```
Traceback (most recent call last):
  File "/airbyte/integration_code/main.py", line 13, in <module>
    launch(source, sys.argv[1:])
  File "/usr/local/lib/python3.9/site-packages/airbyte_cdk/entrypoint.py", line 156, in launch
    for message in source_entrypoint.run(parsed_args):
  File "/usr/local/lib/python3.9/site-packages/airbyte_cdk/entrypoint.py", line 91, in run
    yield from map(AirbyteEntrypoint.airbyte_message_to_string, self.check(source_spec, config))
  File "/usr/local/lib/python3.9/site-packages/airbyte_cdk/entrypoint.py", line 112, in check
    check_result = self.source.check(self.logger, config)
  File "/usr/local/lib/python3.9/site-packages/airbyte_cdk/sources/abstract_source.py", line 84, in check
    check_succeeded, error = self.check_connection(logger, config)
  File "/airbyte/integration_code/source_smartsheets/source.py", line 17, in check_connection
    sheet = SmartSheetAPIWrapper(config)
  File "/airbyte/integration_code/source_smartsheets/sheet.py", line 18, in __init__
    self._metadata = config["metadata_fields"]
KeyError: 'metadata_fields'
```

## How

Get default empty list value if field is not set on the config
This also unpins the version on cloud


## 🚨 User Impact 🚨
*Are there any breaking changes? What is the end result perceived by the user?*

*For connector PRs, use this section to explain which type of semantic versioning bump occurs as a result of the changes. Refer to our [Semantic Versioning for Connectors](https://docs.airbyte.com/contributing-to-airbyte/#semantic-versioning-for-connectors) guidelines for more information. **Breaking changes to connectors must be documented by an Airbyte engineer (PR author, or reviewer for community PRs) by using the [Breaking Change Release Playbook](https://docs.google.com/document/d/1VYQggHbL_PN0dDDu7rCyzBLGRtX-R3cpwXaY8QxEgzw/edit).***

*If there are breaking changes, please merge this PR with the 🚨🚨 emoji so changelog authors can further highlight this if needed.*


## Pre-merge Actions
*Expand the relevant checklist and delete the others.*

<details><summary><strong>New Connector</strong></summary>

### Community member or Airbyter

- **Community member?** Grant edit access to maintainers ([instructions](https://docs.github.com/en/github/collaborating-with-pull-requests/working-with-forks/allowing-changes-to-a-pull-request-branch-created-from-a-fork#enabling-repository-maintainer-permissions-on-existing-pull-requests))
- Unit & integration tests added and passing. Community members, please provide proof of success locally e.g: screenshot or copy-paste unit, integration, and acceptance test output. To run acceptance tests for a Python connector, follow instructions in the README. For java connectors run `./gradlew :airbyte-integrations:connectors:<name>:integrationTest`.
- Connector version is set to `0.0.1`
    - `Dockerfile` has version `0.0.1`
- Documentation updated
    - Connector's `README.md`
    - Connector's `bootstrap.md`. See [description and examples](https://docs.google.com/document/d/1ypdgmwmEHWv-TrO4_YOQ7pAJGVrMp5BOkEVh831N260/edit?usp=sharing)
    - `docs/integrations/<source or destination>/<name>.md` including changelog with an entry for the initial version. See changelog [example](https://docs.airbyte.io/integrations/sources/stripe#changelog)
    - `docs/integrations/README.md`

### Airbyter

If this is a community PR, the Airbyte engineer reviewing this PR is responsible for the below items.

- Create a non-forked branch based on this PR and test the below items on it
- Build is successful
- If new credentials are required for use in CI, add them to GSM. [Instructions](https://docs.airbyte.io/connector-development#using-credentials-in-ci).

</details>

<details><summary><strong>Updating a connector</strong></summary>

### Community member or Airbyter

- Grant edit access to maintainers ([instructions](https://docs.github.com/en/github/collaborating-with-pull-requests/working-with-forks/allowing-changes-to-a-pull-request-branch-created-from-a-fork#enabling-repository-maintainer-permissions-on-existing-pull-requests))
- Unit & integration tests added


### Airbyter

If this is a community PR, the Airbyte engineer reviewing this PR is responsible for the below items.

- Create a non-forked branch based on this PR and test the below items on it
- Build is successful
- If new credentials are required for use in CI, add them to GSM. [Instructions](https://docs.airbyte.io/connector-development#using-credentials-in-ci).

</details>

<details><summary><strong>Connector Generator</strong></summary>

- Issue acceptance criteria met
- PR name follows [PR naming conventions](https://docs.airbyte.com/contributing-to-airbyte/issues-and-pull-requests#pull-request-title-convention)
- If adding a new generator, add it to the [list of scaffold modules being tested](https://github.com/airbytehq/airbyte/blob/master/airbyte-integrations/connector-templates/generator/build.gradle#L41)
- The generator test modules (all connectors with `-scaffold` in their name) have been updated with the latest scaffold by running `./gradlew :airbyte-integrations:connector-templates:generator:testScaffoldTemplates` then checking in your changes
- Documentation which references the generator is updated as needed

</details>
