### PR TITLE
airbyte-ci: missing missing module errors

### DIFF
--- a/tools/ci_connector_ops/ci_connector_ops/pipelines/helpers/__init__.py
+++ b/tools/ci_connector_ops/ci_connector_ops/pipelines/helpers/__init__.py
@@ -1,0 +1,3 @@
+#
+# Copyright (c) 2023 Airbyte, Inc., all rights reserved.
+#


### PR DESCRIPTION
## What
An `__init__.py` file was missing in the helpers module, led to `ModuleNotFoundError: No module named 'ci_connector_ops.pipelines.helpers'`