### PR TITLE
[Ssdp 192] Use the schema registry to derive a stream schema in the kafka source

### DIFF
--- a/airbyte-integrations/connectors/source-kafka/src/main/java/io/airbyte/integrations/source/kafka/KafkaSource.java
+++ b/airbyte-integrations/connectors/source-kafka/src/main/java/io/airbyte/integrations/source/kafka/KafkaSource.java
@@ -40,7 +40,7 @@ public class KafkaSource extends BaseConnector implements Source {
   @Override
   public AirbyteCatalog discover(final JsonNode config) {
     KafkaFormat kafkaFormat = KafkaFormatFactory.getFormat(config);
-    final List<AirbyteStream> streams = kafkaFormat.getStreams();
+    final List<AirbyteStream> streams = kafkaFormat.getStreams(config);
     return new AirbyteCatalog().withStreams(streams);
   }
 

--- a/airbyte-integrations/connectors/source-kafka/src/main/java/io/airbyte/integrations/source/kafka/format/Avro2JsonConvert.java
+++ b/airbyte-integrations/connectors/source-kafka/src/main/java/io/airbyte/integrations/source/kafka/format/Avro2JsonConvert.java
@@ -1,0 +1,154 @@
+package io.airbyte.integrations.source.kafka.format;
+
+
+import com.fasterxml.jackson.core.type.TypeReference;
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+
+import java.util.*;
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
+
+import static java.util.Map.entry;
+
+public class Avro2JsonConvert {
+
+    private ObjectMapper mapper = new ObjectMapper();
+
+    /**
+     * Mapping from avro to Json type
+     * @link https://docs.airbyte.com/understanding-airbyte/json-avro-conversion/#conversion-rules
+     */
+    private static final Map<String, List<String>> AVRO_TO_JSON_DATA_TYPE_MAPPING = Map.ofEntries(
+            entry("null", List.of("null")),
+            entry("boolean", List.of("boolean", "null")),
+            entry("int", List.of("integer", "null")),
+            entry("long", List.of("integer", "null")),
+            entry("float", List.of("number", "null")),
+            entry("double", List.of("number", "null")),
+            entry("bytes", List.of("string", "null")),
+            entry("string", List.of("string", "null")),
+            entry("record", List.of("object", "null")),
+            entry("enum", List.of("string", "null")),
+            entry("array", List.of("array", "null")),
+            entry("map", List.of("object", "null")),
+            entry("fixed", List.of("string", "null"))
+    );
+
+
+    private List<String> avroTypeToJsonType(String avroType) {
+        List<String> jsonTypes = AVRO_TO_JSON_DATA_TYPE_MAPPING.get(avroType);
+        if (jsonTypes == null) {
+            throw new IllegalArgumentException("Unknown Avro type: " + avroType);
+        }
+        return jsonTypes;
+    }
+
+    public JsonNode convertoToAirbyteJson(String avroSchema) throws Exception {
+        Map<String, Object> mapAvroSchema = mapper.readValue(avroSchema, new TypeReference<>() {
+        });
+        Map<String, Object> mapJsonSchema = convertoToAirbyteJson(mapAvroSchema);
+        JsonNode jsonSchema = mapper.readValue(mapper.writeValueAsString(mapJsonSchema), JsonNode.class);
+
+        return jsonSchema;
+    }
+
+    /**
+     * Method to convert the avro schema in to Json schema in order to save the schema in the Airbyte Catalog
+     * @link https://docs.airbyte.com/understanding-airbyte/json-avro-conversion/
+     * @param avroSchema  Map<String, Object> map with Avro struct
+     * @return Map<String, Object> map with Json struct
+     * @throws Exception
+     */
+    public Map<String, Object> convertoToAirbyteJson(Map<String, Object> avroSchema) throws Exception {
+        Map<String, Object> jsonSchema = new HashMap<>();
+        List<Map<String, Object>> fields = (List<Map<String, Object>>) avroSchema.get("fields");
+        for (Map<String, Object> field : fields) {
+            String fieldName = (String) field.get("name");
+            Object fieldSchema = null;
+            List<Object> filedTypes = null;
+            if (field.get("type") instanceof List) {
+                List fieldType = (List<Object>) field.get("type");
+                filedTypes = fieldType.stream().filter(x -> (x != null) && (!x.equals("null"))).toList();
+                //Case when there is a list of type ex. ["null", "string"]
+                if (filedTypes instanceof List) {
+                    if (filedTypes.stream().filter(x -> x instanceof String).count() == 1) {
+                        String singleType = (String) filedTypes.stream()
+                                .findFirst()
+                                .orElse(null);
+                        fieldSchema = Map.of("type", avroTypeToJsonType(singleType));
+                    } else if (filedTypes.stream().filter(x -> x instanceof String).count() > 1) {
+
+                        List<Object> anyOfSchemas = new ArrayList<>();
+                        filedTypes.forEach(type -> anyOfSchemas.add(Map.of("type", avroTypeToJsonType((String) type))));
+                        fieldSchema = Map.of("anyOf", anyOfSchemas);
+                    }
+                } else {
+                    Map<String, Object> mapType = (Map<String, Object>) removeNull(fieldType);
+                    if (mapType.get("type").equals("array") && mapType.get("items") instanceof List) {
+                        List<Object> typeList = (ArrayList<Object>) mapType.get("items");
+                        Object items = removeNull(typeList);
+                        if (items instanceof Map) {
+                            //Case when there is a List of Object
+                            fieldSchema = Map.of("type", avroTypeToJsonType("array"), "items", List.of(convertoToAirbyteJson((Map<String, Object>) items)));
+                        } else {
+                            //Case when there is a List of type
+                            List<Map<String, List<String>>> types = typeList.stream().map(x -> Map.of("type", avroTypeToJsonType((String) x))).toList();
+                            fieldSchema = Map.of("type", avroTypeToJsonType("array"), "items", types);
+                        }
+                    } else if (mapType.get("type").equals("array") && mapType.get("items") instanceof Map) {
+                        //Case when there is a single Object
+                        fieldSchema = Map.of("type", avroTypeToJsonType("array"), "items", convertoToAirbyteJson((Map<String, Object>) mapType.get("items")));
+                    } else {
+                        fieldSchema = convertoToAirbyteJson(mapType);
+                    }
+
+                }
+            } else if (field.get("type") instanceof Map) {
+                //Case when there are a list of Objetct not in the array
+                Map<String, Object> fieldType = (Map<String, Object>) field.get("type");
+                Map<String, Object> map3 = Stream.of(Map.of("type", new String[]{"object", "null"}), convertoToAirbyteJson(fieldType))
+                        .flatMap(map -> map.entrySet().stream())
+                        .collect(Collectors.toMap(
+                                Map.Entry::getKey,
+                                Map.Entry::getValue));
+                fieldSchema = map3;
+            } else if (field.get("type") instanceof List) {
+                List<String> fieldTypes = (List<String>) field.get("type");
+                List<Object> anyOfSchemas = new ArrayList<>();
+                fieldTypes.forEach(type -> anyOfSchemas.add(avroTypeToJsonType(type)));
+                for (String type : fieldTypes) {
+                    if (!type.equals("fields")) {
+                        continue;
+                    }
+                    anyOfSchemas.add(avroTypeToJsonType(type));
+                }
+                fieldSchema = Map.of("anyOf", anyOfSchemas);
+            } else {
+                String singleType = List.of((String) field.get("type")).stream()
+                        .filter(type -> !"null".equals(type))
+                        .findFirst()
+                        .orElse(null);
+                fieldSchema = Map.of("type", avroTypeToJsonType(singleType));
+            }
+            jsonSchema.put(fieldName, fieldSchema);
+        }
+        return jsonSchema;
+    }
+
+    /**
+     * Remove null or "null" value present in the Type array
+     * @param field
+     * @return
+     * @throws Exception
+     */
+    private static Object removeNull(List field) throws Exception {
+        Optional<Object> fieldWithoutNull = field.stream().filter(x -> (x != null) && (!x.equals("null"))).findFirst();
+        if (fieldWithoutNull.isEmpty()) {
+            throw new Exception("Unknown Avro converter:" + field);
+        }
+        return fieldWithoutNull.get();
+    }
+
+
+}

--- a/airbyte-integrations/connectors/source-kafka/src/main/java/io/airbyte/integrations/source/kafka/format/AvroFormat.java
+++ b/airbyte-integrations/connectors/source-kafka/src/main/java/io/airbyte/integrations/source/kafka/format/AvroFormat.java
@@ -3,8 +3,7 @@
  */
 
 package io.airbyte.integrations.source.kafka.format;
-import io.airbyte.integrations.source.kafka.MessageFormat;
-import io.airbyte.protocol.models.v0.AirbyteMessage;
+
 import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;
@@ -16,19 +15,18 @@ import io.airbyte.commons.util.AutoCloseableIterators;
 import io.airbyte.integrations.source.kafka.KafkaStrategy;
 import io.airbyte.protocol.models.Field;
 import io.airbyte.protocol.models.JsonSchemaType;
-import io.airbyte.protocol.models.v0.*;
+import io.airbyte.protocol.models.v0.AirbyteMessage;
+import io.airbyte.protocol.models.v0.AirbyteRecordMessage;
+import io.airbyte.protocol.models.v0.AirbyteStream;
+import io.airbyte.protocol.models.v0.CatalogHelpers;
+import io.airbyte.protocol.models.v0.SyncMode;
 import io.confluent.kafka.schemaregistry.avro.AvroSchemaProvider;
 import io.confluent.kafka.schemaregistry.client.CachedSchemaRegistryClient;
 import io.confluent.kafka.schemaregistry.client.SchemaMetadata;
-import io.confluent.kafka.schemaregistry.client.SchemaRegistryClient;
 import io.confluent.kafka.schemaregistry.client.SchemaRegistryClientConfig;
-import io.confluent.kafka.schemaregistry.client.rest.RestService;
-import io.confluent.kafka.schemaregistry.client.rest.exceptions.RestClientException;
 import io.confluent.kafka.serializers.KafkaAvroDeserializer;
 import io.confluent.kafka.serializers.KafkaAvroDeserializerConfig;
 import io.confluent.kafka.serializers.KafkaAvroSerializerConfig;
-
-import java.io.IOException;
 import java.time.Duration;
 import java.time.Instant;
 import java.time.temporal.ChronoUnit;
@@ -36,9 +34,6 @@ import java.util.*;
 import java.util.concurrent.atomic.AtomicInteger;
 import java.util.regex.Pattern;
 import java.util.stream.Collectors;
-import java.util.stream.Stream;
-
-import org.apache.avro.Schema;
 import org.apache.avro.generic.GenericRecord;
 import org.apache.commons.lang3.StringUtils;
 import org.apache.kafka.clients.consumer.ConsumerConfig;
@@ -52,225 +47,194 @@ import org.slf4j.LoggerFactory;
 
 public class AvroFormat extends AbstractFormat {
 
-  private static final Logger LOGGER = LoggerFactory.getLogger(AvroFormat.class);
+    private static final Logger LOGGER = LoggerFactory.getLogger(AvroFormat.class);
 
-  private KafkaConsumer<String, GenericRecord> consumer;
+    private KafkaConsumer<String, GenericRecord> consumer;
 
-  public AvroFormat(JsonNode jsonConfig) {
-    super(jsonConfig);
-  }
-
-  @Override
-  protected Map<String, Object> getKafkaConfig() {
-    Map<String, Object> properties =  super.getKafkaConfig();
-    final JsonNode avro_config = config.get("MessageFormat");
-    properties.put(ConsumerConfig.KEY_DESERIALIZER_CLASS_CONFIG, StringDeserializer.class.getName());
-    properties.put(ConsumerConfig.VALUE_DESERIALIZER_CLASS_CONFIG, KafkaAvroDeserializer.class.getName());
-    properties.put(SchemaRegistryClientConfig.BASIC_AUTH_CREDENTIALS_SOURCE, "USER_INFO");
-    properties.put(SchemaRegistryClientConfig.USER_INFO_CONFIG,
-            String.format("%s:%s", avro_config.get("schema_registry_username").asText(), avro_config.get("schema_registry_password").asText()));
-    properties.put(KafkaAvroDeserializerConfig.SCHEMA_REGISTRY_URL_CONFIG, avro_config.get("schema_registry_url").asText());
-    properties.put(KafkaAvroSerializerConfig.VALUE_SUBJECT_NAME_STRATEGY,
-            KafkaStrategy.getStrategyName(avro_config.get("deserialization_strategy").asText()));
-
-
-
-    // normal consumer
-  //  properties.put("bootstrap.servers", "pkc-e8mp5.eu-west-1.aws.confluent.cloud:9092");
-  //  properties.put("key.deserializer", "org.apache.kafka.common.serialization.StringDeserializer");
- //   properties.put("value.deserializer", "io.confluent.kafka.serializers.KafkaAvroDeserializer");
-
-
-    //properties.put("auto.offset.reset", "earliest");
-
- //   properties.put("sasl.jaas.config", "org.apache.kafka.common.security.plain.PlainLoginModule required username=\"KEPWQXZOVJFGKREP\" password=\"3NjIiv0BppSttm5RbVbIb2nx1Y8JWHpueq0g1+lTxvyPHpoWSXgujlkqDmxr3WqV\";");
-  //  properties.put("security.protocol", "SASL_SSL");
-  //  properties.put("sasl.mechanism", "PLAIN");
-   // properties.put("ssl.endpoint.identification.algorithm", "https");
-   // properties.put("auto.register.schemas", "true");
- //   properties.put("schema.registry.url", "https://psrc-8vyvr.eu-central-1.aws.confluent.cloud");
-    Random random = new Random();
-    // genera numero casuale tra 0 e 3
-    int number = random.nextInt(50000);
-    properties.put("group.id", "test-"+ number);
-//    properties.put("schema.registry.basic.auth.credentials.source" ,  "USER_INFO");
-//    properties.put("schema.registry.basic.auth.user.info" ,  "BDDHNB6IT6DRT4E4:vtKtc4k0xwdQ5xHEojKpaifNxjQopDEUAyJf9hy3bj+kv1B1ZnD+TzLgbztMLR1s");
-    return properties;
-  }
-
-  @Override
-  protected KafkaConsumer<String, GenericRecord> getConsumer() {
-    if (consumer != null) {
-      return consumer;
+    public AvroFormat(JsonNode jsonConfig) {
+        super(jsonConfig);
     }
-    Map<String, Object> filteredProps = getKafkaConfig();
-    consumer = new KafkaConsumer<>(filteredProps);
 
-    final JsonNode subscription = config.get("subscription");
-    LOGGER.info("Kafka subscribe method: {}", subscription.toString());
-    switch (subscription.get("subscription_type").asText()) {
-      case "subscribe" -> {
-        final String topicPattern = subscription.get("topic_pattern").asText();
-        consumer.subscribe(Pattern.compile(topicPattern));
-        topicsToSubscribe = consumer.listTopics().keySet().stream()
-            .filter(topic -> topic.matches(topicPattern))
-            .collect(Collectors.toSet());
-        LOGGER.info("Topic list: {}", topicsToSubscribe);
-      }
-      case "assign" -> {
-        topicsToSubscribe = new HashSet<>();
-        final String topicPartitions = subscription.get("topic_partitions").asText();
-        final String[] topicPartitionsStr = topicPartitions.replaceAll("\\s+", "").split(",");
-        final List<TopicPartition> topicPartitionList = Arrays.stream(topicPartitionsStr).map(topicPartition -> {
-          final String[] pair = topicPartition.split(":");
-          topicsToSubscribe.add(pair[0]);
-          return new TopicPartition(pair[0], Integer.parseInt(pair[1]));
-        }).collect(Collectors.toList());
-        LOGGER.info("Topic-partition list: {}", topicPartitionList);
-        consumer.assign(topicPartitionList);
-      }
+    @Override
+    protected Map<String, Object> getKafkaConfig() {
+        Map<String, Object> props = super.getKafkaConfig();
+        final JsonNode avro_config = config.get("MessageFormat");
+        props.put(ConsumerConfig.KEY_DESERIALIZER_CLASS_CONFIG, StringDeserializer.class.getName());
+        props.put(ConsumerConfig.VALUE_DESERIALIZER_CLASS_CONFIG, KafkaAvroDeserializer.class.getName());
+        props.put(SchemaRegistryClientConfig.BASIC_AUTH_CREDENTIALS_SOURCE, "USER_INFO");
+        props.put(SchemaRegistryClientConfig.USER_INFO_CONFIG,
+                String.format("%s:%s", avro_config.get("schema_registry_username").asText(), avro_config.get("schema_registry_password").asText()));
+        props.put(KafkaAvroDeserializerConfig.SCHEMA_REGISTRY_URL_CONFIG, avro_config.get("schema_registry_url").asText());
+        props.put(KafkaAvroSerializerConfig.VALUE_SUBJECT_NAME_STRATEGY,
+                KafkaStrategy.getStrategyName(avro_config.get("deserialization_strategy").asText()));
+        return props;
     }
-    return consumer;
-  }
 
-  @Override
-  protected Set<String> getTopicsToSubscribe() {
-    if (topicsToSubscribe == null) {
-      getConsumer();
-    }
-    return topicsToSubscribe;
-  }
-
-  @Override
-  public boolean isAccessible() {
-    try {
-      final String testTopic = config.has("test_topic") ? config.get("test_topic").asText() : "";
-      if (!testTopic.isBlank()) {
-        final KafkaConsumer<String, GenericRecord> consumer = getConsumer();
-        consumer.subscribe(Pattern.compile(testTopic));
-        consumer.listTopics();
-        consumer.close();
-        LOGGER.info("Successfully connected to Kafka brokers for topic '{}'.", config.get("test_topic").asText());
-      }
-      return true;
-    } catch (final Exception e) {
-      LOGGER.error("Exception attempting to connect to the Kafka brokers: ", e);
-      return false;
-    }
-  }
-
-  @Override
-  public List<AirbyteStream> getStreams(final JsonNode config) {
-    final JsonNode avroConfig = config.get("MessageFormat");
-    String schemRegistryUrl = avroConfig.get("schema_registry_url").asText();
-
-    Map<String, Object> properties = new HashMap<>();
-
-    properties.put(SchemaRegistryClientConfig.BASIC_AUTH_CREDENTIALS_SOURCE, "USER_INFO");
-    properties.put(SchemaRegistryClientConfig.USER_INFO_CONFIG, String.format("%s:%s", avroConfig.get("schema_registry_username").asText(), avroConfig.get("schema_registry_password").asText()));
-
-    CachedSchemaRegistryClient schemaRegistryClient = new CachedSchemaRegistryClient(schemRegistryUrl, 1000, List.of(new AvroSchemaProvider()), properties);
-
-    final Set<String> topicsToSubscribe = getTopicsToSubscribe();
-    final List<AirbyteStream> streams = topicsToSubscribe.stream().map(topic ->
-               CatalogHelpers
-                      .createAirbyteStream(topic, Field.of("value", JsonSchemaType.STRING))
-                       .withJsonSchema(extractSchemaStream(schemaRegistryClient, topic))
-                      .withSupportedSyncModes(Lists.newArrayList(SyncMode.FULL_REFRESH, SyncMode.INCREMENTAL))
-
-            )
-        .collect(Collectors.toList());
-    return streams;
-  }
-
-  private static JsonNode extractSchemaStream(CachedSchemaRegistryClient client, String topic) {
-    try {
-      SchemaMetadata schema = client.getLatestSchemaMetadata(topic+ "-value");
-      Avro2JsonConvert converter = new  Avro2JsonConvert();
-      return converter.convertoToAirbyteJson(schema.getSchema());
-    } catch (Exception e) {
-      LOGGER.error("Errore when extract and convert avro schema" + e.getMessage());
-      throw new RuntimeException(e);
-    }
-  }
-
-  @Override
-  public AutoCloseableIterator<AirbyteMessage> read() {
-
-    final KafkaConsumer<String, GenericRecord> consumer = getConsumer();
-    final List<ConsumerRecord<String, GenericRecord>> recordsList = new ArrayList<>();
-    final int retry = config.has("repeated_calls") ? config.get("repeated_calls").intValue() : 0;
-    final int polling_time = config.has("polling_time") ? config.get("polling_time").intValue() : 10000;
-    final int max_records = config.has("max_records_process") ? config.get("max_records_process").intValue() : 100000;
-    AtomicInteger record_count = new AtomicInteger();
-    final Map<String, Integer> poll_lookup = new HashMap<>();
-    getTopicsToSubscribe().forEach(topic -> poll_lookup.put(topic, 0));
-    while (true) {
-      final ConsumerRecords<String, GenericRecord> consumerRecords = consumer.poll(Duration.of(polling_time, ChronoUnit.MILLIS));
-      consumerRecords.forEach(record -> {
-        record_count.getAndIncrement();
-        recordsList.add(record);
-      });
-
-      consumer.commitAsync();
-
-      if (consumerRecords.count() == 0) {
-        consumer.assignment().stream().map(record -> record.topic()).distinct().forEach(
-            topic -> {
-              poll_lookup.put(topic, poll_lookup.get(topic) + 1);
-            });
-        boolean is_complete = poll_lookup.entrySet().stream().allMatch(
-            e -> e.getValue() > retry);
-        if (is_complete) {
-          LOGGER.info("There is no new data in the queue!!");
-          break;
+    @Override
+    protected KafkaConsumer<String, GenericRecord> getConsumer() {
+        if (consumer != null) {
+            return consumer;
         }
-      } else if (record_count.get() > max_records) {
-        LOGGER.info("Max record count is reached !!");
-        break;
-      }
-    }
-    consumer.close();
-    final Iterator<ConsumerRecord<String, GenericRecord>> iterator = recordsList.iterator();
-    return AutoCloseableIterators.fromIterator(new AbstractIterator<>() {
+        Map<String, Object> filteredProps = getKafkaConfig();
+        consumer = new KafkaConsumer<>(filteredProps);
 
-      @Override
-      protected AirbyteMessage computeNext() {
-        if (iterator.hasNext()) {
-          final ConsumerRecord<String, GenericRecord> record = iterator.next();
-          GenericRecord avro_data = record.value();
-          ObjectMapper mapper = new ObjectMapper();
-          Schema schema = avro_data.getSchema();
-          LOGGER.info("Schema avro"+ schema.toString());
-          String namespace = avro_data.getSchema().getNamespace();
-          String name = avro_data.getSchema().getName();
-          JsonNode output;
-          try {
-            // Todo dynamic namespace is not supported now hence, adding avro schema name in the message
-            if (StringUtils.isNoneEmpty(namespace) && StringUtils.isNoneEmpty(name)) {
-              String newString = String.format("{\"avro_schema\": \"%s\",\"name\":\"%s\"}", namespace, name);
-              JsonNode newNode = mapper.readTree(newString);
-              output = mapper.readTree(avro_data.toString());
-              ((ObjectNode) output).set("_namespace_", newNode);
-            } else {
-              output = mapper.readTree(avro_data.toString());
+        final JsonNode subscription = config.get("subscription");
+        LOGGER.info("Kafka subscribe method: {}", subscription.toString());
+        switch (subscription.get("subscription_type").asText()) {
+            case "subscribe" -> {
+                final String topicPattern = subscription.get("topic_pattern").asText();
+                consumer.subscribe(Pattern.compile(topicPattern));
+                topicsToSubscribe = consumer.listTopics().keySet().stream()
+                        .filter(topic -> topic.matches(topicPattern))
+                        .collect(Collectors.toSet());
+                LOGGER.info("Topic list: {}", topicsToSubscribe);
             }
-          } catch (JsonProcessingException e) {
-            LOGGER.error("Exception whilst reading avro data from stream", e);
-            throw new RuntimeException(e);
-          }
-          return new AirbyteMessage()
-              .withType(AirbyteMessage.Type.RECORD)
-              .withRecord(new AirbyteRecordMessage()
-                  .withStream(record.topic())
-                  .withEmittedAt(Instant.now().toEpochMilli())
-                  .withData(output));
+            case "assign" -> {
+                topicsToSubscribe = new HashSet<>();
+                final String topicPartitions = subscription.get("topic_partitions").asText();
+                final String[] topicPartitionsStr = topicPartitions.replaceAll("\\s+", "").split(",");
+                final List<TopicPartition> topicPartitionList = Arrays.stream(topicPartitionsStr).map(topicPartition -> {
+                    final String[] pair = topicPartition.split(":");
+                    topicsToSubscribe.add(pair[0]);
+                    return new TopicPartition(pair[0], Integer.parseInt(pair[1]));
+                }).collect(Collectors.toList());
+                LOGGER.info("Topic-partition list: {}", topicPartitionList);
+                consumer.assign(topicPartitionList);
+            }
         }
+        return consumer;
+    }
 
-        return endOfData();
-      }
+    @Override
+    protected Set<String> getTopicsToSubscribe() {
+        if (topicsToSubscribe == null) {
+            getConsumer();
+        }
+        return topicsToSubscribe;
+    }
 
-    });
-  }
+    @Override
+    public boolean isAccessible() {
+        try {
+            final String testTopic = config.has("test_topic") ? config.get("test_topic").asText() : "";
+            if (!testTopic.isBlank()) {
+                final KafkaConsumer<String, GenericRecord> consumer = getConsumer();
+                consumer.subscribe(Pattern.compile(testTopic));
+                consumer.listTopics();
+                consumer.close();
+                LOGGER.info("Successfully connected to Kafka brokers for topic '{}'.", config.get("test_topic").asText());
+            }
+            return true;
+        } catch (final Exception e) {
+            LOGGER.error("Exception attempting to connect to the Kafka brokers: ", e);
+            return false;
+        }
+    }
+
+    @Override
+    public List<AirbyteStream> getStreams(final JsonNode config) {
+        final JsonNode avroConfig = config.get("MessageFormat");
+        String schemRegistryUrl = avroConfig.get("schema_registry_url").asText();
+        Map<String, Object> properties = Map.of(SchemaRegistryClientConfig.BASIC_AUTH_CREDENTIALS_SOURCE, "USER_INFO",
+                SchemaRegistryClientConfig.USER_INFO_CONFIG, String.format("%s:%s", avroConfig.get("schema_registry_username").asText(), avroConfig.get("schema_registry_password").asText()));
+        CachedSchemaRegistryClient schemaRegistryClient = new CachedSchemaRegistryClient(schemRegistryUrl, 1000, List.of(new AvroSchemaProvider()), properties);
+        final Set<String> topicsToSubscribe = getTopicsToSubscribe();
+        final List<AirbyteStream> streams = topicsToSubscribe.stream().map(topic ->
+                        CatalogHelpers
+                                .createAirbyteStream(topic, Field.of("value", JsonSchemaType.STRING))
+                                .withJsonSchema(extractSchemaStream(schemaRegistryClient, topic))
+                                .withSupportedSyncModes(Lists.newArrayList(SyncMode.FULL_REFRESH, SyncMode.INCREMENTAL))
+
+                )
+                .collect(Collectors.toList());
+        return streams;
+    }
+
+    private static JsonNode extractSchemaStream(CachedSchemaRegistryClient client, String topic) {
+        try {
+            SchemaMetadata schema = client.getLatestSchemaMetadata(topic + "-value");
+            Avro2JsonConvert converter = new Avro2JsonConvert();
+            return converter.convertoToAirbyteJson(schema.getSchema());
+        } catch (Exception e) {
+            LOGGER.error("Errore when extract and convert avro schema" + e.getMessage());
+            throw new RuntimeException(e);
+        }
+    }
+
+    @Override
+    public AutoCloseableIterator<AirbyteMessage> read() {
+
+        final KafkaConsumer<String, GenericRecord> consumer = getConsumer();
+        final List<ConsumerRecord<String, GenericRecord>> recordsList = new ArrayList<>();
+        final int retry = config.has("repeated_calls") ? config.get("repeated_calls").intValue() : 0;
+        final int polling_time = config.has("polling_time") ? config.get("polling_time").intValue() : 100;
+        final int max_records = config.has("max_records_process") ? config.get("max_records_process").intValue() : 100000;
+        AtomicInteger record_count = new AtomicInteger();
+        final Map<String, Integer> poll_lookup = new HashMap<>();
+        getTopicsToSubscribe().forEach(topic -> poll_lookup.put(topic, 0));
+        while (true) {
+            final ConsumerRecords<String, GenericRecord> consumerRecords = consumer.poll(Duration.of(polling_time, ChronoUnit.MILLIS));
+            consumerRecords.forEach(record -> {
+                record_count.getAndIncrement();
+                recordsList.add(record);
+            });
+            consumer.commitAsync();
+
+            if (consumerRecords.count() == 0) {
+                consumer.assignment().stream().map(record -> record.topic()).distinct().forEach(
+                        topic -> {
+                            poll_lookup.put(topic, poll_lookup.get(topic) + 1);
+                        });
+                boolean is_complete = poll_lookup.entrySet().stream().allMatch(
+                        e -> e.getValue() > retry);
+                if (is_complete) {
+                    LOGGER.info("There is no new data in the queue!!");
+                    break;
+                }
+            } else if (record_count.get() > max_records) {
+                LOGGER.info("Max record count is reached !!");
+                break;
+            }
+        }
+        consumer.close();
+        final Iterator<ConsumerRecord<String, GenericRecord>> iterator = recordsList.iterator();
+        return AutoCloseableIterators.fromIterator(new AbstractIterator<>() {
+
+            @Override
+            protected AirbyteMessage computeNext() {
+                if (iterator.hasNext()) {
+                    final ConsumerRecord<String, GenericRecord> record = iterator.next();
+                    GenericRecord avro_data = record.value();
+                    ObjectMapper mapper = new ObjectMapper();
+                    String namespace = avro_data.getSchema().getNamespace();
+                    String name = avro_data.getSchema().getName();
+                    JsonNode output;
+                    try {
+                        // Todo dynamic namespace is not supported now hence, adding avro schema name in the message
+                        if (StringUtils.isNoneEmpty(namespace) && StringUtils.isNoneEmpty(name)) {
+                            String newString = String.format("{\"avro_schema\": \"%s\",\"name\":\"%s\"}", namespace, name);
+                            JsonNode newNode = mapper.readTree(newString);
+                            output = mapper.readTree(avro_data.toString());
+                            ((ObjectNode) output).set("_namespace_", newNode);
+                        } else {
+                            output = mapper.readTree(avro_data.toString());
+                        }
+                    } catch (JsonProcessingException e) {
+                        LOGGER.error("Exception whilst reading avro data from stream", e);
+                        throw new RuntimeException(e);
+                    }
+                    return new AirbyteMessage()
+                            .withType(AirbyteMessage.Type.RECORD)
+                            .withRecord(new AirbyteRecordMessage()
+                                    .withStream(record.topic())
+                                    .withEmittedAt(Instant.now().toEpochMilli())
+                                    .withData(output));
+                }
+
+                return endOfData();
+            }
+
+        });
+    }
 
 }

--- a/airbyte-integrations/connectors/source-kafka/src/main/java/io/airbyte/integrations/source/kafka/format/JsonFormat.java
+++ b/airbyte-integrations/connectors/source-kafka/src/main/java/io/airbyte/integrations/source/kafka/format/JsonFormat.java
@@ -11,11 +11,8 @@ import io.airbyte.commons.util.AutoCloseableIterator;
 import io.airbyte.commons.util.AutoCloseableIterators;
 import io.airbyte.protocol.models.Field;
 import io.airbyte.protocol.models.JsonSchemaType;
-import io.airbyte.protocol.models.v0.AirbyteMessage;
-import io.airbyte.protocol.models.v0.AirbyteRecordMessage;
-import io.airbyte.protocol.models.v0.AirbyteStream;
-import io.airbyte.protocol.models.v0.CatalogHelpers;
-import io.airbyte.protocol.models.v0.SyncMode;
+import io.airbyte.protocol.models.v0.*;
+
 import java.time.Duration;
 import java.time.Instant;
 import java.time.temporal.ChronoUnit;
@@ -94,7 +91,7 @@ public class JsonFormat extends AbstractFormat {
   }
 
   @Override
-  public List<AirbyteStream> getStreams() {
+  public List<AirbyteStream> getStreams(JsonNode config) {
     final Set<String> topicsToSubscribe = getTopicsToSubscribe();
     final List<AirbyteStream> streams = topicsToSubscribe.stream().map(topic -> CatalogHelpers
         .createAirbyteStream(topic, Field.of("value", JsonSchemaType.STRING))
@@ -104,7 +101,7 @@ public class JsonFormat extends AbstractFormat {
   }
 
   @Override
-  public AutoCloseableIterator<AirbyteMessage> read() {
+  public AutoCloseableIterator<AirbyteMessage> read(){
 
     final KafkaConsumer<String, JsonNode> consumer = getConsumer();
     final List<ConsumerRecord<String, JsonNode>> recordsList = new ArrayList<>();

--- a/airbyte-integrations/connectors/source-kafka/src/main/java/io/airbyte/integrations/source/kafka/format/JsonFormat.java
+++ b/airbyte-integrations/connectors/source-kafka/src/main/java/io/airbyte/integrations/source/kafka/format/JsonFormat.java
@@ -11,8 +11,11 @@ import io.airbyte.commons.util.AutoCloseableIterator;
 import io.airbyte.commons.util.AutoCloseableIterators;
 import io.airbyte.protocol.models.Field;
 import io.airbyte.protocol.models.JsonSchemaType;
-import io.airbyte.protocol.models.v0.*;
-
+import io.airbyte.protocol.models.v0.AirbyteMessage;
+import io.airbyte.protocol.models.v0.AirbyteRecordMessage;
+import io.airbyte.protocol.models.v0.AirbyteStream;
+import io.airbyte.protocol.models.v0.CatalogHelpers;
+import io.airbyte.protocol.models.v0.SyncMode;
 import java.time.Duration;
 import java.time.Instant;
 import java.time.temporal.ChronoUnit;
@@ -101,7 +104,7 @@ public class JsonFormat extends AbstractFormat {
   }
 
   @Override
-  public AutoCloseableIterator<AirbyteMessage> read(){
+  public AutoCloseableIterator<AirbyteMessage> read() {
 
     final KafkaConsumer<String, JsonNode> consumer = getConsumer();
     final List<ConsumerRecord<String, JsonNode>> recordsList = new ArrayList<>();

--- a/airbyte-integrations/connectors/source-kafka/src/main/java/io/airbyte/integrations/source/kafka/format/KafkaFormat.java
+++ b/airbyte-integrations/connectors/source-kafka/src/main/java/io/airbyte/integrations/source/kafka/format/KafkaFormat.java
@@ -4,16 +4,19 @@
 
 package io.airbyte.integrations.source.kafka.format;
 
+import com.fasterxml.jackson.databind.JsonNode;
 import io.airbyte.commons.util.AutoCloseableIterator;
 import io.airbyte.protocol.models.v0.AirbyteMessage;
 import io.airbyte.protocol.models.v0.AirbyteStream;
+import io.airbyte.protocol.models.v0.ConfiguredAirbyteCatalog;
+
 import java.util.List;
 
 public interface KafkaFormat {
 
   boolean isAccessible();
 
-  List<AirbyteStream> getStreams();
+  List<AirbyteStream> getStreams(final JsonNode config);
 
   AutoCloseableIterator<AirbyteMessage> read();
 

--- a/airbyte-integrations/connectors/source-kafka/src/main/java/io/airbyte/integrations/source/kafka/format/KafkaFormat.java
+++ b/airbyte-integrations/connectors/source-kafka/src/main/java/io/airbyte/integrations/source/kafka/format/KafkaFormat.java
@@ -8,8 +8,6 @@ import com.fasterxml.jackson.databind.JsonNode;
 import io.airbyte.commons.util.AutoCloseableIterator;
 import io.airbyte.protocol.models.v0.AirbyteMessage;
 import io.airbyte.protocol.models.v0.AirbyteStream;
-import io.airbyte.protocol.models.v0.ConfiguredAirbyteCatalog;
-
 import java.util.List;
 
 public interface KafkaFormat {

--- a/airbyte-integrations/connectors/source-kafka/src/main/resources/spec.json
+++ b/airbyte-integrations/connectors/source-kafka/src/main/resources/spec.json
@@ -48,7 +48,8 @@
               },
               "schema_registry_password": {
                 "type": "string",
-                "default": ""
+                "default": "",
+                "airbyte_secret": true
               }
             }
           }

--- a/airbyte-integrations/connectors/source-kafka/src/test/java/io/airbyte/integrations/source/kafka/AvroConverterTest.java
+++ b/airbyte-integrations/connectors/source-kafka/src/test/java/io/airbyte/integrations/source/kafka/AvroConverterTest.java
@@ -1,0 +1,351 @@
+/*
+ * Copyright (c) 2023 Airbyte, Inc., all rights reserved.
+ */
+
+package io.airbyte.integrations.source.kafka;
+
+import com.fasterxml.jackson.core.type.TypeReference;
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import io.airbyte.integrations.source.kafka.format.Avro2JsonConvert;
+import org.junit.jupiter.api.Test;
+
+import java.util.Map;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+public class AvroConverterTest {
+
+    ObjectMapper mapper = new ObjectMapper();
+
+    String avroSimpleSchema = """
+            {
+                "type": "record",
+                "name": "sampleAvro",
+                "namespace": "AVRO",
+                "fields": [
+                    {"name": "name", "type": "string"},
+                    {"name": "age", "type": ["int", "null"]},
+                    {"name": "address", "type": ["float", "null"]},
+                    {"name": "street", "type": "float"},
+                    {"name": "valid", "type": "boolean"}
+                ]
+            }
+                """;
+
+    String jsonSimpleSchema = """
+            {"address": {"type": ["number", "null"]},
+              "age": {"type": ["integer", "null"]},
+              "name": {"type": ["string", "null"]},
+              "street": {"type": ["number", "null"]},
+              "valid": {"type": ["boolean", "null"]}
+            }
+              
+             """;
+
+
+    String avroNestedRecordsSchema = """
+              {
+                "type": "record",
+                "name": "sampleAvroNested",
+                "namespace": "AVRO",
+                "fields": [
+                    {"name": "lastname", "type": "string"},
+                    {"name": "address","type": {
+                                    "type" : "record",
+                                    "name" : "AddressUSRecord",
+                                    "fields" : [
+                                        {"name": "streetaddress", "type": "string"},
+                                        {"name": "city", "type": "string"}
+                                    ]
+                                }
+                    }
+                ]
+            }
+                      """;
+
+
+    String jsonNestedRecordSchema = """
+             {
+                "address":{
+                   "type":["object", "null"],
+                   "city":{
+                        "type":[ "string","null"]
+                         },
+                   "streetaddress":{
+                    "type":["string","null"]
+                   }
+                },
+                "lastname":{
+                "type":["string","null"]
+                }
+             }
+            """;
+
+
+    String avroWithArraySchema = """
+            {
+              "type": "record",
+              "fields": [
+                {
+                  "name": "identifier",
+                  "type": [
+                    null,
+                    {
+                      "type": "array",
+                      "items": ["null", "string"]
+                    }
+                  ]
+                }
+              ]
+            }
+                      
+            """;
+
+    String jsonWithArraySchema = """
+            {
+            "identifier": {
+                  "type": ["array", "null"],
+                  "items" :  [
+                    {"type":["null"]},
+                    {"type":["string","null"]}
+                  ]
+                }
+                }
+            """;
+
+    String avroWithArrayAndRecordSchema = """
+            {
+                "type": "record",
+                "name": "TestObject",
+                "namespace": "ca.dataedu",
+                "fields": [{
+                    "name": "array_field",
+                    "type": ["null", {
+                        "type": "array",
+                        "items": ["null", {
+                            "type": "record",
+                            "name": "Array_field",
+                            "fields": [{
+                                "name": "id",
+                                "type": ["null", {
+                                    "type": "record",
+                                    "name": "Id",
+                                    "fields": [{
+                                        "name": "id_part_1",
+                                        "type": ["null", "int"],
+                                        "default": null
+                                    }]
+                                }],
+                                "default": null
+                            }]
+                        }]
+                    }],
+                    "default": null
+                }]
+            }
+                      
+            """;
+
+
+    String jsonWithArrayAndRecordSchema = """
+            {
+              "array_field": {
+                "type": ["array", "null"],
+                "items": [
+                  {
+                      "id": {
+                          "id_part_1": { "type": ["integer", "null"] }
+                      }
+                    }
+                ]
+              }
+            }
+            """;
+
+
+    String avroWithArrayAndNestedRecordSchema = """
+            {
+                "type": "record",
+                "name": "TestObject",
+                "namespace": "ca.dataedu",
+                "fields": [{
+                    "name": "array_field",
+                    "type": ["null", {
+                        "type": "array",
+                        "items": ["null", {
+                            "type": "record",
+                            "name": "Array_field",
+                            "fields": [{
+                                "name": "id",
+                                "type": ["null", {
+                                    "type": "record",
+                                    "name": "Id",
+                                    "fields": [{
+                                        "name": "id_part_1",
+                                        "type": ["null", "int"],
+                                        "default": null
+                                    }, {
+                                        "name": "id_part_2",
+                                        "type": ["null", "string"],
+                                        "default": null
+                                    }]
+                                }],
+                                "default": null
+                            }, {
+                                "name": "message",
+                                "type": ["null", "string"],
+                                "default": null
+                            }]
+                        }]
+                    }],
+                    "default": null
+                }]
+            }
+                      
+            """;
+
+    String jsonWithArrayAndNestedRecordSchema = """
+            {
+              "array_field": {
+                "type": ["array", "null"],
+                "items": [
+                  {
+                      "id": {
+                          "id_part_1": { "type": ["integer", "null"] },
+                          "id_part_2": { "type": ["string", "null"] }
+                      },
+                      "message" : {"type": [ "string", "null"] }
+                  }
+                ]
+              }
+            }
+            """;
+
+
+    String avroWithCombinedRestrictionsSchema = """
+                {
+                "type": "record",
+                "name": "sampleAvro",
+                "namespace": "AVRO",
+                "fields": [
+                    {"name": "name", "type": "string"},
+                    {"name": "age", "type": ["int", "null"]},
+                    {"name": "address", "type": ["float", "string", "null"]}
+                ]
+            }
+                """;
+
+    String jsonWithCombinedRestrictionsSchema = """
+            {
+             "address": {"anyOf": [ 
+                           {"type": ["string", "null"]},
+                           {"type": ["number", "null"]}
+                         ]},
+              "age": {"type": ["integer", "null"]},
+              "name": {"type": ["string", "null"]}
+            }
+              
+             """;
+
+
+    @Test
+    public void testConverterAvroSimpleSchema() throws Exception {
+        Map<String, Object> jsonSchema = mapper.readValue(avroSimpleSchema, new TypeReference<Map<String, Object>>() {
+        });
+        Avro2JsonConvert converter = new Avro2JsonConvert();
+        Map<String, Object> airbyteSchema = converter.convertoToAirbyteJson(jsonSchema);
+        JsonNode expect = mapper.readTree(jsonSimpleSchema);
+        JsonNode actual = mapper.readValue(mapper.writeValueAsString(airbyteSchema), JsonNode.class);
+        assertEquals(expect, actual);
+    }
+
+    @Test
+    public void testConverterAvroNestedSchema() throws Exception {
+        Map<String, Object> jsonSchema = mapper.readValue(avroNestedRecordsSchema, new TypeReference<Map<String, Object>>() {
+        });
+        Avro2JsonConvert converter = new Avro2JsonConvert();
+        Map<String, Object> airbyteSchema = converter.convertoToAirbyteJson(jsonSchema);
+        JsonNode expect = mapper.readTree(jsonNestedRecordSchema);
+        System.out.println(mapper.writeValueAsString(airbyteSchema));
+        JsonNode actual = mapper.readValue(mapper.writeValueAsString(airbyteSchema), JsonNode.class);
+
+        System.out.println(mapper.writeValueAsString(jsonSchema));
+
+
+        assertEquals(expect, actual);
+    }
+
+    @Test
+    public void testConverterAvroWithArray() throws Exception {
+
+        Map<String, Object> jsonSchema = mapper.readValue(avroWithArraySchema, new TypeReference<Map<String, Object>>() {
+        });
+        Avro2JsonConvert converter = new Avro2JsonConvert();
+        Map<String, Object> airbyteSchema = converter.convertoToAirbyteJson(jsonSchema);
+        JsonNode expect = mapper.readTree(jsonWithArraySchema);
+        System.out.println(mapper.writeValueAsString(airbyteSchema));
+        JsonNode actual = mapper.readValue(mapper.writeValueAsString(airbyteSchema), JsonNode.class);
+
+        System.out.println(mapper.writeValueAsString(jsonSchema));
+
+
+        assertEquals(expect, actual);
+    }
+
+
+    @Test
+    public void testConverterAvroWithArrayComplex() throws Exception {
+
+        Map<String, Object> jsonSchema = mapper.readValue(avroWithArrayAndRecordSchema, new TypeReference<Map<String, Object>>() {
+        });
+        Avro2JsonConvert converter = new Avro2JsonConvert();
+        Map<String, Object> airbyteSchema = converter.convertoToAirbyteJson(jsonSchema);
+        JsonNode expect = mapper.readTree(jsonWithArrayAndRecordSchema);
+        System.out.println(mapper.writeValueAsString(airbyteSchema));
+        JsonNode actual = mapper.readValue(mapper.writeValueAsString(airbyteSchema), JsonNode.class);
+
+        System.out.println(mapper.writeValueAsString(jsonSchema));
+
+
+        assertEquals(expect, actual);
+    }
+
+
+    @Test
+    public void testConverterAvroWithCombinedRestrictions() throws Exception {
+
+        Map<String, Object> jsonSchema = mapper.readValue(avroWithCombinedRestrictionsSchema, new TypeReference<Map<String, Object>>() {
+        });
+        Avro2JsonConvert converter = new Avro2JsonConvert();
+        Map<String, Object> airbyteSchema = converter.convertoToAirbyteJson(jsonSchema);
+        JsonNode expect = mapper.readTree(jsonWithCombinedRestrictionsSchema);
+        System.out.println(mapper.writeValueAsString(airbyteSchema));
+        JsonNode actual = mapper.readValue(mapper.writeValueAsString(airbyteSchema), JsonNode.class);
+
+        System.out.println(mapper.writeValueAsString(jsonSchema));
+
+
+        assertEquals(expect, actual);
+    }
+
+
+    @Test
+    public void testConverterAvroWithArrayComplex2() throws Exception {
+
+        Map<String, Object> jsonSchema = mapper.readValue(avroWithArrayAndNestedRecordSchema, new TypeReference<Map<String, Object>>() {
+        });
+        Avro2JsonConvert converter = new Avro2JsonConvert();
+        Map<String, Object> airbyteSchema = converter.convertoToAirbyteJson(jsonSchema);
+        JsonNode expect = mapper.readTree(jsonWithArrayAndNestedRecordSchema);
+        System.out.println(mapper.writeValueAsString(airbyteSchema));
+        JsonNode actual = mapper.readValue(mapper.writeValueAsString(airbyteSchema), JsonNode.class);
+
+        System.out.println(mapper.writeValueAsString(jsonSchema));
+
+
+        assertEquals(expect, actual);
+    }
+
+
+}

--- a/airbyte-integrations/connectors/source-kafka/src/test/java/io/airbyte/integrations/source/kafka/KafkaSourceTest.java
+++ b/airbyte-integrations/connectors/source-kafka/src/test/java/io/airbyte/integrations/source/kafka/KafkaSourceTest.java
@@ -9,9 +9,14 @@ import static org.junit.jupiter.api.Assertions.assertInstanceOf;
 import com.fasterxml.jackson.databind.JsonNode;
 import io.airbyte.commons.json.Jsons;
 import io.airbyte.commons.resources.MoreResources;
+import io.airbyte.commons.util.AutoCloseableIterator;
+import io.airbyte.integrations.base.IntegrationRunner;
+import io.airbyte.integrations.base.Source;
 import io.airbyte.integrations.source.kafka.format.AvroFormat;
 import io.airbyte.integrations.source.kafka.format.KafkaFormat;
 import java.io.IOException;
+
+import io.airbyte.protocol.models.v0.AirbyteMessage;
 import org.junit.jupiter.api.Test;
 
 public class KafkaSourceTest {
@@ -20,7 +25,21 @@ public class KafkaSourceTest {
   public void testAvroformat() throws IOException {
     final JsonNode configJson = Jsons.deserialize(MoreResources.readResource("test_config.json"));
     final KafkaFormat kafkaFormat = KafkaFormatFactory.getFormat(configJson);
+//    AutoCloseableIterator<AirbyteMessage> message = kafkaFormat.read();
+//    AirbyteMessage mesag = message.next();
     assertInstanceOf(AvroFormat.class, kafkaFormat);
   }
+
+//  @Test
+//  public void testAvroMessage() throws Exception {
+//    final JsonNode configJson = Jsons.deserialize(MoreResources.readResource("test_config.json"));
+//    final Source source = new KafkaSource();
+//    source.discover(configJson);
+//
+//  }
+
+
+
+
 
 }


### PR DESCRIPTION
## What
Fetch the avro schema from schema registry for each topic and save the schema in the Airbyte Catalog. 

## How
In the discovery method call a Schema Registry to fetch the correct schema message with an API Confluent, and after transform it in the Json format and save in the Airbyte Catalog.

## Recommended reading order
1. `x.java`
2. `y.python`

## 🚨 User Impact 🚨
*Are there any breaking changes? What is the end result perceived by the user?*

*For connector PRs, use this section to explain which type of semantic versioning bump occurs as a result of the changes. Refer to our [Semantic Versioning for Connectors](https://docs.airbyte.com/contributing-to-airbyte/#semantic-versioning-for-connectors) guidelines for more information. **Breaking changes to connectors must be documented by an Airbyte engineer (PR author, or reviewer for community PRs) by using the [Breaking Change Release Playbook](https://docs.google.com/document/d/1VYQggHbL_PN0dDDu7rCyzBLGRtX-R3cpwXaY8QxEgzw/edit).***

*If there are breaking changes, please merge this PR with the 🚨🚨 emoji so changelog authors can further highlight this if needed.*


## Pre-merge Actions
*Expand the relevant checklist and delete the others.*

<details><summary><strong>New Connector</strong></summary>

### Community member or Airbyter

- **Community member?** Grant edit access to maintainers ([instructions](https://docs.github.com/en/github/collaborating-with-pull-requests/working-with-forks/allowing-changes-to-a-pull-request-branch-created-from-a-fork#enabling-repository-maintainer-permissions-on-existing-pull-requests))
- Unit & integration tests added and passing. Community members, please provide proof of success locally e.g: screenshot or copy-paste unit, integration, and acceptance test output. To run acceptance tests for a Python connector, follow instructions in the README. For java connectors run `./gradlew :airbyte-integrations:connectors:<name>:integrationTest`.
- Connector version is set to `0.0.1`
    - `Dockerfile` has version `0.0.1`
- Documentation updated
    - Connector's `README.md`
    - Connector's `bootstrap.md`. See [description and examples](https://docs.google.com/document/d/1ypdgmwmEHWv-TrO4_YOQ7pAJGVrMp5BOkEVh831N260/edit?usp=sharing)
    - `docs/integrations/<source or destination>/<name>.md` including changelog with an entry for the initial version. See changelog [example](https://docs.airbyte.io/integrations/sources/stripe#changelog)
    - `docs/integrations/README.md`

### Airbyter

If this is a community PR, the Airbyte engineer reviewing this PR is responsible for the below items.

- Create a non-forked branch based on this PR and test the below items on it
- Build is successful
- If new credentials are required for use in CI, add them to GSM. [Instructions](https://docs.airbyte.io/connector-development#using-credentials-in-ci).

</details>

<details><summary><strong>Updating a connector</strong></summary>

### Community member or Airbyter

- Grant edit access to maintainers ([instructions](https://docs.github.com/en/github/collaborating-with-pull-requests/working-with-forks/allowing-changes-to-a-pull-request-branch-created-from-a-fork#enabling-repository-maintainer-permissions-on-existing-pull-requests))
- Unit & integration tests added


### Airbyter

If this is a community PR, the Airbyte engineer reviewing this PR is responsible for the below items.

- Create a non-forked branch based on this PR and test the below items on it
- Build is successful
- If new credentials are required for use in CI, add them to GSM. [Instructions](https://docs.airbyte.io/connector-development#using-credentials-in-ci).

</details>

<details><summary><strong>Connector Generator</strong></summary>

- Issue acceptance criteria met
- PR name follows [PR naming conventions](https://docs.airbyte.com/contributing-to-airbyte/issues-and-pull-requests#pull-request-title-convention)
- If adding a new generator, add it to the [list of scaffold modules being tested](https://github.com/airbytehq/airbyte/blob/master/airbyte-integrations/connector-templates/generator/build.gradle#L41)
- The generator test modules (all connectors with `-scaffold` in their name) have been updated with the latest scaffold by running `./gradlew :airbyte-integrations:connector-templates:generator:testScaffoldTemplates` then checking in your changes
- Documentation which references the generator is updated as needed

</details>
