### PR TITLE
📝 Fix broken connector documentation links

### DIFF
--- a/airbyte-integrations/connectors/destination-azure-blob-storage/metadata.yaml
+++ b/airbyte-integrations/connectors/destination-azure-blob-storage/metadata.yaml
@@ -20,7 +20,7 @@ data:
         resourceRequirements:
           memory_limit: 1Gi
           memory_request: 1Gi
-  documentationUrl: https://docs.airbyte.com/integrations/destinations/azureblobstorage
+  documentationUrl: https://docs.airbyte.com/integrations/destinations/azure-blob-storage
   tags:
     - language:java
 metadataSpecVersion: "1.0"

--- a/airbyte-integrations/connectors/destination-csv/metadata.yaml
+++ b/airbyte-integrations/connectors/destination-csv/metadata.yaml
@@ -14,7 +14,7 @@ data:
     oss:
       enabled: true
   releaseStage: alpha
-  documentationUrl: https://docs.airbyte.com/integrations/destinations/local-csv
+  documentationUrl: https://docs.airbyte.com/integrations/destinations/csv
   tags:
     - language:java
 metadataSpecVersion: "1.0"

--- a/airbyte-integrations/connectors/destination-sqlite/metadata.yaml
+++ b/airbyte-integrations/connectors/destination-sqlite/metadata.yaml
@@ -14,7 +14,7 @@ data:
     oss:
       enabled: true
   releaseStage: alpha
-  documentationUrl: https://docs.airbyte.com/integrations/destinations/local-sqlite
+  documentationUrl: https://docs.airbyte.com/integrations/destinations/sqlite
   tags:
     - language:python
 metadataSpecVersion: "1.0"

--- a/airbyte-integrations/connectors/source-clickup-api/metadata.yaml
+++ b/airbyte-integrations/connectors/source-clickup-api/metadata.yaml
@@ -14,7 +14,7 @@ data:
     oss:
       enabled: true
   releaseStage: alpha
-  documentationUrl: https://docs.airbyte.com/integrations/sources/click-up
+  documentationUrl: https://docs.airbyte.com/integrations/sources/clickup-api
   tags:
     - language:low-code
     - language:python

--- a/airbyte-integrations/connectors/source-exchange-rates/metadata.yaml
+++ b/airbyte-integrations/connectors/source-exchange-rates/metadata.yaml
@@ -18,7 +18,7 @@ data:
     oss:
       enabled: true
   releaseStage: alpha
-  documentationUrl: https://docs.airbyte.com/integrations/sources/exchangeratesapi
+  documentationUrl: https://docs.airbyte.com/integrations/sources/exchange-rates
   tags:
     - language:python
 metadataSpecVersion: "1.0"

--- a/airbyte-integrations/connectors/source-hellobaton/metadata.yaml
+++ b/airbyte-integrations/connectors/source-hellobaton/metadata.yaml
@@ -14,7 +14,7 @@ data:
     oss:
       enabled: true
   releaseStage: alpha
-  documentationUrl: https://docs.airbyte.com/integrations/sources/hellobaton
+  documentationUrl: https://docs.airbyte.com/integrations/sources/baton
   tags:
     - language:python
 metadataSpecVersion: "1.0"

--- a/airbyte-integrations/connectors/source-kustomer-singer/metadata.yaml
+++ b/airbyte-integrations/connectors/source-kustomer-singer/metadata.yaml
@@ -14,7 +14,7 @@ data:
     oss:
       enabled: true
   releaseStage: alpha
-  documentationUrl: https://docs.airbyte.com/integrations/sources/kustomer
+  documentationUrl: https://docs.airbyte.com/integrations/sources/kustomer-singer
   tags:
     - language:python
 metadataSpecVersion: "1.0"

--- a/airbyte-integrations/connectors/source-qonto/metadata.yaml
+++ b/airbyte-integrations/connectors/source-qonto/metadata.yaml
@@ -14,7 +14,7 @@ data:
     oss:
       enabled: true
   releaseStage: alpha
-  documentationUrl: https://docs.airbyte.com/integrations/sources/public-qonto
+  documentationUrl: https://docs.airbyte.com/integrations/sources/qonto
   tags:
     - language:python
 metadataSpecVersion: "1.0"

--- a/airbyte-integrations/connectors/source-zapier-supported-storage/metadata.yaml
+++ b/airbyte-integrations/connectors/source-zapier-supported-storage/metadata.yaml
@@ -14,7 +14,7 @@ data:
     oss:
       enabled: true
   releaseStage: alpha
-  documentationUrl: https://docs.airbyte.com/integrations/sources/zendesk-supported-storage
+  documentationUrl: https://docs.airbyte.com/integrations/sources/zapier-supported-storage
   tags:
     - language:low-code
     - language:python


### PR DESCRIPTION
## What
Fixes broken doc links in `metadata.yml` files, which resulted in the docs not displaying correctly in-app or in the [connector catalog](https://docs.airbyte.com/integrations/) for the following connectors:

- `source/clickup` (cloud)
- `source/exchange-rates` (cloud)
- `source/hello-baton`
- `source/kustomer` (cloud)
- `source/qonto`
- `source/zapier-supported-storage`
- `destination/local-csv`
- `destination/local-sqlite`
- `destination/azure-blob-storage` (cloud)

I'm assuming we don't need to bump connector versions for this, but please lmk if that's not the case!
