### PR TITLE
🐛 Source facebook-marketing: Pin FB marketing to 0.4.0 on Cloud

### DIFF
--- a/airbyte-integrations/connectors/source-facebook-marketing/metadata.yaml
+++ b/airbyte-integrations/connectors/source-facebook-marketing/metadata.yaml
@@ -14,6 +14,7 @@ data:
   registries:
     cloud:
       enabled: true
+      dockerImageTag: 0.4.0 # pinned because of reasons
     oss:
       enabled: true
   releaseStage: generally_available

--- a/airbyte-integrations/connectors/source-facebook-marketing/metadata.yaml
+++ b/airbyte-integrations/connectors/source-facebook-marketing/metadata.yaml
@@ -14,7 +14,7 @@ data:
   registries:
     cloud:
       enabled: true
-      dockerImageTag: 0.4.0 # pinned because of reasons
+      dockerImageTag: 0.4.0 # pinned because of OC#2239
     oss:
       enabled: true
   releaseStage: generally_available


### PR DESCRIPTION
## What
[This PR](https://github.com/airbytehq/airbyte/pull/26941) seems to be preventing users from saving changes or retesting their existing Source