### PR TITLE
source-file: bump version in metadata.yaml

### DIFF
--- a/airbyte-integrations/connectors/source-file/metadata.yaml
+++ b/airbyte-integrations/connectors/source-file/metadata.yaml
@@ -5,7 +5,7 @@ data:
   connectorSubtype: file
   connectorType: source
   definitionId: 778daa7c-feaf-4db6-96f3-70fd645acc77
-  dockerImageTag: 0.3.10
+  dockerImageTag: 0.3.11
   dockerRepository: airbyte/source-file
   githubIssueLabel: source-file
   icon: file.svg


### PR DESCRIPTION
## What
The `dockerImageTag` of `source-file` in `metadata.yaml` does not match with the dockerfile.
`source-file-secure` was correctly published and bumped to 0.3.11 in previous PR but source-file was not bumped in metadata, so `source-file` 0.3.11 was not published.
