### PR TITLE
connector_ci: more granular mgmt of concurrency

### DIFF
--- a/tools/ci_connector_ops/ci_connector_ops/pipelines/commands/groups/connectors.py
+++ b/tools/ci_connector_ops/ci_connector_ops/pipelines/commands/groups/connectors.py
@@ -223,30 +223,13 @@ def test(
     try:
         anyio.run(
             run_connectors_pipelines,
-            [
-                connector_context
-                for connector_context in connectors_tests_contexts
-                if connector_context.connector.language != ConnectorLanguage.JAVA
-            ],
+            [connector_context for connector_context in connectors_tests_contexts],
             run_connector_test_pipeline,
             "Test Pipeline",
             ctx.obj["concurrency"],
             ctx.obj["execute_timeout"],
         )
-        # We run the Java connectors tests sequentially because we currently have memory issues when Java integration tests are run in parallel.
-        # See https://github.com/airbytehq/airbyte/issues/27168
-        anyio.run(
-            run_connectors_pipelines,
-            [
-                connector_context
-                for connector_context in connectors_tests_contexts
-                if connector_context.connector.language == ConnectorLanguage.JAVA
-            ],
-            run_connector_test_pipeline,
-            "Test Pipeline",
-            1,
-            ctx.obj["execute_timeout"],
-        )
+
     except Exception as e:
         click.secho(str(e), err=True, fg="red")
         update_global_commit_status_check_for_tests(ctx.obj, "failure")


### PR DESCRIPTION
## What
With current implementation `run_connectors_pipelines` is called twice: once for python connector, another time for java connectors with forced concurrency.
It's problematic because the `run_connectors_pipelines` uploads the `complete.json` file which should be a singleton aggregating all the connector test reports.
This PR slightly changes the logic. 
We call `run_connectors_pipelines` but use different semaphore object according to connector language. Concurrency is forced to 1 for Java connectors.

It has the following impact:
Only a single java connectors is tested at a time, but multiple python connectors can be tested in parallel.
Python and Java connectors are now tested concurrently, not Python connectors first, then Java connectors.

