### PR TITLE
Update connector builder docs for auto-import schema change

### DIFF
--- a/docs/connector-development/connector-builder-ui/record-processing.mdx
+++ b/docs/connector-development/connector-builder-ui/record-processing.mdx
@@ -1,39 +1,27 @@
-import Diff from "./assets/record-processing-schema-diff.png";
+import Diff from './assets/record-processing-schema-diff.png';
 
 # Record processing
 
 Connectors built with the connector builder always make HTTP requests, receive the responses and emit records. Besides making the right requests, it's important to properly hand over the records to the system:
-
-- Extract the records (record selection)
-- Do optional post-processing (transformations)
-- Provide record meta data to the system to inform downstream processes (primary key and declared schema)
+* Extract the records (record selection)
+* Do optional post-processing (transformations)
+* Provide record meta data to the system to inform downstream processes (primary key and declared schema)
 
 ## Record selection
 
-<iframe
-  width="640"
-  height="393"
-  src="https://www.loom.com/embed/06d0fe35d79b40c5b1aea29a7fa7f113"
-  frameborder="0"
-  webkitallowfullscreen
-  mozallowfullscreen
-  allowfullscreen
-></iframe>
+<iframe width="640" height="393" src="https://www.loom.com/embed/06d0fe35d79b40c5b1aea29a7fa7f113" frameborder="0" webkitallowfullscreen mozallowfullscreen allowfullscreen></iframe>
 
 When doing HTTP requests, the connector expects the records to be part of the response JSON body. The "Record selector" field of the stream needs to be set to the property of the response object that holds the records.
 
 Very often, the response body contains an array of records along with some suplementary information (for example meta data for pagination).
 
 For example the ["Most popular" NY Times API](https://developer.nytimes.com/docs/most-popular-product/1/overview) returns the following response body:
-
 <pre>
-  {`{
+{`{
     "status": "OK",
     "copyright": "Copyright (c) 2023 The New York Times Company.  All Rights Reserved.",
     "num_results": 20,
-    `}
-  <b>{`"results": [`}</b>
-  {`
+    `}<b>{`"results": [`}</b>{`
       {
         "uri": "nyt://article/c15e5227-ed68-54d9-9e5b-acf5a451ec37",
         "url": "https://www.nytimes.com/2023/04/16/us/science-of-reading-literacy-parents.html",
@@ -43,9 +31,7 @@ For example the ["Most popular" NY Times API](https://developer.nytimes.com/docs
         // ...
       },
       // ..
-    `}
-  <b>{`]`}</b>
-  {`,
+    `}<b>{`]`}</b>{`,
     // ...
 }`}
 </pre>
@@ -55,14 +41,11 @@ For example the ["Most popular" NY Times API](https://developer.nytimes.com/docs
 ### Nested objects
 
 In some cases the array of actual records is nested multiple levels deep in the response, like for the ["Archive" NY Times API](https://developer.nytimes.com/docs/archive-product/1/overview):
-
 <pre>
-  {`{
+{`{
     "copyright": "Copyright (c) 2020 The New York Times Company. All Rights Reserved.",
     "response": {
-      `}
-  <b>{`"docs": [`}</b>
-  {`
+      `}<b>{`"docs": [`}</b>{`
         {
           "abstract": "From the Treaty of Versailles to Prohibition, the events of that year shaped America, and the world, for a century to come. ",
           "web_url": "https://www.nytimes.com/2018/12/31/opinion/1919-america.html",
@@ -70,11 +53,9 @@ In some cases the array of actual records is nested multiple levels deep in the 
           // ...
         },
         // ...
-      `}
-  <b>{`]`}</b>
-  {`
+      `}<b>{`]`}</b>{`
     }
-}`}
+}`}    
 </pre>
 
 **Setting the record selector needs to be set to "`response`,`docs`"** selects the nested array.
@@ -82,10 +63,8 @@ In some cases the array of actual records is nested multiple levels deep in the 
 ### Root array
 
 In some cases, the response body itself is an array of records, like in the [CoinAPI API](https://docs.coinapi.io/market-data/rest-api/quotes):
-
 <pre>
-  <b>{`[`}</b>
-  {`
+<b>{`[`}</b>{`
   {
     "symbol_id": "BITSTAMP_SPOT_BTC_USD",
     "time_exchange": "2013-09-28T22:40:50.0000000Z",
@@ -99,8 +78,7 @@ In some cases, the response body itself is an array of records, like in the [Coi
    // ..
   }
   // ...
-`}
-  <b>{`]`}</b>
+`}<b>{`]`}</b>
 </pre>
 
 In this case, **the record selector can be omitted** and the whole response becomes the list of records.
@@ -108,23 +86,18 @@ In this case, **the record selector can be omitted** and the whole response beco
 ### Single object
 
 Sometimes, there is only one record returned per request from the API. In this case, the record selector can also point to an object instead of an array which will be handled as the only record, like in the case of the [Exchange Rates API](https://exchangeratesapi.io/documentation/#historicalrates):
-
 <pre>
-  {`{
+{`{
     "success": true,
     "historical": true,
     "date": "2013-12-24",
     "timestamp": 1387929599,
     "base": "GBP",
-    `}
-  <b>{`"rates": {`}</b>
-  {`
+    `}<b>{`"rates": {`}</b>{`
         "USD": 1.636492,
         "EUR": 1.196476,
         "CAD": 1.739516
-    `}
-  <b>{`}`}</b>
-  {`
+    `}<b>{`}`}</b>{`
 }`}
 </pre>
 
@@ -169,27 +142,17 @@ In this case a record selector with a placeholder `*` selects all children at th
 ## Transformations
 
 It is recommended to not change records during the extraction process the connector is performing, but instead load them into the downstream warehouse unchanged and perform necessary transformations there in order to stay flexible in what data is required. However there are some reasons that require the modifying the fields of records before they are sent to the warehouse:
-
-- Remove personally identifiable information (PII) to ensure compliance with local legislation
-- Pseudonymise sensitive fields
-- Remove large fields that don't contain interesting information and significantly increase load on the system
+* Remove personally identifiable information (PII) to ensure compliance with local legislation
+* Pseudonymise sensitive fields
+* Remove large fields that don't contain interesting information and significantly increase load on the system
 
 The "transformations" feature can be used for these purposes.
 
 ### Removing fields
 
-<iframe
-  width="640"
-  height="538"
-  src="https://www.loom.com/embed/8dca8feaa54f49848667d3fd5b945372"
-  frameborder="0"
-  webkitallowfullscreen
-  mozallowfullscreen
-  allowfullscreen
-></iframe>
+<iframe width="640" height="538" src="https://www.loom.com/embed/8dca8feaa54f49848667d3fd5b945372" frameborder="0" webkitallowfullscreen mozallowfullscreen allowfullscreen></iframe>
 
 To remove a field from a record, add a new transformation in the "Transformations" section of type "remove" and enter the field path. For example in case of the [EmailOctopus API](https://emailoctopus.com/api-documentation/campaigns/get-all), the campaigns records also include the html content of the mailing which takes up a lot of space:
-
 ```
 {
     "data": [
@@ -214,7 +177,6 @@ To remove a field from a record, add a new transformation in the "Transformation
 ```
 
 Setting the "Path" of the remove-transformation to `content` removes these fields from the records:
-
 ```
 {
     "id": "00000000-0000-0000-0000-000000000000",
@@ -250,7 +212,6 @@ Imagine that regardless of which level a properties appears, it should be remove
 ```
 
 The `*` character can also be used as a placeholder to filter for all fields that start with a certain prefix - the "Path" `s*` will remove all fields from the top level that start with the character s:
-
 ```
 {
     "id": "00000000-0000-0000-0000-000000000000",
@@ -261,20 +222,12 @@ The `*` character can also be used as a placeholder to filter for all fields tha
 }
 ```
 
+
 ### Adding fields
 
-<iframe
-  width="640"
-  height="409"
-  src="https://www.loom.com/embed/ab3b72cafb734112b645607ab6d1ab1f"
-  frameborder="0"
-  webkitallowfullscreen
-  mozallowfullscreen
-  allowfullscreen
-></iframe>
+<iframe width="640" height="409" src="https://www.loom.com/embed/ab3b72cafb734112b645607ab6d1ab1f" frameborder="0" webkitallowfullscreen mozallowfullscreen allowfullscreen></iframe>
 
 Adding fields can be used to apply a hashing function to an existing field to pseudonymize it. To do this, add a new transformation in the "Transformations" section of type "add" and enter the field path and the new value. For example in case of the [EmailOctopus API](https://emailoctopus.com/api-documentation/campaigns/get-all), the campaigns records include the name of the sender:
-
 ```
 {
     "data": [
@@ -295,7 +248,6 @@ Adding fields can be used to apply a hashing function to an existing field to ps
 ```
 
 To apply a hash function to it, set the "Path" to "`from`, `name`" to select the name property nested in the from object and set the value to `{{ record['from']['name'] | hash('md5') }}`. This hashes the name in the record:
-
 ```
 {
     "id": "00000000-0000-0000-0000-000000000000",
@@ -326,7 +278,6 @@ The "Primary key" field specifies how to uniquely identify a record. This is imp
 In a lot of cases, like for the EmailOctopus example from above, there is a dedicated id field that can be used for this purpose. It's important that the value of the id field is guaranteed to only occur once for a single record.
 
 In some cases there is no such field but a combination of multiple fields is guaranteed to be unique, for example the shipping zone locations of the [Woocommerce API](https://woocommerce.github.io/woocommerce-rest-api-docs/#shipping-zone-locations) do not have an id, but each combination of the `code` and `type` fields is guaranteed to be unique:
-
 ```
 [
   {
@@ -347,16 +298,14 @@ In this case, the "Primary key" can be set to "`code`, `type`" to allow automati
 Similar to the "Primary key", the "Declared schema" defines how the records will be shaped via a [JSON Schema definition](https://json-schema.org/). It defines which fields and nested fields occur in the records, whether they are always available or sometimes missing and which types they are.
 
 This information is used by the Airbyte system for different purposes:
-
-- **Column selection** when configuring a connection - in Airbyte cloud, the declared schema allows the user to pick which columns/fields are passed to the destination to dynamically reduce the amount of synced data
-- **Recreating the data structure with right columns** in destination - this allows a warehouse destination to create a SQL table which the columns matching the fields of records
-- **Detecting schema changes** - if the schema of a stream changes for an existing connection, this situation can be handled gracefully by Airbyte instead of causing errors in the destination
+* **Column selection** when configuring a connection - in Airbyte cloud, the declared schema allows the user to pick which columns/fields are passed to the destination to dynamically reduce the amount of synced data
+* **Recreating the data structure with right columns** in destination - this allows a warehouse destination to create a SQL table which the columns matching the fields of records
+* **Detecting schema changes** - if the schema of a stream changes for an existing connection, this situation can be handled gracefully by Airbyte instead of causing errors in the destination
 
 When doing test reads, the connector builder analyzes the test records and shows the derived schema in the "Detected schema" tab. By default, new streams are configured to automatically import the detected schema into the declared schema on every test read.
 This behavior can be toggled off by disabling the `Automatically import declared schema` switch, in which case the declared schema can be manually edited in the UI and it will no longer be automatically updated when triggering test reads.
 
 For example the following test records:
-
 ```
 [
   {
@@ -377,7 +326,6 @@ For example the following test records:
 ```
 
 result in the following schema:
-
 ```
 {
   "$schema": "http://json-schema.org/schema#",
@@ -406,14 +354,9 @@ More strict is always better, but the detected schema is a good default to rely 
 
 If `Automatically import detected schema` is disabled, and the declared schema deviates from the detected schema, the "Detected schema" tab in the testing panel highlights the differences. It's important to note that differences are not necessarily a problem that needs to be fixed - in some cases the currently loaded set of records in the testing panel doesn't feature all possible cases so the detected schema is too strict. However, if the declared schema is incompatible with the detected schema based on the test records, it's very likely there will be errors when running syncs.
 
-<img
-  src={Diff}
-  width="600"
-  alt="Detected schema with highlighted differences"
-/>
+<img src={Diff} width="600" alt="Detected schema with highlighted differences" />
 
 In the case of the example above, there are two differences between detected and declared schema. The first difference for the `name` field is not problematic:
-
 ```
      "name": {
 -      "type": [
@@ -427,7 +370,6 @@ In the case of the example above, there are two differences between detected and
 The declared schema allows the `null` value for the name while the detected schema only encountered strings. If it's possible the `name` is set to null, the detected schema is configured correctly.
 
 The second difference will likely cause problems:
-
 ```
      "subject": {
 -      "type": "number"
@@ -436,8 +378,7 @@ The second difference will likely cause problems:
 ```
 
 The `subject` field was detected as `string`, but is configured to be a `number` in the declared schema. As the API returned string subjects during testing, it's likely this will also happen during syncs which would render the declared schema inaccurate. Depending on the situation this can be fixed in multiple ways:
-
-- If the API changed and subject is always a string now, the declared schema should be updated to reflect this: `"subject": { "type": "string" }`
-- If the API is sometimes returning subject as number of string depending on the record, the declared schema should be updated to allow both data types: `"subject": { "type": ["string","number"] }`
+* If the API changed and subject is always a string now, the declared schema should be updated to reflect this: `"subject": { "type": "string" }`
+* If the API is sometimes returning subject as number of string depending on the record, the declared schema should be updated to allow both data types: `"subject": { "type": ["string","number"] }`
 
 A common situation is that certain record fields do not have any any values for the test read data, so they are set to `null`. In the detected schema, these field are of type `"null"` which is most likely not correct for all cases. In these situations, the declared schema should be manually corrected.

--- a/docs/connector-development/connector-builder-ui/record-processing.mdx
+++ b/docs/connector-development/connector-builder-ui/record-processing.mdx
@@ -1,27 +1,39 @@
-import Diff from './assets/record-processing-schema-diff.png';
+import Diff from "./assets/record-processing-schema-diff.png";
 
 # Record processing
 
 Connectors built with the connector builder always make HTTP requests, receive the responses and emit records. Besides making the right requests, it's important to properly hand over the records to the system:
-* Extract the records (record selection)
-* Do optional post-processing (transformations)
-* Provide record meta data to the system to inform downstream processes (primary key and declared schema)
+
+- Extract the records (record selection)
+- Do optional post-processing (transformations)
+- Provide record meta data to the system to inform downstream processes (primary key and declared schema)
 
 ## Record selection
 
-<iframe width="640" height="393" src="https://www.loom.com/embed/06d0fe35d79b40c5b1aea29a7fa7f113" frameborder="0" webkitallowfullscreen mozallowfullscreen allowfullscreen></iframe>
+<iframe
+  width="640"
+  height="393"
+  src="https://www.loom.com/embed/06d0fe35d79b40c5b1aea29a7fa7f113"
+  frameborder="0"
+  webkitallowfullscreen
+  mozallowfullscreen
+  allowfullscreen
+></iframe>
 
 When doing HTTP requests, the connector expects the records to be part of the response JSON body. The "Record selector" field of the stream needs to be set to the property of the response object that holds the records.
 
 Very often, the response body contains an array of records along with some suplementary information (for example meta data for pagination).
 
 For example the ["Most popular" NY Times API](https://developer.nytimes.com/docs/most-popular-product/1/overview) returns the following response body:
+
 <pre>
-{`{
+  {`{
     "status": "OK",
     "copyright": "Copyright (c) 2023 The New York Times Company.  All Rights Reserved.",
     "num_results": 20,
-    `}<b>{`"results": [`}</b>{`
+    `}
+  <b>{`"results": [`}</b>
+  {`
       {
         "uri": "nyt://article/c15e5227-ed68-54d9-9e5b-acf5a451ec37",
         "url": "https://www.nytimes.com/2023/04/16/us/science-of-reading-literacy-parents.html",
@@ -31,7 +43,9 @@ For example the ["Most popular" NY Times API](https://developer.nytimes.com/docs
         // ...
       },
       // ..
-    `}<b>{`]`}</b>{`,
+    `}
+  <b>{`]`}</b>
+  {`,
     // ...
 }`}
 </pre>
@@ -41,11 +55,14 @@ For example the ["Most popular" NY Times API](https://developer.nytimes.com/docs
 ### Nested objects
 
 In some cases the array of actual records is nested multiple levels deep in the response, like for the ["Archive" NY Times API](https://developer.nytimes.com/docs/archive-product/1/overview):
+
 <pre>
-{`{
+  {`{
     "copyright": "Copyright (c) 2020 The New York Times Company. All Rights Reserved.",
     "response": {
-      `}<b>{`"docs": [`}</b>{`
+      `}
+  <b>{`"docs": [`}</b>
+  {`
         {
           "abstract": "From the Treaty of Versailles to Prohibition, the events of that year shaped America, and the world, for a century to come. ",
           "web_url": "https://www.nytimes.com/2018/12/31/opinion/1919-america.html",
@@ -53,9 +70,11 @@ In some cases the array of actual records is nested multiple levels deep in the 
           // ...
         },
         // ...
-      `}<b>{`]`}</b>{`
+      `}
+  <b>{`]`}</b>
+  {`
     }
-}`}    
+}`}
 </pre>
 
 **Setting the record selector needs to be set to "`response`,`docs`"** selects the nested array.
@@ -63,8 +82,10 @@ In some cases the array of actual records is nested multiple levels deep in the 
 ### Root array
 
 In some cases, the response body itself is an array of records, like in the [CoinAPI API](https://docs.coinapi.io/market-data/rest-api/quotes):
+
 <pre>
-<b>{`[`}</b>{`
+  <b>{`[`}</b>
+  {`
   {
     "symbol_id": "BITSTAMP_SPOT_BTC_USD",
     "time_exchange": "2013-09-28T22:40:50.0000000Z",
@@ -78,7 +99,8 @@ In some cases, the response body itself is an array of records, like in the [Coi
    // ..
   }
   // ...
-`}<b>{`]`}</b>
+`}
+  <b>{`]`}</b>
 </pre>
 
 In this case, **the record selector can be omitted** and the whole response becomes the list of records.
@@ -86,18 +108,23 @@ In this case, **the record selector can be omitted** and the whole response beco
 ### Single object
 
 Sometimes, there is only one record returned per request from the API. In this case, the record selector can also point to an object instead of an array which will be handled as the only record, like in the case of the [Exchange Rates API](https://exchangeratesapi.io/documentation/#historicalrates):
+
 <pre>
-{`{
+  {`{
     "success": true,
     "historical": true,
     "date": "2013-12-24",
     "timestamp": 1387929599,
     "base": "GBP",
-    `}<b>{`"rates": {`}</b>{`
+    `}
+  <b>{`"rates": {`}</b>
+  {`
         "USD": 1.636492,
         "EUR": 1.196476,
         "CAD": 1.739516
-    `}<b>{`}`}</b>{`
+    `}
+  <b>{`}`}</b>
+  {`
 }`}
 </pre>
 
@@ -142,17 +169,27 @@ In this case a record selector with a placeholder `*` selects all children at th
 ## Transformations
 
 It is recommended to not change records during the extraction process the connector is performing, but instead load them into the downstream warehouse unchanged and perform necessary transformations there in order to stay flexible in what data is required. However there are some reasons that require the modifying the fields of records before they are sent to the warehouse:
-* Remove personally identifiable information (PII) to ensure compliance with local legislation
-* Pseudonymise sensitive fields
-* Remove large fields that don't contain interesting information and significantly increase load on the system
+
+- Remove personally identifiable information (PII) to ensure compliance with local legislation
+- Pseudonymise sensitive fields
+- Remove large fields that don't contain interesting information and significantly increase load on the system
 
 The "transformations" feature can be used for these purposes.
 
 ### Removing fields
 
-<iframe width="640" height="538" src="https://www.loom.com/embed/8dca8feaa54f49848667d3fd5b945372" frameborder="0" webkitallowfullscreen mozallowfullscreen allowfullscreen></iframe>
+<iframe
+  width="640"
+  height="538"
+  src="https://www.loom.com/embed/8dca8feaa54f49848667d3fd5b945372"
+  frameborder="0"
+  webkitallowfullscreen
+  mozallowfullscreen
+  allowfullscreen
+></iframe>
 
 To remove a field from a record, add a new transformation in the "Transformations" section of type "remove" and enter the field path. For example in case of the [EmailOctopus API](https://emailoctopus.com/api-documentation/campaigns/get-all), the campaigns records also include the html content of the mailing which takes up a lot of space:
+
 ```
 {
     "data": [
@@ -177,6 +214,7 @@ To remove a field from a record, add a new transformation in the "Transformation
 ```
 
 Setting the "Path" of the remove-transformation to `content` removes these fields from the records:
+
 ```
 {
     "id": "00000000-0000-0000-0000-000000000000",
@@ -212,6 +250,7 @@ Imagine that regardless of which level a properties appears, it should be remove
 ```
 
 The `*` character can also be used as a placeholder to filter for all fields that start with a certain prefix - the "Path" `s*` will remove all fields from the top level that start with the character s:
+
 ```
 {
     "id": "00000000-0000-0000-0000-000000000000",
@@ -222,12 +261,20 @@ The `*` character can also be used as a placeholder to filter for all fields tha
 }
 ```
 
-
 ### Adding fields
 
-<iframe width="640" height="409" src="https://www.loom.com/embed/ab3b72cafb734112b645607ab6d1ab1f" frameborder="0" webkitallowfullscreen mozallowfullscreen allowfullscreen></iframe>
+<iframe
+  width="640"
+  height="409"
+  src="https://www.loom.com/embed/ab3b72cafb734112b645607ab6d1ab1f"
+  frameborder="0"
+  webkitallowfullscreen
+  mozallowfullscreen
+  allowfullscreen
+></iframe>
 
 Adding fields can be used to apply a hashing function to an existing field to pseudonymize it. To do this, add a new transformation in the "Transformations" section of type "add" and enter the field path and the new value. For example in case of the [EmailOctopus API](https://emailoctopus.com/api-documentation/campaigns/get-all), the campaigns records include the name of the sender:
+
 ```
 {
     "data": [
@@ -248,6 +295,7 @@ Adding fields can be used to apply a hashing function to an existing field to ps
 ```
 
 To apply a hash function to it, set the "Path" to "`from`, `name`" to select the name property nested in the from object and set the value to `{{ record['from']['name'] | hash('md5') }}`. This hashes the name in the record:
+
 ```
 {
     "id": "00000000-0000-0000-0000-000000000000",
@@ -278,6 +326,7 @@ The "Primary key" field specifies how to uniquely identify a record. This is imp
 In a lot of cases, like for the EmailOctopus example from above, there is a dedicated id field that can be used for this purpose. It's important that the value of the id field is guaranteed to only occur once for a single record.
 
 In some cases there is no such field but a combination of multiple fields is guaranteed to be unique, for example the shipping zone locations of the [Woocommerce API](https://woocommerce.github.io/woocommerce-rest-api-docs/#shipping-zone-locations) do not have an id, but each combination of the `code` and `type` fields is guaranteed to be unique:
+
 ```
 [
   {
@@ -298,13 +347,16 @@ In this case, the "Primary key" can be set to "`code`, `type`" to allow automati
 Similar to the "Primary key", the "Declared schema" defines how the records will be shaped via a [JSON Schema definition](https://json-schema.org/). It defines which fields and nested fields occur in the records, whether they are always available or sometimes missing and which types they are.
 
 This information is used by the Airbyte system for different purposes:
-* **Column selection** when configuring a connection - in Airbyte cloud, the declared schema allows the user to pick which columns/fields are passed to the destination to dynamically reduce the amount of synced data
-* **Recreating the data structure with right columns** in destination - this allows a warehouse destination to create a SQL table which the columns matching the fields of records
-* **Detecting schema changes** - if the schema of a stream changes for an existing connection, this situation can be handled gracefully by Airbyte instead of causing errors in the destination
 
-When doing test reads, the connector builder analyzes the test records and shows the derived schema in the "Detected schema" tab. This schema can be copied over as the declared schema of the stream with a single click.
+- **Column selection** when configuring a connection - in Airbyte cloud, the declared schema allows the user to pick which columns/fields are passed to the destination to dynamically reduce the amount of synced data
+- **Recreating the data structure with right columns** in destination - this allows a warehouse destination to create a SQL table which the columns matching the fields of records
+- **Detecting schema changes** - if the schema of a stream changes for an existing connection, this situation can be handled gracefully by Airbyte instead of causing errors in the destination
+
+When doing test reads, the connector builder analyzes the test records and shows the derived schema in the "Detected schema" tab. By default, new streams are configured to automatically import the detected schema into the declared schema on every test read.
+This behavior can be toggled off by disabling the `Automatically import declared schema` switch, in which case the declared schema can be manually edited in the UI and it will no longer be automatically updated when triggering test reads.
 
 For example the following test records:
+
 ```
 [
   {
@@ -325,6 +377,7 @@ For example the following test records:
 ```
 
 result in the following schema:
+
 ```
 {
   "$schema": "http://json-schema.org/schema#",
@@ -351,11 +404,16 @@ result in the following schema:
 
 More strict is always better, but the detected schema is a good default to rely on. See the documentation about [supported data types](https://docs.airbyte.com/understanding-airbyte/supported-data-types/) for JSON schema structures that will be picked up by the Airbyte system.
 
-In case the declared schema deviates from the detected schema, the "Detected schema" tab in the testing panel highlights the differences. It's important to note that differences are not necessarily a problem that needs to be fixed - in some cases the currently loaded set of records in the testing panel doesn't feature all possible cases so the detected schema is too strict. However, if the declared schema is incompatible with the detected schema based on the test records, it's very likely there will be errors when running syncs.
+If `Automatically import detected schema` is disabled, and the declared schema deviates from the detected schema, the "Detected schema" tab in the testing panel highlights the differences. It's important to note that differences are not necessarily a problem that needs to be fixed - in some cases the currently loaded set of records in the testing panel doesn't feature all possible cases so the detected schema is too strict. However, if the declared schema is incompatible with the detected schema based on the test records, it's very likely there will be errors when running syncs.
 
-<img src={Diff} width="600" alt="Detected schema with highlighted differences" />
+<img
+  src={Diff}
+  width="600"
+  alt="Detected schema with highlighted differences"
+/>
 
 In the case of the example above, there are two differences between detected and declared schema. The first difference for the `name` field is not problematic:
+
 ```
      "name": {
 -      "type": [
@@ -369,6 +427,7 @@ In the case of the example above, there are two differences between detected and
 The declared schema allows the `null` value for the name while the detected schema only encountered strings. If it's possible the `name` is set to null, the detected schema is configured correctly.
 
 The second difference will likely cause problems:
+
 ```
      "subject": {
 -      "type": "number"
@@ -377,7 +436,8 @@ The second difference will likely cause problems:
 ```
 
 The `subject` field was detected as `string`, but is configured to be a `number` in the declared schema. As the API returned string subjects during testing, it's likely this will also happen during syncs which would render the declared schema inaccurate. Depending on the situation this can be fixed in multiple ways:
-* If the API changed and subject is always a string now, the declared schema should be updated to reflect this: `"subject": { "type": "string" }`
-* If the API is sometimes returning subject as number of string depending on the record, the declared schema should be updated to allow both data types: `"subject": { "type": ["string","number"] }`
+
+- If the API changed and subject is always a string now, the declared schema should be updated to reflect this: `"subject": { "type": "string" }`
+- If the API is sometimes returning subject as number of string depending on the record, the declared schema should be updated to allow both data types: `"subject": { "type": ["string","number"] }`
 
 A common situation is that certain record fields do not have any any values for the test read data, so they are set to `null`. In the detected schema, these field are of type `"null"` which is most likely not correct for all cases. In these situations, the declared schema should be manually corrected.

--- a/docs/connector-development/connector-builder-ui/tutorial.mdx
+++ b/docs/connector-development/connector-builder-ui/tutorial.mdx
@@ -104,7 +104,7 @@ In a real sync, this record will be passed on to a destination like a warehouse.
 
 The request/response tabs are helpful during development to see which requests and responses your connector will send and receive from the API.
 
-The detected schema tab indicates the schema that was detected by analyzing the returned records; this schema is automatically set as the declared schema for this stream, which you can see by visiting the Declared schema tab in the center stream configuration view.
+The detected schema tab indicates the schema that was detected by analyzing the returned records; this detected schema is automatically set as the declared schema for this stream, which you can see by visiting the Declared schema tab in the center stream configuration view.
 
 ## Step 3 - Advanced configuration
 

--- a/docs/connector-development/connector-builder-ui/tutorial.mdx
+++ b/docs/connector-development/connector-builder-ui/tutorial.mdx
@@ -39,78 +39,34 @@ This can be done by signing up for the Free tier plan on [Exchange Rates API](ht
 ### Setting up the environment
 
 Besides an Exchange Rates API key, only a browser and an up-to-date running Airbyte instance is required. There are two ways to accomplish this:
-
-- Sign up on [cloud.airbyte.com](https://cloud.airbyte.com/)
-- Download and run Airbyte [on your own infrastructure](https://github.com/airbytehq/airbyte#quick-start). Make sure you are running version 0.43.0 or later
+* Sign up on [cloud.airbyte.com](https://cloud.airbyte.com/)
+* Download and run Airbyte [on your own infrastructure](https://github.com/airbytehq/airbyte#quick-start). Make sure you are running version 0.43.0 or later
 
 ## Step 2 - Basic configuration
 
 ### Creating a connector builder project
 
-<div
-  style={{
-    position: "relative",
-    paddingBottom: "59.66850828729282%",
-    height: 0,
-  }}
->
-  <iframe
-    src="https://www.loom.com/embed/c21f7b421f954e0a82b931446dda3d51"
-    frameborder="0"
-    webkitallowfullscreen
-    mozallowfullscreen
-    allowfullscreen
-    style={{
-      position: "absolute",
-      top: 0,
-      left: 0,
-      width: "100%",
-      height: "100%",
-    }}
-  ></iframe>
-</div>
+<div style={{ position: "relative", paddingBottom: "59.66850828729282%", height: 0 }}><iframe src="https://www.loom.com/embed/c21f7b421f954e0a82b931446dda3d51" frameborder="0" webkitallowfullscreen mozallowfullscreen allowfullscreen style={{position: "absolute", top: 0, left: 0, width: "100%", height: "100%"}}></iframe></div>
 
 When developing a connector using the connector builder UI, the current state is saved in a connector builder project. These projects are saved as part of the Airbyte workspace and are separate from your source configurations and connections. In the last step of this tutorial you will publish the connector builder project to make it ready to use in connections to run syncs.
 
 To get started, follow the following steps:
-
-- Visit the Airbyte UI in your browser
-- Go to the connector builder page by clicking the "Builder" item in the left hand navigation bar
-- Select "Start from scratch" to start a new connector builder project (in case you have already created builder connectors before, click the "New custom connector" button in the top right corner)
-- Set the connector name to `Exchange Rates (Tutorial)`
+* Visit the Airbyte UI in your browser
+* Go to the connector builder page by clicking the "Builder" item in the left hand navigation bar
+* Select "Start from scratch" to start a new connector builder project (in case you have already created builder connectors before, click the "New custom connector" button in the top right corner)
+* Set the connector name to `Exchange Rates (Tutorial)`
 
 Your connector builder project is now set up. The next steps describe how to configure your connector to extract records from the Exchange Rates API.
 
 ### Setting up global configuration
 
-<div
-  style={{
-    position: "relative",
-    paddingBottom: "65.69343065693431%",
-    height: 0,
-  }}
->
-  <iframe
-    src="https://www.loom.com/embed/86832440d02e45b0b6c45d169b3606a1"
-    frameborder="0"
-    webkitallowfullscreen
-    mozallowfullscreen
-    allowfullscreen
-    style={{
-      position: "absolute",
-      top: 0,
-      left: 0,
-      width: "100%",
-      height: "100%",
-    }}
-  ></iframe>
-</div>
+<div style={{ position: "relative", paddingBottom: "65.69343065693431%", height: 0 }}><iframe src="https://www.loom.com/embed/86832440d02e45b0b6c45d169b3606a1" frameborder="0" webkitallowfullscreen mozallowfullscreen allowfullscreen style={{position: "absolute", top: 0, left: 0, width: "100%", height: "100%"}}></iframe></div>
 
 On the "global configuration" page, general settings applying to all streams are configured - the base URL that requests are sent to, as well as configuration for how to authenticate with the API server.
 
-- Set the base URL to `https://api.apilayer.com`
-- Select the "API Key" authentication method
-- Set the "Header" to `apikey`
+* Set the base URL to `https://api.apilayer.com`
+* Select the "API Key" authentication method
+* Set the "Header" to `apikey`
 
 The actual API Key you copied from apilayer.com will not be part of the connector itself - instead it will be set as part of the source configuration when configuring a connection based on your connector in a later step.
 
@@ -118,41 +74,18 @@ You can find more information about authentication method on the [authentication
 
 ### Setting up and testing a stream
 
-<div
-  style={{
-    position: "relative",
-    paddingBottom: "59.66850828729282%",
-    height: 0,
-  }}
->
-  <iframe
-    src="https://www.loom.com/embed/9c31b779dc9e4c6bbaa10f19b00ee893"
-    frameborder="0"
-    webkitallowfullscreen
-    mozallowfullscreen
-    allowfullscreen
-    style={{
-      position: "absolute",
-      top: 0,
-      left: 0,
-      width: "100%",
-      height: "100%",
-    }}
-  ></iframe>
-</div>
+<div style={{ position: "relative", paddingBottom: "59.66850828729282%", height: 0 }}><iframe src="https://www.loom.com/embed/9c31b779dc9e4c6bbaa10f19b00ee893" frameborder="0" webkitallowfullscreen mozallowfullscreen allowfullscreen style={{position: "absolute", top: 0, left: 0, width: "100%", height: "100%"}}></iframe></div>
 
 Now that you configured how to talk the API, let's set up the stream of records that will be sent to a destination later on. To do so, click the button with the plus icon next to the "Streams" section in the side menu and fill out the form:
-
-- Set the name to "Rates"
-- Set the "URL path" to `/exchangerates_data/latest`
-- Submit
+* Set the name to "Rates"
+* Set the "URL path" to `/exchangerates_data/latest`
+* Submit
 
 Now the basic stream is configured and can be tested. To send test requests, supply testing values by clicking the "Testing values" button in top right and pasting your API key in the input.
 
 This form corresponds to what a user of this connector will need to provide when setting up a connection later on. The testing values are not saved along with the connector project.
 
 Now, click the "Test" button to trigger a test read to simulate what will happen during a sync. After a little while, you should see a single record that looks like this:
-
 ```
 {
   "base": "EUR",
@@ -177,45 +110,23 @@ The detected schema tab indicates the schema that was detected by analyzing the 
 
 ### Making the stream configurable
 
-<div
-  style={{
-    position: "relative",
-    paddingBottom: "59.66850828729282%",
-    height: 0,
-  }}
->
-  <iframe
-    src="https://www.loom.com/embed/9fa4f22914db48a1876413f67cd6e2f0"
-    frameborder="0"
-    webkitallowfullscreen
-    mozallowfullscreen
-    allowfullscreen
-    style={{
-      position: "absolute",
-      top: 0,
-      left: 0,
-      width: "100%",
-      height: "100%",
-    }}
-  ></iframe>
-</div>
+<div style={{ position: "relative", paddingBottom: "59.66850828729282%", height: 0 }}><iframe src="https://www.loom.com/embed/9fa4f22914db48a1876413f67cd6e2f0" frameborder="0" webkitallowfullscreen mozallowfullscreen allowfullscreen style={{position: "absolute", top: 0, left: 0, width: "100%", height: "100%"}}></iframe></div>
 
 The exchange rate API supports configuring a different base currency via request parameter - let's make this part of the user inputs that can be controlled by the user of the connector when configuring a source, similar to the API key.
 
 To do so, follow these steps:
-
-- Scroll down to the "Request parameters" section and add a new request parameter
-- Set the key to `base`
-- For the value, click the user icon in the input and select "New user input"
-- Set the name to "Base"
-- Click "Create"
+* Scroll down to the "Request parameters" section and add a new request parameter
+* Set the key to `base`
+* For the value, click the user icon in the input and select "New user input"
+* Set the name to "Base"
+* Click "Create"
 
 The value input is now set to `{{ config['base'] }}`. When making requests, the connector will replace this placeholder by the user supplied value. This syntax can be used in all fields that have a user icon on the right side, see the full reference [here](/connector-development/config-based/understanding-the-yaml-file/reference#variables).
+
 
 Now your connector has a second configuration input. To test it, click the "Testing values" button again, set the "Base" to `USD`. Then, click the "Test" button again to issue a new test read.
 
 The record should update to use USD as the base currency:
-
 ```
 {
     "base": "USD",
@@ -232,28 +143,7 @@ The record should update to use USD as the base currency:
 
 ### Adding incremental reads
 
-<div
-  style={{
-    position: "relative",
-    paddingBottom: "59.66850828729282%",
-    height: 0,
-  }}
->
-  <iframe
-    src="https://www.loom.com/embed/223d28508682464481a433396cab2a3a"
-    frameborder="0"
-    webkitallowfullscreen
-    mozallowfullscreen
-    allowfullscreen
-    style={{
-      position: "absolute",
-      top: 0,
-      left: 0,
-      width: "100%",
-      height: "100%",
-    }}
-  ></iframe>
-</div>
+<div style={{ position: "relative", paddingBottom: "59.66850828729282%", height: 0 }}><iframe src="https://www.loom.com/embed/223d28508682464481a433396cab2a3a" frameborder="0" webkitallowfullscreen mozallowfullscreen allowfullscreen style={{position: "absolute", top: 0, left: 0, width: "100%", height: "100%"}}></iframe></div>
 
 We now have a working implementation of a connector reading the latest exchange rates for a given currency.
 In this section, we'll update the source to read historical data instead of only reading the latest exchange rates.
@@ -261,18 +151,17 @@ In this section, we'll update the source to read historical data instead of only
 According to the API documentation, we can read the exchange rate for a specific date range by querying the `"/exchangerates_data/{date}"` endpoint instead of `"/exchangerates_data/latest"`.
 
 To configure your connector to request every day individually, follow these steps:
-
-- On top of the form, change the "Path URL" input to `/exchangerates_data/{{ stream_interval.start_time }}` to [inject](/connector-development/config-based/understanding-the-yaml-file/reference#variables) the date to fetch data for into the path of the request
-- Enable "Incremental sync" for the Rates stream
-- Set the "Cursor field" to `date` - this is the property in our records to check what date got synced last
-- Set the "Datetime format" to `%Y-%m-%d` to match the format of the date in the record returned from the API
-- Set the "Cursor granularity" to `P1D` to tell the connector the API only supports daily increments
-- Leave start time to "User input" so the end user can set the desired start time for syncing data
-- Leave end time to "Now" to always sync exchange rates up to the current date
-- In a lot of cases the start and end date are injected into the request body or request parameters. However in the case of the exchange rate API it needs to be added to the path of the request, so disable the "Inject start/end time into outgoing HTTP request" options
-- Open the "Advanced" section and set "Step" to `P1D` to configure the connector to do one separate request per day by partitioning the dataset into daily intervals
-- Set a start date (like `2023-03-03`) in the "Testing values" menu
-- Hit the "Test" button to trigger a new test read
+* On top of the form, change the "Path URL" input to `/exchangerates_data/{{ stream_interval.start_time }}` to [inject](/connector-development/config-based/understanding-the-yaml-file/reference#variables) the date to fetch data for into the path of the request
+* Enable "Incremental sync" for the Rates stream
+* Set the "Cursor field" to `date` - this is the property in our records to check what date got synced last
+* Set the "Datetime format" to `%Y-%m-%d` to match the format of the date in the record returned from the API
+* Set the "Cursor granularity" to `P1D` to tell the connector the API only supports daily increments
+* Leave start time to "User input" so the end user can set the desired start time for syncing data
+* Leave end time to "Now" to always sync exchange rates up to the current date
+* In a lot of cases the start and end date are injected into the request body or request parameters. However in the case of the exchange rate API it needs to be added to the path of the request, so disable the "Inject start/end time into outgoing HTTP request" options
+* Open the "Advanced" section and set "Step" to `P1D` to configure the connector to do one separate request per day by partitioning the dataset into daily intervals
+* Set a start date (like `2023-03-03`) in the "Testing values" menu
+* Hit the "Test" button to trigger a new test read
 
 Now, you should see a dropdown above the records view that lets you step through the daily exchange rates along with the requests performed to fetch this data. Note that in the connector builder at most 5 partitions are requested to speed up testing. During a proper sync the full time range between your configured start date and the current day will be executed.
 
@@ -282,61 +171,38 @@ You can find more information about incremental syncs on the [incremental sync c
 
 ## Step 4 - Publishing and syncing
 
-<div
-  style={{
-    position: "relative",
-    paddingBottom: "59.66850828729282%",
-    height: 0,
-  }}
->
-  <iframe
-    src="https://www.loom.com/embed/a6896c6aa8f047f0aeefec08d37a1384"
-    frameborder="0"
-    webkitallowfullscreen
-    mozallowfullscreen
-    allowfullscreen
-    style={{
-      position: "absolute",
-      top: 0,
-      left: 0,
-      width: "100%",
-      height: "100%",
-    }}
-  ></iframe>
-</div>
+<div style={{ position: "relative", paddingBottom: "59.66850828729282%", height: 0 }}><iframe src="https://www.loom.com/embed/a6896c6aa8f047f0aeefec08d37a1384" frameborder="0" webkitallowfullscreen mozallowfullscreen allowfullscreen style={{position: "absolute", top: 0, left: 0, width: "100%", height: "100%"}}></iframe></div>
 
 So far, the connector is only configured as part of the connector builder project. To make it possible to use it in actual connections, you need to publish the connector. This captures the current state of the configuration and makes the connector available as a custom connector within the current Airbyte workspace.
 
 To use the connector for a proper sync, follow these steps:
-
-- Click the "Publish" button and publish the first version of the "Exchange Rates (Tutorial)" connector
-- Go to the "Connections" page and create a new connection
-- As Source type, pick the "Exchange Rates (Tutorial)" connector you just created
-- Set API Key, base currency and start date for the sync - to avoid a large number of requests, set the start date to one week in the past
-- Click "Set up source" and wait for the connection check to validate the provided configuration is valid
-- Set up a destination - to keep things simple let's choose the "E2E Testing" destination type
-- Click "Set up destination", keeping the default configurations
-- Wait for Airbyte to check the record schema, then click "Set up connection" - this will create the connection and kick off the first sync
-- After a short while, the sync should complete successfully
+* Click the "Publish" button and publish the first version of the "Exchange Rates (Tutorial)" connector
+* Go to the "Connections" page and create a new connection
+* As Source type, pick the "Exchange Rates (Tutorial)" connector you just created
+* Set API Key, base currency and start date for the sync - to avoid a large number of requests, set the start date to one week in the past
+* Click "Set up source" and wait for the connection check to validate the provided configuration is valid
+* Set up a destination - to keep things simple let's choose the "E2E Testing" destination type
+* Click "Set up destination", keeping the default configurations
+* Wait for Airbyte to check the record schema, then click "Set up connection" - this will create the connection and kick off the first sync
+* After a short while, the sync should complete successfully
 
 Congratulations! You just completed the following steps:
-
-- Configured a production-ready connector to extract currency exchange data from an HTTP-based API:
-  - Configurable API key, start date and base currency
-  - Incremental sync to keep the number of requests small
-- Tested whether the connector works correctly in the builder
-- Made the working connector available to configure sources in the workspace
-- Set up a connection using the published connector and synced data from the Exchange Rates API
+* Configured a production-ready connector to extract currency exchange data from an HTTP-based API:
+  * Configurable API key, start date and base currency
+  * Incremental sync to keep the number of requests small
+  * Schema declaration to enable normalization in the destination
+* Tested whether the connector works correctly in the builder
+* Made the working connector available to configure sources in the workspace
+* Set up a connection using the published connector and synced data from the Exchange Rates API
 
 ## Next steps
 
 This tutorial didn't go into depth about all features that can be used in the connector builder. Check out the concept pages for more information about certain topics:
-
-- [Authentication](/connector-development/connector-builder-ui/authentication/)
-- [Record processing](/connector-development/connector-builder-ui/record-processing/)
-- [Pagination](/connector-development/connector-builder-ui/pagination/)
-- [Incremental sync](/connector-development/connector-builder-ui/incremental-sync/)
-- [Partitioning](/connector-development/connector-builder-ui/partitioning/)
-- [Error handling](/connector-development/connector-builder-ui/error-handling/)
+* [Authentication](/connector-development/connector-builder-ui/authentication/)
+* [Record processing](/connector-development/connector-builder-ui/record-processing/)
+* [Pagination](/connector-development/connector-builder-ui/pagination/)
+* [Incremental sync](/connector-development/connector-builder-ui/incremental-sync/)
+* [Partitioning](/connector-development/connector-builder-ui/partitioning/)
+* [Error handling](/connector-development/connector-builder-ui/error-handling/)
 
 Not every possible API can be consumed by connectors configured in the connector builder. The [compatibility guide](/connector-development/connector-builder-ui/connector-builder-compatibility#oauth) can help determining whether another technology should be used to integrate an API with the Airbyte platform.

--- a/docs/connector-development/connector-builder-ui/tutorial.mdx
+++ b/docs/connector-development/connector-builder-ui/tutorial.mdx
@@ -39,34 +39,78 @@ This can be done by signing up for the Free tier plan on [Exchange Rates API](ht
 ### Setting up the environment
 
 Besides an Exchange Rates API key, only a browser and an up-to-date running Airbyte instance is required. There are two ways to accomplish this:
-* Sign up on [cloud.airbyte.com](https://cloud.airbyte.com/)
-* Download and run Airbyte [on your own infrastructure](https://github.com/airbytehq/airbyte#quick-start). Make sure you are running version 0.43.0 or later
+
+- Sign up on [cloud.airbyte.com](https://cloud.airbyte.com/)
+- Download and run Airbyte [on your own infrastructure](https://github.com/airbytehq/airbyte#quick-start). Make sure you are running version 0.43.0 or later
 
 ## Step 2 - Basic configuration
 
 ### Creating a connector builder project
 
-<div style={{ position: "relative", paddingBottom: "59.66850828729282%", height: 0 }}><iframe src="https://www.loom.com/embed/c21f7b421f954e0a82b931446dda3d51" frameborder="0" webkitallowfullscreen mozallowfullscreen allowfullscreen style={{position: "absolute", top: 0, left: 0, width: "100%", height: "100%"}}></iframe></div>
+<div
+  style={{
+    position: "relative",
+    paddingBottom: "59.66850828729282%",
+    height: 0,
+  }}
+>
+  <iframe
+    src="https://www.loom.com/embed/c21f7b421f954e0a82b931446dda3d51"
+    frameborder="0"
+    webkitallowfullscreen
+    mozallowfullscreen
+    allowfullscreen
+    style={{
+      position: "absolute",
+      top: 0,
+      left: 0,
+      width: "100%",
+      height: "100%",
+    }}
+  ></iframe>
+</div>
 
 When developing a connector using the connector builder UI, the current state is saved in a connector builder project. These projects are saved as part of the Airbyte workspace and are separate from your source configurations and connections. In the last step of this tutorial you will publish the connector builder project to make it ready to use in connections to run syncs.
 
 To get started, follow the following steps:
-* Visit the Airbyte UI in your browser
-* Go to the connector builder page by clicking the "Builder" item in the left hand navigation bar
-* Select "Start from scratch" to start a new connector builder project (in case you have already created builder connectors before, click the "New custom connector" button in the top right corner)
-* Set the connector name to `Exchange Rates (Tutorial)`
+
+- Visit the Airbyte UI in your browser
+- Go to the connector builder page by clicking the "Builder" item in the left hand navigation bar
+- Select "Start from scratch" to start a new connector builder project (in case you have already created builder connectors before, click the "New custom connector" button in the top right corner)
+- Set the connector name to `Exchange Rates (Tutorial)`
 
 Your connector builder project is now set up. The next steps describe how to configure your connector to extract records from the Exchange Rates API.
 
 ### Setting up global configuration
 
-<div style={{ position: "relative", paddingBottom: "65.69343065693431%", height: 0 }}><iframe src="https://www.loom.com/embed/86832440d02e45b0b6c45d169b3606a1" frameborder="0" webkitallowfullscreen mozallowfullscreen allowfullscreen style={{position: "absolute", top: 0, left: 0, width: "100%", height: "100%"}}></iframe></div>
+<div
+  style={{
+    position: "relative",
+    paddingBottom: "65.69343065693431%",
+    height: 0,
+  }}
+>
+  <iframe
+    src="https://www.loom.com/embed/86832440d02e45b0b6c45d169b3606a1"
+    frameborder="0"
+    webkitallowfullscreen
+    mozallowfullscreen
+    allowfullscreen
+    style={{
+      position: "absolute",
+      top: 0,
+      left: 0,
+      width: "100%",
+      height: "100%",
+    }}
+  ></iframe>
+</div>
 
 On the "global configuration" page, general settings applying to all streams are configured - the base URL that requests are sent to, as well as configuration for how to authenticate with the API server.
 
-* Set the base URL to `https://api.apilayer.com`
-* Select the "API Key" authentication method
-* Set the "Header" to `apikey`
+- Set the base URL to `https://api.apilayer.com`
+- Select the "API Key" authentication method
+- Set the "Header" to `apikey`
 
 The actual API Key you copied from apilayer.com will not be part of the connector itself - instead it will be set as part of the source configuration when configuring a connection based on your connector in a later step.
 
@@ -74,18 +118,41 @@ You can find more information about authentication method on the [authentication
 
 ### Setting up and testing a stream
 
-<div style={{ position: "relative", paddingBottom: "59.66850828729282%", height: 0 }}><iframe src="https://www.loom.com/embed/9c31b779dc9e4c6bbaa10f19b00ee893" frameborder="0" webkitallowfullscreen mozallowfullscreen allowfullscreen style={{position: "absolute", top: 0, left: 0, width: "100%", height: "100%"}}></iframe></div>
+<div
+  style={{
+    position: "relative",
+    paddingBottom: "59.66850828729282%",
+    height: 0,
+  }}
+>
+  <iframe
+    src="https://www.loom.com/embed/9c31b779dc9e4c6bbaa10f19b00ee893"
+    frameborder="0"
+    webkitallowfullscreen
+    mozallowfullscreen
+    allowfullscreen
+    style={{
+      position: "absolute",
+      top: 0,
+      left: 0,
+      width: "100%",
+      height: "100%",
+    }}
+  ></iframe>
+</div>
 
 Now that you configured how to talk the API, let's set up the stream of records that will be sent to a destination later on. To do so, click the button with the plus icon next to the "Streams" section in the side menu and fill out the form:
-* Set the name to "Rates"
-* Set the "URL path" to `/exchangerates_data/latest`
-* Submit
+
+- Set the name to "Rates"
+- Set the "URL path" to `/exchangerates_data/latest`
+- Submit
 
 Now the basic stream is configured and can be tested. To send test requests, supply testing values by clicking the "Testing values" button in top right and pasting your API key in the input.
 
 This form corresponds to what a user of this connector will need to provide when setting up a connection later on. The testing values are not saved along with the connector project.
 
 Now, click the "Test" button to trigger a test read to simulate what will happen during a sync. After a little while, you should see a single record that looks like this:
+
 ```
 {
   "base": "EUR",
@@ -104,39 +171,51 @@ In a real sync, this record will be passed on to a destination like a warehouse.
 
 The request/response tabs are helpful during development to see which requests and responses your connector will send and receive from the API.
 
-### Declaring the record schema
-
-<div style={{ position: "relative", paddingBottom: "59.66850828729282%", height: 0 }}><iframe src="https://www.loom.com/embed/56899a92afe047eba461f32d19c8ca94" frameborder="0" webkitallowfullscreen mozallowfullscreen allowfullscreen style={{position: "absolute", top: 0, left: 0, width: "100%", height: "100%"}}></iframe></div>
-
-Each stream of a connector needs to declare how emitted records will look like (which properties do they have, what data types will be used, ...). During a sync, this information will be passed on to the destination to configure it correctly - for example a SQL database destination can use it to properly set up the destination table, assigning the right type to each column.
-
-By default, the stream schema is set to a simple object with unspecified properties. However, the connector builder can infer the schema based on the test read you just issued. To use the infered schema, switch to the "Detected schema" tab and click the "Import schema" button.
-
-The warning icon disappears indicating that the declared schema of your stream matches the test data.
-
-You can find more information about schema declaration on the [record processing concept page](./record-processing).
+The detected schema tab indicates the schema that was detected by analyzing the returned records; this schema is automatically set as the declared schema for this stream, which you can see by visiting the Declared schema tab in the center stream configuration view.
 
 ## Step 3 - Advanced configuration
 
 ### Making the stream configurable
 
-<div style={{ position: "relative", paddingBottom: "59.66850828729282%", height: 0 }}><iframe src="https://www.loom.com/embed/9fa4f22914db48a1876413f67cd6e2f0" frameborder="0" webkitallowfullscreen mozallowfullscreen allowfullscreen style={{position: "absolute", top: 0, left: 0, width: "100%", height: "100%"}}></iframe></div>
+<div
+  style={{
+    position: "relative",
+    paddingBottom: "59.66850828729282%",
+    height: 0,
+  }}
+>
+  <iframe
+    src="https://www.loom.com/embed/9fa4f22914db48a1876413f67cd6e2f0"
+    frameborder="0"
+    webkitallowfullscreen
+    mozallowfullscreen
+    allowfullscreen
+    style={{
+      position: "absolute",
+      top: 0,
+      left: 0,
+      width: "100%",
+      height: "100%",
+    }}
+  ></iframe>
+</div>
 
 The exchange rate API supports configuring a different base currency via request parameter - let's make this part of the user inputs that can be controlled by the user of the connector when configuring a source, similar to the API key.
 
 To do so, follow these steps:
-* Scroll down to the "Request parameters" section and add a new request parameter
-* Set the key to `base`
-* For the value, click the user icon in the input and select "New user input"
-* Set the name to "Base"
-* Click "Create"
+
+- Scroll down to the "Request parameters" section and add a new request parameter
+- Set the key to `base`
+- For the value, click the user icon in the input and select "New user input"
+- Set the name to "Base"
+- Click "Create"
 
 The value input is now set to `{{ config['base'] }}`. When making requests, the connector will replace this placeholder by the user supplied value. This syntax can be used in all fields that have a user icon on the right side, see the full reference [here](/connector-development/config-based/understanding-the-yaml-file/reference#variables).
-
 
 Now your connector has a second configuration input. To test it, click the "Testing values" button again, set the "Base" to `USD`. Then, click the "Test" button again to issue a new test read.
 
 The record should update to use USD as the base currency:
+
 ```
 {
     "base": "USD",
@@ -153,7 +232,28 @@ The record should update to use USD as the base currency:
 
 ### Adding incremental reads
 
-<div style={{ position: "relative", paddingBottom: "59.66850828729282%", height: 0 }}><iframe src="https://www.loom.com/embed/223d28508682464481a433396cab2a3a" frameborder="0" webkitallowfullscreen mozallowfullscreen allowfullscreen style={{position: "absolute", top: 0, left: 0, width: "100%", height: "100%"}}></iframe></div>
+<div
+  style={{
+    position: "relative",
+    paddingBottom: "59.66850828729282%",
+    height: 0,
+  }}
+>
+  <iframe
+    src="https://www.loom.com/embed/223d28508682464481a433396cab2a3a"
+    frameborder="0"
+    webkitallowfullscreen
+    mozallowfullscreen
+    allowfullscreen
+    style={{
+      position: "absolute",
+      top: 0,
+      left: 0,
+      width: "100%",
+      height: "100%",
+    }}
+  ></iframe>
+</div>
 
 We now have a working implementation of a connector reading the latest exchange rates for a given currency.
 In this section, we'll update the source to read historical data instead of only reading the latest exchange rates.
@@ -161,17 +261,18 @@ In this section, we'll update the source to read historical data instead of only
 According to the API documentation, we can read the exchange rate for a specific date range by querying the `"/exchangerates_data/{date}"` endpoint instead of `"/exchangerates_data/latest"`.
 
 To configure your connector to request every day individually, follow these steps:
-* On top of the form, change the "Path URL" input to `/exchangerates_data/{{ stream_interval.start_time }}` to [inject](/connector-development/config-based/understanding-the-yaml-file/reference#variables) the date to fetch data for into the path of the request
-* Enable "Incremental sync" for the Rates stream
-* Set the "Cursor field" to `date` - this is the property in our records to check what date got synced last
-* Set the "Datetime format" to `%Y-%m-%d` to match the format of the date in the record returned from the API
-* Set the "Cursor granularity" to `P1D` to tell the connector the API only supports daily increments
-* Leave start time to "User input" so the end user can set the desired start time for syncing data
-* Leave end time to "Now" to always sync exchange rates up to the current date
-* In a lot of cases the start and end date are injected into the request body or request parameters. However in the case of the exchange rate API it needs to be added to the path of the request, so disable the "Inject start/end time into outgoing HTTP request" options
-* Open the "Advanced" section and set "Step" to `P1D` to configure the connector to do one separate request per day by partitioning the dataset into daily intervals
-* Set a start date (like `2023-03-03`) in the "Testing values" menu
-* Hit the "Test" button to trigger a new test read
+
+- On top of the form, change the "Path URL" input to `/exchangerates_data/{{ stream_interval.start_time }}` to [inject](/connector-development/config-based/understanding-the-yaml-file/reference#variables) the date to fetch data for into the path of the request
+- Enable "Incremental sync" for the Rates stream
+- Set the "Cursor field" to `date` - this is the property in our records to check what date got synced last
+- Set the "Datetime format" to `%Y-%m-%d` to match the format of the date in the record returned from the API
+- Set the "Cursor granularity" to `P1D` to tell the connector the API only supports daily increments
+- Leave start time to "User input" so the end user can set the desired start time for syncing data
+- Leave end time to "Now" to always sync exchange rates up to the current date
+- In a lot of cases the start and end date are injected into the request body or request parameters. However in the case of the exchange rate API it needs to be added to the path of the request, so disable the "Inject start/end time into outgoing HTTP request" options
+- Open the "Advanced" section and set "Step" to `P1D` to configure the connector to do one separate request per day by partitioning the dataset into daily intervals
+- Set a start date (like `2023-03-03`) in the "Testing values" menu
+- Hit the "Test" button to trigger a new test read
 
 Now, you should see a dropdown above the records view that lets you step through the daily exchange rates along with the requests performed to fetch this data. Note that in the connector builder at most 5 partitions are requested to speed up testing. During a proper sync the full time range between your configured start date and the current day will be executed.
 
@@ -179,55 +280,63 @@ When used in a connection, the connector will make sure exchange rates for the s
 
 You can find more information about incremental syncs on the [incremental sync concept page](./incremental-sync).
 
-### Adding transformations
-
-<div style={{ position: "relative", paddingBottom: "59.66850828729282%", height: 0 }}><iframe src="https://www.loom.com/embed/42ab3872c9284296b452a99e90b26738" frameborder="0" webkitallowfullscreen mozallowfullscreen allowfullscreen style={{position: "absolute", top: 0, left: 0, width: "100%", height: "100%"}}></iframe></div>
-
-Note that a warning icon should show next to the "Detected schema" tab - using the per-date endpoint instead of the latest endpoint slightly changed the shape of the records by adding a `historical` property. As we don't need this property in our destination, we can remove it using a transformation.
-
-To do so, follow these steps:
-* Enable the "Transformations" section
-* Set the "Path" to `historical`
-* Trigger a new test read
-
-The `historical` property in the records tab and the schema warning should disappear.
-
-You can find more information about incremental syncs on the [incremental sync concept page](./incremental-sync).
-
 ## Step 4 - Publishing and syncing
 
-<div style={{ position: "relative", paddingBottom: "59.66850828729282%", height: 0 }}><iframe src="https://www.loom.com/embed/a6896c6aa8f047f0aeefec08d37a1384" frameborder="0" webkitallowfullscreen mozallowfullscreen allowfullscreen style={{position: "absolute", top: 0, left: 0, width: "100%", height: "100%"}}></iframe></div>
+<div
+  style={{
+    position: "relative",
+    paddingBottom: "59.66850828729282%",
+    height: 0,
+  }}
+>
+  <iframe
+    src="https://www.loom.com/embed/a6896c6aa8f047f0aeefec08d37a1384"
+    frameborder="0"
+    webkitallowfullscreen
+    mozallowfullscreen
+    allowfullscreen
+    style={{
+      position: "absolute",
+      top: 0,
+      left: 0,
+      width: "100%",
+      height: "100%",
+    }}
+  ></iframe>
+</div>
 
 So far, the connector is only configured as part of the connector builder project. To make it possible to use it in actual connections, you need to publish the connector. This captures the current state of the configuration and makes the connector available as a custom connector within the current Airbyte workspace.
 
 To use the connector for a proper sync, follow these steps:
-* Click the "Publish" button and publish the first version of the "Exchange Rates (Tutorial)" connector
-* Go to the "Connections" page and create a new connection
-* As Source type, pick the "Exchange Rates (Tutorial)" connector you just created
-* Set API Key, base currency and start date for the sync - to avoid a large number of requests, set the start date to one week in the past
-* Click "Set up source" and wait for the connection check to validate the provided configuration is valid
-* Set up a destination - to keep things simple let's choose the "E2E Testing" destination type
-* Click "Set up destination", keeping the default configurations
-* Wait for Airbyte to check the record schema, then click "Set up connection" - this will create the connection and kick off the first sync
-* After a short while, the sync should complete successfully
+
+- Click the "Publish" button and publish the first version of the "Exchange Rates (Tutorial)" connector
+- Go to the "Connections" page and create a new connection
+- As Source type, pick the "Exchange Rates (Tutorial)" connector you just created
+- Set API Key, base currency and start date for the sync - to avoid a large number of requests, set the start date to one week in the past
+- Click "Set up source" and wait for the connection check to validate the provided configuration is valid
+- Set up a destination - to keep things simple let's choose the "E2E Testing" destination type
+- Click "Set up destination", keeping the default configurations
+- Wait for Airbyte to check the record schema, then click "Set up connection" - this will create the connection and kick off the first sync
+- After a short while, the sync should complete successfully
 
 Congratulations! You just completed the following steps:
-* Configured a production-ready connector to extract currency exchange data from an HTTP-based API:
-  * Configurable API key, start date and base currency
-  * Incremental sync to keep the number of requests small
-  * Schema declaration to enable normalization in the destination
-* Tested whether the connector works correctly in the builder
-* Made the working connector available to configure sources in the workspace
-* Set up a connection using the published connector and synced data from the Exchange Rates API
+
+- Configured a production-ready connector to extract currency exchange data from an HTTP-based API:
+  - Configurable API key, start date and base currency
+  - Incremental sync to keep the number of requests small
+- Tested whether the connector works correctly in the builder
+- Made the working connector available to configure sources in the workspace
+- Set up a connection using the published connector and synced data from the Exchange Rates API
 
 ## Next steps
 
 This tutorial didn't go into depth about all features that can be used in the connector builder. Check out the concept pages for more information about certain topics:
-* [Authentication](/connector-development/connector-builder-ui/authentication/)
-* [Record processing](/connector-development/connector-builder-ui/record-processing/)
-* [Pagination](/connector-development/connector-builder-ui/pagination/)
-* [Error handling](/connector-development/connector-builder-ui/error-handling/)
-* [Incremental sync](/connector-development/connector-builder-ui/incremental-sync/)
-* [Partitioning](/connector-development/connector-builder-ui/partitioning/)
+
+- [Authentication](/connector-development/connector-builder-ui/authentication/)
+- [Record processing](/connector-development/connector-builder-ui/record-processing/)
+- [Pagination](/connector-development/connector-builder-ui/pagination/)
+- [Incremental sync](/connector-development/connector-builder-ui/incremental-sync/)
+- [Partitioning](/connector-development/connector-builder-ui/partitioning/)
+- [Error handling](/connector-development/connector-builder-ui/error-handling/)
 
 Not every possible API can be consumed by connectors configured in the connector builder. The [compatibility guide](/connector-development/connector-builder-ui/connector-builder-compatibility#oauth) can help determining whether another technology should be used to integrate an API with the Airbyte platform.


### PR DESCRIPTION
## What
Relates to https://github.com/airbytehq/airbyte/issues/25321

As a result of [this change](https://github.com/airbytehq/airbyte-platform-internal/pull/7113#issuecomment-1584627218) to add auto-import schema functionality to the connector builder, the docs need to be updated to reflect this.

## How
Updates the connector builder docs to reflect the fact that detected schemas are now automatically set as the declared schema by default.