### PR TITLE
Registry: Disable all hidden connectors in cloud

### DIFF
--- a/airbyte-integrations/connectors/destination-amazon-sqs/metadata.yaml
+++ b/airbyte-integrations/connectors/destination-amazon-sqs/metadata.yaml
@@ -10,7 +10,7 @@ data:
   name: Amazon SQS
   registries:
     cloud:
-      enabled: true
+      enabled: false
     oss:
       enabled: true
   releaseStage: alpha

--- a/airbyte-integrations/connectors/destination-amazon-sqs/metadata.yaml
+++ b/airbyte-integrations/connectors/destination-amazon-sqs/metadata.yaml
@@ -10,7 +10,7 @@ data:
   name: Amazon SQS
   registries:
     cloud:
-      enabled: false
+      enabled: false # hide Amazon SQS Destination https://github.com/airbytehq/airbyte/issues/16316
     oss:
       enabled: true
   releaseStage: alpha

--- a/airbyte-integrations/connectors/destination-cassandra/metadata.yaml
+++ b/airbyte-integrations/connectors/destination-cassandra/metadata.yaml
@@ -10,7 +10,7 @@ data:
   name: Cassandra
   registries:
     cloud:
-      enabled: true
+      enabled: false
     oss:
       enabled: true
   releaseStage: alpha

--- a/airbyte-integrations/connectors/destination-cassandra/metadata.yaml
+++ b/airbyte-integrations/connectors/destination-cassandra/metadata.yaml
@@ -10,7 +10,7 @@ data:
   name: Cassandra
   registries:
     cloud:
-      enabled: false
+      enabled: false # hide Cassandra Destination https://github.com/airbytehq/airbyte-cloud/issues/2606
     oss:
       enabled: true
   releaseStage: alpha

--- a/airbyte-integrations/connectors/destination-kafka/metadata.yaml
+++ b/airbyte-integrations/connectors/destination-kafka/metadata.yaml
@@ -10,7 +10,7 @@ data:
   name: Kafka
   registries:
     cloud:
-      enabled: false
+      enabled: false # hide Kafka Destination https://github.com/airbytehq/airbyte-cloud/issues/2610
     oss:
       enabled: true
   releaseStage: alpha

--- a/airbyte-integrations/connectors/destination-mariadb-columnstore/metadata.yaml
+++ b/airbyte-integrations/connectors/destination-mariadb-columnstore/metadata.yaml
@@ -10,7 +10,7 @@ data:
   name: MariaDB ColumnStore
   registries:
     cloud:
-      enabled: false
+      enabled: false # hide MariaDB Destination https://github.com/airbytehq/airbyte-cloud/issues/2611
     oss:
       enabled: true
   releaseStage: alpha

--- a/airbyte-integrations/connectors/destination-mariadb-columnstore/metadata.yaml
+++ b/airbyte-integrations/connectors/destination-mariadb-columnstore/metadata.yaml
@@ -10,7 +10,7 @@ data:
   name: MariaDB ColumnStore
   registries:
     cloud:
-      enabled: true
+      enabled: false
     oss:
       enabled: true
   releaseStage: alpha

--- a/airbyte-integrations/connectors/destination-meilisearch/metadata.yaml
+++ b/airbyte-integrations/connectors/destination-meilisearch/metadata.yaml
@@ -10,7 +10,7 @@ data:
   name: MeiliSearch
   registries:
     cloud:
-      enabled: false
+      enabled: false # hide MeiliSearch Destination https://github.com/airbytehq/airbyte/issues/16313
     oss:
       enabled: true
   releaseStage: alpha

--- a/airbyte-integrations/connectors/destination-meilisearch/metadata.yaml
+++ b/airbyte-integrations/connectors/destination-meilisearch/metadata.yaml
@@ -10,7 +10,7 @@ data:
   name: MeiliSearch
   registries:
     cloud:
-      enabled: true
+      enabled: false
     oss:
       enabled: true
   releaseStage: alpha

--- a/airbyte-integrations/connectors/destination-mqtt/metadata.yaml
+++ b/airbyte-integrations/connectors/destination-mqtt/metadata.yaml
@@ -10,7 +10,7 @@ data:
   name: MQTT
   registries:
     cloud:
-      enabled: false
+      enabled: false # hide MQTT Destination https://github.com/airbytehq/airbyte-cloud/issues/2613
     oss:
       enabled: true
   releaseStage: alpha

--- a/airbyte-integrations/connectors/destination-pulsar/metadata.yaml
+++ b/airbyte-integrations/connectors/destination-pulsar/metadata.yaml
@@ -10,7 +10,7 @@ data:
   name: Pulsar
   registries:
     cloud:
-      enabled: true
+      enabled: false
     oss:
       enabled: true
   releaseStage: alpha

--- a/airbyte-integrations/connectors/destination-pulsar/metadata.yaml
+++ b/airbyte-integrations/connectors/destination-pulsar/metadata.yaml
@@ -10,7 +10,7 @@ data:
   name: Pulsar
   registries:
     cloud:
-      enabled: false
+      enabled: false # hide Pulsar Destination https://github.com/airbytehq/airbyte-cloud/issues/2614
     oss:
       enabled: true
   releaseStage: alpha

--- a/airbyte-integrations/connectors/destination-rabbitmq/metadata.yaml
+++ b/airbyte-integrations/connectors/destination-rabbitmq/metadata.yaml
@@ -10,7 +10,7 @@ data:
   name: RabbitMQ
   registries:
     cloud:
-      enabled: false
+      enabled: false # hide RabbitMQ Destination https://github.com/airbytehq/airbyte/issues/16315
     oss:
       enabled: true
   releaseStage: alpha

--- a/airbyte-integrations/connectors/destination-rabbitmq/metadata.yaml
+++ b/airbyte-integrations/connectors/destination-rabbitmq/metadata.yaml
@@ -10,7 +10,7 @@ data:
   name: RabbitMQ
   registries:
     cloud:
-      enabled: true
+      enabled: false
     oss:
       enabled: true
   releaseStage: alpha

--- a/airbyte-integrations/connectors/destination-rockset/metadata.yaml
+++ b/airbyte-integrations/connectors/destination-rockset/metadata.yaml
@@ -9,7 +9,7 @@ data:
   name: Rockset
   registries:
     cloud:
-      enabled: false
+      enabled: false # hide Rockset Destination https://github.com/airbytehq/airbyte-cloud/issues/2615
     oss:
       enabled: true
   releaseStage: alpha

--- a/airbyte-integrations/connectors/destination-rockset/metadata.yaml
+++ b/airbyte-integrations/connectors/destination-rockset/metadata.yaml
@@ -9,7 +9,7 @@ data:
   name: Rockset
   registries:
     cloud:
-      enabled: true
+      enabled: false
     oss:
       enabled: true
   releaseStage: alpha

--- a/airbyte-integrations/connectors/destination-scylla/metadata.yaml
+++ b/airbyte-integrations/connectors/destination-scylla/metadata.yaml
@@ -10,7 +10,7 @@ data:
   name: Scylla
   registries:
     cloud:
-      enabled: true
+      enabled: false
     oss:
       enabled: true
   releaseStage: alpha

--- a/airbyte-integrations/connectors/destination-scylla/metadata.yaml
+++ b/airbyte-integrations/connectors/destination-scylla/metadata.yaml
@@ -10,7 +10,7 @@ data:
   name: Scylla
   registries:
     cloud:
-      enabled: false
+      enabled: false # hide Scylla Destination https://github.com/airbytehq/airbyte-cloud/issues/2617
     oss:
       enabled: true
   releaseStage: alpha

--- a/airbyte-integrations/connectors/source-drift/metadata.yaml
+++ b/airbyte-integrations/connectors/source-drift/metadata.yaml
@@ -13,7 +13,7 @@ data:
   name: Drift
   registries:
     cloud:
-      enabled: false
+      enabled: false # hide Source Drift https://github.com/airbytehq/airbyte/issues/24270
     oss:
       enabled: true
   releaseStage: alpha

--- a/airbyte-integrations/connectors/source-salesforce-singer/metadata.yaml
+++ b/airbyte-integrations/connectors/source-salesforce-singer/metadata.yaml
@@ -9,7 +9,7 @@ data:
   name: Salesforce (Singer)
   registries:
     cloud:
-      enabled: true
+      enabled: false
     oss:
       enabled: false
   releaseStage: alpha


### PR DESCRIPTION
## What
There are a number of connectors that are in the cloud connector registry that have been hidden from the users
https://github.com/airbytehq/airbyte-platform-internal/blob/master/oss/airbyte-webapp/src/core/domain/connector/constants.ts#L2

This PR disables them in the cloud registry so that we dont tell prospective customers they are available when they are not

closes #27254
