### PR TITLE
[ISSUE #26607] CATs: support list in state

### DIFF
--- a/airbyte-integrations/bases/connector-acceptance-test/connector_acceptance_test/config.py
+++ b/airbyte-integrations/bases/connector-acceptance-test/connector_acceptance_test/config.py
@@ -7,7 +7,7 @@ import logging
 from copy import deepcopy
 from enum import Enum
 from pathlib import Path
-from typing import Generic, List, Mapping, Optional, Set, TypeVar
+from typing import Generic, List, Mapping, Optional, Set, TypeVar, Union
 
 from pydantic import BaseModel, Field, root_validator, validator
 from pydantic.generics import GenericModel
@@ -160,7 +160,7 @@ class FutureStateConfig(BaseConfig):
 class IncrementalConfig(BaseConfig):
     config_path: str = config_path
     configured_catalog_path: Optional[str] = configured_catalog_path
-    cursor_paths: Optional[Mapping[str, List[str]]] = Field(
+    cursor_paths: Optional[Mapping[str, List[Union[int, str]]]] = Field(
         description="For each stream, the path of its cursor field in the output state messages."
     )
     future_state: Optional[FutureStateConfig] = Field(description="Configuration for the future state.")

--- a/airbyte-integrations/bases/connector-acceptance-test/connector_acceptance_test/tests/test_incremental.py
+++ b/airbyte-integrations/bases/connector-acceptance-test/connector_acceptance_test/tests/test_incremental.py
@@ -155,7 +155,7 @@ class TestIncremental(BaseTest):
         inputs: IncrementalConfig,
         connector_config: SecretDict,
         configured_catalog_for_incremental: ConfiguredAirbyteCatalog,
-        cursor_paths: dict[str, list[str]],
+        cursor_paths: dict[str, list[Union[int, str]]],
         docker_runner: ConnectorRunner,
     ):
         threshold_days = getattr(inputs, "threshold_days") or 0

--- a/airbyte-integrations/bases/connector-acceptance-test/connector_acceptance_test/utils/json_schema_helper.py
+++ b/airbyte-integrations/bases/connector-acceptance-test/connector_acceptance_test/utils/json_schema_helper.py
@@ -43,7 +43,7 @@ class CatalogField:
             return pendulum.parse(value)
         return value
 
-    def parse(self, record: Mapping[str, Any], path: Optional[List[str]] = None) -> Any:
+    def parse(self, record: Mapping[str, Any], path: Optional[List[Union[int, str]]] = None) -> Any:
         """Extract field value from the record and cast it to native type"""
         path = path or self.path
         value = reduce(lambda data, key: data[key], path, record)


### PR DESCRIPTION
## What
Following https://github.com/airbytehq/airbyte/pull/27223, we will have states with array in them. We would like to be able to reference them with indices like:

```
  incremental:
    - <...>
      cursor_paths:
        "answers": [ "states", 0, "cursor", "inserted_at" ]
        "answers_survey_group": [ "states", 0, "cursor", "inserted_at" ]
```

## How
Allowing to parse int and str for `cursor_paths` field allow to fetch in a dict or in a list.

## 🚨 User Impact 🚨
The change is not fully backward compatible. If a user would have defined a cursor_path as `[ "cursor", 0 ]`, today it would cast the int as a string and would generate the cursor_path [ "cursor", "0" ]. However, I have not seen such case like this in the repo as all values are strings.

 It will also unblock https://github.com/airbytehq/airbyte/issues/26607. 