### PR TITLE
Adding new endpoint contributor_commit_activity to source-github

### DIFF
--- a/airbyte-integrations/connectors/source-github/Dockerfile
+++ b/airbyte-integrations/connectors/source-github/Dockerfile
@@ -12,5 +12,5 @@ RUN pip install .
 ENV AIRBYTE_ENTRYPOINT "python /airbyte/integration_code/main.py"
 ENTRYPOINT ["python", "/airbyte/integration_code/main.py"]
 
-LABEL io.airbyte.version=1.0.1
+LABEL io.airbyte.version=1.0.2
 LABEL io.airbyte.name=airbyte/source-github

--- a/airbyte-integrations/connectors/source-github/integration_tests/configured_catalog.json
+++ b/airbyte-integrations/connectors/source-github/integration_tests/configured_catalog.json
@@ -410,6 +410,16 @@
       },
       "sync_mode": "full_refresh",
       "destination_sync_mode": "overwrite"
+    },
+    {
+      "stream": {
+        "name": "contributor_commit_activity",
+        "json_schema": {},
+        "supported_sync_modes": ["full_refresh"],
+        "source_defined_primary_key": [["url"]]
+      },
+      "sync_mode": "full_refresh",
+      "destination_sync_mode": "overwrite"
     }
   ]
 }

--- a/airbyte-integrations/connectors/source-github/metadata.yaml
+++ b/airbyte-integrations/connectors/source-github/metadata.yaml
@@ -5,7 +5,7 @@ data:
   connectorSubtype: api
   connectorType: source
   definitionId: ef69ef6e-aa7f-4af1-a01d-ef775033524e
-  dockerImageTag: 1.0.1
+  dockerImageTag: 1.0.2
   maxSecondsBetweenMessages: 5400
   dockerRepository: airbyte/source-github
   githubIssueLabel: source-github
@@ -30,6 +30,7 @@ data:
       - tags
       - teams
       - users
+      - contributor_comunity_activities
   documentationUrl: https://docs.airbyte.com/integrations/sources/github
   tags:
     - language:python

--- a/airbyte-integrations/connectors/source-github/source_github/schemas/contributor_commit_activity.json
+++ b/airbyte-integrations/connectors/source-github/source_github/schemas/contributor_commit_activity.json
@@ -1,0 +1,217 @@
+{
+    "type": "array",
+    "items": {
+      "title": "Contributor Activity",
+      "description": "Contributor Activity",
+      "type": "object",
+      "properties": {
+        "author": {
+          "anyOf": [
+            {
+              "type": "null"
+            },
+            {
+              "title": "Simple User",
+              "description": "A GitHub user.",
+              "type": "object",
+              "properties": {
+                "name": {
+                  "type": [
+                    "string",
+                    "null"
+                  ]
+                },
+                "email": {
+                  "type": [
+                    "string",
+                    "null"
+                  ]
+                },
+                "login": {
+                  "type": "string",
+                  "examples": [
+                    "octocat"
+                  ]
+                },
+                "id": {
+                  "type": "integer",
+                  "examples": [
+                    1
+                  ]
+                },
+                "node_id": {
+                  "type": "string",
+                  "examples": [
+                    "MDQ6VXNlcjE="
+                  ]
+                },
+                "avatar_url": {
+                  "type": "string",
+                  "format": "uri",
+                  "examples": [
+                    "https://github.com/images/error/octocat_happy.gif"
+                  ]
+                },
+                "gravatar_id": {
+                  "type": [
+                    "string",
+                    "null"
+                  ],
+                  "examples": [
+                    "41d064eb2195891e12d0413f63227ea7"
+                  ]
+                },
+                "url": {
+                  "type": "string",
+                  "format": "uri",
+                  "examples": [
+                    "https://api.github.com/users/octocat"
+                  ]
+                },
+                "html_url": {
+                  "type": "string",
+                  "format": "uri",
+                  "examples": [
+                    "https://github.com/octocat"
+                  ]
+                },
+                "followers_url": {
+                  "type": "string",
+                  "format": "uri",
+                  "examples": [
+                    "https://api.github.com/users/octocat/followers"
+                  ]
+                },
+                "following_url": {
+                  "type": "string",
+                  "examples": [
+                    "https://api.github.com/users/octocat/following{/other_user}"
+                  ]
+                },
+                "gists_url": {
+                  "type": "string",
+                  "examples": [
+                    "https://api.github.com/users/octocat/gists{/gist_id}"
+                  ]
+                },
+                "starred_url": {
+                  "type": "string",
+                  "examples": [
+                    "https://api.github.com/users/octocat/starred{/owner}{/repo}"
+                  ]
+                },
+                "subscriptions_url": {
+                  "type": "string",
+                  "format": "uri",
+                  "examples": [
+                    "https://api.github.com/users/octocat/subscriptions"
+                  ]
+                },
+                "organizations_url": {
+                  "type": "string",
+                  "format": "uri",
+                  "examples": [
+                    "https://api.github.com/users/octocat/orgs"
+                  ]
+                },
+                "repos_url": {
+                  "type": "string",
+                  "format": "uri",
+                  "examples": [
+                    "https://api.github.com/users/octocat/repos"
+                  ]
+                },
+                "events_url": {
+                  "type": "string",
+                  "examples": [
+                    "https://api.github.com/users/octocat/events{/privacy}"
+                  ]
+                },
+                "received_events_url": {
+                  "type": "string",
+                  "format": "uri",
+                  "examples": [
+                    "https://api.github.com/users/octocat/received_events"
+                  ]
+                },
+                "type": {
+                  "type": "string",
+                  "examples": [
+                    "User"
+                  ]
+                },
+                "site_admin": {
+                  "type": "boolean"
+                },
+                "starred_at": {
+                  "type": "string",
+                  "examples": [
+                    "\"2020-07-09T00:17:55Z\""
+                  ]
+                }
+              },
+              "required": [
+                "avatar_url",
+                "events_url",
+                "followers_url",
+                "following_url",
+                "gists_url",
+                "gravatar_id",
+                "html_url",
+                "id",
+                "node_id",
+                "login",
+                "organizations_url",
+                "received_events_url",
+                "repos_url",
+                "site_admin",
+                "starred_url",
+                "subscriptions_url",
+                "type",
+                "url"
+              ]
+            }
+          ]
+        },
+        "total": {
+          "type": "integer",
+          "examples": [
+            135
+          ]
+        },
+        "weeks": {
+          "type": "array",
+          "items": {
+            "type": "object",
+            "properties": {
+              "w": {
+                "type": "integer"
+              },
+              "a": {
+                "type": "integer"
+              },
+              "d": {
+                "type": "integer"
+              },
+              "c": {
+                "type": "integer"
+              }
+            }
+          },
+          "examples": [
+            {
+              "w": "1367712000",
+              "a": 6898,
+              "d": 77,
+              "c": 10
+            }
+          ]
+        }
+      },
+      "required": [
+        "author",
+        "total",
+        "weeks"
+      ]
+    }
+  }

--- a/airbyte-integrations/connectors/source-github/source_github/source.py
+++ b/airbyte-integrations/connectors/source-github/source_github/source.py
@@ -51,6 +51,7 @@ from .streams import (
     WorkflowJobs,
     WorkflowRuns,
     Workflows,
+    ContributorCommitActivity
 )
 from .utils import read_full_refresh
 
@@ -288,4 +289,5 @@ class SourceGithub(AbstractSource):
             workflow_runs_stream,
             WorkflowJobs(parent=workflow_runs_stream, **repository_args_with_start_date),
             TeamMemberships(parent=team_members_stream, **repository_args),
+            ContributorCommitActivity(**repository_args),
         ]

--- a/airbyte-integrations/connectors/source-github/source_github/streams.py
+++ b/airbyte-integrations/connectors/source-github/source_github/streams.py
@@ -360,6 +360,17 @@ class Collaborators(GithubStream):
     API docs: https://docs.github.com/en/rest/reference/repos#list-repository-collaborators
     """
 
+class ContributorCommitActivity(GithubStream):
+    """
+    API docs: https://docs.github.com/en/rest/metrics/statistics#get-all-contributor-commit-activity--status-codes
+    """
+
+    def path(self, stream_slice: Mapping[str, Any] = None, **kwargs) -> str:
+        return f"repos/{stream_slice['repository']}/stats/contributors"
+    
+    def parse_response(self, response: requests.Response, stream_slice: Mapping[str, Any] = None, **kwargs) -> Iterable[Mapping]:
+        for record in response.json():  # GitHub puts records in an array.
+            yield self.transform(record=record, stream_slice=stream_slice)
 
 class IssueLabels(GithubStream):
     """


### PR DESCRIPTION
## What
I'm enabling a new endpoint about the Contributors commit activity for the source-github. More details about this new enpoint can be seen here: https://docs.github.com/en/rest/metrics/statistics?apiVersion=2022-11-28#get-all-contributor-commit-activity

## How
I've added a new stream under the existing ones, calling for the 
![image](https://github.com/airbytehq/airbyte/assets/89807801/9a7e5904-53f5-4a71-9645-aa11eb493bfd)

I've also added the metadata description for this endpoint.

## Recommended reading order
1. `airbyte-integrations/connectors/source-github/source_github/schemas/contributor_commit_activity.json`
2. `airbyte-integrations/connectors/source-github/source_github/streams.py`
3. `airbyte-integrations/connectors/source-github/source_github/source.py`
4. `airbyte-integrations/connectors/source-github/integration_tests/configured_catalog.json`

## 🚨 User Impact 🚨
Other users should not be impacted by this release, this will only enable a new stream for them.


## Pre-merge Actions

<summary><strong>Updating a connector</strong></summary>

### Community member or Airbyter

- Grant edit access to maintainers ([instructions](https://docs.github.com/en/github/collaborating-with-pull-requests/working-with-forks/allowing-changes-to-a-pull-request-branch-created-from-a-fork#enabling-repository-maintainer-permissions-on-existing-pull-requests))
- Unit & integration tests added


### Airbyter

If this is a community PR, the Airbyte engineer reviewing this PR is responsible for the below items.

- Create a non-forked branch based on this PR and test the below items on it
- Build is successful
- If new credentials are required for use in CI, add them to GSM. [Instructions](https://docs.airbyte.io/connector-development#using-credentials-in-ci).
