### PR TITLE
✨Source Outreach: add streams users, tasks, templates, snippets

### DIFF
--- a/airbyte-integrations/connectors/source-outreach/Dockerfile
+++ b/airbyte-integrations/connectors/source-outreach/Dockerfile
@@ -34,5 +34,5 @@ COPY source_outreach ./source_outreach
 ENV AIRBYTE_ENTRYPOINT "python /airbyte/integration_code/main.py"
 ENTRYPOINT ["python", "/airbyte/integration_code/main.py"]
 
-LABEL io.airbyte.version=0.3.0
+LABEL io.airbyte.version=0.4.0
 LABEL io.airbyte.name=airbyte/source-outreach

--- a/airbyte-integrations/connectors/source-outreach/integration_tests/abnormal_state.json
+++ b/airbyte-integrations/connectors/source-outreach/integration_tests/abnormal_state.json
@@ -31,5 +31,17 @@
   },
   "calls": {
     "updatedAt": "2040-11-16T00:00:00Z"
+  },
+  "users": {
+    "updatedAt": "2040-11-16T00:00:00Z"
+  },
+  "tasks": {
+    "updatedAt": "2040-11-16T00:00:00Z"
+  },
+  "templates": {
+    "updatedAt": "2040-11-16T00:00:00Z"
+  },
+  "snippets": {
+    "updatedAt": "2040-11-16T00:00:00Z"
   }
 }

--- a/airbyte-integrations/connectors/source-outreach/integration_tests/configured_catalog.json
+++ b/airbyte-integrations/connectors/source-outreach/integration_tests/configured_catalog.json
@@ -142,6 +142,58 @@
       "sync_mode": "incremental",
       "destination_sync_mode": "overwrite",
       "cursor_field": ["updatedAt"]
+    },
+    {
+      "stream": {
+        "name": "users",
+        "json_schema": {},
+        "supported_sync_modes": ["full_refresh", "incremental"],
+        "source_defined_cursor": true,
+        "default_cursor_field": ["updatedAt"],
+        "source_defined_primary_key": [["id"]]
+      },
+      "sync_mode": "incremental",
+      "destination_sync_mode": "overwrite",
+      "cursor_field": ["updatedAt"]
+    },
+    {
+      "stream": {
+        "name": "tasks",
+        "json_schema": {},
+        "supported_sync_modes": ["full_refresh", "incremental"],
+        "source_defined_cursor": true,
+        "default_cursor_field": ["updatedAt"],
+        "source_defined_primary_key": [["id"]]
+      },
+      "sync_mode": "incremental",
+      "destination_sync_mode": "overwrite",
+      "cursor_field": ["updatedAt"]
+    },
+    {
+      "stream": {
+        "name": "templates",
+        "json_schema": {},
+        "supported_sync_modes": ["full_refresh", "incremental"],
+        "source_defined_cursor": true,
+        "default_cursor_field": ["updatedAt"],
+        "source_defined_primary_key": [["id"]]
+      },
+      "sync_mode": "incremental",
+      "destination_sync_mode": "overwrite",
+      "cursor_field": ["updatedAt"]
+    },
+    {
+      "stream": {
+        "name": "snippets",
+        "json_schema": {},
+        "supported_sync_modes": ["full_refresh", "incremental"],
+        "source_defined_cursor": true,
+        "default_cursor_field": ["updatedAt"],
+        "source_defined_primary_key": [["id"]]
+      },
+      "sync_mode": "incremental",
+      "destination_sync_mode": "overwrite",
+      "cursor_field": ["updatedAt"]
     }
   ]
 }

--- a/airbyte-integrations/connectors/source-outreach/integration_tests/sample_state.json
+++ b/airbyte-integrations/connectors/source-outreach/integration_tests/sample_state.json
@@ -31,5 +31,17 @@
   },
   "calls": {
     "updatedAt": "2021-06-28T10:10:20Z"
+  },
+  "users": {
+    "updatedAt": "2021-06-28T10:10:20Z"
+  },
+  "tasks": {
+    "updatedAt": "2021-06-28T10:10:20Z"
+  },
+  "templates": {
+    "updatedAt": "2021-06-28T10:10:20Z"
+  },
+  "snippets": {
+    "updatedAt": "2021-06-28T10:10:20Z"
   }
 }

--- a/airbyte-integrations/connectors/source-outreach/metadata.yaml
+++ b/airbyte-integrations/connectors/source-outreach/metadata.yaml
@@ -2,7 +2,7 @@ data:
   connectorSubtype: api
   connectorType: source
   definitionId: 3490c201-5d95-4783-b600-eaf07a4c7787
-  dockerImageTag: 0.3.0
+  dockerImageTag: 0.4.0
   dockerRepository: airbyte/source-outreach
   githubIssueLabel: source-outreach
   icon: outreach.svg

--- a/airbyte-integrations/connectors/source-outreach/source_outreach/schemas/snippets.json
+++ b/airbyte-integrations/connectors/source-outreach/source_outreach/schemas/snippets.json
@@ -1,0 +1,57 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "type": "object",
+  "additionalProperties": true,
+  "properties": {
+    "id": {
+      "type": "integer"
+    },
+    "bodyHtml": {
+      "type": ["null", "string"]
+    },
+    "bodyText": {
+      "type": ["null", "string"]
+    },
+    "createdAt": {
+      "type": ["null", "string"],
+      "format": "date-time"
+    },
+    "name": {
+      "type": ["null", "string"]
+    },
+    "shareType": {
+      "type": ["null", "string"]
+    },
+    "tags": {
+      "type": ["null", "string"]
+    },
+    "updatedAt": {
+      "type": ["null", "string"],
+      "format": "date-time"
+    },
+    "contentCategoryMemberships": {
+      "type": ["null", "array"],
+      "items": {
+        "type": ["null", "integer"]
+      }
+    },
+    "creator": {
+      "type": ["null", "array"],
+      "items": {
+        "type": ["null", "integer"]
+      }
+    },
+    "owner": {
+      "type": ["null", "array"],
+      "items": {
+        "type": ["null", "integer"]
+      }
+    },
+    "updater": {
+      "type": ["null", "array"],
+      "items": {
+        "type": ["null", "integer"]
+      }
+    }
+  }
+}

--- a/airbyte-integrations/connectors/source-outreach/source_outreach/schemas/tasks.json
+++ b/airbyte-integrations/connectors/source-outreach/source_outreach/schemas/tasks.json
@@ -1,0 +1,167 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "type": "object",
+  "additionalProperties": true,
+  "properties": {
+    "id": {
+      "type": "integer"
+    },
+    "action": {
+      "type": ["null", "string"]
+    },
+    "autoskipAt": {
+      "type": ["null", "string"],
+      "format": "date-time"
+    },
+    "compiledSequenceTemplateHtml": {
+      "type": ["null", "string"]
+    },
+    "completed": {
+      "type": ["null", "boolean"]
+    },
+    "completedAt": {
+      "type": ["null", "string"],
+      "format": "date-time"
+    },
+    "createdAt": {
+      "type": ["null", "string"],
+      "format": "date-time"
+    },
+    "dueAt": {
+      "type": ["null", "string"],
+      "format": "date-time"
+    },
+    "note": {
+      "type": ["null", "string"]
+    },
+    "opportunityAssociation": {
+      "type": ["null", "string"]
+    },
+    "scheduledAt": {
+      "type": ["null", "string"],
+      "format": "date-time"
+    },
+    "state": {
+      "type": ["null", "string"]
+    },
+    "stateChangedAt": {
+      "type": ["null", "string"],
+      "format": "date-time"
+    },
+    "taskType": {
+      "type": ["null", "string"]
+    },
+    "updatedAt": {
+      "type": ["null", "string"],
+      "format": "date-time"
+    },
+    "account": {
+      "type": ["null", "array"],
+      "items": {
+        "type": ["null", "integer"]
+      }
+    },
+    "call": {
+      "type": ["null", "array"],
+      "items": {
+        "type": ["null", "integer"]
+      }
+    },
+    "calls": {
+      "type": ["null", "array"],
+      "items": {
+        "type": ["null", "integer"]
+      }
+    },
+    "completer": {
+      "type": ["null", "array"],
+      "items": {
+        "type": ["null", "integer"]
+      }
+    },
+    "creator": {
+      "type": ["null", "array"],
+      "items": {
+        "type": ["null", "integer"]
+      }
+    },
+    "mailing": {
+      "type": ["null", "array"],
+      "items": {
+        "type": ["null", "integer"]
+      }
+    },
+    "mailings": {
+      "type": ["null", "array"],
+      "items": {
+        "type": ["null", "integer"]
+      }
+    },
+    "opportunity": {
+      "type": ["null", "array"],
+      "items": {
+        "type": ["null", "integer"]
+      }
+    },
+    "owner": {
+      "type": ["null", "array"],
+      "items": {
+        "type": ["null", "integer"]
+      }
+    },
+    "prospect": {
+      "type": ["null", "array"],
+      "items": {
+        "type": ["null", "integer"]
+      }
+    },
+    "sequence": {
+      "type": ["null", "array"],
+      "items": {
+        "type": ["null", "integer"]
+      }
+    },
+    "sequenceSequenceSteps": {
+      "type": ["null", "array"],
+      "items": {
+        "type": ["null", "integer"]
+      }
+    },
+    "sequenceState": {
+      "type": ["null", "array"],
+      "items": {
+        "type": ["null", "integer"]
+      }
+    },
+    "sequenceStep": {
+      "type": ["null", "array"],
+      "items": {
+        "type": ["null", "integer"]
+      }
+    },
+    "sequenceTemplate": {
+      "type": ["null", "array"],
+      "items": {
+        "type": ["null", "integer"]
+      }
+    },
+    "subject": {
+      "type": ["null", "array"],
+      "items": {
+        "type": ["null", "integer"]
+      }
+    },
+    "taskPriority": {
+      "type": ["null", "array"],
+      "items": {
+        "type": ["null", "integer"]
+      }
+    },
+    "template": {
+      "type": ["null", "array"],
+      "items": {
+        "type": ["null", "integer"]
+      }
+    }
+  }
+}

--- a/airbyte-integrations/connectors/source-outreach/source_outreach/schemas/templates.json
+++ b/airbyte-integrations/connectors/source-outreach/source_outreach/schemas/templates.json
@@ -1,0 +1,131 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "type": "object",
+  "additionalProperties": true,
+  "properties": {
+    "id": {
+      "type": "integer"
+    },
+    "archived": {
+      "type": ["null", "boolean"]
+    },
+    "archivedAt": {
+      "type": ["null", "string"],
+      "format": "date-time"
+    },
+    "bccRecipients": {
+      "type": ["null", "string"]
+    },
+    "bodyHtml": {
+      "type": ["null", "string"]
+    },
+    "bodyText": {
+      "type": ["null", "string"]
+    },
+    "bounceCount": {
+      "type": ["null", "integer"]
+    },
+    "ccRecipients": {
+      "type": ["null", "string"]
+    },
+    "clickCount": {
+      "type": ["null", "integer"]
+    },
+    "createdAt": {
+      "type": ["null", "string"],
+      "format": "date-time"
+    },
+    "deliverCount": {
+      "type": ["null", "integer"]
+    },
+    "failureCount": {
+      "type": ["null", "integer"]
+    },
+    "lastUsedAt": {
+      "type": ["null", "string"],
+      "format": "date-time"
+    },
+    "name": {
+      "type": ["null", "string"]
+    },
+    "negativeReplyCount": {
+      "type": ["null", "integer"]
+    },
+    "neutralReplyCount": {
+      "type": ["null", "integer"]
+    },
+    "openCount": {
+      "type": ["null", "integer"]
+    },
+    "optOutCount": {
+      "type": ["null", "integer"]
+    },
+    "positiveReplyCount": {
+      "type": ["null", "integer"]
+    },
+    "replyCount": {
+      "type": ["null", "integer"]
+    },
+    "scheduleCount": {
+      "type": ["null", "integer"]
+    },
+    "shareType": {
+      "type": ["null", "string"]
+    },
+    "subject": {
+      "type": ["null", "string"]
+    },
+    "tags": {
+      "type": ["null", "string"]
+    },
+    "toRecipients": {
+      "type": ["null", "string"]
+    },
+    "trackLinks": {
+      "type": ["null", "boolean"]
+    },
+    "trackOpens": {
+      "type": ["null", "boolean"]
+    },
+    "updatedAt": {
+      "type": ["null", "string"],
+      "format": "date-time"
+    },
+    "contentCategoryMemberships": {
+      "type": ["null", "array"],
+      "items": {
+        "type": ["null", "integer"]
+      }
+    },
+    "creator": {
+      "type": ["null", "array"],
+      "items": {
+        "type": ["null", "integer"]
+      }
+    },
+    "owner": {
+      "type": ["null", "array"],
+      "items": {
+        "type": ["null", "integer"]
+      }
+    },
+    "recipients": {
+      "type": ["null", "array"],
+      "items": {
+        "type": ["null", "integer"]
+      }
+    },
+    "sequenceTemplates": {
+      "type": ["null", "array"],
+      "items": {
+        "type": ["null", "integer"]
+      }
+    },
+    "updater": {
+      "type": ["null", "array"],
+      "items": {
+        "type": ["null", "integer"]
+      }
+    }
+  }
+}

--- a/airbyte-integrations/connectors/source-outreach/source_outreach/schemas/users.json
+++ b/airbyte-integrations/connectors/source-outreach/source_outreach/schemas/users.json
@@ -1,0 +1,299 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "type": "object",
+  "additionalProperties": true,
+  "properties": {
+    "id": {
+      "type": "integer"
+    },
+    "accountsViewId": {
+      "type": ["null", "integer"]
+    },
+    "activityNotificationsDisabled": {
+      "type": ["null", "boolean"]
+    },
+    "bounceWarningEmailEnabled": {
+      "type": ["null", "boolean"]
+    },
+    "bridgePhone": {
+      "type": ["null", "string"]
+    },
+    "bridgePhoneExtension": {
+      "type": ["null", "string"]
+    },
+    "callsViewId": {
+      "type": ["null", "integer"]
+    },
+    "controlledTabDefault": {
+      "type": ["null", "string"]
+    },
+    "createdAt": {
+      "type": ["null", "string"],
+      "format": "date-time"
+    },
+    "currentSignInAt": {
+      "type": ["null", "string"],
+      "format": "date-time"
+    },
+    "custom1": {
+      "type": ["null", "string"]
+    },
+    "custom2": {
+      "type": ["null", "string"]
+    },
+    "custom3": {
+      "type": ["null", "string"]
+    },
+    "custom4": {
+      "type": ["null", "string"]
+    },
+    "custom5": {
+      "type": ["null", "string"]
+    },
+    "dailyDigestEmailEnabled": {
+      "type": ["null", "boolean"]
+    },
+    "defaultRulesetId": {
+      "type": ["null", "integer"]
+    },
+    "duties": {
+      "items": {
+        "properties": {
+          "duty_type": {
+            "type": ["null", "string"]
+          },
+          "id": {
+            "type": ["null", "integer"]
+          },
+          "name": {
+            "type": ["null", "string"]
+          }
+        },
+        "type": "object"
+      },
+      "type": ["null", "array"]
+    },
+    "email": {
+      "type": ["null", "string"]
+    },
+    "enableVoiceRecordings": {
+      "type": ["null", "boolean"]
+    },
+    "engagementEmailsEnabled": {
+      "type": ["null", "boolean"]
+    },
+    "firstName": {
+      "type": ["null", "string"]
+    },
+    "inboundBridgePhone": {
+      "type": ["null", "string"]
+    },
+    "inboundBridgePhoneExtension": {
+      "type": ["null", "string"]
+    },
+    "inboundCallBehavior": {
+      "type": ["null", "string"]
+    },
+    "inboundPhoneType": {
+      "type": ["null", "string"]
+    },
+    "inboundVoicemailCustomMessageText": {
+      "type": ["null", "string"]
+    },
+    "inboundVoicemailMessageTextVoice": {
+      "type": ["null", "string"]
+    },
+    "inboundVoicemailPromptType": {
+      "type": ["null", "string"]
+    },
+    "kaiaRecordingsViewId": {
+      "type": ["null", "integer"]
+    },
+    "keepBridgePhoneConnected": {
+      "type": ["null", "boolean"]
+    },
+    "lastName": {
+      "type": ["null", "string"]
+    },
+    "lastSignInAt": {
+      "type": ["null", "string"],
+      "format": "date-time"
+    },
+    "locked": {
+      "type": ["null", "boolean"]
+    },
+    "mailboxErrorEmailEnabled": {
+      "type": ["null", "boolean"]
+    },
+    "meetingEngagementNotificationEnabled": {
+      "type": ["null", "boolean"]
+    },
+    "name": {
+      "type": ["null", "string"]
+    },
+    "notificationsEnabled": {
+      "type": ["null", "boolean"]
+    },
+    "oceClickToDialEverywhere": {
+      "type": ["null", "boolean"]
+    },
+    "oceGmailToolbar": {
+      "type": ["null", "boolean"]
+    },
+    "oceGmailTrackingState": {
+      "type": ["null", "string"]
+    },
+    "oceSalesforceEmailDecorating": {
+      "type": ["null", "boolean"]
+    },
+    "oceSalesforcePhoneDecorating": {
+      "type": ["null", "boolean"]
+    },
+    "oceUniversalTaskFlow": {
+      "type": ["null", "boolean"]
+    },
+    "oceWindowMode": {
+      "type": ["null", "boolean"]
+    },
+    "opportunitiesViewId": {
+      "type": ["null", "integer"]
+    },
+    "passwordExpiresAt": {
+      "type": ["null", "string"],
+      "format": "date-time"
+    },
+    "phoneCountryCode": {
+      "type": ["null", "string"]
+    },
+    "phoneNumber": {
+      "type": ["null", "string"]
+    },
+    "phoneType": {
+      "type": ["null", "string"]
+    },
+    "pluginAlertNotificationEnabled": {
+      "type": ["null", "boolean"]
+    },
+    "preferredVoiceRegion": {
+      "type": ["null", "string"]
+    },
+    "prefersLocalPresence": {
+      "type": ["null", "boolean"]
+    },
+    "primaryTimezone": {
+      "type": ["null", "string"]
+    },
+    "prospectsViewId": {
+      "type": ["null", "integer"]
+    },
+    "reportsTeamPerfViewId": {
+      "type": ["null", "integer"]
+    },
+    "reportsViewId": {
+      "type": ["null", "integer"]
+    },
+    "scimExternalId": {
+      "type": ["null", "string"]
+    },
+    "scimSource": {
+      "type": ["null", "string"]
+    },
+    "secondaryTimezone": {
+      "type": ["null", "string"]
+    },
+    "senderNotificationsExcluded": {
+      "type": ["null", "boolean"]
+    },
+    "tasksViewId": {
+      "type": ["null", "integer"]
+    },
+    "teamsViewId": {
+      "type": ["null", "integer"]
+    },
+    "tertiaryTimezone": {
+      "type": ["null", "string"]
+    },
+    "textingEmailNotifications": {
+      "type": ["null", "boolean"]
+    },
+    "title": {
+      "type": ["null", "string"]
+    },
+    "unknownReplyEmailEnabled": {
+      "type": ["null", "boolean"]
+    },
+    "updatedAt": {
+      "type": ["null", "string"],
+      "format": "date-time"
+    },
+    "userGuid": {
+      "type": ["null", "string"]
+    },
+    "username": {
+      "type": ["null", "string"]
+    },
+    "usersViewId": {
+      "type": ["null", "integer"]
+    },
+    "voicemailNotificationEnabled": {
+      "type": ["null", "boolean"]
+    },
+    "weeklyDigestEmailEnabled": {
+      "type": ["null", "boolean"]
+    },
+    "contentCategories": {
+      "type": ["null", "array"],
+      "items": {
+        "type": ["null", "integer"]
+      }
+    },
+    "creator": {
+      "type": ["null", "array"],
+      "items": {
+        "type": ["null", "integer"]
+      }
+    },
+    "mailbox": {
+      "type": ["null", "array"],
+      "items": {
+        "type": ["null", "integer"]
+      }
+    },
+    "mailboxes": {
+      "type": ["null", "array"],
+      "items": {
+        "type": ["null", "integer"]
+      }
+    },
+    "profile": {
+      "type": ["null", "array"],
+      "items": {
+        "type": ["null", "integer"]
+      }
+    },
+    "recipients": {
+      "type": ["null", "array"],
+      "items": {
+        "type": ["null", "integer"]
+      }
+    },
+    "role": {
+      "type": ["null", "array"],
+      "items": {
+        "type": ["null", "integer"]
+      }
+    },
+    "teams": {
+      "type": ["null", "array"],
+      "items": {
+        "type": ["null", "integer"]
+      }
+    },
+    "updater": {
+      "type": ["null", "array"],
+      "items": {
+        "type": ["null", "integer"]
+      }
+    }
+  }
+}

--- a/airbyte-integrations/connectors/source-outreach/source_outreach/source.py
+++ b/airbyte-integrations/connectors/source-outreach/source_outreach/source.py
@@ -208,6 +208,46 @@ class Calls(IncrementalOutreachStream):
         return "calls"
 
 
+class Users(IncrementalOutreachStream):
+    """
+    Users stream. Yields data from the GET /users endpoint.
+    See https://api.outreach.io/api/v2/docs#user
+    """
+
+    def path(self, **kwargs) -> str:
+        return "users"
+
+
+class Tasks(IncrementalOutreachStream):
+    """
+    Tasks stream. Yields data from the GET /tasts endpoint.
+    See https://api.outreach.io/api/v2/docs#task
+    """
+
+    def path(self, **kwargs) -> str:
+        return "tasks"
+
+
+class Templates(IncrementalOutreachStream):
+    """
+    Templates stream. Yields data from the GET /templates endpoint.
+    See https://api.outreach.io/api/v2/docs#template
+    """
+
+    def path(self, **kwargs) -> str:
+        return "templates"
+
+
+class Snippets(IncrementalOutreachStream):
+    """
+    Snippets stream. Yields data from the GET /snippets endpoint.
+    See https://api.outreach.io/api/v2/docs#snippet
+    """
+
+    def path(self, **kwargs) -> str:
+        return "snippets"
+
+
 class OutreachAuthenticator(Oauth2Authenticator):
     def __init__(self, redirect_uri: str, token_refresh_endpoint: str, client_id: str, client_secret: str, refresh_token: str):
         super().__init__(
@@ -256,4 +296,8 @@ class SourceOutreach(AbstractSource):
             Mailboxes(authenticator=auth, **config),
             Stages(authenticator=auth, **config),
             Calls(authenticator=auth, **config),
+            Users(authenticator=auth, **config),
+            Tasks(authenticator=auth, **config),
+            Templates(authenticator=auth, **config),
+            Snippets(authenticator=auth, **config),
         ]

--- a/airbyte-integrations/connectors/source-outreach/unit_tests/test_source.py
+++ b/airbyte-integrations/connectors/source-outreach/unit_tests/test_source.py
@@ -11,5 +11,5 @@ def test_streams(mocker):
     source = SourceOutreach()
     config_mock = MagicMock()
     streams = source.streams(config_mock)
-    expected_streams_number = 11
+    expected_streams_number = 15
     assert len(streams) == expected_streams_number

--- a/docs/integrations/sources/outreach.md
+++ b/docs/integrations/sources/outreach.md
@@ -44,6 +44,10 @@ List of available streams:
 - Personas
 - Mailboxes
 - Stages
+- Users
+- Tasks
+- Templates
+- Snippets
 
 ## Changelog
 

--- a/docs/integrations/sources/outreach.md
+++ b/docs/integrations/sources/outreach.md
@@ -51,9 +51,9 @@ List of available streams:
 
 ## Changelog
 
-| Version | Date | Pull Request | Subject |
-
-| :------ | :-------- | :----- | :------ |
+| Version | Date       | Pull Request | Subject |
+| :------ |:-----------| :----- | :------ |
+| 0.4.0 | 2023-06-14 | [27343](https://github.com/airbytehq/airbyte/pull/27343) | Add Users, Tasks, Templates, Snippets streams
 | 0.3.0 | 2023-05-17 | [26211](https://github.com/airbytehq/airbyte/pull/26211) | Add SequenceStates Stream
 | 0.2.0 | 2022-10-27 | [17385](https://github.com/airbytehq/airbyte/pull/17385) | Add new streams + page size variable + relationship data |
 | 0.1.2 | 2022-07-04 | [14386](https://github.com/airbytehq/airbyte/pull/14386) | Fix stream schema and cursor field |


### PR DESCRIPTION
## What
It adds four additional streams to outreach connector: users, tasks, templates, snippets.
(issue #27328)

## How
By adding streams to `source.py` and stream schemas to `schemas/`

## Recommended reading order
1. `source.py`
2. `schemas/*.json` (see corresponding tables in [Outreach API](https://api.outreach.io/api/v2/docs))
3. everything else (tests)

## 🚨 User Impact 🚨
Currently available streams are not touched, no backward compatibility issues. 
Bumped docker version.


## Pre-merge Actions
### Community member or Airbyter

- ✅Grant edit access to maintainers ([instructions](https://docs.github.com/en/github/collaborating-with-pull-requests/working-with-forks/allowing-changes-to-a-pull-request-branch-created-from-a-fork#enabling-repository-maintainer-permissions-on-existing-pull-requests))
- ✅Integration tests: 
![image](https://github.com/airbytehq/airbyte/assets/477391/5df6af38-071c-4f80-8ee0-6a3457d9f2cb)
- ✅Unit tests: 
![image](https://github.com/airbytehq/airbyte/assets/477391/1747a397-4382-46ad-9078-f523387af274)


### Airbyter

If this is a community PR, the Airbyte engineer reviewing this PR is responsible for the below items.

- Create a non-forked branch based on this PR and test the below items on it
- Build is successful
- If new credentials are required for use in CI, add them to GSM. [Instructions](https://docs.airbyte.io/connector-development#using-credentials-in-ci).
