### PR TITLE
🤖 Cloud Availability updater: new connectors to deploy [20230614]

### DIFF
--- a/airbyte-integrations/connectors/destination-amazon-sqs/metadata.yaml
+++ b/airbyte-integrations/connectors/destination-amazon-sqs/metadata.yaml
@@ -10,7 +10,7 @@ data:
   name: Amazon SQS
   registries:
     cloud:
-      enabled: false # hide Amazon SQS Destination https://github.com/airbytehq/airbyte/issues/16316
+      enabled: true  # hide Amazon SQS Destination https://github.com/airbytehq/airbyte/issues/16316
     oss:
       enabled: true
   releaseStage: alpha

--- a/airbyte-integrations/connectors/destination-cassandra/metadata.yaml
+++ b/airbyte-integrations/connectors/destination-cassandra/metadata.yaml
@@ -10,7 +10,7 @@ data:
   name: Cassandra
   registries:
     cloud:
-      enabled: false # hide Cassandra Destination https://github.com/airbytehq/airbyte-cloud/issues/2606
+      enabled: true  # hide Cassandra Destination https://github.com/airbytehq/airbyte-cloud/issues/2606
     oss:
       enabled: true
   releaseStage: alpha

--- a/airbyte-integrations/connectors/destination-mariadb-columnstore/metadata.yaml
+++ b/airbyte-integrations/connectors/destination-mariadb-columnstore/metadata.yaml
@@ -10,7 +10,7 @@ data:
   name: MariaDB ColumnStore
   registries:
     cloud:
-      enabled: false # hide MariaDB Destination https://github.com/airbytehq/airbyte-cloud/issues/2611
+      enabled: true  # hide MariaDB Destination https://github.com/airbytehq/airbyte-cloud/issues/2611
     oss:
       enabled: true
   releaseStage: alpha

--- a/airbyte-integrations/connectors/destination-pulsar/metadata.yaml
+++ b/airbyte-integrations/connectors/destination-pulsar/metadata.yaml
@@ -10,7 +10,7 @@ data:
   name: Pulsar
   registries:
     cloud:
-      enabled: false # hide Pulsar Destination https://github.com/airbytehq/airbyte-cloud/issues/2614
+      enabled: true  # hide Pulsar Destination https://github.com/airbytehq/airbyte-cloud/issues/2614
     oss:
       enabled: true
   releaseStage: alpha


### PR DESCRIPTION
The Cloud Availability Updater decided that it's the right time to make the following 4 connectors available on Cloud!

# Promoted connectors
|   connector_technical_name    |connector_version|      connector_definition_id       |
|-------------------------------|-----------------|------------------------------------|
|destination-amazon-sqs         |0.1.0            |0eeee7fb-518f-4045-bacc-9619e31c43ea|
|destination-cassandra          |0.1.4            |707456df-6f4f-4ced-b5c6-03f73bcad1c5|
|destination-mariadb-columnstore|0.1.7            |294a4790-429b-40ae-9516-49826b9702e1|
|destination-pulsar             |0.1.3            |2340cbba-358e-11ec-8d3d-0242ac130203|

# Excluded but eligible connectors
|connector_technical_name|connector_version|connector_definition_id|
|------------------------|-----------------|-----------------------|

 ☝️ These eligible connectors are already in the definitions masks. They might have been explicitly pinned or excluded. We're not adding these for safety.