### PR TITLE
connectors-ci: minor cleaning

### DIFF
--- a/tools/ci_connector_ops/ci_connector_ops/pipelines/tests/common.py
+++ b/tools/ci_connector_ops/ci_connector_ops/pipelines/tests/common.py
@@ -155,7 +155,6 @@ class QaChecks(Step):
         filtered_repo = self.context.get_repo_dir(
             include=include,
         )
-        ci_connector_ops = ci_connector_ops.with_mounted_directory("/airbyte", filtered_repo).with_workdir("/airbyte").with_exec(["ls"])
 
         qa_checks = (
             ci_connector_ops.with_mounted_directory("/airbyte", filtered_repo)

--- a/tools/ci_connector_ops/ci_connector_ops/pipelines/utils.py
+++ b/tools/ci_connector_ops/ci_connector_ops/pipelines/utils.py
@@ -241,6 +241,8 @@ def get_modified_connectors(modified_files: Set[Union[str, Path]]) -> dict:
     modified_connectors = {}
     all_connector_dependencies = [(connector, connector.get_local_dependencies_paths()) for connector in get_all_released_connectors()]
     for modified_file in modified_files:
+        if str(modified_file).endswith(".md"):
+            continue
         for connector, connector_dependencies in all_connector_dependencies:
             for connector_dependency in connector_dependencies:
                 connector_dependency_parts = connector_dependency.parts


### PR DESCRIPTION
## What
* Ignore changes to markdown files to detect modified connectors. Doc updates would otherwise trigger tests.
* Remove a superflous `ls` instruction that was used for debugging only