### PR TITLE
Issue 26607/fix cats support array in state

### DIFF
--- a/airbyte-integrations/bases/connector-acceptance-test/CHANGELOG.md
+++ b/airbyte-integrations/bases/connector-acceptance-test/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## 0.10.7
+Fix on supporting arrays in the state (ensure string are parsed as string and not int)
+
+## 0.10.6
+Supporting arrays in the state by allowing ints in cursor_paths
+
 ## 0.10.5
 Skipping test_catalog_has_supported_data_types as it is failing on too many connectors. Will first address globally the type/format problems at scale and then re-enable it.
 

--- a/airbyte-integrations/bases/connector-acceptance-test/Dockerfile
+++ b/airbyte-integrations/bases/connector-acceptance-test/Dockerfile
@@ -33,7 +33,7 @@ COPY pytest.ini setup.py ./
 COPY connector_acceptance_test ./connector_acceptance_test
 RUN pip install .
 
-LABEL io.airbyte.version=0.10.5
+LABEL io.airbyte.version=0.10.7
 LABEL io.airbyte.name=airbyte/connector-acceptance-test
 
 ENTRYPOINT ["python", "-m", "pytest", "-p", "connector_acceptance_test.plugin", "-r", "fEsx"]

--- a/airbyte-integrations/bases/connector-acceptance-test/connector_acceptance_test/config.py
+++ b/airbyte-integrations/bases/connector-acceptance-test/connector_acceptance_test/config.py
@@ -174,6 +174,9 @@ class IncrementalConfig(BaseConfig):
         description="Determines whether to skip more granular testing for incremental syncs", default=False
     )
 
+    class Config:
+       smart_union = True
+
 
 class GenericTestConfig(GenericModel, Generic[TestConfigT]):
     bypass_reason: Optional[str]

--- a/airbyte-integrations/bases/connector-acceptance-test/connector_acceptance_test/config.py
+++ b/airbyte-integrations/bases/connector-acceptance-test/connector_acceptance_test/config.py
@@ -175,7 +175,7 @@ class IncrementalConfig(BaseConfig):
     )
 
     class Config:
-       smart_union = True
+        smart_union = True
 
 
 class GenericTestConfig(GenericModel, Generic[TestConfigT]):

--- a/airbyte-integrations/bases/connector-acceptance-test/unit_tests/test_config.py
+++ b/airbyte-integrations/bases/connector-acceptance-test/unit_tests/test_config.py
@@ -100,6 +100,33 @@ class TestConfig:
             parsed_config = config.Config.parse_obj(raw_config)
             assert parsed_config == expected_output_config
 
+    def test_cursor_path_union_str(self):
+        parsed_config = config.Config.parse_obj(self._config_with_incremental_cursor_paths(["2331"]))
+        assert type(parsed_config.acceptance_tests.incremental.tests[0].cursor_paths["stream_name"][0]) == str
+
+    def test_cursor_path_union_int(self):
+        parsed_config = config.Config.parse_obj(self._config_with_incremental_cursor_paths([2331]))
+        assert type(parsed_config.acceptance_tests.incremental.tests[0].cursor_paths["stream_name"][0]) == int
+
+    @staticmethod
+    def _config_with_incremental_cursor_paths(cursor_paths):
+        return {
+            "connector_image": "foo",
+            "acceptance_tests": {
+                "incremental": {
+                    "tests": [
+                        {
+                            "config_path": "config_path.json",
+                            "cursor_paths": {
+                                "stream_name": cursor_paths
+                            }
+                        }
+                    ]
+                }
+            },
+            "test_strictness_level": "low"
+        }
+
     @pytest.mark.parametrize(
         "legacy_config, expected_parsed_config",
         [


### PR DESCRIPTION
## What
Follow up on https://github.com/airbytehq/airbyte/pull/27306 as Pydantic always try to cast as the first time. source-posthog had a cursor that was "2331" as a string and it was being casted as an int which ended up failing the CATs for this source. So basically, we want "2331" to stay a string and 2331 to stay an int

## How
Pydantic aggressively casts based on the order the Union is defined. In this case, I set it up as Union[int, str] so it would cast as int first and if it didn’t work cast a str. To avoid doing that and keeping the type received, we need to define smart_union = True