### PR TITLE
connectors-ci: java connector auto format

### DIFF
--- a/tools/ci_connector_ops/ci_connector_ops/pipelines/actions/environments.py
+++ b/tools/ci_connector_ops/ci_connector_ops/pipelines/actions/environments.py
@@ -421,11 +421,11 @@ def with_gradle(
         "buildSrc",
         "tools/bin/build_image.sh",
         "tools/lib/lib.sh",
+        "tools/gradle/codestyle",
     ]
 
     if sources_to_include:
         include += sources_to_include
-
     gradle_dependency_cache: CacheVolume = context.dagger_client.cache_volume("gradle-dependencies-caching")
     gradle_build_cache: CacheVolume = context.dagger_client.cache_volume(f"{context.connector.technical_name}-gradle-build-cache")
 
@@ -433,7 +433,7 @@ def with_gradle(
         context.dagger_client.container()
         .from_("openjdk:17.0.1-jdk-slim")
         .with_exec(["apt-get", "update"])
-        .with_exec(["apt-get", "install", "-y", "curl", "jq", "rsync"])
+        .with_exec(["apt-get", "install", "-y", "curl", "jq", "rsync", "npm"])
         .with_env_variable("VERSION", consts.DOCKER_VERSION)
         .with_exec(["sh", "-c", "curl -fsSL https://get.docker.com | sh"])
         .with_env_variable("GRADLE_HOME", "/root/.gradle")

--- a/tools/ci_connector_ops/ci_connector_ops/pipelines/format/__init__.py
+++ b/tools/ci_connector_ops/ci_connector_ops/pipelines/format/__init__.py
@@ -8,7 +8,7 @@ from __future__ import annotations
 import anyio
 from ci_connector_ops.pipelines.bases import ConnectorReport, StepResult
 from ci_connector_ops.pipelines.contexts import ConnectorContext
-from ci_connector_ops.pipelines.format import python_connectors
+from ci_connector_ops.pipelines.format import java_connectors, python_connectors
 from ci_connector_ops.utils import ConnectorLanguage
 
 
@@ -19,7 +19,7 @@ class NoFormatStepForLanguageError(Exception):
 LANGUAGE_FORMAT_CONNECTOR_MAPPING = {
     ConnectorLanguage.PYTHON: python_connectors.run_connector_format,
     ConnectorLanguage.LOW_CODE: python_connectors.run_connector_format,
-    ConnectorLanguage.JAVA: None,
+    ConnectorLanguage.JAVA: java_connectors.run_connector_format,
 }
 
 

--- a/tools/ci_connector_ops/ci_connector_ops/pipelines/format/common.py
+++ b/tools/ci_connector_ops/ci_connector_ops/pipelines/format/common.py
@@ -1,0 +1,14 @@
+#
+# Copyright (c) 2023 Airbyte, Inc., all rights reserved.
+#
+from ci_connector_ops.pipelines.bases import Step, StepResult, StepStatus
+from dagger import Directory
+
+
+class ExportChanges(Step):
+
+    title = "Export changes to local repository"
+
+    async def _run(self, changed_directory: Directory, changed_directory_path_in_repo: str) -> StepResult:
+        await changed_directory.export(changed_directory_path_in_repo)
+        return StepResult(self, StepStatus.SUCCESS, stdout=f"Changes exported to {changed_directory_path_in_repo}")

--- a/tools/ci_connector_ops/ci_connector_ops/pipelines/format/java_connectors.py
+++ b/tools/ci_connector_ops/ci_connector_ops/pipelines/format/java_connectors.py
@@ -1,0 +1,64 @@
+#
+# Copyright (c) 2023 Airbyte, Inc., all rights reserved.
+#
+
+from typing import List, Tuple
+
+import asyncer
+from ci_connector_ops.pipelines.actions import environments
+from ci_connector_ops.pipelines.bases import StepResult, StepStatus
+from ci_connector_ops.pipelines.contexts import ConnectorContext
+from ci_connector_ops.pipelines.format.common import ExportChanges
+from ci_connector_ops.pipelines.git import GitPushChanges
+from ci_connector_ops.pipelines.gradle import GradleTask
+from ci_connector_ops.pipelines.utils import with_exit_code, with_stderr, with_stdout
+
+
+class FormatConnectorCode(GradleTask):
+    """
+    A step to format a Java connector code.
+    """
+
+    title = "Format connector code"
+
+    def _get_gradle_command(self, extra_options: Tuple[str] = ...) -> List:
+        return ["./gradlew", "format"]
+
+    async def _run(self) -> StepResult:
+        formatted = (
+            environments.with_gradle(self.context, self.build_include, bind_to_docker_host=self.BIND_TO_DOCKER_HOST)
+            .with_mounted_directory(str(self.context.connector.code_directory), await self._get_patched_connector_dir())
+            .with_exec(self._get_gradle_command())
+        )
+        async with asyncer.create_task_group() as task_group:
+            soon_exit_code = task_group.soonify(with_exit_code)(formatted)
+            soon_stderr = task_group.soonify(with_stderr)(formatted)
+            soon_stdout = task_group.soonify(with_stdout)(formatted)
+
+        return StepResult(
+            self,
+            StepStatus.from_exit_code(soon_exit_code.value),
+            stderr=soon_stderr.value,
+            stdout=soon_stdout.value,
+            output_artifact=formatted.directory(str(self.context.connector.code_directory)),
+        )
+
+
+async def run_connector_format(context: ConnectorContext) -> List[StepResult]:
+    steps_results = []
+    format_connector_code_result = await FormatConnectorCode(context).run()
+    steps_results.append(format_connector_code_result)
+
+    if context.is_local:
+        export_changes_results = await ExportChanges(context).run(
+            format_connector_code_result.output_artifact, str(context.connector.code_directory)
+        )
+        steps_results.append(export_changes_results)
+    else:
+        git_push_changes_results = await GitPushChanges(context).run(
+            format_connector_code_result.output_artifact,
+            str(context.connector.code_directory),
+            f"Auto format {context.connector.technical_name} code",
+        )
+        steps_results.append(git_push_changes_results)
+    return steps_results


### PR DESCRIPTION
## What
*Describe what the change is solving*
*It helps to add screenshots if it affects the frontend.*

## How
*Describe the solution*

## Recommended reading order
1. `x.java`
2. `y.python`

## 🚨 User Impact 🚨
*Are there any breaking changes? What is the end result perceived by the user?*

*For connector PRs, use this section to explain which type of semantic versioning bump occurs as a result of the changes. Refer to our [Semantic Versioning for Connectors](https://docs.airbyte.com/contributing-to-airbyte/#semantic-versioning-for-connectors) guidelines for more information. **Breaking changes to connectors must be documented by an Airbyte engineer (PR author, or reviewer for community PRs) by using the [Breaking Change Release Playbook](https://docs.google.com/document/d/1VYQggHbL_PN0dDDu7rCyzBLGRtX-R3cpwXaY8QxEgzw/edit).***

*If there are breaking changes, please merge this PR with the 🚨🚨 emoji so changelog authors can further highlight this if needed.*


## Pre-merge Actions
*Expand the relevant checklist and delete the others.*

<details><summary><strong>New Connector</strong></summary>

### Community member or Airbyter

- **Community member?** Grant edit access to maintainers ([instructions](https://docs.github.com/en/github/collaborating-with-pull-requests/working-with-forks/allowing-changes-to-a-pull-request-branch-created-from-a-fork#enabling-repository-maintainer-permissions-on-existing-pull-requests))
- Unit & integration tests added and passing. Community members, please provide proof of success locally e.g: screenshot or copy-paste unit, integration, and acceptance test output. To run acceptance tests for a Python connector, follow instructions in the README. For java connectors run `./gradlew :airbyte-integrations:connectors:<name>:integrationTest`.
- Connector version is set to `0.0.1`
    - `Dockerfile` has version `0.0.1`
- Documentation updated
    - Connector's `README.md`
    - Connector's `bootstrap.md`. See [description and examples](https://docs.google.com/document/d/1ypdgmwmEHWv-TrO4_YOQ7pAJGVrMp5BOkEVh831N260/edit?usp=sharing)
    - `docs/integrations/<source or destination>/<name>.md` including changelog with an entry for the initial version. See changelog [example](https://docs.airbyte.io/integrations/sources/stripe#changelog)
    - `docs/integrations/README.md`

### Airbyter

If this is a community PR, the Airbyte engineer reviewing this PR is responsible for the below items.

- Create a non-forked branch based on this PR and test the below items on it
- Build is successful
- If new credentials are required for use in CI, add them to GSM. [Instructions](https://docs.airbyte.io/connector-development#using-credentials-in-ci).

</details>

<details><summary><strong>Updating a connector</strong></summary>

### Community member or Airbyter

- Grant edit access to maintainers ([instructions](https://docs.github.com/en/github/collaborating-with-pull-requests/working-with-forks/allowing-changes-to-a-pull-request-branch-created-from-a-fork#enabling-repository-maintainer-permissions-on-existing-pull-requests))
- Unit & integration tests added


### Airbyter

If this is a community PR, the Airbyte engineer reviewing this PR is responsible for the below items.

- Create a non-forked branch based on this PR and test the below items on it
- Build is successful
- If new credentials are required for use in CI, add them to GSM. [Instructions](https://docs.airbyte.io/connector-development#using-credentials-in-ci).

</details>

<details><summary><strong>Connector Generator</strong></summary>

- Issue acceptance criteria met
- PR name follows [PR naming conventions](https://docs.airbyte.com/contributing-to-airbyte/issues-and-pull-requests#pull-request-title-convention)
- If adding a new generator, add it to the [list of scaffold modules being tested](https://github.com/airbytehq/airbyte/blob/master/airbyte-integrations/connector-templates/generator/build.gradle#L41)
- The generator test modules (all connectors with `-scaffold` in their name) have been updated with the latest scaffold by running `./gradlew :airbyte-integrations:connector-templates:generator:testScaffoldTemplates` then checking in your changes
- Documentation which references the generator is updated as needed

</details>
