### PR TITLE
Docs: Update documentation for support url to documentation url

### DIFF
--- a/airbyte-ci/connectors/metadata_service/lib/tests/fixtures/metadata_upload/invalid/metadata_cloud_image_does_not_exist.yaml
+++ b/airbyte-ci/connectors/metadata_service/lib/tests/fixtures/metadata_upload/invalid/metadata_cloud_image_does_not_exist.yaml
@@ -6,7 +6,7 @@ data:
   dockerRepository: airbyte/image-exists-1
   githubIssueLabel: source-alloydb-strict-encrypt
   dockerImageTag: 0.0.1-exists
-  supportUrl: https://docs.airbyte.com/integrations/sources/alloydb
+  documentationUrl: https://docs.airbyte.com/integrations/sources/alloydb
   connectorSubtype: database
   releaseStage: generally_available
   license: MIT

--- a/airbyte-ci/connectors/metadata_service/lib/tests/fixtures/metadata_upload/invalid/metadata_main_image_does_not_exist.yaml
+++ b/airbyte-ci/connectors/metadata_service/lib/tests/fixtures/metadata_upload/invalid/metadata_main_image_does_not_exist.yaml
@@ -6,7 +6,7 @@ data:
   dockerRepository: airbyte/image-does-not-exist-1
   githubIssueLabel: source-alloydb-strict-encrypt
   dockerImageTag: 0.0.1-exists
-  supportUrl: https://docs.airbyte.com/integrations/sources/alloydb
+  documentationUrl: https://docs.airbyte.com/integrations/sources/alloydb
   connectorSubtype: database
   releaseStage: generally_available
   license: MIT

--- a/airbyte-ci/connectors/metadata_service/lib/tests/fixtures/metadata_upload/invalid/metadata_normalization_image_does_not_exist.yaml
+++ b/airbyte-ci/connectors/metadata_service/lib/tests/fixtures/metadata_upload/invalid/metadata_normalization_image_does_not_exist.yaml
@@ -6,7 +6,7 @@ data:
   dockerRepository: airbyte/image-exists-1
   githubIssueLabel: source-alloydb-strict-encrypt
   dockerImageTag: 0.0.1-exists
-  supportUrl: https://docs.airbyte.com/integrations/sources/alloydb
+  documentationUrl: https://docs.airbyte.com/integrations/sources/alloydb
   connectorSubtype: database
   releaseStage: generally_available
   license: MIT

--- a/airbyte-ci/connectors/metadata_service/lib/tests/fixtures/metadata_upload/invalid/metadata_oss_image_does_not_exist.yaml
+++ b/airbyte-ci/connectors/metadata_service/lib/tests/fixtures/metadata_upload/invalid/metadata_oss_image_does_not_exist.yaml
@@ -6,7 +6,7 @@ data:
   dockerRepository: airbyte/image-exists-1
   githubIssueLabel: source-alloydb-strict-encrypt
   dockerImageTag: 0.0.1-exists
-  supportUrl: https://docs.airbyte.com/integrations/sources/alloydb
+  documentationUrl: https://docs.airbyte.com/integrations/sources/alloydb
   connectorSubtype: database
   releaseStage: generally_available
   license: MIT

--- a/airbyte-ci/connectors/metadata_service/lib/tests/fixtures/metadata_upload/valid/metadata_all_images_exist.yaml
+++ b/airbyte-ci/connectors/metadata_service/lib/tests/fixtures/metadata_upload/valid/metadata_all_images_exist.yaml
@@ -6,7 +6,7 @@ data:
   dockerRepository: airbyte/image-exists-1
   githubIssueLabel: source-alloydb-strict-encrypt
   dockerImageTag: 0.0.1-exists
-  supportUrl: https://docs.airbyte.com/integrations/sources/alloydb
+  documentationUrl: https://docs.airbyte.com/integrations/sources/alloydb
   connectorSubtype: database
   releaseStage: generally_available
   license: MIT

--- a/airbyte-ci/connectors/metadata_service/lib/tests/fixtures/metadata_upload/valid/metadata_main_image_does_not_exist_but_is_overrode.yaml
+++ b/airbyte-ci/connectors/metadata_service/lib/tests/fixtures/metadata_upload/valid/metadata_main_image_does_not_exist_but_is_overrode.yaml
@@ -6,7 +6,7 @@ data:
   dockerRepository: airbyte/image-does-not-exist-1
   githubIssueLabel: source-alloydb-strict-encrypt
   dockerImageTag: 0.0.1-exists
-  supportUrl: https://docs.airbyte.com/integrations/sources/alloydb
+  documentationUrl: https://docs.airbyte.com/integrations/sources/alloydb
   connectorSubtype: database
   releaseStage: generally_available
   license: MIT

--- a/docs/connector-development/connector-metadata-file.md
+++ b/docs/connector-development/connector-metadata-file.md
@@ -34,7 +34,7 @@ data:
     oss:
       enabled: true
   releaseStage: generally_available
-  supportUrl: https://docs.airbyte.com/integrations/sources/postgres
+  documentationUrl: https://docs.airbyte.com/integrations/sources/postgres
 metadataSpecVersion: "1.0"
 ```
 


### PR DESCRIPTION
## What
There were a few areas we forgot to update metadata examples to use documentationUrl and not supportUrl
