### PR TITLE
🤖 Cloud Availability updater: new connectors to deploy [20230615]

### DIFF
--- a/airbyte-integrations/connectors/destination-amazon-sqs/metadata.yaml
+++ b/airbyte-integrations/connectors/destination-amazon-sqs/metadata.yaml
@@ -10,7 +10,7 @@ data:
   name: Amazon SQS
   registries:
     cloud:
-      enabled: false # hide Amazon SQS Destination https://github.com/airbytehq/airbyte/issues/16316
+      enabled: true  # hide Amazon SQS Destination https://github.com/airbytehq/airbyte/issues/16316
     oss:
       enabled: true
   releaseStage: alpha

--- a/airbyte-integrations/connectors/source-appfollow/metadata.yaml
+++ b/airbyte-integrations/connectors/source-appfollow/metadata.yaml
@@ -10,7 +10,7 @@ data:
   name: Appfollow
   registries:
     cloud:
-      enabled: false
+      enabled: true
     oss:
       enabled: true
   releaseStage: alpha

--- a/airbyte-integrations/connectors/source-firebase-realtime-database/metadata.yaml
+++ b/airbyte-integrations/connectors/source-firebase-realtime-database/metadata.yaml
@@ -12,7 +12,7 @@ data:
   name: Firebase Realtime Database
   registries:
     cloud:
-      enabled: false
+      enabled: true
     oss:
       enabled: true
   releaseStage: alpha

--- a/airbyte-integrations/connectors/source-workramp/metadata.yaml
+++ b/airbyte-integrations/connectors/source-workramp/metadata.yaml
@@ -10,7 +10,7 @@ data:
   name: WorkRamp
   registries:
     cloud:
-      enabled: false
+      enabled: true
     oss:
       enabled: true
   releaseStage: alpha


### PR DESCRIPTION
The Cloud Availability Updater decided that it's the right time to make the following 4 connectors available on Cloud!

# Promoted connectors
|    connector_technical_name     |connector_version|      connector_definition_id       |
|---------------------------------|-----------------|------------------------------------|
|source-appfollow                 |0.1.1            |b4375641-e270-41d3-9c20-4f9cecad87a8|
|source-firebase-realtime-database|0.1.0            |acb5f973-a565-441e-992f-4946f3e65662|
|source-workramp                  |0.1.0            |05b0bce2-4ec4-4534-bb1a-5d0127bd91b7|
|destination-amazon-sqs           |0.1.0            |0eeee7fb-518f-4045-bacc-9619e31c43ea|

# Excluded but eligible connectors
|connector_technical_name|connector_version|connector_definition_id|
|------------------------|-----------------|-----------------------|

 ☝️ These eligible connectors are already in the definitions masks. They might have been explicitly pinned or excluded. We're not adding these for safety.