### PR TITLE
fix trigger on format workflow

### DIFF
--- a/.github/workflows/connectors_format.yml
+++ b/.github/workflows/connectors_format.yml
@@ -2,8 +2,8 @@ name: Format modified connectors
 
 on:
   push:
-    branches-ignore:
-      - master
+    # branches-ignore:
+    #   - master
     # TODO: remove this once we confirm the workflow is working
     branches:
       - "augustin/connectors-ci/python-auto-format"


### PR DESCRIPTION
`branches-ignore` can't be used in combination of `branches`.
Keep only `branches` for testing.