### PR TITLE
Maxi297/refactoring declarative state management

### DIFF
--- a/airbyte-cdk/python/airbyte_cdk/sources/declarative/declarative_component_schema.yaml
+++ b/airbyte-cdk/python/airbyte_cdk/sources/declarative/declarative_component_schema.yaml
@@ -574,7 +574,6 @@ definitions:
         type: string
         interpolation_context:
           - config
-          - stream_state
         examples:
           - "created_at"
           - "{{ config['record_cursor'] }}"
@@ -628,6 +627,8 @@ definitions:
         anyOf:
           - type: string
           - "$ref": "#/definitions/MinMaxDatetime"
+        interpolation_context:
+          - config
         examples:
           - "2021-01-1T00:00:00Z"
           - "{{ now_utc() }}"
@@ -638,6 +639,8 @@ definitions:
         anyOf:
           - type: string
           - "$ref": "#/definitions/MinMaxDatetime"
+        interpolation_context:
+          - config
         examples:
           - "2020-01-1T00:00:00Z"
           - "{{ config['start_time'] }}"
@@ -656,6 +659,8 @@ definitions:
         title: Lookback Window
         description: Time interval before the start_datetime to read data for, e.g. P1M for looking back one month.
         type: string
+        interpolation_context:
+          - config
         examples:
           - "P1D"
           - "P{{ config['lookback_days'] }}D"

--- a/airbyte-cdk/python/airbyte_cdk/sources/declarative/declarative_stream.py
+++ b/airbyte-cdk/python/airbyte_cdk/sources/declarative/declarative_stream.py
@@ -97,7 +97,10 @@ class DeclarativeStream(Stream):
         stream_slice: Mapping[str, Any] = None,
         stream_state: Mapping[str, Any] = None,
     ) -> Iterable[Mapping[str, Any]]:
-        for record in self.retriever.read_records(sync_mode, cursor_field, stream_slice, stream_state):
+        """
+        :param: stream_state We knowingly avoid using stream_state as we want cursors to manage their own state.
+        """
+        for record in self.retriever.read_records(sync_mode, cursor_field, stream_slice):
             yield self._apply_transformations(record, self.config, stream_slice)
 
     def _apply_transformations(
@@ -143,8 +146,7 @@ class DeclarativeStream(Stream):
 
         :param sync_mode:
         :param cursor_field:
-        :param stream_state:
+        :param stream_state: we knowingly avoid using stream_state as we want cursors to manage their own state
         :return:
         """
-        # this is not passing the cursor field because it is known at init time
-        return self.retriever.stream_slices(sync_mode=sync_mode, stream_state=stream_state)
+        return self.retriever.stream_slices(sync_mode=sync_mode)

--- a/airbyte-cdk/python/airbyte_cdk/sources/declarative/incremental/__init__.py
+++ b/airbyte-cdk/python/airbyte_cdk/sources/declarative/incremental/__init__.py
@@ -2,7 +2,8 @@
 # Copyright (c) 2022 Airbyte, Inc., all rights reserved.
 #
 
+from airbyte_cdk.sources.declarative.incremental.cursor import Cursor
 from airbyte_cdk.sources.declarative.incremental.datetime_based_cursor import DatetimeBasedCursor
 from airbyte_cdk.sources.declarative.incremental.per_partition_cursor import CursorFactory, PerPartitionCursor
 
-__all__ = ["CursorFactory", "DatetimeBasedCursor", "PerPartitionCursor"]
+__all__ = ["Cursor", "CursorFactory", "DatetimeBasedCursor", "PerPartitionCursor"]

--- a/airbyte-cdk/python/airbyte_cdk/sources/declarative/incremental/cursor.py
+++ b/airbyte-cdk/python/airbyte_cdk/sources/declarative/incremental/cursor.py
@@ -1,0 +1,41 @@
+from abc import ABC, abstractmethod
+
+from airbyte_cdk.sources.declarative.stream_slicers.stream_slicer import StreamSlicer
+from airbyte_cdk.sources.declarative.types import Record, StreamSlice, StreamState
+
+
+class Cursor(ABC, StreamSlicer):
+    """
+    Cursors are components that allow for incremental syncs. They keep track of what data has been consumed and slices the requests based on
+    that information.
+    """
+
+    @abstractmethod
+    def set_initial_state(self, stream_state: StreamState) -> None:
+        """
+        Cursors are not initialized with their state. As state is needed in order to function properly, this method should be called
+        before calling anything else
+
+        :param stream_state: The state of the stream as returned by get_stream_state
+        """
+
+    @abstractmethod
+    def update_state(self, stream_slice: StreamSlice, last_record: Record) -> None:
+        """
+        Update state based on the latest record
+
+        :param stream_slice: Current stream_slice
+        :param last_record: Last record read from the source
+        """
+
+    @abstractmethod
+    def get_stream_state(self) -> StreamState:
+        """
+        Returns the current stream state. We would like to restrict it's usage since it does expose internal of state. As of 2023-06-14, it
+        is used for two things:
+        * Interpolation of the requests
+        * Saving the state
+
+        For the first case, we are probably stuck with exposing the stream state. For the second, we can probably expose a method that
+        allows for emitting the state to the platform.
+        """

--- a/airbyte-cdk/python/airbyte_cdk/sources/declarative/incremental/cursor.py
+++ b/airbyte-cdk/python/airbyte_cdk/sources/declarative/incremental/cursor.py
@@ -38,6 +38,7 @@ class Cursor(ABC, StreamSlicer):
         Returns the current stream state. We would like to restrict it's usage since it does expose internal of state. As of 2023-06-14, it
         is used for two things:
         * Interpolation of the requests
+        * Transformation of records
         * Saving the state
 
         For the first case, we are probably stuck with exposing the stream state. For the second, we can probably expose a method that

--- a/airbyte-cdk/python/airbyte_cdk/sources/declarative/incremental/cursor.py
+++ b/airbyte-cdk/python/airbyte_cdk/sources/declarative/incremental/cursor.py
@@ -1,3 +1,7 @@
+#
+# Copyright (c) 2023 Airbyte, Inc., all rights reserved.
+#
+
 from abc import ABC, abstractmethod
 
 from airbyte_cdk.sources.declarative.stream_slicers.stream_slicer import StreamSlicer

--- a/airbyte-cdk/python/airbyte_cdk/sources/declarative/incremental/datetime_based_cursor.py
+++ b/airbyte-cdk/python/airbyte_cdk/sources/declarative/incremental/datetime_based_cursor.py
@@ -116,7 +116,7 @@ class DatetimeBasedCursor(Cursor):
         stream_slice_value = stream_slice.get(self.partition_field_start.eval(self.config))
         last_record_value = last_record.get(self.cursor_field.eval(self.config)) if last_record else None
 
-        possible_cursor_values = list(filter(lambda item: item is not None, [stream_slice_value, last_record_value, self._cursor]))
+        possible_cursor_values = list(filter(lambda item: item, [stream_slice_value, last_record_value, self._cursor]))
         self._cursor = max(possible_cursor_values) if possible_cursor_values else None
 
     def stream_slices(self, sync_mode: SyncMode) -> Iterable[Mapping[str, Any]]:

--- a/airbyte-cdk/python/airbyte_cdk/sources/declarative/incremental/datetime_based_cursor.py
+++ b/airbyte-cdk/python/airbyte_cdk/sources/declarative/incremental/datetime_based_cursor.py
@@ -9,8 +9,8 @@ from typing import Any, Iterable, Mapping, Optional, Union
 from airbyte_cdk.models import SyncMode
 from airbyte_cdk.sources.declarative.datetime.datetime_parser import DatetimeParser
 from airbyte_cdk.sources.declarative.datetime.min_max_datetime import MinMaxDatetime
-from airbyte_cdk.sources.declarative.interpolation.interpolated_string import InterpolatedString
 from airbyte_cdk.sources.declarative.incremental.cursor import Cursor
+from airbyte_cdk.sources.declarative.interpolation.interpolated_string import InterpolatedString
 from airbyte_cdk.sources.declarative.interpolation.jinja import JinjaInterpolation
 from airbyte_cdk.sources.declarative.requesters.request_option import RequestOption, RequestOptionType
 from airbyte_cdk.sources.declarative.types import Config, Record, StreamSlice, StreamState

--- a/airbyte-cdk/python/airbyte_cdk/sources/declarative/incremental/datetime_based_cursor.py
+++ b/airbyte-cdk/python/airbyte_cdk/sources/declarative/incremental/datetime_based_cursor.py
@@ -10,17 +10,17 @@ from airbyte_cdk.models import SyncMode
 from airbyte_cdk.sources.declarative.datetime.datetime_parser import DatetimeParser
 from airbyte_cdk.sources.declarative.datetime.min_max_datetime import MinMaxDatetime
 from airbyte_cdk.sources.declarative.interpolation.interpolated_string import InterpolatedString
+from airbyte_cdk.sources.declarative.incremental.cursor import Cursor
 from airbyte_cdk.sources.declarative.interpolation.jinja import JinjaInterpolation
 from airbyte_cdk.sources.declarative.requesters.request_option import RequestOption, RequestOptionType
-from airbyte_cdk.sources.declarative.stream_slicers.stream_slicer import StreamSlicer
 from airbyte_cdk.sources.declarative.types import Config, Record, StreamSlice, StreamState
 from isodate import Duration, parse_duration
 
 
 @dataclass
-class DatetimeBasedCursor(StreamSlicer):
+class DatetimeBasedCursor(Cursor):
     """
-    Slices the stream over a datetime range.
+    Slices the stream over a datetime range and create a state with format {<cursor_field>: <datetime> }
 
     Given a start time, end time, a step function, and an optional lookback window,
     the stream slicer will partition the date range from start time - lookback window to end time.
@@ -34,10 +34,10 @@ class DatetimeBasedCursor(StreamSlicer):
     Attributes:
         start_datetime (Union[MinMaxDatetime, str]): the datetime that determines the earliest record that should be synced
         end_datetime (Optional[Union[MinMaxDatetime, str]]): the datetime that determines the last record that should be synced
-        step (str): size of the timewindow (ISO8601 duration)
         cursor_field (Union[InterpolatedString, str]): record's cursor field
         datetime_format (str): format of the datetime
-        cursor_granularity (str): smallest increment the datetime_format has (ISO 8601 duration) that will be used to ensure that the start of a slice does not overlap with the end of the previous one
+        step (Optional[str]): size of the timewindow (ISO8601 duration)
+        cursor_granularity (Optional[str]): smallest increment the datetime_format has (ISO 8601 duration) that will be used to ensure that the start of a slice does not overlap with the end of the previous one
         config (Config): connection config
         start_time_option (Optional[RequestOption]): request option for start time
         end_time_option (Optional[RequestOption]): request option for end time
@@ -52,7 +52,6 @@ class DatetimeBasedCursor(StreamSlicer):
     config: Config
     parameters: InitVar[Mapping[str, Any]]
     _cursor: dict = field(repr=False, default=None)  # tracks current datetime
-    _cursor_end: dict = field(repr=False, default=None)  # tracks end of current stream slice
     end_datetime: Optional[Union[MinMaxDatetime, str]] = None
     step: Optional[Union[InterpolatedString, str]] = None
     cursor_granularity: Optional[str] = None
@@ -97,33 +96,30 @@ class DatetimeBasedCursor(StreamSlicer):
     def get_stream_state(self) -> StreamState:
         return {self.cursor_field.eval(self.config): self._cursor} if self._cursor else {}
 
-    def update_cursor(self, stream_slice: StreamSlice, last_record: Optional[Record] = None):
+    def set_initial_state(self, stream_state: StreamState) -> None:
+        """
+        Cursors are not initialized with their state. As state is needed in order to function properly, this method should be called
+        before calling anything else
+
+        :param stream_state: The state of the stream as returned by get_stream_state
+        """
+        self._cursor = stream_state.get(self.cursor_field.eval(self.config)) if stream_state else None
+
+    def update_state(self, stream_slice: StreamSlice, last_record: Record) -> None:
         """
         Update the cursor value to the max datetime between the last record, the start of the stream_slice, and the current cursor value.
-        Update the cursor_end value with the stream_slice's end time.
 
         :param stream_slice: current stream slice
         :param last_record: last record read
         :return: None
         """
-        stream_slice_value = stream_slice.get(self.cursor_field.eval(self.config))
-        stream_slice_value_end = stream_slice.get(self.partition_field_end.eval(self.config))
+        stream_slice_value = stream_slice.get(self.partition_field_start.eval(self.config))
         last_record_value = last_record.get(self.cursor_field.eval(self.config)) if last_record else None
-        cursor = None
-        if stream_slice_value and last_record_value:
-            cursor = max(stream_slice_value, last_record_value)
-        elif stream_slice_value:
-            cursor = stream_slice_value
-        else:
-            cursor = last_record_value
-        if self._cursor and cursor:
-            self._cursor = max(cursor, self._cursor)
-        elif cursor:
-            self._cursor = cursor
-        if self.partition_field_end:
-            self._cursor_end = stream_slice_value_end
 
-    def stream_slices(self, sync_mode: SyncMode, stream_state: Mapping[str, Any]) -> Iterable[Mapping[str, Any]]:
+        possible_cursor_values = list(filter(lambda item: item is not None, [stream_slice_value, last_record_value, self._cursor]))
+        self._cursor = max(possible_cursor_values) if possible_cursor_values else None
+
+    def stream_slices(self, sync_mode: SyncMode) -> Iterable[Mapping[str, Any]]:
         """
         Partition the daterange into slices of size = step.
 
@@ -131,25 +127,22 @@ class DatetimeBasedCursor(StreamSlicer):
         The end of the window is the minimum datetime between the start of the window and end_datetime.
 
         :param sync_mode:
-        :param stream_state: current stream state. If set, the start_date will be the day following the stream_state.
         :return:
         """
-        stream_state = stream_state or {}
-        kwargs = {"stream_state": stream_state}
-        end_datetime = self._select_best_end_datetime(kwargs)
-        lookback_delta = self._parse_timedelta(self.lookback_window.eval(self.config, **kwargs) if self.lookback_window else "P0D")
+        end_datetime = self._select_best_end_datetime()
+        lookback_delta = self._parse_timedelta(self.lookback_window.eval(self.config) if self.lookback_window else "P0D")
 
-        earliest_possible_start_datetime = min(self.start_datetime.get_datetime(self.config, **kwargs), end_datetime)
-        cursor_datetime = self._calculate_cursor_datetime_from_state(stream_state)
+        earliest_possible_start_datetime = min(self.start_datetime.get_datetime(self.config), end_datetime)
+        cursor_datetime = self._calculate_cursor_datetime_from_state(self.get_stream_state())
         start_datetime = max(earliest_possible_start_datetime, cursor_datetime) - lookback_delta
 
         return self._partition_daterange(start_datetime, end_datetime, self._step)
 
-    def _select_best_end_datetime(self, kwargs):
+    def _select_best_end_datetime(self):
         now = datetime.datetime.now(tz=self._timezone)
         if not self.end_datetime:
             return now
-        return min(self.end_datetime.get_datetime(self.config, **kwargs), now)
+        return min(self.end_datetime.get_datetime(self.config), now)
 
     def _calculate_cursor_datetime_from_state(self, stream_state: Mapping[str, Any]) -> datetime.datetime:
         if self.cursor_field.eval(self.config, stream_state=stream_state) in stream_state:

--- a/airbyte-cdk/python/airbyte_cdk/sources/declarative/incremental/datetime_based_cursor.py
+++ b/airbyte-cdk/python/airbyte_cdk/sources/declarative/incremental/datetime_based_cursor.py
@@ -113,10 +113,9 @@ class DatetimeBasedCursor(Cursor):
         :param last_record: last record read
         :return: None
         """
-        stream_slice_value = stream_slice.get(self.partition_field_start.eval(self.config))
         last_record_value = last_record.get(self.cursor_field.eval(self.config)) if last_record else None
 
-        possible_cursor_values = list(filter(lambda item: item, [stream_slice_value, last_record_value, self._cursor]))
+        possible_cursor_values = list(filter(lambda item: item, [last_record_value, self._cursor]))
         self._cursor = max(possible_cursor_values) if possible_cursor_values else None
 
     def stream_slices(self, sync_mode: SyncMode) -> Iterable[Mapping[str, Any]]:

--- a/airbyte-cdk/python/airbyte_cdk/sources/declarative/incremental/per_partition_cursor.py
+++ b/airbyte-cdk/python/airbyte_cdk/sources/declarative/incremental/per_partition_cursor.py
@@ -148,9 +148,7 @@ class PerPartitionCursor(Cursor):
 
     def update_state(self, stream_slice: PerPartitionStreamSlice, last_record: Record):
         try:
-            self._cursor_per_partition[self._to_partition_key(stream_slice.partition)].update_state(
-                stream_slice.cursor_slice, last_record
-            )
+            self._cursor_per_partition[self._to_partition_key(stream_slice.partition)].update_state(stream_slice.cursor_slice, last_record)
         except KeyError as exception:
             raise KeyError(
                 f"Partition {str(exception)} could not be found in current state based on the record. This is unexpected because "

--- a/airbyte-cdk/python/airbyte_cdk/sources/declarative/incremental/per_partition_cursor.py
+++ b/airbyte-cdk/python/airbyte_cdk/sources/declarative/incremental/per_partition_cursor.py
@@ -5,6 +5,7 @@
 from typing import Any, Iterable, Mapping, Optional
 
 from airbyte_cdk.models import SyncMode
+from airbyte_cdk.sources.declarative.incremental.cursor import Cursor
 from airbyte_cdk.sources.declarative.stream_slicers.stream_slicer import StreamSlicer
 from airbyte_cdk.sources.declarative.types import Record, StreamSlice, StreamState
 
@@ -93,7 +94,7 @@ class CursorFactory:
         return self._create_function()
 
 
-class PerPartitionCursor(StreamSlicer):
+class PerPartitionCursor(Cursor):
     """
     Given a stream has many partitions, it is important to provide a state per partition.
 
@@ -124,42 +125,37 @@ class PerPartitionCursor(StreamSlicer):
         self._partition_router = partition_router
         self._cursor_per_partition = {}
 
-    def stream_slices(self, sync_mode: SyncMode, stream_state: StreamState) -> Iterable[PerPartitionStreamSlice]:
+    def stream_slices(self, sync_mode: SyncMode) -> Iterable[PerPartitionStreamSlice]:
         """
         We knowingly avoid using stream_state as we want PerPartitionCursor to manage its own state.
         """
-        slices = self._partition_router.stream_slices(sync_mode, self._NO_STATE)
+        slices = self._partition_router.stream_slices(sync_mode)
         for partition in slices:
             cursor = self._cursor_per_partition.get(self._to_partition_key(partition))
             if not cursor:
                 cursor = self._create_cursor(self._NO_CURSOR_STATE)
                 self._cursor_per_partition[self._to_partition_key(partition)] = cursor
 
-            for cursor_slice in cursor.stream_slices(sync_mode, self._get_state_for_partition(partition)):
+            for cursor_slice in cursor.stream_slices(sync_mode):
                 yield PerPartitionStreamSlice(partition, cursor_slice)
 
-    def update_cursor(self, stream_slice: PerPartitionStreamSlice, last_record: Optional[Record] = None):
-        if not last_record:
-            # The `update_cursor` method is called without `last_record` in order to set the initial state. In that case, stream_slice is
-            # not a PerPartitionStreamSlice but is a dict representing the state
-            self._init_state(stream_slice)
-        else:
-            try:
-                self._cursor_per_partition[self._to_partition_key(stream_slice.partition)].update_cursor(
-                    stream_slice.cursor_slice, last_record
-                )
-            except KeyError as exception:
-                raise KeyError(
-                    f"Partition {str(exception)} could not be found in current state based on the record. This is unexpected because "
-                    f"we should only update cursor for partition that where emitted during `stream_slices`"
-                )
-
-    def _init_state(self, stream_state: dict) -> None:
+    def set_initial_state(self, stream_state: StreamState) -> None:
         if not stream_state:
             return
 
         for state in stream_state["states"]:
             self._cursor_per_partition[self._to_partition_key(state["partition"])] = self._create_cursor(state["cursor"])
+
+    def update_state(self, stream_slice: PerPartitionStreamSlice, last_record: Record):
+        try:
+            self._cursor_per_partition[self._to_partition_key(stream_slice.partition)].update_state(
+                stream_slice.cursor_slice, last_record
+            )
+        except KeyError as exception:
+            raise KeyError(
+                f"Partition {str(exception)} could not be found in current state based on the record. This is unexpected because "
+                f"we should only update state for partition that where emitted during `stream_slices`"
+            )
 
     def get_stream_state(self) -> StreamState:
         states = []
@@ -204,7 +200,7 @@ class PerPartitionCursor(StreamSlicer):
 
     def _create_cursor(self, cursor_state: Any) -> StreamSlicer:
         cursor = self._cursor_factory.create()
-        cursor.update_cursor(cursor_state)
+        cursor.set_initial_state(cursor_state)
         return cursor
 
     def get_request_params(

--- a/airbyte-cdk/python/airbyte_cdk/sources/declarative/partition_routers/list_partition_router.py
+++ b/airbyte-cdk/python/airbyte_cdk/sources/declarative/partition_routers/list_partition_router.py
@@ -39,17 +39,6 @@ class ListPartitionRouter(StreamSlicer):
 
         self._cursor = None
 
-    def update_cursor(self, stream_slice: StreamSlice, last_record: Optional[Record] = None):
-        # This method is called after the records are processed.
-        slice_value = stream_slice.get(self.cursor_field.eval(self.config))
-        if slice_value and slice_value in self.values:
-            self._cursor = slice_value
-        else:
-            raise ValueError(f"Unexpected stream slice: {slice_value}")
-
-    def get_stream_state(self) -> StreamState:
-        return {self.cursor_field.eval(self.config): self._cursor} if self._cursor else {}
-
     def get_request_params(
         self,
         stream_state: Optional[StreamState] = None,
@@ -86,7 +75,7 @@ class ListPartitionRouter(StreamSlicer):
         # Pass the stream_slice from the argument, not the cursor because the cursor is updated after processing the response
         return self._get_request_option(RequestOptionType.body_json, stream_slice)
 
-    def stream_slices(self, sync_mode: SyncMode, stream_state: Mapping[str, Any]) -> Iterable[Mapping[str, Any]]:
+    def stream_slices(self, sync_mode: SyncMode) -> Iterable[Mapping[str, Any]]:
         return [{self.cursor_field.eval(self.config): slice_value} for slice_value in self.values]
 
     def _get_request_option(self, request_option_type: RequestOptionType, stream_slice: StreamSlice):

--- a/airbyte-cdk/python/airbyte_cdk/sources/declarative/partition_routers/list_partition_router.py
+++ b/airbyte-cdk/python/airbyte_cdk/sources/declarative/partition_routers/list_partition_router.py
@@ -9,7 +9,7 @@ from airbyte_cdk.models import SyncMode
 from airbyte_cdk.sources.declarative.interpolation.interpolated_string import InterpolatedString
 from airbyte_cdk.sources.declarative.requesters.request_option import RequestOption, RequestOptionType
 from airbyte_cdk.sources.declarative.stream_slicers.stream_slicer import StreamSlicer
-from airbyte_cdk.sources.declarative.types import Config, Record, StreamSlice, StreamState
+from airbyte_cdk.sources.declarative.types import Config, StreamSlice, StreamState
 
 
 @dataclass

--- a/airbyte-cdk/python/airbyte_cdk/sources/declarative/partition_routers/single_partition_router.py
+++ b/airbyte-cdk/python/airbyte_cdk/sources/declarative/partition_routers/single_partition_router.py
@@ -16,12 +16,6 @@ class SinglePartitionRouter(StreamSlicer):
 
     parameters: InitVar[Mapping[str, Any]]
 
-    def update_cursor(self, stream_slice: StreamSlice, last_record: Optional[Record] = None):
-        pass
-
-    def get_stream_state(self) -> StreamState:
-        return {}
-
     def get_request_params(
         self,
         stream_state: Optional[StreamState] = None,
@@ -54,5 +48,5 @@ class SinglePartitionRouter(StreamSlicer):
     ) -> Mapping[str, Any]:
         return {}
 
-    def stream_slices(self, sync_mode: SyncMode, stream_state: Mapping[str, Any]) -> Iterable[StreamSlice]:
+    def stream_slices(self, sync_mode: SyncMode) -> Iterable[StreamSlice]:
         yield dict()

--- a/airbyte-cdk/python/airbyte_cdk/sources/declarative/partition_routers/single_partition_router.py
+++ b/airbyte-cdk/python/airbyte_cdk/sources/declarative/partition_routers/single_partition_router.py
@@ -7,7 +7,7 @@ from typing import Any, Iterable, Mapping, Optional
 
 from airbyte_cdk.models import SyncMode
 from airbyte_cdk.sources.declarative.stream_slicers.stream_slicer import StreamSlicer
-from airbyte_cdk.sources.declarative.types import Record, StreamSlice, StreamState
+from airbyte_cdk.sources.declarative.types import StreamSlice, StreamState
 
 
 @dataclass

--- a/airbyte-cdk/python/airbyte_cdk/sources/declarative/partition_routers/substream_partition_router.py
+++ b/airbyte-cdk/python/airbyte_cdk/sources/declarative/partition_routers/substream_partition_router.py
@@ -10,7 +10,7 @@ from airbyte_cdk.models import AirbyteMessage, SyncMode, Type
 from airbyte_cdk.sources.declarative.interpolation.interpolated_string import InterpolatedString
 from airbyte_cdk.sources.declarative.requesters.request_option import RequestOption, RequestOptionType
 from airbyte_cdk.sources.declarative.stream_slicers.stream_slicer import StreamSlicer
-from airbyte_cdk.sources.declarative.types import Config, Record, StreamSlice, StreamState
+from airbyte_cdk.sources.declarative.types import Config, StreamSlice, StreamState
 from airbyte_cdk.sources.streams.core import Stream
 
 

--- a/airbyte-cdk/python/airbyte_cdk/sources/declarative/partition_routers/substream_partition_router.py
+++ b/airbyte-cdk/python/airbyte_cdk/sources/declarative/partition_routers/substream_partition_router.py
@@ -54,18 +54,7 @@ class SubstreamPartitionRouter(StreamSlicer):
     def __post_init__(self, parameters: Mapping[str, Any]):
         if not self.parent_stream_configs:
             raise ValueError("SubstreamPartitionRouter needs at least 1 parent stream")
-        self._cursor = None
         self._parameters = parameters
-
-    def update_cursor(self, stream_slice: StreamSlice, last_record: Optional[Record] = None):
-        # This method is called after the records are processed.
-        cursor = {}
-        for parent_stream_config in self.parent_stream_configs:
-            partition_field = parent_stream_config.partition_field.eval(self.config)
-            slice_value = stream_slice.get(partition_field)
-            if slice_value:
-                cursor.update({partition_field: slice_value})
-        self._cursor = cursor
 
     def get_request_params(
         self,
@@ -114,9 +103,6 @@ class SubstreamPartitionRouter(StreamSlicer):
                         params.update({parent_config.request_option.field_name: value})
         return params
 
-    def get_stream_state(self) -> StreamState:
-        return self._cursor if self._cursor else {}
-
     def stream_slices(self, sync_mode: SyncMode, stream_state: StreamState) -> Iterable[StreamSlice]:
         """
         Iterate over each parent stream's record and create a StreamSlice for each record.
@@ -139,7 +125,7 @@ class SubstreamPartitionRouter(StreamSlicer):
                 parent_stream = parent_stream_config.stream
                 parent_field = parent_stream_config.parent_key.eval(self.config)
                 stream_state_field = parent_stream_config.partition_field.eval(self.config)
-                for parent_stream_slice in parent_stream.stream_slices(sync_mode=sync_mode, cursor_field=None, stream_state=stream_state):
+                for parent_stream_slice in parent_stream.stream_slices(sync_mode=sync_mode, cursor_field=None, stream_state=None):
                     empty_parent_slice = True
                     parent_slice = parent_stream_slice
 

--- a/airbyte-cdk/python/airbyte_cdk/sources/declarative/retrievers/simple_retriever.py
+++ b/airbyte-cdk/python/airbyte_cdk/sources/declarative/retrievers/simple_retriever.py
@@ -13,6 +13,7 @@ from airbyte_cdk.models import AirbyteLogMessage, AirbyteMessage, Level, SyncMod
 from airbyte_cdk.models import Type as MessageType
 from airbyte_cdk.sources.declarative.exceptions import ReadException
 from airbyte_cdk.sources.declarative.extractors.http_selector import HttpSelector
+from airbyte_cdk.sources.declarative.incremental.cursor import Cursor
 from airbyte_cdk.sources.declarative.interpolation import InterpolatedString
 from airbyte_cdk.sources.declarative.partition_routers.single_partition_router import SinglePartitionRouter
 from airbyte_cdk.sources.declarative.requesters.error_handlers.response_action import ResponseAction
@@ -47,6 +48,7 @@ class SimpleRetriever(Retriever, HttpStream):
         record_selector (HttpSelector): The record selector
         paginator (Optional[Paginator]): The paginator
         stream_slicer (Optional[StreamSlicer]): The stream slicer
+        cursor (Optional[cursor]): The cursor
         parameters (Mapping[str, Any]): Additional runtime parameters to be used for string interpolation
     """
 
@@ -62,6 +64,7 @@ class SimpleRetriever(Retriever, HttpStream):
     _primary_key: str = field(init=False, repr=False, default="")
     paginator: Optional[Paginator] = None
     stream_slicer: Optional[StreamSlicer] = SinglePartitionRouter(parameters={})
+    cursor: Optional[Cursor] = None
     emit_connector_builder_messages: bool = False
     disable_retries: bool = False
 
@@ -384,7 +387,6 @@ class SimpleRetriever(Retriever, HttpStream):
         sync_mode: SyncMode,
         cursor_field: Optional[List[str]] = None,
         stream_slice: Optional[StreamSlice] = None,
-        stream_state: Optional[StreamState] = None,
     ) -> Iterable[StreamData]:
         # Warning: use self.state instead of the stream_state passed as argument!
         stream_slice = stream_slice or {}  # None-check
@@ -400,7 +402,13 @@ class SimpleRetriever(Retriever, HttpStream):
         # * Why is this abstraction not on the DeclarativeStream level? DeclarativeStream does not have a notion of stream slicers and we
         #    would like to avoid exposing the stream state outside of the cursor. This case is needed as of 2023-06-14 because of
         #    interpolation.
-        slice_state = self.stream_slicer.select_state(stream_slice) if hasattr(self.stream_slicer, "select_state") else stream_state
+        if self.cursor and hasattr(self.cursor, "select_state"):
+            slice_state = self.cursor.select_state(stream_slice)
+        elif self.cursor:
+            slice_state = self.cursor.get_stream_state()
+        else:
+            slice_state = {}
+
         records_generator = self._read_pages(
             self.parse_records,
             stream_slice,
@@ -409,14 +417,14 @@ class SimpleRetriever(Retriever, HttpStream):
         cursor_updated = False
         for record in records_generator:
             # Only record messages should be parsed to update the cursor which is indicated by the Mapping type
-            if isinstance(record, Mapping):
-                self.stream_slicer.update_cursor(stream_slice, last_record=record)
+            if self.cursor and isinstance(record, Mapping):
+                self.cursor.update_state(stream_slice, last_record=record)
                 cursor_updated = True
             yield record
-        if not cursor_updated:
+        if self.cursor and not cursor_updated:
             last_record = self._last_records[-1] if self._last_records else None
             if last_record and isinstance(last_record, Mapping):
-                self.stream_slicer.update_cursor(stream_slice, last_record=last_record)
+                self.cursor.update_state(stream_slice, last_record=last_record)
             yield from []
 
     def stream_slices(
@@ -431,16 +439,17 @@ class SimpleRetriever(Retriever, HttpStream):
         :return:
         """
         # Warning: use self.state instead of the stream_state passed as argument!
-        return self.stream_slicer.stream_slices(sync_mode, self.state)
+        return self.stream_slicer.stream_slices(sync_mode)
 
     @property
     def state(self) -> MutableMapping[str, Any]:
-        return self.stream_slicer.get_stream_state()
+        return self.cursor.get_stream_state() if self.cursor else {}
 
     @state.setter
     def state(self, value: StreamState):
         """State setter, accept state serialized by state getter."""
-        self.stream_slicer.update_cursor(value)
+        if self.cursor:
+            self.stream_slicer.set_initial_state(value)
 
     def parse_records(
         self,

--- a/airbyte-cdk/python/airbyte_cdk/sources/declarative/stream_slicers/cartesian_product_stream_slicer.py
+++ b/airbyte-cdk/python/airbyte_cdk/sources/declarative/stream_slicers/cartesian_product_stream_slicer.py
@@ -36,10 +36,6 @@ class CartesianProductStreamSlicer(StreamSlicer):
     stream_slicers: List[StreamSlicer]
     parameters: InitVar[Mapping[str, Any]]
 
-    def update_cursor(self, stream_slice: Mapping[str, Any], last_record: Optional[Mapping[str, Any]] = None):
-        for slicer in self.stream_slicers:
-            slicer.update_cursor(stream_slice, last_record)
-
     def get_request_params(
         self,
         *,
@@ -104,9 +100,6 @@ class CartesianProductStreamSlicer(StreamSlicer):
             )
         )
 
-    def get_stream_state(self) -> Mapping[str, Any]:
-        return dict(ChainMap(*[slicer.get_stream_state() for slicer in self.stream_slicers]))
-
-    def stream_slices(self, sync_mode: SyncMode, stream_state: Mapping[str, Any]) -> Iterable[Mapping[str, Any]]:
-        sub_slices = (s.stream_slices(sync_mode, stream_state) for s in self.stream_slicers)
+    def stream_slices(self, sync_mode: SyncMode) -> Iterable[Mapping[str, Any]]:
+        sub_slices = (s.stream_slices(sync_mode) for s in self.stream_slicers)
         return (dict(ChainMap(*a)) for a in itertools.product(*sub_slices))

--- a/airbyte-cdk/python/airbyte_cdk/sources/declarative/stream_slicers/stream_slicer.py
+++ b/airbyte-cdk/python/airbyte_cdk/sources/declarative/stream_slicers/stream_slicer.py
@@ -8,7 +8,7 @@ from typing import Iterable
 
 from airbyte_cdk.models import SyncMode
 from airbyte_cdk.sources.declarative.requesters.request_options.request_options_provider import RequestOptionsProvider
-from airbyte_cdk.sources.declarative.types import Record, StreamSlice, StreamState
+from airbyte_cdk.sources.declarative.types import StreamSlice
 
 
 @dataclass

--- a/airbyte-cdk/python/airbyte_cdk/sources/declarative/stream_slicers/stream_slicer.py
+++ b/airbyte-cdk/python/airbyte_cdk/sources/declarative/stream_slicers/stream_slicer.py
@@ -4,7 +4,7 @@
 
 from abc import abstractmethod
 from dataclasses import dataclass
-from typing import Iterable, Optional
+from typing import Iterable
 
 from airbyte_cdk.models import SyncMode
 from airbyte_cdk.sources.declarative.requesters.request_options.request_options_provider import RequestOptionsProvider
@@ -23,24 +23,10 @@ class StreamSlicer(RequestOptionsProvider):
     """
 
     @abstractmethod
-    def stream_slices(self, sync_mode: SyncMode, stream_state: StreamState) -> Iterable[StreamSlice]:
+    def stream_slices(self, sync_mode: SyncMode) -> Iterable[StreamSlice]:
         """
         Defines stream slices
 
         :param sync_mode: The sync mode used the read data
-        :param stream_state: The current stream state
         :return: List of stream slices
         """
-
-    @abstractmethod
-    def update_cursor(self, stream_slice: StreamSlice, last_record: Optional[Record] = None):
-        """
-        State setter, accept state serialized by state getter.
-
-        :param stream_slice: Current stream_slice
-        :param last_record: Last record read from the source
-        """
-
-    @abstractmethod
-    def get_stream_state(self) -> StreamState:
-        """Returns the current stream state"""

--- a/airbyte-cdk/python/unit_tests/sources/declarative/incremental/test_datetime_based_cursor.py
+++ b/airbyte-cdk/python/unit_tests/sources/declarative/incremental/test_datetime_based_cursor.py
@@ -20,6 +20,7 @@ config = {"start_date": "2021-01-01T00:00:00.000000+0000", "start_date_ymd": "20
 end_date_now = InterpolatedString(string="{{ today_utc() }}", parameters={})
 cursor_field = "created"
 timezone = datetime.timezone.utc
+NO_STATE = {}
 
 
 class MockedNowDatetime(datetime.datetime):
@@ -38,7 +39,7 @@ def mock_datetime_now(monkeypatch):
     [
         (
             "test_1_day",
-            None,
+            NO_STATE,
             MinMaxDatetime(datetime="{{ config['start_date'] }}", parameters={}),
             MinMaxDatetime(datetime="2021-01-10T00:00:00.000000+0000", parameters={}),
             "P1D",
@@ -61,7 +62,7 @@ def mock_datetime_now(monkeypatch):
         ),
         (
             "test_2_day",
-            None,
+            NO_STATE,
             MinMaxDatetime(datetime="{{ config['start_date'] }}", parameters={}),
             MinMaxDatetime(datetime="2021-01-10T00:00:00.000000+0000", parameters={}),
             "P2D",
@@ -79,7 +80,7 @@ def mock_datetime_now(monkeypatch):
         ),
         (
             "test_1_week",
-            None,
+            NO_STATE,
             MinMaxDatetime(datetime="{{ config['start_date'] }}", parameters={}),
             MinMaxDatetime(datetime="2021-02-10T00:00:00.000000+0000", parameters={}),
             "P1W",
@@ -98,7 +99,7 @@ def mock_datetime_now(monkeypatch):
         ),
         (
             "test_1_month",
-            None,
+            NO_STATE,
             MinMaxDatetime(datetime="{{ config['start_date'] }}", parameters={}),
             MinMaxDatetime(datetime="2021-06-10T00:00:00.000000+0000", parameters={}),
             "P1M",
@@ -117,7 +118,7 @@ def mock_datetime_now(monkeypatch):
         ),
         (
             "test_1_year",
-            None,
+            NO_STATE,
             MinMaxDatetime(datetime="{{ config['start_date'] }}", parameters={}),
             MinMaxDatetime(datetime="2022-06-10T00:00:00.000000+0000", parameters={}),
             "P1Y",
@@ -132,8 +133,8 @@ def mock_datetime_now(monkeypatch):
         ),
         (
             "test_from_stream_state",
-            {"date": "2021-01-05T00:00:00.000000+0000"},
-            MinMaxDatetime(datetime="{{ stream_state['date'] }}", parameters={}),
+            {cursor_field: "2021-01-05T00:00:00.000000+0000"},
+            MinMaxDatetime(datetime="2020-01-05T00:00:00.000000+0000", parameters={}),
             MinMaxDatetime(datetime="2021-01-10T00:00:00.000000+0000", parameters={}),
             "P1D",
             cursor_field,
@@ -151,7 +152,7 @@ def mock_datetime_now(monkeypatch):
         ),
         (
             "test_12_day",
-            None,
+            NO_STATE,
             MinMaxDatetime(datetime="{{ config['start_date'] }}", parameters={}),
             MinMaxDatetime(datetime="2021-01-10T00:00:00.000000+0000", parameters={}),
             "P12D",
@@ -165,7 +166,7 @@ def mock_datetime_now(monkeypatch):
         ),
         (
             "test_end_time_greater_than_now",
-            None,
+            NO_STATE,
             MinMaxDatetime(datetime="2021-12-28T00:00:00.000000+0000", parameters={}),
             MinMaxDatetime(datetime=f"{(FAKE_NOW + datetime.timedelta(days=1)).strftime(datetime_format)}", parameters={}),
             "P1D",
@@ -183,7 +184,7 @@ def mock_datetime_now(monkeypatch):
         ),
         (
             "test_start_date_greater_than_end_time",
-            None,
+            NO_STATE,
             MinMaxDatetime(datetime="2021-01-10T00:00:00.000000+0000", parameters={}),
             MinMaxDatetime(datetime="2021-01-05T00:00:00.000000+0000", parameters={}),
             "P1D",
@@ -197,11 +198,11 @@ def mock_datetime_now(monkeypatch):
         ),
         (
             "test_cursor_date_greater_than_start_date",
-            {"date": "2021-01-05T00:00:00.000000+0000"},
-            MinMaxDatetime(datetime="{{ stream_state['date'] }}", parameters={}),
+            {cursor_field: "2021-01-05T00:00:00.000000+0000"},
+            MinMaxDatetime(datetime="2021-01-01T00:00:00.000000+0000", parameters={}),
             MinMaxDatetime(datetime="2021-01-10T00:00:00.000000+0000", parameters={}),
             "P1D",
-            InterpolatedString(string="{{ stream_state['date'] }}", parameters={}),
+            cursor_field,
             None,
             datetime_format,
             cursor_granularity,
@@ -231,75 +232,16 @@ def mock_datetime_now(monkeypatch):
             ],
         ),
         (
-            "test_start_date_less_than_min_date",
-            {"date": "2021-01-05T00:00:00.000000+0000"},
-            MinMaxDatetime(datetime="{{ config['start_date'] }}", min_datetime="{{ stream_state['date'] }}", parameters={}),
-            MinMaxDatetime(datetime="2021-01-10T00:00:00.000000+0000", parameters={}),
-            "P1D",
-            InterpolatedString(string="{{ stream_state['date'] }}", parameters={}),
-            None,
-            datetime_format,
-            cursor_granularity,
-            [
-                {"start_time": "2021-01-05T00:00:00.000000+0000", "end_time": "2021-01-05T23:59:59.999999+0000"},
-                {"start_time": "2021-01-06T00:00:00.000000+0000", "end_time": "2021-01-06T23:59:59.999999+0000"},
-                {"start_time": "2021-01-07T00:00:00.000000+0000", "end_time": "2021-01-07T23:59:59.999999+0000"},
-                {"start_time": "2021-01-08T00:00:00.000000+0000", "end_time": "2021-01-08T23:59:59.999999+0000"},
-                {"start_time": "2021-01-09T00:00:00.000000+0000", "end_time": "2021-01-09T23:59:59.999999+0000"},
-                {"start_time": "2021-01-10T00:00:00.000000+0000", "end_time": "2021-01-10T00:00:00.000000+0000"},
-            ],
-        ),
-        (
-            "test_end_date_greater_than_max_date",
-            {"date": "2021-01-05T00:00:00.000000+0000"},
-            MinMaxDatetime(datetime="{{ config['start_date'] }}", parameters={}),
-            MinMaxDatetime(datetime="2021-01-10T00:00:00.000000+0000", max_datetime="{{ stream_state['date'] }}", parameters={}),
-            "P1D",
-            cursor_field,
-            None,
-            datetime_format,
-            cursor_granularity,
-            [
-                {"start_time": "2021-01-01T00:00:00.000000+0000", "end_time": "2021-01-01T23:59:59.999999+0000"},
-                {"start_time": "2021-01-02T00:00:00.000000+0000", "end_time": "2021-01-02T23:59:59.999999+0000"},
-                {"start_time": "2021-01-03T00:00:00.000000+0000", "end_time": "2021-01-03T23:59:59.999999+0000"},
-                {"start_time": "2021-01-04T00:00:00.000000+0000", "end_time": "2021-01-04T23:59:59.999999+0000"},
-                {"start_time": "2021-01-05T00:00:00.000000+0000", "end_time": "2021-01-05T00:00:00.000000+0000"},
-            ],
-        ),
-        (
-            "test_start_end_min_max_inherits_datetime_format_from_stream_slicer",
-            {"date": "2021-01-05"},
-            MinMaxDatetime(datetime="{{ config['start_date_ymd'] }}", parameters={}),
-            MinMaxDatetime(datetime="2021-01-10", max_datetime="{{ stream_state['date'] }}", parameters={}),
-            "P1D",
-            cursor_field,
-            None,
-            "%Y-%m-%d",
-            "P1D",
-            [
-                {"start_time": "2021-01-01", "end_time": "2021-01-01"},
-                {"start_time": "2021-01-02", "end_time": "2021-01-02"},
-                {"start_time": "2021-01-03", "end_time": "2021-01-03"},
-                {"start_time": "2021-01-04", "end_time": "2021-01-04"},
-                {"start_time": "2021-01-05", "end_time": "2021-01-05"},
-            ],
-        ),
-        (
             "test_with_lookback_window_from_start_date",
-            {"date": "2021-01-05"},
-            MinMaxDatetime(datetime="{{ config['start_date'] }}", parameters={}),
-            MinMaxDatetime(datetime="2021-01-10", max_datetime="{{ stream_state['date'] }}", datetime_format="%Y-%m-%d", parameters={}),
+            NO_STATE,
+            MinMaxDatetime(datetime="2021-01-05", datetime_format="%Y-%m-%d", parameters={}),
+            MinMaxDatetime(datetime="2021-01-05", datetime_format="%Y-%m-%d", parameters={}),
             "P1D",
             cursor_field,
             "P3D",
             datetime_format,
             cursor_granularity,
             [
-                {"start_time": "2020-12-29T00:00:00.000000+0000", "end_time": "2020-12-29T23:59:59.999999+0000"},
-                {"start_time": "2020-12-30T00:00:00.000000+0000", "end_time": "2020-12-30T23:59:59.999999+0000"},
-                {"start_time": "2020-12-31T00:00:00.000000+0000", "end_time": "2020-12-31T23:59:59.999999+0000"},
-                {"start_time": "2021-01-01T00:00:00.000000+0000", "end_time": "2021-01-01T23:59:59.999999+0000"},
                 {"start_time": "2021-01-02T00:00:00.000000+0000", "end_time": "2021-01-02T23:59:59.999999+0000"},
                 {"start_time": "2021-01-03T00:00:00.000000+0000", "end_time": "2021-01-03T23:59:59.999999+0000"},
                 {"start_time": "2021-01-04T00:00:00.000000+0000", "end_time": "2021-01-04T23:59:59.999999+0000"},
@@ -326,9 +268,9 @@ def mock_datetime_now(monkeypatch):
         ),
         (
             "test_with_lookback_window_defaults_to_0d",
-            {"date": "2021-01-05"},
-            MinMaxDatetime(datetime="{{ config['start_date'] }}", parameters={}),
-            MinMaxDatetime(datetime="2021-01-10", max_datetime="{{ stream_state['date'] }}", datetime_format="%Y-%m-%d", parameters={}),
+            {},
+            MinMaxDatetime(datetime="2021-01-01", datetime_format="%Y-%m-%d", parameters={}),
+            MinMaxDatetime(datetime="2021-01-05", datetime_format="%Y-%m-%d", parameters={}),
             "P1D",
             cursor_field,
             "{{ config['does_not_exist'] }}",
@@ -377,7 +319,7 @@ def test_stream_slices(
     expected_slices,
 ):
     lookback_window = InterpolatedString(string=lookback_window, parameters={}) if lookback_window else None
-    slicer = DatetimeBasedCursor(
+    cursor = DatetimeBasedCursor(
         start_datetime=start,
         end_datetime=end,
         step=step,
@@ -388,7 +330,8 @@ def test_stream_slices(
         config=config,
         parameters={},
     )
-    stream_slices = slicer.stream_slices(SyncMode.incremental, stream_state)
+    cursor.set_initial_state(stream_state)
+    stream_slices = cursor.stream_slices(SyncMode.incremental)
 
     assert stream_slices == expected_slices
 
@@ -396,45 +339,45 @@ def test_stream_slices(
 @pytest.mark.parametrize(
     "test_name, previous_cursor, stream_slice, last_record, expected_state",
     [
-        ("test_update_cursor_no_state_no_record", None, {}, None, {}),
+        ("test_update_state_no_state_no_record", None, {}, None, {}),
         (
-            "test_update_cursor_with_state_no_record",
+            "test_update_state_with_state_no_record",
             None,
-            {cursor_field: "2021-01-02T00:00:00.000000+0000"},
+            {"start_time": "2021-01-02T00:00:00.000000+0000"},
             None,
             {cursor_field: "2021-01-02T00:00:00.000000+0000"},
         ),
         (
-            "test_update_cursor_with_state_equals_record",
+            "test_update_state_with_state_equals_record",
             None,
-            {cursor_field: "2021-01-02T00:00:00.000000+0000"},
+            {"start_time": "2021-01-02T00:00:00.000000+0000"},
             {cursor_field: "2021-01-02T00:00:00.000000+0000"},
             {cursor_field: "2021-01-02T00:00:00.000000+0000"},
         ),
         (
-            "test_update_cursor_with_state_greater_than_record",
+            "test_update_state_with_state_greater_than_record",
             None,
-            {cursor_field: "2021-01-03T00:00:00.000000+0000"},
+            {"start_time": "2021-01-03T00:00:00.000000+0000"},
             {cursor_field: "2021-01-02T00:00:00.000000+0000"},
             {cursor_field: "2021-01-03T00:00:00.000000+0000"},
         ),
         (
-            "test_update_cursor_with_state_less_than_record",
+            "test_update_state_with_state_less_than_record",
             None,
-            {cursor_field: "2021-01-02T00:00:00.000000+0000"},
+            {"start_time": "2021-01-02T00:00:00.000000+0000"},
             {cursor_field: "2021-01-03T00:00:00.000000+0000"},
             {cursor_field: "2021-01-03T00:00:00.000000+0000"},
         ),
         (
-            "test_update_cursor_with_state_less_than_previous_cursor",
+            "test_update_state_with_state_less_than_previous_cursor",
             "2021-01-03T00:00:00.000000+0000",
-            {cursor_field: "2021-01-02T00:00:00.000000+0000"},
+            {"start_time": "2021-01-02T00:00:00.000000+0000"},
             {},
             {cursor_field: "2021-01-03T00:00:00.000000+0000"},
         ),
     ],
 )
-def test_update_cursor(test_name, previous_cursor, stream_slice, last_record, expected_state):
+def test_update_state(test_name, previous_cursor, stream_slice, last_record, expected_state):
     slicer = DatetimeBasedCursor(
         start_datetime=MinMaxDatetime(datetime="2021-01-01T00:00:00.000000+0000", parameters={}),
         end_datetime=MinMaxDatetime(datetime="2021-01-10T00:00:00.000000+0000", parameters={}),
@@ -447,7 +390,7 @@ def test_update_cursor(test_name, previous_cursor, stream_slice, last_record, ex
         parameters={},
     )
     slicer._cursor = previous_cursor
-    slicer.update_cursor(stream_slice, last_record)
+    slicer.update_state(stream_slice, last_record)
     updated_state = slicer.get_stream_state()
     assert expected_state == updated_state
 
@@ -512,7 +455,7 @@ def test_request_option(test_name, inject_into, field_name, expected_req_params,
     )
     stream_slice = {"start_time": "2021-01-01T00:00:00.000000+0000", "end_time": "2021-01-04T00:00:00.000000+0000"}
 
-    slicer.update_cursor(stream_slice)
+    slicer.set_initial_state(stream_slice)
 
     assert expected_req_params == slicer.get_request_params(stream_slice=stream_slice)
     assert expected_headers == slicer.get_request_headers(stream_slice=stream_slice)
@@ -616,7 +559,7 @@ def test_no_cursor_granularity_and_no_step_then_only_return_one_slice():
         config=config,
         parameters={},
     )
-    stream_slices = cursor.stream_slices(SyncMode.incremental, {})
+    stream_slices = cursor.stream_slices(SyncMode.incremental)
     assert stream_slices == [{"start_time": "2021-01-01", "end_time": "2023-01-01"}]
 
 
@@ -628,7 +571,7 @@ def test_no_end_datetime(mock_datetime_now):
         config=config,
         parameters={},
     )
-    stream_slices = cursor.stream_slices(SyncMode.incremental, {})
+    stream_slices = cursor.stream_slices(SyncMode.incremental)
     assert stream_slices == [{"start_time": "2021-01-01", "end_time": FAKE_NOW.strftime("%Y-%m-%d")}]
 
 

--- a/airbyte-cdk/python/unit_tests/sources/declarative/incremental/test_per_partition_cursor_integration.py
+++ b/airbyte-cdk/python/unit_tests/sources/declarative/incremental/test_per_partition_cursor_integration.py
@@ -143,7 +143,7 @@ def test_given_record_for_partition_when_read_then_update_state():
             ).build()
     )
     stream_instance = source.streams({})[0]
-    list(stream_instance.stream_slices(sync_mode=SYNC_MODE, stream_state={}))
+    list(stream_instance.stream_slices(sync_mode=SYNC_MODE))
 
     with patch.object(HttpStream, "_read_pages", side_effect=[[{"a record key": "a record value", CURSOR_FIELD: "2022-01-15"}]]):
         list(

--- a/airbyte-cdk/python/unit_tests/sources/declarative/partition_routers/test_list_partition_router.py
+++ b/airbyte-cdk/python/unit_tests/sources/declarative/partition_routers/test_list_partition_router.py
@@ -37,27 +37,8 @@ parameters = {"cursor_field": "owner_resource"}
 )
 def test_list_partition_router(test_name, partition_values, cursor_field, expected_slices):
     slicer = ListPartitionRouter(values=partition_values, cursor_field=cursor_field, config={}, parameters=parameters)
-    slices = [s for s in slicer.stream_slices(SyncMode.incremental, stream_state=None)]
+    slices = [s for s in slicer.stream_slices(SyncMode.incremental)]
     assert slices == expected_slices
-
-
-@pytest.mark.parametrize(
-    "test_name, stream_slice, last_record, expected_state",
-    [
-        ("test_update_cursor_no_state_no_record", {}, None, {}),
-        ("test_update_cursor_with_state_no_record", {"owner_resource": "customer"}, None, {"owner_resource": "customer"}),
-        ("test_update_cursor_value_not_in_list", {"owner_resource": "invalid"}, None, {}),
-    ],
-)
-def test_update_cursor(test_name, stream_slice, last_record, expected_state):
-    slicer = ListPartitionRouter(values=partition_values, cursor_field=cursor_field, config={}, parameters={})
-    if expected_state:
-        slicer.update_cursor(stream_slice, last_record)
-        updated_state = slicer.get_stream_state()
-        assert expected_state == updated_state
-    else:
-        with pytest.raises(ValueError):
-            slicer.update_cursor(stream_slice, last_record)
 
 
 @pytest.mark.parametrize(

--- a/airbyte-cdk/python/unit_tests/sources/declarative/partition_routers/test_single_partition_router.py
+++ b/airbyte-cdk/python/unit_tests/sources/declarative/partition_routers/test_single_partition_router.py
@@ -9,6 +9,6 @@ from airbyte_cdk.sources.declarative.partition_routers.single_partition_router i
 def test():
     iterator = SinglePartitionRouter(parameters={})
 
-    stream_slices = iterator.stream_slices(SyncMode.incremental, None)
+    stream_slices = iterator.stream_slices(SyncMode.incremental)
     next_slice = next(stream_slices)
     assert next_slice == dict()

--- a/airbyte-cdk/python/unit_tests/sources/declarative/partition_routers/test_substream_partition_router.py
+++ b/airbyte-cdk/python/unit_tests/sources/declarative/partition_routers/test_substream_partition_router.py
@@ -165,43 +165,6 @@ def test_substream_slicer(test_name, parent_stream_configs, expected_slices):
 
 
 @pytest.mark.parametrize(
-    "test_name, stream_slice, expected_state",
-    [
-        ("test_update_cursor_no_state_no_record", {}, {}),
-        ("test_update_cursor_with_state_single_parent", {"first_stream_id": "1234"}, {"first_stream_id": "1234"}),
-        ("test_update_cursor_with_unknown_state_field", {"unknown_stream_id": "1234"}, {}),
-        (
-            "test_update_cursor_with_state_from_both_parents",
-            {"first_stream_id": "1234", "second_stream_id": "4567"},
-            {"first_stream_id": "1234", "second_stream_id": "4567"},
-        ),
-    ],
-)
-def test_update_cursor(test_name, stream_slice, expected_state):
-    parent_stream_name_to_config = [
-        ParentStreamConfig(
-            stream=MockStream(parent_slices, data_first_parent_slice + data_second_parent_slice, "first_stream"),
-            parent_key="id",
-            partition_field="first_stream_id",
-            parameters={},
-            config={},
-        ),
-        ParentStreamConfig(
-            stream=MockStream(second_parent_stream_slice, more_records, "second_stream"),
-            parent_key="id",
-            partition_field="second_stream_id",
-            parameters={},
-            config={},
-        ),
-    ]
-
-    partition_router = SubstreamPartitionRouter(parent_stream_configs=parent_stream_name_to_config, parameters={}, config={})
-    partition_router.update_cursor(stream_slice, None)
-    updated_state = partition_router.get_stream_state()
-    assert expected_state == updated_state
-
-
-@pytest.mark.parametrize(
     "test_name, parent_stream_request_parameters, expected_req_params, expected_headers, expected_body_json, expected_body_data",
     [
         (

--- a/airbyte-cdk/python/unit_tests/sources/declarative/retrievers/test_simple_retriever.py
+++ b/airbyte-cdk/python/unit_tests/sources/declarative/retrievers/test_simple_retriever.py
@@ -11,7 +11,7 @@ import requests
 from airbyte_cdk.models import AirbyteLogMessage, AirbyteMessage, Level, SyncMode, Type
 from airbyte_cdk.sources.declarative.auth.declarative_authenticator import NoAuth
 from airbyte_cdk.sources.declarative.exceptions import ReadException
-from airbyte_cdk.sources.declarative.incremental import DatetimeBasedCursor
+from airbyte_cdk.sources.declarative.incremental import Cursor, DatetimeBasedCursor
 from airbyte_cdk.sources.declarative.partition_routers import SinglePartitionRouter
 from airbyte_cdk.sources.declarative.requesters.error_handlers.response_action import ResponseAction
 from airbyte_cdk.sources.declarative.requesters.error_handlers.response_status import ResponseStatus
@@ -52,14 +52,14 @@ def test_simple_retriever_full(mock_http_stream):
     record_selector = MagicMock()
     record_selector.select_records.return_value = records
 
-    stream_slicer = MagicMock()
+    cursor = MagicMock(spec=Cursor)
     stream_slices = [{"date": "2022-01-01"}, {"date": "2022-01-02"}]
-    stream_slicer.stream_slices.return_value = stream_slices
+    cursor.stream_slices.return_value = stream_slices
 
     response = requests.Response()
 
     underlying_state = {"date": "2021-01-01"}
-    stream_slicer.get_stream_state.return_value = underlying_state
+    cursor.get_stream_state.return_value = underlying_state
 
     requester.get_authenticator.return_value = NoAuth({})
     url_base = "https://airbyte.io"
@@ -91,7 +91,8 @@ def test_simple_retriever_full(mock_http_stream):
         requester=requester,
         paginator=paginator,
         record_selector=record_selector,
-        stream_slicer=stream_slicer,
+        stream_slicer=cursor,
+        cursor=cursor,
         parameters={},
         config={},
     )
@@ -737,7 +738,7 @@ def test_read_records_updates_stream_slicer_once_if_no_records(test_name, last_r
         requester = MagicMock()
         paginator = MagicMock()
         record_selector = MagicMock()
-        stream_slicer = MagicMock()
+        cursor = MagicMock(spec=Cursor)
 
         retriever = SimpleRetriever(
             name="stream_name",
@@ -745,7 +746,8 @@ def test_read_records_updates_stream_slicer_once_if_no_records(test_name, last_r
             requester=requester,
             paginator=paginator,
             record_selector=record_selector,
-            stream_slicer=stream_slicer,
+            stream_slicer=cursor,
+            cursor=cursor,
             parameters={},
             config={},
         )
@@ -753,7 +755,7 @@ def test_read_records_updates_stream_slicer_once_if_no_records(test_name, last_r
 
         list(retriever.read_records(sync_mode=SyncMode.incremental, stream_slice={"repository": "airbyte"}))
 
-        assert stream_slicer.update_cursor.call_count == expected_stream_slicer_update_count
+        assert cursor.update_state.call_count == expected_stream_slicer_update_count
 
 
 def _generate_slices(number_of_slices):
@@ -765,8 +767,8 @@ def test_given_state_selector_when_read_records_use_slice_state(http_stream_read
     requester = MagicMock()
     paginator = MagicMock()
     record_selector = MagicMock()
-    stream_slicer = MagicMock()
-    stream_slicer.select_state.return_value = A_SLICE_STATE
+    cursor = MagicMock(spec=Cursor)
+    cursor.select_state = MagicMock(return_value=A_SLICE_STATE)
 
     retriever = SimpleRetriever(
         name="stream_name",
@@ -774,11 +776,12 @@ def test_given_state_selector_when_read_records_use_slice_state(http_stream_read
         requester=requester,
         paginator=paginator,
         record_selector=record_selector,
-        stream_slicer=stream_slicer,
+        stream_slicer=cursor,
+        cursor=cursor,
         parameters={},
         config={},
     )
-    list(retriever.read_records(SyncMode.incremental, stream_slice=A_STREAM_SLICE, stream_state=A_STREAM_STATE))
+    list(retriever.read_records(SyncMode.incremental, stream_slice=A_STREAM_SLICE))
 
     http_stream_read_pages.assert_called_once_with(retriever.parse_records, A_STREAM_SLICE, A_SLICE_STATE)
 

--- a/airbyte-cdk/python/unit_tests/sources/declarative/stream_slicers/test_cartesian_product_stream_slicer.py
+++ b/airbyte-cdk/python/unit_tests/sources/declarative/stream_slicers/test_cartesian_product_stream_slicer.py
@@ -70,45 +70,8 @@ from airbyte_cdk.sources.declarative.stream_slicers.cartesian_product_stream_sli
 )
 def test_substream_slicer(test_name, stream_slicers, expected_slices):
     slicer = CartesianProductStreamSlicer(stream_slicers=stream_slicers, parameters={})
-    slices = [s for s in slicer.stream_slices(SyncMode.incremental, stream_state=None)]
+    slices = [s for s in slicer.stream_slices(SyncMode.incremental)]
     assert slices == expected_slices
-
-
-@pytest.mark.parametrize(
-    "test_name, stream_slice, expected_state",
-    [
-        ("test_update_cursor_no_state_no_record", {}, {}),
-        ("test_update_cursor_partial_state", {"owner_resource": "customer"}, {"owner_resource": "customer"}),
-        (
-            "test_update_cursor_full_state",
-            {"owner_resource": "customer", "date": "2021-01-01"},
-            {"owner_resource": "customer", "date": "2021-01-01"},
-        ),
-    ],
-)
-def test_update_cursor(test_name, stream_slice, expected_state):
-    stream_slicers = [
-        ListPartitionRouter(values=["customer", "store", "subscription"], cursor_field="owner_resource", config={}, parameters={}),
-        DatetimeBasedCursor(
-            start_datetime=MinMaxDatetime(datetime="2021-01-01", datetime_format="%Y-%m-%d", parameters={}),
-            end_datetime=MinMaxDatetime(datetime="2021-01-03", datetime_format="%Y-%m-%d", parameters={}),
-            step="P1D",
-            cursor_field=InterpolatedString(string="date", parameters={}),
-            datetime_format="%Y-%m-%d",
-            cursor_granularity="P1D",
-            config={},
-            parameters={},
-        ),
-    ]
-    slicer = CartesianProductStreamSlicer(stream_slicers=stream_slicers, parameters={})
-
-    if expected_state:
-        slicer.update_cursor(stream_slice, None)
-        updated_state = slicer.get_stream_state()
-        assert expected_state == updated_state
-    else:
-        with pytest.raises(ValueError):
-            slicer.update_cursor(stream_slice, None)
 
 
 @pytest.mark.parametrize(


### PR DESCRIPTION
## What
Problems:
* It is hard to follow the lifecycle of stream_state
    * The interfaces are not explicit in what it does
        * stream_state passed as a parameter but should not be used. This is a problem since the following implementation relies on the parameter and not their internal state:
             * DatetimeBasedCursor
             * greenhouse
             * intercom
             * posthog
             * railz
             * square
             * zenloop
    * Each method should only do one thing
        * Right now, update_cursor does two things: set up the initial state, update based on a new record
* Some objects provide state while they don’t really have

Note that these problems have a somewhat broad impact on the code base and I went on a killing spree. I'm willing to review the scope and do smaller change if we think it would be wise.

## How
For problem # 1, remove argument `stream_state` from everything below DeclarativeStream.
Note: there is an exception to this and it is for interpolation where source-intercom and source-railz use interpolation for creating the request and filtering.

For problem # 2, create separate interface for StreamSlicer and Cursor where StreamSlicer does not have notions of state. If state is used to determine slices, it will rely on the internals of the class.

## Recommended reading order
1. `airbyte-cdk/python/airbyte_cdk/sources/declarative/incremental/cursor.py` and `airbyte-cdk/python/airbyte_cdk/sources/declarative/stream_slicers/cartesian_product_stream_slicer.py`
2. The rest

## 🚨 User Impact 🚨
The following are a breaking changes:
* `CustomRetriever` (no usage in repository so I'm not worried about this one)
    * `read_records` arg `stream_state` removed
    * if inheriting from SimpleRetriever, split `self.stream_slicer` into `self.stream_slicer` and `self.cursor`
* `CustomIncrementalSync`
    * `update_cursor` split into `set_initial_state` and `update_state`
    * `stream_slices` has doesn't take any parameters anymore
* `CustomPartitionRouter` (no usage in repository so I'm not worried about this one)
    * if `update_cursor` and `get_stream_state` were implemented and relevant, should be migrated to `CustomIncrementalSync`
    * `stream_slices` has doesn't take any parameters anymore
* `DatetimeBasedCursor`: Removed interpolation based on stream_state as part of. Reasons are:
    * It wasn't used
    * The state can change at any point so it's hard for the user to know which state will be used
    * I fear this might create a lot of headaches when we will try to parallelize the requests and I think we prefer parallelization to stream_state interpolation
* `SubstreamPartitionRouter` was passing state to parent_stream. This could be a problem is if parent and child stream were actually sharing the same state with the same cursor parameters (cursor_field, datetime format). As of today, it is not clear to me what is the expectation from the user in terms of incremental stream where the parent is incremental as well and I feel it is somewhat dangerous when a user configure this
