### PR TITLE
connectors-ci: do not run tests on fork PR

### DIFF
--- a/.github/workflows/connectors_tests.yml
+++ b/.github/workflows/connectors_tests.yml
@@ -20,6 +20,13 @@ jobs:
     timeout-minutes: 1440 # 24 hours
     runs-on: dev-medium-runner
     steps:
+      - name: Check if PR is from a fork
+        if: github.event_name == 'pull_request'
+        run: |
+          if [ "${{ github.event.pull_request.head.repo.fork }}" == "true" ]; then
+            echo "PR is from a fork. Exiting workflow..."
+            exit 78
+          fi
       - name: Get start timestamp
         id: get-start-timestamp
         run: echo "::set-output name=start-timestamp::$(date +%s)"

--- a/airbyte-integrations/connectors/source-openweather/metadata.yaml
+++ b/airbyte-integrations/connectors/source-openweather/metadata.yaml
@@ -6,7 +6,7 @@ data:
   dockerRepository: airbyte/source-openweather
   githubIssueLabel: source-openweather
   icon: openweather.svg
-  license: MIT
+  license: Apache-2.0
   name: OpenWeather
   registries:
     cloud:

--- a/airbyte-integrations/connectors/source-openweather/metadata.yaml
+++ b/airbyte-integrations/connectors/source-openweather/metadata.yaml
@@ -6,7 +6,7 @@ data:
   dockerRepository: airbyte/source-openweather
   githubIssueLabel: source-openweather
   icon: openweather.svg
-  license: Apache-2.0
+  license: MIT
   name: OpenWeather
   registries:
     cloud:


### PR DESCRIPTION
## What
More details about the why in #27399

## How
* Exit the connector test GHA workflow if the triggering PR is a fork.