### PR TITLE
Source ZohoCRM: Update api version and default optional fields to None

### DIFF
--- a/airbyte-integrations/connectors/source-zoho-crm/Dockerfile
+++ b/airbyte-integrations/connectors/source-zoho-crm/Dockerfile
@@ -12,5 +12,5 @@ RUN pip install .
 ENV AIRBYTE_ENTRYPOINT "python /airbyte/integration_code/main.py"
 ENTRYPOINT ["python", "/airbyte/integration_code/main.py"]
 
-LABEL io.airbyte.version=0.1.2
+LABEL io.airbyte.version=0.1.3
 LABEL io.airbyte.name=airbyte/source-zoho-crm

--- a/airbyte-integrations/connectors/source-zoho-crm/metadata.yaml
+++ b/airbyte-integrations/connectors/source-zoho-crm/metadata.yaml
@@ -2,7 +2,7 @@ data:
   connectorSubtype: api
   connectorType: source
   definitionId: 4942d392-c7b5-4271-91f9-3b4f4e51eb3e
-  dockerImageTag: 0.1.2
+  dockerImageTag: 0.1.3
   dockerRepository: airbyte/source-zoho-crm
   githubIssueLabel: source-zoho-crm
   icon: zohocrm.svg

--- a/airbyte-integrations/connectors/source-zoho-crm/source_zoho_crm/api.py
+++ b/airbyte-integrations/connectors/source-zoho-crm/source_zoho_crm/api.py
@@ -37,6 +37,7 @@ class ZohoAPI:
     )
     _API_ENV_TO_URL_PREFIX = MappingProxyType({"production": "", "developer": "developer", "sandbox": "sandbox"})
     _CONCURRENCY_API_LIMITS = MappingProxyType({"Free": 5, "Standard": 10, "Professional": 15, "Enterprise": 20, "Ultimate": 25})
+    _API_VERSION = "v4"
 
     def __init__(self, config: Mapping[str, Any]):
         self.config = config
@@ -76,16 +77,16 @@ class ZohoAPI:
         return response.json()[key]
 
     def module_settings(self, module_name: str) -> List[MutableMapping[Any, Any]]:
-        return self._json_from_path(f"/crm/v2/settings/modules/{module_name}", key="modules")
+        return self._json_from_path(f"/crm/{self._API_VERSION}/settings/modules/{module_name}", key="modules")
 
     def modules_settings(self) -> List[MutableMapping[Any, Any]]:
-        return self._json_from_path("/crm/v2/settings/modules", key="modules")
+        return self._json_from_path(f"/crm/{self._API_VERSION}/settings/modules", key="modules")
 
     def fields_settings(self, module_name: str) -> List[MutableMapping[Any, Any]]:
-        return self._json_from_path("/crm/v2/settings/fields", key="fields", params={"module": module_name})
+        return self._json_from_path(f"/crm/{self._API_VERSION}/settings/fields", key="fields", params={"module": module_name})
 
     def check_connection(self) -> Tuple[bool, Any]:
-        path = "/crm/v2/settings/modules"
+        path = f"/crm/{self._API_VERSION}/settings/modules"
         response = requests.get(url=f"{self.api_url}{path}", headers=self.authenticator.get_auth_header())
         try:
             response.raise_for_status()

--- a/airbyte-integrations/connectors/source-zoho-crm/source_zoho_crm/types.py
+++ b/airbyte-integrations/connectors/source-zoho-crm/source_zoho_crm/types.py
@@ -107,13 +107,13 @@ FieldType = Dict[Any, Any]
 @dataclasses.dataclass
 class FieldMeta(FromDictMixin):
     json_type: str
-    length: Optional[int]
     api_name: str
     data_type: str
-    decimal_place: Optional[int]
     system_mandatory: bool
     display_label: str
-    pick_list_values: Optional[List[ZohoPickListItem]]
+    decimal_place: Optional[int] = None
+    pick_list_values: Optional[List[ZohoPickListItem]] = None
+    length: Optional[int] = None
     auto_number: Optional[AutoNumberDict] = AutoNumberDict(prefix="", suffix="")
 
     def _default_type_kwargs(self) -> Dict[str, str]:

--- a/docs/integrations/sources/zoho-crm.md
+++ b/docs/integrations/sources/zoho-crm.md
@@ -130,6 +130,7 @@ Make sure to complete the auth flow quickly, as the initial token granted by Zoh
 
 | Version | Date       | Pull Request                                             | Subject                                                                            |
 |:--------|:-----------|:---------------------------------------------------------|:-----------------------------------------------------------------------------------|
+| 0.1.3   | 2023-07-03 | [23906](https://github.com/airbytehq/airbyte/pull/27423) | Updated api to use v4, fixed optional params being required bug
 | 0.1.2   | 2023-03-09 | [23906](https://github.com/airbytehq/airbyte/pull/23906) | added support for the latest CDK, fixed SAT                                        |
 | 0.1.1   | 2023-03-13 | [23818](https://github.com/airbytehq/airbyte/pull/23818) | Set airbyte type to string for zoho autonumbers when they include prefix or suffix |
 | 0.1.0   | 2022-03-30 | [11193](https://github.com/airbytehq/airbyte/pull/11193) | Initial release                                                                    |


### PR DESCRIPTION
## What
The API Version was out of date which was causing issues because the v2 version has some modules return meta data with missing required fields.
Example: The deals endpoint with our customer's credentials was missing the "json_type" and "length" fields in the meta data which was causing the deals stream to not be available.
Also the optional fields in the FieldMeta class were not actually optional because they weren't being defaulted to None, local testing of that isolated code shows that if we have data missing the picklist_values field (which is supposed to be optional), the __init__() would fail because it wasn't being defaulted to None. 
![image](https://github.com/airbytehq/airbyte/assets/113922446/db5203d5-0856-48dc-a6e4-a87e9834f82c)

## How
Fix #1
Update the zohocrm api version from v2 to v4
This will solve the ZohoCRM API returning data that is missing required fields issue

Fix #2
Have the class FieldMeta's optional fields be defaulted to None
This will solve the FieldMeta's __init__() failing on valid data due to missing optional fields issue

Re-testing shows the deals stream now available
<img width="1018" alt="image" src="https://github.com/airbytehq/airbyte/assets/113922446/71616880-4f8f-448b-a47b-9716283063ee">

## Recommended reading order
This shows that dataclasses optional fields must be defaulted to a value
https://stackoverflow.com/questions/70809438/python-dataclasses-with-optional-attributes

## 🚨 User Impact 🚨

Some of our clients were not seeing key streams such as Deals due to this issue

## Pre-merge Actions
*Expand the relevant checklist and delete the others.*

<details><summary><strong>New Connector</strong></summary>

### Community member or Airbyter

- **Community member?** Grant edit access to maintainers ([instructions](https://docs.github.com/en/github/collaborating-with-pull-requests/working-with-forks/allowing-changes-to-a-pull-request-branch-created-from-a-fork#enabling-repository-maintainer-permissions-on-existing-pull-requests))
- Unit & integration tests added and passing. Community members, please provide proof of success locally e.g: screenshot or copy-paste unit, integration, and acceptance test output. To run acceptance tests for a Python connector, follow instructions in the README. For java connectors run `./gradlew :airbyte-integrations:connectors:<name>:integrationTest`.
- Connector version is set to `0.0.1`
    - `Dockerfile` has version `0.0.1`
- Documentation updated
    - Connector's `README.md`
    - Connector's `bootstrap.md`. See [description and examples](https://docs.google.com/document/d/1ypdgmwmEHWv-TrO4_YOQ7pAJGVrMp5BOkEVh831N260/edit?usp=sharing)
    - `docs/integrations/<source or destination>/<name>.md` including changelog with an entry for the initial version. See changelog [example](https://docs.airbyte.io/integrations/sources/stripe#changelog)
    - `docs/integrations/README.md`

### Airbyter

If this is a community PR, the Airbyte engineer reviewing this PR is responsible for the below items.

- Create a non-forked branch based on this PR and test the below items on it
- Build is successful
- If new credentials are required for use in CI, add them to GSM. [Instructions](https://docs.airbyte.io/connector-development#using-credentials-in-ci).

</details>

<details><summary><strong>Updating a connector</strong></summary>

### Community member or Airbyter

- Grant edit access to maintainers ([instructions](https://docs.github.com/en/github/collaborating-with-pull-requests/working-with-forks/allowing-changes-to-a-pull-request-branch-created-from-a-fork#enabling-repository-maintainer-permissions-on-existing-pull-requests))
- Unit & integration tests added


### Airbyter

If this is a community PR, the Airbyte engineer reviewing this PR is responsible for the below items.

- Create a non-forked branch based on this PR and test the below items on it
- Build is successful
- If new credentials are required for use in CI, add them to GSM. [Instructions](https://docs.airbyte.io/connector-development#using-credentials-in-ci).

</details>

<details><summary><strong>Connector Generator</strong></summary>

- Issue acceptance criteria met
- PR name follows [PR naming conventions](https://docs.airbyte.com/contributing-to-airbyte/issues-and-pull-requests#pull-request-title-convention)
- If adding a new generator, add it to the [list of scaffold modules being tested](https://github.com/airbytehq/airbyte/blob/master/airbyte-integrations/connector-templates/generator/build.gradle#L41)
- The generator test modules (all connectors with `-scaffold` in their name) have been updated with the latest scaffold by running `./gradlew :airbyte-integrations:connector-templates:generator:testScaffoldTemplates` then checking in your changes
- Documentation which references the generator is updated as needed

</details>
