### PR TITLE
cat: increase docker connection timeout to 2mn

### DIFF
--- a/airbyte-integrations/bases/connector-acceptance-test/CHANGELOG.md
+++ b/airbyte-integrations/bases/connector-acceptance-test/CHANGELOG.md
@@ -1,5 +1,8 @@
 # Changelog
 
+## 0.10.8
+Increase the connection timeout to Docker client to 2 minutes ([context](https://github.com/airbytehq/airbyte/issues/27401))
+
 ## 0.10.7
 Fix on supporting arrays in the state (ensure string are parsed as string and not int)
 

--- a/airbyte-integrations/bases/connector-acceptance-test/Dockerfile
+++ b/airbyte-integrations/bases/connector-acceptance-test/Dockerfile
@@ -33,7 +33,7 @@ COPY pytest.ini setup.py ./
 COPY connector_acceptance_test ./connector_acceptance_test
 RUN pip install .
 
-LABEL io.airbyte.version=0.10.7
+LABEL io.airbyte.version=0.10.8
 LABEL io.airbyte.name=airbyte/connector-acceptance-test
 
 ENTRYPOINT ["python", "-m", "pytest", "-p", "connector_acceptance_test.plugin", "-r", "fEsx"]

--- a/airbyte-integrations/bases/connector-acceptance-test/connector_acceptance_test/utils/connector_runner.py
+++ b/airbyte-integrations/bases/connector-acceptance-test/connector_acceptance_test/utils/connector_runner.py
@@ -24,7 +24,7 @@ class ConnectorRunner:
         connector_configuration_path: Optional[Path] = None,
         custom_environment_variables: Optional[Mapping] = {},
     ):
-        self._client = docker.from_env()
+        self._client = docker.from_env(timeout=120)
         try:
             self._image = self._client.images.get(image_name)
         except docker.errors.ImageNotFound:


### PR DESCRIPTION
## What
Fixes https://github.com/airbytehq/airbyte/issues/27401

## How
Increase the docker client connection timeout to 2mn in the `ConnectorRunner`