### PR TITLE
Google Analytics V4: Set 500Mi for check_connection jobs

### DIFF
--- a/airbyte-integrations/connectors/source-google-analytics-v4/metadata.yaml
+++ b/airbyte-integrations/connectors/source-google-analytics-v4/metadata.yaml
@@ -20,6 +20,12 @@ data:
     oss:
       enabled: true
   releaseStage: generally_available
+  resourceRequirements:
+    jobSpecific:
+      - jobType: check_connection
+        resourceRequirements:
+          memory_limit: 500Mi
+          memory_request: 500Mi
   documentationUrl: https://docs.airbyte.com/integrations/sources/google-analytics-v4
   tags:
     - language:python


### PR DESCRIPTION
## What
Some check connection jobs were failing due to OOM for the Google Analytics v4. This should increase the memory allocated from the default 200Mi to 500Mi

## How
Add check_connection resource requirement in metadata.yaml

