### PR TITLE
🤖 Cloud Availability updater: new connectors to deploy [20230617]

### DIFF
--- a/airbyte-integrations/connectors/destination-amazon-sqs/metadata.yaml
+++ b/airbyte-integrations/connectors/destination-amazon-sqs/metadata.yaml
@@ -10,7 +10,7 @@ data:
   name: Amazon SQS
   registries:
     cloud:
-      enabled: false # hide Amazon SQS Destination https://github.com/airbytehq/airbyte/issues/16316
+      enabled: true  # hide Amazon SQS Destination https://github.com/airbytehq/airbyte/issues/16316
     oss:
       enabled: true
   releaseStage: alpha

--- a/airbyte-integrations/connectors/destination-timeplus/metadata.yaml
+++ b/airbyte-integrations/connectors/destination-timeplus/metadata.yaml
@@ -10,7 +10,7 @@ data:
   name: Timeplus
   registries:
     cloud:
-      enabled: false
+      enabled: true
     oss:
       enabled: true
   releaseStage: alpha

--- a/airbyte-integrations/connectors/destination-xata/metadata.yaml
+++ b/airbyte-integrations/connectors/destination-xata/metadata.yaml
@@ -1,7 +1,7 @@
 data:
   registries:
     cloud:
-      enabled: false
+      enabled: true
     oss:
       enabled: true
   connectorSubtype: database

--- a/airbyte-integrations/connectors/source-appfollow/metadata.yaml
+++ b/airbyte-integrations/connectors/source-appfollow/metadata.yaml
@@ -10,7 +10,7 @@ data:
   name: Appfollow
   registries:
     cloud:
-      enabled: false
+      enabled: true
     oss:
       enabled: true
   releaseStage: alpha

--- a/airbyte-integrations/connectors/source-coingecko-coins/metadata.yaml
+++ b/airbyte-integrations/connectors/source-coingecko-coins/metadata.yaml
@@ -10,7 +10,7 @@ data:
   name: CoinGecko Coins
   registries:
     cloud:
-      enabled: false
+      enabled: true
     oss:
       enabled: true
   releaseStage: alpha


### PR DESCRIPTION
The Cloud Availability Updater decided that it's the right time to make the following 5 connectors available on Cloud!

# Promoted connectors
|connector_technical_name|connector_version|      connector_definition_id       |
|------------------------|-----------------|------------------------------------|
|source-appfollow        |0.1.1            |b4375641-e270-41d3-9c20-4f9cecad87a8|
|source-coingecko-coins  |0.1.0            |9cdd4183-d0ba-40c3-aad3-6f46d4103974|
|destination-amazon-sqs  |0.1.0            |0eeee7fb-518f-4045-bacc-9619e31c43ea|
|destination-timeplus    |0.1.0            |f70a8ece-351e-4790-b37b-cb790bcd6d54|
|destination-xata        |0.1.0            |2a51c92d-0fb4-4e54-94d2-cce631f24d1f|

# Excluded but eligible connectors
|connector_technical_name|connector_version|connector_definition_id|
|------------------------|-----------------|-----------------------|

 ☝️ These eligible connectors are already in the definitions masks. They might have been explicitly pinned or excluded. We're not adding these for safety.