### PR TITLE
🐛 Source Typeform: add undeclared columns to streams

### DIFF
--- a/airbyte-integrations/connectors/source-typeform/Dockerfile
+++ b/airbyte-integrations/connectors/source-typeform/Dockerfile
@@ -12,5 +12,5 @@ COPY main.py ./
 ENV AIRBYTE_ENTRYPOINT "python /airbyte/integration_code/main.py"
 ENTRYPOINT ["python", "/airbyte/integration_code/main.py"]
 
-LABEL io.airbyte.version=0.2.12
+LABEL io.airbyte.version=0.2.0
 LABEL io.airbyte.name=airbyte/source-typeform

--- a/airbyte-integrations/connectors/source-typeform/Dockerfile
+++ b/airbyte-integrations/connectors/source-typeform/Dockerfile
@@ -12,5 +12,5 @@ COPY main.py ./
 ENV AIRBYTE_ENTRYPOINT "python /airbyte/integration_code/main.py"
 ENTRYPOINT ["python", "/airbyte/integration_code/main.py"]
 
-LABEL io.airbyte.version=0.1.12
+LABEL io.airbyte.version=0.1.13
 LABEL io.airbyte.name=airbyte/source-typeform

--- a/airbyte-integrations/connectors/source-typeform/Dockerfile
+++ b/airbyte-integrations/connectors/source-typeform/Dockerfile
@@ -12,5 +12,5 @@ COPY main.py ./
 ENV AIRBYTE_ENTRYPOINT "python /airbyte/integration_code/main.py"
 ENTRYPOINT ["python", "/airbyte/integration_code/main.py"]
 
-LABEL io.airbyte.version=0.1.13
+LABEL io.airbyte.version=0.2.12
 LABEL io.airbyte.name=airbyte/source-typeform

--- a/airbyte-integrations/connectors/source-typeform/acceptance-test-config.yml
+++ b/airbyte-integrations/connectors/source-typeform/acceptance-test-config.yml
@@ -21,7 +21,7 @@ acceptance_tests:
         bypass_reason: "no data"
       expect_records:
         path: "integration_tests/expected_records.jsonl"
-      fail_on_extra_columns: false
+      fail_on_extra_columns: true
   incremental:
     tests:
     - config_path: "secrets/incremental_config.json"

--- a/airbyte-integrations/connectors/source-typeform/metadata.yaml
+++ b/airbyte-integrations/connectors/source-typeform/metadata.yaml
@@ -5,7 +5,7 @@ data:
   connectorSubtype: api
   connectorType: source
   definitionId: e7eff203-90bf-43e5-a240-19ea3056c474
-  dockerImageTag: 0.2.12
+  dockerImageTag: 0.2.0
   dockerRepository: airbyte/source-typeform
   githubIssueLabel: source-typeform
   icon: typeform.svg

--- a/airbyte-integrations/connectors/source-typeform/metadata.yaml
+++ b/airbyte-integrations/connectors/source-typeform/metadata.yaml
@@ -5,7 +5,7 @@ data:
   connectorSubtype: api
   connectorType: source
   definitionId: e7eff203-90bf-43e5-a240-19ea3056c474
-  dockerImageTag: 0.1.12
+  dockerImageTag: 0.1.13
   dockerRepository: airbyte/source-typeform
   githubIssueLabel: source-typeform
   icon: typeform.svg

--- a/airbyte-integrations/connectors/source-typeform/metadata.yaml
+++ b/airbyte-integrations/connectors/source-typeform/metadata.yaml
@@ -5,7 +5,7 @@ data:
   connectorSubtype: api
   connectorType: source
   definitionId: e7eff203-90bf-43e5-a240-19ea3056c474
-  dockerImageTag: 0.1.13
+  dockerImageTag: 0.2.12
   dockerRepository: airbyte/source-typeform
   githubIssueLabel: source-typeform
   icon: typeform.svg

--- a/airbyte-integrations/connectors/source-typeform/source_typeform/schemas/forms.json
+++ b/airbyte-integrations/connectors/source-typeform/source_typeform/schemas/forms.json
@@ -8,13 +8,16 @@
       "type": ["null", "string"]
     },
     "created_at": {
-      "type": ["null", "string"]
+      "type": ["null", "string"],
+      "format": "date-time"
     },
     "last_updated_at": {
-      "type": ["null", "string"]
+      "type": ["null", "string"],
+      "format": "date-time"
     },
     "published_at": {
-      "type": ["null", "string"]
+      "type": ["null", "string"],
+      "format": "date-time"
     },
     "title": {
       "type": ["null", "string"]

--- a/airbyte-integrations/connectors/source-typeform/source_typeform/schemas/forms.json
+++ b/airbyte-integrations/connectors/source-typeform/source_typeform/schemas/forms.json
@@ -7,6 +7,15 @@
     "type": {
       "type": ["null", "string"]
     },
+    "created_at": {
+      "type": ["null", "string"]
+    },
+    "last_updated_at": {
+      "type": ["null", "string"]
+    },
+    "published_at": {
+      "type": ["null", "string"]
+    },
     "title": {
       "type": ["null", "string"]
     },

--- a/airbyte-integrations/connectors/source-typeform/source_typeform/schemas/images.json
+++ b/airbyte-integrations/connectors/source-typeform/source_typeform/schemas/images.json
@@ -9,6 +9,21 @@
     },
     "src": {
       "type": ["null", "string"]
+    },
+    "width":{
+      "type": ["null", "integer"]
+    },
+    "height": {
+      "type": ["null", "integer"]
+    },
+    "media_type": {
+      "type": ["null", "string"]
+    },
+    "avg_color":{
+      "type": ["null", "string"]
+    },
+    "has_alpha": {
+      "type": ["null", "boolean"]
     }
   },
   "$schema": "http://json-schema.org/draft-07/schema#"

--- a/airbyte-integrations/connectors/source-typeform/source_typeform/schemas/responses.json
+++ b/airbyte-integrations/connectors/source-typeform/source_typeform/schemas/responses.json
@@ -7,7 +7,13 @@
     "landed_at": {
       "type": ["null", "string"]
     },
+    "landing_id": {
+      "type": ["null", "string"]
+    },
     "submitted_at": {
+      "type": ["null", "string"]
+    },
+    "token": {
       "type": ["null", "string"]
     },
     "metadata": {

--- a/airbyte-integrations/connectors/source-typeform/source_typeform/schemas/themes.json
+++ b/airbyte-integrations/connectors/source-typeform/source_typeform/schemas/themes.json
@@ -55,6 +55,9 @@
     "name": {
       "type": ["null", "string"]
     },
+    "rounded_corners": {
+      "type": ["null", "string"]
+    },
     "screens": {
       "type": ["null", "object"],
       "properties": {
@@ -67,6 +70,12 @@
       }
     },
     "visibility": {
+      "type": ["null", "string"]
+    },
+    "updated_at": {
+      "type": ["null", "string"]
+    },
+    "created_at": {
       "type": ["null", "string"]
     }
   },

--- a/airbyte-integrations/connectors/source-typeform/source_typeform/schemas/themes.json
+++ b/airbyte-integrations/connectors/source-typeform/source_typeform/schemas/themes.json
@@ -73,10 +73,12 @@
       "type": ["null", "string"]
     },
     "updated_at": {
-      "type": ["null", "string"]
+      "type": ["null", "string"],
+      "format": "date-time"
     },
     "created_at": {
-      "type": ["null", "string"]
+      "type": ["null", "string"],
+      "format": "date-time"
     }
   },
   "$schema": "http://json-schema.org/draft-07/schema#"

--- a/airbyte-integrations/connectors/source-typeform/source_typeform/schemas/workspaces.json
+++ b/airbyte-integrations/connectors/source-typeform/source_typeform/schemas/workspaces.json
@@ -1,6 +1,12 @@
 {
   "type": "object",
   "properties": {
+    "account_id": {
+      "type": ["null", "string"]
+    },
+    "default":{
+      "type": ["null", "boolean"]
+    },
     "forms": {
       "type": ["null", "object"],
       "properties": {

--- a/docs/integrations/sources/typeform.md
+++ b/docs/integrations/sources/typeform.md
@@ -70,7 +70,7 @@ API rate limits \(2 requests per second\): [https://developer.typeform.com/get-s
 
 | Version | Date       | Pull Request                                             | Subject                                                                 |
 |:--------|:-----------|:---------------------------------------------------------|:------------------------------------------------------------------------|
-| 0.1.13  | 2023-06-17 | [27455](https://github.com/airbytehq/airbyte/pull/27455) | Add missing schema fields in `forms`, `themes`, `images`, `workspaces`, and `responses` streams                                                   |
+| 0.2.12  | 2023-06-17 | [27455](https://github.com/airbytehq/airbyte/pull/27455) | Add missing schema fields in `forms`, `themes`, `images`, `workspaces`, and `responses` streams                                                   |
 | 0.1.12  | 2023-02-21 | [22824](https://github.com/airbytehq/airbyte/pull/22824) | Specified date formatting in specification                                                   |
 | 0.1.11  | 2023-02-20 | [23248](https://github.com/airbytehq/airbyte/pull/23248) | Store cursor value as a string                                          |
 | 0.1.10  | 2023-01-07 | [16125](https://github.com/airbytehq/airbyte/pull/16125) | Certification to Beta                                                   |

--- a/docs/integrations/sources/typeform.md
+++ b/docs/integrations/sources/typeform.md
@@ -70,6 +70,7 @@ API rate limits \(2 requests per second\): [https://developer.typeform.com/get-s
 
 | Version | Date       | Pull Request                                             | Subject                                                                 |
 |:--------|:-----------|:---------------------------------------------------------|:------------------------------------------------------------------------|
+| 0.1.13  | 2023-06-17 | [00000](https://github.com/airbytehq/airbyte/pull/00000) | Add missing schema fields in `forms`, `themes`, `images` and `workspaces` streams                                                   |
 | 0.1.12  | 2023-02-21 | [22824](https://github.com/airbytehq/airbyte/pull/22824) | Specified date formatting in specification                                                   |
 | 0.1.11  | 2023-02-20 | [23248](https://github.com/airbytehq/airbyte/pull/23248) | Store cursor value as a string                                          |
 | 0.1.10  | 2023-01-07 | [16125](https://github.com/airbytehq/airbyte/pull/16125) | Certification to Beta                                                   |

--- a/docs/integrations/sources/typeform.md
+++ b/docs/integrations/sources/typeform.md
@@ -70,7 +70,7 @@ API rate limits \(2 requests per second\): [https://developer.typeform.com/get-s
 
 | Version | Date       | Pull Request                                             | Subject                                                                 |
 |:--------|:-----------|:---------------------------------------------------------|:------------------------------------------------------------------------|
-| 0.1.13  | 2023-06-17 | [00000](https://github.com/airbytehq/airbyte/pull/00000) | Add missing schema fields in `forms`, `themes`, `images` and `workspaces` streams                                                   |
+| 0.1.13  | 2023-06-17 | [27455](https://github.com/airbytehq/airbyte/pull/27455) | Add missing schema fields in `forms`, `themes`, `images`, `workspaces`, and `responses` streams                                                   |
 | 0.1.12  | 2023-02-21 | [22824](https://github.com/airbytehq/airbyte/pull/22824) | Specified date formatting in specification                                                   |
 | 0.1.11  | 2023-02-20 | [23248](https://github.com/airbytehq/airbyte/pull/23248) | Store cursor value as a string                                          |
 | 0.1.10  | 2023-01-07 | [16125](https://github.com/airbytehq/airbyte/pull/16125) | Certification to Beta                                                   |

--- a/docs/integrations/sources/typeform.md
+++ b/docs/integrations/sources/typeform.md
@@ -70,7 +70,7 @@ API rate limits \(2 requests per second\): [https://developer.typeform.com/get-s
 
 | Version | Date       | Pull Request                                             | Subject                                                                 |
 |:--------|:-----------|:---------------------------------------------------------|:------------------------------------------------------------------------|
-| 0.2.12  | 2023-06-17 | [27455](https://github.com/airbytehq/airbyte/pull/27455) | Add missing schema fields in `forms`, `themes`, `images`, `workspaces`, and `responses` streams                                                   |
+| 0.2.0  | 2023-06-17 | [27455](https://github.com/airbytehq/airbyte/pull/27455) | Add missing schema fields in `forms`, `themes`, `images`, `workspaces`, and `responses` streams                                                   |
 | 0.1.12  | 2023-02-21 | [22824](https://github.com/airbytehq/airbyte/pull/22824) | Specified date formatting in specification                                                   |
 | 0.1.11  | 2023-02-20 | [23248](https://github.com/airbytehq/airbyte/pull/23248) | Store cursor value as a string                                          |
 | 0.1.10  | 2023-01-07 | [16125](https://github.com/airbytehq/airbyte/pull/16125) | Certification to Beta                                                   |


### PR DESCRIPTION
## What
Resolving issue described here:
https://github.com/airbytehq/airbyte/issues/24506
Streams `forms`, `images`, `workspaces`, `responses` and `themes` have some undeclared columns which are needed to be added to corresponding schemas.
## How
Added missing fields to number of streams:
* `forms` - `created_at`, `last_updated_at`, `published_at`
* `images` - `width`, `height`, `media_type`, `avg_color`, `has_alpha`
* `responses` - `landing_id`, `token`
* `themes` - `rounded_corners`, `created_at`, `updated_at`
* `workspaces` - `account_id`, `default`


