### PR TITLE
fix: pin retry action version as latest is not stable

### DIFF
--- a/.github/workflows/gradle.yml
+++ b/.github/workflows/gradle.yml
@@ -126,7 +126,7 @@ jobs:
           EOF
 
       - name: Format
-        uses: Wandalen/wretry.action@master
+        uses: Wandalen/wretry.action@v1.0.42
         with:
           command: SUB_BUILD=OCTAVIA_CLI ./gradlew format --scan --info --stacktrace
           attempt_limit: 3
@@ -136,14 +136,14 @@ jobs:
         run: ./tools/bin/check_for_file_changes
 
       - name: Build
-        uses: Wandalen/wretry.action@master
+        uses: Wandalen/wretry.action@v1.0.42
         with:
           command: SUB_BUILD=OCTAVIA_CLI ./gradlew :octavia-cli:build javadoc --scan
           attempt_limit: 3
           attempt_delay: 5000 # in ms
 
       - name: Run integration tests
-        uses: Wandalen/wretry.action@master
+        uses: Wandalen/wretry.action@v1.0.42
         with:
           command: ./tools/bin/integration_tests_octavia.sh
           attempt_limit: 3
@@ -189,7 +189,7 @@ jobs:
           EOF
 
       - name: Format
-        uses: Wandalen/wretry.action@master
+        uses: Wandalen/wretry.action@v1.0.42
         with:
           command: SUB_BUILD=CDK ./gradlew format --scan --info --stacktrace
           attempt_limit: 3
@@ -203,7 +203,7 @@ jobs:
           commit_user_email: octavia-squidington-iii@users.noreply.github.com
 
       - name: Build
-        uses: Wandalen/wretry.action@master
+        uses: Wandalen/wretry.action@v1.0.42
         with:
           command: SUB_BUILD=CDK ./gradlew build --scan
           attempt_limit: 3
@@ -290,7 +290,7 @@ jobs:
           EOF
 
       - name: Generate Template scaffold
-        uses: Wandalen/wretry.action@master
+        uses: Wandalen/wretry.action@v1.0.42
         with:
           command: ./gradlew :airbyte-integrations:connector-templates:generator:testScaffoldTemplates --scan
           attempt_limit: 3
@@ -301,21 +301,21 @@ jobs:
         run: git --no-pager diff && test -z "$(git --no-pager diff)"
 
       - name: Format
-        uses: Wandalen/wretry.action@master
+        uses: Wandalen/wretry.action@v1.0.42
         with:
           command: SUB_BUILD=CONNECTORS_BASE ./gradlew format --scan --info --stacktrace
           attempt_limit: 3
           attempt_delay: 5000 # in ms
 
       - name: Build
-        uses: Wandalen/wretry.action@master
+        uses: Wandalen/wretry.action@v1.0.42
         with:
           command: SUB_BUILD=CONNECTORS_BASE ./gradlew build --scan
           attempt_limit: 3
           attempt_delay: 5000 # in ms
 
       - name: Process Resources
-        uses: Wandalen/wretry.action@master
+        uses: Wandalen/wretry.action@v1.0.42
         with:
           command: SUB_BUILD=CONNECTORS_BASE ./gradlew :airbyte-config-oss:init-oss:processResources --scan
           attempt_limit: 3

--- a/.github/workflows/legacy-publish-command.yml
+++ b/.github/workflows/legacy-publish-command.yml
@@ -281,7 +281,7 @@ jobs:
           echo "IMAGE_VERSION=$(_get_docker_image_version ${DOCKERFILE} ${{ github.event.inputs.pre-release }})" >> $GITHUB_ENV
       - name: Prepare Sentry
         if: startsWith(matrix.connector, 'connectors')
-        uses: Wandalen/wretry.action@master
+        uses: Wandalen/wretry.action@v1.0.42
         with:
           attempt_limit: 3
           attempt_delay: 5000 # in ms
@@ -299,7 +299,7 @@ jobs:
           DOCKER_HUB_PASSWORD: ${{ secrets.DOCKER_HUB_PASSWORD }}
           # Oracle expects this variable to be set. Although usually present, this is not set by default on Github virtual runners.
           TZ: UTC
-        uses: Wandalen/wretry.action@master
+        uses: Wandalen/wretry.action@v1.0.42
         with:
           command: |
             echo "$SPEC_CACHE_SERVICE_ACCOUNT_KEY" > spec_cache_key_file.json && docker login -u ${DOCKER_HUB_USERNAME} -p ${DOCKER_HUB_PASSWORD}

--- a/.github/workflows/legacy-test-command.yml
+++ b/.github/workflows/legacy-test-command.yml
@@ -124,7 +124,7 @@ jobs:
           ORG_GRADLE_PROJECT_connectorAcceptanceTestVersion: ${{github.event.inputs.connector-acceptance-test-version}}
           S3_BUILD_CACHE_ACCESS_KEY_ID: ${{ secrets.SELF_RUNNER_AWS_ACCESS_KEY_ID }}
           S3_BUILD_CACHE_SECRET_KEY: ${{ secrets.SELF_RUNNER_AWS_SECRET_ACCESS_KEY }}
-        uses: Wandalen/wretry.action@master
+        uses: Wandalen/wretry.action@v1.0.42
         with:
           command: ./tools/bin/ci_integration_test.sh ${{ github.event.inputs.connector }} ${{ github.event.inputs.local_cdk }}
           attempt_limit: 3

--- a/.github/workflows/publish-cdk-command-manually.yml
+++ b/.github/workflows/publish-cdk-command-manually.yml
@@ -240,7 +240,7 @@ jobs:
           DOCKER_HUB_PASSWORD: ${{ secrets.DOCKER_HUB_PASSWORD }}
           # Oracle expects this variable to be set. Although usually present, this is not set by default on Github virtual runners.
           TZ: UTC
-        uses: Wandalen/wretry.action@master
+        uses: Wandalen/wretry.action@v1.0.42
         with:
           command: |
             docker login -u ${DOCKER_HUB_USERNAME} -p ${DOCKER_HUB_PASSWORD}


### PR DESCRIPTION
## What
The GH marketplace action we're using to retry steps is not pinned to a specific version.
The latest version has a bug https://github.com/Wandalen/wretry.action/issues/93

## How
We shall pin to the last stable version (1.0.42) to get our workflow running.
