### PR TITLE
✨ Source auth0: add new streams `Organizations`, `OrganizationMembers`, `OrganizationMemberRoles`

### DIFF
--- a/airbyte-integrations/connectors/source-auth0/Dockerfile
+++ b/airbyte-integrations/connectors/source-auth0/Dockerfile
@@ -34,5 +34,5 @@ COPY source_auth0 ./source_auth0
 ENV AIRBYTE_ENTRYPOINT "python /airbyte/integration_code/main.py"
 ENTRYPOINT ["python", "/airbyte/integration_code/main.py"]
 
-LABEL io.airbyte.version=0.2.0
+LABEL io.airbyte.version=0.3.0
 LABEL io.airbyte.name=airbyte/source-auth0

--- a/airbyte-integrations/connectors/source-auth0/acceptance-test-config.yml
+++ b/airbyte-integrations/connectors/source-auth0/acceptance-test-config.yml
@@ -1,22 +1,30 @@
 connector_image: airbyte/source-auth0:dev
-tests:
+acceptance_tests:
   spec:
-    - spec_path: "source_auth0/spec.yaml"
+    tests:
+      - spec_path: "source_auth0/spec.yaml"
   connection:
-    - config_path: "secrets/config.json"
-      status: "succeed"
-    - config_path: "integration_tests/invalid_config.json"
-      status: "failed"
+    tests:
+      - config_path: "secrets/config.json"
+        status: "succeed"
+      - config_path: "integration_tests/invalid_config.json"
+        status: "failed"
   discovery:
-    - config_path: "secrets/config.json"
+    tests:
+      - config_path: "secrets/config.json"
   basic_read:
-    - config_path: "secrets/config.json"
-      configured_catalog_path: "integration_tests/configured_catalog.json"
-      empty_streams: []
+    tests:
+      - config_path: "secrets/config.json"
+        configured_catalog_path: "integration_tests/configured_catalog.json"
+        empty_streams: []
+        fail_on_extra_columns: false
   incremental:
-    - config_path: "secrets/config.json"
-      configured_catalog_path: "integration_tests/configured_catalog.json"
-      future_state_path: "integration_tests/abnormal_state.json"
+    tests:
+      - config_path: "secrets/config.json"
+        configured_catalog_path: "integration_tests/configured_catalog.json"
+        future_state:
+          future_state_path: "integration_tests/abnormal_state.json"
   full_refresh:
-    - config_path: "secrets/config.json"
-      configured_catalog_path: "integration_tests/configured_catalog.json"
+    tests:
+      - config_path: "secrets/config.json"
+        configured_catalog_path: "integration_tests/configured_catalog.json"

--- a/airbyte-integrations/connectors/source-auth0/integration_tests/configured_catalog.json
+++ b/airbyte-integrations/connectors/source-auth0/integration_tests/configured_catalog.json
@@ -20,6 +20,36 @@
       "sync_mode": "full_refresh",
       "destination_sync_mode": "overwrite",
       "primary_key": [["client_id"]]
+    },
+    {
+      "stream": {
+        "name": "organizations",
+        "json_schema": {},
+        "supported_sync_modes": ["full_refresh"]
+      },
+      "sync_mode": "full_refresh",
+      "destination_sync_mode": "overwrite",
+      "primary_key": [["id"]]
+    },
+    {
+      "stream": {
+        "name": "organization_members",
+        "json_schema": {},
+        "supported_sync_modes": ["full_refresh"]
+      },
+      "sync_mode": "full_refresh",
+      "destination_sync_mode": "overwrite",
+      "primary_key": [["id"]]
+    },
+    {
+      "stream": {
+        "name": "organization_member_roles",
+        "json_schema": {},
+        "supported_sync_modes": ["full_refresh"]
+      },
+      "sync_mode": "full_refresh",
+      "destination_sync_mode": "overwrite",
+      "primary_key": [["id"]]
     }
   ]
 }

--- a/airbyte-integrations/connectors/source-auth0/metadata.yaml
+++ b/airbyte-integrations/connectors/source-auth0/metadata.yaml
@@ -2,7 +2,7 @@ data:
   connectorSubtype: api
   connectorType: source
   definitionId: 6c504e48-14aa-4221-9a72-19cf5ff1ae78
-  dockerImageTag: 0.2.0
+  dockerImageTag: 0.3.0
   dockerRepository: airbyte/source-auth0
   githubIssueLabel: source-auth0
   icon: auth0.svg

--- a/airbyte-integrations/connectors/source-auth0/source_auth0/schemas/clients.json
+++ b/airbyte-integrations/connectors/source-auth0/source_auth0/schemas/clients.json
@@ -79,10 +79,7 @@
       }
     },
     "allowed_logout_urls": {
-      "type": ["null", "array"],
-      "items": {
-        "type": ["string", "null"]
-      }
+      "type": ["null", "array"]
     },
     "oidc_backchannel_logout": {
       "type": ["object", "null"],
@@ -97,10 +94,7 @@
       }
     },
     "grant_types": {
-      "type": ["null", "array"],
-      "items": {
-        "type": ["string", "null"]
-      }
+      "type": ["null", "array"]
     },
     "jwt_configuration": {
       "type": ["object", "null"],
@@ -121,8 +115,8 @@
       }
     },
     "signing_keys": {
-      "type": ["array", "null"],
-      "items": {
+      "type": ["null", "array"],
+      "string": {
         "type": ["object", "null"],
         "additionalProperties": true
       }

--- a/airbyte-integrations/connectors/source-auth0/source_auth0/schemas/clients.json
+++ b/airbyte-integrations/connectors/source-auth0/source_auth0/schemas/clients.json
@@ -79,7 +79,10 @@
       }
     },
     "allowed_logout_urls": {
-      "type": ["null", "array"]
+      "type": ["null", "array"],
+      "items": {
+        "type": ["string", "null"]
+      }
     },
     "oidc_backchannel_logout": {
       "type": ["object", "null"],
@@ -94,7 +97,10 @@
       }
     },
     "grant_types": {
-      "type": ["null", "array"]
+      "type": ["null", "array"],
+      "items": {
+        "type": ["string", "null"]
+      }
     },
     "jwt_configuration": {
       "type": ["object", "null"],
@@ -116,7 +122,7 @@
     },
     "signing_keys": {
       "type": ["null", "array"],
-      "string": {
+      "items": {
         "type": ["object", "null"],
         "additionalProperties": true
       }

--- a/airbyte-integrations/connectors/source-auth0/source_auth0/schemas/organization_member_roles.json
+++ b/airbyte-integrations/connectors/source-auth0/source_auth0/schemas/organization_member_roles.json
@@ -1,0 +1,21 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "type": ["object", "null"],
+  "properties": {
+    "id": {
+      "type": ["string", "null"]
+    },
+    "org_id": {
+      "type": ["string", "null"]
+    },
+    "user_id": {
+      "type": ["string", "null"]
+    },
+    "name": {
+      "type": ["string", "null"]
+    },
+    "description": {
+      "type": ["string", "null"]
+    }
+  }
+}

--- a/airbyte-integrations/connectors/source-auth0/source_auth0/schemas/organization_member_roles.json
+++ b/airbyte-integrations/connectors/source-auth0/source_auth0/schemas/organization_member_roles.json
@@ -1,6 +1,7 @@
 {
   "$schema": "http://json-schema.org/draft-07/schema#",
   "type": ["object", "null"],
+  "additionalProperties": true,
   "properties": {
     "id": {
       "type": ["string", "null"]

--- a/airbyte-integrations/connectors/source-auth0/source_auth0/schemas/organization_members.json
+++ b/airbyte-integrations/connectors/source-auth0/source_auth0/schemas/organization_members.json
@@ -1,0 +1,25 @@
+{
+    "$schema": "http://json-schema.org/draft-07/schema#",
+    "type": ["object", "null"],
+    "additionalProperties": true,
+    "properties":{
+        "id": {
+          "type": ["string", "null"]
+        },
+        "org_id": {
+          "type": ["string", "null"]
+        },
+        "user_id": {
+          "type": ["string", "null"]
+        },
+        "name": {
+          "type": ["string", "null"]
+        },
+        "email": {
+          "type": ["string", "null"]
+        },
+        "picture": {
+          "type": ["string", "null"]
+        }
+    }
+}

--- a/airbyte-integrations/connectors/source-auth0/source_auth0/schemas/organizations.json
+++ b/airbyte-integrations/connectors/source-auth0/source_auth0/schemas/organizations.json
@@ -1,0 +1,24 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "type": ["object", "null"],
+  "additionalProperties": true,
+  "properties": {
+    "id": {
+      "type": ["string", "null"]
+    },
+    "name": {
+      "type": ["string", "null"]
+    },
+    "display_name": {
+      "type": ["string", "null"]
+    },
+    "branding": {
+      "type": ["object", "null"],
+      "additionalProperties": true
+    },
+    "metadata": {
+      "type": ["object", "null"],
+      "additionalProperties": true
+    }
+  }
+}

--- a/airbyte-integrations/connectors/source-auth0/source_auth0/schemas/users.json
+++ b/airbyte-integrations/connectors/source-auth0/source_auth0/schemas/users.json
@@ -56,8 +56,7 @@
       "type": ["string", "null"]
     },
     "multifactor": {
-      "type": ["object", "null"],
-      "additionalProperties": true
+      "type": ["null", "array"]
     },
     "last_ip": {
       "type": ["string", "null"]

--- a/airbyte-integrations/connectors/source-auth0/source_auth0/schemas/users.json
+++ b/airbyte-integrations/connectors/source-auth0/source_auth0/schemas/users.json
@@ -56,7 +56,11 @@
       "type": ["string", "null"]
     },
     "multifactor": {
-      "type": ["null", "array"]
+      "type": ["null", "array"],
+      "additionalProperties": true,
+      "items": {
+        "type": ["string", "null"]
+      }
     },
     "last_ip": {
       "type": ["string", "null"]

--- a/airbyte-integrations/connectors/source-auth0/source_auth0/source.py
+++ b/airbyte-integrations/connectors/source-auth0/source_auth0/source.py
@@ -10,13 +10,11 @@ from urllib import parse
 
 import pendulum
 import requests
+from airbyte_cdk.models import SyncMode
 from airbyte_cdk.sources import AbstractSource
 from airbyte_cdk.sources.streams import IncrementalMixin, Stream
 from airbyte_cdk.sources.streams.http import HttpStream
 from source_auth0.utils import get_api_endpoint, initialize_authenticator
-from airbyte_cdk.sources.streams.core import StreamData
-
-from airbyte_cdk.models import SyncMode
 
 
 def read_full_refresh(stream_instance: Stream):

--- a/airbyte-integrations/connectors/source-auth0/unit_tests/conftest.py
+++ b/airbyte-integrations/connectors/source-auth0/unit_tests/conftest.py
@@ -240,9 +240,49 @@ def clients_instance():
         },
         "organization_usage": "deny",
         "organization_require_behavior": "no_prompt",
-        "client_authentication_methods": {"private_key_jwt": {"credentials": ["object"]}}
+        "client_authentication_methods": {"private_key_jwt": {"credentials": ["object"]}},
     }
 
+
+@pytest.fixture()
+def organization_instance():
+    """
+    Clients instance object response
+    """
+    return {
+        "id": "my_org_id",
+        "name": "My application",
+        "display_name": "My display_name",
+        "branding": "brand",
+        "metadata": "metadata_example",
+    }
+
+@pytest.fixture()
+def organization_member_instance():
+    """
+    Clients instance object response
+    """
+    return {
+        "id": "my_org_id_my_user_id",
+        "org_id": "my_org_id",
+        "user_id": "my_user_id",
+        "name": "my_name",
+        "email": "my_email",
+        "picture": "my_picture",
+    }
+
+@pytest.fixture()
+def organization_member_roles_instance():
+    """
+    Clients instance object response
+    """
+    return {
+        "id": "something",
+        "org_id": "my_org_id",
+        "user_id": "my_user_id",
+        "name": "my_name",
+        "description": "desc",
+    }
 
 @pytest.fixture()
 def latest_record_instance():

--- a/airbyte-integrations/connectors/source-auth0/unit_tests/conftest.py
+++ b/airbyte-integrations/connectors/source-auth0/unit_tests/conftest.py
@@ -257,6 +257,7 @@ def organization_instance():
         "metadata": "metadata_example",
     }
 
+
 @pytest.fixture()
 def organization_member_instance():
     """
@@ -271,6 +272,7 @@ def organization_member_instance():
         "picture": "my_picture",
     }
 
+
 @pytest.fixture()
 def organization_member_roles_instance():
     """
@@ -283,6 +285,7 @@ def organization_member_roles_instance():
         "name": "my_name",
         "description": "desc",
     }
+
 
 @pytest.fixture()
 def latest_record_instance():

--- a/airbyte-integrations/connectors/source-auth0/unit_tests/test_source.py
+++ b/airbyte-integrations/connectors/source-auth0/unit_tests/test_source.py
@@ -6,7 +6,15 @@ from unittest.mock import MagicMock
 
 from airbyte_cdk.sources.streams.http.requests_native_auth.token import TokenAuthenticator
 from source_auth0.authenticator import Auth0Oauth2Authenticator
-from source_auth0.source import SourceAuth0, Clients, Users, initialize_authenticator
+from source_auth0.source import (
+    SourceAuth0,
+    Clients,
+    Users,
+    initialize_authenticator,
+    Organizations,
+    OrganizationMemberRoles,
+    OrganizationMembers,
+)
 
 
 class TestAuthentication:
@@ -71,14 +79,23 @@ class TestAuthentication:
         source_auth0 = SourceAuth0()
         requests_mock.get(f"{api_url}/api/v2/users?per_page=1", json={"connect": "ok"})
         requests_mock.get(f"{api_url}/api/v2/clients?per_page=1", json={"connect": "ok"})
+        requests_mock.get(f"{api_url}/api/v2/organizations?per_page=1", json={"connect": "ok"})
+        requests_mock.get(f"{api_url}/api/v2/organizations/test_org_id/members?per_page=1", json={"connect": "ok"})
+        requests_mock.get(f"{api_url}/api/v2/organizations/test_org_id/members/test_user_id/roles?per_page=1", json={"connect": "ok"})
         requests_mock.post(f"{api_url}/oauth/token", json={"access_token": "test_token", "expires_in": 948})
         streams = source_auth0.streams(config=oauth_config)
 
-        streams_supported = [Clients, Users]
+        streams_supported = [
+            Clients,
+            Organizations,
+            OrganizationMembers,
+            OrganizationMemberRoles,
+            Users,
+        ]
 
         # check the number of streams supported
         assert len(streams) == len(streams_supported)
 
         # and each stream to be specific stream
-        assert isinstance(streams[0], streams_supported[0])
-        assert isinstance(streams[1], streams_supported[1])
+        for s in range(len(streams)):
+            assert isinstance(streams[s], streams_supported[s])

--- a/airbyte-integrations/connectors/source-auth0/unit_tests/test_source.py
+++ b/airbyte-integrations/connectors/source-auth0/unit_tests/test_source.py
@@ -7,13 +7,13 @@ from unittest.mock import MagicMock
 from airbyte_cdk.sources.streams.http.requests_native_auth.token import TokenAuthenticator
 from source_auth0.authenticator import Auth0Oauth2Authenticator
 from source_auth0.source import (
-    SourceAuth0,
     Clients,
-    Users,
-    initialize_authenticator,
-    Organizations,
     OrganizationMemberRoles,
     OrganizationMembers,
+    Organizations,
+    SourceAuth0,
+    Users,
+    initialize_authenticator,
 )
 
 

--- a/airbyte-integrations/connectors/source-auth0/unit_tests/test_streams.py
+++ b/airbyte-integrations/connectors/source-auth0/unit_tests/test_streams.py
@@ -9,7 +9,15 @@ from unittest.mock import MagicMock
 import pytest
 import requests
 from airbyte_cdk.models import SyncMode
-from source_auth0.source import Auth0Stream, IncrementalAuth0Stream, Users, Clients
+from source_auth0.source import (
+    Auth0Stream,
+    IncrementalAuth0Stream,
+    Users,
+    Clients,
+    Organizations,
+    OrganizationMembers,
+    OrganizationMemberRoles,
+)
 
 
 @pytest.fixture
@@ -258,3 +266,93 @@ class TestStreamClients:
             json={"total": 1, "start": 0, "limit": 50, "clients": [clients_instance]},
         )
         assert list(stream.parse_response(response=requests.get(f"{api_url}/clients"))) == [clients_instance]
+
+
+class TestStreamOrganizations:
+    def test_stream_organizations(self, patch_base_class, organization_instance, url_base, api_url, requests_mock):
+        stream = Organizations(url_base=url_base)
+        requests_mock.get(
+            f"{api_url}/organizations",
+            json={"total": 1, "start": 0, "limit": 50, "organizations": [organization_instance]},
+        )
+        inputs = {"sync_mode": SyncMode.full_refresh}
+        assert list(stream.read_records(**inputs)) == [organization_instance]
+
+    def test_organizations_source_parse_response(self, requests_mock, patch_base_class, organization_instance, url_base, api_url):
+        stream = Organizations(url_base=url_base)
+        requests_mock.get(
+            f"{api_url}/organizations",
+            json={"total": 1, "start": 0, "limit": 50, "organizations": [organization_instance]},
+        )
+        assert list(stream.parse_response(response=requests.get(f"{api_url}/organizations"))) == [organization_instance]
+
+
+class TestStreamOrganizationsMembers:
+    def test_stream_organizations(
+        self, patch_base_class, organization_instance, organization_member_instance, url_base, api_url, requests_mock
+    ):
+        stream = OrganizationMembers(url_base=url_base)
+        requests_mock.get(
+            f"{api_url}/organizations",
+            json={"total": 1, "start": 0, "limit": 50, "organizations": [organization_instance]},
+        )
+        requests_mock.get(
+            f"{api_url}/organizations/my_org_id/members",
+            json={"total": 1, "start": 0, "limit": 50, "members": [organization_member_instance]},
+        )
+        inputs = {"sync_mode": SyncMode.full_refresh}
+        assert list(stream.read_records(**inputs)) == [organization_member_instance]
+
+    def test_organizations_source_parse_response(self, requests_mock, patch_base_class, organization_member_instance, url_base, api_url):
+        stream = OrganizationMembers(url_base=url_base)
+        requests_mock.get(
+            f"{api_url}/organizations/my_org_id/members",
+            json={"total": 1, "start": 0, "limit": 50, "members": [organization_member_instance]},
+        )
+        stream_slice = {"organization_id": "my_org_id"}
+        assert list(
+            stream.parse_response(response=requests.get(f"{api_url}/organizations/my_org_id/members"), stream_slice=stream_slice)
+        ) == [organization_member_instance]
+
+
+class TestStreamOrganizationsMemberRoles:
+    def test_stream_organizations(
+        self,
+        patch_base_class,
+        organization_instance,
+        organization_member_instance,
+        organization_member_roles_instance,
+        url_base,
+        api_url,
+        requests_mock,
+    ):
+        stream = OrganizationMemberRoles(url_base=url_base)
+        requests_mock.get(
+            f"{api_url}/organizations",
+            json={"total": 1, "start": 0, "limit": 50, "organizations": [organization_instance]},
+        )
+        requests_mock.get(
+            f"{api_url}/organizations/my_org_id/members",
+            json={"total": 1, "start": 0, "limit": 50, "members": [organization_member_instance]},
+        )
+        requests_mock.get(
+            f"{api_url}/organizations/my_org_id/members/my_user_id/roles",
+            json={"total": 1, "start": 0, "limit": 50, "roles": [organization_member_roles_instance]},
+        )
+        inputs = {"sync_mode": SyncMode.full_refresh}
+        assert list(stream.read_records(**inputs)) == [organization_member_roles_instance]
+
+    def test_organizations_source_parse_response(
+        self, requests_mock, patch_base_class, organization_member_roles_instance, url_base, api_url
+    ):
+        stream = OrganizationMemberRoles(url_base=url_base)
+        requests_mock.get(
+            f"{api_url}/organizations/my_org_id/members/my_user_id/roles",
+            json={"total": 1, "start": 0, "limit": 50, "roles": [organization_member_roles_instance]},
+        )
+        stream_slice = {"organization_id": "my_org_id", "user_id": "my_user_id"}
+        assert list(
+            stream.parse_response(
+                response=requests.get(f"{api_url}/organizations/my_org_id/members/my_user_id/roles"), stream_slice=stream_slice
+            )
+        ) == [organization_member_roles_instance]

--- a/airbyte-integrations/connectors/source-auth0/unit_tests/test_streams.py
+++ b/airbyte-integrations/connectors/source-auth0/unit_tests/test_streams.py
@@ -11,12 +11,12 @@ import requests
 from airbyte_cdk.models import SyncMode
 from source_auth0.source import (
     Auth0Stream,
-    IncrementalAuth0Stream,
-    Users,
     Clients,
-    Organizations,
-    OrganizationMembers,
+    IncrementalAuth0Stream,
     OrganizationMemberRoles,
+    OrganizationMembers,
+    Organizations,
+    Users,
 )
 
 

--- a/docs/integrations/sources/auth0.md
+++ b/docs/integrations/sources/auth0.md
@@ -41,6 +41,10 @@ The Auth0 source connector supports the following [sync modes](https://docs.airb
 
 ## Supported Streams
 
+- [Clients](https://auth0.com/docs/api/management/v2#!/Clients/get_clients)
+- [Organizations](https://auth0.com/docs/api/management/v2#!/Organizations/get_organizations)
+- [OrganizationMembers](https://auth0.com/docs/api/management/v2#!/Organizations/get_members)
+- [OrganizationMemberRoles](https://auth0.com/docs/api/management/v2#!/Organizations/get_organization_member_roles)
 - [Users](https://auth0.com/docs/api/management/v2#!/Users/get_users)
 
 ## Performance considerations
@@ -51,6 +55,7 @@ The connector is restricted by Auth0 [rate limits](https://auth0.com/docs/troubl
 
 | Version | Date       | Pull Request                                             | Subject                                                                        |
 |:--------|:-----------|:---------------------------------------------------------|:-------------------------------------------------------------------------------|
+| 0.3.0  | 2023-06-20 | TBD | Add Organizations, OrganizationMembers, OrganizationMemberRoles streams |
 | 0.2.0  | 2023-05-23 | 26445 | Add Clients stream |
 | 0.1.0  | 2022-10-21 | TBD | Add Auth0 and Users stream |
 


### PR DESCRIPTION
## What
*Add support for organization related streams in auth0 source connector* issue #27499


## How
*Connector in place had all the scaffolding ready, so adding a new stream was simple enough*


## 🚨 User Impact 🚨
No breaking changes

## Pre-merge Actions

<details><summary><strong>New Stream for source Connector auth0</strong></summary>

### Community member or Airbyter

- **Community member?** Grant edit access to maintainers ([instructions](https://docs.github.com/en/github/collaborating-with-pull-requests/working-with-forks/allowing-changes-to-a-pull-request-branch-created-from-a-fork#enabling-repository-maintainer-permissions-on-existing-pull-requests))
- Unit & integration tests added and passing. Community members, please provide proof of success locally e.g: screenshot or copy-paste unit, integration, and acceptance test output. To run acceptance tests for a Python connector, follow instructions in the README. For java connectors run `./gradlew :airbyte-integrations:connectors:<name>:integrationTest`.
- Connector version is set to `0.2.0`
    - `Dockerfile` has version `0.0.1`
- Documentation updated
    - Connector's `README.md`
    - Connector's `bootstrap.md`. See [description and examples](https://docs.google.com/document/d/1ypdgmwmEHWv-TrO4_YOQ7pAJGVrMp5BOkEVh831N260/edit?usp=sharing)
    - `docs/integrations/<source or destination>/<name>.md` including changelog with an entry for the initial version. See changelog [example](https://docs.airbyte.io/integrations/sources/stripe#changelog)
    - `docs/integrations/README.md`

### Airbyter

If this is a community PR, the Airbyte engineer reviewing this PR is responsible for the below items.

- Create a non-forked branch based on this PR and test the below items on it
- Build is successful
- If new credentials are required for use in CI, add them to GSM. [Instructions](https://docs.airbyte.io/connector-development#using-credentials-in-ci).

</details>

<details><summary><strong>Updating a connector</strong></summary>

### Community member or Airbyter

- Grant edit access to maintainers ([instructions](https://docs.github.com/en/github/collaborating-with-pull-requests/working-with-forks/allowing-changes-to-a-pull-request-branch-created-from-a-fork#enabling-repository-maintainer-permissions-on-existing-pull-requests))
- Unit & integration tests added


### Airbyter

If this is a community PR, the Airbyte engineer reviewing this PR is responsible for the below items.

- Create a non-forked branch based on this PR and test the below items on it
- Build is successful
- If new credentials are required for use in CI, add them to GSM. [Instructions](https://docs.airbyte.io/connector-development#using-credentials-in-ci).

</details>

<details><summary><strong>Connector Generator</strong></summary>

- Issue acceptance criteria met
- PR name follows [PR naming conventions](https://docs.airbyte.com/contributing-to-airbyte/issues-and-pull-requests#pull-request-title-convention)
- If adding a new generator, add it to the [list of scaffold modules being tested](https://github.com/airbytehq/airbyte/blob/master/airbyte-integrations/connector-templates/generator/build.gradle#L41)
- The generator test modules (all connectors with `-scaffold` in their name) have been updated with the latest scaffold by running `./gradlew :airbyte-integrations:connector-templates:generator:testScaffoldTemplates` then checking in your changes
- Documentation which references the generator is updated as needed

</details>
