### PR TITLE
ref: broaden the use of the run-dagger-pipeline action

### DIFF
--- a/.github/actions/run-dagger-pipeline/action.yml
+++ b/.github/actions/run-dagger-pipeline/action.yml
@@ -4,32 +4,86 @@ inputs:
   subcommand:
     description: "Subcommand for airbyte-ci"
     required: true
-  options:
-    description: "Options for the subcommand"
-    required: false
   context:
     description: "CI context (e.g., pull_request, manual)"
     required: true
   github_token:
     description: "GitHub token"
     required: true
+  docker_hub_username:
+    description: "Dockerhub username"
+    required: true
+  docker_hub_password:
+    description: "Dockerhub password"
+    required: true
+  options:
+    description: "Options for the subcommand"
+    required: false
+  production:
+    description: "Whether to run in production mode"
+    required: false
+    default: "True"
+  report_bucket_name:
+    description: "Bucket name for CI reports"
+    required: false
+    default: "airbyte-ci-reports"
+  gcp_gsm_credentials:
+    description: "GCP credentials for GCP Secret Manager"
+    required: false
+    default: ""
+  git_branch:
+    description: "Git branch to checkout"
+    required: false
+  git_revision:
+    description: "Git revision to checkout"
+    required: false
+  slack_webhook_url:
+    description: "Slack webhook URL"
+    required: false
+  metadata_service_gcs_credentials:
+    description: "GCP credentials for metadata service"
+    required: false
+  metadata_service_bucket_name:
+    description: "Bucket name for metadata service"
+    required: false
+    default: "prod-airbyte-cloud-connector-metadata-service"
+  spec_cache_bucket_name:
+    description: "Bucket name for GCS spec cache"
+    required: false
+    default: "io-airbyte-cloud-spec-cache"
+  spec_cache_gcs_credentials:
+    description: "GCP credentials for GCS spec cache"
+    required: false
+  gcs_credentials:
+    description: "GCP credentials for GCS"
+    required: false
+  dagger_cli_commit:
+    description: "Commit SHA of dagger-cli to use"
+    required: false
+    default: "6ed6264f1c4efbf84d310a104b57ef1bc57d57b0"
+  ci_job_key:
+    description: "CI job key"
+    required: false
 runs:
   using: "composite"
   steps:
+    - name: Check if PR is from a fork
+      if: github.event_name == 'pull_request'
+      shell: bash
+      run: |
+        if [ "${{ github.event.pull_request.head.repo.fork }}" == "true" ]; then
+          echo "PR is from a fork. Exiting workflow..."
+          exit 78
+        fi
+    - name: Docker login
+      uses: docker/login-action@v1
+      with:
+        username: ${{ inputs.docker_hub_username }}
+        password: ${{ inputs.docker_hub_password }}
     - name: Get start timestamp
       id: get-start-timestamp
-      run: echo "::set-output name=start-timestamp::$(date +%s)"
       shell: bash
-    - name: Checkout Airbyte
-      uses: actions/checkout@v3
-      with:
-        repository: ${{ github.event.inputs.repo }}
-        ref: ${{ github.event.inputs.gitref }}
-    - name: Extract branch name
-      shell: bash
-      if: github.event_name == 'workflow_dispatch'
-      run: echo "##[set-output name=branch;]$(echo ${GITHUB_REF#refs/heads/})"
-      id: extract_branch
+      run: echo "name=start-timestamp=$(date +%s)" >> $GITHUB_OUTPUT
     - name: Install Python 3.10
       uses: actions/setup-python@v4
       with:
@@ -42,7 +96,7 @@ runs:
       shell: bash
       run: |
         export _EXPERIMENTAL_DAGGER_RUNNER_HOST="unix:///var/run/buildkit/buildkitd.sock"
-        DAGGER_CLI_COMMIT="2370d5eb65e511cf7f1611aebaacc6d48cf0907a"
+        DAGGER_CLI_COMMIT=${{ inputs.dagger_cli_commit }}
         DAGGER_TMP_BINDIR="/tmp/dagger_${DAGGER_CLI_COMMIT}"
         export _EXPERIMENTAL_DAGGER_CLI_BIN="$DAGGER_TMP_BINDIR/dagger"
         if [ ! -f  "$_EXPERIMENTAL_DAGGER_CLI_BIN" ]; then
@@ -50,9 +104,23 @@ runs:
           curl "https://dl.dagger.io/dagger/main/${DAGGER_CLI_COMMIT}/dagger_${DAGGER_CLI_COMMIT}_$(uname -s | tr A-Z a-z)_$(uname -m | sed s/x86_64/amd64/).tar.gz" | tar xvz -C "$DAGGER_TMP_BINDIR"
         fi
         airbyte-ci --is-ci --gha-workflow-run-id=${{ github.run_id }} ${{ inputs.subcommand }} ${{ inputs.options }}
-
       env:
-        CI_GIT_BRANCH: ${{ github.head_ref }}
-        CI_GIT_REVISION: ${{ github.event.pull_request.head.sha }}
+        _EXPERIMENTAL_DAGGER_CLOUD_TOKEN: "p.eyJ1IjogIjFiZjEwMmRjLWYyZmQtNDVhNi1iNzM1LTgxNzI1NGFkZDU2ZiIsICJpZCI6ICJlNjk3YzZiYy0yMDhiLTRlMTktODBjZC0yNjIyNGI3ZDBjMDEifQ.hT6eMOYt3KZgNoVGNYI3_v4CC-s19z8uQsBkGrBhU3k"
         CI_CONTEXT: "${{ inputs.context }}"
+        CI_GIT_BRANCH: ${{ inputs.git_branch || github.head_ref }}
+        CI_GIT_REVISION: ${{ inputs.git_revision || github.sha }}
+        CI_GITHUB_ACCESS_TOKEN: ${{ inputs.github_token }}
+        CI_JOB_KEY: ${{ inputs.ci_job_key }}
         CI_PIPELINE_START_TIMESTAMP: ${{ steps.get-start-timestamp.outputs.start-timestamp }}
+        CI_REPORT_BUCKET_NAME: ${{ inputs.report_bucket_name }}
+        GCP_GSM_CREDENTIALS: ${{ inputs.gcp_gsm_credentials }}
+        GCS_CREDENTIALS: ${{ inputs.gcs_credentials }}
+        METADATA_SERVICE_GCS_BUCKET_NAME: ${{ inputs.metadata_service_bucket_name }}
+        METADATA_SERVICE_GCS_CREDENTIALS: ${{ inputs.metadata_service_gcs_credentials }}
+        PRODUCTION: ${{ inputs.production }}
+        PULL_REQUEST_NUMBER: ${{ github.event.pull_request.number }}
+        SLACK_WEBHOOK: ${{ inputs.slack_webhook_url }}
+        SPEC_CACHE_BUCKET_NAME: ${{ inputs.spec_cache_bucket_name }}
+        SPEC_CACHE_GCS_CREDENTIALS: ${{ inputs.spec_cache_gcs_credentials }}
+        DOCKER_HUB_USERNAME: ${{ inputs.docker_hub_username }}
+        DOCKER_HUB_PASSWORD: ${{ inputs.docker_hub_password }}

--- a/.github/workflows/connectors_nightly_build.yml
+++ b/.github/workflows/connectors_nightly_build.yml
@@ -22,14 +22,6 @@ jobs:
     timeout-minutes: 1380 # 23 hours
     runs-on: ${{ inputs.runs-on || 'dev-large-runner' }}
     steps:
-      - name: Get start timestamp
-        id: get-start-timestamp
-        run: echo "::set-output name=start-timestamp::$(date +%s)"
-      - name: Login to DockerHub
-        run: "docker login -u ${DOCKER_HUB_USERNAME} -p ${DOCKER_HUB_PASSWORD}"
-        env:
-          DOCKER_HUB_USERNAME: ${{ secrets.DOCKER_HUB_USERNAME }}
-          DOCKER_HUB_PASSWORD: ${{ secrets.DOCKER_HUB_PASSWORD }}
       - name: Checkout Airbyte
         uses: actions/checkout@v3
         with:
@@ -37,32 +29,15 @@ jobs:
           ref: ${{ github.event.inputs.gitref }}
       - name: Extract branch name
         shell: bash
-        if: github.event_name == 'workflow_dispatch'
-        run: echo "##[set-output name=branch;]$(echo ${GITHUB_REF#refs/heads/})"
+        run: echo "branch=${GITHUB_REF#refs/heads/}" >> $GITHUB_OUTPUT
         id: extract_branch
-      - name: Install Python 3.10
-        uses: actions/setup-python@v4
-        with:
-          python-version: "3.10"
-          token: ${{ secrets.GH_PAT_MAINTENANCE_OCTAVIA }}
-      - name: Install ci-connector-ops package
-        run: pip install ./tools/ci_connector_ops\[pipelines]\
       - name: Test connectors
-        run: |
-          export _EXPERIMENTAL_DAGGER_RUNNER_HOST="unix:///var/run/buildkit/buildkitd.sock"
-          DAGGER_CLI_COMMIT="6ed6264f1c4efbf84d310a104b57ef1bc57d57b0"
-          DAGGER_TMP_BINDIR="/tmp/dagger_${DAGGER_CLI_COMMIT}"
-          export _EXPERIMENTAL_DAGGER_CLI_BIN="$DAGGER_TMP_BINDIR/dagger"
-          if [ ! -f  "$_EXPERIMENTAL_DAGGER_CLI_BIN" ]; then
-            mkdir -p "$DAGGER_TMP_BINDIR"
-            curl "https://dl.dagger.io/dagger/main/${DAGGER_CLI_COMMIT}/dagger_${DAGGER_CLI_COMMIT}_$(uname -s | tr A-Z a-z)_$(uname -m | sed s/x86_64/amd64/).tar.gz" | tar xvz -C "$DAGGER_TMP_BINDIR"
-          fi
-          airbyte-ci --is-ci --gha-workflow-run-id=${{ github.run_id }} connectors ${{ inputs.test-connectors-options || '--concurrency=8 --release-stage=generally_available --release-stage=beta' }} test
-        env:
-          _EXPERIMENTAL_DAGGER_CLOUD_TOKEN: "p.eyJ1IjogIjFiZjEwMmRjLWYyZmQtNDVhNi1iNzM1LTgxNzI1NGFkZDU2ZiIsICJpZCI6ICJlNjk3YzZiYy0yMDhiLTRlMTktODBjZC0yNjIyNGI3ZDBjMDEifQ.hT6eMOYt3KZgNoVGNYI3_v4CC-s19z8uQsBkGrBhU3k"
-          GCP_GSM_CREDENTIALS: ${{ secrets.GCP_GSM_CREDENTIALS }}
-          CI_REPORT_BUCKET_NAME: "airbyte-ci-reports"
-          CI_GITHUB_ACCESS_TOKEN: ${{ secrets.GH_PAT_MAINTENANCE_OCTAVIA }}
-          CI_GIT_BRANCH: ${{ steps.extract_branch.outputs.branch }}
-          CI_CONTEXT: "nightly_builds"
-          CI_PIPELINE_START_TIMESTAMP: ${{ steps.get-start-timestamp.outputs.start-timestamp }}
+        uses: ./.github/actions/run-dagger-pipeline
+        with:
+          context: "nightly_builds"
+          docker_hub_password: ${{ secrets.DOCKER_HUB_PASSWORD }}
+          docker_hub_username: ${{ secrets.DOCKER_HUB_USERNAME }}
+          gcp_gsm_credentials: ${{ secrets.GCP_GSM_CREDENTIALS }}
+          git_branch: ${{ steps.extract_branch.outputs.branch }}
+          github_token: ${{ secrets.GH_PAT_MAINTENANCE_OCTAVIA }}
+          subcommand: "connectors ${{ inputs.test-connectors-options || '--concurrency=8 --release-stage=generally_available --release-stage=beta' }} test"

--- a/.github/workflows/connectors_tests.yml
+++ b/.github/workflows/connectors_tests.yml
@@ -9,6 +9,9 @@ on:
       test-connectors-options:
         description: "Options to pass to the 'airbyte-ci connectors test' command"
         default: "--modified"
+      runner:
+        description: "The runner to use for this job"
+        default: "dev-medium-runner"
   pull_request:
     types:
       - opened
@@ -18,134 +21,62 @@ jobs:
   connectors_ci:
     name: Connectors CI
     timeout-minutes: 1440 # 24 hours
-    runs-on: dev-medium-runner
+    runs-on: ${{ inputs.runner || 'dev-medium-runner'}}
     steps:
-      - name: Check if PR is from a fork
-        if: github.event_name == 'pull_request'
-        run: |
-          if [ "${{ github.event.pull_request.head.repo.fork }}" == "true" ]; then
-            echo "PR is from a fork. Exiting workflow..."
-            exit 78
-          fi
-      - name: Get start timestamp
-        id: get-start-timestamp
-        run: echo "::set-output name=start-timestamp::$(date +%s)"
-      - name: Login to DockerHub
-        run: "docker login -u ${DOCKER_HUB_USERNAME} -p ${DOCKER_HUB_PASSWORD}"
-        env:
-          DOCKER_HUB_USERNAME: ${{ secrets.DOCKER_HUB_USERNAME }}
-          DOCKER_HUB_PASSWORD: ${{ secrets.DOCKER_HUB_PASSWORD }}
       - name: Checkout Airbyte
         uses: actions/checkout@v3
-        with:
-          repository: ${{ github.event.inputs.repo }}
-          ref: ${{ github.event.inputs.gitref }}
-      - name: Extract branch name
+      - name: Extract branch name [WORKFLOW DISPATCH]
         shell: bash
         if: github.event_name == 'workflow_dispatch'
-        run: echo "##[set-output name=branch;]$(echo ${GITHUB_REF#refs/heads/})"
+        run: echo "branch=${GITHUB_REF#refs/heads/}" >> $GITHUB_OUTPUT
         id: extract_branch
-      - name: Install Python 3.10
-        uses: actions/setup-python@v4
-        with:
-          python-version: "3.10"
-          token: ${{ secrets.GH_PAT_MAINTENANCE_OCTAVIA }}
-      - name: Install ci-connector-ops package
-        run: pip install -e ./tools/ci_connector_ops\[pipelines]\
-      - name: Run airbyte-ci connectors format [WORKFLOW DISPATCH]
-        if: github.event_name == 'workflow_dispatch'
-        run: |
-          export _EXPERIMENTAL_DAGGER_RUNNER_HOST="unix:///var/run/buildkit/buildkitd.sock"
-          DAGGER_CLI_COMMIT="6ed6264f1c4efbf84d310a104b57ef1bc57d57b0"
-          DAGGER_TMP_BINDIR="/tmp/dagger_${DAGGER_CLI_COMMIT}"
-          export _EXPERIMENTAL_DAGGER_CLI_BIN="$DAGGER_TMP_BINDIR/dagger"
-          if [ ! -f  "$_EXPERIMENTAL_DAGGER_CLI_BIN" ]; then
-            mkdir -p "$DAGGER_TMP_BINDIR"
-            curl "https://dl.dagger.io/dagger/main/${DAGGER_CLI_COMMIT}/dagger_${DAGGER_CLI_COMMIT}_$(uname -s | tr A-Z a-z)_$(uname -m | sed s/x86_64/amd64/).tar.gz" | tar xvz -C "$DAGGER_TMP_BINDIR"
-          fi
-          airbyte-ci --is-ci --gha-workflow-run-id=${{ github.run_id }} connectors ${{ github.event.inputs.test-connectors-options }} format
-        env:
-          _EXPERIMENTAL_DAGGER_CLOUD_TOKEN: "p.eyJ1IjogIjFiZjEwMmRjLWYyZmQtNDVhNi1iNzM1LTgxNzI1NGFkZDU2ZiIsICJpZCI6ICJlNjk3YzZiYy0yMDhiLTRlMTktODBjZC0yNjIyNGI3ZDBjMDEifQ.hT6eMOYt3KZgNoVGNYI3_v4CC-s19z8uQsBkGrBhU3k"
-          GCP_GSM_CREDENTIALS: ${{ secrets.GCP_GSM_CREDENTIALS }}
-          CI_REPORT_BUCKET_NAME: "airbyte-ci-reports"
-          CI_GITHUB_ACCESS_TOKEN: ${{ secrets.GH_PAT_MAINTENANCE_OCTAVIA }}
-          CI_GIT_BRANCH: ${{ steps.extract_branch.outputs.branch }}
-          CI_GIT_REVISION: ${{ github.sha }}
-          CI_CONTEXT: "manual"
-          CI_PIPELINE_START_TIMESTAMP: ${{ steps.get-start-timestamp.outputs.start-timestamp }}
-          PRODUCTION: "True"
-      - name: Run airbyte-ci connectors format [PULL REQUESTS]
+      - name: Format connectors [PULL REQUESTS]
         if: github.event_name == 'pull_request'
-        run: |
-          export _EXPERIMENTAL_DAGGER_RUNNER_HOST="unix:///var/run/buildkit/buildkitd.sock"
-          DAGGER_CLI_COMMIT="6ed6264f1c4efbf84d310a104b57ef1bc57d57b0"
-          DAGGER_TMP_BINDIR="/tmp/dagger_${DAGGER_CLI_COMMIT}"
-          export _EXPERIMENTAL_DAGGER_CLI_BIN="$DAGGER_TMP_BINDIR/dagger"
-          if [ ! -f  "$_EXPERIMENTAL_DAGGER_CLI_BIN" ]; then
-            mkdir -p "$DAGGER_TMP_BINDIR"
-            curl "https://dl.dagger.io/dagger/main/${DAGGER_CLI_COMMIT}/dagger_${DAGGER_CLI_COMMIT}_$(uname -s | tr A-Z a-z)_$(uname -m | sed s/x86_64/amd64/).tar.gz" | tar xvz -C "$DAGGER_TMP_BINDIR"
-          fi
-          airbyte-ci --is-ci --gha-workflow-run-id=${{ github.run_id }} connectors --modified format
-        env:
-          _EXPERIMENTAL_DAGGER_CLOUD_TOKEN: "p.eyJ1IjogIjFiZjEwMmRjLWYyZmQtNDVhNi1iNzM1LTgxNzI1NGFkZDU2ZiIsICJpZCI6ICJlNjk3YzZiYy0yMDhiLTRlMTktODBjZC0yNjIyNGI3ZDBjMDEifQ.hT6eMOYt3KZgNoVGNYI3_v4CC-s19z8uQsBkGrBhU3k"
-          GCP_GSM_CREDENTIALS: ${{ secrets.GCP_GSM_CREDENTIALS }}
-          CI_REPORT_BUCKET_NAME: "airbyte-ci-reports"
-          CI_GITHUB_ACCESS_TOKEN: ${{ secrets.GH_PAT_MAINTENANCE_OCTAVIA }}
-          CI_GIT_BRANCH: ${{ github.head_ref }}
-          CI_CONTEXT: "pull_request"
-          CI_PIPELINE_START_TIMESTAMP: ${{ steps.get-start-timestamp.outputs.start-timestamp }}
-          PULL_REQUEST_NUMBER: ${{ github.event.pull_request.number }}
-          PRODUCTION: "True"
-      - name: "Fetch last commit id from remote branch"
-        id: fetch_last_commit_id
-        run: |
-          commit_id=$(git ls-remote --heads origin augustin/connectors-ci/python-auto-format | cut -f 1)
-          echo "::set-output name=commit_id::$commit_id"
-      - name: Checkout Airbyte
+        uses: ./.github/actions/run-dagger-pipeline
+        with:
+          context: "pull_request"
+          docker_hub_password: ${{ secrets.DOCKER_HUB_PASSWORD }}
+          docker_hub_username: ${{ secrets.DOCKER_HUB_USERNAME }}
+          gcp_gsm_credentials: ${{ secrets.GCP_GSM_CREDENTIALS }}
+          git_branch: ${{ github.head_ref }}
+          git_revision: ${{ github.sha }}
+          github_token: ${{ secrets.GH_PAT_MAINTENANCE_OCTAVIA }}
+          subcommand: "connectors --modified format"
+      - name: Fetch last commit id from remote branch [PULL REQUESTS]
+        if: github.event_name == 'pull_request'
+        id: fetch_last_commit_id_pr
+        run: echo "commit_id=$(git ls-remote --heads origin ${{ github.head_ref }} | cut -f 1)" >> $GITHUB_OUTPUT
+      - name: Fetch last commit id from remote branch [WORKFLOW DISPATCH]
+        if: github.event_name == 'workflow_dispatch'
+        id: fetch_last_commit_id_wd
+        run: echo "commit_id=$(git ls-remote --heads origin ${{ steps.extract_branch.outputs.branch }} | cut -f 1)" >> $GITHUB_OUTPUT
+      - name: Pull formatting changes [PULL REQUESTS]
+        if: github.event_name == 'pull_request'
         uses: actions/checkout@v3
         with:
           repository: ${{ github.event.inputs.repo }}
-          ref: ${{ steps.fetch_last_commit_id.outputs.commit_id }}
-      - name: Run airbyte-ci connectors test [WORKFLOW DISPATCH]
+          ref: ${{ steps.fetch_last_commit_id_pr.outputs.commit_id }}
+      - name: Test connectors [WORKFLOW DISPATCH]
         if: github.event_name == 'workflow_dispatch'
-        run: |
-          export _EXPERIMENTAL_DAGGER_RUNNER_HOST="unix:///var/run/buildkit/buildkitd.sock"
-          DAGGER_CLI_COMMIT="6ed6264f1c4efbf84d310a104b57ef1bc57d57b0"
-          DAGGER_TMP_BINDIR="/tmp/dagger_${DAGGER_CLI_COMMIT}"
-          export _EXPERIMENTAL_DAGGER_CLI_BIN="$DAGGER_TMP_BINDIR/dagger"
-          if [ ! -f  "$_EXPERIMENTAL_DAGGER_CLI_BIN" ]; then
-            mkdir -p "$DAGGER_TMP_BINDIR"
-            curl "https://dl.dagger.io/dagger/main/${DAGGER_CLI_COMMIT}/dagger_${DAGGER_CLI_COMMIT}_$(uname -s | tr A-Z a-z)_$(uname -m | sed s/x86_64/amd64/).tar.gz" | tar xvz -C "$DAGGER_TMP_BINDIR"
-          fi
-          airbyte-ci --is-ci --gha-workflow-run-id=${{ github.run_id }} connectors ${{ github.event.inputs.test-connectors-options }} test
-        env:
-          _EXPERIMENTAL_DAGGER_CLOUD_TOKEN: "p.eyJ1IjogIjFiZjEwMmRjLWYyZmQtNDVhNi1iNzM1LTgxNzI1NGFkZDU2ZiIsICJpZCI6ICJlNjk3YzZiYy0yMDhiLTRlMTktODBjZC0yNjIyNGI3ZDBjMDEifQ.hT6eMOYt3KZgNoVGNYI3_v4CC-s19z8uQsBkGrBhU3k"
-          GCP_GSM_CREDENTIALS: ${{ secrets.GCP_GSM_CREDENTIALS }}
-          CI_REPORT_BUCKET_NAME: "airbyte-ci-reports"
-          CI_GITHUB_ACCESS_TOKEN: ${{ secrets.GH_PAT_MAINTENANCE_OCTAVIA }}
-          CI_GIT_BRANCH: ${{ steps.extract_branch.outputs.branch }}
-          CI_CONTEXT: "manual"
-          CI_PIPELINE_START_TIMESTAMP: ${{ steps.get-start-timestamp.outputs.start-timestamp }}
-          PRODUCTION: "True"
-      - name: Run airbyte-ci connectors test [PULL REQUESTS]
+        uses: ./.github/actions/run-dagger-pipeline
+        with:
+          context: "manual"
+          docker_hub_password: ${{ secrets.DOCKER_HUB_PASSWORD }}
+          docker_hub_username: ${{ secrets.DOCKER_HUB_USERNAME }}
+          gcp_gsm_credentials: ${{ secrets.GCP_GSM_CREDENTIALS }}
+          git_branch: ${{ steps.extract_branch.outputs.branch }}
+          git_revision: ${{ steps.fetch_last_commit_id_pr.outputs.commit_id }}
+          github_token: ${{ secrets.GH_PAT_MAINTENANCE_OCTAVIA }}
+          subcommand: "connectors ${{ github.event.inputs.test-connectors-options }} test"
+      - name: Test connectors [PULL REQUESTS]
         if: github.event_name == 'pull_request'
-        run: |
-          export _EXPERIMENTAL_DAGGER_RUNNER_HOST="unix:///var/run/buildkit/buildkitd.sock"
-          DAGGER_CLI_COMMIT="6ed6264f1c4efbf84d310a104b57ef1bc57d57b0"
-          DAGGER_TMP_BINDIR="/tmp/dagger_${DAGGER_CLI_COMMIT}"
-          export _EXPERIMENTAL_DAGGER_CLI_BIN="$DAGGER_TMP_BINDIR/dagger"
-          if [ ! -f  "$_EXPERIMENTAL_DAGGER_CLI_BIN" ]; then
-            mkdir -p "$DAGGER_TMP_BINDIR"
-            curl "https://dl.dagger.io/dagger/main/${DAGGER_CLI_COMMIT}/dagger_${DAGGER_CLI_COMMIT}_$(uname -s | tr A-Z a-z)_$(uname -m | sed s/x86_64/amd64/).tar.gz" | tar xvz -C "$DAGGER_TMP_BINDIR"
-          fi
-          airbyte-ci --is-ci --gha-workflow-run-id=${{ github.run_id }} connectors --modified test
-        env:
-          _EXPERIMENTAL_DAGGER_CLOUD_TOKEN: "p.eyJ1IjogIjFiZjEwMmRjLWYyZmQtNDVhNi1iNzM1LTgxNzI1NGFkZDU2ZiIsICJpZCI6ICJlNjk3YzZiYy0yMDhiLTRlMTktODBjZC0yNjIyNGI3ZDBjMDEifQ.hT6eMOYt3KZgNoVGNYI3_v4CC-s19z8uQsBkGrBhU3k"
-          GCP_GSM_CREDENTIALS: ${{ secrets.GCP_GSM_CREDENTIALS }}
-          CI_REPORT_BUCKET_NAME: "airbyte-ci-reports"
-          CI_GITHUB_ACCESS_TOKEN: ${{ secrets.GH_PAT_MAINTENANCE_OCTAVIA }}
-          CI_GIT_BRANCH: ${{ github.head_ref }}
-          CI_CONTEXT: "pull_request"
-          CI_PIPELINE_START_TIMESTAMP: ${{ steps.get-start-timestamp.outputs.start-timestamp }}
-          PULL_REQUEST_NUMBER: ${{ github.event.pull_request.number }}
-          PRODUCTION: "True"
+        uses: ./.github/actions/run-dagger-pipeline
+        with:
+          context: "pull_request"
+          docker_hub_password: ${{ secrets.DOCKER_HUB_PASSWORD }}
+          docker_hub_username: ${{ secrets.DOCKER_HUB_USERNAME }}
+          gcp_gsm_credentials: ${{ secrets.GCP_GSM_CREDENTIALS }}
+          git_branch: ${{ github.head_ref }}
+          git_revision: ${{ steps.fetch_last_commit_id_pr.outputs.commit_id }}
+          github_token: ${{ secrets.GH_PAT_MAINTENANCE_OCTAVIA }}
+          subcommand: "connectors --modified test"

--- a/.github/workflows/connectors_weekly_build.yml
+++ b/.github/workflows/connectors_weekly_build.yml
@@ -14,22 +14,14 @@ on:
         default: --concurrency=3 --release-stage=alpha
         required: true
 
-run-name: "Test connectors: ${{ inputs.test-connectors-options || 'nightly build for Alpha connectors' }} - on ${{ inputs.runs-on || 'dev-large-runner' }}"
+run-name: "Test connectors: ${{ inputs.test-connectors-options || 'weekly build for Alpha connectors' }} - on ${{ inputs.runs-on || 'dev-large-runner' }}"
 
 jobs:
   test_connectors:
-    name: "Test connectors: ${{ inputs.test-connectors-options || 'nightly build for Alpha connectors' }} - on ${{ inputs.runs-on || 'dev-large-runner' }}"
+    name: "Test connectors: ${{ inputs.test-connectors-options || 'weekly build for Alpha connectors' }} - on ${{ inputs.runs-on || 'dev-large-runner' }}"
     timeout-minutes: 8640 # 6 days
     runs-on: ${{ inputs.runs-on || 'dev-large-runner' }}
     steps:
-      - name: Get start timestamp
-        id: get-start-timestamp
-        run: echo "::set-output name=start-timestamp::$(date +%s)"
-      - name: Login to DockerHub
-        run: "docker login -u ${DOCKER_HUB_USERNAME} -p ${DOCKER_HUB_PASSWORD}"
-        env:
-          DOCKER_HUB_USERNAME: ${{ secrets.DOCKER_HUB_USERNAME }}
-          DOCKER_HUB_PASSWORD: ${{ secrets.DOCKER_HUB_PASSWORD }}
       - name: Checkout Airbyte
         uses: actions/checkout@v3
         with:
@@ -37,33 +29,16 @@ jobs:
           ref: ${{ github.event.inputs.gitref }}
       - name: Extract branch name
         shell: bash
-        if: github.event_name == 'workflow_dispatch'
-        run: echo "##[set-output name=branch;]$(echo ${GITHUB_REF#refs/heads/})"
+        run: echo "branch=${GITHUB_REF#refs/heads/}" >> $GITHUB_OUTPUT
         id: extract_branch
-      - name: Install Python 3.10
-        uses: actions/setup-python@v4
-        with:
-          python-version: "3.10"
-          token: ${{ secrets.GH_PAT_MAINTENANCE_OCTAVIA }}
-      - name: Install ci-connector-ops package
-        run: pip install ./tools/ci_connector_ops\[pipelines]\
       - name: Test connectors
-        run: |
-          export _EXPERIMENTAL_DAGGER_RUNNER_HOST="unix:///var/run/buildkit/buildkitd.sock"
-          DAGGER_CLI_COMMIT="6ed6264f1c4efbf84d310a104b57ef1bc57d57b0"
-          DAGGER_TMP_BINDIR="/tmp/dagger_${DAGGER_CLI_COMMIT}"
-          export _EXPERIMENTAL_DAGGER_CLI_BIN="$DAGGER_TMP_BINDIR/dagger"
-          if [ ! -f  "$_EXPERIMENTAL_DAGGER_CLI_BIN" ]; then
-            mkdir -p "$DAGGER_TMP_BINDIR"
-            curl "https://dl.dagger.io/dagger/main/${DAGGER_CLI_COMMIT}/dagger_${DAGGER_CLI_COMMIT}_$(uname -s | tr A-Z a-z)_$(uname -m | sed s/x86_64/amd64/).tar.gz" | tar xvz -C "$DAGGER_TMP_BINDIR"
-          fi
-          airbyte-ci --is-ci --gha-workflow-run-id=${{ github.run_id }} connectors ${{ inputs.test-connectors-options || '--concurrency=3 --release-stage=alpha' }} test
-        env:
-          _EXPERIMENTAL_DAGGER_CLOUD_TOKEN: "p.eyJ1IjogIjFiZjEwMmRjLWYyZmQtNDVhNi1iNzM1LTgxNzI1NGFkZDU2ZiIsICJpZCI6ICJlNjk3YzZiYy0yMDhiLTRlMTktODBjZC0yNjIyNGI3ZDBjMDEifQ.hT6eMOYt3KZgNoVGNYI3_v4CC-s19z8uQsBkGrBhU3k"
-          GCP_GSM_CREDENTIALS: ${{ secrets.GCP_GSM_CREDENTIALS }}
-          CI_REPORT_BUCKET_NAME: "airbyte-ci-reports"
-          CI_GITHUB_ACCESS_TOKEN: ${{ secrets.GH_PAT_MAINTENANCE_OCTAVIA }}
-          CI_GIT_BRANCH: ${{ steps.extract_branch.outputs.branch }}
-          CI_CONTEXT: "nightly_builds"
-          CI_PIPELINE_START_TIMESTAMP: ${{ steps.get-start-timestamp.outputs.start-timestamp }}
-          CI_JOB_KEY: "weekly_alpha_test"
+        uses: ./.github/actions/run-dagger-pipeline
+        with:
+          context: "nightly_builds"
+          ci_job_key: "weekly_alpha_test"
+          docker_hub_password: ${{ secrets.DOCKER_HUB_PASSWORD }}
+          docker_hub_username: ${{ secrets.DOCKER_HUB_USERNAME }}
+          gcp_gsm_credentials: ${{ secrets.GCP_GSM_CREDENTIALS }}
+          git_branch: ${{ steps.extract_branch.outputs.branch }}
+          github_token: ${{ secrets.GH_PAT_MAINTENANCE_OCTAVIA }}
+          subcommand: "connectors ${{ inputs.test-connectors-options || '--concurrency=3 --release-stage=alpha' }} test"

--- a/.github/workflows/publish_connectors.yml
+++ b/.github/workflows/publish_connectors.yml
@@ -18,40 +18,37 @@ jobs:
   publish_connectors:
     name: Publish connectors
     runs-on: large-runner
-    env:
-      CI_GITHUB_ACCESS_TOKEN: ${{ secrets.GH_PAT_MAINTENANCE_OCTAVIA }}
-      DOCKER_HUB_PASSWORD: ${{ secrets.DOCKER_HUB_PASSWORD }}
-      DOCKER_HUB_USERNAME: ${{ secrets.DOCKER_HUB_USERNAME }}
-      GCP_GSM_CREDENTIALS: ${{ secrets.GCP_GSM_CREDENTIALS }}
-      GCS_CREDENTIALS: ${{ secrets.METADATA_SERVICE_PROD_GCS_CREDENTIALS }}
-      METADATA_SERVICE_GCS_CREDENTIALS: ${{ secrets.METADATA_SERVICE_PROD_GCS_CREDENTIALS }}
-      METADATA_SERVICE_BUCKET_NAME: prod-airbyte-cloud-connector-metadata-service
-      SPEC_CACHE_BUCKET_NAME: io-airbyte-cloud-spec-cache
-      SPEC_CACHE_GCS_CREDENTIALS: ${{ secrets.SPEC_CACHE_SERVICE_ACCOUNT_KEY_PUBLISH }}
-      CI_REPORT_BUCKET_NAME: "airbyte-ci-reports"
-      SLACK_WEBHOOK: ${{ secrets.PUBLISH_ON_MERGE_SLACK_WEBHOOK }}
     steps:
       - name: Checkout Airbyte
-        uses: actions/checkout@v2
-      - name: Login to DockerHub
-        run: "docker login -u ${DOCKER_HUB_USERNAME} -p ${DOCKER_HUB_PASSWORD}"
+        uses: actions/checkout@v3
       - name: Publish modified connectors [On merge to master]
         id: publish-modified-connectors
         if: github.event_name == 'push'
         uses: ./.github/actions/run-dagger-pipeline
         with:
-          # Only pre-release images are published until the correct behavior is observed in prod.
-          # Setting concurrency to 1 for safety:
-          # High concurrency can lead to resource issues for java connectors.
-          # As speed is not a concern in this context I think not publishing connectors in parallel is fine.
-          subcommand: "connectors --concurrency=1 --execute-timeout=3600 --modified publish --main-release"
           context: "master"
+          docker_hub_password: ${{ secrets.DOCKER_HUB_PASSWORD }}
+          docker_hub_username: ${{ secrets.DOCKER_HUB_USERNAME }}
+          gcp_gsm_credentials: ${{ secrets.GCP_GSM_CREDENTIALS }}
+          gcs_credentials: ${{ secrets.METADATA_SERVICE_PROD_GCS_CREDENTIALS }}
           github_token: ${{ secrets.GH_PAT_MAINTENANCE_OCTAVIA }}
+          metadata_service_gcs_credentials: ${{ secrets.METADATA_SERVICE_PROD_GCS_CREDENTIALS }}
+          slack_webhook_url: ${{ secrets.PUBLISH_ON_MERGE_SLACK_WEBHOOK }}
+          spec_cache_gcs_credentials: ${{ secrets.SPEC_CACHE_SERVICE_ACCOUNT_KEY_PUBLISH }}
+          subcommand: "connectors --concurrency=1 --execute-timeout=3600 --modified publish --main-release"
+
       - name: Publish connectors [manual]
         id: publish-connectors
         if: github.event_name == 'workflow_dispatch'
         uses: ./.github/actions/run-dagger-pipeline
         with:
-          subcommand: "connectors ${{ github.event.inputs.connectors-options }} publish ${{ github.event.inputs.publish-options }}"
           context: "manual"
+          docker_hub_password: ${{ secrets.DOCKER_HUB_PASSWORD }}
+          docker_hub_username: ${{ secrets.DOCKER_HUB_USERNAME }}
+          gcp_gsm_credentials: ${{ secrets.GCP_GSM_CREDENTIALS }}
+          gcs_credentials: ${{ secrets.METADATA_SERVICE_PROD_GCS_CREDENTIALS }}
           github_token: ${{ secrets.GH_PAT_MAINTENANCE_OCTAVIA }}
+          metadata_service_gcs_credentials: ${{ secrets.METADATA_SERVICE_PROD_GCS_CREDENTIALS }}
+          slack_webhook_url: ${{ secrets.PUBLISH_ON_MERGE_SLACK_WEBHOOK }}
+          spec_cache_gcs_credentials: ${{ secrets.SPEC_CACHE_SERVICE_ACCOUNT_KEY_PUBLISH }}
+          subcommand: "connectors ${{ github.event.inputs.connectors-options }} publish ${{ github.event.inputs.publish-options }}"

--- a/tools/ci_connector_ops/ci_connector_ops/pipelines/contexts.py
+++ b/tools/ci_connector_ops/ci_connector_ops/pipelines/contexts.py
@@ -170,11 +170,7 @@ class PipelineContext:
     def get_repo_dir(self, subdir: str = ".", exclude: Optional[List[str]] = None, include: Optional[List[str]] = None) -> Directory:
         """Get a directory from the current repository.
 
-        If running in the CI:
-        The directory is extracted from the git branch.
-
-        If running locally:
-        The directory is extracted from your host file system.
+        The directory is extracted from the host file system.
         A couple of files or directories that could corrupt builds are exclude by default (check DEFAULT_EXCLUDED_FILES).
 
         Args:

--- a/tools/ci_connector_ops/ci_connector_ops/pipelines/publish.py
+++ b/tools/ci_connector_ops/ci_connector_ops/pipelines/publish.py
@@ -97,7 +97,7 @@ class PullConnectorImageFromRegistry(Step):
                 raise Exception(f"Failed to inspect {self.context.docker_image_name}: {inspect_stderr}")
             try:
                 for layer in json.loads(inspect_stdout)["layers"]:
-                    if not layer["mediaType"].endswith(".gzip"):
+                    if not layer["mediaType"].endswith("gzip"):
                         return False
                 return True
             except (KeyError, json.JSONDecodeError) as e:


### PR DESCRIPTION
## What
Fixes #27479
This PR refactors our Github action workflow using dagger to use the same `run-dagger-pipeline` action.
It also fixes the test pipeline that was reporting status check to wrong commit id... 