### PR TITLE
qa-check: add pydash deps

### DIFF
--- a/tools/ci_connector_ops/setup.py
+++ b/tools/ci_connector_ops/setup.py
@@ -14,6 +14,7 @@ MAIN_REQUIREMENTS = [
     "pydantic~=1.9",
     "PyGithub~=1.58.0",
     "rich",
+    "pydash~=7.0.4",
 ]
 
 


### PR DESCRIPTION
## What
Pydash library was introduced in https://github.com/airbytehq/airbyte/pull/27294 but not added as a dependency.