### PR TITLE
connectors-ci: better connector test debugging experience (1/2)

### DIFF
--- a/tools/ci_connector_ops/ci_connector_ops/pipelines/commands/groups/connectors.py
+++ b/tools/ci_connector_ops/ci_connector_ops/pipelines/commands/groups/connectors.py
@@ -220,6 +220,7 @@ def test(
             ci_context=ctx.obj.get("ci_context"),
             pull_request=ctx.obj.get("pull_request"),
             ci_gcs_credentials=ctx.obj["ci_gcs_credentials"],
+            should_save_report=True,
         )
         for connector, modified_files in ctx.obj["selected_connectors_and_files"].items()
     ]
@@ -489,6 +490,8 @@ def format(ctx: click.Context) -> bool:
             ci_gcs_credentials=ctx.obj["ci_gcs_credentials"],
             ci_git_user=ctx.obj["ci_git_user"],
             ci_github_access_token=ctx.obj["ci_github_access_token"],
+            pull_request=ctx.obj.get("pull_request"),
+            should_save_report=False,
         )
         for connector, modified_files in connectors_and_files_to_format
     ]

--- a/tools/ci_connector_ops/ci_connector_ops/pipelines/contexts.py
+++ b/tools/ci_connector_ops/ci_connector_ops/pipelines/contexts.py
@@ -111,6 +111,7 @@ class PipelineContext:
         self.ci_github_access_token = ci_github_access_token
         self.started_at = None
         self.stopped_at = None
+        self.secrets_to_mask = []
         update_commit_status_check(**self.github_commit_status)
 
     @property
@@ -262,7 +263,6 @@ class PipelineContext:
             self.report = Report(self, steps_results=[])
 
         self.report.print()
-        self.logger.info(self.report.to_json())
 
         await asyncify(update_commit_status_check)(**self.github_commit_status)
         if self.should_send_slack_message:
@@ -297,6 +297,7 @@ class ConnectorContext(PipelineContext):
         slack_webhook: Optional[str] = None,
         reporting_slack_channel: Optional[str] = None,
         pull_request: PullRequest = None,
+        should_save_report: bool = False,
     ):
         """Initialize a connector context.
 
@@ -326,6 +327,7 @@ class ConnectorContext(PipelineContext):
         self._secrets_dir = None
         self._updated_secrets_dir = None
         self.cdk_version = None
+        self.should_save_report = should_save_report
 
         super().__init__(
             pipeline_name=pipeline_name,
@@ -425,9 +427,9 @@ class ConnectorContext(PipelineContext):
             await secrets.upload(self)
 
         self.report.print()
-        self.logger.info(self.report.to_json())
 
-        await self.report.save()
+        if self.should_save_report:
+            await self.report.save()
 
         if self.report.should_be_commented_on_pr:
             self.report.post_comment_on_pr()
@@ -495,6 +497,7 @@ class PublishConnectorContext(ConnectorContext):
             slack_webhook=slack_webhook,
             reporting_slack_channel=reporting_slack_channel,
             ci_gcs_credentials=ci_gcs_credentials,
+            should_save_report=True,
         )
 
     @property

--- a/tools/ci_connector_ops/ci_connector_ops/pipelines/tests/templates/test_report.html.j2
+++ b/tools/ci_connector_ops/ci_connector_ops/pipelines/tests/templates/test_report.html.j2
@@ -30,103 +30,84 @@
       color: #fff;
       border: 1px solid rgba(203, 203, 221, 0.25);
     }
-
     th, td {
       padding: 8px;
       text-align: left;
       border: 1px solid rgba(203, 203, 221, 0.25);
     }
-
     caption {
       font-weight: bold;
       margin-bottom: 10px;
     }
-
     pre {
       background-color: #222;
       padding: 10px;
       color: #fff;
       overflow: auto;
     }
-
     .wrap-collabsible {
       margin-bottom: 10px;
       border: 1px solid rgba(203, 203, 221, 0.25);
-}
-
-input[type='checkbox'] {
-  display: none;
-}
-
-.lbl-toggle {
-  display: block;
-
-  padding: 1rem;
-
-  cursor: pointer;
-
-  border-radius: 0;
-  transition: all 0.25s ease-out;
-}
-
-.lbl-toggle:hover {
-  color: black;
-}
-
-.lbl-toggle::before {
-  content: ' ';
-  display: inline-block;
-
-  border-top: 5px solid transparent;
-  border-bottom: 5px solid transparent;
-  border-left: 5px solid currentColor;
-  vertical-align: middle;
-  margin-right: .7rem;
-  transform: translateY(-2px);
-
-  transition: transform .2s ease-out;
-}
-
-.toggle:checked + .lbl-toggle::before {
-  transform: rotate(90deg) translateX(-3px);
-}
-
-.collapsible-content {
-  max-height: 0px;
-  overflow: auto;
-  transition: max-height .25s ease-in-out;
-}
-
-.toggle:checked + .lbl-toggle + .collapsible-content {
-  max-height: 100vh;
-}
-
-.toggle:checked + .lbl-toggle {
-  border-bottom-right-radius: 0;
-  border-bottom-left-radius: 0;
-}
-
-.collapsible-content .content-inner {
-  background-color: rgba(43, 47, 70, 0.25);
-  padding: .5rem 1rem;
-}
-
-pre {
-  background-color: rgba(43, 47, 70, 0.25);
-}
-.success {
-  background-color: #366a3e;
-}
-.failure {
-  background-color: #88083C;
-}
-.skipped {
-  background-color: #c0c02b;
-}
-.std {
-  font-style: italic;
-  font-family: monospace;
-}
+    }
+    input[type='checkbox'] {
+      display: none;
+    }
+    .lbl-toggle {
+      display: block;
+      padding: 1rem;
+      cursor: pointer;
+      border-radius: 0;
+      transition: all 0.25s ease-out;
+    }
+    .lbl-toggle:hover {
+      color: black;
+    }
+    .lbl-toggle::before {
+      content: ' ';
+      display: inline-block;
+      border-top: 5px solid transparent;
+      border-bottom: 5px solid transparent;
+      border-left: 5px solid currentColor;
+      vertical-align: middle;
+      margin-right: .7rem;
+      transform: translateY(-2px);
+      transition: transform .2s ease-out;
+    }
+    .toggle:checked + .lbl-toggle::before {
+      transform: rotate(90deg) translateX(-3px);
+    }
+    .collapsible-content {
+      max-height: 0px;
+      overflow: auto;
+      transition: max-height .25s ease-in-out;
+    }
+    .toggle:checked + .lbl-toggle + .collapsible-content {
+      max-height: 100vh;
+    }
+    .toggle:checked + .lbl-toggle {
+      border-bottom-right-radius: 0;
+      border-bottom-left-radius: 0;
+    }
+    .collapsible-content .content-inner {
+      background-color: rgba(43, 47, 70, 0.25);
+      padding: .5rem 1rem;
+    }
+    pre {
+      background-color: rgba(43, 47, 70, 0.25);
+    }
+    .success {
+      background-color: #366a3e;
+    }
+    .failure {
+      background-color: #88083C;
+    }
+    .skipped {
+      background-color: #c0c02b;
+    }
+    .std {
+      font-style: italic;
+      font-family: monospace;
+    }
   </style>
 </head>
 <body>
@@ -158,28 +139,27 @@ pre {
     {% endfor %}
   </table>
   <h2>Step details</h2>
-  
   {% for step_result in step_results %}
   <div class="wrap-collabsible">
-  <input id="{{ step_result.step.title }}" class="toggle" type="checkbox">
-  {% if step_result.status == StepStatus.SUCCESS %}
-    <label for="{{ step_result.step.title }}" class="lbl-toggle success">{{ step_result.step.title }}</label>
-  {% elif step_result.status == StepStatus.FAILURE %}
-    <label for="{{ step_result.step.title }}" class="lbl-toggle failure">{{ step_result.step.title }}</label>
-  {% else %}
-    <label for="{{ step_result.step.title }}" class="lbl-toggle">{{ step_result.step.title }}</label>
-  {% endif%}
-  <div class="collapsible-content">
-    <div class="content-inner">
-      {% if step_result.stdout %}
-      <span class="std">Standard output:</span>
-      <pre>{{ step_result.stdout }}</pre>
-      {% endif %}
-      {% if step_result.stderr %}
-      <span class="std">Standard error:</span>
-      <pre>{{ step_result.stderr }}</pre>
-      {% endif %}
-    </div>
+    <input id="{{ step_result.step.title }}" class="toggle" type="checkbox">
+    {% if step_result.status == StepStatus.SUCCESS %}
+      <label for="{{ step_result.step.title }}" class="lbl-toggle success">{{ step_result.step.title }}</label>
+    {% elif step_result.status == StepStatus.FAILURE %}
+      <label for="{{ step_result.step.title }}" class="lbl-toggle failure">{{ step_result.step.title }}</label>
+    {% else %}
+      <label for="{{ step_result.step.title }}" class="lbl-toggle">{{ step_result.step.title }}</label>
+    {% endif %}
+    <div class="collapsible-content">
+      <div class="content-inner">
+        {% if step_result.stdout %}
+        <span class="std">Standard output:</span>
+        <pre>{{ step_result.stdout }}</pre>
+        {% endif %}
+        {% if step_result.stderr %}
+        <span class="std">Standard error:</span>
+        <pre>{{ step_result.stderr }}</pre>
+        {% endif %}
+      </div>
     </div>
   </div>
   {% endfor %}

--- a/tools/ci_connector_ops/ci_connector_ops/pipelines/tests/templates/test_report.html.j2
+++ b/tools/ci_connector_ops/ci_connector_ops/pipelines/tests/templates/test_report.html.j2
@@ -1,0 +1,188 @@
+<!DOCTYPE html>
+<html>
+<head>
+  <title>{{ connector_name }} test report</title>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1">
+  <style>
+    body {
+      font-family: Arial, sans-serif;
+      margin: 20px;
+      background-color: #131226;
+      color: #fff;
+    }
+    a {
+      color: #fff;
+    }
+    h1 {
+      color: #fff;
+    }
+    ul {
+      list-style-type: none;
+      padding-inline-start: 0px;
+    }
+    li {
+      margin-bottom: 5px;
+    }
+    table {
+      border-collapse: collapse;
+      margin-top: 20px;
+      color: #fff;
+      border: 1px solid rgba(203, 203, 221, 0.25);
+    }
+
+    th, td {
+      padding: 8px;
+      text-align: left;
+      border: 1px solid rgba(203, 203, 221, 0.25);
+    }
+
+    caption {
+      font-weight: bold;
+      margin-bottom: 10px;
+    }
+
+    pre {
+      background-color: #222;
+      padding: 10px;
+      color: #fff;
+      overflow: auto;
+    }
+
+    .wrap-collabsible {
+      margin-bottom: 10px;
+      border: 1px solid rgba(203, 203, 221, 0.25);
+}
+
+input[type='checkbox'] {
+  display: none;
+}
+
+.lbl-toggle {
+  display: block;
+
+  padding: 1rem;
+
+  cursor: pointer;
+
+  border-radius: 0;
+  transition: all 0.25s ease-out;
+}
+
+.lbl-toggle:hover {
+  color: black;
+}
+
+.lbl-toggle::before {
+  content: ' ';
+  display: inline-block;
+
+  border-top: 5px solid transparent;
+  border-bottom: 5px solid transparent;
+  border-left: 5px solid currentColor;
+  vertical-align: middle;
+  margin-right: .7rem;
+  transform: translateY(-2px);
+
+  transition: transform .2s ease-out;
+}
+
+.toggle:checked + .lbl-toggle::before {
+  transform: rotate(90deg) translateX(-3px);
+}
+
+.collapsible-content {
+  max-height: 0px;
+  overflow: auto;
+  transition: max-height .25s ease-in-out;
+}
+
+.toggle:checked + .lbl-toggle + .collapsible-content {
+  max-height: 100vh;
+}
+
+.toggle:checked + .lbl-toggle {
+  border-bottom-right-radius: 0;
+  border-bottom-left-radius: 0;
+}
+
+.collapsible-content .content-inner {
+  background-color: rgba(43, 47, 70, 0.25);
+  padding: .5rem 1rem;
+}
+
+pre {
+  background-color: rgba(43, 47, 70, 0.25);
+}
+.success {
+  background-color: #366a3e;
+}
+.failure {
+  background-color: #88083C;
+}
+.skipped {
+  background-color: #c0c02b;
+}
+.std {
+  font-style: italic;
+  font-family: monospace;
+}
+  </style>
+</head>
+<body>
+  <h1><img src="{{ icon_url }}" width="40" height="40"> {{ connector_name }} test report</h1>
+  <ul>
+    <li><b>Created at:</b> {{ created_at }}</li>
+    <li><b>Run duration:</b> {{ run_duration }} seconds</li>
+    {% if commit_url %}
+    <li><b>Commit:</b> <a href="{{ commit_url }}">{{ git_revision[:10] }}</a></li>
+    {% else %}
+    <li><b>Commit:</b> {{ git_revision[:10] }}</li>
+    {% endif %}
+    <li><b>Branch:</b> {{ git_branch }}</li>
+    {% if gha_workflow_run_url %}
+    <li><b>Github Actions run:</b> <a href="{{ gha_workflow_run_url }}">{{ gha_workflow_run_url }}</a></li>
+    {% endif %}
+  </ul>
+  <h2>Summary</h2>
+  <table>
+    <tr>
+      <th>Step Name</th>
+      <th>Status</th>
+    </tr>
+    {% for step_result in step_results %}
+    <tr>
+      <td>{{ step_result.step.title }}</td>
+      <td>{{ step_result.status }}</td>
+    </tr>
+    {% endfor %}
+  </table>
+  <h2>Step details</h2>
+  
+  {% for step_result in step_results %}
+  <div class="wrap-collabsible">
+  <input id="{{ step_result.step.title }}" class="toggle" type="checkbox">
+  {% if step_result.status == StepStatus.SUCCESS %}
+    <label for="{{ step_result.step.title }}" class="lbl-toggle success">{{ step_result.step.title }}</label>
+  {% elif step_result.status == StepStatus.FAILURE %}
+    <label for="{{ step_result.step.title }}" class="lbl-toggle failure">{{ step_result.step.title }}</label>
+  {% else %}
+    <label for="{{ step_result.step.title }}" class="lbl-toggle">{{ step_result.step.title }}</label>
+  {% endif%}
+  <div class="collapsible-content">
+    <div class="content-inner">
+      {% if step_result.stdout %}
+      <span class="std">Standard output:</span>
+      <pre>{{ step_result.stdout }}</pre>
+      {% endif %}
+      {% if step_result.stderr %}
+      <span class="std">Standard error:</span>
+      <pre>{{ step_result.stderr }}</pre>
+      {% endif %}
+    </div>
+    </div>
+  </div>
+  {% endfor %}
+  <p style="margin-top: 50px"><em>These reports are generated from <a href="https://github.com/airbytehq/airbyte/blob/master/tools/ci_connector_ops/ci_connector_ops/pipelines/tests/templates/test_report.html.j2">this code</a>, please reach out to the Connector Operations team for support.</em></p>
+</body>
+</html>

--- a/tools/ci_connector_ops/setup.py
+++ b/tools/ci_connector_ops/setup.py
@@ -53,6 +53,7 @@ PIPELINES_REQUIREMENTS = [
     "semver",
     "airbyte-protocol-models",
     "tabulate",
+    "jinja2",
 ]
 
 setup(
@@ -70,7 +71,7 @@ setup(
         "qa_engine": MAIN_REQUIREMENTS + QA_ENGINE_REQUIREMENTS,
     },
     # python_requires=">=3.10", TODO upgrade all our CI packages + GHA env to 3.10
-    package_data={"ci_connector_ops.qa_engine": ["connector_adoption.sql"]},
+    package_data={"ci_connector_ops.qa_engine": ["connector_adoption.sql"], "ci_connector_ops.pipelines.tests": ["templates/*.j2"]},
     entry_points={
         "console_scripts": [
             "check-test-strictness-level = ci_connector_ops.acceptance_test_config_checks:check_test_strictness_level",


### PR DESCRIPTION
## What
https://github.com/airbytehq/airbyte/issues/27497
We want to better share connector test results with connector developer.
I made the test report generate an HTML page that we upload to our `airbyte-ci-reports` public bucket.
The link to the reports are shared in the test summary commented on the PR.
We'll make them available on nightly build daily report in a second PR.

## How
* Create a jinja template for reports
* Redact secrets from stdout or stderr to get the same level of secret masking we have in GHA
* Upload html reports to GCS when running in the CI, otherwise open the local HTML file in the default web browser.
