### PR TITLE
Run ci checks for Source Google Analytics 4

### DIFF
--- a/airbyte-integrations/connectors/source-google-analytics-data-api/Dockerfile
+++ b/airbyte-integrations/connectors/source-google-analytics-data-api/Dockerfile
@@ -28,5 +28,5 @@ COPY source_google_analytics_data_api ./source_google_analytics_data_api
 ENV AIRBYTE_ENTRYPOINT "python /airbyte/integration_code/main.py"
 ENTRYPOINT ["python", "/airbyte/integration_code/main.py"]
 
-LABEL io.airbyte.version=0.2.7
+LABEL io.airbyte.version=0.2.8
 LABEL io.airbyte.name=airbyte/source-google-analytics-data-api

--- a/airbyte-integrations/connectors/source-google-analytics-data-api/metadata.yaml
+++ b/airbyte-integrations/connectors/source-google-analytics-data-api/metadata.yaml
@@ -7,7 +7,7 @@ data:
   connectorSubtype: api
   connectorType: source
   definitionId: 3cc2eafd-84aa-4dca-93af-322d9dfeec1a
-  dockerImageTag: 0.2.7
+  dockerImageTag: 0.2.8
   dockerRepository: airbyte/source-google-analytics-data-api
   githubIssueLabel: source-google-analytics-data-api
   icon: google-analytics.svg

--- a/airbyte-integrations/connectors/source-google-analytics-data-api/source_google_analytics_data_api/defaults/custom_reports_schema.json
+++ b/airbyte-integrations/connectors/source-google-analytics-data-api/source_google_analytics_data_api/defaults/custom_reports_schema.json
@@ -21,6 +21,12 @@
           "type": "string"
         }
       },
+      "dimensionFilter": {
+        "$ref": "#/$defs/filterExpression"
+      },
+      "metricFilter": {
+        "$ref": "#/$defs/filterExpression"
+      },
       "cohortSpec": {
         "type": ["null", "object"],
         "properties": {
@@ -129,6 +135,121 @@
             "metricAggregations": {
               "type": ["null", "string"],
               "enum": ["COUNT", "TOTAL", "MAXIMUM", "MINIMUM"]
+            }
+          }
+        }
+      }
+    }
+  },
+  "$defs": {
+    "filterExpressionList": {
+      "type": "object",
+      "properties": {
+        "expressions": {
+          "type": "array",
+          "items": {
+            "$ref": "#/$defs/filterExpression"
+          }
+        }
+      }
+    },
+    "filterExpression": {
+      "type": "object",
+      "properties": {
+        "andGroup": {
+          "$ref": "#/$defs/filterExpressionList"
+        },
+        "orGroup": {
+          "$ref": "#/$defs/filterExpressionList"
+        },
+        "notExpression": {
+          "$ref": "#/$defs/filterExpression"
+        },
+        "filter": {
+          "type": "object",
+          "required": ["fieldName"],
+          "properties": {
+            "fieldName": {
+              "type": "string"
+            },
+            "stringFilter": {
+              "type": "object",
+              "required": ["value"],
+              "properties": {
+                "matchType": {
+                  "type": "string",
+                  "enum": ["MATCH_TYPE_UNSPECIFIED", "EXACT", "BEGINS_WITH", "ENDS_WITH", "CONTAINS", "FULL_REGEXP", "PARTIAL_REGEXP"]
+                },
+                "value": {"type": "string"},
+                "caseSensitive": {
+                  "type": "boolean"
+                }
+              }
+            },
+            "inListFilter": {
+              "type": "object",
+              "required": ["values"],
+              "properties": {
+                "values": {
+                  "type": "array",
+                  "items": {
+                    "type": "string"
+                  },
+                  "minItems": 1
+                },
+                "caseSensitive": {
+                  "type": "boolean"
+                }
+              }
+            },
+            "numericFilter": {
+              "type": "object",
+              "required": ["value"],
+              "properties": {
+                "operation": {
+                  "type": "string",
+                  "enum": ["OPERATION_UNSPECIFIED", "EQUAL", "LESS_THAN", "LESS_THAN_OR_EQUAL", "GREATER_THAN", "GREATER_THAN_OR_EQUAL"]
+                },
+                "value": {
+                  "type": "object",
+                  "properties": {
+                    "int64Value": {
+                      "type": "string"
+                    },
+                    "doubleValue": {
+                      "type": "number"
+                    }
+                  }
+                }
+              }
+            },
+            "betweenFilter": {
+              "type": "object",
+              "required": ["fromValue", "toValue"],
+              "properties": {
+                "fromValue": {
+                  "type": "object",
+                  "properties": {
+                    "int64Value": {
+                      "type": "string"
+                    },
+                    "doubleValue": {
+                      "type": "number"
+                    }
+                  }
+                },
+                "toValue": {
+                  "type": "object",
+                  "properties": {
+                    "int64Value": {
+                      "type": "string"
+                    },
+                    "doubleValue": {
+                      "type": "number"
+                    }
+                  }
+                }
+              }
             }
           }
         }

--- a/airbyte-integrations/connectors/source-google-analytics-data-api/source_google_analytics_data_api/source.py
+++ b/airbyte-integrations/connectors/source-google-analytics-data-api/source_google_analytics_data_api/source.py
@@ -439,15 +439,15 @@ class SourceGoogleAnalyticsDataApi(AbstractSource):
     def instantiate_report_class(report: dict, config: Mapping[str, Any]) -> GoogleAnalyticsDataApiBaseStream:
         cohort_spec = report.get("cohortSpec")
         pivots = report.get("pivots")
-        dimension_filter = report.get('dimensionFilter')
-        metric_filter = report.get('metricFilter')
+        dimension_filter = report.get("dimensionFilter")
+        metric_filter = report.get("metricFilter")
         stream_config = {"metrics": report["metrics"], "dimensions": report["dimensions"], **config}
         report_class_tuple = (GoogleAnalyticsDataApiBaseStream,)
 
         if dimension_filter:
-            stream_config['dimension_filter'] = dimension_filter
+            stream_config["dimension_filter"] = dimension_filter
         if metric_filter:
-            stream_config['metric_filter'] = metric_filter
+            stream_config["metric_filter"] = metric_filter
 
         if pivots:
             stream_config["pivots"] = pivots

--- a/airbyte-integrations/connectors/source-google-analytics-data-api/source_google_analytics_data_api/source.py
+++ b/airbyte-integrations/connectors/source-google-analytics-data-api/source_google_analytics_data_api/source.py
@@ -229,6 +229,10 @@ class GoogleAnalyticsDataApiBaseStream(GoogleAnalyticsDataApiAbstractStream):
             "offset": str(0),
             "limit": str(PAGE_SIZE),
         }
+        if "dimension_filter" in self.config:
+            payload.update({"dimensionFilter": self.config["dimension_filter"]})
+        if "metric_filter" in self.config:
+            payload.update({"metricFilter": self.config["metric_filter"]})
         if next_page_token and next_page_token.get("offset") is not None:
             payload.update({"offset": str(next_page_token["offset"])})
         return payload
@@ -435,8 +439,16 @@ class SourceGoogleAnalyticsDataApi(AbstractSource):
     def instantiate_report_class(report: dict, config: Mapping[str, Any]) -> GoogleAnalyticsDataApiBaseStream:
         cohort_spec = report.get("cohortSpec")
         pivots = report.get("pivots")
+        dimension_filter = report.get('dimensionFilter')
+        metric_filter = report.get('metricFilter')
         stream_config = {"metrics": report["metrics"], "dimensions": report["dimensions"], **config}
         report_class_tuple = (GoogleAnalyticsDataApiBaseStream,)
+
+        if dimension_filter:
+            stream_config['dimension_filter'] = dimension_filter
+        if metric_filter:
+            stream_config['metric_filter'] = metric_filter
+
         if pivots:
             stream_config["pivots"] = pivots
             report_class_tuple = (PivotReport,)

--- a/docs/integrations/sources/google-analytics-data-api.md
+++ b/docs/integrations/sources/google-analytics-data-api.md
@@ -4,7 +4,7 @@ This page contains the setup guide and reference information for the Google Anal
 
 :::note
 
-[Google Analytics Universal Analytics (UA) connector](https://docs.airbyte.com/integrations/sources/google-analytics-v4), uses the older version of Google Analytics, which has been the standard for tracking website and app user behavior since 2012. 
+[Google Analytics Universal Analytics (UA) connector](https://docs.airbyte.com/integrations/sources/google-analytics-v4), uses the older version of Google Analytics, which has been the standard for tracking website and app user behavior since 2012.
 
 Google Analytics 4 (GA4) connector is the latest version of Google Analytics, which was introduced in 2020. It offers a new data model that emphasizes events and user properties, rather than pageviews and sessions. This new model allows for more flexible and customizable reporting, as well as more accurate measurement of user behavior across devices and platforms.
 
@@ -12,9 +12,9 @@ Google Analytics 4 (GA4) connector is the latest version of Google Analytics, wh
 
 ## Prerequisites
 
-* JSON credentials for the service account that has access to Google Analytics. For more details check [instructions](https://support.google.com/analytics/answer/1009702)
-* OAuth 2.0 credentials for the service account that has access to Google Analytics
-* Property ID
+- JSON credentials for the service account that has access to Google Analytics. For more details check [instructions](https://support.google.com/analytics/answer/1009702)
+- OAuth 2.0 credentials for the service account that has access to Google Analytics
+- Property ID
 
 ## Step 1: Set up Source
 
@@ -61,7 +61,6 @@ Use the service account email address to [add a user](https://support.google.com
 7. Enter the **Custom Reports (Optional)** a JSON array describing the custom reports you want to sync from Google Analytics.
 8. Enter the **Data request time increment in days (Optional)**. The bigger this value is, the faster the sync will be, but the more likely that sampling will be applied to your data, potentially causing inaccuracies in the returned results. We recommend setting this to 1 unless you have a hard requirement to make the sync faster at the expense of accuracy. The minimum allowed value for this field is 1, and the maximum is 364. (Not applied to custom Cohort reports).
 
-
 ## Supported sync modes
 
 The Google Analytics source connector supports the following [sync modes](https://docs.airbyte.com/cloud/core-concepts#connection-sync-modes):
@@ -75,25 +74,25 @@ The Google Analytics source connector supports the following [sync modes](https:
 
 This connector outputs the following incremental streams:
 
-* Preconfigured streams:
-  * [daily_active_users](https://developers.google.com/analytics/devguides/reporting/data/v1/rest/v1beta/properties/runReport)
-  * [devices](https://developers.google.com/analytics/devguides/reporting/data/v1/rest/v1beta/properties/runReport)
-  * [four_weekly_active_users](https://developers.google.com/analytics/devguides/reporting/data/v1/rest/v1beta/properties/runReport)
-  * [locations](https://developers.google.com/analytics/devguides/reporting/data/v1/rest/v1beta/properties/runReport)
-  * [pages](https://developers.google.com/analytics/devguides/reporting/data/v1/rest/v1beta/properties/runReport)
-  * [traffic_sources](https://developers.google.com/analytics/devguides/reporting/data/v1/rest/v1beta/properties/runReport)
-  * [website_overview](https://developers.google.com/analytics/devguides/reporting/data/v1/rest/v1beta/properties/runReport)
-  * [weekly_active_users](https://developers.google.com/analytics/devguides/reporting/data/v1/rest/v1beta/properties/runReport)
-* [Custom stream\(s\)](https://developers.google.com/analytics/devguides/reporting/data/v1/rest/v1beta/properties/runReport)
+- Preconfigured streams:
+  - [daily_active_users](https://developers.google.com/analytics/devguides/reporting/data/v1/rest/v1beta/properties/runReport)
+  - [devices](https://developers.google.com/analytics/devguides/reporting/data/v1/rest/v1beta/properties/runReport)
+  - [four_weekly_active_users](https://developers.google.com/analytics/devguides/reporting/data/v1/rest/v1beta/properties/runReport)
+  - [locations](https://developers.google.com/analytics/devguides/reporting/data/v1/rest/v1beta/properties/runReport)
+  - [pages](https://developers.google.com/analytics/devguides/reporting/data/v1/rest/v1beta/properties/runReport)
+  - [traffic_sources](https://developers.google.com/analytics/devguides/reporting/data/v1/rest/v1beta/properties/runReport)
+  - [website_overview](https://developers.google.com/analytics/devguides/reporting/data/v1/rest/v1beta/properties/runReport)
+  - [weekly_active_users](https://developers.google.com/analytics/devguides/reporting/data/v1/rest/v1beta/properties/runReport)
+- [Custom stream\(s\)](https://developers.google.com/analytics/devguides/reporting/data/v1/rest/v1beta/properties/runReport)
 
 ## Connector-specific features
 
 :::note
 
-  * Custom reports should be provided in format `[{"name": "<report-name>", "dimensions": ["<dimension-name>", ...], "metrics": ["<metric-name>", ...], "cohortSpec": "<cohortSpec>", "pivots": "<pivots>"}]`
-  * Both `pivots` and `cohortSpec` are optional. Detailed description of the `cohortSpec` and the `pivots` objects you can find [here](https://developers.google.com/analytics/devguides/reporting/data/v1/rest/v1beta/CohortSpec) and [here](https://developers.google.com/analytics/devguides/reporting/data/v1/rest/v1beta/Pivot).
-  * To enable Incremental sync for Custom reports, you need to include the `date` dimension (except for custom Cohort reports).
-:::
+- Custom reports should be provided in format `[{"name": "<report-name>", "dimensions": ["<dimension-name>", ...], "metrics": ["<metric-name>", ...], "cohortSpec": "<cohortSpec>", "pivots": "<pivots>"}]`
+- Both `pivots` and `cohortSpec` are optional. Detailed description of the `cohortSpec` and the `pivots` objects you can find [here](https://developers.google.com/analytics/devguides/reporting/data/v1/rest/v1beta/CohortSpec) and [here](https://developers.google.com/analytics/devguides/reporting/data/v1/rest/v1beta/Pivot).
+- To enable Incremental sync for Custom reports, you need to include the `date` dimension (except for custom Cohort reports).
+  :::
 
 ## Performance Considerations
 
@@ -102,7 +101,7 @@ This connector outputs the following incremental streams:
 ## Data type map
 
 | Integration Type | Airbyte Type | Notes |
-|:-----------------|:-------------|:------|
+| :--------------- | :----------- | :---- |
 | `string`         | `string`     |       |
 | `number`         | `number`     |       |
 | `array`          | `array`      |       |
@@ -111,7 +110,8 @@ This connector outputs the following incremental streams:
 ## Changelog
 
 | Version | Date       | Pull Request                                             | Subject                                                                       |
-|:--------|:-----------|:---------------------------------------------------------|:------------------------------------------------------------------------------|
+| :------ | :--------- | :------------------------------------------------------- | :---------------------------------------------------------------------------- |
+| 0.2.8   | 2023-06-12 | [27264](https://github.com/airbytehq/airbyte/pull/27264) | Added dimensionFilter and metricFilter                                        |
 | 0.2.7   | 2023-06-21 | [27531](https://github.com/airbytehq/airbyte/pull/27531) | Fix formatting                                                                |
 | 0.2.6   | 2023-06-09 | [27207](https://github.com/airbytehq/airbyte/pull/27207) | Improve api rate limit messages                                               |
 | 0.2.5   | 2023-06-08 | [27175](https://github.com/airbytehq/airbyte/pull/27175) | Improve Error Messages                                                        |


### PR DESCRIPTION
## What
Add dimensionFilter and metricFilter parameters to custom_report_shema.json. This PR relates to issue #27119.

## How
Add dimensionFilter, metricFilter and filters' expressions described in [runReport documentation](https://developers.google.com/analytics/devguides/reporting/data/v1/rest/v1beta/properties/runReport) and in [FilterExpression documentation](https://developers.google.com/analytics/devguides/reporting/data/v1/rest/v1beta/FilterExpression) to custom_report_shema.json.

Run ci checks for #27264