### PR TITLE
Update test workflow: Update to use rev-parse

### DIFF
--- a/.github/workflows/connectors_tests.yml
+++ b/.github/workflows/connectors_tests.yml
@@ -49,7 +49,7 @@ jobs:
       - name: Fetch last commit id from remote branch [WORKFLOW DISPATCH]
         if: github.event_name == 'workflow_dispatch'
         id: fetch_last_commit_id_wd
-        run: echo "commit_id=$(git ls-remote --heads origin ${{ steps.extract_branch.outputs.branch }} | cut -f 1)" >> $GITHUB_OUTPUT
+        run: echo "commit_id=$(git rev-parse origin/${{ steps.extract_branch.outputs.branch }})" >> $GITHUB_OUTPUT
       - name: Pull formatting changes [PULL REQUESTS]
         if: github.event_name == 'pull_request'
         uses: actions/checkout@v3


### PR DESCRIPTION
## What
We can run test on master via workflow as their are too many heads that match `master`

this updates the action to use rev-parse