### PR TITLE
[ISSUE #27289] Document macros output in the manifest schema

### DIFF
--- a/airbyte-cdk/python/airbyte_cdk/sources/declarative/declarative_component_schema.yaml
+++ b/airbyte-cdk/python/airbyte_cdk/sources/declarative/declarative_component_schema.yaml
@@ -2034,33 +2034,34 @@ interpolation:
       arguments: {}
       return_type: Datetime
       examples:
-        - "{{ now_utc() }}"
-        - "{{ now_utc().strftime('%Y-%m-%d') }}"
+        - "'{{ now_utc() }}' -> '2021-09-01 00:00:00+00:00'"
+        - "'{{ now_utc().strftime('%Y-%m-%d') }}' -> '2021-09-01'"
     - title: Today (UTC)
       description: Returns the current date in UTC timezone. The output is a date object.
       arguments: {}
       return_type: Date
       examples:
-        - "{{ today_utc() }}"
+        - "'{{ today_utc() }}' -> '2021-09-01'"
+        - "'{{ today_utc().strftime('%Y/%m/%d')}}' -> '2021/09/01'"
     - title: Timestamp
       description: Converts a number or a string representing a datetime (formatted as ISO8601) to a timestamp. If the input is a number, it is converted to an int. If no timezone is specified, the string is interpreted as UTC.
       arguments:
         datetime: A string formatted as ISO8601 or an integer representing a unix timestamp
       return_type: int
       examples:
-        - "{{ timestamp(1646006400) }}"
-        - "{{ timestamp('2022-02-28') }}"
-        - "{{ timestamp('2022-02-28T00:00:00Z') }}"
-        - "{{ timestamp('2022-02-28 00:00:00Z') }}"
-        - "{{ timestamp('2022-02-28T00:00:00:-08:00') }}"
+        - "'{{ timestamp(1646006400) }}' -> 1646006400"
+        - "'{{ timestamp('2022-02-28') }}' -> 1646006400"
+        - "'{{ timestamp('2022-02-28T00:00:00Z') }}' -> 1646006400"
+        - "'{{ timestamp('2022-02-28 00:00:00Z') }}' -> 1646006400"
+        - "'{{ timestamp('2022-02-28T00:00:00-08:00') }}' -> 1646035200"
     - title: Max
       description: Returns the largest object of a iterable, or or two or more arguments.
       arguments:
         args: iterable or a sequence of two or more arguments
       return_type: Any
       examples:
-        - "{{ max(2, 3) }}"
-        - "{{ max([2, 3]) }}"
+        - "'{{ max(2, 3) }}' -> 3"
+        - "'{{ max([2, 3]) }}' -> 3"
     - title: Day Delta
       description: Returns the datetime of now() + num_days.
       arguments:
@@ -2068,17 +2069,18 @@ interpolation:
         format: How to format the output string
       return_type: str
       examples:
-        - "{{ day_delta(25) }}"
-        - "{{ day_delta(25, format='%Y-%m-%d') }}"
+        - "'{{ day_delta(1) }}' -> '2021-09-02T00:00:00.000000+0000'"
+        - "'{{ day_delta(-1) }}' -> '2021-08-31:00:00.000000+0000'"
+        - "'{{ day_delta(25, format='%Y-%m-%d') }}' -> '2021-09-02'"
     - title: Duration
       description: Converts an ISO8601 duratioin to datetime.timedelta.
       arguments:
         duration_string: "A string representing an ISO8601 duration. See https://www.digi.com/resources/documentation/digidocs//90001488-13/reference/r_iso_8601_duration_format.htm for more details."
       return_type: datetime.timedelta
       examples:
-        - "{{ duration('P1D') }}"
-        - "{{ duration('P6DT23H') }}"
-        - "{{ (now_utc() - duration('P1D')).strftime('%Y-%m-%dT%H:%M:%SZ') }}"
+        - "'{{ duration('P1D') }}' -> '1 day, 0:00:00'"
+        - "'{{ duration('P6DT23H') }}' -> '6 days, 23:00:00'"
+        - "'{{ (now_utc() - duration('P1D')).strftime('%Y-%m-%dT%H:%M:%SZ') }}' -> '2021-08-31T00:00:00Z'"
     - title: Format Datetime
       description: Converts a datetime or a datetime-string to the specified format.
       arguments:

--- a/airbyte-cdk/python/unit_tests/sources/declarative/interpolation/test_jinja.py
+++ b/airbyte-cdk/python/unit_tests/sources/declarative/interpolation/test_jinja.py
@@ -190,3 +190,30 @@ def test_undeclared_variables(template_string, expected_error, expected_value):
     else:
         actual_value = interpolation.eval(template_string, config=config, **{"to_be": "that_is_the_question"})
         assert actual_value == expected_value
+
+
+@freeze_time("2021-09-01")
+@pytest.mark.parametrize("template_string, expected_value",[
+    pytest.param("{{ now_utc() }}", "2021-09-01 00:00:00+00:00", id="test_now_utc"),
+    pytest.param("{{ now_utc().strftime('%Y-%m-%d') }}", "2021-09-01", id="test_now_utc_strftime"),
+    pytest.param("{{ today_utc() }}", "2021-09-01", id="test_today_utc"),
+    pytest.param("{{ today_utc().strftime('%Y/%m/%d') }}", "2021/09/01", id="test_todat_utc_stftime"),
+    pytest.param("{{ timestamp(1646006400) }}", 1646006400, id="test_timestamp_from_timestamp"),
+    pytest.param("{{ timestamp('2022-02-28') }}", 1646006400, id="test_timestamp_from_timestamp"),
+    pytest.param("{{ timestamp('2022-02-28T00:00:00Z') }}", 1646006400, id="test_timestamp_from_timestamp"),
+    pytest.param("{{ timestamp('2022-02-28 00:00:00Z') }}", 1646006400, id="test_timestamp_from_timestamp"),
+    pytest.param("{{ timestamp('2022-02-28T00:00:00-08:00') }}", 1646035200, id="test_timestamp_from_date_with_tz"),
+    pytest.param("{{ max(2, 3) }}", 3, id="test_max_with_arguments"),
+    pytest.param("{{ max([2, 3]) }}", 3, id="test_max_with_list"),
+    pytest.param("{{ day_delta(1) }}", "2021-09-02T00:00:00.000000+0000", id="test_day_delta"),
+    pytest.param("{{ day_delta(-1) }}", "2021-08-31T00:00:00.000000+0000", id="test_day_delta_negative"),
+    pytest.param("{{ day_delta(1, format='%Y-%m-%d') }}", "2021-09-02", id="test_day_delta_with_format"),
+    pytest.param("{{ duration('P1D') }}", "1 day, 0:00:00", id="test_duration_one_day"),
+    pytest.param("{{ duration('P6DT23H') }}", "6 days, 23:00:00", id="test_duration_six_days_and_23_hours"),
+    pytest.param("{{ (now_utc() - duration('P1D')).strftime('%Y-%m-%dT%H:%M:%SZ') }}", "2021-08-31T00:00:00Z", id="test_now_utc_with_duration_and_format"),
+])
+def test_macros_examples(template_string, expected_value):
+    # The outputs of this test are referenced in declarative_component_schema.yaml
+    # If you change the expected output, you must also change the expected output in declarative_component_schema.yaml
+    now_utc = interpolation.eval(template_string, {})
+    assert now_utc == expected_value

--- a/airbyte-cdk/python/unit_tests/sources/declarative/interpolation/test_macros.py
+++ b/airbyte-cdk/python/unit_tests/sources/declarative/interpolation/test_macros.py
@@ -28,14 +28,14 @@ def test_macros_export(test_name, fn_name, found_in_macros):
 
 
 @pytest.mark.parametrize("test_name, input_value, format, expected_output", [
-    ("test_datetime_string_to_date", "2022-01-01T01:01:01Z", "%Y-%m-%d","2022-01-01"),
+    ("test_datetime_string_to_date", "2022-01-01T01:01:01Z", "%Y-%m-%d", "2022-01-01"),
     ("test_date_string_to_date", "2022-01-01", "%Y-%m-%d", "2022-01-01"),
     ("test_datetime_string_to_date", "2022-01-01T00:00:00Z", "%Y-%m-%d", "2022-01-01"),
     ("test_datetime_with_tz_string_to_date", "2022-01-01T00:00:00Z", "%Y-%m-%d", "2022-01-01"),
     ("test_datetime_string_to_datetime", "2022-01-01T01:01:01Z", "%Y-%m-%dT%H:%M:%SZ", "2022-01-01T01:01:01Z"),
     ("test_datetime_string_with_tz_to_datetime", "2022-01-01T01:01:01-0800", "%Y-%m-%dT%H:%M:%SZ", "2022-01-01T09:01:01Z"),
-    ("test_datetime_object_tz_to_date", datetime.datetime(2022,1,1,1,1,1), "%Y-%m-%d", "2022-01-01"),
-    ("test_datetime_object_tz_to_datetime", datetime.datetime(2022,1,1,1,1,1), "%Y-%m-%dT%H:%M:%SZ", "2022-01-01T01:01:01Z"),
+    ("test_datetime_object_tz_to_date", datetime.datetime(2022, 1, 1, 1, 1, 1), "%Y-%m-%d", "2022-01-01"),
+    ("test_datetime_object_tz_to_datetime", datetime.datetime(2022, 1, 1, 1, 1, 1), "%Y-%m-%dT%H:%M:%SZ", "2022-01-01T01:01:01Z"),
 ])
 def test_format_datetime(test_name, input_value, format, expected_output):
     format_datetime = macros["format_datetime"]
@@ -54,7 +54,7 @@ def test_duration(test_name, input_value, expected_output):
 
 
 @pytest.mark.parametrize(
-    "test_name, input_value, expected_output",[
+    "test_name, input_value, expected_output", [
         ("test_int_input", 1646006400, 1646006400),
         ("test_float_input", 100.0, 100),
         ("test_float_input_is_floored", 100.9, 100),

--- a/docs/integrations/sources/woocommerce.md
+++ b/docs/integrations/sources/woocommerce.md
@@ -97,11 +97,12 @@ Useful links:
 
 ## Changelog
 
-| Version | Date       | Pull Request                                             | Subject                                                                 |
-| :------ | :--------- | :------------------------------------------------------- | :---------------------------------------------------------------------- |
-| 0.2.3   | 2023-06-02 | [26955](https://github.com/airbytehq/airbyte/pull/26955) | Added `block_context` and `author` properties to the `Products` stream  |
-| 0.2.2   | 2023-03-03 | [23599](https://github.com/airbytehq/airbyte/pull/23599) | Fix pagination and removed lookback window                              |
-| 0.2.1   | 2023-02-10 | [22821](https://github.com/airbytehq/airbyte/pull/22821) | Specified date formatting in specification                              |
-| 0.2.0   | 2022-11-30 | [19903](https://github.com/airbytehq/airbyte/pull/19903) | Migrate to low-code; Certification to Beta                              |
-| 0.1.1   | 2021-11-08 | [7499](https://github.com/airbytehq/airbyte/pull/7499)   | Remove base-python dependencies                                         |
-| 0.1.0   | 2021-09-09 | [5955](https://github.com/airbytehq/airbyte/pull/5955)   | Initial Release. Source WooCommerce                                     |
+| Version | Date       | Pull Request                                             | Subject                                                                |
+| :------ |:-----------| :------------------------------------------------------- |:-----------------------------------------------------------------------|
+| 1.0.0   | 2023-06-21 | [27596](https://github.com/airbytehq/airbyte/pull/27596) | Added `srcset` field the `Products` stream      |
+| 0.2.3   | 2023-06-02 | [26955](https://github.com/airbytehq/airbyte/pull/26955) | Added `block_context` and `author` properties to the `Products` stream |
+| 0.2.2   | 2023-03-03 | [23599](https://github.com/airbytehq/airbyte/pull/23599) | Fix pagination and removed lookback window                             |
+| 0.2.1   | 2023-02-10 | [22821](https://github.com/airbytehq/airbyte/pull/22821) | Specified date formatting in specification                             |
+| 0.2.0   | 2022-11-30 | [19903](https://github.com/airbytehq/airbyte/pull/19903) | Migrate to low-code; Certification to Beta                             |
+| 0.1.1   | 2021-11-08 | [7499](https://github.com/airbytehq/airbyte/pull/7499)   | Remove base-python dependencies                                        |
+| 0.1.0   | 2021-09-09 | [5955](https://github.com/airbytehq/airbyte/pull/5955)   | Initial Release. Source WooCommerce                                    |

--- a/docs/integrations/sources/woocommerce.md
+++ b/docs/integrations/sources/woocommerce.md
@@ -97,12 +97,11 @@ Useful links:
 
 ## Changelog
 
-| Version | Date       | Pull Request                                             | Subject                                                                |
-| :------ |:-----------| :------------------------------------------------------- |:-----------------------------------------------------------------------|
-| 1.0.0   | 2023-06-21 | [27596](https://github.com/airbytehq/airbyte/pull/27596) | Added `srcset` field the `Products` stream      |
-| 0.2.3   | 2023-06-02 | [26955](https://github.com/airbytehq/airbyte/pull/26955) | Added `block_context` and `author` properties to the `Products` stream |
-| 0.2.2   | 2023-03-03 | [23599](https://github.com/airbytehq/airbyte/pull/23599) | Fix pagination and removed lookback window                             |
-| 0.2.1   | 2023-02-10 | [22821](https://github.com/airbytehq/airbyte/pull/22821) | Specified date formatting in specification                             |
-| 0.2.0   | 2022-11-30 | [19903](https://github.com/airbytehq/airbyte/pull/19903) | Migrate to low-code; Certification to Beta                             |
-| 0.1.1   | 2021-11-08 | [7499](https://github.com/airbytehq/airbyte/pull/7499)   | Remove base-python dependencies                                        |
-| 0.1.0   | 2021-09-09 | [5955](https://github.com/airbytehq/airbyte/pull/5955)   | Initial Release. Source WooCommerce                                    |
+| Version | Date       | Pull Request                                             | Subject                                                                 |
+| :------ | :--------- | :------------------------------------------------------- | :---------------------------------------------------------------------- |
+| 0.2.3   | 2023-06-02 | [26955](https://github.com/airbytehq/airbyte/pull/26955) | Added `block_context` and `author` properties to the `Products` stream  |
+| 0.2.2   | 2023-03-03 | [23599](https://github.com/airbytehq/airbyte/pull/23599) | Fix pagination and removed lookback window                              |
+| 0.2.1   | 2023-02-10 | [22821](https://github.com/airbytehq/airbyte/pull/22821) | Specified date formatting in specification                              |
+| 0.2.0   | 2022-11-30 | [19903](https://github.com/airbytehq/airbyte/pull/19903) | Migrate to low-code; Certification to Beta                              |
+| 0.1.1   | 2021-11-08 | [7499](https://github.com/airbytehq/airbyte/pull/7499)   | Remove base-python dependencies                                         |
+| 0.1.0   | 2021-09-09 | [5955](https://github.com/airbytehq/airbyte/pull/5955)   | Initial Release. Source WooCommerce                                     |


### PR DESCRIPTION
## What
* Document the output of the macros in the manifest
* The format of the examples deviates slightly from the issue description because it wouldn't be a valid yaml file otherwise.
* format is "'{{ macro_function() }}' -> <output>"