### PR TITLE
✨ Source Zenloop: improve error message on state discrepancy

### DIFF
--- a/airbyte-integrations/connectors/source-zenloop/Dockerfile
+++ b/airbyte-integrations/connectors/source-zenloop/Dockerfile
@@ -34,5 +34,5 @@ COPY source_zenloop ./source_zenloop
 ENV AIRBYTE_ENTRYPOINT "python /airbyte/integration_code/main.py"
 ENTRYPOINT ["python", "/airbyte/integration_code/main.py"]
 
-LABEL io.airbyte.version=0.1.7
+LABEL io.airbyte.version=0.1.8
 LABEL io.airbyte.name=airbyte/source-zenloop

--- a/airbyte-integrations/connectors/source-zenloop/metadata.yaml
+++ b/airbyte-integrations/connectors/source-zenloop/metadata.yaml
@@ -5,7 +5,7 @@ data:
   connectorSubtype: api
   connectorType: source
   definitionId: f1e4c7f6-db5c-4035-981f-d35ab4998794
-  dockerImageTag: 0.1.7
+  dockerImageTag: 0.1.8
   dockerRepository: airbyte/source-zenloop
   githubIssueLabel: source-zenloop
   icon: zenloop.svg

--- a/airbyte-integrations/connectors/source-zenloop/setup.py
+++ b/airbyte-integrations/connectors/source-zenloop/setup.py
@@ -6,7 +6,7 @@
 from setuptools import find_packages, setup
 
 MAIN_REQUIREMENTS = [
-    "airbyte-cdk>=0.42.0",
+    "airbyte-cdk>=0.42.1",
 ]
 
 TEST_REQUIREMENTS = [

--- a/docs/integrations/sources/zenloop.md
+++ b/docs/integrations/sources/zenloop.md
@@ -71,7 +71,8 @@ The Zenloop connector should not run into Zenloop API limitations under normal u
 
 | Version | Date       | Pull Request                                             | Subject                                                 |
 |:--------|:-----------| :------------------------------------------------------- |:--------------------------------------------------------|
-| 0.1.7   | 2023-06-15 | [27243](https://github.com/airbytehq/airbyte/pull/27243) | State per partition (breaking change - require reset)   |
+| 0.1.8   | 2023-06-22 | [27243](https://github.com/airbytehq/airbyte/pull/27243) | Improving error message on state discrepancy            |
+| 0.1.7   | 2023-06-22 | [27243](https://github.com/airbytehq/airbyte/pull/27243) | State per partition (breaking change - require reset)   |
 | 0.1.6   | 2023-03-06 | [23231](https://github.com/airbytehq/airbyte/pull/23231) | Publish using low-code CDK Beta version                 |
 | 0.1.5   | 2023-02-08 | [00000](https://github.com/airbytehq/airbyte/pull/00000) | Fix unhashable type in ZenloopSubstreamSlicer component |
 | 0.1.4   | 2022-11-18 | [19624](https://github.com/airbytehq/airbyte/pull/19624) | Migrate to low code                                     |


### PR DESCRIPTION
## What
[This message change](https://github.com/airbytehq/airbyte/commit/d9a5e2d873a036a464c955aec7f5809c3760f432#diff-cb24ede0b6b09974da9a16d25d8fa5f772ae497c742224f08dac1bdc1a903f9dR163) was not released before the merge so the zenloop connector did not benefit from it

## How
Releasing new patch version of CDK and updating it in zenloop

## 🚨 User Impact 🚨
Error messaging will be better than just "KeyError: states no in dict"
