### PR TITLE
connectors-ci: slugify branch name for better sanitization

### DIFF
--- a/tools/ci_connector_ops/ci_connector_ops/pipelines/commands/groups/connectors.py
+++ b/tools/ci_connector_ops/ci_connector_ops/pipelines/commands/groups/connectors.py
@@ -19,7 +19,7 @@ from ci_connector_ops.pipelines.github import update_global_commit_status_check_
 from ci_connector_ops.pipelines.pipelines.connectors import run_connectors_pipelines
 from ci_connector_ops.pipelines.publish import reorder_contexts, run_connector_publish_pipeline
 from ci_connector_ops.pipelines.tests import run_connector_test_pipeline
-from ci_connector_ops.pipelines.utils import DaggerPipelineCommand, get_modified_connectors, get_modified_metadata_files
+from ci_connector_ops.pipelines.utils import DaggerPipelineCommand, get_modified_connectors, get_modified_metadata_files, slugify
 from ci_connector_ops.utils import ConnectorLanguage, console, get_all_released_connectors
 from rich.logging import RichHandler
 from rich.table import Table
@@ -69,7 +69,7 @@ def render_report_output_prefix(ctx: click.Context) -> str:
     ci_context = ctx.obj["ci_context"]
     ci_job_key = ctx.obj["ci_job_key"] if ctx.obj.get("ci_job_key") else ci_context
 
-    sanitized_branch = git_branch.replace("/", "_")
+    sanitized_branch = slugify(git_branch.replace("/", "_"))
 
     # get the command name for the current context, if a group then prepend the parent command name
     invoked_subcommand = ctx.invoked_subcommand

--- a/tools/ci_connector_ops/tests/test_pipelines/test_commands/test_groups/test_connectors.py
+++ b/tools/ci_connector_ops/tests/test_pipelines/test_commands/test_groups/test_connectors.py
@@ -1,0 +1,100 @@
+#
+# Copyright (c) 2023 Airbyte, Inc., all rights reserved.
+#
+from unittest import mock
+
+import pytest
+from ci_connector_ops.pipelines.commands.groups import connectors
+
+
+@pytest.mark.parametrize(
+    "ctx, expected",
+    [
+        (
+            mock.MagicMock(
+                command_path="my_command_path",
+                invoked_subcommand="my_subcommand",
+                obj={
+                    "git_branch": "my_branch",
+                    "git_revision": "my_git_revision",
+                    "pipeline_start_timestamp": "my_pipeline_start_timestamp",
+                    "ci_context": "my_ci_context",
+                    "ci_job_key": None,
+                },
+            ),
+            "my_command_path/my_subcommand/my_ci_context/my_branch/my_pipeline_start_timestamp/my_git_revision",
+        ),
+        (
+            mock.MagicMock(
+                command_path="my_command_path",
+                invoked_subcommand="my_subcommand",
+                obj={
+                    "git_branch": "my_branch",
+                    "git_revision": "my_git_revision",
+                    "pipeline_start_timestamp": "my_pipeline_start_timestamp",
+                    "ci_context": "my_ci_context",
+                    "ci_job_key": "my_ci_job_key",
+                },
+            ),
+            "my_command_path/my_subcommand/my_ci_job_key/my_branch/my_pipeline_start_timestamp/my_git_revision",
+        ),
+        (
+            mock.MagicMock(
+                command_path="my_command_path another_command",
+                invoked_subcommand="my_subcommand",
+                obj={
+                    "git_branch": "my_branch",
+                    "git_revision": "my_git_revision",
+                    "pipeline_start_timestamp": "my_pipeline_start_timestamp",
+                    "ci_context": "my_ci_context",
+                    "ci_job_key": "my_ci_job_key",
+                },
+            ),
+            "my_command_path/another_command/my_subcommand/my_ci_job_key/my_branch/my_pipeline_start_timestamp/my_git_revision",
+        ),
+        (
+            mock.MagicMock(
+                command_path=None,
+                invoked_subcommand="my_subcommand",
+                obj={
+                    "git_branch": "my_branch",
+                    "git_revision": "my_git_revision",
+                    "pipeline_start_timestamp": "my_pipeline_start_timestamp",
+                    "ci_context": "my_ci_context",
+                    "ci_job_key": "my_ci_job_key",
+                },
+            ),
+            "my_subcommand/my_ci_job_key/my_branch/my_pipeline_start_timestamp/my_git_revision",
+        ),
+        (
+            mock.MagicMock(
+                command_path=None,
+                invoked_subcommand="my_subcommand",
+                obj={
+                    "git_branch": "my_branch/with/slashes",
+                    "git_revision": "my_git_revision",
+                    "pipeline_start_timestamp": "my_pipeline_start_timestamp",
+                    "ci_context": "my_ci_context",
+                    "ci_job_key": "my_ci_job_key",
+                },
+            ),
+            "my_subcommand/my_ci_job_key/my_branch_with_slashes/my_pipeline_start_timestamp/my_git_revision",
+        ),
+        (
+            mock.MagicMock(
+                command_path=None,
+                invoked_subcommand="my_subcommand",
+                obj={
+                    "git_branch": "my_branch/with/slashes#and!special@characters",
+                    "git_revision": "my_git_revision",
+                    "pipeline_start_timestamp": "my_pipeline_start_timestamp",
+                    "ci_context": "my_ci_context",
+                    "ci_job_key": "my_ci_job_key",
+                },
+            ),
+            "my_subcommand/my_ci_job_key/my_branch_with_slashesandspecialcharacters/my_pipeline_start_timestamp/my_git_revision",
+        ),
+    ],
+)
+def test_render_report_output_prefix(ctx, expected):
+    assert connectors.render_report_output_prefix(ctx) == expected


### PR DESCRIPTION
## What
Some generated prefix for report we upload to GCS are invalid URIs.
This is due to special characters being used on some branches eg https://github.com/airbytehq/airbyte/pull/27612

## How
* Slugify the branch name
* Unit test `render_report_output_prefix`