### PR TITLE
Switch to new support portal

### DIFF
--- a/docusaurus/docusaurus.config.js
+++ b/docusaurus/docusaurus.config.js
@@ -169,7 +169,7 @@ const config = {
             position: "left",
           },
           {
-            href: "https://discuss.airbyte.io/",
+            href: "https://support.airbyte.com/",
             label: "Support",
             position: "left",
           },


### PR DESCRIPTION
## What

Changes the "Support" link in the doc page to point to the new support portal.
