### PR TITLE
fix docker auth for metadata tests and orchestrator deploy

### DIFF
--- a/.github/actions/run-dagger-pipeline/action.yml
+++ b/.github/actions/run-dagger-pipeline/action.yml
@@ -54,6 +54,9 @@ inputs:
   spec_cache_gcs_credentials:
     description: "GCP credentials for GCS spec cache"
     required: false
+  dagster_cloud_metadata_api_token:
+    description: "Dagster Cloud API token"
+    required: false
   gcs_credentials:
     description: "GCP credentials for GCS"
     required: false
@@ -115,6 +118,7 @@ runs:
         CI_REPORT_BUCKET_NAME: ${{ inputs.report_bucket_name }}
         GCP_GSM_CREDENTIALS: ${{ inputs.gcp_gsm_credentials }}
         GCS_CREDENTIALS: ${{ inputs.gcs_credentials }}
+        DAGSTER_CLOUD_METADATA_API_TOKEN: ${{ inputs.dagster_cloud_metadata_api_token }}
         METADATA_SERVICE_BUCKET_NAME: ${{ inputs.metadata_service_bucket_name }}
         METADATA_SERVICE_GCS_CREDENTIALS: ${{ inputs.metadata_service_gcs_credentials }}
         PRODUCTION: ${{ inputs.production }}

--- a/.github/actions/run-dagger-pipeline/action.yml
+++ b/.github/actions/run-dagger-pipeline/action.yml
@@ -54,9 +54,6 @@ inputs:
   spec_cache_gcs_credentials:
     description: "GCP credentials for GCS spec cache"
     required: false
-  dagster_cloud_metadata_api_token:
-    description: "Dagster Cloud API token"
-    required: false
   gcs_credentials:
     description: "GCP credentials for GCS"
     required: false
@@ -118,7 +115,6 @@ runs:
         CI_REPORT_BUCKET_NAME: ${{ inputs.report_bucket_name }}
         GCP_GSM_CREDENTIALS: ${{ inputs.gcp_gsm_credentials }}
         GCS_CREDENTIALS: ${{ inputs.gcs_credentials }}
-        DAGSTER_CLOUD_METADATA_API_TOKEN: ${{ inputs.dagster_cloud_metadata_api_token }}
         METADATA_SERVICE_BUCKET_NAME: ${{ inputs.metadata_service_bucket_name }}
         METADATA_SERVICE_GCS_CREDENTIALS: ${{ inputs.metadata_service_gcs_credentials }}
         PRODUCTION: ${{ inputs.production }}

--- a/.github/workflows/metadata_service_deploy_orchestrator_dagger.yml
+++ b/.github/workflows/metadata_service_deploy_orchestrator_dagger.yml
@@ -22,5 +22,6 @@ jobs:
           docker_hub_username: ${{ secrets.DOCKER_HUB_USERNAME }}
           gcp_gsm_credentials: ${{ secrets.GCP_GSM_CREDENTIALS }}
           github_token: ${{ secrets.GH_PAT_MAINTENANCE_OCTAVIA }}
-          dagster_cloud_metadata_api_token: ${{ secrets.DAGSTER_CLOUD_METADATA_API_TOKEN }}
           subcommand: "metadata deploy orchestrator"
+        env:
+          DAGSTER_CLOUD_METADATA_API_TOKEN: ${{ secrets.DAGSTER_CLOUD_METADATA_API_TOKEN }}

--- a/.github/workflows/metadata_service_deploy_orchestrator_dagger.yml
+++ b/.github/workflows/metadata_service_deploy_orchestrator_dagger.yml
@@ -18,7 +18,9 @@ jobs:
         id: metadata-orchestrator-deploy-orchestrator-pipeline
         uses: ./.github/actions/run-dagger-pipeline
         with:
+          docker_hub_password: ${{ secrets.DOCKER_HUB_PASSWORD }}
+          docker_hub_username: ${{ secrets.DOCKER_HUB_USERNAME }}
+          gcp_gsm_credentials: ${{ secrets.GCP_GSM_CREDENTIALS }}
+          github_token: ${{ secrets.GH_PAT_MAINTENANCE_OCTAVIA }}
+          dagster_cloud_metadata_api_token: ${{ secrets.DAGSTER_CLOUD_METADATA_API_TOKEN }}
           subcommand: "metadata deploy orchestrator"
-        env:
-          DAGSTER_CLOUD_METADATA_API_TOKEN: ${{ secrets.DAGSTER_CLOUD_METADATA_API_TOKEN }}
-          CI_GITHUB_ACCESS_TOKEN: ${{ secrets.GH_PAT_MAINTENANCE_OCTAVIA }}

--- a/.github/workflows/metadata_service_deploy_orchestrator_dagger.yml
+++ b/.github/workflows/metadata_service_deploy_orchestrator_dagger.yml
@@ -19,6 +19,7 @@ jobs:
         uses: ./.github/actions/run-dagger-pipeline
         with:
           subcommand: "metadata deploy orchestrator"
+          context: "master"
           github_token: ${{ secrets.GH_PAT_MAINTENANCE_OCTAVIA }}
           docker_hub_username: ${{ secrets.DOCKER_HUB_USERNAME }}
           docker_hub_password: ${{ secrets.DOCKER_HUB_PASSWORD }}

--- a/.github/workflows/metadata_service_deploy_orchestrator_dagger.yml
+++ b/.github/workflows/metadata_service_deploy_orchestrator_dagger.yml
@@ -18,10 +18,10 @@ jobs:
         id: metadata-orchestrator-deploy-orchestrator-pipeline
         uses: ./.github/actions/run-dagger-pipeline
         with:
-          docker_hub_password: ${{ secrets.DOCKER_HUB_PASSWORD }}
-          docker_hub_username: ${{ secrets.DOCKER_HUB_USERNAME }}
-          gcp_gsm_credentials: ${{ secrets.GCP_GSM_CREDENTIALS }}
-          github_token: ${{ secrets.GH_PAT_MAINTENANCE_OCTAVIA }}
           subcommand: "metadata deploy orchestrator"
+          github_token: ${{ secrets.GH_PAT_MAINTENANCE_OCTAVIA }}
+          docker_hub_username: ${{ secrets.DOCKER_HUB_USERNAME }}
+          docker_hub_password: ${{ secrets.DOCKER_HUB_PASSWORD }}
+          gcp_gsm_credentials: ${{ secrets.GCP_GSM_CREDENTIALS }}
         env:
           DAGSTER_CLOUD_METADATA_API_TOKEN: ${{ secrets.DAGSTER_CLOUD_METADATA_API_TOKEN }}

--- a/.github/workflows/metadata_service_tests_dagger.yml
+++ b/.github/workflows/metadata_service_tests_dagger.yml
@@ -18,11 +18,19 @@ jobs:
         id: metadata-lib-test-pipeline
         uses: ./.github/actions/run-dagger-pipeline
         with:
-          subcommand: "metadata test lib"
           context: "pull_request"
+          docker_hub_password: ${{ secrets.DOCKER_HUB_PASSWORD }}
+          docker_hub_username: ${{ secrets.DOCKER_HUB_USERNAME }}
+          gcp_gsm_credentials: ${{ secrets.GCP_GSM_CREDENTIALS }}
+          github_token: ${{ secrets.GH_PAT_MAINTENANCE_OCTAVIA }}
+          subcommand: "metadata test lib"
       - name: Run test for the metadata orchestrator
         id: metadata-orchestrator-test-pipeline
         uses: ./.github/actions/run-dagger-pipeline
         with:
-          subcommand: "metadata test orchestrator"
           context: "pull_request"
+          docker_hub_password: ${{ secrets.DOCKER_HUB_PASSWORD }}
+          docker_hub_username: ${{ secrets.DOCKER_HUB_USERNAME }}
+          gcp_gsm_credentials: ${{ secrets.GCP_GSM_CREDENTIALS }}
+          github_token: ${{ secrets.GH_PAT_MAINTENANCE_OCTAVIA }}
+          subcommand: "metadata test orchestrator"

--- a/.github/workflows/metadata_service_tests_dagger.yml
+++ b/.github/workflows/metadata_service_tests_dagger.yml
@@ -18,19 +18,19 @@ jobs:
         id: metadata-lib-test-pipeline
         uses: ./.github/actions/run-dagger-pipeline
         with:
-          context: "pull_request"
-          docker_hub_password: ${{ secrets.DOCKER_HUB_PASSWORD }}
-          docker_hub_username: ${{ secrets.DOCKER_HUB_USERNAME }}
-          gcp_gsm_credentials: ${{ secrets.GCP_GSM_CREDENTIALS }}
-          github_token: ${{ secrets.GH_PAT_MAINTENANCE_OCTAVIA }}
           subcommand: "metadata test lib"
+          context: "pull_request"
+          github_token: ${{ secrets.GH_PAT_MAINTENANCE_OCTAVIA }}
+          docker_hub_username: ${{ secrets.DOCKER_HUB_USERNAME }}
+          docker_hub_password: ${{ secrets.DOCKER_HUB_PASSWORD }}
+          gcp_gsm_credentials: ${{ secrets.GCP_GSM_CREDENTIALS }}
       - name: Run test for the metadata orchestrator
         id: metadata-orchestrator-test-pipeline
         uses: ./.github/actions/run-dagger-pipeline
         with:
-          context: "pull_request"
-          docker_hub_password: ${{ secrets.DOCKER_HUB_PASSWORD }}
-          docker_hub_username: ${{ secrets.DOCKER_HUB_USERNAME }}
-          gcp_gsm_credentials: ${{ secrets.GCP_GSM_CREDENTIALS }}
-          github_token: ${{ secrets.GH_PAT_MAINTENANCE_OCTAVIA }}
           subcommand: "metadata test orchestrator"
+          context: "pull_request"
+          github_token: ${{ secrets.GH_PAT_MAINTENANCE_OCTAVIA }}
+          docker_hub_username: ${{ secrets.DOCKER_HUB_USERNAME }}
+          docker_hub_password: ${{ secrets.DOCKER_HUB_PASSWORD }}
+          gcp_gsm_credentials: ${{ secrets.GCP_GSM_CREDENTIALS }}

--- a/airbyte-ci/connectors/metadata_service/lib/tests/test_commands.py
+++ b/airbyte-ci/connectors/metadata_service/lib/tests/test_commands.py
@@ -18,6 +18,7 @@ def test_valid_metadata_yaml_files(valid_metadata_yaml_files):
         assert result.exit_code == 0, f"Validation failed for {file_path} with error: {result.output}"
 
 
+
 def test_invalid_metadata_yaml_files(invalid_metadata_yaml_files):
     runner = CliRunner()
 


### PR DESCRIPTION
## What
* Handle issues where metadata ci wasn't running because we were missing docker login info

## How
* Pass in the expected inputs to the run-dagger-pipeline action in all places which weren't yet
