### PR TITLE
Low-code CDK: Serialize request body as string for connector builder module

### DIFF
--- a/airbyte-cdk/python/airbyte_cdk/connector_builder/models.py
+++ b/airbyte-cdk/python/airbyte_cdk/connector_builder/models.py
@@ -17,7 +17,7 @@ class HttpResponse:
 class HttpRequest:
     url: str
     parameters: Optional[Dict[str, Any]]
-    body: Optional[Dict[str, Any]]
+    body: Optional[str] = None
     headers: Optional[Dict[str, Any]]
     http_method: str
 

--- a/airbyte-cdk/python/airbyte_cdk/connector_builder/models.py
+++ b/airbyte-cdk/python/airbyte_cdk/connector_builder/models.py
@@ -17,9 +17,9 @@ class HttpResponse:
 class HttpRequest:
     url: str
     parameters: Optional[Dict[str, Any]]
-    body: Optional[str] = None
     headers: Optional[Dict[str, Any]]
     http_method: str
+    body: Optional[str] = None
 
 
 @dataclass

--- a/airbyte-cdk/python/airbyte_cdk/sources/declarative/retrievers/simple_retriever.py
+++ b/airbyte-cdk/python/airbyte_cdk/sources/declarative/retrievers/simple_retriever.py
@@ -496,22 +496,14 @@ def _prepared_request_to_airbyte_message(request: requests.PreparedRequest) -> A
         "url": request.url,
         "http_method": request.method,
         "headers": dict(request.headers),
-        "body": _body_binary_string_to_dict(request.body),
+        "body": _normalize_body_string(request.body),
     }
     log_message = filter_secrets(f"request:{json.dumps(request_dict)}")
     return AirbyteMessage(type=MessageType.LOG, log=AirbyteLogMessage(level=Level.INFO, message=log_message))
 
 
-def _body_binary_string_to_dict(body_str: str) -> Optional[Mapping[str, str]]:
-    if body_str:
-        if isinstance(body_str, (bytes, bytearray)):
-            body_str = body_str.decode()
-        try:
-            return json.loads(body_str)
-        except JSONDecodeError:
-            return {k: v for k, v in [s.split("=") for s in body_str.split("&")]}
-    else:
-        return None
+def _normalize_body_string(body_str: Optional[Union[str, bytes]]) -> Optional[str]:
+    return body_str.decode() if isinstance(body_str, (bytes, bytearray)) else body_str
 
 
 def _response_to_airbyte_message(response: requests.Response) -> AirbyteMessage:

--- a/airbyte-cdk/python/airbyte_cdk/sources/declarative/retrievers/simple_retriever.py
+++ b/airbyte-cdk/python/airbyte_cdk/sources/declarative/retrievers/simple_retriever.py
@@ -5,7 +5,6 @@
 import json
 from dataclasses import InitVar, dataclass, field
 from itertools import islice
-from json import JSONDecodeError
 from typing import Any, Iterable, List, Mapping, MutableMapping, Optional, Union
 
 import requests

--- a/airbyte-cdk/python/unit_tests/sources/declarative/retrievers/test_simple_retriever.py
+++ b/airbyte-cdk/python/unit_tests/sources/declarative/retrievers/test_simple_retriever.py
@@ -574,7 +574,7 @@ def test_path(test_name, requester_path, paginator_path, expected_path):
                 type=Type.LOG,
                 log=AirbyteLogMessage(
                     level=Level.INFO,
-                    message='request:{"url": "https://airbyte.io/", "http_method": "GET", "headers": {"Content-Type": "application/json", "Content-Length": "24"}, "body": {"b1": "v1", "b2": "v2"}}',
+                    message='request:{"url": "https://airbyte.io/", "http_method": "GET", "headers": {"Content-Type": "application/json", "Content-Length": "24"}, "body": "{\\"b1\\": \\"v1\\", \\"b2\\": \\"v2\\"}"}',
                 ),
             ),
         ),
@@ -590,7 +590,7 @@ def test_path(test_name, requester_path, paginator_path, expected_path):
                 type=Type.LOG,
                 log=AirbyteLogMessage(
                     level=Level.INFO,
-                    message='request:{"url": "https://airbyte.io/?p1=v1&p2=v2", "http_method": "GET", "headers": {"Content-Type": "application/json", "h1": "v1", "Content-Length": "24"}, "body": {"b1": "v1", "b2": "v2"}}',
+                    message='request:{"url": "https://airbyte.io/?p1=v1&p2=v2", "http_method": "GET", "headers": {"Content-Type": "application/json", "h1": "v1", "Content-Length": "24"}, "body": "{\\"b1\\": \\"v1\\", \\"b2\\": \\"v2\\"}"}',
                 ),
             ),
         ),
@@ -598,7 +598,7 @@ def test_path(test_name, requester_path, paginator_path, expected_path):
             "test_get_request_with_request_body_data",
             HttpMethod.GET,
             "https://airbyte.io",
-            {"Content-Type": "application/json"},
+            {"Content-Type": "application/x-www-form-urlencoded"},
             {},
             {},
             {"b1": "v1", "b2": "v2"},
@@ -606,7 +606,7 @@ def test_path(test_name, requester_path, paginator_path, expected_path):
                 type=Type.LOG,
                 log=AirbyteLogMessage(
                     level=Level.INFO,
-                    message='request:{"url": "https://airbyte.io/", "http_method": "GET", "headers": {"Content-Type": "application/json", "Content-Length": "11"}, "body": {"b1": "v1", "b2": "v2"}}',
+                    message='request:{"url": "https://airbyte.io/", "http_method": "GET", "headers": {"Content-Type": "application/x-www-form-urlencoded", "Content-Length": "11"}, "body": "b1=v1&b2=v2"}',
                 ),
             ),
         ),


### PR DESCRIPTION
## What

First part of https://github.com/airbytehq/airbyte/issues/26832

## How

Handle the request body like the response body wrt serializing it for sending it out to the connector builder (just send a string and move the responsibility to parse it to the frontend.

I already prepared the PR on the other side: https://github.com/airbytehq/airbyte-platform-internal/pull/7470
