### PR TITLE
Normalization integration tests: set explicit cursor on cdc streams

### DIFF
--- a/airbyte-integrations/bases/base-normalization/integration_tests/resources/test_simple_streams/data_input/catalog.json
+++ b/airbyte-integrations/bases/base-normalization/integration_tests/resources/test_simple_streams/data_input/catalog.json
@@ -124,10 +124,10 @@
         },
         "supported_sync_modes": ["full_refresh", "incremental"],
         "source_defined_cursor": true,
-        "default_cursor_field": []
+        "default_cursor_field": ["_ab_cdc_updated_at"]
       },
       "sync_mode": "incremental",
-      "cursor_field": [],
+      "cursor_field": ["_ab_cdc_updated_at"],
       "destination_sync_mode": "append_dedup",
       "primary_key": [["id"]]
     },
@@ -156,10 +156,10 @@
         },
         "supported_sync_modes": ["full_refresh", "incremental"],
         "source_defined_cursor": true,
-        "default_cursor_field": []
+        "default_cursor_field": ["_ab_cdc_lsn"]
       },
       "sync_mode": "incremental",
-      "cursor_field": [],
+      "cursor_field": ["_ab_cdc_lsn"],
       "destination_sync_mode": "append_dedup",
       "primary_key": [["id"]]
     },
@@ -191,10 +191,10 @@
         },
         "supported_sync_modes": ["full_refresh", "incremental"],
         "source_defined_cursor": true,
-        "default_cursor_field": []
+        "default_cursor_field": ["_ab_cdc_lsn"]
       },
       "sync_mode": "full_refresh",
-      "cursor_field": [],
+      "cursor_field": ["_ab_cdc_lsn"],
       "destination_sync_mode": "append_dedup",
       "primary_key": [["id"]]
     },

--- a/airbyte-integrations/bases/base-normalization/integration_tests/resources/test_simple_streams/data_input/catalog_schema_change.json
+++ b/airbyte-integrations/bases/base-normalization/integration_tests/resources/test_simple_streams/data_input/catalog_schema_change.json
@@ -113,10 +113,10 @@
         },
         "supported_sync_modes": ["full_refresh", "incremental"],
         "source_defined_cursor": true,
-        "default_cursor_field": []
+        "default_cursor_field": ["_ab_cdc_lsn"]
       },
       "sync_mode": "incremental",
-      "cursor_field": [],
+      "cursor_field": ["_ab_cdc_lsn"],
       "destination_sync_mode": "append_dedup",
       "primary_key": [["id"]]
     },
@@ -145,10 +145,10 @@
         },
         "supported_sync_modes": ["full_refresh", "incremental"],
         "source_defined_cursor": true,
-        "default_cursor_field": []
+        "default_cursor_field": ["_ab_cdc_lsn"]
       },
       "sync_mode": "incremental",
-      "cursor_field": [],
+      "cursor_field": ["_ab_cdc_lsn"],
       "destination_sync_mode": "append_dedup",
       "primary_key": [["id"]]
     }


### PR DESCRIPTION
DB sources intend to set a cursor on their discovered catalogs. Update legacy normalization tests to reflect this and verify that we behave nicely.

I've already run some manual syncs (postgres->postgres, where source-postgres was built from https://github.com/airbytehq/airbyte/pull/27442) and everything looks good. This PR is just to run normalization tests on all destinations.