### PR TITLE
🤖 Cloud Availability updater: new connectors to deploy [20230625]

### DIFF
--- a/airbyte-integrations/connectors/source-coingecko-coins/metadata.yaml
+++ b/airbyte-integrations/connectors/source-coingecko-coins/metadata.yaml
@@ -10,7 +10,7 @@ data:
   name: CoinGecko Coins
   registries:
     cloud:
-      enabled: false # Did not pass acceptance tests
+      enabled: true  # Did not pass acceptance tests
     oss:
       enabled: true
   releaseStage: alpha


### PR DESCRIPTION
The Cloud Availability Updater decided that it's the right time to make the following 1 connectors available on Cloud!

# Promoted connectors
|connector_technical_name|connector_version|      connector_definition_id       |
|------------------------|-----------------|------------------------------------|
|source-coingecko-coins  |0.1.0            |9cdd4183-d0ba-40c3-aad3-6f46d4103974|

# Excluded but eligible connectors
|connector_technical_name|connector_version|connector_definition_id|
|------------------------|-----------------|-----------------------|

 ☝️ These eligible connectors are already in the definitions masks. They might have been explicitly pinned or excluded. We're not adding these for safety.