### PR TITLE
connectors-ci: per connector dockerd

### DIFF
--- a/tools/ci_connector_ops/ci_connector_ops/pipelines/format/__init__.py
+++ b/tools/ci_connector_ops/ci_connector_ops/pipelines/format/__init__.py
@@ -8,9 +8,7 @@ from __future__ import annotations
 import sys
 from typing import List, Optional
 
-import anyio
 import dagger
-from ci_connector_ops.pipelines.actions import environments
 from ci_connector_ops.pipelines.bases import ConnectorReport, Step, StepResult, StepStatus
 from ci_connector_ops.pipelines.contexts import ConnectorContext
 from ci_connector_ops.pipelines.format import java_connectors, python_connectors
@@ -85,18 +83,9 @@ async def run_connectors_format_pipelines(
 ) -> List[ConnectorContext]:
 
     async with dagger.Connection(dagger.Config(log_output=sys.stderr, execute_timeout=execute_timeout)) as dagger_client:
-        requires_dind = any(context.connector.language == ConnectorLanguage.JAVA for context in contexts)
-        dockerd_service = environments.with_global_dockerd_service(dagger_client)
-        async with anyio.create_task_group() as tg_main:
-            if requires_dind:
-                tg_main.start_soon(dockerd_service.exit_code)
-                await anyio.sleep(10)  # Wait for the docker service to be ready
-            for context in contexts:
-                context.dagger_client = dagger_client.pipeline(f"Format - {context.connector.technical_name}")
-                context.dockerd_service = dockerd_service
-                await run_connector_format_pipeline(context)
-            # When the connectors pipelines are done, we can stop the dockerd service
-            tg_main.cancel_scope.cancel()
+        for context in contexts:
+            context.dagger_client = dagger_client.pipeline(f"Format - {context.connector.technical_name}")
+            await run_connector_format_pipeline(context)
 
         await run_report_complete_pipeline(dagger_client, contexts)
 

--- a/tools/ci_connector_ops/ci_connector_ops/pipelines/pipelines/connectors.py
+++ b/tools/ci_connector_ops/ci_connector_ops/pipelines/pipelines/connectors.py
@@ -9,7 +9,6 @@ from typing import Callable, List, Optional
 
 import anyio
 import dagger
-from ci_connector_ops.pipelines.actions import environments
 from ci_connector_ops.pipelines.bases import NoOpStep, Report, StepResult, StepStatus
 from ci_connector_ops.pipelines.contexts import ConnectorContext, ContextState
 from ci_connector_ops.utils import ConnectorLanguage
@@ -82,25 +81,15 @@ async def run_connectors_pipelines(
     default_connectors_semaphore = anyio.Semaphore(concurrency)
     dagger_logs_output = sys.stderr if not dagger_logs_path else open(dagger_logs_path, "w")
     async with dagger.Connection(Config(log_output=dagger_logs_output, execute_timeout=execute_timeout)) as dagger_client:
-        # HACK: This is to get a long running dockerd service to be shared across all the connectors pipelines
-        # Using the "normal" service binding leads to restart of dockerd during pipeline run that can cause corrupted docker state
-        # See https://github.com/airbytehq/airbyte/issues/27233
-        dockerd_service = environments.with_global_dockerd_service(dagger_client)
-        async with anyio.create_task_group() as tg_main:
-            tg_main.start_soon(dockerd_service.exit_code)
-            await anyio.sleep(10)  # Wait for the docker service to be ready
-            async with anyio.create_task_group() as tg_connectors:
-                for context in contexts:
-                    context.dagger_client = dagger_client.pipeline(f"{pipeline_name} - {context.connector.technical_name}")
-                    context.dockerd_service = dockerd_service
-                    tg_connectors.start_soon(
-                        connector_pipeline,
-                        context,
-                        CONNECTOR_LANGUAGE_TO_FORCED_CONCURRENCY_MAPPING.get(context.connector.language, default_connectors_semaphore),
-                        *args,
-                    )
-            # When the connectors pipelines are done, we can stop the dockerd service
-            tg_main.cancel_scope.cancel()
+        async with anyio.create_task_group() as tg_connectors:
+            for context in contexts:
+                context.dagger_client = dagger_client.pipeline(f"{pipeline_name} - {context.connector.technical_name}")
+                tg_connectors.start_soon(
+                    connector_pipeline,
+                    context,
+                    CONNECTOR_LANGUAGE_TO_FORCED_CONCURRENCY_MAPPING.get(context.connector.language, default_connectors_semaphore),
+                    *args,
+                )
         await run_report_complete_pipeline(dagger_client, contexts)
 
     return contexts


### PR DESCRIPTION
## What
*Describe what the change is solving*
*It helps to add screenshots if it affects the frontend.*

## How
*Describe the solution*

## Recommended reading order
1. `x.java`
2. `y.python`

## 🚨 User Impact 🚨
*Are there any breaking changes? What is the end result perceived by the user?*

*For connector PRs, use this section to explain which type of semantic versioning bump occurs as a result of the changes. Refer to our [Semantic Versioning for Connectors](https://docs.airbyte.com/contributing-to-airbyte/#semantic-versioning-for-connectors) guidelines for more information. **Breaking changes to connectors must be documented by an Airbyte engineer (PR author, or reviewer for community PRs) by using the [Breaking Change Release Playbook](https://docs.google.com/document/d/1VYQggHbL_PN0dDDu7rCyzBLGRtX-R3cpwXaY8QxEgzw/edit).***

*If there are breaking changes, please merge this PR with the 🚨🚨 emoji so changelog authors can further highlight this if needed.*


## Pre-merge Actions
*Expand the relevant checklist and delete the others.*

<details><summary><strong>New Connector</strong></summary>

### Community member or Airbyter

- **Community member?** Grant edit access to maintainers ([instructions](https://docs.github.com/en/github/collaborating-with-pull-requests/working-with-forks/allowing-changes-to-a-pull-request-branch-created-from-a-fork#enabling-repository-maintainer-permissions-on-existing-pull-requests))
- Unit & integration tests added and passing. Community members, please provide proof of success locally e.g: screenshot or copy-paste unit, integration, and acceptance test output. To run acceptance tests for a Python connector, follow instructions in the README. For java connectors run `./gradlew :airbyte-integrations:connectors:<name>:integrationTest`.
- Connector version is set to `0.0.1`
    - `Dockerfile` has version `0.0.1`
- Documentation updated
    - Connector's `README.md`
    - Connector's `bootstrap.md`. See [description and examples](https://docs.google.com/document/d/1ypdgmwmEHWv-TrO4_YOQ7pAJGVrMp5BOkEVh831N260/edit?usp=sharing)
    - `docs/integrations/<source or destination>/<name>.md` including changelog with an entry for the initial version. See changelog [example](https://docs.airbyte.io/integrations/sources/stripe#changelog)
    - `docs/integrations/README.md`

### Airbyter

If this is a community PR, the Airbyte engineer reviewing this PR is responsible for the below items.

- Create a non-forked branch based on this PR and test the below items on it
- Build is successful
- If new credentials are required for use in CI, add them to GSM. [Instructions](https://docs.airbyte.io/connector-development#using-credentials-in-ci).

</details>

<details><summary><strong>Updating a connector</strong></summary>

### Community member or Airbyter

- Grant edit access to maintainers ([instructions](https://docs.github.com/en/github/collaborating-with-pull-requests/working-with-forks/allowing-changes-to-a-pull-request-branch-created-from-a-fork#enabling-repository-maintainer-permissions-on-existing-pull-requests))
- Unit & integration tests added


### Airbyter

If this is a community PR, the Airbyte engineer reviewing this PR is responsible for the below items.

- Create a non-forked branch based on this PR and test the below items on it
- Build is successful
- If new credentials are required for use in CI, add them to GSM. [Instructions](https://docs.airbyte.io/connector-development#using-credentials-in-ci).

</details>

<details><summary><strong>Connector Generator</strong></summary>

- Issue acceptance criteria met
- PR name follows [PR naming conventions](https://docs.airbyte.com/contributing-to-airbyte/issues-and-pull-requests#pull-request-title-convention)
- If adding a new generator, add it to the [list of scaffold modules being tested](https://github.com/airbytehq/airbyte/blob/master/airbyte-integrations/connector-templates/generator/build.gradle#L41)
- The generator test modules (all connectors with `-scaffold` in their name) have been updated with the latest scaffold by running `./gradlew :airbyte-integrations:connector-templates:generator:testScaffoldTemplates` then checking in your changes
- Documentation which references the generator is updated as needed

</details>
