### PR TITLE
Source Yandex Metrica: increase timeout

### DIFF
--- a/airbyte-integrations/connectors/source-yandex-metrica/acceptance-test-config.yml
+++ b/airbyte-integrations/connectors/source-yandex-metrica/acceptance-test-config.yml
@@ -19,10 +19,13 @@ tests:
         extra_fields: no
         exact_order: no
         extra_records: yes
+      timeout_seconds: 3600
   full_refresh:
     - config_path: "secrets/config.json"
       configured_catalog_path: "integration_tests/configured_catalog.json"
+      timeout_seconds: 3600
   incremental:
     - config_path: "secrets/config.json"
       configured_catalog_path: "integration_tests/configured_catalog.json"
       future_state_path: "integration_tests/abnormal_state.json"
+      timeout_seconds: 3600


### PR DESCRIPTION
## What

Fix Source Yandex Metrica Connector health report

## How
Increase test timeout

## Recommended reading order
1. `acceptance-test-config.yml`

## 🚨 User Impact 🚨

no breaking changes

## Pre-merge Actions

<details><summary><strong>Updating a connector</strong></summary>

### Community member or Airbyter

- Grant edit access to maintainers ([instructions](https://docs.github.com/en/github/collaborating-with-pull-requests/working-with-forks/allowing-changes-to-a-pull-request-branch-created-from-a-fork#enabling-repository-maintainer-permissions-on-existing-pull-requests))
- Unit & integration tests added


### Airbyter

If this is a community PR, the Airbyte engineer reviewing this PR is responsible for the below items.

- Create a non-forked branch based on this PR and test the below items on it
- Build is successful
- If new credentials are required for use in CI, add them to GSM. [Instructions](https://docs.airbyte.io/connector-development#using-credentials-in-ci).

</details>
