### PR TITLE
publish pipeline: mention connector ops instead of channel

### DIFF
--- a/tools/ci_connector_ops/ci_connector_ops/pipelines/contexts.py
+++ b/tools/ci_connector_ops/ci_connector_ops/pipelines/contexts.py
@@ -546,5 +546,5 @@ class PublishConnectorContext(ConnectorContext):
         if self.state is ContextState.SUCCESSFUL:
             message += f"⏲️ Run duration: {round(self.report.run_duration)}s\n"
         if self.state is ContextState.FAILURE:
-            message += "\ncc. <!channel>"
+            message += "\ncc. <!subteam^S0407GYHW4E>"  # @dev-connector-ops
         return message


### PR DESCRIPTION
## What
In case of pipeline failure we'd like to mention @dev-connector-ops instead of @channel 