### PR TITLE
weekly build: fix typo on workflow name

### DIFF
--- a/.github/workflows/connectors_weekly_build.yml
+++ b/.github/workflows/connectors_weekly_build.yml
@@ -14,11 +14,11 @@ on:
         default: --concurrency=3 --release-stage=alpha
         required: true
 
-run-name: "Test connectors: ${{ inputs.test-connectors-options || 'weekly build for Alpha connectors' }} - on ${{ inputs.runs-on || 'dev-large-runner' }}"
+run-name: "Test connectors: ${{ inputs.test-connectors-options || 'weekly build for Alpha connectors' }} - on ${{ inputs.runs-on || 'conn-nightly-xlarge-runner' }}"
 
 jobs:
   test_connectors:
-    name: "Test connectors: ${{ inputs.test-connectors-options || 'weekly build for Alpha connectors' }} - on ${{ inputs.runs-on || 'dev-large-runner' }}"
+    name: "Test connectors: ${{ inputs.test-connectors-options || 'weekly build for Alpha connectors' }} - on ${{ inputs.runs-on || 'conn-nightly-xlarge-runner' }}"
     timeout-minutes: 8640 # 6 days
     runs-on: ${{ inputs.runs-on || 'conn-nightly-xlarge-runner' }}
     steps:


### PR DESCRIPTION
## What
A legacy runner name was used in the workflow job names.
