### PR TITLE
Source Stripe: allow specifying API Version to use

### DIFF
--- a/airbyte-integrations/connectors/source-stripe/Dockerfile
+++ b/airbyte-integrations/connectors/source-stripe/Dockerfile
@@ -14,5 +14,5 @@ ENTRYPOINT ["python", "/airbyte/integration_code/main.py"]
 
 
 
-LABEL io.airbyte.version=3.10.0
+LABEL io.airbyte.version=3.11.0
 LABEL io.airbyte.name=airbyte/source-stripe

--- a/airbyte-integrations/connectors/source-stripe/source_stripe/source.py
+++ b/airbyte-integrations/connectors/source-stripe/source_stripe/source.py
@@ -75,6 +75,7 @@ class SourceStripe(AbstractSource):
             "account_id": config["account_id"],
             "start_date": start_date,
             "slice_range": config.get("slice_range"),
+            "version": config.get("api_version", "2017-08-15"),
         }
         incremental_args = {**args, "lookback_window_days": config.get("lookback_window_days")}
         return [

--- a/airbyte-integrations/connectors/source-stripe/source_stripe/spec.yaml
+++ b/airbyte-integrations/connectors/source-stripe/source_stripe/spec.yaml
@@ -56,3 +56,9 @@ connectionSpecification:
         the less requests will be made and faster the sync will be. On the other hand, the more seldom
         the state is persisted.
       order: 4
+    api_version:
+      type: string
+      title: Stripe API Version to use
+      default: "2017-08-15"
+      description: >-
+        The API Version to use when sending requests to Stripe

--- a/airbyte-integrations/connectors/source-stripe/source_stripe/streams.py
+++ b/airbyte-integrations/connectors/source-stripe/source_stripe/streams.py
@@ -29,11 +29,12 @@ class StripeStream(HttpStream, ABC):
     DEFAULT_SLICE_RANGE = 365
     transformer = TypeTransformer(TransformConfig.DefaultSchemaNormalization)
 
-    def __init__(self, start_date: int, account_id: str, slice_range: int = DEFAULT_SLICE_RANGE, **kwargs):
+    def __init__(self, start_date: int, account_id: str, api_version: str, slice_range: int = DEFAULT_SLICE_RANGE, **kwargs):
         super().__init__(**kwargs)
         self.account_id = account_id
         self.start_date = start_date
         self.slice_range = slice_range or self.DEFAULT_SLICE_RANGE
+        self.api_version = api_version
 
     def next_page_token(self, response: requests.Response) -> Optional[Mapping[str, Any]]:
         decoded_response = response.json()
@@ -56,9 +57,10 @@ class StripeStream(HttpStream, ABC):
         return params
 
     def request_headers(self, **kwargs) -> Mapping[str, Any]:
+        headers = {"Stripe-Version": self.api_version}
         if self.account_id:
-            return {"Stripe-Account": self.account_id}
-        return {}
+            headers["Stripe-Account"] = self.account_id
+        return headers
 
     def parse_response(self, response: requests.Response, **kwargs) -> Iterable[Mapping]:
         response_json = response.json()

--- a/airbyte-integrations/connectors/source-stripe/unit_tests/test_source.py
+++ b/airbyte-integrations/connectors/source-stripe/unit_tests/test_source.py
@@ -48,7 +48,9 @@ def test_source_streams():
 @pytest.fixture(name="config")
 def config_fixture():
     config = {"client_secret": "sk_test(live)_<secret>",
-              "account_id": "<account_id>", "start_date": "2020-05-01T00:00:00Z"}
+              "account_id": "<account_id>", "start_date":
+              "2020-05-01T00:00:00Z",
+              "api_version": "2017-08-15"}
     return config
 
 


### PR DESCRIPTION
## What
- Allow users to specify API Version to be used with Source Stripe, since different Stripe API Versions behave differently, and some users using specific features can only access their data if they use the appropriate API Version. For example, products and promotion_codes with `type: service` do not show up for API Versions before 2018-02-05.

## How
- Add a new config parameter `api_version` with default `2017-08-15` (which is the version used by default if the header is omitted. So right now the connector is using this API Version)

## Recommended reading order
1. `spec.yaml`
2. `source.py`
3. `streams.py`

## 🚨 User Impact 🚨
*Are there any breaking changes? What is the end result perceived by the user?*

No, there should be no breaking change as a result of this pull-request. The change is backward-compatible since the default API version is the same as the API version the connector uses without this header.

## Pre-merge Actions
*Expand the relevant checklist and delete the others.*

<strong>Updating a connector</strong>

### Community member or Airbyter

- Grant edit access to maintainers ([instructions](https://docs.github.com/en/github/collaborating-with-pull-requests/working-with-forks/allowing-changes-to-a-pull-request-branch-created-from-a-fork#enabling-repository-maintainer-permissions-on-existing-pull-requests))
- Unit & integration tests added


### Airbyter

If this is a community PR, the Airbyte engineer reviewing this PR is responsible for the below items.

- Create a non-forked branch based on this PR and test the below items on it
- Build is successful
- If new credentials are required for use in CI, add them to GSM. [Instructions](https://docs.airbyte.io/connector-development#using-credentials-in-ci).
