### PR TITLE
Remove methods from FiledBasedStreamReader and AbstractFileBasedStream interface

### DIFF
--- a/airbyte-cdk/python/airbyte_cdk/sources/file_based/file_based_stream_reader.py
+++ b/airbyte-cdk/python/airbyte_cdk/sources/file_based/file_based_stream_reader.py
@@ -3,9 +3,8 @@
 #
 
 from abc import abstractmethod
-from datetime import datetime
 from io import IOBase
-from typing import Iterable, List, Optional
+from typing import Iterable, List
 
 from airbyte_cdk.sources.file_based.remote_file import RemoteFile
 from pydantic import BaseModel
@@ -30,11 +29,9 @@ class AbstractFileBasedStreamReader(BaseModel):
     def get_matching_files(
         self,
         globs: List[str],
-        from_date: Optional[datetime] = None,
     ) -> Iterable[RemoteFile]:
         """
-        Return all files that match any of the globs. If a from_date provided,
-        return only files last modified after that date.
+        Return all files that match any of the globs.
 
         Example:
 

--- a/airbyte-cdk/python/airbyte_cdk/sources/file_based/stream/abstract_file_based_stream.py
+++ b/airbyte-cdk/python/airbyte_cdk/sources/file_based/stream/abstract_file_based_stream.py
@@ -101,20 +101,6 @@ class AbstractFileBasedStream(Stream):
         ...
 
     @abstractmethod
-    def list_files(self) -> List[RemoteFile]:
-        """
-        List all files that belong to the stream.
-        """
-        ...
-
-    @abstractmethod
-    def list_files_for_this_sync(self) -> Iterable[RemoteFile]:
-        """
-        Return the subset of this stream's files that will be read in the current sync.
-        """
-        ...
-
-    @abstractmethod
     def infer_schema(self, files: List[RemoteFile]) -> Mapping[str, Any]:
         """
         Infer the schema for files in the stream.

--- a/airbyte-cdk/python/airbyte_cdk/sources/file_based/stream/default_file_based_stream.py
+++ b/airbyte-cdk/python/airbyte_cdk/sources/file_based/stream/default_file_based_stream.py
@@ -109,9 +109,12 @@ class DefaultFileBasedStream(AbstractFileBasedStream, IncrementalMixin):
             type_mapping = self.infer_schema(files)
         return type_mapping
 
+    @cache
     def _list_files(self) -> List[RemoteFile]:
         """
         List all files that belong to the stream as defined by the stream's globs.
+        The output of this method is cached so we don't need to list the files more than once.
+        This means we won't pick up changes to the files during a sync.
         """
         return list(self._stream_reader.get_matching_files(self.config.globs))
 

--- a/airbyte-cdk/python/airbyte_cdk/sources/file_based/stream/default_file_based_stream.py
+++ b/airbyte-cdk/python/airbyte_cdk/sources/file_based/stream/default_file_based_stream.py
@@ -50,8 +50,8 @@ class DefaultFileBasedStream(AbstractFileBasedStream, IncrementalMixin):
         # Sort files by last_modified, uri and return them grouped by last_modified
         all_files = self._list_files()
         files_to_read = self._cursor.get_files_to_sync(all_files, self.logger)
-        files = sorted(files_to_read, key=lambda f: (f.last_modified, f.uri))
-        slices = [{"files": list(group[1])} for group in itertools.groupby(files, lambda f: f.last_modified)]
+        sorted_files_to_read = sorted(files_to_read, key=lambda f: (f.last_modified, f.uri))
+        slices = [{"files": list(group[1])} for group in itertools.groupby(sorted_files_to_read, lambda f: f.last_modified)]
         return slices
 
     def read_records_from_slice(self, stream_slice: StreamSlice) -> Iterable[Mapping[str, Any]]:

--- a/airbyte-cdk/python/airbyte_cdk/sources/file_based/stream/default_file_based_stream.py
+++ b/airbyte-cdk/python/airbyte_cdk/sources/file_based/stream/default_file_based_stream.py
@@ -48,7 +48,9 @@ class DefaultFileBasedStream(AbstractFileBasedStream, IncrementalMixin):
 
     def compute_slices(self) -> Iterable[Optional[Mapping[str, Any]]]:
         # Sort files by last_modified, uri and return them grouped by last_modified
-        files = sorted(self.list_files_for_this_sync(), key=lambda f: (f.last_modified, f.uri))
+        all_files = self._list_files()
+        files_to_read = self._cursor.get_files_to_sync(all_files, self.logger)
+        files = sorted(files_to_read, key=lambda f: (f.last_modified, f.uri))
         slices = [{"files": list(group[1])} for group in itertools.groupby(files, lambda f: f.last_modified)]
         return slices
 
@@ -90,16 +92,15 @@ class DefaultFileBasedStream(AbstractFileBasedStream, IncrementalMixin):
             self.ab_last_mod_col: {"type": "string"},
             self.ab_file_name_col: {"type": "string"},
         }
-        schema = self.get_raw_json_schema()
+        schema = self._get_raw_json_schema()
         schema["properties"] = {**extra_fields, **schema.get("properties", {})}
         return schema
 
-    @cache
-    def get_raw_json_schema(self) -> Mapping[str, Any]:
+    def _get_raw_json_schema(self) -> Mapping[str, Any]:
         if self.config.input_schema:
             type_mapping = self.config.input_schema
         else:
-            files = self.list_files()
+            files = self._list_files()
             max_n_files_for_schema_inference = self._discovery_policy.max_n_files_for_schema_inference
             if len(files) > max_n_files_for_schema_inference:
                 # Use the most recent files for schema inference, so we pick up schema changes during discovery.
@@ -108,24 +109,11 @@ class DefaultFileBasedStream(AbstractFileBasedStream, IncrementalMixin):
             type_mapping = self.infer_schema(files)
         return type_mapping
 
-    @cache
-    def list_files(self) -> List[RemoteFile]:
+    def _list_files(self) -> List[RemoteFile]:
         """
         List all files that belong to the stream as defined by the stream's globs.
         """
         return list(self._stream_reader.get_matching_files(self.config.globs))
-
-    def list_files_for_this_sync(self) -> Iterable[RemoteFile]:
-        """
-        Return the subset of this stream's files that will be read in the current sync.
-
-        Specifically:
-
-        - Take the output of `list_files`
-        - Remove files that have already been read in previous syncs, according to the state
-        """
-        all_files = self._stream_reader.get_matching_files(self.config.globs, self._cursor.get_start_time())
-        yield from self._cursor.get_files_to_sync(all_files, self.logger)
 
     def infer_schema(self, files: List[RemoteFile]) -> Mapping[str, Any]:
         loop = asyncio.get_event_loop()

--- a/airbyte-cdk/python/unit_tests/sources/file_based/in_memory_files_source.py
+++ b/airbyte-cdk/python/unit_tests/sources/file_based/in_memory_files_source.py
@@ -6,7 +6,7 @@ import csv
 import io
 from datetime import datetime
 from io import IOBase
-from typing import Dict, Iterable, List, Optional, Type
+from typing import Dict, Iterable, List, Type
 
 from airbyte_cdk.sources.file_based.discovery_policy import AbstractDiscoveryPolicy
 from airbyte_cdk.sources.file_based.file_based_source import FileBasedSource
@@ -45,7 +45,6 @@ class InMemoryFilesStreamReader(AbstractFileBasedStreamReader):
     def get_matching_files(
         self,
         globs: List[str],
-        from_date: Optional[datetime] = None,
     ) -> Iterable[RemoteFile]:
         yield from AbstractFileBasedStreamReader.filter_files_by_globs([
             RemoteFile(uri=f, last_modified=datetime.strptime(data["last_modified"], "%Y-%m-%dT%H:%M:%S.%fZ"), file_type=self.file_type)


### PR DESCRIPTION
## What
Refactoring of some of the file based classes as per comments in https://github.com/airbytehq/airbyte/pull/27382

## How
* Remove `from_date` from the `FiledBasedStreamReader` interface since the parameter is not used
* Remove `list_files` and `list_files_for_this_sync` from the `AbstractFileBasedStream` interface since the methods aren't used
* Make `DefaultFileBasedStream._get_raw_json_schema` and `DefaultFileBasedStream._list_files` private

## Recommended reading order
1. `x.java`
2. `y.python`

## 🚨 User Impact 🚨
*Are there any breaking changes? What is the end result perceived by the user?*

*For connector PRs, use this section to explain which type of semantic versioning bump occurs as a result of the changes. Refer to our [Semantic Versioning for Connectors](https://docs.airbyte.com/contributing-to-airbyte/#semantic-versioning-for-connectors) guidelines for more information. **Breaking changes to connectors must be documented by an Airbyte engineer (PR author, or reviewer for community PRs) by using the [Breaking Change Release Playbook](https://docs.google.com/document/d/1VYQggHbL_PN0dDDu7rCyzBLGRtX-R3cpwXaY8QxEgzw/edit).***

*If there are breaking changes, please merge this PR with the 🚨🚨 emoji so changelog authors can further highlight this if needed.*


## Pre-merge Actions
*Expand the relevant checklist and delete the others.*

<details><summary><strong>New Connector</strong></summary>

### Community member or Airbyter

- **Community member?** Grant edit access to maintainers ([instructions](https://docs.github.com/en/github/collaborating-with-pull-requests/working-with-forks/allowing-changes-to-a-pull-request-branch-created-from-a-fork#enabling-repository-maintainer-permissions-on-existing-pull-requests))
- Unit & integration tests added and passing. Community members, please provide proof of success locally e.g: screenshot or copy-paste unit, integration, and acceptance test output. To run acceptance tests for a Python connector, follow instructions in the README. For java connectors run `./gradlew :airbyte-integrations:connectors:<name>:integrationTest`.
- Connector version is set to `0.0.1`
    - `Dockerfile` has version `0.0.1`
- Documentation updated
    - Connector's `README.md`
    - Connector's `bootstrap.md`. See [description and examples](https://docs.google.com/document/d/1ypdgmwmEHWv-TrO4_YOQ7pAJGVrMp5BOkEVh831N260/edit?usp=sharing)
    - `docs/integrations/<source or destination>/<name>.md` including changelog with an entry for the initial version. See changelog [example](https://docs.airbyte.io/integrations/sources/stripe#changelog)
    - `docs/integrations/README.md`

### Airbyter

If this is a community PR, the Airbyte engineer reviewing this PR is responsible for the below items.

- Create a non-forked branch based on this PR and test the below items on it
- Build is successful
- If new credentials are required for use in CI, add them to GSM. [Instructions](https://docs.airbyte.io/connector-development#using-credentials-in-ci).

</details>

<details><summary><strong>Updating a connector</strong></summary>

### Community member or Airbyter

- Grant edit access to maintainers ([instructions](https://docs.github.com/en/github/collaborating-with-pull-requests/working-with-forks/allowing-changes-to-a-pull-request-branch-created-from-a-fork#enabling-repository-maintainer-permissions-on-existing-pull-requests))
- Unit & integration tests added


### Airbyter

If this is a community PR, the Airbyte engineer reviewing this PR is responsible for the below items.

- Create a non-forked branch based on this PR and test the below items on it
- Build is successful
- If new credentials are required for use in CI, add them to GSM. [Instructions](https://docs.airbyte.io/connector-development#using-credentials-in-ci).

</details>

<details><summary><strong>Connector Generator</strong></summary>

- Issue acceptance criteria met
- PR name follows [PR naming conventions](https://docs.airbyte.com/contributing-to-airbyte/issues-and-pull-requests#pull-request-title-convention)
- If adding a new generator, add it to the [list of scaffold modules being tested](https://github.com/airbytehq/airbyte/blob/master/airbyte-integrations/connector-templates/generator/build.gradle#L41)
- The generator test modules (all connectors with `-scaffold` in their name) have been updated with the latest scaffold by running `./gradlew :airbyte-integrations:connector-templates:generator:testScaffoldTemplates` then checking in your changes
- Documentation which references the generator is updated as needed

</details>
