### PR TITLE
connectors-ci: switch back to large-runner

### DIFF
--- a/.github/workflows/connectors_tests.yml
+++ b/.github/workflows/connectors_tests.yml
@@ -11,7 +11,7 @@ on:
         default: "--modified"
       runner:
         description: "The runner to use for this job"
-        default: "conn-prod-xlarge-runner"
+        default: "dev-large-runner"
   pull_request:
     types:
       - opened
@@ -21,7 +21,7 @@ jobs:
   connectors_ci:
     name: Connectors CI
     timeout-minutes: 1440 # 24 hours
-    runs-on: ${{ inputs.runner || 'conn-prod-xlarge-runner'}}
+    runs-on: ${{ inputs.runner || 'dev-large-runner'}}
     steps:
       - name: Checkout Airbyte
         uses: actions/checkout@v3

--- a/.github/workflows/publish_connectors.yml
+++ b/.github/workflows/publish_connectors.yml
@@ -17,7 +17,7 @@ on:
 jobs:
   publish_connectors:
     name: Publish connectors
-    runs-on: conn-prod-xlarge-runner
+    runs-on: large-runner
     steps:
       - name: Checkout Airbyte
         uses: actions/checkout@v3


### PR DESCRIPTION
## What
Seems like targeting the new runners leads to infinite waiting for a runner to be available.
See https://airbytehq-team.slack.com/archives/C046KQF5GBT/p1687839804807449
