### PR TITLE
connectors-ci: change report bucket

### DIFF
--- a/.github/actions/run-dagger-pipeline/action.yml
+++ b/.github/actions/run-dagger-pipeline/action.yml
@@ -26,7 +26,7 @@ inputs:
   report_bucket_name:
     description: "Bucket name for CI reports"
     required: false
-    default: "airbyte-ci-reports"
+    default: "airbyte-ci-reports-multi"
   gcp_gsm_credentials:
     description: "GCP credentials for GCP Secret Manager"
     required: false


### PR DESCRIPTION
## What
The `airbyte-ci-reports` bucket was not hosted in multi region mode. This prevented ingestion of its data as an external bigquery table.

## How
* We manually created a new bucket `airbyte-ci-reports-multi` to which we transferred the old data and set the same permissions.
