### PR TITLE
Source Airtable: fix test config

### DIFF
--- a/airbyte-integrations/connectors/source-airtable/acceptance-test-config.yml
+++ b/airbyte-integrations/connectors/source-airtable/acceptance-test-config.yml
@@ -17,7 +17,7 @@ acceptance_tests:
       - config_path: "integration_tests/invalid_config_oauth.json"
         status: "failed"
       - config_path: "integration_tests/invalid_config_oauth_missing_fields.json"
-        status: "exception"
+        status: "failed"
   discovery:
     tests:
       - config_path: "secrets/config.json"

--- a/airbyte-integrations/connectors/source-airtable/acceptance-test-config.yml
+++ b/airbyte-integrations/connectors/source-airtable/acceptance-test-config.yml
@@ -17,7 +17,7 @@ acceptance_tests:
       - config_path: "integration_tests/invalid_config_oauth.json"
         status: "failed"
       - config_path: "integration_tests/invalid_config_oauth_missing_fields.json"
-        status: "failed"
+        status: "exception"
   discovery:
     tests:
       - config_path: "secrets/config.json"

--- a/airbyte-integrations/connectors/source-airtable/acceptance-test-config.yml
+++ b/airbyte-integrations/connectors/source-airtable/acceptance-test-config.yml
@@ -21,11 +21,7 @@ acceptance_tests:
   discovery:
     tests:
       - config_path: "secrets/config.json"
-        backward_compatibility_tests_config:
-          disable_for_version: 2.0.4
       - config_path: "secrets/config_oauth.json"
-        backward_compatibility_tests_config:
-          disable_for_version: 2.0.4
   basic_read:
     tests:
       - config_path: "secrets/config.json"


### PR DESCRIPTION
## What

Fix Source Airtable Connector health report

## How
Fix test config

## Recommended reading order
1. `acceptance-test-config.yml`

## 🚨 User Impact 🚨

no breaking changes

## Pre-merge Actions

<details><summary><strong>Updating a connector</strong></summary>

### Community member or Airbyter

- Grant edit access to maintainers ([instructions](https://docs.github.com/en/github/collaborating-with-pull-requests/working-with-forks/allowing-changes-to-a-pull-request-branch-created-from-a-fork#enabling-repository-maintainer-permissions-on-existing-pull-requests))
- Unit & integration tests added


### Airbyter

If this is a community PR, the Airbyte engineer reviewing this PR is responsible for the below items.

- Create a non-forked branch based on this PR and test the below items on it
- Build is successful
- If new credentials are required for use in CI, add them to GSM. [Instructions](https://docs.airbyte.io/connector-development#using-credentials-in-ci).

</details>
