### PR TITLE
🐛 Source Zenloop: update following state management changes in the CDK

### DIFF
--- a/airbyte-integrations/connectors/source-zenloop/Dockerfile
+++ b/airbyte-integrations/connectors/source-zenloop/Dockerfile
@@ -34,5 +34,5 @@ COPY source_zenloop ./source_zenloop
 ENV AIRBYTE_ENTRYPOINT "python /airbyte/integration_code/main.py"
 ENTRYPOINT ["python", "/airbyte/integration_code/main.py"]
 
-LABEL io.airbyte.version=0.1.8
+LABEL io.airbyte.version=0.1.9
 LABEL io.airbyte.name=airbyte/source-zenloop

--- a/airbyte-integrations/connectors/source-zenloop/metadata.yaml
+++ b/airbyte-integrations/connectors/source-zenloop/metadata.yaml
@@ -5,7 +5,7 @@ data:
   connectorSubtype: api
   connectorType: source
   definitionId: f1e4c7f6-db5c-4035-981f-d35ab4998794
-  dockerImageTag: 0.1.8
+  dockerImageTag: 0.1.9
   dockerRepository: airbyte/source-zenloop
   githubIssueLabel: source-zenloop
   icon: zenloop.svg

--- a/airbyte-integrations/connectors/source-zenloop/setup.py
+++ b/airbyte-integrations/connectors/source-zenloop/setup.py
@@ -6,7 +6,7 @@
 from setuptools import find_packages, setup
 
 MAIN_REQUIREMENTS = [
-    "airbyte-cdk>=0.42.1",
+    "airbyte-cdk>=0.43.2",
 ]
 
 TEST_REQUIREMENTS = [

--- a/airbyte-integrations/connectors/source-zenloop/source_zenloop/components.py
+++ b/airbyte-integrations/connectors/source-zenloop/source_zenloop/components.py
@@ -16,7 +16,7 @@ class ZenloopPartitionRouter(SubstreamPartitionRouter):
 
     config: Config
 
-    def stream_slices(self, sync_mode: SyncMode, stream_state: StreamState) -> Iterable[StreamSlice]:
+    def stream_slices(self) -> Iterable[StreamSlice]:
         """
 
         config_parent_field : parent field name in config
@@ -29,7 +29,7 @@ class ZenloopPartitionRouter(SubstreamPartitionRouter):
         custom_stream_state_value = self.config.get(parent_field)
 
         if not custom_stream_state_value:
-            yield from super().stream_slices(sync_mode, stream_state)
+            yield from super().stream_slices()
         else:
             for parent_stream_config in self.parent_stream_configs:
                 stream_state_field = parent_stream_config.partition_field.eval(self.config)

--- a/airbyte-integrations/connectors/source-zenloop/source_zenloop/components.py
+++ b/airbyte-integrations/connectors/source-zenloop/source_zenloop/components.py
@@ -7,7 +7,7 @@ from dataclasses import dataclass
 from typing import Iterable
 
 from airbyte_cdk.sources.declarative.partition_routers import SubstreamPartitionRouter
-from airbyte_cdk.sources.declarative.types import Config, StreamSlice, StreamState
+from airbyte_cdk.sources.declarative.types import Config, StreamSlice
 
 
 @dataclass

--- a/airbyte-integrations/connectors/source-zenloop/source_zenloop/components.py
+++ b/airbyte-integrations/connectors/source-zenloop/source_zenloop/components.py
@@ -6,7 +6,6 @@
 from dataclasses import dataclass
 from typing import Iterable
 
-from airbyte_cdk.models import SyncMode
 from airbyte_cdk.sources.declarative.partition_routers import SubstreamPartitionRouter
 from airbyte_cdk.sources.declarative.types import Config, StreamSlice, StreamState
 

--- a/docs/integrations/sources/zenloop.md
+++ b/docs/integrations/sources/zenloop.md
@@ -71,7 +71,7 @@ The Zenloop connector should not run into Zenloop API limitations under normal u
 
 | Version | Date       | Pull Request                                             | Subject                                                 |
 |:--------|:-----------| :------------------------------------------------------- |:--------------------------------------------------------|
-| 0.1.9   | 2023-06-28 | [27243](https://github.com/airbytehq/airbyte/pull/27243) | Update following state breaking changes                 |
+| 0.1.9   | 2023-06-28 | [27761](https://github.com/airbytehq/airbyte/pull/27761) | Update following state breaking changes                 |
 | 0.1.8   | 2023-06-22 | [27243](https://github.com/airbytehq/airbyte/pull/27243) | Improving error message on state discrepancy            |
 | 0.1.7   | 2023-06-22 | [27243](https://github.com/airbytehq/airbyte/pull/27243) | State per partition (breaking change - require reset)   |
 | 0.1.6   | 2023-03-06 | [23231](https://github.com/airbytehq/airbyte/pull/23231) | Publish using low-code CDK Beta version                 |

--- a/docs/integrations/sources/zenloop.md
+++ b/docs/integrations/sources/zenloop.md
@@ -71,6 +71,7 @@ The Zenloop connector should not run into Zenloop API limitations under normal u
 
 | Version | Date       | Pull Request                                             | Subject                                                 |
 |:--------|:-----------| :------------------------------------------------------- |:--------------------------------------------------------|
+| 0.1.9   | 2023-06-28 | [27243](https://github.com/airbytehq/airbyte/pull/27243) | Update following state breaking changes                 |
 | 0.1.8   | 2023-06-22 | [27243](https://github.com/airbytehq/airbyte/pull/27243) | Improving error message on state discrepancy            |
 | 0.1.7   | 2023-06-22 | [27243](https://github.com/airbytehq/airbyte/pull/27243) | State per partition (breaking change - require reset)   |
 | 0.1.6   | 2023-03-06 | [23231](https://github.com/airbytehq/airbyte/pull/23231) | Publish using low-code CDK Beta version                 |


### PR DESCRIPTION
## What
Breaking changes were done as part of https://github.com/airbytehq/airbyte/commit/a45a1e33413eacccb2b8a83450d1638c48fd2042. This PR fixes the breaking changes for zenloop.

## How
Updating the interfaces that were affected by breaking changes.

## 🚨 User Impact 🚨
None as the code should have the exact same behavior
