### PR TITLE
Metadata: Persist Registry entries

### DIFF
--- a/airbyte-ci/connectors/metadata_service/lib/metadata_service/validators/metadata_validator.py
+++ b/airbyte-ci/connectors/metadata_service/lib/metadata_service/validators/metadata_validator.py
@@ -75,8 +75,7 @@ POST_UPLOAD_VALIDATORS = PRE_UPLOAD_VALIDATORS + [
 
 
 def validate_and_load(
-    file_path: pathlib.Path,
-    validators_to_run: List[Validator]
+    file_path: pathlib.Path, validators_to_run: List[Validator]
 ) -> Tuple[Optional[ConnectorMetadataDefinitionV0], Optional[ValidationError]]:
     """Load a metadata file from a path (runs jsonschema validation) and run optional extra validators.
 

--- a/airbyte-ci/connectors/metadata_service/lib/tests/fixtures/__init__.py
+++ b/airbyte-ci/connectors/metadata_service/lib/tests/fixtures/__init__.py
@@ -8,6 +8,7 @@ def list_all_paths_in_fixture_directory(folder_name: str) -> List[str]:
     for root, dirs, files in os.walk(file_path):
         return [os.path.join(root, file_name) for file_name in files]
 
+
 @pytest.fixture(scope="session")
 def valid_metadata_yaml_files() -> List[str]:
     return list_all_paths_in_fixture_directory("metadata_validate/valid")

--- a/airbyte-ci/connectors/metadata_service/orchestrator/orchestrator/__init__.py
+++ b/airbyte-ci/connectors/metadata_service/orchestrator/orchestrator/__init__.py
@@ -17,7 +17,7 @@ from orchestrator.assets import (
     metadata,
 )
 
-from orchestrator.jobs.registry import generate_registry_reports, generate_registry
+from orchestrator.jobs.registry import generate_registry_reports, generate_registry, generate_registry_entry
 from orchestrator.jobs.connector_test_report import generate_nightly_reports, generate_connector_test_summary_reports
 from orchestrator.sensors.registry import registry_updated_sensor
 from orchestrator.sensors.gcs import new_gcs_blobs_sensor, new_gcs_blobs_partition_sensor
@@ -107,7 +107,7 @@ SENSORS = [
         interval=(1 * 60 * 60),
     ),
     new_gcs_blobs_partition_sensor(
-        job=generate_registry,
+        job=generate_registry_entry,
         resources_def=RESOURCES,
         partitions_def=registry_entry.metadata_partitions_def,
         gcs_blobs_resource_key="latest_metadata_file_blobs",

--- a/airbyte-ci/connectors/metadata_service/orchestrator/orchestrator/__init__.py
+++ b/airbyte-ci/connectors/metadata_service/orchestrator/orchestrator/__init__.py
@@ -69,6 +69,9 @@ RESOURCES = {
     "registry_directory_manager": gcs_file_manager.configured({"gcs_bucket": {"env": "METADATA_BUCKET"}, "prefix": REGISTRIES_FOLDER}),
     "registry_report_directory_manager": gcs_file_manager.configured({"gcs_bucket": {"env": "METADATA_BUCKET"}, "prefix": REPORT_FOLDER}),
     "root_metadata_directory_manager": gcs_file_manager.configured({"gcs_bucket": {"env": "METADATA_BUCKET"}, "prefix": ""}),
+    "all_metadata_file_blobs": gcs_directory_blobs.configured(
+        {"gcs_bucket": {"env": "METADATA_BUCKET"}, "prefix": METADATA_FOLDER, "match_regex": f".*/{METADATA_FILE_NAME}$"}
+    ),
     "latest_metadata_file_blobs": gcs_directory_blobs.configured(
         {"gcs_bucket": {"env": "METADATA_BUCKET"}, "prefix": METADATA_FOLDER, "match_regex": f".*latest/{METADATA_FILE_NAME}$"}
     ),
@@ -123,7 +126,7 @@ SENSORS = [
         job=generate_registry_entry,
         resources_def=RESOURCES,
         partitions_def=registry_entry.metadata_partitions_def,
-        gcs_blobs_resource_key="latest_metadata_file_blobs",
+        gcs_blobs_resource_key="all_metadata_file_blobs",
         interval=30,
     ),
 ]

--- a/airbyte-ci/connectors/metadata_service/orchestrator/orchestrator/__init__.py
+++ b/airbyte-ci/connectors/metadata_service/orchestrator/orchestrator/__init__.py
@@ -68,6 +68,7 @@ RESOURCES = {
     ),
     "registry_directory_manager": gcs_file_manager.configured({"gcs_bucket": {"env": "METADATA_BUCKET"}, "prefix": REGISTRIES_FOLDER}),
     "registry_report_directory_manager": gcs_file_manager.configured({"gcs_bucket": {"env": "METADATA_BUCKET"}, "prefix": REPORT_FOLDER}),
+    "root_metadata_directory_manager": gcs_file_manager.configured({"gcs_bucket": {"env": "METADATA_BUCKET"}, "prefix": ""}),
     "latest_metadata_file_blobs": gcs_directory_blobs.configured(
         {"gcs_bucket": {"env": "METADATA_BUCKET"}, "prefix": METADATA_FOLDER, "match_regex": f".*latest/{METADATA_FILE_NAME}$"}
     ),

--- a/airbyte-ci/connectors/metadata_service/orchestrator/orchestrator/__init__.py
+++ b/airbyte-ci/connectors/metadata_service/orchestrator/orchestrator/__init__.py
@@ -13,13 +13,14 @@ from orchestrator.assets import (
     spec_cache,
     registry,
     registry_report,
+    registry_entry,
     metadata,
 )
 
 from orchestrator.jobs.registry import generate_registry_reports, generate_registry
 from orchestrator.jobs.connector_test_report import generate_nightly_reports, generate_connector_test_summary_reports
 from orchestrator.sensors.registry import registry_updated_sensor
-from orchestrator.sensors.gcs import new_gcs_blobs_sensor
+from orchestrator.sensors.gcs import new_gcs_blobs_sensor, new_gcs_blobs_partition_sensor
 
 from orchestrator.config import (
     REPORT_FOLDER,
@@ -44,6 +45,7 @@ ASSETS = load_assets_from_modules(
         registry,
         registry_report,
         connector_test_report,
+        registry_entry,
     ]
 )
 
@@ -104,6 +106,13 @@ SENSORS = [
         gcs_blobs_resource_key="latest_nightly_complete_file_blobs",
         interval=(1 * 60 * 60),
     ),
+    new_gcs_blobs_partition_sensor(
+        job=generate_registry,
+        resources_def=RESOURCES,
+        partitions_def=registry_entry.metadata_partitions_def,
+        gcs_blobs_resource_key="latest_metadata_file_blobs",
+        interval=30,
+    )
 ]
 
 SCHEDULES = [ScheduleDefinition(job=generate_connector_test_summary_reports, cron_schedule="@hourly")]

--- a/airbyte-ci/connectors/metadata_service/orchestrator/orchestrator/__init__.py
+++ b/airbyte-ci/connectors/metadata_service/orchestrator/orchestrator/__init__.py
@@ -17,7 +17,7 @@ from orchestrator.assets import (
     metadata,
 )
 
-from orchestrator.jobs.registry import generate_registry_reports,  generate_oss_registry, generate_cloud_registry, generate_registry_entry
+from orchestrator.jobs.registry import generate_registry_reports, generate_oss_registry, generate_cloud_registry, generate_registry_entry
 from orchestrator.jobs.connector_test_report import generate_nightly_reports, generate_connector_test_summary_reports
 from orchestrator.sensors.registry import registry_updated_sensor
 from orchestrator.sensors.gcs import new_gcs_blobs_sensor, new_gcs_blobs_partition_sensor
@@ -125,7 +125,7 @@ SENSORS = [
         partitions_def=registry_entry.metadata_partitions_def,
         gcs_blobs_resource_key="latest_metadata_file_blobs",
         interval=30,
-    )
+    ),
 ]
 
 SCHEDULES = [ScheduleDefinition(job=generate_connector_test_summary_reports, cron_schedule="@hourly")]

--- a/airbyte-ci/connectors/metadata_service/orchestrator/orchestrator/__init__.py
+++ b/airbyte-ci/connectors/metadata_service/orchestrator/orchestrator/__init__.py
@@ -133,7 +133,7 @@ SENSORS = [
 
 SCHEDULES = [ScheduleDefinition(job=generate_connector_test_summary_reports, cron_schedule="@hourly")]
 
-JOBS = [generate_registry_reports, generate_oss_registry, generate_cloud_registry]
+JOBS = [generate_registry_reports, generate_oss_registry, generate_cloud_registry, generate_registry_entry, generate_nightly_reports]
 
 """
 START HERE

--- a/airbyte-ci/connectors/metadata_service/orchestrator/orchestrator/assets/connector_test_report.py
+++ b/airbyte-ci/connectors/metadata_service/orchestrator/orchestrator/assets/connector_test_report.py
@@ -121,6 +121,7 @@ def compute_connector_nightly_report_history(
 
     return matrix_df
 
+
 # ASSETS
 
 
@@ -200,7 +201,9 @@ def persist_connectors_test_summary_files(context: OpExecutionContext, last_10_c
     all_connector_names = last_10_connector_test_results["connector_name"].unique()
     for connector_name in all_connector_names:
         all_connector_test_results = last_10_connector_test_results[last_10_connector_test_results["connector_name"] == connector_name]
-        connector_test_summary = all_connector_test_results[["timestamp", "connector_version", "success", "gha_workflow_run_url", "html_report_url"]]
+        connector_test_summary = all_connector_test_results[
+            ["timestamp", "connector_version", "success", "gha_workflow_run_url", "html_report_url"]
+        ]
 
         # Order by timestamp descending
         connector_test_summary = connector_test_summary.sort_values("timestamp", ascending=False)

--- a/airbyte-ci/connectors/metadata_service/orchestrator/orchestrator/assets/registry.py
+++ b/airbyte-ci/connectors/metadata_service/orchestrator/orchestrator/assets/registry.py
@@ -54,7 +54,8 @@ def generate_and_persist_registry(
     registry_dict = {"sources": [], "destinations": []}
     for blob in registry_entry_file_blobs:
         registry_entry, connector_type = read_registry_entry_blob(blob)
-        registry_dict[connector_type].append(registry_entry)
+        plural_connector_type = f"{connector_type}s"
+        registry_dict[plural_connector_type].append(registry_entry)
 
     registry_model = ConnectorRegistryV0.parse_obj(registry_dict)
 

--- a/airbyte-ci/connectors/metadata_service/orchestrator/orchestrator/assets/registry.py
+++ b/airbyte-ci/connectors/metadata_service/orchestrator/orchestrator/assets/registry.py
@@ -1,25 +1,16 @@
 #
 # Copyright (c) 2023 Airbyte, Inc., all rights reserved.
 #
-import copy
 import json
-from typing import List, Optional
-from pydash.objects import get
-
-import pandas as pd
-from dagster import asset, OpExecutionContext, MetadataValue, Output
 from google.cloud import storage
 
-from metadata_service.spec_cache import get_cached_spec
-
-from orchestrator.models.metadata import LatestMetadataEntry
-from orchestrator.assets.registry_entry import read_registry_entry_blob
-from orchestrator.utils.dagster_helpers import OutputDataFrame
-from orchestrator.utils.object_helpers import deep_copy_params
-
+from dagster import asset, OpExecutionContext, MetadataValue, Output
 from dagster_gcp.gcs.file_manager import GCSFileManager, GCSFileHandle
 
 from metadata_service.models.generated.ConnectorRegistryV0 import ConnectorRegistryV0
+from orchestrator.assets.registry_entry import read_registry_entry_blob
+
+from typing import List
 
 
 GROUP_NAME = "registry"

--- a/airbyte-ci/connectors/metadata_service/orchestrator/orchestrator/assets/registry.py
+++ b/airbyte-ci/connectors/metadata_service/orchestrator/orchestrator/assets/registry.py
@@ -8,10 +8,12 @@ from pydash.objects import get
 
 import pandas as pd
 from dagster import asset, OpExecutionContext, MetadataValue, Output
+from google.cloud import storage
 
 from metadata_service.spec_cache import get_cached_spec
 
 from orchestrator.models.metadata import LatestMetadataEntry
+from orchestrator.assets.registry_entry import read_registry_entry_blob
 from orchestrator.utils.dagster_helpers import OutputDataFrame
 from orchestrator.utils.object_helpers import deep_copy_params
 
@@ -21,181 +23,6 @@ from metadata_service.models.generated.ConnectorRegistryV0 import ConnectorRegis
 
 
 GROUP_NAME = "registry"
-
-# ERRORS
-
-
-class MissingCachedSpecError(Exception):
-    pass
-
-
-# HELPERS
-
-
-@deep_copy_params
-def apply_overrides_from_registry(metadata_data: dict, override_registry_key: str) -> dict:
-    """Apply the overrides from the registry to the metadata data.
-
-    Args:
-        metadata_data (dict): The metadata data field.
-        override_registry_key (str): The key of the registry to override the metadata with.
-
-    Returns:
-        dict: The metadata data field with the overrides applied.
-    """
-    override_registry = metadata_data["registries"][override_registry_key]
-    del override_registry["enabled"]
-
-    # remove any None values from the override registry
-    override_registry = {k: v for k, v in override_registry.items() if v is not None}
-
-    metadata_data.update(override_registry)
-
-    return metadata_data
-
-
-def calculate_migration_documentation_url(releases_or_breaking_change: dict, documentation_url: str, version: Optional[str] = None) -> str:
-    """Calculate the migration documentation url for the connector releases.
-
-    Args:
-        metadata_releases (dict): The connector releases.
-
-    Returns:
-        str: The migration documentation url.
-    """
-
-    base_url = f"{documentation_url}-migrations"
-    default_migration_documentation_url = f"{base_url}#{version}" if version is not None else base_url
-
-    return releases_or_breaking_change.get("migrationDocumentationUrl", default_migration_documentation_url)
-
-
-@deep_copy_params
-def apply_connector_release_defaults(metadata: dict) -> Optional[pd.DataFrame]:
-    metadata_releases = metadata.get("releases")
-    documentation_url = metadata.get("documentationUrl")
-    if metadata_releases is None:
-        return None
-
-    # apply defaults for connector releases
-    metadata_releases["migrationDocumentationUrl"] = calculate_migration_documentation_url(metadata_releases, documentation_url)
-
-    # releases has a dictionary field called breakingChanges, where the key is the version and the value is the data for the breaking change
-    # each breaking change has a migrationDocumentationUrl field that is optional, so we need to apply defaults to it
-    breaking_changes = metadata_releases["breakingChanges"]
-    if breaking_changes is not None:
-        for version, breaking_change in breaking_changes.items():
-            breaking_change["migrationDocumentationUrl"] = calculate_migration_documentation_url(
-                breaking_change, documentation_url, version
-            )
-
-    return metadata_releases
-
-
-@deep_copy_params
-def metadata_to_registry_entry(metadata_entry: LatestMetadataEntry, connector_type: str, override_registry_key: str) -> dict:
-    """Convert the metadata definition to a registry entry.
-
-    Args:
-        metadata_definition (dict): The metadata definition.
-        connector_type (str): One of "source" or "destination".
-        override_registry_key (str): The key of the registry to override the metadata with.
-
-    Returns:
-        dict: The registry equivalent of the metadata definition.
-    """
-    metadata_definition = metadata_entry.metadata_definition.dict()
-
-    metadata_data = metadata_definition["data"]
-
-    # apply overrides from the registry
-    overrode_metadata_data = apply_overrides_from_registry(metadata_data, override_registry_key)
-
-    # remove fields that are not needed in the registry
-    del overrode_metadata_data["registries"]
-    del overrode_metadata_data["connectorType"]
-
-    # rename field connectorSubtype to sourceType
-    connection_type = overrode_metadata_data.get("connectorSubtype")
-    if connection_type:
-        overrode_metadata_data["sourceType"] = overrode_metadata_data["connectorSubtype"]
-        del overrode_metadata_data["connectorSubtype"]
-
-    # rename definitionId field to sourceDefinitionId or destinationDefinitionId
-    id_field = "sourceDefinitionId" if connector_type == "source" else "destinationDefinitionId"
-    overrode_metadata_data[id_field] = overrode_metadata_data["definitionId"]
-    del overrode_metadata_data["definitionId"]
-
-    # add in useless fields that are currently required for porting to the actor definition spec
-    overrode_metadata_data["tombstone"] = False
-    overrode_metadata_data["custom"] = False
-    overrode_metadata_data["public"] = True
-
-    # if there is no releaseStage, set it to "alpha"
-    if not overrode_metadata_data.get("releaseStage"):
-        overrode_metadata_data["releaseStage"] = "alpha"
-
-    # apply generated fields
-    overrode_metadata_data["iconUrl"] = metadata_entry.icon_url
-    overrode_metadata_data["releases"] = apply_connector_release_defaults(overrode_metadata_data)
-
-    return overrode_metadata_data
-
-
-def is_metadata_registry_enabled(metadata_entry: LatestMetadataEntry, registry_name: str) -> bool:
-    metadata_definition = metadata_entry.metadata_definition.dict()
-    return get(metadata_definition, f"data.registries.{registry_name}.enabled", False)
-
-
-def is_metadata_connector_type(metadata_entry: LatestMetadataEntry, connector_type: str) -> bool:
-    metadata_definition = metadata_entry.metadata_definition.dict()
-    return metadata_definition["data"]["connectorType"] == connector_type
-
-
-def construct_registry_from_metadata(metadata_entries: List[LatestMetadataEntry], registry_name: str) -> ConnectorRegistryV0:
-    """Construct the registry from the metadata definitions.
-
-    Args:
-        metadata_entries (List[dict]): Metadata definitions that have been derived from the existing registry.
-        registry_name (str): The name of the registry to construct. One of "cloud" or "oss".
-
-    Returns:
-        dict: The registry.
-    """
-    registry_sources = [
-        metadata_to_registry_entry(metadata_entry, "source", registry_name)
-        for metadata_entry in metadata_entries
-        if is_metadata_registry_enabled(metadata_entry, registry_name) and is_metadata_connector_type(metadata_entry, "source")
-    ]
-    registry_destinations = [
-        metadata_to_registry_entry(metadata_entry, "destination", registry_name)
-        for metadata_entry in metadata_entries
-        if is_metadata_registry_enabled(metadata_entry, registry_name) and is_metadata_connector_type(metadata_entry, "destination")
-    ]
-
-    return {"sources": registry_sources, "destinations": registry_destinations}
-
-
-def construct_registry_with_spec_from_registry(registry: dict, cached_specs: OutputDataFrame) -> dict:
-    entries = [("source", entry) for entry in registry["sources"]] + [("destinations", entry) for entry in registry["destinations"]]
-
-    cached_connector_version = {
-        (cached_spec["docker_repository"], cached_spec["docker_image_tag"]): cached_spec["spec_cache_path"]
-        for cached_spec in cached_specs.to_dict(orient="records")
-    }
-    registry_with_specs = {"sources": [], "destinations": []}
-    for connector_type, entry in entries:
-        try:
-            spec_path = cached_connector_version[(entry["dockerRepository"], entry["dockerImageTag"])]
-            entry_with_spec = copy.deepcopy(entry)
-            entry_with_spec["spec"] = get_cached_spec(spec_path)
-            if connector_type == "source":
-                registry_with_specs["sources"].append(entry_with_spec)
-            else:
-                registry_with_specs["destinations"].append(entry_with_spec)
-        except KeyError:
-            raise MissingCachedSpecError(f"No cached spec found for {entry['dockerRepository']}:{entry['dockerImageTag']}")
-    return registry_with_specs
 
 
 def persist_registry_to_json(
@@ -219,8 +46,7 @@ def persist_registry_to_json(
 
 
 def generate_and_persist_registry(
-    metadata_definitions: List[LatestMetadataEntry],
-    cached_specs: OutputDataFrame,
+    registry_entry_file_blobs: List[storage.Blob],
     registry_directory_manager: GCSFileManager,
     registry_name: str,
 ) -> Output[ConnectorRegistryV0]:
@@ -228,15 +54,17 @@ def generate_and_persist_registry(
 
     Args:
         context (OpExecutionContext): The execution context.
-        metadata_definitions (List[LatestMetadataEntry]): The metadata definitions.
+        registry_entry_file_blobs (storage.Blob): The metadata definitions.
         cached_specs (OutputDataFrame): The cached specs.
 
     Returns:
         Output[ConnectorRegistryV0]: The registry.
     """
+    registry_dict = {"sources": [], "destinations": []}
+    for blob in registry_entry_file_blobs:
+        registry_entry, connector_type = read_registry_entry_blob(blob)
+        registry_dict[connector_type].append(registry_entry)
 
-    from_metadata = construct_registry_from_metadata(metadata_definitions, registry_name)
-    registry_dict = construct_registry_with_spec_from_registry(from_metadata, cached_specs)
     registry_model = ConnectorRegistryV0.parse_obj(registry_dict)
 
     file_handle = persist_registry_to_json(registry_model, registry_name, registry_directory_manager)
@@ -250,38 +78,32 @@ def generate_and_persist_registry(
 
 # Registry Generation
 
-
-@asset(required_resource_keys={"registry_directory_manager"}, group_name=GROUP_NAME)
-def persist_cloud_registry_from_metadata(
-    context: OpExecutionContext, metadata_definitions: List[LatestMetadataEntry], cached_specs: OutputDataFrame
-) -> Output[ConnectorRegistryV0]:
-    """
-    This asset is used to generate the cloud registry from the metadata definitions.
-    """
-    registry_name = "cloud"
-    registry_directory_manager = context.resources.registry_directory_manager
-
-    return generate_and_persist_registry(
-        metadata_definitions=metadata_definitions,
-        cached_specs=cached_specs,
-        registry_directory_manager=registry_directory_manager,
-        registry_name=registry_name,
-    )
-
-
-@asset(required_resource_keys={"registry_directory_manager"}, group_name=GROUP_NAME)
-def persist_oss_registry_from_metadata(
-    context: OpExecutionContext, metadata_definitions: List[LatestMetadataEntry], cached_specs: OutputDataFrame
-) -> Output[ConnectorRegistryV0]:
+@asset(required_resource_keys={"registry_directory_manager", "latest_oss_registry_entries_file_blobs"}, group_name=GROUP_NAME)
+def persist_oss_registry_from_entries(context: OpExecutionContext) -> Output[ConnectorRegistryV0]:
     """
     This asset is used to generate the oss registry from the metadata definitions.
     """
     registry_name = "oss"
     registry_directory_manager = context.resources.registry_directory_manager
+    latest_oss_registry_entries_file_blobs = context.resources.latest_oss_registry_entries_file_blobs
 
     return generate_and_persist_registry(
-        metadata_definitions=metadata_definitions,
-        cached_specs=cached_specs,
+        registry_entry_file_blobs=latest_oss_registry_entries_file_blobs,
+        registry_directory_manager=registry_directory_manager,
+        registry_name=registry_name,
+    )
+
+@asset(required_resource_keys={"registry_directory_manager", "latest_cloud_registry_entries_file_blobs"}, group_name=GROUP_NAME)
+def persist_cloud_registry_from_entries(context: OpExecutionContext) -> Output[ConnectorRegistryV0]:
+    """
+    This asset is used to generate the cloud registry from the metadata definitions.
+    """
+    registry_name = "cloud"
+    registry_directory_manager = context.resources.registry_directory_manager
+    latest_cloud_registry_entries_file_blobs = context.resources.latest_cloud_registry_entries_file_blobs
+
+    return generate_and_persist_registry(
+        registry_entry_file_blobs=latest_cloud_registry_entries_file_blobs,
         registry_directory_manager=registry_directory_manager,
         registry_name=registry_name,
     )

--- a/airbyte-ci/connectors/metadata_service/orchestrator/orchestrator/assets/registry.py
+++ b/airbyte-ci/connectors/metadata_service/orchestrator/orchestrator/assets/registry.py
@@ -69,6 +69,7 @@ def generate_and_persist_registry(
 
 # Registry Generation
 
+
 @asset(required_resource_keys={"registry_directory_manager", "latest_oss_registry_entries_file_blobs"}, group_name=GROUP_NAME)
 def persist_oss_registry_from_entries(context: OpExecutionContext) -> Output[ConnectorRegistryV0]:
     """
@@ -83,6 +84,7 @@ def persist_oss_registry_from_entries(context: OpExecutionContext) -> Output[Con
         registry_directory_manager=registry_directory_manager,
         registry_name=registry_name,
     )
+
 
 @asset(required_resource_keys={"registry_directory_manager", "latest_cloud_registry_entries_file_blobs"}, group_name=GROUP_NAME)
 def persist_cloud_registry_from_entries(context: OpExecutionContext) -> Output[ConnectorRegistryV0]:

--- a/airbyte-ci/connectors/metadata_service/orchestrator/orchestrator/assets/registry.py
+++ b/airbyte-ci/connectors/metadata_service/orchestrator/orchestrator/assets/registry.py
@@ -45,8 +45,7 @@ def generate_and_persist_registry(
 
     Args:
         context (OpExecutionContext): The execution context.
-        registry_entry_file_blobs (storage.Blob): The metadata definitions.
-        cached_specs (OutputDataFrame): The cached specs.
+        registry_entry_file_blobs (storage.Blob): The registry entries.
 
     Returns:
         Output[ConnectorRegistryV0]: The registry.
@@ -74,7 +73,7 @@ def generate_and_persist_registry(
 @asset(required_resource_keys={"registry_directory_manager", "latest_oss_registry_entries_file_blobs"}, group_name=GROUP_NAME)
 def persist_oss_registry_from_entries(context: OpExecutionContext) -> Output[ConnectorRegistryV0]:
     """
-    This asset is used to generate the oss registry from the metadata definitions.
+    This asset is used to generate the oss registry from the registry entries.
     """
     registry_name = "oss"
     registry_directory_manager = context.resources.registry_directory_manager
@@ -90,7 +89,7 @@ def persist_oss_registry_from_entries(context: OpExecutionContext) -> Output[Con
 @asset(required_resource_keys={"registry_directory_manager", "latest_cloud_registry_entries_file_blobs"}, group_name=GROUP_NAME)
 def persist_cloud_registry_from_entries(context: OpExecutionContext) -> Output[ConnectorRegistryV0]:
     """
-    This asset is used to generate the cloud registry from the metadata definitions.
+    This asset is used to generate the cloud registry from the registry entries.
     """
     registry_name = "cloud"
     registry_directory_manager = context.resources.registry_directory_manager

--- a/airbyte-ci/connectors/metadata_service/orchestrator/orchestrator/assets/registry.py
+++ b/airbyte-ci/connectors/metadata_service/orchestrator/orchestrator/assets/registry.py
@@ -71,7 +71,7 @@ def generate_and_persist_registry(
 
 
 @asset(required_resource_keys={"registry_directory_manager", "latest_oss_registry_entries_file_blobs"}, group_name=GROUP_NAME)
-def persist_oss_registry_from_entries(context: OpExecutionContext) -> Output[ConnectorRegistryV0]:
+def persisted_oss_registry(context: OpExecutionContext) -> Output[ConnectorRegistryV0]:
     """
     This asset is used to generate the oss registry from the registry entries.
     """
@@ -87,7 +87,7 @@ def persist_oss_registry_from_entries(context: OpExecutionContext) -> Output[Con
 
 
 @asset(required_resource_keys={"registry_directory_manager", "latest_cloud_registry_entries_file_blobs"}, group_name=GROUP_NAME)
-def persist_cloud_registry_from_entries(context: OpExecutionContext) -> Output[ConnectorRegistryV0]:
+def persisted_cloud_registry(context: OpExecutionContext) -> Output[ConnectorRegistryV0]:
     """
     This asset is used to generate the cloud registry from the registry entries.
     """

--- a/airbyte-ci/connectors/metadata_service/orchestrator/orchestrator/assets/registry_entry.py
+++ b/airbyte-ci/connectors/metadata_service/orchestrator/orchestrator/assets/registry_entry.py
@@ -1,0 +1,25 @@
+from dagster import (
+    DynamicPartitionsDefinition,
+    asset,
+)
+
+GROUP_NAME = "registry_entry"
+
+metadata_partitions_def = DynamicPartitionsDefinition(name="metadata")
+
+@asset(required_resource_keys={"latest_metadata_file_blobs"}, group_name=GROUP_NAME, partitions_def=metadata_partitions_def)
+def registry_entry(context):
+    etag = context.partition_key
+    latest_metadata_file_blobs = context.resources.latest_metadata_file_blobs
+
+    # find the blob with the matching etag
+    matching_blob = next(
+        (blob for blob in latest_metadata_file_blobs if blob.etag == etag), None
+    )
+
+    if not matching_blob:
+        raise Exception(f"Could not find blob with etag {etag}")
+
+    # read the blob
+    filename = matching_blob.name
+    return filename

--- a/airbyte-ci/connectors/metadata_service/orchestrator/orchestrator/assets/registry_entry.py
+++ b/airbyte-ci/connectors/metadata_service/orchestrator/orchestrator/assets/registry_entry.py
@@ -307,7 +307,6 @@ def metadata_entry(context: OpExecutionContext) -> Output[LatestMetadataEntry]:
     etag = context.partition_key
     all_metadata_file_blobs = context.resources.all_metadata_file_blobs
 
-
     # find the blob with the matching etag
     matching_blob = next((blob for blob in all_metadata_file_blobs if blob.etag == etag), None)
     metadata_file_path = matching_blob.name

--- a/airbyte-ci/connectors/metadata_service/orchestrator/orchestrator/assets/registry_entry.py
+++ b/airbyte-ci/connectors/metadata_service/orchestrator/orchestrator/assets/registry_entry.py
@@ -1,14 +1,26 @@
-from dagster import (
-    DynamicPartitionsDefinition,
-    asset,
-)
+import pandas as pd
+import numpy as np
+import os
+from typing import List
+from dagster import DynamicPartitionsDefinition, asset, OpExecutionContext
+import yaml
+
+from metadata_service.models.generated.ConnectorMetadataDefinitionV0 import ConnectorMetadataDefinitionV0
+from metadata_service.constants import METADATA_FILE_NAME, ICON_FILE_NAME
+
+from orchestrator.utils.object_helpers import are_values_equal, merge_values
+from orchestrator.models.metadata import PartialMetadataDefinition, MetadataDefinition, LatestMetadataEntry
+from orchestrator.config import get_public_url_for_gcs_file
+
+from orchestrator.utils.dagster_helpers import OutputDataFrame, output_dataframe
+
 
 GROUP_NAME = "registry_entry"
 
 metadata_partitions_def = DynamicPartitionsDefinition(name="metadata")
 
 @asset(required_resource_keys={"latest_metadata_file_blobs"}, group_name=GROUP_NAME, partitions_def=metadata_partitions_def)
-def registry_entry(context):
+def metadata_entry(context: OpExecutionContext) -> LatestMetadataEntry:
     etag = context.partition_key
     latest_metadata_file_blobs = context.resources.latest_metadata_file_blobs
 
@@ -20,6 +32,32 @@ def registry_entry(context):
     if not matching_blob:
         raise Exception(f"Could not find blob with etag {etag}")
 
-    # read the blob
-    filename = matching_blob.name
-    return filename
+    # read the matching_blob
+    yaml_string = matching_blob.download_as_string().decode("utf-8")
+    metadata_dict = yaml.safe_load(yaml_string)
+    metadata_def = MetadataDefinition.parse_obj(metadata_dict)
+
+    metadata_file_path = matching_blob.name
+    icon_file_path = metadata_file_path.replace(METADATA_FILE_NAME, ICON_FILE_NAME)
+    icon_blob = matching_blob.bucket.blob(icon_file_path)
+
+    icon_url = (
+        get_public_url_for_gcs_file(icon_blob.bucket.name, icon_blob.name, os.getenv("METADATA_CDN_BASE_URL"))
+        if icon_blob.exists()
+        else None
+    )
+
+    metadata_entry = LatestMetadataEntry(
+        metadata_definition=metadata_def,
+        icon_url=icon_url,
+        bucket_name=matching_blob.bucket.name,
+        file_path=metadata_file_path,
+    )
+    # import pdb; pdb.set_trace()
+    return metadata_entry
+
+@asset(group_name=GROUP_NAME, partitions_def=metadata_partitions_def)
+def registry_entry(context: OpExecutionContext, metadata_entry: LatestMetadataEntry) -> OutputDataFrame:
+    metadata_entry_df = pd.DataFrame(metadata_entry.dict())
+    return output_dataframe(metadata_entry_df)
+

--- a/airbyte-ci/connectors/metadata_service/orchestrator/orchestrator/assets/registry_entry.py
+++ b/airbyte-ci/connectors/metadata_service/orchestrator/orchestrator/assets/registry_entry.py
@@ -279,14 +279,14 @@ def delete_registry_entry(registry_name, registry_entry: LatestMetadataEntry, me
 # ASSETS
 
 
-@asset(required_resource_keys={"latest_metadata_file_blobs"}, group_name=GROUP_NAME, partitions_def=metadata_partitions_def)
+@asset(required_resource_keys={"all_metadata_file_blobs"}, group_name=GROUP_NAME, partitions_def=metadata_partitions_def)
 def metadata_entry(context: OpExecutionContext) -> LatestMetadataEntry:
     """Parse and compute the LatestMetadataEntry for the given metadata file."""
     etag = context.partition_key
-    latest_metadata_file_blobs = context.resources.latest_metadata_file_blobs
+    all_metadata_file_blobs = context.resources.all_metadata_file_blobs
 
     # find the blob with the matching etag
-    matching_blob = next((blob for blob in latest_metadata_file_blobs if blob.etag == etag), None)
+    matching_blob = next((blob for blob in all_metadata_file_blobs if blob.etag == etag), None)
 
     if not matching_blob:
         raise Exception(f"Could not find blob with etag {etag}")

--- a/airbyte-ci/connectors/metadata_service/orchestrator/orchestrator/assets/registry_entry.py
+++ b/airbyte-ci/connectors/metadata_service/orchestrator/orchestrator/assets/registry_entry.py
@@ -1,8 +1,8 @@
 import pandas as pd
 import numpy as np
 import os
-from typing import List
-from dagster import DynamicPartitionsDefinition, asset, OpExecutionContext
+from typing import List, Optional
+from dagster import DynamicPartitionsDefinition, asset, OpExecutionContext, Output
 import yaml
 
 from metadata_service.models.generated.ConnectorMetadataDefinitionV0 import ConnectorMetadataDefinitionV0
@@ -13,11 +13,183 @@ from orchestrator.models.metadata import PartialMetadataDefinition, MetadataDefi
 from orchestrator.config import get_public_url_for_gcs_file
 
 from orchestrator.utils.dagster_helpers import OutputDataFrame, output_dataframe
+from metadata_service.models.generated.ConnectorRegistryDestinationDefinition import ConnectorRegistryDestinationDefinition
+from metadata_service.models.generated.ConnectorRegistrySourceDefinition import ConnectorRegistrySourceDefinition
+from orchestrator.utils.object_helpers import deep_copy_params
+from metadata_service.spec_cache import get_cached_spec
 
+import copy
 
 GROUP_NAME = "registry_entry"
 
 metadata_partitions_def = DynamicPartitionsDefinition(name="metadata")
+
+# ERRORS
+
+class MissingCachedSpecError(Exception):
+    pass
+
+# HELPERS
+
+def construct_registry_with_spec_from_registry(registry: dict, cached_specs: OutputDataFrame) -> dict:
+    # TODO just call the get_cached_spec directly
+    entries = [("source", entry) for entry in registry["sources"]] + [("destinations", entry) for entry in registry["destinations"]]
+
+    cached_connector_version = {
+        (cached_spec["docker_repository"], cached_spec["docker_image_tag"]): cached_spec["spec_cache_path"]
+        for cached_spec in cached_specs.to_dict(orient="records")
+    }
+    registry_with_specs = {"sources": [], "destinations": []}
+    for connector_type, entry in entries:
+        try:
+            spec_path = cached_connector_version[(entry["dockerRepository"], entry["dockerImageTag"])]
+            entry_with_spec = copy.deepcopy(entry)
+            entry_with_spec["spec"] = get_cached_spec(spec_path)
+            if connector_type == "source":
+                registry_with_specs["sources"].append(entry_with_spec)
+            else:
+                registry_with_specs["destinations"].append(entry_with_spec)
+        except KeyError:
+            raise MissingCachedSpecError(f"No cached spec found for {entry['dockerRepository']}:{entry['dockerImageTag']}")
+    return registry_with_specs
+
+def calculate_migration_documentation_url(releases_or_breaking_change: dict, documentation_url: str, version: Optional[str] = None) -> str:
+    """Calculate the migration documentation url for the connector releases.
+
+    Args:
+        metadata_releases (dict): The connector releases.
+
+    Returns:
+        str: The migration documentation url.
+    """
+
+    base_url = f"{documentation_url}-migrations"
+    default_migration_documentation_url = f"{base_url}#{version}" if version is not None else base_url
+
+    return releases_or_breaking_change.get("migrationDocumentationUrl", default_migration_documentation_url)
+
+
+@deep_copy_params
+def apply_connector_release_defaults(metadata: dict) -> Optional[pd.DataFrame]:
+    metadata_releases = metadata.get("releases")
+    documentation_url = metadata.get("documentationUrl")
+    if metadata_releases is None:
+        return None
+
+    # apply defaults for connector releases
+    metadata_releases["migrationDocumentationUrl"] = calculate_migration_documentation_url(metadata_releases, documentation_url)
+
+    # releases has a dictionary field called breakingChanges, where the key is the version and the value is the data for the breaking change
+    # each breaking change has a migrationDocumentationUrl field that is optional, so we need to apply defaults to it
+    breaking_changes = metadata_releases["breakingChanges"]
+    if breaking_changes is not None:
+        for version, breaking_change in breaking_changes.items():
+            breaking_change["migrationDocumentationUrl"] = calculate_migration_documentation_url(
+                breaking_change, documentation_url, version
+            )
+
+    return metadata_releases
+
+@deep_copy_params
+def apply_overrides_from_registry(metadata_data: dict, override_registry_key: str) -> dict:
+    """Apply the overrides from the registry to the metadata data.
+
+    Args:
+        metadata_data (dict): The metadata data field.
+        override_registry_key (str): The key of the registry to override the metadata with.
+
+    Returns:
+        dict: The metadata data field with the overrides applied.
+    """
+    override_registry = metadata_data["registries"][override_registry_key]
+    del override_registry["enabled"]
+
+    # remove any None values from the override registry
+    override_registry = {k: v for k, v in override_registry.items() if v is not None}
+
+    metadata_data.update(override_registry)
+
+    return metadata_data
+
+@deep_copy_params
+def metadata_to_registry_entry(metadata_entry: LatestMetadataEntry, connector_type: str, override_registry_key: str) -> dict:
+    """Convert the metadata definition to a registry entry.
+
+    Args:
+        metadata_definition (dict): The metadata definition.
+        connector_type (str): One of "source" or "destination".
+        override_registry_key (str): The key of the registry to override the metadata with.
+
+    Returns:
+        dict: The registry equivalent of the metadata definition.
+    """
+    metadata_definition = metadata_entry.metadata_definition.dict()
+
+    metadata_data = metadata_definition["data"]
+
+    # apply overrides from the registry
+    overrode_metadata_data = apply_overrides_from_registry(metadata_data, override_registry_key)
+
+    # remove fields that are not needed in the registry
+    del overrode_metadata_data["registries"]
+    del overrode_metadata_data["connectorType"]
+
+    # rename field connectorSubtype to sourceType
+    connection_type = overrode_metadata_data.get("connectorSubtype")
+    if connection_type:
+        overrode_metadata_data["sourceType"] = overrode_metadata_data["connectorSubtype"]
+        del overrode_metadata_data["connectorSubtype"]
+
+    # rename definitionId field to sourceDefinitionId or destinationDefinitionId
+    id_field = "sourceDefinitionId" if connector_type == "source" else "destinationDefinitionId"
+    overrode_metadata_data[id_field] = overrode_metadata_data["definitionId"]
+    del overrode_metadata_data["definitionId"]
+
+    # add in useless fields that are currently required for porting to the actor definition spec
+    overrode_metadata_data["tombstone"] = False
+    overrode_metadata_data["custom"] = False
+    overrode_metadata_data["public"] = True
+
+    # if there is no releaseStage, set it to "alpha"
+    if not overrode_metadata_data.get("releaseStage"):
+        overrode_metadata_data["releaseStage"] = "alpha"
+
+    # apply generated fields
+    overrode_metadata_data["iconUrl"] = metadata_entry.icon_url
+    overrode_metadata_data["releases"] = apply_connector_release_defaults(overrode_metadata_data)
+
+    return overrode_metadata_data
+
+def generate_and_persist_registry_entry(
+    metadata_entry: LatestMetadataEntry,
+    cached_specs: OutputDataFrame,
+    registry_directory_manager: GCSFileManager,
+    registry_name: str,
+) -> Output[ConnectorRegistrySourceDefinition | ConnectorRegistryDestinationDefinition]:
+    """Generate the selected registry from the metadata files, and persist it to GCS.
+
+    Args:
+        context (OpExecutionContext): The execution context.
+        metadata_entry (List[LatestMetadataEntry]): The metadata definitions.
+        cached_specs (OutputDataFrame): The cached specs.
+
+    Returns:
+        Output[ConnectorRegistryV0]: The registry.
+    """
+
+    from_metadata = metadata_to_registry_entry(metadata_entry, registry_name)
+    registry_dict = construct_registry_with_spec_from_registry(from_metadata, cached_specs)
+    registry_model = ConnectorRegistryV0.parse_obj(registry_dict)
+
+    file_handle = persist_registry_to_json(registry_model, registry_name, registry_directory_manager)
+
+    metadata = {
+        "gcs_path": MetadataValue.url(file_handle.public_url),
+    }
+
+    return Output(metadata=metadata, value=registry_model)
+
+# ASSETS
 
 @asset(required_resource_keys={"latest_metadata_file_blobs"}, group_name=GROUP_NAME, partitions_def=metadata_partitions_def)
 def metadata_entry(context: OpExecutionContext) -> LatestMetadataEntry:
@@ -58,6 +230,12 @@ def metadata_entry(context: OpExecutionContext) -> LatestMetadataEntry:
 
 @asset(group_name=GROUP_NAME, partitions_def=metadata_partitions_def)
 def registry_entry(context: OpExecutionContext, metadata_entry: LatestMetadataEntry) -> OutputDataFrame:
+    """
+    TODO
+    1. parse into the individual registry files
+    2. update registry sensor to use these files
+    3. update the metadata entry to span all the registry files
+    """
     metadata_entry_df = pd.DataFrame(metadata_entry.dict())
     return output_dataframe(metadata_entry_df)
 

--- a/airbyte-ci/connectors/metadata_service/orchestrator/orchestrator/assets/registry_entry.py
+++ b/airbyte-ci/connectors/metadata_service/orchestrator/orchestrator/assets/registry_entry.py
@@ -203,10 +203,10 @@ def persist_registry_entry_to_json(
         registry_entry (ConnectorRegistryV0): The registry_entry.
         registry_name (str): The name of the registry_entry. One of "cloud" or "oss".
         metadata_entry (LatestMetadataEntry): The related Metadata Entry.
-        registry_directory_manager (OutputDataFrame): The registry_entry directory manager.
+        registry_directory_manager (GCSFileHandle): The registry_entry directory manager.
 
     Returns:
-        OutputDataFrame: The registry_entry directory manager.
+        GCSFileHandle: The registry_entry directory manager.
     """
     registry_entry_write_path = get_registry_entry_write_path(metadata_entry, registry_name)
     registry_entry_json = registry_entry.json(exclude_none=True)

--- a/airbyte-ci/connectors/metadata_service/orchestrator/orchestrator/assets/registry_entry.py
+++ b/airbyte-ci/connectors/metadata_service/orchestrator/orchestrator/assets/registry_entry.py
@@ -248,12 +248,10 @@ def get_registry_status_lists(registry_entry: LatestMetadataEntry) -> Tuple[List
         registry_entry (LatestMetadataEntry): The metadata entry.
 
     Returns:
-        List[str]: The enabled registries.
+        Tuple[List[str], List[str]]: The enabled and disabled registries.
     """
     metadata_data_dict = registry_entry.metadata_definition.dict()
     registries_field = metadata_data_dict["data"].get("registries", {})
-
-    print(f"registries_field: {registries_field}")
 
     # registries is a dict of registry_name -> {enabled: bool}
     all_enabled_registries = [registry_name for registry_name, registry_data in registries_field.items() if registry_data.get("enabled")]

--- a/airbyte-ci/connectors/metadata_service/orchestrator/orchestrator/assets/specs_secrets_mask.py
+++ b/airbyte-ci/connectors/metadata_service/orchestrator/orchestrator/assets/specs_secrets_mask.py
@@ -47,10 +47,10 @@ def get_secrets_properties_from_registry_entry(registry_entry: dict) -> List[str
 
 @asset(group_name=GROUP_NAME)
 def all_specs_secrets(
-    persist_oss_registry_from_metadata: ConnectorRegistryV0, persist_cloud_registry_from_metadata: ConnectorRegistryV0
+    persist_oss_registry_from_entries: ConnectorRegistryV0, persist_cloud_registry_from_entries: ConnectorRegistryV0
 ) -> Set[str]:
-    oss_registry_from_metadata_dict = persist_oss_registry_from_metadata.dict()
-    cloud_registry_from_metadata_dict = persist_cloud_registry_from_metadata.dict()
+    oss_registry_from_metadata_dict = persist_oss_registry_from_entries.dict()
+    cloud_registry_from_metadata_dict = persist_cloud_registry_from_entries.dict()
 
     all_secret_properties = []
     all_entries = (

--- a/airbyte-ci/connectors/metadata_service/orchestrator/orchestrator/assets/specs_secrets_mask.py
+++ b/airbyte-ci/connectors/metadata_service/orchestrator/orchestrator/assets/specs_secrets_mask.py
@@ -47,10 +47,10 @@ def get_secrets_properties_from_registry_entry(registry_entry: dict) -> List[str
 
 @asset(group_name=GROUP_NAME)
 def all_specs_secrets(
-    persist_oss_registry_from_entries: ConnectorRegistryV0, persist_cloud_registry_from_entries: ConnectorRegistryV0
+    persisted_oss_registry: ConnectorRegistryV0, persisted_cloud_registry: ConnectorRegistryV0
 ) -> Set[str]:
-    oss_registry_from_metadata_dict = persist_oss_registry_from_entries.dict()
-    cloud_registry_from_metadata_dict = persist_cloud_registry_from_entries.dict()
+    oss_registry_from_metadata_dict = persisted_oss_registry.dict()
+    cloud_registry_from_metadata_dict = persisted_cloud_registry.dict()
 
     all_secret_properties = []
     all_entries = (

--- a/airbyte-ci/connectors/metadata_service/orchestrator/orchestrator/assets/specs_secrets_mask.py
+++ b/airbyte-ci/connectors/metadata_service/orchestrator/orchestrator/assets/specs_secrets_mask.py
@@ -46,9 +46,7 @@ def get_secrets_properties_from_registry_entry(registry_entry: dict) -> List[str
 
 
 @asset(group_name=GROUP_NAME)
-def all_specs_secrets(
-    persisted_oss_registry: ConnectorRegistryV0, persisted_cloud_registry: ConnectorRegistryV0
-) -> Set[str]:
+def all_specs_secrets(persisted_oss_registry: ConnectorRegistryV0, persisted_cloud_registry: ConnectorRegistryV0) -> Set[str]:
     oss_registry_from_metadata_dict = persisted_oss_registry.dict()
     cloud_registry_from_metadata_dict = persisted_cloud_registry.dict()
 

--- a/airbyte-ci/connectors/metadata_service/orchestrator/orchestrator/config.py
+++ b/airbyte-ci/connectors/metadata_service/orchestrator/orchestrator/config.py
@@ -1,6 +1,7 @@
 import os
 from typing import Optional
 
+VALID_REGISTRIES = ["oss", "cloud"]
 REGISTRIES_FOLDER = "registries/v0"
 REPORT_FOLDER = "generated_reports"
 

--- a/airbyte-ci/connectors/metadata_service/orchestrator/orchestrator/jobs/registry.py
+++ b/airbyte-ci/connectors/metadata_service/orchestrator/orchestrator/jobs/registry.py
@@ -1,10 +1,15 @@
 from dagster import define_asset_job, AssetSelection
 from orchestrator.assets import registry_entry
 
-registries_inclusive = AssetSelection.keys(
-    "persist_cloud_registry_from_metadata", "persist_oss_registry_from_metadata", "specs_secrets_mask_yaml"
+oss_registry_inclusive = AssetSelection.keys(
+    "persist_oss_registry_from_entries", "specs_secrets_mask_yaml"
 ).upstream()
-generate_registry = define_asset_job(name="generate_registry", selection=registries_inclusive)
+generate_oss_registry = define_asset_job(name="generate_oss_registry", selection=oss_registry_inclusive)
+
+cloud_registry_inclusive = AssetSelection.keys(
+    "persist_cloud_registry_from_entries", "specs_secrets_mask_yaml"
+).upstream()
+generate_cloud_registry = define_asset_job(name="generate_cloud_registry", selection=cloud_registry_inclusive)
 
 registry_reports_inclusive = AssetSelection.keys("connector_registry_report").upstream()
 generate_registry_reports = define_asset_job(name="generate_registry_reports", selection=registry_reports_inclusive)

--- a/airbyte-ci/connectors/metadata_service/orchestrator/orchestrator/jobs/registry.py
+++ b/airbyte-ci/connectors/metadata_service/orchestrator/orchestrator/jobs/registry.py
@@ -1,4 +1,5 @@
 from dagster import define_asset_job, AssetSelection
+from orchestrator.assets import registry_entry
 
 registries_inclusive = AssetSelection.keys(
     "persist_cloud_registry_from_metadata", "persist_oss_registry_from_metadata", "specs_secrets_mask_yaml"
@@ -7,3 +8,10 @@ generate_registry = define_asset_job(name="generate_registry", selection=registr
 
 registry_reports_inclusive = AssetSelection.keys("connector_registry_report").upstream()
 generate_registry_reports = define_asset_job(name="generate_registry_reports", selection=registry_reports_inclusive)
+
+registry_entry_inclusive = AssetSelection.keys("registry_entry").upstream()
+generate_registry_entry = define_asset_job(
+    name="generate_registry_entry",
+    selection=registry_entry_inclusive,
+    partitions_def=registry_entry.metadata_partitions_def,
+)

--- a/airbyte-ci/connectors/metadata_service/orchestrator/orchestrator/jobs/registry.py
+++ b/airbyte-ci/connectors/metadata_service/orchestrator/orchestrator/jobs/registry.py
@@ -1,14 +1,10 @@
 from dagster import define_asset_job, AssetSelection
 from orchestrator.assets import registry_entry
 
-oss_registry_inclusive = AssetSelection.keys(
-    "persist_oss_registry_from_entries", "specs_secrets_mask_yaml"
-).upstream()
+oss_registry_inclusive = AssetSelection.keys("persist_oss_registry_from_entries", "specs_secrets_mask_yaml").upstream()
 generate_oss_registry = define_asset_job(name="generate_oss_registry", selection=oss_registry_inclusive)
 
-cloud_registry_inclusive = AssetSelection.keys(
-    "persist_cloud_registry_from_entries", "specs_secrets_mask_yaml"
-).upstream()
+cloud_registry_inclusive = AssetSelection.keys("persist_cloud_registry_from_entries", "specs_secrets_mask_yaml").upstream()
 generate_cloud_registry = define_asset_job(name="generate_cloud_registry", selection=cloud_registry_inclusive)
 
 registry_reports_inclusive = AssetSelection.keys("connector_registry_report").upstream()

--- a/airbyte-ci/connectors/metadata_service/orchestrator/orchestrator/jobs/registry.py
+++ b/airbyte-ci/connectors/metadata_service/orchestrator/orchestrator/jobs/registry.py
@@ -1,10 +1,10 @@
 from dagster import define_asset_job, AssetSelection
 from orchestrator.assets import registry_entry
 
-oss_registry_inclusive = AssetSelection.keys("persist_oss_registry_from_entries", "specs_secrets_mask_yaml").upstream()
+oss_registry_inclusive = AssetSelection.keys("persisted_oss_registry", "specs_secrets_mask_yaml").upstream()
 generate_oss_registry = define_asset_job(name="generate_oss_registry", selection=oss_registry_inclusive)
 
-cloud_registry_inclusive = AssetSelection.keys("persist_cloud_registry_from_entries", "specs_secrets_mask_yaml").upstream()
+cloud_registry_inclusive = AssetSelection.keys("persisted_cloud_registry", "specs_secrets_mask_yaml").upstream()
 generate_cloud_registry = define_asset_job(name="generate_cloud_registry", selection=cloud_registry_inclusive)
 
 registry_reports_inclusive = AssetSelection.keys("connector_registry_report").upstream()

--- a/airbyte-ci/connectors/metadata_service/orchestrator/orchestrator/models/ci_report.py
+++ b/airbyte-ci/connectors/metadata_service/orchestrator/orchestrator/models/ci_report.py
@@ -1,9 +1,9 @@
-
 from typing import Optional, List
 from pydantic import BaseModel, Extra
 
 # TODO (ben): When the pipeline project is brought into the airbyte-ci folder
 # we should update these models to import their twin models from the pipeline project
+
 
 class ConnectorNightlyReport(BaseModel):
     file_path: str

--- a/airbyte-ci/connectors/metadata_service/orchestrator/orchestrator/models/metadata.py
+++ b/airbyte-ci/connectors/metadata_service/orchestrator/orchestrator/models/metadata.py
@@ -1,5 +1,5 @@
 from metadata_service.models.generated.ConnectorMetadataDefinitionV0 import ConnectorMetadataDefinitionV0
-from pydantic import ValidationError
+from pydantic import ValidationError, BaseModel
 from dataclasses import dataclass
 from typing import Tuple, Any, Optional
 
@@ -41,7 +41,8 @@ class MetadataDefinition(PydanticDictMixin, ConnectorMetadataDefinitionV0):
     pass
 
 
-@dataclass(frozen=True)
-class LatestMetadataEntry:
+class LatestMetadataEntry(BaseModel):
     metadata_definition: MetadataDefinition
     icon_url: Optional[str] = None
+    bucket_name: Optional[str] = None
+    file_path: Optional[str] = None

--- a/airbyte-ci/connectors/metadata_service/orchestrator/orchestrator/resources/gcp.py
+++ b/airbyte-ci/connectors/metadata_service/orchestrator/orchestrator/resources/gcp.py
@@ -176,8 +176,4 @@ def gcs_directory_blobs(resource_context: InitResourceContext) -> storage.Blob:
     if match_regex:
         gcs_file_blobs = [blob for blob in gcs_file_blobs if re.match(match_regex, blob.name)]
 
-    # TODO remove
-    # Limit to 20
-    gcs_file_blobs = gcs_file_blobs[:20]
-
     return gcs_file_blobs

--- a/airbyte-ci/connectors/metadata_service/orchestrator/orchestrator/resources/gcp.py
+++ b/airbyte-ci/connectors/metadata_service/orchestrator/orchestrator/resources/gcp.py
@@ -49,6 +49,11 @@ class ContentTypeAwareGCSFileManager(GCSFileManager):
         key = check.opt_str_param(key, "key", default=str(uuid.uuid4()))
         check_file_like_obj(file_obj)
         gcs_key = self.get_full_key(key + (("." + ext) if ext is not None else ""))
+
+        # remove the first slash if it exists to prevent double slashes
+        if gcs_key.startswith("/"):
+            gcs_key = gcs_key[1:]
+
         bucket_obj = self._client.bucket(self._gcs_bucket)
         blob = bucket_obj.blob(gcs_key)
 

--- a/airbyte-ci/connectors/metadata_service/orchestrator/orchestrator/resources/gcp.py
+++ b/airbyte-ci/connectors/metadata_service/orchestrator/orchestrator/resources/gcp.py
@@ -49,7 +49,6 @@ class ContentTypeAwareGCSFileManager(GCSFileManager):
 
         return full_key
 
-
     def write(self, file_obj, mode="wb", ext=None, key: Optional[str] = None) -> PublicGCSFileHandle:
         """
         Reworked from dagster_gcp.gcs.file_manager.GCSFileManager.write

--- a/airbyte-ci/connectors/metadata_service/orchestrator/orchestrator/resources/gcp.py
+++ b/airbyte-ci/connectors/metadata_service/orchestrator/orchestrator/resources/gcp.py
@@ -40,7 +40,17 @@ class ContentTypeAwareGCSFileManager(GCSFileManager):
         else:
             return "text/plain"
 
-    def write(self, file_obj, mode="wb", ext=None, key: Optional[str] = None):
+    def get_full_key(self, *args, **kwargs):
+        full_key = super().get_full_key(*args, **kwargs)
+
+        # remove the first slash if it exists to prevent double slashes
+        if full_key.startswith("/"):
+            full_key = full_key[1:]
+
+        return full_key
+
+
+    def write(self, file_obj, mode="wb", ext=None, key: Optional[str] = None) -> PublicGCSFileHandle:
         """
         Reworked from dagster_gcp.gcs.file_manager.GCSFileManager.write
 
@@ -49,10 +59,6 @@ class ContentTypeAwareGCSFileManager(GCSFileManager):
         key = check.opt_str_param(key, "key", default=str(uuid.uuid4()))
         check_file_like_obj(file_obj)
         gcs_key = self.get_full_key(key + (("." + ext) if ext is not None else ""))
-
-        # remove the first slash if it exists to prevent double slashes
-        if gcs_key.startswith("/"):
-            gcs_key = gcs_key[1:]
 
         bucket_obj = self._client.bucket(self._gcs_bucket)
         blob = bucket_obj.blob(gcs_key)
@@ -64,6 +70,18 @@ class ContentTypeAwareGCSFileManager(GCSFileManager):
         blob.content_type = self.get_content_type(ext)
 
         blob.upload_from_file(file_obj)
+        return PublicGCSFileHandle(self._gcs_bucket, gcs_key)
+
+    def delete_by_key(self, key: str, ext: Optional[str] = None) -> Optional[PublicGCSFileHandle]:
+        gcs_key = self.get_full_key(key + (("." + ext) if ext is not None else ""))
+        bucket_obj = self._client.bucket(self._gcs_bucket)
+        blob = bucket_obj.blob(gcs_key)
+
+        # if the file does not exist, return None
+        if not blob.exists():
+            return None
+
+        blob.delete()
         return PublicGCSFileHandle(self._gcs_bucket, gcs_key)
 
 

--- a/airbyte-ci/connectors/metadata_service/orchestrator/orchestrator/resources/gcp.py
+++ b/airbyte-ci/connectors/metadata_service/orchestrator/orchestrator/resources/gcp.py
@@ -153,4 +153,8 @@ def gcs_directory_blobs(resource_context: InitResourceContext) -> storage.Blob:
     if match_regex:
         gcs_file_blobs = [blob for blob in gcs_file_blobs if re.match(match_regex, blob.name)]
 
+    # TODO remove
+    # Limit to 20
+    gcs_file_blobs = gcs_file_blobs[:20]
+
     return gcs_file_blobs

--- a/airbyte-ci/connectors/metadata_service/orchestrator/orchestrator/sensors/gcs.py
+++ b/airbyte-ci/connectors/metadata_service/orchestrator/orchestrator/sensors/gcs.py
@@ -3,10 +3,10 @@ from dagster import (
     RunRequest,
     SkipReason,
     SensorDefinition,
+    SensorResult,
     SensorEvaluationContext,
     build_resources,
     DefaultSensorStatus,
-    SensorResult,
 )
 from orchestrator.utils.dagster_helpers import string_array_to_hash
 
@@ -65,7 +65,7 @@ def new_gcs_blobs_partition_sensor(
     TODO
     """
 
-    sensor_name = f"{job.name}_on_new_{gcs_blobs_resource_key}"
+    sensor_name = f"{job.name}_on_new_part_{gcs_blobs_resource_key}"
 
     @sensor(
         name=sensor_name,
@@ -78,8 +78,6 @@ def new_gcs_blobs_partition_sensor(
 
         with build_resources(resources_def) as resources:
             context.log.info(f"Got resources for {sensor_name}")
-
-            context.log.info(f"Old etag cursor: {context.cursor}")
 
             gcs_blobs_resource = getattr(resources, gcs_blobs_resource_key)
 

--- a/airbyte-ci/connectors/metadata_service/orchestrator/orchestrator/sensors/gcs.py
+++ b/airbyte-ci/connectors/metadata_service/orchestrator/orchestrator/sensors/gcs.py
@@ -54,6 +54,7 @@ def new_gcs_blobs_sensor(
 
     return new_gcs_blobs_sensor_definition
 
+
 def new_gcs_blobs_partition_sensor(
     gcs_blobs_resource_key,
     job,
@@ -84,13 +85,7 @@ def new_gcs_blobs_partition_sensor(
 
             gcs_blobs_resource = getattr(resources, gcs_blobs_resource_key)
 
-            new_blobs = [
-                blob
-                for blob in gcs_blobs_resource
-                if not context.instance.has_dynamic_partition(
-                    partitions_def.name, blob.etag
-                )
-            ]
+            new_blobs = [blob for blob in gcs_blobs_resource if not context.instance.has_dynamic_partition(partitions_def.name, blob.etag)]
 
             new_etags_found = [blob.etag for blob in new_blobs]
             context.log.info(f"New etags found: {new_etags_found}")
@@ -105,14 +100,8 @@ def new_gcs_blobs_partition_sensor(
                 context.log.info(f"Only processing first {BLOB_CHUNK_SIZE} new blobs: {new_etags_found}")
 
             return SensorResult(
-                run_requests=[
-                    RunRequest(partition_key=blob.etag) for blob in new_blobs
-                ],
-                dynamic_partitions_requests=[
-                    partitions_def.build_add_request(new_etags_found)
-                ],
+                run_requests=[RunRequest(partition_key=blob.etag) for blob in new_blobs],
+                dynamic_partitions_requests=[partitions_def.build_add_request(new_etags_found)],
             )
 
     return new_gcs_blobs_sensor_definition
-
-

--- a/airbyte-ci/connectors/metadata_service/orchestrator/orchestrator/sensors/gcs.py
+++ b/airbyte-ci/connectors/metadata_service/orchestrator/orchestrator/sensors/gcs.py
@@ -63,9 +63,9 @@ def new_gcs_blobs_partition_sensor(
     partitions_def,
 ) -> SensorDefinition:
     """
-    TODO
+    This sensor is responsible for polling a list of gcs blobs and triggering a partitioned job when the list changes.
     """
-
+    BLOB_CHUNK_SIZE = 30
     sensor_name = f"{job.name}_on_new_{gcs_blobs_resource_key}"
 
     @sensor(
@@ -75,7 +75,6 @@ def new_gcs_blobs_partition_sensor(
         default_status=DefaultSensorStatus.STOPPED,
     )
     def new_gcs_blobs_sensor_definition(context: SensorEvaluationContext):
-        BLOB_CHUNK_SIZE = 25
         context.log.info(f"Starting {sensor_name}")
 
         with build_resources(resources_def) as resources:

--- a/airbyte-ci/connectors/metadata_service/orchestrator/poetry.lock
+++ b/airbyte-ci/connectors/metadata_service/orchestrator/poetry.lock
@@ -475,19 +475,19 @@ tox = ["tox"]
 
 [[package]]
 name = "dagit"
-version = "1.2.7"
+version = "1.3.11"
 description = "Web UI for dagster."
 optional = false
 python-versions = "*"
 files = [
-    {file = "dagit-1.2.7-py3-none-any.whl", hash = "sha256:c1203d02d8fff28a51793fdf3d10826f019fca62d0859e2eac3c3c3237006ed4"},
-    {file = "dagit-1.2.7.tar.gz", hash = "sha256:057f852ab4296028ab87024f45ecc61cfffe20c8815169da51d7258204e80c4f"},
+    {file = "dagit-1.3.11-py3-none-any.whl", hash = "sha256:9b3f65535807d3214dfdfb46f271f6034d81690cc71937bed4f3b39626c56a94"},
+    {file = "dagit-1.3.11.tar.gz", hash = "sha256:f22b95553bfbc215d78ed9905fa020f5bf8e4bd6233f82725a71f5f0971e54f5"},
 ]
 
 [package.dependencies]
 click = ">=7.0,<9.0"
-dagster = "1.2.7"
-dagster-graphql = "1.2.7"
+dagster = "1.3.11"
+dagster-graphql = "1.3.11"
 starlette = "*"
 uvicorn = {version = "*", extras = ["standard"]}
 
@@ -497,17 +497,17 @@ test = ["starlette[full]"]
 
 [[package]]
 name = "dagster"
-version = "1.2.7"
+version = "1.3.11"
 description = "The data orchestration platform built for productivity."
 optional = false
 python-versions = "*"
 files = [
-    {file = "dagster-1.2.7-py3-none-any.whl", hash = "sha256:2063ac378db51bdcb2fffc05eef9b732ea3dcc7099f604a517276f8f0a82117f"},
-    {file = "dagster-1.2.7.tar.gz", hash = "sha256:993a92b29eda9a403b59b4d3bcf18bc4081eae8cb5330f256141143adf531928"},
+    {file = "dagster-1.3.11-py3-none-any.whl", hash = "sha256:8967efad4e75deaad9f7da4031bf5583336063acc127c29ad215a0ba0b71177a"},
+    {file = "dagster-1.3.11.tar.gz", hash = "sha256:20431db82f3d0b2bb47d0828a3ea25ece4ea24f6d8ca8475f7ecc7a0a66d841c"},
 ]
 
 [package.dependencies]
-alembic = ">=1.2.1,<1.6.3 || >1.6.3,<1.7.0 || >1.7.0"
+alembic = ">=1.2.1,<1.6.3 || >1.6.3,<1.7.0 || >1.7.0,<1.11.0 || >1.11.0"
 click = ">=5.0"
 coloredlogs = ">=6.1,<=14.0"
 croniter = ">=0.3.34"
@@ -516,13 +516,16 @@ grpcio = [
     {version = ">=1.44.0,<1.48.0", markers = "python_version < \"3.11\""},
     {version = ">=1.44.0", markers = "python_version >= \"3.11\""},
 ]
-grpcio-health-checking = ">=1.44.0"
+grpcio-health-checking = [
+    {version = ">=1.44.0,<1.48.0", markers = "python_version < \"3.11\""},
+    {version = ">=1.44.0", markers = "python_version >= \"3.11\""},
+]
 Jinja2 = "*"
 packaging = ">=20.9"
 pendulum = "*"
 protobuf = ">=3.20.0"
 psutil = {version = ">=1.0", markers = "platform_system == \"Windows\""}
-pydantic = "*"
+pydantic = "<1.10.7 || >1.10.7,<2.0.0"
 python-dateutil = "*"
 python-dotenv = "*"
 pytz = "*"
@@ -530,7 +533,7 @@ pywin32 = {version = "!=226", markers = "platform_system == \"Windows\""}
 PyYAML = ">=5.1"
 requests = "*"
 setuptools = "*"
-sqlalchemy = ">=1.0,<2.0.0"
+sqlalchemy = ">=1.0"
 tabulate = "*"
 tomli = "*"
 toposort = ">=1.0"
@@ -543,47 +546,47 @@ watchdog = ">=0.8.3"
 black = ["black[jupyter] (==22.12.0)"]
 docker = ["docker"]
 mypy = ["mypy (==0.991)"]
-pyright = ["pandas-stubs", "pyright (==1.1.298)", "types-PyYAML", "types-backports", "types-certifi", "types-chardet", "types-croniter", "types-cryptography", "types-mock", "types-paramiko", "types-pkg-resources", "types-pyOpenSSL", "types-python-dateutil", "types-pytz", "types-requests", "types-simplejson", "types-six", "types-sqlalchemy", "types-tabulate", "types-toml", "types-tzlocal"]
+pyright = ["pandas-stubs", "pyright (==1.1.298)", "types-PyYAML", "types-backports", "types-certifi", "types-chardet", "types-croniter", "types-cryptography", "types-mock", "types-paramiko", "types-pkg-resources", "types-pyOpenSSL", "types-python-dateutil", "types-pytz", "types-requests", "types-simplejson", "types-six", "types-sqlalchemy (==1.4.53.34)", "types-tabulate", "types-toml", "types-tzlocal"]
 ruff = ["ruff (==0.0.255)"]
-test = ["buildkite-test-collector", "docker", "grpcio-tools (>=1.44.0)", "mock (==3.0.5)", "objgraph", "pytest (==7.0.1)", "pytest-cov (==2.10.1)", "pytest-dependency (==0.5.1)", "pytest-mock (==3.3.1)", "pytest-rerunfailures (==10.0)", "pytest-runner (==5.2)", "pytest-xdist (==2.1.0)", "responses", "snapshottest (==0.6.0)", "tox (==3.25.0)", "yamllint"]
+test = ["buildkite-test-collector", "docker", "grpcio-tools (>=1.44.0)", "grpcio-tools (>=1.44.0,<1.48.0)", "mock (==3.0.5)", "objgraph", "pytest (==7.0.1)", "pytest-cov (==2.10.1)", "pytest-dependency (==0.5.1)", "pytest-mock (==3.3.1)", "pytest-rerunfailures (==10.0)", "pytest-runner (==5.2)", "pytest-xdist (==2.1.0)", "responses", "snapshottest (==0.6.0)", "tox (==3.25.0)", "yamllint"]
 
 [[package]]
 name = "dagster-cloud"
-version = "1.2.7"
+version = "1.3.11"
 description = ""
 optional = false
 python-versions = "*"
 files = [
-    {file = "dagster_cloud-1.2.7-py3-none-any.whl", hash = "sha256:5f4a077ebc1170cd8d241a6347cca0346cbaeb85b82fee8697b66e71fba431e1"},
-    {file = "dagster_cloud-1.2.7.tar.gz", hash = "sha256:517f23424166051285ad8e7bd8c7c976c9d072f51709846e7a900942d14a62ad"},
+    {file = "dagster_cloud-1.3.11-py3-none-any.whl", hash = "sha256:d75c3d0fae09713bd5b59bc0e594d236a276b74f1f5d080feffaa10c06d6f1b0"},
+    {file = "dagster_cloud-1.3.11.tar.gz", hash = "sha256:2ec0254c0a325cebebe68954b033f977ee98f16ecca882d16df220b1bd136d61"},
 ]
 
 [package.dependencies]
-dagster = "1.2.7"
-dagster-cloud-cli = "1.2.7"
+dagster = "1.3.11"
+dagster-cloud-cli = "1.3.11"
 pex = "*"
 questionary = "*"
 requests = "*"
 typer = {version = "*", extras = ["all"]}
 
 [package.extras]
-docker = ["dagster-docker (==0.18.7)", "docker"]
-ecs = ["boto3", "dagster-aws (==0.18.7)"]
-kubernetes = ["dagster-k8s (==0.18.7)", "kubernetes"]
+docker = ["dagster-docker (==0.19.11)", "docker"]
+ecs = ["boto3", "dagster-aws (==0.19.11)"]
+kubernetes = ["dagster-k8s (==0.19.11)", "kubernetes"]
 pex = ["boto3"]
 sandbox = ["supervisor"]
 serverless = ["boto3"]
-tests = ["black", "dagster-cloud-test-infra", "dagster-k8s (==0.18.7)", "docker", "httpretty", "isort", "kubernetes", "moto[all]", "mypy", "paramiko", "pylint", "pytest", "types-PyYAML", "types-requests"]
+tests = ["black", "dagster-cloud-test-infra", "dagster-k8s (==0.19.11)", "docker", "httpretty", "isort", "kubernetes", "moto[all]", "mypy", "paramiko", "pylint", "pytest", "types-PyYAML", "types-requests"]
 
 [[package]]
 name = "dagster-cloud-cli"
-version = "1.2.7"
+version = "1.3.11"
 description = ""
 optional = false
 python-versions = "*"
 files = [
-    {file = "dagster_cloud_cli-1.2.7-py3-none-any.whl", hash = "sha256:9a1c41ca3d5c15657f180e042327954e853342fe299a74e0a2721e22078f690f"},
-    {file = "dagster_cloud_cli-1.2.7.tar.gz", hash = "sha256:695881c458759f09187a785522f86756f6ee2f3abac3d4a6638d92ae4206f55e"},
+    {file = "dagster_cloud_cli-1.3.11-py3-none-any.whl", hash = "sha256:89e22b2f35f9b7fbb00a28eff68e4ef18b7c05ad3e5bea77ea8ae885db80d443"},
+    {file = "dagster_cloud_cli-1.3.11.tar.gz", hash = "sha256:dc16f97b7021dbe2492ffa8a05102439b394ab04a21fc3990d1d96f147392d07"},
 ]
 
 [package.dependencies]
@@ -599,18 +602,18 @@ tests = ["freezegun"]
 
 [[package]]
 name = "dagster-gcp"
-version = "0.18.7"
+version = "0.19.11"
 description = "Package for GCP-specific Dagster framework op and resource components."
 optional = false
 python-versions = "*"
 files = [
-    {file = "dagster-gcp-0.18.7.tar.gz", hash = "sha256:942e8313c6b94c194aa313f66bc3fa06daefa35801787ad501739c06a4246523"},
-    {file = "dagster_gcp-0.18.7-py3-none-any.whl", hash = "sha256:6ccd5fd1ed23b4ed8db6651b601acfcc21de73a95636865d85a2b1ec37140aa8"},
+    {file = "dagster-gcp-0.19.11.tar.gz", hash = "sha256:d432d734faff3dbc94d85a5933ae70a5770bf72a4ef035107a010c9dadcbd7cc"},
+    {file = "dagster_gcp-0.19.11-py3-none-any.whl", hash = "sha256:156fcd1b5e849bdc73803079e7f65ca480c25fbfc8b51a20efd0b36c0110b665"},
 ]
 
 [package.dependencies]
-dagster = "1.2.7"
-dagster-pandas = "0.18.7"
+dagster = "1.3.11"
+dagster-pandas = "0.19.11"
 db-dtypes = "*"
 google-api-python-client = "*"
 google-cloud-bigquery = "*"
@@ -622,35 +625,36 @@ pyarrow = ["pyarrow"]
 
 [[package]]
 name = "dagster-graphql"
-version = "1.2.7"
+version = "1.3.11"
 description = "The GraphQL frontend to python dagster."
 optional = false
 python-versions = "*"
 files = [
-    {file = "dagster-graphql-1.2.7.tar.gz", hash = "sha256:394f4933eb7fd3ab789cefdcd98f521e57e31b88f18f38807efbee55a9f9a378"},
-    {file = "dagster_graphql-1.2.7-py3-none-any.whl", hash = "sha256:e07a4f3505219d76302b48e5e5d568b0bd51b7508d071d269ebd59ce598e01e8"},
+    {file = "dagster-graphql-1.3.11.tar.gz", hash = "sha256:ff05df0bb0d89299250af090166f0a288530d1ac48ce16706b3aed10b44bc864"},
+    {file = "dagster_graphql-1.3.11-py3-none-any.whl", hash = "sha256:043d9d5493a6b74779a926fbdf5eb3f295dd8ccf8f0009173f2a7294ae846dba"},
 ]
 
 [package.dependencies]
-dagster = "1.2.7"
+dagster = "1.3.11"
 gql = {version = ">=3.0.0", extras = ["requests"]}
 graphene = ">=3"
 requests = "*"
 starlette = "*"
+urllib3 = "<2.0.0"
 
 [[package]]
 name = "dagster-pandas"
-version = "0.18.7"
+version = "0.19.11"
 description = "Utilities and examples for working with pandas and dagster, an opinionated framework for expressing data pipelines"
 optional = false
 python-versions = "*"
 files = [
-    {file = "dagster-pandas-0.18.7.tar.gz", hash = "sha256:aa4e984a4c762d8dd121f139b11d821b5e29de5d4e67c168a3936e317ef5dbe8"},
-    {file = "dagster_pandas-0.18.7-py3-none-any.whl", hash = "sha256:64737bcf9d94666c3dc8ca5f3dc12426ed3f557bf4596847874d9d8bb15b0373"},
+    {file = "dagster-pandas-0.19.11.tar.gz", hash = "sha256:4db127b7fcdf08cd2d03da007549b022ca82c5757060b09ba7f721a2b37329de"},
+    {file = "dagster_pandas-0.19.11-py3-none-any.whl", hash = "sha256:f2f07cf8e246adfd11eef6d3bbe40fa79b4f61757fd035f9d14684037d0e5094"},
 ]
 
 [package.dependencies]
-dagster = "1.2.7"
+dagster = "1.3.11"
 pandas = "*"
 
 [[package]]
@@ -2722,47 +2726,47 @@ files = [
 
 [[package]]
 name = "pydantic"
-version = "1.10.7"
+version = "1.10.9"
 description = "Data validation and settings management using python type hints"
 optional = false
 python-versions = ">=3.7"
 files = [
-    {file = "pydantic-1.10.7-cp310-cp310-macosx_10_9_x86_64.whl", hash = "sha256:e79e999e539872e903767c417c897e729e015872040e56b96e67968c3b918b2d"},
-    {file = "pydantic-1.10.7-cp310-cp310-macosx_11_0_arm64.whl", hash = "sha256:01aea3a42c13f2602b7ecbbea484a98169fb568ebd9e247593ea05f01b884b2e"},
-    {file = "pydantic-1.10.7-cp310-cp310-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:516f1ed9bc2406a0467dd777afc636c7091d71f214d5e413d64fef45174cfc7a"},
-    {file = "pydantic-1.10.7-cp310-cp310-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:ae150a63564929c675d7f2303008d88426a0add46efd76c3fc797cd71cb1b46f"},
-    {file = "pydantic-1.10.7-cp310-cp310-musllinux_1_1_i686.whl", hash = "sha256:ecbbc51391248116c0a055899e6c3e7ffbb11fb5e2a4cd6f2d0b93272118a209"},
-    {file = "pydantic-1.10.7-cp310-cp310-musllinux_1_1_x86_64.whl", hash = "sha256:f4a2b50e2b03d5776e7f21af73e2070e1b5c0d0df255a827e7c632962f8315af"},
-    {file = "pydantic-1.10.7-cp310-cp310-win_amd64.whl", hash = "sha256:a7cd2251439988b413cb0a985c4ed82b6c6aac382dbaff53ae03c4b23a70e80a"},
-    {file = "pydantic-1.10.7-cp311-cp311-macosx_10_9_x86_64.whl", hash = "sha256:68792151e174a4aa9e9fc1b4e653e65a354a2fa0fed169f7b3d09902ad2cb6f1"},
-    {file = "pydantic-1.10.7-cp311-cp311-macosx_11_0_arm64.whl", hash = "sha256:dfe2507b8ef209da71b6fb5f4e597b50c5a34b78d7e857c4f8f3115effaef5fe"},
-    {file = "pydantic-1.10.7-cp311-cp311-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:10a86d8c8db68086f1e30a530f7d5f83eb0685e632e411dbbcf2d5c0150e8dcd"},
-    {file = "pydantic-1.10.7-cp311-cp311-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:d75ae19d2a3dbb146b6f324031c24f8a3f52ff5d6a9f22f0683694b3afcb16fb"},
-    {file = "pydantic-1.10.7-cp311-cp311-musllinux_1_1_i686.whl", hash = "sha256:464855a7ff7f2cc2cf537ecc421291b9132aa9c79aef44e917ad711b4a93163b"},
-    {file = "pydantic-1.10.7-cp311-cp311-musllinux_1_1_x86_64.whl", hash = "sha256:193924c563fae6ddcb71d3f06fa153866423ac1b793a47936656e806b64e24ca"},
-    {file = "pydantic-1.10.7-cp311-cp311-win_amd64.whl", hash = "sha256:b4a849d10f211389502059c33332e91327bc154acc1845f375a99eca3afa802d"},
-    {file = "pydantic-1.10.7-cp37-cp37m-macosx_10_9_x86_64.whl", hash = "sha256:cc1dde4e50a5fc1336ee0581c1612215bc64ed6d28d2c7c6f25d2fe3e7c3e918"},
-    {file = "pydantic-1.10.7-cp37-cp37m-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:e0cfe895a504c060e5d36b287ee696e2fdad02d89e0d895f83037245218a87fe"},
-    {file = "pydantic-1.10.7-cp37-cp37m-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:670bb4683ad1e48b0ecb06f0cfe2178dcf74ff27921cdf1606e527d2617a81ee"},
-    {file = "pydantic-1.10.7-cp37-cp37m-musllinux_1_1_i686.whl", hash = "sha256:950ce33857841f9a337ce07ddf46bc84e1c4946d2a3bba18f8280297157a3fd1"},
-    {file = "pydantic-1.10.7-cp37-cp37m-musllinux_1_1_x86_64.whl", hash = "sha256:c15582f9055fbc1bfe50266a19771bbbef33dd28c45e78afbe1996fd70966c2a"},
-    {file = "pydantic-1.10.7-cp37-cp37m-win_amd64.whl", hash = "sha256:82dffb306dd20bd5268fd6379bc4bfe75242a9c2b79fec58e1041fbbdb1f7914"},
-    {file = "pydantic-1.10.7-cp38-cp38-macosx_10_9_x86_64.whl", hash = "sha256:8c7f51861d73e8b9ddcb9916ae7ac39fb52761d9ea0df41128e81e2ba42886cd"},
-    {file = "pydantic-1.10.7-cp38-cp38-macosx_11_0_arm64.whl", hash = "sha256:6434b49c0b03a51021ade5c4daa7d70c98f7a79e95b551201fff682fc1661245"},
-    {file = "pydantic-1.10.7-cp38-cp38-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:64d34ab766fa056df49013bb6e79921a0265204c071984e75a09cbceacbbdd5d"},
-    {file = "pydantic-1.10.7-cp38-cp38-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:701daea9ffe9d26f97b52f1d157e0d4121644f0fcf80b443248434958fd03dc3"},
-    {file = "pydantic-1.10.7-cp38-cp38-musllinux_1_1_i686.whl", hash = "sha256:cf135c46099ff3f919d2150a948ce94b9ce545598ef2c6c7bf55dca98a304b52"},
-    {file = "pydantic-1.10.7-cp38-cp38-musllinux_1_1_x86_64.whl", hash = "sha256:b0f85904f73161817b80781cc150f8b906d521fa11e3cdabae19a581c3606209"},
-    {file = "pydantic-1.10.7-cp38-cp38-win_amd64.whl", hash = "sha256:9f6f0fd68d73257ad6685419478c5aece46432f4bdd8d32c7345f1986496171e"},
-    {file = "pydantic-1.10.7-cp39-cp39-macosx_10_9_x86_64.whl", hash = "sha256:c230c0d8a322276d6e7b88c3f7ce885f9ed16e0910354510e0bae84d54991143"},
-    {file = "pydantic-1.10.7-cp39-cp39-macosx_11_0_arm64.whl", hash = "sha256:976cae77ba6a49d80f461fd8bba183ff7ba79f44aa5cfa82f1346b5626542f8e"},
-    {file = "pydantic-1.10.7-cp39-cp39-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:7d45fc99d64af9aaf7e308054a0067fdcd87ffe974f2442312372dfa66e1001d"},
-    {file = "pydantic-1.10.7-cp39-cp39-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:d2a5ebb48958754d386195fe9e9c5106f11275867051bf017a8059410e9abf1f"},
-    {file = "pydantic-1.10.7-cp39-cp39-musllinux_1_1_i686.whl", hash = "sha256:abfb7d4a7cd5cc4e1d1887c43503a7c5dd608eadf8bc615413fc498d3e4645cd"},
-    {file = "pydantic-1.10.7-cp39-cp39-musllinux_1_1_x86_64.whl", hash = "sha256:80b1fab4deb08a8292d15e43a6edccdffa5377a36a4597bb545b93e79c5ff0a5"},
-    {file = "pydantic-1.10.7-cp39-cp39-win_amd64.whl", hash = "sha256:d71e69699498b020ea198468e2480a2f1e7433e32a3a99760058c6520e2bea7e"},
-    {file = "pydantic-1.10.7-py3-none-any.whl", hash = "sha256:0cd181f1d0b1d00e2b705f1bf1ac7799a2d938cce3376b8007df62b29be3c2c6"},
-    {file = "pydantic-1.10.7.tar.gz", hash = "sha256:cfc83c0678b6ba51b0532bea66860617c4cd4251ecf76e9846fa5a9f3454e97e"},
+    {file = "pydantic-1.10.9-cp310-cp310-macosx_10_9_x86_64.whl", hash = "sha256:e692dec4a40bfb40ca530e07805b1208c1de071a18d26af4a2a0d79015b352ca"},
+    {file = "pydantic-1.10.9-cp310-cp310-macosx_11_0_arm64.whl", hash = "sha256:3c52eb595db83e189419bf337b59154bdcca642ee4b2a09e5d7797e41ace783f"},
+    {file = "pydantic-1.10.9-cp310-cp310-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:939328fd539b8d0edf244327398a667b6b140afd3bf7e347cf9813c736211896"},
+    {file = "pydantic-1.10.9-cp310-cp310-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:b48d3d634bca23b172f47f2335c617d3fcb4b3ba18481c96b7943a4c634f5c8d"},
+    {file = "pydantic-1.10.9-cp310-cp310-musllinux_1_1_i686.whl", hash = "sha256:f0b7628fb8efe60fe66fd4adadd7ad2304014770cdc1f4934db41fe46cc8825f"},
+    {file = "pydantic-1.10.9-cp310-cp310-musllinux_1_1_x86_64.whl", hash = "sha256:e1aa5c2410769ca28aa9a7841b80d9d9a1c5f223928ca8bec7e7c9a34d26b1d4"},
+    {file = "pydantic-1.10.9-cp310-cp310-win_amd64.whl", hash = "sha256:eec39224b2b2e861259d6f3c8b6290d4e0fbdce147adb797484a42278a1a486f"},
+    {file = "pydantic-1.10.9-cp311-cp311-macosx_10_9_x86_64.whl", hash = "sha256:d111a21bbbfd85c17248130deac02bbd9b5e20b303338e0dbe0faa78330e37e0"},
+    {file = "pydantic-1.10.9-cp311-cp311-macosx_11_0_arm64.whl", hash = "sha256:2e9aec8627a1a6823fc62fb96480abe3eb10168fd0d859ee3d3b395105ae19a7"},
+    {file = "pydantic-1.10.9-cp311-cp311-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:07293ab08e7b4d3c9d7de4949a0ea571f11e4557d19ea24dd3ae0c524c0c334d"},
+    {file = "pydantic-1.10.9-cp311-cp311-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:7ee829b86ce984261d99ff2fd6e88f2230068d96c2a582f29583ed602ef3fc2c"},
+    {file = "pydantic-1.10.9-cp311-cp311-musllinux_1_1_i686.whl", hash = "sha256:4b466a23009ff5cdd7076eb56aca537c745ca491293cc38e72bf1e0e00de5b91"},
+    {file = "pydantic-1.10.9-cp311-cp311-musllinux_1_1_x86_64.whl", hash = "sha256:7847ca62e581e6088d9000f3c497267868ca2fa89432714e21a4fb33a04d52e8"},
+    {file = "pydantic-1.10.9-cp311-cp311-win_amd64.whl", hash = "sha256:7845b31959468bc5b78d7b95ec52fe5be32b55d0d09983a877cca6aedc51068f"},
+    {file = "pydantic-1.10.9-cp37-cp37m-macosx_10_9_x86_64.whl", hash = "sha256:517a681919bf880ce1dac7e5bc0c3af1e58ba118fd774da2ffcd93c5f96eaece"},
+    {file = "pydantic-1.10.9-cp37-cp37m-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:67195274fd27780f15c4c372f4ba9a5c02dad6d50647b917b6a92bf00b3d301a"},
+    {file = "pydantic-1.10.9-cp37-cp37m-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:2196c06484da2b3fded1ab6dbe182bdabeb09f6318b7fdc412609ee2b564c49a"},
+    {file = "pydantic-1.10.9-cp37-cp37m-musllinux_1_1_i686.whl", hash = "sha256:6257bb45ad78abacda13f15bde5886efd6bf549dd71085e64b8dcf9919c38b60"},
+    {file = "pydantic-1.10.9-cp37-cp37m-musllinux_1_1_x86_64.whl", hash = "sha256:3283b574b01e8dbc982080d8287c968489d25329a463b29a90d4157de4f2baaf"},
+    {file = "pydantic-1.10.9-cp37-cp37m-win_amd64.whl", hash = "sha256:5f8bbaf4013b9a50e8100333cc4e3fa2f81214033e05ac5aa44fa24a98670a29"},
+    {file = "pydantic-1.10.9-cp38-cp38-macosx_10_9_x86_64.whl", hash = "sha256:b9cd67fb763248cbe38f0593cd8611bfe4b8ad82acb3bdf2b0898c23415a1f82"},
+    {file = "pydantic-1.10.9-cp38-cp38-macosx_11_0_arm64.whl", hash = "sha256:f50e1764ce9353be67267e7fd0da08349397c7db17a562ad036aa7c8f4adfdb6"},
+    {file = "pydantic-1.10.9-cp38-cp38-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:73ef93e5e1d3c8e83f1ff2e7fdd026d9e063c7e089394869a6e2985696693766"},
+    {file = "pydantic-1.10.9-cp38-cp38-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:128d9453d92e6e81e881dd7e2484e08d8b164da5507f62d06ceecf84bf2e21d3"},
+    {file = "pydantic-1.10.9-cp38-cp38-musllinux_1_1_i686.whl", hash = "sha256:ad428e92ab68798d9326bb3e5515bc927444a3d71a93b4a2ca02a8a5d795c572"},
+    {file = "pydantic-1.10.9-cp38-cp38-musllinux_1_1_x86_64.whl", hash = "sha256:fab81a92f42d6d525dd47ced310b0c3e10c416bbfae5d59523e63ea22f82b31e"},
+    {file = "pydantic-1.10.9-cp38-cp38-win_amd64.whl", hash = "sha256:963671eda0b6ba6926d8fc759e3e10335e1dc1b71ff2a43ed2efd6996634dafb"},
+    {file = "pydantic-1.10.9-cp39-cp39-macosx_10_9_x86_64.whl", hash = "sha256:970b1bdc6243ef663ba5c7e36ac9ab1f2bfecb8ad297c9824b542d41a750b298"},
+    {file = "pydantic-1.10.9-cp39-cp39-macosx_11_0_arm64.whl", hash = "sha256:7e1d5290044f620f80cf1c969c542a5468f3656de47b41aa78100c5baa2b8276"},
+    {file = "pydantic-1.10.9-cp39-cp39-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:83fcff3c7df7adff880622a98022626f4f6dbce6639a88a15a3ce0f96466cb60"},
+    {file = "pydantic-1.10.9-cp39-cp39-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:0da48717dc9495d3a8f215e0d012599db6b8092db02acac5e0d58a65248ec5bc"},
+    {file = "pydantic-1.10.9-cp39-cp39-musllinux_1_1_i686.whl", hash = "sha256:0a2aabdc73c2a5960e87c3ffebca6ccde88665616d1fd6d3db3178ef427b267a"},
+    {file = "pydantic-1.10.9-cp39-cp39-musllinux_1_1_x86_64.whl", hash = "sha256:9863b9420d99dfa9c064042304868e8ba08e89081428a1c471858aa2af6f57c4"},
+    {file = "pydantic-1.10.9-cp39-cp39-win_amd64.whl", hash = "sha256:e7c9900b43ac14110efa977be3da28931ffc74c27e96ee89fbcaaf0b0fe338e1"},
+    {file = "pydantic-1.10.9-py3-none-any.whl", hash = "sha256:6cafde02f6699ce4ff643417d1a9223716ec25e228ddc3b436fe7e2d25a1f305"},
+    {file = "pydantic-1.10.9.tar.gz", hash = "sha256:95c70da2cd3b6ddf3b9645ecaa8d98f3d80c606624b6d245558d202cd23ea3be"},
 ]
 
 [package.dependencies]
@@ -4155,4 +4159,4 @@ testing = ["big-O", "flake8 (<5)", "jaraco.functools", "jaraco.itertools", "more
 [metadata]
 lock-version = "2.0"
 python-versions = "^3.9"
-content-hash = "5301b7d20abd2ad167ab1d1148e41ab360e44cd754ca938c6108fbb457d7ae9d"
+content-hash = "dab138e37f6453cf163afb60cc4c2942a8bdc5a72253c8f6bf934fb76ceb1ca1"

--- a/airbyte-ci/connectors/metadata_service/orchestrator/poetry.lock
+++ b/airbyte-ci/connectors/metadata_service/orchestrator/poetry.lock
@@ -65,6 +65,24 @@ files = [
 ]
 
 [[package]]
+name = "attrs"
+version = "23.1.0"
+description = "Classes Without Boilerplate"
+optional = false
+python-versions = ">=3.7"
+files = [
+    {file = "attrs-23.1.0-py3-none-any.whl", hash = "sha256:1f28b4522cdc2fb4256ac1a020c78acf9cba2c6b461ccd2c126f3aa8e8335d04"},
+    {file = "attrs-23.1.0.tar.gz", hash = "sha256:6279836d581513a26f1bf235f9acd333bc9115683f14f7e8fae46c98fc50e015"},
+]
+
+[package.extras]
+cov = ["attrs[tests]", "coverage[toml] (>=5.3)"]
+dev = ["attrs[docs,tests]", "pre-commit"]
+docs = ["furo", "myst-parser", "sphinx", "sphinx-notfound-page", "sphinxcontrib-towncrier", "towncrier", "zope-interface"]
+tests = ["attrs[tests-no-zope]", "zope-interface"]
+tests-no-zope = ["cloudpickle", "hypothesis", "mypy (>=1.1.1)", "pympler", "pytest (>=4.3.0)", "pytest-mypy-plugins", "pytest-xdist[psutil]"]
+
+[[package]]
 name = "backoff"
 version = "2.2.1"
 description = "Function decoration for backoff and retry"
@@ -92,6 +110,49 @@ soupsieve = ">1.2"
 [package.extras]
 html5lib = ["html5lib"]
 lxml = ["lxml"]
+
+[[package]]
+name = "build"
+version = "0.10.0"
+description = "A simple, correct Python build frontend"
+optional = false
+python-versions = ">= 3.7"
+files = [
+    {file = "build-0.10.0-py3-none-any.whl", hash = "sha256:af266720050a66c893a6096a2f410989eeac74ff9a68ba194b3f6473e8e26171"},
+    {file = "build-0.10.0.tar.gz", hash = "sha256:d5b71264afdb5951d6704482aac78de887c80691c52b88a9ad195983ca2c9269"},
+]
+
+[package.dependencies]
+colorama = {version = "*", markers = "os_name == \"nt\""}
+packaging = ">=19.0"
+pyproject_hooks = "*"
+tomli = {version = ">=1.1.0", markers = "python_version < \"3.11\""}
+
+[package.extras]
+docs = ["furo (>=2021.08.31)", "sphinx (>=4.0,<5.0)", "sphinx-argparse-cli (>=1.5)", "sphinx-autodoc-typehints (>=1.10)"]
+test = ["filelock (>=3)", "pytest (>=6.2.4)", "pytest-cov (>=2.12)", "pytest-mock (>=2)", "pytest-rerunfailures (>=9.1)", "pytest-xdist (>=1.34)", "setuptools (>=42.0.0)", "setuptools (>=56.0.0)", "toml (>=0.10.0)", "wheel (>=0.36.0)"]
+typing = ["importlib-metadata (>=5.1)", "mypy (==0.991)", "tomli", "typing-extensions (>=3.7.4.3)"]
+virtualenv = ["virtualenv (>=20.0.35)"]
+
+[[package]]
+name = "cachecontrol"
+version = "0.12.14"
+description = "httplib2 caching for requests"
+optional = false
+python-versions = ">=3.6"
+files = [
+    {file = "CacheControl-0.12.14-py2.py3-none-any.whl", hash = "sha256:1c2939be362a70c4e5f02c6249462b3b7a24441e4f1ced5e9ef028172edf356a"},
+    {file = "CacheControl-0.12.14.tar.gz", hash = "sha256:d1087f45781c0e00616479bfd282c78504371ca71da017b49df9f5365a95feba"},
+]
+
+[package.dependencies]
+lockfile = {version = ">=0.9", optional = true, markers = "extra == \"filecache\""}
+msgpack = ">=0.5.2"
+requests = "*"
+
+[package.extras]
+filecache = ["lockfile (>=0.9)"]
+redis = ["redis (>=2.10.5)"]
 
 [[package]]
 name = "cachetools"
@@ -276,6 +337,21 @@ files = [
 ]
 
 [[package]]
+name = "cleo"
+version = "2.0.1"
+description = "Cleo allows you to create beautiful and testable command-line interfaces."
+optional = false
+python-versions = ">=3.7,<4.0"
+files = [
+    {file = "cleo-2.0.1-py3-none-any.whl", hash = "sha256:6eb133670a3ed1f3b052d53789017b6e50fca66d1287e6e6696285f4cb8ea448"},
+    {file = "cleo-2.0.1.tar.gz", hash = "sha256:eb4b2e1f3063c11085cebe489a6e9124163c226575a3c3be69b2e51af4a15ec5"},
+]
+
+[package.dependencies]
+crashtest = ">=0.4.1,<0.5.0"
+rapidfuzz = ">=2.2.0,<3.0.0"
+
+[[package]]
 name = "click"
 version = "8.1.3"
 description = "Composable command line interface toolkit"
@@ -330,6 +406,17 @@ files = [
 
 [package.extras]
 test = ["flake8 (==3.7.8)", "hypothesis (==3.55.3)"]
+
+[[package]]
+name = "crashtest"
+version = "0.4.1"
+description = "Manage Python errors with ease"
+optional = false
+python-versions = ">=3.7,<4.0"
+files = [
+    {file = "crashtest-0.4.1-py3-none-any.whl", hash = "sha256:8d23eac5fa660409f57472e3851dab7ac18aba459a8d19cbbba86d3d5aecd2a5"},
+    {file = "crashtest-0.4.1.tar.gz", hash = "sha256:80d7b1f316ebfbd429f648076d6275c877ba30ba48979de4191714a75266f0ce"},
+]
 
 [[package]]
 name = "croniter"
@@ -619,6 +706,17 @@ wrapt = ">=1.10,<2"
 dev = ["PyTest", "PyTest (<5)", "PyTest-Cov", "PyTest-Cov (<2.6)", "bump2version (<1)", "configparser (<5)", "importlib-metadata (<3)", "importlib-resources (<4)", "sphinx (<2)", "sphinxcontrib-websupport (<2)", "tox", "zipp (<2)"]
 
 [[package]]
+name = "distlib"
+version = "0.3.6"
+description = "Distribution utilities"
+optional = false
+python-versions = "*"
+files = [
+    {file = "distlib-0.3.6-py2.py3-none-any.whl", hash = "sha256:f35c4b692542ca110de7ef0bea44d73981caeb34ca0b9b6b2e6d7790dda8f80e"},
+    {file = "distlib-0.3.6.tar.gz", hash = "sha256:14bad2d9b04d3a36127ac97f30b12a19268f211063d8f8ee4f47108896e11b46"},
+]
+
+[[package]]
 name = "docstring-parser"
 version = "0.15"
 description = "Parse Python docstrings in reST, Google and Numpydoc format"
@@ -641,6 +739,80 @@ files = [
 ]
 
 [[package]]
+name = "dulwich"
+version = "0.21.5"
+description = "Python Git Library"
+optional = false
+python-versions = ">=3.7"
+files = [
+    {file = "dulwich-0.21.5-cp310-cp310-macosx_10_9_universal2.whl", hash = "sha256:8864719bc176cdd27847332a2059127e2f7bab7db2ff99a999873cb7fff54116"},
+    {file = "dulwich-0.21.5-cp310-cp310-macosx_10_9_x86_64.whl", hash = "sha256:3800cdc17d144c1f7e114972293bd6c46688f5bcc2c9228ed0537ded72394082"},
+    {file = "dulwich-0.21.5-cp310-cp310-macosx_11_0_arm64.whl", hash = "sha256:e2f676bfed8146966fe934ee734969d7d81548fbd250a8308582973670a9dab1"},
+    {file = "dulwich-0.21.5-cp310-cp310-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:4db330fb59fe3b9d253bdf0e49a521739db83689520c4921ab1c5242aaf77b82"},
+    {file = "dulwich-0.21.5-cp310-cp310-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:3e8f6d4f4f4d01dd1d3c968e486d4cd77f96f772da7265941bc506de0944ddb9"},
+    {file = "dulwich-0.21.5-cp310-cp310-musllinux_1_1_aarch64.whl", hash = "sha256:1cc0c9ba19ac1b2372598802bc9201a9c45e5d6f1f7a80ec40deeb10acc4e9ae"},
+    {file = "dulwich-0.21.5-cp310-cp310-musllinux_1_1_x86_64.whl", hash = "sha256:61e10242b5a7a82faa8996b2c76239cfb633620b02cdd2946e8af6e7eb31d651"},
+    {file = "dulwich-0.21.5-cp310-cp310-win32.whl", hash = "sha256:7f357639b56146a396f48e5e0bc9bbaca3d6d51c8340bd825299272b588fff5f"},
+    {file = "dulwich-0.21.5-cp310-cp310-win_amd64.whl", hash = "sha256:891d5c73e2b66d05dbb502e44f027dc0dbbd8f6198bc90dae348152e69d0befc"},
+    {file = "dulwich-0.21.5-cp311-cp311-macosx_10_9_universal2.whl", hash = "sha256:45d6198e804b539708b73a003419e48fb42ff2c3c6dd93f63f3b134dff6dd259"},
+    {file = "dulwich-0.21.5-cp311-cp311-macosx_10_9_x86_64.whl", hash = "sha256:c2a565d4e704d7f784cdf9637097141f6d47129c8fffc2fac699d57cb075a169"},
+    {file = "dulwich-0.21.5-cp311-cp311-macosx_11_0_arm64.whl", hash = "sha256:823091d6b6a1ea07dc4839c9752198fb39193213d103ac189c7669736be2eaff"},
+    {file = "dulwich-0.21.5-cp311-cp311-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:b2c9931b657f2206abec0964ec2355ee2c1e04d05f8864e823ffa23c548c4548"},
+    {file = "dulwich-0.21.5-cp311-cp311-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:7dc358c2ee727322a09b7c6da43d47a1026049dbd3ad8d612eddca1f9074b298"},
+    {file = "dulwich-0.21.5-cp311-cp311-musllinux_1_1_aarch64.whl", hash = "sha256:6155ab7388ee01c670f7c5d8003d4e133eebebc7085a856c007989f0ba921b36"},
+    {file = "dulwich-0.21.5-cp311-cp311-musllinux_1_1_x86_64.whl", hash = "sha256:a605e10d72f90a39ea2e634fbfd80f866fc4df29a02ea6db52ae92e5fd4a2003"},
+    {file = "dulwich-0.21.5-cp311-cp311-win32.whl", hash = "sha256:daa607370722c3dce99a0022397c141caefb5ed32032a4f72506f4817ea6405b"},
+    {file = "dulwich-0.21.5-cp311-cp311-win_amd64.whl", hash = "sha256:5e56b2c1911c344527edb2bf1a4356e2fb7e086b1ba309666e1e5c2224cdca8a"},
+    {file = "dulwich-0.21.5-cp37-cp37m-macosx_10_9_x86_64.whl", hash = "sha256:85d3401d08b1ec78c7d58ae987c4bb7b768a438f3daa74aeb8372bebc7fb16fa"},
+    {file = "dulwich-0.21.5-cp37-cp37m-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:90479608e49db93d8c9e4323bc0ec5496678b535446e29d8fd67dc5bbb5d51bf"},
+    {file = "dulwich-0.21.5-cp37-cp37m-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:f9a6bf99f57bcac4c77fc60a58f1b322c91cc4d8c65dc341f76bf402622f89cb"},
+    {file = "dulwich-0.21.5-cp37-cp37m-musllinux_1_1_aarch64.whl", hash = "sha256:3e68b162af2aae995355e7920f89d50d72b53d56021e5ac0a546d493b17cbf7e"},
+    {file = "dulwich-0.21.5-cp37-cp37m-musllinux_1_1_x86_64.whl", hash = "sha256:0ab86d6d42e385bf3438e70f3c9b16de68018bd88929379e3484c0ef7990bd3c"},
+    {file = "dulwich-0.21.5-cp37-cp37m-win32.whl", hash = "sha256:f2eeca6d61366cf5ee8aef45bed4245a67d4c0f0d731dc2383eabb80fa695683"},
+    {file = "dulwich-0.21.5-cp37-cp37m-win_amd64.whl", hash = "sha256:1b20a3656b48c941d49c536824e1e5278a695560e8de1a83b53a630143c4552e"},
+    {file = "dulwich-0.21.5-cp38-cp38-macosx_10_9_universal2.whl", hash = "sha256:3932b5e17503b265a85f1eda77ede647681c3bab53bc9572955b6b282abd26ea"},
+    {file = "dulwich-0.21.5-cp38-cp38-macosx_10_9_x86_64.whl", hash = "sha256:6616132d219234580de88ceb85dd51480dc43b1bdc05887214b8dd9cfd4a9d40"},
+    {file = "dulwich-0.21.5-cp38-cp38-macosx_11_0_arm64.whl", hash = "sha256:eaf6c7fb6b13495c19c9aace88821c2ade3c8c55b4e216cd7cc55d3e3807d7fa"},
+    {file = "dulwich-0.21.5-cp38-cp38-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:be12a46f73023970125808a4a78f610c055373096c1ecea3280edee41613eba8"},
+    {file = "dulwich-0.21.5-cp38-cp38-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:baecef0d8b9199822c7912876a03a1af17833f6c0d461efb62decebd45897e49"},
+    {file = "dulwich-0.21.5-cp38-cp38-musllinux_1_1_aarch64.whl", hash = "sha256:82f632afb9c7c341a875d46aaa3e6c5e586c7a64ce36c9544fa400f7e4f29754"},
+    {file = "dulwich-0.21.5-cp38-cp38-musllinux_1_1_x86_64.whl", hash = "sha256:82cdf482f8f51fcc965ffad66180b54a9abaea9b1e985a32e1acbfedf6e0e363"},
+    {file = "dulwich-0.21.5-cp38-cp38-win32.whl", hash = "sha256:c8ded43dc0bd2e65420eb01e778034be5ca7f72e397a839167eda7dcb87c4248"},
+    {file = "dulwich-0.21.5-cp38-cp38-win_amd64.whl", hash = "sha256:2aba0fdad2a19bd5bb3aad6882580cb33359c67b48412ccd4cfccd932012b35e"},
+    {file = "dulwich-0.21.5-cp39-cp39-macosx_10_9_universal2.whl", hash = "sha256:fd4ad079758514375f11469e081723ba8831ce4eaa1a64b41f06a3a866d5ac34"},
+    {file = "dulwich-0.21.5-cp39-cp39-macosx_10_9_x86_64.whl", hash = "sha256:7fe62685bf356bfb4d0738f84a3fcf0d1fc9e11fee152e488a20b8c66a52429e"},
+    {file = "dulwich-0.21.5-cp39-cp39-macosx_11_0_arm64.whl", hash = "sha256:aae448da7d80306dda4fc46292fed7efaa466294571ab3448be16714305076f1"},
+    {file = "dulwich-0.21.5-cp39-cp39-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:b24cb1fad0525dba4872e9381bc576ea2a6dcdf06b0ed98f8e953e3b1d719b89"},
+    {file = "dulwich-0.21.5-cp39-cp39-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:1e39b7c2c9bda6acae83b25054650a8bb7e373e886e2334721d384e1479bf04b"},
+    {file = "dulwich-0.21.5-cp39-cp39-musllinux_1_1_aarch64.whl", hash = "sha256:26456dba39d1209fca17187db06967130e27eeecad2b3c2bbbe63467b0bf09d6"},
+    {file = "dulwich-0.21.5-cp39-cp39-musllinux_1_1_x86_64.whl", hash = "sha256:281310644e02e3aa6d76bcaffe2063b9031213c4916b5f1a6e68c25bdecfaba4"},
+    {file = "dulwich-0.21.5-cp39-cp39-win32.whl", hash = "sha256:4814ca3209dabe0fe7719e9545fbdad7f8bb250c5a225964fe2a31069940c4cf"},
+    {file = "dulwich-0.21.5-cp39-cp39-win_amd64.whl", hash = "sha256:c922a4573267486be0ef85216f2da103fb38075b8465dc0e90457843884e4860"},
+    {file = "dulwich-0.21.5-pp37-pypy37_pp73-macosx_10_9_x86_64.whl", hash = "sha256:e52b20c4368171b7d32bd3ab0f1d2402e76ad4f2ea915ff9aa73bc9fa2b54d6d"},
+    {file = "dulwich-0.21.5-pp37-pypy37_pp73-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:aeb736d777ee21f2117a90fc453ee181aa7eedb9e255b5ef07c51733f3fe5cb6"},
+    {file = "dulwich-0.21.5-pp37-pypy37_pp73-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:5e8a79c1ed7166f32ad21974fa98d11bf6fd74e94a47e754c777c320e01257c6"},
+    {file = "dulwich-0.21.5-pp37-pypy37_pp73-win_amd64.whl", hash = "sha256:b943517e30bd651fbc275a892bb96774f3893d95fe5a4dedd84496a98eaaa8ab"},
+    {file = "dulwich-0.21.5-pp38-pypy38_pp73-macosx_10_9_x86_64.whl", hash = "sha256:32493a456358a3a6c15bbda07106fc3d4cc50834ee18bc7717968d18be59b223"},
+    {file = "dulwich-0.21.5-pp38-pypy38_pp73-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:0aa44b812d978fc22a04531f5090c3c369d5facd03fa6e0501d460a661800c7f"},
+    {file = "dulwich-0.21.5-pp38-pypy38_pp73-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:6f46bcb6777e5f9f4af24a2bd029e88b77316269d24ce66be590e546a0d8f7b7"},
+    {file = "dulwich-0.21.5-pp38-pypy38_pp73-win_amd64.whl", hash = "sha256:a917fd3b4493db3716da2260f16f6b18f68d46fbe491d851d154fc0c2d984ae4"},
+    {file = "dulwich-0.21.5-pp39-pypy39_pp73-macosx_10_9_x86_64.whl", hash = "sha256:684c52cff867d10c75a7238151ca307582b3d251bbcd6db9e9cffbc998ef804e"},
+    {file = "dulwich-0.21.5-pp39-pypy39_pp73-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:9019189d7a8f7394df6a22cd5b484238c5776e42282ad5d6d6c626b4c5f43597"},
+    {file = "dulwich-0.21.5-pp39-pypy39_pp73-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:494024f74c2eef9988adb4352b3651ac1b6c0466176ec62b69d3d3672167ba68"},
+    {file = "dulwich-0.21.5-pp39-pypy39_pp73-win_amd64.whl", hash = "sha256:f9b6ac1b1c67fc6083c42b7b6cd3b211292c8a6517216c733caf23e8b103ab6d"},
+    {file = "dulwich-0.21.5.tar.gz", hash = "sha256:70955e4e249ddda6e34a4636b90f74e931e558f993b17c52570fa6144b993103"},
+]
+
+[package.dependencies]
+urllib3 = ">=1.25"
+
+[package.extras]
+fastimport = ["fastimport"]
+https = ["urllib3 (>=1.24.1)"]
+paramiko = ["paramiko"]
+pgp = ["gpg"]
+
+[[package]]
 name = "exceptiongroup"
 version = "1.1.1"
 description = "Backport of PEP 654 (exception groups)"
@@ -653,6 +825,21 @@ files = [
 
 [package.extras]
 test = ["pytest (>=6)"]
+
+[[package]]
+name = "filelock"
+version = "3.12.2"
+description = "A platform independent file lock."
+optional = false
+python-versions = ">=3.7"
+files = [
+    {file = "filelock-3.12.2-py3-none-any.whl", hash = "sha256:cbb791cdea2a72f23da6ac5b5269ab0a0d161e9ef0100e653b69049a7706d1ec"},
+    {file = "filelock-3.12.2.tar.gz", hash = "sha256:002740518d8aa59a26b0c76e10fb8c6e15eae825d34b6fdf670333fd7b938d81"},
+]
+
+[package.extras]
+docs = ["furo (>=2023.5.20)", "sphinx (>=7.0.1)", "sphinx-autodoc-typehints (>=1.23,!=1.23.4)"]
+testing = ["covdefaults (>=2.3)", "coverage (>=7.2.7)", "diff-cover (>=7.5)", "pytest (>=7.3.1)", "pytest-cov (>=4.1)", "pytest-mock (>=3.10)", "pytest-timeout (>=2.1)"]
 
 [[package]]
 name = "fsspec"
@@ -1455,6 +1642,27 @@ files = [
 ]
 
 [[package]]
+name = "html5lib"
+version = "1.1"
+description = "HTML parser based on the WHATWG HTML specification"
+optional = false
+python-versions = ">=2.7, !=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*, !=3.4.*"
+files = [
+    {file = "html5lib-1.1-py2.py3-none-any.whl", hash = "sha256:0d78f8fde1c230e99fe37986a60526d7049ed4bf8a9fadbad5f00e22e58e041d"},
+    {file = "html5lib-1.1.tar.gz", hash = "sha256:b2e5b40261e20f354d198eae92afc10d750afb487ed5e50f9c4eaf07c184146f"},
+]
+
+[package.dependencies]
+six = ">=1.9"
+webencodings = "*"
+
+[package.extras]
+all = ["chardet (>=2.2)", "genshi", "lxml"]
+chardet = ["chardet (>=2.2)"]
+genshi = ["genshi"]
+lxml = ["lxml"]
+
+[[package]]
 name = "httplib2"
 version = "0.22.0"
 description = "A comprehensive HTTP client library."
@@ -1547,6 +1755,25 @@ files = [
 ]
 
 [[package]]
+name = "importlib-metadata"
+version = "6.7.0"
+description = "Read metadata from Python packages"
+optional = false
+python-versions = ">=3.7"
+files = [
+    {file = "importlib_metadata-6.7.0-py3-none-any.whl", hash = "sha256:cb52082e659e97afc5dac71e79de97d8681de3aa07ff18578330904a9d18e5b5"},
+    {file = "importlib_metadata-6.7.0.tar.gz", hash = "sha256:1aaf550d4f73e5d6783e7acb77aec43d49da8017410afae93822cc9cca98c4d4"},
+]
+
+[package.dependencies]
+zipp = ">=0.5"
+
+[package.extras]
+docs = ["furo", "jaraco.packaging (>=9)", "jaraco.tidelift (>=1.4)", "rst.linker (>=1.9)", "sphinx (>=3.5)", "sphinx-lint"]
+perf = ["ipython"]
+testing = ["flufl.flake8", "importlib-resources (>=1.3)", "packaging", "pyfakefs", "pytest (>=6)", "pytest-black (>=0.3.7)", "pytest-checkdocs (>=2.4)", "pytest-cov", "pytest-enabler (>=1.3)", "pytest-mypy (>=0.9.1)", "pytest-perf (>=0.9.2)", "pytest-ruff"]
+
+[[package]]
 name = "iniconfig"
 version = "2.0.0"
 description = "brain-dead simple config-ini parsing"
@@ -1556,6 +1783,35 @@ files = [
     {file = "iniconfig-2.0.0-py3-none-any.whl", hash = "sha256:b6a85871a79d2e3b22d2d1b94ac2824226a63c6b741c88f7ae975f18b6778374"},
     {file = "iniconfig-2.0.0.tar.gz", hash = "sha256:2d91e135bf72d31a410b17c16da610a82cb55f6b0477d1a902134b24a455b8b3"},
 ]
+
+[[package]]
+name = "installer"
+version = "0.7.0"
+description = "A library for installing Python wheels."
+optional = false
+python-versions = ">=3.7"
+files = [
+    {file = "installer-0.7.0-py3-none-any.whl", hash = "sha256:05d1933f0a5ba7d8d6296bb6d5018e7c94fa473ceb10cf198a92ccea19c27b53"},
+    {file = "installer-0.7.0.tar.gz", hash = "sha256:a26d3e3116289bb08216e0d0f7d925fcef0b0194eedfa0c944bcaaa106c4b631"},
+]
+
+[[package]]
+name = "jaraco-classes"
+version = "3.2.3"
+description = "Utility functions for Python class constructs"
+optional = false
+python-versions = ">=3.7"
+files = [
+    {file = "jaraco.classes-3.2.3-py3-none-any.whl", hash = "sha256:2353de3288bc6b82120752201c6b1c1a14b058267fa424ed5ce5984e3b922158"},
+    {file = "jaraco.classes-3.2.3.tar.gz", hash = "sha256:89559fa5c1d3c34eff6f631ad80bb21f378dbcbb35dd161fd2c6b93f5be2f98a"},
+]
+
+[package.dependencies]
+more-itertools = "*"
+
+[package.extras]
+docs = ["jaraco.packaging (>=9)", "jaraco.tidelift (>=1.4)", "rst.linker (>=1.9)", "sphinx (>=3.5)"]
+testing = ["flake8 (<5)", "pytest (>=6)", "pytest-black (>=0.3.7)", "pytest-checkdocs (>=2.4)", "pytest-cov", "pytest-enabler (>=1.3)", "pytest-flake8", "pytest-mypy (>=0.9.1)"]
 
 [[package]]
 name = "jedi"
@@ -1577,6 +1833,21 @@ qa = ["flake8 (==3.8.3)", "mypy (==0.782)"]
 testing = ["Django (<3.1)", "attrs", "colorama", "docopt", "pytest (<7.0.0)"]
 
 [[package]]
+name = "jeepney"
+version = "0.8.0"
+description = "Low-level, pure Python DBus protocol wrapper."
+optional = false
+python-versions = ">=3.7"
+files = [
+    {file = "jeepney-0.8.0-py3-none-any.whl", hash = "sha256:c0a454ad016ca575060802ee4d590dd912e35c122fa04e70306de3d076cce755"},
+    {file = "jeepney-0.8.0.tar.gz", hash = "sha256:5efe48d255973902f6badc3ce55e2aa6c5c3b3bc642059ef3a91247bcfcc5806"},
+]
+
+[package.extras]
+test = ["async-timeout", "pytest", "pytest-asyncio (>=0.17)", "pytest-trio", "testpath", "trio"]
+trio = ["async_generator", "trio"]
+
+[[package]]
 name = "jinja2"
 version = "3.1.2"
 description = "A very fast and expressive template engine."
@@ -1592,6 +1863,59 @@ MarkupSafe = ">=2.0"
 
 [package.extras]
 i18n = ["Babel (>=2.7)"]
+
+[[package]]
+name = "jsonschema"
+version = "4.17.3"
+description = "An implementation of JSON Schema validation for Python"
+optional = false
+python-versions = ">=3.7"
+files = [
+    {file = "jsonschema-4.17.3-py3-none-any.whl", hash = "sha256:a870ad254da1a8ca84b6a2905cac29d265f805acc57af304784962a2aa6508f6"},
+    {file = "jsonschema-4.17.3.tar.gz", hash = "sha256:0f864437ab8b6076ba6707453ef8f98a6a0d512a80e93f8abdb676f737ecb60d"},
+]
+
+[package.dependencies]
+attrs = ">=17.4.0"
+pyrsistent = ">=0.14.0,<0.17.0 || >0.17.0,<0.17.1 || >0.17.1,<0.17.2 || >0.17.2"
+
+[package.extras]
+format = ["fqdn", "idna", "isoduration", "jsonpointer (>1.13)", "rfc3339-validator", "rfc3987", "uri-template", "webcolors (>=1.11)"]
+format-nongpl = ["fqdn", "idna", "isoduration", "jsonpointer (>1.13)", "rfc3339-validator", "rfc3986-validator (>0.1.0)", "uri-template", "webcolors (>=1.11)"]
+
+[[package]]
+name = "keyring"
+version = "23.13.1"
+description = "Store and access your passwords safely."
+optional = false
+python-versions = ">=3.7"
+files = [
+    {file = "keyring-23.13.1-py3-none-any.whl", hash = "sha256:771ed2a91909389ed6148631de678f82ddc73737d85a927f382a8a1b157898cd"},
+    {file = "keyring-23.13.1.tar.gz", hash = "sha256:ba2e15a9b35e21908d0aaf4e0a47acc52d6ae33444df0da2b49d41a46ef6d678"},
+]
+
+[package.dependencies]
+importlib-metadata = {version = ">=4.11.4", markers = "python_version < \"3.12\""}
+"jaraco.classes" = "*"
+jeepney = {version = ">=0.4.2", markers = "sys_platform == \"linux\""}
+pywin32-ctypes = {version = ">=0.2.0", markers = "sys_platform == \"win32\""}
+SecretStorage = {version = ">=3.2", markers = "sys_platform == \"linux\""}
+
+[package.extras]
+completion = ["shtab"]
+docs = ["furo", "jaraco.packaging (>=9)", "jaraco.tidelift (>=1.4)", "rst.linker (>=1.9)", "sphinx (>=3.5)"]
+testing = ["flake8 (<5)", "pytest (>=6)", "pytest-black (>=0.3.7)", "pytest-checkdocs (>=2.4)", "pytest-cov", "pytest-enabler (>=1.3)", "pytest-flake8", "pytest-mypy (>=0.9.1)"]
+
+[[package]]
+name = "lockfile"
+version = "0.12.2"
+description = "Platform-independent file locking module"
+optional = false
+python-versions = "*"
+files = [
+    {file = "lockfile-0.12.2-py2.py3-none-any.whl", hash = "sha256:6c3cb24f344923d30b2785d5ad75182c8ea7ac1b6171b08657258ec7429d50fa"},
+    {file = "lockfile-0.12.2.tar.gz", hash = "sha256:6aed02de03cba24efabcd600b30540140634fc06cfa603822d508d5361e9f799"},
+]
 
 [[package]]
 name = "mako"
@@ -1703,6 +2027,89 @@ pyyaml = "^6.0"
 [package.source]
 type = "directory"
 url = "../lib"
+
+[[package]]
+name = "more-itertools"
+version = "9.1.0"
+description = "More routines for operating on iterables, beyond itertools"
+optional = false
+python-versions = ">=3.7"
+files = [
+    {file = "more-itertools-9.1.0.tar.gz", hash = "sha256:cabaa341ad0389ea83c17a94566a53ae4c9d07349861ecb14dc6d0345cf9ac5d"},
+    {file = "more_itertools-9.1.0-py3-none-any.whl", hash = "sha256:d2bc7f02446e86a68911e58ded76d6561eea00cddfb2a91e7019bbb586c799f3"},
+]
+
+[[package]]
+name = "msgpack"
+version = "1.0.5"
+description = "MessagePack serializer"
+optional = false
+python-versions = "*"
+files = [
+    {file = "msgpack-1.0.5-cp310-cp310-macosx_10_9_universal2.whl", hash = "sha256:525228efd79bb831cf6830a732e2e80bc1b05436b086d4264814b4b2955b2fa9"},
+    {file = "msgpack-1.0.5-cp310-cp310-macosx_10_9_x86_64.whl", hash = "sha256:4f8d8b3bf1ff2672567d6b5c725a1b347fe838b912772aa8ae2bf70338d5a198"},
+    {file = "msgpack-1.0.5-cp310-cp310-macosx_11_0_arm64.whl", hash = "sha256:cdc793c50be3f01106245a61b739328f7dccc2c648b501e237f0699fe1395b81"},
+    {file = "msgpack-1.0.5-cp310-cp310-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:5cb47c21a8a65b165ce29f2bec852790cbc04936f502966768e4aae9fa763cb7"},
+    {file = "msgpack-1.0.5-cp310-cp310-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:e42b9594cc3bf4d838d67d6ed62b9e59e201862a25e9a157019e171fbe672dd3"},
+    {file = "msgpack-1.0.5-cp310-cp310-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:55b56a24893105dc52c1253649b60f475f36b3aa0fc66115bffafb624d7cb30b"},
+    {file = "msgpack-1.0.5-cp310-cp310-musllinux_1_1_aarch64.whl", hash = "sha256:1967f6129fc50a43bfe0951c35acbb729be89a55d849fab7686004da85103f1c"},
+    {file = "msgpack-1.0.5-cp310-cp310-musllinux_1_1_i686.whl", hash = "sha256:20a97bf595a232c3ee6d57ddaadd5453d174a52594bf9c21d10407e2a2d9b3bd"},
+    {file = "msgpack-1.0.5-cp310-cp310-musllinux_1_1_x86_64.whl", hash = "sha256:d25dd59bbbbb996eacf7be6b4ad082ed7eacc4e8f3d2df1ba43822da9bfa122a"},
+    {file = "msgpack-1.0.5-cp310-cp310-win32.whl", hash = "sha256:382b2c77589331f2cb80b67cc058c00f225e19827dbc818d700f61513ab47bea"},
+    {file = "msgpack-1.0.5-cp310-cp310-win_amd64.whl", hash = "sha256:4867aa2df9e2a5fa5f76d7d5565d25ec76e84c106b55509e78c1ede0f152659a"},
+    {file = "msgpack-1.0.5-cp311-cp311-macosx_10_9_universal2.whl", hash = "sha256:9f5ae84c5c8a857ec44dc180a8b0cc08238e021f57abdf51a8182e915e6299f0"},
+    {file = "msgpack-1.0.5-cp311-cp311-macosx_10_9_x86_64.whl", hash = "sha256:9e6ca5d5699bcd89ae605c150aee83b5321f2115695e741b99618f4856c50898"},
+    {file = "msgpack-1.0.5-cp311-cp311-macosx_11_0_arm64.whl", hash = "sha256:5494ea30d517a3576749cad32fa27f7585c65f5f38309c88c6d137877fa28a5a"},
+    {file = "msgpack-1.0.5-cp311-cp311-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:1ab2f3331cb1b54165976a9d976cb251a83183631c88076613c6c780f0d6e45a"},
+    {file = "msgpack-1.0.5-cp311-cp311-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:28592e20bbb1620848256ebc105fc420436af59515793ed27d5c77a217477705"},
+    {file = "msgpack-1.0.5-cp311-cp311-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:fe5c63197c55bce6385d9aee16c4d0641684628f63ace85f73571e65ad1c1e8d"},
+    {file = "msgpack-1.0.5-cp311-cp311-musllinux_1_1_aarch64.whl", hash = "sha256:ed40e926fa2f297e8a653c954b732f125ef97bdd4c889f243182299de27e2aa9"},
+    {file = "msgpack-1.0.5-cp311-cp311-musllinux_1_1_i686.whl", hash = "sha256:b2de4c1c0538dcb7010902a2b97f4e00fc4ddf2c8cda9749af0e594d3b7fa3d7"},
+    {file = "msgpack-1.0.5-cp311-cp311-musllinux_1_1_x86_64.whl", hash = "sha256:bf22a83f973b50f9d38e55c6aade04c41ddda19b00c4ebc558930d78eecc64ed"},
+    {file = "msgpack-1.0.5-cp311-cp311-win32.whl", hash = "sha256:c396e2cc213d12ce017b686e0f53497f94f8ba2b24799c25d913d46c08ec422c"},
+    {file = "msgpack-1.0.5-cp311-cp311-win_amd64.whl", hash = "sha256:6c4c68d87497f66f96d50142a2b73b97972130d93677ce930718f68828b382e2"},
+    {file = "msgpack-1.0.5-cp36-cp36m-macosx_10_9_x86_64.whl", hash = "sha256:a2b031c2e9b9af485d5e3c4520f4220d74f4d222a5b8dc8c1a3ab9448ca79c57"},
+    {file = "msgpack-1.0.5-cp36-cp36m-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:4f837b93669ce4336e24d08286c38761132bc7ab29782727f8557e1eb21b2080"},
+    {file = "msgpack-1.0.5-cp36-cp36m-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:b1d46dfe3832660f53b13b925d4e0fa1432b00f5f7210eb3ad3bb9a13c6204a6"},
+    {file = "msgpack-1.0.5-cp36-cp36m-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:366c9a7b9057e1547f4ad51d8facad8b406bab69c7d72c0eb6f529cf76d4b85f"},
+    {file = "msgpack-1.0.5-cp36-cp36m-musllinux_1_1_aarch64.whl", hash = "sha256:4c075728a1095efd0634a7dccb06204919a2f67d1893b6aa8e00497258bf926c"},
+    {file = "msgpack-1.0.5-cp36-cp36m-musllinux_1_1_i686.whl", hash = "sha256:f933bbda5a3ee63b8834179096923b094b76f0c7a73c1cfe8f07ad608c58844b"},
+    {file = "msgpack-1.0.5-cp36-cp36m-musllinux_1_1_x86_64.whl", hash = "sha256:36961b0568c36027c76e2ae3ca1132e35123dcec0706c4b7992683cc26c1320c"},
+    {file = "msgpack-1.0.5-cp36-cp36m-win32.whl", hash = "sha256:b5ef2f015b95f912c2fcab19c36814963b5463f1fb9049846994b007962743e9"},
+    {file = "msgpack-1.0.5-cp36-cp36m-win_amd64.whl", hash = "sha256:288e32b47e67f7b171f86b030e527e302c91bd3f40fd9033483f2cacc37f327a"},
+    {file = "msgpack-1.0.5-cp37-cp37m-macosx_10_9_x86_64.whl", hash = "sha256:137850656634abddfb88236008339fdaba3178f4751b28f270d2ebe77a563b6c"},
+    {file = "msgpack-1.0.5-cp37-cp37m-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:0c05a4a96585525916b109bb85f8cb6511db1c6f5b9d9cbcbc940dc6b4be944b"},
+    {file = "msgpack-1.0.5-cp37-cp37m-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:56a62ec00b636583e5cb6ad313bbed36bb7ead5fa3a3e38938503142c72cba4f"},
+    {file = "msgpack-1.0.5-cp37-cp37m-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:ef8108f8dedf204bb7b42994abf93882da1159728a2d4c5e82012edd92c9da9f"},
+    {file = "msgpack-1.0.5-cp37-cp37m-musllinux_1_1_aarch64.whl", hash = "sha256:1835c84d65f46900920b3708f5ba829fb19b1096c1800ad60bae8418652a951d"},
+    {file = "msgpack-1.0.5-cp37-cp37m-musllinux_1_1_i686.whl", hash = "sha256:e57916ef1bd0fee4f21c4600e9d1da352d8816b52a599c46460e93a6e9f17086"},
+    {file = "msgpack-1.0.5-cp37-cp37m-musllinux_1_1_x86_64.whl", hash = "sha256:17358523b85973e5f242ad74aa4712b7ee560715562554aa2134d96e7aa4cbbf"},
+    {file = "msgpack-1.0.5-cp37-cp37m-win32.whl", hash = "sha256:cb5aaa8c17760909ec6cb15e744c3ebc2ca8918e727216e79607b7bbce9c8f77"},
+    {file = "msgpack-1.0.5-cp37-cp37m-win_amd64.whl", hash = "sha256:ab31e908d8424d55601ad7075e471b7d0140d4d3dd3272daf39c5c19d936bd82"},
+    {file = "msgpack-1.0.5-cp38-cp38-macosx_10_9_universal2.whl", hash = "sha256:b72d0698f86e8d9ddf9442bdedec15b71df3598199ba33322d9711a19f08145c"},
+    {file = "msgpack-1.0.5-cp38-cp38-macosx_10_9_x86_64.whl", hash = "sha256:379026812e49258016dd84ad79ac8446922234d498058ae1d415f04b522d5b2d"},
+    {file = "msgpack-1.0.5-cp38-cp38-macosx_11_0_arm64.whl", hash = "sha256:332360ff25469c346a1c5e47cbe2a725517919892eda5cfaffe6046656f0b7bb"},
+    {file = "msgpack-1.0.5-cp38-cp38-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:476a8fe8fae289fdf273d6d2a6cb6e35b5a58541693e8f9f019bfe990a51e4ba"},
+    {file = "msgpack-1.0.5-cp38-cp38-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:a9985b214f33311df47e274eb788a5893a761d025e2b92c723ba4c63936b69b1"},
+    {file = "msgpack-1.0.5-cp38-cp38-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:48296af57cdb1d885843afd73c4656be5c76c0c6328db3440c9601a98f303d87"},
+    {file = "msgpack-1.0.5-cp38-cp38-musllinux_1_1_aarch64.whl", hash = "sha256:addab7e2e1fcc04bd08e4eb631c2a90960c340e40dfc4a5e24d2ff0d5a3b3edb"},
+    {file = "msgpack-1.0.5-cp38-cp38-musllinux_1_1_i686.whl", hash = "sha256:916723458c25dfb77ff07f4c66aed34e47503b2eb3188b3adbec8d8aa6e00f48"},
+    {file = "msgpack-1.0.5-cp38-cp38-musllinux_1_1_x86_64.whl", hash = "sha256:821c7e677cc6acf0fd3f7ac664c98803827ae6de594a9f99563e48c5a2f27eb0"},
+    {file = "msgpack-1.0.5-cp38-cp38-win32.whl", hash = "sha256:1c0f7c47f0087ffda62961d425e4407961a7ffd2aa004c81b9c07d9269512f6e"},
+    {file = "msgpack-1.0.5-cp38-cp38-win_amd64.whl", hash = "sha256:bae7de2026cbfe3782c8b78b0db9cbfc5455e079f1937cb0ab8d133496ac55e1"},
+    {file = "msgpack-1.0.5-cp39-cp39-macosx_10_9_universal2.whl", hash = "sha256:20c784e66b613c7f16f632e7b5e8a1651aa5702463d61394671ba07b2fc9e025"},
+    {file = "msgpack-1.0.5-cp39-cp39-macosx_10_9_x86_64.whl", hash = "sha256:266fa4202c0eb94d26822d9bfd7af25d1e2c088927fe8de9033d929dd5ba24c5"},
+    {file = "msgpack-1.0.5-cp39-cp39-macosx_11_0_arm64.whl", hash = "sha256:18334484eafc2b1aa47a6d42427da7fa8f2ab3d60b674120bce7a895a0a85bdd"},
+    {file = "msgpack-1.0.5-cp39-cp39-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:57e1f3528bd95cc44684beda696f74d3aaa8a5e58c816214b9046512240ef437"},
+    {file = "msgpack-1.0.5-cp39-cp39-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:586d0d636f9a628ddc6a17bfd45aa5b5efaf1606d2b60fa5d87b8986326e933f"},
+    {file = "msgpack-1.0.5-cp39-cp39-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:a740fa0e4087a734455f0fc3abf5e746004c9da72fbd541e9b113013c8dc3282"},
+    {file = "msgpack-1.0.5-cp39-cp39-musllinux_1_1_aarch64.whl", hash = "sha256:3055b0455e45810820db1f29d900bf39466df96ddca11dfa6d074fa47054376d"},
+    {file = "msgpack-1.0.5-cp39-cp39-musllinux_1_1_i686.whl", hash = "sha256:a61215eac016f391129a013c9e46f3ab308db5f5ec9f25811e811f96962599a8"},
+    {file = "msgpack-1.0.5-cp39-cp39-musllinux_1_1_x86_64.whl", hash = "sha256:362d9655cd369b08fda06b6657a303eb7172d5279997abe094512e919cf74b11"},
+    {file = "msgpack-1.0.5-cp39-cp39-win32.whl", hash = "sha256:ac9dd47af78cae935901a9a500104e2dea2e253207c924cc95de149606dc43cc"},
+    {file = "msgpack-1.0.5-cp39-cp39-win_amd64.whl", hash = "sha256:06f5174b5f8ed0ed919da0e62cbd4ffde676a374aba4020034da05fab67b9164"},
+    {file = "msgpack-1.0.5.tar.gz", hash = "sha256:c075544284eadc5cddc70f4757331d99dcbc16b2bbd4849d15f8aae4cf36d31c"},
+]
 
 [[package]]
 name = "multidict"
@@ -1981,6 +2388,49 @@ requests = ["requests (>=2.8.14)"]
 subprocess = ["subprocess32 (>=3.2.7)"]
 
 [[package]]
+name = "pexpect"
+version = "4.8.0"
+description = "Pexpect allows easy control of interactive console applications."
+optional = false
+python-versions = "*"
+files = [
+    {file = "pexpect-4.8.0-py2.py3-none-any.whl", hash = "sha256:0b48a55dcb3c05f3329815901ea4fc1537514d6ba867a152b581d69ae3710937"},
+    {file = "pexpect-4.8.0.tar.gz", hash = "sha256:fc65a43959d153d0114afe13997d439c22823a27cefceb5ff35c2178c6784c0c"},
+]
+
+[package.dependencies]
+ptyprocess = ">=0.5"
+
+[[package]]
+name = "pkginfo"
+version = "1.9.6"
+description = "Query metadata from sdists / bdists / installed packages."
+optional = false
+python-versions = ">=3.6"
+files = [
+    {file = "pkginfo-1.9.6-py3-none-any.whl", hash = "sha256:4b7a555a6d5a22169fcc9cf7bfd78d296b0361adad412a346c1226849af5e546"},
+    {file = "pkginfo-1.9.6.tar.gz", hash = "sha256:8fd5896e8718a4372f0ea9cc9d96f6417c9b986e23a4d116dda26b62cc29d046"},
+]
+
+[package.extras]
+testing = ["pytest", "pytest-cov"]
+
+[[package]]
+name = "platformdirs"
+version = "3.8.0"
+description = "A small Python package for determining appropriate platform-specific dirs, e.g. a \"user data dir\"."
+optional = false
+python-versions = ">=3.7"
+files = [
+    {file = "platformdirs-3.8.0-py3-none-any.whl", hash = "sha256:ca9ed98ce73076ba72e092b23d3c93ea6c4e186b3f1c3dad6edd98ff6ffcca2e"},
+    {file = "platformdirs-3.8.0.tar.gz", hash = "sha256:b0cabcb11063d21a0b261d557acb0a9d2126350e63b70cdf7db6347baea456dc"},
+]
+
+[package.extras]
+docs = ["furo (>=2023.5.20)", "proselint (>=0.13)", "sphinx (>=7.0.1)", "sphinx-autodoc-typehints (>=1.23,!=1.23.4)"]
+test = ["appdirs (==1.4.4)", "covdefaults (>=2.3)", "pytest (>=7.3.1)", "pytest-cov (>=4.1)", "pytest-mock (>=3.10)"]
+
+[[package]]
 name = "pluggy"
 version = "1.0.0"
 description = "plugin and hook calling mechanisms for python"
@@ -2006,15 +2456,71 @@ files = [
 ]
 
 [[package]]
+name = "poetry"
+version = "1.5.1"
+description = "Python dependency management and packaging made easy."
+optional = false
+python-versions = ">=3.7,<4.0"
+files = [
+    {file = "poetry-1.5.1-py3-none-any.whl", hash = "sha256:dfc7ce3a38ae216c0465694e2e674bef6eb1a2ba81aa47a26f9dc03362fe2f5f"},
+    {file = "poetry-1.5.1.tar.gz", hash = "sha256:cc7ea4524d1a11558006224bfe8ba8ed071417d4eb5ef6c89decc6a37d437eeb"},
+]
+
+[package.dependencies]
+build = ">=0.10.0,<0.11.0"
+cachecontrol = {version = ">=0.12.9,<0.13.0", extras = ["filecache"]}
+cleo = ">=2.0.0,<3.0.0"
+crashtest = ">=0.4.1,<0.5.0"
+dulwich = ">=0.21.2,<0.22.0"
+filelock = ">=3.8.0,<4.0.0"
+html5lib = ">=1.0,<2.0"
+importlib-metadata = {version = ">=4.4", markers = "python_version < \"3.10\""}
+installer = ">=0.7.0,<0.8.0"
+jsonschema = ">=4.10.0,<5.0.0"
+keyring = ">=23.9.0,<24.0.0"
+lockfile = ">=0.12.2,<0.13.0"
+packaging = ">=20.4"
+pexpect = ">=4.7.0,<5.0.0"
+pkginfo = ">=1.9.4,<2.0.0"
+platformdirs = ">=3.0.0,<4.0.0"
+poetry-core = "1.6.1"
+poetry-plugin-export = ">=1.4.0,<2.0.0"
+pyproject-hooks = ">=1.0.0,<2.0.0"
+requests = ">=2.18,<3.0"
+requests-toolbelt = ">=0.9.1,<2"
+shellingham = ">=1.5,<2.0"
+tomli = {version = ">=2.0.1,<3.0.0", markers = "python_version < \"3.11\""}
+tomlkit = ">=0.11.4,<1.0.0"
+trove-classifiers = ">=2022.5.19"
+urllib3 = ">=1.26.0,<2.0.0"
+virtualenv = ">=20.22.0,<21.0.0"
+xattr = {version = ">=0.10.0,<0.11.0", markers = "sys_platform == \"darwin\""}
+
+[[package]]
 name = "poetry-core"
-version = "1.5.2"
+version = "1.6.1"
 description = "Poetry PEP 517 Build Backend"
 optional = false
 python-versions = ">=3.7,<4.0"
 files = [
-    {file = "poetry_core-1.5.2-py3-none-any.whl", hash = "sha256:832d40a1ea5fd10c0f648d0575cadddc8b79f06f91d83a1f1a73a7e1dfacfbd7"},
-    {file = "poetry_core-1.5.2.tar.gz", hash = "sha256:c6556c3b1ec5b8668e6ef5a4494726bc41d31907339425e194e78a6178436c14"},
+    {file = "poetry_core-1.6.1-py3-none-any.whl", hash = "sha256:70707340447dee0e7f334f9495ae652481c67b32d8d218f296a376ac2ed73573"},
+    {file = "poetry_core-1.6.1.tar.gz", hash = "sha256:0f9b0de39665f36d6594657e7d57b6f463cc10f30c28e6d1c3b9ff54c26c9ac3"},
 ]
+
+[[package]]
+name = "poetry-plugin-export"
+version = "1.4.0"
+description = "Poetry plugin to export the dependencies to various formats"
+optional = false
+python-versions = ">=3.7,<4.0"
+files = [
+    {file = "poetry_plugin_export-1.4.0-py3-none-any.whl", hash = "sha256:5d9186d6f77cf2bf35fc96bd11fe650cc7656e515b17d99cb65018d50ba22589"},
+    {file = "poetry_plugin_export-1.4.0.tar.gz", hash = "sha256:f16974cd9f222d4ef640fa97a8d661b04d4fb339e51da93973f1bc9d578e183f"},
+]
+
+[package.dependencies]
+poetry = ">=1.5.0,<2.0.0"
+poetry-core = ">=1.6.0,<2.0.0"
 
 [[package]]
 name = "poetry2setup"
@@ -2129,6 +2635,17 @@ pygments = "*"
 [package.extras]
 all = ["black"]
 ptipython = ["ipython"]
+
+[[package]]
+name = "ptyprocess"
+version = "0.7.0"
+description = "Run a subprocess in a pseudo terminal"
+optional = false
+python-versions = "*"
+files = [
+    {file = "ptyprocess-0.7.0-py2.py3-none-any.whl", hash = "sha256:4b41f3967fce3af57cc7e94b888626c18bf37a083e3651ca8feeb66d492fef35"},
+    {file = "ptyprocess-0.7.0.tar.gz", hash = "sha256:5c5d0a3b48ceee0b48485e0c26037c0acd7d29765ca3fbb5cb3831d347423220"},
+]
 
 [[package]]
 name = "pyarrow"
@@ -2361,6 +2878,20 @@ files = [
 diagrams = ["jinja2", "railroad-diagrams"]
 
 [[package]]
+name = "pyproject-hooks"
+version = "1.0.0"
+description = "Wrappers to call pyproject.toml-based build backend hooks."
+optional = false
+python-versions = ">=3.7"
+files = [
+    {file = "pyproject_hooks-1.0.0-py3-none-any.whl", hash = "sha256:283c11acd6b928d2f6a7c73fa0d01cb2bdc5f07c57a2eeb6e83d5e56b97976f8"},
+    {file = "pyproject_hooks-1.0.0.tar.gz", hash = "sha256:f271b298b97f5955d53fb12b72c1fb1948c22c1a6b70b315c54cedaca0264ef5"},
+]
+
+[package.dependencies]
+tomli = {version = ">=1.1.0", markers = "python_version < \"3.11\""}
+
+[[package]]
 name = "pyreadline3"
 version = "3.4.1"
 description = "A python implementation of GNU readline."
@@ -2369,6 +2900,42 @@ python-versions = "*"
 files = [
     {file = "pyreadline3-3.4.1-py3-none-any.whl", hash = "sha256:b0efb6516fd4fb07b45949053826a62fa4cb353db5be2bbb4a7aa1fdd1e345fb"},
     {file = "pyreadline3-3.4.1.tar.gz", hash = "sha256:6f3d1f7b8a31ba32b73917cefc1f28cc660562f39aea8646d30bd6eff21f7bae"},
+]
+
+[[package]]
+name = "pyrsistent"
+version = "0.19.3"
+description = "Persistent/Functional/Immutable data structures"
+optional = false
+python-versions = ">=3.7"
+files = [
+    {file = "pyrsistent-0.19.3-cp310-cp310-macosx_10_9_universal2.whl", hash = "sha256:20460ac0ea439a3e79caa1dbd560344b64ed75e85d8703943e0b66c2a6150e4a"},
+    {file = "pyrsistent-0.19.3-cp310-cp310-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:4c18264cb84b5e68e7085a43723f9e4c1fd1d935ab240ce02c0324a8e01ccb64"},
+    {file = "pyrsistent-0.19.3-cp310-cp310-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:4b774f9288dda8d425adb6544e5903f1fb6c273ab3128a355c6b972b7df39dcf"},
+    {file = "pyrsistent-0.19.3-cp310-cp310-win32.whl", hash = "sha256:5a474fb80f5e0d6c9394d8db0fc19e90fa540b82ee52dba7d246a7791712f74a"},
+    {file = "pyrsistent-0.19.3-cp310-cp310-win_amd64.whl", hash = "sha256:49c32f216c17148695ca0e02a5c521e28a4ee6c5089f97e34fe24163113722da"},
+    {file = "pyrsistent-0.19.3-cp311-cp311-macosx_10_9_universal2.whl", hash = "sha256:f0774bf48631f3a20471dd7c5989657b639fd2d285b861237ea9e82c36a415a9"},
+    {file = "pyrsistent-0.19.3-cp311-cp311-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:3ab2204234c0ecd8b9368dbd6a53e83c3d4f3cab10ecaf6d0e772f456c442393"},
+    {file = "pyrsistent-0.19.3-cp311-cp311-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:e42296a09e83028b3476f7073fcb69ffebac0e66dbbfd1bd847d61f74db30f19"},
+    {file = "pyrsistent-0.19.3-cp311-cp311-win32.whl", hash = "sha256:64220c429e42a7150f4bfd280f6f4bb2850f95956bde93c6fda1b70507af6ef3"},
+    {file = "pyrsistent-0.19.3-cp311-cp311-win_amd64.whl", hash = "sha256:016ad1afadf318eb7911baa24b049909f7f3bb2c5b1ed7b6a8f21db21ea3faa8"},
+    {file = "pyrsistent-0.19.3-cp37-cp37m-macosx_10_9_x86_64.whl", hash = "sha256:c4db1bd596fefd66b296a3d5d943c94f4fac5bcd13e99bffe2ba6a759d959a28"},
+    {file = "pyrsistent-0.19.3-cp37-cp37m-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:aeda827381f5e5d65cced3024126529ddc4289d944f75e090572c77ceb19adbf"},
+    {file = "pyrsistent-0.19.3-cp37-cp37m-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:42ac0b2f44607eb92ae88609eda931a4f0dfa03038c44c772e07f43e738bcac9"},
+    {file = "pyrsistent-0.19.3-cp37-cp37m-win32.whl", hash = "sha256:e8f2b814a3dc6225964fa03d8582c6e0b6650d68a232df41e3cc1b66a5d2f8d1"},
+    {file = "pyrsistent-0.19.3-cp37-cp37m-win_amd64.whl", hash = "sha256:c9bb60a40a0ab9aba40a59f68214eed5a29c6274c83b2cc206a359c4a89fa41b"},
+    {file = "pyrsistent-0.19.3-cp38-cp38-macosx_10_9_universal2.whl", hash = "sha256:a2471f3f8693101975b1ff85ffd19bb7ca7dd7c38f8a81701f67d6b4f97b87d8"},
+    {file = "pyrsistent-0.19.3-cp38-cp38-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:cc5d149f31706762c1f8bda2e8c4f8fead6e80312e3692619a75301d3dbb819a"},
+    {file = "pyrsistent-0.19.3-cp38-cp38-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:3311cb4237a341aa52ab8448c27e3a9931e2ee09561ad150ba94e4cfd3fc888c"},
+    {file = "pyrsistent-0.19.3-cp38-cp38-win32.whl", hash = "sha256:f0e7c4b2f77593871e918be000b96c8107da48444d57005b6a6bc61fb4331b2c"},
+    {file = "pyrsistent-0.19.3-cp38-cp38-win_amd64.whl", hash = "sha256:c147257a92374fde8498491f53ffa8f4822cd70c0d85037e09028e478cababb7"},
+    {file = "pyrsistent-0.19.3-cp39-cp39-macosx_10_9_universal2.whl", hash = "sha256:b735e538f74ec31378f5a1e3886a26d2ca6351106b4dfde376a26fc32a044edc"},
+    {file = "pyrsistent-0.19.3-cp39-cp39-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:99abb85579e2165bd8522f0c0138864da97847875ecbd45f3e7e2af569bfc6f2"},
+    {file = "pyrsistent-0.19.3-cp39-cp39-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:3a8cb235fa6d3fd7aae6a4f1429bbb1fec1577d978098da1252f0489937786f3"},
+    {file = "pyrsistent-0.19.3-cp39-cp39-win32.whl", hash = "sha256:c74bed51f9b41c48366a286395c67f4e894374306b197e62810e0fdaf2364da2"},
+    {file = "pyrsistent-0.19.3-cp39-cp39-win_amd64.whl", hash = "sha256:878433581fc23e906d947a6814336eee031a00e6defba224234169ae3d3d6a98"},
+    {file = "pyrsistent-0.19.3-py3-none-any.whl", hash = "sha256:ccf0d6bd208f8111179f0c26fdf84ed7c3891982f2edaeae7422575f47e66b64"},
+    {file = "pyrsistent-0.19.3.tar.gz", hash = "sha256:1a2994773706bbb4995c31a97bc94f1418314923bd1048c6d964837040376440"},
 ]
 
 [[package]]
@@ -2467,6 +3034,17 @@ files = [
 ]
 
 [[package]]
+name = "pywin32-ctypes"
+version = "0.2.1"
+description = "A (partial) reimplementation of pywin32 using ctypes/cffi"
+optional = false
+python-versions = ">=3.6"
+files = [
+    {file = "pywin32-ctypes-0.2.1.tar.gz", hash = "sha256:934a2def1e5cbc472b2b6bf80680c0f03cd87df65dfd58bfd1846969de095b03"},
+    {file = "pywin32_ctypes-0.2.1-py3-none-any.whl", hash = "sha256:b9a53ef754c894a525469933ab2a447c74ec1ea6b9d2ef446f40ec50d3dcec9f"},
+]
+
+[[package]]
 name = "pyyaml"
 version = "6.0"
 description = "YAML parser and emitter for Python"
@@ -2531,6 +3109,110 @@ prompt_toolkit = ">=2.0,<4.0"
 
 [package.extras]
 docs = ["Sphinx (>=3.3,<4.0)", "sphinx-autobuild (>=2020.9.1,<2021.0.0)", "sphinx-autodoc-typehints (>=1.11.1,<2.0.0)", "sphinx-copybutton (>=0.3.1,<0.4.0)", "sphinx-rtd-theme (>=0.5.0,<0.6.0)"]
+
+[[package]]
+name = "rapidfuzz"
+version = "2.15.1"
+description = "rapid fuzzy string matching"
+optional = false
+python-versions = ">=3.7"
+files = [
+    {file = "rapidfuzz-2.15.1-cp310-cp310-macosx_10_9_universal2.whl", hash = "sha256:fc0bc259ebe3b93e7ce9df50b3d00e7345335d35acbd735163b7c4b1957074d3"},
+    {file = "rapidfuzz-2.15.1-cp310-cp310-macosx_10_9_x86_64.whl", hash = "sha256:d59fb3a410d253f50099d7063855c2b95df1ef20ad93ea3a6b84115590899f25"},
+    {file = "rapidfuzz-2.15.1-cp310-cp310-macosx_11_0_arm64.whl", hash = "sha256:c525a3da17b6d79d61613096c8683da86e3573e807dfaecf422eea09e82b5ba6"},
+    {file = "rapidfuzz-2.15.1-cp310-cp310-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:d4deae6a918ecc260d0c4612257be8ba321d8e913ccb43155403842758c46fbe"},
+    {file = "rapidfuzz-2.15.1-cp310-cp310-manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:2577463d10811386e704a3ab58b903eb4e2a31b24dfd9886d789b0084d614b01"},
+    {file = "rapidfuzz-2.15.1-cp310-cp310-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:f67d5f56aa48c0da9de4ab81bffb310683cf7815f05ea38e5aa64f3ba4368339"},
+    {file = "rapidfuzz-2.15.1-cp310-cp310-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:d7927722ff43690e52b3145b5bd3089151d841d350c6f8378c3cfac91f67573a"},
+    {file = "rapidfuzz-2.15.1-cp310-cp310-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:6534afc787e32c4104f65cdeb55f6abe4d803a2d0553221d00ef9ce12788dcde"},
+    {file = "rapidfuzz-2.15.1-cp310-cp310-musllinux_1_1_aarch64.whl", hash = "sha256:d0ae6ec79a1931929bb9dd57bc173eb5ba4c7197461bf69e3a34b6dd314feed2"},
+    {file = "rapidfuzz-2.15.1-cp310-cp310-musllinux_1_1_i686.whl", hash = "sha256:be7ccc45c4d1a7dfb595f260e8022a90c6cb380c2a346ee5aae93f85c96d362b"},
+    {file = "rapidfuzz-2.15.1-cp310-cp310-musllinux_1_1_ppc64le.whl", hash = "sha256:8ba013500a2b68c64b2aecc5fb56a2dad6c2872cf545a0308fd044827b6e5f6a"},
+    {file = "rapidfuzz-2.15.1-cp310-cp310-musllinux_1_1_s390x.whl", hash = "sha256:4d9f7d10065f657f960b48699e7dddfce14ab91af4bab37a215f0722daf0d716"},
+    {file = "rapidfuzz-2.15.1-cp310-cp310-musllinux_1_1_x86_64.whl", hash = "sha256:7e24a1b802cea04160b3fccd75d2d0905065783ebc9de157d83c14fb9e1c6ce2"},
+    {file = "rapidfuzz-2.15.1-cp310-cp310-win32.whl", hash = "sha256:dffdf03499e0a5b3442951bb82b556333b069e0661e80568752786c79c5b32de"},
+    {file = "rapidfuzz-2.15.1-cp310-cp310-win_amd64.whl", hash = "sha256:7d150d90a7c6caae7962f29f857a4e61d42038cfd82c9df38508daf30c648ae7"},
+    {file = "rapidfuzz-2.15.1-cp310-cp310-win_arm64.whl", hash = "sha256:87c30e9184998ff6eb0fa9221f94282ce7c908fd0da96a1ef66ecadfaaa4cdb7"},
+    {file = "rapidfuzz-2.15.1-cp311-cp311-macosx_10_9_universal2.whl", hash = "sha256:6986413cb37035eb796e32f049cbc8c13d8630a4ac1e0484e3e268bb3662bd1b"},
+    {file = "rapidfuzz-2.15.1-cp311-cp311-macosx_10_9_x86_64.whl", hash = "sha256:a72f26e010d4774b676f36e43c0fc8a2c26659efef4b3be3fd7714d3491e9957"},
+    {file = "rapidfuzz-2.15.1-cp311-cp311-macosx_11_0_arm64.whl", hash = "sha256:b5cd54c98a387cca111b3b784fc97a4f141244bbc28a92d4bde53f164464112e"},
+    {file = "rapidfuzz-2.15.1-cp311-cp311-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:da7fac7c3da39f93e6b2ebe386ed0ffe1cefec91509b91857f6e1204509e931f"},
+    {file = "rapidfuzz-2.15.1-cp311-cp311-manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:f976e76ac72f650790b3a5402431612175b2ac0363179446285cb3c901136ca9"},
+    {file = "rapidfuzz-2.15.1-cp311-cp311-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:abde47e1595902a490ed14d4338d21c3509156abb2042a99e6da51f928e0c117"},
+    {file = "rapidfuzz-2.15.1-cp311-cp311-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:ca8f1747007a3ce919739a60fa95c5325f7667cccf6f1c1ef18ae799af119f5e"},
+    {file = "rapidfuzz-2.15.1-cp311-cp311-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:c35da09ab9797b020d0d4f07a66871dfc70ea6566363811090353ea971748b5a"},
+    {file = "rapidfuzz-2.15.1-cp311-cp311-musllinux_1_1_aarch64.whl", hash = "sha256:a3a769ca7580686a66046b77df33851b3c2d796dc1eb60c269b68f690f3e1b65"},
+    {file = "rapidfuzz-2.15.1-cp311-cp311-musllinux_1_1_i686.whl", hash = "sha256:d50622efefdb03a640a51a6123748cd151d305c1f0431af762e833d6ffef71f0"},
+    {file = "rapidfuzz-2.15.1-cp311-cp311-musllinux_1_1_ppc64le.whl", hash = "sha256:b7461b0a7651d68bc23f0896bffceea40f62887e5ab8397bf7caa883592ef5cb"},
+    {file = "rapidfuzz-2.15.1-cp311-cp311-musllinux_1_1_s390x.whl", hash = "sha256:074ee9e17912e025c72a5780ee4c7c413ea35cd26449719cc399b852d4e42533"},
+    {file = "rapidfuzz-2.15.1-cp311-cp311-musllinux_1_1_x86_64.whl", hash = "sha256:7025fb105a11f503943f17718cdb8241ea3bb4d812c710c609e69bead40e2ff0"},
+    {file = "rapidfuzz-2.15.1-cp311-cp311-win32.whl", hash = "sha256:2084d36b95139413cef25e9487257a1cc892b93bd1481acd2a9656f7a1d9930c"},
+    {file = "rapidfuzz-2.15.1-cp311-cp311-win_amd64.whl", hash = "sha256:5a738fcd24e34bce4b19126b92fdae15482d6d3a90bd687fd3d24ce9d28ce82d"},
+    {file = "rapidfuzz-2.15.1-cp311-cp311-win_arm64.whl", hash = "sha256:dc3cafa68cfa54638632bdcadf9aab89a3d182b4a3f04d2cad7585ed58ea8731"},
+    {file = "rapidfuzz-2.15.1-cp37-cp37m-macosx_10_9_x86_64.whl", hash = "sha256:3c53d57ba7a88f7bf304d4ea5a14a0ca112db0e0178fff745d9005acf2879f7d"},
+    {file = "rapidfuzz-2.15.1-cp37-cp37m-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:a6ee758eec4cf2215dc8d8eafafcea0d1f48ad4b0135767db1b0f7c5c40a17dd"},
+    {file = "rapidfuzz-2.15.1-cp37-cp37m-manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:2d93ba3ae59275e7a3a116dac4ffdb05e9598bf3ee0861fecc5b60fb042d539e"},
+    {file = "rapidfuzz-2.15.1-cp37-cp37m-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:7c3ff75e647908ddbe9aa917fbe39a112d5631171f3fcea5809e2363e525a59d"},
+    {file = "rapidfuzz-2.15.1-cp37-cp37m-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:6d89c421702474c6361245b6b199e6e9783febacdbfb6b002669e6cb3ef17a09"},
+    {file = "rapidfuzz-2.15.1-cp37-cp37m-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:4f69e6199fec0f58f9a89afbbaea78d637c7ce77f656a03a1d6ea6abdc1d44f8"},
+    {file = "rapidfuzz-2.15.1-cp37-cp37m-musllinux_1_1_aarch64.whl", hash = "sha256:41dfea282844d0628279b4db2929da0dacb8ac317ddc5dcccc30093cf16357c1"},
+    {file = "rapidfuzz-2.15.1-cp37-cp37m-musllinux_1_1_i686.whl", hash = "sha256:2dd03477feefeccda07b7659dd614f6738cfc4f9b6779dd61b262a73b0a9a178"},
+    {file = "rapidfuzz-2.15.1-cp37-cp37m-musllinux_1_1_ppc64le.whl", hash = "sha256:5efe035aa76ff37d1b5fa661de3c4b4944de9ff227a6c0b2e390a95c101814c0"},
+    {file = "rapidfuzz-2.15.1-cp37-cp37m-musllinux_1_1_s390x.whl", hash = "sha256:ed2cf7c69102c7a0a06926d747ed855bc836f52e8d59a5d1e3adfd980d1bd165"},
+    {file = "rapidfuzz-2.15.1-cp37-cp37m-musllinux_1_1_x86_64.whl", hash = "sha256:a0e441d4c2025110ec3eba5d54f11f78183269a10152b3a757a739ffd1bb12bf"},
+    {file = "rapidfuzz-2.15.1-cp37-cp37m-win32.whl", hash = "sha256:a4a54efe17cc9f53589c748b53f28776dfdfb9bc83619685740cb7c37985ac2f"},
+    {file = "rapidfuzz-2.15.1-cp37-cp37m-win_amd64.whl", hash = "sha256:bb8318116ecac4dfb84841d8b9b461f9bb0c3be5b616418387d104f72d2a16d1"},
+    {file = "rapidfuzz-2.15.1-cp38-cp38-macosx_10_9_universal2.whl", hash = "sha256:e9296c530e544f68858c3416ad1d982a1854f71e9d2d3dcedb5b216e6d54f067"},
+    {file = "rapidfuzz-2.15.1-cp38-cp38-macosx_10_9_x86_64.whl", hash = "sha256:49c4bcdb9238f11f8c4eba1b898937f09b92280d6f900023a8216008f299b41a"},
+    {file = "rapidfuzz-2.15.1-cp38-cp38-macosx_11_0_arm64.whl", hash = "sha256:ebb40a279e134bb3fef099a8b58ed5beefb201033d29bdac005bddcdb004ef71"},
+    {file = "rapidfuzz-2.15.1-cp38-cp38-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:a7381c11cb590bbd4e6f2d8779a0b34fdd2234dfa13d0211f6aee8ca166d9d05"},
+    {file = "rapidfuzz-2.15.1-cp38-cp38-manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:cfdcdedfd12a0077193f2cf3626ff6722c5a184adf0d2d51f1ec984bf21c23c3"},
+    {file = "rapidfuzz-2.15.1-cp38-cp38-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:f85bece1ec59bda8b982bd719507d468d4df746dfb1988df11d916b5e9fe19e8"},
+    {file = "rapidfuzz-2.15.1-cp38-cp38-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:b1b393f4a1eaa6867ffac6aef58cfb04bab2b3d7d8e40b9fe2cf40dd1d384601"},
+    {file = "rapidfuzz-2.15.1-cp38-cp38-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:53de456ef020a77bf9d7c6c54860a48e2e902584d55d3001766140ac45c54bc7"},
+    {file = "rapidfuzz-2.15.1-cp38-cp38-musllinux_1_1_aarch64.whl", hash = "sha256:2492330bc38b76ed967eab7bdaea63a89b6ceb254489e2c65c3824efcbf72993"},
+    {file = "rapidfuzz-2.15.1-cp38-cp38-musllinux_1_1_i686.whl", hash = "sha256:099e4c6befaa8957a816bdb67ce664871f10aaec9bebf2f61368cf7e0869a7a1"},
+    {file = "rapidfuzz-2.15.1-cp38-cp38-musllinux_1_1_ppc64le.whl", hash = "sha256:46599b2ad4045dd3f794a24a6db1e753d23304699d4984462cf1ead02a51ddf3"},
+    {file = "rapidfuzz-2.15.1-cp38-cp38-musllinux_1_1_s390x.whl", hash = "sha256:591f19d16758a3c55c9d7a0b786b40d95599a5b244d6eaef79c7a74fcf5104d8"},
+    {file = "rapidfuzz-2.15.1-cp38-cp38-musllinux_1_1_x86_64.whl", hash = "sha256:ed17359061840eb249f8d833cb213942e8299ffc4f67251a6ed61833a9f2ea20"},
+    {file = "rapidfuzz-2.15.1-cp38-cp38-win32.whl", hash = "sha256:aa1e5aad325168e29bf8e17006479b97024aa9d2fdbe12062bd2f8f09080acf8"},
+    {file = "rapidfuzz-2.15.1-cp38-cp38-win_amd64.whl", hash = "sha256:c2bb68832b140c551dbed691290bef4ee6719d4e8ce1b7226a3736f61a9d1a83"},
+    {file = "rapidfuzz-2.15.1-cp39-cp39-macosx_10_9_universal2.whl", hash = "sha256:3fac40972cf7b6c14dded88ae2331eb50dfbc278aa9195473ef6fc6bfe49f686"},
+    {file = "rapidfuzz-2.15.1-cp39-cp39-macosx_10_9_x86_64.whl", hash = "sha256:f0e456cbdc0abf39352800309dab82fd3251179fa0ff6573fa117f51f4e84be8"},
+    {file = "rapidfuzz-2.15.1-cp39-cp39-macosx_11_0_arm64.whl", hash = "sha256:22b9d22022b9d09fd4ece15102270ab9b6a5cfea8b6f6d1965c1df7e3783f5ff"},
+    {file = "rapidfuzz-2.15.1-cp39-cp39-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:46754fe404a9a6f5cbf7abe02d74af390038d94c9b8c923b3f362467606bfa28"},
+    {file = "rapidfuzz-2.15.1-cp39-cp39-manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:91abb8bf7610efe326394adc1d45e1baca8f360e74187f3fa0ef3df80cdd3ba6"},
+    {file = "rapidfuzz-2.15.1-cp39-cp39-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:e40a2f60024f9d3c15401e668f732800114a023f3f8d8c40f1521a62081ff054"},
+    {file = "rapidfuzz-2.15.1-cp39-cp39-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:a48ee83916401ac73938526d7bd804e01d2a8fe61809df7f1577b0b3b31049a3"},
+    {file = "rapidfuzz-2.15.1-cp39-cp39-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:c71580052f9dbac443c02f60484e5a2e5f72ad4351b84b2009fbe345b1f38422"},
+    {file = "rapidfuzz-2.15.1-cp39-cp39-musllinux_1_1_aarch64.whl", hash = "sha256:82b86d5b8c1b9bcbc65236d75f81023c78d06a721c3e0229889ff4ed5c858169"},
+    {file = "rapidfuzz-2.15.1-cp39-cp39-musllinux_1_1_i686.whl", hash = "sha256:fc4528b7736e5c30bc954022c2cf410889abc19504a023abadbc59cdf9f37cae"},
+    {file = "rapidfuzz-2.15.1-cp39-cp39-musllinux_1_1_ppc64le.whl", hash = "sha256:e1e0e569108a5760d8f01d0f2148dd08cc9a39ead79fbefefca9e7c7723c7e88"},
+    {file = "rapidfuzz-2.15.1-cp39-cp39-musllinux_1_1_s390x.whl", hash = "sha256:94e1c97f0ad45b05003806f8a13efc1fc78983e52fa2ddb00629003acf4676ef"},
+    {file = "rapidfuzz-2.15.1-cp39-cp39-musllinux_1_1_x86_64.whl", hash = "sha256:47e81767a962e41477a85ad7ac937e34d19a7d2a80be65614f008a5ead671c56"},
+    {file = "rapidfuzz-2.15.1-cp39-cp39-win32.whl", hash = "sha256:79fc574aaf2d7c27ec1022e29c9c18f83cdaf790c71c05779528901e0caad89b"},
+    {file = "rapidfuzz-2.15.1-cp39-cp39-win_amd64.whl", hash = "sha256:f3dd4bcef2d600e0aa121e19e6e62f6f06f22a89f82ef62755e205ce14727874"},
+    {file = "rapidfuzz-2.15.1-cp39-cp39-win_arm64.whl", hash = "sha256:cac095cbdf44bc286339a77214bbca6d4d228c9ebae3da5ff6a80aaeb7c35634"},
+    {file = "rapidfuzz-2.15.1-pp37-pypy37_pp73-macosx_10_9_x86_64.whl", hash = "sha256:b89d1126be65c85763d56e3b47d75f1a9b7c5529857b4d572079b9a636eaa8a7"},
+    {file = "rapidfuzz-2.15.1-pp37-pypy37_pp73-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:19b7460e91168229768be882ea365ba0ac7da43e57f9416e2cfadc396a7df3c2"},
+    {file = "rapidfuzz-2.15.1-pp37-pypy37_pp73-manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:93c33c03e7092642c38f8a15ca2d8fc38da366f2526ec3b46adf19d5c7aa48ba"},
+    {file = "rapidfuzz-2.15.1-pp37-pypy37_pp73-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:040faca2e26d9dab5541b45ce72b3f6c0e36786234703fc2ac8c6f53bb576743"},
+    {file = "rapidfuzz-2.15.1-pp37-pypy37_pp73-win_amd64.whl", hash = "sha256:6e2a3b23e1e9aa13474b3c710bba770d0dcc34d517d3dd6f97435a32873e3f28"},
+    {file = "rapidfuzz-2.15.1-pp38-pypy38_pp73-macosx_10_9_x86_64.whl", hash = "sha256:2e597b9dfd6dd180982684840975c458c50d447e46928efe3e0120e4ec6f6686"},
+    {file = "rapidfuzz-2.15.1-pp38-pypy38_pp73-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:d14752c9dd2036c5f36ebe8db5f027275fa7d6b3ec6484158f83efb674bab84e"},
+    {file = "rapidfuzz-2.15.1-pp38-pypy38_pp73-manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:558224b6fc6124d13fa32d57876f626a7d6188ba2a97cbaea33a6ee38a867e31"},
+    {file = "rapidfuzz-2.15.1-pp38-pypy38_pp73-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:3c89cfa88dc16fd8c9bcc0c7f0b0073f7ef1e27cceb246c9f5a3f7004fa97c4d"},
+    {file = "rapidfuzz-2.15.1-pp38-pypy38_pp73-win_amd64.whl", hash = "sha256:509c5b631cd64df69f0f011893983eb15b8be087a55bad72f3d616b6ae6a0f96"},
+    {file = "rapidfuzz-2.15.1-pp39-pypy39_pp73-macosx_10_9_x86_64.whl", hash = "sha256:0f73a04135a03a6e40393ecd5d46a7a1049d353fc5c24b82849830d09817991f"},
+    {file = "rapidfuzz-2.15.1-pp39-pypy39_pp73-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:8c99d53138a2dfe8ada67cb2855719f934af2733d726fbf73247844ce4dd6dd5"},
+    {file = "rapidfuzz-2.15.1-pp39-pypy39_pp73-manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:f01fa757f0fb332a1f045168d29b0d005de6c39ee5ce5d6c51f2563bb53c601b"},
+    {file = "rapidfuzz-2.15.1-pp39-pypy39_pp73-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:60368e1add6e550faae65614844c43f8a96e37bf99404643b648bf2dba92c0fb"},
+    {file = "rapidfuzz-2.15.1-pp39-pypy39_pp73-win_amd64.whl", hash = "sha256:785744f1270828cc632c5a3660409dee9bcaac6931a081bae57542c93e4d46c4"},
+    {file = "rapidfuzz-2.15.1.tar.gz", hash = "sha256:d62137c2ca37aea90a11003ad7dc109c8f1739bfbe5a9a217f3cdb07d7ac00f6"},
+]
+
+[package.extras]
+full = ["numpy"]
 
 [[package]]
 name = "requests"
@@ -2598,6 +3280,21 @@ files = [
 
 [package.dependencies]
 pyasn1 = ">=0.1.3"
+
+[[package]]
+name = "secretstorage"
+version = "3.3.3"
+description = "Python bindings to FreeDesktop.org Secret Service API"
+optional = false
+python-versions = ">=3.6"
+files = [
+    {file = "SecretStorage-3.3.3-py3-none-any.whl", hash = "sha256:f356e6628222568e3af06f2eba8df495efa13b3b63081dafd4f7d9a7b7bc9f99"},
+    {file = "SecretStorage-3.3.3.tar.gz", hash = "sha256:2403533ef369eca6d2ba81718576c5e0f564d5cca1b58f73a8b23e7d4eeebd77"},
+]
+
+[package.dependencies]
+cryptography = ">=2.0"
+jeepney = ">=0.6"
 
 [[package]]
 name = "setuptools"
@@ -2792,6 +3489,17 @@ files = [
 ]
 
 [[package]]
+name = "tomlkit"
+version = "0.11.8"
+description = "Style preserving TOML library"
+optional = false
+python-versions = ">=3.7"
+files = [
+    {file = "tomlkit-0.11.8-py3-none-any.whl", hash = "sha256:8c726c4c202bdb148667835f68d68780b9a003a9ec34167b6c673b38eff2a171"},
+    {file = "tomlkit-0.11.8.tar.gz", hash = "sha256:9330fc7faa1db67b541b28e62018c17d20be733177d290a13b24c62d1614e0c3"},
+]
+
+[[package]]
 name = "toposort"
 version = "1.10"
 description = "Implements a topological sort algorithm."
@@ -2821,6 +3529,17 @@ dev = ["py-make (>=0.1.0)", "twine", "wheel"]
 notebook = ["ipywidgets (>=6)"]
 slack = ["slack-sdk"]
 telegram = ["requests"]
+
+[[package]]
+name = "trove-classifiers"
+version = "2023.5.24"
+description = "Canonical source for classifiers on PyPI (pypi.org)."
+optional = false
+python-versions = "*"
+files = [
+    {file = "trove-classifiers-2023.5.24.tar.gz", hash = "sha256:fd5a1546283be941f47540a135bdeae8fb261380a6a204d9c18012f2a1b0ceae"},
+    {file = "trove_classifiers-2023.5.24-py3-none-any.whl", hash = "sha256:d9d7ae14fb90bf3d50bef99c3941b176b5326509e6e9037e622562d6352629d0"},
+]
 
 [[package]]
 name = "typer"
@@ -2970,6 +3689,26 @@ docs = ["Sphinx (>=4.1.2,<4.2.0)", "sphinx-rtd-theme (>=0.5.2,<0.6.0)", "sphinxc
 test = ["Cython (>=0.29.32,<0.30.0)", "aiohttp", "flake8 (>=3.9.2,<3.10.0)", "mypy (>=0.800)", "psutil", "pyOpenSSL (>=22.0.0,<22.1.0)", "pycodestyle (>=2.7.0,<2.8.0)"]
 
 [[package]]
+name = "virtualenv"
+version = "20.23.1"
+description = "Virtual Python Environment builder"
+optional = false
+python-versions = ">=3.7"
+files = [
+    {file = "virtualenv-20.23.1-py3-none-any.whl", hash = "sha256:34da10f14fea9be20e0fd7f04aba9732f84e593dac291b757ce42e3368a39419"},
+    {file = "virtualenv-20.23.1.tar.gz", hash = "sha256:8ff19a38c1021c742148edc4f81cb43d7f8c6816d2ede2ab72af5b84c749ade1"},
+]
+
+[package.dependencies]
+distlib = ">=0.3.6,<1"
+filelock = ">=3.12,<4"
+platformdirs = ">=3.5.1,<4"
+
+[package.extras]
+docs = ["furo (>=2023.5.20)", "proselint (>=0.13)", "sphinx (>=7.0.1)", "sphinx-argparse (>=0.4)", "sphinxcontrib-towncrier (>=0.2.1a0)", "towncrier (>=23.6)"]
+test = ["covdefaults (>=2.3)", "coverage (>=7.2.7)", "coverage-enable-subprocess (>=1)", "flaky (>=3.7)", "packaging (>=23.1)", "pytest (>=7.3.1)", "pytest-env (>=0.8.1)", "pytest-freezer (>=0.4.6)", "pytest-mock (>=3.10)", "pytest-randomly (>=3.12)", "pytest-timeout (>=2.1)", "setuptools (>=67.8)", "time-machine (>=2.9)"]
+
+[[package]]
 name = "watchdog"
 version = "3.0.0"
 description = "Filesystem events monitoring"
@@ -3051,6 +3790,17 @@ python-versions = "*"
 files = [
     {file = "wcwidth-0.2.6-py2.py3-none-any.whl", hash = "sha256:795b138f6875577cd91bba52baf9e445cd5118fd32723b460e30a0af30ea230e"},
     {file = "wcwidth-0.2.6.tar.gz", hash = "sha256:a5220780a404dbe3353789870978e472cfe477761f06ee55077256e509b156d0"},
+]
+
+[[package]]
+name = "webencodings"
+version = "0.5.1"
+description = "Character encoding aliases for legacy web content"
+optional = false
+python-versions = "*"
+files = [
+    {file = "webencodings-0.5.1-py2.py3-none-any.whl", hash = "sha256:a0af1213f3c2226497a97e2b3aa01a7e4bee4f403f95be16fc9acd2947514a78"},
+    {file = "webencodings-0.5.1.tar.gz", hash = "sha256:b36a1c245f2d304965eb4e0a82848379241dc04b865afcc4aab16748587e1923"},
 ]
 
 [[package]]
@@ -3217,6 +3967,90 @@ files = [
 ]
 
 [[package]]
+name = "xattr"
+version = "0.10.1"
+description = "Python wrapper for extended filesystem attributes"
+optional = false
+python-versions = "*"
+files = [
+    {file = "xattr-0.10.1-cp27-cp27m-macosx_10_9_x86_64.whl", hash = "sha256:16a660a883e703b311d1bbbcafc74fa877585ec081cd96e8dd9302c028408ab1"},
+    {file = "xattr-0.10.1-cp27-cp27m-manylinux1_i686.whl", hash = "sha256:1e2973e72faa87ca29d61c23b58c3c89fe102d1b68e091848b0e21a104123503"},
+    {file = "xattr-0.10.1-cp27-cp27m-manylinux1_x86_64.whl", hash = "sha256:13279fe8f7982e3cdb0e088d5cb340ce9cbe5ef92504b1fd80a0d3591d662f68"},
+    {file = "xattr-0.10.1-cp27-cp27m-manylinux2010_i686.whl", hash = "sha256:1dc9b9f580ef4b8ac5e2c04c16b4d5086a611889ac14ecb2e7e87170623a0b75"},
+    {file = "xattr-0.10.1-cp27-cp27m-manylinux2010_x86_64.whl", hash = "sha256:485539262c2b1f5acd6b6ea56e0da2bc281a51f74335c351ea609c23d82c9a79"},
+    {file = "xattr-0.10.1-cp27-cp27mu-manylinux1_i686.whl", hash = "sha256:295b3ab335fcd06ca0a9114439b34120968732e3f5e9d16f456d5ec4fa47a0a2"},
+    {file = "xattr-0.10.1-cp27-cp27mu-manylinux1_x86_64.whl", hash = "sha256:a126eb38e14a2f273d584a692fe36cff760395bf7fc061ef059224efdb4eb62c"},
+    {file = "xattr-0.10.1-cp27-cp27mu-manylinux2010_i686.whl", hash = "sha256:b0e919c24f5b74428afa91507b15e7d2ef63aba98e704ad13d33bed1288dca81"},
+    {file = "xattr-0.10.1-cp27-cp27mu-manylinux2010_x86_64.whl", hash = "sha256:e31d062cfe1aaeab6ba3db6bd255f012d105271018e647645941d6609376af18"},
+    {file = "xattr-0.10.1-cp310-cp310-macosx_10_9_universal2.whl", hash = "sha256:209fb84c09b41c2e4cf16dd2f481bb4a6e2e81f659a47a60091b9bcb2e388840"},
+    {file = "xattr-0.10.1-cp310-cp310-macosx_10_9_x86_64.whl", hash = "sha256:c4120090dac33eddffc27e487f9c8f16b29ff3f3f8bcb2251b2c6c3f974ca1e1"},
+    {file = "xattr-0.10.1-cp310-cp310-macosx_11_0_arm64.whl", hash = "sha256:3e739d624491267ec5bb740f4eada93491de429d38d2fcdfb97b25efe1288eca"},
+    {file = "xattr-0.10.1-cp310-cp310-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:2677d40b95636f3482bdaf64ed9138fb4d8376fb7933f434614744780e46e42d"},
+    {file = "xattr-0.10.1-cp310-cp310-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:40039f1532c4456fd0f4c54e9d4e01eb8201248c321c6c6856262d87e9a99593"},
+    {file = "xattr-0.10.1-cp310-cp310-manylinux_2_5_x86_64.manylinux1_x86_64.manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:148466e5bb168aba98f80850cf976e931469a3c6eb11e9880d9f6f8b1e66bd06"},
+    {file = "xattr-0.10.1-cp310-cp310-musllinux_1_1_aarch64.whl", hash = "sha256:0aedf55b116beb6427e6f7958ccd80a8cbc80e82f87a4cd975ccb61a8d27b2ee"},
+    {file = "xattr-0.10.1-cp310-cp310-musllinux_1_1_i686.whl", hash = "sha256:c3024a9ff157247c8190dd0eb54db4a64277f21361b2f756319d9d3cf20e475f"},
+    {file = "xattr-0.10.1-cp310-cp310-musllinux_1_1_x86_64.whl", hash = "sha256:f1be6e733e9698f645dbb98565bb8df9b75e80e15a21eb52787d7d96800e823b"},
+    {file = "xattr-0.10.1-cp311-cp311-macosx_10_9_universal2.whl", hash = "sha256:7880c8a54c18bc091a4ce0adc5c6d81da1c748aec2fe7ac586d204d6ec7eca5b"},
+    {file = "xattr-0.10.1-cp311-cp311-macosx_10_9_x86_64.whl", hash = "sha256:89c93b42c3ba8aedbc29da759f152731196c2492a2154371c0aae3ef8ba8301b"},
+    {file = "xattr-0.10.1-cp311-cp311-macosx_11_0_arm64.whl", hash = "sha256:6b905e808df61b677eb972f915f8a751960284358b520d0601c8cbc476ba2df6"},
+    {file = "xattr-0.10.1-cp311-cp311-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:d1ef954d0655f93a34d07d0cc7e02765ec779ff0b59dc898ee08c6326ad614d5"},
+    {file = "xattr-0.10.1-cp311-cp311-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:199b20301b6acc9022661412346714ce764d322068ef387c4de38062474db76c"},
+    {file = "xattr-0.10.1-cp311-cp311-manylinux_2_5_x86_64.manylinux1_x86_64.manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:ec0956a8ab0f0d3f9011ba480f1e1271b703d11542375ef73eb8695a6bd4b78b"},
+    {file = "xattr-0.10.1-cp311-cp311-musllinux_1_1_aarch64.whl", hash = "sha256:ffcb57ca1be338d69edad93cf59aac7c6bb4dbb92fd7bf8d456c69ea42f7e6d2"},
+    {file = "xattr-0.10.1-cp311-cp311-musllinux_1_1_i686.whl", hash = "sha256:1f0563196ee54756fe2047627d316977dc77d11acd7a07970336e1a711e934db"},
+    {file = "xattr-0.10.1-cp311-cp311-musllinux_1_1_x86_64.whl", hash = "sha256:fc354f086f926a1c7f04886f97880fed1a26d20e3bc338d0d965fd161dbdb8ab"},
+    {file = "xattr-0.10.1-cp36-cp36m-macosx_10_9_x86_64.whl", hash = "sha256:c0cd2d02ef2fb45ecf2b0da066a58472d54682c6d4f0452dfe7ae2f3a76a42ea"},
+    {file = "xattr-0.10.1-cp36-cp36m-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:49626096ddd72dcc1654aadd84b103577d8424f26524a48d199847b5d55612d0"},
+    {file = "xattr-0.10.1-cp36-cp36m-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:ceaa26bef8fcb17eb59d92a7481c2d15d20211e217772fb43c08c859b01afc6a"},
+    {file = "xattr-0.10.1-cp36-cp36m-manylinux_2_5_x86_64.manylinux1_x86_64.manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:e8c014c371391f28f8cd27d73ea59f42b30772cd640b5a2538ad4f440fd9190b"},
+    {file = "xattr-0.10.1-cp36-cp36m-musllinux_1_1_aarch64.whl", hash = "sha256:46c32cd605673606b9388a313b0050ee7877a0640d7561eea243ace4fa2cc5a6"},
+    {file = "xattr-0.10.1-cp36-cp36m-musllinux_1_1_i686.whl", hash = "sha256:772b22c4ff791fe5816a7c2a1c9fcba83f9ab9bea138eb44d4d70f34676232b4"},
+    {file = "xattr-0.10.1-cp36-cp36m-musllinux_1_1_x86_64.whl", hash = "sha256:183ad611a2d70b5a3f5f7aadef0fcef604ea33dcf508228765fd4ddac2c7321d"},
+    {file = "xattr-0.10.1-cp37-cp37m-macosx_10_9_x86_64.whl", hash = "sha256:8068df3ebdfa9411e58d5ae4a05d807ec5994645bb01af66ec9f6da718b65c5b"},
+    {file = "xattr-0.10.1-cp37-cp37m-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:5bc40570155beb85e963ae45300a530223d9822edfdf09991b880e69625ba38a"},
+    {file = "xattr-0.10.1-cp37-cp37m-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:436e1aaf23c07e15bed63115f1712d2097e207214fc6bcde147c1efede37e2c5"},
+    {file = "xattr-0.10.1-cp37-cp37m-manylinux_2_5_x86_64.manylinux1_x86_64.manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:7298455ccf3a922d403339781b10299b858bb5ec76435445f2da46fb768e31a5"},
+    {file = "xattr-0.10.1-cp37-cp37m-musllinux_1_1_aarch64.whl", hash = "sha256:986c2305c6c1a08f78611eb38ef9f1f47682774ce954efb5a4f3715e8da00d5f"},
+    {file = "xattr-0.10.1-cp37-cp37m-musllinux_1_1_i686.whl", hash = "sha256:5dc6099e76e33fa3082a905fe59df766b196534c705cf7a2e3ad9bed2b8a180e"},
+    {file = "xattr-0.10.1-cp37-cp37m-musllinux_1_1_x86_64.whl", hash = "sha256:042ad818cda6013162c0bfd3816f6b74b7700e73c908cde6768da824686885f8"},
+    {file = "xattr-0.10.1-cp38-cp38-macosx_10_9_universal2.whl", hash = "sha256:9d4c306828a45b41b76ca17adc26ac3dc00a80e01a5ba85d71df2a3e948828f2"},
+    {file = "xattr-0.10.1-cp38-cp38-macosx_10_9_x86_64.whl", hash = "sha256:a606280b0c9071ef52572434ecd3648407b20df3d27af02c6592e84486b05894"},
+    {file = "xattr-0.10.1-cp38-cp38-macosx_11_0_arm64.whl", hash = "sha256:5b49d591cf34cda2079fd7a5cb2a7a1519f54dc2e62abe3e0720036f6ed41a85"},
+    {file = "xattr-0.10.1-cp38-cp38-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:6b8705ac6791426559c1a5c2b88bb2f0e83dc5616a09b4500899bfff6a929302"},
+    {file = "xattr-0.10.1-cp38-cp38-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:a5ea974930e876bc5c146f54ac0f85bb39b7b5de2b6fc63f90364712ae368ebe"},
+    {file = "xattr-0.10.1-cp38-cp38-manylinux_2_5_x86_64.manylinux1_x86_64.manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:f55a2dd73a12a1ae5113c5d9cd4b4ab6bf7950f4d76d0a1a0c0c4264d50da61d"},
+    {file = "xattr-0.10.1-cp38-cp38-musllinux_1_1_aarch64.whl", hash = "sha256:475c38da0d3614cc5564467c4efece1e38bd0705a4dbecf8deeb0564a86fb010"},
+    {file = "xattr-0.10.1-cp38-cp38-musllinux_1_1_i686.whl", hash = "sha256:925284a4a28e369459b2b7481ea22840eed3e0573a4a4c06b6b0614ecd27d0a7"},
+    {file = "xattr-0.10.1-cp38-cp38-musllinux_1_1_x86_64.whl", hash = "sha256:aa32f1b45fed9122bed911de0fcc654da349e1f04fa4a9c8ef9b53e1cc98b91e"},
+    {file = "xattr-0.10.1-cp39-cp39-macosx_10_9_universal2.whl", hash = "sha256:c5d3d0e728bace64b74c475eb4da6148cd172b2d23021a1dcd055d92f17619ac"},
+    {file = "xattr-0.10.1-cp39-cp39-macosx_10_9_x86_64.whl", hash = "sha256:8faaacf311e2b5cc67c030c999167a78a9906073e6abf08eaa8cf05b0416515c"},
+    {file = "xattr-0.10.1-cp39-cp39-macosx_11_0_arm64.whl", hash = "sha256:cc6b8d5ca452674e1a96e246a3d2db5f477aecbc7c945c73f890f56323e75203"},
+    {file = "xattr-0.10.1-cp39-cp39-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:3725746a6502f40f72ef27e0c7bfc31052a239503ff3eefa807d6b02a249be22"},
+    {file = "xattr-0.10.1-cp39-cp39-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:789bd406d1aad6735e97b20c6d6a1701e1c0661136be9be862e6a04564da771f"},
+    {file = "xattr-0.10.1-cp39-cp39-manylinux_2_5_x86_64.manylinux1_x86_64.manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:a9a7a807ab538210ff8532220d8fc5e2d51c212681f63dbd4e7ede32543b070f"},
+    {file = "xattr-0.10.1-cp39-cp39-musllinux_1_1_aarch64.whl", hash = "sha256:3e5825b5fc99ecdd493b0cc09ec35391e7a451394fdf623a88b24726011c950d"},
+    {file = "xattr-0.10.1-cp39-cp39-musllinux_1_1_i686.whl", hash = "sha256:80638d1ce7189dc52f26c234cee3522f060fadab6a8bc3562fe0ddcbe11ba5a4"},
+    {file = "xattr-0.10.1-cp39-cp39-musllinux_1_1_x86_64.whl", hash = "sha256:3ff0dbe4a6ce2ce065c6de08f415bcb270ecfd7bf1655a633ddeac695ce8b250"},
+    {file = "xattr-0.10.1-pp37-pypy37_pp73-macosx_10_9_x86_64.whl", hash = "sha256:5267e5f9435c840d2674194150b511bef929fa7d3bc942a4a75b9eddef18d8d8"},
+    {file = "xattr-0.10.1-pp37-pypy37_pp73-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:b27dfc13b193cb290d5d9e62f806bb9a99b00cd73bb6370d556116ad7bb5dc12"},
+    {file = "xattr-0.10.1-pp37-pypy37_pp73-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:636ebdde0277bce4d12d2ef2550885804834418fee0eb456b69be928e604ecc4"},
+    {file = "xattr-0.10.1-pp37-pypy37_pp73-manylinux_2_5_x86_64.manylinux1_x86_64.manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:d60c27922ec80310b45574351f71e0dd3a139c5295e8f8b19d19c0010196544f"},
+    {file = "xattr-0.10.1-pp38-pypy38_pp73-macosx_10_9_x86_64.whl", hash = "sha256:b34df5aad035d0343bd740a95ca30db99b776e2630dca9cc1ba8e682c9cc25ea"},
+    {file = "xattr-0.10.1-pp38-pypy38_pp73-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:f24a7c04ff666d0fe905dfee0a84bc899d624aeb6dccd1ea86b5c347f15c20c1"},
+    {file = "xattr-0.10.1-pp38-pypy38_pp73-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:a3878e1aff8eca64badad8f6d896cb98c52984b1e9cd9668a3ab70294d1ef92d"},
+    {file = "xattr-0.10.1-pp38-pypy38_pp73-manylinux_2_5_x86_64.manylinux1_x86_64.manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:4abef557028c551d59cf2fb3bf63f2a0c89f00d77e54c1c15282ecdd56943496"},
+    {file = "xattr-0.10.1-pp39-pypy39_pp73-macosx_10_9_x86_64.whl", hash = "sha256:0e14bd5965d3db173d6983abdc1241c22219385c22df8b0eb8f1846c15ce1fee"},
+    {file = "xattr-0.10.1-pp39-pypy39_pp73-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:7f9be588a4b6043b03777d50654c6079af3da60cc37527dbb80d36ec98842b1e"},
+    {file = "xattr-0.10.1-pp39-pypy39_pp73-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:b7bc4ae264aa679aacf964abf3ea88e147eb4a22aea6af8c6d03ebdebd64cfd6"},
+    {file = "xattr-0.10.1-pp39-pypy39_pp73-manylinux_2_5_x86_64.manylinux1_x86_64.manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:827b5a97673b9997067fde383a7f7dc67342403093b94ea3c24ae0f4f1fec649"},
+    {file = "xattr-0.10.1.tar.gz", hash = "sha256:c12e7d81ffaa0605b3ac8c22c2994a8e18a9cf1c59287a1b7722a2289c952ec5"},
+]
+
+[package.dependencies]
+cffi = ">=1.0"
+
+[[package]]
 name = "yarl"
 version = "1.9.2"
 description = "Yet another URL library"
@@ -3303,7 +4137,22 @@ files = [
 idna = ">=2.0"
 multidict = ">=4.0"
 
+[[package]]
+name = "zipp"
+version = "3.15.0"
+description = "Backport of pathlib-compatible object wrapper for zip files"
+optional = false
+python-versions = ">=3.7"
+files = [
+    {file = "zipp-3.15.0-py3-none-any.whl", hash = "sha256:48904fc76a60e542af151aded95726c1a5c34ed43ab4134b597665c86d7ad556"},
+    {file = "zipp-3.15.0.tar.gz", hash = "sha256:112929ad649da941c23de50f356a2b5570c954b65150642bccdd66bf194d224b"},
+]
+
+[package.extras]
+docs = ["furo", "jaraco.packaging (>=9)", "jaraco.tidelift (>=1.4)", "rst.linker (>=1.9)", "sphinx (>=3.5)", "sphinx-lint"]
+testing = ["big-O", "flake8 (<5)", "jaraco.functools", "jaraco.itertools", "more-itertools", "pytest (>=6)", "pytest-black (>=0.3.7)", "pytest-checkdocs (>=2.4)", "pytest-cov", "pytest-enabler (>=1.3)", "pytest-flake8", "pytest-mypy (>=0.9.1)"]
+
 [metadata]
 lock-version = "2.0"
 python-versions = "^3.9"
-content-hash = "8239e74ac8e6ec0009c0ea9c624fb022796f169deabaf7d9ac1043c426fce9a0"
+content-hash = "5301b7d20abd2ad167ab1d1148e41ab360e44cd754ca938c6108fbb457d7ae9d"

--- a/airbyte-ci/connectors/metadata_service/orchestrator/pyproject.toml
+++ b/airbyte-ci/connectors/metadata_service/orchestrator/pyproject.toml
@@ -8,10 +8,10 @@ packages = [{include = "orchestrator"}]
 
 [tool.poetry.dependencies]
 python = "^3.9"
-dagit = "^1.1.21"
+dagit = "^1.3.11"
 dagster = "^1.1.21"
 pandas = "^1.5.3"
-dagster-gcp = "^0.18.6"
+dagster-gcp = "^0.19.11"
 google = "^3.0.0"
 jinja2 = "^3.1.2"
 pygithub = "^1.58.0"

--- a/airbyte-ci/connectors/metadata_service/orchestrator/pyproject.toml
+++ b/airbyte-ci/connectors/metadata_service/orchestrator/pyproject.toml
@@ -24,6 +24,7 @@ dagster-cloud = "^1.2.6"
 grpcio = "^1.47.0"
 poetry2setup = "^1.1.0"
 slack-sdk = "^3.21.3"
+poetry = "^1.5.1"
 
 
 [tool.poetry.group.dev.dependencies]

--- a/airbyte-ci/connectors/metadata_service/orchestrator/tests/test_debug.py
+++ b/airbyte-ci/connectors/metadata_service/orchestrator/tests/test_debug.py
@@ -2,8 +2,10 @@ from dagster import build_op_context
 
 from orchestrator.resources.gcp import gcp_gcs_client, gcs_directory_blobs, gcs_file_manager
 from orchestrator.assets.connector_test_report import generate_nightly_report, persist_connectors_test_summary_files
+from orchestrator.assets.registry_entry import registry_entry, metadata_entry
 from orchestrator.config import NIGHTLY_INDIVIDUAL_TEST_REPORT_FILE_NAME, NIGHTLY_FOLDER, NIGHTLY_COMPLETE_REPORT_FILE_NAME, REPORT_FOLDER
 
+from metadata_service.constants import METADATA_FILE_NAME, METADATA_FOLDER
 
 def debug_nightly_report():
     resources = {
@@ -38,3 +40,21 @@ def debug_badges():
 
     context = build_op_context(resources=resources)
     persist_connectors_test_summary_files(context).value
+
+def test_debug_registry_entry():
+    resources = {
+        "gcp_gcs_client": gcp_gcs_client.configured(
+            {
+                "gcp_gcs_cred_string": {"env": "GCS_CREDENTIALS"},
+            }
+        ),
+        "latest_metadata_file_blobs": gcs_directory_blobs.configured(
+            {"gcs_bucket": {"env": "METADATA_BUCKET"}, "prefix": METADATA_FOLDER, "match_regex": f".*latest/{METADATA_FILE_NAME}$"}
+        )
+    }
+
+    part_key = "CPuD29SE4v8CEAE="
+
+    context = build_op_context(resources=resources , partition_key=part_key)
+    metadata_entry_val = metadata_entry(context)
+

--- a/airbyte-ci/connectors/metadata_service/orchestrator/tests/test_debug.py
+++ b/airbyte-ci/connectors/metadata_service/orchestrator/tests/test_debug.py
@@ -7,6 +7,7 @@ from orchestrator.config import NIGHTLY_INDIVIDUAL_TEST_REPORT_FILE_NAME, NIGHTL
 
 from metadata_service.constants import METADATA_FILE_NAME, METADATA_FOLDER
 
+
 def debug_nightly_report():
     resources = {
         "gcp_gcs_client": gcp_gcs_client.configured(
@@ -18,7 +19,11 @@ def debug_nightly_report():
             {"gcs_bucket": {"env": "CI_REPORT_BUCKET"}, "prefix": NIGHTLY_FOLDER, "match_regex": f".*{NIGHTLY_COMPLETE_REPORT_FILE_NAME}$"}
         ),
         "latest_nightly_test_output_file_blobs": gcs_directory_blobs.configured(
-            {"gcs_bucket": {"env": "CI_REPORT_BUCKET"}, "prefix": NIGHTLY_FOLDER, "match_regex": f".*{NIGHTLY_INDIVIDUAL_TEST_REPORT_FILE_NAME}$"}
+            {
+                "gcs_bucket": {"env": "CI_REPORT_BUCKET"},
+                "prefix": NIGHTLY_FOLDER,
+                "match_regex": f".*{NIGHTLY_INDIVIDUAL_TEST_REPORT_FILE_NAME}$",
+            }
         ),
     }
 
@@ -41,7 +46,8 @@ def debug_badges():
     context = build_op_context(resources=resources)
     persist_connectors_test_summary_files(context).value
 
-def test_debug_registry_entry():
+
+def debug_registry_entry():
     resources = {
         "gcp_gcs_client": gcp_gcs_client.configured(
             {
@@ -50,11 +56,10 @@ def test_debug_registry_entry():
         ),
         "latest_metadata_file_blobs": gcs_directory_blobs.configured(
             {"gcs_bucket": {"env": "METADATA_BUCKET"}, "prefix": METADATA_FOLDER, "match_regex": f".*latest/{METADATA_FILE_NAME}$"}
-        )
+        ),
     }
 
     part_key = "CPuD29SE4v8CEAE="
 
-    context = build_op_context(resources=resources , partition_key=part_key)
+    context = build_op_context(resources=resources, partition_key=part_key)
     metadata_entry_val = metadata_entry(context)
-

--- a/airbyte-ci/connectors/metadata_service/orchestrator/tests/test_registry.py
+++ b/airbyte-ci/connectors/metadata_service/orchestrator/tests/test_registry.py
@@ -2,7 +2,7 @@ import pytest
 from unittest.mock import Mock
 from metadata_service.models.generated.ConnectorRegistryV0 import ConnectorRegistryV0
 
-from orchestrator.assets.registry import metadata_to_registry_entry
+from orchestrator.assets.registry_entry import metadata_to_registry_entry
 from orchestrator.assets.registry_report import (
     all_sources_dataframe,
     all_destinations_dataframe,
@@ -74,7 +74,7 @@ def test_definition_id_conversion(registry_type, connector_type, expected_id_fie
     mock_metadata_entry.metadata_definition.dict.return_value = metadata
     mock_metadata_entry.icon_url = "test-icon-url"
 
-    result = metadata_to_registry_entry(mock_metadata_entry, connector_type, registry_type)
+    result = metadata_to_registry_entry(mock_metadata_entry, registry_type)
     assert "definitionId" not in result
     assert result[expected_id_field] == "test-id"
 
@@ -89,7 +89,7 @@ def test_tombstone_custom_public_set():
     mock_metadata_entry.metadata_definition.dict.return_value = metadata
     mock_metadata_entry.icon_url = "test-icon-url"
 
-    result = metadata_to_registry_entry(mock_metadata_entry, "source", "oss")
+    result = metadata_to_registry_entry(mock_metadata_entry, "oss")
     assert result["tombstone"] is False
     assert result["custom"] is False
     assert result["public"] is True
@@ -105,7 +105,7 @@ def test_fields_deletion():
     mock_metadata_entry.metadata_definition.dict.return_value = metadata
     mock_metadata_entry.icon_url = "test-icon-url"
 
-    result = metadata_to_registry_entry(mock_metadata_entry, "source", "oss")
+    result = metadata_to_registry_entry(mock_metadata_entry, "oss")
     assert "registries" not in result
     assert "connectorType" not in result
     assert "definitionId" not in result
@@ -136,7 +136,7 @@ def test_overrides_application(registry_type, expected_docker_image_tag, expecte
     mock_metadata_entry.metadata_definition.dict.return_value = metadata
     mock_metadata_entry.icon_url = "test-icon-url"
 
-    result = metadata_to_registry_entry(mock_metadata_entry, "source", registry_type)
+    result = metadata_to_registry_entry(mock_metadata_entry, registry_type)
     assert result["dockerImageTag"] == expected_docker_image_tag
     assert result["additionalField"] == expected_additional_field
 
@@ -158,7 +158,7 @@ def test_source_type_extraction():
     mock_metadata_entry.metadata_definition.dict.return_value = metadata
     mock_metadata_entry.icon_url = "test-icon-url"
 
-    result = metadata_to_registry_entry(mock_metadata_entry, "source", "oss")
+    result = metadata_to_registry_entry(mock_metadata_entry, "oss")
     assert result["sourceType"] == "database"
 
 
@@ -172,7 +172,7 @@ def test_release_stage_default():
     mock_metadata_entry.metadata_definition.dict.return_value = metadata
     mock_metadata_entry.icon_url = "test-icon-url"
 
-    result = metadata_to_registry_entry(mock_metadata_entry, "source", "oss")
+    result = metadata_to_registry_entry(mock_metadata_entry, "oss")
     assert result["releaseStage"] == "alpha"
 
 
@@ -197,7 +197,7 @@ def test_migration_documentation_url_default():
     expected_top_migration_documentation_url = "test-doc-url-migrations"
     expected_version_migration_documentation_url = "test-doc-url-migrations#1.0.0"
 
-    result = metadata_to_registry_entry(mock_metadata_entry, "source", "oss")
+    result = metadata_to_registry_entry(mock_metadata_entry, "oss")
     assert result["releases"]["migrationDocumentationUrl"] == expected_top_migration_documentation_url
     assert result["releases"]["breakingChanges"]["1.0.0"]["migrationDocumentationUrl"] == expected_version_migration_documentation_url
 
@@ -223,7 +223,7 @@ def test_breaking_changes_migration_documentation_url():
     mock_metadata_entry.metadata_definition.dict.return_value = metadata
     mock_metadata_entry.icon_url = "test-icon-url"
 
-    result = metadata_to_registry_entry(mock_metadata_entry, "source", "oss")
+    result = metadata_to_registry_entry(mock_metadata_entry, "oss")
     assert result["releases"]["migrationDocumentationUrl"] == "test-migration-doc-url"
     assert result["releases"]["breakingChanges"]["1.0.0"]["migrationDocumentationUrl"] == "test-migration-doc-url-version"
 
@@ -238,5 +238,5 @@ def test_icon_url():
     mock_metadata_entry.metadata_definition.dict.return_value = metadata
     mock_metadata_entry.icon_url = "test-icon-url"
 
-    result = metadata_to_registry_entry(mock_metadata_entry, "source", "oss")
+    result = metadata_to_registry_entry(mock_metadata_entry, "oss")
     assert result["iconUrl"] == "test-icon-url"

--- a/airbyte-ci/connectors/metadata_service/orchestrator/tests/test_registry.py
+++ b/airbyte-ci/connectors/metadata_service/orchestrator/tests/test_registry.py
@@ -10,7 +10,12 @@ from metadata_service.models.generated.ConnectorRegistryV0 import ConnectorRegis
 from metadata_service.models.generated.ConnectorRegistrySourceDefinition import ConnectorRegistrySourceDefinition
 from metadata_service.models.generated.ConnectorRegistryDestinationDefinition import ConnectorRegistryDestinationDefinition
 
-from orchestrator.assets.registry_entry import metadata_to_registry_entry, get_connector_type_from_registry_entry, get_registry_status_lists, safe_parse_metadata_definition
+from orchestrator.assets.registry_entry import (
+    metadata_to_registry_entry,
+    get_connector_type_from_registry_entry,
+    get_registry_status_lists,
+    safe_parse_metadata_definition,
+)
 from orchestrator.assets.registry_report import (
     all_sources_dataframe,
     all_destinations_dataframe,
@@ -34,17 +39,21 @@ VALID_METADATA_DICT = {
         "githubIssueLabel": "test_label",
         "connectorSubtype": "api",
         "releaseStage": "alpha",
-        "registries": {"oss": {"enabled": True}, "cloud": {"enabled": True}}
-    }
+        "registries": {"oss": {"enabled": True}, "cloud": {"enabled": True}},
+    },
 }
 INVALID_METADATA_DICT = {"invalid": "metadata"}
 
-@pytest.mark.parametrize("blob_name, blob_content, expected_result, expected_exception", [
-    ("1.2.3/metadata.yaml", yaml.dump(VALID_METADATA_DICT), MetadataDefinition.parse_obj(VALID_METADATA_DICT), None),
-    ("latest/metadata.yaml", yaml.dump(VALID_METADATA_DICT), MetadataDefinition.parse_obj(VALID_METADATA_DICT), None),
-    ("1.2.3/metadata.yaml", yaml.dump(INVALID_METADATA_DICT), None, None),
-    ("latest/metadata.yaml", yaml.dump(INVALID_METADATA_DICT), None, ValidationError)
-])
+
+@pytest.mark.parametrize(
+    "blob_name, blob_content, expected_result, expected_exception",
+    [
+        ("1.2.3/metadata.yaml", yaml.dump(VALID_METADATA_DICT), MetadataDefinition.parse_obj(VALID_METADATA_DICT), None),
+        ("latest/metadata.yaml", yaml.dump(VALID_METADATA_DICT), MetadataDefinition.parse_obj(VALID_METADATA_DICT), None),
+        ("1.2.3/metadata.yaml", yaml.dump(INVALID_METADATA_DICT), None, None),
+        ("latest/metadata.yaml", yaml.dump(INVALID_METADATA_DICT), None, ValidationError),
+    ],
+)
 def test_safe_parse_metadata_definition(blob_name, blob_content, expected_result, expected_exception):
     # Mock the Blob object
     mock_blob = mock.create_autospec(storage.Blob, instance=True)
@@ -60,23 +69,26 @@ def test_safe_parse_metadata_definition(blob_name, blob_content, expected_result
         assert result == expected_result
 
 
-@pytest.mark.parametrize("registries_data, expected_enabled, expected_disabled", [
-    (
-        {"oss": {"enabled": True}, "cloud": {"enabled": True}},
-        ["oss", "cloud"],
-        [],
-    ),
-    (
-        {"oss": {"enabled": False}, "cloud": {"enabled": True}},
-        ["cloud"],
-        ["oss"],
-    ),
-    (
-        {"oss": {"enabled": False}, "cloud": {"enabled": False}},
-        [],
-        ["oss", "cloud"],
-    ),
-])
+@pytest.mark.parametrize(
+    "registries_data, expected_enabled, expected_disabled",
+    [
+        (
+            {"oss": {"enabled": True}, "cloud": {"enabled": True}},
+            ["oss", "cloud"],
+            [],
+        ),
+        (
+            {"oss": {"enabled": False}, "cloud": {"enabled": True}},
+            ["cloud"],
+            ["oss"],
+        ),
+        (
+            {"oss": {"enabled": False}, "cloud": {"enabled": False}},
+            [],
+            ["oss", "cloud"],
+        ),
+    ],
+)
 def test_get_registry_status_lists(registries_data, expected_enabled, expected_disabled):
     metadata_dict = {
         "metadataSpecVersion": "1.0",
@@ -91,8 +103,8 @@ def test_get_registry_status_lists(registries_data, expected_enabled, expected_d
             "githubIssueLabel": "test_label",
             "connectorSubtype": "api",
             "releaseStage": "alpha",
-            "registries": registries_data
-        }
+            "registries": registries_data,
+        },
     }
     metadata_definition = MetadataDefinition.parse_obj(metadata_dict)
     registry_entry = LatestMetadataEntry(metadata_definition=metadata_definition)
@@ -100,11 +112,15 @@ def test_get_registry_status_lists(registries_data, expected_enabled, expected_d
     assert set(enabled) == set(expected_enabled)
     assert set(disabled) == set(expected_disabled)
 
-@pytest.mark.parametrize("registry_entry, expected_type, expected_class", [
-    ({"sourceDefinitionId": "abc"}, "source", ConnectorRegistrySourceDefinition),
-    ({"destinationDefinitionId": "abc"}, "destination", ConnectorRegistryDestinationDefinition),
-    ({}, None, None)
-])
+
+@pytest.mark.parametrize(
+    "registry_entry, expected_type, expected_class",
+    [
+        ({"sourceDefinitionId": "abc"}, "source", ConnectorRegistrySourceDefinition),
+        ({"destinationDefinitionId": "abc"}, "destination", ConnectorRegistryDestinationDefinition),
+        ({}, None, None),
+    ],
+)
 def test_get_connector_type_from_registry_entry(registry_entry, expected_type, expected_class):
     if expected_type and expected_class:
         connector_type, connector_class = get_connector_type_from_registry_entry(registry_entry)


### PR DESCRIPTION
## What
Updates the metadata service so
1. Metadata files are transformed into registry entries first
2. Those entries are written to `<metadata_bucket>/metadata/connector_folder/oss.json` `<metadata_bucket>/metadata/connector_folder/cloud.json`
3. Deletes any registry entries in the case of a disabled connector
4. Updates our registry to listen for and be generated from these new files
5. Adds a partiition sensor and asset to allow for metadata failures to not block new connector updats

closes #26878 