### PR TITLE
Google Sheets Destination passes QA check

### DIFF
--- a/airbyte-integrations/connectors/destination-google-sheets/Dockerfile
+++ b/airbyte-integrations/connectors/destination-google-sheets/Dockerfile
@@ -13,5 +13,5 @@ RUN pip install .
 
 ENTRYPOINT ["python", "/airbyte/integration_code/main.py"]
 
-LABEL io.airbyte.version=0.2.0
+LABEL io.airbyte.version=0.2.1
 LABEL io.airbyte.name=airbyte/destination-google-sheets

--- a/airbyte-integrations/connectors/destination-google-sheets/destination_google_sheets/helpers.py
+++ b/airbyte-integrations/connectors/destination-google-sheets/destination_google_sheets/helpers.py
@@ -18,7 +18,7 @@ logger = AirbyteLogger()
 
 
 def get_spreadsheet_id(id_or_url: str) -> str:
-    if re.match(r"(http://)|(https://)", id_or_url):
+    if re.match(r"(https://)", id_or_url):
         m = re.search(r"(/)([-\w]{40,})([/]?)", id_or_url)
         if m.group(2):
             return m.group(2)

--- a/airbyte-integrations/connectors/destination-google-sheets/metadata.yaml
+++ b/airbyte-integrations/connectors/destination-google-sheets/metadata.yaml
@@ -2,7 +2,7 @@ data:
   connectorSubtype: api
   connectorType: destination
   definitionId: a4cbd2d1-8dbe-4818-b8bc-b90ad782d12a
-  dockerImageTag: 0.2.0
+  dockerImageTag: 0.2.1
   dockerRepository: airbyte/destination-google-sheets
   githubIssueLabel: destination-google-sheets
   icon: google-sheets.svg

--- a/docs/integrations/destinations/google-sheets.md
+++ b/docs/integrations/destinations/google-sheets.md
@@ -130,6 +130,7 @@ You cannot create more than 200 worksheets within single spreadsheet.
 
 | Version | Date       | Pull Request                                             | Subject                             |
 | ------- | ---------- | -------------------------------------------------------- | ----------------------------------- |
+| 0.2.1   | 2023-06-26 | [xxx](https://github.com/airbytehq/airbyte/pull/xxx)     | Only allow HTTPS urls               |
 | 0.2.0   | 2023-06-26 | [27780](https://github.com/airbytehq/airbyte/pull/27780) | License Update: Elv2                |
 | 0.1.2   | 2022-10-31 | [18729](https://github.com/airbytehq/airbyte/pull/18729) | Fix empty headers list              |
 | 0.1.1   | 2022-06-15 | [14751](https://github.com/airbytehq/airbyte/pull/14751) | Yield state only when records saved |

--- a/docs/integrations/destinations/google-sheets.md
+++ b/docs/integrations/destinations/google-sheets.md
@@ -130,7 +130,7 @@ You cannot create more than 200 worksheets within single spreadsheet.
 
 | Version | Date       | Pull Request                                             | Subject                             |
 | ------- | ---------- | -------------------------------------------------------- | ----------------------------------- |
-| 0.2.1   | 2023-06-26 | [xxx](https://github.com/airbytehq/airbyte/pull/xxx)     | Only allow HTTPS urls               |
+| 0.2.1   | 2023-06-26 | [27782](https://github.com/airbytehq/airbyte/pull/27782) | Only allow HTTPS urls               |
 | 0.2.0   | 2023-06-26 | [27780](https://github.com/airbytehq/airbyte/pull/27780) | License Update: Elv2                |
 | 0.1.2   | 2022-10-31 | [18729](https://github.com/airbytehq/airbyte/pull/18729) | Fix empty headers list              |
 | 0.1.1   | 2022-06-15 | [14751](https://github.com/airbytehq/airbyte/pull/14751) | Yield state only when records saved |


### PR DESCRIPTION
This connector was failing the QA check because of the "http:" in the codebase.  Google Sheets will never have http: URLs.