### PR TITLE
Revert "Low-Code CDK: make RecordFilter.filter_records as generator (…

### DIFF
--- a/airbyte-cdk/python/airbyte_cdk/sources/declarative/extractors/record_filter.py
+++ b/airbyte-cdk/python/airbyte_cdk/sources/declarative/extractors/record_filter.py
@@ -33,6 +33,4 @@ class RecordFilter:
         next_page_token: Optional[Mapping[str, Any]] = None,
     ) -> List[Record]:
         kwargs = {"stream_state": stream_state, "stream_slice": stream_slice, "next_page_token": next_page_token}
-        for record in records:
-            if self._filter_interpolator.eval(self.config, record=record, **kwargs):
-                yield record
+        return [record for record in records if self._filter_interpolator.eval(self.config, record=record, **kwargs)]

--- a/airbyte-cdk/python/unit_tests/sources/declarative/extractors/test_record_filter.py
+++ b/airbyte-cdk/python/unit_tests/sources/declarative/extractors/test_record_filter.py
@@ -52,4 +52,4 @@ def test_record_filter(test_name, filter_template, records, expected_records):
     actual_records = record_filter.filter_records(
         records, stream_state=stream_state, stream_slice=stream_slice, next_page_token=next_page_token
     )
-    assert list(actual_records) == expected_records
+    assert actual_records == expected_records

--- a/airbyte-cdk/python/unit_tests/sources/declarative/extractors/test_record_selector.py
+++ b/airbyte-cdk/python/unit_tests/sources/declarative/extractors/test_record_selector.py
@@ -78,7 +78,7 @@ def test_record_filter(test_name, field_path, filter_template, body, expected_re
     actual_records = record_selector.select_records(
         response=response, stream_state=stream_state, stream_slice=stream_slice, next_page_token=next_page_token
     )
-    assert list(actual_records) == expected_records
+    assert actual_records == expected_records
 
 
 def create_response(body):


### PR DESCRIPTION
…#24772)"

This reverts commit 032f9b80453d43991d02eb80a4fadc6142d114ff.

## What
* The record_filter was updated to return a generator instead of a list of records. This was done as an optimization for source-amplitude's event stream (it didn't help)
* This is however not a good solution because it changes the interface of the component and other components (such as the pagination), expect its output to be the list of records, not a generator
* [Amplitude's event stream was already reverted to use Python code in this PR](https://github.com/airbytehq/airbyte/pull/25317)
* This PR reverts the erroneous change.

## How
* `git revert 032f9b80453d43991d02eb80a4fadc6142d114ff`