### PR TITLE
Fix Stripe title in menu

### DIFF
--- a/docs/integrations/sources/stripe.md
+++ b/docs/integrations/sources/stripe.md
@@ -1,8 +1,8 @@
+# Stripe
+
 :::warning
 Stripe API Restriction: Access to the events endpoint is [guaranteed only for the last 30 days](https://stripe.com/docs/api/events). Using the full-refresh-overwrite sync from Airbyte will delete the events data older than 30 days from your target destination.
 :::
-
-# Stripe
 
 This page guides you through the process of setting up the Stripe source connector.
 


### PR DESCRIPTION
## What

Makes sure the Stripe connector appears as "Stripe" instead of "stripe" in the menu bar anymore. This happened since there was content before the title in the doc, so docusaurus did just use the filename as a title instead.