### PR TITLE
[ISSUE #26343] update close_slice to use the greater record

### DIFF
--- a/airbyte-cdk/python/airbyte_cdk/sources/declarative/incremental/cursor.py
+++ b/airbyte-cdk/python/airbyte_cdk/sources/declarative/incremental/cursor.py
@@ -56,3 +56,9 @@ class Cursor(ABC, StreamSlicer):
         """
         Evaluating if a record should be synced allows for filtering and stop condition on pagination
         """
+
+    @abstractmethod
+    def is_greater_than_or_equal(self, first: Record, second: Record) -> bool:
+        """
+        Evaluating which record is greater in terms of cursor. This is used to avoid having to capture all the records to close a slice
+        """

--- a/airbyte-cdk/python/airbyte_cdk/sources/declarative/incremental/cursor.py
+++ b/airbyte-cdk/python/airbyte_cdk/sources/declarative/incremental/cursor.py
@@ -25,7 +25,7 @@ class Cursor(ABC, StreamSlicer):
         """
 
     @abstractmethod
-    def close_slice(self, stream_slice: StreamSlice, last_record: Optional[Record]) -> None:
+    def close_slice(self, stream_slice: StreamSlice, most_recent_record: Optional[Record]) -> None:
         """
         Update state based on the stream slice and the latest record. Note that `stream_slice.cursor_slice` and
         `last_record.associated_slice` are expected to be the same but we make it explicit here that `stream_slice` should be leveraged to

--- a/airbyte-cdk/python/airbyte_cdk/sources/declarative/incremental/datetime_based_cursor.py
+++ b/airbyte-cdk/python/airbyte_cdk/sources/declarative/incremental/datetime_based_cursor.py
@@ -259,3 +259,14 @@ class DatetimeBasedCursor(Cursor):
                     log=AirbyteLogMessage(level=level, message=message),
                 )
             )
+
+    def is_greater_than_or_equal(self, first: Record, second: Record) -> bool:
+        cursor_field = self.cursor_field.eval(self.config)
+        first_cursor_value = first.get(cursor_field)
+        second_cursor_value = second.get(cursor_field)
+        if first_cursor_value and second_cursor_value:
+            return self.parse_date(first_cursor_value) >= self.parse_date(second_cursor_value)
+        elif first_cursor_value:
+            return True
+        else:
+            return False

--- a/airbyte-cdk/python/airbyte_cdk/sources/declarative/incremental/datetime_based_cursor.py
+++ b/airbyte-cdk/python/airbyte_cdk/sources/declarative/incremental/datetime_based_cursor.py
@@ -107,8 +107,8 @@ class DatetimeBasedCursor(Cursor):
         """
         self._cursor = stream_state.get(self.cursor_field.eval(self.config)) if stream_state else None
 
-    def close_slice(self, stream_slice: StreamSlice, last_record: Optional[Record]) -> None:
-        last_record_cursor_value = last_record.get(self.cursor_field.eval(self.config)) if last_record else None
+    def close_slice(self, stream_slice: StreamSlice, most_recent_record: Optional[Record]) -> None:
+        last_record_cursor_value = most_recent_record.get(self.cursor_field.eval(self.config)) if most_recent_record else None
         stream_slice_value_end = stream_slice.get(self.partition_field_end.eval(self.config))
         possible_cursor_values = list(
             map(

--- a/airbyte-cdk/python/airbyte_cdk/sources/declarative/incremental/per_partition_cursor.py
+++ b/airbyte-cdk/python/airbyte_cdk/sources/declarative/incremental/per_partition_cursor.py
@@ -253,7 +253,25 @@ class PerPartitionCursor(Cursor):
         )
 
     def should_be_synced(self, record: Record) -> bool:
+        return self._get_cursor(record).should_be_synced(self._convert_record_to_cursor_record(record))
+
+    def is_greater_than_or_equal(self, first: Record, second: Record) -> bool:
+        if first.associated_slice.partition != second.associated_slice.partition:
+            raise ValueError(
+                f"To compare records, partition should be the same but got {first.associated_slice.partition} and {second.associated_slice.partition}"
+            )
+
+        return self._get_cursor(first).is_greater_than_or_equal(
+            self._convert_record_to_cursor_record(first), self._convert_record_to_cursor_record(second)
+        )
+
+    @staticmethod
+    def _convert_record_to_cursor_record(record: Record):
+        return Record(record.data, record.associated_slice.cursor_slice)
+
+    def _get_cursor(self, record: Record) -> Cursor:
         partition_key = self._to_partition_key(record.associated_slice.partition)
         if partition_key not in self._cursor_per_partition:
             raise ValueError("Invalid state as stream slices that are emitted should refer to an existing cursor")
-        return self._cursor_per_partition[partition_key].should_be_synced(Record(record.data, record.associated_slice.cursor_slice))
+        cursor = self._cursor_per_partition[partition_key]
+        return cursor

--- a/airbyte-cdk/python/airbyte_cdk/sources/declarative/incremental/per_partition_cursor.py
+++ b/airbyte-cdk/python/airbyte_cdk/sources/declarative/incremental/per_partition_cursor.py
@@ -144,11 +144,13 @@ class PerPartitionCursor(Cursor):
         for state in stream_state["states"]:
             self._cursor_per_partition[self._to_partition_key(state["partition"])] = self._create_cursor(state["cursor"])
 
-    def close_slice(self, stream_slice: StreamSlice, last_record: Optional[Record]) -> None:
+    def close_slice(self, stream_slice: StreamSlice, most_recent_record: Optional[Record]) -> None:
         try:
-            cursor_last_record = Record(last_record.data, stream_slice.cursor_slice) if last_record else last_record
+            cursor_most_recent_record = (
+                Record(most_recent_record.data, stream_slice.cursor_slice) if most_recent_record else most_recent_record
+            )
             self._cursor_per_partition[self._to_partition_key(stream_slice.partition)].close_slice(
-                stream_slice.cursor_slice, cursor_last_record
+                stream_slice.cursor_slice, cursor_most_recent_record
             )
         except KeyError as exception:
             raise ValueError(

--- a/airbyte-cdk/python/airbyte_cdk/sources/declarative/retrievers/simple_retriever.py
+++ b/airbyte-cdk/python/airbyte_cdk/sources/declarative/retrievers/simple_retriever.py
@@ -361,8 +361,6 @@ class SimpleRetriever(Retriever, HttpStream):
             response=response, stream_state=self.state, stream_slice=stream_slice, next_page_token=next_page_token
         )
         self._records_from_last_response = records
-        if records:
-            self._latest_record = records[-1]
         return records
 
     @property
@@ -412,13 +410,21 @@ class SimpleRetriever(Retriever, HttpStream):
         else:
             slice_state = {}
 
-        yield from self._read_pages(
-            self.parse_records,
-            stream_slice,
-            slice_state,
-        )
+        most_recent_record_from_slice = None
+        for record in self._read_pages(self.parse_records, stream_slice, slice_state):
+            if self.cursor:
+                if not most_recent_record_from_slice:
+                    most_recent_record_from_slice = record
+                else:
+                    most_recent_record_from_slice = (
+                        most_recent_record_from_slice
+                        if self.cursor.is_greater_than_or_equal(most_recent_record_from_slice, record)
+                        else record
+                    )
+            yield record
+
         if self.cursor:
-            self.cursor.close_slice(stream_slice, self._latest_record)
+            self.cursor.close_slice(stream_slice, most_recent_record_from_slice)
         return
 
     def stream_slices(self) -> Iterable[Optional[Mapping[str, Any]]]:

--- a/airbyte-cdk/python/airbyte_cdk/sources/declarative/retrievers/simple_retriever.py
+++ b/airbyte-cdk/python/airbyte_cdk/sources/declarative/retrievers/simple_retriever.py
@@ -72,7 +72,6 @@ class SimpleRetriever(Retriever, HttpStream):
         HttpStream.__init__(self, self.requester.get_authenticator())
         self._last_response = None
         self._records_from_last_response = None
-        self._latest_record = None
         self._parameters = parameters
         self.name = InterpolatedString(self._name, parameters=parameters)
 

--- a/airbyte-cdk/python/unit_tests/sources/declarative/incremental/test_datetime_based_cursor.py
+++ b/airbyte-cdk/python/unit_tests/sources/declarative/incremental/test_datetime_based_cursor.py
@@ -653,5 +653,49 @@ def test_given_record_without_cursor_value_when_should_be_synced_then_return_tru
     assert cursor.should_be_synced(Record({"record without cursor value": "any"}, ANY_SLICE))
 
 
+def test_given_first_greater_than_second_then_return_true():
+    cursor = DatetimeBasedCursor(
+        start_datetime=MinMaxDatetime("3000-01-01", parameters={}),
+        cursor_field="cursor_field",
+        datetime_format="%Y-%m-%d",
+        config=config,
+        parameters={},
+    )
+    assert cursor.is_greater_than_or_equal(Record({"cursor_field": "2023-01-01"}, {}), Record({"cursor_field": "2021-01-01"}, {}))
+
+
+def test_given_first_lesser_than_second_then_return_false():
+    cursor = DatetimeBasedCursor(
+        start_datetime=MinMaxDatetime("3000-01-01", parameters={}),
+        cursor_field="cursor_field",
+        datetime_format="%Y-%m-%d",
+        config=config,
+        parameters={},
+    )
+    assert not cursor.is_greater_than_or_equal(Record({"cursor_field": "2021-01-01"}, {}), Record({"cursor_field": "2023-01-01"}, {}))
+
+
+def test_given_no_cursor_value_for_second_than_second_then_return_true():
+    cursor = DatetimeBasedCursor(
+        start_datetime=MinMaxDatetime("3000-01-01", parameters={}),
+        cursor_field="cursor_field",
+        datetime_format="%Y-%m-%d",
+        config=config,
+        parameters={},
+    )
+    assert cursor.is_greater_than_or_equal(Record({"cursor_field": "2021-01-01"}, {}), Record({}, {}))
+
+
+def test_given_no_cursor_value_for_first_than_second_then_return_false():
+    cursor = DatetimeBasedCursor(
+        start_datetime=MinMaxDatetime("3000-01-01", parameters={}),
+        cursor_field="cursor_field",
+        datetime_format="%Y-%m-%d",
+        config=config,
+        parameters={},
+    )
+    assert not cursor.is_greater_than_or_equal(Record({}, {}), Record({"cursor_field": "2021-01-01"}, {}))
+
+
 if __name__ == "__main__":
     unittest.main()

--- a/airbyte-cdk/python/unit_tests/sources/declarative/retrievers/test_simple_retriever.py
+++ b/airbyte-cdk/python/unit_tests/sources/declarative/retrievers/test_simple_retriever.py
@@ -3,7 +3,7 @@
 #
 
 from typing import Mapping
-from unittest.mock import MagicMock, patch
+from unittest.mock import MagicMock, Mock, patch
 
 import airbyte_cdk.sources.declarative.requesters.error_handlers.response_status as response_status
 import pytest
@@ -194,7 +194,6 @@ def test_simple_retriever_with_request_response_log_last_records(mock_http_strea
     assert retriever.parse_response(response, stream_state={}) == request_response_logs
     assert retriever._last_response == response
     assert retriever._records_from_last_response == request_response_logs
-    assert retriever._latest_record == request_response_logs[-1]
 
     [r for r in retriever.read_records(SyncMode.full_refresh)]
     paginator.reset.assert_called()
@@ -727,19 +726,22 @@ def test_limit_stream_slices():
 
 
 @pytest.mark.parametrize(
-    "test_name, last_records, records, latest_record",
+    "test_name, first_greater_than_second",
     [
-        ("test_two_records", [{"id": -1}], records, records[-1]),
-        ("test_no_records", [{"id": -1}], [], None),
-        ("test_no_records_no_previous_records", [], [], None)
-    ]
+        ("test_first_greater_than_second", True),
+        ("test_second_greater_than_first", False),
+    ],
 )
-def test_read_records_then_cursor_close_slice(test_name, last_records, records, latest_record):
+def test_when_read_records_then_cursor_close_slice_with_greater_record(test_name, first_greater_than_second):
     requester = MagicMock()
     paginator = MagicMock()
     record_selector = MagicMock()
+    first_record = Mock()
+    second_record = Mock()
+    records = [first_record, second_record]
     record_selector.select_records.return_value = records
     cursor = MagicMock(spec=Cursor)
+    cursor.is_greater_than_or_equal.return_value = first_greater_than_second
 
     retriever = SimpleRetriever(
         name="stream_name",
@@ -753,39 +755,16 @@ def test_read_records_then_cursor_close_slice(test_name, last_records, records, 
         config={},
     )
     stream_slice = {"repository": "airbyte"}
-    with patch.object(HttpStream, "_read_pages", return_value=iter(records), side_effect=lambda _, __, ___: retriever.parse_records(request=MagicMock(), response=MagicMock(), stream_state=None, stream_slice=stream_slice)):
+
+    with patch.object(HttpStream, "_read_pages", return_value=iter([first_record, second_record]), side_effect=lambda _, __, ___: retriever.parse_records(request=MagicMock(), response=MagicMock(), stream_state=None, stream_slice=stream_slice)):
         list(retriever.read_records(sync_mode=SyncMode.incremental, stream_slice=stream_slice))
-        cursor.close_slice.assert_called_once_with(stream_slice, latest_record)
+        cursor.close_slice.assert_called_once_with(stream_slice, first_record if first_greater_than_second else second_record)
 
 
 def parse_two_pages_and_return_records(retriever, stream_slice, records):
     list(retriever.parse_records(request=MagicMock(), response=MagicMock(), stream_state=None, stream_slice=stream_slice))
     list(retriever.parse_records(request=MagicMock(), response=MagicMock(), stream_state=None, stream_slice=stream_slice))
     return records
-
-
-def test_given_latest_response_has_no_records_when_read_records_then_close_slice_using_latest_record_from_previous_response():
-    requester = MagicMock()
-    paginator = MagicMock()
-    record_selector = MagicMock()
-    record_selector.select_records.side_effect = [records, []]
-    cursor = MagicMock(spec=Cursor)
-
-    retriever = SimpleRetriever(
-        name="stream_name",
-        primary_key=primary_key,
-        requester=requester,
-        paginator=paginator,
-        record_selector=record_selector,
-        stream_slicer=cursor,
-        cursor=cursor,
-        parameters={},
-        config={},
-    )
-    stream_slice = {"repository": "airbyte"}
-    with patch.object(HttpStream, "_read_pages", side_effect=lambda _, __, ___: parse_two_pages_and_return_records(retriever, stream_slice, records)):
-        list(retriever.read_records(sync_mode=SyncMode.incremental, stream_slice=stream_slice))
-        cursor.close_slice.assert_called_once_with(stream_slice, records[-1])
 
 
 def _generate_slices(number_of_slices):


### PR DESCRIPTION
## What
Following the data feed release, we expected to update the state while closing a slice using the latest record. This doesn't work because the latest record is not necessarily the one with the state being the greatest. For example, within the same HTTP request, posthog last record has cursor field value `2021-12-10T10:21:35.003000+00:00` but there is a record before with `2021-12-10T10:21:35.208000+00:00`

## How
Compare record using the cursor and only keep the one with the highest cursor field value.

## 🚨 User Impact 🚨
With the current CDK release following the data feed feature, connectors are at risk of not updating the cursor field properly. This should fix the issue
