### PR TITLE
connectors-ci: use new domain for test reports

### DIFF
--- a/airbyte-integrations/connectors/source-openweather/metadata.yaml
+++ b/airbyte-integrations/connectors/source-openweather/metadata.yaml
@@ -6,7 +6,7 @@ data:
   dockerRepository: airbyte/source-openweather
   githubIssueLabel: source-openweather
   icon: openweather.svg
-  license: MIT
+  license: MIT # TO REVERT
   name: OpenWeather
   registries:
     cloud:

--- a/airbyte-integrations/connectors/source-openweather/metadata.yaml
+++ b/airbyte-integrations/connectors/source-openweather/metadata.yaml
@@ -6,7 +6,7 @@ data:
   dockerRepository: airbyte/source-openweather
   githubIssueLabel: source-openweather
   icon: openweather.svg
-  license: MIT # TO REVERT
+  license: MIT
   name: OpenWeather
   registries:
     cloud:

--- a/tools/ci_connector_ops/ci_connector_ops/pipelines/bases.py
+++ b/tools/ci_connector_ops/ci_connector_ops/pipelines/bases.py
@@ -19,7 +19,7 @@ import anyio
 import asyncer
 from anyio import Path
 from ci_connector_ops.pipelines.actions import remote_storage
-from ci_connector_ops.pipelines.consts import LOCAL_REPORTS_PATH_ROOT, PYPROJECT_TOML_FILE_PATH
+from ci_connector_ops.pipelines.consts import GCS_PUBLIC_DOMAIN, LOCAL_REPORTS_PATH_ROOT, PYPROJECT_TOML_FILE_PATH
 from ci_connector_ops.pipelines.utils import check_path_in_workdir, format_duration, slugify, with_exit_code, with_stderr, with_stdout
 from ci_connector_ops.utils import console
 from dagger import Container, QueryError
@@ -404,7 +404,7 @@ class Report:
             flags=gcs_cp_flags,
         )
         gcs_uri = "gs://" + self.pipeline_context.ci_report_bucket + "/" + remote_key
-        public_url = f"https://storage.googleapis.com/{self.pipeline_context.ci_report_bucket}/{remote_key}"
+        public_url = f"{GCS_PUBLIC_DOMAIN}/{self.pipeline_context.ci_report_bucket}/{remote_key}"
         if report_upload_exit_code != 0:
             self.pipeline_context.logger.error(f"Uploading {local_path} to {gcs_uri} failed.")
         else:
@@ -502,7 +502,7 @@ class ConnectorReport(Report):
 
     @property
     def html_report_url(self) -> str:  # noqa D102
-        return f"https://storage.googleapis.com/{self.pipeline_context.ci_report_bucket}/{self.html_report_remote_storage_key}"
+        return f"{GCS_PUBLIC_DOMAIN}/{self.pipeline_context.ci_report_bucket}/{self.html_report_remote_storage_key}"
 
     @property
     def should_be_commented_on_pr(self) -> bool:  # noqa D102

--- a/tools/ci_connector_ops/ci_connector_ops/pipelines/consts.py
+++ b/tools/ci_connector_ops/ci_connector_ops/pipelines/consts.py
@@ -33,4 +33,5 @@ GRADLE_CACHE_PATH = "/root/.gradle/caches"
 GRADLE_BUILD_CACHE_PATH = f"{GRADLE_CACHE_PATH}/build-cache-1"
 GRADLE_READ_ONLY_DEPENDENCY_CACHE_PATH = "/root/gradle_dependency_cache"
 LOCAL_REPORTS_PATH_ROOT = "tools/ci_connector_ops/pipeline_reports/"
+GCS_PUBLIC_DOMAIN = "https://storage.cloud.google.com"
 Path(LOCAL_REPORTS_PATH_ROOT).mkdir(parents=True, exist_ok=True)

--- a/tools/ci_connector_ops/ci_connector_ops/pipelines/utils.py
+++ b/tools/ci_connector_ops/ci_connector_ops/pipelines/utils.py
@@ -19,6 +19,7 @@ import asyncer
 import click
 import git
 from ci_connector_ops.pipelines import consts, main_logger
+from ci_connector_ops.pipelines.consts import GCS_PUBLIC_DOMAIN
 from ci_connector_ops.utils import get_all_released_connectors, get_changed_connectors
 from dagger import Config, Connection, Container, DaggerError, File, ImageLayerCompression, QueryError
 from google.cloud import storage
@@ -357,7 +358,7 @@ class DaggerPipelineCommand(click.Command):
                 ctx.obj["dagger_logs_path"] = dagger_log_path
                 main_logger.info(f"Saving dagger logs to: {dagger_log_path}")
                 if ctx.obj["is_ci"]:
-                    ctx.obj["dagger_logs_url"] = f"https://storage.googleapis.com/{ctx.obj['ci_report_bucket_name']}/{dagger_logs_gcs_key}"
+                    ctx.obj["dagger_logs_url"] = f"{GCS_PUBLIC_DOMAIN}/{ctx.obj['ci_report_bucket_name']}/{dagger_logs_gcs_key}"
                 else:
                     ctx.obj["dagger_logs_url"] = None
             else:
@@ -493,5 +494,5 @@ def upload_to_gcs(file_path: Path, bucket_name: str, object_name: str, credentia
     blob = bucket.blob(object_name)
     blob.upload_from_filename(str(file_path))
     gcs_uri = f"gs://{bucket_name}/{object_name}"
-    public_url = f"https://storage.googleapis.com/{bucket_name}/{object_name}"
+    public_url = f"{GCS_PUBLIC_DOMAIN}/{bucket_name}/{object_name}"
     return gcs_uri, public_url


### PR DESCRIPTION
## What
Closes #27497

Using the `https://storage.cloud.google.com` domain we can implement cookie based authentication to restrict access to the test reprots to a specific set of google email addresses / group.

This PR has no direct effect on the bucket permission, but a 👍 from reviewer will make me:
* Remove public access to the `airbyte-ci-reports-multi` bucket
* Allow airbyters and GL team to be Storage Object viewers


