### PR TITLE
connectors-ci: fix typo in duration

### DIFF
--- a/tools/ci_connector_ops/ci_connector_ops/pipelines/bases.py
+++ b/tools/ci_connector_ops/ci_connector_ops/pipelines/bases.py
@@ -546,7 +546,7 @@ class ConnectorReport(Report):
         global_status_emoji = "✅" if self.success else "❌"
         commit_url = f"{self.pipeline_context.pull_request.html_url}/commits/{self.pipeline_context.git_revision}"
         markdown_comment = f'## <img src="{icon_url}" width="40" height="40"> {self.pipeline_context.connector.technical_name} test report (commit [`{self.pipeline_context.git_revision[:10]}`]({commit_url})) - {global_status_emoji}\n\n'
-        markdown_comment += f"⏲️  Total pipeline duration: {format_duration(self.run_duration)}\n\n"
+        markdown_comment += f"⏲️  Total pipeline duration: {format_duration(self.run_duration)} \n\n"
         report_data = [
             [step_result.step.title, step_result.status.get_emoji()]
             for step_result in self.steps_results

--- a/tools/ci_connector_ops/ci_connector_ops/pipelines/bases.py
+++ b/tools/ci_connector_ops/ci_connector_ops/pipelines/bases.py
@@ -546,7 +546,7 @@ class ConnectorReport(Report):
         global_status_emoji = "✅" if self.success else "❌"
         commit_url = f"{self.pipeline_context.pull_request.html_url}/commits/{self.pipeline_context.git_revision}"
         markdown_comment = f'## <img src="{icon_url}" width="40" height="40"> {self.pipeline_context.connector.technical_name} test report (commit [`{self.pipeline_context.git_revision[:10]}`]({commit_url})) - {global_status_emoji}\n\n'
-        markdown_comment += f"⏲️  Total pipeline duration: {format_duration(self.run_duration)} seconds\n\n"
+        markdown_comment += f"⏲️  Total pipeline duration: {format_duration(self.run_duration)}\n\n"
         report_data = [
             [step_result.step.title, step_result.status.get_emoji()]
             for step_result in self.steps_results


### PR DESCRIPTION
## What
A `seconds` suffix was remaining, but the `format_duration` function correctly adds the mn and s suffixes already.
