### PR TITLE
Add api keyword to gradle dependencies regex

### DIFF
--- a/tools/ci_connector_ops/ci_connector_ops/utils.py
+++ b/tools/ci_connector_ops/ci_connector_ops/utils.py
@@ -125,7 +125,7 @@ def parse_gradle_dependencies(build_file: Path) -> Tuple[List[Path], List[Path]]
 
     # Find all matches for test dependencies and regular dependencies
     matches = re.findall(
-        r"(testImplementation|integrationTestJavaImplementation|performanceTestJavaImplementation|implementation).*?project\(['\"](.*?)['\"]\)",
+        r"(testImplementation|integrationTestJavaImplementation|performanceTestJavaImplementation|implementation|api).*?project\(['\"](.*?)['\"]\)",
         dependencies_block,
     )
     if matches:


### PR DESCRIPTION
## What
Adds `api` to allow lines like
```
dependencies {
    api project(':airbyte-db:db-lib')
    implementation project(':airbyte-api')
```

to import `airbyte-db:db-lib`