### PR TITLE
Source Typeform: pin to 0.3.0 in Cloud

### DIFF
--- a/airbyte-integrations/connectors/source-typeform/metadata.yaml
+++ b/airbyte-integrations/connectors/source-typeform/metadata.yaml
@@ -14,7 +14,7 @@ data:
   registries:
     cloud:
       enabled: true
-      dockerImageTag: 0.4.2
+      dockerImageTag: 0.3.0
     oss:
       enabled: true
   releaseStage: beta

--- a/airbyte-integrations/connectors/source-typeform/metadata.yaml
+++ b/airbyte-integrations/connectors/source-typeform/metadata.yaml
@@ -14,6 +14,7 @@ data:
   registries:
     cloud:
       enabled: true
+      dockerImageTag: 0.4.2
     oss:
       enabled: true
   releaseStage: beta


### PR DESCRIPTION
## What
Pin current version of Source Typeform on Cloud to 0.3.0, as we are waiting for [this PR with Java Implementation OAuth](https://github.com/airbytehq/airbyte-platform-internal/pull/7173) to be properly released to platform, after which the changes in the [Python implementation](https://github.com/airbytehq/airbyte/pull/27240) will be published. Until then, the version of connector on cloud would be 0.3.0

## How
Update `metadata.yml`

