### PR TITLE
Fixing an issue with square as CATs only compare string and not datetime

### DIFF
--- a/airbyte-cdk/python/airbyte_cdk/sources/declarative/incremental/datetime_based_cursor.py
+++ b/airbyte-cdk/python/airbyte_cdk/sources/declarative/incremental/datetime_based_cursor.py
@@ -110,13 +110,19 @@ class DatetimeBasedCursor(Cursor):
     def close_slice(self, stream_slice: StreamSlice, most_recent_record: Optional[Record]) -> None:
         last_record_cursor_value = most_recent_record.get(self.cursor_field.eval(self.config)) if most_recent_record else None
         stream_slice_value_end = stream_slice.get(self.partition_field_end.eval(self.config))
-        possible_cursor_values = list(
+        cursor_value_str_by_cursor_value_datetime = dict(
             map(
-                lambda datetime_str: self.parse_date(datetime_str),
+                # we need to ensure the cursor value is preserved as is in the state else the CATs might complain of something like
+                # 2023-01-04T17:30:19.000Z' <= '2023-01-04T17:30:19.000000Z'
+                lambda datetime_str: (self.parse_date(datetime_str), datetime_str),
                 filter(lambda item: item, [self._cursor, last_record_cursor_value, stream_slice_value_end]),
             )
         )
-        self._cursor = self._format_datetime(max(possible_cursor_values)) if possible_cursor_values else None
+        self._cursor = (
+            cursor_value_str_by_cursor_value_datetime[max(cursor_value_str_by_cursor_value_datetime.keys())]
+            if cursor_value_str_by_cursor_value_datetime
+            else None
+        )
 
     def stream_slices(self) -> Iterable[StreamSlice]:
         """

--- a/airbyte-cdk/python/unit_tests/sources/declarative/incremental/test_datetime_based_cursor.py
+++ b/airbyte-cdk/python/unit_tests/sources/declarative/incremental/test_datetime_based_cursor.py
@@ -713,6 +713,5 @@ def test_given_no_cursor_value_for_first_than_second_then_return_false():
     assert not cursor.is_greater_than_or_equal(Record({}, {}), Record({"cursor_field": "2021-01-01"}, {}))
 
 
-
 if __name__ == "__main__":
     unittest.main()

--- a/airbyte-cdk/python/unit_tests/sources/declarative/incremental/test_datetime_based_cursor.py
+++ b/airbyte-cdk/python/unit_tests/sources/declarative/incremental/test_datetime_based_cursor.py
@@ -391,6 +391,22 @@ def test_close_slice(test_name, previous_cursor, stream_slice, latest_record_dat
     assert expected_state == updated_state
 
 
+def test_given_datetime_format_differs_from_cursor_value_when_close_slice_then_use_cursor_value_and_not_formatted_value():
+    cursor = DatetimeBasedCursor(
+        start_datetime=MinMaxDatetime(datetime="2021-01-01T00:00:00.000000+0000", parameters={}),
+        cursor_field=cursor_field,
+        datetime_format="%Y-%m-%dT%H:%M:%S.%fZ",
+        config=config,
+        parameters={},
+    )
+
+    _slice = {}
+    record_cursor_value = "2023-01-04T17:30:19.000Z"
+    cursor.close_slice(_slice, Record({cursor_field: record_cursor_value}, _slice))
+
+    assert cursor.get_stream_state()[cursor_field] == record_cursor_value
+
+
 def test_given_partition_end_is_specified_and_greater_than_record_when_close_slice_then_use_partition_end():
     partition_field_end = "partition_field_end"
     cursor = DatetimeBasedCursor(
@@ -695,6 +711,7 @@ def test_given_no_cursor_value_for_first_than_second_then_return_false():
         parameters={},
     )
     assert not cursor.is_greater_than_or_equal(Record({}, {}), Record({"cursor_field": "2021-01-01"}, {}))
+
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## What
Issue: https://storage.googleapis.com/airbyte-ci-reports-multi/airbyte-ci/connectors/test/pull_request/maxi297-state-changes_square/1688051383/35787de568588beab80ce8565b1a8290f1709dae/source-square/1.1.1/output.html

This is only seems like an issue because CATs only supports primitive as types for states. If we could have datetime, that would be neat but this is not something that can be changed easily.

## How
Ensure we use the cursor field value from the record and not a formatted version
