### PR TITLE
📚 CI credentials: fix `GCP_GSM_CREDENTIALS` export syntax

### DIFF
--- a/tools/ci_credentials/README.md
+++ b/tools/ci_credentials/README.md
@@ -29,7 +29,7 @@ Download a Service account json key that has access to Google Secrets Manager.
 * Click on "ADD KEY -> Create new key" and select JSON. This will download a file on your computer
 
 ### Setup ci_credentials
-* In your .zshrc, add: `export GCP_GSM_CREDENTIALS=cat $(<path to JSON file>)`
+* In your .zshrc, add: `export GCP_GSM_CREDENTIALS=$(cat <path to JSON file>)`
 * Follow README.md under `tools/ci_credentials`
 
 After making a change, you have to reinstall it to run the bash command: `pip install --quiet -e ./tools/ci_*`


### PR DESCRIPTION
The `cat` was in the wrong place before and every time I would open a new terminal window it would try to execute the contents of the service account key JSON file. This fixed being able to pull GSM creds properly.