### PR TITLE
pin dest-bq to 1.4.5

### DIFF
--- a/airbyte-integrations/connectors/destination-bigquery/metadata.yaml
+++ b/airbyte-integrations/connectors/destination-bigquery/metadata.yaml
@@ -2,7 +2,7 @@ data:
   connectorSubtype: database
   connectorType: destination
   definitionId: 22f6c74f-5699-40ff-833c-4a879ea40133
-  dockerImageTag: 1.5.0
+  dockerImageTag: 1.4.5
   dockerRepository: airbyte/destination-bigquery
   githubIssueLabel: destination-bigquery
   icon: bigquery.svg


### PR DESCRIPTION
standard inserts mode is currently trying to execute the new t+d logic every 10K records, so any sync >10K will fail.