### PR TITLE
🐛 Destination Bigquery: fix bug in standard inserts for syncs >10K records

### DIFF
--- a/airbyte-integrations/connectors/destination-bigquery/src/main/java/io/airbyte/integrations/destination/bigquery/BigQueryRecordConsumer.java
+++ b/airbyte-integrations/connectors/destination-bigquery/src/main/java/io/airbyte/integrations/destination/bigquery/BigQueryRecordConsumer.java
@@ -205,10 +205,12 @@ public class BigQueryRecordConsumer extends FailureTrackingAirbyteMessageConsume
   }
 
   private void doTypingAndDeduping(final StreamConfig stream) throws InterruptedException {
-    String suffix;
-    suffix = overwriteStreamsWithTmpTable.getOrDefault(stream.id(), "");
-    final String sql = sqlGenerator.updateTable(suffix, stream);
-    destinationHandler.execute(sql);
+    if (use1s1t) {
+      String suffix;
+      suffix = overwriteStreamsWithTmpTable.getOrDefault(stream.id(), "");
+      final String sql = sqlGenerator.updateTable(suffix, stream);
+      destinationHandler.execute(sql);
+    }
   }
 
 }

--- a/docs/integrations/destinations/bigquery.md
+++ b/docs/integrations/destinations/bigquery.md
@@ -135,7 +135,6 @@ Now that you have set up the BigQuery destination connector, check out the follo
 
 | Version | Date       | Pull Request                                               | Subject                                                                                                                  |
 | :------ | :--------- | :--------------------------------------------------------- | :----------------------------------------------------------------------------------------------------------------------- |
-| 1.5.3   | 2023-06-20 | [\#27856](https://github.com/airbytehq/airbyte/pull/27856) | Fix bug in standard inserts, which caused syncs >10K records to fail                                                     |
 | 1.5.2   | 2023-07-05 | [\#27936](https://github.com/airbytehq/airbyte/pull/27936) | Internal scaffolding change for future development                                                                       |
 | 1.5.1   | 2023-06-30 | [\#27891](https://github.com/airbytehq/airbyte/pull/27891) | Revert bugged update                                                                                                     |
 | 1.5.0   | 2023-06-27 | [\#27781](https://github.com/airbytehq/airbyte/pull/27781) | License Update: Elv2                                                                                                     |

--- a/docs/integrations/destinations/bigquery.md
+++ b/docs/integrations/destinations/bigquery.md
@@ -135,6 +135,7 @@ Now that you have set up the BigQuery destination connector, check out the follo
 
 | Version | Date       | Pull Request                                               | Subject                                                                                                                  |
 | :------ | :--------- | :--------------------------------------------------------- | :----------------------------------------------------------------------------------------------------------------------- |
+| 1.5.3   | 2023-06-20 | [\#27856](https://github.com/airbytehq/airbyte/pull/27856) | Fix bug in standard inserts, which caused syncs >10K records to fail                                                     |
 | 1.5.2   | 2023-07-05 | [\#27936](https://github.com/airbytehq/airbyte/pull/27936) | Internal scaffolding change for future development                                                                       |
 | 1.5.1   | 2023-06-30 | [\#27891](https://github.com/airbytehq/airbyte/pull/27891) | Revert bugged update                                                                                                     |
 | 1.5.0   | 2023-06-27 | [\#27781](https://github.com/airbytehq/airbyte/pull/27781) | License Update: Elv2                                                                                                     |


### PR DESCRIPTION
there was a bug in an unreleased feature, which was intended to be gated behind an inactive flag. That flag didn't properly gate everything. Fix it.