### PR TITLE
make publish_option required in publish connectors workflow

### DIFF
--- a/.github/workflows/publish_connectors.yml
+++ b/.github/workflows/publish_connectors.yml
@@ -9,11 +9,12 @@ on:
   workflow_dispatch:
     inputs:
       connectors-options:
-        description: "Options to pass to the 'airbyte-ci connectors' command group"
+        description: "Options to pass to the 'airbyte-ci connectors' command group."
         default: "--name=source-pokeapi"
       publish-options:
-        description: "Options to pass to the 'airbyte-ci connectors publish' command"
+        description: "Options to pass to the 'airbyte-ci connectors publish' command. Use --pre-release or --main-release depending on whether you want to publish a dev image or not. "
         default: "--pre-release"
+        required: true
 jobs:
   publish_connectors:
     name: Publish connectors


### PR DESCRIPTION
I ran into a situation where I kept unknowingly publishing dev images because I replaced `--pre-release` with an empty string. Turns out github interprets the empty string as having omitted that input field and replaces it with the default value. Making this required so the empty string doesn't go through

