### PR TITLE
Switch "request parameters" to "query parameters" in connector builder docs

### DIFF
--- a/docs/connector-development/connector-builder-ui/incremental-sync.md
+++ b/docs/connector-development/connector-builder-ui/incremental-sync.md
@@ -24,7 +24,7 @@ In the builder UI, these things are specified like this:
 * The "Cursor granularity" is the smallest time unit supported by the API to specify the time range to request records for expressed as [ISO 8601 duration](https://en.wikipedia.org/wiki/ISO_8601#Durations)
 * The "Start datetime" is the initial start date of the time range to fetch records for. When doing incremental syncs, the second sync will overwrite this date with the last record that got synced so far.
 * The "End datetime" is the end date of the time range to fetch records for. In most cases it's set to the current date and time when the sync is started to sync all changes that happened so far.
-* The "Inject start/end time into outgoing HTTP request" defines how to request records that got changed in the time range to sync. In most cases the start and end time is added as a request parameter or body parameter
+* The "Inject start/end time into outgoing HTTP request" defines how to request records that got changed in the time range to sync. In most cases the start and end time is added as a query parameter or body parameter
 
 ## Example
 
@@ -56,7 +56,7 @@ As this fulfills the requirements for incremental syncs, we can configure the "I
 <iframe width="640" height="835" src="https://www.loom.com/embed/78eb5da26e2e4f4aa9c3a48573d9ed3b" frameborder="0" webkitallowfullscreen mozallowfullscreen allowfullscreen></iframe>
 
 This API orders records by default from new to old, which is not optimal for a reliable sync as the last encountered cursor value will be the most recent date even if some older records did not get synced (for example if a sync fails halfway through). It's better to start with the oldest records and work your way up to make sure that all older records are synced already once a certain date is encountered on a record. In this case the API can be configured to behave like this by setting an additional parameter:
-* At the bottom of the stream configuration page, add a new "Request parameter"
+* Add a new "Query Parameter" near the top of the page
 * Set the key to `order-by`
 * Set the value to `oldest`
 
@@ -148,4 +148,4 @@ Using the "Inject start time / end time into outgoing HTTP request" option in th
 To handle these cases, disable injection in the incremental sync form and use the generic parameter section at the bottom of the stream configuration form to freely configure query parameters, headers and properties of the JSON body, by using jinja expressions and [available variables](/connector-development/config-based/understanding-the-yaml-file/reference/#/variables). You can also use these variables as part of the URL path.
 
 For example the [Sendgrid API](https://docs.sendgrid.com/api-reference/e-mail-activity/filter-all-messages) requires setting both start and end time in a `query` parameter.
-For this case, you can use the `stream_interval` variable to configure a request parameter with "key" `query` and "value" `last_event_time BETWEEN TIMESTAMP "{{stream_interval.start_time}}" AND TIMESTAMP "{{stream_interval.end_time}}"` to filter down to the right window in time.
+For this case, you can use the `stream_interval` variable to configure a query parameter with "key" `query` and "value" `last_event_time BETWEEN TIMESTAMP "{{stream_interval.start_time}}" AND TIMESTAMP "{{stream_interval.end_time}}"` to filter down to the right window in time.

--- a/docs/connector-development/connector-builder-ui/pagination.md
+++ b/docs/connector-development/connector-builder-ui/pagination.md
@@ -91,7 +91,7 @@ GET https://api.example.com/products?limit=3&offset=4
      // less than 2 records returned -> stop
 ```
 
-The Connector Builder currently supports injecting these values into the request parameters (i.e. query parameters), headers, or body.
+The Connector Builder currently supports injecting these values into the query parameters (i.e. request parameters), headers, or body.
 
 #### Examples
 
@@ -189,7 +189,7 @@ GET https://api.example.com/products?page_size=3&page=3
      // less than 2 records returned -> stop
 ```
 
-The Connector Builder currently supports injecting these values into the request parameters (i.e. query parameters), headers, or body.
+The Connector Builder currently supports injecting these values into the query parameters (i.e. request parameters), headers, or body.
 
 #### Examples
 
@@ -264,7 +264,7 @@ This API also has a boolean `has_more` property included in the response to indi
 
 The following APIs implement cursor pagination in various ways:
 
-- [Twitter API](https://developer.twitter.com/en/docs/twitter-api/pagination) - includes `next_token` IDs in its responses which are passed in as request parameters to subsequent requests
+- [Twitter API](https://developer.twitter.com/en/docs/twitter-api/pagination) - includes `next_token` IDs in its responses which are passed in as query parameters to subsequent requests
 - [GitHub API](https://docs.github.com/en/rest/guides/using-pagination-in-the-rest-api?apiVersion=2022-11-28) - includes full-URL `link`s to subsequent pages of results
 - [FourSquare API](https://location.foursquare.com/developer/reference/pagination) - includes full-URL `link`s to subsequent pages of results
 
@@ -278,5 +278,5 @@ Using the "Inject page size / limit / offset into outgoing HTTP request" option 
 
 To handle these cases, disable injection in the pagination form and use the generic parameter section at the bottom of the stream configuration form to freely configure query parameters, headers and properties of the JSON body, by using jinja expressions and [available variables](/connector-development/config-based/understanding-the-yaml-file/reference/#/variables). You can also use these variables as part of the URL path.
 
-For example the [Prestashop API](https://devdocs.prestashop-project.org/8/webservice/cheat-sheet/#list-options) requires to set offset and limit separated by a comma into a single request parameter (`?limit=<offset>,<limit>`)
-For this case, you can use the `next_page_token` variable to configure a request parameter with key `limit` and value `{{ next_page_token['next_page_token'] or '0' }},50` to inject the offset from the pagination strategy and a hardcoded limit of 50 into the same parameter.
+For example the [Prestashop API](https://devdocs.prestashop-project.org/8/webservice/cheat-sheet/#list-options) requires to set offset and limit separated by a comma into a single query parameter (`?limit=<offset>,<limit>`)
+For this case, you can use the `next_page_token` variable to configure a query parameter with key `limit` and value `{{ next_page_token['next_page_token'] or '0' }},50` to inject the offset from the pagination strategy and a hardcoded limit of 50 into the same parameter.

--- a/docs/connector-development/connector-builder-ui/partitioning.md
+++ b/docs/connector-development/connector-builder-ui/partitioning.md
@@ -45,7 +45,7 @@ To enable user-configurable static partitions for the [Woocommerce API](https://
 * Name it `Order IDs`, set type to `array` and click create
 * Set "Current partition value identifier" to `order`
 * "Inject partition value into outgoing HTTP request" is disabled, because the order id needs to be injected into the path
-* In the general section of the stream configuration, the "Path URL" is set to `/orders/{{ stream_partition.order }}/notes`
+* In the general section of the stream configuration, the "URL Path" is set to `/orders/{{ stream_partition.order }}/notes`
 
 <iframe width="640" height="777" src="https://www.loom.com/embed/df5d437eeaf545a9be25a1e7649217dc" frameborder="0" webkitallowfullscreen mozallowfullscreen allowfullscreen></iframe>
 
@@ -70,7 +70,7 @@ The following fields have to be configured to use the substream partition router
 To enable dynamic partition routing for the [Woocommerce API](https://woocommerce.github.io/woocommerce-rest-api-docs/#order-notes) order notes, first an "orders" stream needs to be configured for the `/orders` endpoint to fetch a list of orders. Once this is done, the partition router for responses has be configured like this:
 * "Parent key" is set to `id`
 * "Current partition value identifier" is set to `order`
-* In the general section of the stream configuration, the "Path URL" is set to `/orders/{{ stream_partition.order }}/notes`
+* In the general section of the stream configuration, the "URL Path" is set to `/orders/{{ stream_partition.order }}/notes`
 
 <iframe width="640" height="765" src="https://www.loom.com/embed/41bb2ffba45644bbbda43f7e679f2754" frameborder="0" webkitallowfullscreen mozallowfullscreen allowfullscreen></iframe>
 

--- a/docs/connector-development/connector-builder-ui/tutorial.mdx
+++ b/docs/connector-development/connector-builder-ui/tutorial.mdx
@@ -112,10 +112,10 @@ The detected schema tab indicates the schema that was detected by analyzing the 
 
 <div style={{ position: "relative", paddingBottom: "59.66850828729282%", height: 0 }}><iframe src="https://www.loom.com/embed/9fa4f22914db48a1876413f67cd6e2f0" frameborder="0" webkitallowfullscreen mozallowfullscreen allowfullscreen style={{position: "absolute", top: 0, left: 0, width: "100%", height: "100%"}}></iframe></div>
 
-The exchange rate API supports configuring a different base currency via request parameter - let's make this part of the user inputs that can be controlled by the user of the connector when configuring a source, similar to the API key.
+The exchange rate API supports configuring a different base currency via query parameter - let's make this part of the user inputs that can be controlled by the user of the connector when configuring a source, similar to the API key.
 
 To do so, follow these steps:
-* Scroll down to the "Request parameters" section and add a new request parameter
+* Scroll down to the "Query Parameters" section and add a new query parameter
 * Set the key to `base`
 * For the value, click the user icon in the input and select "New user input"
 * Set the name to "Base"

--- a/docs/connector-development/connector-builder-ui/tutorial.mdx
+++ b/docs/connector-development/connector-builder-ui/tutorial.mdx
@@ -151,13 +151,13 @@ In this section, we'll update the source to read historical data instead of only
 According to the API documentation, we can read the exchange rate for a specific date range by querying the `"/exchangerates_data/{date}"` endpoint instead of `"/exchangerates_data/latest"`.
 
 To configure your connector to request every day individually, follow these steps:
-* On top of the form, change the "Path URL" input to `/exchangerates_data/{{ stream_interval.start_time }}` to [inject](/connector-development/config-based/understanding-the-yaml-file/reference#variables) the date to fetch data for into the path of the request
+* On top of the form, change the "URL Path" input to `/exchangerates_data/{{ stream_interval.start_time }}` to [inject](/connector-development/config-based/understanding-the-yaml-file/reference#variables) the date to fetch data for into the path of the request
 * Enable "Incremental sync" for the Rates stream
 * Set the "Cursor Field" to `date` - this is the property in our records to check what date got synced last
 * Set the "Cursor Field Datetime Format" to `%Y-%m-%d` to match the format of the date in the record returned from the API
 * Leave start time to "User input" so the end user can set the desired start time for syncing data
 * Leave end time to "Now" to always sync exchange rates up to the current date
-* In a lot of cases the start and end date are injected into the request body or request parameters. However in the case of the exchange rate API it needs to be added to the path of the request, so disable the "Inject start/end time into outgoing HTTP request" options
+* In a lot of cases the start and end date are injected into the request body or query parameters. However in the case of the exchange rate API it needs to be added to the path of the request, so disable the "Inject start/end time into outgoing HTTP request" options
 * Open the "Advanced" section and enable "Split up interval" so that the connector will partition the dataset into chunks
 * Set "Step" to `P1D` to configure the connector to do one separate request per day
 * Set the "Cursor granularity" to `P1D` to tell the connector the API only supports daily increments


### PR DESCRIPTION
## What
We changed the connector builder to use the term "Query Parameters" instead of "Request Parameters" since we felt that was a clearer term to use.

However, not all of the connector builder docs were updated to reflect this change

## How
Update the connector builder documentation to reflect the term change
