### PR TITLE
Destinations V2: handle optional fields for `object` and `array` types

### DIFF
--- a/airbyte-integrations/bases/base-typing-deduping/src/main/java/io/airbyte/integrations/base/destination/typing_deduping/AirbyteType.java
+++ b/airbyte-integrations/bases/base-typing-deduping/src/main/java/io/airbyte/integrations/base/destination/typing_deduping/AirbyteType.java
@@ -28,6 +28,9 @@ public sealed interface AirbyteType permits Array,OneOf,Struct,UnsupportedOneOf,
    * probably fail the sync. (but see also {@link OneOf#asColumns()}).
    */
   static AirbyteType fromJsonSchema(final JsonNode schema) {
+    if (schema == null) {
+      return AirbyteProtocolType.UNKNOWN;
+    }
     final JsonNode topLevelType = schema.get("type");
     if (topLevelType != null) {
       if (topLevelType.isTextual()) {

--- a/airbyte-integrations/bases/base-typing-deduping/src/main/java/io/airbyte/integrations/base/destination/typing_deduping/AirbyteType.java
+++ b/airbyte-integrations/bases/base-typing-deduping/src/main/java/io/airbyte/integrations/base/destination/typing_deduping/AirbyteType.java
@@ -80,11 +80,13 @@ public sealed interface AirbyteType permits Array,OneOf,Struct,UnsupportedOneOf,
   private static Struct getStruct(final JsonNode schema) {
     final LinkedHashMap<String, AirbyteType> propertiesMap = new LinkedHashMap<>();
     final JsonNode properties = schema.get("properties");
-    properties.fields().forEachRemaining(property -> {
-      final String key = property.getKey();
-      final JsonNode value = property.getValue();
-      propertiesMap.put(key, fromJsonSchema(value));
-    });
+    if (properties != null) {
+      properties.fields().forEachRemaining(property -> {
+        final String key = property.getKey();
+        final JsonNode value = property.getValue();
+        propertiesMap.put(key, fromJsonSchema(value));
+      });
+    }
     return new Struct(propertiesMap);
   }
 

--- a/airbyte-integrations/bases/base-typing-deduping/src/test/java/io/airbyte/integrations/base/destination/typing_deduping/AirbyteTypeTest.java
+++ b/airbyte-integrations/bases/base-typing-deduping/src/test/java/io/airbyte/integrations/base/destination/typing_deduping/AirbyteTypeTest.java
@@ -22,57 +22,160 @@ public class AirbyteTypeTest {
 
   @Test
   public void testStruct() {
-    final String structSchema = """
-                                {
-                                  "type": "object",
-                                  "properties": {
-                                    "key1": {
-                                      "type": "boolean"
-                                    },
-                                    "key2": {
-                                      "type": "integer"
-                                    },
-                                    "key3": {
-                                      "type": "number",
-                                      "airbyte_type": "integer"
-                                    },
-                                    "key4": {
-                                      "type": "number"
-                                    },
-                                    "key5": {
-                                      "type": "string",
-                                      "format": "date"
-                                    },
-                                    "key6": {
-                                      "type": "string",
-                                      "format": "time",
-                                      "airbyte_type": "timestamp_without_timezone"
-                                    },
-                                    "key7": {
-                                      "type": "string",
-                                      "format": "time",
-                                      "airbyte_type": "timestamp_with_timezone"
-                                    },
-                                    "key8": {
-                                      "type": "string",
-                                      "format": "date-time",
-                                      "airbyte_type": "timestamp_without_timezone"
-                                    },
-                                    "key9": {
-                                      "type": "string",
-                                      "format": ["date-time", "foo"],
-                                      "airbyte_type": "timestamp_with_timezone"
-                                    },
-                                    "key10": {
-                                      "type": "string",
-                                      "format": "date-time"
-                                    },
-                                    "key11": {
-                                      "type": "string"
-                                    }
-                                  }
-                                }
-                                """;
+    final List<String> structSchema = new ArrayList<>();
+    structSchema.add("""
+                     {
+                       "type": "object",
+                       "properties": {
+                         "key1": {
+                           "type": "boolean"
+                         },
+                         "key2": {
+                           "type": "integer"
+                         },
+                         "key3": {
+                           "type": "number",
+                           "airbyte_type": "integer"
+                         },
+                         "key4": {
+                           "type": "number"
+                         },
+                         "key5": {
+                           "type": "string",
+                           "format": "date"
+                         },
+                         "key6": {
+                           "type": "string",
+                           "format": "time",
+                           "airbyte_type": "timestamp_without_timezone"
+                         },
+                         "key7": {
+                           "type": "string",
+                           "format": "time",
+                           "airbyte_type": "timestamp_with_timezone"
+                         },
+                         "key8": {
+                           "type": "string",
+                           "format": "date-time",
+                           "airbyte_type": "timestamp_without_timezone"
+                         },
+                         "key9": {
+                           "type": "string",
+                           "format": ["date-time", "foo"],
+                           "airbyte_type": "timestamp_with_timezone"
+                         },
+                         "key10": {
+                           "type": "string",
+                           "format": "date-time"
+                         },
+                         "key11": {
+                           "type": "string"
+                         }
+                       }
+                     }
+                     """);
+    structSchema.add("""
+                     {
+                       "type": ["object"],
+                       "properties": {
+                         "key1": {
+                           "type": ["boolean"]
+                         },
+                         "key2": {
+                           "type": ["integer"]
+                         },
+                         "key3": {
+                           "type": ["number"],
+                           "airbyte_type": "integer"
+                         },
+                         "key4": {
+                           "type": ["number"]
+                         },
+                         "key5": {
+                           "type": ["string"],
+                           "format": "date"
+                         },
+                         "key6": {
+                           "type": ["string"],
+                           "format": "time",
+                           "airbyte_type": "timestamp_without_timezone"
+                         },
+                         "key7": {
+                           "type": ["string"],
+                           "format": "time",
+                           "airbyte_type": "timestamp_with_timezone"
+                         },
+                         "key8": {
+                           "type": ["string"],
+                           "format": "date-time",
+                           "airbyte_type": "timestamp_without_timezone"
+                         },
+                         "key9": {
+                           "type": ["string"],
+                           "format": ["date-time", "foo"],
+                           "airbyte_type": "timestamp_with_timezone"
+                         },
+                         "key10": {
+                           "type": ["string"],
+                           "format": "date-time"
+                         },
+                         "key11": {
+                           "type": ["string"]
+                         }
+                       }
+                     }
+                     """);
+    structSchema.add("""
+                     {
+                       "type": ["null", "object"],
+                       "properties": {
+                         "key1": {
+                           "type": ["null", "boolean"]
+                         },
+                         "key2": {
+                           "type": ["null", "integer"]
+                         },
+                         "key3": {
+                           "type": ["null", "number"],
+                           "airbyte_type": "integer"
+                         },
+                         "key4": {
+                           "type": ["null", "number"]
+                         },
+                         "key5": {
+                           "type": ["null", "string"],
+                           "format": "date"
+                         },
+                         "key6": {
+                           "type": ["null", "string"],
+                           "format": "time",
+                           "airbyte_type": "timestamp_without_timezone"
+                         },
+                         "key7": {
+                           "type": ["null", "string"],
+                           "format": "time",
+                           "airbyte_type": "timestamp_with_timezone"
+                         },
+                         "key8": {
+                           "type": ["null", "string"],
+                           "format": "date-time",
+                           "airbyte_type": "timestamp_without_timezone"
+                         },
+                         "key9": {
+                           "type": ["null", "string"],
+                           "format": ["date-time", "foo"],
+                           "airbyte_type": "timestamp_with_timezone"
+                         },
+                         "key10": {
+                           "type": ["null", "string"],
+                           "format": "date-time"
+                         },
+                         "key11": {
+                           "type": ["null", "string"]
+                         }
+                       }
+                     }
+                     """);
 
     final LinkedHashMap<String, AirbyteType> propertiesMap = new LinkedHashMap<>();
     propertiesMap.put("key1", AirbyteProtocolType.BOOLEAN);
@@ -88,185 +191,34 @@ public class AirbyteTypeTest {
     propertiesMap.put("key11", AirbyteProtocolType.STRING);
 
     final AirbyteType struct = new Struct(propertiesMap);
-    assertEquals(struct, AirbyteType.fromJsonSchema(Jsons.deserialize(structSchema)));
-  }
-
-  @Test
-  public void testStructSingletonListDecl() {
-    final String structSchema = """
-                                {
-                                  "type": ["object"],
-                                  "properties": {
-                                    "key1": {
-                                      "type": ["boolean"]
-                                    },
-                                    "key2": {
-                                      "type": ["integer"]
-                                    },
-                                    "key3": {
-                                      "type": ["number"],
-                                      "airbyte_type": "integer"
-                                    },
-                                    "key4": {
-                                      "type": ["number"]
-                                    },
-                                    "key5": {
-                                      "type": ["string"],
-                                      "format": "date"
-                                    },
-                                    "key6": {
-                                      "type": ["string"],
-                                      "format": "time",
-                                      "airbyte_type": "timestamp_without_timezone"
-                                    },
-                                    "key7": {
-                                      "type": ["string"],
-                                      "format": "time",
-                                      "airbyte_type": "timestamp_with_timezone"
-                                    },
-                                    "key8": {
-                                      "type": ["string"],
-                                      "format": "date-time",
-                                      "airbyte_type": "timestamp_without_timezone"
-                                    },
-                                    "key9": {
-                                      "type": ["string"],
-                                      "format": ["date-time", "foo"],
-                                      "airbyte_type": "timestamp_with_timezone"
-                                    },
-                                    "key10": {
-                                      "type": ["string"],
-                                      "format": "date-time"
-                                    },
-                                    "key11": {
-                                      "type": ["string"]
-                                    }
-                                  }
-                                }
-                                """;
-
-    final LinkedHashMap<String, AirbyteType> propertiesMap = new LinkedHashMap<>();
-    propertiesMap.put("key1", AirbyteProtocolType.BOOLEAN);
-    propertiesMap.put("key2", AirbyteProtocolType.INTEGER);
-    propertiesMap.put("key3", AirbyteProtocolType.INTEGER);
-    propertiesMap.put("key4", AirbyteProtocolType.NUMBER);
-    propertiesMap.put("key5", AirbyteProtocolType.DATE);
-    propertiesMap.put("key6", AirbyteProtocolType.TIME_WITHOUT_TIMEZONE);
-    propertiesMap.put("key7", AirbyteProtocolType.TIME_WITH_TIMEZONE);
-    propertiesMap.put("key8", AirbyteProtocolType.TIMESTAMP_WITHOUT_TIMEZONE);
-    propertiesMap.put("key9", AirbyteProtocolType.TIMESTAMP_WITH_TIMEZONE);
-    propertiesMap.put("key10", AirbyteProtocolType.TIMESTAMP_WITH_TIMEZONE);
-    propertiesMap.put("key11", AirbyteProtocolType.STRING);
-
-    final AirbyteType struct = new Struct(propertiesMap);
-    assertEquals(struct, AirbyteType.fromJsonSchema(Jsons.deserialize(structSchema)));
-  }
-
-  @Test
-  public void testStructNullableSingletonListDecl() {
-    final String structSchema = """
-                                {
-                                  "type": ["null", "object"],
-                                  "properties": {
-                                    "key1": {
-                                      "type": ["null", "boolean"]
-                                    },
-                                    "key2": {
-                                      "type": ["null", "integer"]
-                                    },
-                                    "key3": {
-                                      "type": ["null", "number"],
-                                      "airbyte_type": "integer"
-                                    },
-                                    "key4": {
-                                      "type": ["null", "number"]
-                                    },
-                                    "key5": {
-                                      "type": ["null", "string"],
-                                      "format": "date"
-                                    },
-                                    "key6": {
-                                      "type": ["null", "string"],
-                                      "format": "time",
-                                      "airbyte_type": "timestamp_without_timezone"
-                                    },
-                                    "key7": {
-                                      "type": ["null", "string"],
-                                      "format": "time",
-                                      "airbyte_type": "timestamp_with_timezone"
-                                    },
-                                    "key8": {
-                                      "type": ["null", "string"],
-                                      "format": "date-time",
-                                      "airbyte_type": "timestamp_without_timezone"
-                                    },
-                                    "key9": {
-                                      "type": ["null", "string"],
-                                      "format": ["date-time", "foo"],
-                                      "airbyte_type": "timestamp_with_timezone"
-                                    },
-                                    "key10": {
-                                      "type": ["null", "string"],
-                                      "format": "date-time"
-                                    },
-                                    "key11": {
-                                      "type": ["null", "string"]
-                                    }
-                                  }
-                                }
-                                """;
-
-    final LinkedHashMap<String, AirbyteType> propertiesMap = new LinkedHashMap<>();
-    propertiesMap.put("key1", AirbyteProtocolType.BOOLEAN);
-    propertiesMap.put("key2", AirbyteProtocolType.INTEGER);
-    propertiesMap.put("key3", AirbyteProtocolType.INTEGER);
-    propertiesMap.put("key4", AirbyteProtocolType.NUMBER);
-    propertiesMap.put("key5", AirbyteProtocolType.DATE);
-    propertiesMap.put("key6", AirbyteProtocolType.TIME_WITHOUT_TIMEZONE);
-    propertiesMap.put("key7", AirbyteProtocolType.TIME_WITH_TIMEZONE);
-    propertiesMap.put("key8", AirbyteProtocolType.TIMESTAMP_WITHOUT_TIMEZONE);
-    propertiesMap.put("key9", AirbyteProtocolType.TIMESTAMP_WITH_TIMEZONE);
-    propertiesMap.put("key10", AirbyteProtocolType.TIMESTAMP_WITH_TIMEZONE);
-    propertiesMap.put("key11", AirbyteProtocolType.STRING);
-
-    final AirbyteType struct = new Struct(propertiesMap);
-    assertEquals(struct, AirbyteType.fromJsonSchema(Jsons.deserialize(structSchema)));
+    for (final String schema : structSchema) {
+      assertEquals(struct, AirbyteType.fromJsonSchema(Jsons.deserialize(schema)));
+    }
   }
 
   @Test
   public void testEmptyStruct() {
-    final String structSchema = """
-                               {
-                                 "type": "object"
-                               }
-                               """;
+    final List<String> structSchema = new ArrayList<>();
+    structSchema.add("""
+                     {
+                       "type": "object"
+                     }
+                     """);
+    structSchema.add("""
+                     {
+                       "type": ["object"]
+                     }
+                     """);
+    structSchema.add("""
+                     {
+                       "type": ["null", "object"]
+                     }
+                     """);
 
     final AirbyteType struct = new Struct(new LinkedHashMap<>());
-    assertEquals(struct, AirbyteType.fromJsonSchema(Jsons.deserialize(structSchema)));
-  }
-
-  @Test
-  public void testEmptyStructSingletonListDecl() {
-    final String structSchema = """
-                               {
-                                 "type": ["object"]
-                               }
-                               """;
-
-    final AirbyteType struct = new Struct(new LinkedHashMap<>());
-    assertEquals(struct, AirbyteType.fromJsonSchema(Jsons.deserialize(structSchema)));
-  }
-
-  @Test
-  public void testEmptyStructNullableSingletonListDecl() {
-    final String structSchema = """
-                               {
-                                 "type": ["null", "object"]
-                               }
-                               """;
-
-    final AirbyteType struct = new Struct(new LinkedHashMap<>());
-    assertEquals(struct, AirbyteType.fromJsonSchema(Jsons.deserialize(structSchema)));
+    for (final String schema : structSchema) {
+      assertEquals(struct, AirbyteType.fromJsonSchema(Jsons.deserialize(schema)));
+    }
   }
 
   @Test
@@ -290,89 +242,69 @@ public class AirbyteTypeTest {
 
   @Test
   public void testArray() {
-    final String arraySchema = """
-                               {
-                                 "type": "array",
-                                 "items": {
-                                   "type": "string",
-                                   "format": "date-time",
-                                   "airbyte_type": "timestamp_with_timezone"
-                                 }
-                               }
-                               """;
+    final List<String> arraySchema = new ArrayList<>();
+    arraySchema.add("""
+                    {
+                      "type": "array",
+                      "items": {
+                        "type": "string",
+                        "format": "date-time",
+                        "airbyte_type": "timestamp_with_timezone"
+                      }
+                    }
+                    """);
+    arraySchema.add("""
+                    {
+                      "type": ["array"],
+                      "items": {
+                        "type": ["string"],
+                        "format": "date-time",
+                        "airbyte_type": "timestamp_with_timezone"
+                      }
+                    }
+                    """);
+    arraySchema.add("""
+                    {
+                      "type": ["null", "array"],
+                      "items": {
+                        "type": ["null", "string"],
+                        "format": "date-time",
+                        "airbyte_type": "timestamp_with_timezone"
+                      }
+                    }
+                    """);
 
     final AirbyteType array = new Array(AirbyteProtocolType.TIMESTAMP_WITH_TIMEZONE);
-    assertEquals(array, AirbyteType.fromJsonSchema(Jsons.deserialize(arraySchema)));
-  }
-
-  @Test
-  public void testArraySingletonListDecl() {
-    final String arraySchema = """
-                               {
-                                 "type": ["array"],
-                                 "items": {
-                                   "type": ["string"],
-                                   "format": "date-time",
-                                   "airbyte_type": "timestamp_with_timezone"
-                                 }
-                               }
-                               """;
-
-    final AirbyteType array = new Array(AirbyteProtocolType.TIMESTAMP_WITH_TIMEZONE);
-    assertEquals(array, AirbyteType.fromJsonSchema(Jsons.deserialize(arraySchema)));
-  }
-
-  @Test
-  public void testArrayNullableSingletonListDecl() {
-    final String arraySchema = """
-                               {
-                                 "type": ["null", "array"],
-                                 "items": {
-                                   "type": ["null", "string"],
-                                   "format": "date-time",
-                                   "airbyte_type": "timestamp_with_timezone"
-                                 }
-                               }
-                               """;
-
-    final AirbyteType array = new Array(AirbyteProtocolType.TIMESTAMP_WITH_TIMEZONE);
-    assertEquals(array, AirbyteType.fromJsonSchema(Jsons.deserialize(arraySchema)));
+    for (final String schema : arraySchema) {
+      assertEquals(array, AirbyteType.fromJsonSchema(Jsons.deserialize(schema)));
+    }
   }
 
   @Test
   public void testEmptyArray() {
-    final String arraySchema = """
-                               {
-                                 "type": "array"
-                               }
-                               """;
+    final List<String> arraySchema = new ArrayList<>();
+    arraySchema.add("""
+                    {
+                      "type": "array"
+                    }
+                    """);
+    arraySchema.add("""
+                    {
+                      "type": ["array"]
+                    }
+                    """);
+
+    arraySchema.add("""
+                    {
+                      "type": ["null", "array"]
+                    }
+                    """);
+
 
     final AirbyteType array = new Array(AirbyteProtocolType.UNKNOWN);
-    assertEquals(array, AirbyteType.fromJsonSchema(Jsons.deserialize(arraySchema)));
-  }
-
-  @Test
-  public void testEmptyArraySingletonListDecl() {
-    final String arraySchema = """
-                               {
-                                 "type": ["array"]
-                               }
-                               """;
-
-    final AirbyteType array = new Array(AirbyteProtocolType.UNKNOWN);
-    assertEquals(array, AirbyteType.fromJsonSchema(Jsons.deserialize(arraySchema)));
-  }
-
-  @Test
-  public void testEmptyArrayNullableSingletonListDecl() {
-    final String arraySchema = """
-                               {
-                                 "type": ["null", "array"]
-                               }
-                               """;
-
-    final AirbyteType array = new Array(AirbyteProtocolType.UNKNOWN);
-    assertEquals(array, AirbyteType.fromJsonSchema(Jsons.deserialize(arraySchema)));
+    for (final String schema : arraySchema) {
+      assertEquals(array, AirbyteType.fromJsonSchema(Jsons.deserialize(schema)));
+    }
   }
 
   @Test
@@ -409,12 +341,6 @@ public class AirbyteTypeTest {
   }
 
   @Test
-  public void testEmpty() {
-    final String emptySchema = "{}";
-    assertEquals(AirbyteProtocolType.UNKNOWN, AirbyteType.fromJsonSchema(Jsons.deserialize(emptySchema)));
-  }
-
-  @Test
   public void testInvalidTextualType() {
     final String invalidTypeSchema = """
                                      {
@@ -432,6 +358,22 @@ public class AirbyteTypeTest {
                                      }
                                      """;
     assertEquals(AirbyteProtocolType.UNKNOWN, AirbyteType.fromJsonSchema(Jsons.deserialize(invalidTypeSchema)));
+  }
+
+  @Test
+  public void testInvalid() {
+    final List<String> invalidSchema = new ArrayList<>();
+    invalidSchema.add("null");
+    invalidSchema.add("true");
+    invalidSchema.add("false");
+    invalidSchema.add("1");
+    invalidSchema.add("\"\"");
+    invalidSchema.add("[]");
+    invalidSchema.add("{}");
+
+    for (final String schema : invalidSchema) {
+      assertEquals(AirbyteProtocolType.UNKNOWN, AirbyteType.fromJsonSchema(Jsons.deserialize(schema)));
+    }
   }
 
   @Test

--- a/airbyte-integrations/bases/base-typing-deduping/src/test/java/io/airbyte/integrations/base/destination/typing_deduping/AirbyteTypeTest.java
+++ b/airbyte-integrations/bases/base-typing-deduping/src/test/java/io/airbyte/integrations/base/destination/typing_deduping/AirbyteTypeTest.java
@@ -234,6 +234,42 @@ public class AirbyteTypeTest {
   }
 
   @Test
+  public void testEmptyStruct() {
+    final String structSchema = """
+                               {
+                                 "type": "object"
+                               }
+                               """;
+
+    final AirbyteType struct = new Struct(new LinkedHashMap<>());
+    assertEquals(struct, AirbyteType.fromJsonSchema(Jsons.deserialize(structSchema)));
+  }
+
+  @Test
+  public void testEmptyStructSingletonListDecl() {
+    final String structSchema = """
+                               {
+                                 "type": ["object"]
+                               }
+                               """;
+
+    final AirbyteType struct = new Struct(new LinkedHashMap<>());
+    assertEquals(struct, AirbyteType.fromJsonSchema(Jsons.deserialize(structSchema)));
+  }
+
+  @Test
+  public void testEmptyStructNullableSingletonListDecl() {
+    final String structSchema = """
+                               {
+                                 "type": ["null", "object"]
+                               }
+                               """;
+
+    final AirbyteType struct = new Struct(new LinkedHashMap<>());
+    assertEquals(struct, AirbyteType.fromJsonSchema(Jsons.deserialize(structSchema)));
+  }
+
+  @Test
   public void testImplicitStruct() {
     final String structSchema = """
                                 {
@@ -300,6 +336,42 @@ public class AirbyteTypeTest {
                                """;
 
     final AirbyteType array = new Array(AirbyteProtocolType.TIMESTAMP_WITH_TIMEZONE);
+    assertEquals(array, AirbyteType.fromJsonSchema(Jsons.deserialize(arraySchema)));
+  }
+
+  @Test
+  public void testEmptyArray() {
+    final String arraySchema = """
+                               {
+                                 "type": "array"
+                               }
+                               """;
+
+    final AirbyteType array = new Array(AirbyteProtocolType.UNKNOWN);
+    assertEquals(array, AirbyteType.fromJsonSchema(Jsons.deserialize(arraySchema)));
+  }
+
+  @Test
+  public void testEmptyArraySingletonListDecl() {
+    final String arraySchema = """
+                               {
+                                 "type": ["array"]
+                               }
+                               """;
+
+    final AirbyteType array = new Array(AirbyteProtocolType.UNKNOWN);
+    assertEquals(array, AirbyteType.fromJsonSchema(Jsons.deserialize(arraySchema)));
+  }
+
+  @Test
+  public void testEmptyArrayNullableSingletonListDecl() {
+    final String arraySchema = """
+                               {
+                                 "type": ["null", "array"]
+                               }
+                               """;
+
+    final AirbyteType array = new Array(AirbyteProtocolType.UNKNOWN);
     assertEquals(array, AirbyteType.fromJsonSchema(Jsons.deserialize(arraySchema)));
   }
 

--- a/airbyte-integrations/bases/base-typing-deduping/src/test/java/io/airbyte/integrations/base/destination/typing_deduping/AirbyteTypeTest.java
+++ b/airbyte-integrations/bases/base-typing-deduping/src/test/java/io/airbyte/integrations/base/destination/typing_deduping/AirbyteTypeTest.java
@@ -363,6 +363,7 @@ public class AirbyteTypeTest {
   @Test
   public void testInvalid() {
     final List<String> invalidSchema = new ArrayList<>();
+    invalidSchema.add("");
     invalidSchema.add("null");
     invalidSchema.add("true");
     invalidSchema.add("false");


### PR DESCRIPTION
closes #27877 

The `items` field is optional for `array` types, and similarly the `properties` field is optional for `object` types. Fix the Destinations V2 type parsing logic to allow for these cases.

Tested against all json schema referenced out of #27877.