### PR TITLE
Stream state is not recorded if cursor field is result of transformation

### DIFF
--- a/airbyte-cdk/python/airbyte_cdk/sources/declarative/declarative_component_schema.yaml
+++ b/airbyte-cdk/python/airbyte_cdk/sources/declarative/declarative_component_schema.yaml
@@ -868,6 +868,8 @@ definitions:
         anyOf:
           - "$ref": "#/definitions/InlineSchemaLoader"
           - "$ref": "#/definitions/JsonFileSchemaLoader"
+      # TODO we have move the transformation to the RecordSelector level in the code but kept this here for
+      # compatibility reason. We should eventually move this to align with the code.
       transformations:
         title: Transformations
         description: A list of transformations to be applied to each output record.

--- a/airbyte-cdk/python/airbyte_cdk/sources/declarative/declarative_stream.py
+++ b/airbyte-cdk/python/airbyte_cdk/sources/declarative/declarative_stream.py
@@ -5,13 +5,13 @@
 from dataclasses import InitVar, dataclass, field
 from typing import Any, Iterable, List, Mapping, MutableMapping, Optional, Union
 
-from airbyte_cdk.models import AirbyteMessage, SyncMode
+from airbyte_cdk.models import SyncMode
 from airbyte_cdk.sources.declarative.interpolation import InterpolatedString
 from airbyte_cdk.sources.declarative.retrievers.retriever import Retriever
 from airbyte_cdk.sources.declarative.schema import DefaultSchemaLoader
 from airbyte_cdk.sources.declarative.schema.schema_loader import SchemaLoader
-from airbyte_cdk.sources.declarative.types import Config, Record, StreamSlice
-from airbyte_cdk.sources.streams.core import Stream, StreamData
+from airbyte_cdk.sources.declarative.types import Config
+from airbyte_cdk.sources.streams.core import Stream
 
 
 @dataclass

--- a/airbyte-cdk/python/airbyte_cdk/sources/declarative/declarative_stream.py
+++ b/airbyte-cdk/python/airbyte_cdk/sources/declarative/declarative_stream.py
@@ -10,7 +10,6 @@ from airbyte_cdk.sources.declarative.interpolation import InterpolatedString
 from airbyte_cdk.sources.declarative.retrievers.retriever import Retriever
 from airbyte_cdk.sources.declarative.schema import DefaultSchemaLoader
 from airbyte_cdk.sources.declarative.schema.schema_loader import SchemaLoader
-from airbyte_cdk.sources.declarative.transformations import RecordTransformation
 from airbyte_cdk.sources.declarative.types import Config, Record, StreamSlice
 from airbyte_cdk.sources.streams.core import Stream, StreamData
 
@@ -27,7 +26,6 @@ class DeclarativeStream(Stream):
         retriever (Retriever): The retriever
         config (Config): The user-provided configuration as specified by the source's spec
         stream_cursor_field (Optional[Union[InterpolatedString, str]]): The cursor field
-        transformations (List[RecordTransformation]): A list of transformations to be applied to each output record in the
         stream. Transformations are applied in the order in which they are defined.
     """
 
@@ -41,11 +39,9 @@ class DeclarativeStream(Stream):
     _primary_key: str = field(init=False, repr=False, default="")
     _schema_loader: SchemaLoader = field(init=False, repr=False, default=None)
     stream_cursor_field: Optional[Union[InterpolatedString, str]] = None
-    transformations: List[RecordTransformation] = None
 
     def __post_init__(self, parameters: Mapping[str, Any]):
         self.stream_cursor_field = InterpolatedString.create(self.stream_cursor_field, parameters=parameters)
-        self.transformations = self.transformations or []
         self._schema_loader = self.schema_loader if self.schema_loader else DefaultSchemaLoader(config=self.config, parameters=parameters)
 
     @property
@@ -100,36 +96,7 @@ class DeclarativeStream(Stream):
         """
         :param: stream_state We knowingly avoid using stream_state as we want cursors to manage their own state.
         """
-        for record in self.retriever.read_records(sync_mode, cursor_field, stream_slice):
-            yield self._apply_transformations(record, self.config, stream_slice)
-
-    def _apply_transformations(
-        self,
-        message_or_record_data: StreamData,
-        config: Config,
-        stream_slice: StreamSlice,
-    ):
-        # If the input is an AirbyteMessage with a record, transform the record's data
-        # If the input is another type of AirbyteMessage, return it as is
-        # If the input is a dict, transform it
-        if isinstance(message_or_record_data, AirbyteMessage):
-            if message_or_record_data.record:
-                record = message_or_record_data.record.data
-            else:
-                return message_or_record_data
-        elif isinstance(message_or_record_data, dict):
-            record = message_or_record_data
-        elif isinstance(message_or_record_data, Record):
-            record = message_or_record_data.data
-        else:
-            # Raise an error because this is unexpected and indicative of a typing problem in the CDK
-            raise ValueError(
-                f"Unexpected record type. Expected {StreamData}. Got {type(message_or_record_data)}. This is probably due to a bug in the CDK."
-            )
-        for transformation in self.transformations:
-            transformation.transform(record, config=config, stream_state=self.state, stream_slice=stream_slice)
-
-        return message_or_record_data
+        yield from self.retriever.read_records(sync_mode, cursor_field, stream_slice)
 
     def get_json_schema(self) -> Mapping[str, Any]:
         """

--- a/airbyte-cdk/python/airbyte_cdk/sources/declarative/extractors/dpath_extractor.py
+++ b/airbyte-cdk/python/airbyte_cdk/sources/declarative/extractors/dpath_extractor.py
@@ -63,7 +63,7 @@ class DpathExtractor(RecordExtractor):
             if isinstance(self.field_path[path_index], str):
                 self.field_path[path_index] = InterpolatedString.create(self.field_path[path_index], parameters=parameters)
 
-    def extract_records(self, response: requests.Response) -> List[Record]:
+    def extract_records(self, response: requests.Response) -> List[Mapping[str, Any]]:
         response_body = self.decoder.decode(response)
         if len(self.field_path) == 0:
             extracted = response_body

--- a/airbyte-cdk/python/airbyte_cdk/sources/declarative/extractors/dpath_extractor.py
+++ b/airbyte-cdk/python/airbyte_cdk/sources/declarative/extractors/dpath_extractor.py
@@ -11,7 +11,7 @@ from airbyte_cdk.sources.declarative.decoders.decoder import Decoder
 from airbyte_cdk.sources.declarative.decoders.json_decoder import JsonDecoder
 from airbyte_cdk.sources.declarative.extractors.record_extractor import RecordExtractor
 from airbyte_cdk.sources.declarative.interpolation.interpolated_string import InterpolatedString
-from airbyte_cdk.sources.declarative.types import Config, Record
+from airbyte_cdk.sources.declarative.types import Config
 
 
 @dataclass

--- a/airbyte-cdk/python/airbyte_cdk/sources/declarative/extractors/record_selector.py
+++ b/airbyte-cdk/python/airbyte_cdk/sources/declarative/extractors/record_selector.py
@@ -2,14 +2,15 @@
 # Copyright (c) 2023 Airbyte, Inc., all rights reserved.
 #
 
-from dataclasses import InitVar, dataclass
+from dataclasses import InitVar, dataclass, field
 from typing import Any, List, Mapping, Optional
 
 import requests
 from airbyte_cdk.sources.declarative.extractors.http_selector import HttpSelector
 from airbyte_cdk.sources.declarative.extractors.record_extractor import RecordExtractor
 from airbyte_cdk.sources.declarative.extractors.record_filter import RecordFilter
-from airbyte_cdk.sources.declarative.types import Record, StreamSlice, StreamState
+from airbyte_cdk.sources.declarative.transformations import RecordTransformation
+from airbyte_cdk.sources.declarative.types import Config, Record, StreamSlice, StreamState
 
 
 @dataclass
@@ -21,11 +22,14 @@ class RecordSelector(HttpSelector):
     Attributes:
         extractor (RecordExtractor): The record extractor responsible for extracting records from a response
         record_filter (RecordFilter): The record filter responsible for filtering extracted records
+        transformations (List[RecordTransformation]): The transformations to be done on the records
     """
 
     extractor: RecordExtractor
+    config: Config
     parameters: InitVar[Mapping[str, Any]]
     record_filter: RecordFilter = None
+    transformations: List[RecordTransformation] = field(default_factory=lambda: [])
 
     def __post_init__(self, parameters: Mapping[str, Any]):
         self._parameters = parameters
@@ -38,8 +42,29 @@ class RecordSelector(HttpSelector):
         next_page_token: Optional[Mapping[str, Any]] = None,
     ) -> List[Record]:
         all_records = [Record(data, stream_slice) for data in self.extractor.extract_records(response)]
+        filtered_records = self._filter(all_records, stream_state, stream_slice, next_page_token)
+        self._transform(filtered_records, stream_state, stream_slice)
+        return filtered_records
+
+    def _filter(
+        self,
+        records: List[Mapping[str, Any]],
+        stream_state: StreamState,
+        stream_slice: Optional[StreamSlice],
+        next_page_token: Optional[Mapping[str, Any]],
+    ) -> List[Mapping[str, Any]]:
         if self.record_filter:
             return self.record_filter.filter_records(
-                all_records, stream_state=stream_state, stream_slice=stream_slice, next_page_token=next_page_token
+                records, stream_state=stream_state, stream_slice=stream_slice, next_page_token=next_page_token
             )
-        return all_records
+        return records
+
+    def _transform(
+        self,
+        records: List[Mapping[str, Any]],
+        stream_state: StreamState,
+        stream_slice: Optional[StreamSlice] = None,
+    ) -> None:
+        for record in records:
+            for transformation in self.transformations:
+                transformation.transform(record, config=self.config, stream_state=stream_state, stream_slice=stream_slice)

--- a/airbyte-cdk/python/airbyte_cdk/sources/declarative/parsers/model_to_component_factory.py
+++ b/airbyte-cdk/python/airbyte_cdk/sources/declarative/parsers/model_to_component_factory.py
@@ -488,7 +488,7 @@ class ModelToComponentFactory:
             primary_key=primary_key,
             stream_slicer=combined_slicers,
             stop_condition_on_cursor=stop_condition_on_cursor,
-            transformations=transformations
+            transformations=transformations,
         )
         cursor_field = model.incremental_sync.cursor_field if model.incremental_sync else None
 
@@ -768,11 +768,15 @@ class ModelToComponentFactory:
         inject_into = RequestOptionType(model.inject_into.value)
         return RequestOption(field_name=model.field_name, inject_into=inject_into, parameters={})
 
-    def create_record_selector(self, model: RecordSelectorModel, config: Config, *, transformations: List[RecordTransformation], **kwargs) -> RecordSelector:
+    def create_record_selector(
+        self, model: RecordSelectorModel, config: Config, *, transformations: List[RecordTransformation], **kwargs
+    ) -> RecordSelector:
         extractor = self._create_component_from_model(model=model.extractor, config=config)
         record_filter = self._create_component_from_model(model.record_filter, config=config) if model.record_filter else None
 
-        return RecordSelector(extractor=extractor, config=config, record_filter=record_filter, transformations=transformations, parameters=model.parameters)
+        return RecordSelector(
+            extractor=extractor, config=config, record_filter=record_filter, transformations=transformations, parameters=model.parameters
+        )
 
     @staticmethod
     def create_remove_fields(model: RemoveFieldsModel, config: Config, **kwargs) -> RemoveFields:

--- a/airbyte-cdk/python/airbyte_cdk/sources/declarative/parsers/model_to_component_factory.py
+++ b/airbyte-cdk/python/airbyte_cdk/sources/declarative/parsers/model_to_component_factory.py
@@ -103,7 +103,7 @@ from airbyte_cdk.sources.declarative.retrievers import SimpleRetriever, SimpleRe
 from airbyte_cdk.sources.declarative.schema import DefaultSchemaLoader, InlineSchemaLoader, JsonFileSchemaLoader
 from airbyte_cdk.sources.declarative.spec import Spec
 from airbyte_cdk.sources.declarative.stream_slicers import CartesianProductStreamSlicer, StreamSlicer
-from airbyte_cdk.sources.declarative.transformations import AddFields, RemoveFields
+from airbyte_cdk.sources.declarative.transformations import AddFields, RecordTransformation, RemoveFields
 from airbyte_cdk.sources.declarative.transformations.add_fields import AddedFieldDefinition
 from airbyte_cdk.sources.declarative.types import Config
 from airbyte_cdk.sources.message import InMemoryMessageRepository
@@ -477,6 +477,10 @@ class ModelToComponentFactory:
         stop_condition_on_cursor = (
             model.incremental_sync and hasattr(model.incremental_sync, "is_data_feed") and model.incremental_sync.is_data_feed
         )
+        transformations = []
+        if model.transformations:
+            for transformation_model in model.transformations:
+                transformations.append(self._create_component_from_model(model=transformation_model, config=config))
         retriever = self._create_component_from_model(
             model=model.retriever,
             config=config,
@@ -484,8 +488,8 @@ class ModelToComponentFactory:
             primary_key=primary_key,
             stream_slicer=combined_slicers,
             stop_condition_on_cursor=stop_condition_on_cursor,
+            transformations=transformations
         )
-
         cursor_field = model.incremental_sync.cursor_field if model.incremental_sync else None
 
         if model.schema_loader:
@@ -496,17 +500,12 @@ class ModelToComponentFactory:
                 options["name"] = model.name
             schema_loader = DefaultSchemaLoader(config=config, parameters=options)
 
-        transformations = []
-        if model.transformations:
-            for transformation_model in model.transformations:
-                transformations.append(self._create_component_from_model(model=transformation_model, config=config))
         return DeclarativeStream(
             name=model.name,
             primary_key=primary_key,
             retriever=retriever,
             schema_loader=schema_loader,
             stream_cursor_field=cursor_field or "",
-            transformations=transformations,
             config=config,
             parameters=model.parameters,
         )
@@ -769,11 +768,11 @@ class ModelToComponentFactory:
         inject_into = RequestOptionType(model.inject_into.value)
         return RequestOption(field_name=model.field_name, inject_into=inject_into, parameters={})
 
-    def create_record_selector(self, model: RecordSelectorModel, config: Config, **kwargs) -> RecordSelector:
+    def create_record_selector(self, model: RecordSelectorModel, config: Config, *, transformations: List[RecordTransformation], **kwargs) -> RecordSelector:
         extractor = self._create_component_from_model(model=model.extractor, config=config)
         record_filter = self._create_component_from_model(model.record_filter, config=config) if model.record_filter else None
 
-        return RecordSelector(extractor=extractor, record_filter=record_filter, parameters=model.parameters)
+        return RecordSelector(extractor=extractor, config=config, record_filter=record_filter, transformations=transformations, parameters=model.parameters)
 
     @staticmethod
     def create_remove_fields(model: RemoveFieldsModel, config: Config, **kwargs) -> RemoveFields:
@@ -805,9 +804,10 @@ class ModelToComponentFactory:
         primary_key: Optional[Union[str, List[str], List[List[str]]]],
         stream_slicer: Optional[StreamSlicer],
         stop_condition_on_cursor: bool = False,
+        transformations: List[RecordTransformation],
     ) -> SimpleRetriever:
         requester = self._create_component_from_model(model=model.requester, config=config, name=name)
-        record_selector = self._create_component_from_model(model=model.record_selector, config=config)
+        record_selector = self._create_component_from_model(model=model.record_selector, config=config, transformations=transformations)
         url_base = model.requester.url_base if hasattr(model.requester, "url_base") else requester.get_url_base()
         stream_slicer = stream_slicer or SinglePartitionRouter(parameters={})
         cursor = stream_slicer if isinstance(stream_slicer, Cursor) else None

--- a/airbyte-cdk/python/airbyte_cdk/sources/declarative/retrievers/simple_retriever.py
+++ b/airbyte-cdk/python/airbyte_cdk/sources/declarative/retrievers/simple_retriever.py
@@ -418,16 +418,14 @@ class SimpleRetriever(Retriever, HttpStream):
             self.cursor.close_slice(stream_slice, most_recent_record_from_slice)
         return
 
-    def _get_most_recent_record(self, current_most_recent: Optional[Record], stream_data: StreamData, stream_slice: StreamSlice) -> Optional[Record]:
+    def _get_most_recent_record(
+        self, current_most_recent: Optional[Record], stream_data: StreamData, stream_slice: StreamSlice
+    ) -> Optional[Record]:
         if self.cursor and (record := self._extract_record(stream_data, stream_slice)):
             if not current_most_recent:
                 return record
             else:
-                return (
-                    current_most_recent
-                    if self.cursor.is_greater_than_or_equal(current_most_recent, record)
-                    else record
-                )
+                return current_most_recent if self.cursor.is_greater_than_or_equal(current_most_recent, record) else record
         else:
             return None
 

--- a/airbyte-cdk/python/airbyte_cdk/sources/declarative/retrievers/simple_retriever.py
+++ b/airbyte-cdk/python/airbyte_cdk/sources/declarative/retrievers/simple_retriever.py
@@ -410,21 +410,40 @@ class SimpleRetriever(Retriever, HttpStream):
             slice_state = {}
 
         most_recent_record_from_slice = None
-        for record in self._read_pages(self.parse_records, stream_slice, slice_state):
-            if self.cursor:
-                if not most_recent_record_from_slice:
-                    most_recent_record_from_slice = record
-                else:
-                    most_recent_record_from_slice = (
-                        most_recent_record_from_slice
-                        if self.cursor.is_greater_than_or_equal(most_recent_record_from_slice, record)
-                        else record
-                    )
-            yield record
+        for stream_data in self._read_pages(self.parse_records, stream_slice, slice_state):
+            most_recent_record_from_slice = self._get_most_recent_record(most_recent_record_from_slice, stream_data, stream_slice)
+            yield stream_data
 
         if self.cursor:
             self.cursor.close_slice(stream_slice, most_recent_record_from_slice)
         return
+
+    def _get_most_recent_record(self, current_most_recent: Optional[Record], stream_data: StreamData, stream_slice: StreamSlice) -> Optional[Record]:
+        if self.cursor and (record := self._extract_record(stream_data, stream_slice)):
+            if not current_most_recent:
+                return record
+            else:
+                return (
+                    current_most_recent
+                    if self.cursor.is_greater_than_or_equal(current_most_recent, record)
+                    else record
+                )
+        else:
+            return None
+
+    @staticmethod
+    def _extract_record(stream_data: StreamData, stream_slice: StreamSlice) -> Optional[Record]:
+        """
+        As we allow the output of _read_pages to be StreamData, it can be multiple things. Therefore, we need to filter out and normalize
+        to data to streamline the rest of the process.
+        """
+        if isinstance(stream_data, Record):
+            # Record is not part of `StreamData` but is the most common implementation of `Mapping[str, Any]` which is part of `StreamData`
+            return stream_data
+        elif isinstance(stream_data, (dict, Mapping)):
+            return Record(dict(stream_data), stream_slice)
+        elif isinstance(stream_data, AirbyteMessage) and stream_data.record:
+            return Record(stream_data.record.data, stream_slice)
 
     def stream_slices(self) -> Iterable[Optional[Mapping[str, Any]]]:
         """

--- a/airbyte-cdk/python/unit_tests/sources/declarative/extractors/test_record_selector.py
+++ b/airbyte-cdk/python/unit_tests/sources/declarative/extractors/test_record_selector.py
@@ -6,10 +6,12 @@ import json
 
 import pytest
 import requests
+from unittest.mock import call, Mock
 from airbyte_cdk.sources.declarative.decoders.json_decoder import JsonDecoder
 from airbyte_cdk.sources.declarative.extractors.dpath_extractor import DpathExtractor
 from airbyte_cdk.sources.declarative.extractors.record_filter import RecordFilter
 from airbyte_cdk.sources.declarative.extractors.record_selector import RecordSelector
+from airbyte_cdk.sources.declarative.transformations import RecordTransformation
 from airbyte_cdk.sources.declarative.types import Record
 
 
@@ -66,6 +68,9 @@ def test_record_filter(test_name, field_path, filter_template, body, expected_da
     stream_state = {"created_at": "06-06-21"}
     stream_slice = {"last_seen": "06-10-21"}
     next_page_token = {"last_seen_id": 14}
+    first_transformation = Mock(spec=RecordTransformation)
+    second_transformation = Mock(spec=RecordTransformation)
+    transformations = [first_transformation, second_transformation]
 
     response = create_response(body)
     decoder = JsonDecoder(parameters={})
@@ -74,12 +79,24 @@ def test_record_filter(test_name, field_path, filter_template, body, expected_da
         record_filter = None
     else:
         record_filter = RecordFilter(config=config, condition=filter_template, parameters=parameters)
-    record_selector = RecordSelector(extractor=extractor, record_filter=record_filter, parameters=parameters)
+    record_selector = RecordSelector(
+        extractor=extractor,
+        record_filter=record_filter,
+        transformations=transformations,
+        config=config,
+        parameters=parameters
+    )
 
     actual_records = record_selector.select_records(
         response=response, stream_state=stream_state, stream_slice=stream_slice, next_page_token=next_page_token
     )
     assert actual_records == [Record(data, stream_slice) for data in expected_data]
+    calls = []
+    for record in expected_data:
+        calls.append(call(record, config=config, stream_state=stream_state, stream_slice=stream_slice))
+    for transformation in transformations:
+        assert transformation.transform.call_count == len(expected_data)
+        transformation.transform.assert_has_calls(calls)
 
 
 def create_response(body):

--- a/airbyte-cdk/python/unit_tests/sources/declarative/extractors/test_record_selector.py
+++ b/airbyte-cdk/python/unit_tests/sources/declarative/extractors/test_record_selector.py
@@ -3,10 +3,10 @@
 #
 
 import json
+from unittest.mock import Mock, call
 
 import pytest
 import requests
-from unittest.mock import call, Mock
 from airbyte_cdk.sources.declarative.decoders.json_decoder import JsonDecoder
 from airbyte_cdk.sources.declarative.extractors.dpath_extractor import DpathExtractor
 from airbyte_cdk.sources.declarative.extractors.record_filter import RecordFilter

--- a/airbyte-cdk/python/unit_tests/sources/declarative/parsers/test_model_to_component_factory.py
+++ b/airbyte-cdk/python/unit_tests/sources/declarative/parsers/test_model_to_component_factory.py
@@ -199,8 +199,8 @@ spec:
     assert isinstance(stream.schema_loader, JsonFileSchemaLoader)
     assert stream.schema_loader._get_json_filepath() == "./source_sendgrid/schemas/lists.json"
 
-    assert len(stream.transformations) == 1
-    add_fields = stream.transformations[0]
+    assert len(stream.retriever.record_selector.transformations) == 1
+    add_fields = stream.retriever.record_selector.transformations[0]
     assert isinstance(add_fields, AddFields)
     assert add_fields.fields[0].path == ["extra"]
     assert add_fields.fields[0].value.string == "{{ response.to_add }}"
@@ -704,7 +704,7 @@ def test_create_record_selector(test_name, record_selector, expected_runtime_sel
     resolved_manifest = resolver.preprocess_manifest(parsed_manifest)
     selector_manifest = transformer.propagate_types_and_parameters("", resolved_manifest["selector"], {})
 
-    selector = factory.create_component(model_type=RecordSelectorModel, component_definition=selector_manifest, config=input_config)
+    selector = factory.create_component(model_type=RecordSelectorModel, component_definition=selector_manifest, transformations=[], config=input_config)
 
     assert isinstance(selector, RecordSelector)
     assert isinstance(selector.extractor, DpathExtractor)
@@ -1245,7 +1245,7 @@ class TestCreateTransformations:
         stream = factory.create_component(model_type=DeclarativeStreamModel, component_definition=stream_manifest, config=input_config)
 
         assert isinstance(stream, DeclarativeStream)
-        assert [] == stream.transformations
+        assert [] == stream.retriever.record_selector.transformations
 
     def test_remove_fields(self):
         content = f"""
@@ -1268,7 +1268,7 @@ class TestCreateTransformations:
 
         assert isinstance(stream, DeclarativeStream)
         expected = [RemoveFields(field_pointers=[["path", "to", "field1"], ["path2"]], parameters={})]
-        assert stream.transformations == expected
+        assert stream.retriever.record_selector.transformations == expected
 
     def test_add_fields(self):
         content = f"""
@@ -1302,7 +1302,7 @@ class TestCreateTransformations:
                 parameters={},
             )
         ]
-        assert stream.transformations == expected
+        assert stream.retriever.record_selector.transformations == expected
 
     def test_default_schema_loader(self):
         component_definition = {
@@ -1474,6 +1474,7 @@ def test_simple_retriever_emit_log_messages():
         name="Test",
         primary_key="id",
         stream_slicer=None,
+        transformations=[],
     )
 
     assert isinstance(retriever, SimpleRetrieverTestReadDecorator)
@@ -1500,6 +1501,7 @@ def test_ignore_retry():
         name="Test",
         primary_key="id",
         stream_slicer=None,
+        transformations=[]
     )
 
     assert retriever.max_retries == 0

--- a/airbyte-cdk/python/unit_tests/sources/declarative/test_declarative_stream.py
+++ b/airbyte-cdk/python/unit_tests/sources/declarative/test_declarative_stream.py
@@ -16,9 +16,6 @@ from airbyte_cdk.models import (
     Type,
 )
 from airbyte_cdk.sources.declarative.declarative_stream import DeclarativeStream
-from airbyte_cdk.sources.declarative.transformations import AddFields, RecordTransformation
-from airbyte_cdk.sources.declarative.transformations.add_fields import AddedFieldDefinition
-from airbyte_cdk.sources.declarative.types import Record
 
 SLICE_NOT_CONSIDERED_FOR_EQUALITY = {}
 
@@ -50,10 +47,6 @@ def test_declarative_stream():
     retriever.read_records.return_value = records
     retriever.stream_slices.return_value = stream_slices
 
-    no_op_transform = mock.create_autospec(spec=RecordTransformation)
-    no_op_transform.transform = MagicMock(side_effect=lambda record, config, stream_slice, stream_state: record)
-    transformations = [no_op_transform]
-
     config = {"api_key": "open_sesame"}
 
     stream = DeclarativeStream(
@@ -63,7 +56,6 @@ def test_declarative_stream():
         schema_loader=schema_loader,
         retriever=retriever,
         config=config,
-        transformations=transformations,
         parameters={"cursor_field": "created_at"},
     )
 
@@ -75,73 +67,6 @@ def test_declarative_stream():
     assert stream.primary_key == primary_key
     assert stream.cursor_field == cursor_field
     assert stream.stream_slices(sync_mode=SyncMode.incremental, cursor_field=cursor_field, stream_state=None) == stream_slices
-    for transformation in transformations:
-        expected_calls = [
-            call(record, config=config, stream_slice=input_slice, stream_state=state) for record in records if isinstance(record, dict)
-        ]
-        assert len(transformation.transform.call_args_list) == len(expected_calls)
-        transformation.transform.assert_has_calls(expected_calls, any_order=False)
-
-
-def test_declarative_stream_with_add_fields_transform():
-    name = "stream"
-    primary_key = "pk"
-    cursor_field = "created_at"
-
-    schema_loader = MagicMock()
-    json_schema = {"name": {"type": "string"}}
-    schema_loader.get_json_schema.return_value = json_schema
-
-    state = MagicMock()
-    stream_slices = [
-        {"date": "2021-01-01"},
-        {"date": "2021-01-02"},
-        {"date": "2021-01-03"},
-    ]
-    input_slice = stream_slices[0]
-
-    retriever_records = [
-        {"pk": 1234, "field": "value"},
-        Record({"pk": 4567, "field": "different_value"}, input_slice),
-        AirbyteMessage(type=Type.RECORD, record=AirbyteRecordMessage(data={"pk": 1357, "field": "a_value"}, emitted_at=12344, stream="stream")),
-        AirbyteMessage(type=Type.LOG, log=AirbyteLogMessage(level=Level.INFO, message="This is a log  message")),
-        AirbyteMessage(type=Type.TRACE, trace=AirbyteTraceMessage(type=TraceType.ERROR, emitted_at=12345)),
-    ]
-
-    expected_records = [
-        {"pk": 1234, "field": "value", "added_key": "added_value"},
-        {"pk": 4567, "field": "different_value", "added_key": "added_value"},
-        AirbyteMessage(type=Type.RECORD, record=AirbyteRecordMessage(data={"pk": 1357, "field": "a_value", "added_key": "added_value"}, emitted_at=12344, stream="stream")),
-        AirbyteMessage(type=Type.LOG, log=AirbyteLogMessage(level=Level.INFO, message="This is a log  message")),
-        AirbyteMessage(type=Type.TRACE, trace=AirbyteTraceMessage(type=TraceType.ERROR, emitted_at=12345)),
-    ]
-
-    retriever = MagicMock()
-    retriever.state = state
-    retriever.read_records.return_value = retriever_records
-    retriever.stream_slices.return_value = stream_slices
-
-    inputs = [AddedFieldDefinition(path=["added_key"], value="added_value", parameters={})]
-    add_fields_transform = AddFields(fields=inputs, parameters={})
-    transformations = [add_fields_transform]
-
-    config = {"api_key": "open_sesame"}
-
-    stream = DeclarativeStream(
-        name=name,
-        primary_key=primary_key,
-        stream_cursor_field="{{ parameters['cursor_field'] }}",
-        schema_loader=schema_loader,
-        retriever=retriever,
-        config=config,
-        transformations=transformations,
-        parameters={"cursor_field": "created_at"},
-    )
-
-    assert stream.name == name
-    assert stream.get_json_schema() == json_schema
-    assert stream.state == state
-    assert list(stream.read_records(SyncMode.full_refresh, cursor_field, input_slice, state)) == expected_records
 
 
 def test_state_checkpoint_interval():
@@ -152,7 +77,6 @@ def test_state_checkpoint_interval():
         schema_loader=MagicMock(),
         retriever=MagicMock(),
         config={},
-        transformations=MagicMock(),
         parameters={},
     )
 

--- a/airbyte-cdk/python/unit_tests/sources/declarative/test_declarative_stream.py
+++ b/airbyte-cdk/python/unit_tests/sources/declarative/test_declarative_stream.py
@@ -2,19 +2,9 @@
 # Copyright (c) 2023 Airbyte, Inc., all rights reserved.
 #
 
-from unittest import mock
-from unittest.mock import MagicMock, call
+from unittest.mock import MagicMock
 
-from airbyte_cdk.models import (
-    AirbyteLogMessage,
-    AirbyteMessage,
-    AirbyteRecordMessage,
-    AirbyteTraceMessage,
-    Level,
-    SyncMode,
-    TraceType,
-    Type,
-)
+from airbyte_cdk.models import AirbyteLogMessage, AirbyteMessage, AirbyteTraceMessage, Level, SyncMode, TraceType, Type
 from airbyte_cdk.sources.declarative.declarative_stream import DeclarativeStream
 
 SLICE_NOT_CONSIDERED_FOR_EQUALITY = {}


### PR DESCRIPTION
## What
Addresses https://github.com/airbytehq/airbyte/issues/27494

## How
By moving the transformation earlier in the pipeline so that anyone that requires those "AddFields" has access to it.

## 🚨 User Impact 🚨
This is a breaking change:
* RemoveFields occurs earlier so if part of the sync relied on a field that would later be extracted, this will fail now
* Custom components that
    * Relied on `DeclarativeStream.transformations` being defined
    * Re-implemented RecordSelector without considering the new `transformations` field
