### PR TITLE
📝 docs: update confluence source page

### DIFF
--- a/docs/integrations/sources/confluence.md
+++ b/docs/integrations/sources/confluence.md
@@ -10,26 +10,19 @@ This page contains the setup guide and reference information for the
 * Your Confluence login email
 
 ## Setup guide
-### Create an API Token 
+### Step 1: Create an API Token 
 
 For detailed instructions on creating an Atlassian API Token, please refer to the 
 [official documentation](https://support.atlassian.com/atlassian-account/docs/manage-api-tokens-for-your-atlassian-account/).
 
-### Set up Confluence connector in Airbyte
+### Step 2: Set up the Confluence connector in Airbyte
 1. [Log in to your Airbyte Cloud](https://cloud.airbyte.com/workspaces) account, or navigate to the Airbyte Open Source dashboard.
-2. In the left navigation bar, click **Sources**.
-
-:::tip
-If this is your first time setting up an Airbyte source, skip the next step and proceed to step 4.
-:::
-
-3. In the top-right corner, click **+ New source**.
-4. Find and select **Confluence** from the list of available sources.
-5. Enter a **Source name** of your choosing.
-6. In the **API Token** field, enter your Atlassian API Token.
-7. In the **Domain name** field, enter your Confluence domain name.
-8. In the **Email** field, enter your Confluence login email.
-9. Click **Set up source** and wait for the tests to complete.
+2. From the Airbyte UI, click **Sources**, then click on **+ New Source** and select **Confluence** from the list of available sources.
+3. Enter a **Source name** of your choosing.
+4. In the **API Token** field, enter your Atlassian API Token.
+5. In the **Domain name** field, enter your Confluence domain name.
+6. In the **Email** field, enter your Confluence login email.
+7. Click **Set up source** and wait for the tests to complete.
 
 ## Supported sync modes
 
@@ -43,11 +36,13 @@ If this is your first time setting up an Airbyte source, skip the next step and 
 
 ## Supported streams
 
-* [Pages](https://developer.atlassian.com/cloud/confluence/rest/api-group-content/#api-wiki-rest-api-content-get)
-* [Blog Posts](https://developer.atlassian.com/cloud/confluence/rest/api-group-content/#api-wiki-rest-api-content-get)
-* [Space](https://developer.atlassian.com/cloud/confluence/rest/api-group-space/#api-wiki-rest-api-space-get)
-* [Group](https://developer.atlassian.com/cloud/confluence/rest/api-group-group/#api-wiki-rest-api-group-get)
 * [Audit](https://developer.atlassian.com/cloud/confluence/rest/api-group-audit/#api-wiki-rest-api-audit-get)
+* [Blog Posts](https://developer.atlassian.com/cloud/confluence/rest/api-group-content/#api-wiki-rest-api-content-get)
+* [Group](https://developer.atlassian.com/cloud/confluence/rest/api-group-group/#api-wiki-rest-api-group-get)
+* [Pages](https://developer.atlassian.com/cloud/confluence/rest/api-group-content/#api-wiki-rest-api-content-get)
+* [Space](https://developer.atlassian.com/cloud/confluence/rest/api-group-space/#api-wiki-rest-api-space-get)
+
+
 
 :::note
 The `audit` stream requires a Standard or Premium plan.

--- a/docs/integrations/sources/confluence.md
+++ b/docs/integrations/sources/confluence.md
@@ -1,22 +1,35 @@
 # Confluence
 
-This page contains the setup guide and reference information for the Confluence source connector.
+This page contains the setup guide and reference information for the 
+[Confluence](https://www.atlassian.com/software/confluence) source connector.
 
 ## Prerequisites
 
-* [API Token](https://support.atlassian.com/atlassian-account/docs/manage-api-tokens-for-your-atlassian-account/)
+* Atlassian API Token
 * Your Confluence domain name
 * Your Confluence login email
 
 ## Setup guide
-### Step 1: Set up Confluence connector
-1. Log into your [Airbyte Cloud](https://cloud.airbyte.io/workspaces) or Airbyte Open Source account.
-2. Click **Sources** and then click **+ New source**. 
-3. On the Set up the source page, select **Confluence** from the Source type dropdown.
-4. Enter a name for your source.
-5. For **API Token** follow the Jira confluence for generating an  [API Token](https://support.atlassian.com/atlassian-account/docs/manage-api-tokens-for-your-atlassian-account/)
-6. For **Domain name** enter your Confluence domain name.
-7. For **Email** enter your Confluence login email.
+### Create an API Token 
+
+For detailed instructions on creating an Atlassian API Token, please refer to the 
+[official documentation](https://support.atlassian.com/atlassian-account/docs/manage-api-tokens-for-your-atlassian-account/).
+
+### Set up Confluence connector in Airbyte
+1. [Log in to your Airbyte Cloud](https://cloud.airbyte.com/workspaces) account, or navigate to the Airbyte Open Source dashboard.
+2. In the left navigation bar, click **Sources**.
+
+:::tip
+If this is your first time setting up an Airbyte source, skip the next step and proceed to step 4.
+:::
+
+3. In the top-right corner, click **+ New source**.
+4. Find and select **Confluence** from the list of available sources.
+5. Enter a **Source name** of your choosing.
+6. In the **API Token** field, enter your Atlassian API Token.
+7. In the **Domain name** field, enter your Confluence domain name.
+8. In the **Email** field, enter your Confluence login email.
+9. Click **Set up source** and wait for the tests to complete.
 
 ## Supported sync modes
 
@@ -28,7 +41,7 @@ This page contains the setup guide and reference information for the Confluence 
 | SSL connection            | No         |
 | Namespaces                | No         |
 
-## Supported Streams
+## Supported streams
 
 * [Pages](https://developer.atlassian.com/cloud/confluence/rest/api-group-content/#api-wiki-rest-api-content-get)
 * [Blog Posts](https://developer.atlassian.com/cloud/confluence/rest/api-group-content/#api-wiki-rest-api-content-get)
@@ -37,12 +50,13 @@ This page contains the setup guide and reference information for the Confluence 
 * [Audit](https://developer.atlassian.com/cloud/confluence/rest/api-group-audit/#api-wiki-rest-api-audit-get)
 
 :::note
-Stream Audit requires Standard or Premium plan.
+The `audit` stream requires a Standard or Premium plan.
 :::
-## Data type map
-The [Confluence API](https://developer.atlassian.com/cloud/confluence/rest/intro/#about) uses the same [JSONSchema](https://json-schema.org/understanding-json-schema/reference/index.html) types that Airbyte uses internally \(`string`, `date-time`, `object`, `array`, `boolean`, `integer`, and `number`\), so no type conversions happen as part of this source.
 
-### Performance considerations
+## Data type mapping
+The [Confluence Cloud REST API](https://developer.atlassian.com/cloud/confluence/rest/v1/intro/#about) uses the same [JSONSchema](https://json-schema.org/understanding-json-schema/reference/index.html) types that Airbyte uses internally \(`string`, `date-time`, `object`, `array`, `boolean`, `integer`, and `number`\), so no type conversions happen as part of this source.
+
+## Performance considerations
 
 The Confluence connector should not run into Confluence API limitations under normal usage. Please [create an issue](https://github.com/airbytehq/airbyte/issues) if you see any rate limit issues that are not automatically retried successfully.
 


### PR DESCRIPTION
## What
Update and expand documentation for Confluence source.

## How
- Added link to source.
- Removed duplicate link to Atlassian API token documentation and moved original link from prerequisites to setup instructions.
- Expanded setup instructions.
- Updated link to Confluence REST API in data mapping.
- Minor grammar/typo fixes.

## 🚨 User Impact 🚨
Improvements to navigation of Confluence source page in docs.
