### PR TITLE
connectors-ci: mount secrets in a late layer for CAT

### DIFF
--- a/tools/ci_connector_ops/ci_connector_ops/pipelines/gradle.py
+++ b/tools/ci_connector_ops/ci_connector_ops/pipelines/gradle.py
@@ -97,11 +97,11 @@ class GradleTask(Step, ABC):
             .with_mounted_directory("buildSrc", await self._get_patched_build_src_dir())
             # Disable the Ryuk container because it needs privileged docker access that does not work:
             .with_env_variable("TESTCONTAINERS_RYUK_DISABLED", "true")
+            .with_(environments.mounted_connector_secrets(self.context, f"{self.context.connector.code_directory}/secrets"))
+            .with_exec(self._get_gradle_command())
         )
-        connector_under_test_with_secrets = environments.with_mounted_connector_secrets(
-            self.context, connector_under_test, f"{self.context.connector.code_directory}/secrets"
-        )
-        results = await self.get_step_result(connector_under_test_with_secrets.with_exec(self._get_gradle_command()))
+
+        results = await self.get_step_result(connector_under_test)
 
         await self._export_gradle_dependency_cache(connector_under_test)
         return results

--- a/tools/ci_connector_ops/ci_connector_ops/pipelines/tests/python_connectors.py
+++ b/tools/ci_connector_ops/ci_connector_ops/pipelines/tests/python_connectors.py
@@ -84,7 +84,7 @@ class UnitTests(PytestStep):
         Returns:
             StepResult: Failure or success of the unit tests with stdout and stdout.
         """
-        connector_under_test_with_secrets = environments.with_mounted_connector_secrets(self.context, connector_under_test)
+        connector_under_test_with_secrets = connector_under_test.with_(environments.mounted_connector_secrets(self.context))
         return await self._run_tests_in_directory(connector_under_test_with_secrets, "unit_tests")
 
 
@@ -102,9 +102,10 @@ class IntegrationTests(PytestStep):
         Returns:
             StepResult: Failure or success of the integration tests with stdout and stdout.
         """
-        connector_under_test = environments.with_bound_docker_host(self.context, connector_under_test)
-        connector_under_test = environments.with_mounted_connector_secrets(self.context, connector_under_test)
 
+        connector_under_test = connector_under_test.with_(environments.bound_docker_host(self.context)).with_(
+            environments.mounted_connector_secrets(self.context)
+        )
         return await self._run_tests_in_directory(connector_under_test, "integration_tests")
 
 


### PR DESCRIPTION
## What
Addresses #27867

Mount secret to the CAT container in a later layer.
I'm not sure how well the mounted secrets layer is burst on every CAT run. I suspect failure like [this one](https://storage.cloud.google.com/airbyte-ci-reports-multi/airbyte-ci/connectors/test/nightly_builds/master/1688343674/bdbe549a90a646f2568cba02c9e04e9783477626/source-strava/0.1.4/output.html) to be due to abusively cached secrets / connector config.

## How
Mount secrets later in the CAT container declaration to make sure they are re-mounted every time the cache is bursted.