### PR TITLE
Fix Dagster Deploy Failure

### DIFF
--- a/airbyte-ci/connectors/metadata_service/orchestrator/pyproject.toml
+++ b/airbyte-ci/connectors/metadata_service/orchestrator/pyproject.toml
@@ -25,6 +25,7 @@ grpcio = "^1.47.0"
 poetry2setup = "^1.1.0"
 slack-sdk = "^3.21.3"
 poetry = "^1.5.1"
+pydantic = "^1.10.6"
 
 
 [tool.poetry.group.dev.dependencies]

--- a/tools/ci_connector_ops/ci_connector_ops/pipelines/pipelines/metadata.py
+++ b/tools/ci_connector_ops/ci_connector_ops/pipelines/pipelines/metadata.py
@@ -123,7 +123,7 @@ class DeployOrchestrator(Step):
     async def _run(self) -> StepResult:
         parent_dir = self.context.get_repo_dir(METADATA_DIR)
         python_base = with_python_base(self.context)
-        python_with_dependencies = with_pip_packages(python_base, ["dagster-cloud==1.2.6", "poetry2setup==1.1.0"])
+        python_with_dependencies = with_pip_packages(python_base, ["dagster-cloud==1.2.6", "pydantic==1.10.6", "poetry2setup==1.1.0"])
         dagster_cloud_api_token_secret: dagger.Secret = (
             self.context.dagger_client.host().env_variable("DAGSTER_CLOUD_METADATA_API_TOKEN").secret()
         )


### PR DESCRIPTION
## What
Hot fixing to add pydantic to the dagster deploy pipeline.

This is the sad result of dagster cloud not yet supporting pyproject.toml