### PR TITLE
connectors-ci: revert to Dagger 0.5.4

### DIFF
--- a/.github/actions/run-dagger-pipeline/action.yml
+++ b/.github/actions/run-dagger-pipeline/action.yml
@@ -95,6 +95,14 @@ runs:
     - name: Run airbyte-ci
       shell: bash
       run: |
+        export _EXPERIMENTAL_DAGGER_RUNNER_HOST="unix:///var/run/buildkit/buildkitd.sock"
+        DAGGER_CLI_COMMIT=${{ inputs.dagger_cli_commit }}
+        DAGGER_TMP_BINDIR="/tmp/dagger_${DAGGER_CLI_COMMIT}"
+        export _EXPERIMENTAL_DAGGER_CLI_BIN="$DAGGER_TMP_BINDIR/dagger"
+        if [ ! -f  "$_EXPERIMENTAL_DAGGER_CLI_BIN" ]; then
+          mkdir -p "$DAGGER_TMP_BINDIR"
+          curl "https://dl.dagger.io/dagger/main/${DAGGER_CLI_COMMIT}/dagger_${DAGGER_CLI_COMMIT}_$(uname -s | tr A-Z a-z)_$(uname -m | sed s/x86_64/amd64/).tar.gz" | tar xvz -C "$DAGGER_TMP_BINDIR"
+        fi
         airbyte-ci --is-ci --gha-workflow-run-id=${{ github.run_id }} ${{ inputs.subcommand }} ${{ inputs.options }}
       env:
         _EXPERIMENTAL_DAGGER_CLOUD_TOKEN: "p.eyJ1IjogIjFiZjEwMmRjLWYyZmQtNDVhNi1iNzM1LTgxNzI1NGFkZDU2ZiIsICJpZCI6ICJlNjk3YzZiYy0yMDhiLTRlMTktODBjZC0yNjIyNGI3ZDBjMDEifQ.hT6eMOYt3KZgNoVGNYI3_v4CC-s19z8uQsBkGrBhU3k"

--- a/tools/ci_connector_ops/setup.py
+++ b/tools/ci_connector_ops/setup.py
@@ -45,7 +45,7 @@ QA_ENGINE_REQUIREMENTS = [
 ]
 
 PIPELINES_REQUIREMENTS = [
-    "dagger-io==0.6.2",
+    "dagger-io==0.6.3",
     "asyncer",
     "anyio",
     "more-itertools",

--- a/tools/ci_connector_ops/setup.py
+++ b/tools/ci_connector_ops/setup.py
@@ -45,7 +45,7 @@ QA_ENGINE_REQUIREMENTS = [
 ]
 
 PIPELINES_REQUIREMENTS = [
-    "dagger-io==0.6.3",
+    "dagger-io==0.5.4",
     "asyncer",
     "anyio",
     "more-itertools",


### PR DESCRIPTION
## What
Closes https://github.com/airbytehq/airbyte/issues/27970

## How
Reverting Dagger SDK to 0.5.4
Infra PR: https://github.com/airbytehq/airbyte-infra/pull/44