### PR TITLE
Source Google Analytics Data API: add end date parameter

### DIFF
--- a/airbyte-integrations/connectors/source-google-analytics-data-api/source_google_analytics_data_api/source.py
+++ b/airbyte-integrations/connectors/source-google-analytics-data-api/source_google_analytics_data_api/source.py
@@ -271,6 +271,10 @@ class GoogleAnalyticsDataApiBaseStream(GoogleAnalyticsDataApiAbstractStream):
 
         today: datetime.date = datetime.date.today()
 
+        end_date = self.config.get("date_ranges_end_date", today)
+        end_date = datetime.datetime.strptime(end_date) if isinstance(end_date, str) else end_date
+        end_date = min(end_date, today)
+
         start_date = stream_state and stream_state.get(self.cursor_field)
         if start_date:
             start_date = utils.string_to_date(start_date, self._record_date_format, old_format=DATE_FORMAT)
@@ -279,7 +283,7 @@ class GoogleAnalyticsDataApiBaseStream(GoogleAnalyticsDataApiAbstractStream):
         else:
             start_date = self.config["date_ranges_start_date"]
 
-        while start_date <= today:
+        while start_date <= end_date:
             # stop producing slices if 429 + specific scenario is hit
             # see GoogleAnalyticsQuotaHandler for more info.
             if GoogleAnalyticsQuotaHandler.stop_iter:


### PR DESCRIPTION
## What
Links to https://github.com/airbytehq/airbyte/issues/27986
This PR adds the ability to specify an end date in the config for the GA4 connector. This is useful is you use the incremental sync mode for airbyte, where the data is subject to change for the last 48 hours.

For a custom report that pulls google analytics traffic split by channel the data make not have a key on which to deduplicate data where the state is changing over the first 48 hours. Therefore the strategy we are taking is to use two airbyte setups for GA4.

1. A full-refresh & overwrite for the 3 day window from `today - 2 days` to `today`.
2. A incremental append for the window from `12 months ago` to `today - 3 days`. 

We are hoping this solution will strike the balance of keeping costs low and data accurate. Specifying an end date in the config enables this.

## How
Take the min date between `today` and the specified `date_ranges_end_date`.

## 🚨 User Impact 🚨
No.

## Pre-merge Actions


<strong>Updating a connector</strong>

### Community member or Airbyter

- [X] Grant edit access to maintainers ([instructions](https://docs.github.com/en/github/collaborating-with-pull-requests/working-with-forks/allowing-changes-to-a-pull-request-branch-created-from-a-fork#enabling-repository-maintainer-permissions-on-existing-pull-requests))
- [X] Unit & integration tests added


### Airbyter

If this is a community PR, the Airbyte engineer reviewing this PR is responsible for the below items.

- Create a non-forked branch based on this PR and test the below items on it
- Build is successful
- If new credentials are required for use in CI, add them to GSM. [Instructions](https://docs.airbyte.io/connector-development#using-credentials-in-ci).

