### PR TITLE
Test solution with logic in SubstreamPartitionRouter

### DIFF
--- a/airbyte-cdk/python/airbyte_cdk/sources/declarative/parsers/model_to_component_factory.py
+++ b/airbyte-cdk/python/airbyte_cdk/sources/declarative/parsers/model_to_component_factory.py
@@ -869,7 +869,7 @@ class ModelToComponentFactory:
                 ]
             )
 
-        return SubstreamPartitionRouter(parent_stream_configs=parent_stream_configs, parameters=model.parameters, config=config)
+        return SubstreamPartitionRouter(parent_stream_configs=parent_stream_configs, parameters=model.parameters, config=config, message_repository=self._message_repository)
 
     @staticmethod
     def create_wait_time_from_header(model: WaitTimeFromHeaderModel, config: Config, **kwargs) -> WaitTimeFromHeaderBackoffStrategy:

--- a/airbyte-cdk/python/airbyte_cdk/sources/http_logger.py
+++ b/airbyte-cdk/python/airbyte_cdk/sources/http_logger.py
@@ -43,5 +43,19 @@ def create_airbyte_log_message(response: requests.Response, logger: str):
     return AirbyteMessage(type=MessageType.LOG, log=AirbyteLogMessage(level=Level.DEBUG, message=format_http_json(response, logger)))
 
 
+def create_new_log_with_updated_logger(log: str, logger: str) -> str:
+    """
+    Only supports HTTP logs. If log is not HTTP, will raise ValueError
+    """
+    try:
+        log_as_json = json.loads(log)
+        if "http" not in log_as_json:
+            raise ValueError(f"Log is not HTTP")
+        log_as_json["log"]["logger"] = logger
+        return json.dumps(log_as_json)
+    except json.JSONDecodeError:
+        return False
+
+
 def _normalize_body_string(body_str: Optional[Union[str, bytes]]) -> Optional[str]:
     return body_str.decode() if isinstance(body_str, (bytes, bytearray)) else body_str


### PR DESCRIPTION
## What
Addresses https://github.com/airbytehq/airbyte/issues/21014 that targets specifically SubstreamPartitionRouter. 

Other solution: https://github.com/airbytehq/airbyte/pull/27990

This solution parse the records returned as AirbyteMessage from the parent stream, parse them as JSON and update the relevant parameters (in this PR, I've used the logger name but it could be a `airbyte_cdk.stream.is_substream`). 

### Benefits
* The solution feels simpler

### Drawbacks
* Performance as [we need to try to json parse every log message](https://github.com/airbytehq/airbyte/pull/27989/files#diff-ee270a0d8d444a149875c1fb37a35d511499e502d502f4013863eee149a58415R46) to see if this is a log which could be enhanced
* We are bound by the way logs are returned i.e. we won't be able to use the MessageRepository for [those logs](https://github.com/airbytehq/airbyte/blob/086ddb750ba0fa3eed40034c55d19b1cd4e88865/airbyte-cdk/python/airbyte_cdk/sources/declarative/retrievers/simple_retriever.py#L487-L488) as they need to be returned by `stream. read_records`. 

