### PR TITLE
Test solution with logic in MessageRepository

### DIFF
--- a/airbyte-cdk/python/airbyte_cdk/connector_builder/message_grouper.py
+++ b/airbyte-cdk/python/airbyte_cdk/connector_builder/message_grouper.py
@@ -180,7 +180,7 @@ class MessageGrouper:
         return (
             at_least_one_page_in_group
             and message.type == MessageType.LOG
-            and (message.log.message.startswith("slice:") or MessageGrouper._is_page_http_request(json_message))
+            and (MessageGrouper._is_page_http_request(json_message) or message.log.message.startswith("slice:"))
         )
 
     @staticmethod
@@ -193,6 +193,12 @@ class MessageGrouper:
 
     @staticmethod
     def _is_global_request(message: Optional[dict]) -> bool:
+        """
+        A global request is a request that is performed and will not directly lead to record for the specific stream it is being queried. A
+        couple of examples are:
+        * OAuth authentication
+        * Substream slice generation
+        """
         if not message:
             return False
 

--- a/airbyte-cdk/python/airbyte_cdk/connector_builder/message_grouper.py
+++ b/airbyte-cdk/python/airbyte_cdk/connector_builder/message_grouper.py
@@ -143,7 +143,12 @@ class MessageGrouper:
             elif message.type == MessageType.LOG:
                 if self._is_http_log(json_message):
                     if self._is_global_request(json_message):
+                        title_prefix = (
+                           "Parent stream: " if json_message.get("airbyte_cdk", {}).get("stream", {}).get("is_substream", False) else ""
+                        )
                         yield GlobalRequest(
+                            title=title_prefix + json_message.get("http", {}).get("title", None),
+                            description=json_message.get("http", {}).get("description", None),
                             request=self._create_request_from_log_message(json_message),
                             response=self._create_response_from_log_message(json_message),
                         )

--- a/airbyte-cdk/python/airbyte_cdk/connector_builder/message_grouper.py
+++ b/airbyte-cdk/python/airbyte_cdk/connector_builder/message_grouper.py
@@ -10,7 +10,7 @@ from typing import Any, Dict, Iterable, Iterator, List, Mapping, Optional, Union
 from urllib.parse import parse_qs, urlparse
 
 from airbyte_cdk.connector_builder.models import (
-    GlobalRequest,
+    AuxiliaryRequest,
     HttpRequest,
     HttpResponse,
     LogMessage,
@@ -65,7 +65,7 @@ class MessageGrouper:
         slices = []
         log_messages = []
         latest_config_update: AirbyteControlMessage = None
-        global_requests = []
+        auxiliary_requests = []
         for message_group in self._get_message_groups(
                 self._read_stream(source, config, configured_catalog),
                 schema_inferrer,
@@ -81,8 +81,8 @@ class MessageGrouper:
             elif isinstance(message_group, AirbyteControlMessage):
                 if not latest_config_update or latest_config_update.emitted_at <= message_group.emitted_at:
                     latest_config_update = message_group
-            elif isinstance(message_group, GlobalRequest):
-                global_requests.append(message_group)
+            elif isinstance(message_group, AuxiliaryRequest):
+                auxiliary_requests.append(message_group)
             else:
                 slices.append(message_group)
 
@@ -90,7 +90,7 @@ class MessageGrouper:
             logs=log_messages,
             slices=slices,
             test_read_limit_reached=self._has_reached_limit(slices),
-            global_requests=global_requests,
+            auxiliary_requests=auxiliary_requests,
             inferred_schema=schema_inferrer.get_stream_schema(
                 configured_catalog.streams[0].stream.name
             ),  # The connector builder currently only supports reading from a single stream at a time
@@ -100,7 +100,7 @@ class MessageGrouper:
 
     def _get_message_groups(
             self, messages: Iterator[AirbyteMessage], schema_inferrer: SchemaInferrer, datetime_format_inferrer: DatetimeFormatInferrer, limit: int
-    ) -> Iterable[Union[StreamReadPages, AirbyteControlMessage, AirbyteLogMessage, AirbyteTraceMessage, GlobalRequest]]:
+    ) -> Iterable[Union[StreamReadPages, AirbyteControlMessage, AirbyteLogMessage, AirbyteTraceMessage, AuxiliaryRequest]]:
         """
         Message groups are partitioned according to when request log messages are received. Subsequent response log messages
         and record messages belong to the prior request log message and when we encounter another request, append the latest
@@ -142,11 +142,11 @@ class MessageGrouper:
                 current_slice_descriptor = self._parse_slice_description(message.log.message)
             elif message.type == MessageType.LOG:
                 if self._is_http_log(json_message):
-                    if self._is_global_request(json_message):
+                    if self._is_auxiliary_http_request(json_message):
                         title_prefix = (
                            "Parent stream: " if json_message.get("airbyte_cdk", {}).get("stream", {}).get("is_substream", False) else ""
                         )
-                        yield GlobalRequest(
+                        yield AuxiliaryRequest(
                             title=title_prefix + json_message.get("http", {}).get("title", None),
                             description=json_message.get("http", {}).get("description", None),
                             request=self._create_request_from_log_message(json_message),
@@ -185,17 +185,17 @@ class MessageGrouper:
 
     @staticmethod
     def _is_page_http_request(json_message):
-        return MessageGrouper._is_http_log(json_message) and not MessageGrouper._is_global_request(json_message)
+        return MessageGrouper._is_http_log(json_message) and not MessageGrouper._is_auxiliary_http_request(json_message)
 
     @staticmethod
     def _is_http_log(message: Optional[dict]) -> bool:
         return message and bool(message.get("http", False))
 
     @staticmethod
-    def _is_global_request(message: Optional[dict]) -> bool:
+    def _is_auxiliary_http_request(message: Optional[dict]) -> bool:
         """
-        A global request is a request that is performed and will not directly lead to record for the specific stream it is being queried. A
-        couple of examples are:
+        A auxiliary request is a request that is performed and will not directly lead to record for the specific stream it is being queried.
+        A couple of examples are:
         * OAuth authentication
         * Substream slice generation
         """
@@ -203,9 +203,7 @@ class MessageGrouper:
             return False
 
         is_http = MessageGrouper._is_http_log(message)
-        has_stream_name = message.get("airbyte_cdk", {}).get("stream", {}).get("name", False)
-        is_substream = message.get("airbyte_cdk", {}).get("stream", {}).get("is_substream", False)
-        return is_http and (not has_stream_name or is_substream)
+        return is_http and message.get("http", {}).get("is_auxiliary", False)
 
     @staticmethod
     def _close_page(current_page_request, current_page_response, current_slice_pages, current_page_records, validate_page_complete: bool):

--- a/airbyte-cdk/python/airbyte_cdk/connector_builder/models.py
+++ b/airbyte-cdk/python/airbyte_cdk/connector_builder/models.py
@@ -43,7 +43,7 @@ class LogMessage:
 
 
 @dataclass
-class GlobalRequest:
+class AuxiliaryRequest:
     title: str
     description: str
     request: HttpRequest
@@ -55,7 +55,7 @@ class StreamRead(object):
     logs: List[LogMessage]
     slices: List[StreamReadSlices]
     test_read_limit_reached: bool
-    global_requests: List[GlobalRequest]
+    auxiliary_requests: List[AuxiliaryRequest]
     inferred_schema: Optional[Dict[str, Any]]
     inferred_datetime_formats: Optional[Dict[str, str]]
     latest_config_update: Optional[Dict[str, Any]]

--- a/airbyte-cdk/python/airbyte_cdk/connector_builder/models.py
+++ b/airbyte-cdk/python/airbyte_cdk/connector_builder/models.py
@@ -44,6 +44,8 @@ class LogMessage:
 
 @dataclass
 class GlobalRequest:
+    title: str
+    description: str
     request: HttpRequest
     response: HttpResponse
 

--- a/airbyte-cdk/python/airbyte_cdk/sources/declarative/manifest_declarative_source.py
+++ b/airbyte-cdk/python/airbyte_cdk/sources/declarative/manifest_declarative_source.py
@@ -79,9 +79,7 @@ class ManifestDeclarativeSource(DeclarativeSource):
         check = self._source_config["check"]
         if "type" not in check:
             check["type"] = "CheckStream"
-        check_stream = self._constructor.create_component(
-            CheckStreamModel, check, dict(), emit_connector_builder_messages=self._emit_connector_builder_messages
-        )
+        check_stream = self._constructor.create_component(CheckStreamModel, check, dict())
         if isinstance(check_stream, ConnectionChecker):
             return check_stream
         else:
@@ -91,9 +89,7 @@ class ManifestDeclarativeSource(DeclarativeSource):
         self._emit_manifest_debug_message(extra_args={"source_name": self.name, "parsed_config": json.dumps(self._source_config)})
 
         source_streams = [
-            self._constructor.create_component(
-                DeclarativeStreamModel, stream_config, config, emit_connector_builder_messages=self._emit_connector_builder_messages
-            )
+            self._constructor.create_component(DeclarativeStreamModel, stream_config, config)
             for stream_config in self._stream_configs(self._source_config)
         ]
 

--- a/airbyte-cdk/python/airbyte_cdk/sources/declarative/manifest_declarative_source.py
+++ b/airbyte-cdk/python/airbyte_cdk/sources/declarative/manifest_declarative_source.py
@@ -79,7 +79,9 @@ class ManifestDeclarativeSource(DeclarativeSource):
         check = self._source_config["check"]
         if "type" not in check:
             check["type"] = "CheckStream"
-        check_stream = self._constructor.create_component(CheckStreamModel, check, dict())
+        check_stream = self._constructor.create_component(
+            CheckStreamModel, check, dict(), emit_connector_builder_messages=self._emit_connector_builder_messages
+        )
         if isinstance(check_stream, ConnectionChecker):
             return check_stream
         else:
@@ -89,7 +91,9 @@ class ManifestDeclarativeSource(DeclarativeSource):
         self._emit_manifest_debug_message(extra_args={"source_name": self.name, "parsed_config": json.dumps(self._source_config)})
 
         source_streams = [
-            self._constructor.create_component(DeclarativeStreamModel, stream_config, config)
+            self._constructor.create_component(
+                DeclarativeStreamModel, stream_config, config, emit_connector_builder_messages=self._emit_connector_builder_messages
+            )
             for stream_config in self._stream_configs(self._source_config)
         ]
 

--- a/airbyte-cdk/python/airbyte_cdk/sources/declarative/parsers/model_to_component_factory.py
+++ b/airbyte-cdk/python/airbyte_cdk/sources/declarative/parsers/model_to_component_factory.py
@@ -883,7 +883,7 @@ class ModelToComponentFactory:
             emit_connector_builder_messages=self._emit_connector_builder_messages,
             disable_retries=self._disable_retries,
             message_repository=LogAppenderMessageRepositoryDecorator(
-                {"airbyte_cdk": {"stream": {"is_substream": True}}},
+                {"airbyte_cdk": {"stream": {"is_substream": True}}, "http": {"is_auxiliary": True}},
                 self._message_repository,
                 self._evaluate_log_level(self._emit_connector_builder_messages),
             ),

--- a/airbyte-cdk/python/airbyte_cdk/sources/declarative/parsers/model_to_component_factory.py
+++ b/airbyte-cdk/python/airbyte_cdk/sources/declarative/parsers/model_to_component_factory.py
@@ -107,7 +107,7 @@ from airbyte_cdk.sources.declarative.stream_slicers import CartesianProductStrea
 from airbyte_cdk.sources.declarative.transformations import AddFields, RemoveFields
 from airbyte_cdk.sources.declarative.transformations.add_fields import AddedFieldDefinition
 from airbyte_cdk.sources.declarative.types import Config
-from airbyte_cdk.sources.message import InMemoryMessageRepository
+from airbyte_cdk.sources.message import InMemoryMessageRepository, LogAppenderMessageRepositoryDecorator, MessageRepository
 from pydantic import BaseModel
 
 ComponentDefinition: Union[Literal, Mapping, List]
@@ -122,14 +122,19 @@ class ModelToComponentFactory:
         limit_pages_fetched_per_slice: int = None,
         limit_slices_fetched: int = None,
         emit_connector_builder_messages: bool = False,
-        disable_retries=False,
+        disable_retries: bool = False,
+        message_repository: MessageRepository = None
     ):
         self._init_mappings()
         self._limit_pages_fetched_per_slice = limit_pages_fetched_per_slice
         self._limit_slices_fetched = limit_slices_fetched
         self._emit_connector_builder_messages = emit_connector_builder_messages
         self._disable_retries = disable_retries
-        self._message_repository = InMemoryMessageRepository(Level.DEBUG if emit_connector_builder_messages else Level.INFO)
+        self._message_repository = (
+            message_repository
+            if message_repository
+            else InMemoryMessageRepository(self._evaluate_log_level(emit_connector_builder_messages))
+        )
 
     def _init_mappings(self):
         self.PYDANTIC_MODEL_TO_CONSTRUCTOR: [Type[BaseModel], Callable] = {
@@ -836,6 +841,7 @@ class ModelToComponentFactory:
                 maximum_number_of_slices=self._limit_slices_fetched,
                 parameters=model.parameters,
                 disable_retries=self._disable_retries,
+                message_repository=self._message_repository,
             )
         return SimpleRetriever(
             name=name,
@@ -848,6 +854,7 @@ class ModelToComponentFactory:
             config=config,
             parameters=model.parameters,
             disable_retries=self._disable_retries,
+            message_repository=self._message_repository,
         )
 
     @staticmethod
@@ -864,12 +871,22 @@ class ModelToComponentFactory:
         if model.parent_stream_configs:
             parent_stream_configs.extend(
                 [
-                    self._create_component_from_model(model=parent_stream_config, config=config)
+                    self._create_message_repository_substream_wrapper(model=parent_stream_config, config=config)
                     for parent_stream_config in model.parent_stream_configs
                 ]
             )
 
         return SubstreamPartitionRouter(parent_stream_configs=parent_stream_configs, parameters=model.parameters, config=config)
+
+    def _create_message_repository_substream_wrapper(self, model, config):
+        substream_factory = ModelToComponentFactory(
+            limit_pages_fetched_per_slice=self._limit_pages_fetched_per_slice,
+            limit_slices_fetched=self._limit_slices_fetched,
+            emit_connector_builder_messages=self._emit_connector_builder_messages,
+            disable_retries=self._disable_retries,
+            message_repository=LogAppenderMessageRepositoryDecorator({"airbyte_cdk": {"stream": {"is_substream": True}}}, self._message_repository, self._evaluate_log_level(self._emit_connector_builder_messages)),
+        )
+        return substream_factory._create_component_from_model(model=model, config=config)
 
     @staticmethod
     def create_wait_time_from_header(model: WaitTimeFromHeaderModel, config: Config, **kwargs) -> WaitTimeFromHeaderBackoffStrategy:
@@ -885,3 +902,6 @@ class ModelToComponentFactory:
 
     def get_message_repository(self):
         return self._message_repository
+
+    def _evaluate_log_level(self, emit_connector_builder_messages) -> Level:
+        return Level.DEBUG if emit_connector_builder_messages else Level.INFO

--- a/airbyte-cdk/python/airbyte_cdk/sources/declarative/parsers/model_to_component_factory.py
+++ b/airbyte-cdk/python/airbyte_cdk/sources/declarative/parsers/model_to_component_factory.py
@@ -130,7 +130,9 @@ class ModelToComponentFactory:
         self._limit_slices_fetched = limit_slices_fetched
         self._emit_connector_builder_messages = emit_connector_builder_messages
         self._disable_retries = disable_retries
-        self._message_repository = message_repository or InMemoryMessageRepository(self._evaluate_log_level(emit_connector_builder_messages))
+        self._message_repository = message_repository or InMemoryMessageRepository(
+            self._evaluate_log_level(emit_connector_builder_messages)
+        )
 
     def _init_mappings(self):
         self.PYDANTIC_MODEL_TO_CONSTRUCTOR: [Type[BaseModel], Callable] = {

--- a/airbyte-cdk/python/airbyte_cdk/sources/declarative/parsers/model_to_component_factory.py
+++ b/airbyte-cdk/python/airbyte_cdk/sources/declarative/parsers/model_to_component_factory.py
@@ -130,11 +130,7 @@ class ModelToComponentFactory:
         self._limit_slices_fetched = limit_slices_fetched
         self._emit_connector_builder_messages = emit_connector_builder_messages
         self._disable_retries = disable_retries
-        self._message_repository = (
-            message_repository
-            if message_repository
-            else InMemoryMessageRepository(self._evaluate_log_level(emit_connector_builder_messages))
-        )
+        self._message_repository = message_repository or InMemoryMessageRepository(self._evaluate_log_level(emit_connector_builder_messages))
 
     def _init_mappings(self):
         self.PYDANTIC_MODEL_TO_CONSTRUCTOR: [Type[BaseModel], Callable] = {
@@ -890,7 +886,6 @@ class ModelToComponentFactory:
                 self._evaluate_log_level(self._emit_connector_builder_messages),
             ),
         )
-        # noinspection PyProtectedMember
         return substream_factory._create_component_from_model(model=model, config=config)
 
     @staticmethod

--- a/airbyte-cdk/python/airbyte_cdk/sources/declarative/parsers/model_to_component_factory.py
+++ b/airbyte-cdk/python/airbyte_cdk/sources/declarative/parsers/model_to_component_factory.py
@@ -123,7 +123,7 @@ class ModelToComponentFactory:
         limit_slices_fetched: int = None,
         emit_connector_builder_messages: bool = False,
         disable_retries: bool = False,
-        message_repository: MessageRepository = None
+        message_repository: MessageRepository = None,
     ):
         self._init_mappings()
         self._limit_pages_fetched_per_slice = limit_pages_fetched_per_slice
@@ -884,7 +884,11 @@ class ModelToComponentFactory:
             limit_slices_fetched=self._limit_slices_fetched,
             emit_connector_builder_messages=self._emit_connector_builder_messages,
             disable_retries=self._disable_retries,
-            message_repository=LogAppenderMessageRepositoryDecorator({"airbyte_cdk": {"stream": {"is_substream": True}}}, self._message_repository, self._evaluate_log_level(self._emit_connector_builder_messages)),
+            message_repository=LogAppenderMessageRepositoryDecorator(
+                {"airbyte_cdk": {"stream": {"is_substream": True}}},
+                self._message_repository,
+                self._evaluate_log_level(self._emit_connector_builder_messages),
+            ),
         )
         # noinspection PyProtectedMember
         return substream_factory._create_component_from_model(model=model, config=config)

--- a/airbyte-cdk/python/airbyte_cdk/sources/declarative/parsers/model_to_component_factory.py
+++ b/airbyte-cdk/python/airbyte_cdk/sources/declarative/parsers/model_to_component_factory.py
@@ -123,18 +123,13 @@ class ModelToComponentFactory:
         limit_slices_fetched: int = None,
         emit_connector_builder_messages: bool = False,
         disable_retries: bool = False,
-        message_repository: MessageRepository = None
     ):
         self._init_mappings()
         self._limit_pages_fetched_per_slice = limit_pages_fetched_per_slice
         self._limit_slices_fetched = limit_slices_fetched
         self._emit_connector_builder_messages = emit_connector_builder_messages
         self._disable_retries = disable_retries
-        self._message_repository = (
-            message_repository
-            if message_repository
-            else InMemoryMessageRepository(self._evaluate_log_level(emit_connector_builder_messages))
-        )
+        self._message_repository = InMemoryMessageRepository(self._evaluate_log_level(emit_connector_builder_messages))
 
     def _init_mappings(self):
         self.PYDANTIC_MODEL_TO_CONSTRUCTOR: [Type[BaseModel], Callable] = {
@@ -219,6 +214,8 @@ class ModelToComponentFactory:
         if model.__class__ not in self.PYDANTIC_MODEL_TO_CONSTRUCTOR:
             raise ValueError(f"{model.__class__} with attributes {model} is not a valid component type")
         component_constructor = self.PYDANTIC_MODEL_TO_CONSTRUCTOR.get(model.__class__)
+        if "message_repository" not in kwargs and "message_repository" in component_constructor.__code__.co_varnames:
+            kwargs["message_repository"] = self._message_repository
         return component_constructor(model=model, config=config, **kwargs)
 
     @staticmethod
@@ -301,7 +298,7 @@ class ModelToComponentFactory:
             parameters=model.parameters,
         )
 
-    def create_custom_component(self, model, config: Config, **kwargs) -> type:
+    def create_custom_component(self, model, config: Config, message_repository: MessageRepository, **kwargs) -> type:
         """
         Generically creates a custom component based on the model type and a class_name reference to the custom Python class being
         instantiated. Only the model's additional properties that match the custom class definition are passed to the constructor
@@ -331,7 +328,7 @@ class ModelToComponentFactory:
                     model_value["type"] = derived_type
 
             if self._is_component(model_value):
-                model_args[model_field] = self._create_nested_component(model, model_field, model_value, config)
+                model_args[model_field] = self._create_nested_component(model, model_field, model_value, config, message_repository)
             elif isinstance(model_value, list):
                 vals = []
                 for v in model_value:
@@ -340,7 +337,7 @@ class ModelToComponentFactory:
                         if derived_type:
                             v["type"] = derived_type
                     if self._is_component(v):
-                        vals.append(self._create_nested_component(model, model_field, v, config))
+                        vals.append(self._create_nested_component(model, model_field, v, config, message_repository))
                     else:
                         vals.append(v)
                 model_args[model_field] = vals
@@ -386,7 +383,7 @@ class ModelToComponentFactory:
         else:
             return []
 
-    def _create_nested_component(self, model, model_field: str, model_value: Any, config: Config) -> Any:
+    def _create_nested_component(self, model, model_field: str, model_value: Any, config: Config, message_repository: MessageRepository) -> Any:
         type_name = model_value.get("type", None)
         if not type_name:
             # If no type is specified, we can assume this is a dictionary object which can be returned instead of a subcomponent
@@ -406,6 +403,8 @@ class ModelToComponentFactory:
                 constructor_kwargs = inspect.getfullargspec(model_constructor).kwonlyargs
                 model_parameters = model_value.get("$parameters", {})
                 matching_parameters = {kwarg: model_parameters[kwarg] for kwarg in constructor_kwargs if kwarg in model_parameters}
+                if "message_repository" in model_constructor.__code__.co_varnames:
+                    matching_parameters["message_repository"] = message_repository
                 return self._create_component_from_model(model=parsed_model, config=config, **matching_parameters)
             except TypeError as error:
                 missing_parameters = self._extract_missing_parameters(error)
@@ -424,7 +423,7 @@ class ModelToComponentFactory:
     def _is_component(model_value: Any) -> bool:
         return isinstance(model_value, dict) and model_value.get("type")
 
-    def create_datetime_based_cursor(self, model: DatetimeBasedCursorModel, config: Config, **kwargs) -> DatetimeBasedCursor:
+    def create_datetime_based_cursor(self, model: DatetimeBasedCursorModel, config: Config, message_repository: MessageRepository, **kwargs) -> DatetimeBasedCursor:
         start_datetime = (
             model.start_datetime if isinstance(model.start_datetime, str) else self.create_min_max_datetime(model.start_datetime, config)
         )
@@ -467,17 +466,17 @@ class ModelToComponentFactory:
             start_time_option=start_time_option,
             partition_field_end=model.partition_field_end,
             partition_field_start=model.partition_field_start,
-            message_repository=self._message_repository,
+            message_repository=message_repository,
             config=config,
             parameters=model.parameters,
         )
 
-    def create_declarative_stream(self, model: DeclarativeStreamModel, config: Config, **kwargs) -> DeclarativeStream:
+    def create_declarative_stream(self, model: DeclarativeStreamModel, config: Config, message_repository: MessageRepository, **kwargs) -> DeclarativeStream:
         # When constructing a declarative stream, we assemble the incremental_sync component and retriever's partition_router field
         # components if they exist into a single CartesianProductStreamSlicer. This is then passed back as an argument when constructing the
         # Retriever. This is done in the declarative stream not the retriever to support custom retrievers. The custom create methods in
         # the factory only support passing arguments to the component constructors, whereas this performs a merge of all slicers into one.
-        combined_slicers = self._merge_stream_slicers(model=model, config=config)
+        combined_slicers = self._merge_stream_slicers(model=model, config=config, message_repository=message_repository)
 
         primary_key = model.primary_key.__root__ if model.primary_key else None
         stop_condition_on_cursor = (
@@ -490,6 +489,7 @@ class ModelToComponentFactory:
             primary_key=primary_key,
             stream_slicer=combined_slicers,
             stop_condition_on_cursor=stop_condition_on_cursor,
+            message_repository=message_repository,
         )
 
         cursor_field = model.incremental_sync.cursor_field if model.incremental_sync else None
@@ -517,27 +517,27 @@ class ModelToComponentFactory:
             parameters=model.parameters,
         )
 
-    def _merge_stream_slicers(self, model: DeclarativeStreamModel, config: Config) -> Optional[StreamSlicer]:
+    def _merge_stream_slicers(self, model: DeclarativeStreamModel, config: Config, message_repository: MessageRepository) -> Optional[StreamSlicer]:
         stream_slicer = None
         if hasattr(model.retriever, "partition_router") and model.retriever.partition_router:
             stream_slicer_model = model.retriever.partition_router
             stream_slicer = (
                 CartesianProductStreamSlicer(
-                    [self._create_component_from_model(model=slicer, config=config) for slicer in stream_slicer_model], parameters={}
+                    [self._create_component_from_model(model=slicer, config=config, message_repository=message_repository) for slicer in stream_slicer_model], parameters={}
                 )
                 if type(stream_slicer_model) == list
-                else self._create_component_from_model(model=stream_slicer_model, config=config)
+                else self._create_component_from_model(model=stream_slicer_model, config=config, message_repository=message_repository)
             )
 
         if model.incremental_sync and stream_slicer:
             return PerPartitionCursor(
                 cursor_factory=CursorFactory(
-                    lambda: self._create_component_from_model(model=model.incremental_sync, config=config),
+                    lambda: self._create_component_from_model(model=model.incremental_sync, config=config, message_repository=message_repository),
                 ),
                 partition_router=stream_slicer,
             )
         elif model.incremental_sync:
-            return self._create_component_from_model(model=model.incremental_sync, config=config) if model.incremental_sync else None
+            return self._create_component_from_model(model=model.incremental_sync, config=config, message_repository=message_repository)
         elif stream_slicer:
             return stream_slicer
         else:
@@ -608,9 +608,9 @@ class ModelToComponentFactory:
     def create_exponential_backoff_strategy(model: ExponentialBackoffStrategyModel, config: Config) -> ExponentialBackoffStrategy:
         return ExponentialBackoffStrategy(factor=model.factor, parameters=model.parameters, config=config)
 
-    def create_http_requester(self, model: HttpRequesterModel, config: Config, *, name: str) -> HttpRequester:
+    def create_http_requester(self, model: HttpRequesterModel, config: Config, message_repository: MessageRepository, *, name: str) -> HttpRequester:
         authenticator = (
-            self._create_component_from_model(model=model.authenticator, config=config, url_base=model.url_base)
+            self._create_component_from_model(model=model.authenticator, config=config, url_base=model.url_base, message_repository=message_repository)
             if model.authenticator
             else None
         )
@@ -707,7 +707,7 @@ class ModelToComponentFactory:
     def create_no_pagination(model: NoPaginationModel, config: Config, **kwargs) -> NoPagination:
         return NoPagination(parameters={})
 
-    def create_oauth_authenticator(self, model: OAuthAuthenticatorModel, config: Config, **kwargs) -> DeclarativeOauth2Authenticator:
+    def create_oauth_authenticator(self, model: OAuthAuthenticatorModel, config: Config, message_repository: MessageRepository, **kwargs) -> DeclarativeOauth2Authenticator:
         if model.refresh_token_updater:
             return DeclarativeSingleUseRefreshTokenOauth2Authenticator(
                 config,
@@ -724,7 +724,7 @@ class ModelToComponentFactory:
                 refresh_request_body=InterpolatedMapping(model.refresh_request_body or {}, parameters=model.parameters).eval(config),
                 scopes=model.scopes,
                 token_expiry_date_format=model.token_expiry_date_format,
-                message_repository=self._message_repository,
+                message_repository=message_repository,
             )
         return DeclarativeOauth2Authenticator(
             access_token_name=model.access_token_name,
@@ -740,7 +740,7 @@ class ModelToComponentFactory:
             token_refresh_endpoint=model.token_refresh_endpoint,
             config=config,
             parameters=model.parameters,
-            message_repository=self._message_repository,
+            message_repository=message_repository,
         )
 
     @staticmethod
@@ -751,8 +751,8 @@ class ModelToComponentFactory:
     def create_page_increment(model: PageIncrementModel, config: Config, **kwargs) -> PageIncrement:
         return PageIncrement(page_size=model.page_size, start_from_page=model.start_from_page, parameters=model.parameters)
 
-    def create_parent_stream_config(self, model: ParentStreamConfigModel, config: Config, **kwargs) -> ParentStreamConfig:
-        declarative_stream = self._create_component_from_model(model.stream, config=config)
+    def create_parent_stream_config(self, model: ParentStreamConfigModel, config: Config, message_repository: MessageRepository, **kwargs) -> ParentStreamConfig:
+        declarative_stream = self._create_component_from_model(model.stream, config=config, message_repository=message_repository)
         request_option = self._create_component_from_model(model.request_option, config=config) if model.request_option else None
         return ParentStreamConfig(
             parent_key=model.parent_key,
@@ -811,9 +811,10 @@ class ModelToComponentFactory:
         name: str,
         primary_key: Optional[Union[str, List[str], List[List[str]]]],
         stream_slicer: Optional[StreamSlicer],
+        message_repository: MessageRepository,
         stop_condition_on_cursor: bool = False,
     ) -> SimpleRetriever:
-        requester = self._create_component_from_model(model=model.requester, config=config, name=name)
+        requester = self._create_component_from_model(model=model.requester, config=config, name=name, message_repository=message_repository)
         record_selector = self._create_component_from_model(model=model.record_selector, config=config)
         url_base = model.requester.url_base if hasattr(model.requester, "url_base") else requester.get_url_base()
         stream_slicer = stream_slicer or SinglePartitionRouter(parameters={})
@@ -841,7 +842,7 @@ class ModelToComponentFactory:
                 maximum_number_of_slices=self._limit_slices_fetched,
                 parameters=model.parameters,
                 disable_retries=self._disable_retries,
-                message_repository=self._message_repository,
+                message_repository=message_repository
             )
         return SimpleRetriever(
             name=name,
@@ -854,7 +855,7 @@ class ModelToComponentFactory:
             config=config,
             parameters=model.parameters,
             disable_retries=self._disable_retries,
-            message_repository=self._message_repository,
+            message_repository=message_repository,
         )
 
     @staticmethod
@@ -866,27 +867,22 @@ class ModelToComponentFactory:
             parameters={},
         )
 
-    def create_substream_partition_router(self, model: SubstreamPartitionRouterModel, config: Config, **kwargs) -> SubstreamPartitionRouter:
+    def create_substream_partition_router(self, model: SubstreamPartitionRouterModel, config: Config, message_repository: MessageRepository, **kwargs) -> SubstreamPartitionRouter:
         parent_stream_configs = []
         if model.parent_stream_configs:
+            substream_message_repository = LogAppenderMessageRepositoryDecorator(
+                {"airbyte_cdk": {"stream": {"is_substream": True}}},
+                message_repository,
+                self._evaluate_log_level(self._emit_connector_builder_messages)
+            )
             parent_stream_configs.extend(
                 [
-                    self._create_message_repository_substream_wrapper(model=parent_stream_config, config=config)
+                    self._create_component_from_model(model=parent_stream_config, config=config, message_repository=substream_message_repository)
                     for parent_stream_config in model.parent_stream_configs
                 ]
             )
 
         return SubstreamPartitionRouter(parent_stream_configs=parent_stream_configs, parameters=model.parameters, config=config)
-
-    def _create_message_repository_substream_wrapper(self, model, config):
-        substream_factory = ModelToComponentFactory(
-            limit_pages_fetched_per_slice=self._limit_pages_fetched_per_slice,
-            limit_slices_fetched=self._limit_slices_fetched,
-            emit_connector_builder_messages=self._emit_connector_builder_messages,
-            disable_retries=self._disable_retries,
-            message_repository=LogAppenderMessageRepositoryDecorator({"airbyte_cdk": {"stream": {"is_substream": True}}}, self._message_repository, self._evaluate_log_level(self._emit_connector_builder_messages)),
-        )
-        return substream_factory._create_component_from_model(model=model, config=config)
 
     @staticmethod
     def create_wait_time_from_header(model: WaitTimeFromHeaderModel, config: Config, **kwargs) -> WaitTimeFromHeaderBackoffStrategy:

--- a/airbyte-cdk/python/airbyte_cdk/sources/declarative/retrievers/simple_retriever.py
+++ b/airbyte-cdk/python/airbyte_cdk/sources/declarative/retrievers/simple_retriever.py
@@ -20,7 +20,7 @@ from airbyte_cdk.sources.declarative.requesters.requester import Requester
 from airbyte_cdk.sources.declarative.retrievers.retriever import Retriever
 from airbyte_cdk.sources.declarative.stream_slicers.stream_slicer import StreamSlicer
 from airbyte_cdk.sources.declarative.types import Config, Record, StreamSlice, StreamState
-from airbyte_cdk.sources.http_logger import format_http_json
+from airbyte_cdk.sources.http_logger import format_http_message
 from airbyte_cdk.sources.message import MessageRepository, NoopMessageRepository
 from airbyte_cdk.sources.streams.core import StreamData
 from airbyte_cdk.sources.streams.http import HttpStream
@@ -64,7 +64,7 @@ class SimpleRetriever(Retriever, HttpStream):
     stream_slicer: Optional[StreamSlicer] = SinglePartitionRouter(parameters={})
     cursor: Optional[Cursor] = None
     disable_retries: bool = False
-    message_repository: MessageRepository = NoopMessageRepository
+    message_repository: MessageRepository = NoopMessageRepository()
 
     def __post_init__(self, parameters: Mapping[str, Any]):
         self.paginator = self.paginator or NoPagination(parameters=parameters)
@@ -500,5 +500,5 @@ class SimpleRetrieverTestReadDecorator(SimpleRetriever):
         stream_state: Mapping[str, Any],
         stream_slice: Mapping[str, Any],
     ) -> Iterable[StreamData]:
-        self.message_repository.log_message(Level.DEBUG, lambda: format_http_json(response, self.name))
+        self.message_repository.log_message(Level.DEBUG, lambda: format_http_message(response, self.name))
         yield from self.parse_response(response, stream_slice=stream_slice, stream_state=stream_state)

--- a/airbyte-cdk/python/airbyte_cdk/sources/declarative/retrievers/simple_retriever.py
+++ b/airbyte-cdk/python/airbyte_cdk/sources/declarative/retrievers/simple_retriever.py
@@ -500,5 +500,13 @@ class SimpleRetrieverTestReadDecorator(SimpleRetriever):
         stream_state: Mapping[str, Any],
         stream_slice: Mapping[str, Any],
     ) -> Iterable[StreamData]:
-        self.message_repository.log_message(Level.DEBUG, lambda: format_http_message(response, self.name))
+        self.message_repository.log_message(
+            Level.DEBUG,
+            lambda: format_http_message(
+                response,
+                f"Stream '{self.name}' request",
+                f"Request performed in order to extract records for stream '{self.name}'",
+                self.name,
+            ),
+        )
         yield from self.parse_response(response, stream_slice=stream_slice, stream_state=stream_state)

--- a/airbyte-cdk/python/airbyte_cdk/sources/http_logger.py
+++ b/airbyte-cdk/python/airbyte_cdk/sources/http_logger.py
@@ -8,10 +8,12 @@ import requests
 from airbyte_cdk.sources.message import LogMessage
 
 
-def format_http_message(response: requests.Response, stream_name: Optional[str]) -> LogMessage:
+def format_http_message(response: requests.Response, title: str, description: str, stream_name: Optional[str]) -> LogMessage:
     request = response.request
     log_message = {
         "http": {
+            "title": title,
+            "description": description,
             "request": {
                 "method": request.method,
                 "body": {

--- a/airbyte-cdk/python/airbyte_cdk/sources/http_logger.py
+++ b/airbyte-cdk/python/airbyte_cdk/sources/http_logger.py
@@ -8,7 +8,7 @@ import requests
 from airbyte_cdk.sources.message import LogMessage
 
 
-def format_http_json(response: requests.Response, stream_name: Optional[str]) -> LogMessage:
+def format_http_message(response: requests.Response, stream_name: Optional[str]) -> LogMessage:
     request = response.request
     log_message = {
         "http": {
@@ -33,11 +33,7 @@ def format_http_json(response: requests.Response, stream_name: Optional[str]) ->
         "url": {"full": request.url},
     }
     if stream_name:
-        log_message["airbyte_cdk"] = {
-            "stream": {
-                "name": stream_name
-            }
-        }
+        log_message["airbyte_cdk"] = {"stream": {"name": stream_name}}
     return log_message
 
 

--- a/airbyte-cdk/python/airbyte_cdk/sources/http_logger.py
+++ b/airbyte-cdk/python/airbyte_cdk/sources/http_logger.py
@@ -8,7 +8,9 @@ import requests
 from airbyte_cdk.sources.message import LogMessage
 
 
-def format_http_message(response: requests.Response, title: str, description: str, stream_name: Optional[str]) -> LogMessage:
+def format_http_message(
+    response: requests.Response, title: str, description: str, stream_name: Optional[str], is_auxiliary: bool = None
+) -> LogMessage:
     request = response.request
     log_message = {
         "http": {
@@ -34,6 +36,8 @@ def format_http_message(response: requests.Response, title: str, description: st
         },
         "url": {"full": request.url},
     }
+    if is_auxiliary is not None:
+        log_message["http"]["is_auxiliary"] = is_auxiliary
     if stream_name:
         log_message["airbyte_cdk"] = {"stream": {"name": stream_name}}
     return log_message

--- a/airbyte-cdk/python/airbyte_cdk/sources/message/__init__.py
+++ b/airbyte-cdk/python/airbyte_cdk/sources/message/__init__.py
@@ -2,6 +2,12 @@
 # Copyright (c) 2021 Airbyte, Inc., all rights reserved.
 #
 
-from .repository import InMemoryMessageRepository, LogAppenderMessageRepositoryDecorator, LogMessage, MessageRepository, NoopMessageRepository
+from .repository import (
+    InMemoryMessageRepository,
+    LogAppenderMessageRepositoryDecorator,
+    LogMessage,
+    MessageRepository,
+    NoopMessageRepository,
+)
 
 __all__ = ["InMemoryMessageRepository", "LogAppenderMessageRepositoryDecorator", "LogMessage", "MessageRepository", "NoopMessageRepository"]

--- a/airbyte-cdk/python/airbyte_cdk/sources/message/__init__.py
+++ b/airbyte-cdk/python/airbyte_cdk/sources/message/__init__.py
@@ -2,6 +2,6 @@
 # Copyright (c) 2021 Airbyte, Inc., all rights reserved.
 #
 
-from .repository import InMemoryMessageRepository, MessageRepository, NoopMessageRepository
+from .repository import InMemoryMessageRepository, LogAppenderMessageRepositoryDecorator, LogMessage, MessageRepository, NoopMessageRepository
 
-__all__ = ["InMemoryMessageRepository", "MessageRepository", "NoopMessageRepository"]
+__all__ = ["InMemoryMessageRepository", "LogAppenderMessageRepositoryDecorator", "LogMessage", "MessageRepository", "NoopMessageRepository"]

--- a/airbyte-cdk/python/airbyte_cdk/sources/message/repository.py
+++ b/airbyte-cdk/python/airbyte_cdk/sources/message/repository.py
@@ -3,7 +3,6 @@
 #
 
 import json
-
 from abc import ABC, abstractmethod
 from typing import Callable, Iterable, Union
 
@@ -73,7 +72,9 @@ class InMemoryMessageRepository(MessageRepository):
 
     def log_message(self, level: Level, message_provider: Callable[[], LogMessage]) -> None:
         if _is_severe_enough(self._log_level, level):
-            self.emit_message(AirbyteMessage(type=Type.LOG, log=AirbyteLogMessage(level=level, message=filter_secrets(json.dumps(message_provider())))))
+            self.emit_message(
+                AirbyteMessage(type=Type.LOG, log=AirbyteLogMessage(level=level, message=filter_secrets(json.dumps(message_provider()))))
+            )
 
     def consume_queue(self) -> Iterable[AirbyteMessage]:
         while self._message_queue:
@@ -96,8 +97,7 @@ class LogAppenderMessageRepositoryDecorator(MessageRepository):
             self._decorated.log_message(level, lambda: message)
 
     def consume_queue(self) -> Iterable[AirbyteMessage]:
-        # FIXME return or yield from?
-        yield from self._decorated.consume_queue()
+        return self._decorated.consume_queue()
 
     def _append_second_to_first(self, first, second, path=None):
         if path is None:
@@ -110,7 +110,7 @@ class LogAppenderMessageRepositoryDecorator(MessageRepository):
                 elif first[key] == second[key]:
                     pass
                 else:
-                    raise Exception('Conflict at %s' % '.'.join(path + [str(key)]))
+                    raise ValueError("Conflict at %s" % ".".join(path + [str(key)]))
             else:
                 first[key] = second[key]
         return first

--- a/airbyte-cdk/python/airbyte_cdk/sources/message/repository.py
+++ b/airbyte-cdk/python/airbyte_cdk/sources/message/repository.py
@@ -32,7 +32,9 @@ def _is_severe_enough(threshold: Level, level: Level):
         return True
 
     if level not in _SEVERITY_BY_LOG_LEVEL:
-        _LOGGER.warning(f"Log level {level} is not supported. This is probably a source bug. Please contact the owner of the source or Airbyte.")
+        _LOGGER.warning(
+            f"Log level {level} is not supported. This is probably a source bug. Please contact the owner of the source or Airbyte."
+        )
         return True
 
     return _SEVERITY_BY_LOG_LEVEL[threshold] >= _SEVERITY_BY_LOG_LEVEL[level]

--- a/airbyte-cdk/python/airbyte_cdk/sources/message/repository.py
+++ b/airbyte-cdk/python/airbyte_cdk/sources/message/repository.py
@@ -2,12 +2,30 @@
 # Copyright (c) 2023 Airbyte, Inc., all rights reserved.
 #
 
+import json
+
 from abc import ABC, abstractmethod
-from typing import Callable, Iterable
+from typing import Callable, Iterable, Union
 
 from airbyte_cdk.models import AirbyteLogMessage, AirbyteMessage, Level, Type
+from airbyte_cdk.utils.airbyte_secrets_utils import filter_secrets
 
 _SUPPORTED_MESSAGE_TYPES = {Type.CONTROL, Type.LOG}
+JsonType = Union[dict[str, "JsonType"], list["JsonType"], str, int, float, bool, None]
+LogMessage = dict[str, JsonType]
+
+_SEVERITY_BY_LOG_LEVEL = {
+    Level.FATAL: 1,
+    Level.ERROR: 2,
+    Level.WARN: 3,
+    Level.INFO: 4,
+    Level.DEBUG: 5,
+    Level.TRACE: 5,
+}
+
+
+def _is_severe_enough(threshold: Level, level: Level):
+    return _SEVERITY_BY_LOG_LEVEL[threshold] >= _SEVERITY_BY_LOG_LEVEL[level]
 
 
 class MessageRepository(ABC):
@@ -16,7 +34,7 @@ class MessageRepository(ABC):
         raise NotImplementedError()
 
     @abstractmethod
-    def log_message(self, level: Level, message_provider: Callable[[], AirbyteMessage]) -> None:
+    def log_message(self, level: Level, message_provider: Callable[[], LogMessage]) -> None:
         """
         Computing messages can be resource consuming. This method is specialized for logging because we want to allow for lazy evaluation if
         the log level is less severe than what is configured
@@ -32,7 +50,7 @@ class NoopMessageRepository(MessageRepository):
     def emit_message(self, message: AirbyteMessage) -> None:
         pass
 
-    def log_message(self, level: Level, message_provider: Callable[[], AirbyteMessage]) -> None:
+    def log_message(self, level: Level, message_provider: Callable[[], LogMessage]) -> None:
         pass
 
     def consume_queue(self) -> Iterable[AirbyteMessage]:
@@ -40,15 +58,6 @@ class NoopMessageRepository(MessageRepository):
 
 
 class InMemoryMessageRepository(MessageRepository):
-    _SEVERITY_BY_LOG_LEVEL = {
-        Level.FATAL: 1,
-        Level.ERROR: 2,
-        Level.WARN: 3,
-        Level.INFO: 4,
-        Level.DEBUG: 5,
-        Level.TRACE: 5,
-    }
-
     def __init__(self, log_level=Level.INFO):
         self._message_queue = []
         self._log_level = log_level
@@ -62,10 +71,46 @@ class InMemoryMessageRepository(MessageRepository):
             raise ValueError(f"As of today, only {_SUPPORTED_MESSAGE_TYPES} are supported as part of the InMemoryMessageRepository")
         self._message_queue.append(message)
 
-    def log_message(self, level: Level, message_provider: Callable[[], AirbyteMessage]) -> None:
-        if self._SEVERITY_BY_LOG_LEVEL[self._log_level] >= self._SEVERITY_BY_LOG_LEVEL[level]:
-            self.emit_message(AirbyteMessage(type=Type.LOG, log=AirbyteLogMessage(level=level, message=message_provider())))
+    def log_message(self, level: Level, message_provider: Callable[[], LogMessage]) -> None:
+        if _is_severe_enough(self._log_level, level):
+            self.emit_message(AirbyteMessage(type=Type.LOG, log=AirbyteLogMessage(level=level, message=filter_secrets(json.dumps(message_provider())))))
 
     def consume_queue(self) -> Iterable[AirbyteMessage]:
         while self._message_queue:
             yield self._message_queue.pop(0)
+
+
+class LogAppenderMessageRepositoryDecorator(MessageRepository):
+    def __init__(self, dict_to_append: LogMessage, decorated: MessageRepository, log_level=Level.INFO):
+        self._dict_to_append = dict_to_append
+        self._decorated = decorated
+        self._log_level = log_level
+
+    def emit_message(self, message: AirbyteMessage) -> None:
+        self._decorated.emit_message(message)
+
+    def log_message(self, level: Level, message_provider: Callable[[], LogMessage]) -> None:
+        if _is_severe_enough(self._log_level, level):
+            message = message_provider()
+            self._append_second_to_first(message, self._dict_to_append)
+            self._decorated.log_message(level, lambda: message)
+
+    def consume_queue(self) -> Iterable[AirbyteMessage]:
+        # FIXME return or yield from?
+        yield from self._decorated.consume_queue()
+
+    def _append_second_to_first(self, first, second, path=None):
+        if path is None:
+            path = []
+
+        for key in second:
+            if key in first:
+                if isinstance(first[key], dict) and isinstance(second[key], dict):
+                    self._append_second_to_first(first[key], second[key], path + [str(key)])
+                elif first[key] == second[key]:
+                    pass
+                else:
+                    raise Exception('Conflict at %s' % '.'.join(path + [str(key)]))
+            else:
+                first[key] = second[key]
+        return first

--- a/airbyte-cdk/python/airbyte_cdk/sources/streams/http/requests_native_auth/abstract_oauth.py
+++ b/airbyte-cdk/python/airbyte_cdk/sources/streams/http/requests_native_auth/abstract_oauth.py
@@ -10,7 +10,7 @@ import backoff
 import pendulum
 import requests
 from airbyte_cdk.models import Level
-from airbyte_cdk.sources.http_logger import format_http_json
+from airbyte_cdk.sources.http_logger import format_http_message
 from airbyte_cdk.sources.message import MessageRepository, NoopMessageRepository
 from requests.auth import AuthBase
 
@@ -167,4 +167,4 @@ class AbstractOauth2Authenticator(AuthBase):
         return _NOOP_MESSAGE_REPOSITORY
 
     def _log_response(self, response: requests.Response):
-        self._message_repository.log_message(Level.DEBUG, lambda: format_http_json(response, self._NO_STREAM_NAME))
+        self._message_repository.log_message(Level.DEBUG, lambda: format_http_message(response, self._NO_STREAM_NAME))

--- a/airbyte-cdk/python/airbyte_cdk/sources/streams/http/requests_native_auth/abstract_oauth.py
+++ b/airbyte-cdk/python/airbyte_cdk/sources/streams/http/requests_native_auth/abstract_oauth.py
@@ -174,5 +174,6 @@ class AbstractOauth2Authenticator(AuthBase):
                 "Refresh token",
                 "Obtains access token",
                 self._NO_STREAM_NAME,
+                is_auxiliary=True,
             ),
         )

--- a/airbyte-cdk/python/airbyte_cdk/sources/streams/http/requests_native_auth/abstract_oauth.py
+++ b/airbyte-cdk/python/airbyte_cdk/sources/streams/http/requests_native_auth/abstract_oauth.py
@@ -27,7 +27,7 @@ class AbstractOauth2Authenticator(AuthBase):
     delegating that behavior to the classes implementing the interface.
     """
 
-    LOGGER_NAME = "AbstractOauth2Authenticator"
+    _NO_STREAM_NAME = None
 
     def __call__(self, request: requests.Request) -> requests.Request:
         """Attach the HTTP headers required to authenticate on the HTTP request"""
@@ -167,4 +167,4 @@ class AbstractOauth2Authenticator(AuthBase):
         return _NOOP_MESSAGE_REPOSITORY
 
     def _log_response(self, response: requests.Response):
-        self._message_repository.log_message(Level.DEBUG, lambda: format_http_json(response, self.LOGGER_NAME))
+        self._message_repository.log_message(Level.DEBUG, lambda: format_http_json(response, self._NO_STREAM_NAME))

--- a/airbyte-cdk/python/airbyte_cdk/sources/streams/http/requests_native_auth/abstract_oauth.py
+++ b/airbyte-cdk/python/airbyte_cdk/sources/streams/http/requests_native_auth/abstract_oauth.py
@@ -167,4 +167,12 @@ class AbstractOauth2Authenticator(AuthBase):
         return _NOOP_MESSAGE_REPOSITORY
 
     def _log_response(self, response: requests.Response):
-        self._message_repository.log_message(Level.DEBUG, lambda: format_http_message(response, self._NO_STREAM_NAME))
+        self._message_repository.log_message(
+            Level.DEBUG,
+            lambda: format_http_message(
+                response,
+                "Refresh token",
+                "Obtains access token",
+                self._NO_STREAM_NAME,
+            ),
+        )

--- a/airbyte-cdk/python/unit_tests/connector_builder/test_connector_builder_handler.py
+++ b/airbyte-cdk/python/unit_tests/connector_builder/test_connector_builder_handler.py
@@ -422,7 +422,7 @@ def test_read():
                 state=None,
             )
         ],
-        global_requests=[],
+        auxiliary_requests=[],
         test_read_limit_reached=False,
         inferred_schema=None,
         inferred_datetime_formats=None,
@@ -439,7 +439,7 @@ def test_read():
                     {"pages": [{"records": [real_record], "request": None, "response": None}], "slice_descriptor": None, "state": None}
                 ],
                 "test_read_limit_reached": False,
-                "global_requests": [],
+                "auxiliary_requests": [],
                 "inferred_schema": None,
                 "inferred_datetime_formats": None,
                 "latest_config_update": {}
@@ -514,7 +514,7 @@ def test_read_returns_error_response(mock_from_exception):
                                           pages=[StreamReadPages(records=[], request=None, response=None)],
                                           slice_descriptor=None, state=None)],
                                       test_read_limit_reached=False,
-                                      global_requests=[],
+                                      auxiliary_requests=[],
                                       inferred_schema=None,
                                       inferred_datetime_formats={},
                                       latest_config_update=None)

--- a/airbyte-cdk/python/unit_tests/connector_builder/test_message_grouper.py
+++ b/airbyte-cdk/python/unit_tests/connector_builder/test_message_grouper.py
@@ -586,11 +586,11 @@ def test_given_multiple_control_messages_with_same_timestamp_then_stream_read_ha
 
 
 @patch('airbyte_cdk.connector_builder.message_grouper.AirbyteEntrypoint.read')
-def test_given_global_requests_then_return_global_request(mock_entrypoint_read):
+def test_given_auxiliary_requests_then_return_global_request(mock_entrypoint_read):
     mock_source = make_mock_source(mock_entrypoint_read, iter(
         any_request_and_response_with_a_record() +
         [
-            global_request_log_message()
+            auxiliary_request_log_message()
         ]
     ))
     connector_builder_handler = MessageGrouper(MAX_PAGES_PER_SLICE, MAX_SLICES)
@@ -598,7 +598,7 @@ def test_given_global_requests_then_return_global_request(mock_entrypoint_read):
         source=mock_source, config=CONFIG, configured_catalog=create_configured_catalog("hashiras")
     )
 
-    assert len(stream_read.global_requests) == 1
+    assert len(stream_read.auxiliary_requests) == 1
 
 
 def make_mock_source(mock_entrypoint_read, return_value: Iterator) -> MagicMock:
@@ -634,10 +634,10 @@ def connector_configuration_control_message(emitted_at: float, config: dict) -> 
     )
 
 
-def global_request_log_message():
+def auxiliary_request_log_message():
     return AirbyteMessage(type=MessageType.LOG, log=AirbyteLogMessage(level=Level.INFO, message=json.dumps({
-            "airbyte_cdk": {"stream": {"is_substream": True}},
             "http": {
+                "is_auxiliary": True,
                 "title": "a title",
                 "description": "a description",
                 "request": {},

--- a/airbyte-cdk/python/unit_tests/connector_builder/test_message_grouper.py
+++ b/airbyte-cdk/python/unit_tests/connector_builder/test_message_grouper.py
@@ -638,6 +638,8 @@ def global_request_log_message():
     return AirbyteMessage(type=MessageType.LOG, log=AirbyteLogMessage(level=Level.INFO, message=json.dumps({
             "airbyte_cdk": {"stream": {"is_substream": True}},
             "http": {
+                "title": "a title",
+                "description": "a description",
                 "request": {},
                 "response": {},
             },
@@ -649,6 +651,8 @@ def request_response_log_message(request: dict, response: dict, url: str):
     return AirbyteMessage(type=MessageType.LOG, log=AirbyteLogMessage(level=Level.INFO, message=json.dumps({
             "airbyte_cdk": {"stream": {"name": "a stream name"}},
             "http": {
+                "title": "a title",
+                "description": "a description",
                 "request": request,
                 "response": response
             },

--- a/airbyte-cdk/python/unit_tests/connector_builder/test_message_grouper.py
+++ b/airbyte-cdk/python/unit_tests/connector_builder/test_message_grouper.py
@@ -19,7 +19,6 @@ from airbyte_cdk.models import (
     OrchestratorType,
 )
 from airbyte_cdk.models import Type as MessageType
-from airbyte_cdk.sources.declarative.retrievers import SimpleRetriever
 from unit_tests.connector_builder.utils import create_configured_catalog
 
 MAX_PAGES_PER_SLICE = 4
@@ -96,7 +95,7 @@ def test_get_grouped_messages(mock_entrypoint_read):
     }
     response = {"status_code": 200, "headers": {"field": "value"}, "body": {"content": '{"name": "field"}'}}
     expected_schema = {"$schema": "http://json-schema.org/schema#", "properties": {"name": {"type": "string"}, "date": {"type": "string"}}, "type": "object"}
-    expected_datetime_fields = {"date":"%Y-%m-%d"}
+    expected_datetime_fields = {"date": "%Y-%m-%d"}
     expected_pages = [
         StreamReadPages(
             request=HttpRequest(
@@ -637,7 +636,7 @@ def connector_configuration_control_message(emitted_at: float, config: dict) -> 
 
 def global_request_log_message():
     return AirbyteMessage(type=MessageType.LOG, log=AirbyteLogMessage(level=Level.INFO, message=json.dumps({
-            "log": {"logger": "a logger"},
+            "airbyte_cdk": {"stream": {"is_substream": True}},
             "http": {
                 "request": {},
                 "response": {},
@@ -648,7 +647,7 @@ def global_request_log_message():
 
 def request_response_log_message(request: dict, response: dict, url: str):
     return AirbyteMessage(type=MessageType.LOG, log=AirbyteLogMessage(level=Level.INFO, message=json.dumps({
-            "log": {"logger": SimpleRetriever.LOGGER_NAME},
+            "airbyte_cdk": {"stream": {"name": "a stream name"}},
             "http": {
                 "request": request,
                 "response": response

--- a/airbyte-cdk/python/unit_tests/sources/message/test_repository.py
+++ b/airbyte-cdk/python/unit_tests/sources/message/test_repository.py
@@ -117,10 +117,10 @@ class TestLogAppenderMessageRepositoryDecorator:
             }
         }
 
-    def test_given_value_clash_when_log_message_then_raise_error(self, decorated):
+    def test_given_value_clash_when_log_message_then_overwrite_value(self, decorated):
         repo = LogAppenderMessageRepositoryDecorator({"clash": "appended value"}, decorated, Level.DEBUG)
-        with pytest.raises(ValueError):
-            repo.log_message(Level.INFO, lambda: {"clash": "original value"})
+        repo.log_message(Level.INFO, lambda: {"clash": "original value"})
+        assert decorated.log_message.call_args_list[0].args[1]() == {"clash": "appended value"}
 
     def test_given_log_level_is_severe_enough_when_log_message_then_allow_message_to_be_consumed(self, decorated):
         repo = LogAppenderMessageRepositoryDecorator(self._DICT_TO_APPEND, decorated, Level.DEBUG)

--- a/airbyte-cdk/python/unit_tests/sources/message/test_repository.py
+++ b/airbyte-cdk/python/unit_tests/sources/message/test_repository.py
@@ -2,6 +2,8 @@
 # Copyright (c) 2023 Airbyte, Inc., all rights reserved.
 #
 
+from unittest.mock import Mock
+
 import pytest
 from airbyte_cdk.models import (
     AirbyteControlConnectorConfigMessage,
@@ -12,13 +14,23 @@ from airbyte_cdk.models import (
     OrchestratorType,
     Type,
 )
-from airbyte_cdk.sources.message import InMemoryMessageRepository
+from airbyte_cdk.sources.message import (
+    InMemoryMessageRepository,
+    LogAppenderMessageRepositoryDecorator,
+    MessageRepository,
+    NoopMessageRepository,
+)
 
 A_CONTROL = AirbyteControlMessage(
     type=OrchestratorType.CONNECTOR_CONFIG,
     emitted_at=0,
     connectorConfig=AirbyteControlConnectorConfigMessage(config={"a config": "value"}),
 )
+ANY_MESSAGE = AirbyteMessage(type=Type.CONTROL, control=AirbyteControlMessage(
+    type=OrchestratorType.CONNECTOR_CONFIG,
+    emitted_at=0,
+    connectorConfig=AirbyteControlConnectorConfigMessage(config={"any message": "value"}),
+))
 ANOTHER_CONTROL = AirbyteControlMessage(
     type=OrchestratorType.CONNECTOR_CONFIG,
     emitted_at=0,
@@ -26,52 +38,105 @@ ANOTHER_CONTROL = AirbyteControlMessage(
 )
 
 
-def test_given_no_messages_when_consume_queue_then_return_empty():
-    repo = InMemoryMessageRepository()
-    messages = list(repo.consume_queue())
-    assert messages == []
+class TestInMemoryMessageRepository:
+    def test_given_no_messages_when_consume_queue_then_return_empty(self):
+        repo = InMemoryMessageRepository()
+        messages = list(repo.consume_queue())
+        assert messages == []
+
+    def test_given_messages_when_consume_queue_then_return_messages(self):
+        repo = InMemoryMessageRepository()
+        first_message = AirbyteMessage(type=Type.CONTROL, control=A_CONTROL)
+        repo.emit_message(first_message)
+        second_message = AirbyteMessage(type=Type.CONTROL, control=ANOTHER_CONTROL)
+        repo.emit_message(second_message)
+
+        messages = repo.consume_queue()
+
+        assert list(messages) == [first_message, second_message]
+
+    def test_given_message_is_consumed_when_consume_queue_then_remove_message_from_queue(self):
+        repo = InMemoryMessageRepository()
+        first_message = AirbyteMessage(type=Type.CONTROL, control=A_CONTROL)
+        repo.emit_message(first_message)
+        second_message = AirbyteMessage(type=Type.CONTROL, control=ANOTHER_CONTROL)
+        repo.emit_message(second_message)
+
+        message_generator = repo.consume_queue()
+        consumed_message = next(message_generator)
+        assert consumed_message == first_message
+
+        second_message_generator = repo.consume_queue()
+        assert list(second_message_generator) == [second_message]
+
+    def test_given_message_is_not_control_nor_log_message_when_emit_message_then_raise_error(self):
+        repo = InMemoryMessageRepository()
+        with pytest.raises(ValueError):
+            repo.emit_message(AirbyteMessage(type=Type.STATE, state=AirbyteStateMessage(data={"state": "state value"})))
+
+    def test_given_log_level_is_severe_enough_when_log_message_then_allow_message_to_be_consumed(self):
+        repo = InMemoryMessageRepository(Level.DEBUG)
+        repo.log_message(Level.INFO, lambda: "this is a log message")
+        assert list(repo.consume_queue())
+
+    def test_given_log_level_not_severe_enough_when_log_message_then_do_not_allow_message_to_be_consumed(self):
+        repo = InMemoryMessageRepository(Level.ERROR)
+        repo.log_message(Level.INFO, lambda: "this is a log message")
+        assert not list(repo.consume_queue())
 
 
-def test_given_messages_when_consume_queue_then_return_messages():
-    repo = InMemoryMessageRepository()
-    first_message = AirbyteMessage(type=Type.CONTROL, control=A_CONTROL)
-    repo.emit_message(first_message)
-    second_message = AirbyteMessage(type=Type.CONTROL, control=ANOTHER_CONTROL)
-    repo.emit_message(second_message)
+class TestNoopMessageRepository:
+    def test_given_message_emitted_when_consume_queue_then_return_empty(self):
+        repo = NoopMessageRepository()
+        repo.emit_message(AirbyteMessage(type=Type.CONTROL, control=A_CONTROL))
+        repo.log_message(Level.INFO, lambda: "this is a log message")
 
-    messages = repo.consume_queue()
-
-    assert list(messages) == [first_message, second_message]
+        assert not list(repo.consume_queue())
 
 
-def test_given_message_is_consumed_when_consume_queue_then_remove_message_from_queue():
-    repo = InMemoryMessageRepository()
-    first_message = AirbyteMessage(type=Type.CONTROL, control=A_CONTROL)
-    repo.emit_message(first_message)
-    second_message = AirbyteMessage(type=Type.CONTROL, control=ANOTHER_CONTROL)
-    repo.emit_message(second_message)
+class TestLogAppenderMessageRepositoryDecorator:
 
-    message_generator = repo.consume_queue()
-    consumed_message = next(message_generator)
-    assert consumed_message == first_message
+    _DICT_TO_APPEND = {"airbyte_cdk": {"stream": {"is_substream": False}}}
 
-    second_message_generator = repo.consume_queue()
-    assert list(second_message_generator) == [second_message]
+    @pytest.fixture()
+    def decorated(self):
+        return Mock(spec=MessageRepository)
 
+    def test_when_emit_message_then_delegate_call(self, decorated):
+        repo = LogAppenderMessageRepositoryDecorator(self._DICT_TO_APPEND, decorated, Level.DEBUG)
+        repo.emit_message(ANY_MESSAGE)
+        decorated.emit_message.assert_called_once_with(ANY_MESSAGE)
 
-def test_given_message_is_not_control_nor_log_message_when_emit_message_then_raise_error():
-    repo = InMemoryMessageRepository()
-    with pytest.raises(ValueError):
-        repo.emit_message(AirbyteMessage(type=Type.STATE, state=AirbyteStateMessage(data={"state": "state value"})))
+    def test_when_log_message_then_append(self, decorated):
+        repo = LogAppenderMessageRepositoryDecorator({"a": {"dict_to_append": "appended value"}}, decorated, Level.DEBUG)
+        repo.log_message(Level.INFO, lambda: {"a": {"original": "original value"}})
+        assert decorated.log_message.call_args_list[0].args[1]() == {
+            "a": {
+                "dict_to_append": "appended value",
+                "original": "original value"
+            }
+        }
 
+    def test_given_value_clash_when_log_message_then_raise_error(self, decorated):
+        repo = LogAppenderMessageRepositoryDecorator({"clash": "appended value"}, decorated, Level.DEBUG)
+        with pytest.raises(ValueError):
+            repo.log_message(Level.INFO, lambda: {"clash": "original value"})
 
-def test_given_log_level_is_severe_enough_when_log_message_then_allow_message_to_be_consumed():
-    repo = InMemoryMessageRepository(Level.DEBUG)
-    repo.log_message(Level.INFO, lambda: "this is a log message")
-    assert list(repo.consume_queue())
+    def test_given_log_level_is_severe_enough_when_log_message_then_allow_message_to_be_consumed(self, decorated):
+        repo = LogAppenderMessageRepositoryDecorator(self._DICT_TO_APPEND, decorated, Level.DEBUG)
+        repo.log_message(Level.INFO, lambda: {})
+        assert decorated.log_message.call_count == 1
 
+    def test_given_log_level_not_severe_enough_when_log_message_then_do_not_allow_message_to_be_consumed(self, decorated):
+        repo = LogAppenderMessageRepositoryDecorator(self._DICT_TO_APPEND, decorated, Level.ERROR)
+        repo.log_message(Level.INFO, lambda: {})
+        assert decorated.log_message.call_count == 0
 
-def test_given_log_level_not_severe_enough_when_log_message_then_do_not_allow_message_to_be_consumed():
-    repo = InMemoryMessageRepository(Level.ERROR)
-    repo.log_message(Level.INFO, lambda: "this is a log message")
-    assert not list(repo.consume_queue())
+    def test_when_consume_queue_then_return_delegate_queue(self, decorated):
+        repo = LogAppenderMessageRepositoryDecorator(self._DICT_TO_APPEND, decorated, Level.DEBUG)
+        queue = [ANY_MESSAGE, ANY_MESSAGE, ANY_MESSAGE]
+        decorated.consume_queue.return_value = iter(queue)
+
+        result = list(repo.consume_queue())
+
+        assert result == queue

--- a/airbyte-cdk/python/unit_tests/sources/message/test_repository.py
+++ b/airbyte-cdk/python/unit_tests/sources/message/test_repository.py
@@ -2,7 +2,6 @@
 # Copyright (c) 2023 Airbyte, Inc., all rights reserved.
 #
 
-from pydantic.error_wrappers import ValidationError
 from unittest.mock import Mock
 
 import pytest
@@ -21,6 +20,7 @@ from airbyte_cdk.sources.message import (
     MessageRepository,
     NoopMessageRepository,
 )
+from pydantic.error_wrappers import ValidationError
 
 A_CONTROL = AirbyteControlMessage(
     type=OrchestratorType.CONNECTOR_CONFIG,

--- a/airbyte-cdk/python/unit_tests/sources/streams/http/requests_native_auth/test_requests_native_auth.py
+++ b/airbyte-cdk/python/unit_tests/sources/streams/http/requests_native_auth/test_requests_native_auth.py
@@ -306,7 +306,7 @@ class TestSingleUseRefreshTokenOauth2Authenticator:
             message_repository=message_repository,
         )
         mocker.patch("airbyte_cdk.sources.streams.http.requests_native_auth.abstract_oauth.requests.request")
-        mocker.patch("airbyte_cdk.sources.streams.http.requests_native_auth.abstract_oauth.format_http_json", return_value="formatted json")
+        mocker.patch("airbyte_cdk.sources.streams.http.requests_native_auth.abstract_oauth.format_http_message", return_value="formatted json")
         authenticator.token_has_expired = mocker.Mock(return_value=True)
 
         authenticator.get_access_token()

--- a/airbyte-cdk/python/unit_tests/sources/test_http_logger.py
+++ b/airbyte-cdk/python/unit_tests/sources/test_http_logger.py
@@ -6,6 +6,8 @@ import pytest
 import requests
 from airbyte_cdk.sources.http_logger import format_http_message
 
+A_TITLE = "a title"
+A_DESCRIPTION = "a description"
 A_STREAM_NAME = "a stream name"
 ANY_REQUEST = requests.Request(method="POST", url="http://a-url.com", headers={}, params={}).prepare()
 
@@ -56,7 +58,7 @@ EMPTY_RESPONSE = {"body": {"content": ""}, "headers": {}, "status_code": 100}
             {},
             {},
             {},
-            {"airbyte_cdk": {"stream": {"name": A_STREAM_NAME}}, "http": {"request": {"method": "GET", "body": {"content": None}, "headers": {}}, "response": EMPTY_RESPONSE}, "log": {"level": "debug"}, "url": {"full": "https://airbyte.io/"}},
+            {"airbyte_cdk": {"stream": {"name": A_STREAM_NAME}}, "http": {"title": A_TITLE, "description": A_DESCRIPTION, "request": {"method": "GET", "body": {"content": None}, "headers": {}}, "response": EMPTY_RESPONSE}, "log": {"level": "debug"}, "url": {"full": "https://airbyte.io/"}},
         ),
         (
             "test_get_request_with_headers",
@@ -66,7 +68,7 @@ EMPTY_RESPONSE = {"body": {"content": ""}, "headers": {}, "status_code": 100}
             {},
             {},
             {},
-            {"airbyte_cdk": {"stream": {"name": A_STREAM_NAME}}, "http": {"request": {"method": "GET", "body": {"content": None}, "headers": {"h1": "v1", "h2": "v2"}}, "response": EMPTY_RESPONSE}, "log": {"level": "debug"}, "url": {"full": "https://airbyte.io/"}},
+            {"airbyte_cdk": {"stream": {"name": A_STREAM_NAME}}, "http": {"title": A_TITLE, "description": A_DESCRIPTION, "request": {"method": "GET", "body": {"content": None}, "headers": {"h1": "v1", "h2": "v2"}}, "response": EMPTY_RESPONSE}, "log": {"level": "debug"}, "url": {"full": "https://airbyte.io/"}},
         ),
         (
             "test_get_request_with_request_params",
@@ -76,7 +78,7 @@ EMPTY_RESPONSE = {"body": {"content": ""}, "headers": {}, "status_code": 100}
             {"p1": "v1", "p2": "v2"},
             {},
             {},
-            {"airbyte_cdk": {"stream": {"name": A_STREAM_NAME}}, "http": {"request": {"method": "GET", "body": {"content": None}, "headers": {}}, "response": EMPTY_RESPONSE}, "log": {"level": "debug"}, "url": {"full": "https://airbyte.io/?p1=v1&p2=v2"}},
+            {"airbyte_cdk": {"stream": {"name": A_STREAM_NAME}}, "http": {"title": A_TITLE, "description": A_DESCRIPTION, "request": {"method": "GET", "body": {"content": None}, "headers": {}}, "response": EMPTY_RESPONSE}, "log": {"level": "debug"}, "url": {"full": "https://airbyte.io/?p1=v1&p2=v2"}},
         ),
         (
             "test_get_request_with_request_body_json",
@@ -86,7 +88,7 @@ EMPTY_RESPONSE = {"body": {"content": ""}, "headers": {}, "status_code": 100}
             {},
             {"b1": "v1", "b2": "v2"},
             {},
-            {"airbyte_cdk": {"stream": {"name": A_STREAM_NAME}}, "http": {"request": {"method": "GET", "body": {"content": '{"b1": "v1", "b2": "v2"}'}, "headers": {"Content-Type": "application/json", "Content-Length": "24"}}, "response": EMPTY_RESPONSE}, "log": {"level": "debug"}, "url": {"full": "https://airbyte.io/"}}
+            {"airbyte_cdk": {"stream": {"name": A_STREAM_NAME}}, "http": {"title": A_TITLE, "description": A_DESCRIPTION, "request": {"method": "GET", "body": {"content": '{"b1": "v1", "b2": "v2"}'}, "headers": {"Content-Type": "application/json", "Content-Length": "24"}}, "response": EMPTY_RESPONSE}, "log": {"level": "debug"}, "url": {"full": "https://airbyte.io/"}}
         ),
         (
             "test_get_request_with_headers_params_and_body",
@@ -96,7 +98,7 @@ EMPTY_RESPONSE = {"body": {"content": ""}, "headers": {}, "status_code": 100}
             {"p1": "v1", "p2": "v2"},
             {"b1": "v1", "b2": "v2"},
             {},
-            {"airbyte_cdk": {"stream": {"name": A_STREAM_NAME}}, "http": {"request": {"method": "GET", "body": {"content": '{"b1": "v1", "b2": "v2"}'}, "headers": {"Content-Type": "application/json", "Content-Length": "24", "h1": "v1"}}, "response": EMPTY_RESPONSE}, "log": {"level": "debug"}, "url": {"full": "https://airbyte.io/?p1=v1&p2=v2"}},
+            {"airbyte_cdk": {"stream": {"name": A_STREAM_NAME}}, "http": {"title": A_TITLE, "description": A_DESCRIPTION, "request": {"method": "GET", "body": {"content": '{"b1": "v1", "b2": "v2"}'}, "headers": {"Content-Type": "application/json", "Content-Length": "24", "h1": "v1"}}, "response": EMPTY_RESPONSE}, "log": {"level": "debug"}, "url": {"full": "https://airbyte.io/?p1=v1&p2=v2"}},
         ),
         (
             "test_get_request_with_request_body_data",
@@ -106,7 +108,7 @@ EMPTY_RESPONSE = {"body": {"content": ""}, "headers": {}, "status_code": 100}
             {},
             {},
             {"b1": "v1", "b2": "v2"},
-            {"airbyte_cdk": {"stream": {"name": A_STREAM_NAME}}, "http": {"request": {"method": "GET", "body": {"content": "b1=v1&b2=v2"}, "headers": {"Content-Type": "application/x-www-form-urlencoded", "Content-Length": "11"}}, "response": EMPTY_RESPONSE}, "log": {"level": "debug"}, "url": {"full": "https://airbyte.io/"}},
+            {"airbyte_cdk": {"stream": {"name": A_STREAM_NAME}}, "http": {"title": A_TITLE, "description": A_DESCRIPTION, "request": {"method": "GET", "body": {"content": "b1=v1&b2=v2"}, "headers": {"Content-Type": "application/x-www-form-urlencoded", "Content-Length": "11"}}, "response": EMPTY_RESPONSE}, "log": {"level": "debug"}, "url": {"full": "https://airbyte.io/"}},
         ),
         (
             "test_basic_post_request",
@@ -116,7 +118,7 @@ EMPTY_RESPONSE = {"body": {"content": ""}, "headers": {}, "status_code": 100}
             {},
             {},
             {},
-            {"airbyte_cdk": {"stream": {"name": A_STREAM_NAME}}, "http": {"request": {"method": "POST", "body": {"content": None}, "headers": {"Content-Length": "0"}}, "response": EMPTY_RESPONSE}, "log": {"level": "debug"}, "url": {"full": "https://airbyte.io/"}}
+            {"airbyte_cdk": {"stream": {"name": A_STREAM_NAME}}, "http": {"title": A_TITLE, "description": A_DESCRIPTION, "request": {"method": "POST", "body": {"content": None}, "headers": {"Content-Length": "0"}}, "response": EMPTY_RESPONSE}, "log": {"level": "debug"}, "url": {"full": "https://airbyte.io/"}}
         ),
     ],
 )
@@ -128,7 +130,7 @@ def test_prepared_request_to_airbyte_message(test_name, http_method, url, header
         request.data = body_data
     prepared_request = request.prepare()
 
-    actual_airbyte_message = format_http_message(ResponseBuilder().request(prepared_request).build(), A_STREAM_NAME)
+    actual_airbyte_message = format_http_message(ResponseBuilder().request(prepared_request).build(), A_TITLE, A_DESCRIPTION, A_STREAM_NAME)
 
     assert actual_airbyte_message == expected_airbyte_message
 
@@ -169,6 +171,6 @@ def test_prepared_request_to_airbyte_message(test_name, http_method, url, header
 def test_response_to_airbyte_message(test_name, response_body, response_headers, status_code, expected_airbyte_message):
     response = ResponseBuilder().body_content(response_body).headers(response_headers).status_code(status_code).build()
 
-    actual_airbyte_message = format_http_message(response, A_STREAM_NAME)
+    actual_airbyte_message = format_http_message(response, A_TITLE, A_DESCRIPTION, A_STREAM_NAME)
 
     assert actual_airbyte_message["http"]["response"] == expected_airbyte_message

--- a/airbyte-cdk/python/unit_tests/sources/test_http_logger.py
+++ b/airbyte-cdk/python/unit_tests/sources/test_http_logger.py
@@ -2,13 +2,11 @@
 # Copyright (c) 2023 Airbyte, Inc., all rights reserved.
 #
 
-import json
-
 import pytest
 import requests
-from airbyte_cdk.sources.http_logger import format_http_json
+from airbyte_cdk.sources.http_logger import format_http_message
 
-A_LOGGER = "a logger"
+A_STREAM_NAME = "a stream name"
 ANY_REQUEST = requests.Request(method="POST", url="http://a-url.com", headers={}, params={}).prepare()
 
 
@@ -58,7 +56,7 @@ EMPTY_RESPONSE = {"body": {"content": ""}, "headers": {}, "status_code": 100}
             {},
             {},
             {},
-            {"http": {"request": {"method": "GET", "body": {"content": None}, "headers": {}}, "response": EMPTY_RESPONSE}, "log": {"logger": A_LOGGER, "level": "debug"}, "url": {"full": "https://airbyte.io/"}},
+            {"airbyte_cdk": {"stream": {"name": A_STREAM_NAME}}, "http": {"request": {"method": "GET", "body": {"content": None}, "headers": {}}, "response": EMPTY_RESPONSE}, "log": {"level": "debug"}, "url": {"full": "https://airbyte.io/"}},
         ),
         (
             "test_get_request_with_headers",
@@ -68,7 +66,7 @@ EMPTY_RESPONSE = {"body": {"content": ""}, "headers": {}, "status_code": 100}
             {},
             {},
             {},
-            {"http": {"request": {"method": "GET", "body": {"content": None}, "headers": {"h1": "v1", "h2": "v2"}}, "response": EMPTY_RESPONSE}, "log": {"logger": A_LOGGER, "level": "debug"}, "url": {"full": "https://airbyte.io/"}},
+            {"airbyte_cdk": {"stream": {"name": A_STREAM_NAME}}, "http": {"request": {"method": "GET", "body": {"content": None}, "headers": {"h1": "v1", "h2": "v2"}}, "response": EMPTY_RESPONSE}, "log": {"level": "debug"}, "url": {"full": "https://airbyte.io/"}},
         ),
         (
             "test_get_request_with_request_params",
@@ -78,7 +76,7 @@ EMPTY_RESPONSE = {"body": {"content": ""}, "headers": {}, "status_code": 100}
             {"p1": "v1", "p2": "v2"},
             {},
             {},
-            {"http": {"request": {"method": "GET", "body": {"content": None}, "headers": {}}, "response": EMPTY_RESPONSE}, "log": {"logger": A_LOGGER, "level": "debug"}, "url": {"full": "https://airbyte.io/?p1=v1&p2=v2"}},
+            {"airbyte_cdk": {"stream": {"name": A_STREAM_NAME}}, "http": {"request": {"method": "GET", "body": {"content": None}, "headers": {}}, "response": EMPTY_RESPONSE}, "log": {"level": "debug"}, "url": {"full": "https://airbyte.io/?p1=v1&p2=v2"}},
         ),
         (
             "test_get_request_with_request_body_json",
@@ -88,7 +86,7 @@ EMPTY_RESPONSE = {"body": {"content": ""}, "headers": {}, "status_code": 100}
             {},
             {"b1": "v1", "b2": "v2"},
             {},
-            {"http": {"request": {"method": "GET", "body": {"content": '{"b1": "v1", "b2": "v2"}'}, "headers": {"Content-Type": "application/json", "Content-Length": "24"}}, "response": EMPTY_RESPONSE}, "log": {"logger": A_LOGGER, "level": "debug"}, "url": {"full": "https://airbyte.io/"}}
+            {"airbyte_cdk": {"stream": {"name": A_STREAM_NAME}}, "http": {"request": {"method": "GET", "body": {"content": '{"b1": "v1", "b2": "v2"}'}, "headers": {"Content-Type": "application/json", "Content-Length": "24"}}, "response": EMPTY_RESPONSE}, "log": {"level": "debug"}, "url": {"full": "https://airbyte.io/"}}
         ),
         (
             "test_get_request_with_headers_params_and_body",
@@ -98,7 +96,7 @@ EMPTY_RESPONSE = {"body": {"content": ""}, "headers": {}, "status_code": 100}
             {"p1": "v1", "p2": "v2"},
             {"b1": "v1", "b2": "v2"},
             {},
-            {"http": {"request": {"method": "GET", "body": {"content": '{"b1": "v1", "b2": "v2"}'}, "headers": {"Content-Type": "application/json", "Content-Length": "24", "h1": "v1"}}, "response": EMPTY_RESPONSE}, "log": {"logger": A_LOGGER, "level": "debug"}, "url": {"full": "https://airbyte.io/?p1=v1&p2=v2"}},
+            {"airbyte_cdk": {"stream": {"name": A_STREAM_NAME}}, "http": {"request": {"method": "GET", "body": {"content": '{"b1": "v1", "b2": "v2"}'}, "headers": {"Content-Type": "application/json", "Content-Length": "24", "h1": "v1"}}, "response": EMPTY_RESPONSE}, "log": {"level": "debug"}, "url": {"full": "https://airbyte.io/?p1=v1&p2=v2"}},
         ),
         (
             "test_get_request_with_request_body_data",
@@ -108,7 +106,7 @@ EMPTY_RESPONSE = {"body": {"content": ""}, "headers": {}, "status_code": 100}
             {},
             {},
             {"b1": "v1", "b2": "v2"},
-            {"http": {"request": {"method": "GET", "body": {"content": "b1=v1&b2=v2"}, "headers": {"Content-Type": "application/x-www-form-urlencoded", "Content-Length": "11"}}, "response": EMPTY_RESPONSE}, "log": {"logger": A_LOGGER, "level": "debug"}, "url": {"full": "https://airbyte.io/"}},
+            {"airbyte_cdk": {"stream": {"name": A_STREAM_NAME}}, "http": {"request": {"method": "GET", "body": {"content": "b1=v1&b2=v2"}, "headers": {"Content-Type": "application/x-www-form-urlencoded", "Content-Length": "11"}}, "response": EMPTY_RESPONSE}, "log": {"level": "debug"}, "url": {"full": "https://airbyte.io/"}},
         ),
         (
             "test_basic_post_request",
@@ -118,7 +116,7 @@ EMPTY_RESPONSE = {"body": {"content": ""}, "headers": {}, "status_code": 100}
             {},
             {},
             {},
-            {"http": {"request": {"method": "POST", "body": {"content": None}, "headers": {"Content-Length": "0"}}, "response": EMPTY_RESPONSE}, "log": {"logger": A_LOGGER, "level": "debug"}, "url": {"full": "https://airbyte.io/"}}
+            {"airbyte_cdk": {"stream": {"name": A_STREAM_NAME}}, "http": {"request": {"method": "POST", "body": {"content": None}, "headers": {"Content-Length": "0"}}, "response": EMPTY_RESPONSE}, "log": {"level": "debug"}, "url": {"full": "https://airbyte.io/"}}
         ),
     ],
 )
@@ -130,7 +128,7 @@ def test_prepared_request_to_airbyte_message(test_name, http_method, url, header
         request.data = body_data
     prepared_request = request.prepare()
 
-    actual_airbyte_message = json.loads(format_http_json(ResponseBuilder().request(prepared_request).build(), A_LOGGER))
+    actual_airbyte_message = format_http_message(ResponseBuilder().request(prepared_request).build(), A_STREAM_NAME)
 
     assert actual_airbyte_message == expected_airbyte_message
 
@@ -171,6 +169,6 @@ def test_prepared_request_to_airbyte_message(test_name, http_method, url, header
 def test_response_to_airbyte_message(test_name, response_body, response_headers, status_code, expected_airbyte_message):
     response = ResponseBuilder().body_content(response_body).headers(response_headers).status_code(status_code).build()
 
-    actual_airbyte_message = json.loads(format_http_json(response, A_LOGGER))
+    actual_airbyte_message = format_http_message(response, A_STREAM_NAME)
 
     assert actual_airbyte_message["http"]["response"] == expected_airbyte_message


### PR DESCRIPTION
## What
Addresses https://github.com/airbytehq/airbyte/issues/21014 that targets specifically SubstreamPartitionRouter. 

~~Other solution: https://github.com/airbytehq/airbyte/pull/27989~~ rejected

This solution change how SimpleRetriever logs messages to use MessageRepository and we wrap MessageRepository to add information to the logs. In order to do this, we needed a wrapper around MessageRepository. 

### Benefits
* Remove logs from `read_records` and move it to MessageRepository.log_message
* We can enhance the logs without having to json parse (see https://github.com/airbytehq/airbyte/pull/27990/files#diff-fa683949c758fb9056f1525e9e429eb996c714450ce3b432861bca5a983b1957R95)

### Drawbacks
* It removes the ability for `ModelToComponentFactory` to have a global shared state for all the components creation (see https://github.com/airbytehq/airbyte/pull/27990/files#diff-bbfbb380b441567d8e40967c149ae0397e41357a213f05add6d3b72cf92a91fdR881). The other solution would be to add the argument `message_repository` to every single method which is annoying but allows `ModelToComponentFactory` to have a common state while using the wrapped MessageRepository where needed

