### PR TITLE
:tada: Source RD Station Marketing: migrated to advancedOAuth

### DIFF
--- a/airbyte-integrations/connectors/source-rd-station-marketing/Dockerfile
+++ b/airbyte-integrations/connectors/source-rd-station-marketing/Dockerfile
@@ -34,5 +34,5 @@ COPY source_rd_station_marketing ./source_rd_station_marketing
 ENV AIRBYTE_ENTRYPOINT "python /airbyte/integration_code/main.py"
 ENTRYPOINT ["python", "/airbyte/integration_code/main.py"]
 
-LABEL io.airbyte.version=0.1.1
+LABEL io.airbyte.version=0.1.2
 LABEL io.airbyte.name=airbyte/source-rd-station-marketing

--- a/airbyte-integrations/connectors/source-rd-station-marketing/metadata.yaml
+++ b/airbyte-integrations/connectors/source-rd-station-marketing/metadata.yaml
@@ -2,7 +2,7 @@ data:
   connectorSubtype: api
   connectorType: source
   definitionId: fb141f29-be2a-450b-a4f2-2cd203a00f84
-  dockerImageTag: 0.1.1
+  dockerImageTag: 0.1.2
   dockerRepository: airbyte/source-rd-station-marketing
   githubIssueLabel: source-rd-station-marketing
   icon: rdstation.svg

--- a/airbyte-integrations/connectors/source-rd-station-marketing/source_rd_station_marketing/spec.json
+++ b/airbyte-integrations/connectors/source-rd-station-marketing/source_rd_station_marketing/spec.json
@@ -54,12 +54,45 @@
     }
   },
   "supportsIncremental": true,
-  "authSpecification": {
-    "auth_type": "oauth2.0",
-    "oauth2Specification": {
-      "rootObject": ["authorization", 0],
-      "oauthFlowInitParameters": [["client_id"], ["client_secret"]],
-      "oauthFlowOutputParameters": [["refresh_token"]]
+  "advanced_auth": {
+    "auth_flow_type": "oauth2.0",
+    "oauth_config_specification": {
+      "complete_oauth_output_specification": {
+        "type": "object",
+        "additionalProperties": true,
+        "properties": {
+          "refresh_token": {
+            "type": "string",
+            "path_in_connector_config": ["authorization", "refresh_token"]
+          }
+        }
+      },
+      "complete_oauth_server_input_specification": {
+        "type": "object",
+        "additionalProperties": true,
+        "properties": {
+          "client_id": {
+            "type": "string"
+          },
+          "client_secret": {
+            "type": "string"
+          }
+        }
+      },
+      "complete_oauth_server_output_specification": {
+        "type": "object",
+        "additionalProperties": true,
+        "properties": {
+          "client_id": {
+            "type": "string",
+            "path_in_connector_config": ["authorization", "client_id"]
+          },
+          "client_secret": {
+            "type": "string",
+            "path_in_connector_config": ["authorization", "client_secret"]
+          }
+        }
+      }
     }
   }
 }

--- a/docs/integrations/sources/rd-station-marketing.md
+++ b/docs/integrations/sources/rd-station-marketing.md
@@ -39,7 +39,8 @@ Each endpoint has its own performance limitations, which also consider the accou
 
 ## Changelog
 
-| Version | Date       | Pull Request                                             | Subject                                                         |
-| :------ | :--------- | :------------------------------------------------------- | :-------------------------------------------------------------- |
-| 0.1.1   | 2022-11-01 | [18826](https://github.com/airbytehq/airbyte/pull/18826) | Fix stream analytics_conversions                                |
-| 0.1.0   | 2022-10-23 | [18348](https://github.com/airbytehq/airbyte/pull/18348) | Initial Release                                                 |
+| Version | Date       | Pull Request                                              | Subject                          |
+|:--------|:-----------|:----------------------------------------------------------|:---------------------------------|
+| 0.1.2   | 2022-07-06 | [28009](https://github.com/airbytehq/airbyte/pull/28009/) | Migrated to advancedOAuth        |
+| 0.1.1   | 2022-11-01 | [18826](https://github.com/airbytehq/airbyte/pull/18826)  | Fix stream analytics_conversions |
+| 0.1.0   | 2022-10-23 | [18348](https://github.com/airbytehq/airbyte/pull/18348)  | Initial Release                  |


### PR DESCRIPTION
## What
resolved: https://github.com/airbytehq/airbyte/issues/27974

## How
Removed deprecated authSpecification, switched to advanced_auth

## Note
Acceptance test are blocked by test creds. This connector is disabled on cloud, so this part of code was not used. So PR can be merged without passed tests ([slack thread](https://airbyte-globallogic.slack.com/archives/C02U9R3AF37/p1688643296648019?thread_ts=1688643023.947839&cid=C02U9R3AF37))