### PR TITLE
File-based CDK: handle user-input schema

### DIFF
--- a/airbyte-cdk/python/airbyte_cdk/sources/file_based/exceptions.py
+++ b/airbyte-cdk/python/airbyte_cdk/sources/file_based/exceptions.py
@@ -11,6 +11,9 @@ class FileBasedSourceError(Enum):
     GLOB_PARSE_ERROR = (
         "Error parsing glob pattern. Please refer to the glob pattern rules at https://facelessuser.github.io/wcmatch/glob/#split."
     )
+    ERROR_CASTING_VALUE = "Could not cast the value to the expected type."
+    ERROR_CASTING_VALUE_UNRECOGNIZED_TYPE = "Could not cast the value to the expected type because the type is not recognized. Valid types are null, array, boolean, integer, number, object, and string."
+    ERROR_DECODING_VALUE = "Expected a JSON-decodeable value but could not decode record."
     ERROR_LISTING_FILES = (
         "Error listing files. Please check the credentials provided in the config and verify that they provide permission to list files."
     )
@@ -18,14 +21,14 @@ class FileBasedSourceError(Enum):
         "Error opening file. Please check the credentials provided in the config and verify that they provide permission to read files."
     )
     ERROR_PARSING_RECORD = "Error parsing record. This could be due to a mismatch between the config's file type and the actual file type, or because the file or record is not parseable."
-    ERROR_PARSING_USER_PROVIDED_SCHEMA = "The provided schema could not be transformed into valid JSON Schema."  # TODO
+    ERROR_PARSING_USER_PROVIDED_SCHEMA = "The provided schema could not be transformed into valid JSON Schema."
     ERROR_VALIDATING_RECORD = "One or more records do not pass the schema validation policy. Please modify your input schema, or select a more lenient validation policy."
     STOP_SYNC_PER_SCHEMA_VALIDATION_POLICY = (
         "Stopping sync in accordance with the configured validation policy. Records in file did not conform to the schema."
     )
     NULL_VALUE_IN_SCHEMA = "Error during schema inference: no type was detected for key."
     UNRECOGNIZED_TYPE = "Error during schema inference: unrecognized type."
-    SCHEMA_INFERENCE_ERROR = "Error inferring schema for file. Is the file valid?"
+    SCHEMA_INFERENCE_ERROR = "Error inferring schema from files. Are the files valid?"
     INVALID_SCHEMA_ERROR = "No fields were identified for this schema. This may happen if the stream is empty. Please check your configuration to verify that there are files that match the stream's glob patterns."
     CONFIG_VALIDATION_ERROR = "Error creating stream config object."
     MISSING_SCHEMA = "Expected `json_schema` in the configured catalog but it is missing."

--- a/airbyte-cdk/python/airbyte_cdk/sources/file_based/file_types/avro_parser.py
+++ b/airbyte-cdk/python/airbyte_cdk/sources/file_based/file_types/avro_parser.py
@@ -2,6 +2,7 @@
 # Copyright (c) 2023 Airbyte, Inc., all rights reserved.
 #
 
+import logging
 from typing import Any, Dict, Iterable
 
 from airbyte_cdk.sources.file_based.config.file_based_stream_config import FileBasedStreamConfig
@@ -12,11 +13,19 @@ from airbyte_cdk.sources.file_based.remote_file import RemoteFile
 
 class AvroParser(FileTypeParser):
     async def infer_schema(
-        self, config: FileBasedStreamConfig, file: RemoteFile, stream_reader: AbstractFileBasedStreamReader
+        self,
+        config: FileBasedStreamConfig,
+        file: RemoteFile,
+        stream_reader: AbstractFileBasedStreamReader,
+        logger: logging.Logger,
     ) -> Dict[str, Any]:
         ...
 
     def parse_records(
-        self, config: FileBasedStreamConfig, file: RemoteFile, stream_reader: AbstractFileBasedStreamReader
+        self,
+        config: FileBasedStreamConfig,
+        file: RemoteFile,
+        stream_reader: AbstractFileBasedStreamReader,
+        logger: logging.Logger,
     ) -> Iterable[Dict[str, Any]]:
         ...

--- a/airbyte-cdk/python/airbyte_cdk/sources/file_based/file_types/csv_parser.py
+++ b/airbyte-cdk/python/airbyte_cdk/sources/file_based/file_types/csv_parser.py
@@ -3,12 +3,17 @@
 #
 
 import csv
-from typing import Any, Dict, Iterable
+import json
+import logging
+from distutils.util import strtobool
+from typing import Any, Dict, Iterable, Mapping, Optional
 
 from airbyte_cdk.sources.file_based.config.file_based_stream_config import FileBasedStreamConfig, QuotingBehavior
+from airbyte_cdk.sources.file_based.exceptions import FileBasedSourceError
 from airbyte_cdk.sources.file_based.file_based_stream_reader import AbstractFileBasedStreamReader
 from airbyte_cdk.sources.file_based.file_types.file_type_parser import FileTypeParser
 from airbyte_cdk.sources.file_based.remote_file import RemoteFile
+from airbyte_cdk.sources.file_based.schema_helpers import TYPE_PYTHON_MAPPING
 
 DIALECT_NAME = "_config_dialect"
 
@@ -22,7 +27,11 @@ config_to_quoting: [QuotingBehavior, int] = {
 
 class CsvParser(FileTypeParser):
     async def infer_schema(
-        self, config: FileBasedStreamConfig, file: RemoteFile, stream_reader: AbstractFileBasedStreamReader
+        self,
+        config: FileBasedStreamConfig,
+        file: RemoteFile,
+        stream_reader: AbstractFileBasedStreamReader,
+        logger: logging.Logger,
     ) -> Dict[str, Any]:
         config_format = config.format.get(config.file_type) if config.format else None
         if config_format:
@@ -48,8 +57,13 @@ class CsvParser(FileTypeParser):
                 return {field.strip(): {"type": "string"} for field in next(reader)}
 
     def parse_records(
-        self, config: FileBasedStreamConfig, file: RemoteFile, stream_reader: AbstractFileBasedStreamReader
+        self,
+        config: FileBasedStreamConfig,
+        file: RemoteFile,
+        stream_reader: AbstractFileBasedStreamReader,
+        logger: logging.Logger,
     ) -> Iterable[Dict[str, Any]]:
+        schema = config.input_schema
         config_format = config.format.get(config.file_type) if config.format else None
         if config_format:
             # Formats are configured individually per-stream so a unique dialect should be registered for each stream.
@@ -67,8 +81,93 @@ class CsvParser(FileTypeParser):
                 # todo: the existing InMemoryFilesSource.open_file() test source doesn't currently require an encoding, but actual
                 #  sources will likely require one. Rather than modify the interface now we can wait until the real use case
                 reader = csv.DictReader(fp, dialect=dialect_name)
-                yield from reader
+                yield from self._read_and_cast_types(reader, schema, logger)
         else:
             with stream_reader.open_file(file) as fp:
                 reader = csv.DictReader(fp)
-                yield from reader
+                yield from self._read_and_cast_types(reader, schema, logger)
+
+    @staticmethod
+    def _read_and_cast_types(
+        reader: csv.DictReader, schema: Optional[Mapping[str, str]], logger: logging.Logger
+    ) -> Iterable[Dict[str, Any]]:
+        """
+        If the user provided a schema, attempt to cast the record values to the associated type.
+
+        If a column is not in the schema or cannot be cast to an appropriate python type,
+        cast it to a string. Downstream, the user's validation policy will determine whether the
+        record should be emitted.
+        """
+        if not schema:
+            yield from reader
+
+        else:
+            property_types = {col: prop["type"] for col, prop in schema["properties"].items()}
+            for row in reader:
+                yield cast_types(row, property_types, logger)
+
+
+def cast_types(row: Dict[str, str], property_types: Dict[str, Any], logger: logging.Logger) -> Dict[str, Any]:
+    """
+    Casts the values in the input 'row' dictionary according to the types defined in the JSON schema.
+
+    Array and object types are only handled if they can be deserialized as JSON.
+
+    If any errors are encountered, the value will be emitted as a string.
+    """
+    warnings = []
+    result = {}
+
+    for key, value in row.items():
+        prop_type = property_types.get(key)
+        cast_value = value
+
+        if prop_type in TYPE_PYTHON_MAPPING:
+            _, python_type = TYPE_PYTHON_MAPPING[prop_type]
+
+            if python_type is None:
+                if value == "":
+                    cast_value = None
+                else:
+                    warnings.append(_format_warning(key, value, prop_type))
+
+            elif python_type == bool:
+                try:
+                    cast_value = strtobool(value)
+                except ValueError:
+                    warnings.append(_format_warning(key, value, prop_type))
+
+            elif python_type == dict:
+                try:
+                    cast_value = json.loads(value)
+                except json.JSONDecodeError:
+                    warnings.append(_format_warning(key, value, prop_type))
+
+            elif python_type == list:
+                try:
+                    parsed_value = json.loads(value)
+                    if isinstance(parsed_value, list):
+                        cast_value = parsed_value
+                except json.JSONDecodeError:
+                    warnings.append(_format_warning(key, value, prop_type))
+
+            elif python_type:
+                try:
+                    cast_value = python_type(value)
+                except ValueError:
+                    warnings.append(_format_warning(key, value, prop_type))
+
+        else:
+            warnings.append(_format_warning(key, value, prop_type))
+
+        result[key] = cast_value
+
+    if warnings:
+        logger.warning(
+            f"{FileBasedSourceError.ERROR_CASTING_VALUE.value}: {','.join([w for w in warnings])}",
+        )
+    return result
+
+
+def _format_warning(key: str, value: str, expected_type: str) -> str:
+    return f"{key}: value={value},expected_type={expected_type}"

--- a/airbyte-cdk/python/airbyte_cdk/sources/file_based/file_types/file_type_parser.py
+++ b/airbyte-cdk/python/airbyte_cdk/sources/file_based/file_types/file_type_parser.py
@@ -2,6 +2,7 @@
 # Copyright (c) 2023 Airbyte, Inc., all rights reserved.
 #
 
+import logging
 from abc import ABC, abstractmethod
 from typing import Any, Dict, Iterable
 
@@ -20,7 +21,13 @@ class FileTypeParser(ABC):
     """
 
     @abstractmethod
-    async def infer_schema(self, config: FileBasedStreamConfig, file: RemoteFile, stream_reader: AbstractFileBasedStreamReader) -> Schema:
+    async def infer_schema(
+        self,
+        config: FileBasedStreamConfig,
+        file: RemoteFile,
+        stream_reader: AbstractFileBasedStreamReader,
+        logger: logging.Logger,
+    ) -> Schema:
         """
         Infer the JSON Schema for this file.
         """
@@ -28,7 +35,11 @@ class FileTypeParser(ABC):
 
     @abstractmethod
     def parse_records(
-        self, config: FileBasedStreamConfig, file: RemoteFile, stream_reader: AbstractFileBasedStreamReader
+        self,
+        config: FileBasedStreamConfig,
+        file: RemoteFile,
+        stream_reader: AbstractFileBasedStreamReader,
+        logger: logging.Logger,
     ) -> Iterable[Record]:
         """
         Parse and emit each record.

--- a/airbyte-cdk/python/airbyte_cdk/sources/file_based/file_types/jsonl_parser.py
+++ b/airbyte-cdk/python/airbyte_cdk/sources/file_based/file_types/jsonl_parser.py
@@ -2,6 +2,7 @@
 # Copyright (c) 2023 Airbyte, Inc., all rights reserved.
 #
 
+import logging
 from typing import Any, Dict, Iterable
 
 from airbyte_cdk.sources.file_based.config.file_based_stream_config import FileBasedStreamConfig
@@ -15,11 +16,19 @@ class JsonlParser(FileTypeParser):
     MAX_BYTES_PER_FILE_FOR_SCHEMA_INFERENCE = 1_000_000
 
     async def infer_schema(
-        self, config: FileBasedStreamConfig, file: RemoteFile, stream_reader: AbstractFileBasedStreamReader
+        self,
+        config: FileBasedStreamConfig,
+        file: RemoteFile,
+        stream_reader: AbstractFileBasedStreamReader,
+        logger: logging.Logger,
     ) -> Dict[str, Any]:
         ...
 
     def parse_records(
-        self, config: FileBasedStreamConfig, file: RemoteFile, stream_reader: AbstractFileBasedStreamReader
+        self,
+        config: FileBasedStreamConfig,
+        file: RemoteFile,
+        stream_reader: AbstractFileBasedStreamReader,
+        logger: logging.Logger,
     ) -> Iterable[Dict[str, Any]]:
         ...

--- a/airbyte-cdk/python/airbyte_cdk/sources/file_based/file_types/parquet_parser.py
+++ b/airbyte-cdk/python/airbyte_cdk/sources/file_based/file_types/parquet_parser.py
@@ -3,6 +3,7 @@
 #
 
 import json
+import logging
 from typing import Any, Dict, Iterable, Mapping
 
 import pyarrow as pa
@@ -16,7 +17,11 @@ from pyarrow import Scalar
 
 class ParquetParser(FileTypeParser):
     async def infer_schema(
-        self, config: FileBasedStreamConfig, file: RemoteFile, stream_reader: AbstractFileBasedStreamReader
+        self,
+        config: FileBasedStreamConfig,
+        file: RemoteFile,
+        stream_reader: AbstractFileBasedStreamReader,
+        logger: logging.Logger,
     ) -> Dict[str, Any]:
         # Pyarrow can detect the schema of a parquet file by reading only its metadata.
         # https://github.com/apache/arrow/blob/main/python/pyarrow/_parquet.pyx#L1168-L1243
@@ -26,7 +31,11 @@ class ParquetParser(FileTypeParser):
         return schema
 
     def parse_records(
-        self, config: FileBasedStreamConfig, file: RemoteFile, stream_reader: AbstractFileBasedStreamReader
+        self,
+        config: FileBasedStreamConfig,
+        file: RemoteFile,
+        stream_reader: AbstractFileBasedStreamReader,
+        logger: logging.Logger,
     ) -> Iterable[Dict[str, Any]]:
         table = pq.read_table(stream_reader.open_file(file))
         for batch in table.to_batches():

--- a/airbyte-cdk/python/airbyte_cdk/sources/file_based/schema_validation_policies/abstract_schema_validation_policy.py
+++ b/airbyte-cdk/python/airbyte_cdk/sources/file_based/schema_validation_policies/abstract_schema_validation_policy.py
@@ -8,6 +8,7 @@ from typing import Any, Mapping
 
 class AbstractSchemaValidationPolicy(ABC):
     name: str
+    validate_schema_before_sync = False  # Whether to verify that records conform to the schema during the stream's availabilty check
 
     @abstractmethod
     def record_passes_validation_policy(self, record: Mapping[str, Any], schema: Mapping[str, Any]) -> bool:

--- a/airbyte-cdk/python/airbyte_cdk/sources/file_based/schema_validation_policies/default_schema_validation_policies.py
+++ b/airbyte-cdk/python/airbyte_cdk/sources/file_based/schema_validation_policies/default_schema_validation_policies.py
@@ -25,6 +25,7 @@ class SkipRecordPolicy(AbstractSchemaValidationPolicy):
 
 class WaitForDiscoverPolicy(AbstractSchemaValidationPolicy):
     name = "wait_for_discover"
+    validate_schema_before_sync = True
 
     def record_passes_validation_policy(self, record: Mapping[str, Any], schema: Mapping[str, Any]) -> bool:
         if not conforms_to_schema(record, schema):

--- a/airbyte-cdk/python/airbyte_cdk/sources/file_based/stream/abstract_file_based_stream.py
+++ b/airbyte-cdk/python/airbyte_cdk/sources/file_based/stream/abstract_file_based_stream.py
@@ -43,16 +43,16 @@ class AbstractFileBasedStream(Stream):
         availability_strategy: AvailabilityStrategy,
         discovery_policy: AbstractDiscoveryPolicy,
         parsers: Dict[str, FileTypeParser],
-        validation_policies: Dict[str, AbstractSchemaValidationPolicy],
+        validation_policy: AbstractSchemaValidationPolicy,
     ):
         super().__init__()
         self.config = config
-        self._catalog_schema = catalog_schema
+        self.catalog_schema = catalog_schema
+        self.validation_policy = validation_policy
         self._stream_reader = stream_reader
         self._discovery_policy = discovery_policy
         self._availability_strategy = availability_strategy
         self._parsers = parsers
-        self._validation_policies = validation_policies
 
     @property
     @abstractmethod
@@ -125,9 +125,8 @@ class AbstractFileBasedStream(Stream):
             raise UndefinedParserError(FileBasedSourceError.UNDEFINED_PARSER, stream=self.name, file_type=file_type)
 
     def record_passes_validation_policy(self, record: Mapping[str, Any]) -> bool:
-        validation_policy = self._validation_policies.get(self.config.validation_policy)
-        if validation_policy:
-            return validation_policy.record_passes_validation_policy(record=record, schema=self._catalog_schema)
+        if self.validation_policy:
+            return self.validation_policy.record_passes_validation_policy(record=record, schema=self.catalog_schema)
         else:
             raise RecordParseError(
                 FileBasedSourceError.UNDEFINED_VALIDATION_POLICY, stream=self.name, validation_policy=self.config.validation_policy

--- a/airbyte-cdk/python/unit_tests/sources/file_based/file_types/test_csv_parser.py
+++ b/airbyte-cdk/python/unit_tests/sources/file_based/file_types/test_csv_parser.py
@@ -1,0 +1,66 @@
+#
+# Copyright (c) 2023 Airbyte, Inc., all rights reserved.
+#
+
+import logging
+
+import pytest
+from airbyte_cdk.sources.file_based.file_types.csv_parser import cast_types
+
+PROPERTY_TYPES = {
+    "col1": "null",
+    "col2": "boolean",
+    "col3": "integer",
+    "col4": "number",
+    "col5": "string",
+    "col6": "object",
+    "col7": "array",
+    "col8": "array",
+    "col9": "array",
+}
+
+logger = logging.getLogger()
+
+
+@pytest.mark.parametrize(
+    "row,expected_output",
+    [
+        pytest.param(
+            {
+                "col1": "",
+                "col2": "true",
+                "col3": "1",
+                "col4": "1.1",
+                "col5": "asdf",
+                "col6": '{"a": "b"}',
+                "col7": '[1, 2]',
+                "col8": '["1", "2"]',
+                "col9": '[{"a": "b"}, {"a": "c"}]',
+            }, {
+                "col1": None,
+                "col2": True,
+                "col3": 1,
+                "col4": 1.1,
+                "col5": "asdf",
+                "col6": {"a": "b"},
+                "col7": [1, 2],
+                "col8": ["1", "2"],
+                "col9": [{"a": "b"}, {"a": "c"}],
+            }, id="cast-all-cols"),
+        pytest.param({"col1": "1"}, {"col1": "1"}, id="cannot-cast-to-null"),
+        pytest.param({"col2": "1"}, {"col2": True}, id="cast-1-to-bool"),
+        pytest.param({"col2": "0"}, {"col2": False}, id="cast-0-to-bool"),
+        pytest.param({"col2": "yes"}, {"col2": True}, id="cast-yes-to-bool"),
+        pytest.param({"col2": "no"}, {"col2": False}, id="cast-no-to-bool"),
+        pytest.param({"col2": "10"}, {"col2": "10"}, id="cannot-cast-to-bool"),
+        pytest.param({"col3": "1.1"}, {"col3": "1.1"}, id="cannot-cast-to-int"),
+        pytest.param({"col4": "asdf"}, {"col4": "asdf"}, id="cannot-cast-to-float"),
+        pytest.param({"col6": "{'a': 'b'}"}, {"col6": "{'a': 'b'}"}, id="cannot-cast-to-dict"),
+        pytest.param({"col7": "['a', 'b']"}, {"col7": "['a', 'b']"}, id="cannot-cast-to-list-of-ints"),
+        pytest.param({"col8": "['a', 'b']"}, {"col8": "['a', 'b']"}, id="cannot-cast-to-list-of-strings"),
+        pytest.param({"col9": "['a', 'b']"}, {"col9": "['a', 'b']"}, id="cannot-cast-to-list-of-objects"),
+        pytest.param({"col10": "x"}, {"col10": "x"}, id="item-not-in-props-doesn't-error"),
+    ]
+)
+def test_cast_to_python_type(row, expected_output):
+    assert cast_types(row, PROPERTY_TYPES, logger) == expected_output

--- a/airbyte-cdk/python/unit_tests/sources/file_based/helpers.py
+++ b/airbyte-cdk/python/unit_tests/sources/file_based/helpers.py
@@ -42,6 +42,7 @@ class TestErrorOpenFileInMemoryFilesStreamReader(InMemoryFilesStreamReader):
 
 class FailingSchemaValidationPolicy(AbstractSchemaValidationPolicy):
     ALWAYS_FAIL = "always_fail"
+    validate_schema_before_sync = True
 
     def record_passes_validation_policy(self, record: Mapping[str, Any], schema: Mapping[str, Any]) -> bool:
         return False

--- a/airbyte-cdk/python/unit_tests/sources/file_based/scenarios/check_scenarios.py
+++ b/airbyte-cdk/python/unit_tests/sources/file_based/scenarios/check_scenarios.py
@@ -112,7 +112,7 @@ success_user_provided_schema_scenario = (
                     "file_type": "csv",
                     "globs": ["*.csv"],
                     "validation_policy": "emit_record",
-                    "input_schema": {"col1": "string", "col2": "string"},
+                    "input_schema": '{"col1": "string", "col2": "string"}',
                 }
             ],
         }
@@ -169,7 +169,7 @@ error_record_validation_user_provided_schema_scenario = (
                     "file_type": "csv",
                     "globs": ["*.csv"],
                     "validation_policy": "always_fail",
-                    "input_schema": {"col1": "number", "col2": "string"},
+                    "input_schema": '{"col1": "number", "col2": "string"}',
                 }
             ],
         }

--- a/airbyte-cdk/python/unit_tests/sources/file_based/scenarios/incremental_scenarios.py
+++ b/airbyte-cdk/python/unit_tests/sources/file_based/scenarios/incremental_scenarios.py
@@ -48,8 +48,8 @@ single_csv_input_state_is_earlier_scenario = (
     ))
     .set_expected_records(
         [
-            {"col1": "val11", "col2": "val12", "_ab_source_file_last_modified": "2023-06-05T03:54:07Z", "_ab_source_file_url": "a.csv"},
-            {"col1": "val21", "col2": "val22", "_ab_source_file_last_modified": "2023-06-05T03:54:07Z", "_ab_source_file_url": "a.csv"},
+            {"data": {"col1": "val11", "col2": "val12", "_ab_source_file_last_modified": "2023-06-05T03:54:07Z", "_ab_source_file_url": "a.csv"}, "stream": "stream1"},
+            {"data": {"col1": "val21", "col2": "val22", "_ab_source_file_last_modified": "2023-06-05T03:54:07Z", "_ab_source_file_url": "a.csv"}, "stream": "stream1"},
             {
                 "stream1": {
                     "history": {
@@ -217,8 +217,8 @@ single_csv_file_is_synced_if_modified_at_is_more_recent_than_in_history = (
     ))
     .set_expected_records(
         [
-            {"col1": "val11", "col2": "val12", "_ab_source_file_last_modified": "2023-06-05T03:54:07Z", "_ab_source_file_url": "a.csv"},
-            {"col1": "val21", "col2": "val22", "_ab_source_file_last_modified": "2023-06-05T03:54:07Z", "_ab_source_file_url": "a.csv"},
+            {"data": {"col1": "val11", "col2": "val12", "_ab_source_file_last_modified": "2023-06-05T03:54:07Z", "_ab_source_file_url": "a.csv"}, "stream": "stream1"},
+            {"data": {"col1": "val21", "col2": "val22", "_ab_source_file_last_modified": "2023-06-05T03:54:07Z", "_ab_source_file_url": "a.csv"}, "stream": "stream1"},
             {
                 "stream1": {
                     "history": {
@@ -316,8 +316,8 @@ single_csv_no_input_state_scenario = (
     )
     .set_expected_records(
         [
-            {"col1": "val11", "col2": "val12", "_ab_source_file_last_modified": "2023-06-05T03:54:07Z", "_ab_source_file_url": "a.csv"},
-            {"col1": "val21", "col2": "val22", "_ab_source_file_last_modified": "2023-06-05T03:54:07Z", "_ab_source_file_url": "a.csv"},
+            {"data": {"col1": "val11", "col2": "val12", "_ab_source_file_last_modified": "2023-06-05T03:54:07Z", "_ab_source_file_url": "a.csv"}, "stream": "stream1"},
+            {"data": {"col1": "val21", "col2": "val22", "_ab_source_file_last_modified": "2023-06-05T03:54:07Z", "_ab_source_file_url": "a.csv"}, "stream": "stream1"},
             {
                 "stream1": {
                     "history": {
@@ -401,12 +401,12 @@ multi_csv_same_timestamp_scenario = (
     )
     .set_expected_records(
         [
-            {"col1": "val11a", "col2": "val12a", "_ab_source_file_last_modified": "2023-06-05T03:54:07Z", "_ab_source_file_url": "a.csv"},
-            {"col1": "val21a", "col2": "val22a", "_ab_source_file_last_modified": "2023-06-05T03:54:07Z", "_ab_source_file_url": "a.csv"},
-            {"col1": "val11b", "col2": "val12b", "col3": "val13b", "_ab_source_file_last_modified": "2023-06-05T03:54:07Z",
-             "_ab_source_file_url": "b.csv"},
-            {"col1": "val21b", "col2": "val22b", "col3": "val23b", "_ab_source_file_last_modified": "2023-06-05T03:54:07Z",
-             "_ab_source_file_url": "b.csv"},
+            {"data": {"col1": "val11a", "col2": "val12a", "_ab_source_file_last_modified": "2023-06-05T03:54:07Z", "_ab_source_file_url": "a.csv"}, "stream": "stream1"},
+            {"data": {"col1": "val21a", "col2": "val22a", "_ab_source_file_last_modified": "2023-06-05T03:54:07Z", "_ab_source_file_url": "a.csv"}, "stream": "stream1"},
+            {"data": {"col1": "val11b", "col2": "val12b", "col3": "val13b", "_ab_source_file_last_modified": "2023-06-05T03:54:07Z",
+             "_ab_source_file_url": "b.csv"}, "stream": "stream1"},
+            {"data": {"col1": "val21b", "col2": "val22b", "col3": "val23b", "_ab_source_file_last_modified": "2023-06-05T03:54:07Z",
+             "_ab_source_file_url": "b.csv"}, "stream": "stream1"},
             {
                 "stream1": {
                     "history": {
@@ -479,8 +479,8 @@ single_csv_input_state_is_later_scenario = (
     )
     .set_expected_records(
         [
-            {"col1": "val11", "col2": "val12", "_ab_source_file_last_modified": "2023-06-05T03:54:07Z", "_ab_source_file_url": "a.csv"},
-            {"col1": "val21", "col2": "val22", "_ab_source_file_last_modified": "2023-06-05T03:54:07Z", "_ab_source_file_url": "a.csv"},
+            {"data": {"col1": "val11", "col2": "val12", "_ab_source_file_last_modified": "2023-06-05T03:54:07Z", "_ab_source_file_url": "a.csv"}, "stream": "stream1"},
+            {"data": {"col1": "val21", "col2": "val22", "_ab_source_file_last_modified": "2023-06-05T03:54:07Z", "_ab_source_file_url": "a.csv"}, "stream": "stream1"},
             {
                 "stream1": {
                     "history": {
@@ -576,8 +576,8 @@ multi_csv_different_timestamps_scenario = (
     )
     .set_expected_records(
         [
-            {"col1": "val11a", "col2": "val12a", "_ab_source_file_last_modified": "2023-06-04T03:54:07Z", "_ab_source_file_url": "a.csv"},
-            {"col1": "val21a", "col2": "val22a", "_ab_source_file_last_modified": "2023-06-04T03:54:07Z", "_ab_source_file_url": "a.csv"},
+            {"data": {"col1": "val11a", "col2": "val12a", "_ab_source_file_last_modified": "2023-06-04T03:54:07Z", "_ab_source_file_url": "a.csv"}, "stream": "stream1"},
+            {"data": {"col1": "val21a", "col2": "val22a", "_ab_source_file_last_modified": "2023-06-04T03:54:07Z", "_ab_source_file_url": "a.csv"}, "stream": "stream1"},
             {
                 "stream1": {
                     "history": {
@@ -585,10 +585,10 @@ multi_csv_different_timestamps_scenario = (
                     },
                 }
             },
-            {"col1": "val11b", "col2": "val12b", "col3": "val13b", "_ab_source_file_last_modified": "2023-06-05T03:54:07Z",
-             "_ab_source_file_url": "b.csv"},
-            {"col1": "val21b", "col2": "val22b", "col3": "val23b", "_ab_source_file_last_modified": "2023-06-05T03:54:07Z",
-             "_ab_source_file_url": "b.csv"},
+            {"data": {"col1": "val11b", "col2": "val12b", "col3": "val13b", "_ab_source_file_last_modified": "2023-06-05T03:54:07Z",
+             "_ab_source_file_url": "b.csv"}, "stream": "stream1"},
+            {"data": {"col1": "val21b", "col2": "val22b", "col3": "val23b", "_ab_source_file_last_modified": "2023-06-05T03:54:07Z",
+             "_ab_source_file_url": "b.csv"}, "stream": "stream1"},
             {
                 "stream1": {
                     "history": {
@@ -681,12 +681,12 @@ multi_csv_per_timestamp_scenario = (
     )
     .set_expected_records(
         [
-            {"col1": "val11a", "col2": "val12a", "_ab_source_file_last_modified": "2023-06-05T03:54:07Z", "_ab_source_file_url": "a.csv"},
-            {"col1": "val21a", "col2": "val22a", "_ab_source_file_last_modified": "2023-06-05T03:54:07Z", "_ab_source_file_url": "a.csv"},
-            {"col1": "val11b", "col2": "val12b", "col3": "val13b", "_ab_source_file_last_modified": "2023-06-05T03:54:07Z",
-             "_ab_source_file_url": "b.csv"},
-            {"col1": "val21b", "col2": "val22b", "col3": "val23b", "_ab_source_file_last_modified": "2023-06-05T03:54:07Z",
-             "_ab_source_file_url": "b.csv"},
+            {"data": {"col1": "val11a", "col2": "val12a", "_ab_source_file_last_modified": "2023-06-05T03:54:07Z", "_ab_source_file_url": "a.csv"}, "stream": "stream1"},
+            {"data": {"col1": "val21a", "col2": "val22a", "_ab_source_file_last_modified": "2023-06-05T03:54:07Z", "_ab_source_file_url": "a.csv"}, "stream": "stream1"},
+            {"data": {"col1": "val11b", "col2": "val12b", "col3": "val13b", "_ab_source_file_last_modified": "2023-06-05T03:54:07Z",
+             "_ab_source_file_url": "b.csv"}, "stream": "stream1"},
+            {"data": {"col1": "val21b", "col2": "val22b", "col3": "val23b", "_ab_source_file_last_modified": "2023-06-05T03:54:07Z",
+             "_ab_source_file_url": "b.csv"}, "stream": "stream1"},
             {
                 "stream1": {
                     "history": {
@@ -695,10 +695,10 @@ multi_csv_per_timestamp_scenario = (
                     },
                 }
             },
-            {"col1": "val11c", "col2": "val12c", "col3": "val13c", "_ab_source_file_last_modified": "2023-06-06T03:54:07Z",
-             "_ab_source_file_url": "c.csv"},
-            {"col1": "val21c", "col2": "val22c", "col3": "val23c", "_ab_source_file_last_modified": "2023-06-06T03:54:07Z",
-             "_ab_source_file_url": "c.csv"},
+            {"data": {"col1": "val11c", "col2": "val12c", "col3": "val13c", "_ab_source_file_last_modified": "2023-06-06T03:54:07Z",
+             "_ab_source_file_url": "c.csv"}, "stream": "stream1"},
+            {"data": {"col1": "val21c", "col2": "val22c", "col3": "val23c", "_ab_source_file_last_modified": "2023-06-06T03:54:07Z",
+             "_ab_source_file_url": "c.csv"}, "stream": "stream1"},
             {
                 "stream1": {
                     "history": {
@@ -792,12 +792,12 @@ multi_csv_skip_file_if_already_in_history = (
     )
     .set_expected_records(
         [
-            # {"col1": "val11a", "col2": "val12a"}, # this file is skipped
-            # {"col1": "val21a", "col2": "val22a"}, # this file is skipped
-            {"col1": "val11b", "col2": "val12b", "col3": "val13b", "_ab_source_file_last_modified": "2023-06-05T03:54:07Z",
-             "_ab_source_file_url": "b.csv"},
-            {"col1": "val21b", "col2": "val22b", "col3": "val23b", "_ab_source_file_last_modified": "2023-06-05T03:54:07Z",
-             "_ab_source_file_url": "b.csv"},
+            # {"data": {"col1": "val11a", "col2": "val12a"}, "stream": "stream1"}, # this file is skipped
+            # {"data": {"col1": "val21a", "col2": "val22a"}, "stream": "stream1"}, # this file is skipped
+            {"data": {"col1": "val11b", "col2": "val12b", "col3": "val13b", "_ab_source_file_last_modified": "2023-06-05T03:54:07Z",
+             "_ab_source_file_url": "b.csv"}, "stream": "stream1"},
+            {"data": {"col1": "val21b", "col2": "val22b", "col3": "val23b", "_ab_source_file_last_modified": "2023-06-05T03:54:07Z",
+             "_ab_source_file_url": "b.csv"}, "stream": "stream1"},
             {
                 "stream1": {
                     "history": {
@@ -806,10 +806,10 @@ multi_csv_skip_file_if_already_in_history = (
                     },
                 }
             },
-            {"col1": "val11c", "col2": "val12c", "col3": "val13c", "_ab_source_file_last_modified": "2023-06-06T03:54:07Z",
-             "_ab_source_file_url": "c.csv"},
-            {"col1": "val21c", "col2": "val22c", "col3": "val23c", "_ab_source_file_last_modified": "2023-06-06T03:54:07Z",
-             "_ab_source_file_url": "c.csv"},
+            {"data": {"col1": "val11c", "col2": "val12c", "col3": "val13c", "_ab_source_file_last_modified": "2023-06-06T03:54:07Z",
+             "_ab_source_file_url": "c.csv"}, "stream": "stream1"},
+            {"data": {"col1": "val21c", "col2": "val22c", "col3": "val23c", "_ab_source_file_last_modified": "2023-06-06T03:54:07Z",
+             "_ab_source_file_url": "c.csv"}, "stream": "stream1"},
             {
                 "stream1": {
                     "history": {
@@ -912,14 +912,14 @@ multi_csv_include_missing_files_within_history_range = (
     )
     .set_expected_records(
         [
-            # {"col1": "val11a", "col2": "val12a"}, # this file is skipped
-            # {"col1": "val21a", "col2": "val22a"}, # this file is skipped
-            {"col1": "val11b", "col2": "val12b", "col3": "val13b", "_ab_source_file_last_modified": "2023-06-05T03:54:07Z",
-             "_ab_source_file_url": "b.csv"},
-            {"col1": "val21b", "col2": "val22b", "col3": "val23b", "_ab_source_file_last_modified": "2023-06-05T03:54:07Z",
-             "_ab_source_file_url": "b.csv"},
-            # {"col1": "val11c", "col2": "val12c", "col3": "val13c"}, # this file is skipped
-            # {"col1": "val21c", "col2": "val22c", "col3": "val23c"}, # this file is skipped
+            # {"data": {"col1": "val11a", "col2": "val12a"}, "stream": "stream1"}, # this file is skipped
+            # {"data": {"col1": "val21a", "col2": "val22a"}, "stream": "stream1"}, # this file is skipped
+            {"data": {"col1": "val11b", "col2": "val12b", "col3": "val13b", "_ab_source_file_last_modified": "2023-06-05T03:54:07Z",
+             "_ab_source_file_url": "b.csv"}, "stream": "stream1"},
+            {"data": {"col1": "val21b", "col2": "val22b", "col3": "val23b", "_ab_source_file_last_modified": "2023-06-05T03:54:07Z",
+             "_ab_source_file_url": "b.csv"}, "stream": "stream1"},
+            # {"data": {"col1": "val11c", "col2": "val12c", "col3": "val13c"}, "stream": "stream1"}, # this file is skipped
+            # {"data": {"col1": "val21c", "col2": "val22c", "col3": "val23c"}, "stream": "stream1"}, # this file is skipped
             {
                 "stream1": {
                     "history": {
@@ -1026,8 +1026,8 @@ multi_csv_remove_old_files_if_history_is_full_scenario = (
     )
     .set_expected_records(
         [
-            {"col1": "val11a", "col2": "val12a", "_ab_source_file_last_modified": "2023-06-06T03:54:07Z", "_ab_source_file_url": "a.csv"},
-            {"col1": "val21a", "col2": "val22a", "_ab_source_file_last_modified": "2023-06-06T03:54:07Z", "_ab_source_file_url": "a.csv"},
+            {"data": {"col1": "val11a", "col2": "val12a", "_ab_source_file_last_modified": "2023-06-06T03:54:07Z", "_ab_source_file_url": "a.csv"}, "stream": "stream1"},
+            {"data": {"col1": "val21a", "col2": "val22a", "_ab_source_file_last_modified": "2023-06-06T03:54:07Z", "_ab_source_file_url": "a.csv"}, "stream": "stream1"},
             {
                 "stream1": {
                     "history": {
@@ -1037,10 +1037,10 @@ multi_csv_remove_old_files_if_history_is_full_scenario = (
                     },
                 }
             },
-            {"col1": "val11b", "col2": "val12b", "col3": "val13b", "_ab_source_file_last_modified": "2023-06-07T03:54:07Z",
-             "_ab_source_file_url": "b.csv"},
-            {"col1": "val21b", "col2": "val22b", "col3": "val23b", "_ab_source_file_last_modified": "2023-06-07T03:54:07Z",
-             "_ab_source_file_url": "b.csv"},
+            {"data": {"col1": "val11b", "col2": "val12b", "col3": "val13b", "_ab_source_file_last_modified": "2023-06-07T03:54:07Z",
+             "_ab_source_file_url": "b.csv"}, "stream": "stream1"},
+            {"data": {"col1": "val21b", "col2": "val22b", "col3": "val23b", "_ab_source_file_last_modified": "2023-06-07T03:54:07Z",
+             "_ab_source_file_url": "b.csv"}, "stream": "stream1"},
             {
                 "stream1": {
                     "history": {
@@ -1050,10 +1050,10 @@ multi_csv_remove_old_files_if_history_is_full_scenario = (
                     },
                 }
             },
-            {"col1": "val11c", "col2": "val12c", "col3": "val13c", "_ab_source_file_last_modified": "2023-06-10T03:54:07Z",
-             "_ab_source_file_url": "c.csv"},
-            {"col1": "val21c", "col2": "val22c", "col3": "val23c", "_ab_source_file_last_modified": "2023-06-10T03:54:07Z",
-             "_ab_source_file_url": "c.csv"},
+            {"data": {"col1": "val11c", "col2": "val12c", "col3": "val13c", "_ab_source_file_last_modified": "2023-06-10T03:54:07Z",
+             "_ab_source_file_url": "c.csv"}, "stream": "stream1"},
+            {"data": {"col1": "val21c", "col2": "val22c", "col3": "val23c", "_ab_source_file_last_modified": "2023-06-10T03:54:07Z",
+             "_ab_source_file_url": "c.csv"}, "stream": "stream1"},
             {
                 "stream1": {
                     "history": {
@@ -1170,20 +1170,20 @@ multi_csv_same_timestamp_more_files_than_history_size_scenario = (
     )
     .set_expected_records(
         [
-            {"col1": "val11a", "col2": "val12a", "_ab_source_file_last_modified": "2023-06-05T03:54:07Z", "_ab_source_file_url": "a.csv"},
-            {"col1": "val21a", "col2": "val22a", "_ab_source_file_last_modified": "2023-06-05T03:54:07Z", "_ab_source_file_url": "a.csv"},
-            {"col1": "val11b", "col2": "val12b", "col3": "val13b", "_ab_source_file_last_modified": "2023-06-05T03:54:07Z",
-             "_ab_source_file_url": "b.csv"},
-            {"col1": "val21b", "col2": "val22b", "col3": "val23b", "_ab_source_file_last_modified": "2023-06-05T03:54:07Z",
-             "_ab_source_file_url": "b.csv"},
-            {"col1": "val11c", "col2": "val12c", "col3": "val13c", "_ab_source_file_last_modified": "2023-06-05T03:54:07Z",
-             "_ab_source_file_url": "c.csv"},
-            {"col1": "val21c", "col2": "val22c", "col3": "val23c", "_ab_source_file_last_modified": "2023-06-05T03:54:07Z",
-             "_ab_source_file_url": "c.csv"},
-            {"col1": "val11d", "col2": "val12d", "col3": "val13d", "_ab_source_file_last_modified": "2023-06-05T03:54:07Z",
-             "_ab_source_file_url": "d.csv"},
-            {"col1": "val21d", "col2": "val22d", "col3": "val23d", "_ab_source_file_last_modified": "2023-06-05T03:54:07Z",
-             "_ab_source_file_url": "d.csv"},
+            {"data": {"col1": "val11a", "col2": "val12a", "_ab_source_file_last_modified": "2023-06-05T03:54:07Z", "_ab_source_file_url": "a.csv"}, "stream": "stream1"},
+            {"data": {"col1": "val21a", "col2": "val22a", "_ab_source_file_last_modified": "2023-06-05T03:54:07Z", "_ab_source_file_url": "a.csv"}, "stream": "stream1"},
+            {"data": {"col1": "val11b", "col2": "val12b", "col3": "val13b", "_ab_source_file_last_modified": "2023-06-05T03:54:07Z",
+             "_ab_source_file_url": "b.csv"}, "stream": "stream1"},
+            {"data": {"col1": "val21b", "col2": "val22b", "col3": "val23b", "_ab_source_file_last_modified": "2023-06-05T03:54:07Z",
+             "_ab_source_file_url": "b.csv"}, "stream": "stream1"},
+            {"data": {"col1": "val11c", "col2": "val12c", "col3": "val13c", "_ab_source_file_last_modified": "2023-06-05T03:54:07Z",
+             "_ab_source_file_url": "c.csv"}, "stream": "stream1"},
+            {"data": {"col1": "val21c", "col2": "val22c", "col3": "val23c", "_ab_source_file_last_modified": "2023-06-05T03:54:07Z",
+             "_ab_source_file_url": "c.csv"}, "stream": "stream1"},
+            {"data": {"col1": "val11d", "col2": "val12d", "col3": "val13d", "_ab_source_file_last_modified": "2023-06-05T03:54:07Z",
+             "_ab_source_file_url": "d.csv"}, "stream": "stream1"},
+            {"data": {"col1": "val21d", "col2": "val22d", "col3": "val23d", "_ab_source_file_last_modified": "2023-06-05T03:54:07Z",
+             "_ab_source_file_url": "d.csv"}, "stream": "stream1"},
             {
                 "stream1": {
                     "history": {
@@ -1403,12 +1403,12 @@ multi_csv_sync_files_within_time_window_if_history_is_incomplete__different_time
     )
     .set_expected_records(
         [
-            # {"col1": "val11a", "col2": "val12a"}, # This file is skipped because it is older than the time_window
-            # {"col1": "val21a", "col2": "val22a"},
-            {"col1": "val11b", "col2": "val12b", "col3": "val13b", "_ab_source_file_last_modified": "2023-06-06T03:54:07Z",
-             "_ab_source_file_url": "b.csv"},
-            {"col1": "val21b", "col2": "val22b", "col3": "val23b", "_ab_source_file_last_modified": "2023-06-06T03:54:07Z",
-             "_ab_source_file_url": "b.csv"},
+            # {"data": {"col1": "val11a", "col2": "val12a"}, "stream": "stream1"}, # This file is skipped because it is older than the time_window
+            # {"data": {"col1": "val21a", "col2": "val22a"}, "stream": "stream1"},
+            {"data": {"col1": "val11b", "col2": "val12b", "col3": "val13b", "_ab_source_file_last_modified": "2023-06-06T03:54:07Z",
+             "_ab_source_file_url": "b.csv"}, "stream": "stream1"},
+            {"data": {"col1": "val21b", "col2": "val22b", "col3": "val23b", "_ab_source_file_last_modified": "2023-06-06T03:54:07Z",
+             "_ab_source_file_url": "b.csv"}, "stream": "stream1"},
             {
                 "stream1": {
                     "history": {
@@ -1525,10 +1525,10 @@ multi_csv_sync_files_within_history_time_window_if_history_is_incomplete_differe
     )
     .set_expected_records(
         [
-            {"col1": "val11a", "col2": "val12a", "_ab_source_file_last_modified": "2023-06-05T03:54:07Z",
-             "_ab_source_file_url": "a.csv"},
-            {"col1": "val21a", "col2": "val22a", "_ab_source_file_last_modified": "2023-06-05T03:54:07Z",
-             "_ab_source_file_url": "a.csv"},
+            {"data": {"col1": "val11a", "col2": "val12a", "_ab_source_file_last_modified": "2023-06-05T03:54:07Z",
+             "_ab_source_file_url": "a.csv"}, "stream": "stream1"},
+            {"data": {"col1": "val21a", "col2": "val22a", "_ab_source_file_last_modified": "2023-06-05T03:54:07Z",
+             "_ab_source_file_url": "a.csv"}, "stream": "stream1"},
             {
                 "stream1": {
                     "history": {
@@ -1538,10 +1538,10 @@ multi_csv_sync_files_within_history_time_window_if_history_is_incomplete_differe
                     },
                 }
             },
-            {"col1": "val11b", "col2": "val12b", "col3": "val13b", "_ab_source_file_last_modified": "2023-06-06T03:54:07Z",
-             "_ab_source_file_url": "b.csv"},
-            {"col1": "val21b", "col2": "val22b", "col3": "val23b", "_ab_source_file_last_modified": "2023-06-06T03:54:07Z",
-             "_ab_source_file_url": "b.csv"},
+            {"data": {"col1": "val11b", "col2": "val12b", "col3": "val13b", "_ab_source_file_last_modified": "2023-06-06T03:54:07Z",
+             "_ab_source_file_url": "b.csv"}, "stream": "stream1"},
+            {"data": {"col1": "val21b", "col2": "val22b", "col3": "val23b", "_ab_source_file_last_modified": "2023-06-06T03:54:07Z",
+             "_ab_source_file_url": "b.csv"}, "stream": "stream1"},
             {
                 "stream1": {
                     "history": {

--- a/airbyte-cdk/python/unit_tests/sources/file_based/scenarios/scenario_builder.py
+++ b/airbyte-cdk/python/unit_tests/sources/file_based/scenarios/scenario_builder.py
@@ -32,7 +32,7 @@ class TestScenario:
             expected_spec: Optional[Dict[str, Any]],
             expected_check_status: Optional[str],
             expected_catalog: Optional[Dict[str, Any]],
-            expected_logs: Optional[Dict[str, Any]],
+            expected_logs: Optional[Dict[str, Dict[str, Any]]],
             expected_records: Optional[Dict[str, Any]],
             availability_strategy: Optional[AvailabilityStrategy],
             discovery_policy: Optional[AbstractDiscoveryPolicy],
@@ -56,6 +56,7 @@ class TestScenario:
         self.expected_check_error = expected_check_error
         self.expected_discover_error = expected_discover_error
         self.expected_read_error = expected_read_error
+        self.expected_logs = expected_logs
         self.source = InMemoryFilesSource(
             files,
             file_type,
@@ -110,7 +111,7 @@ class TestScenarioBuilder:
         self._expected_spec = None
         self._expected_check_status = None
         self._expected_catalog = {}
-        self._expected_logs = {}
+        self._expected_logs = None
         self._expected_records = {}
         self._availability_strategy = None
         self._discovery_policy = DefaultDiscoveryPolicy()
@@ -152,7 +153,7 @@ class TestScenarioBuilder:
         self._expected_catalog = expected_catalog
         return self
 
-    def set_expected_logs(self, expected_logs: Dict[str, Any]):
+    def set_expected_logs(self, expected_logs: Dict[str, List[Dict[str, Any]]]):
         self._expected_logs = expected_logs
         return self
 

--- a/airbyte-cdk/python/unit_tests/sources/file_based/scenarios/user_input_schema_scenarios.py
+++ b/airbyte-cdk/python/unit_tests/sources/file_based/scenarios/user_input_schema_scenarios.py
@@ -1,0 +1,720 @@
+#
+# Copyright (c) 2023 Airbyte, Inc., all rights reserved.
+#
+
+
+from airbyte_cdk.sources.file_based.exceptions import ConfigValidationError, FileBasedSourceError
+from unit_tests.sources.file_based.scenarios.scenario_builder import TestScenarioBuilder
+
+"""
+User input schema rules:
+  - `check`: Successful if the schema conforms to a record, otherwise ConfigValidationError.
+  - `discover`: User-input schema is output if the schema is valid, otherwise ConfigValidationError.
+  - `read`: If the schema is valid, record values are cast to types in the schema; if this is successful
+    the records are emitted. otherwise an error is logged. If the schema is not valid, ConfigValidationError.
+"""
+
+
+_base_user_input_schema_scenario = (
+    TestScenarioBuilder()
+    .set_files(
+        {
+            "a.csv": {
+                "contents": [
+                    ("col1", "col2"),
+                    ("val11", "val12"),
+                    ("val21", "val22"),
+                ],
+                "last_modified": "2023-06-05T03:54:07.000Z",
+            }
+        }
+    )
+    .set_file_type("csv")
+    .set_expected_catalog(
+        {
+            "streams": [
+                {
+                    "default_cursor_field": ["_ab_source_file_last_modified"],
+                    "json_schema": {
+                        "type": "object",
+                        "properties": {
+                            "col1": {
+                                "type": "string"
+                            },
+                            "col2": {
+                                "type": "string"
+                            },
+                            "_ab_source_file_last_modified": {
+                                "type": "string"
+                            },
+                            "_ab_source_file_url": {
+                                "type": "string"
+                            },
+                        },
+                    },
+                    "name": "stream1",
+                    "source_defined_cursor": True,
+                    "supported_sync_modes": ["full_refresh", "incremental"],
+                }
+            ]
+        }
+    )
+    .set_expected_records(
+        [
+            {"data": {"col1": "val11", "col2": "val12", "_ab_source_file_last_modified": "2023-06-05T03:54:07Z",
+                      "_ab_source_file_url": "a.csv"}, "stream": "stream1"},
+            {"data": {"col1": "val21", "col2": "val22", "_ab_source_file_last_modified": "2023-06-05T03:54:07Z",
+                      "_ab_source_file_url": "a.csv"}, "stream": "stream1"},
+        ]
+    )
+)
+
+
+valid_single_stream_user_input_schema_scenario = (
+    _base_user_input_schema_scenario.copy()
+    .set_name("valid_single_stream_user_input_schema_scenario")
+    .set_config(
+        {
+            "streams": [
+                {
+                    "name": "stream1",
+                    "file_type": "csv",
+                    "globs": ["*"],
+                    "validation_policy": "emit_record",
+                    "input_schema": '{"col1": "string", "col2": "string"}',
+                }
+            ]
+        }
+    )
+    .set_expected_check_status("SUCCEEDED")
+).build()
+
+
+single_stream_user_input_schema_scenario_schema_is_invalid = (
+    _base_user_input_schema_scenario.copy()
+    .set_name("single_stream_user_input_schema_scenario_schema_is_invalid")
+    .set_config(
+        {
+            "streams": [
+                {
+                    "name": "stream1",
+                    "file_type": "csv",
+                    "globs": ["*"],
+                    "validation_policy": "emit_record",
+                    "input_schema": '{"col1": "x", "col2": "string"}',
+                }
+            ]
+        }
+    )
+    .set_expected_check_status("FAILED")
+    .set_expected_check_error(None, FileBasedSourceError.ERROR_PARSING_USER_PROVIDED_SCHEMA.value)
+    .set_expected_discover_error(ConfigValidationError, FileBasedSourceError.ERROR_PARSING_USER_PROVIDED_SCHEMA.value)
+    .set_expected_read_error(ConfigValidationError, FileBasedSourceError.ERROR_PARSING_USER_PROVIDED_SCHEMA.value)
+).build()
+
+
+single_stream_user_input_schema_scenario_emit_nonconforming_records = (
+    _base_user_input_schema_scenario.copy()
+    .set_name("single_stream_user_input_schema_scenario_emit_nonconforming_records")
+    .set_config(
+        {
+            "streams": [
+                {
+                    "name": "stream1",
+                    "file_type": "csv",
+                    "globs": ["*"],
+                    "validation_policy": "emit_record",
+                    "input_schema": '{"col1": "integer", "col2": "string"}',
+                }
+            ]
+        }
+    )
+    .set_expected_check_status("FAILED")
+    .set_expected_check_error(None, FileBasedSourceError.SCHEMA_INFERENCE_ERROR.value)
+    .set_expected_catalog(
+        {
+            "streams": [
+                {
+                    "default_cursor_field": ["_ab_source_file_last_modified"],
+                    "json_schema": {
+                        "type": "object",
+                        "properties": {
+                            "col1": {
+                                "type": "integer"
+                            },
+                            "col2": {
+                                "type": "string"
+                            },
+                            "_ab_source_file_last_modified": {
+                                "type": "string"
+                            },
+                            "_ab_source_file_url": {
+                                "type": "string"
+                            },
+                        },
+                    },
+                    "name": "stream1",
+                    "source_defined_cursor": True,
+                    "supported_sync_modes": ["full_refresh", "incremental"],
+                }
+            ]
+        }
+    )
+).build()
+
+
+single_stream_user_input_schema_scenario_skip_nonconforming_records = (
+    _base_user_input_schema_scenario.copy()
+    .set_name("single_stream_user_input_schema_scenario_skip_nonconforming_records")
+    .set_config(
+        {
+            "streams": [
+                {
+                    "name": "stream1",
+                    "file_type": "csv",
+                    "globs": ["*"],
+                    "validation_policy": "skip_record",
+                    "input_schema": '{"col1": "integer", "col2": "string"}',
+                }
+            ]
+        }
+    )
+    .set_expected_check_status("FAILED")
+    .set_expected_check_error(None, FileBasedSourceError.SCHEMA_INFERENCE_ERROR.value)
+    .set_expected_catalog(
+        {
+            "streams": [
+                {
+                    "default_cursor_field": ["_ab_source_file_last_modified"],
+                    "json_schema": {
+                        "type": "object",
+                        "properties": {
+                            "col1": {
+                                "type": "integer"
+                            },
+                            "col2": {
+                                "type": "string"
+                            },
+                            "_ab_source_file_last_modified": {
+                                "type": "string"
+                            },
+                            "_ab_source_file_url": {
+                                "type": "string"
+                            },
+                        },
+                    },
+                    "name": "stream1",
+                    "source_defined_cursor": True,
+                    "supported_sync_modes": ["full_refresh", "incremental"],
+                }
+            ]
+        }
+    )
+    .set_expected_records([])
+    .set_expected_logs({
+        "read": [
+            {
+                'level': 'WARN',
+                'message': 'Records in file did not pass validation policy. stream=stream1 file=a.csv n_skipped=2 validation_policy=skip_record',
+            },
+            {
+                'level': 'WARNING',
+                'message': 'Could not cast the value to the expected type.: col1: value=val11,expected_type=integer',
+            },
+            {
+                'level': 'WARNING',
+                'message': 'Could not cast the value to the expected type.: col1: value=val11,expected_type=integer',
+            },
+            {
+                'level': 'WARNING',
+                'message': 'Could not cast the value to the expected type.: col1: value=val21,expected_type=integer',
+            },
+        ]
+    })
+).build()
+
+
+_base_multi_stream_user_input_schema_scenario = (
+    TestScenarioBuilder()
+    .set_files(
+        {
+            "a.csv": {
+                "contents": [
+                    ("col1", "col2"),
+                    ("val11a", 21),
+                    ("val12a", 22),
+                ],
+                "last_modified": "2023-06-05T03:54:07.000Z",
+            },
+            "b.csv": {
+                "contents": [
+                    ("col1", "col2", "col3"),
+                    ("val11b", "val12b", "val13b"),
+                    ("val21b", "val22b", "val23b"),
+                ],
+                "last_modified": "2023-06-05T03:54:07.000Z",
+            },
+            "c.csv": {
+                "contents": [
+                    ("col1",),
+                    ("val11c",),
+                    ("val21c",),
+                ],
+                "last_modified": "2023-06-05T03:54:07.000Z",
+            },
+        }
+    )
+    .set_file_type("csv")
+    .set_expected_catalog(
+        {
+            "streams": [
+                {
+                    "default_cursor_field": ["_ab_source_file_last_modified"],
+                    "json_schema": {
+                        "type": "object",
+                        "properties": {
+                            "col1": {
+                                "type": "string",
+                            },
+                            "col2": {
+                                "type": "integer",
+                            },
+                            "_ab_source_file_last_modified": {
+                                "type": "string"
+                            },
+                            "_ab_source_file_url": {
+                                "type": "string"
+                            },
+                        }
+                    },
+                    "name": "stream1",
+                    "source_defined_cursor": True,
+                    "supported_sync_modes": ["full_refresh", "incremental"],
+                },
+                {
+                    "default_cursor_field": ["_ab_source_file_last_modified"],
+                    "json_schema": {
+                        "type": "object",
+                        "properties": {
+                            "col1": {
+                                "type": "string",
+                            },
+                            "col2": {
+                                "type": "string",
+                            },
+                            "col3": {
+                                "type": "string",
+                            },
+                            "_ab_source_file_last_modified": {
+                                "type": "string"
+                            },
+                            "_ab_source_file_url": {
+                                "type": "string"
+                            },
+                        }
+                    },
+                    "name": "stream2",
+                    "source_defined_cursor": True,
+                    "supported_sync_modes": ["full_refresh", "incremental"],
+                },
+                {
+                    "default_cursor_field": ["_ab_source_file_last_modified"],
+                    "json_schema": {
+                        "type": "object",
+                        "properties": {
+                            "col1": {
+                                "type": "string",
+                            },
+                            "_ab_source_file_last_modified": {
+                                "type": "string"
+                            },
+                            "_ab_source_file_url": {
+                                "type": "string"
+                            },
+                        }
+                    },
+                    "name": "stream3",
+                    "source_defined_cursor": True,
+                    "supported_sync_modes": ["full_refresh", "incremental"],
+                },
+            ]
+        }
+    )
+    .set_expected_records(
+        [
+            {"data": {"col1": "val11a", "col2": 21, "_ab_source_file_last_modified": "2023-06-05T03:54:07Z",
+                      "_ab_source_file_url": "a.csv"}, "stream": "stream1"},
+            {"data": {"col1": "val12a", "col2": 22, "_ab_source_file_last_modified": "2023-06-05T03:54:07Z",
+                      "_ab_source_file_url": "a.csv"}, "stream": "stream1"},
+            # The files in b.csv are emitted despite having an invalid schema
+            {"data": {"col1": "val11b", "col2": "val12b", "col3": "val13b", "_ab_source_file_last_modified": "2023-06-05T03:54:07Z",
+                      "_ab_source_file_url": "b.csv"}, "stream": "stream2"},
+            {"data": {"col1": "val21b", "col2": "val22b", "col3": "val23b", "_ab_source_file_last_modified": "2023-06-05T03:54:07Z",
+                      "_ab_source_file_url": "b.csv"}, "stream": "stream2"},
+            {"data": {"col1": "val11c", "_ab_source_file_last_modified": "2023-06-05T03:54:07Z",
+                      "_ab_source_file_url": "c.csv"}, "stream": "stream3"},
+            {"data": {"col1": "val21c", "_ab_source_file_last_modified": "2023-06-05T03:54:07Z",
+                      "_ab_source_file_url": "c.csv"}, "stream": "stream3"},
+        ]
+    )
+)
+
+
+valid_multi_stream_user_input_schema_scenario = (
+    _base_multi_stream_user_input_schema_scenario.copy()
+    .set_name("valid_multi_stream_user_input_schema_scenario")
+    .set_config(
+        {
+            "streams": [
+                {
+                    "name": "stream1",
+                    "file_type": "csv",
+                    "globs": ["a.csv"],
+                    "validation_policy": "emit_record",
+                    "input_schema": '{"col1": "string", "col2": "integer"}',
+                },
+                {
+                    "name": "stream2",
+                    "file_type": "csv",
+                    "globs": ["b.csv"],
+                    "validation_policy": "emit_record",
+                    "input_schema": '{"col1": "string", "col2": "string", "col3": "string"}',
+                },
+                {
+                    "name": "stream3",
+                    "file_type": "csv",
+                    "globs": ["c.csv"],
+                    "validation_policy": "emit_record",
+                },
+
+            ]
+        }
+    )
+    .set_expected_check_status("SUCCEEDED")
+).build()
+
+
+multi_stream_user_input_schema_scenario_schema_is_invalid = (
+    _base_multi_stream_user_input_schema_scenario.copy()
+    .set_name("multi_stream_user_input_schema_scenario_schema_is_invalid")
+    .set_config(
+        {
+            "streams": [
+                {
+                    "name": "stream1",
+                    "file_type": "csv",
+                    "globs": ["a.csv"],
+                    "validation_policy": "emit_record",
+                    "input_schema": '{"col1": "string", "col2": "integer"}',
+                },
+                {
+                    "name": "stream2",
+                    "file_type": "csv",
+                    "globs": ["b.csv"],
+                    "validation_policy": "emit_record",
+                    "input_schema": '{"col1": "x", "col2": "string", "col3": "string"}',  # this stream's schema is invalid
+                },
+                {
+                    "name": "stream3",
+                    "file_type": "csv",
+                    "globs": ["c.csv"],
+                    "validation_policy": "emit_record",
+                },
+
+            ]
+        }
+    )
+    .set_expected_check_status("FAILED")
+    .set_expected_check_error(None, FileBasedSourceError.ERROR_PARSING_USER_PROVIDED_SCHEMA.value)
+    .set_expected_discover_error(ConfigValidationError, FileBasedSourceError.ERROR_PARSING_USER_PROVIDED_SCHEMA.value)
+    .set_expected_read_error(ConfigValidationError, FileBasedSourceError.ERROR_PARSING_USER_PROVIDED_SCHEMA.value)
+).build()
+
+
+multi_stream_user_input_schema_scenario_emit_nonconforming_records = (
+    _base_multi_stream_user_input_schema_scenario.copy()
+    .set_name("multi_stream_user_input_schema_scenario_emit_nonconforming_records")
+    .set_config(
+        {
+            "streams": [
+                {
+                    "name": "stream1",
+                    "file_type": "csv",
+                    "globs": ["a.csv"],
+                    "validation_policy": "emit_record",
+                    "input_schema": '{"col1": "string", "col2": "integer"}',
+                },
+                {
+                    "name": "stream2",
+                    "file_type": "csv",
+                    "globs": ["b.csv"],
+                    "validation_policy": "emit_record",
+                    "input_schema": '{"col1": "string", "col2": "integer", "col3": "string"}',  # this stream's records do not conform to the schema
+                },
+                {
+                    "name": "stream3",
+                    "file_type": "csv",
+                    "globs": ["c.csv"],
+                    "validation_policy": "emit_record",
+                },
+
+            ]
+        }
+    )
+    .set_expected_catalog(
+        {
+            "streams": [
+                {
+                    "default_cursor_field": ["_ab_source_file_last_modified"],
+                    "json_schema": {
+                        "type": "object",
+                        "properties": {
+                            "col1": {
+                                "type": "string"
+                            },
+                            "col2": {
+                                "type": "integer"
+                            },
+                            "_ab_source_file_last_modified": {
+                                "type": "string"
+                            },
+                            "_ab_source_file_url": {
+                                "type": "string"
+                            },
+                        },
+                    },
+                    "name": "stream1",
+                    "source_defined_cursor": True,
+                    "supported_sync_modes": ["full_refresh", "incremental"],
+                },
+                {
+                    "default_cursor_field": ["_ab_source_file_last_modified"],
+                    "json_schema": {
+                        "type": "object",
+                        "properties": {
+                            "col1": {
+                                "type": "string"
+                            },
+                            "col2": {
+                                "type": "integer"
+                            },
+                            "col3": {
+                                "type": "string"
+                            },
+                            "_ab_source_file_last_modified": {
+                                "type": "string"
+                            },
+                            "_ab_source_file_url": {
+                                "type": "string"
+                            },
+                        },
+                    },
+                    "name": "stream2",
+                    "source_defined_cursor": True,
+                    "supported_sync_modes": ["full_refresh", "incremental"],
+                },
+                {
+                    "default_cursor_field": ["_ab_source_file_last_modified"],
+                    "json_schema": {
+                        "type": "object",
+                        "properties": {
+                            "col1": {
+                                "type": "string",
+                            },
+                            "_ab_source_file_last_modified": {
+                                "type": "string"
+                            },
+                            "_ab_source_file_url": {
+                                "type": "string"
+                            },
+                        },
+                    },
+                    "name": "stream3",
+                    "source_defined_cursor": True,
+                    "supported_sync_modes": ["full_refresh", "incremental"],
+                },
+            ]
+        }
+    )
+    .set_expected_check_status("FAILED")
+    .set_expected_check_error(None, FileBasedSourceError.ERROR_PARSING_USER_PROVIDED_SCHEMA.value)
+    .set_expected_records(
+        [
+            {"data": {"col1": "val11a", "col2": 21, "_ab_source_file_last_modified": "2023-06-05T03:54:07Z",
+                      "_ab_source_file_url": "a.csv"}, "stream": "stream1"},
+            {"data": {"col1": "val12a", "col2": 22, "_ab_source_file_last_modified": "2023-06-05T03:54:07Z",
+                      "_ab_source_file_url": "a.csv"}, "stream": "stream1"},
+            {"data": {"col1": "val11b", "col2": "val12b", "col3": "val13b", "_ab_source_file_last_modified": "2023-06-05T03:54:07Z",
+                      "_ab_source_file_url": "b.csv"}, "stream": "stream2"},
+            {"data": {"col1": "val21b", "col2": "val22b", "col3": "val23b", "_ab_source_file_last_modified": "2023-06-05T03:54:07Z",
+                      "_ab_source_file_url": "b.csv"}, "stream": "stream2"},
+            {"data": {"col1": "val11c", "_ab_source_file_last_modified": "2023-06-05T03:54:07Z",
+                      "_ab_source_file_url": "c.csv"}, "stream": "stream3"},
+            {"data": {"col1": "val21c", "_ab_source_file_last_modified": "2023-06-05T03:54:07Z",
+                      "_ab_source_file_url": "c.csv"}, "stream": "stream3"},
+        ]
+    )
+    .set_expected_logs({
+        "read": [
+            {
+                'level': 'WARNING',
+                'message': 'Could not cast the value to the expected type.: col2: value=val12b,expected_type=integer',
+            },
+            {
+                'level': 'WARNING',
+                'message': 'Could not cast the value to the expected type.: col2: value=val12b,expected_type=integer',
+            },
+            {
+                'level': 'WARNING',
+                'message': 'Could not cast the value to the expected type.: col2: value=val22b,expected_type=integer',
+            },
+        ]
+
+    })
+).build()
+
+
+multi_stream_user_input_schema_scenario_skip_nonconforming_records = (
+    _base_multi_stream_user_input_schema_scenario.copy()
+    .set_name("multi_stream_user_input_schema_scenario_skip_nonconforming_records")
+    .set_config(
+        {
+            "streams": [
+                {
+                    "name": "stream1",
+                    "file_type": "csv",
+                    "globs": ["a.csv"],
+                    "validation_policy": "emit_record",
+                    "input_schema": '{"col1": "string", "col2": "integer"}',
+                },
+                {
+                    "name": "stream2",
+                    "file_type": "csv",
+                    "globs": ["b.csv"],
+                    "validation_policy": "skip_record",
+                    "input_schema": '{"col1": "string", "col2": "integer", "col3": "string"}',  # this stream's records do not conform to the schema
+                },
+                {
+                    "name": "stream3",
+                    "file_type": "csv",
+                    "globs": ["c.csv"],
+                    "validation_policy": "emit_record",
+                },
+
+            ]
+        }
+    )
+    .set_expected_catalog(
+        {
+            "streams": [
+                {
+                    "default_cursor_field": ["_ab_source_file_last_modified"],
+                    "json_schema": {
+                        "type": "object",
+                        "properties": {
+                            "col1": {
+                                "type": "string"
+                            },
+                            "col2": {
+                                "type": "integer"
+                            },
+                            "_ab_source_file_last_modified": {
+                                "type": "string"
+                            },
+                            "_ab_source_file_url": {
+                                "type": "string"
+                            },
+                        },
+                    },
+                    "name": "stream1",
+                    "source_defined_cursor": True,
+                    "supported_sync_modes": ["full_refresh", "incremental"],
+                },
+                {
+                    "default_cursor_field": ["_ab_source_file_last_modified"],
+                    "json_schema": {
+                        "type": "object",
+                        "properties": {
+                            "col1": {
+                                "type": "string"
+                            },
+                            "col2": {
+                                "type": "integer"
+                            },
+                            "col3": {
+                                "type": "string"
+                            },
+                            "_ab_source_file_last_modified": {
+                                "type": "string"
+                            },
+                            "_ab_source_file_url": {
+                                "type": "string"
+                            },
+                        },
+                    },
+                    "name": "stream2",
+                    "source_defined_cursor": True,
+                    "supported_sync_modes": ["full_refresh", "incremental"],
+                },
+                {
+                    "default_cursor_field": ["_ab_source_file_last_modified"],
+                    "json_schema": {
+                        "type": "object",
+                        "properties": {
+                            "col1": {
+                                "type": "string",
+                            },
+                            "_ab_source_file_last_modified": {
+                                "type": "string"
+                            },
+                            "_ab_source_file_url": {
+                                "type": "string"
+                            },
+                        },
+                    },
+                    "name": "stream3",
+                    "source_defined_cursor": True,
+                    "supported_sync_modes": ["full_refresh", "incremental"],
+                },
+            ]
+        }
+    )
+    .set_expected_check_status("FAILED")
+    .set_expected_check_error(None, FileBasedSourceError.ERROR_PARSING_USER_PROVIDED_SCHEMA.value)
+    .set_expected_records(
+        [
+            {"data": {"col1": "val11a", "col2": 21, "_ab_source_file_last_modified": "2023-06-05T03:54:07Z",
+                      "_ab_source_file_url": "a.csv"}, "stream": "stream1"},
+            {"data": {"col1": "val12a", "col2": 22, "_ab_source_file_last_modified": "2023-06-05T03:54:07Z",
+                      "_ab_source_file_url": "a.csv"}, "stream": "stream1"},
+            # {"data": {"col1": "val11b", "col2": "val12b", "col3": "val13b", "_ab_source_file_last_modified": "2023-06-05T03:54:07Z",
+            #           "_ab_source_file_url": "b.csv"}, "stream": "stream2"},
+            # {"data": {"col1": "val21b", "col2": "val22b", "col3": "val23b", "_ab_source_file_last_modified": "2023-06-05T03:54:07Z",
+            #           "_ab_source_file_url": "b.csv"}, "stream": "stream2"},
+            {"data": {"col1": "val11c", "_ab_source_file_last_modified": "2023-06-05T03:54:07Z",
+                      "_ab_source_file_url": "c.csv"}, "stream": "stream3"},
+            {"data": {"col1": "val21c", "_ab_source_file_last_modified": "2023-06-05T03:54:07Z",
+                      "_ab_source_file_url": "c.csv"}, "stream": "stream3"},
+        ]
+    )
+    .set_expected_logs({
+        "read": [
+            {
+                'level': 'WARN',
+                'message': 'Records in file did not pass validation policy. stream=stream2 file=b.csv n_skipped=2 validation_policy=skip_record',
+            },
+            {
+                'level': 'WARNING',
+                'message': 'Could not cast the value to the expected type.: col2: value=val12b,expected_type=integer',
+            },
+            {
+                'level': 'WARNING',
+                'message': 'Could not cast the value to the expected type.: col2: value=val12b,expected_type=integer',
+            },
+            {
+                'level': 'WARNING',
+                'message': 'Could not cast the value to the expected type.: col2: value=val22b,expected_type=integer',
+            },
+        ]
+    })
+).build()

--- a/airbyte-cdk/python/unit_tests/sources/file_based/scenarios/validation_policy_scenarios.py
+++ b/airbyte-cdk/python/unit_tests/sources/file_based/scenarios/validation_policy_scenarios.py
@@ -223,18 +223,18 @@ skip_record_scenario_single_stream = (
             {"data": {"col1": "val_d_11", "_ab_source_file_last_modified": "2023-06-05T03:54:07Z", "_ab_source_file_url": "d.csv"}, "stream": "stream1"},
         ]
     )
-    .set_expected_logs(
-        [
+    .set_expected_logs({
+        "read": [
             {
-                "level": "INFO",
+                "level": "WARN",
                 "message": "Records in file did not pass validation policy. stream=stream1 file=a.csv n_skipped=2 validation_policy=skip_record",
             },
             {
-                "level": "INFO",
+                "level": "WARN",
                 "message": "Records in file did not pass validation policy. stream=stream1 file=c.csv n_skipped=1 validation_policy=skip_record",
             },
         ]
-    )
+    })
 ).build()
 
 
@@ -278,22 +278,22 @@ skip_record_scenario_multi_stream = (
             {"data": {"col1": "val_bb3_12", "_ab_source_file_last_modified": "2023-06-05T03:54:07Z", "_ab_source_file_url": "b/b3.csv"}, "stream": "stream2"},
         ]
     )
-    .set_expected_logs(
-        [
+    .set_expected_logs({
+        "read": [
             {
-                "level": "INFO",
+                "level": "WARN",
                 "message": "Records in file did not pass validation policy. stream=stream1 file=a/a1.csv n_skipped=2 validation_policy=skip_record",
             },
             {
-                "level": "INFO",
+                "level": "WARN",
                 "message": "Records in file did not pass validation policy. stream=stream1 file=a/a3.csv n_skipped=1 validation_policy=skip_record",
             },
             {
-                "level": "INFO",
+                "level": "WARN",
                 "message": "Records in file did not pass validation policy. stream=stream2 file=b/b2.csv n_skipped=2 validation_policy=skip_record",
             },
         ]
-    )
+    })
 ).build()
 
 
@@ -320,18 +320,18 @@ emit_record_scenario_single_stream = (
             {"data": {"col1": "val_b_12", "_ab_source_file_last_modified": "2023-06-05T03:54:07Z", "_ab_source_file_url": "b.csv"}, "stream": "stream1"},
             {"data": {"col1": "val_c_11", "_ab_source_file_last_modified": "2023-06-05T03:54:07Z", "_ab_source_file_url": "c.csv"}, "stream": "stream1"},
             # {"data": {"col1": "val_c_12", None: "val_c_22", "_ab_source_file_last_modified": "2023-06-05T03:54:07Z", "_ab_source_file_url": "c.csv"}, "stream": "stream1"},  # This record is malformed so should not be emitted
-            # {"data": {"col1": "val_c_13", "_ab_source_file_last_modified": "2023-06-05T03:54:07Z", "_ab_source_file_url": "c.csv"}, "stream": "stream1"},  # No more records from this file are emitted after we hit a parse error
-            {"data": {"col1": "val_d_11", "_ab_source_file_last_modified": "2023-06-05T03:54:07Z", "_ab_source_file_url": "d.csv"}, "stream": "stream1"},
+            # {"data": {"col1": "val_c_13", "_ab_source_file_last_modified": "2023-06-05T03:54:07Z", "_ab_source_file_url": "c.csv"}, "stream": "stream1"},  # No more records from this stream are emitted after we hit a parse error
+            # {"data": {"col1": "val_d_11", "_ab_source_file_last_modified": "2023-06-05T03:54:07Z", "_ab_source_file_url": "d.csv"}, "stream": "stream1"},
         ]
     )
-    .set_expected_logs(
-        [
+    .set_expected_logs({
+        "read": [
             {
                 "level": "ERROR",
                 "message": f"{FileBasedSourceError.ERROR_PARSING_RECORD.value} stream=stream1 file=c.csv line_no=2 n_skipped=0",
             },
         ]
-    )
+    })
 ).build()
 
 
@@ -365,8 +365,8 @@ emit_record_scenario_multi_stream = (
             {"data": {"col1": "val_aa2_12", "_ab_source_file_last_modified": "2023-06-05T03:54:07Z", "_ab_source_file_url": "a/a2.csv"}, "stream": "stream1"},
             {"data": {"col1": "val_aa3_11", "_ab_source_file_last_modified": "2023-06-05T03:54:07Z", "_ab_source_file_url": "a/a3.csv"}, "stream": "stream1"},
             # {"data": {"col1": "val_aa3_12", None: "val_aa3_22", "_ab_source_file_last_modified": "2023-06-05T03:54:07Z", "_ab_source_file_url": "a/a3.csv"}, "stream": "stream1"},  # This record is malformed so should not be emitted
-            # {"data": {"col1": "val_aa3_13", "_ab_source_file_last_modified": "2023-06-05T03:54:07Z", "_ab_source_file_url": "a/a3.csv"}, "stream": "stream1"},  # No more records from this file are emitted after we hit a parse error
-            {"data": {"col1": "val_aa4_11", "_ab_source_file_last_modified": "2023-06-05T03:54:07Z", "_ab_source_file_url": "a/a4.csv"}, "stream": "stream1"},
+            # {"data": {"col1": "val_aa3_13", "_ab_source_file_last_modified": "2023-06-05T03:54:07Z", "_ab_source_file_url": "a/a3.csv"}, "stream": "stream1"},  # No more records from this stream are emitted after we hit a parse error
+            # {"data": {"col1": "val_aa4_11", "_ab_source_file_last_modified": "2023-06-05T03:54:07Z", "_ab_source_file_url": "a/a4.csv"}, "stream": "stream1"},
             {"data": {"col1": "val_bb1_11", "_ab_source_file_last_modified": "2023-06-05T03:54:07Z", "_ab_source_file_url": "b/b1.csv"}, "stream": "stream2"},
             {"data": {"col1": "val_bb1_12", "_ab_source_file_last_modified": "2023-06-05T03:54:07Z", "_ab_source_file_url": "b/b1.csv"}, "stream": "stream2"},
             {"data": {"col1": "val_bb2_11", "col2": "val_bb2_21", "_ab_source_file_last_modified": "2023-06-05T03:54:07Z", "_ab_source_file_url": "b/b2.csv"}, "stream": "stream2"},
@@ -375,14 +375,14 @@ emit_record_scenario_multi_stream = (
             {"data": {"col1": "val_bb3_12", "_ab_source_file_last_modified": "2023-06-05T03:54:07Z", "_ab_source_file_url": "b/b3.csv"}, "stream": "stream2"},
         ]
     )
-    .set_expected_logs(
-        [
+    .set_expected_logs({
+        "read": [
             {
                 "level": "ERROR",
                 "message": f"{FileBasedSourceError.ERROR_PARSING_RECORD.value} stream=stream1 file=a/a3.csv line_no=2 n_skipped=0",
             },
         ]
-    )
+    })
 ).build()
 
 
@@ -404,14 +404,16 @@ wait_for_rediscovery_scenario_single_stream = (
     .set_expected_records(
         []  # No records are expected because the very first file did not conform to the schema
     )
-    .set_expected_logs(
-        [
+    .set_expected_logs({
+        "read": [
             {
-                "level": "INFO",
-                "message": "Stopping sync in accordance with the configured validation policy. Records in file did not conform to the schema. stream=stream1 file=a.csv validation_policy=wait_for_discover n_skipped=0",
+                # For this stream, the record that we check during the availability check does conform to the schema, but during the sync
+                # we encounter a record that does not, so stop the in-progress sync.
+                "level": "WARNING",
+                "message": "Skipped syncing stream 'stream1' because it was unavailable.",
             },
         ]
-    )
+    })
 ).build()
 
 
@@ -455,18 +457,22 @@ wait_for_rediscovery_scenario_multi_stream = (
             # {"data": {"col1": "val_bb3_12", "_ab_source_file_last_modified": "2023-06-05T03:54:07Z", "_ab_source_file_url": "b/b3.csv"}, "stream": "stream2"},
         ]
     )
-    .set_expected_logs(
-        [
+    .set_expected_logs({
+        "read": [
             {
-                "level": "INFO",
-                "message": "Stopping sync in accordance with the configured validation policy. Records in file did not conform to the schema. stream=stream1 file=a/a1.csv validation_policy=wait_for_discover n_skipped=0",
-            },
-            {
-                "level": "INFO",
+                # For this stream, the record that we check during the availability check does not conform to the schema so we do not proceed
+                # with the sync for that stream.
+                "level": "WARN",
                 "message": "Stopping sync in accordance with the configured validation policy. Records in file did not conform to the schema. stream=stream2 file=b/b2.csv validation_policy=wait_for_discover n_skipped=0",
             },
+            {
+                # For this stream, the record that we check during the availability check does conform to the schema, but during the sync
+                # we encounter a record that does not, so stop the in-progress sync.
+                "level": "WARNING",
+                "message": "Skipped syncing stream 'stream1' because it was unavailable.",
+            },
         ]
-    )
+    })
 ).build()
 
 

--- a/airbyte-cdk/python/unit_tests/sources/file_based/test_scenarios.py
+++ b/airbyte-cdk/python/unit_tests/sources/file_based/test_scenarios.py
@@ -64,6 +64,16 @@ from unit_tests.sources.file_based.scenarios.parquet_scenarios import (
     single_parquet_scenario,
 )
 from unit_tests.sources.file_based.scenarios.scenario_builder import TestScenario
+from unit_tests.sources.file_based.scenarios.user_input_schema_scenarios import (
+    multi_stream_user_input_schema_scenario_emit_nonconforming_records,
+    multi_stream_user_input_schema_scenario_schema_is_invalid,
+    multi_stream_user_input_schema_scenario_skip_nonconforming_records,
+    single_stream_user_input_schema_scenario_emit_nonconforming_records,
+    single_stream_user_input_schema_scenario_schema_is_invalid,
+    single_stream_user_input_schema_scenario_skip_nonconforming_records,
+    valid_multi_stream_user_input_schema_scenario,
+    valid_single_stream_user_input_schema_scenario,
+)
 from unit_tests.sources.file_based.scenarios.validation_policy_scenarios import (
     emit_record_scenario_multi_stream,
     emit_record_scenario_single_stream,
@@ -108,19 +118,34 @@ discover_scenarios = [
     schemaless_csv_multi_stream_scenario,
     schemaless_with_user_input_schema_fails_connection_check_multi_stream_scenario,
     schemaless_with_user_input_schema_fails_connection_check_scenario,
+    single_stream_user_input_schema_scenario_schema_is_invalid,
+    single_stream_user_input_schema_scenario_emit_nonconforming_records,
+    single_stream_user_input_schema_scenario_skip_nonconforming_records,
+    multi_stream_user_input_schema_scenario_emit_nonconforming_records,
+    multi_stream_user_input_schema_scenario_skip_nonconforming_records,
+    multi_stream_user_input_schema_scenario_schema_is_invalid,
+    valid_multi_stream_user_input_schema_scenario,
+    valid_single_stream_user_input_schema_scenario,
 ]
 
 
 @pytest.mark.parametrize("scenario", discover_scenarios, ids=[s.name for s in discover_scenarios])
 def test_discover(capsys: CaptureFixture[str], tmp_path: PosixPath, scenario: TestScenario) -> None:
     expected_exc, expected_msg = scenario.expected_discover_error
+    expected_logs = scenario.expected_logs
     if expected_exc:
         with pytest.raises(expected_exc) as exc:
             discover(capsys, tmp_path, scenario)
         if expected_msg:
             assert expected_msg in get_error_message_from_exc(exc)
     else:
-        assert discover(capsys, tmp_path, scenario) == scenario.expected_catalog
+        output = discover(capsys, tmp_path, scenario)
+        catalog, logs = output["catalog"], output["logs"]
+        assert catalog == scenario.expected_catalog
+        if expected_logs:
+            expected_logs = expected_logs.get("discover", [])
+            logs = [log for log in logs if log.get("log", {}).get("level") in ("ERROR", "WARN")]
+            _verify_expected_logs(logs, expected_logs)
 
 
 read_scenarios = discover_scenarios + [
@@ -137,61 +162,63 @@ read_scenarios = discover_scenarios + [
 
 @pytest.mark.parametrize("scenario", read_scenarios, ids=[s.name for s in read_scenarios])
 @freeze_time("2023-06-09T00:00:00Z")
-def test_read(capsys: CaptureFixture[str], tmp_path: PosixPath, scenario: TestScenario) -> None:
+def test_read(capsys: CaptureFixture[str], caplog: CaptureFixture[str], tmp_path: PosixPath, scenario: TestScenario):
     if scenario.incremental_scenario_config:
-        run_test_read_incremental(capsys, tmp_path, scenario)
+        run_test_read_incremental(capsys, caplog, tmp_path, scenario)
     else:
-        run_test_read_full_refresh(capsys, tmp_path, scenario)
+        run_test_read_full_refresh(capsys, caplog, tmp_path, scenario)
 
 
-def run_test_read_full_refresh(capsys: CaptureFixture[str], tmp_path: PosixPath, scenario: TestScenario) -> None:
+def run_test_read_full_refresh(capsys: CaptureFixture[str], caplog: CaptureFixture[str], tmp_path: PosixPath, scenario: TestScenario) -> None:
     expected_exc, expected_msg = scenario.expected_read_error
-    expected_records = scenario.expected_records
-    expected_logs = scenario.expected_logs
     if expected_exc:
         with pytest.raises(expected_exc) as exc:  # noqa
-            read(capsys, tmp_path, scenario)
+            read(capsys, caplog, tmp_path, scenario)
         if expected_msg:
             assert expected_msg in get_error_message_from_exc(exc)
     else:
-        output = read(capsys, tmp_path, scenario)
-        records, logs = output["records"], output["logs"]
-        assert len(records) == len(expected_records)
-        assert len(logs) == len(expected_logs)
-        assert_expected_records_match_output(records, expected_records)
-        assert_expected_logs_match_output(logs, expected_logs)
+        output = read(capsys, caplog, tmp_path, scenario)
+        _verify_read_output(output, scenario)
 
 
-def assert_expected_records_match_output(output: List[Mapping[str, Any]], expected_output: List[Mapping[str, Any]]) -> None:
-    for actual, expected in zip(output, expected_output):
-        for key, value in actual["record"]["data"].items():
-            if isinstance(value, float):
-                assert math.isclose(value, expected["data"][key], abs_tol=1e-06)
-            else:
-                assert value == expected["data"][key]
-        assert actual["record"]["stream"] == expected["stream"]
-
-
-def assert_expected_logs_match_output(logs: List[Mapping[str, Any]], expected_logs: List[Mapping[str, Any]]) -> None:
-    for actual, expected in zip(logs, expected_logs):
-        assert actual["log"]["level"] == expected["level"]
-        assert actual["log"]["message"] == expected["message"]
-
-
-def run_test_read_incremental(capsys: CaptureFixture[str], tmp_path: PosixPath, scenario: TestScenario) -> None:
+def run_test_read_incremental(capsys: CaptureFixture[str], caplog: CaptureFixture[str], tmp_path: PosixPath, scenario: TestScenario) -> None:
     expected_exc, expected_msg = scenario.expected_read_error
     if expected_exc:
         with pytest.raises(expected_exc):
-            read_with_state(capsys, tmp_path, scenario)
+            read_with_state(capsys, caplog, tmp_path, scenario)
     else:
-        output = read_with_state(capsys, tmp_path, scenario)
-        expected_output = scenario.expected_records
-        assert len(output) == len(expected_output)
-        for actual, expected in zip(output, expected_output):
-            if "record" in actual:
-                assert actual["record"]["data"] == expected
-            elif "state" in actual:
-                assert actual["state"]["data"] == expected
+        output = read_with_state(capsys, caplog, tmp_path, scenario)
+        _verify_read_output(output, scenario)
+
+
+def _verify_read_output(output, scenario):
+    records, logs = output["records"], output["logs"]
+    logs = [log for log in logs if log.get("level") in ("ERROR", "WARN", "WARNING")]
+    expected_records = scenario.expected_records
+    assert len(records) == len(expected_records)
+    for actual, expected in zip(records, expected_records):
+        if "record" in actual:
+            for key, value in actual["record"]["data"].items():
+                if isinstance(value, float):
+                    assert math.isclose(value, expected["data"][key], abs_tol=1e-06)
+                else:
+                    assert value == expected["data"][key]
+            assert actual["record"]["stream"] == expected["stream"]
+        elif "state" in actual:
+            assert actual["state"]["data"] == expected
+
+    if scenario.expected_logs:
+        expected_logs = scenario.expected_logs.get("read", [])
+        assert len(logs) == len(expected_logs)
+        _verify_expected_logs(logs, expected_logs)
+
+
+def _verify_expected_logs(logs: List[Dict[str, Any]], expected_logs: List[Dict[str, Any]]):
+    for actual, expected in zip(logs, expected_logs):
+        actual_level, actual_message = actual["level"], actual["message"]
+        expected_level, expected_message = expected["level"], expected["message"]
+        assert actual_level == expected_level
+        assert expected_message in actual_message
 
 
 spec_scenarios = [
@@ -202,7 +229,7 @@ spec_scenarios = [
 
 @pytest.mark.parametrize("scenario", spec_scenarios, ids=[c.name for c in spec_scenarios])
 def test_spec(capsys, scenario):
-    assert spec(capsys, single_csv_scenario) == single_csv_scenario.expected_spec
+    assert spec(capsys, scenario) == single_csv_scenario.expected_spec
 
 
 check_scenarios = [
@@ -218,6 +245,7 @@ check_scenarios = [
     success_user_provided_schema_scenario,
     schemaless_with_user_input_schema_fails_connection_check_multi_stream_scenario,
     schemaless_with_user_input_schema_fails_connection_check_scenario,
+    valid_single_stream_user_input_schema_scenario,
 ]
 
 
@@ -261,11 +289,15 @@ def discover(capsys: CaptureFixture[str], tmp_path: PosixPath, scenario: TestSce
         scenario.source,
         ["discover", "--config", make_file(tmp_path / "config.json", scenario.config)],
     )
-    captured = capsys.readouterr()
-    return json.loads(captured.out.splitlines()[0])["catalog"]  # type: ignore
+    output = [json.loads(line) for line in capsys.readouterr().out.splitlines()]
+    [catalog] = [o["catalog"] for o in output if o.get("catalog")]  # type: ignore
+    return {
+            "catalog": catalog,
+            "logs": [o["log"] for o in output if o.get("log")],
+        }
 
 
-def read(capsys: CaptureFixture[str], tmp_path: PosixPath, scenario: TestScenario) -> Dict[str, Any]:
+def read(capsys: CaptureFixture[str], caplog: CaptureFixture[str], tmp_path: PosixPath, scenario: TestScenario) -> Dict[str, Any]:
     launch(
         scenario.source,
         [
@@ -277,6 +309,7 @@ def read(capsys: CaptureFixture[str], tmp_path: PosixPath, scenario: TestScenari
         ],
     )
     captured = capsys.readouterr().out.splitlines()
+    logs = caplog.records
     return {
         "records": [
             msg
@@ -284,14 +317,14 @@ def read(capsys: CaptureFixture[str], tmp_path: PosixPath, scenario: TestScenari
             if msg["type"] == "RECORD"
         ],
         "logs": [
-            msg
+            msg["log"]
             for msg in (json.loads(line) for line in captured)
             if msg["type"] == "LOG"
-        ]
+        ] + [{"level": log.levelname, "message": log.message} for log in logs]
     }
 
 
-def read_with_state(capsys: CaptureFixture[str], tmp_path: PosixPath, scenario: TestScenario) -> List[Dict[str, Any]]:
+def read_with_state(capsys: CaptureFixture[str], caplog: CaptureFixture[str], tmp_path: PosixPath, scenario: TestScenario) -> Dict[str, List[Any]]:
     launch(
         scenario.source,
         [
@@ -305,11 +338,19 @@ def read_with_state(capsys: CaptureFixture[str], tmp_path: PosixPath, scenario: 
         ],
     )
     captured = capsys.readouterr()
-    return [
-        msg
-        for msg in (json.loads(line) for line in captured.out.splitlines())
-        if msg["type"] in ("RECORD", "STATE")
-    ]
+    logs = caplog.records
+    return {
+        "records": [
+            msg
+            for msg in (json.loads(line) for line in captured.out.splitlines())
+            if msg["type"] in ("RECORD", "STATE")
+        ],
+        "logs": [
+            msg["log"]
+            for msg in (json.loads(line) for line in captured.out.splitlines())
+            if msg["type"] == "LOG"
+        ] + [{"level": log.levelname, "message": log.message} for log in logs]
+    }
 
 
 def make_file(path: Path, file_contents: Optional[Union[Mapping[str, Any], List[Mapping[str, Any]]]]) -> str:

--- a/airbyte-cdk/python/unit_tests/sources/file_based/test_schema_helpers.py
+++ b/airbyte-cdk/python/unit_tests/sources/file_based/test_schema_helpers.py
@@ -5,8 +5,8 @@
 from typing import Any, Mapping
 
 import pytest
-from airbyte_cdk.sources.file_based.exceptions import SchemaInferenceError
-from airbyte_cdk.sources.file_based.schema_helpers import ComparableType, conforms_to_schema, merge_schemas
+from airbyte_cdk.sources.file_based.exceptions import ConfigValidationError, SchemaInferenceError
+from airbyte_cdk.sources.file_based.schema_helpers import ComparableType, conforms_to_schema, merge_schemas, type_mapping_to_jsonschema
 
 COMPLETE_CONFORMING_RECORD = {
     "null_field": None,
@@ -243,3 +243,103 @@ def test_merge_schemas(schema1, schema2, expected_result):
     else:
         with pytest.raises(SchemaInferenceError):
             merge_schemas(schema1, schema2)
+
+
+@pytest.mark.parametrize(
+    "type_mapping,expected_schema,expected_exc_msg",
+    [
+        pytest.param(
+            '{"col1": "null", "col2": "array", "col3": "boolean", "col4": "float", "col5": "integer", "col6": "number", "col7": "object", "col8": "string"}',
+            {
+                "type": "object",
+                "properties": {
+                    "col1": {
+                        "type": "null"
+                    },
+                    "col2": {
+                        "type": "array"
+                    },
+                    "col3": {
+                        "type": "boolean"
+                    },
+                    "col4": {
+                        "type": "number"
+                    },
+                    "col5": {
+                        "type": "integer"
+                    },
+                    "col6": {
+                        "type": "number"
+                    },
+                    "col7": {
+                        "type": "object"
+                    },
+                    "col8": {
+                        "type": "string"
+                    }
+                }
+            },
+            None,
+            id="valid_all_types"
+        ),
+        pytest.param(
+            '{"col1 ": " string", "col2":  " integer"}',
+            {
+                "type": "object",
+                "properties": {
+                    "col1": {
+                        "type": "string"
+                    },
+                    "col2": {
+                        "type": "integer"
+                    }
+                }
+            },
+            None,
+            id="valid_extra_spaces",
+        ),
+        pytest.param(
+            "",
+            None,
+            None,
+            id="valid_empty_string",
+        ),
+        pytest.param(
+            '{"col1": "x", "col2": "integer"}',
+            None,
+            "Invalid type 'x' for property 'col1'",
+            id="invalid_type",
+        ),
+        pytest.param(
+            '{"col1": "", "col2": "integer"}',
+            None,
+            "Invalid input schema",
+            id="invalid_missing_type",
+        ),
+        pytest.param(
+            '{"": "string", "col2": "integer"}',
+            None,
+            "Invalid input schema",
+            id="invalid_missing_name",
+        ),
+        pytest.param(
+            '{"type": "object", "properties": {"col1": {"type": "string"}, "col2": {"type": "integer"}}}',
+            None,
+            "Invalid input schema; nested schemas are not supported.",
+            id="invalid_nested_input_string",
+        ),
+        pytest.param(
+            '{"type": "object", "properties": {"col1": {"type": "string"}, "col2": {"type": "integer"}}}',
+            None,
+            "Invalid input schema; nested schemas are not supported.",
+            id="invalid_nested_input_json",
+        ),
+    ],
+)
+def test_type_mapping_to_jsonschema(type_mapping, expected_schema, expected_exc_msg):
+    if expected_exc_msg:
+        with pytest.raises(ConfigValidationError) as exc:
+            type_mapping_to_jsonschema(type_mapping)
+        assert expected_exc_msg in exc.value.args[0]
+    else:
+        assert type_mapping_to_jsonschema(type_mapping) == expected_schema


### PR DESCRIPTION
## What
Wires through the ability for users to input a schema, in as a name-type mapping.

## How
Allows the user to input a schema in name-type mapping format, as a comma-separated or JSON string.

We then validate the input schema and turn it into a JSON Schema at `FileBasedStreamConfig` creation time.

- During `check`, if a user has input a schema, we verify that a record from one file conforms to the schema so that they can modify it if needed.
- During `read`, if a user has input a schema, we attempt to cast the types from CSVs to the type in the schema. On error we keep the value's type a string.

## Recommended reading order
1. `airbyte-cdk/python/airbyte_cdk/sources/file_based/config/file_based_stream_config.py`
2. `airbyte-cdk/python/airbyte_cdk/sources/file_based/file_types/csv_parser.py`
3. `airbyte-cdk/python/airbyte_cdk/sources/file_based/schema_helpers.py`
4. `airbyte-cdk/python/airbyte_cdk/sources/file_based/default_file_based_availability_strategy.py`

Closes https://github.com/airbytehq/airbyte/issues/26759.