### PR TITLE
File-based CDK: implement schemaless option

### DIFF
--- a/airbyte-cdk/python/airbyte_cdk/sources/file_based/config/file_based_stream_config.py
+++ b/airbyte-cdk/python/airbyte_cdk/sources/file_based/config/file_based_stream_config.py
@@ -72,6 +72,7 @@ class FileBasedStreamConfig(BaseModel):
     max_history_size: Optional[int]
     days_to_sync_if_history_is_full: Optional[int]
     format: Optional[Mapping[str, CsvFormat]]  # this will eventually be a Union once we have more than one format type
+    schemaless: bool = False
 
     @validator("file_type", pre=True)
     def validate_file_type(cls, v):

--- a/airbyte-cdk/python/airbyte_cdk/sources/file_based/schema_helpers.py
+++ b/airbyte-cdk/python/airbyte_cdk/sources/file_based/schema_helpers.py
@@ -14,6 +14,8 @@ type_widths = {str: 0}
 JsonSchemaSupportedType = Union[List, Literal["string"], str]
 SchemaType = Dict[str, Dict[str, JsonSchemaSupportedType]]
 
+schemaless_schema = {"data": {"type": "object"}}
+
 
 @total_ordering
 class ComparableType(Enum):

--- a/airbyte-cdk/python/unit_tests/sources/file_based/scenarios/csv_scenarios.py
+++ b/airbyte-cdk/python/unit_tests/sources/file_based/scenarios/csv_scenarios.py
@@ -778,3 +778,185 @@ empty_schema_inference_scenario = (
         ]
     )
 ).build()
+
+
+schemaless_csv_scenario = (
+    TestScenarioBuilder()
+    .set_name("schemaless_csv_scenario")
+    .set_config(
+        {
+            "streams": [
+                {
+                    "name": "stream1",
+                    "file_type": "csv",
+                    "globs": ["*"],
+                    "validation_policy": "skip_record",
+                    "schemaless": True,
+                }
+            ]
+        }
+    )
+    .set_files(
+        {
+            "a.csv": {
+                "contents": [
+                    ("col1", "col2"),
+                    ("val11a", "val12a"),
+                    ("val21a", "val22a"),
+                ],
+                "last_modified": "2023-06-05T03:54:07.000Z",
+            },
+            "b.csv": {
+                "contents": [
+                    ("col1", "col2", "col3"),
+                    ("val11b", "val12b", "val13b"),
+                    ("val21b", "val22b", "val23b"),
+                ],
+                "last_modified": "2023-06-05T03:54:07.000Z",
+            },
+        }
+    )
+    .set_file_type("csv")
+    .set_expected_catalog(
+        {
+            "streams": [
+                {
+                    "default_cursor_field": ["_ab_source_file_last_modified"],
+                    "json_schema": {
+                        "type": "object",
+                        "properties": {
+                            "data": {
+                                "type": "object"
+                            },
+                            "_ab_source_file_last_modified": {
+                                "type": "string"
+                            },
+                            "_ab_source_file_url": {
+                                "type": "string"
+                            },
+                        }
+                    },
+                    "name": "stream1",
+                    "source_defined_cursor": True,
+                    "supported_sync_modes": ["full_refresh", "incremental"],
+                }
+            ]
+        }
+    )
+    .set_expected_records(
+        [
+            {"data": {"data": {"col1": "val11a", "col2": "val12a"}, "_ab_source_file_last_modified": "2023-06-05T03:54:07Z",
+                      "_ab_source_file_url": "a.csv"}, "stream": "stream1"},
+            {"data": {"data": {"col1": "val21a", "col2": "val22a"}, "_ab_source_file_last_modified": "2023-06-05T03:54:07Z",
+                      "_ab_source_file_url": "a.csv"}, "stream": "stream1"},
+            {"data": {"data": {"col1": "val11b", "col2": "val12b", "col3": "val13b"}, "_ab_source_file_last_modified": "2023-06-05T03:54:07Z",
+                      "_ab_source_file_url": "b.csv"}, "stream": "stream1"},
+            {"data": {"data": {"col1": "val21b", "col2": "val22b", "col3": "val23b"}, "_ab_source_file_last_modified": "2023-06-05T03:54:07Z",
+                      "_ab_source_file_url": "b.csv"}, "stream": "stream1"},
+        ]
+    )
+).build()
+
+
+schemaless_csv_multi_stream_scenario = (
+    TestScenarioBuilder()
+    .set_name("schemaless_csv_multi_stream_scenario")
+    .set_config(
+        {
+            "streams": [
+                {
+                    "name": "stream1",
+                    "file_type": "csv",
+                    "globs": ["a.csv"],
+                    "validation_policy": "skip_record",
+                    "schemaless": True,
+                },
+                {
+                    "name": "stream2",
+                    "file_type": "csv",
+                    "globs": ["b.csv"],
+                    "validation_policy": "skip_record",
+                }
+            ]
+        }
+    )
+    .set_files(
+        {
+            "a.csv": {
+                "contents": [
+                    ("col1", "col2"),
+                    ("val11a", "val12a"),
+                    ("val21a", "val22a"),
+                ],
+                "last_modified": "2023-06-05T03:54:07.000Z",
+            },
+            "b.csv": {
+                "contents": [
+                    ("col3",),
+                    ("val13b",),
+                    ("val23b",),
+                ],
+                "last_modified": "2023-06-05T03:54:07.000Z",
+            },
+        }
+    )
+    .set_file_type("csv")
+    .set_expected_catalog(
+        {
+            "streams": [
+                {
+                    "json_schema": {
+                        "type": "object",
+                        "properties": {
+                            "data": {
+                                "type": "object"
+                            },
+                            "_ab_source_file_last_modified": {
+                                "type": "string"
+                            },
+                            "_ab_source_file_url": {
+                                "type": "string"
+                            },
+                        },
+                    },
+                    "name": "stream1",
+                    "supported_sync_modes": ["full_refresh", "incremental"],
+                    "source_defined_cursor": True,
+                    "default_cursor_field": ["_ab_source_file_last_modified"],
+                },
+                {
+                    "json_schema": {
+                        "type": "object",
+                        "properties": {
+                            "col3": {
+                                "type": "string"
+                            },
+                            "_ab_source_file_last_modified": {
+                                "type": "string"
+                            },
+                            "_ab_source_file_url": {
+                                "type": "string"
+                            },
+                        },
+                    },
+                    "name": "stream2",
+                    "source_defined_cursor": True,
+                    "default_cursor_field": ["_ab_source_file_last_modified"],
+                    "supported_sync_modes": ["full_refresh", "incremental"],
+                },
+            ]
+        }
+    )
+    .set_expected_records(
+        [
+            {"data": {"data": {"col1": "val11a", "col2": "val12a"}, "_ab_source_file_last_modified": "2023-06-05T03:54:07Z",
+                      "_ab_source_file_url": "a.csv"}, "stream": "stream1"},
+            {"data": {"data": {"col1": "val21a", "col2": "val22a"}, "_ab_source_file_last_modified": "2023-06-05T03:54:07Z",
+                      "_ab_source_file_url": "a.csv"}, "stream": "stream1"},
+            {"data": {"col3": "val13b", "_ab_source_file_last_modified": "2023-06-05T03:54:07Z", "_ab_source_file_url": "b.csv"},
+             "stream": "stream2"},
+            {"data": {"col3": "val23b", "_ab_source_file_last_modified": "2023-06-05T03:54:07Z", "_ab_source_file_url": "b.csv"},
+             "stream": "stream2"},
+        ]
+    )
+).build()

--- a/airbyte-cdk/python/unit_tests/sources/file_based/scenarios/csv_scenarios.py
+++ b/airbyte-cdk/python/unit_tests/sources/file_based/scenarios/csv_scenarios.py
@@ -2,7 +2,7 @@
 # Copyright (c) 2023 Airbyte, Inc., all rights reserved.
 #
 
-from airbyte_cdk.sources.file_based.exceptions import FileBasedSourceError, InvalidSchemaError, SchemaInferenceError
+from airbyte_cdk.sources.file_based.exceptions import ConfigValidationError, FileBasedSourceError, InvalidSchemaError, SchemaInferenceError
 from unit_tests.sources.file_based.helpers import EmptySchemaParser, LowInferenceLimitDiscoveryPolicy
 from unit_tests.sources.file_based.scenarios.scenario_builder import TestScenarioBuilder
 
@@ -959,4 +959,172 @@ schemaless_csv_multi_stream_scenario = (
              "stream": "stream2"},
         ]
     )
+).build()
+
+
+schemaless_with_user_input_schema_fails_connection_check_scenario = (
+    TestScenarioBuilder()
+    .set_name("schemaless_with_user_input_schema_fails_connection_check_scenario")
+    .set_config(
+        {
+            "streams": [
+                {
+                    "name": "stream1",
+                    "file_type": "csv",
+                    "globs": ["*"],
+                    "validation_policy": "skip_record",
+                    "input_schema": {"col1": "string", "col2": "string", "col3": "string"},
+                    "schemaless": True,
+                }
+            ]
+        }
+    )
+    .set_files(
+        {
+            "a.csv": {
+                "contents": [
+                    ("col1", "col2"),
+                    ("val11a", "val12a"),
+                    ("val21a", "val22a"),
+                ],
+                "last_modified": "2023-06-05T03:54:07.000Z",
+            },
+            "b.csv": {
+                "contents": [
+                    ("col1", "col2", "col3"),
+                    ("val11b", "val12b", "val13b"),
+                    ("val21b", "val22b", "val23b"),
+                ],
+                "last_modified": "2023-06-05T03:54:07.000Z",
+            },
+        }
+    )
+    .set_file_type("csv")
+    .set_expected_catalog(
+        {
+            "streams": [
+                {
+                    "default_cursor_field": ["_ab_source_file_last_modified"],
+                    "json_schema": {
+                        "type": "object",
+                        "properties": {
+                            "data": {
+                                "type": "object"
+                            },
+                            "_ab_source_file_last_modified": {
+                                "type": "string"
+                            },
+                            "_ab_source_file_url": {
+                                "type": "string"
+                            },
+                        }
+                    },
+                    "name": "stream1",
+                    "source_defined_cursor": True,
+                    "supported_sync_modes": ["full_refresh", "incremental"],
+                }
+            ]
+        }
+    )
+    .set_expected_check_status("FAILED")
+    .set_expected_check_error(ConfigValidationError, FileBasedSourceError.CONFIG_VALIDATION_ERROR.value)
+    .set_expected_discover_error(ConfigValidationError, FileBasedSourceError.CONFIG_VALIDATION_ERROR.value)
+    .set_expected_read_error(ConfigValidationError, FileBasedSourceError.CONFIG_VALIDATION_ERROR.value)
+).build()
+
+
+schemaless_with_user_input_schema_fails_connection_check_multi_stream_scenario = (
+    TestScenarioBuilder()
+    .set_name("schemaless_with_user_input_schema_fails_connection_check_multi_stream_scenario")
+    .set_config(
+        {
+            "streams": [
+                {
+                    "name": "stream1",
+                    "file_type": "csv",
+                    "globs": ["a.csv"],
+                    "validation_policy": "skip_record",
+                    "schemaless": True,
+                    "input_schema": {"col1": "string", "col2": "string", "col3": "string"},
+                },
+                {
+                    "name": "stream2",
+                    "file_type": "csv",
+                    "globs": ["b.csv"],
+                    "validation_policy": "skip_record",
+                }
+            ]
+        }
+    )
+    .set_files(
+        {
+            "a.csv": {
+                "contents": [
+                    ("col1", "col2"),
+                    ("val11a", "val12a"),
+                    ("val21a", "val22a"),
+                ],
+                "last_modified": "2023-06-05T03:54:07.000Z",
+            },
+            "b.csv": {
+                "contents": [
+                    ("col3",),
+                    ("val13b",),
+                    ("val23b",),
+                ],
+                "last_modified": "2023-06-05T03:54:07.000Z",
+            },
+        }
+    )
+    .set_file_type("csv")
+    .set_expected_catalog(
+        {
+            "streams": [
+                {
+                    "json_schema": {
+                        "type": "object",
+                        "properties": {
+                            "data": {
+                                "type": "object"
+                            },
+                            "_ab_source_file_last_modified": {
+                                "type": "string"
+                            },
+                            "_ab_source_file_url": {
+                                "type": "string"
+                            },
+                        },
+                    },
+                    "name": "stream1",
+                    "supported_sync_modes": ["full_refresh", "incremental"],
+                    "source_defined_cursor": True,
+                    "default_cursor_field": ["_ab_source_file_last_modified"],
+                },
+                {
+                    "json_schema": {
+                        "type": "object",
+                        "properties": {
+                            "col3": {
+                                "type": "string"
+                            },
+                            "_ab_source_file_last_modified": {
+                                "type": "string"
+                            },
+                            "_ab_source_file_url": {
+                                "type": "string"
+                            },
+                        },
+                    },
+                    "name": "stream2",
+                    "source_defined_cursor": True,
+                    "default_cursor_field": ["_ab_source_file_last_modified"],
+                    "supported_sync_modes": ["full_refresh", "incremental"],
+                },
+            ]
+        }
+    )
+    .set_expected_check_status("FAILED")
+    .set_expected_check_error(ConfigValidationError, FileBasedSourceError.CONFIG_VALIDATION_ERROR.value)
+    .set_expected_discover_error(ConfigValidationError, FileBasedSourceError.CONFIG_VALIDATION_ERROR.value)
+    .set_expected_read_error(ConfigValidationError, FileBasedSourceError.CONFIG_VALIDATION_ERROR.value)
 ).build()

--- a/airbyte-cdk/python/unit_tests/sources/file_based/test_scenarios.py
+++ b/airbyte-cdk/python/unit_tests/sources/file_based/test_scenarios.py
@@ -32,6 +32,8 @@ from unit_tests.sources.file_based.scenarios.csv_scenarios import (
     multi_csv_scenario,
     multi_csv_stream_n_file_exceeds_limit_for_inference,
     multi_stream_custom_format,
+    schemaless_csv_multi_stream_scenario,
+    schemaless_csv_scenario,
     single_csv_scenario,
 )
 from unit_tests.sources.file_based.scenarios.incremental_scenarios import (
@@ -87,6 +89,8 @@ discover_scenarios = [
     csv_custom_format_scenario,
     multi_stream_custom_format,
     empty_schema_inference_scenario,
+    schemaless_csv_scenario,
+    schemaless_csv_multi_stream_scenario,
 ]
 
 

--- a/airbyte-cdk/python/unit_tests/sources/file_based/test_scenarios.py
+++ b/airbyte-cdk/python/unit_tests/sources/file_based/test_scenarios.py
@@ -34,6 +34,8 @@ from unit_tests.sources.file_based.scenarios.csv_scenarios import (
     multi_stream_custom_format,
     schemaless_csv_multi_stream_scenario,
     schemaless_csv_scenario,
+    schemaless_with_user_input_schema_fails_connection_check_multi_stream_scenario,
+    schemaless_with_user_input_schema_fails_connection_check_scenario,
     single_csv_scenario,
 )
 from unit_tests.sources.file_based.scenarios.incremental_scenarios import (
@@ -91,6 +93,8 @@ discover_scenarios = [
     empty_schema_inference_scenario,
     schemaless_csv_scenario,
     schemaless_csv_multi_stream_scenario,
+    schemaless_with_user_input_schema_fails_connection_check_multi_stream_scenario,
+    schemaless_with_user_input_schema_fails_connection_check_scenario,
 ]
 
 
@@ -182,6 +186,8 @@ check_scenarios = [
     success_extensionless_scenario,
     success_multi_stream_scenario,
     success_user_provided_schema_scenario,
+    schemaless_with_user_input_schema_fails_connection_check_multi_stream_scenario,
+    schemaless_with_user_input_schema_fails_connection_check_scenario,
 ]
 
 


### PR DESCRIPTION
## What
Handle the "schemaless" config option.

This option allows users to emit records as JSON in a single "data" column.

## How
- Return the "schemaless" schema on `discover`.
- Once records have been parsed by the appropriate parser, wrap them in a data key - `{"data": <record>}`

Closes https://github.com/airbytehq/airbyte/issues/27013.