### PR TITLE
[Docs] Add comment for updating Airbyte Cloud IPs list

### DIFF
--- a/docs/cloud/getting-started-with-airbyte-cloud.md
+++ b/docs/cloud/getting-started-with-airbyte-cloud.md
@@ -197,6 +197,9 @@ Depending on your [data residency](https://docs.airbyte.com/cloud/managing-airby
 
 ### United States and Airbyte Default
 #### GCP region: us-west3
+
+[comment]: # (IMPORTANT: if changing the list of IP addresses below, you must also update the connector.airbyteCloudIpAddresses LaunchDarkly flag to show the new list so that the correct list is shown in the Airbyte Cloud UI, then reach out to the frontend team and ask them to update the default value in the useAirbyteCloudIps hook!)
+
 * 34.106.109.131
 * 34.106.196.165
 * 34.106.60.246


### PR DESCRIPTION
## What
Related to https://github.com/airbytehq/airbyte-platform-internal/pull/7660

Adds a (non-rendered) comment to the Allowlist IPs documentation page to remind Airbyters to update the LaunchDarkly flag and ask the frontend team to update the default value if the list of Airbyte Cloud IP addresses changes.
