### PR TITLE
docs: update link in connector checklist

### DIFF
--- a/airbyte-ci/connectors/CONNECTOR_CHECKLIST.yaml
+++ b/airbyte-ci/connectors/CONNECTOR_CHECKLIST.yaml
@@ -1,6 +1,6 @@
 paths:
   "airbyte-integrations/connectors/**":
-    - PR name follows [PR naming conventions](https://docs.airbyte.com/contributing-to-airbyte/issues-and-pull-requests#pull-request-title-convention)
+    - PR name follows [PR naming conventions](https://docs.airbyte.com/contributing-to-airbyte/resources/pull-requests-handbook/#pull-request-title-convention)
     - "[Breaking changes are considered](https://docs.airbyte.com/contributing-to-airbyte/#breaking-changes-to-connectors). If a **Breaking Change** is being introduced, ensure an Airbyte engineer has created a Breaking Change Plan and you've followed all steps in the [Breaking Changes Checklist](https://docs.airbyte.com/contributing-to-airbyte/#checklist-for-contributors)"
     - Connector version has been incremented in the Dockerfile and metadata.yaml according to our [Semantic Versioning for Connectors](https://docs.airbyte.com/contributing-to-airbyte/#semantic-versioning-for-connectors) guidelines
     - Secrets in the connector's spec are annotated with `airbyte_secret`


### PR DESCRIPTION
Pull request conventions doc was moved to a new home, the connector checklist was returning the old link still so this PR updates it.