### PR TITLE
Refactor config to not store validation_policies on the config itself

### DIFF
--- a/airbyte-cdk/python/airbyte_cdk/sources/file_based/exceptions.py
+++ b/airbyte-cdk/python/airbyte_cdk/sources/file_based/exceptions.py
@@ -30,6 +30,7 @@ class FileBasedSourceError(Enum):
     CONFIG_VALIDATION_ERROR = "Error creating stream config object."
     MISSING_SCHEMA = "Expected `json_schema` in the configured catalog but it is missing."
     UNDEFINED_PARSER = "No parser is defined for this file type."
+    UNDEFINED_VALIDATION_POLICY = "The validation policy defined in the config does not exist for the source."
 
 
 class BaseFileBasedSourceError(Exception):

--- a/airbyte-cdk/python/airbyte_cdk/sources/file_based/file_based_source.py
+++ b/airbyte-cdk/python/airbyte_cdk/sources/file_based/file_based_source.py
@@ -81,7 +81,11 @@ class FileBasedSource(AbstractSource, ABC):
         try:
             streams = []
             for stream in config["streams"]:
-                stream_config = FileBasedStreamConfig(validation_policies=self.validation_policies, **stream)
+                stream_config = FileBasedStreamConfig(**stream)
+                if stream_config.validation_policy not in self.validation_policies:
+                    raise ValidationError(
+                        f"validation_policy must be one of {list(self.validation_policies.keys())}", model=FileBasedStreamConfig
+                    )
                 streams.append(
                     DefaultFileBasedStream(
                         config=stream_config,
@@ -90,6 +94,7 @@ class FileBasedSource(AbstractSource, ABC):
                         availability_strategy=self.availability_strategy,
                         discovery_policy=self.discovery_policy,
                         parsers=self.parsers,
+                        validation_policies=self.validation_policies,
                         cursor=DefaultFileBasedCursor(stream_config.max_history_size, stream_config.days_to_sync_if_history_is_full),
                     )
                 )

--- a/airbyte-cdk/python/airbyte_cdk/sources/file_based/stream/default_file_based_stream.py
+++ b/airbyte-cdk/python/airbyte_cdk/sources/file_based/stream/default_file_based_stream.py
@@ -93,7 +93,7 @@ class DefaultFileBasedStream(AbstractFileBasedStream, IncrementalMixin):
                     type=Type.LOG,
                     log=AirbyteLogMessage(
                         level=Level.INFO,
-                        message=f"Stopping sync in accordance with the configured validation policy. Records in file did not conform to the schema. stream={self.name} file={file.uri} validation_policy={self.config.validation_policy.name} n_skipped={n_skipped}",
+                        message=f"Stopping sync in accordance with the configured validation policy. Records in file did not conform to the schema. stream={self.name} file={file.uri} validation_policy={self.config.validation_policy} n_skipped={n_skipped}",
                     ),
                 )
                 break
@@ -114,7 +114,7 @@ class DefaultFileBasedStream(AbstractFileBasedStream, IncrementalMixin):
                         type=Type.LOG,
                         log=AirbyteLogMessage(
                             level=Level.INFO,
-                            message=f"Records in file did not pass validation policy. stream={self.name} file={file.uri} n_skipped={n_skipped} validation_policy={self.config.validation_policy.name}",
+                            message=f"Records in file did not pass validation policy. stream={self.name} file={file.uri} n_skipped={n_skipped} validation_policy={self.config.validation_policy}",
                         ),
                     )
 

--- a/airbyte-cdk/python/unit_tests/sources/file_based/config/test_file_based_stream_config.py
+++ b/airbyte-cdk/python/unit_tests/sources/file_based/config/test_file_based_stream_config.py
@@ -3,8 +3,7 @@
 #
 
 import pytest as pytest
-from airbyte_cdk.sources.file_based.config.file_based_stream_config import FileBasedStreamConfig, QuotingBehavior
-from airbyte_cdk.sources.file_based.schema_validation_policies import EmitRecordPolicy
+from airbyte_cdk.sources.file_based.config.file_based_stream_config import CsvFormat, FileBasedStreamConfig, QuotingBehavior
 from pydantic import ValidationError
 
 
@@ -27,9 +26,11 @@ def test_csv_config(file_type, input_format, expected_format, expected_error):
         "file_type": file_type,
         "globs": ["*"],
         "validation_policy": "emit_record",
-        "validation_policies": {"emit_record": EmitRecordPolicy()},
-        "format": input_format,
+        "format": {
+            file_type: input_format
+        },
     }
+
     if expected_error:
         with pytest.raises(expected_error):
             FileBasedStreamConfig(**stream_config)
@@ -37,4 +38,41 @@ def test_csv_config(file_type, input_format, expected_format, expected_error):
         actual_config = FileBasedStreamConfig(**stream_config)
         assert not hasattr(actual_config.format[file_type], "filetype")
         for expected_format_field, expected_format_value in expected_format.items():
+            assert isinstance(actual_config.format[file_type], CsvFormat)
             assert getattr(actual_config.format[file_type], expected_format_field) == expected_format_value
+
+
+def test_legacy_format():
+    """
+    This test verifies that we can process the legacy format of the config object used by the existing S3 source with a
+    single `format` option as opposed to the current file_type -> format mapping.
+    """
+    stream_config = {
+        "name": "stream1",
+        "file_type": "csv",
+        "globs": ["*"],
+        "validation_policy": "emit_record_on_schema_mismatch",
+        "format": {
+            "filetype": "csv",
+            "delimiter": "d",
+            "quote_char": "q",
+            "escape_char": "e",
+            "encoding": "ascii",
+            "double_quote": True,
+            "quoting_behavior": "Quote All"
+        },
+    }
+
+    expected_format = {
+        "delimiter": "d",
+        "quote_char": "q",
+        "escape_char": "e",
+        "encoding": "ascii",
+        "double_quote": True,
+        "quoting_behavior": QuotingBehavior.QUOTE_ALL
+    }
+
+    actual_config = FileBasedStreamConfig(**stream_config)
+    assert isinstance(actual_config.format["csv"], CsvFormat)
+    for expected_format_field, expected_format_value in expected_format.items():
+        assert getattr(actual_config.format["csv"], expected_format_field) == expected_format_value

--- a/airbyte-cdk/python/unit_tests/sources/file_based/scenarios/check_scenarios.py
+++ b/airbyte-cdk/python/unit_tests/sources/file_based/scenarios/check_scenarios.py
@@ -2,7 +2,7 @@
 # Copyright (c) 2023 Airbyte, Inc., all rights reserved.
 #
 
-from airbyte_cdk.sources.file_based.exceptions import ConfigValidationError, FileBasedSourceError
+from airbyte_cdk.sources.file_based.exceptions import FileBasedSourceError
 from unit_tests.sources.file_based.helpers import (
     FailingSchemaValidationPolicy,
     TestErrorListMatchingFilesInMemoryFilesStreamReader,
@@ -174,8 +174,8 @@ error_record_validation_user_provided_schema_scenario = (
             ],
         }
     )
-    .set_validation_policies(FailingSchemaValidationPolicy)
-    .set_expected_check_error(ConfigValidationError, FileBasedSourceError.ERROR_VALIDATING_RECORD)
+    .set_validation_policies({FailingSchemaValidationPolicy.ALWAYS_FAIL:  FailingSchemaValidationPolicy()})
+    .set_expected_check_error(None, FileBasedSourceError.ERROR_VALIDATING_RECORD)
 ).build()
 
 


### PR DESCRIPTION
Closes https://github.com/airbytehq/airbyte/issues/28101

## What
When I was writing up the changes to support file-based spec operations, I started to observe some undesirable behavior in our config interface that was being surfaced now that we were validating user configs against the spec json schema. A snippet from a slack convo:


> I’m wondering if we should actually remove the @ root_validator, that we had originally added in. It feels like a bit of a code smell that we have to:
manipulate the validation_policy and assign it to an instance in the pydantic validator
because we’re doing 1, we also end up loosening the types on FileBasedStreamConfig to str or Any which isn’t quite representative. From the user spec point of view, it should always be a str


## How
These changes should have no functional impact, but it refactors how we ensure the config's validation policy is valid and how we retrieve the correct policy implementation. And we do it without appending additional fields into the `FileBasedStreamConfig` which is used to generate the spec. The gist of the refactor:

* Remove the root validation that checks if the validation policy is in validation policies
* In FileBasedSource, we have an custom check that the config’s policy is in the source’s validation_policies
* We now also pass validation_policies to the stream obj.
* AbstractFileBasedStream.record_passes_validation_policy() now has to resolve the config’s validation_policy, and then invokes it

## Recommended reading order
1. `file_based_stream_config.py`
2. `file_based_source.py`
3. `file_based_stream.py`
