### PR TITLE
Improve protocol type parsing

### DIFF
--- a/airbyte-integrations/bases/base-typing-deduping/src/main/java/io/airbyte/integrations/base/destination/typing_deduping/AirbyteTypeUtils.java
+++ b/airbyte-integrations/bases/base-typing-deduping/src/main/java/io/airbyte/integrations/base/destination/typing_deduping/AirbyteTypeUtils.java
@@ -68,12 +68,13 @@ public class AirbyteTypeUtils {
   }
 
   protected static AirbyteType getAirbyteProtocolType(final JsonNode node) {
+    if (node.isTextual()) {
+      return AirbyteProtocolType.matches(node.asText());
+    }
+
     final JsonNode propertyType = node.get("type");
     final JsonNode airbyteType = node.get("airbyte_type");
     final JsonNode format = node.get("format");
-    if (Stream.of(propertyType, airbyteType, format).allMatch(Objects::isNull)) {
-      return AirbyteProtocolType.matches(node.asText());
-    }
 
     if (nodeIsOrContainsType(propertyType, "boolean")) {
       return AirbyteProtocolType.BOOLEAN;


### PR DESCRIPTION
We were logging a bunch of protocol type parsing errors on empty strings (which were actually ObjectNode schemas converted asText). Only look for a protocol type match if the schema isTextual, otherwise just return UNKNOWN directly.

(I ran this on [the test schemas](https://github.com/airbytehq/typing-tests/tree/main/test-schema) and all the error messages are gone, i.e. no real protocol type parsing errors.)