### PR TITLE
Change from T&D every 10k records to an increasing time based interval

### DIFF
--- a/airbyte-integrations/bases/base-typing-deduping/src/main/java/io/airbyte/integrations/base/destination/typing_deduping/TypeAndDedupeOperationValve.java
+++ b/airbyte-integrations/bases/base-typing-deduping/src/main/java/io/airbyte/integrations/base/destination/typing_deduping/TypeAndDedupeOperationValve.java
@@ -1,0 +1,104 @@
+package io.airbyte.integrations.base.destination.typing_deduping;
+
+import io.airbyte.protocol.models.v0.AirbyteStreamNameNamespacePair;
+
+import java.util.List;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.function.Supplier;
+
+/**
+ * A slightly more complicated way to keep track of when to perform type and dedupe operations per stream
+ */
+public class TypeAndDedupeOperationValve extends ConcurrentHashMap<AirbyteStreamNameNamespacePair, Long> {
+
+    private static final long TWO_MINUTES_MILLIS = 1000 * 60 * 2;
+
+    private static final long FIVE_MINUTES_MILLIS = 1000 * 60 * 5;
+
+    private static final long TEN_MINUTES_MILLIS = 1000 * 60 * 10;
+
+    private static final long FIFTEEN_MINUTES_MILLIS = 1000 * 60 * 15;
+
+    // New users of airbyte likely want to see data flowing into their tables as soon as possible
+    // However, as their destination tables grow in size, typing and de-duping data becomes an expensive operation
+    // To strike a balance between showing data quickly and not slowing down the entire sync, we use an increasing
+    // interval based approach. This is not fancy, just hard coded intervals.
+    private static final List<Long> typeAndDedupeIncreasingIntervals = List.of(
+            TWO_MINUTES_MILLIS,
+            FIVE_MINUTES_MILLIS,
+            TEN_MINUTES_MILLIS,
+            FIFTEEN_MINUTES_MILLIS
+    );
+
+    private static final Supplier<Long> SYSTEM_NOW = () -> System.currentTimeMillis();
+
+    private ConcurrentHashMap<AirbyteStreamNameNamespacePair, Integer> incrementalIndex;
+
+    private final Supplier<Long> nowness;
+
+    public TypeAndDedupeOperationValve() {
+        this(SYSTEM_NOW);
+    }
+
+    /**
+     * This constructor is here because mocking System.currentTimeMillis() is a pain :(
+     * @param nownessSupplier Supplier which will return a long value representing now
+     */
+    public TypeAndDedupeOperationValve(Supplier<Long> nownessSupplier) {
+        super();
+        incrementalIndex = new ConcurrentHashMap<>();
+        this.nowness = nownessSupplier;
+    }
+
+    @Override
+    public Long put(final AirbyteStreamNameNamespacePair key, final Long value) {
+        if (!incrementalIndex.containsKey(key)) {
+            incrementalIndex.put(key, 0);
+        }
+        return super.put(key, value);
+    }
+
+    /**
+     * Adds a stream specific timestamp to track type and dedupe operations
+     * @param key the AirbyteStreamNameNamespacePair to track
+     */
+    public void addStream(final AirbyteStreamNameNamespacePair key) {
+        put(key, nowness.get());
+    }
+
+    /**
+     * Whether we should type and dedupe at this point in time for this particular stream.
+     * @param key the stream in question
+     * @return a boolean indicating whether we have crossed the interval threshold for typing and deduping.
+     */
+    public boolean readyToTypeAndDedupe(final AirbyteStreamNameNamespacePair key) {
+        if (!containsKey(key)) {
+            return false;
+        }
+        return nowness.get() - get(key) > typeAndDedupeIncreasingIntervals.get(incrementalIndex.get(key));
+    }
+
+    /**
+     * Increment the interval at which typing and deduping should occur for the stream, max out at last index of
+     * {@link TypeAndDedupeOperationValve#typeAndDedupeIncreasingIntervals}
+     * @param key the stream to increment the interval of
+     * @return the index of the typing and deduping interval associated with this stream
+     */
+    public int incrementInterval(final AirbyteStreamNameNamespacePair key) {
+        if (incrementalIndex.get(key) < typeAndDedupeIncreasingIntervals.size() - 1) {
+            incrementalIndex.put(key, incrementalIndex.get(key) + 1);
+        }
+        return incrementalIndex.get(key);
+    }
+
+    /**
+     * Meant to be called after {@link TypeAndDedupeOperationValve#readyToTypeAndDedupe(AirbyteStreamNameNamespacePair)}
+     * will set a streams last operation to the current time and increase its index reference in
+     * {@link TypeAndDedupeOperationValve#typeAndDedupeIncreasingIntervals}
+     * @param key the stream to update
+     */
+    public void updateTimeAndIncreaseInterval(final AirbyteStreamNameNamespacePair key) {
+        put(key, nowness.get());
+        incrementInterval(key);
+    }
+}

--- a/airbyte-integrations/bases/base-typing-deduping/src/main/java/io/airbyte/integrations/base/destination/typing_deduping/TypeAndDedupeOperationValve.java
+++ b/airbyte-integrations/bases/base-typing-deduping/src/main/java/io/airbyte/integrations/base/destination/typing_deduping/TypeAndDedupeOperationValve.java
@@ -1,104 +1,117 @@
+/*
+ * Copyright (c) 2023 Airbyte, Inc., all rights reserved.
+ */
+
 package io.airbyte.integrations.base.destination.typing_deduping;
 
 import io.airbyte.protocol.models.v0.AirbyteStreamNameNamespacePair;
-
 import java.util.List;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.function.Supplier;
 
 /**
- * A slightly more complicated way to keep track of when to perform type and dedupe operations per stream
+ * A slightly more complicated way to keep track of when to perform type and dedupe operations per
+ * stream
  */
 public class TypeAndDedupeOperationValve extends ConcurrentHashMap<AirbyteStreamNameNamespacePair, Long> {
 
-    private static final long TWO_MINUTES_MILLIS = 1000 * 60 * 2;
+  private static final long TWO_MINUTES_MILLIS = 1000 * 60 * 2;
 
-    private static final long FIVE_MINUTES_MILLIS = 1000 * 60 * 5;
+  private static final long FIVE_MINUTES_MILLIS = 1000 * 60 * 5;
 
-    private static final long TEN_MINUTES_MILLIS = 1000 * 60 * 10;
+  private static final long TEN_MINUTES_MILLIS = 1000 * 60 * 10;
 
-    private static final long FIFTEEN_MINUTES_MILLIS = 1000 * 60 * 15;
+  private static final long FIFTEEN_MINUTES_MILLIS = 1000 * 60 * 15;
 
-    // New users of airbyte likely want to see data flowing into their tables as soon as possible
-    // However, as their destination tables grow in size, typing and de-duping data becomes an expensive operation
-    // To strike a balance between showing data quickly and not slowing down the entire sync, we use an increasing
-    // interval based approach. This is not fancy, just hard coded intervals.
-    private static final List<Long> typeAndDedupeIncreasingIntervals = List.of(
-            TWO_MINUTES_MILLIS,
-            FIVE_MINUTES_MILLIS,
-            TEN_MINUTES_MILLIS,
-            FIFTEEN_MINUTES_MILLIS
-    );
+  // New users of airbyte likely want to see data flowing into their tables as soon as possible
+  // However, as their destination tables grow in size, typing and de-duping data becomes an expensive
+  // operation
+  // To strike a balance between showing data quickly and not slowing down the entire sync, we use an
+  // increasing
+  // interval based approach. This is not fancy, just hard coded intervals.
+  private static final List<Long> typeAndDedupeIncreasingIntervals = List.of(
+      TWO_MINUTES_MILLIS,
+      FIVE_MINUTES_MILLIS,
+      TEN_MINUTES_MILLIS,
+      FIFTEEN_MINUTES_MILLIS);
 
-    private static final Supplier<Long> SYSTEM_NOW = () -> System.currentTimeMillis();
+  private static final Supplier<Long> SYSTEM_NOW = () -> System.currentTimeMillis();
 
-    private ConcurrentHashMap<AirbyteStreamNameNamespacePair, Integer> incrementalIndex;
+  private ConcurrentHashMap<AirbyteStreamNameNamespacePair, Integer> incrementalIndex;
 
-    private final Supplier<Long> nowness;
+  private final Supplier<Long> nowness;
 
-    public TypeAndDedupeOperationValve() {
-        this(SYSTEM_NOW);
+  public TypeAndDedupeOperationValve() {
+    this(SYSTEM_NOW);
+  }
+
+  /**
+   * This constructor is here because mocking System.currentTimeMillis() is a pain :(
+   *
+   * @param nownessSupplier Supplier which will return a long value representing now
+   */
+  public TypeAndDedupeOperationValve(Supplier<Long> nownessSupplier) {
+    super();
+    incrementalIndex = new ConcurrentHashMap<>();
+    this.nowness = nownessSupplier;
+  }
+
+  @Override
+  public Long put(final AirbyteStreamNameNamespacePair key, final Long value) {
+    if (!incrementalIndex.containsKey(key)) {
+      incrementalIndex.put(key, 0);
     }
+    return super.put(key, value);
+  }
 
-    /**
-     * This constructor is here because mocking System.currentTimeMillis() is a pain :(
-     * @param nownessSupplier Supplier which will return a long value representing now
-     */
-    public TypeAndDedupeOperationValve(Supplier<Long> nownessSupplier) {
-        super();
-        incrementalIndex = new ConcurrentHashMap<>();
-        this.nowness = nownessSupplier;
-    }
+  /**
+   * Adds a stream specific timestamp to track type and dedupe operations
+   *
+   * @param key the AirbyteStreamNameNamespacePair to track
+   */
+  public void addStream(final AirbyteStreamNameNamespacePair key) {
+    put(key, nowness.get());
+  }
 
-    @Override
-    public Long put(final AirbyteStreamNameNamespacePair key, final Long value) {
-        if (!incrementalIndex.containsKey(key)) {
-            incrementalIndex.put(key, 0);
-        }
-        return super.put(key, value);
+  /**
+   * Whether we should type and dedupe at this point in time for this particular stream.
+   *
+   * @param key the stream in question
+   * @return a boolean indicating whether we have crossed the interval threshold for typing and
+   *         deduping.
+   */
+  public boolean readyToTypeAndDedupe(final AirbyteStreamNameNamespacePair key) {
+    if (!containsKey(key)) {
+      return false;
     }
+    return nowness.get() - get(key) > typeAndDedupeIncreasingIntervals.get(incrementalIndex.get(key));
+  }
 
-    /**
-     * Adds a stream specific timestamp to track type and dedupe operations
-     * @param key the AirbyteStreamNameNamespacePair to track
-     */
-    public void addStream(final AirbyteStreamNameNamespacePair key) {
-        put(key, nowness.get());
+  /**
+   * Increment the interval at which typing and deduping should occur for the stream, max out at last
+   * index of {@link TypeAndDedupeOperationValve#typeAndDedupeIncreasingIntervals}
+   *
+   * @param key the stream to increment the interval of
+   * @return the index of the typing and deduping interval associated with this stream
+   */
+  public int incrementInterval(final AirbyteStreamNameNamespacePair key) {
+    if (incrementalIndex.get(key) < typeAndDedupeIncreasingIntervals.size() - 1) {
+      incrementalIndex.put(key, incrementalIndex.get(key) + 1);
     }
+    return incrementalIndex.get(key);
+  }
 
-    /**
-     * Whether we should type and dedupe at this point in time for this particular stream.
-     * @param key the stream in question
-     * @return a boolean indicating whether we have crossed the interval threshold for typing and deduping.
-     */
-    public boolean readyToTypeAndDedupe(final AirbyteStreamNameNamespacePair key) {
-        if (!containsKey(key)) {
-            return false;
-        }
-        return nowness.get() - get(key) > typeAndDedupeIncreasingIntervals.get(incrementalIndex.get(key));
-    }
+  /**
+   * Meant to be called after
+   * {@link TypeAndDedupeOperationValve#readyToTypeAndDedupe(AirbyteStreamNameNamespacePair)} will set
+   * a streams last operation to the current time and increase its index reference in
+   * {@link TypeAndDedupeOperationValve#typeAndDedupeIncreasingIntervals}
+   *
+   * @param key the stream to update
+   */
+  public void updateTimeAndIncreaseInterval(final AirbyteStreamNameNamespacePair key) {
+    put(key, nowness.get());
+    incrementInterval(key);
+  }
 
-    /**
-     * Increment the interval at which typing and deduping should occur for the stream, max out at last index of
-     * {@link TypeAndDedupeOperationValve#typeAndDedupeIncreasingIntervals}
-     * @param key the stream to increment the interval of
-     * @return the index of the typing and deduping interval associated with this stream
-     */
-    public int incrementInterval(final AirbyteStreamNameNamespacePair key) {
-        if (incrementalIndex.get(key) < typeAndDedupeIncreasingIntervals.size() - 1) {
-            incrementalIndex.put(key, incrementalIndex.get(key) + 1);
-        }
-        return incrementalIndex.get(key);
-    }
-
-    /**
-     * Meant to be called after {@link TypeAndDedupeOperationValve#readyToTypeAndDedupe(AirbyteStreamNameNamespacePair)}
-     * will set a streams last operation to the current time and increase its index reference in
-     * {@link TypeAndDedupeOperationValve#typeAndDedupeIncreasingIntervals}
-     * @param key the stream to update
-     */
-    public void updateTimeAndIncreaseInterval(final AirbyteStreamNameNamespacePair key) {
-        put(key, nowness.get());
-        incrementInterval(key);
-    }
 }

--- a/airbyte-integrations/bases/base-typing-deduping/src/main/java/io/airbyte/integrations/base/destination/typing_deduping/TypeAndDedupeOperationValve.java
+++ b/airbyte-integrations/bases/base-typing-deduping/src/main/java/io/airbyte/integrations/base/destination/typing_deduping/TypeAndDedupeOperationValve.java
@@ -21,7 +21,9 @@ public class TypeAndDedupeOperationValve extends ConcurrentHashMap<AirbyteStream
 
   private static final long TEN_MINUTES_MILLIS = 1000 * 60 * 10;
 
-  private static final long FIFTEEN_MINUTES_MILLIS = 1000 * 60 * 15;
+    // 15 minutes is the maximum amount of time allowed between checkpoints as defined by
+    // The Airbyte Protocol
+    private static final long FIFTEEN_MINUTES_MILLIS = 1000 * 60 * 15;
 
   // New users of airbyte likely want to see data flowing into their tables as soon as possible
   // However, as their destination tables grow in size, typing and de-duping data becomes an expensive
@@ -35,83 +37,110 @@ public class TypeAndDedupeOperationValve extends ConcurrentHashMap<AirbyteStream
       TEN_MINUTES_MILLIS,
       FIFTEEN_MINUTES_MILLIS);
 
-  private static final Supplier<Long> SYSTEM_NOW = () -> System.currentTimeMillis();
+    // Constantly getting the system time adds a bit of overhead, adding a minimum record count
+    // To reduce calls for system time
+    private static final int MINIMUM_RECORD_INTERVAL = 100;
+
+    private static final Supplier<Long> SYSTEM_NOW = () -> System.currentTimeMillis();
 
   private ConcurrentHashMap<AirbyteStreamNameNamespacePair, Integer> incrementalIndex;
 
   private final Supplier<Long> nowness;
+    private ConcurrentHashMap<AirbyteStreamNameNamespacePair, Long> recordCounts;
+
 
   public TypeAndDedupeOperationValve() {
     this(SYSTEM_NOW);
   }
 
-  /**
-   * This constructor is here because mocking System.currentTimeMillis() is a pain :(
-   *
-   * @param nownessSupplier Supplier which will return a long value representing now
-   */
-  public TypeAndDedupeOperationValve(Supplier<Long> nownessSupplier) {
-    super();
-    incrementalIndex = new ConcurrentHashMap<>();
-    this.nowness = nownessSupplier;
-  }
 
-  @Override
-  public Long put(final AirbyteStreamNameNamespacePair key, final Long value) {
-    if (!incrementalIndex.containsKey(key)) {
-      incrementalIndex.put(key, 0);
+    /**
+     * This constructor is here because mocking System.currentTimeMillis() is a pain :(
+     * @param nownessSupplier Supplier which will return a long value representing now
+     */
+    public TypeAndDedupeOperationValve(Supplier<Long> nownessSupplier) {
+        super();
+        incrementalIndex = new ConcurrentHashMap<>();
+        recordCounts = new ConcurrentHashMap<>();
+        this.nowness = nownessSupplier;
     }
-    return super.put(key, value);
-  }
 
-  /**
-   * Adds a stream specific timestamp to track type and dedupe operations
-   *
-   * @param key the AirbyteStreamNameNamespacePair to track
-   */
-  public void addStream(final AirbyteStreamNameNamespacePair key) {
-    put(key, nowness.get());
-  }
+    @Override
+    public Long put(final AirbyteStreamNameNamespacePair key, final Long value) {
+        if (!incrementalIndex.containsKey(key)) {
+            incrementalIndex.put(key, 0);
+        }
+        if (!recordCounts.containsKey(key)) {
+            recordCounts.put(key, 1l);
+        }
+        return super.put(key, value);
 
-  /**
-   * Whether we should type and dedupe at this point in time for this particular stream.
-   *
-   * @param key the stream in question
-   * @return a boolean indicating whether we have crossed the interval threshold for typing and
-   *         deduping.
-   */
-  public boolean readyToTypeAndDedupe(final AirbyteStreamNameNamespacePair key) {
-    if (!containsKey(key)) {
-      return false;
     }
-    return nowness.get() - get(key) > typeAndDedupeIncreasingIntervals.get(incrementalIndex.get(key));
-  }
 
-  /**
-   * Increment the interval at which typing and deduping should occur for the stream, max out at last
-   * index of {@link TypeAndDedupeOperationValve#typeAndDedupeIncreasingIntervals}
-   *
-   * @param key the stream to increment the interval of
-   * @return the index of the typing and deduping interval associated with this stream
-   */
-  public int incrementInterval(final AirbyteStreamNameNamespacePair key) {
-    if (incrementalIndex.get(key) < typeAndDedupeIncreasingIntervals.size() - 1) {
-      incrementalIndex.put(key, incrementalIndex.get(key) + 1);
+    /**
+     * Adds a stream specific timestamp to track type and dedupe operations
+     *
+     * @param key the AirbyteStreamNameNamespacePair to track
+     */
+    public void addStream(final AirbyteStreamNameNamespacePair key) {
+        put(key, nowness.get());
     }
-    return incrementalIndex.get(key);
-  }
 
-  /**
-   * Meant to be called after
-   * {@link TypeAndDedupeOperationValve#readyToTypeAndDedupe(AirbyteStreamNameNamespacePair)} will set
-   * a streams last operation to the current time and increase its index reference in
-   * {@link TypeAndDedupeOperationValve#typeAndDedupeIncreasingIntervals}
-   *
-   * @param key the stream to update
-   */
-  public void updateTimeAndIncreaseInterval(final AirbyteStreamNameNamespacePair key) {
-    put(key, nowness.get());
-    incrementInterval(key);
-  }
+    /**
+     * Whether we should type and dedupe at this point in time for this particular stream.
+     * @param key the stream in question
+     * @return a boolean indicating whether we have crossed the interval threshold for typing and deduping.
+     */
+    public boolean readyToTypeAndDedupe(final AirbyteStreamNameNamespacePair key) {
+        if (!containsKey(key)) {
+            return false;
+        }
+        recordCounts.put(key, recordCounts.get(key) + 1);
+        if (recordCounts.get(key) % MINIMUM_RECORD_INTERVAL == 0) {
+            return nowness.get() - get(key) > typeAndDedupeIncreasingIntervals.get(incrementalIndex.get(key));
+        }
+        return false;
+    }
 
+    /**
+     * Increment the interval at which typing and deduping should occur for the stream, max out at last index of
+     * {@link TypeAndDedupeOperationValve#typeAndDedupeIncreasingIntervals}
+     * @param key the stream to increment the interval of
+     * @return the index of the typing and deduping interval associated with this stream
+     */
+    public int incrementInterval(final AirbyteStreamNameNamespacePair key) {
+        if (incrementalIndex.get(key) < typeAndDedupeIncreasingIntervals.size() - 1) {
+            incrementalIndex.put(key, incrementalIndex.get(key) + 1);
+        }
+        return incrementalIndex.get(key);
+    }
+
+    /**
+     * Meant to be called after {@link TypeAndDedupeOperationValve#readyToTypeAndDedupe(AirbyteStreamNameNamespacePair)}
+     * will set a streams last operation to the current time and increase its index reference in
+     * {@link TypeAndDedupeOperationValve#typeAndDedupeIncreasingIntervals}
+     * @param key the stream to update
+     */
+    public void updateTimeAndIncreaseInterval(final AirbyteStreamNameNamespacePair key) {
+        put(key, nowness.get());
+        incrementInterval(key);
+    }
+
+    /**
+     * Get the current interval for the stream
+     * @param key the stream in question
+     * @return a long value representing the length of the interval milliseconds
+     */
+    public Long getIncrementInterval(final AirbyteStreamNameNamespacePair key) {
+        return typeAndDedupeIncreasingIntervals.get(incrementalIndex.get(key));
+    }
+
+    /**
+     * Get the current record count per stream
+     * @param key the stream in question
+     * @return the recrod count
+     */
+    public Long getRecordCount(final AirbyteStreamNameNamespacePair key) {
+        return recordCounts.get(key);
+    }
 }

--- a/airbyte-integrations/bases/base-typing-deduping/src/test/java/io/airbyte/integrations/base/destination/typing_deduping/TypeAndDedupeOperationValveTest.java
+++ b/airbyte-integrations/bases/base-typing-deduping/src/test/java/io/airbyte/integrations/base/destination/typing_deduping/TypeAndDedupeOperationValveTest.java
@@ -27,67 +27,91 @@ public class TypeAndDedupeOperationValveTest {
     minuteUpdates = () -> start.getAndUpdate(l -> l + (60 * 1000));
   }
 
-  @Test
-  public void testAddStream() {
-    final var valve = new TypeAndDedupeOperationValve(ALWAYS_ZERO);
-    valve.addStream(STREAM_A);
-    Assertions.assertFalse(valve.readyToTypeAndDedupe(STREAM_A));
-    Assertions.assertEquals(valve.get(STREAM_A), 0l);
-  }
-
-  @Test
-  public void testReadyToTypeAndDedupe() {
-    final var valve = new TypeAndDedupeOperationValve(minuteUpdates);
-    // method call increments time
-    valve.addStream(STREAM_A);
-    // method call increments time
-    Assertions.assertFalse(valve.readyToTypeAndDedupe(STREAM_A));
-    // method call increments time
-    valve.addStream(STREAM_B);
-    // method call increments time
-    Assertions.assertTrue(valve.readyToTypeAndDedupe(STREAM_A));
-    // method call increments time
-    Assertions.assertFalse(valve.readyToTypeAndDedupe(STREAM_B));
-    // method call increments time
-    Assertions.assertTrue(valve.readyToTypeAndDedupe(STREAM_B));
-  }
-
-  @Test
-  public void testIncrementInterval() {
-    final var valve = new TypeAndDedupeOperationValve(ALWAYS_ZERO);
-    valve.addStream(STREAM_A);
-    IntStream.rangeClosed(1, 3).forEach(i -> {
-      final var index = valve.incrementInterval(STREAM_A);
-      Assertions.assertEquals(i, index);
+  private void elapseTime(Supplier<Long> timing, int iterations) {
+    IntStream.range(0, iterations).forEach(__ -> {
+        timing.get();
     });
-    Assertions.assertEquals(3, valve.incrementInterval(STREAM_A));
-    // Twice to be sure
-    Assertions.assertEquals(3, valve.incrementInterval(STREAM_A));
   }
 
-  @Test
-  public void testUpdateTimeAndIncreaseInterval() {
-    final var valve = new TypeAndDedupeOperationValve(minuteUpdates);
-    valve.addStream(STREAM_A);
-    // 2 minutes
-    IntStream.range(0, 2).forEach(__ -> Assertions.assertFalse(valve.readyToTypeAndDedupe(STREAM_A)));
-    Assertions.assertTrue(valve.readyToTypeAndDedupe(STREAM_A));
-    valve.updateTimeAndIncreaseInterval(STREAM_A);
-    // 5 minutes
-    IntStream.range(0, 5).forEach(__ -> Assertions.assertFalse(valve.readyToTypeAndDedupe(STREAM_A)));
-    Assertions.assertTrue(valve.readyToTypeAndDedupe(STREAM_A));
-    valve.updateTimeAndIncreaseInterval(STREAM_A);
-    // 10 minutes
-    IntStream.range(0, 10).forEach(__ -> Assertions.assertFalse(valve.readyToTypeAndDedupe(STREAM_A)));
-    Assertions.assertTrue(valve.readyToTypeAndDedupe(STREAM_A));
-    valve.updateTimeAndIncreaseInterval(STREAM_A);
-    // 15 minutes
-    IntStream.range(0, 15).forEach(__ -> Assertions.assertFalse(valve.readyToTypeAndDedupe(STREAM_A)));
-    Assertions.assertTrue(valve.readyToTypeAndDedupe(STREAM_A));
-    valve.updateTimeAndIncreaseInterval(STREAM_A);
-    // 15 minutes again
-    IntStream.range(0, 15).forEach(__ -> Assertions.assertFalse(valve.readyToTypeAndDedupe(STREAM_A)));
-    Assertions.assertTrue(valve.readyToTypeAndDedupe(STREAM_A));
-  }
+    @Test
+    public void testAddStream() {
+        final var valve = new TypeAndDedupeOperationValve(ALWAYS_ZERO);
+        valve.addStream(STREAM_A);
+        Assertions.assertEquals(1l, valve.getRecordCount(STREAM_A));
+        Assertions.assertEquals(1000 * 60 * 2, valve.getIncrementInterval(STREAM_A));
+        Assertions.assertFalse(valve.readyToTypeAndDedupe(STREAM_A));
+        Assertions.assertEquals(valve.get(STREAM_A), 0l);
+    }
 
+    @Test
+    public void testReadyToTypeAndDedupe() {
+        final var valve = new TypeAndDedupeOperationValve(minuteUpdates);
+        // method call increments time
+        valve.addStream(STREAM_A);
+        IntStream.range(0, 98).forEach(__ -> Assertions.assertFalse(valve.readyToTypeAndDedupe(STREAM_A)));
+        elapseTime(minuteUpdates, 1);
+        // method call increments time
+        valve.addStream(STREAM_B);
+        // method call increments time
+        Assertions.assertTrue(valve.readyToTypeAndDedupe(STREAM_A));
+        IntStream.range(0, 98).forEach(__ -> Assertions.assertFalse(valve.readyToTypeAndDedupe(STREAM_B)));
+        elapseTime(minuteUpdates, 1);
+        Assertions.assertTrue(valve.readyToTypeAndDedupe(STREAM_B));
+        valve.updateTimeAndIncreaseInterval(STREAM_A);
+        Assertions.assertEquals(1000 * 60 * 5, valve.getIncrementInterval(STREAM_A));
+        IntStream.range(0, 99).forEach(__ -> Assertions.assertFalse(valve.readyToTypeAndDedupe(STREAM_A)));
+        Assertions.assertEquals(199, valve.getRecordCount(STREAM_A));
+        // method call increments time
+        // This puts it at 200 records, which should then check to see if enough time has passed
+        // but only one minute has passed
+        Assertions.assertFalse(valve.readyToTypeAndDedupe(STREAM_A));
+        elapseTime(minuteUpdates, 5);
+        IntStream.range(0, 99).forEach(__ -> Assertions.assertFalse(valve.readyToTypeAndDedupe(STREAM_A)));
+        Assertions.assertEquals(299, valve.getRecordCount(STREAM_A));
+        // More than enough time has passed now and this will be the 300th record
+        Assertions.assertTrue(valve.readyToTypeAndDedupe(STREAM_A));
+    }
+
+    @Test
+    public void testIncrementInterval() {
+        final var valve = new TypeAndDedupeOperationValve(ALWAYS_ZERO);
+        valve.addStream(STREAM_A);
+        IntStream.rangeClosed(1, 3).forEach(i -> {
+            final var index = valve.incrementInterval(STREAM_A);
+            Assertions.assertEquals(i, index);
+        });
+        Assertions.assertEquals(3, valve.incrementInterval(STREAM_A));
+        // Twice to be sure
+        Assertions.assertEquals(3, valve.incrementInterval(STREAM_A));
+    }
+
+    @Test
+    public void testUpdateTimeAndIncreaseInterval() {
+        final var valve = new TypeAndDedupeOperationValve(minuteUpdates);
+        valve.addStream(STREAM_A);
+        // 2 minutes
+        IntStream.range(0, 98).forEach(__ -> Assertions.assertFalse(valve.readyToTypeAndDedupe(STREAM_A)));
+        elapseTime(minuteUpdates, 2);
+        Assertions.assertTrue(valve.readyToTypeAndDedupe(STREAM_A));
+        valve.updateTimeAndIncreaseInterval(STREAM_A);
+        // 5 minutes
+        IntStream.range(0, 99).forEach(__ -> Assertions.assertFalse(valve.readyToTypeAndDedupe(STREAM_A)));
+        elapseTime(minuteUpdates, 5);
+        Assertions.assertTrue(valve.readyToTypeAndDedupe(STREAM_A));
+        valve.updateTimeAndIncreaseInterval(STREAM_A);
+        // 10 minutes
+        IntStream.range(0, 99).forEach(__ -> Assertions.assertFalse(valve.readyToTypeAndDedupe(STREAM_A)));
+        elapseTime(minuteUpdates, 10);
+        Assertions.assertTrue(valve.readyToTypeAndDedupe(STREAM_A));
+        valve.updateTimeAndIncreaseInterval(STREAM_A);
+        // 15 minutes
+        IntStream.range(0, 99).forEach(__ -> Assertions.assertFalse(valve.readyToTypeAndDedupe(STREAM_A)));
+        elapseTime(minuteUpdates, 15);
+        Assertions.assertTrue(valve.readyToTypeAndDedupe(STREAM_A));
+        valve.updateTimeAndIncreaseInterval(STREAM_A);
+        // 15 minutes again
+        IntStream.range(0, 99).forEach(__ -> Assertions.assertFalse(valve.readyToTypeAndDedupe(STREAM_A)));
+        elapseTime(minuteUpdates, 15);
+        Assertions.assertTrue(valve.readyToTypeAndDedupe(STREAM_A));
+    }
 }

--- a/airbyte-integrations/bases/base-typing-deduping/src/test/java/io/airbyte/integrations/base/destination/typing_deduping/TypeAndDedupeOperationValveTest.java
+++ b/airbyte-integrations/bases/base-typing-deduping/src/test/java/io/airbyte/integrations/base/destination/typing_deduping/TypeAndDedupeOperationValveTest.java
@@ -29,89 +29,90 @@ public class TypeAndDedupeOperationValveTest {
 
   private void elapseTime(Supplier<Long> timing, int iterations) {
     IntStream.range(0, iterations).forEach(__ -> {
-        timing.get();
+      timing.get();
     });
   }
 
-    @Test
-    public void testAddStream() {
-        final var valve = new TypeAndDedupeOperationValve(ALWAYS_ZERO);
-        valve.addStream(STREAM_A);
-        Assertions.assertEquals(1l, valve.getRecordCount(STREAM_A));
-        Assertions.assertEquals(1000 * 60 * 2, valve.getIncrementInterval(STREAM_A));
-        Assertions.assertFalse(valve.readyToTypeAndDedupe(STREAM_A));
-        Assertions.assertEquals(valve.get(STREAM_A), 0l);
-    }
+  @Test
+  public void testAddStream() {
+    final var valve = new TypeAndDedupeOperationValve(ALWAYS_ZERO);
+    valve.addStream(STREAM_A);
+    Assertions.assertEquals(1l, valve.getRecordCount(STREAM_A));
+    Assertions.assertEquals(1000 * 60 * 2, valve.getIncrementInterval(STREAM_A));
+    Assertions.assertFalse(valve.readyToTypeAndDedupe(STREAM_A));
+    Assertions.assertEquals(valve.get(STREAM_A), 0l);
+  }
 
-    @Test
-    public void testReadyToTypeAndDedupe() {
-        final var valve = new TypeAndDedupeOperationValve(minuteUpdates);
-        // method call increments time
-        valve.addStream(STREAM_A);
-        IntStream.range(0, 98).forEach(__ -> Assertions.assertFalse(valve.readyToTypeAndDedupe(STREAM_A)));
-        elapseTime(minuteUpdates, 1);
-        // method call increments time
-        valve.addStream(STREAM_B);
-        // method call increments time
-        Assertions.assertTrue(valve.readyToTypeAndDedupe(STREAM_A));
-        IntStream.range(0, 98).forEach(__ -> Assertions.assertFalse(valve.readyToTypeAndDedupe(STREAM_B)));
-        elapseTime(minuteUpdates, 1);
-        Assertions.assertTrue(valve.readyToTypeAndDedupe(STREAM_B));
-        valve.updateTimeAndIncreaseInterval(STREAM_A);
-        Assertions.assertEquals(1000 * 60 * 5, valve.getIncrementInterval(STREAM_A));
-        IntStream.range(0, 99).forEach(__ -> Assertions.assertFalse(valve.readyToTypeAndDedupe(STREAM_A)));
-        Assertions.assertEquals(199, valve.getRecordCount(STREAM_A));
-        // method call increments time
-        // This puts it at 200 records, which should then check to see if enough time has passed
-        // but only one minute has passed
-        Assertions.assertFalse(valve.readyToTypeAndDedupe(STREAM_A));
-        elapseTime(minuteUpdates, 5);
-        IntStream.range(0, 99).forEach(__ -> Assertions.assertFalse(valve.readyToTypeAndDedupe(STREAM_A)));
-        Assertions.assertEquals(299, valve.getRecordCount(STREAM_A));
-        // More than enough time has passed now and this will be the 300th record
-        Assertions.assertTrue(valve.readyToTypeAndDedupe(STREAM_A));
-    }
+  @Test
+  public void testReadyToTypeAndDedupe() {
+    final var valve = new TypeAndDedupeOperationValve(minuteUpdates);
+    // method call increments time
+    valve.addStream(STREAM_A);
+    IntStream.range(0, 98).forEach(__ -> Assertions.assertFalse(valve.readyToTypeAndDedupe(STREAM_A)));
+    elapseTime(minuteUpdates, 1);
+    // method call increments time
+    valve.addStream(STREAM_B);
+    // method call increments time
+    Assertions.assertTrue(valve.readyToTypeAndDedupe(STREAM_A));
+    IntStream.range(0, 98).forEach(__ -> Assertions.assertFalse(valve.readyToTypeAndDedupe(STREAM_B)));
+    elapseTime(minuteUpdates, 1);
+    Assertions.assertTrue(valve.readyToTypeAndDedupe(STREAM_B));
+    valve.updateTimeAndIncreaseInterval(STREAM_A);
+    Assertions.assertEquals(1000 * 60 * 5, valve.getIncrementInterval(STREAM_A));
+    IntStream.range(0, 99).forEach(__ -> Assertions.assertFalse(valve.readyToTypeAndDedupe(STREAM_A)));
+    Assertions.assertEquals(199, valve.getRecordCount(STREAM_A));
+    // method call increments time
+    // This puts it at 200 records, which should then check to see if enough time has passed
+    // but only one minute has passed
+    Assertions.assertFalse(valve.readyToTypeAndDedupe(STREAM_A));
+    elapseTime(minuteUpdates, 5);
+    IntStream.range(0, 99).forEach(__ -> Assertions.assertFalse(valve.readyToTypeAndDedupe(STREAM_A)));
+    Assertions.assertEquals(299, valve.getRecordCount(STREAM_A));
+    // More than enough time has passed now and this will be the 300th record
+    Assertions.assertTrue(valve.readyToTypeAndDedupe(STREAM_A));
+  }
 
-    @Test
-    public void testIncrementInterval() {
-        final var valve = new TypeAndDedupeOperationValve(ALWAYS_ZERO);
-        valve.addStream(STREAM_A);
-        IntStream.rangeClosed(1, 3).forEach(i -> {
-            final var index = valve.incrementInterval(STREAM_A);
-            Assertions.assertEquals(i, index);
-        });
-        Assertions.assertEquals(3, valve.incrementInterval(STREAM_A));
-        // Twice to be sure
-        Assertions.assertEquals(3, valve.incrementInterval(STREAM_A));
-    }
+  @Test
+  public void testIncrementInterval() {
+    final var valve = new TypeAndDedupeOperationValve(ALWAYS_ZERO);
+    valve.addStream(STREAM_A);
+    IntStream.rangeClosed(1, 3).forEach(i -> {
+      final var index = valve.incrementInterval(STREAM_A);
+      Assertions.assertEquals(i, index);
+    });
+    Assertions.assertEquals(3, valve.incrementInterval(STREAM_A));
+    // Twice to be sure
+    Assertions.assertEquals(3, valve.incrementInterval(STREAM_A));
+  }
 
-    @Test
-    public void testUpdateTimeAndIncreaseInterval() {
-        final var valve = new TypeAndDedupeOperationValve(minuteUpdates);
-        valve.addStream(STREAM_A);
-        // 2 minutes
-        IntStream.range(0, 98).forEach(__ -> Assertions.assertFalse(valve.readyToTypeAndDedupe(STREAM_A)));
-        elapseTime(minuteUpdates, 2);
-        Assertions.assertTrue(valve.readyToTypeAndDedupe(STREAM_A));
-        valve.updateTimeAndIncreaseInterval(STREAM_A);
-        // 5 minutes
-        IntStream.range(0, 99).forEach(__ -> Assertions.assertFalse(valve.readyToTypeAndDedupe(STREAM_A)));
-        elapseTime(minuteUpdates, 5);
-        Assertions.assertTrue(valve.readyToTypeAndDedupe(STREAM_A));
-        valve.updateTimeAndIncreaseInterval(STREAM_A);
-        // 10 minutes
-        IntStream.range(0, 99).forEach(__ -> Assertions.assertFalse(valve.readyToTypeAndDedupe(STREAM_A)));
-        elapseTime(minuteUpdates, 10);
-        Assertions.assertTrue(valve.readyToTypeAndDedupe(STREAM_A));
-        valve.updateTimeAndIncreaseInterval(STREAM_A);
-        // 15 minutes
-        IntStream.range(0, 99).forEach(__ -> Assertions.assertFalse(valve.readyToTypeAndDedupe(STREAM_A)));
-        elapseTime(minuteUpdates, 15);
-        Assertions.assertTrue(valve.readyToTypeAndDedupe(STREAM_A));
-        valve.updateTimeAndIncreaseInterval(STREAM_A);
-        // 15 minutes again
-        IntStream.range(0, 99).forEach(__ -> Assertions.assertFalse(valve.readyToTypeAndDedupe(STREAM_A)));
-        elapseTime(minuteUpdates, 15);
-        Assertions.assertTrue(valve.readyToTypeAndDedupe(STREAM_A));
-    }
+  @Test
+  public void testUpdateTimeAndIncreaseInterval() {
+    final var valve = new TypeAndDedupeOperationValve(minuteUpdates);
+    valve.addStream(STREAM_A);
+    // 2 minutes
+    IntStream.range(0, 98).forEach(__ -> Assertions.assertFalse(valve.readyToTypeAndDedupe(STREAM_A)));
+    elapseTime(minuteUpdates, 2);
+    Assertions.assertTrue(valve.readyToTypeAndDedupe(STREAM_A));
+    valve.updateTimeAndIncreaseInterval(STREAM_A);
+    // 5 minutes
+    IntStream.range(0, 99).forEach(__ -> Assertions.assertFalse(valve.readyToTypeAndDedupe(STREAM_A)));
+    elapseTime(minuteUpdates, 5);
+    Assertions.assertTrue(valve.readyToTypeAndDedupe(STREAM_A));
+    valve.updateTimeAndIncreaseInterval(STREAM_A);
+    // 10 minutes
+    IntStream.range(0, 99).forEach(__ -> Assertions.assertFalse(valve.readyToTypeAndDedupe(STREAM_A)));
+    elapseTime(minuteUpdates, 10);
+    Assertions.assertTrue(valve.readyToTypeAndDedupe(STREAM_A));
+    valve.updateTimeAndIncreaseInterval(STREAM_A);
+    // 15 minutes
+    IntStream.range(0, 99).forEach(__ -> Assertions.assertFalse(valve.readyToTypeAndDedupe(STREAM_A)));
+    elapseTime(minuteUpdates, 15);
+    Assertions.assertTrue(valve.readyToTypeAndDedupe(STREAM_A));
+    valve.updateTimeAndIncreaseInterval(STREAM_A);
+    // 15 minutes again
+    IntStream.range(0, 99).forEach(__ -> Assertions.assertFalse(valve.readyToTypeAndDedupe(STREAM_A)));
+    elapseTime(minuteUpdates, 15);
+    Assertions.assertTrue(valve.readyToTypeAndDedupe(STREAM_A));
+  }
+
 }

--- a/airbyte-integrations/bases/base-typing-deduping/src/test/java/io/airbyte/integrations/base/destination/typing_deduping/TypeAndDedupeOperationValveTest.java
+++ b/airbyte-integrations/bases/base-typing-deduping/src/test/java/io/airbyte/integrations/base/destination/typing_deduping/TypeAndDedupeOperationValveTest.java
@@ -1,0 +1,90 @@
+package io.airbyte.integrations.base.destination.typing_deduping;
+
+import io.airbyte.protocol.models.v0.AirbyteStreamNameNamespacePair;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import java.util.concurrent.atomic.AtomicLong;
+import java.util.function.Supplier;
+import java.util.stream.IntStream;
+
+public class TypeAndDedupeOperationValveTest {
+
+    private static final AirbyteStreamNameNamespacePair STREAM_A = new AirbyteStreamNameNamespacePair("a", "a");
+    private static final AirbyteStreamNameNamespacePair STREAM_B = new AirbyteStreamNameNamespacePair("b", "b");
+
+    private static final Supplier<Long> ALWAYS_ZERO = () -> 0l;
+
+    private Supplier<Long> minuteUpdates;
+
+    @BeforeEach
+    public void setup() {
+        AtomicLong start = new AtomicLong(0);
+        minuteUpdates = () -> start.getAndUpdate(l -> l + (60 * 1000));
+    }
+
+
+    @Test
+    public void testAddStream() {
+        final var valve = new TypeAndDedupeOperationValve(ALWAYS_ZERO);
+        valve.addStream(STREAM_A);
+        Assertions.assertFalse(valve.readyToTypeAndDedupe(STREAM_A));
+        Assertions.assertEquals(valve.get(STREAM_A), 0l);
+    }
+
+    @Test
+    public void testReadyToTypeAndDedupe() {
+        final var valve = new TypeAndDedupeOperationValve(minuteUpdates);
+        // method call increments time
+        valve.addStream(STREAM_A);
+        // method call increments time
+        Assertions.assertFalse(valve.readyToTypeAndDedupe(STREAM_A));
+        // method call increments time
+        valve.addStream(STREAM_B);
+        // method call increments time
+        Assertions.assertTrue(valve.readyToTypeAndDedupe(STREAM_A));
+        // method call increments time
+        Assertions.assertFalse(valve.readyToTypeAndDedupe(STREAM_B));
+        // method call increments time
+        Assertions.assertTrue(valve.readyToTypeAndDedupe(STREAM_B));
+    }
+
+    @Test
+    public void testIncrementInterval() {
+        final var valve = new TypeAndDedupeOperationValve(ALWAYS_ZERO);
+        valve.addStream(STREAM_A);
+        IntStream.rangeClosed(1, 3).forEach(i -> {
+            final var index = valve.incrementInterval(STREAM_A);
+            Assertions.assertEquals(i, index);
+        });
+        Assertions.assertEquals(3, valve.incrementInterval(STREAM_A));
+        // Twice to be sure
+        Assertions.assertEquals(3, valve.incrementInterval(STREAM_A));
+    }
+
+    @Test
+    public void testUpdateTimeAndIncreaseInterval() {
+        final var valve = new TypeAndDedupeOperationValve(minuteUpdates);
+        valve.addStream(STREAM_A);
+        // 2 minutes
+        IntStream.range(0, 2).forEach(__ -> Assertions.assertFalse(valve.readyToTypeAndDedupe(STREAM_A)));
+        Assertions.assertTrue(valve.readyToTypeAndDedupe(STREAM_A));
+        valve.updateTimeAndIncreaseInterval(STREAM_A);
+        // 5 minutes
+        IntStream.range(0, 5).forEach(__ -> Assertions.assertFalse(valve.readyToTypeAndDedupe(STREAM_A)));
+        Assertions.assertTrue(valve.readyToTypeAndDedupe(STREAM_A));
+        valve.updateTimeAndIncreaseInterval(STREAM_A);
+        // 10 minutes
+        IntStream.range(0, 10).forEach(__ -> Assertions.assertFalse(valve.readyToTypeAndDedupe(STREAM_A)));
+        Assertions.assertTrue(valve.readyToTypeAndDedupe(STREAM_A));
+        valve.updateTimeAndIncreaseInterval(STREAM_A);
+        // 15 minutes
+        IntStream.range(0, 15).forEach(__ -> Assertions.assertFalse(valve.readyToTypeAndDedupe(STREAM_A)));
+        Assertions.assertTrue(valve.readyToTypeAndDedupe(STREAM_A));
+        valve.updateTimeAndIncreaseInterval(STREAM_A);
+        // 15 minutes again
+        IntStream.range(0, 15).forEach(__ -> Assertions.assertFalse(valve.readyToTypeAndDedupe(STREAM_A)));
+        Assertions.assertTrue(valve.readyToTypeAndDedupe(STREAM_A));
+    }
+}

--- a/airbyte-integrations/bases/base-typing-deduping/src/test/java/io/airbyte/integrations/base/destination/typing_deduping/TypeAndDedupeOperationValveTest.java
+++ b/airbyte-integrations/bases/base-typing-deduping/src/test/java/io/airbyte/integrations/base/destination/typing_deduping/TypeAndDedupeOperationValveTest.java
@@ -1,90 +1,93 @@
+/*
+ * Copyright (c) 2023 Airbyte, Inc., all rights reserved.
+ */
+
 package io.airbyte.integrations.base.destination.typing_deduping;
 
 import io.airbyte.protocol.models.v0.AirbyteStreamNameNamespacePair;
+import java.util.concurrent.atomic.AtomicLong;
+import java.util.function.Supplier;
+import java.util.stream.IntStream;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
-import java.util.concurrent.atomic.AtomicLong;
-import java.util.function.Supplier;
-import java.util.stream.IntStream;
-
 public class TypeAndDedupeOperationValveTest {
 
-    private static final AirbyteStreamNameNamespacePair STREAM_A = new AirbyteStreamNameNamespacePair("a", "a");
-    private static final AirbyteStreamNameNamespacePair STREAM_B = new AirbyteStreamNameNamespacePair("b", "b");
+  private static final AirbyteStreamNameNamespacePair STREAM_A = new AirbyteStreamNameNamespacePair("a", "a");
+  private static final AirbyteStreamNameNamespacePair STREAM_B = new AirbyteStreamNameNamespacePair("b", "b");
 
-    private static final Supplier<Long> ALWAYS_ZERO = () -> 0l;
+  private static final Supplier<Long> ALWAYS_ZERO = () -> 0l;
 
-    private Supplier<Long> minuteUpdates;
+  private Supplier<Long> minuteUpdates;
 
-    @BeforeEach
-    public void setup() {
-        AtomicLong start = new AtomicLong(0);
-        minuteUpdates = () -> start.getAndUpdate(l -> l + (60 * 1000));
-    }
+  @BeforeEach
+  public void setup() {
+    AtomicLong start = new AtomicLong(0);
+    minuteUpdates = () -> start.getAndUpdate(l -> l + (60 * 1000));
+  }
 
+  @Test
+  public void testAddStream() {
+    final var valve = new TypeAndDedupeOperationValve(ALWAYS_ZERO);
+    valve.addStream(STREAM_A);
+    Assertions.assertFalse(valve.readyToTypeAndDedupe(STREAM_A));
+    Assertions.assertEquals(valve.get(STREAM_A), 0l);
+  }
 
-    @Test
-    public void testAddStream() {
-        final var valve = new TypeAndDedupeOperationValve(ALWAYS_ZERO);
-        valve.addStream(STREAM_A);
-        Assertions.assertFalse(valve.readyToTypeAndDedupe(STREAM_A));
-        Assertions.assertEquals(valve.get(STREAM_A), 0l);
-    }
+  @Test
+  public void testReadyToTypeAndDedupe() {
+    final var valve = new TypeAndDedupeOperationValve(minuteUpdates);
+    // method call increments time
+    valve.addStream(STREAM_A);
+    // method call increments time
+    Assertions.assertFalse(valve.readyToTypeAndDedupe(STREAM_A));
+    // method call increments time
+    valve.addStream(STREAM_B);
+    // method call increments time
+    Assertions.assertTrue(valve.readyToTypeAndDedupe(STREAM_A));
+    // method call increments time
+    Assertions.assertFalse(valve.readyToTypeAndDedupe(STREAM_B));
+    // method call increments time
+    Assertions.assertTrue(valve.readyToTypeAndDedupe(STREAM_B));
+  }
 
-    @Test
-    public void testReadyToTypeAndDedupe() {
-        final var valve = new TypeAndDedupeOperationValve(minuteUpdates);
-        // method call increments time
-        valve.addStream(STREAM_A);
-        // method call increments time
-        Assertions.assertFalse(valve.readyToTypeAndDedupe(STREAM_A));
-        // method call increments time
-        valve.addStream(STREAM_B);
-        // method call increments time
-        Assertions.assertTrue(valve.readyToTypeAndDedupe(STREAM_A));
-        // method call increments time
-        Assertions.assertFalse(valve.readyToTypeAndDedupe(STREAM_B));
-        // method call increments time
-        Assertions.assertTrue(valve.readyToTypeAndDedupe(STREAM_B));
-    }
+  @Test
+  public void testIncrementInterval() {
+    final var valve = new TypeAndDedupeOperationValve(ALWAYS_ZERO);
+    valve.addStream(STREAM_A);
+    IntStream.rangeClosed(1, 3).forEach(i -> {
+      final var index = valve.incrementInterval(STREAM_A);
+      Assertions.assertEquals(i, index);
+    });
+    Assertions.assertEquals(3, valve.incrementInterval(STREAM_A));
+    // Twice to be sure
+    Assertions.assertEquals(3, valve.incrementInterval(STREAM_A));
+  }
 
-    @Test
-    public void testIncrementInterval() {
-        final var valve = new TypeAndDedupeOperationValve(ALWAYS_ZERO);
-        valve.addStream(STREAM_A);
-        IntStream.rangeClosed(1, 3).forEach(i -> {
-            final var index = valve.incrementInterval(STREAM_A);
-            Assertions.assertEquals(i, index);
-        });
-        Assertions.assertEquals(3, valve.incrementInterval(STREAM_A));
-        // Twice to be sure
-        Assertions.assertEquals(3, valve.incrementInterval(STREAM_A));
-    }
+  @Test
+  public void testUpdateTimeAndIncreaseInterval() {
+    final var valve = new TypeAndDedupeOperationValve(minuteUpdates);
+    valve.addStream(STREAM_A);
+    // 2 minutes
+    IntStream.range(0, 2).forEach(__ -> Assertions.assertFalse(valve.readyToTypeAndDedupe(STREAM_A)));
+    Assertions.assertTrue(valve.readyToTypeAndDedupe(STREAM_A));
+    valve.updateTimeAndIncreaseInterval(STREAM_A);
+    // 5 minutes
+    IntStream.range(0, 5).forEach(__ -> Assertions.assertFalse(valve.readyToTypeAndDedupe(STREAM_A)));
+    Assertions.assertTrue(valve.readyToTypeAndDedupe(STREAM_A));
+    valve.updateTimeAndIncreaseInterval(STREAM_A);
+    // 10 minutes
+    IntStream.range(0, 10).forEach(__ -> Assertions.assertFalse(valve.readyToTypeAndDedupe(STREAM_A)));
+    Assertions.assertTrue(valve.readyToTypeAndDedupe(STREAM_A));
+    valve.updateTimeAndIncreaseInterval(STREAM_A);
+    // 15 minutes
+    IntStream.range(0, 15).forEach(__ -> Assertions.assertFalse(valve.readyToTypeAndDedupe(STREAM_A)));
+    Assertions.assertTrue(valve.readyToTypeAndDedupe(STREAM_A));
+    valve.updateTimeAndIncreaseInterval(STREAM_A);
+    // 15 minutes again
+    IntStream.range(0, 15).forEach(__ -> Assertions.assertFalse(valve.readyToTypeAndDedupe(STREAM_A)));
+    Assertions.assertTrue(valve.readyToTypeAndDedupe(STREAM_A));
+  }
 
-    @Test
-    public void testUpdateTimeAndIncreaseInterval() {
-        final var valve = new TypeAndDedupeOperationValve(minuteUpdates);
-        valve.addStream(STREAM_A);
-        // 2 minutes
-        IntStream.range(0, 2).forEach(__ -> Assertions.assertFalse(valve.readyToTypeAndDedupe(STREAM_A)));
-        Assertions.assertTrue(valve.readyToTypeAndDedupe(STREAM_A));
-        valve.updateTimeAndIncreaseInterval(STREAM_A);
-        // 5 minutes
-        IntStream.range(0, 5).forEach(__ -> Assertions.assertFalse(valve.readyToTypeAndDedupe(STREAM_A)));
-        Assertions.assertTrue(valve.readyToTypeAndDedupe(STREAM_A));
-        valve.updateTimeAndIncreaseInterval(STREAM_A);
-        // 10 minutes
-        IntStream.range(0, 10).forEach(__ -> Assertions.assertFalse(valve.readyToTypeAndDedupe(STREAM_A)));
-        Assertions.assertTrue(valve.readyToTypeAndDedupe(STREAM_A));
-        valve.updateTimeAndIncreaseInterval(STREAM_A);
-        // 15 minutes
-        IntStream.range(0, 15).forEach(__ -> Assertions.assertFalse(valve.readyToTypeAndDedupe(STREAM_A)));
-        Assertions.assertTrue(valve.readyToTypeAndDedupe(STREAM_A));
-        valve.updateTimeAndIncreaseInterval(STREAM_A);
-        // 15 minutes again
-        IntStream.range(0, 15).forEach(__ -> Assertions.assertFalse(valve.readyToTypeAndDedupe(STREAM_A)));
-        Assertions.assertTrue(valve.readyToTypeAndDedupe(STREAM_A));
-    }
 }


### PR DESCRIPTION
Instead of Typing and deduping every 10k records, use an increasing interval so users can both see new records quickly at the start of a sync but not slow down the entire sync too much.

Closes #27920 