### PR TITLE
🐛 Source Apple Search Ads: manifest.yaml duplicate key error

### DIFF
--- a/airbyte-integrations/connectors/source-apple-search-ads/Dockerfile
+++ b/airbyte-integrations/connectors/source-apple-search-ads/Dockerfile
@@ -34,5 +34,5 @@ COPY source_apple_search_ads ./source_apple_search_ads
 ENV AIRBYTE_ENTRYPOINT "python /airbyte/integration_code/main.py"
 ENTRYPOINT ["python", "/airbyte/integration_code/main.py"]
 
-LABEL io.airbyte.version=0.1.0
+LABEL io.airbyte.version=0.1.1
 LABEL io.airbyte.name=airbyte/source-apple-search-ads

--- a/airbyte-integrations/connectors/source-apple-search-ads/metadata.yaml
+++ b/airbyte-integrations/connectors/source-apple-search-ads/metadata.yaml
@@ -2,7 +2,7 @@ data:
   connectorSubtype: api
   connectorType: source
   definitionId: e59c8416-c2fa-4bd3-9e95-52677ea281c1
-  dockerImageTag: 0.1.0
+  dockerImageTag: 0.1.1
   dockerRepository: airbyte/source-apple-search-ads
   githubIssueLabel: source-apple-search-ads
   icon: apple.svg

--- a/airbyte-integrations/connectors/source-apple-search-ads/source_apple_search_ads/manifest.yaml
+++ b/airbyte-integrations/connectors/source-apple-search-ads/source_apple_search_ads/manifest.yaml
@@ -94,7 +94,6 @@ definitions:
     cursor_granularity: "P1D"
     cursor_field: "date"
     lookback_window: "P30D"
-    datetime_format: "%Y-%m-%d"
 
   report_stream:
     selector:

--- a/docs/integrations/sources/apple-search-ads.md
+++ b/docs/integrations/sources/apple-search-ads.md
@@ -46,5 +46,6 @@ However, at this moment and as indicated in the stream names, the connector only
 
 ## Changelog
 | Version | Date       | Pull Request                                            | Subject                                                                              |
-| :------ |:-----------|:--------------------------------------------------------|:-------------------------------------------------------------------------------------|
+|:--------|:-----------|:--------------------------------------------------------|:-------------------------------------------------------------------------------------|
+| 0.1.1   | 2023-07-11 | [28153](https://github.com/airbytehq/airbyte/pull/28153) | Fix manifest duplicate key (no change in behavior for the syncs)                     |
 | 0.1.0   | 2022-11-17 | [19557](https://github.com/airbytehq/airbyte/pull/19557) | Initial release with campaigns, adgroups & keywords streams (base and daily reports) |


### PR DESCRIPTION
## What
Manifest could not be uploaded in connector builder

## How
Remove the duplicate key

## 🚨 User Impact 🚨
No change in behavior for the source since the value was the same for both `datetime_format`. This will however allow for the connector builder to import the manifest