### PR TITLE
Update on-gcp-compute-engine.md

### DIFF
--- a/docs/deploying-airbyte/on-gcp-compute-engine.md
+++ b/docs/deploying-airbyte/on-gcp-compute-engine.md
@@ -20,6 +20,7 @@ The instructions have been tested on a `Debian GNU/Linux 10` VM instance.
 
 ```bash
 PROJECT_ID=PROJECT_ID_WHERE_YOU_CREATED_YOUR_INSTANCE
+INSTANCE_ZONE=ZONE_WHERE_YOU_CREATED_YOUR_INSTANCE (ex. northamerica-northeast1-a)
 INSTANCE_NAME=airbyte # or any other name that you've used
 ```
 
@@ -97,7 +98,9 @@ For security reasons, we strongly recommended not exposing Airbyte publicly.
 1. In your local terminal, create an SSH tunnel to connect the GCP instance to Airbyte:
 
 ```bash
-gcloud --project=$PROJECT_ID beta compute ssh $INSTANCE_NAME -- -L 8000:localhost:8000 -N -f
+gcloud compute ssh --project=$PROJECT_ID\
+ --zone=$INSTANCE_ZONE \
+ $INSTANCE_NAME -- -NL 8000:localhost:8000
 ```
 
 2. Verify the connection by visiting [http://localhost:8000](http://localhost:8000) in your browser.


### PR DESCRIPTION
Added new env var. Updated local ssh tunnel command. Changed flags to keep tunnel running in terminal.

## What
Current documentation was using the beta gcloud ssh command, missing the VM zone and a flag. 

## How
New command follows official GCP documentation for connecting to a VM instance. Using `-NL` keeps the tunnel active in the terminal so you can kill it with ctrl+c and easily view error logs when trying to connect to vm.  

## Recommended reading order

## 🚨 User Impact 🚨
No user impact


## Pre-merge Actions
None

### Community member or Airbyter

- **Community member?** Grant edit access to maintainers ([instructions](https://docs.github.com/en/github/collaborating-with-pull-requests/working-with-forks/allowing-changes-to-a-pull-request-branch-created-from-a-fork#enabling-repository-maintainer-permissions-on-existing-pull-requests))
- Unit & integration tests added and passing. Community members, please provide proof of success locally e.g: screenshot or copy-paste unit, integration, and acceptance test output. To run acceptance tests for a Python connector, follow instructions in the README. For java connectors run `./gradlew :airbyte-integrations:connectors:<name>:integrationTest`.
- Connector version is set to `0.0.1`
    - `Dockerfile` has version `0.0.1`
- Documentation updated
    - Connector's `README.md`
    - Connector's `bootstrap.md`. See [description and examples](https://docs.google.com/document/d/1ypdgmwmEHWv-TrO4_YOQ7pAJGVrMp5BOkEVh831N260/edit?usp=sharing)
    - `docs/integrations/<source or destination>/<name>.md` including changelog with an entry for the initial version. See changelog [example](https://docs.airbyte.io/integrations/sources/stripe#changelog)
    - `docs/integrations/README.md`

### Airbyter

If this is a community PR, the Airbyte engineer reviewing this PR is responsible for the below items.

- Create a non-forked branch based on this PR and test the below items on it
- Build is successful
- If new credentials are required for use in CI, add them to GSM. [Instructions](https://docs.airbyte.io/connector-development#using-credentials-in-ci).

</details>

<details><summary><strong>Updating a connector</strong></summary>

### Community member or Airbyter

- Grant edit access to maintainers ([instructions](https://docs.github.com/en/github/collaborating-with-pull-requests/working-with-forks/allowing-changes-to-a-pull-request-branch-created-from-a-fork#enabling-repository-maintainer-permissions-on-existing-pull-requests))
- Unit & integration tests added


### Airbyter

If this is a community PR, the Airbyte engineer reviewing this PR is responsible for the below items.

- Create a non-forked branch based on this PR and test the below items on it
- Build is successful
- If new credentials are required for use in CI, add them to GSM. [Instructions](https://docs.airbyte.io/connector-development#using-credentials-in-ci).

</details>

<details><summary><strong>Connector Generator</strong></summary>

- Issue acceptance criteria met
- PR name follows [PR naming conventions](https://docs.airbyte.com/contributing-to-airbyte/issues-and-pull-requests#pull-request-title-convention)
- If adding a new generator, add it to the [list of scaffold modules being tested](https://github.com/airbytehq/airbyte/blob/master/airbyte-integrations/connector-templates/generator/build.gradle#L41)
- The generator test modules (all connectors with `-scaffold` in their name) have been updated with the latest scaffold by running `./gradlew :airbyte-integrations:connector-templates:generator:testScaffoldTemplates` then checking in your changes
- Documentation which references the generator is updated as needed

</details>
