### PR TITLE
[Source-Postgres] Rollback to 2.1.1 in case 3.0.0 fails [DO NOT MERGE]

### DIFF
--- a/airbyte-integrations/connectors/source-postgres/metadata.yaml
+++ b/airbyte-integrations/connectors/source-postgres/metadata.yaml
@@ -19,6 +19,7 @@ data:
       dockerImageTag: 2.1.1 # Pinned to rollback https://github.com/airbytehq/airbyte/pull/27442
       enabled: true
     oss:
+      dockerImageTag: 2.1.1 # Pinned to rollback https://github.com/airbytehq/airbyte/pull/27442
       enabled: true
   releaseStage: generally_available
   documentationUrl: https://docs.airbyte.com/integrations/sources/postgres

--- a/airbyte-integrations/connectors/source-postgres/metadata.yaml
+++ b/airbyte-integrations/connectors/source-postgres/metadata.yaml
@@ -6,7 +6,7 @@ data:
   connectorSubtype: database
   connectorType: source
   definitionId: decd338e-5647-4c0b-adf4-da0e75f5a750
-  dockerImageTag: 2.1.1
+  dockerImageTag: 3.0.0
   maxSecondsBetweenMessages: 7200
   dockerRepository: airbyte/source-postgres
   githubIssueLabel: source-postgres
@@ -16,6 +16,7 @@ data:
   registries:
     cloud:
       dockerRepository: airbyte/source-postgres-strict-encrypt
+      dockerImageTag: 2.1.1 # Pinned to rollback https://github.com/airbytehq/airbyte/pull/27442
       enabled: true
     oss:
       enabled: true


### PR DESCRIPTION
## What
In the case that we need to rollback this [change](https://github.com/airbytehq/airbyte/pull/27442). This PR redirects version 3.0.0 to point at 2.1.1. In the case that we need to rollback, this PR will be merged, and another PR will be submitted with version 3.0.1 that removes the previous changes. Also, `postgres.md` changelog will be updated with version 3.0.1 stating the rollback.

