### PR TITLE
[Source-Postgres] Handle empty table when syncing via Ctid -> cursor-based 

### DIFF
--- a/airbyte-integrations/connectors/source-postgres/src/main/java/io/airbyte/integrations/source/postgres/PostgresQueryUtils.java
+++ b/airbyte-integrations/connectors/source-postgres/src/main/java/io/airbyte/integrations/source/postgres/PostgresQueryUtils.java
@@ -159,14 +159,14 @@ public class PostgresQueryUtils {
         final List<JsonNode> jsonNodes = database.bufferedResultSetQuery(conn -> conn.prepareStatement(cursorBasedSyncStatusQuery).executeQuery(),
             resultSet -> JdbcUtils.getDefaultSourceOperations().rowToJson(resultSet));
         final CursorBasedStatus cursorBasedStatus = new CursorBasedStatus();
+        cursorBasedStatus.setStateType(StateType.CURSOR_BASED);
+        cursorBasedStatus.setVersion(2L);
         cursorBasedStatus.setStreamName(name);
         cursorBasedStatus.setStreamNamespace(namespace);
         cursorBasedStatus.setCursorField(ImmutableList.of(cursorField));
 
         if (!jsonNodes.isEmpty()) {
           final JsonNode result = jsonNodes.get(0);
-          cursorBasedStatus.setStateType(StateType.CURSOR_BASED);
-          cursorBasedStatus.setVersion(2L);
           cursorBasedStatus.setCursor(result.get(cursorField).asText());
           cursorBasedStatus.setCursorRecordCount((long) jsonNodes.size());
 

--- a/airbyte-integrations/connectors/source-postgres/src/main/java/io/airbyte/integrations/source/postgres/PostgresQueryUtils.java
+++ b/airbyte-integrations/connectors/source-postgres/src/main/java/io/airbyte/integrations/source/postgres/PostgresQueryUtils.java
@@ -169,9 +169,8 @@ public class PostgresQueryUtils {
           final JsonNode result = jsonNodes.get(0);
           cursorBasedStatus.setCursor(result.get(cursorField).asText());
           cursorBasedStatus.setCursorRecordCount((long) jsonNodes.size());
-
-          cursorBasedStatusMap.put(new AirbyteStreamNameNamespacePair(name, namespace), cursorBasedStatus);
         }
+        
         cursorBasedStatusMap.put(new AirbyteStreamNameNamespacePair(name, namespace), cursorBasedStatus);
       } catch (final SQLException e) {
         throw new RuntimeException(e);

--- a/airbyte-integrations/connectors/source-postgres/src/main/java/io/airbyte/integrations/source/postgres/PostgresQueryUtils.java
+++ b/airbyte-integrations/connectors/source-postgres/src/main/java/io/airbyte/integrations/source/postgres/PostgresQueryUtils.java
@@ -158,17 +158,20 @@ public class PostgresQueryUtils {
             name);
         final List<JsonNode> jsonNodes = database.bufferedResultSetQuery(conn -> conn.prepareStatement(cursorBasedSyncStatusQuery).executeQuery(),
             resultSet -> JdbcUtils.getDefaultSourceOperations().rowToJson(resultSet));
-        final JsonNode result = jsonNodes.get(0);
         final CursorBasedStatus cursorBasedStatus = new CursorBasedStatus();
-
-        cursorBasedStatus.setStateType(StateType.CURSOR_BASED);
-        cursorBasedStatus.setVersion(2L);
-        cursorBasedStatus.setCursorField(ImmutableList.of(cursorField));
-        cursorBasedStatus.setCursor(result.get(cursorField).asText());
-        cursorBasedStatus.setCursorRecordCount((long) jsonNodes.size());
         cursorBasedStatus.setStreamName(name);
         cursorBasedStatus.setStreamNamespace(namespace);
+        cursorBasedStatus.setCursorField(ImmutableList.of(cursorField));
 
+        if (!jsonNodes.isEmpty()) {
+          final JsonNode result = jsonNodes.get(0);
+          cursorBasedStatus.setStateType(StateType.CURSOR_BASED);
+          cursorBasedStatus.setVersion(2L);
+          cursorBasedStatus.setCursor(result.get(cursorField).asText());
+          cursorBasedStatus.setCursorRecordCount((long) jsonNodes.size());
+
+          cursorBasedStatusMap.put(new AirbyteStreamNameNamespacePair(name, namespace), cursorBasedStatus);
+        }
         cursorBasedStatusMap.put(new AirbyteStreamNameNamespacePair(name, namespace), cursorBasedStatus);
       } catch (final SQLException e) {
         throw new RuntimeException(e);


### PR DESCRIPTION
## What
https://github.com/airbytehq/airbyte/issues/28262
This handles the case of when a source table is empty and does not return a high watermark value when querying for the max cursor value

## How
Emit a default stream state, see example below, when a source table is empty
```
[
  {
    "streamDescriptor": {
      "name": "mock",
      "namespace": "public"
    },
    "streamState": {
      "state_type": "cursorBased",
      "version": 2,
      "stream_name": "mock",
      "cursor_field": [
        "id"
      ],
      "stream_namespace": "public"
    }
  }
]
```
