### PR TITLE
Destination bigquery 1s1t: print better stats

### DIFF
--- a/airbyte-integrations/connectors/destination-bigquery/src/main/java/io/airbyte/integrations/destination/bigquery/typing_deduping/BigQueryDestinationHandler.java
+++ b/airbyte-integrations/connectors/destination-bigquery/src/main/java/io/airbyte/integrations/destination/bigquery/typing_deduping/BigQueryDestinationHandler.java
@@ -5,6 +5,9 @@
 package io.airbyte.integrations.destination.bigquery.typing_deduping;
 
 import com.google.cloud.bigquery.BigQuery;
+import com.google.cloud.bigquery.Job;
+import com.google.cloud.bigquery.JobInfo;
+import com.google.cloud.bigquery.JobStatistics;
 import com.google.cloud.bigquery.QueryJobConfiguration;
 import com.google.cloud.bigquery.Table;
 import com.google.cloud.bigquery.TableDefinition;
@@ -41,9 +44,15 @@ public class BigQueryDestinationHandler {
     }
     final UUID queryId = UUID.randomUUID();
     LOGGER.info("Executing sql {}: {}", queryId, sql);
-    long start = System.currentTimeMillis();
-    bq.query(QueryJobConfiguration.newBuilder(sql).build());
-    LOGGER.info("Completed sql {} in {} ms", queryId, System.currentTimeMillis() - start);
+
+    Job job = bq.create(JobInfo.of(QueryJobConfiguration.newBuilder(sql).build()));
+    job = job.waitFor();
+
+    JobStatistics.QueryStatistics statistics = job.getStatistics();
+    LOGGER.info("Completed sql {} in {} ms; processed {} bytes",
+        queryId,
+        statistics.getEndTime() - statistics.getStartTime(),
+        statistics.getTotalBytesBilled());
   }
 
 }

--- a/airbyte-integrations/connectors/destination-bigquery/src/main/java/io/airbyte/integrations/destination/bigquery/typing_deduping/BigQueryDestinationHandler.java
+++ b/airbyte-integrations/connectors/destination-bigquery/src/main/java/io/airbyte/integrations/destination/bigquery/typing_deduping/BigQueryDestinationHandler.java
@@ -49,9 +49,10 @@ public class BigQueryDestinationHandler {
     job = job.waitFor();
 
     JobStatistics.QueryStatistics statistics = job.getStatistics();
-    LOGGER.info("Completed sql {} in {} ms; processed {} bytes",
+    LOGGER.info("Completed sql {} in {} ms; processed {} bytes; billed for {} bytes",
         queryId,
         statistics.getEndTime() - statistics.getStartTime(),
+        statistics.getTotalBytesProcessed(),
         statistics.getTotalBytesBilled());
   }
 


### PR DESCRIPTION
use bigquery's job runtime instead of our wall time. Presumably that's slightly more accurate. Also get some stats around actual data volume.

interesting note from https://cloud.google.com/bigquery/pricing#on-demand-pricing-details

> Charges are rounded up to the nearest MB, with a minimum 10 MB data processed per table referenced by the query, and with a minimum 10 MB data processed per query.

e.g. running the `incrementalDedup()` test locally - `12688 ms; processed 2800 bytes; billed for 94371840 bytes`